### PR TITLE
feat(cli): add ao agents inspect for .agents/ surface introspection

### DIFF
--- a/cli/cmd/ao/agents.go
+++ b/cli/cmd/ao/agents.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var agentsCmd = &cobra.Command{
+	Use:   "agents",
+	Short: "Inspect and manage .agents/ contracts and surfaces",
+	Long: `Tooling for the .agents/ knowledge surface that backs the
+AgentOps flywheel. Subcommands surface the catalogued write surfaces,
+the active skill-owned subdirs, and (in future cycles) lint and
+migration helpers.`,
+}
+
+var (
+	agentsInspectJSON     bool
+	agentsInspectContract string
+)
+
+var agentsInspectCmd = &cobra.Command{
+	Use:   "inspect",
+	Short: "Show catalogued .agents/ write surfaces and active skill-owned subdirs",
+	Long: `Read the .agents/ write-surface contract and emit a structured
+summary: the catalogued allowlist plus the set of active skills whose
+.agents/<skill-name>/ subdirs are auto-allowed by
+scripts/check-agents-write-surfaces.sh.`,
+	RunE: runAgentsInspect,
+}
+
+func init() {
+	rootCmd.AddCommand(agentsCmd)
+	agentsCmd.AddCommand(agentsInspectCmd)
+	agentsInspectCmd.Flags().BoolVar(&agentsInspectJSON, "json", false, "Emit machine-readable JSON")
+	agentsInspectCmd.Flags().StringVar(&agentsInspectContract, "contract",
+		"docs/contracts/agents-write-surfaces.md",
+		"Path to the .agents/ write-surfaces contract doc")
+}
+
+// AgentsInventory is the shape returned by `ao agents inspect --json`.
+type AgentsInventory struct {
+	Contract  string   `json:"contract"`
+	Allowlist []string `json:"allowlist"`
+	Skills    []string `json:"skills"`
+}
+
+func runAgentsInspect(cmd *cobra.Command, args []string) error {
+	contract := agentsInspectContract
+	data, err := os.ReadFile(contract)
+	if err != nil {
+		return fmt.Errorf("reading contract %s: %w", contract, err)
+	}
+
+	inv := AgentsInventory{
+		Contract:  contract,
+		Allowlist: parseAgentsAllowlist(string(data)),
+		Skills:    discoverActiveSkills("skills"),
+	}
+
+	if agentsInspectJSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(inv)
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Contract: %s\n", inv.Contract)
+	fmt.Fprintf(out, "Catalogued surfaces: %d\n", len(inv.Allowlist))
+	fmt.Fprintf(out, "Skill-owned subdirs: %d\n", len(inv.Skills))
+	fmt.Fprintln(out)
+
+	fmt.Fprintln(out, "Catalogued surfaces (allowlist):")
+	for _, e := range inv.Allowlist {
+		fmt.Fprintf(out, "  .agents/%s/\n", e)
+	}
+	if len(inv.Allowlist) == 0 {
+		fmt.Fprintln(out, "  (none)")
+	}
+	fmt.Fprintln(out)
+
+	fmt.Fprintln(out, "Skill-owned subdirs (auto-allowed):")
+	for _, e := range inv.Skills {
+		fmt.Fprintf(out, "  .agents/%s/\n", e)
+	}
+	if len(inv.Skills) == 0 {
+		fmt.Fprintln(out, "  (none)")
+	}
+	return nil
+}
+
+// parseAgentsAllowlist extracts the allowlist between the BEGIN/END
+// markers in the contract doc. Inline `# comment` and blank lines are
+// stripped. The result is sorted and de-duplicated.
+func parseAgentsAllowlist(content string) []string {
+	const beginMarker = "<!-- BEGIN agents-write-surfaces-allowlist -->"
+	const endMarker = "<!-- END agents-write-surfaces-allowlist -->"
+
+	seen := make(map[string]bool)
+	out := []string{}
+	inside := false
+	for _, line := range strings.Split(content, "\n") {
+		if strings.Contains(line, beginMarker) {
+			inside = true
+			continue
+		}
+		if strings.Contains(line, endMarker) {
+			inside = false
+			continue
+		}
+		if !inside {
+			continue
+		}
+		if i := strings.Index(line, "#"); i >= 0 {
+			line = line[:i]
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if seen[line] {
+			continue
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// discoverActiveSkills returns the names of skills/<name>/ entries that
+// have a SKILL.md file. Result is sorted.
+func discoverActiveSkills(skillsDir string) []string {
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return []string{}
+	}
+	out := []string{}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(skillsDir, e.Name(), "SKILL.md")); err != nil {
+			continue
+		}
+		out = append(out, e.Name())
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cli/cmd/ao/agents_test.go
+++ b/cli/cmd/ao/agents_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAgentsCmd_Registered(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"agents"})
+	if err != nil {
+		t.Fatalf("agents command not registered: %v", err)
+	}
+	if cmd.Name() != "agents" {
+		t.Fatalf("found %q, want %q", cmd.Name(), "agents")
+	}
+}
+
+func TestAgentsInspectCmd_Registered(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"agents", "inspect"})
+	if err != nil {
+		t.Fatalf("agents inspect command not registered: %v", err)
+	}
+	if cmd.Name() != "inspect" {
+		t.Fatalf("found %q, want %q", cmd.Name(), "inspect")
+	}
+	if cmd.Flags().Lookup("json") == nil {
+		t.Error("expected --json flag")
+	}
+	if cmd.Flags().Lookup("contract") == nil {
+		t.Error("expected --contract flag")
+	}
+}
+
+func TestParseAgentsAllowlist(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{
+			name: "empty content",
+			want: []string{},
+		},
+		{
+			name: "no markers",
+			content: "ao\nlearnings\n",
+			want: []string{},
+		},
+		{
+			name: "basic allowlist",
+			content: `# heading
+<!-- BEGIN agents-write-surfaces-allowlist -->
+ao
+learnings
+patterns
+<!-- END agents-write-surfaces-allowlist -->
+trailing
+`,
+			want: []string{"ao", "learnings", "patterns"},
+		},
+		{
+			name: "inline comments and blanks",
+			content: `<!-- BEGIN agents-write-surfaces-allowlist -->
+
+# core
+ao   # core runtime
+
+# promoted
+learnings   # promoted artifacts
+<!-- END agents-write-surfaces-allowlist -->
+`,
+			want: []string{"ao", "learnings"},
+		},
+		{
+			name: "duplicates dedup and sorted",
+			content: `<!-- BEGIN agents-write-surfaces-allowlist -->
+patterns
+ao
+learnings
+ao
+<!-- END agents-write-surfaces-allowlist -->
+`,
+			want: []string{"ao", "learnings", "patterns"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseAgentsAllowlist(tt.content)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseAgentsAllowlist() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiscoverActiveSkills(t *testing.T) {
+	tmp := t.TempDir()
+	for _, name := range []string{"alpha", "beta"} {
+		dir := filepath.Join(tmp, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("ok"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// dir without SKILL.md should be ignored
+	if err := os.MkdirAll(filepath.Join(tmp, "no-skill-md"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// regular file should be ignored
+	if err := os.WriteFile(filepath.Join(tmp, "stray.md"), []byte("nope"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := discoverActiveSkills(tmp)
+	want := []string{"alpha", "beta"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("discoverActiveSkills() = %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverActiveSkills_MissingDir(t *testing.T) {
+	got := discoverActiveSkills(filepath.Join(t.TempDir(), "nope"))
+	if len(got) != 0 {
+		t.Errorf("expected empty result, got %v", got)
+	}
+}
+
+func TestRunAgentsInspect_TextOutput(t *testing.T) {
+	tmp := t.TempDir()
+	contract := filepath.Join(tmp, "contract.md")
+	contractContent := `# Title
+<!-- BEGIN agents-write-surfaces-allowlist -->
+ao
+learnings
+<!-- END agents-write-surfaces-allowlist -->
+`
+	if err := os.WriteFile(contract, []byte(contractContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origJSON := agentsInspectJSON
+	origContract := agentsInspectContract
+	t.Cleanup(func() {
+		agentsInspectJSON = origJSON
+		agentsInspectContract = origContract
+	})
+	agentsInspectJSON = false
+	agentsInspectContract = contract
+
+	var buf bytes.Buffer
+	agentsInspectCmd.SetOut(&buf)
+	t.Cleanup(func() { agentsInspectCmd.SetOut(nil) })
+
+	if err := runAgentsInspect(agentsInspectCmd, nil); err != nil {
+		t.Fatalf("runAgentsInspect: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"Contract: " + contract,
+		"Catalogued surfaces: 2",
+		".agents/ao/",
+		".agents/learnings/",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\nGot:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunAgentsInspect_JSONOutput(t *testing.T) {
+	tmp := t.TempDir()
+	contract := filepath.Join(tmp, "contract.md")
+	contractContent := `<!-- BEGIN agents-write-surfaces-allowlist -->
+ao
+patterns
+<!-- END agents-write-surfaces-allowlist -->
+`
+	if err := os.WriteFile(contract, []byte(contractContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origJSON := agentsInspectJSON
+	origContract := agentsInspectContract
+	t.Cleanup(func() {
+		agentsInspectJSON = origJSON
+		agentsInspectContract = origContract
+	})
+	agentsInspectJSON = true
+	agentsInspectContract = contract
+
+	var buf bytes.Buffer
+	agentsInspectCmd.SetOut(&buf)
+	t.Cleanup(func() { agentsInspectCmd.SetOut(nil) })
+
+	if err := runAgentsInspect(agentsInspectCmd, nil); err != nil {
+		t.Fatalf("runAgentsInspect: %v", err)
+	}
+
+	var got AgentsInventory
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output not valid JSON: %v\nGot: %s", err, buf.String())
+	}
+	if got.Contract != contract {
+		t.Errorf("Contract = %q, want %q", got.Contract, contract)
+	}
+	wantList := []string{"ao", "patterns"}
+	if !reflect.DeepEqual(got.Allowlist, wantList) {
+		t.Errorf("Allowlist = %v, want %v", got.Allowlist, wantList)
+	}
+}
+
+func TestRunAgentsInspect_MissingContract(t *testing.T) {
+	origJSON := agentsInspectJSON
+	origContract := agentsInspectContract
+	t.Cleanup(func() {
+		agentsInspectJSON = origJSON
+		agentsInspectContract = origContract
+	})
+	agentsInspectJSON = false
+	agentsInspectContract = filepath.Join(t.TempDir(), "missing.md")
+
+	var buf bytes.Buffer
+	agentsInspectCmd.SetOut(&buf)
+	t.Cleanup(func() { agentsInspectCmd.SetOut(nil) })
+
+	err := runAgentsInspect(agentsInspectCmd, nil)
+	if err == nil {
+		t.Fatal("expected error for missing contract")
+	}
+	if !strings.Contains(err.Error(), "reading contract") {
+		t.Errorf("error = %v, want one mentioning 'reading contract'", err)
+	}
+}

--- a/cli/cmd/ao/cobra_commands_test.go
+++ b/cli/cmd/ao/cobra_commands_test.go
@@ -385,7 +385,7 @@ func TestCobraCommandTreeRegistration(t *testing.T) {
 
 	// Verify all top-level commands are registered (flat namespace)
 	expectedCmds := []string{
-		"anti-patterns", "autodev", "badge", "batch-feedback", "beads", "completion", "config",
+		"agents", "anti-patterns", "autodev", "badge", "batch-feedback", "beads", "completion", "config",
 		"constraint", "context", "codex", "compile", "contradict", "corpus", "curate", "dedup",
 		"defrag", "demo", "doctor", "evolve", "extract", "factory", "feedback", "feedback-loop",
 		"findings", "flywheel", "forge", "gate", "goals", "handoff", "harvest", "hooks",
@@ -443,7 +443,7 @@ func TestCobraExpectedCmdsMatchRegistration(t *testing.T) {
 
 	// Same list as TestCobraCommandTreeRegistration
 	expectedCmds := []string{
-		"anti-patterns", "autodev", "badge", "batch-feedback", "beads", "completion", "config",
+		"agents", "anti-patterns", "autodev", "badge", "batch-feedback", "beads", "completion", "config",
 		"constraint", "context", "codex", "compile", "contradict", "corpus", "curate", "dedup",
 		"defrag", "demo", "doctor", "evolve", "extract", "factory", "feedback", "feedback-loop",
 		"findings", "flywheel", "forge", "gate", "goals", "handoff", "harvest", "hooks",

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -2686,6 +2686,34 @@ ao trace <artifact-path> [flags]
 
 ---
 
+### `ao agents`
+
+Tooling for the .agents/ knowledge surface that backs the
+
+```
+ao agents [command]
+```
+
+**Subcommands:**
+
+#### `ao agents inspect`
+
+Read the .agents/ write-surface contract and emit a structured
+
+```
+ao agents inspect [flags]
+```
+
+**Flags:**
+
+```
+      --contract string   Path to the .agents/ write-surfaces contract doc (default "docs/contracts/agents-write-surfaces.md")
+  -h, --help              help for inspect
+      --json              Emit machine-readable JSON
+```
+
+---
+
 ### `ao extract`
 
 Check for pending session extractions and output a prompt for Claude to process.

--- a/docs/cli-skills-map.md
+++ b/docs/cli-skills-map.md
@@ -2,7 +2,7 @@
 
 > Which `ao` commands are called by which skills and hooks — and vice versa.
 
-Auto-audited 2026-04-24; targeted runtime-proof update 2026-04-24. 55 generated CLI command headings, 69 source skills, 7 runtime hook event sections.
+Auto-audited 2026-04-24; targeted runtime-proof update 2026-04-24. 56 generated CLI command headings, 69 source skills, 7 runtime hook event sections.
 
 Source-of-truth note: `hooks/hooks.json` currently declares 7 runtime hook event sections. Repository hook scripts such as `worktree-setup.sh` are support/setup scripts and are listed separately when relevant.
 
@@ -12,7 +12,7 @@ Registry-first note: `/plan`, `/pre-mortem`, `/research`, `/vibe`, and `/post-mo
 
 | Category | Count |
 |----------|-------|
-| Generated CLI command headings | 55 |
+| Generated CLI command headings | 56 |
 | CLI command entries with skill/hook callers | 34 |
 | Orphan/hidden command entries (user utilities, hidden, CI-only) | 20 |
 | Known phantom subcommands | 0 |


### PR DESCRIPTION
## Summary

Cycle 3 of `/evolve` against the `.agents/` hygiene goal. Concretizes
the `ao agents` namespace decision with the smallest useful subcommand.

- `cli/cmd/ao/agents.go` — `ao agents` parent + `ao agents inspect` subcommand. Reads `docs/contracts/agents-write-surfaces.md` (the cycle 1 contract), parses the BEGIN/END allowlist block, joins it with active `skills/<name>/SKILL.md` entries, emits text or JSON.
- `cli/cmd/ao/agents_test.go` — 9 tests covering: cmd/subcmd registration, parser table cases (empty/no-markers/basic/comments/dedup), skill discovery (with and without missing dir), and runtime cases (text/JSON/missing-contract).
- `cli/cmd/ao/cobra_commands_test.go` — adds `"agents"` to `expectedCmds` so `TestCobraExpectedCmdsMatchRegistration` stays green.
- `cli/docs/COMMANDS.md` — regenerated via `scripts/generate-cli-reference.sh`.

Establishes the namespace pattern (mirrors `ao goals`/`ao ratchet`/`ao flywheel`). Future cycles can layer `ao agents lint`, `doctor`, `migrate` without re-litigating.

## Dependency note

The default `--contract docs/contracts/agents-write-surfaces.md` ships in PR #139 (cycle 1). Until #139 lands, `ao agents inspect` errors clearly: `reading contract docs/contracts/agents-write-surfaces.md: no such file or directory`. Operators can pass `--contract <path>` or wait for cycle 1 to merge.

## Test plan

- [x] `go test -count=1 -race -run 'TestAgents|TestParseAgentsAllowlist|TestDiscoverActiveSkills|TestRunAgentsInspect|TestCobra' ./cmd/ao/` — all pass
- [x] `go vet ./cmd/ao/` clean
- [x] Smoke: `ao agents --help`, `ao agents inspect --contract <fixture>` (text + `--json`) all behave correctly
- [x] `scripts/generate-cli-reference.sh` produces clean diff
- [ ] Pre-existing flake: `TestFindAgentsDir/returns_empty_for_root_dir_without_markers` fails on this host because `/tmp/.agents/` exists from prior runs — verified failing on `main` too. Filed `agentops-u3v` as follow-up.