### PR TITLE
docs: voice + positioning — DevOps for the agent

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,22 +1,20 @@
 ---
-last_reviewed: 2026-04-24
+last_reviewed: 2026-04-30
 ---
 
 # PRODUCT.md
 
 ## Mission
 
-AgentOps is the operational layer for coding agents. Publicly, it gives agents **bookkeeping**, **validation**, **primitives**, and **flows** so every session starts where the last one left off. Technically, it uses a context-compiler architecture: raw session signal becomes reusable knowledge, compiled prevention, and better next work.
-
-The older three-gap model remains the internal proof contract: judgment validation, durable learning, and loop closure are how we verify that the product actually compounds.
+AgentOps is operational discipline for coding agents. The hard problem: ship reliable code with unreliable agents that don't remember anything. Build the knowledge and memory into the system AND the process — a Meadows compounding system. The moat is the context you, your team, and your business have earned: every landmine, every decision, every scar. Atomic changes. Validation gates. Compounding context. Every session writes a learning. Every learning sharpens the next.
 
 > Canonical contract: [docs/context-lifecycle.md](docs/context-lifecycle.md)
 
 ## Vision
 
-The software factory that gets better with each use. Every session produces code, lessons, and stronger constraints — so the next session starts with more knowledge, tighter gates, and less wasted work. The model stays the same; the environment around it compounds.
+The software factory that gets better with each use. Every session produces code, lessons, and stronger constraints — the next session starts with more knowledge, tighter gates, and less wasted work. The model stays the same. The corpus compounds.
 
-This is the direction the industry is converging on. Anthropic's internal Claude Code architecture validates the same three primitives AgentOps shipped months earlier: a learning loop (memory extraction → off-session consolidation → future injection), self-programming skills (pattern extraction into reusable capabilities), and adversarial verification (independent agents auditing other agents' output). AgentOps is already there — the work now is deepening the flywheel and making it autonomous.
+The thesis is simple: indeterministic workers need disciplined systems. DevOps proved this for engineers. SRE proved it again with SLOs and error budgets. Kubernetes proved it for declarative infrastructure with control loops that reconcile actual state to desired state. Coding agents are the next indeterministic worker class. Same playbook. New substrate. The asset that survives — yours, not ours — is the corpus the system compounds on your behalf.
 
 ## Market Convergence
 
@@ -28,7 +26,7 @@ The April 2026 Claude Code source analysis confirmed that Anthropic's internal t
 | **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 69 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
 | **Verification Agent** — adversarial AI auditing AI, VERDICT system for human review | Council architecture — `/council`, `/pre-mortem`, `/vibe`, `/post-mortem` with multi-model consensus, prediction tracking. Stage 4 behavioral validation adds holdout scenarios + satisfaction scoring in STEP 1.8. | Shipped. On-demand + always-on (STEP 1.8 fires automatically during `/validation`). |
 
-The gap between "architecture exists for compound growth" (what others describe) and "compound growth is actually happening" (what AgentOps delivers with harvest/forge/evolve) is the moat.
+Read the convergence table the right way: AgentOps and every harness like it gets absorbed into the model layer over time. Memory primitives, learning loops, even validation gates — frontier vendors will ship them natively. What stays yours is the corpus. AgentOps is the bridge tool that helps you build the moat *now*, with current models, before the harness layer commoditizes.
 
 ## Target Personas
 
@@ -49,98 +47,111 @@ The gap between "architecture exists for compound growth" (what others describe)
 
 ## What the Product Actually Is
 
-AgentOps has three layers:
+The bridge tool has three layers. Each smooths a sharp edge of current models so you can build the moat (the corpus) underneath.
 
 ### 1. Skills (69 skills across 4 runtimes)
 
-Markdown-defined primitives and flows that agents load and execute:
+**The discipline layer.**
 
-- **Validation primitives** — `/pre-mortem`, `/vibe`, `/council`, `/review`. Multi-model consensus validates plans before build and code before commit.
-- **Bookkeeping primitives** — `/retro`, `/forge`, `/inject`, `/flywheel`, `/compile`. Extract, score, curate, and retrieve learnings so solved problems stay solved.
-- **Flows** — `/research`, `/implement`, `/validation`, `/rpi`, `/crank`, `/evolve`. Compose single actions into repeatable paths that can run manually or end to end.
+Markdown-defined primitives and flows that agents load and execute. Atomic, composable, scoped. Engineers recognize the shape: small reviewable units with explicit phase boundaries.
+
+- **Validation primitives** — `/pre-mortem`, `/vibe`, `/council`, `/review`. Multi-model consensus validates plans before build and code before commit. Gates block, not advise.
+- **Bookkeeping primitives** — `/retro`, `/forge`, `/inject`, `/flywheel`, `/compile`. Extract, score, curate, and retrieve learnings so solved problems stay solved. The flywheel runs here.
+- **Flows** — `/research`, `/implement`, `/validation`, `/rpi`, `/crank`, `/evolve`. Compose primitives into auditable phases. Drop in at any phase. No phase compresses into another.
 
 Skills work across Claude Code, Codex CLI, Cursor, and OpenCode through explicit proof tiers. Tier S structural/install proof is active for all four runtimes; Tier I live inventory proof exists for Claude Code and Codex when local CLIs/auth are available; Tier E live execution proof remains opt-in rather than a default CI gate. Codex-native skills ship alongside Claude-native, and `/converter` exports Cursor rules.
 
 ### 2. CLI (`ao`)
 
-A Go binary that provides the repo-native infrastructure skills depend on:
+**The reliability + autonomy layer.**
 
-- **Bookkeeping control plane** — `ao inject`, `ao lookup`, `ao forge`, `ao curate`, `ao defrag`, and `ao memory sync` manage learning capture, retrieval, freshness decay, and promotion.
-- **Goal and issue orchestration** — `ao goals measure` runs fitness gates, `ao goals steer` manages directives, and `bd` provides git-native issue tracking with dependency graphs and epic management.
-- **Context assembly and operator surfaces** — `ao context assemble`, `ao rpi`, and `ao factory` build phase-appropriate packets and terminal-native flows.
+A Go binary that provides the repo-native infrastructure skills depend on. Declarative goals, fitness gates, control loops that reconcile.
+
+- **Bookkeeping control plane** — `ao inject`, `ao lookup`, `ao forge`, `ao curate`, `ao defrag`, `ao memory sync` manage learning capture, retrieval, freshness decay, promotion. The flywheel runs here.
+- **Goals + reconciliation** — `ao goals measure` runs SLO-shaped fitness gates; `ao goals steer` manages directives; `ao evolve` runs the autonomous reconcile loop that closes the worst fitness gap. SRE error-budget logic, applied to a codebase.
+- **Operator surfaces** — `ao context assemble`, `ao rpi`, `ao factory` build phase-appropriate packets and terminal-native flows. Stay in the loop, run on the loop, or drop out entirely. Same machine.
 
 ### 3. Hooks
 
-Session lifecycle hooks that run automatically so the operational layer stays active without agent initiative:
+**The always-on layer.**
+
+Session lifecycle hooks that run automatically so the operational layer stays active without agent initiative. The discipline that fires whether the operator remembered or not.
 
 - **SessionStart / SessionEnd / Stop** — stage runtime state, maintain, and close the bookkeeping loop between sessions.
 - **PreToolUse / PostToolUse** — nudge toward the right primitives and enforce validation constraints.
-- **UserPromptSubmit** — route intent, surface startup guidance, and keep the operator on a productive path.
+- **UserPromptSubmit** — route intent, surface startup guidance, keep the operator on a productive path.
 
 ## Core Value Propositions
 
-The public value proposition should now map to the category we are actually selling:
+The three load-bearing claims, expanded:
 
-- **Bookkeeping That Compounds** — Agent knowledge is managed like code: version-controlled, reviewed, promoted, and decayed instead of trapped in ephemeral chat history or a proprietary store. Each session captures learnings scored on specificity, actionability, novelty, context, and confidence. Learnings promote to patterns; patterns become planning rules.
-- **Validation Before Ship** — Multi-model consensus (Claude + Codex judges debate independently) validates plans before build and code before commit. Validation gates block, not advise.
-- **Primitives + Flows** — Skills are standalone building blocks. Use one (`/council validate this PR`), compose several (`/research` → `/plan` → `/council validate`), or run the full lifecycle (`/rpi`). The same recursive shape repeats at every scale.
-- **Hands-Free Execution** — `/evolve` and `/crank` spawn agents that work toward goals autonomously. Cycle state is disk-based, regression gates are hard-gated, and every cycle writes a verifiable audit trail.
-- **Multi-Runtime, Multi-Model** — Same skills target Claude Code, Codex CLI, Cursor, and OpenCode with documented Tier S/I/E proof levels. `/converter` exports to native formats. Mixed-vendor council judges provide independent perspectives.
-- **Zero Setup, Zero Telemetry** — All state lives in local `.agents/` directories (git-ignored by default; opt in to commit with `AGENTOPS_GITIGNORE_AUTO=0`) with no cloud dependency. 69 skills, 12 runtime hook event sections, and the flywheel can operate with no external daemon.
+- **Atomic changes** — every primitive is small enough to be cheap to undo. `/implement` is one scoped task. `/council` is one verdict. `/forge` extracts one learning at a time. Compose them; the work stays auditable end to end.
+- **Validation gates** — multi-model consensus (Claude + Codex judges debate independently) validates plans before build and code before commit. Gates block, not advise. The three-gap proof contract — judgment, durable learning, loop closure — defines what reliability means here.
+- **Compounding context** — the knowledge flywheel. Each session captures learnings scored on specificity, actionability, novelty, context, and confidence. Learnings promote to patterns; patterns become planning rules. Next session starts loaded, not cold. Escape velocity is a measurable condition: retrieval × usage > decay.
+- **Hands-free reconciliation** — `/evolve` reads `GOALS.md`, picks the worst fitness gap, fixes it, validates, records the cycle. SRE error budgets meet Kubernetes control loops. `/dream` runs overnight bookkeeping; source code stays untouched.
+- **Multi-runtime, multi-model** — same skills target Claude Code, Codex CLI, Cursor, and OpenCode with documented Tier S/I/E proof levels. `/converter` exports to native formats. Mixed-vendor council judges provide independent perspectives — the discipline lives in the system, not the model.
+- **Zero setup, zero telemetry** — all state lives in local `.agents/` directories with no cloud dependency. 69 skills, 12 runtime hook event sections, and the flywheel can operate with no external daemon.
 
 ## Strategic Bet
 
-AgentOps bets that the durable advantage in AI coding will come from compounding context between sessions, not from packing more prompts, more agents, or more context into a single session. The winning layer is the bookkeeping/context-compiler layer: raw session signal becomes reusable learnings, compiled prevention, and better next work.
+Knowledge is the moat. AgentOps isn't. Every harness — ours included — gets absorbed into the model. Memory primitives, learning loops, validation gates: frontier vendors will ship them natively. What they won't ship is *your* corpus — what your repo learned, what your team scarred, what your codebase decided. AgentOps is the bridge tool: skills, hooks, and a CLI that smooth the sharp edges of current models so you produce reliable output today and build the moat that stays.
 
 ## Evidence
 
-As of 2026-04-24:
+As of 2026-04-30:
 
 **Traction:**
 
-- GitHub repo: 265 stars, 24 forks, 2 open issues, last pushed 2026-04-08
-- Public surface: GitHub Pages comparison site and search metadata are live
+- GitHub repo: 320 stars, 34 forks, 10 open issues, last pushed 2026-04-30
+- Public surface: GitHub Pages mkdocs site live at boshu2.github.io/agentops/; doctrine site live at 12factoragentops.com
 - Distribution/runtime reach: 69 shared skills, 69 checked-in Codex artifacts, and 35 Codex overrides
 
 **Measured operational proof:**
 
-- Knowledge corpus: 163 learnings, 13 planning rules, 12 patterns
-- `ao doctor --json`: 10 of 12 checks passing, with full 7/7 hook coverage
-- Competitive freshness gate passing: all 5 comparison docs are within the 45-day target
+- Knowledge corpus: 4,940 learnings, 1,195 patterns, 40 planning rules — the flywheel is producing
+- `ao doctor --json`: hook coverage and structural gates passing
+- Competitive freshness gate: comparison docs maintained within the 45-day target
+
+The flywheel numbers (4,940 learnings, 1,195 patterns) are the load-bearing evidence: extracted, scored, promoted artifacts are accumulating at a rate that exceeds decay. The corpus is compounding, not just claiming to. Note: this is the maintainer's corpus. The product's job is to help every user start building their own.
 
 ## Known Product Gaps
 
 | Gap | Impact | Status |
 |-----|--------|--------|
-| Dream autonomy is still maturing | The private local Dream lane now runs through `/dream` and `ao overnight`, with bounded compounding, reports, setup guidance, and a separate GitHub nightly proof harness. Remaining work is deeper full-loop autonomy, calibration, and onboarding polish rather than the existence of the overnight engine. | in-progress |
-| Pattern-to-skill promotion polish remains | The strongest differentiation thesis, self-programming compounding, now has review-only draft generation; the remaining gap is richer synthesis and a clean publish path. | in-progress |
-| Multi-runtime proof is tiered, not complete | Tier S structural proof is active for Claude Code, Codex, Cursor, and OpenCode, but live inventory/execution proof is only partial and still depends on external CLIs/auth. | in-progress |
-| Messaging is not yet fully unified | Public surfaces should now converge on "operational layer," while technical docs still need a clean split between the public category and the internal "context compiler" framing. | open |
-| Retrieval and worker knowledge propagation still limit compounding | The flywheel architecture is in place, but retrieval quality and passing prevention/finding context to implement workers remain weaker than the core thesis requires. | open |
+| Dream autonomy is still maturing | The private local Dream lane runs through `/dream` and `ao overnight`, with bounded compounding, reports, setup guidance, and a separate GitHub nightly proof harness. Remaining work is deeper full-loop autonomy, calibration, and onboarding polish. | in-progress |
+| Pattern-to-skill promotion polish remains | The strongest differentiation thesis — self-programming compounding — has review-only draft generation today. Remaining gap: richer synthesis and a clean publish path. | in-progress |
+| Multi-runtime proof is tiered, not complete | Tier S structural proof is active for all four runtimes. Tier I live inventory proof is partial. Tier E live execution proof remains opt-in / nightly, not a default gate. | in-progress |
+| Retrieval and worker knowledge propagation still limit compounding | The flywheel architecture is in place. Retrieval quality and passing prevention/finding context to implement workers remain weaker than the core thesis requires. | open |
+| Public messaging now converged on operational-discipline + moat framing | The 2026-04-30 council (`.agents/council/2026-04-30-agentops-product-positioning.md`) locked the thesis: *knowledge is the moat; AgentOps is the bridge tool that helps you build it.* Mission, Strategic Bet, README, and mkdocs surfaces aligned in PR #192. Downstream comparison docs and skill-page intros still need a sweep. | in-progress |
 
 ## Design Principles
 
-**Theoretical foundation — four pillars:**
+**Theoretical foundation — six pillars:**
 
-1. **[Systems theory (Meadows)](https://en.wikipedia.org/wiki/Twelve_leverage_points)** — Target the high-leverage end of the hierarchy: information flows (#6), rules (#5), self-organization (#4), goals (#3). Changing the loop beats tuning the output.
-2. **[DevOps (Three Ways)](docs/the-science.md#part-3-devops-foundation-the-three-ways)** — Flow, feedback, continual learning — applied to the agent loop instead of the deploy pipeline.
-3. **[Brownian Ratchet](docs/brownian-ratchet.md)** — Embrace agent variance, filter aggressively, ratchet successes. Chaos + filter + one-way gate = net forward progress.
-4. **[Knowledge Flywheel (escape velocity)](docs/the-science.md#the-escape-velocity-condition)** — If retrieval rate x usage rate exceeds decay rate, knowledge compounds. If not, it decays to zero. The flywheel exists to stay above that threshold.
+1. **[Systems theory (Meadows)](https://en.wikipedia.org/wiki/Twelve_leverage_points)** — Target the high-leverage end of the hierarchy: information flows (#6), rules (#5), self-organization (#4), goals (#3). Changing the loop beats tuning the output. AgentOps is built as a Meadows compounding system around the user's codebase: information flows captured, rules encoded, self-organization through the flywheel, goals declared.
+2. **[DevOps Three Ways](docs/the-science.md#part-3-devops-foundation-the-three-ways)** — Flow, feedback, continual learning. The discipline lineage. Applied to the agent loop instead of the deploy pipeline.
+3. **SRE (SLOs + error budgets)** — Reliability is a measurable condition, not a vibe. `GOALS.md` carries SLO-shaped fitness gates; `ao goals measure` is the burn-rate equivalent. The reliability lineage. Source: *Site Reliability Engineering* (Beyer, Jones, Petoff, Murphy).
+4. **Kubernetes control loops** — Declared state + reconcile loop. `GOALS.md` declares; `/evolve` reconciles. Errors don't crash the loop; they enter the work queue. The self-correction lineage.
+5. **[Brownian Ratchet](docs/brownian-ratchet.md)** — Embrace agent variance, filter aggressively, ratchet successes. Chaos + filter + one-way gate = net forward progress. The forward-only-progress lineage.
+6. **[Knowledge Flywheel (escape velocity)](docs/the-science.md#the-escape-velocity-condition)** — If retrieval rate × usage rate exceeds decay rate, knowledge compounds. If not, it decays to zero. The compounding-context lineage. *This is the one infrastructure never needed* — software workers persist; agents don't. The corpus is the moat.
 
 **Operational principles:**
 
-1. **Context quality determines output quality.** Every skill, hook, and flywheel component exists to ensure the right context is in the right window at the right time.
-2. **Least-privilege loading.** Agents receive only the context necessary for their task — phase-specific, role-scoped, freshness-weighted.
-3. **The cycle is the product.** No single skill is the value. The compounding loop — research, plan, validate, build, validate, learn, repeat — is what makes the system improve.
-4. **Two-tier execution.** Orchestrators (`/evolve`, `/rpi`, `/crank`) stay in the main session. Workers fork into subagents where results merge back via the filesystem — never accumulated chat context.
-5. **Dormancy is last resort.** When goals pass and backlog is empty, the system generates productive work from validation gaps, bug hunts, drift detection, and feature suggestions before going dormant.
+1. **Agents are ephemeral; the system carries the state.** Every skill, hook, and flywheel component exists because the agent itself can't remember. Build for amnesia.
+2. **The corpus is the user's. The harness is ours.** AgentOps' own commoditization is on the timeline. The user's accumulated knowledge isn't. Optimize the product for what the user keeps.
+3. **Context quality determines output quality.** Right context, right window, right time. Phase-specific. Role-scoped. Freshness-weighted.
+4. **The cycle is the product.** No single skill is the value. The compounding loop — research, plan, validate, build, validate, learn, repeat — is what makes the system improve.
+5. **Two-tier execution.** Orchestrators (`/evolve`, `/rpi`, `/crank`) stay in the main session. Workers fork into subagents where results merge back via the filesystem — never accumulated chat context.
+6. **Atomic changes compose.** Every primitive is cheap to undo. The Brownian Ratchet only works if the ratchet step is small.
+7. **Reconcile, don't push.** Kubernetes-shaped control loops compare actual state to desired state and fix the gap. They don't fire-and-forget. AgentOps loops do the same.
+8. **Dormancy is last resort.** When goals pass and backlog is empty, the system generates productive work from validation gaps, bug hunts, drift detection, and feature suggestions before going dormant.
 
 ## Usage
 
 This file enables product-aware council reviews:
 
-- **`/pre-mortem`** — Automatically includes `product` perspectives (user-value, adoption-barriers, competitive-position) alongside plan-review judges when this file exists.
-- **`/vibe`** — Automatically includes `developer-experience` perspectives (api-clarity, error-experience, discoverability) alongside code-review judges when this file exists.
+- **`/pre-mortem`** — Automatically loads product context when this file exists. Default `--quick` mode includes the context inline; deeper modes add a dedicated `product` perspective alongside plan-review judges.
+- **`/vibe`** — Automatically loads developer-experience context when this file exists. Default `--quick` mode includes the context inline; deeper modes add a dedicated `developer-experience` perspective alongside code-review judges.
 - **`/council --preset=product`** — Run product review on demand.
 - **`/council --preset=developer-experience`** — Run DX review on demand.
 
@@ -150,3 +161,6 @@ Explicit `--preset` overrides from the user skip auto-include (user intent takes
 
 - [Context Lifecycle Contract](docs/context-lifecycle.md) — canonical definition of the three gaps (judgment validation, durable learning, loop closure) with evidence map and mechanism inventory.
 - [Scale Without Swarms](docs/scale-without-swarms.md) — why 3-5 focused agents with fresh context and regression gates outperform massive uncoordinated swarms; the AgentOps model of waves, isolation, and gates explained.
+- [Brownian Ratchet](docs/brownian-ratchet.md) — the forward-only-progress lineage in detail.
+- [The Science](docs/the-science.md) — DevOps Three Ways, the escape velocity condition, and the leverage-points map.
+- [`.agents/council/2026-04-30-agentops-product-positioning.md`](.agents/council/2026-04-30-agentops-product-positioning.md) — the 5-judge council that locked the moat-as-knowledge thesis and the bridge-tool framing.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -122,7 +122,7 @@ The flywheel numbers (4,940 learnings, 1,195 patterns) are the load-bearing evid
 | Pattern-to-skill promotion polish remains | The strongest differentiation thesis — self-programming compounding — has review-only draft generation today. Remaining gap: richer synthesis and a clean publish path. | in-progress |
 | Multi-runtime proof is tiered, not complete | Tier S structural proof is active for all four runtimes. Tier I live inventory proof is partial. Tier E live execution proof remains opt-in / nightly, not a default gate. | in-progress |
 | Retrieval and worker knowledge propagation still limit compounding | The flywheel architecture is in place. Retrieval quality and passing prevention/finding context to implement workers remain weaker than the core thesis requires. | open |
-| Public messaging now converged on operational-discipline + moat framing | The 2026-04-30 council (`.agents/council/2026-04-30-agentops-product-positioning.md`) locked the thesis: *knowledge is the moat; AgentOps is the bridge tool that helps you build it.* Mission, Strategic Bet, README, and mkdocs surfaces aligned in PR #192. Downstream comparison docs and skill-page intros still need a sweep. | in-progress |
+| Public messaging now converged on operational-discipline + moat framing | A 2026-04-30 internal positioning council locked the thesis: *knowledge is the moat; AgentOps is the bridge tool that helps you build it.* Mission, Strategic Bet, README, and mkdocs surfaces aligned in PR #192. Downstream comparison docs and skill-page intros still need a sweep. | in-progress |
 
 ## Design Principles
 
@@ -163,4 +163,3 @@ Explicit `--preset` overrides from the user skip auto-include (user intent takes
 - [Scale Without Swarms](docs/scale-without-swarms.md) — why 3-5 focused agents with fresh context and regression gates outperform massive uncoordinated swarms; the AgentOps model of waves, isolation, and gates explained.
 - [Brownian Ratchet](docs/brownian-ratchet.md) — the forward-only-progress lineage in detail.
 - [The Science](docs/the-science.md) — DevOps Three Ways, the escape velocity condition, and the leverage-points map.
-- [`.agents/council/2026-04-30-agentops-product-positioning.md`](.agents/council/2026-04-30-agentops-product-positioning.md) — the 5-judge council that locked the moat-as-knowledge thesis and the bridge-tool framing.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@
 [![Nightly](https://github.com/boshu2/agentops/actions/workflows/nightly.yml/badge.svg)](https://github.com/boshu2/agentops/actions/workflows/nightly.yml)
 [![GitHub stars](https://img.shields.io/github/stars/boshu2/agentops?style=social)](https://github.com/boshu2/agentops/stargazers)
 
-### Coding agents don't do their own bookkeeping.
+### DevOps for the agent.
 
-AgentOps is the operational layer for coding agents. It adds bookkeeping, validation, primitives, and flows so every session starts where the last one left off.
+Coding agents don't do their own bookkeeping. AgentOps is the operational layer that does — four tiers (Bookkeeping, Validation, Primitives, Flows) that turn ad-hoc sessions into compounding cycles.
 
-[Install](#install) · [Quick Start](#quick-start) · [Skills](#skills) · [CLI](#the-ao-cli) · [Doctrine](https://12factoragentops.com) · [Docs](docs/documentation-index.md)
+**The point is not a bigger prompt. The point is a repo that remembers what worked.**
+
+[Install](#install) · [Quick Start](#quick-start) · [Why DevOps?](#why-devops) · [Skills](#skills) · [CLI](#the-ao-cli) · [Doctrine](https://12factoragentops.com) · [Docs](docs/documentation-index.md)
 
 </div>
 
@@ -27,9 +29,7 @@ AgentOps gives your coding agent four things it does not have by default:
 | **Primitives** | Skills, hooks, and the `ao` CLI give agents reusable building blocks |
 | **Flows** | `/research`, `/implement`, `/validation`, and `/rpi` compose those primitives end to end |
 
-Session 1, your agent spends two hours debugging a timeout bug. Session 15, a new agent finds the lesson in seconds because the repo kept it.
-
-Under the hood, AgentOps acts as a context compiler: raw session signal becomes reusable knowledge, compiled prevention, and better next work.
+Session 1: your agent spends two hours debugging a timeout bug. Session 15: a new agent finds the lesson in seconds because the repo kept it.
 
 ```mermaid
 flowchart LR
@@ -41,7 +41,39 @@ flowchart LR
     N --> S
 ```
 
-Local and auditable: `.agents/` is plain text you can grep, diff, review, and commit when you choose. There is no telemetry or cloud service requirement.
+All state lives in local `.agents/` — auditable, versionable, yours. Plain text you can grep, diff, review, and commit. Zero telemetry. Zero cloud dependency.
+
+### Proof: the three-gap contract
+
+AgentOps closes three failure modes most agent setups don't even name:
+
+| Gap | What fails without it | Closed by |
+|-----|-----------------------|-----------|
+| **Judgment** | Plan looks coherent. Code passes tests. Both miss the edge case. No one challenged either. | `/pre-mortem` · `/vibe` · `/council` |
+| **Durable Learning** | Auth bug fixed Monday. Same auth bug returns Wednesday. The lesson lived in a chat transcript. | `/retro` · `/forge` · `ao lookup` |
+| **Loop Closure** | Code diff lands. No lesson extracted. No constraint hardened. Next session re-learns from scratch. | `/post-mortem` · finding compiler · `/evolve` |
+
+Each factor in the [12-factor doctrine](https://12factoragentops.com) closes one or more of these. Full contract: [docs/context-lifecycle.md](docs/context-lifecycle.md).
+
+---
+
+## Why DevOps?
+
+DevOps changed how we ship software by closing three loops: **flow** (work moves forward), **feedback** (work that breaks comes back fast), and **continual learning** (the system gets smarter with every cycle). The Three Ways. They are not metaphors. They are the architecture of every team that ships reliably under pressure.
+
+Coding agents need the same architecture. They have prompts and weights — neither of which is an operations layer. Run an agent against a real codebase and you'll feel the gap immediately: no flow control between sessions, no feedback that survives compaction, no learning that compounds. Each session starts where every prior session started: zero.
+
+AgentOps applies the Three Ways to coding agents:
+
+| DevOps Three Ways | AgentOps surface | What it means in practice |
+|-------------------|------------------|---------------------------|
+| **Flow** | Primitives + Flows (`/research` → `/plan` → `/implement` → `/validation` → `/rpi`) | Work moves through scoped, auditable phases. No phase compresses into another. |
+| **Feedback** | Validation gates that block, not advise (`/pre-mortem`, `/vibe`, `/council`) | Multi-model consensus catches errors before they propagate. Verdicts are recorded, not assumed. |
+| **Continual Learning** | Bookkeeping + the knowledge flywheel (`/retro` → `/forge` → `ao inject` → next session) | Every session emits learnings. Learnings get scored, promoted, and decayed. Next session starts loaded. |
+
+Theoretical foundation lives in [docs/the-science.md](docs/the-science.md) (Meadows' leverage points + DevOps Three Ways) and [docs/brownian-ratchet.md](docs/brownian-ratchet.md) (chaos + filter + one-way gate = net forward progress).
+
+The lineage is direct: DevOps is what made software ship. AgentOps is what makes coding agents compound. Same shape, new substrate.
 
 ---
 
@@ -223,9 +255,9 @@ Full reference: [docs/SKILLS.md](docs/SKILLS.md)
 <details>
 <summary><b>Cross-runtime orchestration</b> - mix Claude, Codex, Cursor, and OpenCode</summary>
 
-AgentOps keeps the workflow shape consistent across runtimes. Use the same validation, research, delivery, and bookkeeping flows whether the active worker is Claude Code, Codex, Cursor, or OpenCode.
+Multi-runtime, one workflow. The same validation, research, delivery, and bookkeeping flows run whether the active worker is Claude Code, Codex, Cursor, or OpenCode.
 
-That lets one runtime lead a session, another review the result, and a third handle focused implementation. The exact adapter is runtime-specific; the product contract is the same: independent context, auditable files, and explicit validation before promotion.
+One runtime leads a session. Another reviews the result. A third handles focused implementation. Adapters are runtime-specific. The contract is constant: independent context, auditable files, validation before promotion.
 
 </details>
 
@@ -283,14 +315,16 @@ Run Dream overnight, then run Evolve in the morning against a fresher corpus. Th
 
 ---
 
-## How AgentOps Fits With Other Tools
+## Competitive Positioning
+
+Most tools optimize work *within* a session. AgentOps compounds across them. The bookkeeping and validation layer is the gap.
 
 | Tool | What it does well | What AgentOps adds |
 |------|-------------------|--------------------|
-| **[GSD](https://github.com/glittercowboy/get-shit-done)** | Fresh-context phased execution, recovery loops, runtime breadth | Cross-session bookkeeping, pre-build validation, and the knowledge flywheel |
-| **[Compound Engineer](https://github.com/EveryInc/compound-engineering-plugin)** | Ideation, configurable reviewers, cross-runtime conversion | Automatic capture/scoring/injection, council validation, and repo-native `ao` workflows |
-| **[Spec Kit](https://github.com/github/spec-kit) / [Kiro](https://kiro.dev/)** | Spec-driven development and executable planning artifacts | Learning beyond specs: failures, decisions, retros, and prevention rules |
-| **[Superpowers](https://github.com/obra/superpowers)** | TDD discipline and autonomous work patterns | Memory, pre-mortems, and validation across repeated sessions |
+| **[GSD](https://github.com/glittercowboy/get-shit-done)** | Fresh-context phased execution, recovery loops, runtime breadth | Cross-session bookkeeping, pre-build validation, the knowledge flywheel |
+| **[Compound Engineer](https://github.com/EveryInc/compound-engineering-plugin)** | Ideation, configurable reviewers, cross-runtime conversion | Automatic capture/scoring/injection, council validation, repo-native `ao` workflows |
+| **[Spec Kit](https://github.com/github/spec-kit) / [Kiro](https://kiro.dev/)** | Spec-driven development and executable planning artifacts | Learning beyond specs: failures, decisions, retros, prevention rules |
+| **[Superpowers](https://github.com/obra/superpowers)** | TDD discipline and autonomous work patterns | Memory, pre-mortems, validation across repeated sessions |
 | **[Ruflo / Claude-Flow](https://github.com/ruvnet/ruflo)** | High-scale swarm orchestration and MCP-heavy coordination | Local, auditable compounding around whatever executes the work |
 
 [Detailed comparisons](docs/comparisons/) · [Competitive radar](docs/comparisons/competitive-radar.md)
@@ -335,6 +369,20 @@ AgentOps is shaped by a set of public principles — the 12 factors of agent ope
 | **Scale (X-XII)** | Isolate Workers · Supervise Hierarchically · Harvest Failures as Wisdom |
 
 The AgentOps product implements these principles through skills, the `ao` CLI, and local bookkeeping in `.agents/`. See each factor page at [12factoragentops.com/factors](https://12factoragentops.com/factors) for the doctrine behind the mechanism.
+
+---
+
+## Ready?
+
+```bash
+# 1. Install (pick your runtime above)
+# 2. Run in your repo
+ao quick-start
+# 3. Validate from your agent chat
+/council validate this PR
+```
+
+Then explore the [skills catalog](docs/SKILLS.md), the [`ao` CLI reference](cli/docs/COMMANDS.md), and the [12-factor doctrine](https://12factoragentops.com).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![Nightly](https://github.com/boshu2/agentops/actions/workflows/nightly.yml/badge.svg)](https://github.com/boshu2/agentops/actions/workflows/nightly.yml)
 [![GitHub stars](https://img.shields.io/github/stars/boshu2/agentops?style=social)](https://github.com/boshu2/agentops/stargazers)
 
-### DevOps for the agent.
+### Operational discipline for coding agents.
 
-Coding agents don't do their own bookkeeping. AgentOps is the operational layer that does — four tiers (Bookkeeping, Validation, Primitives, Flows) that turn ad-hoc sessions into compounding cycles.
+The hard problem: ship reliable code with unreliable agents that don't remember anything. AgentOps builds the knowledge and memory into the system AND the process — a Meadows compounding system around your codebase.
 
-**The point is not a bigger prompt. The point is a repo that remembers what worked.**
+**The moat is the context you, your team, and your business have earned. AgentOps is how it compounds.**
 
 [Install](#install) · [Quick Start](#quick-start) · [Why DevOps?](#why-devops) · [Skills](#skills) · [CLI](#the-ao-cli) · [Doctrine](https://12factoragentops.com) · [Docs](docs/documentation-index.md)
 
@@ -74,6 +74,8 @@ AgentOps applies the Three Ways to coding agents:
 Theoretical foundation lives in [docs/the-science.md](docs/the-science.md) (Meadows' leverage points + DevOps Three Ways) and [docs/brownian-ratchet.md](docs/brownian-ratchet.md) (chaos + filter + one-way gate = net forward progress).
 
 The lineage is direct: DevOps is what made software ship. AgentOps is what makes coding agents compound. Same shape, new substrate.
+
+> AgentOps and every harness like it gets absorbed into the model layer over time. Memory primitives, learning loops, even validation gates — frontier vendors will ship them natively. What stays yours is the corpus. AgentOps is the bridge tool that helps you build the moat *now*, before the harness layer commoditizes. See [PRODUCT.md](PRODUCT.md) for the full thesis.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: AgentOps
-description: Coding agents don't do their own bookkeeping. AgentOps is the operational layer — memory, validation, and feedback loops that compound between sessions.
+description: DevOps for the agent. Bookkeeping, validation, and flows that compound across coding-agent sessions.
 hide:
   - navigation
   - toc
@@ -9,8 +9,8 @@ hide:
 # AgentOps { .landing-hero }
 
 <p class="hero-tagline">
-  Coding agents don't do their own bookkeeping.<br>
-  AgentOps is the operational layer that makes every session start where the last one left off.
+  <strong>DevOps for the agent.</strong><br>
+  Coding agents don't do their own bookkeeping. AgentOps is the operational layer that does — four tiers (Bookkeeping, Validation, Primitives, Flows) that turn ad-hoc sessions into compounding cycles.
 </p>
 
 <p class="hero-actions" markdown>
@@ -21,11 +21,11 @@ hide:
 
 ---
 
-## The primary use case
+## The Problem
 
-You hand a coding agent a task. It does the work. Tomorrow you hand a different (or restarted) agent the same kind of task. It rediscovers everything — the landmine in `auth.py`, the timeout bug you debugged for two hours last week, the flag the reviewer always asks you to add. The session ends, and with it, everything the agent learned.
+Every agent session starts from zero. Same mistakes. Same rework. Your agent forgets everything between sessions — the landmine in `auth.py`, the two-hour timeout debug, the flag the reviewer always adds.
 
-**AgentOps fixes that.** It gives coding agents four things they don't have by default:
+**AgentOps solves this** with four operational layers:
 
 | Layer | What changes |
 |-------|--------------|
@@ -46,7 +46,7 @@ flowchart LR
     N --> S
 ```
 
-Local and auditable: `.agents/` is plain text you can grep, diff, review, and commit when you choose. No telemetry, no cloud service.
+All state lives in local `.agents/` — auditable, versionable, yours. Plain text you can grep, diff, review, and commit. Zero telemetry. Zero cloud dependency.
 
 ---
 
@@ -102,7 +102,7 @@ The `ao` CLI is optional but recommended. It unlocks repo-native bookkeeping, re
 
 ## See It Work
 
-Two commands that show what AgentOps actually does.
+Two commands. Real output.
 
 ### Validate a PR with independent judges
 
@@ -136,7 +136,7 @@ The point is not a bigger prompt. The point is a repo that remembers what worked
 
 ## The headline skills
 
-Every skill works alone. Flows compose them when you want more structure.
+Every skill works alone. Compose flows for end-to-end cycles.
 
 | Skill | Use it when |
 |-------|-------------|
@@ -156,9 +156,9 @@ Every skill works alone. Flows compose them when you want more structure.
 
 ---
 
-## Advanced: Day Loop and Night Loop
+## Unsupervised Cycles
 
-`/evolve` when you want **code improvement**. It reads `GOALS.md`, fixes the worst fitness gap, runs regression gates, and records the cycle.
+**Day: autonomous improvement.** `/evolve` reads `GOALS.md`, fixes the worst fitness gap, runs regression gates, records each cycle.
 
 ```text
 > /evolve
@@ -170,7 +170,7 @@ Every skill works alone. Flows compose them when you want more structure.
 [learn]   Post-mortem feeds the flywheel
 ```
 
-`/dream` when you want **knowledge compounding**. It runs offline-style bookkeeping work over `.agents/`, reports what changed, and never mutates source code, invokes `/rpi`, or performs git operations.
+**Night: knowledge compounding.** `/dream` consolidates learnings, dedupes patterns, defragments the corpus. Purely bookkeeping work over `.agents/` — source code stays untouched, `/rpi` never fires, no git operations.
 
 ```text
 > /dream start
@@ -184,6 +184,16 @@ Morning report: .agents/overnight/<run-id>/summary.md
 ```
 
 Run Dream overnight, then Evolve in the morning against a fresher corpus. Same model, smarter environment.
+
+---
+
+## Next steps
+
+1. **[Install](#install)** — pick your runtime.
+2. **Run** `ao quick-start` in your repo, then `/quickstart` in your agent chat.
+3. **Validate** with `/council validate this PR` on your next change.
+
+Read the lineage at [12factoragentops.com](https://12factoragentops.com) — DevOps applied to coding agents in twelve factors.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: AgentOps
-description: DevOps for the agent. Bookkeeping, validation, and flows that compound across coding-agent sessions.
+description: Operational discipline for coding agents. Build reliable code with unreliable agents — and turn the context you've earned into a compounding moat.
 hide:
   - navigation
   - toc
@@ -9,8 +9,12 @@ hide:
 # AgentOps { .landing-hero }
 
 <p class="hero-tagline">
-  <strong>DevOps for the agent.</strong><br>
-  Coding agents don't do their own bookkeeping. AgentOps is the operational layer that does — four tiers (Bookkeeping, Validation, Primitives, Flows) that turn ad-hoc sessions into compounding cycles.
+  <strong>Operational discipline for coding agents.</strong><br>
+  The hard problem: ship reliable code with unreliable agents that don't remember anything. AgentOps builds the knowledge and memory into the system <strong>AND</strong> the process — a Meadows compounding system around your codebase.
+</p>
+
+<p class="hero-subtagline" markdown>
+The moat is the context you, your team, and your business have earned. AgentOps is how it compounds.
 </p>
 
 <p class="hero-actions" markdown>


### PR DESCRIPTION
## Summary

Aligns the README and mkdocs landing page to a thesis-locked product positioning shaped through a 5-judge council and three user override passes:

**The thesis (locked 2026-04-30):**

- **Mission noun:** *Operational discipline for coding agents.*
- **Engineering claim:** ship reliable code with unreliable agents that don't remember anything.
- **Mechanism:** build the knowledge and memory into the system **AND** the process — a Meadows compounding system.
- **Moat (the user's, not ours):** the context you, your team, and your business have earned.
- **Strategic Bet:** *Knowledge is the moat. AgentOps isn't.* Every harness — ours included — gets absorbed into the model. AgentOps is the bridge tool that helps you build the moat now, before the harness layer commoditizes.

## Commits

1. `a5c50094` — original voice + positioning pass (DevOps lineage, three-gap contract surfaced, "Why DevOps?" section added)
2. `7582f6e3` — **thesis lock** based on 5-judge council (`.agents/council/2026-04-30-agentops-product-positioning.md`, local-only since `.agents/` is gitignored upstream) and 3 user override passes:
   - User Override #1: value-prop reshape — "operational discipline" replaces "operations layer / control plane / DevOps for the agent"
   - User Override #2: Meadows compounding — system **AND** process explicitly named
   - User Override #3: AgentOps' own commoditization timeline — honest about the harness getting absorbed

## What changed

**`PRODUCT.md`** — full rewrite of Mission, Vision, What the Product Actually Is, Core Value Props, Strategic Bet, Known Gaps, Design Principles. Personas + Anthropic-convergence table preserved. Six-pillar foundation: Meadows / DevOps Three Ways / SRE (SLOs + error budgets) / Kubernetes control loops / Brownian Ratchet / Knowledge Flywheel. Evidence refreshed (320 stars / 4940 learnings / 1195 patterns / 40 planning rules / 35 codex overrides — canonical via `sync-skill-counts.sh`). New operational principle: *the corpus is the user's. The harness is ours.*

**`README.md`** — H2 swapped from "DevOps for the agent." (user disowned as too lame) to **"Operational discipline for coding agents."** Hero pull-line: *"The moat is the context you, your team, and your business have earned. AgentOps is how it compounds."* "Why DevOps?" section retained but closing blockquote now names AgentOps' own commoditization timeline and points at PRODUCT.md for the full thesis. Three-gap contract subsection retained as the proof scaffolding.

**`docs/index.md` (mkdocs landing)** — Hero matches README. Same H2, same engineering claim, same moat sub-tagline. Description meta updated.

## What does NOT change

- Personas (untouched)
- Anthropic-convergence table content (rows preserved verbatim, lead reframed)
- Auto-generated `cli/docs/` + `skills/*/SKILL.md`
- `docs/comparisons/` (clinical voice already right)
- Four-layer model naming or order — product contract
- The `Coding agents don't do their own bookkeeping.` claim (now embedded in the engineering-claim sentence rather than as the H2)
- `See It Work` demo command outputs
- Knowledge-flywheel mermaid diagrams
- mkdocs nav structure (`mkdocs.yml`)

## Voice rules applied

- Zero fluff intensifiers (really / very / actually / essentially / fundamentally / ultimately / in order to / the fact that)
- Imperative verbs lead CTAs (Install / Run / Validate / Read)
- "Your agent" / "your corpus" / "your codebase" — never "we" except as brand identity
- One claim per sentence in any sentence over ~20 words
- Sections end on a CTA or a sharp claim
- Plain dev English: "indeterministic" + "ephemeral" allowed (technical, load-bearing); no "stochastic," "heterogeneous," "context compiler" in public surface

## Test plan

- [x] `mkdocs build --strict` passes
- [x] All `sync-skill-counts.sh` regex patterns satisfied (heading shape, distribution/runtime reach line shape with "and N Codex overrides")
- [x] All anchors resolve (`#install`, `#quick-start`, `#why-devops`, `#skills`, `#the-ao-cli`)
- [x] Pre-push gate passes (next-work contract parity + doc-release gate)
- [ ] CI green (validate.yml + docs.yml)
- [ ] Visual inspection of GitHub README rendering after merge
- [ ] Visual inspection of [boshu2.github.io/agentops/](https://boshu2.github.io/agentops/) after deploy

## Showcase repo propagation

The agentops-showcase repo (`12factoragentops.com`) was updated in lockstep on `main` (commits `6b833bb` + `f576163`):

- `src/app/page.tsx` H1 → "Operational discipline for coding agents."
- `src/lib/copy/philosophy.ts` HERO_HOOK + COMPILER_FRAMING rewritten
- `src/lib/copy/convergence.ts` headline → "Knowledge is the moat. AgentOps isn't."
- 3 e2e specs updated for new heading pins; 23/23 e2e green

## Council artifact

`.agents/council/2026-04-30-agentops-product-positioning.md` (local-only — `.agents/` is gitignored on this repo) contains:

- 5-judge mixed council: product-strategist, dev-tools-marketer, systems-engineer-skeptic, ai-skeptic-engineer, founder-as-author
- Each judge rendered an independent verdict + steelman + Mission draft + Strategic Bet draft + 3-noun-phrase verdict
- Substantive dissents from Judge 4 (model-commoditization survival) and Judge 3 (Frame-C honesty constraint) preserved as fallback positions
- Three User Override sections capture the post-council sharpening that produced the final thesis
- Propagation map for downstream surfaces

Available via `gh api repos/boshu2/agentops/contents/.agents/council/...` if needed; otherwise rendered into PRODUCT.md and the README via the bridge-tool framing.