### PR TITLE
fix(ci): trigger windows-smoke on its own test-script changes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,6 +44,7 @@ jobs:
               - 'cli/**'
               - 'go.mod'
               - 'go.sum'
+              - 'tests/windows/**'
             skills:
               - 'skills/**'
               - 'skills-codex/**'


### PR DESCRIPTION
## Summary
The `windows-smoke` job is gated on `if: changes.outputs.go || changes.outputs.ci`, but the `go` filter (`cli/**`, `go.mod`, `go.sum`) and `ci` filter (`.github/**`) didn't cover `tests/windows/**`. A PR touching only `tests/windows/test-windows-smoke.ps1` therefore **skipped the very job that runs that script** — PR #283's windows-smoke fix shipped to `main` unverified.

Adds `tests/windows/**` to the `go` filter, mirroring the `skills` filter's existing `tests/skills/**` shape. Because this PR touches `.github/**` it trips the `ci` filter, so `windows-smoke` runs here — exercising the already-merged PR #283 PS fix and confirming it green.

## Test plan
- [x] `validate.yml` parses as valid YAML
- [ ] `windows-smoke` runs on this PR (no longer skipped) and passes