### PR TITLE
fix: daily bug scan citation and embedded hook regressions

### DIFF
--- a/cli/cmd/ao/citation_port_adapter.go
+++ b/cli/cmd/ao/citation_port_adapter.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/boshu2/agentops/cli/internal/ports"
 )
@@ -35,6 +36,12 @@ func newProductionCitationAdapter() *productionCitationAdapter {
 func (a *productionCitationAdapter) Verify(ctx context.Context, req ports.CitationRequest) (ports.CitationVerdict, error) {
 	if err := ctx.Err(); err != nil {
 		return ports.CitationVerdict{}, err
+	}
+	if strings.TrimSpace(req.Raw) == "" {
+		return ports.CitationVerdict{
+			Status: ports.CitationStatusUnknown,
+			Reason: "empty Raw",
+		}, nil
 	}
 	c := Citation{Kind: string(req.Kind), Raw: req.Raw}
 	switch req.Kind {

--- a/cli/cmd/ao/citation_port_adapter_test.go
+++ b/cli/cmd/ao/citation_port_adapter_test.go
@@ -107,6 +107,29 @@ func TestProductionCitationAdapter_UnknownKindReturnsUnknown(t *testing.T) {
 	}
 }
 
+func TestProductionCitationAdapter_EmptyRawReturnsUnknown(t *testing.T) {
+	a := newProductionCitationAdapter()
+	cases := []ports.CitationRequest{
+		{Kind: ports.CitationKindFile, Raw: "", Cwd: t.TempDir()},
+		{Kind: ports.CitationKindFunction, Raw: "  ", Cwd: t.TempDir()},
+		{Kind: ports.CitationKindSymbol, Raw: "\t\n", Cwd: t.TempDir()},
+	}
+	for _, req := range cases {
+		t.Run(string(req.Kind), func(t *testing.T) {
+			v, err := a.Verify(context.Background(), req)
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if v.Status != ports.CitationStatusUnknown {
+				t.Fatalf("Status = %q, want UNKNOWN for empty Raw (reason: %s)", v.Status, v.Reason)
+			}
+			if v.Reason == "" {
+				t.Fatal("Reason must be non-empty per port contract")
+			}
+		})
+	}
+}
+
 func TestProductionCitationAdapter_HonorsContextCancellation(t *testing.T) {
 	a := newProductionCitationAdapter()
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary
- return UNKNOWN for empty CitationPort raw input before dispatching to legacy helpers
- add regression coverage for productionCitationAdapter empty Raw across file/function/symbol kinds
- sync embedded session-start hook after the Codex hooks feature-flag migration

## Evidence
- 3791568f introduced the CitationPort empty Raw contract
- 4e91ab58 added productionCitationAdapter without the empty Raw guard
- 3fb9963f failed Validate run 25767576085 on embedded-sync because cli/embedded/hooks/session-start.sh was stale

## Validation
- cd cli && go test ./cmd/ao -run 'TestProductionCitationAdapter' -count=1\n- cd cli && go test ./internal/ports -run 'TestInMemoryCitation' -count=1\n- scripts/validate-embedded-sync.sh\n- bash tests/hooks/test-hooks.sh\n- bash tests/scripts/test-codex-plugin-install.sh\n- git diff --check\n- scripts/pre-push-gate.sh --fast\n\nNote: codex-automation label was requested by automation policy but is not available in this repo; applied codex label.