### PR TITLE
feat(harvest): recurse into nested artifact dirs and emit real rig metadata

### DIFF
--- a/cli/internal/harvest/extract.go
+++ b/cli/internal/harvest/extract.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -83,49 +84,71 @@ func ExtractArtifactsWithStats(rig RigInfo, opts WalkOptions) ExtractionResult {
 			continue
 		}
 
-		entries, err := os.ReadDir(dir)
-		if err != nil {
-			warn(dir, "read_dir", fmt.Errorf("reading subdir %s: %w", dir, err))
-			continue
-		}
-
 		artType := singularType(subdir)
 
-		for _, e := range entries {
-			if e.IsDir() {
-				continue
-			}
-			name := e.Name()
-			ext := strings.ToLower(filepath.Ext(name))
-			if ext != ".md" && ext != ".jsonl" {
-				continue
+		walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				if os.IsPermission(err) {
+					warn(path, "walk_dir", err)
+					if d != nil && d.IsDir() {
+						return filepath.SkipDir
+					}
+					return nil
+				}
+				return err
 			}
 
-			path := filepath.Join(dir, name)
+			if d.IsDir() {
+				if path == dir {
+					return nil
+				}
+				name := d.Name()
+				if isSkipDir(name, opts.SkipDirs) {
+					return filepath.SkipDir
+				}
+				// Skip hidden subdirs (.git, .archive, etc.) under artifact dirs.
+				if strings.HasPrefix(name, ".") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+
+			// Plain files only — symlinks fall through fs.DirEntry as non-dir
+			// non-regular and are skipped here.
+			if !d.Type().IsRegular() {
+				return nil
+			}
+
+			name := d.Name()
+			ext := strings.ToLower(filepath.Ext(name))
+			if ext != ".md" && ext != ".jsonl" {
+				return nil
+			}
+
 			result.CandidateFiles++
 
 			if opts.MaxFileSize > 0 {
-				fi, err := e.Info()
-				if err != nil {
-					warn(path, "stat", fmt.Errorf("stat %s: %w", path, err))
-					continue
+				fi, statErr := d.Info()
+				if statErr != nil {
+					warn(path, "stat", fmt.Errorf("stat %s: %w", path, statErr))
+					return nil
 				}
 				if fi.Size() > opts.MaxFileSize {
-					continue
+					return nil
 				}
 			}
 
-			data, err := os.ReadFile(path)
-			if err != nil {
-				warn(path, "read_file", fmt.Errorf("reading %s: %w", path, err))
-				continue
+			data, readErr := os.ReadFile(path)
+			if readErr != nil {
+				warn(path, "read_file", fmt.Errorf("reading %s: %w", path, readErr))
+				return nil
 			}
 
 			content := string(data)
-			fm, body, err := parseFrontmatter(content)
-			if err != nil {
-				warn(path, "parse_frontmatter", fmt.Errorf("parsing frontmatter in %s: %w", path, err))
-				continue
+			fm, body, parseErr := parseFrontmatter(content)
+			if parseErr != nil {
+				warn(path, "parse_frontmatter", fmt.Errorf("parsing frontmatter in %s: %w", path, parseErr))
+				return nil
 			}
 
 			fm = NormalizeFrontmatter(fm)
@@ -150,6 +173,10 @@ func ExtractArtifactsWithStats(rig RigInfo, opts WalkOptions) ExtractionResult {
 				Date:        date,
 				Frontmatter: fm,
 			})
+			return nil
+		})
+		if walkErr != nil {
+			warn(dir, "walk_dir", fmt.Errorf("walking %s: %w", dir, walkErr))
 		}
 	}
 

--- a/cli/internal/harvest/extract_test.go
+++ b/cli/internal/harvest/extract_test.go
@@ -537,3 +537,101 @@ func TestExtractTitle_FallbackToFilename(t *testing.T) {
 		t.Errorf("extractTitle = %q, want %q", got, "my-doc")
 	}
 }
+
+// TestExtractArtifacts_RecursesIntoNestedSubdirs guards the 2026-04-25
+// regression: ao harvest only descended depth-1 under .agents/learnings/,
+// silently dropping ~76% of /home/boful's corpus that lived at depth 2-3.
+// The walker must descend to arbitrary depth so nested rig-prefixed legacy
+// dirs (learnings/learning/<rig>-<file>.md) are captured.
+func TestExtractArtifacts_RecursesIntoNestedSubdirs(t *testing.T) {
+	tmp := t.TempDir()
+	agentsDir := filepath.Join(tmp, ".agents")
+	learningsDir := filepath.Join(agentsDir, "learnings")
+	if err := os.MkdirAll(learningsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// depth-1 file
+	depth1 := "---\ntitle: Depth One\ndate: \"2026-04-01\"\n---\nbody1\n"
+	if err := os.WriteFile(filepath.Join(learningsDir, "2026-04-01-depth-one.md"), []byte(depth1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// depth-2 file: learnings/learning/<file>.md
+	nested1 := filepath.Join(learningsDir, "learning")
+	if err := os.MkdirAll(nested1, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	depth2 := "---\ntitle: Depth Two\ndate: \"2026-04-02\"\n---\nbody2\n"
+	if err := os.WriteFile(filepath.Join(nested1, "2026-04-02-depth-two.md"), []byte(depth2), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// depth-3 file: learnings/learning/sub/<file>.md
+	nested2 := filepath.Join(nested1, "sub")
+	if err := os.MkdirAll(nested2, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	depth3 := "---\ntitle: Depth Three\ndate: \"2026-04-03\"\n---\nbody3\n"
+	if err := os.WriteFile(filepath.Join(nested2, "2026-04-03-depth-three.md"), []byte(depth3), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hidden dir (.git) should be skipped even when nested under an artifact dir.
+	hidden := filepath.Join(learningsDir, ".git")
+	if err := os.MkdirAll(hidden, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hidden, "should-not-be-found.md"), []byte("---\ntitle: Hidden\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Configured skip dir (archive) should be skipped.
+	archive := filepath.Join(learningsDir, "archive")
+	if err := os.MkdirAll(archive, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(archive, "should-not-be-found.md"), []byte("---\ntitle: Archived\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rig := RigInfo{
+		Path:    agentsDir,
+		Project: "agentops",
+		Crew:    "nami",
+		Rig:     "agentops-nami",
+	}
+	opts := WalkOptions{
+		MaxFileSize: 1048576,
+		IncludeDirs: []string{"learnings"},
+		SkipDirs:    []string{"archive", ".tmp", ".git"},
+	}
+
+	artifacts, warnings := ExtractArtifacts(rig, opts)
+	if len(warnings) != 0 {
+		t.Fatalf("ExtractArtifacts warnings = %#v, want none", warnings)
+	}
+
+	if len(artifacts) != 3 {
+		t.Fatalf("expected 3 artifacts (depth-1+2+3, hidden+archive skipped), got %d", len(artifacts))
+	}
+
+	titles := map[string]bool{}
+	for _, a := range artifacts {
+		titles[a.Title] = true
+		if a.Type != "learning" {
+			t.Errorf("artifact %q: type = %q, want learning", a.Title, a.Type)
+		}
+		if a.SourceRig != "agentops-nami" {
+			t.Errorf("artifact %q: source_rig = %q, want agentops-nami", a.Title, a.SourceRig)
+		}
+	}
+	for _, want := range []string{"Depth One", "Depth Two", "Depth Three"} {
+		if !titles[want] {
+			t.Errorf("missing artifact %q in result; got titles %v", want, titles)
+		}
+	}
+	if titles["Hidden"] || titles["Archived"] {
+		t.Errorf("walker descended into a skip-dir; got titles %v", titles)
+	}
+}

--- a/cli/internal/harvest/walker.go
+++ b/cli/internal/harvest/walker.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -38,7 +39,7 @@ func DefaultWalkOptions() WalkOptions {
 	return WalkOptions{
 		Roots:       []string{filepath.Join(home, "gt")},
 		MaxFileSize: 1048576,
-		SkipDirs:    []string{"archive", ".tmp", "test-fixtures", "node_modules", "vendor", ".archive"},
+		SkipDirs:    []string{"archive", ".tmp", "test-fixtures", "node_modules", "vendor", ".archive", ".git"},
 		IncludeDirs: []string{"learnings", "patterns", "research"},
 	}
 }
@@ -186,34 +187,147 @@ func inspectAgentsDir(agentsPath, project, crew string) (RigInfo, error) {
 	}, nil
 }
 
-// extractProvenance derives project and crew from the filesystem path.
-// Pattern: {root}/{project}/crew/{crew}/.agents/ -> project, crew
-// Pattern: {root}/{project}/.agents/ -> project, project
-// Fallback: "unknown", "unknown"
+// extractProvenance derives project and crew. Resolution order:
+//  1. .agents/.config file (project: foo, crew: bar)
+//  2. Path patterns: {root}/{project}/crew/{crew}/.agents and {root}/{project}/.agents
+//  3. Path-prefix fallback: e.g. /mnt/c/Users/X/.agents -> ("mnt-c", "x"),
+//     /home/boful/.agents -> ("home-boful", "root").
+//
+// Returns "unknown", "unknown" only as a last resort when no signal is recoverable.
 func extractProvenance(root, agentsPath string) (string, string) {
-	// Get relative path from root to .agents/.
+	if proj, crew, ok := readAgentsConfig(agentsPath); ok {
+		return proj, crew
+	}
+
 	rel, err := filepath.Rel(root, agentsPath)
+	if err == nil && rel != "." {
+		parts := strings.Split(rel, string(filepath.Separator))
+
+		// Pattern: {project}/crew/{crew}/.agents
+		if len(parts) >= 4 && parts[len(parts)-3] == "crew" {
+			return parts[0], parts[len(parts)-2]
+		}
+
+		// Pattern: {project}/.agents
+		if len(parts) >= 2 && parts[0] != "" {
+			return parts[0], parts[0]
+		}
+	}
+
+	// Root IS the .agents dir (or path-rel returned ".") — derive from absolute path.
+	return derivePathPrefixProvenance(agentsPath)
+}
+
+// readAgentsConfig reads project/crew from <agentsPath>/.config if present.
+// Format is line-based "key: value" so the file stays trivial to author by hand.
+// Lines beginning with "#" are comments. Returns ok=false when no .config exists
+// or no usable project key was found.
+func readAgentsConfig(agentsPath string) (string, string, bool) {
+	data, err := os.ReadFile(filepath.Join(agentsPath, ".config"))
 	if err != nil {
+		return "", "", false
+	}
+	var project, crew string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		val := strings.Trim(strings.TrimSpace(parts[1]), "\"'")
+		switch key {
+		case "project":
+			project = val
+		case "crew":
+			crew = val
+		}
+	}
+	if project == "" {
+		return "", "", false
+	}
+	if crew == "" {
+		crew = project
+	}
+	return project, crew, true
+}
+
+// derivePathPrefixProvenance returns a sensible (project, crew) pair from the
+// absolute path of an .agents/ directory. Used when neither .agents/.config
+// nor the {root}/{project}/[crew/{crew}/].agents/ pattern resolves the rig.
+//
+// Conventions:
+//
+//	/mnt/<drive>/<...>/.agents          -> ("mnt-<drive>", "<...leaf>" or "root")
+//	/home/<user>/.agents                -> ("home-<user>", "root")
+//	/home/<user>/<a>/.../.agents        -> ("home-<user>", "<...leaf>")
+//	/<top>/<...>/.agents                -> ("<top>", "<...leaf>" or "<top>")
+var rigSanitizeRe = regexp.MustCompile(`[^a-z0-9-]`)
+
+func derivePathPrefixProvenance(agentsPath string) (string, string) {
+	abs, err := filepath.Abs(agentsPath)
+	if err != nil {
+		abs = agentsPath
+	}
+	abs = filepath.Clean(abs)
+
+	parts := strings.Split(strings.TrimPrefix(abs, string(filepath.Separator)), string(filepath.Separator))
+	// Anchor on the parent of .agents so the rig describes the containing tree.
+	if len(parts) > 0 && parts[len(parts)-1] == ".agents" {
+		parts = parts[:len(parts)-1]
+	}
+	if len(parts) == 0 {
 		return "unknown", "unknown"
 	}
 
-	parts := strings.Split(rel, string(filepath.Separator))
-	// parts[-1] is always ".agents"
-
-	// Pattern: {project}/crew/{crew}/.agents
-	if len(parts) >= 4 && parts[len(parts)-3] == "crew" {
-		project := parts[0]
-		crew := parts[len(parts)-2]
-		return project, crew
+	var project, crew string
+	switch parts[0] {
+	case "mnt":
+		if len(parts) >= 2 {
+			project = "mnt-" + parts[1]
+			if len(parts) >= 3 {
+				crew = parts[len(parts)-1]
+			} else {
+				crew = "root"
+			}
+		} else {
+			project = "mnt"
+			crew = "root"
+		}
+	case "home":
+		if len(parts) >= 2 {
+			project = "home-" + parts[1]
+			if len(parts) >= 3 {
+				crew = parts[len(parts)-1]
+			} else {
+				crew = "root"
+			}
+		} else {
+			project = "home"
+			crew = "root"
+		}
+	default:
+		project = parts[0]
+		if len(parts) >= 2 {
+			crew = parts[len(parts)-1]
+		} else {
+			crew = parts[0]
+		}
 	}
+	return sanitizeRigToken(project), sanitizeRigToken(crew)
+}
 
-	// Pattern: {project}/.agents
-	if len(parts) >= 2 {
-		project := parts[0]
-		return project, project
+func sanitizeRigToken(s string) string {
+	s = strings.ToLower(s)
+	s = rigSanitizeRe.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	if s == "" {
+		return "unknown"
 	}
-
-	return "unknown", "unknown"
+	return s
 }
 
 // isSkipDir returns true if the directory name matches a skip entry.

--- a/cli/internal/harvest/walker_test.go
+++ b/cli/internal/harvest/walker_test.go
@@ -290,6 +290,119 @@ func TestDiscoverRigs_SkipGlobalHub_OmitsHome(t *testing.T) {
 	}
 }
 
+// TestExtractProvenance_PathPrefixFallback guards the 2026-04-25 regression:
+// when --roots= points directly at an .agents dir (e.g. /home/boful/.agents
+// or /mnt/c/Users/Boful/.agents), the prior provenance logic returned
+// ("unknown", "unknown") because filepath.Rel(root, path) was ".". Every
+// rig in the catalog inherited "unknown-unknown" and per-tree grouping
+// became impossible via the rig field. The fallback now derives a sensible
+// (project, crew) pair from the absolute path.
+func TestExtractProvenance_PathPrefixFallback(t *testing.T) {
+	cases := []struct {
+		name        string
+		root        string
+		path        string
+		wantProject string
+		wantCrew    string
+	}{
+		{
+			name:        "home user .agents directly as root",
+			root:        "/home/boful/.agents",
+			path:        "/home/boful/.agents",
+			wantProject: "home-boful",
+			wantCrew:    "root",
+		},
+		{
+			name:        "mnt drive .agents directly as root",
+			root:        "/mnt/d/.agents",
+			path:        "/mnt/d/.agents",
+			wantProject: "mnt-d",
+			wantCrew:    "root",
+		},
+		{
+			name:        "mnt drive nested user .agents directly as root",
+			root:        "/mnt/c/Users/Boful/.agents",
+			path:        "/mnt/c/Users/Boful/.agents",
+			wantProject: "mnt-c",
+			wantCrew:    "boful",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotProject, gotCrew := extractProvenance(tc.root, tc.path)
+			if gotProject != tc.wantProject {
+				t.Errorf("project = %q, want %q", gotProject, tc.wantProject)
+			}
+			if gotCrew != tc.wantCrew {
+				t.Errorf("crew = %q, want %q", gotCrew, tc.wantCrew)
+			}
+			if gotProject == "unknown" || gotCrew == "unknown" {
+				t.Errorf("provenance must never be 'unknown' for resolvable absolute paths; got (%q, %q)", gotProject, gotCrew)
+			}
+		})
+	}
+}
+
+// TestExtractProvenance_PreservesPathPatterns ensures the legacy
+// {root}/{project}/crew/{crew}/.agents pattern still resolves correctly
+// after the path-prefix fallback was introduced.
+func TestExtractProvenance_PreservesPathPatterns(t *testing.T) {
+	root := "/work"
+	cases := []struct {
+		name        string
+		path        string
+		wantProject string
+		wantCrew    string
+	}{
+		{
+			name:        "{project}/crew/{crew}/.agents",
+			path:        "/work/agentops/crew/nami/.agents",
+			wantProject: "agentops",
+			wantCrew:    "nami",
+		},
+		{
+			name:        "{project}/.agents",
+			path:        "/work/myproject/.agents",
+			wantProject: "myproject",
+			wantCrew:    "myproject",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotProject, gotCrew := extractProvenance(root, tc.path)
+			if gotProject != tc.wantProject {
+				t.Errorf("project = %q, want %q", gotProject, tc.wantProject)
+			}
+			if gotCrew != tc.wantCrew {
+				t.Errorf("crew = %q, want %q", gotCrew, tc.wantCrew)
+			}
+		})
+	}
+}
+
+// TestExtractProvenance_AgentsConfigOverrides verifies that .agents/.config
+// (when present) takes precedence over both path patterns and the path-
+// prefix fallback. Format is line-based "key: value".
+func TestExtractProvenance_AgentsConfigOverrides(t *testing.T) {
+	tmp := t.TempDir()
+	agentsDir := filepath.Join(tmp, ".agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := "# rig identity\nproject: my-project\ncrew: my-crew\n"
+	if err := os.WriteFile(filepath.Join(agentsDir, ".config"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	gotProject, gotCrew := extractProvenance(tmp, agentsDir)
+	if gotProject != "my-project" {
+		t.Errorf("project = %q, want %q", gotProject, "my-project")
+	}
+	if gotCrew != "my-crew" {
+		t.Errorf("crew = %q, want %q", gotCrew, "my-crew")
+	}
+}
+
 // --- helpers ---
 
 func mustMkdirAll(t *testing.T, path string) {


### PR DESCRIPTION
## Summary

Two-part fix for `ao harvest`, surfaced by the 2026-04-25 agents-mining-pipeline Phase 1 verifier:

- **Walker recursion (`extract.go`):** `filepath.WalkDir` each include dir (`learnings/`, `research/`, `patterns/`) to arbitrary depth so nested rig-prefixed legacy artifacts under `learnings/learning/`, `learnings/research/`, `learnings/pattern/` are captured. Previously only depth-1 entries were extracted, silently dropping ~76% of the largest local corpus. Skips hidden subdirs (e.g. `.git`) and configured `SkipDirs`; symlinks are skipped via `fs.DirEntry.Type().IsRegular()` so cycles can't form.
- **Rig metadata (`walker.go`):** `extractProvenance` now resolves identity in three steps — `.agents/.config` (line-based `key: value`) → existing `{root}/{project}/[crew/{crew}/]/.agents` patterns (preserved) → path-prefix fallback for the case where the root *is* the `.agents` directory (`/home/<user>/.agents` → `home-<user>`/`root`; `/mnt/<drive>/<...>/.agents` → `mnt-<drive>`/`<leaf>`). Previously every artifact inherited `source_rig: "unknown-unknown"` whenever `--roots=` pointed directly at an `.agents/` dir. Adds `.git` to default `SkipDirs` as belt-and-suspenders.

Postpatch verifier (`/tmp/ao-postpatch-verify`, command per acceptance criterion A1):

| Tree | Before | After |
|---|---:|---:|
| /home/boful learnings | 216 | **1115** |
| /home/boful research / patterns | 41 / 12 | 41 / 12 |
| /mnt/c (all types) | 22 | 22 |
| /mnt/d (all types) | 2 | 2 |
| Catalog total | 293 | **1192** |
| Duplicate excess | 0 | 235 |

Every rig now emits a non-`unknown` project/crew (`mnt-c-boful`, `mnt-d-root`, `home-boful-root`) and 0 artifacts retain `unknown-unknown`.

## Test plan

- [x] `go test ./...` clean (existing harvest tests preserved; new `TestExtractArtifacts_RecursesIntoNestedSubdirs`, `TestExtractProvenance_PathPrefixFallback`, `TestExtractProvenance_PreservesPathPatterns`, `TestExtractProvenance_AgentsConfigOverrides`)
- [x] `go vet ./...` clean
- [x] `make build` succeeds; rebuilt binary copied to `~/.local/bin/ao`
- [x] Reinstalled binary reproduces A1–A3 — outputs at `~/wiki/eval/runs/verify-2026-04-25-postpatch/`
- [ ] CI green