### PR TITLE
docs(positioning): wiki-framing sweep across all surface docs (soc-9xn0)

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -1,11 +1,12 @@
 # Goals
 
-The operational layer for coding agents — repo-native bookkeeping, validation, primitives, and flows that make every session smarter than the last.
+A wiki for your agents — repo-native, version-controlled, mechanically maintained — that turns your context into the durable moat under any model or harness.
 
 ## North Stars
 
 <!-- agentops:claim:AOP-CLAIM-GOALS-DREAM-VALIDATED -->
 - The knowledge flywheel is the product — every session makes the next session smarter
+- The wiki maintains itself: every session contributes to `.agents/` by default
 - Skills work identically across Claude Code, Codex CLI, Cursor, and OpenCode
 - Knowledge captured in one session is retrieved and applied in the next
 - The flywheel runs autonomously between sessions (dream cycle), not just on-demand
@@ -93,6 +94,14 @@ The existing eval suites are CI canaries (contract checks). None answers "did th
 **Progress:** Workbench built: 3 components (Go CLI, Python FastAPI, DevOps scripts), 12 tasks with setup/score scripts, behavioral eval suite (`workbench-behavioral-v1`) with 12 cases covering bug-fix, feature implementation, security, refactoring, test-writing, and edge-case handling. `make -C evals/workbench verify` passes golden (12/12) and broken detection (12/12). A/B comparison via DeltaScorecard validated. Agent harness script with industry-proven eval patterns shipped. `eval-skill-delta` CI gate added to `validate.yml` (structural, runs on eval file changes). `--two-pass` mode added to pre-push head gate for local skill-delta validation. Remaining gap: expanding eval-skill-delta from structural-only to a default blocking gate with full skill-on vs skill-off execution across the workbench.
 
 **Steer:** increase (behavioral eval tasks with scoring scripts)
+
+### 11. Durability of the corpus across runtime cleanup
+
+On 2026-05-07, routine maintenance wiped most of `.agents/` runtime subdirs (only `.agents/nightly/` is git-tracked); a fresh `scripts/corpus-stats.sh` returns near-zero counts even though the 2026-05-04 stable snapshot recorded ~1,842 learnings, ~186 patterns, ~80 planning rules, and ~3,867 cited decisions. The dogfood receipts claim — and the broader "corpus is the moat" positioning — depends on that asset being durable across cleanup, machine moves, and reinstalls. This directive tracks the design and implementation of a snapshot/restore mechanism: scheduled snapshots of `.agents/` runtime state to durable storage, restore tooling that can rehydrate a fresh checkout, and a freshness/coverage gate so degradation is visible before the receipts go stale. Tracked under bd issue soc-rv5p.
+
+**Steer:** increase (snapshots / restore mechanism)
+
+**Tags:** corpus-state
 
 ## Three-Gap Contract Proof Surface
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,12 +1,12 @@
 ---
-last_reviewed: 2026-05-06
+last_reviewed: 2026-05-07
 ---
 
 # PRODUCT.md
 
 ## Mission
 
-**AgentOps keeps the books, compiles the context, and compounds the corpus that feeds your software factory.**
+**AgentOps automates the discipline of building a wiki for your agents.** The wiki is markdown in `.agents/` next to your code; the agents that use it also produce it. The compounded corpus is the moat.
 
 <!-- agentops:claim:AOP-CLAIM-PRODUCT-CONTEXT-ARTIFACT -->
 The highest-leverage input to coding agents is context: what the system knows, what it has tried, what failed, what the codebase decided, and what gates must hold. AgentOps automates the bookkeeping agents do not reliably do for themselves, then turns that record into an engineering artifact: typed, versioned, retrieved, validated, and fed back into the next run.
@@ -29,6 +29,14 @@ The software factory that gets better with each use. Every session produces code
 The aspiration is factory-grade throughput for code: enough structure that agents can run against a defined process, with the operator setting cadence, rigor, and escalation boundaries. Same shape that turned software delivery into an engineering discipline — applied to coding agents.
 
 The thesis is simple: indeterministic workers need disciplined systems. DevOps proved this for engineers. SRE proved it again with SLOs and error budgets. Kubernetes proved it for declarative infrastructure with control loops that reconcile actual state to desired state. Coding agents are the next indeterministic worker class. Same playbook. New substrate. The asset that survives — yours, not ours — is the corpus the system compounds on your behalf.
+
+## What if the labs ship this natively?
+
+They will. Anthropic's Managed Agents is the first move; others will follow. That's fine — the value isn't in this tool. It's in the corpus you build with it.
+
+AgentOps is bridge infrastructure. Your `.agents/` directory is plain markdown in your repo. If a frontier vendor ships native equivalents in 12 months, your corpus carries forward. If we get acquired or change direction, your corpus is yours. If you outgrow the tool entirely, fork it, customize it, replace it — the corpus is what matters.
+
+Open source forever. Built so you own the asset, not the tool.
 
 ## Market Convergence
 
@@ -63,7 +71,9 @@ Read the convergence table the right way: AgentOps and every harness like it get
 
 ## What the Product Actually Is
 
-AgentOps is a software factory with three surfaces and four user-facing layers: Bookkeeping, Context Compiler, Validation Gates, and Knowledge Flywheel. Dream is the scheduled overnight mode of the flywheel, not a separate peer product. The CDLC — the [Context Development Life Cycle](docs/cdlc.md) — is what the factory executes.
+AgentOps is a wiki for your agents. `.agents/` is markdown in your repo, version-controlled with your code, that agents read, traverse, and contribute to — the kind of wiki your team should already have, except agents do the maintenance. AgentOps automates the discipline of building one: capture, retrieval, validation, and compounding all happen mechanically so the wiki stays current instead of bitrotting.
+
+That wiki is the substrate underneath a software factory with three surfaces and four user-facing layers: Bookkeeping, Context Compiler, Validation Gates, and Knowledge Flywheel. Dream is the scheduled overnight mode of the flywheel, not a separate peer product. The CDLC — the [Context Development Life Cycle](docs/cdlc.md) — is what the factory executes. The deeper proof-contract framing — identity, reproducibility, evaluation, evidence, recovery — lives in [docs/trust-factory.md](docs/trust-factory.md).
 
 ### Three surfaces
 
@@ -198,6 +208,8 @@ As of 2026-05-04:
 
 These are this repo's corpus stats; your own AgentOps install will produce its own. Run `scripts/corpus-stats.sh --table` (or `--json` / `--markdown`) against `$AO_CORPUS_ROOT` to derive yours. The previously-cited "4,940 learnings, 1,195 patterns, 40 planning rules" line was removed because no on-disk source reconciled it; the numbers above are what the tracked source actually returns at the time of writing.
 
+*`.agents/` runtime state was wiped by routine cleanup on 2026-05-07; receipts use 2026-05-04 stable snapshot. Durability fix tracked in soc-rv5p.*
+
 Your corpus grows every session — learnings, patterns, and constraints accumulate in your repo, not ours. The system writes the substrate; you decide on what cadence the dream/evolution/compile loops run via `ao schedule`. Scale and compounding follow from the schedule you set, not from a claim we make.
 
 ## Desired State vs Current State
@@ -279,6 +291,8 @@ Explicit `--preset` overrides from the user skip auto-include (user intent takes
 ## See Also
 
 - [Context Lifecycle Contract](docs/context-lifecycle.md) — canonical definition of judgment validation, durable learning, and loop closure, with evidence map and mechanism inventory.
+- [Trust Factory](docs/trust-factory.md) — how AgentOps maps to the five-step proof contract (identity, reproducibility, evaluation, evidence, recovery).
+- [Wiki for your agents](docs/wiki-for-agents.md) — the wiki framing as a standalone document.
 - [Scale Without Swarms](docs/scale-without-swarms.md) — why 3-5 focused agents with fresh context and regression gates outperform massive uncoordinated swarms; the AgentOps model of waves, isolation, and gates explained.
 - [Brownian Ratchet](docs/brownian-ratchet.md) — the forward-only-progress lineage in detail.
 - [The Science](docs/the-science.md) — DevOps Three Ways, the escape velocity condition, and the leverage-points map.

--- a/README.md
+++ b/README.md
@@ -2,26 +2,19 @@
 
 # AgentOps
 
-[![Validate](https://github.com/boshu2/agentops/actions/workflows/validate.yml/badge.svg?branch=main)](https://github.com/boshu2/agentops/actions/workflows/validate.yml)
-[![Nightly](https://github.com/boshu2/agentops/actions/workflows/nightly.yml/badge.svg)](https://github.com/boshu2/agentops/actions/workflows/nightly.yml)
 [![GitHub stars](https://img.shields.io/github/stars/boshu2/agentops?style=social)](https://github.com/boshu2/agentops/stargazers)
 
-### Operational discipline for coding agents.
+### A wiki for your agents. Built so you own the moat.
 
-Ship reliable code with unreliable agents.
+`.agents/` is just a wiki — markdown files in your repo, version-controlled with your code, that agents read, traverse, and contribute to. The kind of wiki your team should already have. AgentOps automates the discipline of building one.
 
-<!-- agentops:claim:AOP-CLAIM-README-FACTORY-CONTEXT -->
-**AgentOps keeps the books for coding agents, then compiles that record into context for your software factory.** It captures what agents tried, what worked, what failed, what was validated, and what should constrain the next run.
+*The only verifiable moat in this uncertain time is context. Models will get smarter, harnesses will commoditize, agents will get cheaper. Your accumulated context — the lessons learned about your individual problems, the patterns that worked, the decisions that survived review — is the one asset that compounds and doesn't get eaten by the next vendor release. That's what your company actually is.*
 
-In practice, AgentOps turns each agent run into an evidence trail, uses that trail to brief the next run, and blocks risky work before it ships.
+*AgentOps is the shovel. Start digging.*
 
-It encodes the DevSecOps SDLC as the **CDLC**: isolated context per worker, shared corpus coordination, planner/implementer/validator separation, validation gates, and scheduled compounding.
+> AgentOps is not a coding harness. The labs are building those, and they will keep getting better. AgentOps sits on top of whichever harness you already use — Claude Code, Codex, Cursor, OpenCode — and turns your business, codebase, and team practices into a context library those agents mix and match from. Mix and match Claude, Codex, or any model at every phase. Lives in `.agents/` in your repo. Runs on your hardware. Evolves with the models.
 
-Runs on your hardware, your repos, your subscriptions. Choose the posture: in-the-loop for high-rigor work, on-the-loop for scheduled compounding. Works across Claude Code, Codex, Cursor, and OpenCode. For constrained or regulated environments, see the [Assurance Posture](PRODUCT.md#assurance-posture).
-
-→ See [scheduling reference](docs/scheduling.md) and [example schedules](examples/schedules/) for the always-on lane.
-
-[Install](#install) · [See It Work](#see-it-work) · [Quick Start](#quick-start) · [Why DevOps?](#why-devops) · [Skills](#skills) · [CLI](#the-ao-cli) · [Doctrine](https://12factoragentops.com) · [Docs](docs/documentation-index.md)
+*AgentOps was used to develop AgentOps. As of 2026-05-04, this repo's `.agents/` directory contained ~1,842 learnings, ~186 patterns, ~80 planning rules, and ~3,867 cited decisions captured by the system on itself across thousands of phase transitions. Re-run anytime: `bash scripts/corpus-stats.sh`. Independent 3-judge audit (2026-05-06) confirmed parity with Anthropic Managed Agents on rubric authoring, separate-context grading, and iterate-until-pass.*
 
 </div>
 
@@ -64,7 +57,7 @@ npx skills@latest add boshu2/agentops --cursor -g
 
 Restart your agent after install. Then type `/quickstart` in your agent chat.
 
-The `ao` CLI is optional, but recommended. It unlocks repo-native bookkeeping, retrieval, health checks, and terminal workflows.
+The `ao` CLI is optional but recommended — repo-native bookkeeping, retrieval, health checks, and terminal workflows.
 
 **macOS**
 
@@ -81,24 +74,27 @@ irm https://raw.githubusercontent.com/boshu2/agentops/main/scripts/install-ao.ps
 ao version
 ```
 
-You can also install the CLI from [release binaries](https://github.com/boshu2/agentops/releases) or [build from source](cli/README.md).
-
-| Concern | Answer |
-|---------|--------|
-| What it touches | Installs skills globally and registers runtime hooks when requested; agent work writes local bookkeeping to `.agents/` |
-| Source code changes | None during install |
-| Network behavior | Install and update paths fetch from GitHub; repo artifacts stay local unless you choose external tools or remote model runtimes |
-| Telemetry | No AgentOps product telemetry required |
-| Permission surface | Skills can run shell commands and read or write repo files during agent work, so install where you want agents to operate |
-| Reversible | Remove the installed skill directories, delete `.agents/`, and remove hook entries from your runtime settings |
-
-Troubleshooting: [docs/troubleshooting.md](docs/troubleshooting.md) · Configuration: [docs/ENV-VARS.md](docs/ENV-VARS.md)
+You can also install from [release binaries](https://github.com/boshu2/agentops/releases) or [build from source](cli/README.md). Troubleshooting: [docs/troubleshooting.md](docs/troubleshooting.md). Configuration: [docs/ENV-VARS.md](docs/ENV-VARS.md).
 
 ---
 
 ## See It Work
 
-**One command: validate a PR across Claude and Codex**
+**One command: per-phase model routing across Claude and Codex**
+
+```text
+$ ao rpi "add rate limiting to /login"
+[research/claude]    found 3 prior auth changes in .agents/decisions/
+[plan/claude]        proposed: token bucket, 5/min per IP, Redis-backed
+[pre-mortem/codex]   WARN: Redis unreachable case unhandled
+[implement/codex]    wrote middleware/ratelimit.go, 2 tests
+[validate/claude]    go test ./... PASS, gate: WARN — missing jitter
+[recorded]           .agents/runs/2026-05-07-rate-limit/
+```
+
+Claude does discovery, Codex implements, a fresh Claude validates, all in one loop with state preserved across boundaries. Nobody else does this.
+
+And when you want a second opinion before shipping: `/council --mixed`
 
 ```text
 > /council --mixed validate this PR
@@ -112,20 +108,6 @@ Consensus: WARN - fix /login rate limit and add refill jitter before shipping
 Recorded: .agents/council/<run-id>/verdict.md
 ```
 
-**Full loop: research through post-mortem**
-
-```text
-> /rpi "add retry backoff to rate limiter"
-
-[research]    Found 3 prior learnings on rate limiting
-[plan]        2 issues, 1 wave
-[pre-mortem]  Council validates the plan
-[crank]       Executes the scoped work
-[vibe]        Council validates the code
-[post-mortem] Captures new learnings in .agents/
-[flywheel]    Next session starts with better context
-```
-
 The point is not a bigger prompt. The point is a repo that remembers what was tried, what worked, what failed, and what should constrain the next run.
 
 ---
@@ -133,7 +115,6 @@ The point is not a bigger prompt. The point is a repo that remembers what was tr
 ## What AgentOps Gives You
 
 Four layers. Each solves a different problem. All four compound.
-<!-- agentops:claim:AOP-CLAIM-README-AUTONOMOUS-FLYWHEEL -->
 
 | Layer | Problem | What changes |
 |-------|---------|--------------|
@@ -142,31 +123,21 @@ Four layers. Each solves a different problem. All four compound.
 | **Validation Gates** | Agents ship confident garbage | `/pre-mortem`, `/vibe`, `/council` — multi-model consensus validates plans before build and code before commit. Gates block, not advise. *Three fresh judges catch what one agent can't.* |
 | **Knowledge Flywheel** | Lessons disappear between sessions | `/forge` extracts learnings from the bookkeeping trail. `ao flywheel close-loop` scores and promotes. `/evolve` fixes the worst gap autonomously. `/dream` compounds overnight. *Session 15 starts with everything session 1 learned.* |
 
-```mermaid
-flowchart LR
-    S[Session starts] --> L1[Compile context]
-    L1 --> W[Agent works]
-    W --> B[Record bookkeeping]
-    B --> L2[Validate output]
-    L2 --> E[Session ends]
-    E --> L3[Extract + compound]
-    L3 -->|better context| S
-```
+All state lives in local `.agents/` — plain text you can grep, diff, and review. No AgentOps-managed telemetry or hosted control plane. Runtime-neutral across Claude Code, Codex CLI, Cursor, and OpenCode.
 
-All state lives in local `.agents/` — plain text you can grep, diff, and review. No AgentOps-managed telemetry or hosted control plane; model runtimes, Git remotes, installers, and external tools are operator-selected dependencies. Runtime-neutral across Claude Code, Codex CLI, and OpenCode. That local, auditable posture is intentional: the product is designed for teams that need constrained-network discipline, explicit evidence, and human authority boundaries.
+### Why not just use Notion or Confluence?
 
-### The failure modes (proof contract)
+| Notion / Confluence | AgentOps `.agents/` |
+|---|---|
+| Written for humans; agents can't traverse it efficiently | LLM Wiki of Markdown — agents read it natively |
+| Lives in SaaS, not your repo | Lives in `.agents/` next to the code |
+| Not version-controlled with your code | Diffable, branchable, mergeable |
+| No decay ranking, no retrieval scoring | `ao inject` returns decay-ranked, token-budgeted packets |
+| No validation gates, no automated capture | Sessions write to it automatically; councils validate it |
+| Doesn't compound; you maintain it manually | Daemon defrags, evolves, and compounds it overnight |
+| Read-only artifact | Writes itself: agents that use it also produce it |
 
-The four layers close failure modes most agent setups don't even name:
-
-| Gap | Where the loop breaks | Closed by |
-|-----|-----------------------|-----------|
-| **Bookkeeping** | Agent tries three approaches, drops two, and the next session never knows why. | `.agents/` traces · `/trace` · `/provenance` · citations · handoffs |
-| **Judgment** | Plan looks coherent. Code passes tests. Both miss the edge case. | Validation Gates: `/pre-mortem` · `/vibe` · `/council` |
-| **Durable Learning** | Auth bug fixed Monday. Same bug returns Wednesday. | Knowledge Flywheel: `/forge` · `ao flywheel` · `ao inject` |
-| **Loop Closure** | Code lands. No lesson extracted. Next session re-learns from scratch. | Flywheel → Context Compiler: `/evolve` · finding compiler · `/dream` |
-
-Each factor in the [12-factor doctrine](https://12factoragentops.com) closes one or more of these gaps. Full contract: [docs/context-lifecycle.md](docs/context-lifecycle.md).
+More: [docs/wiki-for-agents.md](docs/wiki-for-agents.md) · [docs/trust-factory.md](docs/trust-factory.md).
 
 ---
 
@@ -174,25 +145,25 @@ Each factor in the [12-factor doctrine](https://12factoragentops.com) closes one
 
 DevOps proved that disciplined systems around indeterministic workers produce reliable output. SRE proved it again with SLOs and error budgets. Kubernetes proved it for infrastructure with control loops. Coding agents are the next indeterministic worker class. Same playbook. New substrate.
 
-DevOps had the SDLC — the infinity loop that made software delivery an engineering discipline. Coding agents need an equivalent: the **Context Development Life Cycle (CDLC)**. Every SDLC phase has a context counterpart. AgentOps implements all of them.
+Every primitive software engineering already gave us has a counterpart in the agent world:
 
-| SDLC | CDLC | AgentOps surface |
-|------|------|------------------|
-| **Plan** | **Generate** | `/research`, `/plan`, SKILL.md authoring |
-| **Code + Build** | **Compile** | `ao context assemble`, `ao inject`, decay-ranked retrieval |
-| **Test** | **Test** | `/pre-mortem`, `/vibe`, `/council`, `ao eval run` |
-| **Release** | **Distribute** | Skills registry, `/converter`, cross-runtime export |
-| **Deploy** | **Deliver** | `SessionStart` hooks, `ao inject --for=<skill>` |
-| **Operate** | **Observe** | Citation tracking, quality signals, session-outcome |
-| **Monitor → Plan** | **Adapt** | MemRL feedback, `/forge`, `/evolve`, `/dream` |
+| Software Engineering | Coding-Agent World |
+|---|---|
+| Source code | Context (corpus, planning rules, learnings) |
+| SDLC | CDLC (Context Development Lifecycle) |
+| Libraries (Maven, npm, crates.io) | Context libraries (the `.agents/` corpus) |
+| Compilers | Context compilers (`ao compile` → wiki) |
+| Code review | Multi-model councils |
+| CI/CD | Validation gates (`/vibe`, `/pre-mortem`) |
+| Postmortems | Automated postmortems (`/post-mortem` → learnings) |
+| Runbooks | Skills + planning rules |
+| Software factories | Software factory daemon (`ao daemon`) |
+| Markdown / Git / Linux (open primitives) | LLM Wiki of Markdown |
+| Open-source corpus | Your private corpus (`.agents/` in your repo) |
 
-LLMs are engines. Context is fuel. You can't tune the engine — that's the model vendor's job. But you can engineer the fuel. The CDLC is how.
+Major engineering organizations are reorganizing around feeding their agents the right context — restructuring teams, building internal context platforms, hiring "context engineering" leads. AgentOps is that pattern for solo developers and small teams. Same playbook. Same asset class. Different scale.
 
-Each generation of software practice gave teams a durable artifact: the wiki, the runbook, the postmortem, the toil budget. AgentOps gives your agents the same kind of artifact — **the corpus**. It starts as bookkeeping, then becomes a typed, versioned, agent-readable knowledge store maintained alongside the code. The model stays the same. The corpus compounds.
-
-> The harness layer commoditizes. Memory primitives, learning loops, validation gates — frontier vendors will ship them natively. What stays yours is the corpus. AgentOps is the bridge tool that helps you build that moat now. See [PRODUCT.md](PRODUCT.md) for the full thesis.
-
-Full CDLC treatment: [docs/cdlc.md](docs/cdlc.md). Theoretical foundations: [docs/the-science.md](docs/the-science.md) and [docs/brownian-ratchet.md](docs/brownian-ratchet.md).
+LLMs are engines. Context is fuel. You can't tune the engine — that's the model vendor's job. But you can engineer the fuel. Full CDLC treatment: [docs/cdlc.md](docs/cdlc.md).
 
 ---
 
@@ -200,7 +171,6 @@ Full CDLC treatment: [docs/cdlc.md](docs/cdlc.md). Theoretical foundations: [doc
 
 Inside a repo, use the path that matches what you are trying to do.
 
-<!-- agentops:claim:AOP-CLAIM-README-FIRST-VALIDATED -->
 | Path | Run | Done when |
 |------|-----|-----------|
 | **First repo setup** | `ao quick-start`, then `/quickstart` | AgentOps reports repo readiness and a next action |
@@ -214,10 +184,7 @@ ao quick-start     # Canonical
 ao quickstart      # Stable alias
 ```
 
-That command applies the repeatable core seed: `.agents/`, `GOALS.md`,
-AgentOps instructions, starter knowledge, and readiness guidance. Use
-`/bootstrap` after that when you want the product/operations layer:
-`PRODUCT.md`, `README.md`, `PROGRAM.md`/`AUTODEV.md`, and optional hooks.
+That command applies the repeatable core seed: `.agents/`, `GOALS.md`, AgentOps instructions, starter knowledge, and readiness guidance. Use `/bootstrap` after that when you want the product/operations layer: `PRODUCT.md`, `README.md`, `PROGRAM.md`/`AUTODEV.md`, and optional hooks.
 
 Already installed? Ask your agent for the next action:
 
@@ -252,35 +219,7 @@ Every skill works alone. Flows compose them when you want more structure.
 | `/evolve` | You want a goal-driven improvement loop with regression gates |
 | `/dream` | You want overnight knowledge compounding that never mutates source code |
 
-<details>
-<summary><b>Full catalog</b> — organized by product layer</summary>
-
-**Bookkeeping (L0):** `/retro` · `/trace` · `/provenance` · `/post-mortem` · `/handoff`
-
-**Context Compiler (L1):** `/research` · `/compile` · `/inject` · `/recover`
-
-**Validation Gates (L2):** `/council` · `/vibe` · `/pre-mortem`
-
-**Knowledge Flywheel (L3):** `/forge` · `/flywheel` · `/dream`
-
-**Orchestrated Flows:** `/plan` · `/implement` · `/crank` · `/swarm` · `/rpi` · `/evolve`
-
-**Session & Product:** `/status` · `/trace` · `/provenance` · `/product` · `/goals` · `/release` · `/readme` · `/doc`
-
-**Utility:** `/brainstorm` · `/bug-hunt` · `/complexity` · `/scaffold` · `/push`
-
-Full reference: [docs/SKILLS.md](docs/SKILLS.md)
-
-</details>
-
-<details>
-<summary><b>Cross-runtime orchestration</b> — mix Claude, Codex, Cursor, and OpenCode</summary>
-
-Multi-runtime, one workflow. The same four layers — bookkeeping, context compilation, validation gates, and knowledge flywheel — run whether the active worker is Claude Code, Codex, Cursor, or OpenCode.
-
-One runtime leads a session. Another reviews the result. A third handles focused implementation. Adapters are runtime-specific. The contract is constant: independent context, auditable files, validation before promotion.
-
-</details>
+Full reference: [docs/SKILLS.md](docs/SKILLS.md).
 
 ---
 
@@ -290,7 +229,6 @@ The `ao` CLI is the repo-native control plane behind the skills. It handles retr
 
 ```bash
 ao quick-start                            # Set up AgentOps in a repo
-ao quickstart                             # Alias for quick-start
 ao doctor                                 # Check local health
 ao demo                                   # See the value path in 5 minutes
 ao search "query"                         # Search session history and local knowledge
@@ -302,56 +240,22 @@ ao overnight setup                        # Prepare private Dream runs
 ao metrics health                         # Show flywheel health
 ```
 
-Full reference: [CLI Commands](cli/docs/COMMANDS.md)
+Full reference: [CLI Commands](cli/docs/COMMANDS.md).
 
 ---
 
-## Advanced: Day Loop And Night Loop
+## Two ways to use it: hand agents and the software factory
 
-<!-- agentops:claim:AOP-CLAIM-README-EVOLVE-AUTONOMOUS -->
-Use `/evolve` when you want code improvement. It reads `GOALS.md`, fixes the worst fitness gap, runs regression gates, and records the cycle.
+| Surface | When to use it | What it looks like | Operator role |
+|---------|---------------|-------------------|---------------|
+| **Hand agents** (skills surface) | Active work, exploration, high-stakes decisions, ambiguous scope | `/research`, `/plan`, `/pre-mortem`, `/council`, `/rpi` invoked from chat | Driving — agents respond, you steer |
+| **Software factory** (daemon) | Vetted, well-defined work; overnight compounding; bulk processing | `ao schedule` + `ao daemon` running dream / evolve / compile / defrag / forge unattended; mix-and-match councils per phase | Operator — you set cadence and quality bars; the factory runs |
 
-```text
-> /evolve
+**Hand agents** — when you're driving. Skills (`/rpi`, `/council`, `/pre-mortem`, `/vibe`) work in chat. Different rigor levels available — light skills for exploratory work, full RPI loop for everything that should be tracked, council validation before shipping.
 
-[evolve] GOALS.md loaded
-[cycle-1] Worst gap selected
-[rpi]     Implements the fix
-[gate]    Tests and quality checks pass
-[learn]   Post-mortem feeds the flywheel
-```
+**Software factory** — when work is vetted and ready. The `ao daemon` runs scheduled jobs against your local subscription on your hardware. Mix and match models per phase: Claude for discovery, Codex for implementation, a fresh Claude for validation, an open-weights local model for overnight defrag. Run Dream overnight, then Evolve in the morning against a fresher corpus.
 
-Use `/dream` when you want knowledge compounding. It runs offline-style bookkeeping work over `.agents/`, reports what changed, and never mutates source code, invokes `/rpi`, or performs git operations.
-
-```text
-> /dream start
-
-[overnight] INGEST  harvest new artifacts
-[overnight] REDUCE  dedup, defrag, close loops
-[overnight] MEASURE corpus quality
-[halted]    plateau reached
-
-Morning report: .agents/overnight/<run-id>/summary.md
-```
-
-Run Dream overnight, then run Evolve in the morning against a fresher corpus. The model may be the same; the environment is smarter.
-
----
-
-## Competitive Positioning
-
-<!-- agentops:claim:AOP-CLAIM-README-COMPETITIVE-MEMORY -->
-Most tools optimize work *within* a session. AgentOps compounds across them. The four product layers — Bookkeeping, Context Compiler, Validation Gates, Knowledge Flywheel — are the gap.
-
-| Tool | What it does well | What AgentOps adds |
-|------|-------------------|--------------------|
-| **[GSD](https://github.com/glittercowboy/get-shit-done)** | Fresh-context phased execution, recovery loops, runtime breadth | Context Compiler (cross-session retrieval), Validation Gates (pre-build), Knowledge Flywheel |
-| **[Compound Engineer](https://github.com/EveryInc/compound-engineering-plugin)** ([vs.](docs/comparisons/vs-compound-engineer.md)) | Ideation, configurable reviewers, cross-runtime conversion | Automatic capture/scoring/injection, council validation, repo-native `ao` workflows |
-| **[Spec Kit](https://github.com/github/spec-kit) / [Kiro](https://kiro.dev/)** | Spec-driven development and executable planning artifacts | Learning beyond specs: failures, decisions, retros, prevention rules |
-| **[Superpowers](https://github.com/obra/superpowers)** | TDD discipline and autonomous work patterns | Memory, pre-mortems, validation across repeated sessions |
-| **[Ruflo / Claude-Flow](https://github.com/ruvnet/ruflo)** | High-scale swarm orchestration and MCP-heavy coordination | Local, auditable compounding around whatever executes the work |
-
-[Detailed comparisons](docs/comparisons/) · [Competitive radar](docs/comparisons/competitive-radar.md)
+→ [scheduling reference](docs/scheduling.md) · [example schedules](examples/schedules/).
 
 ---
 
@@ -366,48 +270,19 @@ Most tools optimize work *within* a session. AgentOps compounds across them. The
 | Full skill catalog | [Skills](docs/SKILLS.md) |
 | CLI reference | [CLI commands](cli/docs/COMMANDS.md) |
 | Architecture | [Architecture](docs/ARCHITECTURE.md) |
-| Behavioral discipline | [Behavior guide](docs/behavioral-discipline.md) |
 | FAQ | [FAQ](docs/FAQ.md) |
 
-**Building docs locally.** The site is built with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/). Python 3.10+ is required; the dev toolchain is pinned in `requirements-docs.txt`.
-
-```bash
-scripts/docs-build.sh --serve    # live-reload dev server at http://127.0.0.1:8000
-scripts/docs-build.sh --check    # strict build (mirrors what CI runs)
-scripts/docs-build.sh            # build site to _site/
-```
-
-The first run creates `.venv-docs/` and installs the toolchain via `uv` (preferred) or `pip`. The deploy workflow at `.github/workflows/docs.yml` runs the same `mkdocs build --strict` on every push to `main` and publishes to GitHub Pages.
+AgentOps is built on the 12-factor doctrine — see [12factoragentops.com](https://12factoragentops.com).
 
 ---
 
-## The 12-Factor Doctrine
+## What if the labs ship this natively?
 
-AgentOps is shaped by a set of public principles — the 12 factors of agent operations. Foundation, Flow, Knowledge, and Scale. Read them at **[12factoragentops.com](https://12factoragentops.com)**.
+They will. Anthropic's Managed Agents is the first move; others will follow. That's fine — the value isn't in this tool. It's in the corpus you build with it.
 
-| Tier | Factors |
-|------|---------|
-| **Foundation (I-III)** | Context Is Everything · Track Everything in Git · One Agent, One Job |
-| **Flow (IV-VI)** | Research Before You Build · Validate Externally · Lock Progress Forward |
-| **Knowledge (VII-IX)** | Extract Learnings · Compound Knowledge · Measure What Matters |
-| **Scale (X-XII)** | Isolate Workers · Supervise Hierarchically · Harvest Failures as Wisdom |
+AgentOps is bridge infrastructure. Your `.agents/` directory is plain markdown in your repo. If a frontier vendor ships native equivalents in 12 months, your corpus carries forward. If we get acquired or change direction, your corpus is yours. If you outgrow the tool entirely, fork it, customize it, replace it — the corpus is what matters.
 
-The AgentOps product implements these principles through skills, the `ao` CLI, and local bookkeeping in `.agents/`. See each factor page at [12factoragentops.com/factors](https://12factoragentops.com/factors) for the doctrine behind the mechanism.
-
----
-
-## Ready?
-
-```bash
-# 1. Install (pick your runtime above)
-# 2. Run in your repo
-ao quick-start
-#    or: ao quickstart
-# 3. Validate from your agent chat
-/council validate this PR
-```
-
-Then explore the [skills catalog](docs/SKILLS.md), the [`ao` CLI reference](cli/docs/COMMANDS.md), and the [12-factor doctrine](https://12factoragentops.com).
+Open source forever. Built so you own the asset, not the tool.
 
 ---
 

--- a/docs/agentops-brief.md
+++ b/docs/agentops-brief.md
@@ -1,12 +1,16 @@
 # AgentOps — One-Page Brief
 
-**The problem:** AI coding tools behave like contractors with amnesia. Every session starts from zero — no memory of what broke last week, no record of decisions already made, no awareness of what was tried and abandoned. You brief them today. Tomorrow you brief them again.
+`.agents/` is just a wiki — markdown files in your repo, version-controlled with your code, that agents read, traverse, and contribute to. The kind of wiki your team should already have. AgentOps automates the discipline of building one.
+
+*The only verifiable moat in this uncertain time is context. Models will get smarter, harnesses will commoditize, agents will get cheaper. Your accumulated context — the lessons learned about your individual problems, the patterns that worked, the decisions that survived review — is the one asset that compounds and doesn't get eaten by the next vendor release. That's what your company actually is.*
+
+AgentOps is the shovel. Start digging.
 
 ---
 
 ## What It Is
 
-A repo-native operational layer for coding agents.
+A wiki for your agents — repo-native, version-controlled, mechanically maintained.
 
 <!-- agentops:claim:AOP-CLAIM-BRIEF-FOUR-LAYERS -->
 AgentOps gives every session four product layers: **Bookkeeping** that records what agents tried and validated, a **Context Compiler** that loads the right repo context before work starts, **Validation Gates** that challenge plans and code before they ship, and a **Knowledge Flywheel** that extracts learnings and feeds them back so the next session starts smarter.
@@ -109,6 +113,19 @@ preserves the evidence trail, the Context Compiler loads the right context,
 Validation Gates block bad output, and the Knowledge Flywheel ensures every
 session leaves the repo smarter. The
 three-gap contract remains the internal proof model.
+
+---
+
+## What if the labs ship this natively?
+
+They will. Anthropic's Managed Agents is the first move; others will follow. That's fine — the value isn't in this tool, it's in the corpus you build with it. AgentOps is bridge infrastructure: your `.agents/` directory is plain markdown in your repo, so if a frontier vendor ships native equivalents in 12 months, your corpus carries forward unchanged.
+
+---
+
+## See also
+
+- [docs/wiki-for-agents.md](wiki-for-agents.md) — the wiki framing as a standalone document.
+- [docs/trust-factory.md](trust-factory.md) — AgentOps mapped to the five-step trust factory primitive.
 
 ---
 

--- a/docs/cdlc.md
+++ b/docs/cdlc.md
@@ -1,6 +1,31 @@
-# Context Development Life Cycle (CDLC)
+# Context Development Life Cycle
 
-> **TL;DR:** DevOps gave us the SDLC — a disciplined lifecycle for code. CDLC is the same thing for context. Every phase of the software development lifecycle has a context counterpart. AgentOps implements all of them.
+> **TL;DR:** Software engineering took 50 years to build the discipline that turned indeterministic teams into shippable software. The same shape, applied to context, is what AgentOps does. Every phase of the software development lifecycle has a context counterpart. AgentOps implements all of them.
+
+Software engineering took 50 years to build the discipline that turned indeterministic teams into shippable software. The same shape, applied to context, is what AgentOps does.
+
+The translation is direct. Each piece of the software-engineering stack has a coding-agent counterpart:
+
+| Software Engineering | Coding-Agent World |
+|---|---|
+| Source code | Context (corpus, planning rules, learnings) |
+| SDLC | Context Development Lifecycle |
+| Libraries (Maven, npm, crates.io) | Context libraries (the `.agents/` corpus) |
+| Compilers | Context compilers (`ao compile` → wiki) |
+| Code review | Multi-model councils |
+| CI/CD | Validation gates (`/vibe`, `/pre-mortem`) |
+| Postmortems | Automated postmortems (`/post-mortem` → learnings) |
+| Runbooks | Skills + planning rules |
+| Software factories | Software factory daemon (`ao daemon`) |
+| Markdown / Git / Linux (open primitives) | LLM Wiki of Markdown |
+| Open-source corpus | Your private corpus (`.agents/` in your repo) |
+
+We call this the **Context Development Lifecycle (CDLC)** — the body of this doc explains how each SDLC phase has a CDLC counterpart.
+
+### Companion docs
+
+- [Wiki for agents](./wiki-for-agents.md) — what `.agents/` actually is and why agents can read it natively
+- [Trust factory](./trust-factory.md) — how the validation gates and councils make agent output trustworthy
 
 ---
 
@@ -8,7 +33,7 @@
 
 In 2009, DevOps asked: *what if ops looked more like dev?* The answer was CI/CD, infrastructure as code, and the SDLC infinity loop — Plan, Code, Build, Test, Release, Deploy, Operate, Monitor.
 
-CDLC asks the same question about context: *what if the instructions, knowledge, and constraints we feed to coding agents were engineered with the same rigor as the code they produce?*
+The CDLC asks the same question about context: *what if the instructions, knowledge, and constraints we feed to coding agents were engineered with the same rigor as the code they produce?*
 
 The answer is the same shape. Different substrate.
 

--- a/docs/comparisons/competitive-radar.md
+++ b/docs/comparisons/competitive-radar.md
@@ -39,7 +39,7 @@ empty, and the rest of this radar is about staying in it.
 
 What each competitor wins on (the structural advantage AgentOps cannot beat
 them on) and what AgentOps wins on against them. Sourced from the
-[2026-05-07 council research](../../.agents/council/2026-05-07-research-readme-positioning.md).
+2026-05-07 council research (`.agents/council/2026-05-07-research-readme-positioning.md` in the repo).
 
 | Competitor | Lane | What they win on | What AgentOps wins on |
 |------------|------|------------------|------------------------|
@@ -105,7 +105,7 @@ AgentOps's posture toward it (compete, complement, or ignore).
 ## Where AgentOps Wins
 
 Six differentiators no competitor in the seven-competitor set has. Sourced from
-the [2026-05-07 council research](../../.agents/council/2026-05-07-research-readme-positioning.md).
+the 2026-05-07 council research (`.agents/council/2026-05-07-research-readme-positioning.md` in the repo).
 
 ### 1. Persistent corpus
 

--- a/docs/comparisons/competitive-radar.md
+++ b/docs/comparisons/competitive-radar.md
@@ -1,74 +1,182 @@
 ---
 title: "AgentOps Competitive Radar"
-description: "Current market read for AgentOps against coding-agent workflow, plugin, orchestration, and spec-driven development competitors."
+description: "Current market read for AgentOps against the Claude Code skills/plugin ecosystem and adjacent agent-workflow tools."
 permalink: /comparisons/competitive-radar
-last_reviewed: 2026-04-13
+last_reviewed: 2026-05-07
 ---
 
 # Competitive Radar
 
-AgentOps should not try to be every agent workflow tool at once. The strongest
-position is narrower and harder to copy: make repeated work on the same codebase
-compound through local bookkeeping, validation, and retrieval.
+AgentOps should not try to be every agent workflow tool at once. The Claude
+Code skills/plugin ecosystem has consolidated into five lanes; the strongest
+position is narrower and harder to copy than any of them: **a wiki for your
+agents, version-controlled in your repo, that compounds across sessions**.
+The corpus is the moat. The tool is replaceable.
 
 ## Source Set
 
-| Source | Current signal | Link |
-|--------|----------------|------|
-| AgentOps | Operational layer for coding agents; local bookkeeping, validation, flows, `ao` CLI | [boshu2/agentops](https://github.com/boshu2/agentops) |
-| GSD | Fresh-context execution framework with broad runtime support and recovery loops | [glittercowboy/get-shit-done](https://github.com/glittercowboy/get-shit-done) |
-| Compound Engineer | Ideate-to-compound workflow, configurable reviewers, cross-runtime conversion | [EveryInc/compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) |
-| Superpowers | TDD discipline and autonomous work patterns | [obra/superpowers](https://github.com/obra/superpowers) |
-| Ruflo / Claude-Flow | High-scale swarm orchestration and MCP-heavy agent coordination | [ruvnet/ruflo](https://github.com/ruvnet/ruflo) |
-| GitHub Spec Kit | Spec-driven development becoming a mainstream, multi-agent workflow | [github/spec-kit](https://github.com/github/spec-kit) |
-| Kiro | Productized spec-driven IDE with steering, agent hooks, and MCP | [kiro.dev](https://kiro.dev/) |
+| Source | Lane | Link |
+|--------|------|------|
+| AgentOps | Context library / wiki for agents (this doc) | [boshu2/agentops](https://github.com/boshu2/agentops) |
+| obra/superpowers | Methodology (TDD discipline, autonomy patterns) | [obra/superpowers](https://github.com/obra/superpowers) |
+| EveryInc/compound-engineering-plugin | Methodology (ideate→compound, 7-phase loop) | [EveryInc/compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) |
+| anthropics/claude-plugins-official | Curation (first-party marketplace) | [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official) |
+| jeremylongshore/claude-code-plugins-plus-skills | Volume marketplace (CCPI manager) | [jeremylongshore/claude-code-plugins-plus-skills](https://github.com/jeremylongshore/claude-code-plugins-plus-skills) |
+| alirezarezvani/claude-skills | Volume + breadth (skills × platforms) | [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) |
+| affaan-m/everything-claude-code | Cross-harness (DRY parity across runtimes) | [affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code) |
+| trailofbits/skills | Vertical authority (security domain) | [trailofbits/skills](https://github.com/trailofbits/skills) |
 
 ## Market Read
 
-| Trend | Why it matters | AgentOps response |
-|-------|----------------|-------------------|
-| Runtime portability is table stakes | GSD, Compound Engineer, and Spec Kit all emphasize multi-agent or multi-runtime reach. | Keep Claude, Codex, OpenCode, and skills-compatible install paths working, and show proof instead of only claiming parity. |
-| Spec-first is mainstream | GitHub Spec Kit and Kiro make executable specs feel normal rather than niche. | Treat specs as one input to the flywheel: capture what was planned, then capture what the session learned. |
-| Context isolation is a competitive feature | GSD's clean-agent pattern and Ruflo's swarm framing both sell fresh context as a quality lever. | Make AgentOps' context compiler story concrete: phase-scoped packets, retrieval scoring, and worker-safe handoffs. |
-| Compounding is now contested | Compound Engineer is philosophically close and has a strong ideate-to-refresh loop. | Win on automation: extraction, scoring, injection, maturity, and decay without relying on the operator to remember each step. |
-| Visible proof beats claims | Every serious competitor can explain a workflow. The winner needs a proof loop users can run. | Put `ao doctor`, `ao demo`, Dream reports, and comparison freshness in the public path. |
+The five-lane consolidation (see *Lane segmentation* below) means most
+"compete with AgentOps" framings are category errors. A volume marketplace
+sells inventory; a methodology plugin sells discipline; a vertical-authority
+collection sells domain credibility. None of the seven sells **persistent
+context that compounds across sessions on your hardware**. That lane is
+empty, and the rest of this radar is about staying in it.
 
-## Competitive Matrix
+## Seven-competitor lane table
 
-| Competitor | Best at | Risk to AgentOps | AgentOps counter | Pressure to add |
-|------------|---------|------------------|------------------|-----------------|
-| GSD | Fresh-context phased execution, model/cost tiers, broad runtime install | Looks more immediately execution-focused and portable | Knowledge flywheel, pre-mortem, council validation, beads issue graph, Go CLI | Cost tiers, clearer worker context budgets, stronger prompt-guard story |
-| Compound Engineer | Ideation, per-project reviewer routing, knowledge refresh, 10-target conversion | Closest substitute for teams that want compounding and portability | Automated capture/scoring/injection, runtime hooks, goals/evolve, dependency-aware execution | Configurable reviewer routing, investigative freshness checks |
-| Spec Kit / Kiro | Specs as the first-class product artifact | Users may think specs alone solve agent drift | AgentOps captures specs plus learnings, failures, decisions, retros, and prevention rules | Better spec import/export and "specs are not the flywheel" examples |
-| Superpowers | Strict TDD and senior-engineer discipline | Simpler quality story for greenfield work | Cross-session memory, pre-implementation validation, repo-local proof artifacts | Sharper TDD-first path for `/implement` and `/crank` |
-| Ruflo / Claude-Flow | Large-scale orchestration and MCP breadth | More impressive swarm scale and enterprise orchestration story | Smaller, auditable loops that compound knowledge across sessions | Better "AgentOps plus external orchestrator" integration docs |
+What each competitor wins on (the structural advantage AgentOps cannot beat
+them on) and what AgentOps wins on against them. Sourced from the
+[2026-05-07 council research](../../.agents/council/2026-05-07-research-readme-positioning.md).
+
+| Competitor | Lane | What they win on | What AgentOps wins on |
+|------------|------|------------------|------------------------|
+| [obra/superpowers](https://github.com/obra/superpowers) | Methodology | Official Anthropic marketplace placement, ~29K stars, Jesse Vincent brand, TDD red-green-refactor as a sharp methodology hook | Persistent corpus accumulating across sessions; cross-session memory in `.agents/`; multi-model council as a commit gate; off-API daemon on your hardware |
+| [EveryInc/compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) | Methodology | 10-target runtime conversion CLI; configurable per-project reviewer routing; ideation-to-compound surface area; closest philosophical neighbor | Model-independent **per-phase** routing (Claude for discovery, Codex for implementation, fresh Claude for validation, local model for overnight defrag — in one workflow); persistent corpus that lives in your repo, not the tool |
+| [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official) | Curation | First-party authority; default discovery channel; "trust before installing" posture | Operates underneath any harness — Claude Code, Codex, Cursor, OpenCode — turning sessions into a context library you own. AgentOps is not a coding harness; it sits on top of whichever harness you already use |
+| [jeremylongshore/claude-code-plugins-plus-skills](https://github.com/jeremylongshore/claude-code-plugins-plus-skills) | Volume marketplace | 425 plugins / 2,810 skills inventory; CCPI package manager; sponsored placement; daily download metrics | Compounding context vs. static inventory: skills don't accumulate, a wiki does. AgentOps ships a bookkeeping schema that grows; volume marketplaces ship an inventory that doesn't |
+| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | Volume + breadth | ~5,200+ stars; 235 skills × 12 platforms; 305 stdlib Python tools; multi-domain coverage (engineering + marketing + compliance) | Same persistent-corpus argument plus model-independent phase routing inside one session — breadth of skills doesn't replace cross-session memory |
+| [affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code) | Cross-harness | DRY parity across 5 runtimes; 48 subagents; "Anthropic Hackathon Winner" credential. (README also claims 140K+ stars / 21K forks; the entire Claude Code ecosystem is below those numbers — flagged as not validated.) | Cross-runtime *distribution* is not cross-model *per-phase routing*. AgentOps mixes models per phase within one RPI loop, with state preserved across boundaries — a different optimization |
+| [trailofbits/skills](https://github.com/trailofbits/skills) | Vertical authority (security) | Trail of Bits brand; security skills + a "Trophy Case" of CVE-shaped findings; domain credentialing no general-purpose tool can match | Different category — AgentOps is the substrate a vertical-authority collection runs on. Their skills can live inside an AgentOps corpus; the inverse is not true |
+
+**What this table reveals:** none of the seven are selling persistence,
+sovereignty, off-API operation, multi-model per-phase routing, or
+context-as-a-discipline. The substrate / wiki-for-agents lane is empty if
+AgentOps claims it.
+
+## Lane segmentation
+
+The Claude Code skills/plugin ecosystem has consolidated into five lanes.
+Each row names the lane, the canonical examples, the buyer signal, and
+AgentOps's posture toward it (compete, complement, or ignore).
+
+### 1. Volume (marketplace / many skills)
+
+**Examples:** [jeremylongshore/claude-code-plugins-plus-skills](https://github.com/jeremylongshore/claude-code-plugins-plus-skills) (425 plugins, 2,810 skills, CCPI manager, 100-point grading); [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) (235 skills × 12 platforms); [affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code) (182 skills, 48 subagents) overlaps here too.
+
+**Buyer signal:** "We have the most stuff." Inventory bulk as the value prop. Costco bulk-buy of pre-built skills.
+
+**AgentOps's posture:** **Complement, do not compete.** AgentOps is a different category — a context library / wiki, not a skills inventory. The two combine: install the volume marketplace for breadth; run AgentOps for the corpus discipline that turns those skills' outputs into persistent context.
+
+### 2. Methodology (workflow / discipline)
+
+**Examples:** [obra/superpowers](https://github.com/obra/superpowers) (TDD red-green-refactor); [EveryInc/compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) (ideate→compound, 7-phase loop, 10-target conversion).
+
+**Buyer signal:** "Use our workflow and your agents will produce better code." A sharp opinion about *how* to drive agents.
+
+**AgentOps's posture:** **Compete obliquely, do not contest head-on.** This lane is structurally hard to win — Superpowers has 29K stars and official-marketplace placement; Compound Engineer has the closest philosophical positioning. Winning the methodology lane is *not* AgentOps's bet. AgentOps offers methodology surfaces (`/rpi`, `/council`, `/pre-mortem`, `/vibe`) but its claim is one level deeper: methodology sits on top of context, and the context is what compounds. Anthropic's Managed Agents (May 2026) is also moving into this lane natively.
+
+### 3. Vertical (specific domain)
+
+**Examples:** [trailofbits/skills](https://github.com/trailofbits/skills) (security skills + Trophy Case of findings).
+
+**Buyer signal:** "We are the authoritative source for skills in domain X." Domain credibility no general-purpose tool can replicate.
+
+**AgentOps's posture:** **Complement.** Vertical collections produce skills; AgentOps produces the context library those skills run inside. A security team can install Trail of Bits skills on top of an AgentOps corpus; the security findings then flow into `.agents/` as persistent learnings. AgentOps does not chase vertical authority — that's a brand investment, not a tool feature.
+
+### 4. Curation (small high-quality set)
+
+**Examples:** [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official) (first-party marketplace, "trust before installing"); selective collections that prioritize quality over volume.
+
+**Buyer signal:** "We curate so you don't have to." Trust + discovery channel as the value prop.
+
+**AgentOps's posture:** **Ignore as a competitor; respect as distribution.** First-party curation is unbeatable for trust and discovery, and the right move is to be installable through it rather than to compete with it. AgentOps's claim is orthogonal: it's not "trust this skill" but "build a corpus that survives whichever skill you used last week."
+
+### 5. Cross-harness (multi-runtime parity)
+
+**Examples:** [affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code) (DRY parity across Claude Code, Cursor, Codex, OpenCode, Gemini); [EveryInc/compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) (10-target conversion CLI) overlaps here.
+
+**Buyer signal:** "Our skills run everywhere." Multi-runtime distribution as the value prop.
+
+**AgentOps's posture:** **Compete on a sharper claim.** Cross-harness *distribution* is multi-runtime spread of one workflow shape. AgentOps does cross-harness *and* model-independent **per-phase routing** — Claude does discovery, Codex implements, fresh Claude validates, an open-weights local model handles overnight defrag, all in one RPI loop with state preserved across boundaries. Nobody else in the seven-competitor set does this. The pitch is "mix and match models per phase," not "the same skill on five runtimes."
 
 ## Where AgentOps Wins
 
-| Moat | Why it is hard to copy |
-|------|------------------------|
-| Automated flywheel | Session-end extraction, scoring, maturity, decay, and injection are mechanical rather than remembered process steps. |
-| Validation before build | `/pre-mortem`, `/council`, and `/vibe` create failure-prevention gates, not only post-hoc review. |
-| Repo-native control plane | `ao`, `.agents/`, hooks, schemas, and beads keep state local, diffable, auditable, and scriptable. |
-| Strategic loops | `GOALS.md`, `/evolve`, and Dream turn repeated work into a measured improvement loop. |
+Six differentiators no competitor in the seven-competitor set has. Sourced from
+the [2026-05-07 council research](../../.agents/council/2026-05-07-research-readme-positioning.md).
+
+### 1. Persistent corpus
+
+A bookkeeping schema that *grows*: learnings, patterns, planning rules, and
+cited decisions accumulate in `.agents/` as plain markdown, version-controlled
+with the code. Competitors ship skills (static inventory); AgentOps ships the
+discipline that turns sessions into a wiki. Receipts: as of 2026-05-04, this
+repo's `.agents/` contained ~1,842 learnings, ~186 patterns, ~80 planning
+rules, and ~3,867 cited decisions captured by the system on itself.
+
+### 2. Off-API daemon
+
+`ao schedule` + `ao daemon` runs dream / evolve / compile / defrag / forge
+overnight, off-vendor, on your hardware, against your subscription. All seven
+competitors are in-session plugins. The daemon is the structural answer to
+"what if a frontier vendor ships native equivalents in 12 months" — your
+corpus and your scheduler keep running regardless.
+
+### 3. Multi-model council
+
+`/council --mixed` runs Claude + Codex (and other) judges in parallel against
+one evidence packet, producing a verdict before commit. Compound Engineer has
+reviewer agents but they are single-model and post-implementation. A
+multi-model commit gate is the strongest validation primitive in the set.
+
+### 4. Model-independent phase routing
+
+Pick Claude for ideation, Codex for validation, an open-weights local model
+for overnight defrag — *per phase, in one workflow,* with state preserved
+across the boundaries. Cross-harness *distribution* (everything-claude-code,
+Compound Engineer's 10-target conversion) is multi-runtime spread of one
+workflow shape; per-phase routing is mixing models inside one workflow.
+Different optimization. Nobody in the seven does it.
+
+### 5. Context-engineering vocabulary
+
+AgentOps owns "wiki for agents" + "context library" + "context compiler"
++ "CDLC" as a coherent vocabulary, anchored by the SE → context translation
+table (source code → context, SDLC → CDLC, libraries → context libraries,
+compilers → context compilers, code review → multi-model councils, CI/CD →
+validation gates, postmortems → automated postmortems, runbooks → skills +
+planning rules, software factories → software factory daemon, Markdown/Git
+/Linux → LLM Wiki of Markdown, open-source corpus → your private corpus).
+Vocabulary ownership is durable; Superpowers owns "TDD," AgentOps can own
+"context engineering."
+
+### 6. Honest empirical disclosure
+
+Δ=+0.0000 at workbench v1 difficulty, published in-repo. Independent 3-judge
+audit (2026-05-06) confirmed parity with Anthropic Managed Agents on rubric
+authoring, separate-context grading, and iterate-until-pass. In a market of
+inflated star counts and ungraded "100-point validations," a published null
+result and a transparent audit are credibility assets.
 
 ## Current Vulnerabilities
 
 | Vulnerability | Impact | Best next move |
 |---------------|--------|----------------|
-| Runtime proof lags runtime claims | Competitors can look more portable even when AgentOps has multiple install paths. | Maintain a visible runtime proof matrix tied to smoke tests and `ao doctor` output. |
-| Compounding proof is still too implicit | Users have to trust the flywheel story before they feel it. | Put Dream reports and `ao demo` examples in the first-run path. |
-| Reviewer routing is less configurable | Compound Engineer can feel more tailored to a stack. | Add or document per-project validation profile selection. |
-| Context budget and model cost controls are under-marketed | GSD owns the "fresh context and cost tiers" story. | Expose phase/worker context budgets and model profiles in a simple operator surface. |
-| Knowledge freshness is time-weighted more than investigation-weighted | Time decay is useful, but stale patterns can require active verification. | Add investigative refresh for high-value patterns before decay/archive decisions. |
+| Corpus durability under routine cleanup | The receipts claim ("1,842 learnings") becomes fragile if maintenance can wipe `.agents/` subdirs (observed 2026-05-07). | Snapshot/restore mechanism + tracked durability fix; in the meantime, receipts cite the 2026-05-04 stable snapshot with timestamp. |
+| Methodology lane is being eaten | Anthropic's Managed Agents (May 2026) and Superpowers' marketplace placement compress the methodology buyer's choice set. | Stay out of the methodology lane head-on; lead with the wiki framing and lane-segmentation argument. |
+| Compounding proof is still too implicit | Users have to trust the flywheel story before they feel it. | Put Dream reports, `ao demo`, and corpus-stats in the first-run path. |
+| Reviewer routing is less configurable than Compound Engineer | CE can feel more tailored to a stack. | Document per-project validation profile selection; expose council config more visibly. |
+| Volume-marketplace shoppers may bounce off "73 skills" framing | Inventory-comparison buyers will not see the corpus advantage. | Keep the volume comparison explicit (vs-tons-of-skills doc); reframe the question from "how many skills" to "what does the asset look like in 6 months". |
 
 ## Execution Bias
 
-Do not respond to every competitor feature by adding another command. Favor moves
-that make the flywheel visible, automatic, and verifiable:
+Do not respond to every competitor feature by adding another command. Favor
+moves that make the wiki visible, automatic, and verifiable:
 
-1. Prove install and runtime parity continuously.
-2. Make first value obvious in under five minutes.
-3. Make the knowledge flywheel produce inspectable artifacts.
-4. Turn repeated findings into stronger gates.
-5. Keep comparison docs tied to current official sources.
+1. Make the corpus inspectable on day one (`scripts/corpus-stats.sh`, `ao inject` traces).
+2. Make first value obvious in under five minutes (skills install + first session writes to `.agents/`).
+3. Keep the per-phase model-routing demo as the anchor (it's the killer feature buried in the founder pitch).
+4. Defend the wiki/context-engineering vocabulary in every doc; do not drift to "skills repo" or "methodology" framings.
+5. Keep comparison docs tied to current official sources; re-run `scripts/check-competitive-freshness.sh` before each release.

--- a/docs/comparisons/vs-compound-engineer.md
+++ b/docs/comparisons/vs-compound-engineer.md
@@ -2,13 +2,14 @@
 title: "AgentOps vs Compound Engineer — Detailed Comparison"
 description: "How AgentOps compares to Compound Engineer for AI coding agents. Both compound knowledge, but AgentOps automates the flywheel while Compound Engineer requires manual invocation."
 permalink: /comparisons/agentops-vs-compound-engineer
+last_reviewed: 2026-05-07
 ---
 
 # AgentOps vs Compound Engineer
 
-> **Compound Engineer** is Every's coding-agent plugin implementing a knowledge-compounding development workflow. The core thesis: "Each unit of engineering work should make subsequent units easier." Includes 45+ skills, 25+ agents, ideation with adversarial filtering, knowledge maintenance, and cross-runtime support for 10 targets. Recent additions: stack-aware reviewer routing, mandatory code review by default, and PR description filtering.
+> **Compound Engineer** is Every's coding-agent plugin implementing a knowledge-compounding development workflow. The core thesis: "Each unit of engineering work should make subsequent units easier." Current state (May 2026): 37 skills, 51 agents, an explicit 7-phase workflow (ideate → brainstorm → plan → work → review → compound → refresh), and a 10-target cross-runtime conversion CLI. Recent additions: stack-aware reviewer routing, mandatory code review by default, and PR description filtering.
 >
-> *Comparison updated April 2026. See the [Compound Engineer repo](https://github.com/EveryInc/compound-engineering-plugin) for current features.*
+> See the [Compound Engineer repo](https://github.com/EveryInc/compound-engineering-plugin) for current features.
 
 ---
 
@@ -20,7 +21,7 @@ permalink: /comparisons/agentops-vs-compound-engineer
 | **Core strength** | Full ideate-to-compound loop, cross-runtime portability, configurable review agents | Git-tracked memory, validation gates, knowledge flywheel with scoring |
 | **GitHub** | EveryInc/compound-engineering-plugin | boshu2/agentops |
 | **Latest** | Active development (April 2026) | v2.39.0 (April 2026) |
-| **Scale** | 45+ skills, 25+ agents, 10 runtime targets | 73 skills, compiled CLI, hooks, schemas |
+| **Scale** | 37 skills, 51 agents, 10 runtime targets | 73 skills, compiled CLI, hooks, schemas |
 | **Primary use** | Standardized engineering workflow with knowledge capture | Ongoing codebase work with persistent memory and validation |
 
 ### Three-Layer Comparison
@@ -149,6 +150,20 @@ Compound Engineer's `/ce:work` executes plan files with todo tracking and suppor
 
 AgentOps has GOALS.md, `ao goals measure`, and `/evolve` for measuring progress toward higher-level objectives. Compound Engineer has no equivalent goal-tracking or strategic direction mechanism.
 
+### Model-Independent Phase Routing
+
+AgentOps routes a different model to each phase of one RPI loop, with state preserved across boundaries:
+
+| Phase | Model | Why |
+|-------|-------|-----|
+| Research / Discovery | Claude | Long-context synthesis over the corpus |
+| Plan | Claude | Architectural reasoning |
+| Pre-mortem | Codex (or `/council --mixed`) | Adversarial second opinion from a different family |
+| Implement | Codex | Code generation throughput |
+| Validate | Fresh Claude | Independent reviewer with no prior context bias |
+
+Compound Engineer's 10-target conversion is multi-runtime *distribution* — running the same Claude-shaped workflow on Codex, Gemini, OpenCode, etc. AgentOps does that too via supported runtimes, but additionally swaps models *per phase within a single session* so each phase runs on the model best suited to that phase. CE doesn't do this per-phase model swap; the workflow is single-model end-to-end inside whichever runtime executes it.
+
 ---
 
 ## Where Compound Engineer Goes Further
@@ -188,6 +203,7 @@ While AgentOps has maturity scoring and decay, Compound Engineer's `/ce:compound
 | **Knowledge scoring** | ⚠️ Pattern detection at 3+ | ✅ Maturity + confidence + decay | **AgentOps** |
 | **Pre-mortem simulation** | ❌ Not present | ✅ Before implementation | **AgentOps** |
 | **Multi-model council** | ❌ Not present | ✅ Multi-perspective validation | **AgentOps** |
+| **Model-independent phase routing** | ❌ Single-model workflow per runtime | ✅ Per-phase model swap (Claude → Codex → fresh Claude) in one RPI loop | **AgentOps** |
 | **Issue graph execution** | ⚠️ Plan-based todos | ✅ Beads + dependency waves | **AgentOps** |
 | **Strategic goals** | ❌ No goal tracking | ✅ GOALS.md + evolve | **AgentOps** |
 | **Compiled CLI** | ❌ No binary | ✅ Go binary (ao) | **AgentOps** |

--- a/docs/comparisons/vs-everything-claude-code.md
+++ b/docs/comparisons/vs-everything-claude-code.md
@@ -1,0 +1,181 @@
+---
+title: "AgentOps vs everything-claude-code (affaan-m)"
+description: "Cross-harness performance system vs. context library — different optimizations."
+permalink: /comparisons/agentops-vs-everything-claude-code
+last_reviewed: 2026-05-07
+---
+
+# AgentOps vs. everything-claude-code
+
+> **everything-claude-code** ([affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code))
+> positions itself as *"the performance system for AI agent harnesses"* — DRY
+> parity across Claude Code, Cursor, Codex, OpenCode, and Gemini, shipping
+> **48 subagents and 182 skills** with a single set of definitions kept in sync
+> across all five runtimes.
+
+> **Note on social proof.** The everything-claude-code README claims 140K+ stars
+> and 21K+ forks. The entire Claude Code plugin ecosystem is below those numbers
+> as of 2026-05-07; AgentOps does not validate that claim. The comparison below
+> evaluates the project on its concrete features, not the unverified social-proof
+> metric.
+
+---
+
+## At a glance
+
+| Aspect | everything-claude-code | AgentOps |
+|---|---|---|
+| **Category** | Cross-harness skill collection | Context library / wiki for agents |
+| **Multi-runtime claim** | DRY parity across 5 runtimes (Claude Code, Cursor, Codex, OpenCode, Gemini) | Skills run on 4 runtimes; *and* mix-and-match models per phase within one session |
+| **Inventory** | 182 skills, 48 subagents | 73 skills + your accumulated corpus |
+| **Persistence** | In-session | Cross-session via `.agents/` corpus |
+| **Discipline mechanism** | DRY parity tooling | Multi-model councils + RPI phase contracts |
+| **Off-API surface** | None (in-session only) | `ao daemon` runs dream / evolve / compile overnight |
+| **Open source** | Yes | Yes (forever) |
+
+The two products optimize for different axes. everything-claude-code optimizes
+for *"the same skill set works in every harness."* AgentOps optimizes for
+*"the same model-routed workflow accumulates context across every session."*
+
+---
+
+## The model-independent-per-phase distinction
+
+This is the load-bearing difference, and it is easy to miss.
+
+everything-claude-code's "cross-harness parity" is **multi-runtime distribution
+of a Claude-shaped workflow**: one set of skill and subagent definitions, kept
+DRY across five harnesses, so a developer who lives in Cursor today can move to
+Codex tomorrow and keep the same skill surface. That is real engineering work —
+maintaining parity across five runtime conventions is harder than it sounds —
+and the value is portability across editors.
+
+AgentOps's **per-phase model routing** is a different shape entirely: inside a
+single RPI loop, Claude does discovery, Codex implements, fresh Claude
+validates, all in one workflow with state preserved across the model
+boundaries. The handoff is the feature.
+
+```
+$ ao rpi "add rate limiting to /login"
+[research/claude]    found 3 prior auth changes in .agents/decisions/
+[plan/claude]        proposed: token bucket, 5/min per IP, Redis-backed
+[pre-mortem/codex]   WARN: Redis unreachable case unhandled
+[implement/codex]    wrote middleware/ratelimit.go, 2 tests
+[validate/claude]    go test ./... PASS, gate: WARN — missing jitter
+[recorded]           .agents/runs/2026-05-07-rate-limit/
+```
+
+The labels in brackets are the entire pitch made literal. Each phase picks the
+model that is best for that phase; the validation phase sees a fresh context
+window so it does not rubber-stamp work it just produced. Skills in any
+harness — including everything-claude-code's parity-shipped catalog — inherit
+the harness's single active model. They do not compose model choices per phase
+within one workflow. Nobody else in the ecosystem does this.
+
+Cross-harness parity and per-phase model routing are not the same capability.
+The first is *"my skill set is portable."* The second is *"my workflow uses
+multiple models inside one task."* A team can want both, but a buyer should
+not assume one implies the other.
+
+---
+
+## When to pick which
+
+- **Pick everything-claude-code** if your bottleneck is *"I switch between
+  Claude Code, Cursor, and Codex daily and want the same skills everywhere."*
+  Cross-harness parity is the headline value, and 182 skills + 48 subagents
+  is a sizeable catalog out of the box.
+- **Pick AgentOps** if your bottleneck is *"my agents keep re-learning the
+  same lessons because nothing persists between sessions."* The corpus is
+  the moat; the per-phase model routing and council validation are the
+  discipline that makes the corpus trustworthy.
+- **They are not mutually exclusive.** Install both: use
+  everything-claude-code's catalog as portable skill inventory across
+  whichever harness you happen to be in today, and use AgentOps for the
+  context library that compounds across all of them.
+
+---
+
+## Where everything-claude-code wins
+
+**Cross-harness DRY parity tooling.** Maintaining the same skill and
+subagent definitions across five runtimes — each with its own conventions
+for tool surfaces, file locations, and execution model — is real engineering
+work. If you genuinely live across multiple harnesses and value the same
+skill being available the same way in each one, that is a concrete win
+AgentOps does not directly compete with. AgentOps ships skills for four
+runtimes (Claude Code, Codex, OpenClaw, Cursor) but does not market its
+parity-maintenance pipeline as the headline feature; the headline is the
+corpus that the skills produce.
+
+**Catalog size for a single-developer audience.** 182 skills + 48 subagents
+is a larger pre-built catalog than AgentOps's 73 skills, and a buyer whose
+question is *"how many skills can I install today"* will see that number
+first.
+
+---
+
+## Where AgentOps wins
+
+**Persistent corpus.** AgentOps's `.agents/` directory is a markdown wiki in
+your repo, version-controlled with your code. Every session writes
+learnings, decisions, citations, and validation verdicts; future sessions
+read them through decay-ranked retrieval (`ao inject`). everything-claude-code
+ships skills that run in-session; the work ends when the session does.
+
+**Multi-model councils.** `/council --mixed` runs Claude and Codex judges
+in parallel against one evidence packet and returns structured consensus
+before commit. This is a validation primitive that catches "looks good to
+one model" failure modes before the bug ships. A skill catalog — however
+large or harness-portable — does not provide this surface.
+
+**Model-independent phase routing inside one RPI loop.** Per the section
+above: pick the model that is best for each phase, with state preserved
+across the boundaries. This is a workflow-level capability that is
+orthogonal to (and does not depend on) cross-harness parity.
+
+**Off-API daemon on your hardware.** `ao schedule` and `ao daemon` run
+dream / evolve / compile / defrag / forge passes against your subscription,
+off-vendor, overnight. The corpus compounds while you sleep.
+everything-claude-code is in-session by design; the off-API surface is not
+part of its category.
+
+---
+
+## Both are open source
+
+Both projects are open source. AgentOps is open source forever — the
+corpus that compounds in *your* repo is yours, the schema is portable,
+and the discipline survives any single vendor's roadmap. If you are
+evaluating durability of either project, the source code is the receipt;
+inflated star counts and other unverified metrics are not.
+
+---
+
+## Bottom line
+
+Different optimization targets, not direct competition.
+
+everything-claude-code is selling **cross-harness portability**: one skill
+set, five runtimes, kept in DRY parity by the maintainers' tooling. If
+your friction is editor switching, that is real value.
+
+AgentOps is selling **corpus discipline + per-phase model routing**: the
+operational layer that turns each session's research, decisions,
+validations, and learnings into a markdown wiki your agents read on the
+next session, and the workflow primitive that lets you compose Claude,
+Codex, and other models per phase inside one task.
+
+A buyer who lives across harnesses and does not yet care about persistence
+should pick everything-claude-code. A buyer who is bottlenecked on
+"my agents forget what we learned last week" should pick AgentOps. A
+buyer with both bottlenecks should install both — they sit at different
+layers of the stack.
+
+---
+
+<div align="center">
+
+[← Back to Comparisons](README.md)
+
+</div>

--- a/docs/comparisons/vs-superpowers.md
+++ b/docs/comparisons/vs-superpowers.md
@@ -2,13 +2,14 @@
 title: "AgentOps vs Superpowers — Detailed Comparison"
 description: "How AgentOps compares to Superpowers for AI coding agents. Superpowers enforces strict TDD. AgentOps adds cross-session memory and multi-model validation councils."
 permalink: /comparisons/agentops-vs-superpowers
+last_reviewed: 2026-05-07
 ---
 
 # AgentOps vs Superpowers
 
-> **Superpowers** is a popular coding agent plugin known for disciplined TDD workflows and autonomous operation. Now supports Kimi Code CLI, OpenClaw, and Mistral Vibe (April 2026). Major architectural shift: skills separated into a dedicated repo (obra/superpowers-skills) — the plugin is now a lightweight shim that auto-updates skills on session start.
+> **Superpowers** is a popular coding agent plugin known for disciplined TDD workflows and autonomous operation (29K+ GitHub stars). It now ships via the official Anthropic marketplace (`claude-plugins-official`), and supports Kimi Code CLI, OpenClaw, and Mistral Vibe. The plugin is a lightweight shim that auto-updates skills on session start; skills live in a dedicated repo (obra/superpowers-skills).
 >
-> *Comparison updated April 2026. See [Superpowers repo](https://github.com/obra/superpowers) for current features.*
+> *Comparison updated 2026-05-07. See [Superpowers repo](https://github.com/obra/superpowers) for current features.*
 
 ---
 
@@ -80,6 +81,8 @@ Built-in enforcement of software engineering best practices. No over-engineering
 ```
 
 **Superpowers resets every session.** Your agent debugs the same issues repeatedly with no memory of past solutions.
+
+**The mechanism is a wiki.** AgentOps's `.agents/` directory is markdown in your repo, version-controlled with your code, that agents read and contribute to. Wikis are a 25-year-old idea — that is the deflationary positioning. The novel part is not the format; it is making one for agents to traverse, and making the discipline of maintenance mechanical so it actually happens. Superpowers does not implement a corpus of this kind; learnings live in the session and end with it.
 
 ### No Failure Prevention
 

--- a/docs/comparisons/vs-tons-of-skills.md
+++ b/docs/comparisons/vs-tons-of-skills.md
@@ -1,0 +1,90 @@
+---
+title: "AgentOps vs Tons-of-Skills (jeremylongshore/claude-code-plugins-plus-skills)"
+description: "Volume marketplace vs. context library — different categories, different buyers."
+permalink: /comparisons/agentops-vs-tons-of-skills
+last_reviewed: 2026-05-07
+---
+
+# AgentOps vs. Tons-of-Skills
+
+> **Tons-of-Skills** ([jeremylongshore/claude-code-plugins-plus-skills](https://github.com/jeremylongshore/claude-code-plugins-plus-skills))
+> is a volume marketplace: **425 plugins, 2,810 skills, 200 agents**, a CCPI
+> package manager, and a 100-point validation grading rubric. It is a different
+> category from AgentOps. This page exists to clarify the comparison for buyers
+> shopping both.
+
+---
+
+## At a glance
+
+| Aspect | Tons-of-Skills | AgentOps |
+|---|---|---|
+| **Category** | Skills marketplace | Context library / wiki for agents |
+| **Inventory claim** | 2,810 skills, 425 plugins, 200 agents | 73 skills + your accumulated corpus |
+| **Buyer pitch** | "We have the most stuff" | "You build the moat" |
+| **Validation** | 100-point CCPI grading rubric | Multi-model councils + validation gates |
+| **Distribution** | CCPI package manager | Native marketplace per runtime + `curl \| bash` install |
+| **Persistence** | Per-skill, in-session | Cross-session via `.agents/` corpus |
+| **Open source** | Yes | Yes (forever) |
+
+The two products answer different questions. Tons-of-Skills answers *"what skills can I install?"* AgentOps answers *"how do I make my agents remember what we already learned?"*
+
+---
+
+## When to pick which
+
+- **Pick Tons-of-Skills** if you want a bulk-buy of pre-built skills covering many domains, with a package manager and a published grading rubric to filter by.
+- **Pick AgentOps** if you want to build a context library that compounds across sessions — a wiki for your agents, persisted in your repo, that grows with every run.
+- **They are not mutually exclusive.** Install both. Use Tons-of-Skills as a skill catalog for breadth; use AgentOps for the corpus discipline that turns one-off skill outputs into accumulated knowledge.
+
+This is the cleanest framing: a marketplace and a context library are complementary tools. The marketplace gets you skills on day one. The context library is what makes day 100 different from day 1.
+
+---
+
+## Where Tons-of-Skills wins
+
+**Inventory breadth.** 2,810 skills is the largest catalog in the Claude Code ecosystem. If your bottleneck is "I need a skill for X and don't want to write one," Tons-of-Skills has the highest probability of already having it. AgentOps ships 73 skills focused on the operational layer (research, plan, validate, harvest, council, etc.) — the inventories don't overlap heavily.
+
+**Validation grading rigor.** The 100-point CCPI grading rubric is a public scoring system applied per-skill. That is a real artifact: a published, comparable score across thousands of skills. AgentOps does not grade skills on a 100-point scale; its quality posture is multi-model council consensus and validation gates run *on the agent's output*, not on the skill definition itself. Different surface, different rigor.
+
+**Package management.** CCPI is a dedicated package manager for skills. AgentOps installs via the Claude Code, Codex, OpenClaw, and Cursor native marketplaces plus a `curl | bash` script — there is no AgentOps-specific package manager because AgentOps treats the runtime's marketplace as the distribution layer.
+
+---
+
+## Where AgentOps wins
+
+**Persistent corpus.** AgentOps's `.agents/` directory is a markdown wiki in your repo, version-controlled with your code. Learnings, decisions, citations, and validation verdicts are extracted and stored every session, then injected into future sessions via decay-ranked retrieval. Tons-of-Skills ships skills; the skill output ends with the session. AgentOps ships a bookkeeping schema that turns each session's output into durable corpus that the next session reads.
+
+**Multi-model councils.** `/council --mixed` runs Claude and Codex judges in parallel against one evidence packet, returning structured consensus before commit. This is a validation primitive, not a skill — it is the thing that catches "looks good to one model" before the bug ships. Tons-of-Skills's grading rubric scores skills before you install them; AgentOps's councils score *the work the agent just did* before it lands.
+
+**Model-independent phase routing.** Inside a single RPI loop, AgentOps runs Claude for research, Codex for implementation, fresh Claude for validation, with state preserved across the boundaries. Skills in any marketplace inherit the harness's model — they don't compose model choices per phase. This is a workflow-level capability, orthogonal to skill inventory.
+
+**Off-API daemon.** `ao schedule` and `ao daemon` run dream / evolve / compile / defrag / forge passes on your hardware against your subscription, off-vendor, overnight. The corpus compounds while you sleep. Tons-of-Skills is in-session by design; the off-API surface is not part of its category.
+
+---
+
+## Both are open source
+
+Both projects are open source and intended to stay that way. Tons-of-Skills is MIT-licensed on GitHub with sponsorship-funded development. AgentOps is open source forever — the corpus that compounds in *your* repo is yours, the schema is portable, and the discipline survives any single vendor's roadmap. If you are evaluating durability of either, the source code is the receipt.
+
+This matters more than it sounds. The structural risk in the agent ecosystem is "vendor ships Managed Agents and eats the plugin." Open-source skill inventories and open-source context libraries both survive that move; they live in your repo, not in someone's hosted product.
+
+---
+
+## Bottom line
+
+These are different categories, not competition.
+
+Tons-of-Skills is selling **inventory**: the largest catalog of pre-built skills in the ecosystem, with a package manager and a published grading rubric. If you measure by "skills installed per developer," it wins by construction.
+
+AgentOps is selling **corpus discipline**: the operational layer that turns each session's research, decisions, validations, and learnings into a markdown wiki your agents read on the next session. If you measure by "what the agent knows about this codebase that it didn't know last week," AgentOps is the substrate that makes that question answerable.
+
+A buyer shopping both should install both. Use Tons-of-Skills when the question is *"is there a skill for this?"* Use AgentOps when the question is *"how do we stop re-learning the same lessons every session?"*
+
+---
+
+<div align="center">
+
+[← Back to Comparisons](README.md)
+
+</div>

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -29,6 +29,11 @@
 
 Deep dives: [CDLC](cdlc.md) (tier-to-layer mapping), [Knowledge Flywheel](knowledge-flywheel.md), [Context Lifecycle](context-lifecycle.md), [Assurance Profile](assurance-profile.md), [PRODUCT.md](https://github.com/boshu2/agentops/blob/main/PRODUCT.md)
 
+Bridge / framing docs:
+
+- [A wiki for your agents](wiki-for-agents.md) — `.agents/` as a markdown wiki agents read, traverse, and contribute to (deflationary framing for the busy buyer)
+- [AgentOps as a Trust Factory](trust-factory.md) — Mapping AgentOps to the five-step trust-factory primitive (identity, reproducibility, evaluation, evidence, recovery)
+
 ## Architecture
 
 - [How It Works](how-it-works.md) — Brownian Ratchet, Ralph Wiggum Pattern, agent backends, hooks, context windowing
@@ -174,6 +179,8 @@ Deep dives: [CDLC](cdlc.md) (tier-to-layer mapping), [Knowledge Flywheel](knowle
 - [vs Superpowers](comparisons/vs-superpowers.md) — AgentOps vs Superpowers plugin
 - [vs Claude-Flow](comparisons/vs-claude-flow.md) — AgentOps vs Claude-Flow orchestration
 - [vs Compound Engineer](comparisons/vs-compound-engineer.md) — AgentOps vs Compound Engineering plugin
+- [vs Tons-of-Skills](comparisons/vs-tons-of-skills.md) — AgentOps vs `jeremylongshore/claude-code-plugins-plus-skills` (volume marketplace lane)
+- [vs everything-claude-code](comparisons/vs-everything-claude-code.md) — AgentOps vs `affaan-m/everything-claude-code` (cross-harness lane)
 - [Competitive Radar](comparisons/competitive-radar.md) — Current market read and improvement pressure
 
 ## Positioning

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,16 +8,14 @@ hide:
 
 # AgentOps { .landing-hero }
 
-<p class="hero-tagline">
-  Software factory for coding agents.<br>
-  Keep the books. Compile context. Gate output. Compound knowledge.<br>
-  <strong>AI-agent pace with serious-operator discipline.</strong>
-</p>
+### A wiki for your agents. Built so you own the moat.
 
-<p class="hero-subtagline">
-  <!-- agentops:claim:AOP-CLAIM-DOCS-INDEX-CORPUS -->
-  Every coding session reads from the corpus on the way in and writes back on the way out — typed, versioned, validated, decay-ranked. Vendor memory follows the chat. The corpus follows the team.
-</p>
+<!-- agentops:claim:AOP-CLAIM-DOCS-INDEX-CORPUS -->
+`.agents/` is just a wiki — markdown files in your repo, version-controlled with your code, that agents read, traverse, and contribute to. The kind of wiki your team should already have. AgentOps automates the discipline of building one.
+
+*The only verifiable moat in this uncertain time is context. Models will get smarter, harnesses will commoditize, agents will get cheaper. Your accumulated context — the lessons learned about your individual problems, the patterns that worked, the decisions that survived review — is the one asset that compounds and doesn't get eaten by the next vendor release. That's what your company actually is.*
+
+*AgentOps is the shovel. Start digging.*
 
 <p class="hero-actions" markdown>
 [:octicons-rocket-24: Install](#install){ .md-button .md-button--primary }

--- a/docs/positioning/devops-for-vibe-coding.md
+++ b/docs/positioning/devops-for-vibe-coding.md
@@ -1,18 +1,22 @@
 # DevOps for Vibe-Coding
 
-**Version:** 1.2.0
-**Date:** 2026-01-31
+**Version:** 1.3.0
+**Date:** 2026-05-07
 **Status:** Supporting bridge narrative, not the primary category page
+
+> **See also:** [A wiki for your agents](../wiki-for-agents.md) — the primary
+> category framing this doc supports. The DevOps argument below is the
+> historical lineage; the wiki framing is the current headline.
 
 ---
 
 ## Tagline
 
-**Primary:** The operational layer for coding agents.
+**Primary:** A wiki for your agents — built so you own the moat.
 
-**Secondary:** Bookkeeping, validation, primitives, and flows that compound between sessions.
+**Secondary (DevOps lineage):** Bookkeeping, validation, primitives, and flows that compound between sessions, drawn from 50 years of operational discipline.
 
-**Category:** Operational layer for coding agents
+**Category:** Context library / wiki for agents (DevOps lineage, not the category label)
 
 **Legacy (SEO/blog only):** DevOps for Vibe-Coding
 
@@ -20,10 +24,12 @@
 
 ## Elevator Pitch (30 seconds)
 
-> AgentOps is the operational layer for coding agents. DevOps is the lineage,
-> not the category. It gives coding agents bookkeeping, validation,
-> primitives, and flows so work starts with repo context instead of a blank
-> prompt, gets challenged before shipping, and compounds between sessions.
+> AgentOps is a wiki for your agents — markdown in `.agents/` next to your
+> code, version-controlled, that agents read, traverse, and contribute to.
+> DevOps is the lineage, not the category: AgentOps automates the discipline
+> of building and maintaining that wiki, so work starts with repo context
+> instead of a blank prompt, gets challenged before shipping, and compounds
+> between sessions.
 
 ### One-Liner (10 seconds)
 
@@ -209,11 +215,13 @@ Every session makes the next one better because the environment changes, not bec
 
 ### When Asked "What is 12-Factor AgentOps?"
 
-> Publicly, AgentOps is the operational layer for coding agents. It gives
-> coding agents bookkeeping, validation, primitives, and flows so every
-> session starts where the last one left off. Under the hood, DevOps and
-> 12-factor ideas explain why the lifecycle/control plane looks the way it
-> does.
+> Publicly, AgentOps is a wiki for your agents — repo-native markdown in
+> `.agents/` that agents read and contribute to, with the discipline of
+> maintenance automated. It gives coding agents bookkeeping, validation,
+> primitives, and flows so every session starts where the last one left
+> off. Under the hood, DevOps and 12-factor ideas explain why the
+> lifecycle/control plane looks the way it does — see also the
+> [wiki-for-agents](../wiki-for-agents.md) primary framing.
 
 ### When Asked "How is it different from X?"
 

--- a/docs/the-science.md
+++ b/docs/the-science.md
@@ -2,6 +2,13 @@
 
 > **TL;DR:** One model of knowledge decay (Darr 1995) suggests ~17%/week without reinforcement. Knowledge compounds when retrieval × usage beats decay and scale friction. Early growth can be exponential; long-run growth requires active limits-to-growth controls.
 
+> For the practitioner-facing distillation, see [Trust Factory](trust-factory.md). For the wiki framing of the same mechanism, see [A wiki for your agents](wiki-for-agents.md).
+
+## Companion docs
+
+- [Trust Factory](trust-factory.md) — the practitioner-facing distillation: how the science maps to identity, reproducibility, evaluation, evidence, and recovery.
+- [A wiki for your agents](wiki-for-agents.md) — the deflationary framing for the same mechanism (`.agents/` as a 25-year-old idea, mechanically maintained).
+
 ---
 
 ## The Journey

--- a/docs/trust-factory.md
+++ b/docs/trust-factory.md
@@ -1,0 +1,112 @@
+---
+title: "AgentOps as a Trust Factory"
+description: "How AgentOps maps to the five-step preparation engine: identity, reproducibility, evaluation, evidence, recovery."
+permalink: /trust-factory
+last_reviewed: 2026-05-07
+---
+
+# AgentOps as a Trust Factory
+
+> Generation is becoming cheap. Validation is becoming the moat. Software
+> engineering has spent 50 years building trust factories — the systems that
+> turn changed artifacts into trusted capability. AgentOps is that pattern
+> applied to the artifacts AI coding agents produce.
+
+A trust factory is the discipline that sits between *something changed* and
+*we believe it*. Compilers, build systems, code review, CI, staging, canaries,
+post-mortems — none of them generate value by themselves. They generate
+*permission to ship*. As coding agents commoditize generation, the part of the
+loop that earns permission is what compounds.
+
+## The five-step primitive
+
+Every artifact promotion needs five things, in order:
+
+1. **Identity** — what changed?
+2. **Reproducibility** — can we replay it?
+3. **Evaluation** — what did it pass?
+4. **Evidence** — where is the proof?
+5. **Recovery** — what if we were wrong?
+
+Drop any one of them and trust collapses. Identity without reproducibility is
+a name with no body. Evaluation without evidence is a claim no one can audit.
+Evidence without recovery is a museum. The five together are what turn a code
+change, a model weight, a config, or a mission plan into something an
+organization is willing to stand behind.
+
+## How AgentOps maps to the primitive
+
+| Trust factory step | AgentOps mechanism |
+|---|---|
+| Identity | `.agents/runs/<id>/` packets, citations, versioned context |
+| Reproducibility | RPI phase contracts + worktree isolation + captured packets |
+| Evaluation | `/pre-mortem`, `/vibe`, `/council`, `ao goals measure` |
+| Evidence | Council verdicts, citations, ratchet records, post-mortems |
+| Recovery | Ratchet rollback, learnings → planning rules → prevention |
+
+**Identity.** Every agent run gets a discovery packet under `.agents/runs/<id>/`
+that records what was being changed, which corpus entries were injected, and
+which sources were cited. The `ao inject` retrieval that loaded the working
+context is logged so a later reviewer can ask *what did the agent actually
+know when it acted?* without guessing.
+
+**Reproducibility.** The RPI workflow (Research → Plan → Implement → Validate)
+runs each phase against a written contract, and `ao crank` isolates parallel
+work in worktrees so the inputs to a phase can be replayed. The packet captured
+at planning time is the same packet a re-run consumes; deviations show up as
+diffs against a known input, not as drift.
+
+**Evaluation.** Plans are stress-tested with `/pre-mortem` before code is
+written, code is challenged with `/vibe` before it leaves the working tree, and
+high-stakes changes go through `/council` for multi-judge consensus. Strategic
+fitness is checked separately with `ao goals measure`, which asserts that the
+change actually moves the GOALS.md needles instead of merely passing tests.
+
+**Evidence.** Council verdicts, citation logs, ratchet records, and the
+findings written by `/post-mortem` are durable artifacts under `.agents/`. They
+stay diffable in git, so the proof of why a change was promoted lives next to
+the change itself, not in a SaaS tool that the next vendor can take away.
+
+**Recovery.** When a change turns out to have been wrong, the ratchet record
+is the rollback unit, and the failure is converted by `/post-mortem` and
+`/forge` into a learning, then into a planning rule that prevents the same
+class of mistake from being injected again. The loop is closed inside the
+corpus, not inside a chat transcript.
+
+## Why this primitive generalizes
+
+The same five steps apply to anything that gets promoted: model weights,
+mission plans, agent actions, infrastructure configs, training data. Identity,
+reproducibility, evaluation, evidence, and recovery are how regulated
+industries already think about change — they just call it configuration
+management, model risk management, or operational acceptance depending on the
+substrate.
+
+AgentOps is not the trust factory for all of those substrates. It is the first
+instance of the pattern *for the artifacts AI coding agents produce*: code
+diffs, learnings, planning rules, skill changes, corpus updates. The pattern
+travels; the implementation is scoped. As other artifact classes get their own
+agent-shaped pipelines, the same five-step primitive is what each will need.
+
+## When to use this framing vs. the wiki framing
+
+The [wiki framing](./wiki-for-agents.md) is the right opener for the busy
+engineer who responds to deflationary framing — "it's a wiki for your agents,
+version-controlled in your repo." It earns trust by under-claiming.
+
+The trust-factory framing is the right opener for engineering leads in
+regulated environments who already think in terms of identity, reproducibility,
+evaluation, evidence, and recovery. They recognize the vocabulary and skip the
+explanation tax. Lead with this framing for buyers who already know that
+"validation is the moat"; lead with the wiki framing for buyers who want to
+see the artifact before the philosophy.
+
+Both framings describe the same product. They optimize for different listeners.
+
+## See also
+
+- [README](../README.md) — product-level framing and dogfood receipts
+- [PRODUCT.md](../PRODUCT.md) — internal positioning and four-layer model
+- [docs/wiki-for-agents.md](./wiki-for-agents.md) — the wiki-framing companion
+- [docs/cdlc.md](./cdlc.md) — the Context Development Lifecycle in full
+- [docs/the-science.md](./the-science.md) — knowledge-decay and compounding model

--- a/docs/trust-factory.md
+++ b/docs/trust-factory.md
@@ -105,8 +105,8 @@ Both framings describe the same product. They optimize for different listeners.
 
 ## See also
 
-- [README](../README.md) — product-level framing and dogfood receipts
-- [PRODUCT.md](../PRODUCT.md) — internal positioning and four-layer model
+- [README](https://github.com/boshu2/agentops/blob/main/README.md) — product-level framing and dogfood receipts
+- [PRODUCT.md](https://github.com/boshu2/agentops/blob/main/PRODUCT.md) — internal positioning and four-layer model
 - [docs/wiki-for-agents.md](./wiki-for-agents.md) — the wiki-framing companion
 - [docs/cdlc.md](./cdlc.md) — the Context Development Lifecycle in full
 - [docs/the-science.md](./the-science.md) — knowledge-decay and compounding model

--- a/docs/wiki-for-agents.md
+++ b/docs/wiki-for-agents.md
@@ -90,4 +90,4 @@ The wiki is yours. Open source forever. Built so you own the asset, not the tool
 
 `.agents/` is plain markdown in your repo. If a frontier vendor ships native equivalents next year, the corpus carries forward. If AgentOps changes direction, your corpus is yours. If you outgrow this tool entirely, fork it, customize it, replace it — the corpus is what matters.
 
-For the deeper view of how the same mechanism doubles as a trust factory — identity, reproducibility, evaluation, evidence, recovery — see [trust-factory.md](./trust-factory.md). For the full README, see [../README.md](../README.md).
+For the deeper view of how the same mechanism doubles as a trust factory — identity, reproducibility, evaluation, evidence, recovery — see [trust-factory.md](./trust-factory.md). For the full README, see [the project README on GitHub](https://github.com/boshu2/agentops/blob/main/README.md).

--- a/docs/wiki-for-agents.md
+++ b/docs/wiki-for-agents.md
@@ -1,0 +1,93 @@
+---
+title: "A wiki for your agents"
+description: ".agents/ is just markdown in your repo, version-controlled with your code, that agents read and contribute to."
+permalink: /wiki-for-agents
+last_reviewed: 2026-05-07
+---
+
+# A wiki for your agents
+
+> Wikis aren't new. They've been around for 25 years. The novel part is building one for agents to read, traverse, and contribute to — and making the discipline of maintenance mechanical so it actually happens.
+
+Every engineer has used a wiki. MediaWiki, Confluence, Notion, a `docs/` directory that grew teeth. AgentOps is that shape, with two changes: the readers are agents, and the writers are agents too.
+
+## What `.agents/` actually is
+
+Run `ls .agents/` in an initialized repo. Plain directories of plain markdown:
+
+```
+.agents/
+├── council/         # multi-judge verdicts on plans, PRs, releases
+├── decisions/       # what was chosen, what was rejected, why
+├── findings/        # surprises and gotchas surfaced by sessions
+├── learnings/       # promoted lessons that survived review
+├── patterns/        # recurring shapes worth reusing
+├── planning-rules/  # constraints that fire during planning
+└── runs/            # per-session packets with citations and evidence
+```
+
+`tree .agents/ -L 1` shows the rest. Every leaf is a markdown file. The whole tree is committed alongside your code: version-controlled, diffable, branchable, mergeable. Nothing about it is exotic. That is the point.
+
+## Why most wikis fail
+
+Writing the wiki is a tax humans pay grudgingly, after the work is already done. The tax falls hardest on the contributors who learned the most — the ones whose attention is most valuable elsewhere.
+
+So the wiki bitrots. Pages drift behind the code. The "current architecture" page describes a system that was rewritten last quarter. New hires read it once, find it lying, and stop trusting it.
+
+By week four it is a read-only artifact. Search breaks because no one tags. The team falls back to Slack scrollback and the one engineer who remembers everything.
+
+AgentOps inverts this. Sessions write to the wiki by default — runs land citations, councils land verdicts, post-mortems land learnings, the daemon defrags overnight. The agents that consume `.agents/` also produce it. Maintenance is mechanical, not voluntary. The wiki maintains itself because it sits on the path of everything else.
+
+## Why not Notion or Confluence?
+
+| Notion / Confluence | AgentOps `.agents/` |
+|---|---|
+| Written for humans; agents can't traverse it efficiently | LLM Wiki of Markdown — agents read it natively |
+| Lives in SaaS, not your repo | Lives in `.agents/` next to the code |
+| Not version-controlled with your code | Diffable, branchable, mergeable |
+| No decay ranking, no retrieval scoring | `ao inject` returns decay-ranked, token-budgeted packets |
+| No validation gates, no automated capture | Sessions write to it automatically; councils validate it |
+| Doesn't compound; you maintain it manually | Daemon defrags, evolves, and compounds it overnight |
+| Read-only artifact | Writes itself: agents that use it also produce it |
+
+**Native agent traversal.** Markdown is the format models read best; a SaaS page has to be exported and re-embedded before an agent can use it.
+
+**Locality.** "What changed in this PR" includes the wiki delta. Reviewers see context move with the code instead of switching tabs.
+
+**Version control.** Diffs, branches, and merges are how engineers already think about change. A wiki you can `git revert` is a wiki you can trust.
+
+**Decay-ranked retrieval.** `ao inject --query "..."` returns a token-budgeted packet weighted by recency, citations, and validation history — different from full-text search.
+
+**Automated capture.** Sessions write run packets, citations, and verdicts without anyone being asked. The discipline lives in the tooling.
+
+**Overnight compounding.** The `ao daemon` runs defrag, evolve, compile, and dream against the corpus while you sleep. A SaaS wiki cannot get smarter on its own.
+
+**Self-writing.** Every consumer of the wiki is also a producer of it. That is the inversion that makes the whole thing tractable.
+
+## How to start
+
+Install for your runtime:
+
+```bash
+# Claude Code
+claude plugin install agentops@agentops-marketplace
+
+# Codex CLI
+curl -fsSL https://raw.githubusercontent.com/boshu2/agentops/main/scripts/install-codex.sh | bash
+```
+
+Then, inside any repo:
+
+```bash
+ao quick-start          # seed .agents/, GOALS.md, AgentOps instructions
+```
+
+That is the entry point. After that, work with your agents normally — `/rpi`, `/council`, `/research`, `/vibe`. `.agents/` accumulates without explicit attention. `ao inject --query "..."` returns a decay-ranked, token-budgeted packet whenever you ask.
+
+## What you own at the end
+
+The wiki is yours. Open source forever. Built so you own the asset, not the tool.
+
+`.agents/` is plain markdown in your repo. If a frontier vendor ships native equivalents next year, the corpus carries forward. If AgentOps changes direction, your corpus is yours. If you outgrow this tool entirely, fork it, customize it, replace it — the corpus is what matters.
+
+For the deeper view of how the same mechanism doubles as a trust factory — identity, reproducibility, evaluation, evidence, recovery — see [trust-factory.md](./trust-factory.md). For the full README, see [../README.md](../README.md).


### PR DESCRIPTION
## Summary

Lock single positioning thesis (**wiki for your agents** + **corpus moat**) across all surface docs. Adds 2 new bridge documents (`docs/trust-factory.md`, `docs/wiki-for-agents.md`) and 2 new comparison docs (`vs-tons-of-skills`, `vs-everything-claude-code`). Aligns README, PRODUCT, GOALS, docs/index, agentops-brief, 3 existing comparison docs, and 3 light-touch body docs.

Source artifacts:
- Discovery packet: `.agents/discovery/2026-05-07-positioning-doc-sweep.md`
- Council research: `.agents/council/2026-05-07-research-readme-positioning.md`
- Brainstorm: `.agents/brainstorm/2026-05-07-trust-infrastructure-shovels-thesis.md`

The 10 locked decisions (D1–D10) — headline, opening paragraph, the moat statement, the "not a coding harness" non-positioning move, the receipts block, the enterprise-pattern statement, the "What if the labs ship this natively?" section, the Notion comparison table, the SE→Context translation table, and the 300-line README target — are all placed.

## What changed

**README.md (Wave 1):** 420 → 295 lines. New hero (D1+D2+D3+D4+D5), Notion comparison table (D8, 7 rows), SE→Context translation table (D9, 11 rows), enterprise-pattern statement (D6), "What if the labs ship this natively?" section (D7). Drops: intra-page nav bar, Validate/Nightly badges, Competitive Positioning section, 12-Factor Doctrine 4-tier table, mermaid diagram.

**Strategic docs (Wave 2):** PRODUCT.md, GOALS.md, docs/index.md, docs/agentops-brief.md aligned to wiki framing. PRODUCT gains D7 + receipts timestamp + corpus-durability tracking ref to soc-rv5p. GOALS gains a new North Star ("the wiki maintains itself") and a new directive #11 (corpus durability).

**Comparison surface (Wave 3):** competitive-radar refreshed with 7-competitor lane table + 6 differentiators + 5-lane segmentation. vs-compound-engineer updated to current state (37 skills, 51 agents, 7-phase, 10-target). vs-superpowers updated (Anthropic marketplace, 29K+ stars, wiki mechanism). NEW vs-tons-of-skills (volume-marketplace lane). NEW vs-everything-claude-code (cross-harness lane, with credibility-move flag on the unverified 140K+ stars / 21K+ forks claim from their README).

**Bridge docs (Wave 4):** NEW docs/trust-factory.md (5-step trust factory primitive — Identity → Reproducibility → Evaluation → Evidence → Recovery — for engineering-leads framing). NEW docs/wiki-for-agents.md (deflationary wiki framing for the busy buyer). documentation-index updated with all 4 new docs.

**Body doc light touch (Wave 5):** docs/cdlc.md leads with SE→Context concept, defers CDLC acronym to body. docs/the-science.md gains practitioner-facing pointer to trust-factory. docs/positioning/devops-for-vibe-coding.md taglines aligned, DevOps argument preserved.

**Validation (Wave 6):** Fixed 5 mkdocs --strict link warnings by switching `../README.md`/`../PRODUCT.md` cross-links in new bridge docs to absolute github.com URLs (matches existing convention).

## Validation results

- `scripts/docs-build.sh --check` (mkdocs --strict): **PASS**
- `scripts/check-competitive-freshness.sh`: **PASS** (all 8 docs ≤ 45 days)
- `scripts/corpus-stats.sh --table`: runs clean
- `wc -l README.md`: **295** (≤ 300 target)
- D1–D10 visible across 6 target docs
- Cross-link triad present: README→{wiki-for-agents, trust-factory}, PRODUCT→{trust-factory, wiki-for-agents}

## Test plan

- [ ] `scripts/docs-build.sh --check` passes locally and in CI
- [ ] `scripts/check-competitive-freshness.sh` passes (45-day window)
- [ ] mkdocs renders the new hero centered correctly (verify GitHub social card preview after merge)
- [ ] Internal links resolve (mkdocs strict catches; manual spot-check on the 4 new doc cross-links)

## Beads epic

- Epic: `soc-9xn0` (CLOSED)
- 16 sub-issues across 6 waves (all CLOSED)
- 1 follow-up bug filed: `soc-rv5p` (corpus-durability fix; out of scope for this docs sweep)

## Out of scope (intentional non-goals)

- 12factoragentops.com site (separate repo)
- Skill SKILL.md sweep
- CLI help text (generated)
- Founder essay (separate channel)
- Corpus durability fix (filed as soc-rv5p bug)