### PR TITLE
fix(cmd): Use '--json' instead of '-o json' in bd invocations

### DIFF
--- a/cli/cmd/ao/fire.go
+++ b/cli/cmd/ao/fire.go
@@ -320,7 +320,7 @@ func escalatePhase(failures []string, retryQueue map[string]*RetryInfo, cfg Fire
 // =============================================================================
 
 func bdReady(epicID string) ([]string, error) {
-	args := []string{"ready", "-o", "json"}
+	args := []string{"ready", "--json"}
 	if epicID != "" {
 		args = append(args, "--parent", epicID)
 	}
@@ -335,7 +335,7 @@ func bdReady(epicID string) ([]string, error) {
 }
 
 func bdListByStatus(epicID, status string) ([]string, error) {
-	args := []string{"list", "--status", status, "-o", "json"}
+	args := []string{"list", "--status", status, "--json"}
 	if epicID != "" {
 		args = append(args, "--parent", epicID)
 	}
@@ -350,7 +350,7 @@ func bdListByStatus(epicID, status string) ([]string, error) {
 }
 
 func bdBlocked(epicID string) ([]string, error) {
-	args := []string{"blocked", "-o", "json"}
+	args := []string{"blocked", "--json"}
 	if epicID != "" {
 		args = append(args, "--parent", epicID)
 	}
@@ -365,7 +365,7 @@ func bdBlocked(epicID string) ([]string, error) {
 }
 
 func bdShowStatus(issueID string) (string, error) {
-	cmd := exec.Command("bd", "show", issueID, "-o", "json")
+	cmd := exec.Command("bd", "show", issueID, "--json")
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/cli/cmd/ao/plans.go
+++ b/cli/cmd/ao/plans.go
@@ -681,7 +681,7 @@ type beadsEpic struct {
 // queryBeadsEpics queries beads for epic statuses.
 func queryBeadsEpics() ([]beadsEpic, error) {
 	// Run bd list --type epic to get epics
-	cmd := exec.Command("bd", "list", "--type", "epic", "-o", "json")
+	cmd := exec.Command("bd", "list", "--type", "epic", "--json")
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("bd list: %w", err)


### PR DESCRIPTION
# Pull Request

## Description

**What does this PR do?**

Changes `-o json` to `--json` in bd commands

## Type of Change

**What type of change is this?**

- [ ] New plugin submission
- [ ] Plugin update/enhancement
- [x] Bug fix
- [ ] Documentation update
- [ ] Infrastructure/tooling improvement
- [ ] Breaking change
- [ ] Other: [specify]

## Related Issues

**Does this PR address any issues?**

Closes #[issue-number]
Fixes #[issue-number]
Relates to #[issue-number]

---

## For Plugin Submissions

**If this is a new plugin or plugin update, complete this section:**

### Plugin Information

- **Name:** [plugin-name]
- **Version:** [1.0.0]
- **Description:** [Brief description]
- **Token Budget:** [~X tokens (X%)]

### Components Added/Changed

- [ ] Agents (list: )
- [ ] Commands (list: )
- [ ] Skills (list: )
- [ ] Hooks (list: )
- [ ] MCP servers (list: )

### Dependencies

- [ ] core-workflow (required/optional)
- [ ] Other plugins: [list]

### Testing Completed

**Pre-submission testing:**

- [ ] Plugin installs successfully locally
- [ ] All agents tested and working as expected
- [ ] All commands tested and working as expected
- [ ] All skills tested and working as expected
- [ ] JSON manifests validated (no syntax errors)
- [ ] YAML frontmatter validated (all agents)
- [ ] Token budget verified through actual testing
- [ ] Documentation is complete and accurate
- [ ] All examples tested and working
- [ ] No hardcoded secrets or credentials
- [ ] No security vulnerabilities identified
- [ ] All links in documentation work

**Installation test command:**

```bash
/plugin install file://$(pwd)/plugins/[plugin-name]
```

### Usage Examples

**Provide at least one working example:**

```bash
# Example usage
```

**Expected output:**
[What should happen]

---

## For Bug Fixes

**If this is a bug fix, complete this section:**

### Bug Description

I was getting `no epic found in bd list output` during `ao rpi loop`; used verbose and traced it to the `bd list` invocation, which when you run it gives you `Error: unknown shorthand flag: 'o' in -o`. `bd` uses `--json` instead of `-o json` - maybe it used `-o` at some point, but [as far as I can tell](https://github.com/steveyegge/beads/blob/d99ad718a1148314388680c3db44213c435f9927/docs/FAQ.md?plain=1#L50) `--json` has been standard for a while.

### Root Cause

Running `bd` commands with the `-o json` flag rather than `--json`

### Solution

`-o json` -> `--json`

### Testing

- [x] Bug reproduced before fix
- [x] Bug no longer occurs after fix
- [x] No regression in other functionality
- [ ] Added test to prevent regression

---

## For Documentation Updates

**If this is a documentation update:**

### Changes Made

- [ ] README.md updated
- [ ] Plugin documentation updated
- [ ] Contributing guidelines updated
- [ ] Security policy updated
- [ ] Other: [specify]

### Reason for Update

[Why was this documentation update needed?]

---

## Changes Made

**Detailed breakdown of changes:**

### Files Added

- `path/to/file.ext` - [Purpose]

### Files Modified

- `path/to/file.ext` - [What changed and why]

### Files Deleted

- `path/to/file.ext` - [Why deleted]

## Testing Strategy

**How did you test these changes?**

1. [Test approach 1]
2. [Test approach 2]
3. [Test approach 3]

**Test results:**

```
[Include relevant test output or screenshots]
```

## Breaking Changes

**Does this PR introduce breaking changes?**

- [ ] Yes (explain below)
- [x] No

**If yes, describe the breaking changes:**

- [What breaks]
- [Migration path for users]
- [Documentation updates needed]

## Documentation

**Have you updated relevant documentation?**

- [ ] README.md (if user-facing changes)
- [ ] CHANGELOG.md (if version bump)
- [ ] Plugin README (if plugin changes)
- [ ] Agent documentation (if agent changes)
- [ ] Contributing guidelines (if process changes)
- [x] N/A - No documentation needed

## Code Quality

**Self-review checklist:**

- [x] Code follows project style guidelines
- [x] Added comments for complex logic
- [x] No unnecessary console.log or debug code
- [x] No commented-out code (unless explained)
- [x] Variable/function names are descriptive
- [x] Error handling is appropriate
- [x] Security best practices followed

## Security

**Security considerations:**

- [ ] No secrets or credentials in code
- [ ] Input validation where needed
- [ ] No SQL injection vulnerabilities
- [ ] No XSS vulnerabilities
- [ ] Dependencies are up to date
- [ ] Security policy reviewed
- [x] N/A - No security implications

## Performance

**Performance impact:**

- [x] No significant performance impact
- [ ] Performance improved (explain how)
- [ ] Performance regressed (explain why acceptable)
- [ ] Not applicable

## Deployment

**Deployment considerations:**

- [x] No special deployment steps needed
- [ ] Requires configuration changes (documented)
- [ ] Requires database migration
- [ ] Requires dependency installation
- [ ] Other: [specify]

## Screenshots/Examples

**If applicable, add screenshots or examples:**

[Attach or describe visual changes]

## Checklist

**Before submitting, ensure:**

- [x] I have read the [Contributing Guidelines](../docs/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](../docs/CODE_OF_CONDUCT.md)
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented complex code appropriately
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] Any dependent changes have been merged and published
- [x] I have updated CHANGELOG.md (if applicable)

## Additional Notes

**Any additional information for reviewers:**

- Special considerations
- Known limitations
- Future enhancements planned
- Questions for reviewers

---

## For Reviewers

**Review checklist:**

- [ ] Code quality is acceptable
- [ ] Tests are comprehensive
- [ ] Documentation is complete
- [ ] No security issues identified
- [ ] Performance impact is acceptable
- [ ] Breaking changes are justified (if any)
- [ ] CHANGELOG.md updated (if needed)
- [ ] Ready to merge

**Review notes:**

[Space for reviewer comments]
