### PR TITLE
PR-2: Eval CLI integration (5 commits) — coverage reports + governance canary stabilization

### DIFF
--- a/cli/cmd/ao/cobra_commands_test.go
+++ b/cli/cmd/ao/cobra_commands_test.go
@@ -272,6 +272,7 @@ func executeCommand(args ...string) (string, error) {
 	evalCoverageRoot = "evals/agentops-core"
 	evalCoverageDomains = []string{"cli", "hook", "skill", "rpi", "runtime", "retrieval", "scenario", "mixed"}
 	evalCoverageDims = []string{"correctness", "process_adherence", "artifact_quality", "runtime_compatibility", "efficiency", "safety", "learning_closure"}
+	evalCoverageRuntimes = []string{"static", "shell", "mock"}
 	overnightGoal = ""
 	overnightOutputDir = ""
 	overnightRunTimeout = ""

--- a/cli/cmd/ao/cobra_commands_test.go
+++ b/cli/cmd/ao/cobra_commands_test.go
@@ -270,7 +270,8 @@ func executeCommand(args ...string) (string, error) {
 	evalBaselineBy = ""
 	evalBaselineReason = ""
 	evalCoverageRoot = "evals/agentops-core"
-	evalCoverageRequire = []string{"cli", "hook", "skill", "rpi", "runtime", "retrieval", "scenario", "mixed"}
+	evalCoverageDomains = []string{"cli", "hook", "skill", "rpi", "runtime", "retrieval", "scenario", "mixed"}
+	evalCoverageDims = []string{"correctness", "process_adherence", "artifact_quality", "runtime_compatibility", "efficiency", "safety", "learning_closure"}
 	overnightGoal = ""
 	overnightOutputDir = ""
 	overnightRunTimeout = ""

--- a/cli/cmd/ao/eval.go
+++ b/cli/cmd/ao/eval.go
@@ -26,7 +26,8 @@ var (
 	evalBaselineBy      string
 	evalBaselineReason  string
 	evalCoverageRoot    string
-	evalCoverageRequire []string
+	evalCoverageDomains []string
+	evalCoverageDims    []string
 	evalConfigured      bool
 )
 
@@ -192,9 +193,10 @@ var evalCoverageCmd = &cobra.Command{
 			roots = append(roots, evalCoverageRoot)
 		}
 		report, err := aoeval.BuildCoverageReport(aoeval.CoverageOptions{
-			SuitePaths:      args,
-			Roots:           roots,
-			RequiredDomains: evalCoverageRequire,
+			SuitePaths:         args,
+			Roots:              roots,
+			RequiredDomains:    evalCoverageDomains,
+			RequiredDimensions: evalCoverageDims,
 		})
 		if err != nil {
 			return err
@@ -207,6 +209,11 @@ var evalCoverageCmd = &cobra.Command{
 			fmt.Fprintf(cmd.OutOrStdout(), "Missing required domains: %s\n", strings.Join(report.MissingRequiredDomains, ", "))
 		} else if len(report.RequiredDomains) > 0 {
 			fmt.Fprintln(cmd.OutOrStdout(), "Required domains covered")
+		}
+		if len(report.MissingRequiredDimensions) > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "Missing required dimensions: %s\n", strings.Join(report.MissingRequiredDimensions, ", "))
+		} else if len(report.RequiredDimensions) > 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "Required dimensions covered")
 		}
 		return nil
 	},
@@ -244,7 +251,8 @@ func configureEvalCommand() {
 	evalBaselineCmd.Flags().StringVar(&evalBaselineReason, "rationale", "", "rationale for promoting the baseline")
 
 	evalCoverageCmd.Flags().StringVar(&evalCoverageRoot, "root", "evals/agentops-core", "suite root to scan when no suite paths are provided")
-	evalCoverageCmd.Flags().StringArrayVar(&evalCoverageRequire, "require-domain", aoeval.DefaultCoverageDomains, "required product domain for missing-domain reporting")
+	evalCoverageCmd.Flags().StringArrayVar(&evalCoverageDomains, "require-domain", aoeval.DefaultCoverageDomains, "required product domain for missing-domain reporting")
+	evalCoverageCmd.Flags().StringArrayVar(&evalCoverageDims, "require-dimension", aoeval.DefaultCoverageDimensions, "required score dimension for missing-dimension reporting")
 
 	evalScorecardCmd.Flags().StringVar(&evalScorecardOutput, "out", "", "write scorecard JSON to path")
 	evalScorecardCmd.Flags().StringVar(&evalScorecardKind, "kind", string(aoeval.ScorecardKindRPI), "scorecard kind (rpi, skill-change)")

--- a/cli/cmd/ao/eval.go
+++ b/cli/cmd/ao/eval.go
@@ -12,23 +12,24 @@ import (
 )
 
 var (
-	evalRunOutput       string
-	evalRunID           string
-	evalRunRuntime      string
-	evalRunBaseline     string
-	evalCompareOutput   string
-	evalCompareMaxAgg   float64
-	evalCompareMaxDim   float64
-	evalScorecardOutput string
-	evalScorecardKind   string
-	evalScorecardMaxCat float64
-	evalBaselineOutput  string
-	evalBaselineBy      string
-	evalBaselineReason  string
-	evalCoverageRoot    string
-	evalCoverageDomains []string
-	evalCoverageDims    []string
-	evalConfigured      bool
+	evalRunOutput        string
+	evalRunID            string
+	evalRunRuntime       string
+	evalRunBaseline      string
+	evalCompareOutput    string
+	evalCompareMaxAgg    float64
+	evalCompareMaxDim    float64
+	evalScorecardOutput  string
+	evalScorecardKind    string
+	evalScorecardMaxCat  float64
+	evalBaselineOutput   string
+	evalBaselineBy       string
+	evalBaselineReason   string
+	evalCoverageRoot     string
+	evalCoverageDomains  []string
+	evalCoverageDims     []string
+	evalCoverageRuntimes []string
+	evalConfigured       bool
 )
 
 var evalCmd = &cobra.Command{
@@ -197,6 +198,7 @@ var evalCoverageCmd = &cobra.Command{
 			Roots:              roots,
 			RequiredDomains:    evalCoverageDomains,
 			RequiredDimensions: evalCoverageDims,
+			RequiredRuntimes:   evalCoverageRuntimes,
 		})
 		if err != nil {
 			return err
@@ -214,6 +216,11 @@ var evalCoverageCmd = &cobra.Command{
 			fmt.Fprintf(cmd.OutOrStdout(), "Missing required dimensions: %s\n", strings.Join(report.MissingRequiredDimensions, ", "))
 		} else if len(report.RequiredDimensions) > 0 {
 			fmt.Fprintln(cmd.OutOrStdout(), "Required dimensions covered")
+		}
+		if len(report.MissingRequiredRuntimes) > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "Missing required runtimes: %s\n", strings.Join(report.MissingRequiredRuntimes, ", "))
+		} else if len(report.RequiredRuntimes) > 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "Required runtimes covered")
 		}
 		return nil
 	},
@@ -253,6 +260,7 @@ func configureEvalCommand() {
 	evalCoverageCmd.Flags().StringVar(&evalCoverageRoot, "root", "evals/agentops-core", "suite root to scan when no suite paths are provided")
 	evalCoverageCmd.Flags().StringArrayVar(&evalCoverageDomains, "require-domain", aoeval.DefaultCoverageDomains, "required product domain for missing-domain reporting")
 	evalCoverageCmd.Flags().StringArrayVar(&evalCoverageDims, "require-dimension", aoeval.DefaultCoverageDimensions, "required score dimension for missing-dimension reporting")
+	evalCoverageCmd.Flags().StringArrayVar(&evalCoverageRuntimes, "require-runtime", aoeval.DefaultCoverageRuntimes, "required deterministic runtime for missing-runtime reporting")
 
 	evalScorecardCmd.Flags().StringVar(&evalScorecardOutput, "out", "", "write scorecard JSON to path")
 	evalScorecardCmd.Flags().StringVar(&evalScorecardKind, "kind", string(aoeval.ScorecardKindRPI), "scorecard kind (rpi, skill-change)")

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -898,6 +898,7 @@ ao eval coverage [suite.json ...] [flags]
   -h, --help                            help for coverage
       --require-dimension stringArray   required score dimension for missing-dimension reporting (default [correctness,process_adherence,artifact_quality,runtime_compatibility,efficiency,safety,learning_closure])
       --require-domain stringArray      required product domain for missing-domain reporting (default [cli,hook,skill,rpi,runtime,retrieval,scenario,mixed])
+      --require-runtime stringArray     required deterministic runtime for missing-runtime reporting (default [static,shell,mock])
       --root string                     suite root to scan when no suite paths are provided (default "evals/agentops-core")
 ```
 

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -895,9 +895,10 @@ ao eval coverage [suite.json ...] [flags]
 **Flags:**
 
 ```
-  -h, --help                         help for coverage
-      --require-domain stringArray   required product domain for missing-domain reporting (default [cli,hook,skill,rpi,runtime,retrieval,scenario,mixed])
-      --root string                  suite root to scan when no suite paths are provided (default "evals/agentops-core")
+  -h, --help                            help for coverage
+      --require-dimension stringArray   required score dimension for missing-dimension reporting (default [correctness,process_adherence,artifact_quality,runtime_compatibility,efficiency,safety,learning_closure])
+      --require-domain stringArray      required product domain for missing-domain reporting (default [cli,hook,skill,rpi,runtime,retrieval,scenario,mixed])
+      --root string                     suite root to scan when no suite paths are provided (default "evals/agentops-core")
 ```
 
 #### `ao eval run`

--- a/cli/internal/eval/coverage.go
+++ b/cli/internal/eval/coverage.go
@@ -20,22 +20,35 @@ var DefaultCoverageDomains = []string{
 	"mixed",
 }
 
+var DefaultCoverageDimensions = []string{
+	string(DimensionCorrectness),
+	string(DimensionProcessAdherence),
+	string(DimensionArtifactQuality),
+	string(DimensionRuntimeCompatibility),
+	string(DimensionEfficiency),
+	string(DimensionSafety),
+	string(DimensionLearningClosure),
+}
+
 type CoverageOptions struct {
-	SuitePaths      []string
-	Roots           []string
-	RequiredDomains []string
+	SuitePaths         []string
+	Roots              []string
+	RequiredDomains    []string
+	RequiredDimensions []string
 }
 
 type CoverageReport struct {
-	SuiteCount             int                       `json:"suite_count"`
-	CaseCount              int                       `json:"case_count"`
-	CriticalCaseCount      int                       `json:"critical_case_count"`
-	Suites                 []CoverageSuite           `json:"suites"`
-	Domains                map[string]CoverageBucket `json:"domains"`
-	Dimensions             map[string]int            `json:"dimensions"`
-	Runtimes               map[string]int            `json:"runtimes"`
-	RequiredDomains        []string                  `json:"required_domains,omitempty"`
-	MissingRequiredDomains []string                  `json:"missing_required_domains,omitempty"`
+	SuiteCount                int                       `json:"suite_count"`
+	CaseCount                 int                       `json:"case_count"`
+	CriticalCaseCount         int                       `json:"critical_case_count"`
+	Suites                    []CoverageSuite           `json:"suites"`
+	Domains                   map[string]CoverageBucket `json:"domains"`
+	Dimensions                map[string]int            `json:"dimensions"`
+	Runtimes                  map[string]int            `json:"runtimes"`
+	RequiredDomains           []string                  `json:"required_domains,omitempty"`
+	MissingRequiredDomains    []string                  `json:"missing_required_domains,omitempty"`
+	RequiredDimensions        []string                  `json:"required_dimensions,omitempty"`
+	MissingRequiredDimensions []string                  `json:"missing_required_dimensions,omitempty"`
 }
 
 type CoverageSuite struct {
@@ -72,8 +85,10 @@ func BuildCoverageReport(opts CoverageOptions) (*CoverageReport, error) {
 		}
 		addSuiteCoverage(report, suite)
 	}
-	report.RequiredDomains = normalizedCoverageDomains(opts.RequiredDomains)
+	report.RequiredDomains = normalizedCoverageValues(opts.RequiredDomains)
 	report.MissingRequiredDomains = missingCoverageDomains(report.Domains, report.RequiredDomains)
+	report.RequiredDimensions = normalizedCoverageValues(opts.RequiredDimensions)
+	report.MissingRequiredDimensions = missingCoverageDimensions(report.Dimensions, report.RequiredDimensions)
 	return report, nil
 }
 
@@ -214,7 +229,7 @@ func coverageRuntimes(suite *Suite) []string {
 	return sortedCoverageKeys(seen)
 }
 
-func normalizedCoverageDomains(values []string) []string {
+func normalizedCoverageValues(values []string) []string {
 	seen := map[string]struct{}{}
 	for _, value := range values {
 		value = strings.TrimSpace(value)
@@ -231,6 +246,17 @@ func missingCoverageDomains(domains map[string]CoverageBucket, required []string
 	for _, domain := range required {
 		if domains[domain].SuiteCount == 0 {
 			missing = append(missing, domain)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+func missingCoverageDimensions(dimensions map[string]int, required []string) []string {
+	var missing []string
+	for _, dimension := range required {
+		if dimensions[dimension] == 0 {
+			missing = append(missing, dimension)
 		}
 	}
 	sort.Strings(missing)

--- a/cli/internal/eval/coverage.go
+++ b/cli/internal/eval/coverage.go
@@ -30,11 +30,18 @@ var DefaultCoverageDimensions = []string{
 	string(DimensionLearningClosure),
 }
 
+var DefaultCoverageRuntimes = []string{
+	string(RuntimeStatic),
+	string(RuntimeShell),
+	string(RuntimeMock),
+}
+
 type CoverageOptions struct {
 	SuitePaths         []string
 	Roots              []string
 	RequiredDomains    []string
 	RequiredDimensions []string
+	RequiredRuntimes   []string
 }
 
 type CoverageReport struct {
@@ -49,6 +56,8 @@ type CoverageReport struct {
 	MissingRequiredDomains    []string                  `json:"missing_required_domains,omitempty"`
 	RequiredDimensions        []string                  `json:"required_dimensions,omitempty"`
 	MissingRequiredDimensions []string                  `json:"missing_required_dimensions,omitempty"`
+	RequiredRuntimes          []string                  `json:"required_runtimes,omitempty"`
+	MissingRequiredRuntimes   []string                  `json:"missing_required_runtimes,omitempty"`
 }
 
 type CoverageSuite struct {
@@ -89,6 +98,8 @@ func BuildCoverageReport(opts CoverageOptions) (*CoverageReport, error) {
 	report.MissingRequiredDomains = missingCoverageDomains(report.Domains, report.RequiredDomains)
 	report.RequiredDimensions = normalizedCoverageValues(opts.RequiredDimensions)
 	report.MissingRequiredDimensions = missingCoverageDimensions(report.Dimensions, report.RequiredDimensions)
+	report.RequiredRuntimes = normalizedCoverageValues(opts.RequiredRuntimes)
+	report.MissingRequiredRuntimes = missingCoverageValues(report.Runtimes, report.RequiredRuntimes)
 	return report, nil
 }
 
@@ -253,10 +264,14 @@ func missingCoverageDomains(domains map[string]CoverageBucket, required []string
 }
 
 func missingCoverageDimensions(dimensions map[string]int, required []string) []string {
+	return missingCoverageValues(dimensions, required)
+}
+
+func missingCoverageValues(counts map[string]int, required []string) []string {
 	var missing []string
-	for _, dimension := range required {
-		if dimensions[dimension] == 0 {
-			missing = append(missing, dimension)
+	for _, value := range required {
+		if counts[value] == 0 {
+			missing = append(missing, value)
 		}
 	}
 	sort.Strings(missing)

--- a/cli/internal/eval/coverage_test.go
+++ b/cli/internal/eval/coverage_test.go
@@ -15,6 +15,7 @@ func TestBuildCoverageReportSummarizesDomains(t *testing.T) {
 		Roots:              []string{dir},
 		RequiredDomains:    []string{"cli", "skill", "scenario"},
 		RequiredDimensions: []string{"correctness", "efficiency"},
+		RequiredRuntimes:   []string{"shell", "static", "mock"},
 	})
 	if err != nil {
 		t.Fatalf("BuildCoverageReport failed: %v", err)
@@ -33,6 +34,9 @@ func TestBuildCoverageReportSummarizesDomains(t *testing.T) {
 	}
 	if len(report.MissingRequiredDimensions) != 1 || report.MissingRequiredDimensions[0] != "efficiency" {
 		t.Fatalf("missing required dimensions = %v, want [efficiency]", report.MissingRequiredDimensions)
+	}
+	if len(report.MissingRequiredRuntimes) != 1 || report.MissingRequiredRuntimes[0] != "mock" {
+		t.Fatalf("missing required runtimes = %v, want [mock]", report.MissingRequiredRuntimes)
 	}
 }
 

--- a/cli/internal/eval/coverage_test.go
+++ b/cli/internal/eval/coverage_test.go
@@ -12,8 +12,9 @@ func TestBuildCoverageReportSummarizesDomains(t *testing.T) {
 	writeCoverageSuite(t, filepath.Join(dir, "skill.json"), "coverage.skill", "skill", "static")
 
 	report, err := BuildCoverageReport(CoverageOptions{
-		Roots:           []string{dir},
-		RequiredDomains: []string{"cli", "skill", "scenario"},
+		Roots:              []string{dir},
+		RequiredDomains:    []string{"cli", "skill", "scenario"},
+		RequiredDimensions: []string{"correctness", "efficiency"},
 	})
 	if err != nil {
 		t.Fatalf("BuildCoverageReport failed: %v", err)
@@ -29,6 +30,9 @@ func TestBuildCoverageReportSummarizesDomains(t *testing.T) {
 	}
 	if report.Dimensions[string(DimensionCorrectness)] != 2 {
 		t.Fatalf("correctness dimension count = %d, want 2", report.Dimensions[string(DimensionCorrectness)])
+	}
+	if len(report.MissingRequiredDimensions) != 1 || report.MissingRequiredDimensions[0] != "efficiency" {
+		t.Fatalf("missing required dimensions = %v, want [efficiency]", report.MissingRequiredDimensions)
 	}
 }
 

--- a/cli/internal/eval/expectations.go
+++ b/cli/internal/eval/expectations.go
@@ -27,98 +27,122 @@ type expectationResult struct {
 func evaluateExpectation(exp Expectation, ctx caseContext) expectationResult {
 	switch exp.Type {
 	case "exit_code":
-		want, ok := intValue(exp.Value)
-		if !ok {
-			want = 0
-		}
-		if ctx.exitCode == want {
-			return passf("exit_code matched %d", want)
-		}
-		return failf("exit_code = %d, want %d", ctx.exitCode, want)
+		return evaluateExitCode(exp, ctx)
 	case "stdout_contains":
-		needle := stringExpectationValue(exp)
-		if strings.Contains(ctx.stdout, needle) {
-			return passf("stdout contains %q", needle)
-		}
-		return failf("stdout does not contain %q", needle)
+		return evaluateStringContains("stdout", ctx.stdout, stringExpectationValue(exp))
 	case "stderr_contains":
-		needle := stringExpectationValue(exp)
-		if strings.Contains(ctx.stderr, needle) {
-			return passf("stderr contains %q", needle)
-		}
-		return failf("stderr does not contain %q", needle)
+		return evaluateStringContains("stderr", ctx.stderr, stringExpectationValue(exp))
 	case "file_exists":
-		path := resolvePath(ctx.suiteDir, exp.Target)
-		if info, err := os.Stat(path); err == nil && !info.IsDir() {
-			return passf("file exists: %s", exp.Target)
-		}
-		return failf("file does not exist: %s", exp.Target)
+		return evaluateFileExists(exp, ctx)
 	case "file_absent":
-		path := resolvePath(ctx.suiteDir, exp.Target)
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			return passf("file absent: %s", exp.Target)
-		}
-		return failf("file exists: %s", exp.Target)
+		return evaluateFileAbsent(exp, ctx)
 	case "artifact_contains":
-		path := resolvePath(ctx.suiteDir, exp.Target)
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return failf("read artifact %s: %v", exp.Target, err)
-		}
-		needle := stringExpectationValue(exp)
-		if strings.Contains(string(data), needle) {
-			return passf("artifact %s contains %q", exp.Target, needle)
-		}
-		return failf("artifact %s does not contain %q", exp.Target, needle)
+		return evaluateArtifactContains(exp, ctx)
 	case "json_path":
-		actual, ok, err := jsonPathValue(exp.Target, ctx)
-		if err != nil {
-			return failf("json_path %s: %v", exp.Target, err)
-		}
-		if !ok {
-			return failf("json_path %s not found", exp.Target)
-		}
-		if exp.Value == nil {
-			return passf("json_path %s exists", exp.Target)
-		}
-		if jsonValuesEqual(actual, exp.Value) {
-			return passf("json_path %s matched", exp.Target)
-		}
-		return failf("json_path %s = %v, want %v", exp.Target, actual, exp.Value)
+		return evaluateJSONPath(exp, ctx)
 	case "schema_valid":
 		if err := validateSchemaTarget(exp, ctx); err != nil {
 			return failf("schema_valid %s: %v", exp.Target, err)
 		}
 		return passf("schema_valid %s matched", exp.Target)
 	case "score_at_least":
-		actual, ok, err := jsonPathValue(exp.Target, ctx)
-		if err != nil {
-			return failf("score_at_least %s: %v", exp.Target, err)
-		}
-		if !ok {
-			return failf("score_at_least target %s not found", exp.Target)
-		}
-		actualScore, ok := floatValue(actual)
-		if !ok {
-			return failf("score_at_least target %s is not numeric", exp.Target)
-		}
-		threshold := 1.0
-		if exp.Threshold != nil {
-			threshold = *exp.Threshold
-		} else if exp.Value != nil {
-			if parsed, ok := floatValue(exp.Value); ok {
-				threshold = parsed
-			}
-		}
-		if actualScore >= threshold {
-			return passf("score %.4f >= %.4f", actualScore, threshold)
-		}
-		return failf("score %.4f < %.4f", actualScore, threshold)
+		return evaluateScoreAtLeast(exp, ctx)
 	case "manual_review":
 		return failf("manual_review is not supported by deterministic evals")
 	default:
 		return failf("unsupported expectation type %q", exp.Type)
 	}
+}
+
+func evaluateExitCode(exp Expectation, ctx caseContext) expectationResult {
+	want, ok := intValue(exp.Value)
+	if !ok {
+		want = 0
+	}
+	if ctx.exitCode == want {
+		return passf("exit_code matched %d", want)
+	}
+	return failf("exit_code = %d, want %d", ctx.exitCode, want)
+}
+
+func evaluateStringContains(name, haystack, needle string) expectationResult {
+	if strings.Contains(haystack, needle) {
+		return passf("%s contains %q", name, needle)
+	}
+	return failf("%s does not contain %q", name, needle)
+}
+
+func evaluateFileExists(exp Expectation, ctx caseContext) expectationResult {
+	path := resolvePath(ctx.suiteDir, exp.Target)
+	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		return passf("file exists: %s", exp.Target)
+	}
+	return failf("file does not exist: %s", exp.Target)
+}
+
+func evaluateFileAbsent(exp Expectation, ctx caseContext) expectationResult {
+	path := resolvePath(ctx.suiteDir, exp.Target)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return passf("file absent: %s", exp.Target)
+	}
+	return failf("file exists: %s", exp.Target)
+}
+
+func evaluateArtifactContains(exp Expectation, ctx caseContext) expectationResult {
+	path := resolvePath(ctx.suiteDir, exp.Target)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return failf("read artifact %s: %v", exp.Target, err)
+	}
+	return evaluateStringContains("artifact "+exp.Target, string(data), stringExpectationValue(exp))
+}
+
+func evaluateJSONPath(exp Expectation, ctx caseContext) expectationResult {
+	actual, ok, err := jsonPathValue(exp.Target, ctx)
+	if err != nil {
+		return failf("json_path %s: %v", exp.Target, err)
+	}
+	if !ok {
+		return failf("json_path %s not found", exp.Target)
+	}
+	if exp.Value == nil {
+		return passf("json_path %s exists", exp.Target)
+	}
+	if jsonValuesEqual(actual, exp.Value) {
+		return passf("json_path %s matched", exp.Target)
+	}
+	return failf("json_path %s = %v, want %v", exp.Target, actual, exp.Value)
+}
+
+func evaluateScoreAtLeast(exp Expectation, ctx caseContext) expectationResult {
+	actual, ok, err := jsonPathValue(exp.Target, ctx)
+	if err != nil {
+		return failf("score_at_least %s: %v", exp.Target, err)
+	}
+	if !ok {
+		return failf("score_at_least target %s not found", exp.Target)
+	}
+	actualScore, ok := floatValue(actual)
+	if !ok {
+		return failf("score_at_least target %s is not numeric", exp.Target)
+	}
+	threshold := scoreThreshold(exp)
+	if actualScore >= threshold {
+		return passf("score %.4f >= %.4f", actualScore, threshold)
+	}
+	return failf("score %.4f < %.4f", actualScore, threshold)
+}
+
+func scoreThreshold(exp Expectation) float64 {
+	if exp.Threshold != nil {
+		return *exp.Threshold
+	}
+	if exp.Value != nil {
+		if parsed, ok := floatValue(exp.Value); ok {
+			return parsed
+		}
+	}
+	return 1.0
 }
 
 func expectationRequired(exp Expectation) bool {

--- a/cli/internal/eval/io.go
+++ b/cli/internal/eval/io.go
@@ -65,6 +65,17 @@ func WriteRun(path string, run *RunRecord) error {
 
 func ValidateSuite(suite *Suite) error {
 	var errs []string
+	errs = append(errs, validateSuiteMetadata(suite)...)
+	errs = append(errs, validateSuiteScoring(suite)...)
+	errs = append(errs, validateSuiteCases(suite)...)
+	if len(errs) > 0 {
+		return fmt.Errorf("eval suite validation failed: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func validateSuiteMetadata(suite *Suite) []string {
+	var errs []string
 	if suite.SchemaVersion != 1 {
 		errs = append(errs, "schema_version must be 1")
 	}
@@ -83,6 +94,14 @@ func ValidateSuite(suite *Suite) error {
 	if suite.Tier != TierDeterministic {
 		errs = append(errs, fmt.Sprintf("tier %q is out of deterministic scope", suite.Tier))
 	}
+	if strings.TrimSpace(suite.BaselinePolicy.Mode) == "" {
+		errs = append(errs, "baseline_policy.mode is required")
+	}
+	return errs
+}
+
+func validateSuiteScoring(suite *Suite) []string {
+	var errs []string
 	if suite.Scoring.AggregateThreshold < 0 || suite.Scoring.AggregateThreshold > 1 {
 		errs = append(errs, "scoring.aggregate_threshold must be in [0,1]")
 	}
@@ -100,9 +119,11 @@ func ValidateSuite(suite *Suite) error {
 			errs = append(errs, fmt.Sprintf("scoring.dimensions[%d].threshold must be in [0,1]", i))
 		}
 	}
-	if strings.TrimSpace(suite.BaselinePolicy.Mode) == "" {
-		errs = append(errs, "baseline_policy.mode is required")
-	}
+	return errs
+}
+
+func validateSuiteCases(suite *Suite) []string {
+	var errs []string
 	if len(suite.Cases) == 0 {
 		errs = append(errs, "cases must contain at least one case")
 	}
@@ -136,13 +157,21 @@ func ValidateSuite(suite *Suite) error {
 			}
 		}
 	}
+	return errs
+}
+
+func ValidateRun(run *RunRecord) error {
+	var errs []string
+	errs = append(errs, validateRunMetadata(run)...)
+	errs = append(errs, validateRunScores(run)...)
+	errs = append(errs, validateRunCaseResults(run)...)
 	if len(errs) > 0 {
-		return fmt.Errorf("eval suite validation failed: %s", strings.Join(errs, "; "))
+		return fmt.Errorf("eval run validation failed: %s", strings.Join(errs, "; "))
 	}
 	return nil
 }
 
-func ValidateRun(run *RunRecord) error {
+func validateRunMetadata(run *RunRecord) []string {
 	var errs []string
 	if run.SchemaVersion != 1 {
 		errs = append(errs, "schema_version must be 1")
@@ -186,6 +215,11 @@ func ValidateRun(run *RunRecord) error {
 	if len(run.CaseResults) == 0 {
 		errs = append(errs, "case_results must contain at least one case")
 	}
+	return errs
+}
+
+func validateRunScores(run *RunRecord) []string {
+	var errs []string
 	if !scoreInRange(run.AggregateScore) {
 		errs = append(errs, "aggregate_score must be in [0,1]")
 	}
@@ -200,6 +234,11 @@ func ValidateRun(run *RunRecord) error {
 			errs = append(errs, fmt.Sprintf("dimension_scores.%s must be in [0,1]", dim))
 		}
 	}
+	return errs
+}
+
+func validateRunCaseResults(run *RunRecord) []string {
+	var errs []string
 	for i, result := range run.CaseResults {
 		if strings.TrimSpace(result.ID) == "" {
 			errs = append(errs, fmt.Sprintf("case_results[%d].id is required", i))
@@ -214,10 +253,7 @@ func ValidateRun(run *RunRecord) error {
 			errs = append(errs, fmt.Sprintf("case_results[%d].dimension_scores is required", i))
 		}
 	}
-	if len(errs) > 0 {
-		return fmt.Errorf("eval run validation failed: %s", strings.Join(errs, "; "))
-	}
-	return nil
+	return errs
 }
 
 func decodeStrict(data []byte, target any) error {

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -68,8 +68,10 @@ scripts/eval-agentops.sh --fast
 
 The runner writes artifacts under `.agents/evals/runs/`. If a promoted baseline
 exists under `.agents/evals/baselines/`, the runner compares the new run against
-it and fails on regressions. Missing baselines are warnings, not failures, so new
-canaries can land before their ratchet is promoted.
+it and fails on regressions. In `--fast` mode it also writes `coverage.json` and
+fails when required domains, score dimensions, or deterministic runtimes are
+missing. Missing baselines are warnings, not failures, so new canaries can land
+before their ratchet is promoted.
 
 Baseline promotion is explicit and requires a rationale:
 

--- a/scripts/eval-agentops.sh
+++ b/scripts/eval-agentops.sh
@@ -160,6 +160,29 @@ scorecard_kind_for_suite() {
     esac
 }
 
+coverage_missing_summary() {
+    local path="$1"
+    python3 - "$path" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    data = json.load(fh)
+
+parts = []
+for label, key in (
+    ("domains", "missing_required_domains"),
+    ("dimensions", "missing_required_dimensions"),
+    ("runtimes", "missing_required_runtimes"),
+):
+    values = data.get(key) or []
+    if values:
+        parts.append(f"{label}={','.join(values)}")
+
+print("; ".join(parts))
+PY
+}
+
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agentops-eval.XXXXXX")"
 trap 'rm -rf "$tmp_dir"' EXIT
 
@@ -261,6 +284,24 @@ for suite in "${SUITES[@]}"; do
         fi
     fi
 done
+
+if [[ "$FAST" == "true" ]]; then
+    coverage_path="$run_dir/coverage.json"
+    coverage_stdout="$run_dir/coverage.stdout.json"
+    echo ""
+    echo "== eval coverage =="
+    if ! "$AO_BIN" eval coverage --root evals/agentops-core --json >"$coverage_path"; then
+        record_failure "coverage command failed"
+    else
+        cp "$coverage_path" "$coverage_stdout"
+        coverage_missing="$(coverage_missing_summary "$coverage_path")"
+        if [[ -n "$coverage_missing" ]]; then
+            record_failure "coverage gaps: $coverage_missing"
+        else
+            echo "coverage: required domains, dimensions, and runtimes covered"
+        fi
+    fi
+fi
 
 echo ""
 echo "AgentOps eval summary: failures=$failures warnings=$warnings artifacts=$run_dir"

--- a/scripts/generate-cli-reference.sh
+++ b/scripts/generate-cli-reference.sh
@@ -9,10 +9,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CLI_DIR="$REPO_ROOT/cli"
-AO_BIN="$CLI_DIR/.tmp/ao-docgen"
 OUTPUT="$REPO_ROOT/cli/docs/COMMANDS.md"
 CHECK_MODE=false
 TMPFILE=""
+TMP_AO_DIR=""
+AO_BIN=""
 
 if [[ "${1:-}" == "--check" ]]; then
   CHECK_MODE=true
@@ -25,12 +26,13 @@ fi
 
 cleanup() {
   [[ -n "$TMPFILE" ]] && rm -f "$TMPFILE"
-  rm -f "$AO_BIN"
+  [[ -n "$TMP_AO_DIR" ]] && rm -rf "$TMP_AO_DIR"
 }
 trap cleanup EXIT
 
 build_ao() {
-  mkdir -p "$(dirname "$AO_BIN")"
+  TMP_AO_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ao-docgen.XXXXXX")"
+  AO_BIN="$TMP_AO_DIR/ao-docgen"
   (
     cd "$CLI_DIR"
     go build -o "$AO_BIN" ./cmd/ao

--- a/scripts/generate-cli-reference.sh
+++ b/scripts/generate-cli-reference.sh
@@ -100,6 +100,11 @@ has_non_help_flags() {
   grep -Ev '^[[:space:]]*-h,[[:space:]]*--help[[:space:]]+help for' | grep -Ev '^[[:space:]]*$'
 }
 
+first_line() {
+  local text="$1"
+  printf '%s\n' "${text%%$'\n'*}"
+}
+
 generate() {
   cat <<DOC_HEADER
 # ao CLI Reference
@@ -117,13 +122,13 @@ DOC_HEADER
 
 DOC_GLOBAL_FLAGS
 
-  extract_flags <<<"$top_help" | while IFS= read -r line; do
+  echo "$top_help" | extract_flags | while IFS= read -r line; do
     echo "    $line"
   done
   echo ""
 
   local commands
-  commands="$(extract_commands <<<"$top_help" | grep -v '^$')"
+  commands="$(echo "$top_help" | extract_commands | grep -v '^$')"
 
   cat <<'DOC_COMMANDS'
 ---
@@ -137,7 +142,7 @@ DOC_COMMANDS
     cmd_help="$("$AO_BIN" "$cmd" --help 2>&1 || true)"
 
     local description
-    description="$(echo "$cmd_help" | sed -n '1p')"
+    description="$(first_line "$cmd_help")"
 
     echo "### \`ao ${cmd}\`"
     echo ""
@@ -145,7 +150,7 @@ DOC_COMMANDS
     echo ""
 
     local usage
-    usage="$(extract_usage <<<"$cmd_help" || true)"
+    usage="$(echo "$cmd_help" | extract_usage || true)"
     if [[ -n "$usage" ]]; then
       echo '```'
       echo "$usage"
@@ -154,8 +159,8 @@ DOC_COMMANDS
     fi
 
     local flags_block
-    flags_block="$(extract_flags <<<"$cmd_help" || true)"
-    if has_non_help_flags <<<"$flags_block" >/dev/null 2>&1; then
+    flags_block="$(echo "$cmd_help" | extract_flags || true)"
+    if echo "$flags_block" | has_non_help_flags >/dev/null 2>&1; then
       echo "**Flags:**"
       echo ""
       echo '```'
@@ -165,7 +170,7 @@ DOC_COMMANDS
     fi
 
     local subcmds
-    subcmds="$(extract_commands <<<"$cmd_help" | grep -v '^$' || true)"
+    subcmds="$(echo "$cmd_help" | extract_commands | grep -v '^$' || true)"
     if [[ -n "$subcmds" ]]; then
       echo "**Subcommands:**"
       echo ""
@@ -174,7 +179,7 @@ DOC_COMMANDS
         sub_help="$("$AO_BIN" "$cmd" "$sub" --help 2>&1 || true)"
 
         local sub_desc
-        sub_desc="$(echo "$sub_help" | sed -n '1p')"
+        sub_desc="$(first_line "$sub_help")"
 
         echo "#### \`ao ${cmd} ${sub}\`"
         echo ""
@@ -182,7 +187,7 @@ DOC_COMMANDS
         echo ""
 
         local sub_usage
-        sub_usage="$(extract_usage <<<"$sub_help" || true)"
+        sub_usage="$(echo "$sub_help" | extract_usage || true)"
         if [[ -n "$sub_usage" ]]; then
           echo '```'
           echo "$sub_usage"
@@ -191,8 +196,8 @@ DOC_COMMANDS
         fi
 
         local sub_flags
-        sub_flags="$(extract_flags <<<"$sub_help" || true)"
-        if has_non_help_flags <<<"$sub_flags" >/dev/null 2>&1; then
+        sub_flags="$(echo "$sub_help" | extract_flags || true)"
+        if echo "$sub_flags" | has_non_help_flags >/dev/null 2>&1; then
           echo "**Flags:**"
           echo ""
           echo '```'
@@ -202,14 +207,14 @@ DOC_COMMANDS
         fi
 
         local subsub_cmds
-        subsub_cmds="$(extract_commands <<<"$sub_help" | grep -v '^$' || true)"
+        subsub_cmds="$(echo "$sub_help" | extract_commands | grep -v '^$' || true)"
         if [[ -n "$subsub_cmds" ]]; then
           for subsub in $subsub_cmds; do
             local subsub_help
             subsub_help="$("$AO_BIN" "$cmd" "$sub" "$subsub" --help 2>&1 || true)"
 
             local subsub_desc
-            subsub_desc="$(echo "$subsub_help" | sed -n '1p')"
+            subsub_desc="$(first_line "$subsub_help")"
 
             echo "##### \`ao ${cmd} ${sub} ${subsub}\`"
             echo ""
@@ -217,7 +222,7 @@ DOC_COMMANDS
             echo ""
 
             local subsub_usage
-            subsub_usage="$(extract_usage <<<"$subsub_help" || true)"
+            subsub_usage="$(echo "$subsub_help" | extract_usage || true)"
             if [[ -n "$subsub_usage" ]]; then
               echo '```'
               echo "$subsub_usage"
@@ -226,8 +231,8 @@ DOC_COMMANDS
             fi
 
             local subsub_flags
-            subsub_flags="$(extract_flags <<<"$subsub_help" || true)"
-            if has_non_help_flags <<<"$subsub_flags" >/dev/null 2>&1; then
+            subsub_flags="$(echo "$subsub_help" | extract_flags || true)"
+            if echo "$subsub_flags" | has_non_help_flags >/dev/null 2>&1; then
               echo "**Flags:**"
               echo ""
               echo '```'


### PR DESCRIPTION
## Summary

PR-2 of 3 in the eval-environment landing series (epic ag-3lx). **Stacked on top of PR-1 (#169).** Cherry-picks CLI integration work + coverage reports + a stabilization fix.

Commits:
1. `ac8e7e2b` refactor: reduce eval validation complexity
2. `5a298343` feat: report eval dimension coverage
3. `159c0a42` feat: report eval runtime coverage
4. `1982e659` fix(evals): stabilize security governance canary (parallel-session commit; adds HOST_BASH_DIR for macOS bash 3.2 compatibility, addresses ag-5p8 finding 2)
5. `d6283159` ci: gate eval coverage completeness

## Deliberately skipped (compared to original plan's 6-commit estimate)

- `c6cefc98` chore: refresh beads codex artifact metadata — empty after rebase; main's hash is already current via newer commits, so the cherry-pick became a no-op.
- `92e9a689` feat: activate harvested knowledge natively — main already has native knowledge harvest from PR #163 (`a9b27c7b feat(knowledge): native harvest implementation`). The branch's older implementation conflicts with the merged native version. Closing as redundant.

## Hand-merges resolved

- `scripts/generate-cli-reference.sh`: took branch's `first_line` helper (cleaner than main's `sed -n '1p'`; functionally equivalent)
- `skills-codex/.agentops-manifest.json` + `skills-codex/beads/.agentops-generated.json`: kept main's hashes (already current; the branch's c6cefc98 was a stale refresh)

## Tests

- [x] `cd cli && go build ./... && go test ./...` PASS locally
- [x] `scripts/generate-cli-reference.sh` clean (zero diff after running)
- [ ] CI green on this PR
- [ ] Reviewer approval

## Stack

- PR-1: foundation (#169)
- **PR-2: this PR** (CLI integration + coverage)
- PR-3: canaries + closeout (76 commits) — depends on PR-1, PR-2

Closes ag-rnb.