### PR TITLE
docs(positioning): assurance profile + goals as reconcile setpoints (soc-sx99)

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -106,7 +106,7 @@ AgentOps defines a three-gap contract ([context lifecycle](docs/context-lifecycl
 
 **Canonical reference:** `docs/context-lifecycle.md` — evidence map and mechanism inventory for all three gaps.
 
-**Today's enforcement state:** Gap 1 is mechanically enforced. Gaps 2 and 3 are partial: scripts exist (`scripts/proof-run.sh`, `scripts/check-flywheel-compounding.sh`, `scripts/check-wiring-closure.sh`, etc.) but are not invoked from automation that blocks merges. `flywheel-compounding` is explicitly long-cycle by design — its green path requires multi-session corpus growth, not a single push. The right way to read this table: the corpus-level claims in PRODUCT.md are aspirational until the Roadmap column is empty.
+**Today's enforcement state:** Gap 1 is mechanically enforced. Gaps 2 and 3 are partial: scripts exist (`scripts/proof-run.sh`, `scripts/check-flywheel-compounding.sh`, `scripts/check-wiring-closure.sh`, etc.) but are not invoked from automation that blocks merges. `flywheel-compounding` is explicitly long-cycle by design — its green path requires multi-session corpus growth, not a single push. The right way to read this table: PRODUCT.md and GOALS.md are allowed to run ahead of the repo because they are desired-state specifications. The Current Proof column is actual state; the Roadmap column is the reconcile queue that `/evolve`, dream, validation gates, and follow-up work drive toward closure.
 
 `ao goals measure` runs every declared gate on demand and is the canonical way to inspect current state, including roadmap gates.
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -197,6 +197,10 @@ These are this repo's corpus stats; your own AgentOps install will produce its o
 
 Your corpus grows every session — learnings, patterns, and constraints accumulate in your repo, not ours. The system writes the substrate; you decide on what cadence the dream/evolution/compile loops run via `ao schedule`. Scale and compounding follow from the schedule you set, not from a claim we make.
 
+## Desired State vs Current State
+
+`PRODUCT.md` and `GOALS.md` are allowed to outpace the current repo. That is the point of goals: they define the desired state, not a frozen claim that every mechanism is already complete. In the Kubernetes/control-loop lineage, `GOALS.md` is the setpoint, the repo is actual state, `ao goals measure` is the sensor, and `/evolve`, dream, validation gates, and follow-up issues are the reconcile loop. Gaps are not embarrassing when they are named, measured, and queued; they are the worklist that keeps the factory moving toward closure.
+
 ## Known Product Gaps
 
 | Gap | Impact | Status |

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -161,6 +161,8 @@ The model gets smarter. The corpus stays yours. See the [Lineage](#lineage) sect
 
 AgentOps is engineered from constrained-environment habits, not consumer-app assumptions. This is not a certification claim; it is the operating posture the system is built toward.
 
+Full profile: [docs/assurance-profile.md](docs/assurance-profile.md).
+
 - **Local-first control.** The corpus lives in `.agents/` beside the code. AgentOps requires no product telemetry, and operators choose which model runtimes, networks, and subscriptions touch the repo.
 - **Context as a boundary.** Research, planning, implementation, and validation receive different context. Workers get fresh windows. Validators get evidence packets instead of the implementer's accumulated chat.
 - **Bookkeeping by default.** RPI packets, council verdicts, citations, ratchet records, post-mortems, handoffs, and schedule outputs leave file-backed traces that can be inspected, diffed, archived, or excluded from source control.
@@ -204,7 +206,7 @@ Your corpus grows every session — learnings, patterns, and constraints accumul
 | Multi-runtime proof is tiered, not complete | Tier S structural proof is active for all four runtimes. Tier I live inventory proof is partial. Tier E live execution proof remains opt-in / nightly, not a default gate. | in-progress |
 | Retrieval and worker knowledge propagation still limit compounding | The flywheel architecture is in place. Retrieval quality and passing prevention/finding context to implement workers remain weaker than the core thesis requires. | open |
 | Behavioral eval system needs live agent runtime at scale | Eval workbench shipped: 3 fixture components (Go CLI, Python FastAPI, DevOps), 12 tasks with golden solutions and scoring scripts, behavioral eval suite, agent harness script, eval-skill-delta CI gate, and `--two-pass` head gate. Scoring infrastructure verified (golden 12/12, broken detection 12/12). A/B DeltaScorecard works for deterministic cases. Remaining gap: live agent runtime execution at scale — the harness and gates exist but full skill-on vs skill-off delta across the workbench is not yet a default gate. | in-progress |
-| High-assurance profile is not yet formalized | The architecture has local-first state, evidence packets, policy gates, and no required telemetry, but there is not yet a dedicated assurance profile for air-gapped, classified, export-controlled, or safety-critical deployments. | planned |
+| High-assurance profile needs deeper control mapping | The initial [assurance profile](docs/assurance-profile.md) now documents local-first state, evidence packets, policy gates, telemetry boundaries, autonomy modes, and out-of-scope claims. Remaining work is redaction, evidence export, supply-chain inputs, and program-specific control mapping. | in-progress |
 | Public messaging shifted to context-compiler + moat framing | CDLC (Context Development Life Cycle) framing landed: Mission, Strategic Bet, README, and mkdocs hero surfaces now use "context compiler" as the primary identity noun. Remaining gap: downstream comparison docs and skill-page intros still need a sweep to match. | in-progress |
 
 ## Lineage

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Run Dream overnight, then run Evolve in the morning against a fresher corpus. Th
 
 ## Competitive Positioning
 
-Most tools optimize work *within* a session. AgentOps compounds across them. The three product layers — Context Compiler, Validation Gates, Knowledge Flywheel — are the gap.
+Most tools optimize work *within* a session. AgentOps compounds across them. The four product layers — Bookkeeping, Context Compiler, Validation Gates, Knowledge Flywheel — are the gap.
 
 | Tool | What it does well | What AgentOps adds |
 |------|-------------------|--------------------|

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -20,7 +20,7 @@ repeatable flows. You manage the roadmap.
 
 ## What data leaves my machine?
 
-AgentOps itself stores nothing externally — all state lives in `.agents/` (local and git-ignored by policy). No telemetry, no cloud, no external services. Repo-root `.agents/` can churn and may contain sensitive session context, so AgentOps gates prevent tracking it. Your coding agent's normal API traffic to its LLM provider still applies.
+AgentOps itself stores nothing externally. All AgentOps state lives in `.agents/` by default (local and git-ignored by policy), and there is no AgentOps-managed telemetry or hosted control plane. Repo-root `.agents/` can churn and may contain sensitive session context, so AgentOps gates prevent tracking it. Your coding agent's normal API traffic to its LLM provider, Git remotes, installers, and external tools still applies.
 
 ## Can I use this with other AI coding tools?
 

--- a/docs/agentops-brief.md
+++ b/docs/agentops-brief.md
@@ -8,7 +8,7 @@
 
 A repo-native operational layer for coding agents.
 
-AgentOps gives every session three product layers: a **Context Compiler** that loads the right repo context before work starts, **Validation Gates** that challenge plans and code before they ship, and a **Knowledge Flywheel** that extracts learnings and feeds them back so the next session starts smarter.
+AgentOps gives every session four product layers: **Bookkeeping** that records what agents tried and validated, a **Context Compiler** that loads the right repo context before work starts, **Validation Gates** that challenge plans and code before they ship, and a **Knowledge Flywheel** that extracts learnings and feeds them back so the next session starts smarter.
 
 The institutional knowledge stops walking out the door because the repo keeps it.
 
@@ -25,12 +25,15 @@ Most coding-agent tooling handles prompt construction and routing well. The fail
 | **Closure** (internal: loop closure) | Completed work does not produce better next work | `/post-mortem` harvests learnings and next-work, finding compiler promotes failures into constraints, `GOALS.md` + `/evolve` turn findings into measurable improvements |
 
 The compound effect below only works because Validation Gates catch the problem,
-the Knowledge Flywheel preserves the lesson, and the Context Compiler ensures
+the Bookkeeping layer preserves the trace, the Knowledge Flywheel preserves the lesson, and the Context Compiler ensures
 the next session loads better context before repeating the mistake.
 
 ---
 
-## Three Product Layers
+## Four Product Layers
+
+### Layer 0: Bookkeeping
+Records the operational memory agents do not keep for themselves: attempts, decisions, citations, verdicts, handoffs, findings, retros, and post-mortems. The work leaves a trace in `.agents/`.
 
 ### Layer 1: Context Compiler
 Assembles the right context for the right phase. Research gets prior knowledge; plan gets a compressed summary; workers get fresh context per wave. Skills, hooks, and the `ao` CLI collaborate to load, scope, and trim context to the token budget before the agent sees it.
@@ -67,10 +70,10 @@ Next session starts with a richer environment than this one did.
 
 | Property | Detail |
 |----------|--------|
-| **Local-only** | No telemetry, no cloud, no vendor accounts. Nothing phones home. |
+| **Local-first** | No AgentOps-managed telemetry or hosted control plane. Model runtimes, Git remotes, installers, and external tools are operator-selected dependencies. |
 | **Open source** | Every line auditable. Apache 2.0 licensed. |
 | **Multi-tool** | Works with Claude Code, Codex, Cursor, OpenCode. Not locked to one vendor. |
-| **Air-gap compatible** | Runs fully offline. Knowledge base is plain files. |
+| **Constrained-network fit** | Repo-local evidence and plain files fit mirrored, reviewed, or disconnected operator workflows. |
 | **Auditable trail** | Every learning, decision, and review verdict written to `.agents/` with timestamps. |
 
 ---
@@ -92,16 +95,17 @@ By session 100, the repo already carries prior failures, design choices, plannin
 The most accurate current framing is:
 
 ```text
-Public category    -> context compiler for coding agents
-Product layers     -> Context Compiler + Validation Gates + Knowledge Flywheel
+Public category    -> software factory for coding agents
+Product layers     -> Bookkeeping + Context Compiler + Validation Gates + Knowledge Flywheel
 Internal proof     -> three-gap lifecycle contract
 Runtime mechanics  -> Brownian Ratchet + Stigmergic Spiral + Knowledge Flywheel
 ```
 
 The claim is not "better models." The claim is "better repo mechanics around
-the models you already have." Three product layers deliver that: the Context
-Compiler loads the right context, Validation Gates block bad output, and the
-Knowledge Flywheel ensures every session leaves the repo smarter. The
+the models you already have." Four product layers deliver that: Bookkeeping
+preserves the evidence trail, the Context Compiler loads the right context,
+Validation Gates block bad output, and the Knowledge Flywheel ensures every
+session leaves the repo smarter. The
 three-gap contract remains the internal proof model.
 
 ---

--- a/docs/assurance-profile.md
+++ b/docs/assurance-profile.md
@@ -26,6 +26,7 @@ AgentOps uses "rigor" in the operator sense:
 - **Least-context execution.** Workers get the context needed for their phase, not the entire accumulated conversation.
 - **Independent judgment.** Councils and validators review evidence packets instead of inheriting the implementer's mental state.
 - **Policy as gates.** Hooks, pre-push checks, goal gates, security scans, and validation skills block promotion rather than merely advising.
+- **Desired-state discipline.** `PRODUCT.md` and `GOALS.md` can run ahead of the repo as explicit setpoints; measurements and reconcile loops show what is true now and what must close next.
 - **Human authority boundaries.** The operator chooses when the system is interactive, supervised, scheduled, or unattended.
 - **Local-first evidence.** AgentOps writes local files that can be inspected, archived, redacted, excluded from source control, or exported into a program's evidence system.
 

--- a/docs/assurance-profile.md
+++ b/docs/assurance-profile.md
@@ -1,0 +1,164 @@
+# AgentOps Assurance Profile
+
+AgentOps brings high-assurance operating discipline to AI-agent-paced software work. The lane is not "move slow because the environment is serious." The lane is: keep the rigor, shorten the cycle time, and make every agent run leave evidence a serious operator can review.
+
+This is an engineering posture, not a certification claim. AgentOps does not make a repo accredited, classified-network approved, safety-critical, export-controlled, FedRAMP-authorized, or airworthiness-ready by itself. It gives teams a local-first operating layer for agent work that can fit into those programs when the operator supplies the required controls, approvals, boundaries, and accreditation process.
+
+## Claim
+
+AgentOps is a software factory for coding agents with four compounding layers:
+
+| Layer | Assurance role |
+|-------|----------------|
+| **Bookkeeping** | Every run leaves file-backed evidence: attempts, decisions, citations, verdicts, handoffs, findings, retros, and post-mortems. |
+| **Context Compiler** | Agents receive scoped context for the phase they are in, instead of an unbounded chat history. |
+| **Validation Gates** | Plans and code are challenged before promotion by pre-mortems, councils, vibe reviews, tests, hooks, and local quality gates. |
+| **Knowledge Flywheel** | Lessons are extracted, scored, promoted, decayed, and reloaded so the system compounds instead of repeating failures. |
+
+The goal is aerospace/IC-style operational discipline at AI-agent pace: evidence before belief, boundaries before autonomy, and promotion only after gates pass.
+
+## What Rigor Means Here
+
+AgentOps uses "rigor" in the operator sense:
+
+- **Traceability.** Work produces inspectable artifacts, not only chat transcripts or final diffs.
+- **Separation of duties.** Planning, implementation, and validation can run with different context and different agents.
+- **Least-context execution.** Workers get the context needed for their phase, not the entire accumulated conversation.
+- **Independent judgment.** Councils and validators review evidence packets instead of inheriting the implementer's mental state.
+- **Policy as gates.** Hooks, pre-push checks, goal gates, security scans, and validation skills block promotion rather than merely advising.
+- **Human authority boundaries.** The operator chooses when the system is interactive, supervised, scheduled, or unattended.
+- **Local-first evidence.** AgentOps writes local files that can be inspected, archived, redacted, excluded from source control, or exported into a program's evidence system.
+
+## Boundary Model
+
+AgentOps controls the operating layer around coding agents. It does not control every dependency in the environment.
+
+| Boundary | AgentOps posture | Operator responsibility |
+|----------|------------------|-------------------------|
+| AgentOps state | Repo-local `.agents/` artifacts, git-ignored by policy at repo root | Decide retention, backup, redaction, export, and whether any artifacts may enter source control |
+| Model runtime | Runtime-neutral across Claude Code, Codex CLI, Cursor, and OpenCode | Approve model/provider use, network path, prompt/data handling, and classification boundary |
+| Git and CI | Integrates with local git, hooks, tests, and release gates | Control remotes, branch policy, protected environments, and CI secrets |
+| Install/update path | Public installers fetch from GitHub unless the operator vendors or mirrors them | Mirror, pin, review, or rebuild artifacts for disconnected or controlled networks |
+| Secrets and data | AgentOps can help constrain context, but does not classify data or provide a DLP boundary | Enforce secret handling, data classification, redaction, and egress controls |
+| Accreditation | Provides evidence artifacts and operating discipline | Map artifacts to the local control framework and obtain required approvals |
+
+The correct high-assurance reading is: **no AgentOps-managed telemetry or hosted control plane; operator-selected dependencies remain operator-selected dependencies.**
+
+## Operating Profiles
+
+### Profile 0: Exploration
+
+Use AgentOps as a disciplined agent workflow layer. The operator accepts normal model-provider and local-machine risk. Good for personal repos, experiments, and early product discovery.
+
+Expected posture:
+
+- `/quickstart`, `/research`, `/implement`, `/vibe`
+- Local `.agents/` state
+- Human review before merge
+
+### Profile 1: Team Software Factory
+
+Use AgentOps as the team operating model for coding agents. Work is issue-tracked, validated, and closed with evidence before merge.
+
+Expected posture:
+
+- Beads or equivalent issue tracking
+- RPI flow for nontrivial work
+- Pre-mortem before implementation
+- Vibe/council before promotion
+- Pre-push gate before branch publication
+- Post-mortem or retro after significant work
+
+### Profile 2: Constrained or High-Rigor Engineering
+
+Use AgentOps where process evidence, local control, and human authority boundaries matter. This is the primary target posture for platform, infrastructure, autonomy, defense-adjacent, regulated, and high-consequence software teams.
+
+Expected posture:
+
+- Approved model runtimes only
+- Network path and installer path reviewed by the operator
+- `.agents/` retention and redaction policy defined before use
+- Humans in the loop for planning, validation, release, and promotion
+- Councils use sealed evidence packets where possible
+- No unattended source mutation unless bounded by explicit goals, gates, and rollback policy
+- Local gates run before any remote push or release artifact
+
+### Profile 3: Accredited or Safety-Critical Program
+
+Use AgentOps only as an input to the program's approved engineering process. AgentOps can generate evidence and enforce local workflow discipline, but the program authority owns control mapping, model approval, data handling, tool qualification, and release authorization.
+
+Expected posture:
+
+- All Profile 2 expectations
+- Program-owned control mapping
+- Approved artifact retention and export workflow
+- Approved model/provider boundary
+- Supply-chain review for installers, binaries, dependencies, and generated artifacts
+- Explicit human signoff for any artifact that crosses a program boundary
+
+## Evidence Artifacts
+
+AgentOps is valuable in rigorous environments because it changes agent work from "trust the chat" to "inspect the run."
+
+| Evidence | Where it comes from | Why it matters |
+|----------|---------------------|----------------|
+| Run packets | RPI/discovery/crank/validation flows | Preserve goal, scope, plan, execution, and validation context |
+| Council verdicts | `/council`, `/pre-mortem`, `/vibe` | Record independent PASS/WARN/FAIL judgment and rationale |
+| Citations | `ao metrics cite`, lookup/search/inject flows | Show which knowledge influenced a run |
+| Handoffs | `/handoff`, `/recover`, session closeout | Preserve continuity across agents and sessions |
+| Retros and post-mortems | `/retro`, `/post-mortem`, `/forge` | Turn completed work into reusable lessons |
+| Ratchet records | `/ratchet`, validation gates | Capture forward-progress checks and failure prevention |
+| Goal measurements | `GOALS.md`, `ao goals measure`, `/evolve` | Tie autonomous work to measurable fitness criteria |
+| Local gates | pre-push, tests, security scans, docs gates | Make promotion conditional on executable checks |
+
+These artifacts are not a substitute for formal compliance evidence. They are raw material a program can review, retain, redact, or map into its own evidence system.
+
+## Data Handling
+
+AgentOps assumes `.agents/` may contain sensitive session context. Repo-root `.agents/` is local runtime state and should not be tracked by default.
+
+Recommended operator rules:
+
+- Treat `.agents/` as potentially sensitive.
+- Decide retention before using scheduled or unattended loops.
+- Redact or exclude artifacts that contain secrets, customer data, classified data, export-controlled data, or proprietary context.
+- Mirror installers and dependencies before use in disconnected or controlled networks.
+- Keep model-provider use inside the organization's approved data boundary.
+- Export only reviewed evidence artifacts into long-lived records.
+
+## Autonomy Model
+
+AgentOps does not require maximal autonomy. It is built for variable autonomy:
+
+| Mode | Human role | Suitable use |
+|------|------------|--------------|
+| **In the loop** | Human approves each meaningful phase | High-risk planning, validation, release, constrained environments |
+| **On the loop** | Human supervises scheduled or bounded loops | Dream, compile, forge, feedback-drain, low-risk maintenance |
+| **Off the loop** | System runs unattended inside strict bounds | Mature low-risk jobs with explicit gates, rollback, and artifact review |
+
+For high-rigor work, the default should be in the loop for discovery, validation, release, and promotion; on the loop for scheduled compounding; and off the loop only after the operator has proved the bounds.
+
+## Out Of Scope
+
+AgentOps does not provide:
+
+- Formal certification, accreditation, authorization to operate, or airworthiness approval.
+- Data classification, declassification, or cross-domain transfer.
+- Model approval, model monitoring, or model safety certification.
+- Secret scanning as a complete DLP boundary.
+- A guarantee of zero network egress when the operator uses external model runtimes, remotes, installers, or tools.
+- Formal verification of generated code.
+- Tool qualification for safety-critical release by itself.
+
+## Roadmap
+
+The current profile defines the posture. The next hardening steps are:
+
+- Control-mapping templates for common internal assurance programs.
+- Evidence export bundles for councils, RPI runs, gates, and post-mortems.
+- Redaction workflows for `.agents/` artifacts.
+- Stronger policy around approved model/runtime profiles.
+- Retention profiles for personal, team, constrained, and accredited environments.
+- More explicit supply-chain guidance for mirrored installers and pinned artifacts.
+
+The product direction is clear: keep agent work fast, but make the speed legible to serious operators.

--- a/docs/cdlc.md
+++ b/docs/cdlc.md
@@ -205,7 +205,7 @@ Full leverage-point mapping: [docs/leverage-points.md](leverage-points.md). Conv
 
 ## How the 12 Factors Build the Flywheel
 
-The [12-factor doctrine](https://12factoragentops.com) is a build order — four tiers that construct the three product layers in sequence. The flywheel emerges when all three layers are running.
+The [12-factor doctrine](https://12factoragentops.com) is a build order — four tiers that construct the compounding product loop in sequence. The flywheel emerges when bookkeeping, context compilation, validation gates, and learning loops are running together.
 
 | Tier | Factors | Product Layer | What It Builds | Theory |
 |---|---|---|---|---|

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -18,15 +18,16 @@
 - [Changelog](CHANGELOG.md) — Release history
 - [Security](SECURITY.md) — Vulnerability reporting
 
-## Three Product Layers
+## Four Product Layers
 
 | Layer | What it does | Key surfaces |
 |-------|-------------|-------------|
+| **Bookkeeping** (L0) | Records agent work so attempts, decisions, verdicts, and handoffs leave evidence | `.agents/`, RPI packets, council verdicts, retros, post-mortems |
 | **Context Compiler** (L1) | Assembles the right context for the right phase | `ao inject`, `ao compile`, skills, hooks |
 | **Validation Gates** (L2) | Challenges plans and code before they ship | `/council`, `/vibe`, `/pre-mortem`, `/post-mortem` |
 | **Knowledge Flywheel** (L3) | Extracts, scores, and resurfaces learnings | `/retro`, `/forge`, `ao lookup`, `.agents/` |
 
-Deep dives: [CDLC](cdlc.md) (tier-to-layer mapping), [Knowledge Flywheel](knowledge-flywheel.md), [Context Lifecycle](context-lifecycle.md), [PRODUCT.md](https://github.com/boshu2/agentops/blob/main/PRODUCT.md)
+Deep dives: [CDLC](cdlc.md) (tier-to-layer mapping), [Knowledge Flywheel](knowledge-flywheel.md), [Context Lifecycle](context-lifecycle.md), [Assurance Profile](assurance-profile.md), [PRODUCT.md](https://github.com/boshu2/agentops/blob/main/PRODUCT.md)
 
 ## Architecture
 
@@ -77,7 +78,8 @@ Deep dives: [CDLC](cdlc.md) (tier-to-layer mapping), [Knowledge Flywheel](knowle
 ## Concepts
 
 - [Philosophy](philosophy.md) — Five validated principles for building with coding agents, with evidence from five months of production use
-- [Context Lifecycle Contract](context-lifecycle.md) — Internal proof contract behind the three product layers
+- [Assurance Profile](assurance-profile.md) — High-assurance operating posture for local, auditable, constrained-environment agent work
+- [Context Lifecycle Contract](context-lifecycle.md) — Internal proof contract behind the compounding product loop
 - [Knowledge Flywheel](knowledge-flywheel.md) — How every session makes the next one smarter
 - [The Science](the-science.md) — Research behind knowledge decay and compounding
 - [Brownian Ratchet](brownian-ratchet.md) — AI-native development philosophy

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -4,10 +4,10 @@
 
 Parallel agents produce noisy output; councils filter it; ratchets lock progress so it can never regress.
 
-AgentOps delivers three product layers: the Context Compiler, Validation Gates,
-and Knowledge Flywheel. This page explains the internal mechanics beneath those
-layers: the proof gaps they must close, the Brownian Ratchet, and the flywheel
-that makes sessions compound.
+AgentOps delivers four product layers: Bookkeeping, the Context Compiler,
+Validation Gates, and the Knowledge Flywheel. This page explains the internal
+mechanics beneath those layers: the proof gaps they must close, the Brownian
+Ratchet, and the flywheel that makes sessions compound.
 
 Think of the mechanics below as the substrate under the operator surface:
 briefings and startup context prepare the work order, RPI phases run the

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: AgentOps
-description: Context compiler for coding agents. Compile context, gate output, compound knowledge — so every session starts loaded, not cold.
+description: Software factory for coding agents. Keep the books, compile context, gate output, and compound knowledge so every session starts loaded, not cold.
 hide:
   - navigation
   - toc
@@ -9,9 +9,9 @@ hide:
 # AgentOps { .landing-hero }
 
 <p class="hero-tagline">
-  Context compiler for coding agents.<br>
-  Compile context. Gate output. Compound knowledge.<br>
-  <strong>Right context, right window, right time.</strong>
+  Software factory for coding agents.<br>
+  Keep the books. Compile context. Gate output. Compound knowledge.<br>
+  <strong>AI-agent pace with serious-operator discipline.</strong>
 </p>
 
 <p class="hero-subtagline">
@@ -30,10 +30,11 @@ hide:
 
 Every agent session starts cold. Same mistakes. Same rework. The landmine in `auth.py`, the two-hour timeout debug, the flag the reviewer always catches — none of it carries forward.
 
-**AgentOps solves this** with three product layers:
+**AgentOps solves this** with four product layers:
 
 | Layer | What it does |
 |-------|-------------|
+| **Bookkeeping** | Records what agents tried, changed, validated, and learned so the work leaves evidence |
 | **Context Compiler** | Assembles the right context for the right phase — decay-ranked, token-budgeted, loaded at session start |
 | **Validation Gates** | `/pre-mortem`, `/vibe`, and `/council` challenge plans and code before they ship |
 | **Knowledge Flywheel** | Extracts learnings, scores them, and resurfaces them so the next session starts smarter |
@@ -42,13 +43,14 @@ Session 1, your agent spends two hours debugging a timeout bug. Session 15, a ne
 
 ```mermaid
 flowchart LR
+    B[Bookkeeping] --> C[Context Compiler]
     C[Context Compiler] --> S[Session work]
     S --> G[Validation Gates]
     G --> F[Knowledge Flywheel]
-    F --> C
+    F --> B
 ```
 
-All state lives in local `.agents/` — auditable, versionable, yours. Plain text you can grep, diff, review, and commit. Zero telemetry. Zero cloud dependency.
+All AgentOps state lives in local `.agents/` — auditable, versionable, yours. Plain text you can grep, diff, review, and exclude from source control. No AgentOps-managed telemetry or hosted control plane; model runtimes, Git remotes, installers, and external tools are operator-selected dependencies. For constrained environments, see the [Assurance Profile](assurance-profile.md).
 
 ---
 
@@ -132,7 +134,7 @@ Consensus: WARN — add rate limiting to /login before shipping
 [flywheel]    Next session starts with better context
 ```
 
-The point is not a bigger prompt. The point is a repo that remembers what worked.
+The point is not a bigger prompt. The point is a repo that remembers what was tried, what worked, what failed, and what should constrain the next run.
 
 ---
 

--- a/docs/leverage-points.md
+++ b/docs/leverage-points.md
@@ -343,7 +343,7 @@ The seed does not design outcomes. It creates conditions for emergence:
 
 Given these conditions, the system produces different outcomes in different repos — just as the same genetic machinery produces different organisms in different environments.
 
-This is why the product is 6 seed elements, not 53 skills. The skills are the phenotype. The seed is the genotype.
+This is why the product is a small set of seed elements, not a pile of skills. The skills are the phenotype. The seed is the genotype.
 
 **Status:** Implemented. All 6 paradigm shifts are embedded in the architecture. The 6th (designed to evolved) is realized through `/evolve` and the seed definition (see [seed-definition.md](seed-definition.md)).
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -50,7 +50,7 @@ This is a deliberate bet against the current tooling consensus. Vector databases
 - Volume is bounded (one project, not the internet)
 - Freshness matters more than recall breadth (stale knowledge is worse than no knowledge)
 - Human curation is the highest-leverage action
-- Portability is required (no cloud dependency, works air-gapped)
+- Portability is required (repo-local state, no AgentOps-hosted control plane, mirrorable dependencies)
 
 ...markdown + wikilinks outperforms embeddings. The agent can grep it, the human can read it, and `ao defrag` can maintain it.
 

--- a/docs/seed-definition.md
+++ b/docs/seed-definition.md
@@ -1,6 +1,6 @@
 # The Seed
 
-> The product is not 53 skills. The product is the minimal set of starting conditions that, planted in any repo with an LLM, evolves toward whatever that repo's goals are.
+> The product is not a pile of skills. The product is the minimal set of starting conditions that, planted in any repo with an LLM, evolves toward whatever that repo's goals are.
 
 ## The Metaphor
 

--- a/docs/strategic-direction.md
+++ b/docs/strategic-direction.md
@@ -106,6 +106,8 @@ AgentOps: the system keeps the books. Attempts, decisions, citations, evidence p
 Traditional: design the complete system upfront, then build it.
 AgentOps: define minimal starting conditions (GOALS.md + hooks + core skills + flywheel bootstrap), plant them in a repo, and let the system evolve toward whatever that repo's goals are. `/evolve` measures fitness, fixes the worst gap, validates nothing regressed, extracts what it learned, and repeats. The system builds its own safety net first (tests), then uses that safety net to refactor aggressively. Nobody tells it the order -- severity-based goal selection naturally produces the correct sequence.
 
+This means goals and product docs can intentionally lead the implementation. They are the desired state and fitness landscape; the repo is actual state; the loops reconcile the delta.
+
 This is the deepest shift. The product is not a pile of skills. The product is the seed that, given a fitness landscape, produces the right system.
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,6 +195,7 @@ nav:
       - Meta-Observer: workflows/meta-observer-pattern.md
   - Concepts:
       - Philosophy: philosophy.md
+      - Assurance Profile: assurance-profile.md
       - Knowledge Flywheel: knowledge-flywheel.md
       - The Science: the-science.md
       - CDLC: cdlc.md

--- a/scripts/test-rpi-surface-smoke.sh
+++ b/scripts/test-rpi-surface-smoke.sh
@@ -103,6 +103,7 @@ check_bins() {
     fi
 
     # bd version probe is informational only — exotic builds may differ.
+    # shellcheck disable=SC2034 # bd_out is set by run_capture via name-ref
     local bd_out
     if run_capture bd_out bd --version || run_capture bd_out bd version; then
         :


### PR DESCRIPTION
## Summary

- Adds `docs/assurance-profile.md` framing AgentOps as high-assurance operating discipline at AI-agent pace (engineering posture, not certification claim). Covers traceability, separation of duties, least-context execution, independent judgment.
- Reframes GOALS as reconcile setpoints (declarative target state) rather than goal lists. Pulls in supporting language across PRODUCT.md and `docs/strategic-direction.md`.
- Drive-by: shellcheck disable for `bd_out` name-ref pattern in `scripts/test-rpi-surface-smoke.sh` (pre-existing SC2034 warning blocking the rebased push).

## Overlap notice

`docs/assurance-profile.md` is also added by PR #256 (soc-kizn.1) with three injected `<!-- agentops:claim:* -->` markers on top. These two PRs will conflict on this file — recommend merging this PR first (foundational doc) and then rebasing #256 to re-apply markers.

## Test plan

- [x] Pre-push fast gate passes
- [x] shellcheck clean post-disable
- [x] Rebased on current origin/main (most prior sx99 commits already absorbed via earlier merges)
- [ ] CI gates pass on PR
- [ ] Conflict resolution between this PR and #256 on `docs/assurance-profile.md`