### PR TITLE
feat(eval): classify evidence and audit baselines

### DIFF
--- a/.agents/learnings/2026-04-29-quick-eval-evidence-kind-baseline-policy.md
+++ b/.agents/learnings/2026-04-29-quick-eval-evidence-kind-baseline-policy.md
@@ -1,0 +1,30 @@
+---
+type: learning
+source: retro-quick
+source_bead: ag-v29
+source_phase: validate
+date: 2026-04-29
+maturity: provisional
+utility: 0.5
+reward_count: 0
+helpful_count: 0
+harmful_count: 0
+confidence: 0.0000
+---
+
+# Learning: Eval Evidence Kind And Baseline Policy Are Separate Axes
+
+**Category**: testing
+**Confidence**: medium
+
+## What We Learned
+
+Do not infer an eval case's evidence kind from `baseline_policy.mode=compare`.
+Baseline comparison is governance metadata about candidate-vs-baseline handling,
+while evidence kind describes what the case itself proves. Collapsing the two
+would make broad baseline adoption hide the real mix of contract canaries, gate
+wrappers, behavior fixtures, holdouts, and runtime checks.
+
+## Source
+
+Quick capture via `$validation` during ag-v29 RPI implementation.

--- a/.agents/rpi/phase-2-summary-2026-04-29-eval-suite-implementation.md
+++ b/.agents/rpi/phase-2-summary-2026-04-29-eval-suite-implementation.md
@@ -1,0 +1,29 @@
+# Phase 2 Summary: Crank Implementation
+
+- **Epic:** ag-v29
+- **Status:** PARTIAL
+- **Timestamp:** 2026-04-29T20:52:00Z
+- **Completed issues:** ag-v29.1, ag-v29.2
+- **Remaining issues:** ag-v29.3, ag-v29.4, ag-v29.5, ag-v29.6, ag-cxh
+- **Branch:** codex/eval-suite-implementation
+
+## Delivered
+
+- Added first-class eval `evidence_kind` schema fields, Go constants, validation, coverage aggregation, JSON output, and `--require-evidence-kind`.
+- Documented what each evidence kind proves and does not prove in the eval environment contract.
+- Added `ao eval baseline-audit` to compare suite baseline policy with promoted baseline files.
+- Aligned 54 public canary suites with promoted baselines using `baseline_policy.mode=compare`; kept the two suites with no baseline as deliberate `none`.
+- Made `scripts/eval-agentops.sh --fast` policy-aware so missing-baseline warnings only fire when suite policy expects a baseline.
+- Updated brittle canaries affected by the new command and generated CLI docs.
+
+## Proof
+
+- `cd cli && env -u AGENTOPS_RPI_RUNTIME go test ./cmd/ao ./internal/eval`
+- `cd cli && env -u AGENTOPS_RPI_RUNTIME go run ./cmd/ao eval coverage --root ../evals/agentops-core --json | jq -e '.evidence_kinds'`
+- `cd cli && env -u AGENTOPS_RPI_RUNTIME go run ./cmd/ao eval baseline-audit --root ../evals/agentops-core --baseline-dir ../.agents/evals/baselines --json | jq -e '.policy_mismatch_count == 0'`
+- `scripts/eval-agentops.sh --fast`
+- `scripts/pre-push-gate.sh --fast --scope worktree`
+
+## Follow-Up
+
+- ag-cxh records the 54 stale baseline suite hashes surfaced by the new audit. Policy is aligned, but baseline hashes were not refreshed in this implementation pass.

--- a/.agents/rpi/phase-3-summary-2026-04-29-eval-suite-implementation.md
+++ b/.agents/rpi/phase-3-summary-2026-04-29-eval-suite-implementation.md
@@ -1,0 +1,21 @@
+# Phase 3 Summary: Validation
+
+- **Epic:** ag-v29
+- **Vibe verdict:** PASS
+- **Post-mortem verdict:** WARN
+- **Retro:** captured
+- **Forge:** queued
+- **Complexity:** standard
+- **Status:** DONE
+- **Timestamp:** 2026-04-29T20:52:00Z
+
+## Four-Surface Closure
+
+- **Code:** PASS. Go tests, eval command checks, shellcheck via pre-push, and changed-scope race tests passed.
+- **Documentation:** PASS. Eval contract and generated CLI reference were updated; doc-release and mkdocs strict checks passed.
+- **Examples:** PASS. `ao eval baseline-audit --help`, `ao eval coverage --json`, command-surface smoke, and CLI docs parity passed.
+- **Proof:** PASS. Fast eval canaries passed with `failures=0 warnings=0`; baseline audit reported `policy_mismatch_count=0`.
+
+## Known Residual Risk
+
+The full ag-v29 epic is not complete. This validation covers the implemented taxonomy and baseline-policy slices only. Remaining work is still tracked in ag-v29.3 through ag-v29.6, plus ag-cxh for stale baseline hash refresh.

--- a/cli/cmd/ao/cobra_commands_test.go
+++ b/cli/cmd/ao/cobra_commands_test.go
@@ -443,7 +443,7 @@ func TestCobraCommandTreeRegistration(t *testing.T) {
 		"autodev":    {"init", "validate", "show"},
 		"beads":      {"verify", "lint", "harvest"},
 		"daemon":     {"run", "ready", "status", "service"},
-		"eval":       {"run", "compare", "baseline", "scorecard", "coverage"},
+		"eval":       {"run", "compare", "baseline", "baseline-audit", "scorecard", "coverage"},
 		"factory":    {"start"},
 		"goals":      {"validate", "measure", "drift"},
 		"knowledge":  {"activate", "beliefs", "playbooks", "brief", "gaps"},

--- a/cli/cmd/ao/eval.go
+++ b/cli/cmd/ao/eval.go
@@ -12,24 +12,27 @@ import (
 )
 
 var (
-	evalRunOutput        string
-	evalRunID            string
-	evalRunRuntime       string
-	evalRunBaseline      string
-	evalCompareOutput    string
-	evalCompareMaxAgg    float64
-	evalCompareMaxDim    float64
-	evalScorecardOutput  string
-	evalScorecardKind    string
-	evalScorecardMaxCat  float64
-	evalBaselineOutput   string
-	evalBaselineBy       string
-	evalBaselineReason   string
-	evalCoverageRoot     string
-	evalCoverageDomains  []string
-	evalCoverageDims     []string
-	evalCoverageRuntimes []string
-	evalConfigured       bool
+	evalRunOutput         string
+	evalRunID             string
+	evalRunRuntime        string
+	evalRunBaseline       string
+	evalCompareOutput     string
+	evalCompareMaxAgg     float64
+	evalCompareMaxDim     float64
+	evalScorecardOutput   string
+	evalScorecardKind     string
+	evalScorecardMaxCat   float64
+	evalBaselineOutput    string
+	evalBaselineBy        string
+	evalBaselineReason    string
+	evalBaselineAuditRoot string
+	evalBaselineAuditDir  string
+	evalCoverageRoot      string
+	evalCoverageDomains   []string
+	evalCoverageEvidence  []string
+	evalCoverageDims      []string
+	evalCoverageRuntimes  []string
+	evalConfigured        bool
 )
 
 var evalCmd = &cobra.Command{
@@ -141,6 +144,43 @@ var evalBaselineCmd = &cobra.Command{
 	},
 }
 
+var evalBaselineAuditCmd = &cobra.Command{
+	Use:   "baseline-audit [suite.json ...]",
+	Short: "Audit eval suite baseline policy against promoted baselines",
+	Args:  cobra.ArbitraryArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		roots := []string{}
+		if len(args) == 0 {
+			roots = append(roots, evalBaselineAuditRoot)
+		}
+		report, err := aoeval.AuditBaselinePolicy(aoeval.BaselineAuditOptions{
+			SuitePaths:  args,
+			Roots:       roots,
+			BaselineDir: evalBaselineAuditDir,
+		})
+		if err != nil {
+			return err
+		}
+		if GetOutput() == "json" {
+			return writeEvalJSON(cmd, report)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Eval baseline audit: %d suites, %d baselines, %d policy mismatches\n", report.SuiteCount, report.BaselineCount, report.PolicyMismatchCount)
+		if len(report.MissingCompareBaselines) > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "Missing compare baselines: %d\n", len(report.MissingCompareBaselines))
+		}
+		if len(report.UnexpectedBaselinesForNone) > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "Unexpected baselines for none policy: %d\n", len(report.UnexpectedBaselinesForNone))
+		}
+		if len(report.OrphanBaselines) > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "Orphan baselines: %d\n", len(report.OrphanBaselines))
+		}
+		if len(report.StaleSuiteHashes) > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "Stale suite hashes: %d\n", len(report.StaleSuiteHashes))
+		}
+		return nil
+	},
+}
+
 var evalScorecardCmd = &cobra.Command{
 	Use:   "scorecard <candidate-run.json> [baseline-run.json]",
 	Short: "Build an eval scorecard from run records",
@@ -194,11 +234,12 @@ var evalCoverageCmd = &cobra.Command{
 			roots = append(roots, evalCoverageRoot)
 		}
 		report, err := aoeval.BuildCoverageReport(aoeval.CoverageOptions{
-			SuitePaths:         args,
-			Roots:              roots,
-			RequiredDomains:    evalCoverageDomains,
-			RequiredDimensions: evalCoverageDims,
-			RequiredRuntimes:   evalCoverageRuntimes,
+			SuitePaths:            args,
+			Roots:                 roots,
+			RequiredDomains:       evalCoverageDomains,
+			RequiredEvidenceKinds: evalCoverageEvidence,
+			RequiredDimensions:    evalCoverageDims,
+			RequiredRuntimes:      evalCoverageRuntimes,
 		})
 		if err != nil {
 			return err
@@ -211,6 +252,11 @@ var evalCoverageCmd = &cobra.Command{
 			fmt.Fprintf(cmd.OutOrStdout(), "Missing required domains: %s\n", strings.Join(report.MissingRequiredDomains, ", "))
 		} else if len(report.RequiredDomains) > 0 {
 			fmt.Fprintln(cmd.OutOrStdout(), "Required domains covered")
+		}
+		if len(report.MissingRequiredEvidenceKinds) > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "Missing required evidence kinds: %s\n", strings.Join(report.MissingRequiredEvidenceKinds, ", "))
+		} else if len(report.RequiredEvidenceKinds) > 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "Required evidence kinds covered")
 		}
 		if len(report.MissingRequiredDimensions) > 0 {
 			fmt.Fprintf(cmd.OutOrStdout(), "Missing required dimensions: %s\n", strings.Join(report.MissingRequiredDimensions, ", "))
@@ -257,8 +303,12 @@ func configureEvalCommand() {
 	evalBaselineCmd.Flags().StringVar(&evalBaselineBy, "promoted-by", "", "identity promoting the baseline")
 	evalBaselineCmd.Flags().StringVar(&evalBaselineReason, "rationale", "", "rationale for promoting the baseline")
 
+	evalBaselineAuditCmd.Flags().StringVar(&evalBaselineAuditRoot, "root", "evals/agentops-core", "suite root to scan when no suite paths are provided")
+	evalBaselineAuditCmd.Flags().StringVar(&evalBaselineAuditDir, "baseline-dir", ".agents/evals/baselines", "promoted baseline directory")
+
 	evalCoverageCmd.Flags().StringVar(&evalCoverageRoot, "root", "evals/agentops-core", "suite root to scan when no suite paths are provided")
 	evalCoverageCmd.Flags().StringArrayVar(&evalCoverageDomains, "require-domain", aoeval.DefaultCoverageDomains, "required product domain for missing-domain reporting")
+	evalCoverageCmd.Flags().StringArrayVar(&evalCoverageEvidence, "require-evidence-kind", nil, "required evidence kind for missing-evidence-kind reporting")
 	evalCoverageCmd.Flags().StringArrayVar(&evalCoverageDims, "require-dimension", aoeval.DefaultCoverageDimensions, "required score dimension for missing-dimension reporting")
 	evalCoverageCmd.Flags().StringArrayVar(&evalCoverageRuntimes, "require-runtime", aoeval.DefaultCoverageRuntimes, "required deterministic runtime for missing-runtime reporting")
 
@@ -267,7 +317,7 @@ func configureEvalCommand() {
 	evalScorecardCmd.Flags().Float64Var(&evalScorecardMaxCat, "max-category-regression", 0, "allowed per-category regression before verdict becomes regression")
 	_ = evalScorecardCmd.RegisterFlagCompletionFunc("kind", staticCompletionFunc(string(aoeval.ScorecardKindRPI), string(aoeval.ScorecardKindSkillChange)))
 
-	evalCmd.AddCommand(evalRunCmd, evalCompareCmd, evalBaselineCmd, evalScorecardCmd, evalCoverageCmd)
+	evalCmd.AddCommand(evalRunCmd, evalCompareCmd, evalBaselineCmd, evalBaselineAuditCmd, evalScorecardCmd, evalCoverageCmd)
 }
 
 func parseEvalRuntime(value string) (aoeval.Runtime, error) {

--- a/cli/cmd/ao/eval_test.go
+++ b/cli/cmd/ao/eval_test.go
@@ -241,8 +241,57 @@ func TestEvalCoverageCommandJSON(t *testing.T) {
 	if report.Domains["cli"].SuiteCount != 1 {
 		t.Fatalf("cli domain coverage = %+v, want one suite", report.Domains["cli"])
 	}
+	if report.EvidenceKinds[string(aoeval.EvidenceKindContractCanary)].CaseCount != 1 {
+		t.Fatalf("contract_canary evidence coverage = %+v, want one case", report.EvidenceKinds[string(aoeval.EvidenceKindContractCanary)])
+	}
 	if len(report.MissingRequiredDomains) == 0 {
 		t.Fatalf("missing required domains empty; want gaps for non-cli domains")
+	}
+}
+
+func TestEvalBaselineAuditCommandJSON(t *testing.T) {
+	withEvalCommand(t)
+	dir := t.TempDir()
+	writeEvalCmdFile(t, filepath.Join(dir, "fixture.txt"), "ok\n")
+	writeEvalCmdFile(t, filepath.Join(dir, "suite.json"), `{
+  "schema_version": 1,
+  "id": "baseline.audit",
+  "name": "Baseline Audit",
+  "domain": "cli",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "allowed_runtimes": ["static"],
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "correctness", "weight": 1, "threshold": 1}
+    ]
+  },
+  "baseline_policy": {"mode": "compare"},
+  "cases": [
+    {
+      "id": "fixture",
+      "title": "fixture",
+      "kind": "artifact_check",
+      "objective": "fixture",
+      "expectations": [
+        {"type": "file_exists", "target": "fixture.txt"}
+      ],
+      "critical": true
+    }
+  ]
+}`)
+
+	out, err := executeCommand("eval", "baseline-audit", "--root", dir, "--baseline-dir", filepath.Join(dir, "baselines"), "--json")
+	if err != nil {
+		t.Fatalf("ao eval baseline-audit failed: %v\noutput: %s", err, out)
+	}
+	var report aoeval.BaselineAuditReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("baseline audit JSON parse failed: %v\noutput: %s", err, out)
+	}
+	if report.PolicyMismatchCount != 1 || len(report.MissingCompareBaselines) != 1 {
+		t.Fatalf("baseline audit report = %+v, want one missing compare baseline", report)
 	}
 }
 

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -1069,6 +1069,22 @@ ao eval baseline <run.json> [flags]
       --rationale string     rationale for promoting the baseline
 ```
 
+#### `ao eval baseline-audit`
+
+Audit eval suite baseline policy against promoted baselines
+
+```
+ao eval baseline-audit [suite.json ...] [flags]
+```
+
+**Flags:**
+
+```
+      --baseline-dir string   promoted baseline directory (default ".agents/evals/baselines")
+  -h, --help                  help for baseline-audit
+      --root string           suite root to scan when no suite paths are provided (default "evals/agentops-core")
+```
+
 #### `ao eval compare`
 
 Compare an eval run against a baseline
@@ -1097,11 +1113,12 @@ ao eval coverage [suite.json ...] [flags]
 **Flags:**
 
 ```
-  -h, --help                            help for coverage
-      --require-dimension stringArray   required score dimension for missing-dimension reporting (default [correctness,process_adherence,artifact_quality,runtime_compatibility,efficiency,safety,learning_closure])
-      --require-domain stringArray      required product domain for missing-domain reporting (default [cli,hook,skill,rpi,runtime,retrieval,scenario,mixed,security])
-      --require-runtime stringArray     required deterministic runtime for missing-runtime reporting (default [static,shell,mock])
-      --root string                     suite root to scan when no suite paths are provided (default "evals/agentops-core")
+  -h, --help                                help for coverage
+      --require-dimension stringArray       required score dimension for missing-dimension reporting (default [correctness,process_adherence,artifact_quality,runtime_compatibility,efficiency,safety,learning_closure])
+      --require-domain stringArray          required product domain for missing-domain reporting (default [cli,hook,skill,rpi,runtime,retrieval,scenario,mixed,security])
+      --require-evidence-kind stringArray   required evidence kind for missing-evidence-kind reporting
+      --require-runtime stringArray         required deterministic runtime for missing-runtime reporting (default [static,shell,mock])
+      --root string                         suite root to scan when no suite paths are provided (default "evals/agentops-core")
 ```
 
 #### `ao eval run`

--- a/cli/internal/eval/baseline_audit.go
+++ b/cli/internal/eval/baseline_audit.go
@@ -1,0 +1,155 @@
+package eval
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type BaselineAuditOptions struct {
+	SuitePaths  []string
+	Roots       []string
+	BaselineDir string
+}
+
+type BaselineAuditReport struct {
+	SuiteCount                 int                    `json:"suite_count"`
+	BaselineCount              int                    `json:"baseline_count"`
+	PolicyMismatchCount        int                    `json:"policy_mismatch_count"`
+	MissingCompareBaselines    []BaselineAuditFinding `json:"missing_compare_baselines,omitempty"`
+	UnexpectedBaselinesForNone []BaselineAuditFinding `json:"unexpected_baselines_for_none,omitempty"`
+	OrphanBaselines            []BaselineAuditFinding `json:"orphan_baselines,omitempty"`
+	StaleSuiteHashes           []BaselineAuditFinding `json:"stale_suite_hashes,omitempty"`
+}
+
+type BaselineAuditFinding struct {
+	SuiteID      string `json:"suite_id,omitempty"`
+	SuitePath    string `json:"suite_path,omitempty"`
+	BaselinePath string `json:"baseline_path,omitempty"`
+	Mode         string `json:"mode,omitempty"`
+	ExpectedSHA  string `json:"expected_sha,omitempty"`
+	ActualSHA    string `json:"actual_sha,omitempty"`
+}
+
+func AuditBaselinePolicy(opts BaselineAuditOptions) (*BaselineAuditReport, error) {
+	paths, err := coverageSuitePaths(CoverageOptions{
+		SuitePaths: opts.SuitePaths,
+		Roots:      opts.Roots,
+	})
+	if err != nil {
+		return nil, err
+	}
+	baselines, err := discoverBaselines(opts.BaselineDir)
+	if err != nil {
+		return nil, err
+	}
+	report := &BaselineAuditReport{
+		SuiteCount:    len(paths),
+		BaselineCount: len(baselines),
+	}
+	seenSuites := map[string]struct{}{}
+	for _, path := range paths {
+		suite, data, err := LoadSuite(path)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+		seenSuites[suite.ID] = struct{}{}
+		baselinePath, hasBaseline := baselines[suite.ID]
+		mode := strings.TrimSpace(suite.BaselinePolicy.Mode)
+		switch mode {
+		case "compare":
+			if !hasBaseline {
+				report.MissingCompareBaselines = append(report.MissingCompareBaselines, BaselineAuditFinding{
+					SuiteID:   suite.ID,
+					SuitePath: path,
+					Mode:      mode,
+				})
+			}
+		case "none", "":
+			if hasBaseline {
+				report.UnexpectedBaselinesForNone = append(report.UnexpectedBaselinesForNone, BaselineAuditFinding{
+					SuiteID:      suite.ID,
+					SuitePath:    path,
+					BaselinePath: baselinePath,
+					Mode:         mode,
+				})
+			}
+		}
+		if hasBaseline {
+			report.StaleSuiteHashes = append(report.StaleSuiteHashes, staleSuiteHashFinding(suite.ID, path, baselinePath, sha256Hex(data))...)
+		}
+	}
+	for suiteID, baselinePath := range baselines {
+		if _, ok := seenSuites[suiteID]; !ok {
+			report.OrphanBaselines = append(report.OrphanBaselines, BaselineAuditFinding{
+				SuiteID:      suiteID,
+				BaselinePath: baselinePath,
+			})
+		}
+	}
+	sortBaselineAuditFindings(report.MissingCompareBaselines)
+	sortBaselineAuditFindings(report.UnexpectedBaselinesForNone)
+	sortBaselineAuditFindings(report.OrphanBaselines)
+	sortBaselineAuditFindings(report.StaleSuiteHashes)
+	report.PolicyMismatchCount = len(report.MissingCompareBaselines) + len(report.UnexpectedBaselinesForNone) + len(report.OrphanBaselines)
+	return report, nil
+}
+
+func discoverBaselines(dir string) (map[string]string, error) {
+	baselines := map[string]string{}
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return baselines, nil
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return baselines, nil
+		}
+		return nil, fmt.Errorf("inspect baseline dir %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("baseline dir %s is not a directory", dir)
+	}
+	err = filepath.WalkDir(dir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".baseline.json") {
+			return nil
+		}
+		suiteID := strings.TrimSuffix(entry.Name(), ".baseline.json")
+		baselines[suiteID] = path
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk baseline dir %s: %w", dir, err)
+	}
+	return baselines, nil
+}
+
+func staleSuiteHashFinding(suiteID, suitePath, baselinePath, actualSHA string) []BaselineAuditFinding {
+	baseline, err := LoadRun(baselinePath)
+	if err != nil || strings.TrimSpace(baseline.Suite.SHA256) == "" || baseline.Suite.SHA256 == actualSHA {
+		return nil
+	}
+	return []BaselineAuditFinding{{
+		SuiteID:      suiteID,
+		SuitePath:    suitePath,
+		BaselinePath: baselinePath,
+		ExpectedSHA:  baseline.Suite.SHA256,
+		ActualSHA:    actualSHA,
+	}}
+}
+
+func sortBaselineAuditFindings(findings []BaselineAuditFinding) {
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].SuiteID != findings[j].SuiteID {
+			return findings[i].SuiteID < findings[j].SuiteID
+		}
+		return findings[i].BaselinePath < findings[j].BaselinePath
+	})
+}

--- a/cli/internal/eval/baseline_audit_test.go
+++ b/cli/internal/eval/baseline_audit_test.go
@@ -1,0 +1,164 @@
+package eval
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAuditBaselinePolicyFindsPolicyMismatches(t *testing.T) {
+	dir := t.TempDir()
+	suiteDir := filepath.Join(dir, "evals")
+	baselineDir := filepath.Join(dir, "baselines")
+	nonePath := filepath.Join(suiteDir, "none.json")
+	comparePath := filepath.Join(suiteDir, "compare.json")
+	writeCoverageSuite(t, nonePath, "audit.none", "cli", "static")
+	writeCoverageSuiteWithPolicy(t, comparePath, "audit.compare", "cli", "static", `"baseline_policy": {"mode": "compare"}`)
+	writeBaselineRecord(t, filepath.Join(baselineDir, "audit.none.baseline.json"), "audit.none", nonePath, "")
+	writeBaselineRecord(t, filepath.Join(baselineDir, "audit.orphan.baseline.json"), "audit.orphan", "evals/orphan.json", "")
+
+	report, err := AuditBaselinePolicy(BaselineAuditOptions{
+		Roots:       []string{suiteDir},
+		BaselineDir: baselineDir,
+	})
+	if err != nil {
+		t.Fatalf("AuditBaselinePolicy failed: %v", err)
+	}
+	if report.PolicyMismatchCount != 3 {
+		t.Fatalf("policy mismatch count = %d, want 3; report=%+v", report.PolicyMismatchCount, report)
+	}
+	if len(report.UnexpectedBaselinesForNone) != 1 || report.UnexpectedBaselinesForNone[0].SuiteID != "audit.none" {
+		t.Fatalf("unexpected baselines = %+v, want audit.none", report.UnexpectedBaselinesForNone)
+	}
+	if len(report.MissingCompareBaselines) != 1 || report.MissingCompareBaselines[0].SuiteID != "audit.compare" {
+		t.Fatalf("missing compare baselines = %+v, want audit.compare", report.MissingCompareBaselines)
+	}
+	if len(report.OrphanBaselines) != 1 || report.OrphanBaselines[0].SuiteID != "audit.orphan" {
+		t.Fatalf("orphan baselines = %+v, want audit.orphan", report.OrphanBaselines)
+	}
+}
+
+func TestAuditBaselinePolicyReportsStaleSuiteHashSeparately(t *testing.T) {
+	dir := t.TempDir()
+	suiteDir := filepath.Join(dir, "evals")
+	baselineDir := filepath.Join(dir, "baselines")
+	suitePath := filepath.Join(suiteDir, "compare.json")
+	writeCoverageSuiteWithPolicy(t, suitePath, "audit.compare", "cli", "static", `"baseline_policy": {"mode": "compare"}`)
+	writeBaselineRecord(t, filepath.Join(baselineDir, "audit.compare.baseline.json"), "audit.compare", suitePath, "deadbeef")
+
+	report, err := AuditBaselinePolicy(BaselineAuditOptions{
+		Roots:       []string{suiteDir},
+		BaselineDir: baselineDir,
+	})
+	if err != nil {
+		t.Fatalf("AuditBaselinePolicy failed: %v", err)
+	}
+	if report.PolicyMismatchCount != 0 {
+		t.Fatalf("policy mismatch count = %d, want 0", report.PolicyMismatchCount)
+	}
+	if len(report.StaleSuiteHashes) != 1 || report.StaleSuiteHashes[0].SuiteID != "audit.compare" {
+		t.Fatalf("stale suite hashes = %+v, want audit.compare", report.StaleSuiteHashes)
+	}
+}
+
+func writeCoverageSuiteWithPolicy(t *testing.T, path, id, domain, runtimeName, baselinePolicy string) {
+	t.Helper()
+	writeCoverageSuiteBody(t, path, id, domain, runtimeName, baselinePolicy)
+}
+
+func writeCoverageSuiteBody(t *testing.T, path, id, domain, runtimeName, baselinePolicy string) {
+	t.Helper()
+	body := `{
+  "schema_version": 1,
+  "id": "` + id + `",
+  "name": "` + id + `",
+  "domain": "` + domain + `",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "allowed_runtimes": ["` + runtimeName + `"],
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "correctness", "weight": 1, "threshold": 1}
+    ]
+  },
+  ` + baselinePolicy + `,
+  "cases": [
+    {
+      "id": "case",
+      "title": "case",
+      "kind": "artifact_check",
+      "objective": "case",
+      "runtime": "` + runtimeName + `",
+      "expectations": [
+        {"type": "file_exists", "target": "fixture.txt"}
+      ],
+      "critical": true
+    }
+  ]
+}`
+	writeBaselineAuditFile(t, path, body)
+	writeBaselineAuditFile(t, filepath.Join(filepath.Dir(path), "fixture.txt"), "ok\n")
+}
+
+func writeBaselineAuditFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func writeBaselineRecord(t *testing.T, path, suiteID, suitePath, suiteSHA string) {
+	t.Helper()
+	started := time.Date(2026, 4, 29, 20, 0, 0, 0, time.UTC)
+	run := &RunRecord{
+		SchemaVersion: 1,
+		RunID:         suiteID + "-baseline",
+		Suite: SuiteRef{
+			ID:         suiteID,
+			Path:       suitePath,
+			Visibility: VisibilityPublicCanary,
+			Tier:       TierDeterministic,
+			SHA256:     suiteSHA,
+		},
+		StartedAt: started,
+		Status:    StatusPass,
+		Verdict:   VerdictPass,
+		Git: GitRecord{
+			CandidateRef: "test",
+			CandidateSHA: "0123456",
+			Dirty:        false,
+		},
+		Runtime: RuntimeRecord{
+			Name: RuntimeStatic,
+			Live: false,
+		},
+		Environment: EnvironmentRecord{
+			ScrubbedEnvPrefixes: []string{},
+			NetworkAccess:       NetworkDisabled,
+		},
+		Baseline: &BaselineRecord{
+			Mode:         BaselineModePromote,
+			BaselinePath: path,
+		},
+		CaseResults: []CaseResult{{
+			ID:     "case",
+			Status: StatusPass,
+			Score:  1,
+			DimensionScores: map[Dimension]float64{
+				DimensionCorrectness: 1,
+			},
+		}},
+		AggregateScore: 1,
+		DimensionScores: map[Dimension]float64{
+			DimensionCorrectness: 1,
+		},
+	}
+	if err := WriteRun(path, run); err != nil {
+		t.Fatalf("write baseline %s: %v", path, err)
+	}
+}

--- a/cli/internal/eval/coverage.go
+++ b/cli/internal/eval/coverage.go
@@ -37,28 +37,42 @@ var DefaultCoverageRuntimes = []string{
 	string(RuntimeMock),
 }
 
+var DefaultCoverageEvidenceKinds = []string{
+	string(EvidenceKindContractCanary),
+	string(EvidenceKindGateWrapper),
+	string(EvidenceKindBehaviorFixture),
+	string(EvidenceKindBaselineRegression),
+	string(EvidenceKindScorecardFixture),
+	string(EvidenceKindLiveRuntime),
+	string(EvidenceKindHoldout),
+}
+
 type CoverageOptions struct {
-	SuitePaths         []string
-	Roots              []string
-	RequiredDomains    []string
-	RequiredDimensions []string
-	RequiredRuntimes   []string
+	SuitePaths            []string
+	Roots                 []string
+	RequiredDomains       []string
+	RequiredDimensions    []string
+	RequiredRuntimes      []string
+	RequiredEvidenceKinds []string
 }
 
 type CoverageReport struct {
-	SuiteCount                int                       `json:"suite_count"`
-	CaseCount                 int                       `json:"case_count"`
-	CriticalCaseCount         int                       `json:"critical_case_count"`
-	Suites                    []CoverageSuite           `json:"suites"`
-	Domains                   map[string]CoverageBucket `json:"domains"`
-	Dimensions                map[string]int            `json:"dimensions"`
-	Runtimes                  map[string]int            `json:"runtimes"`
-	RequiredDomains           []string                  `json:"required_domains,omitempty"`
-	MissingRequiredDomains    []string                  `json:"missing_required_domains,omitempty"`
-	RequiredDimensions        []string                  `json:"required_dimensions,omitempty"`
-	MissingRequiredDimensions []string                  `json:"missing_required_dimensions,omitempty"`
-	RequiredRuntimes          []string                  `json:"required_runtimes,omitempty"`
-	MissingRequiredRuntimes   []string                  `json:"missing_required_runtimes,omitempty"`
+	SuiteCount                   int                       `json:"suite_count"`
+	CaseCount                    int                       `json:"case_count"`
+	CriticalCaseCount            int                       `json:"critical_case_count"`
+	Suites                       []CoverageSuite           `json:"suites"`
+	Domains                      map[string]CoverageBucket `json:"domains"`
+	EvidenceKinds                map[string]CoverageBucket `json:"evidence_kinds"`
+	Dimensions                   map[string]int            `json:"dimensions"`
+	Runtimes                     map[string]int            `json:"runtimes"`
+	RequiredDomains              []string                  `json:"required_domains,omitempty"`
+	MissingRequiredDomains       []string                  `json:"missing_required_domains,omitempty"`
+	RequiredEvidenceKinds        []string                  `json:"required_evidence_kinds,omitempty"`
+	MissingRequiredEvidenceKinds []string                  `json:"missing_required_evidence_kinds,omitempty"`
+	RequiredDimensions           []string                  `json:"required_dimensions,omitempty"`
+	MissingRequiredDimensions    []string                  `json:"missing_required_dimensions,omitempty"`
+	RequiredRuntimes             []string                  `json:"required_runtimes,omitempty"`
+	MissingRequiredRuntimes      []string                  `json:"missing_required_runtimes,omitempty"`
 }
 
 type CoverageSuite struct {
@@ -66,6 +80,7 @@ type CoverageSuite struct {
 	Domain            string   `json:"domain"`
 	Tier              string   `json:"tier"`
 	Visibility        string   `json:"visibility"`
+	EvidenceKinds     []string `json:"evidence_kinds"`
 	CaseCount         int      `json:"case_count"`
 	CriticalCaseCount int      `json:"critical_case_count"`
 	Dimensions        []string `json:"dimensions"`
@@ -84,9 +99,10 @@ func BuildCoverageReport(opts CoverageOptions) (*CoverageReport, error) {
 		return nil, err
 	}
 	report := &CoverageReport{
-		Domains:    map[string]CoverageBucket{},
-		Dimensions: map[string]int{},
-		Runtimes:   map[string]int{},
+		Domains:       map[string]CoverageBucket{},
+		EvidenceKinds: map[string]CoverageBucket{},
+		Dimensions:    map[string]int{},
+		Runtimes:      map[string]int{},
 	}
 	for _, path := range paths {
 		suite, _, err := LoadSuite(path)
@@ -97,6 +113,8 @@ func BuildCoverageReport(opts CoverageOptions) (*CoverageReport, error) {
 	}
 	report.RequiredDomains = normalizedCoverageValues(opts.RequiredDomains)
 	report.MissingRequiredDomains = missingCoverageDomains(report.Domains, report.RequiredDomains)
+	report.RequiredEvidenceKinds = normalizedCoverageValues(opts.RequiredEvidenceKinds)
+	report.MissingRequiredEvidenceKinds = missingCoverageBuckets(report.EvidenceKinds, report.RequiredEvidenceKinds)
 	report.RequiredDimensions = normalizedCoverageValues(opts.RequiredDimensions)
 	report.MissingRequiredDimensions = missingCoverageDimensions(report.Dimensions, report.RequiredDimensions)
 	report.RequiredRuntimes = normalizedCoverageValues(opts.RequiredRuntimes)
@@ -175,6 +193,7 @@ func addSuiteCoverage(report *CoverageReport, suite *Suite) {
 	report.CaseCount += summary.CaseCount
 	report.CriticalCaseCount += summary.CriticalCaseCount
 	addDomainCoverage(report, summary)
+	addEvidenceKindCoverage(report, suite)
 	for _, dim := range summary.Dimensions {
 		report.Dimensions[dim]++
 	}
@@ -186,6 +205,7 @@ func addSuiteCoverage(report *CoverageReport, suite *Suite) {
 func coverageSuiteSummary(suite *Suite) CoverageSuite {
 	dimensions := coverageDimensions(suite)
 	runtimes := coverageRuntimes(suite)
+	evidenceKinds := coverageEvidenceKinds(suite)
 	critical := 0
 	for _, evalCase := range suite.Cases {
 		if evalCase.Critical {
@@ -197,6 +217,7 @@ func coverageSuiteSummary(suite *Suite) CoverageSuite {
 		Domain:            suite.Domain,
 		Tier:              string(suite.Tier),
 		Visibility:        string(suite.Visibility),
+		EvidenceKinds:     evidenceKinds,
 		CaseCount:         len(suite.Cases),
 		CriticalCaseCount: critical,
 		Dimensions:        dimensions,
@@ -212,6 +233,30 @@ func addDomainCoverage(report *CoverageReport, suite CoverageSuite) {
 	report.Domains[suite.Domain] = bucket
 }
 
+func addEvidenceKindCoverage(report *CoverageReport, suite *Suite) {
+	suiteKinds := map[string]struct{}{}
+	caseBuckets := map[string]CoverageBucket{}
+	for _, evalCase := range suite.Cases {
+		kind := string(resolveEvidenceKind(suite, evalCase))
+		suiteKinds[kind] = struct{}{}
+		bucket := caseBuckets[kind]
+		bucket.CaseCount++
+		if evalCase.Critical {
+			bucket.CriticalCaseCount++
+		}
+		caseBuckets[kind] = bucket
+	}
+	for kind, caseBucket := range caseBuckets {
+		bucket := report.EvidenceKinds[kind]
+		bucket.CaseCount += caseBucket.CaseCount
+		bucket.CriticalCaseCount += caseBucket.CriticalCaseCount
+		if _, ok := suiteKinds[kind]; ok {
+			bucket.SuiteCount++
+		}
+		report.EvidenceKinds[kind] = bucket
+	}
+}
+
 func coverageDimensions(suite *Suite) []string {
 	seen := map[string]struct{}{}
 	for _, dim := range suite.Scoring.Dimensions {
@@ -221,6 +266,14 @@ func coverageDimensions(suite *Suite) []string {
 		for _, dim := range evalCase.Dimensions {
 			seen[string(dim)] = struct{}{}
 		}
+	}
+	return sortedCoverageKeys(seen)
+}
+
+func coverageEvidenceKinds(suite *Suite) []string {
+	seen := map[string]struct{}{}
+	for _, evalCase := range suite.Cases {
+		seen[string(resolveEvidenceKind(suite, evalCase))] = struct{}{}
 	}
 	return sortedCoverageKeys(seen)
 }
@@ -241,6 +294,68 @@ func coverageRuntimes(suite *Suite) []string {
 	return sortedCoverageKeys(seen)
 }
 
+func resolveEvidenceKind(suite *Suite, evalCase Case) EvidenceKind {
+	if evalCase.EvidenceKind != "" {
+		return evalCase.EvidenceKind
+	}
+	if suite.EvidenceKind != "" {
+		return suite.EvidenceKind
+	}
+	marker := evidenceKindMarker(suite, evalCase)
+	switch {
+	case strings.Contains(marker, "baseline-regression") || strings.Contains(marker, "baseline regression"):
+		return EvidenceKindBaselineRegression
+	case strings.Contains(marker, "holdout"):
+		return EvidenceKindHoldout
+	case strings.Contains(marker, "scorecard"):
+		return EvidenceKindScorecardFixture
+	case isLiveEvidence(marker, evalCase.Runtime):
+		return EvidenceKindLiveRuntime
+	case evalCase.Kind == "scenario" || evalCase.Kind == "rpi_flow" || strings.Contains(marker, "behavior"):
+		return EvidenceKindBehaviorFixture
+	case isGateWrapperCase(evalCase.Kind):
+		return EvidenceKindGateWrapper
+	default:
+		return EvidenceKindContractCanary
+	}
+}
+
+func isLiveEvidence(marker string, runtime Runtime) bool {
+	if strings.Contains(marker, "live-runtime") || strings.Contains(marker, "live runtime") {
+		return true
+	}
+	switch runtime {
+	case RuntimeClaude, RuntimeCodex, RuntimeManual:
+		return true
+	default:
+		return false
+	}
+}
+
+func isGateWrapperCase(kind string) bool {
+	switch kind {
+	case "command", "hook_event", "retrieval_query":
+		return true
+	default:
+		return false
+	}
+}
+
+func evidenceKindMarker(suite *Suite, evalCase Case) string {
+	parts := []string{
+		suite.ID,
+		suite.Name,
+		suite.Description,
+		evalCase.ID,
+		evalCase.Title,
+		evalCase.Kind,
+		evalCase.Objective,
+	}
+	parts = append(parts, suite.Tags...)
+	parts = append(parts, evalCase.Tags...)
+	return strings.ToLower(strings.Join(parts, " "))
+}
+
 func normalizedCoverageValues(values []string) []string {
 	seen := map[string]struct{}{}
 	for _, value := range values {
@@ -254,9 +369,13 @@ func normalizedCoverageValues(values []string) []string {
 }
 
 func missingCoverageDomains(domains map[string]CoverageBucket, required []string) []string {
+	return missingCoverageBuckets(domains, required)
+}
+
+func missingCoverageBuckets(buckets map[string]CoverageBucket, required []string) []string {
 	var missing []string
 	for _, domain := range required {
-		if domains[domain].SuiteCount == 0 {
+		if buckets[domain].SuiteCount == 0 {
 			missing = append(missing, domain)
 		}
 	}

--- a/cli/internal/eval/coverage_test.go
+++ b/cli/internal/eval/coverage_test.go
@@ -26,6 +26,9 @@ func TestBuildCoverageReportSummarizesDomains(t *testing.T) {
 	if report.Domains["cli"].SuiteCount != 1 || report.Domains["skill"].SuiteCount != 1 {
 		t.Fatalf("domain coverage = %+v, want cli and skill", report.Domains)
 	}
+	if report.EvidenceKinds[string(EvidenceKindContractCanary)].CaseCount != 2 {
+		t.Fatalf("contract_canary evidence coverage = %+v, want two cases", report.EvidenceKinds[string(EvidenceKindContractCanary)])
+	}
 	if len(report.MissingRequiredDomains) != 1 || report.MissingRequiredDomains[0] != "scenario" {
 		t.Fatalf("missing required domains = %v, want [scenario]", report.MissingRequiredDomains)
 	}
@@ -40,6 +43,29 @@ func TestBuildCoverageReportSummarizesDomains(t *testing.T) {
 	}
 }
 
+func TestBuildCoverageReportEvidenceKinds(t *testing.T) {
+	dir := t.TempDir()
+	writeCoverageSuite(t, filepath.Join(dir, "behavior.json"), "coverage.behavior", "rpi", "shell", string(EvidenceKindBehaviorFixture))
+	writeCoverageSuite(t, filepath.Join(dir, "scorecard.json"), "coverage.rpi-scorecard", "rpi", "static")
+
+	report, err := BuildCoverageReport(CoverageOptions{
+		Roots:                 []string{dir},
+		RequiredEvidenceKinds: []string{string(EvidenceKindBehaviorFixture), string(EvidenceKindLiveRuntime)},
+	})
+	if err != nil {
+		t.Fatalf("BuildCoverageReport failed: %v", err)
+	}
+	if got := report.EvidenceKinds[string(EvidenceKindBehaviorFixture)].CaseCount; got != 1 {
+		t.Fatalf("behavior_fixture case count = %d, want 1", got)
+	}
+	if got := report.EvidenceKinds[string(EvidenceKindScorecardFixture)].CaseCount; got != 1 {
+		t.Fatalf("scorecard_fixture case count = %d, want 1", got)
+	}
+	if len(report.MissingRequiredEvidenceKinds) != 1 || report.MissingRequiredEvidenceKinds[0] != string(EvidenceKindLiveRuntime) {
+		t.Fatalf("missing required evidence kinds = %v, want [live_runtime]", report.MissingRequiredEvidenceKinds)
+	}
+}
+
 func TestBuildCoverageReportMissingRootFails(t *testing.T) {
 	_, err := BuildCoverageReport(CoverageOptions{Roots: []string{filepath.Join(t.TempDir(), "missing")}})
 	if err == nil {
@@ -47,8 +73,13 @@ func TestBuildCoverageReportMissingRootFails(t *testing.T) {
 	}
 }
 
-func writeCoverageSuite(t *testing.T, path, id, domain, runtimeName string) {
+func writeCoverageSuite(t *testing.T, path, id, domain, runtimeName string, evidenceKind ...string) {
 	t.Helper()
+	evidenceField := ""
+	if len(evidenceKind) > 0 && evidenceKind[0] != "" {
+		evidenceField = `,
+      "evidence_kind": "` + evidenceKind[0] + `"`
+	}
 	body := `{
   "schema_version": 1,
   "id": "` + id + `",
@@ -69,7 +100,7 @@ func writeCoverageSuite(t *testing.T, path, id, domain, runtimeName string) {
       "id": "case",
       "title": "case",
       "kind": "artifact_check",
-      "objective": "case",
+      "objective": "case"` + evidenceField + `,
       "runtime": "` + runtimeName + `",
       "expectations": [
         {"type": "file_exists", "target": "fixture.txt"}

--- a/cli/internal/eval/io.go
+++ b/cli/internal/eval/io.go
@@ -94,6 +94,9 @@ func validateSuiteMetadata(suite *Suite) []string {
 	if suite.Tier != TierDeterministic {
 		errs = append(errs, fmt.Sprintf("tier %q is out of deterministic scope", suite.Tier))
 	}
+	if suite.EvidenceKind != "" && !validEvidenceKind(suite.EvidenceKind) {
+		errs = append(errs, fmt.Sprintf("evidence_kind %q is invalid", suite.EvidenceKind))
+	}
 	if strings.TrimSpace(suite.BaselinePolicy.Mode) == "" {
 		errs = append(errs, "baseline_policy.mode is required")
 	}
@@ -144,6 +147,9 @@ func validateSuiteCases(suite *Suite) []string {
 		}
 		if strings.TrimSpace(c.Objective) == "" {
 			errs = append(errs, fmt.Sprintf("cases[%d].objective is required", i))
+		}
+		if c.EvidenceKind != "" && !validEvidenceKind(c.EvidenceKind) {
+			errs = append(errs, fmt.Sprintf("cases[%d].evidence_kind %q is invalid", i, c.EvidenceKind))
 		}
 		if c.Runtime != "" && !validDeterministicRuntime(c.Runtime) {
 			errs = append(errs, fmt.Sprintf("cases[%d].runtime %q is out of deterministic scope", i, c.Runtime))
@@ -287,6 +293,16 @@ func validTier(t Tier) bool {
 
 func validRuntime(r Runtime) bool {
 	return r == RuntimeStatic || r == RuntimeMock || r == RuntimeShell || r == RuntimeClaude || r == RuntimeCodex || r == RuntimeManual
+}
+
+func validEvidenceKind(kind EvidenceKind) bool {
+	switch kind {
+	case EvidenceKindContractCanary, EvidenceKindGateWrapper, EvidenceKindBehaviorFixture,
+		EvidenceKindBaselineRegression, EvidenceKindScorecardFixture, EvidenceKindLiveRuntime, EvidenceKindHoldout:
+		return true
+	default:
+		return false
+	}
 }
 
 func validDeterministicRuntime(r Runtime) bool {

--- a/cli/internal/eval/types.go
+++ b/cli/internal/eval/types.go
@@ -29,6 +29,18 @@ const (
 	RuntimeManual Runtime = "manual"
 )
 
+type EvidenceKind string
+
+const (
+	EvidenceKindContractCanary     EvidenceKind = "contract_canary"
+	EvidenceKindGateWrapper        EvidenceKind = "gate_wrapper"
+	EvidenceKindBehaviorFixture    EvidenceKind = "behavior_fixture"
+	EvidenceKindBaselineRegression EvidenceKind = "baseline_regression"
+	EvidenceKindScorecardFixture   EvidenceKind = "scorecard_fixture"
+	EvidenceKindLiveRuntime        EvidenceKind = "live_runtime"
+	EvidenceKindHoldout            EvidenceKind = "holdout"
+)
+
 type Dimension string
 
 const (
@@ -86,6 +98,7 @@ type Suite struct {
 	Domain         string           `json:"domain"`
 	Visibility     Visibility       `json:"visibility"`
 	Tier           Tier             `json:"tier"`
+	EvidenceKind   EvidenceKind     `json:"evidence_kind,omitempty"`
 	Owners         []string         `json:"owners,omitempty"`
 	Tags           []string         `json:"tags,omitempty"`
 	Allowed        []Runtime        `json:"allowed_runtimes,omitempty"`
@@ -142,6 +155,7 @@ type Case struct {
 	Title          string         `json:"title"`
 	Kind           string         `json:"kind"`
 	Objective      string         `json:"objective"`
+	EvidenceKind   EvidenceKind   `json:"evidence_kind,omitempty"`
 	Runtime        Runtime        `json:"runtime,omitempty"`
 	TimeoutSeconds int            `json:"timeout_seconds,omitempty"`
 	Fixtures       []string       `json:"fixtures,omitempty"`

--- a/docs/contracts/eval-environment.md
+++ b/docs/contracts/eval-environment.md
@@ -98,6 +98,27 @@ Suites declare one tier:
 The first blocking tier must be deterministic. Live runtime suites are opt-in and
 advisory until repeated runs establish variance, timeout behavior, and cost.
 
+## Evidence Kinds
+
+Suites and cases may declare `evidence_kind`. When omitted, `ao eval coverage`
+infers the kind from suite metadata, case kind, runtime, tags, and baseline
+policy so older suites can still be audited during migration.
+
+| Evidence kind | What it proves | What it does not prove |
+|---------------|----------------|------------------------|
+| `contract_canary` | A public contract string, file, schema, or documented invariant still exists. | The product behavior is correct end to end. |
+| `gate_wrapper` | A lower-level command, script, linter, or validator still passes inside the eval harness. | The eval itself adds independent behavioral coverage. |
+| `behavior_fixture` | A deterministic fixture exercises product behavior directly. | Live runtime behavior across real agents or models. |
+| `baseline_regression` | A candidate run preserves or improves against a promoted baseline under declared thresholds. | That the baseline itself is still the right target. |
+| `scorecard_fixture` | Scorecard categories, deltas, and failure paths respond to known-good and regressed fixtures. | That category labels alone imply behavior quality. |
+| `live_runtime` | A Claude, Codex, or headless runtime path ran or skipped with recorded runtime metadata. | A stable PR-blocking signal before variance and auth behavior are calibrated. |
+| `holdout` | A public or private scenario/holdout expectation was evaluated. | That hidden scenario text can be disclosed to implementers. |
+
+This taxonomy is intentionally blunt: a passing public canary can be valuable
+without being a behavioral eval. Operators should use `ao eval coverage --json`
+to inspect `evidence_kinds` before interpreting a score as product behavior,
+runtime quality, baseline health, or contract preservation.
+
 ## Runtime Isolation
 
 Live or headless runtime evaluations must record runtime hygiene:
@@ -158,6 +179,18 @@ Promotion requires:
 Live runtime baselines must include repeat count, variance notes, skipped cases,
 and advisory/blocking status. A single live pass is not enough to make a live
 suite blocking.
+
+Suite `baseline_policy.mode` has operational meaning:
+
+- `none`: no promoted baseline is expected; missing-baseline warnings are noise.
+- `compare`: a promoted baseline is expected in the configured baseline
+  directory; missing files are warnings unless `blocking_gate` promotes them.
+- `promotable`: a baseline may be created, but absence is deliberate.
+
+Run `ao eval baseline-audit --json` to compare suite policy with promoted
+baseline files. The audit reports policy mismatches separately from stale suite
+hashes so operators can fix governance drift without claiming old baselines were
+refreshed.
 
 ## Verdict Rules
 

--- a/evals/agentops-core/beads-issue-tracking.json
+++ b/evals/agentops-core/beads-issue-tracking.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.beads-issue-tracking.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "ao-beads-command-tests",

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.cli-command-surface-matrix.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "documented-cli-help-matrix",
@@ -40,7 +40,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=58 sub=139 all=197"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=58 sub=140 all=198"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/cli-contracts.json
+++ b/evals/agentops-core/cli-contracts.json
@@ -24,7 +24,7 @@
       {"name": "runtime_compatibility", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.cli-contracts.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "cli-reference-current",

--- a/evals/agentops-core/cli-onboarding-health.json
+++ b/evals/agentops-core/cli-onboarding-health.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1, "critical": true}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.cli-onboarding-health.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "install-script-smoke",

--- a/evals/agentops-core/contract-schema-governance.json
+++ b/evals/agentops-core/contract-schema-governance.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.contract-schema-governance.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "contract-compatibility-gate",

--- a/evals/agentops-core/converter-update-runtime-parity.json
+++ b/evals/agentops-core/converter-update-runtime-parity.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.converter-update-runtime-parity.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "converter-update-validator-portability",

--- a/evals/agentops-core/core-surfaces.json
+++ b/evals/agentops-core/core-surfaces.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1, "critical": true}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.core-surfaces.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "repo-root-surface-files",

--- a/evals/agentops-core/curation-feedback-governance.json
+++ b/evals/agentops-core/curation-feedback-governance.json
@@ -26,7 +26,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.curation-feedback-governance.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "curation-feedback-go-tests",

--- a/evals/agentops-core/distribution-install-update.json
+++ b/evals/agentops-core/distribution-install-update.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1, "critical": true}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.distribution-install-update.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "shell-installer-smoke",

--- a/evals/agentops-core/docs-release-governance.json
+++ b/evals/agentops-core/docs-release-governance.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.docs-release-governance.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "doc-release-stabilization-gate",

--- a/evals/agentops-core/dream-software-factory-operator.json
+++ b/evals/agentops-core/dream-software-factory-operator.json
@@ -26,7 +26,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.dream-software-factory-operator.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "dream-operator-go-tests",

--- a/evals/agentops-core/efficiency-budgets.json
+++ b/evals/agentops-core/efficiency-budgets.json
@@ -24,7 +24,7 @@
       {"name": "efficiency", "weight": 2, "threshold": 1, "critical": true}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.efficiency-budgets.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "coverage-command-budget",
@@ -50,7 +50,7 @@
       "expectations": [
         {"type": "artifact_contains", "target": "../../scripts/pre-push-gate.sh", "value": "AgentOps eval canaries"},
         {"type": "artifact_contains", "target": "../../scripts/pre-push-gate.sh", "value": "^evals/|^schemas/eval-|^scripts/eval-agentops\\.sh$|^cli/internal/eval/|^cli/cmd/ao/eval"},
-        {"type": "artifact_contains", "target": "../../scripts/pre-push-gate.sh", "value": "scripts/eval-agentops.sh --fast"}
+        {"type": "artifact_contains", "target": "../../scripts/pre-push-gate.sh", "value": "eval_args=(--fast)"}
       ],
       "dimensions": ["efficiency", "process_adherence"]
     },

--- a/evals/agentops-core/eval-runner-engine-control-plane.json
+++ b/evals/agentops-core/eval-runner-engine-control-plane.json
@@ -27,7 +27,7 @@
       {"name": "efficiency", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.eval-runner-engine-control-plane.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "eval-runner-engine-go-tests",
@@ -38,7 +38,7 @@
       "timeout_seconds": 180,
       "inputs": {
         "cwd": "../../cli",
-        "shell": "env -u AGENTOPS_RPI_RUNTIME go test -timeout=180s ./cmd/ao ./internal/eval -run '^(TestEvalRunCommandJSON|TestEvalRunCommandMissingSuiteFails|TestEvalCompareCommandJSON|TestEvalCompareCommandJSONIncludesZeroAggregateDelta|TestEvalScorecardCommandJSON|TestEvalBaselineCommandJSON|TestEvalCoverageCommandJSON|TestRunSuiteArtifactCheckPasses|TestRunSuiteCommandCasePasses|TestRunSuiteExpectationFailureFailsRun|TestRunSuiteRejectsLiveTier|TestCompareRunsMarksRegression|TestPromoteBaselineWritesRunRecord|TestCollectGitRecordPreservesDirtyPathNames|TestRunRecordJSONRoundTrip|TestBuildCoverageReportSummarizesDomains|TestBuildCoverageReportMissingRootFails|TestBuildScorecardRPICategories|TestBuildScorecardSkillChangeCategories|TestBuildScorecardMissingCategoryFails|TestBuildScorecardBaselineDeltaRegressionImprovement|TestBuildScorecardFailedCandidateFails|TestRunLiveRuntimeSkipsWhenExecutableUnavailable|TestRunLiveRuntimeDisabledSkipsBeforeExternalProbe|TestRunLiveRuntimeIsolatesAndScrubsCodexEnvironment|TestRunLiveRuntimeCapturesTranscriptAndScorecardArtifacts|TestRunLiveRuntimePropagatesRunnerErrors)$'"
+        "shell": "env -u AGENTOPS_RPI_RUNTIME go test -timeout=180s ./cmd/ao ./internal/eval -run '^(TestEvalRunCommandJSON|TestEvalRunCommandMissingSuiteFails|TestEvalCompareCommandJSON|TestEvalCompareCommandJSONIncludesZeroAggregateDelta|TestEvalScorecardCommandJSON|TestEvalBaselineCommandJSON|TestEvalBaselineAuditCommandJSON|TestEvalCoverageCommandJSON|TestRunSuiteArtifactCheckPasses|TestRunSuiteCommandCasePasses|TestRunSuiteExpectationFailureFailsRun|TestRunSuiteRejectsLiveTier|TestCompareRunsMarksRegression|TestPromoteBaselineWritesRunRecord|TestAuditBaselinePolicyFindsPolicyMismatches|TestAuditBaselinePolicyReportsStaleSuiteHashSeparately|TestCollectGitRecordPreservesDirtyPathNames|TestRunRecordJSONRoundTrip|TestBuildCoverageReportSummarizesDomains|TestBuildCoverageReportMissingRootFails|TestBuildScorecardRPICategories|TestBuildScorecardSkillChangeCategories|TestBuildScorecardMissingCategoryFails|TestBuildScorecardBaselineDeltaRegressionImprovement|TestBuildScorecardFailedCandidateFails|TestRunLiveRuntimeSkipsWhenExecutableUnavailable|TestRunLiveRuntimeDisabledSkipsBeforeExternalProbe|TestRunLiveRuntimeIsolatesAndScrubsCodexEnvironment|TestRunLiveRuntimeCapturesTranscriptAndScorecardArtifacts|TestRunLiveRuntimePropagatesRunnerErrors)$'"
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
@@ -57,7 +57,7 @@
       "timeout_seconds": 120,
       "inputs": {
         "cwd": "../..",
-        "shell": "tmp=$(mktemp -d); trap 'rm -rf \"$tmp\"' EXIT; (cd cli && env -u AGENTOPS_RPI_RUNTIME go build -o \"$tmp/ao\" ./cmd/ao); \"$tmp/ao\" eval --help >/dev/null; \"$tmp/ao\" eval run --help >/dev/null; \"$tmp/ao\" eval compare --help >/dev/null; \"$tmp/ao\" eval baseline --help >/dev/null; \"$tmp/ao\" eval coverage --help >/dev/null; \"$tmp/ao\" eval scorecard --help >/dev/null"
+        "shell": "tmp=$(mktemp -d); trap 'rm -rf \"$tmp\"' EXIT; (cd cli && env -u AGENTOPS_RPI_RUNTIME go build -o \"$tmp/ao\" ./cmd/ao); \"$tmp/ao\" eval --help >/dev/null; \"$tmp/ao\" eval run --help >/dev/null; \"$tmp/ao\" eval compare --help >/dev/null; \"$tmp/ao\" eval baseline --help >/dev/null; \"$tmp/ao\" eval baseline-audit --help >/dev/null; \"$tmp/ao\" eval coverage --help >/dev/null; \"$tmp/ao\" eval scorecard --help >/dev/null"
       },
       "expectations": [
         {"type": "exit_code", "value": 0}
@@ -82,9 +82,12 @@
         {"type": "artifact_contains", "target": "../../cli/docs/COMMANDS.md", "value": "#### `ao eval baseline`"},
         {"type": "artifact_contains", "target": "../../cli/docs/COMMANDS.md", "value": "--promoted-by string   identity promoting the baseline"},
         {"type": "artifact_contains", "target": "../../cli/docs/COMMANDS.md", "value": "--rationale string     rationale for promoting the baseline"},
+        {"type": "artifact_contains", "target": "../../cli/docs/COMMANDS.md", "value": "#### `ao eval baseline-audit`"},
+        {"type": "artifact_contains", "target": "../../cli/docs/COMMANDS.md", "value": "--baseline-dir string   promoted baseline directory"},
         {"type": "artifact_contains", "target": "../../cli/docs/COMMANDS.md", "value": "#### `ao eval coverage`"},
-        {"type": "artifact_contains", "target": "../../cli/docs/COMMANDS.md", "value": "--require-domain stringArray      required product domain for missing-domain reporting"},
-        {"type": "artifact_contains", "target": "../../cli/docs/COMMANDS.md", "value": "--require-runtime stringArray     required deterministic runtime for missing-runtime reporting"},
+        {"type": "artifact_contains", "target": "../../cli/docs/COMMANDS.md", "value": "--require-domain stringArray          required product domain for missing-domain reporting"},
+        {"type": "artifact_contains", "target": "../../cli/docs/COMMANDS.md", "value": "--require-evidence-kind stringArray   required evidence kind for missing-evidence-kind reporting"},
+        {"type": "artifact_contains", "target": "../../cli/docs/COMMANDS.md", "value": "--require-runtime stringArray         required deterministic runtime for missing-runtime reporting"},
         {"type": "artifact_contains", "target": "../../cli/docs/COMMANDS.md", "value": "#### `ao eval scorecard`"},
         {"type": "artifact_contains", "target": "../../cli/docs/COMMANDS.md", "value": "--kind string                     scorecard kind (rpi, skill-change)"}
       ],
@@ -100,6 +103,7 @@
         {"type": "artifact_contains", "target": "../../cli/cmd/ao/eval.go", "value": "Live Claude and Codex adapters are evaluated by a later runtime tier."},
         {"type": "artifact_contains", "target": "../../cli/cmd/ao/eval.go", "value": "runtime %q is out of deterministic scope (use static, mock, or shell)"},
         {"type": "artifact_contains", "target": "../../cli/cmd/ao/eval.go", "value": "evalRunCmd.Flags().StringVar(&evalRunBaseline, \"baseline\", \"\", \"compare the run against a baseline run record\")"},
+        {"type": "artifact_contains", "target": "../../cli/cmd/ao/eval.go", "value": "evalBaselineAuditCmd"},
         {"type": "artifact_contains", "target": "../../cli/cmd/ao/eval.go", "value": "evalScorecardCmd.Flags().StringVar(&evalScorecardKind, \"kind\", string(aoeval.ScorecardKindRPI), \"scorecard kind (rpi, skill-change)\")"},
         {"type": "artifact_contains", "target": "../../cli/internal/eval/engine.go", "value": "if !validDeterministicRuntime(runtimeName)"},
         {"type": "artifact_contains", "target": "../../cli/internal/eval/engine.go", "value": "record, err = CompareRuns(record, baseline, compareOptionsFromSuite(*suite))"},
@@ -115,7 +119,9 @@
         {"type": "artifact_contains", "target": "../../cli/internal/eval/expectations.go", "value": "manual_review is not supported by deterministic evals"},
         {"type": "artifact_contains", "target": "../../cli/internal/eval/compare.go", "value": "aggregate score regressed by %.4f"},
         {"type": "artifact_contains", "target": "../../cli/internal/eval/baseline.go", "value": "PromotedFromRunID: run.RunID"},
+        {"type": "artifact_contains", "target": "../../cli/internal/eval/baseline_audit.go", "value": "AuditBaselinePolicy"},
         {"type": "artifact_contains", "target": "../../cli/internal/eval/coverage.go", "value": "DefaultCoverageDomains"},
+        {"type": "artifact_contains", "target": "../../cli/internal/eval/coverage.go", "value": "DefaultCoverageEvidenceKinds"},
         {"type": "artifact_contains", "target": "../../cli/internal/eval/coverage.go", "value": "MissingRequiredRuntimes"},
         {"type": "artifact_contains", "target": "../../cli/internal/eval/scorecard.go", "value": "candidate regressed one or more scorecard categories"},
         {"type": "artifact_contains", "target": "../../cli/internal/eval/runtime.go", "value": "skips instead of invoking external processes unless"},
@@ -165,6 +171,7 @@
         {"type": "artifact_contains", "target": "../../scripts/eval-agentops.sh", "value": "eval run \"$suite\" --run-id"},
         {"type": "artifact_contains", "target": "../../scripts/eval-agentops.sh", "value": "eval compare \"$run_path\" \"$baseline_path\""},
         {"type": "artifact_contains", "target": "../../scripts/eval-agentops.sh", "value": "eval baseline \"$run_path\" --out \"$baseline_path\" --promoted-by \"$PROMOTED_BY\" --rationale \"$RATIONALE\""},
+        {"type": "artifact_contains", "target": "../../scripts/eval-agentops.sh", "value": "eval baseline-audit --root evals/agentops-core --baseline-dir \"$BASELINE_DIR\" --json"},
         {"type": "artifact_contains", "target": "../../scripts/eval-agentops.sh", "value": "eval coverage --root evals/agentops-core --json"},
         {"type": "artifact_contains", "target": "../../scripts/eval-agentops.sh", "value": "coverage: required domains, dimensions, and runtimes covered"},
         {"type": "artifact_contains", "target": "../../scripts/eval-agentops.sh", "value": "if [[ \"$failures\" -gt 0 && \"$ADVISORY\" != \"true\" ]]"}

--- a/evals/agentops-core/explicit-skill-prompts.json
+++ b/evals/agentops-core/explicit-skill-prompts.json
@@ -32,7 +32,7 @@
       {"name": "learning_closure", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.explicit-skill-prompts.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "explicit-skill-prompt-catalog",

--- a/evals/agentops-core/finding-prevention-governance.json
+++ b/evals/agentops-core/finding-prevention-governance.json
@@ -25,7 +25,7 @@
       {"name": "learning_closure", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.finding-prevention-governance.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "finding-registry-skill-flow",

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,4} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "58" || "$sub_count" != "139" || "$all_count" != "197" ]]; then
+if [[ "$top_count" != "58" || "$sub_count" != "140" || "$all_count" != "198" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 197 ]]; then
+if [[ "${#commands[@]}" -ne 198 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/evals/agentops-core/goals-autodev-evolve.json
+++ b/evals/agentops-core/goals-autodev-evolve.json
@@ -25,7 +25,7 @@
       {"name": "learning_closure", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.goals-autodev-evolve.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "goals-autodev-evolve-focused-tests",

--- a/evals/agentops-core/goals-management-lifecycle.json
+++ b/evals/agentops-core/goals-management-lifecycle.json
@@ -25,7 +25,7 @@
       {"name": "learning_closure", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.goals-management-lifecycle.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "goals-management-focused-tests",

--- a/evals/agentops-core/headless-runtime-skills.json
+++ b/evals/agentops-core/headless-runtime-skills.json
@@ -27,7 +27,7 @@
       {"name": "safety", "weight": 1, "threshold": 1, "critical": true}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.headless-runtime-skills.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "headless-runtime-script-tests",

--- a/evals/agentops-core/hidden-cli-internals.json
+++ b/evals/agentops-core/hidden-cli-internals.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.hidden-cli-internals.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "hidden-cli-internals-go-tests",

--- a/evals/agentops-core/holdout-isolation-behavior.json
+++ b/evals/agentops-core/holdout-isolation-behavior.json
@@ -32,7 +32,7 @@
       {"name": "runtime_compatibility", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.holdout-isolation-behavior.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "holdout-isolation-source-and-embedded",

--- a/evals/agentops-core/hook-gates.json
+++ b/evals/agentops-core/hook-gates.json
@@ -24,7 +24,7 @@
       {"name": "safety", "weight": 1, "threshold": 1, "critical": true}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.hook-gates.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "hook-preflight",

--- a/evals/agentops-core/hook-lifecycle-behavior.json
+++ b/evals/agentops-core/hook-lifecycle-behavior.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 2, "threshold": 1, "critical": true}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.hook-lifecycle-behavior.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "dev-hook-install-tests",

--- a/evals/agentops-core/hook-manifest-runtime-contracts.json
+++ b/evals/agentops-core/hook-manifest-runtime-contracts.json
@@ -25,7 +25,7 @@
       {"name": "runtime_compatibility", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.hook-manifest-runtime-contracts.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "hook-preflight-and-orphan-audit",

--- a/evals/agentops-core/knowledge-flywheel-ingestion.json
+++ b/evals/agentops-core/knowledge-flywheel-ingestion.json
@@ -25,7 +25,7 @@
       {"name": "artifact_quality", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.knowledge-flywheel-ingestion.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "flywheel-ingestion-command-tests",

--- a/evals/agentops-core/mock-runtime-contracts.json
+++ b/evals/agentops-core/mock-runtime-contracts.json
@@ -23,7 +23,7 @@
       {"name": "artifact_quality", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.mock-runtime-contracts.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "mock-runtime-record",

--- a/evals/agentops-core/model-upgrade-readiness.json
+++ b/evals/agentops-core/model-upgrade-readiness.json
@@ -32,7 +32,7 @@
       {"name": "artifact_quality", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.model-upgrade-readiness.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "synthetic-model-regression-detected",

--- a/evals/agentops-core/operator-workflow-skills.json
+++ b/evals/agentops-core/operator-workflow-skills.json
@@ -26,7 +26,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.operator-workflow-skills.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "operator-workflow-skill-validators",

--- a/evals/agentops-core/optimization-dependency-governance.json
+++ b/evals/agentops-core/optimization-dependency-governance.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.optimization-dependency-governance.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "optimization-skill-validators",

--- a/evals/agentops-core/parallel-execution-evidence.json
+++ b/evals/agentops-core/parallel-execution-evidence.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 2, "threshold": 1, "critical": true}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.parallel-execution-evidence.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "parallel-execution-skill-validators",

--- a/evals/agentops-core/planning-premortem-gates.json
+++ b/evals/agentops-core/planning-premortem-gates.json
@@ -26,7 +26,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.planning-premortem-gates.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "plan-premortem-validators-and-hook",

--- a/evals/agentops-core/pre-push-gate-governance.json
+++ b/evals/agentops-core/pre-push-gate-governance.json
@@ -25,7 +25,7 @@
       {"name": "runtime_compatibility", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.pre-push-gate-governance.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "pre-push-bats-suite",
@@ -40,10 +40,10 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "1..19"},
+        {"type": "stdout_contains", "value": "1..27"},
         {"type": "stdout_contains", "value": "ok 5 pre-push-gate.sh passes when no Go changes"},
-        {"type": "stdout_contains", "value": "ok 15 pre-push-gate.sh clears GIT env for skill CLI snippets"},
-        {"type": "stdout_contains", "value": "ok 16 pre-push-gate.sh clears GIT env for CLI docs parity"}
+        {"type": "stdout_contains", "value": "ok 19 pre-push-gate.sh clears GIT env for skill CLI snippets"},
+        {"type": "stdout_contains", "value": "ok 20 pre-push-gate.sh clears GIT env for CLI docs parity"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "safety"],
       "critical": true
@@ -72,7 +72,8 @@
       "objective": "Ensure eval changes trigger the AgentOps fast eval gate and that eval-agentops warnings remain visible in pre-push output.",
       "expectations": [
         {"type": "artifact_contains", "target": "../../scripts/pre-push-gate.sh", "value": "scripts/eval-agentops.sh"},
-        {"type": "artifact_contains", "target": "../../scripts/pre-push-gate.sh", "value": "eval_agentops_output=\"$(run_without_git_env_isolated_agents_home scripts/eval-agentops.sh --fast 2>&1)\""},
+        {"type": "artifact_contains", "target": "../../scripts/pre-push-gate.sh", "value": "eval_args=(--fast)"},
+        {"type": "artifact_contains", "target": "../../scripts/pre-push-gate.sh", "value": "eval_agentops_output=\"$(run_without_git_env_isolated_agents_home scripts/eval-agentops.sh \"${eval_args[@]}\" 2>&1)\""},
         {"type": "artifact_contains", "target": "../../scripts/pre-push-gate.sh", "value": "grep -q '^WARN eval-agentops:'"},
         {"type": "artifact_contains", "target": "../../scripts/pre-push-gate.sh", "value": "warn \"AgentOps eval canaries\""},
         {"type": "artifact_contains", "target": "../../scripts/pre-push-gate.sh", "value": "fail \"missing executable: scripts/eval-agentops.sh\""},

--- a/evals/agentops-core/push-worktree-closeout.json
+++ b/evals/agentops-core/push-worktree-closeout.json
@@ -25,7 +25,7 @@
       {"name": "runtime_compatibility", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.push-worktree-closeout.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "push-skill-validators",

--- a/evals/agentops-core/ratchet-lifecycle-ledger.json
+++ b/evals/agentops-core/ratchet-lifecycle-ledger.json
@@ -25,7 +25,7 @@
       {"name": "learning_closure", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.ratchet-lifecycle-ledger.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "ratchet-lifecycle-focused-tests",

--- a/evals/agentops-core/red-team-adversarial-validation.json
+++ b/evals/agentops-core/red-team-adversarial-validation.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.red-team-adversarial-validation.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "red-team-validator-and-codex-reference-parity",

--- a/evals/agentops-core/release-security-gates.json
+++ b/evals/agentops-core/release-security-gates.json
@@ -25,7 +25,7 @@
       {"name": "runtime_compatibility", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.release-security-gates.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "security-gate-script-tests",

--- a/evals/agentops-core/retag-release-governance.json
+++ b/evals/agentops-core/retag-release-governance.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1, "critical": true}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.retag-release-governance.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "retag-release-bats",

--- a/evals/agentops-core/retrieval-brokerage-citations.json
+++ b/evals/agentops-core/retrieval-brokerage-citations.json
@@ -26,7 +26,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.retrieval-brokerage-citations.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "retrieval-brokerage-go-tests",

--- a/evals/agentops-core/retrieval-contracts.json
+++ b/evals/agentops-core/retrieval-contracts.json
@@ -24,7 +24,7 @@
       {"name": "runtime_compatibility", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.retrieval-contracts.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "retrieval-cli-docs",

--- a/evals/agentops-core/retrieval-quality-gates.json
+++ b/evals/agentops-core/retrieval-quality-gates.json
@@ -32,7 +32,7 @@
       {"name": "runtime_compatibility", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.retrieval-quality-gates.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "retrieval-quality-smoke",

--- a/evals/agentops-core/rpi-behavior.json
+++ b/evals/agentops-core/rpi-behavior.json
@@ -24,7 +24,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.rpi-behavior.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "rpi-runtime-files",

--- a/evals/agentops-core/rpi-control-plane-orchestration.json
+++ b/evals/agentops-core/rpi-control-plane-orchestration.json
@@ -26,7 +26,7 @@
       {"name": "efficiency", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.rpi-control-plane-orchestration.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "rpi-control-plane-go-tests",

--- a/evals/agentops-core/rpi-scorecard.json
+++ b/evals/agentops-core/rpi-scorecard.json
@@ -24,7 +24,7 @@
       {"name": "safety", "weight": 1, "threshold": 1, "critical": true}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.rpi-scorecard.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "scorecard.artifact-completeness.surface",

--- a/evals/agentops-core/runtime-contracts.json
+++ b/evals/agentops-core/runtime-contracts.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1, "critical": true}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.runtime-contracts.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "runtime-isolation-contract",

--- a/evals/agentops-core/runtime-smoke-matrix.json
+++ b/evals/agentops-core/runtime-smoke-matrix.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1, "critical": true}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.runtime-smoke-matrix.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "claude-code-runtime-smoke",

--- a/evals/agentops-core/scenario-contracts.json
+++ b/evals/agentops-core/scenario-contracts.json
@@ -24,7 +24,7 @@
       {"name": "safety", "weight": 1, "threshold": 1, "critical": true}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.scenario-contracts.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "scenario-schema-contract",

--- a/evals/agentops-core/security-suite-behavioral-gates.json
+++ b/evals/agentops-core/security-suite-behavioral-gates.json
@@ -25,7 +25,7 @@
       {"name": "artifact_quality", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.security-suite-behavioral-gates.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "security-suite-validators-and-redteam-tests",

--- a/evals/agentops-core/security-toolchain-governance.json
+++ b/evals/agentops-core/security-toolchain-governance.json
@@ -25,7 +25,7 @@
       {"name": "runtime_compatibility", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.security-toolchain-governance.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "toolchain-gate-exit-semantics",

--- a/evals/agentops-core/session-continuity-context.json
+++ b/evals/agentops-core/session-continuity-context.json
@@ -26,7 +26,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.session-continuity-context.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "session-continuity-go-tests",

--- a/evals/agentops-core/skill-catalog.json
+++ b/evals/agentops-core/skill-catalog.json
@@ -24,7 +24,7 @@
       {"name": "runtime_compatibility", "weight": 1, "threshold": 1, "critical": true}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.skill-catalog.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "skill-counts-synced",

--- a/evals/agentops-core/skill-change-scorecard.json
+++ b/evals/agentops-core/skill-change-scorecard.json
@@ -25,7 +25,7 @@
       {"name": "learning_closure", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.skill-change-scorecard.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "scorecard.structural.surface",

--- a/evals/agentops-core/skill-quality-gates.json
+++ b/evals/agentops-core/skill-quality-gates.json
@@ -25,7 +25,7 @@
       {"name": "efficiency", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.skill-quality-gates.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "skill-validation-suite",

--- a/evals/agentops-core/standards-governance.json
+++ b/evals/agentops-core/standards-governance.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.standards-governance.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "standards-skill-validators",

--- a/evals/agentops-core/status-quickstart-dashboard.json
+++ b/evals/agentops-core/status-quickstart-dashboard.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.status-quickstart-dashboard.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "status-quickstart-skill-validators",

--- a/evals/agentops-core/supporting-cli-utilities.json
+++ b/evals/agentops-core/supporting-cli-utilities.json
@@ -25,7 +25,7 @@
       {"name": "safety", "weight": 1, "threshold": 1}
     ]
   },
-  "baseline_policy": {"mode": "none"},
+  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.supporting-cli-utilities.baseline.json", "blocking_gate": "none"},
   "cases": [
     {
       "id": "supporting-cli-utility-go-tests",

--- a/schemas/eval-suite.v1.schema.json
+++ b/schemas/eval-suite.v1.schema.json
@@ -45,6 +45,9 @@
     "tier": {
       "$ref": "#/$defs/tier"
     },
+    "evidence_kind": {
+      "$ref": "#/$defs/evidence_kind"
+    },
     "owners": {
       "type": "array",
       "items": {
@@ -248,6 +251,18 @@
         "manual"
       ]
     },
+    "evidence_kind": {
+      "type": "string",
+      "enum": [
+        "contract_canary",
+        "gate_wrapper",
+        "behavior_fixture",
+        "baseline_regression",
+        "scorecard_fixture",
+        "live_runtime",
+        "holdout"
+      ]
+    },
     "dimension": {
       "type": "string",
       "enum": [
@@ -344,6 +359,9 @@
         "objective": {
           "type": "string",
           "minLength": 1
+        },
+        "evidence_kind": {
+          "$ref": "#/$defs/evidence_kind"
         },
         "runtime": {
           "$ref": "#/$defs/runtime"

--- a/scripts/eval-agentops.sh
+++ b/scripts/eval-agentops.sh
@@ -224,6 +224,8 @@ for suite in "${SUITES[@]}"; do
     run_stdout="$run_dir/${suite_id}.run.stdout.json"
     baseline_path="$BASELINE_DIR/${suite_id}.baseline.json"
     compare_path="$run_dir/${suite_id}.compare.json"
+    baseline_mode="$(json_get_default "$suite" "baseline_policy.mode" "none")"
+    baseline_gate="$(json_get_default "$suite" "baseline_policy.blocking_gate" "none")"
 
     echo ""
     echo "== $suite_id =="
@@ -272,7 +274,23 @@ for suite in "${SUITES[@]}"; do
             fi
         fi
     else
-        record_warning "$suite_id has no promoted baseline at $baseline_path"
+        case "$baseline_mode" in
+            compare)
+                if [[ "$baseline_gate" == "pre-push" || "$baseline_gate" == "ci" || "$baseline_gate" == "release" || "$baseline_gate" == "model-upgrade" ]]; then
+                    record_failure "$suite_id requires a promoted baseline at $baseline_path"
+                else
+                    record_warning "$suite_id has no promoted baseline at $baseline_path"
+                fi
+                ;;
+            promotable)
+                record_warning "$suite_id is promotable but has no promoted baseline at $baseline_path"
+                ;;
+            none|"")
+                ;;
+            *)
+                record_warning "$suite_id has unknown baseline_policy.mode=$baseline_mode"
+                ;;
+        esac
     fi
 
     if [[ "$PROMOTE" == "true" ]]; then
@@ -288,6 +306,8 @@ done
 if [[ "$FAST" == "true" ]]; then
     coverage_path="$run_dir/coverage.json"
     coverage_stdout="$run_dir/coverage.stdout.json"
+    baseline_audit_path="$run_dir/baseline-audit.json"
+    baseline_audit_stdout="$run_dir/baseline-audit.stdout.json"
     echo ""
     echo "== eval coverage =="
     if ! "$AO_BIN" eval coverage --root evals/agentops-core --json >"$coverage_path"; then
@@ -299,6 +319,27 @@ if [[ "$FAST" == "true" ]]; then
             record_failure "coverage gaps: $coverage_missing"
         else
             echo "coverage: required domains, dimensions, and runtimes covered"
+        fi
+    fi
+    echo ""
+    echo "== eval baseline audit =="
+    if ! "$AO_BIN" eval baseline-audit --root evals/agentops-core --baseline-dir "$BASELINE_DIR" --json >"$baseline_audit_path"; then
+        record_failure "baseline audit command failed"
+    else
+        cp "$baseline_audit_path" "$baseline_audit_stdout"
+        policy_mismatches="$(json_get "$baseline_audit_path" "policy_mismatch_count")"
+        stale_hashes="$(python3 - "$baseline_audit_path" <<'PY'
+import json
+import sys
+with open(sys.argv[1], encoding="utf-8") as fh:
+    data = json.load(fh)
+print(len(data.get("stale_suite_hashes") or []))
+PY
+)"
+        if [[ "$policy_mismatches" != "0" ]]; then
+            record_failure "baseline policy mismatches: $policy_mismatches"
+        else
+            echo "baseline audit: policy mismatches=0 stale_suite_hashes=$stale_hashes"
         fi
     fi
 fi


### PR DESCRIPTION
## Summary
- add eval evidence_kind schema/types, coverage aggregation, and --require-evidence-kind reporting
- add ao eval baseline-audit and make eval-agentops baseline warnings policy-aware
- align public suite baseline_policy with promoted baseline artifacts and update affected canaries/docs

## RPI scope
- completes ag-v29.1 and ag-v29.2
- leaves ag-v29.3 through ag-v29.6 open for later waves
- adds ag-cxh for stale baseline suite hash refresh

## Validation
- python3 -m json.tool schemas/eval-suite.v1.schema.json
- find evals/agentops-core -maxdepth 1 -name '*.json' -print0 | xargs -0 -n1 python3 -m json.tool
- cd cli && env -u AGENTOPS_RPI_RUNTIME go test ./cmd/ao ./internal/eval
- cd cli && env -u AGENTOPS_RPI_RUNTIME go run ./cmd/ao eval coverage --root ../evals/agentops-core --json | jq -e '.evidence_kinds'
- cd cli && env -u AGENTOPS_RPI_RUNTIME go run ./cmd/ao eval baseline-audit --root ../evals/agentops-core --baseline-dir ../.agents/evals/baselines --json | jq -e '.policy_mismatch_count == 0'
- scripts/eval-agentops.sh --fast
- scripts/pre-push-gate.sh --fast --scope staged