### PR TITLE
fix(ci): regen codex hashes; restore filepath.Join allowlist entries

### DIFF
--- a/cli/cmd/ao/agents_smoke_test.go
+++ b/cli/cmd/ao/agents_smoke_test.go
@@ -82,6 +82,7 @@ func findContractRoot(t *testing.T) (string, string) {
 // write-side gates agree on what counts as a reference.
 func scanProductionAgentsReferences(repoRoot string) (map[string]bool, error) {
 	literalRe := regexp.MustCompile(`\.agents/([a-z][a-zA-Z0-9_-]*)`)
+	joinRe := regexp.MustCompile(`filepath\.Join\([^)]*\.agents"\s*,\s*"([a-z][a-zA-Z0-9_-]*)`)
 	found := map[string]bool{}
 
 	walkOne := func(rootDir string, isProductionFile func(path string, d fs.DirEntry) bool) error {
@@ -104,6 +105,9 @@ func scanProductionAgentsReferences(repoRoot string) (map[string]bool, error) {
 				return nil
 			}
 			for _, m := range literalRe.FindAllSubmatch(data, -1) {
+				found[string(m[1])] = true
+			}
+			for _, m := range joinRe.FindAllSubmatch(data, -1) {
 				found[string(m[1])] = true
 			}
 			return nil

--- a/docs/contracts/agents-write-surfaces.md
+++ b/docs/contracts/agents-write-surfaces.md
@@ -30,6 +30,7 @@ allowlist nor an active skill name fails the gate.
 | `compiled` | cli (compile pipeline) | regenerated | Compiled wiki output (subset; see `wiki/`) |
 | `config` | cli (.agents/.config) | persistent | Rig identity (project/crew) — read by harvest path-prefix fallback |
 | `constraints` | cli (constraints subsystem) | persistent | Compiled constraint manifests |
+| `context` | cli (context assembly) | rolling | Adhoc context assembly artifacts created for explicit context requests |
 | `defrag` | cli (compile defrag), scripts | rolling | Defrag run state and dry-run reports |
 | `findings` | scripts, /forge | persistent | Mined findings awaiting promotion |
 | `git` | cli (git-aware tooling) | persistent | Git-derived state cached for the runtime |
@@ -41,6 +42,7 @@ allowlist nor an active skill name fails the gate.
 | `mine` | cli (compile mine), /forge | rolling | Mined raw signal awaiting promotion |
 | `opencode-tests` | scripts (opencode runtime tests) | regenerated | Opencode runtime test fixtures and outputs |
 | `overnight` | scripts (nightly dream cycle), /dream | rolling | Overnight run state and morning packets |
+| `packets` | cli (context packet rollout) | rolling | Source manifests and promoted context packets for startup/context assembly |
 | `patterns` | cli (curate), /post-mortem, /retro | persistent | Promoted pattern artifacts |
 | `planning-rules` | cli (planning) | persistent | Planning rules sourced from skills/contracts |
 | `plans` | /plan, scripts | persistent | Planning artifacts |
@@ -53,6 +55,7 @@ allowlist nor an active skill name fails the gate.
 | `retros` | /retro | persistent | Retrospectives |
 | `sessions` | cli (`.agents/ao/sessions`), hooks | rolling | Session transcripts and matches |
 | `signals` | hooks (quality-signals) | rolling | Append-only quality signal log |
+| `skill-drafts` | cli (ratchet) | regenerated | Draft skill proposals and evidence generated from recurring patterns |
 | `skills` | cli (`doctor`, install) | persistent | User-installed skill state (alt path under `~/.agents/skills/`) |
 | `smoke-test` | scripts (smoke harness) | regenerated | Smoke test scratch dirs |
 | `specs` | /plan, /pre-mortem | persistent | Specs gating ratchet steps |
@@ -60,6 +63,8 @@ allowlist nor an active skill name fails the gate.
 | `synthesis` | /plan, /forge, /compile | persistent | Synthesis output |
 | `tasks` | cli (quickstart beads-optional mode) | persistent | Beads-optional task tracking fallback |
 | `teams` | cli (`codex-team`, `swarm`) | rolling | Team coordination state |
+| `topics` | cli (context packet rollout) | persistent | Topic packet artifacts used by context assembly health checks |
+| `wiki` | cli (forge, dream, search) | persistent | Session wiki sources, entities, concepts, and synthesis used by forge/search workflows |
 
 ### Skill-owned subdirs
 
@@ -81,6 +86,7 @@ compile
 compiled
 config
 constraints
+context
 defrag
 findings
 git
@@ -92,6 +98,7 @@ memory
 mine
 opencode-tests
 overnight
+packets
 patterns
 planning-rules
 plans
@@ -104,6 +111,7 @@ releases
 retros
 sessions
 signals
+skill-drafts
 skills
 smoke-test
 specs
@@ -111,6 +119,8 @@ swarm-role
 synthesis
 tasks
 teams
+topics
+wiki
 <!-- END agents-write-surfaces-allowlist -->
 
 ## How to update

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -692,7 +692,7 @@
       "name": "crank",
       "source_skill": "skills/crank",
       "source_hash": "928d1301b7f3bf12607e779cdec279924b5b29d681faffd01e6819651def92e7",
-      "generated_hash": "2a0078618d49f2048978451334d01c363202836165802eb0f13268dec5f9ffa5"
+      "generated_hash": "8e34e5804113ee4eec7207e0c5dea9f74f331a10939405060a858e255ca462a9"
     },
     {
       "name": "deps",
@@ -704,7 +704,7 @@
       "name": "design",
       "source_skill": "skills/design",
       "source_hash": "",
-      "generated_hash": "f3089a1425339cf222d714f2451216ba683474765f56bed4c644cbf76f168b92"
+      "generated_hash": "a4e7da1773158a760532ce1c6309c8b7a9764d8e494f9d964c92d7c87bd1840a"
     },
     {
       "name": "discovery",
@@ -776,7 +776,7 @@
       "name": "implement",
       "source_skill": "skills/implement",
       "source_hash": "2ab197d1810fd3eb56f73aac4645c02edc01aa41e524064b12b993c6861ebc32",
-      "generated_hash": "aa7f88ad80c6fb371f277c90d2a9e45985f481cb5319e9e87ef137ea4aabea9f"
+      "generated_hash": "6f777d710e54ec80f6a22b7ecf5bf612048123919fd377804cbda0008832c721"
     },
     {
       "name": "inject",
@@ -788,7 +788,7 @@
       "name": "knowledge-activation",
       "source_skill": "skills/knowledge-activation",
       "source_hash": "",
-      "generated_hash": "4cb77cd02ce82a2b3bd0091e192626e9a67d21507d67034d060f2bce973d7b2b"
+      "generated_hash": "d99845f6dd23f271c09374b2760286288602a61eef3c92f0d7be82587467dd7d"
     },
     {
       "name": "openai-docs",
@@ -884,7 +884,7 @@
       "name": "quickstart",
       "source_skill": "skills/quickstart",
       "source_hash": "68a6463ab7dded893cbdd27d7697c70d871ed4149b5c7cbe8bf20369c1e0a813",
-      "generated_hash": "3069919895447f39b60d3f19a37bd96ec4d5b2f869e6266f2ad07c15870241b6"
+      "generated_hash": "b324bc730e1cfb07bb35a2e5801737ae4ba2774346a5f956e63c034479e51d44"
     },
     {
       "name": "ratchet",
@@ -908,7 +908,7 @@
       "name": "red-team",
       "source_skill": "skills/red-team",
       "source_hash": "e7ae62c4a820cf3b7c93e1e0e5913e046013d9dfe8ff48ffa9f85294376bb037",
-      "generated_hash": "345e71a7c9d165615b9f10d4c1826e1b3203e36e5aee03cdaa64ea682556bb3a"
+      "generated_hash": "58c40ad88b7a82fb41c69a7c462f70f6ecfb801bbf5232653c88fcc8fb002c62"
     },
     {
       "name": "refactor",
@@ -986,7 +986,7 @@
       "name": "standards",
       "source_skill": "skills/standards",
       "source_hash": "837a4c5f624c5de7dbe37193fb1671a97d2f4c9381355c4b3745e247b632577a",
-      "generated_hash": "a0eeea87ffddd155c82fc10eee522d3d36cfd054067b03af72da292c08cd3ed3"
+      "generated_hash": "99f93b242b597c068a7678eb3fb75ca771f5253164449bba459a6dd4c609cfeb"
     },
     {
       "name": "status",
@@ -1028,7 +1028,7 @@
       "name": "validation",
       "source_skill": "skills/validation",
       "source_hash": "2e71f8dbe94c65971f0dff7f82ac83396649ff036bbea388060174945f660c5c",
-      "generated_hash": "4c1bf07ba20d26e8c82d40272dcfbd520241f9033454c4bf2730a59defaf8d40"
+      "generated_hash": "6bfca442ae4fd63dba32b16fc30a1ed8d32d7c1427f70b2ae27392082f3a428b"
     },
     {
       "name": "vibe",

--- a/skills-codex/crank/.agentops-generated.json
+++ b/skills-codex/crank/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/crank",
   "layout": "modular",
   "source_hash": "928d1301b7f3bf12607e779cdec279924b5b29d681faffd01e6819651def92e7",
-  "generated_hash": "2a0078618d49f2048978451334d01c363202836165802eb0f13268dec5f9ffa5"
+  "generated_hash": "8e34e5804113ee4eec7207e0c5dea9f74f331a10939405060a858e255ca462a9"
 }

--- a/skills-codex/design/.agentops-generated.json
+++ b/skills-codex/design/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/design",
   "layout": "modular",
   "source_hash": "",
-  "generated_hash": "f3089a1425339cf222d714f2451216ba683474765f56bed4c644cbf76f168b92"
+  "generated_hash": "a4e7da1773158a760532ce1c6309c8b7a9764d8e494f9d964c92d7c87bd1840a"
 }

--- a/skills-codex/implement/.agentops-generated.json
+++ b/skills-codex/implement/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/implement",
   "layout": "modular",
   "source_hash": "2ab197d1810fd3eb56f73aac4645c02edc01aa41e524064b12b993c6861ebc32",
-  "generated_hash": "aa7f88ad80c6fb371f277c90d2a9e45985f481cb5319e9e87ef137ea4aabea9f"
+  "generated_hash": "6f777d710e54ec80f6a22b7ecf5bf612048123919fd377804cbda0008832c721"
 }

--- a/skills-codex/knowledge-activation/.agentops-generated.json
+++ b/skills-codex/knowledge-activation/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/knowledge-activation",
   "layout": "modular",
   "source_hash": "",
-  "generated_hash": "4cb77cd02ce82a2b3bd0091e192626e9a67d21507d67034d060f2bce973d7b2b"
+  "generated_hash": "d99845f6dd23f271c09374b2760286288602a61eef3c92f0d7be82587467dd7d"
 }

--- a/skills-codex/quickstart/.agentops-generated.json
+++ b/skills-codex/quickstart/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/quickstart",
   "layout": "modular",
   "source_hash": "68a6463ab7dded893cbdd27d7697c70d871ed4149b5c7cbe8bf20369c1e0a813",
-  "generated_hash": "3069919895447f39b60d3f19a37bd96ec4d5b2f869e6266f2ad07c15870241b6"
+  "generated_hash": "b324bc730e1cfb07bb35a2e5801737ae4ba2774346a5f956e63c034479e51d44"
 }

--- a/skills-codex/red-team/.agentops-generated.json
+++ b/skills-codex/red-team/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/red-team",
   "layout": "modular",
   "source_hash": "e7ae62c4a820cf3b7c93e1e0e5913e046013d9dfe8ff48ffa9f85294376bb037",
-  "generated_hash": "345e71a7c9d165615b9f10d4c1826e1b3203e36e5aee03cdaa64ea682556bb3a"
+  "generated_hash": "58c40ad88b7a82fb41c69a7c462f70f6ecfb801bbf5232653c88fcc8fb002c62"
 }

--- a/skills-codex/standards/.agentops-generated.json
+++ b/skills-codex/standards/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/standards",
   "layout": "modular",
   "source_hash": "837a4c5f624c5de7dbe37193fb1671a97d2f4c9381355c4b3745e247b632577a",
-  "generated_hash": "a0eeea87ffddd155c82fc10eee522d3d36cfd054067b03af72da292c08cd3ed3"
+  "generated_hash": "99f93b242b597c068a7678eb3fb75ca771f5253164449bba459a6dd4c609cfeb"
 }

--- a/skills-codex/validation/.agentops-generated.json
+++ b/skills-codex/validation/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/validation",
   "layout": "modular",
   "source_hash": "2e71f8dbe94c65971f0dff7f82ac83396649ff036bbea388060174945f660c5c",
-  "generated_hash": "4c1bf07ba20d26e8c82d40272dcfbd520241f9033454c4bf2730a59defaf8d40"
+  "generated_hash": "6bfca442ae4fd63dba32b16fc30a1ed8d32d7c1427f70b2ae27392082f3a428b"
 }


### PR DESCRIPTION
## Summary

Fixes the two CI failures on main introduced by the recent batch of PR merges (#157–#163).

### 1. `codex-runtime-sections` (failed)

`skills-codex/` `generated_hash` drift across 8 skills: crank, design, implement, knowledge-activation, quickstart, red-team, standards, validation.

**Fix:** Regenerated via `scripts/regen-codex-hashes.sh`.

### 2. `bats-tests` (failed)

`scripts/check-agents-write-surfaces.sh --json` reported `"undocumented":["context","packets","skill-drafts","topics","wiki"]` and `"status":"fail"`. These 5 entries were pruned during PR #161's merge resolution because the Go smoke test (`TestAgentsWriteSurfaces_EachAllowlistEntryHasProductionReference`) reported them as orphaned.

The Go test was wrong: those surfaces ARE referenced — via `filepath.Join(".agents", "name", ...)` patterns in production code (e.g. `cli/internal/ratchet/skill_drafts.go:72`, `cli/cmd/ao/inject_context_paths.go`, `cli/cmd/ao/context_packet_status.go`, `cli/cmd/ao/dream_subcycle.go`, etc.). The shell script's regex catches that pattern; the Go test's regex only matched literal `.agents/name` strings.

**Fix:**
- Restored the 5 allowlist entries (both the descriptive table and the `<!-- BEGIN agents-write-surfaces-allowlist -->` block) in `docs/contracts/agents-write-surfaces.md`.
- Added a `filepath.Join` regex to `scanProductionAgentsReferences` in `cli/cmd/ao/agents_smoke_test.go` mirroring `scripts/check-agents-write-surfaces.sh`, so the read-side and write-side gates agree.

## Test plan

- [x] `bash scripts/validate-codex-generated-artifacts.sh --scope head` — passes
- [x] `bash scripts/check-agents-write-surfaces.sh` — `agents-write-surfaces contract OK: 55 referenced subdirs, 45 allowlisted`
- [x] `bats tests/scripts/check-agents-write-surfaces.bats` — all 15 tests pass (including the previously failing #15 "repo allowlist entries are referenced or explicitly lifecycle-only")
- [x] `bats tests/hooks/*.bats tests/scripts/*.bats` — full sweep, zero `not ok`
- [x] `cd cli && go test ./cmd/ao/ -count=1` — passes (smoke test now correctly resolves the 5 surfaces)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7bgsiuuq2BYnENyqCbrRR)_