### PR TITLE
fix(cli): correct doc typo and normalize JSON output

### DIFF
--- a/cli/cmd/ao/main.go
+++ b/cli/cmd/ao/main.go
@@ -1,4 +1,4 @@
-// Package main is the entry point for the ol CLI.
+// Package main is the entry point for the ao CLI.
 package main
 
 // version is set at build time via ldflags.

--- a/cli/cmd/ao/search.go
+++ b/cli/cmd/ao/search.go
@@ -123,12 +123,9 @@ func outputSearchResults(query string, results []searchResult) error {
 		if results == nil {
 			results = []searchResult{}
 		}
-		data, err := json.MarshalIndent(results, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal search results: %w", err)
-		}
-		fmt.Println(string(data))
-		return nil
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(results)
 	}
 	displaySearchResults(query, results)
 	return nil

--- a/cli/cmd/ao/status.go
+++ b/cli/cmd/ao/status.go
@@ -172,12 +172,9 @@ func printFlywheelHealth(fw *flywheelBrief) {
 
 func outputStatus(status *statusOutput) error {
 	if GetOutput() == "json" {
-		data, err := json.MarshalIndent(status, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal status: %w", err)
-		}
-		fmt.Println(string(data))
-		return nil
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(status)
 	}
 
 	fmt.Println("AgentOps Status")

--- a/cli/cmd/ao/trace.go
+++ b/cli/cmd/ao/trace.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -45,12 +46,9 @@ func traceOneArtifact(graph *provenance.Graph, artifactPath string) error {
 	}
 
 	if GetOutput() == "json" {
-		data, err := json.MarshalIndent(result, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal trace result: %w", err)
-		}
-		fmt.Println(string(data))
-		return nil
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
 	}
 
 	if len(result.Chain) == 0 {


### PR DESCRIPTION
## Summary
- Fix package doc comment in `main.go` from "ol CLI" to "ao CLI"
- Replace `json.MarshalIndent` + `fmt.Println` with `json.NewEncoder(os.Stdout)` pattern in `status.go`, `trace.go`, and `search.go` to eliminate double-newline (`Encode` already appends `\n`) and align with idiomatic encoder usage elsewhere in the codebase

## Test plan
- [x] `cd cli && make build` passes
- [x] `cd cli && make test` passes (all packages OK)
- [x] Verified no test assertions depend on double-newline behavior (tests use `strings.TrimSpace` or `strings.Contains`)