### PR TITLE
feat(ci): enforce inner/middle/outer loop boundaries

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,63 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+      skills: ${{ steps.filter.outputs.skills }}
+      hooks: ${{ steps.filter.outputs.hooks }}
+      docs: ${{ steps.filter.outputs.docs }}
+      eval: ${{ steps.filter.outputs.eval }}
+      codex: ${{ steps.filter.outputs.codex }}
+      shell: ${{ steps.filter.outputs.shell }}
+      ci: ${{ steps.filter.outputs.ci }}
+      contracts: ${{ steps.filter.outputs.contracts }}
+      learning: ${{ steps.filter.outputs.learning }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            go:
+              - 'cli/**'
+              - 'go.mod'
+              - 'go.sum'
+            skills:
+              - 'skills/**'
+              - 'skills-codex/**'
+              - 'skills-codex-overrides/**'
+              - 'tests/skills/**'
+            hooks:
+              - 'hooks/**'
+              - 'lib/**'
+              - 'cli/embedded/**'
+            docs:
+              - 'docs/**'
+              - 'README.md'
+              - 'CHANGELOG.md'
+              - 'PRODUCT.md'
+              - 'SKILL-TIERS.md'
+            eval:
+              - 'evals/**'
+              - 'cli/internal/eval/**'
+              - 'cli/cmd/ao/eval*'
+              - 'schemas/eval-*'
+            codex:
+              - 'skills-codex/**'
+              - 'skills-codex-overrides/**'
+            shell:
+              - '**/*.sh'
+              - 'scripts/**'
+            ci:
+              - '.github/**'
+            contracts:
+              - 'schemas/**'
+              - 'docs/contracts/**'
+            learning:
+              - '.agents/learnings/**'
+
   doc-release-gate:
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +111,8 @@ jobs:
           ./scripts/check-pre-push-gate-wired.sh --dry-run-smoke
 
   agentops-eval-baseline-audit:
+    needs: [changes]
+    if: needs.changes.outputs.eval == 'true' || needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true'
     name: agentops-eval-baseline-audit (required)
     runs-on: ubuntu-latest
     steps:
@@ -138,6 +197,8 @@ jobs:
   # bundle checks removed — skills-codex/ is manually maintained. Audit drift with
   # scripts/audit-codex-parity.sh.
   validate-codex-runtime-sections:
+    needs: [changes]
+    if: needs.changes.outputs.codex == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -148,6 +209,8 @@ jobs:
           ./scripts/validate-codex-runtime-sections.sh
 
   validate-codex-generated-artifacts:
+    needs: [changes]
+    if: needs.changes.outputs.codex == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -158,6 +221,8 @@ jobs:
           ./scripts/validate-codex-generated-artifacts.sh --scope head
 
   validate-codex-backbone-prompts:
+    needs: [changes]
+    if: needs.changes.outputs.codex == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -168,6 +233,8 @@ jobs:
           ./scripts/validate-codex-backbone-prompts.sh
 
   validate-codex-override-coverage:
+    needs: [changes]
+    if: needs.changes.outputs.codex == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -178,6 +245,8 @@ jobs:
           ./scripts/validate-codex-override-coverage.sh
 
   validate-codex-rpi-contract:
+    needs: [changes]
+    if: needs.changes.outputs.codex == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -187,6 +256,8 @@ jobs:
           bash scripts/validate-codex-rpi-contract.sh
 
   validate-codex-lifecycle-guards:
+    needs: [changes]
+    if: needs.changes.outputs.codex == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -280,6 +351,8 @@ jobs:
           scripts/test-agentops-contract-canaries.sh
 
   eval-workbench-verify:
+    needs: [changes]
+    if: needs.changes.outputs.eval == 'true' || needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true'
     name: eval-workbench-verify (required)
     runs-on: ubuntu-latest
     steps:
@@ -309,6 +382,8 @@ jobs:
           bash scripts/check-eval-workbench.sh
 
   agentops-eval-advisory:
+    needs: [changes]
+    if: needs.changes.outputs.eval == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.ci == 'true'
     name: agentops-eval-advisory (advisory)
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -344,6 +419,8 @@ jobs:
           ./scripts/eval-agentops.sh --fast
 
   eval-skill-delta:
+    needs: [changes]
+    if: needs.changes.outputs.eval == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.ci == 'true'
     name: eval-skill-delta (structural gate)
     runs-on: ubuntu-latest
     steps:
@@ -779,6 +856,8 @@ jobs:
         run: AGENTOPS_RETRIEVAL_SMOKE_AO=/tmp/ao-test bash scripts/retrieval-quality-smoke.sh
 
   go-build:
+    needs: [changes]
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -943,6 +1022,8 @@ jobs:
         run: .\tests\windows\test-windows-smoke.ps1
 
   cli-integration:
+    needs: [changes]
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -1055,6 +1136,8 @@ jobs:
           bash tests/skills/run-all.sh
 
   learning-coherence:
+    needs: [changes]
+    if: needs.changes.outputs.learning == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -1122,7 +1205,7 @@ jobs:
           echo "File manifests found in evidence — overlap check delegated to file-manifest-overlap job"
 
   summary:
-    needs: [doc-release-gate, smoke-test, hook-preflight, pre-push-gate-wired, agentops-eval-baseline-audit, standards-injector-completeness, validate-hooks-doc-parity, hook-output-schema-lint, validate-ci-policy-parity, validate-codex-runtime-sections, validate-codex-generated-artifacts, validate-codex-backbone-prompts, validate-codex-override-coverage, validate-codex-rpi-contract, validate-codex-lifecycle-guards, validate-headless-runtime-skills, embedded-sync, cli-docs-parity, registry-check, agentops-contract-canaries, eval-workbench-verify, agentops-eval-advisory, eval-skill-delta, shellcheck, markdownlint, security-scan, security-toolchain-gate, skill-integrity, skill-schema, skill-dependency-check, contract-compatibility-gate, memrl-health, plugin-load-test, go-build, windows-smoke, cli-integration, json-flag-consistency, file-manifest-overlap, doctor-check, skill-lint, learning-coherence, bats-tests, check-test-staleness, swarm-evidence]
+    needs: [changes, doc-release-gate, smoke-test, hook-preflight, pre-push-gate-wired, agentops-eval-baseline-audit, standards-injector-completeness, validate-hooks-doc-parity, hook-output-schema-lint, validate-ci-policy-parity, validate-codex-runtime-sections, validate-codex-generated-artifacts, validate-codex-backbone-prompts, validate-codex-override-coverage, validate-codex-rpi-contract, validate-codex-lifecycle-guards, validate-headless-runtime-skills, embedded-sync, cli-docs-parity, registry-check, agentops-contract-canaries, eval-workbench-verify, agentops-eval-advisory, eval-skill-delta, shellcheck, markdownlint, security-scan, security-toolchain-gate, skill-integrity, skill-schema, skill-dependency-check, contract-compatibility-gate, memrl-health, plugin-load-test, go-build, windows-smoke, cli-integration, json-flag-consistency, file-manifest-overlap, doctor-check, skill-lint, learning-coherence, bats-tests, check-test-staleness, swarm-evidence]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -1174,47 +1257,10 @@ jobs:
           echo "check-test-staleness: ${{ needs.check-test-staleness.result }}"
           echo "swarm-evidence: ${{ needs.swarm-evidence.result }}"
 
-          if [[ "${{ needs.doc-release-gate.result }}" != "success" ]] || \
-             [[ "${{ needs.smoke-test.result }}" != "success" ]] || \
-             [[ "${{ needs.hook-preflight.result }}" != "success" ]] || \
-             [[ "${{ needs.pre-push-gate-wired.result }}" != "success" ]] || \
-             [[ "${{ needs.agentops-eval-baseline-audit.result }}" != "success" ]] || \
-             [[ "${{ needs.standards-injector-completeness.result }}" != "success" ]] || \
-             [[ "${{ needs.validate-hooks-doc-parity.result }}" != "success" ]] || \
-             [[ "${{ needs.hook-output-schema-lint.result }}" != "success" ]] || \
-             [[ "${{ needs.validate-ci-policy-parity.result }}" != "success" ]] || \
-             [[ "${{ needs.validate-codex-runtime-sections.result }}" != "success" ]] || \
-             [[ "${{ needs.validate-codex-generated-artifacts.result }}" != "success" ]] || \
-             [[ "${{ needs.validate-codex-backbone-prompts.result }}" != "success" ]] || \
-             [[ "${{ needs.validate-codex-override-coverage.result }}" != "success" ]] || \
-             [[ "${{ needs.validate-codex-rpi-contract.result }}" != "success" ]] || \
-             [[ "${{ needs.validate-codex-lifecycle-guards.result }}" != "success" ]] || \
-             [[ "${{ needs.validate-headless-runtime-skills.result }}" != "success" ]] || \
-             [[ "${{ needs.embedded-sync.result }}" != "success" ]] || \
-             [[ "${{ needs.cli-docs-parity.result }}" != "success" ]] || \
-             [[ "${{ needs.registry-check.result }}" != "success" ]] || \
-             [[ "${{ needs.agentops-contract-canaries.result }}" != "success" ]] || \
-             [[ "${{ needs.eval-workbench-verify.result }}" != "success" ]] || \
-             [[ "${{ needs.eval-skill-delta.result }}" != "success" ]] || \
-             [[ "${{ needs.shellcheck.result }}" != "success" ]] || \
-             [[ "${{ needs.markdownlint.result }}" != "success" ]] || \
-             [[ "${{ needs.security-scan.result }}" != "success" ]] || \
-             [[ "${{ needs.skill-integrity.result }}" != "success" ]] || \
-             [[ "${{ needs.skill-schema.result }}" != "success" ]] || \
-             [[ "${{ needs.skill-dependency-check.result }}" != "success" ]] || \
-             [[ "${{ needs.contract-compatibility-gate.result }}" != "success" ]] || \
-             [[ "${{ needs.memrl-health.result }}" != "success" ]] || \
-             [[ "${{ needs.plugin-load-test.result }}" != "success" ]] || \
-             [[ "${{ needs.go-build.result }}" != "success" ]] || \
-             [[ "${{ needs.windows-smoke.result }}" != "success" ]] || \
-             [[ "${{ needs.cli-integration.result }}" != "success" ]] || \
-             [[ "${{ needs.json-flag-consistency.result }}" != "success" ]] || \
-             [[ "${{ needs.file-manifest-overlap.result }}" != "success" ]] || \
-             [[ "${{ needs.skill-lint.result }}" != "success" ]] || \
-             [[ "${{ needs.learning-coherence.result }}" != "success" ]] || \
-             [[ "${{ needs.bats-tests.result }}" != "success" ]]; then
+          # Fail only on actual failures — skipped jobs (path-filtered) are OK
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
             echo ""
-            echo "❌ Some checks failed"
+            echo "❌ Some checks failed (failure detected)"
             exit 1
           fi
 

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint clean install sync-hooks
+.PHONY: build test lint clean install sync-hooks inner
 
 # Build variables
 BINARY_NAME=ao
@@ -58,6 +58,11 @@ run: build
 # Tidy go modules
 tidy:
 	go mod tidy
+
+# Inner loop: <10s compile + vet (cached)
+inner:
+	go build ./...
+	go vet ./...
 
 # Format code
 fmt:

--- a/docs/LOOP-BUDGET.md
+++ b/docs/LOOP-BUDGET.md
@@ -1,0 +1,131 @@
+# Loop Budget
+
+Dev loop structure and latency budgets for the AgentOps repo. Every check and CI job is classified into one loop. Adding a new check requires declaring its loop affinity and proving it fits the budget.
+
+## Loop Definitions
+
+| Loop | Latency Budget | Question Answered | Gate Character |
+|------|---------------|-------------------|----------------|
+| **Inner** | <10s | "Does it compile?" | `make inner` — non-blocking, instant feedback |
+| **Middle (blocking)** | <30s | "Will this break others?" | Pre-push pass 1 — blocks push |
+| **Middle (advisory)** | <3min | "Are there quality concerns?" | Pre-push pass 2 — warns, does not block |
+| **Outer** | <10min | "Is the system healthy?" | CI — runs on PR/push to main |
+
+## Invocation
+
+```bash
+cd cli && make inner                           # Inner loop (<10s)
+git push                                       # Two-pass gate (default):
+                                               #   Pass 1: blocking (<30s)
+                                               #   Pass 2: advisory (<3min)
+scripts/pre-push-gate.sh --single-pass         # Full single-pass (old behavior)
+```
+
+## Pre-Push Check Classification
+
+| # | Check | Category | Loop | Blocking? |
+|---|-------|----------|------|-----------|
+| 1 | Go build + vet | go | Middle (blocking) | Yes |
+| 2 | Go race tests (changed scope) | go | Middle (blocking) | Yes |
+| 3 | Command/test pairing | go | Middle (blocking) | Yes |
+| 3a | Mutation-route bypass guard | always | Middle (blocking) | Yes |
+| 3b | HOME isolation in test files | go | Middle (blocking) | Yes |
+| 3b2 | Test HOME isolation (broader) | go/shell | Middle (blocking) | Yes |
+| 3d | .agents/ write-surface contract | always | Middle (advisory) | No |
+| 4 | cmd/ao coverage floor | go | Middle (advisory) | No |
+| 4b | Per-package coverage ratchet | go | Outer (CI only) | No |
+| 5 | Embedded hooks sync | hook | Middle (blocking) | Yes |
+| 6 | Skill count sync | skill | Middle (blocking) | Yes |
+| 7 | Worktree disposition | always | Middle (advisory) | No |
+| 8 | Skill runtime/CLI parity | skill | Middle (advisory) | No |
+| 9 | Codex skill parity | skill | Outer (skipped) | No |
+| 10 | Codex install bundle parity | skill | Outer (skipped) | No |
+| 11 | Codex runtime section format | skill | Outer (CI) | No |
+| 12 | Skill integrity (refs/xrefs) | skill | Middle (advisory) | No |
+| 13 | Skill lint suite | skill | Middle (advisory) | No |
+| 14 | Skill schema validation | skill | Middle (advisory) | No |
+| 15 | Manifest schema validation | skill | Middle (advisory) | No |
+| 16 | Codex artifact metadata | skill | Outer (CI) | No |
+| 17 | Codex backbone prompts | skill | Outer (CI) | No |
+| 18 | Codex override coverage | skill | Outer (CI) | No |
+| 19 | Next-work contract parity | always | Outer (CI) | No |
+| 19b | bd closeout contract parity | always | Outer (CI) | No |
+| 19c | Retrieval quality ratchet | always | Outer (CI) | No |
+| 20 | Skill runtime formats | skill | Middle (advisory) | No |
+| 21 | Codex RPI contract | skill | Outer (CI) | No |
+| 22 | Codex lifecycle guards | skill | Outer (CI) | No |
+| 23 | Skill CLI snippets | skill | Middle (advisory) | No |
+| 24 | Headless runtime smoke | skill | Outer (CI) | No |
+| 24b | CLI docs parity | go | Middle (advisory) | No |
+| 24c | Eval canaries (deterministic) | eval | Outer (CI) | No |
+| 24e | Contract canaries | contract | Outer (CI) | No |
+| 25 | Doc-release gate | docs | Outer (CI) | No |
+| 25b | Release audit artifact refs | docs | Outer (CI) | No |
+| 26 | Contract compatibility | contract | Middle (advisory) | No |
+| 27 | Hook preflight | hook | Middle (blocking) | Yes |
+| 28 | Hooks/docs parity | hook | Middle (advisory) | No |
+| 29 | CI policy parity | ci_policy | Outer (CI) | No |
+| 30 | ShellCheck | shell | Middle (advisory) | No |
+| 31 | Plugin load test (symlinks) | always | Middle (blocking) | Yes |
+| 32 | Learning coherence | learning | Outer (CI) | No |
+| 33 | BATS orphan hooks audit | hook | Outer (CI) | No |
+| 34 | Skill citation parity | skill | Outer (CI) | No |
+| 35 | Flywheel health | always | Outer (CI) | No |
+
+## CI Job Classification
+
+| Job | Path Group | Loop |
+|-----|-----------|------|
+| go-build | go | Outer |
+| cli-integration | go | Outer |
+| cli-docs-parity | go | Outer |
+| json-flag-consistency | go | Outer |
+| embedded-sync | hooks | Outer |
+| hook-preflight | hooks | Outer |
+| hook-output-schema-lint | hooks | Outer |
+| validate-hooks-doc-parity | hooks | Outer |
+| bats-tests | hooks | Outer |
+| skill-integrity | skills | Outer |
+| skill-lint | skills | Outer |
+| skill-schema | skills | Outer |
+| skill-dependency-check | skills | Outer |
+| validate-headless-runtime-skills | skills | Outer |
+| validate-codex-runtime-sections | codex | Outer |
+| validate-codex-generated-artifacts | codex | Outer |
+| validate-codex-backbone-prompts | codex | Outer |
+| validate-codex-override-coverage | codex | Outer |
+| validate-codex-rpi-contract | codex | Outer |
+| validate-codex-lifecycle-guards | codex | Outer |
+| agentops-eval-baseline-audit | eval | Outer |
+| eval-workbench-verify | eval | Outer |
+| agentops-eval-advisory | eval | Outer |
+| eval-skill-delta | eval | Outer |
+| doc-release-gate | docs | Outer |
+| markdownlint | docs | Outer |
+| smoke-test | always | Outer |
+| shellcheck | shell | Outer |
+| security-scan | always | Outer |
+| security-toolchain-gate | always | Outer |
+| agentops-contract-canaries | contracts | Outer |
+| contract-compatibility-gate | contracts | Outer |
+| validate-ci-policy-parity | ci | Outer |
+| pre-push-gate-wired | always | Outer |
+| registry-check | skills | Outer |
+| standards-injector-completeness | skills | Outer |
+| plugin-load-test | always | Outer |
+| learning-coherence | learning | Outer |
+| memrl-health | always | Outer |
+| file-manifest-overlap | always | Outer |
+| doctor-check | always | Outer |
+| check-test-staleness | always | Outer |
+| swarm-evidence | always | Outer |
+| windows-smoke | always | Outer |
+| summary | always | Outer (gateway) |
+
+## Policy: Adding New Checks
+
+1. Declare the loop affinity (inner/middle-blocking/middle-advisory/outer).
+2. Measure the check's runtime. It must fit within the loop's latency budget.
+3. Middle-blocking checks must prevent real breakage (compilation failure, sync drift, security bypass). Quality/drift/hygiene checks belong in middle-advisory or outer.
+4. If the check requires `go build` or network access, it cannot be inner-loop.
+5. Update this document when adding or reclassifying a check.

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -116,6 +116,7 @@ else
 fi
 FAST_MODE=false
 TWO_PASS=false
+SINGLE_PASS=false
 FAIL_FAST_SETTING="${PRE_PUSH_FAIL_FAST:-auto}"
 FAIL_FAST_EFFECTIVE=false
 FAIL_FAST_PENDING=false
@@ -201,15 +202,17 @@ run_hash_snapshot() {
 usage() {
     cat <<'EOF'
 Usage: scripts/pre-push-gate.sh [--fast] [--scope auto|upstream|staged|worktree|head]
-       scripts/pre-push-gate.sh --two-pass
+       scripts/pre-push-gate.sh --single-pass
 
 Options:
-  --fast       Only run checks relevant to changed files
-  --scope      How to determine changed files (default: head local, upstream CI)
-  --fail-fast  Stop after first blocking failure
-  --accumulate Continue after failures and report all blocking failures
-  --two-pass   Pass 1: --fast --scope head --fail-fast (blocking)
-               Pass 2: --scope upstream --accumulate (advisory, WARN not FAIL)
+  --fast        Only run checks relevant to changed files
+  --scope       How to determine changed files (default: head local, upstream CI)
+  --fail-fast   Stop after first blocking failure
+  --accumulate  Continue after failures and report all blocking failures
+  --two-pass    Pass 1: --fast --scope head --fail-fast (blocking)
+                Pass 2: --scope upstream --accumulate (advisory, WARN not FAIL)
+                NOTE: two-pass is now the default for local pushes
+  --single-pass Opt out of two-pass default; run full single-pass gate
 
 Environment:
   PRE_PUSH_FAIL_FAST=0|1|auto   default auto: enabled for local --fast, off in CI
@@ -224,6 +227,8 @@ EOF
 
 if truthy "${PRE_PUSH_TWO_PASS:-0}"; then
     TWO_PASS=true
+elif [[ -n "${PRE_PUSH_TWO_PASS:-}" ]] && ! truthy "${PRE_PUSH_TWO_PASS}"; then
+    SINGLE_PASS=true
 fi
 
 while [[ $# -gt 0 ]]; do
@@ -247,6 +252,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --two-pass)
             TWO_PASS=true
+            shift
+            ;;
+        --single-pass)
+            SINGLE_PASS=true
             shift
             ;;
         -h|--help)
@@ -280,6 +289,11 @@ if [[ "$FAIL_FAST_SETTING" == "auto" ]]; then
     fi
 elif truthy "$FAIL_FAST_SETTING"; then
     FAIL_FAST_EFFECTIVE=true
+fi
+
+# --- Default to two-pass for local pushes (inner/middle loop separation) ---
+if [[ "$SINGLE_PASS" != "true" ]] && [[ "$TWO_PASS" != "true" ]] && ! is_ci_env; then
+    TWO_PASS=true
 fi
 
 # --- Two-pass mode: re-invoke as pass 1 (blocking) + pass 2 (advisory) ---

--- a/scripts/validate-ci-policy-parity.sh
+++ b/scripts/validate-ci-policy-parity.sh
@@ -79,6 +79,22 @@ extract_summary_needs() {
 
 extract_summary_failset() {
   local file="$1"
+  # New pattern: contains(needs.*.result, 'failure') means all needs jobs are
+  # in the fail set EXCEPT those with continue-on-error: true (which always
+  # report success and thus can never trigger the failure check).
+  if grep -q "contains(needs\.\*\.result" "$file"; then
+    local coe_jobs
+    coe_jobs="$(awk '
+      /^  [a-z][a-z0-9_-]+:/ { job=$0; gsub(/^  /,"",job); gsub(/:/,"",job) }
+      /continue-on-error:[[:space:]]*true/ { print job }
+    ' "$file" | sort -u)"
+    extract_summary_needs "$file" \
+      | grep -v '^changes$' \
+      | grep -vxF "$coe_jobs" \
+      || true
+    return
+  fi
+  # Legacy pattern: individual if [[ "needs.X.result" != "success" ]] checks
   awk '
     /^  summary:/ { in_summary=1 }
     in_summary && /^[[:space:]]*if[[:space:]]+\[\[/ { in_condition=1 }
@@ -112,6 +128,8 @@ if ! extract_summary_needs "$WORKFLOW_PATH" > "$WF_NEEDS_FILE"; then
   echo "Expected style: summary.needs with bracket list (needs: [job-a, job-b])."
   exit 1
 fi
+# Exclude utility jobs (path-filter detection) from parity comparison
+sed -i '/^changes$/d' "$WF_NEEDS_FILE"
 
 if [[ ! -s "$AGENTS_JOBS_FILE" ]]; then
   echo "CI_POLICY_PARITY: no CI jobs parsed from AGENTS table under '### CI Jobs and What They Check'."


### PR DESCRIPTION
## Summary
- Default pre-push gate to two-pass mode: pass 1 blocks in <10s, pass 2 is advisory
- Add `make inner` target for <10s edit-time validation
- Add `dorny/paths-filter` to CI so path-irrelevant jobs are skipped (docs-only PR → ~10 jobs instead of 46)
- Fix summary job to tolerate skipped jobs (`contains(needs.*.result, 'failure')` instead of `!= success`)
- Add `docs/LOOP-BUDGET.md` classifying all checks by loop affinity
- Update CI policy parity script to handle the new `contains()` pattern

## Test plan
- [x] `bash -n scripts/pre-push-gate.sh` — syntax valid
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML valid
- [x] `cd cli && make inner` — completes in <10s
- [x] `scripts/validate-ci-policy-parity.sh` — PASS (44 jobs; 5 non-blocking)
- [x] Two-pass gate ran correctly on push (pass 1 fast, pass 2 advisory)