### PR TITLE
test(capture): lock json stdout panic restore

### DIFF
--- a/cli/cmd/ao/testutil_capture_test.go
+++ b/cli/cmd/ao/testutil_capture_test.go
@@ -89,3 +89,21 @@ func TestCaptureStdoutRestoresStdoutAfterPanic(t *testing.T) {
 		panic("boom")
 	})
 }
+
+func TestCaptureJSONStdoutRestoresStdoutAfterPanic(t *testing.T) {
+	original := os.Stdout
+
+	defer func() {
+		if recovered := recover(); recovered == nil {
+			t.Fatal("expected panic from captureJSONStdout callback")
+		}
+		if os.Stdout != original {
+			t.Fatal("stdout was not restored after JSON capture panic")
+		}
+	}()
+
+	_ = captureJSONStdout(t, func() {
+		_, _ = fmt.Fprint(os.Stdout, `{"boom":true}`)
+		panic("boom")
+	})
+}


### PR DESCRIPTION
## Summary
- Add a panic-restore regression test for captureJSONStdout
- Covers the same stdout-restoration contract already asserted for captureStdout

## Bead
- na-uuy.6.2

## Validation
- env -u AGENTOPS_RPI_RUNTIME go test ./cmd/ao -run 'TestCapture.*Panic|TestCaptureJSONStdoutRestoresStdoutAfterPanic' -count=1\n- env -u AGENTOPS_RPI_RUNTIME go test ./cmd/ao -run 'TestCapture' -count=1\n- WORKTREE_DISPOSITION_EXTRA_ALLOWED_BRANCHES=w6-tier2-gate env -u AGENTOPS_RPI_RUNTIME scripts/pre-push-gate.sh --fast