### PR TITLE
CI toil-reduction sweep: registry determinism + codex auto-refresh + local CI dry-run (3 beads)

### DIFF
--- a/cli/embedded/hooks/hooks.json
+++ b/cli/embedded/hooks/hooks.json
@@ -250,6 +250,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/edit-audit.sh",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/postedit-codex-refresh.sh",
+            "timeout": 10
           }
         ]
       },
@@ -265,6 +270,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/edit-audit.sh",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/postedit-codex-refresh.sh",
+            "timeout": 10
           }
         ]
       },

--- a/cli/embedded/hooks/postedit-codex-refresh.sh
+++ b/cli/embedded/hooks/postedit-codex-refresh.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# PostToolUse hook: auto-refresh codex artifacts after edits to skills/<name>/.
+#
+# Filed as soc-7qq9 in the 2026-05-07 CI-push-gate-toil retrospective. The
+# pre-push gate enforces codex parity (skills/* must have matching
+# skills-codex/<name>/.agents-generated.json hashes), but the refresh is
+# manual via scripts/refresh-codex-artifacts.sh. Discovering the drift only
+# at push time costs one round-trip per skill-edit PR.
+#
+# This hook moves discovery to edit time: after every Edit/Write under
+# skills/<name>/, run the refresh script in --scope head mode (auto-recompute
+# hashes for the touched skill). Operator never sees the parity warning.
+#
+# Disable with AGENTOPS_HOOKS_DISABLED=1 or AGENTOPS_CODEX_AUTOREFRESH_DISABLED=1.
+# Best-effort and silent on success; failures log to stderr but exit 0
+# (informational hook — never blocks the editor).
+
+set -uo pipefail
+
+[[ "${AGENTOPS_HOOKS_DISABLED:-}" == "1" ]] && exit 0
+[[ "${AGENTOPS_CODEX_AUTOREFRESH_DISABLED:-}" == "1" ]] && exit 0
+
+# Read the JSON input from stdin (Claude Code hook protocol).
+INPUT="$(cat)"
+
+# Extract the edited file_path. If jq is unavailable or the input is not JSON,
+# fail silent — hook is best-effort.
+if ! command -v jq >/dev/null 2>&1; then
+    exit 0
+fi
+
+FILE_PATH="$(jq -r '.tool_input.file_path // empty' <<<"$INPUT" 2>/dev/null || true)"
+
+# Only fire on edits under skills/<name>/. Skip non-skill edits, skip
+# skills-codex/ edits (those are the targets, not sources), skip
+# .agents-generated.json edits (would re-trigger ourselves).
+case "$FILE_PATH" in
+    */skills/*/SKILL.md|*/skills/*/references/*.md|*/skills/*/scripts/*|*/skills/*/schemas/*) ;;
+    *) exit 0 ;;
+esac
+
+# Resolve repo root from the file path (assumes file lives inside the repo).
+REPO_ROOT="$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null || true)"
+[[ -z "$REPO_ROOT" ]] && exit 0
+
+REFRESH="$REPO_ROOT/scripts/refresh-codex-artifacts.sh"
+[[ -x "$REFRESH" ]] || exit 0
+
+# Run refresh in scope=head (only changed skills since the last commit).
+# Output is suppressed unless the script returns non-zero, in which case we
+# log a one-line warning to stderr but never block the editor.
+if ! out=$("$REFRESH" --scope head 2>&1); then
+    printf 'codex auto-refresh: WARN — refresh-codex-artifacts exited non-zero (run manually for details)\n' >&2
+    [[ "${AGENTOPS_CODEX_AUTOREFRESH_VERBOSE:-}" == "1" ]] && printf '%s\n' "$out" >&2 || true
+fi
+
+exit 0

--- a/evals/agentops-core/hook-lifecycle-behavior.json
+++ b/evals/agentops-core/hook-lifecycle-behavior.json
@@ -94,7 +94,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "Total: 222"},
+        {"type": "stdout_contains", "value": "Total: 226"},
         {"type": "stdout_contains", "value": "Fail: 0"},
         {"type": "stdout_contains", "value": "ALL PASSED"}
       ],

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -250,6 +250,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/edit-audit.sh",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/postedit-codex-refresh.sh",
+            "timeout": 10
           }
         ]
       },
@@ -265,6 +270,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/edit-audit.sh",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/postedit-codex-refresh.sh",
+            "timeout": 10
           }
         ]
       },

--- a/hooks/postedit-codex-refresh.sh
+++ b/hooks/postedit-codex-refresh.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# PostToolUse hook: auto-refresh codex artifacts after edits to skills/<name>/.
+#
+# Filed as soc-7qq9 in the 2026-05-07 CI-push-gate-toil retrospective. The
+# pre-push gate enforces codex parity (skills/* must have matching
+# skills-codex/<name>/.agents-generated.json hashes), but the refresh is
+# manual via scripts/refresh-codex-artifacts.sh. Discovering the drift only
+# at push time costs one round-trip per skill-edit PR.
+#
+# This hook moves discovery to edit time: after every Edit/Write under
+# skills/<name>/, run the refresh script in --scope head mode (auto-recompute
+# hashes for the touched skill). Operator never sees the parity warning.
+#
+# Disable with AGENTOPS_HOOKS_DISABLED=1 or AGENTOPS_CODEX_AUTOREFRESH_DISABLED=1.
+# Best-effort and silent on success; failures log to stderr but exit 0
+# (informational hook — never blocks the editor).
+
+set -uo pipefail
+
+[[ "${AGENTOPS_HOOKS_DISABLED:-}" == "1" ]] && exit 0
+[[ "${AGENTOPS_CODEX_AUTOREFRESH_DISABLED:-}" == "1" ]] && exit 0
+
+# Read the JSON input from stdin (Claude Code hook protocol).
+INPUT="$(cat)"
+
+# Extract the edited file_path. If jq is unavailable or the input is not JSON,
+# fail silent — hook is best-effort.
+if ! command -v jq >/dev/null 2>&1; then
+    exit 0
+fi
+
+FILE_PATH="$(jq -r '.tool_input.file_path // empty' <<<"$INPUT" 2>/dev/null || true)"
+
+# Only fire on edits under skills/<name>/. Skip non-skill edits, skip
+# skills-codex/ edits (those are the targets, not sources), skip
+# .agents-generated.json edits (would re-trigger ourselves).
+case "$FILE_PATH" in
+    */skills/*/SKILL.md|*/skills/*/references/*.md|*/skills/*/scripts/*|*/skills/*/schemas/*) ;;
+    *) exit 0 ;;
+esac
+
+# Resolve repo root from the file path (assumes file lives inside the repo).
+REPO_ROOT="$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null || true)"
+[[ -z "$REPO_ROOT" ]] && exit 0
+
+REFRESH="$REPO_ROOT/scripts/refresh-codex-artifacts.sh"
+[[ -x "$REFRESH" ]] || exit 0
+
+# Run refresh in scope=head (only changed skills since the last commit).
+# Output is suppressed unless the script returns non-zero, in which case we
+# log a one-line warning to stderr but never block the editor.
+if ! out=$("$REFRESH" --scope head 2>&1); then
+    printf 'codex auto-refresh: WARN — refresh-codex-artifacts exited non-zero (run manually for details)\n' >&2
+    [[ "${AGENTOPS_CODEX_AUTOREFRESH_VERBOSE:-}" == "1" ]] && printf '%s\n' "$out" >&2 || true
+fi
+
+exit 0

--- a/registry.json
+++ b/registry.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-07T22:30:59Z",
+  "generated_at": "2026-05-07T23:17:15Z",
   "summary": {
     "skills": 73,
-    "hooks": 41,
+    "hooks": 43,
     "knowledge_stores": 1,
     "job_types": 14,
     "eval_files": 61,
@@ -643,6 +643,22 @@
         "matcher": "all",
         "timeout": 15,
         "path": "hooks/go-vet-post-edit.sh",
+        "type": "command"
+      },
+      {
+        "name": "postedit-codex-refresh",
+        "lifecycle": "PostToolUse",
+        "matcher": "Write",
+        "timeout": 10,
+        "path": "hooks/postedit-codex-refresh.sh",
+        "type": "command"
+      },
+      {
+        "name": "postedit-codex-refresh",
+        "lifecycle": "PostToolUse",
+        "matcher": "Edit",
+        "timeout": 10,
+        "path": "hooks/postedit-codex-refresh.sh",
         "type": "command"
       },
       {

--- a/scripts/generate-registry.sh
+++ b/scripts/generate-registry.sh
@@ -110,8 +110,11 @@ build_hooks() {
 # ─── Knowledge Stores (.agents/ dirs) ────────────────────────────────────────
 
 build_knowledge_stores() {
-  local agents_dir="${REPO_ROOT}/.agents"
-  [[ -d "$agents_dir" ]] || { echo "[]"; return; }
+  # soc-k47k: don't early-return on missing .agents/ — `git ls-files` reads the
+  # index, which is authoritative regardless of working-tree state. CI clean
+  # checkout always populates the tracked files, so the only case where the
+  # tracked list is empty is when the repo genuinely has no tracked .agents/
+  # entries.
 
   # Known purpose map — manually maintained since .agents/ has no manifest
   local -A purposes=(
@@ -163,15 +166,34 @@ build_knowledge_stores() {
     [wiki]="Internal wiki entries"
   )
 
-  local result="[]"
-  for dir in "${agents_dir}"/*/; do
-    [[ -d "$dir" ]] || continue
-    local name
-    name="$(basename "$dir")"
-    local purpose="${purposes[$name]:-"Unknown — needs documentation"}"
-    local file_count
-    file_count=$(find "$dir" -type f 2>/dev/null | wc -l | tr -d ' ')
+  # soc-k47k: walk `git ls-files .agents/` instead of filesystem so the registry
+  # is deterministic across environments. CI's clean checkout and a session-built
+  # local checkout will produce identical output. Only directories containing
+  # tracked files appear in knowledge_stores; the file_count is the tracked-file
+  # count (which is reproducible — `find` was not).
+  local tracked
+  tracked=$(cd "$REPO_ROOT" && git ls-files .agents/ 2>/dev/null || true)
+  if [[ -z "$tracked" ]]; then
+    echo "[]"
+    return
+  fi
 
+  # Build (name → file_count) map from tracked .agents/<name>/... entries.
+  declare -A counts=()
+  while IFS= read -r tracked_path; do
+    [[ -z "$tracked_path" ]] && continue
+    # Extract the immediate child of .agents/ (e.g., "nightly" from ".agents/nightly/2026-05-07/foo.json").
+    local subdir
+    subdir="${tracked_path#.agents/}"
+    subdir="${subdir%%/*}"
+    [[ -n "$subdir" && "$subdir" != "$tracked_path" ]] || continue
+    counts[$subdir]=$((${counts[$subdir]:-0} + 1))
+  done <<< "$tracked"
+
+  local result="[]"
+  for name in "${!counts[@]}"; do
+    local purpose="${purposes[$name]:-"Unknown — needs documentation"}"
+    local file_count="${counts[$name]}"
     result=$(echo "$result" | jq --arg name "$name" \
       --arg purpose "$purpose" \
       --arg path ".agents/${name}/" \

--- a/scripts/test-ci-deterministic-gates.sh
+++ b/scripts/test-ci-deterministic-gates.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# scripts/test-ci-deterministic-gates.sh — local CI-equivalent dry-run.
+#
+# Runs the deterministic CI gates that have historically surprised PRs at push
+# time (registry-check, skill-lint, heal --strict, codex artifact metadata)
+# in a single non-fail-fast batch. Reports all failures together so you can
+# fix them in one diagnostic round instead of N push iterations.
+#
+# Filed as soc-ws40 in the 2026-05-07 CI-push-gate-toil retrospective. See
+# .agents/learnings/2026-05-07-ci-push-gate-toil-pattern.md for the data.
+#
+# Usage:
+#   bash scripts/test-ci-deterministic-gates.sh             # full surface
+#   bash scripts/test-ci-deterministic-gates.sh -q          # quiet (rc only)
+#   bash scripts/test-ci-deterministic-gates.sh --skip-codex # skip codex parity
+#
+# Exit:
+#   0  all gates pass
+#   1  one or more gates fail (each failure prints diagnostic + final summary)
+#   2  argument or environment error
+#
+# Pairs with scripts/pre-push-gate.sh: that script runs --fast, this one runs
+# the deterministic-only surface. Run both before push when changes touch
+# skills/, schemas/, registry-input paths, or codex-mirrored skills.
+
+set -euo pipefail
+
+QUIET=0
+SKIP_CODEX=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -q|--quiet) QUIET=1; shift ;;
+    --skip-codex) SKIP_CODEX=1; shift ;;
+    -h|--help)
+      sed -n '2,21p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ANSI colors only when stdout is a TTY.
+if [[ -t 1 ]]; then
+  GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[0;33m'; RESET='\033[0m'
+else
+  GREEN=''; RED=''; YELLOW=''; RESET=''
+fi
+
+declare -a FAILURES=()
+declare -a PASSES=()
+
+log() {
+  [[ "$QUIET" == 1 ]] && return 0
+  printf '%b\n' "$*"
+}
+
+run_gate() {
+  local name="$1"; shift
+  local cmd=("$@")
+  local out rc
+  if out=$("${cmd[@]}" 2>&1); then
+    rc=0
+  else
+    rc=$?
+  fi
+  if [[ "$rc" -eq 0 ]]; then
+    PASSES+=("$name")
+    log "${GREEN}  ok${RESET}  $name"
+  else
+    FAILURES+=("$name")
+    log "${RED}FAIL${RESET}  $name (exit $rc)"
+    if [[ "$QUIET" != 1 ]]; then
+      printf '%s\n' "$out" | sed 's/^/    /'
+    fi
+  fi
+}
+
+log "=== CI-deterministic gates (local dry-run) ==="
+log "REPO_ROOT=$REPO_ROOT"
+log ""
+
+# Gate 1: registry-check (post-soc-k47k: deterministic across local/CI).
+run_gate "registry-check" bash scripts/generate-registry.sh --check
+
+# Gate 2: skill-lint suite.
+run_gate "skill-lint" bash tests/skills/lint-skills.sh
+
+# Gate 3: heal-skill --strict (catches dead refs, unlinked refs, name mismatches).
+run_gate "heal-skill --strict" bash skills/heal-skill/scripts/heal.sh --strict
+
+# Gate 4: codex artifact metadata (skip with --skip-codex when iterating fast).
+if [[ "$SKIP_CODEX" == 0 ]]; then
+  if [[ -x scripts/refresh-codex-artifacts.sh ]]; then
+    # --check-only path: validate without writing. The refresh script's
+    # validation FAILS when source skills changed without matching codex
+    # mirror updates. We invoke it with a workspace-preserving check.
+    run_gate "codex artifact metadata" bash -c '
+      bash scripts/refresh-codex-artifacts.sh --scope head 2>&1
+      # If the refresh wrote any changes, the audit found drift — fail.
+      if ! git diff --quiet -- skills-codex/; then
+        echo "drift detected in skills-codex/ after refresh" >&2
+        # Restore so we do not leave the workspace dirty when only running
+        # gates. Operator should re-run the refresh and commit if real.
+        git checkout -- skills-codex/ 2>/dev/null || true
+        exit 1
+      fi
+    '
+  else
+    log "${YELLOW}WARN${RESET}  codex artifact metadata: refresh-codex-artifacts.sh not executable; skipped"
+  fi
+fi
+
+log ""
+log "=== Summary ==="
+log "Passed: ${#PASSES[@]}"
+log "Failed: ${#FAILURES[@]}"
+if [[ "${#FAILURES[@]}" -gt 0 ]]; then
+  log ""
+  log "${RED}FAIL gates:${RESET} ${FAILURES[*]}"
+  log ""
+  log "Fix locally before pushing — these gates run in CI and will block the PR."
+  exit 1
+fi
+log "${GREEN}All deterministic CI gates pass.${RESET}"
+exit 0

--- a/tests/hooks/test-hooks.sh
+++ b/tests/hooks/test-hooks.sh
@@ -2245,6 +2245,46 @@ fi
 
 # ============================================================
 echo ""
+echo "=== postedit-codex-refresh.sh ==="
+# ============================================================
+# soc-7qq9: PostToolUse hook auto-runs refresh-codex-artifacts after skill edits.
+# Smoke tests verify the hook (1) is silent + exits 0 on a non-skill path,
+# (2) attempts to run refresh on a skill path inside a real repo, and
+# (3) honors the disable env var.
+
+# Test 1: non-skill path is a no-op (silent, exit 0).
+NON_SKILL_INPUT='{"tool_name":"Edit","tool_input":{"file_path":"/tmp/some/random/file.go"}}'
+if printf '%s\n' "$NON_SKILL_INPUT" | bash "$HOOKS_DIR/postedit-codex-refresh.sh" >/dev/null 2>&1; then
+    pass "postedit-codex-refresh exits 0 on non-skill path"
+else
+    fail "postedit-codex-refresh exits 0 on non-skill path"
+fi
+
+# Test 2: AGENTOPS_HOOKS_DISABLED=1 short-circuits (no jq calls etc.).
+DISABLED_INPUT='{"tool_name":"Edit","tool_input":{"file_path":"/tmp/skills/some-skill/SKILL.md"}}'
+if printf '%s\n' "$DISABLED_INPUT" | AGENTOPS_HOOKS_DISABLED=1 bash "$HOOKS_DIR/postedit-codex-refresh.sh" >/dev/null 2>&1; then
+    pass "postedit-codex-refresh respects AGENTOPS_HOOKS_DISABLED=1"
+else
+    fail "postedit-codex-refresh respects AGENTOPS_HOOKS_DISABLED=1"
+fi
+
+# Test 3: AGENTOPS_CODEX_AUTOREFRESH_DISABLED=1 also short-circuits.
+if printf '%s\n' "$DISABLED_INPUT" | AGENTOPS_CODEX_AUTOREFRESH_DISABLED=1 bash "$HOOKS_DIR/postedit-codex-refresh.sh" >/dev/null 2>&1; then
+    pass "postedit-codex-refresh respects AGENTOPS_CODEX_AUTOREFRESH_DISABLED=1"
+else
+    fail "postedit-codex-refresh respects AGENTOPS_CODEX_AUTOREFRESH_DISABLED=1"
+fi
+
+# Test 4: skill path outside any repo silently exits (no git root → no-op).
+ORPHAN_SKILL_INPUT='{"tool_name":"Edit","tool_input":{"file_path":"/tmp/orphan/skills/foo/SKILL.md"}}'
+if printf '%s\n' "$ORPHAN_SKILL_INPUT" | bash "$HOOKS_DIR/postedit-codex-refresh.sh" >/dev/null 2>&1; then
+    pass "postedit-codex-refresh silent when path is outside a git repo"
+else
+    fail "postedit-codex-refresh silent when path is outside a git repo"
+fi
+
+# ============================================================
+echo ""
 echo "=== Coverage check ==="
 # ============================================================
 


### PR DESCRIPTION
## Summary

Closes 3 beads (soc-k47k, soc-7qq9, soc-ws40) filed during the 2026-05-07 retrospective on CI/push-gate toil. See `.agents/learnings/2026-05-07-ci-push-gate-toil-pattern.md` for the data: **9 push iterations across 4 PRs**, ~45min wall-clock + thousands of orchestrator tokens spent diagnosing identical-looking failures with different root causes.

Three compounding fixes shipped together to amortize the CI cycle cost (the very pattern the learning argues for).

## What changed

### soc-k47k — registry-check determinism
- `scripts/generate-registry.sh` `build_knowledge_stores()` now walks `git ls-files .agents/` instead of filesystem `find`. CI's clean checkout and a session-built local checkout produce identical output (both consult the git index — deterministic).
- Removed `[[ -d .agents ]] || return` early-exit so behavior is uniform regardless of working-tree state.
- **Eliminates the dominant single source of failed-push retries this session** (5 iterations across PRs #255 and #260 alone).

### soc-7qq9 — PostToolUse codex auto-refresh
- New `hooks/postedit-codex-refresh.sh` fires after Edit/Write of any `skills/<name>/SKILL.md`, `references/`, `scripts/`, or `schemas/` file.
- Auto-runs `scripts/refresh-codex-artifacts.sh --scope head` so codex hashes stay current; operator never sees the parity warning.
- Registered in `hooks/hooks.json` (matchers Edit + Write, 10s timeout). Embedded copy synced via `make sync-hooks`.
- Disable via `AGENTOPS_HOOKS_DISABLED=1` or `AGENTOPS_CODEX_AUTOREFRESH_DISABLED=1`.
- Best-effort: failures log to stderr but always exit 0 (informational hook — never blocks the editor).

### soc-ws40 — local CI-equivalent dry-run
- New `scripts/test-ci-deterministic-gates.sh` runs the 4 deterministic CI gates in <30s: registry-check, skill-lint, heal-skill --strict, codex artifact metadata.
- **Non-fail-fast**: reports all failures together so you can fix them in one diagnostic round instead of N push iterations.
- Currently runs in <30s on a clean tree (vs. ~5min for one CI canary cycle).

### Test coverage
- 4 smoke tests for `postedit-codex-refresh.sh` in `tests/hooks/test-hooks.sh` (non-skill path no-op, both disable env vars, orphan path).
- `scripts/check-test-fixture-parity.sh` passes (was failing without the new tests).

## Test plan

- [x] `bash scripts/test-ci-deterministic-gates.sh` → 4/4 PASS
- [x] `bash tests/hooks/test-hooks.sh` (post-edit-codex-refresh suite) → 4/4 PASS
- [x] `bash scripts/check-test-fixture-parity.sh` → exit 0
- [x] `cd cli && go test ./...` → 11858 passing
- [x] Pre-push gate (fast) passed
- [ ] Live verification: edit any skill/SKILL.md and observe `skills-codex/<name>/.agentops-generated.json` auto-refresh

## How this composes

With #1 + #2 + #3 wired:
- **#1** ensures `--check` mode is honest — no more "passes locally, fails on CI" surprise.
- **#2** ensures codex parity drift never reaches push time.
- **#3** turns the 4 deterministic CI gates into a single local command. Run before push when changes touch skills/, schemas/, registry-input paths.

Together: the CI surprises that drove this session's toil should be catchable locally before push. Future PR CI cycles should compress from N iterations to 1.

## Closes

- soc-k47k (registry-check determinism via git ls-files)
- soc-7qq9 (PostToolUse codex auto-refresh)
- soc-ws40 (scripts/test-ci-deterministic-gates.sh local dry-run)