### PR TITLE
refactor(inject): dedup frontmatter parsing in inject_patterns

### DIFF
--- a/cli/cmd/ao/inject_patterns.go
+++ b/cli/cmd/ao/inject_patterns.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -162,23 +161,13 @@ func parsePatternFile(path string) (pattern, error) {
 }
 
 // parseFrontmatterBlock scans YAML frontmatter and returns content start index and utility value.
+// Delegates to parseFrontMatter (inject_learnings.go) for the actual parsing.
 func parseFrontmatterBlock(lines []string) (contentStart int, utility float64) {
-	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
-		return 0, 0
+	fm, start := parseFrontMatter(lines)
+	if fm.HasUtility {
+		utility = fm.Utility
 	}
-	for i := 1; i < len(lines); i++ {
-		line := strings.TrimSpace(lines[i])
-		if line == "---" {
-			return i + 1, utility
-		}
-		if strings.HasPrefix(line, "utility:") {
-			utilityStr := strings.TrimSpace(strings.TrimPrefix(line, "utility:"))
-			if u, parseErr := strconv.ParseFloat(utilityStr, 64); parseErr == nil && u > 0 {
-				utility = u
-			}
-		}
-	}
-	return 0, utility
+	return start, utility
 }
 
 // assembleDescriptionFrom builds a description by joining the line at index i


### PR DESCRIPTION
## Summary
- Replace duplicated YAML frontmatter scanning logic in `parseFrontmatterBlock()` (inject_patterns.go) with delegation to the canonical `parseFrontMatter()` from inject_learnings.go
- Both functions are in the same `main` package; the duplicate scanned for `---` delimiters and `utility:` fields identically
- Removes ~12 lines of duplicated code and the now-unused `strconv` import

## Test plan
- [x] All existing tests pass (`go test ./...` — all 20 packages OK)
- [x] `TestHelper3_parseFrontmatterBlock` covers: valid frontmatter, no frontmatter, empty lines, frontmatter without utility, unclosed frontmatter
- [x] `TestParsePatternFile` covers end-to-end pattern parsing including utility extraction from frontmatter
- [x] Build verified (`make build`)