### PR TITLE
Nightly 2026-04-17 v2 — 6 cycles, next-work enum contract fix + GOALS.md-migration cleanup + demo test speedup

### DIFF
--- a/cli/cmd/ao/cobra_commands_test.go
+++ b/cli/cmd/ao/cobra_commands_test.go
@@ -632,6 +632,7 @@ func TestCobraDemoConceptsCommand(t *testing.T) {
 
 // TestCobraDemoQuickCommand exercises the demo --quick command.
 func TestCobraDemoQuickCommand(t *testing.T) {
+	withoutDemoDelay(t)
 	out, err := executeCommand("demo", "--quick")
 	if err != nil {
 		t.Fatalf("ao demo --quick failed: %v", err)

--- a/cli/cmd/ao/demo.go
+++ b/cli/cmd/ao/demo.go
@@ -32,6 +32,10 @@ Examples:
 var (
 	demoQuick    bool
 	demoConcepts bool
+	// demoStepDelay is the pause between terminal "cards" in quickDemo.
+	// Exposed at package scope so tests can zero it out — the 500 ms is for
+	// human pacing in a live terminal and has no behavioral meaning.
+	demoStepDelay = 500 * time.Millisecond
 )
 
 func init() {
@@ -147,7 +151,9 @@ func quickDemo() error {
 		fmt.Printf("│  $ %s\n", step.cmd)
 		fmt.Printf("│  → %s\n", step.explain)
 		fmt.Print("└─\n")
-		time.Sleep(500 * time.Millisecond)
+		if demoStepDelay > 0 {
+			time.Sleep(demoStepDelay)
+		}
 	}
 
 	fmt.Println(`

--- a/cli/cmd/ao/demo_test.go
+++ b/cli/cmd/ao/demo_test.go
@@ -4,6 +4,17 @@ import (
 	"testing"
 )
 
+// withoutDemoDelay zeroes demoStepDelay for the duration of a test so the
+// 500 ms × 5-step pacing sleep in quickDemo does not inflate test runtime.
+// The 500 ms is purely for human pacing in a live terminal; nothing in
+// quickDemo depends on it for correctness.
+func withoutDemoDelay(t *testing.T) {
+	t.Helper()
+	prev := demoStepDelay
+	demoStepDelay = 0
+	t.Cleanup(func() { demoStepDelay = prev })
+}
+
 func TestDemo_CommandExists(t *testing.T) {
 	if demoCmd == nil {
 		t.Fatal("demoCmd should not be nil")
@@ -33,6 +44,7 @@ func TestDemo_ShowConcepts(t *testing.T) {
 }
 
 func TestDemo_QuickDemo(t *testing.T) {
+	withoutDemoDelay(t)
 	err := quickDemo()
 	if err != nil {
 		t.Fatalf("quickDemo returned error: %v", err)
@@ -56,6 +68,7 @@ func TestDemo_RunDemoDispatch_Concepts(t *testing.T) {
 }
 
 func TestDemo_RunDemoDispatch_Quick(t *testing.T) {
+	withoutDemoDelay(t)
 	origConcepts := demoConcepts
 	origQuick := demoQuick
 	defer func() {

--- a/cli/internal/overnight/findings_router.go
+++ b/cli/internal/overnight/findings_router.go
@@ -306,17 +306,18 @@ func extractFrontmatterField(frontmatter, key string) string {
 }
 
 // mapSeverity normalizes the finding-schema severity vocabulary to the
-// next-work.jsonl "low|medium|high|critical" vocabulary.
+// next-work.jsonl severity enum, which is strictly "low|medium|high"
+// (see docs/contracts/next-work.schema.md §Enums → Severity). Finding-schema
+// values above "high" ("critical", "blocker") collapse to "high" rather than
+// emitting a value the next-work contract rejects.
 func mapSeverity(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "minor", "low":
 		return "low"
 	case "medium", "significant":
 		return "medium"
-	case "high", "major":
+	case "high", "major", "critical", "blocker":
 		return "high"
-	case "critical", "blocker":
-		return "critical"
 	default:
 		return "medium"
 	}

--- a/cli/internal/overnight/findings_router.go
+++ b/cli/internal/overnight/findings_router.go
@@ -19,8 +19,11 @@ var findingFilenameRe = regexp.MustCompile(`^f-\d{4}-\d{2}-\d{2}-\d{3}\.md$`)
 // routedFinding is the structured next-work item written by RouteFindings.
 //
 // Fields map to the existing next-work.jsonl item shape. New routes always
-// set Type="finding" and Source="finding-router"; Severity defaults to
-// "medium" when the finding body does not declare one.
+// set Type="tech-debt" and Source="council-finding" to satisfy the v1.3
+// next-work enum contract (see docs/contracts/next-work.schema.md). The
+// original finding provenance lives in SourcePath and in the finding file's
+// own frontmatter. Severity defaults to "medium" when the finding body does
+// not declare one.
 type routedFinding struct {
 	ID          string `json:"id"`
 	Title       string `json:"title"`
@@ -254,9 +257,9 @@ func parseFinding(id, path, cwd string) (routedFinding, error) {
 	return routedFinding{
 		ID:          id,
 		Title:       title,
-		Type:        "finding",
+		Type:        "tech-debt",
 		Severity:    severity,
-		Source:      "finding-router",
+		Source:      "council-finding",
 		Description: description,
 		TargetRepo:  filepath.Base(cwd),
 		SourcePath:  relPath,

--- a/cli/internal/overnight/findings_router_test.go
+++ b/cli/internal/overnight/findings_router_test.go
@@ -55,6 +55,68 @@ func readNextWorkLines(t *testing.T, cwd string) []string {
 	return out
 }
 
+// validNextWorkItemTypes mirrors the `Type` enum in
+// docs/contracts/next-work.schema.md §Enums. It is intentionally hard-coded
+// here (not imported) so that a schema-doc drift requires a deliberate
+// test-code update, which is exactly the contract this guard enforces.
+var validNextWorkItemTypes = map[string]struct{}{
+	"tech-debt":           {},
+	"improvement":         {},
+	"pattern-fix":         {},
+	"process-improvement": {},
+	"feature":             {},
+	"bug":                 {},
+	"task":                {},
+}
+
+// validNextWorkItemSources mirrors the `Source` enum in
+// docs/contracts/next-work.schema.md §Enums.
+var validNextWorkItemSources = map[string]struct{}{
+	"council-finding":    {},
+	"retro-learning":     {},
+	"retro-pattern":      {},
+	"evolve-generator":   {},
+	"feature-suggestion": {},
+	"backlog-processing": {},
+}
+
+// TestRouteFindings_EmitsSchemaCompliantEnums is a build-time guard against
+// the next-work v1.3 enum drift that previously tripped the pre-push gate's
+// contract parity check (see fix commit 271d4de4). Any future change to the
+// router's `Type`/`Source` string literals that picks a value outside the
+// schema's allowed enum will now fail this test instead of surviving until
+// push time.
+func TestRouteFindings_EmitsSchemaCompliantEnums(t *testing.T) {
+	cwd := t.TempDir()
+	writeFinding(t, cwd, "f-2026-04-17-001.md", "Schema guard", "Body.")
+
+	routed, _, err := RouteFindings(cwd)
+	if err != nil {
+		t.Fatalf("RouteFindings: %v", err)
+	}
+	if routed != 1 {
+		t.Fatalf("expected routed=1, got %d", routed)
+	}
+
+	lines := readNextWorkLines(t, cwd)
+	var parsed struct {
+		Items []routedFinding `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(lines[0]), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(parsed.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(parsed.Items))
+	}
+	item := parsed.Items[0]
+	if _, ok := validNextWorkItemTypes[item.Type]; !ok {
+		t.Fatalf("router emitted type=%q which is not in the next-work schema enum; update docs/contracts/next-work.schema.md AND this test together if the schema genuinely grew", item.Type)
+	}
+	if _, ok := validNextWorkItemSources[item.Source]; !ok {
+		t.Fatalf("router emitted source=%q which is not in the next-work schema enum; update docs/contracts/next-work.schema.md AND this test together if the schema genuinely grew", item.Source)
+	}
+}
+
 func TestRouteFindings_MissingFindingsDir_SoftFail(t *testing.T) {
 	cwd := t.TempDir()
 	routed, degraded, err := RouteFindings(cwd)

--- a/cli/internal/overnight/findings_router_test.go
+++ b/cli/internal/overnight/findings_router_test.go
@@ -80,6 +80,15 @@ var validNextWorkItemSources = map[string]struct{}{
 	"backlog-processing": {},
 }
 
+// validNextWorkItemSeverities mirrors the `Severity` enum in
+// docs/contracts/next-work.schema.md §Enums. Note: "critical" is NOT valid —
+// any finding-schema severity above "high" must collapse to "high".
+var validNextWorkItemSeverities = map[string]struct{}{
+	"low":    {},
+	"medium": {},
+	"high":   {},
+}
+
 // TestRouteFindings_EmitsSchemaCompliantEnums is a build-time guard against
 // the next-work v1.3 enum drift that previously tripped the pre-push gate's
 // contract parity check (see fix commit 271d4de4). Any future change to the
@@ -114,6 +123,42 @@ func TestRouteFindings_EmitsSchemaCompliantEnums(t *testing.T) {
 	}
 	if _, ok := validNextWorkItemSources[item.Source]; !ok {
 		t.Fatalf("router emitted source=%q which is not in the next-work schema enum; update docs/contracts/next-work.schema.md AND this test together if the schema genuinely grew", item.Source)
+	}
+	if _, ok := validNextWorkItemSeverities[item.Severity]; !ok {
+		t.Fatalf("router emitted severity=%q which is not in the next-work schema enum {low,medium,high}; update docs/contracts/next-work.schema.md AND this test together if the schema genuinely grew", item.Severity)
+	}
+}
+
+// TestMapSeverity_CollapsesCriticalToHigh documents the deliberate mapping
+// choice: finding-schema "critical"/"blocker" collapse to "high" because the
+// next-work v1.3 severity enum is {low, medium, high}. Prior to this test
+// mapSeverity returned "critical" which was silently rejected by the
+// pre-push contract parity gate.
+func TestMapSeverity_CollapsesCriticalToHigh(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", "medium"},
+		{"low", "low"},
+		{"minor", "low"},
+		{"medium", "medium"},
+		{"significant", "medium"},
+		{"high", "high"},
+		{"major", "high"},
+		{"critical", "high"},
+		{"blocker", "high"},
+		{"  CRITICAL  ", "high"},
+		{"unknown-severity", "medium"},
+	}
+	for _, tc := range cases {
+		got := mapSeverity(tc.in)
+		if got != tc.want {
+			t.Errorf("mapSeverity(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+		if _, ok := validNextWorkItemSeverities[got]; !ok {
+			t.Errorf("mapSeverity(%q) = %q which is outside the next-work severity enum", tc.in, got)
+		}
 	}
 }
 

--- a/cli/internal/overnight/findings_router_test.go
+++ b/cli/internal/overnight/findings_router_test.go
@@ -118,8 +118,11 @@ func TestRouteFindings_FirstCall_RoutesAllUnseen(t *testing.T) {
 			t.Fatalf("unexpected id %s", it.ID)
 		}
 		wantIDs[it.ID] = true
-		if it.Type != "finding" {
-			t.Fatalf("expected type=finding, got %s", it.Type)
+		if it.Type != "tech-debt" {
+			t.Fatalf("expected type=tech-debt, got %s", it.Type)
+		}
+		if it.Source != "council-finding" {
+			t.Fatalf("expected source=council-finding, got %s", it.Source)
 		}
 	}
 	for id, seen := range wantIDs {

--- a/scripts/check-goal-quality.sh
+++ b/scripts/check-goal-quality.sh
@@ -20,6 +20,14 @@ set -uo pipefail
 GOALS_FILE="${1:-GOALS.yaml}"
 
 if [[ ! -f "$GOALS_FILE" ]]; then
+  # Post-GOALS.md migration (see CLAUDE.md §Agent Goals): the narrative
+  # markdown format does not carry machine-readable `check:` fields, so the
+  # anti-pattern detection here has nothing to run against. Skip gracefully
+  # so that the script is safe to run locally without yelling misconfigured.
+  if [[ -f "GOALS.md" ]]; then
+    echo "SKIP: GOALS.yaml not found; repo uses GOALS.md (post-migration). Nothing to check." >&2
+    exit 0
+  fi
   echo "ERROR: $GOALS_FILE not found" >&2
   exit 2
 fi

--- a/scripts/check-goal-staleness.sh
+++ b/scripts/check-goal-staleness.sh
@@ -11,6 +11,12 @@
 #
 # Usage: ./scripts/check-goal-staleness.sh
 # Requires: yq (YAML processor), date (macOS compatible)
+#
+# GOALS.md migration (see CLAUDE.md §Agent Goals): this repo converted
+# GOALS.yaml -> GOALS.md, so machine-readable `added:` / `check:` fields are no
+# longer present. If GOALS.yaml is absent, the script skips with exit 0 rather
+# than erroring, because no downstream gate depends on its output and erroring
+# misleads readers about a real problem.
 
 set -uo pipefail
 
@@ -29,6 +35,13 @@ fi
 GOALS_FILE="${1:-GOALS.yaml}"
 
 if [ ! -f "$GOALS_FILE" ]; then
+  # Post-GOALS.md migration: GOALS.yaml is the legacy YAML format. When it is
+  # absent we skip because this script has no way to apply its staleness
+  # heuristics against the current narrative markdown format.
+  if [ -f "GOALS.md" ]; then
+    echo "SKIP: GOALS.yaml not found; repo uses GOALS.md (post-migration). Nothing to check." >&2
+    exit 0
+  fi
   echo "ERROR: GOALS.yaml not found at $GOALS_FILE" >&2
   exit 1
 fi

--- a/scripts/check-pillar-coverage.sh
+++ b/scripts/check-pillar-coverage.sh
@@ -1,8 +1,23 @@
 #!/usr/bin/env bash
 # check-pillar-coverage.sh — Verify GOALS.yaml has goals for all 4 pillars.
+#
+# Post-GOALS.md migration (see CLAUDE.md §Agent Goals): GOALS.yaml is the
+# legacy YAML format. When it is absent but GOALS.md is present, skip with
+# exit 0 because the markdown narrative does not carry machine-readable
+# per-goal `pillar` fields; no downstream gate depends on this script today.
 set -uo pipefail
 
 GOALS_FILE="${1:-GOALS.yaml}"
+
+if [ ! -f "$GOALS_FILE" ]; then
+  if [ -f "GOALS.md" ]; then
+    echo "SKIP: GOALS.yaml not found; repo uses GOALS.md (post-migration). Pillar coverage is documented in the narrative, not machine-checkable here." >&2
+    exit 0
+  fi
+  echo "ERROR: GOALS.yaml not found at $GOALS_FILE" >&2
+  exit 1
+fi
+
 pillars=$(yq '.goals[].pillar' "$GOALS_FILE" | sort -u)
 
 for p in knowledge-compounding validated-acceleration goal-driven-automation zero-friction-workflow; do


### PR DESCRIPTION
## Summary

Autonomous nightly run on `nightly/2026-04-17-v2` off `origin/main` (`f45bc11e`).
6 productive cycles, 0 auto-reverts, 0 regressions.

This is the second nightly pass of 2026-04-17 (first pass landed as PR #114
on `nightly/2026-04-17`). Scope is intentionally orthogonal: PR #114 did an
ASCII-fast-path sweep; this PR targets the next-work v1.3 contract
drift + post-`GOALS.md`-migration orphaned-script error chatter + a
test-suite speedup.

## Fitness delta

| Signal | Baseline | Post-cycles | Δ |
|---|---|---|---|
| `ao autodev validate --file ../PROGRAM.md --json` | `valid: true` | `valid: true` | — |
| `go build ./... && go vet ./...` | passes | passes | — |
| `go test ./cmd/ao ./internal/autodev -count=1` | passes | passes | — |
| `skills/heal-skill/scripts/heal.sh --strict` | All clean. No findings. | All clean. No findings. | — |
| `scripts/validate-next-work-contract-parity.sh` | WOULD fail after any Dream run (router enum drift) | passes — router output is now v1.3-compliant | **fix** |
| `scripts/pre-push-gate.sh --fast` | 1 FAIL (worktree — known false positive), 31 skipped | 1 FAIL (same worktree false positive), 31 skipped | — |
| Findings router → next-work enum compliance | `type=finding`, `source=finding-router` (both invalid) | `type=tech-debt`, `source=council-finding` (both in v1.3 enum) | **fix** |
| `mapSeverity("critical"/"blocker")` | `"critical"` (invalid — enum is {low,medium,high}) | `"high"` (collapses to enum ceiling) | **fix** |
| `cli/internal/overnight` schema-drift coverage | none — push-time parity check only | build-time unit guard + mapSeverity table coverage | **+2 tests** |
| `cli/internal/overnight` `mapSeverity` statement coverage | 66.7 % | 100 % | **+33.3 %** |
| cmd/ao suite runtime | ~62 s | ~55 s | **−7 s** |
| `bash scripts/check-goal-staleness.sh` on current repo | exit 1, misleading error | exit 0, skips with migration note | **fix** |
| `bash scripts/check-pillar-coverage.sh` on current repo | exit 1, yq crash + MISSING pillar | exit 0, skips with migration note | **fix** |
| `bash scripts/check-goal-quality.sh` on current repo | exit 2, "GOALS.yaml not found" | exit 0, skips with migration note | **fix** |

> `ao goals measure --json` is **not** in the table because it **hangs**
> locally (times out at 60 s even with `--timeout 30`). Inherited from PR #114's
> findings — same reproduction.

## Per-cycle summary

| # | Commit | Title | Files |
|---|---|---|---|
| 1 | [`271d4de4`](../../commit/271d4de4) | `fix(overnight)` emit valid next-work v1.3 enums in findings router | `cli/internal/overnight/findings_router.go`, `cli/internal/overnight/findings_router_test.go` |
| 2 | [`bcd6c336`](../../commit/bcd6c336) | `test(overnight)` build-time guard that findings router emits schema-compliant enums | `cli/internal/overnight/findings_router_test.go` |
| 3 | [`2da07bb0`](../../commit/2da07bb0) | `fix(overnight)` collapse critical/blocker severity to high for next-work v1.3 | `cli/internal/overnight/findings_router.go`, `cli/internal/overnight/findings_router_test.go` |
| 4 | [`ac90b955`](../../commit/ac90b955) | `test(demo)` zero the pacing sleep in demo tests, save ~7 s per suite run | `cli/cmd/ao/demo.go`, `cli/cmd/ao/demo_test.go`, `cli/cmd/ao/cobra_commands_test.go` |
| 5 | [`f8bc3f5b`](../../commit/f8bc3f5b) | `fix(scripts)` goal-staleness skips cleanly after GOALS.yaml → GOALS.md migration | `scripts/check-goal-staleness.sh` |
| 6 | [`4269c665`](../../commit/4269c665) | `fix(scripts)` extend GOALS.md migration skip to pillar-coverage and goal-quality | `scripts/check-pillar-coverage.sh`, `scripts/check-goal-quality.sh` |

## Previous-run audit (vs PR #114 anchor)

- Most recent nightly: `origin/nightly/2026-04-17 @ 19bc8c85` (still open as PR #114)
- `main` did not move since that PR's base — no merged commits to compare against.
- Fitness baseline is identical to PR #114's baseline. No regressions observed
  against either the anchor or `origin/main`.
- The earlier run's biggest limitation — the pre-push gate's `next-work contract
  parity` failing after every Dream run — was fixed in Cycle 1 of this run.

## Findings closed (this run)

- **Router enum drift** (no finding ID yet; pattern documented in PR #114 body
  as "Dream findings router emits schema-invalid next-work entries"). Closed
  by mapping `type=finding → tech-debt`, `source=finding-router →
  council-finding`, and `severity=critical|blocker → high`. Guard test added
  so the same drift now fails at `go test` time instead of at push time.
- **`mapSeverity("critical")` returned `"critical"`** even though the next-work
  v1.3 severity enum is `{low, medium, high}`. Closed by collapsing to `"high"`
  and adding `TestMapSeverity_CollapsesCriticalToHigh` covering the full
  mapping table (11 cases: all documented inputs + whitespace + default).
- **Three `check-*.sh` scripts error out on this repo** because they hard-code
  `GOALS.yaml` and the repo migrated to `GOALS.md`. Closed by teaching each
  script to skip with exit 0 (and an explicit migration message) when
  `GOALS.yaml` is absent and `GOALS.md` is present. Pre-migration behavior
  preserved when YAML is supplied explicitly.
- **`demo --quick` tests eating 7+ seconds of artificial pacing**. Closed by
  injecting `demoStepDelay time.Duration` at package scope and a
  `withoutDemoDelay(t)` helper that zeroes it for affected tests. Production
  demo behavior is unchanged (500 ms default).

## Findings discovered (this run, deferred)

- **Next-work queue has high stale-finding density.** Triaging harvested items
  during selection, I found 6 of the first 10 concrete-looking items were
  already resolved in-tree (e.g., "Replace bc dependency in proof-run.sh with
  awk" — `proof-run.sh` never used bc; "Add go mod tidy + symlink checks to
  post-merge-check.sh" — both already present; "Make private globLearningFiles
  return errors" — already exported with error return; etc.). A finding-
  consumption ratchet or a periodic `bd status` pass against harvested titles
  would cut noise materially. Needs a bead (bd still unavailable here — same
  constraint as PR #114).
- **No closer between `.agents/findings/*.md` and `next-work.jsonl`.** The
  router appends findings as `dream-findings-router` epic entries but there
  is no return signal marking the finding as routed; re-routing is dedup'd
  only by ID match against items currently on disk. A finding whose item
  gets consumed and truncated out of the queue would be re-routed on the
  next Dream run. Same bead requirement.
- **`ao goals measure --json` hang reproduces identically to PR #114's report.**
  30 s timeout produces no output, exit 143. Blocks numeric goal-weight delta
  reporting. Same bead requirement.

## Auto-reverts

None this run. Cycle 1's router fix removed the reason for PR #114's single
auto-revert (`.agents/rpi/next-work.jsonl` drift); no cycle in this run
tripped any validation that required rollback.

## Quarantined goals

None. No goals flipped failing during the run, so no oscillation quarantine
triggered.

## Known / expected

- `scripts/check-worktree-disposition.sh` fails because `HEAD` is on
  `nightly/2026-04-17-v2` instead of `main`. Nightly task explicitly
  classifies this as a known false positive.
- `retrieval quality ratchet` WARN is pre-existing (17 missing ground truth
  entries, unchanged this run).
- `bd` CLI is not installed in the session environment — same as PR #114.
  Discovered-finding bead creation is not possible this run; follow-ups are
  listed in "Findings discovered" above.
- The tag `nightly/2026-04-17-v2` exists locally. Remote tag push returned
  `sideband disconnect`; the PR's final commit SHA is a stable anchor for
  tomorrow's audit if the tag cannot be pushed.

## Test plan

- [x] `cd cli && env -u AGENTOPS_RPI_RUNTIME go build ./...` — passes
- [x] `cd cli && env -u AGENTOPS_RPI_RUNTIME go vet ./...` — passes
- [x] `cd cli && env -u AGENTOPS_RPI_RUNTIME go test ./cmd/ao ./internal/autodev -count=1` — passes
- [x] `cd cli && env -u AGENTOPS_RPI_RUNTIME go run ./cmd/ao autodev validate --file ../PROGRAM.md --json` — `valid: true`
- [x] `env -u AGENTOPS_RPI_RUNTIME bash skills/heal-skill/scripts/heal.sh --strict` — All clean. No findings.
- [x] `bash scripts/validate-next-work-contract-parity.sh` — passes
- [x] `bash scripts/check-goal-staleness.sh` — SKIP (exit 0, migration note)
- [x] `bash scripts/check-pillar-coverage.sh` — SKIP (exit 0, migration note)
- [x] `bash scripts/check-goal-quality.sh` — SKIP (exit 0, migration note)
- [x] `env -u AGENTOPS_RPI_RUNTIME scripts/pre-push-gate.sh --fast` — 1 FAIL (known worktree false positive on nightly branch), no other failures
- [x] `go test -v -run TestMapSeverity_CollapsesCriticalToHigh ./internal/overnight` — PASS (11 cases)
- [x] `go test -v -run TestRouteFindings_EmitsSchemaCompliantEnums ./internal/overnight` — PASS
