### PR TITLE
fix(hooks): reconcile stale .agents/.gitignore deny-all (soc-rv5p)

### DIFF
--- a/cli/embedded/hooks/session-start.sh
+++ b/cli/embedded/hooks/session-start.sh
@@ -100,16 +100,22 @@ if [ -d "$ROOT/.git" ]; then
         printf '# AgentOps session artifacts\n/.agents/\n' > "$GITIGNORE" 2>/dev/null
     fi
 fi
-# Only install the deny-all child .gitignore when the repo's root
-# .gitignore lacks an allowlist for /.agents/ paths. AgentOps itself
-# force-tracks audit-truth artifacts (.agents/findings/registry.jsonl,
-# .agents/nightly/<date>/baseline-goals.json, etc.) via `!/.agents/...`
-# re-includes; a blanket `*` deny-all child would override every
-# parent re-include because gitignore's last-match-wins rule applies
-# to the deeper file. External repos without an allowlist still get
-# the safety belt.
-if [ ! -f "$ROOT/.agents/.gitignore" ] && \
-   ! grep -qE '^!/?\.agents/' "$ROOT/.gitignore" 2>/dev/null; then
+# Reconcile the deny-all child .gitignore with the root .gitignore allowlist.
+# AgentOps itself force-tracks audit-truth artifacts (.agents/findings/registry.jsonl,
+# .agents/nightly/<date>/baseline-goals.json, etc.) via `!/.agents/...` re-includes;
+# a blanket `*` deny-all child would override every parent re-include because
+# gitignore's last-match-wins rule applies to the deeper file.
+#
+# - Root has `!/.agents/` allowlist → REMOVE any deny-all child that would
+#   sabotage the allowlist (audit truth wins; this catches stale child files
+#   from older hook versions or external tooling).
+# - Root has no allowlist → INSTALL the deny-all child (external repos that
+#   embed AgentOps still get the safety belt against runtime-state leaks).
+if grep -qE '^!/?\.agents/' "$ROOT/.gitignore" 2>/dev/null; then
+    if [ -f "$ROOT/.agents/.gitignore" ] && grep -qxE '\*' "$ROOT/.agents/.gitignore" 2>/dev/null; then
+        rm -f "$ROOT/.agents/.gitignore" 2>/dev/null
+    fi
+elif [ ! -f "$ROOT/.agents/.gitignore" ]; then
     cat > "$ROOT/.agents/.gitignore" 2>/dev/null <<'EOF'
 # Deny all by default — session artifacts must not leak to git.
 *

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -100,16 +100,22 @@ if [ -d "$ROOT/.git" ]; then
         printf '# AgentOps session artifacts\n/.agents/\n' > "$GITIGNORE" 2>/dev/null
     fi
 fi
-# Only install the deny-all child .gitignore when the repo's root
-# .gitignore lacks an allowlist for /.agents/ paths. AgentOps itself
-# force-tracks audit-truth artifacts (.agents/findings/registry.jsonl,
-# .agents/nightly/<date>/baseline-goals.json, etc.) via `!/.agents/...`
-# re-includes; a blanket `*` deny-all child would override every
-# parent re-include because gitignore's last-match-wins rule applies
-# to the deeper file. External repos without an allowlist still get
-# the safety belt.
-if [ ! -f "$ROOT/.agents/.gitignore" ] && \
-   ! grep -qE '^!/?\.agents/' "$ROOT/.gitignore" 2>/dev/null; then
+# Reconcile the deny-all child .gitignore with the root .gitignore allowlist.
+# AgentOps itself force-tracks audit-truth artifacts (.agents/findings/registry.jsonl,
+# .agents/nightly/<date>/baseline-goals.json, etc.) via `!/.agents/...` re-includes;
+# a blanket `*` deny-all child would override every parent re-include because
+# gitignore's last-match-wins rule applies to the deeper file.
+#
+# - Root has `!/.agents/` allowlist → REMOVE any deny-all child that would
+#   sabotage the allowlist (audit truth wins; this catches stale child files
+#   from older hook versions or external tooling).
+# - Root has no allowlist → INSTALL the deny-all child (external repos that
+#   embed AgentOps still get the safety belt against runtime-state leaks).
+if grep -qE '^!/?\.agents/' "$ROOT/.gitignore" 2>/dev/null; then
+    if [ -f "$ROOT/.agents/.gitignore" ] && grep -qxE '\*' "$ROOT/.agents/.gitignore" 2>/dev/null; then
+        rm -f "$ROOT/.agents/.gitignore" 2>/dev/null
+    fi
+elif [ ! -f "$ROOT/.agents/.gitignore" ]; then
     cat > "$ROOT/.agents/.gitignore" 2>/dev/null <<'EOF'
 # Deny all by default — session artifacts must not leak to git.
 *

--- a/tests/hooks/test-hooks.bats
+++ b/tests/hooks/test-hooks.bats
@@ -74,6 +74,57 @@ GIT
     [ ! -f "$mock/.agents/.gitignore" ]
 }
 
+@test "session-start: removes stale deny-all child when parent has allowlist" {
+    # soc-rv5p: a stale `.agents/.gitignore` deny-all child (left from an
+    # older hook version, an external tool, or a pre-fix session) silently
+    # overrides every parent `!/.agents/...` re-include via gitignore's
+    # last-match-wins precedence. Each new session must reconcile by
+    # REMOVING the deny-all child whenever the parent has an allowlist —
+    # otherwise force-tracked audit artifacts (.agents/nightly/<date>/...,
+    # .agents/findings/registry.jsonl, etc.) drop off git invisibly.
+    local mock="$TMP_TEST_DIR/mock-stale-deny-all"
+    mkdir -p "$mock/.agents"
+    git -C "$mock" init -q >/dev/null 2>&1
+    cat > "$mock/.gitignore" <<'GIT'
+/.agents/*
+/.agents/**/*
+!/.agents/findings/
+!/.agents/findings/registry.jsonl
+GIT
+    cat > "$mock/.agents/.gitignore" <<'GIT'
+# Deny all by default — session artifacts must not leak to git.
+*
+
+# Allow only this file for local deny-by-default semantics.
+!.gitignore
+GIT
+    (cd "$mock" && bash "$HOOKS_DIR/session-start.sh" >/dev/null 2>&1 || true)
+    [ ! -f "$mock/.agents/.gitignore" ]
+    # Verify the parent allowlist now governs (force-tracked path tracks).
+    (cd "$mock" && git check-ignore -v .agents/findings/registry.jsonl 2>&1 | grep -q '!/.agents/findings/registry.jsonl' )
+}
+
+@test "session-start: preserves non-deny-all child gitignore" {
+    # Reconciliation must only target the deny-all `*` pattern. A user-
+    # authored child .gitignore with project-specific rules must survive
+    # untouched.
+    local mock="$TMP_TEST_DIR/mock-custom-child"
+    mkdir -p "$mock/.agents"
+    git -C "$mock" init -q >/dev/null 2>&1
+    cat > "$mock/.gitignore" <<'GIT'
+/.agents/*
+!/.agents/findings/
+GIT
+    cat > "$mock/.agents/.gitignore" <<'GIT'
+# Project-specific ignore rules (not deny-all)
+*.tmp
+scratch/
+GIT
+    (cd "$mock" && bash "$HOOKS_DIR/session-start.sh" >/dev/null 2>&1 || true)
+    [ -f "$mock/.agents/.gitignore" ]
+    grep -qx '*.tmp' "$mock/.agents/.gitignore"
+}
+
 @test "session-start: external repo without allowlist still gets deny-all child" {
     # Inverse lock for the allowlist-aware guard above: repos that DON'T
     # force-track anything under .agents/ should still receive the


### PR DESCRIPTION
## Summary

Fixes the corpus-durability bug filed as `soc-rv5p` (the pre-flight finding from PR #262's positioning doc sweep).

The session-start hook's deny-all `.agents/.gitignore` child file was silently overriding the root `.gitignore`'s `!/.agents/...` force-tracked allowlist. Force-tracked audit-truth artifacts (`.agents/nightly/<date>/baseline-goals.json`, `.agents/findings/registry.jsonl`, `.agents/rpi/next-work.jsonl`, `.agents/evolve/cycle-history.jsonl`) were dropping off git invisibly between sessions because gitignore's last-match-wins rule applied to the deeper child file.

The prior hook only gated CREATION of the child file. Once a stale deny-all child existed (from an older hook version, external tooling, or a pre-fix session), nothing would remove it.

## What changed

- `hooks/session-start.sh` (and embedded copy): switch from one-shot guard to reconciler. When the parent `.gitignore` has a `!/.agents/` allowlist, REMOVE any existing deny-all child. Otherwise (external repos), keep installing the safety belt.
- `tests/hooks/test-hooks.bats`: 2 new regression tests
  - "removes stale deny-all child when parent has allowlist" — locks the reconciler
  - "preserves non-deny-all child gitignore" — locks reconciler scope (only `*` pattern is targeted)

All 86 hook bats tests pass; 226 hook shell tests still pass.

## Verification

```
$ rm .agents/.gitignore && bash hooks/session-start.sh
$ git check-ignore -v .agents/nightly/foo.txt
.gitignore:140:!/.agents/nightly/**    .agents/nightly/foo.txt
```

The parent allowlist now governs as intended.

## Beads

Closes `soc-rv5p` (filed as the pre-flight finding from the positioning doc sweep — the dogfood receipts claim becomes durable now).

## Test plan

- [x] `bats tests/hooks/test-hooks.bats` — 86/86 pass
- [x] `bash tests/hooks/test-hooks.sh` — 226/226 pass
- [x] `cd cli && make sync-hooks` — embedded copy in sync
- [ ] CI validate workflow passes