### PR TITLE
fix(cli/rpi): capture epic_id at phase-1 creation, deprecate retroactive poll (S1 of M3.5 lifecycle preconditions)

### DIFF
--- a/cli/cmd/ao/rpi_phased_discovery.go
+++ b/cli/cmd/ao/rpi_phased_discovery.go
@@ -29,7 +29,40 @@ func parseIssueTypeFromShowJSON(data []byte) (bool, error) {
 
 // --- Epic and completion helpers ---
 
+// captureCreatedEpicID returns the most recently created open epic created at or
+// after `since` (RFC3339 timestamp). It is the cycle-binding-safe replacement for
+// extractEpicID, which polled all open epics regardless of creation time and
+// could bind cycles to stale unrelated epics (see soc-uo44).
+//
+// Callers should pass state.StartedAt — the timestamp the orchestrator stored
+// when phase-1 began — so that pre-cycle epics are excluded.
+//
+// Returns ("", error) when no epic was created during this cycle (the bd JSON
+// list is empty after filtering). The caller should treat that as a signal to
+// fall back to extractEpicID with a logged warning, not as a hard failure.
+func captureCreatedEpicID(bdCommand, since string) (string, error) {
+	if strings.TrimSpace(since) == "" {
+		return "", fmt.Errorf("captureCreatedEpicID: since timestamp required (cycle binding cannot use unfiltered poll)")
+	}
+	command := effectiveBDCommand(bdCommand)
+
+	cmd := exec.Command(command, "list", "--type", "epic", "--status", "open", "--created-after", since, "--json")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("bd list --created-after %s: %w", since, err)
+	}
+	return parseLatestEpicIDFromJSON(out)
+}
+
 // extractEpicID finds the most recently created open epic ID via bd CLI.
+//
+// Deprecated for cycle binding: this function does NOT filter by creation time
+// and can return stale unrelated epics (e.g. backlog items) when those exist.
+// Cycle-binding callers MUST use captureCreatedEpicID(bdCommand, sinceRFC3339)
+// instead so the result is restricted to epics created during the current
+// cycle. extractEpicID is retained for diagnostic and legacy callers, and as a
+// last-resort fallback when no since-timestamp is available.
+//
 // bd list returns epics in creation order; we take the LAST match so that
 // the epic just created by the plan phase is selected over older ones.
 func extractEpicID(bdCommand string) (string, error) {

--- a/cli/cmd/ao/rpi_phased_discovery_test.go
+++ b/cli/cmd/ao/rpi_phased_discovery_test.go
@@ -400,3 +400,96 @@ func TestParseCrankCompletion_CheckmarkAsClosed(t *testing.T) {
 		t.Errorf("parseCrankCompletion with checkmarks = %q, want %q", got, "DONE")
 	}
 }
+
+// --- captureCreatedEpicID (soc-uo44 / mc-m3.5-pre1) ---
+//
+// These tests verify that cycle binding uses an epic created DURING this cycle
+// rather than retroactively polling all open epics (which historically picked
+// stale unrelated epics like soc-scad and bound every cycle's gate to the wrong
+// tracker state). See .agents/research/2026-05-06-evolve-lifecycle-mid-session-discovery.md.
+
+// fakeBDWithCreatedAfter writes a /bin/sh fake-bd into tmp that responds to
+// `bd list ... --created-after <ts> --json` by emitting epicsAfter, and to
+// `bd list --type epic --status open --json` (no filter) by emitting epicsAll.
+// Returns the absolute path to the script.
+func fakeBDWithCreatedAfter(t *testing.T, epicsAll, epicsAfter string) string {
+	t.Helper()
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "fake-bd")
+	// The shell branches on the presence of --created-after. When that flag is
+	// passed, emit epicsAfter; otherwise emit epicsAll.
+	script := "#!/bin/sh\n" +
+		"for arg in \"$@\"; do\n" +
+		"  if [ \"$arg\" = \"--created-after\" ]; then\n" +
+		"    cat <<'AFTER'\n" + epicsAfter + "\nAFTER\n" +
+		"    exit 0\n" +
+		"  fi\n" +
+		"done\n" +
+		"cat <<'ALL'\n" + epicsAll + "\nALL\n"
+	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestCaptureCreatedEpicID_PrefersThisRunsCreation(t *testing.T) {
+	// Discovery created soc-newepic during this cycle. captureCreatedEpicID
+	// must filter by --created-after and return ONLY epics created since.
+	epicsAll := `[{"id":"soc-stale","status":"open"},{"id":"soc-newepic","status":"open"}]`
+	epicsAfter := `[{"id":"soc-newepic","status":"open"}]`
+	bd := fakeBDWithCreatedAfter(t, epicsAll, epicsAfter)
+
+	got, err := captureCreatedEpicID(bd, "2026-05-06T14:00:00Z")
+	if err != nil {
+		t.Fatalf("captureCreatedEpicID: %v", err)
+	}
+	if got != "soc-newepic" {
+		t.Errorf("captureCreatedEpicID = %q, want %q", got, "soc-newepic")
+	}
+}
+
+func TestCaptureCreatedEpicID_IgnoresStaleOpenEpics(t *testing.T) {
+	// Tracker has stale unrelated epic (e.g. soc-scad) plus a freshly created one.
+	// captureCreatedEpicID's bd invocation includes --created-after, which the fake-bd
+	// honors by returning only fresh epics. Assert the stale id is NEVER returned.
+	epicsAll := `[{"id":"soc-scad","status":"open"},{"id":"soc-fresh","status":"open"}]`
+	epicsAfter := `[{"id":"soc-fresh","status":"open"}]`
+	bd := fakeBDWithCreatedAfter(t, epicsAll, epicsAfter)
+
+	got, err := captureCreatedEpicID(bd, "2026-05-06T14:00:00Z")
+	if err != nil {
+		t.Fatalf("captureCreatedEpicID: %v", err)
+	}
+	if got == "soc-scad" {
+		t.Fatalf("captureCreatedEpicID returned stale epic %q — must never bind to pre-cycle epics", got)
+	}
+	if got != "soc-fresh" {
+		t.Errorf("captureCreatedEpicID = %q, want %q", got, "soc-fresh")
+	}
+}
+
+func TestCaptureCreatedEpicID_NoEpicCreatedThisCycleReturnsEmpty(t *testing.T) {
+	// Legitimate case: cycle ran without creating an epic (e.g. tasklist mode).
+	// captureCreatedEpicID returns ("", err) for all-empty so callers can fall
+	// back to extractEpicID with a logged warning rather than failing the cycle.
+	epicsAll := `[{"id":"soc-stale","status":"open"}]`
+	epicsAfter := `[]`
+	bd := fakeBDWithCreatedAfter(t, epicsAll, epicsAfter)
+
+	got, _ := captureCreatedEpicID(bd, "2026-05-06T14:00:00Z")
+	// Empty result is the contract; some non-nil err is acceptable since
+	// parseLatestEpicIDFromJSON returns an error on all-empty entries.
+	if got != "" {
+		t.Errorf("captureCreatedEpicID with empty filtered list = %q, want \"\"", got)
+	}
+}
+
+func TestCaptureCreatedEpicID_RequiresSinceTimestamp(t *testing.T) {
+	// Empty since must error — without a filter we'd be back to retroactive poll
+	// behavior (the bug we're fixing).
+	bd := fakeBDWithCreatedAfter(t, `[]`, `[]`)
+	_, err := captureCreatedEpicID(bd, "")
+	if err == nil {
+		t.Error("captureCreatedEpicID with empty since timestamp returned nil error; must require since")
+	}
+}

--- a/cli/cmd/ao/rpi_phased_gates.go
+++ b/cli/cmd/ao/rpi_phased_gates.go
@@ -74,14 +74,27 @@ func processDiscoveryPhase(cwd string, state *phasedState, logPath string) error
 }
 
 func resolveDiscoveryEpicID(cwd string, state *phasedState, tracker trackerHealth, logPath string) (string, error) {
-	if tracker.Healthy {
-		if epicID, err := extractEpicID(state.Opts.BDCommand); err == nil {
+	if !tracker.Healthy {
+		return resolveDiscoveryFallback(cwd, state, tracker, logPath, nil)
+	}
+	// Prefer epics created during THIS cycle (since state.StartedAt) so that
+	// stale unrelated open epics never win cycle binding. See soc-uo44.
+	if state.StartedAt != "" {
+		if epicID, err := captureCreatedEpicID(state.Opts.BDCommand, state.StartedAt); err == nil && epicID != "" {
 			return epicID, nil
-		} else {
-			return resolveDiscoveryFallback(cwd, state, tracker, logPath, err)
+		} else if err != nil {
+			VerbosePrintf("captureCreatedEpicID since=%s failed: %v (falling back to retroactive poll)\n", state.StartedAt, err)
 		}
 	}
-	return resolveDiscoveryFallback(cwd, state, tracker, logPath, nil)
+	// Retroactive-poll fallback. Result may be a stale epic; warning logged so
+	// downstream debugging is possible. Kept for cycles whose phase-1 did not
+	// create an epic (e.g. tasklist mode) and for cycles missing StartedAt.
+	if epicID, err := extractEpicID(state.Opts.BDCommand); err == nil {
+		VerbosePrintf("Warning: no epic created since %q; using retroactive poll fallback (got %q) — see soc-uo44\n", state.StartedAt, epicID)
+		return epicID, nil
+	} else {
+		return resolveDiscoveryFallback(cwd, state, tracker, logPath, err)
+	}
 }
 
 func resolveDiscoveryFallback(cwd string, state *phasedState, tracker trackerHealth, logPath string, epicErr error) (string, error) {


### PR DESCRIPTION
## Summary

Phase-1 cycle binding called `extractEpicID()` (cli/cmd/ao/rpi_phased_discovery.go:35) which polled `bd list --type epic --status open` and took the most-recently-created match. When stale unrelated open epics existed (e.g. `soc-scad`), every cycle bound to the wrong one and the phase-2 gate then asked the tracker about the wrong epic's children, decided BLOCKED, and orphaned the cycle's real commits on worktree cleanup.

Root cause behind the 2026-05-06 overnight `ao evolve --max-cycles=20` run that produced 4 cycles in 9 hours and landed 0 commits on main. Three commits (cycle 1 `2aac0116`, cycle 4 `5d3d0374`, cycle 5 `a8d4dba2`) were confirmed unreachable in `git fsck` and required manual recovery to `codex/preserve-*-cycleN` branches.

Add `captureCreatedEpicID(bdCommand, since)` which calls `bd list ... --created-after <since> --json` so only epics created during the current cycle are eligible. `resolveDiscoveryEpicID` now prefers this path, using `state.StartedAt` as the since-filter. `extractEpicID` retained as a last-resort fallback (with verbose warning) and documented as deprecated for cycle binding.

## Test plan

- [x] `TestCaptureCreatedEpicID_PrefersThisRunsCreation`
- [x] `TestCaptureCreatedEpicID_IgnoresStaleOpenEpics`
- [x] `TestCaptureCreatedEpicID_NoEpicCreatedThisCycleReturnsEmpty`
- [x] `TestCaptureCreatedEpicID_RequiresSinceTimestamp`
- [x] Build + vet clean
- [x] Full ./cmd/ao -short suite: ok 79.886s, no regressions

## Refs

- Bead: soc-uo44 ([mc-m3.5-pre1])
- Sibling PRs: S2 (soc-3mtv), S3 (soc-ewne), S4 (soc-k3fa) — all unblock M3.5 (soc-fu7v)