### PR TITLE
Cross-link worker-specs from /swarm (closes soc-yjzp.8)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-07T22:14:17Z",
+  "generated_at": "2026-05-07T22:23:57Z",
   "summary": {
     "skills": 73,
     "hooks": 41,
@@ -289,7 +289,7 @@
         "path": "skills/swarm/",
         "has_skill_md": true,
         "has_references": true,
-        "reference_count": 14
+        "reference_count": 15
       },
       {
         "name": "test",

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-07T22:23:57Z",
+  "generated_at": "2026-05-07T22:30:59Z",
   "summary": {
     "skills": 73,
     "hooks": 41,
-    "knowledge_stores": 0,
+    "knowledge_stores": 1,
     "job_types": 14,
     "eval_files": 61,
     "cli_commands": 147
@@ -926,7 +926,14 @@
         "type": "command"
       }
     ],
-    "knowledge_stores": [],
+    "knowledge_stores": [
+      {
+        "name": "nightly",
+        "path": ".agents/nightly/",
+        "purpose": "Nightly run outputs and digests",
+        "file_count": 6
+      }
+    ],
     "job_types": [
       {
         "job_type": "dream.run",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1033,7 +1033,7 @@
     {
       "name": "swarm",
       "source_skill": "skills/swarm",
-      "source_hash": "5adcedf2ffdfaf50e5345f3afb3bf4e0f1c3b565e12fe85e9ec857d0782a6c82",
+      "source_hash": "2dc8db4f67fc5536b248c89dda334d728ebe71f0a278ff663a08ca08234b9f53",
       "generated_hash": "6014e1965271b39d3d77781dbd0ba25c4b147676937fb67092c8fcab11d2b7be"
     },
     {

--- a/skills-codex/swarm/.agentops-generated.json
+++ b/skills-codex/swarm/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/swarm",
   "layout": "modular",
-  "source_hash": "5adcedf2ffdfaf50e5345f3afb3bf4e0f1c3b565e12fe85e9ec857d0782a6c82",
+  "source_hash": "2dc8db4f67fc5536b248c89dda334d728ebe71f0a278ff663a08ca08234b9f53",
   "generated_hash": "6014e1965271b39d3d77781dbd0ba25c4b147676937fb67092c8fcab11d2b7be"
 }

--- a/skills/swarm/SKILL.md
+++ b/skills/swarm/SKILL.md
@@ -113,6 +113,7 @@ This is how the prevention ratchet applies shift-left mechanically: active compi
 - If you cannot enumerate files yet, add a planning step to identify them before spawning workers. An empty or missing manifest signals the need for more planning, not unconstrained workers.
 - Workers receive the manifest in their prompt and are instructed to stay within it (see `references/local-mode.md` worker prompt template).
 - The worker prompt MUST include the `metadata.files` array as the FILE MANIFEST section. Workers grep for existing function signatures before writing new code to avoid duplication.
+- Per-worker model/tool/prompt isolation specs: see [`references/worker-specs.md`](references/worker-specs.md) and [`schemas/worker-spec.v1.schema.json`](../../schemas/worker-spec.v1.schema.json). When a wave's tasks declare a `metadata.worker_spec` reference, the spawned worker honors the named spec's model/tool/prompt allowlist instead of inheriting the lead agent's surface.
 
 ```json
 {

--- a/skills/swarm/references/worker-specs.md
+++ b/skills/swarm/references/worker-specs.md
@@ -1,0 +1,74 @@
+# Worker Specs
+
+> Per-worker model, tool, and prompt isolation for `/crank` and `/swarm`. Schema: `schemas/worker-spec.v1.schema.json`.
+
+## Why
+
+Anthropic's Managed Agents launch (May 2026) gives each specialist its own model, prompt, and tool set. AgentOps workers currently inherit the lead agent's tools — fine for most cases but limits the "haiku-lead delegates to opus-implementer" pattern that smaller managed-agent setups exploit.
+
+A worker spec is a small YAML/JSON file declaring which model, tool subset, and prompt template a worker uses. `/crank` reads the spec at spawn time, the worker inherits only the declared surface.
+
+## When to use a spec
+
+| Situation | Use a spec? |
+|---|---|
+| All workers in the wave do the same thing (e.g. all docs edits) | No — inherit lead defaults |
+| Different roles in the wave (spec-author, test-writer, impl) | Yes — one spec per role |
+| Mixing models (cheap lead, opus implementer) | Yes |
+| Restricting tool surface (worker that should only Read+Edit, not Bash) | Yes |
+| One-off task | Probably not — specs are for repeated patterns |
+
+## Schema
+
+See `schemas/worker-spec.v1.schema.json`. Minimal example:
+
+```yaml
+version: 1
+name: spec-author
+model: claude-sonnet-4-6
+tools: [Read, Write, Grep, Glob]
+effort: medium
+timeout_seconds: 300
+```
+
+Tool list of `[]` means no tools (read-only reasoning). Omitting `tools` means inherit lead's tool set. `model: inherit` uses the lead's model.
+
+## Storage convention
+
+Reusable specs live at `skills/<skill>/worker-specs/<role>.yaml` (e.g. `skills/crank/worker-specs/spec-author.yaml`). One-off specs can be inlined in plan documents under a `worker_specs` section.
+
+## How `/crank` consumes specs
+
+```
+plan/<epic>/issues.json:
+  - id: epic-1
+    worker_spec: skills/crank/worker-specs/spec-author.yaml
+    metadata:
+      validation: { ... }
+      files: [...]
+```
+
+When crank dispatches `epic-1`, it:
+1. Loads `worker_spec`, validates against `schemas/worker-spec.v1.schema.json`
+2. Resolves `model: inherit` to the lead's model
+3. Builds the spawn payload using ONLY tools from `tools` (cross-checked against tool registry)
+4. Prepends the prompt file (if any) to the per-task instructions
+5. Spawns with `effort` mapped to the runtime's effort tier
+
+## Anti-patterns
+
+**Don't ladder model overrides in plan files.** If the same role is used by multiple issues, write one spec file and reference it from each. Inline specs are fine for one-offs but become a maintenance hazard at scale.
+
+**Don't use specs to gate access to dangerous tools.** Specs reduce surface for the worker's convenience and cost; security comes from the runtime's permission model, not the spec.
+
+**Don't mix `model: inherit` with `effort: high` if the lead is on Haiku.** The runtime will warn and fail the spawn. Pick a concrete model when overriding effort.
+
+## Validation
+
+`scripts/validate-worker-specs.sh` (to be added with the implementation) walks all `**/worker-specs/*.{yaml,json}` and validates against the schema. CI gate to be added at implementation time.
+
+## See also
+
+- Schema: [schemas/worker-spec.v1.schema.json](../../../schemas/worker-spec.v1.schema.json)
+- Spec issue: soc-yjzp.8
+- Pre-mortem fix 6: enum strictness on the `model` field (applied — see schema)


### PR DESCRIPTION
## Summary

Closes soc-yjzp.8. Bead description called for `cli/cmd/ao/crank.go` + `swarm.go` consumers, but those files don't exist — `/crank` and `/swarm` are pure slash-skills (markdown). "Consumption" is SKILL.md text directing workers to honor `metadata.worker_spec`.

State already shipped from prior work:
- `schemas/worker-spec.v1.schema.json` ✓
- `skills/crank/references/worker-specs.md` ✓
- `skills/crank/SKILL.md` cross-link ✓

This PR adds the missing **swarm-side** cross-link to symmetrize:
- `skills/swarm/SKILL.md`: cross-link in Task Typing section
- `skills/swarm/references/worker-specs.md`: NEW (copy per repo "no symlinks" convention — same pattern used for isolation-contract.md / best-practices.md during soc-bcrn)

## Test plan

- [x] `bash skills/heal-skill/scripts/heal.sh --strict` → All clean
- [x] `bash tests/skills/lint-skills.sh` → All skills pass
- [x] No code changes; no test regression possible

## Closes

- soc-yjzp.8