### PR TITLE
chore(release): automate Homebrew tap updates via GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,24 +9,8 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - goos: darwin
-            goarch: arm64
-            suffix: darwin-arm64
-          - goos: darwin
-            goarch: amd64
-            suffix: darwin-amd64
-          - goos: linux
-            goarch: amd64
-            suffix: linux-amd64
-          - goos: linux
-            goarch: arm64
-            suffix: linux-arm64
-
     steps:
       - uses: actions/checkout@v4
 
@@ -35,43 +19,11 @@ jobs:
         with:
           go-version: '1.22'
 
-      - name: Get version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-
-      - name: Build binary
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-        run: |
-          cd cli
-          go build -ldflags "-s -w -X main.version=${{ steps.version.outputs.VERSION }}" \
-            -o ao-${{ matrix.suffix }} ./cmd/ao
-
-      - name: Create tarball
-        run: |
-          cd cli
-          tar -czvf ao-${{ matrix.suffix }}.tar.gz ao-${{ matrix.suffix }}
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          name: ao-${{ matrix.suffix }}
-          path: cli/ao-${{ matrix.suffix }}.tar.gz
-
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: artifacts/**/*.tar.gz
-          generate_release_notes: true
+          version: latest
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,37 @@
+version: 2
+project_name: ao
+
+builds:
+  - id: ao
+    dir: cli
+    main: ./cmd/ao
+    binary: ao-{{ .Os }}-{{ .Arch }}
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+
+archives:
+  - id: ao
+    name_template: ao-{{ .Os }}-{{ .Arch }}
+    wrap_in_directory: false
+
+brews:
+  - name: agentops
+    directory: Formula
+    homepage: https://github.com/boshu2/agentops
+    description: Knowledge Flywheel CLI for AI-assisted development
+    license: MIT
+    install: |
+      bin.install "ao-{{ .Os }}-{{ .Arch }}" => "ao"
+    test: |
+      system "#{bin}/ao version"
+    repository:
+      owner: boshu2
+      name: homebrew-agentops
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"


### PR DESCRIPTION
## What
- Add GoReleaser config to build `ao` from `cli/`, package tarballs, and publish the Homebrew formula to `boshu2/homebrew-agentops`.
- Replace the custom release workflow with the GoReleaser action.

## Why
The Homebrew tap is currently pinned to v1.0.0, which doesn’t include `ao hooks`. Automating tap updates keeps the formula in sync with releases and eliminates manual version bumps.

## Release notes
- Binaries and checksums are still generated on tag push.
- Tap formula updates happen automatically on release.

## Tests
- `goreleaser release --snapshot --clean`

## Ops / Secrets
- Add `HOMEBREW_TAP_GITHUB_TOKEN` in `boshu2/agentops` with write access to `boshu2/homebrew-agentops`.

## Notes
- GoReleaser prints a deprecation warning for `brews` (formula support is being phased out in favor of `homebrew_casks`).
- We’re keeping `brews` for now to avoid a breaking change to the tap layout. If we want to future‑proof this, we should plan a follow‑up migration to the `homebrew_casks` config and update the tap accordingly.