### PR TITLE
fix(ci): make install smoke timeout portable

### DIFF
--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -79,7 +79,13 @@ jobs:
       - name: Verify install-smoke (fast structural check still green)
         run: |
           chmod +x tests/install/test-install-smoke.sh
-          timeout 60 bash tests/install/test-install-smoke.sh
+          if command -v timeout >/dev/null 2>&1; then
+            timeout 60 bash tests/install/test-install-smoke.sh
+          elif command -v gtimeout >/dev/null 2>&1; then
+            gtimeout 60 bash tests/install/test-install-smoke.sh
+          else
+            bash tests/install/test-install-smoke.sh
+          fi
 
   macos-install:
     runs-on: macos-latest
@@ -132,4 +138,10 @@ jobs:
       - name: Verify install-smoke (fast structural check still green)
         run: |
           chmod +x tests/install/test-install-smoke.sh
-          timeout 60 bash tests/install/test-install-smoke.sh
+          if command -v timeout >/dev/null 2>&1; then
+            timeout 60 bash tests/install/test-install-smoke.sh
+          elif command -v gtimeout >/dev/null 2>&1; then
+            gtimeout 60 bash tests/install/test-install-smoke.sh
+          else
+            bash tests/install/test-install-smoke.sh
+          fi

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -79,13 +79,18 @@ jobs:
       - name: Verify install-smoke (fast structural check still green)
         run: |
           chmod +x tests/install/test-install-smoke.sh
-          if command -v timeout >/dev/null 2>&1; then
-            timeout 60 bash tests/install/test-install-smoke.sh
-          elif command -v gtimeout >/dev/null 2>&1; then
-            gtimeout 60 bash tests/install/test-install-smoke.sh
-          else
-            bash tests/install/test-install-smoke.sh
-          fi
+          run_with_timeout() {
+            seconds="$1"
+            shift
+            if command -v timeout >/dev/null 2>&1; then
+              timeout "$seconds" "$@"
+            elif command -v gtimeout >/dev/null 2>&1; then
+              gtimeout "$seconds" "$@"
+            else
+              perl -e 'alarm shift @ARGV; exec @ARGV or die "exec failed: $!\n"' "$seconds" "$@"
+            fi
+          }
+          run_with_timeout 60 bash tests/install/test-install-smoke.sh
 
   macos-install:
     runs-on: macos-latest
@@ -138,10 +143,15 @@ jobs:
       - name: Verify install-smoke (fast structural check still green)
         run: |
           chmod +x tests/install/test-install-smoke.sh
-          if command -v timeout >/dev/null 2>&1; then
-            timeout 60 bash tests/install/test-install-smoke.sh
-          elif command -v gtimeout >/dev/null 2>&1; then
-            gtimeout 60 bash tests/install/test-install-smoke.sh
-          else
-            bash tests/install/test-install-smoke.sh
-          fi
+          run_with_timeout() {
+            seconds="$1"
+            shift
+            if command -v timeout >/dev/null 2>&1; then
+              timeout "$seconds" "$@"
+            elif command -v gtimeout >/dev/null 2>&1; then
+              gtimeout "$seconds" "$@"
+            else
+              perl -e 'alarm shift @ARGV; exec @ARGV or die "exec failed: $!\n"' "$seconds" "$@"
+            fi
+          }
+          run_with_timeout 60 bash tests/install/test-install-smoke.sh


### PR DESCRIPTION
## Summary
- Make install-e2e smoke invocation portable across Ubuntu/macOS by falling back from `timeout` to `gtimeout` or the job-level timeout.

## Evidence
- install-e2e run 25857490452 failed on `baecb57f` in `macos-install` with `timeout: command not found`.
- Main later absorbed the registry, operator write-surface, and CLI canary count fixes in `5428adbc`; this PR is now rebased to only keep the install-e2e portability fix.

## Validation
- `bash tests/install/test-install-smoke.sh`
- Simulated no-GNU-timeout fallback with `PATH=/bin:/usr/bin ...`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/install-e2e.yml")'`\n- `bash scripts/generate-registry.sh --check`\n- `scripts/pre-push-gate.sh --fast`\n- `scripts/test-agentops-contract-canaries.sh` on the clean pre-rebase amended tree; the rebased branch keeps only the install-e2e workflow diff