### PR TITLE
[codex] stop sending AgentOps metadata as GasCity options

### DIFF
--- a/cli/internal/agentworker/gascity.go
+++ b/cli/internal/agentworker/gascity.go
@@ -141,12 +141,13 @@ func (w *GasCityWorker) Start(ctx context.Context, req StartRequest) (AgentSessi
 
 	alias := w.aliasFunc(req)
 	session, createMeta, err := w.client.CreateSession(ctx, w.cityName, gascity.SessionCreateRequest{
-		Kind:    "agent",
-		Name:    string(req.WorkerKind),
-		Alias:   alias,
-		Async:   true,
-		Options: gasCitySessionOptions(req),
-		Title:   firstNonEmpty(req.Metadata["title"], req.JobID, string(req.WorkerKind)+" worker"),
+		Kind:  "agent",
+		Name:  string(req.WorkerKind),
+		Alias: alias,
+		Async: true,
+		// GasCity validates options against the provider schema. AgentOps job
+		// metadata is arbitrary and remains in AgentOps' durable SessionRef.
+		Title: firstNonEmpty(req.Metadata["title"], req.JobID, string(req.WorkerKind)+" worker"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("gascity create %s session: %w", req.WorkerKind, err)
@@ -339,34 +340,6 @@ func validateGasCityWorkerKind(kind WorkerKind) error {
 	default:
 		return fmt.Errorf("unsupported gascity worker kind %q", kind)
 	}
-}
-
-func gasCitySessionOptions(req StartRequest) map[string]string {
-	options := map[string]string{
-		"agentops.worker_kind": string(req.WorkerKind),
-	}
-	if req.Model != "" {
-		options["agentops.model"] = req.Model
-	}
-	if req.CWD != "" {
-		options["agentops.cwd"] = req.CWD
-	}
-	if req.JobID != "" {
-		options["agentops.job_id"] = req.JobID
-	}
-	if req.AttemptID != "" {
-		options["agentops.attempt_id"] = req.AttemptID
-	}
-	if req.RequestID != "" {
-		options["agentops.request_id"] = req.RequestID
-	}
-	for key, value := range req.Metadata {
-		if strings.TrimSpace(key) == "" {
-			continue
-		}
-		options[key] = value
-	}
-	return options
 }
 
 func gasCitySessionRef(req StartRequest, session gascity.Session, requestID string, status SessionStatus) SessionRef {

--- a/cli/internal/agentworker/gascity_test.go
+++ b/cli/internal/agentworker/gascity_test.go
@@ -65,8 +65,15 @@ func TestGasCityAgentWorkerStartsCodexSessionAndStreamsTerminal(t *testing.T) {
 	if len(fake.createCalls) != 1 || fake.createCalls[0].req.Name != "codex" {
 		t.Fatalf("create calls: %#v", fake.createCalls)
 	}
-	if fake.createCalls[0].req.Options["agentops.cwd"] != "/repo" {
-		t.Fatalf("create options: %#v", fake.createCalls[0].req.Options)
+	createReq := fake.createCalls[0].req
+	if len(createReq.Options) != 0 {
+		t.Fatalf("create options should not carry AgentOps metadata: %#v", createReq.Options)
+	}
+	if createReq.Title != "wiki forge" {
+		t.Fatalf("create title = %q, want wiki forge", createReq.Title)
+	}
+	if createReq.Alias != "agentworker-wiki-forge-1" {
+		t.Fatalf("create alias = %q, want agentworker-wiki-forge-1", createReq.Alias)
 	}
 	if len(fake.submitCalls) != 1 || fake.submitCalls[0].req.Message != "extract wiki lessons" {
 		t.Fatalf("submit calls: %#v", fake.submitCalls)


### PR DESCRIPTION
## Summary
- Stop populating GasCity session-create `options` with AgentOps job metadata.
- Keep useful operator context in the session alias/title and AgentOps' durable `SessionRef`.
- Update the GasCity worker test to assert arbitrary AgentOps metadata does not enter the options payload.

## Why
GasCity v1 validates session-create `options` against the resolved provider `OptionsSchema`. AgentOps was sending keys such as `agentops.cwd`, `agentops.job_id`, `daemon_job_id`, `source_path`, and `dream_run_id` through `options`; those values are arbitrary per job and cannot be represented by GasCity's current fixed-choice option schema. The result was HTTP 400 `unknown_option`/`invalid_option_value` before a Codex session could start.

## Scope
This chooses the AgentOps-side strategy for the options-validation drift tracked in `soc-6hgw`. It intentionally does not add a GasCity metadata field or loosen GasCity option validation. Future per-session model/permission overrides can be added later by querying/mapping the GasCity provider schema explicitly.

## Validation
- `git diff --check main...HEAD`
- `go test ./internal/agentworker` from `cli/`
- `go vet ./internal/agentworker` from `cli/`
- `make -C cli build`
- pre-commit Go build + vet passed
- `git push` pre-push fast gate passed