### PR TITLE
chore(skills): backfill docs, validators, and lint; fix codex drift no-op

### DIFF
--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -52,7 +52,7 @@ What are you trying to do?
 │
 ├─ "Learn from past work"
 │   ├─ Turn the corpus into operator surfaces ─► /knowledge-activation
-│   ├─ What do we know about X? ──► /knowledge <query>
+│   ├─ What do we know about X? ──► ao lookup "<query>" / ao search
 │   ├─ Save this insight ─────────► /retro --quick "insight"
 │   └─ Full retrospective ────────► /post-mortem
 │
@@ -202,15 +202,18 @@ Root cause analysis with git archaeology.
 /bug-hunt "login fails after password reset"
 ```
 
-### /knowledge
+### Knowledge queries (no slash command)
 
-Query knowledge artifacts across locations.
+Query knowledge artifacts across locations via the CLI. There is no standalone
+`/knowledge` skill — use `/knowledge-activation` to build operator surfaces, or
+run the CLI below for ad-hoc lookup.
 
 ```bash
-/knowledge "patterns for rate limiting"
+ao lookup "patterns for rate limiting"
+ao search --all "patterns for rate limiting"
 ```
 
-**Searches:** `.agents/learnings/`, `.agents/patterns/`, `.agents/research/`
+**Searches:** `.agents/learnings/`, `.agents/patterns/`, `.agents/research/`, `.agents/compiled/`
 
 ### /llm-wiki
 
@@ -473,6 +476,37 @@ Reinstall all AgentOps skills globally from the latest source.
 
 ---
 
+## Additional Skills
+
+Single-purpose skills not listed above. See each skill's `SKILL.md` for triggers,
+phases, and flags.
+
+| Skill | Purpose |
+|-------|---------|
+| `/autodev` | Manage the `PROGRAM.md` operational contract for autonomous development loops |
+| `/bootstrap` | One-command product-layer setup (`GOALS.md`, `PRODUCT.md`, `README.md`, `.agents/`, hooks) |
+| `/compile` | Compile raw `.agents/` artifacts into an interlinked wiki at `.agents/compiled/` (Mine → Grow → Defrag → Lint) |
+| `/deps` | Dependency audit, updates, vulnerability scanning, license compliance |
+| `/design` | Product validation gate — aligns goal with `PRODUCT.md` before discovery |
+| `/discovery` | Full discovery-phase orchestrator (brainstorm + search + research + plan + pre-mortem) |
+| `/goals` | Maintain `GOALS.yaml`/`GOALS.md` fitness specs; measure drift; add/prune directives |
+| `/grafana-platform-dashboard` | Design/refactor/validate Grafana dashboards for OpenShift/Kubernetes platform ops |
+| `/harvest` | Cross-rig knowledge consolidation and tiered promotion to the global hub |
+| `/perf` | Performance profiling, benchmarking, regression detection, optimization |
+| `/push` | Atomic test-commit-push with conventional-commit message |
+| `/readme` | Generate a gold-standard README via interview + council validation |
+| `/red-team` | Persona-based adversarial validation — probes whether docs/skills actually work |
+| `/refactor` | Safe, verified refactoring with regression tests at each step |
+| `/reverse-engineer-rpi` | Reverse-engineer a product into feature catalog, code map, and specs |
+| `/review` | Structured review of incoming PRs, agent-generated changes, or diffs |
+| `/scaffold` | Project scaffolding, component generation, boilerplate |
+| `/scenario` | Author/manage holdout scenarios in `.agents/holdout/` for behavioral validation |
+| `/security` | Continuous repository security scanning and release gating |
+| `/security-suite` | Composable security suite — static, dynamic, redteam, baseline drift, policy gating |
+| `/test` | Test generation, coverage analysis, TDD workflow |
+
+---
+
 ## Internal Skills
 
 These fire automatically and are not directly invoked:
@@ -480,8 +514,7 @@ These fire automatically and are not directly invoked:
 | Skill | Purpose |
 |-------|---------|
 | `inject` | Load knowledge at session start (`ao inject`) |
-| `extract` | Extract decisions/learnings from transcripts |
-| `forge` | Mine transcripts for knowledge artifacts |
+| `forge` | Mine transcripts for knowledge artifacts (decisions, learnings, failures, patterns) |
 | `ratchet` | Progress gates for RPI workflow |
 | `flywheel` | Knowledge health monitoring |
 | `provenance` | Trace knowledge artifact lineage |

--- a/scripts/check-codex-parity-drift.sh
+++ b/scripts/check-codex-parity-drift.sh
@@ -1,32 +1,27 @@
 #!/usr/bin/env bash
 # check-codex-parity-drift.sh — Goal gate script
-# Runs audit-codex-parity in check mode and fails if any findings exist.
+# Runs audit-codex-parity.py and fails if any findings exist.
 # Exit 0 = pass (no drift), exit 1 = fail (drift detected)
 set -euo pipefail
 
 ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Not in a git repo"; exit 1; }
 
-AUDIT_SCRIPT="$ROOT/scripts/audit-codex-parity.sh"
-AUDIT_CMD=()
-if [[ ! -x "$AUDIT_SCRIPT" ]]; then
-    # Try Python version
-    AUDIT_SCRIPT="$ROOT/scripts/audit-codex-parity.py"
-    if [[ ! -f "$AUDIT_SCRIPT" ]]; then
-        echo "SKIP: No audit-codex-parity script found"
-        exit 0
-    fi
-    AUDIT_CMD=(python3 "$AUDIT_SCRIPT" --repo-root "$ROOT" --check)
-else
-    AUDIT_CMD=("$AUDIT_SCRIPT" --check)
+AUDIT_PY="$ROOT/scripts/audit-codex-parity.py"
+if [[ ! -f "$AUDIT_PY" ]]; then
+    echo "SKIP: $AUDIT_PY not found"
+    exit 0
 fi
 
-# Run audit in check mode, capture output
-OUTPUT=$("${AUDIT_CMD[@]}" 2>&1) || true
-FINDING_COUNT=$(echo "$OUTPUT" | grep -c "FINDING\|DRIFT\|LEAK" 2>/dev/null) || FINDING_COUNT=0
+# Run audit in JSON mode. The script exits 0 when clean, 1 when drift exists.
+# We always want to see findings on failure, so capture output and status separately.
+JSON_OUTPUT=$(python3 "$AUDIT_PY" --repo-root "$ROOT" --json 2>/dev/null || true)
+STATUS=0
+python3 "$AUDIT_PY" --repo-root "$ROOT" >/dev/null 2>&1 || STATUS=$?
 
-if [[ "$FINDING_COUNT" -gt 0 ]]; then
-    echo "FAIL: $FINDING_COUNT codex parity findings detected"
-    echo "$OUTPUT" | grep "FINDING\|DRIFT\|LEAK" | head -10
+if [[ "$STATUS" -ne 0 ]]; then
+    FINDING_COUNT=$(python3 -c "import json,sys; print(len(json.loads(sys.argv[1] or '[]')))" "$JSON_OUTPUT" 2>/dev/null || echo "?")
+    echo "FAIL: $FINDING_COUNT codex parity finding(s) detected"
+    python3 "$AUDIT_PY" --repo-root "$ROOT" 2>&1 | head -40 || true
     exit 1
 fi
 

--- a/scripts/check-skill-size.sh
+++ b/scripts/check-skill-size.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# check-skill-size.sh — warn on oversized SKILL.md files.
+#
+# Skills with very long SKILL.md bodies are harder to load into a fork context
+# and often bundle reference material that belongs in references/*.md. This
+# script reports every skill whose SKILL.md exceeds WARN_LINES (default 500)
+# and hard-fails above FAIL_LINES (default 800) unless --warn-only is passed.
+#
+# Usage:
+#   scripts/check-skill-size.sh              # warn and fail above threshold
+#   scripts/check-skill-size.sh --warn-only  # report only (exit 0)
+#   WARN_LINES=400 scripts/check-skill-size.sh
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Not in a git repo"; exit 1; }
+cd "$ROOT"
+
+WARN_LINES=${WARN_LINES:-500}
+FAIL_LINES=${FAIL_LINES:-800}
+WARN_ONLY=0
+for arg in "$@"; do
+    case "$arg" in
+        --warn-only) WARN_ONLY=1 ;;
+    esac
+done
+
+WARN_COUNT=0
+FAIL_COUNT=0
+printf "Checking SKILL.md sizes (warn>%d, fail>%d)\n" "$WARN_LINES" "$FAIL_LINES"
+printf -- "---\n"
+
+while IFS= read -r skill_md; do
+    lines=$(wc -l < "$skill_md")
+    name=$(basename "$(dirname "$skill_md")")
+    if [[ "$lines" -gt "$FAIL_LINES" ]]; then
+        printf "FAIL  %4d lines  %s  (move reference material to %s/references/)\n" \
+            "$lines" "$skill_md" "$(dirname "$skill_md")"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    elif [[ "$lines" -gt "$WARN_LINES" ]]; then
+        printf "WARN  %4d lines  %s\n" "$lines" "$skill_md"
+        WARN_COUNT=$((WARN_COUNT + 1))
+    fi
+done < <(find skills -maxdepth 2 -name SKILL.md -type f | sort)
+
+printf -- "---\n"
+printf "Summary: %d warn, %d fail\n" "$WARN_COUNT" "$FAIL_COUNT"
+
+if [[ "$FAIL_COUNT" -gt 0 && "$WARN_ONLY" -eq 0 ]]; then
+    echo "Fix: split the flagged SKILL.md(s) into references/*.md linked from the main body."
+    exit 1
+fi
+exit 0

--- a/skills/autodev/scripts/validate.sh
+++ b/skills/autodev/scripts/validate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+
+check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+
+check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
+check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+check "SKILL.md has name: autodev" "grep -q '^name: autodev' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md references PROGRAM.md" "grep -q 'PROGRAM\\.md' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions autonomous loop" "grep -qi 'autonomous' '$SKILL_DIR/SKILL.md'"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/skills/bootstrap/scripts/validate.sh
+++ b/skills/bootstrap/scripts/validate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+
+check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+
+check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
+check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+check "SKILL.md has name: bootstrap" "grep -q '^name: bootstrap' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions GOALS.md" "grep -q 'GOALS\\.md' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions PRODUCT.md" "grep -q 'PRODUCT\\.md' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions progressive/gap-filling behavior" "grep -qiE 'progressive|fills? gaps|idempotent' '$SKILL_DIR/SKILL.md'"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/skills/deps/scripts/validate.sh
+++ b/skills/deps/scripts/validate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+
+check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+
+check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
+check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+check "SKILL.md has name: deps" "grep -q '^name: deps' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions vulnerability scanning" "grep -qi 'vulnerab' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions license compliance" "grep -qi 'license' '$SKILL_DIR/SKILL.md'"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/skills/design/scripts/validate.sh
+++ b/skills/design/scripts/validate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+
+check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+
+check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
+check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+check "SKILL.md has name: design" "grep -q '^name: design' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md references PRODUCT.md alignment" "grep -q 'PRODUCT\\.md' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions council gate or product preset" "grep -qiE 'council|preset=product' '$SKILL_DIR/SKILL.md'"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/skills/discovery/scripts/validate.sh
+++ b/skills/discovery/scripts/validate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+
+check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+
+check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
+check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+check "SKILL.md has name: discovery" "grep -q '^name: discovery' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions brainstorm phase" "grep -qi 'brainstorm' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions research phase" "grep -qi 'research' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions plan phase" "grep -qi 'plan' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions pre-mortem gate" "grep -qi 'pre-mortem' '$SKILL_DIR/SKILL.md'"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/skills/dream/scripts/validate.sh
+++ b/skills/dream/scripts/validate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+
+check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+
+check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
+check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+check "SKILL.md has name: dream" "grep -q '^name: dream' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions overnight engine" "grep -qi 'overnight' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions setup/start/report surfaces" "grep -qE 'setup|start|report' '$SKILL_DIR/SKILL.md'"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/skills/harvest/scripts/validate.sh
+++ b/skills/harvest/scripts/validate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+
+check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+
+check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
+check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+check "SKILL.md has name: harvest" "grep -q '^name: harvest' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions cross-rig consolidation" "grep -qiE 'cross-rig|federation|consolidat' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions dedupe or promotion" "grep -qiE 'deduplicat|promot' '$SKILL_DIR/SKILL.md'"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/skills/llm-wiki/scripts/validate.sh
+++ b/skills/llm-wiki/scripts/validate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+
+check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+
+check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
+check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+check "SKILL.md has name: llm-wiki" "grep -q '^name: llm-wiki' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions ingest/query/lint verbs" "grep -qE 'ingest|query|lint' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions raw/ or wiki/ surfaces" "grep -qE 'raw/|wiki/' '$SKILL_DIR/SKILL.md'"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/skills/perf/scripts/validate.sh
+++ b/skills/perf/scripts/validate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+
+check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+
+check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
+check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+check "SKILL.md has name: perf" "grep -q '^name: perf' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions benchmarking" "grep -qi 'benchmark' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions profiling" "grep -qi 'profil' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions regression detection" "grep -qi 'regression' '$SKILL_DIR/SKILL.md'"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/skills/red-team/scripts/validate.sh
+++ b/skills/red-team/scripts/validate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+
+check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+
+check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
+check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+check "SKILL.md has name: red-team" "grep -q '^name: red-team' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions persona-based probing" "grep -qi 'persona' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions council consolidation" "grep -qi 'council' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions adversarial or zero-context probe" "grep -qiE 'adversarial|zero-context' '$SKILL_DIR/SKILL.md'"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/skills/refactor/scripts/validate.sh
+++ b/skills/refactor/scripts/validate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+
+check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+
+check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
+check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+check "SKILL.md has name: refactor" "grep -q '^name: refactor' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions regression testing" "grep -qi 'regression' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions incremental or step-wise execution" "grep -qiE 'incremental|step|safe' '$SKILL_DIR/SKILL.md'"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/skills/review/scripts/validate.sh
+++ b/skills/review/scripts/validate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+
+check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+
+check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
+check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+check "SKILL.md has name: review" "grep -q '^name: review' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md covers security check dimension" "grep -qi 'security' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md covers correctness check dimension" "grep -qi 'correctness' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions PR or diff review" "grep -qiE 'PR|diff' '$SKILL_DIR/SKILL.md'"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/skills/scaffold/scripts/validate.sh
+++ b/skills/scaffold/scripts/validate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+
+check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+
+check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
+check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+check "SKILL.md has name: scaffold" "grep -q '^name: scaffold' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions boilerplate or starter" "grep -qiE 'boilerplate|starter' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions component or project generation" "grep -qiE 'component|project|generat' '$SKILL_DIR/SKILL.md'"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/skills/scenario/scripts/validate.sh
+++ b/skills/scenario/scripts/validate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+
+check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+
+check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
+check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+check "SKILL.md has name: scenario" "grep -q '^name: scenario' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md references holdout directory" "grep -q '\\.agents/holdout' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions behavioral validation" "grep -qi 'behavioral' '$SKILL_DIR/SKILL.md'"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/skills/test/scripts/validate.sh
+++ b/skills/test/scripts/validate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+
+check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+
+check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
+check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+check "SKILL.md has name: test" "grep -q '^name: test' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions TDD workflow" "grep -qi 'tdd' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md mentions coverage analysis" "grep -qi 'coverage' '$SKILL_DIR/SKILL.md'"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/skills/validation/scripts/validate.sh
+++ b/skills/validation/scripts/validate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+
+check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+
+check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
+check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+check "SKILL.md has name: validation" "grep -q '^name: validation' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md wraps /vibe" "grep -q '/vibe' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md wraps /post-mortem" "grep -q '/post-mortem' '$SKILL_DIR/SKILL.md'"
+check "SKILL.md wraps /retro" "grep -q '/retro' '$SKILL_DIR/SKILL.md'"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Closes the documentation, behavioral-contract, and CI-gate gaps surfaced by a fresh audit of `skills/` and `skills-codex/`.

- **docs/SKILLS.md** now covers all 69 skills. Added an "Additional Skills" table for the 21 previously undocumented entries (`autodev`, `bootstrap`, `compile`, `deps`, `design`, `discovery`, `goals`, `grafana-platform-dashboard`, `harvest`, `perf`, `push`, `readme`, `red-team`, `refactor`, `reverse-engineer-rpi`, `review`, `scaffold`, `scenario`, `security`, `security-suite`, `test`). Removed stale `/knowledge` router alias (no such skill) and the nonexistent `extract` internal-table row.
- **16 new `scripts/validate.sh`** files, bringing behavioral-contract coverage from 53/69 → **69/69**. Each encodes skill-specific assertions beyond frontmatter (e.g., `bootstrap` checks for `GOALS.md`/`PRODUCT.md`/progressive-gap language; `discovery` checks each phase is mentioned; `validation` checks it wraps `/vibe`, `/post-mortem`, `/retro`).
- **Fixed `scripts/check-codex-parity-drift.sh`** — it was a silent no-op. It passed a nonexistent `--check` flag to `audit-codex-parity.py`, swallowed the argparse error via `|| true`, then grep'd for strings the audit never emits (`FINDING`/`DRIFT`/`LEAK`). Now uses the exit code + JSON output; fail path verified via injected drift.
- **Added `scripts/check-skill-size.sh`** (warn>500, fail>800 lines) to flag oversized `SKILL.md` files that should decompose into `references/*.md`. Current ecosystem: 6 warnings (`crank`/`implement`/`post-mortem`/`release`/`swarm`/`vibe`), 0 fails.

## Test plan

- [x] `bash skills/heal-skill/scripts/heal.sh --check --strict` → "All clean. No findings."
- [x] `python3 scripts/audit-codex-parity.py` → "Codex parity audit passed."
- [x] `bash scripts/check-codex-parity-drift.sh` → `PASS: No codex parity drift detected`
- [x] Drift-check fail path verified by injecting a Claude-era tool name into a temporary copy → `FAIL: 1 codex parity finding(s) detected` with exit 1.
- [x] All 69 `skills/*/scripts/validate.sh` pass (69 PASS / 0 FAIL).
- [x] `bash scripts/check-skill-size.sh --warn-only` → 6 warn, 0 fail.
- [x] `bash scripts/pre-push-gate.sh --fast` — only failure is the expected worktree-disposition check (branch != main); all content checks pass or are correctly skipped.

https://claude.ai/code/session_014AgjT36REb94fjL7sxrnFf