### PR TITLE
feat: content address wiki phase artifacts

### DIFF
--- a/cli/internal/daemon/artifacts.go
+++ b/cli/internal/daemon/artifacts.go
@@ -1,0 +1,208 @@
+package daemon
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const artifactStoreRel = ".agents/handoffs/sha256"
+
+// ArtifactRef is the ledger-resident identity for an artifact stored by
+// content hash. Path is repository-relative so replay can reconstruct the
+// compatibility artifact map without consulting local runtime state.
+type ArtifactRef struct {
+	Path      string `json:"path"`
+	SHA256    string `json:"sha256"`
+	Size      int64  `json:"size"`
+	WrittenAt string `json:"written_at"`
+}
+
+type ArtifactStoreOptions struct {
+	Now func() time.Time
+}
+
+type ContentAddressedArtifactStore struct {
+	root string
+	now  func() time.Time
+}
+
+func NewContentAddressedArtifactStore(root string, opts ArtifactStoreOptions) *ContentAddressedArtifactStore {
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &ContentAddressedArtifactStore{root: root, now: now}
+}
+
+func (r ArtifactRef) Validate() error {
+	if strings.TrimSpace(r.Path) == "" {
+		return fmt.Errorf("artifact path is required")
+	}
+	if len(r.SHA256) != sha256.Size*2 {
+		return fmt.Errorf("artifact sha256 must be %d hex characters", sha256.Size*2)
+	}
+	if _, err := hex.DecodeString(r.SHA256); err != nil {
+		return fmt.Errorf("artifact sha256 must be hex: %w", err)
+	}
+	if r.Size < 0 {
+		return fmt.Errorf("artifact size must be >= 0")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, r.WrittenAt); err != nil {
+		return fmt.Errorf("artifact written_at is invalid: %w", err)
+	}
+	return nil
+}
+
+func (s *ContentAddressedArtifactStore) PutBytes(data []byte) (ArtifactRef, error) {
+	sum := sha256.Sum256(data)
+	digest := hex.EncodeToString(sum[:])
+	relPath := filepath.ToSlash(filepath.Join(artifactStoreRel, digest[:2], digest[2:4], digest))
+	absPath := filepath.Join(s.root, filepath.FromSlash(relPath))
+	ref := ArtifactRef{
+		Path:      relPath,
+		SHA256:    digest,
+		Size:      int64(len(data)),
+		WrittenAt: s.now().UTC().Format(time.RFC3339Nano),
+	}
+	if info, err := os.Stat(absPath); err == nil {
+		if err := verifyArtifactFile(absPath, digest); err != nil {
+			return ArtifactRef{}, err
+		}
+		ref.WrittenAt = info.ModTime().UTC().Format(time.RFC3339Nano)
+		return ref, nil
+	} else if !os.IsNotExist(err) {
+		return ArtifactRef{}, fmt.Errorf("stat artifact %s: %w", relPath, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o700); err != nil {
+		return ArtifactRef{}, fmt.Errorf("create artifact dir: %w", err)
+	}
+	tmp, err := writeArtifactTemp(filepath.Dir(absPath), digest, data)
+	if err != nil {
+		return ArtifactRef{}, err
+	}
+	if err := os.Rename(tmp, absPath); err != nil {
+		_ = os.Remove(tmp)
+		if info, statErr := os.Stat(absPath); statErr == nil {
+			if verifyErr := verifyArtifactFile(absPath, digest); verifyErr != nil {
+				return ArtifactRef{}, verifyErr
+			}
+			ref.WrittenAt = info.ModTime().UTC().Format(time.RFC3339Nano)
+			return ref, nil
+		}
+		return ArtifactRef{}, fmt.Errorf("commit artifact %s: %w", relPath, err)
+	}
+	return ref, nil
+}
+
+func writeArtifactTemp(dir, digest string, data []byte) (string, error) {
+	tmp := filepath.Join(dir, "."+digest+".tmp")
+	file, err := os.OpenFile(tmp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if os.IsExist(err) {
+		tmp = filepath.Join(dir, fmt.Sprintf(".%s.%d.tmp", digest, os.Getpid()))
+		file, err = os.OpenFile(tmp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	}
+	if err != nil {
+		return "", fmt.Errorf("create artifact temp: %w", err)
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("write artifact temp: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("sync artifact temp: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("close artifact temp: %w", err)
+	}
+	return tmp, nil
+}
+
+func verifyArtifactFile(path, wantSHA256 string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open existing artifact: %w", err)
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return fmt.Errorf("hash existing artifact: %w", err)
+	}
+	if got := hex.EncodeToString(hash.Sum(nil)); got != wantSHA256 {
+		return fmt.Errorf("artifact hash path contains different content: path=%s got=%s want=%s", path, got, wantSHA256)
+	}
+	return nil
+}
+
+func cloneArtifactRefs(in map[string]ArtifactRef) map[string]ArtifactRef {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]ArtifactRef, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func validateArtifactRefs(refs map[string]ArtifactRef) error {
+	for key, ref := range refs {
+		if strings.TrimSpace(key) == "" {
+			return fmt.Errorf("artifact ref key is required")
+		}
+		if err := ref.Validate(); err != nil {
+			return fmt.Errorf("artifact ref %q: %w", key, err)
+		}
+	}
+	return nil
+}
+
+func artifactRefsFromPayload(payload map[string]any) map[string]ArtifactRef {
+	raw, ok := payload["artifact_refs"]
+	if !ok {
+		return nil
+	}
+	out := map[string]ArtifactRef{}
+	switch values := raw.(type) {
+	case map[string]ArtifactRef:
+		for key, value := range values {
+			out[key] = value
+		}
+	case map[string]any:
+		for key, value := range values {
+			ref, ok := artifactRefFromValue(value)
+			if ok {
+				out[key] = ref
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func artifactRefFromValue(value any) (ArtifactRef, bool) {
+	if ref, ok := value.(ArtifactRef); ok {
+		return ref, true
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return ArtifactRef{}, false
+	}
+	var ref ArtifactRef
+	if err := json.Unmarshal(data, &ref); err != nil {
+		return ArtifactRef{}, false
+	}
+	return ref, true
+}

--- a/cli/internal/daemon/artifacts_test.go
+++ b/cli/internal/daemon/artifacts_test.go
@@ -1,0 +1,67 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestArtifactRef(t *testing.T) {
+	ref := ArtifactRef{
+		Path:      ".agents/handoffs/sha256/aa/bb/" + strings.Repeat("a", 64),
+		SHA256:    strings.Repeat("a", 64),
+		Size:      12,
+		WrittenAt: projectionTestTime(t, 0).Format(time.RFC3339Nano),
+	}
+	if err := ref.Validate(); err != nil {
+		t.Fatalf("valid ref rejected: %v", err)
+	}
+	for name, bad := range map[string]ArtifactRef{
+		"missing path": {SHA256: ref.SHA256, Size: 1, WrittenAt: ref.WrittenAt},
+		"bad hash":     {Path: ref.Path, SHA256: "not-sha", Size: 1, WrittenAt: ref.WrittenAt},
+		"bad size":     {Path: ref.Path, SHA256: ref.SHA256, Size: -1, WrittenAt: ref.WrittenAt},
+		"bad time":     {Path: ref.Path, SHA256: ref.SHA256, Size: 1, WrittenAt: "yesterday"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := bad.Validate(); err == nil {
+				t.Fatal("invalid ref accepted")
+			}
+		})
+	}
+}
+
+func TestContentAddressedStore(t *testing.T) {
+	root := t.TempDir()
+	now := projectionTestTime(t, 3)
+	store := NewContentAddressedArtifactStore(root, ArtifactStoreOptions{Now: func() time.Time { return now }})
+	ref, err := store.PutBytes([]byte("content-addressed artifact\n"))
+	if err != nil {
+		t.Fatalf("PutBytes: %v", err)
+	}
+	if err := ref.Validate(); err != nil {
+		t.Fatalf("ref invalid: %v", err)
+	}
+	if !strings.HasPrefix(ref.Path, ".agents/handoffs/sha256/") {
+		t.Fatalf("path = %q, want content-addressed handoff path", ref.Path)
+	}
+	parts := strings.Split(ref.Path, "/")
+	if len(parts) < 6 || parts[len(parts)-3] != ref.SHA256[:2] || parts[len(parts)-2] != ref.SHA256[2:4] || parts[len(parts)-1] != ref.SHA256 {
+		t.Fatalf("path = %q, want aa/bb/full-sha layout for %s", ref.Path, ref.SHA256)
+	}
+	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(ref.Path)))
+	if err != nil {
+		t.Fatalf("read stored artifact: %v", err)
+	}
+	if string(data) != "content-addressed artifact\n" {
+		t.Fatalf("stored data = %q", string(data))
+	}
+	again, err := store.PutBytes([]byte("content-addressed artifact\n"))
+	if err != nil {
+		t.Fatalf("PutBytes duplicate: %v", err)
+	}
+	if again.Path != ref.Path || again.SHA256 != ref.SHA256 || again.Size != ref.Size {
+		t.Fatalf("duplicate ref = %#v, want same path/hash/size as %#v", again, ref)
+	}
+}

--- a/cli/internal/daemon/jobs.go
+++ b/cli/internal/daemon/jobs.go
@@ -612,6 +612,13 @@ func (q *Queue) applyQueueEvent(job *QueueJobState, event LedgerEvent) bool {
 	if isTerminalStatus(job.Status) {
 		return false
 	}
+	applyQueueEventMetadata(job, event)
+	applyQueueEventArtifacts(job, event)
+	applyQueueEventStatus(job, event)
+	return true
+}
+
+func applyQueueEventMetadata(job *QueueJobState, event LedgerEvent) {
 	if jobType, ok, err := jobTypeFromPayload(event.Payload); err == nil && ok {
 		job.JobType = jobType
 	}
@@ -629,6 +636,9 @@ func (q *Queue) applyQueueEvent(job *QueueJobState, event LedgerEvent) bool {
 	if maxAttempts, ok := intPayload(event.Payload, "max_attempts"); ok {
 		job.MaxAttempts = maxAttempts
 	}
+}
+
+func applyQueueEventArtifacts(job *QueueJobState, event LedgerEvent) {
 	for key, value := range artifactsFromPayload(event.Payload) {
 		job.Artifacts[key] = value
 	}
@@ -641,30 +651,16 @@ func (q *Queue) applyQueueEvent(job *QueueJobState, event LedgerEvent) bool {
 			job.Artifacts[key] = ref.Path
 		}
 	}
+}
 
+func applyQueueEventStatus(job *QueueJobState, event LedgerEvent) {
 	switch event.EventType {
 	case EventJobAccepted:
 		job.Status = JobStatusQueued
 	case EventJobClaimed:
-		job.Status = JobStatusRunning
-		job.RetryExhausted = false
-		job.ClaimToken, _ = stringPayload(event.Payload, "claim_token")
-		job.LeaseEpoch, _ = intPayload(event.Payload, "lease_epoch")
-		job.LeaseExpiresAt, _ = stringPayload(event.Payload, "lease_expires_at")
-		if attempt, ok := intPayload(event.Payload, "attempt"); ok {
-			job.Attempt = attempt
-		}
+		applyJobClaimedEvent(job, event)
 	case EventJobHeartbeat:
-		job.Status = JobStatusRunning
-		if token, ok := stringPayload(event.Payload, "claim_token"); ok {
-			job.ClaimToken = token
-		}
-		if epoch, ok := intPayload(event.Payload, "lease_epoch"); ok {
-			job.LeaseEpoch = epoch
-		}
-		if expiresAt, ok := stringPayload(event.Payload, "lease_expires_at"); ok {
-			job.LeaseExpiresAt = expiresAt
-		}
+		applyJobHeartbeatEvent(job, event)
 	case EventJobLeaseExpired:
 		job.Status = JobStatusRetryWaiting
 		job.ClaimToken = ""
@@ -677,7 +673,30 @@ func (q *Queue) applyQueueEvent(job *QueueJobState, event LedgerEvent) bool {
 	case EventJobCancelled:
 		job.Status = JobStatusCancelled
 	}
-	return true
+}
+
+func applyJobClaimedEvent(job *QueueJobState, event LedgerEvent) {
+	job.Status = JobStatusRunning
+	job.RetryExhausted = false
+	job.ClaimToken, _ = stringPayload(event.Payload, "claim_token")
+	job.LeaseEpoch, _ = intPayload(event.Payload, "lease_epoch")
+	job.LeaseExpiresAt, _ = stringPayload(event.Payload, "lease_expires_at")
+	if attempt, ok := intPayload(event.Payload, "attempt"); ok {
+		job.Attempt = attempt
+	}
+}
+
+func applyJobHeartbeatEvent(job *QueueJobState, event LedgerEvent) {
+	job.Status = JobStatusRunning
+	if token, ok := stringPayload(event.Payload, "claim_token"); ok {
+		job.ClaimToken = token
+	}
+	if epoch, ok := intPayload(event.Payload, "lease_epoch"); ok {
+		job.LeaseEpoch = epoch
+	}
+	if expiresAt, ok := stringPayload(event.Payload, "lease_expires_at"); ok {
+		job.LeaseExpiresAt = expiresAt
+	}
 }
 
 func (q *Queue) isClaimable(job QueueJobState) bool {

--- a/cli/internal/daemon/jobs.go
+++ b/cli/internal/daemon/jobs.go
@@ -72,25 +72,26 @@ type QueueClaim struct {
 }
 
 type QueueJobState struct {
-	JobID             string            `json:"job_id"`
-	JobType           JobType           `json:"job_type"`
-	RequestID         string            `json:"request_id"`
-	RequestIDs        []string          `json:"request_ids,omitempty"`
-	Status            JobStatus         `json:"status"`
-	IdempotencyKey    string            `json:"idempotency_key,omitempty"`
-	Attempt           int               `json:"attempt"`
-	MaxAttempts       int               `json:"max_attempts"`
-	ClaimToken        string            `json:"claim_token,omitempty"`
-	LeaseEpoch        int               `json:"lease_epoch,omitempty"`
-	LeaseExpiresAt    string            `json:"lease_expires_at,omitempty"`
-	RetryExhausted    bool              `json:"retry_exhausted,omitempty"`
-	Failure           *JobFailure       `json:"failure,omitempty"`
-	Artifacts         map[string]string `json:"artifacts,omitempty"`
-	ProjectionTargets []ProjectionName  `json:"projection_targets,omitempty"`
-	Payload           map[string]any    `json:"payload,omitempty"`
-	LastEventID       string            `json:"last_event_id,omitempty"`
-	CreatedAt         string            `json:"created_at,omitempty"`
-	UpdatedAt         string            `json:"updated_at,omitempty"`
+	JobID             string                 `json:"job_id"`
+	JobType           JobType                `json:"job_type"`
+	RequestID         string                 `json:"request_id"`
+	RequestIDs        []string               `json:"request_ids,omitempty"`
+	Status            JobStatus              `json:"status"`
+	IdempotencyKey    string                 `json:"idempotency_key,omitempty"`
+	Attempt           int                    `json:"attempt"`
+	MaxAttempts       int                    `json:"max_attempts"`
+	ClaimToken        string                 `json:"claim_token,omitempty"`
+	LeaseEpoch        int                    `json:"lease_epoch,omitempty"`
+	LeaseExpiresAt    string                 `json:"lease_expires_at,omitempty"`
+	RetryExhausted    bool                   `json:"retry_exhausted,omitempty"`
+	Failure           *JobFailure            `json:"failure,omitempty"`
+	Artifacts         map[string]string      `json:"artifacts,omitempty"`
+	ArtifactRefs      map[string]ArtifactRef `json:"artifact_refs,omitempty"`
+	ProjectionTargets []ProjectionName       `json:"projection_targets,omitempty"`
+	Payload           map[string]any         `json:"payload,omitempty"`
+	LastEventID       string                 `json:"last_event_id,omitempty"`
+	CreatedAt         string                 `json:"created_at,omitempty"`
+	UpdatedAt         string                 `json:"updated_at,omitempty"`
 }
 
 type QueueSnapshot struct {
@@ -99,31 +100,34 @@ type QueueSnapshot struct {
 }
 
 type HeartbeatInput struct {
-	JobID      string
-	RequestID  RequestID
-	ClaimToken string
-	LeaseEpoch int
-	Actor      string
-	Artifacts  map[string]string
+	JobID        string
+	RequestID    RequestID
+	ClaimToken   string
+	LeaseEpoch   int
+	Actor        string
+	Artifacts    map[string]string
+	ArtifactRefs map[string]ArtifactRef
 }
 
 type CompleteJobInput struct {
-	JobID      string
-	RequestID  RequestID
-	ClaimToken string
-	LeaseEpoch int
-	Actor      string
-	Artifacts  map[string]string
+	JobID        string
+	RequestID    RequestID
+	ClaimToken   string
+	LeaseEpoch   int
+	Actor        string
+	Artifacts    map[string]string
+	ArtifactRefs map[string]ArtifactRef
 }
 
 type FailJobInput struct {
-	JobID      string
-	RequestID  RequestID
-	ClaimToken string
-	LeaseEpoch int
-	Actor      string
-	Failure    JobFailure
-	Artifacts  map[string]string
+	JobID        string
+	RequestID    RequestID
+	ClaimToken   string
+	LeaseEpoch   int
+	Actor        string
+	Failure      JobFailure
+	Artifacts    map[string]string
+	ArtifactRefs map[string]ArtifactRef
 }
 
 // CancelJobInput identifies a job cancellation request.
@@ -258,6 +262,9 @@ func (q *Queue) Heartbeat(input HeartbeatInput, opts QueueMutationOptions) (Queu
 	if err != nil {
 		return QueueJobState{}, err
 	}
+	if err := validateArtifactRefs(input.ArtifactRefs); err != nil {
+		return QueueJobState{}, err
+	}
 	expiresAt := q.now().Add(q.opts.LeaseDuration).UTC()
 	event, err := NewLedgerEvent(LedgerEventInput{
 		EventID:    q.nextEventID(EventJobHeartbeat, input.JobID),
@@ -266,12 +273,11 @@ func (q *Queue) Heartbeat(input HeartbeatInput, opts QueueMutationOptions) (Queu
 		EventType:  EventJobHeartbeat,
 		OccurredAt: q.now(),
 		Actor:      q.actor(input.Actor),
-		Payload: map[string]any{
+		Payload: jobMutationPayload(map[string]any{
 			"claim_token":      input.ClaimToken,
 			"lease_epoch":      input.LeaseEpoch,
 			"lease_expires_at": expiresAt.Format(time.RFC3339Nano),
-			"artifacts":        input.Artifacts,
-		},
+		}, input.Artifacts, input.ArtifactRefs),
 	})
 	if err != nil {
 		return QueueJobState{}, err
@@ -287,6 +293,9 @@ func (q *Queue) CompleteJob(input CompleteJobInput, opts QueueMutationOptions) (
 	if err != nil {
 		return QueueJobState{}, err
 	}
+	if err := validateArtifactRefs(input.ArtifactRefs); err != nil {
+		return QueueJobState{}, err
+	}
 	if isTerminalStatus(job.Status) {
 		return job, nil
 	}
@@ -297,12 +306,11 @@ func (q *Queue) CompleteJob(input CompleteJobInput, opts QueueMutationOptions) (
 		EventType:  EventJobCompleted,
 		OccurredAt: q.now(),
 		Actor:      q.actor(input.Actor),
-		Payload: map[string]any{
+		Payload: jobMutationPayload(map[string]any{
 			"claim_token":   input.ClaimToken,
 			"lease_epoch":   input.LeaseEpoch,
 			"result_status": string(JobResultSucceeded),
-			"artifacts":     input.Artifacts,
-		},
+		}, input.Artifacts, input.ArtifactRefs),
 	})
 	if err != nil {
 		return QueueJobState{}, err
@@ -316,6 +324,9 @@ func (q *Queue) CompleteJob(input CompleteJobInput, opts QueueMutationOptions) (
 func (q *Queue) FailJob(input FailJobInput, opts QueueMutationOptions) (QueueJobState, error) {
 	job, err := q.terminalClaimJob(input.JobID, input.ClaimToken, input.LeaseEpoch)
 	if err != nil {
+		return QueueJobState{}, err
+	}
+	if err := validateArtifactRefs(input.ArtifactRefs); err != nil {
 		return QueueJobState{}, err
 	}
 	if isTerminalStatus(job.Status) {
@@ -334,7 +345,7 @@ func (q *Queue) FailJob(input FailJobInput, opts QueueMutationOptions) (QueueJob
 		EventType:  EventJobFailed,
 		OccurredAt: q.now(),
 		Actor:      q.actor(input.Actor),
-		Payload: map[string]any{
+		Payload: jobMutationPayload(map[string]any{
 			"claim_token": input.ClaimToken,
 			"lease_epoch": input.LeaseEpoch,
 			"failure": map[string]any{
@@ -342,8 +353,7 @@ func (q *Queue) FailJob(input FailJobInput, opts QueueMutationOptions) (QueueJob
 				"message":   input.Failure.Message,
 				"retryable": input.Failure.Retryable,
 			},
-			"artifacts": input.Artifacts,
-		},
+		}, input.Artifacts, input.ArtifactRefs),
 	})
 	if err != nil {
 		return QueueJobState{}, err
@@ -559,12 +569,13 @@ func (q *Queue) snapshotFromEvents(events []LedgerEvent) (QueueSnapshot, error) 
 		job := jobsByID[event.JobID]
 		if job == nil {
 			job = &QueueJobState{
-				JobID:       event.JobID,
-				RequestID:   event.RequestID,
-				RequestIDs:  []string{event.RequestID},
-				Status:      JobStatusQueued,
-				MaxAttempts: q.opts.MaxAttempts,
-				Artifacts:   map[string]string{},
+				JobID:        event.JobID,
+				RequestID:    event.RequestID,
+				RequestIDs:   []string{event.RequestID},
+				Status:       JobStatusQueued,
+				MaxAttempts:  q.opts.MaxAttempts,
+				Artifacts:    map[string]string{},
+				ArtifactRefs: map[string]ArtifactRef{},
 			}
 			jobsByID[event.JobID] = job
 			order = append(order, event.JobID)
@@ -582,6 +593,9 @@ func (q *Queue) snapshotFromEvents(events []LedgerEvent) (QueueSnapshot, error) 
 		job := *jobsByID[jobID]
 		if len(job.Artifacts) == 0 {
 			job.Artifacts = nil
+		}
+		if len(job.ArtifactRefs) == 0 {
+			job.ArtifactRefs = nil
 		}
 		if job.Status == JobStatusRunning && q.jobLeaseExpired(job) {
 			job.Status = JobStatusRetryWaiting
@@ -617,6 +631,15 @@ func (q *Queue) applyQueueEvent(job *QueueJobState, event LedgerEvent) bool {
 	}
 	for key, value := range artifactsFromPayload(event.Payload) {
 		job.Artifacts[key] = value
+	}
+	for key, ref := range artifactRefsFromPayload(event.Payload) {
+		if job.ArtifactRefs == nil {
+			job.ArtifactRefs = map[string]ArtifactRef{}
+		}
+		job.ArtifactRefs[key] = ref
+		if ref.Path != "" {
+			job.Artifacts[key] = ref.Path
+		}
 	}
 
 	switch event.EventType {
@@ -697,6 +720,16 @@ func (snapshot QueueSnapshot) jobByID(jobID string) (QueueJobState, error) {
 
 func (q *Queue) nextEventID(eventType EventType, jobID string) string {
 	return q.nextID("evt_"+sanitizeIDPart(string(eventType)), jobID)
+}
+
+func jobMutationPayload(base map[string]any, artifacts map[string]string, refs map[string]ArtifactRef) map[string]any {
+	if len(artifacts) > 0 {
+		base["artifacts"] = artifacts
+	}
+	if len(refs) > 0 {
+		base["artifact_refs"] = refs
+	}
+	return base
 }
 
 func (q *Queue) nextID(prefix, seed string) string {

--- a/cli/internal/daemon/projections.go
+++ b/cli/internal/daemon/projections.go
@@ -58,18 +58,19 @@ type ProjectionManifest struct {
 }
 
 type JobProjection struct {
-	JobID             string            `json:"job_id"`
-	JobType           JobType           `json:"job_type,omitempty"`
-	RequestID         string            `json:"request_id"`
-	RequestIDs        []string          `json:"request_ids,omitempty"`
-	Status            JobStatus         `json:"status"`
-	ResultStatus      JobResultStatus   `json:"result_status,omitempty"`
-	Failure           *JobFailure       `json:"failure,omitempty"`
-	Artifacts         map[string]string `json:"artifacts,omitempty"`
-	ProjectionTargets []ProjectionName  `json:"projection_targets,omitempty"`
-	CreatedAt         string            `json:"created_at,omitempty"`
-	UpdatedAt         string            `json:"updated_at,omitempty"`
-	LastEventID       string            `json:"last_event_id,omitempty"`
+	JobID             string                 `json:"job_id"`
+	JobType           JobType                `json:"job_type,omitempty"`
+	RequestID         string                 `json:"request_id"`
+	RequestIDs        []string               `json:"request_ids,omitempty"`
+	Status            JobStatus              `json:"status"`
+	ResultStatus      JobResultStatus        `json:"result_status,omitempty"`
+	Failure           *JobFailure            `json:"failure,omitempty"`
+	Artifacts         map[string]string      `json:"artifacts,omitempty"`
+	ArtifactRefs      map[string]ArtifactRef `json:"artifact_refs,omitempty"`
+	ProjectionTargets []ProjectionName       `json:"projection_targets,omitempty"`
+	CreatedAt         string                 `json:"created_at,omitempty"`
+	UpdatedAt         string                 `json:"updated_at,omitempty"`
+	LastEventID       string                 `json:"last_event_id,omitempty"`
 }
 
 type RPIRegistryProjection struct {
@@ -183,11 +184,12 @@ func ensureJobProjection(jobsByID map[string]*JobProjection, event LedgerEvent) 
 		return job, false
 	}
 	job := &JobProjection{
-		JobID:      event.JobID,
-		RequestID:  event.RequestID,
-		RequestIDs: []string{event.RequestID},
-		Status:     JobStatusQueued,
-		Artifacts:  map[string]string{},
+		JobID:        event.JobID,
+		RequestID:    event.RequestID,
+		RequestIDs:   []string{event.RequestID},
+		Status:       JobStatusQueued,
+		Artifacts:    map[string]string{},
+		ArtifactRefs: map[string]ArtifactRef{},
 	}
 	jobsByID[event.JobID] = job
 	return job, true
@@ -219,6 +221,15 @@ func applyPayloadToJob(job *JobProjection, event LedgerEvent) error {
 	for key, value := range artifactsFromPayload(event.Payload) {
 		job.Artifacts[key] = value
 	}
+	for key, ref := range artifactRefsFromPayload(event.Payload) {
+		if job.ArtifactRefs == nil {
+			job.ArtifactRefs = map[string]ArtifactRef{}
+		}
+		job.ArtifactRefs[key] = ref
+		if ref.Path != "" {
+			job.Artifacts[key] = ref.Path
+		}
+	}
 	return nil
 }
 
@@ -228,6 +239,9 @@ func collectJobsIntoSet(jobsByID map[string]*JobProjection, jobOrder []string, s
 		job := *jobsByID[jobID]
 		if len(job.Artifacts) == 0 {
 			job.Artifacts = nil
+		}
+		if len(job.ArtifactRefs) == 0 {
+			job.ArtifactRefs = nil
 		}
 		set.Jobs = append(set.Jobs, job)
 		classifyJobIntoBuckets(job, set)

--- a/cli/internal/daemon/projections_test.go
+++ b/cli/internal/daemon/projections_test.go
@@ -101,6 +101,38 @@ func TestProjectionRebuildsRpiDreamWikiAndOpenClawFromLedger(t *testing.T) {
 	}
 }
 
+func TestProjectionReplayContentAddressedArtifacts(t *testing.T) {
+	ref := ArtifactRef{
+		Path:      ".agents/handoffs/sha256/aa/bb/" + strings.Repeat("a", 64),
+		SHA256:    strings.Repeat("a", 64),
+		Size:      42,
+		WrittenAt: projectionTestTime(t, 2).Format(time.RFC3339Nano),
+	}
+	events := []LedgerEvent{
+		mustNewProjectionTestEvent(t, "evt-wiki-accepted", "req-wiki-1", "job-wiki", EventJobAccepted, JobTypeWikiForge, 0, nil),
+		mustNewProjectionTestEvent(t, "evt-wiki-completed", "req-wiki-2", "job-wiki", EventJobCompleted, "", 1, map[string]any{
+			"artifact_refs": map[string]ArtifactRef{"worker_session_refs": ref},
+		}),
+	}
+	projections, err := RebuildProjections(events, ProjectionRebuildOptions{RebuiltAt: projectionTestTime(t, 10)})
+	if err != nil {
+		t.Fatalf("rebuild projections: %v", err)
+	}
+	if len(projections.Wiki.Jobs) != 1 {
+		t.Fatalf("wiki jobs = %#v", projections.Wiki.Jobs)
+	}
+	job := projections.Wiki.Jobs[0]
+	if got := job.ArtifactRefs["worker_session_refs"]; got != ref {
+		t.Fatalf("artifact ref = %#v, want %#v", got, ref)
+	}
+	if got := job.Artifacts["worker_session_refs"]; got != ref.Path {
+		t.Fatalf("compat artifact path = %q, want %q", got, ref.Path)
+	}
+	if got := projections.OpenClaw.Resources.Wiki[0].ArtifactRefs["worker_session_refs"]; got != ref {
+		t.Fatalf("openclaw artifact ref = %#v, want %#v", got, ref)
+	}
+}
+
 func TestProjectionReplayFromStoreCarriesRequestIDsAndDegradesOnCorruptLedger(t *testing.T) {
 	store := NewStore(t.TempDir())
 	if _, err := store.AppendLedgerEvent(mustNewProjectionTestEvent(t, "evt-rpi-accepted", "req-rpi-1", "job-rpi", EventJobAccepted, JobTypeRPIPhase, 0, nil)); err != nil {

--- a/cli/internal/daemon/server.go
+++ b/cli/internal/daemon/server.go
@@ -561,6 +561,7 @@ func openClawResourcesFromJobs(jobs []JobProjection, kind openclaw.ResourceKind)
 			ResultStatus:      string(job.ResultStatus),
 			Failure:           openClawFailure(job.Failure),
 			Artifacts:         cloneStringMap(job.Artifacts),
+			ArtifactRefs:      openClawArtifactRefs(job.ArtifactRefs),
 			ProjectionTargets: projectionTargetStrings(job.ProjectionTargets),
 			CreatedAt:         job.CreatedAt,
 			UpdatedAt:         job.UpdatedAt,
@@ -570,6 +571,22 @@ func openClawResourcesFromJobs(jobs []JobProjection, kind openclaw.ResourceKind)
 	}
 	if out == nil {
 		return []openclaw.ResourceSummary{}
+	}
+	return out
+}
+
+func openClawArtifactRefs(in map[string]ArtifactRef) map[string]openclaw.ArtifactRef {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]openclaw.ArtifactRef, len(in))
+	for key, ref := range in {
+		out[key] = openclaw.ArtifactRef{
+			Path:      ref.Path,
+			SHA256:    ref.SHA256,
+			Size:      ref.Size,
+			WrittenAt: ref.WrittenAt,
+		}
 	}
 	return out
 }

--- a/cli/internal/daemon/server_test.go
+++ b/cli/internal/daemon/server_test.go
@@ -127,13 +127,19 @@ func TestOpenClawReadOnlyEndpoints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("claim wiki job: %v", err)
 	}
+	refsArtifact := ArtifactRef{
+		Path:      ".agents/handoffs/sha256/aa/bb/" + strings.Repeat("a", 64),
+		SHA256:    strings.Repeat("a", 64),
+		Size:      128,
+		WrittenAt: now.Format(time.RFC3339Nano),
+	}
 	if _, err := queue.CompleteJob(CompleteJobInput{
-		JobID:      "job-wiki",
-		RequestID:  "req-wiki-complete",
-		ClaimToken: claim.ClaimToken,
-		LeaseEpoch: claim.LeaseEpoch,
-		Actor:      "wiki-worker",
-		Artifacts:  map[string]string{"worker_session_refs": ".agents/daemon/wiki/job-wiki-worker-sessions.json"},
+		JobID:        "job-wiki",
+		RequestID:    "req-wiki-complete",
+		ClaimToken:   claim.ClaimToken,
+		LeaseEpoch:   claim.LeaseEpoch,
+		Actor:        "wiki-worker",
+		ArtifactRefs: map[string]ArtifactRef{"worker_session_refs": refsArtifact},
 	}, QueueMutationOptions{}); err != nil {
 		t.Fatalf("complete wiki job: %v", err)
 	}
@@ -155,6 +161,12 @@ func TestOpenClawReadOnlyEndpoints(t *testing.T) {
 	}
 	if len(snapshot.Resources.Wiki) != 1 || snapshot.Resources.Wiki[0].ResourceKind != openclaw.ResourceKindWiki {
 		t.Fatalf("snapshot wiki = %#v", snapshot.Resources.Wiki)
+	}
+	if got := snapshot.Resources.Wiki[0].ArtifactRefs["worker_session_refs"].SHA256; got != refsArtifact.SHA256 {
+		t.Fatalf("snapshot artifact ref sha = %q, want %q", got, refsArtifact.SHA256)
+	}
+	if got := snapshot.Resources.Wiki[0].Artifacts["worker_session_refs"]; got != refsArtifact.Path {
+		t.Fatalf("snapshot compat artifact path = %q, want %q", got, refsArtifact.Path)
 	}
 	if !hasOpenClawProvenance(snapshot.Resources.Wiki[0].Provenance, "source-event", "daemon-ledger-event", "") {
 		t.Fatalf("wiki missing source-event provenance: %#v", snapshot.Resources.Wiki[0].Provenance)

--- a/cli/internal/daemon/supervisor.go
+++ b/cli/internal/daemon/supervisor.go
@@ -10,7 +10,8 @@ import (
 
 // JobExecutionResult is the terminal output from a daemon job executor.
 type JobExecutionResult struct {
-	Artifacts map[string]string
+	Artifacts    map[string]string
+	ArtifactRefs map[string]ArtifactRef
 }
 
 // JobExecutor runs claimed daemon jobs for one or more job types.
@@ -108,6 +109,7 @@ func (s *Supervisor) RunOnce(ctx context.Context) (SupervisorRunOnceResult, erro
 	}
 	result, execErr := s.runExecutorWithHeartbeat(ctx, executor, claim)
 	artifacts := result.Artifacts
+	artifactRefs := result.ArtifactRefs
 	if execErr != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil && errors.Is(execErr, ctxErr) {
 			return SupervisorRunOnceResult{Claimed: true, Job: claim.Job}, nil
@@ -122,7 +124,8 @@ func (s *Supervisor) RunOnce(ctx context.Context) (SupervisorRunOnceResult, erro
 				Code:    FailureRequestRejected,
 				Message: execErr.Error(),
 			},
-			Artifacts: artifacts,
+			Artifacts:    artifacts,
+			ArtifactRefs: artifactRefs,
 		}, QueueMutationOptions{})
 		if err != nil {
 			return SupervisorRunOnceResult{}, err
@@ -130,12 +133,13 @@ func (s *Supervisor) RunOnce(ctx context.Context) (SupervisorRunOnceResult, erro
 		return SupervisorRunOnceResult{Claimed: true, Job: failed}, nil
 	}
 	completed, err := s.queue.CompleteJob(CompleteJobInput{
-		JobID:      claim.Job.JobID,
-		RequestID:  RequestID(claim.Job.RequestID),
-		ClaimToken: claim.ClaimToken,
-		LeaseEpoch: claim.LeaseEpoch,
-		Actor:      s.actor,
-		Artifacts:  artifacts,
+		JobID:        claim.Job.JobID,
+		RequestID:    RequestID(claim.Job.RequestID),
+		ClaimToken:   claim.ClaimToken,
+		LeaseEpoch:   claim.LeaseEpoch,
+		Actor:        s.actor,
+		Artifacts:    artifacts,
+		ArtifactRefs: artifactRefs,
 	}, QueueMutationOptions{})
 	if err != nil {
 		return SupervisorRunOnceResult{}, err

--- a/cli/internal/daemon/wiki_executor.go
+++ b/cli/internal/daemon/wiki_executor.go
@@ -81,24 +81,31 @@ func (e *WikiForgeExecutor) RunJob(ctx context.Context, claim QueueClaim) (JobEx
 			Terminal:   result.Terminal,
 		})
 	}
-	refsPath, err := writeWikiWorkerSessionRefs(e.store.root, claim.Job.JobID, refs)
+	refsArtifact, err := writeWikiWorkerSessionRefs(e.store.root, claim.Job.JobID, refs)
 	if err != nil {
 		return JobExecutionResult{}, err
 	}
-	return JobExecutionResult{Artifacts: wikiForgeSuccessArtifacts(refsPath, refs)}, nil
+	return JobExecutionResult{
+		Artifacts:    wikiForgeSuccessArtifacts(refs),
+		ArtifactRefs: wikiForgeSuccessArtifactRefs(refsArtifact),
+	}, nil
 }
 
-func wikiForgeSuccessArtifacts(refsPath string, refs []WikiWorkerSessionRef) map[string]string {
-	artifacts := map[string]string{"worker_session_refs": refsPath}
+func wikiForgeSuccessArtifacts(refs []WikiWorkerSessionRef) map[string]string {
 	if len(refs) == 0 {
-		return artifacts
+		return nil
 	}
+	artifacts := map[string]string{}
 	last := refs[len(refs)-1]
 	artifacts["provider_request_id"] = last.Session.ProviderRequestID
 	artifacts["session_id"] = last.Session.SessionID
 	artifacts["event_cursor"] = last.Session.EventCursor
 	artifacts["terminal_status"] = string(last.Terminal.Status)
 	return artifacts
+}
+
+func wikiForgeSuccessArtifactRefs(refsArtifact ArtifactRef) map[string]ArtifactRef {
+	return map[string]ArtifactRef{"worker_session_refs": refsArtifact}
 }
 
 func wikiForgeFailureArtifacts(result wikiworker.ExtractionResult, err error) map[string]string {

--- a/cli/internal/daemon/wiki_executor_test.go
+++ b/cli/internal/daemon/wiki_executor_test.go
@@ -55,6 +55,13 @@ func TestWikiForgeExecutorCompletesJobWithAgentWorkerSessionRefs(t *testing.T) {
 	if result.Job.Artifacts["terminal_status"] != string(agentworker.StatusCompleted) {
 		t.Fatalf("terminal_status = %q", result.Job.Artifacts["terminal_status"])
 	}
+	ref := result.Job.ArtifactRefs["worker_session_refs"]
+	if err := ref.Validate(); err != nil {
+		t.Fatalf("worker_session_refs ref invalid: %v", err)
+	}
+	if result.Job.Artifacts["worker_session_refs"] != ref.Path {
+		t.Fatalf("compat worker_session_refs = %q, want %q", result.Job.Artifacts["worker_session_refs"], ref.Path)
+	}
 }
 
 func TestWikiForgeExecutorInvalidOutputFailsWithQuarantineArtifact(t *testing.T) {

--- a/cli/internal/daemon/wiki_jobs.go
+++ b/cli/internal/daemon/wiki_jobs.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/boshu2/agentops/cli/internal/agentworker"
 	"github.com/boshu2/agentops/cli/internal/wikiworker"
@@ -63,6 +62,7 @@ type WikiForgeJobRunResult struct {
 	DreamRunID     string                 `json:"dream_run_id,omitempty"`
 	Status         JobStatus              `json:"status"`
 	Artifacts      map[string]string      `json:"artifacts,omitempty"`
+	ArtifactRefs   map[string]ArtifactRef `json:"artifact_refs,omitempty"`
 	WorkerSessions []WikiWorkerSessionRef `json:"worker_sessions,omitempty"`
 	Failure        *JobFailure            `json:"failure,omitempty"`
 }
@@ -214,18 +214,20 @@ func (r *WikiForgeRunner) runClaimedWikiForgeJob(ctx context.Context, claim Queu
 			Terminal:   result.Terminal,
 		})
 	}
-	refsPath, err := writeWikiWorkerSessionRefs(r.store.root, claim.Job.JobID, refs)
+	refsArtifact, err := writeWikiWorkerSessionRefs(r.store.root, claim.Job.JobID, refs)
 	if err != nil {
 		failure := JobFailure{Code: FailureRequestRejected, Message: err.Error(), Retryable: false}
 		return r.failWikiForgeJob(claim, failure), err
 	}
+	artifactRefs := wikiForgeSuccessArtifactRefs(refsArtifact)
 	job, err := r.queue.CompleteJob(CompleteJobInput{
-		JobID:      claim.Job.JobID,
-		RequestID:  RequestID(claim.Job.RequestID),
-		ClaimToken: claim.ClaimToken,
-		LeaseEpoch: claim.LeaseEpoch,
-		Actor:      r.actor,
-		Artifacts:  map[string]string{"worker_session_refs": refsPath},
+		JobID:        claim.Job.JobID,
+		RequestID:    RequestID(claim.Job.RequestID),
+		ClaimToken:   claim.ClaimToken,
+		LeaseEpoch:   claim.LeaseEpoch,
+		Actor:        r.actor,
+		Artifacts:    wikiForgeSuccessArtifacts(refs),
+		ArtifactRefs: artifactRefs,
 	}, QueueMutationOptions{})
 	if err != nil {
 		return WikiForgeJobRunResult{}, err
@@ -235,6 +237,7 @@ func (r *WikiForgeRunner) runClaimedWikiForgeJob(ctx context.Context, claim Queu
 		DreamRunID:     spec.DreamRunID,
 		Status:         job.Status,
 		Artifacts:      job.Artifacts,
+		ArtifactRefs:   job.ArtifactRefs,
 		WorkerSessions: refs,
 	}, nil
 }
@@ -324,36 +327,21 @@ func wikiForgePrompt(ctx wikiForgePromptContext) string {
 	}, " ")
 }
 
-func writeWikiWorkerSessionRefs(root, jobID string, refs []WikiWorkerSessionRef) (string, error) {
-	dir := filepath.Join(root, ".agents", "daemon", "wiki")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", err
-	}
-	path := filepath.Join(dir, sanitizeWikiArtifactName(jobID)+"-worker-sessions.json")
+func writeWikiWorkerSessionRefs(root, jobID string, refs []WikiWorkerSessionRef) (ArtifactRef, error) {
 	data, err := json.MarshalIndent(struct {
 		SchemaVersion  int                    `json:"schema_version"`
 		JobID          string                 `json:"job_id"`
 		WorkerSessions []WikiWorkerSessionRef `json:"worker_sessions"`
-		WrittenAt      string                 `json:"written_at"`
 	}{
 		SchemaVersion:  1,
 		JobID:          jobID,
 		WorkerSessions: refs,
-		WrittenAt:      time.Now().UTC().Format(time.RFC3339Nano),
 	}, "", "  ")
 	if err != nil {
-		return "", err
+		return ArtifactRef{}, err
 	}
 	data = append(data, '\n')
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		return "", err
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return "", err
-	}
-	return path, nil
+	return NewContentAddressedArtifactStore(root, ArtifactStoreOptions{}).PutBytes(data)
 }
 
 func sanitizeWikiArtifactName(value string) string {

--- a/cli/internal/daemon/wiki_jobs_test.go
+++ b/cli/internal/daemon/wiki_jobs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -26,7 +27,7 @@ func TestWikiForgeJobSpecRoundTrip(t *testing.T) {
 	}
 }
 
-func TestWikiForgeRunnerCompletesJobWithAgentWorkerSessionRefs(t *testing.T) {
+func TestWikiForgeRunnerCompletesJobWithContentAddressedHash(t *testing.T) {
 	root := t.TempDir()
 	store := NewStore(root)
 	queue := NewQueue(store, QueueOptions{})
@@ -94,7 +95,17 @@ func TestWikiForgeRunnerCompletesJobWithAgentWorkerSessionRefs(t *testing.T) {
 		}
 	}
 	refsPath := result.Artifacts["worker_session_refs"]
-	data, err := os.ReadFile(refsPath)
+	ref := result.ArtifactRefs["worker_session_refs"]
+	if err := ref.Validate(); err != nil {
+		t.Fatalf("worker_session_refs ref invalid: %v", err)
+	}
+	if refsPath != ref.Path {
+		t.Fatalf("compat refs path = %q, want artifact ref path %q", refsPath, ref.Path)
+	}
+	if filepath.Base(ref.Path) != ref.SHA256 {
+		t.Fatalf("artifact ref path = %q, sha256 = %q", ref.Path, ref.SHA256)
+	}
+	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(refsPath)))
 	if err != nil {
 		t.Fatalf("read refs artifact: %v", err)
 	}

--- a/cli/internal/openclaw/types.go
+++ b/cli/internal/openclaw/types.go
@@ -57,28 +57,36 @@ type SnapshotResources struct {
 }
 
 type ResourceSummary struct {
-	ResourceID        string            `json:"resource_id"`
-	ResourceKind      ResourceKind      `json:"resource_kind"`
-	JobID             string            `json:"job_id,omitempty"`
-	JobType           string            `json:"job_type,omitempty"`
-	RunID             string            `json:"run_id,omitempty"`
-	RequestID         string            `json:"request_id,omitempty"`
-	RequestIDs        []string          `json:"request_ids,omitempty"`
-	Status            string            `json:"status"`
-	ResultStatus      string            `json:"result_status,omitempty"`
-	Failure           *FailureSummary   `json:"failure,omitempty"`
-	Artifacts         map[string]string `json:"artifacts,omitempty"`
-	ProjectionTargets []string          `json:"projection_targets,omitempty"`
-	CreatedAt         string            `json:"created_at,omitempty"`
-	UpdatedAt         string            `json:"updated_at,omitempty"`
-	LastEventID       string            `json:"last_event_id,omitempty"`
-	Provenance        []ProvenanceLink  `json:"provenance,omitempty"`
+	ResourceID        string                 `json:"resource_id"`
+	ResourceKind      ResourceKind           `json:"resource_kind"`
+	JobID             string                 `json:"job_id,omitempty"`
+	JobType           string                 `json:"job_type,omitempty"`
+	RunID             string                 `json:"run_id,omitempty"`
+	RequestID         string                 `json:"request_id,omitempty"`
+	RequestIDs        []string               `json:"request_ids,omitempty"`
+	Status            string                 `json:"status"`
+	ResultStatus      string                 `json:"result_status,omitempty"`
+	Failure           *FailureSummary        `json:"failure,omitempty"`
+	Artifacts         map[string]string      `json:"artifacts,omitempty"`
+	ArtifactRefs      map[string]ArtifactRef `json:"artifact_refs,omitempty"`
+	ProjectionTargets []string               `json:"projection_targets,omitempty"`
+	CreatedAt         string                 `json:"created_at,omitempty"`
+	UpdatedAt         string                 `json:"updated_at,omitempty"`
+	LastEventID       string                 `json:"last_event_id,omitempty"`
+	Provenance        []ProvenanceLink       `json:"provenance,omitempty"`
 }
 
 type FailureSummary struct {
 	Code      string `json:"code"`
 	Message   string `json:"message"`
 	Retryable bool   `json:"retryable,omitempty"`
+}
+
+type ArtifactRef struct {
+	Path      string `json:"path"`
+	SHA256    string `json:"sha256"`
+	Size      int64  `json:"size"`
+	WrittenAt string `json:"written_at"`
 }
 
 type ProvenanceLink struct {

--- a/docs/contracts/agents-write-surfaces.md
+++ b/docs/contracts/agents-write-surfaces.md
@@ -36,6 +36,7 @@ allowlist nor an active skill name fails the gate.
 | `evals` | cli eval runtime, scripts (`eval-agentops`) | persistent | Eval run outputs, promoted baselines, and suite execution state |
 | `findings` | scripts, /forge | persistent | Mined findings awaiting promotion |
 | `git` | cli (git-aware tooling) | persistent | Git-derived state cached for the runtime |
+| `handoffs` | cli (daemon content-addressed artifacts) | persistent | Content-addressed handoff artifacts keyed by sha256 for daemon job replay |
 | `holdout` | cli (`/scenario`) | persistent | Holdout scenarios stored outside the codebase view |
 | `knowledge` | cli (compile knowledge surface) | persistent | Promoted knowledge artifacts |
 | `learnings` | cli (curate `TierLearning`), /post-mortem, /retro | persistent | Promoted learning artifacts |
@@ -95,6 +96,7 @@ defrag
 evals
 findings
 git
+handoffs
 holdout
 knowledge
 learnings


### PR DESCRIPTION
## Summary
- add ArtifactRef plus a content-addressed sha256 artifact store under .agents/handoffs/sha256/<aa>/<bb>/<hash>
- propagate artifact_refs through queue terminal events, snapshots, projections, and OpenClaw resources while preserving legacy artifacts as a compatibility path view
- move wiki worker session refs to content-addressed storage and keep replay deterministic from ledger payloads
- document the new .agents/handoffs write surface

## Pre-mortem
- quick pre-mortem completed: .agents/council/2026-04-30-pre-mortem-soc-5of-2-content-addressed-artifacts.md
- verdict: WARN/proceed with constraints; GC intentionally deferred and legacy artifact replay preserved

## Validation
- go test ./internal/daemon -run 'TestArtifactRef|TestContentAddressedStore|TestWikiForgeRunner.*Hash|TestWikiForgeExecutorCompletesJobWithAgentWorkerSessionRefs|TestProjectionReplay.*Artifacts'
- go test ./internal/daemon ./internal/openclaw ./cmd/ao -run 'TestArtifactRef|TestContentAddressedStore|TestWikiForgeRunner.*Hash|TestWikiForgeExecutorCompletesJobWithAgentWorkerSessionRefs|TestProjectionReplay.*Artifacts|TestOpenClawReadOnlyEndpoints|TestCobraConformance|TestCobraExpectedCmdsMatchRegistration'
- go test ./internal/daemon ./internal/openclaw ./cmd/ao
- scripts/check-agents-write-surfaces.sh
- ./scripts/generate-cli-reference.sh --check
- git diff --check
- git push pre-push fast gate passed

Bead: soc-5of.2