### PR TITLE
fix: align with Anthropic marketplace standards

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "knowledge-os-marketplace",
   "version": "2.0.0",
-  "schema": "anthropic-2025-marketplace-v1",
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "owner": {
     "name": "Brandon Fuller",
     "email": "fullerbt@users.noreply.github.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "knowledge-os",
   "version": "1.0.0",
   "description": "Complete Knowledge OS for Claude Code - Research/Plan/Implement workflow, session management, vibe-coding metrics, and 85+ specialized agents",

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# CODEOWNERS for Knowledge OS Marketplace
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+* @boshu2
+
+# Plugin marketplace definition
+/.claude-plugin/ @boshu2
+
+# Agents directory
+/agents/ @boshu2
+
+# Commands directory
+/commands/ @boshu2
+
+# Skills directory
+/skills/ @boshu2
+
+# Profiles directory
+/profiles/ @boshu2
+
+# Workflows directory
+/workflows/ @boshu2


### PR DESCRIPTION
- Add CODEOWNERS file (required for marketplace plugins)
- Update marketplace.json to use official $schema URL
- Add $schema field to plugin.json for validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch marketplace/plugin configs to official $schema URLs and add CODEOWNERS with @boshu2 as owner.
> 
> - **Compliance/metadata**:
>   - Update `/.claude-plugin/marketplace.json` to use `$schema: https://anthropic.com/claude-code/marketplace.schema.json` (replacing prior `schema` field).
>   - Add `$schema: https://anthropic.com/claude-code/plugin.schema.json` to `/.claude-plugin/plugin.json`.
> - **Repo governance**:
>   - Add `/.github/CODEOWNERS` assigning `@boshu2` as owner for repo-wide and key directories (`.claude-plugin/`, `agents/`, `commands/`, `skills/`, `profiles/`, `workflows/`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b72cf79fec5d425288d2794fb2dde6fc4e92a7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->