### PR TITLE
Daemon RPI runner emits agent-update events on phase boundaries (soc-y0ct.2)

### DIFF
--- a/cli/cmd/ao/agentopsd.go
+++ b/cli/cmd/ao/agentopsd.go
@@ -577,9 +577,15 @@ func buildAgentOpsDaemonCLIFallbackRPIExecutor(cwd string, runOverride daemonpkg
 	if run == nil {
 		run = defaultCLIFallbackRPIRunFunc
 	}
+	// soc-y0ct.2: pass the daemon Store so the executor emits agent-update
+	// events on phase boundaries (phase_start before runner, phase_complete +
+	// phase_handoff after). Tests that don't need ledger emission omit Store
+	// and the executor falls back to runner-only behavior.
 	return daemonpkg.NewRPIRunExecutor(daemonpkg.RPIRunExecutorOptions{
-		Root: cwd,
-		Run:  run,
+		Root:  cwd,
+		Run:   run,
+		Store: daemonpkg.NewStore(cwd),
+		Actor: "agentopsd-rpi-run",
 	})
 }
 

--- a/cli/internal/daemon/rpi_run.go
+++ b/cli/internal/daemon/rpi_run.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // RPIRunRequest is the per-job input handed to the runner function injected
@@ -36,9 +37,17 @@ type RPIRunResult struct {
 type RPIRunFunc func(ctx context.Context, req RPIRunRequest) (RPIRunResult, error)
 
 // RPIRunExecutorOptions configures NewRPIRunExecutor.
+//
+// Store/Clock/Actor are optional. When Store is non-nil, RunJob emits agent-update
+// ledger events on phase boundaries (phase_start before the runner; phase_complete
+// + phase_handoff after) per soc-y0ct.2. When Store is nil, no events are emitted —
+// preserves back-compat with sub-wave 5a tests that injected a fake runner only.
 type RPIRunExecutorOptions struct {
-	Run  RPIRunFunc
-	Root string
+	Run   RPIRunFunc
+	Root  string
+	Store *Store
+	Clock func() time.Time
+	Actor string
 }
 
 // RPIRunExecutor is a JobExecutor for rpi.run that calls the injected runner
@@ -46,13 +55,17 @@ type RPIRunExecutorOptions struct {
 // CLI-fallback wire-up. Mirrors DreamExecutor's function-pointer pattern.
 //
 // soc-bcrn.3.6 (E3.W4 sub-5a): see RPIRunRequest for context.
+// soc-y0ct.2: emits agent-update events on phase boundaries when store != nil.
 type RPIRunExecutor struct {
-	run  RPIRunFunc
-	root string
+	run   RPIRunFunc
+	root  string
+	store *Store
+	now   func() time.Time
+	actor string
 }
 
-// NewRPIRunExecutor constructs an RPIRunExecutor. Both the runner function and
-// the root cwd are required.
+// NewRPIRunExecutor constructs an RPIRunExecutor. Run and Root are required;
+// Store/Clock/Actor are optional and gate agent-update emission.
 func NewRPIRunExecutor(opts RPIRunExecutorOptions) (*RPIRunExecutor, error) {
 	if opts.Run == nil {
 		return nil, errors.New("rpi run executor: Run is required")
@@ -60,7 +73,15 @@ func NewRPIRunExecutor(opts RPIRunExecutorOptions) (*RPIRunExecutor, error) {
 	if strings.TrimSpace(opts.Root) == "" {
 		return nil, errors.New("rpi run executor: Root is required")
 	}
-	return &RPIRunExecutor{run: opts.Run, root: opts.Root}, nil
+	now := opts.Clock
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	actor := strings.TrimSpace(opts.Actor)
+	if actor == "" {
+		actor = "agentopsd-rpi-run"
+	}
+	return &RPIRunExecutor{run: opts.Run, root: opts.Root, store: opts.Store, now: now, actor: actor}, nil
 }
 
 // JobTypes reports the queue job types this executor handles.
@@ -87,20 +108,85 @@ func (e *RPIRunExecutor) RunJob(ctx context.Context, claim QueueClaim) (JobExecu
 	if err := validateRPIRunFullRun(spec); err != nil {
 		return JobExecutionResult{Artifacts: artifacts}, err
 	}
+
+	queue := e.queueOrNil()
+	e.emitAgentUpdate(claim, queue, NewAgentUpdatePhaseStartEvent(AgentUpdatePhaseStart{
+		PhaseName: "rpi.run",
+		RunID:     spec.RunID,
+		Timestamp: e.now().UTC().Format(time.RFC3339Nano),
+	}))
+
+	startedAt := e.now()
 	res, err := e.run(ctx, RPIRunRequest{Spec: spec, Claim: claim, Root: e.root})
-	if err != nil {
-		// Merge any runner-emitted artifacts even on failure so operators can
-		// inspect partial outputs (e.g., the run log path the runner already
-		// opened) alongside the failure record.
-		for k, v := range res.Artifacts {
-			artifacts[k] = v
-		}
-		return JobExecutionResult{Artifacts: artifacts}, err
-	}
+	durationMs := e.now().Sub(startedAt).Milliseconds()
+
+	// Merge runner-emitted artifacts (success or failure) so operators can inspect
+	// partial outputs (e.g., the run log path the runner already opened).
 	for k, v := range res.Artifacts {
 		artifacts[k] = v
 	}
-	return JobExecutionResult{Artifacts: artifacts}, nil
+
+	completeStatus := "success"
+	if err != nil {
+		completeStatus = "failure"
+	}
+	e.emitAgentUpdate(claim, queue, NewAgentUpdatePhaseCompleteEvent(AgentUpdatePhaseComplete{
+		PhaseName:  "rpi.run",
+		RunID:      spec.RunID,
+		Timestamp:  e.now().UTC().Format(time.RFC3339Nano),
+		Status:     completeStatus,
+		DurationMs: durationMs,
+		Artifacts:  res.Artifacts,
+	}))
+
+	if err == nil {
+		e.emitAgentUpdate(claim, queue, NewAgentUpdatePhaseHandoffEvent(AgentUpdatePhaseHandoff{
+			FromPhase:  "rpi.run",
+			ToPhase:    "operator",
+			RunID:      spec.RunID,
+			Timestamp:  e.now().UTC().Format(time.RFC3339Nano),
+			PacketPath: spec.ExecutionPacketPath,
+		}))
+	}
+
+	return JobExecutionResult{Artifacts: artifacts}, err
+}
+
+// queueOrNil returns a Queue scoped to this executor's actor/clock when a Store
+// is configured, otherwise nil. Used to mint deterministic event IDs without
+// forcing every caller to pass a Queue through.
+func (e *RPIRunExecutor) queueOrNil() *Queue {
+	if e.store == nil {
+		return nil
+	}
+	return NewQueue(e.store, QueueOptions{Actor: e.actor, Now: e.now})
+}
+
+// emitAgentUpdate stamps the boilerplate ledger fields onto a payload-only
+// LedgerEventInput from the agent_update.go constructors and appends to the
+// store. No-op when the executor has no Store configured (back-compat with
+// callers that only inject a runner). Errors are logged via the queue contract
+// but do not fail the job — the runner result is the source of truth for the
+// supervisor's terminal-record.
+func (e *RPIRunExecutor) emitAgentUpdate(claim QueueClaim, queue *Queue, base LedgerEventInput) {
+	if e.store == nil || queue == nil {
+		return
+	}
+	requestID := RequestID(claim.Job.RequestID)
+	if strings.TrimSpace(string(requestID)) == "" {
+		requestID = RequestID("req-" + claim.Job.JobID)
+	}
+	base.EventID = queue.nextEventID(base.EventType, claim.Job.JobID)
+	base.RequestID = requestID
+	base.JobID = claim.Job.JobID
+	base.JobType = claim.Job.JobType
+	base.Actor = e.actor
+	base.OccurredAt = e.now()
+	event, err := NewLedgerEvent(base)
+	if err != nil {
+		return
+	}
+	_, _ = e.store.AppendLedgerEvent(event)
 }
 
 // rpiRunArtifactsFor mirrors RPICLIExecutor.artifactsFor but tags

--- a/cli/internal/daemon/rpi_run_test.go
+++ b/cli/internal/daemon/rpi_run_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestRPIRunExecutor_RunsViaFunc verifies the executor dispatches to the
@@ -233,6 +234,141 @@ func TestRPIRunJobSpec_AcceptsSupervisorPolicyFields(t *testing.T) {
 	}
 	if parsed.KillSwitchPath != ".agents/rpi/KILL" {
 		t.Errorf("KillSwitchPath = %q, want .agents/rpi/KILL", parsed.KillSwitchPath)
+	}
+}
+
+// TestRPIRunEmitsAgentUpdates exercises soc-y0ct.2: when a Store is wired into
+// the executor, RunJob emits agent-update phase_start before the runner and
+// phase_complete + phase_handoff after a successful run. Without a Store, no
+// events are appended (back-compat with sub-5a callers that injected a runner
+// only).
+func TestRPIRunEmitsAgentUpdates(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		runErr      error
+		wantStatus  string
+		wantHandoff bool
+	}{
+		{name: "success", runErr: nil, wantStatus: "success", wantHandoff: true},
+		{name: "failure", runErr: errors.New("runner exploded"), wantStatus: "failure", wantHandoff: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			store := NewStore(root)
+			// Advancing clock so duration_ms is populated on phase_complete (the
+			// constructor drops zero-valued duration_ms via omitempty).
+			startTime := time.Date(2026, 5, 7, 21, 0, 0, 0, time.UTC)
+			tickCount := 0
+			tickingClock := func() time.Time {
+				t := startTime.Add(time.Duration(tickCount) * 10 * time.Millisecond)
+				tickCount++
+				return t
+			}
+			exec, err := NewRPIRunExecutor(RPIRunExecutorOptions{
+				Root:  root,
+				Store: store,
+				Actor: "test-actor",
+				Clock: tickingClock,
+				Run: func(_ context.Context, _ RPIRunRequest) (RPIRunResult, error) {
+					return RPIRunResult{Artifacts: map[string]string{"runner_marker": "ok"}}, tc.runErr
+				},
+			})
+			if err != nil {
+				t.Fatalf("new executor: %v", err)
+			}
+			spec := NewRPIRunJobSpec("run-emit", "exercise emission")
+			spec.ExecutionPacketPath = ".agents/rpi/runs/run-emit/execution-packet.json"
+			jobSpec, err := spec.ToJobSpec("job-emit")
+			if err != nil {
+				t.Fatalf("job spec: %v", err)
+			}
+			claim := QueueClaim{Job: QueueJobState{
+				JobID:     jobSpec.ID,
+				RequestID: "req-emit",
+				JobType:   jobSpec.Type,
+				Payload:   jobSpec.Payload,
+			}}
+			if _, err := exec.RunJob(context.Background(), claim); !errors.Is(err, tc.runErr) {
+				t.Fatalf("RunJob err = %v, want %v", err, tc.runErr)
+			}
+
+			events, err := store.ReadLedger()
+			if err != nil {
+				t.Fatalf("read ledger: %v", err)
+			}
+			var got []EventType
+			for _, ev := range events {
+				got = append(got, ev.EventType)
+			}
+			want := []EventType{EventAgentUpdatePhaseStart, EventAgentUpdatePhaseComplete}
+			if tc.wantHandoff {
+				want = append(want, EventAgentUpdatePhaseHandoff)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("emitted event types = %v, want %v", got, want)
+			}
+
+			// Verify boilerplate (JobID, Actor, RequestID) and payload (run_id, phase_name)
+			// on the phase_start event so we know the wrapper carries claim metadata.
+			start := events[0]
+			if start.JobID != "job-emit" || string(start.RequestID) != "req-emit" || start.Actor != "test-actor" {
+				t.Errorf("phase_start boilerplate = %+v", start)
+			}
+			if start.Payload["run_id"] != "run-emit" || start.Payload["phase_name"] != "rpi.run" {
+				t.Errorf("phase_start payload = %v", start.Payload)
+			}
+
+			// Verify phase_complete reports the right status and carries duration_ms.
+			complete := events[1]
+			if complete.Payload["status"] != tc.wantStatus {
+				t.Errorf("phase_complete status = %v, want %s", complete.Payload["status"], tc.wantStatus)
+			}
+			if _, ok := complete.Payload["duration_ms"]; !ok {
+				t.Errorf("phase_complete missing duration_ms; payload = %v", complete.Payload)
+			}
+
+			if tc.wantHandoff {
+				handoff := events[2]
+				if handoff.Payload["from_phase"] != "rpi.run" || handoff.Payload["to_phase"] != "operator" {
+					t.Errorf("phase_handoff payload = %v", handoff.Payload)
+				}
+				if handoff.Payload["packet_path"] != spec.ExecutionPacketPath {
+					t.Errorf("phase_handoff packet_path = %v", handoff.Payload["packet_path"])
+				}
+			}
+		})
+	}
+}
+
+// TestRPIRunNoEmissionWithoutStore confirms back-compat: callers that don't
+// pass a Store get the runner-only behavior with zero events appended.
+func TestRPIRunNoEmissionWithoutStore(t *testing.T) {
+	root := t.TempDir()
+	// Set up a side-channel store JUST to assert no events landed; executor
+	// is not configured with it.
+	witness := NewStore(root + "-witness")
+	exec, err := NewRPIRunExecutor(RPIRunExecutorOptions{
+		Root: root,
+		Run:  func(_ context.Context, _ RPIRunRequest) (RPIRunResult, error) { return RPIRunResult{}, nil },
+	})
+	if err != nil {
+		t.Fatalf("new executor: %v", err)
+	}
+	spec := NewRPIRunJobSpec("run-silent", "no store wired")
+	jobSpec, err := spec.ToJobSpec("job-silent")
+	if err != nil {
+		t.Fatalf("job spec: %v", err)
+	}
+	claim := QueueClaim{Job: QueueJobState{JobID: jobSpec.ID, JobType: jobSpec.Type, Payload: jobSpec.Payload}}
+	if _, err := exec.RunJob(context.Background(), claim); err != nil {
+		t.Fatalf("RunJob: %v", err)
+	}
+	events, err := witness.ReadLedger()
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected zero events on the witness store, got %d", len(events))
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes ac-aup.3 of the soc-y0ct umbrella by wiring agent-update emission into the daemon's rpi.run executor.

The protocol surface landed in soc-y0ct.1 (#255 squashed `cli/internal/daemon/agent_update.go` + schema + 4 EventType constants); this PR connects the emission point.

- `RPIRunExecutorOptions` gains optional `Store`, `Clock`, `Actor`. When `Store` is non-nil, `RunJob` emits 3 events per cycle:
  - `phase_start` before invoking the runner
  - `phase_complete` after (status=success|failure, duration_ms, runner artifacts)
  - `phase_handoff` on success (from=`rpi.run`, to=`operator`, packet_path)
- When `Store` is nil, no events emitted — preserves back-compat with sub-5a tests that inject a runner only.
- Production daemon (`agentopsd.go:buildAgentOpsDaemonCLIFallbackRPIExecutor`) now passes `daemonpkg.NewStore(cwd)` + `Actor="agentopsd-rpi-run"`.

Deferred (out of scope for this bead): `criterion_verdict` event emission. Requires reading per-criterion verdicts from the execution packet post-run; not on this AC's critical path. File a follow-up bead under soc-y0ct if the reader path becomes useful.

## Test plan

- [x] `go test ./internal/daemon/... -run RPIRun` → all pass (4 new tests + 13 existing)
- [x] `go test ./...` → 11856 passing in 50 packages
- [x] go build/vet clean
- [x] Pre-push gate (fast) passed
- [ ] Live verification: next nightly run will exercise the production path; check `ao daemon events tail` for `agent_update.*` event types after first daemon-submitted rpi.run job lands

## ACs

- `ac-uw7-2.1`: rpi_run.go emits agent-update events on phase boundaries → covered by `TestRPIRunEmitsAgentUpdates`
- soc-y0ct umbrella ac-aup.3 → satisfied (was DEFERRED in #255)
- soc-y0ct ac-aup.4 (no regression) → 11856 passing, no removed tests

## Closes

- soc-y0ct.2 (UW7-2)
- soc-y0ct umbrella now ready to close (3/4 → 4/4 ACs PASS)