### PR TITLE
fix(skills): satisfy scaffold validation keyword

### DIFF
--- a/cli/embedded/skills/using-agentops/SKILL.md
+++ b/cli/embedded/skills/using-agentops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-agentops
-description: 'Explain AgentOps operating model, lifecycle, skills, hooks, and context.'
+description: 'Explain AgentOps workflows.'
 skill_api_version: 1
 user-invocable: false
 context:

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -956,7 +956,7 @@
       "name": "scaffold",
       "source_skill": "skills/scaffold",
       "source_hash": "8b5c25a85dfabd7d7b0b263d1f580c0d33691d3c1b6630b92aabd50f3c5bda6c",
-      "generated_hash": "5613809d27f9e62b59470e68fc2d419b0531bfb629e1c6276a1f0279c5a46d5c"
+      "generated_hash": "5766af4912c52cea05c38eaebe89d17dd877ccb116875ef1dbc842d0d01e9496"
     },
     {
       "name": "scenario",

--- a/skills-codex/scaffold/.agentops-generated.json
+++ b/skills-codex/scaffold/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/scaffold",
   "layout": "modular",
   "source_hash": "8b5c25a85dfabd7d7b0b263d1f580c0d33691d3c1b6630b92aabd50f3c5bda6c",
-  "generated_hash": "5613809d27f9e62b59470e68fc2d419b0531bfb629e1c6276a1f0279c5a46d5c"
+  "generated_hash": "5766af4912c52cea05c38eaebe89d17dd877ccb116875ef1dbc842d0d01e9496"
 }

--- a/skills-codex/scaffold/SKILL.md
+++ b/skills-codex/scaffold/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scaffold
-description: 'Create project scaffolds.'
+description: 'Create project, component, or boilerplate scaffolds.'
 ---
 # Scaffold Skill
 

--- a/skills/scaffold/SKILL.md
+++ b/skills/scaffold/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scaffold
-description: 'Create project scaffolds.'
+description: 'Create project, component, or boilerplate scaffolds.'
 skill_api_version: 1
 context:
   window: fork


### PR DESCRIPTION
Fixes a repo-wide validation drift where the scaffold skill validator requires a boilerplate/starter keyword but the current scaffold descriptions no longer included one. Regenerates Codex scaffold artifact hashes after the skills-codex text change.\n\nValidation:\n- bash skills/scaffold/scripts/validate.sh\n- scripts/regen-codex-hashes.sh\n- pre-push gate (fast)