### PR TITLE
docs: add competitive radar + freshness check

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -56,7 +56,7 @@ CC 20 ceiling was achieved. Gate enforces the threshold — the directive is to 
 
 ### 6. Maintain competitive awareness
 
-Competitive analysis docs (`docs/comparisons/vs-*.md`) must stay fresh. GSD, Compound Engineer, and sdd are actively iterating — stale analysis means blind spots. Refresh comparisons within 45 days of last update. `/evolve` picks this up automatically when other goals pass.
+Competitive analysis docs (`docs/comparisons/vs-*.md` and `docs/comparisons/competitive-radar.md`) must stay fresh. GSD, Compound Engineer, and sdd are actively iterating — stale analysis means blind spots. Refresh comparisons within 45 days of last update. `/evolve` picks this up automatically when other goals pass.
 
 **Steer:** decrease (stale comparison doc count)
 

--- a/README.md
+++ b/README.md
@@ -287,10 +287,13 @@ Run Dream overnight, then run Evolve in the morning against a fresher corpus. Th
 
 | Tool | What it does well | What AgentOps adds |
 |------|-------------------|--------------------|
-| **[GSD](https://github.com/glittercowboy/get-shit-done)** | Clean subagent spawning, fights context rot | Cross-session bookkeeping and validation gates |
-| **[Compound Engineer](https://github.com/EveryInc/compound-engineering-plugin)** | Knowledge compounding, structured loop | Multi-runtime skills, council validation, and repo-native `ao` workflows |
+| **[GSD](https://github.com/glittercowboy/get-shit-done)** | Fresh-context phased execution, recovery loops, runtime breadth | Cross-session bookkeeping, pre-build validation, and the knowledge flywheel |
+| **[Compound Engineer](https://github.com/EveryInc/compound-engineering-plugin)** | Ideation, configurable reviewers, cross-runtime conversion | Automatic capture/scoring/injection, council validation, and repo-native `ao` workflows |
+| **[Spec Kit](https://github.com/github/spec-kit) / [Kiro](https://kiro.dev/)** | Spec-driven development and executable planning artifacts | Learning beyond specs: failures, decisions, retros, and prevention rules |
+| **[Superpowers](https://github.com/obra/superpowers)** | TDD discipline and autonomous work patterns | Memory, pre-mortems, and validation across repeated sessions |
+| **[Ruflo / Claude-Flow](https://github.com/ruvnet/ruflo)** | High-scale swarm orchestration and MCP-heavy coordination | Local, auditable compounding around whatever executes the work |
 
-[Detailed comparisons](docs/comparisons/)
+[Detailed comparisons](docs/comparisons/) · [Competitive radar](docs/comparisons/competitive-radar.md)
 
 ---
 

--- a/docs/comparisons/README.md
+++ b/docs/comparisons/README.md
@@ -22,6 +22,9 @@ The AI coding agent ecosystem has exploded. Here's how the major players stack u
 | [GSD](vs-gsd.md) | Spec-driven execution | 53 commands, 7 runtimes, advisor mode | Planning persistence, limited governed memory |
 | [Compound Engineer](vs-compound-engineer.md) | Plan/work/review/compound | Stack-aware routing, 10 runtimes | Manual/doc-solution compounding, no validation gates |
 
+For the operator-facing readout across all competitors, see the
+[Competitive Radar](competitive-radar.md).
+
 ---
 
 ## The Core Insight
@@ -86,9 +89,9 @@ Compound Engineer is the exception in this set: it also aims at compounding, but
 - Documentation is your primary artifact
 
 ### Use GSD if:
-- You want minimal overhead
-- You're prototyping or shipping fast
-- You don't need persistence
+- You want fresh-context execution for each worker
+- You want model/cost tiers and task-repair loops
+- You're doing spec-driven phased work that does not need a knowledge flywheel
 
 ### Use Compound Engineer if:
 - You want a clean `Plan -> Work -> Review -> Compound` loop
@@ -140,8 +143,9 @@ By session 100:
 - [vs. Superpowers](vs-superpowers.md) — The TDD powerhouse
 - [vs. Claude-Flow / Ruflo](vs-claude-flow.md) — The swarm orchestrator
 - [vs. SDD Tools](vs-sdd.md) — The spec-driven approach
-- [vs. GSD](vs-gsd.md) — The lightweight shipper
+- [vs. GSD](vs-gsd.md) — The fresh-context execution framework
 - [vs. Compound Engineer](vs-compound-engineer.md) — The closest philosophical neighbor
+- [Competitive Radar](competitive-radar.md) — The current market read and next-move pressure
 
 ---
 
@@ -154,7 +158,7 @@ By session 100:
 | AgentOps + Superpowers | ⚠️ | Overlapping planning; pick one |
 | AgentOps + Claude-Flow | ✅ | Claude-Flow for orchestration, AgentOps for memory |
 | AgentOps + SDD | ✅ | SDD for specs, AgentOps captures learnings |
-| AgentOps + GSD | ⚠️ | GSD is lightweight; AgentOps adds overhead |
+| AgentOps + GSD | ⚠️ | Both manage workflow state; use GSD for greenfield phased execution and AgentOps for long-lived compounding |
 | AgentOps + Compound Engineer | ✅ | Compound Engineer for workflow shell, AgentOps for memory and validation |
 
 The key: AgentOps' value is in the **knowledge layer**. If another tool handles execution better for your use case, AgentOps can still capture and compound the learnings.

--- a/docs/comparisons/competitive-radar.md
+++ b/docs/comparisons/competitive-radar.md
@@ -1,0 +1,74 @@
+---
+title: "AgentOps Competitive Radar"
+description: "Current market read for AgentOps against coding-agent workflow, plugin, orchestration, and spec-driven development competitors."
+permalink: /comparisons/competitive-radar
+last_reviewed: 2026-04-13
+---
+
+# Competitive Radar
+
+AgentOps should not try to be every agent workflow tool at once. The strongest
+position is narrower and harder to copy: make repeated work on the same codebase
+compound through local bookkeeping, validation, and retrieval.
+
+## Source Set
+
+| Source | Current signal | Link |
+|--------|----------------|------|
+| AgentOps | Operational layer for coding agents; local bookkeeping, validation, flows, `ao` CLI | [boshu2/agentops](https://github.com/boshu2/agentops) |
+| GSD | Fresh-context execution framework with broad runtime support and recovery loops | [glittercowboy/get-shit-done](https://github.com/glittercowboy/get-shit-done) |
+| Compound Engineer | Ideate-to-compound workflow, configurable reviewers, cross-runtime conversion | [EveryInc/compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) |
+| Superpowers | TDD discipline and autonomous work patterns | [obra/superpowers](https://github.com/obra/superpowers) |
+| Ruflo / Claude-Flow | High-scale swarm orchestration and MCP-heavy agent coordination | [ruvnet/ruflo](https://github.com/ruvnet/ruflo) |
+| GitHub Spec Kit | Spec-driven development becoming a mainstream, multi-agent workflow | [github/spec-kit](https://github.com/github/spec-kit) |
+| Kiro | Productized spec-driven IDE with steering, agent hooks, and MCP | [kiro.dev](https://kiro.dev/) |
+
+## Market Read
+
+| Trend | Why it matters | AgentOps response |
+|-------|----------------|-------------------|
+| Runtime portability is table stakes | GSD, Compound Engineer, and Spec Kit all emphasize multi-agent or multi-runtime reach. | Keep Claude, Codex, OpenCode, and skills-compatible install paths working, and show proof instead of only claiming parity. |
+| Spec-first is mainstream | GitHub Spec Kit and Kiro make executable specs feel normal rather than niche. | Treat specs as one input to the flywheel: capture what was planned, then capture what the session learned. |
+| Context isolation is a competitive feature | GSD's clean-agent pattern and Ruflo's swarm framing both sell fresh context as a quality lever. | Make AgentOps' context compiler story concrete: phase-scoped packets, retrieval scoring, and worker-safe handoffs. |
+| Compounding is now contested | Compound Engineer is philosophically close and has a strong ideate-to-refresh loop. | Win on automation: extraction, scoring, injection, maturity, and decay without relying on the operator to remember each step. |
+| Visible proof beats claims | Every serious competitor can explain a workflow. The winner needs a proof loop users can run. | Put `ao doctor`, `ao demo`, Dream reports, and comparison freshness in the public path. |
+
+## Competitive Matrix
+
+| Competitor | Best at | Risk to AgentOps | AgentOps counter | Pressure to add |
+|------------|---------|------------------|------------------|-----------------|
+| GSD | Fresh-context phased execution, model/cost tiers, broad runtime install | Looks more immediately execution-focused and portable | Knowledge flywheel, pre-mortem, council validation, beads issue graph, Go CLI | Cost tiers, clearer worker context budgets, stronger prompt-guard story |
+| Compound Engineer | Ideation, per-project reviewer routing, knowledge refresh, 10-target conversion | Closest substitute for teams that want compounding and portability | Automated capture/scoring/injection, runtime hooks, goals/evolve, dependency-aware execution | Configurable reviewer routing, investigative freshness checks |
+| Spec Kit / Kiro | Specs as the first-class product artifact | Users may think specs alone solve agent drift | AgentOps captures specs plus learnings, failures, decisions, retros, and prevention rules | Better spec import/export and "specs are not the flywheel" examples |
+| Superpowers | Strict TDD and senior-engineer discipline | Simpler quality story for greenfield work | Cross-session memory, pre-implementation validation, repo-local proof artifacts | Sharper TDD-first path for `/implement` and `/crank` |
+| Ruflo / Claude-Flow | Large-scale orchestration and MCP breadth | More impressive swarm scale and enterprise orchestration story | Smaller, auditable loops that compound knowledge across sessions | Better "AgentOps plus external orchestrator" integration docs |
+
+## Where AgentOps Wins
+
+| Moat | Why it is hard to copy |
+|------|------------------------|
+| Automated flywheel | Session-end extraction, scoring, maturity, decay, and injection are mechanical rather than remembered process steps. |
+| Validation before build | `/pre-mortem`, `/council`, and `/vibe` create failure-prevention gates, not only post-hoc review. |
+| Repo-native control plane | `ao`, `.agents/`, hooks, schemas, and beads keep state local, diffable, auditable, and scriptable. |
+| Strategic loops | `GOALS.md`, `/evolve`, and Dream turn repeated work into a measured improvement loop. |
+
+## Current Vulnerabilities
+
+| Vulnerability | Impact | Best next move |
+|---------------|--------|----------------|
+| Runtime proof lags runtime claims | Competitors can look more portable even when AgentOps has multiple install paths. | Maintain a visible runtime proof matrix tied to smoke tests and `ao doctor` output. |
+| Compounding proof is still too implicit | Users have to trust the flywheel story before they feel it. | Put Dream reports and `ao demo` examples in the first-run path. |
+| Reviewer routing is less configurable | Compound Engineer can feel more tailored to a stack. | Add or document per-project validation profile selection. |
+| Context budget and model cost controls are under-marketed | GSD owns the "fresh context and cost tiers" story. | Expose phase/worker context budgets and model profiles in a simple operator surface. |
+| Knowledge freshness is time-weighted more than investigation-weighted | Time decay is useful, but stale patterns can require active verification. | Add investigative refresh for high-value patterns before decay/archive decisions. |
+
+## Execution Bias
+
+Do not respond to every competitor feature by adding another command. Favor moves
+that make the flywheel visible, automatic, and verifiable:
+
+1. Prove install and runtime parity continuously.
+2. Make first value obvious in under five minutes.
+3. Make the knowledge flywheel produce inspectable artifacts.
+4. Turn repeated findings into stronger gates.
+5. Keep comparison docs tied to current official sources.

--- a/docs/comparisons/vs-compound-engineer.md
+++ b/docs/comparisons/vs-compound-engineer.md
@@ -166,7 +166,7 @@ While AgentOps has maturity scoring and decay, Compound Engineer's `/ce:compound
 
 | Feature | Compound Engineer | AgentOps | Winner |
 |---------|:-----------------:|:--------:|:------:|
-| Cross-runtime support | ✅ 10 targets + sync | ⚠️ Claude Code primary | CE |
+| Cross-runtime support | ✅ 10 targets + sync | ⚠️ 4 supported runtime paths, no 10-target converter | CE |
 | Configurable review agents | ✅ 15 agents, per-project | ⚠️ Fixed pipeline | CE |
 | Ideation + adversarial filtering | ✅ Structured pipeline | ⚠️ Brainstorm skill | CE |
 | Knowledge maintenance | ✅ compound-refresh (investigative) | ✅ Maturity + decay (automated) | Tie |
@@ -261,7 +261,7 @@ The knowledge systems are complementary: CE's `docs/solutions/` captures explici
 | **Optimizes** | Workflow breadth (ideation to maintenance) | Repo intelligence (learning to injection) |
 | **Knowledge model** | Capture → document → refresh | Extract → score → inject → decay |
 | **Review model** | 15 configurable agents per project | Fixed gates (pre-mortem, council, vibe) |
-| **Runtime reach** | 10 targets + plugin marketplace | Claude Code primary |
+| **Runtime reach** | 10 targets + plugin marketplace | 4 supported runtime paths, no 10-target converter |
 | **Best fit** | Teams wanting portable, structured workflow | Long-running codebases needing accumulated intelligence |
 
 **Compound Engineer is the closest philosophical neighbor in this comparison set.** Both believe in knowledge compounding. The difference: CE compounds through workflow discipline and explicit documentation. AgentOps compounds through automated extraction, scoring, and mechanical injection.

--- a/docs/comparisons/vs-gsd.md
+++ b/docs/comparisons/vs-gsd.md
@@ -136,7 +136,7 @@ GSD's review command supports cross-AI peer review (Gemini, Claude, Codex), but 
 
 | Feature | GSD | AgentOps | Winner |
 |---------|:---:|:--------:|:------:|
-| Multi-runtime support | ✅ 7 runtimes | ⚠️ Claude Code primary | GSD |
+| Multi-runtime support | ✅ 7 runtimes | ⚠️ 4 supported runtime paths, less broad than GSD | GSD |
 | Fresh context per agent | ✅ Core design | ⚠️ Swarm workers | GSD |
 | Model cost tiers | ✅ 4 profiles | ❌ Not yet | GSD |
 | Auto-repair on failure | ✅ RETRY/DECOMPOSE/PRUNE | ⚠️ Crank retries | GSD |

--- a/docs/comparisons/vs-sdd.md
+++ b/docs/comparisons/vs-sdd.md
@@ -135,7 +135,7 @@ AgentOps `/vibe` asks 8 questions:
 | Feature | SDD Tools | AgentOps | Winner |
 |---------|:---------:|:--------:|:------:|
 | Spec-first workflow | ✅ Core focus | ✅ Via `/plan` | SDD |
-| Cross-platform | ✅ 7+ agents | ⚠️ Claude Code focus | SDD |
+| Cross-platform | ✅ 7+ agents | ⚠️ 4 supported runtime paths | SDD |
 | Structured templates | ✅ Comprehensive | ⚠️ Via standards | SDD |
 | Human approval gates | ✅ Built-in | ✅ 4 gates | Tie |
 | **Cross-session memory** | ❌ Specs only | ✅ Learnings + patterns | **AgentOps** |
@@ -282,7 +282,7 @@ AgentOps doesn't aim for "spec-as-source" — it captures *learnings*, not just 
 | **What persists** | Documents | Learnings + patterns |
 | **Validation** | Spec match | 8-aspect semantic |
 | **Learning** | None | Compounds over time |
-| **Cross-platform** | 7+ agents | Claude Code |
+| **Cross-platform** | 7+ agents | 4 supported runtime paths |
 
 **SDD captures *what you decided*.**
 **AgentOps captures *what you learned*.**

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -152,6 +152,7 @@
 - [vs Superpowers](comparisons/vs-superpowers.md) — AgentOps vs Superpowers plugin
 - [vs Claude-Flow](comparisons/vs-claude-flow.md) — AgentOps vs Claude-Flow orchestration
 - [vs Compound Engineer](comparisons/vs-compound-engineer.md) — AgentOps vs Compound Engineering plugin
+- [Competitive Radar](comparisons/competitive-radar.md) — Current market read and improvement pressure
 
 ## Positioning
 

--- a/scripts/check-competitive-freshness.sh
+++ b/scripts/check-competitive-freshness.sh
@@ -4,27 +4,50 @@
 # Exit 0 = pass, exit 1 = fail (stale comparisons found)
 set -euo pipefail
 
-ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Not in a git repo"; exit 1; }
-COMPARISONS_DIR="$ROOT/docs/comparisons"
+ROOT="${COMPETITIVE_FRESHNESS_ROOT:-}"
+if [[ -z "$ROOT" ]]; then
+    ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Not in a git repo"; exit 1; }
+fi
+COMPARISONS_DIR="${COMPETITIVE_FRESHNESS_COMPARISONS_DIR:-$ROOT/docs/comparisons}"
 
 if [[ ! -d "$COMPARISONS_DIR" ]]; then
     echo "FAIL: docs/comparisons/ directory not found"
     exit 1
 fi
 
-STALE_DAYS=45
+STALE_DAYS="${COMPETITIVE_FRESHNESS_STALE_DAYS:-45}"
 NOW=$(date +%s)
 STALE_COUNT=0
 TOTAL=0
 
-for f in "$COMPARISONS_DIR"/vs-*.md; do
-    [[ -f "$f" ]] || continue
+file_mtime() {
+    stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0
+}
+
+comparison_files=()
+while IFS= read -r f; do
+    comparison_files+=("$f")
+done < <(find "$COMPARISONS_DIR" -maxdepth 1 -type f \( -name 'vs-*.md' -o -name 'competitive-radar.md' \) | sort)
+
+required_docs=("$COMPARISONS_DIR/competitive-radar.md")
+for required_doc in "${required_docs[@]}"; do
+    if [[ ! -f "$required_doc" ]]; then
+        echo "FAIL: missing required competitive analysis: $(basename "$required_doc")"
+        STALE_COUNT=$((STALE_COUNT + 1))
+    fi
+done
+
+for f in "${comparison_files[@]}"; do
     TOTAL=$((TOTAL + 1))
 
     # Use git log for last-modified date (more reliable than filesystem mtime)
-    LAST_COMMIT=$(git log -1 --format="%ct" -- "$f" 2>/dev/null) || LAST_COMMIT=0
+    REL_PATH="${f#"$ROOT"/}"
+    LAST_COMMIT=$(git -C "$ROOT" log -1 --format="%ct" -- "$REL_PATH" 2>/dev/null || true)
+    if [[ -z "$LAST_COMMIT" ]]; then
+        LAST_COMMIT="$(file_mtime "$f")"
+    fi
     if [[ "$LAST_COMMIT" -eq 0 ]]; then
-        echo "STALE: $(basename "$f") — never committed"
+        echo "STALE: $(basename "$f") — no commit or working-tree timestamp"
         STALE_COUNT=$((STALE_COUNT + 1))
         continue
     fi
@@ -37,12 +60,12 @@ for f in "$COMPARISONS_DIR"/vs-*.md; do
 done
 
 if [[ "$TOTAL" -eq 0 ]]; then
-    echo "FAIL: No vs-*.md comparison docs found"
+    echo "FAIL: No competitive analysis docs found"
     exit 1
 fi
 
 if [[ "$STALE_COUNT" -gt 0 ]]; then
-    echo "FAIL: $STALE_COUNT/$TOTAL competitive analyses are stale (>${STALE_DAYS} days)"
+    echo "FAIL: $STALE_COUNT competitive analysis issue(s); $TOTAL doc(s) checked (missing or >${STALE_DAYS} days old)"
     exit 1
 fi
 

--- a/scripts/ci-local-release.sh
+++ b/scripts/ci-local-release.sh
@@ -667,6 +667,7 @@ run_step_bg "Skill lint" bash ./tests/skills/run-all.sh
 run_step_bg "Headless runtime skill smoke" bash ./scripts/validate-headless-runtime-skills.sh
 run_step_bg "CLI integration smoke tests" ./tests/integration/test-cli-commands.sh
 run_step_bg "Command/test pairing gate tests" ./tests/scripts/test-go-command-test-pair.sh
+run_step_bg "Competitive freshness tests" bash ./tests/scripts/test-competitive-freshness.sh
 run_step_bg "Go fast scope tests" bats ./tests/scripts/validate-go-fast.bats
 run_step_bg "Skill runtime parity tests" bash ./tests/scripts/test-skill-runtime-parity.sh
 run_step_bg "Skill CLI snippet tests" bash ./tests/scripts/test-skill-cli-snippets.sh

--- a/tests/scripts/test-competitive-freshness.sh
+++ b/tests/scripts/test-competitive-freshness.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/check-competitive-freshness.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+make_repo() {
+  local path="$1"
+  mkdir -p "$path/docs/comparisons"
+  git -C "$path" init -q
+  git -C "$path" config user.email test@example.com
+  git -C "$path" config user.name "Competitive Freshness Test"
+}
+
+write_doc() {
+  local path="$1"
+  local title="$2"
+  cat > "$path" <<EOF
+# $title
+
+Reviewed for competitive freshness.
+EOF
+}
+
+test_passes_with_required_radar() {
+  local fixture="$TMP_DIR/fresh"
+  make_repo "$fixture"
+  write_doc "$fixture/docs/comparisons/vs-example.md" "Example"
+  write_doc "$fixture/docs/comparisons/competitive-radar.md" "Radar"
+  git -C "$fixture" add docs/comparisons
+  git -C "$fixture" commit -q -m "docs: add fresh comparisons"
+
+  if COMPETITIVE_FRESHNESS_ROOT="$fixture" bash "$SCRIPT" >/dev/null; then
+    pass "passes when comparison docs and radar are fresh"
+  else
+    fail "should pass with fresh docs and radar"
+  fi
+}
+
+test_fails_without_required_radar() {
+  local fixture="$TMP_DIR/missing-radar"
+  make_repo "$fixture"
+  write_doc "$fixture/docs/comparisons/vs-example.md" "Example"
+  git -C "$fixture" add docs/comparisons
+  git -C "$fixture" commit -q -m "docs: add comparison"
+
+  if COMPETITIVE_FRESHNESS_ROOT="$fixture" bash "$SCRIPT" >/dev/null 2>&1; then
+    fail "should fail when competitive-radar.md is missing"
+  else
+    pass "fails when competitive-radar.md is missing"
+  fi
+}
+
+test_uncommitted_radar_counts_as_current() {
+  local fixture="$TMP_DIR/uncommitted-radar"
+  make_repo "$fixture"
+  write_doc "$fixture/docs/comparisons/vs-example.md" "Example"
+  git -C "$fixture" add docs/comparisons
+  git -C "$fixture" commit -q -m "docs: add comparison"
+  write_doc "$fixture/docs/comparisons/competitive-radar.md" "Radar"
+
+  if COMPETITIVE_FRESHNESS_ROOT="$fixture" bash "$SCRIPT" >/dev/null; then
+    pass "passes for newly added working-tree radar before commit"
+  else
+    fail "should use working-tree timestamp for new radar docs"
+  fi
+}
+
+test_fails_stale_committed_docs() {
+  local fixture="$TMP_DIR/stale"
+  make_repo "$fixture"
+  write_doc "$fixture/docs/comparisons/vs-example.md" "Example"
+  write_doc "$fixture/docs/comparisons/competitive-radar.md" "Radar"
+  git -C "$fixture" add docs/comparisons
+  GIT_AUTHOR_DATE="2000-01-01T00:00:00Z" \
+    GIT_COMMITTER_DATE="2000-01-01T00:00:00Z" \
+    git -C "$fixture" commit -q -m "docs: add stale comparisons"
+
+  if COMPETITIVE_FRESHNESS_ROOT="$fixture" bash "$SCRIPT" >/dev/null 2>&1; then
+    fail "should fail stale committed docs"
+  else
+    pass "fails stale committed docs"
+  fi
+}
+
+echo "== test-competitive-freshness =="
+test_passes_with_required_radar
+test_fails_without_required_radar
+test_uncommitted_radar_counts_as_current
+test_fails_stale_committed_docs
+
+echo ""
+echo "Results: $PASS PASS, $FAIL FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds competitive-radar doc, a freshness check script with bats tests, and ci-local-release wiring.

## Changes
- New: `docs/comparisons/competitive-radar.md` (74 lines)
- New: `tests/scripts/test-competitive-freshness.sh` (105 lines)
- Updated: `scripts/check-competitive-freshness.sh`, `scripts/ci-local-release.sh`
- Updated: `GOALS.md`, `README.md`, several `docs/comparisons/vs-*.md`
- Updated: `docs/INDEX.md` — **will conflict** with main's rename to `docs/documentation-index.md` (ec188aca)

11 files, +234/-23.

## Conflicts (heads-up)

- `docs/INDEX.md` was renamed on main — rebase needs to apply the +1 line addition to `docs/documentation-index.md` instead.
- Operational `.agents/*` files may conflict.

## Provenance

Branch existed unmerged; surfaced + opened as part of [git topology consolidation epic](.agents/plans/2026-04-26-git-topology-consolidation.md) (ag-06p) follow-up.

## Test plan
- [ ] Rebase: replay `docs/INDEX.md` change against `docs/documentation-index.md`
- [ ] `bash tests/scripts/test-competitive-freshness.sh`
- [ ] `scripts/ci-local-release.sh`