### PR TITLE
test(rpi): harden supervisor determinism and recovery edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,8 @@ ao rpi status --watch                          # Monitor active/terminal runs
 
 Walk away, come back to committed code + extracted learnings.
 
+Supervisor determinism contract: task failures mark queue entries failed, infrastructure failures leave queue entries retryable, and `ao rpi cancel` ignores stale supervisor lease metadata. For recovery/hygiene, pair `ao rpi cancel` with `ao rpi cleanup --all --prune-worktrees --prune-branches`.
+
 ```bash
 ao search "query"      # Search knowledge across files and chat history
 ao demo                # Interactive demo


### PR DESCRIPTION
## Summary
- ignore stale/corrupt supervisor lease metadata in `ao rpi cancel`
- add deterministic loop tests for `stop|continue` queue mutation and cycle counts
- add kill-switch/cancel/cleanup reliability tests for malformed/missing state, dry-run, active worktree/branch safety
- add landing lock race + repeated dirty-repo landing coverage
- document supervisor determinism contract in README

## Validation
- cd cli && go test ./cmd/ao -count=1
- scripts/validate-go-fast.sh
- scripts/pre-push-gate.sh (passes when run directly; push hook race-check is intermittently flaky and tracked in ag-9hv)

## Tracking
- implements progress on ag-aoh
- follow-up issue: ag-9hv