### PR TITLE
fix(eval): sync canaries + json-flag test to the ao doctor surface

### DIFF
--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=70 sub=173 all=243"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=70 sub=184 all=254"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/distribution-install-update.json
+++ b/evals/agentops-core/distribution-install-update.json
@@ -98,7 +98,7 @@
         {"type": "artifact_contains", "target": "../../tests/windows/test-windows-smoke.ps1", "value": "Test-PowerShellSyntax (Join-PathSegments -Base $RepoRoot -Segments 'scripts', 'install-codex.ps1')"},
         {"type": "artifact_contains", "target": "../../tests/windows/test-windows-smoke.ps1", "value": "Invoke-NestedScript -ScriptPath $installAoScript -ScriptArgs @('-InstallDir', $aoInstallDir, '-NoPathUpdate')"},
         {"type": "artifact_contains", "target": "../../tests/windows/test-windows-smoke.ps1", "value": "Invoke-NestedScript -ScriptPath $installCodexScript -ScriptArgs @('-RepoRoot', $RepoRoot, '-CodexHome', $codexHome)"},
-        {"type": "artifact_contains", "target": "../../tests/windows/test-windows-smoke.ps1", "value": "$builtAO doctor --json"},
+        {"type": "artifact_contains", "target": "../../tests/windows/test-windows-smoke.ps1", "value": "$builtAO doctor"},
         {"type": "artifact_contains", "target": "../../.github/workflows/validate.yml", "value": "windows-smoke"},
         {"type": "artifact_contains", "target": "../../.github/workflows/validate.yml", "value": ".\\tests\\windows\\test-windows-smoke.ps1"},
         {"type": "artifact_contains", "target": "../../docs/CI-CD.md", "value": "Windows installer smoke must pass"}

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,4} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "70" || "$sub_count" != "173" || "$all_count" != "243" ]]; then
+if [[ "$top_count" != "70" || "$sub_count" != "184" || "$all_count" != "254" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 243 ]]; then
+if [[ "${#commands[@]}" -ne 254 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/tests/cli/test-json-flag-consistency.sh
+++ b/tests/cli/test-json-flag-consistency.sh
@@ -43,11 +43,19 @@ echo "Binary: $AO"
 echo ""
 
 # ── Helper: test a command with --json ───────────────────────────────
-# Usage: test_json_cmd <label> <ao-args...>
+# Usage: test_json_cmd [--diagnostic] <label> <ao-args...>
 # Runs the command, checks:
 #   1. --json flag is accepted (not "unknown flag")
 #   2. stdout is valid JSON (via jq empty)
+# With --diagnostic, the command is allowed to exit 1 as well as 0 —
+# diagnostic commands (e.g. `ao doctor`) exit 1 when findings are present,
+# which is a contractual outcome, not a failure. Exit codes >=2 still fail.
 test_json_cmd() {
+  local max_rc=0
+  if [[ "${1:-}" == "--diagnostic" ]]; then
+    max_rc=1
+    shift
+  fi
   local label="$1"; shift
   local stdout stderr rc
 
@@ -61,14 +69,14 @@ test_json_cmd() {
     return
   fi
 
-  if [[ $rc -ne 0 ]]; then
+  if [[ $rc -gt $max_rc ]]; then
     fail "$label — exited $rc with --json"
     return
   fi
 
   # Empty stdout: command ran but produced no output
   if [[ -z "$stdout" ]]; then
-    fail "$label — exited 0 but produced no JSON output"
+    fail "$label — produced no JSON output despite --json flag"
     return
   fi
 
@@ -86,7 +94,7 @@ echo "--- Core commands ---"
 test_json_cmd "ao version"          version
 test_json_cmd "ao config --show"    config --show
 test_json_cmd "ao status"           status
-test_json_cmd "ao doctor"           doctor
+test_json_cmd --diagnostic "ao doctor" doctor
 test_json_cmd "ao badge"            badge
 
 echo ""


### PR DESCRIPTION
## Summary
The `ao doctor` engine (PRs #281–#284) drifted three offline canaries. CI path-filtering skipped these on the doctor PRs themselves; they surfaced on a downstream PR. All three are doctor-stream drift — fixed here so the canary gate goes green.

- **json-flag-consistency** — `tests/cli/test-json-flag-consistency.sh` hard-failed on any non-zero exit, but `ao doctor --json` exits 1 by contract when findings exist. `test_json_cmd` now takes `--diagnostic` (accepts exit 0/1; ≥2 still fails), mirroring the `diagnostic` handling in `cli/cmd/ao/flag_matrix_test.go`. Errors 1 → 0 (16/16 pass).
- **cli-command-surface-matrix** — the 9 new `ao doctor` subcommands grew the generated `COMMANDS.md` heading count 173/243 → 184/254. Updated the fixture's internal guard and the eval's `stdout_contains`.
- **distribution-install-update** — PR #283 changed `test-windows-smoke.ps1` from `$builtAO doctor --json` to plain `$builtAO doctor`; updated the `artifact_contains` expectation.

## Test plan
- [x] `tests/cli/test-json-flag-consistency.sh` → `Errors: 0` (16/16)
- [x] `cli-command-surface-smoke.sh` → `cli-command-headings: top=70 sub=184 all=254` + `cli-help-matrix-ok`
- [x] both canary JSONs valid; `test-windows-smoke.ps1` contains `$builtAO doctor`