### PR TITLE
Fix commit-review redaction and add agents guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Run Dream overnight, then run Evolve in the morning against a fresher corpus. Th
 | Published site | [boshu2.github.io/agentops](https://boshu2.github.io/agentops/) |
 | Start navigating | [Docs index](docs/INDEX.md) |
 | New contributor orientation | [Newcomer guide](docs/newcomer-guide.md) |
+| Working with `.agents/` | [Operator guide](docs/agents-operator-guide.md) |
 | Full skill catalog | [Skills](docs/SKILLS.md) |
 | CLI reference | [CLI commands](cli/docs/COMMANDS.md) |
 | Architecture | [Architecture](docs/ARCHITECTURE.md) |

--- a/cli/cmd/ao/hooks_run.go
+++ b/cli/cmd/ao/hooks_run.go
@@ -200,8 +200,8 @@ func firstLines(s string, limit int) string {
 }
 
 var (
-	diffSecretAssignmentRE = regexp.MustCompile("(?i)((?:[A-Za-z0-9_-]*(?:api[_-]?key|token|password|passwd|secret)[A-Za-z0-9_-]*)[[:space:]]*[:=][[:space:]]*)[^[:space:]\"'`]+")
-	diffAuthorizationRE    = regexp.MustCompile("(?i)((?:Authorization)[[:space:]]*:[[:space:]]*(?:Bearer|Basic)[[:space:]]+)[^[:space:]\"'`]+")
+	diffSecretAssignmentRE = regexp.MustCompile("(?i)((?:[A-Za-z0-9_-]*(?:api[_-]?key|token|password|passwd|secret)[A-Za-z0-9_-]*)[[:space:]]*[:=][[:space:]]*)(?:\"[^\"\\r\\n]*\"|'[^'\\r\\n]*'|`[^`\\r\\n]*`|[^[:space:]\"'`]+)")
+	diffAuthorizationRE    = regexp.MustCompile("(?i)((?:Authorization)[[:space:]]*:[[:space:]]*(?:Bearer|Basic)[[:space:]]+)(?:\"[^\"\\r\\n]*\"|'[^'\\r\\n]*'|`[^`\\r\\n]*`|[^[:space:]\"'`]+)")
 )
 
 func redactSensitiveDiff(diff string) string {

--- a/cli/cmd/ao/hooks_run_test.go
+++ b/cli/cmd/ao/hooks_run_test.go
@@ -33,13 +33,22 @@ func captureHookStdout(t *testing.T, fn func() error) string {
 }
 
 func TestHooksRunRedactsSensitiveDiff(t *testing.T) {
-	diff := "API_TOKEN=not-a-secret-fixture\nAuthorization: Bearer plain-text"
+	diff := strings.Join([]string{
+		"API_TOKEN=not-a-secret-fixture",
+		`QUOTED_API_TOKEN="quoted-secret-fixture"`,
+		"Authorization: Bearer plain-text",
+		`Authorization: Bearer "quoted-token-fixture"`,
+	}, "\n")
 	redacted := redactSensitiveDiff(diff)
-	if strings.Contains(redacted, "not-a-secret-fixture") || strings.Contains(redacted, "plain-text") {
-		t.Fatalf("diff was not redacted: %q", redacted)
+	for _, leaked := range []string{"not-a-secret-fixture", "quoted-secret-fixture", "plain-text", "quoted-token-fixture"} {
+		if strings.Contains(redacted, leaked) {
+			t.Fatalf("diff leaked %q after redaction: %q", leaked, redacted)
+		}
 	}
-	if !strings.Contains(redacted, "API_TOKEN=[REDACTED]") || !strings.Contains(redacted, "Authorization: Bearer [REDACTED]") {
-		t.Fatalf("redacted markers missing: %q", redacted)
+	if !strings.Contains(redacted, "API_TOKEN=[REDACTED]") ||
+		!strings.Contains(redacted, "QUOTED_API_TOKEN=[REDACTED]") ||
+		!strings.Contains(redacted, "Authorization: Bearer [REDACTED]") {
+		t.Fatalf("diff was not redacted: %q", redacted)
 	}
 }
 

--- a/cli/embedded/hooks/commit-review-gate.sh
+++ b/cli/embedded/hooks/commit-review-gate.sh
@@ -24,9 +24,18 @@ fi
 
 if ! declare -F redact_sensitive_diff >/dev/null 2>&1; then
     redact_sensitive_diff() {
+        local secret_name='[A-Za-z0-9_-]*([Aa][Pp][Ii][_-]?[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Pp][Aa][Ss][Ss][Ww][Dd]|[Ss][Ee][Cc][Rr][Ee][Tt])[A-Za-z0-9_-]*'
+        local assign_prefix="((${secret_name})[[:space:]]*[:=][[:space:]]*)"
+        local auth_prefix='(([Aa]uthorization|AUTHORIZATION)[[:space:]]*:[[:space:]]*([Bb]earer|[Bb]asic)[[:space:]]+)'
         sed -E \
-            -e 's/(([A-Za-z0-9_-]*([Aa][Pp][Ii][_-]?[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Pp][Aa][Ss][Ss][Ww][Dd]|[Ss][Ee][Cc][Rr][Ee][Tt])[A-Za-z0-9_-]*)[[:space:]]*[:=][[:space:]]*)[^[:space:]"'\''`]+/\1[REDACTED]/g' \
-            -e 's/(([Aa]uthorization|AUTHORIZATION)[[:space:]]*:[[:space:]]*([Bb]earer|[Bb]asic)[[:space:]]+)[^[:space:]"'\''`]+/\1[REDACTED]/g'
+            -e "s/${assign_prefix}\"[^\"]*\"/\\1[REDACTED]/g" \
+            -e "s/${assign_prefix}'[^']*'/\\1[REDACTED]/g" \
+            -e 's/(([A-Za-z0-9_-]*([Aa][Pp][Ii][_-]?[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Pp][Aa][Ss][Ss][Ww][Dd]|[Ss][Ee][Cc][Rr][Ee][Tt])[A-Za-z0-9_-]*)[[:space:]]*[:=][[:space:]]*)`[^`]*`/\1[REDACTED]/g' \
+            -e "s/${assign_prefix}[^[:space:]\"'\`]+/\\1[REDACTED]/g" \
+            -e "s/${auth_prefix}\"[^\"]*\"/\\1[REDACTED]/g" \
+            -e "s/${auth_prefix}'[^']*'/\\1[REDACTED]/g" \
+            -e 's/(([Aa]uthorization|AUTHORIZATION)[[:space:]]*:[[:space:]]*([Bb]earer|[Bb]asic)[[:space:]]+)`[^`]*`/\1[REDACTED]/g' \
+            -e "s/${auth_prefix}[^[:space:]\"'\`]+/\\1[REDACTED]/g"
     }
 fi
 

--- a/cli/embedded/lib/hook-helpers.sh
+++ b/cli/embedded/lib/hook-helpers.sh
@@ -241,9 +241,18 @@ emit_hook_context() {
 
 # redact_sensitive_diff — Scrub secret-like values from diff previews.
 redact_sensitive_diff() {
+    local secret_name='[A-Za-z0-9_-]*([Aa][Pp][Ii][_-]?[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Pp][Aa][Ss][Ss][Ww][Dd]|[Ss][Ee][Cc][Rr][Ee][Tt])[A-Za-z0-9_-]*'
+    local assign_prefix="((${secret_name})[[:space:]]*[:=][[:space:]]*)"
+    local auth_prefix='(([Aa]uthorization|AUTHORIZATION)[[:space:]]*:[[:space:]]*([Bb]earer|[Bb]asic)[[:space:]]+)'
     sed -E \
-        -e 's/(([A-Za-z0-9_-]*([Aa][Pp][Ii][_-]?[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Pp][Aa][Ss][Ss][Ww][Dd]|[Ss][Ee][Cc][Rr][Ee][Tt])[A-Za-z0-9_-]*)[[:space:]]*[:=][[:space:]]*)[^[:space:]"'\''`]+/\1[REDACTED]/g' \
-        -e 's/(([Aa]uthorization|AUTHORIZATION)[[:space:]]*:[[:space:]]*([Bb]earer|[Bb]asic)[[:space:]]+)[^[:space:]"'\''`]+/\1[REDACTED]/g'
+        -e "s/${assign_prefix}\"[^\"]*\"/\\1[REDACTED]/g" \
+        -e "s/${assign_prefix}'[^']*'/\\1[REDACTED]/g" \
+        -e 's/(([A-Za-z0-9_-]*([Aa][Pp][Ii][_-]?[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Pp][Aa][Ss][Ss][Ww][Dd]|[Ss][Ee][Cc][Rr][Ee][Tt])[A-Za-z0-9_-]*)[[:space:]]*[:=][[:space:]]*)`[^`]*`/\1[REDACTED]/g' \
+        -e "s/${assign_prefix}[^[:space:]\"'\`]+/\\1[REDACTED]/g" \
+        -e "s/${auth_prefix}\"[^\"]*\"/\\1[REDACTED]/g" \
+        -e "s/${auth_prefix}'[^']*'/\\1[REDACTED]/g" \
+        -e 's/(([Aa]uthorization|AUTHORIZATION)[[:space:]]*:[[:space:]]*([Bb]earer|[Bb]asic)[[:space:]]+)`[^`]*`/\1[REDACTED]/g' \
+        -e "s/${auth_prefix}[^[:space:]\"'\`]+/\\1[REDACTED]/g"
 }
 
 # hash_text — Stable content fingerprint without retaining raw content.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -180,6 +180,7 @@
 - [Agent Footguns](agent-footguns.md) — Common agent failure modes and mitigations
 - [AgentOps Brief](agentops-brief.md) — Executive summary
 - [AgentOps System Map](agentops-system-map.md) — Visual system map
+- [Working with `.agents/`](agents-operator-guide.md) — Operator guide for `.agents/` state, write surfaces, and contributor flow
 - [Glossary](GLOSSARY.md) — Definitions of domain-specific terms (Beads, Brownian Ratchet, RPI, etc.)
 - [CLI Reference](https://github.com/boshu2/agentops/blob/main/cli/docs/COMMANDS.md) — Complete `ao` command reference (generated from source)
 - [Hooks Reference](HOOKS.md) — Lifecycle events, what each hook does, how to customize

--- a/docs/agents-operator-guide.md
+++ b/docs/agents-operator-guide.md
@@ -1,0 +1,72 @@
+# Working with `.agents/`
+
+`.agents/` is AgentOps' repo-local operating ledger. It holds the durable
+state, evidence, and generated artifacts that let agent sessions continue
+across turns, runtimes, and worktrees without depending on a separate service.
+
+The directory is intentionally structured. Production write surfaces are
+catalogued in [`docs/contracts/agents-write-surfaces.md`](contracts/agents-write-surfaces.md),
+and the contract gate rejects undocumented top-level subdirs. Skill-owned
+subdirs follow the `.agents/<skill-name>/` convention and are validated against
+the active skill catalog.
+
+Use `.agents/` for agent-operational state, not for ad hoc scratch files. If an
+artifact should be preserved, searched, cited, or replayed by AgentOps, give it
+a documented owner, lifecycle, and validation path.
+
+## Inspect the Current Surface
+
+Use these commands before changing the surface:
+
+```bash
+ao agents inspect
+ao agents lint
+scripts/check-agents-write-surfaces.sh
+```
+
+`ao agents inspect` shows the documented surface. `ao agents lint` and the
+script check production code against the contract.
+
+## Add a New Surface
+
+Follow the layering in
+[`docs/patterns/agents-hygiene-contract.md`](patterns/agents-hygiene-contract.md):
+contract doc, shell lint, regression tests, CLI surface, and pre-push wire-in.
+Small stacked changes are easier to validate than one broad surface expansion.
+
+For a new top-level `.agents/<name>/` write:
+
+1. Add the production write in the owning Go, shell, hook, or script code.
+2. Add the surface to the table and allowlist in
+   [`docs/contracts/agents-write-surfaces.md`](contracts/agents-write-surfaces.md).
+3. Add or update regression coverage in
+   `tests/scripts/check-agents-write-surfaces.bats` when the change introduces
+   a new contract dimension.
+4. Run `ao agents lint` or `scripts/check-agents-write-surfaces.sh`, then run
+   the relevant local gate before pushing.
+
+Pure read-side mirrors usually do not need a new contract. Prefer an
+end-to-end smoke test that locks the read invariant, as described in the
+hygiene pattern.
+
+## Contributor Flow
+
+1. Identify the owner and lifecycle: decide whether the artifact is persistent,
+   rolling, regenerated, or skill-owned.
+2. Patch code and contract together: production writes and the documented
+   allowlist must land in the same change.
+3. Prove the surface: run `ao agents inspect`, `ao agents lint`, and focused
+   tests for the changed owner.
+4. Close the loop: update linked docs or CLI help when behavior changes, record
+   validation evidence in bd, and keep the branch clean before push.
+
+## When a Gate Fails
+
+If the lint reports an undocumented `.agents/<name>` literal, either document it
+as a real write surface or remove the production write. If the surface is owned
+by a skill, confirm `skills/<name>/SKILL.md` exists and the code follows the
+skill-owned directory convention.
+
+Do not bypass the contract by moving writes to a less precise path. The purpose
+of the gate is to make ownership and cleanup rules visible to the next operator.
+

--- a/docs/agents-operator-guide.md
+++ b/docs/agents-operator-guide.md
@@ -69,4 +69,3 @@ skill-owned directory convention.
 
 Do not bypass the contract by moving writes to a less precise path. The purpose
 of the gate is to make ownership and cleanup rules visible to the next operator.
-

--- a/hooks/commit-review-gate.sh
+++ b/hooks/commit-review-gate.sh
@@ -24,9 +24,18 @@ fi
 
 if ! declare -F redact_sensitive_diff >/dev/null 2>&1; then
     redact_sensitive_diff() {
+        local secret_name='[A-Za-z0-9_-]*([Aa][Pp][Ii][_-]?[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Pp][Aa][Ss][Ss][Ww][Dd]|[Ss][Ee][Cc][Rr][Ee][Tt])[A-Za-z0-9_-]*'
+        local assign_prefix="((${secret_name})[[:space:]]*[:=][[:space:]]*)"
+        local auth_prefix='(([Aa]uthorization|AUTHORIZATION)[[:space:]]*:[[:space:]]*([Bb]earer|[Bb]asic)[[:space:]]+)'
         sed -E \
-            -e 's/(([A-Za-z0-9_-]*([Aa][Pp][Ii][_-]?[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Pp][Aa][Ss][Ss][Ww][Dd]|[Ss][Ee][Cc][Rr][Ee][Tt])[A-Za-z0-9_-]*)[[:space:]]*[:=][[:space:]]*)[^[:space:]"'\''`]+/\1[REDACTED]/g' \
-            -e 's/(([Aa]uthorization|AUTHORIZATION)[[:space:]]*:[[:space:]]*([Bb]earer|[Bb]asic)[[:space:]]+)[^[:space:]"'\''`]+/\1[REDACTED]/g'
+            -e "s/${assign_prefix}\"[^\"]*\"/\\1[REDACTED]/g" \
+            -e "s/${assign_prefix}'[^']*'/\\1[REDACTED]/g" \
+            -e 's/(([A-Za-z0-9_-]*([Aa][Pp][Ii][_-]?[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Pp][Aa][Ss][Ss][Ww][Dd]|[Ss][Ee][Cc][Rr][Ee][Tt])[A-Za-z0-9_-]*)[[:space:]]*[:=][[:space:]]*)`[^`]*`/\1[REDACTED]/g' \
+            -e "s/${assign_prefix}[^[:space:]\"'\`]+/\\1[REDACTED]/g" \
+            -e "s/${auth_prefix}\"[^\"]*\"/\\1[REDACTED]/g" \
+            -e "s/${auth_prefix}'[^']*'/\\1[REDACTED]/g" \
+            -e 's/(([Aa]uthorization|AUTHORIZATION)[[:space:]]*:[[:space:]]*([Bb]earer|[Bb]asic)[[:space:]]+)`[^`]*`/\1[REDACTED]/g' \
+            -e "s/${auth_prefix}[^[:space:]\"'\`]+/\\1[REDACTED]/g"
     }
 fi
 

--- a/lib/hook-helpers.sh
+++ b/lib/hook-helpers.sh
@@ -241,9 +241,18 @@ emit_hook_context() {
 
 # redact_sensitive_diff — Scrub secret-like values from diff previews.
 redact_sensitive_diff() {
+    local secret_name='[A-Za-z0-9_-]*([Aa][Pp][Ii][_-]?[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Pp][Aa][Ss][Ss][Ww][Dd]|[Ss][Ee][Cc][Rr][Ee][Tt])[A-Za-z0-9_-]*'
+    local assign_prefix="((${secret_name})[[:space:]]*[:=][[:space:]]*)"
+    local auth_prefix='(([Aa]uthorization|AUTHORIZATION)[[:space:]]*:[[:space:]]*([Bb]earer|[Bb]asic)[[:space:]]+)'
     sed -E \
-        -e 's/(([A-Za-z0-9_-]*([Aa][Pp][Ii][_-]?[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Pp][Aa][Ss][Ss][Ww][Dd]|[Ss][Ee][Cc][Rr][Ee][Tt])[A-Za-z0-9_-]*)[[:space:]]*[:=][[:space:]]*)[^[:space:]"'\''`]+/\1[REDACTED]/g' \
-        -e 's/(([Aa]uthorization|AUTHORIZATION)[[:space:]]*:[[:space:]]*([Bb]earer|[Bb]asic)[[:space:]]+)[^[:space:]"'\''`]+/\1[REDACTED]/g'
+        -e "s/${assign_prefix}\"[^\"]*\"/\\1[REDACTED]/g" \
+        -e "s/${assign_prefix}'[^']*'/\\1[REDACTED]/g" \
+        -e 's/(([A-Za-z0-9_-]*([Aa][Pp][Ii][_-]?[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Pp][Aa][Ss][Ss][Ww][Dd]|[Ss][Ee][Cc][Rr][Ee][Tt])[A-Za-z0-9_-]*)[[:space:]]*[:=][[:space:]]*)`[^`]*`/\1[REDACTED]/g' \
+        -e "s/${assign_prefix}[^[:space:]\"'\`]+/\\1[REDACTED]/g" \
+        -e "s/${auth_prefix}\"[^\"]*\"/\\1[REDACTED]/g" \
+        -e "s/${auth_prefix}'[^']*'/\\1[REDACTED]/g" \
+        -e 's/(([Aa]uthorization|AUTHORIZATION)[[:space:]]*:[[:space:]]*([Bb]earer|[Bb]asic)[[:space:]]+)`[^`]*`/\1[REDACTED]/g' \
+        -e "s/${auth_prefix}[^[:space:]\"'\`]+/\\1[REDACTED]/g"
 }
 
 # hash_text — Stable content fingerprint without retaining raw content.

--- a/scripts/generate-cli-reference.sh
+++ b/scripts/generate-cli-reference.sh
@@ -117,13 +117,13 @@ DOC_HEADER
 
 DOC_GLOBAL_FLAGS
 
-  echo "$top_help" | extract_flags | while IFS= read -r line; do
+  extract_flags <<<"$top_help" | while IFS= read -r line; do
     echo "    $line"
   done
   echo ""
 
   local commands
-  commands="$(echo "$top_help" | extract_commands | grep -v '^$')"
+  commands="$(extract_commands <<<"$top_help" | grep -v '^$')"
 
   cat <<'DOC_COMMANDS'
 ---
@@ -137,7 +137,7 @@ DOC_COMMANDS
     cmd_help="$("$AO_BIN" "$cmd" --help 2>&1 || true)"
 
     local description
-    description="$(echo "$cmd_help" | head -n1)"
+    description="${cmd_help%%$'\n'*}"
 
     echo "### \`ao ${cmd}\`"
     echo ""
@@ -145,7 +145,7 @@ DOC_COMMANDS
     echo ""
 
     local usage
-    usage="$(echo "$cmd_help" | extract_usage || true)"
+    usage="$(extract_usage <<<"$cmd_help" || true)"
     if [[ -n "$usage" ]]; then
       echo '```'
       echo "$usage"
@@ -154,8 +154,8 @@ DOC_COMMANDS
     fi
 
     local flags_block
-    flags_block="$(echo "$cmd_help" | extract_flags || true)"
-    if echo "$flags_block" | has_non_help_flags >/dev/null 2>&1; then
+    flags_block="$(extract_flags <<<"$cmd_help" || true)"
+    if has_non_help_flags <<<"$flags_block" >/dev/null 2>&1; then
       echo "**Flags:**"
       echo ""
       echo '```'
@@ -165,7 +165,7 @@ DOC_COMMANDS
     fi
 
     local subcmds
-    subcmds="$(echo "$cmd_help" | extract_commands | grep -v '^$' || true)"
+    subcmds="$(extract_commands <<<"$cmd_help" | grep -v '^$' || true)"
     if [[ -n "$subcmds" ]]; then
       echo "**Subcommands:**"
       echo ""
@@ -174,7 +174,7 @@ DOC_COMMANDS
         sub_help="$("$AO_BIN" "$cmd" "$sub" --help 2>&1 || true)"
 
         local sub_desc
-        sub_desc="$(echo "$sub_help" | head -n1)"
+        sub_desc="${sub_help%%$'\n'*}"
 
         echo "#### \`ao ${cmd} ${sub}\`"
         echo ""
@@ -182,7 +182,7 @@ DOC_COMMANDS
         echo ""
 
         local sub_usage
-        sub_usage="$(echo "$sub_help" | extract_usage || true)"
+        sub_usage="$(extract_usage <<<"$sub_help" || true)"
         if [[ -n "$sub_usage" ]]; then
           echo '```'
           echo "$sub_usage"
@@ -191,8 +191,8 @@ DOC_COMMANDS
         fi
 
         local sub_flags
-        sub_flags="$(echo "$sub_help" | extract_flags || true)"
-        if echo "$sub_flags" | has_non_help_flags >/dev/null 2>&1; then
+        sub_flags="$(extract_flags <<<"$sub_help" || true)"
+        if has_non_help_flags <<<"$sub_flags" >/dev/null 2>&1; then
           echo "**Flags:**"
           echo ""
           echo '```'
@@ -202,14 +202,14 @@ DOC_COMMANDS
         fi
 
         local subsub_cmds
-        subsub_cmds="$(echo "$sub_help" | extract_commands | grep -v '^$' || true)"
+        subsub_cmds="$(extract_commands <<<"$sub_help" | grep -v '^$' || true)"
         if [[ -n "$subsub_cmds" ]]; then
           for subsub in $subsub_cmds; do
             local subsub_help
             subsub_help="$("$AO_BIN" "$cmd" "$sub" "$subsub" --help 2>&1 || true)"
 
             local subsub_desc
-            subsub_desc="$(echo "$subsub_help" | head -n1)"
+            subsub_desc="${subsub_help%%$'\n'*}"
 
             echo "##### \`ao ${cmd} ${sub} ${subsub}\`"
             echo ""
@@ -217,7 +217,7 @@ DOC_COMMANDS
             echo ""
 
             local subsub_usage
-            subsub_usage="$(echo "$subsub_help" | extract_usage || true)"
+            subsub_usage="$(extract_usage <<<"$subsub_help" || true)"
             if [[ -n "$subsub_usage" ]]; then
               echo '```'
               echo "$subsub_usage"
@@ -226,8 +226,8 @@ DOC_COMMANDS
             fi
 
             local subsub_flags
-            subsub_flags="$(echo "$subsub_help" | extract_flags || true)"
-            if echo "$subsub_flags" | has_non_help_flags >/dev/null 2>&1; then
+            subsub_flags="$(extract_flags <<<"$subsub_help" || true)"
+            if has_non_help_flags <<<"$subsub_flags" >/dev/null 2>&1; then
               echo "**Flags:**"
               echo ""
               echo '```'

--- a/tests/hooks/hook-output-schema.bats
+++ b/tests/hooks/hook-output-schema.bats
@@ -178,16 +178,24 @@ EOF
     echo "initial" > "$MOCK_REPO/file.txt"
     git -C "$MOCK_REPO" add file.txt
     git -C "$MOCK_REPO" -c user.name=test -c user.email=t@t commit -q -m "init" 2>/dev/null
-    echo "TOKEN_FOR_REDACTION=not-a-secret-fixture" > "$MOCK_REPO/config.env"
+    cat > "$MOCK_REPO/config.env" <<'EOF'
+TOKEN_FOR_REDACTION=not-a-secret-fixture
+QUOTED_TOKEN_FOR_REDACTION="quoted-secret-fixture"
+Authorization: Bearer "quoted-token-fixture"
+EOF
     git -C "$MOCK_REPO" add config.env
-    run bash -c 'cd "$1" && printf "%s" "$2" | bash "$3" 2>&1' \
+    run bash -c 'cd "$1" && printf "%s" "$2" | AGENTOPS_MANAGED_HOOK_BACKEND_DISABLED=1 bash "$3" 2>&1' \
         -- "$MOCK_REPO" '{"tool_name":"Bash","tool_input":{"command":"git commit -m test"}}' "$HOOKS_DIR/commit-review-gate.sh"
     [ "$status" -eq 0 ]
     [ -n "$output" ]
     local ctx
     ctx=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
     [[ "$ctx" == *"TOKEN_FOR_REDACTION=[REDACTED]"* ]]
+    [[ "$ctx" == *"QUOTED_TOKEN_FOR_REDACTION=[REDACTED]"* ]]
+    [[ "$ctx" == *"Authorization: Bearer [REDACTED]"* ]]
     [[ "$ctx" != *"not-a-secret-fixture"* ]]
+    [[ "$ctx" != *"quoted-secret-fixture"* ]]
+    [[ "$ctx" != *"quoted-token-fixture"* ]]
 }
 
 @test "commit-review-gate: non-git command emits no output" {


### PR DESCRIPTION
## Summary
- redact quoted secret assignments and quoted Authorization bearer tokens in commit-review paths
- add a Working with `.agents/` operator guide and link it from README/docs index
- fix CLI docs parity false failures from SIGPIPE under `pipefail`

## Validation
- `go test ./cmd/ao -run 'TestHooksRun|TestRunManagedHook' -count=1`\n- `bats tests/hooks/hook-output-schema.bats --filter 'commit-review-gate'`\n- `shellcheck --severity=error hooks/commit-review-gate.sh lib/hook-helpers.sh cli/embedded/hooks/commit-review-gate.sh cli/embedded/lib/hook-helpers.sh scripts/generate-cli-reference.sh`\n- `bash scripts/validate-hooks-doc-parity.sh`\n- `npx -y markdownlint-cli docs/agents-operator-guide.md docs/INDEX.md README.md`\n- `bash tests/docs/validate-doc-release.sh`\n- `scripts/generate-cli-reference.sh --check`\n- `git diff --check`\n- `AGENTS_HUB_OVERRIDE=/tmp/empty-agents-hub-for-next-work HASH_GATE_IGNORE_UNTRACKED=1 scripts/pre-push-gate.sh --fast` (blocked only by unrelated dirty canonical root disposition)\n