### PR TITLE
feat(release): require workflow-rich HIL evidence

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -36,7 +36,7 @@ git tag vX.Y.Z
 
 - [ ] Local CI release gate passes (`./scripts/ci-local-release.sh`; once the target version is known, rerun as `./scripts/ci-local-release.sh --release-version X.Y.Z`)
 - [ ] Official readiness score is at least 8/10 (`release-readiness.json` has `release_status: pass`)
-- [ ] SIL/VIL/HIL evidence is attached (`hil-evidence.json`; use `--hil-target` or an explicit `--hil-waiver "reason"`)
+- [ ] SIL/VIL/HIL evidence is attached (`hil-evidence.json`; use a workflow-rich `--hil-target` or an explicit `--hil-waiver "reason"`)
 - [ ] Local gate artifacts generated (`.agents/releases/local-ci/<timestamp>/` includes SBOM, security report, readiness, and HIL evidence)
 - [ ] Release validation did not mutate tracked `.agents/findings/*` metadata; `scripts/ci-local-release.sh` guards this by default.
 - [ ] All tests pass locally (`cd cli && make test`)
@@ -191,7 +191,7 @@ Release validation is local-first and enforced by:
 ./scripts/ci-local-release.sh
 ```
 
-This local gate runs doc checks, manifest/schema checks, smoke/integration checks, hook and `ao rpi` smoke paths, binary validation, SBOM generation, security scans, AgentOps eval evidence, digital-twin/VIL evidence, and the release readiness score. Official release audits require SIL/VIL evidence plus HIL evidence or an explicit HIL waiver.
+This local gate runs doc checks, manifest/schema checks, smoke/integration checks, hook and `ao rpi` smoke paths, binary validation, SBOM generation, security scans, AgentOps eval evidence, digital-twin/VIL evidence, and the release readiness score. Official release audits require SIL/VIL evidence plus workflow-rich HIL evidence or an explicit HIL waiver.
 For command variants and expected release-E2E smoke markers, see [Release E2E Checklist](release-e2e-checklist.md).
 
 ## Failure Modes

--- a/docs/contracts/release-readiness.md
+++ b/docs/contracts/release-readiness.md
@@ -51,11 +51,17 @@ unless `--readiness-mode` overrides it.
 
 Targets are supplied with repeated `--hil-target` flags on the local release
 gate, with `AGENTOPS_RELEASE_HIL_TARGETS`, or by calling the HIL script
-directly:
+directly. Official targets must exercise more than `ao version`; evidence
+records the command fingerprint, OS/architecture/runtime identity, workflow
+checks, and optional release-version match.
 
 ```bash
-scripts/check-release-hil.sh --target 'local:bushido:ao version'
-scripts/check-release-hil.sh --target 'ssh:bushido:bushido:ao version'
+scripts/check-release-hil.sh \
+  --expected-version X.Y.Z \
+  --target 'local:bushido:ao version && ao init --help && ao hooks show && ao rpi status'
+scripts/check-release-hil.sh \
+  --expected-version X.Y.Z \
+  --target 'ssh:bushido:bushido:ao version && ao init --help && ao hooks show && ao rpi status'
 ```
 
 When no physical target is available for an official release, the release owner

--- a/docs/release-e2e-checklist.md
+++ b/docs/release-e2e-checklist.md
@@ -39,7 +39,9 @@ Reference test: `tests/integration/test-release-e2e-validation.sh`.
 Run:
 
 ```bash
-bash scripts/ci-local-release.sh --release-version X.Y.Z --hil-target 'local:bushido:ao version'
+bash scripts/ci-local-release.sh \
+  --release-version X.Y.Z \
+  --hil-target 'local:bushido:ao version && ao init --help && ao hooks show && ao rpi status'
 ```
 
 Expect:
@@ -54,7 +56,7 @@ Expect:
   - `hil_evidence`
   - `vil_evidence` and `digital_twin_evidence`
 - `.agents/releases/local-ci/<timestamp>/release-readiness.json` has `release_status: pass` and `release_readiness_score >= 8`
-- `.agents/releases/local-ci/<timestamp>/hil-evidence.json` has `status: pass` or `status: waived`
+- `.agents/releases/local-ci/<timestamp>/hil-evidence.json` has `status: pass` or `status: waived`; passing targets record OS/architecture/runtime identity, workflow checks, command fingerprint, and release-version verification
 - `.agents/releases/local-ci/<timestamp>/digital-twin-evidence.json` has `status: pass` and `dimensions.vil.status: pass`
 - `.agents/releases/local-ci/<timestamp>/eval-agentops-fast.json` has `status: pass`, and `eval-baseline-audit.json` has no `stale_suite_hashes`
 

--- a/scripts/check-release-hil.sh
+++ b/scripts/check-release-hil.sh
@@ -6,6 +6,7 @@ REQUIRED=false
 WAIVER="${AGENTOPS_RELEASE_HIL_WAIVER:-}"
 TIMEOUT_SECONDS="${AGENTOPS_RELEASE_HIL_TIMEOUT:-30}"
 ENV_TARGETS="${AGENTOPS_RELEASE_HIL_TARGETS:-}"
+EXPECTED_VERSION="${AGENTOPS_RELEASE_VERSION:-}"
 TARGETS=()
 
 usage() {
@@ -22,6 +23,8 @@ Options:
   --targets TEXT      Newline-separated target specs
   --required          Fail when no target is available unless --waiver is set
   --waiver TEXT       Record an explicit HIL waiver
+  --expected-version V
+                      Require target output to mention this release version
   --timeout SECONDS   Per-target timeout when timeout(1) is available (default: 30)
   -h, --help          Show this help
 
@@ -49,6 +52,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --waiver)
             WAIVER="${2:-}"
+            shift 2
+            ;;
+        --expected-version)
+            EXPECTED_VERSION="${2:-}"
             shift 2
             ;;
         --timeout)
@@ -87,6 +94,51 @@ timestamp() {
     date -u +%Y-%m-%dT%H:%M:%SZ
 }
 
+json_array_add() {
+    local current_json="$1"
+    local value="$2"
+
+    jq -c --arg value "$value" '. + [$value]' <<<"$current_json"
+}
+
+command_sha256() {
+    local command_string="$1"
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        printf '%s' "$command_string" | sha256sum | awk '{print $1}'
+    else
+        printf '%s' "$command_string" | shasum -a 256 | awk '{print $1}'
+    fi
+}
+
+detect_workflow_checks() {
+    local command_string="$1"
+    local checks='[]'
+
+    [[ "$command_string" == *"ao version"* ]] && checks="$(json_array_add "$checks" "ao-version")"
+    [[ "$command_string" == *"ao init"* ]] && checks="$(json_array_add "$checks" "ao-init")"
+    [[ "$command_string" == *"ao hooks"* ]] && checks="$(json_array_add "$checks" "ao-hooks")"
+    [[ "$command_string" == *"ao rpi"* ]] && checks="$(json_array_add "$checks" "ao-rpi")"
+    [[ "$command_string" == *" install"* || "$command_string" == install* ]] && checks="$(json_array_add "$checks" "install")"
+    [[ "$command_string" == *" upgrade"* || "$command_string" == upgrade* ]] && checks="$(json_array_add "$checks" "upgrade")"
+
+    printf '%s\n' "$checks"
+}
+
+local_runtime_identity() {
+    jq -n \
+        --arg os "$(uname -s 2>/dev/null || true)" \
+        --arg arch "$(uname -m 2>/dev/null || true)" \
+        --arg kernel "$(uname -r 2>/dev/null || true)" \
+        --arg hostname "$(hostname 2>/dev/null || true)" \
+        '{os: $os, arch: $arch, kernel: $kernel, hostname: $hostname}'
+}
+
+remote_runtime_identity() {
+    local host="$1"
+    jq -n --arg host "$host" '{host: $host, runtime_identity: "remote-command"}'
+}
+
 run_local_target() {
     local cmd_string="$1"
     if command -v timeout >/dev/null 2>&1; then
@@ -115,6 +167,13 @@ append_target_result() {
     local exit_code="$6"
     local duration_seconds="$7"
     local output_preview="$8"
+    local command_hash="$9"
+    local workflow_checks="${10}"
+    local workflow_strength="${11}"
+    local expected_version="${12}"
+    local version_verified="${13}"
+    local runtime_identity="${14}"
+    local failure_reasons="${15}"
 
     jq -c \
         --arg name "$name" \
@@ -122,8 +181,15 @@ append_target_result() {
         --arg host "$host" \
         --arg status "$status" \
         --arg output_preview "$output_preview" \
+        --arg command_sha256 "$command_hash" \
+        --arg workflow_strength "$workflow_strength" \
+        --arg expected_version "$expected_version" \
+        --arg version_verified "$version_verified" \
         --argjson exit_code "$exit_code" \
         --argjson duration_seconds "$duration_seconds" \
+        --argjson workflow_checks "$workflow_checks" \
+        --argjson runtime_identity "$runtime_identity" \
+        --argjson failure_reasons "$failure_reasons" \
         '. + [{
           name: $name,
           kind: $kind,
@@ -131,6 +197,13 @@ append_target_result() {
           status: $status,
           exit_code: $exit_code,
           duration_seconds: $duration_seconds,
+          command_sha256: $command_sha256,
+          workflow_strength: $workflow_strength,
+          workflow_checks: $workflow_checks,
+          expected_version: (if $expected_version == "" then null else $expected_version end),
+          version_verified: (if $expected_version == "" then null else ($version_verified == "true") end),
+          runtime: $runtime_identity,
+          failure_reasons: $failure_reasons,
           output_preview: $output_preview
         }]' <<<"$current_json"
 }
@@ -160,12 +233,15 @@ else
         target_command=""
         tmp_output="$(mktemp)"
         target_rc=0
+        failure_reasons='[]'
+        runtime_identity='{}'
 
         if [[ "$target_spec" == local:*:* ]]; then
             target_kind="local"
             rest="${target_spec#local:}"
             target_name="${rest%%:*}"
             target_command="${rest#*:}"
+            runtime_identity="$(local_runtime_identity)"
             set +e
             run_local_target "$target_command" >"$tmp_output" 2>&1
             target_rc=$?
@@ -177,6 +253,7 @@ else
             rest="${rest#*:}"
             target_host="${rest%%:*}"
             target_command="${rest#*:}"
+            runtime_identity="$(remote_runtime_identity "$target_host")"
             set +e
             run_ssh_target "$target_host" "$target_command" >"$tmp_output" 2>&1
             target_rc=$?
@@ -192,15 +269,41 @@ else
         output_preview="$(tail -20 "$tmp_output")"
         rm -f "$tmp_output"
 
+        workflow_checks="$(detect_workflow_checks "$target_command")"
+        workflow_count="$(jq -r 'length' <<<"$workflow_checks")"
+        workflow_strength="strong"
+        if [[ "$workflow_count" -lt 2 ]]; then
+            workflow_strength="weak"
+        fi
+
+        version_verified=false
+        if [[ -n "$EXPECTED_VERSION" ]]; then
+            if grep -Fq "$EXPECTED_VERSION" <<<"$output_preview"; then
+                version_verified=true
+            else
+                failure_reasons="$(json_array_add "$failure_reasons" "version_mismatch")"
+            fi
+        fi
+
         target_status="pass"
         if [[ "$target_rc" -ne 0 ]]; then
+            failure_reasons="$(json_array_add "$failure_reasons" "command_failed")"
+        fi
+        if [[ "$REQUIRED" == "true" && "$workflow_strength" == "weak" ]]; then
+            failure_reasons="$(json_array_add "$failure_reasons" "weak_workflow")"
+        fi
+        if [[ "$(jq -r 'length' <<<"$failure_reasons")" -gt 0 ]]; then
             target_status="fail"
             FAILURES=$((FAILURES + 1))
             STATUS="fail"
             EXIT_CODE=1
         fi
 
-        TARGET_RESULTS="$(append_target_result "$TARGET_RESULTS" "$target_name" "$target_kind" "$target_host" "$target_status" "$target_rc" "$duration_seconds" "$output_preview")"
+        TARGET_RESULTS="$(append_target_result \
+            "$TARGET_RESULTS" "$target_name" "$target_kind" "$target_host" \
+            "$target_status" "$target_rc" "$duration_seconds" "$output_preview" \
+            "$(command_sha256 "$target_command")" "$workflow_checks" "$workflow_strength" \
+            "$EXPECTED_VERSION" "$version_verified" "$runtime_identity" "$failure_reasons")"
     done
 fi
 
@@ -211,6 +314,7 @@ DOCUMENT="$(jq -n \
     --arg generated_at "$(timestamp)" \
     --arg status "$STATUS" \
     --arg waiver "$WAIVER" \
+    --arg expected_version "$EXPECTED_VERSION" \
     --argjson required "$REQUIRED_JSON" \
     --argjson timeout_seconds "$TIMEOUT_SECONDS" \
     --argjson targets "$TARGET_RESULTS" \
@@ -220,6 +324,7 @@ DOCUMENT="$(jq -n \
       status: $status,
       required: $required,
       waiver: (if $waiver == "" then null else $waiver end),
+      expected_version: (if $expected_version == "" then null else $expected_version end),
       timeout_seconds: $timeout_seconds,
       targets: $targets
     }')"

--- a/scripts/ci-local-release.sh
+++ b/scripts/ci-local-release.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 #   ./scripts/ci-local-release.sh              # full gate (parallel where possible)
 #   ./scripts/ci-local-release.sh --fast       # skip heavy checks (~20s vs ~100s)
 #   ./scripts/ci-local-release.sh --security-mode quick
-#   ./scripts/ci-local-release.sh --release-version X.Y.Z --hil-target 'local:gpu:ao version'
+#   ./scripts/ci-local-release.sh --release-version X.Y.Z --hil-target 'local:gpu:ao version && ao init --help && ao hooks show && ao rpi status'
 #
 # Exit codes:
 #   0 = all checks passed
@@ -660,9 +660,14 @@ release_readiness_mode() {
 
 run_release_hil_evidence() {
     local mode
+    local version
     local args=("--out" "$ARTIFACT_DIR/hil-evidence.json")
 
     mode="$(release_readiness_mode)"
+    version="$(release_version)"
+    if [[ -n "$version" ]]; then
+        args+=("--expected-version" "$version")
+    fi
     if [[ "$mode" == "official" ]]; then
         args+=("--required")
     fi

--- a/tests/scripts/release-hil.bats
+++ b/tests/scripts/release-hil.bats
@@ -43,7 +43,7 @@ teardown() {
     run bash "$SCRIPT" --target "local:loop:true" --out "$out"
 
     [ "$status" -eq 0 ]
-    jq -e '.status == "pass" and .targets[0].name == "loop" and .targets[0].status == "pass"' "$out"
+    jq -e '.status == "pass" and .targets[0].name == "loop" and .targets[0].status == "pass" and .targets[0].runtime.os != null and .targets[0].command_sha256 != null' "$out"
 }
 
 @test "local HIL target failure fails the evidence lane" {
@@ -53,4 +53,43 @@ teardown() {
 
     [ "$status" -eq 1 ]
     jq -e '.status == "fail" and .targets[0].status == "fail"' "$out"
+}
+
+@test "required HIL target rejects ao version only as weak evidence" {
+    out="$TMP_DIR/hil-evidence.json"
+
+    run bash "$SCRIPT" \
+        --required \
+        --expected-version "2.42.0" \
+        --target "local:loop:printf 'ao version 2.42.0\n'" \
+        --out "$out"
+
+    [ "$status" -eq 1 ]
+    jq -e '.status == "fail" and .targets[0].workflow_strength == "weak" and (.targets[0].failure_reasons | index("weak_workflow")) != null' "$out"
+}
+
+@test "required HIL target records strong install hooks rpi workflow evidence" {
+    out="$TMP_DIR/hil-evidence.json"
+
+    run bash "$SCRIPT" \
+        --required \
+        --expected-version "2.42.0" \
+        --target "local:loop:printf 'ao version 2.42.0\nao init ok\nao hooks ok\nao rpi ok\n'" \
+        --out "$out"
+
+    [ "$status" -eq 0 ]
+    jq -e '.status == "pass" and .expected_version == "2.42.0" and .targets[0].workflow_strength == "strong" and .targets[0].version_verified == true and (.targets[0].workflow_checks | index("ao-rpi")) != null' "$out"
+}
+
+@test "required HIL target rejects mismatched release version" {
+    out="$TMP_DIR/hil-evidence.json"
+
+    run bash "$SCRIPT" \
+        --required \
+        --expected-version "2.42.0" \
+        --target "local:loop:printf 'ao version 2.41.0\nao init ok\nao hooks ok\nao rpi ok\n'" \
+        --out "$out"
+
+    [ "$status" -eq 1 ]
+    jq -e '.status == "fail" and .targets[0].version_verified == false and (.targets[0].failure_reasons | index("version_mismatch")) != null' "$out"
 }


### PR DESCRIPTION
## Summary
- strengthen check-release-hil.sh target evidence with runtime identity, command fingerprint, workflow checks, and expected-version verification
- make official local release HIL pass the release version into evidence capture
- reject weak ao-version-only targets and mismatched release versions in focused tests
- update release readiness and E2E docs with workflow-rich target examples

## Validation
- bash -n scripts/check-release-hil.sh scripts/ci-local-release.sh
- shellcheck --severity=error scripts/check-release-hil.sh scripts/ci-local-release.sh
- bats tests/scripts/release-hil.bats tests/scripts/release-readiness.bats tests/scripts/ci-local-release.bats
- git diff --check
- markdownlint docs/RELEASING.md docs/release-e2e-checklist.md docs/contracts/release-readiness.md
- bash tests/docs/validate-doc-release.sh
- scripts/pre-push-gate.sh --fast (passed; warn-only executable-spec link-integrity reports unknown flags --lint/--orphans)

Stacked on PR #298 / soc-owed.5.
Bead: soc-owed.6