### PR TITLE
feat(daemon,doctor): add ao doctor ledger-health surface (TB-Δ3 Phase 2-C)

### DIFF
--- a/cli/cmd/ao/doctor.go
+++ b/cli/cmd/ao/doctor.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/boshu2/agentops/cli/internal/daemon"
 	"github.com/boshu2/agentops/cli/internal/openclaw"
 	"github.com/boshu2/agentops/cli/internal/quality"
 	"github.com/boshu2/agentops/cli/internal/storage"
@@ -54,6 +55,7 @@ func gatherDoctorChecks() []doctorCheck {
 		{Name: "ao CLI", Status: "pass", Detail: formatVersion(version), Required: true},
 		checkCLIDependencies(),
 		checkDaemonRuntime(),
+		checkDaemonLedgerHealth(time.Now(), daemon.LedgerHealthDefaultThresholds()),
 		checkGasCityBridge(),
 		checkOpenClawConsumer(),
 		checkHookCoverage(),
@@ -125,6 +127,42 @@ func checkDaemonRuntimeURL(baseURL string) doctorCheck {
 		return doctorCheck{Name: "Daemon Runtime", Status: "warn", Detail: "not ready at " + detail, Required: false}
 	}
 	return doctorCheck{Name: "Daemon Runtime", Status: "pass", Detail: "ready at " + detail, Required: false}
+}
+
+func checkDaemonLedgerHealth(now time.Time, thresholds daemon.LedgerHealthThresholds) doctorCheck {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return doctorCheck{Name: "Daemon Ledger Health", Status: "warn", Detail: "cannot determine working directory", Required: false}
+	}
+	store := daemon.NewStore(cwd)
+	if _, statErr := os.Stat(store.Dir()); os.IsNotExist(statErr) {
+		return doctorCheck{Name: "Daemon Ledger Health", Status: "pass", Detail: "no daemon store at " + store.Dir(), Required: false}
+	}
+	health, err := store.LedgerHealth(now, thresholds)
+	if err != nil {
+		return doctorCheck{Name: "Daemon Ledger Health", Status: "warn", Detail: fmt.Sprintf("ledger health unavailable: %v", err), Required: false}
+	}
+	detail := formatLedgerHealthDetail(health)
+	if len(health.WarnReasons) > 0 {
+		return doctorCheck{Name: "Daemon Ledger Health", Status: "warn", Detail: detail + "; " + strings.Join(health.WarnReasons, "; "), Required: false}
+	}
+	return doctorCheck{Name: "Daemon Ledger Health", Status: "pass", Detail: detail, Required: false}
+}
+
+func formatLedgerHealthDetail(h daemon.LedgerHealth) string {
+	parts := []string{
+		fmt.Sprintf("ledger=%dB/%dB", h.LedgerSizeBytes, h.LedgerMaxBytes),
+	}
+	if h.HasSnapshot {
+		parts = append(parts, fmt.Sprintf("snapshot_age=%s", h.LatestSnapshotAge.Round(time.Second)))
+	} else {
+		parts = append(parts, "snapshot=none")
+	}
+	parts = append(parts, fmt.Sprintf("archives=%d", h.ArchiveCount))
+	if !h.OldestArchiveTime.IsZero() {
+		parts = append(parts, "oldest_archive="+h.OldestArchiveTime.Format(time.RFC3339))
+	}
+	return strings.Join(parts, "; ")
 }
 
 func checkGasCityBridge() doctorCheck {

--- a/cli/cmd/ao/doctor_product_runtime_test.go
+++ b/cli/cmd/ao/doctor_product_runtime_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -38,6 +40,73 @@ func TestDoctorOpenClawConsumerCheckPassesWithReadyServer(t *testing.T) {
 	}
 	if !strings.Contains(check.Detail, "snapshot_status=current") || !strings.Contains(check.Detail, "jobs=0") {
 		t.Fatalf("OpenClaw detail = %q, want snapshot/count details", check.Detail)
+	}
+}
+
+func TestDoctorLedgerHealthCheckPassesOnFreshStore(t *testing.T) {
+	t.Chdir(t.TempDir())
+	check := checkDaemonLedgerHealth(time.Now(), daemonpkg.LedgerHealthDefaultThresholds())
+	if check.Name != "Daemon Ledger Health" {
+		t.Fatalf("Name = %q", check.Name)
+	}
+	if check.Status != "pass" {
+		t.Fatalf("Status = %q, want pass on missing daemon dir", check.Status)
+	}
+	if !strings.Contains(check.Detail, "no daemon store") {
+		t.Fatalf("Detail = %q, want missing-store message", check.Detail)
+	}
+}
+
+func TestDoctorLedgerHealthCheckWarnsOnStaleSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	store := daemonpkg.NewStore(dir)
+	rebuiltAt := time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC)
+	now := rebuiltAt.Add(72 * time.Hour)
+	set := daemonpkg.ProjectionSet{
+		SchemaVersion: daemonpkg.ProjectionSchemaVersion,
+		RebuiltAt:     rebuiltAt.Format(time.RFC3339Nano),
+		LastEventID:   "evt-snap",
+		Manifests:     map[daemonpkg.ProjectionName]daemonpkg.ProjectionManifest{},
+	}
+	if _, err := store.WriteProjectionSnapshot(set); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+
+	check := checkDaemonLedgerHealth(now, daemonpkg.LedgerHealthDefaultThresholds())
+	if check.Status != "warn" {
+		t.Fatalf("Status = %q, want warn (72h old snapshot vs 24h threshold)", check.Status)
+	}
+	if !strings.Contains(check.Detail, "snapshot_age=") {
+		t.Fatalf("Detail = %q, want snapshot_age in detail", check.Detail)
+	}
+	if !strings.Contains(check.Detail, "snapshot age") {
+		t.Fatalf("Detail = %q, want snapshot-age warn reason", check.Detail)
+	}
+}
+
+func TestDoctorLedgerHealthCheckSurfacesArchiveCount(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	store := daemonpkg.NewStore(dir)
+	if err := os.MkdirAll(store.Dir(), 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, ts := range []string{"20260101T000000.000000000Z", "20260102T000000.000000000Z"} {
+		path := filepath.Join(store.Dir(), "ledger."+ts+".jsonl")
+		if err := os.WriteFile(path, []byte("{}\n"), 0600); err != nil {
+			t.Fatalf("plant archive: %v", err)
+		}
+	}
+	check := checkDaemonLedgerHealth(time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC), daemonpkg.LedgerHealthDefaultThresholds())
+	if check.Status != "pass" {
+		t.Fatalf("Status = %q, want pass with 2 archives under threshold of 20", check.Status)
+	}
+	if !strings.Contains(check.Detail, "archives=2") {
+		t.Fatalf("Detail = %q, want archives=2", check.Detail)
+	}
+	if !strings.Contains(check.Detail, "oldest_archive=2026-01-01") {
+		t.Fatalf("Detail = %q, want oldest_archive timestamp", check.Detail)
 	}
 }
 

--- a/cli/internal/daemon/ledger_health.go
+++ b/cli/internal/daemon/ledger_health.go
@@ -1,0 +1,120 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// LedgerHealth summarizes durability state for the ao doctor surface (TB-Δ3
+// Phase 2-C). Read-only — populated by Store.LedgerHealth from on-disk facts.
+type LedgerHealth struct {
+	LedgerSizeBytes      int64         `json:"ledger_size_bytes"`
+	LedgerMaxBytes       int64         `json:"ledger_max_bytes"`
+	LedgerSizeRatio      float64       `json:"ledger_size_ratio"`
+	LatestSnapshotPath   string        `json:"latest_snapshot_path,omitempty"`
+	LatestSnapshotAge    time.Duration `json:"latest_snapshot_age_ns"`
+	HasSnapshot          bool          `json:"has_snapshot"`
+	ArchiveCount         int           `json:"archive_count"`
+	OldestArchiveTime    time.Time     `json:"oldest_archive_time,omitempty"`
+	WarnReasons          []string      `json:"warn_reasons,omitempty"`
+}
+
+// LedgerHealthThresholds controls the WARN bands. Zero-value means "use
+// LedgerHealthDefaultThresholds()". Operators may override per-call.
+type LedgerHealthThresholds struct {
+	// LedgerSizeWarnRatio fires WARN when ledger.jsonl size / max >= ratio.
+	LedgerSizeWarnRatio float64
+	// SnapshotMaxAge fires WARN when latest snapshot age >= this duration.
+	// Zero disables the snapshot-age check.
+	SnapshotMaxAge time.Duration
+	// ArchiveCountWarn fires WARN when archive count >= this value. Zero
+	// disables the check.
+	ArchiveCountWarn int
+}
+
+func LedgerHealthDefaultThresholds() LedgerHealthThresholds {
+	return LedgerHealthThresholds{
+		LedgerSizeWarnRatio: 0.80,
+		SnapshotMaxAge:      24 * time.Hour,
+		ArchiveCountWarn:    20,
+	}
+}
+
+// LedgerHealth gathers ledger-durability facts for the doctor surface. now
+// must be supplied (caller's clock) so tests can be deterministic. thresholds
+// uses LedgerHealthDefaultThresholds when its LedgerSizeWarnRatio is zero.
+func (s *Store) LedgerHealth(now time.Time, thresholds LedgerHealthThresholds) (LedgerHealth, error) {
+	if thresholds.LedgerSizeWarnRatio == 0 {
+		thresholds = LedgerHealthDefaultThresholds()
+	}
+	out := LedgerHealth{
+		LedgerMaxBytes: s.ledgerMaxBytes,
+	}
+
+	if info, err := os.Stat(s.LedgerPath()); err == nil {
+		out.LedgerSizeBytes = info.Size()
+	} else if !os.IsNotExist(err) {
+		return LedgerHealth{}, fmt.Errorf("stat ledger: %w", err)
+	}
+	if out.LedgerMaxBytes > 0 {
+		out.LedgerSizeRatio = float64(out.LedgerSizeBytes) / float64(out.LedgerMaxBytes)
+	}
+
+	snapshot, snapshotPath, snapErr := s.LoadLatestProjectionSnapshot()
+	if snapErr != nil && !os.IsNotExist(snapErr) {
+		// Surface as a warn reason; don't fail the whole check.
+		out.WarnReasons = append(out.WarnReasons, "snapshot load error: "+snapErr.Error())
+	}
+	if snapshotPath != "" && snapErr == nil {
+		out.HasSnapshot = true
+		out.LatestSnapshotPath = snapshotPath
+		if snapshot.RebuiltAt != "" {
+			if rebuiltAt, err := time.Parse(time.RFC3339Nano, snapshot.RebuiltAt); err == nil {
+				out.LatestSnapshotAge = now.Sub(rebuiltAt)
+			}
+		}
+	}
+
+	archives, err := s.LedgerArchivePaths()
+	if err != nil {
+		return LedgerHealth{}, fmt.Errorf("list archives: %w", err)
+	}
+	out.ArchiveCount = len(archives)
+	if len(archives) > 0 {
+		out.OldestArchiveTime = parseArchiveTimestamp(archives[0])
+	}
+
+	if out.LedgerMaxBytes > 0 && out.LedgerSizeRatio >= thresholds.LedgerSizeWarnRatio {
+		out.WarnReasons = append(out.WarnReasons,
+			fmt.Sprintf("ledger %d/%d bytes (%.0f%% of cap)",
+				out.LedgerSizeBytes, out.LedgerMaxBytes, out.LedgerSizeRatio*100))
+	}
+	if thresholds.SnapshotMaxAge > 0 && out.HasSnapshot && out.LatestSnapshotAge >= thresholds.SnapshotMaxAge {
+		out.WarnReasons = append(out.WarnReasons,
+			fmt.Sprintf("snapshot age %s (>= %s)", out.LatestSnapshotAge.Round(time.Second), thresholds.SnapshotMaxAge))
+	}
+	if thresholds.ArchiveCountWarn > 0 && out.ArchiveCount >= thresholds.ArchiveCountWarn {
+		out.WarnReasons = append(out.WarnReasons,
+			fmt.Sprintf("archives=%d (>= %d)", out.ArchiveCount, thresholds.ArchiveCountWarn))
+	}
+	return out, nil
+}
+
+// parseArchiveTimestamp extracts the UTC timestamp encoded in
+// ledger.<UTC-ts>.jsonl[.gz]. Returns zero time on parse failure (caller
+// treats as "unknown" rather than erroring).
+func parseArchiveTimestamp(path string) time.Time {
+	name := filepath.Base(path)
+	name = strings.TrimPrefix(name, ledgerArchivePrefix)
+	name = strings.TrimSuffix(name, ".gz")
+	name = strings.TrimSuffix(name, ledgerArchiveSuffix)
+	for _, layout := range []string{"20060102T150405.000000000Z", "20060102T150405Z"} {
+		if t, err := time.Parse(layout, name); err == nil {
+			return t.UTC()
+		}
+	}
+	return time.Time{}
+}

--- a/cli/internal/daemon/ledger_health_test.go
+++ b/cli/internal/daemon/ledger_health_test.go
@@ -1,0 +1,152 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLedgerHealthReportsZeroStateForFreshStore(t *testing.T) {
+	store := NewStore(t.TempDir())
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	got, err := store.LedgerHealth(now, LedgerHealthThresholds{})
+	if err != nil {
+		t.Fatalf("LedgerHealth: %v", err)
+	}
+	if got.LedgerSizeBytes != 0 {
+		t.Fatalf("LedgerSizeBytes = %d, want 0", got.LedgerSizeBytes)
+	}
+	if got.LedgerMaxBytes != DefaultLedgerMaxBytes {
+		t.Fatalf("LedgerMaxBytes = %d, want %d", got.LedgerMaxBytes, DefaultLedgerMaxBytes)
+	}
+	if got.HasSnapshot {
+		t.Fatalf("HasSnapshot = true, want false on fresh store")
+	}
+	if got.ArchiveCount != 0 {
+		t.Fatalf("ArchiveCount = %d, want 0", got.ArchiveCount)
+	}
+	if len(got.WarnReasons) != 0 {
+		t.Fatalf("WarnReasons = %#v, want none on fresh store", got.WarnReasons)
+	}
+}
+
+func TestLedgerHealthReportsLedgerSizeAndRatio(t *testing.T) {
+	store := NewStore(t.TempDir()).WithLedgerMaxBytes(1024)
+	if _, err := store.AppendLedgerEvent(mustNewProjectionTestEvent(t, "evt-001", "req-1", "job-1", EventJobAccepted, JobTypeRPIRun, 0, nil)); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	got, err := store.LedgerHealth(now, LedgerHealthThresholds{LedgerSizeWarnRatio: 0.001, ArchiveCountWarn: 100, SnapshotMaxAge: time.Hour})
+	if err != nil {
+		t.Fatalf("LedgerHealth: %v", err)
+	}
+	if got.LedgerSizeBytes <= 0 {
+		t.Fatalf("LedgerSizeBytes = %d, want > 0", got.LedgerSizeBytes)
+	}
+	if got.LedgerMaxBytes != 1024 {
+		t.Fatalf("LedgerMaxBytes = %d, want 1024", got.LedgerMaxBytes)
+	}
+	if got.LedgerSizeRatio == 0 {
+		t.Fatalf("LedgerSizeRatio = 0, want > 0")
+	}
+	// Ratio threshold 0.001 should fire WARN with any nonzero ledger size.
+	foundSizeReason := false
+	for _, r := range got.WarnReasons {
+		if strings.Contains(r, "of cap") {
+			foundSizeReason = true
+			break
+		}
+	}
+	if !foundSizeReason {
+		t.Fatalf("WarnReasons = %#v, want size warn", got.WarnReasons)
+	}
+}
+
+func TestLedgerHealthReportsSnapshotAgeAndArchiveCount(t *testing.T) {
+	store := NewStore(t.TempDir())
+	rebuiltAt := time.Date(2026, 4, 30, 6, 0, 0, 0, time.UTC)
+	now := rebuiltAt.Add(48 * time.Hour) // age = 48h
+	set := ProjectionSet{
+		SchemaVersion: ProjectionSchemaVersion,
+		RebuiltAt:     rebuiltAt.Format(time.RFC3339Nano),
+		LastEventID:   "evt-snap",
+		Manifests:     map[ProjectionName]ProjectionManifest{},
+	}
+	if _, err := store.WriteProjectionSnapshot(set); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+	// Plant 3 archive files with valid timestamps.
+	if err := os.MkdirAll(store.Dir(), 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, ts := range []string{"20260101T000000.000000000Z", "20260201T000000.000000000Z", "20260301T000000.000000000Z"} {
+		path := filepath.Join(store.Dir(), "ledger."+ts+".jsonl")
+		if err := os.WriteFile(path, []byte("{}\n"), 0600); err != nil {
+			t.Fatalf("plant archive: %v", err)
+		}
+	}
+	got, err := store.LedgerHealth(now, LedgerHealthThresholds{
+		LedgerSizeWarnRatio: 0.99,
+		SnapshotMaxAge:      24 * time.Hour,
+		ArchiveCountWarn:    2,
+	})
+	if err != nil {
+		t.Fatalf("LedgerHealth: %v", err)
+	}
+	if !got.HasSnapshot {
+		t.Fatal("HasSnapshot = false, want true")
+	}
+	if got.LatestSnapshotAge < 47*time.Hour || got.LatestSnapshotAge > 49*time.Hour {
+		t.Fatalf("LatestSnapshotAge = %s, want ~48h", got.LatestSnapshotAge)
+	}
+	if got.ArchiveCount != 3 {
+		t.Fatalf("ArchiveCount = %d, want 3", got.ArchiveCount)
+	}
+	expectedOldest := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	if !got.OldestArchiveTime.Equal(expectedOldest) {
+		t.Fatalf("OldestArchiveTime = %v, want %v", got.OldestArchiveTime, expectedOldest)
+	}
+	foundSnapAge := false
+	foundArchiveCount := false
+	for _, r := range got.WarnReasons {
+		if strings.Contains(r, "snapshot age") {
+			foundSnapAge = true
+		}
+		if strings.Contains(r, "archives=3") {
+			foundArchiveCount = true
+		}
+	}
+	if !foundSnapAge {
+		t.Fatalf("WarnReasons = %#v, want snapshot-age reason", got.WarnReasons)
+	}
+	if !foundArchiveCount {
+		t.Fatalf("WarnReasons = %#v, want archive-count reason", got.WarnReasons)
+	}
+}
+
+func TestLedgerHealthIgnoresDisabledThresholds(t *testing.T) {
+	store := NewStore(t.TempDir()).WithLedgerMaxBytes(0) // rotation disabled
+	if _, err := store.AppendLedgerEvent(mustNewProjectionTestEvent(t, "evt-001", "req-1", "job-1", EventJobAccepted, JobTypeRPIRun, 0, nil)); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	got, err := store.LedgerHealth(now, LedgerHealthThresholds{
+		LedgerSizeWarnRatio: 0.5,
+		SnapshotMaxAge:      0, // disabled
+		ArchiveCountWarn:    0, // disabled
+	})
+	if err != nil {
+		t.Fatalf("LedgerHealth: %v", err)
+	}
+	if got.LedgerMaxBytes != 0 {
+		t.Fatalf("LedgerMaxBytes = %d, want 0 (rotation disabled)", got.LedgerMaxBytes)
+	}
+	if got.LedgerSizeRatio != 0 {
+		t.Fatalf("LedgerSizeRatio = %v, want 0 with rotation disabled", got.LedgerSizeRatio)
+	}
+	if len(got.WarnReasons) != 0 {
+		t.Fatalf("WarnReasons = %#v, want none with all thresholds disabled or rotation off", got.WarnReasons)
+	}
+}

--- a/cli/internal/daemon/store.go
+++ b/cli/internal/daemon/store.go
@@ -2,11 +2,15 @@ package daemon
 
 import (
 	"bufio"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -15,10 +19,23 @@ const (
 	LedgerFileName      = "ledger.jsonl"
 	QuarantineDirName   = "quarantine"
 	LedgerSchemaVersion = 1
+	// DefaultLedgerMaxBytes is the size threshold at which ledger.jsonl is
+	// rotated. Operators may override via Store.WithLedgerMaxBytes.
+	DefaultLedgerMaxBytes int64 = 50 * 1024 * 1024
+	// ledgerArchivePrefix is the filename prefix for rotated ledger archives.
+	// Format: ledger.<RFC3339-no-colons>.jsonl[.gz].
+	ledgerArchivePrefix = "ledger."
+	ledgerArchiveSuffix = ".jsonl"
 )
 
+// Store persists daemon ledger events to ~/<root>/.agents/daemon/ledger.jsonl.
+// Concurrent writers are serialized through s.mu; readers (Replay*) operate on
+// committed file contents and do not contend for the lock — O_APPEND atomicity
+// covers per-line consistency.
 type Store struct {
-	root string
+	root           string
+	mu             sync.Mutex
+	ledgerMaxBytes int64
 }
 
 type LedgerEvent struct {
@@ -44,7 +61,16 @@ type CorruptRecord struct {
 }
 
 func NewStore(root string) *Store {
-	return &Store{root: root}
+	return &Store{root: root, ledgerMaxBytes: DefaultLedgerMaxBytes}
+}
+
+// WithLedgerMaxBytes overrides the rotation threshold and returns the store
+// for fluent configuration. Pass <=0 to disable rotation entirely.
+func (s *Store) WithLedgerMaxBytes(n int64) *Store {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ledgerMaxBytes = n
+	return s
 }
 
 func (s *Store) Dir() string {
@@ -59,20 +85,42 @@ func (s *Store) QuarantineDir() string {
 	return filepath.Join(s.Dir(), QuarantineDirName)
 }
 
+// LedgerArchivePaths returns the rotated ledger archives in chronological
+// order (oldest first). Each path is one of ledger.<ts>.jsonl[.gz]; the
+// active ledger.jsonl is excluded.
+func (s *Store) LedgerArchivePaths() ([]string, error) {
+	entries, err := os.ReadDir(s.Dir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read store dir: %w", err)
+	}
+	var archives []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name == LedgerFileName {
+			continue
+		}
+		if !strings.HasPrefix(name, ledgerArchivePrefix) {
+			continue
+		}
+		if !strings.HasSuffix(name, ledgerArchiveSuffix) && !strings.HasSuffix(name, ledgerArchiveSuffix+".gz") {
+			continue
+		}
+		archives = append(archives, filepath.Join(s.Dir(), name))
+	}
+	sort.Strings(archives)
+	return archives, nil
+}
+
 func (s *Store) AppendLedgerEvent(event LedgerEvent) (LedgerEvent, error) {
 	event, err := NormalizeLedgerEvent(event)
 	if err != nil {
 		return LedgerEvent{}, err
-	}
-
-	replay, err := s.ReplayLedger()
-	if err != nil {
-		return LedgerEvent{}, err
-	}
-	for _, existing := range replay.Events {
-		if existing.EventID == event.EventID {
-			return existing, nil
-		}
 	}
 
 	if err := os.MkdirAll(s.Dir(), 0700); err != nil {
@@ -82,18 +130,124 @@ func (s *Store) AppendLedgerEvent(event LedgerEvent) (LedgerEvent, error) {
 	if err != nil {
 		return LedgerEvent{}, fmt.Errorf("marshal ledger event: %w", err)
 	}
+	line := append(data, '\n')
+
+	// Serialize the dedup pre-check, rotation decision, and write together so
+	// concurrent writers don't observe a half-rotated state nor write the same
+	// EventID twice. Replay outside the lock would race with rotation.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	replay, err := s.replayLedger(true)
+	if err != nil {
+		return LedgerEvent{}, err
+	}
+	for _, existing := range replay.Events {
+		if existing.EventID == event.EventID {
+			return existing, nil
+		}
+	}
+
+	if err := s.maybeRotate(int64(len(line))); err != nil {
+		return LedgerEvent{}, err
+	}
+
 	file, err := os.OpenFile(s.LedgerPath(), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		return LedgerEvent{}, fmt.Errorf("open ledger: %w", err)
 	}
 	defer file.Close()
-	if _, err := file.Write(append(data, '\n')); err != nil {
+	if _, err := file.Write(line); err != nil {
 		return LedgerEvent{}, fmt.Errorf("append ledger: %w", err)
 	}
 	if err := file.Sync(); err != nil {
 		return LedgerEvent{}, fmt.Errorf("sync ledger: %w", err)
 	}
 	return event, nil
+}
+
+// maybeRotate is called with s.mu held. It checks the current ledger size
+// and rotates if appending pendingBytes would push it past the threshold.
+func (s *Store) maybeRotate(pendingBytes int64) error {
+	if s.ledgerMaxBytes <= 0 {
+		return nil
+	}
+	info, err := os.Stat(s.LedgerPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat ledger: %w", err)
+	}
+	if info.Size()+pendingBytes <= s.ledgerMaxBytes {
+		return nil
+	}
+	return s.rotateLedger()
+}
+
+// rotateLedger atomically renames ledger.jsonl to a timestamped archive and
+// gzip-compresses it. A fresh ledger.jsonl is created implicitly on the next
+// append. Caller must hold s.mu.
+func (s *Store) rotateLedger() error {
+	timestamp := time.Now().UTC().Format("20060102T150405.000000000Z")
+	archive := filepath.Join(s.Dir(), ledgerArchivePrefix+timestamp+ledgerArchiveSuffix)
+	if err := os.Rename(s.LedgerPath(), archive); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("rotate ledger: rename: %w", err)
+	}
+	if err := gzipFileInPlace(archive); err != nil {
+		// Compression failure leaves the .jsonl archive in place; replay still
+		// reads it (LedgerArchivePaths accepts both extensions).
+		return fmt.Errorf("rotate ledger: gzip: %w", err)
+	}
+	return nil
+}
+
+// gzipFileInPlace compresses src to src+".gz" atomically: writes the gzip
+// stream to a sibling tmp file, fsyncs and closes it, then renames it onto the
+// final ".gz" path so concurrent readers never observe a partial gzip stream.
+// The uncompressed src is removed only after the rename succeeds.
+func gzipFileInPlace(src string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	dst := src + ".gz"
+	tmp := dst + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	zw := gzip.NewWriter(out)
+	if _, err := io.Copy(zw, in); err != nil {
+		_ = zw.Close()
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := zw.Close(); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := out.Sync(); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, dst); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return os.Remove(src)
 }
 
 func (s *Store) ReadLedger() ([]LedgerEvent, error) {
@@ -112,33 +266,66 @@ func (s *Store) ReplayLedgerReadOnly() (ReplayResult, error) {
 	return s.replayLedger(false)
 }
 
+// replayLedger walks rotated archives oldest-first then the current ledger,
+// dedup by EventID across the entire chain so rotation is invisible to readers.
 func (s *Store) replayLedger(quarantine bool) (ReplayResult, error) {
-	file, err := os.Open(s.LedgerPath())
+	archives, err := s.LedgerArchivePaths()
+	if err != nil {
+		return ReplayResult{}, err
+	}
+
+	var result ReplayResult
+	seen := map[string]struct{}{}
+	lineCounter := 0
+
+	for _, archive := range archives {
+		if err := s.replayLedgerFile(archive, &lineCounter, seen, &result, quarantine); err != nil {
+			return result, err
+		}
+	}
+	if err := s.replayLedgerFile(s.LedgerPath(), &lineCounter, seen, &result, quarantine); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+// replayLedgerFile reads a single ledger file (current or archive) and appends
+// valid events to result.Events. Deduplication is shared across calls via seen.
+func (s *Store) replayLedgerFile(path string, lineCounter *int, seen map[string]struct{}, result *ReplayResult, quarantine bool) error {
+	file, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return ReplayResult{}, nil
+			return nil
 		}
-		return ReplayResult{}, fmt.Errorf("open ledger: %w", err)
+		return fmt.Errorf("open ledger %s: %w", filepath.Base(path), err)
 	}
 	defer file.Close()
 
-	var result ReplayResult
-	scanner := bufio.NewScanner(file)
-	lineNumber := 0
-	seen := map[string]struct{}{}
+	var reader io.Reader = file
+	if strings.HasSuffix(path, ".gz") {
+		zr, err := gzip.NewReader(file)
+		if err != nil {
+			return fmt.Errorf("open gzip archive %s: %w", filepath.Base(path), err)
+		}
+		defer zr.Close()
+		reader = zr
+	}
+
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
-		lineNumber++
+		*lineCounter++
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
 			continue
 		}
 		var event LedgerEvent
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			result.Corrupt = append(result.Corrupt, s.corruptRecord(lineNumber, line, err, quarantine))
+			result.Corrupt = append(result.Corrupt, s.corruptRecord(*lineCounter, line, err, quarantine))
 			continue
 		}
 		if err := ValidateLedgerEvent(event); err != nil {
-			result.Corrupt = append(result.Corrupt, s.corruptRecord(lineNumber, line, err, quarantine))
+			result.Corrupt = append(result.Corrupt, s.corruptRecord(*lineCounter, line, err, quarantine))
 			continue
 		}
 		if _, ok := seen[event.EventID]; ok {
@@ -148,9 +335,9 @@ func (s *Store) replayLedger(quarantine bool) (ReplayResult, error) {
 		result.Events = append(result.Events, event)
 	}
 	if err := scanner.Err(); err != nil {
-		return result, fmt.Errorf("scan ledger: %w", err)
+		return fmt.Errorf("scan ledger %s: %w", filepath.Base(path), err)
 	}
-	return result, nil
+	return nil
 }
 
 func ValidateLedgerEvent(event LedgerEvent) error {

--- a/cli/internal/daemon/store_test.go
+++ b/cli/internal/daemon/store_test.go
@@ -2,9 +2,11 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -206,4 +208,147 @@ func mustLedgerLine(t *testing.T, event LedgerEvent) string {
 		t.Fatalf("marshal ledger fixture: %v", err)
 	}
 	return string(data)
+}
+
+// TestLedgerRotation drives the size-cap path: append enough events that the
+// active ledger crosses the configured threshold, assert that an archive
+// appears, the active file shrinks, and ReplayLedger still returns every event
+// in append order across the rotation boundary.
+func TestLedgerRotation(t *testing.T) {
+	store := NewStore(t.TempDir()).WithLedgerMaxBytes(1024)
+
+	const totalEvents = 30
+	for i := 0; i < totalEvents; i++ {
+		ev := testLedgerEvent(fmt.Sprintf("evt-%03d", i), EventJobAccepted)
+		if _, err := store.AppendLedgerEvent(ev); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+
+	archives, err := store.LedgerArchivePaths()
+	if err != nil {
+		t.Fatalf("list archives: %v", err)
+	}
+	if len(archives) == 0 {
+		t.Fatalf("expected at least one archive after %d appends, got 0", totalEvents)
+	}
+	for _, a := range archives {
+		if !strings.HasSuffix(a, ".jsonl.gz") {
+			t.Fatalf("archive %s missing .jsonl.gz suffix", a)
+		}
+	}
+
+	info, err := os.Stat(store.LedgerPath())
+	if err != nil {
+		t.Fatalf("stat active ledger: %v", err)
+	}
+	if info.Size() > 1024 {
+		t.Fatalf("active ledger size %d > cap 1024 after rotation", info.Size())
+	}
+
+	events, err := store.ReadLedger()
+	if err != nil {
+		t.Fatalf("read ledger across archives: %v", err)
+	}
+	if len(events) != totalEvents {
+		t.Fatalf("read %d events, want %d (rotation lost data)", len(events), totalEvents)
+	}
+	for i, ev := range events {
+		want := fmt.Sprintf("evt-%03d", i)
+		if ev.EventID != want {
+			t.Fatalf("events[%d].EventID = %q, want %q (rotation reordered)", i, ev.EventID, want)
+		}
+	}
+}
+
+// TestRotateWhileAppendingDoesNotLoseEvents stresses the lock contract:
+// concurrent appends across multiple goroutines must produce a complete,
+// deduplicated event stream after replay even when rotation triggers
+// repeatedly mid-flight.
+func TestRotateWhileAppendingDoesNotLoseEvents(t *testing.T) {
+	store := NewStore(t.TempDir()).WithLedgerMaxBytes(512)
+
+	const writers = 4
+	const perWriter = 25
+	totalUnique := writers * perWriter
+
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for w := 0; w < writers; w++ {
+		w := w
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				ev := testLedgerEvent(fmt.Sprintf("w%d-%03d", w, i), EventJobAccepted)
+				if _, err := store.AppendLedgerEvent(ev); err != nil {
+					t.Errorf("writer %d append %d: %v", w, i, err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	archives, err := store.LedgerArchivePaths()
+	if err != nil {
+		t.Fatalf("list archives: %v", err)
+	}
+	if len(archives) == 0 {
+		t.Fatalf("rotation never fired during concurrent stress")
+	}
+
+	events, err := store.ReadLedger()
+	if err != nil {
+		t.Fatalf("replay after concurrent appends: %v", err)
+	}
+	if len(events) != totalUnique {
+		t.Fatalf("replayed %d events, want %d (concurrent rotation lost data)", len(events), totalUnique)
+	}
+	seen := map[string]struct{}{}
+	for _, ev := range events {
+		if _, dup := seen[ev.EventID]; dup {
+			t.Fatalf("duplicate event ID after rotation+replay: %s", ev.EventID)
+		}
+		seen[ev.EventID] = struct{}{}
+	}
+}
+
+// TestReplayReadsArchivesInChronologicalOrder seeds two pre-rotated archive
+// files plus a current ledger and asserts replay yields events in the
+// archive-then-current order — protects against alphabetical re-sort regressions.
+func TestReplayReadsArchivesInChronologicalOrder(t *testing.T) {
+	store := NewStore(t.TempDir()).WithLedgerMaxBytes(0) // rotation disabled
+	if err := os.MkdirAll(store.Dir(), 0700); err != nil {
+		t.Fatalf("create dir: %v", err)
+	}
+
+	old := mustLedgerLine(t, testLedgerEvent("old-1", EventJobAccepted))
+	mid := mustLedgerLine(t, testLedgerEvent("mid-1", EventJobClaimed))
+	current := mustLedgerLine(t, testLedgerEvent("now-1", EventJobCompleted))
+
+	oldPath := filepath.Join(store.Dir(), "ledger.20260101T000000.000000000Z.jsonl")
+	midPath := filepath.Join(store.Dir(), "ledger.20260201T000000.000000000Z.jsonl")
+	if err := os.WriteFile(oldPath, []byte(old+"\n"), 0600); err != nil {
+		t.Fatalf("write old archive: %v", err)
+	}
+	if err := os.WriteFile(midPath, []byte(mid+"\n"), 0600); err != nil {
+		t.Fatalf("write mid archive: %v", err)
+	}
+	if err := os.WriteFile(store.LedgerPath(), []byte(current+"\n"), 0600); err != nil {
+		t.Fatalf("write current ledger: %v", err)
+	}
+
+	events, err := store.ReadLedger()
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("got %d events across archives, want 3", len(events))
+	}
+	wantOrder := []string{"old-1", "mid-1", "now-1"}
+	for i, want := range wantOrder {
+		if events[i].EventID != want {
+			t.Fatalf("events[%d].EventID = %q, want %q", i, events[i].EventID, want)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- soc-5of.14 / TB-Δ3 Phase 2-C. Surfaces ledger durability state in the existing \`ao doctor\` pipeline so operators can see growth-cap headroom, snapshot freshness, and archive accumulation in one place.
- Stacks on **fix/snapshot-startup-wiring** (Phase 2-B, PR #195) which itself stacks on **fix/projection-snapshot-serialize** (Phase 2-A) and **fix/ledger-rotation** (Phase 1). All four merges needed for the production surface to light up.

## New surface
- \`daemon.LedgerHealth\` value type — ledger size + ratio, snapshot age + path, archive count + oldest, warn reasons.
- \`Store.LedgerHealth(now, thresholds)\` — pure read-only computation over on-disk state. Caller-supplied clock for deterministic tests.
- \`LedgerHealthDefaultThresholds\` — 80% size ratio, 24h snapshot age, 20 archives. Each band individually disable-able.

## Doctor wiring
- New \"Daemon Ledger Health\" check in \`gatherDoctorChecks\`.
- \`pass\` when no daemon dir exists (dev boxes), \`pass\`/\`warn\` from health WarnReasons otherwise.
- Detail format: \`ledger=NB/NB; snapshot_age=...; archives=N; oldest_archive=RFC3339\`.

## Test plan
- [x] \`TestLedgerHealthReportsZeroStateForFreshStore\` — fresh store reports zeros and no warnings.
- [x] \`TestLedgerHealthReportsLedgerSizeAndRatio\` — ratio threshold fires.
- [x] \`TestLedgerHealthReportsSnapshotAgeAndArchiveCount\` — snapshot age + archive count + oldest archive timestamp.
- [x] \`TestLedgerHealthIgnoresDisabledThresholds\` — zero-valued thresholds skip checks.
- [x] \`TestDoctorLedgerHealthCheckPassesOnFreshStore\` — missing daemon dir is non-fatal.
- [x] \`TestDoctorLedgerHealthCheckWarnsOnStaleSnapshot\` — 72h-old snapshot trips 24h threshold.
- [x] \`TestDoctorLedgerHealthCheckSurfacesArchiveCount\` — archives + oldest_archive in detail string.
- [x] \`go test ./...\` green; \`go vet\` clean.