### PR TITLE
feat(loop): enforce vertical-slice bead evidence

### DIFF
--- a/cli/cmd/ao/flywheel_citation_feedback.go
+++ b/cli/cmd/ao/flywheel_citation_feedback.go
@@ -539,10 +539,15 @@ type qualitySignalEntry struct {
 }
 
 // processQualitySignalFeedback reads correction signals from
-// .agents/signals/session-quality.jsonl and applies negative utility
-// adjustments to skills that were loaded during the given session.
+// .agents/signals/session-quality.jsonl and records quality feedback for
+// skills that were loaded during the given session.
 // Returns the number of correction signals found for the session.
-func processQualitySignalFeedback(cwd, sessionID string, mutateArtifacts bool) (int, error) {
+func processQualitySignalFeedback(cwd, sessionID string, _ bool) (int, error) {
+	targetAliases := qualityFeedbackSessionAliases(sessionID)
+	if len(targetAliases) == 0 {
+		return 0, nil
+	}
+
 	signalsPath := filepath.Join(cwd, ".agents", "signals", "session-quality.jsonl")
 	f, err := os.Open(signalsPath)
 	if err != nil {
@@ -566,7 +571,7 @@ func processQualitySignalFeedback(cwd, sessionID string, mutateArtifacts bool) (
 		if err := json.Unmarshal(line, &entry); err != nil {
 			continue
 		}
-		if entry.SessionID == sessionID && entry.SignalType == "correction" {
+		if entry.SignalType == "correction" && qualityFeedbackSessionMatches(entry.SessionID, targetAliases) {
 			correctionCount++
 		}
 	}
@@ -589,61 +594,15 @@ func processQualitySignalFeedback(cwd, sessionID string, mutateArtifacts bool) (
 		return correctionCount, fmt.Errorf("load citations for quality feedback: %w", err)
 	}
 
-	res := resolver.NewFileResolver(cwd)
-	appliedMutate := mutateArtifacts && !GetDryRun()
-
 	var feedbackEvents []FeedbackEvent
 	for _, c := range citations {
-		if c.CitationType != "skill_loaded" {
+		if canonicalCitationType(c.CitationType) != "skill_loaded" {
 			continue
 		}
-
-		learningID := extractLearningID(c.ArtifactPath)
-		path, resolveErr := res.Resolve(learningID)
-		if resolveErr != nil {
+		if !qualityFeedbackSessionMatches(c.SessionID, targetAliases) {
 			continue
 		}
-
-		if !appliedMutate {
-			currentUtility := parseUtilityFromFile(path)
-			event := FeedbackEvent{
-				SessionID:       sessionID,
-				ArtifactPath:    path,
-				CitationType:    "skill_loaded",
-				MetricNamespace: "quality-signal",
-				Decision:        "penalized",
-				Reason:          fmt.Sprintf("quality-correction-count-%d", correctionCount),
-				Reward:          penalty,
-				UtilityBefore:   currentUtility,
-				UtilityAfter:    currentUtility,
-				Alpha:           0,
-				RecordedAt:      time.Now(),
-			}
-			feedbackEvents = append(feedbackEvents, event)
-			continue
-		}
-
-		rewardCount := getLearningRewardCount(path)
-		alpha := annealedAlpha(types.DefaultAlpha, rewardCount)
-		oldUtility, newUtility, updateErr := updateLearningUtility(path, penalty, alpha)
-		if updateErr != nil {
-			continue
-		}
-
-		event := FeedbackEvent{
-			SessionID:       sessionID,
-			ArtifactPath:    path,
-			CitationType:    "skill_loaded",
-			MetricNamespace: "quality-signal",
-			Decision:        "penalized",
-			Reason:          fmt.Sprintf("quality-correction-count-%d", correctionCount),
-			Reward:          penalty,
-			UtilityBefore:   oldUtility,
-			UtilityAfter:    newUtility,
-			Alpha:           alpha,
-			RecordedAt:      time.Now(),
-		}
-		feedbackEvents = append(feedbackEvents, event)
+		feedbackEvents = append(feedbackEvents, qualityFeedbackSkillLoadedEvent(cwd, sessionID, c, correctionCount, penalty))
 	}
 
 	if !GetDryRun() && len(feedbackEvents) > 0 {
@@ -651,4 +610,107 @@ func processQualitySignalFeedback(cwd, sessionID string, mutateArtifacts bool) (
 	}
 
 	return correctionCount, nil
+}
+
+func qualityFeedbackSessionAliases(sessionID string) map[string]struct{} {
+	trimmed := strings.TrimSpace(sessionID)
+	if trimmed == "" {
+		return nil
+	}
+	aliases := make(map[string]struct{})
+	for _, alias := range sessionIDAliases(trimmed) {
+		if alias != "" {
+			aliases[alias] = struct{}{}
+		}
+	}
+	return aliases
+}
+
+func qualityFeedbackSessionMatches(sessionID string, targetAliases map[string]struct{}) bool {
+	trimmed := strings.TrimSpace(sessionID)
+	if trimmed == "" || len(targetAliases) == 0 {
+		return false
+	}
+	for _, alias := range sessionIDAliases(trimmed) {
+		if _, ok := targetAliases[alias]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func qualityFeedbackSkillLoadedEvent(cwd, sessionID string, citation types.CitationEvent, correctionCount int, penalty float64) FeedbackEvent {
+	path := canonicalArtifactPath(cwd, citation.ArtifactPath)
+	kind := qualityFeedbackArtifactKind(cwd, path)
+	currentUtility := qualityFeedbackCurrentUtility(path, kind)
+	return FeedbackEvent{
+		SessionID:       canonicalSessionID(sessionID),
+		ArtifactPath:    path,
+		ArtifactKind:    kind,
+		CitationType:    "skill_loaded",
+		MetricNamespace: "quality-signal",
+		Decision:        "audited",
+		Reason:          fmt.Sprintf("quality-correction-count-%d", correctionCount),
+		Reward:          penalty,
+		UtilityBefore:   currentUtility,
+		UtilityAfter:    currentUtility,
+		Alpha:           0,
+		RecordedAt:      time.Now(),
+	}
+}
+
+func qualityFeedbackCurrentUtility(path, kind string) float64 {
+	switch kind {
+	case "learning", "pattern":
+		return parseUtilityFromFile(path)
+	default:
+		return 0
+	}
+}
+
+func qualityFeedbackArtifactKind(cwd, artifactPath string) string {
+	switch {
+	case isSkillArtifactPath(cwd, artifactPath):
+		return "skill"
+	case isFindingArtifactPath(cwd, artifactPath):
+		return "finding"
+	case artifactPathUnder(cwd, artifactPath, ".agents", "patterns"):
+		return "pattern"
+	case artifactPathUnder(cwd, artifactPath, ".agents", "learnings"):
+		return "learning"
+	default:
+		return "unknown"
+	}
+}
+
+func isSkillArtifactPath(cwd, artifactPath string) bool {
+	rel := relativeArtifactPath(cwd, artifactPath)
+	if rel == "" || !strings.HasSuffix(rel, "/SKILL.md") {
+		return false
+	}
+	for _, prefix := range []string{"skills/", "skills-codex/", "skills-codex-overrides/"} {
+		if strings.HasPrefix(rel, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func artifactPathUnder(cwd, artifactPath string, parts ...string) bool {
+	path := filepath.ToSlash(canonicalArtifactPath(cwd, artifactPath))
+	root := filepath.ToSlash(canonicalArtifactPath(cwd, filepath.Join(parts...))) + "/"
+	return strings.HasPrefix(path, root)
+}
+
+func relativeArtifactPath(cwd, artifactPath string) string {
+	path := canonicalArtifactPath(cwd, artifactPath)
+	rel, err := filepath.Rel(cwd, path)
+	if err != nil {
+		return ""
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == ".." || strings.HasPrefix(rel, "../") {
+		return ""
+	}
+	return rel
 }

--- a/cli/cmd/ao/flywheel_citation_feedback_test.go
+++ b/cli/cmd/ao/flywheel_citation_feedback_test.go
@@ -456,6 +456,28 @@ func readCitationFeedbackEvent(t *testing.T, feedbackPath string) FeedbackEvent 
 	return event
 }
 
+func readCitationFeedbackEvents(t *testing.T, feedbackPath string) []FeedbackEvent {
+	t.Helper()
+
+	feedbackData, err := os.ReadFile(feedbackPath)
+	if err != nil {
+		t.Fatalf("feedback.jsonl not created: %v", err)
+	}
+	trimmed := strings.TrimSpace(string(feedbackData))
+	if trimmed == "" {
+		t.Fatal("feedback.jsonl is empty")
+	}
+	var events []FeedbackEvent
+	for _, line := range strings.Split(trimmed, "\n") {
+		var event FeedbackEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("failed to parse FeedbackEvent: %v", err)
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
 func assertCitationFeedbackEvent(t *testing.T, event FeedbackEvent) {
 	t.Helper()
 
@@ -982,5 +1004,168 @@ func TestProcessQualitySignalFeedback_MissingFile(t *testing.T) {
 	}
 	if correctionCount != 0 {
 		t.Errorf("expected 0 corrections for missing file, got %d", correctionCount)
+	}
+}
+
+func TestProcessQualitySignalFeedback_FiltersSkillLoadedBySessionAndAuditsSkillArtifact(t *testing.T) {
+	tmp := t.TempDir()
+	aoDir := filepath.Join(tmp, ".agents", "ao")
+	if err := os.MkdirAll(aoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeQualitySignalEntries(t, tmp, []qualitySignalEntry{
+		{Timestamp: "2026-05-04T00:00:00Z", SignalType: "correction", Detail: "target", SessionID: "session-a"},
+		{Timestamp: "2026-05-04T00:00:01Z", SignalType: "correction", Detail: "other", SessionID: "session-b"},
+	})
+	writeCitationFeedbackCitations(t, aoDir, []types.CitationEvent{
+		{
+			ArtifactPath:  "skills/alpha/SKILL.md",
+			SessionID:     "session-a",
+			CitedAt:       time.Now(),
+			CitationType:  "skill_loaded",
+			WorkspacePath: tmp,
+		},
+		{
+			ArtifactPath:  "skills/beta/SKILL.md",
+			SessionID:     "session-b",
+			CitedAt:       time.Now(),
+			CitationType:  "skill_loaded",
+			WorkspacePath: tmp,
+		},
+	})
+
+	correctionCount, err := processQualitySignalFeedback(tmp, "session-a", true)
+	if err != nil {
+		t.Fatalf("processQualitySignalFeedback returned error: %v", err)
+	}
+	if correctionCount != 1 {
+		t.Fatalf("expected 1 correction, got %d", correctionCount)
+	}
+
+	events := readCitationFeedbackEvents(t, filepath.Join(aoDir, "feedback.jsonl"))
+	if len(events) != 1 {
+		t.Fatalf("expected 1 feedback event, got %d", len(events))
+	}
+	event := events[0]
+	if event.SessionID != "session-a" {
+		t.Errorf("SessionID = %q, want session-a", event.SessionID)
+	}
+	if event.ArtifactKind != "skill" {
+		t.Errorf("ArtifactKind = %q, want skill", event.ArtifactKind)
+	}
+	if !strings.HasSuffix(filepath.ToSlash(event.ArtifactPath), "/skills/alpha/SKILL.md") {
+		t.Errorf("ArtifactPath = %q, want alpha skill path", event.ArtifactPath)
+	}
+	if event.Decision != "audited" {
+		t.Errorf("Decision = %q, want audited", event.Decision)
+	}
+	if event.Reward != -0.1 {
+		t.Errorf("Reward = %f, want -0.1", event.Reward)
+	}
+	if event.UtilityBefore != 0 || event.UtilityAfter != 0 || event.Alpha != 0 {
+		t.Errorf("skill audit mutated utility fields: before=%f after=%f alpha=%f", event.UtilityBefore, event.UtilityAfter, event.Alpha)
+	}
+}
+
+func TestProcessQualitySignalFeedback_EmptySessionDoesNotAuditSkillLoadedCitations(t *testing.T) {
+	tmp := t.TempDir()
+	aoDir := filepath.Join(tmp, ".agents", "ao")
+	if err := os.MkdirAll(aoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeQualitySignalEntries(t, tmp, []qualitySignalEntry{
+		{Timestamp: "2026-05-04T00:00:00Z", SignalType: "correction", Detail: "empty", SessionID: ""},
+	})
+	writeCitationFeedbackCitations(t, aoDir, []types.CitationEvent{
+		{
+			ArtifactPath: "skills/empty/SKILL.md",
+			SessionID:    "",
+			CitedAt:      time.Now(),
+			CitationType: "skill_loaded",
+		},
+	})
+
+	correctionCount, err := processQualitySignalFeedback(tmp, "", true)
+	if err != nil {
+		t.Fatalf("processQualitySignalFeedback returned error: %v", err)
+	}
+	if correctionCount != 0 {
+		t.Fatalf("expected 0 corrections for empty target session, got %d", correctionCount)
+	}
+	if _, err := os.Stat(filepath.Join(aoDir, "feedback.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("feedback.jsonl should not be created for empty target session, err=%v", err)
+	}
+}
+
+func TestProcessQualitySignalFeedback_SkillLoadedLearningPathAuditedWithoutMutation(t *testing.T) {
+	tmp := t.TempDir()
+	aoDir := filepath.Join(tmp, ".agents", "ao")
+	if err := os.MkdirAll(aoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	learningPath := filepath.Join(tmp, ".agents", "learnings", "candidate.md")
+	if err := os.MkdirAll(filepath.Dir(learningPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	learningContent := "---\nutility: 0.8\nreward_count: 0\n---\n# Candidate\n"
+	if err := os.WriteFile(learningPath, []byte(learningContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeQualitySignalEntries(t, tmp, []qualitySignalEntry{
+		{Timestamp: "2026-05-04T00:00:00Z", SignalType: "correction", Detail: "target", SessionID: "session-learning"},
+	})
+	writeCitationFeedbackCitations(t, aoDir, []types.CitationEvent{
+		{
+			ArtifactPath: ".agents/learnings/candidate.md",
+			SessionID:    "session-learning",
+			CitedAt:      time.Now(),
+			CitationType: "skill_loaded",
+		},
+	})
+
+	correctionCount, err := processQualitySignalFeedback(tmp, "session-learning", true)
+	if err != nil {
+		t.Fatalf("processQualitySignalFeedback returned error: %v", err)
+	}
+	if correctionCount != 1 {
+		t.Fatalf("expected 1 correction, got %d", correctionCount)
+	}
+	if got := parseUtilityFromFile(learningPath); got != 0.8 {
+		t.Fatalf("learning utility mutated to %f, want 0.8", got)
+	}
+
+	events := readCitationFeedbackEvents(t, filepath.Join(aoDir, "feedback.jsonl"))
+	if len(events) != 1 {
+		t.Fatalf("expected 1 feedback event, got %d", len(events))
+	}
+	event := events[0]
+	if event.ArtifactKind != "learning" {
+		t.Errorf("ArtifactKind = %q, want learning", event.ArtifactKind)
+	}
+	if event.Decision != "audited" {
+		t.Errorf("Decision = %q, want audited", event.Decision)
+	}
+	if event.UtilityBefore != 0.8 || event.UtilityAfter != 0.8 || event.Alpha != 0 {
+		t.Errorf("learning audit should not mutate utility fields: before=%f after=%f alpha=%f", event.UtilityBefore, event.UtilityAfter, event.Alpha)
+	}
+}
+
+func writeQualitySignalEntries(t *testing.T, dir string, entries []qualitySignalEntry) {
+	t.Helper()
+
+	signalsDir := filepath.Join(dir, ".agents", "signals")
+	if err := os.MkdirAll(signalsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var lines []string
+	for _, entry := range entries {
+		data, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lines = append(lines, string(data))
+	}
+	if err := os.WriteFile(filepath.Join(signalsDir, "session-quality.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/cli/cmd/ao/flywheel_close_loop.go
+++ b/cli/cmd/ao/flywheel_close_loop.go
@@ -158,13 +158,13 @@ func performFlywheelCloseLoopWithCitationMutation(cwd, pendingDir string, thresh
 		return flywheelCloseLoopResult{}, err
 	}
 
-	// Quality-signal feedback: apply negative utility to skills loaded in
+	// Quality-signal feedback: record correction signals for skills loaded in
 	// sessions where the user had to correct the agent.
 	sessionID := canonicalSessionID("")
 	if qualityCorrections, qErr := processQualitySignalFeedback(cwd, sessionID, mutateCitationArtifacts); qErr != nil {
 		fmt.Fprintf(os.Stderr, "WARN: quality-signal feedback: %v\n", qErr)
 	} else if qualityCorrections > 0 {
-		VerbosePrintf("quality-signal feedback: %d corrections applied to skill-loaded citations\n", qualityCorrections)
+		VerbosePrintf("quality-signal feedback: %d corrections matched for skill-loaded citations\n", qualityCorrections)
 	}
 
 	return convertLifecycleCloseLoopResult(res), nil

--- a/cli/cmd/ao/loop_append_test.go
+++ b/cli/cmd/ao/loop_append_test.go
@@ -101,19 +101,28 @@ func TestLoadCycleTrace_EmptyArgYieldsNil(t *testing.T) {
 }
 
 func TestLoadCycleTrace_InlineJSON(t *testing.T) {
-	tr, err := loadCycleTrace(`{"goal_hypothesis":"raise pass rate","ratchet_action":"record implement"}`)
+	tr, err := loadCycleTrace(`{"goal_hypothesis":"raise pass rate","ratchet_action":"record implement","bead_id":"soc-z4tl","acceptance_examples":["Scenario: closeout maps evidence"],"validation_commands":["go test ./cmd/ao -run TestLoadCycleTrace"],"closeout_verdict":"passed"}`)
 	if err != nil {
 		t.Fatalf("inline JSON: %v", err)
 	}
 	if tr == nil || tr.GoalHypothesis != "raise pass rate" || tr.RatchetAction != "record implement" {
 		t.Fatalf("inline JSON parsed to %+v", tr)
 	}
+	if tr.BeadID != "soc-z4tl" || tr.CloseoutVerdict != "passed" {
+		t.Fatalf("inline closeout fields parsed to %+v", tr)
+	}
+	if len(tr.AcceptanceExamples) != 1 || tr.AcceptanceExamples[0] != "Scenario: closeout maps evidence" {
+		t.Fatalf("inline acceptance examples parsed to %+v", tr.AcceptanceExamples)
+	}
+	if len(tr.ValidationCommands) != 1 || tr.ValidationCommands[0] != "go test ./cmd/ao -run TestLoadCycleTrace" {
+		t.Fatalf("inline validation commands parsed to %+v", tr.ValidationCommands)
+	}
 }
 
 func TestLoadCycleTrace_FromFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "trace.json")
-	if err := os.WriteFile(path, []byte(`{"exemption_reason":"trivial typo fix"}`), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(`{"exemption_reason":"trivial typo fix","bead_id":"soc-file","validation_commands":["bash scripts/check-loop-shape.sh --self-test"],"closeout_verdict":"exempt"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	tr, err := loadCycleTrace(path)
@@ -122,6 +131,12 @@ func TestLoadCycleTrace_FromFile(t *testing.T) {
 	}
 	if tr == nil || tr.ExemptionReason != "trivial typo fix" {
 		t.Fatalf("file arg parsed to %+v", tr)
+	}
+	if tr.BeadID != "soc-file" || tr.CloseoutVerdict != "exempt" {
+		t.Fatalf("file closeout fields parsed to %+v", tr)
+	}
+	if len(tr.ValidationCommands) != 1 || tr.ValidationCommands[0] != "bash scripts/check-loop-shape.sh --self-test" {
+		t.Fatalf("file validation commands parsed to %+v", tr.ValidationCommands)
 	}
 }
 

--- a/cli/cmd/ao/loop_writer_adapter_test.go
+++ b/cli/cmd/ao/loop_writer_adapter_test.go
@@ -167,6 +167,10 @@ func TestProductionLoopWriter_RoundTripsTrace(t *testing.T) {
 			ValidationEvidence: "go test ./... green",
 			RatchetAction:      "ao ratchet record implement",
 			GoalReshape:        "gap closed",
+			BeadID:             "soc-z4tl",
+			AcceptanceExamples: []string{"Scenario: closeout maps evidence"},
+			ValidationCommands: []string{"go test ./cmd/ao -run TestProductionLoopWriter_RoundTripsTrace"},
+			CloseoutVerdict:    "passed",
 		},
 	}
 	if _, err := w.Append(context.Background(), traced); err != nil {
@@ -197,6 +201,15 @@ func TestProductionLoopWriter_RoundTripsTrace(t *testing.T) {
 	}
 	if entries[0].Trace.RatchetAction != "ao ratchet record implement" {
 		t.Errorf("round-trip RatchetAction = %q, want \"ao ratchet record implement\"", entries[0].Trace.RatchetAction)
+	}
+	if entries[0].Trace.BeadID != "soc-z4tl" || entries[0].Trace.CloseoutVerdict != "passed" {
+		t.Errorf("round-trip closeout fields = %+v", entries[0].Trace)
+	}
+	if len(entries[0].Trace.AcceptanceExamples) != 1 || entries[0].Trace.AcceptanceExamples[0] != "Scenario: closeout maps evidence" {
+		t.Errorf("round-trip AcceptanceExamples = %+v", entries[0].Trace.AcceptanceExamples)
+	}
+	if len(entries[0].Trace.ValidationCommands) != 1 || entries[0].Trace.ValidationCommands[0] != "go test ./cmd/ao -run TestProductionLoopWriter_RoundTripsTrace" {
+		t.Errorf("round-trip ValidationCommands = %+v", entries[0].Trace.ValidationCommands)
 	}
 	if entries[1].Trace != nil {
 		t.Errorf("trace-less entry read back a non-nil Trace: %+v", entries[1].Trace)

--- a/cli/internal/lifecycle/feedback_loop_helpers.go
+++ b/cli/internal/lifecycle/feedback_loop_helpers.go
@@ -15,6 +15,7 @@ import (
 type FeedbackLoopEvent struct {
 	SessionID       string    `json:"session_id"`
 	ArtifactPath    string    `json:"artifact_path"`
+	ArtifactKind    string    `json:"artifact_kind,omitempty"`
 	WorkspacePath   string    `json:"workspace_path,omitempty"`
 	CitationType    string    `json:"citation_type,omitempty"`
 	MetricNamespace string    `json:"metric_namespace,omitempty"`

--- a/cli/internal/ports/loop_trace.go
+++ b/cli/internal/ports/loop_trace.go
@@ -14,17 +14,21 @@ package ports
 // fields are omitempty so a partially-recorded or exempt trace stays
 // compact on disk. soc-y5vh.9 (epic soc-y5vh, BC3 Loop).
 type CycleTrace struct {
-	GoalHypothesis     string `json:"goal_hypothesis,omitempty"`
-	SelectedGap        string `json:"selected_gap,omitempty"`
-	Gherkin            string `json:"gherkin,omitempty"`
-	ExemptionReason    string `json:"exemption_reason,omitempty"`
-	FirstFailingProof  string `json:"first_failing_proof,omitempty"`
-	RedEvidence        string `json:"red_evidence,omitempty"`
-	GreenEvidence      string `json:"green_evidence,omitempty"`
-	RefactorNote       string `json:"refactor_note,omitempty"`
-	ValidationEvidence string `json:"validation_evidence,omitempty"`
-	RatchetAction      string `json:"ratchet_action,omitempty"`
-	GoalReshape        string `json:"goal_reshape,omitempty"`
+	GoalHypothesis     string   `json:"goal_hypothesis,omitempty"`
+	SelectedGap        string   `json:"selected_gap,omitempty"`
+	Gherkin            string   `json:"gherkin,omitempty"`
+	ExemptionReason    string   `json:"exemption_reason,omitempty"`
+	FirstFailingProof  string   `json:"first_failing_proof,omitempty"`
+	RedEvidence        string   `json:"red_evidence,omitempty"`
+	GreenEvidence      string   `json:"green_evidence,omitempty"`
+	RefactorNote       string   `json:"refactor_note,omitempty"`
+	ValidationEvidence string   `json:"validation_evidence,omitempty"`
+	RatchetAction      string   `json:"ratchet_action,omitempty"`
+	GoalReshape        string   `json:"goal_reshape,omitempty"`
+	BeadID             string   `json:"bead_id,omitempty"`
+	AcceptanceExamples []string `json:"acceptance_examples,omitempty"`
+	ValidationCommands []string `json:"validation_commands,omitempty"`
+	CloseoutVerdict    string   `json:"closeout_verdict,omitempty"`
 }
 
 // traceField pairs a kernel field's on-disk name with an accessor, so

--- a/docs/architecture/operating-loop.md
+++ b/docs/architecture/operating-loop.md
@@ -81,6 +81,11 @@ Any failed row → slices run **sequential**. Skill: `/plan` declares the wave; 
 
 Every Given/When/Then maps to a passing test. Every non-goal is still untouched. Every rollback path is reachable. Evidence is recorded. Activity logs do not close beads. Skills: `/validation`, `/council`, `/vibe`.
 
+When a cycle is logged, the CycleTrace can carry the closeout join explicitly:
+`bead_id`, `acceptance_examples`, `validation_commands`, and
+`closeout_verdict`. That join is the reviewer path from a bead's Gherkin
+example to the test, gate, or eval that proved it.
+
 ### 7. Capture evidence and learning, then ratchet
 
 Two outputs per loop turn — evidence into `.agents/ratchet/` and the bead; learnings only if they cleared the promotion bar (next section). Skills: `/post-mortem`, `/forge`, `/retro`, `/ratchet`, `/flywheel`, `/harvest`.

--- a/docs/templates/intent-issue.md
+++ b/docs/templates/intent-issue.md
@@ -3,6 +3,8 @@
 > Copy this file when shaping a new piece of work. The issue is **not ready** until every section below is filled in and the acceptance examples are testable. Skill that produces this artifact: [`/discovery`](../../skills/discovery/SKILL.md) (and `/brainstorm` for the earlier free-text → structured pass).
 >
 > See [`docs/architecture/operating-loop.md`](../architecture/operating-loop.md) for why this template exists and where it sits in the loop.
+>
+> Fast path: `scripts/render-intent-bead.sh --help` renders a Directive 12 compliant dry-run body and labels for `bd create`.
 
 ---
 
@@ -13,6 +15,7 @@
 ## Bounded context
 
 > Which bounded context from [`docs/contracts/context-map.md`](../contracts/context-map.md) does this work belong to? If it crosses contexts, this is two issues, not one.
+> The bead must carry exactly one matching label: `bc-corpus`, `bc-validation`, `bc-loop`, `bc-factory`, or `bc-runtime`.
 
 ## Domain terms
 
@@ -68,7 +71,7 @@ Feature: <feature name from above>
 
 > Initial slice list, one per acceptance example (minimum). `/plan` will refine this into the final slice + wave plan. Each slice must have a nameable first failing test, a write-scope sketch, and a bounded-context tag (defaults to the one above).
 
-| Slice ID | Scenario | First failing test (proposed) | Write scope (proposed) | Notes |
+| Slice ID | Scenario | First failing proof/test (proposed) | Write scope (proposed) | Notes |
 |----------|----------|-------------------------------|------------------------|-------|
 | S1 | <name from acceptance examples> | `<test path:name>` | `<files / packages>` | <e.g., "depends on S2 — sequential"> |
 | S2 | … | … | … | … |
@@ -87,11 +90,11 @@ Feature: <feature name from above>
 A `/pre-mortem` or `/council` must verify these before the issue leaves discovery:
 
 - [ ] Acceptance examples are written in Given/When/Then and each is testable as written
-- [ ] Bounded context is named and present in the context map
+- [ ] Bounded context is named, present in the context map, and represented by exactly one `bc-*` label
 - [ ] All domain terms used are registered in the ubiquitous-language register
 - [ ] Non-goals are explicit
 - [ ] Rollback or containment path is named (or its absence is named explicitly)
 - [ ] Evidence list points to concrete artifacts, not vague descriptions
-- [ ] Slice candidates exist (at least one per acceptance example)
+- [ ] Slice candidates exist (at least one per acceptance example) and each has a first failing proof/test
 
 If any box is unchecked, the issue is not ready — send it back to `/discovery` or `/brainstorm`.

--- a/docs/templates/slice-validation.md
+++ b/docs/templates/slice-validation.md
@@ -15,8 +15,9 @@
 ## Slice-level validation
 
 > One row per slice from the intent issue's slice candidates. Each slice must have a **first failing test** before any implementation begins (the TDD discipline of move 4 in the operating loop).
+> In beads and CycleTrace payloads this may be named **First failing proof** when the proof is a gate, smoke script, or eval rather than a Go/Python unit test.
 
-| Slice ID | Behavior under test | First failing test | Implementation scope | Validation lane | Evidence on green | Acceptance example covered |
+| Slice ID | Behavior under test | First failing proof/test | Implementation scope | Validation lane | Evidence on green | Acceptance example covered |
 |----------|--------------------|--------------------|----------------------|-----------------|--------------------|----------------------------|
 | S1 | <single Given/When/Then behavior> | `<file:test_name>` — must fail for the right reason (missing behavior, not syntax) | `<files / packages this slice modifies>` | L1 unit / L2 integration / L3 e2e / property / snapshot / council | <test verdict + snapshot id + ratchet entry> | <Scenario name from intent issue> |
 | S2 | … | … | … | … | … | … |
@@ -81,7 +82,7 @@
 
 ## Closing checklist
 
-- [ ] Every slice has a first failing test linked, and that test failed before implementation began
+- [ ] Every slice has a first failing proof/test linked, and that proof failed before implementation began
 - [ ] Every slice's evidence row is filled in with a concrete artifact, not a description
 - [ ] If any slices ran in parallel, every wave-validity row was checked at the time of wave start
 - [ ] Every acceptance example from the intent issue maps to at least one passing test

--- a/scripts/check-loop-shape.sh
+++ b/scripts/check-loop-shape.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# practices: [process-gates-first, ai-assisted-dev, resilience-patterns]
+# practices: [bdd-gherkin, ddd-bounded-context, tdd]
 # check-loop-shape.sh — warn-only loop-shape gate for non-trivial beads.
 #
 # Implements the initial gate declared by GOALS.md Directive 12: beads tagged
-# `non-trivial` should expose loop shape before implementation — at least one
-# Gherkin block (Given/When/Then) and at least one slice candidate in the
-# issue body. This is the BDD/Gherkin/XP operating loop's mechanical warning.
+# `non-trivial` should expose loop shape before implementation — exactly one
+# bounded context label, at least one Gherkin block (Given/When/Then), at least
+# one slice candidate, and one first-failing proof. This is the
+# BDD/Gherkin/DDD/XP operating loop's mechanical warning.
 #
 # Posture: WARN-ONLY. The script exits 0 even when beads are missing loop
 # shape, so it never blocks a push. It flips to blocking only when invoked
@@ -66,25 +67,46 @@ analyze_beads() {
   local json="$1"
   local rows
   rows=$(printf '%s' "$json" | jq -r '
+    def evidence_text:
+      [(.description // ""), (.acceptance_criteria // ""), (.notes // "")]
+      | join("\n");
+    def context_labels:
+      [(.labels // [])[]
+       | select(test("^bc-(corpus|validation|loop|factory|runtime)$"))]
+      | unique;
     [ .[]
       | select((.labels // []) | index("non-trivial"))
       | { id: .id,
-          gherkin: (((.description // "")
-            | test("Given") and test("When") and test("Then"))),
-          slice: (((.description // "")
-            | test("(?i)slice") or test("\\bS[0-9]"))) }
-    ] | .[] | [.id, (.gherkin|tostring), (.slice|tostring)] | @tsv
+          gherkin: ((evidence_text | test("\\bGiven\\b") and test("\\bWhen\\b") and test("\\bThen\\b"))),
+          slice: ((evidence_text | test("(?i)\\bslice(s| candidates)?\\b") or test("\\bS[0-9]+\\b"))),
+          proof: ((evidence_text | test("(?i)first[ _-]*failing[ _-]*(proof|test)"))),
+          contexts: context_labels }
+    ] | .[] | [.id, (.gherkin|tostring), (.slice|tostring), (.proof|tostring), ((.contexts|length)|tostring), (.contexts|join(","))] | @tsv
   ' 2>/dev/null)
 
   local offenders=0
   if [ -n "$rows" ]; then
-    while IFS=$'\t' read -r id gherkin slice; do
+    while IFS=$'\t' read -r id gherkin slice proof context_count contexts; do
       [ -z "$id" ] && continue
       local missing=""
-      [ "$gherkin" != "true" ] && missing="Gherkin block (Given/When/Then)"
+      if [ "$context_count" != "1" ]; then
+        missing="bounded context label (exactly one of bc-corpus|bc-validation|bc-loop|bc-factory|bc-runtime"
+        if [ -n "$contexts" ]; then
+          missing="$missing; found $contexts"
+        fi
+        missing="$missing)"
+      fi
+      if [ "$gherkin" != "true" ]; then
+        [ -n "$missing" ] && missing="$missing and "
+        missing="${missing}Gherkin block (Given/When/Then)"
+      fi
       if [ "$slice" != "true" ]; then
         [ -n "$missing" ] && missing="$missing and "
         missing="${missing}slice candidate"
+      fi
+      if [ "$proof" != "true" ]; then
+        [ -n "$missing" ] && missing="$missing and "
+        missing="${missing}first failing proof"
       fi
       if [ -n "$missing" ]; then
         echo "WARN: $id — non-trivial bead is missing: $missing"
@@ -99,12 +121,22 @@ self_test() {
   local fixture
   fixture=$(cat <<'EOF'
 [
-  { "id": "fix-good",  "labels": ["non-trivial", "xp"],
-    "description": "Feature: x\n  Scenario: y\n    Given a\n    When b\n    Then c\nSlice candidates: S1 do the thing" },
-  { "id": "fix-nogherkin", "labels": ["non-trivial"],
-    "description": "Just do the work. Slice S1 covers it." },
-  { "id": "fix-noslice", "labels": ["non-trivial"],
-    "description": "Given a\n  When b\n  Then c" },
+  { "id": "fix-good",  "labels": ["non-trivial", "bc-loop", "xp"],
+    "description": "Feature: x\n  Scenario: y\n    Given a\n    When b\n    Then c\nSlice candidates: S1 do the thing\nFirst failing proof: go test ./..." },
+  { "id": "fix-split-fields", "labels": ["non-trivial", "bc-corpus"],
+    "description": "Problem statement only.",
+    "acceptance_criteria": "Slice candidates: S1 do the thing\nFirst failing proof: go test ./...",
+    "notes": "Feature: x\n  Scenario: y\n    Given a\n    When b\n    Then c" },
+  { "id": "fix-nogherkin", "labels": ["non-trivial", "bc-loop"],
+    "description": "Just do the work. Slice S1 covers it. First failing proof: go test ./..." },
+  { "id": "fix-noslice", "labels": ["non-trivial", "bc-loop"],
+    "description": "Given a\n  When b\n  Then c\nFirst failing proof: go test ./..." },
+  { "id": "fix-nocontext", "labels": ["non-trivial"],
+    "description": "Given a\nWhen b\nThen c\nSlice candidates: S1\nFirst failing proof: go test ./..." },
+  { "id": "fix-multicontext", "labels": ["non-trivial", "bc-loop", "bc-corpus"],
+    "description": "Given a\nWhen b\nThen c\nSlice candidates: S1\nFirst failing proof: go test ./..." },
+  { "id": "fix-noproof", "labels": ["non-trivial", "bc-loop"],
+    "description": "Given a\nWhen b\nThen c\nSlice candidates: S1" },
   { "id": "fix-trivial", "labels": ["chore"],
     "description": "rename a variable" }
 ]
@@ -116,8 +148,8 @@ EOF
   count=$(printf '%s\n' "$out" | sed -n 's/^OFFENDERS: //p')
   local fails=0
 
-  if [ "$count" != "2" ]; then
-    echo "SELF-TEST FAIL: expected 2 offenders, got '$count'" >&2
+  if [ "$count" != "5" ]; then
+    echo "SELF-TEST FAIL: expected 5 offenders, got '$count'" >&2
     fails=$((fails + 1))
   fi
   if ! printf '%s\n' "$out" | grep -q "^WARN: fix-nogherkin .*Gherkin block"; then
@@ -128,8 +160,24 @@ EOF
     echo "SELF-TEST FAIL: fix-noslice should warn about a missing slice candidate" >&2
     fails=$((fails + 1))
   fi
+  if ! printf '%s\n' "$out" | grep -q "^WARN: fix-nocontext .*bounded context label"; then
+    echo "SELF-TEST FAIL: fix-nocontext should warn about a missing bounded context label" >&2
+    fails=$((fails + 1))
+  fi
+  if ! printf '%s\n' "$out" | grep -q "^WARN: fix-multicontext .*bounded context label"; then
+    echo "SELF-TEST FAIL: fix-multicontext should warn about multiple bounded context labels" >&2
+    fails=$((fails + 1))
+  fi
+  if ! printf '%s\n' "$out" | grep -q "^WARN: fix-noproof .*first failing proof"; then
+    echo "SELF-TEST FAIL: fix-noproof should warn about a missing first failing proof" >&2
+    fails=$((fails + 1))
+  fi
   if printf '%s\n' "$out" | grep -q "^WARN: fix-good"; then
     echo "SELF-TEST FAIL: fix-good has full loop shape and must not warn" >&2
+    fails=$((fails + 1))
+  fi
+  if printf '%s\n' "$out" | grep -q "^WARN: fix-split-fields"; then
+    echo "SELF-TEST FAIL: fix-split-fields has evidence across bd fields and must not warn" >&2
     fails=$((fails + 1))
   fi
   if printf '%s\n' "$out" | grep -q "^WARN: fix-trivial"; then

--- a/scripts/render-intent-bead.sh
+++ b/scripts/render-intent-bead.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# practices: [bdd-gherkin, ddd-bounded-context, tdd]
+# Render a Directive 12 compliant intent-bead body.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/render-intent-bead.sh --title TEXT --context bc-loop \
+  --scenario TEXT --given TEXT --when TEXT --then TEXT \
+  --slice TEXT --proof COMMAND [options]
+
+Required:
+  --title TEXT          Bead title / feature name
+  --context bc-*        Exactly one bounded context label:
+                        bc-corpus, bc-validation, bc-loop, bc-factory, bc-runtime
+  --scenario TEXT       Gherkin scenario name
+  --given TEXT          Gherkin Given line body
+  --when TEXT           Gherkin When line body
+  --then TEXT           Gherkin Then line body
+  --slice TEXT          Vertical slice description
+  --proof COMMAND       First failing proof command or test name
+
+Optional:
+  --slice-id ID         Slice id (default: S1)
+  --write-scope TEXT    Proposed write scope (default: TBD)
+  --json                Emit a bd-like JSON object instead of dry-run text
+  -h, --help            Show this help
+
+The text output is designed to be copied into:
+  bd create --body-file <file> --labels non-trivial,<context>,operating-loop,bdd,ddd,xp
+EOF
+}
+
+die() {
+  echo "render-intent-bead: $*" >&2
+  exit 2
+}
+
+TITLE=""
+CONTEXT=""
+SCENARIO=""
+GIVEN=""
+WHEN=""
+THEN=""
+SLICE=""
+SLICE_ID="S1"
+PROOF=""
+WRITE_SCOPE="TBD"
+JSON=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --title) TITLE="${2:-}"; shift 2 ;;
+    --context) CONTEXT="${2:-}"; shift 2 ;;
+    --scenario) SCENARIO="${2:-}"; shift 2 ;;
+    --given) GIVEN="${2:-}"; shift 2 ;;
+    --when) WHEN="${2:-}"; shift 2 ;;
+    --then) THEN="${2:-}"; shift 2 ;;
+    --slice) SLICE="${2:-}"; shift 2 ;;
+    --slice-id) SLICE_ID="${2:-}"; shift 2 ;;
+    --proof) PROOF="${2:-}"; shift 2 ;;
+    --write-scope) WRITE_SCOPE="${2:-}"; shift 2 ;;
+    --json) JSON=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+for pair in \
+  "title:$TITLE" \
+  "context:$CONTEXT" \
+  "scenario:$SCENARIO" \
+  "given:$GIVEN" \
+  "when:$WHEN" \
+  "then:$THEN" \
+  "slice:$SLICE" \
+  "proof:$PROOF"; do
+  name="${pair%%:*}"
+  value="${pair#*:}"
+  [ -n "$value" ] || die "--$name is required"
+done
+
+case "$CONTEXT" in
+  bc-corpus|bc-validation|bc-loop|bc-factory|bc-runtime) ;;
+  *) die "--context must be one of bc-corpus|bc-validation|bc-loop|bc-factory|bc-runtime" ;;
+esac
+
+LABELS="non-trivial,$CONTEXT,operating-loop,bdd,ddd,xp"
+
+BODY="$(
+  cat <<EOF
+Problem:
+<Describe the observed gap in product/runtime terms.>
+
+Bounded context: $CONTEXT
+Labels: $LABELS
+
+BDD:
+\`\`\`gherkin
+Feature: $TITLE
+  Scenario: $SCENARIO
+    Given $GIVEN
+    When $WHEN
+    Then $THEN
+\`\`\`
+
+Slice candidates:
+- $SLICE_ID: $SLICE
+  - First failing proof: $PROOF
+  - Write scope: $WRITE_SCOPE
+
+Validation evidence:
+- Red: run \`$PROOF\` before implementation and capture the expected failure.
+- Green: rerun \`$PROOF\` after implementation and capture the passing result.
+
+Residual gaps:
+- None known at creation.
+EOF
+)"
+
+if [ "$JSON" = true ]; then
+  command -v jq >/dev/null 2>&1 || die "jq is required for --json"
+  labels_json="$(printf '%s' "$LABELS" | jq -R 'split(",")')"
+  jq -n \
+    --arg id "intent-dry-run" \
+    --arg title "$TITLE" \
+    --arg description "$BODY" \
+    --argjson labels "$labels_json" \
+    '{id:$id,title:$title,status:"open",labels:$labels,description:$description}'
+  exit 0
+fi
+
+cat <<EOF
+Labels: $LABELS
+
+$BODY
+EOF

--- a/tests/scripts/test-render-intent-bead.sh
+++ b/tests/scripts/test-render-intent-bead.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# practices: [bdd-gherkin, tdd]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+TEXT_OUT="$TMP_DIR/intent.txt"
+JSON_OBJ="$TMP_DIR/intent.json"
+JSON_ARRAY="$TMP_DIR/intent-array.json"
+
+"$ROOT/scripts/render-intent-bead.sh" \
+  --title "Loop shape helper smoke" \
+  --context bc-loop \
+  --scenario "Generated bead passes loop shape" \
+  --given "an operator has a non-trivial loop change" \
+  --when "the intent-bead helper renders a dry-run body" \
+  --then "the body contains BDD, bounded context, slice, and proof evidence" \
+  --slice "Render one compliant intent bead body" \
+  --proof "bash scripts/check-loop-shape.sh --self-test" \
+  --write-scope "scripts/render-intent-bead.sh tests/scripts/test-render-intent-bead.sh" \
+  >"$TEXT_OUT"
+
+grep -q "Labels: non-trivial,bc-loop,operating-loop,bdd,ddd,xp" "$TEXT_OUT"
+grep -q "Given an operator has a non-trivial loop change" "$TEXT_OUT"
+grep -q "First failing proof: bash scripts/check-loop-shape.sh --self-test" "$TEXT_OUT"
+
+"$ROOT/scripts/render-intent-bead.sh" \
+  --json \
+  --title "Loop shape helper smoke" \
+  --context bc-loop \
+  --scenario "Generated bead passes loop shape" \
+  --given "an operator has a non-trivial loop change" \
+  --when "the intent-bead helper renders a dry-run body" \
+  --then "the body contains BDD, bounded context, slice, and proof evidence" \
+  --slice "Render one compliant intent bead body" \
+  --proof "bash scripts/check-loop-shape.sh --self-test" \
+  --write-scope "scripts/render-intent-bead.sh tests/scripts/test-render-intent-bead.sh" \
+  >"$JSON_OBJ"
+
+jq -e '.labels | index("non-trivial") and index("bc-loop")' "$JSON_OBJ" >/dev/null
+jq -s '.' "$JSON_OBJ" >"$JSON_ARRAY"
+bash "$ROOT/scripts/check-loop-shape.sh" --strict --json "$JSON_ARRAY" >/dev/null
+
+echo "test-render-intent-bead: PASS"


### PR DESCRIPTION
## Summary

Enforce the new operating-loop shape for non-trivial beads and add the helper/evidence plumbing needed to run vertical slices through XP/BDD/DDD discipline.

## Changes

- Tighten `scripts/check-loop-shape.sh` so non-trivial beads require exactly one bounded-context label, Gherkin evidence, a slice candidate, and a first failing proof across description, acceptance criteria, and notes.
- Add `scripts/render-intent-bead.sh` plus a smoke test for generating compliant intent-bead bodies.
- Extend `CycleTrace` with advisory closeout fields that join bead acceptance examples to validation commands and verdicts.
- Adjust quality-signal feedback so skill-loaded citations are audited by session and artifact kind without mutating skill/learning utility.

## Test Plan

- [x] `git diff --check`
- [x] `shellcheck --severity=error scripts/check-loop-shape.sh scripts/render-intent-bead.sh tests/scripts/test-render-intent-bead.sh`
- [x] `bash scripts/check-loop-shape.sh --self-test`
- [x] `bash tests/scripts/test-render-intent-bead.sh`
- [x] `cd cli && go vet ./...`
- [x] `cd cli && go test ./... -count=1 -short`
- [x] `scripts/pre-push-gate.sh --fast`