### PR TITLE
fix(search): use root-scoped fallback reads

### DIFF
--- a/cli/cmd/ao/search.go
+++ b/cli/cmd/ao/search.go
@@ -559,11 +559,22 @@ func searchMarkdownFilesByTokens(query, dir, resultType string, limit int) []sea
 	minMatches := searchFallbackMinMatches(len(tokens))
 
 	results := make([]searchResult, 0)
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		VerbosePrintf("token fallback search root error for %s: %v\n", dir, err)
+		return nil
+	}
+	defer root.Close()
+
 	if err := filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error {
 		if err != nil || entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
 			return nil
 		}
-		data, err := os.ReadFile(path)
+		relPath, err := filepath.Rel(dir, path)
+		if err != nil || relPath == "." || relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
+			return nil
+		}
+		data, err := root.ReadFile(relPath)
 		if err != nil {
 			return nil
 		}


### PR DESCRIPTION
## Summary
- Reads markdown fallback search matches through `os.OpenRoot` instead of raw `filepath.WalkDir` callback paths.
- Keeps fallback scoring behavior unchanged while clearing GoSec G122.

## Validation
- `cd cli; go test ./cmd/ao -run "TestSearchRepoLocalKnowledgeTokenFallbackFindsMultiTokenNonPhrase|TestSearchRepoLocalKnowledgeFindsMarkdownLearningTokenFallback|TestSearchRepoLocalKnowledgeTokenFallbackUsesPathTokens|TestOutputSearchResults|TestFilterByType|TestNormalizeSearchType|TestRunSearch_JSON" -count=1`
- `cd cli; go run github.com/securego/gosec/v2/cmd/gosec@latest -quiet -fmt json -include=G122 ./cmd/ao` -> `issues=0`
- `cd cli; go build ./cmd/ao`