### PR TITLE
fix(plans,ratchet): skip os.TempDir() in FindAgentsDir walk-up

### DIFF
--- a/cli/internal/plans/plans.go
+++ b/cli/internal/plans/plans.go
@@ -69,17 +69,25 @@ func ResolvePlanName(explicit, planPath string) string {
 }
 
 // FindAgentsDir looks for .agents directory walking up to rig root.
+//
+// Skips the OS tempdir (os.TempDir()) when traversing — a stale
+// /tmp/.agents/ left over from a prior test run or scratch session
+// is not a real rig root and must not shadow legitimate startDirs that
+// happen to live below /tmp.
 func FindAgentsDir(startDir string) string {
+	tmpDir := filepath.Clean(os.TempDir())
 	dir := startDir
 	for {
-		candidate := filepath.Join(dir, ".agents")
-		if _, err := os.Stat(candidate); err == nil {
-			return candidate
-		}
-		markers := []string{".beads", "crew", "polecats"}
-		for _, marker := range markers {
-			if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
-				return filepath.Join(dir, ".agents")
+		if filepath.Clean(dir) != tmpDir {
+			candidate := filepath.Join(dir, ".agents")
+			if _, err := os.Stat(candidate); err == nil {
+				return candidate
+			}
+			markers := []string{".beads", "crew", "polecats"}
+			for _, marker := range markers {
+				if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
+					return filepath.Join(dir, ".agents")
+				}
 			}
 		}
 		parent := filepath.Dir(dir)

--- a/cli/internal/plans/plans_test.go
+++ b/cli/internal/plans/plans_test.go
@@ -1,0 +1,82 @@
+package plans
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFindAgentsDir_SkipsOsTempDir guards against the 2026-04-25
+// regression where a stale /tmp/.agents/ from a prior test run was
+// returned by FindAgentsDir for any startDir under /tmp. Operators
+// running ao under the OS tempdir would inherit cruft state instead
+// of getting the "no rig found" empty-string result.
+func TestFindAgentsDir_SkipsOsTempDir(t *testing.T) {
+	// Simulate the polluted-tempdir scenario by overriding TMPDIR to
+	// a fresh dir, planting a .agents/ inside it, and pointing the
+	// startDir at a sibling. FindAgentsDir must skip the planted
+	// .agents/ at the (now overridden) os.TempDir() boundary.
+	fakeTmp := t.TempDir()
+	t.Setenv("TMPDIR", fakeTmp)
+
+	if err := os.MkdirAll(filepath.Join(fakeTmp, ".agents"), 0o755); err != nil {
+		t.Fatalf("seeding planted .agents: %v", err)
+	}
+
+	startDir := filepath.Join(fakeTmp, "child", "leaf")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatalf("creating startDir: %v", err)
+	}
+
+	got := FindAgentsDir(startDir)
+	if got != "" {
+		t.Errorf("FindAgentsDir(%q) = %q; want empty (must not return planted %s/.agents)",
+			startDir, got, fakeTmp)
+	}
+}
+
+// TestFindAgentsDir_ReturnsRealAncestor confirms the skip-tempdir
+// fix doesn't break the happy path: a real .agents/ ancestor below
+// the tempdir boundary is still returned.
+func TestFindAgentsDir_ReturnsRealAncestor(t *testing.T) {
+	fakeTmp := t.TempDir()
+	t.Setenv("TMPDIR", fakeTmp)
+
+	rigRoot := filepath.Join(fakeTmp, "myrig")
+	rigAgents := filepath.Join(rigRoot, ".agents")
+	if err := os.MkdirAll(rigAgents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	startDir := filepath.Join(rigRoot, "deep", "nested", "leaf")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := FindAgentsDir(startDir)
+	if got != rigAgents {
+		t.Errorf("FindAgentsDir(%q) = %q; want %q", startDir, got, rigAgents)
+	}
+}
+
+// TestFindAgentsDir_ReturnsRigMarkerAncestor verifies the rig-marker
+// fast path (.beads / crew / polecats) still works under the
+// skip-tempdir rule.
+func TestFindAgentsDir_ReturnsRigMarkerAncestor(t *testing.T) {
+	fakeTmp := t.TempDir()
+	t.Setenv("TMPDIR", fakeTmp)
+
+	rigRoot := filepath.Join(fakeTmp, "myrig")
+	if err := os.MkdirAll(filepath.Join(rigRoot, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	startDir := filepath.Join(rigRoot, "child")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := FindAgentsDir(startDir)
+	want := filepath.Join(rigRoot, ".agents")
+	if got != want {
+		t.Errorf("FindAgentsDir(%q) = %q; want %q", startDir, got, want)
+	}
+}

--- a/cli/internal/ratchet/chain.go
+++ b/cli/internal/ratchet/chain.go
@@ -353,12 +353,19 @@ func (c *Chain) SetPath(path string) {
 }
 
 // findAgentsDir walks up from startDir looking for a .agents directory.
+//
+// Skips the OS tempdir (os.TempDir()) when traversing — a stale
+// /tmp/.agents/ left over from a prior test run or scratch session
+// must not shadow startDirs that legitimately live below /tmp.
 func findAgentsDir(startDir string) (string, error) {
+	tmpDir := filepath.Clean(os.TempDir())
 	dir := startDir
 	for {
-		agentsPath := filepath.Join(dir, ".agents")
-		if info, err := os.Stat(agentsPath); err == nil && info.IsDir() {
-			return agentsPath, nil
+		if filepath.Clean(dir) != tmpDir {
+			agentsPath := filepath.Join(dir, ".agents")
+			if info, err := os.Stat(agentsPath); err == nil && info.IsDir() {
+				return agentsPath, nil
+			}
 		}
 
 		parent := filepath.Dir(dir)


### PR DESCRIPTION
## Summary

Cycle 4 of `/evolve` against the `.agents/` hygiene goal. Fixes a real production bug surfaced as a flaky test (`agentops-u3v`).

`FindAgentsDir` (in `cli/internal/plans/`) and the parallel `findAgentsDir` (in `cli/internal/ratchet/`) walk parent directories looking for a `.agents/` folder or a rig marker. When run from any startDir below `/tmp` on a host where `/tmp/.agents/` exists (left over from a prior test run or scratch session), they returned `/tmp/.agents` — meaning `ao` would adopt stale tempdir state as the active rig root.

The flake landed as `TestFindAgentsDir/returns_empty_for_root_dir_without_markers`. Verified failing on `main` before this change.

## Changes

- `cli/internal/plans/plans.go` — `FindAgentsDir` skips the marker check at `filepath.Clean(os.TempDir())`.
- `cli/internal/ratchet/chain.go` — `findAgentsDir` parity fix.
- `cli/internal/plans/plans_test.go` (new) — three `TestFindAgentsDir_*` cases that lock the new behavior on a clean machine: skip-tempdir guard, real-ancestor happy path, rig-marker happy path. Each uses `t.Setenv("TMPDIR", ...)` to be host-independent.

## Test plan

- [x] `go test -count=1 -race -run 'FindAgentsDir' ./internal/plans/ ./internal/ratchet/ ./cmd/ao/` — all pass
- [x] Pre-existing failing sub-test `TestFindAgentsDir/returns_empty_for_root_dir_without_markers` now passes on this contaminated host (previously failed on `main`)
- [x] `go vet ./internal/plans/ ./internal/ratchet/` clean

Closes `agentops-u3v`.