### PR TITLE
fix(pr-research): add push access verification

### DIFF
--- a/plugins/pr-kit/skills/pr-research/SKILL.md
+++ b/plugins/pr-kit/skills/pr-research/SKILL.md
@@ -482,6 +482,38 @@ Next: /pr-plan ~/gt/.agents/<rig>/research/YYYY-MM-DD-pr-{repo}.md
 | Start with large PRs | Begin with small, focused changes |
 | Assume conventions | Check commit message style |
 | Ignore issue labels | Look for "good first issue" |
+| **Assume push access** | **Always verify with `gh repo view --json viewerPermission`** |
+
+---
+
+## Push Access Verification
+
+**CRITICAL**: Never assume the user has push access to external repositories.
+
+### Check Access Level
+
+```bash
+# Verify actual permissions
+gh repo view <owner/repo> --json viewerPermission --jq '.viewerPermission'
+```
+
+| Permission | Meaning | Workflow |
+|------------|---------|----------|
+| `ADMIN` | Owner/admin | Can push directly |
+| `WRITE` | Collaborator | Can push directly |
+| `READ` | Read-only | **Must fork and PR** |
+| `NONE` | No access | **Must fork and PR** |
+
+### Default Assumption
+
+**Unless `viewerPermission` is `ADMIN` or `WRITE`, assume fork-based workflow is required.**
+
+Do NOT tell users they have push access based on:
+- Being "crew" or having a local clone
+- The repo being in their workspace
+- Any assumption about their role
+
+**Always verify programmatically.**
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds explicit push access verification guidance to `/pr-research` skill
- Requires `gh repo view --json viewerPermission` check before assuming workflow
- Prevents false "you have push access" messages

## Fixes

Closes #8 - skill incorrectly assumed user had push access to external repo based on workspace context

## Changes

Added new "Push Access Verification" section with:
- Command to check actual permissions
- Permission level table (ADMIN/WRITE = push, READ/NONE = fork)
- Anti-pattern entry for assuming push access
- Explicit guidance to never assume access without verification

## Test plan

- [ ] Run `/pr-research` on a repo you don't have push access to
- [ ] Verify it recommends fork-based workflow