### PR TITLE
fix(nightly): repair Athena and security regressions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           ./cli/bin/ao defrag \
             --prune --dedup --oscillation-sweep \
-            --output /tmp/athena/defrag
+            --output-dir /tmp/athena/defrag
 
       - name: Check Athena health gates
         run: bash scripts/check-athena-health.sh
@@ -177,10 +177,15 @@ jobs:
 
           Please investigate and fix before the next release."
 
+          LABEL_ARGS=(--label bug)
+          if gh label list --limit 200 --json name --jq '.[].name' | grep -Fxq "nightly-failure"; then
+            LABEL_ARGS+=(--label nightly-failure)
+          fi
+
           # Check if issue already exists for today
-          EXISTING=$(gh issue list --label "nightly-failure" --search "$TITLE" --state open --json number --jq '.[0].number' 2>/dev/null || true)
-          if [[ -z "$EXISTING" ]]; then
-            gh issue create --title "$TITLE" --body "$BODY" --label "bug,nightly-failure"
+          EXISTING=$(gh issue list --state open --search "\"$TITLE\" in:title" --json number,title --jq 'map(select(.title == "'"$TITLE"'")) | .[0].number' 2>/dev/null || true)
+          if [[ -z "$EXISTING" || "$EXISTING" == "null" ]]; then
+            gh issue create --title "$TITLE" --body "$BODY" "${LABEL_ARGS[@]}"
           else
             echo "Issue #$EXISTING already exists for today's failure"
           fi

--- a/cli/cmd/ao/inject_context_paths.go
+++ b/cli/cmd/ao/inject_context_paths.go
@@ -1,21 +1,33 @@
 package main
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
-	"math/rand"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
 )
+
+var contextRandReader io.Reader = rand.Reader
 
 // contextArtifactDir returns the path for context-scoped artifacts.
 // If runID is empty, generates an adhoc identifier from the current timestamp.
 // Called automatically when --for is used; uses RPI_RUN_ID if set.
 func contextArtifactDir(runID string) string {
 	if runID == "" {
-		runID = fmt.Sprintf("adhoc-%d-%04x", time.Now().Unix(), rand.Intn(0x10000)) //nolint:gosec // non-cryptographic use
+		runID = newAdhocContextRunID(time.Now(), contextRandReader)
 	}
 	return filepath.Join(".agents", "context", runID)
+}
+
+func newAdhocContextRunID(now time.Time, r io.Reader) string {
+	suffix := make([]byte, 2)
+	if _, err := io.ReadFull(r, suffix); err != nil {
+		return fmt.Sprintf("adhoc-%d-%04x", now.Unix(), uint16(now.UnixNano()))
+	}
+	return fmt.Sprintf("adhoc-%d-%s", now.Unix(), hex.EncodeToString(suffix))
 }
 
 // ensureContextDir creates the context artifact directory on disk.

--- a/cli/cmd/ao/inject_context_paths_test.go
+++ b/cli/cmd/ao/inject_context_paths_test.go
@@ -1,11 +1,19 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
+
+type errReader struct{}
+
+func (errReader) Read(_ []byte) (int, error) {
+	return 0, errors.New("boom")
+}
 
 func TestContextArtifactDir_WithRunID(t *testing.T) {
 	got := contextArtifactDir("run-abc123")
@@ -39,6 +47,22 @@ func TestContextArtifactDir_Empty(t *testing.T) {
 		if len(parts[1]) != 4 {
 			t.Errorf("contextArtifactDir(\"\") hex suffix %q expected 4 characters", parts[1])
 		}
+	}
+}
+
+func TestNewAdhocContextRunID_UsesCryptoSuffix(t *testing.T) {
+	got := newAdhocContextRunID(time.Unix(1234, 0), strings.NewReader("\xab\xcd"))
+	if got != "adhoc-1234-abcd" {
+		t.Fatalf("newAdhocContextRunID() = %q, want %q", got, "adhoc-1234-abcd")
+	}
+}
+
+func TestNewAdhocContextRunID_FallsBackToTimeBits(t *testing.T) {
+	now := time.Unix(1234, 0).Add(0x1234)
+	got := newAdhocContextRunID(now, errReader{})
+	want := "adhoc-1234-c634"
+	if got != want {
+		t.Fatalf("newAdhocContextRunID() fallback = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace the adhoc context ID suffix with crypto/rand-backed generation and fallback tests
- fix nightly Athena defrag invocation to use --output-dir so the health gate sees latest.json
- make nightly failure issue creation tolerate a missing nightly-failure label

## Validation
- cd cli && go test ./cmd/ao
- cd cli && make build
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly.yml")'
- ./cli/bin/ao defrag --prune --dedup --oscillation-sweep --output-dir /tmp/athena-local-check/defrag && ATHENA_OUTPUT_DIR=/tmp/athena-local-check bash scripts/check-athena-health.sh