### PR TITLE
Daemon emits agent_update.criterion_verdict from wave checkpoints (soc-awx8)

### DIFF
--- a/cli/internal/daemon/rpi_run.go
+++ b/cli/internal/daemon/rpi_run.go
@@ -2,8 +2,10 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -139,6 +141,24 @@ func (e *RPIRunExecutor) RunJob(ctx context.Context, claim QueueClaim) (JobExecu
 		Artifacts:  res.Artifacts,
 	}))
 
+	// soc-awx8: emit one criterion_verdict event per verdict found in any wave
+	// checkpoint under .agents/crank/wave-*-checkpoint.json. Best-effort —
+	// missing/unreadable checkpoints emit zero events and do NOT fail the job.
+	// Order: AFTER phase_complete, BEFORE phase_handoff, so consumers see the
+	// per-criterion results as part of the closing-out sequence.
+	if err == nil {
+		for _, v := range readWaveCheckpointVerdicts(e.root) {
+			e.emitAgentUpdate(claim, queue, NewAgentUpdateCriterionVerdictEvent(AgentUpdateCriterionVerdict{
+				CriterionID:  v.ID,
+				Status:       v.Status,
+				EvidencePath: v.EvidencePath,
+				Notes:        v.Notes,
+				RunID:        spec.RunID,
+				Timestamp:    e.now().UTC().Format(time.RFC3339Nano),
+			}))
+		}
+	}
+
 	if err == nil {
 		e.emitAgentUpdate(claim, queue, NewAgentUpdatePhaseHandoffEvent(AgentUpdatePhaseHandoff{
 			FromPhase:  "rpi.run",
@@ -226,3 +246,43 @@ func validateRPIRunFullRun(spec RPIRunJobSpec) error {
 }
 
 var _ JobExecutor = (*RPIRunExecutor)(nil)
+
+// waveCheckpointVerdict mirrors the verdict-row shape /crank writes into
+// `.agents/crank/wave-*-checkpoint.json` per skills/crank/SKILL.md Step 5.7.
+// Verdict source-of-truth is the per-criterion-rubric reference doc; this is
+// the read-side projection used by the daemon's agent-update emitter.
+type waveCheckpointVerdict struct {
+	ID           string `json:"id"`
+	Status       string `json:"status"`
+	EvidencePath string `json:"evidence_path,omitempty"`
+	Notes        string `json:"notes,omitempty"`
+}
+
+// readWaveCheckpointVerdicts scans `<root>/.agents/crank/wave-*-checkpoint.json`
+// and returns the flattened list of `criterion_verdicts` rows. Best-effort:
+// missing dir, unreadable files, and malformed JSON yield an empty slice (no
+// error surfaced) so the daemon's emission loop degrades to "zero verdict
+// events" rather than failing the job. Filenames are scanned in lexicographic
+// order so wave-1, wave-2, ... emit in the same order operators would read
+// them off disk.
+func readWaveCheckpointVerdicts(root string) []waveCheckpointVerdict {
+	matches, err := filepath.Glob(filepath.Join(root, ".agents", "crank", "wave-*-checkpoint.json"))
+	if err != nil || len(matches) == 0 {
+		return nil
+	}
+	var verdicts []waveCheckpointVerdict
+	for _, path := range matches {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var checkpoint struct {
+			CriterionVerdicts []waveCheckpointVerdict `json:"criterion_verdicts"`
+		}
+		if err := json.Unmarshal(data, &checkpoint); err != nil {
+			continue
+		}
+		verdicts = append(verdicts, checkpoint.CriterionVerdicts...)
+	}
+	return verdicts
+}

--- a/cli/internal/daemon/rpi_run_test.go
+++ b/cli/internal/daemon/rpi_run_test.go
@@ -3,6 +3,8 @@ package daemon
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -337,6 +339,118 @@ func TestRPIRunEmitsAgentUpdates(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestRPIRunEmitsCriterionVerdicts exercises soc-awx8: when wave checkpoints
+// exist under .agents/crank/wave-*-checkpoint.json, RunJob emits one
+// agent_update.criterion_verdict event per verdict row, ordered AFTER
+// phase_complete and BEFORE phase_handoff. Multiple checkpoints contribute in
+// lexicographic order (wave-1, wave-2, …).
+func TestRPIRunEmitsCriterionVerdicts(t *testing.T) {
+	root := t.TempDir()
+	checkpointDir := filepath.Join(root, ".agents", "crank")
+	if err := os.MkdirAll(checkpointDir, 0o755); err != nil {
+		t.Fatalf("mkdir checkpoint: %v", err)
+	}
+	wave1 := []byte(`{
+	  "wave": 1,
+	  "criterion_verdicts": [
+	    {"id": "ac-foo.1", "status": "PASS", "evidence_path": "cli/foo.go", "notes": "ok"},
+	    {"id": "ac-foo.2", "status": "FAIL", "notes": "exit 1"}
+	  ]
+	}`)
+	wave2 := []byte(`{
+	  "wave": 2,
+	  "criterion_verdicts": [
+	    {"id": "ac-bar.1", "status": "SKIP", "notes": "deferred"}
+	  ]
+	}`)
+	if err := os.WriteFile(filepath.Join(checkpointDir, "wave-1-checkpoint.json"), wave1, 0o644); err != nil {
+		t.Fatalf("write wave-1: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(checkpointDir, "wave-2-checkpoint.json"), wave2, 0o644); err != nil {
+		t.Fatalf("write wave-2: %v", err)
+	}
+
+	store := NewStore(root)
+	startTime := time.Date(2026, 5, 7, 22, 0, 0, 0, time.UTC)
+	tickCount := 0
+	tickingClock := func() time.Time {
+		t := startTime.Add(time.Duration(tickCount) * 10 * time.Millisecond)
+		tickCount++
+		return t
+	}
+	exec, err := NewRPIRunExecutor(RPIRunExecutorOptions{
+		Root:  root,
+		Store: store,
+		Actor: "test-actor",
+		Clock: tickingClock,
+		Run: func(_ context.Context, _ RPIRunRequest) (RPIRunResult, error) {
+			return RPIRunResult{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("new executor: %v", err)
+	}
+	spec := NewRPIRunJobSpec("run-verdicts", "exercise verdict emission")
+	jobSpec, err := spec.ToJobSpec("job-verdicts")
+	if err != nil {
+		t.Fatalf("job spec: %v", err)
+	}
+	claim := QueueClaim{Job: QueueJobState{
+		JobID:     jobSpec.ID,
+		RequestID: "req-verdicts",
+		JobType:   jobSpec.Type,
+		Payload:   jobSpec.Payload,
+	}}
+	if _, err := exec.RunJob(context.Background(), claim); err != nil {
+		t.Fatalf("RunJob: %v", err)
+	}
+
+	events, err := store.ReadLedger()
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	var got []EventType
+	for _, ev := range events {
+		got = append(got, ev.EventType)
+	}
+	want := []EventType{
+		EventAgentUpdatePhaseStart,
+		EventAgentUpdatePhaseComplete,
+		EventAgentUpdateCriterionVerdict,
+		EventAgentUpdateCriterionVerdict,
+		EventAgentUpdateCriterionVerdict,
+		EventAgentUpdatePhaseHandoff,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("event sequence = %v, want %v", got, want)
+	}
+
+	// Verify each verdict event carries the right per-row payload + the run_id
+	// from the spec.
+	verdicts := []struct {
+		id, status, evidence string
+	}{
+		{"ac-foo.1", "PASS", "cli/foo.go"},
+		{"ac-foo.2", "FAIL", ""},
+		{"ac-bar.1", "SKIP", ""},
+	}
+	for i, want := range verdicts {
+		ev := events[2+i]
+		if ev.Payload["criterion_id"] != want.id {
+			t.Errorf("event[%d].criterion_id = %v, want %s", 2+i, ev.Payload["criterion_id"], want.id)
+		}
+		if ev.Payload["status"] != want.status {
+			t.Errorf("event[%d].status = %v, want %s", 2+i, ev.Payload["status"], want.status)
+		}
+		if ev.Payload["run_id"] != "run-verdicts" {
+			t.Errorf("event[%d].run_id = %v, want run-verdicts", 2+i, ev.Payload["run_id"])
+		}
+		if want.evidence != "" && ev.Payload["evidence_path"] != want.evidence {
+			t.Errorf("event[%d].evidence_path = %v, want %s", 2+i, ev.Payload["evidence_path"], want.evidence)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the 4th agent-update event type. Builds on:
- soc-y0ct.1 (#255): protocol surface — schema + EventType constants + payload constructors
- soc-y0ct.2 (#258): wrapper-emitter for phase_start / phase_complete / phase_handoff

This PR wires emission of `agent_update.criterion_verdict` events.

### Discovery during implementation

The bead body originally guessed verdicts live in the execution packet. Actually they live in `.agents/crank/wave-*-checkpoint.json` per `skills/crank/SKILL.md` Step 5.7 — written by /crank, not by the validation phase. Reader adjusted accordingly.

### What changed

- New `readWaveCheckpointVerdicts(root)` helper globs `.agents/crank/wave-*-checkpoint.json` in lexicographic order, flattens the `criterion_verdicts` arrays. Best-effort: missing dir / malformed JSON → empty slice (no error surfaced).
- `RunJob` emits one `agent_update.criterion_verdict` event per row, ordered **AFTER** `phase_complete` and **BEFORE** `phase_handoff`. Only emits on success path.
- 1 new test (`TestRPIRunEmitsCriterionVerdicts`); existing tests preserved (back-compat: zero checkpoints → zero verdict events).

### Sequence after this PR

A successful daemon-mode rpi.run job now emits this event sequence:

```
phase_start
phase_complete
criterion_verdict × N      (one per row across all wave-*-checkpoint.json files)
phase_handoff
```

## Test plan

- [x] `go test ./internal/daemon/... -run RPIRun` → 17 passing
- [x] `go test ./...` → 11857 passing in 50 packages
- [x] go build/vet clean
- [x] Pre-push gate (fast) passed
- [x] Back-compat: `TestRPIRunEmitsAgentUpdates` (no checkpoints) still emits exactly 3 events (no spurious verdicts)
- [ ] Live verification: next nightly produces verdict events visible in `ao daemon events tail`

## ACs

- `ac-cv.1` (one criterion_verdict event per verdict in checkpoint) → covered by `TestRPIRunEmitsCriterionVerdicts`
- `ac-cv.2` (no checkpoints → zero events, no failure) → covered by `TestRPIRunEmitsAgentUpdates` (existing)

## Closes

- soc-awx8