### PR TITLE
fix(nightly): ship 5 retrospective code fixes (truncate, standards gate, probed_stale_at, dream-probe, bd-install)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,6 +42,16 @@ jobs:
           chmod +x scripts/validate-hook-preflight.sh
           ./scripts/validate-hook-preflight.sh
 
+  standards-injector-completeness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify standards-injector references are complete
+        run: |
+          chmod +x scripts/check-standards-injector-completeness.sh
+          ./scripts/check-standards-injector-completeness.sh
+
   validate-hooks-doc-parity:
     runs-on: ubuntu-latest
     steps:
@@ -845,7 +855,7 @@ jobs:
           echo "File manifests found in evidence — overlap check delegated to file-manifest-overlap job"
 
   summary:
-    needs: [doc-release-gate, smoke-test, hook-preflight, validate-hooks-doc-parity, validate-ci-policy-parity, codex-runtime-sections, embedded-sync, cli-docs-parity, shellcheck, markdownlint, security-scan, security-toolchain-gate, skill-integrity, skill-schema, skill-dependency-check, contract-compatibility-gate, memrl-health, plugin-load-test, go-build, windows-smoke, cli-integration, json-flag-consistency, file-manifest-overlap, doctor-check, skill-lint, learning-coherence, bats-tests, check-test-staleness, swarm-evidence]
+    needs: [doc-release-gate, smoke-test, hook-preflight, standards-injector-completeness, validate-hooks-doc-parity, validate-ci-policy-parity, codex-runtime-sections, embedded-sync, cli-docs-parity, shellcheck, markdownlint, security-scan, security-toolchain-gate, skill-integrity, skill-schema, skill-dependency-check, contract-compatibility-gate, memrl-health, plugin-load-test, go-build, windows-smoke, cli-integration, json-flag-consistency, file-manifest-overlap, doctor-check, skill-lint, learning-coherence, bats-tests, check-test-staleness, swarm-evidence]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -855,6 +865,7 @@ jobs:
           echo "doc-release-gate: ${{ needs.doc-release-gate.result }}"
           echo "smoke-test: ${{ needs.smoke-test.result }}"
           echo "hook-preflight: ${{ needs.hook-preflight.result }}"
+          echo "standards-injector-completeness: ${{ needs.standards-injector-completeness.result }}"
           echo "validate-hooks-doc-parity: ${{ needs.validate-hooks-doc-parity.result }}"
           echo "validate-ci-policy-parity: ${{ needs.validate-ci-policy-parity.result }}"
           echo "codex-runtime-sections: ${{ needs.codex-runtime-sections.result }}"
@@ -885,6 +896,7 @@ jobs:
           if [[ "${{ needs.doc-release-gate.result }}" != "success" ]] || \
              [[ "${{ needs.smoke-test.result }}" != "success" ]] || \
              [[ "${{ needs.hook-preflight.result }}" != "success" ]] || \
+             [[ "${{ needs.standards-injector-completeness.result }}" != "success" ]] || \
              [[ "${{ needs.validate-hooks-doc-parity.result }}" != "success" ]] || \
              [[ "${{ needs.validate-ci-policy-parity.result }}" != "success" ]] || \
              [[ "${{ needs.codex-runtime-sections.result }}" != "success" ]] || \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,7 @@ This repo has a canonical root worktree. It owns the common `.git` directory and
 | **skill-lint** | Skill line limits, required sections, Claude feature coverage | Judgment-tier skill exceeds 600 lines; missing `## Examples` in user-facing skill |
 | **skill-schema** | SKILL frontmatter conforms to schema | Missing/invalid frontmatter fields in SKILL.md |
 | **smoke-test** | Repo smoke surface: skill frontmatter, placeholder/TODO hygiene, plus standalone Claude/Codex/OpenCode runtime smoke scripts and mocked headless runtime validation | Runtime install/bundle drift or placeholder/TODO regressions |
+| **standards-injector-completeness** | Every `<lang>` mapped by `hooks/standards-injector.sh` has a matching `skills/standards/references/<lang>.md` | Adding a case branch without the reference file (the hook fails open silently) |
 | **swarm-evidence** | Swarm evidence files and file manifests are valid | Missing or malformed swarm evidence artifacts |
 | **validate-ci-policy-parity** | AGENTS CI table and blocking policy match workflow summary enforcement | Docs say non-blocking/required but workflow differs |
 | **validate-hooks-doc-parity** | Scoped docs avoid stale hook-count claims vs runtime `hooks/hooks.json` | Runtime hook contract changed but docs were not updated |

--- a/cli/cmd/ao/overnight.go
+++ b/cli/cmd/ao/overnight.go
@@ -113,6 +113,11 @@ type overnightSummary struct {
 	Council        *overnightCouncilSummary `json:"council,omitempty" yaml:"council,omitempty"`
 	Dreamscape     *overnightDreamscape     `json:"dreamscape,omitempty" yaml:"dreamscape,omitempty"`
 	MorningPackets []overnightMorningPacket `json:"morning_packets,omitempty" yaml:"morning_packets,omitempty"`
+	// CuratorSuppressed lists candidate packets the Dream curator skipped
+	// because their cited file/symbol/script was already tracked. Lets
+	// operators see what was suppressed instead of a silent gap. Added
+	// 2026-04-26 nightly retro task 4.
+	CuratorSuppressed []dreamCuratorSuppression `json:"dream-curator-suppressed,omitempty" yaml:"dream-curator-suppressed,omitempty"`
 	Degraded       []string                 `json:"degraded,omitempty" yaml:"degraded,omitempty"`
 	Recommended    []string                 `json:"recommended,omitempty" yaml:"recommended,omitempty"`
 	NextAction     string                   `json:"next_action,omitempty" yaml:"next_action,omitempty"`

--- a/cli/cmd/ao/overnight_packets.go
+++ b/cli/cmd/ao/overnight_packets.go
@@ -55,9 +55,27 @@ type dreamPacketIssueRecord struct {
 	Title  string `json:"title"`
 }
 
+// dreamCuratorProbeTimeout caps each tractability probe so a slow grep
+// cannot stall packet emission. Per the 2026-04-26 retro the probe is a
+// "5-second" check; this constant matches the documented intent.
+const dreamCuratorProbeTimeout = 5 * time.Second
+
+// dreamCuratorSuppression records that the curator skipped a packet
+// because the tractability probe found the cited surface already
+// present. Surfaces in the run summary so operators can see what was
+// suppressed instead of getting a silent gap.
+type dreamCuratorSuppression struct {
+	PacketID string `json:"packet_id"`
+	Title    string `json:"title"`
+	Source   string `json:"source"`
+	Reason   string `json:"reason"`
+	Match    string `json:"match,omitempty"`
+}
+
 func executeDreamMorningPackets(cwd string, summary *overnightSummary) {
 	snapshotDreamPacketYield(summary)
-	plans, err := buildDreamMorningPacketPlans(cwd, *summary)
+	plans, suppressed, err := buildDreamMorningPacketPlans(cwd, *summary)
+	summary.CuratorSuppressed = append(summary.CuratorSuppressed, suppressed...)
 	if err != nil {
 		setOvernightStepStatus(summary, "morning-packets", "soft-fail", summary.Artifacts["morning_packets_json"], err.Error())
 		setOvernightStepStatus(summary, "bead-sync", "soft-fail", "", "packet synthesis aborted")
@@ -90,11 +108,11 @@ func executeDreamMorningPackets(cwd string, summary *overnightSummary) {
 	refreshOvernightTelemetry(summary)
 }
 
-func buildDreamMorningPacketPlans(cwd string, summary overnightSummary) ([]dreamMorningPacketPlan, error) {
+func buildDreamMorningPacketPlans(cwd string, summary overnightSummary) ([]dreamMorningPacketPlan, []dreamCuratorSuppression, error) {
 	nextWorkPath := filepath.Join(cwd, ".agents", "rpi", "next-work.jsonl")
 	entries, err := readQueueEntries(nextWorkPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	repoFilter := detectRepoName(cwd)
@@ -102,9 +120,26 @@ func buildDreamMorningPacketPlans(cwd string, summary overnightSummary) ([]dream
 	selectedIDs := make(map[string]struct{}, len(selections))
 	existingByID := indexDreamExistingQueueItems(entries)
 
+	var suppressed []dreamCuratorSuppression
 	plans := make([]dreamMorningPacketPlan, 0, maxDreamMorningPackets)
 	for i, sel := range selections {
 		packet := buildDreamQueuePacket(summary, sel, i+1)
+		// Curator-side tractability probe: per the 2026-04-26 retro,
+		// the curator emitted the same stale packets ("philosophy doc",
+		// "next-work schema v1.3") three nightlies in a row because no
+		// gate verified the cited surface wasn't already shipped. If
+		// the probe is conclusively stale, suppress and record; if
+		// inconclusive, emit normally.
+		if reason, match, ok := probeDreamPacketStaleness(cwd, packet); ok {
+			suppressed = append(suppressed, dreamCuratorSuppression{
+				PacketID: packet.ID,
+				Title:    strings.TrimSpace(packet.Title),
+				Source:   strings.TrimSpace(packet.Source),
+				Reason:   reason,
+				Match:    match,
+			})
+			continue
+		}
 		if packet.ID != "" {
 			selectedIDs[packet.ID] = struct{}{}
 		}
@@ -123,6 +158,16 @@ func buildDreamMorningPacketPlans(cwd string, summary overnightSummary) ([]dream
 		if _, exists := selectedIDs[packet.ID]; exists {
 			continue
 		}
+		if reason, match, ok := probeDreamPacketStaleness(cwd, packet); ok {
+			suppressed = append(suppressed, dreamCuratorSuppression{
+				PacketID: packet.ID,
+				Title:    strings.TrimSpace(packet.Title),
+				Source:   strings.TrimSpace(packet.Source),
+				Reason:   reason,
+				Match:    match,
+			})
+			continue
+		}
 		packet.Rank = len(plans) + 1
 		plan := dreamMorningPacketPlan{Packet: packet}
 		if existing, ok := existingByID[packet.ID]; ok {
@@ -135,8 +180,87 @@ func buildDreamMorningPacketPlans(cwd string, summary overnightSummary) ([]dream
 		selectedIDs[packet.ID] = struct{}{}
 	}
 
-	return plans, nil
+	return plans, suppressed, nil
 }
+
+// probeDreamPacketStaleness runs a 5-second tractability probe against the
+// candidate packet. It checks two surfaces:
+//  1. TargetFiles entries — if any cited path already exists on disk, the
+//     packet is treated as already done.
+//  2. The morning_command and title — if a unique-looking script reference
+//     in either field resolves to an existing scripts/* file, treat as done.
+//
+// On conclusive staleness it returns (reason, match, true). On inconclusive
+// signals it returns (_, _, false) and the curator emits the packet normally.
+func probeDreamPacketStaleness(cwd string, packet overnightMorningPacket) (string, string, bool) {
+	deadline := time.Now().Add(dreamCuratorProbeTimeout)
+	for _, raw := range packet.TargetFiles {
+		if time.Now().After(deadline) {
+			return "", "", false
+		}
+		path := strings.TrimSpace(raw)
+		if path == "" {
+			continue
+		}
+		// Skip absolute paths outside the repo and obvious URLs.
+		if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+			continue
+		}
+		candidate := path
+		if !filepath.IsAbs(candidate) {
+			candidate = filepath.Join(cwd, candidate)
+		}
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return "target file already tracked", path, true
+		}
+	}
+
+	// Look for "scripts/<name>.sh" tokens in the morning command or title.
+	// These are the most common false-positive surface from the retro.
+	for _, hay := range []string{packet.MorningCommand, packet.Title} {
+		if time.Now().After(deadline) {
+			break
+		}
+		token := extractScriptsRef(hay)
+		if token == "" {
+			continue
+		}
+		candidate := filepath.Join(cwd, token)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return "scripts/ reference already tracked", token, true
+		}
+	}
+
+	return "", "", false
+}
+
+// extractScriptsRef pulls the first scripts/<...>.sh occurrence from s.
+// Returns "" when no match is found. Kept narrow so we don't false-positive
+// on prose mentions of "scripts" in general.
+func extractScriptsRef(s string) string {
+	const prefix = "scripts/"
+	idx := strings.Index(s, prefix)
+	if idx < 0 {
+		return ""
+	}
+	rest := s[idx:]
+	end := len(rest)
+	for i, r := range rest {
+		switch {
+		case r == ' ', r == '"', r == '\'', r == ')', r == '`', r == '\n':
+			end = i
+		}
+		if end != len(rest) {
+			break
+		}
+	}
+	tok := rest[:end]
+	if !strings.HasSuffix(tok, ".sh") {
+		return ""
+	}
+	return tok
+}
+
 
 func rankDreamMorningQueueSelections(cwd string, entries []nextWorkEntry, repoFilter string, limit int) []queueSelection {
 	if limit <= 0 || len(entries) == 0 {

--- a/cli/cmd/ao/overnight_packets_test.go
+++ b/cli/cmd/ao/overnight_packets_test.go
@@ -316,6 +316,95 @@ esac
 	}
 }
 
+// TestExecuteDreamMorningPackets_SuppressesPacketWhenTargetFileExists guards
+// the 2026-04-26 retro fix: the curator must run a tractability probe before
+// emitting a packet whose first_move grep would match an existing tracked
+// file. The synthetic queue item below points at cli/cmd/ao/overnight.go,
+// which is shipped — so the curator should suppress instead of emit and
+// surface a dream-curator-suppressed entry.
+func TestExecuteDreamMorningPackets_SuppressesPacketWhenTargetFileExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	nextWorkPath := filepath.Join(tmpDir, ".agents", "rpi", "next-work.jsonl")
+	if err := os.MkdirAll(filepath.Dir(nextWorkPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Drop a sentinel file inside the tmp repo and have the queue item
+	// cite it as target_files. Probe should hit, packet should be suppressed.
+	relTarget := "cli/cmd/ao/overnight.go"
+	if err := os.MkdirAll(filepath.Join(tmpDir, "cli", "cmd", "ao"), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, relTarget), []byte("// already shipped\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	queue := `{"source_epic":"dream-stale","timestamp":"2026-04-26T12:00:00Z","items":[{"id":"stale-1","title":"Ship overnight.go feature already done","type":"task","severity":"high","source":"council-finding","description":"Cited target file already exists.","target_files":["cli/cmd/ao/overnight.go"],"consumed":false,"claim_status":"available"}],"consumed":false,"claim_status":"available"}`
+	if err := os.WriteFile(nextWorkPath, []byte(queue+"\n"), 0o644); err != nil {
+		t.Fatalf("write queue: %v", err)
+	}
+
+	binDir := t.TempDir()
+	writeExecutable(t, binDir, "bd", "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", binDir)
+
+	summary := newDreamPacketTestSummary(t, tmpDir, "")
+	executeDreamMorningPackets(tmpDir, &summary)
+
+	if len(summary.MorningPackets) != 0 {
+		t.Fatalf("expected suppression, got %d packets: %+v", len(summary.MorningPackets), summary.MorningPackets)
+	}
+	if len(summary.CuratorSuppressed) != 1 {
+		t.Fatalf("expected 1 suppression, got %d: %+v", len(summary.CuratorSuppressed), summary.CuratorSuppressed)
+	}
+	got := summary.CuratorSuppressed[0]
+	if got.PacketID != "stale-1" {
+		t.Errorf("suppression packet_id = %q, want stale-1", got.PacketID)
+	}
+	if got.Match != "cli/cmd/ao/overnight.go" {
+		t.Errorf("suppression match = %q, want cli/cmd/ao/overnight.go", got.Match)
+	}
+	if got.Reason == "" {
+		t.Error("suppression reason should be non-empty")
+	}
+}
+
+// TestExecuteDreamMorningPackets_EmitsWhenProbeInconclusive verifies that
+// the probe does NOT suppress when no cited surface resolves on disk —
+// inconclusive evidence should let the packet through normally.
+func TestExecuteDreamMorningPackets_EmitsWhenProbeInconclusive(t *testing.T) {
+	tmpDir := t.TempDir()
+	nextWorkPath := filepath.Join(tmpDir, ".agents", "rpi", "next-work.jsonl")
+	if err := os.MkdirAll(filepath.Dir(nextWorkPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	queue := `{"source_epic":"dream-fresh","timestamp":"2026-04-26T12:00:00Z","items":[{"id":"fresh-1","title":"Implement brand new module","type":"feature","severity":"high","source":"council-finding","description":"No file cited yet.","target_files":["cli/internal/totally-new-package/foo.go"],"consumed":false,"claim_status":"available"}],"consumed":false,"claim_status":"available"}`
+	if err := os.WriteFile(nextWorkPath, []byte(queue+"\n"), 0o644); err != nil {
+		t.Fatalf("write queue: %v", err)
+	}
+
+	binDir := t.TempDir()
+	writeExecutable(t, binDir, "bd", `#!/bin/sh
+case "$1" in
+  list) echo '[]' ;;
+  create) echo '[{"id":"na-fresh","status":"open","title":"Implement brand new module"}]' ;;
+  update) echo '[{"id":"na-fresh","status":"open","title":"Implement brand new module"}]' ;;
+  *) echo "unexpected" >&2; exit 1 ;;
+esac
+`)
+	t.Setenv("PATH", binDir)
+
+	summary := newDreamPacketTestSummary(t, tmpDir, "")
+	executeDreamMorningPackets(tmpDir, &summary)
+
+	if len(summary.MorningPackets) != 1 {
+		t.Fatalf("expected 1 packet to emit, got %d", len(summary.MorningPackets))
+	}
+	if len(summary.CuratorSuppressed) != 0 {
+		t.Fatalf("expected 0 suppressions, got %+v", summary.CuratorSuppressed)
+	}
+}
+
 func newDreamPacketTestSummary(t *testing.T, repoRoot, goal string) overnightSummary {
 	t.Helper()
 

--- a/cli/cmd/ao/rpi_mark_probed.go
+++ b/cli/cmd/ao/rpi_mark_probed.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	cliRPI "github.com/boshu2/agentops/cli/internal/rpi"
+)
+
+var (
+	rpiMarkProbedID    string
+	rpiMarkProbedBy    string
+	rpiMarkProbedQueue string
+	rpiMarkProbedAt    string
+)
+
+func init() {
+	markProbedCmd := &cobra.Command{
+		Use:   "mark-probed",
+		Short: "Stamp a next-work item as probed-stale without consuming it",
+		Long: `Set probed_stale_at and probed_by on a next-work item whose tractability
+probe (file/symbol/script grep) matched existing tracked work. The item
+stays unconsumed (consumption requires real proof), but later nightlies
+can read these fields to skip re-probing the same item.
+
+The item is matched by --id (matches item.id, item.bead_id, or
+item.title). The first matching item is stamped; if multiple items
+share the identifier the gate is the queue's responsibility, not this
+command.`,
+		RunE: runRPIMarkProbed,
+	}
+	markProbedCmd.Flags().StringVar(&rpiMarkProbedID, "id", "", "Item identifier (id, bead_id, or title) to stamp (required)")
+	markProbedCmd.Flags().StringVar(&rpiMarkProbedBy, "by", "", "Probe author tag, e.g. nightly/2026-04-26-v3 (required)")
+	markProbedCmd.Flags().StringVar(&rpiMarkProbedQueue, "queue", ".agents/rpi/next-work.jsonl", "Path to next-work.jsonl")
+	markProbedCmd.Flags().StringVar(&rpiMarkProbedAt, "at", "", "Override the probed-at timestamp (RFC3339); defaults to now")
+	rpiCmd.AddCommand(markProbedCmd)
+}
+
+func runRPIMarkProbed(_ *cobra.Command, _ []string) error {
+	if strings.TrimSpace(rpiMarkProbedID) == "" {
+		return errors.New("--id is required")
+	}
+	if strings.TrimSpace(rpiMarkProbedBy) == "" {
+		return errors.New("--by is required")
+	}
+
+	stamp := rpiMarkProbedAt
+	if stamp == "" {
+		stamp = time.Now().UTC().Format(time.RFC3339)
+	}
+	if _, err := time.Parse(time.RFC3339, stamp); err != nil {
+		return fmt.Errorf("--at must be RFC3339: %w", err)
+	}
+
+	queuePath := rpiMarkProbedQueue
+	if !filepath.IsAbs(queuePath) {
+		// Resolve relative to repo root if we're in one; otherwise relative to cwd.
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("getwd: %w", err)
+		}
+		queuePath = filepath.Join(cwd, queuePath)
+	}
+
+	raw, err := os.ReadFile(queuePath)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", queuePath, err)
+	}
+
+	var outLines []string
+	matched := 0
+	scanner := bufio.NewScanner(strings.NewReader(string(raw)))
+	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			outLines = append(outLines, line)
+			continue
+		}
+		var entry cliRPI.NextWorkEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			// Preserve malformed lines verbatim — schema gate handles them separately.
+			outLines = append(outLines, line)
+			continue
+		}
+		changed := false
+		for i := range entry.Items {
+			it := &entry.Items[i]
+			if matchesProbedID(it, rpiMarkProbedID) {
+				it.ProbedStaleAt = &stamp
+				it.ProbedBy = &rpiMarkProbedBy
+				changed = true
+				matched++
+				break // first matching item per entry; stop here
+			}
+		}
+		if changed {
+			b, err := json.Marshal(&entry)
+			if err != nil {
+				return fmt.Errorf("re-marshalling entry: %w", err)
+			}
+			outLines = append(outLines, string(b))
+		} else {
+			outLines = append(outLines, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scanning queue: %w", err)
+	}
+	if matched == 0 {
+		return fmt.Errorf("no item matched id=%q in %s", rpiMarkProbedID, queuePath)
+	}
+
+	tmp := queuePath + ".tmp"
+	if err := os.WriteFile(tmp, []byte(strings.Join(outLines, "\n")+"\n"), 0o644); err != nil {
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := os.Rename(tmp, queuePath); err != nil {
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
+
+	fmt.Printf("ok: stamped probed_stale_at=%s probed_by=%s on %d item(s) in %s\n",
+		stamp, rpiMarkProbedBy, matched, queuePath)
+	return nil
+}
+
+func matchesProbedID(item *cliRPI.NextWorkItem, id string) bool {
+	if item == nil {
+		return false
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return false
+	}
+	return item.ID == id || item.BeadID == id || item.Title == id
+}

--- a/cli/cmd/ao/rpi_mark_probed_test.go
+++ b/cli/cmd/ao/rpi_mark_probed_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cliRPI "github.com/boshu2/agentops/cli/internal/rpi"
+)
+
+// writeQueueFile is a small helper that writes the supplied entries to a
+// freshly-created next-work.jsonl in a tmp dir and returns its path.
+func writeQueueFile(t *testing.T, entries []cliRPI.NextWorkEntry) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "next-work.jsonl")
+	var b strings.Builder
+	for _, e := range entries {
+		raw, err := json.Marshal(e)
+		if err != nil {
+			t.Fatalf("marshal entry: %v", err)
+		}
+		b.WriteString(string(raw))
+		b.WriteString("\n")
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		t.Fatalf("write queue file: %v", err)
+	}
+	return path
+}
+
+func resetMarkProbedFlags() {
+	rpiMarkProbedID = ""
+	rpiMarkProbedBy = ""
+	rpiMarkProbedQueue = ".agents/rpi/next-work.jsonl"
+	rpiMarkProbedAt = ""
+}
+
+func TestRPIMarkProbed_StampsMatchingItemByID(t *testing.T) {
+	defer resetMarkProbedFlags()
+
+	queue := writeQueueFile(t, []cliRPI.NextWorkEntry{
+		{
+			SourceEpic: "test-epic",
+			Timestamp:  "2026-04-26T00:00:00Z",
+			Items: []cliRPI.NextWorkItem{
+				{ID: "item-1", Title: "first", Type: "task", Severity: "low", Source: "council-finding", Description: "d1"},
+				{ID: "item-2", Title: "second", Type: "task", Severity: "low", Source: "council-finding", Description: "d2"},
+			},
+		},
+	})
+
+	rpiMarkProbedID = "item-2"
+	rpiMarkProbedBy = "nightly/2026-04-26-v3"
+	rpiMarkProbedQueue = queue
+	rpiMarkProbedAt = "2026-04-26T22:30:00Z"
+
+	if err := runRPIMarkProbed(nil, nil); err != nil {
+		t.Fatalf("runRPIMarkProbed: %v", err)
+	}
+
+	out, err := os.ReadFile(queue)
+	if err != nil {
+		t.Fatalf("read queue: %v", err)
+	}
+	var entry cliRPI.NextWorkEntry
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(out))), &entry); err != nil {
+		t.Fatalf("unmarshal queue line: %v\nraw=%s", err, out)
+	}
+
+	if entry.Items[0].ProbedStaleAt != nil {
+		t.Errorf("first item should be untouched; got ProbedStaleAt=%v", entry.Items[0].ProbedStaleAt)
+	}
+	if entry.Items[1].ProbedStaleAt == nil || *entry.Items[1].ProbedStaleAt != "2026-04-26T22:30:00Z" {
+		t.Errorf("second item ProbedStaleAt = %v, want %q", entry.Items[1].ProbedStaleAt, "2026-04-26T22:30:00Z")
+	}
+	if entry.Items[1].ProbedBy == nil || *entry.Items[1].ProbedBy != "nightly/2026-04-26-v3" {
+		t.Errorf("second item ProbedBy = %v, want %q", entry.Items[1].ProbedBy, "nightly/2026-04-26-v3")
+	}
+}
+
+func TestRPIMarkProbed_ErrorsWhenNoMatch(t *testing.T) {
+	defer resetMarkProbedFlags()
+
+	queue := writeQueueFile(t, []cliRPI.NextWorkEntry{
+		{
+			SourceEpic: "epic",
+			Timestamp:  "2026-04-26T00:00:00Z",
+			Items: []cliRPI.NextWorkItem{
+				{ID: "real-id", Title: "t", Type: "task", Severity: "low", Source: "council-finding", Description: "d"},
+			},
+		},
+	})
+
+	rpiMarkProbedID = "missing-id"
+	rpiMarkProbedBy = "test"
+	rpiMarkProbedQueue = queue
+
+	err := runRPIMarkProbed(nil, nil)
+	if err == nil {
+		t.Fatal("expected error for missing id, got nil")
+	}
+	if !strings.Contains(err.Error(), "no item matched") {
+		t.Errorf("error = %v, want it to mention no match", err)
+	}
+}
+
+func TestRPIMarkProbed_RequiresIDAndBy(t *testing.T) {
+	defer resetMarkProbedFlags()
+
+	rpiMarkProbedID = ""
+	rpiMarkProbedBy = "x"
+	if err := runRPIMarkProbed(nil, nil); err == nil || !strings.Contains(err.Error(), "--id is required") {
+		t.Errorf("missing --id: err=%v", err)
+	}
+
+	rpiMarkProbedID = "x"
+	rpiMarkProbedBy = ""
+	if err := runRPIMarkProbed(nil, nil); err == nil || !strings.Contains(err.Error(), "--by is required") {
+		t.Errorf("missing --by: err=%v", err)
+	}
+}
+
+func TestRPIMarkProbed_RejectsNonRFC3339At(t *testing.T) {
+	defer resetMarkProbedFlags()
+
+	queue := writeQueueFile(t, []cliRPI.NextWorkEntry{
+		{
+			SourceEpic: "epic",
+			Timestamp:  "2026-04-26T00:00:00Z",
+			Items: []cliRPI.NextWorkItem{
+				{ID: "id", Title: "t", Type: "task", Severity: "low", Source: "council-finding", Description: "d"},
+			},
+		},
+	})
+
+	rpiMarkProbedID = "id"
+	rpiMarkProbedBy = "test"
+	rpiMarkProbedQueue = queue
+	rpiMarkProbedAt = "2026/04/26 22:30:00"
+
+	err := runRPIMarkProbed(nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "RFC3339") {
+		t.Errorf("expected RFC3339 error, got %v", err)
+	}
+}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -1590,6 +1590,24 @@ ao rpi loop [goal] [flags]
       --supervisor                        Enable autonomous supervisor mode (lease lock, self-heal, retries, gates, cleanup)
 ```
 
+#### `ao rpi mark-probed`
+
+Set probed_stale_at and probed_by on a next-work item whose tractability
+
+```
+ao rpi mark-probed [flags]
+```
+
+**Flags:**
+
+```
+      --at string      Override the probed-at timestamp (RFC3339); defaults to now
+      --by string      Probe author tag, e.g. nightly/2026-04-26-v3 (required)
+  -h, --help           help for mark-probed
+      --id string      Item identifier (id, bead_id, or title) to stamp (required)
+      --queue string   Path to next-work.jsonl (default ".agents/rpi/next-work.jsonl")
+```
+
 #### `ao rpi nudge`
 
 Send a message to an active tmux-backed RPI phase session.

--- a/cli/internal/goals/measure.go
+++ b/cli/internal/goals/measure.go
@@ -41,17 +41,29 @@ func classifyResult(ctxErr, cmdErr error) string {
 	}
 }
 
-// truncateOutput limits output to 500 runes and trims whitespace.
-// Uses rune-aware truncation to avoid splitting multi-byte UTF-8 characters.
+// truncateOutput caps output at 500 runes by keeping the first 200 and last
+// 200 runes joined by a truncation marker, then trims whitespace.
+// Diagnostic gate output (e.g. check-flywheel-compounding.sh) often puts the
+// operator hint at the END of stdout; head-only truncation cuts that hint.
+// The head+tail shape preserves both the failure label and the trailing fix.
+const (
+	truncateLimit  = 500
+	truncateHead   = 200
+	truncateTail   = 200
+	truncateMarker = "\n…[truncated]…\n"
+)
+
 func truncateOutput(raw []byte) string {
 	s := string(raw)
 	// Fast path: byte length is an upper bound on rune count, so any output
 	// whose byte length is already within the cap needs no rune counting or
 	// []rune allocation. Hot paths (successful gates with short stdout)
 	// always take this branch.
-	if len(s) > 500 && utf8.RuneCountInString(s) > 500 {
+	if len(s) > truncateLimit && utf8.RuneCountInString(s) > truncateLimit {
 		runes := []rune(s)
-		s = string(runes[:500])
+		head := string(runes[:truncateHead])
+		tail := string(runes[len(runes)-truncateTail:])
+		s = head + truncateMarker + tail
 	}
 	return strings.TrimSpace(s)
 }

--- a/cli/internal/goals/measure_test.go
+++ b/cli/internal/goals/measure_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -63,7 +64,46 @@ func TestMeasureOne_OutputTruncated(t *testing.T) {
 	}
 	m := MeasureOne(goal, 5*time.Second)
 	if len([]rune(m.Output)) > 500 {
-		t.Errorf("output should be truncated to 500 runes, got %d", len([]rune(m.Output)))
+		t.Errorf("output should be truncated to <= 500 runes, got %d", len([]rune(m.Output)))
+	}
+}
+
+// TestTruncateOutput_PreservesTailHint guards against the regression seen in
+// the 2026-04-26 nightly retro: head-only truncation cut diagnostic hints
+// that operators rely on (e.g. "sessions must use 'ao lookup --cite ...'").
+// A 1000-rune input must keep both the leading FAIL label and the trailing
+// HINT_AT_END marker.
+func TestTruncateOutput_PreservesTailHint(t *testing.T) {
+	prefix := "FAIL: "
+	suffix := " — HINT_AT_END"
+	fillerRunes := 1000 - len([]rune(prefix)) - len([]rune(suffix))
+	input := prefix + strings.Repeat("x", fillerRunes) + suffix
+	if len([]rune(input)) != 1000 {
+		t.Fatalf("test fixture wrong size: got %d runes, want 1000", len([]rune(input)))
+	}
+
+	got := truncateOutput([]byte(input))
+	if !strings.Contains(got, "HINT_AT_END") {
+		t.Errorf("trailing hint dropped; output = %q", got)
+	}
+	if !strings.Contains(got, "FAIL:") {
+		t.Errorf("leading FAIL label dropped; output = %q", got)
+	}
+	if !strings.Contains(got, "[truncated]") {
+		t.Errorf("truncation marker missing; output = %q", got)
+	}
+	if got == input {
+		t.Errorf("output unchanged from input; truncation did not run")
+	}
+}
+
+// TestTruncateOutput_ShortInputUntouched verifies the fast path is unchanged
+// for inputs at or below the cap.
+func TestTruncateOutput_ShortInputUntouched(t *testing.T) {
+	short := "FAIL: small output — operator hint here"
+	got := truncateOutput([]byte(short))
+	if got != short {
+		t.Errorf("short input mutated: got %q, want %q", got, short)
 	}
 }
 
@@ -269,11 +309,10 @@ func TestTruncateOutput_MultiByteRunes(t *testing.T) {
 
 	result := truncateOutput(input)
 	runeCount := len([]rune(result))
-	if runeCount > 500 {
-		t.Errorf("expected <=500 runes, got %d", runeCount)
-	}
-	if runeCount < 500 {
-		t.Errorf("expected exactly 500 runes (not fewer), got %d", runeCount)
+	// New shape: head (200 CJK) + marker (ASCII + ellipses) + tail (200 CJK).
+	expected := truncateHead + len([]rune(truncateMarker)) + truncateTail
+	if runeCount != expected {
+		t.Errorf("rune count = %d, want %d (head+marker+tail shape)", runeCount, expected)
 	}
 	for i, r := range result {
 		if r == '\uFFFD' {

--- a/cli/internal/rpi/types.go
+++ b/cli/internal/rpi/types.go
@@ -78,6 +78,12 @@ type NextWorkItem struct {
 	ConsumedBy  *string           `json:"consumed_by,omitempty"`
 	ConsumedAt  *string           `json:"consumed_at,omitempty"`
 	FailedAt    *string           `json:"failed_at,omitempty"`
+	// ProbedStaleAt records when a tractability probe found this item
+	// already satisfied (file/symbol/script grep matched) but the item
+	// has not yet been marked consumed. Pairs with ProbedBy so future
+	// nightlies can skip the item without re-probing.
+	ProbedStaleAt *string `json:"probed_stale_at,omitempty"`
+	ProbedBy      *string `json:"probed_by,omitempty"`
 }
 
 // QueueSelection holds the selected item together with its source entry index

--- a/cli/internal/rpi/types_test.go
+++ b/cli/internal/rpi/types_test.go
@@ -1,0 +1,70 @@
+package rpi
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestNextWorkItem_ProbedFieldsRoundTrip verifies the probed_stale_at /
+// probed_by fields survive a Marshal/Unmarshal round trip and end up in the
+// expected JSON shape. Added for the 2026-04-26 nightly retro task 3 so a
+// future schema change can't silently drop the field.
+func TestNextWorkItem_ProbedFieldsRoundTrip(t *testing.T) {
+	stamp := "2026-04-26T22:30:00Z"
+	by := "nightly/2026-04-26-v3"
+	in := NextWorkItem{
+		Title:         "stale item",
+		Type:          "tech-debt",
+		Severity:      "low",
+		Source:        "council-finding",
+		Description:   "already done — probe matched",
+		ProbedStaleAt: &stamp,
+		ProbedBy:      &by,
+	}
+
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	if !strings.Contains(got, `"probed_stale_at":"2026-04-26T22:30:00Z"`) {
+		t.Errorf("probed_stale_at missing or wrong shape; json = %s", got)
+	}
+	if !strings.Contains(got, `"probed_by":"nightly/2026-04-26-v3"`) {
+		t.Errorf("probed_by missing or wrong shape; json = %s", got)
+	}
+
+	var out NextWorkItem
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.ProbedStaleAt == nil || *out.ProbedStaleAt != stamp {
+		t.Errorf("ProbedStaleAt round-trip = %v, want %q", out.ProbedStaleAt, stamp)
+	}
+	if out.ProbedBy == nil || *out.ProbedBy != by {
+		t.Errorf("ProbedBy round-trip = %v, want %q", out.ProbedBy, by)
+	}
+}
+
+// TestNextWorkItem_ProbedFieldsOmittedWhenAbsent verifies omitempty
+// suppresses the new fields for items that have never been probed.
+func TestNextWorkItem_ProbedFieldsOmittedWhenAbsent(t *testing.T) {
+	in := NextWorkItem{
+		Title:    "fresh item",
+		Type:     "task",
+		Severity: "medium",
+		Source:   "evolve-generator",
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	if strings.Contains(got, "probed_stale_at") {
+		t.Errorf("expected probed_stale_at to be omitted when nil; json = %s", got)
+	}
+	if strings.Contains(got, "probed_by") {
+		t.Errorf("expected probed_by to be omitted when nil; json = %s", got)
+	}
+}

--- a/docs/contracts/next-work.schema.md
+++ b/docs/contracts/next-work.schema.md
@@ -59,6 +59,8 @@ One actionable follow-up item.
 | `consumed_by` | string or null | no | Consumer that finalized this item |
 | `consumed_at` | string (ISO-8601) or null | no | When this item was consumed |
 | `failed_at` | string (ISO-8601) or null | no | Last failure timestamp for retry ordering; retry metadata only, not completion proof |
+| `probed_stale_at` | string (ISO-8601) or null | no | When a probe found this item already done (file/symbol/script grep matched) but the item was not yet marked consumed. Lets the next nightly skip the same item without re-probing. |
+| `probed_by` | string or null | no | Identifier of the run that wrote `probed_stale_at` (e.g. `nightly/2026-04-26-v3`). Pairs with `probed_stale_at` so probe writes are auditable. |
 
 Compatibility notes:
 - omitted item `claim_status` means `available`

--- a/scripts/check-standards-injector-completeness.sh
+++ b/scripts/check-standards-injector-completeness.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# check-standards-injector-completeness.sh
+#
+# Asserts that every <lang> mapped by hooks/standards-injector.sh has a
+# corresponding skills/standards/references/<lang>.md file. The hook fails
+# open when a reference is missing — that's how `.js` lost standards inject
+# for weeks until the 2026-04-26 nightly retro caught it. This gate makes
+# the omission loud at lint time.
+#
+# Exit 0: every mapped lang has a reference file.
+# Exit 1: at least one mapped lang is missing its reference file.
+# Exit 2: parser failed (case statement not where expected).
+
+set -euo pipefail
+
+# Resolve repo root from script location.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Allow override for tests (so the bats harness can point at a fake repo).
+HOOK_FILE="${STANDARDS_INJECTOR_HOOK:-$REPO_ROOT/hooks/standards-injector.sh}"
+REFS_DIR="${STANDARDS_REFERENCES_DIR:-$REPO_ROOT/skills/standards/references}"
+
+if [[ ! -f "$HOOK_FILE" ]]; then
+    echo "ERROR: hook file not found: $HOOK_FILE" >&2
+    exit 2
+fi
+if [[ ! -d "$REFS_DIR" ]]; then
+    echo "ERROR: references dir not found: $REFS_DIR" >&2
+    exit 2
+fi
+
+# Parse case statement of form:
+#   case "$EXT" in
+#       py)        LANG="python" ;;
+#       ts|tsx)    LANG="typescript" ;;
+#       *)         exit 0 ;;
+#   esac
+#
+# Strategy: extract lines containing LANG="..." and pull the language name
+# out of the right side. The case-pattern on the left can have | alternation,
+# but we only care about the LANG mapping (one entry per pattern → one ref
+# file). The wildcard pattern *) does not assign LANG so it is skipped.
+LANGS=$(awk '
+    /case[[:space:]]+"\$EXT"[[:space:]]+in/ { in_case = 1; next }
+    in_case && /^[[:space:]]*esac/ { in_case = 0; next }
+    in_case && /LANG=/ {
+        # Extract the value inside LANG="..."
+        if (match($0, /LANG="[^"]+"/)) {
+            s = substr($0, RSTART + 6, RLENGTH - 7)
+            print s
+        }
+    }
+' "$HOOK_FILE" | sort -u)
+
+if [[ -z "$LANGS" ]]; then
+    echo "ERROR: parser found no LANG= assignments inside case block of $HOOK_FILE" >&2
+    echo "       This is a parser failure, not a missing-language failure." >&2
+    exit 2
+fi
+
+missing=()
+for lang in $LANGS; do
+    if [[ ! -f "$REFS_DIR/$lang.md" ]]; then
+        missing+=("$lang")
+    fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "FAIL: standards-injector maps language(s) with no reference file:" >&2
+    for lang in "${missing[@]}"; do
+        echo "  - $lang  (expected: $REFS_DIR/$lang.md)" >&2
+    done
+    echo >&2
+    echo "Hint: either add the missing reference file under skills/standards/references/," >&2
+    echo "      or remove the language from the case statement in $HOOK_FILE." >&2
+    exit 1
+fi
+
+echo "OK: all $(echo "$LANGS" | wc -l | tr -d ' ') languages mapped by standards-injector.sh have reference files."
+exit 0

--- a/scripts/install-bd.sh
+++ b/scripts/install-bd.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# install-bd.sh — install the `bd` (beads) CLI to ~/.local/bin/bd.
+#
+# Beads has been "unavailable" in three consecutive nightly runs (2026-04-26
+# retro task 5). Upstream publishes signed binaries for darwin/linux/windows
+# under https://github.com/steveyegge/beads/releases. This script detects the
+# platform, downloads the matching tarball, and verifies the binary launches.
+#
+# Idempotent: re-running with bd already on PATH at the requested version is
+# a no-op (exit 0). Use --force to redownload.
+#
+# Examples:
+#   scripts/install-bd.sh                   # install latest tagged release
+#   scripts/install-bd.sh --version v1.0.3  # pin a version
+#   scripts/install-bd.sh --force           # redownload even if installed
+#
+# Exit codes:
+#   0   bd installed (or already present at the requested version)
+#   1   download or extraction failed
+#   2   unsupported platform / arch
+#   3   verification failed (binary did not launch)
+
+set -euo pipefail
+
+REPO="steveyegge/beads"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+VERSION=""
+FORCE=0
+
+usage() {
+    sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version) VERSION="$2"; shift 2 ;;
+        --force)   FORCE=1; shift ;;
+        --install-dir) INSTALL_DIR="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown flag: $1" >&2; exit 1 ;;
+    esac
+done
+
+# --- detect platform ---
+uname_s="$(uname -s)"
+uname_m="$(uname -m)"
+case "$uname_s" in
+    Darwin)      os="darwin" ;;
+    Linux)       os="linux" ;;
+    *)           echo "unsupported OS: $uname_s" >&2; exit 2 ;;
+esac
+case "$uname_m" in
+    x86_64|amd64) arch="amd64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *)            echo "unsupported arch: $uname_m" >&2; exit 2 ;;
+esac
+
+# --- resolve version ---
+if [[ -z "$VERSION" ]]; then
+    if ! command -v curl >/dev/null 2>&1; then
+        echo "curl is required to resolve latest version" >&2
+        exit 1
+    fi
+    VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+        | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)"
+    if [[ -z "$VERSION" ]]; then
+        echo "could not resolve latest beads release tag" >&2
+        exit 1
+    fi
+fi
+
+# --- short-circuit if already installed at the requested version ---
+if [[ "$FORCE" -eq 0 ]] && command -v bd >/dev/null 2>&1; then
+    have="$(bd version 2>&1 | head -1 || true)"
+    # bd version output is like "bd version 1.0.3 (Homebrew)"
+    if [[ "$have" == *"${VERSION#v}"* ]]; then
+        echo "bd ${VERSION} already installed at $(command -v bd) — skipping (--force to override)"
+        exit 0
+    fi
+fi
+
+# --- download and extract ---
+ver_no_v="${VERSION#v}"
+asset="beads_${ver_no_v}_${os}_${arch}.tar.gz"
+url="https://github.com/${REPO}/releases/download/${VERSION}/${asset}"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+echo "downloading $url"
+if ! curl -fsSL "$url" -o "$tmp_dir/$asset"; then
+    echo "download failed: $url" >&2
+    exit 1
+fi
+
+echo "extracting $asset"
+if ! tar -xzf "$tmp_dir/$asset" -C "$tmp_dir"; then
+    echo "extraction failed" >&2
+    exit 1
+fi
+
+# --- find the bd binary in the extracted tree ---
+binary=""
+for candidate in "$tmp_dir/bd" "$tmp_dir/beads" "$tmp_dir"/*/bd "$tmp_dir"/*/beads; do
+    if [[ -f "$candidate" && -x "$candidate" ]]; then
+        binary="$candidate"
+        break
+    fi
+done
+if [[ -z "$binary" ]]; then
+    echo "could not locate bd binary in tarball" >&2
+    ls -R "$tmp_dir" >&2
+    exit 1
+fi
+
+# --- install ---
+mkdir -p "$INSTALL_DIR"
+target="$INSTALL_DIR/bd"
+cp "$binary" "$target"
+chmod +x "$target"
+echo "installed bd to $target"
+
+# --- verify ---
+if ! "$target" version >/dev/null 2>&1; then
+    echo "verification failed: $target version did not launch" >&2
+    exit 3
+fi
+
+actual="$("$target" version 2>&1 | head -1)"
+echo "verified: $actual"
+
+# --- PATH hint ---
+case ":$PATH:" in
+    *":$INSTALL_DIR:"*) ;;
+    *)
+        echo
+        echo "note: $INSTALL_DIR is not on \$PATH. Add this to your shell rc:"
+        echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+        ;;
+esac
+
+exit 0

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -775,6 +775,22 @@ else
     skip "hook preflight"
 fi
 
+# --- 27b. Standards-injector reference completeness ---
+if needs_check hook; then
+    if [[ -x scripts/check-standards-injector-completeness.sh ]]; then
+        if standards_inj_output="$(./scripts/check-standards-injector-completeness.sh 2>&1)"; then
+            pass "standards-injector references complete"
+        else
+            fail "standards-injector references complete"
+            indent_output "$standards_inj_output"
+        fi
+    else
+        fail "missing executable: scripts/check-standards-injector-completeness.sh"
+    fi
+else
+    skip "standards-injector references complete"
+fi
+
 # --- 28. Hooks/docs parity ---
 if needs_check hook; then
     if [[ -x scripts/validate-hooks-doc-parity.sh ]]; then

--- a/tests/scripts/check-next-work-schema-rows.bats
+++ b/tests/scripts/check-next-work-schema-rows.bats
@@ -85,6 +85,17 @@ EOF
     [[ "$output" == *"claim_status=claimed"* ]]
 }
 
+@test "accepts items carrying probed_stale_at and probed_by" {
+    # 2026-04-26 nightly retro task 3: schema gate must accept the new
+    # optional fields without flagging them as drift.
+    cat > "$QUEUE" <<'EOF'
+{"source_epic":"e1","timestamp":"2026-04-26T00:00:00Z","items":[{"title":"probed item","type":"tech-debt","severity":"medium","source":"council-finding","description":"d","probed_stale_at":"2026-04-26T22:30:00Z","probed_by":"nightly/2026-04-26-v3"}],"consumed":false,"claim_status":"available"}
+EOF
+    run env QUEUE="$QUEUE" bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"* ]]
+}
+
 @test "skips empty lines" {
     printf '\n\n' > "$QUEUE"
     cat >> "$QUEUE" <<'EOF'

--- a/tests/scripts/check-standards-injector-completeness.bats
+++ b/tests/scripts/check-standards-injector-completeness.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+
+# Regression tests for scripts/check-standards-injector-completeness.sh.
+# Each test builds a self-contained tmpdir with a fake standards-injector.sh
+# and a refs/ directory, then runs the gate via the env-var overrides that
+# the script supports (STANDARDS_INJECTOR_HOOK, STANDARDS_REFERENCES_DIR).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/check-standards-injector-completeness.sh"
+
+    TMP_DIR="$(mktemp -d)"
+    HOOK_FILE="$TMP_DIR/standards-injector.sh"
+    REFS_DIR="$TMP_DIR/refs"
+    mkdir -p "$REFS_DIR"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+# Helper: write a fake hook with a given case body. Wraps the snippet in the
+# minimum boilerplate the parser expects (`case "$EXT" in ... esac`).
+write_hook() {
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf 'EXT="${1##*.}"\n'
+        printf 'case "$EXT" in\n'
+        printf '%s\n' "$1"
+        printf '    *)         exit 0 ;;\n'
+        printf 'esac\n'
+    } > "$HOOK_FILE"
+}
+
+# Helper: create empty reference files for the listed langs.
+make_refs() {
+    for lang in "$@"; do
+        : > "$REFS_DIR/$lang.md"
+    done
+}
+
+@test "script exists and is executable" {
+    [ -f "$SCRIPT" ]
+    [ -x "$SCRIPT" ]
+}
+
+@test "passes when every mapped language has a reference file" {
+    write_hook '    py)        LANG="python" ;;
+    go)        LANG="go" ;;
+    sh)        LANG="shell" ;;'
+    make_refs python go shell
+
+    run env STANDARDS_INJECTOR_HOOK="$HOOK_FILE" STANDARDS_REFERENCES_DIR="$REFS_DIR" "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK"* ]]
+}
+
+@test "fails and names the missing language when one reference is absent" {
+    write_hook '    py)        LANG="python" ;;
+    js)        LANG="javascript" ;;
+    sh)        LANG="shell" ;;'
+    make_refs python shell  # javascript intentionally missing
+
+    run env STANDARDS_INJECTOR_HOOK="$HOOK_FILE" STANDARDS_REFERENCES_DIR="$REFS_DIR" "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"FAIL"* ]]
+    [[ "$output" == *"javascript"* ]]
+    # Should not falsely flag the languages that do have refs.
+    [[ "$output" != *"- python"* ]]
+    [[ "$output" != *"- shell"* ]]
+}
+
+@test "handles | alternation in case patterns (ts|tsx maps to one lang)" {
+    write_hook '    ts|tsx)    LANG="typescript" ;;
+    yaml|yml)  LANG="yaml" ;;'
+    make_refs typescript yaml
+
+    run env STANDARDS_INJECTOR_HOOK="$HOOK_FILE" STANDARDS_REFERENCES_DIR="$REFS_DIR" "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"2 languages"* ]]
+}
+
+@test "fails with parser error code 2 when case block has no LANG mappings" {
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf 'case "$EXT" in\n'
+        printf '    *) exit 0 ;;\n'
+        printf 'esac\n'
+    } > "$HOOK_FILE"
+
+    run env STANDARDS_INJECTOR_HOOK="$HOOK_FILE" STANDARDS_REFERENCES_DIR="$REFS_DIR" "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"parser"* ]] || [[ "$output" == *"no LANG"* ]]
+}
+
+@test "real repo passes the completeness gate" {
+    # Sanity check: the repo as committed must be in a passing state.
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+}

--- a/tests/scripts/install-bd.bats
+++ b/tests/scripts/install-bd.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+# Lightweight smoke tests for scripts/install-bd.sh. Network-dependent paths
+# (download, version-resolve from GitHub) are skipped here to keep CI offline-
+# safe; the verify-existing-install short-circuit and the unsupported-platform
+# branches are exercised.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/install-bd.sh"
+}
+
+@test "script exists and is executable" {
+    [ -f "$SCRIPT" ]
+    [ -x "$SCRIPT" ]
+}
+
+@test "--help prints usage and exits 0" {
+    run "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"install the \`bd\`"* ]]
+    [[ "$output" == *"--version"* ]]
+}
+
+@test "rejects unknown flag" {
+    run "$SCRIPT" --bogus
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unknown flag"* ]]
+}
+
+@test "short-circuits when bd is already installed at the requested version" {
+    if ! command -v bd >/dev/null 2>&1; then
+        skip "bd not on PATH on this host"
+    fi
+    have="$(bd version 2>&1 | head -1 || true)"
+    # Pull the version number out of "bd version 1.0.3 (Homebrew)".
+    ver="$(printf '%s' "$have" | sed -n 's/.*version[[:space:]]\([0-9.][0-9.]*\).*/\1/p' | head -1)"
+    if [[ -z "$ver" ]]; then
+        skip "could not parse current bd version: $have"
+    fi
+    run "$SCRIPT" --version "v$ver"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already installed"* ]] || [[ "$output" == *"skipping"* ]]
+}

--- a/tests/scripts/pre-push-gate.bats
+++ b/tests/scripts/pre-push-gate.bats
@@ -59,6 +59,7 @@ setup() {
     make_stub "$FAKE_REPO/scripts/check-contract-compatibility.sh"
     make_stub "$FAKE_REPO/scripts/validate-swarm-evidence.sh"
     make_stub "$FAKE_REPO/scripts/validate-hook-preflight.sh"
+    make_stub "$FAKE_REPO/scripts/check-standards-injector-completeness.sh"
     make_stub "$FAKE_REPO/scripts/validate-hooks-doc-parity.sh"
     make_stub "$FAKE_REPO/scripts/validate-ci-policy-parity.sh"
     make_stub "$FAKE_REPO/scripts/validate-embedded-sync.sh"


### PR DESCRIPTION
## Summary

Five code-level fixes from the 2026-04-26 nightly retrospective. Each commit closes one recurring gap so the prompt-side mitigations no longer have to compensate for missing tooling.

### Task 1 — truncateOutput preserves diagnostic tail (`e702b9c0`)
**Bug:** `cli/internal/goals/measure.go` capped output at 500 runes from the start, cutting the operator hint off the end of verbose gate output (e.g. flywheel-compounding's `sessions must use 'ao lookup --cite ...'`).
**Fix:** keep first 200 + truncation marker + last 200 runes when input exceeds 500. Short inputs untouched.
**Verify:** live `ao goals measure --json` now exposes both the failure label and the trailing hint on 6 long-output gates (flywheel-proof, hook-preflight, go-cli-tests, contract-compatibility, install-smoke, flywheel-lifecycle).

### Task 2 — standards-injector reference completeness gate (`231d3475`)
**Bug:** `hooks/standards-injector.sh` failed open when a mapped `<lang>` had no `references/<lang>.md`. That's how `.js` lost standards inject for weeks.
**Fix:** new `scripts/check-standards-injector-completeness.sh` parses the hook's case statement, asserts every mapped language has its file. Wired into pre-push-gate (slot 27b) and `.github/workflows/validate.yml` (parallel job + summary deps).
**Verify:** removing `skills/standards/references/javascript.md` temporarily makes the gate FAIL with a clear message; restoring makes it PASS. bats fixture covers happy path, named-missing, `|`-alternation, parser failure, and real-repo sanity (6/6).

### Task 3 — probed_stale_at field + `ao rpi mark-probed` (`515824c3`)
**Bug:** when a nightly probes a queue item and finds it stale, the knowledge dies in the digest — tomorrow re-probes the same item.
**Fix:** added optional `probed_stale_at` (RFC3339) + `probed_by` to the v1.3 item schema, the Go `NextWorkItem` round-trip type, the schema-rows acceptance test, and a new `ao rpi mark-probed --id=... --by=...` subcommand so future nightlies can write back without hand-editing JSON.
**Verify:** synthetic `next-work.jsonl` entry with `probed_stale_at` set passes the schema gate; `validate-next-work-contract-parity.sh` stays green.

### Task 4 — Dream curator probes before emit (`6149be09`)
**Bug:** three nightlies in a row emitted the same two stale packets ("philosophy doc", "next-work schema v1.3") because the curator never verified the cited file/script wasn't already shipped.
**Fix:** before writing a packet to `.agents/overnight/latest/morning-packets/`, the curator runs a 5-second tractability probe against the candidate's `target_files` and `scripts/<name>.sh` references in the morning command. Conclusively-stale packets are suppressed and recorded as `dream-curator-suppressed` entries on the run summary; inconclusive evidence emits normally.
**Verify:** integration test feeds a curator a packet citing `cli/cmd/ao/overnight.go` (existing file) → packet suppressed, suppression entry recorded with the matched path. A second test verifies an inconclusive probe still emits.

### Task 5 — `scripts/install-bd.sh` (`35a8a937`)
**Bug:** `bd` has been "unavailable" in three consecutive nightly runs.
**Fix:** new installer detects platform (darwin/linux × amd64/arm64), downloads the matching tarball from `steveyegge/beads` GitHub releases, installs to `~/.local/bin/bd`, verifies via `bd version`. Idempotent — short-circuits when the requested version is already present.
**Verify:** end-to-end download/install/verify tested live on darwin/arm64.

## ao goals measure --json summary

| | score | passing | failing |
|---|---|---|---|
| baseline (HEAD~5) | 73.39 | 14 | 5 |
| after (HEAD)      | 80.73 | 15 | 4 |
| delta             | +7.34 | +1 | -1 |

Tooling/correctness pass — no goal with weight ≥3 regressed.

## Per-commit SHA list

- `e702b9c0` fix(goals): preserve diagnostic tail in truncateOutput
- `231d3475` feat(ci): add standards-injector reference completeness gate
- `515824c3` feat(rpi): add probed_stale_at + probed_by + ao rpi mark-probed
- `6149be09` fix(overnight): probe Dream packets for staleness before emit
- `35a8a937` chore(scripts): add install-bd.sh installer

## Test plan

- [ ] `cd cli && go build ./... && go vet ./... && go test -race ./...` green
- [ ] `bats tests/scripts/check-standards-injector-completeness.bats` (6/6)
- [ ] `bats tests/scripts/check-next-work-schema-rows.bats` (11/11)
- [ ] `bats tests/scripts/install-bd.bats` (4/4)
- [ ] `scripts/pre-push-gate.sh` runs the new standards-injector gate
- [ ] CI `validate.yml` runs the new `standards-injector-completeness` job
- [ ] `ao rpi mark-probed --help` lists the new subcommand