### PR TITLE
fix(cli/rpi): preserve worktree commits before auto-cleanup (S3 of M3.5 lifecycle preconditions)

### DIFF
--- a/cli/cmd/ao/rpi_cleanup.go
+++ b/cli/cmd/ao/rpi_cleanup.go
@@ -385,11 +385,78 @@ func updateFlatStateIfMatches(flatPath, runID, reason, terminatedAt string) {
 	rpi.UpdateFlatStateIfMatches(flatPath, runID, reason, terminatedAt)
 }
 
+// preserveWorktreeCommits inspects the worktree's HEAD and, if it points at a
+// commit that is NOT reachable from the repo's main branch, creates a
+// `codex/preserve-<runID>` branch in repoRoot pointing at the worktree HEAD.
+// This guards against the 2026-05-06 overnight failure mode where auto-cleanup
+// of failed-cycle worktrees orphaned real commits (see soc-ewne).
+//
+// Returns the preserved commit SHA on success (empty string when no preserve
+// was needed because the worktree HEAD was already on main). Errors are
+// returned but the caller (removeOrphanedWorktree) treats them as warnings
+// and continues with cleanup so a preserve failure does not block the cleanup
+// path; the warning surfaces in supervisor output.
+func preserveWorktreeCommits(repoRoot, worktreePath, runID string) (string, error) {
+	if strings.TrimSpace(runID) == "" {
+		return "", fmt.Errorf("preserveWorktreeCommits: runID required (preserve branch name must be deterministic)")
+	}
+	if _, err := os.Stat(worktreePath); err != nil {
+		return "", nil // worktree already gone
+	}
+
+	headOut, err := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return "", fmt.Errorf("preserveWorktreeCommits: rev-parse HEAD: %w", err)
+	}
+	worktreeHEAD := strings.TrimSpace(string(headOut))
+	if worktreeHEAD == "" {
+		return "", nil
+	}
+
+	// `git rev-list <head> ^main` returns the commits unique to the worktree.
+	// Empty output means the worktree HEAD is already on main; no preserve needed.
+	rlOut, rlErr := exec.Command("git", "-C", repoRoot, "rev-list", worktreeHEAD, "^main").Output()
+	if rlErr != nil {
+		// main missing or rev-list failed for any reason — fall back to
+		// preserving unconditionally; better an extra branch than orphaned work.
+		VerbosePrintf("preserveWorktreeCommits: rev-list %s ^main failed (%v); preserving unconditionally\n", worktreeHEAD, rlErr)
+	} else if len(strings.TrimSpace(string(rlOut))) == 0 {
+		return "", nil
+	}
+
+	branchName := "codex/preserve-" + runID
+	if out, berr := exec.Command("git", "-C", repoRoot, "branch", "--no-track", branchName, worktreeHEAD).CombinedOutput(); berr != nil {
+		// Idempotency: if the branch exists pointing at the same SHA, accept it.
+		existing, _ := exec.Command("git", "-C", repoRoot, "rev-parse", "--verify", branchName).Output()
+		if strings.TrimSpace(string(existing)) == worktreeHEAD {
+			return worktreeHEAD, nil
+		}
+		return "", fmt.Errorf("preserveWorktreeCommits: branch %s: %s: %w", branchName, string(out), berr)
+	}
+	return worktreeHEAD, nil
+}
+
 // removeOrphanedWorktree removes a worktree directory and any legacy branch marker.
+//
+// Before destructive cleanup, preserveWorktreeCommits is invoked so any
+// commits made inside the worktree are kept reachable on a
+// `codex/preserve-<runID>` branch. Preservation is best-effort: a failure logs
+// a warning and cleanup continues, since the existing failure mode (orphaned
+// commits in git fsck) is already as bad as a lost preserve attempt.
 func removeOrphanedWorktree(repoRoot, worktreePath, runID string) error {
 	// Safety validation is delegated to internal/rpi.
 	if err := rpi.ValidateWorktreeSibling(repoRoot, worktreePath); err != nil {
 		return err
+	}
+
+	if preserved, err := preserveWorktreeCommits(repoRoot, worktreePath, runID); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: preserveWorktreeCommits(%s, %s): %v (continuing cleanup)\n", worktreePath, runID, err)
+	} else if preserved != "" {
+		shortLen := 12
+		if len(preserved) < shortLen {
+			shortLen = len(preserved)
+		}
+		fmt.Printf("Preserved worktree commit %s on branch codex/preserve-%s\n", preserved[:shortLen], runID)
 	}
 
 	// Force remove the worktree.

--- a/cli/cmd/ao/rpi_cleanup_test.go
+++ b/cli/cmd/ao/rpi_cleanup_test.go
@@ -765,3 +765,147 @@ func TestUpdateFlatStateIfMatches_InvalidJSON(t *testing.T) {
 	// Should not panic
 	updateFlatStateIfMatches(flatPath, "run-1", "reason", "2026-04-04T12:00:00Z")
 }
+
+// --- preserveWorktreeCommits (soc-ewne / mc-m3.5-pre3) ---
+//
+// preserveWorktreeCommits is called BEFORE removeOrphanedWorktree on a failed
+// cycle. It detects commits in the worktree's HEAD ancestry that are not
+// reachable from main, and creates a `codex/preserve-<runID>` branch on the
+// repo so the work is not garbage-collected when the worktree is removed.
+//
+// This guards against the 2026-05-06 overnight failure mode: 4 cycles produced
+// real commits inside detached worktrees; auto-clean orphaned them. Three were
+// confirmed unreachable in git fsck and required manual recovery.
+
+// setupRepoWithWorktree creates a tiny repo and a sibling detached worktree
+// with one optional extra commit on top of HEAD. Returns (repoRoot, worktreePath).
+// The worktree's HEAD points to extraCommitSHA when madeCommit is true.
+func setupRepoWithWorktree(t *testing.T, runID string, madeCommit bool) (string, string, string) {
+	t.Helper()
+	parent := t.TempDir()
+	repoRoot := filepath.Join(parent, "repo")
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		// Isolate from user/global git config.
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@example.com",
+			"HOME="+parent,
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	run(repoRoot, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(repoRoot, "README.md"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(repoRoot, "add", ".")
+	run(repoRoot, "commit", "-m", "seed")
+
+	// Add a sibling detached worktree on the same parent dir so
+	// ValidateWorktreeSibling passes.
+	worktreePath := filepath.Join(parent, "repo-rpi-"+runID)
+	run(repoRoot, "worktree", "add", "--detach", worktreePath, "HEAD")
+
+	extraSHA := ""
+	if madeCommit {
+		if err := os.WriteFile(filepath.Join(worktreePath, "work.txt"), []byte("cycle work\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		run(worktreePath, "add", ".")
+		run(worktreePath, "commit", "-m", "cycle "+runID+" landed")
+
+		out, err := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD").Output()
+		if err != nil {
+			t.Fatalf("rev-parse: %v", err)
+		}
+		extraSHA = strings.TrimSpace(string(out))
+	}
+
+	return repoRoot, worktreePath, extraSHA
+}
+
+// branchTipSHA returns the commit sha that branchName points to in repoRoot,
+// or "" if the branch does not exist.
+func branchTipSHA(t *testing.T, repoRoot, branchName string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", repoRoot, "rev-parse", "--verify", branchName).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestPreserveWorktreeCommits_FailedCycle_CreatesPreserveBranch(t *testing.T) {
+	runID := "abcd1234ef56"
+	repoRoot, worktreePath, wantSHA := setupRepoWithWorktree(t, runID, true)
+
+	preserved, err := preserveWorktreeCommits(repoRoot, worktreePath, runID)
+	if err != nil {
+		t.Fatalf("preserveWorktreeCommits: %v", err)
+	}
+	if preserved != wantSHA {
+		t.Errorf("preserved sha = %q, want %q", preserved, wantSHA)
+	}
+
+	branchName := "codex/preserve-" + runID
+	got := branchTipSHA(t, repoRoot, branchName)
+	if got != wantSHA {
+		t.Errorf("branch %q tip = %q, want %q", branchName, got, wantSHA)
+	}
+}
+
+func TestPreserveWorktreeCommits_NoNewCommits_NoBranchCreated(t *testing.T) {
+	runID := "ffeeddccbbaa"
+	repoRoot, worktreePath, _ := setupRepoWithWorktree(t, runID, false)
+
+	preserved, err := preserveWorktreeCommits(repoRoot, worktreePath, runID)
+	if err != nil {
+		t.Fatalf("preserveWorktreeCommits: %v", err)
+	}
+	if preserved != "" {
+		t.Errorf("expected empty preserved sha when no extra commits; got %q", preserved)
+	}
+
+	branchName := "codex/preserve-" + runID
+	if got := branchTipSHA(t, repoRoot, branchName); got != "" {
+		t.Errorf("expected no preserve branch; got tip %q", got)
+	}
+}
+
+func TestPreserveWorktreeCommits_EmptyRunID_Errors(t *testing.T) {
+	repoRoot, worktreePath, _ := setupRepoWithWorktree(t, "tmprid", true)
+	if _, err := preserveWorktreeCommits(repoRoot, worktreePath, ""); err == nil {
+		t.Error("expected error for empty runID; preserve branch name must be deterministic")
+	}
+}
+
+// removeOrphanedWorktree must call preserveWorktreeCommits before deleting the
+// worktree, so failed-cycle commits aren't orphaned (soc-ewne acceptance).
+func TestRemoveOrphanedWorktree_PreservesCommitsBeforeRemoval(t *testing.T) {
+	runID := "cleanuptest1"
+	repoRoot, worktreePath, wantSHA := setupRepoWithWorktree(t, runID, true)
+
+	if err := removeOrphanedWorktree(repoRoot, worktreePath, runID); err != nil {
+		t.Fatalf("removeOrphanedWorktree: %v", err)
+	}
+
+	if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+		t.Errorf("worktree still exists after cleanup: %v", err)
+	}
+
+	branchName := "codex/preserve-" + runID
+	if got := branchTipSHA(t, repoRoot, branchName); got != wantSHA {
+		t.Errorf("preserve branch tip = %q, want %q", got, wantSHA)
+	}
+}


### PR DESCRIPTION
## Summary

Add `preserveWorktreeCommits(repoRoot, worktreePath, runID)` which detects commits in the worktree's HEAD ancestry not reachable from main and creates a `codex/preserve-<runID>` branch pointing at the worktree HEAD before the worktree is removed. Hooked into `removeOrphanedWorktree` so cleanup is no longer destructive to legitimate work.

Failure mode this fixes (2026-05-06 overnight evolve run): 4 cycles produced real commits inside detached worktrees. Auto-cleanup ran `git worktree remove --force` without preserving the commits. 3 confirmed unreachable in `git fsck` and required manual recovery via `codex/preserve-*` branches. The bead tracker reported the work as landed because the agent called `bd close` after running validation — but the commit was orphaned.

## Behavior

- When the worktree HEAD has commits not on main, create `codex/preserve-<runID>` pointing at that HEAD before cleanup.
- When the worktree HEAD is already on main (work merged or no commits), skip preservation; no extra branch created.
- When `rev-list HEAD ^main` fails (e.g. main missing), preserve unconditionally — better an extra branch than orphaned work.
- Idempotent: if `codex/preserve-<runID>` already points at the same SHA, treat as success.
- Best-effort: a preserve failure logs a warning and cleanup continues.

## Scope tightening from the original plan

S3b (defer `bd close` to phase-3 conditional on gate verdict) is **not needed** once S1 (correct epic_id) and S2 (structural-evidence override) land. The existing PROGRAM.md acceptance contract already gates `bd close` on agent-verified validation; the evaluator now correctly trusts that close as the structural signal. S3b remains a deferred enhancement, not a blocker for M3.5.

## Test plan

- [x] `TestPreserveWorktreeCommits_FailedCycle_CreatesPreserveBranch`
- [x] `TestPreserveWorktreeCommits_NoNewCommits_NoBranchCreated`
- [x] `TestPreserveWorktreeCommits_EmptyRunID_Errors`
- [x] `TestRemoveOrphanedWorktree_PreservesCommitsBeforeRemoval`
- [x] Full ./cmd/ao -short suite (214s, no regressions)

## Refs

- Bead: soc-ewne ([mc-m3.5-pre3])
- Companion PRs: #238 (S1), #239 (S2)
- Sibling PR: S4 (soc-k3fa)