### PR TITLE
feat(nightly): DF local pilot readiness control plane

### DIFF
--- a/docs/runbooks/nightly-evolution.md
+++ b/docs/runbooks/nightly-evolution.md
@@ -142,6 +142,97 @@ Use Claude and Codex differently until eval evidence says mixed mode is stable:
 - `bushido-box ai-sane` must pass in execute mode unless
   `--no-require-ai-sane` is supplied.
 
+## L3 Rehearsal — First No-Merge Local Pilot
+
+Before enabling recurring scheduled runs, prove the full execute+evolve
+path with a mocked work order that cannot merge.
+
+### Step 1: Dry-run
+
+```bash
+scripts/nightly-evolution.sh
+```
+
+Verify `digest.json` is written and `admission_context` is populated.
+
+### Step 2: Dream-only execute
+
+```bash
+scripts/nightly-evolution.sh --execute --run-dream
+```
+
+Verify Dream submits (or falls back) without requiring a work order.
+
+### Step 3: Execute+evolve blocked by admission
+
+Create an expired work order to confirm the preflight refuses:
+
+```bash
+jq -n '{
+  schema_version: 1, work_order_id: "rehearsal-blocked",
+  generated_at: "2020-01-01T00:00:00Z", expires_at: "2020-01-01T01:00:00Z",
+  base_sha: "abcdef1", target: {type:"goal",id:"t",summary:"T"},
+  allowed_files: ["scripts/nightly-evolution.sh"],
+  validation_commands: ["echo ok"], landing_policy: "off",
+  digest_policy: "required", open_pr_blockers: [],
+  main_ci_baseline: {status:"green",checked_at:"2020-01-01T00:00:00Z",failed_jobs:[]}
+}' > /tmp/rehearsal-blocked.json
+
+scripts/nightly-evolution.sh \
+  --execute --run-evolve \
+  --work-order /tmp/rehearsal-blocked.json
+# Expected: non-zero exit, "work order expired"
+```
+
+### Step 4: Execute+evolve admitted (no-merge)
+
+Create a valid work order and run with `--landing-policy off`:
+
+```bash
+jq -n --arg sha "$(git rev-parse HEAD)" \
+  --arg ea "$(date -u -d '+1 hour' +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg ga "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '{
+  schema_version: 1, work_order_id: "rehearsal-admitted",
+  generated_at: $ga, expires_at: $ea, base_sha: $sha,
+  target: {type:"goal",id:"rehearsal",summary:"L3 rehearsal"},
+  allowed_files: ["scripts/nightly-evolution.sh"],
+  validation_commands: ["echo ok"], landing_policy: "off",
+  digest_policy: "required", open_pr_blockers: [],
+  main_ci_baseline: {status:"green",checked_at:$ga,failed_jobs:[]}
+}' > /tmp/rehearsal-admitted.json
+
+scripts/nightly-evolution.sh \
+  --execute --run-evolve \
+  --work-order /tmp/rehearsal-admitted.json \
+  --landing-policy off \
+  --runtime-cmd claude \
+  --max-cycles 1
+# Expected: exit 0, digest records admitted run
+```
+
+### Step 5: Review digest
+
+```bash
+cat .agents/nightly/$(date -u +%F)/*/digest.md
+cat .agents/nightly/$(date -u +%F)/*/pr-body.md
+```
+
+Verify the digest includes the admission context table, stop reasons (step
+3), and admitted verdict (step 4).
+
+The pilot is not recurring until this rehearsal passes all five steps.
+
+### BATS validation
+
+Run the full scenario suite:
+
+```bash
+bats tests/scripts/nightly-evolution.bats
+```
+
+Scenario fixtures for the blocked and admitted rehearsals are at
+`tests/scenarios/nightly-evolution/auto-nightly-evolution-l3-rehearsal-*.json`.
+
 ## Outputs
 
 Each run writes:
@@ -152,6 +243,8 @@ Each run writes:
 - `dream-setup.json`
 - `runtime-inventory.tsv`
 - `open-prs.json`
+- `blocker-matrix.json`
+- `main-ci-baseline.json`
 - optional `nightly-brief/`
 - optional `systemd/`
 - optional `dream-run-payload.json`, `dream-submit.json`, and

--- a/scripts/nightly-evolution.sh
+++ b/scripts/nightly-evolution.sh
@@ -27,6 +27,7 @@ Options:
   --max-cycles <n>          Max evolve cycles when --run-evolve is used (default: 1).
   --gate-policy <policy>    Evolve gate policy (default: required).
   --landing-policy <policy> Evolve landing policy (default: off).
+  --work-order <path>       Work order JSON for --execute --run-evolve preflight.
   --schedule <calendar>     systemd OnCalendar value (default: *-*-* 12:15:00 UTC).
   --no-require-ai-sane      Do not block execute mode when bushido-box ai-sane fails.
   -h, --help                Show this help.
@@ -34,7 +35,7 @@ Options:
 Examples:
   scripts/nightly-evolution.sh --emit-systemd
   scripts/nightly-evolution.sh --execute --run-dream
-  scripts/nightly-evolution.sh --execute --run-evolve --runtime-cmd codex
+  scripts/nightly-evolution.sh --execute --run-evolve --work-order work-order.json
 EOF
 }
 
@@ -174,6 +175,57 @@ build_main_ci_baseline() {
     '{status: $status, run_id: $run_id, checked_at: $ts, failed_jobs: []}' >"$out_file"
 }
 
+preflight_evolve() {
+  local wo="$1"
+  local repo="$2"
+  local runtime_cmd="$3"
+  local gh_evidence="$4"
+  local main_ci_status="$5"
+  local worktree_status="$6"
+
+  if [[ -z "$wo" || ! -f "$wo" ]]; then
+    die "execute+run-evolve requires --work-order; none provided or file not found"
+  fi
+
+  if ! jq -e '.schema_version == 1 and .work_order_id and .target and .allowed_files' "$wo" >/dev/null 2>&1; then
+    die "work order is malformed or missing required fields: $wo"
+  fi
+
+  local expires_at now_epoch expires_epoch
+  expires_at="$(jq -r '.expires_at // ""' "$wo")"
+  if [[ -n "$expires_at" ]]; then
+    now_epoch="$(date -u +%s)"
+    expires_epoch="$(date -u -d "$expires_at" +%s 2>/dev/null || echo 0)"
+    if [[ "$expires_epoch" -gt 0 && "$now_epoch" -gt "$expires_epoch" ]]; then
+      die "work order expired at $expires_at"
+    fi
+  fi
+
+  if [[ -n "$worktree_status" ]]; then
+    die "execute+run-evolve requires clean worktree; uncommitted changes found"
+  fi
+
+  if [[ "$gh_evidence" != "ok" ]]; then
+    die "execute+run-evolve requires GitHub evidence; got: $gh_evidence"
+  fi
+
+  if [[ "$main_ci_status" == "red" ]]; then
+    die "execute+run-evolve blocked: main CI is red"
+  fi
+
+  if [[ "$main_ci_status" == "unknown" ]]; then
+    die "execute+run-evolve blocked: main CI status is unknown"
+  fi
+
+  if [[ -n "$(git -C "$repo" ls-files .agents 2>/dev/null)" ]]; then
+    die "execute+run-evolve blocked: tracked .agents directory found"
+  fi
+
+  if ! command -v "$runtime_cmd" >/dev/null 2>&1; then
+    die "execute+run-evolve requires runtime command: $runtime_cmd"
+  fi
+}
+
 compute_branch() {
   local date_value="$1"
   local base="nightly/${date_value}"
@@ -272,6 +324,7 @@ RUNTIME_MODE="auto"
 MAX_CYCLES="1"
 GATE_POLICY="required"
 LANDING_POLICY="off"
+WORK_ORDER=""
 SCHEDULE="*-*-* 12:15:00 UTC"
 
 while [[ $# -gt 0 ]]; do
@@ -336,6 +389,10 @@ while [[ $# -gt 0 ]]; do
       LANDING_POLICY="${2:-}"
       shift 2
       ;;
+    --work-order)
+      WORK_ORDER="${2:-}"
+      shift 2
+      ;;
     --schedule)
       SCHEDULE="${2:-}"
       shift 2
@@ -367,6 +424,8 @@ cd "$REPO_ROOT"
 require_cmd git
 require_cmd jq
 require_cmd ao
+
+WORKTREE_STATUS="$(git status --porcelain -uno 2>/dev/null || true)"
 
 RUN_STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 RUN_ID="nightly-evolution-${RUN_STAMP}"
@@ -523,6 +582,7 @@ if [[ "$RUN_EVOLVE" == true ]]; then
   if [[ "$EXECUTE" != true ]]; then
     EVOLVE_STATUS="planned"
   else
+    preflight_evolve "$WORK_ORDER" "$REPO_ROOT" "$RUNTIME_CMD" "$GH_EVIDENCE" "$MAIN_CI_STATUS" "$WORKTREE_STATUS"
     export AGENTOPS_RPI_RUNTIME_MODE="$RUNTIME_MODE"
     export AGENTOPS_RPI_RUNTIME_COMMAND="$RUNTIME_CMD"
     if [[ -n "$BRANCH" ]]; then

--- a/scripts/nightly-evolution.sh
+++ b/scripts/nightly-evolution.sh
@@ -106,6 +106,74 @@ write_runtime_inventory() {
   done
 }
 
+build_blocker_matrix() {
+  local prs_json="$1"
+  local out_file="$2"
+  local gh_evidence="$3"
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  if [[ "$gh_evidence" != "ok" ]]; then
+    jq -n --arg status "$gh_evidence" --arg ts "$ts" \
+      '{status: $status, checked_at: $ts, prs: []}' >"$out_file"
+    return
+  fi
+
+  jq --arg ts "$ts" '
+    {
+      status: "ok",
+      checked_at: $ts,
+      prs: [.[] | {
+        pr_number: .number,
+        head_ref: .headRefName,
+        base_ref: .baseRefName,
+        changed_file_count: .changedFiles,
+        title: .title
+      }]
+    }' "$prs_json" >"$out_file"
+}
+
+build_main_ci_baseline() {
+  local out_file="$1"
+  local run_dir="$2"
+  local gh_evidence="$3"
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  if [[ "$gh_evidence" != "ok" ]]; then
+    jq -n --arg status "unknown" --arg ts "$ts" \
+      '{status: $status, checked_at: $ts, failed_jobs: []}' >"$out_file"
+    return
+  fi
+
+  local ci_json="$run_dir/main-ci-raw.json"
+  local ci_err="$run_dir/main-ci-raw.stderr"
+  if ! run_json_capture "$ci_json" "$ci_err" \
+    gh run list --branch main --limit 1 --json conclusion,databaseId; then
+    jq -n --arg status "unknown" --arg ts "$ts" \
+      '{status: $status, checked_at: $ts, failed_jobs: []}' >"$out_file"
+    return
+  fi
+
+  if [[ "$(jq 'length' "$ci_json")" == "0" ]]; then
+    jq -n --arg status "unknown" --arg ts "$ts" \
+      '{status: $status, checked_at: $ts, failed_jobs: []}' >"$out_file"
+    return
+  fi
+
+  local conclusion run_id ci_status
+  conclusion="$(jq -r '.[0].conclusion // "unknown"' "$ci_json")"
+  run_id="$(jq -r '.[0].databaseId | tostring' "$ci_json" 2>/dev/null || echo "")"
+  ci_status="unknown"
+  case "$conclusion" in
+    success) ci_status="green" ;;
+    failure) ci_status="red" ;;
+  esac
+
+  jq -n --arg status "$ci_status" --arg run_id "$run_id" --arg ts "$ts" \
+    '{status: $status, run_id: $run_id, checked_at: $ts, failed_jobs: []}' >"$out_file"
+}
+
 compute_branch() {
   local date_value="$1"
   local base="nightly/${date_value}"
@@ -168,6 +236,8 @@ write_markdown_digest() {
   local dream_status="$6"
   local evolve_status="$7"
   local systemd_dir="$8"
+  local gh_evidence="${9:-unavailable}"
+  local main_ci_status="${10:-unknown}"
 
   {
     printf '# Nightly Evolution Digest\n\n'
@@ -175,6 +245,8 @@ write_markdown_digest() {
     printf -- '- Mode: `%s`\n' "$mode"
     printf -- '- Planned branch: `%s`\n' "$branch"
     printf -- '- AI readiness: `%s`\n' "$ai_sane_status"
+    printf -- '- GitHub evidence: `%s`\n' "$gh_evidence"
+    printf -- '- Main CI baseline: `%s`\n' "$main_ci_status"
     printf -- '- Dream phase: `%s`\n' "$dream_status"
     printf -- '- Evolve phase: `%s`\n' "$evolve_status"
     if [[ -n "$systemd_dir" ]]; then
@@ -360,17 +432,27 @@ if ! run_json_capture "$DREAM_SETUP_JSON" "$DREAM_SETUP_ERR" ao overnight setup 
   json_empty_object >"$DREAM_SETUP_JSON"
 fi
 
+GH_EVIDENCE="unavailable"
 OPEN_PRS_JSON="$OUTPUT_DIR/open-prs.json"
 OPEN_PRS_ERR="$OUTPUT_DIR/open-prs.stderr"
+BLOCKER_MATRIX_JSON="$OUTPUT_DIR/blocker-matrix.json"
+MAIN_CI_JSON="$OUTPUT_DIR/main-ci-baseline.json"
 if command -v gh >/dev/null 2>&1; then
-  if ! run_json_capture "$OPEN_PRS_JSON" "$OPEN_PRS_ERR" \
+  if run_json_capture "$OPEN_PRS_JSON" "$OPEN_PRS_ERR" \
     gh pr list --state open --limit 30 --json number,title,headRefName,baseRefName,changedFiles,url,labels; then
+    GH_EVIDENCE="ok"
+  else
+    GH_EVIDENCE="failed"
     json_empty_array >"$OPEN_PRS_JSON"
   fi
 else
   json_empty_array >"$OPEN_PRS_JSON"
   : >"$OPEN_PRS_ERR"
 fi
+
+build_blocker_matrix "$OPEN_PRS_JSON" "$BLOCKER_MATRIX_JSON" "$GH_EVIDENCE"
+build_main_ci_baseline "$MAIN_CI_JSON" "$OUTPUT_DIR" "$GH_EVIDENCE"
+MAIN_CI_STATUS="$(jq -r '.status // "unknown"' "$MAIN_CI_JSON")"
 
 BRIEF_STATUS="skipped"
 if [[ "$SKIP_BRIEF" != true ]]; then
@@ -483,6 +565,9 @@ jq -n \
   --slurpfile ai "$AI_SANE_JSON" \
   --slurpfile dreamSetup "$DREAM_SETUP_JSON" \
   --slurpfile openPrs "$OPEN_PRS_JSON" \
+  --slurpfile blockerMatrix "$BLOCKER_MATRIX_JSON" \
+  --slurpfile mainCi "$MAIN_CI_JSON" \
+  --arg gh_evidence "$GH_EVIDENCE" \
   --rawfile runtimeInventory "$RUNTIME_TSV" '
   {
     schema_version: ($schema_version | tonumber),
@@ -506,6 +591,11 @@ jq -n \
     github: {
       open_prs: ($openPrs[0] // [])
     },
+    admission_context: {
+      gh_evidence: $gh_evidence,
+      blocker_matrix: ($blockerMatrix[0] // {}),
+      main_ci_baseline: ($mainCi[0] // {})
+    },
     phases: {
       nightly_brief: $brief_status,
       dream: $dream_status,
@@ -522,7 +612,7 @@ jq -n \
     }
   }' >"$DIGEST_JSON"
 
-write_markdown_digest "$DIGEST_MD" "$RUN_ID" "$MODE" "$BRANCH" "$AI_SANE_STATUS" "$DREAM_STATUS" "$EVOLVE_STATUS" "$SYSTEMD_DIR"
+write_markdown_digest "$DIGEST_MD" "$RUN_ID" "$MODE" "$BRANCH" "$AI_SANE_STATUS" "$DREAM_STATUS" "$EVOLVE_STATUS" "$SYSTEMD_DIR" "$GH_EVIDENCE" "$MAIN_CI_STATUS"
 
 log "digest=$DIGEST_JSON"
 

--- a/scripts/nightly-evolution.sh
+++ b/scripts/nightly-evolution.sh
@@ -28,6 +28,7 @@ Options:
   --gate-policy <policy>    Evolve gate policy (default: required).
   --landing-policy <policy> Evolve landing policy (default: off).
   --work-order <path>       Work order JSON for --execute --run-evolve preflight.
+  --landing-branch <name>   Override the computed nightly branch for evolve landing.
   --schedule <calendar>     systemd OnCalendar value (default: *-*-* 12:15:00 UTC).
   --no-require-ai-sane      Do not block execute mode when bushido-box ai-sane fails.
   -h, --help                Show this help.
@@ -182,6 +183,8 @@ preflight_evolve() {
   local gh_evidence="$4"
   local main_ci_status="$5"
   local worktree_status="$6"
+  local landing_policy="$7"
+  local landing_branch="$8"
 
   if [[ -z "$wo" || ! -f "$wo" ]]; then
     die "execute+run-evolve requires --work-order; none provided or file not found"
@@ -223,6 +226,21 @@ preflight_evolve() {
 
   if ! command -v "$runtime_cmd" >/dev/null 2>&1; then
     die "execute+run-evolve requires runtime command: $runtime_cmd"
+  fi
+
+  case "$landing_policy" in
+    off|manual_pr) ;;
+    *) die "execute+run-evolve blocked: landing policy '$landing_policy' not allowed for pilot; use off or manual_pr" ;;
+  esac
+
+  if [[ -n "$landing_branch" ]]; then
+    local default_branch
+    default_branch="$(git -C "$repo" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || echo main)"
+    case "$landing_branch" in
+      main|master|"$default_branch")
+        die "execute+run-evolve blocked: landing on '$landing_branch' not allowed for pilot; use a nightly/* branch"
+        ;;
+    esac
   fi
 }
 
@@ -325,6 +343,7 @@ MAX_CYCLES="1"
 GATE_POLICY="required"
 LANDING_POLICY="off"
 WORK_ORDER=""
+LANDING_BRANCH_OVERRIDE=""
 SCHEDULE="*-*-* 12:15:00 UTC"
 
 while [[ $# -gt 0 ]]; do
@@ -393,6 +412,10 @@ while [[ $# -gt 0 ]]; do
       WORK_ORDER="${2:-}"
       shift 2
       ;;
+    --landing-branch)
+      LANDING_BRANCH_OVERRIDE="${2:-}"
+      shift 2
+      ;;
     --schedule)
       SCHEDULE="${2:-}"
       shift 2
@@ -453,7 +476,11 @@ fi
 
 log "run_id=$RUN_ID mode=$MODE output_dir=$OUTPUT_DIR"
 
-BRANCH="$(compute_branch "$RUN_DATE")"
+if [[ -n "$LANDING_BRANCH_OVERRIDE" ]]; then
+  BRANCH="$LANDING_BRANCH_OVERRIDE"
+else
+  BRANCH="$(compute_branch "$RUN_DATE")"
+fi
 RUNTIME_TSV="$OUTPUT_DIR/runtime-inventory.tsv"
 split_csv "$RUNNERS" RUNNER_ARRAY
 write_runtime_inventory "$RUNTIME_TSV" "${RUNNER_ARRAY[@]}" "$RUNTIME_CMD" gh bd
@@ -582,7 +609,7 @@ if [[ "$RUN_EVOLVE" == true ]]; then
   if [[ "$EXECUTE" != true ]]; then
     EVOLVE_STATUS="planned"
   else
-    preflight_evolve "$WORK_ORDER" "$REPO_ROOT" "$RUNTIME_CMD" "$GH_EVIDENCE" "$MAIN_CI_STATUS" "$WORKTREE_STATUS"
+    preflight_evolve "$WORK_ORDER" "$REPO_ROOT" "$RUNTIME_CMD" "$GH_EVIDENCE" "$MAIN_CI_STATUS" "$WORKTREE_STATUS" "$LANDING_POLICY" "$BRANCH"
     export AGENTOPS_RPI_RUNTIME_MODE="$RUNTIME_MODE"
     export AGENTOPS_RPI_RUNTIME_COMMAND="$RUNTIME_CMD"
     if [[ -n "$BRANCH" ]]; then

--- a/scripts/nightly-pr-digest.sh
+++ b/scripts/nightly-pr-digest.sh
@@ -300,6 +300,48 @@ build_auto_reverts() {
   fi
 }
 
+build_admission_context() {
+  printf '### Admission Context\n\n'
+
+  local gh_evidence
+  gh_evidence="$(jq -r '.admission_context.gh_evidence // "not present"' "$DIGEST_JSON")"
+  if [[ "$gh_evidence" == "not present" ]]; then
+    printf '_(no admission context in digest)_\n\n'
+    return
+  fi
+
+  local ci_status blocker_count landing_policy
+  ci_status="$(jq -r '.admission_context.main_ci_baseline.status // "unknown"' "$DIGEST_JSON")"
+  blocker_count="$(jq -r '.admission_context.blocker_matrix.prs | length' "$DIGEST_JSON" 2>/dev/null || echo 0)"
+  landing_policy="$(jq -r '.admission_context.main_ci_baseline // {} | .landing_policy // "unknown"' "$DIGEST_JSON" 2>/dev/null || echo "unknown")"
+
+  printf '| Field | Value |\n|---|---|\n'
+  printf '| GitHub evidence | %s |\n' "$gh_evidence"
+  printf '| Main CI baseline | %s |\n' "$ci_status"
+  printf '| Open PR blockers | %s |\n' "$blocker_count"
+
+  if [[ "$blocker_count" -gt 0 ]] 2>/dev/null; then
+    printf '\n**Blocker PRs:**\n\n'
+    printf '| # | Branch | Files |\n|---|---|---|\n'
+    jq -r '.admission_context.blocker_matrix.prs[] | "| #\(.pr_number) | `\(.head_ref)` | \(.changed_file_count) |"' "$DIGEST_JSON" 2>/dev/null | head -10
+    printf '\n'
+  fi
+
+  local mode evolve_status
+  mode="$(jq -r '.mode // "unknown"' "$DIGEST_JSON")"
+  evolve_status="$(jq -r '.phases.evolve // "not-requested"' "$DIGEST_JSON")"
+
+  if [[ "$mode" != "execute" ]]; then
+    printf '\n**Verdict:** dry-run (no source mutation attempted)\n\n'
+  elif [[ "$evolve_status" == "not-requested" ]]; then
+    printf '\n**Verdict:** evolve not requested\n\n'
+  elif [[ "$evolve_status" == "ok" ]]; then
+    printf '\n**Verdict:** admitted and completed\n\n'
+  else
+    printf '\n**Verdict:** %s\n\n' "$evolve_status"
+  fi
+}
+
 build_tag_push_status() {
   printf '### Tag-Push Status\n\n'
 
@@ -324,6 +366,7 @@ build_tag_push_status() {
 
 emit_markdown() {
   build_header
+  build_admission_context
   build_goals_section
   build_cycle_history
   build_runtime_flips
@@ -341,17 +384,24 @@ emit_json() {
   tmp_md="$(mktemp "${TMPDIR:-/tmp}/pr-digest-XXXXXX.md")"
   emit_markdown > "$tmp_md"
 
+  local admission_json="{}"
+  if [[ -f "$DIGEST_JSON" ]]; then
+    admission_json="$(jq '.admission_context // {}' "$DIGEST_JSON" 2>/dev/null || echo '{}')"
+  fi
+
   jq -n \
     --arg schema_version "1" \
     --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     --arg branch "$BRANCH" \
     --arg run_dir "$RUN_DIR" \
+    --argjson admission "$admission_json" \
     --rawfile body "$tmp_md" \
     '{
       schema_version: ($schema_version | tonumber),
       generated_at: $generated_at,
       branch: $branch,
       run_dir: $run_dir,
+      admission_context: $admission,
       pr_body: $body
     }'
   rm -f "$tmp_md"

--- a/tests/scenarios/nightly-evolution/auto-nightly-evolution-l3-rehearsal-admitted.json
+++ b/tests/scenarios/nightly-evolution/auto-nightly-evolution-l3-rehearsal-admitted.json
@@ -1,0 +1,40 @@
+{
+  "id": "auto-nightly-evolution-l3-rehearsal-admitted",
+  "version": 1,
+  "date": "2026-05-05",
+  "goal": "Execute+run-evolve is admitted when a valid work order passes all preflight checks.",
+  "narrative": "An operator runs a no-merge local pilot rehearsal with a valid work order, green CI, clean worktree, and landing-policy off on a nightly branch. The preflight admits the run, evolve executes, and the digest records the admission context.",
+  "expected_outcome": "Exit 0 with evolve phase ok. Digest includes admission_context with gh_evidence ok, main CI green, and blocker matrix. PR body includes admission context table with verdict.",
+  "acceptance_vectors": [
+    {
+      "dimension": "safety",
+      "threshold": 1.0,
+      "check": "bats tests/scripts/nightly-evolution.bats --filter 'execute run-evolve passes runtime env and branch'"
+    },
+    {
+      "dimension": "observability",
+      "threshold": 1.0,
+      "check": "bats tests/scripts/nightly-evolution.bats --filter 'pr digest includes admission context'"
+    },
+    {
+      "dimension": "completeness",
+      "threshold": 0.9,
+      "check": "digest.json admission_context has gh_evidence, blocker_matrix, and main_ci_baseline"
+    }
+  ],
+  "satisfaction_threshold": 0.95,
+  "scope": {
+    "files": [
+      "scripts/nightly-evolution.sh",
+      "scripts/nightly-pr-digest.sh",
+      "tests/scripts/nightly-evolution.bats"
+    ],
+    "behaviors": [
+      "admitted evolve execution",
+      "admission-aware digest",
+      "work order validation"
+    ]
+  },
+  "source": "agent",
+  "status": "active"
+}

--- a/tests/scenarios/nightly-evolution/auto-nightly-evolution-l3-rehearsal-blocked.json
+++ b/tests/scenarios/nightly-evolution/auto-nightly-evolution-l3-rehearsal-blocked.json
@@ -1,0 +1,39 @@
+{
+  "id": "auto-nightly-evolution-l3-rehearsal-blocked",
+  "version": 1,
+  "date": "2026-05-05",
+  "goal": "Execute+run-evolve is blocked by admission preflight when evidence is missing or unsafe.",
+  "narrative": "An operator runs a no-merge local pilot rehearsal to prove the fail-closed preflight stops source mutation when conditions are unsafe: missing work order, expired work order, red main CI, unknown GH evidence, dirty worktree, tracked .agents, missing runtime, or forbidden landing policy.",
+  "expected_outcome": "Each stop reason produces a non-zero exit with a descriptive error. No source mutation occurs. Dream-only execute remains allowed.",
+  "acceptance_vectors": [
+    {
+      "dimension": "safety",
+      "threshold": 1.0,
+      "check": "bats tests/scripts/nightly-evolution.bats --filter 'execute\\+run-evolve refuses'"
+    },
+    {
+      "dimension": "completeness",
+      "threshold": 1.0,
+      "check": "All 8 stop reasons are tested: missing work order, expired, dirty worktree, unknown gh, red CI, tracked .agents, missing runtime, forbidden landing policy"
+    },
+    {
+      "dimension": "isolation",
+      "threshold": 1.0,
+      "check": "bats tests/scripts/nightly-evolution.bats --filter 'execute\\+run-dream allowed without work order'"
+    }
+  ],
+  "satisfaction_threshold": 0.95,
+  "scope": {
+    "files": [
+      "scripts/nightly-evolution.sh",
+      "tests/scripts/nightly-evolution.bats"
+    ],
+    "behaviors": [
+      "preflight_evolve stop reasons",
+      "fail-closed source mutation gate",
+      "Dream-only execute bypass"
+    ]
+  },
+  "source": "agent",
+  "status": "active"
+}

--- a/tests/scripts/nightly-evolution.bats
+++ b/tests/scripts/nightly-evolution.bats
@@ -703,6 +703,71 @@ STUB
     [[ "$output" == *"requires runtime command: nonexistent-runtime-xyz"* ]]
 }
 
+@test "execute+run-evolve refuses sync-push landing policy" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+    local wo="$TMP_DIR/work-order.json"
+    create_valid_work_order "$wo"
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-01 \
+        --skip-brief \
+        --execute \
+        --run-evolve \
+        --work-order "$wo" \
+        --landing-policy sync_push
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"landing policy 'sync_push' not allowed"* ]]
+}
+
+@test "execute+run-evolve refuses main branch landing" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+    local wo="$TMP_DIR/work-order.json"
+    create_valid_work_order "$wo"
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-01 \
+        --skip-brief \
+        --execute \
+        --run-evolve \
+        --work-order "$wo" \
+        --landing-policy off \
+        --landing-branch main
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"landing on 'main' not allowed"* ]]
+}
+
+@test "execute+run-evolve passes non-main generated branch with landing-policy off" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+    local wo="$TMP_DIR/work-order.json"
+    create_valid_work_order "$wo"
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-02 \
+        --skip-brief \
+        --execute \
+        --run-evolve \
+        --work-order "$wo" \
+        --landing-policy off \
+        --runtime-cmd codex
+
+    [ "$status" -eq 0 ]
+    jq -e '.phases.evolve == "ok"' "$TMP_DIR/out/digest.json"
+}
+
 @test "execute+run-dream allowed without work order" {
     AO_LOG="$TMP_DIR/ao.log"
     AO_RPI_LOG="$TMP_DIR/rpi.log"

--- a/tests/scripts/nightly-evolution.bats
+++ b/tests/scripts/nightly-evolution.bats
@@ -76,6 +76,18 @@ STUB
     cat >"$MOCK_BIN/gh" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
+if [[ "$1 $2" == "pr list" ]]; then
+  printf '%s\n' "${GH_PR_LIST_RESPONSE:-[]}"
+  exit 0
+fi
+if [[ "$1 $2" == "run list" ]]; then
+  if [[ -n "${GH_RUN_LIST_RESPONSE:-}" ]]; then
+    printf '%s\n' "$GH_RUN_LIST_RESPONSE"
+  else
+    printf '[{"conclusion":"success","databaseId":99999}]\n'
+  fi
+  exit 0
+fi
 printf '[]\n'
 STUB
     chmod +x "$MOCK_BIN/gh"
@@ -123,6 +135,21 @@ set -euo pipefail
 exit 42
 STUB
     chmod +x "$FAKE_REPO/scripts/nightly-rpi-brief.sh"
+}
+
+make_path_without_gh() {
+    local restricted_bin="$TMP_DIR/restricted-bin"
+    mkdir -p "$restricted_bin"
+    local f
+    for f in "$MOCK_BIN"/*; do
+        [[ "$(basename "$f")" != "gh" ]] && cp -f "$f" "$restricted_bin/"
+    done
+    local tool tool_path
+    for tool in bash git jq date timeout printf grep cut wc sort head tail dirname basename mkdir mktemp cat rm chmod find sed tr cp touch env; do
+        tool_path="$(command -v "$tool" 2>/dev/null || true)"
+        [[ -n "$tool_path" && ! -e "$restricted_bin/$tool" ]] && ln -sf "$tool_path" "$restricted_bin/$tool"
+    done
+    printf '%s' "$restricted_bin"
 }
 
 add_remote_nightly_branches() {
@@ -397,4 +424,85 @@ add_remote_nightly_branches() {
     [ "$status" -eq 0 ]
     grep -q -- '--landing-branch nightly/2026-05-01' "$AO_RPI_LOG"
     jq -e '.runtime.command == "codex" and .runtime.mode == "direct" and .phases.evolve == "ok"' "$TMP_DIR/out/digest.json"
+}
+
+@test "dry-run builds blocker matrix and main CI baseline artifacts" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+    export GH_PR_LIST_RESPONSE='[{"number":42,"title":"feat: add widget","headRefName":"feat/widget","baseRefName":"main","changedFiles":3,"url":"https://github.com/test/42","labels":[]}]'
+    export GH_RUN_LIST_RESPONSE='[{"conclusion":"success","databaseId":12345}]'
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-01 \
+        --skip-brief
+
+    [ "$status" -eq 0 ]
+    [ -f "$TMP_DIR/out/blocker-matrix.json" ]
+    [ -f "$TMP_DIR/out/main-ci-baseline.json" ]
+    jq -e '.status == "ok" and (.prs | length) == 1 and .prs[0].pr_number == 42' "$TMP_DIR/out/blocker-matrix.json"
+    jq -e '.status == "green" and .run_id == "12345"' "$TMP_DIR/out/main-ci-baseline.json"
+    jq -e '.admission_context.gh_evidence == "ok"' "$TMP_DIR/out/digest.json"
+    jq -e '.admission_context.blocker_matrix.status == "ok"' "$TMP_DIR/out/digest.json"
+    jq -e '.admission_context.main_ci_baseline.status == "green"' "$TMP_DIR/out/digest.json"
+}
+
+@test "gh failure produces unknown CI and failed blocker matrix" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+
+    cat >"$MOCK_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+    chmod +x "$MOCK_BIN/gh"
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-01 \
+        --skip-brief
+
+    [ "$status" -eq 0 ]
+    jq -e '.status == "failed"' "$TMP_DIR/out/blocker-matrix.json"
+    jq -e '.status == "unknown"' "$TMP_DIR/out/main-ci-baseline.json"
+    jq -e '.admission_context.gh_evidence == "failed"' "$TMP_DIR/out/digest.json"
+}
+
+@test "gh unavailable produces unknown CI and unavailable blocker matrix" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+    NO_GH_PATH="$(make_path_without_gh)"
+
+    run env PATH="$NO_GH_PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-01 \
+        --skip-brief
+
+    [ "$status" -eq 0 ]
+    jq -e '.status == "unavailable"' "$TMP_DIR/out/blocker-matrix.json"
+    jq -e '.status == "unknown"' "$TMP_DIR/out/main-ci-baseline.json"
+    jq -e '.admission_context.gh_evidence == "unavailable"' "$TMP_DIR/out/digest.json"
+}
+
+@test "red main CI baseline is classified correctly" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+    export GH_RUN_LIST_RESPONSE='[{"conclusion":"failure","databaseId":99998}]'
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-01 \
+        --skip-brief
+
+    [ "$status" -eq 0 ]
+    jq -e '.status == "red" and .run_id == "99998"' "$TMP_DIR/out/main-ci-baseline.json"
+    jq -e '.admission_context.main_ci_baseline.status == "red"' "$TMP_DIR/out/digest.json"
 }

--- a/tests/scripts/nightly-evolution.bats
+++ b/tests/scripts/nightly-evolution.bats
@@ -12,6 +12,9 @@ setup() {
     cp "$SCRIPT" "$FAKE_REPO/scripts/nightly-evolution.sh"
     chmod +x "$FAKE_REPO/scripts/nightly-evolution.sh"
 
+    cp "$REPO_ROOT/scripts/nightly-pr-digest.sh" "$FAKE_REPO/scripts/nightly-pr-digest.sh"
+    chmod +x "$FAKE_REPO/scripts/nightly-pr-digest.sh"
+
     cat >"$FAKE_REPO/scripts/nightly-rpi-brief.sh" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -783,4 +786,49 @@ STUB
 
     [ "$status" -eq 0 ]
     jq -e '.phases.dream == "submitted"' "$TMP_DIR/out/digest.json"
+}
+
+@test "pr digest includes admission context table" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+    export GH_PR_LIST_RESPONSE='[{"number":77,"title":"fix: thing","headRefName":"fix/thing","baseRefName":"main","changedFiles":2,"url":"https://github.com/test/77","labels":[]}]'
+    export GH_RUN_LIST_RESPONSE='[{"conclusion":"success","databaseId":88888}]'
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-01 \
+        --skip-brief
+
+    [ "$status" -eq 0 ]
+    [ -f "$TMP_DIR/out/pr-body.md" ]
+    grep -q 'Admission Context' "$TMP_DIR/out/pr-body.md"
+    grep -q 'GitHub evidence.*ok' "$TMP_DIR/out/pr-body.md"
+    grep -q 'Main CI baseline.*green' "$TMP_DIR/out/pr-body.md"
+    grep -q 'Open PR blockers.*1' "$TMP_DIR/out/pr-body.md"
+    grep -q 'dry-run' "$TMP_DIR/out/pr-body.md"
+}
+
+@test "pr digest json includes admission context fields" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+    export GH_RUN_LIST_RESPONSE='[{"conclusion":"failure","databaseId":44444}]'
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-01 \
+        --skip-brief
+
+    [ "$status" -eq 0 ]
+
+    "$FAKE_REPO/scripts/nightly-pr-digest.sh" \
+        --run-dir "$TMP_DIR/out" \
+        --format json \
+        --output "$TMP_DIR/out/pr-digest.json"
+
+    jq -e '.admission_context.gh_evidence == "ok"' "$TMP_DIR/out/pr-digest.json"
+    jq -e '.admission_context.main_ci_baseline.status == "red"' "$TMP_DIR/out/pr-digest.json"
 }

--- a/tests/scripts/nightly-evolution.bats
+++ b/tests/scripts/nightly-evolution.bats
@@ -152,6 +152,54 @@ make_path_without_gh() {
     printf '%s' "$restricted_bin"
 }
 
+create_valid_work_order() {
+    local path="$1"
+    local expires_at
+    expires_at="$(date -u -d '+1 hour' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v+1H +%Y-%m-%dT%H:%M:%SZ)"
+    local sha
+    sha="$(git -C "$FAKE_REPO" rev-parse HEAD)"
+    jq -n \
+      --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --arg expires_at "$expires_at" \
+      --arg sha "$sha" \
+      '{
+        schema_version: 1,
+        work_order_id: "test-wo-001",
+        generated_at: $generated_at,
+        expires_at: $expires_at,
+        base_sha: $sha,
+        target: {type: "goal", id: "test-goal", summary: "Test work order"},
+        allowed_files: ["scripts/nightly-evolution.sh"],
+        validation_commands: ["echo ok"],
+        landing_policy: "off",
+        digest_policy: "required",
+        open_pr_blockers: [],
+        main_ci_baseline: {status: "green", checked_at: $generated_at, failed_jobs: []}
+      }' >"$path"
+}
+
+create_expired_work_order() {
+    local path="$1"
+    local sha
+    sha="$(git -C "$FAKE_REPO" rev-parse HEAD)"
+    jq -n \
+      --arg sha "$sha" \
+      '{
+        schema_version: 1,
+        work_order_id: "test-wo-expired",
+        generated_at: "2020-01-01T00:00:00Z",
+        expires_at: "2020-01-01T01:00:00Z",
+        base_sha: $sha,
+        target: {type: "goal", id: "test-goal", summary: "Expired work order"},
+        allowed_files: ["scripts/nightly-evolution.sh"],
+        validation_commands: ["echo ok"],
+        landing_policy: "off",
+        digest_policy: "required",
+        open_pr_blockers: [],
+        main_ci_baseline: {status: "green", checked_at: "2020-01-01T00:00:00Z", failed_jobs: []}
+      }' >"$path"
+}
+
 add_remote_nightly_branches() {
     git init --bare -q "$TMP_DIR/origin.git"
     git -C "$FAKE_REPO" remote add origin "$TMP_DIR/origin.git"
@@ -409,6 +457,8 @@ add_remote_nightly_branches() {
     AO_LOG="$TMP_DIR/ao.log"
     AO_RPI_LOG="$TMP_DIR/rpi.log"
     export AO_LOG AO_RPI_LOG
+    local wo="$TMP_DIR/work-order.json"
+    create_valid_work_order "$wo"
 
     run env PATH="$MOCK_BIN:$PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
         --repo-root "$FAKE_REPO" \
@@ -417,6 +467,7 @@ add_remote_nightly_branches() {
         --skip-brief \
         --execute \
         --run-evolve \
+        --work-order "$wo" \
         --runtime-cmd codex \
         --runtime-mode direct \
         --landing-policy off
@@ -505,4 +556,166 @@ STUB
     [ "$status" -eq 0 ]
     jq -e '.status == "red" and .run_id == "99998"' "$TMP_DIR/out/main-ci-baseline.json"
     jq -e '.admission_context.main_ci_baseline.status == "red"' "$TMP_DIR/out/digest.json"
+}
+
+@test "execute+run-evolve refuses missing work order" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-01 \
+        --skip-brief \
+        --execute \
+        --run-evolve
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"requires --work-order"* ]]
+}
+
+@test "execute+run-evolve refuses expired work order" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+    local wo="$TMP_DIR/expired-wo.json"
+    create_expired_work_order "$wo"
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-01 \
+        --skip-brief \
+        --execute \
+        --run-evolve \
+        --work-order "$wo"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"work order expired"* ]]
+}
+
+@test "execute+run-evolve refuses dirty worktree" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+    local wo="$TMP_DIR/work-order.json"
+    create_valid_work_order "$wo"
+    echo "dirty" >> "$FAKE_REPO/README.md"
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-01 \
+        --skip-brief \
+        --execute \
+        --run-evolve \
+        --work-order "$wo"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"clean worktree"* ]]
+}
+
+@test "execute+run-evolve refuses unknown gh evidence" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+    local wo="$TMP_DIR/work-order.json"
+    create_valid_work_order "$wo"
+    NO_GH_PATH="$(make_path_without_gh)"
+
+    run env PATH="$NO_GH_PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-01 \
+        --skip-brief \
+        --execute \
+        --run-evolve \
+        --work-order "$wo"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"requires GitHub evidence"* ]]
+}
+
+@test "execute+run-evolve refuses red main CI" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+    export GH_RUN_LIST_RESPONSE='[{"conclusion":"failure","databaseId":55555}]'
+    local wo="$TMP_DIR/work-order.json"
+    create_valid_work_order "$wo"
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-01 \
+        --skip-brief \
+        --execute \
+        --run-evolve \
+        --work-order "$wo"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"main CI is red"* ]]
+}
+
+@test "execute+run-evolve refuses tracked .agents" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+    local wo="$TMP_DIR/work-order.json"
+    create_valid_work_order "$wo"
+    mkdir -p "$FAKE_REPO/.agents"
+    touch "$FAKE_REPO/.agents/tracked-file"
+    git -C "$FAKE_REPO" add .agents/tracked-file
+    git -C "$FAKE_REPO" commit -q -m "track .agents"
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-01 \
+        --skip-brief \
+        --execute \
+        --run-evolve \
+        --work-order "$wo"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"tracked .agents"* ]]
+}
+
+@test "execute+run-evolve refuses missing runtime command" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+    local wo="$TMP_DIR/work-order.json"
+    create_valid_work_order "$wo"
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-01 \
+        --skip-brief \
+        --execute \
+        --run-evolve \
+        --work-order "$wo" \
+        --runtime-cmd nonexistent-runtime-xyz
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"requires runtime command: nonexistent-runtime-xyz"* ]]
+}
+
+@test "execute+run-dream allowed without work order" {
+    AO_LOG="$TMP_DIR/ao.log"
+    AO_RPI_LOG="$TMP_DIR/rpi.log"
+    export AO_LOG AO_RPI_LOG
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$FAKE_REPO/scripts/nightly-evolution.sh" \
+        --repo-root "$FAKE_REPO" \
+        --output-dir "$TMP_DIR/out" \
+        --date 2026-05-01 \
+        --skip-brief \
+        --execute \
+        --run-dream
+
+    [ "$status" -eq 0 ]
+    jq -e '.phases.dream == "submitted"' "$TMP_DIR/out/digest.json"
 }


### PR DESCRIPTION
## Summary

- Build blocker matrix and main CI baseline artifacts in `nightly-evolution.sh`
- Enforce fail-closed execute preflight for `--execute --run-evolve` with 8 safety checks
- Guard evolve landing to manual PR-only policy (reject sync-push and main branch)
- Make morning digest admission-aware with GH evidence, CI baseline, and blocker table
- Add L3 rehearsal scenario fixtures and operator runbook section

## Details

Epic soc-y8b.11: 6 beads, 1 closed as superseded (daemon already covers it), 5 implemented.

**New flags:** `--work-order <path>`, `--landing-branch <name>`

**New artifacts per run:** `blocker-matrix.json`, `main-ci-baseline.json`

**Preflight checks (fail-closed):** valid work order, not expired, clean worktree, GH evidence available, main CI green, no tracked .agents, runtime command present, safe landing policy, non-main branch.

## Test plan

- [x] 31 BATS tests (17 new), all passing
- [x] Factory admission contract tests still pass
- [x] Scenario fixtures validate against schema (BATS test 1)
- [x] Each preflight stop reason has a dedicated test
- [x] GH unavailable/failed/ok states all tested
- [x] CI green/red/unknown classification tested
- [x] PR digest markdown and JSON include admission context