### PR TITLE
fix(codex): audit noisy hook injections

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -13,20 +13,21 @@ For the comprehensive technical reference — including CASS wiring, token budge
 
 When `hooks.json` disagrees with this page, trust `hooks.json`.
 
-## Lifecycle events
+## Lifecycle Events
 
-AgentOps currently uses six lifecycle events. Every event dispatches one or more scripts in `hooks/`.
+AgentOps currently uses seven lifecycle event sections in `hooks/hooks.json`. Every event dispatches one or more scripts in `hooks/`.
 
 | Event | Purpose | Representative scripts |
 |-------|---------|-----------------------|
-| `SessionStart` | Seed the session with recent learnings, pointers to MEMORY.md | `session-start.sh`, `ao-inject.sh` |
+| `SessionStart` | Prepare session state and startup context | `session-start.sh`, `ao-inject.sh` |
 | `SessionEnd` | Compile session signal, maintain the knowledge pool | `session-end-maintenance.sh`, `compile-session-defrag.sh` |
 | `Stop` | Close the flywheel for the turn | `ao-flywheel-close.sh` |
 | `UserPromptSubmit` | Route the prompt, nudge discipline, echo intent | `factory-router.sh`, `prompt-nudge.sh`, `intent-echo.sh`, `quality-signals.sh` |
 | `PreToolUse` | Gate risky tool calls (commits, edits, reads in isolation) | `pre-mortem-gate.sh`, `commit-review-gate.sh`, `holdout-isolation-gate.sh`, `go-test-precommit.sh` |
 | `PostToolUse` | Quality and loop-detection after edits | `write-time-quality.sh`, `go-complexity-precommit.sh`, `go-vet-post-edit.sh`, `research-loop-detector.sh`, `context-monitor.sh` |
+| `TaskCompleted` | Validate completed delegated work when the runtime emits task events | `task-validation-gate.sh` |
 
-A `TaskCompleted` block also exists in the manifest (for `task-validation-gate.sh`); it is runtime-dependent and may be a no-op on agents that do not emit that event.
+Codex native hooks intentionally install a narrower event set from `hooks/codex-hooks.json`. The Codex manifest excludes historically noisy startup injection such as `ao-inject.sh`; `session-start.sh` prepares state silently.
 
 ## Install and uninstall
 
@@ -42,6 +43,25 @@ ao hooks uninstall     # removes ao hook entries (other entries are preserved)
 ### Codex (v0.115.0+)
 
 Use `scripts/install-codex-plugin.sh` or `scripts/install-codex.sh` to install the native hook manifest to `~/.codex/hooks.json`.
+
+The Codex installer preserves unrelated hooks already present in `~/.codex/hooks.json`. If Codex starts injecting unrelated context, audit the active manifest:
+
+```bash
+bash scripts/audit-codex-hooks.sh
+```
+
+To remove non-AgentOps Codex hook handlers, run the pruning mode. It writes a timestamped `hooks.json.bak.*` backup before editing:
+
+```bash
+bash scripts/audit-codex-hooks.sh --prune-foreign
+```
+
+You can also point the audit at another installed hook manifest when debugging
+runtime crossover or stale plugin caches:
+
+```bash
+bash scripts/audit-codex-hooks.sh --hooks-file ~/.agentops/hooks/hooks.json --strict
+```
 
 ### Codex (older)
 

--- a/scripts/audit-codex-hooks.sh
+++ b/scripts/audit-codex-hooks.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# audit-codex-hooks.sh — Audit active Codex hooks for non-AgentOps context injectors.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+HOOKS_FILE=""
+PRUNE_FOREIGN="false"
+STRICT="false"
+JSON_OUTPUT="false"
+
+usage() {
+  cat <<'EOF'
+audit-codex-hooks.sh
+
+Audit ~/.codex/hooks.json for AgentOps-managed and foreign hook handlers.
+
+Options:
+  --codex-home <dir>   Codex home to inspect (default: $CODEX_HOME or ~/.codex)
+  --hooks-file <file>   Hook manifest to inspect (default: <codex-home>/hooks.json)
+  --prune-foreign      Remove non-AgentOps hook handlers after writing a backup
+  --strict             Exit non-zero when foreign hook handlers are present
+  --json               Emit machine-readable JSON
+  --help               Show this help
+
+Examples:
+  bash scripts/audit-codex-hooks.sh
+  bash scripts/audit-codex-hooks.sh --strict
+  bash scripts/audit-codex-hooks.sh --prune-foreign
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --codex-home)
+      CODEX_HOME="${2:-}"
+      shift 2
+      ;;
+    --hooks-file)
+      HOOKS_FILE="${2:-}"
+      shift 2
+      ;;
+    --prune-foreign)
+      PRUNE_FOREIGN="true"
+      shift
+      ;;
+    --strict)
+      STRICT="true"
+      shift
+      ;;
+    --json)
+      JSON_OUTPUT="true"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$CODEX_HOME" ]]; then
+  echo "ERROR: --codex-home cannot be empty" >&2
+  exit 2
+fi
+
+if [[ -z "$HOOKS_FILE" ]]; then
+  HOOKS_FILE="$CODEX_HOME/hooks.json"
+fi
+
+build_agentops_scripts_json() {
+  local hooks_dir="$REPO_ROOT/hooks"
+  if [[ ! -d "$hooks_dir" ]]; then
+    printf '%s\n' '["session-start.sh","ao-flywheel-close.sh","prompt-nudge.sh","quality-signals.sh","go-test-precommit.sh","commit-review-gate.sh","ratchet-advance.sh"]'
+    return 0
+  fi
+
+  find "$hooks_dir" -maxdepth 1 -type f -name '*.sh' -exec basename {} \; \
+    | sort \
+    | jq -R . \
+    | jq -s .
+}
+
+AGENTOPS_SCRIPTS_JSON="$(build_agentops_scripts_json)"
+
+require_jq() {
+  command -v jq >/dev/null 2>&1 || {
+    echo "ERROR: jq is required" >&2
+    exit 2
+  }
+}
+
+require_hooks_file() {
+  [[ -f "$HOOKS_FILE" ]] || {
+    echo "ERROR: Codex hooks file not found: $HOOKS_FILE" >&2
+    exit 2
+  }
+}
+
+validate_hooks_shape() {
+  jq -e '.hooks | type == "object"' "$HOOKS_FILE" >/dev/null 2>&1 || {
+    echo "ERROR: $HOOKS_FILE must use the Codex event-map schema under .hooks" >&2
+    exit 2
+  }
+}
+
+collect_handlers() {
+  jq -c --argjson scripts "$AGENTOPS_SCRIPTS_JSON" '
+    def is_agentops_command($cmd):
+      ($cmd | type == "string") and (
+        ($cmd | contains("ao "))
+        or ($cmd | contains("${CLAUDE_PLUGIN_ROOT}/hooks/"))
+        or any($scripts[]; . as $script | ($cmd | test("(^|[[:space:]])[^[:space:]]*/hooks/" + $script + "([[:space:]]|$)")))
+        or
+        any($scripts[]; . as $script | ($cmd | contains("${AGENTOPS_PLUGIN_ROOT") and ($cmd | contains("/hooks/" + $script))))
+      );
+    def model_visible_event($event):
+      ($event == "SessionStart" or
+       $event == "UserPromptSubmit" or
+       $event == "PreToolUse" or
+       $event == "PostToolUse" or
+       $event == "PreCompact");
+    [
+      .hooks | to_entries[]?
+      | .key as $event
+      | .value[]? as $group
+      | ($group.matcher // "") as $matcher
+      | $group.hooks[]?
+      | {
+          event: $event,
+          matcher: $matcher,
+          command: (.command // ""),
+          timeout: (.timeout // null),
+          agentops: is_agentops_command(.command // ""),
+          model_visible_event: model_visible_event($event)
+        }
+    ]
+  ' "$HOOKS_FILE"
+}
+
+prune_foreign_handlers() {
+  local tmp_file backup_file
+  tmp_file="$(mktemp)"
+  backup_file="${HOOKS_FILE}.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+
+  jq --argjson scripts "$AGENTOPS_SCRIPTS_JSON" '
+    def is_agentops_command($cmd):
+      ($cmd | type == "string") and (
+        ($cmd | contains("ao "))
+        or ($cmd | contains("${CLAUDE_PLUGIN_ROOT}/hooks/"))
+        or any($scripts[]; . as $script | ($cmd | test("(^|[[:space:]])[^[:space:]]*/hooks/" + $script + "([[:space:]]|$)")))
+        or
+        any($scripts[]; . as $script | ($cmd | contains("${AGENTOPS_PLUGIN_ROOT") and ($cmd | contains("/hooks/" + $script))))
+      );
+    .hooks |= with_entries(
+      .value |= [
+        .[]?
+        | .hooks = [
+            .hooks[]?
+            | select(is_agentops_command(.command // ""))
+          ]
+        | select((.hooks | length) > 0)
+      ]
+    )
+    | .hooks |= with_entries(select((.value | length) > 0))
+  ' "$HOOKS_FILE" > "$tmp_file"
+
+  cp "$HOOKS_FILE" "$backup_file"
+  mv "$tmp_file" "$HOOKS_FILE"
+  printf '%s\n' "$backup_file"
+}
+
+print_text_report() {
+  local handlers_json="$1"
+  local backup_file="${2:-}"
+  local total agentops foreign visible_foreign
+
+  total="$(jq 'length' <<< "$handlers_json")"
+  agentops="$(jq '[.[] | select(.agentops)] | length' <<< "$handlers_json")"
+  foreign="$(jq '[.[] | select(.agentops | not)] | length' <<< "$handlers_json")"
+  visible_foreign="$(jq '[.[] | select((.agentops | not) and .model_visible_event)] | length' <<< "$handlers_json")"
+
+  echo "Codex hooks audit: $HOOKS_FILE"
+  echo "Total handlers: $total"
+  echo "AgentOps handlers: $agentops"
+  echo "Foreign handlers: $foreign"
+  echo "Foreign handlers on model-visible events: $visible_foreign"
+
+  if [[ "$foreign" -gt 0 ]]; then
+    echo
+    echo "Foreign handlers:"
+    jq -r '
+      .[]
+      | select(.agentops | not)
+      | "- " + .event + (if .matcher != "" then " [" + .matcher + "]" else "" end) + ": " + .command
+    ' <<< "$handlers_json"
+  fi
+
+  if [[ -n "$backup_file" ]]; then
+    echo
+    echo "Pruned foreign handlers."
+    echo "Backup: $backup_file"
+  fi
+}
+
+print_json_report() {
+  local handlers_json="$1"
+  local backup_file="${2:-}"
+
+  jq -n \
+    --arg hooks_file "$HOOKS_FILE" \
+    --arg backup_file "$backup_file" \
+    --argjson handlers "$handlers_json" \
+    '{
+      hooks_file: $hooks_file,
+      backup_file: (if $backup_file == "" then null else $backup_file end),
+      total_handlers: ($handlers | length),
+      agentops_handlers: ($handlers | map(select(.agentops)) | length),
+      foreign_handlers: ($handlers | map(select(.agentops | not)) | length),
+      foreign_model_visible_handlers: ($handlers | map(select((.agentops | not) and .model_visible_event)) | length),
+      handlers: $handlers
+    }'
+}
+
+require_jq
+require_hooks_file
+validate_hooks_shape
+
+handlers_before="$(collect_handlers)"
+foreign_count="$(jq '[.[] | select(.agentops | not)] | length' <<< "$handlers_before")"
+backup_path=""
+
+if [[ "$PRUNE_FOREIGN" == "true" && "$foreign_count" -gt 0 ]]; then
+  backup_path="$(prune_foreign_handlers)"
+  handlers_after="$(collect_handlers)"
+else
+  handlers_after="$handlers_before"
+fi
+
+if [[ "$JSON_OUTPUT" == "true" ]]; then
+  print_json_report "$handlers_after" "$backup_path"
+else
+  print_text_report "$handlers_after" "$backup_path"
+fi
+
+remaining_foreign="$(jq '[.[] | select(.agentops | not)] | length' <<< "$handlers_after")"
+if [[ "$STRICT" == "true" && "$remaining_foreign" -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/scripts/test-audit-codex-hooks.sh
+++ b/tests/scripts/test-audit-codex-hooks.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/audit-codex-hooks.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+setup_hooks_fixture() {
+  local codex_home="$1"
+  mkdir -p "$codex_home"
+  cat > "$codex_home/hooks.json" <<'EOF'
+{
+  "$schema": "../schemas/hooks-manifest.v1.schema.json",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /plugin/hooks/session-start.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash /plugin/hooks/factory-router.sh",
+            "timeout": 8
+          },
+          {
+            "type": "command",
+            "command": "python3 /custom/noisy-context.py --event SessionStart",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /plugin/hooks/quality-signals.sh",
+            "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "python3 /custom/noisy-context.py --event UserPromptSubmit",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /plugin/hooks/commit-review-gate.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /custom/session-end-freshness.sh",
+            "timeout": 35
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+}
+
+test_reports_foreign_handlers() {
+  local codex_home="$TMP_DIR/report/.codex"
+  local output
+  setup_hooks_fixture "$codex_home"
+
+  output="$(bash "$SCRIPT" --codex-home "$codex_home" --json)"
+  if jq -e \
+    '.total_handlers == 7
+     and .agentops_handlers == 4
+     and .foreign_handlers == 3
+     and .foreign_model_visible_handlers == 2' <<< "$output" >/dev/null; then
+    pass "reports AgentOps and foreign Codex hook counts"
+  else
+    fail "unexpected audit JSON: $output"
+  fi
+
+  if bash "$SCRIPT" --codex-home "$codex_home" --strict >/dev/null 2>&1; then
+    fail "strict audit should fail when foreign handlers exist"
+  else
+    pass "strict audit fails on foreign Codex hooks"
+  fi
+}
+
+test_prunes_foreign_handlers() {
+  local codex_home="$TMP_DIR/prune/.codex"
+  local output
+  setup_hooks_fixture "$codex_home"
+
+  output="$(bash "$SCRIPT" --codex-home "$codex_home" --prune-foreign --json)"
+
+  if ! jq -e '.foreign_handlers == 0 and .agentops_handlers == 4' <<< "$output" >/dev/null; then
+    fail "prune output did not report only AgentOps handlers: $output"
+    return
+  fi
+  if ! jq -e '[.hooks | to_entries[] | .value[] | .hooks[] | select(.command | contains("/custom/"))] | length == 0' \
+    "$codex_home/hooks.json" >/dev/null; then
+    fail "foreign hooks still present after prune"
+    return
+  fi
+  if ! jq -e '[.hooks | to_entries[] | .value[] | .hooks[] | select(.command | contains("/hooks/"))] | length == 4' \
+    "$codex_home/hooks.json" >/dev/null; then
+    fail "AgentOps hooks were not preserved after prune"
+    return
+  fi
+  if ! find "$codex_home" -maxdepth 1 -name 'hooks.json.bak.*' | grep -q .; then
+    fail "prune did not create a backup"
+    return
+  fi
+
+  pass "prunes foreign hooks and preserves AgentOps handlers"
+}
+
+echo "== test-audit-codex-hooks =="
+test_reports_foreign_handlers
+test_prunes_foreign_handlers
+
+echo ""
+echo "Results: $PASS PASS, $FAIL FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a script + tests to audit the codex hook injection surface for noise patterns.

## Changes
- New: `scripts/audit-codex-hooks.sh` (257 lines)
- New: `tests/scripts/test-audit-codex-hooks.sh` (148 lines)
- Updated: `docs/HOOKS.md` (+24/-4)

3 files, +429/-4. No code changes outside scripts.

## Provenance

Branch existed unmerged; surfaced + opened as part of [git topology consolidation epic](.agents/plans/2026-04-26-git-topology-consolidation.md) (ag-06p) follow-up.

## Test plan
- [ ] `bash tests/scripts/test-audit-codex-hooks.sh`
- [ ] Spot-check `scripts/audit-codex-hooks.sh` output against current hook surface