### PR TITLE
refactor: rename autopilot to crank throughout

### DIFF
--- a/.agents/learnings/2025-12-30-progressive-documentation.md
+++ b/.agents/learnings/2025-12-30-progressive-documentation.md
@@ -39,7 +39,7 @@ Kelsey Hightower's approach: each level adds exactly ONE new concept. Don't bund
 - L2: +persistence (.agents/)
 - L3: +issue tracking (beads)
 - L4: +parallelization (waves)
-- L5: +automation (autopilot)
+- L5: +automation (crank)
 
 **Application:** When teaching complex systems:
 1. Identify the 3-5 core concepts

--- a/.agents/patterns/progressive-levels.md
+++ b/.agents/patterns/progressive-levels.md
@@ -144,7 +144,7 @@ levels/
 │   ├── implement-wave.md  # 92 lines - parallel execution
 │   └── demo/              # 1 transcript
 └── L5-orchestration/
-    ├── autopilot.md       # 94 lines - full automation
+    ├── crank.md       # 94 lines - full automation
     └── demo/              # 1 transcript
 ```
 

--- a/.agents/research/2025-12-30-kelsey-style-restructure.md
+++ b/.agents/research/2025-12-30-kelsey-style-restructure.md
@@ -97,7 +97,7 @@ Current `implement.md` structure:
 - L2: Add persistent output (.agents/)
 - L3: Add issue tracking concepts
 - L4: Add parallelization (waves)
-- L5: Full orchestration (autopilot)
+- L5: Full orchestration (crank)
 
 ### Finding 3: Framework Content Should Be Reference, Not Inline
 
@@ -190,7 +190,7 @@ agentops/
 │   ├── L2-persistence/          # Add .agents/ output
 │   ├── L3-state-management/     # Issue tracking patterns
 │   ├── L4-parallelization/      # Wave execution
-│   └── L5-orchestration/        # Full autopilot
+│   └── L5-orchestration/        # Full crank
 ├── reference/                   # NEW: Framework content
 │   ├── pdc-framework.md
 │   ├── faafo-alignment.md

--- a/levels/L2-persistence/README.md
+++ b/levels/L2-persistence/README.md
@@ -42,7 +42,7 @@ Add the `.agents/` directory for cross-session memory.
 
 - No issue tracking
 - No parallelization
-- No autopilot
+- No crank
 
 ## Next Level
 

--- a/levels/L3-state-management/README.md
+++ b/levels/L3-state-management/README.md
@@ -44,7 +44,7 @@ bd sync                     # Sync at session end
 ## What's NOT at This Level
 
 - No parallel execution
-- No autopilot
+- No crank
 
 ## Next Level
 

--- a/levels/L4-parallelization/README.md
+++ b/levels/L4-parallelization/README.md
@@ -44,7 +44,7 @@ Next wave begins
 
 ## What's NOT at This Level
 
-- No full autopilot
+- No full crank
 - Human triggers each wave
 
 ## Next Level

--- a/levels/L5-orchestration/README.md
+++ b/levels/L5-orchestration/README.md
@@ -1,10 +1,10 @@
 # L5 — Orchestration
 
-Full autonomous operation with autopilot.
+Full autonomous operation with crank.
 
 ## What You'll Learn
 
-- Using `/autopilot` for epic-to-completion
+- Using `/crank` for epic-to-completion
 - Reconciliation loops
 - Validation gates
 - Human checkpoint patterns
@@ -19,7 +19,7 @@ Full autonomous operation with autopilot.
 
 | Command | Purpose |
 |---------|---------|
-| `/autopilot` | Epic-to-completion with validation gates |
+| `/crank` | Epic-to-completion with validation gates |
 | `/implement-wave` | Same as L4 |
 | `/plan <goal>` | Same as L3 |
 | `/research <topic>` | Same as L2 |
@@ -36,7 +36,7 @@ Full autonomous operation with autopilot.
 ## Autopilot Flow
 
 ```
-/autopilot <epic>
+/crank <epic>
     ↓
 Plan decomposition
     ↓

--- a/levels/L5-orchestration/crank.md
+++ b/levels/L5-orchestration/crank.md
@@ -2,16 +2,16 @@
 description: Execute an epic to completion with automated reconciliation
 ---
 
-# /autopilot
+# /crank
 
 Runs an entire epic through waves automatically. Validates between waves. Pauses for human review when needed.
 
 ## Usage
 
 ```
-/autopilot <epic-id>
-/autopilot agentops-xyz
-/autopilot agentops-xyz --dry-run
+/crank <epic-id>
+/crank agentops-xyz
+/crank agentops-xyz --dry-run
 ```
 
 ## What's Different from L4
@@ -43,7 +43,7 @@ At L5, full autonomy:
 ## Output
 
 ```
-/autopilot agentops-epic-123
+/crank agentops-epic-123
 
 Epic: "Add user dashboard"
 Total: 8 issues across 4 waves

--- a/levels/L5-orchestration/demo/crank-session.md
+++ b/levels/L5-orchestration/demo/crank-session.md
@@ -1,4 +1,4 @@
-# Demo: /autopilot Session
+# Demo: /crank Session
 
 A session showing autonomous epic execution with validation gates.
 
@@ -28,7 +28,7 @@ Issues:
 ## Session
 
 ```
-You: /autopilot agentops-epic-xyz
+You: /crank agentops-epic-xyz
 
 Claude: Loading epic...
 
@@ -138,7 +138,7 @@ Severity: HIGH
 Options:
   [continue] - Proceed anyway (not recommended)
   [fix]      - Fix the issue, then continue
-  [abort]    - Stop autopilot, manual intervention
+  [abort]    - Stop crank, manual intervention
 
 Your choice: fix
 
@@ -149,7 +149,7 @@ Claude: Fixing XSS issue...
 $ npm run security-scan
 No issues
 
-Resuming autopilot...
+Resuming crank...
 ```
 
 ---

--- a/levels/README.md
+++ b/levels/README.md
@@ -18,7 +18,7 @@ Each level builds on the previous. Master L1 before attempting L2. The levels ar
 | L2 | Persistence | `.agents/` output | State survives sessions |
 | L3 | State Management | Issue tracking | `/plan`, beads integration |
 | L4 | Parallelization | Wave execution | `/implement-wave` |
-| L5 | Orchestration | Full autopilot | `/autopilot`, reconciliation loops |
+| L5 | Orchestration | Full crank | `/crank`, reconciliation loops |
 
 ## Progression Path
 
@@ -49,7 +49,7 @@ Add issue tracking with beads. `/plan` creates structured work items. Track prog
 Execute independent work in parallel. `/implement-wave` runs multiple issues concurrently. Speed through unblocked work.
 
 ### L5 — Orchestration
-Full autonomous operation. `/autopilot` handles epic-to-completion with validation gates and human checkpoints.
+Full autonomous operation. `/crank` handles epic-to-completion with validation gates and human checkpoints.
 
 ## Getting Started
 

--- a/plugins/core-kit/skills/crank/SKILL.md
+++ b/plugins/core-kit/skills/crank/SKILL.md
@@ -349,6 +349,6 @@ bd list --parent=<epic> --status=closed       # What completed
 
 - [odmcr.md](odmcr.md) - Detailed ODMCR loop specification
 - [failure-taxonomy.md](failure-taxonomy.md) - Failure types and handling
-- `/autopilot` - Supervised execution with validation gates
+- `/crank` - Supervised execution with validation gates
 - `/implement` - Single issue execution (used by crew mode)
 - `/implement-wave` - Single wave execution

--- a/plugins/core-kit/skills/formulate/SKILL.md
+++ b/plugins/core-kit/skills/formulate/SKILL.md
@@ -26,7 +26,7 @@ for parallel execution.
 
 **Core Purpose**: Transform a goal into a reusable formula template (.formula.toml) that
 captures the pattern for creating beads issues with dependency ordering and wave-based
-parallelization for `/autopilot` and `/implement-wave`.
+parallelization for `/crank` and `/implement-wave`.
 
 **Key Capabilities**:
 - 6-tier context discovery hierarchy
@@ -413,7 +413,7 @@ See `references/templates.md` for full template.
 
 ### Phase 8: Output Summary
 
-Output structured summary with autopilot handoff:
+Output structured summary with crank handoff:
 
 ```markdown
 # Formula Complete: [Goal]
@@ -431,8 +431,8 @@ Output structured summary with autopilot handoff:
 
 ## Ready for Autopilot
 ```bash
-/autopilot ai-platform-xxx --dry-run
-/autopilot ai-platform-xxx
+/crank ai-platform-xxx --dry-run
+/crank ai-platform-xxx
 ```
 ```
 
@@ -481,7 +481,7 @@ Output structured summary with autopilot handoff:
   - [ ] `[[steps]]` with id, title, description, needs
 - [ ] Ran `bd cook` or instantiated manually (Phase 5.5/6)
 - [ ] Wrote companion .md documentation (Phase 7)
-- [ ] Output summary with autopilot handoff (Phase 8)
+- [ ] Output summary with crank handoff (Phase 8)
 - [ ] Synced with `bd sync`
 
 ### Immediate Flow (--immediate flag)
@@ -493,7 +493,7 @@ Output structured summary with autopilot handoff:
 - [ ] Added file annotations with `bd comment`
 - [ ] Added Children comment to epic
 - [ ] Started epic with `bd update <epic> --status in_progress`
-- [ ] Output summary with autopilot handoff
+- [ ] Output summary with crank handoff
 - [ ] Synced with `bd sync`
 
 ---

--- a/plugins/core-kit/skills/formulate/references/templates.md
+++ b/plugins/core-kit/skills/formulate/references/templates.md
@@ -296,14 +296,14 @@ bd mol pour {topic-slug} --var service_name=rate-limiter
 ```
 
 ## Next Steps
-Run `/autopilot <epic-id> --dry-run` to validate, then `/autopilot <epic-id>` to execute.
+Run `/crank <epic-id> --dry-run` to validate, then `/crank <epic-id>` to execute.
 ```
 
 ---
 
-## Formula Summary Template (Autopilot Handoff)
+## Formula Summary Template (Crank Handoff)
 
-Output this after cooking/pouring a formula. This is the **handoff to autopilot**.
+Output this after cooking/pouring a formula. This is the **handoff to crank**.
 
 ```markdown
 ---
@@ -361,10 +361,10 @@ Wave 2 (depends on Wave 1):
 
 ```bash
 # Validate structure first
-/autopilot xxx --dry-run
+/crank xxx --dry-run
 
 # Full execution
-/autopilot xxx
+/crank xxx
 ```
 
 ### Alternative: Manual Execution

--- a/plugins/core-kit/skills/plan/SKILL.md
+++ b/plugins/core-kit/skills/plan/SKILL.md
@@ -23,7 +23,7 @@ Produces beads issues with proper dependencies and wave computation for parallel
 ## Overview
 
 **Core Purpose**: Transform a goal into an executable plan with discrete beads issues,
-dependency ordering, and wave-based parallelization for `/autopilot` and `/implement-wave`.
+dependency ordering, and wave-based parallelization for `/crank` and `/implement-wave`.
 
 **Key Capabilities**:
 - 6-tier context discovery hierarchy
@@ -212,7 +212,7 @@ See `references/templates.md` for full template. Key elements:
 
 ### Phase 6: Output Summary
 
-Output structured summary with autopilot handoff:
+Output structured summary with crank handoff:
 
 ```markdown
 # Plan Complete: [Goal]
@@ -229,8 +229,8 @@ Output structured summary with autopilot handoff:
 
 ## Ready for Autopilot
 ```bash
-/autopilot ai-platform-xxx --dry-run
-/autopilot ai-platform-xxx
+/crank ai-platform-xxx --dry-run
+/crank ai-platform-xxx
 ```
 ```
 
@@ -275,7 +275,7 @@ Output structured summary with autopilot handoff:
 - [ ] Started epic with `bd update <epic> --status in_progress`
 - [ ] Verified with `bd show <epic-id>`
 - [ ] Synced with `bd sync`
-- [ ] Output summary with autopilot handoff
+- [ ] Output summary with crank handoff
 - [ ] Wrote plan to `~/gt/.agents/$RIG/plans/`
 
 ---
@@ -330,7 +330,7 @@ bd update ai-platform-200 --status in_progress
 
 # Phase 5: Write plan to ~/gt/.agents/athena/plans/2026-01-03-rate-limiting.md
 
-# Phase 5: Output summary with autopilot handoff
+# Phase 5: Output summary with crank handoff
 ```
 
 **Result**: 3 features, Wave 1 (201, 202 parallel), Wave 2 (203).

--- a/plugins/core-kit/skills/plan/references/templates.md
+++ b/plugins/core-kit/skills/plan/references/templates.md
@@ -74,17 +74,17 @@ Wave 2 (Depends on Wave 1):
 [Key decisions, patterns to follow, risks identified]
 
 ## External Requirements
-[Any prerequisites for autopilot: Langfuse enabled, secrets configured, migrations run, etc.]
+[Any prerequisites for crank: Langfuse enabled, secrets configured, migrations run, etc.]
 
 ## Next Steps
-Run `/autopilot <epic-id> --dry-run` to validate, then `/autopilot <epic-id>` to execute.
+Run `/crank <epic-id> --dry-run` to validate, then `/crank <epic-id>` to execute.
 ```
 
 ---
 
-## Plan Summary Template (Autopilot Handoff)
+## Plan Summary Template (Crank Handoff)
 
-Output this after creating issues. This is the **handoff to autopilot**.
+Output this after creating issues. This is the **handoff to crank**.
 
 ```markdown
 ---
@@ -145,10 +145,10 @@ Wave 3 (Depends on Wave 2):
 
 ```bash
 # Validate structure first
-/autopilot bd-epic-id --dry-run
+/crank bd-epic-id --dry-run
 
 # Full execution
-/autopilot bd-epic-id
+/crank bd-epic-id
 ```
 
 ### Alternative: Manual Execution

--- a/plugins/core-kit/skills/retro/SKILL.md
+++ b/plugins/core-kit/skills/retro/SKILL.md
@@ -169,7 +169,7 @@ fi
 
 # Source 3: Autopilot state (for polecat sessions)
 if [ -z "$SESSION_ID" ]; then
-    SESSION_ID=$(cat .agents/blackboard/autopilot-state.json 2>/dev/null | jq -r '.session_id // empty')
+    SESSION_ID=$(cat .agents/blackboard/crank-state.json 2>/dev/null | jq -r '.session_id // empty')
 fi
 ```
 

--- a/plugins/core-kit/skills/retro/references/context-gathering.md
+++ b/plugins/core-kit/skills/retro/references/context-gathering.md
@@ -56,7 +56,7 @@ python3 ~/.claude/scripts/analyze-sessions.py --session=$SESSION_ID --limit=50
 
 1. **Environment variable**: `$CLAUDE_SESSION_ID` (set by Claude Code)
 2. **Recent session detection**: Find most recent `.jsonl` in `~/.claude/projects/`
-3. **Beads comment**: Sessions may be recorded in autopilot state
+3. **Beads comment**: Sessions may be recorded in crank state
 
 ### When No Session Available
 
@@ -91,7 +91,7 @@ bd show <child-id>
 
 ```bash
 ls .agents/blackboard/
-cat .agents/blackboard/autopilot-state.json 2>/dev/null
+cat .agents/blackboard/crank-state.json 2>/dev/null
 ```
 
 ---

--- a/plugins/gastown-kit/skills/gastown/references/rpi-flow.md
+++ b/plugins/gastown-kit/skills/gastown/references/rpi-flow.md
@@ -199,7 +199,7 @@ def gastown_full_safe(goal: str, rig: str):
     try:
         # Check prerequisites
         if not gas_town_available():
-            print("Gas Town not available. Use /autopilot instead.")
+            print("Gas Town not available. Use /crank instead.")
             return
 
         gastown_full(goal, rig)

--- a/plugins/vibe-kit/skills/validation-chain/SKILL.md
+++ b/plugins/vibe-kit/skills/validation-chain/SKILL.md
@@ -166,12 +166,12 @@ bd create --title "[Quality] $FINDING_TITLE" --type task --priority 1
 
 ---
 
-## Integration with /autopilot
+## Integration with /crank
 
 When `--validate` flag is used:
 
 ```markdown
-/autopilot <epic> --validate
+/crank <epic> --validate
 ```
 
 The validation chain runs after each wave completes, before proceeding to next wave.


### PR DESCRIPTION
## Summary

- `/crank` is now the canonical autonomous execution skill (ODMCR loop)
- `/autopilot` is deprecated across all documentation and skills
- Renamed files and updated all references for consistency

## Changes

| File | Change |
|------|--------|
| `levels/L5-orchestration/autopilot.md` | → `crank.md` |
| `levels/L5-orchestration/demo/autopilot-session.md` | → `crank-session.md` |
| 17 additional files | Updated `/autopilot` → `/crank` references |

## Test plan

- [x] Verified no `/autopilot` references remain (except historical context)
- [x] Skill trigger phrases updated
- [x] Workflow documentation accurate