### PR TITLE
fix(plans,ratchet): widen FindAgentsDir tempdir skip to /tmp + /var/tmp + os.TempDir()

### DIFF
--- a/cli/internal/plans/plans.go
+++ b/cli/internal/plans/plans.go
@@ -70,15 +70,21 @@ func ResolvePlanName(explicit, planPath string) string {
 
 // FindAgentsDir looks for .agents directory walking up to rig root.
 //
-// Skips the OS tempdir (os.TempDir()) when traversing — a stale
-// /tmp/.agents/ left over from a prior test run or scratch session
-// is not a real rig root and must not shadow legitimate startDirs that
-// happen to live below /tmp.
+// Skips well-known tempdir roots (/tmp, /var/tmp, os.TempDir()) when
+// traversing — a stale /tmp/.agents/ left over from a prior test run
+// or scratch session is not a real rig root and must not shadow
+// legitimate startDirs that happen to live below them. The set
+// covers callers that override TMPDIR mid-run; a single os.TempDir()
+// check alone would miss /tmp once TMPDIR no longer points at it.
 func FindAgentsDir(startDir string) string {
-	tmpDir := filepath.Clean(os.TempDir())
+	tmpDirs := map[string]struct{}{
+		filepath.Clean(os.TempDir()): {},
+		"/tmp":                       {},
+		"/var/tmp":                   {},
+	}
 	dir := startDir
 	for {
-		if filepath.Clean(dir) != tmpDir {
+		if _, isTmp := tmpDirs[filepath.Clean(dir)]; !isTmp {
 			candidate := filepath.Join(dir, ".agents")
 			if _, err := os.Stat(candidate); err == nil {
 				return candidate

--- a/cli/internal/ratchet/chain.go
+++ b/cli/internal/ratchet/chain.go
@@ -354,14 +354,19 @@ func (c *Chain) SetPath(path string) {
 
 // findAgentsDir walks up from startDir looking for a .agents directory.
 //
-// Skips the OS tempdir (os.TempDir()) when traversing — a stale
-// /tmp/.agents/ left over from a prior test run or scratch session
-// must not shadow startDirs that legitimately live below /tmp.
+// Skips well-known tempdir roots (/tmp, /var/tmp, os.TempDir()) so a
+// stale /tmp/.agents/ from a prior session can not shadow startDirs
+// that legitimately live below them. The set covers callers that
+// override TMPDIR mid-run.
 func findAgentsDir(startDir string) (string, error) {
-	tmpDir := filepath.Clean(os.TempDir())
+	tmpDirs := map[string]struct{}{
+		filepath.Clean(os.TempDir()): {},
+		"/tmp":                       {},
+		"/var/tmp":                   {},
+	}
 	dir := startDir
 	for {
-		if filepath.Clean(dir) != tmpDir {
+		if _, isTmp := tmpDirs[filepath.Clean(dir)]; !isTmp {
 			agentsPath := filepath.Join(dir, ".agents")
 			if info, err := os.Stat(agentsPath); err == nil && info.IsDir() {
 				return agentsPath, nil


### PR DESCRIPTION
## Summary

Cycle 7 of `/evolve` — incremental hardening of cycle 4 (PR #142).

`PR #142` skipped `filepath.Clean(os.TempDir())` only. When `TMPDIR` is overridden mid-process (e.g., `t.Setenv("TMPDIR", fakeTmp)` in `TestFindAgentsDir_SkipsOsTempDir`), `os.TempDir()` no longer points at `/tmp`, and the walk-up resumes finding a stale `/tmp/.agents/` from a prior session.

This widens the skip to a Set that always includes `/tmp`, `/var/tmp`, and the current `os.TempDir()`. The same fix lands in both `cli/internal/plans/plans.go` and `cli/internal/ratchet/chain.go` for parity.

## Verification

- [x] `TestFindAgentsDir_SkipsOsTempDir` (the cycle 4 regression test) passes on this host where `/tmp/.agents/` exists.
- [x] `TestFindAgentsDir/returns_empty_for_root_dir_without_markers` (the original flake) stays green.
- [x] `go vet ./internal/plans/ ./internal/ratchet/` clean.
- [x] `go build ./internal/plans/ ./internal/ratchet/` clean.

Closes `agentops-0fd`.