### PR TITLE
Add native Windows smoke coverage

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -611,6 +611,21 @@ jobs:
           path: cli/coverage.out
           retention-days: 7
 
+  windows-smoke:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: Run native Windows smoke tests
+        shell: pwsh
+        run: .\tests\windows\test-windows-smoke.ps1
+
   cli-integration:
     runs-on: ubuntu-latest
     steps:
@@ -784,7 +799,7 @@ jobs:
           echo "File manifests found in evidence — overlap check delegated to file-manifest-overlap job"
 
   summary:
-    needs: [doc-release-gate, smoke-test, hook-preflight, validate-hooks-doc-parity, validate-ci-policy-parity, codex-runtime-sections, embedded-sync, cli-docs-parity, shellcheck, markdownlint, security-scan, security-toolchain-gate, skill-integrity, skill-schema, skill-dependency-check, contract-compatibility-gate, memrl-health, plugin-load-test, go-build, cli-integration, json-flag-consistency, file-manifest-overlap, doctor-check, skill-lint, learning-coherence, bats-tests, check-test-staleness, swarm-evidence]
+    needs: [doc-release-gate, smoke-test, hook-preflight, validate-hooks-doc-parity, validate-ci-policy-parity, codex-runtime-sections, embedded-sync, cli-docs-parity, shellcheck, markdownlint, security-scan, security-toolchain-gate, skill-integrity, skill-schema, skill-dependency-check, contract-compatibility-gate, memrl-health, plugin-load-test, go-build, windows-smoke, cli-integration, json-flag-consistency, file-manifest-overlap, doctor-check, skill-lint, learning-coherence, bats-tests, check-test-staleness, swarm-evidence]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -810,6 +825,7 @@ jobs:
           echo "memrl-health: ${{ needs.memrl-health.result }}"
           echo "plugin-load-test: ${{ needs.plugin-load-test.result }}"
           echo "go-build: ${{ needs.go-build.result }}"
+          echo "windows-smoke: ${{ needs.windows-smoke.result }}"
           echo "cli-integration: ${{ needs.cli-integration.result }}"
           echo "json-flag-consistency: ${{ needs.json-flag-consistency.result }}"
           echo "file-manifest-overlap: ${{ needs.file-manifest-overlap.result }}"
@@ -838,6 +854,7 @@ jobs:
              [[ "${{ needs.memrl-health.result }}" != "success" ]] || \
              [[ "${{ needs.plugin-load-test.result }}" != "success" ]] || \
              [[ "${{ needs.go-build.result }}" != "success" ]] || \
+             [[ "${{ needs.windows-smoke.result }}" != "success" ]] || \
              [[ "${{ needs.cli-integration.result }}" != "success" ]] || \
              [[ "${{ needs.json-flag-consistency.result }}" != "success" ]] || \
              [[ "${{ needs.file-manifest-overlap.result }}" != "success" ]] || \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,7 @@ This repo has a canonical root worktree. It owns the common `.git` directory and
 | **swarm-evidence** | Swarm evidence files and file manifests are valid | Missing or malformed swarm evidence artifacts |
 | **validate-ci-policy-parity** | AGENTS CI table and blocking policy match workflow summary enforcement | Docs say non-blocking/required but workflow differs |
 | **validate-hooks-doc-parity** | Scoped docs avoid stale hook-count claims vs runtime `hooks/hooks.json` | Runtime hook contract changed but docs were not updated |
+| **windows-smoke** | Native Windows PowerShell installer smoke, Codex plugin temp install, local `ao doctor` Windows hints, and focused Windows-sensitive Go tests | Windows install/plugin/runtime surfaces regress while Ubuntu CI stays green |
 | **bats-tests** | BATS integration tests for shell scripts pass | Hook or script behavioral regression |
 | **check-test-staleness** | Detects stale/abandoned test files | Non-blocking (`continue-on-error: true`) |
 | **file-manifest-overlap** | No file path conflicts between workers/skills | Two skills claim the same output file |

--- a/cli/internal/rpi/worktree_test.go
+++ b/cli/internal/rpi/worktree_test.go
@@ -428,30 +428,6 @@ func TestAcquireMergeLock_MkdirAllFails(t *testing.T) {
 	}
 }
 
-func TestAcquireMergeLock_OpenFileFails(t *testing.T) {
-	if os.Getuid() == 0 {
-		t.Skip("root bypasses filesystem permissions")
-	}
-	// Exercise acquireMergeLock where os.OpenFile fails.
-	tmp := t.TempDir()
-	lockDir := filepath.Join(tmp, ".git", "agentops")
-	if err := os.MkdirAll(lockDir, 0750); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chmod(lockDir, 0500); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(lockDir, 0750) })
-
-	_, err := acquireMergeLock(tmp)
-	if err == nil {
-		t.Fatal("expected error when lock file cannot be opened")
-	}
-	if !strings.Contains(err.Error(), "open merge lock") {
-		t.Errorf("expected 'open merge lock' error, got: %v", err)
-	}
-}
-
 func TestMergeWorktree_LockDirBlocked(t *testing.T) {
 	// Exercise MergeWorktree where acquireMergeLock fails.
 	repo := initGitRepo(t)

--- a/cli/internal/rpi/worktree_unix_test.go
+++ b/cli/internal/rpi/worktree_unix_test.go
@@ -38,3 +38,28 @@ func TestAcquireMergeLock_LockFileFails_FIFO(t *testing.T) {
 		t.Errorf("expected 'acquire merge lock' error, got: %v", err)
 	}
 }
+
+func TestAcquireMergeLock_OpenFileFails(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses filesystem permissions")
+	}
+	// Exercise acquireMergeLock where os.OpenFile fails. This relies on Unix
+	// chmod semantics; Windows ACLs do not make the directory unwritable here.
+	tmp := t.TempDir()
+	lockDir := filepath.Join(tmp, ".git", "agentops")
+	if err := os.MkdirAll(lockDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(lockDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(lockDir, 0o750) })
+
+	_, err := acquireMergeLock(tmp)
+	if err == nil {
+		t.Fatal("expected error when lock file cannot be opened")
+	}
+	if !strings.Contains(err.Error(), "open merge lock") {
+		t.Errorf("expected 'open merge lock' error, got: %v", err)
+	}
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Native Windows smoke gate** — `tests/windows/test-windows-smoke.ps1` now exercises the PowerShell `ao` and Codex installers, local `ao doctor` Windows guidance, and focused Windows-sensitive Go tests, with a blocking `windows-smoke` job in `validate.yml`.
+
 ## [2.36.0] - 2026-04-11
 
 ### Added

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -1,12 +1,12 @@
 # CI/CD Architecture
 
-CI ensures code quality, security, and release integrity for the AgentOps repository. Every push and PR runs a 29-job validation pipeline. Releases are automated through GoReleaser with SBOM generation and SLSA provenance attestation.
+CI ensures code quality, security, and release integrity for the AgentOps repository. Every push and PR runs a 30-job validation pipeline. Releases are automated through GoReleaser with SBOM generation and SLSA provenance attestation.
 
 ## Workflow Map
 
 | Workflow | File | Trigger | Purpose |
 |----------|------|---------|---------|
-| Validate | `validate.yml` | Push to `main`, PRs to `main` | Primary quality gate (29 jobs) |
+| Validate | `validate.yml` | Push to `main`, PRs to `main` | Primary quality gate (30 jobs) |
 | Release Publisher | `release.yml` | Tag push (`v*`), manual dispatch | Build, publish, attest releases |
 | Nightly | `nightly.yml` | Daily 6am UTC, manual | Public proof harness: full test suite + retrieval + security + compile cycle + Dream report-shape validation over repo-visible artifacts |
 | Stale Issues | `stale.yml` | Weekly Monday 9am UTC | Auto-mark/close inactive issues and PRs |
@@ -30,13 +30,13 @@ and scheduling semantics.
 
 ## validate.yml Architecture
 
-The validate workflow runs **29 jobs** across 4 tiers of parallelism. Most jobs run independently with no `needs` dependencies, maximizing throughput.
+The validate workflow runs **30 jobs** across 4 tiers of parallelism. Most jobs run independently with no `needs` dependencies, maximizing throughput.
 
 ### Job Dependency Graph
 
 ```text
                     ┌───────────────────────────────────────────────┐
-                    │         25 independent parallel jobs          │
+                    │         26 independent parallel jobs          │
                     │                                               │
                     │  doc-release-gate    smoke-test               │
                     │  hook-preflight      validate-hooks-doc-parity│
@@ -49,7 +49,8 @@ The validate workflow runs **29 jobs** across 4 tiers of parallelism. Most jobs 
                     │  skill-dependency-check                       │
                     │  contract-compatibility-gate                  │
                     │  memrl-health        plugin-load-test         │
-                    │  go-build            cli-integration          │
+                    │  go-build            windows-smoke            │
+                    │  cli-integration                              │
                     │  file-manifest-overlap                        │
                     │  skill-lint          learning-coherence       │
                     │  bats-tests          check-test-staleness     │
@@ -66,7 +67,7 @@ The validate workflow runs **29 jobs** across 4 tiers of parallelism. Most jobs 
                       │            │              │
                     ┌─┴────────────┴──────────────┴─┐
                     │           summary             │
-                    │  (needs: ALL 28 jobs)         │
+                    │  (needs: ALL 29 jobs)         │
                     │  if: always()                 │
                     └───────────────────────────────┘
 ```
@@ -104,9 +105,10 @@ Consolidated checklist of rules enforced by the pipeline:
 5. **CLI docs must stay in sync.** After adding/changing CLI commands or flags: run `scripts/generate-cli-reference.sh`. Checked by `cli-docs-parity`.
 6. **Contracts must be catalogued.** Files added to `docs/contracts/` need a link in `docs/INDEX.md`. Checked by `contract-compatibility-gate`.
 7. **Go complexity budget.** New/modified functions must stay under cyclomatic complexity 25 (warn at 15). Checked by `go-build` via `check-go-complexity.sh`.
-8. **No TODOs in SKILL.md.** Use `bd` issue tracking instead. Checked by `skill-lint`.
-9. **No secrets in code.** `security-scan` greps for hardcoded passwords, API keys, and tokens in non-test files.
-10. **No dangerous shell patterns.** `security-scan` rejects `rm -rf /`, `curl | sh`, etc. in scripts (with explicit exceptions for installer scripts).
+8. **Windows installer smoke must pass.** PowerShell installers need to parse, temp installs need to work, and focused Windows-sensitive Go tests must pass on `windows-latest`. Checked by `windows-smoke`.
+9. **No TODOs in SKILL.md.** Use `bd` issue tracking instead. Checked by `skill-lint`.
+10. **No secrets in code.** `security-scan` greps for hardcoded passwords, API keys, and tokens in non-test files.
+11. **No dangerous shell patterns.** `security-scan` rejects `rm -rf /`, `curl | sh`, etc. in scripts (with explicit exceptions for installer scripts).
 
 ## Local CI Guide
 
@@ -144,6 +146,9 @@ bash skills/heal-skill/scripts/heal.sh --strict   # Skill integrity
 
 # If you changed Go code:
 cd cli && make build && make test
+
+# If you changed Windows installers, Codex install surfaces, or OS-specific file locking:
+powershell -ExecutionPolicy Bypass -File .\tests\windows\test-windows-smoke.ps1
 
 # If you changed hooks or lib/hook-helpers.sh:
 cd cli && make sync-hooks

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -9,6 +9,7 @@ Testing ensures AgentOps skills, hooks, and the `ao` CLI work correctly across c
 | Unit (Go) | `cli/**/*_test.go` | Go unit tests for CLI internals |
 | Integration | `tests/integration/` | Shell scripts testing CLI commands, skill invocation, hook chains |
 | Smoke | `tests/smoke-test.sh` | Quick sanity checks that the plugin loads correctly |
+| Windows smoke | `tests/windows/test-windows-smoke.ps1` | Native Windows smoke for PowerShell installers, Codex plugin staging, `ao doctor` hints, and focused Windows-sensitive Go tests |
 | Contract | `tests/hooks/*.bats`, `scripts/check-contract-compatibility.sh` | Schema and contract validation |
 | BATS | `tests/hooks/*.bats`, `tests/scripts/*.bats` | Unit tests for shell hooks and scripts using the BATS framework |
 | E2E | `tests/e2e/` | Full pipeline proof runs |
@@ -51,6 +52,7 @@ Run a specific tier:
 | Doc validation | `./tests/docs/validate-doc-release.sh` | ~10s |
 | Contract compatibility | `./scripts/check-contract-compatibility.sh` | ~10s |
 | Full CI gate (local) | `scripts/ci-local-release.sh` | 5-10 min |
+| Native Windows smoke | `powershell -ExecutionPolicy Bypass -File .\tests\windows\test-windows-smoke.ps1` | ~1-3 min |
 
 ## Writing New Tests
 
@@ -73,6 +75,7 @@ That activates `.githooks/pre-commit` and `.githooks/pre-push` for the current c
 | Script tests (BATS) | `tests/scripts/` |
 | Skill validation | `skills/<name>/scripts/validate.sh` |
 | Integration tests | `tests/integration/test-<name>.sh` |
+| Native Windows smoke | `tests/windows/` |
 | E2E proof runs | `tests/e2e/` |
 | Doc validation | `tests/docs/` |
 | Goal validation | `tests/goals/` |
@@ -215,6 +218,7 @@ Quarantined tests are excluded from the default `run-all.sh` tiers and CI. Stand
 | `tests/lint/` | Lint allowlists and code style checks |
 | `tests/explicit-skill-requests/` | Tests for explicit skill trigger patterns |
 | `tests/cli/` | CLI flag consistency and behavior tests |
+| `tests/windows/` | Native Windows installer, plugin staging, and focused CLI portability smoke tests |
 | `tests/e2e/` | End-to-end proof runs (full pipeline) |
 | `tests/docs/` | Documentation validation (links, skill counts, goal counts) |
 | `tests/scripts/` | BATS tests for repo scripts (`scripts/*.sh`) |

--- a/tests/windows/test-windows-smoke.ps1
+++ b/tests/windows/test-windows-smoke.ps1
@@ -1,0 +1,131 @@
+# test-windows-smoke.ps1 - Native Windows smoke tests for AgentOps installers and ao.
+
+[CmdletBinding()]
+param(
+  [string]$RepoRoot
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+  $scriptRoot = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
+  $RepoRoot = (Resolve-Path (Join-Path $scriptRoot "..\..")).Path
+}
+
+function Write-Step {
+  param([string]$Message)
+  Write-Host "==> $Message"
+}
+
+function Test-PowerShellSyntax {
+  param([string]$Path)
+
+  $errors = $null
+  $null = [System.Management.Automation.PSParser]::Tokenize((Get-Content -Raw -LiteralPath $Path), [ref]$errors)
+  if ($errors) {
+    $errors | ForEach-Object { Write-Error $_ }
+    throw "PowerShell syntax check failed: $Path"
+  }
+}
+
+function Invoke-GoTest {
+  param([string[]]$TestArgs)
+
+  Push-Location (Join-Path $RepoRoot "cli")
+  try {
+    & go test @TestArgs
+  }
+  finally {
+    Pop-Location
+  }
+  if ($LASTEXITCODE -ne 0) {
+    throw "go test failed: $($TestArgs -join ' ')"
+  }
+}
+
+Write-Step "Checking PowerShell installer syntax"
+Test-PowerShellSyntax (Join-Path $RepoRoot "scripts\install-ao.ps1")
+Test-PowerShellSyntax (Join-Path $RepoRoot "scripts\install-codex.ps1")
+
+Write-Step "Installing ao release binary into a temp directory"
+$aoInstallDir = Join-Path ([System.IO.Path]::GetTempPath()) ("agentops-ao-smoke-" + [Guid]::NewGuid().ToString("N"))
+try {
+  & powershell -ExecutionPolicy Bypass -File (Join-Path $RepoRoot "scripts\install-ao.ps1") -InstallDir $aoInstallDir -NoPathUpdate
+  if ($LASTEXITCODE -ne 0) {
+    throw "install-ao.ps1 failed"
+  }
+  $releaseAO = Join-Path $aoInstallDir "ao.exe"
+  & $releaseAO version
+  if ($LASTEXITCODE -ne 0) {
+    throw "installed ao.exe version smoke failed"
+  }
+}
+finally {
+  if (Test-Path -LiteralPath $aoInstallDir) {
+    Remove-Item -LiteralPath $aoInstallDir -Recurse -Force
+  }
+}
+
+Write-Step "Installing Codex plugin into a temp CODEX_HOME"
+$codexHome = Join-Path ([System.IO.Path]::GetTempPath()) ("agentops-codex-smoke-" + [Guid]::NewGuid().ToString("N"))
+try {
+  & powershell -ExecutionPolicy Bypass -File (Join-Path $RepoRoot "scripts\install-codex.ps1") -RepoRoot $RepoRoot -CodexHome $codexHome
+  if ($LASTEXITCODE -ne 0) {
+    throw "install-codex.ps1 failed"
+  }
+  $pluginRoot = Join-Path $codexHome "plugins\cache\agentops-marketplace\agentops\local"
+  $skillsRoot = Join-Path $pluginRoot "skills-codex"
+  $metadata = Join-Path $codexHome ".agentops-codex-install.json"
+  if (-not (Test-Path -LiteralPath $skillsRoot)) {
+    throw "Codex skills root missing after install: $skillsRoot"
+  }
+  if (-not (Test-Path -LiteralPath $metadata)) {
+    throw "Codex install metadata missing after install: $metadata"
+  }
+}
+finally {
+  if (Test-Path -LiteralPath $codexHome) {
+    Remove-Item -LiteralPath $codexHome -Recurse -Force
+  }
+}
+
+Write-Step "Building local ao and checking Windows doctor hints"
+$builtAO = Join-Path ([System.IO.Path]::GetTempPath()) ("ao-windows-smoke-" + [Guid]::NewGuid().ToString("N") + ".exe")
+try {
+  Push-Location (Join-Path $RepoRoot "cli")
+  try {
+    & go build -o $builtAO .\cmd\ao
+  }
+  finally {
+    Pop-Location
+  }
+  if ($LASTEXITCODE -ne 0) {
+    throw "go build failed"
+  }
+
+  $doctorJSON = & $builtAO doctor --json
+  if ($LASTEXITCODE -ne 0) {
+    throw "ao doctor --json failed"
+  }
+  $doctorText = ($doctorJSON -join "`n")
+  if ($doctorText -notmatch "install-codex\.ps1") {
+    throw "doctor output did not include the Windows Codex installer hint"
+  }
+  if ($doctorText -notmatch "Windows release|WSL/Homebrew") {
+    throw "doctor output did not include Windows dependency guidance"
+  }
+}
+finally {
+  if (Test-Path -LiteralPath $builtAO) {
+    Remove-Item -LiteralPath $builtAO -Force
+  }
+}
+
+Write-Step "Running focused Windows-sensitive Go tests"
+Invoke-GoTest -TestArgs @("-timeout", "3m", "./internal/quality")
+Invoke-GoTest -TestArgs @("-timeout", "3m", "./cmd/ao", "-run", "^(TestBatchForge_appendForgedRecord|TestAppendForgedRecord|TestBatchForgeSkipsAlreadyForged|TestLoadAndFilterTranscripts_RespectsForgedIndex|TestCanonicalArtifactPath|TestCobraDemoConceptsCommand|TestCobraDemoQuickCommand|TestCobraShowConcepts)$")
+Invoke-GoTest -TestArgs @("-timeout", "3m", "./internal/storage", "-run", "^TestWithLockedFile_")
+Invoke-GoTest -TestArgs @("-timeout", "3m", "./internal/rpi", "-run", "^TestAcquireMergeLock")
+
+Write-Host "Windows smoke tests passed"


### PR DESCRIPTION
## Summary
- add a native Windows PowerShell smoke script for installer and CLI compatibility
- wire the smoke into validate.yml as a blocking windows-smoke job
- move a Unix-permission-specific RPI lock test behind the existing !windows test file
- document the Windows smoke gate in testing and CI docs

## Local validation
- powershell -ExecutionPolicy Bypass -File .\tests\windows\test-windows-smoke.ps1
- git diff --cached --check

## Notes
A broad native Windows `go test ./...` discovery run is still red due pre-existing Windows portability debt across path separator assumptions, read-only permission tests, global HOME/.agents leakage, tmux/PID signal assumptions, symlink privilege requirements, and chain locking. The new smoke gate intentionally locks the installer/plugin/doctor/RPI-lock slice that this Windows pass exercised.