### PR TITLE
Fix overnight process liveness on Windows

### DIFF
--- a/cli/internal/overnight/recovery.go
+++ b/cli/internal/overnight/recovery.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -305,6 +306,9 @@ func ProcessAlive(pid int) bool {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
 	}
 	// signal(0) returns nil if the process exists and the caller has
 	// permission to signal it. ESRCH (or os.ErrProcessDone on Darwin /

--- a/tests/windows/test-windows-smoke.ps1
+++ b/tests/windows/test-windows-smoke.ps1
@@ -127,5 +127,6 @@ Invoke-GoTest -TestArgs @("-timeout", "3m", "./internal/quality")
 Invoke-GoTest -TestArgs @("-timeout", "3m", "./cmd/ao", "-run", "^(TestBatchForge_appendForgedRecord|TestAppendForgedRecord|TestBatchForgeSkipsAlreadyForged|TestLoadAndFilterTranscripts_RespectsForgedIndex|TestCanonicalArtifactPath|TestCobraDemoConceptsCommand|TestCobraDemoQuickCommand|TestCobraShowConcepts)$")
 Invoke-GoTest -TestArgs @("-timeout", "3m", "./internal/storage", "-run", "^TestWithLockedFile_")
 Invoke-GoTest -TestArgs @("-timeout", "3m", "./internal/rpi", "-run", "^TestAcquireMergeLock")
+Invoke-GoTest -TestArgs @("-timeout", "5m", "./internal/overnight")
 
 Write-Host "Windows smoke tests passed"


### PR DESCRIPTION
## Summary
- make overnight ProcessAlive stop before Unix signal(0) probing on Windows
- add the overnight package to the native Windows smoke gate

## Validation
- go test -timeout 3m ./internal/overnight -run ^(TestLockIsStale_OldLockLivePID|TestLockIsStale_OldLockDeadPID|TestProcessAlive_CurrentProcess|TestProcessAlive_DefinitelyDead)$ -v
- go test -timeout 5m ./internal/overnight
- powershell -ExecutionPolicy Bypass -File .\tests\windows\test-windows-smoke.ps1
- git diff --check