### PR TITLE
fix(rpi): sort verdicts deterministically in context and status helpers

### DIFF
--- a/cli/cmd/ao/rpi_phased_context_test.go
+++ b/cli/cmd/ao/rpi_phased_context_test.go
@@ -386,6 +386,42 @@ func TestCtx_BuildPhaseContext_GoalAndVerdicts(t *testing.T) {
 	}
 }
 
+// TestCtx_BuildPhaseContext_DeterministicVerdictOrder ensures verdict lines are
+// emitted in a stable alphabetical order regardless of Go's map iteration.
+// Regression test for tech-debt judge W-7 (map iteration non-determinism).
+func TestCtx_BuildPhaseContext_DeterministicVerdictOrder(t *testing.T) {
+	state := &phasedState{
+		Verdicts: map[string]string{
+			"zebra":      "FAIL",
+			"apple":      "PASS",
+			"pre_mortem": "WARN",
+			"mango":      "PASS",
+		},
+		Attempts: map[string]int{},
+	}
+
+	first := buildPhaseContext("", state, 2)
+	for i := 0; i < 50; i++ {
+		if got := buildPhaseContext("", state, 2); got != first {
+			t.Fatalf("buildPhaseContext not deterministic:\nfirst=%q\n got =%q", first, got)
+		}
+	}
+
+	// Confirm keys appear in sorted order. Keys are sorted before the
+	// "_"->"-" substitution, so alphabetic order is on raw keys.
+	aIdx := strings.Index(first, "apple verdict:")
+	mIdx := strings.Index(first, "mango verdict:")
+	pIdx := strings.Index(first, "pre-mortem verdict:")
+	zIdx := strings.Index(first, "zebra verdict:")
+	if aIdx < 0 || mIdx < 0 || pIdx < 0 || zIdx < 0 {
+		t.Fatalf("expected all verdicts in context, got: %q", first)
+	}
+	if !(aIdx < mIdx && mIdx < pIdx && pIdx < zIdx) {
+		t.Errorf("verdicts not in sorted order: apple=%d mango=%d pre-mortem=%d zebra=%d\nctx=%q",
+			aIdx, mIdx, pIdx, zIdx, first)
+	}
+}
+
 func TestCtx_ReadPhaseSummaries_CapsAt2000(t *testing.T) {
 	tmp := t.TempDir()
 	rpiDir := filepath.Join(tmp, ".agents", "rpi")

--- a/cli/cmd/ao/rpi_status_test.go
+++ b/cli/cmd/ao/rpi_status_test.go
@@ -1763,34 +1763,43 @@ func TestJoinVerdicts(t *testing.T) {
 	tests := []struct {
 		name     string
 		verdicts map[string]string
-		wantLen  int // check length of joined result (ordering not deterministic)
+		want     string
 	}{
-		{"nil map", nil, 0},
-		{"empty map", map[string]string{}, 0},
-		{"single entry", map[string]string{"vibe": "PASS"}, len("vibe=PASS")},
+		{"nil map", nil, ""},
+		{"empty map", map[string]string{}, ""},
+		{"single entry", map[string]string{"vibe": "PASS"}, "vibe=PASS"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := joinVerdicts(tt.verdicts)
-			if len(got) != tt.wantLen {
-				t.Errorf("joinVerdicts length = %d, want %d (got %q)", len(got), tt.wantLen, got)
+			if got != tt.want {
+				t.Errorf("joinVerdicts = %q, want %q", got, tt.want)
 			}
 		})
 	}
 }
 
 func TestJoinVerdicts_MultipleEntries(t *testing.T) {
-	verdicts := map[string]string{"pre_mortem": "PASS", "vibe": "WARN"}
+	verdicts := map[string]string{"vibe": "WARN", "pre_mortem": "PASS"}
 	got := joinVerdicts(verdicts)
-	// Should contain both entries separated by comma
-	if !strings.Contains(got, "pre_mortem=PASS") {
-		t.Errorf("expected pre_mortem=PASS in %q", got)
+	// Keys are sorted: "pre_mortem" < "vibe".
+	want := "pre_mortem=PASS,vibe=WARN"
+	if got != want {
+		t.Errorf("joinVerdicts = %q, want %q (sorted order)", got, want)
 	}
-	if !strings.Contains(got, "vibe=WARN") {
-		t.Errorf("expected vibe=WARN in %q", got)
+}
+
+func TestJoinVerdicts_DeterministicAcrossRuns(t *testing.T) {
+	verdicts := map[string]string{"z": "1", "a": "2", "m": "3", "b": "4"}
+	first := joinVerdicts(verdicts)
+	for i := 0; i < 50; i++ {
+		if got := joinVerdicts(verdicts); got != first {
+			t.Fatalf("joinVerdicts not deterministic: first=%q got=%q", first, got)
+		}
 	}
-	if !strings.Contains(got, ",") {
-		t.Errorf("expected comma separator in %q", got)
+	want := "a=2,b=4,m=3,z=1"
+	if first != want {
+		t.Errorf("joinVerdicts = %q, want %q (sorted order)", first, want)
 	}
 }
 

--- a/cli/internal/rpi/phased_context.go
+++ b/cli/internal/rpi/phased_context.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -293,8 +294,13 @@ func BuildPhaseContext(cwd, goal string, verdicts map[string]string, phaseNum in
 		parts = append(parts, fmt.Sprintf("Goal: %s", goal))
 	}
 
-	for key, verdict := range verdicts {
-		parts = append(parts, fmt.Sprintf("%s verdict: %s", strings.ReplaceAll(key, "_", "-"), verdict))
+	verdictKeys := make([]string, 0, len(verdicts))
+	for k := range verdicts {
+		verdictKeys = append(verdictKeys, k)
+	}
+	sort.Strings(verdictKeys)
+	for _, key := range verdictKeys {
+		parts = append(parts, fmt.Sprintf("%s verdict: %s", strings.ReplaceAll(key, "_", "-"), verdicts[key]))
 	}
 
 	if cwd != "" {

--- a/cli/internal/rpi/status.go
+++ b/cli/internal/rpi/status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 )
@@ -344,15 +345,21 @@ func FormattedLogRunStatus(run RPIRun) string {
 }
 
 // JoinVerdicts joins a verdict map into a "key=val,key=val" string.
+// Keys are sorted so output is deterministic across runs.
 func JoinVerdicts(verdicts map[string]string) string {
-	verdictStr := ""
-	for k, v := range verdicts {
-		if verdictStr != "" {
-			verdictStr += ","
-		}
-		verdictStr += k + "=" + v
+	if len(verdicts) == 0 {
+		return ""
 	}
-	return verdictStr
+	keys := make([]string, 0, len(verdicts))
+	for k := range verdicts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+verdicts[k])
+	}
+	return strings.Join(parts, ",")
 }
 
 // TrackerSummary returns a short tracker display string.


### PR DESCRIPTION
## Summary

`BuildPhaseContext` and `JoinVerdicts` iterated the verdicts map directly, producing non-deterministic output across runs. This branch sorts keys before rendering so prompt injection and status logs are reproducible.

## Changes
- `cli/internal/rpi/status.go` — sort keys in `JoinVerdicts`
- `cli/internal/rpi/phased_context.go` — sort keys in `BuildPhaseContext`
- `cli/cmd/ao/rpi_phased_context_test.go`, `cli/cmd/ao/rpi_status_test.go` — replace "ordering not deterministic" waivers with exact-order asserts; add 50-run stability check
- `.agents/rpi/next-work.jsonl` — touched (operational; will conflict on rebase)

Closes council finding W-7 (context-orchestration-leverage batch).

## Provenance

Branch existed unmerged; surfaced + opened as part of [git topology consolidation epic](.agents/plans/2026-04-26-git-topology-consolidation.md) (ag-06p) follow-up.

## Test plan
- [ ] Rebase against current main (resolve `next-work.jsonl` append-conflict)
- [ ] `cd cli && make test`
- [ ] Verify 50-run stability check passes