### PR TITLE
chore(ci): upgrade @claude workflow permissions to write (soc-8xav #claude-yml-write-perms)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,11 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write       # @claude commits fixes to PR branches
+      pull-requests: write  # @claude updates PR description, labels, comments, marks ready
+      issues: write         # @claude closes/comments on issues
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read         # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## What

The default `/install-github-app` setup creates `.github/workflows/claude.yml` with **read-only** permissions, which means `@claude` mentions on PRs produce "skipped" workflow runs — the bot can read context but cannot push commits.

Upgrade to **write** so `@claude` becomes a real committing agent. This is the delegation pattern from the 2026-05-17 cascade session.

## Permissions diff

| Permission | Before | After | Why |
|---|---|---|---|
| `contents` | read | **write** | Push commits to PR branches |
| `pull-requests` | read | **write** | Update description, labels, comments, mark ready |
| `issues` | read | **write** | Close/comment on issues |
| `id-token` | write | write | unchanged (OIDC) |
| `actions` | read | read | unchanged (read CI results) |

## Safety

The elevated permissions are scoped to the workflow's runtime. Any `@claude` commit still goes through the same gates as a human PR:
- Branch protection on `main` (require PR, no direct push)
- `summary` + `claude-review` required status checks
- Squash-only merge

## Verified problem

PRs #273 and #270 received `@claude` comments at 2026-05-18T01:05Z. Both produced `skipped` workflow runs because read-only perms tripped the bot's safety check. After this PR merges, re-mention `@claude` on those PRs to retrigger.

## Acceptance

- `.github/workflows/claude.yml` permissions show all three of `contents`/`pull-requests`/`issues` as `write`
- A test `@claude` mention on any PR triggers a real workflow run (not skipped)