### PR TITLE
refactor(goals): use formatter.Table in goals_history and goals_meta

### DIFF
--- a/cli/cmd/ao/goals_history.go
+++ b/cli/cmd/ao/goals_history.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/boshu2/agentops/cli/internal/formatter"
 	"github.com/boshu2/agentops/cli/internal/goals"
 	"github.com/spf13/cobra"
 )
@@ -47,15 +48,12 @@ var goalsHistoryCmd = &cobra.Command{
 		}
 
 		// Table output
-		fmt.Printf("%-20s %6s %6s %8s %10s\n", "TIMESTAMP", "PASS", "TOTAL", "SCORE", "GIT SHA")
-		fmt.Printf("%-20s %6s %6s %8s %10s\n", "---------", "----", "-----", "-----", "-------")
+		tbl := formatter.NewTable(os.Stdout, "TIMESTAMP", "PASS", "TOTAL", "SCORE", "GIT SHA")
+		tbl.SetMaxWidth(0, 20)
 		for _, e := range entries {
-			ts := e.Timestamp
-			if len(ts) > 20 {
-				ts = ts[:20]
-			}
-			fmt.Printf("%-20s %6d %6d %7.1f%% %10s\n", ts, e.GoalsPassing, e.GoalsTotal, e.Score, e.GitSHA)
+			tbl.AddRow(e.Timestamp, fmt.Sprintf("%d", e.GoalsPassing), fmt.Sprintf("%d", e.GoalsTotal), fmt.Sprintf("%.1f%%", e.Score), e.GitSHA)
 		}
+		tbl.Render()
 
 		return nil
 	},

--- a/cli/cmd/ao/goals_meta.go
+++ b/cli/cmd/ao/goals_meta.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/boshu2/agentops/cli/internal/formatter"
 	"github.com/boshu2/agentops/cli/internal/goals"
 	"github.com/spf13/cobra"
 )
@@ -51,15 +52,12 @@ var goalsMetaCmd = &cobra.Command{
 
 		// Table output.
 		fmt.Printf("Meta-Goals: %d total\n\n", len(metaGoals))
-		fmt.Printf("%-30s %-6s %8s\n", "GOAL", "RESULT", "DURATION")
-		fmt.Printf("%-30s %-6s %8s\n", "----", "------", "--------")
+		tbl := formatter.NewTable(os.Stdout, "GOAL", "RESULT", "DURATION")
+		tbl.SetMaxWidth(0, 30)
 		for _, m := range snap.Goals {
-			id := m.GoalID
-			if len(id) > 30 {
-				id = id[:27] + "..."
-			}
-			fmt.Printf("%-30s %-6s %7.1fs\n", id, m.Result, m.Duration)
+			tbl.AddRow(m.GoalID, m.Result, fmt.Sprintf("%.1fs", m.Duration))
 		}
+		tbl.Render()
 		fmt.Println()
 
 		if snap.Summary.Failing > 0 {


### PR DESCRIPTION
## Summary

- Replace hardcoded `fmt.Printf` table formatting in `goals_history.go` and `goals_meta.go` with the shared `formatter.Table` API.
- Eliminate inline truncation logic (manual string slicing like `ts[:20]` and `id[:27]+"..."`) in favor of `SetMaxWidth`, which handles truncation with trailing `...` automatically.
- Ensures consistent `tabwriter`-based column alignment across all CLI table outputs.

## Test plan

- [x] `cd cli && make build` passes
- [x] `cd cli && make test` passes (all 13 goals_history + goals_meta tests green)
- [x] Full test suite (`go test ./...`) passes
- [ ] Verify CI passes on this branch