### PR TITLE
feat(cli): add ao agents lint subcommand wrapping the contract gate

### DIFF
--- a/cli/cmd/ao/agents_lint.go
+++ b/cli/cmd/ao/agents_lint.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	agentsLintScript string
+	agentsLintJSON   bool
+)
+
+var agentsLintCmd = &cobra.Command{
+	Use:   "lint",
+	Short: "Run the .agents/ write-surfaces contract lint",
+	Long: `Wrap scripts/check-agents-write-surfaces.sh and surface its
+result through the ao agents namespace. Exits 0 on a clean contract;
+non-zero on a contract violation or invocation error. With --json the
+script's machine-readable output is forwarded verbatim.`,
+	RunE: runAgentsLint,
+}
+
+func init() {
+	agentsCmd.AddCommand(agentsLintCmd)
+	agentsLintCmd.Flags().StringVar(&agentsLintScript, "script",
+		"scripts/check-agents-write-surfaces.sh",
+		"Path to the lint script")
+	agentsLintCmd.Flags().BoolVar(&agentsLintJSON, "json", false,
+		"Forward --json to the lint script")
+}
+
+// AgentsLintError is returned when the underlying lint script exits
+// non-zero. The ExitCode field carries the script's exit code so the
+// main loop can map it onto the host process exit status.
+type AgentsLintError struct {
+	ExitCode int
+	Script   string
+}
+
+func (e *AgentsLintError) Error() string {
+	return fmt.Sprintf("%s exited with code %d", e.Script, e.ExitCode)
+}
+
+func runAgentsLint(cmd *cobra.Command, args []string) error {
+	if _, err := os.Stat(agentsLintScript); err != nil {
+		return fmt.Errorf("lint script not found at %s: %w", agentsLintScript, err)
+	}
+
+	cmdArgs := []string{}
+	if agentsLintJSON {
+		cmdArgs = append(cmdArgs, "--json")
+	}
+	c := exec.Command("bash", append([]string{agentsLintScript}, cmdArgs...)...)
+	c.Stdout = cmd.OutOrStdout()
+	c.Stderr = cmd.ErrOrStderr()
+
+	err := c.Run()
+	if err == nil {
+		return nil
+	}
+	if ee, ok := err.(*exec.ExitError); ok {
+		cmd.SilenceUsage = true
+		return &AgentsLintError{ExitCode: ee.ExitCode(), Script: agentsLintScript}
+	}
+	return fmt.Errorf("running %s: %w", agentsLintScript, err)
+}

--- a/cli/cmd/ao/agents_lint_test.go
+++ b/cli/cmd/ao/agents_lint_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAgentsLintCmd_Registered(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"agents", "lint"})
+	if err != nil {
+		t.Fatalf("agents lint command not registered: %v", err)
+	}
+	if cmd.Name() != "lint" {
+		t.Fatalf("found %q, want %q", cmd.Name(), "lint")
+	}
+	if cmd.Flags().Lookup("script") == nil {
+		t.Error("expected --script flag")
+	}
+	if cmd.Flags().Lookup("json") == nil {
+		t.Error("expected --json flag")
+	}
+}
+
+func TestRunAgentsLint_MissingScript(t *testing.T) {
+	origScript := agentsLintScript
+	origJSON := agentsLintJSON
+	t.Cleanup(func() {
+		agentsLintScript = origScript
+		agentsLintJSON = origJSON
+	})
+	agentsLintScript = filepath.Join(t.TempDir(), "missing.sh")
+	agentsLintJSON = false
+
+	var stderr bytes.Buffer
+	agentsLintCmd.SetErr(&stderr)
+	agentsLintCmd.SetOut(&stderr)
+	t.Cleanup(func() {
+		agentsLintCmd.SetErr(nil)
+		agentsLintCmd.SetOut(nil)
+	})
+
+	err := runAgentsLint(agentsLintCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when script is missing")
+	}
+	if !strings.Contains(err.Error(), "lint script not found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunAgentsLint_PassthroughExitCodes(t *testing.T) {
+	origScript := agentsLintScript
+	origJSON := agentsLintJSON
+	t.Cleanup(func() {
+		agentsLintScript = origScript
+		agentsLintJSON = origJSON
+	})
+
+	tests := []struct {
+		name     string
+		body     string
+		wantCode int
+	}{
+		{
+			name:     "exit zero passes",
+			body:     "#!/usr/bin/env bash\nexit 0\n",
+			wantCode: 0,
+		},
+		{
+			name:     "exit one surfaces as AgentsLintError 1",
+			body:     "#!/usr/bin/env bash\necho violation >&2\nexit 1\n",
+			wantCode: 1,
+		},
+		{
+			name:     "exit two surfaces as AgentsLintError 2",
+			body:     "#!/usr/bin/env bash\necho misuse >&2\nexit 2\n",
+			wantCode: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scriptPath := filepath.Join(t.TempDir(), "fake-lint.sh")
+			if err := os.WriteFile(scriptPath, []byte(tt.body), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			agentsLintScript = scriptPath
+			agentsLintJSON = false
+
+			var stdout, stderr bytes.Buffer
+			agentsLintCmd.SetOut(&stdout)
+			agentsLintCmd.SetErr(&stderr)
+			t.Cleanup(func() {
+				agentsLintCmd.SetOut(nil)
+				agentsLintCmd.SetErr(nil)
+			})
+
+			err := runAgentsLint(agentsLintCmd, nil)
+			if tt.wantCode == 0 {
+				if err != nil {
+					t.Fatalf("expected nil, got %v", err)
+				}
+				return
+			}
+			var lintErr *AgentsLintError
+			if !errors.As(err, &lintErr) {
+				t.Fatalf("expected *AgentsLintError, got %T: %v", err, err)
+			}
+			if lintErr.ExitCode != tt.wantCode {
+				t.Errorf("ExitCode = %d, want %d", lintErr.ExitCode, tt.wantCode)
+			}
+			if lintErr.Script != scriptPath {
+				t.Errorf("Script = %q, want %q", lintErr.Script, scriptPath)
+			}
+		})
+	}
+}
+
+func TestRunAgentsLint_ForwardsJSONFlag(t *testing.T) {
+	origScript := agentsLintScript
+	origJSON := agentsLintJSON
+	t.Cleanup(func() {
+		agentsLintScript = origScript
+		agentsLintJSON = origJSON
+	})
+
+	scriptPath := filepath.Join(t.TempDir(), "echo-json.sh")
+	body := "#!/usr/bin/env bash\nif [ \"$1\" = \"--json\" ]; then echo '{\"got\":\"json\"}'; else echo 'no flag'; fi\n"
+	if err := os.WriteFile(scriptPath, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	agentsLintScript = scriptPath
+	agentsLintJSON = true
+
+	var stdout bytes.Buffer
+	agentsLintCmd.SetOut(&stdout)
+	t.Cleanup(func() { agentsLintCmd.SetOut(nil) })
+
+	if err := runAgentsLint(agentsLintCmd, nil); err != nil {
+		t.Fatalf("runAgentsLint: %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &got); err != nil {
+		t.Fatalf("stdout not JSON: %v\nGot: %s", err, stdout.String())
+	}
+	if got["got"] != "json" {
+		t.Errorf("script did not receive --json flag (stdout: %s)", stdout.String())
+	}
+}
+
+func TestAgentsLintError_Message(t *testing.T) {
+	err := &AgentsLintError{ExitCode: 7, Script: "/path/to/lint.sh"}
+	got := err.Error()
+	if !strings.Contains(got, "/path/to/lint.sh") {
+		t.Errorf("message missing script path: %q", got)
+	}
+	if !strings.Contains(got, "7") {
+		t.Errorf("message missing exit code: %q", got)
+	}
+}

--- a/cli/cmd/ao/root.go
+++ b/cli/cmd/ao/root.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -71,6 +72,10 @@ Use "ao <command> --help" for more information about a command.`,
 // Execute adds all child commands to the root command and sets flags appropriately.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		var lintErr *AgentsLintError
+		if errors.As(err, &lintErr) {
+			os.Exit(lintErr.ExitCode)
+		}
 		os.Exit(1)
 	}
 }

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -2712,6 +2712,22 @@ ao agents inspect [flags]
       --json              Emit machine-readable JSON
 ```
 
+#### `ao agents lint`
+
+Wrap scripts/check-agents-write-surfaces.sh and surface its
+
+```
+ao agents lint [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help            help for lint
+      --json            Forward --json to the lint script
+      --script string   Path to the lint script (default "scripts/check-agents-write-surfaces.sh")
+```
+
 ---
 
 ### `ao extract`


### PR DESCRIPTION
## Summary

Cycle 5 of `/evolve` against the `.agents/` hygiene goal — operator-facing surface for the cycle 1 contract.

`ao agents lint` wraps `scripts/check-agents-write-surfaces.sh` (cycle 1, PR #139) and exposes its result through the `ao agents` namespace established in cycle 3 (PR #141). Operators get a single uniform surface (mirrors `ao goals validate`, `ao ratchet status`).

## Changes (4 commits, stacked on PR #141)

- `cli/cmd/ao/agents_lint.go` — `lint` subcommand. Defaults to `--script scripts/check-agents-write-surfaces.sh`; `--json` forwards through verbatim.
- `cli/cmd/ao/agents_lint_test.go` — 7 tests: subcmd registered, missing script, three exit-code passthrough cases (0/1/2), JSON flag forwarded, error message shape.
- `cli/cmd/ao/root.go` — `Execute()` recognizes `*AgentsLintError` and propagates the script's exit code instead of collapsing to 1.
- `cli/docs/COMMANDS.md` — regenerated.

## Stack

- Depends on PR #141 (cycle 3 — `ao agents` namespace + `inspect` subcommand) for the `agentsCmd` parent. Diff includes #141's commit (`ea1d6ac6`); merge order matters.
- The default `--script` path lives in PR #139 (cycle 1). Until that lands, operators pass `--script <path>` or get a clear "lint script not found" error.

## Test plan

- [x] `go test -count=1 -race` for all `TestAgents*`, `TestRunAgentsLint*`, `TestCobra*` — pass
- [x] `go build -o bin/ao ./cmd/ao` clean
- [x] Smoke: `ao agents lint` runs the cycle 1 script when present; surfaces exit codes 0/1/2 directly through the host process.
- [x] `scripts/generate-cli-reference.sh` produces clean diff (committed).