### PR TITLE
fix(mine): guard writeMineReport against empty output dir

### DIFF
--- a/cli/cmd/ao/mine.go
+++ b/cli/cmd/ao/mine.go
@@ -458,6 +458,9 @@ func countRecentEdits(cwd, file string) int {
 
 // writeMineReport writes the mine report as JSON to the output directory.
 func writeMineReport(dir string, r *MineReport) error {
+	if dir == "" {
+		return fmt.Errorf("output directory must not be empty")
+	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create mine output dir: %w", err)
 	}

--- a/cli/cmd/ao/mine_test.go
+++ b/cli/cmd/ao/mine_test.go
@@ -592,6 +592,20 @@ func TestEmitMineWorkItems_ItemLevelDedup(t *testing.T) {
 	}
 }
 
+func TestWriteMineReport_EmptyDir(t *testing.T) {
+	// writeMineReport with empty dir should return an explicit error,
+	// NOT silently write to "." (current working directory).
+	// filepath.Clean("") returns "." so without an explicit guard,
+	// MkdirAll(filepath.Clean("")) would succeed and write to CWD.
+	err := writeMineReport("", &MineReport{})
+	if err == nil {
+		t.Fatal("expected error for empty output dir, got nil")
+	}
+	if !strings.Contains(err.Error(), "must not be empty") {
+		t.Errorf("expected 'must not be empty' in error, got: %v", err)
+	}
+}
+
 func countNonEmptyLines(data []byte) int {
 	count := 0
 	for _, line := range bytes.Split(bytes.TrimSpace(data), []byte("\n")) {


### PR DESCRIPTION
## Summary

- Add explicit empty-string guard in `writeMineReport` before `os.MkdirAll` call
- `filepath.Clean("")` returns `"."`, so without this guard, `ao mine --output-dir ""` would silently write reports to CWD instead of failing
- TDD: test written first (RED), then minimal fix (GREEN), full suite verified (REFACTOR)

## Context

Found by Codex review on PR #64. The `os.MkdirAll("")` call happens to fail on macOS with "no such file or directory", but this is platform-dependent behavior. If anyone ever adds `filepath.Clean(dir)` before the `MkdirAll` (a common refactor), it would silently succeed and write to CWD. The explicit guard makes the contract clear.

## Test plan

- [x] `TestWriteMineReport_EmptyDir` verifies empty dir returns error with "must not be empty" message
- [x] Full `make build && make test` passes with no regressions