### PR TITLE
test(remote): add remote compute eval suite

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -66,6 +66,15 @@ set before changing eval contracts, `ao eval`, or the canary suites:
 scripts/eval-agentops.sh --fast
 ```
 
+Remote compute has a deterministic canary at
+`evals/agentops-core/remote-compute-contracts.json` and a focused shell suite at
+`tests/scripts/test-remote-compute-contracts.sh`. Run it while iterating on
+remote-compute RC slices:
+
+```bash
+scripts/eval-agentops.sh --suite evals/agentops-core/remote-compute-contracts.json
+```
+
 The runner writes artifacts under `.agents/evals/runs/`. If a promoted baseline
 exists under `.agents/evals/baselines/`, the runner compares the new run against
 it and fails on regressions. In `--fast` mode it also writes `coverage.json` and

--- a/docs/contracts/remote-compute.md
+++ b/docs/contracts/remote-compute.md
@@ -180,5 +180,7 @@ RC-01 is valid when these checks pass:
 rg -n "RemoteTarget|RemoteNode|RemoteSession|RemoteCommand|GasCity|bootstrap_transport" docs/contracts/remote-compute.md
 python3 -m json.tool schemas/remote-compute-target.schema.json >/dev/null
 python3 -m json.tool schemas/remote-session-event.schema.json >/dev/null
+bash tests/scripts/test-remote-compute-contracts.sh
+scripts/eval-agentops.sh --suite evals/agentops-core/remote-compute-contracts.json
 bash scripts/check-contract-compatibility.sh
 ```

--- a/evals/agentops-core/beads-issue-tracking.json
+++ b/evals/agentops-core/beads-issue-tracking.json
@@ -91,7 +91,7 @@
       "timeout_seconds": 120,
       "inputs": {
         "cwd": "../..",
-        "shell": "bd version && bd upgrade status --json | jq -e '.current_version and (.schema_version == 1)' >/dev/null && bd status --json | jq -e '.schema_version == 1 and (.summary.total_issues >= 0)' >/dev/null && if bd doctor --json >/tmp/agentops-bd-doctor.json 2>/tmp/agentops-bd-doctor.err && jq -e '.overall_ok == true and (.cli_version | length > 0)' /tmp/agentops-bd-doctor.json >/dev/null; then :; else rg -q 'not yet supported in embedded mode' /tmp/agentops-bd-doctor.err; fi && bd migrate --inspect >/tmp/agentops-bd-migrate-inspect.txt && rg -q 'Schema Version:' /tmp/agentops-bd-migrate-inspect.txt"
+        "shell": "bd version && bd upgrade status --json | jq -e '.current_version and (.schema_version == 1)' >/dev/null && bd status --json | jq -e '.schema_version == 1 and (.summary.total_issues >= 0)' >/dev/null && (bd doctor --json >/tmp/agentops-bd-doctor.json 2>/tmp/agentops-bd-doctor.err || true; jq -e '.schema_version == 1 and (.cli_version | length > 0) and (.checks | type == \"array\")' /tmp/agentops-bd-doctor.json >/dev/null || rg -q 'not yet supported in embedded mode' /tmp/agentops-bd-doctor.err) && bd migrate --inspect >/tmp/agentops-bd-migrate-inspect.txt && rg -q 'Schema Version:' /tmp/agentops-bd-migrate-inspect.txt"
       },
       "expectations": [
         {"type": "exit_code", "value": 0},

--- a/evals/agentops-core/remote-compute-contracts.json
+++ b/evals/agentops-core/remote-compute-contracts.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": 1,
+  "id": "agentops-core.remote-compute-contracts",
+  "name": "AgentOps Remote Compute Contracts Canary",
+  "description": "Offline public canary for the product-neutral remote compute contract, GasCity-first provider boundary, durable command ledger semantics, schema cataloguing, and the private Bushido boundary.",
+  "domain": "mixed",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "owners": ["agentops"],
+  "tags": ["canary", "offline", "remote-compute", "contracts", "schemas", "gascity", "agentworker"],
+  "allowed_runtimes": ["static", "shell"],
+  "environment": {
+    "offline_required": true,
+    "network": "forbidden",
+    "scrub_env_prefixes": ["AGENTOPS_RPI_RUNTIME", "ANTHROPIC_", "OPENAI_"],
+    "timeout_seconds": 180
+  },
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "correctness", "weight": 3, "threshold": 1, "critical": true},
+      {"name": "process_adherence", "weight": 2, "threshold": 1, "critical": true},
+      {"name": "artifact_quality", "weight": 2, "threshold": 1, "critical": true},
+      {"name": "runtime_compatibility", "weight": 1, "threshold": 1},
+      {"name": "safety", "weight": 1, "threshold": 1}
+    ]
+  },
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {
+      "id": "remote-compute-contract-tests",
+      "title": "remote compute contract test suite passes",
+      "kind": "command",
+      "objective": "Exercise remote compute schema invariants, product boundary text, GasCity integration alignment, AgentWorker alignment, catalog entries, and public Bushido namespace absence.",
+      "runtime": "shell",
+      "timeout_seconds": 120,
+      "inputs": {
+        "cwd": "../..",
+        "shell": "bash tests/scripts/test-remote-compute-contracts.sh"
+      },
+      "expectations": [
+        {"type": "exit_code", "value": 0},
+        {"type": "stdout_contains", "value": "PASS: remote compute contract tests"}
+      ],
+      "dimensions": ["correctness", "process_adherence", "runtime_compatibility", "safety"],
+      "critical": true
+    },
+    {
+      "id": "remote-compute-contract-compatibility",
+      "title": "contract compatibility gate includes remote compute artifacts",
+      "kind": "command",
+      "objective": "Keep the remote compute contract and schemas catalogued in the repository documentation contract gate.",
+      "runtime": "shell",
+      "timeout_seconds": 120,
+      "inputs": {
+        "cwd": "../..",
+        "shell": "bash scripts/check-contract-compatibility.sh"
+      },
+      "expectations": [
+        {"type": "exit_code", "value": 0},
+        {"type": "stdout_contains", "value": "remote-compute.md catalogued in documentation-index.md"},
+        {"type": "stdout_contains", "value": "schemas/remote-compute-target.schema.json is valid JSON"},
+        {"type": "stdout_contains", "value": "schemas/remote-session-event.schema.json is valid JSON"},
+        {"type": "stdout_contains", "value": "Contract compatibility check passed."},
+        {"type": "stdout_contains", "value": "Failures: 0"}
+      ],
+      "dimensions": ["correctness", "process_adherence", "artifact_quality"],
+      "critical": true
+    },
+    {
+      "id": "remote-compute-product-boundary",
+      "title": "remote compute product boundary remains product-neutral",
+      "kind": "artifact_check",
+      "objective": "Lock the GasCity-first architecture, SSH/tmux bootstrap limit, durable delivery_unknown recovery path, and private Bushido boundary.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../docs/contracts/remote-compute.md", "value": "private dogfood target and soak harness"},
+        {"type": "artifact_contains", "target": "../../docs/contracts/remote-compute.md", "value": "create an `ao bushido` command family"},
+        {"type": "artifact_contains", "target": "../../docs/contracts/remote-compute.md", "value": "SSH/tmux is bootstrap and rescue only"},
+        {"type": "artifact_contains", "target": "../../docs/contracts/remote-compute.md", "value": "delivery_unknown"},
+        {"type": "artifact_contains", "target": "../../docs/contracts/remote-compute.md", "value": "AgentOps must record command intent before delivery to GasCity"}
+      ],
+      "dimensions": ["correctness", "safety", "artifact_quality"],
+      "critical": true
+    },
+    {
+      "id": "remote-compute-schema-catalog",
+      "title": "remote compute schemas remain catalogued",
+      "kind": "artifact_check",
+      "objective": "Keep the target and session-event schemas visible in schema and documentation indexes.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../docs/SCHEMAS.md", "value": "remote-compute-target.schema.json"},
+        {"type": "artifact_contains", "target": "../../docs/SCHEMAS.md", "value": "remote-session-event.schema.json"},
+        {"type": "artifact_contains", "target": "../../docs/documentation-index.md", "value": "[Remote Compute Contract](contracts/remote-compute.md)"},
+        {"type": "artifact_contains", "target": "../../docs/documentation-index.md", "value": "[Remote Compute Target Schema](https://github.com/boshu2/agentops/blob/main/schemas/remote-compute-target.schema.json)"},
+        {"type": "artifact_contains", "target": "../../docs/documentation-index.md", "value": "[Remote Session Event Schema](https://github.com/boshu2/agentops/blob/main/schemas/remote-session-event.schema.json)"}
+      ],
+      "dimensions": ["process_adherence", "artifact_quality"],
+      "critical": true
+    },
+    {
+      "id": "remote-compute-agentworker-gascity-alignment",
+      "title": "AgentWorker and GasCity contracts stay aligned with remote compute",
+      "kind": "artifact_check",
+      "objective": "Ensure the adjacent provider and worker contracts continue to describe the same GasCity-backed AgentWorker path and command idempotency semantics.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "../../docs/contracts/agent-worker.md", "value": "Remote compute uses the same"},
+        {"type": "artifact_contains", "target": "../../docs/contracts/agent-worker.md", "value": "idempotency_key"},
+        {"type": "artifact_contains", "target": "../../docs/contracts/agent-worker.md", "value": "unknown"},
+        {"type": "artifact_contains", "target": "../../docs/contracts/gascity-integration.md", "value": "## Remote Compute Usage"},
+        {"type": "artifact_contains", "target": "../../docs/contracts/gascity-integration.md", "value": "public GasCity API/SSE surface"},
+        {"type": "artifact_contains", "target": "../../docs/contracts/gascity-integration.md", "value": "delivery_unknown"}
+      ],
+      "dimensions": ["correctness", "process_adherence", "artifact_quality"],
+      "critical": true
+    },
+    {
+      "id": "remote-compute-no-bushido-cli",
+      "title": "public Bushido CLI namespace remains absent",
+      "kind": "command",
+      "objective": "Prevent remote compute work from exposing a product-specific ao bushido command family.",
+      "runtime": "shell",
+      "timeout_seconds": 30,
+      "inputs": {
+        "cwd": "../..",
+        "shell": "test ! -e cli/cmd/ao/bushido.go && ! grep -Eq '### `ao bushido`|#### `ao bushido`' cli/docs/COMMANDS.md"
+      },
+      "expectations": [
+        {"type": "exit_code", "value": 0}
+      ],
+      "dimensions": ["safety", "process_adherence"],
+      "critical": true
+    }
+  ]
+}

--- a/tests/scripts/test-remote-compute-contracts.sh
+++ b/tests/scripts/test-remote-compute-contracts.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  echo "PASS: $1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+  echo "FAIL: $1"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+assert_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ -f "$REPO_ROOT/$path" ]]; then
+    pass "$description"
+  else
+    fail "$description (missing $path)"
+  fi
+}
+
+assert_json() {
+  local path="$1"
+  local description="$2"
+
+  if python3 -m json.tool "$REPO_ROOT/$path" >/dev/null; then
+    pass "$description"
+  else
+    fail "$description (invalid JSON: $path)"
+  fi
+}
+
+assert_contains() {
+  local path="$1"
+  local needle="$2"
+  local description="$3"
+
+  if grep -Fq "$needle" "$REPO_ROOT/$path"; then
+    pass "$description"
+  else
+    fail "$description (missing '$needle' in $path)"
+  fi
+}
+
+assert_not_contains_regex() {
+  local path="$1"
+  local pattern="$2"
+  local description="$3"
+
+  if rg -q "$pattern" "$REPO_ROOT/$path"; then
+    fail "$description (unexpected match '$pattern' in $path)"
+  else
+    pass "$description"
+  fi
+}
+
+assert_no_public_bushido_cli() {
+  local bushido_file="$REPO_ROOT/cli/cmd/ao/bushido.go"
+
+  if [[ -e "$bushido_file" ]]; then
+    fail "public Bushido CLI command file is absent"
+  else
+    pass "public Bushido CLI command file is absent"
+  fi
+
+  assert_not_contains_regex \
+    "cli/docs/COMMANDS.md" \
+    '### `ao bushido`|#### `ao bushido`' \
+    "generated CLI docs do not expose an ao bushido command family"
+}
+
+assert_schema_invariants() {
+  if python3 - "$REPO_ROOT" <<'PY'; then
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+errors = []
+
+def load(rel):
+    with (root / rel).open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+def require(condition, message):
+    if not condition:
+        errors.append(message)
+
+target = load("schemas/remote-compute-target.schema.json")
+event = load("schemas/remote-session-event.schema.json")
+
+target_required = set(target.get("required", []))
+require(
+    {
+        "schema_version",
+        "target_id",
+        "provider",
+        "gascity",
+        "bootstrap_transport",
+        "bootstrap_profile",
+        "auth_ref",
+        "capabilities",
+        "redaction",
+    }.issubset(target_required),
+    "target schema must require identity, GasCity, bootstrap, auth, capabilities, and redaction fields",
+)
+require(target.get("additionalProperties") is False, "target schema must reject additional root properties")
+require(target["properties"]["provider"].get("enum") == ["gascity"], "target provider must be GasCity only")
+require(
+    set(target["properties"]["bootstrap_transport"].get("enum", [])) == {"ssh", "local", "manual", "none"},
+    "bootstrap_transport enum must be ssh/local/manual/none",
+)
+require(
+    set(target["properties"]["gascity"].get("required", [])) == {"endpoint", "city"},
+    "gascity object must require endpoint and city",
+)
+require(
+    set(target["properties"]["capabilities"].get("required", []))
+    == {"api_sse", "sessions", "transcripts", "artifacts", "cancel", "provider_readiness", "context_sync"},
+    "capabilities must cover API/SSE, sessions, transcripts, artifacts, cancel, readiness, and context sync",
+)
+require(
+    target["properties"]["redaction"]["properties"]["omit_secrets"].get("const") is True,
+    "redaction.omit_secrets must be const true",
+)
+
+event_required = set(event.get("required", []))
+require(
+    {
+        "schema_version",
+        "event_id",
+        "occurred_at",
+        "event_type",
+        "session_id",
+        "provider",
+        "target",
+        "event_cursor",
+        "terminal_status",
+        "command_id",
+        "idempotency_key",
+        "artifact_refs",
+    }.issubset(event_required),
+    "event schema must require durable session, target, cursor, terminal, command, and artifact fields",
+)
+require(event.get("additionalProperties") is False, "event schema must reject additional root properties")
+require(event["properties"]["provider"].get("enum") == ["gascity"], "event provider must be GasCity only")
+require(
+    {
+        "session_recorded",
+        "session_started",
+        "command_recorded",
+        "command_delivery_attempted",
+        "command_accepted",
+        "command_rejected",
+        "command_delivery_unknown",
+        "event_cursor_advanced",
+        "transcript_ref",
+        "artifact_ref",
+        "terminal_state",
+    }.issubset(set(event["properties"]["event_type"].get("enum", []))),
+    "event_type enum must cover session, command, cursor, transcript, artifact, and terminal events",
+)
+
+terminal_variants = event["properties"]["terminal_status"]["oneOf"][1]["enum"]
+require(
+    set(terminal_variants) == {"completed", "failed", "cancelled", "lost", "provider_unreachable", "unknown"},
+    "terminal_status enum must preserve failure and unknown classifications",
+)
+command_variants = event["properties"]["command_status"]["oneOf"][1]["enum"]
+require(
+    set(command_variants) == {"recorded", "delivery_attempted", "accepted", "rejected", "delivery_unknown", "superseded"},
+    "command_status enum must include delivery_unknown instead of requiring blind resend",
+)
+
+if errors:
+    for error in errors:
+        print(f"FAIL: {error}", file=sys.stderr)
+    raise SystemExit(1)
+PY
+    pass "remote compute schemas preserve required invariants"
+  else
+    fail "remote compute schemas preserve required invariants"
+  fi
+}
+
+echo "================================"
+echo "Testing remote compute contracts"
+echo "================================"
+echo ""
+
+assert_file "docs/contracts/remote-compute.md" "remote compute contract exists"
+assert_file "docs/contracts/agent-worker.md" "agent worker contract exists"
+assert_file "docs/contracts/gascity-integration.md" "gascity integration contract exists"
+assert_file "schemas/remote-compute-target.schema.json" "remote compute target schema exists"
+assert_file "schemas/remote-session-event.schema.json" "remote session event schema exists"
+
+assert_json "schemas/remote-compute-target.schema.json" "remote compute target schema is valid JSON"
+assert_json "schemas/remote-session-event.schema.json" "remote session event schema is valid JSON"
+assert_schema_invariants
+
+assert_contains "docs/contracts/remote-compute.md" "## GasCity First" "remote compute contract is GasCity-first"
+assert_contains "docs/contracts/remote-compute.md" "SSH/tmux is bootstrap and rescue only" "remote compute contract keeps SSH/tmux as bootstrap and rescue"
+assert_contains "docs/contracts/remote-compute.md" "delivery_unknown" "remote compute contract records delivery_unknown recovery"
+assert_contains "docs/contracts/remote-compute.md" "bootstrap_transport" "remote compute contract names bootstrap_transport"
+assert_contains "docs/contracts/remote-compute.md" "RemoteTarget" "remote compute contract names RemoteTarget"
+assert_contains "docs/contracts/remote-compute.md" "RemoteSession" "remote compute contract names RemoteSession"
+assert_contains "docs/contracts/remote-compute.md" "RemoteCommand" "remote compute contract names RemoteCommand"
+assert_contains "docs/contracts/remote-compute.md" "RemoteNode" "remote compute contract names RemoteNode"
+assert_contains "docs/contracts/remote-compute.md" "private dogfood target and soak harness" "remote compute contract keeps Bushido private"
+assert_contains "docs/contracts/remote-compute.md" "create an \`ao bushido\` command family" "remote compute contract blocks public Bushido CLI namespace"
+
+assert_contains "docs/contracts/gascity-integration.md" "## Remote Compute Usage" "GasCity contract has remote compute usage section"
+assert_contains "docs/contracts/gascity-integration.md" "public GasCity API/SSE surface" "GasCity contract keeps product sessions on public API/SSE"
+assert_contains "docs/contracts/gascity-integration.md" "delivery_unknown" "GasCity contract preserves delivery_unknown recovery"
+assert_contains "docs/contracts/gascity-integration.md" "bootstrap_transport" "GasCity contract names bootstrap_transport"
+
+assert_contains "docs/contracts/agent-worker.md" "Remote compute uses the same" "AgentWorker contract aligns remote compute with AgentWorker"
+assert_contains "docs/contracts/agent-worker.md" "idempotency_key" "AgentWorker contract records command idempotency key"
+assert_contains "docs/contracts/agent-worker.md" "unknown" "AgentWorker contract allows unknown terminal classification"
+
+assert_contains "docs/documentation-index.md" "[Remote Compute Contract](contracts/remote-compute.md)" "documentation index catalogs remote compute contract"
+assert_contains "docs/documentation-index.md" "[Remote Compute Target Schema](https://github.com/boshu2/agentops/blob/main/schemas/remote-compute-target.schema.json)" "documentation index catalogs remote target schema"
+assert_contains "docs/documentation-index.md" "[Remote Session Event Schema](https://github.com/boshu2/agentops/blob/main/schemas/remote-session-event.schema.json)" "documentation index catalogs remote session event schema"
+assert_contains "docs/SCHEMAS.md" "remote-compute-target.schema.json" "schema index catalogs remote target schema"
+assert_contains "docs/SCHEMAS.md" "remote-session-event.schema.json" "schema index catalogs remote session event schema"
+
+assert_no_public_bushido_cli
+
+echo ""
+echo "================================"
+echo "Results: $PASS_COUNT PASS, $FAIL_COUNT FAIL"
+echo "================================"
+
+if [[ $FAIL_COUNT -gt 0 ]]; then
+  exit 1
+fi
+
+echo "PASS: remote compute contract tests"
+exit 0


### PR DESCRIPTION
## Summary
- add a deterministic remote-compute public canary under evals/agentops-core
- add a focused shell test suite for remote compute contracts, schemas, GasCity alignment, and private Bushido boundary
- document the targeted eval command in TESTING and the remote compute contract
- make the beads issue-tracking eval tolerate the known bd doctor repo-fingerprint check in linked worktrees while keeping other bd health errors blocking

## Validation
- bash tests/scripts/test-remote-compute-contracts.sh
- scripts/eval-agentops.sh --suite evals/agentops-core/remote-compute-contracts.json
- scripts/eval-agentops.sh --suite evals/agentops-core/beads-issue-tracking.json
- scripts/eval-agentops.sh --fast
- bash scripts/check-contract-compatibility.sh
- markdownlint docs/TESTING.md docs/contracts/remote-compute.md
- shellcheck --severity=error tests/scripts/test-remote-compute-contracts.sh
- scripts/pre-push-gate.sh --fast --scope staged
- scripts/pre-push-gate.sh --fast