### PR TITLE
docs(cli): add forge review command reference

### DIFF
--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -2273,6 +2273,21 @@ ao forge markdown <path-or-glob> [flags]
       --quiet   Suppress all output (for hooks)
 ```
 
+#### `ao forge review`
+
+Review draft session pages in .agents/ao/sessions/ and promote
+
+```
+ao forge review [flags]
+```
+
+**Flags:**
+
+```
+      --dry-run   Show what would be promoted without writing
+  -h, --help      help for review
+```
+
 #### `ao forge transcript`
 
 Parse Claude Code JSONL transcript files and extract knowledge candidates.


### PR DESCRIPTION
## Summary
- Regenerate cli/docs/COMMANDS.md for the shipped `ao forge review` subcommand
- Unblocks CLI docs parity on PR branches based on W6

## Bead
- na-uuy.5.1

## Validation
- scripts/generate-cli-reference.sh --check
- WORKTREE_DISPOSITION_EXTRA_ALLOWED_BRANCHES=codex/capture-json-stdout-panic-regression env -u AGENTOPS_RPI_RUNTIME scripts/pre-push-gate.sh --fast