### PR TITLE
fix(rpi): align execution packet loop fields

### DIFF
--- a/cli/cmd/ao/rpi_discovery_artifact.go
+++ b/cli/cmd/ao/rpi_discovery_artifact.go
@@ -297,16 +297,40 @@ func writeExecutionPacketFromArtifact(cwd string, art *discoveryArtifact, goalOv
 	if err != nil {
 		return "", err
 	}
+	generatedAt := time.Now().UTC().Format(time.RFC3339)
 
 	packet := map[string]any{
 		// Canonical executionPacket fields (kept in-sync with rpi_execution_packet.go).
-		"schema_version":      1,
-		"objective":           goal,
+		"schema_version": 1,
+		"objective":      goal,
+		"density": map[string]any{
+			"intent": goal,
+			"boundary": map[string]any{
+				"bounded_context": executionPacketBoundedContext(cwd),
+				"non_goals":       orEmptyStringSlice(art.OutOfScope),
+				"write_scope":     orEmptyStringSlice(art.InScope),
+			},
+			"evidence":    append(orEmptyStringSlice(art.TDDMatrix), orEmptyStringSlice(art.AbortGates)...),
+			"decision":    "Discovery artifact supplied by operator; implementation starts from the artifact-backed execution packet.",
+			"constraint":  orEmptyStringSlice(art.AbortGates),
+			"next_action": "/crank .agents/rpi/execution-packet.json",
+		},
+		"artifacts": map[string]any{
+			"research_path":      art.SourcePath,
+			"ranked_packet_path": executionPacketRankedPacketPath,
+		},
 		"contract_surfaces":   contractSurfaces,
 		"validation_commands": orEmptyStringSlice(profile.ValidationCommands),
 		"validation_lanes":    profile.ValidationLanes,
 		"done_criteria":       doneCriteria,
 		"tracker_mode":        "discovery-artifact",
+		"test_levels": map[string]any{
+			"required":    []string{"L0", "L1"},
+			"recommended": []string{"L2"},
+			"rationale":   "Discovery-artifact handoff preserves the standard autonomous proof floor unless the artifact narrows it with explicit criteria.",
+		},
+		"ranked_packet_path":  executionPacketRankedPacketPath,
+		"discovery_timestamp": generatedAt,
 
 		// Discovery-artifact-mode extensions (documented in
 		// skills/rpi/references/discovery-artifact-mode.md).
@@ -321,7 +345,7 @@ func writeExecutionPacketFromArtifact(cwd string, art *discoveryArtifact, goalOv
 		"abort_gates":  orEmptyStringSlice(art.AbortGates),
 		"tdd_matrix":   orEmptyStringSlice(art.TDDMatrix),
 		"risks":        orEmptyStringSlice(art.Risks),
-		"generated_at": time.Now().UTC().Format(time.RFC3339),
+		"generated_at": generatedAt,
 	}
 
 	packetPath := filepath.Join(packetDir, "execution-packet.json")

--- a/cli/cmd/ao/rpi_discovery_artifact_test.go
+++ b/cli/cmd/ao/rpi_discovery_artifact_test.go
@@ -102,6 +102,32 @@ func TestRPIDiscoveryArtifact_LoadEmptyPath(t *testing.T) {
 	}
 }
 
+func TestRPIDiscoveryArtifact_LoadRejectsDirectoryAndPreloadNoop(t *testing.T) {
+	tmp := t.TempDir()
+	if _, err := loadDiscoveryArtifact(tmp); err == nil {
+		t.Fatalf("expected directory artifact error")
+	}
+	if _, err := loadDiscoveryArtifact("bad\x00path"); err == nil {
+		t.Fatalf("expected invalid path artifact error")
+	}
+
+	art, args, err := preloadDiscoveryArtifact(" ", []string{"keep goal"})
+	if err != nil {
+		t.Fatalf("preloadDiscoveryArtifact empty path: %v", err)
+	}
+	if art != nil {
+		t.Fatalf("artifact = %#v, want nil for empty path", art)
+	}
+	if !stringSlicesEqual(args, []string{"keep goal"}) {
+		t.Fatalf("args = %#v, want preserved args", args)
+	}
+
+	_, _, err = preloadDiscoveryArtifact(filepath.Join(tmp, "missing.md"), nil)
+	if err == nil {
+		t.Fatalf("expected missing artifact preload error")
+	}
+}
+
 func TestRPIDiscoveryArtifact_PreloadUsesArtifactGoalFallback(t *testing.T) {
 	tmp := t.TempDir()
 	artPath := filepath.Join(tmp, "art.md")
@@ -139,6 +165,49 @@ func TestRPIDiscoveryArtifact_ApplyIgnoresDiscoveryStart(t *testing.T) {
 	packetPath := filepath.Join(tmp, ".agents", "rpi", "execution-packet.json")
 	if _, err := os.Stat(packetPath); !os.IsNotExist(err) {
 		t.Fatalf("execution packet stat err = %v, want not exist", err)
+	}
+}
+
+func TestRPIDiscoveryArtifact_ApplyWritesImplementationPacket(t *testing.T) {
+	tmp := t.TempDir()
+	art := &discoveryArtifact{
+		Goal:       "implementation handoff",
+		InScope:    []string{"cli/cmd/ao/rpi_discovery_artifact.go"},
+		AbortGates: []string{"required gate"},
+		SourcePath: filepath.Join(tmp, "art.md"),
+	}
+
+	if err := applyDiscoveryArtifactToPacket(tmp, art, 2, "override goal"); err != nil {
+		t.Fatalf("applyDiscoveryArtifactToPacket: %v", err)
+	}
+	packetPath := filepath.Join(tmp, ".agents", "rpi", "execution-packet.json")
+	buf, err := os.ReadFile(packetPath)
+	if err != nil {
+		t.Fatalf("read execution packet: %v", err)
+	}
+	var packet map[string]any
+	if err := json.Unmarshal(buf, &packet); err != nil {
+		t.Fatalf("unmarshal packet: %v", err)
+	}
+	if got, want := packet["objective"], "override goal"; got != want {
+		t.Fatalf("objective = %v, want %v", got, want)
+	}
+	if got, want := packet["phase"], "implementation"; got != want {
+		t.Fatalf("phase = %v, want %v", got, want)
+	}
+}
+
+func TestRPIDiscoveryArtifact_ApplySurfacesPacketWriteError(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "docs", "contracts"), 0o750); err != nil {
+		t.Fatalf("create contracts dir: %v", err)
+	}
+	if err := os.WriteFile(repoExecutionProfileJSONPath(tmp), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write invalid profile: %v", err)
+	}
+	art := &discoveryArtifact{Goal: "bad profile", SourcePath: filepath.Join(tmp, "art.md")}
+	if err := applyDiscoveryArtifactToPacket(tmp, art, 2, ""); err == nil {
+		t.Fatalf("expected applyDiscoveryArtifactToPacket profile error")
 	}
 }
 
@@ -274,6 +343,41 @@ func TestRPIDiscoveryArtifact_GoalOverrideWins(t *testing.T) {
 	}
 }
 
+func TestRPIDiscoveryArtifact_WriteRejectsNilAndProfileErrors(t *testing.T) {
+	tmp := t.TempDir()
+	if _, err := writeExecutionPacketFromArtifact(tmp, nil, ""); err == nil {
+		t.Fatalf("expected nil discovery artifact error")
+	}
+
+	fileRoot := filepath.Join(tmp, "file-root")
+	if err := os.WriteFile(fileRoot, []byte("not a dir"), 0o600); err != nil {
+		t.Fatalf("write file root: %v", err)
+	}
+	if _, err := writeExecutionPacketFromArtifact(fileRoot, &discoveryArtifact{Goal: "mkdir error"}, ""); err == nil {
+		t.Fatalf("expected packet directory creation error")
+	}
+
+	writeRoot := filepath.Join(tmp, "write-root")
+	packetPath := filepath.Join(writeRoot, ".agents", "rpi", "execution-packet.json")
+	if err := os.MkdirAll(packetPath, 0o750); err != nil {
+		t.Fatalf("create packet path as directory: %v", err)
+	}
+	if _, err := writeExecutionPacketFromArtifact(writeRoot, &discoveryArtifact{Goal: "write error"}, ""); err == nil {
+		t.Fatalf("expected packet write error")
+	}
+
+	if err := os.MkdirAll(filepath.Join(tmp, "docs", "contracts"), 0o750); err != nil {
+		t.Fatalf("create contracts dir: %v", err)
+	}
+	if err := os.WriteFile(repoExecutionProfileJSONPath(tmp), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write invalid profile: %v", err)
+	}
+	art := &discoveryArtifact{Goal: "profile error", SourcePath: filepath.Join(tmp, "art.md")}
+	if _, err := writeExecutionPacketFromArtifact(tmp, art, ""); err == nil {
+		t.Fatalf("expected invalid repo execution profile error")
+	}
+}
+
 // TestRPIDiscoveryArtifact_ParseEmptyContent asserts the minimal degraded
 // behavior documented in the spec: empty content produces an empty artifact
 // (no goal, no scope) without panicking. Callers are expected to downgrade.
@@ -287,6 +391,42 @@ func TestRPIDiscoveryArtifact_ParseEmptyContent(t *testing.T) {
 	}
 	if len(art.InScope) != 0 {
 		t.Errorf("in_scope = %v, want empty", art.InScope)
+	}
+}
+
+func TestRPIDiscoveryArtifact_ParserHelperFallbacks(t *testing.T) {
+	body, fm := splitFrontmatter(`---
+# ignored
+
+goal: helper goal
+loc_estimate: '13'
+---
+## Heading Only
+
+plain fallback`)
+	if fm["goal"] != "helper goal" || fm["loc_estimate"] != "13" {
+		t.Fatalf("frontmatter = %#v", fm)
+	}
+	if body == "" {
+		t.Fatalf("body is empty")
+	}
+	if got := extractGoalFromBody("## ignored heading\n\nplain fallback"); got != "plain fallback" {
+		t.Fatalf("extractGoalFromBody fallback = %q", got)
+	}
+	if got := extractBulletItem("-    "); got != "" {
+		t.Fatalf("extractBulletItem blank = %q", got)
+	}
+
+	pathCases := map[string]bool{
+		"":               false,
+		"`cli/file.go`":  true,
+		"not a path":     false,
+		"docs/contracts": true,
+	}
+	for input, want := range pathCases {
+		if got := looksLikePath(input); got != want {
+			t.Fatalf("looksLikePath(%q) = %v, want %v", input, got, want)
+		}
 	}
 }
 

--- a/cli/cmd/ao/rpi_execution_packet.go
+++ b/cli/cmd/ao/rpi_execution_packet.go
@@ -7,45 +7,53 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/boshu2/agentops/cli/internal/autodev"
 	"github.com/boshu2/agentops/cli/internal/rpi"
 )
 
 const executionPacketFile = rpi.ExecutionPacketFile
+const executionPacketRankedPacketPath = ".agents/rpi/ranked-packet.json"
 
 // executionPacketProgram is a thin alias for the internal type.
 type executionPacketProgram = rpi.ExecutionPacketProgram
 
 type executionPacket struct {
-	SchemaVersion           int                        `json:"schema_version"`
-	Objective               string                     `json:"objective"`
-	RunID                   string                     `json:"run_id,omitempty"`
-	EpicID                  string                     `json:"epic_id,omitempty"`
-	BeadID                  string                     `json:"bead_id,omitempty"`
-	TrackingRepoRoot        string                     `json:"tracking_repo_root,omitempty"`
-	BeadsDir                string                     `json:"beads_dir,omitempty"`
-	PRURL                   string                     `json:"pr_url,omitempty"`
-	MergeCommit             string                     `json:"merge_commit,omitempty"`
-	PlanPath                string                     `json:"plan_path,omitempty"`
-	ContractSurfaces        []string                   `json:"contract_surfaces"`
-	ValidationCommands      []string                   `json:"validation_commands,omitempty"`
-	ValidationLanes         []rpi.ValidationLane       `json:"validation_lanes,omitempty"`
-	TrackerMode             string                     `json:"tracker_mode"`
-	TrackerHealth           *trackerHealth             `json:"tracker_health,omitempty"`
-	DoneCriteria            []string                   `json:"done_criteria,omitempty"`
-	EpicCriteria            []rpi.Criterion            `json:"epic_criteria,omitempty"`
-	BeadCriteria            map[string][]rpi.Criterion `json:"bead_criteria,omitempty"`
-	Complexity              string                     `json:"complexity,omitempty"`
-	ProofArtifacts          []string                   `json:"proof_artifacts,omitempty"`
-	EvaluatorArtifacts      map[string]string          `json:"evaluator_artifacts,omitempty"`
-	ProofUpdatedAt          string                     `json:"proof_updated_at,omitempty"`
-	AutodevProgram          *executionPacketProgram    `json:"autodev_program,omitempty"`
-	MixedModeRequested      bool                       `json:"mixed_mode_requested,omitempty"`
-	MixedModeEffective      bool                       `json:"mixed_mode_effective,omitempty"`
-	PlannerVendor           string                     `json:"planner_vendor,omitempty"`
-	ReviewerVendor          string                     `json:"reviewer_vendor,omitempty"`
-	MixedModeDegradedReason string                     `json:"mixed_mode_degraded_reason,omitempty"`
+	SchemaVersion           int                            `json:"schema_version"`
+	Objective               string                         `json:"objective"`
+	RunID                   string                         `json:"run_id,omitempty"`
+	EpicID                  string                         `json:"epic_id,omitempty"`
+	BeadID                  string                         `json:"bead_id,omitempty"`
+	TrackingRepoRoot        string                         `json:"tracking_repo_root,omitempty"`
+	BeadsDir                string                         `json:"beads_dir,omitempty"`
+	PRURL                   string                         `json:"pr_url,omitempty"`
+	MergeCommit             string                         `json:"merge_commit,omitempty"`
+	PlanPath                string                         `json:"plan_path,omitempty"`
+	Density                 *rpi.ExecutionPacketDensity    `json:"density,omitempty"`
+	Artifacts               *rpi.ExecutionPacketArtifacts  `json:"artifacts,omitempty"`
+	ContractSurfaces        []string                       `json:"contract_surfaces"`
+	ValidationCommands      []string                       `json:"validation_commands,omitempty"`
+	ValidationLanes         []rpi.ValidationLane           `json:"validation_lanes,omitempty"`
+	TrackerMode             string                         `json:"tracker_mode"`
+	TrackerHealth           *trackerHealth                 `json:"tracker_health,omitempty"`
+	DoneCriteria            []string                       `json:"done_criteria,omitempty"`
+	EpicCriteria            []rpi.Criterion                `json:"epic_criteria,omitempty"`
+	BeadCriteria            map[string][]rpi.Criterion     `json:"bead_criteria,omitempty"`
+	Complexity              string                         `json:"complexity,omitempty"`
+	PreMortemVerdict        string                         `json:"pre_mortem_verdict,omitempty"`
+	TestLevels              *rpi.ExecutionPacketTestLevels `json:"test_levels,omitempty"`
+	RankedPacketPath        string                         `json:"ranked_packet_path,omitempty"`
+	DiscoveryTimestamp      string                         `json:"discovery_timestamp,omitempty"`
+	ProofArtifacts          []string                       `json:"proof_artifacts,omitempty"`
+	EvaluatorArtifacts      map[string]string              `json:"evaluator_artifacts,omitempty"`
+	ProofUpdatedAt          string                         `json:"proof_updated_at,omitempty"`
+	AutodevProgram          *executionPacketProgram        `json:"autodev_program,omitempty"`
+	MixedModeRequested      bool                           `json:"mixed_mode_requested,omitempty"`
+	MixedModeEffective      bool                           `json:"mixed_mode_effective,omitempty"`
+	PlannerVendor           string                         `json:"planner_vendor,omitempty"`
+	ReviewerVendor          string                         `json:"reviewer_vendor,omitempty"`
+	MixedModeDegradedReason string                         `json:"mixed_mode_degraded_reason,omitempty"`
 }
 
 type repoExecutionProfile struct {
@@ -108,6 +116,11 @@ func writeExecutionPacketSeed(cwd string, state *phasedState) error {
 			StopConditions:     prog.StopConditions,
 		}
 	}
+	packet.Density = executionPacketDensityForState(cwd, state, &packet)
+	packet.Artifacts = executionPacketArtifactsForPacket(packet)
+	packet.TestLevels = executionPacketTestLevelsForState(state)
+	packet.RankedPacketPath = executionPacketRankedPacketPath
+	packet.DiscoveryTimestamp = time.Now().UTC().Format(time.RFC3339)
 
 	data, err := json.MarshalIndent(packet, "", "  ")
 	if err != nil {
@@ -118,6 +131,107 @@ func writeExecutionPacketSeed(cwd string, state *phasedState) error {
 		return fmt.Errorf("write execution packet: %w", err)
 	}
 	return nil
+}
+
+func executionPacketDensityForState(cwd string, state *phasedState, packet *executionPacket) *rpi.ExecutionPacketDensity {
+	intent := ""
+	complexity := ""
+	if state != nil {
+		intent = strings.TrimSpace(state.Goal)
+		complexity = strings.TrimSpace(string(state.Complexity))
+	}
+	if intent == "" && packet != nil {
+		intent = strings.TrimSpace(packet.Objective)
+	}
+	if complexity == "" {
+		complexity = string(ComplexityStandard)
+	}
+	writeScope := []string{}
+	evidence := []string{}
+	if packet != nil {
+		writeScope = append(writeScope, packet.ContractSurfaces...)
+		evidence = append(evidence, packet.ValidationCommands...)
+	}
+	return &rpi.ExecutionPacketDensity{
+		Intent: intent,
+		Boundary: rpi.ExecutionPacketBoundary{
+			BoundedContext: executionPacketBoundedContext(cwd),
+			NonGoals:       []string{},
+			WriteScope:     writeScope,
+		},
+		Evidence: evidence,
+		Decision: fmt.Sprintf("Seeded by ao rpi discovery for %s complexity; detailed decisions live in linked artifacts.", complexity),
+		Constraint: []string{
+			"Keep raw research, plan prose, and council deliberation in referenced artifacts.",
+			"Use repo execution profile lanes for validation selection.",
+		},
+		NextAction: executionPacketNextAction(state),
+	}
+}
+
+func executionPacketBoundedContext(cwd string) string {
+	root := executionPacketTrackingRepoRoot(cwd)
+	name := filepath.Base(root)
+	if name == "." || name == string(filepath.Separator) || name == "" {
+		return "repository"
+	}
+	return name
+}
+
+func executionPacketNextAction(state *phasedState) string {
+	if state != nil {
+		epicID := strings.TrimSpace(state.EpicID)
+		if epicID != "" && !isPlanFileEpic(epicID) {
+			return "/crank " + epicID
+		}
+	}
+	return "/crank .agents/rpi/execution-packet.json"
+}
+
+func executionPacketArtifactsForPacket(packet executionPacket) *rpi.ExecutionPacketArtifacts {
+	return &rpi.ExecutionPacketArtifacts{
+		PlanPath:         strings.TrimSpace(packet.PlanPath),
+		RankedPacketPath: executionPacketRankedPacketPath,
+	}
+}
+
+func executionPacketTestLevelsForState(state *phasedState) *rpi.ExecutionPacketTestLevels {
+	complexity := ComplexityStandard
+	testFirst := false
+	if state != nil {
+		complexity = state.Complexity
+		testFirst = state.TestFirst
+	}
+	switch complexity {
+	case ComplexityFast:
+		return &rpi.ExecutionPacketTestLevels{
+			Required:    []string{"L0"},
+			Recommended: []string{"L1"},
+			Rationale:   "Fast-path discovery keeps the autonomous proof floor small and recommends one focused unit-level check.",
+		}
+	case ComplexityFull:
+		return &rpi.ExecutionPacketTestLevels{
+			Required:    []string{"L0", "L1", "L2"},
+			Recommended: []string{"L3"},
+			Rationale:   "Full discovery expects contract, unit, and integration evidence before higher-level component coverage.",
+		}
+	default:
+		required := []string{"L0", "L1"}
+		recommended := []string{"L2"}
+		if testFirst {
+			required = append(required, "L2")
+			recommended = []string{"L3"}
+		}
+		rationale := "Standard discovery requires contract and unit-level proof, with integration evidence recommended when the slice crosses adapters."
+		if testFirst {
+			rationale = "Test-first standard discovery requires contract, unit, and integration proof for the selected implementation slice."
+		}
+		return &rpi.ExecutionPacketTestLevels{
+			Required:    required,
+			Recommended: recommended,
+			Rationale:   rationale,
+		}
+	}
 }
 
 func repoExecutionProfileJSONPath(cwd string) string {

--- a/cli/cmd/ao/rpi_execution_packet_test.go
+++ b/cli/cmd/ao/rpi_execution_packet_test.go
@@ -4,20 +4,48 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/boshu2/agentops/cli/internal/rpi"
 )
 
 func TestExecutionPacket_RoundTripWithCriteria(t *testing.T) {
 	original := executionPacket{
-		SchemaVersion:    1,
-		Objective:        "round trip criteria",
-		RunID:            "run-1",
-		EpicID:           "soc-bcrn",
+		SchemaVersion: 1,
+		Objective:     "round trip criteria",
+		RunID:         "run-1",
+		EpicID:        "soc-bcrn",
+		Density: &rpi.ExecutionPacketDensity{
+			Intent: "round trip criteria",
+			Boundary: rpi.ExecutionPacketBoundary{
+				BoundedContext: "agentops",
+				NonGoals:       []string{"unrelated refactors"},
+				WriteScope:     []string{"cli/cmd/ao/rpi_execution_packet.go"},
+			},
+			Evidence:   []string{"go test ./cmd/ao -run ExecutionPacket"},
+			Decision:   "align schema and runtime packet fields",
+			Constraint: []string{"do not touch doctor workspace"},
+			NextAction: "/crank soc-bcrn",
+		},
+		Artifacts: &rpi.ExecutionPacketArtifacts{
+			ResearchPath:     ".agents/research/topic.md",
+			PlanPath:         ".agents/plans/topic.md",
+			PreMortemPath:    ".agents/council/pre-mortem-topic.md",
+			RankedPacketPath: ".agents/rpi/ranked-packet.json",
+		},
 		ContractSurfaces: []string{"docs/contracts/repo-execution-profile.md"},
 		TrackerMode:      "bd",
+		TestLevels: &rpi.ExecutionPacketTestLevels{
+			Required:    []string{"L0", "L1"},
+			Recommended: []string{"L2"},
+			Rationale:   "schema fixture covers loop-density handoff fields",
+		},
+		RankedPacketPath:   ".agents/rpi/ranked-packet.json",
+		DiscoveryTimestamp: "2026-05-16T00:00:00Z",
 		EpicCriteria: []rpi.Criterion{
 			{
 				ID:               "ac-soc-bcrn.1",
@@ -141,5 +169,439 @@ func TestExecutionPacket_OmitEmptyCriteria(t *testing.T) {
 	}
 	if bytes.Contains(data, []byte(`"bead_criteria"`)) {
 		t.Errorf("bead_criteria key should be omitted when empty; got: %s", data)
+	}
+}
+
+func TestWriteExecutionPacketSeed_PopulatesLoopDensityFields(t *testing.T) {
+	tmpDir := t.TempDir()
+	state := &phasedState{
+		Goal:       "ship loop density",
+		EpicID:     "soc-z3qo.1",
+		RunID:      "density-run",
+		Complexity: ComplexityStandard,
+		Opts:       phasedEngineOptions{},
+	}
+
+	if err := writeExecutionPacketSeed(tmpDir, state); err != nil {
+		t.Fatalf("writeExecutionPacketSeed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, ".agents", "rpi", "execution-packet.json"))
+	if err != nil {
+		t.Fatalf("read execution packet: %v", err)
+	}
+	var packet executionPacket
+	if err := json.Unmarshal(data, &packet); err != nil {
+		t.Fatalf("unmarshal execution packet: %v", err)
+	}
+
+	if packet.Density == nil {
+		t.Fatalf("Density = nil")
+	}
+	if packet.Density.Intent != "ship loop density" {
+		t.Fatalf("Density.Intent = %q", packet.Density.Intent)
+	}
+	if packet.Density.Boundary.BoundedContext == "" {
+		t.Fatalf("Density.Boundary.BoundedContext is empty")
+	}
+	if packet.Density.NextAction != "/crank soc-z3qo.1" {
+		t.Fatalf("Density.NextAction = %q", packet.Density.NextAction)
+	}
+	if packet.Artifacts == nil || packet.Artifacts.RankedPacketPath != executionPacketRankedPacketPath {
+		t.Fatalf("Artifacts = %#v, want ranked packet path", packet.Artifacts)
+	}
+	if packet.TestLevels == nil || !reflect.DeepEqual(packet.TestLevels.Required, []string{"L0", "L1"}) {
+		t.Fatalf("TestLevels = %#v, want required L0/L1", packet.TestLevels)
+	}
+	if packet.RankedPacketPath != executionPacketRankedPacketPath {
+		t.Fatalf("RankedPacketPath = %q", packet.RankedPacketPath)
+	}
+	if _, err := time.Parse(time.RFC3339, packet.DiscoveryTimestamp); err != nil {
+		t.Fatalf("DiscoveryTimestamp = %q is not RFC3339: %v", packet.DiscoveryTimestamp, err)
+	}
+}
+
+func TestWriteExecutionPacketSeed_IncludesRepoProfileAndPlanEpic(t *testing.T) {
+	tmpDir := t.TempDir()
+	contractsDir := filepath.Join(tmpDir, "docs", "contracts")
+	if err := os.MkdirAll(contractsDir, 0o750); err != nil {
+		t.Fatalf("create contracts dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(contractsDir, "repo-execution-profile.md"), []byte("# Profile\n"), 0o600); err != nil {
+		t.Fatalf("write profile doc: %v", err)
+	}
+	profileJSON := `{
+		"validation_commands": ["scripts/pre-push-gate.sh --fast"],
+		"validation_lanes": [
+			{
+				"name": "pre-push-fast",
+				"command": "scripts/pre-push-gate.sh --fast",
+				"read_only": true,
+				"writes_artifacts": false,
+				"isolated_agents_home": true,
+				"release_only": false,
+				"mutation_escape_hatch": null,
+				"cost_class": "standard",
+				"auto_select": "default",
+				"timeout_seconds": 180
+			}
+		]
+	}`
+	if err := os.WriteFile(repoExecutionProfileJSONPath(tmpDir), []byte(profileJSON), 0o600); err != nil {
+		t.Fatalf("write profile json: %v", err)
+	}
+
+	state := &phasedState{
+		Goal:       "profile-backed packet",
+		EpicID:     "plan:.agents/plans/profile-plan.md",
+		RunID:      "profile-run",
+		Complexity: ComplexityFull,
+		TestFirst:  true,
+		Opts:       phasedEngineOptions{},
+	}
+	if err := writeExecutionPacketSeed(tmpDir, state); err != nil {
+		t.Fatalf("writeExecutionPacketSeed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, ".agents", "rpi", "execution-packet.json"))
+	if err != nil {
+		t.Fatalf("read execution packet: %v", err)
+	}
+	var packet executionPacket
+	if err := json.Unmarshal(data, &packet); err != nil {
+		t.Fatalf("unmarshal execution packet: %v", err)
+	}
+
+	if packet.PlanPath != ".agents/plans/profile-plan.md" {
+		t.Fatalf("PlanPath = %q", packet.PlanPath)
+	}
+	if !containsProgramContract(packet.ContractSurfaces, "docs/contracts/repo-execution-profile.md") ||
+		!containsProgramContract(packet.ContractSurfaces, "docs/contracts/repo-execution-profile.json") {
+		t.Fatalf("ContractSurfaces = %#v, want repo execution profile surfaces", packet.ContractSurfaces)
+	}
+	if !stringSlicesEqual(packet.ValidationCommands, []string{"scripts/pre-push-gate.sh --fast"}) {
+		t.Fatalf("ValidationCommands = %#v", packet.ValidationCommands)
+	}
+	if len(packet.ValidationLanes) != 1 || packet.ValidationLanes[0].Name != "pre-push-fast" {
+		t.Fatalf("ValidationLanes = %#v", packet.ValidationLanes)
+	}
+	if packet.BeadID != "" {
+		t.Fatalf("BeadID = %q, want empty for plan-file epic", packet.BeadID)
+	}
+	if packet.TestLevels == nil || !stringSlicesEqual(packet.TestLevels.Required, []string{"L0", "L1", "L2"}) {
+		t.Fatalf("TestLevels = %#v, want full proof floor", packet.TestLevels)
+	}
+	if packet.Density == nil || !stringSlicesEqual(packet.Density.Evidence, []string{"scripts/pre-push-gate.sh --fast"}) {
+		t.Fatalf("Density = %#v, want profile command evidence", packet.Density)
+	}
+}
+
+func TestExecutionPacketLoopDensityHelpers_CoverFallbackBranches(t *testing.T) {
+	tmpDir := t.TempDir()
+	packet := &executionPacket{
+		Objective:          "objective fallback",
+		ContractSurfaces:   []string{"schemas/execution-packet.schema.json"},
+		ValidationCommands: []string{"go test ./cmd/ao -run ExecutionPacket"},
+	}
+	density := executionPacketDensityForState(tmpDir, nil, packet)
+	if density.Intent != "objective fallback" {
+		t.Fatalf("density intent = %q", density.Intent)
+	}
+	if !stringSlicesEqual(density.Boundary.WriteScope, packet.ContractSurfaces) {
+		t.Fatalf("density write scope = %#v", density.Boundary.WriteScope)
+	}
+	if !stringSlicesEqual(density.Evidence, packet.ValidationCommands) {
+		t.Fatalf("density evidence = %#v", density.Evidence)
+	}
+	if density.NextAction != "/crank .agents/rpi/execution-packet.json" {
+		t.Fatalf("density next action = %q", density.NextAction)
+	}
+	if got := executionPacketBoundedContext(string(filepath.Separator)); got != "repository" {
+		t.Fatalf("executionPacketBoundedContext(/) = %q", got)
+	}
+	if got := executionPacketTrackingRepoRoot(" "); got == "" {
+		t.Fatalf("executionPacketTrackingRepoRoot(empty) returned empty")
+	}
+	if got := executionPacketBeadID(nil); got != "" {
+		t.Fatalf("executionPacketBeadID(nil) = %q", got)
+	}
+	if got := executionPacketBeadID(&phasedState{EpicID: "plan:.agents/plans/x.md"}); got != "" {
+		t.Fatalf("executionPacketBeadID(plan epic) = %q", got)
+	}
+
+	fast := executionPacketTestLevelsForState(&phasedState{Complexity: ComplexityFast})
+	if !stringSlicesEqual(fast.Required, []string{"L0"}) || !stringSlicesEqual(fast.Recommended, []string{"L1"}) {
+		t.Fatalf("fast test levels = %#v", fast)
+	}
+	testFirst := executionPacketTestLevelsForState(&phasedState{Complexity: ComplexityStandard, TestFirst: true})
+	if !stringSlicesEqual(testFirst.Required, []string{"L0", "L1", "L2"}) ||
+		!stringSlicesEqual(testFirst.Recommended, []string{"L3"}) {
+		t.Fatalf("test-first levels = %#v", testFirst)
+	}
+}
+
+func TestExecutionPacketStorageHelpers_CoverArchiveAndRestore(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("BEADS_DIR", filepath.Join(tmpDir, "custom-beads"))
+	if got := executionPacketBeadsDir(tmpDir); got != filepath.Join(tmpDir, "custom-beads") {
+		t.Fatalf("executionPacketBeadsDir env = %q", got)
+	}
+	t.Setenv("BEADS_DIR", "")
+	if err := os.Mkdir(filepath.Join(tmpDir, ".beads"), 0o750); err != nil {
+		t.Fatalf("create .beads: %v", err)
+	}
+	if got := executionPacketBeadsDir(tmpDir); got != filepath.Join(tmpDir, ".beads") {
+		t.Fatalf("executionPacketBeadsDir .beads = %q", got)
+	}
+
+	data := []byte(`{"schema_version":1,"objective":"archive","contract_surfaces":[],"tracker_mode":"bd"}` + "\n")
+	if err := writeExecutionPacketDataToRoot(tmpDir, "run-archive", data); err != nil {
+		t.Fatalf("writeExecutionPacketDataToRoot: %v", err)
+	}
+	archivePath := filepath.Join(tmpDir, ".agents", "rpi", "runs", "run-archive", "execution-packet.json")
+	if _, err := os.Stat(archivePath); err != nil {
+		t.Fatalf("archive stat: %v", err)
+	}
+
+	snap, err := captureExecutionPacketAliasSnapshot(tmpDir)
+	if err != nil {
+		t.Fatalf("capture snapshot: %v", err)
+	}
+	latestPath := filepath.Join(tmpDir, ".agents", "rpi", "execution-packet.json")
+	if err := os.WriteFile(latestPath, []byte("changed\n"), 0o600); err != nil {
+		t.Fatalf("overwrite latest: %v", err)
+	}
+	if err := snap.restore(); err != nil {
+		t.Fatalf("restore existing snapshot: %v", err)
+	}
+	restored, err := os.ReadFile(latestPath)
+	if err != nil {
+		t.Fatalf("read restored latest: %v", err)
+	}
+	if !bytes.Equal(restored, data) {
+		t.Fatalf("restored data = %q, want %q", restored, data)
+	}
+
+	missingRoot := filepath.Join(tmpDir, "missing")
+	missingSnap, err := captureExecutionPacketAliasSnapshot(missingRoot)
+	if err != nil {
+		t.Fatalf("capture missing snapshot: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(missingSnap.path), 0o750); err != nil {
+		t.Fatalf("create missing snapshot dir: %v", err)
+	}
+	if err := os.WriteFile(missingSnap.path, []byte("dry-run\n"), 0o600); err != nil {
+		t.Fatalf("write dry-run alias: %v", err)
+	}
+	if err := missingSnap.restore(); err != nil {
+		t.Fatalf("restore missing snapshot: %v", err)
+	}
+	if _, err := os.Stat(missingSnap.path); !os.IsNotExist(err) {
+		t.Fatalf("missing snapshot path stat = %v, want removed", err)
+	}
+	if err := (*executionPacketAliasSnapshot)(nil).restore(); err != nil {
+		t.Fatalf("nil snapshot restore: %v", err)
+	}
+}
+
+func TestExecutionPacketStorageHelpers_ErrorBranches(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	rootFile := filepath.Join(tmpDir, "root-file")
+	if err := os.WriteFile(rootFile, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write root file: %v", err)
+	}
+	if err := writeExecutionPacketData(rootFile, nil, "", []byte("{}\n")); err == nil {
+		t.Fatalf("expected writeExecutionPacketData to fail for file root")
+	}
+	if err := writeExecutionPacketDataToRoot(rootFile, "", []byte("{}\n")); err == nil {
+		t.Fatalf("expected writeExecutionPacketDataToRoot to fail for file root")
+	}
+	if _, err := captureExecutionPacketAliasSnapshot(rootFile); err == nil {
+		t.Fatalf("expected capture snapshot to fail for file root")
+	}
+
+	contractsDir := filepath.Join(tmpDir, "docs", "contracts")
+	if err := os.MkdirAll(contractsDir, 0o750); err != nil {
+		t.Fatalf("create contracts dir: %v", err)
+	}
+	if err := os.Mkdir(repoExecutionProfileJSONPath(tmpDir), 0o750); err != nil {
+		t.Fatalf("create profile path as directory: %v", err)
+	}
+	if _, err := loadRepoExecutionProfile(tmpDir); err == nil {
+		t.Fatalf("expected read repo execution profile error")
+	}
+
+	runRoot := filepath.Join(tmpDir, "run-root")
+	if err := os.MkdirAll(filepath.Join(runRoot, ".agents", "rpi"), 0o750); err != nil {
+		t.Fatalf("create rpi dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runRoot, ".agents", "rpi", "runs"), []byte("not a dir"), 0o600); err != nil {
+		t.Fatalf("write runs file: %v", err)
+	}
+	if err := writeExecutionPacketDataToRoot(runRoot, "run-mkdir-fails", []byte("{}\n")); err == nil {
+		t.Fatalf("expected run archive mkdir error")
+	}
+
+	archiveRoot := filepath.Join(tmpDir, "archive-root")
+	archivePath := filepath.Join(archiveRoot, ".agents", "rpi", "runs", "run-write-fails", "execution-packet.json")
+	if err := os.MkdirAll(archivePath, 0o750); err != nil {
+		t.Fatalf("create archive path as directory: %v", err)
+	}
+	if err := writeExecutionPacketDataToRoot(archiveRoot, "run-write-fails", []byte("{}\n")); err == nil {
+		t.Fatalf("expected run archive write error")
+	}
+
+	if err := (&executionPacketAliasSnapshot{path: filepath.Join(rootFile, "alias.json")}).restore(); err == nil {
+		t.Fatalf("expected missing snapshot restore remove error")
+	}
+	if err := (&executionPacketAliasSnapshot{
+		path:    filepath.Join(rootFile, "alias.json"),
+		data:    []byte("original\n"),
+		existed: true,
+	}).restore(); err == nil {
+		t.Fatalf("expected existing snapshot restore mkdir error")
+	}
+	writeErrorPath := filepath.Join(tmpDir, "alias-dir", "execution-packet.json")
+	if err := os.MkdirAll(writeErrorPath, 0o750); err != nil {
+		t.Fatalf("create alias path as directory: %v", err)
+	}
+	if err := (&executionPacketAliasSnapshot{
+		path:    writeErrorPath,
+		data:    []byte("original\n"),
+		existed: true,
+	}).restore(); err == nil {
+		t.Fatalf("expected existing snapshot restore write error")
+	}
+}
+
+func TestLoadRepoExecutionProfile_InvalidJSONReturnsContext(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "docs", "contracts"), 0o750); err != nil {
+		t.Fatalf("create contracts dir: %v", err)
+	}
+	if err := os.WriteFile(repoExecutionProfileJSONPath(tmpDir), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write invalid profile: %v", err)
+	}
+	if _, err := loadRepoExecutionProfile(tmpDir); err == nil {
+		t.Fatalf("expected invalid profile error")
+	}
+}
+
+func TestWriteExecutionPacketSeed_ReturnsProfileAndProgramErrors(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "docs", "contracts"), 0o750); err != nil {
+		t.Fatalf("create contracts dir: %v", err)
+	}
+	if err := os.WriteFile(repoExecutionProfileJSONPath(tmpDir), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write invalid profile: %v", err)
+	}
+	state := &phasedState{Goal: "bad profile", RunID: "bad-profile", Opts: phasedEngineOptions{}}
+	if err := writeExecutionPacketSeed(tmpDir, state); err == nil {
+		t.Fatalf("expected writeExecutionPacketSeed profile error")
+	}
+
+	programRoot := t.TempDir()
+	programState := &phasedState{
+		Goal:        "bad program",
+		RunID:       "bad-program",
+		ProgramPath: "PROGRAM.md",
+		Opts:        phasedEngineOptions{},
+	}
+	if err := os.WriteFile(filepath.Join(programRoot, "PROGRAM.md"), []byte(" \n"), 0o600); err != nil {
+		t.Fatalf("write invalid program: %v", err)
+	}
+	if err := writeExecutionPacketSeed(programRoot, programState); err == nil {
+		t.Fatalf("expected writeExecutionPacketSeed program error")
+	}
+}
+
+func TestExecutionPacketSchema_CoversLoopDensityFixture(t *testing.T) {
+	schemaPath := findRepoFileForTest(t, "schemas", "execution-packet.schema.json")
+	data, err := os.ReadFile(schemaPath)
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	var schema struct {
+		AdditionalProperties bool           `json:"additionalProperties"`
+		Properties           map[string]any `json:"properties"`
+		Defs                 map[string]any `json:"$defs"`
+		Required             []string       `json:"required"`
+	}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+	if schema.AdditionalProperties {
+		t.Fatalf("schema additionalProperties = true, want false")
+	}
+
+	fixture := executionPacket{
+		SchemaVersion: 1,
+		Objective:     "fixture",
+		Density: &rpi.ExecutionPacketDensity{
+			Intent: "fixture",
+			Boundary: rpi.ExecutionPacketBoundary{
+				BoundedContext: "agentops",
+				NonGoals:       []string{"doctor workspace"},
+				WriteScope:     []string{"schemas/execution-packet.schema.json"},
+			},
+			Evidence:   []string{"go test ./cmd/ao -run ExecutionPacket"},
+			Decision:   "prove schema names every loop-density field",
+			Constraint: []string{"additive schema change only"},
+			NextAction: "/crank .agents/rpi/execution-packet.json",
+		},
+		Artifacts: &rpi.ExecutionPacketArtifacts{
+			ResearchPath:     ".agents/research/fixture.md",
+			PlanPath:         ".agents/plans/fixture.md",
+			PreMortemPath:    ".agents/council/pre-mortem-fixture.md",
+			RankedPacketPath: executionPacketRankedPacketPath,
+		},
+		ContractSurfaces: []string{"docs/contracts/repo-execution-profile.md"},
+		TrackerMode:      "bd",
+		TestLevels: &rpi.ExecutionPacketTestLevels{
+			Required:    []string{"L0", "L1"},
+			Recommended: []string{"L2"},
+			Rationale:   "fixture",
+		},
+		RankedPacketPath:   executionPacketRankedPacketPath,
+		DiscoveryTimestamp: "2026-05-16T00:00:00Z",
+	}
+	payload, err := json.Marshal(fixture)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	var topLevel map[string]any
+	if err := json.Unmarshal(payload, &topLevel); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	for key := range topLevel {
+		if _, ok := schema.Properties[key]; !ok {
+			t.Fatalf("schema missing top-level property %q for fixture JSON: %s", key, payload)
+		}
+	}
+	for _, def := range []string{"Density", "Boundary", "Artifacts", "TestLevels", "TestLevel"} {
+		if _, ok := schema.Defs[def]; !ok {
+			t.Fatalf("schema missing $defs.%s", def)
+		}
+	}
+}
+
+func findRepoFileForTest(t *testing.T, parts ...string) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		candidate := filepath.Join(append([]string{dir}, parts...)...)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find repo file %s", filepath.Join(parts...))
+		}
+		dir = parent
 	}
 }

--- a/cli/internal/rpi/execution_packet.go
+++ b/cli/internal/rpi/execution_packet.go
@@ -56,3 +56,40 @@ type ValidationLane struct {
 	TimeoutSeconds      int      `json:"timeout_seconds,omitempty"`
 	ExpensiveReason     string   `json:"expensive_reason,omitempty"`
 }
+
+// ExecutionPacketDensity carries the dense phase-boundary context that
+// discovery passes to implementation without copying raw research or plan prose.
+type ExecutionPacketDensity struct {
+	Intent     string                  `json:"intent"`
+	Boundary   ExecutionPacketBoundary `json:"boundary"`
+	Evidence   []string                `json:"evidence"`
+	Decision   string                  `json:"decision"`
+	Constraint []string                `json:"constraint"`
+	NextAction string                  `json:"next_action"`
+}
+
+// ExecutionPacketBoundary describes the work boundary for the next phase.
+type ExecutionPacketBoundary struct {
+	BoundedContext string   `json:"bounded_context"`
+	NonGoals       []string `json:"non_goals"`
+	WriteScope     []string `json:"write_scope"`
+}
+
+// ExecutionPacketArtifacts links the compact packet to larger durable
+// artifacts. Empty paths are omitted so early seed packets can remain valid
+// before discovery has produced every artifact.
+type ExecutionPacketArtifacts struct {
+	ResearchPath     string `json:"research_path,omitempty"`
+	PlanPath         string `json:"plan_path,omitempty"`
+	PreMortemPath    string `json:"pre_mortem_path,omitempty"`
+	RankedPacketPath string `json:"ranked_packet_path,omitempty"`
+}
+
+// ExecutionPacketTestLevels records the test pyramid levels selected for the
+// handoff. Required levels are the minimum autonomous proof floor; recommended
+// levels are advisory unless a bead acceptance criterion names them.
+type ExecutionPacketTestLevels struct {
+	Required    []string `json:"required"`
+	Recommended []string `json:"recommended"`
+	Rationale   string   `json:"rationale"`
+}

--- a/cli/internal/rpi/execution_packet_test.go
+++ b/cli/internal/rpi/execution_packet_test.go
@@ -1,0 +1,58 @@
+package rpi
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestExecutionPacketLoopDensityTypesRoundTrip(t *testing.T) {
+	original := struct {
+		Density          ExecutionPacketDensity    `json:"density"`
+		Artifacts        ExecutionPacketArtifacts  `json:"artifacts"`
+		TestLevels       ExecutionPacketTestLevels `json:"test_levels"`
+		RankedPacketPath string                    `json:"ranked_packet_path"`
+	}{
+		Density: ExecutionPacketDensity{
+			Intent: "ship a dense handoff",
+			Boundary: ExecutionPacketBoundary{
+				BoundedContext: "agentops",
+				NonGoals:       []string{"doctor workspace"},
+				WriteScope:     []string{"schemas/execution-packet.schema.json"},
+			},
+			Evidence:   []string{"go test ./cmd/ao ./internal/rpi -run ExecutionPacket"},
+			Decision:   "align schema and runtime packet fields",
+			Constraint: []string{"keep raw artifacts out of the packet"},
+			NextAction: "/crank .agents/rpi/execution-packet.json",
+		},
+		Artifacts: ExecutionPacketArtifacts{
+			ResearchPath:     ".agents/research/topic.md",
+			PlanPath:         ".agents/plans/topic.md",
+			PreMortemPath:    ".agents/council/pre-mortem-topic.md",
+			RankedPacketPath: ".agents/rpi/ranked-packet.json",
+		},
+		TestLevels: ExecutionPacketTestLevels{
+			Required:    []string{"L0", "L1"},
+			Recommended: []string{"L2"},
+			Rationale:   "standard autonomous proof floor",
+		},
+		RankedPacketPath: ".agents/rpi/ranked-packet.json",
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded struct {
+		Density          ExecutionPacketDensity    `json:"density"`
+		Artifacts        ExecutionPacketArtifacts  `json:"artifacts"`
+		TestLevels       ExecutionPacketTestLevels `json:"test_levels"`
+		RankedPacketPath string                    `json:"ranked_packet_path"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(original, decoded) {
+		t.Fatalf("round-trip mismatch:\noriginal=%#v\ndecoded =%#v", original, decoded)
+	}
+}

--- a/registry.json
+++ b/registry.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-16T15:02:21Z",
+  "generated_at": "2026-05-16T20:22:31Z",
   "summary": {
     "skills": 77,
     "hooks": 43,
     "knowledge_stores": 4,
     "job_types": 14,
     "eval_files": 62,
-    "cli_commands": 160
+    "cli_commands": 161
   },
   "surfaces": {
     "skills": [
@@ -1311,6 +1311,10 @@
       {
         "name": "doctor",
         "path": "cli/cmd/ao/doctor.go"
+      },
+      {
+        "name": "doctor_surface",
+        "path": "cli/cmd/ao/doctor_surface.go"
       },
       {
         "name": "eval",

--- a/schemas/execution-packet.schema.json
+++ b/schemas/execution-packet.schema.json
@@ -44,6 +44,12 @@
     "plan_path": {
       "type": "string"
     },
+    "density": {
+      "$ref": "#/$defs/Density"
+    },
+    "artifacts": {
+      "$ref": "#/$defs/Artifacts"
+    },
     "contract_surfaces": {
       "type": "array",
       "items": {
@@ -95,6 +101,20 @@
     "complexity": {
       "type": "string"
     },
+    "pre_mortem_verdict": {
+      "type": "string",
+      "enum": ["PASS", "WARN", "FAIL"]
+    },
+    "test_levels": {
+      "$ref": "#/$defs/TestLevels"
+    },
+    "ranked_packet_path": {
+      "type": "string"
+    },
+    "discovery_timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
     "proof_artifacts": {
       "type": "array",
       "items": {
@@ -127,9 +147,179 @@
     },
     "mixed_mode_degraded_reason": {
       "type": "string"
+    },
+    "phase": {
+      "type": "string"
+    },
+    "source": {
+      "type": "string"
+    },
+    "discovery_artifacts": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "scope": {
+      "$ref": "#/$defs/DiscoveryArtifactScope"
+    },
+    "abort_gates": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tdd_matrix": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
     }
   },
   "$defs": {
+    "Density": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "intent",
+        "boundary",
+        "evidence",
+        "decision",
+        "constraint",
+        "next_action"
+      ],
+      "properties": {
+        "intent": {
+          "type": "string"
+        },
+        "boundary": {
+          "$ref": "#/$defs/Boundary"
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "decision": {
+          "type": "string"
+        },
+        "constraint": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "next_action": {
+          "type": "string"
+        }
+      }
+    },
+    "Boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bounded_context",
+        "non_goals",
+        "write_scope"
+      ],
+      "properties": {
+        "bounded_context": {
+          "type": "string"
+        },
+        "non_goals": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "write_scope": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "research_path": {
+          "type": "string"
+        },
+        "plan_path": {
+          "type": "string"
+        },
+        "pre_mortem_path": {
+          "type": "string"
+        },
+        "ranked_packet_path": {
+          "type": "string"
+        }
+      }
+    },
+    "TestLevels": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required",
+        "recommended",
+        "rationale"
+      ],
+      "properties": {
+        "required": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TestLevel"
+          }
+        },
+        "recommended": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TestLevel"
+          }
+        },
+        "rationale": {
+          "type": "string"
+        }
+      }
+    },
+    "TestLevel": {
+      "type": "string",
+      "enum": ["L0", "L1", "L2", "L3"]
+    },
+    "DiscoveryArtifactScope": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "in_scope": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "out_of_scope": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "loc_estimate": {
+          "type": "integer"
+        }
+      }
+    },
     "Criterion": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
## Summary
- add loop-density, artifact-link, test-level, ranked-packet, and discovery timestamp fields to the execution-packet schema
- populate the new fields from the RPI seed writer and discovery-artifact packet path
- add focused round-trip/schema coverage and regenerate registry.json so it includes the landed doctor surface plus this branch

## Validation
- go test ./cmd/ao ./internal/rpi -run 'ExecutionPacket|RPIDiscoveryArtifact'\n- go vet ./...\n- go test ./... -count=1 -short\n- bash scripts/check-contract-compatibility.sh\n- bash scripts/generate-registry.sh --check\n- bash scripts/audit-codex-parity.sh --skill discovery\n- scripts/pre-push-gate.sh --fast\n- git diff --check\n\nTracks soc-z3qo.1.