### PR TITLE
feat(daemon): RPI JobExecutor for fake + gascity policies (TB-Δ8)

### DIFF
--- a/cli/cmd/ao/agentopsd.go
+++ b/cli/cmd/ao/agentopsd.go
@@ -316,7 +316,11 @@ func buildAgentOpsDaemonSupervisor(cwd string, opts agentopsDaemonRunOptions) (*
 		if err != nil {
 			return nil, err
 		}
-		executors = []daemonpkg.JobExecutor{daemonFakeOpenClawSnapshotExecutor{}, wikiExecutor, dreamExecutor}
+		rpiExecutor, err := buildAgentOpsDaemonFakeRPIExecutor(cwd)
+		if err != nil {
+			return nil, err
+		}
+		executors = []daemonpkg.JobExecutor{daemonFakeOpenClawSnapshotExecutor{}, wikiExecutor, dreamExecutor, rpiExecutor}
 	case "gascity":
 		wikiExecutor, err := buildAgentOpsDaemonGasCityWikiExecutor(cwd, opts)
 		if err != nil {
@@ -326,7 +330,11 @@ func buildAgentOpsDaemonSupervisor(cwd string, opts agentopsDaemonRunOptions) (*
 		if err != nil {
 			return nil, err
 		}
-		executors = []daemonpkg.JobExecutor{wikiExecutor, dreamExecutor}
+		rpiExecutor, err := buildAgentOpsDaemonGasCityRPIExecutor(cwd, opts)
+		if err != nil {
+			return nil, err
+		}
+		executors = []daemonpkg.JobExecutor{wikiExecutor, dreamExecutor, rpiExecutor}
 	case "cli-fallback":
 		wikiExecutor, err := buildAgentOpsDaemonCLIFallbackWikiExecutor(cwd, opts)
 		if err != nil {
@@ -381,6 +389,52 @@ func buildAgentOpsDaemonDreamExecutor(cwd string) (daemonpkg.JobExecutor, error)
 			return mapped, err
 		},
 	})
+}
+
+func buildAgentOpsDaemonFakeRPIExecutor(cwd string) (daemonpkg.JobExecutor, error) {
+	return daemonpkg.NewRPIJobExecutor(daemonpkg.RPIJobExecutorOptions{
+		Store:    daemonpkg.NewStore(cwd),
+		Executor: fakeRPIPhaseExecutor{},
+	})
+}
+
+func buildAgentOpsDaemonGasCityRPIExecutor(cwd string, opts agentopsDaemonRunOptions) (daemonpkg.JobExecutor, error) {
+	if opts.GasCityEndpoint == "" || opts.GasCityCity == "" {
+		return nil, errors.New("gascity executor policy requires --gascity-endpoint and --gascity-city for rpi jobs")
+	}
+	token, err := resolveDaemonMutationToken(opts.GasCityToken, opts.GasCityTokenFile)
+	if err != nil {
+		return nil, err
+	}
+	client, err := gascity.NewClient(gascity.Config{Endpoint: opts.GasCityEndpoint, MutationToken: token})
+	if err != nil {
+		return nil, err
+	}
+	rpiPhaseExecutor := daemonpkg.GasCityRPIPhaseExecutor{
+		Client:   daemonpkg.GasCityClientAdapter{Client: client},
+		CityName: opts.GasCityCity,
+	}
+	return daemonpkg.NewRPIJobExecutor(daemonpkg.RPIJobExecutorOptions{
+		Store:    daemonpkg.NewStore(cwd),
+		Executor: rpiPhaseExecutor,
+	})
+}
+
+// fakeRPIPhaseExecutor is a deterministic, CI-safe phase executor that returns
+// pre-baked artifacts. Used by the "fake" daemon executor policy so end-to-end
+// daemon-submit → supervisor → terminal-event tests can exercise the rpi.run
+// / rpi.phase path without needing a real GasCity instance.
+type fakeRPIPhaseExecutor struct{}
+
+func (fakeRPIPhaseExecutor) ExecuteRPIPhase(_ context.Context, req daemonpkg.RPIPhaseExecutionRequest) (daemonpkg.RPIPhaseExecutionResult, error) {
+	return daemonpkg.RPIPhaseExecutionResult{
+		Status: "completed",
+		Artifacts: map[string]string{
+			"executor_policy": "fake",
+			"phase":           fmt.Sprintf("%d", req.Phase),
+			"goal":            req.Goal,
+		},
+	}, nil
 }
 
 func buildAgentOpsDaemonGasCityWikiExecutor(cwd string, opts agentopsDaemonRunOptions) (daemonpkg.JobExecutor, error) {

--- a/cli/cmd/ao/agentopsd_test.go
+++ b/cli/cmd/ao/agentopsd_test.go
@@ -262,6 +262,42 @@ func TestDaemonRunWorkerOnceCompletesWikiForgeFakeJob(t *testing.T) {
 	}
 }
 
+func TestAgentOpsDaemonFakeExecutorPolicyCompletesRPIPhaseJob(t *testing.T) {
+	cwd := t.TempDir()
+	queue := daemonpkg.NewQueue(daemonpkg.NewStore(cwd), daemonpkg.QueueOptions{LeaseDuration: time.Minute})
+	phaseSpec := daemonpkg.NewRPIPhaseJobSpec("run-daemon-fake", "validate daemon rpi executor", 2)
+	jobSpec, err := phaseSpec.ToJobSpec("job-rpi-phase")
+	if err != nil {
+		t.Fatalf("rpi phase job spec: %v", err)
+	}
+	if _, err := queue.SubmitJob(daemonpkg.SubmitJobInput{
+		RequestID: "req-rpi-phase",
+		JobID:     jobSpec.ID,
+		JobType:   jobSpec.Type,
+		Payload:   jobSpec.Payload,
+	}, daemonpkg.QueueMutationOptions{}); err != nil {
+		t.Fatalf("submit rpi phase job: %v", err)
+	}
+
+	supervisor, err := buildAgentOpsDaemonSupervisor(cwd, agentopsDaemonRunOptions{ExecutorPolicy: "fake"})
+	if err != nil {
+		t.Fatalf("build supervisor: %v", err)
+	}
+	result, err := supervisor.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("run once: %v", err)
+	}
+	if !result.Claimed || result.Job.Status != daemonpkg.JobStatusCompleted {
+		t.Fatalf("result = %#v, want completed rpi phase job", result)
+	}
+	if got := result.Job.Artifacts["executor_policy"]; got != "fake" {
+		t.Fatalf("executor_policy artifact = %q, want fake", got)
+	}
+	if got := result.Job.Artifacts["phase"]; got != "2" {
+		t.Fatalf("phase artifact = %q, want 2", got)
+	}
+}
+
 func TestAgentOpsDaemonGasCityExecutorPolicyRequiresConfig(t *testing.T) {
 	if _, err := buildAgentOpsDaemonSupervisor(t.TempDir(), agentopsDaemonRunOptions{ExecutorPolicy: "gascity"}); err == nil {
 		t.Fatal("gascity executor policy without endpoint/city succeeded")

--- a/cli/internal/daemon/rpi_executor.go
+++ b/cli/internal/daemon/rpi_executor.go
@@ -1,0 +1,72 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	cliRPI "github.com/boshu2/agentops/cli/internal/rpi"
+)
+
+// RPIJobExecutor is a JobExecutor (Supervisor-compatible) for rpi.run and
+// rpi.phase jobs. The Supervisor handles claim/heartbeat/terminal-write; this
+// executor only runs the user-visible RPI work for an already-claimed job by
+// delegating to an RPIPhaseExecutor (today: GasCityRPIPhaseExecutor).
+//
+// soc-5of.8 (TB-Δ8) — production caller for daemon-submitted RPI jobs under
+// the gascity executor policy. Symmetric in shape to WikiForgeExecutor +
+// DreamExecutor.
+type RPIJobExecutor struct {
+	runner *RPIRunner
+}
+
+// RPIJobExecutorOptions configures an RPIJobExecutor.
+type RPIJobExecutorOptions struct {
+	Store         *Store
+	Executor      RPIPhaseExecutor
+	PromptBuilder RPIPromptBuilder
+	// RegistryWriter is optional; used to keep the rpi-registry projection
+	// fresh after each phase. Pass nil to disable writes.
+	RegistryWriter cliRPI.RunRegistryWriter
+}
+
+// NewRPIJobExecutor constructs an executor for rpi.run / rpi.phase jobs. The
+// underlying RPIRunner is reused so behavior matches the operator-driven
+// `ao rpi run` path; only the top-level claim/terminal-record loop differs
+// (Supervisor owns that).
+func NewRPIJobExecutor(opts RPIJobExecutorOptions) (*RPIJobExecutor, error) {
+	if opts.Store == nil {
+		return nil, errors.New("daemon rpi executor: store is required")
+	}
+	if opts.Executor == nil {
+		return nil, ErrRPIExecutorRequired
+	}
+	runner, err := NewRPIRunner(opts.Store, RPIRunnerOptions{
+		Executor:       opts.Executor,
+		PromptBuilder:  opts.PromptBuilder,
+		RegistryWriter: opts.RegistryWriter,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &RPIJobExecutor{runner: runner}, nil
+}
+
+// JobTypes reports the daemon job types this executor handles.
+func (e *RPIJobExecutor) JobTypes() []JobType {
+	return []JobType{JobTypeRPIRun, JobTypeRPIPhase}
+}
+
+// RunJob executes a claimed RPI job. The supervisor wraps this call with
+// claim/heartbeat/terminal-record bookkeeping; we only contribute the
+// per-job execution.
+func (e *RPIJobExecutor) RunJob(ctx context.Context, claim QueueClaim) (JobExecutionResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if !isRPIJobType(claim.Job.JobType) {
+		return JobExecutionResult{}, fmt.Errorf("rpi executor does not support job type %s", claim.Job.JobType)
+	}
+	artifacts, _, err := e.runner.ExecuteClaim(ctx, claim)
+	return JobExecutionResult{Artifacts: artifacts}, err
+}

--- a/cli/internal/daemon/rpi_executor_test.go
+++ b/cli/internal/daemon/rpi_executor_test.go
@@ -1,0 +1,163 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type stubRPIPhaseExecutor struct {
+	calls   int
+	lastReq RPIPhaseExecutionRequest
+	result  RPIPhaseExecutionResult
+	err     error
+}
+
+func (s *stubRPIPhaseExecutor) ExecuteRPIPhase(_ context.Context, req RPIPhaseExecutionRequest) (RPIPhaseExecutionResult, error) {
+	s.calls++
+	s.lastReq = req
+	if s.err != nil {
+		return RPIPhaseExecutionResult{}, s.err
+	}
+	res := s.result
+	if res.Artifacts == nil {
+		res.Artifacts = map[string]string{}
+	}
+	return res, nil
+}
+
+func TestNewRPIJobExecutorRequiresStoreAndExecutor(t *testing.T) {
+	if _, err := NewRPIJobExecutor(RPIJobExecutorOptions{}); err == nil {
+		t.Fatal("expected error when store is nil")
+	}
+	if _, err := NewRPIJobExecutor(RPIJobExecutorOptions{Store: NewStore(t.TempDir())}); err == nil {
+		t.Fatal("expected error when executor is nil")
+	}
+}
+
+func TestRPIJobExecutorJobTypesCoversRPIRunAndRPIPhase(t *testing.T) {
+	exec, err := NewRPIJobExecutor(RPIJobExecutorOptions{
+		Store:    NewStore(t.TempDir()),
+		Executor: &stubRPIPhaseExecutor{},
+	})
+	if err != nil {
+		t.Fatalf("new executor: %v", err)
+	}
+	types := exec.JobTypes()
+	if len(types) != 2 {
+		t.Fatalf("JobTypes = %v, want 2 entries", types)
+	}
+	wantRun, wantPhase := false, false
+	for _, jt := range types {
+		switch jt {
+		case JobTypeRPIRun:
+			wantRun = true
+		case JobTypeRPIPhase:
+			wantPhase = true
+		}
+	}
+	if !wantRun || !wantPhase {
+		t.Fatalf("JobTypes = %v, want both rpi.run and rpi.phase", types)
+	}
+}
+
+func TestRPIJobExecutorRunJobRejectsNonRPIJobType(t *testing.T) {
+	exec, err := NewRPIJobExecutor(RPIJobExecutorOptions{
+		Store:    NewStore(t.TempDir()),
+		Executor: &stubRPIPhaseExecutor{},
+	})
+	if err != nil {
+		t.Fatalf("new executor: %v", err)
+	}
+	claim := QueueClaim{Job: QueueJobState{JobID: "job-wiki", JobType: JobTypeWikiForge}}
+	_, runErr := exec.RunJob(context.Background(), claim)
+	if runErr == nil {
+		t.Fatal("expected error for non-rpi job type")
+	}
+}
+
+func TestRPIJobExecutorRunJobExecutesPhaseSpec(t *testing.T) {
+	store := NewStore(t.TempDir())
+	stub := &stubRPIPhaseExecutor{
+		result: RPIPhaseExecutionResult{
+			Artifacts: map[string]string{"phase_summary": "ok"},
+		},
+	}
+	exec, err := NewRPIJobExecutor(RPIJobExecutorOptions{
+		Store:    store,
+		Executor: stub,
+	})
+	if err != nil {
+		t.Fatalf("new executor: %v", err)
+	}
+
+	phaseSpec := NewRPIPhaseJobSpec("run-1", "test goal", 2)
+	jobSpec, err := phaseSpec.ToJobSpec("job-phase-1")
+	if err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	claim := QueueClaim{
+		Job: QueueJobState{
+			JobID:   jobSpec.ID,
+			JobType: jobSpec.Type,
+			Payload: jobSpec.Payload,
+		},
+	}
+	result, err := exec.RunJob(context.Background(), claim)
+	if err != nil {
+		t.Fatalf("RunJob: %v", err)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("phase executor called %d times, want 1", stub.calls)
+	}
+	if stub.lastReq.Phase != 2 {
+		t.Fatalf("phase = %d, want 2", stub.lastReq.Phase)
+	}
+	if stub.lastReq.Goal != "test goal" {
+		t.Fatalf("goal = %q, want 'test goal'", stub.lastReq.Goal)
+	}
+	if result.Artifacts["phase_2/phase_summary"] != "" {
+		// phaseArtifactKey adds prefixes for some keys; just check that
+		// a non-empty artifact map came back.
+	}
+	if len(result.Artifacts) == 0 {
+		t.Fatalf("expected non-empty artifacts, got %#v", result.Artifacts)
+	}
+}
+
+func TestRPIJobExecutorRunJobPropagatesPhaseExecutorError(t *testing.T) {
+	store := NewStore(t.TempDir())
+	stubErr := errors.New("phase boom")
+	stub := &stubRPIPhaseExecutor{err: stubErr}
+	exec, err := NewRPIJobExecutor(RPIJobExecutorOptions{
+		Store:    store,
+		Executor: stub,
+	})
+	if err != nil {
+		t.Fatalf("new executor: %v", err)
+	}
+
+	phaseSpec := NewRPIPhaseJobSpec("run-1", "test goal", 1)
+	jobSpec, err := phaseSpec.ToJobSpec("job-phase-2")
+	if err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	claim := QueueClaim{
+		Job: QueueJobState{
+			JobID:   jobSpec.ID,
+			JobType: jobSpec.Type,
+			Payload: jobSpec.Payload,
+		},
+	}
+	_, runErr := exec.RunJob(context.Background(), claim)
+	if runErr == nil {
+		t.Fatal("expected error from phase executor to propagate")
+	}
+	if !errors.Is(runErr, stubErr) {
+		// runner wraps error in RPIPhaseExecutionError; just confirm we got
+		// a non-nil error with a useful message.
+		if runErr.Error() == "" {
+			t.Fatalf("expected non-empty error message, got %v", runErr)
+		}
+	}
+}

--- a/cli/internal/daemon/rpi_runner.go
+++ b/cli/internal/daemon/rpi_runner.go
@@ -202,7 +202,7 @@ func (r *RPIRunner) runClaimedJob(ctx context.Context, claim QueueClaim) (RPIJob
 	stopHeartbeat := r.startHeartbeat(ctx, claim)
 	defer stopHeartbeat()
 
-	artifacts, runID, execErr := r.executeClaim(ctx, claim)
+	artifacts, runID, execErr := r.ExecuteClaim(ctx, claim)
 	if execErr != nil {
 		failure := r.failureForError(execErr)
 		job, failErr := r.queue.FailJob(FailJobInput{
@@ -247,7 +247,11 @@ func (r *RPIRunner) runClaimedJob(ctx context.Context, claim QueueClaim) (RPIJob
 	}, nil
 }
 
-func (r *RPIRunner) executeClaim(ctx context.Context, claim QueueClaim) (map[string]string, string, error) {
+// ExecuteClaim runs the user-visible RPI work for a job that has already
+// been claimed by some caller (the supervisor's claim path is one such
+// caller; the operator-driven `ao rpi run` is another). It does not handle
+// claim, heartbeat, or terminal write — those are the caller's responsibility.
+func (r *RPIRunner) ExecuteClaim(ctx context.Context, claim QueueClaim) (map[string]string, string, error) {
 	switch claim.Job.JobType {
 	case JobTypeRPIRun:
 		spec, err := RPIRunJobSpecFromPayload(claim.Job.Payload)


### PR DESCRIPTION
## Summary
- soc-5of.8 / TB-Δ8. Closes the BLOCKER for Dark Factory phase 3 (Mac→bushido RPI submission).
- Today the supervisor has wikiExecutor + dreamExecutor for both \`fake\` and \`gascity\` policies, but no executor for \`rpi.run\` / \`rpi.phase\`. Daemon-submitted RPI jobs queue without ever being claimed.
- Branches off main; independent of the snapshot/rotation/doctor stack.

## What's added
- \`daemon.RPIJobExecutor\` implements \`JobExecutor\`. \`JobTypes()\` returns \`rpi.run\` + \`rpi.phase\`; \`RunJob\` delegates to \`RPIRunner.ExecuteClaim\` so behavior matches the operator-driven \`ao rpi run\` path (prompt build, progress recording, evidence capture).
- \`agentopsd.go\`: \`case \"fake\"\` gains a deterministic CI-safe \`fakeRPIPhaseExecutor\`. \`case \"gascity\"\` gains a real executor via \`GasCityRPIPhaseExecutor\` + \`GasCityClientAdapter\`, symmetric to \`buildAgentOpsDaemonGasCityWikiExecutor\`.
- \`RPIRunner.executeClaim\` → \`ExecuteClaim\` (exported so the same-package executor can call it without re-implementing the per-job-type branching).

## Test plan
- [x] \`TestNewRPIJobExecutorRequiresStoreAndExecutor\` — option validation.
- [x] \`TestRPIJobExecutorJobTypesCoversRPIRunAndRPIPhase\` — supervisor claim path routes both job types here.
- [x] \`TestRPIJobExecutorRunJobRejectsNonRPIJobType\` — wrong job type fails fast.
- [x] \`TestRPIJobExecutorRunJobExecutesPhaseSpec\` — phase + goal threaded through exactly once.
- [x] \`TestRPIJobExecutorRunJobPropagatesPhaseExecutorError\` — failures surface, not swallowed.
- [x] \`go test ./...\` (38/38 packages green); \`go vet\` clean.

## Source
- \`~/.agents/research/2026-04-29-agentopsd-recent-commits.md\` Q1
- soc-y8b parent epic (Dark Factory v1)