### PR TITLE
feat(crank): three-tier parallel-wave isolation (branch rule + conditional worktrees + cleanup gate)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -692,7 +692,7 @@
       "name": "crank",
       "source_skill": "skills/crank",
       "source_hash": "928d1301b7f3bf12607e779cdec279924b5b29d681faffd01e6819651def92e7",
-      "generated_hash": "8e34e5804113ee4eec7207e0c5dea9f74f331a10939405060a858e255ca462a9"
+      "generated_hash": "cbb028cd9bfc55b96a2f55037dd35080c511019e844ef0c3b462dfc0b06026a4"
     },
     {
       "name": "deps",

--- a/skills-codex/crank/.agentops-generated.json
+++ b/skills-codex/crank/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/crank",
   "layout": "modular",
   "source_hash": "928d1301b7f3bf12607e779cdec279924b5b29d681faffd01e6819651def92e7",
-  "generated_hash": "8e34e5804113ee4eec7207e0c5dea9f74f331a10939405060a858e255ca462a9"
+  "generated_hash": "cbb028cd9bfc55b96a2f55037dd35080c511019e844ef0c3b462dfc0b06026a4"
 }

--- a/skills-codex/crank/SKILL.md
+++ b/skills-codex/crank/SKILL.md
@@ -270,6 +270,14 @@ for task in wave_tasks:
 
 Display an ownership table before spawning workers. If conflicts exist, split into sub-waves and keep file ownership disjoint.
 
+#### 4c.1: Parallel-Wave Isolation (wave size ≥ 2)
+
+For waves with 2+ workers, three tiers prevent sibling-worker clobber without re-introducing worktree sprawl. Read [references/parallel-wave-isolation.md](references/parallel-wave-isolation.md) for the full tier definitions, the worker prompt template, the `preflight-swarm.sh` escalation criterion, and the `check-worktree-disposition.sh` cleanup gate.
+
+Tier 1 (always): inject the branch-isolation prompt rule (worker's first git op = `git checkout -b feat/<epic>-<slug> origin/main`; never `git switch`, `stash pop`, `reset --hard`).
+Tier 2 (escalate on `preflight-swarm.sh` non-zero): ephemeral per-worker worktree.
+Tier 3 (wave-end): `scripts/check-worktree-disposition.sh` flags stragglers.
+
 #### 4d: Spawn Workers
 
 Spawn one agent per issue. Prefer `worker` roles for implementation and `explorer` roles for file discovery when the runtime exposes `agent_type`.
@@ -511,6 +519,7 @@ fi
 ## Reference Documents
 
 - [references/de-sloppify.md](references/de-sloppify.md) - cleanup pass after implementation waves
+- [references/parallel-wave-isolation.md](references/parallel-wave-isolation.md) - branch-isolation rule + conditional ephemeral worktrees + cleanup gate for parallel waves
 - [references/plan-mutations.md](references/plan-mutations.md) - plan mutation audit trail for drift analysis
 - [references/shared-task-notes.md](references/shared-task-notes.md) - cross-wave context persistence
 - [references/commit-strategies.md](references/commit-strategies.md) - per-task vs wave-batch commits

--- a/skills-codex/crank/references/parallel-wave-isolation.md
+++ b/skills-codex/crank/references/parallel-wave-isolation.md
@@ -1,0 +1,92 @@
+# Parallel-Wave Isolation (wave size ≥ 2)
+
+## Problem
+
+When `/crank` dispatches 2+ parallel workers in a shared clone, sibling workers can clobber each other's staged files. The proximate cause is `git checkout` mutating the shared working tree mid-task — worker A stages files, worker B runs `git checkout` to switch to its branch, worker A's stage is gone.
+
+Observed 2026-04-30 (soc-lrwk crank): 2 of 3 parallel workers lost staged work and recovered via stash + ephemeral worktrees, costing ~30% wall-time per affected worker.
+
+## Why three tiers, not just "always use worktrees"
+
+The user already invested in worktree-sprawl prevention:
+- Commit `83bea6bd` enforces canonical-root worktree hygiene.
+- `scripts/check-worktree-disposition.sh` flags stray worktrees in CI.
+- `ao worktree gc` cleans up stale ones.
+- AGENTS.md documents the policy.
+
+Defaulting to per-worker worktrees regresses that investment. The right answer is conditional escalation, gated on the actual signal (`scripts/preflight-swarm.sh`).
+
+Council brainstorm + judge verdicts: `.agents/council/2026-04-30-brainstorm-crank-parallel-wave.md`.
+
+## Tier 1 — Branch isolation prompt rule (every parallel wave ≥ 2)
+
+Inject this rule verbatim at the top of every worker's `spawn_agent(message=...)` text, before the issue body:
+
+```
+WORKER GIT DISCIPLINE (parallel wave — read first):
+- Your first git op is: git checkout -b feat/<epic-id>-<task-slug> origin/main
+- You MUST NOT run any of these on the shared working tree:
+  - git checkout <existing-branch>
+  - git switch
+  - git stash pop
+  - git reset --hard
+- Stay on your branch for the entire task. To inspect another branch's
+  content, use: git show <branch>:<path> (read-only, no checkout).
+```
+
+This is the load-bearing default. It prevents the proximate failure (sibling worker's `git checkout` mutates your staged files in the shared tree) at zero infrastructure cost. Workers' tooling (`gh pr merge`, `git stash pop` in recovery flows, etc.) is the typical violator — the rule must be in-context, not just in doctrine.
+
+## Tier 2 — Pre-flight + conditional escalation to ephemeral worktrees
+
+Before spawning workers, run:
+
+```bash
+bash scripts/preflight-swarm.sh "$WAVE_TASK_FILES" || PREFLIGHT_RC=$?
+```
+
+- **Exit 0:** Tier 1 alone is sufficient. Spawn workers in the shared clone.
+- **Non-zero (conflict risk detected):** Escalate this wave to per-worker ephemeral worktrees per [worktree-per-worker.md](worktree-per-worker.md):
+
+  ```bash
+  for task in $WAVE_TASKS; do
+      worktree="${REPO_ROOT}-worktrees/wave-${wave}-${task}"
+      git worktree add "$worktree" -b "feat/<epic>-${task}" origin/main
+      # Inject "WORKING DIRECTORY: $worktree" into the worker prompt
+  done
+  ```
+
+  Workers in escalated mode operate in their own worktree. Orchestrator removes the worktree at wave-end after the worker's commit + push lands:
+
+  ```bash
+  for task in $WAVE_TASKS; do
+      git worktree remove "${REPO_ROOT}-worktrees/wave-${wave}-${task}"
+  done
+  ```
+
+The escalation criterion is **owned by `preflight-swarm.sh`**, not duplicated here. Tune heuristics there if needed.
+
+## Tier 3 — Wave-end disposition gate
+
+After every wave (Tier 1 OR Tier 2), run:
+
+```bash
+bash scripts/check-worktree-disposition.sh
+```
+
+This catches stragglers — worktrees that should have been removed but weren't. Output is advisory; the orchestrator MUST surface flagged worktrees in the wave summary. If more than 2 are leftover after a Tier 2 wave, the cleanup loop is broken — STOP and report.
+
+## Why this layering
+
+| Tier | Cost | Fires When | Solves |
+|---|---|---|---|
+| 1 | $0 (prompt only) | Every parallel wave ≥ 2 | Sibling-worker `git checkout` clobber (the proximate failure) |
+| 2 | One worktree per worker, ephemeral | `preflight-swarm.sh` flags overlap | Same-file collisions, generated-artifact races |
+| 3 | One script call | Every wave-end | Sprawl regression — leftover worktrees |
+
+Reuses existing tooling: `scripts/preflight-swarm.sh`, `scripts/check-worktree-disposition.sh`, [worktree-per-worker.md](worktree-per-worker.md), `ao worktree gc`. No new scripts.
+
+## See Also
+
+- [worktree-per-worker.md](worktree-per-worker.md) — when ephemeral per-worker worktrees ARE warranted (the "USE/DON'T USE" matrix Tier 2 routes through)
+- `.agents/learnings/2026-04-30-branch-isolation-for-multi-session-crank.md` — branch-isolation pattern that Tier 1 codifies
+- `.agents/council/2026-04-30-brainstorm-crank-parallel-wave.md` — full council judgment behind this design

--- a/skills/crank/SKILL.md
+++ b/skills/crank/SKILL.md
@@ -341,6 +341,10 @@ Worker prompt signpost:
 
 Read `.agents/crank/SHARED_TASK_NOTES.md` and inject its contents into every worker's TaskCreate description (after the issue body). Include a `DISCOVERY REPORTING` instruction so workers report new findings for the orchestrator to harvest. See [references/shared-task-notes.md](references/shared-task-notes.md) for the injection template, size management rules, and discovery reporting format.
 
+### Step 3b.3: Parallel-Wave Isolation (wave size ≥ 2)
+
+**Skip if wave has only 1 worker.** Parallel workers in a shared clone can clobber each other's staged work when sibling workers run `git checkout` mid-task. Three-tier protection (prompt rule → conditional ephemeral worktrees → disposition gate) prevents this without re-introducing worktree sprawl. Read [references/parallel-wave-isolation.md](references/parallel-wave-isolation.md) for the full tier definitions, the worker prompt template, the `preflight-swarm.sh` escalation criterion, and the `check-worktree-disposition.sh` cleanup gate.
+
 ### Step 4: Execute Wave via Swarm
 
 **GREEN mode (--test-first only):** If `--test-first` is set and SPEC/TEST waves have completed, modify worker prompts for spec-eligible issues:
@@ -638,6 +642,7 @@ If unsure whether a step is orchestrator-owned or delegatable, the default is **
 ## Reference Documents
 
 - [references/de-sloppify.md](references/de-sloppify.md)
+- [references/parallel-wave-isolation.md](references/parallel-wave-isolation.md)
 - [references/plan-mutations.md](references/plan-mutations.md)
 - [references/shared-task-notes.md](references/shared-task-notes.md)
 - [references/claude-code-latest-features.md](references/claude-code-latest-features.md)

--- a/skills/crank/references/parallel-wave-isolation.md
+++ b/skills/crank/references/parallel-wave-isolation.md
@@ -1,0 +1,92 @@
+# Parallel-Wave Isolation (wave size ≥ 2)
+
+## Problem
+
+When `/crank` dispatches 2+ parallel workers in a shared clone, sibling workers can clobber each other's staged files. The proximate cause is `git checkout` mutating the shared working tree mid-task — worker A stages files, worker B runs `git checkout` to switch to its branch, worker A's stage is gone.
+
+Observed 2026-04-30 (soc-lrwk crank): 2 of 3 parallel workers lost staged work and recovered via stash + ephemeral worktrees, costing ~30% wall-time per affected worker.
+
+## Why three tiers, not just "always use worktrees"
+
+The user already invested in worktree-sprawl prevention:
+- Commit `83bea6bd` enforces canonical-root worktree hygiene.
+- `scripts/check-worktree-disposition.sh` flags stray worktrees in CI.
+- `ao worktree gc` cleans up stale ones.
+- AGENTS.md documents the policy.
+
+Defaulting to per-worker worktrees regresses that investment. The right answer is conditional escalation, gated on the actual signal (`scripts/preflight-swarm.sh`).
+
+Council brainstorm + judge verdicts: `.agents/council/2026-04-30-brainstorm-crank-parallel-wave.md`.
+
+## Tier 1 — Branch isolation prompt rule (every parallel wave ≥ 2)
+
+Inject this rule verbatim at the top of every worker's TaskCreate description, before the issue body:
+
+```
+WORKER GIT DISCIPLINE (parallel wave — read first):
+- Your first git op is: git checkout -b feat/<epic-id>-<task-slug> origin/main
+- You MUST NOT run any of these on the shared working tree:
+  - git checkout <existing-branch>
+  - git switch
+  - git stash pop
+  - git reset --hard
+- Stay on your branch for the entire task. To inspect another branch's
+  content, use: git show <branch>:<path> (read-only, no checkout).
+```
+
+This is the load-bearing default. It prevents the proximate failure (sibling worker's `git checkout` mutates your staged files in the shared tree) at zero infrastructure cost. Workers' tooling (`gh pr merge`, `git stash pop` in recovery flows, etc.) is the typical violator — the rule must be in-context, not just in doctrine.
+
+## Tier 2 — Pre-flight + conditional escalation to ephemeral worktrees
+
+Before spawning workers, run:
+
+```bash
+bash scripts/preflight-swarm.sh "$WAVE_TASK_FILES" || PREFLIGHT_RC=$?
+```
+
+- **Exit 0:** Tier 1 alone is sufficient. Spawn workers in the shared clone.
+- **Non-zero (conflict risk detected):** Escalate this wave to per-worker ephemeral worktrees per [worktree-per-worker.md](worktree-per-worker.md):
+
+  ```bash
+  for task in $WAVE_TASKS; do
+      worktree="${REPO_ROOT}-worktrees/wave-${wave}-${task}"
+      git worktree add "$worktree" -b "feat/<epic>-${task}" origin/main
+      # Inject "WORKING DIRECTORY: $worktree" into the worker prompt
+  done
+  ```
+
+  Workers in escalated mode operate in their own worktree. Orchestrator removes the worktree at wave-end after the worker's commit + push lands:
+
+  ```bash
+  for task in $WAVE_TASKS; do
+      git worktree remove "${REPO_ROOT}-worktrees/wave-${wave}-${task}"
+  done
+  ```
+
+The escalation criterion is **owned by `preflight-swarm.sh`**, not duplicated here. Tune heuristics there if needed.
+
+## Tier 3 — Wave-end disposition gate
+
+After every wave (Tier 1 OR Tier 2), run:
+
+```bash
+bash scripts/check-worktree-disposition.sh
+```
+
+This catches stragglers — worktrees that should have been removed but weren't. Output is advisory; the orchestrator MUST surface flagged worktrees in the wave summary. If more than 2 are leftover after a Tier 2 wave, the cleanup loop is broken — STOP and report.
+
+## Why this layering
+
+| Tier | Cost | Fires When | Solves |
+|---|---|---|---|
+| 1 | $0 (prompt only) | Every parallel wave ≥ 2 | Sibling-worker `git checkout` clobber (the proximate failure) |
+| 2 | One worktree per worker, ephemeral | `preflight-swarm.sh` flags overlap | Same-file collisions, generated-artifact races |
+| 3 | One script call | Every wave-end | Sprawl regression — leftover worktrees |
+
+Reuses existing tooling: `scripts/preflight-swarm.sh`, `scripts/check-worktree-disposition.sh`, [worktree-per-worker.md](worktree-per-worker.md), `ao worktree gc`. No new scripts.
+
+## See Also
+
+- [worktree-per-worker.md](worktree-per-worker.md) — when ephemeral per-worker worktrees ARE warranted (the "USE/DON'T USE" matrix Tier 2 routes through)
+- `.agents/learnings/2026-04-30-branch-isolation-for-multi-session-crank.md` — branch-isolation pattern that Tier 1 codifies
+- `.agents/council/2026-04-30-brainstorm-crank-parallel-wave.md` — full council judgment behind this design


### PR DESCRIPTION
## Summary

Prevents the shared-clone failure mode in `/crank` parallel waves (sibling worker's `git checkout` mutates a peer's staged files, costing ~30% wall-time per affected worker) without re-introducing worktree sprawl.

## What changed

`skills/crank/SKILL.md` adds **Step 3b.3: Parallel-Wave Isolation (wave size ≥ 2)** with a 5-line inline summary pointing to a new reference doc. The reference (`skills/crank/references/parallel-wave-isolation.md`) defines three tiers:

1. **Tier 1 — Branch isolation prompt rule (every parallel wave ≥ 2).** Inject into every worker's `TaskCreate` description: worker's first git op is `git checkout -b feat/<epic>-<slug> origin/main`; never `git checkout <existing>`, `git switch`, `git stash pop`, or `git reset --hard` on the shared tree. Load-bearing default; prevents the proximate failure at zero infrastructure cost.

2. **Tier 2 — Conditional escalation.** Orchestrator runs `scripts/preflight-swarm.sh`. On non-zero exit (real overlap risk), escalate that wave to per-worker ephemeral worktrees per the existing `references/worktree-per-worker.md` matrix. Cleanup at wave-end.

3. **Tier 3 — Wave-end disposition gate.** `scripts/check-worktree-disposition.sh` flags stragglers. STOP if >2 leftover worktrees after a Tier 2 wave.

Codex parity mirror in `skills-codex/crank/` (same 3-tier design, uses `spawn_agent(message=...)` vocabulary instead of `TaskCreate`).

## Why three tiers, not "always per-worker worktrees"

Defaulting to per-worker worktrees regresses an explicit prior investment:

- Commit `83bea6bd` enforces canonical-root worktree hygiene
- `scripts/check-worktree-disposition.sh` flags stray worktrees in CI
- `ao worktree gc` cleans up stale ones
- `AGENTS.md` documents the policy

Conditional escalation, gated on `preflight-swarm.sh`, is the shape that fits: `/crank` becomes a CONSUMER of existing policy, not a parallel authority. No new scripts. Council brainstorm verdict: 2× E (tiered) + 1× B (rule-only); synthesis blends them by making B the load-bearing default tier within the E framework.

Full prior-art audit + judge verdicts: `.agents/council/2026-04-30-brainstorm-crank-parallel-wave.md` (vault-side, not in this PR).

## Test plan

- [x] `bash skills/heal-skill/scripts/heal.sh --strict` — clean
- [x] `bash scripts/audit-codex-parity.sh --skill crank` — passed (after fixing `TaskCreate` → `spawn_agent(message=)` in the codex reference)
- [x] `bash scripts/regen-codex-hashes.sh` — manifest + generated hash updated
- [x] `bash scripts/pre-push-gate.sh --fast` — passed (42 conditional checks skipped, 0 failed)
- [ ] First real `/crank` parallel-wave invocation post-merge will exercise Tiers 1 + 3 by default. Tier 2 only fires when `preflight-swarm.sh` flags overlap, which is rare.

## Known preexisting tech debt (NOT addressed here)

`skills/crank/SKILL.md` was already 660 lines vs the 248-line skill-lint budget before this PR. My net add is +5 inline lines + a new reference link. The lint overrun is preexisting and out of scope for this fix.

## Source

Failure observed during soc-lrwk Phase 4 hardening crank (2026-04-30): 2 of 3 parallel workers lost staged work and recovered via stash + ephemeral worktrees. Council convened with three perspectives (pragmatist / minimalist / ecosystem-fit) to synthesize this design against existing prior art.