### PR TITLE
docs: add newcomer guide and update onboarding references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,17 +6,18 @@ This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get sta
 
 If you spawn into this repo without context, do this first:
 
-1. Open `docs/README.md` then `docs/INDEX.md` to get the current doc map.
-2. Identify your task domain:
+1. Read `docs/newcomer-guide.md` first for a practical repo orientation.
+2. Open `docs/README.md` then `docs/INDEX.md` to get the current doc map.
+3. Identify your task domain:
    - CLI behavior: `cli/cmd/ao/`, `cli/internal/`, `cli/docs/COMMANDS.md`
    - Skill behavior: `skills/<name>/SKILL.md`
    - Hook/gate behavior: `hooks/hooks.json` + `hooks/*.sh`
    - Validation/release/security flows: `scripts/*.sh` + `tests/`
-3. Use source-of-truth precedence when docs disagree:
+4. Use source-of-truth precedence when docs disagree:
    1. Executable code and generated artifacts (`cli/**`, `hooks/**`, `scripts/**`, `cli/docs/COMMANDS.md`)
    2. Skill contracts and manifests (`skills/**/SKILL.md`, `hooks/hooks.json`, `schemas/**`)
    3. Explanatory docs (`docs/**`, `README.md`)
-4. If you find conflicts, follow the higher-precedence source and call out the mismatch explicitly in your report/PR.
+5. If you find conflicts, follow the higher-precedence source and call out the mismatch explicitly in your report/PR.
 
 ## Installing/Updating Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,10 @@
 
 If this is your first message in a fresh session, orient in this order:
 
-1. `docs/README.md` and `docs/INDEX.md` for navigation.
-2. `README.md` for product-level framing.
-3. Task-specific canonical surfaces:
+1. `docs/newcomer-guide.md` for a practical repo orientation and learning path.
+2. `docs/README.md` and `docs/INDEX.md` for navigation.
+3. `README.md` for product-level framing.
+4. Task-specific canonical surfaces:
    - CLI behavior: `cli/cmd/ao/`, `cli/internal/`, generated `cli/docs/COMMANDS.md`
    - Skills behavior: `skills/**/SKILL.md`
    - Hooks/gates: `hooks/hooks.json` and `hooks/*.sh`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ### Coding agents forget everything between sessions. This fixes that.
 
-[How It Works](#how-it-works) · [Install](#install) · [See It Work](#see-it-work) · [Skills](#skills) · [CLI](#the-ao-cli) · [FAQ](#faq)
+[How It Works](#how-it-works) · [Install](#install) · [See It Work](#see-it-work) · [Skills](#skills) · [CLI](#the-ao-cli) · [FAQ](#faq) · [Newcomer Guide](docs/newcomer-guide.md)
 
 </div>
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -5,6 +5,7 @@
 ## Getting Started
 
 - [README](../README.md) — Project overview and quick start
+- [Newcomer Guide](newcomer-guide.md) — Fast orientation to repo structure, architecture, and contribution path
 - [FAQ](FAQ.md) — Comparisons, limitations, subagent nesting, uninstall
 - [CONTRIBUTING](CONTRIBUTING.md) — How to contribute
 - [AGENTS.md](../AGENTS.md) — Local agent instructions for this repo

--- a/docs/newcomer-guide.md
+++ b/docs/newcomer-guide.md
@@ -1,0 +1,106 @@
+# Newcomer Guide: Understanding the AgentOps Repo
+
+If you're new to this repository, this guide gives you a practical mental model, a map of where things live, and a fast path to becoming productive.
+
+## What this repo is
+
+AgentOps is a **skills + hooks + CLI** system that helps coding agents compound knowledge across sessions instead of restarting from zero each time.
+
+At a high level:
+
+1. Run workflows with skills (`/research`, `/plan`, `/crank`, `/vibe`, `/post-mortem`)
+2. Persist knowledge in `.agents/`
+3. Inject the best prior learnings into the next session
+4. Enforce quality through hooks and CI gates
+
+See also:
+
+- [README](../README.md)
+- [Architecture](ARCHITECTURE.md)
+- [How It Works](how-it-works.md)
+
+## Repo structure (what matters most)
+
+Think in five layers:
+
+1. **Product/docs layer** — `docs/` + root docs (`README.md`, `CONTRIBUTING.md`, etc.)
+2. **Skills layer** — `skills/` and `skills-codex/` (`SKILL.md` contracts + per-skill scripts/references)
+3. **Hooks layer** — `hooks/` with active runtime manifest in `hooks/hooks.json`
+4. **CLI layer** — `cli/` (`cli/cmd/ao/`, `cli/internal/`, generated `cli/docs/COMMANDS.md`)
+5. **Validation layer** — `scripts/`, `tests/`, and `.github/workflows/validate.yml`
+
+## Source-of-truth precedence
+
+When docs disagree, follow this order:
+
+1. Executable code + generated artifacts (`cli/**`, `hooks/**`, `scripts/**`, `cli/docs/COMMANDS.md`)
+2. Skill contracts/manifests (`skills/**/SKILL.md`, `hooks/hooks.json`, `schemas/**`)
+3. Explanatory docs (`docs/**`, `README.md`)
+
+This keeps behavior aligned with what actually runs in CI and at runtime.
+
+## Key concepts to learn first
+
+### 1) Context quality is the core design principle
+
+The architecture assumes output quality depends on input context quality. Most patterns in this repo are about context scoping, isolation, and compounding.
+
+### 2) Skills are composable workflows
+
+Use the router in [Skills Reference](SKILLS.md) to choose the right entry point:
+
+- Start with uncertainty: `/research`
+- Break work into issues: `/plan`
+- Implement one issue: `/implement`
+- Run multi-issue waves: `/crank`
+- Run end-to-end lifecycle: `/rpi`
+
+### 3) Hooks are part of runtime behavior
+
+The active hook manifest in `hooks/hooks.json` is authoritative for what runs at session boundaries.
+
+### 4) CLI docs are generated, not hand-maintained
+
+`cli/docs/COMMANDS.md` is generated. If command behavior changes, regenerate docs and keep parity checks passing.
+
+### 5) CI checks many non-code contracts
+
+CI validates not just builds/tests but also docs parity, hook safety, skill integrity/schema, security scans, and contract compatibility.
+
+## Suggested learning path
+
+### Day 1 reading order
+
+1. `README.md`
+2. `docs/INDEX.md`
+3. `docs/how-it-works.md`
+4. `docs/ARCHITECTURE.md`
+5. `docs/SKILLS.md`
+
+### Then pick one domain
+
+- **CLI behavior:** `cli/cmd/ao/`, `cli/internal/`, `cli/docs/COMMANDS.md`
+- **Skill behavior:** `skills/<name>/SKILL.md`
+- **Hook/gate behavior:** `hooks/hooks.json` + `hooks/*.sh`
+- **Validation/release/security:** `scripts/*.sh` + `tests/` + `.github/workflows/validate.yml`
+
+### Recommended first contributions
+
+1. **Docs-only fix** (safe): update wording or cross-links and run docs validation scripts.
+2. **Hook/docs parity fix** (medium): update docs to match runtime hook manifest and validate parity.
+3. **Small CLI command improvement** (advanced beginner): update command behavior, regenerate CLI docs, and run CLI checks.
+
+## Practical tips
+
+- Trust runtime files over narrative docs when there is a mismatch.
+- Keep changes small and verify with local gates before pushing.
+- Treat `.agents/` and hooks as first-class parts of the system behavior.
+- If you touch command surfaces or hook contracts, expect related parity checks to fail until updated.
+
+## Where to go next
+
+- [Documentation Index](INDEX.md)
+- [Contributing Guide](CONTRIBUTING.md)
+- [Skills Reference](SKILLS.md)
+- [CLI Reference](../cli/docs/COMMANDS.md)
+- [Troubleshooting](troubleshooting.md)


### PR DESCRIPTION
### Motivation

- Provide a practical, fast orientation for new contributors so they can quickly learn repository structure, patterns, and first contributions. 
- Surface the new guide as the first step in zero-context startup flows and navigation so agents and humans start with a consistent learning path.

### Description

- Add `docs/newcomer-guide.md` which outlines repo purpose, key concepts, repo structure, source-of-truth precedence, and a suggested learning path.
- Update `AGENTS.md` and `CLAUDE.md` startup steps to reference `docs/newcomer-guide.md` as the first onboarding action and reorder steps accordingly.
- Add a `Newcomer Guide` link to `README.md` navigation and include the guide in `docs/INDEX.md` table of contents.

### Testing

- No automated tests were run as part of this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a02f52e15c832488a1790ad3a4fa29)