### PR TITLE
chore(lint): add gocyclo, misspell, govet to linter config

### DIFF
--- a/cli/.golangci.yml
+++ b/cli/.golangci.yml
@@ -1,9 +1,14 @@
 linters:
   enable:
     - errcheck
+    - gocyclo
+    - govet
+    - misspell
     - staticcheck
 
 linters-settings:
+  gocyclo:
+    min-complexity: 25
   errcheck:
     # Don't check return values of fmt.Fprint*/fmt.Fprintln (stdout writes)
     exclude-functions:
@@ -16,7 +21,9 @@ issues:
   exclude-dirs:
     - ../tests/fixtures
   exclude-rules:
-    # Test files: defer cleanup and env manipulation don't need error checks
+    # Test files: defer cleanup and env manipulation don't need error checks;
+    # test functions naturally have high cyclomatic complexity from subtests.
     - path: _test\.go
       linters:
         - errcheck
+        - gocyclo

--- a/cli/cmd/ao/notebook_test.go
+++ b/cli/cmd/ao/notebook_test.go
@@ -248,9 +248,8 @@ func TestNotebookUpdate_EmptyPending(t *testing.T) {
 	if entry != nil {
 		t.Errorf("expected nil entry, got %+v", entry)
 	}
-	if err == nil {
-		// File doesn't exist — that's fine, err will be non-nil
-	}
+	// err is expected to be non-nil since file doesn't exist
+	_ = err
 }
 
 func TestNotebookUpdate_AtomicWrite(t *testing.T) {

--- a/cli/cmd/ao/rpi_stream_coverage_test.go
+++ b/cli/cmd/ao/rpi_stream_coverage_test.go
@@ -384,10 +384,8 @@ func TestStreamCoverage_UpdateLivePhaseStatus(t *testing.T) {
 			{Name: "planning", CurrentAction: "pending"},
 		}
 		updateLivePhaseStatus(statusPath, phases, 1, "running tests", 2, "timeout")
-		if phases[0].CurrentAction == "pending" {
-			// It should have been updated to something based on "running tests"
-			// The summarizeStatusAction function handles truncation
-		}
+		// CurrentAction may have been updated by summarizeStatusAction;
+		// the important assertion is RetryCount below.
 		if phases[0].RetryCount != 2 {
 			t.Errorf("RetryCount = %d, want 2", phases[0].RetryCount)
 		}

--- a/cli/cmd/ao/task_sync_test.go
+++ b/cli/cmd/ao/task_sync_test.go
@@ -674,7 +674,7 @@ func TestTaskSync_processTranscriptLine(t *testing.T) {
 
 	// Line with TaskCreate
 	lineCreate := `{"sessionId":"sess-42","message":{"content":[{"type":"tool_use","name":"TaskCreate","input":{"subject":"My task"}}]}}`
-	sid = processTranscriptLine(lineCreate, "", "sess-42", taskMap)
+	_ = processTranscriptLine(lineCreate, "", "sess-42", taskMap)
 	if len(taskMap) != 1 {
 		t.Fatalf("expected 1 task, got %d", len(taskMap))
 	}

--- a/cli/cmd/ao/worktree_test.go
+++ b/cli/cmd/ao/worktree_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -301,7 +302,7 @@ func TestWorktree_findRPISiblingWorktreePaths(t *testing.T) {
 
 	for _, p := range paths {
 		base := filepath.Base(p)
-		if !filepath.HasPrefix(base, "myproject-rpi-") {
+		if !strings.HasPrefix(base, "myproject-rpi-") {
 			t.Errorf("unexpected worktree path: %s", p)
 		}
 	}

--- a/cli/internal/safety/safety_test.go
+++ b/cli/internal/safety/safety_test.go
@@ -686,12 +686,10 @@ func TestFailOpen_MissingInfrastructure(t *testing.T) {
 
 	for _, check := range checks {
 		t.Run(check.name, func(t *testing.T) {
-			if !check.available {
-				// Fail open: allow the operation
-				// This mirrors "if ! command -v jq >/dev/null 2>&1; then exit 0; fi"
-				// A missing tool should NOT block operations.
-			}
+			// Fail open: whether tool is available or not, operations should
+			// not be blocked. This mirrors "if ! command -v jq >/dev/null 2>&1; then exit 0; fi"
 			// Either way, we should reach here without blocking.
+			_ = check.available
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Enables `gocyclo` (min-complexity: 25), `govet`, and `misspell` linters in `cli/.golangci.yml`, enforcing the documented cyclomatic complexity budget
- Excludes `gocyclo` from test files (alongside existing `errcheck` exclusion) since test functions with subtests naturally exceed CC thresholds
- Fixes all lint findings surfaced by the new linters: deprecated `filepath.HasPrefix`, empty if-branches (SA9003), and an ineffectual assignment

## Test plan

- [x] `golangci-lint run ./...` exits clean (0 findings)
- [x] `make build` succeeds
- [x] `go test ./...` passes all packages
- [x] No production code required `nolint` annotations — all fixes are in test files