### PR TITLE
Nightly 2026-04-29 — 9 productive cycles, +1 code goal, +2 runtime, -1 quarantined

### DIFF
--- a/.agents/findings/f-2026-04-29-001.md
+++ b/.agents/findings/f-2026-04-29-001.md
@@ -1,0 +1,85 @@
+---
+id: "f-2026-04-29-001"
+type: "finding"
+version: 1
+date: "2026-04-29"
+source_skill: "evolve"
+source_artifact: ".agents/nightly/2026-04-29/cycle-1-quarantine-proposal.md"
+
+
+title: "flywheel-compounding gate is corpus-state-bound and cannot be moved by single-session automation; weight should be reduced from 8 to 3."
+summary: "The flywheel-compounding goal asserts σρ > δ — escape velocity from the knowledge flywheel. The metric requires citation activity (σ = unique skills cited, ρ = unique sources cited) inside its measurement window, which only accrues when humans/LLMs actually run sessions that hit `ao lookup --cite`. Three consecutive nightlies (PR #165 2026-04-27, PR #174 2026-04-28, this run 2026-04-29) have failed to flip the metric because the nightly automation legitimately cannot manufacture citations without gaming. Two prior attempts took an observability axis (restore tags column; route check to rich-diagnostic script) and the diagnostic is now actionable, but the gate itself remains weighted 8 — the same as `go-cli-builds` and `go-cli-tests` — which causes every nightly to spend a heavy-goal slot on a metric that nightly automation cannot influence."
+pattern: "Goals whose green path requires multi-session corpus growth carry weights matched to code-actionable goals, drowning code-actionable signals in unfixable noise."
+detection_question: "When a goal carries the corpus-state tag AND has gone three or more consecutive nightlies without flipping, is the weight reduced or the gate converted to soft-warn?"
+checklist_item: "If a goal tagged `corpus-state` or `long-cycle` accumulates three failed consecutive nightlies, lower its weight to ≤ 3 and document the multi-session dependency in GOALS.md so /evolve does not re-spend heavy-goal slots on it."
+severity: "significant"
+detectability: "advisory"
+status: "active"
+compiler_targets: ["plan","goals"]
+scope_tags: ["goals-tuning","corpus-state","quarantine"]
+dedup_key: "goals-tuning|flywheel-compounding-corpus-state-quarantine|corpus-state"
+applicable_when: ["goals-tuning","quarantine","corpus-state"]
+applicable_languages: ["go","markdown"]
+tier: "local"
+confidence: "high"
+ttl_days: 90
+hit_count: 0
+
+
+
+
+---
+# Finding: flywheel-compounding gate is corpus-state-bound and cannot be moved by single-session automation; weight should be reduced from 8 to 3.
+
+## Summary
+
+The `flywheel-compounding` goal asserts `σρ > δ` — escape velocity from the knowledge flywheel. The metric requires citation activity (σ = unique skills cited, ρ = unique sources cited) inside its measurement window, which only accrues when human or LLM sessions actually run `ao lookup --cite`. The 2026-04-29 baseline diagnostic reports `σ=0 ρ=0 σρ=0 δ=1.6436...` — i.e. zero citations recorded; corpus is dormant.
+
+## Three-attempt history (per `.agents/goals/flywheel-compounding/attempts.jsonl`)
+
+| Run | Angle | Outcome |
+|-----|-------|---------|
+| 2026-04-27 (PR #165) | observability: restore long-cycle/corpus-state tags column stripped by PR #162 | metric unchanged |
+| 2026-04-28 (PR #174) | observability: route goal command to rich-diagnostic script (`scripts/check-flywheel-compounding.sh`) | metric unchanged; diagnostic actionable |
+| 2026-04-29 (this run) | quarantine proposal: lower weight 8→3, document corpus-state dependency in GOALS.md | this finding |
+
+Per the run-brief rule "If 3+ consecutive nightlies attempted the same goal without flipping the metric, the next attempt MUST be a quarantine proposal," this run cannot legitimately attempt a fourth observability axis — gaming the metric is explicitly disallowed.
+
+## Pattern
+
+Goals whose green path requires multi-session corpus growth carry weights matched to code-actionable goals, drowning code-actionable signals in unfixable noise. The `long-cycle` and `corpus-state` tags exist precisely to mark these — but the weight scale was not adjusted when the tags were introduced (PR #165, 2026-04-27).
+
+## Why weight 3 (not 0/remove)
+
+- The gate still produces useful signal when the corpus IS active (real human/agent sessions over multiple days). Removing it loses that observation.
+- Weight 3 matches `competitive-freshness` (also a slow-moving doc-cadence gate). It keeps the gate visible without crowding out heavy goals.
+- The diagnostic now produced by `scripts/check-flywheel-compounding.sh` (PR #174) remains valuable: an operator running the gate by hand sees actionable σρδ structure.
+
+## Recommendation (paired GOALS.md change in this cycle)
+
+| Field | Before | After |
+|-------|--------|-------|
+| weight | 8 | 3 |
+| description | Knowledge flywheel above escape velocity (σρ > δ), a necessary but not sufficient condition for true compounding | Knowledge flywheel above escape velocity (σρ > δ); requires multi-session citation activity, not movable by single-session automation — see `.agents/findings/f-2026-04-29-001.md` |
+| tags | long-cycle, corpus-state | long-cycle, corpus-state |
+
+## Rollback path
+
+If, at some future point, the citation corpus accumulates enough activity that this gate flips green and stays green for ≥7 consecutive nightlies, weight may be raised back to 5–8. The `attempts.jsonl` ledger is the system of record for that rollback decision.
+
+## Applicability
+
+- Work shapes: goals-tuning, quarantine, corpus-state
+- Languages: go, markdown
+- Scope tags: goals-tuning, corpus-state, quarantine
+
+## Lifecycle
+
+- Status: active
+- Detectability: advisory
+- Confidence: high
+
+## Source
+
+- Skill: evolve
+- Artifact: .agents/nightly/2026-04-29/cycle-1-quarantine-proposal.md

--- a/.agents/goals/flywheel-compounding/attempts.jsonl
+++ b/.agents/goals/flywheel-compounding/attempts.jsonl
@@ -1,0 +1,3 @@
+{"date": "2026-04-27", "nightly_pr": 165, "angle": "observability:restore-tags-column", "commit_sha": "unknown-pr-165", "outcome": "metric-unchanged"}
+{"date": "2026-04-28", "nightly_pr": 174, "angle": "observability:rich-diagnostic-script", "commit_sha": "5b8aecfe", "outcome": "metric-unchanged"}
+{"date": "2026-04-29", "nightly_pr": "pending", "angle": "quarantine:weight-reduce-8-to-3", "commit_sha": "TBD", "outcome": "weight-reduced", "finding": "f-2026-04-29-001"}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -141,6 +141,7 @@ jobs:
           ./scripts/generate-cli-reference.sh --check
 
   agentops-eval-advisory:
+    name: agentops-eval-advisory (warn-only)
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -286,6 +287,7 @@ jobs:
           echo "✅ No dangerous patterns"
 
   security-toolchain-gate:
+    name: security-toolchain-gate (warn-only)
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 15
@@ -787,6 +789,7 @@ jobs:
           scripts/check-file-manifest-overlap.sh "$CLEAN_TMP"
 
   doctor-check:
+    name: doctor-check (warn-only)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: go-build
@@ -855,6 +858,7 @@ jobs:
         run: bash tests/hooks/test-orphan-hooks.sh
 
   check-test-staleness:
+    name: check-test-staleness (warn-only)
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/GOALS.md
+++ b/GOALS.md
@@ -112,7 +112,7 @@ artifact produced by a separate run (e.g. `ao defrag` writing
 
 | ID | Check | Weight | Description | Tags |
 |----|-------|--------|-------------|------|
-| flywheel-compounding | `bash scripts/check-flywheel-compounding.sh` | 8 | Knowledge flywheel above escape velocity (σρ > δ), a necessary but not sufficient condition for true compounding | long-cycle, corpus-state |
+| flywheel-compounding | `bash scripts/check-flywheel-compounding.sh` | 3 | Knowledge flywheel above escape velocity (σρ > δ); requires multi-session citation activity, not movable by single-session automation — see `.agents/findings/f-2026-04-29-001.md` | long-cycle, corpus-state |
 | flywheel-proof | `bash scripts/proof-run.sh` | 7 | Flywheel compounds across sessions (automated proof) |  |
 | skill-frontmatter | `bash -c 'for f in skills/*/SKILL.md; do head -5 "$f" \| grep -q "^---" && head -10 "$f" \| grep -q "^name:" && head -10 "$f" \| grep -q "^description:" \|\| { echo FAIL:$f; exit 1; }; done'` | 6 | Every skill has valid YAML frontmatter |  |
 | hook-preflight | `timeout 60 ./scripts/validate-hook-preflight.sh` | 6 | All hooks pass safety checks |  |

--- a/cli/cmd/ao/config_test.go
+++ b/cli/cmd/ao/config_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
@@ -57,14 +56,7 @@ func TestRunConfig_ShowJSON(t *testing.T) {
 
 func TestRunConfig_ShowTable(t *testing.T) {
 	dir := t.TempDir()
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(oldWD) }()
+	t.Chdir(dir)
 
 	oldShow := configShow
 	configShow = true
@@ -100,14 +92,7 @@ func TestRunConfig_ShowTable(t *testing.T) {
 
 func TestRunConfig_ShowTable_NoConfigFiles(t *testing.T) {
 	dir := t.TempDir()
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(oldWD) }()
+	t.Chdir(dir)
 
 	oldShow := configShow
 	configShow = true
@@ -132,14 +117,7 @@ func TestRunConfig_ShowTable_NoConfigFiles(t *testing.T) {
 
 func TestRunConfig_ShowTable_WithEnvVars(t *testing.T) {
 	dir := t.TempDir()
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(oldWD) }()
+	t.Chdir(dir)
 
 	t.Setenv("AGENTOPS_OUTPUT", "json")
 
@@ -165,14 +143,7 @@ func TestRunConfig_ShowTable_WithEnvVars(t *testing.T) {
 
 func TestRunConfigModels_Table(t *testing.T) {
 	dir := t.TempDir()
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(oldWD) }()
+	t.Chdir(dir)
 
 	oldOutput := output
 	output = "table"
@@ -201,14 +172,7 @@ func TestRunConfigModels_Table(t *testing.T) {
 
 func TestRunConfigModels_JSON(t *testing.T) {
 	dir := t.TempDir()
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(oldWD) }()
+	t.Chdir(dir)
 
 	oldOutput := output
 	output = "json"
@@ -236,14 +200,7 @@ func TestRunConfigModels_JSON(t *testing.T) {
 
 func TestRunConfigModels_WithEnvOverride(t *testing.T) {
 	dir := t.TempDir()
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(oldWD) }()
+	t.Chdir(dir)
 
 	t.Setenv("AGENTOPS_MODEL_TIER", "budget")
 
@@ -268,14 +225,7 @@ func TestRunConfigModels_WithEnvOverride(t *testing.T) {
 
 func TestConfigModels_SetTier(t *testing.T) {
 	dir := t.TempDir()
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(oldWD) }()
+	t.Chdir(dir)
 
 	// Clear env so project config is used from cwd
 	t.Setenv("AGENTOPS_CONFIG", "")
@@ -312,14 +262,7 @@ func TestConfigModels_SetTier(t *testing.T) {
 
 func TestConfigModels_SetSkill(t *testing.T) {
 	dir := t.TempDir()
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(oldWD) }()
+	t.Chdir(dir)
 
 	t.Setenv("AGENTOPS_CONFIG", "")
 
@@ -354,14 +297,7 @@ func TestConfigModels_SetSkill(t *testing.T) {
 
 func TestConfigModels_SetTierAndSkill_JSON(t *testing.T) {
 	dir := t.TempDir()
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(oldWD) }()
+	t.Chdir(dir)
 
 	t.Setenv("AGENTOPS_CONFIG", "")
 
@@ -456,14 +392,7 @@ func TestConfigModels_SetTier_InvalidTier(t *testing.T) {
 
 func TestRunConfig_ShowTable_NoEnvVars(t *testing.T) {
 	dir := t.TempDir()
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(oldWD) }()
+	t.Chdir(dir)
 
 	// Clear all known env vars
 	for _, env := range []string{

--- a/cli/cmd/ao/dedup_test.go
+++ b/cli/cmd/ao/dedup_test.go
@@ -82,11 +82,7 @@ func TestRunDedup_NoDuplicates(t *testing.T) {
 	}
 
 	// Change to temp dir for the command
-	origDir, _ := os.Getwd()
-	if err := os.Chdir(tmp); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(origDir) }()
+	t.Chdir(tmp)
 
 	// Force JSON output so we can parse the result
 	origOutput := output
@@ -147,11 +143,7 @@ func TestRunDedup_IncludesPatterns(t *testing.T) {
 	}
 
 	// Change to temp dir for the command
-	origDir, _ := os.Getwd()
-	if err := os.Chdir(tmp); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(origDir) }()
+	t.Chdir(tmp)
 
 	// Force JSON output
 	origOutput := output
@@ -225,11 +217,7 @@ func TestRunDedup_FindsDuplicates(t *testing.T) {
 	}
 
 	// Change to temp dir for the command
-	origDir, _ := os.Getwd()
-	if err := os.Chdir(tmp); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(origDir) }()
+	t.Chdir(tmp)
 
 	// Force JSON output so we can parse the result
 	origOutput := output
@@ -291,11 +279,7 @@ func TestRunDedup_MergeKeepsHighestUtility(t *testing.T) {
 	}
 
 	// Change to temp dir
-	origDir, _ := os.Getwd()
-	if err := os.Chdir(tmp); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(origDir) }()
+	t.Chdir(tmp)
 
 	// Enable merge flag, disable dry-run
 	origMerge := dedupMerge

--- a/cli/cmd/ao/metrics_flywheel_test.go
+++ b/cli/cmd/ao/metrics_flywheel_test.go
@@ -268,14 +268,7 @@ func TestFlywheelStatus_GoldenSignalsAlwaysShown(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, ".agents", "ao", "citations.jsonl"), []byte{}, 0644)
 	os.WriteFile(filepath.Join(dir, ".agents", "ao", "feedback.jsonl"), []byte{}, 0644)
 
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(oldWD) }()
+	t.Chdir(dir)
 
 	oldOutput := output
 	defer func() { output = oldOutput }()
@@ -360,14 +353,7 @@ func TestRunFlywheelStatus_JSONOutput(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(oldWD) }()
+	t.Chdir(dir)
 
 	oldOutput := output
 	output = "json"
@@ -445,14 +431,7 @@ func TestPrintFlywheelStatus_IncludesScorecard(t *testing.T) {
 func TestRunFlywheelStatus_YAMLOutput(t *testing.T) {
 	dir := t.TempDir()
 
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(oldWD) }()
+	t.Chdir(dir)
 
 	oldOutput := output
 	output = "yaml"
@@ -483,14 +462,7 @@ func TestRunFlywheelStatus_YAMLOutput(t *testing.T) {
 func TestRunFlywheelStatus_TableOutput(t *testing.T) {
 	dir := t.TempDir()
 
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(oldWD) }()
+	t.Chdir(dir)
 
 	oldOutput := output
 	output = "table"

--- a/cli/cmd/ao/metrics_health_test.go
+++ b/cli/cmd/ao/metrics_health_test.go
@@ -524,14 +524,7 @@ func TestMetricsHealth_JSONOutput(t *testing.T) {
 	})
 
 	// Save and restore global state
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.Chdir(oldWD) }()
+	t.Chdir(dir)
 
 	oldOutput := output
 	output = "json"

--- a/cli/cmd/ao/plans_test.go
+++ b/cli/cmd/ao/plans_test.go
@@ -389,11 +389,7 @@ func TestGetManifestPath(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		oldWD, _ := os.Getwd()
-		if err := os.Chdir(dir); err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(oldWD) }()
+		t.Chdir(dir)
 
 		path, err := getManifestPath()
 		if err != nil {
@@ -407,11 +403,7 @@ func TestGetManifestPath(t *testing.T) {
 	t.Run("returns default path when no .agents exists", func(t *testing.T) {
 		dir := t.TempDir()
 
-		oldWD, _ := os.Getwd()
-		if err := os.Chdir(dir); err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(oldWD) }()
+		t.Chdir(dir)
 
 		path, err := getManifestPath()
 		if err != nil {
@@ -434,11 +426,7 @@ func TestGetManifestPath(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		oldWD, _ := os.Getwd()
-		if err := os.Chdir(subDir); err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(oldWD) }()
+		t.Chdir(subDir)
 
 		path, err := getManifestPath()
 		if err != nil {
@@ -705,11 +693,7 @@ func TestLoadOrCreateManifest(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		oldWD, _ := os.Getwd()
-		if err := os.Chdir(dir); err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(oldWD) }()
+		t.Chdir(dir)
 
 		manifestPath, entries, err := loadOrCreateManifest()
 		if err != nil {
@@ -739,11 +723,7 @@ func TestLoadOrCreateManifest(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		oldWD, _ := os.Getwd()
-		if err := os.Chdir(dir); err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(oldWD) }()
+		t.Chdir(dir)
 
 		_, entries, err := loadOrCreateManifest()
 		if err != nil {
@@ -1091,11 +1071,7 @@ func TestRunPlansRegister(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		oldWD, _ := os.Getwd()
-		if err := os.Chdir(dir); err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(oldWD) }()
+		t.Chdir(dir)
 
 		cmd := &cobra.Command{}
 		err := runPlansRegister(cmd, []string{planPath})
@@ -1132,11 +1108,7 @@ func TestRunPlansRegister(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		oldWD, _ := os.Getwd()
-		if err := os.Chdir(dir); err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(oldWD) }()
+		t.Chdir(dir)
 
 		cmd := &cobra.Command{}
 		// Register first time
@@ -1180,11 +1152,7 @@ func TestRunPlansList(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		oldWD, _ := os.Getwd()
-		if err := os.Chdir(dir); err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(oldWD) }()
+		t.Chdir(dir)
 
 		planProjectPath = ""
 		planStatus = ""
@@ -1213,11 +1181,7 @@ func TestRunPlansList(t *testing.T) {
 			_ = f.Close()
 		}
 
-		oldWD, _ := os.Getwd()
-		if err := os.Chdir(dir); err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(oldWD) }()
+		t.Chdir(dir)
 
 		planProjectPath = ""
 		planStatus = ""
@@ -1241,11 +1205,7 @@ func TestRunPlansList(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		oldWD, _ := os.Getwd()
-		if err := os.Chdir(dir); err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(oldWD) }()
+		t.Chdir(dir)
 
 		planProjectPath = ""
 		planStatus = "nonexistent-status"
@@ -1266,11 +1226,7 @@ func TestRunPlansSearch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		oldWD, _ := os.Getwd()
-		if err := os.Chdir(dir); err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(oldWD) }()
+		t.Chdir(dir)
 
 		cmd := &cobra.Command{}
 		err := runPlansSearch(cmd, []string{"anything"})
@@ -1299,11 +1255,7 @@ func TestRunPlansSearch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		oldWD, _ := os.Getwd()
-		if err := os.Chdir(dir); err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(oldWD) }()
+		t.Chdir(dir)
 
 		cmd := &cobra.Command{}
 		err := runPlansSearch(cmd, []string{"auth"})
@@ -1324,11 +1276,7 @@ func TestRunPlansSearch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		oldWD, _ := os.Getwd()
-		if err := os.Chdir(dir); err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(oldWD) }()
+		t.Chdir(dir)
 
 		cmd := &cobra.Command{}
 		err := runPlansSearch(cmd, []string{"zzzznonexistent"})
@@ -1382,11 +1330,7 @@ func TestRunPlansUpdate(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		oldWD, _ := os.Getwd()
-		if err := os.Chdir(dir); err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(oldWD) }()
+		t.Chdir(dir)
 
 		cmd := &cobra.Command{}
 		err := runPlansUpdate(cmd, []string{planPath})
@@ -1423,11 +1367,7 @@ func TestRunPlansUpdate(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		oldWD, _ := os.Getwd()
-		if err := os.Chdir(dir); err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(oldWD) }()
+		t.Chdir(dir)
 
 		cmd := &cobra.Command{}
 		err := runPlansUpdate(cmd, []string{"/nonexistent/plan.md"})
@@ -1469,11 +1409,7 @@ func TestRunPlansSync(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		oldWD, _ := os.Getwd()
-		if err := os.Chdir(dir); err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(oldWD) }()
+		t.Chdir(dir)
 
 		cmd := &cobra.Command{}
 		// This will fail to query beads (bd not available) but should handle gracefully

--- a/cli/internal/gascity/events.go
+++ b/cli/internal/gascity/events.go
@@ -407,21 +407,8 @@ func (d *SSEDecoder) readRawFrame() (rawSSEFrame, error) {
 			continue
 		}
 
-		field, value, _ := strings.Cut(line, ":")
-		value = strings.TrimPrefix(value, " ")
-		switch field {
-		case "id":
-			frame.id = value
-		case "event":
-			frame.event = value
-		case "retry":
-			retry, parseErr := strconv.Atoi(value)
-			if parseErr != nil {
-				return rawSSEFrame{}, fmt.Errorf("parse SSE retry %q: %w", value, parseErr)
-			}
-			frame.retry = retry
-		case "data":
-			data = append(data, value)
+		if perr := assignSSEField(line, &frame, &data); perr != nil {
+			return rawSSEFrame{}, perr
 		}
 
 		if err == io.EOF {
@@ -429,6 +416,30 @@ func (d *SSEDecoder) readRawFrame() (rawSSEFrame, error) {
 			return frame, nil
 		}
 	}
+}
+
+// assignSSEField parses a single non-empty, non-comment SSE line of the
+// form `field:value` and folds it into the in-progress frame. Only the
+// retry field can produce a parse error; unknown fields are silently
+// ignored per the SSE spec.
+func assignSSEField(line string, frame *rawSSEFrame, data *[]string) error {
+	field, value, _ := strings.Cut(line, ":")
+	value = strings.TrimPrefix(value, " ")
+	switch field {
+	case "id":
+		frame.id = value
+	case "event":
+		frame.event = value
+	case "retry":
+		retry, parseErr := strconv.Atoi(value)
+		if parseErr != nil {
+			return fmt.Errorf("parse SSE retry %q: %w", value, parseErr)
+		}
+		frame.retry = retry
+	case "data":
+		*data = append(*data, value)
+	}
+	return nil
 }
 
 // DecodeWireEventJSONLines parses JSONL emitted by city-scoped gc events list mode.

--- a/cli/internal/llm/forge_tier1.go
+++ b/cli/internal/llm/forge_tier1.go
@@ -96,37 +96,8 @@ type Tier1Result struct {
 // switch (KillSwitchEnv=1) short-circuits the whole path at the very top so
 // operators can disable Tier 1 instantly without a code change.
 func RunForgeTier1(opts Tier1Options) (*Tier1Result, error) {
-	if os.Getenv(KillSwitchEnv) == "1" {
-		return nil, fmt.Errorf("%s=1 set: tier 1 forge is disabled", KillSwitchEnv)
-	}
-	if len(opts.SourcePaths) == 0 {
-		return nil, fmt.Errorf("tier1: no source paths supplied")
-	}
-	if opts.OutputDir == "" {
-		return nil, fmt.Errorf("tier1: OutputDir is required")
-	}
-	if opts.Model == "" {
-		return nil, fmt.Errorf("tier1: Model is required")
-	}
-	if opts.Worker == nil && opts.clientFactory == nil && !opts.LegacyLocalLLM {
-		return nil, fmt.Errorf("tier1: local Ollama LLM is legacy-only; set LegacyLocalLLM or provide an AgentWorker")
-	}
-	if opts.Endpoint == "" {
-		opts.Endpoint = ResolveDefaultEndpoint()
-	}
-	if opts.MaxChars <= 0 {
-		opts.MaxChars = DefaultMaxChars
-	}
-	if opts.Writer == nil {
-		opts.Writer = os.Stdout
-	}
-	if opts.Workspace == "" {
-		if wd, err := os.Getwd(); err == nil {
-			opts.Workspace = wd
-		}
-	}
-	if opts.IngestedBy == "" {
-		opts.IngestedBy = "ao-forge-tier1"
+	if err := validateAndDefaultTier1Options(&opts); err != nil {
+		return nil, err
 	}
 
 	// Build the LLM client once per invocation (init-phase /api/tags probe
@@ -159,6 +130,46 @@ func RunForgeTier1(opts Tier1Options) (*Tier1Result, error) {
 		}
 	}
 	return result, nil
+}
+
+// validateAndDefaultTier1Options enforces required fields, applies the
+// kill-switch short-circuit, and fills in environment-derived defaults
+// (endpoint, max chars, writer, workspace, ingestor tag). Mutates opts
+// in place so the caller observes the resolved values.
+func validateAndDefaultTier1Options(opts *Tier1Options) error {
+	if os.Getenv(KillSwitchEnv) == "1" {
+		return fmt.Errorf("%s=1 set: tier 1 forge is disabled", KillSwitchEnv)
+	}
+	if len(opts.SourcePaths) == 0 {
+		return fmt.Errorf("tier1: no source paths supplied")
+	}
+	if opts.OutputDir == "" {
+		return fmt.Errorf("tier1: OutputDir is required")
+	}
+	if opts.Model == "" {
+		return fmt.Errorf("tier1: Model is required")
+	}
+	if opts.Worker == nil && opts.clientFactory == nil && !opts.LegacyLocalLLM {
+		return fmt.Errorf("tier1: local Ollama LLM is legacy-only; set LegacyLocalLLM or provide an AgentWorker")
+	}
+	if opts.Endpoint == "" {
+		opts.Endpoint = ResolveDefaultEndpoint()
+	}
+	if opts.MaxChars <= 0 {
+		opts.MaxChars = DefaultMaxChars
+	}
+	if opts.Writer == nil {
+		opts.Writer = os.Stdout
+	}
+	if opts.Workspace == "" {
+		if wd, err := os.Getwd(); err == nil {
+			opts.Workspace = wd
+		}
+	}
+	if opts.IngestedBy == "" {
+		opts.IngestedBy = "ao-forge-tier1"
+	}
+	return nil
 }
 
 func processOneSession(path string, opts Tier1Options, p *parser.Parser, s *Summarizer, gen Generator) (string, error) {

--- a/cli/internal/rpi/artifacts.go
+++ b/cli/internal/rpi/artifacts.go
@@ -157,15 +157,30 @@ func ClassifyRPIArtifact(rel, phasedStateFile, c2EventsFileName string) (kind, l
 		return "plan", "Plan", 0
 	case strings.Contains(rel, "/research/"):
 		return "research", "Research", 0
-	case strings.Contains(rel, "/council/") && strings.Contains(strings.ToLower(base), "pre-mortem"):
-		return "council_pre_mortem", "Pre-mortem report", 0
-	case strings.Contains(rel, "/council/") && strings.Contains(strings.ToLower(base), "post-mortem"):
-		return "council_post_mortem", "Post-mortem report", 0
-	case strings.Contains(rel, "/council/") && strings.Contains(strings.ToLower(base), "vibe"):
-		return "council_vibe", "Vibe report", 0
-	default:
-		return "artifact", base, phase
 	}
+	if k, l, ok := classifyCouncilArtifact(rel, base); ok {
+		return k, l, 0
+	}
+	return "artifact", base, phase
+}
+
+// classifyCouncilArtifact returns the council kind/label for /council/-rooted
+// artifacts (pre-mortem, post-mortem, vibe). ok is false for non-council
+// paths or unknown council variants.
+func classifyCouncilArtifact(rel, base string) (kind, label string, ok bool) {
+	if !strings.Contains(rel, "/council/") {
+		return "", "", false
+	}
+	lower := strings.ToLower(base)
+	switch {
+	case strings.Contains(lower, "pre-mortem"):
+		return "council_pre_mortem", "Pre-mortem report", true
+	case strings.Contains(lower, "post-mortem"):
+		return "council_post_mortem", "Post-mortem report", true
+	case strings.Contains(lower, "vibe"):
+		return "council_vibe", "Vibe report", true
+	}
+	return "", "", false
 }
 
 // ArtifactPhaseNumber extracts the phase number from a filename like "phase-2-result.json".


### PR DESCRIPTION
## Digest

**9 productive cycles.** Fitness improved from 4 failing goals (warm baseline) → 1 failing (`flywheel-compounding`, now at quarantine weight 3, corpus-state-bound and unmovable by single-session automation per the 3-attempt rule).

- **1 code-driven flip:** `go-complexity-ceiling` (W=6) — eliminated five CC violations across daemon, gascity, llm, rpi (5 cycles, ExecuteRPIPhase 27 → ~10, RebuildProjections 24 → ~9, applyQueueEvent 22 → ~7, readRawFrame 22 → ~17, RunForgeTier1 19 → ~7, ClassifyRPIArtifact 19 → ~14).
- **2 runtime-artifact flips:** `compile-freshness`, `compile-no-oscillation` — Dream phase produced `.agents/overnight/latest/defrag/latest.json`; gitignored, **does not propagate** to other environments.
- **1 quarantine:** `flywheel-compounding` (W=8 → W=3) — attempt 3 in three consecutive nightlies; mandatory quarantine per the run-brief rule.
- **0 auto-reverts** and **0 transient-flake non-reverts** (no regressions during the run).

## Fitness delta (warm baseline → final)

| Goal | Tags | Baseline weight | Final weight | Baseline | Final | Notes |
|---|---|---|---|---|---|---|
| flywheel-compounding | long-cycle, corpus-state | 8 | **3** | **fail** | **fail** | Quarantined (cycle 1; finding `f-2026-04-29-001`); metric still corpus-bound but no longer crowds heavy-goal slot |
| flywheel-proof | — | 7 | 7 | pass | pass | held |
| wiring-closure | — | 7 | 7 | pass | pass | held |
| go-cli-builds | — | 8 | 8 | pass | pass | held |
| go-cli-tests | — | 8 | 8 | pass | pass | held (warmed in prelude — see "cold-cache flake avoided" below) |
| go-complexity-ceiling | — | 6 | 6 | **fail** | **pass** | Code-driven flip across cycles 2–6 |
| skill-frontmatter | — | 6 | 6 | pass | pass | held |
| hook-preflight | — | 6 | 6 | pass | pass | held |
| security-gate | — | 6 | 6 | pass | pass | held |
| flywheel-lifecycle | — | 6 | 6 | pass | pass | held |
| codex-parity-drift | — | 5 | 5 | pass | pass | held |
| go-vet-clean | — | 5 | 5 | pass | pass | held |
| manifest-versions-match | — | 5 | 5 | pass | pass | held |
| contract-compatibility | — | 5 | 5 | pass | pass | held |
| goals-validate | — | 5 | 5 | pass | pass | held |
| install-smoke | — | 5 | 5 | pass | pass | held |
| compile-freshness | runtime-artifact | 4 | 4 | **fail** | **pass** | Runtime-artifact flip (Dream defrag) — does not propagate |
| compile-no-oscillation | runtime-artifact | 4 | 4 | **fail** | **pass** | Same defrag artifact |
| competitive-freshness | — | 3 | 3 | pass | pass | held |

**Final: 18 pass / 1 fail (vs warm baseline 15 pass / 4 fail).** `go-complexity-ceiling` (W=6) was the only heavy goal that this run could legitimately move; it flipped via code.

### Code-driven flips vs runtime-artifact flips (tabulated separately)

| Type | Goal | Cycles | Source |
|---|---|---|---|
| Code-driven | `go-complexity-ceiling` | 2, 3, 4, 5, 6 | five extract-helper refactors across daemon (`rpi_runner.go`, `projections.go`, `jobs.go`), gascity (`events.go`), llm (`forge_tier1.go`), rpi (`artifacts.go`); see per-cycle summary |
| Runtime-artifact | `compile-freshness` | (Dream phase) | `.agents/overnight/latest/defrag/latest.json` produced by `ao overnight start --max-iterations 1 --warn-only`; gitignored, does not propagate |
| Runtime-artifact | `compile-no-oscillation` | (Dream phase) | same defrag artifact |

## Per-cycle summary

| # | Type | Goal/Finding | Commit | Fitness before → after |
|---|---|---|---|---|
| 1 | **Heavy-goal quarantine** (3-attempt rule MUST) | `flywheel-compounding` W=8 → W=3 + finding `f-2026-04-29-001` + `attempts.jsonl` ledger | `a17032ff` | warm 4 fail → 2 fail |
| 2 | Heavy-goal partial fix (extract-helper) | `go-complexity-ceiling` — `ExecuteRPIPhase` CC 27 → ~10 (+ helpers `resolveReadyCity`, `openSession`, `streamUntilTerminal`, `processGasCityFrame`, `classifyGasCityStreamError`) | `a1b66ba0` | 2 fail → 2 fail |
| 3 | Heavy-goal partial fix | `go-complexity-ceiling` — `RebuildProjections` CC 24 → ~9 via `applyJobLedgerEvent` | `49a04c67` | 2 fail → 2 fail |
| 4 | Heavy-goal partial fix | `go-complexity-ceiling` — `applyQueueEvent` CC 22 → ~7 via metadata/status split | `7d015081` | 2 fail → 2 fail |
| 5 | Heavy-goal partial fix | `go-complexity-ceiling` — `readRawFrame` CC 22 → ~17 via `assignSSEField`. **cli/ now green at threshold 20.** | `30ecff03` | 2 fail → 2 fail |
| 6 | **Heavy-goal flip** | `go-complexity-ceiling` — `RunForgeTier1` 19 → ~7 (`validateAndDefaultTier1Options`) + `ClassifyRPIArtifact` 19 → ~14 (`classifyCouncilArtifact`). **cli/internal/ green at 18; goal flipped pass.** | `03a010c4` | 2 fail → 1 fail |
| 7 | Generator-layer test hygiene | t.Chdir migration: `cli/cmd/ao/plans_test.go` (16 sites) | `01f38792` | 1 fail → 1 fail |
| 8 | Generator-layer test hygiene | t.Chdir migration: `dedup_test`, `config_test`, `metrics_flywheel_test`, `metrics_health_test` (19 sites, 4 files; both pattern A and B) | `4a9e52b4` | 1 fail → 1 fail |
| 9 | Generator-layer CI hygiene | Surface `(warn-only)` suffix on advisory CI jobs (`agentops-eval-advisory`, `security-toolchain-gate`, `doctor-check`, `check-test-staleness`) — closes harvested council finding "Rename warn-only CI checks with explicit suffix" | `1b52db48` | 1 fail → 1 fail |

Total t.Chdir migration footprint this run: **35 sites across 5 test files**, ~221 net lines deleted.

## Auto-reverts and transient-flake non-reverts

| Cycle | Action | Reason |
|---|---|---|
| — | None | No regressions observed; no transient flakes hit. |

**Cold-cache flake avoided.** During the prelude the first `ao goals measure` showed `go-cli-tests` failing (CC=8 cold) and the second showed it passing (warm cache). The run-brief calls this out explicitly: "A cold module cache makes `go-cli-tests` (240s timeout) flake on the first measure, falsely flipping a goal fail→pass between baseline and final." We discarded the cold measure and re-warmed via `cd cli && go test -count=1 ./...` before persisting the baseline. Stable warm baseline: 15 pass / 4 fail (no `go-cli-tests` regression).

## Quarantined goals + proposed weight reductions

| Goal | Weight before | Weight after | Status | Finding | Recommendation |
|---|---|---|---|---|---|
| `flywheel-compounding` | 8 | **3** | long-cycle, corpus-state | `f-2026-04-29-001` | Three consecutive nightlies (PR #165 → PR #174 → this run) failed to flip the metric because σρ requires multi-session human/agent citation activity. Lowered weight to 3 (matching `competitive-freshness`, the other slow-cadence gate). Diagnostic from PR #174's rich script remains actionable. **Rollback path:** if citations accumulate and gate stays green ≥7 consecutive nightlies, raise weight back to 5–8. |

## Heavy-goal attempt history

| Goal | Run | Angle | Outcome |
|---|---|---|---|
| `flywheel-compounding` | 2026-04-27 (PR #165) | observability: restore long-cycle/corpus-state Tags column stripped by PR #162 | metric unchanged |
| `flywheel-compounding` | 2026-04-28 (PR #174) | observability: route goal command to rich-diagnostic script | metric unchanged; diagnostic actionable |
| `flywheel-compounding` | **2026-04-29 (this run)** | **quarantine: weight 8 → 3 + GOALS.md note + finding** | **3-attempt rule fired; quarantine MUST per run-brief** |
| `go-complexity-ceiling` | 2026-04-28 (PR #174, cycle 1) | extract-helper: `probeRuntimeVersion` from `RunLiveRuntime` (CC 21 → 17) | flipped pass |
| `go-complexity-ceiling` | **2026-04-29 (this run, cycles 2–6)** | extract-helper × 5: `ExecuteRPIPhase`, `RebuildProjections`, `applyQueueEvent`, `readRawFrame`, `RunForgeTier1` + `ClassifyRPIArtifact` | flipped pass after recent daemon ship reintroduced regressions |

The `flywheel-compounding` row hits the run-brief's "3+ consecutive nightlies attempted the same goal without flipping the metric, the next attempt MUST be a quarantine proposal." This run's cycle 1 satisfies that — see commit `a17032ff` and `.agents/findings/f-2026-04-29-001.md`. The goal will not be re-attempted on the heavy axis until the citation corpus is non-empty.

The `go-complexity-ceiling` row took the same axis (extract-helper) as PR #174, but only **one** prior nightly took that axis (PR #165 didn't touch this goal), so the "prior 2 nightlies same axis" rule did not fire.

## Dream probe-results summary

- **Total morning packets:** 3
- **Stale ratio:** 1/3 = **33%** (above 30% but below 50% — `dream-curator-degraded` finding **not** triggered, matching yesterday's run)
- **Per-packet** (persisted to `.agents/dream/probe-results.jsonl`):
  - `01-audit-context-injection-latency` — `inconclusive` (investigative, no concrete deliverable)
  - `02-decompose-skills-crank-skill-md` — **stale** (claimed 248-line limit; `skills/crank/SKILL.md` is execution-tier with limit 800; current 660 lines is fine — same staleness as yesterday)
  - `03-replace-os-chdir` — `live` (42 test files still contain os.Chdir; cycles 7–8 consumed this packet)

Yesterday's PR #174 noted "tomorrow's curator could still benefit from probing before emitting packet #02" — same packet emitted again today. The signal continues to accumulate; if a third consecutive nightly receives the same stale packet, file `dream-curator-degraded` regardless of the 30% threshold.

## Findings opened, closed, deferred

- **Opened:** `f-2026-04-29-001` — flywheel-compounding quarantine proposal (force-tracked under `.agents/findings/`).
- **Closed:** none in bd (bd unavailable). Code goals: `go-complexity-ceiling` flipped pass; `compile-freshness` and `compile-no-oscillation` flipped pass via runtime artifact.
- **Deferred:**
  - `flywheel-compounding` re-attempt — locked at quarantine weight until citation corpus accumulates.
  - Pattern C/D (t.Cleanup-style) os.Chdir migration in `curate_test`, `inject_context_test`, `feedback_test`, `index_test`, `hooks_test` — first attempt this run hit `err`-shadowing in `curate_test` (the outer `oldDir, err := os.Getwd()` declares an `err` reused later by `err = runCurateVerify(...)`). Reverted; needs per-site review to keep `var err error` declarations where needed. Logged for next nightly.

## Stale-audit count

- **Inline-probe rejections during selection:** 2 (Dream packets #01 inconclusive + #02 stale — short-circuited before claim).
- **Explicit stale-audit cycles:** **0**.
- **Cap binding:** triage ran earlier today (PR #176; fast-forwarded into nightly base) AND the Dream probe-stale rate (33%) is below the 50% trigger AND below the 30% MUST-spend trigger. Cap binds at zero, exactly as the run-brief predicts: "If `triage` ran earlier today AND probe-stale rate < 30%, expect the cap to bind at zero." (Note: 33% is between 30% and 50% so cap binding is "may but not must"; this run had concrete heavy-goal work so didn't need to spend the bookkeeping cap.)

## bd / tracker degradation notes

- **`bd` is NOT available in this environment.** `scripts/install-bd.sh` returns curl 403. All bead-tracking ops are soft-fail throughout the run (Dream `bead-sync` reports `soft-fail (bd not available)`). New findings discovered this run are recorded in this PR body and as files under `.agents/findings/`, not in beads. Restoring local `bd` availability is independent of nightly work.

## Tag push degradation

- **`git push origin refs/tags/nightly/2026-04-29` failed with HTTP 403** (same endpoint signature as yesterday's tag push and today's bd-install 403). Per the run-brief rule, did not retry; falling back to the **branch ref `nightly/2026-04-29`** as the anchor for tomorrow's audit. Local tag exists at `1b52db48` for archival.

## Coordination notes

- **PR #176** (`triage/2026-04-29`, "chore(triage): mark 3 stale items consumed 2026-04-29") was open at run start. The nightly branch is based on `origin/triage/2026-04-29` (fast-forwarded into local main during prelude), so PR #176's `.agents/rpi/next-work.jsonl` rewrite + triage digest are inherited. **Files-touched overlap:** PR #176 touches `.agents/rpi/next-work.jsonl`, `.agents/triage/2026-04-29/baseline.json`, `.agents/triage/2026-04-29/digest.md`. This PR additionally touches GOALS.md, 4 daemon/llm/rpi/gascity Go files, 5 test files, 1 workflow file, and 2 new `.agents/findings/` + `.agents/goals/` files. **Disjoint** with PR #176's incremental write set; no conflicts expected.
- The `.agents/rpi/next-work.jsonl` mutations from `ao overnight start` and goal measurements were reset before each commit (per prelude rules) so each cycle's diff contains only its intended changes.
- The `cli/embedded/skills/compile/scripts/compile.sh` mutation that Dream's `make sync-hooks` produced was also reset — it appears to be sync-hooks correcting an accidental embedded drift introduced by the recent `feat(daemon)` commit (`6e7ed526`), but resyncing it in a nightly cycle would be bookkeeping rather than productive. Logged as "next nightly should re-run `make sync-hooks` and ship the embedded resync as a tracked cycle."

## Worktree-disposition gate FAIL

The known-false-positive worktree-disposition gate fails on a nightly branch (`canonical root /home/user/agentops is on nightly/2026-04-29; expected main`). Per the run-brief notes this is expected and not investigated. No env bypass exists in the current script.

## Commit links

- `a17032ff` — goals(flywheel-compounding): quarantine — reduce weight 8 → 3 (attempt 3)
- `a1b66ba0` — refactor(daemon): split ExecuteRPIPhase to drop CC 27 → ~10
- `49a04c67` — refactor(daemon): extract applyJobLedgerEvent to drop RebuildProjections CC 24 → ~9
- `7d015081` — refactor(daemon): split applyQueueEvent metadata vs status (CC 22 → ~7 each)
- `30ecff03` — refactor(gascity): extract assignSSEField from readRawFrame (CC 22 → ~17)
- `03a010c4` — refactor: drop final two CC 19 violations — go-complexity-ceiling flips
- `01f38792` — test(plans): replace defer os.Chdir restore with t.Chdir (16 sites)
- `4a9e52b4` — test(cmd/ao): replace defer os.Chdir restore with t.Chdir (19 sites, 4 files)
- `1b52db48` — ci(validate): surface warn-only suffix on continue-on-error jobs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sjd8AFQVEcZJgdv86nP7BU)_