### PR TITLE
[codex] handle gc v1 readiness items shape

### DIFF
--- a/cli/internal/agentworker/gascity.go
+++ b/cli/internal/agentworker/gascity.go
@@ -131,8 +131,8 @@ func (w *GasCityWorker) Start(ctx context.Context, req StartRequest) (AgentSessi
 	if err != nil {
 		return nil, fmt.Errorf("gascity city readiness for %q: %w", w.cityName, err)
 	}
-	if !ready.Ready {
-		status := strings.TrimSpace(ready.Status)
+	if !ready.IsReady() {
+		status := strings.TrimSpace(ready.EffectiveStatus())
 		if status == "" {
 			status = "not ready"
 		}

--- a/cli/internal/gascity/types.go
+++ b/cli/internal/gascity/types.go
@@ -38,11 +38,79 @@ type HealthResponse struct {
 
 // ReadinessResponse is the narrow DTO for supervisor, provider, or city
 // readiness probes.
+//
+// Two upstream shapes are accepted:
+//
+//   - Legacy / fixture shape (gascity ≤ 0.13.x): top-level {ready,status,degraded,providers}.
+//   - gc v1.0.0+ shape: {items: {<name>: {status: configured|...}}} with no
+//     top-level ready boolean. Callers should use IsReady / EffectiveStatus
+//     rather than reading Ready directly.
 type ReadinessResponse struct {
-	Ready     bool     `json:"ready"`
-	Status    string   `json:"status,omitempty"`
-	Degraded  []string `json:"degraded,omitempty"`
-	Providers []string `json:"providers,omitempty"`
+	Ready     bool                     `json:"ready"`
+	Status    string                   `json:"status,omitempty"`
+	Degraded  []string                 `json:"degraded,omitempty"`
+	Providers []string                 `json:"providers,omitempty"`
+	Items     map[string]ReadinessItem `json:"items,omitempty"`
+}
+
+// ReadinessItem is one entry in the gc v1.0.0+ items-shape readiness response.
+type ReadinessItem struct {
+	Name        string `json:"name,omitempty"`
+	Kind        string `json:"kind,omitempty"`
+	DisplayName string `json:"display_name,omitempty"`
+	Status      string `json:"status"`
+	Detail      string `json:"detail,omitempty"`
+}
+
+// IsReady reports whether the readiness response signals a usable city / scope.
+// It accepts either the legacy top-level Ready bool or the gc v1.0.0+ items map
+// (ready when at least one item is "configured" or "ready" and none are
+// "degraded"/"error"). Empty responses report not ready.
+func (r ReadinessResponse) IsReady() bool {
+	if r.Ready {
+		return true
+	}
+	if len(r.Items) == 0 {
+		return false
+	}
+	hasConfigured := false
+	for _, item := range r.Items {
+		switch item.Status {
+		case "configured", "ready":
+			hasConfigured = true
+		case "degraded", "error", "unavailable":
+			return false
+		}
+	}
+	return hasConfigured
+}
+
+// EffectiveStatus returns a human-readable status string, preferring the
+// legacy Status field but synthesising from Items when only the gc v1.0.0+
+// shape is present.
+func (r ReadinessResponse) EffectiveStatus() string {
+	if r.Status != "" {
+		return r.Status
+	}
+	if len(r.Items) == 0 {
+		return "no readiness data"
+	}
+	configured, missing := 0, 0
+	for _, item := range r.Items {
+		switch item.Status {
+		case "configured", "ready":
+			configured++
+		default:
+			missing++
+		}
+	}
+	if configured > 0 && missing == 0 {
+		return "ready"
+	}
+	if configured > 0 {
+		return fmt.Sprintf("partial (%d configured, %d missing)", configured, missing)
+	}
+	return "not ready"
 }
 
 // CityCreateRequest is the request body for POST /v0/city.

--- a/cli/internal/gascity/types_test.go
+++ b/cli/internal/gascity/types_test.go
@@ -8,6 +8,66 @@ import (
 	"testing"
 )
 
+func TestReadinessResponseIsReadyBothShapes(t *testing.T) {
+	cases := []struct {
+		name      string
+		json      string
+		wantReady bool
+		wantStat  string
+	}{
+		{
+			name:      "legacy_ready_true",
+			json:      `{"ready":true,"status":"ready"}`,
+			wantReady: true,
+			wantStat:  "ready",
+		},
+		{
+			name:      "legacy_ready_false",
+			json:      `{"ready":false,"status":"degraded","degraded":["claude"]}`,
+			wantReady: false,
+			wantStat:  "degraded",
+		},
+		{
+			name:      "gc_v1_items_all_configured",
+			json:      `{"items":{"claude":{"status":"configured"},"codex":{"status":"configured"}}}`,
+			wantReady: true,
+			wantStat:  "ready",
+		},
+		{
+			name:      "gc_v1_items_partial",
+			json:      `{"items":{"claude":{"status":"configured"},"gemini":{"status":"not_installed"}}}`,
+			wantReady: true,
+			wantStat:  "partial (1 configured, 1 missing)",
+		},
+		{
+			name:      "gc_v1_items_degraded_blocks",
+			json:      `{"items":{"claude":{"status":"configured"},"codex":{"status":"degraded"}}}`,
+			wantReady: false,
+			wantStat:  "partial (1 configured, 1 missing)",
+		},
+		{
+			name:      "empty",
+			json:      `{}`,
+			wantReady: false,
+			wantStat:  "no readiness data",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var resp ReadinessResponse
+			if err := json.Unmarshal([]byte(tc.json), &resp); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := resp.IsReady(); got != tc.wantReady {
+				t.Fatalf("IsReady() = %v, want %v (response=%#v)", got, tc.wantReady, resp)
+			}
+			if got := resp.EffectiveStatus(); got != tc.wantStat {
+				t.Fatalf("EffectiveStatus() = %q, want %q", got, tc.wantStat)
+			}
+		})
+	}
+}
+
 func TestContractVersion(t *testing.T) {
 	if err := ValidateContractVersion(AdapterContractVersion); err != nil {
 		t.Fatalf("current contract rejected: %v", err)


### PR DESCRIPTION
## Summary
- Add `items` support to `gascity.ReadinessResponse` while keeping the legacy top-level readiness fields.
- Add `IsReady()` and `EffectiveStatus()` helpers so the worker no longer treats gc v1 readiness responses as false zero-values.
- Cover legacy, gc v1, partial, empty, and degraded-blocking readiness cases.

## Why
When agentopsd is configured with `--executor-policy=gascity`, gc v1.0.0 returns `/v0/city/<name>/readiness` as an `items` map instead of the older top-level `{ready,status,...}` shape. The worker decoded that into `Ready=false` and refused every job before creating a GasCity session.

## Scope
This is intentionally limited to Drift 1 from the 2026-04-29 handoff. It does not change session-create options handling; the gc v1 unknown-options contract drift is tracked separately in `soc-6hgw`.

## Validation
- `git diff --check main...HEAD`
- `go test ./internal/gascity ./internal/agentworker` from `cli/`
- `go vet ./internal/gascity ./internal/agentworker` from `cli/`
- `make -C cli build`
- `git push` pre-push fast gate passed