### PR TITLE
Fix hook payload schema by including hookEventName

### DIFF
--- a/cli/embedded/hooks/commit-review-gate.sh
+++ b/cli/embedded/hooks/commit-review-gate.sh
@@ -55,13 +55,13 @@ ${DIFF_CONTENT}"
 
 # Inject as additionalContext
 if command -v jq >/dev/null 2>&1; then
-    jq -n --arg ctx "$REVIEW_MSG" '{"hookSpecificOutput":{"additionalContext":$ctx}}'
+    jq -n --arg ctx "$REVIEW_MSG" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":$ctx}}'
 else
     # Fallback: escape for JSON
     safe_msg=${REVIEW_MSG//\\/\\\\}
     safe_msg=${safe_msg//\"/\\\"}
     safe_msg=$(echo "$safe_msg" | tr '\n' ' ')
-    echo "{\"hookSpecificOutput\":{\"additionalContext\":\"$safe_msg\"}}"
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"$safe_msg\"}}"
 fi
 
 exit 0

--- a/cli/embedded/hooks/context-guard.sh
+++ b/cli/embedded/hooks/context-guard.sh
@@ -66,11 +66,11 @@ fi
 
 if [ -n "$MESSAGE" ] && [ "$MESSAGE" != "null" ]; then
     if command -v jq >/dev/null 2>&1; then
-        jq -n --arg msg "$MESSAGE" '{"hookSpecificOutput":{"additionalContext":$msg}}'
+        jq -n --arg msg "$MESSAGE" '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":$msg}}'
     else
         safe_msg=${MESSAGE//\\/\\\\}
         safe_msg=${safe_msg//\"/\\\"}
-        echo "{\"hookSpecificOutput\":{\"additionalContext\":\"$safe_msg\"}}"
+        echo "{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"$safe_msg\"}}"
     fi
 fi
 

--- a/cli/embedded/hooks/go-vet-post-edit.sh
+++ b/cli/embedded/hooks/go-vet-post-edit.sh
@@ -45,7 +45,7 @@ if [[ "$FILE_PATH" == *_test.go ]] && [[ -f "$FILE_PATH" ]]; then
     DENSITY_MSG="Assertion density warning: test functions with no assertions detected:
 $(printf '%b' "$EMPTY_TESTS")  These tests will pass regardless of code behavior."
     if command -v jq >/dev/null 2>&1; then
-      jq -n --arg ctx "$DENSITY_MSG" '{"hookSpecificOutput":{"additionalContext":$ctx}}'
+      jq -n --arg ctx "$DENSITY_MSG" '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":$ctx}}'
     else
       echo "$DENSITY_MSG" >&2
     fi

--- a/cli/embedded/hooks/intent-echo.sh
+++ b/cli/embedded/hooks/intent-echo.sh
@@ -75,12 +75,12 @@ ECHO_MSG="HIGH-STAKES OPERATION DETECTED. Before proceeding:
 Proceed ONLY after this confirmation step."
 
 if command -v jq >/dev/null 2>&1; then
-    jq -n --arg ctx "$ECHO_MSG" '{"hookSpecificOutput":{"additionalContext":$ctx}}'
+    jq -n --arg ctx "$ECHO_MSG" '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":$ctx}}'
 else
     safe_msg=${ECHO_MSG//\\/\\\\}
     safe_msg=${safe_msg//\"/\\\"}
     safe_msg=$(echo "$safe_msg" | tr '\n' ' ')
-    echo "{\"hookSpecificOutput\":{\"additionalContext\":\"$safe_msg\"}}"
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"$safe_msg\"}}"
 fi
 
 exit 0

--- a/cli/embedded/hooks/precompact-snapshot.sh
+++ b/cli/embedded/hooks/precompact-snapshot.sh
@@ -187,11 +187,11 @@ fi
 
 # Output JSON for hook system
 if command -v jq >/dev/null 2>&1; then
-  jq -n --arg summary "$SUMMARY" '{"hookSpecificOutput":{"additionalContext":$summary}}'
+  jq -n --arg summary "$SUMMARY" '{"hookSpecificOutput":{"hookEventName":"PreCompact","additionalContext":$summary}}'
 else
   safe_summary=${SUMMARY//\\/\\\\}
   safe_summary=${safe_summary//\"/\\\"}
-  echo "{\"hookSpecificOutput\":{\"additionalContext\":\"$safe_summary\"}}"
+  echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreCompact\",\"additionalContext\":\"$safe_summary\"}}"
 fi
 
 # Cleanup: keep last 5 snapshots, remove older

--- a/cli/embedded/hooks/prompt-nudge.sh
+++ b/cli/embedded/hooks/prompt-nudge.sh
@@ -91,6 +91,6 @@ fi
 [ -z "$NUDGE" ] && exit 0
 
 # Output nudge as additionalContext
-jq -n --arg nudge "$NUDGE" '{"hookSpecificOutput":{"additionalContext":$nudge}}'
+jq -n --arg nudge "$NUDGE" '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":$nudge}}'
 
 exit 0

--- a/cli/embedded/hooks/ratchet-advance.sh
+++ b/cli/embedded/hooks/ratchet-advance.sh
@@ -133,5 +133,5 @@ else
 fi
 
 # Output as additionalContext
-printf '{"hookSpecificOutput":{"additionalContext":"%s"}}\n' "$MSG"
+printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"%s"}}\n' "$MSG"
 exit 0

--- a/cli/embedded/hooks/research-loop-detector.sh
+++ b/cli/embedded/hooks/research-loop-detector.sh
@@ -57,11 +57,11 @@ case "$TOOL_NAME" in
 
         if [ -n "$NUDGE" ]; then
             if command -v jq >/dev/null 2>&1; then
-                jq -n --arg ctx "$NUDGE" '{"hookSpecificOutput":{"additionalContext":$ctx}}'
+                jq -n --arg ctx "$NUDGE" '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":$ctx}}'
             else
                 safe_msg=${NUDGE//\\/\\\\}
                 safe_msg=${safe_msg//\"/\\\"}
-                echo "{\"hookSpecificOutput\":{\"additionalContext\":\"$safe_msg\"}}"
+                echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"$safe_msg\"}}"
             fi
         fi
         ;;

--- a/cli/embedded/hooks/standards-injector.sh
+++ b/cli/embedded/hooks/standards-injector.sh
@@ -61,6 +61,6 @@ CONTENT=$(cat "$STANDARDS_FILE")
 ESCAPED=$(printf '%s' "$CONTENT" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/	/\\t/g' | awk '{if(NR>1) printf "\\n"; printf "%s", $0}')
 
 # Output hookSpecificOutput JSON
-printf '{"hookSpecificOutput":{"additionalContext":"%s"}}\n' "$ESCAPED"
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"%s"}}\n' "$ESCAPED"
 
 exit 0

--- a/hooks/commit-review-gate.sh
+++ b/hooks/commit-review-gate.sh
@@ -55,13 +55,13 @@ ${DIFF_CONTENT}"
 
 # Inject as additionalContext
 if command -v jq >/dev/null 2>&1; then
-    jq -n --arg ctx "$REVIEW_MSG" '{"hookSpecificOutput":{"additionalContext":$ctx}}'
+    jq -n --arg ctx "$REVIEW_MSG" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":$ctx}}'
 else
     # Fallback: escape for JSON
     safe_msg=${REVIEW_MSG//\\/\\\\}
     safe_msg=${safe_msg//\"/\\\"}
     safe_msg=$(echo "$safe_msg" | tr '\n' ' ')
-    echo "{\"hookSpecificOutput\":{\"additionalContext\":\"$safe_msg\"}}"
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"$safe_msg\"}}"
 fi
 
 exit 0

--- a/hooks/context-guard.sh
+++ b/hooks/context-guard.sh
@@ -66,11 +66,11 @@ fi
 
 if [ -n "$MESSAGE" ] && [ "$MESSAGE" != "null" ]; then
     if command -v jq >/dev/null 2>&1; then
-        jq -n --arg msg "$MESSAGE" '{"hookSpecificOutput":{"additionalContext":$msg}}'
+        jq -n --arg msg "$MESSAGE" '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":$msg}}'
     else
         safe_msg=${MESSAGE//\\/\\\\}
         safe_msg=${safe_msg//\"/\\\"}
-        echo "{\"hookSpecificOutput\":{\"additionalContext\":\"$safe_msg\"}}"
+        echo "{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"$safe_msg\"}}"
     fi
 fi
 

--- a/hooks/go-vet-post-edit.sh
+++ b/hooks/go-vet-post-edit.sh
@@ -45,7 +45,7 @@ if [[ "$FILE_PATH" == *_test.go ]] && [[ -f "$FILE_PATH" ]]; then
     DENSITY_MSG="Assertion density warning: test functions with no assertions detected:
 $(printf '%b' "$EMPTY_TESTS")  These tests will pass regardless of code behavior."
     if command -v jq >/dev/null 2>&1; then
-      jq -n --arg ctx "$DENSITY_MSG" '{"hookSpecificOutput":{"additionalContext":$ctx}}'
+      jq -n --arg ctx "$DENSITY_MSG" '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":$ctx}}'
     else
       echo "$DENSITY_MSG" >&2
     fi

--- a/hooks/intent-echo.sh
+++ b/hooks/intent-echo.sh
@@ -75,12 +75,12 @@ ECHO_MSG="HIGH-STAKES OPERATION DETECTED. Before proceeding:
 Proceed ONLY after this confirmation step."
 
 if command -v jq >/dev/null 2>&1; then
-    jq -n --arg ctx "$ECHO_MSG" '{"hookSpecificOutput":{"additionalContext":$ctx}}'
+    jq -n --arg ctx "$ECHO_MSG" '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":$ctx}}'
 else
     safe_msg=${ECHO_MSG//\\/\\\\}
     safe_msg=${safe_msg//\"/\\\"}
     safe_msg=$(echo "$safe_msg" | tr '\n' ' ')
-    echo "{\"hookSpecificOutput\":{\"additionalContext\":\"$safe_msg\"}}"
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"$safe_msg\"}}"
 fi
 
 exit 0

--- a/hooks/precompact-snapshot.sh
+++ b/hooks/precompact-snapshot.sh
@@ -187,11 +187,11 @@ fi
 
 # Output JSON for hook system
 if command -v jq >/dev/null 2>&1; then
-  jq -n --arg summary "$SUMMARY" '{"hookSpecificOutput":{"additionalContext":$summary}}'
+  jq -n --arg summary "$SUMMARY" '{"hookSpecificOutput":{"hookEventName":"PreCompact","additionalContext":$summary}}'
 else
   safe_summary=${SUMMARY//\\/\\\\}
   safe_summary=${safe_summary//\"/\\\"}
-  echo "{\"hookSpecificOutput\":{\"additionalContext\":\"$safe_summary\"}}"
+  echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreCompact\",\"additionalContext\":\"$safe_summary\"}}"
 fi
 
 # Cleanup: keep last 5 snapshots, remove older

--- a/hooks/prompt-nudge.sh
+++ b/hooks/prompt-nudge.sh
@@ -91,6 +91,6 @@ fi
 [ -z "$NUDGE" ] && exit 0
 
 # Output nudge as additionalContext
-jq -n --arg nudge "$NUDGE" '{"hookSpecificOutput":{"additionalContext":$nudge}}'
+jq -n --arg nudge "$NUDGE" '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":$nudge}}'
 
 exit 0

--- a/hooks/ratchet-advance.sh
+++ b/hooks/ratchet-advance.sh
@@ -133,5 +133,5 @@ else
 fi
 
 # Output as additionalContext
-printf '{"hookSpecificOutput":{"additionalContext":"%s"}}\n' "$MSG"
+printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"%s"}}\n' "$MSG"
 exit 0

--- a/hooks/research-loop-detector.sh
+++ b/hooks/research-loop-detector.sh
@@ -57,11 +57,11 @@ case "$TOOL_NAME" in
 
         if [ -n "$NUDGE" ]; then
             if command -v jq >/dev/null 2>&1; then
-                jq -n --arg ctx "$NUDGE" '{"hookSpecificOutput":{"additionalContext":$ctx}}'
+                jq -n --arg ctx "$NUDGE" '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":$ctx}}'
             else
                 safe_msg=${NUDGE//\\/\\\\}
                 safe_msg=${safe_msg//\"/\\\"}
-                echo "{\"hookSpecificOutput\":{\"additionalContext\":\"$safe_msg\"}}"
+                echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"$safe_msg\"}}"
             fi
         fi
         ;;

--- a/hooks/standards-injector.sh
+++ b/hooks/standards-injector.sh
@@ -61,6 +61,6 @@ CONTENT=$(cat "$STANDARDS_FILE")
 ESCAPED=$(printf '%s' "$CONTENT" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/	/\\t/g' | awk '{if(NR>1) printf "\\n"; printf "%s", $0}')
 
 # Output hookSpecificOutput JSON
-printf '{"hookSpecificOutput":{"additionalContext":"%s"}}\n' "$ESCAPED"
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"%s"}}\n' "$ESCAPED"
 
 exit 0


### PR DESCRIPTION
## Summary
Fixes hook JSON payload compatibility with newer Claude Code schema by adding `hookSpecificOutput.hookEventName` to hook outputs that emit `additionalContext`.

This updates both source hooks (`hooks/`) and embedded copies (`cli/embedded/hooks/`) so runtime and embedded-sync stay aligned.

## What changed
- `hooks/commit-review-gate.sh` -> `PreToolUse`
- `hooks/context-guard.sh` -> `UserPromptSubmit`
- `hooks/go-vet-post-edit.sh` -> `PostToolUse`
- `hooks/intent-echo.sh` -> `UserPromptSubmit`
- `hooks/precompact-snapshot.sh` -> `PreCompact`
- `hooks/prompt-nudge.sh` -> `UserPromptSubmit`
- `hooks/ratchet-advance.sh` -> `PostToolUse`
- `hooks/research-loop-detector.sh` -> `PostToolUse`
- `hooks/standards-injector.sh` -> `PreToolUse`
- Synced matching files under `cli/embedded/hooks/`

## Why
Without `hookEventName`, recent Claude Code versions reject these hook outputs with repeated validation errors such as:
- `Hook JSON output validation failed`
- `Hook UserPromptSubmit (UserPromptSubmit) error`

## Validation
- `bash scripts/validate-embedded-sync.sh` ✅
- `bash -n` on all changed source + embedded hook scripts ✅
- Targeted runtime checks for changed hooks (intent-echo, research-loop-detector, ratchet-advance, standards-injector, precompact-snapshot) confirming `hookEventName` present ✅

## Notes
Existing repo test suites currently show unrelated baseline failures in this environment:
- `tests/hooks/test-hooks.sh` fails coverage gate (`hooks with no test coverage: context-contract-check`)
- `tests/integration/test-hook-chain.sh` fails expected `environment.json` creation checks

These failures are pre-existing and not introduced by this patch.
