### PR TITLE
PR-1: Eval foundation (7 commits) — schemas, CLI core, runtime, scorecards, coverage

### DIFF
--- a/.agents/brainstorm/2026-04-24-agentops-evaluation-environment.md
+++ b/.agents/brainstorm/2026-04-24-agentops-evaluation-environment.md
@@ -1,0 +1,91 @@
+---
+id: brainstorm-2026-04-24-agentops-evaluation-environment
+type: brainstorm
+date: 2026-04-24
+---
+
+# Brainstorm: AgentOps Evaluation Environment
+
+## Problem Statement
+
+AgentOps needs a repeatable evaluation environment that can tell whether changes to skills, hooks, or the `ao` CLI improve or degrade real agent outcomes across RPI flows, Claude/Codex runtime behavior, and new model releases.
+
+## Approaches Considered
+
+### Approach 1: Extend Existing CI Gates
+
+Add more checks to the current validation scripts, especially `validate-headless-runtime-skills.sh`, Codex parity scripts, hook tests, and RPI tests.
+
+Pros:
+- Smallest implementation footprint.
+- Builds on existing CI and scripts.
+- Good for catching structural regressions.
+
+Cons:
+- Keeps eval logic scattered.
+- Does not create baselines, scorecards, or model comparison reports.
+- Still cannot answer whether a skill is better or worse after a prompt/body change.
+
+Red-team result: HIGH RISK. It fails the baseline and cross-runtime comparison requirements.
+
+### Approach 2: External Eval Service
+
+Use an external eval framework or service to run model prompts against AgentOps scenarios and score outputs.
+
+Pros:
+- Could provide dashboards, retries, and model comparison quickly.
+- Separates eval execution from the repo.
+
+Cons:
+- Violates AgentOps' local/auditable posture.
+- Harder to test hooks and `ao` CLI behavior in the real repo filesystem.
+- Adds auth, cost, and vendor coupling before the local contract is mature.
+
+Red-team result: HIGH RISK. It defers the most important repo-native contracts.
+
+### Approach 3: Repo-Native `ao eval` Subsystem
+
+Create a checked-in eval pack format plus `ao eval` commands for running deterministic suites, optional live runtime/model suites, baseline capture, candidate-vs-baseline comparison, and scorecard generation.
+
+Pros:
+- Directly measures skills, hooks, CLI behavior, and RPI artifacts in real worktrees.
+- Produces durable, reviewable baselines and scorecards.
+- Can support Claude, Codex, and future GPT models through a runtime adapter layer.
+- Matches existing retrieval-bench and security-suite patterns.
+
+Cons:
+- Larger implementation.
+- Needs careful split between deterministic CI gates and costly/nondeterministic live model gates.
+- Requires scenario corpus governance to avoid overfitting.
+
+Red-team result: viable if implemented in tiers.
+
+## Selected Approach
+
+Select Approach 3: a repo-native layered eval subsystem.
+
+The initial shape should be:
+
+- `evals/` for checked-in public canary suites, seed repos, rubrics, and manifests.
+- `.agents/evals/` for generated run outputs, local baselines, and trend reports.
+- `ao eval run` to execute suites against a candidate branch, runtime, and model.
+- `ao eval compare` to compare candidate results with a known-good baseline.
+- `ao eval baseline` to capture and promote baselines intentionally.
+- Scorecards with deterministic dimensions first: artifact presence, command success, test pass/fail, phase order, hook behavior, CLI JSON validity, scenario satisfaction, runtime load, and transcript/tool-error signals.
+
+Live Claude/Codex/model execution should be tiered:
+
+- PR/fast: deterministic fixture suites and mocked runtime adapters.
+- Nightly/local opt-in: live headless Claude/Codex execution with isolated HOME/CODEX_HOME and env scrubbing.
+- Release/model-upgrade: repeated RPI canary runs with variance reporting and baseline comparison.
+
+## Open Questions
+
+- Where should private holdout suites live for local-only evaluation without leaking into checked-in public canaries?
+- What is the minimum RPI canary suite that deserves a hard 100% pass gate?
+- How many repeated live runs are enough before a model/runtime regression is credible?
+- Should the first implementation expose `ao eval` as a top-level command immediately, or start with `ao rpi eval` plus a reusable internal package?
+
+## Next Step: $plan
+
+Run `$plan --auto "build a repo-native AgentOps eval subsystem with checked-in eval packs, ao eval run/compare/baseline commands, RPI canary suites, Claude/Codex runtime adapters, and scorecards for skill/hook/CLI regressions"`.

--- a/.agents/council/2026-04-24-pre-mortem-agentops-evaluation-environment.md
+++ b/.agents/council/2026-04-24-pre-mortem-agentops-evaluation-environment.md
@@ -1,0 +1,78 @@
+---
+id: pre-mortem-2026-04-24-agentops-evaluation-environment
+type: pre-mortem
+date: 2026-04-24
+source: "[[.agents/plans/2026-04-24-agentops-evaluation-environment]]"
+prediction_ids:
+  - pm-20260424-001
+  - pm-20260424-002
+  - pm-20260424-003
+---
+
+# Pre-Mortem: AgentOps Evaluation Environment
+
+## Council Verdict: WARN
+
+| ID | Judge | Finding | Severity | Prediction |
+|----|-------|---------|----------|------------|
+| pm-20260424-001 | Missing-Requirements | Public canaries alone will overfit quickly unless private holdouts and baseline promotion rules are part of the contract. | significant | The first eval suite reports green while live RPI still regresses on unseen goals. |
+| pm-20260424-002 | Feasibility | Live runtime/model evals will be flaky if they become PR-blocking before auth, cost, timeouts, and variance are calibrated. | significant | A good PR gets blocked by model availability or nondeterministic scoring instead of a product regression. |
+| pm-20260424-003 | Spec-Completeness | Scenario authoring is currently documented but not implemented in `ao scenario`; eval corpus work depends on closing that mismatch. | moderate | Eval authors hand-write inconsistent scenarios and the suite drifts from the skill contract. |
+
+## Pseudocode Fixes
+
+Finding: pm-20260424-002 — live runtime env contamination and nondeterminism
+Severity: significant
+Fix (pseudocode):
+
+```go
+func sanitizedEvalEnv(base []string) []string {
+    denyPrefixes := []string{"AGENTOPS_RPI_RUNTIME"}
+    out := make([]string, 0, len(base))
+    for _, kv := range base {
+        keep := true
+        for _, prefix := range denyPrefixes {
+            if strings.HasPrefix(kv, prefix+"=") {
+                keep = false
+                break
+            }
+        }
+        if keep {
+            out = append(out, kv)
+        }
+    }
+    out = append(out, "AGENTOPS_HOOKS_DISABLED=1")
+    return out
+}
+```
+
+Affected files: `cli/internal/eval/runner.go`, `cli/internal/eval/runtime_*.go`
+
+## Shared Findings
+
+- The plan is strategically correct but should stay advisory for live model runs until repeated nightly/release runs establish variance.
+- The storage split between checked-in `evals/` and generated `.agents/evals/` is necessary because `.agents/holdout` is ignored and unsuitable as the only baseline source.
+- The first hard gate should be deterministic: schema validation, fixture commands, hook IO, CLI JSON validity, and RPI artifact/phase checks.
+
+## Known Risks Applied
+
+- `f-2026-04-14-001` — Applied to require direct `cli/cmd/ao` tests for every new `ao eval` command.
+- `f-2026-04-14-002` — Applied to require durable eval pack and baseline paths.
+- `learning-2026-04-14-scrub-rpi-runtime-from-raw-validation` — Applied to require `AGENTOPS_RPI_RUNTIME*` scrubbing.
+- `2026-04-07-v2.35.0-release-postmortem` — Applied to require local, CI, and live/nightly layers.
+
+## Concerns Raised
+
+- "100%" must be defined as 100% pass on a named critical canary suite over a configured repeat count; anything broader is not measurable.
+- LLM judge scorecards need calibration data before they can block releases.
+- RPI canaries must score file artifacts and commands first; exact prose matching will be brittle.
+
+## Recommendation
+
+Proceed with the plan as a staged implementation. Keep Wave 1 and Wave 2 focused on deterministic contracts and `ao eval` core. Do not make live runtime/model evals blocking until at least one stable baseline exists and variance is reported.
+
+## Decision Gate
+
+[ ] PROCEED - Council passed, ready to implement
+[x] ADDRESS - Fix concerns before implementing
+[ ] RETHINK - Fundamental issues, needs redesign

--- a/.agents/design/2026-04-24-design-agentops-evaluation-environment.md
+++ b/.agents/design/2026-04-24-design-agentops-evaluation-environment.md
@@ -1,0 +1,33 @@
+---
+id: design-2026-04-24-agentops-evaluation-environment
+type: design
+date: 2026-04-24
+---
+
+# Design: AgentOps Evaluation Environment
+
+## Goal
+
+Design an evaluation environment for AgentOps that can repeatedly measure whether changes to skills, hooks, and the `ao` CLI make the system better or worse across RPI flows, Claude/Codex runtime behavior, and new model releases.
+
+## Alignment Matrix
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Gap Alignment | 3/3 | Directly addresses the PRODUCT.md gap that multi-runtime proof is tiered rather than complete, and strengthens the validation/flywheel proof model. |
+| Persona Fit | 3/3 | Serves the Quality-First Maintainer, Agent Orchestrator, and Solo Developer by turning agent behavior quality from opinion into repeatable evidence. |
+| Competitive Diff | 3/3 | A repo-native eval harness for skills, hooks, CLI behavior, and model migration would make AgentOps' compounding claims mechanically provable rather than narrative. |
+| Precedent | 2/3 | Existing headless runtime smoke, Codex parity audits, hooks parity, skill integrity checks, and council/pre-mortem flows provide partial patterns, but not an end-to-end eval baseline. |
+| Scope Fit | 2/3 | The objective is broad, but can be staged as baseline capture, scenario runner, scoring contract, dashboards, and gate integration without blocking on a perfect harness. |
+
+Average: 2.6/3.0
+
+## Inline Assessment
+
+The capability is strongly aligned with AgentOps' mission: if the product claims that sessions compound, changes must be scored against stable behavioral baselines. The current product already has structural validation and runtime smoke, but lacks a persistent scenario corpus, model/runtime comparison harness, and trendable quality metrics for skills such as RPI.
+
+## Final Verdict
+
+DESIGN VERDICT: PASS
+
+Recommendation: proceed to research and planning. Treat this as a new validation subsystem rather than a one-off script, with the first milestone focused on repeatable baseline scenarios and scorecards before any CI-blocking gates are introduced.

--- a/.agents/plans/2026-04-24-agentops-evaluation-environment.md
+++ b/.agents/plans/2026-04-24-agentops-evaluation-environment.md
@@ -1,0 +1,320 @@
+---
+id: plan-2026-04-24-agentops-evaluation-environment
+type: plan
+date: 2026-04-24
+source: "[[.agents/research/2026-04-24-agentops-evaluation-environment]]"
+---
+
+# Plan: AgentOps Evaluation Environment
+
+## Context
+
+AgentOps has structural validation for skills, hooks, Codex artifacts, RPI contracts, and retrieval quality, but no unified way to score whether a skill, hook, CLI, runtime, or model change made outcomes better or worse. The plan creates a repo-native eval subsystem that treats AgentOps itself as the product under test.
+
+Applied findings:
+- `f-2026-04-14-001` — Every new `cli/cmd/ao` eval command must ship with direct command tests in the same slice.
+- `f-2026-04-14-002` — Baselines and scorecards must cite durable checked-in eval packs or committed run packets, not transient local-only seed files.
+- `learning-2026-04-14-scrub-rpi-runtime-from-raw-validation` — Runtime eval runners must scrub host RPI/runtime variables.
+- `2026-04-07-v2.35.0-release-postmortem` — Split validation into local, CI, and live/nightly layers because no single environment catches every failure surface.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `docs/contracts/eval-environment.md` | **NEW** — eval architecture, suite tiers, baseline lifecycle, score dimensions. |
+| `docs/INDEX.md` | Add contract entry. |
+| `schemas/eval-suite.v1.schema.json` | **NEW** — checked-in suite and case manifest schema. |
+| `schemas/eval-run.v1.schema.json` | **NEW** — run result and scorecard schema. |
+| `evals/agentops-core/` | **NEW** — public canary eval packs for skills, hooks, CLI, and RPI. |
+| `cli/cmd/ao/eval*.go` | **NEW** — `ao eval run`, `ao eval compare`, `ao eval baseline`, and JSON output. |
+| `cli/internal/eval/` | **NEW** — suite loader, runner, scorer, baseline comparator, runtime adapter interfaces. |
+| `cli/cmd/ao/eval*_test.go` | **NEW** — command tests paired with production command files. |
+| `cli/internal/eval/*_test.go` | **NEW** — loader, scorer, baseline, env-isolation, and fixture tests. |
+| `cli/docs/COMMANDS.md` | Regenerate after adding commands. |
+| `skills/scenario/SKILL.md` | Align documented scenario authoring with actual CLI behavior. |
+| `cli/cmd/ao/scenario_add.go` | **NEW** — implement `ao scenario add` or remove documented command from skill if deferred. |
+| `scripts/eval-agentops.sh` | **NEW** — stable local entrypoint for deterministic eval suites. |
+| `.github/workflows/validate.yml` | Add non-blocking/advisory eval job first, then ratchet later. |
+| `docs/TESTING.md` | Document eval tiers, when to run them, and baseline promotion rules. |
+
+## Boundaries
+
+**Always:** Keep deterministic evals runnable offline; isolate HOME/CODEX_HOME for live runtime runs; scrub `AGENTOPS_RPI_RUNTIME*`; emit JSON scorecards; keep private holdouts separate from public canaries; preserve existing validation scripts and wrap/reuse them instead of deleting them.
+
+**Ask First:** Before making live model evals blocking in PR CI; before committing private holdout scenarios; before promoting a new baseline after a known behavioral regression.
+
+**Never:** Gate normal PRs on nondeterministic live model availability; score exact prose when a mechanical artifact or command result can be scored; let implementing agents read private holdouts; treat 95% live pass rate as equivalent to 100% canary pass rate.
+
+## Baseline Audit
+
+| Metric | Command | Result |
+|--------|---------|--------|
+| Shared skill count | `find skills -mindepth 1 -maxdepth 1 -type d | wc -l` | 69 |
+| Codex skill count | `find skills-codex -mindepth 1 -maxdepth 1 -type d | wc -l` | 69 |
+| Claude hook handlers | `jq '[.hooks | to_entries[] | .value[] | .hooks[]] | length' hooks/hooks.json` | 28 |
+| Codex hook handlers | `jq '[.hooks | to_entries[] | .value[] | .hooks[]] | length' hooks/codex-hooks.json` | 7 |
+| Eval-adjacent files | `rg --files tests scripts cli/cmd/ao cli/internal/rpi skills | rg '(rpi|scenario|headless|codex|retrieval|runtime|skill).*(_test\\.go|\\.sh|\\.bats|\\.md|\\.json)$' | wc -l` | 653 |
+| Scenario subcommands | `cd cli && env -u AGENTOPS_RPI_RUNTIME go run ./cmd/ao scenario --help` | `init`, `list`, `validate`; no `add` |
+| Retrieval baseline smoke | `cd cli && env -u AGENTOPS_RPI_RUNTIME go run ./cmd/ao retrieval-bench --json` | 6 queries, `avg_precision_at_k=1.0`, `avg_mrr=1.0` |
+| Code map availability | `test -d docs/code-map && echo present || echo absent` | absent |
+| Tracker health | `bd ready --json`; `bd list --type epic --status open --json` | both crashed inside Dolt storage; discovery continued in tasklist mode |
+
+## Implementation
+
+### 1. Define Eval Contracts And Storage
+
+Create `docs/contracts/eval-environment.md` and schemas for:
+
+- `eval_suite`: suite id, domain (`skill|hook|cli|rpi|runtime|retrieval`), tier (`deterministic|headless|live|release`), cases, fixtures, allowed runtimes, scoring dimensions, baseline policy.
+- `eval_run`: run id, git SHA, candidate ref, baseline ref, runtime, model, suite id, case results, aggregate score, verdict, artifacts, transcript paths, environment scrub record.
+- `eval_scorecard`: dimension scores for correctness, process adherence, artifact quality, runtime compatibility, efficiency, safety, and learning closure.
+
+Use `evals/` for committed canary packs and `.agents/evals/` for generated local outputs. Public canaries must be stable and reviewable. Private holdouts can stay outside git but must use the same schema.
+
+### 2. Build `ao eval` CLI Core
+
+Add `ao eval` with:
+
+- `ao eval run --suite <id|path> --runtime <static|mock|claude|codex> --model <name> --out <dir> --json`
+- `ao eval compare --baseline <run.json> --candidate <run.json> --json`
+- `ao eval baseline capture --suite <id> --out <dir>`
+- `ao eval baseline promote --run <run.json> --baseline-dir <dir>`
+
+The first implementation should run deterministic suites and mocked runtime adapters. Live Claude/Codex adapters can share the same interface but start as opt-in.
+
+Key helpers:
+
+```go
+type Suite struct {
+    ID string
+    Domain string
+    Tier string
+    Cases []Case
+}
+
+type Runner interface {
+    Run(ctx context.Context, suite Suite, opts RunOptions) (RunResult, error)
+}
+
+type Score struct {
+    Correctness float64
+    ProcessAdherence float64
+    ArtifactQuality float64
+    RuntimeCompatibility float64
+    Efficiency float64
+    Safety float64
+    LearningClosure float64
+}
+```
+
+### 3. Seed Public Canary Suites
+
+Create `evals/agentops-core/` with initial suites:
+
+- `cli-smoke`: command help, JSON output, `ao scenario`, `ao retrieval-bench`, `ao rpi verify`.
+- `hook-io`: fixture stdin events for key hooks, expected exit codes and JSON decisions.
+- `skill-contracts`: selected skill invocation contracts for `rpi`, `discovery`, `validation`, `scenario`, `heal-skill`, and their Codex counterparts.
+- `runtime-inventory`: wrap existing headless inventory checks as an eval case with structured results.
+- `rpi-canary`: fixture repo plus goal, expected artifacts, phase order, pre-mortem/vibe verdict extraction, scenario satisfaction score, and no-host-env-leak checks.
+
+Fix the scenario command mismatch in the same wave: either implement `ao scenario add` according to `skills/scenario/SKILL.md`, or patch the skill to stop documenting a nonexistent command. Prefer implementing the command because eval authors need a durable scenario-authoring path.
+
+### 4. Add Live Runtime Adapters
+
+Add Claude and Codex adapters using `docs/contracts/headless-invocation-standards.md` and `scripts/validate-headless-runtime-skills.sh` as precedent. Requirements:
+
+- Isolated HOME and CODEX_HOME.
+- `env -u AGENTOPS_RPI_RUNTIME` and scrub all `AGENTOPS_RPI_RUNTIME*`.
+- Timeout, budget, and retry fields in the run result.
+- Transcript/stream capture in `.agents/evals/runs/<run-id>/`.
+- A strict JSON result extraction path with fallback diagnostics.
+- Runtime matrix metadata: runtime, version, model, profile, auth availability, skipped reason.
+
+Live suites should be advisory by default and suitable for nightly/release/model-upgrade validation, not required for every PR.
+
+### 5. Score RPI And Skill Changes Against Baselines
+
+Define scoring for RPI canaries:
+
+- Required artifacts exist: execution packet, plan, pre-mortem report, phase summaries, evaluator artifacts, scenario results when scenarios exist.
+- Required phase order observed.
+- No objective narrowing from lifecycle objective to one child slice.
+- No Codex wrapper-command orchestration when `$skill` chaining is required.
+- Tests/commands in the fixture repo pass.
+- Validator phase is separate from implementation phase when live runtime data exists.
+- Scorecard does not rely on self-declared success alone.
+
+For skill changes, compare:
+
+- Structural pass/fail from existing validators.
+- Trigger clarity via explicit skill request tests.
+- Runtime inventory and live smoke when available.
+- Scenario satisfaction and RPI canary score deltas.
+- Stocktake dimensions from `skills/heal-skill/references/skill-stocktake.md`: actionability, scope fit, uniqueness, currency, trigger clarity.
+
+Use candidate-vs-baseline comparison rather than a single absolute grade. A change is "better" only when it improves or preserves critical canary scores without regressing runtime compatibility, safety, or artifact quality.
+
+### 6. Wire Gates, Reports, And Ratchets
+
+Add `scripts/eval-agentops.sh --fast` for deterministic local use and a non-blocking CI job first. Once baselines stabilize:
+
+- PR gate: deterministic suites only.
+- Nightly: live Claude/Codex runtime suites and repeated RPI canaries.
+- Release/model-upgrade gate: compare candidate model/runtime against promoted baselines; require 100% pass on critical canaries and report variance for noncritical suites.
+- Pre-push: run fast suites when `skills/`, `skills-codex/`, `hooks/`, `cli/cmd/ao/`, or eval packs change.
+
+Outputs:
+
+- `.agents/evals/runs/<run-id>/run.json`
+- `.agents/evals/runs/<run-id>/scorecard.md`
+- `.agents/evals/baselines/<suite>/<runtime>/<model>/baseline.json`
+- `docs/releases/<date>-eval-summary.md` for release-grade baseline updates.
+
+## Tests
+
+**`cli/internal/eval/*_test.go`**:
+- suite schema validation
+- missing fixture failure
+- deterministic scorer behavior
+- baseline compare: pass, regression, improvement, inconclusive
+- env scrub removes `AGENTOPS_RPI_RUNTIME*`
+
+**`cli/cmd/ao/eval*_test.go`**:
+- command registration
+- `--json` emits valid JSON
+- `run`, `compare`, and `baseline` commands handle bad paths and missing suites
+- production command tests paired with every new command file
+
+**`cli/cmd/ao/scenario_add_test.go`**:
+- creates schema-valid scenario file
+- rejects invalid thresholds/statuses
+- stable ID generation with injectable clock
+
+**Shell/BATS**:
+- `scripts/eval-agentops.sh --fast` succeeds on fixtures
+- hook-IO eval cases enforce expected decisions
+- CI job remains advisory until baseline ratchet flips
+
+## Conformance Checks
+
+| Issue | Check Type | Check |
+|-------|------------|-------|
+| 1 | files_exist | `docs/contracts/eval-environment.md`, `schemas/eval-suite.v1.schema.json`, `schemas/eval-run.v1.schema.json` |
+| 1 | command | `./scripts/check-contract-compatibility.sh` |
+| 2 | tests | `cd cli && env -u AGENTOPS_RPI_RUNTIME go test ./cmd/ao ./internal/eval` |
+| 2 | content_check | `cli/docs/COMMANDS.md` includes `ao eval` after regeneration |
+| 3 | files_exist | `evals/agentops-core/suite.json` |
+| 3 | command | `cd cli && env -u AGENTOPS_RPI_RUNTIME go run ./cmd/ao scenario --help` includes `add` |
+| 4 | tests | `bash tests/scripts/test-headless-runtime-skills.sh` remains green |
+| 5 | command | `scripts/eval-agentops.sh --fast --suite rpi-canary` |
+| 6 | command | `scripts/pre-push-gate.sh --fast` |
+
+## Verification
+
+1. `cd cli && env -u AGENTOPS_RPI_RUNTIME go test ./cmd/ao ./internal/eval`
+2. `scripts/eval-agentops.sh --fast`
+3. `bash tests/scripts/test-headless-runtime-skills.sh`
+4. `bash scripts/validate-hooks-doc-parity.sh`
+5. `bash scripts/validate-codex-rpi-contract.sh`
+6. `bash scripts/validate-codex-lifecycle-guards.sh`
+7. `bash scripts/audit-codex-parity.sh`
+8. `scripts/pre-push-gate.sh --fast`
+
+## Issues
+
+### Issue 1: Define eval contracts, schemas, and docs
+
+**Dependencies:** None
+**Acceptance:** Contract docs are indexed, schemas validate, and the docs explain public canaries, private holdouts, baseline promotion, score dimensions, and live runtime tiers.
+**Description:** Add the contract and schemas before implementing commands so eval artifacts have a stable format.
+
+### Issue 2: Implement `ao eval` deterministic core
+
+**Dependencies:** Issue 1
+**Acceptance:** `ao eval run/compare/baseline --json` works on fixture suites; command tests cover success and failure paths; CLI docs are regenerated.
+**Description:** Add `cli/internal/eval` and `cli/cmd/ao/eval*.go`.
+
+### Issue 3: Seed public canary suites and fix scenario authoring
+
+**Dependencies:** Issue 1, Issue 2
+**Acceptance:** Checked-in suites cover CLI, hooks, skills, runtime inventory, and RPI; `ao scenario add` exists or the skill docs are corrected; scenario files validate.
+**Description:** Create `evals/agentops-core/` and close the scenario doc/CLI mismatch.
+
+### Issue 4: Add live Claude/Codex runtime adapters
+
+**Dependencies:** Issue 2
+**Acceptance:** Live adapters can be skipped with an explicit reason, run in isolated homes, scrub host env, capture transcripts, and emit scorecard fields without being required in PR CI.
+**Description:** Extend the runner interface to execute real runtime prompts.
+
+### Issue 5: Add RPI and skill-change scorecards
+
+**Dependencies:** Issue 3, Issue 4
+**Acceptance:** RPI canary produces a scorecard with artifact, phase-order, objective-spine, validation separation, scenario satisfaction, and runtime-safety dimensions. Skill-change scorecard reports structural, trigger, runtime, scenario, and stocktake deltas.
+**Description:** Turn "better or worse" into candidate-vs-baseline score comparisons.
+
+### Issue 6: Integrate eval gates, baselines, and ratchets
+
+**Dependencies:** Issue 2, Issue 3, Issue 5
+**Acceptance:** `scripts/eval-agentops.sh --fast` runs locally; CI has an advisory eval job; baseline promotion is explicit; docs explain when a suite becomes blocking.
+**Description:** Wire evals into local, CI, nightly, release, and model-upgrade workflows without making nondeterministic live model runs block normal PRs.
+
+## Execution Order
+
+**Wave 1:** Issue 1
+**Wave 2:** Issue 2
+**Wave 3:** Issue 3 and Issue 4
+**Wave 4:** Issue 5
+**Wave 5:** Issue 6
+
+## File Dependency Matrix
+
+| File/Area | Owner Issue | Downstream |
+|-----------|-------------|------------|
+| `docs/contracts/eval-environment.md` | 1 | 2, 3, 5, 6 |
+| `schemas/eval-*.json` | 1 | 2, 3, 5 |
+| `cli/internal/eval/` | 2 | 3, 4, 5, 6 |
+| `cli/cmd/ao/eval*.go` | 2 | 6 |
+| `evals/agentops-core/` | 3 | 5, 6 |
+| `cli/cmd/ao/scenario_add.go` | 3 | 5 |
+| Runtime adapters | 4 | 5, 6 |
+| `scripts/eval-agentops.sh` | 6 | CI/pre-push |
+
+## File-Conflict Matrix
+
+| Files | Conflict Risk | Resolution |
+|-------|---------------|------------|
+| `cli/cmd/ao/*` | Medium | Issue 2 owns `eval*.go`; Issue 3 owns `scenario_add.go`; regenerate CLI docs after both. |
+| `.github/workflows/validate.yml` | Low | Only Issue 6 edits CI after commands exist. |
+| `docs/INDEX.md` | Low | Issue 1 owns contract index edit. |
+| `evals/agentops-core/` | Low | Issue 3 owns initial corpus. |
+
+## Cross-Wave Shared File Registry
+
+| Shared File | Waves | Rule |
+|-------------|-------|------|
+| `cli/docs/COMMANDS.md` | 2, 3, 6 | Regenerate once after all CLI command changes land. |
+| `docs/TESTING.md` | 1, 6 | Issue 1 can add contract references; Issue 6 adds operational commands. |
+| `.github/workflows/validate.yml` | 6 | Keep advisory until at least one release cycle proves stability. |
+
+## Planning Rules Compliance
+
+| Rule | Status | Justification |
+|------|--------|---------------|
+| PR-001: Mechanical Enforcement | PASS | Every issue has command/file checks and JSON schemas. |
+| PR-002: External Validation | PASS | Candidate-vs-baseline comparison and runtime adapters are separate from implementer self-assessment. |
+| PR-003: Feedback Loops | PASS | Scorecards and baseline ratchets feed future model/skill decisions. |
+| PR-004: Separation Over Layering | PASS | Contract, CLI core, canaries, live adapters, scorecards, and gates are staged separately. |
+| PR-005: Process Gates First | PASS | Schemas and baseline rules precede CLI and gate integration. |
+| PR-006: Cross-Layer Consistency | PASS | Skills, hooks, CLI, CI, docs, schemas, and Codex artifacts are included. |
+| PR-007: Phased Rollout | PASS | Advisory first; blocking only after baseline stability. |
+
+Unchecked rules: 0
+
+## Post-Merge Cleanup
+
+After implementation, audit for scaffold-era names in `cli/internal/eval/`, ensure generated CLI docs are updated, and run `rg -n 'TODO|FIXME|HACK|XXX' evals cli/internal/eval cli/cmd/ao/eval*.go`.
+
+## Next Steps
+
+- Run `$pre-mortem .agents/plans/2026-04-24-agentops-evaluation-environment.md --quick`.
+- If the pre-mortem is PASS/WARN, implement Wave 1 first.

--- a/.agents/research/2026-04-24-agentops-evaluation-environment.md
+++ b/.agents/research/2026-04-24-agentops-evaluation-environment.md
@@ -1,0 +1,93 @@
+---
+id: research-2026-04-24-agentops-evaluation-environment
+type: research
+date: 2026-04-24
+---
+
+# Research: AgentOps Evaluation Environment
+
+**Backend:** inline
+**Scope:** Existing validation, runtime smoke, RPI, scenario, skill, hook, CLI, and baseline machinery relevant to evaluating AgentOps skills, hooks, and the `ao` CLI across Claude and Codex.
+
+## Summary
+
+AgentOps already has many proof fragments: structural runtime smoke, Codex parity guards, headless inventory checks, retrieval benchmarks, RPI phase evaluator artifacts, holdout scenario contracts, and baseline comparison precedent in the security suite. The missing piece is a unified eval substrate: checked-in eval suites, repeatable run records, baseline promotion/comparison, live runtime/model matrices, and scorecards that answer whether a skill/hook/CLI change improved or degraded agent outcomes.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `.github/workflows/validate.yml` | Runs Codex runtime, RPI contract, lifecycle, headless runtime, and retrieval-quality gates. |
+| `scripts/validate-headless-runtime-skills.sh` | Opens headless Claude/Codex sessions and compares visible skill inventory against repo definitions. |
+| `scripts/validate-codex-rpi-contract.sh` | Enforces Codex-specific RPI orchestration and no-beads handoff contracts. |
+| `scripts/validate-codex-lifecycle-guards.sh` | Enforces `ao codex ensure-start` / `ensure-stop` lifecycle guard wording across Codex skills. |
+| `scripts/audit-codex-parity.py` | Detects Claude-era primitives and stale runtime language in Codex artifacts. |
+| `skills/validation/references/step-1.8-behavioral-validation.md` | Defines holdout scenario satisfaction scoring during validation. |
+| `skills/scenario/SKILL.md` | Documents scenario authoring, isolation, lifecycle, and validation intent. |
+| `cli/cmd/ao/scenario*.go` | Implements `ao scenario init/list/validate`; no `add` command exists. |
+| `schemas/scenario.v1.schema.json` | Defines scenario fields, acceptance vectors, thresholds, and statuses. |
+| `hooks/holdout-isolation-gate.sh` and `hooks/hooks.json` | Blocks `.agents/holdout` reads unless `AGENTOPS_HOLDOUT_EVALUATOR=1`. |
+| `cli/cmd/ao/retrieval_bench.go` | Implements deterministic retrieval evals with train/holdout splits, P@K, MRR, and section metrics. |
+| `scripts/check-retrieval-quality-ratchet.sh` | Warn-then-fail retrieval quality ratchet with a fallback eval manifest. |
+| `cli/cmd/ao/rpi_evaluator.go` | Emits per-phase evaluator artifacts with verdicts, evidence paths, transcript-derived reward, and findings. |
+| `skills/heal-skill/references/skill-stocktake.md` | Describes a not-yet-integrated AI quality stocktake for skill keep/improve/merge/retire decisions. |
+| `skills/security-suite/SKILL.md` | Shows a mature baseline-capture and candidate-vs-baseline comparison pattern. |
+
+## Findings
+
+### Existing Proof Fragments
+
+CI already runs several relevant gates. The Codex runtime job validates runtime sections, generated artifacts, backbone prompts, override coverage, Codex RPI contract, lifecycle guards, and headless runtime skills (`.github/workflows/validate.yml:70`, `.github/workflows/validate.yml:79`, `.github/workflows/validate.yml:94`, `.github/workflows/validate.yml:98`, `.github/workflows/validate.yml:103`). Retrieval quality has a dedicated job that builds `ao`, runs `retrieval-bench --json`, and currently treats low precision as advisory until a stronger baseline is stable (`.github/workflows/validate.yml:482`, `.github/workflows/validate.yml:497`, `.github/workflows/validate.yml:503`).
+
+The headless runtime validator compares expected skill inventories against live Claude and Codex sessions, but it is still Tier I inventory proof rather than Tier E execution proof. The script prints the proof-tier matrix (`scripts/validate-headless-runtime-skills.sh:22`), builds expected inventories from `skills/` and `skills-codex/` (`scripts/validate-headless-runtime-skills.sh:365`), runs Claude with `--no-session-persistence` and a budget cap (`scripts/validate-headless-runtime-skills.sh:440`), installs the Codex plugin into an isolated `CODEX_HOME` (`scripts/validate-headless-runtime-skills.sh:541`), and runs Codex in read-only JSON mode (`scripts/validate-headless-runtime-skills.sh:552`).
+
+Codex-specific RPI behavior already has contract-level validation. `validate-codex-rpi-contract.sh` requires file-backed handoff via `$crank .agents/rpi/execution-packet.json`, standalone `$validation`, and explicit `$skill` chaining defaults (`scripts/validate-codex-rpi-contract.sh:36`, `scripts/validate-codex-rpi-contract.sh:48`, `scripts/validate-codex-rpi-contract.sh:58`). Lifecycle guard validation enforces `ao codex ensure-start` on entry skills and `ao codex ensure-stop` on closeout skills (`scripts/validate-codex-lifecycle-guards.sh:39`, `scripts/validate-codex-lifecycle-guards.sh:67`, `scripts/validate-codex-lifecycle-guards.sh:73`).
+
+RPI itself is already structured for phase isolation and file-backed handoff. The CLI help text describes three fresh-context phases (`cli/cmd/ao/rpi_phased.go:63`), dry-run support (`cli/cmd/ao/rpi_phased.go:82`), runtime selection (`cli/cmd/ao/rpi_phased.go:104`), and mixed-model execution (`cli/cmd/ao/rpi_phased.go:108`). RPI post-processing writes execution packets, extracts pre-mortem/vibe verdicts, and emits evaluator artifacts (`cli/cmd/ao/rpi_phased_gates.go:46`, `cli/cmd/ao/rpi_phased_gates.go:161`, `cli/cmd/ao/rpi_phased_gates.go:269`). Per-phase evaluator artifacts include run id, phase, verdict, findings, evidence, and transcript outcome fields (`cli/cmd/ao/rpi_evaluator.go:22`, `cli/cmd/ao/rpi_evaluator.go:36`, `cli/cmd/ao/rpi_evaluator.go:87`).
+
+Retrieval has the closest existing eval pattern. `retrieval-bench` has explicit query cases, expected results, best IDs, train/holdout splits, Precision@K, MRR, and section-aware scoring (`cli/cmd/ao/retrieval_bench.go:26`, `cli/cmd/ao/retrieval_bench.go:36`, `cli/cmd/ao/retrieval_bench.go:61`). It documents determinism for fixed corpora (`cli/cmd/ao/retrieval_bench.go:595`) and defaults include holdout queries (`cli/cmd/ao/retrieval_bench.go:584`). A local run on this worktree returned 6/6 passing queries with `avg_precision_at_k=1.0` and `avg_mrr=1.0`.
+
+The security suite provides a useful baseline pattern: capture a known-good baseline, run a candidate, compare contract drift, enforce policy, and write machine-consumable outputs (`skills/security-suite/SKILL.md:31`, `skills/security-suite/SKILL.md:49`, `skills/security-suite/SKILL.md:80`, `skills/security-suite/SKILL.md:87`).
+
+### Missing Eval Substrate
+
+There is no single `ao eval` command, checked-in suite layout, result schema, or baseline promotion flow that covers skills, hooks, CLI behavior, and live runtime/model execution. Existing gates answer "does this contract still structurally load?" much more often than "did this change make the agent complete the task better?"
+
+Scenario support is promising but incomplete. The scenario skill says scenarios define measurable acceptance vectors and live in `.agents/holdout` (`skills/scenario/SKILL.md:12`), documents `/scenario add` (`skills/scenario/SKILL.md:23`), and says validation consumes scenarios in STEP 1.8 (`skills/scenario/SKILL.md:98`). The Go CLI only registers `init`, `list`, and `validate` (`cli/cmd/ao/scenario.go:5`, `cli/cmd/ao/scenario_init.go:11`, `cli/cmd/ao/scenario_list.go:14`, `cli/cmd/ao/scenario_validate.go:14`), and `ao scenario --help` confirms no `add` command exists. This is a source-of-truth mismatch that must be fixed before scenario authoring can anchor evals.
+
+Holdout storage is also not durable by default. `.agents/holdout` is ignored by `.gitignore`, so human-authored eval scenarios under `.agents/holdout` will not naturally become a versioned baseline. The existing isolation hook is useful (`hooks/holdout-isolation-gate.sh:8`, `hooks/hooks.json:147`), but an AgentOps eval environment needs a checked-in public canary corpus plus optional private holdouts, not only ignored local state.
+
+Validation STEP 1.8 specifies satisfaction scoring and a scenario-results artifact (`skills/validation/references/step-1.8-behavioral-validation.md:22`, `skills/validation/references/step-1.8-behavioral-validation.md:28`, `skills/validation/references/step-1.8-behavioral-validation.md:37`), but there is no unified runner that executes those scenarios against candidate branches, models, runtimes, and baselines.
+
+Skill pruning/refactor evaluation is described but not productized. The stocktake reference proposes deterministic inventory plus AI evaluation using actionability, scope fit, uniqueness, currency, and trigger clarity, with Keep/Improve/Update/Retire/Merge verdicts (`skills/heal-skill/references/skill-stocktake.md:13`, `skills/heal-skill/references/skill-stocktake.md:37`, `skills/heal-skill/references/skill-stocktake.md:44`). That should become part of the eval environment, not a standalone reference.
+
+### Prior Knowledge Applied
+
+- `.agents/findings/f-2026-04-14-001.md` applies because any `ao eval` CLI work must pair production command changes with command tests; the finding explicitly asks for paired `cli/cmd/ao` tests and pre-push validation (`.agents/findings/f-2026-04-14-001.md:42`).
+- `.agents/findings/f-2026-04-14-002.md` applies because eval baselines and closure artifacts must point at durable, committed files rather than ephemeral `.agents` seed paths (`.agents/findings/f-2026-04-14-002.md:42`).
+- `.agents/learnings/2026-04-14-scrub-rpi-runtime-from-raw-validation.md` applies because model/runtime evals must scrub host variables such as `AGENTOPS_RPI_RUNTIME` before comparing results (`.agents/learnings/2026-04-14-scrub-rpi-runtime-from-raw-validation.md:16`).
+- `.agents/learnings/2026-04-07-v2.35.0-release-postmortem.md` applies because local and remote CI have different failure surfaces; the eval environment needs local, CI, and live/nightly tiers instead of assuming one gate is sufficient (`.agents/learnings/2026-04-07-v2.35.0-release-postmortem.md:16`).
+
+## Quality Validation
+
+Coverage checked: docs/index orientation, product context, CI workflow, runtime validation scripts, Codex parity scripts, RPI CLI/skill contracts, scenario CLI/schema/hook support, retrieval benchmark, flywheel gate, security baseline precedent, test fixtures, and prior findings/learnings.
+
+Depth ratings:
+
+| Area | Depth | Notes |
+|------|-------|-------|
+| Runtime loading/proof tiers | 3/4 | Inventory proof is clear; live execution scoring remains missing. |
+| RPI phase/evaluator contracts | 3/4 | Phase artifacts and evaluator output are clear enough for planning. |
+| Scenario/holdout validation | 2/4 | Intent is clear, but command support and durable corpus design are incomplete. |
+| Baseline comparison | 3/4 | Retrieval and security suite provide concrete patterns. |
+| Skill quality/pruning | 2/4 | Stocktake is specified as a reference but not integrated into executable flows. |
+
+Assumptions challenged:
+
+- "100% reliable" should mean 100% pass rate on a defined critical canary suite over repeated runs, not mathematical proof over all possible agent behavior.
+- Public checked-in scenarios are necessary for reproducibility, while private holdouts are necessary to detect overfitting.
+- Live model evals should start advisory or nightly because model availability, auth, cost, and nondeterminism make them too unstable for every PR.
+
+## Recommendations
+
+Build a layered `ao eval` subsystem instead of adding more isolated validators. The first version should define a checked-in eval pack format, run deterministic suites locally, support optional live Claude/Codex headless execution, produce scorecards, and compare candidates against a known-good baseline. Use existing retrieval-bench and security-suite patterns for scoring and baseline promotion, and treat RPI as a top-level canary suite with strict phase/artifact checks plus behavioral satisfaction scoring.

--- a/.agents/rpi/phase-1-summary-2026-04-24-agentops-evaluation-environment.md
+++ b/.agents/rpi/phase-1-summary-2026-04-24-agentops-evaluation-environment.md
@@ -1,0 +1,13 @@
+# Phase 1 Summary: Discovery
+
+- **Goal:** Design a repo-native evaluation environment for AgentOps skills, hooks, `ao` CLI behavior, RPI flows, and Claude/Codex model/runtime changes.
+- **Epic:** none (tasklist fallback; bd crashed during readiness probes)
+- **Issues:** 6
+- **Complexity:** standard
+- **Pre-mortem:** WARN (attempt 1/3)
+- **Brainstorm:** used after research per user request
+- **History search:** 4 applied prior findings/learnings
+- **Research:** `.agents/research/2026-04-24-agentops-evaluation-environment.md`
+- **Plan:** `.agents/plans/2026-04-24-agentops-evaluation-environment.md`
+- **Status:** DONE
+- **Timestamp:** 2026-04-24T15:45:00-04:00

--- a/.agents/rpi/phase-1-summary-2026-04-24-agentops-evaluation-environment.md
+++ b/.agents/rpi/phase-1-summary-2026-04-24-agentops-evaluation-environment.md
@@ -1,7 +1,7 @@
 # Phase 1 Summary: Discovery
 
 - **Goal:** Design a repo-native evaluation environment for AgentOps skills, hooks, `ao` CLI behavior, RPI flows, and Claude/Codex model/runtime changes.
-- **Epic:** none (tasklist fallback; bd crashed during readiness probes)
+- **Epic:** `agentops-dv5` (recovered after bd upgrade; original run fell back to tasklist because bd crashed during readiness probes)
 - **Issues:** 6
 - **Complexity:** standard
 - **Pre-mortem:** WARN (attempt 1/3)

--- a/.agents/rpi/runs/discovery-20260424-agentops-eval-env/execution-packet.json
+++ b/.agents/rpi/runs/discovery-20260424-agentops-eval-env/execution-packet.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "run_id": "discovery-20260424-agentops-eval-env",
   "objective": "Design a repo-native evaluation environment for AgentOps skills, hooks, ao CLI behavior, RPI flows, and Claude/Codex model/runtime changes.",
-  "epic_id": null,
+  "epic_id": "agentops-dv5",
   "plan_path": ".agents/plans/2026-04-24-agentops-evaluation-environment.md",
   "contract_surfaces": [
     "docs/contracts/repo-execution-profile.md",
@@ -18,11 +18,11 @@
     "bash scripts/audit-codex-parity.sh",
     "scripts/pre-push-gate.sh --fast"
   ],
-  "tracker_mode": "tasklist",
+  "tracker_mode": "beads",
   "tracker_health": {
-    "healthy": false,
-    "mode": "tasklist",
-    "reason": "bd readiness probes crashed inside Dolt-backed storage in the linked worktree; discovery stayed file-backed."
+    "healthy": true,
+    "mode": "beads",
+    "reason": "Recovered after bd upgrade: the original discovery stayed file-backed because bd readiness probes crashed, then the plan was restored into epic agentops-dv5 with six child beads."
   },
   "done_criteria": [
     "Eval suite and run schemas exist and are indexed.",

--- a/.agents/rpi/runs/discovery-20260424-agentops-eval-env/execution-packet.json
+++ b/.agents/rpi/runs/discovery-20260424-agentops-eval-env/execution-packet.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": 1,
+  "run_id": "discovery-20260424-agentops-eval-env",
+  "objective": "Design a repo-native evaluation environment for AgentOps skills, hooks, ao CLI behavior, RPI flows, and Claude/Codex model/runtime changes.",
+  "epic_id": null,
+  "plan_path": ".agents/plans/2026-04-24-agentops-evaluation-environment.md",
+  "contract_surfaces": [
+    "docs/contracts/repo-execution-profile.md",
+    "docs/contracts/headless-invocation-standards.md",
+    "docs/contracts/codex-skill-api.md"
+  ],
+  "validation_commands": [
+    "cd cli && env -u AGENTOPS_RPI_RUNTIME go test ./cmd/ao ./internal/eval",
+    "scripts/eval-agentops.sh --fast",
+    "bash tests/scripts/test-headless-runtime-skills.sh",
+    "bash scripts/validate-codex-rpi-contract.sh",
+    "bash scripts/validate-codex-lifecycle-guards.sh",
+    "bash scripts/audit-codex-parity.sh",
+    "scripts/pre-push-gate.sh --fast"
+  ],
+  "tracker_mode": "tasklist",
+  "tracker_health": {
+    "healthy": false,
+    "mode": "tasklist",
+    "reason": "bd readiness probes crashed inside Dolt-backed storage in the linked worktree; discovery stayed file-backed."
+  },
+  "done_criteria": [
+    "Eval suite and run schemas exist and are indexed.",
+    "ao eval can run deterministic suites and compare candidate-vs-baseline results.",
+    "Public canary suites cover skills, hooks, CLI, runtime inventory, and RPI.",
+    "Live Claude/Codex adapters are opt-in, isolated, and environment-scrubbed.",
+    "RPI and skill-change scorecards define better/worse decisions from baseline deltas.",
+    "Local/CI/nightly/release gate tiers are documented and initially advisory for live runs."
+  ],
+  "complexity": "standard",
+  "pre_mortem_verdict": "WARN",
+  "test_levels": {
+    "required": ["L0", "L1", "L2", "L3"],
+    "recommended": ["live-nightly", "release-model-matrix"],
+    "rationale": "The eval environment touches schemas/docs, CLI commands, shell hooks, headless runtime I/O, RPI end-to-end behavior, and cross-runtime model validation."
+  },
+  "ranked_packet_path": ".agents/rpi/ranked-packet.json",
+  "discovery_timestamp": "2026-04-24T15:45:00-04:00"
+}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -140,6 +140,23 @@ jobs:
           chmod +x scripts/generate-cli-reference.sh
           ./scripts/generate-cli-reference.sh --check
 
+  agentops-eval-advisory:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache-dependency-path: cli/go.sum
+
+      - name: Run AgentOps public eval canaries
+        run: |
+          chmod +x scripts/eval-agentops.sh
+          ./scripts/eval-agentops.sh --fast
+
   shellcheck:
     runs-on: ubuntu-latest
     steps:
@@ -854,7 +871,7 @@ jobs:
           echo "File manifests found in evidence — overlap check delegated to file-manifest-overlap job"
 
   summary:
-    needs: [doc-release-gate, smoke-test, hook-preflight, standards-injector-completeness, validate-hooks-doc-parity, validate-ci-policy-parity, codex-runtime-sections, embedded-sync, cli-docs-parity, shellcheck, markdownlint, security-scan, security-toolchain-gate, skill-integrity, skill-schema, skill-dependency-check, contract-compatibility-gate, memrl-health, plugin-load-test, go-build, windows-smoke, cli-integration, json-flag-consistency, file-manifest-overlap, doctor-check, skill-lint, learning-coherence, bats-tests, check-test-staleness, swarm-evidence]
+    needs: [doc-release-gate, smoke-test, hook-preflight, standards-injector-completeness, validate-hooks-doc-parity, validate-ci-policy-parity, codex-runtime-sections, embedded-sync, cli-docs-parity, agentops-eval-advisory, shellcheck, markdownlint, security-scan, security-toolchain-gate, skill-integrity, skill-schema, skill-dependency-check, contract-compatibility-gate, memrl-health, plugin-load-test, go-build, windows-smoke, cli-integration, json-flag-consistency, file-manifest-overlap, doctor-check, skill-lint, learning-coherence, bats-tests, check-test-staleness, swarm-evidence]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -870,6 +887,7 @@ jobs:
           echo "codex-runtime-sections: ${{ needs.codex-runtime-sections.result }}"
           echo "embedded-sync: ${{ needs.embedded-sync.result }}"
           echo "cli-docs-parity: ${{ needs.cli-docs-parity.result }}"
+          echo "agentops-eval-advisory: ${{ needs.agentops-eval-advisory.result }}"
           echo "shellcheck: ${{ needs.shellcheck.result }}"
           echo "markdownlint: ${{ needs.markdownlint.result }}"
           echo "security-scan: ${{ needs.security-scan.result }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ scripts/validate-go-fast.sh     # Quick Go validation (build + vet + test)
 
 ## CI Validation — Passing the Pipeline
 
-All pushes to `main` and PRs run `.github/workflows/validate.yml`. **Run checks locally before pushing.** The summary job gates on all checks except security-toolchain-gate (non-blocking), doctor-check (non-blocking), and check-test-staleness (non-blocking).
+All pushes to `main` and PRs run `.github/workflows/validate.yml`. **Run checks locally before pushing.** The summary job gates on all checks except agentops-eval-advisory (non-blocking), security-toolchain-gate (non-blocking), doctor-check (non-blocking), and check-test-staleness (non-blocking).
 Blocking policy list (must match the validate summary failset): every job in the CI table below except jobs marked `(non-blocking)`, including `codex-runtime-sections`.
 
 ### Local Pre-Push Checklist
@@ -122,6 +122,9 @@ find skills -type l  # must be empty — zero symlinks allowed
 
  # 14. Codex semantic parity audit (generated skills still match Codex-native tool/runtime semantics)
  bash scripts/audit-codex-parity.sh
+
+ # 15. AgentOps eval canaries
+ scripts/eval-agentops.sh --fast
 
 # Full gate (runs everything above and more):
 scripts/ci-local-release.sh
@@ -191,6 +194,7 @@ This repo has a canonical root worktree. It owns the common `.git` directory and
 
 | Job | What it validates | Common failure |
 |-----|-------------------|----------------|
+| **agentops-eval-advisory** | Runs deterministic public AgentOps eval canaries and baseline comparisons when baselines exist | Non-blocking (`continue-on-error: true`); eval suite or scorecard regression until baselines are ratcheted |
 | **cli-docs-parity** | `cli/docs/COMMANDS.md` matches `ao --help` output | Adding a CLI command without running `scripts/generate-cli-reference.sh` |
 | **cli-integration** | Built CLI runs integration command matrix and hook lifecycle smoke tests | CLI command behavior drift not covered by unit tests |
 | **codex-runtime-sections** | Required Codex runtime sections and ordering remain valid; CI also enforces Codex artifact metadata parity, backbone prompts, override coverage, RPI contract, lifecycle guards, and headless runtime smoke in this job | AGENTS/runtime guidance changes drift from required Codex runtime section rules or Codex artifact/runtime checks stop matching the shipped local gate stack |

--- a/cli/cmd/ao/cobra_commands_test.go
+++ b/cli/cmd/ao/cobra_commands_test.go
@@ -256,6 +256,16 @@ func executeCommand(args ...string) (string, error) {
 	findingsPullForce = false
 	findingsRetireBy = ""
 	scenarioListStatus = ""
+	evalRunOutput = ""
+	evalRunID = ""
+	evalRunRuntime = ""
+	evalRunBaseline = ""
+	evalCompareOutput = ""
+	evalCompareMaxAgg = 0
+	evalCompareMaxDim = 0
+	evalBaselineOutput = ""
+	evalBaselineBy = ""
+	evalBaselineReason = ""
 	overnightGoal = ""
 	overnightOutputDir = ""
 	overnightRunTimeout = ""
@@ -387,7 +397,7 @@ func TestCobraCommandTreeRegistration(t *testing.T) {
 	expectedCmds := []string{
 		"agents", "anti-patterns", "autodev", "badge", "batch-feedback", "beads", "completion", "config",
 		"constraint", "context", "codex", "compile", "contradict", "corpus", "curate", "dedup",
-		"defrag", "demo", "doctor", "evolve", "extract", "factory", "feedback", "feedback-loop",
+		"defrag", "demo", "doctor", "eval", "evolve", "extract", "factory", "feedback", "feedback-loop",
 		"findings", "flywheel", "forge", "gate", "goals", "handoff", "harvest", "hooks",
 		"index", "init", "inject", "knowledge", "lookup", "maturity",
 		"memory", "metrics", "migrate", "mind", "mine", "notebook", "overnight", "plans",
@@ -410,6 +420,7 @@ func TestCobraCommandTreeRegistration(t *testing.T) {
 	parentExpectations := map[string][]string{
 		"autodev":    {"init", "validate", "show"},
 		"beads":      {"verify", "lint", "harvest"},
+		"eval":       {"run", "compare", "baseline"},
 		"factory":    {"start"},
 		"goals":      {"validate", "measure", "drift"},
 		"knowledge":  {"activate", "beliefs", "playbooks", "brief", "gaps"},
@@ -445,7 +456,7 @@ func TestCobraExpectedCmdsMatchRegistration(t *testing.T) {
 	expectedCmds := []string{
 		"agents", "anti-patterns", "autodev", "badge", "batch-feedback", "beads", "completion", "config",
 		"constraint", "context", "codex", "compile", "contradict", "corpus", "curate", "dedup",
-		"defrag", "demo", "doctor", "evolve", "extract", "factory", "feedback", "feedback-loop",
+		"defrag", "demo", "doctor", "eval", "evolve", "extract", "factory", "feedback", "feedback-loop",
 		"findings", "flywheel", "forge", "gate", "goals", "handoff", "harvest", "hooks",
 		"index", "init", "inject", "knowledge", "lookup", "maturity",
 		"memory", "metrics", "migrate", "mind", "mine", "notebook", "overnight", "plans",

--- a/cli/cmd/ao/cobra_commands_test.go
+++ b/cli/cmd/ao/cobra_commands_test.go
@@ -263,6 +263,9 @@ func executeCommand(args ...string) (string, error) {
 	evalCompareOutput = ""
 	evalCompareMaxAgg = 0
 	evalCompareMaxDim = 0
+	evalScorecardOutput = ""
+	evalScorecardKind = "rpi"
+	evalScorecardMaxCat = 0
 	evalBaselineOutput = ""
 	evalBaselineBy = ""
 	evalBaselineReason = ""
@@ -420,7 +423,7 @@ func TestCobraCommandTreeRegistration(t *testing.T) {
 	parentExpectations := map[string][]string{
 		"autodev":    {"init", "validate", "show"},
 		"beads":      {"verify", "lint", "harvest"},
-		"eval":       {"run", "compare", "baseline"},
+		"eval":       {"run", "compare", "baseline", "scorecard"},
 		"factory":    {"start"},
 		"goals":      {"validate", "measure", "drift"},
 		"knowledge":  {"activate", "beliefs", "playbooks", "brief", "gaps"},

--- a/cli/cmd/ao/cobra_commands_test.go
+++ b/cli/cmd/ao/cobra_commands_test.go
@@ -269,6 +269,8 @@ func executeCommand(args ...string) (string, error) {
 	evalBaselineOutput = ""
 	evalBaselineBy = ""
 	evalBaselineReason = ""
+	evalCoverageRoot = "evals/agentops-core"
+	evalCoverageRequire = []string{"cli", "hook", "skill", "rpi", "runtime", "retrieval", "scenario", "mixed"}
 	overnightGoal = ""
 	overnightOutputDir = ""
 	overnightRunTimeout = ""
@@ -423,7 +425,7 @@ func TestCobraCommandTreeRegistration(t *testing.T) {
 	parentExpectations := map[string][]string{
 		"autodev":    {"init", "validate", "show"},
 		"beads":      {"verify", "lint", "harvest"},
-		"eval":       {"run", "compare", "baseline", "scorecard"},
+		"eval":       {"run", "compare", "baseline", "scorecard", "coverage"},
 		"factory":    {"start"},
 		"goals":      {"validate", "measure", "drift"},
 		"knowledge":  {"activate", "beliefs", "playbooks", "brief", "gaps"},

--- a/cli/cmd/ao/eval.go
+++ b/cli/cmd/ao/eval.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	aoeval "github.com/boshu2/agentops/cli/internal/eval"
+)
+
+var (
+	evalRunOutput      string
+	evalRunID          string
+	evalRunRuntime     string
+	evalRunBaseline    string
+	evalCompareOutput  string
+	evalCompareMaxAgg  float64
+	evalCompareMaxDim  float64
+	evalBaselineOutput string
+	evalBaselineBy     string
+	evalBaselineReason string
+	evalConfigured     bool
+)
+
+var evalCmd = &cobra.Command{
+	Use:   "eval",
+	Short: "Run deterministic local evaluation suites",
+	Long: `Run deterministic AgentOps evaluation suites and compare run records.
+
+The eval surface intentionally supports only offline deterministic runs in this
+release. Live Claude and Codex adapters are evaluated by a later runtime tier.`,
+}
+
+var evalRunCmd = &cobra.Command{
+	Use:   "run <suite.json>",
+	Short: "Run a deterministic eval suite",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		runtimeName, err := parseEvalRuntime(evalRunRuntime)
+		if err != nil {
+			return err
+		}
+		run, err := aoeval.RunSuite(aoeval.RunOptions{
+			SuitePath:    args[0],
+			RunID:        evalRunID,
+			Runtime:      runtimeName,
+			OutputPath:   evalRunOutput,
+			BaselinePath: evalRunBaseline,
+		})
+		if err != nil {
+			return err
+		}
+		if GetOutput() == "json" {
+			return writeEvalJSON(cmd, run)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Eval %s: %s (aggregate %.4f, cases %d)\n", run.RunID, run.Status, run.AggregateScore, len(run.CaseResults))
+		if evalRunOutput != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "Run record: %s\n", evalRunOutput)
+		}
+		return nil
+	},
+}
+
+var evalCompareCmd = &cobra.Command{
+	Use:   "compare <candidate-run.json> <baseline-run.json>",
+	Short: "Compare an eval run against a baseline",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		candidate, err := aoeval.LoadRun(args[0])
+		if err != nil {
+			return err
+		}
+		baseline, err := aoeval.LoadRun(args[1])
+		if err != nil {
+			return err
+		}
+		compared, err := aoeval.CompareRuns(candidate, baseline, aoeval.CompareOptions{
+			MaxAggregateRegression: evalCompareMaxAgg,
+			MaxDimensionRegression: evalCompareMaxDim,
+			OutputPath:             evalCompareOutput,
+		})
+		if err != nil {
+			return err
+		}
+		if GetOutput() == "json" {
+			return writeEvalJSON(cmd, compared)
+		}
+		delta := 0.0
+		if compared.BaselineComparison != nil {
+			delta = compared.BaselineComparison.AggregateDelta
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Eval compare %s vs %s: %s (aggregate delta %.4f)\n", compared.RunID, baseline.RunID, compared.Verdict, delta)
+		if evalCompareOutput != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "Comparison record: %s\n", evalCompareOutput)
+		}
+		return nil
+	},
+}
+
+var evalBaselineCmd = &cobra.Command{
+	Use:   "baseline <run.json>",
+	Short: "Promote an eval run record as a baseline",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		run, err := aoeval.LoadRun(args[0])
+		if err != nil {
+			return err
+		}
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		promoted, err := aoeval.PromoteBaseline(run, aoeval.BaselineOptions{
+			OutputPath: evalBaselineOutput,
+			PromotedBy: evalBaselineBy,
+			Rationale:  evalBaselineReason,
+			WorkDir:    cwd,
+		})
+		if err != nil {
+			return err
+		}
+		if GetOutput() == "json" {
+			return writeEvalJSON(cmd, promoted)
+		}
+		path := ""
+		if promoted.Baseline != nil {
+			path = promoted.Baseline.BaselinePath
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Eval baseline promoted: %s\n", path)
+		return nil
+	},
+}
+
+func init() {
+	registerEvalCommand()
+}
+
+func registerEvalCommand() {
+	if !evalConfigured {
+		configureEvalCommand()
+		evalConfigured = true
+	}
+	if evalCmd.Parent() == nil {
+		rootCmd.AddCommand(evalCmd)
+	}
+}
+
+func configureEvalCommand() {
+	evalCmd.GroupID = "workflow"
+
+	evalRunCmd.Flags().StringVar(&evalRunOutput, "out", "", "write eval run record to path")
+	evalRunCmd.Flags().StringVar(&evalRunID, "run-id", "", "stable run id to use in the run record")
+	evalRunCmd.Flags().StringVar(&evalRunRuntime, "runtime", "", "deterministic runtime override (static, mock, shell)")
+	evalRunCmd.Flags().StringVar(&evalRunBaseline, "baseline", "", "compare the run against a baseline run record")
+	_ = evalRunCmd.RegisterFlagCompletionFunc("runtime", staticCompletionFunc("static", "mock", "shell"))
+
+	evalCompareCmd.Flags().StringVar(&evalCompareOutput, "out", "", "write compared eval run record to path")
+	evalCompareCmd.Flags().Float64Var(&evalCompareMaxAgg, "max-aggregate-regression", 0, "allowed aggregate regression before verdict becomes regression")
+	evalCompareCmd.Flags().Float64Var(&evalCompareMaxDim, "max-dimension-regression", 0, "allowed per-dimension regression before verdict becomes regression")
+
+	evalBaselineCmd.Flags().StringVar(&evalBaselineOutput, "out", "", "write promoted baseline run record to path")
+	evalBaselineCmd.Flags().StringVar(&evalBaselineBy, "promoted-by", "", "identity promoting the baseline")
+	evalBaselineCmd.Flags().StringVar(&evalBaselineReason, "rationale", "", "rationale for promoting the baseline")
+
+	evalCmd.AddCommand(evalRunCmd, evalCompareCmd, evalBaselineCmd)
+}
+
+func parseEvalRuntime(value string) (aoeval.Runtime, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	switch aoeval.Runtime(value) {
+	case aoeval.RuntimeStatic, aoeval.RuntimeMock, aoeval.RuntimeShell:
+		return aoeval.Runtime(value), nil
+	default:
+		return "", fmt.Errorf("runtime %q is out of deterministic scope (use static, mock, or shell)", value)
+	}
+}
+
+func writeEvalJSON(cmd *cobra.Command, value any) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(value)
+}

--- a/cli/cmd/ao/eval.go
+++ b/cli/cmd/ao/eval.go
@@ -12,17 +12,20 @@ import (
 )
 
 var (
-	evalRunOutput      string
-	evalRunID          string
-	evalRunRuntime     string
-	evalRunBaseline    string
-	evalCompareOutput  string
-	evalCompareMaxAgg  float64
-	evalCompareMaxDim  float64
-	evalBaselineOutput string
-	evalBaselineBy     string
-	evalBaselineReason string
-	evalConfigured     bool
+	evalRunOutput       string
+	evalRunID           string
+	evalRunRuntime      string
+	evalRunBaseline     string
+	evalCompareOutput   string
+	evalCompareMaxAgg   float64
+	evalCompareMaxDim   float64
+	evalScorecardOutput string
+	evalScorecardKind   string
+	evalScorecardMaxCat float64
+	evalBaselineOutput  string
+	evalBaselineBy      string
+	evalBaselineReason  string
+	evalConfigured      bool
 )
 
 var evalCmd = &cobra.Command{
@@ -134,6 +137,49 @@ var evalBaselineCmd = &cobra.Command{
 	},
 }
 
+var evalScorecardCmd = &cobra.Command{
+	Use:   "scorecard <candidate-run.json> [baseline-run.json]",
+	Short: "Build an eval scorecard from run records",
+	Args:  cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		kind, err := parseScorecardKind(evalScorecardKind)
+		if err != nil {
+			return err
+		}
+		candidate, err := aoeval.LoadRun(args[0])
+		if err != nil {
+			return err
+		}
+		var baseline *aoeval.RunRecord
+		if len(args) == 2 {
+			baseline, err = aoeval.LoadRun(args[1])
+			if err != nil {
+				return err
+			}
+		}
+		scorecard, err := aoeval.BuildScorecard(candidate, baseline, aoeval.ScorecardOptions{
+			Kind:                  kind,
+			MaxCategoryRegression: evalScorecardMaxCat,
+		})
+		if err != nil {
+			return err
+		}
+		if evalScorecardOutput != "" {
+			if err := aoeval.WriteScorecard(evalScorecardOutput, scorecard); err != nil {
+				return err
+			}
+		}
+		if GetOutput() == "json" {
+			return writeEvalJSON(cmd, scorecard)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Eval scorecard %s: %s (%s, categories %d)\n", scorecard.CandidateRunID, scorecard.Verdict, scorecard.Kind, len(scorecard.Categories))
+		if evalScorecardOutput != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "Scorecard: %s\n", evalScorecardOutput)
+		}
+		return nil
+	},
+}
+
 func init() {
 	registerEvalCommand()
 }
@@ -165,7 +211,12 @@ func configureEvalCommand() {
 	evalBaselineCmd.Flags().StringVar(&evalBaselineBy, "promoted-by", "", "identity promoting the baseline")
 	evalBaselineCmd.Flags().StringVar(&evalBaselineReason, "rationale", "", "rationale for promoting the baseline")
 
-	evalCmd.AddCommand(evalRunCmd, evalCompareCmd, evalBaselineCmd)
+	evalScorecardCmd.Flags().StringVar(&evalScorecardOutput, "out", "", "write scorecard JSON to path")
+	evalScorecardCmd.Flags().StringVar(&evalScorecardKind, "kind", string(aoeval.ScorecardKindRPI), "scorecard kind (rpi, skill-change)")
+	evalScorecardCmd.Flags().Float64Var(&evalScorecardMaxCat, "max-category-regression", 0, "allowed per-category regression before verdict becomes regression")
+	_ = evalScorecardCmd.RegisterFlagCompletionFunc("kind", staticCompletionFunc(string(aoeval.ScorecardKindRPI), string(aoeval.ScorecardKindSkillChange)))
+
+	evalCmd.AddCommand(evalRunCmd, evalCompareCmd, evalBaselineCmd, evalScorecardCmd)
 }
 
 func parseEvalRuntime(value string) (aoeval.Runtime, error) {
@@ -178,6 +229,19 @@ func parseEvalRuntime(value string) (aoeval.Runtime, error) {
 		return aoeval.Runtime(value), nil
 	default:
 		return "", fmt.Errorf("runtime %q is out of deterministic scope (use static, mock, or shell)", value)
+	}
+}
+
+func parseScorecardKind(value string) (aoeval.ScorecardKind, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return aoeval.ScorecardKindRPI, nil
+	}
+	switch aoeval.ScorecardKind(value) {
+	case aoeval.ScorecardKindRPI, aoeval.ScorecardKindSkillChange:
+		return aoeval.ScorecardKind(value), nil
+	default:
+		return "", fmt.Errorf("unsupported scorecard kind %q (use rpi or skill-change)", value)
 	}
 }
 

--- a/cli/cmd/ao/eval.go
+++ b/cli/cmd/ao/eval.go
@@ -25,6 +25,8 @@ var (
 	evalBaselineOutput  string
 	evalBaselineBy      string
 	evalBaselineReason  string
+	evalCoverageRoot    string
+	evalCoverageRequire []string
 	evalConfigured      bool
 )
 
@@ -180,6 +182,36 @@ var evalScorecardCmd = &cobra.Command{
 	},
 }
 
+var evalCoverageCmd = &cobra.Command{
+	Use:   "coverage [suite.json ...]",
+	Short: "Summarize eval suite coverage",
+	Args:  cobra.ArbitraryArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		roots := []string{}
+		if len(args) == 0 {
+			roots = append(roots, evalCoverageRoot)
+		}
+		report, err := aoeval.BuildCoverageReport(aoeval.CoverageOptions{
+			SuitePaths:      args,
+			Roots:           roots,
+			RequiredDomains: evalCoverageRequire,
+		})
+		if err != nil {
+			return err
+		}
+		if GetOutput() == "json" {
+			return writeEvalJSON(cmd, report)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Eval coverage: %d suites, %d cases, %d critical cases\n", report.SuiteCount, report.CaseCount, report.CriticalCaseCount)
+		if len(report.MissingRequiredDomains) > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "Missing required domains: %s\n", strings.Join(report.MissingRequiredDomains, ", "))
+		} else if len(report.RequiredDomains) > 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "Required domains covered")
+		}
+		return nil
+	},
+}
+
 func init() {
 	registerEvalCommand()
 }
@@ -211,12 +243,15 @@ func configureEvalCommand() {
 	evalBaselineCmd.Flags().StringVar(&evalBaselineBy, "promoted-by", "", "identity promoting the baseline")
 	evalBaselineCmd.Flags().StringVar(&evalBaselineReason, "rationale", "", "rationale for promoting the baseline")
 
+	evalCoverageCmd.Flags().StringVar(&evalCoverageRoot, "root", "evals/agentops-core", "suite root to scan when no suite paths are provided")
+	evalCoverageCmd.Flags().StringArrayVar(&evalCoverageRequire, "require-domain", aoeval.DefaultCoverageDomains, "required product domain for missing-domain reporting")
+
 	evalScorecardCmd.Flags().StringVar(&evalScorecardOutput, "out", "", "write scorecard JSON to path")
 	evalScorecardCmd.Flags().StringVar(&evalScorecardKind, "kind", string(aoeval.ScorecardKindRPI), "scorecard kind (rpi, skill-change)")
 	evalScorecardCmd.Flags().Float64Var(&evalScorecardMaxCat, "max-category-regression", 0, "allowed per-category regression before verdict becomes regression")
 	_ = evalScorecardCmd.RegisterFlagCompletionFunc("kind", staticCompletionFunc(string(aoeval.ScorecardKindRPI), string(aoeval.ScorecardKindSkillChange)))
 
-	evalCmd.AddCommand(evalRunCmd, evalCompareCmd, evalBaselineCmd, evalScorecardCmd)
+	evalCmd.AddCommand(evalRunCmd, evalCompareCmd, evalBaselineCmd, evalScorecardCmd, evalCoverageCmd)
 }
 
 func parseEvalRuntime(value string) (aoeval.Runtime, error) {

--- a/cli/cmd/ao/eval_test.go
+++ b/cli/cmd/ao/eval_test.go
@@ -86,6 +86,60 @@ func TestEvalCompareCommandJSON(t *testing.T) {
 	}
 }
 
+func TestEvalScorecardCommandJSON(t *testing.T) {
+	withEvalCommand(t)
+	dir := t.TempDir()
+	baselinePath := filepath.Join(dir, "baseline.json")
+	candidatePath := filepath.Join(dir, "candidate.json")
+	writeEvalScorecardRunRecord(t, candidatePath, "candidate-run", map[string]float64{
+		"artifact-completeness": 1,
+		"phase-order":           1,
+		"objective-spine":       1,
+		"validation-separation": 1,
+		"scenario-satisfaction": 1,
+		"runtime-safety":        1,
+	})
+	writeEvalScorecardRunRecord(t, baselinePath, "baseline-run", map[string]float64{
+		"artifact-completeness": 0.8,
+		"phase-order":           1,
+		"objective-spine":       1,
+		"validation-separation": 1,
+		"scenario-satisfaction": 1,
+		"runtime-safety":        1,
+	})
+
+	out, err := executeCommand("eval", "scorecard", candidatePath, baselinePath, "--kind", "rpi", "--json")
+	if err != nil {
+		t.Fatalf("ao eval scorecard failed: %v\noutput: %s", err, out)
+	}
+	var scorecard aoeval.Scorecard
+	if err := json.Unmarshal([]byte(out), &scorecard); err != nil {
+		t.Fatalf("eval scorecard JSON parse failed: %v\noutput: %s", err, out)
+	}
+	if scorecard.Kind != aoeval.ScorecardKindRPI {
+		t.Fatalf("kind = %s, want rpi", scorecard.Kind)
+	}
+	if scorecard.CandidateRunID != "candidate-run" || scorecard.BaselineRunID != "baseline-run" {
+		t.Fatalf("run ids = %q/%q, want candidate-run/baseline-run", scorecard.CandidateRunID, scorecard.BaselineRunID)
+	}
+	if scorecard.Verdict != aoeval.VerdictImprovement {
+		t.Fatalf("verdict = %s, want improvement", scorecard.Verdict)
+	}
+	if len(scorecard.Categories) != 6 {
+		t.Fatalf("category count = %d, want 6", len(scorecard.Categories))
+	}
+	category := evalScorecardCategory(t, scorecard, "artifact completeness")
+	if category.CandidateScore != 1 {
+		t.Fatalf("artifact completeness candidate_score = %v, want 1", category.CandidateScore)
+	}
+	if category.BaselineScore == nil || *category.BaselineScore != 0.8 {
+		t.Fatalf("artifact completeness baseline_score = %v, want 0.8", category.BaselineScore)
+	}
+	if category.Delta == nil || *category.Delta != 0.2 {
+		t.Fatalf("artifact completeness delta = %v, want 0.2", category.Delta)
+	}
+}
+
 func TestEvalBaselineCommandJSON(t *testing.T) {
 	withEvalCommand(t)
 	dir := t.TempDir()
@@ -181,6 +235,87 @@ func writeEvalRunRecord(t *testing.T, path, runID string, score float64) {
 		t.Fatalf("marshal run: %v", err)
 	}
 	writeEvalCmdFile(t, path, string(data))
+}
+
+func writeEvalScorecardRunRecord(t *testing.T, path, runID string, scores map[string]float64) {
+	t.Helper()
+	slugs := []string{
+		"artifact-completeness",
+		"phase-order",
+		"objective-spine",
+		"validation-separation",
+		"scenario-satisfaction",
+		"runtime-safety",
+	}
+	sum := 0.0
+	results := make([]aoeval.CaseResult, 0, len(slugs))
+	for _, slug := range slugs {
+		score := scores[slug]
+		sum += score
+		results = append(results, aoeval.CaseResult{
+			ID:     "scorecard." + slug + ".surface",
+			Status: aoeval.StatusPass,
+			Score:  score,
+			DimensionScores: map[aoeval.Dimension]float64{
+				aoeval.DimensionCorrectness: score,
+			},
+		})
+	}
+	aggregate := sum / float64(len(slugs))
+	run := aoeval.RunRecord{
+		SchemaVersion: 1,
+		RunID:         runID,
+		Suite: aoeval.SuiteRef{
+			ID:         "agentops-core.rpi-scorecard",
+			Path:       "suite.json",
+			Visibility: aoeval.VisibilityPublicCanary,
+			Tier:       aoeval.TierDeterministic,
+		},
+		StartedAt: fixedEvalCmdTime(),
+		Status:    aoeval.StatusPass,
+		Verdict:   aoeval.VerdictPass,
+		Git: aoeval.GitRecord{
+			CandidateRef: "test",
+			CandidateSHA: "0000000",
+			Dirty:        false,
+		},
+		Runtime: aoeval.RuntimeRecord{
+			Name: aoeval.RuntimeStatic,
+			Live: false,
+		},
+		Environment: aoeval.EnvironmentRecord{
+			ScrubbedEnvPrefixes: []string{"AGENTOPS_RPI_RUNTIME"},
+			IsolatedHome:        false,
+			IsolatedCodexHome:   false,
+			NetworkAccess:       aoeval.NetworkDisabled,
+		},
+		CaseResults:    results,
+		AggregateScore: aggregate,
+		DimensionScores: map[aoeval.Dimension]float64{
+			aoeval.DimensionCorrectness:          aggregate,
+			aoeval.DimensionProcessAdherence:     aggregate,
+			aoeval.DimensionArtifactQuality:      aggregate,
+			aoeval.DimensionRuntimeCompatibility: aggregate,
+			aoeval.DimensionSafety:               aggregate,
+			aoeval.DimensionLearningClosure:      aggregate,
+		},
+	}
+	data, err := json.MarshalIndent(run, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal scorecard run: %v", err)
+	}
+	writeEvalCmdFile(t, path, string(data))
+}
+
+func evalScorecardCategory(t *testing.T, scorecard aoeval.Scorecard, name string) aoeval.ScorecardCategory {
+	t.Helper()
+	for _, category := range scorecard.Categories {
+		if category.Category == name {
+			return category
+		}
+	}
+	t.Fatalf("category %q not found in %+v", name, scorecard.Categories)
+	return aoeval.ScorecardCategory{}
 }
 
 func fixedEvalCmdTime() time.Time {

--- a/cli/cmd/ao/eval_test.go
+++ b/cli/cmd/ao/eval_test.go
@@ -169,6 +169,58 @@ func TestEvalBaselineCommandJSON(t *testing.T) {
 	}
 }
 
+func TestEvalCoverageCommandJSON(t *testing.T) {
+	withEvalCommand(t)
+	dir := t.TempDir()
+	writeEvalCmdFile(t, filepath.Join(dir, "fixture.txt"), "ok\n")
+	writeEvalCmdFile(t, filepath.Join(dir, "suite.json"), `{
+  "schema_version": 1,
+  "id": "coverage.cli",
+  "name": "Coverage CLI",
+  "domain": "cli",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "allowed_runtimes": ["static"],
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "correctness", "weight": 1, "threshold": 1}
+    ]
+  },
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {
+      "id": "fixture",
+      "title": "fixture",
+      "kind": "artifact_check",
+      "objective": "fixture",
+      "expectations": [
+        {"type": "file_exists", "target": "fixture.txt"}
+      ],
+      "critical": true
+    }
+  ]
+}`)
+
+	out, err := executeCommand("eval", "coverage", "--root", dir, "--json")
+	if err != nil {
+		t.Fatalf("ao eval coverage failed: %v\noutput: %s", err, out)
+	}
+	var report aoeval.CoverageReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("eval coverage JSON parse failed: %v\noutput: %s", err, out)
+	}
+	if report.SuiteCount != 1 || report.CaseCount != 1 || report.CriticalCaseCount != 1 {
+		t.Fatalf("coverage counts = suites:%d cases:%d critical:%d, want 1/1/1", report.SuiteCount, report.CaseCount, report.CriticalCaseCount)
+	}
+	if report.Domains["cli"].SuiteCount != 1 {
+		t.Fatalf("cli domain coverage = %+v, want one suite", report.Domains["cli"])
+	}
+	if len(report.MissingRequiredDomains) == 0 {
+		t.Fatalf("missing required domains empty; want gaps for non-cli domains")
+	}
+}
+
 func writeEvalCmdSuite(t *testing.T, dir, body string) string {
 	t.Helper()
 	path := filepath.Join(dir, "suite.json")

--- a/cli/cmd/ao/eval_test.go
+++ b/cli/cmd/ao/eval_test.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	aoeval "github.com/boshu2/agentops/cli/internal/eval"
+)
+
+func TestEvalRunCommandJSON(t *testing.T) {
+	withEvalCommand(t)
+	dir := t.TempDir()
+	writeEvalCmdFile(t, filepath.Join(dir, "fixture.txt"), "needle\n")
+	suitePath := writeEvalCmdSuite(t, dir, `{
+  "schema_version": 1,
+  "id": "cmd.pass",
+  "name": "Command pass",
+  "domain": "cli",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "correctness", "weight": 1, "threshold": 1}
+    ]
+  },
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {
+      "id": "contains",
+      "title": "fixture contains needle",
+      "kind": "artifact_check",
+      "objective": "Score fixture deterministically.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "fixture.txt", "value": "needle"}
+      ]
+    }
+  ]
+}`)
+
+	out, err := executeCommand("eval", "run", suitePath, "--run-id", "cmd-pass", "--json")
+	if err != nil {
+		t.Fatalf("ao eval run failed: %v\noutput: %s", err, out)
+	}
+	var run aoeval.RunRecord
+	if err := json.Unmarshal([]byte(out), &run); err != nil {
+		t.Fatalf("eval run JSON parse failed: %v\noutput: %s", err, out)
+	}
+	if run.RunID != "cmd-pass" || run.Status != aoeval.StatusPass {
+		t.Fatalf("run_id/status = %q/%s, want cmd-pass/pass", run.RunID, run.Status)
+	}
+}
+
+func TestEvalRunCommandMissingSuiteFails(t *testing.T) {
+	withEvalCommand(t)
+	out, err := executeCommand("eval", "run", filepath.Join(t.TempDir(), "missing.json"), "--json")
+	if err == nil {
+		t.Fatalf("ao eval run missing suite succeeded; output: %s", out)
+	}
+}
+
+func TestEvalCompareCommandJSON(t *testing.T) {
+	withEvalCommand(t)
+	dir := t.TempDir()
+	baselinePath := filepath.Join(dir, "baseline.json")
+	candidatePath := filepath.Join(dir, "candidate.json")
+	writeEvalRunRecord(t, baselinePath, "baseline-run", 0.80)
+	writeEvalRunRecord(t, candidatePath, "candidate-run", 0.95)
+
+	out, err := executeCommand("eval", "compare", candidatePath, baselinePath, "--json")
+	if err != nil {
+		t.Fatalf("ao eval compare failed: %v\noutput: %s", err, out)
+	}
+	var compared aoeval.RunRecord
+	if err := json.Unmarshal([]byte(out), &compared); err != nil {
+		t.Fatalf("eval compare JSON parse failed: %v\noutput: %s", err, out)
+	}
+	if compared.Verdict != aoeval.VerdictImprovement {
+		t.Fatalf("verdict = %s, want improvement", compared.Verdict)
+	}
+	if compared.BaselineComparison == nil || compared.BaselineComparison.BaselineRunID != "baseline-run" {
+		t.Fatalf("baseline comparison = %+v", compared.BaselineComparison)
+	}
+}
+
+func TestEvalBaselineCommandJSON(t *testing.T) {
+	withEvalCommand(t)
+	dir := t.TempDir()
+	runPath := filepath.Join(dir, "run.json")
+	outputPath := filepath.Join(dir, "baseline.json")
+	writeEvalRunRecord(t, runPath, "candidate-run", 1.0)
+
+	out, err := executeCommand(
+		"eval", "baseline", runPath,
+		"--out", outputPath,
+		"--promoted-by", "tester",
+		"--rationale", "stable canary",
+		"--json",
+	)
+	if err != nil {
+		t.Fatalf("ao eval baseline failed: %v\noutput: %s", err, out)
+	}
+	var promoted aoeval.RunRecord
+	if err := json.Unmarshal([]byte(out), &promoted); err != nil {
+		t.Fatalf("eval baseline JSON parse failed: %v\noutput: %s", err, out)
+	}
+	if promoted.Baseline == nil || promoted.Baseline.Mode != aoeval.BaselineModePromote {
+		t.Fatalf("baseline metadata = %+v, want promote", promoted.Baseline)
+	}
+	if _, err := os.Stat(outputPath); err != nil {
+		t.Fatalf("baseline output not written: %v", err)
+	}
+}
+
+func writeEvalCmdSuite(t *testing.T, dir, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, "suite.json")
+	writeEvalCmdFile(t, path, body)
+	return path
+}
+
+func writeEvalCmdFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func writeEvalRunRecord(t *testing.T, path, runID string, score float64) {
+	t.Helper()
+	run := aoeval.RunRecord{
+		SchemaVersion: 1,
+		RunID:         runID,
+		Suite: aoeval.SuiteRef{
+			ID:         "cmd.pass",
+			Path:       "suite.json",
+			Visibility: aoeval.VisibilityPublicCanary,
+			Tier:       aoeval.TierDeterministic,
+		},
+		StartedAt: fixedEvalCmdTime(),
+		Status:    aoeval.StatusPass,
+		Verdict:   aoeval.VerdictPass,
+		Git: aoeval.GitRecord{
+			CandidateRef: "test",
+			CandidateSHA: "0000000",
+			Dirty:        false,
+		},
+		Runtime: aoeval.RuntimeRecord{
+			Name: aoeval.RuntimeStatic,
+			Live: false,
+		},
+		Environment: aoeval.EnvironmentRecord{
+			ScrubbedEnvPrefixes: []string{"AGENTOPS_RPI_RUNTIME"},
+			IsolatedHome:        false,
+			IsolatedCodexHome:   false,
+			NetworkAccess:       aoeval.NetworkDisabled,
+		},
+		CaseResults: []aoeval.CaseResult{
+			{
+				ID:     "case",
+				Status: aoeval.StatusPass,
+				Score:  score,
+				DimensionScores: map[aoeval.Dimension]float64{
+					aoeval.DimensionCorrectness: score,
+				},
+			},
+		},
+		AggregateScore: score,
+		DimensionScores: map[aoeval.Dimension]float64{
+			aoeval.DimensionCorrectness: score,
+		},
+	}
+	data, err := json.MarshalIndent(run, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal run: %v", err)
+	}
+	writeEvalCmdFile(t, path, string(data))
+}
+
+func fixedEvalCmdTime() time.Time {
+	return time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+}
+
+func withEvalCommand(t *testing.T) {
+	t.Helper()
+	registerEvalCommand()
+}

--- a/cli/cmd/ao/scenario_add.go
+++ b/cli/cmd/ao/scenario_add.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	scenarioIDPattern = regexp.MustCompile(`^(s-\d{4}-\d{2}-\d{2}-\d{3}|auto-.+)$`)
+	scenarioAddNow    = time.Now
+	scenarioAddFlags  = struct {
+		Narrative       string
+		ExpectedOutcome string
+		Threshold       float64
+		Status          string
+		Source          string
+	}{
+		Threshold: 0.8,
+		Status:    "draft",
+		Source:    "human",
+	}
+)
+
+type scenarioFile struct {
+	ID                    string                     `json:"id"`
+	Version               int                        `json:"version"`
+	Date                  string                     `json:"date"`
+	Goal                  string                     `json:"goal"`
+	Narrative             string                     `json:"narrative"`
+	ExpectedOutcome       string                     `json:"expected_outcome"`
+	AcceptanceVectors     []scenarioAcceptanceVector `json:"acceptance_vectors,omitempty"`
+	SatisfactionThreshold float64                    `json:"satisfaction_threshold"`
+	Source                string                     `json:"source,omitempty"`
+	Status                string                     `json:"status"`
+}
+
+type scenarioAcceptanceVector struct {
+	Dimension string  `json:"dimension"`
+	Threshold float64 `json:"threshold"`
+	Check     string  `json:"check,omitempty"`
+}
+
+var scenarioAddCmd = &cobra.Command{
+	Use:   "add <goal>",
+	Short: "Author a holdout scenario from a goal description",
+	Long: `Author a schema-compliant holdout scenario in .agents/holdout/.
+
+The command infers narrative and expected-outcome text from the provided goal
+unless explicit values are supplied. New scenarios default to draft so a human
+or evaluator can review them before activation.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runScenarioAdd,
+}
+
+func runScenarioAdd(cmd *cobra.Command, args []string) error {
+	goal := strings.TrimSpace(args[0])
+	if goal == "" {
+		return fmt.Errorf("goal is required")
+	}
+	if err := validateScenarioAddFlags(); err != nil {
+		return err
+	}
+
+	holdoutDir := filepath.Join(".agents", "holdout")
+	if err := os.MkdirAll(holdoutDir, 0o755); err != nil {
+		return fmt.Errorf("creating holdout directory: %w", err)
+	}
+
+	date := scenarioAddNow().UTC().Format("2006-01-02")
+	id, err := nextScenarioID(holdoutDir, date)
+	if err != nil {
+		return err
+	}
+	scenario := scenarioFile{
+		ID:                    id,
+		Version:               1,
+		Date:                  date,
+		Goal:                  goal,
+		Narrative:             scenarioNarrative(goal, scenarioAddFlags.Narrative),
+		ExpectedOutcome:       scenarioExpectedOutcome(goal, scenarioAddFlags.ExpectedOutcome),
+		SatisfactionThreshold: scenarioAddFlags.Threshold,
+		Source:                scenarioAddFlags.Source,
+		Status:                scenarioAddFlags.Status,
+	}
+
+	path := filepath.Join(holdoutDir, id+".json")
+	data, err := json.MarshalIndent(scenario, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling scenario: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("writing scenario %s: %w", path, err)
+	}
+
+	if GetOutput() == "json" {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(scenario)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Created scenario %s at %s\n", id, path)
+	return nil
+}
+
+func validateScenarioAddFlags() error {
+	if scenarioAddFlags.Threshold < 0 || scenarioAddFlags.Threshold > 1 {
+		return fmt.Errorf("threshold %.2f out of range [0, 1]", scenarioAddFlags.Threshold)
+	}
+	if !validScenarioStatus(scenarioAddFlags.Status) {
+		return fmt.Errorf("invalid status %q (must be active, draft, or retired)", scenarioAddFlags.Status)
+	}
+	if !validScenarioSource(scenarioAddFlags.Source) {
+		return fmt.Errorf("invalid source %q (must be human, agent, or prod-telemetry)", scenarioAddFlags.Source)
+	}
+	return nil
+}
+
+func nextScenarioID(holdoutDir, date string) (string, error) {
+	entries, err := os.ReadDir(holdoutDir)
+	if err != nil {
+		return "", fmt.Errorf("reading holdout directory: %w", err)
+	}
+	prefix := "s-" + date + "-"
+	maxSeq := 0
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		for _, candidate := range scenarioIDCandidates(holdoutDir, entry.Name()) {
+			if seq, ok := scenarioSequence(candidate, prefix); ok && seq > maxSeq {
+				maxSeq = seq
+			}
+		}
+	}
+	return fmt.Sprintf("%s%03d", prefix, maxSeq+1), nil
+}
+
+func scenarioIDCandidates(holdoutDir, fileName string) []string {
+	candidates := []string{strings.TrimSuffix(fileName, filepath.Ext(fileName))}
+	data, err := os.ReadFile(filepath.Join(holdoutDir, fileName))
+	if err != nil {
+		return candidates
+	}
+	var decoded struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(data, &decoded); err == nil && strings.TrimSpace(decoded.ID) != "" {
+		candidates = append(candidates, strings.TrimSpace(decoded.ID))
+	}
+	return candidates
+}
+
+func scenarioSequence(id, prefix string) (int, bool) {
+	if !strings.HasPrefix(id, prefix) {
+		return 0, false
+	}
+	seqText := strings.TrimPrefix(id, prefix)
+	if len(seqText) != 3 {
+		return 0, false
+	}
+	seq, err := strconv.Atoi(seqText)
+	if err != nil {
+		return 0, false
+	}
+	return seq, true
+}
+
+func scenarioNarrative(goal, override string) string {
+	if value := strings.TrimSpace(override); value != "" {
+		return value
+	}
+	return fmt.Sprintf("A user or evaluator exercises the system behavior for this goal: %s.", goal)
+}
+
+func scenarioExpectedOutcome(goal, override string) string {
+	if value := strings.TrimSpace(override); value != "" {
+		return value
+	}
+	return fmt.Sprintf("The implementation satisfies the goal in observable behavior: %s.", goal)
+}
+
+func validScenarioStatus(status string) bool {
+	switch status {
+	case "active", "draft", "retired":
+		return true
+	default:
+		return false
+	}
+}
+
+func validScenarioSource(source string) bool {
+	switch source {
+	case "human", "agent", "prod-telemetry":
+		return true
+	default:
+		return false
+	}
+}
+
+func init() {
+	scenarioAddCmd.Flags().StringVar(&scenarioAddFlags.Narrative, "narrative", "", "Narrative description (default: inferred from goal)")
+	scenarioAddCmd.Flags().StringVar(&scenarioAddFlags.ExpectedOutcome, "expected-outcome", "", "Expected observable outcome (default: inferred from goal)")
+	scenarioAddCmd.Flags().Float64Var(&scenarioAddFlags.Threshold, "threshold", 0.8, "Satisfaction threshold in [0,1]")
+	scenarioAddCmd.Flags().StringVar(&scenarioAddFlags.Status, "status", "draft", "Scenario status (active, draft, retired)")
+	scenarioAddCmd.Flags().StringVar(&scenarioAddFlags.Source, "source", "human", "Scenario source (human, agent, prod-telemetry)")
+	_ = scenarioAddCmd.RegisterFlagCompletionFunc("status", staticCompletionFunc("active", "draft", "retired"))
+	_ = scenarioAddCmd.RegisterFlagCompletionFunc("source", staticCompletionFunc("human", "agent", "prod-telemetry"))
+	scenarioCmd.AddCommand(scenarioAddCmd)
+}

--- a/cli/cmd/ao/scenario_test.go
+++ b/cli/cmd/ao/scenario_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestScenarioInit_CreatesDirectory(t *testing.T) {
@@ -152,6 +153,104 @@ func TestScenarioList_FilterByStatus(t *testing.T) {
 	}
 }
 
+func TestScenarioAdd_CreatesSchemaCompliantScenario(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+	withScenarioClock(t, time.Date(2026, 4, 24, 10, 30, 0, 0, time.UTC))
+
+	out, err := executeCommand(
+		"scenario", "add", "CLI can author holdout scenarios",
+		"--narrative", "Evaluator authors a scenario through the CLI.",
+		"--expected-outcome", "A schema-compliant scenario file is written.",
+		"--status", "active",
+		"--source", "agent",
+		"--threshold", "0.9",
+		"--json",
+	)
+	if err != nil {
+		t.Fatalf("scenario add failed: %v\noutput: %s", err, out)
+	}
+
+	var scenario scenarioFile
+	if err := json.Unmarshal([]byte(out), &scenario); err != nil {
+		t.Fatalf("parse scenario add JSON: %v\noutput: %s", err, out)
+	}
+	if scenario.ID != "s-2026-04-24-001" {
+		t.Fatalf("id = %q, want s-2026-04-24-001", scenario.ID)
+	}
+	if scenario.Date != "2026-04-24" || scenario.Status != "active" || scenario.Source != "agent" {
+		t.Fatalf("unexpected metadata: %+v", scenario)
+	}
+	if scenario.SatisfactionThreshold != 0.9 {
+		t.Fatalf("threshold = %.2f, want 0.90", scenario.SatisfactionThreshold)
+	}
+
+	path := filepath.Join(".agents", "holdout", "s-2026-04-24-001.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("scenario file not written: %v", err)
+	}
+	validateOut, err := executeCommand("scenario", "validate")
+	if err != nil {
+		t.Fatalf("written scenario should validate: %v\noutput: %s", err, validateOut)
+	}
+}
+
+func TestScenarioAdd_IncrementsSameDayID(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+	withScenarioClock(t, time.Date(2026, 4, 24, 10, 30, 0, 0, time.UTC))
+
+	holdoutDir := filepath.Join(".agents", "holdout")
+	if err := os.MkdirAll(holdoutDir, 0755); err != nil {
+		t.Fatalf("mkdir holdout: %v", err)
+	}
+	existing := map[string]interface{}{
+		"id": "s-2026-04-24-003", "version": 1, "date": "2026-04-24",
+		"goal": "existing", "narrative": "existing", "expected_outcome": "existing",
+		"satisfaction_threshold": 0.8, "status": "draft",
+	}
+	data, _ := json.Marshal(existing)
+	if err := os.WriteFile(filepath.Join(holdoutDir, "legacy.json"), data, 0644); err != nil {
+		t.Fatalf("write existing scenario: %v", err)
+	}
+
+	out, err := executeCommand("scenario", "add", "next same-day scenario", "--json")
+	if err != nil {
+		t.Fatalf("scenario add failed: %v\noutput: %s", err, out)
+	}
+	var scenario scenarioFile
+	if err := json.Unmarshal([]byte(out), &scenario); err != nil {
+		t.Fatalf("parse scenario add JSON: %v\noutput: %s", err, out)
+	}
+	if scenario.ID != "s-2026-04-24-004" {
+		t.Fatalf("id = %q, want s-2026-04-24-004", scenario.ID)
+	}
+}
+
+func TestScenarioAdd_RejectsInvalidFlags(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	if out, err := executeCommand("scenario", "add", "bad threshold", "--threshold", "1.2"); err == nil {
+		t.Fatalf("scenario add should reject invalid threshold; output: %s", out)
+	}
+	if out, err := executeCommand("scenario", "add", "bad status", "--status", "blocked"); err == nil {
+		t.Fatalf("scenario add should reject invalid status; output: %s", out)
+	}
+}
+
 func TestScenarioValidate_ValidSchema(t *testing.T) {
 	dir := t.TempDir()
 	origDir, _ := os.Getwd()
@@ -174,6 +273,34 @@ func TestScenarioValidate_ValidSchema(t *testing.T) {
 	out, err := executeCommand("scenario", "validate")
 	if err != nil {
 		t.Fatalf("validate should pass: %v", err)
+	}
+	if !strings.Contains(out, "all pass") {
+		t.Fatalf("expected 'all pass', got: %s", out)
+	}
+}
+
+func TestScenarioValidate_AcceptsAutoID(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	holdoutDir := filepath.Join(".agents", "holdout")
+	os.MkdirAll(holdoutDir, 0755)
+
+	scenario := map[string]interface{}{
+		"id": "auto-agentops-core-cli", "version": 1, "date": "2026-04-24",
+		"goal": "test", "narrative": "test", "expected_outcome": "test",
+		"satisfaction_threshold": 0.7, "status": "draft", "source": "agent",
+	}
+	data, _ := json.Marshal(scenario)
+	os.WriteFile(filepath.Join(holdoutDir, "auto.json"), data, 0644)
+
+	out, err := executeCommand("scenario", "validate")
+	if err != nil {
+		t.Fatalf("validate should accept auto-* IDs: %v\noutput: %s", err, out)
 	}
 	if !strings.Contains(out, "all pass") {
 		t.Fatalf("expected 'all pass', got: %s", out)
@@ -255,4 +382,13 @@ func TestScenarioValidate_EmptyDir(t *testing.T) {
 	if !strings.Contains(out, "No scenario files found") {
 		t.Fatalf("expected empty message, got: %s", out)
 	}
+}
+
+func withScenarioClock(t *testing.T, now time.Time) {
+	t.Helper()
+	orig := scenarioAddNow
+	scenarioAddNow = func() time.Time { return now }
+	t.Cleanup(func() {
+		scenarioAddNow = orig
+	})
 }

--- a/cli/cmd/ao/scenario_validate.go
+++ b/cli/cmd/ao/scenario_validate.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -24,10 +23,6 @@ var scenarioValidateCmd = &cobra.Command{
 			}
 			return fmt.Errorf("reading holdout directory: %w", err)
 		}
-
-		idPattern := regexp.MustCompile(`^s-\d{4}-\d{2}-\d{2}-\d{3}$`)
-		validStatuses := map[string]bool{"active": true, "draft": true, "retired": true}
-		validSources := map[string]bool{"human": true, "agent": true, "prod-telemetry": true}
 
 		var validationErrors []string
 		var validated int
@@ -59,21 +54,21 @@ var scenarioValidateCmd = &cobra.Command{
 
 			// Validate id pattern
 			if id, ok := s["id"].(string); ok {
-				if !idPattern.MatchString(id) {
-					validationErrors = append(validationErrors, fmt.Sprintf("%s: id '%s' does not match pattern s-YYYY-MM-DD-NNN", entry.Name(), id))
+				if !scenarioIDPattern.MatchString(id) {
+					validationErrors = append(validationErrors, fmt.Sprintf("%s: id '%s' does not match pattern s-YYYY-MM-DD-NNN or auto-*", entry.Name(), id))
 				}
 			}
 
 			// Validate status
 			if status, ok := s["status"].(string); ok {
-				if !validStatuses[status] {
+				if !validScenarioStatus(status) {
 					validationErrors = append(validationErrors, fmt.Sprintf("%s: invalid status '%s' (must be active, draft, or retired)", entry.Name(), status))
 				}
 			}
 
 			// Validate source if present
 			if source, ok := s["source"].(string); ok {
-				if !validSources[source] {
+				if !validScenarioSource(source) {
 					validationErrors = append(validationErrors, fmt.Sprintf("%s: invalid source '%s' (must be human, agent, or prod-telemetry)", entry.Name(), source))
 				}
 			}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -902,6 +902,23 @@ ao eval run <suite.json> [flags]
       --runtime string    deterministic runtime override (static, mock, shell)
 ```
 
+#### `ao eval scorecard`
+
+Build an eval scorecard from run records
+
+```
+ao eval scorecard <candidate-run.json> [baseline-run.json] [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help                            help for scorecard
+      --kind string                     scorecard kind (rpi, skill-change) (default "rpi")
+      --max-category-regression float   allowed per-category regression before verdict becomes regression
+      --out string                      write scorecard JSON to path
+```
+
 ---
 
 ### `ao evolve`

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -884,6 +884,22 @@ ao eval compare <candidate-run.json> <baseline-run.json> [flags]
       --out string                       write compared eval run record to path
 ```
 
+#### `ao eval coverage`
+
+Summarize eval suite coverage
+
+```
+ao eval coverage [suite.json ...] [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help                         help for coverage
+      --require-domain stringArray   required product domain for missing-domain reporting (default [cli,hook,skill,rpi,runtime,retrieval,scenario,mixed])
+      --root string                  suite root to scan when no suite paths are provided (default "evals/agentops-core")
+```
+
 #### `ao eval run`
 
 Run a deterministic eval suite

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -2873,6 +2873,25 @@ ao scenario [command]
 
 **Subcommands:**
 
+#### `ao scenario add`
+
+Author a schema-compliant holdout scenario in .agents/holdout/.
+
+```
+ao scenario add <goal> [flags]
+```
+
+**Flags:**
+
+```
+      --expected-outcome string   Expected observable outcome (default: inferred from goal)
+  -h, --help                      help for add
+      --narrative string          Narrative description (default: inferred from goal)
+      --source string             Scenario source (human, agent, prod-telemetry) (default "human")
+      --status string             Scenario status (active, draft, retired) (default "draft")
+      --threshold float           Satisfaction threshold in [0,1] (default 0.8)
+```
+
 #### `ao scenario init`
 
 Initialize .agents/holdout/ directory for scenario storage

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -840,6 +840,70 @@ ao codex stop [flags]
 
 ---
 
+### `ao eval`
+
+Run deterministic AgentOps evaluation suites and compare run records.
+
+```
+ao eval [command]
+```
+
+**Subcommands:**
+
+#### `ao eval baseline`
+
+Promote an eval run record as a baseline
+
+```
+ao eval baseline <run.json> [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help                 help for baseline
+      --out string           write promoted baseline run record to path
+      --promoted-by string   identity promoting the baseline
+      --rationale string     rationale for promoting the baseline
+```
+
+#### `ao eval compare`
+
+Compare an eval run against a baseline
+
+```
+ao eval compare <candidate-run.json> <baseline-run.json> [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help                             help for compare
+      --max-aggregate-regression float   allowed aggregate regression before verdict becomes regression
+      --max-dimension-regression float   allowed per-dimension regression before verdict becomes regression
+      --out string                       write compared eval run record to path
+```
+
+#### `ao eval run`
+
+Run a deterministic eval suite
+
+```
+ao eval run <suite.json> [flags]
+```
+
+**Flags:**
+
+```
+      --baseline string   compare the run against a baseline run record
+  -h, --help              help for run
+      --out string        write eval run record to path
+      --run-id string     stable run id to use in the run record
+      --runtime string    deterministic runtime override (static, mock, shell)
+```
+
+---
+
 ### `ao evolve`
 
 Run the v2 autonomous improvement loop.

--- a/cli/internal/eval/baseline.go
+++ b/cli/internal/eval/baseline.go
@@ -1,0 +1,56 @@
+package eval
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func PromoteBaseline(run *RunRecord, opts BaselineOptions) (*RunRecord, error) {
+	if err := ValidateRun(run); err != nil {
+		return nil, err
+	}
+	promoted, err := cloneRun(run)
+	if err != nil {
+		return nil, err
+	}
+	now := opts.Now
+	if now == nil {
+		now = defaultNow
+	}
+	promotedAt := now().UTC()
+	outputPath := opts.OutputPath
+	if outputPath == "" {
+		workDir := opts.WorkDir
+		if workDir == "" {
+			workDir = "."
+		}
+		outputPath = filepath.Join(workDir, ".agents", "evals", "baselines", sanitizeBaselineFilename(run.Suite.ID+"-"+run.RunID)+".json")
+	}
+	promoted.Baseline = &BaselineRecord{
+		Mode:              BaselineModePromote,
+		BaselineRunID:     run.RunID,
+		BaselinePath:      outputPath,
+		PromotedFromRunID: run.RunID,
+		PromotedAt:        &promotedAt,
+		PromotedBy:        opts.PromotedBy,
+		Rationale:         opts.Rationale,
+	}
+	promoted.Artifacts = append(promoted.Artifacts, Artifact{
+		Path:    outputPath,
+		Purpose: "promoted eval baseline",
+		Kind:    "baseline",
+	})
+	if err := WriteRun(outputPath, promoted); err != nil {
+		return nil, err
+	}
+	return promoted, nil
+}
+
+func sanitizeBaselineFilename(value string) string {
+	value = sanitizeRunID(value)
+	value = strings.Trim(value, ".")
+	if value == "" {
+		return "baseline"
+	}
+	return value
+}

--- a/cli/internal/eval/compare.go
+++ b/cli/internal/eval/compare.go
@@ -1,0 +1,118 @@
+package eval
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+func CompareRuns(candidate, baseline *RunRecord, opts CompareOptions) (*RunRecord, error) {
+	if err := ValidateRun(candidate); err != nil {
+		return nil, err
+	}
+	if err := ValidateRun(baseline); err != nil {
+		return nil, err
+	}
+	compared, err := cloneRun(candidate)
+	if err != nil {
+		return nil, err
+	}
+	aggregateDelta := roundDelta(candidate.AggregateScore - baseline.AggregateScore)
+	dimensionDeltas := compareDimensionScores(candidate.DimensionScores, baseline.DimensionScores)
+	regressions, improvements := classifyDimensionDeltas(dimensionDeltas, opts.MaxDimensionRegression)
+	aggregateRegressed := aggregateDelta < -opts.MaxAggregateRegression
+	if aggregateRegressed && len(regressions) == 0 {
+		regressions = append(regressions, ComparisonItem{
+			Dimension: DimensionCorrectness,
+			Delta:     aggregateDelta,
+			Reason:    fmt.Sprintf("aggregate score regressed by %.4f", aggregateDelta),
+		})
+	}
+	verdict := VerdictPass
+	if len(regressions) > 0 {
+		verdict = VerdictRegression
+	} else if aggregateDelta > 0 || len(improvements) > 0 {
+		verdict = VerdictImprovement
+	}
+	compared.Verdict = verdict
+	compared.Baseline = &BaselineRecord{
+		Mode:          BaselineModeCompare,
+		BaselineRunID: baseline.RunID,
+		BaselineRef:   baseline.Git.CandidateRef,
+	}
+	compared.BaselineComparison = &BaselineComparison{
+		Verdict:        verdict,
+		BaselineRunID:  baseline.RunID,
+		BaselineScore:  baseline.AggregateScore,
+		AggregateDelta: aggregateDelta,
+		DimensionDelta: dimensionDeltas,
+		Regressions:    regressions,
+		Improvements:   improvements,
+	}
+	if opts.OutputPath != "" {
+		compared.Artifacts = append(compared.Artifacts, Artifact{
+			Path:    opts.OutputPath,
+			Purpose: "evaluation comparison run record",
+			Kind:    "run_json",
+		})
+		if err := WriteRun(opts.OutputPath, compared); err != nil {
+			return nil, err
+		}
+	}
+	return compared, nil
+}
+
+func compareDimensionScores(candidate, baseline map[Dimension]float64) map[Dimension]float64 {
+	keys := make(map[Dimension]struct{}, len(candidate)+len(baseline))
+	for dim := range candidate {
+		keys[dim] = struct{}{}
+	}
+	for dim := range baseline {
+		keys[dim] = struct{}{}
+	}
+	out := make(map[Dimension]float64, len(keys))
+	for dim := range keys {
+		out[dim] = roundDelta(candidate[dim] - baseline[dim])
+	}
+	return out
+}
+
+func classifyDimensionDeltas(deltas map[Dimension]float64, maxRegression float64) ([]ComparisonItem, []ComparisonItem) {
+	keys := make([]Dimension, 0, len(deltas))
+	for dim := range deltas {
+		keys = append(keys, dim)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	var regressions []ComparisonItem
+	var improvements []ComparisonItem
+	for _, dim := range keys {
+		delta := deltas[dim]
+		switch {
+		case delta < -maxRegression:
+			regressions = append(regressions, ComparisonItem{
+				Dimension: dim,
+				Delta:     delta,
+				Reason:    fmt.Sprintf("%s regressed by %.4f", dim, delta),
+			})
+		case delta > 0:
+			improvements = append(improvements, ComparisonItem{
+				Dimension: dim,
+				Delta:     delta,
+				Reason:    fmt.Sprintf("%s improved by %.4f", dim, delta),
+			})
+		}
+	}
+	return regressions, improvements
+}
+
+func cloneRun(run *RunRecord) (*RunRecord, error) {
+	data, err := json.Marshal(run)
+	if err != nil {
+		return nil, err
+	}
+	var cloned RunRecord
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return nil, err
+	}
+	return &cloned, nil
+}

--- a/cli/internal/eval/coverage.go
+++ b/cli/internal/eval/coverage.go
@@ -1,0 +1,247 @@
+package eval
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+var DefaultCoverageDomains = []string{
+	"cli",
+	"hook",
+	"skill",
+	"rpi",
+	"runtime",
+	"retrieval",
+	"scenario",
+	"mixed",
+}
+
+type CoverageOptions struct {
+	SuitePaths      []string
+	Roots           []string
+	RequiredDomains []string
+}
+
+type CoverageReport struct {
+	SuiteCount             int                       `json:"suite_count"`
+	CaseCount              int                       `json:"case_count"`
+	CriticalCaseCount      int                       `json:"critical_case_count"`
+	Suites                 []CoverageSuite           `json:"suites"`
+	Domains                map[string]CoverageBucket `json:"domains"`
+	Dimensions             map[string]int            `json:"dimensions"`
+	Runtimes               map[string]int            `json:"runtimes"`
+	RequiredDomains        []string                  `json:"required_domains,omitempty"`
+	MissingRequiredDomains []string                  `json:"missing_required_domains,omitempty"`
+}
+
+type CoverageSuite struct {
+	ID                string   `json:"id"`
+	Domain            string   `json:"domain"`
+	Tier              string   `json:"tier"`
+	Visibility        string   `json:"visibility"`
+	CaseCount         int      `json:"case_count"`
+	CriticalCaseCount int      `json:"critical_case_count"`
+	Dimensions        []string `json:"dimensions"`
+	Runtimes          []string `json:"runtimes"`
+}
+
+type CoverageBucket struct {
+	SuiteCount        int `json:"suite_count"`
+	CaseCount         int `json:"case_count"`
+	CriticalCaseCount int `json:"critical_case_count"`
+}
+
+func BuildCoverageReport(opts CoverageOptions) (*CoverageReport, error) {
+	paths, err := coverageSuitePaths(opts)
+	if err != nil {
+		return nil, err
+	}
+	report := &CoverageReport{
+		Domains:    map[string]CoverageBucket{},
+		Dimensions: map[string]int{},
+		Runtimes:   map[string]int{},
+	}
+	for _, path := range paths {
+		suite, _, err := LoadSuite(path)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+		addSuiteCoverage(report, suite)
+	}
+	report.RequiredDomains = normalizedCoverageDomains(opts.RequiredDomains)
+	report.MissingRequiredDomains = missingCoverageDomains(report.Domains, report.RequiredDomains)
+	return report, nil
+}
+
+func coverageSuitePaths(opts CoverageOptions) ([]string, error) {
+	seen := map[string]struct{}{}
+	var paths []string
+	for _, path := range opts.SuitePaths {
+		addCoveragePath(&paths, seen, path)
+	}
+	for _, root := range opts.Roots {
+		discovered, err := discoverCoverageSuites(root)
+		if err != nil {
+			return nil, err
+		}
+		for _, path := range discovered {
+			addCoveragePath(&paths, seen, path)
+		}
+	}
+	sort.Strings(paths)
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no eval suites found")
+	}
+	return paths, nil
+}
+
+func discoverCoverageSuites(root string) ([]string, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return nil, nil
+	}
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("inspect eval coverage root %s: %w", root, err)
+	}
+	if !info.IsDir() {
+		return []string{root}, nil
+	}
+	var paths []string
+	err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+		paths = append(paths, path)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk eval coverage root %s: %w", root, err)
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func addCoveragePath(paths *[]string, seen map[string]struct{}, path string) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return
+	}
+	if _, ok := seen[path]; ok {
+		return
+	}
+	seen[path] = struct{}{}
+	*paths = append(*paths, path)
+}
+
+func addSuiteCoverage(report *CoverageReport, suite *Suite) {
+	summary := coverageSuiteSummary(suite)
+	report.Suites = append(report.Suites, summary)
+	report.SuiteCount++
+	report.CaseCount += summary.CaseCount
+	report.CriticalCaseCount += summary.CriticalCaseCount
+	addDomainCoverage(report, summary)
+	for _, dim := range summary.Dimensions {
+		report.Dimensions[dim]++
+	}
+	for _, runtime := range summary.Runtimes {
+		report.Runtimes[runtime]++
+	}
+}
+
+func coverageSuiteSummary(suite *Suite) CoverageSuite {
+	dimensions := coverageDimensions(suite)
+	runtimes := coverageRuntimes(suite)
+	critical := 0
+	for _, evalCase := range suite.Cases {
+		if evalCase.Critical {
+			critical++
+		}
+	}
+	return CoverageSuite{
+		ID:                suite.ID,
+		Domain:            suite.Domain,
+		Tier:              string(suite.Tier),
+		Visibility:        string(suite.Visibility),
+		CaseCount:         len(suite.Cases),
+		CriticalCaseCount: critical,
+		Dimensions:        dimensions,
+		Runtimes:          runtimes,
+	}
+}
+
+func addDomainCoverage(report *CoverageReport, suite CoverageSuite) {
+	bucket := report.Domains[suite.Domain]
+	bucket.SuiteCount++
+	bucket.CaseCount += suite.CaseCount
+	bucket.CriticalCaseCount += suite.CriticalCaseCount
+	report.Domains[suite.Domain] = bucket
+}
+
+func coverageDimensions(suite *Suite) []string {
+	seen := map[string]struct{}{}
+	for _, dim := range suite.Scoring.Dimensions {
+		seen[string(dim.Name)] = struct{}{}
+	}
+	for _, evalCase := range suite.Cases {
+		for _, dim := range evalCase.Dimensions {
+			seen[string(dim)] = struct{}{}
+		}
+	}
+	return sortedCoverageKeys(seen)
+}
+
+func coverageRuntimes(suite *Suite) []string {
+	seen := map[string]struct{}{}
+	for _, runtime := range suite.Allowed {
+		seen[string(runtime)] = struct{}{}
+	}
+	for _, evalCase := range suite.Cases {
+		if evalCase.Runtime != "" {
+			seen[string(evalCase.Runtime)] = struct{}{}
+		}
+	}
+	if len(seen) == 0 {
+		seen[string(inferRuntime(*suite))] = struct{}{}
+	}
+	return sortedCoverageKeys(seen)
+}
+
+func normalizedCoverageDomains(values []string) []string {
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		seen[value] = struct{}{}
+	}
+	return sortedCoverageKeys(seen)
+}
+
+func missingCoverageDomains(domains map[string]CoverageBucket, required []string) []string {
+	var missing []string
+	for _, domain := range required {
+		if domains[domain].SuiteCount == 0 {
+			missing = append(missing, domain)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+func sortedCoverageKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cli/internal/eval/coverage_test.go
+++ b/cli/internal/eval/coverage_test.go
@@ -1,0 +1,82 @@
+package eval
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildCoverageReportSummarizesDomains(t *testing.T) {
+	dir := t.TempDir()
+	writeCoverageSuite(t, filepath.Join(dir, "cli.json"), "coverage.cli", "cli", "shell")
+	writeCoverageSuite(t, filepath.Join(dir, "skill.json"), "coverage.skill", "skill", "static")
+
+	report, err := BuildCoverageReport(CoverageOptions{
+		Roots:           []string{dir},
+		RequiredDomains: []string{"cli", "skill", "scenario"},
+	})
+	if err != nil {
+		t.Fatalf("BuildCoverageReport failed: %v", err)
+	}
+	if report.SuiteCount != 2 || report.CaseCount != 2 || report.CriticalCaseCount != 2 {
+		t.Fatalf("counts = suites:%d cases:%d critical:%d, want 2/2/2", report.SuiteCount, report.CaseCount, report.CriticalCaseCount)
+	}
+	if report.Domains["cli"].SuiteCount != 1 || report.Domains["skill"].SuiteCount != 1 {
+		t.Fatalf("domain coverage = %+v, want cli and skill", report.Domains)
+	}
+	if len(report.MissingRequiredDomains) != 1 || report.MissingRequiredDomains[0] != "scenario" {
+		t.Fatalf("missing required domains = %v, want [scenario]", report.MissingRequiredDomains)
+	}
+	if report.Dimensions[string(DimensionCorrectness)] != 2 {
+		t.Fatalf("correctness dimension count = %d, want 2", report.Dimensions[string(DimensionCorrectness)])
+	}
+}
+
+func TestBuildCoverageReportMissingRootFails(t *testing.T) {
+	_, err := BuildCoverageReport(CoverageOptions{Roots: []string{filepath.Join(t.TempDir(), "missing")}})
+	if err == nil {
+		t.Fatalf("BuildCoverageReport missing root succeeded")
+	}
+}
+
+func writeCoverageSuite(t *testing.T, path, id, domain, runtimeName string) {
+	t.Helper()
+	body := `{
+  "schema_version": 1,
+  "id": "` + id + `",
+  "name": "` + id + `",
+  "domain": "` + domain + `",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "allowed_runtimes": ["` + runtimeName + `"],
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "correctness", "weight": 1, "threshold": 1}
+    ]
+  },
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {
+      "id": "case",
+      "title": "case",
+      "kind": "artifact_check",
+      "objective": "case",
+      "runtime": "` + runtimeName + `",
+      "expectations": [
+        {"type": "file_exists", "target": "fixture.txt"}
+      ],
+      "critical": true
+    }
+  ]
+}`
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	if err := os.WriteFile(filepath.Join(filepath.Dir(path), "fixture.txt"), []byte("ok\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}

--- a/cli/internal/eval/engine.go
+++ b/cli/internal/eval/engine.go
@@ -1,0 +1,612 @@
+package eval
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+const defaultTimeoutSeconds = 30
+
+func RunSuite(opts RunOptions) (*RunRecord, error) {
+	if strings.TrimSpace(opts.SuitePath) == "" {
+		return nil, fmt.Errorf("suite path is required")
+	}
+	suite, suiteData, err := LoadSuite(opts.SuitePath)
+	if err != nil {
+		return nil, err
+	}
+	workDir := opts.WorkDir
+	if workDir == "" {
+		workDir, err = os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("get working directory: %w", err)
+		}
+	}
+	now := opts.Now
+	if now == nil {
+		now = defaultNow
+	}
+	started := now().UTC()
+	runID := strings.TrimSpace(opts.RunID)
+	if runID == "" {
+		runID = defaultRunID(suite.ID, started)
+	}
+	runtimeName := opts.Runtime
+	if runtimeName == "" {
+		runtimeName = inferRuntime(*suite)
+	}
+	if !validDeterministicRuntime(runtimeName) {
+		return nil, fmt.Errorf("runtime %q is out of deterministic scope", runtimeName)
+	}
+
+	suiteDir := filepath.Dir(opts.SuitePath)
+	caseResults := make([]CaseResult, 0, len(suite.Cases))
+	for _, evalCase := range suite.Cases {
+		caseResults = append(caseResults, runCase(*suite, suiteDir, evalCase))
+	}
+	aggregate, dimensions := scoreRun(*suite, caseResults)
+	status := runStatus(*suite, caseResults, aggregate, dimensions)
+	verdict := VerdictPass
+	if status != StatusPass {
+		verdict = VerdictFail
+	}
+	completed := now().UTC()
+	record := &RunRecord{
+		SchemaVersion: 1,
+		RunID:         runID,
+		Suite: SuiteRef{
+			ID:         suite.ID,
+			Path:       opts.SuitePath,
+			Visibility: suite.Visibility,
+			Tier:       suite.Tier,
+			SHA256:     sha256Hex(suiteData),
+		},
+		StartedAt:       started,
+		CompletedAt:     &completed,
+		Status:          status,
+		Verdict:         verdict,
+		Git:             collectGitRecord(workDir),
+		Runtime:         runtimeRecord(runtimeName, *suite),
+		Environment:     environmentRecord(*suite),
+		Baseline:        &BaselineRecord{Mode: BaselineModeNone},
+		CaseResults:     caseResults,
+		AggregateScore:  aggregate,
+		DimensionScores: dimensions,
+	}
+	if opts.BaselinePath != "" {
+		baseline, err := LoadRun(opts.BaselinePath)
+		if err != nil {
+			return nil, err
+		}
+		record, err = CompareRuns(record, baseline, compareOptionsFromSuite(*suite))
+		if err != nil {
+			return nil, err
+		}
+		record.Baseline.BaselinePath = opts.BaselinePath
+	}
+	if opts.OutputPath != "" {
+		record.Artifacts = append(record.Artifacts, Artifact{
+			Path:    opts.OutputPath,
+			Purpose: "evaluation run record",
+			Kind:    "run_json",
+		})
+		if err := WriteRun(opts.OutputPath, record); err != nil {
+			return nil, err
+		}
+	}
+	return record, nil
+}
+
+func runCase(suite Suite, suiteDir string, evalCase Case) CaseResult {
+	start := time.Now()
+	ctx := caseContext{
+		suite:    &suite,
+		suiteDir: suiteDir,
+		evalCase: evalCase,
+		exitCode: 0,
+	}
+	if evalCase.Kind == "command" {
+		output, err := executeCaseCommand(suite, suiteDir, evalCase)
+		ctx.stdout = output.stdout
+		ctx.stderr = output.stderr
+		ctx.exitCode = output.exitCode
+		if err != nil && output.infrastructureError {
+			return CaseResult{
+				ID:              evalCase.ID,
+				Status:          StatusError,
+				Score:           0,
+				DimensionScores: caseDimensions(suite, evalCase, 0),
+				DurationMS:      time.Since(start).Milliseconds(),
+				Critical:        evalCase.Critical,
+				FailureMessage:  err.Error(),
+				Diagnostics:     []string{err.Error()},
+			}
+		}
+	}
+
+	requiredTotal := 0
+	requiredPassed := 0
+	var diagnostics []string
+	var failures []string
+	for _, expectation := range evalCase.Expectations {
+		result := evaluateExpectation(expectation, ctx)
+		required := expectationRequired(expectation)
+		if required {
+			requiredTotal++
+			if result.passed {
+				requiredPassed++
+			} else {
+				failures = append(failures, result.message)
+			}
+		}
+		if !result.passed || result.message != "" {
+			diagnostics = append(diagnostics, result.message)
+		}
+	}
+	score := 1.0
+	if requiredTotal > 0 {
+		score = roundScore(float64(requiredPassed) / float64(requiredTotal))
+	}
+	status := StatusPass
+	if requiredPassed != requiredTotal {
+		status = StatusFail
+	}
+	return CaseResult{
+		ID:              evalCase.ID,
+		Status:          status,
+		Score:           score,
+		DimensionScores: caseDimensions(suite, evalCase, score),
+		DurationMS:      time.Since(start).Milliseconds(),
+		Critical:        evalCase.Critical,
+		FailureMessage:  strings.Join(failures, "; "),
+		Diagnostics:     compactStrings(diagnostics),
+	}
+}
+
+type commandOutput struct {
+	stdout              string
+	stderr              string
+	exitCode            int
+	infrastructureError bool
+}
+
+func executeCaseCommand(suite Suite, suiteDir string, evalCase Case) (commandOutput, error) {
+	spec, err := commandSpecFromInputs(evalCase.Inputs)
+	if err != nil {
+		return commandOutput{exitCode: -1, infrastructureError: true}, err
+	}
+	timeout := evalCase.TimeoutSeconds
+	if timeout == 0 {
+		timeout = suite.Environment.TimeoutSeconds
+	}
+	if timeout == 0 {
+		timeout = defaultTimeoutSeconds
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	name := spec.name
+	args := spec.args
+	if spec.shell != "" {
+		name, args = shellCommand(spec.shell)
+	}
+	cmd := exec.CommandContext(ctx, name, args...)
+	if spec.cwd != "" {
+		cmd.Dir = resolvePath(suiteDir, spec.cwd)
+	} else {
+		cmd.Dir = suiteDir
+	}
+	cmd.Env = applyCommandEnv(scrubbedEnv(os.Environ(), scrubPrefixes(suite)), spec.env)
+	if spec.stdin != "" {
+		cmd.Stdin = strings.NewReader(spec.stdin)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	output := commandOutput{
+		stdout:   stdout.String(),
+		stderr:   stderr.String(),
+		exitCode: 0,
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		output.exitCode = -1
+		output.infrastructureError = true
+		return output, fmt.Errorf("command timed out after %ds", timeout)
+	}
+	if err == nil {
+		return output, nil
+	}
+	var exitErr *exec.ExitError
+	if ok := errors.As(err, &exitErr); ok {
+		output.exitCode = exitErr.ExitCode()
+		return output, nil
+	}
+	output.exitCode = -1
+	output.infrastructureError = true
+	return output, fmt.Errorf("run command %q: %w", name, err)
+}
+
+type commandSpec struct {
+	name  string
+	args  []string
+	shell string
+	cwd   string
+	stdin string
+	env   map[string]string
+}
+
+func commandSpecFromInputs(inputs map[string]any) (commandSpec, error) {
+	if len(inputs) == 0 {
+		return commandSpec{}, fmt.Errorf("command case requires inputs.argv, inputs.command, or inputs.shell")
+	}
+	spec := commandSpec{
+		cwd:   inputString(inputs, "cwd"),
+		stdin: inputString(inputs, "stdin"),
+		env:   inputStringMap(inputs, "env"),
+		shell: inputString(inputs, "shell"),
+	}
+	if spec.shell != "" {
+		return spec, nil
+	}
+	argv := inputStringSlice(inputs, "argv")
+	if len(argv) > 0 {
+		spec.name = argv[0]
+		spec.args = argv[1:]
+		return spec, nil
+	}
+	spec.name = inputString(inputs, "command")
+	spec.args = inputStringSlice(inputs, "args")
+	if spec.name == "" {
+		return commandSpec{}, fmt.Errorf("command case requires non-empty command")
+	}
+	return spec, nil
+}
+
+func shellCommand(script string) (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd", []string{"/C", script}
+	}
+	return "sh", []string{"-c", script}
+}
+
+func scoreRun(suite Suite, results []CaseResult) (float64, map[Dimension]float64) {
+	dimensions := make(map[Dimension]float64, len(suite.Scoring.Dimensions))
+	for _, scoringDim := range suite.Scoring.Dimensions {
+		var sum float64
+		var count int
+		for _, result := range results {
+			if score, ok := result.DimensionScores[scoringDim.Name]; ok {
+				sum += score
+				count++
+			}
+		}
+		if count == 0 {
+			dimensions[scoringDim.Name] = 0
+		} else {
+			dimensions[scoringDim.Name] = roundScore(sum / float64(count))
+		}
+	}
+	var weightedSum float64
+	var weightTotal float64
+	for _, scoringDim := range suite.Scoring.Dimensions {
+		weightedSum += dimensions[scoringDim.Name] * scoringDim.Weight
+		weightTotal += scoringDim.Weight
+	}
+	if weightTotal == 0 {
+		return 0, dimensions
+	}
+	return roundScore(weightedSum / weightTotal), dimensions
+}
+
+func runStatus(suite Suite, results []CaseResult, aggregate float64, dimensions map[Dimension]float64) Status {
+	hasError := false
+	hasCriticalFailure := false
+	for _, result := range results {
+		if result.Status == StatusError {
+			hasError = true
+		}
+		if result.Critical && result.Status != StatusPass {
+			hasCriticalFailure = true
+		}
+	}
+	if hasError {
+		return StatusError
+	}
+	if hasCriticalFailure || aggregate < suite.Scoring.AggregateThreshold {
+		return StatusFail
+	}
+	for _, scoringDim := range suite.Scoring.Dimensions {
+		if dimensions[scoringDim.Name] < scoringDim.Threshold {
+			return StatusFail
+		}
+	}
+	return StatusPass
+}
+
+func caseDimensions(suite Suite, evalCase Case, score float64) map[Dimension]float64 {
+	dims := evalCase.Dimensions
+	if len(dims) == 0 {
+		dims = make([]Dimension, 0, len(suite.Scoring.Dimensions))
+		for _, scoringDim := range suite.Scoring.Dimensions {
+			dims = append(dims, scoringDim.Name)
+		}
+	}
+	if len(dims) == 0 {
+		dims = []Dimension{DimensionCorrectness}
+	}
+	out := make(map[Dimension]float64, len(dims))
+	for _, dim := range dims {
+		out[dim] = roundScore(score)
+	}
+	return out
+}
+
+func runtimeRecord(name Runtime, suite Suite) RuntimeRecord {
+	return RuntimeRecord{
+		Name:           name,
+		Live:           false,
+		Attempts:       1,
+		TimeoutSeconds: effectiveTimeout(suite),
+	}
+}
+
+func environmentRecord(suite Suite) EnvironmentRecord {
+	return EnvironmentRecord{
+		ScrubbedEnvPrefixes: scrubPrefixes(suite),
+		IsolatedHome:        suite.Environment.IsolateHome,
+		IsolatedCodexHome:   suite.Environment.IsolateCodexHome,
+		NetworkAccess:       networkAccess(suite),
+	}
+}
+
+func collectGitRecord(workDir string) GitRecord {
+	record := GitRecord{
+		CandidateRef: "unknown",
+		CandidateSHA: "0000000",
+		Dirty:        false,
+	}
+	if ref := gitOutput(workDir, "rev-parse", "--abbrev-ref", "HEAD"); ref != "" {
+		record.CandidateRef = ref
+	}
+	if sha := gitOutput(workDir, "rev-parse", "--short=12", "HEAD"); sha != "" {
+		record.CandidateSHA = sha
+	}
+	status := gitOutput(workDir, "status", "--porcelain")
+	if status == "" {
+		return record
+	}
+	for _, line := range strings.Split(status, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		record.Dirty = true
+		if len(line) > 3 {
+			record.DirtyPaths = append(record.DirtyPaths, strings.TrimSpace(line[3:]))
+		} else {
+			record.DirtyPaths = append(record.DirtyPaths, line)
+		}
+	}
+	sort.Strings(record.DirtyPaths)
+	return record
+}
+
+func gitOutput(workDir string, args ...string) string {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = workDir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func inferRuntime(suite Suite) Runtime {
+	for _, evalCase := range suite.Cases {
+		if evalCase.Runtime == RuntimeShell || evalCase.Kind == "command" {
+			return RuntimeShell
+		}
+		if evalCase.Runtime == RuntimeMock {
+			return RuntimeMock
+		}
+	}
+	return RuntimeStatic
+}
+
+func effectiveTimeout(suite Suite) int {
+	if suite.Environment.TimeoutSeconds > 0 {
+		return suite.Environment.TimeoutSeconds
+	}
+	return defaultTimeoutSeconds
+}
+
+func scrubPrefixes(suite Suite) []string {
+	prefixes := append([]string{}, suite.Environment.ScrubEnvPrefixes...)
+	if len(prefixes) == 0 {
+		prefixes = append(prefixes, "AGENTOPS_RPI_RUNTIME")
+	}
+	sort.Strings(prefixes)
+	return prefixes
+}
+
+func networkAccess(suite Suite) NetworkAccess {
+	if suite.Environment.OfflineRequired || suite.Environment.Network == "forbidden" || suite.Tier == TierDeterministic {
+		return NetworkDisabled
+	}
+	if suite.Environment.Network == "allowed" || suite.Environment.Network == "required" {
+		return NetworkEnabled
+	}
+	return NetworkUnknown
+}
+
+func scrubbedEnv(env []string, prefixes []string) []string {
+	var out []string
+	for _, entry := range env {
+		skip := false
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(entry, prefix) {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+func applyCommandEnv(env []string, overrides map[string]string) []string {
+	if len(overrides) == 0 {
+		return env
+	}
+	filtered := make([]string, 0, len(env)+len(overrides))
+	for _, entry := range env {
+		key := entry
+		if idx := strings.IndexByte(entry, '='); idx >= 0 {
+			key = entry[:idx]
+		}
+		if _, ok := overrides[key]; ok {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	keys := make([]string, 0, len(overrides))
+	for key := range overrides {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		filtered = append(filtered, key+"="+overrides[key])
+	}
+	return filtered
+}
+
+func inputString(inputs map[string]any, key string) string {
+	if raw, ok := inputs[key]; ok {
+		if value, ok := raw.(string); ok {
+			return value
+		}
+	}
+	return ""
+}
+
+func inputStringSlice(inputs map[string]any, key string) []string {
+	raw, ok := inputs[key]
+	if !ok {
+		return nil
+	}
+	switch value := raw.(type) {
+	case []string:
+		return append([]string(nil), value...)
+	case []any:
+		out := make([]string, 0, len(value))
+		for _, item := range value {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func inputStringMap(inputs map[string]any, key string) map[string]string {
+	raw, ok := inputs[key]
+	if !ok {
+		return nil
+	}
+	out := map[string]string{}
+	switch value := raw.(type) {
+	case map[string]string:
+		for k, v := range value {
+			out[k] = v
+		}
+	case map[string]any:
+		for k, v := range value {
+			if s, ok := v.(string); ok {
+				out[k] = s
+			}
+		}
+	}
+	return out
+}
+
+func resolvePath(base, path string) string {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Join(base, path)
+}
+
+func defaultRunID(suiteID string, started time.Time) string {
+	return sanitizeRunID(fmt.Sprintf("eval-%s-%s", started.Format("20060102T150405Z"), suiteID))
+}
+
+func sanitizeRunID(value string) string {
+	var b strings.Builder
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '.' || r == '_' || r == ':' || r == '-' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-_.:")
+	if out == "" {
+		return "eval-run"
+	}
+	return out
+}
+
+func roundScore(value float64) float64 {
+	if value < 0 {
+		value = 0
+	}
+	if value > 1 {
+		value = 1
+	}
+	return math.Round(value*10000) / 10000
+}
+
+func roundDelta(value float64) float64 {
+	return math.Round(value*10000) / 10000
+}
+
+func compactStrings(values []string) []string {
+	out := values[:0]
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			out = append(out, value)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func compareOptionsFromSuite(suite Suite) CompareOptions {
+	opts := CompareOptions{}
+	if suite.BaselinePolicy.MaxAggregateRegression != nil {
+		opts.MaxAggregateRegression = *suite.BaselinePolicy.MaxAggregateRegression
+	}
+	if suite.BaselinePolicy.MaxDimensionRegression != nil {
+		opts.MaxDimensionRegression = *suite.BaselinePolicy.MaxDimensionRegression
+	}
+	return opts
+}

--- a/cli/internal/eval/engine.go
+++ b/cli/internal/eval/engine.go
@@ -389,7 +389,7 @@ func collectGitRecord(workDir string) GitRecord {
 		return record
 	}
 	for _, line := range strings.Split(status, "\n") {
-		line = strings.TrimSpace(line)
+		line = strings.TrimRight(line, "\r\n")
 		if line == "" {
 			continue
 		}
@@ -411,7 +411,7 @@ func gitOutput(workDir string, args ...string) string {
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(out))
+	return strings.TrimRight(string(out), "\r\n")
 }
 
 func inferRuntime(suite Suite) Runtime {

--- a/cli/internal/eval/engine_test.go
+++ b/cli/internal/eval/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -256,6 +257,28 @@ func TestPromoteBaselineWritesRunRecord(t *testing.T) {
 	}
 }
 
+func TestCollectGitRecordPreservesDirtyPathNames(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "tester@example.com")
+	runGit(t, dir, "config", "user.name", "Tester")
+	writeEvalFile(t, filepath.Join(dir, "tracked.txt"), "before\n")
+	runGit(t, dir, "add", "tracked.txt")
+	runGit(t, dir, "commit", "-m", "initial")
+	writeEvalFile(t, filepath.Join(dir, "tracked.txt"), "after\n")
+	writeEvalFile(t, filepath.Join(dir, "new.txt"), "new\n")
+
+	record := collectGitRecord(dir)
+
+	if !record.Dirty {
+		t.Fatal("dirty = false, want true")
+	}
+	want := []string{"new.txt", "tracked.txt"}
+	if fmt.Sprint(record.DirtyPaths) != fmt.Sprint(want) {
+		t.Fatalf("dirty paths = %v, want %v", record.DirtyPaths, want)
+	}
+}
+
 func fixedEvalTime() time.Time {
 	return time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
 }
@@ -274,6 +297,15 @@ func writeEvalFile(t *testing.T, path, body string) {
 	}
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
 	}
 }
 

--- a/cli/internal/eval/engine_test.go
+++ b/cli/internal/eval/engine_test.go
@@ -1,0 +1,334 @@
+package eval
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRunSuiteArtifactCheckPasses(t *testing.T) {
+	dir := t.TempDir()
+	writeEvalFile(t, filepath.Join(dir, "fixture.txt"), "alpha\nneedle\nomega\n")
+	suitePath := writeEvalSuite(t, dir, `{
+  "schema_version": 1,
+  "id": "fixture.pass",
+  "name": "Fixture pass",
+  "domain": "cli",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "correctness", "weight": 1, "threshold": 1}
+    ]
+  },
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {
+      "id": "contains",
+      "title": "fixture contains needle",
+      "kind": "artifact_check",
+      "objective": "Verify static fixtures are scored offline.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "fixture.txt", "value": "needle"}
+      ]
+    }
+  ]
+}`)
+
+	run, err := RunSuite(RunOptions{
+		SuitePath: suitePath,
+		RunID:     "run-pass",
+		Now:       fixedEvalTime,
+	})
+	if err != nil {
+		t.Fatalf("RunSuite returned error: %v", err)
+	}
+
+	if run.Status != StatusPass || run.Verdict != VerdictPass {
+		t.Fatalf("status/verdict = %s/%s, want pass/pass", run.Status, run.Verdict)
+	}
+	if run.AggregateScore != 1 {
+		t.Fatalf("aggregate_score = %v, want 1", run.AggregateScore)
+	}
+	if got := run.DimensionScores["correctness"]; got != 1 {
+		t.Fatalf("correctness score = %v, want 1", got)
+	}
+	if len(run.CaseResults) != 1 || run.CaseResults[0].Score != 1 {
+		t.Fatalf("case results = %+v, want one passing case", run.CaseResults)
+	}
+	if len(run.Suite.SHA256) != 64 {
+		t.Fatalf("suite sha length = %d, want 64", len(run.Suite.SHA256))
+	}
+}
+
+func TestRunSuiteCommandCasePasses(t *testing.T) {
+	if os.Getenv("GO_WANT_EVAL_HELPER_PROCESS") == "1" {
+		fmt.Print(`{"ok":true,"message":"hello from helper"}`)
+		os.Exit(0)
+	}
+
+	dir := t.TempDir()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	suitePath := writeEvalSuite(t, dir, fmt.Sprintf(`{
+  "schema_version": 1,
+  "id": "command.pass",
+  "name": "Command pass",
+  "domain": "cli",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "correctness", "weight": 1, "threshold": 1}
+    ]
+  },
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {
+      "id": "helper",
+      "title": "helper command emits JSON",
+      "kind": "command",
+      "objective": "Run a local deterministic command.",
+      "runtime": "shell",
+      "inputs": {
+        "argv": [%q, "-test.run=TestRunSuiteCommandCasePasses"],
+        "env": {"GO_WANT_EVAL_HELPER_PROCESS": "1"}
+      },
+      "expectations": [
+        {"type": "exit_code", "value": 0},
+        {"type": "stdout_contains", "value": "hello"},
+        {"type": "json_path", "target": "stdout.ok", "value": true}
+      ]
+    }
+  ]
+}`, exe))
+
+	run, err := RunSuite(RunOptions{
+		SuitePath: suitePath,
+		RunID:     "run-command",
+		Now:       fixedEvalTime,
+	})
+	if err != nil {
+		t.Fatalf("RunSuite returned error: %v", err)
+	}
+	if run.Status != StatusPass {
+		t.Fatalf("status = %s, want pass; result=%+v", run.Status, run.CaseResults)
+	}
+	if run.Runtime.Name != RuntimeShell {
+		t.Fatalf("runtime = %s, want shell", run.Runtime.Name)
+	}
+}
+
+func TestRunSuiteExpectationFailureFailsRun(t *testing.T) {
+	dir := t.TempDir()
+	writeEvalFile(t, filepath.Join(dir, "fixture.txt"), "safe text\n")
+	suitePath := writeEvalSuite(t, dir, `{
+  "schema_version": 1,
+  "id": "fixture.fail",
+  "name": "Fixture fail",
+  "domain": "cli",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "correctness", "weight": 1, "threshold": 1}
+    ]
+  },
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {
+      "id": "missing",
+      "title": "fixture lacks needle",
+      "kind": "artifact_check",
+      "objective": "Required expectations fail the case.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "fixture.txt", "value": "needle"}
+      ]
+    }
+  ]
+}`)
+
+	run, err := RunSuite(RunOptions{SuitePath: suitePath, RunID: "run-fail", Now: fixedEvalTime})
+	if err != nil {
+		t.Fatalf("RunSuite returned error: %v", err)
+	}
+	if run.Status != StatusFail || run.Verdict != VerdictFail {
+		t.Fatalf("status/verdict = %s/%s, want fail/fail", run.Status, run.Verdict)
+	}
+	if run.CaseResults[0].FailureMessage == "" {
+		t.Fatalf("expected failure message, got %+v", run.CaseResults[0])
+	}
+}
+
+func TestRunSuiteRejectsLiveTier(t *testing.T) {
+	dir := t.TempDir()
+	suitePath := writeEvalSuite(t, dir, `{
+  "schema_version": 1,
+  "id": "live.out.of.scope",
+  "name": "Live suite",
+  "domain": "runtime",
+  "visibility": "public_canary",
+  "tier": "live",
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "correctness", "weight": 1, "threshold": 1}
+    ]
+  },
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {
+      "id": "prompt",
+      "title": "runtime prompt",
+      "kind": "runtime_prompt",
+      "objective": "Live adapters are not deterministic.",
+      "runtime": "claude",
+      "expectations": [
+        {"type": "manual_review"}
+      ]
+    }
+  ]
+}`)
+
+	if _, err := RunSuite(RunOptions{SuitePath: suitePath, RunID: "run-live", Now: fixedEvalTime}); err == nil {
+		t.Fatal("RunSuite succeeded for live tier, want error")
+	}
+}
+
+func TestCompareRunsMarksRegression(t *testing.T) {
+	baseline := minimalRunRecord("baseline-run", 0.90, map[Dimension]float64{DimensionCorrectness: 0.90})
+	candidate := minimalRunRecord("candidate-run", 0.70, map[Dimension]float64{DimensionCorrectness: 0.70})
+
+	compared, err := CompareRuns(candidate, baseline, CompareOptions{})
+	if err != nil {
+		t.Fatalf("CompareRuns returned error: %v", err)
+	}
+
+	if compared.Verdict != VerdictRegression || compared.Status != StatusPass {
+		t.Fatalf("status/verdict = %s/%s, want pass/regression", compared.Status, compared.Verdict)
+	}
+	if compared.BaselineComparison == nil {
+		t.Fatal("expected baseline comparison")
+	}
+	if got := compared.BaselineComparison.AggregateDelta; got != -0.2 {
+		t.Fatalf("aggregate delta = %v, want -0.2", got)
+	}
+	if len(compared.BaselineComparison.Regressions) != 1 {
+		t.Fatalf("regressions = %+v, want one regression", compared.BaselineComparison.Regressions)
+	}
+}
+
+func TestPromoteBaselineWritesRunRecord(t *testing.T) {
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "baseline.json")
+	run := minimalRunRecord("candidate-run", 1, map[Dimension]float64{DimensionCorrectness: 1})
+
+	promoted, err := PromoteBaseline(run, BaselineOptions{
+		OutputPath: outputPath,
+		PromotedBy: "tester",
+		Rationale:  "stable deterministic canary",
+		Now:        fixedEvalTime,
+	})
+	if err != nil {
+		t.Fatalf("PromoteBaseline returned error: %v", err)
+	}
+
+	if promoted.Baseline == nil || promoted.Baseline.Mode != BaselineModePromote {
+		t.Fatalf("baseline metadata = %+v, want promote", promoted.Baseline)
+	}
+	if promoted.Baseline.PromotedBy != "tester" {
+		t.Fatalf("promoted_by = %q, want tester", promoted.Baseline.PromotedBy)
+	}
+	loaded, err := LoadRun(outputPath)
+	if err != nil {
+		t.Fatalf("LoadRun(%s): %v", outputPath, err)
+	}
+	if loaded.RunID != promoted.RunID {
+		t.Fatalf("loaded run_id = %q, want %q", loaded.RunID, promoted.RunID)
+	}
+}
+
+func fixedEvalTime() time.Time {
+	return time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+}
+
+func writeEvalSuite(t *testing.T, dir, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, "suite.json")
+	writeEvalFile(t, path, body)
+	return path
+}
+
+func writeEvalFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func minimalRunRecord(runID string, aggregate float64, dimensions map[Dimension]float64) *RunRecord {
+	return &RunRecord{
+		SchemaVersion: 1,
+		RunID:         runID,
+		Suite: SuiteRef{
+			ID:         "fixture.pass",
+			Path:       "suite.json",
+			Visibility: VisibilityPublicCanary,
+			Tier:       TierDeterministic,
+		},
+		StartedAt: fixedEvalTime(),
+		Status:    StatusPass,
+		Verdict:   VerdictPass,
+		Git: GitRecord{
+			CandidateRef: "test",
+			CandidateSHA: "0000000",
+			Dirty:        false,
+		},
+		Runtime: RuntimeRecord{
+			Name: RuntimeStatic,
+			Live: false,
+		},
+		Environment: EnvironmentRecord{
+			ScrubbedEnvPrefixes: []string{"AGENTOPS_RPI_RUNTIME"},
+			IsolatedHome:        false,
+			IsolatedCodexHome:   false,
+			NetworkAccess:       NetworkDisabled,
+		},
+		CaseResults: []CaseResult{
+			{
+				ID:              "case",
+				Status:          StatusPass,
+				Score:           aggregate,
+				DimensionScores: dimensions,
+			},
+		},
+		AggregateScore:  aggregate,
+		DimensionScores: dimensions,
+	}
+}
+
+func TestRunRecordJSONRoundTrip(t *testing.T) {
+	run := minimalRunRecord("roundtrip", 1, map[Dimension]float64{DimensionCorrectness: 1})
+	data, err := json.Marshal(run)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded RunRecord
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded.RunID != run.RunID {
+		t.Fatalf("decoded run_id = %q, want %q", decoded.RunID, run.RunID)
+	}
+}

--- a/cli/internal/eval/expectations.go
+++ b/cli/internal/eval/expectations.go
@@ -1,0 +1,360 @@
+package eval
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+type caseContext struct {
+	suite    *Suite
+	suiteDir string
+	evalCase Case
+	stdout   string
+	stderr   string
+	exitCode int
+}
+
+type expectationResult struct {
+	passed  bool
+	message string
+}
+
+func evaluateExpectation(exp Expectation, ctx caseContext) expectationResult {
+	switch exp.Type {
+	case "exit_code":
+		want, ok := intValue(exp.Value)
+		if !ok {
+			want = 0
+		}
+		if ctx.exitCode == want {
+			return passf("exit_code matched %d", want)
+		}
+		return failf("exit_code = %d, want %d", ctx.exitCode, want)
+	case "stdout_contains":
+		needle := stringExpectationValue(exp)
+		if strings.Contains(ctx.stdout, needle) {
+			return passf("stdout contains %q", needle)
+		}
+		return failf("stdout does not contain %q", needle)
+	case "stderr_contains":
+		needle := stringExpectationValue(exp)
+		if strings.Contains(ctx.stderr, needle) {
+			return passf("stderr contains %q", needle)
+		}
+		return failf("stderr does not contain %q", needle)
+	case "file_exists":
+		path := resolvePath(ctx.suiteDir, exp.Target)
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return passf("file exists: %s", exp.Target)
+		}
+		return failf("file does not exist: %s", exp.Target)
+	case "file_absent":
+		path := resolvePath(ctx.suiteDir, exp.Target)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return passf("file absent: %s", exp.Target)
+		}
+		return failf("file exists: %s", exp.Target)
+	case "artifact_contains":
+		path := resolvePath(ctx.suiteDir, exp.Target)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return failf("read artifact %s: %v", exp.Target, err)
+		}
+		needle := stringExpectationValue(exp)
+		if strings.Contains(string(data), needle) {
+			return passf("artifact %s contains %q", exp.Target, needle)
+		}
+		return failf("artifact %s does not contain %q", exp.Target, needle)
+	case "json_path":
+		actual, ok, err := jsonPathValue(exp.Target, ctx)
+		if err != nil {
+			return failf("json_path %s: %v", exp.Target, err)
+		}
+		if !ok {
+			return failf("json_path %s not found", exp.Target)
+		}
+		if exp.Value == nil {
+			return passf("json_path %s exists", exp.Target)
+		}
+		if jsonValuesEqual(actual, exp.Value) {
+			return passf("json_path %s matched", exp.Target)
+		}
+		return failf("json_path %s = %v, want %v", exp.Target, actual, exp.Value)
+	case "schema_valid":
+		if err := validateSchemaTarget(exp, ctx); err != nil {
+			return failf("schema_valid %s: %v", exp.Target, err)
+		}
+		return passf("schema_valid %s matched", exp.Target)
+	case "score_at_least":
+		actual, ok, err := jsonPathValue(exp.Target, ctx)
+		if err != nil {
+			return failf("score_at_least %s: %v", exp.Target, err)
+		}
+		if !ok {
+			return failf("score_at_least target %s not found", exp.Target)
+		}
+		actualScore, ok := floatValue(actual)
+		if !ok {
+			return failf("score_at_least target %s is not numeric", exp.Target)
+		}
+		threshold := 1.0
+		if exp.Threshold != nil {
+			threshold = *exp.Threshold
+		} else if exp.Value != nil {
+			if parsed, ok := floatValue(exp.Value); ok {
+				threshold = parsed
+			}
+		}
+		if actualScore >= threshold {
+			return passf("score %.4f >= %.4f", actualScore, threshold)
+		}
+		return failf("score %.4f < %.4f", actualScore, threshold)
+	case "manual_review":
+		return failf("manual_review is not supported by deterministic evals")
+	default:
+		return failf("unsupported expectation type %q", exp.Type)
+	}
+}
+
+func expectationRequired(exp Expectation) bool {
+	if exp.Required == nil {
+		return true
+	}
+	return *exp.Required
+}
+
+func passf(format string, args ...any) expectationResult {
+	return expectationResult{passed: true, message: fmt.Sprintf(format, args...)}
+}
+
+func failf(format string, args ...any) expectationResult {
+	return expectationResult{passed: false, message: fmt.Sprintf(format, args...)}
+}
+
+func stringExpectationValue(exp Expectation) string {
+	if exp.Value != nil {
+		if value, ok := exp.Value.(string); ok {
+			return value
+		}
+		return fmt.Sprint(exp.Value)
+	}
+	return exp.Target
+}
+
+func intValue(value any) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	case float64:
+		return int(v), true
+	case string:
+		i, err := strconv.Atoi(v)
+		return i, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func floatValue(value any) (float64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case string:
+		f, err := strconv.ParseFloat(v, 64)
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func jsonPathValue(target string, ctx caseContext) (any, bool, error) {
+	source, path := splitJSONTarget(target)
+	var data []byte
+	switch source {
+	case "stdout":
+		data = []byte(ctx.stdout)
+	case "stderr":
+		data = []byte(ctx.stderr)
+	default:
+		filePath := resolvePath(ctx.suiteDir, source)
+		raw, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, false, err
+		}
+		data = raw
+	}
+	var root any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, false, err
+	}
+	if path == "" || path == "$" {
+		return root, true, nil
+	}
+	return walkJSONPath(root, path)
+}
+
+func splitJSONTarget(target string) (string, string) {
+	target = strings.TrimSpace(target)
+	for _, source := range []string{"stdout", "stderr"} {
+		if target == source {
+			return source, ""
+		}
+		if strings.HasPrefix(target, source+".") {
+			return source, strings.TrimPrefix(target, source+".")
+		}
+		if strings.HasPrefix(target, source+":") {
+			return source, strings.TrimPrefix(target, source+":")
+		}
+	}
+	if idx := strings.Index(target, ":"); idx > 0 && !looksLikeWindowsDrive(target, idx) {
+		return target[:idx], target[idx+1:]
+	}
+	return target, ""
+}
+
+func looksLikeWindowsDrive(path string, colon int) bool {
+	return colon == 1 && len(path) > 2 && filepath.VolumeName(path[:2]) != ""
+}
+
+func walkJSONPath(root any, path string) (any, bool, error) {
+	path = strings.TrimPrefix(path, "$.")
+	path = strings.TrimPrefix(path, ".")
+	if path == "" {
+		return root, true, nil
+	}
+	current := root
+	for _, part := range strings.Split(path, ".") {
+		if part == "" {
+			continue
+		}
+		value, ok, err := walkJSONSegment(current, part)
+		if err != nil || !ok {
+			return nil, ok, err
+		}
+		current = value
+	}
+	return current, true, nil
+}
+
+func walkJSONSegment(current any, segment string) (any, bool, error) {
+	name := segment
+	indexes := []int{}
+	for {
+		open := strings.Index(name, "[")
+		if open < 0 {
+			break
+		}
+		closeIdx := strings.Index(name[open:], "]")
+		if closeIdx < 0 {
+			return nil, false, fmt.Errorf("invalid array path segment %q", segment)
+		}
+		idxText := name[open+1 : open+closeIdx]
+		idx, err := strconv.Atoi(idxText)
+		if err != nil {
+			return nil, false, fmt.Errorf("invalid array index %q", idxText)
+		}
+		indexes = append(indexes, idx)
+		name = name[:open] + name[open+closeIdx+1:]
+	}
+	value := current
+	if name != "" {
+		obj, ok := value.(map[string]any)
+		if !ok {
+			return nil, false, nil
+		}
+		value, ok = obj[name]
+		if !ok {
+			return nil, false, nil
+		}
+	}
+	for _, idx := range indexes {
+		arr, ok := value.([]any)
+		if !ok || idx < 0 || idx >= len(arr) {
+			return nil, false, nil
+		}
+		value = arr[idx]
+	}
+	return value, true, nil
+}
+
+func jsonValuesEqual(actual, expected any) bool {
+	if reflect.DeepEqual(actual, expected) {
+		return true
+	}
+	actualFloat, actualOK := floatValue(actual)
+	expectedFloat, expectedOK := floatValue(expected)
+	if actualOK && expectedOK {
+		return actualFloat == expectedFloat
+	}
+	return fmt.Sprint(actual) == fmt.Sprint(expected)
+}
+
+func validateSchemaTarget(exp Expectation, ctx caseContext) error {
+	schema := ""
+	if exp.Value != nil {
+		schema = strings.ToLower(fmt.Sprint(exp.Value))
+	}
+	target := strings.TrimSpace(exp.Target)
+	if target == "" || target == "suite" {
+		if strings.Contains(schema, "run") {
+			return fmt.Errorf("suite target cannot validate eval-run schema")
+		}
+		return ValidateSuite(ctx.suite)
+	}
+	var data []byte
+	switch target {
+	case "stdout":
+		data = []byte(ctx.stdout)
+	case "stderr":
+		data = []byte(ctx.stderr)
+	default:
+		raw, err := os.ReadFile(resolvePath(ctx.suiteDir, target))
+		if err != nil {
+			return err
+		}
+		data = raw
+	}
+	if strings.Contains(schema, "eval-run") || strings.Contains(schema, "run") {
+		var run RunRecord
+		if err := decodeStrict(data, &run); err != nil {
+			return err
+		}
+		return ValidateRun(&run)
+	}
+	if strings.Contains(schema, "eval-suite") || strings.Contains(schema, "suite") {
+		var suite Suite
+		if err := decodeStrict(data, &suite); err != nil {
+			return err
+		}
+		return ValidateSuite(&suite)
+	}
+	var probe map[string]any
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return err
+	}
+	if _, ok := probe["run_id"]; ok {
+		var run RunRecord
+		if err := decodeStrict(data, &run); err != nil {
+			return err
+		}
+		return ValidateRun(&run)
+	}
+	var suite Suite
+	if err := decodeStrict(data, &suite); err != nil {
+		return err
+	}
+	return ValidateSuite(&suite)
+}

--- a/cli/internal/eval/io.go
+++ b/cli/internal/eval/io.go
@@ -1,0 +1,294 @@
+package eval
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+func LoadSuite(path string) (*Suite, []byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read eval suite: %w", err)
+	}
+	var suite Suite
+	if err := decodeStrict(data, &suite); err != nil {
+		return nil, nil, fmt.Errorf("decode eval suite: %w", err)
+	}
+	if err := ValidateSuite(&suite); err != nil {
+		return nil, nil, err
+	}
+	return &suite, data, nil
+}
+
+func LoadRun(path string) (*RunRecord, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read eval run: %w", err)
+	}
+	var run RunRecord
+	if err := decodeStrict(data, &run); err != nil {
+		return nil, fmt.Errorf("decode eval run: %w", err)
+	}
+	if err := ValidateRun(&run); err != nil {
+		return nil, err
+	}
+	return &run, nil
+}
+
+func WriteRun(path string, run *RunRecord) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("output path is required")
+	}
+	if err := ValidateRun(run); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create eval output directory: %w", err)
+	}
+	data, err := json.MarshalIndent(run, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal eval run: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write eval run: %w", err)
+	}
+	return nil
+}
+
+func ValidateSuite(suite *Suite) error {
+	var errs []string
+	if suite.SchemaVersion != 1 {
+		errs = append(errs, "schema_version must be 1")
+	}
+	if !idPattern.MatchString(suite.ID) {
+		errs = append(errs, "id must match ^[a-z0-9][a-z0-9._-]*$")
+	}
+	if strings.TrimSpace(suite.Name) == "" {
+		errs = append(errs, "name is required")
+	}
+	if !validVisibility(suite.Visibility) {
+		errs = append(errs, fmt.Sprintf("visibility %q is not supported", suite.Visibility))
+	}
+	if !validTier(suite.Tier) {
+		errs = append(errs, fmt.Sprintf("tier %q is not supported", suite.Tier))
+	}
+	if suite.Tier != TierDeterministic {
+		errs = append(errs, fmt.Sprintf("tier %q is out of deterministic scope", suite.Tier))
+	}
+	if suite.Scoring.AggregateThreshold < 0 || suite.Scoring.AggregateThreshold > 1 {
+		errs = append(errs, "scoring.aggregate_threshold must be in [0,1]")
+	}
+	if len(suite.Scoring.Dimensions) == 0 {
+		errs = append(errs, "scoring.dimensions must contain at least one dimension")
+	}
+	for i, dim := range suite.Scoring.Dimensions {
+		if !validDimension(dim.Name) {
+			errs = append(errs, fmt.Sprintf("scoring.dimensions[%d].name is invalid", i))
+		}
+		if dim.Weight <= 0 {
+			errs = append(errs, fmt.Sprintf("scoring.dimensions[%d].weight must be > 0", i))
+		}
+		if dim.Threshold < 0 || dim.Threshold > 1 {
+			errs = append(errs, fmt.Sprintf("scoring.dimensions[%d].threshold must be in [0,1]", i))
+		}
+	}
+	if strings.TrimSpace(suite.BaselinePolicy.Mode) == "" {
+		errs = append(errs, "baseline_policy.mode is required")
+	}
+	if len(suite.Cases) == 0 {
+		errs = append(errs, "cases must contain at least one case")
+	}
+	seenCases := make(map[string]struct{}, len(suite.Cases))
+	for i, c := range suite.Cases {
+		if !idPattern.MatchString(c.ID) {
+			errs = append(errs, fmt.Sprintf("cases[%d].id is invalid", i))
+		}
+		if _, ok := seenCases[c.ID]; ok {
+			errs = append(errs, fmt.Sprintf("cases[%d].id %q is duplicated", i, c.ID))
+		}
+		seenCases[c.ID] = struct{}{}
+		if strings.TrimSpace(c.Title) == "" {
+			errs = append(errs, fmt.Sprintf("cases[%d].title is required", i))
+		}
+		if strings.TrimSpace(c.Kind) == "" {
+			errs = append(errs, fmt.Sprintf("cases[%d].kind is required", i))
+		}
+		if strings.TrimSpace(c.Objective) == "" {
+			errs = append(errs, fmt.Sprintf("cases[%d].objective is required", i))
+		}
+		if c.Runtime != "" && !validDeterministicRuntime(c.Runtime) {
+			errs = append(errs, fmt.Sprintf("cases[%d].runtime %q is out of deterministic scope", i, c.Runtime))
+		}
+		if len(c.Expectations) == 0 {
+			errs = append(errs, fmt.Sprintf("cases[%d].expectations must contain at least one expectation", i))
+		}
+		for j, exp := range c.Expectations {
+			if !validExpectationType(exp.Type) {
+				errs = append(errs, fmt.Sprintf("cases[%d].expectations[%d].type %q is invalid", i, j, exp.Type))
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("eval suite validation failed: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func ValidateRun(run *RunRecord) error {
+	var errs []string
+	if run.SchemaVersion != 1 {
+		errs = append(errs, "schema_version must be 1")
+	}
+	if !runIDPattern.MatchString(run.RunID) {
+		errs = append(errs, "run_id is invalid")
+	}
+	if strings.TrimSpace(run.Suite.ID) == "" {
+		errs = append(errs, "suite.id is required")
+	}
+	if strings.TrimSpace(run.Suite.Path) == "" {
+		errs = append(errs, "suite.path is required")
+	}
+	if !validVisibility(run.Suite.Visibility) {
+		errs = append(errs, "suite.visibility is invalid")
+	}
+	if !validTier(run.Suite.Tier) {
+		errs = append(errs, "suite.tier is invalid")
+	}
+	if run.StartedAt.IsZero() {
+		errs = append(errs, "started_at is required")
+	}
+	if !validStatus(run.Status) {
+		errs = append(errs, "status is invalid")
+	}
+	if !validVerdict(run.Verdict) {
+		errs = append(errs, "verdict is invalid")
+	}
+	if strings.TrimSpace(run.Git.CandidateRef) == "" {
+		errs = append(errs, "git.candidate_ref is required")
+	}
+	if !gitSHAPattern.MatchString(run.Git.CandidateSHA) {
+		errs = append(errs, "git.candidate_sha is invalid")
+	}
+	if !validRuntime(run.Runtime.Name) {
+		errs = append(errs, "runtime.name is invalid")
+	}
+	if !validNetwork(run.Environment.NetworkAccess) {
+		errs = append(errs, "environment.network_access is invalid")
+	}
+	if len(run.CaseResults) == 0 {
+		errs = append(errs, "case_results must contain at least one case")
+	}
+	if !scoreInRange(run.AggregateScore) {
+		errs = append(errs, "aggregate_score must be in [0,1]")
+	}
+	if len(run.DimensionScores) == 0 {
+		errs = append(errs, "dimension_scores must contain at least one score")
+	}
+	for dim, score := range run.DimensionScores {
+		if !validDimension(dim) {
+			errs = append(errs, fmt.Sprintf("dimension_scores.%s is invalid", dim))
+		}
+		if !scoreInRange(score) {
+			errs = append(errs, fmt.Sprintf("dimension_scores.%s must be in [0,1]", dim))
+		}
+	}
+	for i, result := range run.CaseResults {
+		if strings.TrimSpace(result.ID) == "" {
+			errs = append(errs, fmt.Sprintf("case_results[%d].id is required", i))
+		}
+		if !validStatus(result.Status) {
+			errs = append(errs, fmt.Sprintf("case_results[%d].status is invalid", i))
+		}
+		if !scoreInRange(result.Score) {
+			errs = append(errs, fmt.Sprintf("case_results[%d].score must be in [0,1]", i))
+		}
+		if len(result.DimensionScores) == 0 {
+			errs = append(errs, fmt.Sprintf("case_results[%d].dimension_scores is required", i))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("eval run validation failed: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func decodeStrict(data []byte, target any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	return dec.Decode(target)
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func defaultNow() time.Time {
+	return time.Now().UTC()
+}
+
+var (
+	idPattern     = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+	runIDPattern  = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._:-]*$`)
+	gitSHAPattern = regexp.MustCompile(`^[a-fA-F0-9]{7,40}$`)
+)
+
+func validVisibility(v Visibility) bool {
+	return v == VisibilityPublicCanary || v == VisibilityPrivateHoldout
+}
+
+func validTier(t Tier) bool {
+	return t == TierDeterministic || t == TierHeadless || t == TierLive || t == TierRelease
+}
+
+func validRuntime(r Runtime) bool {
+	return r == RuntimeStatic || r == RuntimeMock || r == RuntimeShell || r == RuntimeClaude || r == RuntimeCodex || r == RuntimeManual
+}
+
+func validDeterministicRuntime(r Runtime) bool {
+	return r == RuntimeStatic || r == RuntimeMock || r == RuntimeShell
+}
+
+func validDimension(d Dimension) bool {
+	switch d {
+	case DimensionCorrectness, DimensionProcessAdherence, DimensionArtifactQuality,
+		DimensionRuntimeCompatibility, DimensionEfficiency, DimensionSafety, DimensionLearningClosure:
+		return true
+	default:
+		return false
+	}
+}
+
+func validStatus(s Status) bool {
+	return s == StatusPass || s == StatusFail || s == StatusError || s == StatusSkipped || s == StatusInconclusive
+}
+
+func validVerdict(v Verdict) bool {
+	return v == VerdictPass || v == VerdictFail || v == VerdictImprovement || v == VerdictRegression || v == VerdictAdvisory || v == VerdictInconclusive
+}
+
+func validNetwork(n NetworkAccess) bool {
+	return n == NetworkDisabled || n == NetworkEnabled || n == NetworkUnknown
+}
+
+func validExpectationType(kind string) bool {
+	switch kind {
+	case "exit_code", "stdout_contains", "stderr_contains", "json_path", "file_exists",
+		"file_absent", "schema_valid", "artifact_contains", "score_at_least", "manual_review":
+		return true
+	default:
+		return false
+	}
+}
+
+func scoreInRange(score float64) bool {
+	return score >= 0 && score <= 1
+}

--- a/cli/internal/eval/runtime.go
+++ b/cli/internal/eval/runtime.go
@@ -1,0 +1,640 @@
+package eval
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	goruntime "runtime"
+	"sort"
+	"strings"
+	"time"
+
+	rpilib "github.com/boshu2/agentops/cli/internal/rpi"
+)
+
+const (
+	claudeExecutable = "claude"
+	codexExecutable  = "codex"
+)
+
+// LiveRuntimeOptions configures an optional live runtime adapter execution.
+// Callers must set Enabled=true before any external Claude/Codex process is run.
+type LiveRuntimeOptions struct {
+	Suite          *Suite
+	SuitePath      string
+	SuiteData      []byte
+	RunID          string
+	Runtime        Runtime
+	RuntimeCommand string
+	OutputPath     string
+	WorkDir        string
+	Env            []string
+	IsolationRoot  string
+	Model          string
+	Profile        string
+	Enabled        bool
+	Now            func() time.Time
+	LookPath       func(string) (string, error)
+	VersionRunner  RuntimeVersionRunner
+	Runner         RuntimeRunner
+}
+
+// RuntimeCommand describes one Claude or Codex process invocation.
+type RuntimeCommand struct {
+	Executable     string
+	Args           []string
+	Env            []string
+	Dir            string
+	TimeoutSeconds int
+	Attempt        int
+}
+
+// RuntimeExecutionResult captures the score and artifacts returned by a live
+// runtime adapter invocation.
+type RuntimeExecutionResult struct {
+	Status          Status
+	Verdict         Verdict
+	AggregateScore  float64
+	DimensionScores map[Dimension]float64
+	CaseResults     []CaseResult
+	Artifacts       []Artifact
+	TranscriptPath  string
+	ScorecardPath   string
+	Version         string
+	Model           string
+	Profile         string
+	Diagnostics     []string
+}
+
+// RuntimeRunner executes a live runtime prompt command.
+type RuntimeRunner func(context.Context, RuntimeCommand) (RuntimeExecutionResult, error)
+
+// RuntimeVersionRunner probes a live runtime executable for version metadata.
+type RuntimeVersionRunner func(context.Context, RuntimeCommand) (string, error)
+
+type liveRuntimeAdapter interface {
+	DefaultCommand() string
+	VersionArgs() []string
+	DirectArgs(command, prompt string) []string
+}
+
+type staticLiveRuntimeAdapter struct {
+	defaultCommand string
+	versionArgs    []string
+}
+
+func (a staticLiveRuntimeAdapter) DefaultCommand() string {
+	return a.defaultCommand
+}
+
+func (a staticLiveRuntimeAdapter) VersionArgs() []string {
+	return append([]string{}, a.versionArgs...)
+}
+
+func (a staticLiveRuntimeAdapter) DirectArgs(command, prompt string) []string {
+	return rpilib.RuntimeDirectCommandArgs(command, prompt)
+}
+
+// RunLiveRuntime executes an optional Claude or Codex adapter run and returns a
+// normal eval run record. It skips instead of invoking external processes unless
+// opts.Enabled is true.
+func RunLiveRuntime(ctx context.Context, opts LiveRuntimeOptions) (*RunRecord, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if opts.Suite == nil {
+		return nil, fmt.Errorf("suite is required")
+	}
+	suite := *opts.Suite
+	runtimeName := opts.Runtime
+	if runtimeName == "" {
+		var err error
+		runtimeName, err = inferLiveRuntime(suite)
+		if err != nil {
+			return nil, err
+		}
+	}
+	adapter, err := liveRuntimeAdapterFor(runtimeName)
+	if err != nil {
+		return nil, err
+	}
+
+	workDir := opts.WorkDir
+	if workDir == "" {
+		workDir, err = os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("get working directory: %w", err)
+		}
+	}
+	now := opts.Now
+	if now == nil {
+		now = defaultNow
+	}
+	started := now().UTC()
+	record := newLiveRuntimeRecord(opts, suite, runtimeName, workDir, started)
+	model, profile := runtimeMetadataFromCommand(opts.RuntimeCommand)
+	record.Runtime.Model = firstNonEmpty(opts.Model, model)
+	record.Runtime.Profile = firstNonEmpty(opts.Profile, profile)
+
+	if !opts.Enabled {
+		markRuntimeSkipped(record, suite, "live runtime disabled; set LiveRuntimeOptions.Enabled to true")
+		return finishLiveRuntimeRun(opts, record, now)
+	}
+
+	command := strings.TrimSpace(opts.RuntimeCommand)
+	if command == "" {
+		command = adapter.DefaultCommand()
+	}
+	executable, _ := rpilib.SplitRuntimeCommand(command)
+	if executable == "" {
+		markRuntimeSkipped(record, suite, "runtime command is empty")
+		return finishLiveRuntimeRun(opts, record, now)
+	}
+	lookPath := opts.LookPath
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	executablePath, err := lookPath(executable)
+	if err != nil {
+		reason := fmt.Sprintf("%s executable not found: %v", executable, err)
+		markRuntimeSkipped(record, suite, reason)
+		return finishLiveRuntimeRun(opts, record, now)
+	}
+
+	env, hostNotes, err := liveRuntimeEnv(opts, suite)
+	if err != nil {
+		return nil, err
+	}
+	record.Environment.HostNotes = append(record.Environment.HostNotes, hostNotes...)
+
+	versionRunner := opts.VersionRunner
+	if versionRunner == nil {
+		versionRunner = defaultRuntimeVersionRunner
+	}
+	versionCtx := ctx
+	versionCancel := func() {}
+	if record.Runtime.TimeoutSeconds > 0 {
+		versionCtx, versionCancel = context.WithTimeout(ctx, time.Duration(record.Runtime.TimeoutSeconds)*time.Second)
+	}
+	version, err := versionRunner(versionCtx, RuntimeCommand{
+		Executable:     executablePath,
+		Args:           adapter.VersionArgs(),
+		Env:            env,
+		Dir:            workDir,
+		TimeoutSeconds: record.Runtime.TimeoutSeconds,
+	})
+	versionCancel()
+	if err != nil {
+		if errors.Is(versionCtx.Err(), context.DeadlineExceeded) {
+			err = fmt.Errorf("runtime version probe timed out after %ds", record.Runtime.TimeoutSeconds)
+		}
+		record.Environment.HostNotes = append(record.Environment.HostNotes, "runtime version probe failed: "+err.Error())
+	} else {
+		record.Runtime.Version = strings.TrimSpace(version)
+	}
+
+	runner := opts.Runner
+	if runner == nil {
+		runner = defaultRuntimeRunner
+	}
+	result, attempts, runErr := runLiveRuntimeWithAttempts(ctx, runner, RuntimeCommand{
+		Executable:     executablePath,
+		Args:           adapter.DirectArgs(command, liveRuntimePrompt(suite)),
+		Env:            env,
+		Dir:            workDir,
+		TimeoutSeconds: record.Runtime.TimeoutSeconds,
+	}, record.Runtime.Attempts)
+	record.Runtime.Attempts = attempts
+	if runErr != nil {
+		markRuntimeError(record, suite, runErr.Error())
+		return finishLiveRuntimeRun(opts, record, now)
+	}
+	applyRuntimeExecutionResult(record, suite, result)
+	return finishLiveRuntimeRun(opts, record, now)
+}
+
+func liveRuntimeAdapterFor(runtimeName Runtime) (liveRuntimeAdapter, error) {
+	switch runtimeName {
+	case RuntimeClaude:
+		return staticLiveRuntimeAdapter{
+			defaultCommand: claudeExecutable,
+			versionArgs:    []string{"--version"},
+		}, nil
+	case RuntimeCodex:
+		return staticLiveRuntimeAdapter{
+			defaultCommand: codexExecutable,
+			versionArgs:    []string{"--version"},
+		}, nil
+	default:
+		return nil, fmt.Errorf("runtime %q is not a live adapter runtime", runtimeName)
+	}
+}
+
+func inferLiveRuntime(suite Suite) (Runtime, error) {
+	seen := map[Runtime]struct{}{}
+	for _, runtimeName := range suite.Allowed {
+		if runtimeName == RuntimeClaude || runtimeName == RuntimeCodex {
+			seen[runtimeName] = struct{}{}
+		}
+	}
+	for _, evalCase := range suite.Cases {
+		if evalCase.Runtime == RuntimeClaude || evalCase.Runtime == RuntimeCodex {
+			seen[evalCase.Runtime] = struct{}{}
+		}
+	}
+	if len(seen) == 1 {
+		for runtimeName := range seen {
+			return runtimeName, nil
+		}
+	}
+	if len(seen) == 0 {
+		return "", fmt.Errorf("live runtime is required")
+	}
+	return "", fmt.Errorf("live runtime is ambiguous")
+}
+
+func newLiveRuntimeRecord(opts LiveRuntimeOptions, suite Suite, runtimeName Runtime, workDir string, started time.Time) *RunRecord {
+	runID := strings.TrimSpace(opts.RunID)
+	if runID == "" {
+		runID = defaultRunID(suite.ID, started)
+	}
+	suitePath := strings.TrimSpace(opts.SuitePath)
+	if suitePath == "" {
+		suitePath = suite.ID
+	}
+	return &RunRecord{
+		SchemaVersion: 1,
+		RunID:         runID,
+		Suite: SuiteRef{
+			ID:         suite.ID,
+			Path:       suitePath,
+			Visibility: suite.Visibility,
+			Tier:       suite.Tier,
+			SHA256:     optionalSHA256(opts.SuiteData),
+		},
+		StartedAt: started,
+		Status:    StatusInconclusive,
+		Verdict:   VerdictInconclusive,
+		Git:       collectGitRecord(workDir),
+		Runtime: RuntimeRecord{
+			Name:           runtimeName,
+			Live:           true,
+			Attempts:       effectiveAttempts(suite),
+			TimeoutSeconds: effectiveTimeout(suite),
+		},
+		Environment:     liveEnvironmentRecord(suite),
+		Baseline:        &BaselineRecord{Mode: BaselineModeNone},
+		CaseResults:     inconclusiveCaseResults(suite),
+		AggregateScore:  0,
+		DimensionScores: zeroDimensionScores(suite),
+	}
+}
+
+func liveEnvironmentRecord(suite Suite) EnvironmentRecord {
+	return EnvironmentRecord{
+		ScrubbedEnvPrefixes: liveScrubPrefixes(suite),
+		IsolatedHome:        suite.Environment.IsolateHome,
+		IsolatedCodexHome:   suite.Environment.IsolateCodexHome,
+		NetworkAccess:       networkAccess(suite),
+	}
+}
+
+func liveRuntimeEnv(opts LiveRuntimeOptions, suite Suite) ([]string, []string, error) {
+	base := opts.Env
+	if base == nil {
+		base = os.Environ()
+	}
+	env := scrubbedEnv(base, liveScrubPrefixes(suite))
+	var notes []string
+	if suite.Environment.IsolateHome || suite.Environment.IsolateCodexHome {
+		root := opts.IsolationRoot
+		if root == "" {
+			var err error
+			root, err = os.MkdirTemp("", "agentops-eval-runtime-*")
+			if err != nil {
+				return nil, nil, fmt.Errorf("create runtime isolation root: %w", err)
+			}
+		}
+		if suite.Environment.IsolateHome {
+			home := filepath.Join(root, "home")
+			if err := os.MkdirAll(home, 0o700); err != nil {
+				return nil, nil, fmt.Errorf("create isolated home: %w", err)
+			}
+			env = setEnvValue(env, "HOME", home)
+			if goruntime.GOOS == "windows" {
+				env = setEnvValue(env, "USERPROFILE", home)
+			}
+			notes = append(notes, "HOME isolated")
+		}
+		if suite.Environment.IsolateCodexHome {
+			codexHome := filepath.Join(root, "codex-home")
+			if err := os.MkdirAll(codexHome, 0o700); err != nil {
+				return nil, nil, fmt.Errorf("create isolated Codex home: %w", err)
+			}
+			env = setEnvValue(env, "CODEX_HOME", codexHome)
+			notes = append(notes, "CODEX_HOME isolated")
+		}
+	}
+	notes = append(notes, fmt.Sprintf("scrubbed env prefixes: %s", strings.Join(liveScrubPrefixes(suite), ",")))
+	return env, notes, nil
+}
+
+func liveScrubPrefixes(suite Suite) []string {
+	prefixes := append(scrubPrefixes(suite), "AGENTOPS_RPI_RUNTIME", "CLAUDECODE", "CLAUDE_CODE_")
+	sort.Strings(prefixes)
+	out := prefixes[:0]
+	for _, prefix := range prefixes {
+		if prefix == "" {
+			continue
+		}
+		if len(out) == 0 || out[len(out)-1] != prefix {
+			out = append(out, prefix)
+		}
+	}
+	return append([]string{}, out...)
+}
+
+func setEnvValue(env []string, key, value string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(env)+1)
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return append(out, prefix+value)
+}
+
+func runLiveRuntimeWithAttempts(ctx context.Context, runner RuntimeRunner, command RuntimeCommand, maxAttempts int) (RuntimeExecutionResult, int, error) {
+	if maxAttempts <= 0 {
+		maxAttempts = 1
+	}
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		attemptCtx := ctx
+		cancel := func() {}
+		if command.TimeoutSeconds > 0 {
+			attemptCtx, cancel = context.WithTimeout(ctx, time.Duration(command.TimeoutSeconds)*time.Second)
+		}
+		command.Attempt = attempt
+		result, err := runner(attemptCtx, command)
+		cancel()
+		if err == nil {
+			return result, attempt, nil
+		}
+		lastErr = err
+		if errors.Is(attemptCtx.Err(), context.DeadlineExceeded) {
+			lastErr = fmt.Errorf("runtime timed out after %ds", command.TimeoutSeconds)
+		}
+	}
+	return RuntimeExecutionResult{}, maxAttempts, lastErr
+}
+
+func defaultRuntimeVersionRunner(ctx context.Context, command RuntimeCommand) (string, error) {
+	cmd := exec.CommandContext(ctx, command.Executable, command.Args...)
+	cmd.Dir = command.Dir
+	cmd.Env = command.Env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("probe runtime version: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func defaultRuntimeRunner(ctx context.Context, command RuntimeCommand) (RuntimeExecutionResult, error) {
+	cmd := exec.CommandContext(ctx, command.Executable, command.Args...)
+	cmd.Dir = command.Dir
+	cmd.Env = command.Env
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	result := RuntimeExecutionResult{
+		Status:      StatusInconclusive,
+		Verdict:     VerdictInconclusive,
+		Diagnostics: compactStrings([]string{stdout.String(), stderr.String()}),
+	}
+	if err == nil {
+		return result, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return result, fmt.Errorf("%s exited with code %d: %w", command.Executable, exitErr.ExitCode(), err)
+	}
+	return result, fmt.Errorf("run %s: %w", command.Executable, err)
+}
+
+func applyRuntimeExecutionResult(record *RunRecord, suite Suite, result RuntimeExecutionResult) {
+	status := result.Status
+	if status == "" {
+		status = StatusInconclusive
+	}
+	verdict := result.Verdict
+	if verdict == "" {
+		verdict = runtimeVerdict(status)
+	}
+	record.Status = status
+	record.Verdict = verdict
+	if result.Version != "" {
+		record.Runtime.Version = result.Version
+	}
+	if result.Model != "" {
+		record.Runtime.Model = result.Model
+	}
+	if result.Profile != "" {
+		record.Runtime.Profile = result.Profile
+	}
+	if len(result.DimensionScores) > 0 {
+		record.DimensionScores = result.DimensionScores
+	} else {
+		record.DimensionScores = zeroDimensionScores(suite)
+	}
+	record.AggregateScore = roundScore(result.AggregateScore)
+	if len(result.CaseResults) > 0 {
+		record.CaseResults = result.CaseResults
+	} else {
+		record.CaseResults = runtimeCaseResults(suite, status, record.AggregateScore, record.DimensionScores, result.Diagnostics, "")
+	}
+	record.Artifacts = append(record.Artifacts, runtimeArtifacts(result)...)
+}
+
+func markRuntimeSkipped(record *RunRecord, suite Suite, reason string) {
+	record.Status = StatusSkipped
+	record.Verdict = VerdictInconclusive
+	record.Runtime.Attempts = 1
+	record.Runtime.SkippedReason = reason
+	record.CaseResults = runtimeCaseResults(suite, StatusSkipped, 0, zeroDimensionScores(suite), []string{reason}, reason)
+	record.AggregateScore = 0
+	record.DimensionScores = zeroDimensionScores(suite)
+}
+
+func markRuntimeError(record *RunRecord, suite Suite, reason string) {
+	record.Status = StatusError
+	record.Verdict = VerdictFail
+	record.CaseResults = runtimeCaseResults(suite, StatusError, 0, zeroDimensionScores(suite), []string{reason}, reason)
+	record.AggregateScore = 0
+	record.DimensionScores = zeroDimensionScores(suite)
+}
+
+func finishLiveRuntimeRun(opts LiveRuntimeOptions, record *RunRecord, now func() time.Time) (*RunRecord, error) {
+	completed := now().UTC()
+	record.CompletedAt = &completed
+	if opts.OutputPath != "" {
+		record.Artifacts = append(record.Artifacts, Artifact{
+			Path:    opts.OutputPath,
+			Purpose: "evaluation run record",
+			Kind:    "run_json",
+		})
+		if writeErr := WriteRun(opts.OutputPath, record); writeErr != nil {
+			return nil, writeErr
+		}
+	}
+	return record, nil
+}
+
+func runtimeCaseResults(suite Suite, status Status, score float64, dims map[Dimension]float64, diagnostics []string, failure string) []CaseResult {
+	if len(suite.Cases) == 0 {
+		return []CaseResult{{
+			ID:              "runtime",
+			Status:          status,
+			Score:           roundScore(score),
+			DimensionScores: cloneDimensionScores(dims),
+			FailureMessage:  failure,
+			Diagnostics:     compactStrings(diagnostics),
+		}}
+	}
+	results := make([]CaseResult, 0, len(suite.Cases))
+	for _, evalCase := range suite.Cases {
+		results = append(results, CaseResult{
+			ID:              evalCase.ID,
+			Status:          status,
+			Score:           roundScore(score),
+			DimensionScores: caseDimensions(suite, evalCase, score),
+			Critical:        evalCase.Critical,
+			FailureMessage:  failure,
+			Diagnostics:     compactStrings(diagnostics),
+		})
+	}
+	return results
+}
+
+func inconclusiveCaseResults(suite Suite) []CaseResult {
+	return runtimeCaseResults(suite, StatusInconclusive, 0, zeroDimensionScores(suite), nil, "")
+}
+
+func zeroDimensionScores(suite Suite) map[Dimension]float64 {
+	dims := make(map[Dimension]float64, len(suite.Scoring.Dimensions))
+	for _, scoringDim := range suite.Scoring.Dimensions {
+		dims[scoringDim.Name] = 0
+	}
+	if len(dims) == 0 {
+		dims[DimensionRuntimeCompatibility] = 0
+	}
+	return dims
+}
+
+func cloneDimensionScores(dims map[Dimension]float64) map[Dimension]float64 {
+	out := make(map[Dimension]float64, len(dims))
+	for dim, score := range dims {
+		out[dim] = score
+	}
+	return out
+}
+
+func runtimeArtifacts(result RuntimeExecutionResult) []Artifact {
+	var artifacts []Artifact
+	if strings.TrimSpace(result.TranscriptPath) != "" {
+		artifacts = append(artifacts, Artifact{
+			Path:    result.TranscriptPath,
+			Purpose: "runtime transcript",
+			Kind:    "transcript",
+		})
+	}
+	if strings.TrimSpace(result.ScorecardPath) != "" {
+		artifacts = append(artifacts, Artifact{
+			Path:    result.ScorecardPath,
+			Purpose: "runtime scorecard",
+			Kind:    "scorecard",
+		})
+	}
+	artifacts = append(artifacts, result.Artifacts...)
+	return artifacts
+}
+
+func runtimeVerdict(status Status) Verdict {
+	switch status {
+	case StatusPass:
+		return VerdictPass
+	case StatusFail, StatusError:
+		return VerdictFail
+	default:
+		return VerdictInconclusive
+	}
+}
+
+func effectiveAttempts(suite Suite) int {
+	if suite.Environment.MaxAttempts > 0 {
+		return suite.Environment.MaxAttempts
+	}
+	return 1
+}
+
+func liveRuntimePrompt(suite Suite) string {
+	var parts []string
+	for _, evalCase := range suite.Cases {
+		if prompt := strings.TrimSpace(inputString(evalCase.Inputs, "prompt")); prompt != "" {
+			parts = append(parts, prompt)
+		}
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, "\n\n")
+	}
+	if strings.TrimSpace(suite.Description) != "" {
+		return strings.TrimSpace(suite.Description)
+	}
+	return strings.TrimSpace(suite.Name)
+}
+
+func runtimeMetadataFromCommand(command string) (string, string) {
+	_, args := rpilib.SplitRuntimeCommand(command)
+	var model string
+	var profile string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--model" && i+1 < len(args):
+			model = args[i+1]
+			i++
+		case strings.HasPrefix(arg, "--model="):
+			model = strings.TrimPrefix(arg, "--model=")
+		case arg == "--profile" && i+1 < len(args):
+			profile = args[i+1]
+			i++
+		case strings.HasPrefix(arg, "--profile="):
+			profile = strings.TrimPrefix(arg, "--profile=")
+		}
+	}
+	return model, profile
+}
+
+func optionalSHA256(data []byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+	return sha256Hex(data)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/cli/internal/eval/runtime_test.go
+++ b/cli/internal/eval/runtime_test.go
@@ -1,0 +1,336 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestRunLiveRuntimeSkipsWhenExecutableUnavailable(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		runtime    Runtime
+		executable string
+	}{
+		{name: "claude", runtime: RuntimeClaude, executable: "claude"},
+		{name: "codex", runtime: RuntimeCodex, executable: "codex"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			suite := liveRuntimeSuite(tc.runtime)
+
+			run, err := RunLiveRuntime(context.Background(), LiveRuntimeOptions{
+				Suite:   suite,
+				RunID:   "live-skip",
+				Runtime: tc.runtime,
+				Enabled: true,
+				LookPath: func(name string) (string, error) {
+					if name != tc.executable {
+						t.Fatalf("lookPath name = %q, want %s", name, tc.executable)
+					}
+					return "", exec.ErrNotFound
+				},
+				Now: fixedEvalTime,
+			})
+			if err != nil {
+				t.Fatalf("RunLiveRuntime returned error: %v", err)
+			}
+
+			wantReason := tc.executable + " executable not found: executable file not found in $PATH"
+			if run.Status != StatusSkipped {
+				t.Fatalf("status = %s, want skipped", run.Status)
+			}
+			if run.Verdict != VerdictInconclusive {
+				t.Fatalf("verdict = %s, want inconclusive", run.Verdict)
+			}
+			if run.Runtime.Name != tc.runtime || !run.Runtime.Live {
+				t.Fatalf("runtime = %+v, want live %s", run.Runtime, tc.runtime)
+			}
+			if run.Runtime.Attempts != 1 {
+				t.Fatalf("attempts = %d, want 1", run.Runtime.Attempts)
+			}
+			if run.Runtime.TimeoutSeconds != 45 {
+				t.Fatalf("timeout = %d, want 45", run.Runtime.TimeoutSeconds)
+			}
+			if run.Runtime.SkippedReason != wantReason {
+				t.Fatalf("skipped_reason = %q, want %q", run.Runtime.SkippedReason, wantReason)
+			}
+			if len(run.CaseResults) != 1 || run.CaseResults[0].Status != StatusSkipped {
+				t.Fatalf("case results = %+v, want one skipped case", run.CaseResults)
+			}
+			if run.CaseResults[0].FailureMessage != wantReason {
+				t.Fatalf("case failure = %q, want skip reason", run.CaseResults[0].FailureMessage)
+			}
+		})
+	}
+}
+
+func TestRunLiveRuntimeDisabledSkipsBeforeExternalProbe(t *testing.T) {
+	run, err := RunLiveRuntime(context.Background(), LiveRuntimeOptions{
+		Suite:   liveRuntimeSuite(RuntimeCodex),
+		RunID:   "live-disabled",
+		Runtime: RuntimeCodex,
+		LookPath: func(name string) (string, error) {
+			t.Fatalf("lookPath should not be called when live runtime is disabled")
+			return "", nil
+		},
+		Runner: func(ctx context.Context, cmd RuntimeCommand) (RuntimeExecutionResult, error) {
+			t.Fatalf("runner should not be called when live runtime is disabled")
+			return RuntimeExecutionResult{}, nil
+		},
+		Now: fixedEvalTime,
+	})
+	if err != nil {
+		t.Fatalf("RunLiveRuntime returned error: %v", err)
+	}
+	wantReason := "live runtime disabled; set LiveRuntimeOptions.Enabled to true"
+	if run.Status != StatusSkipped {
+		t.Fatalf("status = %s, want skipped", run.Status)
+	}
+	if run.Runtime.SkippedReason != wantReason {
+		t.Fatalf("skipped_reason = %q, want %q", run.Runtime.SkippedReason, wantReason)
+	}
+	if !run.Runtime.Live {
+		t.Fatalf("runtime live = false, want true for attempted live tier")
+	}
+}
+
+func TestRunLiveRuntimeIsolatesAndScrubsCodexEnvironment(t *testing.T) {
+	suite := liveRuntimeSuite(RuntimeCodex)
+	suite.Environment.ScrubEnvPrefixes = []string{"SECRET_"}
+	suite.Environment.IsolateHome = true
+	suite.Environment.IsolateCodexHome = true
+	suite.Environment.Network = "allowed"
+	suite.Environment.MaxAttempts = 2
+	isolationRoot := t.TempDir()
+	var got RuntimeCommand
+
+	run, err := RunLiveRuntime(context.Background(), LiveRuntimeOptions{
+		Suite:          suite,
+		RunID:          "live-codex",
+		Runtime:        RuntimeCodex,
+		RuntimeCommand: "codex --profile ci",
+		Enabled:        true,
+		Env: []string{
+			"PATH=/bin",
+			"SECRET_TOKEN=redacted",
+			"AGENTOPS_RPI_RUNTIME=direct",
+			"KEEP=1",
+		},
+		IsolationRoot: isolationRoot,
+		LookPath: func(name string) (string, error) {
+			if name != "codex" {
+				t.Fatalf("lookPath name = %q, want codex", name)
+			}
+			return "/fake/bin/codex", nil
+		},
+		VersionRunner: func(ctx context.Context, cmd RuntimeCommand) (string, error) {
+			if cmd.Executable != "/fake/bin/codex" {
+				t.Fatalf("version executable = %q, want /fake/bin/codex", cmd.Executable)
+			}
+			return "codex 0.115.0", nil
+		},
+		Runner: func(ctx context.Context, cmd RuntimeCommand) (RuntimeExecutionResult, error) {
+			got = cmd
+			return RuntimeExecutionResult{
+				Status:         StatusInconclusive,
+				Verdict:        VerdictInconclusive,
+				TranscriptPath: filepath.Join(isolationRoot, "transcript.jsonl"),
+				ScorecardPath:  filepath.Join(isolationRoot, "scorecard.json"),
+			}, nil
+		},
+		Now: fixedEvalTime,
+	})
+	if err != nil {
+		t.Fatalf("RunLiveRuntime returned error: %v", err)
+	}
+
+	if got.Executable != "/fake/bin/codex" {
+		t.Fatalf("executable = %q, want /fake/bin/codex", got.Executable)
+	}
+	if want := []string{"--profile", "ci", "exec", "Respond with ok."}; !slices.Equal(got.Args, want) {
+		t.Fatalf("args = %v, want %v", got.Args, want)
+	}
+	if got.TimeoutSeconds != 45 {
+		t.Fatalf("command timeout = %d, want 45", got.TimeoutSeconds)
+	}
+	assertEnvMissingPrefix(t, got.Env, "SECRET_")
+	assertEnvMissingPrefix(t, got.Env, "AGENTOPS_RPI_RUNTIME")
+	assertEnvContains(t, got.Env, "KEEP=1")
+	assertEnvContainsPrefix(t, got.Env, "HOME="+filepath.Join(isolationRoot, "home"))
+	assertEnvContainsPrefix(t, got.Env, "CODEX_HOME="+filepath.Join(isolationRoot, "codex-home"))
+
+	if run.Environment.NetworkAccess != NetworkEnabled {
+		t.Fatalf("network = %s, want enabled", run.Environment.NetworkAccess)
+	}
+	if !run.Environment.IsolatedHome || !run.Environment.IsolatedCodexHome {
+		t.Fatalf("environment isolation = %+v, want home and codex home isolated", run.Environment)
+	}
+	wantPrefixes := []string{"AGENTOPS_RPI_RUNTIME", "CLAUDECODE", "CLAUDE_CODE_", "SECRET_"}
+	if !slices.Equal(run.Environment.ScrubbedEnvPrefixes, wantPrefixes) {
+		t.Fatalf("scrubbed prefixes = %v, want %v", run.Environment.ScrubbedEnvPrefixes, wantPrefixes)
+	}
+	if run.Runtime.Version != "codex 0.115.0" {
+		t.Fatalf("version = %q, want codex 0.115.0", run.Runtime.Version)
+	}
+	if run.Runtime.Profile != "ci" {
+		t.Fatalf("profile = %q, want ci", run.Runtime.Profile)
+	}
+	if run.Runtime.Attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", run.Runtime.Attempts)
+	}
+}
+
+func TestRunLiveRuntimeCapturesTranscriptAndScorecardArtifacts(t *testing.T) {
+	suite := liveRuntimeSuite(RuntimeClaude)
+	transcriptPath := filepath.Join(t.TempDir(), "claude-transcript.jsonl")
+	scorecardPath := filepath.Join(t.TempDir(), "scorecard.json")
+
+	run, err := RunLiveRuntime(context.Background(), LiveRuntimeOptions{
+		Suite:          suite,
+		RunID:          "live-artifacts",
+		Runtime:        RuntimeClaude,
+		RuntimeCommand: "claude --model sonnet",
+		Enabled:        true,
+		LookPath: func(name string) (string, error) {
+			if name != "claude" {
+				t.Fatalf("lookPath name = %q, want claude", name)
+			}
+			return "/fake/bin/claude", nil
+		},
+		VersionRunner: func(ctx context.Context, cmd RuntimeCommand) (string, error) {
+			return "claude 2.0.0", nil
+		},
+		Runner: func(ctx context.Context, cmd RuntimeCommand) (RuntimeExecutionResult, error) {
+			return RuntimeExecutionResult{
+				Status:         StatusInconclusive,
+				Verdict:        VerdictInconclusive,
+				TranscriptPath: transcriptPath,
+				ScorecardPath:  scorecardPath,
+				Artifacts: []Artifact{
+					{Path: filepath.Join(filepath.Dir(scorecardPath), "extra.txt"), Purpose: "runtime note", Kind: "note"},
+				},
+			}, nil
+		},
+		Now: fixedEvalTime,
+	})
+	if err != nil {
+		t.Fatalf("RunLiveRuntime returned error: %v", err)
+	}
+
+	if run.Runtime.Version != "claude 2.0.0" {
+		t.Fatalf("version = %q, want claude 2.0.0", run.Runtime.Version)
+	}
+	if run.Runtime.Model != "sonnet" {
+		t.Fatalf("model = %q, want sonnet", run.Runtime.Model)
+	}
+	assertArtifact(t, run.Artifacts, Artifact{Path: transcriptPath, Purpose: "runtime transcript", Kind: "transcript"})
+	assertArtifact(t, run.Artifacts, Artifact{Path: scorecardPath, Purpose: "runtime scorecard", Kind: "scorecard"})
+	assertArtifact(t, run.Artifacts, Artifact{Path: filepath.Join(filepath.Dir(scorecardPath), "extra.txt"), Purpose: "runtime note", Kind: "note"})
+}
+
+func liveRuntimeSuite(runtimeName Runtime) *Suite {
+	return &Suite{
+		SchemaVersion: 1,
+		ID:            "live.runtime",
+		Name:          "Live runtime",
+		Domain:        "runtime",
+		Visibility:    VisibilityPublicCanary,
+		Tier:          TierLive,
+		Allowed:       []Runtime{runtimeName},
+		Environment: SuiteEnvironment{
+			TimeoutSeconds: 45,
+		},
+		Scoring: Scoring{
+			AggregateThreshold: 1,
+			Dimensions: []ScoringDimension{
+				{Name: DimensionRuntimeCompatibility, Weight: 1, Threshold: 1},
+			},
+		},
+		BaselinePolicy: BaselinePolicy{Mode: "none"},
+		Cases: []Case{
+			{
+				ID:        "prompt",
+				Title:     "runtime prompt",
+				Kind:      "runtime_prompt",
+				Objective: "Exercise an optional live runtime adapter.",
+				Runtime:   runtimeName,
+				Inputs: map[string]any{
+					"prompt": "Respond with ok.",
+				},
+				Expectations: []Expectation{{Type: "manual_review"}},
+			},
+		},
+	}
+}
+
+func assertEnvMissingPrefix(t *testing.T, env []string, prefix string) {
+	t.Helper()
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			t.Fatalf("env contains scrubbed prefix %q in %q", prefix, entry)
+		}
+	}
+}
+
+func assertEnvContains(t *testing.T, env []string, value string) {
+	t.Helper()
+	for _, entry := range env {
+		if entry == value {
+			return
+		}
+	}
+	t.Fatalf("env missing %q; got %v", value, env)
+}
+
+func assertEnvContainsPrefix(t *testing.T, env []string, prefix string) {
+	t.Helper()
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return
+		}
+	}
+	t.Fatalf("env missing prefix %q; got %v", prefix, env)
+}
+
+func assertArtifact(t *testing.T, artifacts []Artifact, want Artifact) {
+	t.Helper()
+	for _, artifact := range artifacts {
+		if artifact == want {
+			return
+		}
+	}
+	t.Fatalf("artifacts missing %+v; got %+v", want, artifacts)
+}
+
+func TestRunLiveRuntimePropagatesRunnerErrors(t *testing.T) {
+	suite := liveRuntimeSuite(RuntimeClaude)
+	run, err := RunLiveRuntime(context.Background(), LiveRuntimeOptions{
+		Suite:   suite,
+		RunID:   "live-error",
+		Runtime: RuntimeClaude,
+		Enabled: true,
+		LookPath: func(name string) (string, error) {
+			return "/fake/bin/claude", nil
+		},
+		VersionRunner: func(ctx context.Context, cmd RuntimeCommand) (string, error) {
+			return "", nil
+		},
+		Runner: func(ctx context.Context, cmd RuntimeCommand) (RuntimeExecutionResult, error) {
+			return RuntimeExecutionResult{}, errors.New("runtime failed")
+		},
+		Now: fixedEvalTime,
+	})
+	if err != nil {
+		t.Fatalf("RunLiveRuntime returned error: %v", err)
+	}
+	if run.Status != StatusError {
+		t.Fatalf("status = %s, want error", run.Status)
+	}
+	if run.CaseResults[0].FailureMessage != "runtime failed" {
+		t.Fatalf("failure = %q, want runtime failed", run.CaseResults[0].FailureMessage)
+	}
+}

--- a/cli/internal/eval/scorecard.go
+++ b/cli/internal/eval/scorecard.go
@@ -1,0 +1,279 @@
+package eval
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ScorecardKind identifies the product surface a scorecard evaluates.
+type ScorecardKind string
+
+const (
+	// ScorecardKindRPI evaluates the RPI lifecycle contract.
+	ScorecardKindRPI ScorecardKind = "rpi"
+	// ScorecardKindSkillChange evaluates whether a skill change improved or
+	// regressed the skill contract.
+	ScorecardKindSkillChange ScorecardKind = "skill-change"
+)
+
+// ScorecardOptions configures candidate-vs-baseline scorecard generation.
+type ScorecardOptions struct {
+	Kind                  ScorecardKind
+	MaxCategoryRegression float64
+}
+
+// Scorecard is a category-level better-or-worse report for an eval run.
+type Scorecard struct {
+	SchemaVersion          int                 `json:"schema_version"`
+	Kind                   ScorecardKind       `json:"kind"`
+	CandidateRunID         string              `json:"candidate_run_id"`
+	BaselineRunID          string              `json:"baseline_run_id,omitempty"`
+	Verdict                Verdict             `json:"verdict"`
+	Reason                 string              `json:"reason,omitempty"`
+	AggregateScore         float64             `json:"aggregate_score"`
+	BaselineAggregateScore *float64            `json:"baseline_aggregate_score,omitempty"`
+	AggregateDelta         *float64            `json:"aggregate_delta,omitempty"`
+	Categories             []ScorecardCategory `json:"categories"`
+}
+
+// ScorecardCategory records one required scorecard category and its baseline
+// comparison when a baseline run is provided.
+type ScorecardCategory struct {
+	Category       string   `json:"category"`
+	CandidateScore float64  `json:"candidate_score"`
+	BaselineScore  *float64 `json:"baseline_score,omitempty"`
+	Delta          *float64 `json:"delta,omitempty"`
+	Verdict        Verdict  `json:"verdict"`
+	Reason         string   `json:"reason"`
+}
+
+type scorecardDefinition struct {
+	label     string
+	slug      string
+	dimension Dimension
+}
+
+// BuildScorecard builds a category-level scorecard from a candidate eval run
+// and, optionally, a baseline run.
+func BuildScorecard(candidate *RunRecord, baseline *RunRecord, opts ScorecardOptions) (*Scorecard, error) {
+	if candidate == nil {
+		return nil, fmt.Errorf("candidate run is required")
+	}
+	if err := ValidateRun(candidate); err != nil {
+		return nil, err
+	}
+	if baseline != nil {
+		if err := ValidateRun(baseline); err != nil {
+			return nil, err
+		}
+	}
+	kind := opts.Kind
+	if kind == "" {
+		kind = ScorecardKindRPI
+	}
+	defs, err := scorecardDefinitions(kind)
+	if err != nil {
+		return nil, err
+	}
+
+	card := &Scorecard{
+		SchemaVersion:  1,
+		Kind:           kind,
+		CandidateRunID: candidate.RunID,
+		Verdict:        VerdictPass,
+		AggregateScore: candidate.AggregateScore,
+	}
+	if baseline != nil {
+		card.BaselineRunID = baseline.RunID
+		score := baseline.AggregateScore
+		card.BaselineAggregateScore = &score
+		delta := roundDelta(candidate.AggregateScore - baseline.AggregateScore)
+		card.AggregateDelta = &delta
+	}
+
+	hasFailure := false
+	hasRegression := false
+	hasImprovement := false
+	for _, def := range defs {
+		category := scorecardCategory(candidate, baseline, def, opts.MaxCategoryRegression)
+		switch category.Verdict {
+		case VerdictFail:
+			hasFailure = true
+		case VerdictRegression:
+			hasRegression = true
+		case VerdictImprovement:
+			hasImprovement = true
+		}
+		card.Categories = append(card.Categories, category)
+	}
+
+	switch {
+	case candidate.Status == StatusFail || candidate.Status == StatusError:
+		card.Verdict = VerdictFail
+		card.Reason = fmt.Sprintf("candidate run status is %s", candidate.Status)
+	case hasFailure:
+		card.Verdict = VerdictFail
+		card.Reason = "candidate is missing required scorecard categories"
+	case hasRegression:
+		card.Verdict = VerdictRegression
+		card.Reason = "candidate regressed one or more scorecard categories"
+	case hasImprovement:
+		card.Verdict = VerdictImprovement
+		card.Reason = "candidate improved one or more scorecard categories"
+	default:
+		card.Verdict = VerdictPass
+		card.Reason = "candidate preserved required scorecard categories"
+	}
+	return card, nil
+}
+
+// WriteScorecard writes a scorecard JSON artifact to disk.
+func WriteScorecard(path string, card *Scorecard) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("output path is required")
+	}
+	if card == nil {
+		return fmt.Errorf("scorecard is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create scorecard output directory: %w", err)
+	}
+	data, err := json.MarshalIndent(card, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal scorecard: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write scorecard: %w", err)
+	}
+	return nil
+}
+
+func scorecardCategory(candidate *RunRecord, baseline *RunRecord, def scorecardDefinition, maxRegression float64) ScorecardCategory {
+	candidateScore, ok := categoryScore(candidate, def)
+	if !ok {
+		return ScorecardCategory{
+			Category:       def.label,
+			CandidateScore: 0,
+			Verdict:        VerdictFail,
+			Reason:         fmt.Sprintf("candidate has no matching case or dimension score for required category %q", def.label),
+		}
+	}
+	category := ScorecardCategory{
+		Category:       def.label,
+		CandidateScore: candidateScore,
+		Verdict:        VerdictPass,
+		Reason:         fmt.Sprintf("candidate preserved %s", def.label),
+	}
+	if baseline == nil {
+		if candidateScore < 1 {
+			category.Verdict = VerdictFail
+			category.Reason = fmt.Sprintf("candidate %s score %.4f is below 1.0000", def.label, candidateScore)
+		}
+		return category
+	}
+	baselineScore, baselineOK := categoryScore(baseline, def)
+	if !baselineOK {
+		category.Reason = fmt.Sprintf("baseline has no matching case or dimension score for category %q", def.label)
+		return category
+	}
+	category.BaselineScore = floatPtr(baselineScore)
+	delta := roundDelta(candidateScore - baselineScore)
+	category.Delta = floatPtr(delta)
+	switch {
+	case delta < -maxRegression:
+		category.Verdict = VerdictRegression
+		category.Reason = fmt.Sprintf("candidate regressed %s by %.4f", def.label, delta)
+	case delta > 0:
+		category.Verdict = VerdictImprovement
+		category.Reason = fmt.Sprintf("candidate improved %s by %.4f", def.label, delta)
+	default:
+		category.Reason = fmt.Sprintf("candidate preserved %s", def.label)
+	}
+	return category
+}
+
+func scorecardDefinitions(kind ScorecardKind) ([]scorecardDefinition, error) {
+	switch kind {
+	case ScorecardKindRPI:
+		return []scorecardDefinition{
+			{label: "artifact completeness", slug: "artifact-completeness", dimension: DimensionArtifactQuality},
+			{label: "phase order", slug: "phase-order", dimension: DimensionProcessAdherence},
+			{label: "objective spine", slug: "objective-spine", dimension: DimensionProcessAdherence},
+			{label: "validation separation", slug: "validation-separation", dimension: DimensionProcessAdherence},
+			{label: "scenario satisfaction", slug: "scenario-satisfaction", dimension: DimensionCorrectness},
+			{label: "runtime safety", slug: "runtime-safety", dimension: DimensionSafety},
+		}, nil
+	case ScorecardKindSkillChange:
+		return []scorecardDefinition{
+			{label: "structural", slug: "structural", dimension: DimensionArtifactQuality},
+			{label: "trigger", slug: "trigger", dimension: DimensionProcessAdherence},
+			{label: "runtime", slug: "runtime", dimension: DimensionRuntimeCompatibility},
+			{label: "scenario", slug: "scenario", dimension: DimensionCorrectness},
+			{label: "stocktake", slug: "stocktake", dimension: DimensionLearningClosure},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported scorecard kind %q", kind)
+	}
+}
+
+func categoryScore(run *RunRecord, def scorecardDefinition) (float64, bool) {
+	var scores []float64
+	for _, result := range run.CaseResults {
+		if scorecardCaseMatches(result.ID, def.slug) {
+			scores = append(scores, result.Score)
+		}
+	}
+	if len(scores) > 0 {
+		sort.Float64s(scores)
+		return roundScore(sumScores(scores) / float64(len(scores))), true
+	}
+	if score, ok := run.DimensionScores[def.dimension]; ok {
+		return score, true
+	}
+	return 0, false
+}
+
+func scorecardCaseMatches(id, slug string) bool {
+	for _, segment := range strings.FieldsFunc(strings.ToLower(id), func(r rune) bool {
+		return r == '.' || r == '/' || r == ':' || r == '@'
+	}) {
+		if normalizeScorecardSlug(segment) == slug {
+			return true
+		}
+	}
+	return normalizeScorecardSlug(id) == slug
+}
+
+func normalizeScorecardSlug(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func sumScores(scores []float64) float64 {
+	total := 0.0
+	for _, score := range scores {
+		total += score
+	}
+	return total
+}
+
+func floatPtr(value float64) *float64 {
+	return &value
+}

--- a/cli/internal/eval/scorecard_test.go
+++ b/cli/internal/eval/scorecard_test.go
@@ -1,0 +1,285 @@
+package eval
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+)
+
+func TestBuildScorecardRPICategories(t *testing.T) {
+	candidate := scorecardRun("candidate-rpi", StatusPass, map[string]float64{
+		"artifact-completeness": 1,
+		"phase-order":           1,
+		"objective-spine":       1,
+		"validation-separation": 1,
+		"scenario-satisfaction": 1,
+		"runtime-safety":        1,
+	})
+
+	scorecard, err := BuildScorecard(candidate, nil, ScorecardOptions{Kind: ScorecardKindRPI})
+	if err != nil {
+		t.Fatalf("BuildScorecard returned error: %v", err)
+	}
+
+	if scorecard.Kind != ScorecardKindRPI {
+		t.Fatalf("kind = %s, want %s", scorecard.Kind, ScorecardKindRPI)
+	}
+	if scorecard.CandidateRunID != "candidate-rpi" {
+		t.Fatalf("candidate_run_id = %q, want candidate-rpi", scorecard.CandidateRunID)
+	}
+	if scorecard.Verdict != VerdictPass {
+		t.Fatalf("verdict = %s, want pass", scorecard.Verdict)
+	}
+	assertScorecardCategories(t, scorecard, []string{
+		"artifact completeness",
+		"phase order",
+		"objective spine",
+		"validation separation",
+		"scenario satisfaction",
+		"runtime safety",
+	})
+	for _, category := range scorecard.Categories {
+		if category.CandidateScore != 1 {
+			t.Fatalf("%s candidate_score = %v, want 1", category.Category, category.CandidateScore)
+		}
+		if category.BaselineScore != nil {
+			t.Fatalf("%s baseline_score = %v, want nil", category.Category, *category.BaselineScore)
+		}
+		if category.Delta != nil {
+			t.Fatalf("%s delta = %v, want nil", category.Category, *category.Delta)
+		}
+		if category.Verdict != VerdictPass {
+			t.Fatalf("%s verdict = %s, want pass", category.Category, category.Verdict)
+		}
+	}
+}
+
+func TestBuildScorecardSkillChangeCategories(t *testing.T) {
+	candidate := scorecardRun("candidate-skill", StatusPass, map[string]float64{
+		"structural": 1,
+		"trigger":    1,
+		"runtime":    1,
+		"scenario":   1,
+		"stocktake":  1,
+	})
+
+	scorecard, err := BuildScorecard(candidate, nil, ScorecardOptions{Kind: ScorecardKindSkillChange})
+	if err != nil {
+		t.Fatalf("BuildScorecard returned error: %v", err)
+	}
+
+	if scorecard.Kind != ScorecardKindSkillChange {
+		t.Fatalf("kind = %s, want %s", scorecard.Kind, ScorecardKindSkillChange)
+	}
+	if scorecard.Verdict != VerdictPass {
+		t.Fatalf("verdict = %s, want pass", scorecard.Verdict)
+	}
+	assertScorecardCategories(t, scorecard, []string{
+		"structural",
+		"trigger",
+		"runtime",
+		"scenario",
+		"stocktake",
+	})
+}
+
+func TestBuildScorecardMissingCategoryFails(t *testing.T) {
+	candidate := scorecardRun("candidate-missing", StatusPass, map[string]float64{
+		"artifact-completeness": 1,
+		"phase-order":           1,
+		"objective-spine":       1,
+		"validation-separation": 1,
+		"scenario-satisfaction": 1,
+	})
+
+	scorecard, err := BuildScorecard(candidate, nil, ScorecardOptions{Kind: ScorecardKindRPI})
+	if err != nil {
+		t.Fatalf("BuildScorecard returned error: %v", err)
+	}
+
+	if scorecard.Verdict != VerdictFail {
+		t.Fatalf("verdict = %s, want fail", scorecard.Verdict)
+	}
+	category := requireScorecardCategory(t, scorecard, "runtime safety")
+	if category.CandidateScore != 0 {
+		t.Fatalf("runtime safety candidate_score = %v, want 0", category.CandidateScore)
+	}
+	if category.Verdict != VerdictFail {
+		t.Fatalf("runtime safety verdict = %s, want fail", category.Verdict)
+	}
+	if category.Reason != `candidate has no matching case or dimension score for required category "runtime safety"` {
+		t.Fatalf("runtime safety reason = %q", category.Reason)
+	}
+}
+
+func TestBuildScorecardBaselineDeltaRegressionImprovement(t *testing.T) {
+	t.Run("improvement", func(t *testing.T) {
+		candidate := scorecardRun("candidate-improves", StatusPass, map[string]float64{
+			"artifact-completeness": 1,
+			"phase-order":           1,
+			"objective-spine":       1,
+			"validation-separation": 1,
+			"scenario-satisfaction": 1,
+			"runtime-safety":        1,
+		})
+		baseline := scorecardRun("baseline", StatusPass, map[string]float64{
+			"artifact-completeness": 0.8,
+			"phase-order":           1,
+			"objective-spine":       1,
+			"validation-separation": 1,
+			"scenario-satisfaction": 1,
+			"runtime-safety":        1,
+		})
+
+		scorecard, err := BuildScorecard(candidate, baseline, ScorecardOptions{Kind: ScorecardKindRPI})
+		if err != nil {
+			t.Fatalf("BuildScorecard returned error: %v", err)
+		}
+		if scorecard.Verdict != VerdictImprovement {
+			t.Fatalf("verdict = %s, want improvement", scorecard.Verdict)
+		}
+		category := requireScorecardCategory(t, scorecard, "artifact completeness")
+		assertFloatPtr(t, category.BaselineScore, 0.8, "artifact completeness baseline_score")
+		assertFloatPtr(t, category.Delta, 0.2, "artifact completeness delta")
+		if category.Verdict != VerdictImprovement {
+			t.Fatalf("artifact completeness verdict = %s, want improvement", category.Verdict)
+		}
+		if category.Reason != "candidate improved artifact completeness by 0.2000" {
+			t.Fatalf("artifact completeness reason = %q", category.Reason)
+		}
+	})
+
+	t.Run("regression", func(t *testing.T) {
+		candidate := scorecardRun("candidate-regresses", StatusPass, map[string]float64{
+			"artifact-completeness": 1,
+			"phase-order":           1,
+			"objective-spine":       1,
+			"validation-separation": 1,
+			"scenario-satisfaction": 1,
+			"runtime-safety":        0.7,
+		})
+		baseline := scorecardRun("baseline", StatusPass, map[string]float64{
+			"artifact-completeness": 1,
+			"phase-order":           1,
+			"objective-spine":       1,
+			"validation-separation": 1,
+			"scenario-satisfaction": 1,
+			"runtime-safety":        0.9,
+		})
+
+		scorecard, err := BuildScorecard(candidate, baseline, ScorecardOptions{
+			Kind:                  ScorecardKindRPI,
+			MaxCategoryRegression: 0.05,
+		})
+		if err != nil {
+			t.Fatalf("BuildScorecard returned error: %v", err)
+		}
+		if scorecard.Verdict != VerdictRegression {
+			t.Fatalf("verdict = %s, want regression", scorecard.Verdict)
+		}
+		category := requireScorecardCategory(t, scorecard, "runtime safety")
+		assertFloatPtr(t, category.BaselineScore, 0.9, "runtime safety baseline_score")
+		assertFloatPtr(t, category.Delta, -0.2, "runtime safety delta")
+		if category.Verdict != VerdictRegression {
+			t.Fatalf("runtime safety verdict = %s, want regression", category.Verdict)
+		}
+		if category.Reason != "candidate regressed runtime safety by -0.2000" {
+			t.Fatalf("runtime safety reason = %q", category.Reason)
+		}
+	})
+}
+
+func TestBuildScorecardFailedCandidateFails(t *testing.T) {
+	candidate := scorecardRun("candidate-failed", StatusError, map[string]float64{
+		"artifact-completeness": 1,
+		"phase-order":           1,
+		"objective-spine":       1,
+		"validation-separation": 1,
+		"scenario-satisfaction": 1,
+		"runtime-safety":        1,
+	})
+
+	scorecard, err := BuildScorecard(candidate, nil, ScorecardOptions{Kind: ScorecardKindRPI})
+	if err != nil {
+		t.Fatalf("BuildScorecard returned error: %v", err)
+	}
+	if scorecard.Verdict != VerdictFail {
+		t.Fatalf("verdict = %s, want fail", scorecard.Verdict)
+	}
+	if scorecard.Reason != "candidate run status is error" {
+		t.Fatalf("reason = %q, want candidate run status is error", scorecard.Reason)
+	}
+}
+
+func scorecardRun(runID string, status Status, caseScores map[string]float64) *RunRecord {
+	run := minimalRunRecord(runID, averageScore(caseScores), map[Dimension]float64{
+		DimensionCorrectness: averageScore(caseScores),
+	})
+	run.Status = status
+	run.Verdict = VerdictPass
+	if status == StatusFail || status == StatusError {
+		run.Verdict = VerdictFail
+	}
+	run.CaseResults = nil
+	slugs := make([]string, 0, len(caseScores))
+	for slug := range caseScores {
+		slugs = append(slugs, slug)
+	}
+	sort.Strings(slugs)
+	for _, slug := range slugs {
+		score := caseScores[slug]
+		run.CaseResults = append(run.CaseResults, CaseResult{
+			ID:     fmt.Sprintf("scorecard.%s.surface", slug),
+			Status: StatusPass,
+			Score:  score,
+			DimensionScores: map[Dimension]float64{
+				DimensionCorrectness: score,
+			},
+		})
+	}
+	return run
+}
+
+func averageScore(scores map[string]float64) float64 {
+	if len(scores) == 0 {
+		return 0
+	}
+	sum := 0.0
+	for _, score := range scores {
+		sum += score
+	}
+	return roundScore(sum / float64(len(scores)))
+}
+
+func assertScorecardCategories(t *testing.T, scorecard *Scorecard, want []string) {
+	t.Helper()
+	if len(scorecard.Categories) != len(want) {
+		t.Fatalf("category count = %d, want %d: %+v", len(scorecard.Categories), len(want), scorecard.Categories)
+	}
+	for i, category := range scorecard.Categories {
+		if category.Category != want[i] {
+			t.Fatalf("categories[%d] = %q, want %q", i, category.Category, want[i])
+		}
+	}
+}
+
+func requireScorecardCategory(t *testing.T, scorecard *Scorecard, name string) ScorecardCategory {
+	t.Helper()
+	for _, category := range scorecard.Categories {
+		if category.Category == name {
+			return category
+		}
+	}
+	t.Fatalf("category %q not found in %+v", name, scorecard.Categories)
+	return ScorecardCategory{}
+}
+
+func assertFloatPtr(t *testing.T, got *float64, want float64, label string) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("%s = nil, want %v", label, want)
+	}
+	if *got != want {
+		t.Fatalf("%s = %v, want %v", label, *got, want)
+	}
+}

--- a/cli/internal/eval/types.go
+++ b/cli/internal/eval/types.go
@@ -1,0 +1,290 @@
+package eval
+
+import "time"
+
+type Tier string
+
+const (
+	TierDeterministic Tier = "deterministic"
+	TierHeadless      Tier = "headless"
+	TierLive          Tier = "live"
+	TierRelease       Tier = "release"
+)
+
+type Visibility string
+
+const (
+	VisibilityPublicCanary   Visibility = "public_canary"
+	VisibilityPrivateHoldout Visibility = "private_holdout"
+)
+
+type Runtime string
+
+const (
+	RuntimeStatic Runtime = "static"
+	RuntimeMock   Runtime = "mock"
+	RuntimeShell  Runtime = "shell"
+	RuntimeClaude Runtime = "claude"
+	RuntimeCodex  Runtime = "codex"
+	RuntimeManual Runtime = "manual"
+)
+
+type Dimension string
+
+const (
+	DimensionCorrectness          Dimension = "correctness"
+	DimensionProcessAdherence     Dimension = "process_adherence"
+	DimensionArtifactQuality      Dimension = "artifact_quality"
+	DimensionRuntimeCompatibility Dimension = "runtime_compatibility"
+	DimensionEfficiency           Dimension = "efficiency"
+	DimensionSafety               Dimension = "safety"
+	DimensionLearningClosure      Dimension = "learning_closure"
+)
+
+type Status string
+
+const (
+	StatusPass         Status = "pass"
+	StatusFail         Status = "fail"
+	StatusError        Status = "error"
+	StatusSkipped      Status = "skipped"
+	StatusInconclusive Status = "inconclusive"
+)
+
+type Verdict string
+
+const (
+	VerdictPass         Verdict = "pass"
+	VerdictFail         Verdict = "fail"
+	VerdictImprovement  Verdict = "improvement"
+	VerdictRegression   Verdict = "regression"
+	VerdictAdvisory     Verdict = "advisory"
+	VerdictInconclusive Verdict = "inconclusive"
+)
+
+type BaselineMode string
+
+const (
+	BaselineModeNone    BaselineMode = "none"
+	BaselineModeCompare BaselineMode = "compare"
+	BaselineModePromote BaselineMode = "promote"
+)
+
+type NetworkAccess string
+
+const (
+	NetworkDisabled NetworkAccess = "disabled"
+	NetworkEnabled  NetworkAccess = "enabled"
+	NetworkUnknown  NetworkAccess = "unknown"
+)
+
+type Suite struct {
+	SchemaVersion  int              `json:"schema_version"`
+	ID             string           `json:"id"`
+	Name           string           `json:"name"`
+	Description    string           `json:"description,omitempty"`
+	Domain         string           `json:"domain"`
+	Visibility     Visibility       `json:"visibility"`
+	Tier           Tier             `json:"tier"`
+	Owners         []string         `json:"owners,omitempty"`
+	Tags           []string         `json:"tags,omitempty"`
+	Allowed        []Runtime        `json:"allowed_runtimes,omitempty"`
+	Environment    SuiteEnvironment `json:"environment,omitempty"`
+	Fixtures       []Fixture        `json:"fixtures,omitempty"`
+	Scoring        Scoring          `json:"scoring"`
+	BaselinePolicy BaselinePolicy   `json:"baseline_policy"`
+	Cases          []Case           `json:"cases"`
+}
+
+type SuiteEnvironment struct {
+	OfflineRequired  bool     `json:"offline_required,omitempty"`
+	Network          string   `json:"network,omitempty"`
+	ScrubEnvPrefixes []string `json:"scrub_env_prefixes,omitempty"`
+	IsolateHome      bool     `json:"isolate_home,omitempty"`
+	IsolateCodexHome bool     `json:"isolate_codex_home,omitempty"`
+	TimeoutSeconds   int      `json:"timeout_seconds,omitempty"`
+	MaxAttempts      int      `json:"max_attempts,omitempty"`
+}
+
+type Fixture struct {
+	Path     string `json:"path"`
+	Purpose  string `json:"purpose"`
+	Required bool   `json:"required,omitempty"`
+	SHA256   string `json:"sha256,omitempty"`
+}
+
+type Scoring struct {
+	AggregateThreshold float64            `json:"aggregate_threshold"`
+	CriticalThreshold  *float64           `json:"critical_threshold,omitempty"`
+	Dimensions         []ScoringDimension `json:"dimensions"`
+}
+
+type ScoringDimension struct {
+	Name      Dimension `json:"name"`
+	Weight    float64   `json:"weight"`
+	Threshold float64   `json:"threshold"`
+	Critical  bool      `json:"critical,omitempty"`
+}
+
+type BaselinePolicy struct {
+	Mode                   string   `json:"mode"`
+	BaselineRef            string   `json:"baseline_ref,omitempty"`
+	BaselinePath           string   `json:"baseline_path,omitempty"`
+	MaxAggregateRegression *float64 `json:"max_aggregate_regression,omitempty"`
+	MaxDimensionRegression *float64 `json:"max_dimension_regression,omitempty"`
+	RepeatCount            int      `json:"repeat_count,omitempty"`
+	PromotionRequires      []string `json:"promotion_requires,omitempty"`
+	BlockingGate           string   `json:"blocking_gate,omitempty"`
+}
+
+type Case struct {
+	ID             string         `json:"id"`
+	Title          string         `json:"title"`
+	Kind           string         `json:"kind"`
+	Objective      string         `json:"objective"`
+	Runtime        Runtime        `json:"runtime,omitempty"`
+	TimeoutSeconds int            `json:"timeout_seconds,omitempty"`
+	Fixtures       []string       `json:"fixtures,omitempty"`
+	Inputs         map[string]any `json:"inputs,omitempty"`
+	Expectations   []Expectation  `json:"expectations"`
+	Dimensions     []Dimension    `json:"dimensions,omitempty"`
+	Critical       bool           `json:"critical,omitempty"`
+	Tags           []string       `json:"tags,omitempty"`
+}
+
+type Expectation struct {
+	Type      string   `json:"type"`
+	Target    string   `json:"target,omitempty"`
+	Value     any      `json:"value,omitempty"`
+	Threshold *float64 `json:"threshold,omitempty"`
+	Required  *bool    `json:"required,omitempty"`
+}
+
+type SuiteRef struct {
+	ID         string     `json:"id"`
+	Path       string     `json:"path"`
+	Visibility Visibility `json:"visibility"`
+	Tier       Tier       `json:"tier"`
+	Version    string     `json:"version,omitempty"`
+	SHA256     string     `json:"sha256,omitempty"`
+}
+
+type GitRecord struct {
+	CandidateRef string   `json:"candidate_ref"`
+	CandidateSHA string   `json:"candidate_sha"`
+	BaselineRef  string   `json:"baseline_ref,omitempty"`
+	BaselineSHA  string   `json:"baseline_sha,omitempty"`
+	Dirty        bool     `json:"dirty"`
+	DirtyPaths   []string `json:"dirty_paths,omitempty"`
+}
+
+type RuntimeRecord struct {
+	Name           Runtime `json:"name"`
+	Version        string  `json:"version,omitempty"`
+	Model          string  `json:"model,omitempty"`
+	Profile        string  `json:"profile,omitempty"`
+	Live           bool    `json:"live"`
+	Attempts       int     `json:"attempts,omitempty"`
+	TimeoutSeconds int     `json:"timeout_seconds,omitempty"`
+	SkippedReason  string  `json:"skipped_reason,omitempty"`
+}
+
+type EnvironmentRecord struct {
+	ScrubbedEnvPrefixes []string      `json:"scrubbed_env_prefixes"`
+	IsolatedHome        bool          `json:"isolated_home"`
+	IsolatedCodexHome   bool          `json:"isolated_codex_home"`
+	NetworkAccess       NetworkAccess `json:"network_access"`
+	HooksDisabled       bool          `json:"hooks_disabled,omitempty"`
+	HostNotes           []string      `json:"host_notes,omitempty"`
+}
+
+type BaselineRecord struct {
+	Mode              BaselineMode `json:"mode"`
+	BaselineRunID     string       `json:"baseline_run_id,omitempty"`
+	BaselineRef       string       `json:"baseline_ref,omitempty"`
+	BaselinePath      string       `json:"baseline_path,omitempty"`
+	PromotedFromRunID string       `json:"promoted_from_run_id,omitempty"`
+	PromotedAt        *time.Time   `json:"promoted_at,omitempty"`
+	PromotedBy        string       `json:"promoted_by,omitempty"`
+	Rationale         string       `json:"rationale,omitempty"`
+}
+
+type ComparisonItem struct {
+	CaseID    string    `json:"case_id,omitempty"`
+	Dimension Dimension `json:"dimension"`
+	Delta     float64   `json:"delta"`
+	Reason    string    `json:"reason"`
+}
+
+type BaselineComparison struct {
+	Verdict        Verdict               `json:"verdict"`
+	BaselineRunID  string                `json:"baseline_run_id,omitempty"`
+	BaselineScore  float64               `json:"baseline_score,omitempty"`
+	AggregateDelta float64               `json:"aggregate_delta,omitempty"`
+	DimensionDelta map[Dimension]float64 `json:"dimension_deltas,omitempty"`
+	Regressions    []ComparisonItem      `json:"regressions,omitempty"`
+	Improvements   []ComparisonItem      `json:"improvements,omitempty"`
+}
+
+type Artifact struct {
+	Path    string `json:"path"`
+	Purpose string `json:"purpose"`
+	Kind    string `json:"kind,omitempty"`
+	SHA256  string `json:"sha256,omitempty"`
+}
+
+type CaseResult struct {
+	ID              string                `json:"id"`
+	Status          Status                `json:"status"`
+	Score           float64               `json:"score"`
+	DimensionScores map[Dimension]float64 `json:"dimension_scores"`
+	DurationMS      int64                 `json:"duration_ms,omitempty"`
+	Critical        bool                  `json:"critical,omitempty"`
+	Artifacts       []Artifact            `json:"artifacts,omitempty"`
+	FailureMessage  string                `json:"failure_message,omitempty"`
+	Diagnostics     []string              `json:"diagnostics,omitempty"`
+}
+
+type RunRecord struct {
+	SchemaVersion      int                   `json:"schema_version"`
+	RunID              string                `json:"run_id"`
+	Suite              SuiteRef              `json:"suite"`
+	StartedAt          time.Time             `json:"started_at"`
+	CompletedAt        *time.Time            `json:"completed_at,omitempty"`
+	Status             Status                `json:"status"`
+	Verdict            Verdict               `json:"verdict"`
+	Git                GitRecord             `json:"git"`
+	Runtime            RuntimeRecord         `json:"runtime"`
+	Environment        EnvironmentRecord     `json:"environment"`
+	Baseline           *BaselineRecord       `json:"baseline,omitempty"`
+	CaseResults        []CaseResult          `json:"case_results"`
+	AggregateScore     float64               `json:"aggregate_score"`
+	DimensionScores    map[Dimension]float64 `json:"dimension_scores"`
+	BaselineComparison *BaselineComparison   `json:"baseline_comparison,omitempty"`
+	Artifacts          []Artifact            `json:"artifacts,omitempty"`
+	Notes              []string              `json:"notes,omitempty"`
+}
+
+type RunOptions struct {
+	SuitePath    string
+	RunID        string
+	Runtime      Runtime
+	OutputPath   string
+	BaselinePath string
+	WorkDir      string
+	Now          func() time.Time
+}
+
+type CompareOptions struct {
+	MaxAggregateRegression float64
+	MaxDimensionRegression float64
+	OutputPath             string
+}
+
+type BaselineOptions struct {
+	OutputPath string
+	PromotedBy string
+	Rationale  string
+	WorkDir    string
+	Now        func() time.Time
+}

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -36,13 +36,14 @@ The validate workflow runs **30 jobs** across 4 tiers of parallelism. Most jobs 
 
 ```text
                     ┌───────────────────────────────────────────────┐
-                    │         26 independent parallel jobs          │
+                    │         27 independent parallel jobs          │
                     │                                               │
                     │  doc-release-gate    smoke-test               │
                     │  hook-preflight      validate-hooks-doc-parity│
                     │  validate-ci-policy-parity                    │
                     │  codex-runtime-sections                       │
                     │  embedded-sync       cli-docs-parity          │
+                    │  agentops-eval-advisory                      │
                     │  shellcheck          markdownlint             │
                     │  security-scan       security-toolchain-gate  │
                     │  skill-integrity     skill-schema             │
@@ -67,7 +68,7 @@ The validate workflow runs **30 jobs** across 4 tiers of parallelism. Most jobs 
                       │            │              │
                     ┌─┴────────────┴──────────────┴─┐
                     │           summary             │
-                    │  (needs: ALL 29 jobs)         │
+                    │  (needs: ALL 30 jobs)         │
                     │  if: always()                 │
                     └───────────────────────────────┘
 ```
@@ -76,7 +77,7 @@ The validate workflow runs **30 jobs** across 4 tiers of parallelism. Most jobs 
 
 The final `summary` job lists every other job in its `needs` array and runs with `if: always()`. It checks each job's result and fails if any **blocking** job did not succeed. This single aggregator is the branch protection target -- repository settings only need to require `summary` to pass, not every individual job.
 
-Notably, `summary` excludes `security-toolchain-gate`, `doctor-check`, and `check-test-staleness` from its failure condition (these are soft gates), while still listing them in `needs` so they appear in the summary output.
+Notably, `summary` excludes `agentops-eval-advisory`, `security-toolchain-gate`, `doctor-check`, and `check-test-staleness` from its failure condition (these are soft gates), while still listing them in `needs` so they appear in the summary output.
 
 ## Blocking vs Soft Gates
 
@@ -86,6 +87,7 @@ These jobs run but their failure does **not** block merges:
 
 | Job | Reason |
 |-----|--------|
+| `agentops-eval-advisory` | Public eval canaries run on every PR, but baseline ratchets start advisory until variance and promotion policy are stable |
 | `security-toolchain-gate` | External scanner tools may be unavailable; pattern scan (`security-scan`) is the blocking check |
 | `doctor-check` | Reports stale CLI references; CI environment lacks some expected tools |
 | `check-test-staleness` | Advisory -- flags tests that may need updating |

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -210,6 +210,15 @@ scripts/security-gate.sh --mode full --json    # Machine-readable output
 scripts/security-gate.sh --require-tools       # Fail if scanners missing
 ```
 
+### scripts/toolchain-validate.sh
+
+Runs the scanner invocation contract used by `scripts/security-gate.sh`, including JSON output, quick-mode skips, and gate exit codes.
+
+```bash
+scripts/toolchain-validate.sh --quick --gate --json
+scripts/toolchain-validate.sh --gate --json
+```
+
 ### Scanners
 
 | Scanner | Target | Purpose |
@@ -223,10 +232,6 @@ scripts/security-gate.sh --require-tools       # Fail if scanners missing
 | ruff | Python | Python linter |
 | radon | Python | Cyclomatic complexity for Python |
 | ShellCheck | Shell | Shell script analysis (also runs standalone in validate.yml) |
-
-### scripts/security-toolchain-validate.sh
-
-Validates that the security toolchain itself is correctly installed and functional. Used by `security-toolchain-gate` in CI.
 
 ## Release Workflow
 

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -32,6 +32,8 @@ These describe data written and consumed at runtime — handoffs between session
 | [`evidence-only-closure.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/evidence-only-closure.v1.schema.json) | Proof artifact for issue closures that rely on validation or policy evidence instead of a code delta. |
 | [`session-quality-signal.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/session-quality-signal.v1.schema.json) | Per-session quality signal rolled up into the knowledge flywheel. |
 | [`scenario.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/scenario.v1.schema.json) | Behavioral validation scenarios stored in `.agents/holdout/`. |
+| [`eval-suite.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/eval-suite.v1.schema.json) | Public canary and private holdout evaluation suite manifests. See [`Eval Environment`](contracts/eval-environment.md). |
+| [`eval-run.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/eval-run.v1.schema.json) | Evaluation run records, scorecards, baseline comparisons, runtime hygiene, and artifacts. See [`Eval Environment`](contracts/eval-environment.md). |
 | [`swarm-evidence.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/swarm-evidence.schema.json) | Permissive shape for files written by swarm workers to `.agents/swarm/results/<task>.json`. Companion strict schema: [`contracts/swarm-worker-result.schema.json`](contracts/swarm-worker-result.schema.json). |
 | [`finding.json`](https://github.com/boshu2/agentops/blob/main/schemas/finding.json) | Canonical finding-item schema for validation skills. Compatible subset of [`contracts/finding-artifact.schema.json`](contracts/finding-artifact.schema.json). |
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -45,6 +45,7 @@ Run a specific tier:
 | Push-time local gate | `scripts/pre-push-gate.sh` | ~30-90s |
 | Activate repo hooks | `bash scripts/install-dev-hooks.sh` | ~1s |
 | Go build + vet + changed-scope race | `scripts/validate-go-fast.sh` | ~20s |
+| AgentOps eval canaries | `scripts/eval-agentops.sh --fast` | ~20s |
 | BATS hook tests | `bats tests/hooks/*.bats` | ~10s |
 | BATS script tests | `bats tests/scripts/*.bats` | ~10s |
 | Skill validation | `tests/skills/run-all.sh` | ~30s |
@@ -53,6 +54,37 @@ Run a specific tier:
 | Contract compatibility | `./scripts/check-contract-compatibility.sh` | ~10s |
 | Full CI gate (local) | `scripts/ci-local-release.sh` | 5-10 min |
 | Native Windows smoke | `powershell -ExecutionPolicy Bypass -File .\tests\windows\test-windows-smoke.ps1` | ~1-3 min |
+
+### AgentOps eval canaries
+
+Public deterministic eval suites live under `evals/agentops-core/` and cover
+the first AgentOps product surfaces that must not regress: CLI contracts,
+hook/runtime inventory, RPI behavior, and scorecard output. Run the fast local
+set before changing eval contracts, `ao eval`, or the canary suites:
+
+```bash
+scripts/eval-agentops.sh --fast
+```
+
+The runner writes artifacts under `.agents/evals/runs/`. If a promoted baseline
+exists under `.agents/evals/baselines/`, the runner compares the new run against
+it and fails on regressions. Missing baselines are warnings, not failures, so new
+canaries can land before their ratchet is promoted.
+
+Baseline promotion is explicit and requires a rationale:
+
+```bash
+scripts/eval-agentops.sh --fast \
+  --promote-baseline \
+  --promoted-by "$USER" \
+  --rationale "Intentional behavior improvement after review"
+```
+
+Local deterministic failures are blocking through `scripts/pre-push-gate.sh
+--fast` when eval-related files change. CI also runs `agentops-eval-advisory`,
+which is intentionally non-blocking while the initial baselines and variance
+policy are established. Live Claude/Codex runtime checks remain advisory unless a
+suite explicitly opts into a deterministic mock or fixture.
 
 ## Writing New Tests
 

--- a/docs/cli-skills-map.md
+++ b/docs/cli-skills-map.md
@@ -2,7 +2,7 @@
 
 > Which `ao` commands are called by which skills and hooks — and vice versa.
 
-Auto-audited 2026-04-24; targeted runtime-proof update 2026-04-24. 56 generated CLI command headings, 69 source skills, 7 runtime hook event sections.
+Auto-audited 2026-04-24; targeted runtime-proof update 2026-04-24. 57 generated CLI command headings, 69 source skills, 7 runtime hook event sections.
 
 Source-of-truth note: `hooks/hooks.json` currently declares 7 runtime hook event sections. Repository hook scripts such as `worktree-setup.sh` are support/setup scripts and are listed separately when relevant.
 
@@ -12,7 +12,7 @@ Registry-first note: `/plan`, `/pre-mortem`, `/research`, `/vibe`, and `/post-mo
 
 | Category | Count |
 |----------|-------|
-| Generated CLI command headings | 56 |
+| Generated CLI command headings | 57 |
 | CLI command entries with skill/hook callers | 34 |
 | Orphan/hidden command entries (user utilities, hidden, CI-only) | 21 |
 | Known phantom subcommands | 0 |

--- a/docs/cli-skills-map.md
+++ b/docs/cli-skills-map.md
@@ -14,7 +14,7 @@ Registry-first note: `/plan`, `/pre-mortem`, `/research`, `/vibe`, and `/post-mo
 |----------|-------|
 | Generated CLI command headings | 56 |
 | CLI command entries with skill/hook callers | 34 |
-| Orphan/hidden command entries (user utilities, hidden, CI-only) | 20 |
+| Orphan/hidden command entries (user utilities, hidden, CI-only) | 21 |
 | Known phantom subcommands | 0 |
 
 ---
@@ -146,6 +146,7 @@ Commands that exist in the Go CLI but are not called by any skill or hook. All a
 | `ao config` | User utility | Config management |
 | `ao demo` | User utility | Interactive demonstration |
 | `ao doctor` | CI/install | Called by install.sh and release-smoke-test.sh |
+| `ao eval` | CI/test | Public AgentOps canary suites and baseline comparisons |
 | `ao version` | User utility | Version query |
 | `ao quick-start` | User utility | `/quickstart` skill is the orchestrator |
 | `ao vibe-check` | User utility | `/vibe` skill orchestrates directly |

--- a/docs/contracts/agents-write-surfaces.md
+++ b/docs/contracts/agents-write-surfaces.md
@@ -32,6 +32,7 @@ allowlist nor an active skill name fails the gate.
 | `constraints` | cli (constraints subsystem) | persistent | Compiled constraint manifests |
 | `context` | cli (context injection) | rolling | Context-scoped ad hoc artifacts produced by `ao inject --for` flows |
 | `defrag` | cli (compile defrag), scripts | rolling | Defrag run state and dry-run reports |
+| `evals` | cli eval runtime, scripts (`eval-agentops`) | persistent | Eval run outputs, promoted baselines, and suite execution state |
 | `findings` | scripts, /forge | persistent | Mined findings awaiting promotion |
 | `git` | cli (git-aware tooling) | persistent | Git-derived state cached for the runtime |
 | `holdout` | cli (`/scenario`) | persistent | Holdout scenarios stored outside the codebase view |
@@ -88,6 +89,7 @@ config
 constraints
 context
 defrag
+evals
 findings
 git
 holdout

--- a/docs/contracts/eval-environment.md
+++ b/docs/contracts/eval-environment.md
@@ -1,0 +1,200 @@
+# Eval Environment Contract
+
+> **Status:** Draft
+> **Suite Schema:** `eval-suite.v1.schema.json`
+> **Run Schema:** `eval-run.v1.schema.json`
+> **Consumers:** future `ao eval` commands, release validation, RPI validation, and runtime/model comparison workflows
+
+This contract defines the durable shape for AgentOps evaluation suites, run
+records, scorecards, baselines, and gate tiers. It exists so skills, hooks, CLI
+commands, RPI flows, and Claude/Codex runtime behavior can be compared against
+stable evidence instead of self-reported success.
+
+## Scope
+
+V1 covers:
+
+- checked-in public canary suites
+- private holdout suites that use the same schema
+- deterministic offline evaluation tiers
+- optional live runtime tiers for Claude and Codex
+- baseline capture and promotion rules
+- candidate-vs-baseline score comparison
+- run records and scorecards for local, CI, nightly, release, and model-upgrade use
+
+V1 does not require:
+
+- live model access for normal PR validation
+- committing private holdout cases
+- exact prose matching when a mechanical artifact, command result, or structured
+  output can be scored
+- blocking gates for live runtime suites before variance is known and ratcheted
+
+## Storage
+
+Use this storage split:
+
+| Path | Purpose | Commit policy |
+|------|---------|---------------|
+| `evals/` | Public canary suites and committed fixtures | Checked in |
+| `.agents/evals/runs/<run-id>/` | Generated run records, transcripts, scorecards, and diagnostics | Local/generated |
+| `.agents/evals/baselines/` | Local baseline candidates and promoted baseline snapshots | Commit only when explicitly promoted |
+| `.agents/holdout/` or private suite roots | Private holdouts | Do not commit unless intentionally publishing a canary |
+
+Public and private suites both validate against
+`eval-suite.v1.schema.json`. Run outputs validate against
+`eval-run.v1.schema.json`.
+
+## Public Canaries
+
+Public canaries are reviewable, checked-in suites that every implementer may
+read and run. They are meant to catch known regressions and preserve product
+contracts.
+
+Required properties:
+
+- stored under `evals/`
+- use `visibility: public_canary`
+- deterministic suites must run without network, model auth, or host-specific
+  local state
+- fixture paths must be repo-relative and committed
+- expected outputs must prefer mechanical checks over subjective prose
+- critical public canaries must require a perfect pass rate before becoming
+  blocking
+
+Public canaries are allowed to become PR or pre-push gates after they are stable.
+They are not sufficient by themselves because public cases can be overfit.
+
+## Private Holdouts
+
+Private holdouts are unseen suites used to detect overfitting and validate real
+behavior beyond the public corpus.
+
+Rules:
+
+- use `visibility: private_holdout`
+- validate against the same suite schema as public canaries
+- may live in `.agents/holdout/`, `.agents/evals/holdouts/`, or an operator-owned
+  private suite root
+- must not be required for normal open source PR validation
+- must not be read by the implementing agent unless the run is explicitly in an
+  evaluator role
+- may be used in nightly, release, model-upgrade, or post-merge validation
+
+Private holdouts should report aggregate scores and regression categories without
+revealing scenario text when secrecy matters.
+
+## Eval Tiers
+
+Suites declare one tier:
+
+| Tier | Deterministic | Runtime access | Intended gate |
+|------|---------------|----------------|---------------|
+| `deterministic` | Yes | None | PR, pre-push, CI |
+| `headless` | Mostly | Local Claude/Codex CLI inventory or mocked runtime I/O | CI advisory or release |
+| `live` | No | Authenticated Claude/Codex model execution | Nightly, release, model upgrade |
+| `release` | Mixed | Deterministic plus approved live/advisory suites | Release readiness |
+
+The first blocking tier must be deterministic. Live runtime suites are opt-in and
+advisory until repeated runs establish variance, timeout behavior, and cost.
+
+## Runtime Isolation
+
+Live or headless runtime evaluations must record runtime hygiene:
+
+- isolated `HOME` for tool state where practical
+- isolated `CODEX_HOME` for Codex runs
+- scrub every `AGENTOPS_RPI_RUNTIME*` environment variable
+- capture runtime name, runtime version, model, timeout, attempts, and skipped
+  reason when unavailable
+- write transcripts or stream logs as run artifacts
+
+A live suite that cannot run because auth, runtime, model, budget, or network is
+unavailable should produce `status: skipped` or `verdict: advisory`, not a false
+regression.
+
+## Score Dimensions
+
+Canonical score dimensions are normalized numbers from `0.0` to `1.0`:
+
+| Dimension | Meaning |
+|-----------|---------|
+| `correctness` | The task or command produced the required result. |
+| `process_adherence` | The run followed required workflow, phase, or skill contract steps. |
+| `artifact_quality` | Required artifacts exist, validate, and contain useful evidence. |
+| `runtime_compatibility` | Behavior remains compatible across declared runtimes and models. |
+| `efficiency` | The run stayed within expected time, budget, retry, and output limits. |
+| `safety` | The run respected isolation, scope, permission, and no-leak requirements. |
+| `learning_closure` | Findings, scorecards, baselines, and follow-up work were recorded when required. |
+
+A suite declares dimension weights and thresholds. A run records case-level
+dimension scores and aggregate dimension scores. A critical dimension regression
+can fail a candidate even when the aggregate score improves.
+
+## Baseline Lifecycle
+
+Baselines are explicit snapshots, not whatever happened to pass most recently.
+
+Lifecycle:
+
+1. **Capture:** run a suite against a known reference and write an eval run record.
+2. **Compare:** run the candidate and compare aggregate, dimension, and critical
+   case deltas against the baseline.
+3. **Review:** inspect scorecard evidence, skipped cases, environment hygiene, and
+   any known variance.
+4. **Promote:** record the promoted run id, candidate ref, baseline path, promoter,
+   timestamp, and rationale.
+5. **Ratchet:** make the suite blocking only after the baseline is stable enough
+   for the target gate.
+
+Promotion requires:
+
+- no failed critical public canary cases
+- no safety regression
+- no unreviewed private-holdout regression when holdouts were run
+- durable suite and run artifacts
+- explicit human or release process rationale
+
+Live runtime baselines must include repeat count, variance notes, skipped cases,
+and advisory/blocking status. A single live pass is not enough to make a live
+suite blocking.
+
+## Verdict Rules
+
+`eval-run.v1.schema.json` records both status and verdict.
+
+Status describes execution:
+
+- `pass`
+- `fail`
+- `error`
+- `skipped`
+- `inconclusive`
+
+Verdict describes comparison:
+
+- `pass`
+- `fail`
+- `improvement`
+- `regression`
+- `advisory`
+- `inconclusive`
+
+A candidate is better only when it preserves critical cases and improves or holds
+the relevant baseline dimensions. A candidate that improves efficiency while
+regressing safety or runtime compatibility is not better.
+
+## Relationship To Existing Contracts
+
+This contract builds on:
+
+- [Headless Invocation Standards](headless-invocation-standards.md) for live
+  Claude/Codex process execution
+- [Hook Runtime Contract](hook-runtime-contract.md) for hook I/O expectations
+- [Codex Skill API](codex-skill-api.md) for Codex runtime skill behavior
+- [Session Intelligence Trust Model](session-intelligence-trust-model.md) for
+  trusted runtime context inputs
+- `scenario.v1.schema.json` for existing holdout scenario files
+
+The eval suite schema may reference scenario fixtures, but scenario files remain
+their own artifact type.

--- a/docs/contracts/index.md
+++ b/docs/contracts/index.md
@@ -25,6 +25,12 @@ skills, the runtime, and external integrations.
 
     RPI run registry specification.
 
+-   :material-clipboard-pulse: **[Eval Environment](eval-environment.md)**
+
+    ---
+
+    Evaluation suite, run, scorecard, baseline, canary, and holdout contract.
+
 -   :material-format-list-numbered: **[Next-Work Queue](next-work.schema.md)**
 
     ---

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -202,6 +202,9 @@
 - [`.agents/` Write Surfaces](contracts/agents-write-surfaces.md) — Catalogued top-level subdirs that production code writes under `.agents/`, gated by `scripts/check-agents-write-surfaces.sh`
 - [Repo Execution Profile Schema](contracts/repo-execution-profile.schema.json) — Machine-readable schema for repo execution profiles
 - [RPI Run Registry](contracts/rpi-run-registry.md) — RPI run registry specification
+- [Eval Environment Contract](contracts/eval-environment.md) — Evaluation suite, run, scorecard, baseline, canary, and holdout contract
+- [Eval Suite Schema](https://github.com/boshu2/agentops/blob/main/schemas/eval-suite.v1.schema.json) — JSON Schema for public canary and private holdout evaluation suites
+- [Eval Run Schema](https://github.com/boshu2/agentops/blob/main/schemas/eval-run.v1.schema.json) — JSON Schema for evaluation run records and scorecards
 - [Next-Work Queue Schema](contracts/next-work.schema.md) — Contract for `.agents/rpi/next-work.jsonl`
 - [RPI Phase Result Schema](contracts/rpi-phase-result.schema.json) — Machine-readable schema for RPI phase results
 - [RPI C2 Events Schema](contracts/rpi-c2-events.schema.json) — Machine-readable schema for per-run `.agents/rpi/runs/<run-id>/events.jsonl`

--- a/evals/agentops-core/core-surfaces.json
+++ b/evals/agentops-core/core-surfaces.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": 1,
+  "id": "agentops-core.core-surfaces",
+  "name": "AgentOps Core Surfaces Canary",
+  "description": "Offline public canary for CLI scenario authoring, hook isolation, skill contracts, and runtime inventory surfaces.",
+  "domain": "mixed",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "owners": ["agentops"],
+  "tags": ["canary", "offline", "cli", "hooks", "skills", "runtime"],
+  "allowed_runtimes": ["static", "shell"],
+  "environment": {
+    "offline_required": true,
+    "network": "forbidden",
+    "scrub_env_prefixes": ["AGENTOPS_RPI_RUNTIME", "ANTHROPIC_", "OPENAI_"],
+    "timeout_seconds": 20
+  },
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "correctness", "weight": 2, "threshold": 1, "critical": true},
+      {"name": "process_adherence", "weight": 1, "threshold": 1},
+      {"name": "artifact_quality", "weight": 1, "threshold": 1},
+      {"name": "runtime_compatibility", "weight": 1, "threshold": 1},
+      {"name": "safety", "weight": 1, "threshold": 1, "critical": true}
+    ]
+  },
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {
+      "id": "repo-root-surface-files",
+      "title": "core surface files resolve from repo root",
+      "kind": "command",
+      "objective": "Verify deterministic eval commands can inspect AgentOps core surfaces from the suite directory.",
+      "runtime": "shell",
+      "inputs": {
+        "cwd": "../..",
+        "shell": "test -f cli/cmd/ao/scenario_add.go && test -f hooks/hooks.json && test -f skills/scenario/SKILL.md && test -f skills-codex-overrides/catalog.json"
+      },
+      "expectations": [
+        {"type": "exit_code", "value": 0}
+      ],
+      "dimensions": ["correctness", "runtime_compatibility"],
+      "critical": true
+    },
+    {
+      "id": "scenario-add-command",
+      "title": "scenario add command is registered in source",
+      "kind": "artifact_check",
+      "objective": "Ensure public scenario authoring has a concrete CLI command.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../cli/cmd/ao/scenario_add.go", "value": "Use:   \"add <goal>\""},
+        {"type": "artifact_contains", "target": "../../cli/cmd/ao/scenario_add.go", "value": "scenarioCmd.AddCommand(scenarioAddCmd)"}
+      ],
+      "dimensions": ["correctness", "artifact_quality"],
+      "critical": true
+    },
+    {
+      "id": "scenario-add-docs",
+      "title": "scenario add appears in generated CLI docs",
+      "kind": "artifact_check",
+      "objective": "Keep CLI reference output aligned with the scenario authoring command.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../cli/docs/COMMANDS.md", "value": "#### `ao scenario add`"},
+        {"type": "artifact_contains", "target": "../../cli/docs/COMMANDS.md", "value": "ao scenario add <goal> [flags]"}
+      ],
+      "dimensions": ["process_adherence", "artifact_quality"]
+    },
+    {
+      "id": "holdout-isolation-hook",
+      "title": "holdout isolation hook remains registered",
+      "kind": "artifact_check",
+      "objective": "Protect private holdout scenarios while public canaries stay checked in.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../hooks/hooks.json", "value": "holdout-isolation-gate.sh"},
+        {"type": "artifact_contains", "target": "../../hooks/holdout-isolation-gate.sh", "value": "AGENTOPS_HOLDOUT_EVALUATOR"}
+      ],
+      "dimensions": ["safety", "process_adherence"],
+      "critical": true
+    },
+    {
+      "id": "scenario-skill-contract",
+      "title": "scenario skill documents add and validate workflow",
+      "kind": "artifact_check",
+      "objective": "Keep the scenario skill contract tied to the implemented CLI surface.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../skills/scenario/SKILL.md", "value": "ao scenario add"},
+        {"type": "artifact_contains", "target": "../../skills/scenario/SKILL.md", "value": "ao scenario validate"}
+      ],
+      "dimensions": ["process_adherence", "artifact_quality"]
+    },
+    {
+      "id": "codex-runtime-inventory",
+      "title": "codex runtime inventory catalog is present",
+      "kind": "artifact_check",
+      "objective": "Ensure deterministic canaries cover runtime inventory metadata without invoking live runtimes.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../skills-codex-overrides/catalog.json", "value": "Machine-readable Codex treatment map"},
+        {"type": "artifact_contains", "target": "../../skills-codex-overrides/catalog.json", "value": "\"name\": \"codex-team\""}
+      ],
+      "dimensions": ["runtime_compatibility", "artifact_quality"]
+    }
+  ]
+}

--- a/evals/agentops-core/fixtures/security-toolchain-governance-smoke.sh
+++ b/evals/agentops-core/fixtures/security-toolchain-governance-smoke.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 TMP_ROOT="$(mktemp -d)"
+HOST_BASH_DIR="$(dirname "$(command -v bash)")"
 
 cleanup() {
   rm -rf "$TMP_ROOT"
@@ -152,7 +153,7 @@ run_toolchain_case() {
 
   set +e
   env \
-    PATH="$repo/mockbin:/usr/bin:/bin" \
+    PATH="$repo/mockbin:$HOST_BASH_DIR:/usr/bin:/bin" \
     TOOLCHAIN_OUTPUT_DIR="$output_dir" \
     SECURITY_TOOLCHAIN_FIXTURE_SEMGREP="$semgrep_mode" \
     SECURITY_TOOLCHAIN_FIXTURE_RUFF="$ruff_mode" \
@@ -257,7 +258,7 @@ case "${1:-}" in
     repo="$(make_fixture_repo "quick-mode")"
     output_dir="$repo/out"
     stdout_json="$repo/stdout.json"
-    env PATH="$repo/mockbin:/usr/bin:/bin" TOOLCHAIN_OUTPUT_DIR="$output_dir" "$repo/scripts/toolchain-validate.sh" --quick --gate --json >"$stdout_json"
+    env PATH="$repo/mockbin:$HOST_BASH_DIR:/usr/bin:/bin" TOOLCHAIN_OUTPUT_DIR="$output_dir" "$repo/scripts/toolchain-validate.sh" --quick --gate --json >"$stdout_json"
     jq -e '.tools.gitleaks == "skipped" and .tools.pytest == "skipped" and .tools["go-test"] == "skipped"' "$stdout_json" >/dev/null
     grep -Fxq "SKIPPED_QUICK_MODE" "$output_dir/gitleaks.txt"
     grep -Fxq "SKIPPED_QUICK_MODE" "$output_dir/pytest.txt"

--- a/evals/agentops-core/rpi-behavior.json
+++ b/evals/agentops-core/rpi-behavior.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": 1,
+  "id": "agentops-core.rpi-behavior",
+  "name": "AgentOps RPI Behavior Canary",
+  "description": "Offline public canary for RPI phased runner contracts and deterministic runtime boundaries.",
+  "domain": "rpi",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "owners": ["agentops"],
+  "tags": ["canary", "offline", "rpi", "runtime"],
+  "allowed_runtimes": ["static", "shell"],
+  "environment": {
+    "offline_required": true,
+    "network": "forbidden",
+    "scrub_env_prefixes": ["AGENTOPS_RPI_RUNTIME", "ANTHROPIC_", "OPENAI_"],
+    "timeout_seconds": 20
+  },
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "correctness", "weight": 2, "threshold": 1, "critical": true},
+      {"name": "process_adherence", "weight": 1, "threshold": 1},
+      {"name": "runtime_compatibility", "weight": 1, "threshold": 1},
+      {"name": "safety", "weight": 1, "threshold": 1}
+    ]
+  },
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {
+      "id": "rpi-runtime-files",
+      "title": "RPI runtime source files are present",
+      "kind": "command",
+      "objective": "Verify the RPI behavior canary resolves repo-root source paths from the suite directory.",
+      "runtime": "shell",
+      "inputs": {
+        "cwd": "../..",
+        "shell": "test -f cli/cmd/ao/rpi_phased.go && test -f cli/cmd/ao/rpi_serve.go && test -f skills/rpi/SKILL.md"
+      },
+      "expectations": [
+        {"type": "exit_code", "value": 0}
+      ],
+      "dimensions": ["correctness", "runtime_compatibility"],
+      "critical": true
+    },
+    {
+      "id": "phased-runner-runtime-contract",
+      "title": "phased runner exposes bounded runtime modes",
+      "kind": "artifact_check",
+      "objective": "Ensure RPI phased execution keeps explicit runtime-mode and runtime-command contracts.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../cli/cmd/ao/rpi_phased.go", "value": "Run RPI with fresh runtime session per phase"},
+        {"type": "artifact_contains", "target": "../../cli/cmd/ao/rpi_phased.go", "value": "Phase runtime mode: auto|direct|stream|tmux"},
+        {"type": "artifact_contains", "target": "../../cli/cmd/ao/rpi_phased.go", "value": "Runtime command used for phase prompts"}
+      ],
+      "dimensions": ["correctness", "runtime_compatibility"],
+      "critical": true
+    },
+    {
+      "id": "serve-runtime-contract",
+      "title": "RPI serve preserves runtime orchestration flags",
+      "kind": "artifact_check",
+      "objective": "Cover the serve entrypoint used for RPI orchestration without invoking a live runtime.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../cli/cmd/ao/rpi_serve.go", "value": "Phase runtime mode for orchestration"},
+        {"type": "artifact_contains", "target": "../../cli/cmd/ao/rpi_serve.go", "value": "Runtime command for orchestration phase prompts"}
+      ],
+      "dimensions": ["process_adherence", "runtime_compatibility"]
+    },
+    {
+      "id": "eval-deterministic-boundary",
+      "title": "eval runner keeps live adapters advisory",
+      "kind": "artifact_check",
+      "objective": "Protect deterministic public canaries from live Claude or Codex execution.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../cli/cmd/ao/eval.go", "value": "Live Claude and Codex adapters are evaluated by a later runtime tier."},
+        {"type": "artifact_contains", "target": "../../cli/cmd/ao/eval.go", "value": "runtime %q is out of deterministic scope"}
+      ],
+      "dimensions": ["runtime_compatibility", "safety"],
+      "critical": true
+    },
+    {
+      "id": "rpi-skill-contract",
+      "title": "RPI skill contract remains available",
+      "kind": "artifact_check",
+      "objective": "Ensure RPI behavior canaries are anchored to the user-facing skill contract.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../skills/rpi/SKILL.md", "value": "RPI"},
+        {"type": "artifact_contains", "target": "../../skills/rpi/SKILL.md", "value": "validation"}
+      ],
+      "dimensions": ["process_adherence", "artifact_quality"]
+    }
+  ]
+}

--- a/evals/agentops-core/rpi-scorecard.json
+++ b/evals/agentops-core/rpi-scorecard.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": 1,
+  "id": "agentops-core.rpi-scorecard",
+  "name": "AgentOps RPI Scorecard Canary",
+  "description": "Offline public canary for the required RPI scorecard categories.",
+  "domain": "rpi",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "owners": ["agentops"],
+  "tags": ["canary", "offline", "rpi", "scorecard"],
+  "allowed_runtimes": ["static"],
+  "environment": {
+    "offline_required": true,
+    "network": "forbidden",
+    "scrub_env_prefixes": ["AGENTOPS_RPI_RUNTIME", "ANTHROPIC_", "OPENAI_"],
+    "timeout_seconds": 20
+  },
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "artifact_quality", "weight": 1, "threshold": 1, "critical": true},
+      {"name": "process_adherence", "weight": 1, "threshold": 1, "critical": true},
+      {"name": "correctness", "weight": 1, "threshold": 1},
+      {"name": "safety", "weight": 1, "threshold": 1, "critical": true}
+    ]
+  },
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {
+      "id": "scorecard.artifact-completeness.surface",
+      "title": "RPI scorecard covers artifact completeness",
+      "kind": "artifact_check",
+      "objective": "Ensure scorecards verify required RPI artifacts exist and validate.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../cli/internal/eval/scorecard.go", "value": "artifact-completeness"}
+      ],
+      "dimensions": ["artifact_quality"],
+      "critical": true
+    },
+    {
+      "id": "scorecard.phase-order.surface",
+      "title": "RPI scorecard covers phase order",
+      "kind": "artifact_check",
+      "objective": "Ensure scorecards verify discovery, crank, and validation ordering.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../cli/internal/eval/scorecard.go", "value": "phase-order"}
+      ],
+      "dimensions": ["process_adherence"],
+      "critical": true
+    },
+    {
+      "id": "scorecard.objective-spine.surface",
+      "title": "RPI scorecard covers objective spine",
+      "kind": "artifact_check",
+      "objective": "Ensure scorecards verify one objective is preserved across RPI phases.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../cli/internal/eval/scorecard.go", "value": "objective-spine"}
+      ],
+      "dimensions": ["process_adherence"],
+      "critical": true
+    },
+    {
+      "id": "scorecard.validation-separation.surface",
+      "title": "RPI scorecard covers validation separation",
+      "kind": "artifact_check",
+      "objective": "Ensure scorecards verify implementation and validation evidence stay distinct.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../cli/internal/eval/scorecard.go", "value": "validation-separation"}
+      ],
+      "dimensions": ["process_adherence"],
+      "critical": true
+    },
+    {
+      "id": "scorecard.scenario-satisfaction.surface",
+      "title": "RPI scorecard covers scenario satisfaction",
+      "kind": "artifact_check",
+      "objective": "Ensure scorecards verify scenario satisfaction evidence.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../cli/internal/eval/scorecard.go", "value": "scenario-satisfaction"}
+      ],
+      "dimensions": ["correctness"],
+      "critical": true
+    },
+    {
+      "id": "scorecard.runtime-safety.surface",
+      "title": "RPI scorecard covers runtime safety",
+      "kind": "artifact_check",
+      "objective": "Ensure scorecards verify runtime safety and isolation evidence.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../cli/internal/eval/scorecard.go", "value": "runtime-safety"}
+      ],
+      "dimensions": ["safety"],
+      "critical": true
+    }
+  ]
+}

--- a/evals/agentops-core/skill-change-scorecard.json
+++ b/evals/agentops-core/skill-change-scorecard.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": 1,
+  "id": "agentops-core.skill-change-scorecard",
+  "name": "AgentOps Skill Change Scorecard Canary",
+  "description": "Offline public canary for required skill-change scorecard categories.",
+  "domain": "skill",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "owners": ["agentops"],
+  "tags": ["canary", "offline", "skills", "scorecard"],
+  "allowed_runtimes": ["static"],
+  "environment": {
+    "offline_required": true,
+    "network": "forbidden",
+    "scrub_env_prefixes": ["AGENTOPS_RPI_RUNTIME", "ANTHROPIC_", "OPENAI_"],
+    "timeout_seconds": 20
+  },
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "artifact_quality", "weight": 1, "threshold": 1, "critical": true},
+      {"name": "process_adherence", "weight": 1, "threshold": 1},
+      {"name": "runtime_compatibility", "weight": 1, "threshold": 1, "critical": true},
+      {"name": "correctness", "weight": 1, "threshold": 1},
+      {"name": "learning_closure", "weight": 1, "threshold": 1}
+    ]
+  },
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {
+      "id": "scorecard.structural.surface",
+      "title": "Skill scorecard covers structural deltas",
+      "kind": "artifact_check",
+      "objective": "Ensure scorecards report structural skill contract deltas.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../cli/internal/eval/scorecard.go", "value": "structural"}
+      ],
+      "dimensions": ["artifact_quality"],
+      "critical": true
+    },
+    {
+      "id": "scorecard.trigger.surface",
+      "title": "Skill scorecard covers trigger deltas",
+      "kind": "artifact_check",
+      "objective": "Ensure scorecards report trigger and activation deltas.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../cli/internal/eval/scorecard.go", "value": "trigger"}
+      ],
+      "dimensions": ["process_adherence"]
+    },
+    {
+      "id": "scorecard.runtime.surface",
+      "title": "Skill scorecard covers runtime deltas",
+      "kind": "artifact_check",
+      "objective": "Ensure scorecards report cross-runtime compatibility deltas.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../cli/internal/eval/scorecard.go", "value": "runtime"}
+      ],
+      "dimensions": ["runtime_compatibility"],
+      "critical": true
+    },
+    {
+      "id": "scorecard.scenario.surface",
+      "title": "Skill scorecard covers scenario deltas",
+      "kind": "artifact_check",
+      "objective": "Ensure scorecards report scenario coverage and satisfaction deltas.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../cli/internal/eval/scorecard.go", "value": "scenario"}
+      ],
+      "dimensions": ["correctness"]
+    },
+    {
+      "id": "scorecard.stocktake.surface",
+      "title": "Skill scorecard covers stocktake deltas",
+      "kind": "artifact_check",
+      "objective": "Ensure scorecards report stocktake and learning closure deltas.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../cli/internal/eval/scorecard.go", "value": "stocktake"}
+      ],
+      "dimensions": ["learning_closure"]
+    }
+  ]
+}

--- a/schemas/eval-run.v1.schema.json
+++ b/schemas/eval-run.v1.schema.json
@@ -1,0 +1,546 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentops.dev/schemas/eval-run.v1.schema.json",
+  "title": "AgentOps Eval Run v1",
+  "description": "Run record and scorecard schema for AgentOps evaluation suites.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "suite",
+    "started_at",
+    "status",
+    "verdict",
+    "git",
+    "runtime",
+    "environment",
+    "case_results",
+    "aggregate_score",
+    "dimension_scores"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "run_id": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._:-]*$"
+    },
+    "suite": {
+      "$ref": "#/$defs/suite_ref"
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "completed_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "status": {
+      "$ref": "#/$defs/status"
+    },
+    "verdict": {
+      "$ref": "#/$defs/verdict"
+    },
+    "git": {
+      "$ref": "#/$defs/git"
+    },
+    "runtime": {
+      "$ref": "#/$defs/runtime_record"
+    },
+    "environment": {
+      "$ref": "#/$defs/environment_record"
+    },
+    "baseline": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "required": [
+        "mode"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "none",
+            "compare",
+            "promote"
+          ]
+        },
+        "baseline_run_id": {
+          "type": "string"
+        },
+        "baseline_ref": {
+          "type": "string"
+        },
+        "baseline_path": {
+          "type": "string"
+        },
+        "promoted_from_run_id": {
+          "type": "string"
+        },
+        "promoted_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "promoted_by": {
+          "type": "string"
+        },
+        "rationale": {
+          "type": "string"
+        }
+      }
+    },
+    "case_results": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/case_result"
+      }
+    },
+    "aggregate_score": {
+      "$ref": "#/$defs/score"
+    },
+    "dimension_scores": {
+      "$ref": "#/$defs/dimension_scores"
+    },
+    "baseline_comparison": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "required": [
+        "verdict"
+      ],
+      "properties": {
+        "verdict": {
+          "$ref": "#/$defs/verdict"
+        },
+        "baseline_run_id": {
+          "type": "string"
+        },
+        "baseline_score": {
+          "$ref": "#/$defs/score"
+        },
+        "aggregate_delta": {
+          "type": "number",
+          "minimum": -1,
+          "maximum": 1
+        },
+        "dimension_deltas": {
+          "$ref": "#/$defs/dimension_deltas"
+        },
+        "regressions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/comparison_item"
+          }
+        },
+        "improvements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/comparison_item"
+          }
+        }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/artifact"
+      }
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "$defs": {
+    "score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail",
+        "error",
+        "skipped",
+        "inconclusive"
+      ]
+    },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail",
+        "improvement",
+        "regression",
+        "advisory",
+        "inconclusive"
+      ]
+    },
+    "runtime": {
+      "type": "string",
+      "enum": [
+        "static",
+        "mock",
+        "shell",
+        "claude",
+        "codex",
+        "manual"
+      ]
+    },
+    "tier": {
+      "type": "string",
+      "enum": [
+        "deterministic",
+        "headless",
+        "live",
+        "release"
+      ]
+    },
+    "visibility": {
+      "type": "string",
+      "enum": [
+        "public_canary",
+        "private_holdout"
+      ]
+    },
+    "suite_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "path",
+        "visibility",
+        "tier"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "visibility": {
+          "$ref": "#/$defs/visibility"
+        },
+        "tier": {
+          "$ref": "#/$defs/tier"
+        },
+        "version": {
+          "type": "string"
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{64}$"
+        }
+      }
+    },
+    "git": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_ref",
+        "candidate_sha",
+        "dirty"
+      ],
+      "properties": {
+        "candidate_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "candidate_sha": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{7,40}$"
+        },
+        "baseline_ref": {
+          "type": "string"
+        },
+        "baseline_sha": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{7,40}$"
+        },
+        "dirty": {
+          "type": "boolean"
+        },
+        "dirty_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "runtime_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "live"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/runtime"
+        },
+        "version": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "profile": {
+          "type": "string"
+        },
+        "live": {
+          "type": "boolean"
+        },
+        "attempts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "timeout_seconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "skipped_reason": {
+          "type": "string"
+        }
+      }
+    },
+    "environment_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scrubbed_env_prefixes",
+        "isolated_home",
+        "isolated_codex_home",
+        "network_access"
+      ],
+      "properties": {
+        "scrubbed_env_prefixes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "isolated_home": {
+          "type": "boolean"
+        },
+        "isolated_codex_home": {
+          "type": "boolean"
+        },
+        "network_access": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "enabled",
+            "unknown"
+          ]
+        },
+        "hooks_disabled": {
+          "type": "boolean"
+        },
+        "host_notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "case_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "status",
+        "score",
+        "dimension_scores"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "$ref": "#/$defs/status"
+        },
+        "score": {
+          "$ref": "#/$defs/score"
+        },
+        "dimension_scores": {
+          "$ref": "#/$defs/dimension_scores"
+        },
+        "duration_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "critical": {
+          "type": "boolean"
+        },
+        "artifacts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/artifact"
+          }
+        },
+        "failure_message": {
+          "type": "string"
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "dimension_scores": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "correctness": {
+          "$ref": "#/$defs/score"
+        },
+        "process_adherence": {
+          "$ref": "#/$defs/score"
+        },
+        "artifact_quality": {
+          "$ref": "#/$defs/score"
+        },
+        "runtime_compatibility": {
+          "$ref": "#/$defs/score"
+        },
+        "efficiency": {
+          "$ref": "#/$defs/score"
+        },
+        "safety": {
+          "$ref": "#/$defs/score"
+        },
+        "learning_closure": {
+          "$ref": "#/$defs/score"
+        }
+      },
+      "minProperties": 1
+    },
+    "dimension_deltas": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "correctness": {
+          "$ref": "#/$defs/delta"
+        },
+        "process_adherence": {
+          "$ref": "#/$defs/delta"
+        },
+        "artifact_quality": {
+          "$ref": "#/$defs/delta"
+        },
+        "runtime_compatibility": {
+          "$ref": "#/$defs/delta"
+        },
+        "efficiency": {
+          "$ref": "#/$defs/delta"
+        },
+        "safety": {
+          "$ref": "#/$defs/delta"
+        },
+        "learning_closure": {
+          "$ref": "#/$defs/delta"
+        }
+      }
+    },
+    "delta": {
+      "type": "number",
+      "minimum": -1,
+      "maximum": 1
+    },
+    "comparison_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "dimension",
+        "delta",
+        "reason"
+      ],
+      "properties": {
+        "case_id": {
+          "type": "string"
+        },
+        "dimension": {
+          "type": "string",
+          "enum": [
+            "correctness",
+            "process_adherence",
+            "artifact_quality",
+            "runtime_compatibility",
+            "efficiency",
+            "safety",
+            "learning_closure"
+          ]
+        },
+        "delta": {
+          "$ref": "#/$defs/delta"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "purpose"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "purpose": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "run_json",
+            "scorecard",
+            "transcript",
+            "stdout",
+            "stderr",
+            "diagnostic",
+            "fixture",
+            "baseline"
+          ]
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{64}$"
+        }
+      }
+    }
+  }
+}

--- a/schemas/eval-suite.v1.schema.json
+++ b/schemas/eval-suite.v1.schema.json
@@ -1,0 +1,428 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentops.dev/schemas/eval-suite.v1.schema.json",
+  "title": "AgentOps Eval Suite v1",
+  "description": "Manifest schema for AgentOps public canary and private holdout evaluation suites.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "name",
+    "domain",
+    "visibility",
+    "tier",
+    "scoring",
+    "baseline_policy",
+    "cases"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*$"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string"
+    },
+    "domain": {
+      "$ref": "#/$defs/domain"
+    },
+    "visibility": {
+      "type": "string",
+      "enum": [
+        "public_canary",
+        "private_holdout"
+      ]
+    },
+    "tier": {
+      "$ref": "#/$defs/tier"
+    },
+    "owners": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "allowed_runtimes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/runtime"
+      },
+      "uniqueItems": true
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "offline_required": {
+          "type": "boolean"
+        },
+        "network": {
+          "type": "string",
+          "enum": [
+            "forbidden",
+            "allowed",
+            "required"
+          ]
+        },
+        "scrub_env_prefixes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "isolate_home": {
+          "type": "boolean"
+        },
+        "isolate_codex_home": {
+          "type": "boolean"
+        },
+        "timeout_seconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_attempts": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "fixtures": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/fixture"
+      }
+    },
+    "scoring": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "dimensions",
+        "aggregate_threshold"
+      ],
+      "properties": {
+        "aggregate_threshold": {
+          "$ref": "#/$defs/score"
+        },
+        "critical_threshold": {
+          "$ref": "#/$defs/score"
+        },
+        "dimensions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/scoring_dimension"
+          }
+        }
+      }
+    },
+    "baseline_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "none",
+            "compare",
+            "promotable"
+          ]
+        },
+        "baseline_ref": {
+          "type": "string"
+        },
+        "baseline_path": {
+          "type": "string"
+        },
+        "max_aggregate_regression": {
+          "$ref": "#/$defs/non_negative_score"
+        },
+        "max_dimension_regression": {
+          "$ref": "#/$defs/non_negative_score"
+        },
+        "repeat_count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "promotion_requires": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "critical_canaries_pass",
+              "no_safety_regression",
+              "no_runtime_compatibility_regression",
+              "private_holdouts_reviewed",
+              "durable_artifacts",
+              "human_rationale"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "blocking_gate": {
+          "type": "string",
+          "enum": [
+            "none",
+            "pre-push",
+            "ci",
+            "nightly",
+            "release",
+            "model-upgrade"
+          ]
+        }
+      }
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/case"
+      }
+    }
+  },
+  "$defs": {
+    "score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "non_negative_score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "domain": {
+      "type": "string",
+      "enum": [
+        "skill",
+        "hook",
+        "cli",
+        "rpi",
+        "runtime",
+        "retrieval",
+        "scenario",
+        "mixed"
+      ]
+    },
+    "tier": {
+      "type": "string",
+      "enum": [
+        "deterministic",
+        "headless",
+        "live",
+        "release"
+      ]
+    },
+    "runtime": {
+      "type": "string",
+      "enum": [
+        "static",
+        "mock",
+        "shell",
+        "claude",
+        "codex",
+        "manual"
+      ]
+    },
+    "dimension": {
+      "type": "string",
+      "enum": [
+        "correctness",
+        "process_adherence",
+        "artifact_quality",
+        "runtime_compatibility",
+        "efficiency",
+        "safety",
+        "learning_closure"
+      ]
+    },
+    "scoring_dimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "weight",
+        "threshold"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/dimension"
+        },
+        "weight": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "threshold": {
+          "$ref": "#/$defs/score"
+        },
+        "critical": {
+          "type": "boolean"
+        }
+      }
+    },
+    "fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "purpose"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "purpose": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{64}$"
+        }
+      }
+    },
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "title",
+        "kind",
+        "objective",
+        "expectations"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._-]*$"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "command",
+            "hook_event",
+            "skill_contract",
+            "rpi_flow",
+            "retrieval_query",
+            "scenario",
+            "runtime_prompt",
+            "artifact_check"
+          ]
+        },
+        "objective": {
+          "type": "string",
+          "minLength": 1
+        },
+        "runtime": {
+          "$ref": "#/$defs/runtime"
+        },
+        "timeout_seconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "fixtures": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "inputs": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "expectations": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/expectation"
+          }
+        },
+        "dimensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/dimension"
+          },
+          "uniqueItems": true
+        },
+        "critical": {
+          "type": "boolean"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "expectation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "exit_code",
+            "stdout_contains",
+            "stderr_contains",
+            "json_path",
+            "file_exists",
+            "file_absent",
+            "schema_valid",
+            "artifact_contains",
+            "score_at_least",
+            "manual_review"
+          ]
+        },
+        "target": {
+          "type": "string"
+        },
+        "value": {},
+        "threshold": {
+          "$ref": "#/$defs/score"
+        },
+        "required": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/scripts/eval-agentops.sh
+++ b/scripts/eval-agentops.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+FAST=false
+PROMOTE=false
+PROMOTED_BY="${USER:-agentops}"
+RATIONALE=""
+BASELINE_DIR=".agents/evals/baselines"
+RUN_ROOT=".agents/evals/runs"
+ADVISORY=false
+SUITES=()
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/eval-agentops.sh [options]
+
+Run AgentOps public evaluation canaries and compare them with promoted baselines
+when baselines exist.
+
+Options:
+  --fast                    Run the repo public canary set under evals/agentops-core
+  --suite PATH              Add one suite path to run; repeatable
+  --baseline-dir PATH       Baseline directory (default: .agents/evals/baselines)
+  --run-root PATH           Run artifact root (default: .agents/evals/runs)
+  --promote-baseline        Promote successful run records as baselines
+  --promoted-by NAME        Identity recorded during baseline promotion
+  --rationale TEXT          Required rationale when promoting baselines
+  --advisory                Report failures but exit 0
+  -h, --help                Show this help
+USAGE
+}
+
+die() {
+    echo "FAIL eval-agentops: $*" >&2
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --fast)
+            FAST=true
+            shift
+            ;;
+        --suite)
+            [[ -n "${2:-}" ]] || die "--suite requires a path"
+            SUITES+=("$2")
+            shift 2
+            ;;
+        --baseline-dir)
+            [[ -n "${2:-}" ]] || die "--baseline-dir requires a path"
+            BASELINE_DIR="$2"
+            shift 2
+            ;;
+        --run-root)
+            [[ -n "${2:-}" ]] || die "--run-root requires a path"
+            RUN_ROOT="$2"
+            shift 2
+            ;;
+        --promote-baseline)
+            PROMOTE=true
+            shift
+            ;;
+        --promoted-by)
+            [[ -n "${2:-}" ]] || die "--promoted-by requires a value"
+            PROMOTED_BY="$2"
+            shift 2
+            ;;
+        --rationale)
+            [[ -n "${2:-}" ]] || die "--rationale requires text"
+            RATIONALE="$2"
+            shift 2
+            ;;
+        --advisory)
+            ADVISORY=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown option: $1"
+            ;;
+    esac
+done
+
+if [[ "$PROMOTE" == "true" && -z "$RATIONALE" ]]; then
+    die "--promote-baseline requires --rationale"
+fi
+
+if [[ "${#SUITES[@]}" -eq 0 ]]; then
+    if [[ "$FAST" == "true" ]]; then
+        while IFS= read -r path; do
+            SUITES+=("$path")
+        done < <(find evals/agentops-core -maxdepth 1 -type f -name '*.json' | sort)
+    else
+        while IFS= read -r path; do
+            SUITES+=("$path")
+        done < <(find evals -type f -name '*.json' | sort)
+    fi
+fi
+
+if [[ "${#SUITES[@]}" -eq 0 ]]; then
+    die "no eval suites found"
+fi
+
+json_get() {
+    local path="$1"
+    local key="$2"
+    python3 - "$path" "$key" <<'PY'
+import json
+import sys
+
+path, key = sys.argv[1], sys.argv[2]
+with open(path, encoding="utf-8") as fh:
+    data = json.load(fh)
+value = data
+for part in key.split("."):
+    value = value[part]
+if isinstance(value, bool):
+    print("true" if value else "false")
+else:
+    print(value)
+PY
+}
+
+scorecard_kind_for_suite() {
+    local suite_id="$1"
+    case "$suite_id" in
+        *rpi-scorecard*) printf 'rpi\n' ;;
+        *skill-change-scorecard*) printf 'skill-change\n' ;;
+        *) printf '\n' ;;
+    esac
+}
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agentops-eval.XXXXXX")"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+AO_BIN="${AO_BIN:-}"
+if [[ -z "$AO_BIN" ]]; then
+    AO_BIN="$tmp_dir/ao"
+    (cd cli && env -u AGENTOPS_RPI_RUNTIME go build -o "$AO_BIN" ./cmd/ao)
+fi
+
+run_id="$(date -u +%Y%m%dT%H%M%SZ)"
+run_dir="$RUN_ROOT/$run_id"
+mkdir -p "$run_dir" "$BASELINE_DIR"
+
+failures=0
+warnings=0
+
+record_failure() {
+    echo "FAIL eval-agentops: $*" >&2
+    failures=$((failures + 1))
+}
+
+record_warning() {
+    echo "WARN eval-agentops: $*" >&2
+    warnings=$((warnings + 1))
+}
+
+echo "AgentOps eval run: $run_id"
+echo "Suites: ${#SUITES[@]}"
+echo "Artifacts: $run_dir"
+
+for suite in "${SUITES[@]}"; do
+    if [[ ! -f "$suite" ]]; then
+        record_failure "suite not found: $suite"
+        continue
+    fi
+
+    suite_id="$(json_get "$suite" "id")"
+    run_path="$run_dir/${suite_id}.run.json"
+    run_stdout="$run_dir/${suite_id}.run.stdout.json"
+    baseline_path="$BASELINE_DIR/${suite_id}.baseline.json"
+    compare_path="$run_dir/${suite_id}.compare.json"
+
+    echo ""
+    echo "== $suite_id =="
+    if ! "$AO_BIN" eval run "$suite" --run-id "${suite_id}-${run_id}" --out "$run_path" --json >"$run_stdout"; then
+        record_failure "$suite_id run command failed"
+        continue
+    fi
+
+    status="$(json_get "$run_path" "status")"
+    verdict="$(json_get "$run_path" "verdict")"
+    aggregate="$(json_get "$run_path" "aggregate_score")"
+    echo "run: status=$status verdict=$verdict aggregate=$aggregate"
+    if [[ "$status" != "pass" || "$verdict" == "fail" || "$verdict" == "regression" ]]; then
+        record_failure "$suite_id run did not pass"
+    fi
+
+    kind="$(scorecard_kind_for_suite "$suite_id")"
+    if [[ -n "$kind" ]]; then
+        scorecard_path="$run_dir/${suite_id}.scorecard.json"
+        scorecard_stdout="$run_dir/${suite_id}.scorecard.stdout.json"
+        scorecard_args=(eval scorecard "$run_path" --kind "$kind" --out "$scorecard_path" --json)
+        if [[ -f "$baseline_path" ]]; then
+            scorecard_args=(eval scorecard "$run_path" "$baseline_path" --kind "$kind" --out "$scorecard_path" --json)
+        fi
+        if ! "$AO_BIN" "${scorecard_args[@]}" >"$scorecard_stdout"; then
+            record_failure "$suite_id scorecard command failed"
+        else
+            scorecard_verdict="$(json_get "$scorecard_path" "verdict")"
+            echo "scorecard: kind=$kind verdict=$scorecard_verdict"
+            if [[ "$scorecard_verdict" == "fail" || "$scorecard_verdict" == "regression" ]]; then
+                record_failure "$suite_id scorecard verdict is $scorecard_verdict"
+            fi
+        fi
+    fi
+
+    if [[ -f "$baseline_path" ]]; then
+        compare_stdout="$run_dir/${suite_id}.compare.stdout.json"
+        if ! "$AO_BIN" eval compare "$run_path" "$baseline_path" --out "$compare_path" --json >"$compare_stdout"; then
+            record_failure "$suite_id baseline compare command failed"
+        else
+            compare_verdict="$(json_get "$compare_path" "verdict")"
+            delta="$(json_get "$compare_path" "baseline_comparison.aggregate_delta")"
+            echo "baseline: verdict=$compare_verdict aggregate_delta=$delta"
+            if [[ "$compare_verdict" == "fail" || "$compare_verdict" == "regression" ]]; then
+                record_failure "$suite_id regressed against baseline"
+            fi
+        fi
+    else
+        record_warning "$suite_id has no promoted baseline at $baseline_path"
+    fi
+
+    if [[ "$PROMOTE" == "true" ]]; then
+        promote_stdout="$run_dir/${suite_id}.baseline.stdout.json"
+        if ! "$AO_BIN" eval baseline "$run_path" --out "$baseline_path" --promoted-by "$PROMOTED_BY" --rationale "$RATIONALE" --json >"$promote_stdout"; then
+            record_failure "$suite_id baseline promotion failed"
+        else
+            echo "promoted baseline: $baseline_path"
+        fi
+    fi
+done
+
+echo ""
+echo "AgentOps eval summary: failures=$failures warnings=$warnings artifacts=$run_dir"
+if [[ "$failures" -gt 0 && "$ADVISORY" != "true" ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/eval-agentops.sh
+++ b/scripts/eval-agentops.sh
@@ -127,6 +127,30 @@ else:
 PY
 }
 
+json_get_default() {
+    local path="$1"
+    local key="$2"
+    local default="$3"
+    python3 - "$path" "$key" "$default" <<'PY'
+import json
+import sys
+
+path, key, default = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, encoding="utf-8") as fh:
+    data = json.load(fh)
+value = data
+for part in key.split("."):
+    if not isinstance(value, dict) or part not in value:
+        print(default)
+        raise SystemExit(0)
+    value = value[part]
+if isinstance(value, bool):
+    print("true" if value else "false")
+else:
+    print(value)
+PY
+}
+
 scorecard_kind_for_suite() {
     local suite_id="$1"
     case "$suite_id" in
@@ -218,7 +242,7 @@ for suite in "${SUITES[@]}"; do
             record_failure "$suite_id baseline compare command failed"
         else
             compare_verdict="$(json_get "$compare_path" "verdict")"
-            delta="$(json_get "$compare_path" "baseline_comparison.aggregate_delta")"
+            delta="$(json_get_default "$compare_path" "baseline_comparison.aggregate_delta" "0")"
             echo "baseline: verdict=$compare_verdict aggregate_delta=$delta"
             if [[ "$compare_verdict" == "fail" || "$compare_verdict" == "regression" ]]; then
                 record_failure "$suite_id regressed against baseline"

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -34,6 +34,7 @@
 #  23. Skill CLI snippets
 #  24. Headless runtime skill smoke (full mode only)
 #  24b. CLI docs parity
+#  24c. AgentOps eval canaries (fast deterministic suites)
 #  --- shifted from CI-only (v2.32) ---
 #  25. Doc-release stabilization gate
 #  25b. Release audit artifact refs
@@ -182,6 +183,7 @@ HAS_HOOK=1
 HAS_DOCS=1
 HAS_SHELL=1
 HAS_LEARNING=1
+HAS_EVAL=1
 
 if [[ "$FAST_MODE" == "true" ]]; then
     all_changed="$(collect_all_changed)"
@@ -215,6 +217,11 @@ if [[ "$FAST_MODE" == "true" ]]; then
     else
         HAS_LEARNING=0
     fi
+    if echo "$all_changed" | grep -qE '^evals/|^schemas/eval-|^scripts/eval-agentops\.sh$|^cli/internal/eval/|^cli/cmd/ao/eval'; then
+        HAS_EVAL=1
+    else
+        HAS_EVAL=0
+    fi
 fi
 
 needs_check() {
@@ -229,6 +236,7 @@ needs_check() {
         docs)     [[ "$HAS_DOCS" -eq 1 ]] ;;
         shell)    [[ "$HAS_SHELL" -eq 1 ]] ;;
         learning) [[ "$HAS_LEARNING" -eq 1 ]] ;;
+        eval)     [[ "$HAS_EVAL" -eq 1 ]] ;;
         always)   return 0 ;;
         *)        return 0 ;;
     esac
@@ -710,6 +718,27 @@ if needs_check go || [[ "$HAS_CMD_AO" -eq 1 ]]; then
     fi
 else
     skip "CLI docs parity"
+fi
+
+# --- 24c. AgentOps eval canaries ---
+if needs_check eval || needs_check go; then
+    if [[ -x scripts/eval-agentops.sh ]]; then
+        if eval_agentops_output="$(run_without_git_env scripts/eval-agentops.sh --fast 2>&1)"; then
+            if grep -q '^WARN eval-agentops:' <<<"$eval_agentops_output"; then
+                warn "AgentOps eval canaries"
+                indent_output "$eval_agentops_output"
+            else
+                pass "AgentOps eval canaries"
+            fi
+        else
+            fail "AgentOps eval canaries"
+            indent_output "$eval_agentops_output"
+        fi
+    else
+        fail "missing executable: scripts/eval-agentops.sh"
+    fi
+else
+    skip "AgentOps eval canaries"
 fi
 
 # --- 25. Doc-release stabilization gate ---

--- a/tests/scripts/pre-push-gate.bats
+++ b/tests/scripts/pre-push-gate.bats
@@ -63,6 +63,7 @@ setup() {
     make_stub "$FAKE_REPO/scripts/validate-hooks-doc-parity.sh"
     make_stub "$FAKE_REPO/scripts/validate-ci-policy-parity.sh"
     make_stub "$FAKE_REPO/scripts/validate-embedded-sync.sh"
+    make_stub "$FAKE_REPO/scripts/eval-agentops.sh"
     make_stub "$FAKE_REPO/tests/hooks/test-orphan-hooks.sh"
     # Check 3b (HOME isolation) and 3c (agents hash snapshot) run unconditionally
     # in non-fast mode. Both must exist as executables so the gate does not fail


### PR DESCRIPTION
## Summary

PR-1 of 3 in the eval-environment landing series (epic ag-3lx). Cherry-picks the 7 foundation commits from `origin/codex/eval-env-discovery` onto a fresh branch off main:

1. `cb1fc5d9` docs: discovery packet
2. `6feac15c` docs: eval environment contract + schemas
3. `2a2faf8c` feat: deterministic ao eval core (cli/internal/eval/)
4. `459ded47` feat: seed canaries + runtime adapters
5. `968f7b7e` feat: eval scorecards
6. `17d6f55e` ci: wire agentops eval canaries (validate.yml + pre-push-gate)
7. `f3af16da` feat: eval coverage report

Plus follow-up commit `aa0664f4` to regenerate `docs/cli-skills-map.md` and `docs/contracts/agents-write-surfaces.md` after the new `ao eval` family was added.

## Hand-merges resolved

- `.github/workflows/validate.yml` summary.needs: kept main's `standards-injector-completeness` AND added branch's `agentops-eval-advisory`
- `docs/cli-skills-map.md`: kept main's audit date label (count regenerated downstream to 57)
- `evals/agentops-core/cli-contracts.json`: dropped (originally added in `a34f6165`, which belongs in PR-3)
- `.agents/rpi/execution-packet.json` + `.agents/rpi/ranked-packet.json`: kept main (state-files)

## What's new

- New schemas: `schemas/eval-suite.v1.schema.json`, `schemas/eval-run.v1.schema.json`
- New contract doc: `docs/contracts/eval-environment.md`
- New CLI surface: `ao eval` with subcommands (run, scorecard, coverage, etc.)
- New CI job: `agentops-eval-advisory` (continue-on-error: true; advisory only)
- New script: `scripts/eval-agentops.sh --fast`
- 4 seed eval suites under `evals/agentops-core/`

## Known issues

- The eval suite `evals/agentops-core/security-toolchain-governance.json` (added in main via ag-5p8 prereq) uses `"domain": "security"` but the schema enum is `{skill,hook,cli,rpi,runtime,retrieval,scenario,mixed}`. Resolution: this PR adds neither the schema nor the suite together — schema is here, suite is on main from prereq. PR-2 or a follow-up should reconcile (add "security" to the enum).
- `agentops-eval-advisory` job is non-blocking (`continue-on-error: true`) so any seed-canary failures will not red-bomb CI.

## Test plan

- [x] `cd cli && go build ./... && go vet ./... && go test ./...` PASS locally
- [x] Pre-push gate (fast) PASS except unrelated worktree-disposition (other parallel sessions)
- [ ] CI green on this PR
- [ ] Reviewer approval

## Stack

- **PR-1: this PR** (foundation)
- PR-2: CLI integration (6 commits) — depends on this PR
- PR-3: canaries + closeout (76 commits) — depends on PR-1, PR-2, and ag-l0w/5p8/aez prereqs (already merged on main)

Closes ag-664.