### PR TITLE
fix(nightly): resolve three causes of CI build failures

### DIFF
--- a/cli/cmd/ao/harvest_test.go
+++ b/cli/cmd/ao/harvest_test.go
@@ -437,6 +437,12 @@ func TestHarvest_LockFileCorrupted_ProceedsWithWarning(t *testing.T) {
 }
 
 func TestRunHarvest_PersistsDiscoveryWarnings(t *testing.T) {
+	// Root bypasses filesystem permission checks, so the chmod(0)
+	// trick below cannot trigger a permission-denied warning.
+	if os.Getuid() == 0 {
+		t.Skip("test requires non-root to enforce directory permissions")
+	}
+
 	tmp := t.TempDir()
 	t.Setenv("HOME", filepath.Join(tmp, "home"))
 

--- a/scripts/toolchain-validate.sh
+++ b/scripts/toolchain-validate.sh
@@ -280,25 +280,32 @@ run_golangci() {
         fi
     done <<< "$modules"
 
-    # Detect golangci-lint / Go version mismatch (e.g. linter built with Go 1.25
-    # but project targets Go 1.26). This is a toolchain gap, not a code finding.
+    local had_version_mismatch=false
     if grep -qE "Go language version .* is lower than the targeted Go version" "$output_file" 2>/dev/null; then
-        log "  [WARN] golangci-lint skipped: built with older Go than project target"
-        TOOL_STATUS["golangci-lint"]="skipped"
-        TOOLS_SKIPPED=$((TOOLS_SKIPPED + 1))
-        return 0
+        had_version_mismatch=true
+        log "  [WARN] golangci-lint: some modules skipped due to Go version mismatch"
     fi
 
     local issues
     issues=$(grep -cE "^[^:]+:[0-9]+:[0-9]+:" "$output_file" 2>/dev/null || true)
     issues=${issues:-0}
     issues=$(echo "$issues" | tr -d '[:space:]')
-    if [[ "$issues" -eq 0 ]] && [[ "$had_findings" == "false" ]]; then
+
+    if [[ "$issues" -gt 0 ]]; then
+        # Real lint findings from modules that ran successfully — count them
+        # even if other modules hit a version mismatch.
+        HIGH_COUNT=$((HIGH_COUNT + issues))
+        QUALITY_HIGH_COUNT=$((QUALITY_HIGH_COUNT + issues))
+        TOOL_STATUS["golangci-lint"]="findings"
+    elif [[ "$had_version_mismatch" == "true" ]]; then
+        # No real findings, but at least one module couldn't be linted.
+        TOOL_STATUS["golangci-lint"]="skipped"
+        TOOLS_SKIPPED=$((TOOLS_SKIPPED + 1))
+    elif [[ "$had_findings" == "false" ]]; then
         echo "CLEAN" > "$output_file"
         TOOL_STATUS["golangci-lint"]="pass"
     else
-        HIGH_COUNT=$((HIGH_COUNT + issues))
-        QUALITY_HIGH_COUNT=$((QUALITY_HIGH_COUNT + issues))
+        # Non-zero exit but no parseable findings (e.g. config error).
         TOOL_STATUS["golangci-lint"]="findings"
     fi
 }

--- a/scripts/toolchain-validate.sh
+++ b/scripts/toolchain-validate.sh
@@ -280,6 +280,15 @@ run_golangci() {
         fi
     done <<< "$modules"
 
+    # Detect golangci-lint / Go version mismatch (e.g. linter built with Go 1.25
+    # but project targets Go 1.26). This is a toolchain gap, not a code finding.
+    if grep -qE "Go language version .* is lower than the targeted Go version" "$output_file" 2>/dev/null; then
+        log "  [WARN] golangci-lint skipped: built with older Go than project target"
+        TOOL_STATUS["golangci-lint"]="skipped"
+        TOOLS_SKIPPED=$((TOOLS_SKIPPED + 1))
+        return 0
+    fi
+
     local issues
     issues=$(grep -cE "^[^:]+:[0-9]+:[0-9]+:" "$output_file" 2>/dev/null || true)
     issues=${issues:-0}
@@ -789,14 +798,25 @@ run_gosec() {
         return 0
     fi
 
-    # Count issues across combined JSON blocks (best-effort)
-    local issues
-    issues=$(grep -c '"severity":' "$output_file" 2>/dev/null || true)
-    issues=${issues:-0}
-    issues=$(echo "$issues" | tr -d '[:space:]')
-    if [[ "$issues" -gt 0 ]]; then
-        HIGH_COUNT=$((HIGH_COUNT + issues))
-        SECURITY_HIGH_COUNT=$((SECURITY_HIGH_COUNT + issues))
+    # Count issues by severity across combined JSON blocks (best-effort).
+    # gosec JSON uses "severity": "HIGH"|"MEDIUM"|"LOW" per finding.
+    # Only HIGH findings should contribute to the security gate.
+    local high_issues medium_issues low_issues
+    high_issues=$(grep -c '"severity": "HIGH"' "$output_file" 2>/dev/null || true)
+    high_issues=${high_issues:-0}
+    high_issues=$(echo "$high_issues" | tr -d '[:space:]')
+    medium_issues=$(grep -c '"severity": "MEDIUM"' "$output_file" 2>/dev/null || true)
+    medium_issues=${medium_issues:-0}
+    medium_issues=$(echo "$medium_issues" | tr -d '[:space:]')
+    low_issues=$(grep -c '"severity": "LOW"' "$output_file" 2>/dev/null || true)
+    low_issues=${low_issues:-0}
+    low_issues=$(echo "$low_issues" | tr -d '[:space:]')
+    local total_issues=$((high_issues + medium_issues + low_issues))
+    if [[ "$total_issues" -gt 0 ]]; then
+        HIGH_COUNT=$((HIGH_COUNT + high_issues))
+        SECURITY_HIGH_COUNT=$((SECURITY_HIGH_COUNT + high_issues))
+        MEDIUM_COUNT=$((MEDIUM_COUNT + medium_issues))
+        LOW_COUNT=$((LOW_COUNT + low_issues))
         TOOL_STATUS["gosec"]="findings"
     else
         TOOL_STATUS["gosec"]="pass"


### PR DESCRIPTION
## Summary

Fixes three root causes behind the recurring nightly build failures reported in #91, #89, and #83:

- **Skip `TestRunHarvest_PersistsDiscoveryWarnings` when running as root** — the test uses `chmod(0)` to simulate permission-denied errors, but root bypasses filesystem permission checks, causing the test to fail in root-based CI/container environments. This was the direct cause of CLI test failures (#89).

- **Detect golangci-lint / Go version mismatch gracefully** — golangci-lint v2.11.4 (latest) is built with Go 1.25 but the project targets Go 1.26. The toolchain now detects this version gap and treats it as "skipped" instead of "findings", preventing false security gate blocks.

- **Fix gosec severity counting in `toolchain-validate.sh`** ��� previously ALL gosec findings (regardless of severity) were added to `SECURITY_HIGH_COUNT`, causing MEDIUM/LOW findings to incorrectly block the security gate. Now properly categorizes findings as HIGH/MEDIUM/LOW, so only HIGH-severity security findings block the gate.

Fixes #91, #89, #83

## Test plan

- [x] `TestRunHarvest_PersistsDiscoveryWarnings` correctly skips when running as root (`go test -run TestRunHarvest -v`)
- [x] Full `go test ./...` passes (all packages OK)
- [x] `go vet ./...` clean
- [x] `make build` succeeds
- [x] `tests/smoke-test.sh` — all checks pass
- [x] `tests/docs/validate-doc-release.sh` — gate succeeds
- [x] `scripts/toolchain-validate.sh --quick --json` — golangci-lint now properly reported as "skipped" (was "findings"), gate PASS

https://claude.ai/code/session_01YWC8ZyAyN7kZRXEpNLTN2n