### PR TITLE
feat: scope daemon mutation tokens

### DIFF
--- a/cli/cmd/ao/agentopsd.go
+++ b/cli/cmd/ao/agentopsd.go
@@ -446,10 +446,6 @@ func startAgentOpsDaemon(ctx context.Context, cwd string, opts agentopsDaemonRun
 	if err := daemonpkg.ValidateLocalBindAddress(addr); err != nil {
 		return nil, nil, agentopsDaemonActivation{}, err
 	}
-	token, err := resolveDaemonMutationToken(opts.Token, opts.TokenFile)
-	if err != nil {
-		return nil, nil, agentopsDaemonActivation{}, err
-	}
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return nil, nil, agentopsDaemonActivation{}, err
@@ -464,15 +460,14 @@ func startAgentOpsDaemon(ctx context.Context, cwd string, opts agentopsDaemonRun
 		return nil, nil, agentopsDaemonActivation{}, fmt.Errorf("daemon startup recovery: %w", err)
 	}
 	store := daemonpkg.NewStore(cwd)
+	mutationPolicy, err := resolveAgentOpsDaemonMutationPolicy(opts.Token, opts.TokenFile)
+	if err != nil {
+		_ = listener.Close()
+		return nil, nil, agentopsDaemonActivation{}, err
+	}
 	router := daemonpkg.NewDaemonRouter(store, daemonpkg.ServerOptions{
-		Now: now,
-		MutationPolicy: daemonpkg.DefaultMutationPolicy(token, []string{
-			"/jobs",
-			"/v1/jobs",
-			"/jobs/cancel",
-			"/v1/jobs/cancel",
-			"/openclaw/v1/triggers/jobs",
-		}),
+		Now:            now,
+		MutationPolicy: mutationPolicy,
 	})
 	server := &http.Server{
 		Handler:           router,
@@ -496,6 +491,33 @@ func startAgentOpsDaemon(ctx context.Context, cwd string, opts agentopsDaemonRun
 		_ = server.Shutdown(shutdownCtx)
 	}()
 	return server, listener, activation, nil
+}
+
+func agentOpsDaemonMutationPaths() []string {
+	return []string{
+		"/jobs",
+		"/v1/jobs",
+		"/jobs/cancel",
+		"/v1/jobs/cancel",
+		"/openclaw/v1/triggers/jobs",
+	}
+}
+
+func resolveAgentOpsDaemonMutationPolicy(token, tokenFile string) (daemonpkg.MutationPolicy, error) {
+	allowedPaths := agentOpsDaemonMutationPaths()
+	if tokenFile != "" {
+		tokens, err := daemonpkg.LoadMutationTokensFile(tokenFile)
+		if err != nil {
+			return daemonpkg.MutationPolicy{}, err
+		}
+		policy := daemonpkg.DefaultMutationPolicy("", allowedPaths)
+		policy.Tokens = tokens
+		return policy, nil
+	}
+	if token == "" {
+		return daemonpkg.DefaultMutationPolicy("", allowedPaths), nil
+	}
+	return daemonpkg.DefaultMutationPolicy(token, allowedPaths), nil
 }
 
 func resolveDaemonMutationToken(token, tokenFile string) (string, error) {

--- a/cli/cmd/ao/agentopsd_test.go
+++ b/cli/cmd/ao/agentopsd_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -262,6 +263,24 @@ func TestDaemonRunWorkerOnceCompletesWikiForgeFakeJob(t *testing.T) {
 func TestAgentOpsDaemonGasCityExecutorPolicyRequiresConfig(t *testing.T) {
 	if _, err := buildAgentOpsDaemonSupervisor(t.TempDir(), agentopsDaemonRunOptions{ExecutorPolicy: "gascity"}); err == nil {
 		t.Fatal("gascity executor policy without endpoint/city succeeded")
+	}
+}
+
+func TestResolveAgentOpsDaemonMutationPolicySupportsScopedTokenFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tokens.json")
+	data := `{"tokens":[{"name":"phone-readonly-submit","token":"phone-token","capabilities":["submit_job"]},{"name":"bushido-admin","token":"admin-token","capabilities":["admin"],"local_only":true}]}`
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("write scoped token file: %v", err)
+	}
+	policy, err := resolveAgentOpsDaemonMutationPolicy("", path)
+	if err != nil {
+		t.Fatalf("resolve policy: %v", err)
+	}
+	if len(policy.Tokens) != 2 || policy.Tokens[0].Name != "phone-readonly-submit" || policy.Token != "" {
+		t.Fatalf("policy = %#v", policy)
+	}
+	if policy.PathCapabilities["/v1/jobs"] != daemonpkg.MutationCapabilitySubmitJob {
+		t.Fatalf("path capabilities = %#v", policy.PathCapabilities)
 	}
 }
 

--- a/cli/internal/daemon/auth.go
+++ b/cli/internal/daemon/auth.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"crypto/subtle"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -23,16 +24,38 @@ var (
 
 type MutationPolicy struct {
 	Token              string
+	Tokens             []MutationToken
 	TokenHeader        string
 	AllowedPaths       []string
 	AllowedMethods     []string
+	PathCapabilities   map[string]MutationCapability
 	AllowedOrigins     []string
 	RequireLocalRemote bool
 }
 
 type MutationDecision struct {
-	Allowed bool   `json:"allowed"`
-	Reason  string `json:"reason,omitempty"`
+	Allowed            bool                 `json:"allowed"`
+	Reason             string               `json:"reason,omitempty"`
+	TokenName          string               `json:"token_name,omitempty"`
+	Capabilities       []MutationCapability `json:"capabilities,omitempty"`
+	RequiredCapability MutationCapability   `json:"required_capability,omitempty"`
+	LocalOnly          bool                 `json:"local_only,omitempty"`
+}
+
+type MutationCapability string
+
+const (
+	MutationCapabilitySubmitJob       MutationCapability = "submit_job"
+	MutationCapabilityCancelJob       MutationCapability = "cancel_job"
+	MutationCapabilityOpenClawTrigger MutationCapability = "openclaw_trigger"
+	MutationCapabilityAdmin           MutationCapability = "admin"
+)
+
+type MutationToken struct {
+	Name         string               `json:"name"`
+	Token        string               `json:"token"` // #nosec G101 -- config field name, not a hard-coded credential.
+	Capabilities []MutationCapability `json:"capabilities"`
+	LocalOnly    bool                 `json:"local_only,omitempty"`
 }
 
 func DefaultMutationPolicy(token string, allowedPaths []string) MutationPolicy {
@@ -41,19 +64,25 @@ func DefaultMutationPolicy(token string, allowedPaths []string) MutationPolicy {
 		TokenHeader:        DefaultMutationTokenHeader,
 		AllowedPaths:       allowedPaths,
 		AllowedMethods:     []string{http.MethodPost, http.MethodPatch, http.MethodDelete},
+		PathCapabilities:   DefaultMutationPathCapabilities(),
 		RequireLocalRemote: true,
 	}
 }
 
+func DefaultMutationPathCapabilities() map[string]MutationCapability {
+	return map[string]MutationCapability{
+		"/jobs":                         MutationCapabilitySubmitJob,
+		"/v1/jobs":                      MutationCapabilitySubmitJob,
+		"/jobs/cancel":                  MutationCapabilityCancelJob,
+		"/v1/jobs/cancel":               MutationCapabilityCancelJob,
+		"/openclaw/v1/triggers/jobs":    MutationCapabilityOpenClawTrigger,
+		"/v1/openclaw/triggers/jobs":    MutationCapabilityOpenClawTrigger,
+		"/v1/openclaw/v1/triggers/jobs": MutationCapabilityOpenClawTrigger,
+	}
+}
+
 func LoadMutationTokenFile(path string) (string, error) {
-	info, err := os.Stat(path)
-	if err != nil {
-		return "", err
-	}
-	if info.Mode().Perm()&0077 != 0 {
-		return "", fmt.Errorf("%w: %s has mode %o", ErrUnsafeTokenFileMode, path, info.Mode().Perm())
-	}
-	data, err := os.ReadFile(path)
+	data, err := readMutationTokenFile(path)
 	if err != nil {
 		return "", err
 	}
@@ -62,6 +91,51 @@ func LoadMutationTokenFile(path string) (string, error) {
 		return "", ErrMutationTokenMissing
 	}
 	return token, nil
+}
+
+func LoadMutationTokensFile(path string) ([]MutationToken, error) {
+	data, err := readMutationTokenFile(path)
+	if err != nil {
+		return nil, err
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return nil, ErrMutationTokenMissing
+	}
+	if !strings.HasPrefix(trimmed, "{") {
+		return []MutationToken{legacyMutationToken(trimmed)}, nil
+	}
+	var parsed struct {
+		Tokens []MutationToken `json:"tokens"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+		return nil, fmt.Errorf("parse scoped mutation token file: %w", err)
+	}
+	if len(parsed.Tokens) == 0 {
+		return nil, ErrMutationTokenMissing
+	}
+	for i := range parsed.Tokens {
+		normalizeMutationToken(&parsed.Tokens[i], fmt.Sprintf("token-%d", i+1))
+		if err := validateMutationToken(parsed.Tokens[i]); err != nil {
+			return nil, err
+		}
+	}
+	return parsed.Tokens, nil
+}
+
+func readMutationTokenFile(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode().Perm()&0077 != 0 {
+		return nil, fmt.Errorf("%w: %s has mode %o", ErrUnsafeTokenFileMode, path, info.Mode().Perm())
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
 }
 
 func ValidateLocalBindAddress(addr string) error {
@@ -79,11 +153,16 @@ func ValidateLocalBindAddress(addr string) error {
 }
 
 func AuthorizeMutation(r *http.Request, policy MutationPolicy) error {
+	_, err := AuthorizeMutationDecision(r, policy)
+	return err
+}
+
+func AuthorizeMutationDecision(r *http.Request, policy MutationPolicy) (MutationDecision, error) {
 	decision := EvaluateMutationPolicy(r, policy)
 	if decision.Allowed {
-		return nil
+		return decision, nil
 	}
-	return fmt.Errorf("%w: %s", ErrMutationDenied, decision.Reason)
+	return decision, fmt.Errorf("%w: %s", ErrMutationDenied, decision.Reason)
 }
 
 func EvaluateMutationPolicy(r *http.Request, policy MutationPolicy) MutationDecision {
@@ -93,7 +172,11 @@ func EvaluateMutationPolicy(r *http.Request, policy MutationPolicy) MutationDeci
 	if len(policy.AllowedMethods) == 0 {
 		policy.AllowedMethods = []string{http.MethodPost, http.MethodPatch, http.MethodDelete}
 	}
-	if strings.TrimSpace(policy.Token) == "" {
+	if len(policy.PathCapabilities) == 0 {
+		policy.PathCapabilities = DefaultMutationPathCapabilities()
+	}
+	tokens := normalizedMutationTokens(policy)
+	if len(tokens) == 0 {
 		return deny("mutation token not configured")
 	}
 	if !stringInSet(r.Method, policy.AllowedMethods) {
@@ -102,9 +185,12 @@ func EvaluateMutationPolicy(r *http.Request, policy MutationPolicy) MutationDeci
 	if len(policy.AllowedPaths) > 0 && !stringInSet(r.URL.Path, policy.AllowedPaths) {
 		return deny("path outside mutation scope")
 	}
+	required := policy.PathCapabilities[r.URL.Path]
+	if required == "" {
+		required = MutationCapabilityAdmin
+	}
 	if policy.RequireLocalRemote && r.RemoteAddr != "" {
-		host, _, err := net.SplitHostPort(r.RemoteAddr)
-		if err != nil || !isLoopbackHost(host) {
+		if !isLoopbackRemote(r.RemoteAddr) {
 			return deny("remote address is not local")
 		}
 	}
@@ -114,10 +200,23 @@ func EvaluateMutationPolicy(r *http.Request, policy MutationPolicy) MutationDeci
 	if fetchSite := strings.ToLower(strings.TrimSpace(r.Header.Get("Sec-Fetch-Site"))); fetchSite == "cross-site" {
 		return deny("browser fetch site is not trusted")
 	}
-	if !constantTimeTokenEqual(extractMutationToken(r, policy.TokenHeader), policy.Token) {
+	credential, ok := matchMutationToken(extractMutationToken(r, policy.TokenHeader), tokens)
+	if !ok {
 		return deny("mutation token mismatch")
 	}
-	return MutationDecision{Allowed: true}
+	if credential.LocalOnly && r.RemoteAddr != "" && !isLoopbackRemote(r.RemoteAddr) {
+		return deny("token requires local remote")
+	}
+	if !mutationTokenAllows(credential, required) {
+		return deny("token capability outside mutation scope")
+	}
+	return MutationDecision{
+		Allowed:            true,
+		TokenName:          credential.Name,
+		Capabilities:       append([]MutationCapability{}, credential.Capabilities...),
+		RequiredCapability: required,
+		LocalOnly:          credential.LocalOnly,
+	}
 }
 
 func extractMutationToken(r *http.Request, tokenHeader string) string {
@@ -137,6 +236,85 @@ func constantTimeTokenEqual(got, want string) bool {
 		return false
 	}
 	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+}
+
+func normalizedMutationTokens(policy MutationPolicy) []MutationToken {
+	tokens := append([]MutationToken{}, policy.Tokens...)
+	if strings.TrimSpace(policy.Token) != "" {
+		tokens = append(tokens, legacyMutationToken(policy.Token))
+	}
+	for i := range tokens {
+		normalizeMutationToken(&tokens[i], fmt.Sprintf("token-%d", i+1))
+	}
+	return tokens
+}
+
+func legacyMutationToken(token string) MutationToken {
+	return MutationToken{
+		Name:         "legacy",
+		Token:        token,
+		Capabilities: defaultMutationCapabilities(),
+		LocalOnly:    true,
+	}
+}
+
+func defaultMutationCapabilities() []MutationCapability {
+	return []MutationCapability{
+		MutationCapabilitySubmitJob,
+		MutationCapabilityCancelJob,
+		MutationCapabilityOpenClawTrigger,
+	}
+}
+
+func normalizeMutationToken(token *MutationToken, fallbackName string) {
+	token.Name = strings.TrimSpace(token.Name)
+	if token.Name == "" {
+		token.Name = fallbackName
+	}
+	token.Token = strings.TrimSpace(token.Token)
+	for i, capability := range token.Capabilities {
+		token.Capabilities[i] = MutationCapability(strings.TrimSpace(string(capability)))
+	}
+}
+
+func validateMutationToken(token MutationToken) error {
+	if strings.TrimSpace(token.Token) == "" {
+		return ErrMutationTokenMissing
+	}
+	if len(token.Capabilities) == 0 {
+		return fmt.Errorf("mutation token %q has no capabilities", token.Name)
+	}
+	for _, capability := range token.Capabilities {
+		switch capability {
+		case MutationCapabilitySubmitJob, MutationCapabilityCancelJob, MutationCapabilityOpenClawTrigger, MutationCapabilityAdmin:
+		default:
+			return fmt.Errorf("mutation token %q has unsupported capability %q", token.Name, capability)
+		}
+	}
+	return nil
+}
+
+func matchMutationToken(raw string, tokens []MutationToken) (MutationToken, bool) {
+	for _, token := range tokens {
+		if constantTimeTokenEqual(raw, token.Token) {
+			return token, true
+		}
+	}
+	return MutationToken{}, false
+}
+
+func mutationTokenAllows(token MutationToken, required MutationCapability) bool {
+	for _, capability := range token.Capabilities {
+		if capability == MutationCapabilityAdmin || capability == required {
+			return true
+		}
+	}
+	return false
+}
+
+func isLoopbackRemote(remoteAddr string) bool {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	return err == nil && isLoopbackHost(host)
 }
 
 func isLoopbackHost(host string) bool {

--- a/cli/internal/daemon/auth_test.go
+++ b/cli/internal/daemon/auth_test.go
@@ -75,6 +75,78 @@ func TestMutationPolicyRejectsOutOfScopeMutation(t *testing.T) {
 	}
 }
 
+func TestScopedMutationPolicyAllowsSubmitAndRejectsCancel(t *testing.T) {
+	policy := MutationPolicy{
+		Tokens: []MutationToken{{
+			Name:         "phone-readonly-submit",
+			Token:        "phone-token",
+			Capabilities: []MutationCapability{MutationCapabilitySubmitJob, MutationCapabilityOpenClawTrigger},
+		}},
+		AllowedPaths:       []string{"/v1/jobs", "/v1/jobs/cancel"},
+		AllowedMethods:     []string{http.MethodPost},
+		PathCapabilities:   DefaultMutationPathCapabilities(),
+		RequireLocalRemote: true,
+	}
+	req := mutationRequest(http.MethodPost, "/v1/jobs", "127.0.0.1:51111")
+	req.Header.Set(DefaultMutationTokenHeader, "phone-token")
+	decision, err := AuthorizeMutationDecision(req, policy)
+	if err != nil {
+		t.Fatalf("submit token rejected: %v", err)
+	}
+	if decision.TokenName != "phone-readonly-submit" || decision.RequiredCapability != MutationCapabilitySubmitJob {
+		t.Fatalf("decision = %#v, want phone submit", decision)
+	}
+	req = mutationRequest(http.MethodPost, "/v1/jobs/cancel", "127.0.0.1:51111")
+	req.Header.Set(DefaultMutationTokenHeader, "phone-token")
+	if err := AuthorizeMutation(req, policy); !errors.Is(err, ErrMutationDenied) {
+		t.Fatalf("phone cancel error = %v, want ErrMutationDenied", err)
+	}
+}
+
+func TestScopedMutationPolicyMacExecutorCanCancel(t *testing.T) {
+	policy := MutationPolicy{
+		Tokens: []MutationToken{{
+			Name:         "mac-executor",
+			Token:        "mac-token",
+			Capabilities: []MutationCapability{MutationCapabilitySubmitJob, MutationCapabilityCancelJob},
+		}},
+		AllowedPaths:       []string{"/v1/jobs/cancel"},
+		AllowedMethods:     []string{http.MethodPost},
+		PathCapabilities:   DefaultMutationPathCapabilities(),
+		RequireLocalRemote: true,
+	}
+	req := mutationRequest(http.MethodPost, "/v1/jobs/cancel", "127.0.0.1:51111")
+	req.Header.Set(DefaultMutationTokenHeader, "mac-token")
+	if err := AuthorizeMutation(req, policy); err != nil {
+		t.Fatalf("mac cancel rejected: %v", err)
+	}
+}
+
+func TestScopedMutationPolicyBushidoAdminLocalOnly(t *testing.T) {
+	policy := MutationPolicy{
+		Tokens: []MutationToken{{
+			Name:         "bushido-admin",
+			Token:        "admin-token",
+			Capabilities: []MutationCapability{MutationCapabilityAdmin},
+			LocalOnly:    true,
+		}},
+		AllowedPaths:       []string{"/v1/jobs/cancel"},
+		AllowedMethods:     []string{http.MethodPost},
+		PathCapabilities:   DefaultMutationPathCapabilities(),
+		RequireLocalRemote: false,
+	}
+	req := mutationRequest(http.MethodPost, "/v1/jobs/cancel", "192.168.1.10:51111")
+	req.Header.Set(DefaultMutationTokenHeader, "admin-token")
+	if err := AuthorizeMutation(req, policy); !errors.Is(err, ErrMutationDenied) {
+		t.Fatalf("remote admin error = %v, want ErrMutationDenied", err)
+	}
+	req = mutationRequest(http.MethodPost, "/v1/jobs/cancel", "127.0.0.1:51111")
+	req.Header.Set(DefaultMutationTokenHeader, "admin-token")
+	if err := AuthorizeMutation(req, policy); err != nil {
+		t.Fatalf("local admin rejected: %v", err)
+	}
+}
+
 func TestLocalhostBindAddressValidation(t *testing.T) {
 	for _, addr := range []string{"127.0.0.1:0", "localhost:8787", "[::1]:8787", "::1"} {
 		if err := ValidateLocalBindAddress(addr); err != nil {
@@ -111,6 +183,33 @@ func TestAuthTokenFilePermissions(t *testing.T) {
 	}
 	if _, err := LoadMutationTokenFile(insecure); !errors.Is(err, ErrUnsafeTokenFileMode) {
 		t.Fatalf("load insecure token error = %v, want ErrUnsafeTokenFileMode", err)
+	}
+}
+
+func TestLoadMutationTokensFileSupportsLegacyAndScopedJSON(t *testing.T) {
+	dir := t.TempDir()
+	legacy := filepath.Join(dir, "legacy-token")
+	if err := os.WriteFile(legacy, []byte("legacy-token\n"), 0o600); err != nil {
+		t.Fatalf("write legacy token: %v", err)
+	}
+	tokens, err := LoadMutationTokensFile(legacy)
+	if err != nil {
+		t.Fatalf("load legacy token: %v", err)
+	}
+	if len(tokens) != 1 || tokens[0].Name != "legacy" || tokens[0].Token != "legacy-token" || !tokens[0].LocalOnly {
+		t.Fatalf("legacy tokens = %#v", tokens)
+	}
+	scoped := filepath.Join(dir, "scoped-token")
+	payload := `{"tokens":[{"name":"phone-readonly-submit","token":"phone-token","capabilities":["submit_job","openclaw_trigger"]},{"name":"bushido-admin","token":"admin-token","capabilities":["admin"],"local_only":true}]}`
+	if err := os.WriteFile(scoped, []byte(payload), 0o600); err != nil {
+		t.Fatalf("write scoped token: %v", err)
+	}
+	tokens, err = LoadMutationTokensFile(scoped)
+	if err != nil {
+		t.Fatalf("load scoped token: %v", err)
+	}
+	if len(tokens) != 2 || tokens[0].Name != "phone-readonly-submit" || tokens[1].Name != "bushido-admin" || !tokens[1].LocalOnly {
+		t.Fatalf("scoped tokens = %#v", tokens)
 	}
 }
 

--- a/cli/internal/daemon/server.go
+++ b/cli/internal/daemon/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/boshu2/agentops/cli/internal/openclaw"
@@ -282,7 +283,8 @@ func (s *ReadOnlyServer) handleOpenClawTriggerJob(w http.ResponseWriter, r *http
 		return
 	}
 	policy := s.mutationPolicy()
-	if err := AuthorizeMutation(r, policy); err != nil {
+	decision, err := AuthorizeMutationDecision(r, policy)
+	if err != nil {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
 		return
 	}
@@ -315,7 +317,7 @@ func (s *ReadOnlyServer) handleOpenClawTriggerJob(w http.ResponseWriter, r *http
 		JobID:          req.JobID,
 		JobType:        jobType,
 		IdempotencyKey: req.IdempotencyKey,
-		Actor:          "openclaw-trigger",
+		Actor:          mutationActor("openclaw-trigger", decision),
 		Payload:        req.Payload,
 	}, QueueMutationOptions{Failpoint: queueFailpointFromRequest(r)})
 	if err != nil {
@@ -348,7 +350,8 @@ func (s *ReadOnlyServer) handleSubmitJob(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	policy := s.mutationPolicy()
-	if err := AuthorizeMutation(r, policy); err != nil {
+	decision, err := AuthorizeMutationDecision(r, policy)
+	if err != nil {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
 		return
 	}
@@ -363,7 +366,7 @@ func (s *ReadOnlyServer) handleSubmitJob(w http.ResponseWriter, r *http.Request)
 		JobID:          req.JobID,
 		JobType:        req.JobType,
 		IdempotencyKey: req.IdempotencyKey,
-		Actor:          "ao-http",
+		Actor:          mutationActor("ao-http", decision),
 		Payload:        req.Payload,
 	}, QueueMutationOptions{Failpoint: queueFailpointFromRequest(r)})
 	if err != nil {
@@ -411,7 +414,8 @@ func (s *ReadOnlyServer) handleCancelJob(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	policy := s.mutationPolicy()
-	if err := AuthorizeMutation(r, policy); err != nil {
+	decision, err := AuthorizeMutationDecision(r, policy)
+	if err != nil {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
 		return
 	}
@@ -424,7 +428,7 @@ func (s *ReadOnlyServer) handleCancelJob(w http.ResponseWriter, r *http.Request)
 	cancelled, err := queue.CancelJob(CancelJobInput{
 		RequestID: RequestID(req.RequestID),
 		JobID:     req.JobID,
-		Actor:     "ao-http",
+		Actor:     mutationActor("ao-http", decision),
 		Reason:    req.Reason,
 	}, QueueMutationOptions{Failpoint: queueFailpointFromRequest(r)})
 	if err != nil {
@@ -627,6 +631,13 @@ func (s *ReadOnlyServer) mutationPolicy() MutationPolicy {
 	}
 	policy.RequireLocalRemote = true
 	return policy
+}
+
+func mutationActor(base string, decision MutationDecision) string {
+	if strings.TrimSpace(decision.TokenName) == "" {
+		return base
+	}
+	return base + ":" + sanitizeIDPart(decision.TokenName)
 }
 
 func openClawTriggerAllowedJobType(jobType JobType) bool {

--- a/cli/internal/daemon/server_mutation_test.go
+++ b/cli/internal/daemon/server_mutation_test.go
@@ -53,6 +53,33 @@ func TestMutationRouteAcceptsJobAfterLedgerAppend(t *testing.T) {
 	}
 }
 
+func TestMutationRouteAuditsScopedTokenName(t *testing.T) {
+	now := projectionTestTime(t, 0)
+	store := NewStore(t.TempDir())
+	policy := DefaultMutationPolicy("", []string{"/v1/jobs", "/v1/jobs/cancel"})
+	policy.Tokens = []MutationToken{{
+		Name:         "phone-readonly-submit",
+		Token:        "phone-token",
+		Capabilities: []MutationCapability{MutationCapabilitySubmitJob},
+	}}
+	router := mutationRouterWithPolicy(store, &now, policy)
+	resp := postJob(t, router, `{"request_id":"req-1","job_id":"job-rpi","job_type":"rpi.run"}`, "phone-token", "")
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("scoped submit status = %d body=%s, want 202", resp.Code, resp.Body.String())
+	}
+	events, err := store.ReadLedger()
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	if len(events) != 1 || events[0].Actor != "ao-http:phone-readonly-submit" {
+		t.Fatalf("ledger events = %#v, want scoped actor", events)
+	}
+	resp = postCancel(t, router, `{"request_id":"req-cancel","job_id":"job-rpi"}`, "phone-token", "")
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("scoped cancel status = %d body=%s, want 403", resp.Code, resp.Body.String())
+	}
+}
+
 func TestMutationAckFailpointBeforeAppendNoSideEffect(t *testing.T) {
 	now := projectionTestTime(t, 0)
 	store := NewStore(t.TempDir())
@@ -129,18 +156,38 @@ func TestMutationProjectionFailpointStillAcknowledgesAcceptedJob(t *testing.T) {
 
 func mutationRouter(t *testing.T, store *Store, now *time.Time) http.Handler {
 	t.Helper()
+	return mutationRouterWithPolicy(store, now, DefaultMutationPolicy("secret-token", []string{
+		"/v1/jobs",
+		"/jobs",
+	}))
+}
+
+func mutationRouterWithPolicy(store *Store, now *time.Time, policy MutationPolicy) http.Handler {
 	return NewDaemonRouter(store, ServerOptions{
-		Now: func() time.Time { return *now },
-		MutationPolicy: DefaultMutationPolicy("secret-token", []string{
-			"/v1/jobs",
-			"/jobs",
-		}),
+		Now:            func() time.Time { return *now },
+		MutationPolicy: policy,
 	})
 }
 
 func postJob(t *testing.T, handler http.Handler, payload, token, failpoint string) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodPost, "/v1/jobs", bytes.NewBufferString(payload))
+	req.RemoteAddr = "127.0.0.1:51111"
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set(DefaultMutationTokenHeader, token)
+	}
+	if failpoint != "" {
+		req.Header.Set("X-AgentOps-Failpoint", failpoint)
+	}
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	return resp
+}
+
+func postCancel(t *testing.T, handler http.Handler, payload, token, failpoint string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/cancel", bytes.NewBufferString(payload))
 	req.RemoteAddr = "127.0.0.1:51111"
 	req.Header.Set("Content-Type", "application/json")
 	if token != "" {

--- a/docs/contracts/agentops-daemon.md
+++ b/docs/contracts/agentops-daemon.md
@@ -223,12 +223,45 @@ The required controls are:
 - load token files only when group/other permission bits are not set
 - reject mutation requests whose method or path is outside the allowlist for
   that route group
+- scope accepted tokens by route capability. Plaintext token files remain
+  supported as legacy local-only tokens with the current mutation scope.
+  JSON token files may provide multiple credentials:
+
+  ```json
+  {
+    "tokens": [
+      {
+        "name": "phone-readonly-submit",
+        "token": "<secret>",
+        "capabilities": ["submit_job", "openclaw_trigger"]
+      },
+      {
+        "name": "mac-executor",
+        "token": "<secret>",
+        "capabilities": ["submit_job", "cancel_job", "openclaw_trigger"]
+      },
+      {
+        "name": "bushido-admin",
+        "token": "<secret>",
+        "capabilities": ["admin"],
+        "local_only": true
+      }
+    ]
+  }
+  ```
+
+  `submit_job` covers `/jobs` and `/v1/jobs`, `cancel_job` covers
+  `/jobs/cancel` and `/v1/jobs/cancel`, and `openclaw_trigger` covers
+  `/openclaw/v1/triggers/jobs`. `admin` satisfies all currently allowlisted
+  daemon mutation capabilities but does not bypass the path allowlist.
 - reject untrusted `Origin` headers and `Sec-Fetch-Site: cross-site` requests
   even when they are sent from a local browser context
 
 Read-only health/status routes may remain easier to inspect locally, but every
 route that appends to the ledger must pass this mutation policy before the
-append is attempted.
+append is attempted. Accepted mutation events include the token profile name in
+the ledger actor label, e.g. `ao-http:phone-readonly-submit`, so scoped-token
+use is auditable during incident review.
 
 ## External Systems
 


### PR DESCRIPTION
## Summary
- add scoped daemon mutation tokens with route capabilities for submit_job, cancel_job, openclaw_trigger, and admin
- support JSON token files with multiple named credentials while preserving legacy plaintext token files
- enforce per-token local_only so bushido-admin remains local-only even under future non-local policies
- include the accepted token profile in ledger actor labels for auditability
- document scoped token file format and capability semantics in the daemon contract

## Pre-mortem
- quick pre-mortem completed: .agents/council/2026-04-30-pre-mortem-soc-5of-10-scoped-mutation-tokens.md
- verdict: WARN/proceed with constraints; no push/shell/key-rotation routes added

## Validation
- go test ./internal/daemon ./cmd/ao -run 'TestAuth|TestMutationPolicy|TestScopedMutationPolicy|TestLoadMutationTokensFile|TestMutationRouteAuditsScopedTokenName|TestResolveAgentOpsDaemonMutationPolicySupportsScopedTokenFile|TestOpenClawTrigger|TestDaemonJobsCancelStaticRouteUsesMutationPolicy|TestCobraConformance|TestCobraExpectedCmdsMatchRegistration'
- go test ./internal/daemon ./cmd/ao
- ./scripts/generate-cli-reference.sh --check
- git diff --check
- git push pre-push fast gate passed

Bead: soc-5of.10