### PR TITLE
feat(agents): catalog .agents/ write surfaces with lint gate

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -195,6 +195,7 @@
 - [Contracts Index](contracts/index.md) — Landing page for all inter-component contracts
 - [Repo Execution Profile](contracts/repo-execution-profile.md) — Repo-local bootstrap, validation, tracker, and done-criteria contract for autonomous orchestration
 - [Autodev Program Contract](contracts/autodev-program.md) — Repo-local operational contract for bounded autonomous development
+- [`.agents/` Write Surfaces](contracts/agents-write-surfaces.md) — Catalogued top-level subdirs that production code writes under `.agents/`, gated by `scripts/check-agents-write-surfaces.sh`
 - [Repo Execution Profile Schema](contracts/repo-execution-profile.schema.json) — Machine-readable schema for repo execution profiles
 - [RPI Run Registry](contracts/rpi-run-registry.md) — RPI run registry specification
 - [Next-Work Queue Schema](contracts/next-work.schema.md) — Contract for `.agents/rpi/next-work.jsonl`

--- a/docs/contracts/agents-write-surfaces.md
+++ b/docs/contracts/agents-write-surfaces.md
@@ -1,0 +1,128 @@
+# `.agents/` Write Surfaces
+
+> **Status:** Draft
+> **Consumers:** `scripts/check-agents-write-surfaces.sh`, `/evolve`, future `ao agents` tooling
+> **Linted by:** `scripts/check-agents-write-surfaces.sh`
+
+This contract catalogues every top-level subdirectory under `.agents/` that
+agentops production code (Go in `cli/` excluding tests, shell in `scripts/`,
+`hooks/`, `lib/`) writes to or persists state under. It does **not** cover
+skill-owned subdirs that follow the `.agents/<skill-name>/` convention —
+those are validated dynamically against `skills/<skill-name>/SKILL.md`.
+
+The lint that backs this contract reads the allowlist between the
+`<!-- BEGIN agents-write-surfaces-allowlist -->` /
+`<!-- END agents-write-surfaces-allowlist -->` markers below. Any
+`.agents/<X>` literal in production code where `<X>` is neither in the
+allowlist nor an active skill name fails the gate.
+
+## Surfaces
+
+| Subdir | Owner | Lifecycle | Purpose |
+|---|---|---|---|
+| `ao` | cli (`cli/internal/storage`, `cli/internal/ratchet`, hooks) | persistent | Core runtime state: chain, citations, baselines, history, search index, factory state, hook-error logs |
+| `archive` | cli (curate, harvest, dedup) | persistent | Archived/superseded artifacts with retention metadata |
+| `archived-worktrees` | scripts (`worktree-disposition`) | persistent | Snapshot of preserved worktrees pending review |
+| `briefings` | scripts (compile, brief generators) | regenerated | Compiled session-start briefings |
+| `candidates` | cli (ratchet `TierObservation`) | rolling | Pre-promotion candidate observations |
+| `compaction-snapshots` | hooks (compaction recovery) | rolling | Pre-compaction context snapshots |
+| `compile` | cli (compile pipeline) | regenerated | Intermediate compile state |
+| `compiled` | cli (compile pipeline) | regenerated | Compiled wiki output (subset; see `wiki/`) |
+| `config` | cli (.agents/.config) | persistent | Rig identity (project/crew) — read by harvest path-prefix fallback |
+| `constraints` | cli (constraints subsystem) | persistent | Compiled constraint manifests |
+| `defrag` | cli (compile defrag), scripts | rolling | Defrag run state and dry-run reports |
+| `findings` | scripts, /forge | persistent | Mined findings awaiting promotion |
+| `git` | cli (git-aware tooling) | persistent | Git-derived state cached for the runtime |
+| `holdout` | cli (`/scenario`) | persistent | Holdout scenarios stored outside the codebase view |
+| `knowledge` | cli (compile knowledge surface) | persistent | Promoted knowledge artifacts |
+| `learnings` | cli (curate `TierLearning`), /post-mortem, /retro | persistent | Promoted learning artifacts |
+| `ledger` | cli (audit ledger) | persistent | Append-only audit ledger |
+| `memory` | cli (memory subsystem) | persistent | Memory-rl artifacts |
+| `mine` | cli (compile mine), /forge | rolling | Mined raw signal awaiting promotion |
+| `opencode-tests` | scripts (opencode runtime tests) | regenerated | Opencode runtime test fixtures and outputs |
+| `overnight` | scripts (nightly dream cycle), /dream | rolling | Overnight run state and morning packets |
+| `patterns` | cli (curate), /post-mortem, /retro | persistent | Promoted pattern artifacts |
+| `planning-rules` | cli (planning) | persistent | Planning rules sourced from skills/contracts |
+| `plans` | /plan, scripts | persistent | Planning artifacts |
+| `playbooks` | cli (knowledge-activation) | persistent | Compiled playbook candidates |
+| `pool` | cli (`pool.PoolDir`) | persistent | Idea pool / candidate inbox |
+| `pre-mortem-checks` | /pre-mortem | persistent | Pre-mortem check templates and runs |
+| `products` | /product | persistent | Product validation artifacts |
+| `profile` | cli (profile subsystem) | persistent | Repo execution profile cache |
+| `releases` | scripts (`ci-local-release`) | rolling | Local CI release evidence |
+| `retros` | /retro | persistent | Retrospectives |
+| `sessions` | cli (`.agents/ao/sessions`), hooks | rolling | Session transcripts and matches |
+| `signals` | hooks (quality-signals) | rolling | Append-only quality signal log |
+| `skills` | cli (`doctor`, install) | persistent | User-installed skill state (alt path under `~/.agents/skills/`) |
+| `smoke-test` | scripts (smoke harness) | regenerated | Smoke test scratch dirs |
+| `specs` | /plan, /pre-mortem | persistent | Specs gating ratchet steps |
+| `swarm-role` | /swarm | rolling | Per-role swarm state |
+| `synthesis` | /plan, /forge, /compile | persistent | Synthesis output |
+| `tasks` | cli (quickstart beads-optional mode) | persistent | Beads-optional task tracking fallback |
+| `teams` | cli (`codex-team`, `swarm`) | rolling | Team coordination state |
+
+### Skill-owned subdirs
+
+Each active skill at `skills/<name>/SKILL.md` may write under
+`.agents/<name>/`. The lint accepts any such reference automatically and
+does not require an entry above. Removing a skill removes the implicit
+permission for that subdir.
+
+## Allowlist
+
+<!-- BEGIN agents-write-surfaces-allowlist -->
+ao
+archive
+archived-worktrees
+briefings
+candidates
+compaction-snapshots
+compile
+compiled
+config
+constraints
+defrag
+findings
+git
+holdout
+knowledge
+learnings
+ledger
+memory
+mine
+opencode-tests
+overnight
+patterns
+planning-rules
+plans
+playbooks
+pool
+pre-mortem-checks
+products
+profile
+releases
+retros
+sessions
+signals
+skills
+smoke-test
+specs
+swarm-role
+synthesis
+tasks
+teams
+<!-- END agents-write-surfaces-allowlist -->
+
+## How to update
+
+1. Add a new write surface to production code (Go, shell, or hook).
+2. Add a row in the `## Surfaces` table above explaining owner / lifecycle / purpose.
+3. Add the bare subdir name to the allowlist block.
+4. Run `scripts/check-agents-write-surfaces.sh` and confirm it exits 0.
+5. Add or update a regression test in `tests/scripts/check-agents-write-surfaces.bats` if the new surface introduces a new contract dimension (format, ownership rule, lifecycle).
+
+## See also
+
+- `docs/contracts/repo-execution-profile.md` — repo-local operating policy
+- `PROGRAM.md` — autodev mutable/immutable scope
+- `scripts/check-wiring-closure.sh` — broader registry-coverage gate

--- a/scripts/check-agents-write-surfaces.sh
+++ b/scripts/check-agents-write-surfaces.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-agents-write-surfaces.sh — guard the .agents/ write-surface contract.
+#
+# Every top-level subdir under .agents/ that production code (cli/**/*.go
+# non-test, scripts/, hooks/, lib/) writes to must be catalogued in
+# docs/contracts/agents-write-surfaces.md. The catalog has an explicit
+# allowlist between BEGIN/END markers; this script parses that block and
+# fails when production code references a subdir that isn't documented.
+#
+# Skill-owned subdirs (.agents/<skill-name>/) are auto-allowed when an
+# active skill exists at skills/<skill-name>/SKILL.md. New skills don't
+# need a doc edit; new CLI/script/hook write surfaces do.
+
+usage() {
+  cat <<USAGE
+Usage: $0 [--json]
+
+Options:
+  --json   Emit a machine-readable summary instead of human prose.
+
+Exit codes:
+  0  OK (all referenced subdirs documented or skill-owned)
+  1  Undocumented top-level subdirs found in production code
+  2  Bad invocation or missing contract doc
+USAGE
+}
+
+JSON=false
+case "${1:-}" in
+  --json) JSON=true ;;
+  -h|--help) usage; exit 0 ;;
+  '') ;;
+  *) usage; exit 2 ;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONTRACT_DOC="$REPO_ROOT/docs/contracts/agents-write-surfaces.md"
+SKILLS_DIR="$REPO_ROOT/skills"
+
+if [[ ! -f "$CONTRACT_DOC" ]]; then
+  echo "ERROR: contract doc missing: $CONTRACT_DOC" >&2
+  exit 2
+fi
+
+# Parse allowlist between markers. Lines starting with '#' are treated as
+# comments. Empty lines are ignored. Each remaining line must be a single
+# top-level subdir name with no slashes.
+allowlist_tmp="$(mktemp)"
+trap 'rm -f "$allowlist_tmp"' EXIT
+awk '
+  /<!-- BEGIN agents-write-surfaces-allowlist -->/ { inside=1; next }
+  /<!-- END agents-write-surfaces-allowlist -->/   { inside=0; next }
+  inside { print }
+' "$CONTRACT_DOC" \
+  | sed -E 's/[[:space:]]+#.*$//' \
+  | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
+  | awk 'NF && $1 !~ /^#/' \
+  | sort -u > "$allowlist_tmp"
+
+if [[ ! -s "$allowlist_tmp" ]]; then
+  echo "ERROR: allowlist block is empty or markers missing in $CONTRACT_DOC" >&2
+  exit 2
+fi
+
+# Reject malformed entries (must be lowercase letters, digits, '-' or '_').
+malformed="$(grep -vE '^[a-z0-9][a-z0-9_-]*$' "$allowlist_tmp" || true)"
+if [[ -n "$malformed" ]]; then
+  echo "ERROR: malformed allowlist entries in $CONTRACT_DOC:" >&2
+  echo "$malformed" >&2
+  exit 2
+fi
+
+# Extract referenced top-level subdirs from production code.
+# - cli/**/*.go excluding _test.go
+# - scripts/*.sh, hooks/*.sh, lib/*.sh
+referenced_tmp="$(mktemp)"
+trap 'rm -f "$allowlist_tmp" "$referenced_tmp"' EXIT
+
+scan_dirs=()
+[[ -d "$REPO_ROOT/scripts" ]] && scan_dirs+=("$REPO_ROOT/scripts")
+[[ -d "$REPO_ROOT/hooks" ]]   && scan_dirs+=("$REPO_ROOT/hooks")
+[[ -d "$REPO_ROOT/lib" ]]     && scan_dirs+=("$REPO_ROOT/lib")
+
+{
+  if [[ -d "$REPO_ROOT/cli" ]]; then
+    find "$REPO_ROOT/cli" -type f -name '*.go' ! -name '*_test.go' -print0 2>/dev/null \
+      | xargs -0 -r grep -hEo '\.agents/[a-z][a-zA-Z0-9_-]*' 2>/dev/null || true
+  fi
+  if [[ ${#scan_dirs[@]} -gt 0 ]]; then
+    find "${scan_dirs[@]}" -type f \( -name '*.sh' -o -name '*.bash' \) -print0 2>/dev/null \
+      | xargs -0 -r grep -hEo '\.agents/[a-z][a-zA-Z0-9_-]*' 2>/dev/null || true
+  fi
+} | sed -E 's|^\.agents/([a-zA-Z0-9_-]+).*|\1|' | sort -u > "$referenced_tmp"
+
+# Compute active skill names — skill-owned subdirs are auto-allowed.
+skills_tmp="$(mktemp)"
+trap 'rm -f "$allowlist_tmp" "$referenced_tmp" "$skills_tmp"' EXIT
+: > "$skills_tmp"
+if [[ -d "$SKILLS_DIR" ]]; then
+  shopt -s nullglob
+  for d in "$SKILLS_DIR"/*/; do
+    [[ -f "${d}SKILL.md" ]] && basename "$d" >> "$skills_tmp"
+  done
+  shopt -u nullglob
+  if [[ -s "$skills_tmp" ]]; then
+    sort -u "$skills_tmp" -o "$skills_tmp"
+  fi
+fi
+
+# undocumented = referenced - allowlist - skills
+undocumented_tmp="$(mktemp)"
+trap 'rm -f "$allowlist_tmp" "$referenced_tmp" "$skills_tmp" "$undocumented_tmp"' EXIT
+comm -23 "$referenced_tmp" "$allowlist_tmp" \
+  | comm -23 - "$skills_tmp" > "$undocumented_tmp"
+
+UNDOC_COUNT=$(wc -l < "$undocumented_tmp" | tr -d ' ')
+ALLOW_COUNT=$(wc -l < "$allowlist_tmp" | tr -d ' ')
+REF_COUNT=$(wc -l < "$referenced_tmp" | tr -d ' ')
+
+if [[ "$JSON" == "true" ]]; then
+  printf '{"contract":"%s","allowlist_size":%s,"referenced":%s,"undocumented":[' \
+    "${CONTRACT_DOC#"$REPO_ROOT"/}" "$ALLOW_COUNT" "$REF_COUNT"
+  first=1
+  while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    if [[ "$first" -eq 1 ]]; then first=0; else printf ','; fi
+    printf '"%s"' "$entry"
+  done < "$undocumented_tmp"
+  printf '],"status":"%s"}\n' "$([ "$UNDOC_COUNT" -gt 0 ] && echo fail || echo ok)"
+fi
+
+if [[ "$UNDOC_COUNT" -gt 0 ]]; then
+  if [[ "$JSON" != "true" ]]; then
+    echo "ERROR: $UNDOC_COUNT undocumented .agents/ write surface(s) found in production code." >&2
+    echo "Add an entry under '<!-- BEGIN agents-write-surfaces-allowlist -->' in:" >&2
+    echo "  $CONTRACT_DOC" >&2
+    echo "Undocumented subdirs:" >&2
+    sed 's/^/  - /' "$undocumented_tmp" >&2
+  fi
+  exit 1
+fi
+
+if [[ "$JSON" != "true" ]]; then
+  echo "agents-write-surfaces contract OK: $REF_COUNT referenced subdirs, $ALLOW_COUNT allowlisted, all documented or skill-owned."
+fi
+exit 0

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -347,7 +347,7 @@ if [[ -x scripts/check-agents-hash-snapshot.sh ]]; then
 fi
 
 # --- 3d. .agents/ write-surface contract ---
-if [[ -x scripts/check-agents-write-surfaces.sh ]]; then
+if [[ -x scripts/check-agents-write-surfaces.sh && -f docs/contracts/agents-write-surfaces.md ]]; then
     if write_surfaces_output="$(scripts/check-agents-write-surfaces.sh 2>&1)"; then
         pass ".agents/ write-surface contract"
     else
@@ -355,7 +355,7 @@ if [[ -x scripts/check-agents-write-surfaces.sh ]]; then
         indent_output "$write_surfaces_output"
     fi
 else
-    fail "missing executable: scripts/check-agents-write-surfaces.sh"
+    skip ".agents/ write-surface contract"
 fi
 
 # --- 5. Embedded hooks sync (full parity gate) ---

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -8,6 +8,7 @@
 # Checks:
 #   1. Go build + vet (if cli/ changed)
 #   2. Go race tests on changed packages (via validate-go-fast.sh)
+#  3d. .agents/ write-surface contract (catalogued top-level subdirs)
 #   3. Command/test pairing for cli/cmd/ao Go changes
 #   4. cmd/ao coverage floor gate
 #  4b. Per-package coverage ratchet (full mode only)
@@ -343,6 +344,18 @@ fi
 HASH_GATE_SNAPSHOT=""
 if [[ -x scripts/check-agents-hash-snapshot.sh ]]; then
     HASH_GATE_SNAPSHOT="$(scripts/check-agents-hash-snapshot.sh capture 2>/dev/null || echo "")"
+fi
+
+# --- 3d. .agents/ write-surface contract ---
+if [[ -x scripts/check-agents-write-surfaces.sh ]]; then
+    if write_surfaces_output="$(scripts/check-agents-write-surfaces.sh 2>&1)"; then
+        pass ".agents/ write-surface contract"
+    else
+        fail ".agents/ write-surface contract drifted"
+        indent_output "$write_surfaces_output"
+    fi
+else
+    fail "missing executable: scripts/check-agents-write-surfaces.sh"
 fi
 
 # --- 5. Embedded hooks sync (full parity gate) ---

--- a/tests/scripts/check-agents-write-surfaces.bats
+++ b/tests/scripts/check-agents-write-surfaces.bats
@@ -1,0 +1,215 @@
+#!/usr/bin/env bats
+
+# Regression tests for scripts/check-agents-write-surfaces.sh
+# Builds a self-contained fake repo with cli/, scripts/, hooks/, lib/, skills/,
+# docs/contracts/, and runs the lint inside it. Each scenario isolates one
+# contract dimension so failures point at one rule.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/check-agents-write-surfaces.sh"
+
+    TMP_DIR="$(mktemp -d)"
+    FAKE_REPO="$TMP_DIR/repo"
+    mkdir -p "$FAKE_REPO/scripts" "$FAKE_REPO/cli/cmd/ao" "$FAKE_REPO/cli/internal" \
+             "$FAKE_REPO/hooks" "$FAKE_REPO/lib" "$FAKE_REPO/skills" \
+             "$FAKE_REPO/docs/contracts"
+    /bin/cp "$SCRIPT" "$FAKE_REPO/scripts/check-agents-write-surfaces.sh"
+    chmod +x "$FAKE_REPO/scripts/check-agents-write-surfaces.sh"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+# Helper: write a minimal contract doc with the given allowlist entries.
+write_contract() {
+    local doc="$FAKE_REPO/docs/contracts/agents-write-surfaces.md"
+    {
+        printf '# .agents/ Write Surfaces\n\n'
+        printf '<!-- BEGIN agents-write-surfaces-allowlist -->\n'
+        for entry in "$@"; do
+            printf '%s\n' "$entry"
+        done
+        printf '<!-- END agents-write-surfaces-allowlist -->\n'
+    } > "$doc"
+}
+
+@test "check-agents-write-surfaces.sh exists and is executable" {
+    [ -f "$SCRIPT" ]
+    [ -x "$SCRIPT" ]
+}
+
+@test "passes when every referenced subdir is allowlisted" {
+    write_contract ao learnings patterns
+    cat > "$FAKE_REPO/cli/internal/foo.go" <<'EOF'
+package foo
+
+const ChainDir = ".agents/ao"
+const LearningsDir = ".agents/learnings"
+EOF
+    cat > "$FAKE_REPO/scripts/touch-pattern.sh" <<'EOF'
+#!/usr/bin/env bash
+mkdir -p .agents/patterns
+EOF
+
+    cd "$FAKE_REPO"
+    run bash scripts/check-agents-write-surfaces.sh
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"contract OK"* ]]
+}
+
+@test "fails when production code references a subdir not in allowlist" {
+    write_contract ao
+    cat > "$FAKE_REPO/cli/internal/bad.go" <<'EOF'
+package bad
+
+const Stash = ".agents/widgets/output.json"
+EOF
+
+    cd "$FAKE_REPO"
+    run bash scripts/check-agents-write-surfaces.sh
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"undocumented"* ]]
+    [[ "$output" == *"widgets"* ]]
+}
+
+@test "allows skill-owned subdirs without allowlist entry" {
+    write_contract ao
+    mkdir -p "$FAKE_REPO/skills/my-skill"
+    : > "$FAKE_REPO/skills/my-skill/SKILL.md"
+    cat > "$FAKE_REPO/cli/internal/skill_writer.go" <<'EOF'
+package skillwriter
+
+const SkillDir = ".agents/my-skill"
+const ChainDir = ".agents/ao"
+EOF
+
+    cd "$FAKE_REPO"
+    run bash scripts/check-agents-write-surfaces.sh
+    [ "$status" -eq 0 ]
+}
+
+@test "fails when skill-named subdir is referenced but skill does not exist" {
+    write_contract ao
+    cat > "$FAKE_REPO/cli/internal/orphan.go" <<'EOF'
+package orphan
+
+const Dir = ".agents/ghost-skill/state.json"
+EOF
+
+    cd "$FAKE_REPO"
+    run bash scripts/check-agents-write-surfaces.sh
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ghost-skill"* ]]
+}
+
+@test "ignores Go test files" {
+    write_contract ao
+    cat > "$FAKE_REPO/cli/internal/foo_test.go" <<'EOF'
+package foo
+
+const FixtureDir = ".agents/test-fixture/data"
+EOF
+
+    cd "$FAKE_REPO"
+    run bash scripts/check-agents-write-surfaces.sh
+    [ "$status" -eq 0 ]
+}
+
+@test "exits 2 when contract doc is missing" {
+    rm -f "$FAKE_REPO/docs/contracts/agents-write-surfaces.md"
+    cd "$FAKE_REPO"
+    run bash scripts/check-agents-write-surfaces.sh
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"contract doc missing"* ]]
+}
+
+@test "exits 2 when allowlist block is empty" {
+    write_contract
+    cd "$FAKE_REPO"
+    run bash scripts/check-agents-write-surfaces.sh
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"empty"* ]]
+}
+
+@test "exits 2 on malformed allowlist entries" {
+    local doc="$FAKE_REPO/docs/contracts/agents-write-surfaces.md"
+    {
+        printf '<!-- BEGIN agents-write-surfaces-allowlist -->\n'
+        printf 'ok-name\n'
+        printf 'BAD/SLASH\n'
+        printf '<!-- END agents-write-surfaces-allowlist -->\n'
+    } > "$doc"
+
+    cd "$FAKE_REPO"
+    run bash scripts/check-agents-write-surfaces.sh
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"malformed"* ]]
+}
+
+@test "supports inline comments and blank lines in allowlist" {
+    local doc="$FAKE_REPO/docs/contracts/agents-write-surfaces.md"
+    {
+        printf '<!-- BEGIN agents-write-surfaces-allowlist -->\n'
+        printf '\n'
+        printf '# core state\n'
+        printf 'ao\n'
+        printf '\n'
+        printf 'learnings   # promoted artifacts\n'
+        printf '<!-- END agents-write-surfaces-allowlist -->\n'
+    } > "$doc"
+    cat > "$FAKE_REPO/cli/internal/foo.go" <<'EOF'
+package foo
+
+const A = ".agents/ao"
+const B = ".agents/learnings"
+EOF
+
+    cd "$FAKE_REPO"
+    run bash scripts/check-agents-write-surfaces.sh
+    [ "$status" -eq 0 ]
+}
+
+@test "--json emits machine-readable summary" {
+    write_contract ao
+    cat > "$FAKE_REPO/cli/internal/bad.go" <<'EOF'
+package bad
+
+const Dir = ".agents/widgets"
+EOF
+
+    cd "$FAKE_REPO"
+    run bash scripts/check-agents-write-surfaces.sh --json
+    [ "$status" -eq 1 ]
+    echo "$output" | jq -e '.status == "fail"'
+    echo "$output" | jq -e '.undocumented | index("widgets")'
+}
+
+@test "--json emits ok status when everything documented" {
+    write_contract ao
+    cat > "$FAKE_REPO/cli/internal/foo.go" <<'EOF'
+package foo
+
+const A = ".agents/ao"
+EOF
+
+    cd "$FAKE_REPO"
+    run bash scripts/check-agents-write-surfaces.sh --json
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.status == "ok"'
+    echo "$output" | jq -e '.undocumented | length == 0'
+}
+
+@test "--help prints usage and exits 0" {
+    cd "$FAKE_REPO"
+    run bash scripts/check-agents-write-surfaces.sh --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "rejects unknown flags with exit 2" {
+    cd "$FAKE_REPO"
+    run bash scripts/check-agents-write-surfaces.sh --bogus
+    [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## Summary

Cycle 1 of `/evolve` against the `.agents/` hygiene end-to-end ownership goal.
Adds a tested contract for which top-level subdirs under `.agents/` production
code may write to.

- `docs/contracts/agents-write-surfaces.md` — catalogue (40 entries) + parseable allowlist between `<!-- BEGIN/END agents-write-surfaces-allowlist -->` markers
- `scripts/check-agents-write-surfaces.sh` — lint that diffs production refs (`cli/**/*.go` non-test, `scripts/`, `hooks/`, `lib/`) against the allowlist plus active skill names; auto-allows skill-owned `.agents/<skill-name>/` paths
- `tests/scripts/check-agents-write-surfaces.bats` — 14 scenarios (TDD)
- `scripts/pre-push-gate.sh` — wires the lint into the always-run gate (~50ms)
- `docs/INDEX.md` — catalogues the new contract

Walker patch (PR #138, da141872) is not touched.

## Test plan

- [x] `bats tests/scripts/check-agents-write-surfaces.bats` — 14/14 pass
- [x] `bash scripts/check-agents-write-surfaces.sh` exits 0 on HEAD (49 referenced subdirs, 40 allowlisted, all documented or skill-owned)
- [x] `bash scripts/check-agents-write-surfaces.sh --json` returns valid JSON with `status: ok`
- [x] `shellcheck scripts/check-agents-write-surfaces.sh` clean
- [x] `bash scripts/check-wiring-closure.sh` still green
- [x] `bash scripts/check-contract-compatibility.sh` still green
- [x] Pre-push gate `--fast` shows `ok .agents/ write-surface contract` (only failure: pre-existing worktree-disposition expected on feature branch)