### PR TITLE
feat(daemon): bound ledger growth via size-cap rotation + archive-aware replay

### DIFF
--- a/cli/internal/daemon/store.go
+++ b/cli/internal/daemon/store.go
@@ -2,11 +2,15 @@ package daemon
 
 import (
 	"bufio"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -15,10 +19,23 @@ const (
 	LedgerFileName      = "ledger.jsonl"
 	QuarantineDirName   = "quarantine"
 	LedgerSchemaVersion = 1
+	// DefaultLedgerMaxBytes is the size threshold at which ledger.jsonl is
+	// rotated. Operators may override via Store.WithLedgerMaxBytes.
+	DefaultLedgerMaxBytes int64 = 50 * 1024 * 1024
+	// ledgerArchivePrefix is the filename prefix for rotated ledger archives.
+	// Format: ledger.<RFC3339-no-colons>.jsonl[.gz].
+	ledgerArchivePrefix = "ledger."
+	ledgerArchiveSuffix = ".jsonl"
 )
 
+// Store persists daemon ledger events to ~/<root>/.agents/daemon/ledger.jsonl.
+// Concurrent writers are serialized through s.mu; readers (Replay*) operate on
+// committed file contents and do not contend for the lock — O_APPEND atomicity
+// covers per-line consistency.
 type Store struct {
-	root string
+	root           string
+	mu             sync.Mutex
+	ledgerMaxBytes int64
 }
 
 type LedgerEvent struct {
@@ -44,7 +61,16 @@ type CorruptRecord struct {
 }
 
 func NewStore(root string) *Store {
-	return &Store{root: root}
+	return &Store{root: root, ledgerMaxBytes: DefaultLedgerMaxBytes}
+}
+
+// WithLedgerMaxBytes overrides the rotation threshold and returns the store
+// for fluent configuration. Pass <=0 to disable rotation entirely.
+func (s *Store) WithLedgerMaxBytes(n int64) *Store {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ledgerMaxBytes = n
+	return s
 }
 
 func (s *Store) Dir() string {
@@ -59,20 +85,42 @@ func (s *Store) QuarantineDir() string {
 	return filepath.Join(s.Dir(), QuarantineDirName)
 }
 
+// LedgerArchivePaths returns the rotated ledger archives in chronological
+// order (oldest first). Each path is one of ledger.<ts>.jsonl[.gz]; the
+// active ledger.jsonl is excluded.
+func (s *Store) LedgerArchivePaths() ([]string, error) {
+	entries, err := os.ReadDir(s.Dir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read store dir: %w", err)
+	}
+	var archives []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name == LedgerFileName {
+			continue
+		}
+		if !strings.HasPrefix(name, ledgerArchivePrefix) {
+			continue
+		}
+		if !strings.HasSuffix(name, ledgerArchiveSuffix) && !strings.HasSuffix(name, ledgerArchiveSuffix+".gz") {
+			continue
+		}
+		archives = append(archives, filepath.Join(s.Dir(), name))
+	}
+	sort.Strings(archives)
+	return archives, nil
+}
+
 func (s *Store) AppendLedgerEvent(event LedgerEvent) (LedgerEvent, error) {
 	event, err := NormalizeLedgerEvent(event)
 	if err != nil {
 		return LedgerEvent{}, err
-	}
-
-	replay, err := s.ReplayLedger()
-	if err != nil {
-		return LedgerEvent{}, err
-	}
-	for _, existing := range replay.Events {
-		if existing.EventID == event.EventID {
-			return existing, nil
-		}
 	}
 
 	if err := os.MkdirAll(s.Dir(), 0700); err != nil {
@@ -82,18 +130,124 @@ func (s *Store) AppendLedgerEvent(event LedgerEvent) (LedgerEvent, error) {
 	if err != nil {
 		return LedgerEvent{}, fmt.Errorf("marshal ledger event: %w", err)
 	}
+	line := append(data, '\n')
+
+	// Serialize the dedup pre-check, rotation decision, and write together so
+	// concurrent writers don't observe a half-rotated state nor write the same
+	// EventID twice. Replay outside the lock would race with rotation.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	replay, err := s.replayLedger(true)
+	if err != nil {
+		return LedgerEvent{}, err
+	}
+	for _, existing := range replay.Events {
+		if existing.EventID == event.EventID {
+			return existing, nil
+		}
+	}
+
+	if err := s.maybeRotate(int64(len(line))); err != nil {
+		return LedgerEvent{}, err
+	}
+
 	file, err := os.OpenFile(s.LedgerPath(), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		return LedgerEvent{}, fmt.Errorf("open ledger: %w", err)
 	}
 	defer file.Close()
-	if _, err := file.Write(append(data, '\n')); err != nil {
+	if _, err := file.Write(line); err != nil {
 		return LedgerEvent{}, fmt.Errorf("append ledger: %w", err)
 	}
 	if err := file.Sync(); err != nil {
 		return LedgerEvent{}, fmt.Errorf("sync ledger: %w", err)
 	}
 	return event, nil
+}
+
+// maybeRotate is called with s.mu held. It checks the current ledger size
+// and rotates if appending pendingBytes would push it past the threshold.
+func (s *Store) maybeRotate(pendingBytes int64) error {
+	if s.ledgerMaxBytes <= 0 {
+		return nil
+	}
+	info, err := os.Stat(s.LedgerPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat ledger: %w", err)
+	}
+	if info.Size()+pendingBytes <= s.ledgerMaxBytes {
+		return nil
+	}
+	return s.rotateLedger()
+}
+
+// rotateLedger atomically renames ledger.jsonl to a timestamped archive and
+// gzip-compresses it. A fresh ledger.jsonl is created implicitly on the next
+// append. Caller must hold s.mu.
+func (s *Store) rotateLedger() error {
+	timestamp := time.Now().UTC().Format("20060102T150405.000000000Z")
+	archive := filepath.Join(s.Dir(), ledgerArchivePrefix+timestamp+ledgerArchiveSuffix)
+	if err := os.Rename(s.LedgerPath(), archive); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("rotate ledger: rename: %w", err)
+	}
+	if err := gzipFileInPlace(archive); err != nil {
+		// Compression failure leaves the .jsonl archive in place; replay still
+		// reads it (LedgerArchivePaths accepts both extensions).
+		return fmt.Errorf("rotate ledger: gzip: %w", err)
+	}
+	return nil
+}
+
+// gzipFileInPlace compresses src to src+".gz" atomically: writes the gzip
+// stream to a sibling tmp file, fsyncs and closes it, then renames it onto the
+// final ".gz" path so concurrent readers never observe a partial gzip stream.
+// The uncompressed src is removed only after the rename succeeds.
+func gzipFileInPlace(src string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	dst := src + ".gz"
+	tmp := dst + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	zw := gzip.NewWriter(out)
+	if _, err := io.Copy(zw, in); err != nil {
+		_ = zw.Close()
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := zw.Close(); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := out.Sync(); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, dst); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return os.Remove(src)
 }
 
 func (s *Store) ReadLedger() ([]LedgerEvent, error) {
@@ -112,33 +266,66 @@ func (s *Store) ReplayLedgerReadOnly() (ReplayResult, error) {
 	return s.replayLedger(false)
 }
 
+// replayLedger walks rotated archives oldest-first then the current ledger,
+// dedup by EventID across the entire chain so rotation is invisible to readers.
 func (s *Store) replayLedger(quarantine bool) (ReplayResult, error) {
-	file, err := os.Open(s.LedgerPath())
+	archives, err := s.LedgerArchivePaths()
+	if err != nil {
+		return ReplayResult{}, err
+	}
+
+	var result ReplayResult
+	seen := map[string]struct{}{}
+	lineCounter := 0
+
+	for _, archive := range archives {
+		if err := s.replayLedgerFile(archive, &lineCounter, seen, &result, quarantine); err != nil {
+			return result, err
+		}
+	}
+	if err := s.replayLedgerFile(s.LedgerPath(), &lineCounter, seen, &result, quarantine); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+// replayLedgerFile reads a single ledger file (current or archive) and appends
+// valid events to result.Events. Deduplication is shared across calls via seen.
+func (s *Store) replayLedgerFile(path string, lineCounter *int, seen map[string]struct{}, result *ReplayResult, quarantine bool) error {
+	file, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return ReplayResult{}, nil
+			return nil
 		}
-		return ReplayResult{}, fmt.Errorf("open ledger: %w", err)
+		return fmt.Errorf("open ledger %s: %w", filepath.Base(path), err)
 	}
 	defer file.Close()
 
-	var result ReplayResult
-	scanner := bufio.NewScanner(file)
-	lineNumber := 0
-	seen := map[string]struct{}{}
+	var reader io.Reader = file
+	if strings.HasSuffix(path, ".gz") {
+		zr, err := gzip.NewReader(file)
+		if err != nil {
+			return fmt.Errorf("open gzip archive %s: %w", filepath.Base(path), err)
+		}
+		defer zr.Close()
+		reader = zr
+	}
+
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
-		lineNumber++
+		*lineCounter++
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
 			continue
 		}
 		var event LedgerEvent
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			result.Corrupt = append(result.Corrupt, s.corruptRecord(lineNumber, line, err, quarantine))
+			result.Corrupt = append(result.Corrupt, s.corruptRecord(*lineCounter, line, err, quarantine))
 			continue
 		}
 		if err := ValidateLedgerEvent(event); err != nil {
-			result.Corrupt = append(result.Corrupt, s.corruptRecord(lineNumber, line, err, quarantine))
+			result.Corrupt = append(result.Corrupt, s.corruptRecord(*lineCounter, line, err, quarantine))
 			continue
 		}
 		if _, ok := seen[event.EventID]; ok {
@@ -148,9 +335,9 @@ func (s *Store) replayLedger(quarantine bool) (ReplayResult, error) {
 		result.Events = append(result.Events, event)
 	}
 	if err := scanner.Err(); err != nil {
-		return result, fmt.Errorf("scan ledger: %w", err)
+		return fmt.Errorf("scan ledger %s: %w", filepath.Base(path), err)
 	}
-	return result, nil
+	return nil
 }
 
 func ValidateLedgerEvent(event LedgerEvent) error {

--- a/cli/internal/daemon/store_test.go
+++ b/cli/internal/daemon/store_test.go
@@ -2,9 +2,11 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -206,4 +208,147 @@ func mustLedgerLine(t *testing.T, event LedgerEvent) string {
 		t.Fatalf("marshal ledger fixture: %v", err)
 	}
 	return string(data)
+}
+
+// TestLedgerRotation drives the size-cap path: append enough events that the
+// active ledger crosses the configured threshold, assert that an archive
+// appears, the active file shrinks, and ReplayLedger still returns every event
+// in append order across the rotation boundary.
+func TestLedgerRotation(t *testing.T) {
+	store := NewStore(t.TempDir()).WithLedgerMaxBytes(1024)
+
+	const totalEvents = 30
+	for i := 0; i < totalEvents; i++ {
+		ev := testLedgerEvent(fmt.Sprintf("evt-%03d", i), EventJobAccepted)
+		if _, err := store.AppendLedgerEvent(ev); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+
+	archives, err := store.LedgerArchivePaths()
+	if err != nil {
+		t.Fatalf("list archives: %v", err)
+	}
+	if len(archives) == 0 {
+		t.Fatalf("expected at least one archive after %d appends, got 0", totalEvents)
+	}
+	for _, a := range archives {
+		if !strings.HasSuffix(a, ".jsonl.gz") {
+			t.Fatalf("archive %s missing .jsonl.gz suffix", a)
+		}
+	}
+
+	info, err := os.Stat(store.LedgerPath())
+	if err != nil {
+		t.Fatalf("stat active ledger: %v", err)
+	}
+	if info.Size() > 1024 {
+		t.Fatalf("active ledger size %d > cap 1024 after rotation", info.Size())
+	}
+
+	events, err := store.ReadLedger()
+	if err != nil {
+		t.Fatalf("read ledger across archives: %v", err)
+	}
+	if len(events) != totalEvents {
+		t.Fatalf("read %d events, want %d (rotation lost data)", len(events), totalEvents)
+	}
+	for i, ev := range events {
+		want := fmt.Sprintf("evt-%03d", i)
+		if ev.EventID != want {
+			t.Fatalf("events[%d].EventID = %q, want %q (rotation reordered)", i, ev.EventID, want)
+		}
+	}
+}
+
+// TestRotateWhileAppendingDoesNotLoseEvents stresses the lock contract:
+// concurrent appends across multiple goroutines must produce a complete,
+// deduplicated event stream after replay even when rotation triggers
+// repeatedly mid-flight.
+func TestRotateWhileAppendingDoesNotLoseEvents(t *testing.T) {
+	store := NewStore(t.TempDir()).WithLedgerMaxBytes(512)
+
+	const writers = 4
+	const perWriter = 25
+	totalUnique := writers * perWriter
+
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for w := 0; w < writers; w++ {
+		w := w
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				ev := testLedgerEvent(fmt.Sprintf("w%d-%03d", w, i), EventJobAccepted)
+				if _, err := store.AppendLedgerEvent(ev); err != nil {
+					t.Errorf("writer %d append %d: %v", w, i, err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	archives, err := store.LedgerArchivePaths()
+	if err != nil {
+		t.Fatalf("list archives: %v", err)
+	}
+	if len(archives) == 0 {
+		t.Fatalf("rotation never fired during concurrent stress")
+	}
+
+	events, err := store.ReadLedger()
+	if err != nil {
+		t.Fatalf("replay after concurrent appends: %v", err)
+	}
+	if len(events) != totalUnique {
+		t.Fatalf("replayed %d events, want %d (concurrent rotation lost data)", len(events), totalUnique)
+	}
+	seen := map[string]struct{}{}
+	for _, ev := range events {
+		if _, dup := seen[ev.EventID]; dup {
+			t.Fatalf("duplicate event ID after rotation+replay: %s", ev.EventID)
+		}
+		seen[ev.EventID] = struct{}{}
+	}
+}
+
+// TestReplayReadsArchivesInChronologicalOrder seeds two pre-rotated archive
+// files plus a current ledger and asserts replay yields events in the
+// archive-then-current order — protects against alphabetical re-sort regressions.
+func TestReplayReadsArchivesInChronologicalOrder(t *testing.T) {
+	store := NewStore(t.TempDir()).WithLedgerMaxBytes(0) // rotation disabled
+	if err := os.MkdirAll(store.Dir(), 0700); err != nil {
+		t.Fatalf("create dir: %v", err)
+	}
+
+	old := mustLedgerLine(t, testLedgerEvent("old-1", EventJobAccepted))
+	mid := mustLedgerLine(t, testLedgerEvent("mid-1", EventJobClaimed))
+	current := mustLedgerLine(t, testLedgerEvent("now-1", EventJobCompleted))
+
+	oldPath := filepath.Join(store.Dir(), "ledger.20260101T000000.000000000Z.jsonl")
+	midPath := filepath.Join(store.Dir(), "ledger.20260201T000000.000000000Z.jsonl")
+	if err := os.WriteFile(oldPath, []byte(old+"\n"), 0600); err != nil {
+		t.Fatalf("write old archive: %v", err)
+	}
+	if err := os.WriteFile(midPath, []byte(mid+"\n"), 0600); err != nil {
+		t.Fatalf("write mid archive: %v", err)
+	}
+	if err := os.WriteFile(store.LedgerPath(), []byte(current+"\n"), 0600); err != nil {
+		t.Fatalf("write current ledger: %v", err)
+	}
+
+	events, err := store.ReadLedger()
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("got %d events across archives, want 3", len(events))
+	}
+	wantOrder := []string{"old-1", "mid-1", "now-1"}
+	for i, want := range wantOrder {
+		if events[i].EventID != want {
+			t.Fatalf("events[%d].EventID = %q, want %q", i, events[i].EventID, want)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Bounds growth of the daemon ledger by adding size-cap rotation in `cli/internal/daemon/store.go` (+231 LOC), plus archive-aware replay so historical events still resolve after rotation.
- Companion test coverage in `cli/internal/daemon/store_test.go` (+145 LOC).
- Single commit; clean against `main` modulo whatever drift has accumulated since 2026-04-30.

## Test plan

- [ ] CI: validate.yml green (go-cli-tests covers daemon/store)
- [ ] Verify rotation thresholds against expected ledger sizes
- [ ] Replay test passes after archived rotation