### PR TITLE
feat(nightly): fail loudly on dream close-loop throughput stalls

### DIFF
--- a/scripts/check-dream-throughput.sh
+++ b/scripts/check-dream-throughput.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# check-dream-throughput.sh — Gate: dream-cycle close-loop pipeline produced
+# non-zero throughput for the candidates it ingested.
+#
+# Guards against the chicken-and-egg gate deadlock documented in
+# .agents/learnings/2026-04-22-close-loop-citation-gate-deadlock.md: when
+# fresh candidates were ingested but none reached auto-promotion, the pipeline
+# is stalled regardless of how "clean" each stage looks in isolation.
+#
+# Consumes the JSON shape emitted by `ao flywheel close-loop --json`:
+#   {"ingest":{"added":N},"auto_promote":{"promoted":M}}
+#
+# Exit codes:
+#   0  PASS  — either no ingest this run, or promoted > 0
+#   1  FAIL  — ingest.added > 0 && auto_promote.promoted == 0 (stall)
+#   2  ERROR — missing/invalid input
+#
+# Usage: check-dream-throughput.sh <close-loop.json>
+set -euo pipefail
+
+INPUT="${1:-}"
+if [[ -z "$INPUT" ]]; then
+  echo "usage: $0 <close-loop.json>" >&2
+  exit 2
+fi
+if [[ ! -f "$INPUT" ]]; then
+  echo "ERROR: $INPUT not found" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq not found" >&2
+  exit 2
+fi
+
+added="$(jq -r '.ingest.added // 0' "$INPUT" 2>/dev/null || echo "")"
+promoted="$(jq -r '.auto_promote.promoted // 0' "$INPUT" 2>/dev/null || echo "")"
+
+if ! [[ "$added" =~ ^[0-9]+$ ]] || ! [[ "$promoted" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: could not parse .ingest.added / .auto_promote.promoted as integers in $INPUT" >&2
+  exit 2
+fi
+
+if (( added > 0 && promoted == 0 )); then
+  cat >&2 <<EOF
+FAIL: dream close-loop throughput stall
+      ingest.added=$added but auto_promote.promoted=0
+      A nonzero ingest with zero promotions is a deadlocked pipeline, not a
+      steady state. See .agents/learnings/2026-04-22-close-loop-citation-gate-deadlock.md.
+EOF
+  exit 1
+fi
+
+if (( added == 0 )); then
+  echo "OK: no candidates ingested this run (ingest.added=0); nothing to promote"
+  exit 0
+fi
+
+echo "PASS: auto_promote.promoted=$promoted / ingest.added=$added"
+exit 0

--- a/scripts/nightly-dream-cycle.sh
+++ b/scripts/nightly-dream-cycle.sh
@@ -206,6 +206,12 @@ close_feedback_rewarded="$(jq -r '.citation_feedback.rewarded // 0' "$CLOSE_LOOP
 close_memory_promoted="$(jq -r '.memory_promoted // 0' "$CLOSE_LOOP_JSON")"
 close_store_indexed="$(jq -r '.store.indexed // 0' "$CLOSE_LOOP_JSON")"
 
+if (( close_ingest_added > 0 && close_auto_promoted == 0 )); then
+  close_throughput_stalled="true"
+else
+  close_throughput_stalled="false"
+fi
+
 defrag_total_learnings="$(jq -r '.prune.total_learnings // 0' "$DEFRAG_JSON")"
 defrag_stale="$(jq -r '.prune.stale_count // 0' "$DEFRAG_JSON")"
 defrag_checked="$(jq -r '.dedup.checked // 0' "$DEFRAG_JSON")"
@@ -252,6 +258,7 @@ jq -n \
   --argjson close_feedback_rewarded "$close_feedback_rewarded" \
   --argjson close_memory_promoted "$close_memory_promoted" \
   --argjson close_store_indexed "$close_store_indexed" \
+  --arg close_throughput_stalled "$close_throughput_stalled" \
   --argjson defrag_total_learnings "$defrag_total_learnings" \
   --argjson defrag_stale "$defrag_stale" \
   --argjson defrag_checked "$defrag_checked" \
@@ -299,7 +306,8 @@ jq -n \
       auto_promoted: $close_auto_promoted,
       feedback_rewarded: $close_feedback_rewarded,
       memory_promoted: $close_memory_promoted,
-      indexed: $close_store_indexed
+      indexed: $close_store_indexed,
+      throughput_stalled: ($close_throughput_stalled == "true")
     },
     defrag: {
       total_learnings: $defrag_total_learnings,
@@ -336,10 +344,18 @@ jq -n \
     }
   }' >"$SUMMARY_JSON"
 
+if [[ "$close_throughput_stalled" == "true" ]]; then
+  throughput_banner="> **Throughput stall detected.** ${close_ingest_added} candidate(s) ingested but 0 auto-promoted. See \`.agents/learnings/2026-04-22-close-loop-citation-gate-deadlock.md\`.
+
+"
+else
+  throughput_banner=""
+fi
+
 cat >"$SUMMARY_MD" <<EOF
 ## Nightly Dream Cycle
 
-This run snapshots the checked-in \`.agents/\` corpus into an ephemeral nightly workspace, runs the dream-cycle primitives there, and uploads the resulting reports with the workflow run.
+${throughput_banner}This run snapshots the checked-in \`.agents/\` corpus into an ephemeral nightly workspace, runs the dream-cycle primitives there, and uploads the resulting reports with the workflow run.
 
 | Stage | Result |
 |-------|--------|
@@ -377,3 +393,25 @@ ${retrieval_hit_summary}
 EOF
 
 echo "Dream-cycle summary written to $SUMMARY_MD"
+
+# Throughput-deadlock gate. Reports (and by default fails) when close-loop
+# ingested candidates but auto-promoted zero — the pattern that quietly
+# persisted through multiple nightly runs before
+# .agents/learnings/2026-04-22-close-loop-citation-gate-deadlock.md.
+# Set NIGHTLY_DREAM_STRICT=0 to downgrade to a warning (e.g. for diagnostic
+# runs where you only want to collect numbers).
+THROUGHPUT_SCRIPT="$(dirname "$0")/check-dream-throughput.sh"
+if [[ -x "$THROUGHPUT_SCRIPT" ]]; then
+  if "$THROUGHPUT_SCRIPT" "$CLOSE_LOOP_JSON"; then
+    :
+  else
+    rc=$?
+    if [[ "${NIGHTLY_DREAM_STRICT:-1}" == "0" ]]; then
+      echo "WARN: throughput gate returned $rc (NIGHTLY_DREAM_STRICT=0 — not failing)" >&2
+    else
+      exit "$rc"
+    fi
+  fi
+else
+  echo "WARN: $THROUGHPUT_SCRIPT not found or not executable; skipping throughput gate" >&2
+fi

--- a/tests/scripts/check-dream-throughput.bats
+++ b/tests/scripts/check-dream-throughput.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+#
+# Covers scripts/check-dream-throughput.sh — the gate that detects the
+# chicken-and-egg close-loop deadlock documented in
+# .agents/learnings/2026-04-22-close-loop-citation-gate-deadlock.md.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/check-dream-throughput.sh"
+    TMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "check-dream-throughput.sh exists and is executable" {
+    [ -f "$SCRIPT" ]
+    [ -x "$SCRIPT" ]
+}
+
+@test "PASS when ingested candidates are auto-promoted" {
+    cat > "$TMP_DIR/close-loop.json" <<'EOF'
+{"ingest":{"added":5},"auto_promote":{"promoted":3}}
+EOF
+    run bash "$SCRIPT" "$TMP_DIR/close-loop.json"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"* ]]
+    [[ "$output" == *"3"* ]]
+    [[ "$output" == *"5"* ]]
+}
+
+@test "OK when nothing was ingested this run" {
+    cat > "$TMP_DIR/close-loop.json" <<'EOF'
+{"ingest":{"added":0},"auto_promote":{"promoted":0}}
+EOF
+    run bash "$SCRIPT" "$TMP_DIR/close-loop.json"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no candidates ingested"* ]]
+}
+
+@test "FAIL on the deadlock pattern: added>0 but promoted==0" {
+    cat > "$TMP_DIR/close-loop.json" <<'EOF'
+{"ingest":{"added":43},"auto_promote":{"promoted":0}}
+EOF
+    run bash "$SCRIPT" "$TMP_DIR/close-loop.json"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"stall"* ]]
+    [[ "$output" == *"43"* ]]
+}
+
+@test "ERROR (exit 2) when input file is missing" {
+    run bash "$SCRIPT" "$TMP_DIR/does-not-exist.json"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"not found"* ]]
+}
+
+@test "ERROR (exit 2) when no argument given" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage"* ]]
+}
+
+@test "ERROR (exit 2) when JSON keys are not integers" {
+    cat > "$TMP_DIR/close-loop.json" <<'EOF'
+{"ingest":{"added":"many"},"auto_promote":{"promoted":0}}
+EOF
+    run bash "$SCRIPT" "$TMP_DIR/close-loop.json"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"integers"* ]]
+}
+
+@test "PASS defaults when keys are missing (treated as 0)" {
+    echo '{}' > "$TMP_DIR/close-loop.json"
+    run bash "$SCRIPT" "$TMP_DIR/close-loop.json"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no candidates ingested"* ]]
+}


### PR DESCRIPTION
## Why

Closes the third corrective action from the 2026-04-22 nightly dream-cycle learning ([`2026-04-22-close-loop-citation-gate-deadlock.md`](../blob/main/.agents/learnings/2026-04-22-close-loop-citation-gate-deadlock.md)).

The learning lists three corrective actions for the chicken-and-egg promotion deadlock that quietly zeroed flywheel throughput for weeks:

| # | Corrective action | Status before this PR |
|---|---|---|
| 1 | Split admission gates by path | ✅ Done in b69a00f |
| 2 | Parameterize shared helpers (`requireCitations bool`) | ✅ Done in b69a00f |
| 3 | **Fail loudly if `ingested > 0 && promoted == 0` across runs** | ❌ Open — **this PR** |

Before this PR, `scripts/nightly-dream-cycle.sh` emitted `close_ingest_added` and `close_auto_promoted` into `summary.json` but never asserted the relationship. The deadlock surfaced only in *downstream* metrics (`sigma=0`, `escape_velocity=false`) — exactly the *"quietly posting another zero-throughput status issue"* pattern the learning warns against. The nightly workflow's `dream-cycle` job exited 0 on a stall, so no failure issue was ever filed.

## What changes

- **`scripts/check-dream-throughput.sh` (new)** — standalone gate consuming the JSON shape of `ao flywheel close-loop --json`. Exits `1` on the deadlock pattern (`added > 0 && promoted == 0`), `0` on healthy / empty-run, `2` on bad input. Mirrors the existing `check-compile-*.sh` gate pattern.
- **`scripts/nightly-dream-cycle.sh`** — invokes the gate *after* the summary artifacts are written (so uploads still succeed even on failure) and exits non-zero when the stall fires. `NIGHTLY_DREAM_STRICT=0` downgrades to a warning for diagnostic runs. `summary.json` grows `close_loop.throughput_stalled: bool`; `summary.md` renders a blockquote banner above the stage table so the auto-filed *"Nightly dream cycle status"* issue leads with it.
- **`tests/scripts/check-dream-throughput.bats` (new)** — 8 cases covering healthy, empty-run, deadlock, missing input, no-arg, non-integer input, missing keys.

## Test plan

- [x] All 8 scenarios pass via direct `bash` invocation (bats not installed locally; equivalent coverage confirmed manually):
  - healthy (`added=5, promoted=3`) → exit 0
  - empty run (`added=0`) → exit 0
  - **stall** (`added=43, promoted=0`) → exit 1 with the "stall" message and pointer to the learning doc
  - missing file → exit 2
  - no arg → exit 2 + usage
  - non-integer input → exit 2
  - empty JSON object → treated as added=0, exit 0
- [x] `bash -n` syntax-checked both scripts
- [x] `summary.json` assembly verified with `jq -n ... '{... throughput_stalled: ($close_throughput_stalled == "true")}'`
- [x] `summary.md` banner rendering verified in both states
- [ ] CI nightly run confirms the gate fires/clears correctly on a real close-loop report

https://claude.ai/code/session_018LG8gtdsUq6bYNKo9NqrxU