### PR TITLE
fix(mine): thread --since window, sanitize path, remove dead code

### DIFF
--- a/cli/cmd/ao/mine.go
+++ b/cli/cmd/ao/mine.go
@@ -153,7 +153,7 @@ func runMine(cmd *cobra.Command, args []string) error {
 			}
 			report.Agents = findings
 		case "code":
-			findings, codeErr := mineCodeComplexity(cwd)
+			findings, codeErr := mineCodeComplexity(cwd, window)
 			if codeErr != nil {
 				if !mineQuiet {
 					fmt.Fprintf(cmd.ErrOrStderr(), "warning: code source: %v\n", codeErr)
@@ -168,7 +168,7 @@ func runMine(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if mineEmitWorkItems && !GetDryRun() {
+	if mineEmitWorkItems {
 		if err := emitMineWorkItems(cwd, report); err != nil && !mineQuiet {
 			fmt.Fprintf(cmd.ErrOrStderr(), "warning: emit-work-items: %v\n", err)
 		}
@@ -394,7 +394,7 @@ func readDirContent(dir string) (map[string]string, error) {
 var gocycloLineRe = regexp.MustCompile(`^(\d+)\s+(\S+)\s+(\S+)\s+(\S+):(\d+):\d+$`)
 
 // mineCodeComplexity runs gocyclo and correlates with recent git edits.
-func mineCodeComplexity(cwd string) (*CodeFindings, error) {
+func mineCodeComplexity(cwd string, window time.Duration) (*CodeFindings, error) {
 	findings := &CodeFindings{}
 
 	gocycloPath, err := exec.LookPath("gocyclo")
@@ -425,7 +425,7 @@ func mineCodeComplexity(cwd string) (*CodeFindings, error) {
 		funcName := matches[3]
 		file := matches[4]
 
-		recentEdits := countRecentEdits(cwd, file)
+		recentEdits := countRecentEdits(cwd, file, window)
 
 		findings.Hotspots = append(findings.Hotspots, ComplexityHotspot{
 			File:        file,
@@ -441,9 +441,10 @@ func mineCodeComplexity(cwd string) (*CodeFindings, error) {
 	return findings, nil
 }
 
-// countRecentEdits counts how many commits touched a file in the last 7 days.
-func countRecentEdits(cwd, file string) int {
-	cmd := exec.Command("git", "log", "--since=7 days ago", "--oneline", "--", file)
+// countRecentEdits counts how many commits touched a file within the given window.
+func countRecentEdits(cwd, file string, window time.Duration) int {
+	sinceArg := fmt.Sprintf("--since=%d seconds ago", int64(window.Seconds()))
+	cmd := exec.Command("git", "log", sinceArg, "--oneline", "--", file)
 	cmd.Dir = cwd
 	out, err := cmd.Output()
 	if err != nil {
@@ -461,6 +462,7 @@ func writeMineReport(dir string, r *MineReport) error {
 	if dir == "" {
 		return fmt.Errorf("output directory must not be empty")
 	}
+	dir = filepath.Clean(dir)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create mine output dir: %w", err)
 	}

--- a/cli/cmd/ao/mine_test.go
+++ b/cli/cmd/ao/mine_test.go
@@ -606,6 +606,41 @@ func TestWriteMineReport_EmptyDir(t *testing.T) {
 	}
 }
 
+func TestCountRecentEdits_UsesWindowParam(t *testing.T) {
+	// Verify the window parameter actually reaches git log --since.
+	// A zero-duration window should count zero edits (--since=0 seconds ago = epoch, but
+	// in a fresh temp dir with no git repo, countRecentEdits returns 0 on error).
+	// With a large window in a real git repo, it should find edits.
+	// We test indirectly: the function signature accepts window and doesn't panic.
+	tmp := t.TempDir()
+
+	// No git repo → returns 0 regardless of window (git fails silently)
+	edits := countRecentEdits(tmp, "nonexistent.go", 26*time.Hour)
+	if edits != 0 {
+		t.Errorf("expected 0 edits in non-git dir, got %d", edits)
+	}
+
+	// Verify different windows don't panic
+	edits2 := countRecentEdits(tmp, "nonexistent.go", 7*24*time.Hour)
+	if edits2 != 0 {
+		t.Errorf("expected 0 edits with 7d window in non-git dir, got %d", edits2)
+	}
+}
+
+func TestMineCodeComplexity_AcceptsWindow(t *testing.T) {
+	// Verify mineCodeComplexity accepts the window param without error.
+	// In a temp dir with no Go code, it should return skipped or empty findings.
+	tmp := t.TempDir()
+	findings, err := mineCodeComplexity(tmp, 26*time.Hour)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Either skipped (no gocyclo) or empty hotspots (no Go files)
+	if !findings.Skipped && len(findings.Hotspots) != 0 {
+		t.Errorf("expected skipped or empty hotspots, got %d", len(findings.Hotspots))
+	}
+}
+
 func countNonEmptyLines(data []byte) int {
 	count := 0
 	for _, line := range bytes.Split(bytes.TrimSpace(data), []byte("\n")) {


### PR DESCRIPTION
## Summary

- **Finding 5 (MEDIUM):** `countRecentEdits` hardcoded `"--since=7 days ago"` instead of using the `--since` flag value. Now threads the parsed `window` duration through `mineCodeComplexity` and `countRecentEdits`, using `fmt.Sprintf("--since=%d seconds ago", ...)` consistently with `mineGitLog`.
- **Finding 6 (MEDIUM):** `writeMineReport` passed the `dir` parameter directly to `os.MkdirAll` without sanitization. Added `filepath.Clean(dir)` before use.
- **Finding 7 (LOW):** The `if mineEmitWorkItems && !GetDryRun()` check was redundant because dry-run already returns early at the top of `runMine`. Simplified to `if mineEmitWorkItems`.

## Test plan

- [x] `cd cli && make build` passes
- [x] `cd cli && make test` (all packages `ok`, including mine_test.go)
- [ ] CI validation workflow passes