### PR TITLE
fix(doctor): repair CI regressions from PR #281

### DIFF
--- a/cli/internal/doctor/lock.go
+++ b/cli/internal/doctor/lock.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
 )
 
 // ErrLockHeld is the sentinel error returned when an advisory lock is already
@@ -35,7 +34,7 @@ func (g *Guard) Release() error {
 	if g.mgr != nil {
 		g.mgr.forget(g.path)
 	}
-	_ = syscall.Flock(int(g.file.Fd()), syscall.LOCK_UN)
+	_ = unlockFile(g.file)
 	return g.file.Close()
 }
 
@@ -85,7 +84,7 @@ func (lm *LockManager) Acquire(path string) (*Guard, error) {
 	if err != nil {
 		return nil, fmt.Errorf("doctor: open lockfile: %w", err)
 	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+	if err := tryLockExclusive(f); err != nil {
 		_ = f.Close()
 		return nil, ErrLockHeld
 	}

--- a/cli/internal/doctor/lock_unix.go
+++ b/cli/internal/doctor/lock_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package doctor
+
+import (
+	"os"
+	"syscall"
+)
+
+// tryLockExclusive takes a non-blocking exclusive advisory lock on f. A non-nil
+// error — including EWOULDBLOCK when another process holds the lock — tells the
+// caller to map the result to ErrLockHeld.
+func tryLockExclusive(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+}
+
+// unlockFile drops the advisory lock held on f.
+func unlockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/cli/internal/doctor/lock_windows.go
+++ b/cli/internal/doctor/lock_windows.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package doctor
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// Windows advisory-lock primitives. Mirrors the filelock_windows.go shape used
+// by internal/storage, but uses LOCKFILE_FAIL_IMMEDIATELY for a non-blocking
+// acquire so the doctor can map a held lock to ErrLockHeld (exit 5).
+var (
+	modkernel32      = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx   = modkernel32.NewProc("LockFileEx")
+	procUnlockFileEx = modkernel32.NewProc("UnlockFileEx")
+)
+
+const (
+	lockfileFailImmediately = uintptr(0x00000001)
+	lockfileExclusiveLock   = uintptr(0x00000002)
+)
+
+// tryLockExclusive takes a non-blocking exclusive lock on f. A non-nil error
+// (e.g. ERROR_LOCK_VIOLATION when another process holds it, or any other
+// failure) tells the caller to map the result to ErrLockHeld.
+func tryLockExclusive(f *os.File) error {
+	var ol syscall.Overlapped
+	r, _, err := procLockFileEx.Call(
+		f.Fd(),
+		lockfileExclusiveLock|lockfileFailImmediately,
+		0, 1, 0,
+		uintptr(unsafe.Pointer(&ol)),
+	)
+	if r != 0 {
+		return nil
+	}
+	return err
+}
+
+// unlockFile drops the advisory lock held on f.
+func unlockFile(f *os.File) error {
+	var ol syscall.Overlapped
+	r, _, err := procUnlockFileEx.Call(
+		f.Fd(),
+		0, 1, 0,
+		uintptr(unsafe.Pointer(&ol)),
+	)
+	if r != 0 {
+		return nil
+	}
+	return err
+}

--- a/tests/integration/test-v218-commands.sh
+++ b/tests/integration/test-v218-commands.sh
@@ -414,19 +414,19 @@ echo "=== --json Flag Matrix ==="
 echo ""
 # ============================================================
 
-# doctor --json
+# doctor --json — a single engine Report (schema_version, findings, exit_code)
 echo "--- doctor --json ---"
-OUTPUT=$("$TMPBIN" doctor --json 2>&1) || true
-if echo "$OUTPUT" | jq -e '.checks' >/dev/null 2>&1; then
-    pass "doctor --json returns checks array"
+OUTPUT=$("$TMPBIN" doctor --json 2>/dev/null) || true
+if echo "$OUTPUT" | jq -e 'has("schema_version") and has("findings") and has("exit_code")' >/dev/null 2>&1; then
+    pass "doctor --json returns an engine Report"
 else
-    fail "doctor --json returns checks array"
+    fail "doctor --json returns an engine Report"
 fi
 
-if echo "$OUTPUT" | jq -e '.checks[] | select(.status)' >/dev/null 2>&1; then
-    pass "doctor --json checks have status field"
+if echo "$OUTPUT" | jq -e '.findings | type == "array"' >/dev/null 2>&1; then
+    pass "doctor --json findings is an array"
 else
-    fail "doctor --json checks have status field"
+    fail "doctor --json findings is an array"
 fi
 
 # search --json empty case


### PR DESCRIPTION
## Summary
PR #281 (`ao doctor` engine) merged via `--admin`, bypassing CI; `validate.yml` then caught two regressions. This fixes both.

- **`windows-smoke`** — `internal/doctor/lock.go` used Unix-only `syscall.Flock`, breaking `go build` on Windows. Split into `lock_unix.go` / `lock_windows.go` behind `tryLockExclusive()`/`unlockFile()`, mirroring the `filelock_{unix,windows}.go` shape in `internal/storage`. `GOOS=windows go build ./...` now succeeds.
- **`cli-integration`** — `tests/integration/test-v218-commands.sh` still asserted the legacy `ao doctor --json` `{checks:[...]}` shape. Updated to the engine Report contract (`schema_version` / `findings` / `exit_code`). Suite goes 35/37 → 37/37.

## Test plan
- [x] `go build ./...` and `GOOS=windows go build ./...` — both succeed
- [x] `go test ./internal/doctor/ ./cmd/ao/` — green (one unrelated pre-existing flaky watchdog test)
- [x] `tests/integration/test-v218-commands.sh` — 37/37 pass