### PR TITLE
docs(inject): note /inject is read-only in SKILL.md summary

### DIFF
--- a/skills/inject/SKILL.md
+++ b/skills/inject/SKILL.md
@@ -30,6 +30,8 @@ output_contract: 'stdout: injected knowledge summary'
 
 **On-demand knowledge retrieval. Not run automatically at startup (since ag-8km).**
 
+It is read-only: it only reads knowledge for injection and never writes to `.agents/`.
+
 Inject relevant prior knowledge into the current session.
 
 ## How It Works


### PR DESCRIPTION
## What

Adds one clarifying sentence to the top-of-file summary of `skills/inject/SKILL.md`:

> It is read-only: it only reads knowledge for injection and never writes to `.agents/`.

## Why

`skills/inject/SKILL.md` never stated that `/inject` only reads — the one prior
"read-only" mention referred to the legacy-patterns surface, not `/inject`
itself. This closes that gap in the top-of-file summary.

## Context

This was the fixed trivial goal for the **soc-etwf.6 RPI token-measurement run**
(bead `soc-0ce2`). The measurement exercised the full discovery → crank →
validation loop on the post-#275 path; results are recorded in
`.agents/research/2026-05-15-rpi-slice-token-measurement.md` (gitignored).

## Scope

Path-scoped: `skills/inject/SKILL.md` only (+2 lines). Unrelated working-tree
changes were deliberately excluded from the commit.

Follow-up (not in this PR): Codex parity copy `skills-codex/inject/SKILL.md`
does not carry the sentence — sync via `audit-codex-parity.sh --skill inject`
if desired.