### PR TITLE
feat(dream): add local Gemma curator adapter

### DIFF
--- a/cli/cmd/ao/overnight_curator.go
+++ b/cli/cmd/ao/overnight_curator.go
@@ -1,0 +1,682 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/boshu2/agentops/cli/internal/config"
+)
+
+const (
+	defaultCuratorEngine    = "ollama"
+	defaultCuratorOllamaURL = "http://127.0.0.1:11435"
+	defaultCuratorModel     = "gemma4:e4b"
+	defaultCuratorHourlyCap = 20
+)
+
+var defaultCuratorJobKinds = []string{"ingest-claude-session", "lint-wiki", "dream-seed"}
+
+var (
+	curatorStatusJSON        bool
+	curatorEnqueueKind       string
+	curatorEnqueueSource     string
+	curatorEnqueueChunkStart int
+	curatorEnqueueChunkEnd   int
+	curatorCompactDryRun     bool
+	curatorCompactApply      bool
+	curatorEventSource       string
+	curatorEventSeverity     string
+	curatorEventAction       string
+	curatorEventTarget       string
+	curatorEventBudget       int
+	curatorEventNote         string
+)
+
+type dreamLocalCuratorStatus struct {
+	Available       bool                           `json:"available" yaml:"available"`
+	Supported       bool                           `json:"supported" yaml:"supported"`
+	Enabled         bool                           `json:"enabled" yaml:"enabled"`
+	Engine          string                         `json:"engine" yaml:"engine"`
+	OllamaURL       string                         `json:"ollama_url,omitempty" yaml:"ollama_url,omitempty"`
+	Model           string                         `json:"model,omitempty" yaml:"model,omitempty"`
+	ModelInstalled  bool                           `json:"model_installed" yaml:"model_installed"`
+	WorkerDir       string                         `json:"worker_dir,omitempty" yaml:"worker_dir,omitempty"`
+	VaultDir        string                         `json:"vault_dir,omitempty" yaml:"vault_dir,omitempty"`
+	HourlyCap       int                            `json:"hourly_cap,omitempty" yaml:"hourly_cap,omitempty"`
+	AllowedJobKinds []string                       `json:"allowed_job_kinds,omitempty" yaml:"allowed_job_kinds,omitempty"`
+	Ollama          curatorOllamaProbe             `json:"ollama" yaml:"ollama"`
+	Worker          curatorWorkerProbe             `json:"worker" yaml:"worker"`
+	Status          map[string]any                 `json:"status_json,omitempty" yaml:"status_json,omitempty"`
+	Diagnostics     []string                       `json:"diagnostics,omitempty" yaml:"diagnostics,omitempty"`
+	Runners         map[string]curatorRunnerStatus `json:"runners,omitempty" yaml:"runners,omitempty"`
+}
+
+type curatorOllamaProbe struct {
+	Reachable bool     `json:"reachable" yaml:"reachable"`
+	Version   string   `json:"version,omitempty" yaml:"version,omitempty"`
+	Models    []string `json:"models,omitempty" yaml:"models,omitempty"`
+	Error     string   `json:"error,omitempty" yaml:"error,omitempty"`
+}
+
+type curatorWorkerProbe struct {
+	QueueDepth      int    `json:"queue_depth" yaml:"queue_depth"`
+	ProcessingDepth int    `json:"processing_depth" yaml:"processing_depth"`
+	PendingLogDepth int    `json:"pending_log_depth" yaml:"pending_log_depth"`
+	StatusPath      string `json:"status_path,omitempty" yaml:"status_path,omitempty"`
+	StalePID        bool   `json:"stale_pid,omitempty" yaml:"stale_pid,omitempty"`
+	Error           string `json:"error,omitempty" yaml:"error,omitempty"`
+}
+
+type curatorRunnerStatus struct {
+	Available bool   `json:"available" yaml:"available"`
+	Command   string `json:"command,omitempty" yaml:"command,omitempty"`
+	Note      string `json:"note,omitempty" yaml:"note,omitempty"`
+}
+
+type curatorJob struct {
+	ID         string            `json:"id"`
+	Kind       string            `json:"kind"`
+	CreatedAt  string            `json:"created_at"`
+	MaxRetries int               `json:"max_retries"`
+	Source     *curatorJobSource `json:"source,omitempty"`
+}
+
+type curatorJobSource struct {
+	Path       string `json:"path"`
+	ChunkStart int    `json:"chunk_start"`
+	ChunkEnd   int    `json:"chunk_end"`
+}
+
+type curatorEvent struct {
+	SchemaVersion    int    `json:"schema_version"`
+	ID               string `json:"id"`
+	CreatedAt        string `json:"created_at"`
+	Source           string `json:"source"`
+	Severity         string `json:"severity"`
+	DesiredAction    string `json:"desired_action"`
+	EscalationTarget string `json:"escalation_target"`
+	Budget           int    `json:"budget"`
+	Note             string `json:"note,omitempty"`
+	Status           string `json:"status"`
+}
+
+var overnightCuratorCmd = &cobra.Command{
+	Use:   "curator",
+	Short: "Operate the local Tier 1 Dream curator",
+	Long: `Inspect and operate a local Tier 1 Dream curator such as Ollama/Gemma.
+
+The curator adapter is intentionally bounded: it can report health, enqueue
+allowlisted knowledge jobs, compact pending audit log entries, and write
+needs-review escalation events for Tier 2 runners. It does not create an
+unbounded model-to-model invocation loop.`,
+}
+
+var overnightCuratorStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Report local curator queue, worker, and model health",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		status, err := getDreamLocalCuratorStatus(2 * time.Second)
+		if err != nil {
+			return err
+		}
+		return outputCuratorStatus(status, curatorStatusJSON || GetOutput() == "json")
+	},
+}
+
+var overnightCuratorDiagnoseCmd = &cobra.Command{
+	Use:   "diagnose",
+	Short: "Explain local curator setup problems",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		status, err := getDreamLocalCuratorStatus(2 * time.Second)
+		if err != nil {
+			return err
+		}
+		if curatorStatusJSON || GetOutput() == "json" {
+			return outputCuratorStatus(status, true)
+		}
+		if len(status.Diagnostics) == 0 {
+			fmt.Println("Local curator looks ready.")
+			return nil
+		}
+		for _, diagnostic := range status.Diagnostics {
+			fmt.Printf("- %s\n", diagnostic)
+		}
+		return nil
+	},
+}
+
+var overnightCuratorEnqueueCmd = &cobra.Command{
+	Use:   "enqueue",
+	Short: "Enqueue an allowlisted local curator job",
+	Args:  cobra.NoArgs,
+	RunE:  runCuratorEnqueue,
+}
+
+var overnightCuratorCompactCmd = &cobra.Command{
+	Use:   "compact",
+	Short: "Run the local curator pending-log compactor",
+	Args:  cobra.NoArgs,
+	RunE:  runCuratorCompact,
+}
+
+var overnightCuratorEventCmd = &cobra.Command{
+	Use:   "event",
+	Short: "Write a bounded needs-review escalation event",
+	Args:  cobra.NoArgs,
+	RunE:  runCuratorEvent,
+}
+
+func init() {
+	overnightCmd.AddCommand(overnightCuratorCmd)
+	overnightCuratorCmd.AddCommand(overnightCuratorStatusCmd, overnightCuratorDiagnoseCmd, overnightCuratorEnqueueCmd, overnightCuratorCompactCmd, overnightCuratorEventCmd)
+
+	overnightCuratorStatusCmd.Flags().BoolVar(&curatorStatusJSON, "json", false, "Render curator status as JSON")
+	overnightCuratorDiagnoseCmd.Flags().BoolVar(&curatorStatusJSON, "json", false, "Render curator diagnosis as JSON")
+
+	overnightCuratorEnqueueCmd.Flags().StringVar(&curatorEnqueueKind, "kind", "", "Job kind to enqueue: ingest-claude-session, lint-wiki, or dream-seed")
+	overnightCuratorEnqueueCmd.Flags().StringVar(&curatorEnqueueSource, "source", "", "Source path for ingest-claude-session jobs")
+	overnightCuratorEnqueueCmd.Flags().IntVar(&curatorEnqueueChunkStart, "chunk-start", 0, "Start chunk index for ingest-claude-session jobs")
+	overnightCuratorEnqueueCmd.Flags().IntVar(&curatorEnqueueChunkEnd, "chunk-end", 0, "End chunk index for ingest-claude-session jobs")
+
+	overnightCuratorCompactCmd.Flags().BoolVar(&curatorCompactDryRun, "dry-run", false, "Preview pending-log compaction without writing")
+	overnightCuratorCompactCmd.Flags().BoolVar(&curatorCompactApply, "apply", false, "Apply pending-log compaction")
+
+	overnightCuratorEventCmd.Flags().StringVar(&curatorEventSource, "source", "", "Event source, for example gemma or local-soc")
+	overnightCuratorEventCmd.Flags().StringVar(&curatorEventSeverity, "severity", "", "Event severity: info, warn, high, or critical")
+	overnightCuratorEventCmd.Flags().StringVar(&curatorEventAction, "desired-action", "", "Requested bounded action for Tier 2 review")
+	overnightCuratorEventCmd.Flags().StringVar(&curatorEventTarget, "target", "dream-council", "Escalation target")
+	overnightCuratorEventCmd.Flags().IntVar(&curatorEventBudget, "budget", 1, "Maximum downstream event budget")
+	overnightCuratorEventCmd.Flags().StringVar(&curatorEventNote, "note", "", "Optional operator note")
+}
+
+func getDreamLocalCuratorStatus(timeout time.Duration) (dreamLocalCuratorStatus, error) {
+	cfg, err := config.Load(nil)
+	if err != nil {
+		return dreamLocalCuratorStatus{}, fmt.Errorf("load config: %w", err)
+	}
+	curator := resolveDreamLocalCuratorConfig(cfg.Dream.LocalCurator, timeout)
+	return buildDreamLocalCuratorStatus(curator, timeout), nil
+}
+
+func resolveDreamLocalCuratorConfig(cfg config.DreamLocalCuratorConfig, timeout time.Duration) config.DreamLocalCuratorConfig {
+	resolved := cfg
+	if resolved.Engine == "" {
+		resolved.Engine = defaultCuratorEngine
+	}
+	if resolved.WorkerDir == "" && curatorDirExists(`D:\dream`) {
+		resolved.WorkerDir = `D:\dream`
+	}
+	if resolved.VaultDir == "" && curatorDirExists(`D:\vault`) {
+		resolved.VaultDir = `D:\vault`
+	}
+	if resolved.OllamaURL == "" {
+		fallbackEndpoint := ""
+		for _, endpoint := range []string{defaultCuratorOllamaURL, "http://127.0.0.1:11434"} {
+			probe := probeOllama(endpoint, timeout)
+			if !probe.Reachable {
+				continue
+			}
+			if fallbackEndpoint == "" {
+				fallbackEndpoint = endpoint
+			}
+			if containsString(probe.Models, defaultCuratorModel) {
+				resolved.OllamaURL = endpoint
+				break
+			}
+		}
+		if resolved.OllamaURL == "" {
+			resolved.OllamaURL = fallbackEndpoint
+		}
+		if resolved.OllamaURL == "" {
+			resolved.OllamaURL = defaultCuratorOllamaURL
+		}
+	}
+	if resolved.Model == "" {
+		probe := probeOllama(resolved.OllamaURL, timeout)
+		for _, candidate := range []string{defaultCuratorModel, "gemma4:latest", "gemma4:26b"} {
+			if containsString(probe.Models, candidate) {
+				resolved.Model = candidate
+				break
+			}
+		}
+		if resolved.Model == "" {
+			resolved.Model = defaultCuratorModel
+		}
+	}
+	if resolved.HourlyCap == 0 {
+		resolved.HourlyCap = defaultCuratorHourlyCap
+	}
+	if len(resolved.AllowedJobKinds) == 0 {
+		resolved.AllowedJobKinds = append([]string{}, defaultCuratorJobKinds...)
+	}
+	if resolved.Enabled == nil {
+		enabled := resolved.WorkerDir != "" || containsString(probeOllama(resolved.OllamaURL, timeout).Models, resolved.Model)
+		resolved.Enabled = &enabled
+	}
+	return resolved
+}
+
+func buildDreamLocalCuratorStatus(curator config.DreamLocalCuratorConfig, timeout time.Duration) dreamLocalCuratorStatus {
+	status := dreamLocalCuratorStatus{
+		Enabled:         curator.Enabled != nil && *curator.Enabled,
+		Engine:          curator.Engine,
+		OllamaURL:       curator.OllamaURL,
+		Model:           curator.Model,
+		WorkerDir:       curator.WorkerDir,
+		VaultDir:        curator.VaultDir,
+		HourlyCap:       curator.HourlyCap,
+		AllowedJobKinds: append([]string{}, curator.AllowedJobKinds...),
+		Runners:         detectCuratorRunnerStatuses(),
+	}
+	status.Ollama = probeOllama(curator.OllamaURL, timeout)
+	status.ModelInstalled = containsString(status.Ollama.Models, curator.Model)
+	status.Worker = probeCuratorWorker(curator.WorkerDir)
+	status.Status = readCuratorStatusJSON(status.Worker.StatusPath)
+	status.Diagnostics = diagnoseLocalCurator(status)
+	status.Available = status.Ollama.Reachable && status.ModelInstalled && status.Worker.Error == ""
+	status.Supported = status.Engine == defaultCuratorEngine
+	return status
+}
+
+func isDreamLocalCuratorConfigured(curator config.DreamLocalCuratorConfig) bool {
+	return curator.Enabled != nil ||
+		curator.Engine != "" ||
+		curator.OllamaURL != "" ||
+		curator.Model != "" ||
+		curator.WorkerDir != "" ||
+		curator.VaultDir != "" ||
+		curator.HourlyCap != 0 ||
+		len(curator.AllowedJobKinds) > 0
+}
+
+func probeOllama(endpoint string, timeout time.Duration) curatorOllamaProbe {
+	probe := curatorOllamaProbe{}
+	if strings.TrimSpace(endpoint) == "" {
+		probe.Error = "ollama URL is empty"
+		return probe
+	}
+	client := &http.Client{Timeout: timeout}
+	versionURL := strings.TrimRight(endpoint, "/") + "/api/version"
+	var versionPayload struct {
+		Version string `json:"version"`
+	}
+	if err := getJSON(client, versionURL, &versionPayload); err != nil {
+		probe.Error = err.Error()
+		return probe
+	}
+	probe.Reachable = true
+	probe.Version = versionPayload.Version
+
+	var tagsPayload struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	tagsURL := strings.TrimRight(endpoint, "/") + "/api/tags"
+	if err := getJSON(client, tagsURL, &tagsPayload); err != nil {
+		probe.Error = err.Error()
+		return probe
+	}
+	for _, model := range tagsPayload.Models {
+		if model.Name != "" {
+			probe.Models = append(probe.Models, model.Name)
+		}
+	}
+	sort.Strings(probe.Models)
+	return probe
+}
+
+func getJSON(client *http.Client, url string, dst any) error {
+	resp, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("%s returned %s: %s", url, resp.Status, strings.TrimSpace(string(body)))
+	}
+	return json.NewDecoder(resp.Body).Decode(dst)
+}
+
+func probeCuratorWorker(workerDir string) curatorWorkerProbe {
+	probe := curatorWorkerProbe{}
+	if strings.TrimSpace(workerDir) == "" {
+		probe.Error = "worker_dir is not configured"
+		return probe
+	}
+	if !curatorDirExists(workerDir) {
+		probe.Error = fmt.Sprintf("worker_dir %q does not exist", workerDir)
+		return probe
+	}
+	probe.QueueDepth = countJSONFiles(filepath.Join(workerDir, "queue"))
+	probe.ProcessingDepth = countJSONFiles(filepath.Join(workerDir, "processing"))
+	probe.PendingLogDepth = countTextFiles(filepath.Join(workerDir, "logs", "pending-log-entries"))
+	probe.StatusPath = filepath.Join(workerDir, "logs", "status.json")
+	status := readCuratorStatusJSON(probe.StatusPath)
+	if pid, ok := status["pid"].(float64); ok && pid > 0 {
+		probe.StalePID = !curatorProcessExists(int(pid))
+	}
+	return probe
+}
+
+func readCuratorStatusJSON(path string) map[string]any {
+	if path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	out := map[string]any{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+func diagnoseLocalCurator(status dreamLocalCuratorStatus) []string {
+	var diagnostics []string
+	if status.Engine != defaultCuratorEngine {
+		diagnostics = append(diagnostics, fmt.Sprintf("unsupported local curator engine %q; V1 supports ollama", status.Engine))
+	}
+	if status.Worker.Error != "" {
+		diagnostics = append(diagnostics, status.Worker.Error)
+	}
+	if strings.TrimSpace(status.VaultDir) == "" {
+		diagnostics = append(diagnostics, "vault_dir is not configured")
+	} else if !curatorDirExists(status.VaultDir) {
+		diagnostics = append(diagnostics, fmt.Sprintf("vault_dir %q does not exist", status.VaultDir))
+	}
+	if !status.Ollama.Reachable {
+		diagnostics = append(diagnostics, fmt.Sprintf("Ollama is not reachable at %s: %s", status.OllamaURL, status.Ollama.Error))
+	}
+	if status.Ollama.Reachable && !status.ModelInstalled {
+		diagnostics = append(diagnostics, fmt.Sprintf("model %q is not installed at %s", status.Model, status.OllamaURL))
+	}
+	if status.Worker.StalePID {
+		diagnostics = append(diagnostics, "worker status.json pid does not appear to be running")
+	}
+	for _, name := range []string{"openclaw", "oc-ask"} {
+		if runner, ok := status.Runners[name]; ok && runner.Available {
+			continue
+		}
+		diagnostics = append(diagnostics, fmt.Sprintf("%s bridge is not discoverable; leaving it unsupported for trigger mesh execution", name))
+	}
+	if runner, ok := status.Runners["codex"]; ok && !runner.Available {
+		diagnostics = append(diagnostics, "codex runner is not discoverable on PATH for Tier 2 review")
+	}
+	if runner, ok := status.Runners["claude"]; ok && !runner.Available {
+		diagnostics = append(diagnostics, "claude runner is not discoverable on PATH for Tier 2 review")
+	}
+	return diagnostics
+}
+
+func detectCuratorRunnerStatuses() map[string]curatorRunnerStatus {
+	out := map[string]curatorRunnerStatus{}
+	for _, name := range []string{"codex", "claude", "openclaw", "oc-ask"} {
+		path, err := exec.LookPath(name)
+		status := curatorRunnerStatus{Available: err == nil}
+		if err == nil {
+			status.Command = path
+		}
+		switch name {
+		case "openclaw", "oc-ask":
+			status.Note = "bridge must be discoverable before OpenClaw/Morai can be marked supported"
+		case "codex", "claude":
+			status.Note = "Tier 2 Dream Council runner"
+		}
+		out[name] = status
+	}
+	return out
+}
+
+func runCuratorEnqueue(cmd *cobra.Command, args []string) error {
+	status, err := getDreamLocalCuratorStatus(2 * time.Second)
+	if err != nil {
+		return err
+	}
+	kind := strings.TrimSpace(curatorEnqueueKind)
+	if !containsString(status.AllowedJobKinds, kind) {
+		return fmt.Errorf("unsupported curator job kind %q: allowed kinds are %s", kind, strings.Join(status.AllowedJobKinds, ", "))
+	}
+	job := curatorJob{
+		ID:         buildCuratorID(kind),
+		Kind:       kind,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		MaxRetries: 1,
+	}
+	if kind == "ingest-claude-session" {
+		if strings.TrimSpace(curatorEnqueueSource) == "" {
+			return errors.New("--source is required for ingest-claude-session")
+		}
+		if curatorEnqueueChunkEnd <= curatorEnqueueChunkStart {
+			return errors.New("--chunk-end must be greater than --chunk-start for ingest-claude-session")
+		}
+		job.Source = &curatorJobSource{
+			Path:       curatorEnqueueSource,
+			ChunkStart: curatorEnqueueChunkStart,
+			ChunkEnd:   curatorEnqueueChunkEnd,
+		}
+	}
+	if GetDryRun() {
+		return outputCuratorObject(map[string]any{"dry_run": true, "job": job}, curatorStatusJSON || GetOutput() == "json")
+	}
+	queueDir := filepath.Join(status.WorkerDir, "queue")
+	if err := os.MkdirAll(queueDir, 0o755); err != nil {
+		return fmt.Errorf("create curator queue dir: %w", err)
+	}
+	path := filepath.Join(queueDir, job.ID+".json")
+	if err := writeJSONAtomic(path, job); err != nil {
+		return err
+	}
+	return outputCuratorObject(map[string]any{"enqueued": path, "job": job}, curatorStatusJSON || GetOutput() == "json")
+}
+
+func runCuratorCompact(cmd *cobra.Command, args []string) error {
+	if curatorCompactDryRun && curatorCompactApply {
+		return errors.New("--dry-run and --apply are mutually exclusive")
+	}
+	status, err := getDreamLocalCuratorStatus(2 * time.Second)
+	if err != nil {
+		return err
+	}
+	script := filepath.Join(status.WorkerDir, "compact-log.js")
+	if _, err := os.Stat(script); err != nil {
+		return fmt.Errorf("compact-log.js is not available at %s: %w", script, err)
+	}
+	args = []string{script}
+	if curatorCompactDryRun || !curatorCompactApply {
+		args = append(args, "--dry-run")
+	}
+	run := exec.Command("node", args...)
+	var stdout, stderr bytes.Buffer
+	run.Stdout = &stdout
+	run.Stderr = &stderr
+	if err := run.Run(); err != nil {
+		return fmt.Errorf("run compact-log.js: %w\n%s", err, strings.TrimSpace(stderr.String()))
+	}
+	fmt.Print(stdout.String())
+	if stderr.Len() > 0 {
+		fmt.Fprint(os.Stderr, stderr.String())
+	}
+	return nil
+}
+
+func runCuratorEvent(cmd *cobra.Command, args []string) error {
+	status, err := getDreamLocalCuratorStatus(2 * time.Second)
+	if err != nil {
+		return err
+	}
+	source := strings.TrimSpace(curatorEventSource)
+	severity := strings.TrimSpace(curatorEventSeverity)
+	action := strings.TrimSpace(curatorEventAction)
+	if source == "" || severity == "" || action == "" {
+		return errors.New("--source, --severity, and --desired-action are required")
+	}
+	if !containsString([]string{"info", "warn", "high", "critical"}, severity) {
+		return fmt.Errorf("unsupported severity %q: expected info, warn, high, or critical", severity)
+	}
+	if curatorEventBudget < 0 {
+		return errors.New("--budget cannot be negative")
+	}
+	event := curatorEvent{
+		SchemaVersion:    1,
+		ID:               buildCuratorID("event"),
+		CreatedAt:        time.Now().UTC().Format(time.RFC3339),
+		Source:           source,
+		Severity:         severity,
+		DesiredAction:    action,
+		EscalationTarget: strings.TrimSpace(curatorEventTarget),
+		Budget:           curatorEventBudget,
+		Note:             strings.TrimSpace(curatorEventNote),
+		Status:           "needs-review",
+	}
+	if event.EscalationTarget == "" {
+		event.EscalationTarget = "dream-council"
+	}
+	if GetDryRun() {
+		return outputCuratorObject(map[string]any{"dry_run": true, "event": event}, curatorStatusJSON || GetOutput() == "json")
+	}
+	eventsDir := filepath.Join(status.WorkerDir, "events")
+	if err := os.MkdirAll(eventsDir, 0o755); err != nil {
+		return fmt.Errorf("create curator events dir: %w", err)
+	}
+	path := filepath.Join(eventsDir, "pending.jsonl")
+	line, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open curator event ledger: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		return fmt.Errorf("write curator event ledger: %w", err)
+	}
+	return outputCuratorObject(map[string]any{"event_path": path, "event": event}, curatorStatusJSON || GetOutput() == "json")
+}
+
+func outputCuratorStatus(status dreamLocalCuratorStatus, asJSON bool) error {
+	return outputCuratorObject(status, asJSON)
+}
+
+func outputCuratorObject(value any, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(value)
+	}
+	if GetOutput() == "yaml" {
+		enc := yaml.NewEncoder(os.Stdout)
+		if err := enc.Encode(value); err != nil {
+			_ = enc.Close()
+			return err
+		}
+		return enc.Close()
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+func writeJSONAtomic(path string, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+	return nil
+}
+
+func buildCuratorID(kind string) string {
+	var b [4]byte
+	_, _ = rand.Read(b[:])
+	suffix := hex.EncodeToString(b[:])
+	return fmt.Sprintf("%s-%s-%s", time.Now().UTC().Format("20060102T150405Z"), strings.ReplaceAll(kind, ":", "-"), suffix)
+}
+
+func curatorDirExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func countJSONFiles(dir string) int {
+	return countFilesByExt(dir, ".json")
+}
+
+func countTextFiles(dir string) int {
+	return countFilesByExt(dir, ".txt")
+}
+
+func countFilesByExt(dir, ext string) int {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	count := 0
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.EqualFold(filepath.Ext(entry.Name()), ext) {
+			count++
+		}
+	}
+	return count
+}
+
+func containsString(items []string, needle string) bool {
+	for _, item := range items {
+		if item == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func curatorProcessExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		out, err := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/FO", "CSV", "/NH").Output()
+		return err == nil && strings.Contains(string(out), fmt.Sprintf(`"%d"`, pid))
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return process.Signal(syscall.Signal(0)) == nil
+}

--- a/cli/cmd/ao/overnight_curator_test.go
+++ b/cli/cmd/ao/overnight_curator_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/boshu2/agentops/cli/internal/config"
+)
+
+func TestResolveDreamLocalCuratorConfigDetectsOllamaModel(t *testing.T) {
+	server := fakeOllamaServer(t, []string{"gemma4:e4b", "gemma2:9b"})
+	workerDir := t.TempDir()
+	vaultDir := t.TempDir()
+
+	enabled := true
+	got := resolveDreamLocalCuratorConfig(config.DreamLocalCuratorConfig{
+		Enabled:   &enabled,
+		OllamaURL: server.URL,
+		WorkerDir: workerDir,
+		VaultDir:  vaultDir,
+	}, time.Second)
+
+	if got.Engine != "ollama" {
+		t.Fatalf("Engine = %q, want ollama", got.Engine)
+	}
+	if got.Model != "gemma4:e4b" {
+		t.Fatalf("Model = %q, want gemma4:e4b", got.Model)
+	}
+	if got.HourlyCap != 20 {
+		t.Fatalf("HourlyCap = %d, want 20", got.HourlyCap)
+	}
+	if got.AllowedJobKinds == nil || strings.Join(got.AllowedJobKinds, ",") != "ingest-claude-session,lint-wiki,dream-seed" {
+		t.Fatalf("AllowedJobKinds = %#v", got.AllowedJobKinds)
+	}
+}
+
+func TestRunCuratorEnqueueWritesValidatedJob(t *testing.T) {
+	server := fakeOllamaServer(t, []string{"gemma4:e4b"})
+	workerDir := t.TempDir()
+	vaultDir := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), ".agentops", "config.yaml")
+	t.Setenv("AGENTOPS_CONFIG", configPath)
+	if err := config.Save(&config.Config{Dream: config.DreamConfig{
+		LocalCurator: config.DreamLocalCuratorConfig{
+			Enabled:         testBoolPtr(true),
+			Engine:          "ollama",
+			OllamaURL:       server.URL,
+			Model:           "gemma4:e4b",
+			WorkerDir:       workerDir,
+			VaultDir:        vaultDir,
+			HourlyCap:       20,
+			AllowedJobKinds: []string{"ingest-claude-session", "lint-wiki", "dream-seed"},
+		},
+	}}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	oldKind := curatorEnqueueKind
+	oldSource := curatorEnqueueSource
+	oldStart := curatorEnqueueChunkStart
+	oldEnd := curatorEnqueueChunkEnd
+	oldDryRun := dryRun
+	oldOutput := output
+	defer func() {
+		curatorEnqueueKind = oldKind
+		curatorEnqueueSource = oldSource
+		curatorEnqueueChunkStart = oldStart
+		curatorEnqueueChunkEnd = oldEnd
+		dryRun = oldDryRun
+		output = oldOutput
+	}()
+
+	dryRun = false
+	output = "json"
+	curatorEnqueueKind = "ingest-claude-session"
+	curatorEnqueueSource = filepath.Join(vaultDir, "session.jsonl")
+	curatorEnqueueChunkStart = 0
+	curatorEnqueueChunkEnd = 10
+
+	if _, err := captureStdout(t, func() error { return runCuratorEnqueue(&cobra.Command{}, nil) }); err != nil {
+		t.Fatalf("runCuratorEnqueue: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(workerDir, "queue"))
+	if err != nil {
+		t.Fatalf("read queue: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("queue entries = %d, want 1", len(entries))
+	}
+	data, err := os.ReadFile(filepath.Join(workerDir, "queue", entries[0].Name()))
+	if err != nil {
+		t.Fatalf("read job: %v", err)
+	}
+	var job curatorJob
+	if err := json.Unmarshal(data, &job); err != nil {
+		t.Fatalf("parse job: %v", err)
+	}
+	if job.Kind != "ingest-claude-session" || job.Source == nil || job.Source.ChunkEnd != 10 {
+		t.Fatalf("job = %#v", job)
+	}
+}
+
+func TestMaybeWriteDreamSchedulerArtifactsWindowsTaskScheduler(t *testing.T) {
+	cwd := t.TempDir()
+	generated, warnings, err := maybeWriteDreamSchedulerArtifacts(cwd, dreamHostProfile{OS: "windows"}, config.DreamConfig{
+		SchedulerMode: "task-scheduler",
+		ScheduleAt:    "02:15",
+	})
+	if err != nil {
+		t.Fatalf("maybeWriteDreamSchedulerArtifacts: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %#v, want none", warnings)
+	}
+	path := generated["task_scheduler"]
+	if path == "" {
+		t.Fatalf("task_scheduler artifact missing: %#v", generated)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read generated artifact: %v", err)
+	}
+	body := string(data)
+	if !strings.Contains(body, "Register-ScheduledTask") || !strings.Contains(body, "ao overnight start") || !strings.Contains(body, "02:15") {
+		t.Fatalf("unexpected task scheduler artifact:\n%s", body)
+	}
+}
+
+func fakeOllamaServer(t *testing.T, models []string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/version":
+			_, _ = w.Write([]byte(`{"version":"0.20.5"}`))
+		case "/api/tags":
+			payload := struct {
+				Models []struct {
+					Name string `json:"name"`
+				} `json:"models"`
+			}{}
+			for _, model := range models {
+				payload.Models = append(payload.Models, struct {
+					Name string `json:"name"`
+				}{Name: model})
+			}
+			_ = json.NewEncoder(w).Encode(payload)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func testBoolPtr(v bool) *bool {
+	return &v
+}

--- a/cli/cmd/ao/overnight_setup.go
+++ b/cli/cmd/ao/overnight_setup.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -55,19 +56,20 @@ type dreamHostProfile struct {
 }
 
 type dreamSetupSummary struct {
-	SchemaVersion  int                  `json:"schema_version" yaml:"schema_version"`
-	Mode           string               `json:"mode" yaml:"mode"`
-	Status         string               `json:"status" yaml:"status"`
-	Apply          bool                 `json:"apply" yaml:"apply"`
-	RepoRoot       string               `json:"repo_root" yaml:"repo_root"`
-	ConfigPath     string               `json:"config_path" yaml:"config_path"`
-	Host           dreamHostProfile     `json:"host" yaml:"host"`
-	Runtimes       []dreamRuntimeStatus `json:"runtimes" yaml:"runtimes"`
-	DreamConfig    config.DreamConfig   `json:"dream" yaml:"dream"`
-	GeneratedFiles map[string]string    `json:"generated_files,omitempty" yaml:"generated_files,omitempty"`
-	Warnings       []string             `json:"warnings,omitempty" yaml:"warnings,omitempty"`
-	Recommended    []string             `json:"recommended,omitempty" yaml:"recommended,omitempty"`
-	NextAction     string               `json:"next_action" yaml:"next_action"`
+	SchemaVersion  int                     `json:"schema_version" yaml:"schema_version"`
+	Mode           string                  `json:"mode" yaml:"mode"`
+	Status         string                  `json:"status" yaml:"status"`
+	Apply          bool                    `json:"apply" yaml:"apply"`
+	RepoRoot       string                  `json:"repo_root" yaml:"repo_root"`
+	ConfigPath     string                  `json:"config_path" yaml:"config_path"`
+	Host           dreamHostProfile        `json:"host" yaml:"host"`
+	Runtimes       []dreamRuntimeStatus    `json:"runtimes" yaml:"runtimes"`
+	LocalCurator   dreamLocalCuratorStatus `json:"local_curator" yaml:"local_curator"`
+	DreamConfig    config.DreamConfig      `json:"dream" yaml:"dream"`
+	GeneratedFiles map[string]string       `json:"generated_files,omitempty" yaml:"generated_files,omitempty"`
+	Warnings       []string                `json:"warnings,omitempty" yaml:"warnings,omitempty"`
+	Recommended    []string                `json:"recommended,omitempty" yaml:"recommended,omitempty"`
+	NextAction     string                  `json:"next_action" yaml:"next_action"`
 }
 
 var overnightSetupCmd = &cobra.Command{
@@ -88,7 +90,7 @@ This command is intentionally conservative:
 func init() {
 	overnightCmd.AddCommand(overnightSetupCmd)
 	overnightSetupCmd.Flags().BoolVar(&overnightSetupApply, "apply", false, "Persist the detected Dream config and generate scheduler assistance artifacts")
-	overnightSetupCmd.Flags().StringVar(&overnightSetupScheduler, "scheduler", "auto", "Scheduler mode to persist (auto, manual, launchd, cron, systemd)")
+	overnightSetupCmd.Flags().StringVar(&overnightSetupScheduler, "scheduler", "auto", "Scheduler mode to persist (auto, manual, launchd, cron, systemd, task-scheduler)")
 	overnightSetupCmd.Flags().StringVar(&overnightSetupAt, "at", "", "Preferred local Dream run time in HH:MM (used for scheduler assistance)")
 	overnightSetupCmd.Flags().StringSliceVar(&overnightSetupRunners, "runner", nil, "Dream runner to persist (repeatable: --runner codex --runner claude)")
 	overnightSetupCmd.Flags().BoolVar(&overnightSetupKeepAwake, "keep-awake", false, "Persist keep-awake on for Dream runs")
@@ -107,6 +109,8 @@ func runOvernightSetup(cmd *cobra.Command, args []string) error {
 
 	host := detectDreamHostProfile()
 	runtimes := detectDreamRuntimes()
+	localCuratorCfg := resolveDreamLocalCuratorConfig(cfg.Dream.LocalCurator, 400*time.Millisecond)
+	localCurator := buildDreamLocalCuratorStatus(localCuratorCfg, 400*time.Millisecond)
 	selectedRunners, warnings := selectDreamRunners(cfg.Dream, runtimes)
 	keepAwake, keepAwakeWarnings := resolveDreamSetupKeepAwake(cfg.Dream, host)
 	warnings = append(warnings, keepAwakeWarnings...)
@@ -145,6 +149,9 @@ func runOvernightSetup(cmd *cobra.Command, args []string) error {
 		ConsensusPolicy: consensusPolicy,
 		CreativeLane:    dreamBoolPtr(creativeLane),
 	}
+	if localCurator.Available || isDreamLocalCuratorConfigured(cfg.Dream.LocalCurator) {
+		dreamCfg.LocalCurator = localCuratorCfg
+	}
 	if dreamCfg.ReportDir == "" {
 		dreamCfg.ReportDir = ".agents/overnight/latest"
 	}
@@ -161,6 +168,7 @@ func runOvernightSetup(cmd *cobra.Command, args []string) error {
 		ConfigPath:    projectConfigPath(),
 		Host:          host,
 		Runtimes:      runtimes,
+		LocalCurator:  localCurator,
 		DreamConfig:   dreamCfg,
 		Warnings:      warnings,
 	}
@@ -244,6 +252,19 @@ func detectDreamHostProfile() dreamHostProfile {
 				host.Schedulers[2].Recommended = false
 			}
 		}
+	case "windows":
+		host.RecommendedMode = "task-scheduler"
+		host.Schedulers = append(host.Schedulers, dreamSchedulerStatus{
+			Mode:        "task-scheduler",
+			Available:   true,
+			Recommended: true,
+			Note:        "Generates a reviewed Windows Task Scheduler script; AgentOps does not register it without operator action.",
+		})
+		host.Schedulers = append(host.Schedulers, dreamSchedulerStatus{
+			Mode:      "manual",
+			Available: true,
+			Note:      "Honest fallback when you want to arm the bedtime run yourself.",
+		})
 	default:
 		host.Schedulers = append(host.Schedulers, dreamSchedulerStatus{
 			Mode:        "manual",
@@ -267,6 +288,8 @@ func detectDreamRuntimes() []dreamRuntimeStatus {
 		{name: "codex", command: "codex", supported: true},
 		{name: "claude", command: "claude", supported: true},
 		{name: "gemini", command: "gemini", supported: false, note: "Detected for future Dream integrations; overnight execution is not wired yet."},
+		{name: "openclaw", command: "openclaw", supported: false, note: "OpenClaw/Morai bridge must be discoverable before Dream Council can execute it."},
+		{name: "oc-ask", command: "oc-ask", supported: false, note: "OpenClaw/Morai bridge must be discoverable before Dream Council can execute it."},
 		{name: "opencode", command: "opencode", supported: false, note: "Detected locally, but Dream Council does not execute it yet."},
 	}
 	out := make([]dreamRuntimeStatus, 0, len(candidates))
@@ -362,9 +385,9 @@ func resolveDreamSchedulerMode(existing config.DreamConfig, host dreamHostProfil
 			mode = "manual"
 		}
 	}
-	valid := map[string]bool{"manual": true, "launchd": true, "cron": true, "systemd": true}
+	valid := map[string]bool{"manual": true, "launchd": true, "cron": true, "systemd": true, "task-scheduler": true}
 	if !valid[mode] {
-		return "", nil, fmt.Errorf("invalid scheduler mode %q: expected auto, manual, launchd, cron, or systemd", mode)
+		return "", nil, fmt.Errorf("invalid scheduler mode %q: expected auto, manual, launchd, cron, systemd, or task-scheduler", mode)
 	}
 	var warnings []string
 	switch mode {
@@ -392,6 +415,11 @@ func resolveDreamSchedulerMode(existing config.DreamConfig, host dreamHostProfil
 		if host.HasBattery {
 			warnings = append(warnings, "cron is best-effort on laptops that sleep")
 		}
+	case "task-scheduler":
+		if dreamOS != "windows" {
+			return "", nil, fmt.Errorf("task-scheduler scheduling is only valid on Windows")
+		}
+		warnings = append(warnings, "Windows Task Scheduler assistance will be generated for review; AgentOps will not register it automatically")
 	}
 	return mode, warnings, nil
 }
@@ -433,6 +461,12 @@ func maybeWriteDreamSchedulerArtifacts(cwd string, host dreamHostProfile, cfg co
 		}
 		generated["systemd_service"] = servicePath
 		generated["systemd_timer"] = timerPath
+	case "task-scheduler":
+		path := filepath.Join(baseDir, "register-dream-task.ps1")
+		if err := os.WriteFile(path, []byte(renderDreamWindowsTaskSchedulerScript(cwd, cfg.ScheduleAt)), 0o644); err != nil {
+			return nil, nil, fmt.Errorf("write Windows Task Scheduler artifact: %w", err)
+		}
+		generated["task_scheduler"] = path
 	}
 
 	var warnings []string
@@ -503,12 +537,28 @@ WantedBy=timers.target
 `, hour, minute)
 }
 
+func renderDreamWindowsTaskSchedulerScript(cwd, at string) string {
+	hour, minute := splitDailyTime(at)
+	taskTime := fmt.Sprintf("%s:%s", hour, minute)
+	logPath := filepath.Join(cwd, ".agents", "overnight", "task-scheduler.log")
+	return fmt.Sprintf(`# Review before running. This script registers the local AgentOps Dream task.
+$TaskName = "AgentOps Dream"
+$WorkingDirectory = %q
+$LogPath = %q
+$Command = "Set-Location -LiteralPath '$WorkingDirectory'; ao overnight start *>> '$LogPath'"
+$Action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoProfile -ExecutionPolicy Bypass -Command $Command"
+$Trigger = New-ScheduledTaskTrigger -Daily -At %q
+$Settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -AllowStartIfOnBatteries:$false -DisallowStartIfOnBatteries:$true
+Register-ScheduledTask -TaskName $TaskName -Action $Action -Trigger $Trigger -Settings $Settings -Description "AgentOps Dream overnight knowledge compounding run"
+`, cwd, logPath, taskTime)
+}
+
 func recommendedDreamSetupCommands(summary dreamSetupSummary) []string {
 	cmds := []string{
 		`ao overnight start`,
 		`ao config --show --json`,
 	}
-	for _, path := range []string{summary.GeneratedFiles["launchd"], summary.GeneratedFiles["cron"], summary.GeneratedFiles["systemd_timer"]} {
+	for _, path := range []string{summary.GeneratedFiles["launchd"], summary.GeneratedFiles["cron"], summary.GeneratedFiles["systemd_timer"], summary.GeneratedFiles["task_scheduler"]} {
 		if path != "" {
 			cmds = append(cmds, fmt.Sprintf(`cat %q`, path))
 		}
@@ -544,6 +594,16 @@ func outputDreamSetupSummary(summary dreamSetupSummary) error {
 		fmt.Fprintf(&b, "- Config: `%s`\n", summary.ConfigPath)
 		fmt.Fprintf(&b, "- Host: `%s` / `%s`\n", summary.Host.OS, summary.Host.DeviceClass)
 		fmt.Fprintf(&b, "- Recommended mode: `%s`\n", summary.Host.RecommendedMode)
+		b.WriteString("\n## Local Curator\n\n")
+		fmt.Fprintf(&b, "- engine: `%s`\n", summary.LocalCurator.Engine)
+		fmt.Fprintf(&b, "- enabled: `%t`\n", summary.LocalCurator.Enabled)
+		fmt.Fprintf(&b, "- available: `%t`\n", summary.LocalCurator.Available)
+		if summary.LocalCurator.Model != "" {
+			fmt.Fprintf(&b, "- model: `%s`\n", summary.LocalCurator.Model)
+		}
+		if summary.LocalCurator.WorkerDir != "" {
+			fmt.Fprintf(&b, "- worker_dir: `%s`\n", summary.LocalCurator.WorkerDir)
+		}
 		b.WriteString("\n## Runtimes\n\n")
 		for _, rt := range summary.Runtimes {
 			fmt.Fprintf(&b, "- `%s`: available=%t supported=%t", rt.Name, rt.Available, rt.Supported)

--- a/cli/cmd/ao/overnight_test.go
+++ b/cli/cmd/ao/overnight_test.go
@@ -6,14 +6,15 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/spf13/cobra"
 
-	ovn "github.com/boshu2/agentops/cli/internal/overnight"
 	v1reader "github.com/boshu2/agentops/cli/cmd/ao/testdata/v1_reader"
+	ovn "github.com/boshu2/agentops/cli/internal/overnight"
 )
 
 func writeExecutable(t *testing.T, dir, name, body string) string {
@@ -21,6 +22,13 @@ func writeExecutable(t *testing.T, dir, name, body string) string {
 	path := filepath.Join(dir, name)
 	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
 		t.Fatalf("write executable %s: %v", name, err)
+	}
+	if runtime.GOOS == "windows" {
+		cmdPath := filepath.Join(dir, name+".cmd")
+		cmdBody := "@echo off\r\nbash \"%~dp0" + name + "\" %*\r\n"
+		if err := os.WriteFile(cmdPath, []byte(cmdBody), 0o755); err != nil {
+			t.Fatalf("write executable shim %s: %v", name, err)
+		}
 	}
 	return path
 }
@@ -290,6 +298,9 @@ func TestRunOvernightSetupApplyWritesSchedulerArtifact(t *testing.T) {
 }
 
 func TestRunDreamCouncilWithMockRunners(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mock shell runners rely on Unix argv quoting")
+	}
 	tmpDir := t.TempDir()
 	writeExecutable(t, tmpDir, "codex", `#!/bin/sh
 out=""

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -1152,6 +1152,98 @@ ao overnight [command]
 
 **Subcommands:**
 
+#### `ao overnight curator`
+
+Inspect and operate a local Tier 1 Dream curator such as Ollama/Gemma.
+
+```
+ao overnight curator [command]
+```
+
+##### `ao overnight curator compact`
+
+Run the local curator pending-log compactor
+
+```
+ao overnight curator compact [flags]
+```
+
+**Flags:**
+
+```
+      --apply     Apply pending-log compaction
+      --dry-run   Preview pending-log compaction without writing
+  -h, --help      help for compact
+```
+
+##### `ao overnight curator diagnose`
+
+Explain local curator setup problems
+
+```
+ao overnight curator diagnose [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help   help for diagnose
+      --json   Render curator diagnosis as JSON
+```
+
+##### `ao overnight curator enqueue`
+
+Enqueue an allowlisted local curator job
+
+```
+ao overnight curator enqueue [flags]
+```
+
+**Flags:**
+
+```
+      --chunk-end int     End chunk index for ingest-claude-session jobs
+      --chunk-start int   Start chunk index for ingest-claude-session jobs
+  -h, --help              help for enqueue
+      --kind string       Job kind to enqueue: ingest-claude-session, lint-wiki, or dream-seed
+      --source string     Source path for ingest-claude-session jobs
+```
+
+##### `ao overnight curator event`
+
+Write a bounded needs-review escalation event
+
+```
+ao overnight curator event [flags]
+```
+
+**Flags:**
+
+```
+      --budget int              Maximum downstream event budget (default 1)
+      --desired-action string   Requested bounded action for Tier 2 review
+  -h, --help                    help for event
+      --note string             Optional operator note
+      --severity string         Event severity: info, warn, high, or critical
+      --source string           Event source, for example gemma or local-soc
+      --target string           Escalation target (default "dream-council")
+```
+
+##### `ao overnight curator status`
+
+Report local curator queue, worker, and model health
+
+```
+ao overnight curator status [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help   help for status
+      --json   Render curator status as JSON
+```
+
 #### `ao overnight report`
 
 Read a Dream report from summary.json and render it as JSON, YAML, or
@@ -1184,7 +1276,7 @@ ao overnight setup [flags]
       --keep-awake         Persist keep-awake on for Dream runs
       --no-keep-awake      Persist keep-awake off for Dream runs
       --runner strings     Dream runner to persist (repeatable: --runner codex --runner claude)
-      --scheduler string   Scheduler mode to persist (auto, manual, launchd, cron, systemd) (default "auto")
+      --scheduler string   Scheduler mode to persist (auto, manual, launchd, cron, systemd, task-scheduler) (default "auto")
 ```
 
 #### `ao overnight start`
@@ -2192,10 +2284,13 @@ ao forge transcript <path-or-glob> [flags]
 **Flags:**
 
 ```
-  -h, --help           help for transcript
-      --last-session   Process only the most recent transcript
-      --queue          Queue session for learning extraction at next session start
-      --quiet          Suppress all output (for hooks)
+  -h, --help                  help for transcript
+      --last-session          Process only the most recent transcript
+      --llm-endpoint string   Ollama HTTP endpoint for --tier=1 (default: $AGENTOPS_LLM_ENDPOINT or http://localhost:11434)
+      --model string          LLM model tag for --tier=1 (e.g. gemma2:9b)
+      --queue                 Queue session for learning extraction at next session start
+      --quiet                 Suppress all output (for hooks)
+      --tier int              Tier 1 local-LLM summarization pipeline (requires --model, --llm-endpoint optional)
 ```
 
 ---

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -170,6 +170,37 @@ type DreamConfig struct {
 	// CreativeLane controls whether Dream Council should request wildcard ideas.
 	// Nil means "not explicitly configured".
 	CreativeLane *bool `yaml:"creative_lane,omitempty" json:"creative_lane,omitempty"`
+
+	// LocalCurator configures a local Tier 1 curator such as Ollama/Gemma.
+	LocalCurator DreamLocalCuratorConfig `yaml:"local_curator,omitempty" json:"local_curator,omitempty"`
+}
+
+// DreamLocalCuratorConfig holds settings for a local Tier 1 Dream curator.
+type DreamLocalCuratorConfig struct {
+	// Enabled controls whether the local curator should be treated as active.
+	// Nil means "not explicitly configured".
+	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+
+	// Engine identifies the local engine. V1 supports "ollama".
+	Engine string `yaml:"engine,omitempty" json:"engine,omitempty"`
+
+	// OllamaURL is the Ollama API root used when Engine is "ollama".
+	OllamaURL string `yaml:"ollama_url,omitempty" json:"ollama_url,omitempty"`
+
+	// Model is the Tier 1 model name.
+	Model string `yaml:"model,omitempty" json:"model,omitempty"`
+
+	// WorkerDir is the local Dream worker directory.
+	WorkerDir string `yaml:"worker_dir,omitempty" json:"worker_dir,omitempty"`
+
+	// VaultDir is the local knowledge vault written by the worker.
+	VaultDir string `yaml:"vault_dir,omitempty" json:"vault_dir,omitempty"`
+
+	// HourlyCap is the worker's bounded autonomy limit.
+	HourlyCap int `yaml:"hourly_cap,omitempty" json:"hourly_cap,omitempty"`
+
+	// AllowedJobKinds is the local curator queue allowlist.
+	AllowedJobKinds []string `yaml:"allowed_job_kinds,omitempty" json:"allowed_job_kinds,omitempty"`
 }
 
 // TierConfig holds model names for a tier.
@@ -420,6 +451,14 @@ func applyEnv(cfg *Config) *Config {
 	if v, ok := getEnvBoolValue("AGENTOPS_DREAM_KEEP_AWAKE"); ok {
 		cfg.Dream.KeepAwake = boolPtr(v)
 	}
+	if v, ok := getEnvBoolValue("AGENTOPS_DREAM_CURATOR_ENABLED"); ok {
+		cfg.Dream.LocalCurator.Enabled = boolPtr(v)
+	}
+	applyEnvStr(&cfg.Dream.LocalCurator.Engine, "AGENTOPS_DREAM_CURATOR_ENGINE")
+	applyEnvStr(&cfg.Dream.LocalCurator.OllamaURL, "AGENTOPS_DREAM_CURATOR_OLLAMA_URL")
+	applyEnvStr(&cfg.Dream.LocalCurator.Model, "AGENTOPS_DREAM_CURATOR_MODEL")
+	applyEnvStr(&cfg.Dream.LocalCurator.WorkerDir, "AGENTOPS_DREAM_CURATOR_WORKER_DIR")
+	applyEnvStr(&cfg.Dream.LocalCurator.VaultDir, "AGENTOPS_DREAM_CURATOR_VAULT_DIR")
 	if v := os.Getenv("AGENTOPS_COUNCIL_MODEL_TIER"); v != "" {
 		if cfg.Models.SkillOverrides == nil {
 			cfg.Models.SkillOverrides = make(map[string]string)
@@ -530,6 +569,22 @@ func mergeDream(dst, src *DreamConfig) {
 	mergeStr(&dst.ConsensusPolicy, src.ConsensusPolicy)
 	if src.CreativeLane != nil {
 		dst.CreativeLane = boolPtr(*src.CreativeLane)
+	}
+	mergeDreamLocalCurator(&dst.LocalCurator, &src.LocalCurator)
+}
+
+func mergeDreamLocalCurator(dst, src *DreamLocalCuratorConfig) {
+	if src.Enabled != nil {
+		dst.Enabled = boolPtr(*src.Enabled)
+	}
+	mergeStr(&dst.Engine, src.Engine)
+	mergeStr(&dst.OllamaURL, src.OllamaURL)
+	mergeStr(&dst.Model, src.Model)
+	mergeStr(&dst.WorkerDir, src.WorkerDir)
+	mergeStr(&dst.VaultDir, src.VaultDir)
+	mergeInt(&dst.HourlyCap, src.HourlyCap)
+	if len(src.AllowedJobKinds) > 0 {
+		dst.AllowedJobKinds = append([]string{}, src.AllowedJobKinds...)
 	}
 }
 
@@ -677,24 +732,31 @@ func resolveStringSliceField(home, project []string, def []string) resolved {
 
 // ResolvedConfig shows config values with their sources.
 type ResolvedConfig struct {
-	Output            resolved `json:"output"`
-	BaseDir           resolved `json:"base_dir"`
-	Verbose           resolved `json:"verbose"`
-	RPIWorktreeMode   resolved `json:"rpi_worktree_mode"`
-	RPIRuntimeMode    resolved `json:"rpi_runtime_mode"`
-	RPIRuntimeCommand resolved `json:"rpi_runtime_command"`
-	RPIAOCommand      resolved `json:"rpi_ao_command"`
-	RPIBDCommand      resolved `json:"rpi_bd_command"`
-	RPITmuxCommand    resolved `json:"rpi_tmux_command"`
-	ModelsDefaultTier resolved `json:"models_default_tier"`
-	DreamReportDir    resolved `json:"dream_report_dir"`
-	DreamRunTimeout   resolved `json:"dream_run_timeout"`
-	DreamKeepAwake    resolved `json:"dream_keep_awake"`
-	DreamRunners      resolved `json:"dream_runners"`
-	DreamScheduler    resolved `json:"dream_scheduler_mode"`
-	DreamScheduleAt   resolved `json:"dream_schedule_at"`
-	DreamConsensus    resolved `json:"dream_consensus_policy"`
-	DreamCreativeLane resolved `json:"dream_creative_lane"`
+	Output                resolved `json:"output"`
+	BaseDir               resolved `json:"base_dir"`
+	Verbose               resolved `json:"verbose"`
+	RPIWorktreeMode       resolved `json:"rpi_worktree_mode"`
+	RPIRuntimeMode        resolved `json:"rpi_runtime_mode"`
+	RPIRuntimeCommand     resolved `json:"rpi_runtime_command"`
+	RPIAOCommand          resolved `json:"rpi_ao_command"`
+	RPIBDCommand          resolved `json:"rpi_bd_command"`
+	RPITmuxCommand        resolved `json:"rpi_tmux_command"`
+	ModelsDefaultTier     resolved `json:"models_default_tier"`
+	DreamReportDir        resolved `json:"dream_report_dir"`
+	DreamRunTimeout       resolved `json:"dream_run_timeout"`
+	DreamKeepAwake        resolved `json:"dream_keep_awake"`
+	DreamRunners          resolved `json:"dream_runners"`
+	DreamScheduler        resolved `json:"dream_scheduler_mode"`
+	DreamScheduleAt       resolved `json:"dream_schedule_at"`
+	DreamConsensus        resolved `json:"dream_consensus_policy"`
+	DreamCreativeLane     resolved `json:"dream_creative_lane"`
+	DreamCuratorEnabled   resolved `json:"dream_curator_enabled"`
+	DreamCuratorEngine    resolved `json:"dream_curator_engine"`
+	DreamCuratorOllamaURL resolved `json:"dream_curator_ollama_url"`
+	DreamCuratorModel     resolved `json:"dream_curator_model"`
+	DreamCuratorWorkerDir resolved `json:"dream_curator_worker_dir"`
+	DreamCuratorVaultDir  resolved `json:"dream_curator_vault_dir"`
+	DreamCuratorJobKinds  resolved `json:"dream_curator_allowed_job_kinds"`
 }
 
 type resolved struct {
@@ -719,6 +781,14 @@ type configFields struct {
 	dreamConsensusPolicy            string
 	dreamCreativeLane               bool
 	dreamCreativeLaneSet            bool
+	dreamCuratorEnabled             bool
+	dreamCuratorEnabledSet          bool
+	dreamCuratorEngine              string
+	dreamCuratorOllamaURL           string
+	dreamCuratorModel               string
+	dreamCuratorWorkerDir           string
+	dreamCuratorVaultDir            string
+	dreamCuratorJobKinds            []string
 }
 
 // extractFields pulls resolution-relevant fields from a Config.
@@ -728,26 +798,34 @@ func extractFields(cfg *Config) configFields {
 		return configFields{}
 	}
 	return configFields{
-		output:               cfg.Output,
-		baseDir:              cfg.BaseDir,
-		verbose:              cfg.Verbose,
-		rpiWorktreeMode:      cfg.RPI.WorktreeMode,
-		rpiRuntimeMode:       cfg.RPI.RuntimeMode,
-		rpiRuntimeCommand:    cfg.RPI.RuntimeCommand,
-		rpiAOCommand:         cfg.RPI.AOCommand,
-		rpiBDCommand:         cfg.RPI.BDCommand,
-		rpiTmuxCommand:       cfg.RPI.TmuxCommand,
-		modelsDefaultTier:    cfg.Models.DefaultTier,
-		dreamReportDir:       cfg.Dream.ReportDir,
-		dreamRunTimeout:      cfg.Dream.RunTimeout,
-		dreamKeepAwake:       cfg.Dream.KeepAwake != nil && *cfg.Dream.KeepAwake,
-		dreamKeepAwakeSet:    cfg.Dream.KeepAwake != nil,
-		dreamRunners:         append([]string{}, cfg.Dream.Runners...),
-		dreamSchedulerMode:   cfg.Dream.SchedulerMode,
-		dreamScheduleAt:      cfg.Dream.ScheduleAt,
-		dreamConsensusPolicy: cfg.Dream.ConsensusPolicy,
-		dreamCreativeLane:    cfg.Dream.CreativeLane != nil && *cfg.Dream.CreativeLane,
-		dreamCreativeLaneSet: cfg.Dream.CreativeLane != nil,
+		output:                 cfg.Output,
+		baseDir:                cfg.BaseDir,
+		verbose:                cfg.Verbose,
+		rpiWorktreeMode:        cfg.RPI.WorktreeMode,
+		rpiRuntimeMode:         cfg.RPI.RuntimeMode,
+		rpiRuntimeCommand:      cfg.RPI.RuntimeCommand,
+		rpiAOCommand:           cfg.RPI.AOCommand,
+		rpiBDCommand:           cfg.RPI.BDCommand,
+		rpiTmuxCommand:         cfg.RPI.TmuxCommand,
+		modelsDefaultTier:      cfg.Models.DefaultTier,
+		dreamReportDir:         cfg.Dream.ReportDir,
+		dreamRunTimeout:        cfg.Dream.RunTimeout,
+		dreamKeepAwake:         cfg.Dream.KeepAwake != nil && *cfg.Dream.KeepAwake,
+		dreamKeepAwakeSet:      cfg.Dream.KeepAwake != nil,
+		dreamRunners:           append([]string{}, cfg.Dream.Runners...),
+		dreamSchedulerMode:     cfg.Dream.SchedulerMode,
+		dreamScheduleAt:        cfg.Dream.ScheduleAt,
+		dreamConsensusPolicy:   cfg.Dream.ConsensusPolicy,
+		dreamCreativeLane:      cfg.Dream.CreativeLane != nil && *cfg.Dream.CreativeLane,
+		dreamCreativeLaneSet:   cfg.Dream.CreativeLane != nil,
+		dreamCuratorEnabled:    cfg.Dream.LocalCurator.Enabled != nil && *cfg.Dream.LocalCurator.Enabled,
+		dreamCuratorEnabledSet: cfg.Dream.LocalCurator.Enabled != nil,
+		dreamCuratorEngine:     cfg.Dream.LocalCurator.Engine,
+		dreamCuratorOllamaURL:  cfg.Dream.LocalCurator.OllamaURL,
+		dreamCuratorModel:      cfg.Dream.LocalCurator.Model,
+		dreamCuratorWorkerDir:  cfg.Dream.LocalCurator.WorkerDir,
+		dreamCuratorVaultDir:   cfg.Dream.LocalCurator.VaultDir,
+		dreamCuratorJobKinds:   append([]string{}, cfg.Dream.LocalCurator.AllowedJobKinds...),
 	}
 }
 
@@ -763,6 +841,13 @@ type envFields struct {
 	dreamReportDir, dreamRunTimeout string
 	dreamKeepAwake                  bool
 	dreamKeepAwakeSet               bool
+	dreamCuratorEnabled             bool
+	dreamCuratorEnabledSet          bool
+	dreamCuratorEngine              string
+	dreamCuratorOllamaURL           string
+	dreamCuratorModel               string
+	dreamCuratorWorkerDir           string
+	dreamCuratorVaultDir            string
 }
 
 // loadEnvFields reads all resolution-relevant environment variables.
@@ -784,6 +869,12 @@ func loadEnvFields() envFields {
 	ef.dreamReportDir, _ = getEnvString("AGENTOPS_DREAM_REPORT_DIR")
 	ef.dreamRunTimeout, _ = getEnvString("AGENTOPS_DREAM_RUN_TIMEOUT")
 	ef.dreamKeepAwake, ef.dreamKeepAwakeSet = getEnvBoolValue("AGENTOPS_DREAM_KEEP_AWAKE")
+	ef.dreamCuratorEnabled, ef.dreamCuratorEnabledSet = getEnvBoolValue("AGENTOPS_DREAM_CURATOR_ENABLED")
+	ef.dreamCuratorEngine, _ = getEnvString("AGENTOPS_DREAM_CURATOR_ENGINE")
+	ef.dreamCuratorOllamaURL, _ = getEnvString("AGENTOPS_DREAM_CURATOR_OLLAMA_URL")
+	ef.dreamCuratorModel, _ = getEnvString("AGENTOPS_DREAM_CURATOR_MODEL")
+	ef.dreamCuratorWorkerDir, _ = getEnvString("AGENTOPS_DREAM_CURATOR_WORKER_DIR")
+	ef.dreamCuratorVaultDir, _ = getEnvString("AGENTOPS_DREAM_CURATOR_VAULT_DIR")
 	return ef
 }
 
@@ -860,5 +951,17 @@ func Resolve(flagOutput, flagBaseDir string, flagVerbose bool) *ResolvedConfig {
 			false, false,
 			false,
 		),
+		DreamCuratorEnabled: resolveBoolField(
+			home.dreamCuratorEnabled, home.dreamCuratorEnabledSet,
+			project.dreamCuratorEnabled, project.dreamCuratorEnabledSet,
+			env.dreamCuratorEnabled, env.dreamCuratorEnabledSet,
+			false,
+		),
+		DreamCuratorEngine:    resolveStringField(home.dreamCuratorEngine, project.dreamCuratorEngine, env.dreamCuratorEngine, "", ""),
+		DreamCuratorOllamaURL: resolveStringField(home.dreamCuratorOllamaURL, project.dreamCuratorOllamaURL, env.dreamCuratorOllamaURL, "", ""),
+		DreamCuratorModel:     resolveStringField(home.dreamCuratorModel, project.dreamCuratorModel, env.dreamCuratorModel, "", ""),
+		DreamCuratorWorkerDir: resolveStringField(home.dreamCuratorWorkerDir, project.dreamCuratorWorkerDir, env.dreamCuratorWorkerDir, "", ""),
+		DreamCuratorVaultDir:  resolveStringField(home.dreamCuratorVaultDir, project.dreamCuratorVaultDir, env.dreamCuratorVaultDir, "", ""),
+		DreamCuratorJobKinds:  resolveStringSliceField(home.dreamCuratorJobKinds, project.dreamCuratorJobKinds, []string{}),
 	}
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -1964,6 +1965,12 @@ func TestApplyEnv_DreamOverrides(t *testing.T) {
 	t.Setenv("AGENTOPS_DREAM_REPORT_DIR", "/tmp/dream")
 	t.Setenv("AGENTOPS_DREAM_RUN_TIMEOUT", "10h")
 	t.Setenv("AGENTOPS_DREAM_KEEP_AWAKE", "false")
+	t.Setenv("AGENTOPS_DREAM_CURATOR_ENABLED", "true")
+	t.Setenv("AGENTOPS_DREAM_CURATOR_ENGINE", "ollama")
+	t.Setenv("AGENTOPS_DREAM_CURATOR_OLLAMA_URL", "http://127.0.0.1:11435")
+	t.Setenv("AGENTOPS_DREAM_CURATOR_MODEL", "gemma4:e4b")
+	t.Setenv("AGENTOPS_DREAM_CURATOR_WORKER_DIR", "D:\\dream")
+	t.Setenv("AGENTOPS_DREAM_CURATOR_VAULT_DIR", "D:\\vault")
 
 	got := applyEnv(cfg)
 	if got.Dream.ReportDir != "/tmp/dream" {
@@ -1974,6 +1981,54 @@ func TestApplyEnv_DreamOverrides(t *testing.T) {
 	}
 	if got.Dream.KeepAwake == nil || *got.Dream.KeepAwake != false {
 		t.Fatalf("Dream.KeepAwake = %#v, want false", got.Dream.KeepAwake)
+	}
+	if got.Dream.LocalCurator.Enabled == nil || *got.Dream.LocalCurator.Enabled != true {
+		t.Fatalf("Dream.LocalCurator.Enabled = %#v, want true", got.Dream.LocalCurator.Enabled)
+	}
+	if got.Dream.LocalCurator.Engine != "ollama" {
+		t.Fatalf("Dream.LocalCurator.Engine = %q, want ollama", got.Dream.LocalCurator.Engine)
+	}
+	if got.Dream.LocalCurator.OllamaURL != "http://127.0.0.1:11435" {
+		t.Fatalf("Dream.LocalCurator.OllamaURL = %q, want http://127.0.0.1:11435", got.Dream.LocalCurator.OllamaURL)
+	}
+	if got.Dream.LocalCurator.Model != "gemma4:e4b" {
+		t.Fatalf("Dream.LocalCurator.Model = %q, want gemma4:e4b", got.Dream.LocalCurator.Model)
+	}
+	if got.Dream.LocalCurator.WorkerDir != "D:\\dream" {
+		t.Fatalf("Dream.LocalCurator.WorkerDir = %q, want D:\\dream", got.Dream.LocalCurator.WorkerDir)
+	}
+	if got.Dream.LocalCurator.VaultDir != "D:\\vault" {
+		t.Fatalf("Dream.LocalCurator.VaultDir = %q, want D:\\vault", got.Dream.LocalCurator.VaultDir)
+	}
+}
+
+func TestResolve_DreamLocalCuratorEnv(t *testing.T) {
+	t.Setenv("AGENTOPS_CONFIG", "")
+	t.Setenv("AGENTOPS_DREAM_CURATOR_ENABLED", "true")
+	t.Setenv("AGENTOPS_DREAM_CURATOR_ENGINE", "ollama")
+	t.Setenv("AGENTOPS_DREAM_CURATOR_OLLAMA_URL", "http://127.0.0.1:11435")
+	t.Setenv("AGENTOPS_DREAM_CURATOR_MODEL", "gemma4:e4b")
+	t.Setenv("AGENTOPS_DREAM_CURATOR_WORKER_DIR", "D:\\dream")
+	t.Setenv("AGENTOPS_DREAM_CURATOR_VAULT_DIR", "D:\\vault")
+
+	rc := Resolve("", "", false)
+	if rc.DreamCuratorEnabled.Value != true || rc.DreamCuratorEnabled.Source != SourceEnv {
+		t.Fatalf("DreamCuratorEnabled = (%v, %v), want (true, %v)", rc.DreamCuratorEnabled.Value, rc.DreamCuratorEnabled.Source, SourceEnv)
+	}
+	if rc.DreamCuratorEngine.Value != "ollama" || rc.DreamCuratorEngine.Source != SourceEnv {
+		t.Fatalf("DreamCuratorEngine = (%v, %v), want (ollama, %v)", rc.DreamCuratorEngine.Value, rc.DreamCuratorEngine.Source, SourceEnv)
+	}
+	if rc.DreamCuratorOllamaURL.Value != "http://127.0.0.1:11435" || rc.DreamCuratorOllamaURL.Source != SourceEnv {
+		t.Fatalf("DreamCuratorOllamaURL = (%v, %v), want env URL", rc.DreamCuratorOllamaURL.Value, rc.DreamCuratorOllamaURL.Source)
+	}
+	if rc.DreamCuratorModel.Value != "gemma4:e4b" || rc.DreamCuratorModel.Source != SourceEnv {
+		t.Fatalf("DreamCuratorModel = (%v, %v), want env model", rc.DreamCuratorModel.Value, rc.DreamCuratorModel.Source)
+	}
+	if rc.DreamCuratorWorkerDir.Value != "D:\\dream" || rc.DreamCuratorWorkerDir.Source != SourceEnv {
+		t.Fatalf("DreamCuratorWorkerDir = (%v, %v), want env worker", rc.DreamCuratorWorkerDir.Value, rc.DreamCuratorWorkerDir.Source)
+	}
+	if rc.DreamCuratorVaultDir.Value != "D:\\vault" || rc.DreamCuratorVaultDir.Source != SourceEnv {
+		t.Fatalf("DreamCuratorVaultDir = (%v, %v), want env vault", rc.DreamCuratorVaultDir.Value, rc.DreamCuratorVaultDir.Source)
 	}
 }
 
@@ -1986,6 +2041,16 @@ func TestMergeDream_ExtendedFields(t *testing.T) {
 			ScheduleAt:      "01:30",
 			ConsensusPolicy: "majority",
 			CreativeLane:    boolPtr(true),
+			LocalCurator: DreamLocalCuratorConfig{
+				Enabled:         boolPtr(true),
+				Engine:          "ollama",
+				OllamaURL:       "http://127.0.0.1:11435",
+				Model:           "gemma4:e4b",
+				WorkerDir:       "D:\\dream",
+				VaultDir:        "D:\\vault",
+				HourlyCap:       20,
+				AllowedJobKinds: []string{"ingest-claude-session", "lint-wiki", "dream-seed"},
+			},
 		},
 	}
 
@@ -2004,6 +2069,18 @@ func TestMergeDream_ExtendedFields(t *testing.T) {
 	}
 	if got.Dream.CreativeLane == nil || !*got.Dream.CreativeLane {
 		t.Fatalf("Dream.CreativeLane = %#v, want true", got.Dream.CreativeLane)
+	}
+	if got.Dream.LocalCurator.Enabled == nil || !*got.Dream.LocalCurator.Enabled {
+		t.Fatalf("Dream.LocalCurator.Enabled = %#v, want true", got.Dream.LocalCurator.Enabled)
+	}
+	if got.Dream.LocalCurator.Model != "gemma4:e4b" {
+		t.Fatalf("Dream.LocalCurator.Model = %q, want gemma4:e4b", got.Dream.LocalCurator.Model)
+	}
+	if got.Dream.LocalCurator.HourlyCap != 20 {
+		t.Fatalf("Dream.LocalCurator.HourlyCap = %d, want 20", got.Dream.LocalCurator.HourlyCap)
+	}
+	if got := strings.Join(got.Dream.LocalCurator.AllowedJobKinds, ","); got != "ingest-claude-session,lint-wiki,dream-seed" {
+		t.Fatalf("Dream.LocalCurator.AllowedJobKinds = %q", got)
 	}
 }
 

--- a/docs/contracts/dream-run-contract.md
+++ b/docs/contracts/dream-run-contract.md
@@ -35,6 +35,7 @@ Primary commands:
 - `ao overnight start`
 - `ao overnight run`
   `run` is an alias for `start`
+- `ao overnight curator status|diagnose|enqueue|compact|event`
 - `ao overnight report --from <dir-or-summary.json>`
 
 Required flags for `start`:
@@ -50,9 +51,17 @@ Required flags for `start`:
 Required flags for `setup`:
 
 - `--apply`
-- `--scheduler <manual|launchd|cron|systemd|auto>`
+- `--scheduler <manual|launchd|cron|systemd|task-scheduler|auto>`
 - `--at <HH:MM>`
 - `--runner <name>` (repeatable)
+
+Required surfaces for `curator`:
+
+- `status --json` reports configured local curator state, Ollama health, model availability, worker queue depth, status.json content, and Tier 2 runner discovery.
+- `diagnose` explains missing worker directories, missing vaults, wrong Ollama endpoint, absent models, stale worker PID when detectable, and unsupported OpenClaw/Morai bridge state.
+- `enqueue --kind <lint-wiki|dream-seed|ingest-claude-session>` writes only allowlisted knowledge jobs into the configured worker queue.
+- `compact --dry-run|--apply` wraps the existing pending-log compaction contract.
+- `event` writes a bounded needs-review event record with source, severity, desired action, escalation target, and event budget.
 
 ## Process Model
 
@@ -159,6 +168,28 @@ They may share primitive steps and report shapes, but they are not the same oper
 
 `ao overnight setup` helps persist `dream.*` config and generate host-specific
 assistance artifacts. The host scheduler still owns actual scheduling semantics.
+On Windows, setup may generate a reviewed Task Scheduler registration script
+under `.agentops/generated/dream/`; it must not silently register autonomous
+jobs.
+
+## Local Curator Contract
+
+`dream.local_curator.*` describes a Tier 1 local curator. V1 supports
+`engine: ollama` with a local Gemma model, a worker directory, a vault directory,
+an hourly cap, and an allowlist of job kinds. Autodetection may recognize a local
+prototype such as `D:\dream`, `D:\vault`, `http://127.0.0.1:11435`, and
+`gemma4:e4b`, but the CLI must continue to work when those machine-local paths
+are absent.
+
+The local curator is separate from Dream Council. Gemma can draft, lint, seed,
+compact audit logs, and emit needs-review events. Tier 2 runners such as Codex
+and Claude can review or synthesize those events. OpenClaw/Morai must remain
+unsupported on Windows until a real bridge command such as `openclaw` or
+`oc-ask` is discoverable from the AgentOps runtime.
+
+No trigger mesh may be unbounded. Every escalation record needs source, severity,
+desired action, escalation target, budget, and a ledger entry. A runner must not
+recursively invoke another runner without an explicit remaining budget.
 
 ## v2 - Iteration Loop (2026-04-09)
 

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -716,7 +716,7 @@
       "name": "dream",
       "source_skill": "skills/dream",
       "source_hash": "28f5f4412bff2be75b748ecd8fd693a523a8977548506675693a95a1826bf122",
-      "generated_hash": "863109a1921169dedb1a96353402da2a2905f8d32a6f0ac73a6e3a672e6a81f7"
+      "generated_hash": "73b0415f29dd6f904ffe5a212e9aad667191acdd74e21ae34dc354f955ba6507"
     },
     {
       "name": "doc",

--- a/skills-codex/dream/.agentops-generated.json
+++ b/skills-codex/dream/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/dream",
   "layout": "modular",
   "source_hash": "28f5f4412bff2be75b748ecd8fd693a523a8977548506675693a95a1826bf122",
-  "generated_hash": "863109a1921169dedb1a96353402da2a2905f8d32a6f0ac73a6e3a672e6a81f7"
+  "generated_hash": "73b0415f29dd6f904ffe5a212e9aad667191acdd74e21ae34dc354f955ba6507"
 }

--- a/skills-codex/dream/SKILL.md
+++ b/skills-codex/dream/SKILL.md
@@ -25,6 +25,7 @@ Anti-goals (hard constraints):
 ### Step 1: Route the request
 
 - `setup` -> `ao overnight setup`
+- `curator` or local Gemma worker requests -> `ao overnight curator status|diagnose|enqueue|compact|event`
 - `start` or `run` -> `ao overnight start`
 - `report` -> `ao overnight report`
 
@@ -39,7 +40,31 @@ ao overnight setup --apply --runner codex --runner claude --at 01:30
 ```
 
 Default to preview. Use `--apply` only when the user explicitly wants Dream
-config or scheduler artifacts persisted.
+config or scheduler artifacts persisted. Setup detects Tier 1 local curator
+state separately from Tier 2 Dream Council runners.
+
+### Step 2a: Local curator lane
+
+Use `ao overnight curator` when the user asks about Gemma, Ollama, the local
+worker, SOC trigger signals, Tier 1 drafts, or pending LOG compaction.
+
+```bash
+ao overnight curator status --json
+ao overnight curator diagnose
+ao overnight curator enqueue --kind lint-wiki
+ao overnight curator enqueue --kind dream-seed
+ao overnight curator compact --dry-run
+ao overnight curator event --source local-soc --severity high --desired-action "review alert cluster" --budget 1
+```
+
+The first supported local curator shape is Ollama + Gemma under
+`dream.local_curator.*`. Treat it as a Tier 1 draft/lint/triage lane, not as a
+Dream Council runner. Gemma may enqueue allowlisted knowledge jobs and emit
+needs-review event records; Codex and Claude remain Tier 2 review/synthesis
+runners; humans own promotion into durable authored memory.
+
+Do not create an unbounded model-to-model loop. Any escalation needs an explicit
+source, severity, desired action, escalation target, budget, and ledger entry.
 
 ### Step 3: Bedtime run lane
 

--- a/skills/dream/SKILL.md
+++ b/skills/dream/SKILL.md
@@ -46,7 +46,8 @@ Map user intent to one of three lanes:
 
 | Intent | Command | Notes |
 |--------|---------|-------|
-| bootstrap, install, configure Dream | `ao overnight setup` | Default to preview. Use `--apply` only when the user explicitly wants config or scheduler artifacts persisted. |
+| bootstrap, install, configure Dream | `ao overnight setup` | Default to preview. Use `--apply` only when the user explicitly wants config or scheduler artifacts persisted. Detects Tier 1 local curator separately from Tier 2 Dream Council runners. |
+| inspect or feed local Gemma curator | `ao overnight curator status|diagnose|enqueue|compact|event` | Use for Ollama/Gemma worker health, allowlisted queue jobs, pending LOG compaction, and bounded needs-review events. |
 | run Dream now | `ao overnight start` | Include `--goal` when the user provides one. Use `--runner` and `--creative-lane` only when the user asks for multimodel or wildcard analysis. |
 | inspect a prior run | `ao overnight report` | Use `--from <dir-or-summary.json>` for non-default report paths. |
 
@@ -61,6 +62,24 @@ Anti-goals (hard constraints):
 - NEVER performs git operations (no commits, branches, push, rebase, checkout).
 - NEVER creates symlinks anywhere.
 - No swarm/gc fan-out inside iterations in the first slice (serial only).
+
+## Tier 1 Curator And Trigger Mesh
+
+Dream can expose a local Tier 1 curator through `dream.local_curator.*`. The
+first supported shape is Ollama + Gemma, backed by an operator-owned worker
+directory such as `D:\dream` and a vault such as `D:\vault`. This is not a Dream
+Council runner: Gemma drafts, lints, triages, and writes auditable queue or event
+records; Codex and Claude remain Tier 2 review/synthesis runners; humans own
+promotion into durable authored memory.
+
+Use `ao overnight curator status --json` to check the worker, queue, model, and
+Ollama endpoint. Use `ao overnight curator enqueue --kind lint-wiki|dream-seed`
+or `--kind ingest-claude-session --source <path> --chunk-start <n> --chunk-end
+<n>` only for allowlisted knowledge jobs. Use `ao overnight curator event` when
+Gemma or a local SOC signal needs Tier 2 attention. Events carry source,
+severity, desired action, escalation target, and budget; no runner should
+recursively invoke another runner without consuming an explicit event budget and
+leaving a ledger entry.
 
 ## Key Rules
 
@@ -112,6 +131,25 @@ Expected outputs:
 
 - a config preview in terminal, JSON, or YAML
 - optional generated scheduler assistance under `.agentops/generated/dream/`
+- optional `dream.local_curator` config when a supported local curator is
+  configured or detected
+
+### Step 2a: Local curator lane
+
+Use `ao overnight curator` when the user asks about Gemma, the local worker, the
+SOC trigger path, or Tier 1 drafts.
+
+```bash
+ao overnight curator status --json
+ao overnight curator diagnose
+ao overnight curator enqueue --kind lint-wiki
+ao overnight curator enqueue --kind dream-seed
+ao overnight curator compact --dry-run
+ao overnight curator event --source local-soc --severity high --desired-action "review alert cluster" --budget 1
+```
+
+Do not promote Tier 1 drafts directly into authored content. Treat draft
+promotion as Tier 2 or human review work.
 
 ### Step 3: Bedtime run lane
 


### PR DESCRIPTION
Adds dream.local_curator config, Ollama/Gemma autodetection, ao overnight curator status/diagnose/enqueue/compact/event, Windows Task Scheduler artifact generation, and refreshed Dream docs/Codex skill metadata. Validated with focused Dream/config Go tests, go build, live curator status/compact/event dry-run smoke tests, skill heal, doc-release, hooks-doc parity, and Codex artifact validation. Full Windows-host validation still has unrelated WSL/toolchain friction captured in bd follow-up.