### PR TITLE
fix(skills): remove duplicate scope-predicate ref in pre-mortem SKILL.md

### DIFF
--- a/skills/pre-mortem/SKILL.md
+++ b/skills/pre-mortem/SKILL.md
@@ -220,5 +220,4 @@ See [references/examples.md](references/examples.md) for the troubleshooting tab
 - [references/prediction-tracking.md](references/prediction-tracking.md)
 - [references/spec-verification-checklist.md](references/spec-verification-checklist.md)
 - [references/temporal-interrogation.md](references/temporal-interrogation.md)
-- [references/scope-predicate-positive-negative-cases.md](references/scope-predicate-positive-negative-cases.md)
 - Shared stale-scope validation rule — re-validate inherited scope estimates against HEAD before acting on deferred beads or handoff docs.


### PR DESCRIPTION
## Summary

`skills/pre-mortem/SKILL.md` had the same reference link on lines 212 and 223. `heal --strict` reports `DUPLICATE_REF` and the `skill-integrity` gate fails on every PR until this is fixed. Removes the line-223 dupe (line 212 is in the logical position after `mandatory-checks`).

This unblocks PRs #214 and #215.

## Test plan

- [x] `bash skills/heal-skill/scripts/heal.sh --strict` — `All clean. No findings.`
- [ ] CI: `skill-integrity` green