### PR TITLE
feat: isolate cli fallback workers

### DIFF
--- a/cli/cmd/ao/agentopsd.go
+++ b/cli/cmd/ao/agentopsd.go
@@ -34,6 +34,9 @@ var (
 	daemonGasCityCity       string
 	daemonGasCityToken      string
 	daemonGasCityTokenFile  string
+	daemonWorkerTimeout     time.Duration
+	daemonWorkerMemoryMax   int64
+	daemonWorkerCgroupRoot  string
 )
 
 type agentopsDaemonActivation struct {
@@ -55,6 +58,9 @@ type agentopsDaemonRunOptions struct {
 	GasCityCity       string
 	GasCityToken      string
 	GasCityTokenFile  string
+	WorkerTimeout     time.Duration
+	WorkerMemoryMax   int64
+	WorkerCgroupRoot  string
 	PollInterval      time.Duration
 	HeartbeatInterval time.Duration
 	Now               func() time.Time
@@ -109,7 +115,10 @@ func init() {
 	daemonRunCmd.Flags().StringVar(&daemonTokenFile, "token-file", "", "Path to mutation token file")
 	daemonRunCmd.Flags().IntVar(&daemonWorkers, "workers", 0, "Number of daemon worker loops to run in the foreground")
 	daemonRunCmd.Flags().BoolVar(&daemonWorkerOnce, "worker-once", false, "Exit after each worker makes one claim attempt")
-	daemonRunCmd.Flags().StringVar(&daemonExecutorPolicy, "executor-policy", "fake", "Daemon executor policy for workers (fake, gascity)")
+	daemonRunCmd.Flags().StringVar(&daemonExecutorPolicy, "executor-policy", "fake", "Daemon executor policy for workers (fake, gascity, cli-fallback)")
+	daemonRunCmd.Flags().DurationVar(&daemonWorkerTimeout, "worker-timeout", 0, "Per-job worker wall-clock cap (0 disables)")
+	daemonRunCmd.Flags().Int64Var(&daemonWorkerMemoryMax, "worker-memory-max-bytes", 0, "Linux cgroup v2 memory.max cap for CLI fallback workers in bytes (0 disables)")
+	daemonRunCmd.Flags().StringVar(&daemonWorkerCgroupRoot, "worker-cgroup-root", "", "Linux cgroup v2 root for worker caps (default /sys/fs/cgroup)")
 	daemonRunCmd.Flags().StringVar(&daemonGasCityEndpoint, "gascity-endpoint", "", "GasCity API endpoint for gascity executor policy")
 	daemonRunCmd.Flags().StringVar(&daemonGasCityCity, "gascity-city", "", "GasCity city name for gascity executor policy")
 	daemonRunCmd.Flags().StringVar(&daemonGasCityToken, "gascity-token", "", "GasCity mutation token for gascity executor policy")
@@ -136,6 +145,9 @@ func runAgentOpsDaemonCommand(cmd *cobra.Command, args []string) error {
 		GasCityCity:      daemonGasCityCity,
 		GasCityToken:     daemonGasCityToken,
 		GasCityTokenFile: daemonGasCityTokenFile,
+		WorkerTimeout:    daemonWorkerTimeout,
+		WorkerMemoryMax:  daemonWorkerMemoryMax,
+		WorkerCgroupRoot: daemonWorkerCgroupRoot,
 	}, cmd.OutOrStdout())
 }
 
@@ -315,6 +327,12 @@ func buildAgentOpsDaemonSupervisor(cwd string, opts agentopsDaemonRunOptions) (*
 			return nil, err
 		}
 		executors = []daemonpkg.JobExecutor{wikiExecutor, dreamExecutor}
+	case "cli-fallback":
+		wikiExecutor, err := buildAgentOpsDaemonCLIFallbackWikiExecutor(cwd, opts)
+		if err != nil {
+			return nil, err
+		}
+		executors = []daemonpkg.JobExecutor{wikiExecutor}
 	default:
 		return nil, fmt.Errorf("unsupported daemon executor policy %q", policy)
 	}
@@ -328,6 +346,7 @@ func buildAgentOpsDaemonSupervisor(cwd string, opts agentopsDaemonRunOptions) (*
 		Actor:             "agentopsd-worker",
 		PollInterval:      opts.PollInterval,
 		HeartbeatInterval: opts.HeartbeatInterval,
+		ExecutionTimeout:  opts.WorkerTimeout,
 	})
 }
 
@@ -392,6 +411,40 @@ func buildAgentOpsDaemonGasCityWikiExecutor(cwd string, opts agentopsDaemonRunOp
 		Store:  daemonpkg.NewStore(cwd),
 		Worker: worker,
 	})
+}
+
+func buildAgentOpsDaemonCLIFallbackWikiExecutor(cwd string, opts agentopsDaemonRunOptions) (daemonpkg.JobExecutor, error) {
+	agent, err := agentworker.NewCLIFallbackWorker(agentworker.CLIFallbackWorkerOptions{
+		WallClockTimeout: opts.WorkerTimeout,
+		MemoryMaxBytes:   opts.WorkerMemoryMax,
+		CgroupRoot:       opts.WorkerCgroupRoot,
+	})
+	if err != nil {
+		return nil, err
+	}
+	worker, err := wikiworker.NewWorker(agent)
+	if err != nil {
+		return nil, err
+	}
+	return daemonpkg.NewWikiForgeExecutor(daemonpkg.WikiForgeExecutorOptions{
+		Store: daemonpkg.NewStore(cwd),
+		Worker: providerOverrideWikiForgeWorker{
+			inner:    worker,
+			provider: agentworker.ProviderCLIFallback,
+		},
+	})
+}
+
+type providerOverrideWikiForgeWorker struct {
+	inner    daemonpkg.WikiForgeWorker
+	provider agentworker.Provider
+}
+
+func (w providerOverrideWikiForgeWorker) RunExtractionWithRetry(ctx context.Context, req wikiworker.ExtractionRequest, opts wikiworker.RetryOptions) (wikiworker.ExtractionResult, error) {
+	if w.provider != "" {
+		req.Provider = w.provider
+	}
+	return w.inner.RunExtractionWithRetry(ctx, req, opts)
 }
 
 func runAgentOpsDaemonWorkersOnce(ctx context.Context, supervisor *daemonpkg.Supervisor, workers int) error {

--- a/cli/cmd/ao/agentopsd_test.go
+++ b/cli/cmd/ao/agentopsd_test.go
@@ -11,7 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/boshu2/agentops/cli/internal/agentworker"
 	daemonpkg "github.com/boshu2/agentops/cli/internal/daemon"
+	"github.com/boshu2/agentops/cli/internal/wikiworker"
 	"github.com/spf13/cobra"
 )
 
@@ -284,10 +286,44 @@ func TestResolveAgentOpsDaemonMutationPolicySupportsScopedTokenFile(t *testing.T
 	}
 }
 
+func TestAgentOpsDaemonCLIFallbackExecutorPolicyBuilds(t *testing.T) {
+	if _, err := buildAgentOpsDaemonSupervisor(t.TempDir(), agentopsDaemonRunOptions{ExecutorPolicy: "cli-fallback"}); err != nil {
+		t.Fatalf("cli-fallback executor policy: %v", err)
+	}
+}
+
+func TestProviderOverrideWikiForgeWorkerForcesCLIFallback(t *testing.T) {
+	inner := &recordingWikiForgeWorker{}
+	worker := providerOverrideWikiForgeWorker{
+		inner:    inner,
+		provider: agentworker.ProviderCLIFallback,
+	}
+	if _, err := worker.RunExtractionWithRetry(context.Background(), wikiworker.ExtractionRequest{
+		Provider: agentworker.ProviderGasCity,
+		Prompt:   "prompt",
+	}, wikiworker.RetryOptions{}); err != nil {
+		t.Fatalf("RunExtractionWithRetry: %v", err)
+	}
+	if inner.req.Provider != agentworker.ProviderCLIFallback {
+		t.Fatalf("provider = %q, want cli-fallback", inner.req.Provider)
+	}
+}
+
 func TestAgentOpsDaemonWorkerFlagsRegistered(t *testing.T) {
-	for _, flag := range []string{"workers", "worker-once", "executor-policy", "gascity-endpoint", "gascity-city", "gascity-token", "gascity-token-file"} {
+	for _, flag := range []string{"workers", "worker-once", "worker-timeout", "worker-memory-max-bytes", "worker-cgroup-root", "executor-policy", "gascity-endpoint", "gascity-city", "gascity-token", "gascity-token-file"} {
 		if daemonRunCmd.Flags().Lookup(flag) == nil {
 			t.Fatalf("daemon run missing --%s flag", flag)
 		}
 	}
+}
+
+type recordingWikiForgeWorker struct {
+	req wikiworker.ExtractionRequest
+}
+
+func (w *recordingWikiForgeWorker) RunExtractionWithRetry(_ context.Context, req wikiworker.ExtractionRequest, _ wikiworker.RetryOptions) (wikiworker.ExtractionResult, error) {
+	w.req = req
+	return wikiworker.ExtractionResult{
+		Terminal: agentworker.TerminalState{Status: agentworker.StatusCompleted},
+	}, nil
 }

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -971,17 +971,20 @@ ao daemon run [flags]
 **Flags:**
 
 ```
-      --addr string                 Loopback address for foreground daemon (default "127.0.0.1:8765")
-      --executor-policy string      Daemon executor policy for workers (fake, gascity) (default "fake")
-      --gascity-city string         GasCity city name for gascity executor policy
-      --gascity-endpoint string     GasCity API endpoint for gascity executor policy
-      --gascity-token string        GasCity mutation token for gascity executor policy
-      --gascity-token-file string   Path to GasCity mutation token file
-  -h, --help                        help for run
-      --token string                Mutation token for daemon write routes
-      --token-file string           Path to mutation token file
-      --worker-once                 Exit after each worker makes one claim attempt
-      --workers int                 Number of daemon worker loops to run in the foreground
+      --addr string                   Loopback address for foreground daemon (default "127.0.0.1:8765")
+      --executor-policy string        Daemon executor policy for workers (fake, gascity, cli-fallback) (default "fake")
+      --gascity-city string           GasCity city name for gascity executor policy
+      --gascity-endpoint string       GasCity API endpoint for gascity executor policy
+      --gascity-token string          GasCity mutation token for gascity executor policy
+      --gascity-token-file string     Path to GasCity mutation token file
+  -h, --help                          help for run
+      --token string                  Mutation token for daemon write routes
+      --token-file string             Path to mutation token file
+      --worker-cgroup-root string     Linux cgroup v2 root for worker caps (default /sys/fs/cgroup)
+      --worker-memory-max-bytes int   Linux cgroup v2 memory.max cap for CLI fallback workers in bytes (0 disables)
+      --worker-once                   Exit after each worker makes one claim attempt
+      --worker-timeout duration       Per-job worker wall-clock cap (0 disables)
+      --workers int                   Number of daemon worker loops to run in the foreground
 ```
 
 #### `ao daemon service`

--- a/cli/internal/agentworker/cgroup.go
+++ b/cli/internal/agentworker/cgroup.go
@@ -1,0 +1,13 @@
+package agentworker
+
+type CgroupLimits struct {
+	Root           string
+	Name           string
+	MemoryMaxBytes int64
+}
+
+type CgroupStatus struct {
+	Applied bool   `json:"applied"`
+	Path    string `json:"path,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+}

--- a/cli/internal/agentworker/cgroup_linux.go
+++ b/cli/internal/agentworker/cgroup_linux.go
@@ -1,0 +1,58 @@
+//go:build linux
+
+package agentworker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const defaultCgroupV2Root = "/sys/fs/cgroup"
+
+func applyCgroupV2Limits(pid int, limits CgroupLimits) CgroupStatus {
+	if pid <= 0 {
+		return CgroupStatus{Reason: "worker pid unavailable"}
+	}
+	if limits.MemoryMaxBytes <= 0 {
+		return CgroupStatus{Reason: "memory cap disabled"}
+	}
+	root := strings.TrimSpace(limits.Root)
+	if root == "" {
+		root = defaultCgroupV2Root
+		if _, err := os.Stat(filepath.Join(root, "cgroup.controllers")); err != nil {
+			return CgroupStatus{Reason: "cgroup v2 unavailable: " + err.Error()}
+		}
+	}
+	name := sanitizeCgroupName(limits.Name)
+	if name == "" {
+		name = fmt.Sprintf("agentops-worker-%d", pid)
+	}
+	path := filepath.Join(root, "agentops", name)
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return CgroupStatus{Path: path, Reason: "create cgroup: " + err.Error()}
+	}
+	if err := os.WriteFile(filepath.Join(path, "memory.max"), []byte(strconv.FormatInt(limits.MemoryMaxBytes, 10)), 0644); err != nil {
+		return CgroupStatus{Path: path, Reason: "set memory.max: " + err.Error()}
+	}
+	if err := os.WriteFile(filepath.Join(path, "cgroup.procs"), []byte(strconv.Itoa(pid)), 0644); err != nil {
+		return CgroupStatus{Path: path, Reason: "attach worker: " + err.Error()}
+	}
+	return CgroupStatus{Applied: true, Path: path}
+}
+
+func sanitizeCgroupName(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}

--- a/cli/internal/agentworker/cgroup_other.go
+++ b/cli/internal/agentworker/cgroup_other.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+package agentworker
+
+import (
+	"runtime"
+	"strings"
+)
+
+func applyCgroupV2Limits(_ int, _ CgroupLimits) CgroupStatus {
+	return CgroupStatus{Reason: "cgroup v2 caps unsupported on " + runtime.GOOS}
+}
+
+func sanitizeCgroupName(value string) string {
+	return strings.TrimSpace(value)
+}

--- a/cli/internal/agentworker/cli_fallback.go
+++ b/cli/internal/agentworker/cli_fallback.go
@@ -1,0 +1,237 @@
+package agentworker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const defaultCLIFallbackWaitDelay = 2 * time.Second
+
+type CLIFallbackWorkerOptions struct {
+	Command           string
+	Args              []string
+	Env               []string
+	WallClockTimeout  time.Duration
+	MemoryMaxBytes    int64
+	CgroupRoot        string
+	CgroupNamePrefix  string
+	DisableCgroupCaps bool
+	Now               func() time.Time
+}
+
+type CLIFallbackWorker struct {
+	command           string
+	args              []string
+	env               []string
+	wallClockTimeout  time.Duration
+	memoryMaxBytes    int64
+	cgroupRoot        string
+	cgroupNamePrefix  string
+	disableCgroupCaps bool
+	now               func() time.Time
+	mu                sync.Mutex
+	sessions          map[string]*CLIFallbackSession
+}
+
+type CLIFallbackSession struct {
+	ref          SessionRef
+	events       []Event
+	transcript   Transcript
+	terminal     TerminalState
+	cgroupStatus CgroupStatus
+}
+
+func NewCLIFallbackWorker(opts CLIFallbackWorkerOptions) (*CLIFallbackWorker, error) {
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	prefix := strings.TrimSpace(opts.CgroupNamePrefix)
+	if prefix == "" {
+		prefix = "agentops-worker"
+	}
+	return &CLIFallbackWorker{
+		command:           strings.TrimSpace(opts.Command),
+		args:              append([]string{}, opts.Args...),
+		env:               append([]string{}, opts.Env...),
+		wallClockTimeout:  opts.WallClockTimeout,
+		memoryMaxBytes:    opts.MemoryMaxBytes,
+		cgroupRoot:        opts.CgroupRoot,
+		cgroupNamePrefix:  prefix,
+		disableCgroupCaps: opts.DisableCgroupCaps,
+		now:               now,
+		sessions:          map[string]*CLIFallbackSession{},
+	}, nil
+}
+
+func (w *CLIFallbackWorker) Start(ctx context.Context, req StartRequest) (AgentSession, error) {
+	if req.Provider == "" {
+		req.Provider = ProviderCLIFallback
+	}
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	if req.Provider != ProviderCLIFallback {
+		return nil, fmt.Errorf("cli fallback worker requires provider %q", ProviderCLIFallback)
+	}
+	command, args := w.commandFor(req)
+	if strings.TrimSpace(command) == "" {
+		return nil, fmt.Errorf("cli fallback command is required")
+	}
+	runCtx := ctx
+	cancel := func() {}
+	if runCtx == nil {
+		runCtx = context.Background()
+	}
+	if w.wallClockTimeout > 0 {
+		runCtx, cancel = context.WithTimeout(runCtx, w.wallClockTimeout)
+	}
+	defer cancel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(runCtx, command, args...)
+	cmd.Dir = strings.TrimSpace(req.CWD)
+	cmd.Env = append(os.Environ(), w.env...)
+	cmd.Stdin = strings.NewReader(req.Prompt)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.WaitDelay = defaultCLIFallbackWaitDelay
+	configureIsolatedProcess(cmd)
+	cmd.Cancel = func() error {
+		return killIsolatedProcess(cmd)
+	}
+
+	startedAt := w.now().UTC()
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start cli fallback worker: %w", err)
+	}
+	sessionID := fmt.Sprintf("cli-%d", cmd.Process.Pid)
+	ref := SessionRef{
+		WorkerKind: req.WorkerKind,
+		Provider:   ProviderCLIFallback,
+		JobID:      req.JobID,
+		AttemptID:  req.AttemptID,
+		RequestID:  req.RequestID,
+		SessionID:  sessionID,
+		Status:     StatusRunning,
+	}
+	cgroupStatus := CgroupStatus{Reason: "cgroup caps disabled"}
+	if !w.disableCgroupCaps {
+		cgroupStatus = applyCgroupV2Limits(cmd.Process.Pid, CgroupLimits{
+			Root:           w.cgroupRoot,
+			Name:           w.cgroupName(req, cmd.Process.Pid),
+			MemoryMaxBytes: w.memoryMaxBytes,
+		})
+	}
+	waitErr := cmd.Wait()
+	completedAt := w.now().UTC()
+	terminal := classifyCLIFallbackTerminal(runCtx, waitErr)
+	ref.Status = terminal.Status
+	transcript := Transcript{
+		Text: stdout.String(),
+		Messages: []TranscriptMessage{
+			{Role: "user", Content: req.Prompt, At: startedAt},
+			{Role: "assistant", Content: stdout.String(), At: completedAt},
+		},
+	}
+	if stderr.Len() > 0 {
+		transcript.Messages = append(transcript.Messages, TranscriptMessage{Role: "stderr", Content: stderr.String(), At: completedAt})
+	}
+	events := []Event{
+		{Cursor: "1", At: startedAt, Type: EventStarted, Message: filepath.Base(command), State: TerminalState{Status: StatusRunning}},
+		{Cursor: "2", At: completedAt, Type: EventTerminal, Message: terminal.Reason, State: terminal},
+	}
+	session := &CLIFallbackSession{
+		ref:          ref,
+		events:       events,
+		transcript:   transcript,
+		terminal:     terminal,
+		cgroupStatus: cgroupStatus,
+	}
+	w.mu.Lock()
+	w.sessions[sessionID] = session
+	w.mu.Unlock()
+	return session, nil
+}
+
+func (w *CLIFallbackWorker) Attach(_ context.Context, ref SessionRef) (AgentSession, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	session, ok := w.sessions[ref.SessionID]
+	if !ok {
+		return nil, fmt.Errorf("cli fallback session not found: %s", ref.SessionID)
+	}
+	return session, nil
+}
+
+func (w *CLIFallbackWorker) commandFor(req StartRequest) (string, []string) {
+	if w.command != "" {
+		return w.command, append([]string{}, w.args...)
+	}
+	return string(req.WorkerKind), nil
+}
+
+func (w *CLIFallbackWorker) cgroupName(req StartRequest, pid int) string {
+	seed := firstNonEmpty(req.JobID, req.RequestID, fmt.Sprintf("%d", pid))
+	return w.cgroupNamePrefix + "-" + sanitizeCgroupName(seed)
+}
+
+func classifyCLIFallbackTerminal(ctx context.Context, err error) TerminalState {
+	if err == nil {
+		return TerminalState{Status: StatusCompleted}
+	}
+	if ctx != nil && ctx.Err() == context.DeadlineExceeded {
+		return TerminalState{Status: StatusFailed, FailureCode: string(StatusFailed), Reason: "worker exceeded wall-clock limit"}
+	}
+	if ctx != nil && ctx.Err() == context.Canceled {
+		return TerminalState{Status: StatusCancelled, FailureCode: string(StatusCancelled), Reason: "worker context cancelled"}
+	}
+	return TerminalState{Status: StatusFailed, FailureCode: string(StatusFailed), Reason: err.Error()}
+}
+
+func (s *CLIFallbackSession) Ref() SessionRef {
+	return s.ref
+}
+
+func (s *CLIFallbackSession) Nudge(_ context.Context, _ NudgeRequest) error {
+	return fmt.Errorf("cli fallback sessions are one-shot and cannot be nudged")
+}
+
+func (s *CLIFallbackSession) Cancel(_ context.Context, req CancelRequest) error {
+	s.terminal = TerminalState{Status: StatusCancelled, FailureCode: string(StatusCancelled), Reason: req.Reason}
+	s.ref.Status = StatusCancelled
+	return nil
+}
+
+func (s *CLIFallbackSession) Stream(_ context.Context, _ StreamOptions) (<-chan Event, error) {
+	ch := make(chan Event, len(s.events))
+	for _, event := range s.events {
+		ch <- event
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (s *CLIFallbackSession) Transcript(_ context.Context) (Transcript, error) {
+	return s.transcript, nil
+}
+
+func (s *CLIFallbackSession) Artifacts(_ context.Context) ([]Artifact, error) {
+	return nil, nil
+}
+
+func (s *CLIFallbackSession) TerminalState(_ context.Context) (TerminalState, error) {
+	return s.terminal, nil
+}
+
+func (s *CLIFallbackSession) CgroupStatus() CgroupStatus {
+	return s.cgroupStatus
+}

--- a/cli/internal/agentworker/cli_fallback_test.go
+++ b/cli/internal/agentworker/cli_fallback_test.go
@@ -1,0 +1,162 @@
+//go:build !windows
+
+package agentworker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestWorkerProcessGroupIsolation_StartsInOwnProcessGroup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process groups are POSIX-only")
+	}
+	worker := newShellFallbackWorker(t, `printf "%s %s" "$$" "$(ps -o pgid= -p $$)"`)
+	session, err := worker.Start(context.Background(), StartRequest{
+		WorkerKind: WorkerKindCodex,
+		Provider:   ProviderCLIFallback,
+		Prompt:     "process group proof",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	transcript, err := session.Transcript(context.Background())
+	if err != nil {
+		t.Fatalf("Transcript: %v", err)
+	}
+	fields := strings.Fields(transcript.Text)
+	if len(fields) != 2 {
+		t.Fatalf("transcript = %q, want pid and pgid", transcript.Text)
+	}
+	childPID, err := strconv.Atoi(fields[0])
+	if err != nil {
+		t.Fatalf("child pid %q: %v", fields[0], err)
+	}
+	childPGID, err := strconv.Atoi(fields[1])
+	if err != nil {
+		t.Fatalf("child pgid %q: %v", fields[1], err)
+	}
+	if childPGID != childPID {
+		t.Fatalf("child pgid = %d, want its pid %d", childPGID, childPID)
+	}
+	if childPGID == syscall.Getpgrp() {
+		t.Fatalf("child pgid = parent pgid %d, want isolated process group", childPGID)
+	}
+}
+
+func TestWorkerProcessGroupIsolation_KillsHungProcessGroup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process group kill is POSIX-only")
+	}
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+	script := `sleep 10 & echo $! > "$PIDFILE"; wait`
+	worker, err := NewCLIFallbackWorker(CLIFallbackWorkerOptions{
+		Command:          "/bin/sh",
+		Args:             []string{"-c", script},
+		Env:              []string{"PIDFILE=" + pidFile},
+		WallClockTimeout: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewCLIFallbackWorker: %v", err)
+	}
+	started := time.Now()
+	session, err := worker.Start(context.Background(), StartRequest{
+		WorkerKind: WorkerKindCodex,
+		Provider:   ProviderCLIFallback,
+		Prompt:     "timeout proof",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if time.Since(started) > time.Second {
+		t.Fatalf("worker timeout took too long")
+	}
+	terminal, err := session.TerminalState(context.Background())
+	if err != nil {
+		t.Fatalf("TerminalState: %v", err)
+	}
+	if terminal.Status != StatusFailed || !strings.Contains(terminal.Reason, "wall-clock") {
+		t.Fatalf("terminal = %#v, want wall-clock failure", terminal)
+	}
+	data, err := os.ReadFile(pidFile)
+	if err != nil {
+		t.Fatalf("read child pid: %v", err)
+	}
+	childPID, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatalf("parse child pid: %v", err)
+	}
+	if processAliveEventually(childPID) {
+		t.Fatalf("child process %d survived process-group cancellation", childPID)
+	}
+}
+
+func TestCLIFallbackWorkerAppliesCgroupV2MemoryLimit(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("cgroup v2 caps are Linux-only")
+	}
+	root := t.TempDir()
+	worker, err := NewCLIFallbackWorker(CLIFallbackWorkerOptions{
+		Command:          "/bin/sh",
+		Args:             []string{"-c", "cat >/dev/null"},
+		CgroupRoot:       root,
+		MemoryMaxBytes:   123456,
+		CgroupNamePrefix: "agentops-test",
+	})
+	if err != nil {
+		t.Fatalf("NewCLIFallbackWorker: %v", err)
+	}
+	session, err := worker.Start(context.Background(), StartRequest{
+		WorkerKind: WorkerKindCodex,
+		Provider:   ProviderCLIFallback,
+		JobID:      "job-cgroup",
+		Prompt:     "cgroup proof",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	status := session.(*CLIFallbackSession).CgroupStatus()
+	if !status.Applied || status.Path == "" {
+		t.Fatalf("cgroup status = %#v, want applied", status)
+	}
+	data, err := os.ReadFile(filepath.Join(status.Path, "memory.max"))
+	if err != nil {
+		t.Fatalf("read memory.max: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "123456" {
+		t.Fatalf("memory.max = %q, want 123456", strings.TrimSpace(string(data)))
+	}
+}
+
+func newShellFallbackWorker(t *testing.T, script string) *CLIFallbackWorker {
+	t.Helper()
+	worker, err := NewCLIFallbackWorker(CLIFallbackWorkerOptions{
+		Command:           "/bin/sh",
+		Args:              []string{"-c", script},
+		DisableCgroupCaps: true,
+		WallClockTimeout:  time.Second,
+		CgroupNamePrefix:  "agentops-test",
+	})
+	if err != nil {
+		t.Fatalf("NewCLIFallbackWorker: %v", err)
+	}
+	return worker
+}
+
+func processAliveEventually(pid int) bool {
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if syscall.Kill(pid, 0) != nil {
+			return false
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return true
+}

--- a/cli/internal/agentworker/process_unix.go
+++ b/cli/internal/agentworker/process_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package agentworker
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureIsolatedProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func killIsolatedProcess(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}

--- a/cli/internal/agentworker/process_windows.go
+++ b/cli/internal/agentworker/process_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package agentworker
+
+import "os/exec"
+
+func configureIsolatedProcess(_ *exec.Cmd) {}
+
+func killIsolatedProcess(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}

--- a/cli/internal/agentworker/types.go
+++ b/cli/internal/agentworker/types.go
@@ -12,11 +12,17 @@ import (
 // WorkerKind identifies the agent runtime the session executes.
 type WorkerKind string
 
+const (
+	WorkerKindCodex  WorkerKind = "codex"
+	WorkerKindClaude WorkerKind = "claude"
+)
+
 // Provider identifies the transport/provider that owns the session.
 type Provider string
 
 const (
-	ProviderGasCity Provider = "gascity"
+	ProviderGasCity     Provider = "gascity"
+	ProviderCLIFallback Provider = "cli-fallback"
 )
 
 // SessionStatus is the AgentOps status vocabulary for worker sessions.

--- a/cli/internal/daemon/supervisor.go
+++ b/cli/internal/daemon/supervisor.go
@@ -27,6 +27,7 @@ type SupervisorOptions struct {
 	Actor             string
 	PollInterval      time.Duration
 	HeartbeatInterval time.Duration
+	ExecutionTimeout  time.Duration
 }
 
 // SupervisorRunOnceResult reports one supervisor claim attempt.
@@ -42,6 +43,7 @@ type Supervisor struct {
 	actor             string
 	pollInterval      time.Duration
 	heartbeatInterval time.Duration
+	executionTimeout  time.Duration
 	claimMu           sync.Mutex
 }
 
@@ -83,6 +85,7 @@ func NewSupervisor(opts SupervisorOptions) (*Supervisor, error) {
 		actor:             actor,
 		pollInterval:      pollInterval,
 		heartbeatInterval: heartbeatInterval,
+		executionTimeout:  opts.ExecutionTimeout,
 	}, nil
 }
 
@@ -179,13 +182,19 @@ func (s *Supervisor) runExecutorWithHeartbeat(ctx context.Context, executor JobE
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	execCtx := ctx
+	cancel := func() {}
+	if s.executionTimeout > 0 {
+		execCtx, cancel = context.WithTimeout(ctx, s.executionTimeout)
+	}
+	defer cancel()
 	type execution struct {
 		result JobExecutionResult
 		err    error
 	}
 	done := make(chan execution, 1)
 	go func() {
-		result, err := executor.RunJob(ctx, claim)
+		result, err := executor.RunJob(execCtx, claim)
 		done <- execution{result: result, err: err}
 	}()
 
@@ -194,6 +203,9 @@ func (s *Supervisor) runExecutorWithHeartbeat(ctx context.Context, executor JobE
 	for {
 		select {
 		case exec := <-done:
+			if s.executionTimeout > 0 && errors.Is(execCtx.Err(), context.DeadlineExceeded) {
+				return exec.result, fmt.Errorf("executor timed out after %s", s.executionTimeout)
+			}
 			return exec.result, exec.err
 		case <-ticker.C:
 			if _, err := s.queue.Heartbeat(HeartbeatInput{
@@ -207,6 +219,11 @@ func (s *Supervisor) runExecutorWithHeartbeat(ctx context.Context, executor JobE
 			}
 		case <-ctx.Done():
 			return JobExecutionResult{}, ctx.Err()
+		case <-execCtx.Done():
+			if s.executionTimeout > 0 && errors.Is(execCtx.Err(), context.DeadlineExceeded) {
+				return JobExecutionResult{}, fmt.Errorf("executor timed out after %s", s.executionTimeout)
+			}
+			return JobExecutionResult{}, execCtx.Err()
 		}
 	}
 }

--- a/cli/internal/daemon/supervisor_test.go
+++ b/cli/internal/daemon/supervisor_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -147,6 +148,58 @@ func TestSupervisor_RunLoopCancelDoesNotFailRunningJob(t *testing.T) {
 	}
 }
 
+func TestSupervisor_KillsHungWorker(t *testing.T) {
+	now := projectionTestTime(t, 0)
+	queue := newTestQueue(t, &now, QueueOptions{LeaseDuration: time.Minute})
+	if _, err := queue.SubmitJob(SubmitJobInput{RequestID: "req-submit", JobID: "job-openclaw", JobType: JobTypeOpenClawSnapshot}, QueueMutationOptions{}); err != nil {
+		t.Fatalf("submit job: %v", err)
+	}
+	executor := &blockingOpenClawExecutor{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	supervisor := newTestSupervisor(t, queue, executor)
+	supervisor.executionTimeout = 20 * time.Millisecond
+
+	result, err := supervisor.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("run once: %v", err)
+	}
+	if result.Job.Status != JobStatusFailed {
+		t.Fatalf("job status = %q, want failed", result.Job.Status)
+	}
+	if result.Job.Failure == nil || !strings.Contains(result.Job.Failure.Message, "executor timed out") {
+		t.Fatalf("failure = %#v, want timeout failure", result.Job.Failure)
+	}
+}
+
+func TestSupervisor_OOMWorkerDoesNotKillDaemon(t *testing.T) {
+	now := projectionTestTime(t, 0)
+	queue := newTestQueue(t, &now, QueueOptions{LeaseDuration: time.Minute})
+	if _, err := queue.SubmitJob(SubmitJobInput{RequestID: "req-oom", JobID: "job-oom", JobType: JobTypeOpenClawSnapshot}, QueueMutationOptions{}); err != nil {
+		t.Fatalf("submit oom job: %v", err)
+	}
+	executor := &oneShotOOMExecutor{}
+	supervisor := newTestSupervisor(t, queue, executor)
+	first, err := supervisor.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("first run once: %v", err)
+	}
+	if first.Job.Status != JobStatusFailed {
+		t.Fatalf("first status = %q, want failed", first.Job.Status)
+	}
+	if _, err := queue.SubmitJob(SubmitJobInput{RequestID: "req-after", JobID: "job-after", JobType: JobTypeOpenClawSnapshot}, QueueMutationOptions{}); err != nil {
+		t.Fatalf("submit second job: %v", err)
+	}
+	second, err := supervisor.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("second run once: %v", err)
+	}
+	if second.Job.Status != JobStatusCompleted {
+		t.Fatalf("second status = %q, want completed after worker OOM failure", second.Job.Status)
+	}
+}
+
 func newTestSupervisor(t *testing.T, queue *Queue, executor JobExecutor) *Supervisor {
 	t.Helper()
 	supervisor, err := NewSupervisor(SupervisorOptions{
@@ -183,6 +236,22 @@ func (e testOpenClawSnapshotExecutor) RunJob(_ context.Context, claim QueueClaim
 		artifacts[key] = value
 	}
 	return JobExecutionResult{Artifacts: artifacts}, e.Err
+}
+
+type oneShotOOMExecutor struct {
+	calls int
+}
+
+func (e *oneShotOOMExecutor) JobTypes() []JobType {
+	return []JobType{JobTypeOpenClawSnapshot}
+}
+
+func (e *oneShotOOMExecutor) RunJob(_ context.Context, _ QueueClaim) (JobExecutionResult, error) {
+	e.calls++
+	if e.calls == 1 {
+		return JobExecutionResult{}, errors.New("worker killed by cgroup memory.max")
+	}
+	return JobExecutionResult{Artifacts: map[string]string{"executor_policy": "recovered"}}, nil
 }
 
 type blockingOpenClawExecutor struct {


### PR DESCRIPTION
## Summary
- add a CLI fallback AgentWorker that runs worker CLIs outside the daemon address space
- isolate POSIX workers with setpgid and cancel by process group; use direct process kill on Windows
- add Linux cgroup v2 memory.max caps with non-Linux / unavailable-cgroup degradation
- add daemon worker timeout and cgroup flags, plus cli-fallback executor policy wiring

## Validation
- go test ./internal/agentworker ./internal/daemon ./cmd/ao -run 'TestWorkerProcessGroupIsolation|TestCLIFallbackWorkerAppliesCgroupV2MemoryLimit|TestSupervisor_KillsHungWorker|TestSupervisor_OOMWorkerDoesNotKillDaemon|TestAgentOpsDaemonCLIFallbackExecutorPolicyBuilds|TestProviderOverrideWikiForgeWorkerForcesCLIFallback|TestAgentOpsDaemonWorkerFlagsRegistered|TestCobraConformance|TestCobraExpectedCmdsMatchRegistration'
- go test -race ./internal/agentworker -run 'TestWorkerProcessGroupIsolation|TestCLIFallbackWorkerAppliesCgroupV2MemoryLimit'
- go test ./internal/agentworker ./internal/daemon ./cmd/ao
- ./scripts/generate-cli-reference.sh --check
- git diff --check
- git push pre-push fast gate passed

Bead: soc-5of.1