### PR TITLE
feat(cli): add ao session spawn for template-driven session launch

### DIFF
--- a/cli/cmd/ao/session_spawn.go
+++ b/cli/cmd/ao/session_spawn.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/spf13/cobra"
+)
+
+type SessionTemplate struct {
+	SchemaVersion int              `toml:"schema_version" json:"schema_version"`
+	Role          string           `toml:"role" json:"role"`
+	Description   string           `toml:"description" json:"description"`
+	Identity      SessionIdentity  `toml:"identity" json:"identity"`
+	Workspace     SessionWorkspace `toml:"workspace" json:"workspace"`
+	Init          SessionInit      `toml:"init" json:"init"`
+	Tmux          SessionTmux      `toml:"tmux" json:"tmux"`
+	Heartbeat     SessionHeartbeat `toml:"heartbeat" json:"heartbeat"`
+	OnExit        SessionOnExit    `toml:"on_exit" json:"on_exit"`
+	Invariants    map[string]string `toml:"invariants" json:"invariants,omitempty"`
+	References    map[string]string `toml:"references" json:"references,omitempty"`
+}
+
+type SessionIdentity struct {
+	BeadsActorTemplate  string `toml:"beads_actor_template" json:"beads_actor_template"`
+	SessionNameTemplate string `toml:"session_name_template" json:"session_name_template"`
+	Agent               string `toml:"agent" json:"agent"`
+}
+
+type SessionWorkspace struct {
+	Cwd                       string `toml:"cwd" json:"cwd"`
+	ValidatorIdentityFile     string `toml:"validator_identity_file" json:"validator_identity_file,omitempty"`
+	ValidatorIdentityTemplate string `toml:"validator_identity_template" json:"validator_identity_template,omitempty"`
+}
+
+type SessionInit struct {
+	Steps []SessionInitStep `toml:"steps" json:"steps"`
+}
+
+type SessionInitStep struct {
+	Name string `toml:"name" json:"name"`
+	Cmd  string `toml:"cmd" json:"cmd"`
+	Note string `toml:"note" json:"note,omitempty"`
+}
+
+type SessionTmux struct {
+	SessionName string        `toml:"session_name" json:"session_name"`
+	Panes       []SessionPane `toml:"panes" json:"panes"`
+}
+
+type SessionPane struct {
+	Position string `toml:"position" json:"position"`
+	Cmd      string `toml:"cmd" json:"cmd"`
+}
+
+type SessionHeartbeat struct {
+	CadenceMinutes int    `toml:"cadence_minutes" json:"cadence_minutes,omitempty"`
+	TargetIssue    string `toml:"target_issue" json:"target_issue,omitempty"`
+	Template       string `toml:"template" json:"template,omitempty"`
+}
+
+type SessionOnExit struct {
+	AutoHandoff         bool   `toml:"auto_handoff" json:"auto_handoff,omitempty"`
+	HandoffPathTemplate string `toml:"handoff_path_template" json:"handoff_path_template,omitempty"`
+	HandoffCommand      string `toml:"handoff_command" json:"handoff_command,omitempty"`
+}
+
+var (
+	spawnDryRun bool
+	spawnNoTmux bool
+	spawnDate   string
+)
+
+var sessionSpawnCmd = &cobra.Command{
+	Use:   "spawn <template-path>",
+	Short: "Cold-start a session from a TOML template",
+	Long: `Read a session template, expand variables, run init steps, and create
+a tmux session with the configured panes.
+
+The template defines the session role, init steps (context loading, handoff
+replay, bead ownership scan), tmux layout, heartbeat cadence, and exit hooks.
+
+Examples:
+  ao session spawn ~/.agentops/sessions/claude-validator.toml
+  ao session spawn ~/.agentops/sessions/claude-validator.toml --dry-run
+  ao session spawn ~/.agentops/sessions/claude-validator.toml --no-tmux`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSessionSpawn,
+}
+
+func init() {
+	sessionsCmd.AddCommand(sessionSpawnCmd)
+	sessionSpawnCmd.Flags().BoolVar(&spawnDryRun, "dry-run", false, "Print expanded template and init steps without executing")
+	sessionSpawnCmd.Flags().BoolVar(&spawnNoTmux, "no-tmux", false, "Run init steps but skip tmux session creation")
+	sessionSpawnCmd.Flags().StringVar(&spawnDate, "date", "", "Override date for template expansion (default: today, YYYY-MM-DD)")
+}
+
+func loadSessionTemplate(path string) (*SessionTemplate, error) {
+	var tmpl SessionTemplate
+	if _, err := toml.DecodeFile(path, &tmpl); err != nil {
+		return nil, fmt.Errorf("parse template %s: %w", path, err)
+	}
+	if tmpl.SchemaVersion != 1 {
+		return nil, fmt.Errorf("unsupported schema_version %d (want 1)", tmpl.SchemaVersion)
+	}
+	if tmpl.Role == "" {
+		return nil, fmt.Errorf("template missing required field: role")
+	}
+	if tmpl.Identity.SessionNameTemplate == "" {
+		return nil, fmt.Errorf("template missing required field: identity.session_name_template")
+	}
+	return &tmpl, nil
+}
+
+func buildTemplateVars(tmpl *SessionTemplate, dateOverride string) map[string]string {
+	dateVal := time.Now().UTC().Format("2006-01-02")
+	if dateOverride != "" {
+		dateVal = dateOverride
+	}
+	hostname, _ := os.Hostname()
+	home, _ := os.UserHomeDir()
+
+	sessionName := tmpl.Identity.SessionNameTemplate
+	sessionName = strings.ReplaceAll(sessionName, "{{date}}", dateVal)
+	sessionName = strings.ReplaceAll(sessionName, "{{hostname}}", hostname)
+
+	return map[string]string{
+		"{{date}}":         dateVal,
+		"{{hostname}}":     hostname,
+		"{{session_name}}": sessionName,
+		"{{timestamp}}":    time.Now().UTC().Format(time.RFC3339),
+		"$HOME":            home,
+	}
+}
+
+func expandVars(s string, vars map[string]string) string {
+	result := s
+	for k, v := range vars {
+		result = strings.ReplaceAll(result, k, v)
+	}
+	return result
+}
+
+func runInitSteps(steps []SessionInitStep, vars map[string]string, cwd string, dryRun bool) error {
+	for i, step := range steps {
+		expanded := expandVars(step.Cmd, vars)
+		if dryRun {
+			fmt.Printf("  [%d] %s\n", i+1, step.Name)
+			if step.Note != "" {
+				fmt.Printf("      # %s\n", step.Note)
+			}
+			fmt.Printf("      $ %s\n", strings.Split(expanded, "\n")[0])
+			if strings.Contains(expanded, "\n") {
+				fmt.Printf("      ... (%d lines)\n", strings.Count(expanded, "\n")+1)
+			}
+			continue
+		}
+		fmt.Printf("  [%d/%d] %s ... ", i+1, len(steps), step.Name)
+		cmd := exec.Command("bash", "-c", expanded)
+		cmd.Dir = cwd
+		cmd.Env = append(os.Environ(), "BEADS_ACTOR="+expandVars(steps[0].Cmd, vars))
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Printf("FAILED\n")
+			if len(out) > 0 {
+				fmt.Printf("      %s\n", strings.TrimSpace(string(out)))
+			}
+			return fmt.Errorf("init step %q failed: %w", step.Name, err)
+		}
+		fmt.Printf("ok\n")
+	}
+	return nil
+}
+
+func createTmuxSession(tmuxCfg SessionTmux, vars map[string]string, cwd string, dryRun bool) error {
+	sessionName := expandVars(tmuxCfg.SessionName, vars)
+
+	if !dryRun {
+		check := exec.Command("tmux", "has-session", "-t", sessionName)
+		if check.Run() == nil {
+			return fmt.Errorf("tmux session %q already exists", sessionName)
+		}
+	}
+
+	if dryRun {
+		fmt.Printf("\nTmux session: %s\n", sessionName)
+		for _, pane := range tmuxCfg.Panes {
+			fmt.Printf("  [%s] %s\n", pane.Position, expandVars(pane.Cmd, vars))
+		}
+		return nil
+	}
+
+	newCmd := exec.Command("tmux", "new-session", "-d", "-s", sessionName, "-c", cwd)
+	if out, err := newCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("tmux new-session: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+
+	for i, pane := range tmuxCfg.Panes {
+		expandedCmd := expandVars(pane.Cmd, vars)
+		if i == 0 {
+			send := exec.Command("tmux", "send-keys", "-t", sessionName, expandedCmd, "Enter")
+			if err := send.Run(); err != nil {
+				return fmt.Errorf("tmux send-keys main pane: %w", err)
+			}
+			continue
+		}
+
+		var splitArgs []string
+		switch {
+		case strings.HasPrefix(pane.Position, "right-"):
+			pct := strings.TrimPrefix(pane.Position, "right-")
+			pct = strings.TrimSuffix(pct, "%")
+			splitArgs = []string{"split-window", "-t", sessionName, "-h", "-p", pct}
+		case strings.HasPrefix(pane.Position, "bottom-"):
+			pct := strings.TrimPrefix(pane.Position, "bottom-")
+			pct = strings.TrimSuffix(pct, "%")
+			splitArgs = []string{"split-window", "-t", sessionName, "-v", "-p", pct}
+		default:
+			splitArgs = []string{"split-window", "-t", sessionName}
+		}
+
+		split := exec.Command("tmux", splitArgs...)
+		if out, err := split.CombinedOutput(); err != nil {
+			return fmt.Errorf("tmux split-window %s: %s: %w", pane.Position, strings.TrimSpace(string(out)), err)
+		}
+
+		paneTarget := fmt.Sprintf("%s.%d", sessionName, i)
+		send := exec.Command("tmux", "send-keys", "-t", paneTarget, expandedCmd, "Enter")
+		if err := send.Run(); err != nil {
+			return fmt.Errorf("tmux send-keys pane %d: %w", i, err)
+		}
+	}
+
+	fmt.Printf("Tmux session created: %s (%d panes)\n", sessionName, len(tmuxCfg.Panes))
+	fmt.Printf("Attach with: tmux attach-session -t %s\n", sessionName)
+	return nil
+}
+
+func runSessionSpawn(cmd *cobra.Command, args []string) error {
+	templatePath := args[0]
+	if strings.HasPrefix(templatePath, "~/") {
+		home, _ := os.UserHomeDir()
+		templatePath = filepath.Join(home, templatePath[2:])
+	}
+
+	tmpl, err := loadSessionTemplate(templatePath)
+	if err != nil {
+		return err
+	}
+
+	vars := buildTemplateVars(tmpl, spawnDate)
+	sessionName := vars["{{session_name}}"]
+	cwd := expandVars(tmpl.Workspace.Cwd, vars)
+
+	fmt.Printf("Session: %s (role: %s, agent: %s)\n", sessionName, tmpl.Role, tmpl.Identity.Agent)
+	fmt.Printf("Working directory: %s\n", cwd)
+
+	if spawnDryRun {
+		fmt.Printf("\nInit steps:\n")
+	} else {
+		fmt.Printf("\nRunning %d init steps:\n", len(tmpl.Init.Steps))
+	}
+
+	if err := runInitSteps(tmpl.Init.Steps, vars, cwd, spawnDryRun); err != nil {
+		return err
+	}
+
+	if spawnNoTmux {
+		fmt.Printf("\n--no-tmux: skipping tmux session creation\n")
+		return nil
+	}
+
+	if err := createTmuxSession(tmpl.Tmux, vars, cwd, spawnDryRun); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cli/cmd/ao/session_spawn_test.go
+++ b/cli/cmd/ao/session_spawn_test.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadSessionTemplate(t *testing.T) {
+	dir := t.TempDir()
+	tmplPath := filepath.Join(dir, "test.toml")
+	content := `
+schema_version = 1
+role = "test-role"
+description = "A test session"
+
+[identity]
+beads_actor_template = "test-{{date}}"
+session_name_template = "test-session-{{date}}"
+agent = "claude"
+
+[workspace]
+cwd = "$HOME"
+
+[[init.steps]]
+name = "step-one"
+cmd = "echo hello"
+note = "a test step"
+
+[tmux]
+session_name = "{{session_name}}"
+
+[[tmux.panes]]
+position = "main"
+cmd = "echo main"
+
+[[tmux.panes]]
+position = "right-30%"
+cmd = "echo side"
+
+[heartbeat]
+cadence_minutes = 30
+target_issue = "test-1"
+
+[on_exit]
+auto_handoff = true
+handoff_path_template = "$HOME/.agents/handoff/test-{{date}}.md"
+handoff_command = "ao handoff --collect"
+`
+	if err := os.WriteFile(tmplPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	tmpl, err := loadSessionTemplate(tmplPath)
+	if err != nil {
+		t.Fatalf("load template: %v", err)
+	}
+	if tmpl.Role != "test-role" {
+		t.Fatalf("role = %q, want test-role", tmpl.Role)
+	}
+	if tmpl.Identity.Agent != "claude" {
+		t.Fatalf("agent = %q, want claude", tmpl.Identity.Agent)
+	}
+	if len(tmpl.Init.Steps) != 1 {
+		t.Fatalf("init steps = %d, want 1", len(tmpl.Init.Steps))
+	}
+	if tmpl.Init.Steps[0].Name != "step-one" {
+		t.Fatalf("step name = %q, want step-one", tmpl.Init.Steps[0].Name)
+	}
+	if len(tmpl.Tmux.Panes) != 2 {
+		t.Fatalf("panes = %d, want 2", len(tmpl.Tmux.Panes))
+	}
+	if tmpl.Heartbeat.CadenceMinutes != 30 {
+		t.Fatalf("heartbeat cadence = %d, want 30", tmpl.Heartbeat.CadenceMinutes)
+	}
+	if !tmpl.OnExit.AutoHandoff {
+		t.Fatal("auto_handoff = false, want true")
+	}
+}
+
+func TestLoadSessionTemplateRejectsInvalid(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{
+			name:    "bad schema version",
+			content: `schema_version = 2` + "\n" + `role = "x"` + "\n" + `[identity]` + "\n" + `session_name_template = "x"`,
+			wantErr: "unsupported schema_version",
+		},
+		{
+			name:    "missing role",
+			content: `schema_version = 1` + "\n" + `[identity]` + "\n" + `session_name_template = "x"`,
+			wantErr: "missing required field: role",
+		},
+		{
+			name:    "missing session name template",
+			content: `schema_version = 1` + "\n" + `role = "x"` + "\n" + `[identity]`,
+			wantErr: "missing required field: identity.session_name_template",
+		},
+	}
+
+	for _, tc := range cases {
+		p := filepath.Join(dir, tc.name+".toml")
+		if err := os.WriteFile(p, []byte(tc.content), 0o644); err != nil {
+			t.Fatalf("%s: write: %v", tc.name, err)
+		}
+		_, err := loadSessionTemplate(p)
+		if err == nil {
+			t.Fatalf("%s: expected error, got nil", tc.name)
+		}
+		if !strings.Contains(err.Error(), tc.wantErr) {
+			t.Fatalf("%s: error = %q, want substring %q", tc.name, err.Error(), tc.wantErr)
+		}
+	}
+}
+
+func TestBuildTemplateVars(t *testing.T) {
+	tmpl := &SessionTemplate{
+		Identity: SessionIdentity{
+			SessionNameTemplate: "validator-{{date}}-{{hostname}}",
+		},
+	}
+	vars := buildTemplateVars(tmpl, "2026-05-05")
+
+	if vars["{{date}}"] != "2026-05-05" {
+		t.Fatalf("date = %q, want 2026-05-05", vars["{{date}}"])
+	}
+	if vars["{{hostname}}"] == "" {
+		t.Fatal("hostname is empty")
+	}
+	if !strings.HasPrefix(vars["{{session_name}}"], "validator-2026-05-05-") {
+		t.Fatalf("session_name = %q, want prefix validator-2026-05-05-", vars["{{session_name}}"])
+	}
+	if vars["$HOME"] == "" {
+		t.Fatal("$HOME is empty")
+	}
+}
+
+func TestExpandVars(t *testing.T) {
+	vars := map[string]string{
+		"{{date}}":         "2026-05-05",
+		"{{session_name}}": "test-session",
+		"$HOME":            "/home/testuser",
+	}
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"{{date}}", "2026-05-05"},
+		{"session-{{date}}-log", "session-2026-05-05-log"},
+		{"$HOME/.agents/{{session_name}}.md", "/home/testuser/.agents/test-session.md"},
+		{"no-vars-here", "no-vars-here"},
+	}
+	for _, tc := range cases {
+		got := expandVars(tc.input, vars)
+		if got != tc.want {
+			t.Fatalf("expandVars(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestRunInitStepsDryRun(t *testing.T) {
+	steps := []SessionInitStep{
+		{Name: "first", Cmd: "echo {{date}}", Note: "test note"},
+		{Name: "second", Cmd: "echo done"},
+	}
+	vars := map[string]string{"{{date}}": "2026-05-05"}
+
+	err := runInitSteps(steps, vars, t.TempDir(), true)
+	if err != nil {
+		t.Fatalf("dry-run init steps: %v", err)
+	}
+}
+
+func TestRunInitStepsExecutes(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "marker.txt")
+	steps := []SessionInitStep{
+		{Name: "create-marker", Cmd: "echo hello > " + marker},
+	}
+	vars := map[string]string{}
+
+	if err := runInitSteps(steps, vars, dir, false); err != nil {
+		t.Fatalf("init steps: %v", err)
+	}
+	data, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	if !strings.Contains(string(data), "hello") {
+		t.Fatalf("marker = %q, want hello", string(data))
+	}
+}
+
+func TestRunInitStepsFailsOnError(t *testing.T) {
+	steps := []SessionInitStep{
+		{Name: "will-fail", Cmd: "exit 1"},
+	}
+	err := runInitSteps(steps, map[string]string{}, t.TempDir(), false)
+	if err == nil {
+		t.Fatal("expected error from failing init step")
+	}
+	if !strings.Contains(err.Error(), "will-fail") {
+		t.Fatalf("error = %q, want step name", err.Error())
+	}
+}
+
+func TestCreateTmuxSessionDryRun(t *testing.T) {
+	cfg := SessionTmux{
+		SessionName: "test-{{date}}",
+		Panes: []SessionPane{
+			{Position: "main", Cmd: "echo main"},
+			{Position: "right-30%", Cmd: "echo side"},
+		},
+	}
+	vars := map[string]string{"{{date}}": "2026-05-05"}
+
+	err := createTmuxSession(cfg, vars, t.TempDir(), true)
+	if err != nil {
+		t.Fatalf("dry-run tmux session: %v", err)
+	}
+}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -3360,6 +3360,23 @@ ao sessions index [flags]
       --sessions-dir string   Directory containing derived session pages (default: .agents/ao/sessions)
 ```
 
+#### `ao sessions spawn`
+
+Read a session template, expand variables, run init steps, and create
+
+```
+ao sessions spawn <template-path> [flags]
+```
+
+**Flags:**
+
+```
+      --date string   Override date for template expansion (default: today, YYYY-MM-DD)
+      --dry-run       Print expanded template and init steps without executing
+  -h, --help          help for spawn
+      --no-tmux       Run init steps but skip tmux session creation
+```
+
 ---
 
 ### `ao trace`

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -17,6 +17,7 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.2.0 // indirect
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 )

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
 filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
## Summary

- Add `ao session spawn <template.toml>` command for cold-starting tmux sessions from TOML templates
- Reads template, expands variables (`{{date}}`, `{{hostname}}`, `{{session_name}}`), runs init steps, creates tmux with configured panes
- Supports `--dry-run` (preview without executing) and `--no-tmux` (init only, skip tmux)
- Adds `github.com/BurntSushi/toml` dependency
- Phase 1 of soc-y8b.7 (session-template launcher for Dark Factory)

## Test plan

- [x] 8 Go tests: template loading, validation rejection, variable expansion, init step execution (real + dry-run), failure handling, tmux dry-run
- [x] Full Go test suite passes (7966 tests)
- [x] Cobra conformance passes (CLI docs regenerated)
- [x] go build + go vet clean