### PR TITLE
docs(evolve): clarify v2 operator loop

### DIFF
--- a/cli/cmd/ao/evolve.go
+++ b/cli/cmd/ao/evolve.go
@@ -21,9 +21,15 @@ var evolveCmd = &cobra.Command{
 	Short: "Run the autonomous code-improvement loop",
 	Long: `Run the v2 autonomous improvement loop.
 
-This is the top-level operator surface for the old /evolve flow. It uses the
-same engine as "ao rpi loop" and defaults to supervisor mode so each cycle gets
-lease locking, compile producer cadence, quality gates, retries, and cleanup.
+This is the top-level operator surface for the old /evolve flow. The v2 name is
+still "evolve": it uses the same engine as "ao rpi loop" and defaults to
+supervisor mode so each cycle gets lease locking, compile producer cadence,
+quality gates, retries, and cleanup.
+
+Operator cadence:
+  post-mortem finished work, analyze repo state, select or create next work,
+  run RPI planning/pre-mortem/implementation/validation, harvest follow-ups,
+  and repeat until the queue is stable or a stop condition fires.
 
 Examples:
   ao evolve                          # run until queue stable or stopped

--- a/cli/cmd/ao/evolve_test.go
+++ b/cli/cmd/ao/evolve_test.go
@@ -50,6 +50,22 @@ func TestEvolveCommandReusesRPILoopFlags(t *testing.T) {
 	}
 }
 
+func TestEvolveHelpDescribesV2OperatorCadence(t *testing.T) {
+	help := evolveCmd.Long
+	for _, want := range []string{
+		`The v2 name is`,
+		`still "evolve"`,
+		"post-mortem finished work",
+		"analyze repo state",
+		"planning/pre-mortem/implementation/validation",
+		"harvest follow-ups",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("evolve help missing %q:\n%s", want, help)
+		}
+	}
+}
+
 func TestApplyEvolveDefaultsEnablesSupervisor(t *testing.T) {
 	prev := snapshotLoopSupervisorGlobals()
 	defer restoreLoopSupervisorGlobals(prev)

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -2192,10 +2192,13 @@ ao forge transcript <path-or-glob> [flags]
 **Flags:**
 
 ```
-  -h, --help           help for transcript
-      --last-session   Process only the most recent transcript
-      --queue          Queue session for learning extraction at next session start
-      --quiet          Suppress all output (for hooks)
+  -h, --help                  help for transcript
+      --last-session          Process only the most recent transcript
+      --llm-endpoint string   Ollama HTTP endpoint for --tier=1 (default: $AGENTOPS_LLM_ENDPOINT or http://localhost:11434)
+      --model string          LLM model tag for --tier=1 (e.g. gemma2:9b)
+      --queue                 Queue session for learning extraction at next session start
+      --quiet                 Suppress all output (for hooks)
+      --tier int              Tier 1 local-LLM summarization pipeline (requires --model, --llm-endpoint optional)
 ```
 
 ---

--- a/skills-codex-overrides/evolve/prompt.md
+++ b/skills-codex-overrides/evolve/prompt.md
@@ -1,6 +1,6 @@
 # evolve
 
-Run `$evolve` as an always-on Codex loop over `$rpi`: keep selecting productive work, compound via harvested follow-ups, and only go dormant as a last resort.
+Run `$evolve` as the Codex-facing operator loop for `ao evolve`: post-mortem finished work, analyze repo state, select or create the next highest-value item, let `$rpi` plan/pre-mortem/implement/validate it, harvest follow-ups, and repeat until a real stop condition fires.
 
 ## Codex Execution Profile
 
@@ -9,6 +9,7 @@ Run `$evolve` as an always-on Codex loop over `$rpi`: keep selecting productive 
 3. Prefer Codex sub-agents for generator layers and sidecar audits when they can run in parallel without blocking the main loop.
 4. Persist loop state under `.agents/evolve/` and recover from disk instead of relying on live context.
 5. When `PROGRAM.md` or `AUTODEV.md` exists, treat it as the active execution layer: keep selection inside mutable scope, escalate immutable-scope work, and use its validation and decision policy in the cycle gate.
+6. Do not invent a new loop skill name when the user asks what this should be called; the v2 command is `ao evolve` and the skill remains `$evolve`.
 
 ## Guardrails
 

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -728,7 +728,7 @@
       "name": "evolve",
       "source_skill": "skills/evolve",
       "source_hash": "d6f47f2fe5d384d3c94143e120a056699c29a548bd391d93aa01d20b9a94dd6c",
-      "generated_hash": "7b16fc22742ea7b632a7acb1ab6d74c01bcdc63040e303c543e8fb5b56d784b7"
+      "generated_hash": "e339bf8e5479621c5c4828a8c2abacf534581248e31048c724b37a3d00e28816"
     },
     {
       "name": "flywheel",

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/evolve",
   "layout": "modular",
   "source_hash": "d6f47f2fe5d384d3c94143e120a056699c29a548bd391d93aa01d20b9a94dd6c",
-  "generated_hash": "7b16fc22742ea7b632a7acb1ab6d74c01bcdc63040e303c543e8fb5b56d784b7"
+  "generated_hash": "e339bf8e5479621c5c4828a8c2abacf534581248e31048c724b37a3d00e28816"
 }

--- a/skills-codex/evolve/SKILL.md
+++ b/skills-codex/evolve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: evolve
-description: 'Goal-driven fitness-scored improvement loop. Measures goals, picks worst gap, runs $rpi, compounds via knowledge flywheel. Also pulls from open beads when goals all pass. Accepts ordered roadmap via --queue for sequential execution with auto-unblocking. Use when you want to "improve", "iterate", "fix issues", "work through tasks", "evolve", "check goal fitness", "run improvement loop", "pick up next work", or "run roadmap".'
+description: 'Goal-driven v2 autonomous improvement loop. Runs the post-mortem, repo analysis, next-work selection, plan/pre-mortem, implementation, validation, and repeat cadence through $rpi and ao evolve. Also pulls from open beads when goals all pass and accepts ordered roadmaps via --queue. Use when you want to "improve", "iterate", "fix issues", "work through tasks", "evolve", "check goal fitness", "run improvement loop", "pick up next work", "postmortem and continue", or "run roadmap".'
 ---
 
 
@@ -8,9 +8,16 @@ description: 'Goal-driven fitness-scored improvement loop. Measures goals, picks
 
 > Measure what's wrong. Fix the worst thing. Measure again. Compound.
 
-**V2 command surface:** use `ao evolve` for the terminal-native loop. It is the
-top-level operator entrypoint for `ao rpi loop --supervisor`, preserving the old
-`$evolve` concept while reusing the v2 RPI loop engine.
+**V2 command surface:** keep the name `evolve`. Use `ao evolve` for the
+terminal-native loop. It is the top-level operator entrypoint for
+`ao rpi loop --supervisor`, preserving the old `$evolve` concept while reusing
+the v2 RPI loop engine.
+
+**Operator cadence:** post-mortem finished work, analyze the current repo state,
+select or create the next highest-value work item, let `$rpi` handle research,
+planning, pre-mortem, implementation, and validation, then harvest follow-ups
+and repeat until a kill switch, max-cycle cap, regression breaker, or real
+dormancy stops the run.
 
 Always-on autonomous loop over `$rpi`. Work selection order:
 0. **Pinned work queue** (`--queue=<file>` or inline roadmap — see `references/pinned-queue.md`)

--- a/skills-codex/evolve/prompt.md
+++ b/skills-codex/evolve/prompt.md
@@ -1,6 +1,6 @@
 # evolve
 
-Run `$evolve` as an always-on Codex loop over `$rpi`: keep selecting productive work, compound via harvested follow-ups, and only go dormant as a last resort.
+Run `$evolve` as the Codex-facing operator loop for `ao evolve`: post-mortem finished work, analyze repo state, select or create the next highest-value item, let `$rpi` plan/pre-mortem/implement/validate it, harvest follow-ups, and repeat until a real stop condition fires.
 
 ## Codex Execution Profile
 
@@ -9,6 +9,7 @@ Run `$evolve` as an always-on Codex loop over `$rpi`: keep selecting productive 
 3. Prefer Codex sub-agents for generator layers and sidecar audits when they can run in parallel without blocking the main loop.
 4. Persist loop state under `.agents/evolve/` and recover from disk instead of relying on live context.
 5. When `PROGRAM.md` or `AUTODEV.md` exists, treat it as the active execution layer: keep selection inside mutable scope, escalate immutable-scope work, and use its validation and decision policy in the cycle gate.
+6. Do not invent a new loop skill name when the user asks what this should be called; the v2 command is `ao evolve` and the skill remains `$evolve`.
 
 ## Guardrails
 

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: evolve
-description: Goal-driven fitness-scored improvement loop. Measures goals, picks worst gap, runs /rpi, compounds via knowledge flywheel. Also pulls from open beads when goals all pass. Accepts ordered roadmap via --queue for sequential execution with auto-unblocking. Use when you want to "improve", "iterate", "fix issues", "work through tasks", "evolve", "check goal fitness", "run improvement loop", "pick up next work", or "run roadmap".
+description: Goal-driven v2 autonomous improvement loop. Runs the post-mortem, repo analysis, next-work selection, plan/pre-mortem, implementation, validation, and repeat cadence through /rpi and ao evolve. Also pulls from open beads when goals all pass and accepts ordered roadmaps via --queue. Use when you want to "improve", "iterate", "fix issues", "work through tasks", "evolve", "check goal fitness", "run improvement loop", "pick up next work", "postmortem and continue", or "run roadmap".
 skill_api_version: 1
 user-invocable: true
 context:
@@ -24,6 +24,8 @@ metadata:
     - roadmap
     - run queue
     - pinned queue
+    - postmortem and continue
+    - analyze repo and keep going
 output_contract: "code changes, GOALS.md fitness deltas"
 ---
 
@@ -31,9 +33,16 @@ output_contract: "code changes, GOALS.md fitness deltas"
 
 > Measure what's wrong. Fix the worst thing. Measure again. Compound.
 
-**V2 command surface:** use `ao evolve` for the terminal-native loop. It is the
-top-level operator entrypoint for `ao rpi loop --supervisor`, preserving the old
-`/evolve` concept while reusing the v2 RPI loop engine.
+**V2 command surface:** keep the name `evolve`. Use `ao evolve` for the
+terminal-native loop. It is the top-level operator entrypoint for
+`ao rpi loop --supervisor`, preserving the old `/evolve` concept while reusing
+the v2 RPI loop engine.
+
+**Operator cadence:** post-mortem finished work, analyze the current repo state,
+select or create the next highest-value work item, let `/rpi` handle research,
+planning, pre-mortem, implementation, and validation, then harvest follow-ups
+and repeat until a kill switch, max-cycle cap, regression breaker, or real
+dormancy stops the run.
 
 Always-on autonomous loop over `/rpi`. Work selection order:
 0. **Pinned work queue** (`--queue=<file>` or inline roadmap — see `references/pinned-queue.md`)


### PR DESCRIPTION
## Summary
- keeps `evolve` as the v2 loop name and points users to `ao evolve`
- documents the operator cadence: post-mortem finished work, analyze repo state, select next work, run RPI plan/pre-mortem/implement/validate, harvest, repeat
- updates source skill, Codex artifact, Codex override prompt, generated Codex metadata, and CLI help
- adds a help-text regression test so the v2 naming/cadence stays visible
- refreshes `cli/docs/COMMANDS.md` after rebasing onto the landed forge Tier 1 flags

## Validation
- `cd cli && env -u AGENTOPS_RPI_RUNTIME go test ./cmd/ao -run 'TestEvolve|TestForgeTranscriptTier1' -count=1`
- `bash skills/evolve/scripts/validate.sh`
- `bash skills/heal-skill/scripts/heal.sh --check --strict skills/evolve skills-codex/evolve`
- `bash scripts/validate-codex-override-coverage.sh`
- `bash scripts/validate-codex-generated-artifacts.sh --scope worktree`
- `bash scripts/audit-codex-parity.sh --skill evolve`
- `scripts/generate-cli-reference.sh --check`
- `scripts/pre-push-gate.sh --fast`

## Bead
- closes `na-7ay`
