### PR TITLE
fix(test): windows-smoke doctor block uses the table, not --json

### DIFF
--- a/tests/windows/test-windows-smoke.ps1
+++ b/tests/windows/test-windows-smoke.ps1
@@ -205,11 +205,15 @@ try {
     throw "go build failed"
   }
 
-  $doctorJSON = & $builtAO doctor --json
-  if ($LASTEXITCODE -ne 0) {
-    throw "ao doctor --json failed"
+  # The Windows install hints live in the legacy check table, which the plain
+  # `ao doctor` still emits — `ao doctor --json` is now the engine Report and
+  # carries findings, not those hints. `ao doctor` exits 0 (healthy) or 1
+  # (findings present); both are valid diagnostic outcomes, only a higher code
+  # is a real failure.
+  $doctorText = (& $builtAO doctor 2>&1) -join "`n"
+  if ($LASTEXITCODE -gt 1) {
+    throw "ao doctor failed (exit $LASTEXITCODE)"
   }
-  $doctorText = ($doctorJSON -join "`n")
   if ($doctorText -notmatch 'install-codex\.ps1') {
     throw "doctor output did not include the Windows Codex installer hint"
   }


### PR DESCRIPTION
## Summary
Follow-up to PR #282. The Windows build fix landed, but `windows-smoke` then failed at the next step: its doctor block was written against the legacy `ao doctor --json` output (asserted exit 0, grepped the JSON for Windows install hints). `ao doctor --json` is now the engine Report — it exits 1 on findings and carries findings, not those hints.

The `install-codex.ps1` / `Windows release` / `WSL/Homebrew` hints come from legacy check details (`internal/quality/skills_codex.go`, `doctor.go`) and still render in the plain `ao doctor` table. The block now runs plain `ao doctor`, tolerates exit 0/1, and keeps the hint assertions.

## Test plan
- [x] Hint strings confirmed present in `internal/quality` (legacy check details → plain `ao doctor` table)
- [ ] CI `windows-smoke` green (this PR)