### PR TITLE
docs: fix broken CLI links, add HOOKS/SCHEMAS/UPGRADING, expand GLOSSARY

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -71,11 +71,13 @@ bash skills/heal-skill/scripts/heal.sh --strict
 bash tests/docs/validate-doc-release.sh
 ```
 
-If you add or remove a skill directory, also run:
+**If you add or remove a skill directory, you must run:**
 
 ```bash
 scripts/sync-skill-counts.sh
 ```
+
+This updates the skill count across `SKILL-TIERS.md`, `PRODUCT.md`, `README.md`, `docs/SKILLS.md`, `docs/ARCHITECTURE.md`, and `using-agentops/SKILL.md`. The `doc-release-gate` CI job fails if counts drift, so skipping this step will block your PR. If you're unsure whether your change affects counts, run the script anyway — it's idempotent when counts are already in sync.
 
 If you touched Codex-facing behavior or checked-in Codex artifacts, also run:
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -2,6 +2,14 @@
 
 Project-specific terms used throughout AgentOps documentation.
 
+## Symbols
+
+### `.agents/`
+Per-repo local directory where AgentOps stores learnings, plans, findings, handoffs, and run state. Plain text — `git grep`, `diff`, and `git log` all work on it. Ignored by default; set `AGENTOPS_GITIGNORE_AUTO=0` to commit it.
+
+### `MEMORY.md`
+Per-repo durable memory file loaded automatically by some runtimes at session start. Compiled by `SessionStart` and `SessionEnd` hooks from `.agents/` artifacts. Primary pointer surface in `AGENTOPS_STARTUP_CONTEXT_MODE=manual`.
+
 ## A
 
 ### AgentOps
@@ -26,14 +34,31 @@ The core execution model: spawn parallel agents (chaos), validate their output w
 ### Codex Team
 A skill (`/codex-team`) that spawns parallel Codex (OpenAI) execution agents orchestrated by Claude, enabling cross-vendor parallel task execution. [Full documentation](skills/codex-team.md)
 
+### Compact / PreCompact
+Runtime event fired when an agent prunes its conversation history. AgentOps uses `precompact-snapshot.sh` to capture signal before compaction so nothing is lost. See [`HOOKS.md`](HOOKS.md).
+
+### Compile
+A lifecycle step that rolls session-level signal into durable knowledge. Runs via `compile-session-defrag.sh` at `SessionEnd` and via `ao compile` on demand. Produces the inputs that `ao inject` pulls from.
+
 ### Context Compiler
 The technical framing for AgentOps. Raw session signal becomes reusable knowledge, compiled prevention, and better next work. The public story is operational layer; the context compiler is the architectural explanation behind it. [Full documentation](https://github.com/boshu2/agentops/blob/main/README.md)
+
+### Context Window
+The bounded token budget an agent has in a single session. AgentOps assumes this is always finite and sometimes shrinking under compaction. The Ralph Wiggum Pattern, fresh-context waves, and `PreCompact` snapshots all exist to work around context-window limits rather than fight them.
 
 ### Council
 The core validation primitive. Spawns independent judge agents (Claude and/or Codex) that review work from different perspectives, deliberate, and converge on a verdict: PASS, WARN, or FAIL. Foundation for `/vibe`, `/pre-mortem`, and `/post-mortem`. [Full documentation](skills/council.md)
 
 ### Crank
 A skill (`/crank`) that executes an epic by spawning parallel worker agents in dependency-ordered waves. Each worker gets fresh context, writes files, and reports back; the lead validates and commits. Runs until every issue in the epic is closed. [Full documentation](skills/crank.md)
+
+## D
+
+### Discovery
+The first phase of the current RPI lifecycle (Discovery → Implementation → Validation). Replaces the older "Research" framing when used at the orchestrator level; `/research` is still the underlying sub-skill.
+
+### Dream (Overnight Run)
+A long-haul autonomous run that executes while you are away, emitting morning work packets with evidence, target files, and follow-up commands. Also called an **overnight run** in older docs; both names refer to the same flow.
 
 ## E
 
@@ -51,6 +76,9 @@ The reconciliation engine that implements the Brownian Ratchet: **F**ind (read c
 ### Flywheel (Knowledge Flywheel)
 The automated loop that extracts learnings from completed work, scores them for quality, and re-injects them at the next session start. Knowledge compounds when retrieval and usage outpace decay and scale friction; otherwise it plateaus until controls improve. [Full documentation](ARCHITECTURE.md#pillar-4-knowledge-flywheel)
 
+### Flywheel Health
+A composite measure of whether the knowledge flywheel is actually compounding: retrieval rate, promotion rate, decay rate, and injection hit rate. Surfaced by `ao flywheel` commands and used by `/evolve` to steer improvements.
+
 ### Forge
 An internal skill that mines session transcripts for knowledge artifacts — decisions, patterns, failures, and fixes — and stores them in `.agents/`. [Full documentation](skills/forge.md)
 
@@ -61,11 +89,17 @@ A checkpoint enforced by a hook that blocks progress until a condition is met. F
 
 ## H
 
+### Harvest
+A curation step that pulls learning candidates from recent sessions, scores them, and filters low-confidence output before they enter the flywheel. Invoked via `ao harvest` or inside `/forge --promote`.
+
 ### Handoff
 A skill (`/handoff`) that creates structured session handoff documents so another agent or future session can continue work with full context. [Full documentation](skills/handoff.md)
 
+### Holdout
+An isolated scenario file under `.agents/holdout/` used for behavioral validation. Read/glob/grep access to holdout directories is gated by `holdout-isolation-gate.sh` so validator and evaluee paths do not cross-contaminate. Schema: [`scenario.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/scenario.v1.schema.json).
+
 ### Hook
-A shell script that fires automatically on agent lifecycle events. AgentOps currently registers 7 hook event sections in `hooks/hooks.json`, spanning session lifecycle, prompt routing, tool-time gates, and task completion. All hooks can be disabled with `AGENTOPS_HOOKS_DISABLED=1`. [Full documentation](https://github.com/boshu2/agentops/blob/main/hooks/hooks.json)
+A shell script that fires automatically on agent lifecycle events. AgentOps currently registers 7 hook event sections in `hooks/hooks.json`, spanning session lifecycle, prompt routing, tool-time gates, and task completion. All hooks can be disabled with `AGENTOPS_HOOKS_DISABLED=1`. [Full documentation](HOOKS.md)
 
 ## I
 
@@ -124,7 +158,13 @@ A skill (`/retro`) that extracts learnings from completed work — decisions mad
 ### RPI (Research-Plan-Implement)
 The historical name for AgentOps' full lifecycle workflow. In current runtime terms, `/rpi` orchestrates **Discovery -> Implementation -> Validation** while `ao rpi phased` enforces fresh context windows between those phases. The older acronym persists in product language and command names, but validation and loop closure are now first-class parts of the executable lifecycle. [Full documentation](ARCHITECTURE.md#the-phased-lifecycle)
 
+### RPI Phase
+One of the three named stages inside an RPI run: **Discovery**, **Implementation**, **Validation**. Each phase gets a fresh context window and emits a [`rpi-phase-result.schema.json`](contracts/rpi-phase-result.schema.json) artifact. Distinct from the broader RPI workflow.
+
 ## S
+
+### Session Lifecycle
+The full arc of a coding-agent session: `SessionStart` → many `UserPromptSubmit` / `PreToolUse` / `PostToolUse` cycles → `Stop` → `SessionEnd`. AgentOps attaches hooks to each of these events. See [`HOOKS.md`](HOOKS.md) and [`workflows/session-lifecycle.md`](workflows/session-lifecycle.md).
 
 ### Skill
 A self-contained capability defined by a `SKILL.md` file with YAML frontmatter. Skills are the primary unit of functionality in AgentOps — each one has triggers, instructions, and optional reference docs loaded just-in-time. AgentOps currently ships 66 shared skills, with runtime-specific artifacts maintained alongside them. [Full documentation](SKILLS.md)

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -1,0 +1,83 @@
+# Hooks
+
+AgentOps ships a set of runtime hooks that wire skills, the `ao` CLI, and the knowledge flywheel into your coding agent. This page is an orientation: what each lifecycle event does, how to install or disable hooks, and where to go for deeper detail.
+
+For the comprehensive technical reference — including CASS wiring, token budgets, environment variables, and runtime-specific install paths — see [`cli/docs/HOOKS.md`](https://github.com/boshu2/agentops/blob/main/cli/docs/HOOKS.md).
+
+## Source of truth
+
+- Hook manifest: [`hooks/hooks.json`](https://github.com/boshu2/agentops/blob/main/hooks/hooks.json) (validated against [`schemas/hooks-manifest.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/hooks-manifest.v1.schema.json))
+- Hook scripts: [`hooks/*.sh`](https://github.com/boshu2/agentops/tree/main/hooks) (shell scripts invoked by the runtime)
+- Shared helpers: [`lib/hook-helpers.sh`](https://github.com/boshu2/agentops/blob/main/lib/hook-helpers.sh)
+- Runtime contract: [`contracts/hook-runtime-contract.md`](contracts/hook-runtime-contract.md)
+
+When `hooks.json` disagrees with this page, trust `hooks.json`.
+
+## Lifecycle events
+
+AgentOps currently uses six lifecycle events. Every event dispatches one or more scripts in `hooks/`.
+
+| Event | Purpose | Representative scripts |
+|-------|---------|-----------------------|
+| `SessionStart` | Seed the session with recent learnings, pointers to MEMORY.md | `session-start.sh`, `ao-inject.sh` |
+| `SessionEnd` | Compile session signal, maintain the knowledge pool | `session-end-maintenance.sh`, `compile-session-defrag.sh` |
+| `Stop` | Close the flywheel for the turn | `ao-flywheel-close.sh` |
+| `UserPromptSubmit` | Route the prompt, nudge discipline, echo intent | `factory-router.sh`, `prompt-nudge.sh`, `intent-echo.sh`, `quality-signals.sh` |
+| `PreToolUse` | Gate risky tool calls (commits, edits, reads in isolation) | `pre-mortem-gate.sh`, `commit-review-gate.sh`, `holdout-isolation-gate.sh`, `go-test-precommit.sh` |
+| `PostToolUse` | Quality and loop-detection after edits | `write-time-quality.sh`, `go-complexity-precommit.sh`, `go-vet-post-edit.sh`, `research-loop-detector.sh`, `context-monitor.sh` |
+
+A `TaskCompleted` block also exists in the manifest (for `task-validation-gate.sh`); it is runtime-dependent and may be a no-op on agents that do not emit that event.
+
+## Install and uninstall
+
+### Claude Code
+
+```bash
+ao hooks install       # writes ~/.claude/settings.json hook entries
+ao hooks show          # prints current effective config
+ao hooks test          # smoke-tests the hook wiring
+ao hooks uninstall     # removes ao hook entries (other entries are preserved)
+```
+
+### Codex (v0.115.0+)
+
+Use `scripts/install-codex-plugin.sh` or `scripts/install-codex.sh` to install the native hook manifest to `~/.codex/hooks.json`.
+
+### Codex (older)
+
+No native hook support. Use the explicit fallback: `ao codex start` at the beginning of a session and `ao codex stop` at the end. See [`architecture/codex-hookless-lifecycle.md`](architecture/codex-hookless-lifecycle.md).
+
+## Customizing behavior
+
+Most hooks read environment variables rather than checking in-tree config. See [`ENV-VARS.md`](ENV-VARS.md) for the full list. Common knobs:
+
+| Variable | Effect |
+|----------|--------|
+| `AGENTOPS_STARTUP_CONTEXT_MODE` | `manual` (default), `lean`, `legacy` — controls how much context `SessionStart` injects |
+| `AGENTOPS_GITIGNORE_AUTO` | Set to `0` to commit `.agents/` artifacts to the repo |
+| `AGENTOPS_HOOKS_DISABLED` | Set to `1` to short-circuit all hooks without uninstalling them |
+| `AGENTOPS_QUIET` | Set to `1` to suppress non-error hook output |
+
+To disable a single hook, either edit the runtime settings manually or delete the entry from your merged settings file (`ao hooks install` preserves unrelated entries on re-run). Do not edit `hooks/hooks.json` directly in an installed copy — edit the repo source and reinstall.
+
+## Common failure modes
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Hook runs but nothing happens | Agent runtime does not emit the event | Check [runtime contract](contracts/hook-runtime-contract.md) |
+| Hook times out | Script exceeded `timeout` in manifest | Increase the timeout in `hooks.json` or make the script cheaper |
+| `ao` not found | CLI not on `PATH` for the runtime's shell | `brew install agentops` or add `~/.local/bin` to PATH |
+| Commit blocked by `commit-review-gate` | Uncommitted or unsigned review trail | Run `/council validate` or review manually |
+| `pre-mortem-gate` fires on every skill call | Expected — it is the shift-left gate | Set `AGENTOPS_PREMORTEM_MODE=advisory` during exploration |
+
+See [`troubleshooting.md`](troubleshooting.md) for more.
+
+## Adding a new hook
+
+1. Add the script to `hooks/<new-hook>.sh`. Source `lib/hook-helpers.sh` for logging, timeouts, and exit-code conventions.
+2. Register it in `hooks/hooks.json` against the appropriate event (and matcher, if relevant).
+3. Run `cd cli && make sync-hooks` so the embedded copy in `cli/embedded/` stays in sync. CI fails if you skip this.
+4. Add an integration test under `tests/` — the shape should follow existing examples for the same event.
+5. Update this page and [`cli/docs/HOOKS.md`](https://github.com/boshu2/agentops/blob/main/cli/docs/HOOKS.md) if the hook introduces a user-visible contract.
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full review gate.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,12 +4,16 @@
 
 ## Getting Started
 
+> **Pick your path:** evaluating the product → [README](https://github.com/boshu2/agentops/blob/main/README.md) then [FAQ](FAQ.md). Installing for real work → [Getting Started landing](getting-started/index.md) then [Create Your First Skill](create-your-first-skill.md). Orienting in the codebase as a contributor → [Newcomer Guide](newcomer-guide.md) then [CONTRIBUTING](CONTRIBUTING.md). Upgrading from an older version → [Upgrading](UPGRADING.md).
+
 - [README](https://github.com/boshu2/agentops/blob/main/README.md) — Project overview and quick start
+- [Getting Started](getting-started/index.md) — Install + first command landing page
 - [Behavioral Discipline](behavioral-discipline.md) — Before/after examples of good coding-agent behavior
 - [Newcomer Guide](newcomer-guide.md) — Fast orientation to repo structure, architecture, and contribution path
 - [FAQ](FAQ.md) — Comparisons, limitations, subagent nesting, uninstall
 - [CONTRIBUTING](CONTRIBUTING.md) — How to contribute
 - [Create Your First Skill](create-your-first-skill.md) — Fast path for authoring a first skill without tripping CI
+- [Upgrading](UPGRADING.md) — Version-to-version migration notes and breaking changes
 - [AGENTS.md](https://github.com/boshu2/agentops/blob/main/AGENTS.md) — Local agent instructions for this repo
 - [Changelog](CHANGELOG.md) — Release history
 - [Security](SECURITY.md) — Vulnerability reporting
@@ -177,11 +181,13 @@
 - [AgentOps Brief](agentops-brief.md) — Executive summary
 - [AgentOps System Map](agentops-system-map.md) — Visual system map
 - [Glossary](GLOSSARY.md) — Definitions of domain-specific terms (Beads, Brownian Ratchet, RPI, etc.)
-- [CLI Reference](cli/commands.md) — Complete `ao` command reference
+- [CLI Reference](https://github.com/boshu2/agentops/blob/main/cli/docs/COMMANDS.md) — Complete `ao` command reference (generated from source)
+- [Hooks Reference](HOOKS.md) — Lifecycle events, what each hook does, how to customize
 - [CLI ↔ Skills/Hooks Map](cli-skills-map.md) — Which commands are called by which skills and hooks
-- [Reference](reference.md) — Deep documentation and pipeline details
+- [Reference](reference.md) — Pipeline stages, execution-model table, and skill-selection matrix (deep-dive companion to SKILLS.md)
 - [Releasing](RELEASING.md) — Release process for ao CLI and plugin
 - [Environment Variables](ENV-VARS.md) — All configuration variables with defaults and precedence
+- [Schemas](SCHEMAS.md) — JSON Schemas for manifests, runtime artifacts, and internal runtime contracts
 - [Skill Router](SKILL-ROUTER.md) — Which skill to use for which task
 - [Troubleshooting](troubleshooting.md) — Common issues and quick fixes
 - [Incident Runbook](INCIDENT-RUNBOOK.md) — Operational runbook for incidents and recovery

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -1,0 +1,80 @@
+# Schemas
+
+AgentOps exposes JSON Schemas for every inter-component contract: installable manifests, runtime artifacts, and skill frontmatter. This page catalogs them and points to the right file when you need to validate or extend a contract.
+
+Schemas live in two places. Both are source of truth:
+
+- [`schemas/`](https://github.com/boshu2/agentops/tree/main/schemas) — user-facing manifests and artifacts versioned with `.v1.schema.json`
+- [`lib/schemas/`](https://github.com/boshu2/agentops/tree/main/lib/schemas) — internal runtime contracts used by the `ao` CLI and swarm runners
+
+Narrative documentation of the contracts (who writes and reads each artifact) lives under [`contracts/`](contracts/index.md) and is indexed from [`contracts/index.md`](contracts/index.md).
+
+## Manifests
+
+Manifests describe installable units — skills, plugins, marketplace entries, hook bindings.
+
+| Schema | Purpose |
+|--------|---------|
+| [`skill-frontmatter.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/skill-frontmatter.v1.schema.json) | YAML frontmatter block at the top of every `SKILL.md`. Validated by `heal.sh --strict` and CI. |
+| [`plugin-manifest.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/plugin-manifest.v1.schema.json) | Claude Code plugin manifest (`plugin.json`). |
+| [`codex-plugin-manifest.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/codex-plugin-manifest.v1.schema.json) | Codex plugin manifest — thin variant used by the Codex marketplace. |
+| [`codex-marketplace.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/codex-marketplace.v1.schema.json) | Top-level marketplace index consumed by `claude plugin marketplace add`. |
+| [`hooks-manifest.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/hooks-manifest.v1.schema.json) | Schema for [`hooks/hooks.json`](https://github.com/boshu2/agentops/blob/main/hooks/hooks.json). See [`HOOKS.md`](HOOKS.md). |
+
+## Runtime artifacts
+
+These describe data written and consumed at runtime — handoffs between sessions, evidence for closure, quality signals.
+
+| Schema | Purpose |
+|--------|---------|
+| [`handoff.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/handoff.v1.schema.json) | Session-boundary handoff artifact written by `ao handoff`, read by the `SessionStart` hook. |
+| [`memory-packet.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/memory-packet.v1.schema.json) | Boundary-memory packet emitted by lifecycle hooks for cross-session continuity. |
+| [`evidence-only-closure.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/evidence-only-closure.v1.schema.json) | Proof artifact for issue closures that rely on validation or policy evidence instead of a code delta. |
+| [`session-quality-signal.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/session-quality-signal.v1.schema.json) | Per-session quality signal rolled up into the knowledge flywheel. |
+| [`scenario.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/scenario.v1.schema.json) | Behavioral validation scenarios stored in `.agents/holdout/`. |
+| [`swarm-evidence.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/swarm-evidence.schema.json) | Permissive shape for files written by swarm workers to `.agents/swarm/results/<task>.json`. Companion strict schema: [`contracts/swarm-worker-result.schema.json`](contracts/swarm-worker-result.schema.json). |
+| [`finding.json`](https://github.com/boshu2/agentops/blob/main/schemas/finding.json) | Canonical finding-item schema for validation skills. Compatible subset of [`contracts/finding-artifact.schema.json`](contracts/finding-artifact.schema.json). |
+
+## Internal runtime contracts
+
+Used by the `ao` CLI team runner and worker pipeline. See [`reference.md`](reference.md) for the team execution model.
+
+| Schema | Purpose |
+|--------|---------|
+| [`lib/schemas/team-spec.json`](https://github.com/boshu2/agentops/blob/main/lib/schemas/team-spec.json) | Team specification consumed by `lib/scripts/team-runner.sh` when launching parallel workers. |
+| [`lib/schemas/worker-output.json`](https://github.com/boshu2/agentops/blob/main/lib/schemas/worker-output.json) | Worker artifact written by Codex and Claude workers; watched by `watch-{codex,claude}-stream.sh`. |
+
+## Related contracts
+
+Machine-readable schemas that live under [`contracts/`](contracts/index.md) (narrative + schema paired in one directory):
+
+- [`contracts/repo-execution-profile.schema.json`](contracts/repo-execution-profile.schema.json) — repo bootstrap/validation/tracker/done-criteria for autonomous runs
+- [`contracts/rpi-phase-result.schema.json`](contracts/rpi-phase-result.schema.json) — RPI phase result artifacts
+- [`contracts/rpi-c2-events.schema.json`](contracts/rpi-c2-events.schema.json) / [`contracts/rpi-c2-commands.schema.json`](contracts/rpi-c2-commands.schema.json) — per-run events/commands JSONL
+- [`contracts/next-work.schema.md`](contracts/next-work.schema.md) — `.agents/rpi/next-work.jsonl` shape
+- [`contracts/swarm-worker-result.schema.json`](contracts/swarm-worker-result.schema.json) — strict completion contract for swarm workers
+- [`contracts/finding-artifact.schema.json`](contracts/finding-artifact.schema.json) — full finding-artifact schema
+
+## Validating against a schema
+
+Most schemas follow JSON Schema Draft 2020-12. Any compatible validator will work. Inside this repo:
+
+```bash
+# Validate skill frontmatter across all skills
+scripts/validate-skills.sh
+
+# Validate hooks manifest
+jq -e . hooks/hooks.json           # well-formed JSON
+ao hooks show --validate           # schema-aware check
+
+# Validate swarm evidence artifacts
+scripts/validate-swarm-evidence.sh
+```
+
+CI enforces schema validity for everything shipped in a release — see [`CI-CD.md`](CI-CD.md).
+
+## Versioning
+
+Schemas are versioned in the filename (`.v1.schema.json`). Breaking changes bump the version and publish a new file; the previous version stays in place until deprecation is announced in [`UPGRADING.md`](UPGRADING.md).
+
+If you are adding a new schema, follow the conventions in [`CONTRIBUTING.md`](CONTRIBUTING.md) and link it from this page plus [`contracts/index.md`](contracts/index.md).

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,0 +1,128 @@
+# Upgrading
+
+This page records **breaking changes, deprecations, and migration steps** for AgentOps users — skill authors, plugin maintainers, CLI users, and anyone who has wired AgentOps into a CI pipeline.
+
+For the full release log, see [`CHANGELOG.md`](CHANGELOG.md). This page is deliberately a thinner, forward-looking companion: it only captures changes that require action.
+
+## Before upgrading
+
+```bash
+# Back up local state if you commit .agents/
+git status .agents/
+
+# Record current version so you can compare
+ao --version
+ao doctor > /tmp/ao-doctor-before.txt
+```
+
+## How to read this page
+
+Each section is keyed by the target version you are upgrading **to**. If you are jumping across several versions, read every intermediate section top-down.
+
+The "Action required" callout distinguishes hard breakages (must fix before running) from advisories (works but deprecated).
+
+---
+
+## Upgrading to 2.38.x (Unreleased)
+
+**Status:** in development — see `[Unreleased]` in [`CHANGELOG.md`](CHANGELOG.md) for latest.
+
+### Strict delegation is now the default for orchestrator skills
+
+**Affects:** anyone invoking `/rpi`, `/discovery`, or `/validation` from wrappers, scripts, or custom skills.
+
+Top-level orchestrator skills now declare strict sub-skill delegation as the default. There is no opt-out flag — strict delegation is always on. Compression is available only through explicit flags:
+
+| Escape | Effect |
+|--------|--------|
+| `--quick`, `--fast-path` | Short-circuit non-essential phases |
+| `--no-retro`, `--no-forge` | Skip post-execution bookkeeping |
+| `--skip-brainstorm`, `--no-scaffold` | Skip planning sub-phases |
+| `--no-behavioral` | Skip behavioral-discipline gate |
+| `--allow-critical-deps` | Permit dependency-risky work |
+
+**Action required:** if you have custom wrappers that inlined orchestrator phases, switch them to invoke the sub-skills directly. See [`skills/shared/references/strict-delegation-contract.md`](https://github.com/boshu2/agentops/blob/main/skills/shared/references/strict-delegation-contract.md).
+
+### `--no-lifecycle` renamed to `--no-scaffold` in `/discovery`
+
+**Affects:** any caller passing `--no-lifecycle` to `/discovery`.
+
+The flag controls STEP 4.5 scaffold auto-invocation only, not broader lifecycle checks. `--no-lifecycle` is honored as a deprecated alias through **v2.40.0**. Other skills (`/crank`, `/validation`, `/implement`, `/evolve`) retain `--no-lifecycle` with its existing semantics.
+
+**Action required:** update scripts and wrappers to use `--no-scaffold` for `/discovery`. `--no-lifecycle` will be removed in v2.41.0.
+
+### Olympus bridge removed
+
+**Affects:** callers referencing `docs/ol-bridge-contracts.md`, `docs/architecture/ao-olympus-ownership-matrix.md`, `.ol/` directories, or `ol-*.sh` scripts.
+
+The AO↔Olympus bridge has been archived. Removed surfaces:
+
+- `docs/ol-bridge-contracts.md`
+- `docs/architecture/ao-olympus-ownership-matrix.md`
+- MemRL policy contracts
+- `skills/*/scripts/ol-*.sh`
+- CLI types: `OLConstraint`, `gatherOLConstraints`
+- `.ol/` directory collector
+
+**Action required:** remove any automation that read from `.ol/` or invoked `ol-*.sh`. Useful patterns from Olympus now live directly inside `ao`.
+
+---
+
+## Upgrading to 2.37.x
+
+### Swarm evidence schema is now validated
+
+**Affects:** any workflow that writes to `.agents/swarm/results/<task>.json`.
+
+A canonical swarm-evidence schema ([`schemas/swarm-evidence.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/swarm-evidence.schema.json)) is now enforced in release and pre-push gates. Historical artifacts are accepted via a permissive shape; new writers should match the strict shape in [`contracts/swarm-worker-result.schema.json`](contracts/swarm-worker-result.schema.json).
+
+**Action required:** run `scripts/validate-swarm-evidence.sh` before shipping new swarm worker code.
+
+### Lead-only worker git guard
+
+**Affects:** custom multi-agent runners that assumed any worker could commit.
+
+Worker sessions now carry an explicit `lead-only-worker-git-guard.sh` hook in the `PreToolUse` chain. Workers that attempt `git commit` will be blocked.
+
+**Action required:** route commits through the lead agent. If you intentionally run a single-agent flow, no action is needed — the guard is a no-op when no worker metadata is present.
+
+### Pre-mortem gate denies on ambiguity
+
+**Affects:** any workflow that relied on the previous fail-open behavior.
+
+The crank pre-mortem gate now denies ambiguous state by default. If your pipeline ran crank jobs with missing pre-mortem context, they will now stop early rather than proceed silently.
+
+**Action required:** either set `AGENTOPS_PREMORTEM_MODE=advisory` for exploratory runs, or ensure pre-mortem artifacts are generated before invoking crank.
+
+---
+
+## Upgrading to 2.37.1 and earlier
+
+See [`CHANGELOG.md`](CHANGELOG.md) directly. No hard breakages were introduced in 2.37.1 or prior 2.37.x releases — all changes were additive.
+
+---
+
+## After upgrading
+
+```bash
+# Verify the new install
+ao --version
+ao doctor
+ao hooks test
+
+# Re-run any local gates touched by the upgrade
+scripts/pre-push-gate.sh --fast
+```
+
+If `ao doctor` reports drift between installed skills and your repo copy, re-run the install script from [Getting Started](getting-started/index.md#install).
+
+## Reporting upgrade issues
+
+If you hit a breakage not described above, open an issue with:
+
+- Before/after `ao --version` output
+- `ao doctor` output from both versions
+- The exact command or hook that failed
+- Runtime (Claude Code, Codex, OpenCode, other)
+
+See [`SECURITY.md`](SECURITY.md) for issues that involve credentials or isolated data.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -2,7 +2,7 @@
 
 New to AgentOps? You're in the right place. This section answers three questions in order: **what is it**, **how do I install it**, and **what's the first useful thing I can run**.
 
-If you're evaluating AgentOps for a team, start with the [Newcomer Guide](../newcomer-guide.md) — it frames the product in fifteen minutes. If you're ready to ship code with it, skip to [Install](#install) and then [First command](#first-command). If you want a structured curriculum, jump to the [Levels](../levels/index.md) path at the bottom.
+If you're evaluating AgentOps for a team, start with the [Newcomer Guide](../newcomer-guide.md) — it frames the product in fifteen minutes. If you're ready to ship code with it, skip to [Install](#install) and then [First command](#first-command). If you want a structured curriculum, jump to the [Levels](../levels/index.md) path at the bottom. If you are upgrading from an older release, read [Upgrading](../UPGRADING.md) first.
 
 <div class="grid cards" markdown>
 
@@ -50,6 +50,17 @@ If you're evaluating AgentOps for a team, start with the [Newcomer Guide](../new
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/boshu2/agentops/main/scripts/install.sh)
 ```
+
+## Verify the install
+
+```bash
+ao doctor              # Checks runtime, skills, hooks, paths
+ao --version           # Prints installed ao version
+```
+
+`ao doctor` is the canonical health check. It prints a per-component status line
+and non-zero exits on a real problem. If anything looks wrong, see
+[Troubleshooting](../troubleshooting.md) or run `ao doctor --verbose`.
 
 ## First command
 

--- a/docs/newcomer-guide.md
+++ b/docs/newcomer-guide.md
@@ -117,5 +117,5 @@ CI validates not just builds/tests but also docs parity, hook safety, skill inte
 - [Documentation Index](INDEX.md)
 - [Contributing Guide](CONTRIBUTING.md)
 - [Skills Reference](SKILLS.md)
-- [CLI Reference](cli/commands.md)
+- [CLI Reference](https://github.com/boshu2/agentops/blob/main/cli/docs/COMMANDS.md)
 - [Troubleshooting](troubleshooting.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -330,6 +330,38 @@ Use `ao doctor --json` for machine-readable output.
 
 ---
 
+## Pre-mortem gate blocks `/crank`
+
+The pre-mortem gate denies ambiguous state by default (as of 2.37.2). If `/crank` exits immediately with a pre-mortem error, it is telling you there is no pre-mortem artifact or the artifact is stale for the current epic.
+
+**Fixes:**
+
+1. Run `/pre-mortem` against the epic before invoking `/crank`.
+2. For exploratory runs where a pre-mortem is not worth the cost:
+   ```bash
+   AGENTOPS_PREMORTEM_MODE=advisory /crank ...
+   ```
+   This downgrades the gate to a warning.
+
+## `go-test-precommit` blocks commits
+
+The `go-test-precommit.sh` hook runs relevant Go tests before tool calls that would mutate Go code. If it fails, look for the test output above the block message. Common causes:
+
+- Tests that depend on network (`go test -short` typically skips these).
+- A package import that fails to compile — fix compilation first, tests second.
+
+**Bypass (not recommended):** set `AGENTOPS_SKIP_GO_TEST_PRECOMMIT=1` for a single session. Prefer fixing the underlying test.
+
+## Context window compacted and lost work
+
+If a session compacts and drops critical context, check whether `precompact-snapshot.sh` ran. Artifacts land in `.agents/compact/<timestamp>/`:
+
+```bash
+ls -lt .agents/compact/ | head
+```
+
+Restore needed state with `ao inject --from .agents/compact/<timestamp>/` or manually re-seed the session with `MEMORY.md`.
+
 ## Getting help
 
 - **New to AgentOps?** Run `/quickstart` for an interactive onboarding walkthrough.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,6 +154,7 @@ nav:
       - Contributing: CONTRIBUTING.md
       - Security: SECURITY.md
       - Changelog: CHANGELOG.md
+      - Upgrading: UPGRADING.md
   - Skills:
       - skills/index.md
       - Skills Reference: SKILLS.md
@@ -165,6 +166,7 @@ nav:
       - cli/index.md
       - Command Reference: cli/commands.md
       - CLI ↔ Skills Map: cli-skills-map.md
+      - Hooks Overview: HOOKS.md
       - Hooks Reference: cli/hooks.md
   - Architecture:
       - architecture/index.md
@@ -221,6 +223,7 @@ nav:
       - reference/index.md
       - Glossary: GLOSSARY.md
       - Environment Variables: ENV-VARS.md
+      - Schemas: SCHEMAS.md
       - Testing: TESTING.md
       - CI/CD: CI-CD.md
       - Releasing: RELEASING.md


### PR DESCRIPTION
## Summary

A batch of documentation improvements identified in a full-docs audit. Reduces newcomer friction from dead links and missing canonical references, and gives skill/plugin authors explicit pages for hooks, schemas, and version migration that were previously implied only by source code.

### Navigation fixes

- `docs/INDEX.md` and `docs/newcomer-guide.md` pointed to a non-existent `cli/commands.md`; replace with the canonical `github.com/.../cli/docs/COMMANDS.md` URL so mkdocs and raw-GitHub readers both land on the file.
- `docs/INDEX.md` Getting Started section now opens with a "pick your path" router so evaluators, installers, contributors, and upgraders don't have to triangulate across three overlapping entry points.
- Link `docs/getting-started/index.md` from INDEX (was orphaned) and add an "Install verification" block pointing at `ao doctor`.

### New pages

- **`docs/HOOKS.md`** — user-facing orientation covering the six lifecycle events, install/uninstall, customization env vars, and common failure modes. Points to `cli/docs/HOOKS.md` for the deep technical reference rather than duplicating.
- **`docs/SCHEMAS.md`** — catalogs every JSON Schema under `schemas/` and `lib/schemas/`, grouped by manifest vs. runtime artifact vs. internal contract, with validation commands.
- **`docs/UPGRADING.md`** — action-required version migration guide seeded with Unreleased (2.38.x) and 2.37.x sections covering strict delegation, `--no-lifecycle` → `--no-scaffold` rename, Olympus bridge removal, swarm-evidence schema enforcement, and pre-mortem gate tightening.

### Reference quality

- `GLOSSARY.md` — 11 new terms (`.agents/`, `MEMORY.md`, Compact/PreCompact, Compile, Context Window, Discovery, Dream/Overnight Run alias, Flywheel Health, Harvest, Holdout, RPI Phase, Session Lifecycle).
- `troubleshooting.md` — three new failure-mode sections: pre-mortem gate blocking `/crank`, `go-test-precommit` blocking commits, context-window compaction recovery.
- `CONTRIBUTING.md` — escalates `sync-skill-counts.sh` requirement from easily-missed sentence to bold callout with CI-failure rationale.

`mkdocs.yml` — registers the three new pages in nav.

## Test plan

- [x] `tests/docs/validate-links.sh` — 1553 links checked, 0 broken
- [x] `tests/docs/validate-doc-release.sh` — PASS
- [x] `tests/docs/validate-skill-count.sh` — PASS (69 skills, cross-file consistent)
- [x] `scripts/docs-build.sh --check` — mkdocs strict build: new docs contribute 0 warnings; only the preexisting `index.md` nav warning remains (out of scope)
- [ ] CI green on the branch