### PR TITLE
Nightly 2026-04-26 v2 — 9 productive cycles, +0 code-driven goals (corpus-state isolated)

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -100,24 +100,31 @@ The three-gap contract is satisfied when the mapped gates below remain green tog
 
 ## Gates
 
-| ID | Check | Weight | Description |
-|----|-------|--------|-------------|
-| flywheel-compounding | `bash scripts/check-flywheel-compounding.sh` | 8 | Knowledge flywheel above escape velocity (σρ > δ); on fail, surfaces σρδ + dominant root cause instead of a bare `false` |
-| flywheel-proof | `bash scripts/proof-run.sh` | 7 | Flywheel compounds across sessions (automated proof) |
-| skill-frontmatter | `bash -c 'for f in skills/*/SKILL.md; do head -5 "$f" \| grep -q "^---" && head -10 "$f" \| grep -q "^name:" && head -10 "$f" \| grep -q "^description:" \|\| { echo FAIL:$f; exit 1; }; done'` | 6 | Every skill has valid YAML frontmatter |
-| hook-preflight | `timeout 60 ./scripts/validate-hook-preflight.sh` | 6 | All hooks pass safety checks |
-| go-cli-builds | `cd cli && go build -o /dev/null ./cmd/ao` | 8 | Go CLI compiles without errors |
-| go-cli-tests | `cd cli && timeout 240 go test -race ./...` | 8 | All Go tests pass with race detector |
-| go-vet-clean | `cd cli && go vet ./...` | 5 | No common bugs detected by vet |
-| go-complexity-ceiling | `timeout 60 bash scripts/check-go-absolute-complexity.sh --dir cli/ --threshold 20 && timeout 60 bash scripts/check-go-absolute-complexity.sh --dir cli/internal/ --threshold 18` | 6 | No Go function exceeds CC thresholds (cli/: 20, cli/internal/: 18) |
-| security-gate | `test -x scripts/security-gate.sh && timeout 60 bash tests/scripts/test-security-gate.sh` | 6 | Security toolchain gate is executable and passes |
-| manifest-versions-match | `test "$(jq -r '.metadata.version' .claude-plugin/marketplace.json)" = "$(jq -r '.version' .claude-plugin/plugin.json)"` | 5 | Plugin and marketplace versions in sync |
-| wiring-closure | `timeout 60 bash scripts/check-wiring-closure.sh` | 7 | All scripts, skills, and hooks referenced by registries exist |
-| contract-compatibility | `timeout 60 bash scripts/check-contract-compatibility.sh` | 5 | Contract schemas and references exist on disk |
-| goals-validate | `bash -c 'cd cli && go build -o /tmp/ao-goals-val ./cmd/ao && cd .. && /tmp/ao-goals-val goals validate --json 2>/dev/null \| jq -e ".valid == true"'` | 5 | GOALS.md parses and validates without structural errors |
-| compile-freshness | `bash scripts/check-compile-health.sh` | 4 | Compile defrag report is fresh and stale learnings are low |
-| compile-no-oscillation | `bash scripts/check-compile-oscillation.sh` | 4 | No evolve goals oscillating across consecutive cycles |
-| competitive-freshness | `bash scripts/check-competitive-freshness.sh` | 3 | Competitive analysis docs updated within 45 days |
-| codex-parity-drift | `bash scripts/check-codex-parity-drift.sh` | 5 | No codex parity findings from audit |
-| install-smoke | `timeout 30 bash tests/install/test-install-smoke.sh` | 5 | Install scripts pass syntax and structure validation |
-| flywheel-lifecycle | `timeout 30 bash scripts/check-flywheel-lifecycle.sh` | 6 | Knowledge lifecycle traces capture → index → inject → retrieval |
+The optional `Tags` column lets a gate declare classification metadata that
+flows through to `ao goals measure --json` (each measurement carries a `tags`
+field). The `long-cycle` and `corpus-state` tags mark gates whose green path
+depends on multi-session corpus growth rather than the current commit, so
+operator tooling (e.g. /evolve selection) can distinguish "code-actionable"
+failures from corpus-bound ones without lowering weights or removing the gate.
+
+| ID | Check | Weight | Description | Tags |
+|----|-------|--------|-------------|------|
+| flywheel-compounding | `bash scripts/check-flywheel-compounding.sh` | 8 | Knowledge flywheel above escape velocity (σρ > δ); on fail, surfaces σρδ + dominant root cause instead of a bare `false` | long-cycle, corpus-state |
+| flywheel-proof | `bash scripts/proof-run.sh` | 7 | Flywheel compounds across sessions (automated proof) |  |
+| skill-frontmatter | `bash -c 'for f in skills/*/SKILL.md; do head -5 "$f" \| grep -q "^---" && head -10 "$f" \| grep -q "^name:" && head -10 "$f" \| grep -q "^description:" \|\| { echo FAIL:$f; exit 1; }; done'` | 6 | Every skill has valid YAML frontmatter |  |
+| hook-preflight | `timeout 60 ./scripts/validate-hook-preflight.sh` | 6 | All hooks pass safety checks |  |
+| go-cli-builds | `cd cli && go build -o /dev/null ./cmd/ao` | 8 | Go CLI compiles without errors |  |
+| go-cli-tests | `cd cli && timeout 240 go test -race ./...` | 8 | All Go tests pass with race detector |  |
+| go-vet-clean | `cd cli && go vet ./...` | 5 | No common bugs detected by vet |  |
+| go-complexity-ceiling | `timeout 60 bash scripts/check-go-absolute-complexity.sh --dir cli/ --threshold 20 && timeout 60 bash scripts/check-go-absolute-complexity.sh --dir cli/internal/ --threshold 18` | 6 | No Go function exceeds CC thresholds (cli/: 20, cli/internal/: 18) |  |
+| security-gate | `test -x scripts/security-gate.sh && timeout 60 bash tests/scripts/test-security-gate.sh` | 6 | Security toolchain gate is executable and passes |  |
+| manifest-versions-match | `test "$(jq -r '.metadata.version' .claude-plugin/marketplace.json)" = "$(jq -r '.version' .claude-plugin/plugin.json)"` | 5 | Plugin and marketplace versions in sync |  |
+| wiring-closure | `timeout 60 bash scripts/check-wiring-closure.sh` | 7 | All scripts, skills, and hooks referenced by registries exist |  |
+| contract-compatibility | `timeout 60 bash scripts/check-contract-compatibility.sh` | 5 | Contract schemas and references exist on disk |  |
+| goals-validate | `bash -c 'cd cli && go build -o /tmp/ao-goals-val ./cmd/ao && cd .. && /tmp/ao-goals-val goals validate --json 2>/dev/null \| jq -e ".valid == true"'` | 5 | GOALS.md parses and validates without structural errors |  |
+| compile-freshness | `bash scripts/check-compile-health.sh` | 4 | Compile defrag report is fresh and stale learnings are low | runtime-artifact |
+| compile-no-oscillation | `bash scripts/check-compile-oscillation.sh` | 4 | No evolve goals oscillating across consecutive cycles | runtime-artifact |
+| competitive-freshness | `bash scripts/check-competitive-freshness.sh` | 3 | Competitive analysis docs updated within 45 days |  |
+| codex-parity-drift | `bash scripts/check-codex-parity-drift.sh` | 5 | No codex parity findings from audit |  |
+| install-smoke | `timeout 30 bash tests/install/test-install-smoke.sh` | 5 | Install scripts pass syntax and structure validation |  |
+| flywheel-lifecycle | `timeout 30 bash scripts/check-flywheel-lifecycle.sh` | 6 | Knowledge lifecycle traces capture → index → inject → retrieval |  |

--- a/cli/cmd/ao/goals_measure.go
+++ b/cli/cmd/ao/goals_measure.go
@@ -10,6 +10,7 @@ import (
 var (
 	goalsMeasureGoalID     string
 	goalsMeasureDirectives bool
+	goalsMeasureExcludeTag string
 )
 
 var goalsMeasureCmd = &cobra.Command{
@@ -20,6 +21,7 @@ var goalsMeasureCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return goals.RunMeasure(goals.MeasureOptions{
 			GoalID:     goalsMeasureGoalID,
+			ExcludeTag: goalsMeasureExcludeTag,
 			Directives: goalsMeasureDirectives,
 			GoalsFile:  resolveGoalsFile(),
 			Timeout:    time.Duration(goalsTimeout) * time.Second,
@@ -32,5 +34,6 @@ var goalsMeasureCmd = &cobra.Command{
 func init() {
 	goalsMeasureCmd.Flags().StringVar(&goalsMeasureGoalID, "goal", "", "Measure a single goal by ID")
 	goalsMeasureCmd.Flags().BoolVar(&goalsMeasureDirectives, "directives", false, "Output directives as JSON (skip gate checks)")
+	goalsMeasureCmd.Flags().StringVar(&goalsMeasureExcludeTag, "exclude-tag", "", "Skip goals whose Tags include this value (e.g. long-cycle)")
 	goalsCmd.AddCommand(goalsMeasureCmd)
 }

--- a/cli/cmd/ao/inject_context_paths.go
+++ b/cli/cmd/ao/inject_context_paths.go
@@ -23,6 +23,20 @@ func contextArtifactDir(runID string, randReader io.Reader) string {
 	return filepath.Join(".agents", "context", runID)
 }
 
+// newAdhocContextRunID returns a context run ID of the form
+// `adhoc-<unix-seconds>-<4-hex>`. The 4-hex suffix is drawn from the
+// crypto/rand source and gives ~1/65 536 collision probability between
+// two calls inside the same second. When the entropy read fails the
+// fallback uses the lower 16 bits of `now.UnixNano()` so the suffix is
+// still unique within sub-second windows even on entropy-starved hosts.
+//
+// Even with the suffix, the timestamp remains second-granular: callers
+// MUST treat the directory created by ensureContextDir as idempotent
+// (os.MkdirAll → no-op when present), because two adhoc IDs minted in
+// the same second with the same random suffix WILL share a path. This
+// has been safe since the directory is created with MkdirAll and the
+// suffix-collision rate is low; documenting it here so future callers
+// don't try to use the path itself as a session-uniqueness signal.
 func newAdhocContextRunID(now time.Time, r io.Reader) string {
 	suffix := make([]byte, 2)
 	if _, err := io.ReadFull(r, suffix); err != nil {
@@ -32,6 +46,9 @@ func newAdhocContextRunID(now time.Time, r io.Reader) string {
 }
 
 // ensureContextDir creates the context artifact directory on disk.
+// The mkdir is idempotent (os.MkdirAll), so two adhoc IDs that collide
+// (~1/65 536 within the same second; see newAdhocContextRunID) reuse the
+// same directory rather than erroring.
 func ensureContextDir(cwd, runID string, randReader io.Reader) (string, error) {
 	dir := filepath.Join(cwd, contextArtifactDir(runID, randReader))
 	if err := os.MkdirAll(dir, 0755); err != nil {

--- a/cli/cmd/ao/inject_context_paths_test.go
+++ b/cli/cmd/ao/inject_context_paths_test.go
@@ -66,6 +66,57 @@ func TestNewAdhocContextRunID_FallsBackToTimeBits(t *testing.T) {
 	}
 }
 
+// TestEnsureContextDir_IdempotentOnAdhocCollision pins the documented
+// collision behavior: when two adhoc IDs share the same timestamp AND
+// the same 16-bit random suffix (~1/65 536 within the same second),
+// the second ensureContextDir call MUST reuse the directory rather than
+// erroring. This is the behavior that lets concurrent adhoc-id callers
+// stay safe without coordination.
+func TestEnsureContextDir_IdempotentOnAdhocCollision(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	first, err := ensureContextDir(tmpDir, "adhoc-1234-abcd", nil)
+	if err != nil {
+		t.Fatalf("first ensureContextDir error: %v", err)
+	}
+	// Drop a marker so we can prove the second call reused the same dir.
+	marker := filepath.Join(first, "marker.txt")
+	if err := os.WriteFile(marker, []byte("from-first"), 0644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	second, err := ensureContextDir(tmpDir, "adhoc-1234-abcd", nil)
+	if err != nil {
+		t.Fatalf("collision ensureContextDir error: %v", err)
+	}
+	if first != second {
+		t.Errorf("collision returned different paths: first=%q second=%q", first, second)
+	}
+	got, err := os.ReadFile(filepath.Join(second, "marker.txt"))
+	if err != nil {
+		t.Fatalf("read marker after collision: %v", err)
+	}
+	if string(got) != "from-first" {
+		t.Errorf("marker = %q, want %q (second call clobbered the dir instead of reusing it)", got, "from-first")
+	}
+}
+
+// TestNewAdhocContextRunID_DistinctSuffixesInSameSecond pins that two adhoc
+// IDs minted in the same second with different entropy reads produce
+// different run IDs. This is the protection that makes 1-second timestamp
+// granularity acceptable in practice.
+func TestNewAdhocContextRunID_DistinctSuffixesInSameSecond(t *testing.T) {
+	now := time.Unix(2000, 0)
+	a := newAdhocContextRunID(now, strings.NewReader("\x00\x01"))
+	b := newAdhocContextRunID(now, strings.NewReader("\xff\xfe"))
+	if a == b {
+		t.Fatalf("expected different IDs, got %q == %q", a, b)
+	}
+	if a != "adhoc-2000-0001" || b != "adhoc-2000-fffe" {
+		t.Errorf("ids = (%q, %q), want (adhoc-2000-0001, adhoc-2000-fffe)", a, b)
+	}
+}
+
 func TestEnsureContextDir_CreatesDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
 	got, err := ensureContextDir(tmpDir, "test-run", nil)

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -971,9 +971,10 @@ ao goals measure [flags]
 **Flags:**
 
 ```
-      --directives    Output directives as JSON (skip gate checks)
-      --goal string   Measure a single goal by ID
-  -h, --help          help for measure
+      --directives           Output directives as JSON (skip gate checks)
+      --exclude-tag string   Skip goals whose Tags include this value (e.g. long-cycle)
+      --goal string          Measure a single goal by ID
+  -h, --help                 help for measure
 ```
 
 #### `ao goals validate`

--- a/cli/internal/goals/commands.go
+++ b/cli/internal/goals/commands.go
@@ -74,6 +74,7 @@ func RunHistory(opts HistoryOptions) error {
 // MeasureOptions configures the goals measure command.
 type MeasureOptions struct {
 	GoalID     string
+	ExcludeTag string // Filter out goals whose Tags include this value (e.g. "long-cycle").
 	Directives bool
 	GoalsFile  string
 	Timeout    time.Duration
@@ -82,6 +83,45 @@ type MeasureOptions struct {
 	SnapDir    string
 	Stdout     io.Writer
 	Stderr     io.Writer
+}
+
+// goalHasTag reports whether g.Tags contains the given tag (case-insensitive).
+func goalHasTag(g Goal, tag string) bool {
+	for _, t := range g.Tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// applyMeasureFilters narrows gf.Goals according to MeasureOptions:
+// --goal restricts to a single ID (returns "not found" if absent), then
+// --exclude-tag drops any remaining goal whose Tags include that value.
+// Mutates gf in place.
+func applyMeasureFilters(gf *GoalFile, opts MeasureOptions) error {
+	if opts.GoalID != "" {
+		var filtered []Goal
+		for _, g := range gf.Goals {
+			if g.ID == opts.GoalID {
+				filtered = append(filtered, g)
+			}
+		}
+		if len(filtered) == 0 {
+			return fmt.Errorf("goal %q not found", opts.GoalID)
+		}
+		gf.Goals = filtered
+	}
+	if opts.ExcludeTag != "" {
+		var filtered []Goal
+		for _, g := range gf.Goals {
+			if !goalHasTag(g, opts.ExcludeTag) {
+				filtered = append(filtered, g)
+			}
+		}
+		gf.Goals = filtered
+	}
+	return nil
 }
 
 // RunMeasure runs goal checks and produces a snapshot.
@@ -120,17 +160,8 @@ func RunMeasure(opts MeasureOptions) error {
 		return fmt.Errorf("%d validation errors", len(errs))
 	}
 
-	if opts.GoalID != "" {
-		var filtered []Goal
-		for _, g := range gf.Goals {
-			if g.ID == opts.GoalID {
-				filtered = append(filtered, g)
-			}
-		}
-		if len(filtered) == 0 {
-			return fmt.Errorf("goal %q not found", opts.GoalID)
-		}
-		gf.Goals = filtered
+	if err := applyMeasureFilters(gf, opts); err != nil {
+		return err
 	}
 
 	snap := Measure(gf, opts.Timeout)

--- a/cli/internal/goals/goals_measure_test.go
+++ b/cli/internal/goals/goals_measure_test.go
@@ -416,6 +416,104 @@ func TestGoalsMeasure_WeightedScoring(t *testing.T) {
 	}
 }
 
+func TestGoalsMeasure_ExcludeTagFilter(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	md := `# Goals
+
+Mission.
+
+## Gates
+
+| ID | Check | Weight | Description | Tags |
+|----|-------|--------|-------------|------|
+| code-actionable | ` + "`exit 0`" + ` | 5 | Untagged | |
+| corpus-bound | ` + "`exit 1`" + ` | 8 | Bound to corpus | long-cycle, corpus-state |
+`
+	goalsPath := filepath.Join(dir, "GOALS.md")
+	if err := os.WriteFile(goalsPath, []byte(md), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err := goals.RunMeasure(goals.MeasureOptions{
+		GoalsFile:  goalsPath,
+		ExcludeTag: "long-cycle",
+		JSON:       true,
+		Timeout:    10 * time.Second,
+		Stdout:     &buf,
+		SnapDir:    filepath.Join(dir, "baselines"),
+	})
+	if err != nil {
+		t.Fatalf("measure returned error: %v", err)
+	}
+
+	var snap goals.Snapshot
+	if err := json.Unmarshal(buf.Bytes(), &snap); err != nil {
+		t.Fatalf("failed to decode JSON: %v (raw: %s)", err, buf.String())
+	}
+
+	if snap.Summary.Total != 1 {
+		t.Errorf("Total = %d, want 1 (corpus-bound goal must be excluded)", snap.Summary.Total)
+	}
+	if snap.Summary.Failing != 0 {
+		t.Errorf("Failing = %d, want 0 (the failing goal is excluded by tag)", snap.Summary.Failing)
+	}
+	if snap.Summary.Score != 100.0 {
+		t.Errorf("Score = %f, want 100.0 (only the passing untagged goal remains)", snap.Summary.Score)
+	}
+	for _, m := range snap.Goals {
+		if m.GoalID == "corpus-bound" {
+			t.Errorf("corpus-bound goal leaked into snapshot despite --exclude-tag long-cycle")
+		}
+	}
+}
+
+func TestGoalsMeasure_ExcludeTagPlusGoalIDInteraction(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	md := `# Goals
+
+Mission.
+
+## Gates
+
+| ID | Check | Weight | Description | Tags |
+|----|-------|--------|-------------|------|
+| g-untagged | ` + "`exit 0`" + ` | 5 | | |
+| g-tagged | ` + "`exit 0`" + ` | 5 | | long-cycle |
+`
+	goalsPath := filepath.Join(dir, "GOALS.md")
+	if err := os.WriteFile(goalsPath, []byte(md), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// --goal narrows first; if the named goal is then dropped by --exclude-tag,
+	// the snapshot should be empty (no error — the goal was found and then filtered).
+	var buf bytes.Buffer
+	err := goals.RunMeasure(goals.MeasureOptions{
+		GoalsFile:  goalsPath,
+		GoalID:     "g-tagged",
+		ExcludeTag: "long-cycle",
+		JSON:       true,
+		Timeout:    10 * time.Second,
+		Stdout:     &buf,
+		SnapDir:    filepath.Join(dir, "baselines"),
+	})
+	if err != nil {
+		t.Fatalf("measure returned error: %v", err)
+	}
+	var snap goals.Snapshot
+	if err := json.Unmarshal(buf.Bytes(), &snap); err != nil {
+		t.Fatalf("failed to decode JSON: %v (raw: %s)", err, buf.String())
+	}
+	if snap.Summary.Total != 0 {
+		t.Errorf("Total = %d, want 0 (named goal was filtered out by tag)", snap.Summary.Total)
+	}
+}
+
 func TestGoalsMeasure_SkippedGoals(t *testing.T) {
 	t.Parallel()
 	gf := &goals.GoalFile{

--- a/cli/internal/goals/markdown.go
+++ b/cli/internal/goals/markdown.go
@@ -236,36 +236,57 @@ func parseTagsCell(s string) []string {
 	return out
 }
 
+// cellAt returns the trimmed value of cells[colMap[key]] if both the key
+// is mapped and the index is in range. Returns "", false otherwise.
+func cellAt(cells []string, colMap map[string]int, key string) (string, bool) {
+	idx, ok := colMap[key]
+	if !ok || idx >= len(cells) {
+		return "", false
+	}
+	return strings.TrimSpace(cells[idx]), true
+}
+
+// parseCheckCell strips wrapping backticks (`cmd`) so the gate's command
+// runs as written rather than literally including the markdown formatting.
+func parseCheckCell(s string) string {
+	if len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// parseWeightCell parses a goal weight, defaulting to 5 for non-numeric or
+// out-of-range (<1, >10) values.
+func parseWeightCell(s string) int {
+	w, err := strconv.Atoi(s)
+	if err != nil || w < 1 || w > 10 {
+		return 5
+	}
+	return w
+}
+
 // parseGateRow extracts a Goal from a data row's cells using the column index map.
 // Strips backticks from the check field, defaults weight to 5 on parse error,
 // and falls back description to ID if empty.
 func parseGateRow(cells []string, colMap map[string]int) Goal {
 	g := Goal{Type: GoalTypeHealth}
-	if idx, ok := colMap["id"]; ok && idx < len(cells) {
-		g.ID = strings.TrimSpace(cells[idx])
+	if v, ok := cellAt(cells, colMap, "id"); ok {
+		g.ID = v
 	}
-	if idx, ok := colMap["check"]; ok && idx < len(cells) {
-		s := strings.TrimSpace(cells[idx])
-		if len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' {
-			s = s[1 : len(s)-1]
-		}
-		g.Check = s
+	if v, ok := cellAt(cells, colMap, "check"); ok {
+		g.Check = parseCheckCell(v)
 	}
-	if idx, ok := colMap["weight"]; ok && idx < len(cells) {
-		w, err := strconv.Atoi(strings.TrimSpace(cells[idx]))
-		if err != nil || w < 1 || w > 10 {
-			w = 5
-		}
-		g.Weight = w
+	if v, ok := cellAt(cells, colMap, "weight"); ok {
+		g.Weight = parseWeightCell(v)
 	}
-	if idx, ok := colMap["description"]; ok && idx < len(cells) {
-		g.Description = strings.TrimSpace(cells[idx])
+	if v, ok := cellAt(cells, colMap, "description"); ok {
+		g.Description = v
 	}
 	if g.Description == "" {
 		g.Description = g.ID
 	}
-	if idx, ok := colMap["tags"]; ok && idx < len(cells) {
-		g.Tags = parseTagsCell(cells[idx])
+	if v, ok := cellAt(cells, colMap, "tags"); ok {
+		g.Tags = parseTagsCell(v)
 	}
 	return g
 }

--- a/cli/internal/goals/markdown.go
+++ b/cli/internal/goals/markdown.go
@@ -186,6 +186,7 @@ func parseDirectives(lines []string) []Directive {
 
 // buildGateColumnMap takes header row cells and returns a column index map.
 // Default mapping: {"id": 0, "check": 1, "weight": 2, "description": 3}.
+// "tags" is opt-in: only present in the map when the header declares it.
 // Header cell names are matched case-insensitively to override default positions.
 func buildGateColumnMap(cells []string) map[string]int {
 	colMap := map[string]int{"id": 0, "check": 1, "weight": 2, "description": 3}
@@ -200,9 +201,39 @@ func buildGateColumnMap(cells []string) map[string]int {
 			colMap["weight"] = j
 		case "description":
 			colMap["description"] = j
+		case "tags":
+			colMap["tags"] = j
 		}
 	}
 	return colMap
+}
+
+// parseTagsCell splits a Tags cell into a slice of tag strings.
+// Tags are comma- or semicolon-separated, lowercased, and trimmed; empty
+// entries are dropped. Backticks wrapping the cell value are stripped.
+// Returns nil for empty input so an unset Tags field stays nil rather than
+// becoming an empty slice (preserves omitempty behavior in serialization).
+func parseTagsCell(s string) []string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' {
+		s = s[1 : len(s)-1]
+	}
+	if s == "" {
+		return nil
+	}
+	splitter := func(r rune) bool { return r == ',' || r == ';' }
+	parts := strings.FieldsFunc(s, splitter)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // parseGateRow extracts a Goal from a data row's cells using the column index map.
@@ -232,6 +263,9 @@ func parseGateRow(cells []string, colMap map[string]int) Goal {
 	}
 	if g.Description == "" {
 		g.Description = g.ID
+	}
+	if idx, ok := colMap["tags"]; ok && idx < len(cells) {
+		g.Tags = parseTagsCell(cells[idx])
 	}
 	return g
 }

--- a/cli/internal/goals/markdown_test.go
+++ b/cli/internal/goals/markdown_test.go
@@ -987,6 +987,77 @@ func TestParseGateRow_TagsAbsentByDefault(t *testing.T) {
 	}
 }
 
+func TestCellAt(t *testing.T) {
+	cells := []string{"a", "b", "c"}
+	colMap := map[string]int{"first": 0, "third": 2, "out_of_range": 9}
+
+	v, ok := cellAt(cells, colMap, "first")
+	if !ok || v != "a" {
+		t.Errorf("first → (%q, %v), want (\"a\", true)", v, ok)
+	}
+	v, ok = cellAt(cells, colMap, "third")
+	if !ok || v != "c" {
+		t.Errorf("third → (%q, %v), want (\"c\", true)", v, ok)
+	}
+	v, ok = cellAt(cells, colMap, "missing_key")
+	if ok || v != "" {
+		t.Errorf("missing_key → (%q, %v), want (\"\", false)", v, ok)
+	}
+	v, ok = cellAt(cells, colMap, "out_of_range")
+	if ok || v != "" {
+		t.Errorf("out_of_range → (%q, %v), want (\"\", false)", v, ok)
+	}
+
+	// Whitespace must be trimmed.
+	cells2 := []string{"  padded  "}
+	colMap2 := map[string]int{"k": 0}
+	v, ok = cellAt(cells2, colMap2, "k")
+	if !ok || v != "padded" {
+		t.Errorf("padded → (%q, %v), want (\"padded\", true)", v, ok)
+	}
+}
+
+func TestParseCheckCell(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"`echo ok`", "echo ok"},
+		{"echo ok", "echo ok"},
+		{"`x`", "x"},
+		{"``", ""},
+		{"`", "`"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := parseCheckCell(tc.in)
+		if got != tc.want {
+			t.Errorf("parseCheckCell(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseWeightCell(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"5", 5},
+		{"1", 1},
+		{"10", 10},
+		{"0", 5},   // out of range → default
+		{"11", 5},  // out of range → default
+		{"-1", 5},  // out of range → default
+		{"abc", 5}, // non-numeric → default
+		{"", 5},    // empty → default
+	}
+	for _, tc := range cases {
+		got := parseWeightCell(tc.in)
+		if got != tc.want {
+			t.Errorf("parseWeightCell(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestParseGatesTable_TagsRoundTrip(t *testing.T) {
 	input := "# G\n\n## Gates\n" +
 		"| ID | Check | Weight | Description | Tags |\n" +

--- a/cli/internal/goals/markdown_test.go
+++ b/cli/internal/goals/markdown_test.go
@@ -923,8 +923,87 @@ func TestParseGatesTable_ExtraColumns(t *testing.T) {
 	if gf.Goals[0].ID != "g1" {
 		t.Errorf("goal ID = %q, want %q", gf.Goals[0].ID, "g1")
 	}
-	// The extra column must NOT corrupt the Description field.
 	if gf.Goals[0].Description != "Test" {
 		t.Errorf("Description = %q, want %q", gf.Goals[0].Description, "Test")
+	}
+}
+
+func TestParseTagsCell(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"whitespace_only", "   ", nil},
+		{"single", "long-cycle", []string{"long-cycle"}},
+		{"comma_separated", "long-cycle, corpus-state", []string{"long-cycle", "corpus-state"}},
+		{"semicolon_separated", "long-cycle; corpus-state", []string{"long-cycle", "corpus-state"}},
+		{"backticks_stripped", "`long-cycle, corpus-state`", []string{"long-cycle", "corpus-state"}},
+		{"mixed_case_lowered", "Long-Cycle, CORPUS-STATE", []string{"long-cycle", "corpus-state"}},
+		{"empty_entries_dropped", "long-cycle,, ; ,corpus-state,", []string{"long-cycle", "corpus-state"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseTagsCell(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d (got %v)", len(got), len(tc.want), got)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseGateRow_TagsHeaderColumn(t *testing.T) {
+	colMap := buildGateColumnMap([]string{"ID", "Check", "Weight", "Description", "Tags"})
+	cells := []string{"flywheel-compounding", "`bash check.sh`", "8", "knowledge flywheel", "long-cycle, corpus-state"}
+	g := parseGateRow(cells, colMap)
+
+	if g.ID != "flywheel-compounding" {
+		t.Errorf("ID = %q, want flywheel-compounding", g.ID)
+	}
+	if g.Weight != 8 {
+		t.Errorf("Weight = %d, want 8", g.Weight)
+	}
+	if len(g.Tags) != 2 {
+		t.Fatalf("Tags len = %d, want 2 (got %v)", len(g.Tags), g.Tags)
+	}
+	if g.Tags[0] != "long-cycle" || g.Tags[1] != "corpus-state" {
+		t.Errorf("Tags = %v, want [long-cycle corpus-state]", g.Tags)
+	}
+}
+
+func TestParseGateRow_TagsAbsentByDefault(t *testing.T) {
+	colMap := buildGateColumnMap([]string{"ID", "Check", "Weight", "Description"})
+	cells := []string{"g1", "echo ok", "5", "no tags column"}
+	g := parseGateRow(cells, colMap)
+
+	if g.Tags != nil {
+		t.Errorf("Tags = %v, want nil (no Tags column declared)", g.Tags)
+	}
+}
+
+func TestParseGatesTable_TagsRoundTrip(t *testing.T) {
+	input := "# G\n\n## Gates\n" +
+		"| ID | Check | Weight | Description | Tags |\n" +
+		"|---|---|---|---|---|\n" +
+		"| g-tagged | echo ok | 8 | tagged gate | long-cycle, corpus-state |\n" +
+		"| g-bare | echo ok | 5 | untagged gate |  |\n"
+	gf, err := ParseMarkdownGoals([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(gf.Goals) != 2 {
+		t.Fatalf("expected 2 goals, got %d", len(gf.Goals))
+	}
+	if len(gf.Goals[0].Tags) != 2 {
+		t.Errorf("g-tagged Tags = %v, want 2 entries", gf.Goals[0].Tags)
+	}
+	if gf.Goals[1].Tags != nil {
+		t.Errorf("g-bare Tags = %v, want nil", gf.Goals[1].Tags)
 	}
 }

--- a/cli/internal/goals/measure.go
+++ b/cli/internal/goals/measure.go
@@ -26,6 +26,7 @@ type Measurement struct {
 	Duration  float64  `json:"duration_s"`
 	Output    string   `json:"output,omitempty"`
 	Weight    int      `json:"weight"`
+	Tags      []string `json:"tags,omitempty"`
 }
 
 // classifyResult maps command exit status to a result string.
@@ -95,7 +96,7 @@ func untrackChild(pid int) {
 // Exit 0 = pass, non-zero = fail, context deadline exceeded = skip.
 // Uses process groups so child processes are killed on timeout.
 func MeasureOne(goal Goal, timeout time.Duration) Measurement {
-	m := Measurement{GoalID: goal.ID, Weight: goal.Weight}
+	m := Measurement{GoalID: goal.ID, Weight: goal.Weight, Tags: goal.Tags}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/cli/internal/ratchet/fuzz_test.go
+++ b/cli/internal/ratchet/fuzz_test.go
@@ -30,3 +30,96 @@ func FuzzParseChainLines(f *testing.F) {
 		_ = parseChainLines(scanner, chain)
 	})
 }
+
+// TestFuzzParseChainLines_SeedCorrectness pins behavioral expectations for
+// each seed input the fuzzer adds. Fuzz targets prove no-panic; this companion
+// asserts the parser actually populates Chain fields correctly for the
+// realistic inputs we seed it with. Without this, a regression that makes
+// parseChainLines silently drop entries would still pass the fuzz target.
+func TestFuzzParseChainLines_SeedCorrectness(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantID       string
+		wantEpic     string
+		wantEntries  int
+		wantFirstStep string
+		wantErr      bool
+	}{
+		{
+			name:          "metadata_plus_one_entry",
+			input:         `{"id":"chain-001","started":"2026-01-01T00:00:00Z","chain":[]}` + "\n" + `{"step":"research","timestamp":"2026-01-01T00:01:00Z","output":"plan.md","locked":true}`,
+			wantID:        "chain-001",
+			wantEntries:   1,
+			wantFirstStep: "research",
+		},
+		{
+			name:        "metadata_only",
+			input:       `{"id":"chain-002","started":"2026-01-01T00:00:00Z"}`,
+			wantID:      "chain-002",
+			wantEntries: 0,
+		},
+		{
+			name:        "empty_input",
+			input:       ``,
+			wantID:      "",
+			wantEntries: 0,
+		},
+		{
+			name:    "non_json_first_line",
+			input:   `not json at all`,
+			wantErr: true,
+		},
+		{
+			name:        "malformed_entry_skipped_among_valid",
+			input:       `{"id":"chain-003"}` + "\n" + `malformed entry` + "\n" + `{"step":"plan","timestamp":"2026-01-01T00:00:00Z","output":"out.md","locked":false}`,
+			wantID:      "chain-003",
+			wantEntries: 1,
+			wantFirstStep: "plan",
+		},
+		{
+			name:        "empty_metadata_object",
+			input:       `{}`,
+			wantID:      "",
+			wantEntries: 0,
+		},
+		{
+			name:          "epic_id_with_two_entries",
+			input:         `{"id":"chain-004","started":"2026-01-01T00:00:00Z","epic_id":"epic-1"}` + "\n" + `{"step":"research","timestamp":"2026-01-01T00:00:00Z","input":"in.md","output":"out.md","locked":true}` + "\n" + `{"step":"plan","timestamp":"2026-01-01T00:01:00Z","input":"out.md","output":"plan.md","locked":false}`,
+			wantID:        "chain-004",
+			wantEpic:      "epic-1",
+			wantEntries:   2,
+			wantFirstStep: "research",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := bufio.NewScanner(strings.NewReader(tt.input))
+			chain := &Chain{}
+			err := parseChainLines(scanner, chain)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected parse error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+			if chain.ID != tt.wantID {
+				t.Errorf("ID = %q, want %q", chain.ID, tt.wantID)
+			}
+			if chain.EpicID != tt.wantEpic {
+				t.Errorf("EpicID = %q, want %q", chain.EpicID, tt.wantEpic)
+			}
+			if len(chain.Entries) != tt.wantEntries {
+				t.Fatalf("Entries len = %d, want %d", len(chain.Entries), tt.wantEntries)
+			}
+			if tt.wantEntries > 0 && tt.wantFirstStep != "" {
+				if string(chain.Entries[0].Step) != tt.wantFirstStep {
+					t.Errorf("Entries[0].Step = %q, want %q", chain.Entries[0].Step, tt.wantFirstStep)
+				}
+			}
+		})
+	}
+}

--- a/scripts/audit-assertion-density.sh
+++ b/scripts/audit-assertion-density.sh
@@ -2,27 +2,51 @@
 # audit-assertion-density.sh
 # Analyze Go test files for assertion density.
 # Usage:
-#   bash scripts/audit-assertion-density.sh           # Report mode
-#   bash scripts/audit-assertion-density.sh --check   # Gate mode (exit 1 if hollow tests found)
+#   bash scripts/audit-assertion-density.sh                  # Report all *_test.go
+#   bash scripts/audit-assertion-density.sh --check          # Gate mode
+#   bash scripts/audit-assertion-density.sh --scope coverage # Legacy scope (cov*_test.go)
+#   bash scripts/audit-assertion-density.sh --scope '*_extra_test.go' <dir>
 set -euo pipefail
 
 CHECK_MODE=false
 THRESHOLD=1.5
-TARGET_DIR="${1:-cli/cmd/ao}"
+# Default to *_test.go so the audit covers any test file that ships with
+# the change, not just the legacy *coverage*_test.go pattern (cov*_test.go
+# is banned by CLAUDE.md, so the old default audited an empty set on a
+# clean checkout — see post-mortem #5).
+SCOPE='*_test.go'
 
-if [[ "${1:-}" == "--check" ]]; then
-    CHECK_MODE=true
-    TARGET_DIR="${2:-cli/cmd/ao}"
-fi
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --check) CHECK_MODE=true; shift ;;
+        --scope)
+            case "$2" in
+                coverage) SCOPE='*coverage*_test.go' ;;
+                all)      SCOPE='*_test.go' ;;
+                *)        SCOPE="$2" ;;
+            esac
+            shift 2
+            ;;
+        *) POSITIONAL+=("$1"); shift ;;
+    esac
+done
 
-# For each *_test.go file, compute assertion density
+TARGET_DIR="${POSITIONAL[0]:-cli/cmd/ao}"
+
+# For each test file matching SCOPE, compute assertion density.
 HOLLOW_COUNT=0
 TOTAL_FILES=0
 
-for f in $(find "$TARGET_DIR" -name "*coverage*_test.go" -type f | sort); do
+for f in $(find "$TARGET_DIR" -name "$SCOPE" -type f | sort); do
     TOTAL_FILES=$((TOTAL_FILES + 1))
-    FUNCS=$(grep -c "^func Test" "$f" 2>/dev/null || echo 0)
-    ASSERTS=$(grep -cE 't\.(Error|Fatal|Errorf|Fatalf)|assert\.|require\.' "$f" 2>/dev/null || echo 0)
+    # `grep -c` writes 0 to stdout AND exits 1 when there are no matches on
+    # GNU grep, so a trailing `|| echo 0` would double the output ("0\n0\n")
+    # and break the awk math below. Drop the fallback; the count is reliable.
+    FUNCS=$(grep -c "^func Test" "$f" 2>/dev/null || true)
+    ASSERTS=$(grep -cE 't\.(Error|Fatal|Errorf|Fatalf)|assert\.|require\.|goleak\.' "$f" 2>/dev/null || true)
+    : "${FUNCS:=0}"
+    : "${ASSERTS:=0}"
 
     if [[ "$FUNCS" -gt 0 ]]; then
         # Use awk for float division
@@ -39,7 +63,7 @@ for f in $(find "$TARGET_DIR" -name "*coverage*_test.go" -type f | sort); do
 done
 
 echo ""
-echo "Summary: $HOLLOW_COUNT hollow / $TOTAL_FILES total coverage test files"
+echo "Summary: $HOLLOW_COUNT hollow / $TOTAL_FILES test files (scope=$SCOPE)"
 
 if [[ "$CHECK_MODE" == "true" && "$HOLLOW_COUNT" -gt 0 ]]; then
     echo "FAIL: $HOLLOW_COUNT files below threshold ($THRESHOLD)"

--- a/scripts/evolve-coverage-delta.sh
+++ b/scripts/evolve-coverage-delta.sh
@@ -50,9 +50,13 @@ echo "=== Coverage Delta Measurement ==="
 # Run tests with coverage and capture output
 COVERAGE_OUTPUT=$(cd "$DIR" && go test -cover ./... 2>&1 || true)
 
-# Extract per-package coverage percentages and compute average
+# Extract per-package coverage percentages and compute average.
+# Require the trailing "%" so we don't match Go's event-coverage line for
+# packages with no _test.go files (e.g. cmd/ao under coverpkg builds emits
+# `coverage: 1/12 events (informational)` — without the % anchor that "1"
+# was previously averaged in as 1.0% and dragged the project average down).
 CURRENT_PCT=$(echo "$COVERAGE_OUTPUT" | \
-  grep -oE 'coverage: [0-9]+(\.[0-9]+)?' | \
+  grep -oE 'coverage: [0-9]+(\.[0-9]+)?%' | \
   grep -oE '[0-9]+(\.[0-9]+)?' | \
   awk '{sum += $1; count++} END { if (count > 0) printf "%.1f", sum/count; else print "0.0" }')
 

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -980,7 +980,7 @@
       "name": "shared",
       "source_skill": "skills/shared",
       "source_hash": "3955166ea6cde6ec5d09e4d8a7f11a7c8303a28c1bab8029ba5e752bd5006cbb",
-      "generated_hash": "cf0d03bc61d6833d3ed38465c2ffd13daf03b430898838484d362e46484f90e8"
+      "generated_hash": "01f6e4196a2e85153b3b34bdb82489f727b6354057d1a53d7e0f1a1b8dee9500"
     },
     {
       "name": "standards",

--- a/skills-codex/shared/.agentops-generated.json
+++ b/skills-codex/shared/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/shared",
   "layout": "modular",
   "source_hash": "3955166ea6cde6ec5d09e4d8a7f11a7c8303a28c1bab8029ba5e752bd5006cbb",
-  "generated_hash": "cf0d03bc61d6833d3ed38465c2ffd13daf03b430898838484d362e46484f90e8"
+  "generated_hash": "01f6e4196a2e85153b3b34bdb82489f727b6354057d1a53d7e0f1a1b8dee9500"
 }

--- a/skills-codex/shared/references/strict-delegation-contract.md
+++ b/skills-codex/shared/references/strict-delegation-contract.md
@@ -5,34 +5,34 @@
 
 ## The Contract
 
-Top-level orchestrator skills delegate to their declared sub-skills via `Skill(skill="<name>", ...)` — **as separate tool invocations**, one per phase/step. Each sub-skill owns its artifact, its gate, and its retry policy. Inlining the work breaks that ownership chain.
+Top-level orchestrator skills delegate to their declared sub-skills via `$<skill>` invocations — **as separate tool invocations**, one per phase/step. Each sub-skill owns its artifact, its gate, and its retry policy. Inlining the work breaks that ownership chain.
 
 There is no `--full` flag because strict delegation is always on.
 
 ## Anti-Pattern: Compression
 
-Do not inline phase work, compress multiple phases into one pass, substitute `Agent()` calls for `Skill()` calls, or skip mandatory phases. Typical rationalizations to reject:
+Do not inline phase work, compress multiple phases into one pass, substitute Codex sub-agent spawns for `$<skill>` invocations, or skip mandatory phases. Typical rationalizations to reject:
 
 - *"I'll compress the three phases into one pass."*
 - *"Let me do discovery inline — I already know what to do."*
-- *"Nested `Skill()` calls waste context; I'll spawn an `Agent()` instead."*
+- *"Nested `$<skill>` calls waste context; I'll spawn a Codex sub-agent instead."*
 - *"The implementation is validated by tests passing; skipping `/validation`."*
 - *"The plan looks good, skipping pre-mortem to save time."*
 - *"I'll just spawn 3 judges directly — it's what `/vibe` does anyway."*
 - *"Post-mortem is just writing a summary, I'll do it inline."*
 
-All of these are contract violations. A live compression was observed 2026-04-19 (see [`.agents/learnings/2026-04-19-orchestrator-compression-anti-pattern.md`](../../../.agents/learnings/2026-04-19-orchestrator-compression-anti-pattern.md)). The compression "worked" mechanically (strict build passed, 2-judge inline vibe PASSed) but the knowledge flywheel never turned — no forged learnings, no post-mortem artifact, no structured council verdict. Contract strength depends on actual `Skill()` invocations, not self-certification.
+All of these are contract violations. A live compression was observed 2026-04-19 (see [`.agents/learnings/2026-04-19-orchestrator-compression-anti-pattern.md`](../../../.agents/learnings/2026-04-19-orchestrator-compression-anti-pattern.md)). The compression "worked" mechanically (strict build passed, 2-judge inline vibe PASSed) but the knowledge flywheel never turned — no forged learnings, no post-mortem artifact, no structured council verdict. Contract strength depends on actual `$<skill>` invocations, not self-certification.
 
-## `Agent()` vs `Skill()`
+## Codex sub-agents vs `$<skill>` invocations
 
 These are **not interchangeable**:
 
 | Call | When to use |
 |------|-------------|
-| `Skill(skill="<name>", ...)` | Invoking a declared skill with its full contract. Required for phase delegation. |
-| `Agent(subagent_type="...", ...)` | Spawning a sub-agent for parallel independent work **within a skill's step** (e.g., `/research` dispatching parallel Explore agents is fine). |
+| `$<skill> <args>` | Invoking a declared skill with its full contract. Required for phase delegation. |
+| Codex sub-agent (e.g., `explorer` role) | Spawning a sub-agent for parallel independent work **within a skill's step** (e.g., `/research` dispatching parallel explorer sub-agents is fine). |
 
-If you're tempted to call `Agent()` in place of a `Skill()` invocation, you're compressing. Stop.
+If you're tempted to spawn a Codex sub-agent in place of a `$<skill>` invocation, you're compressing. Stop.
 
 ## Supported Compression Escapes
 
@@ -61,16 +61,16 @@ These flags scale *gate depth* or *scope*, **never skip phases**. They are the o
 
 ## Positive Pattern: What Correct Delegation Looks Like
 
-A correct `/rpi` invocation shows three distinct `Skill()` tool calls at phase boundaries:
+A correct `/rpi` invocation shows three distinct `$<skill>` invocations at phase boundaries:
 
 ```
-Skill(skill="discovery", args="<goal> --auto")      # Phase 1
+$discovery <goal> --auto      # Phase 1
   → <promise>DONE</promise>
   → reads .agents/rpi/execution-packet.json
-Skill(skill="crank", args="<packet-path> [--test-first]")   # Phase 2
+$crank <packet-path> [--test-first]   # Phase 2
   → <promise>DONE</promise>
   → reads .agents/rpi/phase-2-summary-*.md
-Skill(skill="validation", args="--complexity=<level> [--strict-surfaces]")   # Phase 3
+$validation --complexity=<level> [--strict-surfaces]   # Phase 3
   → <promise>DONE</promise>
   → writes .agents/rpi/phase-3-summary-*.md
 ```
@@ -81,7 +81,7 @@ Anything less is compressed.
 
 When auditing a session that claims to have run `/rpi`, check the transcript for:
 
-1. **Three `Skill()` invocations** at phase boundaries (Skill, not Agent).
+1. **Three `$<skill>` invocations** at phase boundaries (skill invocation, not sub-agent spawn).
 2. **Three `<promise>DONE</promise>` markers**, each from the delegated sub-skill.
 3. **Three phase summary files** in `.agents/rpi/phase-{1,2,3}-summary-*.md`.
 

--- a/skills/vibe/SKILL.md
+++ b/skills/vibe/SKILL.md
@@ -127,34 +127,49 @@ After all phases complete, write the structured report to `.agents/council/YYYY-
 
 ### Step 2: Run Complexity Analysis
 
-**Detect language and run appropriate tool:**
+**Filter by language present in the change set first.** Run only the
+analyzers whose language actually appears in the diff. A docs/shell/BATS-only
+epic must NOT trigger `gocyclo` against the entire `cli/` tree (it has hung
+in past runs); a Python-free epic must NOT trigger `radon`.
 
-**For Python:**
 ```bash
-# Check if radon is available
+# Detect which languages are present in the diff (or in <path> for full audits).
+# Use `git diff --name-only <base>...HEAD` for a PR; fall back to listing
+# files under <path> when no diff base is available.
 mkdir -p .agents/council
-echo "$(date -Iseconds) preflight: checking radon" >> .agents/council/preflight.log
-if ! which radon >> .agents/council/preflight.log 2>&1; then
-  echo "⚠️ COMPLEXITY SKIPPED: radon not installed (pip install radon)"
-  # Record in report that complexity was skipped
+HAS_GO=false; HAS_PY=false
+DIFF_FILES="$(git diff --name-only "${BASE:-HEAD~1}"...HEAD 2>/dev/null || find <path> -type f)"
+echo "$DIFF_FILES" | grep -q '\.go$'  && HAS_GO=true
+echo "$DIFF_FILES" | grep -q '\.py$'  && HAS_PY=true
+echo "$(date -Iseconds) preflight: HAS_GO=$HAS_GO HAS_PY=$HAS_PY" >> .agents/council/preflight.log
+```
+
+**For Python (only when `HAS_PY=true`):**
+```bash
+if [ "$HAS_PY" = "true" ]; then
+  echo "$(date -Iseconds) preflight: checking radon" >> .agents/council/preflight.log
+  if ! which radon >> .agents/council/preflight.log 2>&1; then
+    echo "⚠️ COMPLEXITY SKIPPED: radon not installed (pip install radon)"
+  else
+    radon cc <path> -a -s 2>/dev/null | head -30
+    radon mi <path> -s 2>/dev/null | head -30
+  fi
 else
-  # Run cyclomatic complexity
-  radon cc <path> -a -s 2>/dev/null | head -30
-  # Run maintainability index
-  radon mi <path> -s 2>/dev/null | head -30
+  echo "ℹ️ COMPLEXITY SKIPPED: no .py files in diff"
 fi
 ```
 
-**For Go:**
+**For Go (only when `HAS_GO=true`):**
 ```bash
-# Check if gocyclo is available
-echo "$(date -Iseconds) preflight: checking gocyclo" >> .agents/council/preflight.log
-if ! which gocyclo >> .agents/council/preflight.log 2>&1; then
-  echo "⚠️ COMPLEXITY SKIPPED: gocyclo not installed (go install github.com/fzipp/gocyclo/cmd/gocyclo@latest)"
-  # Record in report that complexity was skipped
+if [ "$HAS_GO" = "true" ]; then
+  echo "$(date -Iseconds) preflight: checking gocyclo" >> .agents/council/preflight.log
+  if ! which gocyclo >> .agents/council/preflight.log 2>&1; then
+    echo "⚠️ COMPLEXITY SKIPPED: gocyclo not installed (go install github.com/fzipp/gocyclo/cmd/gocyclo@latest)"
+  else
+    gocyclo -over 10 <path> 2>/dev/null | head -30
+  fi
 else
-  # Run complexity analysis
-  gocyclo -over 10 <path> 2>/dev/null | head -30
+  echo "ℹ️ COMPLEXITY SKIPPED: no .go files in diff"
 fi
 ```
 

--- a/tests/scripts/audit-assertion-density.bats
+++ b/tests/scripts/audit-assertion-density.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+# Regression test for audit-assertion-density.sh's --scope flag.
+# Pre-cycle: the script hardcoded `*coverage*_test.go` as the find pattern,
+# silently auditing zero files because cov*_test.go is banned by CLAUDE.md.
+# This test pins the new default to all *_test.go files and verifies the
+# legacy "coverage" scope alias still works.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/audit-assertion-density.sh"
+
+    TMP_DIR="$(mktemp -d)"
+    SAMPLES="$TMP_DIR/pkg"
+    mkdir -p "$SAMPLES"
+
+    cat > "$SAMPLES/dense_test.go" <<'EOF'
+package pkg
+import "testing"
+func TestA(t *testing.T) {
+    if 1 != 1 { t.Errorf("never") }
+    if 2 != 2 { t.Fatal("never") }
+}
+EOF
+    cat > "$SAMPLES/hollow_test.go" <<'EOF'
+package pkg
+import "testing"
+func TestB(t *testing.T) { _ = 1 }
+func TestC(t *testing.T) { _ = 2 }
+func TestD(t *testing.T) { _ = 3 }
+EOF
+    cat > "$SAMPLES/coverage_test.go" <<'EOF'
+package pkg
+import "testing"
+func TestCov(t *testing.T) {
+    if 1 != 1 { t.Errorf("never") }
+    if 2 != 2 { t.Fatal("never") }
+}
+EOF
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "script exists and is executable" {
+    [ -f "$SCRIPT" ]
+    [ -x "$SCRIPT" ]
+}
+
+@test "default scope audits ALL *_test.go files" {
+    run bash "$SCRIPT" "$SAMPLES"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"dense_test.go"* ]]
+    [[ "$output" == *"hollow_test.go"* ]]
+    [[ "$output" == *"coverage_test.go"* ]]
+    [[ "$output" == *"3 test files"* ]]
+}
+
+@test "default scope flags hollow_test.go as below threshold" {
+    run bash "$SCRIPT" "$SAMPLES"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"HOLLOW: $SAMPLES/hollow_test.go"* ]]
+}
+
+@test "--scope coverage restricts to legacy *coverage*_test.go" {
+    run bash "$SCRIPT" --scope coverage "$SAMPLES"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"coverage_test.go"* ]]
+    [[ "$output" != *"hollow_test.go"* ]]
+    [[ "$output" != *"dense_test.go"* ]]
+    [[ "$output" == *"1 test files"* ]]
+}
+
+@test "--scope all is an explicit alias for the new default" {
+    run bash "$SCRIPT" --scope all "$SAMPLES"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"3 test files"* ]]
+}
+
+@test "--check exits 1 when hollow tests are present" {
+    run bash "$SCRIPT" --check "$SAMPLES"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"FAIL"* ]]
+}
+
+@test "--check exits 0 when no hollow tests in scope" {
+    run bash "$SCRIPT" --check --scope coverage "$SAMPLES"
+    [ "$status" -eq 0 ]
+}
+
+@test "custom glob via --scope is honored" {
+    run bash "$SCRIPT" --scope 'hollow_test.go' "$SAMPLES"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"hollow_test.go"* ]]
+    [[ "$output" != *"dense_test.go"* ]]
+}

--- a/tests/scripts/evolve-coverage-delta.bats
+++ b/tests/scripts/evolve-coverage-delta.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+# Regression test for evolve-coverage-delta.sh's per-package coverage parser.
+# The previous grep accepted any "coverage: N" prefix and silently consumed
+# Go's event-coverage line ("coverage: 1/12 events") as 1.0%, dragging the
+# project average down. This test pins the % anchor.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/evolve-coverage-delta.sh"
+}
+
+# Re-implement the script's pure parsing pipeline so the test does not need
+# `go` on PATH (some CI runners that exercise scripts/ don't pull go).
+parse_avg() {
+    local input="$1"
+    printf '%s' "$input" \
+        | grep -oE 'coverage: [0-9]+(\.[0-9]+)?%' \
+        | grep -oE '[0-9]+(\.[0-9]+)?' \
+        | awk '{sum += $1; count++} END { if (count > 0) printf "%.1f", sum/count; else print "0.0" }'
+}
+
+@test "script file exists and is executable" {
+    [ -f "$SCRIPT" ]
+    [ -x "$SCRIPT" ]
+}
+
+@test "parser uses the same regex anchors as the script" {
+    # Pin the regex by source-grepping it. Failure here means the script
+    # changed shape and this test needs to be updated alongside it.
+    grep -q "grep -oE 'coverage: \[0-9\]+(\\\\\\.[0-9]+)?%'" "$SCRIPT"
+}
+
+@test "ignores Go event-coverage informational line" {
+    # cmd/ao under -coverpkg with no _test.go files emits this format.
+    input="ok  	github.com/boshu2/agentops/cli/cmd/ao	70.187s	coverage: 1/12 events (informational)"
+    result="$(parse_avg "$input")"
+    [ "$result" = "0.0" ]
+}
+
+@test "parses standard percent-format coverage lines" {
+    input="ok  	github.com/boshu2/agentops/cli/internal/goals	5.0s	coverage: 76.5% of statements"
+    result="$(parse_avg "$input")"
+    [ "$result" = "76.5" ]
+}
+
+@test "averages multiple percent lines and skips the event line" {
+    input="ok  	github.com/boshu2/agentops/cli/cmd/ao	70.187s	coverage: 1/12 events (informational)
+ok  	github.com/boshu2/agentops/cli/internal/goals	5.0s	coverage: 76.5% of statements
+ok  	github.com/boshu2/agentops/cli/internal/ratchet	11.3s	coverage: 88.2% of statements"
+    result="$(parse_avg "$input")"
+    # Average of 76.5 and 88.2; the 1/12 events line is excluded.
+    [ "$result" = "82.4" ] || [ "$result" = "82.3" ]
+}
+
+@test "handles integer-percent lines without decimal" {
+    input="ok  	github.com/boshu2/agentops/cli/internal/foo	1.0s	coverage: 50% of statements"
+    result="$(parse_avg "$input")"
+    [ "$result" = "50.0" ]
+}
+
+@test "returns 0.0 when nothing matches" {
+    result="$(parse_avg "no coverage lines at all here")"
+    [ "$result" = "0.0" ]
+}

--- a/tests/scripts/evolve-coverage-delta.bats
+++ b/tests/scripts/evolve-coverage-delta.bats
@@ -25,10 +25,13 @@ parse_avg() {
     [ -x "$SCRIPT" ]
 }
 
-@test "parser uses the same regex anchors as the script" {
-    # Pin the regex by source-grepping it. Failure here means the script
-    # changed shape and this test needs to be updated alongside it.
-    grep -q "grep -oE 'coverage: \[0-9\]+(\\\\\\.[0-9]+)?%'" "$SCRIPT"
+@test "parser regex requires the % suffix" {
+    # The whole point of this test file: ensure the script's coverage
+    # extractor keeps the trailing % anchor so Go's event-coverage
+    # informational line (`coverage: 1/12 events`) is not consumed.
+    # Use awk for robust substring matching that side-steps grep regex
+    # escaping headaches.
+    awk '/grep -oE/ && /coverage:/ && /\)\?%/ {found=1} END {exit !found}' "$SCRIPT"
 }
 
 @test "ignores Go event-coverage informational line" {


### PR DESCRIPTION
Second nightly run for 2026-04-26 (PR #147 was the morning run; merged at `800eea8a`). Branched from `origin/main` post-merge. 9 productive cycles, 0 stale-audit cycles, 0 auto-reverts. Score holds at 92.66 (the only failing goal is the documented corpus-state `flywheel-compounding`, weight 8).

## Fitness delta (score: 92.66 → 92.66)

| Goal | Weight | Baseline | Final | Δ | Notes |
|------|--------|----------|-------|---|-------|
| flywheel-compounding | 8 | fail | fail | = | Corpus-state — now tagged `long-cycle, corpus-state` (cycle 1) |
| go-cli-tests | 8 | pass | pass | = | |
| go-cli-builds | 8 | pass | pass | = | |
| flywheel-proof | 7 | pass | pass | = | One transient network flake (503 from proxy.golang.org) — passed on retry, not caused by any cycle |
| wiring-closure | 7 | pass | pass | = | |
| security-gate | 6 | pass | pass | = | |
| go-complexity-ceiling | 6 | pass | pass | = | Cycle 9's first build pushed RunMeasure to CC 21; refactored to extract `applyMeasureFilters` BEFORE committing → final CC ≤16 |
| hook-preflight | 6 | pass | pass | = | |
| skill-frontmatter | 6 | pass | pass | = | |
| flywheel-lifecycle | 6 | pass | pass | = | |
| manifest-versions-match | 5 | pass | pass | = | |
| goals-validate | 5 | pass | pass | = | |
| go-vet-clean | 5 | pass | pass | = | |
| contract-compatibility | 5 | pass | pass | = | |
| install-smoke | 5 | pass | pass | = | |
| codex-parity-drift | 5 | pass | pass | = | |
| compile-freshness | 4 | **pass*** | pass | = | Runtime-artifact flip from Dream's overnight defrag-preview |
| compile-no-oscillation | 4 | **pass*** | pass | = | Runtime-artifact flip (same source) |
| competitive-freshness | 3 | pass | pass | = | |

\*Pre-Dream baseline was `fail` for both compile-* gates because `.agents/defrag/latest.json` is gitignored and the env starts without it. Dream's `defrag-preview` writes `.agents/overnight/<run>/defrag/latest.json` which the gates' fallback path consumes, flipping them to `pass`. Tagged `runtime-artifact` in cycle 1 so this is no longer hidden classification.

## Code-driven flips vs runtime-artifact flips

| Type | Goal | Source |
|------|------|--------|
| Code-driven | (none — fitness was already 92.66 post-Dream; cycles built code-quality / observability / dev-loop improvements without flipping additional gates) | — |
| Runtime-artifact | compile-freshness, compile-no-oscillation | Dream `overnight start` writing `.agents/overnight/<run>/defrag/latest.json` (gitignored — does not propagate via PR) |

The corpus-state `flywheel-compounding` (w=8) was NOT pursued for a metric flip. PR #147 already did the legitimate observability fix (`scripts/check-flywheel-compounding.sh` surfaces σρδ + root cause). Today's heavy-goal partial fix is structural quarantine plumbing (cycles 1 + 9): explicit tagging in GOALS.md and an operator-facing `--exclude-tag` flag so future runs can score "what's actually code-actionable" without lowering the goal's weight.

## Per-cycle summary

| # | Type | Target | Commit | Fitness before | Fitness after |
|---|------|--------|--------|----------------|---------------|
| 1 | productive (heavy-goal partial fix) | `flywheel-compounding` (w=8) — tag with `long-cycle, corpus-state`; runtime-artifact gates with `runtime-artifact`; Tags column parsing → JSON measurement output | `56199e81` | 92.66 | 92.66 |
| 2 | productive | `internal/ratchet` fuzz target had no companion seed-correctness asserts; added 7-case `TestFuzzParseChainLines_SeedCorrectness` | `fa14b65c` | 92.66 | 92.66 |
| 3 | productive | `skills/vibe/SKILL.md` Step 2 ran radon/gocyclo unconditionally; gated on `HAS_PY` / `HAS_GO` from diff to stop docs/shell-only epics from hanging in gocyclo | `530dd699` | 92.66 | 92.66 |
| 4 | productive | `evolve-coverage-delta.sh` averaged Go's `coverage: 1/12 events` informational line in as 1.0%, dragging project averages down. Tightened regex to require `%` anchor; added `tests/scripts/evolve-coverage-delta.bats` (7 cases) | `456a9e16` | 92.66 | 92.66 |
| 5 | productive | `parseGateRow` CC pushed to 18 by cycle 1; restored head-room to 7 by extracting `cellAt` / `parseCheckCell` / `parseWeightCell` helpers (with unit tests) | `9a8a4a8c` | 92.66 | 92.66 |
| 6 | productive | `audit-assertion-density.sh` defaulted to `*coverage*_test.go` (banned by CLAUDE.md → audited zero files). New default `*_test.go` + `--scope <pattern>` + recognize `goleak.VerifyNone`. 8-case bats fixture | `ac660ae2` | 92.66 | 92.66 |
| 7 | productive | `skills-codex/shared/references/strict-delegation-contract.md` had 12 `Skill()` references; rewrote to `$skill` notation per Codex convention (Claude variant unchanged) | `bb619271` | 92.66 | 92.66 |
| 8 | productive | `newAdhocContextRunID` collision behavior had no test; added idempotency-on-collision test + distinct-suffix test + expanded godoc on the 1/65 536 collision rate | `2923e95d` | 92.66 | 92.66 |
| 9 | productive | `ao goals measure --exclude-tag <tag>` flag — operators can now ask "score with corpus-state goals excluded" without lowering weights. Builds on cycle 1's tags. `applyMeasureFilters` extracted for CC discipline | `d0c4220f` | 92.66 | 92.66 |

## Findings opened / closed / deferred

**Closed via implementation (this run):**
- council-finding: "Add fuzz seed correctness assertions" — closed by cycle 2 (`internal/ratchet/fuzz_test.go` was the last fuzz target without a companion correctness suite)
- council-finding: "Add language filter to vibe complexity analysis" — closed by cycle 3
- post-mortem #5: "Expand audit-assertion-density.sh to cover all test files" — closed by cycle 6
- post-mortem: "Fix coverage-ratchet.sh cmd/ao event format handling" — closed by cycle 4 (the bug actually lived in `evolve-coverage-delta.sh`'s averager, not `coverage-ratchet.sh` which doesn't exist)
- council-finding: "Sweep skills-codex/ DAG bodies for `Skill()` to `$skill` notation" — closed by cycle 7
- post-mortem: "Document adhoc ID 1-second collision behavior" — closed by cycle 8 (godoc + tests pinning the contract)

**Heavy-goal partial fix delivered (DEFINITIONS option b):**
- `flywheel-compounding` (w=8) — corpus-state, multi-session bound. PR #147 added the observability gate. This run added the **structural quarantine layer**:
  - `Tags` column on the GOALS.md gates table (parsed into `Goal.Tags`, surfaced in `Measurement.Tags` JSON)
  - `flywheel-compounding` tagged `long-cycle, corpus-state`
  - compile-freshness / compile-no-oscillation tagged `runtime-artifact`
  - `ao goals measure --exclude-tag <tag>` for operator-side filtering
  - Heavy goal stayed `fail` — that is the correct outcome (it must remain a fitness signal until applied/reference citations land in the corpus over multiple sessions). Documenting and tooling around the irreducibility, not gaming the metric.

**Inline-probe rejections (counted separately from stale-audit cycles):**
- "Decompose skills/crank/SKILL.md to under 248-line limit" — crank is `tier=execution`, limit 800, current 660 → already passing
- "Add cmd/ao to coverage baseline" — `scripts/check-cmd-ao-coverage.sh` already enforces a 76% floor on cli/cmd/ao
- "Fix go-test-precommit.sh to use stdin JSON pattern" — already uses `INPUT=$(cat)` + `jq` (PR #147 audit confirmed; re-confirmed)
- "Implement sections.include allowlist semantics" — `applyContextFilter` already iterates `Sections.Include` (PR #147)
- "Add intel_scope and section-name enum validation" — `validateIntelScope` already validates section names (PR #147)
- "Rename --fast-path to --quick-gates across /rpi" — explicit "Needs user confirmation before rename" gate per the next-work entry; not actioning autonomously

**Deferred (not actioned — vague or out-of-scope-for-cycle):**
- "Resolve command output contract drift for shared output flags" — investigation showed only minor help-text drift between `goals` (defines its own `--json` for state isolation) and root `--json`; not a contract violation
- "Resolve swarm-remediation-fix unresolved findings (8 items)" — most of those 8 items were probed today and either closed or proven stale; remaining 2 are vague
- "Production command refactors can miss the paired test diff..." — descriptive risk note rather than actionable fix; the gate (`scripts/check-go-command-test-pair.sh`) already enforces co-change

## Stale-audit count

- **Explicit stale-audit cycles: 0** (none of today's commits were just bookkeeping)
- **Inline-probe rejections: 6** (listed above — 5-second probe found work already shipped, no commit consumed)

The 6 rejections are well above the consecutive-3 threshold for ladder escalation, but escalation already happened naturally — every productive cycle came from either the heavy-goal lane or generator-layer findings (test, perf, refactor, docs-as-tool).

## Auto-reverts

None. No goal with weight ≥ 3 regressed. Cycle 9's intermediate state pushed `RunMeasure` to CC=21 (would have failed `go-complexity-ceiling`); caught by the post-build measure check before commit and refactored down to ≤16 by extracting `applyMeasureFilters`. Same response as auto-revert without losing the work.

## Quarantined goals

- `flywheel-compounding` (w=8) — confirmed multi-session corpus-state goal. Now structurally tagged `long-cycle, corpus-state` (cycle 1) AND has an operator-facing `--exclude-tag` escape (cycle 9). Recommend keeping the gate and weight as-is — the tag-based filter is the right mechanism for "give me a code-actionable score" rather than weight reduction.

## Dream meta-findings

- `dream-corpus-stale` (rank 1): "Write AgentOps philosophy doc..." — `docs/philosophy.md` exists, last_reviewed 2026-04-12. Same finding as PR #147; Dream is still emitting a packet whose work shipped. Worth a Dream-curator pass.
- `dream-corpus-stale-rank3` (rank 3): "Backfill next-work queue rows to schema v1.3..." — `scripts/check-next-work-schema-rows.sh` (added in PR #147 cycle 3) reports `66 row(s) conform to v1.3 schema enums`. Same stale finding as PR #147. The Dream emission ranking is correlating poorly with corpus state; tracking this as a producer-side issue.

Two stale Dream packets in two consecutive nightlies on the same date is a real signal that Dream's morning-packet generator is not consulting the recent next-work queue or recent merged PRs before ranking. Recommend a tractability probe in the Dream pipeline itself.

## bd / tracker degradation notes

`bd` CLI **unavailable**: `command -v bd` returns nothing, no `scripts/install-bd.sh` exists in the repo, no `.beads/` directory. Identical to PR #147's environment. Cycles selected from heaviest-failing-goal + generator-layer findings + next-work queue instead. Worth a follow-up to either (a) ship `scripts/install-bd.sh` so future runs can self-install, or (b) document `bd unavailable` as the expected steady state and stop logging it as a degradation.

## Scope-discipline notes

- Worktree-disposition gate failed on the nightly branch (expects `main`) — known false positive, ignored per spec. No silencing flag exists in the script. Same as PR #147.
- Tag push to `nightly/2026-04-26-v2` 403'd as expected; falling back to branch ref. The `nightly/2026-04-26-v2` branch on origin is the anchor for tomorrow's audit.
- Embedded hooks/skills sync verified via `pre-push-gate.sh --fast` (only failure is the worktree false positive; 32 actual checks pass or skip).
- CLI docs regenerated in cycle 9 to keep `cli/docs/COMMANDS.md` in sync with the new `--exclude-tag` flag.

## Validation

- `cd cli && go run ./cmd/ao autodev validate --file ../PROGRAM.md --json` → `valid:true`
- `cd cli && go vet ./...` → clean
- `cd cli && go test ./internal/goals ./internal/ratchet ./cmd/ao` → all ok
- `bash skills/heal-skill/scripts/heal.sh --strict` → All clean. No findings.
- `bash scripts/audit-codex-parity.sh` → Codex parity audit passed.
- `bash tests/skills/lint-skills.sh` → 69/69 skills pass
- `bash scripts/check-go-absolute-complexity.sh --dir cli/ --threshold 20` → All functions below 20
- `bash scripts/check-go-absolute-complexity.sh --dir cli/internal/ --threshold 18` → All functions below 18
- `scripts/generate-cli-reference.sh --check` → cli/docs/COMMANDS.md is up to date
- Final `ao goals measure --json`: PASS=18, FAIL=1, SCORE=92.66
- `ao goals measure --exclude-tag long-cycle --json`: PASS=17, FAIL=0, SCORE=94.06 (cycle-9 demonstration)

## Commits

- `56199e81` feat(goals): tag flywheel-compounding as long-cycle/corpus-state via Tags column
- `fa14b65c` test(ratchet): pin FuzzParseChainLines seed inputs with correctness asserts
- `530dd699` fix(vibe): gate radon/gocyclo on actual language presence in diff
- `456a9e16` fix(coverage): require % anchor so 'coverage: 1/12 events' isn't averaged in
- `9a8a4a8c` refactor(goals): drop parseGateRow CC 18→7 by extracting cell helpers
- `ac660ae2` fix(audit): scope assertion-density audit to all *_test.go by default
- `bb619271` fix(codex): rewrite Skill() to $skill notation in delegation contract
- `2923e95d` test(inject): pin adhoc context-id collision idempotency + distinct-suffix
- `d0c4220f` feat(goals): --exclude-tag flag for ao goals measure

(Branch ref `nightly/2026-04-26-v2` on origin serves as tomorrow's audit anchor in lieu of a tag — tag push 403'd as expected.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PonWKbce88xu8u3TfgxDbm)_