### PR TITLE
test: expand coverage across lifecycle, goals, rpi, context, search, quality, overnight, python

### DIFF
--- a/cli/cmd/ao/knowledge_context_test.go
+++ b/cli/cmd/ao/knowledge_context_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestKnowledgeOrderedItem(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "simple numeric", in: "1. do thing", want: "do thing"},
+		{name: "multi-digit", in: "12. twelve things", want: "twelve things"},
+		{name: "trims surrounding whitespace", in: "3.   spaced out  ", want: "spaced out"},
+		{name: "not ordered list", in: "- dashed item", want: ""},
+		{name: "no space after dot", in: "1.tight", want: ""},
+		{name: "letter prefix rejected", in: "a. something", want: ""},
+		{name: "empty", in: "", want: ""},
+		{name: "leading dot", in: ". nothing", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := knowledgeOrderedItem(tc.in)
+			if got != tc.want {
+				t.Fatalf("knowledgeOrderedItem(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractKnowledgeListItems(t *testing.T) {
+	text := `# Title
+
+## Core Beliefs
+
+- belief one
+- belief two
+1. ordered belief
+- belief two
+
+## Other Section
+
+- unrelated item
+
+## Operating Principles
+
+- principle one
+`
+	got := extractKnowledgeListItems(text, "## Core Beliefs")
+	want := []string{"belief one", "belief two", "ordered belief"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Core Beliefs = %v, want %v", got, want)
+	}
+
+	gotOther := extractKnowledgeListItems(text, "## Operating Principles")
+	wantOther := []string{"principle one"}
+	if !reflect.DeepEqual(gotOther, wantOther) {
+		t.Fatalf("Operating Principles = %v, want %v", gotOther, wantOther)
+	}
+
+	if got := extractKnowledgeListItems(text, "## Missing"); len(got) != 0 {
+		t.Fatalf("missing heading = %v, want empty", got)
+	}
+}
+
+func TestRankKnowledgeContextLines_RanksByTokenScore(t *testing.T) {
+	items := []string{
+		"alpha beta gamma",
+		"gamma delta epsilon",
+		"nothing matches here",
+	}
+	got := rankKnowledgeContextLines("gamma", items, 3)
+	// Items 0 and 1 each contain "gamma" (score 2). They retain original order
+	// as a stable sort tie-break. Item 2 scores 0 and comes last.
+	want := []string{"alpha beta gamma", "gamma delta epsilon", "nothing matches here"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ranked = %v, want %v", got, want)
+	}
+}
+
+func TestRankKnowledgeContextLines_AppliesLimit(t *testing.T) {
+	items := []string{"alpha", "beta", "gamma"}
+	got := rankKnowledgeContextLines("beta", items, 2)
+	// "beta" ranks first; limit cuts at 2.
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 (got %v)", len(got), got)
+	}
+	if got[0] != "beta" {
+		t.Fatalf("first = %q, want %q", got[0], "beta")
+	}
+}
+
+func TestRankKnowledgeContextLines_NoMatchesPreservesOrder(t *testing.T) {
+	items := []string{"alpha", "beta", "gamma"}
+	got := rankKnowledgeContextLines("unrelated", items, 0)
+	want := []string{"alpha", "beta", "gamma"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("no-match = %v, want %v", got, want)
+	}
+}
+
+func TestRankKnowledgeContextLines_NormalizesWhitespace(t *testing.T) {
+	items := []string{"   alpha   beta   "}
+	got := rankKnowledgeContextLines("", items, 0)
+	want := []string{"alpha beta"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalize = %v, want %v", got, want)
+	}
+}
+
+func TestRankKnowledgeContextLines_EmptyInput(t *testing.T) {
+	if got := rankKnowledgeContextLines("q", nil, 5); got != nil {
+		t.Fatalf("nil items = %v, want nil", got)
+	}
+}
+
+func TestKnowledgeAgentsRoot_FallsBackToCwdWhenNoGit(t *testing.T) {
+	dir := t.TempDir()
+	// No .git — findGitRoot returns "" and the cwd should be used.
+	got := knowledgeAgentsRoot(dir)
+	want := filepath.Join(dir, ".agents")
+	if got != want {
+		t.Fatalf("knowledgeAgentsRoot(%q) = %q, want %q", dir, got, want)
+	}
+}
+
+func TestDisplayKnowledgeContextPath_EmptyReturnsEmpty(t *testing.T) {
+	if got := displayKnowledgeContextPath("/tmp", ""); got != "" {
+		t.Fatalf("empty path = %q, want \"\"", got)
+	}
+}
+
+func TestDisplayKnowledgeContextPath_RelativeToCwd(t *testing.T) {
+	cwd := t.TempDir()
+	path := filepath.Join(cwd, "sub", "artifact.md")
+	got := displayKnowledgeContextPath(cwd, path)
+	want := filepath.Join("sub", "artifact.md")
+	if got != want {
+		t.Fatalf("rel path = %q, want %q", got, want)
+	}
+}
+
+func TestDisplayKnowledgeContextPath_AbsoluteWhenOutsideCwd(t *testing.T) {
+	cwd := t.TempDir()
+	other := t.TempDir()
+	path := filepath.Join(other, "elsewhere.md")
+	got := displayKnowledgeContextPath(cwd, path)
+	if got != path {
+		t.Fatalf("outside path = %q, want %q", got, path)
+	}
+}

--- a/cli/cmd/ao/knowledge_files_test.go
+++ b/cli/cmd/ao/knowledge_files_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestWalkKnowledgeFiles_FiltersByExtensionAndSorts(t *testing.T) {
+	dir := t.TempDir()
+
+	// Build a nested layout to exercise recursion.
+	mustWriteFile(t, filepath.Join(dir, "b.md"), "b")
+	mustWriteFile(t, filepath.Join(dir, "a.md"), "a")
+	mustWriteFile(t, filepath.Join(dir, "nested", "c.md"), "c")
+	mustWriteFile(t, filepath.Join(dir, "nested", "skip.txt"), "no")
+	mustWriteFile(t, filepath.Join(dir, "nested", "deeper", "d.MD"), "d") // case-insensitive
+	mustWriteFile(t, filepath.Join(dir, "ignored.json"), "{}")
+
+	got := walkKnowledgeFiles(dir, ".md")
+	want := []string{
+		filepath.Join(dir, "a.md"),
+		filepath.Join(dir, "b.md"),
+		filepath.Join(dir, "nested", "c.md"),
+		filepath.Join(dir, "nested", "deeper", "d.MD"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("walkKnowledgeFiles md = %v\nwant %v", got, want)
+	}
+}
+
+func TestWalkKnowledgeFiles_MultipleExtensions(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "a.md"), "x")
+	mustWriteFile(t, filepath.Join(dir, "b.json"), "{}")
+	mustWriteFile(t, filepath.Join(dir, "c.yaml"), "y")
+
+	got := walkKnowledgeFiles(dir, ".md", ".json")
+	want := []string{
+		filepath.Join(dir, "a.md"),
+		filepath.Join(dir, "b.json"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("walkKnowledgeFiles md+json = %v, want %v", got, want)
+	}
+}
+
+func TestWalkKnowledgeFiles_EmptyDirReturnsNil(t *testing.T) {
+	dir := t.TempDir()
+	got := walkKnowledgeFiles(dir, ".md")
+	if got != nil {
+		t.Fatalf("walkKnowledgeFiles on empty dir = %v, want nil", got)
+	}
+}
+
+func TestWalkKnowledgeFiles_MissingDirReturnsNil(t *testing.T) {
+	got := walkKnowledgeFiles("/definitely/not/here/xyz123", ".md")
+	if got != nil {
+		t.Fatalf("walkKnowledgeFiles on missing dir = %v, want nil", got)
+	}
+}
+
+func TestWalkKnowledgeFiles_EmptyDirArgReturnsNil(t *testing.T) {
+	got := walkKnowledgeFiles("", ".md")
+	if got != nil {
+		t.Fatalf("walkKnowledgeFiles empty dir = %v, want nil", got)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/cli/cmd/ao/knowledge_native_test.go
+++ b/cli/cmd/ao/knowledge_native_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestKnowledgeBriefingOutputPath_UsesSluggedGoal(t *testing.T) {
+	agents := "/tmp/agents"
+	got := knowledgeBriefingOutputPath(agents, "Refactor Dream Council")
+	today := time.Now().Format("2006-01-02")
+	wantSuffix := today + "-refactor-dream-council.md"
+	wantDir := filepath.Join(agents, "briefings")
+	if filepath.Dir(got) != wantDir {
+		t.Fatalf("dir = %q, want %q", filepath.Dir(got), wantDir)
+	}
+	if filepath.Base(got) != wantSuffix {
+		t.Fatalf("base = %q, want %q", filepath.Base(got), wantSuffix)
+	}
+}
+
+func TestKnowledgeBriefingOutputPath_WhitespaceSlug(t *testing.T) {
+	agents := "/tmp/agents"
+	// Pool.Slugify returns the "cand" sentinel (never "") so the filename
+	// always has a real slug segment.
+	got := knowledgeBriefingOutputPath(agents, "   ")
+	today := time.Now().Format("2006-01-02")
+	if !strings.HasSuffix(got, today+"-cand.md") {
+		t.Fatalf("base = %q, want suffix %q", filepath.Base(got), today+"-cand.md")
+	}
+}
+
+func TestKnowledgeBriefingOutputPath_LowercasesAndDelimits(t *testing.T) {
+	agents := "/tmp/agents"
+	got := knowledgeBriefingOutputPath(agents, "Hello World!")
+	today := time.Now().Format("2006-01-02")
+	wantBase := today + "-hello-world.md"
+	if filepath.Base(got) != wantBase {
+		t.Fatalf("base = %q, want %q", filepath.Base(got), wantBase)
+	}
+}

--- a/cli/cmd/ao/overnight_council_test.go
+++ b/cli/cmd/ao/overnight_council_test.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/boshu2/agentops/cli/internal/config"
+)
+
+func TestResolveDreamConsensusPolicy(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "default when empty", in: "", want: "majority"},
+		{name: "default on whitespace", in: "   ", want: "majority"},
+		{name: "custom preserved", in: "unanimous", want: "unanimous"},
+		{name: "trimmed custom", in: "  quorum  ", want: "quorum"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveDreamConsensusPolicy(config.DreamConfig{ConsensusPolicy: tc.in})
+			if got != tc.want {
+				t.Fatalf("resolveDreamConsensusPolicy(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeDreamCouncilRunnerLabel(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{in: "codex", want: "codex"},
+		{in: "  Codex  ", want: "codex"},
+		{in: "claude_dream_council", want: "claude-dream-council"},
+		{in: "Claude Dream Council", want: "claude-dream-council"},
+		{in: "-codex-", want: "codex"},
+		{in: "", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			got := normalizeDreamCouncilRunnerLabel(tc.in)
+			if got != tc.want {
+				t.Fatalf("normalizeDreamCouncilRunnerLabel(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDreamCouncilRunnerMatches(t *testing.T) {
+	tests := []struct {
+		name              string
+		expected, actual  string
+		want              bool
+	}{
+		{name: "exact", expected: "codex", actual: "codex", want: true},
+		{name: "case insensitive", expected: "codex", actual: "CODEX", want: true},
+		{name: "dream-council suffix", expected: "claude", actual: "claude-dream-council", want: true},
+		{name: "underscore suffix", expected: "claude", actual: "claude_dream_council", want: true},
+		{name: "different runner", expected: "codex", actual: "claude", want: false},
+		{name: "extra unexpected suffix", expected: "codex", actual: "codex-extra", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dreamCouncilRunnerMatches(tc.expected, tc.actual)
+			if got != tc.want {
+				t.Fatalf("dreamCouncilRunnerMatches(%q, %q) = %v, want %v",
+					tc.expected, tc.actual, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateDreamCouncilRunnerReport(t *testing.T) {
+	full := overnightCouncilRunnerReport{
+		Runner:                 "codex",
+		Headline:               "ship it",
+		RecommendedKind:        "implement",
+		RecommendedFirstAction: "run make test",
+		Confidence:             "high",
+	}
+	if err := validateDreamCouncilRunnerReport("codex", full); err != nil {
+		t.Fatalf("valid report should pass, got %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		mutate   func(r *overnightCouncilRunnerReport)
+		wantSub  string
+	}{
+		{name: "missing runner", mutate: func(r *overnightCouncilRunnerReport) { r.Runner = "" }, wantSub: "missing runner field"},
+		{name: "runner mismatch", mutate: func(r *overnightCouncilRunnerReport) { r.Runner = "claude" }, wantSub: "runner mismatch"},
+		{name: "missing headline", mutate: func(r *overnightCouncilRunnerReport) { r.Headline = "" }, wantSub: "missing headline"},
+		{name: "missing recommended_kind", mutate: func(r *overnightCouncilRunnerReport) { r.RecommendedKind = "" }, wantSub: "missing recommended_kind"},
+		{name: "missing recommended_first_action", mutate: func(r *overnightCouncilRunnerReport) { r.RecommendedFirstAction = "" }, wantSub: "missing recommended_first_action"},
+		{name: "missing confidence", mutate: func(r *overnightCouncilRunnerReport) { r.Confidence = "" }, wantSub: "missing confidence"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := full
+			tc.mutate(&r)
+			err := validateDreamCouncilRunnerReport("codex", r)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestBuildDreamCouncilPrompt(t *testing.T) {
+	packet := `{"run_id":"r1"}`
+	noCreative := buildDreamCouncilPrompt("codex", packet, false)
+	if !strings.Contains(noCreative, "You are the codex Dream Council runner.") {
+		t.Fatalf("prompt missing runner intro: %q", noCreative)
+	}
+	if !strings.Contains(noCreative, packet) {
+		t.Fatalf("prompt missing packet body")
+	}
+	if !strings.Contains(noCreative, `set runner exactly to "codex"`) {
+		t.Fatalf("prompt missing runner assignment rule")
+	}
+	if !strings.Contains(noCreative, "Return wildcard_idea as an empty string") {
+		t.Fatalf("non-creative prompt should insert the 'return empty' wildcard rule")
+	}
+	if strings.Contains(noCreative, "Include one bounded wildcard idea") {
+		t.Fatalf("non-creative prompt should not include creative wildcard rule")
+	}
+
+	creative := buildDreamCouncilPrompt("claude", packet, true)
+	if !strings.Contains(creative, "Include one bounded wildcard idea") {
+		t.Fatalf("creative prompt should invite a wildcard idea")
+	}
+	if !strings.Contains(creative, `set runner exactly to "claude"`) {
+		t.Fatalf("creative prompt should bind runner to claude")
+	}
+}
+
+func TestExtractDreamClaudeStructuredOutput(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		envelope := `{"type":"result","structured_output":{"runner":"claude","headline":"x"}}`
+		got, err := extractDreamClaudeStructuredOutput([]byte(envelope))
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		want := `{"runner":"claude","headline":"x"}`
+		if string(got) != want {
+			t.Fatalf("payload = %q, want %q", string(got), want)
+		}
+	})
+	t.Run("error envelope", func(t *testing.T) {
+		env := `{"type":"result","is_error":true,"message":"boom"}`
+		_, err := extractDreamClaudeStructuredOutput([]byte(env))
+		if err == nil || !strings.Contains(err.Error(), "reported error") {
+			t.Fatalf("expected reported error err, got %v", err)
+		}
+	})
+	t.Run("wrong type", func(t *testing.T) {
+		env := `{"type":"progress"}`
+		_, err := extractDreamClaudeStructuredOutput([]byte(env))
+		if err == nil || !strings.Contains(err.Error(), "unexpected claude output type") {
+			t.Fatalf("expected unexpected-type err, got %v", err)
+		}
+	})
+	t.Run("missing structured_output", func(t *testing.T) {
+		env := `{"type":"result"}`
+		_, err := extractDreamClaudeStructuredOutput([]byte(env))
+		if err == nil || !strings.Contains(err.Error(), "missing structured_output") {
+			t.Fatalf("expected missing-structured_output err, got %v", err)
+		}
+	})
+	t.Run("bad json", func(t *testing.T) {
+		_, err := extractDreamClaudeStructuredOutput([]byte("not json"))
+		if err == nil || !strings.Contains(err.Error(), "parse claude result envelope") {
+			t.Fatalf("expected parse err, got %v", err)
+		}
+	})
+}
+
+func TestSynthesizeDreamCouncil_ConsensusAndDisagreement(t *testing.T) {
+	reports := []overnightCouncilRunnerReport{
+		{
+			Runner:                 "codex",
+			RecommendedKind:        "implement",
+			RecommendedFirstAction: "run make test",
+			WildcardIdea:           "turn it off and on again",
+		},
+		{
+			Runner:                 "claude",
+			RecommendedKind:        "implement",
+			RecommendedFirstAction: "run make test",
+		},
+	}
+	got := synthesizeDreamCouncil([]string{"codex", "claude"}, nil, "majority", reports)
+
+	if got.ConsensusKind != "implement" {
+		t.Fatalf("ConsensusKind = %q, want %q", got.ConsensusKind, "implement")
+	}
+	if got.RecommendedFirstAction != "run make test" {
+		t.Fatalf("RecommendedFirstAction = %q, want %q", got.RecommendedFirstAction, "run make test")
+	}
+	if len(got.Disagreements) != 0 {
+		t.Fatalf("no disagreements expected, got %v", got.Disagreements)
+	}
+	wantCompleted := []string{"claude", "codex"}
+	if !reflect.DeepEqual(got.CompletedRunners, wantCompleted) {
+		t.Fatalf("CompletedRunners = %v, want %v", got.CompletedRunners, wantCompleted)
+	}
+	wantWildcards := []string{"codex: turn it off and on again"}
+	if !reflect.DeepEqual(got.WildcardIdeas, wantWildcards) {
+		t.Fatalf("WildcardIdeas = %v, want %v", got.WildcardIdeas, wantWildcards)
+	}
+}
+
+func TestSynthesizeDreamCouncil_TiesPickLexicographicallyFirst(t *testing.T) {
+	reports := []overnightCouncilRunnerReport{
+		{Runner: "codex", RecommendedKind: "implement", RecommendedFirstAction: "A"},
+		{Runner: "claude", RecommendedKind: "research", RecommendedFirstAction: "B"},
+	}
+	got := synthesizeDreamCouncil([]string{"codex", "claude"}, nil, "majority", reports)
+	// counts tie (1 each); tie-break picks kind with smaller string: "implement" < "research".
+	if got.ConsensusKind != "implement" {
+		t.Fatalf("ConsensusKind = %q, want %q", got.ConsensusKind, "implement")
+	}
+	if got.RecommendedFirstAction != "A" {
+		t.Fatalf("RecommendedFirstAction = %q, want %q", got.RecommendedFirstAction, "A")
+	}
+	// Claude disagrees.
+	if len(got.Disagreements) != 1 || !strings.Contains(got.Disagreements[0], "claude prefers research") {
+		t.Fatalf("disagreements = %v, want one mentioning 'claude prefers research'", got.Disagreements)
+	}
+}
+
+func TestSynthesizeDreamCouncil_RecordsFailed(t *testing.T) {
+	got := synthesizeDreamCouncil([]string{"codex", "claude"}, []string{"claude"}, "majority", nil)
+	if !reflect.DeepEqual(got.FailedRunners, []string{"claude"}) {
+		t.Fatalf("FailedRunners = %v, want [claude]", got.FailedRunners)
+	}
+	if got.ConsensusPolicy != "majority" {
+		t.Fatalf("ConsensusPolicy = %q, want majority", got.ConsensusPolicy)
+	}
+	if got.ConsensusKind != "" {
+		t.Fatalf("ConsensusKind should be empty when no reports, got %q", got.ConsensusKind)
+	}
+}
+
+func TestWithDreamCouncilRunnerTimeout_UsesConfigured(t *testing.T) {
+	parent := context.Background()
+	ctx, cancel, timeout := withDreamCouncilRunnerTimeout(parent, 42*time.Second)
+	defer cancel()
+	if timeout != 42*time.Second {
+		t.Fatalf("timeout = %v, want 42s", timeout)
+	}
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		t.Fatalf("ctx should carry a deadline")
+	}
+}
+
+func TestWithDreamCouncilRunnerTimeout_FallsBackToDefault(t *testing.T) {
+	parent := context.Background()
+	_, cancel, timeout := withDreamCouncilRunnerTimeout(parent, 0)
+	defer cancel()
+	if timeout != dreamCouncilRunnerTimeout {
+		t.Fatalf("timeout = %v, want default %v", timeout, dreamCouncilRunnerTimeout)
+	}
+}
+
+func TestWithDreamCouncilRunnerTimeout_ShrinksToParentDeadline(t *testing.T) {
+	parent, parentCancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer parentCancel()
+	_, cancel, timeout := withDreamCouncilRunnerTimeout(parent, 10*time.Minute)
+	defer cancel()
+	if timeout > 10*time.Millisecond {
+		t.Fatalf("timeout = %v, should have shrunk below 10ms (parent=5ms)", timeout)
+	}
+	if timeout <= 0 {
+		t.Fatalf("timeout = %v, should be positive (floor of 1s when non-positive)", timeout)
+	}
+}

--- a/cli/cmd/ao/overnight_setup_test.go
+++ b/cli/cmd/ao/overnight_setup_test.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestIsValidDailyTime(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{in: "00:00", want: true},
+		{in: "23:59", want: true},
+		{in: "09:05", want: true},
+		{in: "24:00", want: false},
+		{in: "23:60", want: false},
+		{in: "1:00", want: false},  // hour not zero-padded
+		{in: "01:5", want: false},  // minute not zero-padded
+		{in: "ab:cd", want: false},
+		{in: "11-30", want: false},
+		{in: "", want: false},
+		{in: "11:30:00", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := isValidDailyTime(tc.in); got != tc.want {
+				t.Fatalf("isValidDailyTime(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSplitDailyTime(t *testing.T) {
+	tests := []struct {
+		in                 string
+		wantHour, wantMin  string
+	}{
+		{in: "09:30", wantHour: "09", wantMin: "30"},
+		{in: " 08:15 ", wantHour: "08", wantMin: "15"},
+		{in: "23:59", wantHour: "23", wantMin: "59"},
+		{in: "24:00", wantHour: "", wantMin: ""},
+		{in: "00:60", wantHour: "", wantMin: ""},
+		{in: "bad", wantHour: "", wantMin: ""},
+		{in: "1:00", wantHour: "", wantMin: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			h, m := splitDailyTime(tc.in)
+			if h != tc.wantHour || m != tc.wantMin {
+				t.Fatalf("splitDailyTime(%q) = (%q, %q), want (%q, %q)",
+					tc.in, h, m, tc.wantHour, tc.wantMin)
+			}
+		})
+	}
+}
+
+func TestXMLEscape(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{in: "plain text", want: "plain text"},
+		{in: "a & b", want: "a &amp; b"},
+		{in: "<tag>", want: "&lt;tag&gt;"},
+		{in: `"quoted"`, want: "&quot;quoted&quot;"},
+		{in: "it's", want: "it&apos;s"},
+		{in: "", want: ""},
+		{in: "<&>", want: "&lt;&amp;&gt;"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := xmlEscape(tc.in); got != tc.want {
+				t.Fatalf("xmlEscape(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeDreamRunnerList(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "comma-split and lowercase",
+			in:   []string{"Codex,Claude"},
+			want: []string{"claude", "codex"},
+		},
+		{
+			name: "dedupes",
+			in:   []string{"codex", "codex", "Claude"},
+			want: []string{"claude", "codex"},
+		},
+		{
+			name: "trims whitespace",
+			in:   []string{"  codex , claude  "},
+			want: []string{"claude", "codex"},
+		},
+		{
+			name: "ignores empty parts",
+			in:   []string{",,codex,,"},
+			want: []string{"codex"},
+		},
+		{
+			name:  "empty input",
+			in:    nil,
+			want:  []string{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeDreamRunnerList(tc.in)
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("normalizeDreamRunnerList(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsDreamSchedulerModeValid(t *testing.T) {
+	valid := []string{"manual", "launchd", "cron", "systemd", "task-scheduler"}
+	for _, v := range valid {
+		if !isDreamSchedulerModeValid(v) {
+			t.Fatalf("expected %q to be valid", v)
+		}
+	}
+	invalid := []string{"", "auto", "LAUNCHD", "other", "unknown"}
+	for _, v := range invalid {
+		if isDreamSchedulerModeValid(v) {
+			t.Fatalf("expected %q to be invalid", v)
+		}
+	}
+}
+
+func TestDreamBoolPtr(t *testing.T) {
+	trueP := dreamBoolPtr(true)
+	if trueP == nil || *trueP != true {
+		t.Fatalf("dreamBoolPtr(true) = %v, want pointer to true", trueP)
+	}
+	falseP := dreamBoolPtr(false)
+	if falseP == nil || *falseP != false {
+		t.Fatalf("dreamBoolPtr(false) = %v, want pointer to false", falseP)
+	}
+	// Distinct instances so future mutation doesn't cross-talk.
+	if trueP == falseP {
+		t.Fatalf("dreamBoolPtr should return fresh pointers each call")
+	}
+}
+
+func TestRenderDreamCronLine(t *testing.T) {
+	got := renderDreamCronLine("/repo", "09:05")
+	// Format: "<min> <hour> * * * cd <cwd> && ao overnight start >> <log> 2>&1"
+	if !strings.HasPrefix(got, "05 09 * * * ") {
+		t.Fatalf("cron line should start with '05 09 * * * '; got %q", got)
+	}
+	if !strings.Contains(got, "ao overnight start") {
+		t.Fatalf("cron line missing command: %q", got)
+	}
+	if !strings.HasSuffix(got, "2>&1\n") {
+		t.Fatalf("cron line should end with stderr redirect+newline, got %q", got)
+	}
+}
+
+func TestRenderDreamSystemdTimer(t *testing.T) {
+	got := renderDreamSystemdTimer("07:30")
+	if !strings.Contains(got, "OnCalendar=*-*-* 07:30:00") {
+		t.Fatalf("systemd timer missing OnCalendar line: %q", got)
+	}
+	if !strings.Contains(got, "Persistent=true") {
+		t.Fatalf("systemd timer missing Persistent line: %q", got)
+	}
+	if !strings.Contains(got, "[Install]") {
+		t.Fatalf("systemd timer missing [Install] section: %q", got)
+	}
+}
+
+func TestRenderDreamLaunchdPlist_EscapesXMLAndSetsTimes(t *testing.T) {
+	got := renderDreamLaunchdPlist("/path/with<special>&", "06:45")
+	if !strings.Contains(got, "<key>Hour</key>\n    <integer>06</integer>") {
+		t.Fatalf("launchd plist missing Hour=06, got %q", got)
+	}
+	if !strings.Contains(got, "<key>Minute</key>\n    <integer>45</integer>") {
+		t.Fatalf("launchd plist missing Minute=45, got %q", got)
+	}
+	if !strings.Contains(got, "/path/with&lt;special&gt;&amp;") {
+		t.Fatalf("launchd plist did not XML-escape cwd, got %q", got)
+	}
+}

--- a/cli/internal/context/run_test.go
+++ b/cli/internal/context/run_test.go
@@ -1,0 +1,374 @@
+package context
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRemainingPercent(t *testing.T) {
+	cases := []struct {
+		in, want float64
+	}{
+		{0.0, 1.0},
+		{0.25, 0.75},
+		{1.0, 0.0},
+		{1.5, 0.0},
+		{-0.1, 1.0},
+	}
+	for _, tc := range cases {
+		if got := RemainingPercent(tc.in); got != tc.want {
+			t.Errorf("RemainingPercent(%v) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestReadinessForUsage(t *testing.T) {
+	cases := []struct {
+		usage float64
+		want  string
+	}{
+		{0.0, ReadinessGreen},
+		{0.2, ReadinessGreen},
+		{0.35, ReadinessAmber},
+		{0.55, ReadinessRed},
+		{0.80, ReadinessCritical},
+		{1.0, ReadinessCritical},
+	}
+	for _, tc := range cases {
+		if got := ReadinessForUsage(tc.usage); got != tc.want {
+			t.Errorf("ReadinessForUsage(%v) = %q, want %q", tc.usage, got, tc.want)
+		}
+	}
+}
+
+func TestReadinessAction(t *testing.T) {
+	cases := map[string]string{
+		ReadinessGreen:    "carry_on",
+		ReadinessAmber:    "finish_current_scope",
+		ReadinessRed:      "relief_on_station",
+		ReadinessCritical: "immediate_relief",
+		"UNKNOWN":         "immediate_relief",
+	}
+	for in, want := range cases {
+		if got := ReadinessAction(in); got != want {
+			t.Errorf("ReadinessAction(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestReadinessRank(t *testing.T) {
+	if ReadinessRank(ReadinessCritical) != 0 {
+		t.Error("CRITICAL should rank 0")
+	}
+	if ReadinessRank(ReadinessRed) != 1 {
+		t.Error("RED should rank 1")
+	}
+	if ReadinessRank(ReadinessAmber) != 2 {
+		t.Error("AMBER should rank 2")
+	}
+	if ReadinessRank(ReadinessGreen) != 3 {
+		t.Error("GREEN should rank 3")
+	}
+	if ReadinessRank("UNKNOWN") != 4 {
+		t.Error("unknown should rank 4")
+	}
+	// Whitespace tolerated
+	if ReadinessRank(" CRITICAL ") != 0 {
+		t.Error("whitespace should not break ranking")
+	}
+}
+
+func TestActionForStatus(t *testing.T) {
+	// Stale + non-optimal -> recover
+	if got := ActionForStatus("warning", true, "ok", "crit", "warning"); got != "recover_dead_session" {
+		t.Errorf("got %q", got)
+	}
+	// Critical
+	if got := ActionForStatus("crit", false, "ok", "crit", "warning"); got != "handoff_now" {
+		t.Errorf("got %q", got)
+	}
+	// Warning
+	if got := ActionForStatus("warning", false, "ok", "crit", "warning"); got != "checkpoint_and_prepare_handoff" {
+		t.Errorf("got %q", got)
+	}
+	// Stale + optimal
+	if got := ActionForStatus("ok", true, "ok", "crit", "warning"); got != "investigate_stale_session" {
+		t.Errorf("got %q", got)
+	}
+	// Normal
+	if got := ActionForStatus("ok", false, "ok", "crit", "warning"); got != "continue" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestNonZeroOrDefault(t *testing.T) {
+	if got := NonZeroOrDefault(5, 10); got != 5 {
+		t.Errorf("got %d", got)
+	}
+	if got := NonZeroOrDefault(0, 10); got != 10 {
+		t.Errorf("got %d", got)
+	}
+	if got := NonZeroOrDefault(-1, 10); got != 10 {
+		t.Errorf("got %d", got)
+	}
+}
+
+func TestTruncateDisplay(t *testing.T) {
+	cases := []struct {
+		in   string
+		max  int
+		want string
+	}{
+		{"short", 10, "short"},
+		{"exactly ten", 11, "exactly ten"},
+		{"hello world", 8, "hello..."},
+		{"abc", 2, "ab"}, // max<=3 just truncates
+	}
+	for _, tc := range cases {
+		if got := TruncateDisplay(tc.in, tc.max); got != tc.want {
+			t.Errorf("TruncateDisplay(%q, %d) = %q, want %q", tc.in, tc.max, got, tc.want)
+		}
+	}
+}
+
+func TestDisplayOrDash(t *testing.T) {
+	if got := DisplayOrDash(""); got != "-" {
+		t.Errorf("empty: got %q", got)
+	}
+	if got := DisplayOrDash("   "); got != "-" {
+		t.Errorf("whitespace: got %q", got)
+	}
+	if got := DisplayOrDash("value"); got != "value" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestNormalizeLine(t *testing.T) {
+	cases := map[string]string{
+		"  hello\nworld\n":  "hello world",
+		"a\tb\rc":           "a b c",
+		"   multi   space ": "multi space",
+		"":                  "",
+	}
+	for in, want := range cases {
+		if got := NormalizeLine(in); got != want {
+			t.Errorf("NormalizeLine(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSanitizeForFilename(t *testing.T) {
+	cases := map[string]string{
+		"simple":           "simple",
+		"foo/bar baz":      "foo-bar-baz",
+		"multiple!!chars!!":"multiple-chars",
+		"   ":              "session",
+		"":                 "session",
+		"---leading":       "leading",
+	}
+	for in, want := range cases {
+		if got := SanitizeForFilename(in); got != want {
+			t.Errorf("SanitizeForFilename(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestToRepoRelative(t *testing.T) {
+	cwd := "/repo"
+	if got := ToRepoRelative(cwd, ""); got != "" {
+		t.Errorf("empty: got %q", got)
+	}
+	if got := ToRepoRelative(cwd, "/repo/a/b.txt"); got != "a/b.txt" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractIssueID(t *testing.T) {
+	cases := map[string]string{
+		"context ag-abc123 blah":  "ag-abc123",
+		"context AG-XYZ99 blah":   "ag-xyz99",
+		"no issue here":           "",
+		"ag-alphanum99":           "ag-alphanum99",
+	}
+	for in, want := range cases {
+		if got := ExtractIssueID(in); got != want {
+			t.Errorf("ExtractIssueID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestEstimateTokensFromChars(t *testing.T) {
+	if got := EstimateTokensFromChars("", 4); got != 0 {
+		t.Errorf("empty: got %d", got)
+	}
+	if got := EstimateTokensFromChars("0123456789ab", 4); got != 3 {
+		t.Errorf("12 chars / 4 = 3; got %d", got)
+	}
+	// Small inputs round up to 1
+	if got := EstimateTokensFromChars("xy", 4); got != 1 {
+		t.Errorf("short: got %d", got)
+	}
+	// Default charsPerToken when <=0
+	if got := EstimateTokensFromChars("01234567", 0); got != 2 {
+		t.Errorf("default: got %d", got)
+	}
+}
+
+func TestParseTimestamp(t *testing.T) {
+	// RFC3339
+	ts := ParseTimestamp("2026-04-22T12:00:00Z")
+	if ts.IsZero() {
+		t.Error("valid RFC3339 should parse")
+	}
+	// RFC3339Nano
+	ts2 := ParseTimestamp("2026-04-22T12:00:00.123456789Z")
+	if ts2.IsZero() {
+		t.Error("valid RFC3339Nano should parse")
+	}
+	// Empty -> zero
+	if !ParseTimestamp("").IsZero() {
+		t.Error("empty should zero")
+	}
+	// Invalid -> zero
+	if !ParseTimestamp("not a time").IsZero() {
+		t.Error("invalid should zero")
+	}
+	// UTC
+	ts3 := ParseTimestamp("2026-04-22T14:00:00+02:00")
+	if ts3.Location() != time.UTC {
+		t.Errorf("loc = %v", ts3.Location())
+	}
+}
+
+func TestExtractTextContent_String(t *testing.T) {
+	raw := json.RawMessage(`"  hello world  "`)
+	if got := ExtractTextContent(raw); got != "hello world" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractTextContent_Array(t *testing.T) {
+	raw := json.RawMessage(`[{"type":"text","text":"first content"},{"type":"text","text":"second"}]`)
+	if got := ExtractTextContent(raw); got != "first content" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractTextContent_Empty(t *testing.T) {
+	if got := ExtractTextContent(json.RawMessage("")); got != "" {
+		t.Errorf("empty: got %q", got)
+	}
+	if got := ExtractTextContent(json.RawMessage("   ")); got != "" {
+		t.Errorf("whitespace: got %q", got)
+	}
+	// Empty array
+	if got := ExtractTextContent(json.RawMessage(`[]`)); got != "" {
+		t.Errorf("empty array: got %q", got)
+	}
+	// Invalid JSON
+	if got := ExtractTextContent(json.RawMessage("not json")); got != "" {
+		t.Errorf("invalid: got %q", got)
+	}
+}
+
+func TestScanTailLines(t *testing.T) {
+	data := []byte("line1\nline2\nline3")
+	lines, err := ScanTailLines(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 3 {
+		t.Errorf("got %d lines, want 3", len(lines))
+	}
+	if lines[0] != "line1" || lines[2] != "line3" {
+		t.Errorf("lines = %v", lines)
+	}
+}
+
+func TestReadFileTail_FullFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "f.txt")
+	_ = os.WriteFile(path, []byte("abcdef"), 0o600)
+
+	got, err := ReadFileTail(path, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "abcdef" {
+		t.Errorf("got %q", string(got))
+	}
+}
+
+func TestReadFileTail_TailsLargeFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "f.txt")
+	content := "short1\nshort2\nshort3\nshort4\n"
+	_ = os.WriteFile(path, []byte(content), 0o600)
+
+	got, err := ReadFileTail(path, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Tail should be smaller than full content
+	if len(got) > len(content) {
+		t.Errorf("tail larger than file: %d > %d", len(got), len(content))
+	}
+	// Should NOT begin mid-line (empty is valid when starting byte falls on boundary)
+	s := string(got)
+	if s != "" && strings.HasPrefix(s, "ort") {
+		t.Errorf("mid-line start: %q", s)
+	}
+}
+
+func TestReadFileTail_EmptyFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "empty.txt")
+	_ = os.WriteFile(path, []byte(""), 0o600)
+
+	got, err := ReadFileTail(path, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d bytes, want 0", len(got))
+	}
+}
+
+func TestReadFileTail_MissingFile(t *testing.T) {
+	_, err := ReadFileTail("/nonexistent/xyz.txt", 100)
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestTmuxTargetFromPaneID(t *testing.T) {
+	cases := map[string]string{
+		"":           "",
+		"in-process": "",
+		"session:window.0": "session:window",
+		"simple":     "simple",
+	}
+	for in, want := range cases {
+		if got := TmuxTargetFromPaneID(in); got != want {
+			t.Errorf("TmuxTargetFromPaneID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestTmuxSessionFromTarget(t *testing.T) {
+	cases := map[string]string{
+		"":                  "",
+		"my-session":        "my-session",
+		"my-session:window": "my-session",
+		"  spaced:win  ":    "spaced",
+	}
+	for in, want := range cases {
+		if got := TmuxSessionFromTarget(in); got != want {
+			t.Errorf("TmuxSessionFromTarget(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/cli/internal/goals/commands_test.go
+++ b/cli/internal/goals/commands_test.go
@@ -1,0 +1,757 @@
+package goals
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// chdir switches cwd and returns a cleanup function.
+func chdir(t *testing.T, dir string) func() {
+	t.Helper()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	return func() { _ = os.Chdir(prev) }
+}
+
+// writeGoalsMD writes a minimal valid GOALS.md file at path.
+func writeGoalsMD(t *testing.T, path, extra string) {
+	t.Helper()
+	content := `# Fitness Goals
+
+## Mission
+
+Test mission.
+
+## North Stars
+
+- Green CI
+
+## Anti-Stars
+
+- Untested code
+
+## Directives
+
+### 1. Establish baseline
+
+Get gates green.
+
+**Steer:** increase
+
+## Gates
+
+` + extra
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write goals: %v", err)
+	}
+}
+
+func TestOutputValidateResult_ValidNonJSON(t *testing.T) {
+	var buf bytes.Buffer
+	result := ValidateResult{Valid: true, GoalCount: 3, Version: 4, Format: "md", Directives: 2}
+	if err := OutputValidateResult(&buf, false, result); err != nil {
+		t.Fatal(err)
+	}
+	s := buf.String()
+	if !strings.Contains(s, "VALID: 3 goals") {
+		t.Errorf("output missing summary: %s", s)
+	}
+	if !strings.Contains(s, "Directives: 2") {
+		t.Errorf("output missing directives line: %s", s)
+	}
+}
+
+func TestOutputValidateResult_InvalidNonJSON(t *testing.T) {
+	var buf bytes.Buffer
+	result := ValidateResult{Valid: false, Errors: []string{"missing id"}, Warnings: []string{"no mission"}}
+	err := OutputValidateResult(&buf, false, result)
+	if err == nil {
+		t.Fatal("expected error for invalid result")
+	}
+	s := buf.String()
+	if !strings.Contains(s, "INVALID: 1 errors") {
+		t.Errorf("missing invalid header: %s", s)
+	}
+	if !strings.Contains(s, "ERROR: missing id") {
+		t.Errorf("missing error detail: %s", s)
+	}
+	if !strings.Contains(s, "WARN: no mission") {
+		t.Errorf("missing warning: %s", s)
+	}
+}
+
+func TestOutputValidateResult_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	result := ValidateResult{Valid: true, GoalCount: 2}
+	if err := OutputValidateResult(&buf, true, result); err != nil {
+		t.Fatal(err)
+	}
+	var got ValidateResult
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.GoalCount != 2 || !got.Valid {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestDirectivesFromPillars_WithPillars(t *testing.T) {
+	gs := []Goal{
+		{ID: "a", Pillar: "quality"},
+		{ID: "b", Pillar: "quality"},
+		{ID: "c", Pillar: "health"},
+	}
+	dirs := DirectivesFromPillars(gs)
+	if len(dirs) != 2 {
+		t.Fatalf("expected 2 pillars, got %d", len(dirs))
+	}
+	if dirs[0].Number != 1 {
+		t.Errorf("first number should be 1, got %d", dirs[0].Number)
+	}
+	if dirs[0].Steer != "increase" {
+		t.Errorf("default steer should be 'increase', got %q", dirs[0].Steer)
+	}
+	if !strings.Contains(dirs[0].Title, "quality") {
+		t.Errorf("title should include pillar name, got %q", dirs[0].Title)
+	}
+}
+
+func TestDirectivesFromPillars_NoPillars(t *testing.T) {
+	gs := []Goal{{ID: "a"}, {ID: "b"}}
+	dirs := DirectivesFromPillars(gs)
+	if len(dirs) != 1 {
+		t.Errorf("expected 1 default directive, got %d", len(dirs))
+	}
+}
+
+func TestFindMissingPath(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+
+	_ = os.MkdirAll("scripts", 0o755)
+	_ = os.WriteFile("scripts/real.sh", []byte("#!/bin/sh\n"), 0o600)
+
+	// Existing file -> no missing
+	if got := FindMissingPath("scripts/real.sh"); got != "" {
+		t.Errorf("expected empty for existing, got %q", got)
+	}
+	// Missing file
+	if got := FindMissingPath("scripts/missing.sh"); got != "scripts/missing.sh" {
+		t.Errorf("got %q", got)
+	}
+	// Non-script path with extension detects missing
+	if got := FindMissingPath("tests/nope.bats"); got != "tests/nope.bats" {
+		t.Errorf("tests path: got %q", got)
+	}
+	// No filesystem references
+	if got := FindMissingPath("echo hello world"); got != "" {
+		t.Errorf("pure command should have no missing, got %q", got)
+	}
+}
+
+func TestSplitCommaSeparated(t *testing.T) {
+	cases := map[string][]string{
+		"a, b, c":    {"a", "b", "c"},
+		"a,,b":       {"a", "b"},
+		"  ":         nil,
+		"":           nil,
+		"one":        {"one"},
+		"  a  ,  b ": {"a", "b"},
+	}
+	for in, want := range cases {
+		got := SplitCommaSeparated(in)
+		if len(got) != len(want) {
+			t.Errorf("%q: got %v, want %v", in, got, want)
+			continue
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("%q[%d]: got %q, want %q", in, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestValidSteers(t *testing.T) {
+	for _, s := range []string{"increase", "decrease", "hold", "explore"} {
+		if !ValidSteers[s] {
+			t.Errorf("%q should be valid", s)
+		}
+	}
+	if ValidSteers["nonsense"] {
+		t.Error("nonsense should not be valid")
+	}
+}
+
+func TestDetectGates_GoDir(t *testing.T) {
+	tmp := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(tmp, "cli"), 0o755)
+	_ = os.WriteFile(filepath.Join(tmp, "cli", "go.mod"), []byte("module x\n"), 0o600)
+
+	goals := DetectGates(tmp)
+	ids := map[string]bool{}
+	for _, g := range goals {
+		ids[g.ID] = true
+	}
+	if !ids["go-build"] || !ids["go-test"] {
+		t.Errorf("expected go gates, got %v", ids)
+	}
+}
+
+func TestDetectGates_RootGoMod(t *testing.T) {
+	tmp := t.TempDir()
+	_ = os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module x\n"), 0o600)
+
+	goals := DetectGates(tmp)
+	found := false
+	for _, g := range goals {
+		if g.Check == "go build ./..." {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("root go.mod should yield 'go build ./...', got %+v", goals)
+	}
+}
+
+func TestDetectGates_Multi(t *testing.T) {
+	tmp := t.TempDir()
+	_ = os.WriteFile(filepath.Join(tmp, "package.json"), []byte("{}"), 0o600)
+	_ = os.WriteFile(filepath.Join(tmp, "Cargo.toml"), []byte(""), 0o600)
+	_ = os.WriteFile(filepath.Join(tmp, "pyproject.toml"), []byte(""), 0o600)
+	_ = os.WriteFile(filepath.Join(tmp, "Makefile"), []byte(""), 0o600)
+
+	gates := DetectGates(tmp)
+	want := []string{"npm-test", "cargo-test", "python-test", "make-build"}
+	found := map[string]bool{}
+	for _, g := range gates {
+		found[g.ID] = true
+	}
+	for _, w := range want {
+		if !found[w] {
+			t.Errorf("missing gate %q (got %v)", w, found)
+		}
+	}
+}
+
+func TestAutoDetectTemplate(t *testing.T) {
+	cases := []struct {
+		name    string
+		marker  string
+		content string
+		want    string
+	}{
+		{"go", "go.mod", "module x\n", "go-cli"},
+		{"cli/go", "cli/go.mod", "module x\n", "go-cli"},
+		{"rust", "Cargo.toml", "", "rust-cli"},
+		{"python", "pyproject.toml", "", "python-lib"},
+		{"python setup", "setup.py", "", "python-lib"},
+		{"web", "package.json", "{}", "web-app"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			p := filepath.Join(tmp, tc.marker)
+			_ = os.MkdirAll(filepath.Dir(p), 0o755)
+			_ = os.WriteFile(p, []byte(tc.content), 0o600)
+			if got := AutoDetectTemplate(tmp); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	// No markers -> empty
+	if got := AutoDetectTemplate(t.TempDir()); got != "" {
+		t.Errorf("expected empty for no markers, got %q", got)
+	}
+}
+
+func TestLoadTemplate_ValidYAML(t *testing.T) {
+	body := `name: test
+description: testing
+gates:
+  - id: g1
+    description: gate one
+    check: echo ok
+    weight: 3
+    type: health
+`
+	fsys := fstest.MapFS{"templates/test.yaml": &fstest.MapFile{Data: []byte(body)}}
+	tmpl, err := LoadTemplate(fsys, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tmpl.Name != "test" {
+		t.Errorf("name = %q", tmpl.Name)
+	}
+	if len(tmpl.Gates) != 1 {
+		t.Fatalf("expected 1 gate, got %d", len(tmpl.Gates))
+	}
+	if tmpl.Gates[0].ID != "g1" {
+		t.Errorf("gate id = %q", tmpl.Gates[0].ID)
+	}
+}
+
+func TestLoadTemplate_Missing(t *testing.T) {
+	fsys := fstest.MapFS{}
+	if _, err := LoadTemplate(fsys, "nope"); err == nil {
+		t.Fatal("expected error for missing template")
+	}
+}
+
+func TestLoadTemplate_InvalidYAML(t *testing.T) {
+	// YAML that parses as a list, not as a GoalTemplate struct -> yaml decoder errors
+	fsys := fstest.MapFS{"templates/bad.yaml": &fstest.MapFile{Data: []byte("- just a list item\n- another\n")}}
+	_, err := LoadTemplate(fsys, "bad")
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestTemplateGatesToGoals(t *testing.T) {
+	tmpl := &GoalTemplate{Gates: []GoalTemplateGate{
+		{ID: "a", Description: "A", Check: "echo a", Weight: 1, Type: "health"},
+		{ID: "b", Description: "B", Check: "echo b", Weight: 2, Type: "quality"},
+	}}
+	goals := TemplateGatesToGoals(tmpl)
+	if len(goals) != 2 {
+		t.Fatalf("got %d", len(goals))
+	}
+	if goals[0].ID != "a" || goals[1].Type != GoalType("quality") {
+		t.Errorf("goals = %+v", goals)
+	}
+}
+
+func TestBuildInteractiveGoalFile_AllDefaults(t *testing.T) {
+	in := strings.NewReader("\n\n\n\n\n")
+	gf, err := BuildInteractiveGoalFile(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gf.Version != 4 || gf.Format != "md" {
+		t.Errorf("version/format: %d %q", gf.Version, gf.Format)
+	}
+	if gf.Mission == "" {
+		t.Error("mission should have default")
+	}
+	if len(gf.NorthStars) == 0 || len(gf.AntiStars) == 0 || len(gf.Directives) == 0 {
+		t.Errorf("defaults not populated: %+v", gf)
+	}
+	if gf.Directives[0].Steer != "increase" {
+		t.Errorf("default steer = %q", gf.Directives[0].Steer)
+	}
+}
+
+func TestBuildInteractiveGoalFile_CustomValues(t *testing.T) {
+	in := strings.NewReader("Custom mission\nNS1, NS2\nAS1\nFirst title\nFirst desc\n")
+	gf, err := BuildInteractiveGoalFile(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gf.Mission != "Custom mission" {
+		t.Errorf("mission = %q", gf.Mission)
+	}
+	if len(gf.NorthStars) != 2 || gf.NorthStars[0] != "NS1" {
+		t.Errorf("north stars = %v", gf.NorthStars)
+	}
+	if gf.Directives[0].Title != "First title" {
+		t.Errorf("title = %q", gf.Directives[0].Title)
+	}
+}
+
+func TestBuildDefaultGoalFile(t *testing.T) {
+	gf := BuildDefaultGoalFile()
+	if gf.Version != 4 || gf.Format != "md" {
+		t.Errorf("version/format")
+	}
+	if len(gf.Directives) == 0 {
+		t.Error("no directives")
+	}
+	if gf.Directives[0].Steer != "increase" {
+		t.Errorf("steer = %q", gf.Directives[0].Steer)
+	}
+}
+
+func TestRunSteerAdd_RejectsInvalidSteer(t *testing.T) {
+	opts := SteerAddOptions{Title: "x", Description: "y", Steer: "bogus"}
+	err := RunSteerAdd(opts)
+	if err == nil {
+		t.Fatal("expected error for invalid steer")
+	}
+	if !strings.Contains(err.Error(), "invalid steer") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestRunSteerAdd_AddsDirective(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+	writeGoalsMD(t, "GOALS.md", "")
+
+	var buf bytes.Buffer
+	opts := SteerAddOptions{
+		Title: "New directive", Description: "Desc", Steer: "increase",
+		GoalsFile: "GOALS.md", Stdout: &buf,
+	}
+	if err := RunSteerAdd(opts); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !strings.Contains(buf.String(), "Added directive #2") {
+		t.Errorf("output = %q", buf.String())
+	}
+	// File should now have the directive
+	data, _ := os.ReadFile("GOALS.md")
+	if !strings.Contains(string(data), "New directive") {
+		t.Errorf("file missing new directive")
+	}
+}
+
+func TestRunSteerAdd_DryRun(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+	writeGoalsMD(t, "GOALS.md", "")
+	before, _ := os.ReadFile("GOALS.md")
+
+	var buf bytes.Buffer
+	opts := SteerAddOptions{
+		Title: "Dry", Description: "Dry", Steer: "hold",
+		GoalsFile: "GOALS.md", DryRun: true, Stdout: &buf,
+	}
+	if err := RunSteerAdd(opts); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "Would add") {
+		t.Errorf("output = %q", buf.String())
+	}
+	after, _ := os.ReadFile("GOALS.md")
+	if string(before) != string(after) {
+		t.Errorf("file should be unchanged on dry-run")
+	}
+}
+
+func TestRunSteerRemove_NotFound(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+	writeGoalsMD(t, "GOALS.md", "")
+
+	opts := SteerRemoveOptions{Number: 99, GoalsFile: "GOALS.md"}
+	err := RunSteerRemove(opts)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestRunSteerRemove_RemovesAndRenumbers(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+	writeGoalsMD(t, "GOALS.md", "")
+	// Add a couple extra directives
+	var buf bytes.Buffer
+	_ = RunSteerAdd(SteerAddOptions{Title: "B", Description: "desc B", Steer: "increase", GoalsFile: "GOALS.md", Stdout: &buf})
+	_ = RunSteerAdd(SteerAddOptions{Title: "C", Description: "desc C", Steer: "hold", GoalsFile: "GOALS.md", Stdout: &buf})
+
+	buf.Reset()
+	if err := RunSteerRemove(SteerRemoveOptions{Number: 1, GoalsFile: "GOALS.md", Stdout: &buf}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "Removed directive #1") {
+		t.Errorf("output = %q", buf.String())
+	}
+}
+
+func TestRunSteerPrioritize_InvalidPosition(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+	writeGoalsMD(t, "GOALS.md", "")
+
+	err := RunSteerPrioritize(SteerPrioritizeOptions{Number: 1, NewPosition: 99, GoalsFile: "GOALS.md"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "between 1 and") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestRunSteerPrioritize_NumberNotFound(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+	writeGoalsMD(t, "GOALS.md", "")
+
+	err := RunSteerPrioritize(SteerPrioritizeOptions{Number: 5, NewPosition: 1, GoalsFile: "GOALS.md"})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestRunSteerPrioritize_Moves(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+	writeGoalsMD(t, "GOALS.md", "")
+
+	var buf bytes.Buffer
+	_ = RunSteerAdd(SteerAddOptions{Title: "Second", Description: "d", Steer: "increase", GoalsFile: "GOALS.md", Stdout: &buf})
+	_ = RunSteerAdd(SteerAddOptions{Title: "Third", Description: "d", Steer: "hold", GoalsFile: "GOALS.md", Stdout: &buf})
+
+	buf.Reset()
+	// Move directive 3 (Third) to position 1
+	err := RunSteerPrioritize(SteerPrioritizeOptions{Number: 3, NewPosition: 1, GoalsFile: "GOALS.md", Stdout: &buf})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "Moved directive") {
+		t.Errorf("output = %q", buf.String())
+	}
+}
+
+func TestRunValidate_ValidFile(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+	writeGoalsMD(t, "GOALS.md", `
+
+### build
+**Weight:** 5
+**Type:** health
+
+`+"```bash\ntrue\n```\n")
+
+	var buf bytes.Buffer
+	if err := RunValidate(ValidateOptions{GoalsFile: "GOALS.md", Stdout: &buf}); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !strings.Contains(buf.String(), "VALID") {
+		t.Errorf("output = %q", buf.String())
+	}
+}
+
+func TestRunValidate_MissingFile(t *testing.T) {
+	var buf bytes.Buffer
+	err := RunValidate(ValidateOptions{GoalsFile: "/nope/nonexistent.md", Stdout: &buf})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// Output should contain "INVALID"
+	if !strings.Contains(buf.String(), "INVALID") {
+		t.Errorf("output should contain INVALID, got %q", buf.String())
+	}
+}
+
+func TestRunPrune_NoStale(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+	writeGoalsMD(t, "GOALS.md", `
+
+### health
+**Weight:** 5
+
+`+"```bash\ntrue\n```\n")
+
+	var buf bytes.Buffer
+	err := RunPrune(PruneOptions{GoalsFile: "GOALS.md", DryRun: true, Stdout: &buf})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !strings.Contains(buf.String(), "No stale goals") {
+		t.Errorf("output = %q", buf.String())
+	}
+}
+
+func TestRunPrune_DryRunDoesNotModify(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+	writeGoalsMD(t, "GOALS.md", `
+
+### stale-gate
+**Weight:** 5
+
+`+"```bash\nscripts/nonexistent-script.sh\n```\n")
+
+	before, _ := os.ReadFile("GOALS.md")
+	var buf bytes.Buffer
+	if err := RunPrune(PruneOptions{GoalsFile: "GOALS.md", DryRun: true, Stdout: &buf}); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !strings.Contains(buf.String(), "stale goal") {
+		t.Errorf("expected stale detected, got %q", buf.String())
+	}
+	after, _ := os.ReadFile("GOALS.md")
+	if string(before) != string(after) {
+		t.Errorf("dry-run modified file")
+	}
+}
+
+func TestRunMigrate_YAMLv1ToV2(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+
+	// v1 YAML
+	yaml := `version: 1
+goals:
+  - id: g1
+    description: desc
+    check: "true"
+    weight: 5
+`
+	if err := os.WriteFile("GOALS.yaml", []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	// Note: LoadGoals emits a warning on v1 via stderr. Suppress by redirecting stderr isn't needed for test assertion.
+	err := RunMigrate(MigrateOptions{ToMD: false, GoalsFile: "GOALS.yaml", Stdout: &buf})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if _, err := os.Stat("GOALS.yaml.v1.bak"); err != nil {
+		t.Errorf("expected backup: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Migrated") {
+		t.Errorf("output = %q", buf.String())
+	}
+}
+
+func TestRunMigrate_AlreadyV2(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+
+	yaml := `version: 2
+goals:
+  - id: g1
+    description: desc
+    check: "true"
+    weight: 5
+`
+	_ = os.WriteFile("GOALS.yaml", []byte(yaml), 0o600)
+
+	var buf bytes.Buffer
+	err := RunMigrate(MigrateOptions{ToMD: false, GoalsFile: "GOALS.yaml", Stdout: &buf})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "no migration needed") {
+		t.Errorf("output = %q", buf.String())
+	}
+}
+
+func TestRunInit_CreatesFile(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+
+	var buf bytes.Buffer
+	err := RunInit(InitOptions{
+		NonInteractive: true,
+		GoalsFile:      "GOALS.md",
+		Stdout:         &buf,
+		Stdin:          strings.NewReader(""),
+	})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if _, err := os.Stat("GOALS.md"); err != nil {
+		t.Errorf("file not created: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Created") {
+		t.Errorf("output = %q", buf.String())
+	}
+}
+
+func TestRunInit_FailsIfExists(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+	_ = os.WriteFile("GOALS.md", []byte("existing"), 0o600)
+
+	var buf bytes.Buffer
+	err := RunInit(InitOptions{NonInteractive: true, GoalsFile: "GOALS.md", Stdout: &buf})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestRunInit_DryRun(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+
+	var buf bytes.Buffer
+	err := RunInit(InitOptions{
+		NonInteractive: true, DryRun: true, GoalsFile: "GOALS.md", Stdout: &buf,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat("GOALS.md"); err == nil {
+		t.Errorf("dry-run should not create file")
+	}
+	if !strings.Contains(buf.String(), "Would write") {
+		t.Errorf("output = %q", buf.String())
+	}
+}
+
+func TestRunInit_WithTemplate(t *testing.T) {
+	tmp := t.TempDir()
+	cleanup := chdir(t, tmp)
+	defer cleanup()
+
+	tmplBody := `name: test
+gates:
+  - id: t1
+    description: template gate
+    check: "true"
+    weight: 3
+    type: health
+`
+	fsys := fstest.MapFS{"templates/test.yaml": &fstest.MapFile{Data: []byte(tmplBody)}}
+
+	var buf bytes.Buffer
+	err := RunInit(InitOptions{
+		NonInteractive: true,
+		Template:       "test",
+		GoalsFile:      "GOALS.md",
+		Stdout:         &buf,
+		TemplatesFS:    readFileFSAdapter{fsys},
+	})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	data, _ := os.ReadFile("GOALS.md")
+	if !strings.Contains(string(data), "t1") {
+		t.Errorf("template gate not present: %s", string(data))
+	}
+}
+
+// readFileFSAdapter adapts an fs.FS (MapFS implements fs.ReadFileFS already, but
+// this keeps the interface explicit at call sites).
+type readFileFSAdapter struct{ fs.FS }
+
+func (a readFileFSAdapter) ReadFile(name string) ([]byte, error) {
+	return fs.ReadFile(a.FS, name)
+}

--- a/cli/internal/goals/measure_platform_test.go
+++ b/cli/internal/goals/measure_platform_test.go
@@ -1,0 +1,86 @@
+package goals
+
+import (
+	"os/exec"
+	"runtime"
+	"testing"
+)
+
+func TestConfigureProcGroup_SetsSysProcAttr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// On Windows configureProcGroup is a different implementation;
+		// this test exercises the POSIX path.
+		t.Skip("POSIX-specific behavior tested elsewhere on Windows")
+	}
+	cmd := exec.Command("true")
+	configureProcGroup(cmd)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr should be set on POSIX")
+	}
+	if cmd.Cancel == nil {
+		t.Error("Cancel should be set on POSIX")
+	}
+}
+
+func TestConfigureProcGroup_CancelHandlesNilProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX-specific behavior")
+	}
+	cmd := exec.Command("true")
+	configureProcGroup(cmd)
+	// Process is nil until Start() is called; Cancel must tolerate that.
+	if err := cmd.Cancel(); err != nil {
+		t.Errorf("Cancel with nil Process should return nil, got %v", err)
+	}
+}
+
+func TestTrackAndUntrackChild(t *testing.T) {
+	// Record state
+	childGroups.mu.Lock()
+	before := len(childGroups.pids)
+	childGroups.mu.Unlock()
+
+	trackChild(99999)
+	childGroups.mu.Lock()
+	_, tracked := childGroups.pids[99999]
+	afterAdd := len(childGroups.pids)
+	childGroups.mu.Unlock()
+	if !tracked {
+		t.Error("should be tracked")
+	}
+	if afterAdd != before+1 {
+		t.Errorf("count: %d -> %d", before, afterAdd)
+	}
+
+	untrackChild(99999)
+	childGroups.mu.Lock()
+	_, stillTracked := childGroups.pids[99999]
+	afterRemove := len(childGroups.pids)
+	childGroups.mu.Unlock()
+	if stillTracked {
+		t.Error("should be untracked")
+	}
+	if afterRemove != before {
+		t.Errorf("count not restored: %d != %d", afterRemove, before)
+	}
+}
+
+func TestKillAllChildren_EmptiesMap(t *testing.T) {
+	// Use a fake PID that won't match any running process group.
+	// killAllChildren tries kill(-pid, SIGKILL) which silently errors here
+	// (the PID doesn't exist); but importantly it should clear the map.
+	trackChild(99998)
+	killAllChildren()
+
+	childGroups.mu.Lock()
+	_, stillTracked := childGroups.pids[99998]
+	mapLen := len(childGroups.pids)
+	childGroups.mu.Unlock()
+
+	if stillTracked {
+		t.Error("killAllChildren should remove pids from map")
+	}
+	if mapLen != 0 {
+		t.Errorf("map should be empty after killAllChildren, got %d entries", mapLen)
+	}
+}

--- a/cli/internal/lifecycle/curate_test.go
+++ b/cli/internal/lifecycle/curate_test.go
@@ -1,0 +1,217 @@
+package lifecycle
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestParseFrontmatter_Basic(t *testing.T) {
+	doc := "---\nid: abc\nutility: 0.8\n---\nbody goes here\n"
+	fm, body := ParseFrontmatter(doc)
+	if fm["id"] != "abc" {
+		t.Errorf("id = %v", fm["id"])
+	}
+	if body != "body goes here" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestParseFrontmatter_NoFrontmatter(t *testing.T) {
+	doc := "just a body\n"
+	fm, body := ParseFrontmatter(doc)
+	if len(fm) != 0 {
+		t.Errorf("fm should be empty, got %v", fm)
+	}
+	if body != doc {
+		t.Errorf("body should equal input")
+	}
+}
+
+func TestParseFrontmatter_UnclosedDelimiter(t *testing.T) {
+	doc := "---\nid: abc\nno close here"
+	fm, body := ParseFrontmatter(doc)
+	if len(fm) != 0 {
+		t.Errorf("fm should be empty when delimiter unclosed, got %v", fm)
+	}
+	if body != doc {
+		t.Errorf("body should equal input when no close delimiter")
+	}
+}
+
+func TestParseFrontmatter_InvalidYAML(t *testing.T) {
+	doc := "---\nid: [unclosed\n---\nbody\n"
+	fm, body := ParseFrontmatter(doc)
+	if len(fm) != 0 {
+		t.Errorf("invalid yaml should produce empty fm, got %v", fm)
+	}
+	if body != "body" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestFrontmatterString_Types(t *testing.T) {
+	now := time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC)
+	fm := map[string]any{
+		"s":    "hello",
+		"n":    42,
+		"time": now,
+		"nil":  nil,
+	}
+	if got := FrontmatterString(fm, "s"); got != "hello" {
+		t.Errorf("string = %q", got)
+	}
+	if got := FrontmatterString(fm, "n"); got != "42" {
+		t.Errorf("int = %q", got)
+	}
+	if got := FrontmatterString(fm, "time"); got != "2026-04-22" {
+		t.Errorf("time = %q", got)
+	}
+	if got := FrontmatterString(fm, "missing"); got != "" {
+		t.Errorf("missing = %q", got)
+	}
+	if got := FrontmatterString(fm, "nil"); got != "" {
+		t.Errorf("nil = %q", got)
+	}
+}
+
+func TestGenerateArtifactID_DeterministicAndPrefixed(t *testing.T) {
+	a := GenerateArtifactID("learning", "2026-04-22", "hello world")
+	b := GenerateArtifactID("learning", "2026-04-22", "hello world")
+	if a != b {
+		t.Errorf("ID should be deterministic; got %q vs %q", a, b)
+	}
+	if a[:6] != "learn-" {
+		t.Errorf("ID should be prefixed with 'learn-', got %q", a)
+	}
+
+	c := GenerateArtifactID("decision", "2026-04-22", "hello world")
+	if c[:6] != "decis-" {
+		t.Errorf("decision prefix, got %q", c)
+	}
+	f := GenerateArtifactID("failure", "2026-04-22", "x")
+	if f[:5] != "fail-" {
+		t.Errorf("failure prefix, got %q", f)
+	}
+	p := GenerateArtifactID("pattern", "2026-04-22", "x")
+	if p[:5] != "patt-" {
+		t.Errorf("pattern prefix, got %q", p)
+	}
+}
+
+func TestGenerateArtifactID_DifferentContent(t *testing.T) {
+	a := GenerateArtifactID("learning", "2026-04-22", "one")
+	b := GenerateArtifactID("learning", "2026-04-22", "two")
+	if a == b {
+		t.Error("different content should yield different IDs")
+	}
+}
+
+func TestArtifactDir(t *testing.T) {
+	if ArtifactDir("pattern") != ".agents/patterns" {
+		t.Errorf("pattern dir wrong")
+	}
+	if ArtifactDir("learning") != ".agents/learnings" {
+		t.Errorf("learning dir wrong")
+	}
+	if ArtifactDir("decision") != ".agents/learnings" {
+		t.Errorf("decision dir should default to learnings")
+	}
+}
+
+func TestResolveCurateGoalsFile_FindsFirst(t *testing.T) {
+	tmp := t.TempDir()
+	wd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(wd) }()
+	_ = os.Chdir(tmp)
+
+	if _, err := ResolveCurateGoalsFile(); err == nil {
+		t.Fatalf("expected error when no goals file present")
+	}
+
+	if err := os.WriteFile("GOALS.md", []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ResolveCurateGoalsFile()
+	if err != nil {
+		t.Fatalf("ResolveCurateGoalsFile: %v", err)
+	}
+	if got != "GOALS.md" {
+		t.Errorf("got %q, want GOALS.md", got)
+	}
+}
+
+func TestCountArtifactsInDir(t *testing.T) {
+	tmp := t.TempDir()
+
+	writeArtifact := func(name, typeStr, curatedAt string) {
+		a := CurateArtifact{ID: name, Type: typeStr, CuratedAt: curatedAt}
+		data, _ := json.Marshal(a)
+		if err := os.WriteFile(filepath.Join(tmp, name+".json"), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeArtifact("l1", "learning", "2026-04-20T10:00:00Z")
+	writeArtifact("l2", "learning", "2026-04-22T10:00:00Z")
+	writeArtifact("d1", "decision", "2026-04-21T10:00:00Z")
+
+	_ = os.WriteFile(filepath.Join(tmp, "not-json.txt"), []byte("x"), 0o600)
+
+	counts, latest := CountArtifactsInDir(tmp)
+	if counts["learning"] != 2 {
+		t.Errorf("learning count = %d, want 2", counts["learning"])
+	}
+	if counts["decision"] != 1 {
+		t.Errorf("decision count = %d, want 1", counts["decision"])
+	}
+	expected, _ := time.Parse(time.RFC3339, "2026-04-22T10:00:00Z")
+	if !latest.Equal(expected) {
+		t.Errorf("latest = %v, want %v", latest, expected)
+	}
+}
+
+func TestCountArtifactsInDir_NonExistentDir(t *testing.T) {
+	counts, latest := CountArtifactsInDir("/nonexistent/path/xyz")
+	if len(counts) != 0 {
+		t.Errorf("counts should be empty, got %v", counts)
+	}
+	if !latest.IsZero() {
+		t.Errorf("latest should be zero, got %v", latest)
+	}
+}
+
+func TestCountArtifactsSince(t *testing.T) {
+	tmp := t.TempDir()
+	learnDir := filepath.Join(tmp, "learnings")
+	patDir := filepath.Join(tmp, "patterns")
+	_ = os.MkdirAll(learnDir, 0o755)
+	_ = os.MkdirAll(patDir, 0o755)
+
+	writeArt := func(dir, name, ts string) {
+		a := CurateArtifact{ID: name, Type: "learning", CuratedAt: ts}
+		data, _ := json.Marshal(a)
+		_ = os.WriteFile(filepath.Join(dir, name+".json"), data, 0o600)
+	}
+	writeArt(learnDir, "old", "2026-04-01T00:00:00Z")
+	writeArt(learnDir, "new", "2026-04-22T00:00:00Z")
+	writeArt(patDir, "newpat", "2026-04-23T00:00:00Z")
+
+	since, _ := time.Parse(time.RFC3339, "2026-04-15T00:00:00Z")
+	count := CountArtifactsSince(learnDir, patDir, since)
+	if count != 2 {
+		t.Errorf("count since = %d, want 2", count)
+	}
+}
+
+func TestValidArtifactTypes(t *testing.T) {
+	for _, t1 := range []string{"learning", "decision", "failure", "pattern"} {
+		if !ValidArtifactTypes[t1] {
+			t.Errorf("%q should be valid", t1)
+		}
+	}
+	if ValidArtifactTypes["bogus"] {
+		t.Error("'bogus' should not be valid")
+	}
+}

--- a/cli/internal/lifecycle/dedup_test.go
+++ b/cli/internal/lifecycle/dedup_test.go
@@ -1,0 +1,290 @@
+package lifecycle
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestCollectDedupFiles_NoDirs(t *testing.T) {
+	tmp := t.TempDir()
+	files, err := CollectDedupFiles(tmp)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if files != nil {
+		t.Errorf("expected nil for empty dirs, got %v", files)
+	}
+}
+
+func TestCollectDedupFiles_WithFiles(t *testing.T) {
+	tmp := t.TempDir()
+	learnings := filepath.Join(tmp, ".agents", "learnings")
+	patterns := filepath.Join(tmp, ".agents", "patterns")
+	if err := os.MkdirAll(learnings, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(patterns, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writes := []string{
+		filepath.Join(learnings, "a.md"),
+		filepath.Join(learnings, "b.jsonl"),
+		filepath.Join(patterns, "p.md"),
+		filepath.Join(learnings, "ignore.txt"),
+	}
+	for _, f := range writes {
+		if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files, err := CollectDedupFiles(tmp)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(files) != 3 {
+		t.Errorf("expected 3 artifact files, got %d: %v", len(files), files)
+	}
+}
+
+func TestHashNormalizedContent_NormalizesWhitespaceAndCase(t *testing.T) {
+	a := HashNormalizedContent("Hello   World")
+	b := HashNormalizedContent("hello world")
+	if a != b {
+		t.Errorf("normalization should equate %q and %q", "Hello   World", "hello world")
+	}
+	c := HashNormalizedContent("# heading **bold** `code`")
+	d := HashNormalizedContent("heading bold code")
+	if c != d {
+		t.Errorf("markdown punctuation should be normalized away")
+	}
+}
+
+func TestExtractMarkdownBody(t *testing.T) {
+	text := "---\nutility: 0.5\n---\nthe body\nmore body\n"
+	body := ExtractMarkdownBody(text)
+	if strings.Contains(body, "utility") {
+		t.Errorf("body should not contain frontmatter, got %q", body)
+	}
+	if !strings.Contains(body, "the body") {
+		t.Errorf("body missing content, got %q", body)
+	}
+
+	// No frontmatter -> returns original
+	plain := "just text\n"
+	if ExtractMarkdownBody(plain) != plain {
+		t.Errorf("no frontmatter should return original")
+	}
+}
+
+func TestExtractJSONLBody(t *testing.T) {
+	body := ExtractJSONLBody(`{"content":"the content","title":"a title"}`)
+	if body != "the content" {
+		t.Errorf("content key preferred, got %q", body)
+	}
+
+	body2 := ExtractJSONLBody(`{"title":"only title"}`)
+	if body2 != "only title" {
+		t.Errorf("title fallback, got %q", body2)
+	}
+
+	if ExtractJSONLBody("not json") != "" {
+		t.Errorf("invalid json should return empty")
+	}
+	if ExtractJSONLBody("") != "" {
+		t.Errorf("empty should return empty")
+	}
+}
+
+func TestReadUtilityFromFrontmatter(t *testing.T) {
+	good := "---\nutility: 0.75\nmaturity: candidate\n---\nbody\n"
+	if got := ReadUtilityFromFrontmatter(good, 0.5); got != 0.75 {
+		t.Errorf("got %v, want 0.75", got)
+	}
+
+	missing := "---\nmaturity: candidate\n---\nbody\n"
+	if got := ReadUtilityFromFrontmatter(missing, 0.5); got != 0.5 {
+		t.Errorf("missing should return default, got %v", got)
+	}
+
+	noFM := "just body"
+	if got := ReadUtilityFromFrontmatter(noFM, 0.42); got != 0.42 {
+		t.Errorf("no frontmatter should return default, got %v", got)
+	}
+}
+
+func TestReadUtilityFromJSONL(t *testing.T) {
+	if got := ReadUtilityFromJSONL(`{"utility":0.9}`, 0.5); got != 0.9 {
+		t.Errorf("float: got %v", got)
+	}
+	if got := ReadUtilityFromJSONL(`{"utility":"0.3"}`, 0.5); got != 0.3 {
+		t.Errorf("string-encoded float: got %v", got)
+	}
+	if got := ReadUtilityFromJSONL(`not json`, 0.5); got != 0.5 {
+		t.Errorf("invalid json: got %v", got)
+	}
+	if got := ReadUtilityFromJSONL(`{"other":1}`, 0.5); got != 0.5 {
+		t.Errorf("missing utility: got %v", got)
+	}
+}
+
+func TestReadUtilityFromFile(t *testing.T) {
+	tmp := t.TempDir()
+	mdPath := filepath.Join(tmp, "a.md")
+	jsonlPath := filepath.Join(tmp, "a.jsonl")
+
+	if err := os.WriteFile(mdPath, []byte("---\nutility: 0.8\n---\nbody\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(jsonlPath, []byte(`{"utility":0.2}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := ReadUtilityFromFile(mdPath); got != 0.8 {
+		t.Errorf("md utility: got %v, want 0.8", got)
+	}
+	if got := ReadUtilityFromFile(jsonlPath); got != 0.2 {
+		t.Errorf("jsonl utility: got %v, want 0.2", got)
+	}
+	if got := ReadUtilityFromFile(filepath.Join(tmp, "missing.md")); got != 0.5 {
+		t.Errorf("missing file should return default, got %v", got)
+	}
+}
+
+func TestPickHighestUtility(t *testing.T) {
+	tmp := t.TempDir()
+	files := []string{
+		filepath.Join(tmp, "a.md"),
+		filepath.Join(tmp, "b.md"),
+		filepath.Join(tmp, "c.md"),
+	}
+	contents := map[string]string{
+		files[0]: "---\nutility: 0.3\n---\nbody\n",
+		files[1]: "---\nutility: 0.9\n---\nbody\n",
+		files[2]: "---\nutility: 0.5\n---\nbody\n",
+	}
+	for p, c := range contents {
+		if err := os.WriteFile(p, []byte(c), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	kept, archived := PickHighestUtility(files)
+	if kept != files[1] {
+		t.Errorf("kept = %q, want %q", kept, files[1])
+	}
+	if len(archived) != 2 {
+		t.Errorf("archived len = %d, want 2", len(archived))
+	}
+}
+
+func TestGroupByContentHash_GroupsDuplicates(t *testing.T) {
+	tmp := t.TempDir()
+	a := filepath.Join(tmp, "a.md")
+	b := filepath.Join(tmp, "b.md")
+	c := filepath.Join(tmp, "c.md")
+	_ = os.WriteFile(a, []byte("---\n---\nsame body content here\n"), 0o600)
+	_ = os.WriteFile(b, []byte("---\n---\nSame Body Content Here\n"), 0o600)
+	_ = os.WriteFile(c, []byte("---\n---\nentirely different stuff\n"), 0o600)
+
+	groups := GroupByContentHash([]string{a, b, c})
+	if len(groups) != 2 {
+		t.Errorf("expected 2 hash buckets, got %d", len(groups))
+	}
+	dupCount := 0
+	for _, files := range groups {
+		if len(files) > 1 {
+			dupCount++
+		}
+	}
+	if dupCount != 1 {
+		t.Errorf("expected 1 duplicate group, got %d", dupCount)
+	}
+}
+
+func TestBuildDedupResult(t *testing.T) {
+	tmp := t.TempDir()
+	a := filepath.Join(tmp, "a.md")
+	b := filepath.Join(tmp, "b.md")
+	c := filepath.Join(tmp, "c.md")
+	for _, p := range []string{a, b, c} {
+		_ = os.WriteFile(p, []byte("x"), 0o600)
+	}
+
+	hashes := map[string][]string{
+		"hash1234567890abcdef": {a, b},
+		"hash9999999999999999": {c},
+	}
+	r := BuildDedupResult(hashes, 3, tmp)
+	if r.TotalFiles != 3 {
+		t.Errorf("TotalFiles = %d", r.TotalFiles)
+	}
+	if r.UniqueContent != 2 {
+		t.Errorf("UniqueContent = %d", r.UniqueContent)
+	}
+	if r.DuplicateGroups != 1 {
+		t.Errorf("DuplicateGroups = %d", r.DuplicateGroups)
+	}
+	if r.DuplicateFiles != 2 {
+		t.Errorf("DuplicateFiles = %d", r.DuplicateFiles)
+	}
+	if len(r.Groups) != 1 {
+		t.Errorf("Groups len = %d", len(r.Groups))
+	}
+	if len(r.Groups) > 0 && len(r.Groups[0].Hash) != 12 {
+		t.Errorf("Hash should be truncated to 12 chars, got %q", r.Groups[0].Hash)
+	}
+}
+
+func TestMergeDedupGroups_DryRun(t *testing.T) {
+	tmp := t.TempDir()
+	a := filepath.Join(tmp, "a.md")
+	b := filepath.Join(tmp, "b.md")
+	_ = os.WriteFile(a, []byte("---\nutility: 0.3\n---\nbody\n"), 0o600)
+	_ = os.WriteFile(b, []byte("---\nutility: 0.7\n---\nbody\n"), 0o600)
+
+	groups := map[string][]string{"h": {a, b}}
+	if err := MergeDedupGroups(groups, tmp, true); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+
+	// In dry-run both files should still exist
+	if _, err := os.Stat(a); err != nil {
+		t.Errorf("a should still exist: %v", err)
+	}
+	if _, err := os.Stat(b); err != nil {
+		t.Errorf("b should still exist: %v", err)
+	}
+	archiveDir := filepath.Join(tmp, ".agents", "archive", "dedup")
+	if _, err := os.Stat(archiveDir); err == nil {
+		t.Errorf("dry-run should not create archive dir")
+	}
+}
+
+func TestMergeDedupGroups_ActuallyArchives(t *testing.T) {
+	tmp := t.TempDir()
+	a := filepath.Join(tmp, "a.md")
+	b := filepath.Join(tmp, "b.md")
+	_ = os.WriteFile(a, []byte("---\nutility: 0.9\n---\nbody\n"), 0o600)
+	_ = os.WriteFile(b, []byte("---\nutility: 0.1\n---\nbody\n"), 0o600)
+
+	groups := map[string][]string{"h": {a, b}}
+	if err := MergeDedupGroups(groups, tmp, false); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+
+	// Highest utility (a) should be kept
+	if _, err := os.Stat(a); err != nil {
+		t.Errorf("a should still exist: %v", err)
+	}
+	if _, err := os.Stat(b); err == nil {
+		t.Errorf("b should have been archived")
+	}
+	archived := filepath.Join(tmp, ".agents", "archive", "dedup", "b.md")
+	if _, err := os.Stat(archived); err != nil {
+		t.Errorf("b should exist at archive path %q: %v", archived, err)
+	}
+}
+
+// unused sort import guard
+var _ = sort.Strings

--- a/cli/internal/lifecycle/defrag_test.go
+++ b/cli/internal/lifecycle/defrag_test.go
@@ -1,0 +1,270 @@
+package lifecycle
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIsHashNamed(t *testing.T) {
+	cases := map[string]bool{
+		"2026-02-23-4556c2b4.md":        true,
+		"2026-02-23-ABCDEF12.md":        false, // uppercase hex not accepted
+		"2026-02-23-name.md":            false,
+		"just-four-part-x.md":           false,
+		"2026-02-23-4556c2b4aabbccdd.md": false, // too long last part
+		"a-b-c.md":                      false, // only 3 parts
+	}
+	for name, want := range cases {
+		if got := IsHashNamed(name); got != want {
+			t.Errorf("IsHashNamed(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestBuildTrigrams(t *testing.T) {
+	tg := BuildTrigrams("abcd")
+	if len(tg) != 2 {
+		t.Errorf("expected 2 trigrams, got %d: %v", len(tg), tg)
+	}
+	if !tg["abc"] || !tg["bcd"] {
+		t.Errorf("missing expected trigrams: %v", tg)
+	}
+
+	empty := BuildTrigrams("")
+	if len(empty) != 0 {
+		t.Errorf("empty input should yield 0 trigrams")
+	}
+	short := BuildTrigrams("ab")
+	if len(short) != 0 {
+		t.Errorf("input <3 chars should yield 0 trigrams")
+	}
+}
+
+func TestTrigramOverlap(t *testing.T) {
+	a := BuildTrigrams("abcdef")
+	b := BuildTrigrams("abcdef")
+	if got := TrigramOverlap(a, b); got != 1.0 {
+		t.Errorf("identical overlap = %v, want 1.0", got)
+	}
+
+	c := BuildTrigrams("xyz123")
+	if got := TrigramOverlap(a, c); got != 0 {
+		t.Errorf("disjoint overlap = %v, want 0", got)
+	}
+
+	// Empty maps
+	empty := map[string]bool{}
+	if got := TrigramOverlap(empty, empty); got != 0 {
+		t.Errorf("empty×empty = %v, want 0", got)
+	}
+}
+
+func TestCountAlternations(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []string
+		want    int
+	}{
+		{"empty", []string{}, 0},
+		{"single", []string{"improved"}, 0},
+		{"no alternation", []string{"improved", "improved", "improved"}, 0},
+		{"two alternations", []string{"improved", "fail", "improved"}, 2},
+		{"three alternations", []string{"improved", "fail", "improved", "fail"}, 3},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			records := make([]CycleRecord, len(tc.results))
+			for i, r := range tc.results {
+				records[i] = CycleRecord{Cycle: i, Result: r}
+			}
+			if got := CountAlternations(records); got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSweepOscillatingGoals_NoHistory(t *testing.T) {
+	tmp := t.TempDir()
+	r, err := SweepOscillatingGoals(tmp)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(r.OscillatingGoals) != 0 {
+		t.Errorf("expected empty, got %v", r.OscillatingGoals)
+	}
+}
+
+func TestSweepOscillatingGoals_DetectsOscillation(t *testing.T) {
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, ".agents", "evolve")
+	_ = os.MkdirAll(dir, 0o755)
+	path := filepath.Join(dir, "cycle-history.jsonl")
+
+	records := []CycleRecord{
+		{Cycle: 1, Target: "g1", Result: "improved"},
+		{Cycle: 2, Target: "g1", Result: "fail"},
+		{Cycle: 3, Target: "g1", Result: "improved"},
+		{Cycle: 4, Target: "g1", Result: "fail"},
+		{Cycle: 1, Target: "g2", Result: "improved"},
+		{Cycle: 2, Target: "g2", Result: "improved"},
+	}
+	var sb strings.Builder
+	for _, r := range records {
+		data, _ := json.Marshal(r)
+		sb.Write(data)
+		sb.WriteByte('\n')
+	}
+	_ = os.WriteFile(path, []byte(sb.String()), 0o600)
+
+	result, err := SweepOscillatingGoals(tmp)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(result.OscillatingGoals) != 1 {
+		t.Fatalf("expected 1 oscillating goal, got %d: %+v", len(result.OscillatingGoals), result.OscillatingGoals)
+	}
+	if result.OscillatingGoals[0].Target != "g1" {
+		t.Errorf("target = %q, want g1", result.OscillatingGoals[0].Target)
+	}
+	if result.OscillatingGoals[0].AlternationCount < 3 {
+		t.Errorf("alternations = %d, want >=3", result.OscillatingGoals[0].AlternationCount)
+	}
+}
+
+func TestFindOrphanLearnings_NoLearnings(t *testing.T) {
+	tmp := t.TempDir()
+	r, err := FindOrphanLearnings(tmp, 30)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if r.TotalLearnings != 0 {
+		t.Errorf("TotalLearnings = %d", r.TotalLearnings)
+	}
+}
+
+func TestFindOrphanLearnings_DetectsOrphan(t *testing.T) {
+	tmp := t.TempDir()
+	learnDir := filepath.Join(tmp, ".agents", "learnings")
+	patDir := filepath.Join(tmp, ".agents", "patterns")
+	_ = os.MkdirAll(learnDir, 0o755)
+	_ = os.MkdirAll(patDir, 0o755)
+
+	orphanName := "orphan-learning.md"
+	orphanPath := filepath.Join(learnDir, orphanName)
+	if err := os.WriteFile(orphanPath, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Make it stale (older than cutoff)
+	old := time.Now().AddDate(0, 0, -60)
+	_ = os.Chtimes(orphanPath, old, old)
+
+	referencedName := "linked.md"
+	refPath := filepath.Join(learnDir, referencedName)
+	_ = os.WriteFile(refPath, []byte("x"), 0o600)
+	_ = os.Chtimes(refPath, old, old)
+
+	// Pattern references the linked file
+	_ = os.WriteFile(filepath.Join(patDir, "p1.md"), []byte("see linked.md"), 0o600)
+
+	r, err := FindOrphanLearnings(tmp, 30)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if r.TotalLearnings != 2 {
+		t.Errorf("TotalLearnings = %d, want 2", r.TotalLearnings)
+	}
+	if r.StaleCount != 2 {
+		t.Errorf("StaleCount = %d, want 2", r.StaleCount)
+	}
+	// Only orphan is an orphan (linked is referenced)
+	if len(r.Orphans) != 1 {
+		t.Errorf("Orphans = %v, want len 1", r.Orphans)
+	}
+	if len(r.Orphans) > 0 && !strings.HasSuffix(r.Orphans[0], orphanName) {
+		t.Errorf("orphan should be %q, got %v", orphanName, r.Orphans)
+	}
+}
+
+func TestExecutePrune_DryRunKeepsFiles(t *testing.T) {
+	tmp := t.TempDir()
+	learnDir := filepath.Join(tmp, ".agents", "learnings")
+	_ = os.MkdirAll(learnDir, 0o755)
+	orphan := filepath.Join(learnDir, "orphan.md")
+	_ = os.WriteFile(orphan, []byte("x"), 0o600)
+	old := time.Now().AddDate(0, 0, -60)
+	_ = os.Chtimes(orphan, old, old)
+
+	r, err := ExecutePrune(tmp, true, 30)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(r.Orphans) != 1 {
+		t.Errorf("should detect 1 orphan, got %d", len(r.Orphans))
+	}
+	if len(r.Deleted) != 0 {
+		t.Errorf("dry-run should not delete; got %v", r.Deleted)
+	}
+	if _, err := os.Stat(orphan); err != nil {
+		t.Errorf("file should still exist after dry-run")
+	}
+}
+
+func TestExecutePrune_ActuallyDeletes(t *testing.T) {
+	tmp := t.TempDir()
+	learnDir := filepath.Join(tmp, ".agents", "learnings")
+	_ = os.MkdirAll(learnDir, 0o755)
+	orphan := filepath.Join(learnDir, "orphan.md")
+	_ = os.WriteFile(orphan, []byte("x"), 0o600)
+	old := time.Now().AddDate(0, 0, -60)
+	_ = os.Chtimes(orphan, old, old)
+
+	r, err := ExecutePrune(tmp, false, 30)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(r.Deleted) != 1 {
+		t.Errorf("expected 1 deletion, got %v", r.Deleted)
+	}
+	if _, err := os.Stat(orphan); err == nil {
+		t.Errorf("orphan should be deleted")
+	}
+}
+
+func TestFindDuplicateLearnings_NoDir(t *testing.T) {
+	tmp := t.TempDir()
+	r, err := FindDuplicateLearnings(tmp)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if r.Checked != 0 {
+		t.Errorf("Checked = %d", r.Checked)
+	}
+}
+
+func TestFindDuplicateLearnings_DetectsNearDup(t *testing.T) {
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, ".agents", "learnings")
+	_ = os.MkdirAll(dir, 0o755)
+
+	body := strings.Repeat("the quick brown fox jumps over the lazy dog. ", 10)
+	_ = os.WriteFile(filepath.Join(dir, "a.md"), []byte(body), 0o600)
+	// Near-duplicate: same content -> identical trigram sets (overlap 1.0)
+	_ = os.WriteFile(filepath.Join(dir, "b.md"), []byte(body), 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "c.md"), []byte("completely unrelated content zyxwvu qponml"), 0o600)
+
+	r, err := FindDuplicateLearnings(tmp)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if r.Checked != 3 {
+		t.Errorf("Checked = %d, want 3", r.Checked)
+	}
+	if len(r.DuplicatePairs) == 0 {
+		t.Fatalf("expected at least 1 near-duplicate pair")
+	}
+}

--- a/cli/internal/lifecycle/feedback_test.go
+++ b/cli/internal/lifecycle/feedback_test.go
@@ -1,0 +1,237 @@
+package lifecycle
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveReward(t *testing.T) {
+	cases := []struct {
+		name    string
+		helpful bool
+		harmful bool
+		reward  float64
+		alpha   float64
+		want    float64
+		wantErr bool
+	}{
+		{"both flags error", true, true, -1, 0.5, 0, true},
+		{"helpful sets to 1.0", true, false, -1, 0.5, 1.0, false},
+		{"harmful sets to 0.0", false, true, -1, 0.5, 0.0, false},
+		{"negative reward errors when no shortcut", false, false, -1, 0.5, 0, true},
+		{"reward > 1 errors", false, false, 1.5, 0.5, 0, true},
+		{"alpha 0 errors", false, false, 0.5, 0, 0, true},
+		{"alpha > 1 errors", false, false, 0.5, 1.5, 0, true},
+		{"valid custom reward", false, false, 0.6, 0.3, 0.6, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveReward(tc.helpful, tc.harmful, tc.reward, tc.alpha)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyFeedbackType(t *testing.T) {
+	if ClassifyFeedbackType(true, false) != "helpful" {
+		t.Error("helpful")
+	}
+	if ClassifyFeedbackType(false, true) != "harmful" {
+		t.Error("harmful")
+	}
+	if ClassifyFeedbackType(false, false) != "custom" {
+		t.Error("custom")
+	}
+}
+
+func TestCounterDirectionFromFeedback(t *testing.T) {
+	cases := []struct {
+		name           string
+		reward         float64
+		explicitHelp   bool
+		explicitHarm   bool
+		wantHelpful    bool
+		wantHarmful    bool
+	}{
+		{"explicit helpful wins", 0.1, true, false, true, false},
+		{"explicit harmful wins", 0.9, false, true, false, true},
+		{"high reward implies helpful", 0.9, false, false, true, false},
+		{"low reward implies harmful", 0.1, false, false, false, true},
+		{"neutral middle is neither", 0.5, false, false, false, false},
+		{"boundary 0.8 is helpful", 0.8, false, false, true, false},
+		{"boundary 0.2 is harmful", 0.2, false, false, false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, harm := CounterDirectionFromFeedback(tc.reward, tc.explicitHelp, tc.explicitHarm)
+			if h != tc.wantHelpful || harm != tc.wantHarmful {
+				t.Errorf("got helpful=%v harmful=%v; want helpful=%v harmful=%v", h, harm, tc.wantHelpful, tc.wantHarmful)
+			}
+		})
+	}
+}
+
+func TestParseJSONLFirstLine(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "ok.jsonl")
+	_ = os.WriteFile(path, []byte(`{"utility":0.5,"maturity":"candidate"}`+"\n"), 0o600)
+
+	lines, data, err := ParseJSONLFirstLine(path)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(lines) < 1 {
+		t.Error("should return lines")
+	}
+	if data["utility"] != 0.5 {
+		t.Errorf("utility = %v", data["utility"])
+	}
+
+	// Empty file
+	empty := filepath.Join(tmp, "empty.jsonl")
+	_ = os.WriteFile(empty, []byte(""), 0o600)
+	if _, _, err := ParseJSONLFirstLine(empty); err == nil {
+		t.Error("empty file should error")
+	}
+
+	// Invalid JSON
+	bad := filepath.Join(tmp, "bad.jsonl")
+	_ = os.WriteFile(bad, []byte("not json\n"), 0o600)
+	if _, _, err := ParseJSONLFirstLine(bad); err == nil {
+		t.Error("invalid json should error")
+	}
+
+	// Missing file
+	if _, _, err := ParseJSONLFirstLine(filepath.Join(tmp, "missing.jsonl")); err == nil {
+		t.Error("missing file should error")
+	}
+}
+
+func TestApplyJSONLRewardFields(t *testing.T) {
+	data := map[string]any{
+		"utility":       0.5,
+		"reward_count":  float64(2),
+		"helpful_count": float64(1),
+		"harmful_count": float64(0),
+	}
+	ApplyJSONLRewardFields(data, 0.5, 0.7, 1.0, true, false)
+
+	if data["utility"] != 0.7 {
+		t.Errorf("utility = %v", data["utility"])
+	}
+	if data["last_reward"] != 1.0 {
+		t.Errorf("last_reward = %v", data["last_reward"])
+	}
+	if data["reward_count"] != 3 {
+		t.Errorf("reward_count = %v", data["reward_count"])
+	}
+	if data["helpful_count"] != 2 {
+		t.Errorf("helpful_count = %v (should increment from 1)", data["helpful_count"])
+	}
+	if _, ok := data["confidence"]; !ok {
+		t.Error("confidence should be set")
+	}
+	if _, ok := data["last_reward_at"]; !ok {
+		t.Error("last_reward_at should be set")
+	}
+}
+
+func TestApplyJSONLRewardFields_HarmfulPath(t *testing.T) {
+	data := map[string]any{"utility": 0.3}
+	ApplyJSONLRewardFields(data, 0.3, 0.2, 0.0, false, true)
+	if data["harmful_count"] != 1 {
+		t.Errorf("harmful_count should be 1, got %v", data["harmful_count"])
+	}
+}
+
+func TestParseFrontMatterUtility(t *testing.T) {
+	lines := []string{"---", "utility: 0.75", "maturity: candidate", "---", "body"}
+	endIdx, u, err := ParseFrontMatterUtility(lines)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if endIdx != 3 {
+		t.Errorf("endIdx = %d", endIdx)
+	}
+	if u != 0.75 {
+		t.Errorf("utility = %v", u)
+	}
+
+	// Missing closing ---
+	lines2 := []string{"---", "utility: 0.5"}
+	if _, _, err := ParseFrontMatterUtility(lines2); err == nil {
+		t.Error("missing close should error")
+	}
+}
+
+func TestRebuildWithFrontMatter(t *testing.T) {
+	fm := []string{"utility: 0.5", "maturity: candidate"}
+	body := []string{"line one", "line two"}
+	got := RebuildWithFrontMatter(fm, body)
+	if !strings.HasPrefix(got, "---\n") {
+		t.Error("should start with ---")
+	}
+	if !strings.Contains(got, "utility: 0.5") {
+		t.Error("should contain fm fields")
+	}
+	if !strings.Contains(got, "line one") {
+		t.Error("should contain body")
+	}
+}
+
+func TestUpdateFrontMatterFields_ReplacesAndAppends(t *testing.T) {
+	existing := []string{"utility: 0.3", "maturity: provisional"}
+	result := UpdateFrontMatterFields(existing, map[string]string{
+		"utility":  "0.9",
+		"new_key":  "new_val",
+	})
+	joined := strings.Join(result, "\n")
+	if !strings.Contains(joined, "utility: 0.9") {
+		t.Errorf("should have replaced utility, got %v", result)
+	}
+	if strings.Contains(joined, "utility: 0.3") {
+		t.Errorf("old utility should not remain")
+	}
+	if !strings.Contains(joined, "new_key: new_val") {
+		t.Errorf("missing field should be appended")
+	}
+	if !strings.Contains(joined, "maturity: provisional") {
+		t.Errorf("unrelated fields should be preserved")
+	}
+}
+
+func TestIncrementRewardCount(t *testing.T) {
+	got := IncrementRewardCount([]string{"reward_count: 4"})
+	if got != "5" {
+		t.Errorf("got %q, want 5", got)
+	}
+
+	// Missing field starts at 0
+	if got := IncrementRewardCount([]string{"utility: 0.5"}); got != "1" {
+		t.Errorf("got %q, want 1", got)
+	}
+}
+
+func TestParseFrontMatterInt(t *testing.T) {
+	lines := []string{"reward_count: 7", "helpful_count: 3"}
+	if got := ParseFrontMatterInt(lines, "reward_count"); got != 7 {
+		t.Errorf("got %d", got)
+	}
+	if got := ParseFrontMatterInt(lines, "missing"); got != 0 {
+		t.Errorf("missing should default to 0, got %d", got)
+	}
+}
+
+func TestIncrementFMCount(t *testing.T) {
+	lines := []string{"helpful_count: 2"}
+	if got := IncrementFMCount(lines, "helpful_count"); got != "3" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/cli/internal/lifecycle/maturity_test.go
+++ b/cli/internal/lifecycle/maturity_test.go
@@ -1,0 +1,377 @@
+package lifecycle
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDefaultLearningMetadataFields(t *testing.T) {
+	d := DefaultLearningMetadataFields()
+	expectedKeys := []string{"utility", "maturity", "confidence", "reward_count", "helpful_count", "harmful_count"}
+	for _, k := range expectedKeys {
+		if _, ok := d[k]; !ok {
+			t.Errorf("missing key %q", k)
+		}
+	}
+	if d["maturity"] != "provisional" {
+		t.Errorf("default maturity = %q", d["maturity"])
+	}
+}
+
+func TestParseFrontmatterFields(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "x.md")
+	content := "---\nutility: 0.5\nmaturity: candidate\nquoted: \"value\"\n---\nbody\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ParseFrontmatterFields(path, "utility", "maturity", "quoted", "missing")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got["utility"] != "0.5" {
+		t.Errorf("utility = %q", got["utility"])
+	}
+	if got["maturity"] != "candidate" {
+		t.Errorf("maturity = %q", got["maturity"])
+	}
+	if got["quoted"] != "value" {
+		t.Errorf("quotes should be stripped, got %q", got["quoted"])
+	}
+	if _, ok := got["missing"]; ok {
+		t.Errorf("missing field should not be present")
+	}
+}
+
+func TestIsLowSignalLearningBody(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"empty", "", true},
+		{"too short", "short", true},
+		{"starts with continuation", "and we did something important here today. totally.", true},
+		{"no sentence enders", "a sufficient body of words but lacks punctuation endings here somewhere", true},
+		{"good", "We discovered that goroutine leaks happen when channels aren't closed. Fix by deferring close.", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsLowSignalLearningBody(tc.body); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStripLearningHeading(t *testing.T) {
+	with := "# Title\n\nline one\nline two"
+	if got := StripLearningHeading(with); got != "line one\nline two" {
+		t.Errorf("got %q", got)
+	}
+	without := "line one\nline two"
+	if got := StripLearningHeading(without); got != "line one\nline two" {
+		t.Errorf("without heading: got %q", got)
+	}
+}
+
+func TestIsEvictionEligible(t *testing.T) {
+	cases := []struct {
+		name       string
+		utility    float64
+		confidence float64
+		maturity   string
+		want       bool
+	}{
+		{"established is sacred", 0.0, 0.0, "established", false},
+		{"high utility not eligible", 0.5, 0.0, "provisional", false},
+		{"high confidence not eligible", 0.0, 0.5, "provisional", false},
+		{"low everything is eligible", 0.1, 0.1, "provisional", true},
+		{"boundary utility 0.3", 0.3, 0.0, "provisional", false},
+		{"boundary confidence 0.3", 0.0, 0.3, "provisional", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsEvictionEligible(tc.utility, tc.confidence, tc.maturity); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFloatValueFromData(t *testing.T) {
+	data := map[string]any{"u": 0.75, "s": "str"}
+	if got := FloatValueFromData(data, "u", 0.0); got != 0.75 {
+		t.Errorf("got %v", got)
+	}
+	if got := FloatValueFromData(data, "missing", 0.42); got != 0.42 {
+		t.Errorf("missing default: got %v", got)
+	}
+	if got := FloatValueFromData(data, "s", 0.42); got != 0.42 {
+		t.Errorf("wrong type should default: got %v", got)
+	}
+}
+
+func TestNonEmptyStringFromData(t *testing.T) {
+	data := map[string]any{"a": "hello", "b": ""}
+	if got := NonEmptyStringFromData(data, "a", "d"); got != "hello" {
+		t.Errorf("got %q", got)
+	}
+	if got := NonEmptyStringFromData(data, "b", "d"); got != "d" {
+		t.Errorf("empty should fall back, got %q", got)
+	}
+	if got := NonEmptyStringFromData(data, "missing", "d"); got != "d" {
+		t.Errorf("missing should fall back, got %q", got)
+	}
+}
+
+func TestClassifyExpiryFields(t *testing.T) {
+	now := time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name   string
+		fields map[string]string
+		want   ExpiryClassification
+	}{
+		{"archived", map[string]string{"expiry_status": "archived"}, ExpiryAlreadyArchived},
+		{"no expiry", map[string]string{}, ExpiryNeverExpiring},
+		{"empty expiry", map[string]string{"valid_until": ""}, ExpiryNeverExpiring},
+		{"bad format", map[string]string{"valid_until": "not-a-date"}, ExpiryNeverExpiring},
+		{"still active", map[string]string{"valid_until": "2026-05-22"}, ExpiryActive},
+		{"expired", map[string]string{"valid_until": "2026-03-22"}, ExpiryNewlyExpired},
+		{"rfc3339 active", map[string]string{"valid_until": "2026-05-22T00:00:00Z"}, ExpiryActive},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyExpiryFields(tc.fields, now); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvictionCitationStatus(t *testing.T) {
+	cutoff := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	recent := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	old := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	// Never cited
+	status, evictable := EvictionCitationStatus("f", map[string]time.Time{}, cutoff)
+	if !evictable {
+		t.Error("uncited should be evictable")
+	}
+	if status != "never" {
+		t.Errorf("status = %q, want 'never'", status)
+	}
+
+	// Recently cited -> not evictable
+	_, ev := EvictionCitationStatus("f", map[string]time.Time{"f": recent}, cutoff)
+	if ev {
+		t.Error("recently-cited should not be evictable")
+	}
+
+	// Old citation -> evictable with date
+	status2, ev2 := EvictionCitationStatus("f", map[string]time.Time{"f": old}, cutoff)
+	if !ev2 {
+		t.Error("old citation should be evictable")
+	}
+	if status2 != "2026-03-01" {
+		t.Errorf("status = %q", status2)
+	}
+}
+
+func TestShouldArchiveUncitedLearning(t *testing.T) {
+	cutoff := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	recent := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	old := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	// Established never archived
+	if ShouldArchiveUncitedLearning("established", old, false, cutoff) {
+		t.Error("established should not be archived")
+	}
+	// Anti-pattern never archived
+	if ShouldArchiveUncitedLearning("anti-pattern", old, false, cutoff) {
+		t.Error("anti-pattern should not be archived")
+	}
+	// Recent mod time -> not archived
+	if ShouldArchiveUncitedLearning("provisional", recent, false, cutoff) {
+		t.Error("recently-modified should not be archived")
+	}
+	// Old + cited -> not archived
+	if ShouldArchiveUncitedLearning("provisional", old, true, cutoff) {
+		t.Error("cited learning should not be archived")
+	}
+	// Old + uncited + provisional -> archive
+	if !ShouldArchiveUncitedLearning("provisional", old, false, cutoff) {
+		t.Error("old+uncited+provisional should be archived")
+	}
+}
+
+func TestFormatLastCited(t *testing.T) {
+	when := time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC)
+	if got := FormatLastCited(when, true); got != "2026-04-22" {
+		t.Errorf("got %q", got)
+	}
+	if got := FormatLastCited(when, false); got != "never" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestParseFrontmatterFloats(t *testing.T) {
+	in := map[string]string{
+		"utility":  "0.5",
+		"maturity": "candidate",
+		"count":    "42",
+	}
+	got := ParseFrontmatterFloats(in)
+	if f, ok := got["utility"].(float64); !ok || f != 0.5 {
+		t.Errorf("utility = %v", got["utility"])
+	}
+	if s, ok := got["maturity"].(string); !ok || s != "candidate" {
+		t.Errorf("maturity = %v", got["maturity"])
+	}
+	if f, ok := got["count"].(float64); !ok || f != 42 {
+		t.Errorf("count = %v", got["count"])
+	}
+}
+
+func TestApplyJSONLDefaults_FillsMissing(t *testing.T) {
+	data := map[string]any{"utility": 0.8}
+	changed := ApplyJSONLDefaults(data)
+	if !changed {
+		t.Error("should report changed when filling defaults")
+	}
+	if data["utility"] != 0.8 {
+		t.Errorf("should preserve existing utility, got %v", data["utility"])
+	}
+	if data["maturity"] != "provisional" {
+		t.Errorf("should fill maturity default, got %v", data["maturity"])
+	}
+}
+
+func TestApplyJSONLDefaults_NoChangesWhenAllPresent(t *testing.T) {
+	data := map[string]any{
+		"utility": 0.8, "maturity": "candidate",
+		"confidence": 0.5, "reward_count": 1,
+		"helpful_count": 2, "harmful_count": 0,
+	}
+	if ApplyJSONLDefaults(data) {
+		t.Error("should not report changed when all present")
+	}
+}
+
+func TestMissingMetadataFields(t *testing.T) {
+	existing := map[string]string{"utility": "0.5", "maturity": ""}
+	missing := MissingMetadataFields(existing)
+	if _, ok := missing["utility"]; ok {
+		t.Error("utility should not be missing")
+	}
+	if _, ok := missing["maturity"]; !ok {
+		t.Error("maturity should be reported missing")
+	}
+}
+
+func TestLearningMetadataFieldOrder(t *testing.T) {
+	order := LearningMetadataFieldOrder()
+	if len(order) != 6 {
+		t.Errorf("expected 6 fields, got %d", len(order))
+	}
+	if order[0] != "utility" {
+		t.Errorf("utility should come first, got %v", order)
+	}
+}
+
+func TestBuildMarkdownFrontmatterPrefix(t *testing.T) {
+	got := BuildMarkdownFrontmatterPrefix()
+	if !strings.HasPrefix(got, "---\n") {
+		t.Errorf("should start with ---")
+	}
+	if !strings.HasSuffix(got, "---\n") {
+		t.Errorf("should end with ---")
+	}
+	for _, field := range LearningMetadataFieldOrder() {
+		if !strings.Contains(got, field+":") {
+			t.Errorf("missing field %q in output: %s", field, got)
+		}
+	}
+}
+
+func TestFindFrontmatterEnd(t *testing.T) {
+	lines := []string{"---", "key: value", "---", "body"}
+	if got := FindFrontmatterEnd(lines); got != 2 {
+		t.Errorf("got %d, want 2", got)
+	}
+
+	unclosed := []string{"---", "key: value", "body"}
+	if got := FindFrontmatterEnd(unclosed); got != -1 {
+		t.Errorf("unclosed should return -1, got %d", got)
+	}
+}
+
+func TestHasYAMLFrontmatter(t *testing.T) {
+	if !HasYAMLFrontmatter("---\nkey: val") {
+		t.Error("should detect frontmatter")
+	}
+	if HasYAMLFrontmatter("no frontmatter") {
+		t.Error("false positive")
+	}
+}
+
+func TestNormalizeJSONLLine(t *testing.T) {
+	// Missing fields -> normalize
+	out, changed, err := NormalizeJSONLLine(`{"utility":0.7}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("should be changed")
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed["utility"] != 0.7 {
+		t.Errorf("utility should be preserved, got %v", parsed["utility"])
+	}
+	if parsed["maturity"] != "provisional" {
+		t.Errorf("maturity should be provisional, got %v", parsed["maturity"])
+	}
+
+	// Empty line -> no change
+	_, changed2, err := NormalizeJSONLLine("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed2 {
+		t.Error("empty line should not be changed")
+	}
+
+	// Invalid JSON -> error
+	_, _, err = NormalizeJSONLLine("not json")
+	if err == nil {
+		t.Error("invalid json should error")
+	}
+}
+
+func TestReadLearningJSONLData(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "a.jsonl")
+	_ = os.WriteFile(path, []byte(`{"utility":0.9}`+"\n"), 0o600)
+
+	data, ok := ReadLearningJSONLData(path)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if data["utility"] != 0.9 {
+		t.Errorf("utility = %v", data["utility"])
+	}
+
+	// Missing file
+	if _, ok := ReadLearningJSONLData(filepath.Join(tmp, "missing.jsonl")); ok {
+		t.Error("missing file should return ok=false")
+	}
+}

--- a/cli/internal/lifecycle/seed_test.go
+++ b/cli/internal/lifecycle/seed_test.go
@@ -1,0 +1,140 @@
+package lifecycle
+
+import (
+	"testing"
+	"testing/fstest"
+)
+
+func TestValidateTemplateMapEntries_AllPresent(t *testing.T) {
+	fsys := fstest.MapFS{
+		"templates/go-cli.yaml":     &fstest.MapFile{Data: []byte("x")},
+		"templates/python-lib.yaml": &fstest.MapFile{Data: []byte("x")},
+		"templates/generic.yaml":    &fstest.MapFile{Data: []byte("x")},
+	}
+	templates := map[string]bool{"go-cli": true, "python-lib": true, "generic": true, "rust-cli": false}
+	if err := ValidateTemplateMapEntries(templates, fsys); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestValidateTemplateMapEntries_MissingFile(t *testing.T) {
+	fsys := fstest.MapFS{"templates/go-cli.yaml": &fstest.MapFile{Data: []byte("x")}}
+	templates := map[string]bool{"go-cli": true, "web-app": true}
+	err := ValidateTemplateMapEntries(templates, fsys)
+	if err == nil {
+		t.Fatalf("expected error for missing web-app.yaml")
+	}
+	if !contains(err.Error(), "web-app") {
+		t.Errorf("error should mention missing template name: %v", err)
+	}
+}
+
+func TestBuildSeedGoalFile_KnownTemplate(t *testing.T) {
+	g := BuildSeedGoalFile("/tmp/myproj", "go-cli")
+	if g == nil {
+		t.Fatal("expected non-nil GoalFile")
+	}
+	if g.Version != 4 {
+		t.Errorf("Version = %d, want 4", g.Version)
+	}
+	if g.Format != "md" {
+		t.Errorf("Format = %q, want md", g.Format)
+	}
+	if !contains(g.Mission, "myproj") {
+		t.Errorf("Mission should contain project basename, got %q", g.Mission)
+	}
+	if !contains(g.Mission, "(Go CLI)") {
+		t.Errorf("Mission should contain suffix, got %q", g.Mission)
+	}
+	if len(g.NorthStars) == 0 {
+		t.Error("expected NorthStars populated")
+	}
+	if len(g.Directives) == 0 {
+		t.Error("expected Directives populated")
+	}
+}
+
+func TestBuildSeedGoalFile_UnknownTemplateFallsBackToGeneric(t *testing.T) {
+	g := BuildSeedGoalFile("/x/proj", "no-such-template")
+	generic := TemplateConfigs["generic"]
+	if len(g.Directives) != len(generic.Directives) {
+		t.Errorf("expected generic directives (%d), got %d", len(generic.Directives), len(g.Directives))
+	}
+}
+
+func TestValidTemplates_ContainsExpectedSet(t *testing.T) {
+	expected := []string{"go-cli", "python-lib", "web-app", "rust-cli", "generic"}
+	for _, name := range expected {
+		if !ValidTemplates[name] {
+			t.Errorf("ValidTemplates missing %q", name)
+		}
+	}
+	if ValidTemplates["fake"] {
+		t.Error("ValidTemplates should not contain fake")
+	}
+}
+
+func TestHasSeedMarker(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"empty", "", false},
+		{"current marker", "before\n## AgentOps Knowledge Flywheel\nafter", true},
+		{"legacy marker", "before\n## AgentOps Session Protocol\nafter", true},
+		{"no marker", "some random content", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasSeedMarker(tc.content); got != tc.want {
+				t.Errorf("HasSeedMarker(%q) = %v, want %v", tc.content, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFindSeedMarker(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"empty returns empty", "", ""},
+		{"current marker", "x\n## AgentOps Knowledge Flywheel\ny", ClaudeMDSeedMarker},
+		{"legacy marker only", "x\n## AgentOps Session Protocol\ny", ClaudeMDSeedMarkerLegacy},
+		{"current wins over legacy when both present", "## AgentOps Knowledge Flywheel\n## AgentOps Session Protocol", ClaudeMDSeedMarker},
+		{"no marker", "nothing here", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FindSeedMarker(tc.content); got != tc.want {
+				t.Errorf("FindSeedMarker = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTemplateConfigs_AllTemplatesHaveDirectives(t *testing.T) {
+	for name, cfg := range TemplateConfigs {
+		if len(cfg.Directives) == 0 {
+			t.Errorf("template %q has no directives", name)
+		}
+		if len(cfg.NorthStars) == 0 {
+			t.Errorf("template %q has no north stars", name)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && indexOf(s, sub) >= 0
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/cli/internal/lifecycle/task_sync_test.go
+++ b/cli/internal/lifecycle/task_sync_test.go
@@ -1,0 +1,162 @@
+package lifecycle
+
+import (
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/types"
+)
+
+func TestStatusToMaturity(t *testing.T) {
+	cases := map[string]types.Maturity{
+		"completed":   types.MaturityEstablished,
+		"in_progress": types.MaturityCandidate,
+		"pending":     types.MaturityProvisional,
+		"unknown":     types.MaturityProvisional,
+		"":            types.MaturityProvisional,
+	}
+	for status, want := range cases {
+		if got := StatusToMaturity(status); got != want {
+			t.Errorf("StatusToMaturity(%q) = %v, want %v", status, got, want)
+		}
+	}
+}
+
+func TestCloneStringAnyMap(t *testing.T) {
+	if got := CloneStringAnyMap(nil); got != nil {
+		t.Error("nil in should return nil")
+	}
+	if got := CloneStringAnyMap(map[string]any{}); got != nil {
+		t.Error("empty in should return nil")
+	}
+
+	src := map[string]any{"a": 1, "b": "two"}
+	clone := CloneStringAnyMap(src)
+	if len(clone) != 2 {
+		t.Errorf("clone len = %d", len(clone))
+	}
+	clone["a"] = 999
+	if src["a"] != 1 {
+		t.Error("clone should not alias source")
+	}
+}
+
+func TestExtractContentBlocks(t *testing.T) {
+	// Valid tool_use block
+	data := map[string]any{
+		"message": map[string]any{
+			"content": []any{
+				map[string]any{"type": "text", "text": "hi"},
+				map[string]any{"type": "tool_use", "name": "T"},
+				map[string]any{"type": "tool_use", "name": "U"},
+			},
+		},
+	}
+	blocks := ExtractContentBlocks(data)
+	if len(blocks) != 2 {
+		t.Errorf("got %d blocks, want 2", len(blocks))
+	}
+
+	// No message
+	if got := ExtractContentBlocks(map[string]any{}); got != nil {
+		t.Error("no message should return nil")
+	}
+
+	// Malformed content
+	bad := map[string]any{"message": map[string]any{"content": "not a list"}}
+	if got := ExtractContentBlocks(bad); got != nil {
+		t.Error("non-list content should return nil")
+	}
+}
+
+func TestParseTaskCreate(t *testing.T) {
+	in := map[string]any{
+		"subject":     "fix bug",
+		"description": "investigate foo",
+		"activeForm":  "Fixing bug",
+		"metadata":    map[string]any{"priority": "high"},
+	}
+	subject, desc, active, meta := ParseTaskCreate(in)
+	if subject != "fix bug" {
+		t.Errorf("subject = %q", subject)
+	}
+	if desc != "investigate foo" {
+		t.Errorf("desc = %q", desc)
+	}
+	if active != "Fixing bug" {
+		t.Errorf("active = %q", active)
+	}
+	if meta["priority"] != "high" {
+		t.Errorf("meta = %v", meta)
+	}
+
+	// Empty subject short-circuits
+	subject2, _, _, _ := ParseTaskCreate(map[string]any{"subject": ""})
+	if subject2 != "" {
+		t.Error("empty subject should be empty")
+	}
+}
+
+func TestApplyTaskUpdate(t *testing.T) {
+	in := map[string]any{
+		"status":      "completed",
+		"subject":     "new subject",
+		"description": "new desc",
+		"owner":       "alice",
+	}
+	status, subj, desc, owner := ApplyTaskUpdate(in)
+	if status != "completed" || subj != "new subject" || desc != "new desc" || owner != "alice" {
+		t.Errorf("got status=%q subj=%q desc=%q owner=%q", status, subj, desc, owner)
+	}
+
+	// Partial input
+	s2, _, _, _ := ApplyTaskUpdate(map[string]any{})
+	if s2 != "" {
+		t.Errorf("empty map should give empty status, got %q", s2)
+	}
+}
+
+func TestProcessTranscriptLine(t *testing.T) {
+	line := `{"sessionId":"s1","message":{"content":[{"type":"tool_use","name":"T"}]}}`
+	newSID, blocks := ProcessTranscriptLine(line, "", "")
+	if newSID != "s1" {
+		t.Errorf("sessionId = %q", newSID)
+	}
+	if len(blocks) != 1 {
+		t.Errorf("blocks len = %d", len(blocks))
+	}
+
+	// Filter by different session -> no blocks returned
+	_, blocks2 := ProcessTranscriptLine(line, "other", "")
+	if len(blocks2) != 0 {
+		t.Errorf("filtered-out session should yield 0 blocks, got %d", len(blocks2))
+	}
+
+	// Invalid JSON preserves state
+	sid3, blocks3 := ProcessTranscriptLine("not json", "", "prev")
+	if sid3 != "prev" {
+		t.Errorf("invalid json should preserve currentSessionID, got %q", sid3)
+	}
+	if blocks3 != nil {
+		t.Errorf("invalid json should return nil blocks")
+	}
+}
+
+func TestComputeTaskDistributions(t *testing.T) {
+	statuses := []string{"pending", "pending", "completed"}
+	maturities := []types.Maturity{types.MaturityProvisional, types.MaturityEstablished, types.MaturityEstablished}
+	learningIDs := []string{"l1", "", "l2"}
+
+	d := ComputeTaskDistributions(statuses, maturities, learningIDs)
+	if d.StatusCounts["pending"] != 2 {
+		t.Errorf("pending count = %d", d.StatusCounts["pending"])
+	}
+	if d.StatusCounts["completed"] != 1 {
+		t.Errorf("completed count = %d", d.StatusCounts["completed"])
+	}
+	if d.MaturityCounts[types.MaturityEstablished] != 2 {
+		t.Errorf("established count = %d", d.MaturityCounts[types.MaturityEstablished])
+	}
+	if d.WithLearnings != 2 {
+		t.Errorf("WithLearnings = %d (expected 2; empty string excluded)", d.WithLearnings)
+	}
+}

--- a/cli/internal/lifecycle/temper_test.go
+++ b/cli/internal/lifecycle/temper_test.go
@@ -1,0 +1,252 @@
+package lifecycle
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestIsContainedPath(t *testing.T) {
+	tmp := t.TempDir()
+	inside := filepath.Join(tmp, "a", "b.txt")
+	if err := os.MkdirAll(filepath.Dir(inside), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(inside, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		base string
+		path string
+		want bool
+	}{
+		{"file under base", tmp, inside, true},
+		{"base equals path", tmp, tmp, true},
+		{"escape with ..", tmp, filepath.Join(tmp, "..", "x"), false},
+		{"sibling dir", tmp, filepath.Join(filepath.Dir(tmp), "other"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsContainedPath(tc.base, tc.path); got != tc.want {
+				t.Errorf("IsContainedPath(%q,%q) = %v, want %v", tc.base, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsArtifactFile(t *testing.T) {
+	cases := map[string]bool{
+		"foo.md":      true,
+		"bar.jsonl":   true,
+		"baz.txt":     false,
+		"qux.json":    false,
+		"notes.MD":    false, // case-sensitive
+		"":            false,
+	}
+	for name, want := range cases {
+		if got := IsArtifactFile(name); got != want {
+			t.Errorf("IsArtifactFile(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestParseMarkdownField(t *testing.T) {
+	cases := []struct {
+		line     string
+		field    string
+		wantVal  string
+		wantOK   bool
+	}{
+		{"**ID**: abc-123", "ID", "abc-123", true},
+		{"**ID:** abc-123", "ID", "abc-123", true},
+		{"- **Maturity**: established", "Maturity", "established", true},
+		{"**Other**: x", "ID", "", false},
+		{"no match here", "ID", "", false},
+		{"**ID**:   spaced   ", "ID", "spaced", true},
+	}
+	for _, tc := range cases {
+		gotVal, gotOK := ParseMarkdownField(tc.line, tc.field)
+		if gotOK != tc.wantOK || gotVal != tc.wantVal {
+			t.Errorf("ParseMarkdownField(%q,%q) = (%q,%v), want (%q,%v)", tc.line, tc.field, gotVal, gotOK, tc.wantVal, tc.wantOK)
+		}
+	}
+}
+
+func TestParseMarkdownMeta_Roundtrip(t *testing.T) {
+	content := `
+**ID**: learn-2026-04-22-abcd
+**Maturity**: Established
+**Utility**: 0.75
+**Confidence**: 0.8
+**Schema Version**: 1
+**Status**: tempered
+`
+	meta := ParseMarkdownMeta(content)
+	if meta.ID != "learn-2026-04-22-abcd" {
+		t.Errorf("ID = %q", meta.ID)
+	}
+	if meta.Maturity != "established" {
+		t.Errorf("Maturity = %q (expected lowered)", meta.Maturity)
+	}
+	if meta.Utility != 0.75 {
+		t.Errorf("Utility = %v", meta.Utility)
+	}
+	if meta.Confidence != 0.8 {
+		t.Errorf("Confidence = %v", meta.Confidence)
+	}
+	if meta.SchemaVersion != 1 {
+		t.Errorf("SchemaVersion = %d", meta.SchemaVersion)
+	}
+	if !meta.Tempered {
+		t.Error("Tempered should be true")
+	}
+}
+
+func TestApplyMarkdownLine_StatusLocked(t *testing.T) {
+	meta := ArtifactMeta{}
+	ApplyMarkdownLine("**Status**: locked", &meta)
+	if !meta.Tempered {
+		t.Error("locked status should set Tempered=true")
+	}
+}
+
+func TestValidateArtifactMeta_MissingID(t *testing.T) {
+	meta := ArtifactMeta{Maturity: "established", Utility: 1.0, FeedbackCount: 5, SchemaVersion: 1}
+	issues, _ := ValidateArtifactMeta(meta, "candidate", 0.5, 3)
+	found := false
+	for _, i := range issues {
+		if strings.Contains(i, "missing ID") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected missing-ID issue; got %v", issues)
+	}
+}
+
+func TestValidateArtifactMeta_LowMaturity(t *testing.T) {
+	meta := ArtifactMeta{ID: "x", Maturity: "provisional", Utility: 1.0, FeedbackCount: 10, SchemaVersion: 1}
+	issues, _ := ValidateArtifactMeta(meta, "established", 0.0, 0)
+	if len(issues) == 0 {
+		t.Fatalf("expected maturity issue, got none")
+	}
+	joined := strings.Join(issues, "|")
+	if !strings.Contains(joined, "maturity provisional") {
+		t.Errorf("expected maturity-below complaint, got %v", issues)
+	}
+}
+
+func TestValidateArtifactMeta_SchemaVersionWarning(t *testing.T) {
+	meta := ArtifactMeta{ID: "x", Maturity: "established", Utility: 1.0, FeedbackCount: 10, SchemaVersion: 0}
+	_, warnings := ValidateArtifactMeta(meta, "candidate", 0.0, 0)
+	if len(warnings) == 0 {
+		t.Fatal("expected schema version warning")
+	}
+	if !strings.Contains(warnings[0], "schema_version") {
+		t.Errorf("warning should mention schema_version, got %q", warnings[0])
+	}
+}
+
+func TestValidateArtifactMeta_UtilityAndFeedback(t *testing.T) {
+	meta := ArtifactMeta{ID: "x", Maturity: "established", Utility: 0.1, FeedbackCount: 0, SchemaVersion: 1}
+	issues, _ := ValidateArtifactMeta(meta, "candidate", 0.5, 3)
+	if len(issues) < 2 {
+		t.Errorf("expected at least 2 issues (utility + feedback), got %d: %v", len(issues), issues)
+	}
+}
+
+func TestExpandGlobPattern_FiltersOutsideBase(t *testing.T) {
+	tmp := t.TempDir()
+	otherDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "a.md"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(otherDir, "b.md"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	matches, err := ExpandGlobPattern(tmp, filepath.Join(tmp, "*.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Errorf("expected 1 match in base dir, got %d: %v", len(matches), matches)
+	}
+}
+
+func TestExpandDirectoryRecursive_CollectsArtifacts(t *testing.T) {
+	tmp := t.TempDir()
+	sub := filepath.Join(tmp, "a", "b")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	files := []string{
+		filepath.Join(tmp, "top.md"),
+		filepath.Join(sub, "deep.jsonl"),
+		filepath.Join(sub, "ignore.txt"),
+	}
+	for _, f := range files {
+		if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := ExpandDirectoryRecursive(tmp, tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 artifact files (md+jsonl), got %d: %v", len(got), got)
+	}
+}
+
+func TestExpandDirectoryFlat_NonRecursive(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "a.md"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "sub", "b.md"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := ExpandDirectoryFlat(tmp)
+	if len(got) != 1 {
+		t.Errorf("flat should not descend; got %d files: %v", len(got), got)
+	}
+}
+
+func TestExpandSinglePattern_RejectsEscapes(t *testing.T) {
+	base := t.TempDir()
+	_, err := ExpandSinglePattern(base, "../outside.md", false)
+	if err == nil {
+		t.Fatal("expected containment error")
+	}
+	if !strings.Contains(err.Error(), "outside allowed directory") {
+		t.Errorf("error should mention containment, got %v", err)
+	}
+}
+
+func TestExpandFilePatterns_MultiplePatterns(t *testing.T) {
+	base := t.TempDir()
+	for _, name := range []string{"a.md", "b.md", "c.jsonl"} {
+		if err := os.WriteFile(filepath.Join(base, name), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := ExpandFilePatterns(base, []string{"*.md", "*.jsonl"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	if len(got) != 3 {
+		t.Errorf("expected 3 files, got %d: %v", len(got), got)
+	}
+}

--- a/cli/internal/overnight/loop_test.go
+++ b/cli/internal/overnight/loop_test.go
@@ -1,0 +1,569 @@
+package overnight
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateRunLoopOptions exercises the pure validation helper across
+// the Cwd/OutputDir/RunID matrix. Error strings are asserted verbatim so
+// downstream logs that match them remain stable.
+func TestValidateRunLoopOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    RunLoopOptions
+		wantErr string
+	}{
+		{
+			name:    "missing cwd",
+			opts:    RunLoopOptions{OutputDir: "out", RunID: "r1"},
+			wantErr: "overnight: RunLoopOptions.Cwd is required",
+		},
+		{
+			name:    "missing output dir",
+			opts:    RunLoopOptions{Cwd: "/tmp", RunID: "r1"},
+			wantErr: "overnight: RunLoopOptions.OutputDir is required",
+		},
+		{
+			name:    "missing run id",
+			opts:    RunLoopOptions{Cwd: "/tmp", OutputDir: "out"},
+			wantErr: "overnight: RunLoopOptions.RunID is required",
+		},
+		{
+			name:    "all fields present",
+			opts:    RunLoopOptions{Cwd: "/tmp", OutputDir: "out", RunID: "r1"},
+			wantErr: "",
+		},
+		{
+			name:    "cwd checked before output dir",
+			opts:    RunLoopOptions{},
+			wantErr: "overnight: RunLoopOptions.Cwd is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRunLoopOptions(tt.opts)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateRunLoopOptions: got error %q, want nil", err.Error())
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateRunLoopOptions: got nil, want error %q", tt.wantErr)
+			}
+			if got := err.Error(); got != tt.wantErr {
+				t.Fatalf("validateRunLoopOptions: got %q, want %q", got, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestNewRunLoopResult verifies the constructor copies warn-only ratchet
+// fields into the result and preserves the caller-supplied iterations and
+// degraded slices.
+func TestNewRunLoopResult(t *testing.T) {
+	priors := []IterationSummary{
+		{Index: 1, Status: StatusDone},
+		{Index: 2, Status: StatusDegraded},
+	}
+	degraded := []string{"note a", "note b"}
+
+	t.Run("no ratchet leaves budget zero", func(t *testing.T) {
+		got := newRunLoopResult(priors, degraded, RunLoopOptions{})
+		if got.WarnOnlyBudgetInitial != 0 {
+			t.Fatalf("WarnOnlyBudgetInitial: got %d, want 0", got.WarnOnlyBudgetInitial)
+		}
+		if got.WarnOnlyBudgetRemaining != 0 {
+			t.Fatalf("WarnOnlyBudgetRemaining: got %d, want 0", got.WarnOnlyBudgetRemaining)
+		}
+		if len(got.Iterations) != 2 {
+			t.Fatalf("Iterations length: got %d, want 2", len(got.Iterations))
+		}
+		if got.Iterations[0].Index != 1 {
+			t.Fatalf("Iterations[0].Index: got %d, want 1", got.Iterations[0].Index)
+		}
+		if len(got.Degraded) != 2 {
+			t.Fatalf("Degraded length: got %d, want 2", len(got.Degraded))
+		}
+		if got.Degraded[0] != "note a" {
+			t.Fatalf("Degraded[0]: got %q, want %q", got.Degraded[0], "note a")
+		}
+	})
+
+	t.Run("ratchet populates initial and remaining", func(t *testing.T) {
+		opts := RunLoopOptions{
+			WarnOnlyBudget: &WarnOnlyRatchet{Initial: 7, Remaining: 3},
+		}
+		got := newRunLoopResult(nil, nil, opts)
+		if got.WarnOnlyBudgetInitial != 7 {
+			t.Fatalf("WarnOnlyBudgetInitial: got %d, want 7", got.WarnOnlyBudgetInitial)
+		}
+		if got.WarnOnlyBudgetRemaining != 3 {
+			t.Fatalf("WarnOnlyBudgetRemaining: got %d, want 3", got.WarnOnlyBudgetRemaining)
+		}
+	})
+}
+
+// TestNewLoopIteration asserts the deterministic ID format and initial
+// status.
+func TestNewLoopIteration(t *testing.T) {
+	start := time.Date(2026, 4, 22, 10, 30, 0, 0, time.UTC)
+	got := newLoopIteration("run-abc", 5, start)
+	if string(got.ID) != "run-abc-iter-5" {
+		t.Fatalf("ID: got %q, want %q", string(got.ID), "run-abc-iter-5")
+	}
+	if got.Index != 5 {
+		t.Fatalf("Index: got %d, want 5", got.Index)
+	}
+	if !got.StartedAt.Equal(start) {
+		t.Fatalf("StartedAt: got %v, want %v", got.StartedAt, start)
+	}
+	if got.Status != StatusDone {
+		t.Fatalf("Status: got %q, want %q", got.Status, StatusDone)
+	}
+}
+
+// TestFinishIteration asserts FinishedAt is set in the future of iterStart
+// and Duration is a parseable non-negative string.
+func TestFinishIteration(t *testing.T) {
+	iter := &IterationSummary{}
+	start := time.Now().Add(-2 * time.Second)
+	finishIteration(iter, start)
+	if iter.FinishedAt.Before(start) {
+		t.Fatalf("FinishedAt: got %v, want >= %v", iter.FinishedAt, start)
+	}
+	d, err := time.ParseDuration(iter.Duration)
+	if err != nil {
+		t.Fatalf("Duration parse: got error %q, want nil", err.Error())
+	}
+	if d < 0 {
+		t.Fatalf("Duration: got %v, want >= 0", d)
+	}
+}
+
+// TestLastCompoundedSnapshot walks backwards through prior iterations and
+// returns the most recent corpus-compounded iteration's FitnessAfter as a
+// FitnessSnapshot.
+func TestLastCompoundedSnapshot(t *testing.T) {
+	tests := []struct {
+		name       string
+		priors     []IterationSummary
+		wantNil    bool
+		wantMetric string
+		wantValue  float64
+	}{
+		{
+			name:    "empty slice",
+			priors:  nil,
+			wantNil: true,
+		},
+		{
+			name: "no compounded entries returns nil",
+			priors: []IterationSummary{
+				{Status: StatusDegraded, FitnessAfter: map[string]any{"m": 0.5}},
+				{Status: StatusRolledBackPreCommit, FitnessAfter: map[string]any{"m": 0.6}},
+			},
+			wantNil: true,
+		},
+		{
+			name: "picks most recent StatusDone",
+			priors: []IterationSummary{
+				{Status: StatusDone, FitnessAfter: map[string]any{"m": 0.1}},
+				{Status: StatusDone, FitnessAfter: map[string]any{"m": 0.7}},
+				{Status: StatusDegraded},
+			},
+			wantNil:    false,
+			wantMetric: "m",
+			wantValue:  0.7,
+		},
+		{
+			name: "post-commit halt counts as compounded",
+			priors: []IterationSummary{
+				{Status: StatusDone, FitnessAfter: map[string]any{"m": 0.2}},
+				{Status: StatusHaltedOnRegressionPostCommit, FitnessAfter: map[string]any{"m": 0.9}},
+			},
+			wantNil:    false,
+			wantMetric: "m",
+			wantValue:  0.9,
+		},
+		{
+			name: "stops at first compounded even when its map is unusable",
+			priors: []IterationSummary{
+				{Status: StatusDone, FitnessAfter: map[string]any{"m": 0.3}},
+				{Status: StatusDone, FitnessAfter: map[string]any{}},
+			},
+			wantNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := lastCompoundedSnapshot(tt.priors)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("lastCompoundedSnapshot: got %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("lastCompoundedSnapshot: got nil, want metric %q=%v", tt.wantMetric, tt.wantValue)
+			}
+			if v := got.Metrics[tt.wantMetric]; v != tt.wantValue {
+				t.Fatalf("Metrics[%q]: got %v, want %v", tt.wantMetric, v, tt.wantValue)
+			}
+		})
+	}
+}
+
+// TestIngestSummary asserts the exact field-to-key mapping of the summary
+// marshal.
+func TestIngestSummary(t *testing.T) {
+	r := &IngestResult{
+		HarvestPreviewCount: 4,
+		ForgeArtifactsMined: 5,
+		ProvenanceAudited:   6,
+		MineFindingsNew:     7,
+	}
+	got := ingestSummary(r)
+	if got["harvest_preview_count"] != 4 {
+		t.Fatalf("harvest_preview_count: got %v, want 4", got["harvest_preview_count"])
+	}
+	if got["forge_artifacts_mined"] != 5 {
+		t.Fatalf("forge_artifacts_mined: got %v, want 5", got["forge_artifacts_mined"])
+	}
+	if got["provenance_audited"] != 6 {
+		t.Fatalf("provenance_audited: got %v, want 6", got["provenance_audited"])
+	}
+	if got["mine_findings_new"] != 7 {
+		t.Fatalf("mine_findings_new: got %v, want 7", got["mine_findings_new"])
+	}
+	if len(got) != 4 {
+		t.Fatalf("summary key count: got %d, want 4", len(got))
+	}
+}
+
+// TestReduceSummary asserts every field of ReduceResult is projected to
+// the expected key in the summary map.
+func TestReduceSummary(t *testing.T) {
+	r := &ReduceResult{
+		HarvestPromoted:   1,
+		DedupMerged:       2,
+		MaturityTempered:  3,
+		DefragPruned:      4,
+		CloseLoopPromoted: 5,
+		FindingsRouted:    6,
+		InjectRefreshed:   true,
+		RolledBack:        true,
+	}
+	got := reduceSummary(r)
+	wantInts := map[string]int{
+		"harvest_promoted":    1,
+		"dedup_merged":        2,
+		"maturity_tempered":   3,
+		"defrag_pruned":       4,
+		"close_loop_promoted": 5,
+		"findings_routed":     6,
+	}
+	for k, v := range wantInts {
+		if got[k] != v {
+			t.Fatalf("%s: got %v, want %d", k, got[k], v)
+		}
+	}
+	if got["inject_refreshed"] != true {
+		t.Fatalf("inject_refreshed: got %v, want true", got["inject_refreshed"])
+	}
+	if got["rolled_back"] != true {
+		t.Fatalf("rolled_back: got %v, want true", got["rolled_back"])
+	}
+	if len(got) != 8 {
+		t.Fatalf("summary key count: got %d, want 8", len(got))
+	}
+}
+
+// TestMeasureSummary asserts the summary contains findings/inject keys
+// always, and fitness only when Fitness is non-nil.
+func TestMeasureSummary(t *testing.T) {
+	t.Run("nil fitness omits fitness key", func(t *testing.T) {
+		r := &MeasureResult{FindingsResolved: 2, InjectVisibility: 0.75}
+		got := measureSummary(r)
+		if got["findings_resolved"] != 2 {
+			t.Fatalf("findings_resolved: got %v, want 2", got["findings_resolved"])
+		}
+		if got["inject_visibility"] != 0.75 {
+			t.Fatalf("inject_visibility: got %v, want 0.75", got["inject_visibility"])
+		}
+		if _, ok := got["fitness"]; ok {
+			t.Fatalf("fitness key: got present, want absent")
+		}
+		if len(got) != 2 {
+			t.Fatalf("summary key count: got %d, want 2", len(got))
+		}
+	})
+}
+
+// TestSnapshotToMap asserts every metric key flows into the output map
+// unchanged.
+func TestSnapshotToMap(t *testing.T) {
+	snap := FitnessSnapshot{
+		Metrics: map[string]float64{"a": 1.5, "b": -2.0, "c": 0.0},
+	}
+	got := snapshotToMap(snap)
+	if len(got) != 3 {
+		t.Fatalf("map len: got %d, want 3", len(got))
+	}
+	if got["a"] != 1.5 {
+		t.Fatalf("a: got %v, want 1.5", got["a"])
+	}
+	if got["b"] != -2.0 {
+		t.Fatalf("b: got %v, want -2.0", got["b"])
+	}
+	if got["c"] != 0.0 {
+		t.Fatalf("c: got %v, want 0.0", got["c"])
+	}
+}
+
+// TestSnapshotToMap_Empty exercises the zero-length case.
+func TestSnapshotToMap_Empty(t *testing.T) {
+	got := snapshotToMap(FitnessSnapshot{})
+	if len(got) != 0 {
+		t.Fatalf("empty snapshot map: got len %d, want 0", len(got))
+	}
+}
+
+// TestMapToSnapshot verifies JSON-round-trip numeric decoding and
+// silent-drop semantics on non-numeric entries. Nil input and
+// all-non-numeric input both return nil.
+func TestMapToSnapshot(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      map[string]any
+		wantNil bool
+		want    map[string]float64
+	}{
+		{
+			name:    "nil map",
+			in:      nil,
+			wantNil: true,
+		},
+		{
+			name:    "empty map",
+			in:      map[string]any{},
+			wantNil: true,
+		},
+		{
+			name:    "all non-numeric dropped yields nil",
+			in:      map[string]any{"s": "hello", "b": true},
+			wantNil: true,
+		},
+		{
+			name: "float64 preserved",
+			in:   map[string]any{"a": 1.25, "b": -3.5},
+			want: map[string]float64{"a": 1.25, "b": -3.5},
+		},
+		{
+			name: "int widened to float64",
+			in:   map[string]any{"a": 2, "b": -5},
+			want: map[string]float64{"a": 2.0, "b": -5.0},
+		},
+		{
+			name: "int64 widened to float64",
+			in:   map[string]any{"a": int64(9)},
+			want: map[string]float64{"a": 9.0},
+		},
+		{
+			name: "json.Number parsed to float64",
+			in:   map[string]any{"a": json.Number("3.14")},
+			want: map[string]float64{"a": 3.14},
+		},
+		{
+			name: "json.Number with parse error is silently dropped (alongside valid)",
+			in:   map[string]any{"a": json.Number("not-a-number"), "b": 1.0},
+			want: map[string]float64{"b": 1.0},
+		},
+		{
+			name: "non-numeric values silently dropped alongside numeric",
+			in:   map[string]any{"good": 1.0, "bad": "x"},
+			want: map[string]float64{"good": 1.0},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapToSnapshot(tt.in)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("mapToSnapshot: got %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("mapToSnapshot: got nil, want %v", tt.want)
+			}
+			if len(got.Metrics) != len(tt.want) {
+				t.Fatalf("metrics len: got %d, want %d (got=%v want=%v)",
+					len(got.Metrics), len(tt.want), got.Metrics, tt.want)
+			}
+			for k, v := range tt.want {
+				if got.Metrics[k] != v {
+					t.Fatalf("metric[%q]: got %v, want %v", k, got.Metrics[k], v)
+				}
+			}
+		})
+	}
+}
+
+// TestSnapshotMapRoundTrip verifies snapshotToMap and mapToSnapshot are
+// inverse for purely-numeric inputs.
+func TestSnapshotMapRoundTrip(t *testing.T) {
+	orig := FitnessSnapshot{Metrics: map[string]float64{"p": 0.42, "q": -1.125}}
+	m := snapshotToMap(orig)
+	back := mapToSnapshot(m)
+	if back == nil {
+		t.Fatalf("mapToSnapshot: got nil, want non-nil round-trip")
+	}
+	if len(back.Metrics) != 2 {
+		t.Fatalf("round-trip len: got %d, want 2", len(back.Metrics))
+	}
+	if back.Metrics["p"] != 0.42 {
+		t.Fatalf("p round-trip: got %v, want 0.42", back.Metrics["p"])
+	}
+	if back.Metrics["q"] != -1.125 {
+		t.Fatalf("q round-trip: got %v, want -1.125", back.Metrics["q"])
+	}
+}
+
+// TestRegressionNames asserts extraction is order-preserving and handles
+// the empty slice.
+func TestRegressionNames(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []MetricRegression
+		want []string
+	}{
+		{
+			name: "empty slice yields zero-length result",
+			in:   nil,
+			want: []string{},
+		},
+		{
+			name: "single entry",
+			in:   []MetricRegression{{Name: "retrieval_precision"}},
+			want: []string{"retrieval_precision"},
+		},
+		{
+			name: "preserves input order",
+			in: []MetricRegression{
+				{Name: "a"}, {Name: "b"}, {Name: "c"},
+			},
+			want: []string{"a", "b", "c"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := regressionNames(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len: got %d, want %d", len(got), len(tt.want))
+			}
+			for i, want := range tt.want {
+				if got[i] != want {
+					t.Fatalf("[%d]: got %q, want %q", i, got[i], want)
+				}
+			}
+		})
+	}
+}
+
+// TestRunTestPostCommitFaultInjector_NoInjector returns empty when no hook
+// is registered, which is the only path exercised when tests reset the
+// hook between runs.
+func TestRunTestPostCommitFaultInjector_NoInjector(t *testing.T) {
+	SetTestPostCommitFaultInjector(nil)
+	got := runTestPostCommitFaultInjector(3, "/tmp/doesnt-matter")
+	if got != "" {
+		t.Fatalf("no injector: got %q, want empty string", got)
+	}
+}
+
+// TestRunTestPostCommitFaultInjector_InjectorError exercises the error
+// wrap path. The message embeds both iteration index and the underlying
+// error text.
+func TestRunTestPostCommitFaultInjector_InjectorError(t *testing.T) {
+	t.Cleanup(func() { SetTestPostCommitFaultInjector(nil) })
+	var sawIter int
+	var sawCwd string
+	SetTestPostCommitFaultInjector(func(iterIndex int, cwd string) error {
+		sawIter = iterIndex
+		sawCwd = cwd
+		return &testErr{msg: "synthetic fault"}
+	})
+	got := runTestPostCommitFaultInjector(7, "/tmp/repo")
+	want := "iter-7 post-commit fault injection: synthetic fault"
+	if got != want {
+		t.Fatalf("msg: got %q, want %q", got, want)
+	}
+	if sawIter != 7 {
+		t.Fatalf("injector received iter: got %d, want 7", sawIter)
+	}
+	if sawCwd != "/tmp/repo" {
+		t.Fatalf("injector received cwd: got %q, want %q", sawCwd, "/tmp/repo")
+	}
+}
+
+// TestRunTestPostCommitFaultInjector_InjectorReturnsNil produces empty
+// output when the registered hook does not return an error.
+func TestRunTestPostCommitFaultInjector_InjectorReturnsNil(t *testing.T) {
+	t.Cleanup(func() { SetTestPostCommitFaultInjector(nil) })
+	SetTestPostCommitFaultInjector(func(iterIndex int, cwd string) error {
+		return nil
+	})
+	got := runTestPostCommitFaultInjector(1, "/tmp")
+	if got != "" {
+		t.Fatalf("nil-error injector: got %q, want empty string", got)
+	}
+}
+
+// TestIterationStatusCompoundedEnum asserts the compounded/non-compounded
+// partition the loop depends on. lastCompoundedSnapshot relies on this
+// partition to skip rolled-back and degraded iterations.
+func TestIterationStatusCompoundedEnum(t *testing.T) {
+	compounded := []IterationStatus{
+		StatusDone,
+		StatusHaltedOnRegressionPostCommit,
+	}
+	notCompounded := []IterationStatus{
+		StatusDegraded,
+		StatusRolledBackPreCommit,
+		StatusHaltedOnRegressionPreCommit,
+		StatusFailed,
+	}
+	for _, s := range compounded {
+		if !s.IsCorpusCompounded() {
+			t.Fatalf("IsCorpusCompounded(%q): got false, want true", s)
+		}
+	}
+	for _, s := range notCompounded {
+		if s.IsCorpusCompounded() {
+			t.Fatalf("IsCorpusCompounded(%q): got true, want false", s)
+		}
+	}
+}
+
+// TestErrNotImplementedText pins the sentinel error's public message so
+// callers that match on it stay stable.
+func TestErrNotImplementedText(t *testing.T) {
+	got := ErrNotImplemented.Error()
+	want := "overnight: stage not implemented yet (skeleton wave)"
+	if got != want {
+		t.Fatalf("ErrNotImplemented.Error(): got %q, want %q", got, want)
+	}
+	if !strings.Contains(got, "skeleton wave") {
+		t.Fatalf("ErrNotImplemented.Error(): got %q, want substring %q", got, "skeleton wave")
+	}
+}
+
+// testErr is a tiny error type used to assert the post-commit fault
+// injector wraps the error message intact.
+type testErr struct{ msg string }
+
+func (e *testErr) Error() string { return e.msg }

--- a/cli/internal/quality/metrics_golden_test.go
+++ b/cli/internal/quality/metrics_golden_test.go
@@ -1,0 +1,271 @@
+package quality
+
+import (
+	"bytes"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/boshu2/agentops/cli/internal/types"
+)
+
+func TestCanonicalCitationType(t *testing.T) {
+	cases := map[string]string{
+		"applied":   "applied",
+		"apply":     "applied",
+		"APPLIED":   "applied",
+		"retrieved": "retrieved",
+		"retrieve":  "retrieved",
+		"pulled":    "retrieved",
+		"pull":      "retrieved",
+		"unknown":   "unknown",
+		"  APPLY ":  "applied",
+	}
+	for in, want := range cases {
+		if got := CanonicalCitationType(in); got != want {
+			t.Errorf("%q: got %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestLinearRegressionSlope(t *testing.T) {
+	// Perfect increasing line y = 2x + 1
+	xs := []float64{1, 2, 3, 4, 5}
+	ys := []float64{3, 5, 7, 9, 11}
+	got := LinearRegressionSlope(xs, ys)
+	if math.Abs(got-2.0) > 0.001 {
+		t.Errorf("got %v, want ~2.0", got)
+	}
+
+	// Flat line
+	got2 := LinearRegressionSlope([]float64{1, 2, 3}, []float64{5, 5, 5})
+	if math.Abs(got2) > 0.001 {
+		t.Errorf("flat: got %v, want 0", got2)
+	}
+
+	// Insufficient data
+	if got := LinearRegressionSlope([]float64{1}, []float64{5}); got != 0 {
+		t.Errorf("single point: got %v, want 0", got)
+	}
+
+	// Zero denominator (all xs equal)
+	if got := LinearRegressionSlope([]float64{3, 3, 3}, []float64{1, 2, 3}); got != 0 {
+		t.Errorf("vertical: got %v, want 0", got)
+	}
+}
+
+func TestGiniCoefficient(t *testing.T) {
+	// Perfect equality
+	if got := GiniCoefficient([]float64{5, 5, 5, 5}); math.Abs(got) > 0.001 {
+		t.Errorf("equal: got %v, want ~0", got)
+	}
+
+	// Empty
+	if got := GiniCoefficient(nil); got != 0 {
+		t.Errorf("empty: got %v", got)
+	}
+
+	// All zeros
+	if got := GiniCoefficient([]float64{0, 0, 0}); got != 0 {
+		t.Errorf("zeros: got %v", got)
+	}
+
+	// Max inequality: one person has everything
+	got := GiniCoefficient([]float64{0, 0, 0, 10})
+	if got < 0.5 {
+		t.Errorf("unequal: got %v, want >0.5", got)
+	}
+	if got > 1.0 {
+		t.Errorf("gini must be ≤1, got %v", got)
+	}
+}
+
+func TestTop10BottomRatio(t *testing.T) {
+	// Empty / small
+	if got := Top10BottomRatio(nil); got != 0 {
+		t.Errorf("nil: got %v", got)
+	}
+
+	// Uniform ascending
+	sorted := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	got := Top10BottomRatio(sorted)
+	if got <= 0 {
+		t.Errorf("should be positive, got %v", got)
+	}
+
+	// All zero bottom -> 999
+	zeros := []float64{0, 0, 0, 0, 0, 0, 0, 0, 0, 5}
+	if got := Top10BottomRatio(zeros); got != 999.0 {
+		t.Errorf("all-zero bottom: got %v, want 999", got)
+	}
+}
+
+func TestExtractResearchRefsFromText(t *testing.T) {
+	text := `See .agents/research/alpha.md for details.
+Also /home/user/proj/.agents/research/beta.md matters.
+And .agents/research/alpha.md again (should dedup).
+Non-match: some other file.`
+	refs := ExtractResearchRefsFromText(text)
+	if len(refs) < 2 {
+		t.Errorf("expected at least 2 refs, got %v", refs)
+	}
+}
+
+func TestExtractResearchRefsFromText_Empty(t *testing.T) {
+	if got := ExtractResearchRefsFromText("no refs here"); got != nil {
+		t.Errorf("got %v, want nil", got)
+	}
+}
+
+func TestCountCitationsInPeriod(t *testing.T) {
+	tmp := t.TempDir()
+	citPath := filepath.Join(tmp, "citations.jsonl")
+	recent := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
+	old := time.Now().Add(-365 * 24 * time.Hour).Format(time.RFC3339)
+	body := `{"artifact_path":".agents/learnings/a.md","cited_at":"` + recent + `"}
+{"artifact_path":".agents/learnings/b.md","cited_at":"` + recent + `"}
+{"artifact_path":".agents/learnings/a.md","cited_at":"` + old + `"}
+not-json-line
+`
+	_ = os.WriteFile(citPath, []byte(body), 0o600)
+
+	cutoff := time.Now().Add(-2 * time.Hour)
+	counts := CountCitationsInPeriod(citPath, cutoff)
+	if counts["a.md"] != 1 {
+		t.Errorf("a.md = %d, want 1 (old one filtered)", counts["a.md"])
+	}
+	if counts["b.md"] != 1 {
+		t.Errorf("b.md = %d", counts["b.md"])
+	}
+}
+
+func TestLearningCitationCounts(t *testing.T) {
+	tmp := t.TempDir()
+	names := []string{"a.md", "b.md", "skip.txt"}
+	for _, n := range names {
+		_ = os.WriteFile(filepath.Join(tmp, n), []byte("x"), 0o600)
+	}
+	_ = os.MkdirAll(filepath.Join(tmp, "subdir"), 0o755)
+
+	entries, _ := os.ReadDir(tmp)
+	citCounts := map[string]int{"a.md": 5, "b.md": 0}
+
+	counts, cited, total := LearningCitationCounts(entries, citCounts)
+	if total != 2 {
+		t.Errorf("total = %d (should skip subdir and .txt)", total)
+	}
+	if cited != 1 {
+		t.Errorf("cited = %d", cited)
+	}
+	if len(counts) != 2 {
+		t.Errorf("counts len = %d", len(counts))
+	}
+}
+
+func TestComputeOverallVerdict(t *testing.T) {
+	// 3+ positives -> compounding
+	gs := &types.GoldenSignals{
+		TrendVerdict:         "compounding",
+		PipelineVerdict:      "reinforcing",
+		ClosureVerdict:       "mining",
+		ConcentrationVerdict: "concentrated",
+	}
+	if got := ComputeOverallVerdict(gs); got != "compounding" {
+		t.Errorf("got %q", got)
+	}
+
+	// 3+ negatives -> decaying
+	gs2 := &types.GoldenSignals{
+		TrendVerdict:         "decaying",
+		PipelineVerdict:      "degrading",
+		ClosureVerdict:       "hoarding",
+		ConcentrationVerdict: "dormant",
+	}
+	if got := ComputeOverallVerdict(gs2); got != "decaying" {
+		t.Errorf("got %q", got)
+	}
+
+	// Neutral -> accumulating
+	gs3 := &types.GoldenSignals{
+		TrendVerdict:         "stable",
+		PipelineVerdict:      "stable",
+		ClosureVerdict:       "stable",
+		ConcentrationVerdict: "stable",
+	}
+	if got := ComputeOverallVerdict(gs3); got != "accumulating" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestFprintGoldenSignals_Nil(t *testing.T) {
+	var buf bytes.Buffer
+	FprintGoldenSignals(&buf, nil)
+	if !strings.Contains(buf.String(), "insufficient data") {
+		t.Errorf("output = %q", buf.String())
+	}
+}
+
+func TestFprintGoldenSignals_Populated(t *testing.T) {
+	var buf bytes.Buffer
+	gs := &types.GoldenSignals{
+		TrendVerdict:         "compounding",
+		PipelineVerdict:      "reinforcing",
+		ClosureVerdict:       "mining",
+		ConcentrationVerdict: "concentrated",
+		OverallVerdict:       "compounding",
+	}
+	FprintGoldenSignals(&buf, gs)
+	out := buf.String()
+	for _, expected := range []string{"GOLDEN SIGNALS", "Velocity Trend", "compounding", "OVERALL"} {
+		if !strings.Contains(out, expected) {
+			t.Errorf("missing %q in output: %q", expected, out)
+		}
+	}
+}
+
+func TestReadJSONLFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "a.jsonl")
+	_ = os.WriteFile(path, []byte(`{"a":1}
+
+{"b":2}
+`), 0o600)
+
+	got := ReadJSONLFile(path)
+	if len(got) != 2 {
+		t.Errorf("got %d lines, want 2", len(got))
+	}
+
+	// Missing file returns nil
+	if got := ReadJSONLFile(filepath.Join(tmp, "missing.jsonl")); got != nil {
+		t.Errorf("missing file should return nil, got %v", got)
+	}
+}
+
+func TestComputeVelocityTrend_NoMetrics(t *testing.T) {
+	tmp := t.TempDir()
+	t7, t30, verdict, err := ComputeVelocityTrend(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if t7 != 0 || t30 != 0 {
+		t.Errorf("should be zero, got %v %v", t7, t30)
+	}
+	if verdict != "stagnant" {
+		t.Errorf("got %q", verdict)
+	}
+}
+
+func TestComputeReuseConcentration_NoLearnings(t *testing.T) {
+	tmp := t.TempDir()
+	gini, pct, tb, verdict := ComputeReuseConcentration(tmp, 30)
+	if gini != 0 || pct != 0 || tb != 0 {
+		t.Errorf("all zeros expected, got %v %v %v", gini, pct, tb)
+	}
+	if verdict != "dormant" {
+		t.Errorf("got %q", verdict)
+	}
+}

--- a/cli/internal/rpi/artifacts_test.go
+++ b/cli/internal/rpi/artifacts_test.go
@@ -1,0 +1,126 @@
+package rpi
+
+import (
+	"testing"
+)
+
+func TestPathClean(t *testing.T) {
+	cases := map[string]string{
+		"  foo/bar  ":    "foo/bar",
+		"foo//bar":       "foo/bar",
+		"foo/./bar":      "foo/bar",
+		"foo/bar/../baz": "foo/baz",
+	}
+	for in, want := range cases {
+		if got := PathClean(in); got != want {
+			t.Errorf("PathClean(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestIsSafeArtifactRelPath(t *testing.T) {
+	safe := []string{
+		"a/b.json",
+		"plans/plan.md",
+		"x.txt",
+	}
+	for _, p := range safe {
+		if !IsSafeArtifactRelPath(p) {
+			t.Errorf("%q should be safe", p)
+		}
+	}
+	unsafe := []string{
+		"",
+		".",
+		"..",
+		"../x",
+		"/absolute",
+		"/etc/passwd",
+	}
+	for _, p := range unsafe {
+		if IsSafeArtifactRelPath(p) {
+			t.Errorf("%q should be unsafe", p)
+		}
+	}
+}
+
+func TestClassifyRPIArtifact(t *testing.T) {
+	cases := []struct {
+		rel       string
+		wantKind  string
+		wantPhase int
+	}{
+		{".agents/rpi/runs/x/execution-packet.json", "execution_packet", 0},
+		{".agents/rpi/state.json", "phased_state", 0},
+		{".agents/rpi/runs/x/c2-events.jsonl", "run_events", 0},
+		{".agents/rpi/runs/x/heartbeat.txt", "run_heartbeat", 0},
+		{".agents/rpi/runs/x/phase-2-result.json", "phase_result", 2},
+		{".agents/rpi/runs/x/phase-1-handoff.json", "phase_handoff", 1},
+		{".agents/rpi/runs/x/phase-3-summary.md", "phase_summary", 3},
+		{".agents/rpi/runs/x/phase-2-evaluator.json", "phase_evaluator", 2},
+		{".agents/rpi/plans/foo.md", "plan", 0},
+		{".agents/rpi/research/x.md", "research", 0},
+		{".agents/rpi/council/pre-mortem-x.md", "council_pre_mortem", 0},
+		{".agents/rpi/council/post-mortem-y.md", "council_post_mortem", 0},
+		{".agents/rpi/council/vibe-check.md", "council_vibe", 0},
+		{"random/file.txt", "artifact", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.rel, func(t *testing.T) {
+			kind, _, phase := ClassifyRPIArtifact(tc.rel, "state.json", "c2-events.jsonl")
+			if kind != tc.wantKind || phase != tc.wantPhase {
+				t.Errorf("got (%q, %d), want (%q, %d)", kind, phase, tc.wantKind, tc.wantPhase)
+			}
+		})
+	}
+}
+
+func TestArtifactPhaseNumber(t *testing.T) {
+	cases := map[string]int{
+		"phase-1-result.json":  1,
+		"phase-42-handoff.md":  42,
+		"no-phase-here.txt":    0,
+		"phase-notanumber.txt": 0,
+	}
+	for in, want := range cases {
+		if got := ArtifactPhaseNumber(in); got != want {
+			t.Errorf("ArtifactPhaseNumber(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestArtifactContentType(t *testing.T) {
+	cases := map[string]string{
+		"foo.json":  "application/json",
+		"foo.jsonl": "application/json",
+		"foo.md":    "text/markdown",
+		"foo.mdx":   "text/markdown",
+		"foo.txt":   "text/plain",
+		"foo":       "text/plain",
+		"foo.JSON":  "application/json", // case-insensitive
+	}
+	for in, want := range cases {
+		if got := ArtifactContentType(in); got != want {
+			t.Errorf("ArtifactContentType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSortArtifactRefs(t *testing.T) {
+	refs := []ArtifactRef{
+		{Path: "b.json", UpdatedAt: "2026-04-20T10:00:00Z"},
+		{Path: "a.json", UpdatedAt: "2026-04-22T10:00:00Z"},
+		{Path: "c.json", UpdatedAt: "2026-04-22T10:00:00Z"},
+	}
+	SortArtifactRefs(refs)
+	// Newest first; within same date, alphabetical
+	if refs[0].Path != "a.json" {
+		t.Errorf("[0] = %q", refs[0].Path)
+	}
+	if refs[1].Path != "c.json" {
+		t.Errorf("[1] = %q", refs[1].Path)
+	}
+	if refs[2].Path != "b.json" {
+		t.Errorf("[2] = %q", refs[2].Path)
+	}
+}

--- a/cli/internal/rpi/cancel_test.go
+++ b/cli/internal/rpi/cancel_test.go
@@ -1,0 +1,174 @@
+package rpi
+
+import (
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestParseCancelSignal(t *testing.T) {
+	cases := []struct {
+		in   string
+		want syscall.Signal
+		err  bool
+	}{
+		{"", syscall.SIGTERM, false},
+		{"TERM", syscall.SIGTERM, false},
+		{"SIGTERM", syscall.SIGTERM, false},
+		{"KILL", syscall.SIGKILL, false},
+		{"SIGKILL", syscall.SIGKILL, false},
+		{"INT", syscall.SIGINT, false},
+		{"SIGINT", syscall.SIGINT, false},
+		{"sigkill", syscall.SIGKILL, false}, // lowercase OK
+		{"BOGUS", 0, true},
+	}
+	for _, tc := range cases {
+		got, err := ParseCancelSignal(tc.in)
+		if (err != nil) != tc.err {
+			t.Errorf("%q: err = %v, wantErr = %v", tc.in, err, tc.err)
+			continue
+		}
+		if !tc.err && got != tc.want {
+			t.Errorf("%q: got %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDedupeInts(t *testing.T) {
+	got := DedupeInts([]int{3, 1, 2, 1, 3, 4})
+	want := []int{1, 2, 3, 4}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("[%d] = %d", i, got[i])
+		}
+	}
+}
+
+func TestFilterKillablePIDs(t *testing.T) {
+	got := FilterKillablePIDs([]int{0, 1, 99, 100, 99, 0}, 100)
+	// 0, 1 excluded; 100 is self; duplicates deduped
+	want := []int{99}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestDescendantPIDs(t *testing.T) {
+	// Process tree: 100 -> 200 -> 300, 100 -> 400
+	procs := []ProcessInfo{
+		{PID: 100, PPID: 1, Command: "parent"},
+		{PID: 200, PPID: 100, Command: "child1"},
+		{PID: 300, PPID: 200, Command: "grandchild"},
+		{PID: 400, PPID: 100, Command: "child2"},
+		{PID: 999, PPID: 1, Command: "unrelated"},
+	}
+	got := DescendantPIDs(100, procs)
+	want := map[int]bool{200: true, 300: true, 400: true}
+	if len(got) != 3 {
+		t.Fatalf("got %v, want 3 descendants", got)
+	}
+	for _, pid := range got {
+		if !want[pid] {
+			t.Errorf("unexpected pid %d", pid)
+		}
+	}
+}
+
+func TestProcessExists(t *testing.T) {
+	procs := []ProcessInfo{{PID: 100}, {PID: 200}}
+	if !ProcessExists(100, procs) {
+		t.Error("100 should exist")
+	}
+	if ProcessExists(500, procs) {
+		t.Error("500 should not exist")
+	}
+}
+
+func TestCollectRunProcessPIDs(t *testing.T) {
+	procs := []ProcessInfo{
+		{PID: 100, PPID: 1, Command: "ao rpi orchestrator"},
+		{PID: 200, PPID: 100, Command: "child"},
+		{PID: 300, PPID: 1, Command: "ao-rpi-abc123-p2-worker"},
+		{PID: 400, PPID: 1, Command: "other task in /tmp/worktree/rpi/abc123"},
+		{PID: 999, PPID: 1, Command: "unrelated"},
+	}
+	got := CollectRunProcessPIDs(100, "abc123", "/tmp/worktree/rpi/abc123", procs)
+	found := map[int]bool{}
+	for _, pid := range got {
+		found[pid] = true
+	}
+	if !found[100] || !found[200] {
+		t.Errorf("orchestrator+descendant missing: %v", got)
+	}
+	if !found[300] {
+		t.Errorf("session-needle match missing: %v", got)
+	}
+	if !found[400] {
+		t.Errorf("worktree-match missing: %v", got)
+	}
+	if found[999] {
+		t.Errorf("unrelated PID included: %v", got)
+	}
+}
+
+func TestSupervisorLeaseExpired(t *testing.T) {
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+
+	// No ExpiresAt -> never expires
+	if SupervisorLeaseExpired(SupervisorLeaseMetadata{}, now) {
+		t.Error("empty expiry should not be expired")
+	}
+
+	// Future expiry
+	m := SupervisorLeaseMetadata{ExpiresAt: "2026-04-22T13:00:00Z"}
+	if SupervisorLeaseExpired(m, now) {
+		t.Error("future expiry should not be expired")
+	}
+
+	// Past expiry
+	m2 := SupervisorLeaseMetadata{ExpiresAt: "2026-04-22T10:00:00Z"}
+	if !SupervisorLeaseExpired(m2, now) {
+		t.Error("past expiry should be expired")
+	}
+
+	// Malformed -> stale/expired
+	m3 := SupervisorLeaseMetadata{ExpiresAt: "not a time"}
+	if !SupervisorLeaseExpired(m3, now) {
+		t.Error("malformed expiry should be treated as expired")
+	}
+}
+
+func TestParseProcessList(t *testing.T) {
+	data := []byte(`
+  100     1 init
+  200   100 child proc with args
+  not a number line
+  300   200 grandchild
+`)
+	got, err := ParseProcessList(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d procs, want 3: %+v", len(got), got)
+	}
+	if got[0].PID != 100 || got[0].PPID != 1 || got[0].Command != "init" {
+		t.Errorf("first: %+v", got[0])
+	}
+	if got[1].Command != "child proc with args" {
+		t.Errorf("second command = %q", got[1].Command)
+	}
+}
+
+func TestParseProcessList_EmptyInput(t *testing.T) {
+	got, err := ParseProcessList([]byte(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %+v", got)
+	}
+}

--- a/cli/internal/rpi/cleanup_test.go
+++ b/cli/internal/rpi/cleanup_test.go
@@ -1,0 +1,194 @@
+package rpi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCheckTerminalRunStale_CompletedSkipped(t *testing.T) {
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	_, stale := CheckTerminalRunStale("r1", "/root", "/state", "completed", "", "", "", "/wt", 0, now)
+	if stale {
+		t.Error("completed runs should not be stale")
+	}
+}
+
+func TestCheckTerminalRunStale_NoWorktreeSkipped(t *testing.T) {
+	now := time.Now()
+	_, stale := CheckTerminalRunStale("r1", "/root", "/state", "interrupted", "", "", "", "", 0, now)
+	if stale {
+		t.Error("runs without worktree path should not be stale")
+	}
+}
+
+func TestCheckTerminalRunStale_NonExistentWorktreeSkipped(t *testing.T) {
+	now := time.Now()
+	_, stale := CheckTerminalRunStale("r1", "/root", "/state", "interrupted", "", "", "", "/nonexistent/xyz/abc", 0, now)
+	if stale {
+		t.Error("non-existent worktree should not be stale")
+	}
+}
+
+func TestCheckTerminalRunStale_MinAgeFiltersYoung(t *testing.T) {
+	tmp := t.TempDir()
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	// Started 10 minutes ago; minAge is 1 hour
+	startedAt := now.Add(-10 * time.Minute).Format(time.RFC3339)
+	_, stale := CheckTerminalRunStale("r1", "/root", "/state", "interrupted", "", "", startedAt, tmp, time.Hour, now)
+	if stale {
+		t.Error("young run should be filtered")
+	}
+}
+
+func TestCheckTerminalRunStale_AcceptsOldEnough(t *testing.T) {
+	tmp := t.TempDir()
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	startedAt := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	entry, stale := CheckTerminalRunStale("r1", "/root", "/state", "interrupted", "reason", "", startedAt, tmp, time.Hour, now)
+	if !stale {
+		t.Fatal("old run should be flagged stale")
+	}
+	if entry.RunID != "r1" {
+		t.Errorf("RunID = %q", entry.RunID)
+	}
+	if entry.Reason != "reason" {
+		t.Errorf("reason preserved: %q", entry.Reason)
+	}
+}
+
+func TestCheckTerminalRunStale_DefaultReasonWhenEmpty(t *testing.T) {
+	tmp := t.TempDir()
+	now := time.Now()
+	entry, stale := CheckTerminalRunStale("r1", "/root", "/state", "interrupted", "", "", "", tmp, 0, now)
+	if !stale {
+		t.Fatal("should be stale")
+	}
+	if !strings.Contains(entry.Reason, "terminal status: interrupted") {
+		t.Errorf("default reason = %q", entry.Reason)
+	}
+}
+
+func TestResolveCleanupRepoRoot_PrefersSibling(t *testing.T) {
+	target := "/parent/wt-a"
+	roots := []string{
+		"/parent/wt-b", // sibling
+		target,         // self
+		"/other/dir",   // unrelated
+	}
+	got := ResolveCleanupRepoRoot("/cwd", target, roots)
+	if got != "/parent/wt-b" {
+		t.Errorf("got %q, want sibling", got)
+	}
+}
+
+func TestResolveCleanupRepoRoot_FallsBackToCwd(t *testing.T) {
+	target := "/parent/wt-a"
+	roots := []string{target, "/other/dir"}
+	got := ResolveCleanupRepoRoot("/fallback", target, roots)
+	if got != "/fallback" {
+		t.Errorf("got %q, want /fallback", got)
+	}
+}
+
+func TestValidateWorktreeSibling_ValidSibling(t *testing.T) {
+	if err := ValidateWorktreeSibling("/parent/repo", "/parent/worktree"); err != nil {
+		t.Errorf("sibling should be valid: %v", err)
+	}
+}
+
+func TestValidateWorktreeSibling_NotSibling(t *testing.T) {
+	err := ValidateWorktreeSibling("/parent/repo", "/other/worktree")
+	if err == nil {
+		t.Fatal("should reject non-sibling")
+	}
+	if !strings.Contains(err.Error(), "not a sibling") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestValidateWorktreeSibling_RepoRootRefused(t *testing.T) {
+	err := ValidateWorktreeSibling("/parent/repo", "/parent/repo")
+	if err == nil {
+		t.Fatal("should refuse repo root")
+	}
+	if !strings.Contains(err.Error(), "repo root") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestPatchStateWithCancelFields(t *testing.T) {
+	tmp := t.TempDir()
+	state := filepath.Join(tmp, "state.json")
+	_ = os.WriteFile(state, []byte(`{"run_id":"r1","phase":2}`), 0o600)
+
+	err := PatchStateWithCancelFields(state, "user cancel", "2026-04-22T12:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(state)
+	body := string(data)
+	if !strings.Contains(body, `"terminal_status": "interrupted"`) {
+		t.Errorf("terminal_status missing, got: %s", body)
+	}
+	if !strings.Contains(body, `"terminal_reason": "user cancel"`) {
+		t.Errorf("reason missing: %s", body)
+	}
+}
+
+func TestPatchStateWithCancelFields_MissingFile(t *testing.T) {
+	err := PatchStateWithCancelFields("/nonexistent/xyz.json", "r", "t")
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestPatchStateWithCancelFields_InvalidJSON(t *testing.T) {
+	tmp := t.TempDir()
+	state := filepath.Join(tmp, "bad.json")
+	_ = os.WriteFile(state, []byte("not json"), 0o600)
+
+	err := PatchStateWithCancelFields(state, "r", "t")
+	if err == nil {
+		t.Error("expected error on invalid json")
+	}
+}
+
+func TestUpdateFlatStateIfMatches_MatchingRunID(t *testing.T) {
+	tmp := t.TempDir()
+	flat := filepath.Join(tmp, "flat.json")
+	_ = os.WriteFile(flat, []byte(`{"run_id":"r1","phase":2}`), 0o600)
+
+	UpdateFlatStateIfMatches(flat, "r1", "my reason", "2026-04-22T12:00:00Z")
+
+	data, _ := os.ReadFile(flat)
+	body := string(data)
+	if !strings.Contains(body, `"terminal_status": "stale"`) {
+		t.Errorf("status missing: %s", body)
+	}
+	if !strings.Contains(body, `"my reason"`) {
+		t.Errorf("reason missing: %s", body)
+	}
+}
+
+func TestUpdateFlatStateIfMatches_WrongRunID(t *testing.T) {
+	tmp := t.TempDir()
+	flat := filepath.Join(tmp, "flat.json")
+	original := `{"run_id":"r1","phase":2}`
+	_ = os.WriteFile(flat, []byte(original), 0o600)
+
+	UpdateFlatStateIfMatches(flat, "other-run", "reason", "time")
+
+	data, _ := os.ReadFile(flat)
+	if string(data) != original {
+		t.Errorf("file modified despite non-matching run_id: %s", string(data))
+	}
+}
+
+func TestUpdateFlatStateIfMatches_MissingFile(t *testing.T) {
+	// Should silently no-op, not panic
+	UpdateFlatStateIfMatches("/nonexistent/x.json", "r1", "r", "t")
+}

--- a/cli/internal/rpi/complexity_test.go
+++ b/cli/internal/rpi/complexity_test.go
@@ -1,0 +1,83 @@
+package rpi
+
+import "testing"
+
+func TestContainsWholeWord(t *testing.T) {
+	cases := []struct {
+		text string
+		kw   string
+		want bool
+	}{
+		{"refactor the thing", "refactor", true},
+		{"refactored the thing", "refactor", false},
+		{"support the thing", "port", false},
+		{"migrate this", "migrate", true},
+		{"case insensitive REFACTOR", "refactor", true},
+		{"every module now", "every module", true},
+		{"everyone", "every", false},
+	}
+	for _, tc := range cases {
+		if got := ContainsWholeWord(tc.text, tc.kw); got != tc.want {
+			t.Errorf("ContainsWholeWord(%q, %q) = %v, want %v", tc.text, tc.kw, got, tc.want)
+		}
+	}
+}
+
+func TestClassifyComplexity(t *testing.T) {
+	cases := []struct {
+		name string
+		goal string
+		want ComplexityLevel
+	}{
+		{"trivial fix", "fix typo", ComplexityFast},
+		{"short add", "add a helper", ComplexityFast},
+		{"refactor triggers full", "refactor auth module", ComplexityFull},
+		{"migrate triggers full", "migrate from v1 to v2", ComplexityFull},
+		{"long description triggers full", "This is a very long goal description that exceeds one hundred and twenty characters so it must be considered a complex task for proper handling.", ComplexityFull},
+		{"two scope keywords full", "change global throughout codebase", ComplexityFull},
+		{"one scope keyword is standard", "update the codebase slightly but very small set", ComplexityStandard},
+		{"medium length is standard", "update the login handler to use JWT instead of cookies and log events", ComplexityStandard},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyComplexity(tc.goal); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestScoreGoal(t *testing.T) {
+	s := ScoreGoal("  Refactor all modules to use new API  ")
+	if s.DescLen == 0 {
+		t.Error("DescLen should be populated")
+	}
+	if s.ComplexKeywords < 1 {
+		t.Errorf("expected refactor to match, got %+v", s)
+	}
+	if s.ScopeKeywords < 1 {
+		t.Errorf("expected 'all' scope keyword, got %+v", s)
+	}
+}
+
+func TestLevelFromScore(t *testing.T) {
+	cases := []struct {
+		name  string
+		score ComplexityScore
+		want  ComplexityLevel
+	}{
+		{"complex keyword -> full", ComplexityScore{DescLen: 20, ComplexKeywords: 1}, ComplexityFull},
+		{"2 scope keywords -> full", ComplexityScore{DescLen: 20, ScopeKeywords: 2}, ComplexityFull},
+		{"long desc -> full", ComplexityScore{DescLen: 200}, ComplexityFull},
+		{"medium desc -> standard", ComplexityScore{DescLen: 60}, ComplexityStandard},
+		{"1 scope keyword -> standard", ComplexityScore{DescLen: 20, ScopeKeywords: 1}, ComplexityStandard},
+		{"short trivial -> fast", ComplexityScore{DescLen: 20}, ComplexityFast},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := LevelFromScore(tc.score); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/internal/rpi/evaluator_test.go
+++ b/cli/internal/rpi/evaluator_test.go
@@ -1,0 +1,177 @@
+package rpi
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPhaseNameForNumber(t *testing.T) {
+	cases := map[int]string{
+		1:  "discovery",
+		2:  "implementation",
+		3:  "validation",
+		4:  "phase-4",
+		99: "phase-99",
+	}
+	for in, want := range cases {
+		if got := PhaseNameForNumber(in); got != want {
+			t.Errorf("PhaseNameForNumber(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestPhaseEvaluatorVerdict(t *testing.T) {
+	cases := []struct {
+		name          string
+		phaseNum      int
+		trackerMode   string
+		gateVerdict   string
+		hasTranscript bool
+		reward        float64
+		want          string
+	}{
+		{"fail gate -> FAIL", 2, "", "FAIL", false, 1.0, "FAIL"},
+		{"blocked gate -> FAIL", 2, "", "blocked", false, 1.0, "FAIL"},
+		{"low reward -> FAIL", 2, "", "PASS", true, 0.1, "FAIL"},
+		{"warn gate -> WARN", 2, "", "warn", false, 1.0, "WARN"},
+		{"partial gate -> WARN", 2, "", "partial", false, 1.0, "WARN"},
+		{"skip gate -> WARN", 2, "", "skip", false, 1.0, "WARN"},
+		{"phase 1 tasklist -> WARN", 1, "tasklist", "PASS", false, 1.0, "WARN"},
+		{"mid reward -> WARN", 2, "", "PASS", true, 0.4, "WARN"},
+		{"good reward -> PASS", 2, "", "PASS", true, 0.9, "PASS"},
+		{"no transcript -> PASS", 2, "", "PASS", false, 0.0, "PASS"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := PhaseEvaluatorVerdict(tc.phaseNum, tc.trackerMode, tc.gateVerdict, tc.hasTranscript, tc.reward)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPhaseEvaluatorSummary(t *testing.T) {
+	got := PhaseEvaluatorSummary(2, "", "PASS", true, 0.9, 0)
+	if !strings.Contains(got, "implementation evaluator marked the phase PASS") {
+		t.Errorf("got %q", got)
+	}
+	if !strings.Contains(got, "gate=PASS") {
+		t.Errorf("should include gate: %q", got)
+	}
+	if !strings.Contains(got, "reward=0.90") {
+		t.Errorf("should include reward: %q", got)
+	}
+
+	// With findings
+	got2 := PhaseEvaluatorSummary(2, "", "PASS", false, 0, 3)
+	if !strings.Contains(got2, "findings=3") {
+		t.Errorf("should include findings: %q", got2)
+	}
+
+	// Phase 1 tasklist fallback note
+	got3 := PhaseEvaluatorSummary(1, "tasklist", "PASS", false, 0, 0)
+	if !strings.Contains(got3, "tracker degraded") {
+		t.Errorf("should note tasklist: %q", got3)
+	}
+}
+
+func TestDefaultEvaluatorFindings(t *testing.T) {
+	// FAIL gate produces a finding
+	f := DefaultEvaluatorFindings(2, "", "FAIL", false, 0, "", "ref-1")
+	if len(f) == 0 {
+		t.Fatal("expected FAIL finding")
+	}
+	if !strings.Contains(f[0].Description, "FAIL") {
+		t.Errorf("finding desc = %q", f[0].Description)
+	}
+
+	// BLOCKED
+	f2 := DefaultEvaluatorFindings(2, "", "BLOCKED", false, 0, "", "ref")
+	if len(f2) == 0 || !strings.Contains(f2[0].Description, "blocked") {
+		t.Errorf("blocked finding missing: %+v", f2)
+	}
+
+	// PARTIAL
+	f3 := DefaultEvaluatorFindings(2, "", "PARTIAL", false, 0, "", "ref")
+	if len(f3) == 0 || !strings.Contains(f3[0].Description, "partial") {
+		t.Errorf("partial finding missing: %+v", f3)
+	}
+
+	// phase 1 tasklist
+	f4 := DefaultEvaluatorFindings(1, "tasklist", "PASS", false, 0, "", "ref")
+	found := false
+	for _, item := range f4 {
+		if strings.Contains(item.Description, "Tracker degraded") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("tasklist finding missing: %+v", f4)
+	}
+
+	// Low reward transcript
+	f5 := DefaultEvaluatorFindings(2, "", "PASS", true, 0.1, "/tmp/transcript", "ref")
+	if len(f5) == 0 || !strings.Contains(f5[0].Description, "failing session") {
+		t.Errorf("low reward finding missing: %+v", f5)
+	}
+
+	// Medium reward transcript
+	f6 := DefaultEvaluatorFindings(2, "", "PASS", true, 0.4, "/tmp/transcript", "ref")
+	if len(f6) == 0 || !strings.Contains(f6[0].Description, "weak completion") {
+		t.Errorf("weak completion finding missing: %+v", f6)
+	}
+
+	// Good reward -> no findings
+	f7 := DefaultEvaluatorFindings(2, "", "PASS", true, 0.9, "/tmp/transcript", "ref")
+	if len(f7) != 0 {
+		t.Errorf("expected no findings, got %+v", f7)
+	}
+}
+
+func TestUniqueFindings(t *testing.T) {
+	items := []Finding{
+		{Description: "a", Fix: "x"},
+		{Description: "a", Fix: "x"},    // duplicate
+		{Description: "b"},
+		{Description: "", Fix: "", Ref: ""}, // empty -> dropped
+	}
+	got := UniqueFindings(items)
+	if len(got) != 2 {
+		t.Fatalf("got %d, want 2: %+v", len(got), got)
+	}
+	if got[0].Description != "a" || got[1].Description != "b" {
+		t.Errorf("ordering: %+v", got)
+	}
+}
+
+func TestSessionIDFromEventDetails(t *testing.T) {
+	// Valid
+	data, _ := json.Marshal(map[string]any{"session_id": "s123"})
+	if got := SessionIDFromEventDetails(data); got != "s123" {
+		t.Errorf("got %q", got)
+	}
+
+	// Empty
+	if got := SessionIDFromEventDetails(nil); got != "" {
+		t.Errorf("got %q", got)
+	}
+
+	// Invalid JSON
+	if got := SessionIDFromEventDetails(json.RawMessage("not json")); got != "" {
+		t.Errorf("got %q", got)
+	}
+
+	// Missing field
+	data2, _ := json.Marshal(map[string]any{"other": "value"})
+	if got := SessionIDFromEventDetails(data2); got != "" {
+		t.Errorf("got %q", got)
+	}
+
+	// Whitespace gets trimmed
+	data3, _ := json.Marshal(map[string]any{"session_id": "  s456  "})
+	if got := SessionIDFromEventDetails(data3); got != "s456" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/cli/internal/rpi/handoff_test.go
+++ b/cli/internal/rpi/handoff_test.go
@@ -1,0 +1,223 @@
+package rpi
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUniqueStringsPreserveOrder(t *testing.T) {
+	in := []string{"  b ", "a", "b", "", "a", "  c"}
+	got := UniqueStringsPreserveOrder(in)
+	want := []string{"b", "a", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestStripMarkdownFrontmatter(t *testing.T) {
+	with := "---\nkey: value\n---\nbody content"
+	if got := StripMarkdownFrontmatter(with); got != "body content" {
+		t.Errorf("got %q", got)
+	}
+	without := "body only\nmore"
+	if got := StripMarkdownFrontmatter(without); got != without {
+		t.Error("no frontmatter should be returned as-is")
+	}
+	unterminated := "---\nkey: value\n(never closed)"
+	if got := StripMarkdownFrontmatter(unterminated); got != unterminated {
+		t.Error("unterminated fm should return original")
+	}
+}
+
+func TestExtractFindingIDs(t *testing.T) {
+	text := "found f-2026-04-02-1 and also f-2026-04-02-2, plus f-2026-04-02-1 again. Not a match: f-202-04-02-1"
+	got := ExtractFindingIDs(text)
+	want := []string{"f-2026-04-02-1", "f-2026-04-02-2"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestExtractBulletItemsAfterMarker(t *testing.T) {
+	text := `Some text.
+Marker:
+- item one
+- item two
+- item one
+
+## Next heading
+- ignored`
+	got := ExtractBulletItemsAfterMarker(text, "Marker:")
+	want := []string{"item one", "item two"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestExtractMarkdownListItemsUnderHeading(t *testing.T) {
+	text := `# Title
+
+## Findings
+
+- first
+* second
+- first
+
+## Other
+- not this`
+	got := ExtractMarkdownListItemsUnderHeading(text, "## Findings")
+	want := []string{"first", "second"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestTruncateRunes(t *testing.T) {
+	// Short ASCII
+	if got := TruncateRunes("hello", 10); got != "hello" {
+		t.Errorf("short: got %q", got)
+	}
+	// Long ASCII gets truncated
+	if got := TruncateRunes("hello world", 5); got != "hello..." {
+		t.Errorf("long: got %q", got)
+	}
+	// Multi-byte
+	s := "αβγδε" // 5 runes, 10 bytes
+	if got := TruncateRunes(s, 3); got != "αβγ..." {
+		t.Errorf("multi-byte: got %q", got)
+	}
+	// Multi-byte fits -> no change
+	if got := TruncateRunes(s, 10); got != s {
+		t.Errorf("fits: got %q", got)
+	}
+}
+
+func TestFormatVerdicts(t *testing.T) {
+	if got := FormatVerdicts(nil); got != "" {
+		t.Errorf("nil: got %q", got)
+	}
+	if got := FormatVerdicts(map[string]string{}); got != "" {
+		t.Errorf("empty: got %q", got)
+	}
+	got := FormatVerdicts(map[string]string{"code-review": "PASS", "pre-mortem": "WARN"})
+	// Keys are sorted alphabetically
+	if !strings.Contains(got, "code-review PASS") {
+		t.Errorf("got %q", got)
+	}
+	if !strings.Contains(got, "pre-mortem WARN") {
+		t.Errorf("got %q", got)
+	}
+	// code-review should come before pre-mortem
+	if idx1, idx2 := strings.Index(got, "code-review"), strings.Index(got, "pre-mortem"); idx1 > idx2 {
+		t.Errorf("keys not sorted: %q", got)
+	}
+}
+
+func TestRenderHandoffField(t *testing.T) {
+	if got := RenderHandoffField("Label", ""); got != "" {
+		t.Errorf("empty string: got %q", got)
+	}
+	if got := RenderHandoffField("Label", "value"); got != "Label: value\n" {
+		t.Errorf("got %q", got)
+	}
+	if got := RenderHandoffField("Items", []string{}); got != "" {
+		t.Errorf("empty list: got %q", got)
+	}
+	if got := RenderHandoffField("Items", []string{"a", "b"}); got != "Items: a, b\n" {
+		t.Errorf("got %q", got)
+	}
+	if got := RenderHandoffField("Bad", 42); got != "" {
+		t.Errorf("unsupported type: got %q", got)
+	}
+}
+
+func TestFieldAllowed(t *testing.T) {
+	// Empty list = allow all (backward compat)
+	if !FieldAllowed(nil, "any") {
+		t.Error("empty list should allow all")
+	}
+	if !FieldAllowed([]string{}, "any") {
+		t.Error("empty slice should allow all")
+	}
+	// Listed field allowed
+	if !FieldAllowed([]string{"findings", "verdicts"}, "findings") {
+		t.Error("listed field should be allowed")
+	}
+	// Unlisted field not allowed
+	if FieldAllowed([]string{"findings"}, "other") {
+		t.Error("unlisted field should not be allowed")
+	}
+}
+
+func TestResolveNarrativeCap(t *testing.T) {
+	// Explicit positive cap wins
+	if got := ResolveNarrativeCap(500, nil); got != 500 {
+		t.Errorf("got %d", got)
+	}
+	// Zero with empty fields -> default 1000
+	if got := ResolveNarrativeCap(0, nil); got != 1000 {
+		t.Errorf("got %d", got)
+	}
+	// Zero with non-empty fields -> 0 (omit)
+	if got := ResolveNarrativeCap(0, []string{"findings"}); got != 0 {
+		t.Errorf("got %d", got)
+	}
+}
+
+func TestRenderDegradationWarnings(t *testing.T) {
+	var sb strings.Builder
+	RenderDegradationWarnings(&sb, []int{2, 3})
+	out := sb.String()
+	if !strings.Contains(out, "Phase 1") {
+		t.Errorf("should mention phase-1, got %q", out)
+	}
+	if !strings.Contains(out, "Phase 2") {
+		t.Errorf("should mention phase-2, got %q", out)
+	}
+}
+
+func TestCompiledChecklistSummaryFromContent(t *testing.T) {
+	body := `---
+id: x
+---
+# Heading
+Prevent this known failure mode from recurring.
+
+- Do the thing
+- Source: somewhere
+- Do the other thing
+- Yet another item
+- This should be dropped`
+
+	got := CompiledChecklistSummaryFromContent("f-2026-04-22-1", body)
+	if !strings.HasPrefix(got, "f-2026-04-22-1 —") {
+		t.Errorf("should prefix with id, got %q", got)
+	}
+	if strings.Contains(got, "Source:") {
+		t.Errorf("Source line should be filtered, got %q", got)
+	}
+	if !strings.Contains(got, "Do the thing") {
+		t.Errorf("missing first item: %q", got)
+	}
+}
+
+func TestCompiledChecklistSummaryFromContent_EmptyReturnsID(t *testing.T) {
+	if got := CompiledChecklistSummaryFromContent("x-1", ""); got != "x-1" {
+		t.Errorf("got %q, want x-1", got)
+	}
+}

--- a/cli/internal/search/bead_context_test.go
+++ b/cli/internal/search/bead_context_test.go
@@ -1,0 +1,163 @@
+package search
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestSplitLabels(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"a, b, c", []string{"a", "b", "c"}},
+		{"  a  ,,  b  ", []string{"a", "b"}},
+		{"solo", []string{"solo"}},
+	}
+	for _, tc := range cases {
+		got := SplitLabels(tc.in)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("%q: got %v, want %v", tc.in, got, tc.want)
+		}
+	}
+
+	// Empty string: SplitLabels returns an empty (non-nil) slice.
+	if got := SplitLabels(""); len(got) != 0 {
+		t.Errorf("empty: got %v, want length 0", got)
+	}
+}
+
+func TestBuildKeywords(t *testing.T) {
+	ctx := &BeadContext{
+		Title:  "Fix Auth Bug Authentication",
+		Labels: []string{"bug", "auth", "AUTH"}, // last is duplicate after lower
+	}
+	keywords := BuildKeywords(ctx)
+
+	// Duplicates and short words removed
+	seen := map[string]bool{}
+	for _, k := range keywords {
+		seen[k] = true
+	}
+	if !seen["fix"] || !seen["auth"] || !seen["bug"] {
+		t.Errorf("missing expected keywords: %v", keywords)
+	}
+	// Count of unique lowered words: fix, auth, bug, authentication
+	if len(keywords) != 4 {
+		t.Errorf("got %d unique: %v", len(keywords), keywords)
+	}
+}
+
+func TestBuildKeywords_FiltersShort(t *testing.T) {
+	ctx := &BeadContext{Title: "a an is the fix"}
+	keywords := BuildKeywords(ctx)
+	// Short words (<2 chars) stripped: "a" dropped; "an", "is" kept (>=2)
+	for _, k := range keywords {
+		if len(k) < 2 {
+			t.Errorf("short kept: %q", k)
+		}
+	}
+}
+
+func TestResolveBeadContext_EmptyID(t *testing.T) {
+	if got := ResolveBeadContext("", ""); got != nil {
+		t.Error("empty ID should return nil")
+	}
+}
+
+func TestResolveBeadContext_Minimal(t *testing.T) {
+	tmp := t.TempDir()
+	// Clear relevant env vars
+	os.Unsetenv("HOOK_BEAD_TITLE")
+	os.Unsetenv("HOOK_BEAD_LABELS")
+	os.Unsetenv("HOOK_BEAD_PHASE")
+
+	ctx := ResolveBeadContext("bd-1", tmp)
+	if ctx == nil {
+		t.Fatal("expected non-nil")
+	}
+	if ctx.ID != "bd-1" {
+		t.Errorf("id = %q", ctx.ID)
+	}
+	if ctx.Title != "" {
+		t.Errorf("title should be empty, got %q", ctx.Title)
+	}
+}
+
+func TestResolveBeadContext_FromEnv(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOOK_BEAD_TITLE", "Fix auth")
+	t.Setenv("HOOK_BEAD_LABELS", "bug,auth")
+	t.Setenv("HOOK_BEAD_PHASE", "discovery")
+
+	ctx := ResolveBeadContext("bd-1", tmp)
+	if ctx.Title != "Fix auth" {
+		t.Errorf("title = %q", ctx.Title)
+	}
+	if len(ctx.Labels) != 2 {
+		t.Errorf("labels = %v", ctx.Labels)
+	}
+	if ctx.Phase != "discovery" {
+		t.Errorf("phase = %q", ctx.Phase)
+	}
+	if len(ctx.Keywords) == 0 {
+		t.Error("keywords should be built")
+	}
+}
+
+func TestResolveBeadContext_FromCache(t *testing.T) {
+	tmp := t.TempDir()
+	os.Unsetenv("HOOK_BEAD_TITLE")
+	os.Unsetenv("HOOK_BEAD_LABELS")
+
+	cacheDir := filepath.Join(tmp, ".agents", "ao")
+	_ = os.MkdirAll(cacheDir, 0o755)
+	cached := BeadContext{ID: "bd-42", Title: "Cached Bug", Labels: []string{"a"}}
+	data, _ := json.Marshal(cached)
+	_ = os.WriteFile(filepath.Join(cacheDir, BeadContextCacheFile), data, 0o600)
+
+	ctx := ResolveBeadContext("bd-42", tmp)
+	if ctx == nil {
+		t.Fatal("expected non-nil")
+	}
+	if ctx.Title != "Cached Bug" {
+		t.Errorf("title = %q", ctx.Title)
+	}
+	if len(ctx.Keywords) == 0 {
+		t.Error("keywords should be built from cache")
+	}
+}
+
+func TestReadBeadCache_WrongID(t *testing.T) {
+	tmp := t.TempDir()
+	cacheDir := filepath.Join(tmp, ".agents", "ao")
+	_ = os.MkdirAll(cacheDir, 0o755)
+	cached := BeadContext{ID: "bd-42"}
+	data, _ := json.Marshal(cached)
+	_ = os.WriteFile(filepath.Join(cacheDir, BeadContextCacheFile), data, 0o600)
+
+	// Different bead ID should return nil (cache mismatch)
+	if got := ReadBeadCache(tmp, "bd-99"); got != nil {
+		t.Error("mismatching id should yield nil")
+	}
+}
+
+func TestReadBeadCache_Missing(t *testing.T) {
+	tmp := t.TempDir()
+	if got := ReadBeadCache(tmp, "bd-1"); got != nil {
+		t.Error("missing cache should yield nil")
+	}
+}
+
+func TestReadBeadCache_InvalidJSON(t *testing.T) {
+	tmp := t.TempDir()
+	cacheDir := filepath.Join(tmp, ".agents", "ao")
+	_ = os.MkdirAll(cacheDir, 0o755)
+	_ = os.WriteFile(filepath.Join(cacheDir, BeadContextCacheFile), []byte("not json"), 0o600)
+	if got := ReadBeadCache(tmp, "bd-1"); got != nil {
+		t.Error("invalid json should yield nil")
+	}
+}

--- a/cli/internal/search/constraint_test.go
+++ b/cli/internal/search/constraint_test.go
@@ -1,0 +1,177 @@
+package search
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestConstraintIndexPath(t *testing.T) {
+	if got := ConstraintIndexPath(); got != filepath.Join(".agents", "constraints", "index.json") {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestConstraintLockPath(t *testing.T) {
+	if got := ConstraintLockPath(); got != filepath.Join(".agents", "constraints", "compile.lock") {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestLoadConstraintIndex_Missing(t *testing.T) {
+	tmp := t.TempDir()
+	prev, _ := os.Getwd()
+	defer func() { _ = os.Chdir(prev) }()
+	_ = os.Chdir(tmp)
+
+	_, err := LoadConstraintIndex()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "no constraints") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestLoadConstraintIndex_Valid(t *testing.T) {
+	tmp := t.TempDir()
+	prev, _ := os.Getwd()
+	defer func() { _ = os.Chdir(prev) }()
+	_ = os.Chdir(tmp)
+
+	_ = os.MkdirAll(filepath.Join(".agents", "constraints"), 0o755)
+	idx := ConstraintIndex{SchemaVersion: 1, Constraints: []ConstraintEntry{{ID: "c1", Title: "t"}}}
+	data, _ := json.MarshalIndent(idx, "", "  ")
+	_ = os.WriteFile(ConstraintIndexPath(), data, 0o600)
+
+	got, err := LoadConstraintIndex()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SchemaVersion != 1 || len(got.Constraints) != 1 {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestLoadConstraintIndex_Malformed(t *testing.T) {
+	tmp := t.TempDir()
+	prev, _ := os.Getwd()
+	defer func() { _ = os.Chdir(prev) }()
+	_ = os.Chdir(tmp)
+
+	_ = os.MkdirAll(filepath.Join(".agents", "constraints"), 0o755)
+	_ = os.WriteFile(ConstraintIndexPath(), []byte("not json"), 0o600)
+
+	_, err := LoadConstraintIndex()
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestFindConstraint(t *testing.T) {
+	idx := &ConstraintIndex{Constraints: []ConstraintEntry{
+		{ID: "c1", Title: "A"},
+		{ID: "c2", Title: "B"},
+	}}
+	if got := FindConstraint(idx, "c2"); got == nil || got.Title != "B" {
+		t.Errorf("got %+v", got)
+	}
+	if got := FindConstraint(idx, "missing"); got != nil {
+		t.Errorf("should return nil, got %+v", got)
+	}
+}
+
+func TestFilterStaleConstraints(t *testing.T) {
+	cutoff := time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC)
+	entries := []ConstraintEntry{
+		{ID: "a", Status: "active", CompiledAt: "2026-04-15T00:00:00Z"},   // stale (before cutoff)
+		{ID: "b", Status: "active", CompiledAt: "2026-04-25T00:00:00Z"},   // fresh
+		{ID: "c", Status: "retired", CompiledAt: "2026-04-01T00:00:00Z"},  // retired -> skipped
+		{ID: "d", Status: "draft", CompiledAt: "bogus"},                   // unparseable
+		{ID: "e", Status: "draft", CompiledAt: "2026-04-10"},              // date-only, stale
+	}
+	stale := FilterStaleConstraints(entries, cutoff)
+	ids := map[string]bool{}
+	for _, s := range stale {
+		ids[s.ID] = true
+	}
+	if !ids["a"] {
+		t.Error("a should be stale")
+	}
+	if ids["b"] {
+		t.Error("b should not be stale")
+	}
+	if ids["c"] {
+		t.Error("retired c should be skipped")
+	}
+	if ids["d"] {
+		t.Error("unparseable d should be skipped")
+	}
+	if !ids["e"] {
+		t.Error("date-only e should be stale")
+	}
+}
+
+func TestSaveConstraintIndexUnlocked(t *testing.T) {
+	tmp := t.TempDir()
+	prev, _ := os.Getwd()
+	defer func() { _ = os.Chdir(prev) }()
+	_ = os.Chdir(tmp)
+
+	idx := &ConstraintIndex{SchemaVersion: 1, Constraints: []ConstraintEntry{{ID: "x", Title: "Saved"}}}
+	if err := SaveConstraintIndexUnlocked(idx); err != nil {
+		t.Fatal(err)
+	}
+	// Re-read round-trip
+	loaded, err := LoadConstraintIndex()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Constraints) != 1 || loaded.Constraints[0].Title != "Saved" {
+		t.Errorf("round-trip failed: %+v", loaded)
+	}
+}
+
+func TestWithConstraintLock_RunsOnce(t *testing.T) {
+	tmp := t.TempDir()
+	prev, _ := os.Getwd()
+	defer func() { _ = os.Chdir(prev) }()
+	_ = os.Chdir(tmp)
+
+	called := 0
+	err := WithConstraintLock(func() error {
+		called++
+		// Lock file should exist during fn
+		if _, statErr := os.Stat(ConstraintLockPath()); statErr != nil {
+			t.Errorf("lock file missing during fn")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if called != 1 {
+		t.Errorf("called %d times", called)
+	}
+	// Lock file removed after fn
+	if _, err := os.Stat(ConstraintLockPath()); err == nil {
+		t.Error("lock file should be removed")
+	}
+}
+
+func TestWithConstraintLock_PropagatesError(t *testing.T) {
+	tmp := t.TempDir()
+	prev, _ := os.Getwd()
+	defer func() { _ = os.Chdir(prev) }()
+	_ = os.Chdir(tmp)
+
+	sentinel := errors.New("boom")
+	err := WithConstraintLock(func() error { return sentinel })
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err = %v", err)
+	}
+}

--- a/cli/internal/search/findings_test.go
+++ b/cli/internal/search/findings_test.go
@@ -1,0 +1,249 @@
+package search
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestFindingMatchesQuery(t *testing.T) {
+	f := KnowledgeFinding{
+		ID: "f-1", Title: "Null Pointer", Summary: "Nil deref in parser",
+		SourceSkill: "code-review", Severity: "high",
+		ScopeTags: []string{"go", "parser"},
+	}
+
+	if !FindingMatchesQuery(f, "") {
+		t.Error("empty query should match all")
+	}
+	if !FindingMatchesQuery(f, "null") {
+		t.Error("should match title")
+	}
+	if !FindingMatchesQuery(f, "go") {
+		t.Error("should match scope tag")
+	}
+	if !FindingMatchesQuery(f, "high") {
+		t.Error("should match severity")
+	}
+	if FindingMatchesQuery(f, "nonexistent") {
+		t.Error("unknown query shouldn't match")
+	}
+	// Note: caller is expected to pre-lowercase the query. Upper-case queries won't match.
+	if FindingMatchesQuery(f, "NULL") {
+		t.Error("query is expected to be pre-lowered; upper-case should not match")
+	}
+}
+
+func TestFindingStatusActiveForRetrieval(t *testing.T) {
+	cases := map[string]bool{
+		"":           true,
+		"active":     true,
+		"retired":    false,
+		"RETIRED":    false,
+		"superseded": false,
+		"unknown":    true,
+	}
+	for in, want := range cases {
+		if got := FindingStatusActiveForRetrieval(in); got != want {
+			t.Errorf("%q: got %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestParseFindingTime(t *testing.T) {
+	ts, ok := ParseFindingTime("2026-04-22T12:00:00Z")
+	if !ok {
+		t.Fatal("expected ok=true for valid RFC3339")
+	}
+	if ts.Year() != 2026 {
+		t.Errorf("year = %d", ts.Year())
+	}
+
+	_, ok = ParseFindingTime("")
+	if ok {
+		t.Error("empty should fail")
+	}
+
+	_, ok = ParseFindingTime("not a time")
+	if ok {
+		t.Error("invalid should fail")
+	}
+}
+
+func TestTrimField(t *testing.T) {
+	cases := map[string]string{
+		"key: value":       "value",
+		`key: "quoted"`:    "quoted",
+		"key: 'single'":    "single",
+		"key:   spaced   ": "spaced",
+		"no colon here":    "",
+	}
+	for in, want := range cases {
+		if got := TrimField(in); got != want {
+			t.Errorf("%q: got %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestParseListField(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"[a, b, c]", []string{"a", "b", "c"}},
+		{"a, b", []string{"a", "b"}},
+		{"", nil},
+		{"[]", nil},
+		{`["quoted", "also"]`, []string{"quoted", "also"}},
+	}
+	for _, tc := range cases {
+		got := ParseListField(tc.in)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("%q: got %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseIntField(t *testing.T) {
+	if got := ParseIntField("42"); got != 42 {
+		t.Errorf("got %d", got)
+	}
+	if got := ParseIntField("not a number"); got != 0 {
+		t.Errorf("got %d", got)
+	}
+	if got := ParseIntField("  7  "); got != 7 {
+		t.Errorf("trimmed: got %d", got)
+	}
+}
+
+func TestApplyFindingField(t *testing.T) {
+	var f KnowledgeFinding
+	ApplyFindingField(&f, "id: f-123")
+	ApplyFindingField(&f, "title: My Title")
+	ApplyFindingField(&f, "severity: high")
+	ApplyFindingField(&f, "status: retired")
+	ApplyFindingField(&f, "scope_tags: [go, rust]")
+	ApplyFindingField(&f, "hit_count: 5")
+
+	if f.ID != "f-123" || f.Title != "My Title" || f.Severity != "high" || f.Status != "retired" {
+		t.Errorf("fields wrong: %+v", f)
+	}
+	if len(f.ScopeTags) != 2 || f.ScopeTags[0] != "go" {
+		t.Errorf("scope tags wrong: %v", f.ScopeTags)
+	}
+	if f.HitCount != 5 {
+		t.Errorf("hit count = %d", f.HitCount)
+	}
+}
+
+func TestApplyFindingField_Hyphenated(t *testing.T) {
+	// Both hyphen and underscore forms should be supported
+	var f KnowledgeFinding
+	ApplyFindingField(&f, "source-skill: my-skill")
+	ApplyFindingField(&f, "applicable-languages: [python]")
+	if f.SourceSkill != "my-skill" {
+		t.Errorf("source-skill = %q", f.SourceSkill)
+	}
+	if len(f.ApplicableLanguages) != 1 {
+		t.Errorf("langs = %v", f.ApplicableLanguages)
+	}
+}
+
+func TestParseFindingTitle_FromHeading(t *testing.T) {
+	f := &KnowledgeFinding{}
+	lines := []string{"---", "id: x", "---", "", "# Discovered Bug", "body"}
+	ParseFindingTitle(f, lines, 3, "/x/finding.md")
+	if f.Title != "Discovered Bug" {
+		t.Errorf("got %q", f.Title)
+	}
+}
+
+func TestParseFindingTitle_FallbackToFilename(t *testing.T) {
+	f := &KnowledgeFinding{}
+	lines := []string{"---", "---", "body without heading"}
+	ParseFindingTitle(f, lines, 2, "/x/my-finding.md")
+	if f.Title != "my-finding" {
+		t.Errorf("got %q", f.Title)
+	}
+}
+
+func TestParseFindingTitle_PreservesExistingTitle(t *testing.T) {
+	f := &KnowledgeFinding{Title: "Already Set"}
+	lines := []string{"# Would be overwritten"}
+	ParseFindingTitle(f, lines, 0, "/x/file.md")
+	if f.Title != "Already Set" {
+		t.Errorf("got %q", f.Title)
+	}
+}
+
+func TestApplyFindingFreshness(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "f.md")
+	_ = os.WriteFile(file, []byte("content"), 0o600)
+	old := time.Now().Add(-4 * 7 * 24 * time.Hour)
+	_ = os.Chtimes(file, old, old)
+
+	f := &KnowledgeFinding{}
+	now := time.Now()
+	ApplyFindingFreshness(f, file, now)
+	if f.AgeWeeks < 3 || f.AgeWeeks > 5 {
+		t.Errorf("age = %v", f.AgeWeeks)
+	}
+	if f.FreshnessScore <= 0 || f.FreshnessScore > 1 {
+		t.Errorf("freshness = %v", f.FreshnessScore)
+	}
+	if f.Utility == 0 {
+		t.Error("utility should be initialized")
+	}
+}
+
+func TestApplyFindingFreshness_MissingFile(t *testing.T) {
+	f := &KnowledgeFinding{}
+	ApplyFindingFreshness(f, "/nonexistent/xyz.md", time.Now())
+	if f.FreshnessScore != 0.5 {
+		t.Errorf("missing file should default to 0.5, got %v", f.FreshnessScore)
+	}
+}
+
+func TestParseFindingFile(t *testing.T) {
+	tmp := t.TempDir()
+	content := `---
+id: f-abc-123
+title: My Finding
+severity: high
+source-skill: vibe
+---
+
+# Override Title
+
+Summary paragraph here.
+`
+	path := filepath.Join(tmp, "f-abc-123.md")
+	_ = os.WriteFile(path, []byte(content), 0o600)
+
+	f, err := ParseFindingFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.ID != "f-abc-123" {
+		t.Errorf("id = %q", f.ID)
+	}
+	if f.Title != "My Finding" {
+		t.Errorf("frontmatter title should win, got %q", f.Title)
+	}
+	if f.Severity != "high" {
+		t.Errorf("severity = %q", f.Severity)
+	}
+	if f.SourceSkill != "vibe" {
+		t.Errorf("source = %q", f.SourceSkill)
+	}
+}
+
+func TestParseFindingFile_MissingFile(t *testing.T) {
+	_, err := ParseFindingFile("/nonexistent/finding.md")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}

--- a/tests/python/run-tests.sh
+++ b/tests/python/run-tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# run-tests.sh — run Python unit tests without requiring pytest.
+#
+# Uses stdlib unittest so it works anywhere python3 is installed. CI jobs that
+# already have pytest can also run `pytest tests/python/` — the tests inherit
+# from unittest.TestCase so both runners work.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$REPO_ROOT"
+exec python3 -m unittest discover -s tests/python -p 'test_*.py' "$@"

--- a/tests/python/test_generate_context_shards.py
+++ b/tests/python/test_generate_context_shards.py
@@ -1,0 +1,283 @@
+"""Unit tests for scripts/rpi/generate-context-shards.py.
+
+Uses vanilla unittest + importlib so it runs without pytest installed.
+Focus: pure helpers (unit packing, file classification, manifest verification).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from dataclasses import asdict
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "rpi" / "generate-context-shards.py"
+
+
+def _load_module():
+    name = "generate_context_shards"
+    spec = importlib.util.spec_from_file_location(name, SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # Register in sys.modules so @dataclass can resolve cls.__module__
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_module()
+
+
+class TestIsBinary(unittest.TestCase):
+    def test_text_file_is_not_binary(self):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as f:
+            f.write(b"hello world\n")
+            path = Path(f.name)
+        try:
+            self.assertFalse(mod.is_binary(path))
+        finally:
+            path.unlink()
+
+    def test_file_with_null_byte_is_binary(self):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".bin") as f:
+            f.write(b"abc\x00def")
+            path = Path(f.name)
+        try:
+            self.assertTrue(mod.is_binary(path))
+        finally:
+            path.unlink()
+
+    def test_missing_file_not_classified_binary(self):
+        # OSError path: returns False
+        self.assertFalse(mod.is_binary(Path("/nonexistent/xyz")))
+
+
+class TestCountLines(unittest.TestCase):
+    def test_empty_returns_one(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"")
+            path = Path(f.name)
+        try:
+            self.assertEqual(mod.count_lines(path), 1)
+        finally:
+            path.unlink()
+
+    def test_counts_newlines(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"a\nb\nc\n")
+            path = Path(f.name)
+        try:
+            self.assertEqual(mod.count_lines(path), 3)
+        finally:
+            path.unlink()
+
+    def test_counts_line_without_trailing_newline(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"a\nb")
+            path = Path(f.name)
+        try:
+            self.assertEqual(mod.count_lines(path), 2)
+        finally:
+            path.unlink()
+
+
+class TestUnitsForFile(unittest.TestCase):
+    def test_small_text_file_returns_single_full_unit(self):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as f:
+            f.write(b"one\ntwo\n")
+            path = Path(f.name)
+        try:
+            units = mod.units_for_file(str(path), chunk_target_bytes=10_000)
+            self.assertEqual(len(units), 1)
+            u = units[0]
+            self.assertEqual(u.kind, "text-full")
+            self.assertEqual(u.chunk_index, 1)
+            self.assertEqual(u.chunk_count, 1)
+        finally:
+            path.unlink()
+
+    def test_large_text_splits_into_chunks(self):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as f:
+            # Write 200 lines
+            for i in range(200):
+                f.write(f"line {i}\n".encode())
+            path = Path(f.name)
+        try:
+            units = mod.units_for_file(str(path), chunk_target_bytes=100)
+            self.assertGreater(len(units), 1)
+            for u in units:
+                self.assertEqual(u.kind, "text-chunk")
+                self.assertGreaterEqual(u.line_start, 1)
+                self.assertGreaterEqual(u.line_end, u.line_start)
+        finally:
+            path.unlink()
+
+    def test_binary_returns_metadata_unit(self):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".bin") as f:
+            f.write(b"a\x00b")
+            path = Path(f.name)
+        try:
+            units = mod.units_for_file(str(path), chunk_target_bytes=100)
+            self.assertEqual(len(units), 1)
+            self.assertEqual(units[0].kind, "binary-metadata")
+        finally:
+            path.unlink()
+
+
+class TestPackShards(unittest.TestCase):
+    def test_empty_units_returns_no_shards(self):
+        shards = mod.pack_shards([], max_units=10, max_bytes=1000)
+        self.assertEqual(shards, [])
+
+    def test_single_shard_when_within_limits(self):
+        units = [
+            mod.ReadUnit(path=f"f{i}", kind="text-full", size_bytes=10, budget_bytes=10)
+            for i in range(3)
+        ]
+        shards = mod.pack_shards(units, max_units=10, max_bytes=1000)
+        self.assertEqual(len(shards), 1)
+        self.assertEqual(shards[0].unit_count, 3)
+
+    def test_splits_when_max_units_exceeded(self):
+        units = [
+            mod.ReadUnit(path=f"f{i}", kind="text-full", size_bytes=1, budget_bytes=1)
+            for i in range(5)
+        ]
+        shards = mod.pack_shards(units, max_units=2, max_bytes=1000)
+        self.assertGreaterEqual(len(shards), 3)
+        for s in shards:
+            self.assertLessEqual(s.unit_count, 2)
+
+    def test_splits_when_max_bytes_exceeded(self):
+        units = [
+            mod.ReadUnit(path=f"f{i}", kind="text-full", size_bytes=100, budget_bytes=100)
+            for i in range(5)
+        ]
+        shards = mod.pack_shards(units, max_units=100, max_bytes=150)
+        self.assertGreaterEqual(len(shards), 3)
+
+    def test_estimated_tokens_from_bytes(self):
+        units = [mod.ReadUnit(path="f", kind="text-full", size_bytes=400, budget_bytes=400)]
+        shards = mod.pack_shards(units, max_units=10, max_bytes=10000)
+        self.assertEqual(shards[0].estimated_tokens, 100)  # 400 / 4
+
+
+class TestVerifyManifest(unittest.TestCase):
+    def _mk_manifest(self, files, shards_data):
+        return {
+            "shards": shards_data,
+            "totals": {"files": len(files)},
+        }
+
+    def test_manifest_with_coverage_passes(self):
+        files = ["a.txt", "b.txt"]
+        shards = [
+            {
+                "shard_id": 1,
+                "units": [
+                    {"path": "a.txt", "budget_bytes": 10},
+                    {"path": "b.txt", "budget_bytes": 10},
+                ],
+                "budget_bytes": 20,
+            }
+        ]
+        manifest = self._mk_manifest(files, shards)
+        # Should not raise
+        mod.verify_manifest(manifest, files, max_units=10, max_bytes=1000)
+
+    def test_raises_on_coverage_gap(self):
+        files = ["a.txt", "b.txt"]
+        shards = [
+            {
+                "shard_id": 1,
+                "units": [{"path": "a.txt", "budget_bytes": 10}],
+                "budget_bytes": 10,
+            }
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            mod.verify_manifest(self._mk_manifest(files, shards), files, max_units=10, max_bytes=1000)
+        self.assertIn("coverage gap", str(ctx.exception))
+
+    def test_raises_on_empty_shards(self):
+        with self.assertRaises(ValueError):
+            mod.verify_manifest({"shards": []}, [], max_units=10, max_bytes=100)
+
+    def test_raises_on_unknown_file(self):
+        files = ["a.txt"]
+        shards = [
+            {
+                "shard_id": 1,
+                "units": [{"path": "unknown.txt", "budget_bytes": 10}],
+                "budget_bytes": 10,
+            }
+        ]
+        with self.assertRaises(ValueError):
+            mod.verify_manifest(self._mk_manifest(files, shards), files, max_units=10, max_bytes=1000)
+
+    def test_raises_when_max_units_exceeded(self):
+        files = ["a.txt"]
+        shards = [
+            {
+                "shard_id": 1,
+                "units": [
+                    {"path": "a.txt", "budget_bytes": 1},
+                    {"path": "a.txt", "budget_bytes": 1},
+                    {"path": "a.txt", "budget_bytes": 1},
+                ],
+                "budget_bytes": 3,
+            }
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            mod.verify_manifest(self._mk_manifest(files, shards), files, max_units=2, max_bytes=1000)
+        self.assertIn("max_units", str(ctx.exception))
+
+    def test_raises_when_max_bytes_exceeded(self):
+        files = ["a.txt"]
+        shards = [
+            {
+                "shard_id": 1,
+                "units": [{"path": "a.txt", "budget_bytes": 500}],
+                "budget_bytes": 500,
+            }
+        ]
+        with self.assertRaises(ValueError):
+            mod.verify_manifest(self._mk_manifest(files, shards), files, max_units=10, max_bytes=100)
+
+
+class TestBuildManifest(unittest.TestCase):
+    def test_builds_manifest_with_expected_structure(self):
+        tmp = tempfile.mkdtemp()
+        try:
+            a = Path(tmp) / "a.txt"
+            b = Path(tmp) / "b.txt"
+            a.write_text("aaa\nbbb\n")
+            b.write_text("ccc\n")
+
+            manifest = mod.build_manifest([str(a), str(b)], max_units=10, max_bytes=1_000_000)
+
+            self.assertIn("generated_at", manifest)
+            self.assertIn("shards", manifest)
+            self.assertEqual(manifest["totals"]["files"], 2)
+            self.assertGreater(len(manifest["shards"]), 0)
+        finally:
+            for f in Path(tmp).iterdir():
+                f.unlink()
+            os.rmdir(tmp)
+
+
+class TestReadUnitDataclass(unittest.TestCase):
+    def test_asdict_roundtrip(self):
+        u = mod.ReadUnit(path="x", kind="text-full", size_bytes=10, budget_bytes=10)
+        d = asdict(u)
+        self.assertEqual(d["path"], "x")
+        self.assertEqual(d["kind"], "text-full")
+        self.assertIsNone(d["line_start"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/ci-local-release.bats
+++ b/tests/scripts/ci-local-release.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# ci-local-release.bats — Tests for scripts/ci-local-release.sh
+#
+# Strategy: exercise the script's CLI flag parsing, validation, and fast-path
+# behavior. Heavy gates are excluded via --fast and further neutralized by
+# stubbing the scripts/tests they invoke.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/ci-local-release.sh"
+    TMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "ci-local-release.sh exists and is executable" {
+    [ -f "$SCRIPT" ]
+    [ -x "$SCRIPT" ]
+}
+
+@test "ci-local-release.sh has set -euo pipefail" {
+    run grep -q 'set -euo pipefail' "$SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+@test "--help prints usage and exits 0" {
+    run bash "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage"* ]]
+    [[ "$output" == *"--fast"* ]]
+    [[ "$output" == *"--security-mode"* ]]
+}
+
+@test "-h prints usage and exits 0" {
+    run bash "$SCRIPT" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage"* ]]
+}
+
+@test "unknown flag is rejected with usage and exit 1" {
+    run bash "$SCRIPT" --not-a-real-flag
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unknown option"* ]]
+}
+
+@test "--security-mode rejects invalid values" {
+    run bash "$SCRIPT" --security-mode garbage
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid --security-mode"* ]]
+}
+
+@test "--security-mode accepts quick (help-exit path)" {
+    # The script validates --security-mode before --help short-circuit when given.
+    # So we pass --help last to force an early successful exit without running gates.
+    run bash "$SCRIPT" --security-mode quick --help
+    [ "$status" -eq 0 ]
+}
+
+@test "--security-mode accepts full (help-exit path)" {
+    run bash "$SCRIPT" --security-mode full --help
+    [ "$status" -eq 0 ]
+}
+
+@test "--release-version rejects garbage values" {
+    run bash "$SCRIPT" --release-version not-a-version
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid --release-version"* ]]
+}
+
+@test "--release-version accepts semver (help-exit path)" {
+    run bash "$SCRIPT" --release-version 2.18.0 --help
+    [ "$status" -eq 0 ]
+}
+
+@test "--release-version accepts semver with leading v (help-exit path)" {
+    run bash "$SCRIPT" --release-version v2.18.0 --help
+    [ "$status" -eq 0 ]
+}
+
+@test "--release-version accepts prerelease suffixes (help-exit path)" {
+    run bash "$SCRIPT" --release-version 2.18.0-rc.1 --help
+    [ "$status" -eq 0 ]
+}
+
+@test "--jobs accepts numeric value (help-exit path)" {
+    run bash "$SCRIPT" --jobs 4 --help
+    [ "$status" -eq 0 ]
+}
+
+@test "script references ARTIFACT_DIR for release-grade artifact tracking" {
+    # Verifies the RUN_ID / ARTIFACT_DIR pattern is present, since release
+    # provenance depends on artifacts being written to a dated directory.
+    run grep -q 'ARTIFACT_DIR=' "$SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+@test "script defines pass/fail/warn helpers consistent with pre-push-gate" {
+    run grep -qE '^pass\(\) \{' "$SCRIPT"
+    [ "$status" -eq 0 ]
+    run grep -qE '^fail\(\) \{' "$SCRIPT"
+    [ "$status" -eq 0 ]
+    run grep -qE '^warn\(\) \{' "$SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+@test "script starts errors counter at 0" {
+    run grep -q '^errors=0' "$SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+@test "script defines a FAST_MODE default of false" {
+    run grep -q 'FAST_MODE=false' "$SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+@test "script increments error count from fail helper" {
+    # Guard the convention: fail() must bump errors so the gate can aggregate.
+    run grep -q 'errors=\$((errors + 1))' "$SCRIPT"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Analyzed test coverage of the codebase and implemented the full P0–P3 improvement plan. This PR substantially raises coverage in the packages that were flagged as weakest (`internal/lifecycle` at 4.1%, `internal/rpi` at 18.1%, `internal/search` at 8.7%, `internal/quality` at 15.3%, `internal/context` at 23.9%) and fills gaps in meta-infrastructure (Python, ci-local-release.sh).

## Coverage delta

| Package | Before | After |
|---|---|---|
| `internal/lifecycle` | 4.1% | **71.3%** |
| `internal/goals` | 58.8% | **84.6%** |
| `internal/rpi` | 18.1% | **40.5%** |
| `internal/context` | 23.9% | **41.2%** |
| `internal/search` | 8.7% | **22.4%** |
| `internal/quality` | 15.3% | **27.9%** |
| `internal/overnight` | 77.4% | **78.0%** |

## New test files

**Go (internal/)**: 16 new `_test.go` files covering pure helpers — artifact classification, path safety, complexity scoring, evaluator logic, handoff markdown parsing, cancel-signal PID filtering, stale-run detection, seed/temper/curate/dedup/defrag/maturity helpers, golden signals math (Gini, linear regression, top-10 ratio), findings frontmatter parsing, bead context resolution, constraint index load/save/lock, readiness classification, tmux target parsing, platform-specific process-group tests.

**Go (cmd/ao/)**: verified existing `gc_bridge_test.go`, `gc_events_test.go`, `rpi_phased_gc_test.go` already cover the Gas City bridge at 76–100% per function.

**Shell**: `tests/scripts/ci-local-release.bats` — 17 behavioral cases covering flag parsing, validation, and structural invariants of the release gate.

**Python**: `tests/python/test_generate_context_shards.py` — 22 unittest cases covering `is_binary`, `count_lines`, `units_for_file`, `pack_shards`, `verify_manifest`, `build_manifest`. Runs under vanilla `python3` (no pytest required) via `tests/python/run-tests.sh`.

## Test plan

- [x] `cd cli && go test ./internal/...` — all packages pass
- [x] `tests/python/run-tests.sh` — 22/22 pass
- [x] `bash scripts/ci-local-release.sh --help` — exit 0
- [x] `bash scripts/ci-local-release.sh --security-mode garbage` — exit 1
- [ ] CI bats suite picks up new `ci-local-release.bats` (needs bats runner, verified locally via sanity checks)

https://claude.ai/code/session_01EMusoGMSUSbtPqkotJy3U7