### PR TITLE
fix(swarm): ignore local evidence in default gate

### DIFF
--- a/scripts/validate-swarm-evidence.sh
+++ b/scripts/validate-swarm-evidence.sh
@@ -20,9 +20,19 @@ if [[ -z "$RESULT_FILE" ]]; then
         exit 0
     fi
     EVIDENCE_FILES=()
-    while IFS= read -r -d '' f; do
-        EVIDENCE_FILES+=("$f")
-    done < <(find "$EVIDENCE_DIR" -maxdepth 1 -name '*.json' -type f -print0 2>/dev/null)
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        while IFS= read -r -d '' f; do
+            [[ "$f" == *.json ]] && EVIDENCE_FILES+=("$f")
+        done < <(git ls-files -z -- "$EVIDENCE_DIR" 2>/dev/null || true)
+        if [[ ${#EVIDENCE_FILES[@]} -eq 0 ]]; then
+            echo "SKIP: no tracked evidence files in $EVIDENCE_DIR — nothing to validate"
+            exit 0
+        fi
+    else
+        while IFS= read -r -d '' f; do
+            EVIDENCE_FILES+=("$f")
+        done < <(find "$EVIDENCE_DIR" -maxdepth 1 -name '*.json' -type f -print0 2>/dev/null)
+    fi
     if [[ ${#EVIDENCE_FILES[@]} -eq 0 ]]; then
         echo "SKIP: no evidence files in $EVIDENCE_DIR — nothing to validate"
         exit 0

--- a/tests/scripts/validate-swarm-evidence.bats
+++ b/tests/scripts/validate-swarm-evidence.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/validate-swarm-evidence.sh"
+    TMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+init_fixture_repo() {
+    local repo="$1"
+    mkdir -p "$repo/.agents/swarm/results"
+    git -C "$repo" init -q
+    printf '.agents/\n' > "$repo/.gitignore"
+}
+
+write_invalid_completion() {
+    local path="$1"
+    cat > "$path" <<'JSON'
+{
+  "type": "completion",
+  "status": "done",
+  "artifacts": ["cli/cmd/ao/example.go"]
+}
+JSON
+}
+
+write_valid_completion() {
+    local path="$1"
+    cat > "$path" <<'JSON'
+{
+  "type": "completion",
+  "status": "done",
+  "artifacts": ["cli/cmd/ao/example.go"],
+  "evidence": {
+    "required_checks": ["unit"],
+    "checks": {
+      "unit": {
+        "verdict": "PASS"
+      }
+    }
+  }
+}
+JSON
+}
+
+@test "default scan ignores untracked local swarm evidence in git repos" {
+    repo="$TMP_DIR/repo"
+    init_fixture_repo "$repo"
+    write_invalid_completion "$repo/.agents/swarm/results/legacy.json"
+
+    cd "$repo"
+    run bash "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no tracked evidence files"* ]]
+}
+
+@test "explicit directory validation remains strict for untracked evidence" {
+    repo="$TMP_DIR/repo"
+    init_fixture_repo "$repo"
+    write_invalid_completion "$repo/.agents/swarm/results/legacy.json"
+
+    run bash "$SCRIPT" "$repo/.agents/swarm/results"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"completion result missing evidence block"* ]]
+}
+
+@test "default scan still validates tracked swarm evidence" {
+    repo="$TMP_DIR/repo"
+    init_fixture_repo "$repo"
+    write_valid_completion "$repo/.agents/swarm/results/good.json"
+    git -C "$repo" add -f .agents/swarm/results/good.json
+
+    cd "$repo"
+    run bash "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"EVIDENCE BATCH PASS"* ]]
+}


### PR DESCRIPTION
## Summary
- Make no-arg swarm evidence validation scan tracked evidence in git worktrees, avoiding failures from ignored local .agents/ artifacts.
- Keep explicit file/directory validation strict for all supplied evidence.
- Add BATS coverage for ignored local evidence, explicit invalid directory validation, and tracked evidence validation.

## Bead
- na-uuy.4.1

## Validation
- bash -n scripts/validate-swarm-evidence.sh
- shellcheck --severity=error scripts/validate-swarm-evidence.sh
- bats tests/scripts/validate-swarm-evidence.bats
- root default-mode probe with local ignored evidence
- explicit invalid directory probe
- git diff --check
- env -u AGENTOPS_RPI_RUNTIME scripts/pre-push-gate.sh --fast
