### PR TITLE
feat(dream): aggregate finding generator sidecars

### DIFF
--- a/cli/internal/mine/mine.go
+++ b/cli/internal/mine/mine.go
@@ -6,6 +6,7 @@ package mine
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -216,6 +217,9 @@ type GateVerdictSummary struct {
 // main and cannot be imported from internal/. If MineEventsFn is nil
 // and "events" is in Sources, the events source is treated as a no-op.
 type RunOpts struct {
+	// Context bounds source execution. Nil means context.Background().
+	Context context.Context
+
 	// Sources restricts the scan to a subset of {git,agents,code,events}.
 	// Must be pre-validated via SplitSources.
 	Sources []string
@@ -270,6 +274,10 @@ func Run(cwd string, opts RunOpts) (*Report, error) {
 	if opts.Now == nil {
 		opts.Now = time.Now
 	}
+	ctx := opts.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	report := &Report{
 		Timestamp:    opts.Now().UTC(),
@@ -283,7 +291,9 @@ func Run(cwd string, opts RunOpts) (*Report, error) {
 		return report, nil
 	}
 
-	runSources(cwd, opts, report)
+	if err := runSources(ctx, cwd, opts, report); err != nil {
+		return report, err
+	}
 
 	if err := writeReport(opts.OutputDir, report); err != nil {
 		return report, err
@@ -301,11 +311,14 @@ func Run(cwd string, opts RunOpts) (*Report, error) {
 // runSources dispatches each requested source, accumulating findings
 // into report. Per-source failures are logged to opts.ErrOut as
 // warnings when Quiet is false.
-func runSources(cwd string, opts RunOpts, report *Report) {
+func runSources(ctx context.Context, cwd string, opts RunOpts, report *Report) error {
 	for _, src := range opts.Sources {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		switch src {
 		case "git":
-			findings, gitErr := MineGitLog(cwd, opts.Window)
+			findings, gitErr := MineGitLogContext(ctx, cwd, opts.Window)
 			if gitErr != nil {
 				warnSource(opts, "git", gitErr)
 				continue
@@ -319,7 +332,7 @@ func runSources(cwd string, opts RunOpts, report *Report) {
 			}
 			report.Agents = findings
 		case "code":
-			findings, codeErr := MineCodeComplexity(cwd, opts.Window)
+			findings, codeErr := MineCodeComplexityContext(ctx, cwd, opts.Window)
 			if codeErr != nil {
 				warnSource(opts, "code", codeErr)
 				continue
@@ -337,6 +350,7 @@ func runSources(cwd string, opts RunOpts, report *Report) {
 			report.Events = findings
 		}
 	}
+	return ctx.Err()
 }
 
 // warnSource logs a per-source failure to opts.ErrOut unless Quiet is set.
@@ -369,12 +383,20 @@ var gitLogFixRe = regexp.MustCompile(`(?i)^[0-9a-f]+ (fix|bugfix|hotfix)`)
 // Shells out to `git log`; callers with no git repo should exclude the
 // git source from opts.Sources.
 func MineGitLog(cwd string, window time.Duration) (*GitFindings, error) {
+	return MineGitLogContext(context.Background(), cwd, window)
+}
+
+// MineGitLogContext extracts signal from git log with context cancellation.
+func MineGitLogContext(ctx context.Context, cwd string, window time.Duration) (*GitFindings, error) {
 	sinceArg := fmt.Sprintf("--since=%d seconds ago", int64(window.Seconds()))
-	cmd := exec.Command("git", "log", sinceArg, "--name-only", "--pretty=format:%H %s")
+	cmd := exec.CommandContext(ctx, "git", "log", sinceArg, "--name-only", "--pretty=format:%H %s")
 	cmd.Dir = cwd
 
 	out, err := cmd.Output()
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
 			return nil, fmt.Errorf("git log: %s", strings.TrimSpace(string(exitErr.Stderr)))
@@ -474,6 +496,11 @@ var gocycloLineRe = regexp.MustCompile(`^(\d+)\s+(\S+)\s+(\S+)\s+(\S+):(\d+):\d+
 // hotspots with recent git edits. If gocyclo is not installed or fails,
 // returns a skipped finding without error.
 func MineCodeComplexity(cwd string, window time.Duration) (*CodeFindings, error) {
+	return MineCodeComplexityContext(context.Background(), cwd, window)
+}
+
+// MineCodeComplexityContext runs gocyclo with context cancellation.
+func MineCodeComplexityContext(ctx context.Context, cwd string, window time.Duration) (*CodeFindings, error) {
 	findings := &CodeFindings{}
 
 	gocycloPath, err := exec.LookPath("gocyclo")
@@ -482,11 +509,14 @@ func MineCodeComplexity(cwd string, window time.Duration) (*CodeFindings, error)
 		return findings, nil
 	}
 
-	cmd := exec.Command(gocycloPath, "-top", "10", "cli/")
+	cmd := exec.CommandContext(ctx, gocycloPath, "-top", "10", "cli/")
 	cmd.Dir = cwd
 
 	out, err := cmd.Output()
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return findings, ctxErr
+		}
 		// gocyclo may fail if cli/ doesn't exist
 		findings.Skipped = true
 		return findings, nil
@@ -504,7 +534,7 @@ func MineCodeComplexity(cwd string, window time.Duration) (*CodeFindings, error)
 		funcName := matches[3]
 		file := matches[4]
 
-		recentEdits := CountRecentEdits(cwd, file, window)
+		recentEdits := CountRecentEditsContext(ctx, cwd, file, window)
 
 		findings.Hotspots = append(findings.Hotspots, ComplexityHotspot{
 			File:        file,
@@ -523,8 +553,13 @@ func MineCodeComplexity(cwd string, window time.Duration) (*CodeFindings, error)
 // CountRecentEdits counts how many commits touched a file within the
 // given window.
 func CountRecentEdits(cwd, file string, window time.Duration) int {
+	return CountRecentEditsContext(context.Background(), cwd, file, window)
+}
+
+// CountRecentEditsContext counts recent commits with context cancellation.
+func CountRecentEditsContext(ctx context.Context, cwd, file string, window time.Duration) int {
 	sinceArg := fmt.Sprintf("--since=%d seconds ago", int64(window.Seconds()))
-	cmd := exec.Command("git", "log", sinceArg, "--oneline", "--", file)
+	cmd := exec.CommandContext(ctx, "git", "log", sinceArg, "--oneline", "--", file)
 	cmd.Dir = cwd
 	out, err := cmd.Output()
 	if err != nil {

--- a/cli/internal/mine/mine_test.go
+++ b/cli/internal/mine/mine_test.go
@@ -2,6 +2,7 @@ package mine
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -46,6 +47,29 @@ func TestRun_DryRunSkipsSourcesAndWrites(t *testing.T) {
 	// Sources field should be populated even on dry run.
 	if len(report.Sources) != 1 || report.Sources[0] != "events" {
 		t.Errorf("Sources = %v, want [events]", report.Sources)
+	}
+}
+
+func TestRun_ContextCanceledSkipsSourcesAndWrites(t *testing.T) {
+	tmp := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	opts := RunOpts{
+		Context:   ctx,
+		Sources:   []string{"agents"},
+		Window:    time.Hour,
+		OutputDir: filepath.Join(tmp, "mine-out"),
+	}
+
+	report, err := Run(tmp, opts)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run error = %v, want context.Canceled", err)
+	}
+	if report == nil {
+		t.Fatal("Run returned nil report")
+	}
+	if _, err := os.Stat(opts.OutputDir); !os.IsNotExist(err) {
+		t.Fatalf("canceled run should not create output dir, stat err = %v", err)
 	}
 }
 

--- a/cli/internal/overnight/doc.go
+++ b/cli/internal/overnight/doc.go
@@ -3,15 +3,15 @@
 // Dream runs a bounded outer loop against the local .agents/ corpus. Each
 // iteration is a three-stage wave:
 //
-//   - INGEST (parallel-safe, read-only): harvest, forge-mine, knowledge
-//     generators. Produces a staged catalog and measurement inputs. Never
-//     mutates .agents/.
+//   - INGEST (parallel-safe, read-only): harvest, forge-mine, and bounded
+//     read-side finding generators. Generators may fan out in process and write
+//     sidecars under the run output directory, but never mutate .agents/.
 //
 //   - REDUCE (serial, mutative, checkpointed): dedup, maturity temper,
 //     defrag --apply, close-loop promote, findings→next-work router,
-//     inject-cache refresh. Every mutation writes through a checkpoint
-//     overlay with 2-phase commit semantics, so any failure rolls the
-//     iteration back to the last known-good state.
+//     generator-sidecar aggregation, inject-cache refresh. Every mutation
+//     writes through a checkpoint overlay with 2-phase commit semantics, so any
+//     failure rolls the iteration back to the last known-good state.
 //
 //   - MEASURE (parallel-safe, read-only): retrieval-bench, metrics health,
 //     corpus-quality fitness vector, inject-visibility probe, findings
@@ -30,8 +30,9 @@
 //   - invoke /rpi or any code-mutating flow,
 //   - touch git (no commits, branches, pushes, or remote calls),
 //   - create symlinks anywhere,
-//   - fan work out to swarm / gc agents inside iterations (first slice;
-//     serial goroutines only).
+//   - fan work out to swarm / gc agents inside iterations. Only bounded
+//     in-process read-side generator goroutines are allowed, and REDUCE remains
+//     the serialized queue writer.
 //
 // Writes are confined to .agents/ and, via harvest, to ~/.agents/learnings/
 // (the global hub). A concurrency guard in cli/cmd/ao/harvest.go prevents

--- a/cli/internal/overnight/generator_sidecars.go
+++ b/cli/internal/overnight/generator_sidecars.go
@@ -1,10 +1,12 @@
 package overnight
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 	"unicode"
@@ -13,6 +15,8 @@ import (
 )
 
 const mineFindingsGeneratorName = "mine-findings"
+const findingGeneratorSidecarSchemaVersion = "finding-generator-sidecar/v1"
+const dreamGeneratorAggregatorSourceEpic = "dream-generator-aggregator"
 
 // FindingGeneratorSidecar is the durable per-generator result envelope written
 // by Dream read-side generators. Generators write sidecars; the queue writer
@@ -37,16 +41,28 @@ type FindingGeneratorSidecar struct {
 // FindingGeneratorCandidate is a normalized, read-only candidate emitted into a
 // sidecar. It intentionally mirrors only queue-safe fields and dedup metadata.
 type FindingGeneratorCandidate struct {
-	ID        string `json:"id"`
-	Title     string `json:"title"`
-	Type      string `json:"type"`
-	Severity  string `json:"severity"`
-	Source    string `json:"source"`
-	Evidence  string `json:"evidence,omitempty"`
-	File      string `json:"file,omitempty"`
-	Func      string `json:"func,omitempty"`
-	DedupKey  string `json:"dedup_key"`
-	Duplicate bool   `json:"duplicate"`
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Type        string `json:"type"`
+	Severity    string `json:"severity"`
+	Source      string `json:"source"`
+	Description string `json:"description"`
+	Evidence    string `json:"evidence,omitempty"`
+	File        string `json:"file,omitempty"`
+	Func        string `json:"func,omitempty"`
+	TargetRepo  string `json:"target_repo,omitempty"`
+	DedupKey    string `json:"dedup_key"`
+	Duplicate   bool   `json:"duplicate"`
+}
+
+// FindingGeneratorAggregateResult summarizes the single-writer merge of all
+// completed generator sidecars into one next-work batch.
+type FindingGeneratorAggregateResult struct {
+	SidecarsRead      int
+	SidecarsSoftFail  int
+	CandidatesSeen    int
+	DuplicatesSkipped int
+	ItemsWritten      int
 }
 
 func buildMineGeneratorSidecar(
@@ -64,16 +80,17 @@ func buildMineGeneratorSidecar(
 	for _, item := range items {
 		duplicate := item.ID != "" && existingIDs[item.ID]
 		candidates = append(candidates, FindingGeneratorCandidate{
-			ID:        item.ID,
-			Title:     item.Title,
-			Type:      item.Type,
-			Severity:  item.Severity,
-			Source:    item.Source,
-			Evidence:  item.Evidence,
-			File:      item.File,
-			Func:      item.Func,
-			DedupKey:  mineGeneratorDedupKey(item),
-			Duplicate: duplicate,
+			ID:          item.ID,
+			Title:       item.Title,
+			Type:        normalizeGeneratorCandidateType(item.Type),
+			Severity:    normalizeGeneratorCandidateSeverity(item.Severity),
+			Source:      "evolve-generator",
+			Description: item.Description,
+			Evidence:    item.Evidence,
+			File:        item.File,
+			Func:        item.Func,
+			DedupKey:    mineGeneratorDedupKey(item),
+			Duplicate:   duplicate,
 		})
 	}
 	return newFindingGeneratorSidecar(
@@ -94,14 +111,28 @@ func buildFailedMineGeneratorSidecar(
 	finishedAt time.Time,
 	err error,
 ) FindingGeneratorSidecar {
+	return buildFailedFindingGeneratorSidecar(opts, mineFindingsGeneratorName, "compile-mine", startedAt, finishedAt, err)
+}
+
+func buildFailedFindingGeneratorSidecar(
+	opts RunLoopOptions,
+	generator string,
+	sourceEpic string,
+	startedAt time.Time,
+	finishedAt time.Time,
+	err error,
+) FindingGeneratorSidecar {
 	message := ""
 	if err != nil {
 		message = err.Error()
 	}
+	if sourceEpic == "" {
+		sourceEpic = generator
+	}
 	return newFindingGeneratorSidecar(
 		opts,
-		mineFindingsGeneratorName,
-		"compile-mine",
+		generator,
+		sourceEpic,
 		"soft-fail",
 		startedAt,
 		finishedAt,
@@ -132,7 +163,7 @@ func newFindingGeneratorSidecar(
 		duplicateRate = float64(duplicateCount) / float64(candidateCount)
 	}
 	return FindingGeneratorSidecar{
-		SchemaVersion:     "finding-generator-sidecar/v1",
+		SchemaVersion:     findingGeneratorSidecarSchemaVersion,
 		RunID:             opts.RunID,
 		Generator:         generator,
 		SourceEpic:        sourceEpic,
@@ -188,12 +219,333 @@ func writeFindingGeneratorSidecar(opts RunLoopOptions, sidecar FindingGeneratorS
 	return path, nil
 }
 
+// AggregateFindingGeneratorSidecars reads completed generator sidecars from
+// outputDir, reconciles duplicates, and appends one next-work batch under cwd.
+// It is the only queue writer for read-side generators.
+func AggregateFindingGeneratorSidecars(cwd, outputDir string) (FindingGeneratorAggregateResult, []string, error) {
+	var result FindingGeneratorAggregateResult
+	var degraded []string
+	sidecarDir := filepath.Join(outputDir, "generator-results")
+	entries, err := os.ReadDir(sidecarDir)
+	if os.IsNotExist(err) {
+		return result, []string{"generator-results dir missing"}, nil
+	}
+	if err != nil {
+		return result, nil, fmt.Errorf("read generator-results dir: %w", err)
+	}
+
+	nextWorkPath := filepath.Join(cwd, ".agents", "rpi", "next-work.jsonl")
+	existing, err := loadGeneratorNextWorkDedupState(nextWorkPath)
+	if err != nil {
+		return result, degraded, fmt.Errorf("load generator next-work dedup state: %w", err)
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	selected := map[string]FindingGeneratorCandidate{}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		sidecar, readErr := readFindingGeneratorSidecar(filepath.Join(sidecarDir, entry.Name()))
+		if readErr != nil {
+			degraded = append(degraded, fmt.Sprintf("%s: %v", entry.Name(), readErr))
+			continue
+		}
+		result.SidecarsRead++
+		if sidecar.Status != "completed" {
+			result.SidecarsSoftFail++
+			degraded = append(degraded, fmt.Sprintf("%s: %s", sidecar.Generator, sidecar.Status))
+			continue
+		}
+		for _, candidate := range sidecar.Candidates {
+			result.CandidatesSeen++
+			candidate = normalizeGeneratorCandidate(candidate)
+			key := candidate.DedupKey
+			if key == "" {
+				result.DuplicatesSkipped++
+				degraded = append(degraded, fmt.Sprintf("%s: candidate %q missing dedup key", sidecar.Generator, candidate.Title))
+				continue
+			}
+			if candidate.Duplicate || existing.has(candidate.ID, key) {
+				result.DuplicatesSkipped++
+				continue
+			}
+			if previous, ok := selected[key]; ok {
+				result.DuplicatesSkipped++
+				if preferGeneratorCandidate(candidate, previous) {
+					selected[key] = candidate
+				}
+				continue
+			}
+			selected[key] = candidate
+		}
+	}
+
+	if len(selected) == 0 {
+		return result, degraded, nil
+	}
+
+	items := make([]generatorNextWorkItem, 0, len(selected))
+	keys := make([]string, 0, len(selected))
+	for key := range selected {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		items = append(items, generatorCandidateNextWorkItem(selected[key]))
+	}
+	if err := appendGeneratorNextWorkBatch(nextWorkPath, items, time.Now().UTC()); err != nil {
+		return result, degraded, err
+	}
+	result.ItemsWritten = len(items)
+	return result, degraded, nil
+}
+
 func mineGeneratorDedupKey(item mine.WorkItemEmit) string {
 	target := item.File
 	if target == "" {
 		target = item.Title
 	}
 	return "finding-generator|mine-findings|" + normalizeDedupComponent(item.Type+"|"+item.Title+"|"+target)
+}
+
+type generatorNextWorkDedupState struct {
+	ids       map[string]bool
+	dedupKeys map[string]bool
+}
+
+func (s generatorNextWorkDedupState) has(id, dedupKey string) bool {
+	if id != "" && s.ids[id] {
+		return true
+	}
+	return dedupKey != "" && s.dedupKeys[dedupKey]
+}
+
+type generatorNextWorkItem struct {
+	ID          string `json:"id,omitempty"`
+	Title       string `json:"title"`
+	Type        string `json:"type"`
+	Severity    string `json:"severity"`
+	Source      string `json:"source"`
+	Description string `json:"description"`
+	Evidence    string `json:"evidence,omitempty"`
+	TargetRepo  string `json:"target_repo,omitempty"`
+	File        string `json:"file,omitempty"`
+	Func        string `json:"func,omitempty"`
+	DedupKey    string `json:"dedup_key,omitempty"`
+}
+
+type generatorNextWorkLine struct {
+	SourceEpic  string                  `json:"source_epic"`
+	Timestamp   string                  `json:"timestamp"`
+	Items       []generatorNextWorkItem `json:"items"`
+	Consumed    bool                    `json:"consumed"`
+	ClaimStatus string                  `json:"claim_status"`
+	ClaimedBy   *string                 `json:"claimed_by"`
+	ClaimedAt   *string                 `json:"claimed_at"`
+	ConsumedBy  *string                 `json:"consumed_by"`
+	ConsumedAt  *string                 `json:"consumed_at"`
+}
+
+func readFindingGeneratorSidecar(path string) (FindingGeneratorSidecar, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return FindingGeneratorSidecar{}, err
+	}
+	var sidecar FindingGeneratorSidecar
+	if err := json.Unmarshal(data, &sidecar); err != nil {
+		return FindingGeneratorSidecar{}, fmt.Errorf("decode sidecar: %w", err)
+	}
+	if sidecar.SchemaVersion != findingGeneratorSidecarSchemaVersion {
+		return FindingGeneratorSidecar{}, fmt.Errorf("unsupported sidecar schema %q", sidecar.SchemaVersion)
+	}
+	if sidecar.Generator == "" {
+		return FindingGeneratorSidecar{}, fmt.Errorf("missing generator")
+	}
+	return sidecar, nil
+}
+
+func loadGeneratorNextWorkDedupState(path string) (generatorNextWorkDedupState, error) {
+	state := generatorNextWorkDedupState{
+		ids:       map[string]bool{},
+		dedupKeys: map[string]bool{},
+	}
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return state, nil
+	}
+	if err != nil {
+		return state, err
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var entry struct {
+			Items []struct {
+				ID       string `json:"id"`
+				Type     string `json:"type"`
+				Title    string `json:"title"`
+				File     string `json:"file"`
+				DedupKey string `json:"dedup_key"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		for _, item := range entry.Items {
+			if item.ID != "" {
+				state.ids[item.ID] = true
+			}
+			key := item.DedupKey
+			if key == "" {
+				target := item.File
+				if target == "" {
+					target = item.Title
+				}
+				key = "finding-generator|mine-findings|" + normalizeDedupComponent(item.Type+"|"+item.Title+"|"+target)
+			}
+			if key != "" {
+				state.dedupKeys[key] = true
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return state, err
+	}
+	return state, nil
+}
+
+func appendGeneratorNextWorkBatch(path string, items []generatorNextWorkItem, now time.Time) error {
+	if len(items) == 0 {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir next-work dir: %w", err)
+	}
+	line := generatorNextWorkLine{
+		SourceEpic:  dreamGeneratorAggregatorSourceEpic,
+		Timestamp:   now.UTC().Format(time.RFC3339),
+		Items:       items,
+		Consumed:    false,
+		ClaimStatus: "available",
+		ClaimedBy:   nil,
+		ClaimedAt:   nil,
+		ConsumedBy:  nil,
+		ConsumedAt:  nil,
+	}
+	data, err := json.Marshal(line)
+	if err != nil {
+		return fmt.Errorf("marshal generator next-work line: %w", err)
+	}
+	data = append(data, '\n')
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open next-work.jsonl: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("write next-work.jsonl: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync next-work.jsonl: %w", err)
+	}
+	return nil
+}
+
+func normalizeGeneratorCandidate(candidate FindingGeneratorCandidate) FindingGeneratorCandidate {
+	candidate.Type = normalizeGeneratorCandidateType(candidate.Type)
+	candidate.Severity = normalizeGeneratorCandidateSeverity(candidate.Severity)
+	candidate.Source = "evolve-generator"
+	if candidate.Description == "" {
+		candidate.Description = candidate.Evidence
+	}
+	if candidate.Description == "" {
+		candidate.Description = candidate.Title
+	}
+	candidate.DedupKey = strings.ToLower(strings.TrimSpace(candidate.DedupKey))
+	if candidate.DedupKey != "" && !strings.HasPrefix(candidate.DedupKey, "finding-generator|") {
+		candidate.DedupKey = "finding-generator|" + candidate.DedupKey
+	}
+	if candidate.DedupKey == "" {
+		target := candidate.File
+		if target == "" {
+			target = candidate.Title
+		}
+		candidate.DedupKey = "finding-generator|" + normalizeDedupComponent(candidate.Type+"|"+candidate.Title+"|"+target)
+	}
+	return candidate
+}
+
+func generatorCandidateNextWorkItem(candidate FindingGeneratorCandidate) generatorNextWorkItem {
+	candidate = normalizeGeneratorCandidate(candidate)
+	return generatorNextWorkItem{
+		ID:          candidate.ID,
+		Title:       candidate.Title,
+		Type:        candidate.Type,
+		Severity:    candidate.Severity,
+		Source:      candidate.Source,
+		Description: candidate.Description,
+		Evidence:    candidate.Evidence,
+		TargetRepo:  candidate.TargetRepo,
+		File:        candidate.File,
+		Func:        candidate.Func,
+		DedupKey:    candidate.DedupKey,
+	}
+}
+
+func preferGeneratorCandidate(candidate, previous FindingGeneratorCandidate) bool {
+	cRank := severityRank(candidate.Severity)
+	pRank := severityRank(previous.Severity)
+	if cRank != pRank {
+		return cRank > pRank
+	}
+	if candidate.Title != previous.Title {
+		return candidate.Title < previous.Title
+	}
+	return candidate.ID < previous.ID
+}
+
+func severityRank(severity string) int {
+	switch severity {
+	case "high":
+		return 3
+	case "medium":
+		return 2
+	case "low":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func normalizeGeneratorCandidateType(value string) string {
+	trimmed := strings.TrimSpace(value)
+	switch trimmed {
+	case "tech-debt", "improvement", "pattern-fix", "process-improvement", "feature", "bug", "task":
+		return trimmed
+	case "refactor":
+		return "tech-debt"
+	case "knowledge-gap":
+		return "task"
+	default:
+		return "task"
+	}
+}
+
+func normalizeGeneratorCandidateSeverity(value string) string {
+	trimmed := strings.TrimSpace(value)
+	switch trimmed {
+	case "high", "medium", "low":
+		return trimmed
+	default:
+		return "medium"
+	}
 }
 
 func normalizeGeneratorFilename(name string) string {

--- a/cli/internal/overnight/ingest.go
+++ b/cli/internal/overnight/ingest.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/boshu2/agentops/cli/internal/forge"
@@ -57,9 +58,21 @@ type IngestResult struct {
 	// there are no candidates.
 	GeneratorDuplicateRate float64
 
+	// GeneratorSidecarCount is the count of per-generator sidecars written
+	// during INGEST.
+	GeneratorSidecarCount int
+
+	// GeneratorSoftFailCount is the count of generators that emitted a
+	// soft-fail sidecar instead of completed candidates.
+	GeneratorSoftFailCount int
+
 	// GeneratorSidecarPath points at the latest generator sidecar written
 	// during INGEST, relative or absolute according to RunLoopOptions.
 	GeneratorSidecarPath string
+
+	// GeneratorSidecarPaths points at every generator sidecar written during
+	// INGEST, relative or absolute according to RunLoopOptions.
+	GeneratorSidecarPaths []string
 
 	// Degraded lists human-readable degradation notes for substages that
 	// were skipped, deferred, or soft-failed.
@@ -77,10 +90,9 @@ type IngestResult struct {
 // RunIngest executes the parallel-safe INGEST stage.
 //
 // RunIngest never mutates the Dream corpus or next-work queue. It runs serial
-// substages (no swarm, no goroutine fan-out in the first slice) and each
-// substage degrades independently on failure. Read-side generators may write
-// per-run sidecars under OutputDir/generator-results so candidate yield is
-// measurable without creating queue write races. The stage as a whole only
+// corpus substages, then bounded read-side finding generators may fan out and
+// write per-run sidecars under OutputDir/generator-results so candidate yield
+// is measurable without creating queue write races. The stage as a whole only
 // returns a non-nil error when the harvest catalog cannot be produced — that
 // catalog is the load-bearing output REDUCE needs to run its real promotion
 // pass.
@@ -94,8 +106,8 @@ type IngestResult struct {
 //     under .agents/sessions/ (Wave 2 Issue 5 wiring).
 //  4. provenance.Audit — in-process audit of .agents/learnings/ for
 //     stale/missing citations (Wave 2 Issue 5 wiring).
-//  5. mine.Run — in-process drift/complexity pass with DryRun=true so
-//     INGEST remains read-only (Wave 2 Issue 5 wiring).
+//  5. finding generator fanout — read-only candidate producers, currently
+//     mine.Run with EmitWorkItems=false so INGEST never writes next-work.
 //
 // Substages 3-5 soft-fail independently: a single error degrades that
 // substage only and the stage continues. This is honest degradation per
@@ -126,7 +138,7 @@ func RunIngest(ctx context.Context, opts RunLoopOptions, log io.Writer) (*Ingest
 	if err := runner.runProvenanceAudit(); err != nil {
 		return result, err
 	}
-	if err := runner.runMineFindings(); err != nil {
+	if err := runner.runFindingGenerators(); err != nil {
 		return result, err
 	}
 
@@ -141,6 +153,22 @@ type ingestRunner struct {
 	log     io.Writer
 	result  *IngestResult
 	started time.Time
+}
+
+const defaultFindingGeneratorTimeout = 2 * time.Minute
+
+type findingGenerator struct {
+	name       string
+	sourceEpic string
+	timeout    time.Duration
+	run        func(context.Context, RunLoopOptions) FindingGeneratorSidecar
+}
+
+type findingGeneratorRunResult struct {
+	name    string
+	sidecar FindingGeneratorSidecar
+	path    string
+	err     error
 }
 
 func newIngestResult() *IngestResult {
@@ -270,49 +298,130 @@ func (r *ingestRunner) runProvenanceAudit() error {
 	return nil
 }
 
-func (r *ingestRunner) runMineFindings() error {
+func (r *ingestRunner) runFindingGenerators() error {
 	if err := ctxCheck(r.ctx); err != nil {
 		return err
 	}
-	started := time.Now()
-	mineOpts := mine.RunOpts{
-		Sources: []string{"git", "agents", "code"},
-		Quiet:   true,
-		DryRun:  true,
-	}
-	mineReport, mineErr := mine.Run(r.opts.Cwd, mineOpts)
-	if mineErr != nil {
-		r.result.StageFailures["mine-findings"] = mineErr.Error()
-		r.result.Degraded = append(r.result.Degraded, fmt.Sprintf("mine-findings: %v", mineErr))
-		r.recordMineGeneratorSidecar(buildFailedMineGeneratorSidecar(r.opts, started, time.Now(), mineErr))
+	generators := r.findingGenerators()
+	if len(generators) == 0 {
 		return nil
 	}
-	if mineReport != nil {
-		r.result.MineFindingsNew = countMineFindings(mineReport)
-		existingIDs, dedupErr := mine.LoadExistingMineIDs(filepath.Join(r.opts.Cwd, ".agents", "rpi", "next-work.jsonl"))
-		if dedupErr != nil {
-			r.result.StageFailures["mine-generator-dedup"] = dedupErr.Error()
-			r.result.Degraded = append(r.result.Degraded, fmt.Sprintf("mine-generator-dedup: %v", dedupErr))
-		}
-		r.recordMineGeneratorSidecar(buildMineGeneratorSidecar(r.opts, mineReport, started, time.Now(), existingIDs))
-		fmt.Fprintf(r.log, "overnight/ingest: mine-findings new=%d\n", r.result.MineFindingsNew)
+	results := make(chan findingGeneratorRunResult, len(generators))
+	for _, generator := range generators {
+		generator := generator
+		go func() {
+			results <- runFindingGenerator(r.ctx, r.opts, generator)
+		}()
+	}
+	ordered := make([]findingGeneratorRunResult, 0, len(generators))
+	for range generators {
+		ordered = append(ordered, <-results)
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].name < ordered[j].name })
+	for _, result := range ordered {
+		r.recordFindingGeneratorResult(result)
 	}
 	return nil
 }
 
-func (r *ingestRunner) recordMineGeneratorSidecar(sidecar FindingGeneratorSidecar) {
-	r.result.GeneratorCandidateCount = sidecar.CandidateCount
-	r.result.GeneratorDuplicateCount = sidecar.DuplicateCount
-	r.result.GeneratorDuplicateRate = sidecar.DuplicateRate
-	path, err := writeFindingGeneratorSidecar(r.opts, sidecar)
-	if err != nil {
-		r.result.StageFailures["mine-generator-sidecar"] = err.Error()
-		r.result.Degraded = append(r.result.Degraded, fmt.Sprintf("mine-generator-sidecar: %v", err))
+func (r *ingestRunner) findingGenerators() []findingGenerator {
+	return []findingGenerator{
+		{
+			name:       mineFindingsGeneratorName,
+			sourceEpic: "compile-mine",
+			timeout:    defaultFindingGeneratorTimeout,
+			run:        runMineFindingGenerator,
+		},
+	}
+}
+
+func runFindingGenerator(
+	ctx context.Context,
+	opts RunLoopOptions,
+	generator findingGenerator,
+) findingGeneratorRunResult {
+	timeout := generator.timeout
+	if timeout <= 0 {
+		timeout = defaultFindingGeneratorTimeout
+	}
+	genCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	started := time.Now()
+	done := make(chan FindingGeneratorSidecar, 1)
+	go func() {
+		done <- generator.run(genCtx, opts)
+	}()
+
+	var sidecar FindingGeneratorSidecar
+	select {
+	case sidecar = <-done:
+	case <-genCtx.Done():
+		sidecar = buildFailedFindingGeneratorSidecar(
+			opts,
+			generator.name,
+			generator.sourceEpic,
+			started,
+			time.Now(),
+			genCtx.Err(),
+		)
+	}
+	path, err := writeFindingGeneratorSidecar(opts, sidecar)
+	return findingGeneratorRunResult{
+		name:    generator.name,
+		sidecar: sidecar,
+		path:    path,
+		err:     err,
+	}
+}
+
+func runMineFindingGenerator(ctx context.Context, opts RunLoopOptions) FindingGeneratorSidecar {
+	started := time.Now()
+	mineOpts := mine.RunOpts{
+		Context:       ctx,
+		Sources:       []string{"git", "agents", "code"},
+		Window:        26 * time.Hour,
+		OutputDir:     filepath.Join(opts.OutputDir, "mine-findings"),
+		Quiet:         true,
+		EmitWorkItems: false,
+	}
+	mineReport, mineErr := mine.Run(opts.Cwd, mineOpts)
+	if mineErr != nil {
+		return buildFailedMineGeneratorSidecar(opts, started, time.Now(), mineErr)
+	}
+	existingIDs, dedupErr := mine.LoadExistingMineIDs(filepath.Join(opts.Cwd, ".agents", "rpi", "next-work.jsonl"))
+	if dedupErr != nil {
+		return buildFailedMineGeneratorSidecar(opts, started, time.Now(), fmt.Errorf("mine-generator-dedup: %w", dedupErr))
+	}
+	return buildMineGeneratorSidecar(opts, mineReport, started, time.Now(), existingIDs)
+}
+
+func (r *ingestRunner) recordFindingGeneratorResult(runResult findingGeneratorRunResult) {
+	sidecar := runResult.sidecar
+	if sidecar.Status == "soft-fail" {
+		r.result.GeneratorSoftFailCount++
+		if sidecar.Error != "" {
+			r.result.StageFailures[runResult.name] = sidecar.Error
+			r.result.Degraded = append(r.result.Degraded, fmt.Sprintf("%s: %s", runResult.name, sidecar.Error))
+		}
+	}
+	if runResult.err != nil {
+		r.result.StageFailures[runResult.name+"-sidecar"] = runResult.err.Error()
+		r.result.Degraded = append(r.result.Degraded, fmt.Sprintf("%s-sidecar: %v", runResult.name, runResult.err))
 		return
 	}
-	r.result.GeneratorSidecarPath = path
+	r.result.GeneratorCandidateCount += sidecar.CandidateCount
+	r.result.GeneratorDuplicateCount += sidecar.DuplicateCount
+	if r.result.GeneratorCandidateCount > 0 {
+		r.result.GeneratorDuplicateRate = float64(r.result.GeneratorDuplicateCount) / float64(r.result.GeneratorCandidateCount)
+	}
+	r.result.GeneratorSidecarCount++
+	r.result.GeneratorSidecarPath = runResult.path
+	r.result.GeneratorSidecarPaths = append(r.result.GeneratorSidecarPaths, runResult.path)
+	if sidecar.Generator == mineFindingsGeneratorName {
+		r.result.MineFindingsNew = sidecar.NewCandidateCount
+	}
 	fmt.Fprintf(r.log, "overnight/ingest: %s sidecar candidates=%d duplicates=%d path=%s\n",
-		sidecar.Generator, sidecar.CandidateCount, sidecar.DuplicateCount, path)
+		sidecar.Generator, sidecar.CandidateCount, sidecar.DuplicateCount, runResult.path)
 }
 
 // ctxCheck returns ctx.Err() if ctx has been cancelled, or nil otherwise.

--- a/cli/internal/overnight/loop.go
+++ b/cli/internal/overnight/loop.go
@@ -661,7 +661,10 @@ func ingestSummary(r *IngestResult) map[string]any {
 		"generator_candidate_count": r.GeneratorCandidateCount,
 		"generator_duplicate_count": r.GeneratorDuplicateCount,
 		"generator_duplicate_rate":  r.GeneratorDuplicateRate,
+		"generator_sidecar_count":   r.GeneratorSidecarCount,
+		"generator_soft_fail_count": r.GeneratorSoftFailCount,
 		"generator_sidecar_path":    r.GeneratorSidecarPath,
+		"generator_sidecar_paths":   r.GeneratorSidecarPaths,
 	}
 }
 
@@ -669,14 +672,18 @@ func ingestSummary(r *IngestResult) map[string]any {
 // IterationSummary uses.
 func reduceSummary(r *ReduceResult) map[string]any {
 	return map[string]any{
-		"harvest_promoted":    r.HarvestPromoted,
-		"dedup_merged":        r.DedupMerged,
-		"maturity_tempered":   r.MaturityTempered,
-		"defrag_pruned":       r.DefragPruned,
-		"close_loop_promoted": r.CloseLoopPromoted,
-		"findings_routed":     r.FindingsRouted,
-		"inject_refreshed":    r.InjectRefreshed,
-		"rolled_back":         r.RolledBack,
+		"harvest_promoted":               r.HarvestPromoted,
+		"dedup_merged":                   r.DedupMerged,
+		"maturity_tempered":              r.MaturityTempered,
+		"defrag_pruned":                  r.DefragPruned,
+		"close_loop_promoted":            r.CloseLoopPromoted,
+		"findings_routed":                r.FindingsRouted,
+		"generator_candidates_routed":    r.GeneratorCandidatesRouted,
+		"generator_candidates_skipped":   r.GeneratorCandidatesSkipped,
+		"generator_sidecars_aggregated":  r.GeneratorSidecarsAggregated,
+		"generator_sidecars_soft_failed": r.GeneratorSidecarsSoftFailed,
+		"inject_refreshed":               r.InjectRefreshed,
+		"rolled_back":                    r.RolledBack,
 	}
 }
 

--- a/cli/internal/overnight/loop_test.go
+++ b/cli/internal/overnight/loop_test.go
@@ -228,7 +228,10 @@ func TestIngestSummary(t *testing.T) {
 		GeneratorCandidateCount: 8,
 		GeneratorDuplicateCount: 2,
 		GeneratorDuplicateRate:  0.25,
+		GeneratorSidecarCount:   1,
+		GeneratorSoftFailCount:  0,
 		GeneratorSidecarPath:    ".agents/overnight/test-run/generator-results/mine-findings.json",
+		GeneratorSidecarPaths:   []string{".agents/overnight/test-run/generator-results/mine-findings.json"},
 	}
 	got := ingestSummary(r)
 	if got["harvest_preview_count"] != 4 {
@@ -255,8 +258,18 @@ func TestIngestSummary(t *testing.T) {
 	if got["generator_sidecar_path"] != ".agents/overnight/test-run/generator-results/mine-findings.json" {
 		t.Fatalf("generator_sidecar_path: got %v, want sidecar path", got["generator_sidecar_path"])
 	}
-	if len(got) != 8 {
-		t.Fatalf("summary key count: got %d, want 8", len(got))
+	if got["generator_sidecar_count"] != 1 {
+		t.Fatalf("generator_sidecar_count: got %v, want 1", got["generator_sidecar_count"])
+	}
+	if got["generator_soft_fail_count"] != 0 {
+		t.Fatalf("generator_soft_fail_count: got %v, want 0", got["generator_soft_fail_count"])
+	}
+	paths, ok := got["generator_sidecar_paths"].([]string)
+	if !ok || len(paths) != 1 || paths[0] != ".agents/overnight/test-run/generator-results/mine-findings.json" {
+		t.Fatalf("generator_sidecar_paths: got %#v, want one sidecar path", got["generator_sidecar_paths"])
+	}
+	if len(got) != 11 {
+		t.Fatalf("summary key count: got %d, want 11", len(got))
 	}
 }
 
@@ -264,23 +277,31 @@ func TestIngestSummary(t *testing.T) {
 // the expected key in the summary map.
 func TestReduceSummary(t *testing.T) {
 	r := &ReduceResult{
-		HarvestPromoted:   1,
-		DedupMerged:       2,
-		MaturityTempered:  3,
-		DefragPruned:      4,
-		CloseLoopPromoted: 5,
-		FindingsRouted:    6,
-		InjectRefreshed:   true,
-		RolledBack:        true,
+		HarvestPromoted:             1,
+		DedupMerged:                 2,
+		MaturityTempered:            3,
+		DefragPruned:                4,
+		CloseLoopPromoted:           5,
+		FindingsRouted:              6,
+		GeneratorCandidatesRouted:   7,
+		GeneratorCandidatesSkipped:  8,
+		GeneratorSidecarsAggregated: 9,
+		GeneratorSidecarsSoftFailed: 1,
+		InjectRefreshed:             true,
+		RolledBack:                  true,
 	}
 	got := reduceSummary(r)
 	wantInts := map[string]int{
-		"harvest_promoted":    1,
-		"dedup_merged":        2,
-		"maturity_tempered":   3,
-		"defrag_pruned":       4,
-		"close_loop_promoted": 5,
-		"findings_routed":     6,
+		"harvest_promoted":               1,
+		"dedup_merged":                   2,
+		"maturity_tempered":              3,
+		"defrag_pruned":                  4,
+		"close_loop_promoted":            5,
+		"findings_routed":                6,
+		"generator_candidates_routed":    7,
+		"generator_candidates_skipped":   8,
+		"generator_sidecars_aggregated":  9,
+		"generator_sidecars_soft_failed": 1,
 	}
 	for k, v := range wantInts {
 		if got[k] != v {
@@ -293,8 +314,8 @@ func TestReduceSummary(t *testing.T) {
 	if got["rolled_back"] != true {
 		t.Fatalf("rolled_back: got %v, want true", got["rolled_back"])
 	}
-	if len(got) != 8 {
-		t.Fatalf("summary key count: got %d, want 8", len(got))
+	if len(got) != 12 {
+		t.Fatalf("summary key count: got %d, want 12", len(got))
 	}
 }
 

--- a/cli/internal/overnight/reduce.go
+++ b/cli/internal/overnight/reduce.go
@@ -48,6 +48,23 @@ type ReduceResult struct {
 	// by RouteFindings.
 	FindingsRouted int
 
+	// GeneratorCandidatesRouted is the count of read-side generator
+	// candidates routed to next-work.jsonl by the single-writer sidecar
+	// aggregator.
+	GeneratorCandidatesRouted int
+
+	// GeneratorCandidatesSkipped is the count of read-side generator
+	// candidates skipped during aggregation because they were duplicates.
+	GeneratorCandidatesSkipped int
+
+	// GeneratorSidecarsAggregated is the count of generator sidecar files read
+	// during aggregation.
+	GeneratorSidecarsAggregated int
+
+	// GeneratorSidecarsSoftFailed is the count of generator sidecars that
+	// represented a soft-failed generator.
+	GeneratorSidecarsSoftFailed int
+
 	// InjectRefreshed indicates whether the inject-cache refresh stage
 	// ran successfully. Flipped to true by Wave 4 Issue 16 when the
 	// inject-refresh stage completes without error.
@@ -107,15 +124,17 @@ type reduceStage struct {
 //     the callback set is nil so tests can exercise rollback without
 //     wiring the full cmd/ao helper graph.
 //  6. RouteFindings(cwd) — findings → next-work router.
-//  7. RefreshInjectCache(ctx, cwd) — best-effort inject-cache refresh
+//  7. AggregateFindingGeneratorSidecars(staging, outputDir) — read-side
+//     generator sidecars → next-work queue through one writer.
+//  8. RefreshInjectCache(ctx, cwd) — best-effort inject-cache refresh
 //     (Wave 4 Issue 16). Closes PRODUCT.md Gap #1's loop framing
 //     ("harvest → forge → INJECT → report"). Failures here are
 //     captured as degraded notes on the result and do NOT trigger a
 //     rollback: a stale inject cache is less bad than discarding the
 //     compounded corpus this iteration already landed.
-//  8. VerifyMetadataRoundTrip(cp) — frontmatter strip guard (pm-005).
+//  9. VerifyMetadataRoundTrip(cp) — frontmatter strip guard (pm-005).
 //
-// If ANY stage (1-6) returns an error OR the integrity check in stage 8
+// If ANY stage (1-8) returns an error OR the integrity check in stage 9
 // fails, RunReduce invokes cp.Rollback() and returns a non-nil error
 // with a populated RollbackReason on the result. Partial counters are
 // preserved so the morning report can show what landed before the
@@ -228,6 +247,7 @@ func (r *reduceRunner) stages() []reduceStage {
 		{name: "defrag-prune", run: r.runDefragPrune},
 		{name: "close-loop", run: r.runCloseLoop},
 		{name: "findings-router", run: r.runFindingsRouter},
+		{name: "generator-aggregator", run: r.runGeneratorAggregator},
 		{name: "inject-refresh", run: r.runInjectRefresh},
 	}
 }
@@ -333,6 +353,22 @@ func (r *reduceRunner) runFindingsRouter() error {
 	r.result.FindingsRouted = routed
 	for _, d := range degraded {
 		r.result.Degraded = append(r.result.Degraded, fmt.Sprintf("findings-router: %s", d))
+	}
+	return nil
+}
+
+func (r *reduceRunner) runGeneratorAggregator() error {
+	r.recordStage("generator-aggregator")
+	aggregate, degraded, err := AggregateFindingGeneratorSidecars(r.stagingCwd, r.opts.OutputDir)
+	if err != nil {
+		return err
+	}
+	r.result.GeneratorCandidatesRouted = aggregate.ItemsWritten
+	r.result.GeneratorCandidatesSkipped = aggregate.DuplicatesSkipped
+	r.result.GeneratorSidecarsAggregated = aggregate.SidecarsRead
+	r.result.GeneratorSidecarsSoftFailed = aggregate.SidecarsSoftFail
+	for _, d := range degraded {
+		r.result.Degraded = append(r.result.Degraded, fmt.Sprintf("generator-aggregator: %s", d))
 	}
 	return nil
 }

--- a/cli/internal/overnight/stages_test.go
+++ b/cli/internal/overnight/stages_test.go
@@ -128,6 +128,80 @@ func TestRunIngest_HarvestDryRunDoesNotMutate(t *testing.T) {
 	}
 }
 
+func TestRunIngest_FindingGeneratorEmitsRealSidecarCandidates(t *testing.T) {
+	cwd := t.TempDir()
+	writeLearning(t, cwd, "2026-04-09-static.md", map[string]string{
+		"type":       "learning",
+		"confidence": "0.9",
+	}, "# Static\n\nUntouched body.\n")
+	researchDir := filepath.Join(cwd, ".agents", "research")
+	if err := os.MkdirAll(researchDir, 0o755); err != nil {
+		t.Fatalf("mkdir research: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(researchDir, "orphan.md"), []byte("# Orphan\n"), 0o644); err != nil {
+		t.Fatalf("write orphan research: %v", err)
+	}
+
+	opts := newTestOpts(cwd)
+	res, err := RunIngest(context.Background(), opts, io.Discard)
+	if err != nil {
+		t.Fatalf("RunIngest: %v", err)
+	}
+	if res.GeneratorCandidateCount == 0 {
+		t.Fatal("expected generator candidates from orphaned research")
+	}
+	if res.GeneratorSidecarCount != 1 {
+		t.Fatalf("GeneratorSidecarCount = %d, want 1", res.GeneratorSidecarCount)
+	}
+	if len(res.GeneratorSidecarPaths) != 1 {
+		t.Fatalf("GeneratorSidecarPaths = %v, want one sidecar", res.GeneratorSidecarPaths)
+	}
+	data, err := os.ReadFile(filepath.Join(opts.OutputDir, "generator-results", "mine-findings.json"))
+	if err != nil {
+		t.Fatalf("read mine sidecar: %v", err)
+	}
+	var sidecar FindingGeneratorSidecar
+	if err := json.Unmarshal(data, &sidecar); err != nil {
+		t.Fatalf("decode mine sidecar: %v", err)
+	}
+	if sidecar.Status != "completed" {
+		t.Fatalf("sidecar status = %q, want completed: %s", sidecar.Status, sidecar.Error)
+	}
+	if len(sidecar.Candidates) == 0 {
+		t.Fatal("sidecar candidates empty")
+	}
+	got := sidecar.Candidates[0]
+	if got.Type != "task" || got.Source != "evolve-generator" || got.Description == "" || got.DedupKey == "" {
+		t.Fatalf("candidate not queue-safe: %+v", got)
+	}
+}
+
+func TestRunFindingGenerator_StalledGeneratorWritesSoftFailSidecar(t *testing.T) {
+	cwd := t.TempDir()
+	opts := newTestOpts(cwd)
+	result := runFindingGenerator(context.Background(), opts, findingGenerator{
+		name:       "stalled-generator",
+		sourceEpic: "stall-test",
+		timeout:    5 * time.Millisecond,
+		run: func(context.Context, RunLoopOptions) FindingGeneratorSidecar {
+			select {}
+		},
+	})
+
+	if result.err != nil {
+		t.Fatalf("runFindingGenerator write error: %v", result.err)
+	}
+	if result.sidecar.Status != "soft-fail" {
+		t.Fatalf("sidecar status = %q, want soft-fail", result.sidecar.Status)
+	}
+	if !strings.Contains(result.sidecar.Error, "context deadline exceeded") {
+		t.Fatalf("sidecar error = %q, want context deadline exceeded", result.sidecar.Error)
+	}
+	if _, err := os.Stat(result.path); err != nil {
+		t.Fatalf("expected soft-fail sidecar at %s: %v", result.path, err)
+	}
+}
+
 func TestRunIngest_EmptyCorpus(t *testing.T) {
 	// Isolate HOME to the tempdir so harvest.DiscoverRigs does not pick
 	// up the operator's real ~/.agents/ global hub. DiscoverRigs adds
@@ -306,6 +380,131 @@ func TestWriteFindingGeneratorSidecarAtomicJSON(t *testing.T) {
 	}
 }
 
+func TestAggregateFindingGeneratorSidecarsAppendsOneDedupedBatch(t *testing.T) {
+	cwd := t.TempDir()
+	nextWorkDir := filepath.Join(cwd, ".agents", "rpi")
+	if err := os.MkdirAll(nextWorkDir, 0o755); err != nil {
+		t.Fatalf("mkdir next-work dir: %v", err)
+	}
+	existingLine := `{"source_epic":"seed","timestamp":"2026-04-26T00:00:00Z","items":[{"id":"already-present","title":"Already present","type":"task","severity":"medium","source":"evolve-generator","description":"seed","dedup_key":"finding-generator|mine-findings|already-present"}],"consumed":false,"claim_status":"available","claimed_by":null,"claimed_at":null,"consumed_by":null,"consumed_at":null}` + "\n"
+	if err := os.WriteFile(filepath.Join(nextWorkDir, "next-work.jsonl"), []byte(existingLine), 0o644); err != nil {
+		t.Fatalf("write seed next-work: %v", err)
+	}
+
+	opts := newTestOpts(cwd)
+	completed := FindingGeneratorSidecar{
+		SchemaVersion:  "finding-generator-sidecar/v1",
+		RunID:          opts.RunID,
+		Generator:      mineFindingsGeneratorName,
+		SourceEpic:     "compile-mine",
+		Status:         "completed",
+		CandidateCount: 3,
+		Candidates: []FindingGeneratorCandidate{
+			{
+				ID:          "already-present",
+				Title:       "Already present",
+				Type:        "task",
+				Severity:    "medium",
+				Source:      "evolve-generator",
+				Description: "Seeded duplicate should not be routed again.",
+				DedupKey:    "finding-generator|mine-findings|already-present",
+			},
+			{
+				ID:          "new-high",
+				Title:       "Reduce complexity: runDream",
+				Type:        "tech-debt",
+				Severity:    "high",
+				Source:      "evolve-generator",
+				Description: "Complexity hotspot should be routed.",
+				Evidence:    "complexity=27",
+				File:        "cli/cmd/ao/overnight.go",
+				Func:        "runDream",
+				DedupKey:    "finding-generator|mine-findings|tech-debt-reduce-complexity-rundream",
+			},
+			{
+				ID:          "new-low-duplicate",
+				Title:       "Reduce complexity duplicate",
+				Type:        "tech-debt",
+				Severity:    "medium",
+				Source:      "evolve-generator",
+				Description: "Lower-priority duplicate should lose reconciliation.",
+				DedupKey:    "finding-generator|mine-findings|tech-debt-reduce-complexity-rundream",
+			},
+		},
+	}
+	if _, err := writeFindingGeneratorSidecar(opts, completed); err != nil {
+		t.Fatalf("write completed sidecar: %v", err)
+	}
+	if _, err := writeFindingGeneratorSidecar(opts, FindingGeneratorSidecar{
+		SchemaVersion: "finding-generator-sidecar/v1",
+		RunID:         opts.RunID,
+		Generator:     "slow-generator",
+		SourceEpic:    "compile-mine",
+		Status:        "soft-fail",
+		Error:         "deadline exceeded",
+	}); err != nil {
+		t.Fatalf("write failed sidecar: %v", err)
+	}
+
+	got, degraded, err := AggregateFindingGeneratorSidecars(cwd, opts.OutputDir)
+	if err != nil {
+		t.Fatalf("AggregateFindingGeneratorSidecars: %v", err)
+	}
+	if got.SidecarsRead != 2 {
+		t.Fatalf("SidecarsRead = %d, want 2", got.SidecarsRead)
+	}
+	if got.CandidatesSeen != 3 {
+		t.Fatalf("CandidatesSeen = %d, want 3", got.CandidatesSeen)
+	}
+	if got.DuplicatesSkipped != 2 {
+		t.Fatalf("DuplicatesSkipped = %d, want 2", got.DuplicatesSkipped)
+	}
+	if got.ItemsWritten != 1 {
+		t.Fatalf("ItemsWritten = %d, want 1", got.ItemsWritten)
+	}
+	if !containsSubstring(degraded, "slow-generator: soft-fail") {
+		t.Fatalf("expected soft-fail degradation, got %v", degraded)
+	}
+
+	data, err := os.ReadFile(filepath.Join(nextWorkDir, "next-work.jsonl"))
+	if err != nil {
+		t.Fatalf("read next-work: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("next-work lines = %d, want seed + one aggregate line\n%s", len(lines), data)
+	}
+	var appended struct {
+		SourceEpic  string `json:"source_epic"`
+		ClaimStatus string `json:"claim_status"`
+		Items       []struct {
+			ID          string `json:"id"`
+			Title       string `json:"title"`
+			Type        string `json:"type"`
+			Severity    string `json:"severity"`
+			Source      string `json:"source"`
+			Description string `json:"description"`
+			DedupKey    string `json:"dedup_key"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(lines[1]), &appended); err != nil {
+		t.Fatalf("unmarshal appended line: %v", err)
+	}
+	if appended.SourceEpic != "dream-generator-aggregator" {
+		t.Fatalf("SourceEpic = %q, want dream-generator-aggregator", appended.SourceEpic)
+	}
+	if appended.ClaimStatus != "available" {
+		t.Fatalf("ClaimStatus = %q, want available", appended.ClaimStatus)
+	}
+	if len(appended.Items) != 1 {
+		t.Fatalf("appended items = %d, want 1", len(appended.Items))
+	}
+	item := appended.Items[0]
+	if item.ID != "new-high" || item.Type != "tech-debt" || item.Source != "evolve-generator" || item.Description == "" || item.DedupKey == "" {
+		t.Fatalf("unexpected appended item: %+v", item)
+	}
+}
+
 // --- REDUCE ------------------------------------------------------------
 
 // recordingCallbacks builds a CloseLoopOpts whose callbacks append their
@@ -392,6 +591,49 @@ func TestRunReduce_StageOrderEnforced(t *testing.T) {
 	// loop ran past its position in the stage sequence.
 	if len(rec.order) != 1 || rec.order[0] != "close-loop" {
 		t.Errorf("expected close-loop to be invoked exactly once, got %v", rec.order)
+	}
+}
+
+func TestRunReduce_AggregatesGeneratorSidecarsIntoStagedNextWork(t *testing.T) {
+	cwd, cp, ingest := newReduceFixture(t)
+	opts := newTestOpts(cwd)
+	if _, err := writeFindingGeneratorSidecar(opts, FindingGeneratorSidecar{
+		SchemaVersion: "finding-generator-sidecar/v1",
+		RunID:         opts.RunID,
+		Generator:     mineFindingsGeneratorName,
+		SourceEpic:    "compile-mine",
+		Status:        "completed",
+		Candidates: []FindingGeneratorCandidate{{
+			ID:          "generated-one",
+			Title:       "Generated queue item",
+			Type:        "task",
+			Severity:    "medium",
+			Source:      "evolve-generator",
+			Description: "Aggregator should write this item only inside the checkpoint staging tree.",
+			DedupKey:    "finding-generator|mine-findings|generated-one",
+		}},
+	}); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+
+	res, err := RunReduce(context.Background(), opts, ingest, cp, (&recorder{}).callbacks(), io.Discard)
+	if err != nil {
+		t.Fatalf("RunReduce: %v", err)
+	}
+	if res.GeneratorCandidatesRouted != 1 {
+		t.Fatalf("GeneratorCandidatesRouted = %d, want 1", res.GeneratorCandidatesRouted)
+	}
+	liveNextWork := filepath.Join(cwd, ".agents", "rpi", "next-work.jsonl")
+	if liveData, err := os.ReadFile(liveNextWork); err == nil && strings.Contains(string(liveData), "generated-one") {
+		t.Fatalf("live next-work mutated before checkpoint commit:\n%s", liveData)
+	}
+	stagedNextWork := filepath.Join(cp.StagingDir, ".agents", "rpi", "next-work.jsonl")
+	stagedData, err := os.ReadFile(stagedNextWork)
+	if err != nil {
+		t.Fatalf("read staged next-work: %v", err)
+	}
+	if !strings.Contains(string(stagedData), "generated-one") {
+		t.Fatalf("staged next-work missing generated item:\n%s", stagedData)
 	}
 }
 
@@ -716,6 +958,7 @@ func TestRunReduce_FullStageOrder_Enforced(t *testing.T) {
 		"defrag-prune",
 		"close-loop",
 		"findings-router",
+		"generator-aggregator",
 		"inject-refresh",
 	}
 	if !reflect.DeepEqual(order, want) {

--- a/docs/contracts/dream-run-contract.md
+++ b/docs/contracts/dream-run-contract.md
@@ -208,8 +208,8 @@ Dream v2 replaces the single-pass 5-step script with a bounded outer loop that i
 
 Each iteration runs four stages in order (Micro-epic 8 / C1 Option A, 2026-04-11):
 
-1. **INGEST** - harvest new signal into the corpus (absorbs `/harvest` overnight work)
-2. **REDUCE** - defrag, dedup, compile, and prune. Mutations are written to the checkpoint's **staging tree** (`cp.StagingDir/.agents/<subpath>/`), NOT the live `.agents/` path.
+1. **INGEST** - harvest new signal into the corpus (absorbs `/harvest` overnight work) and run bounded, read-only finding generators that write per-run sidecars only.
+2. **REDUCE** - defrag, dedup, compile, prune, route findings, and aggregate generator sidecars through one serialized `next-work.jsonl` writer. Mutations are written to the checkpoint's **staging tree** (`cp.StagingDir/.agents/<subpath>/`), NOT the live `.agents/` path.
 3. **MEASURE** - `corpus.Compute(cp.StagingDir)` computes fitness against the staged mutations (pre-commit). Under warn-only mode, a regression consumes a rescue and the iteration still commits; under strict mode, a regression (or plateau) triggers `cp.Rollback()` and the iteration halts with status `halted-on-regression-pre-commit` — the live `.agents/` tree is **never mutated**.
 4. **COMMIT** - `cp.Commit()` atomically promotes the staging tree into live. This is the first point at which external observers of `~/.agents/` see the new state. A post-commit metadata integrity check (`VerifyMetadataRoundTripPostCommit`) runs here as a ratchet-forward second-stage defence (strip detection).
 
@@ -244,7 +244,9 @@ Only these paths are mutated and rolled back as a unit:
 - Dream NEVER invokes `/rpi` or any code-mutating flow.
 - Dream NEVER performs git operations (no commits, branches, push, rebase, checkout, etc.).
 - Dream NEVER creates symlinks anywhere.
-- First-slice scope: no swarm/gc fan-out inside iterations (serial goroutines only).
+- Dream NEVER fans work out to swarm/gc agents inside iterations. Bounded
+  in-process read-only finding generators may run concurrently during INGEST,
+  but REDUCE remains the single serialized writer for `.agents/rpi/next-work.jsonl`.
 
 ### New Flags
 

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -716,7 +716,7 @@
       "name": "dream",
       "source_skill": "skills/dream",
       "source_hash": "28f5f4412bff2be75b748ecd8fd693a523a8977548506675693a95a1826bf122",
-      "generated_hash": "9dae1a6fad63508846cb08cf20f931cda6b7ed9dd046324c9a0738a45b7cb5eb"
+      "generated_hash": "e2e6178d4d3b1c10721e291f82aee5bdbbd7e0f185d84db4eac12a31fc0e9e9c"
     },
     {
       "name": "doc",

--- a/skills-codex/dream/.agentops-generated.json
+++ b/skills-codex/dream/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/dream",
   "layout": "modular",
   "source_hash": "28f5f4412bff2be75b748ecd8fd693a523a8977548506675693a95a1826bf122",
-  "generated_hash": "9dae1a6fad63508846cb08cf20f931cda6b7ed9dd046324c9a0738a45b7cb5eb"
+  "generated_hash": "e2e6178d4d3b1c10721e291f82aee5bdbbd7e0f185d84db4eac12a31fc0e9e9c"
 }

--- a/skills-codex/dream/SKILL.md
+++ b/skills-codex/dream/SKILL.md
@@ -17,7 +17,9 @@ Anti-goals (hard constraints):
 - NEVER invokes `$rpi` or any code-mutating flow.
 - NEVER performs git operations (no commits, branches, push, rebase, checkout).
 - NEVER creates symlinks anywhere.
-- No swarm/gc fan-out inside iterations in the first slice (serial only).
+- No swarm/gc agent fan-out inside iterations. Bounded in-process read-only
+  finding generators may run concurrently during INGEST, but REDUCE remains the
+  single serialized writer for `.agents/rpi/next-work.jsonl`.
 
 ## Execution Steps
 

--- a/skills/dream/SKILL.md
+++ b/skills/dream/SKILL.md
@@ -53,7 +53,9 @@ Anti-goals (hard constraints):
 - NEVER invokes `/rpi` or any code-mutating flow.
 - NEVER performs git operations (no commits, branches, push, rebase, checkout).
 - NEVER creates symlinks anywhere.
-- No swarm/gc fan-out inside iterations in the first slice (serial only).
+- No swarm/gc agent fan-out inside iterations. Bounded in-process read-only
+  finding generators may run concurrently during INGEST, but REDUCE remains the
+  single serialized writer for `.agents/rpi/next-work.jsonl`.
 
 ## Tier 1 Curator And Trigger Mesh
 


### PR DESCRIPTION
## Summary

Builds RFC 0001 Proposal 1 fully: Dream keeps `/evolve` serial, but INGEST can run bounded read-side finding generators that emit sidecars, and REDUCE is the sole serialized writer that appends deduped candidates to `.agents/rpi/next-work.jsonl` inside the checkpoint staging tree.

Key behavior:
- registers the first real generator, `mine-findings`, with a per-generator timeout and context-bound mine execution
- runs generators as read-only sidecar producers; `mine.Run` uses `EmitWorkItems=false` and writes reports under the Dream run output dir, not the queue
- adds a REDUCE `generator-aggregator` stage that reads sidecars, soft-fails bad/stalled generators, dedups by id and `dedup_key`, reconciles duplicate candidates by severity, and appends one next-work batch
- surfaces generator sidecar/routing counters in ingest/reduce summaries
- updates Dream contract and runtime skill text to allow bounded in-process read-side generator fanout while keeping queue writes serialized

## Validation

- `cd cli && go test ./internal/overnight ./internal/mine`
- `cd cli && go test ./cmd/ao ./internal/mine ./internal/overnight`
- `cd cli && make build`
- `bash scripts/check-next-work-schema-rows.sh`
- `bash scripts/validate-next-work-contract-parity.sh`
- `markdownlint docs/contracts/dream-run-contract.md skills/dream/SKILL.md skills-codex/dream/SKILL.md`
- `bash scripts/validate-codex-generated-artifacts.sh --scope worktree`
- `bash scripts/validate-codex-rpi-contract.sh`
- `bash scripts/validate-codex-lifecycle-guards.sh`

## Notes

- `scripts/pre-push-gate.sh --fast` was run and failed on pre-existing dirty `docs/INDEX.md` state in the canonical root plus the resulting contract compatibility read of that dirty index. That file is intentionally not included in this PR.
- `bd create` was attempted earlier in this worktree but `bd` is not initialized here (`issue_prefix config is missing`), so this proceeded from the user-selected RFC proposal rather than a bead claim.
