### PR TITLE
refactor(goals): use formatter.Table in goals_drift

### DIFF
--- a/cli/cmd/ao/goals_drift.go
+++ b/cli/cmd/ao/goals_drift.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/boshu2/agentops/cli/internal/formatter"
 	"github.com/boshu2/agentops/cli/internal/goals"
 	"github.com/spf13/cobra"
 )
@@ -67,18 +68,15 @@ var goalsDriftCmd = &cobra.Command{
 			regressions, improvements, len(drifts)-regressions-improvements)
 
 		if regressions > 0 || improvements > 0 {
-			fmt.Printf("%-30s %-10s %-6s   %-6s\n", "GOAL", "DELTA", "BEFORE", "AFTER")
-			fmt.Printf("%-30s %-10s %-6s   %-6s\n", "----", "-----", "------", "-----")
+			tbl := formatter.NewTable(os.Stdout, "GOAL", "DELTA", "BEFORE", "AFTER")
+			tbl.SetMaxWidth(0, 30)
 			for _, d := range drifts {
 				if d.Delta == "unchanged" {
 					continue
 				}
-				id := d.GoalID
-				if len(id) > 30 {
-					id = id[:27] + "..."
-				}
-				fmt.Printf("%-30s %-10s %-6s -> %-6s\n", id, d.Delta, d.Before, d.After)
+				tbl.AddRow(d.GoalID, d.Delta, d.Before, fmt.Sprintf("-> %s", d.After))
 			}
+			_ = tbl.Render()
 			fmt.Println()
 		}
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `fmt.Printf` table formatting in `goals_drift.go` with `formatter.NewTable` for consistent tabwriter-based column alignment
- Leverage `SetMaxWidth(0, 30)` for automatic goal ID truncation (previously manual `[:27] + "..."`)
- Incorporate the `->` arrow into the AFTER column value for clean 4-column layout

## Test plan
- [x] All 7 `TestGoalsDrift_*` tests pass without modification
- [x] Full `go test ./...` passes (19 packages, zero failures)
- [x] `make build` succeeds