### PR TITLE
feat: add daemon watch and telemetry histograms

### DIFF
--- a/cli/cmd/ao/cobra_commands_test.go
+++ b/cli/cmd/ao/cobra_commands_test.go
@@ -426,7 +426,7 @@ func TestCobraCommandTreeRegistration(t *testing.T) {
 		"pool", "quick-start", "ratchet", "retrieval-bench", "rpi",
 		"scenario", "search", "seed", "session", "session-outcome", "sessions", "status",
 		"store", "task-feedback", "task-status", "task-sync", "temper",
-		"trace", "version", "vibe-check", "worktree",
+		"trace", "version", "vibe-check", "watch", "worktree",
 	}
 	cmdSet := make(map[string]bool)
 	for _, name := range cmdNames {
@@ -486,7 +486,7 @@ func TestCobraExpectedCmdsMatchRegistration(t *testing.T) {
 		"pool", "quick-start", "ratchet", "retrieval-bench", "rpi",
 		"scenario", "search", "seed", "session", "session-outcome", "sessions", "status",
 		"store", "task-feedback", "task-status", "task-sync", "temper",
-		"trace", "version", "vibe-check", "worktree",
+		"trace", "version", "vibe-check", "watch", "worktree",
 	}
 
 	// Every expected command must be registered

--- a/cli/cmd/ao/doctor.go
+++ b/cli/cmd/ao/doctor.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/boshu2/agentops/cli/internal/daemon"
+	daemonpkg "github.com/boshu2/agentops/cli/internal/daemon"
 	"github.com/boshu2/agentops/cli/internal/openclaw"
 	"github.com/boshu2/agentops/cli/internal/quality"
 	"github.com/boshu2/agentops/cli/internal/storage"
@@ -55,7 +55,8 @@ func gatherDoctorChecks() []doctorCheck {
 		{Name: "ao CLI", Status: "pass", Detail: formatVersion(version), Required: true},
 		checkCLIDependencies(),
 		checkDaemonRuntime(),
-		checkDaemonLedgerHealth(time.Now(), daemon.LedgerHealthDefaultThresholds()),
+		checkDaemonLedgerHealth(time.Now(), daemonpkg.LedgerHealthDefaultThresholds()),
+		checkDaemonTelemetry(),
 		checkGasCityBridge(),
 		checkOpenClawConsumer(),
 		checkHookCoverage(),
@@ -129,12 +130,12 @@ func checkDaemonRuntimeURL(baseURL string) doctorCheck {
 	return doctorCheck{Name: "Daemon Runtime", Status: "pass", Detail: "ready at " + detail, Required: false}
 }
 
-func checkDaemonLedgerHealth(now time.Time, thresholds daemon.LedgerHealthThresholds) doctorCheck {
+func checkDaemonLedgerHealth(now time.Time, thresholds daemonpkg.LedgerHealthThresholds) doctorCheck {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return doctorCheck{Name: "Daemon Ledger Health", Status: "warn", Detail: "cannot determine working directory", Required: false}
 	}
-	store := daemon.NewStore(cwd)
+	store := daemonpkg.NewStore(cwd)
 	if _, statErr := os.Stat(store.Dir()); os.IsNotExist(statErr) {
 		return doctorCheck{Name: "Daemon Ledger Health", Status: "pass", Detail: "no daemon store at " + store.Dir(), Required: false}
 	}
@@ -149,7 +150,7 @@ func checkDaemonLedgerHealth(now time.Time, thresholds daemon.LedgerHealthThresh
 	return doctorCheck{Name: "Daemon Ledger Health", Status: "pass", Detail: detail, Required: false}
 }
 
-func formatLedgerHealthDetail(h daemon.LedgerHealth) string {
+func formatLedgerHealthDetail(h daemonpkg.LedgerHealth) string {
 	parts := []string{
 		fmt.Sprintf("ledger=%dB/%dB", h.LedgerSizeBytes, h.LedgerMaxBytes),
 	}
@@ -163,6 +164,33 @@ func formatLedgerHealthDetail(h daemon.LedgerHealth) string {
 		parts = append(parts, "oldest_archive="+h.OldestArchiveTime.Format(time.RFC3339))
 	}
 	return strings.Join(parts, "; ")
+}
+
+func checkDaemonTelemetry() doctorCheck {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return doctorCheck{Name: "Daemon Telemetry", Status: "warn", Detail: "cannot determine working directory", Required: false}
+	}
+	baseURL, err := resolveDaemonURL(cwd, "")
+	if err != nil {
+		return doctorCheck{Name: "Daemon Telemetry", Status: "warn", Detail: fmt.Sprintf("activation unavailable: %v", err), Required: false}
+	}
+	return checkDaemonTelemetryURL(baseURL)
+}
+
+func checkDaemonTelemetryURL(baseURL string) doctorCheck {
+	baseURL = strings.TrimRight(baseURL, "/")
+	events, err := fetchDaemonEvents(context.Background(), baseURL)
+	if err != nil {
+		return doctorCheck{Name: "Daemon Telemetry", Status: "warn", Detail: fmt.Sprintf("events unavailable at %s: %v", baseURL, err), Required: false}
+	}
+	telemetry := daemonpkg.BuildLedgerTelemetry(events.Events, time.Now().UTC(), daemonpkg.DefaultTelemetryWindow)
+	return doctorCheck{
+		Name:     "Daemon Telemetry",
+		Status:   "pass",
+		Detail:   daemonpkg.FormatLedgerTelemetrySummary(telemetry),
+		Required: false,
+	}
 }
 
 func checkGasCityBridge() doctorCheck {

--- a/cli/cmd/ao/doctor_product_runtime_test.go
+++ b/cli/cmd/ao/doctor_product_runtime_test.go
@@ -110,6 +110,57 @@ func TestDoctorLedgerHealthCheckSurfacesArchiveCount(t *testing.T) {
 	}
 }
 
+func TestAoDoctorHistograms(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	store := daemonpkg.NewStore(t.TempDir())
+	queue := daemonpkg.NewQueue(store, daemonpkg.QueueOptions{
+		LeaseDuration: time.Minute,
+		Now:           func() time.Time { return now },
+	})
+	if _, err := queue.SubmitJob(daemonpkg.SubmitJobInput{
+		RequestID: "req-phase",
+		JobID:     "job-phase",
+		JobType:   daemonpkg.JobTypeRPIPhase,
+		Payload:   map[string]any{"phase_name": "discovery"},
+	}, daemonpkg.QueueMutationOptions{}); err != nil {
+		t.Fatalf("submit phase: %v", err)
+	}
+	claim, err := queue.ClaimJob("job-phase", "worker", daemonpkg.QueueMutationOptions{})
+	if err != nil {
+		t.Fatalf("claim phase: %v", err)
+	}
+	now = now.Add(12 * time.Second)
+	if _, err := queue.CompleteJob(daemonpkg.CompleteJobInput{
+		JobID:      "job-phase",
+		RequestID:  "req-phase-complete",
+		ClaimToken: claim.ClaimToken,
+		LeaseEpoch: claim.LeaseEpoch,
+		Actor:      "worker",
+	}, daemonpkg.QueueMutationOptions{}); err != nil {
+		t.Fatalf("complete phase: %v", err)
+	}
+	if _, err := queue.SubmitJob(daemonpkg.SubmitJobInput{
+		RequestID: "req-wiki",
+		JobID:     "job-wiki",
+		JobType:   daemonpkg.JobTypeWikiForge,
+		Payload:   map[string]any{"worker_kind": "codex"},
+	}, daemonpkg.QueueMutationOptions{}); err != nil {
+		t.Fatalf("submit wiki: %v", err)
+	}
+	server := httptest.NewServer(daemonpkg.NewReadOnlyRouter(store, daemonpkg.ServerOptions{Now: func() time.Time { return now }}))
+	t.Cleanup(server.Close)
+
+	check := checkDaemonTelemetryURL(server.URL)
+	if check.Name != "Daemon Telemetry" || check.Status != "pass" {
+		t.Fatalf("telemetry check = %#v, want pass", check)
+	}
+	for _, want := range []string{"phase_latency=discovery", "p50=12s", "worker_kind_24h=codex=1", "failure_rate=rpi.phase 0/1"} {
+		if !strings.Contains(check.Detail, want) {
+			t.Fatalf("telemetry detail = %q, want %q", check.Detail, want)
+		}
+	}
+}
+
 func TestDoctorRuntimeChecksWarnWhenUnavailable(t *testing.T) {
 	baseURL := "http://127.0.0.1:1"
 	for _, check := range []doctorCheck{

--- a/cli/cmd/ao/watch.go
+++ b/cli/cmd/ao/watch.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	daemonpkg "github.com/boshu2/agentops/cli/internal/daemon"
+	"github.com/spf13/cobra"
+)
+
+var (
+	watchDaemonURL string
+	watchInterval  time.Duration
+	watchSince     string
+	watchOnce      bool
+)
+
+var watchCmd = &cobra.Command{
+	Use:   "watch",
+	Short: "Watch the agentops daemon event stream",
+	Long: `Poll agentopsd /v1/events and print new ledger events as a TTY-friendly stream.
+
+This intentionally uses plain stdout instead of a TUI library so it works in tmux,
+logs, SSH sessions, and CI artifacts.`,
+	Args: cobra.NoArgs,
+	RunE: runAoWatchCommand,
+}
+
+func init() {
+	watchCmd.GroupID = "core"
+	watchCmd.Flags().StringVar(&watchDaemonURL, "url", "", "Daemon base URL (defaults to activation file)")
+	watchCmd.Flags().StringVar(&watchSince, "since", "", "Only show events after this event id")
+	watchCmd.Flags().DurationVar(&watchInterval, "interval", time.Second, "Polling interval")
+	watchCmd.Flags().BoolVar(&watchOnce, "once", false, "Fetch once and exit")
+	rootCmd.AddCommand(watchCmd)
+}
+
+func runAoWatchCommand(cmd *cobra.Command, args []string) error {
+	cwd, err := resolveProjectDir()
+	if err != nil {
+		return err
+	}
+	baseURL, err := resolveDaemonURL(cwd, watchDaemonURL)
+	if err != nil {
+		return err
+	}
+	interval := watchInterval
+	if interval <= 0 {
+		return fmt.Errorf("watch interval must be positive")
+	}
+	ctx := cobraContext(cmd)
+	since := strings.TrimSpace(watchSince)
+	out := cmd.OutOrStdout()
+	if !watchOnce {
+		fmt.Fprintf(out, "ao watch %s\n", strings.TrimRight(baseURL, "/"))
+		fmt.Fprintln(out, "occurred_at\tevent_id\tevent_type\tjob_id\tjob_type\tactor")
+	}
+	for {
+		events, err := fetchDaemonEventsSince(ctx, baseURL, since)
+		if err != nil {
+			return err
+		}
+		for _, event := range events.Events {
+			fmt.Fprintln(out, formatWatchEvent(event))
+			since = event.EventID
+		}
+		if watchOnce {
+			return nil
+		}
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil
+		case <-timer.C:
+		}
+	}
+}
+
+func fetchDaemonEventsSince(ctx context.Context, baseURL, since string) (daemonpkg.ReadOnlyEventsResponse, error) {
+	eventsURL := strings.TrimRight(baseURL, "/") + "/v1/events"
+	if strings.TrimSpace(since) != "" {
+		parsed, err := url.Parse(eventsURL)
+		if err != nil {
+			return daemonpkg.ReadOnlyEventsResponse{}, err
+		}
+		query := parsed.Query()
+		query.Set("since", since)
+		parsed.RawQuery = query.Encode()
+		eventsURL = parsed.String()
+	}
+	var events daemonpkg.ReadOnlyEventsResponse
+	if err := fetchDaemonJSON(ctx, eventsURL, &events); err != nil {
+		return events, err
+	}
+	return events, nil
+}
+
+func formatWatchEvent(event daemonpkg.LedgerEvent) string {
+	fields := []string{
+		watchValueOrDash(event.OccurredAt),
+		watchValueOrDash(event.EventID),
+		watchValueOrDash(string(event.EventType)),
+		watchValueOrDash(event.JobID),
+		watchValueOrDash(watchEventJobType(event.Payload)),
+		watchValueOrDash(event.Actor),
+	}
+	for i, field := range fields {
+		fields[i] = sanitizeWatchField(field)
+	}
+	return strings.Join(fields, "\t")
+}
+
+func watchEventJobType(payload map[string]any) string {
+	if value, ok := payload["job_type"].(string); ok {
+		return value
+	}
+	raw, ok := payload["job_payload"]
+	if !ok {
+		return ""
+	}
+	if values, ok := raw.(map[string]any); ok {
+		if value, ok := values["job_type"].(string); ok {
+			return value
+		}
+	}
+	return ""
+}
+
+func watchValueOrDash(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return value
+}
+
+func sanitizeWatchField(value string) string {
+	value = strings.ReplaceAll(value, "\t", " ")
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	return value
+}

--- a/cli/cmd/ao/watch_test.go
+++ b/cli/cmd/ao/watch_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	daemonpkg "github.com/boshu2/agentops/cli/internal/daemon"
+	"github.com/spf13/cobra"
+)
+
+func TestAoWatch(t *testing.T) {
+	cwd, server, queue := newDaemonJobsCommandFixture(t)
+	first, err := queue.SubmitJob(daemonpkg.SubmitJobInput{RequestID: "req-rpi", JobID: "job-rpi", JobType: daemonpkg.JobTypeRPIRun}, daemonpkg.QueueMutationOptions{})
+	if err != nil {
+		t.Fatalf("submit first job: %v", err)
+	}
+	if _, err := queue.SubmitJob(daemonpkg.SubmitJobInput{RequestID: "req-dream", JobID: "job-dream", JobType: daemonpkg.JobTypeDreamRun}, daemonpkg.QueueMutationOptions{}); err != nil {
+		t.Fatalf("submit second job: %v", err)
+	}
+
+	out := runWatchCommandForTest(t, cwd, server.URL, first.LastEventID)
+	if strings.Contains(out, "job-rpi") || !strings.Contains(out, "job-dream") {
+		t.Fatalf("watch output = %q, want only events after %s", out, first.LastEventID)
+	}
+	for _, needle := range []string{"job.accepted", "dream.run", "agentopsd"} {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("watch output missing %q:\n%s", needle, out)
+		}
+	}
+}
+
+func runWatchCommandForTest(t *testing.T, cwd, daemonBaseURL, since string) string {
+	t.Helper()
+	prevProjectDir := testProjectDir
+	prevURL := watchDaemonURL
+	prevSince := watchSince
+	prevInterval := watchInterval
+	prevOnce := watchOnce
+	testProjectDir = cwd
+	watchDaemonURL = daemonBaseURL
+	watchSince = since
+	watchInterval = time.Millisecond
+	watchOnce = true
+	t.Cleanup(func() {
+		testProjectDir = prevProjectDir
+		watchDaemonURL = prevURL
+		watchSince = prevSince
+		watchInterval = prevInterval
+		watchOnce = prevOnce
+	})
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	cmd.SetContext(context.Background())
+	if err := runAoWatchCommand(cmd, nil); err != nil {
+		t.Fatalf("runAoWatchCommand: %v", err)
+	}
+	return out.String()
+}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -693,6 +693,26 @@ ao vibe-check [flags]
 
 ---
 
+### `ao watch`
+
+Poll agentopsd /v1/events and print new ledger events as a TTY-friendly stream.
+
+```
+ao watch [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help                help for watch
+      --interval duration   Polling interval (default 1s)
+      --once                Fetch once and exit
+      --since string        Only show events after this event id
+      --url string          Daemon base URL (defaults to activation file)
+```
+
+---
+
 ### `ao autodev`
 
 Define, inspect, and validate the repo-local PROGRAM.md contract.

--- a/cli/internal/daemon/server.go
+++ b/cli/internal/daemon/server.go
@@ -198,11 +198,25 @@ func (s *ReadOnlyServer) handleEvents(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+	events := filterLedgerEventsAfter(state.Replay.Events, r.URL.Query().Get("since"))
 	writeJSON(w, http.StatusOK, ReadOnlyEventsResponse{
-		Events:      state.Replay.Events,
+		Events:      events,
 		Corrupt:     state.Replay.Corrupt,
 		LastEventID: state.Lag.LastEventID,
 	})
+}
+
+func filterLedgerEventsAfter(events []LedgerEvent, after string) []LedgerEvent {
+	after = strings.TrimSpace(after)
+	if after == "" {
+		return events
+	}
+	for i, event := range events {
+		if event.EventID == after {
+			return events[i+1:]
+		}
+	}
+	return nil
 }
 
 func (s *ReadOnlyServer) handleOpenClawHealth(w http.ResponseWriter, r *http.Request) {

--- a/cli/internal/daemon/server_test.go
+++ b/cli/internal/daemon/server_test.go
@@ -50,6 +50,11 @@ func TestReadOnlyHealthReadyStatusEvents(t *testing.T) {
 	if len(events.Events) != 2 || events.LastEventID == "" {
 		t.Fatalf("events = %#v, want two events and last event id", events)
 	}
+	var eventsAfter ReadOnlyEventsResponse
+	getJSON(t, router, "/v1/events?since="+events.Events[0].EventID, &eventsAfter)
+	if len(eventsAfter.Events) != 1 || eventsAfter.Events[0].EventID != events.Events[1].EventID {
+		t.Fatalf("events after = %#v, want only %s", eventsAfter, events.Events[1].EventID)
+	}
 }
 
 func TestReadOnlyServerLoadsProjectionSnapshotOnReadState(t *testing.T) {

--- a/cli/internal/daemon/telemetry.go
+++ b/cli/internal/daemon/telemetry.go
@@ -1,0 +1,278 @@
+package daemon
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+)
+
+const DefaultTelemetryWindow = 24 * time.Hour
+
+type LedgerTelemetry struct {
+	EventCount             int                         `json:"event_count"`
+	Window                 string                      `json:"window"`
+	PhaseLatency           []PhaseLatencyHistogram     `json:"phase_latency,omitempty"`
+	WorkerKindDistribution []WorkerKindDistribution    `json:"worker_kind_distribution,omitempty"`
+	FailureRates           []JobTypeFailureRateSummary `json:"failure_rates,omitempty"`
+}
+
+type PhaseLatencyHistogram struct {
+	PhaseName string `json:"phase_name"`
+	Count     int    `json:"count"`
+	P50Millis int64  `json:"p50_ms"`
+	P99Millis int64  `json:"p99_ms"`
+}
+
+type WorkerKindDistribution struct {
+	WorkerKind string `json:"worker_kind"`
+	Count      int    `json:"count"`
+}
+
+type JobTypeFailureRateSummary struct {
+	JobType       JobType `json:"job_type"`
+	TerminalCount int     `json:"terminal_count"`
+	FailedCount   int     `json:"failed_count"`
+	FailureRate   float64 `json:"failure_rate"`
+}
+
+type telemetryJob struct {
+	jobType    JobType
+	phaseName  string
+	workerKind string
+	acceptedAt time.Time
+	terminalAt time.Time
+	failed     bool
+	cancelled  bool
+	completed  bool
+}
+
+func BuildLedgerTelemetry(events []LedgerEvent, now time.Time, window time.Duration) LedgerTelemetry {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = now.UTC()
+	if window <= 0 {
+		window = DefaultTelemetryWindow
+	}
+	jobs := map[string]*telemetryJob{}
+	workerCounts := map[string]int{}
+	windowStart := now.Add(-window)
+
+	for _, event := range events {
+		occurredAt, hasTime := parseLedgerEventTime(event)
+		job := jobs[event.JobID]
+		if job == nil {
+			job = &telemetryJob{}
+			jobs[event.JobID] = job
+		}
+		applyTelemetryPayload(job, event.Payload)
+		switch event.EventType {
+		case EventJobAccepted:
+			if hasTime {
+				job.acceptedAt = occurredAt
+				if job.workerKind != "" && !occurredAt.Before(windowStart) && !occurredAt.After(now) {
+					workerCounts[job.workerKind]++
+				}
+			}
+		case EventJobCompleted:
+			if hasTime {
+				job.terminalAt = occurredAt
+			}
+			job.completed = true
+		case EventJobFailed:
+			if hasTime {
+				job.terminalAt = occurredAt
+			}
+			job.failed = true
+		case EventJobCancelled:
+			if hasTime {
+				job.terminalAt = occurredAt
+			}
+			job.cancelled = true
+		}
+	}
+
+	return LedgerTelemetry{
+		EventCount:             len(events),
+		Window:                 window.String(),
+		PhaseLatency:           buildPhaseLatencyHistograms(jobs),
+		WorkerKindDistribution: buildWorkerKindDistribution(workerCounts),
+		FailureRates:           buildFailureRates(jobs),
+	}
+}
+
+func FormatLedgerTelemetrySummary(telemetry LedgerTelemetry) string {
+	parts := []string{fmt.Sprintf("events=%d", telemetry.EventCount)}
+	if len(telemetry.PhaseLatency) == 0 {
+		parts = append(parts, "phase_latency=none")
+	} else {
+		values := make([]string, 0, len(telemetry.PhaseLatency))
+		for _, hist := range telemetry.PhaseLatency {
+			values = append(values, fmt.Sprintf("%s n=%d p50=%s p99=%s",
+				hist.PhaseName,
+				hist.Count,
+				time.Duration(hist.P50Millis)*time.Millisecond,
+				time.Duration(hist.P99Millis)*time.Millisecond,
+			))
+		}
+		parts = append(parts, "phase_latency="+strings.Join(values, ", "))
+	}
+	if len(telemetry.WorkerKindDistribution) == 0 {
+		parts = append(parts, "worker_kind_24h=none")
+	} else {
+		values := make([]string, 0, len(telemetry.WorkerKindDistribution))
+		for _, dist := range telemetry.WorkerKindDistribution {
+			values = append(values, fmt.Sprintf("%s=%d", dist.WorkerKind, dist.Count))
+		}
+		parts = append(parts, "worker_kind_24h="+strings.Join(values, ", "))
+	}
+	if len(telemetry.FailureRates) == 0 {
+		parts = append(parts, "failure_rate=none")
+	} else {
+		values := make([]string, 0, len(telemetry.FailureRates))
+		for _, rate := range telemetry.FailureRates {
+			values = append(values, fmt.Sprintf("%s %d/%d %.1f%%",
+				rate.JobType,
+				rate.FailedCount,
+				rate.TerminalCount,
+				rate.FailureRate*100,
+			))
+		}
+		parts = append(parts, "failure_rate="+strings.Join(values, ", "))
+	}
+	return strings.Join(parts, "; ")
+}
+
+func parseLedgerEventTime(event LedgerEvent) (time.Time, bool) {
+	occurredAt, err := time.Parse(time.RFC3339Nano, event.OccurredAt)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return occurredAt.UTC(), true
+}
+
+func applyTelemetryPayload(job *telemetryJob, payload map[string]any) {
+	if jobType, ok, err := jobTypeFromPayload(payload); err == nil && ok {
+		job.jobType = jobType
+	}
+	jobPayload := nestedPayload(payload, "job_payload")
+	if len(jobPayload) == 0 {
+		jobPayload = payload
+	}
+	if jobType, ok, err := jobTypeFromPayload(jobPayload); err == nil && ok {
+		job.jobType = jobType
+	}
+	if phaseName, ok := stringPayload(jobPayload, "phase_name"); ok {
+		job.phaseName = phaseName
+	} else if phase, ok := intPayload(jobPayload, "phase"); ok {
+		job.phaseName = RPIPhaseName(phase)
+	}
+	if workerKind, ok := stringPayload(jobPayload, "worker_kind"); ok {
+		job.workerKind = workerKind
+	} else if workerKind, ok := stringPayload(payload, "worker_kind"); ok {
+		job.workerKind = workerKind
+	}
+}
+
+func buildPhaseLatencyHistograms(jobs map[string]*telemetryJob) []PhaseLatencyHistogram {
+	byPhase := map[string][]time.Duration{}
+	for _, job := range jobs {
+		if job.phaseName == "" || job.acceptedAt.IsZero() || job.terminalAt.IsZero() {
+			continue
+		}
+		latency := job.terminalAt.Sub(job.acceptedAt)
+		if latency < 0 {
+			continue
+		}
+		byPhase[job.phaseName] = append(byPhase[job.phaseName], latency)
+	}
+	phases := make([]string, 0, len(byPhase))
+	for phase := range byPhase {
+		phases = append(phases, phase)
+	}
+	sort.Strings(phases)
+	out := make([]PhaseLatencyHistogram, 0, len(phases))
+	for _, phase := range phases {
+		values := byPhase[phase]
+		sort.Slice(values, func(i, j int) bool { return values[i] < values[j] })
+		out = append(out, PhaseLatencyHistogram{
+			PhaseName: phase,
+			Count:     len(values),
+			P50Millis: percentileDuration(values, 0.50).Milliseconds(),
+			P99Millis: percentileDuration(values, 0.99).Milliseconds(),
+		})
+	}
+	return out
+}
+
+func buildWorkerKindDistribution(counts map[string]int) []WorkerKindDistribution {
+	kinds := make([]string, 0, len(counts))
+	for kind := range counts {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+	out := make([]WorkerKindDistribution, 0, len(kinds))
+	for _, kind := range kinds {
+		out = append(out, WorkerKindDistribution{WorkerKind: kind, Count: counts[kind]})
+	}
+	return out
+}
+
+func buildFailureRates(jobs map[string]*telemetryJob) []JobTypeFailureRateSummary {
+	type counts struct {
+		terminal int
+		failed   int
+	}
+	byType := map[JobType]counts{}
+	for _, job := range jobs {
+		if job.jobType == "" || (!job.completed && !job.failed && !job.cancelled) {
+			continue
+		}
+		count := byType[job.jobType]
+		count.terminal++
+		if job.failed {
+			count.failed++
+		}
+		byType[job.jobType] = count
+	}
+	jobTypes := make([]string, 0, len(byType))
+	for jobType := range byType {
+		jobTypes = append(jobTypes, string(jobType))
+	}
+	sort.Strings(jobTypes)
+	out := make([]JobTypeFailureRateSummary, 0, len(jobTypes))
+	for _, raw := range jobTypes {
+		jobType := JobType(raw)
+		count := byType[jobType]
+		rate := 0.0
+		if count.terminal > 0 {
+			rate = float64(count.failed) / float64(count.terminal)
+		}
+		out = append(out, JobTypeFailureRateSummary{
+			JobType:       jobType,
+			TerminalCount: count.terminal,
+			FailedCount:   count.failed,
+			FailureRate:   rate,
+		})
+	}
+	return out
+}
+
+func percentileDuration(values []time.Duration, pct float64) time.Duration {
+	if len(values) == 0 {
+		return 0
+	}
+	if pct <= 0 {
+		return values[0]
+	}
+	index := int(math.Ceil(pct*float64(len(values)))) - 1
+	if index < 0 {
+		index = 0
+	}
+	if index >= len(values) {
+		index = len(values) - 1
+	}
+	return values[index]
+}

--- a/cli/internal/daemon/telemetry_test.go
+++ b/cli/internal/daemon/telemetry_test.go
@@ -1,0 +1,94 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPhaseLatencyHistogram(t *testing.T) {
+	base := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	events := []LedgerEvent{
+		mustTelemetryEvent(t, "evt-a-accepted", "job-a", EventJobAccepted, base, JobTypeRPIPhase, map[string]any{"job_payload": map[string]any{"phase_name": "discovery"}}),
+		mustTelemetryEvent(t, "evt-a-completed", "job-a", EventJobCompleted, base.Add(10*time.Second), "", nil),
+		mustTelemetryEvent(t, "evt-b-accepted", "job-b", EventJobAccepted, base.Add(time.Minute), JobTypeRPIPhase, map[string]any{"job_payload": map[string]any{"phase_name": "discovery"}}),
+		mustTelemetryEvent(t, "evt-b-completed", "job-b", EventJobCompleted, base.Add(time.Minute+21*time.Second), "", nil),
+		mustTelemetryEvent(t, "evt-c-accepted", "job-c", EventJobAccepted, base.Add(2*time.Minute), JobTypeRPIPhase, map[string]any{"job_payload": map[string]any{"phase_name": "implementation"}}),
+		mustTelemetryEvent(t, "evt-c-completed", "job-c", EventJobCompleted, base.Add(2*time.Minute+3*time.Second), "", nil),
+	}
+
+	telemetry := BuildLedgerTelemetry(events, base.Add(3*time.Minute), DefaultTelemetryWindow)
+	histograms := map[string]PhaseLatencyHistogram{}
+	for _, hist := range telemetry.PhaseLatency {
+		histograms[hist.PhaseName] = hist
+	}
+	discovery := histograms["discovery"]
+	if discovery.Count != 2 || discovery.P50Millis != int64((10*time.Second).Milliseconds()) || discovery.P99Millis != int64((21*time.Second).Milliseconds()) {
+		t.Fatalf("discovery histogram = %#v, want count=2 p50=10s p99=21s", discovery)
+	}
+	implementation := histograms["implementation"]
+	if implementation.Count != 1 || implementation.P50Millis != int64((3*time.Second).Milliseconds()) || implementation.P99Millis != int64((3*time.Second).Milliseconds()) {
+		t.Fatalf("implementation histogram = %#v, want count=1 p50/p99=3s", implementation)
+	}
+}
+
+func TestWorkerKindDistribution(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	events := []LedgerEvent{
+		mustTelemetryEvent(t, "evt-codex-new", "job-codex-new", EventJobAccepted, now.Add(-time.Hour), JobTypeWikiForge, map[string]any{"job_payload": map[string]any{"worker_kind": "codex"}}),
+		mustTelemetryEvent(t, "evt-claude-new", "job-claude-new", EventJobAccepted, now.Add(-2*time.Hour), JobTypeWikiForge, map[string]any{"job_payload": map[string]any{"worker_kind": "claude"}}),
+		mustTelemetryEvent(t, "evt-codex-old", "job-codex-old", EventJobAccepted, now.Add(-48*time.Hour), JobTypeWikiForge, map[string]any{"job_payload": map[string]any{"worker_kind": "codex"}}),
+	}
+
+	telemetry := BuildLedgerTelemetry(events, now, DefaultTelemetryWindow)
+	counts := map[string]int{}
+	for _, dist := range telemetry.WorkerKindDistribution {
+		counts[dist.WorkerKind] = dist.Count
+	}
+	if counts["codex"] != 1 || counts["claude"] != 1 {
+		t.Fatalf("worker counts = %#v, want codex=1 claude=1", counts)
+	}
+}
+
+func TestFailureRateByJobType(t *testing.T) {
+	base := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	events := []LedgerEvent{
+		mustTelemetryEvent(t, "evt-rpi-ok-accepted", "job-rpi-ok", EventJobAccepted, base, JobTypeRPIRun, nil),
+		mustTelemetryEvent(t, "evt-rpi-ok-completed", "job-rpi-ok", EventJobCompleted, base.Add(time.Second), "", nil),
+		mustTelemetryEvent(t, "evt-rpi-fail-accepted", "job-rpi-fail", EventJobAccepted, base, JobTypeRPIRun, nil),
+		mustTelemetryEvent(t, "evt-rpi-fail-failed", "job-rpi-fail", EventJobFailed, base.Add(time.Second), "", nil),
+		mustTelemetryEvent(t, "evt-wiki-cancel-accepted", "job-wiki-cancel", EventJobAccepted, base, JobTypeWikiForge, nil),
+		mustTelemetryEvent(t, "evt-wiki-cancel-cancelled", "job-wiki-cancel", EventJobCancelled, base.Add(time.Second), "", nil),
+	}
+
+	telemetry := BuildLedgerTelemetry(events, base.Add(2*time.Second), DefaultTelemetryWindow)
+	rates := map[JobType]JobTypeFailureRateSummary{}
+	for _, rate := range telemetry.FailureRates {
+		rates[rate.JobType] = rate
+	}
+	rpi := rates[JobTypeRPIRun]
+	if rpi.TerminalCount != 2 || rpi.FailedCount != 1 || rpi.FailureRate != 0.5 {
+		t.Fatalf("rpi failure rate = %#v, want 1/2", rpi)
+	}
+	wiki := rates[JobTypeWikiForge]
+	if wiki.TerminalCount != 1 || wiki.FailedCount != 0 || wiki.FailureRate != 0 {
+		t.Fatalf("wiki failure rate = %#v, want 0/1", wiki)
+	}
+}
+
+func mustTelemetryEvent(t *testing.T, eventID, jobID string, eventType EventType, occurredAt time.Time, jobType JobType, payload map[string]any) LedgerEvent {
+	t.Helper()
+	event, err := NewLedgerEvent(LedgerEventInput{
+		EventID:    eventID,
+		RequestID:  RequestID("req-" + eventID),
+		JobID:      jobID,
+		EventType:  eventType,
+		OccurredAt: occurredAt,
+		Actor:      "test",
+		JobType:    jobType,
+		Payload:    payload,
+	})
+	if err != nil {
+		t.Fatalf("NewLedgerEvent(%s): %v", eventID, err)
+	}
+	return event
+}

--- a/docs/cli-skills-map.md
+++ b/docs/cli-skills-map.md
@@ -2,7 +2,7 @@
 
 > Which `ao` commands are called by which skills and hooks — and vice versa.
 
-Auto-audited 2026-04-24; targeted runtime-proof update 2026-04-28. 58 generated CLI command headings, 69 source skills, 12 runtime hook event sections.
+Auto-audited 2026-04-24; targeted runtime-proof update 2026-04-28. 59 generated CLI command headings, 69 source skills, 12 runtime hook event sections.
 
 Source-of-truth note: `hooks/hooks.json` currently declares the full Claude runtime event surface. `hooks/codex-hooks.json` declares the Codex-native subset that runtime can support.
 
@@ -12,7 +12,7 @@ Registry-first note: `/plan`, `/pre-mortem`, `/research`, `/vibe`, and `/post-mo
 
 | Category | Count |
 |----------|-------|
-| Generated CLI command headings | 58 |
+| Generated CLI command headings | 59 |
 | CLI command entries with skill/hook callers | 34 |
 | Orphan/hidden command entries (user utilities, hidden, CI-only) | 21 |
 | Known phantom subcommands | 0 |


### PR DESCRIPTION
## Summary
- add `ao watch` for plain-stdout polling of agentopsd `/v1/events` with `--since`, `--interval`, `--once`, and `--url`
- add server-side `/v1/events?since=<event_id>` filtering
- add daemon ledger telemetry summaries for phase latency p50/p99, 24h worker-kind distribution, and job-type failure rates in `ao doctor`
- regenerate CLI command docs and Cobra command registration expectations

## Validation
- `go test ./internal/daemon ./cmd/ao -run 'TestAoWatch|TestAoDoctorHistograms|TestPhaseLatencyHistogram|TestWorkerKindDistribution|TestFailureRateByJobType|TestReadOnlyHealthReadyStatusEvents|TestDaemonEventsTailAfter'` from `cli/`
- `go test ./cmd/ao -run 'TestCobraExpectedCmdsMatchRegistration|TestCobraConformance|TestAoWatch|TestAoDoctorHistograms'` from `cli/`
- `go test ./internal/daemon ./cmd/ao` from `cli/`
- `./scripts/generate-cli-reference.sh --check`
- pre-push gate fast path passed on push

Closes soc-5of.4