### PR TITLE
feat(cli): add shell completion for enumerated-value flags

### DIFF
--- a/cli/cmd/ao/completion_values.go
+++ b/cli/cmd/ao/completion_values.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"sort"
+
+	"github.com/boshu2/agentops/cli/internal/lifecycle"
+	"github.com/spf13/cobra"
+)
+
+// staticCompletionFunc returns a cobra flag-completion function that proposes a
+// fixed, sorted list of values and suppresses file completion. Used for flags
+// whose valid values are a known enumerated set.
+func staticCompletionFunc(values ...string) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	sorted := make([]string, len(values))
+	copy(sorted, values)
+	sort.Strings(sorted)
+	return func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return sorted, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// templateCompletionValues returns the sorted list of seed/goals-init template
+// names. Derived from lifecycle.ValidTemplates so the CLI stays in lockstep
+// with the validation source of truth.
+func templateCompletionValues() []string {
+	names := make([]string, 0, len(lifecycle.ValidTemplates))
+	for name, enabled := range lifecycle.ValidTemplates {
+		if enabled {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}

--- a/cli/cmd/ao/completion_values_test.go
+++ b/cli/cmd/ao/completion_values_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/lifecycle"
+	"github.com/spf13/cobra"
+)
+
+func TestStaticCompletionFunc_SortsAndSuppressesFileCompletion(t *testing.T) {
+	fn := staticCompletionFunc("zebra", "apple", "mango")
+	got, directive := fn(nil, nil, "")
+
+	want := []string{"apple", "mango", "zebra"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("values = %v, want %v", got, want)
+	}
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+	}
+}
+
+func TestStaticCompletionFunc_DoesNotMutateCallerSlice(t *testing.T) {
+	values := []string{"zebra", "apple", "mango"}
+	snapshot := append([]string(nil), values...)
+	_ = staticCompletionFunc(values...)
+
+	if !reflect.DeepEqual(values, snapshot) {
+		t.Errorf("caller slice mutated: %v vs %v", values, snapshot)
+	}
+}
+
+func TestTemplateCompletionValues_MatchesLifecycleValidTemplates(t *testing.T) {
+	got := templateCompletionValues()
+
+	want := make([]string, 0, len(lifecycle.ValidTemplates))
+	for name, enabled := range lifecycle.ValidTemplates {
+		if enabled {
+			want = append(want, name)
+		}
+	}
+	if len(got) != len(want) {
+		t.Fatalf("length mismatch: got %d, want %d (%v vs %v)", len(got), len(want), got, want)
+	}
+
+	gotSet := make(map[string]bool, len(got))
+	for _, n := range got {
+		gotSet[n] = true
+	}
+	for _, n := range want {
+		if !gotSet[n] {
+			t.Errorf("completion values missing %q (got %v)", n, got)
+		}
+	}
+}
+
+func TestTemplateCompletionValues_IsSorted(t *testing.T) {
+	got := templateCompletionValues()
+	for i := 1; i < len(got); i++ {
+		if got[i-1] > got[i] {
+			t.Errorf("values not sorted at index %d: %v", i, got)
+		}
+	}
+}
+
+// TestFlagCompletions_Registered verifies that every enumerated flag we care
+// about has a completion function registered with the expected value set.
+// This is an L2 integration test: it exercises the real cobra command tree
+// built by init() side-effects in this package.
+func TestFlagCompletions_Registered(t *testing.T) {
+	tmplValues := templateCompletionValues()
+
+	cases := []struct {
+		name string
+		cmd  *cobra.Command
+		flag string
+		want []string
+	}{
+		{"root --output", rootCmd, "output", []string{"json", "table", "yaml"}},
+		{"seed --template", seedCmd, "template", tmplValues},
+		{"goals init --template", goalsInitCmd, "template", tmplValues},
+		{"inject --format", injectCmd, "format", []string{"json", "markdown"}},
+		{"inject --session-type", injectCmd, "session-type",
+			[]string{"brainstorm", "career", "debug", "implement", "research"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fn, exists := tc.cmd.GetFlagCompletionFunc(tc.flag)
+			if !exists {
+				t.Fatalf("no completion registered for %s %s", tc.cmd.Name(), tc.flag)
+			}
+			got, directive := fn(tc.cmd, nil, "")
+			if directive != cobra.ShellCompDirectiveNoFileComp {
+				t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("completion values = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/cmd/ao/goals_init.go
+++ b/cli/cmd/ao/goals_init.go
@@ -54,4 +54,6 @@ func init() {
 	goalsInitCmd.Flags().BoolVar(&goalsInitNonInteractive, "non-interactive", false, "Use defaults without prompting")
 	goalsInitCmd.Flags().StringVar(&goalsInitTemplate, "template", "", "Goal template (go-cli, python-lib, web-app, rust-cli, generic)")
 	goalsCmd.AddCommand(goalsInitCmd)
+
+	_ = goalsInitCmd.RegisterFlagCompletionFunc("template", staticCompletionFunc(templateCompletionValues()...))
 }

--- a/cli/cmd/ao/inject.go
+++ b/cli/cmd/ao/inject.go
@@ -110,6 +110,9 @@ func init() {
 	injectCmd.Flags().StringVar(&injectForSkill, "for", "", "Skill name — assembles context per skill's context declaration")
 	injectCmd.Flags().StringVar(&injectSessionType, "session-type", "", "Session type for scoring boost (career, research, debug, implement, brainstorm)")
 	injectCmd.Flags().BoolVar(&injectProfile, "profile", false, "Include .agents/profile.md identity artifact in output")
+
+	_ = injectCmd.RegisterFlagCompletionFunc("format", staticCompletionFunc("markdown", "json"))
+	_ = injectCmd.RegisterFlagCompletionFunc("session-type", staticCompletionFunc("career", "research", "debug", "implement", "brainstorm"))
 }
 
 // injectOptionsFromFlags builds an InjectOptions from the cobra flag vars + positional args.

--- a/cli/cmd/ao/root.go
+++ b/cli/cmd/ao/root.go
@@ -92,6 +92,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&output, "output", "o", "table", "Output format (json, table, yaml)")
 	rootCmd.PersistentFlags().BoolVar(&jsonFlag, "json", false, "Output as JSON (shorthand for -o json)")
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file (default: ~/.agentops/config.yaml)")
+
+	_ = rootCmd.RegisterFlagCompletionFunc("output", staticCompletionFunc("json", "table", "yaml"))
 }
 
 // GetDryRun returns the dry-run flag value for use by subcommands.

--- a/cli/cmd/ao/seed.go
+++ b/cli/cmd/ao/seed.go
@@ -60,6 +60,8 @@ func init() {
 	seedCmd.Flags().BoolVar(&seedForce, "force", false, "Overwrite existing seed files")
 	seedCmd.GroupID = "start"
 	rootCmd.AddCommand(seedCmd)
+
+	_ = seedCmd.RegisterFlagCompletionFunc("template", staticCompletionFunc(templateCompletionValues()...))
 }
 
 // validTemplates enumerates the allowed template names.


### PR DESCRIPTION
## Summary

- Register cobra flag completions so `ao <cmd> --<flag> <TAB>` surfaces valid enumerated values instead of falling back to file completion.
- Five flags newly covered:
  - `ao --output` → `json, table, yaml`
  - `ao seed --template` → `generic, go-cli, python-lib, rust-cli, web-app`
  - `ao goals init --template` → same set, derived from `lifecycle.ValidTemplates` so completion stays in lockstep with validation
  - `ao inject --format` → `json, markdown`
  - `ao inject --session-type` → `brainstorm, career, debug, implement, research`
- New file `cli/cmd/ao/completion_values.go` factors a tiny `staticCompletionFunc(values...)` helper that returns a sorted, file-completion-suppressed closure — so adding completion to the next enumerated flag is a one-liner.
- L2 integration tests in `cli/cmd/ao/completion_values_test.go` exercise the real cobra command tree (`GetFlagCompletionFunc`) and assert the exact value set + `ShellCompDirectiveNoFileComp` directive for every wired flag.

## Context

Audit found zero `RegisterFlagCompletionFunc` / `ValidArgsFunction` calls anywhere in `cli/`. This PR is the minimal, additive fix for the highest-traffic enumerated flags. No help text, flag defaults, or command surfaces changed — `scripts/generate-cli-reference.sh --check` is still green.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/ao/` (3 consecutive clean runs)
- [x] Targeted: `TestStaticCompletionFunc_*`, `TestTemplateCompletionValues_*`, `TestFlagCompletions_Registered` all pass
- [x] E2E smoke via `ao __complete seed --template ""` (and the other four flags) returns the expected sorted values with `ShellCompDirectiveNoFileComp`
- [x] `scripts/generate-cli-reference.sh --check` → up to date
- [ ] Try `source <(ao completion bash)` and tab-complete in an interactive shell

https://claude.ai/code/session_01KvJRtiQRZY38PVxNZ7S6Rm