### PR TITLE
test(cli): enforce Cobra command docs conformance

### DIFF
--- a/cli/cmd/ao/cobra_conformance_test.go
+++ b/cli/cmd/ao/cobra_conformance_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+var commandHeadingPattern = regexp.MustCompile("(?m)^#{3,6} `(ao(?: [^`]+)+)`$")
+
+func TestCobraConformance(t *testing.T) {
+	rootCmd.InitDefaultHelpCmd()
+
+	docsPath := filepath.Join("..", "..", "docs", "COMMANDS.md")
+	data, err := os.ReadFile(docsPath)
+	if err != nil {
+		t.Fatalf("read generated CLI reference: %v", err)
+	}
+
+	liveCommands := visibleCobraCommandPaths(rootCmd)
+	documentedCommands := documentedCommandPaths(string(data))
+
+	missingDocs := difference(liveCommands, documentedCommands)
+	staleDocs := difference(documentedCommands, liveCommands)
+	if len(missingDocs) > 0 || len(staleDocs) > 0 {
+		t.Fatalf("cli/docs/COMMANDS.md is not in conformance with the live Cobra tree.\nMissing from docs:%s\nStale in docs:%s\nRun scripts/generate-cli-reference.sh to regenerate.",
+			formatCommandList(missingDocs),
+			formatCommandList(staleDocs),
+		)
+	}
+}
+
+func visibleCobraCommandPaths(root *cobra.Command) map[string]struct{} {
+	paths := map[string]struct{}{}
+
+	var walk func(*cobra.Command)
+	walk = func(parent *cobra.Command) {
+		for _, child := range parent.Commands() {
+			if child.Hidden {
+				continue
+			}
+
+			path := strings.TrimSpace(child.CommandPath())
+			if path != "" {
+				paths[path] = struct{}{}
+			}
+
+			walk(child)
+		}
+	}
+
+	walk(root)
+	return paths
+}
+
+func documentedCommandPaths(docs string) map[string]struct{} {
+	paths := map[string]struct{}{}
+
+	for _, match := range commandHeadingPattern.FindAllStringSubmatch(docs, -1) {
+		paths[strings.TrimSpace(match[1])] = struct{}{}
+	}
+
+	return paths
+}
+
+func difference(left, right map[string]struct{}) []string {
+	var diff []string
+
+	for path := range left {
+		if _, ok := right[path]; !ok {
+			diff = append(diff, path)
+		}
+	}
+
+	sort.Strings(diff)
+	return diff
+}
+
+func formatCommandList(paths []string) string {
+	if len(paths) == 0 {
+		return "\n  - none"
+	}
+
+	var builder strings.Builder
+	for _, path := range paths {
+		fmt.Fprintf(&builder, "\n  - %s", path)
+	}
+
+	return builder.String()
+}

--- a/scripts/generate-cli-reference.sh
+++ b/scripts/generate-cli-reference.sh
@@ -107,6 +107,91 @@ first_line() {
   printf '%s\n' "${text%%$'\n'*}"
 }
 
+heading_for_depth() {
+  local depth="$1"
+  local level=$((depth + 2))
+  local heading=""
+  local i
+
+  if ((level > 6)); then
+    level=6
+  fi
+
+  for ((i = 0; i < level; i++)); do
+    heading+="#"
+  done
+  printf '%s' "$heading"
+}
+
+command_label() {
+  local label="ao"
+  local part
+
+  for part in "$@"; do
+    label+=" $part"
+  done
+
+  printf '%s' "$label"
+}
+
+emit_command_reference() {
+  local depth="$1"
+  shift
+
+  local -a command_path=("$@")
+  local cmd_help
+  cmd_help="$("$AO_BIN" "${command_path[@]}" --help 2>&1 || true)"
+
+  local description
+  description="$(first_line "$cmd_help")"
+
+  local heading
+  heading="$(heading_for_depth "$depth")"
+
+  local label
+  label="$(command_label "${command_path[@]}")"
+
+  echo "${heading} \`${label}\`"
+  echo ""
+  echo "$description"
+  echo ""
+
+  local usage
+  usage="$(echo "$cmd_help" | extract_usage || true)"
+  if [[ -n "$usage" ]]; then
+    echo '```'
+    echo "$usage"
+    echo '```'
+    echo ""
+  fi
+
+  local flags_block
+  flags_block="$(echo "$cmd_help" | extract_flags || true)"
+  if echo "$flags_block" | has_non_help_flags >/dev/null 2>&1; then
+    echo "**Flags:**"
+    echo ""
+    echo '```'
+    echo "$flags_block"
+    echo '```'
+    echo ""
+  fi
+
+  local subcmds
+  subcmds="$(echo "$cmd_help" | extract_commands | grep -v '^$' || true)"
+  if [[ -n "$subcmds" ]]; then
+    if [[ "$depth" -eq 1 ]]; then
+      echo "**Subcommands:**"
+      echo ""
+    fi
+
+    local sub
+    while IFS= read -r sub; do
+      [[ -z "$sub" ]] && continue
+      emit_command_reference "$((depth + 1))" "${command_path[@]}" "$sub"
+    done <<<"$subcmds"
+  fi
+}
+
 generate() {
   cat <<DOC_HEADER
 # ao CLI Reference
@@ -140,113 +225,7 @@ DOC_GLOBAL_FLAGS
 DOC_COMMANDS
 
   for cmd in $commands; do
-    local cmd_help
-    cmd_help="$("$AO_BIN" "$cmd" --help 2>&1 || true)"
-
-    local description
-    description="$(first_line "$cmd_help")"
-
-    echo "### \`ao ${cmd}\`"
-    echo ""
-    echo "$description"
-    echo ""
-
-    local usage
-    usage="$(echo "$cmd_help" | extract_usage || true)"
-    if [[ -n "$usage" ]]; then
-      echo '```'
-      echo "$usage"
-      echo '```'
-      echo ""
-    fi
-
-    local flags_block
-    flags_block="$(echo "$cmd_help" | extract_flags || true)"
-    if echo "$flags_block" | has_non_help_flags >/dev/null 2>&1; then
-      echo "**Flags:**"
-      echo ""
-      echo '```'
-      echo "$flags_block"
-      echo '```'
-      echo ""
-    fi
-
-    local subcmds
-    subcmds="$(echo "$cmd_help" | extract_commands | grep -v '^$' || true)"
-    if [[ -n "$subcmds" ]]; then
-      echo "**Subcommands:**"
-      echo ""
-      for sub in $subcmds; do
-        local sub_help
-        sub_help="$("$AO_BIN" "$cmd" "$sub" --help 2>&1 || true)"
-
-        local sub_desc
-        sub_desc="$(first_line "$sub_help")"
-
-        echo "#### \`ao ${cmd} ${sub}\`"
-        echo ""
-        echo "$sub_desc"
-        echo ""
-
-        local sub_usage
-        sub_usage="$(echo "$sub_help" | extract_usage || true)"
-        if [[ -n "$sub_usage" ]]; then
-          echo '```'
-          echo "$sub_usage"
-          echo '```'
-          echo ""
-        fi
-
-        local sub_flags
-        sub_flags="$(echo "$sub_help" | extract_flags || true)"
-        if echo "$sub_flags" | has_non_help_flags >/dev/null 2>&1; then
-          echo "**Flags:**"
-          echo ""
-          echo '```'
-          echo "$sub_flags"
-          echo '```'
-          echo ""
-        fi
-
-        local subsub_cmds
-        subsub_cmds="$(echo "$sub_help" | extract_commands | grep -v '^$' || true)"
-        if [[ -n "$subsub_cmds" ]]; then
-          for subsub in $subsub_cmds; do
-            local subsub_help
-            subsub_help="$("$AO_BIN" "$cmd" "$sub" "$subsub" --help 2>&1 || true)"
-
-            local subsub_desc
-            subsub_desc="$(first_line "$subsub_help")"
-
-            echo "##### \`ao ${cmd} ${sub} ${subsub}\`"
-            echo ""
-            echo "$subsub_desc"
-            echo ""
-
-            local subsub_usage
-            subsub_usage="$(echo "$subsub_help" | extract_usage || true)"
-            if [[ -n "$subsub_usage" ]]; then
-              echo '```'
-              echo "$subsub_usage"
-              echo '```'
-              echo ""
-            fi
-
-            local subsub_flags
-            subsub_flags="$(echo "$subsub_help" | extract_flags || true)"
-            if echo "$subsub_flags" | has_non_help_flags >/dev/null 2>&1; then
-              echo "**Flags:**"
-              echo ""
-              echo '```'
-              echo "$subsub_flags"
-              echo '```'
-              echo ""
-            fi
-          done
-        fi
-      done
-    fi
-
+    emit_command_reference 1 "$cmd"
     echo "---"
     echo ""
   done


### PR DESCRIPTION
## Summary
- Refactor scripts/generate-cli-reference.sh to recursively walk Cobra help subtrees instead of stopping after fixed nesting levels.
- Add TestCobraConformance to compare cli/docs/COMMANDS.md command headings with the live Cobra command tree.
- Regenerated COMMANDS.md; no content changes were produced.

## Validation
- shellcheck --severity=error scripts/generate-cli-reference.sh
- bash -n scripts/generate-cli-reference.sh
- scripts/generate-cli-reference.sh --check
- cd cli && go test ./cmd/ao -run TestCobraConformance -count=1
- cd cli && go test ./cmd/ao/...
- git diff --check
- scripts/pre-push-gate.sh --fast