### PR TITLE
refactor(rpi): use formatter.Table in rpi_workers

### DIFF
--- a/cli/cmd/ao/rpi_workers.go
+++ b/cli/cmd/ao/rpi_workers.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/boshu2/agentops/cli/internal/formatter"
 	"github.com/spf13/cobra"
 )
 
@@ -78,18 +79,11 @@ func runRPIWorkers(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	fmt.Printf("RUN-ID: %s\n", runID)
-	fmt.Printf("%-10s %-8s %-20s %-28s %s\n", "worker_id", "health", "reason", "last_event", "last_event_at")
-	fmt.Println(strings.Repeat("-", 96))
+	tbl := formatter.NewTable(os.Stdout, "WORKER_ID", "HEALTH", "REASON", "LAST_EVENT", "LAST_EVENT_AT")
 	for _, worker := range workers {
-		fmt.Printf("%-10s %-8s %-20s %-28s %s\n",
-			worker.WorkerID,
-			worker.Health,
-			worker.Reason,
-			worker.LastEventType,
-			worker.LastEventAt,
-		)
+		tbl.AddRow(worker.WorkerID, worker.Health, worker.Reason, worker.LastEventType, worker.LastEventAt)
 	}
-	return nil
+	return tbl.Render()
 }
 
 func projectWorkerHealth(events []RPIC2Event, heartbeat time.Time) []rpiWorkerStatus {


### PR DESCRIPTION
## Summary
- Replace hardcoded `fmt.Printf("%-10s %-8s ...")` column alignment and `strings.Repeat("-", 96)` separator in `rpi_workers.go` with `formatter.NewTable()` from `cli/internal/formatter`.
- The formatter uses `text/tabwriter` for consistent column spacing and auto-generates dash separators matching header widths.
- Net reduction of 6 lines; removes brittle width constants that would drift as data grows.

## Test plan
- [x] `cd cli && make build` passes
- [x] `cd cli && make test` passes (all 19 packages ok)
- No test file exists for `rpi_workers.go`; existing integration coverage via `cli/cmd/ao` package tests still passes