### PR TITLE
refactor(goals): use formatter.Table in goals_measure

### DIFF
--- a/cli/cmd/ao/goals_measure.go
+++ b/cli/cmd/ao/goals_measure.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/boshu2/agentops/cli/internal/formatter"
 	"github.com/boshu2/agentops/cli/internal/goals"
 	"github.com/spf13/cobra"
 )
@@ -83,15 +84,12 @@ var goalsMeasureCmd = &cobra.Command{
 		}
 
 		// Table output
-		fmt.Printf("%-30s %-6s %8s %6s\n", "GOAL", "RESULT", "DURATION", "WEIGHT")
-		fmt.Printf("%-30s %-6s %8s %6s\n", "----", "------", "--------", "------")
+		tbl := formatter.NewTable(os.Stdout, "GOAL", "RESULT", "DURATION", "WEIGHT")
+		tbl.SetMaxWidth(0, 30)
 		for _, m := range snap.Goals {
-			id := m.GoalID
-			if len(id) > 30 {
-				id = id[:27] + "..."
-			}
-			fmt.Printf("%-30s %-6s %7.1fs %6d\n", id, m.Result, m.Duration, m.Weight)
+			tbl.AddRow(m.GoalID, m.Result, fmt.Sprintf("%.1fs", m.Duration), fmt.Sprintf("%d", m.Weight))
 		}
+		tbl.Render()
 		fmt.Println()
 		fmt.Printf("Score: %.1f%% (%d/%d passing, %d skipped)\n",
 			snap.Summary.Score, snap.Summary.Passing, snap.Summary.Total, snap.Summary.Skipped)

--- a/cli/cmd/ao/goals_measure_test.go
+++ b/cli/cmd/ao/goals_measure_test.go
@@ -380,6 +380,100 @@ func TestGoalsMeasure_MissingGoalsFile(t *testing.T) {
 	}
 }
 
+func TestGoalsMeasure_TableOutput(t *testing.T) {
+	dir := t.TempDir()
+
+	md := `# Goals
+
+Mission.
+
+## Gates
+
+| ID | Check | Weight | Description |
+|----|-------|--------|-------------|
+| pass-gate | ` + "`exit 0`" + ` | 5 | Always passes |
+| fail-gate | ` + "`exit 1`" + ` | 3 | Always fails |
+`
+	goalsPath := filepath.Join(dir, "GOALS.md")
+	if err := os.WriteFile(goalsPath, []byte(md), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	oldFile := goalsFile
+	oldJSON := goalsJSON
+	oldTimeout := goalsTimeout
+	oldGoalID := goalsMeasureGoalID
+	oldDirectives := goalsMeasureDirectives
+	defer func() {
+		goalsFile = oldFile
+		goalsJSON = oldJSON
+		goalsTimeout = oldTimeout
+		goalsMeasureGoalID = oldGoalID
+		goalsMeasureDirectives = oldDirectives
+	}()
+
+	goalsFile = goalsPath
+	goalsJSON = false // exercise table output path
+	goalsTimeout = 10
+	goalsMeasureGoalID = ""
+	goalsMeasureDirectives = false
+
+	r, w, _ := os.Pipe()
+	oldStdout := os.Stdout
+	os.Stdout = w
+
+	err := goalsMeasureCmd.RunE(goalsMeasureCmd, nil)
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("measure returned error: %v", err)
+	}
+
+	buf := make([]byte, 16384)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	// Verify table header
+	if !strings.Contains(output, "GOAL") {
+		t.Error("table output missing GOAL header")
+	}
+	if !strings.Contains(output, "RESULT") {
+		t.Error("table output missing RESULT header")
+	}
+	if !strings.Contains(output, "DURATION") {
+		t.Error("table output missing DURATION header")
+	}
+	if !strings.Contains(output, "WEIGHT") {
+		t.Error("table output missing WEIGHT header")
+	}
+
+	// Verify separator dashes
+	if !strings.Contains(output, "----") {
+		t.Error("table output missing header separator")
+	}
+
+	// Verify goal IDs appear
+	if !strings.Contains(output, "pass-gate") {
+		t.Error("table output missing pass-gate row")
+	}
+	if !strings.Contains(output, "fail-gate") {
+		t.Error("table output missing fail-gate row")
+	}
+
+	// Verify score summary line
+	if !strings.Contains(output, "Score:") {
+		t.Error("table output missing Score summary")
+	}
+}
+
 func TestGoalsMeasure_CmdAttributes(t *testing.T) {
 	if goalsMeasureCmd.Use != "measure" {
 		t.Errorf("Use = %q, want measure", goalsMeasureCmd.Use)


### PR DESCRIPTION
## Summary
- Replace hardcoded `fmt.Printf("%-30s %-6s %8s %6s\n", ...)` table formatting in `goals_measure.go` with the shared `formatter.NewTable()` API from `cli/internal/formatter/table.go`
- Eliminates inline `if len(id) > 30` truncation logic — now handled by `tbl.SetMaxWidth(0, 30)`
- Ensures consistent table styling (tabwriter-based) across all `ao` CLI commands
- Add `TestGoalsMeasure_TableOutput` test covering the non-JSON table output code path (previously untested)

## Test plan
- [x] `go test ./...` passes (all 20 packages)
- [x] `make build` succeeds
- [x] New `TestGoalsMeasure_TableOutput` verifies headers, separator, goal rows, and score summary in table mode
- [x] Existing JSON-mode tests unchanged and passing