### PR TITLE
feat(release): derive readiness from evidence artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,8 @@ jobs:
 
           # Build a pre-publish binary for VIL/eval evidence before GoReleaser
           # publishes the official archives.
-          (cd cli && go build -o ../release-artifacts/ao ./cmd/ao)
+          (cd cli && make build VERSION="$VERSION")
+          cp cli/bin/ao release-artifacts/ao
           release-artifacts/ao version > release-artifacts/ao-version.txt
           release-artifacts/ao init --help > /dev/null
           release-artifacts/ao rpi --help > /dev/null
@@ -110,11 +111,12 @@ jobs:
             --arg release_version "$VERSION" \
             '{schema_version:1,evidence_kind:"software_in_loop",generated_at:$generated_at,release_version:$release_version,status:"pass",reason:"release publisher pre-publish checks completed",errors_before_readiness:0}' \
             > release-artifacts/sil-evidence.json
-          jq -n \
-            --arg generated_at "$GENERATED_AT" \
-            --arg release_version "$VERSION" \
-            '{schema_version:1,evidence_kind:"digital_twin",generated_at:$generated_at,release_version:$release_version,status:"pass",reason:"pre-publish ao build, version, init, and rpi smoke completed",dimensions:{vil:{status:"pass"},release_smoke:{status:"pass"},hook_install_smoke:{status:"pass"},rpi_smoke:{status:"pass"}}}' \
-            > release-artifacts/digital-twin-evidence.json
+          chmod +x scripts/check-release-digital-twin.sh
+          scripts/check-release-digital-twin.sh \
+            --mode official \
+            --ao-bin "$PWD/release-artifacts/ao" \
+            --expected-version "$VERSION" \
+            --out release-artifacts/digital-twin-evidence.json
           jq -n \
             --arg generated_at "$GENERATED_AT" \
             --arg release_version "$VERSION" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,23 @@ jobs:
       - name: Generate pre-publish release evidence
         run: |
           mkdir -p release-artifacts
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [[ -n "${{ github.event.inputs.tag }}" ]]; then
+            VERSION="${{ github.event.inputs.tag }}"
+            VERSION="${VERSION#v}"
+          fi
+          GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
           # CycloneDX SBOM for Go module dependencies.
           GOBIN=/usr/local/bin go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.9.0
           (cd cli && cyclonedx-gomod mod -licenses -json -output ../release-artifacts/sbom-cyclonedx-go-mod.json)
+
+          # Build a pre-publish binary for VIL/eval evidence before GoReleaser
+          # publishes the official archives.
+          (cd cli && go build -o ../release-artifacts/ao ./cmd/ao)
+          release-artifacts/ao version > release-artifacts/ao-version.txt
+          release-artifacts/ao init --help > /dev/null
+          release-artifacts/ao rpi --help > /dev/null
 
           # Security is a pre-publish gate. Keep the JSON for release consumers,
           # but fail before GoReleaser when the gate returns findings.
@@ -75,6 +88,14 @@ jobs:
           SECURITY_RC=$?
           set -e
           jq empty release-artifacts/security-gate-summary.json
+          tmp_security="$(mktemp)"
+          jq \
+            --arg generated_at "$GENERATED_AT" \
+            --arg release_version "$VERSION" \
+            --arg artifact_dir "release-artifacts" \
+            '. + {generated_at: $generated_at, release_version: $release_version, artifact_dir: $artifact_dir}' \
+            release-artifacts/security-gate-summary.json > "$tmp_security"
+          mv "$tmp_security" release-artifacts/security-gate-summary.json
           jq -e '((.gate_status // "") | ascii_downcase) == "pass"' release-artifacts/security-gate-summary.json
           if [[ "$SECURITY_RC" -ne 0 ]]; then
             echo "ERROR: pre-publish security gate failed with exit code $SECURITY_RC"
@@ -84,18 +105,69 @@ jobs:
           # Public CI is a VIL lane. Physical HIL remains attached through the
           # authoritative local release audit because private targets are not
           # available to the public publisher runner.
+          jq -n \
+            --arg generated_at "$GENERATED_AT" \
+            --arg release_version "$VERSION" \
+            '{schema_version:1,evidence_kind:"software_in_loop",generated_at:$generated_at,release_version:$release_version,status:"pass",reason:"release publisher pre-publish checks completed",errors_before_readiness:0}' \
+            > release-artifacts/sil-evidence.json
+          jq -n \
+            --arg generated_at "$GENERATED_AT" \
+            --arg release_version "$VERSION" \
+            '{schema_version:1,evidence_kind:"digital_twin",generated_at:$generated_at,release_version:$release_version,status:"pass",reason:"pre-publish ao build, version, init, and rpi smoke completed",dimensions:{vil:{status:"pass"},release_smoke:{status:"pass"},hook_install_smoke:{status:"pass"},rpi_smoke:{status:"pass"}}}' \
+            > release-artifacts/digital-twin-evidence.json
+          jq -n \
+            --arg generated_at "$GENERATED_AT" \
+            --arg release_version "$VERSION" \
+            --arg waiver "GitHub release publisher cannot access private HIL targets; local release audit remains authoritative for HIL" \
+            '{schema_version:1,generated_at:$generated_at,status:"waived",required:true,waiver:$waiver,expected_version:$release_version,timeout_seconds:0,targets:[]}' \
+            > release-artifacts/hil-evidence.json
+          mkdir -p release-artifacts/eval-agentops/runs
+          set +e
+          AO_BIN="$PWD/release-artifacts/ao" ./scripts/eval-agentops.sh \
+            --fast \
+            --run-root release-artifacts/eval-agentops/runs \
+            --baseline-dir release-artifacts/eval-agentops/baselines \
+            > release-artifacts/eval-agentops-fast.log 2>&1
+          EVAL_RC=$?
+          set -e
+          EVAL_RUN_DIR="$(find release-artifacts/eval-agentops/runs -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort | tail -1)"
+          if [[ -n "$EVAL_RUN_DIR" && -f "$EVAL_RUN_DIR/baseline-audit.json" ]]; then
+            jq \
+              --arg generated_at "$GENERATED_AT" \
+              --arg release_version "$VERSION" \
+              '. + {generated_at: $generated_at, release_version: $release_version}' \
+              "$EVAL_RUN_DIR/baseline-audit.json" > release-artifacts/eval-baseline-audit.json
+          else
+            EVAL_RC=1
+            jq -n \
+              --arg generated_at "$GENERATED_AT" \
+              --arg release_version "$VERSION" \
+              '{generated_at:$generated_at,release_version:$release_version,suite_count:0,baseline_count:0,policy_mismatch_count:0,stale_suite_hashes:[]}' \
+              > release-artifacts/eval-baseline-audit.json
+          fi
+          EVAL_STATUS="pass"
+          if [[ "$EVAL_RC" -ne 0 ]]; then
+            EVAL_STATUS="fail"
+          fi
+          jq -n \
+            --arg generated_at "$GENERATED_AT" \
+            --arg release_version "$VERSION" \
+            --arg status "$EVAL_STATUS" \
+            --arg run_dir "$EVAL_RUN_DIR" \
+            '{schema_version:1,evidence_kind:"agentops_eval_fast",generated_at:$generated_at,release_version:$release_version,status:$status,run_dir:(if $run_dir == "" then null else $run_dir end),log:"eval-agentops-fast.log",baseline_audit:"eval-baseline-audit.json"}' \
+            > release-artifacts/eval-agentops-fast.json
+          if [[ "$EVAL_RC" -ne 0 ]]; then
+            echo "ERROR: pre-publish eval evidence failed"
+            cat release-artifacts/eval-agentops-fast.log
+            exit "$EVAL_RC"
+          fi
           chmod +x scripts/check-release-readiness.sh
           scripts/check-release-readiness.sh \
             --mode official \
             --artifact-dir release-artifacts \
-            --out release-artifacts/release-readiness.json \
-            --sil pass \
-            --vil pass \
-            --hil-status waived \
-            --hil-waiver "GitHub release publisher cannot access private HIL targets; local release audit remains authoritative for HIL" \
-            --artifacts pass \
-            --security pass \
-            --eval pass
+            --evidence-dir release-artifacts \
+            --release-version "$VERSION" \
+            --out release-artifacts/release-readiness.json
           jq -e '.release_status == "pass"' release-artifacts/release-readiness.json
 
       - name: Upload pre-publish release evidence
@@ -229,7 +301,13 @@ jobs:
           gh release upload "$VERSION" release-artifacts/sbom-cyclonedx-go-mod.json --clobber
           gh release upload "$VERSION" release-artifacts/security-gate-summary.json --clobber
           gh release upload "$VERSION" release-artifacts/release-readiness.json --clobber
-          echo "Uploaded SBOM + security report + readiness assets"
+          gh release upload "$VERSION" release-artifacts/sil-evidence.json --clobber
+          gh release upload "$VERSION" release-artifacts/hil-evidence.json --clobber
+          gh release upload "$VERSION" release-artifacts/digital-twin-evidence.json --clobber
+          gh release upload "$VERSION" release-artifacts/eval-agentops-fast.json --clobber
+          gh release upload "$VERSION" release-artifacts/eval-agentops-fast.log --clobber
+          gh release upload "$VERSION" release-artifacts/eval-baseline-audit.json --clobber
+          echo "Uploaded SBOM + security report + readiness evidence assets"
 
       - name: Generate SLSA provenance attestation
         uses: actions/attest-build-provenance@v4
@@ -245,3 +323,9 @@ jobs:
             release-artifacts/sbom-cyclonedx-go-mod.json
             release-artifacts/security-gate-summary.json
             release-artifacts/release-readiness.json
+            release-artifacts/sil-evidence.json
+            release-artifacts/hil-evidence.json
+            release-artifacts/digital-twin-evidence.json
+            release-artifacts/eval-agentops-fast.json
+            release-artifacts/eval-agentops-fast.log
+            release-artifacts/eval-baseline-audit.json

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -176,7 +176,7 @@ scripts/ci-local-release.sh --release-version 2.X.Y --hil-waiver 'target unavail
 ```
 
 In `--fast` mode, Phase 4 skips race tests, hook integration tests, SBOM generation, and the security gate. It still builds the binary and runs release validation.
-When `--release-version` is set, Phase 7 runs in official mode and fails unless the readiness score is at least 8/10 with SIL/VIL pass and HIL pass or waiver.
+When `--release-version` is set, Phase 7 runs in official mode and fails unless the readiness score is at least 8/10 with fresh evidence-backed SIL/VIL/security/eval pass and HIL pass or waiver.
 
 ### Minimum Checks Before Any Push
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -192,7 +192,7 @@ Release validation is local-first and enforced by:
 ./scripts/ci-local-release.sh
 ```
 
-This local gate runs doc checks, manifest/schema checks, smoke/integration checks, hook and `ao rpi` smoke paths, binary validation, SBOM generation, security scans, AgentOps eval evidence, digital-twin/VIL evidence, and the release readiness score. Official release audits require fresh SIL/VIL/security/eval evidence JSON plus workflow-rich HIL evidence or an explicit HIL waiver; status strings alone do not satisfy official readiness.
+This local gate runs doc checks, manifest/schema checks, smoke/integration checks, hook and `ao rpi` smoke paths, binary validation, SBOM generation, security scans, AgentOps eval evidence, executable digital-twin/VIL evidence, and the release readiness score. Official release audits require fresh SIL/VIL/security/eval evidence JSON plus workflow-rich HIL evidence or an explicit HIL waiver; status strings alone do not satisfy official readiness.
 For command variants and expected release-E2E smoke markers, see [Release E2E Checklist](release-e2e-checklist.md).
 
 ## Failure Modes

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -168,7 +168,8 @@ Each release produces:
 | `checksums.txt` | SHA256 checksums for all archives |
 | `sbom-cyclonedx-go-mod.json` | Publishable CycloneDX SBOM for Go dependencies |
 | `security-gate-summary.json` | Security scan summary (gitleaks/semgrep/gosec/trivy/etc.) |
-| `release-readiness.json` | Release readiness score with SIL/VIL/HIL status |
+| `release-readiness.json` | Release readiness score linked to evidence artifacts |
+| `sil-evidence.json` | Local software-in-the-loop release gate proof |
 | `eval-agentops-fast.json` | AgentOps eval proof summary for release readiness |
 | `eval-baseline-audit.json` | Eval baseline drift audit; stale suite hashes block audit resolution |
 | `digital-twin-evidence.json` | Local release digital-twin/VIL proof |
@@ -191,7 +192,7 @@ Release validation is local-first and enforced by:
 ./scripts/ci-local-release.sh
 ```
 
-This local gate runs doc checks, manifest/schema checks, smoke/integration checks, hook and `ao rpi` smoke paths, binary validation, SBOM generation, security scans, AgentOps eval evidence, digital-twin/VIL evidence, and the release readiness score. Official release audits require SIL/VIL evidence plus workflow-rich HIL evidence or an explicit HIL waiver.
+This local gate runs doc checks, manifest/schema checks, smoke/integration checks, hook and `ao rpi` smoke paths, binary validation, SBOM generation, security scans, AgentOps eval evidence, digital-twin/VIL evidence, and the release readiness score. Official release audits require fresh SIL/VIL/security/eval evidence JSON plus workflow-rich HIL evidence or an explicit HIL waiver; status strings alone do not satisfy official readiness.
 For command variants and expected release-E2E smoke markers, see [Release E2E Checklist](release-e2e-checklist.md).
 
 ## Failure Modes

--- a/docs/contracts/release-readiness.md
+++ b/docs/contracts/release-readiness.md
@@ -29,6 +29,10 @@ Official release readiness requires both:
 
 In `official` mode, the score alone is not enough. SIL, VIL, artifact,
 security, and eval dimensions must pass. HIL must pass or be explicitly waived.
+Official mode derives those dimensions from evidence JSON files under
+`--evidence-dir`; caller-provided status flags are only advisory/fast-mode
+shortcuts. Evidence files must be fresh, parseable, and version-aligned when
+`--release-version` is supplied.
 
 ## Modes
 
@@ -81,6 +85,7 @@ half of the HIL dimension.
   "eval_fast_report": "eval-agentops-fast.json",
   "eval_baseline_audit": "eval-baseline-audit.json",
   "release_readiness": "release-readiness.json",
+  "sil_evidence": "sil-evidence.json",
   "hil_evidence": "hil-evidence.json",
   "vil_evidence": "digital-twin-evidence.json",
   "digital_twin_evidence": "digital-twin-evidence.json"
@@ -89,7 +94,7 @@ half of the HIL dimension.
 
 `scripts/resolve-release-artifacts.sh` only resolves full release artifact sets
 that include SBOMs, the security report, eval fast and baseline-audit outputs,
-readiness, HIL evidence, and digital-twin/VIL evidence.
+readiness, SIL evidence, HIL evidence, and digital-twin/VIL evidence.
 `scripts/validate-release-audit-artifacts.sh` validates that proof bundle for
 release audits generated on or after 2026-05-02, while still accepting older
 historical audits.

--- a/docs/contracts/release-readiness.md
+++ b/docs/contracts/release-readiness.md
@@ -73,6 +73,22 @@ must pass `--hil-waiver "reason"` so the waiver is visible in both the HIL and
 readiness artifacts. A waiver is acceptable release evidence, but it scores only
 half of the HIL dimension.
 
+## Digital-Twin / VIL Evidence
+
+`scripts/check-release-digital-twin.sh` captures the disposable local workflow
+artifact:
+
+```text
+.agents/releases/local-ci/<run-id>/digital-twin-evidence.json
+```
+
+Official mode requires a real `ao` binary and records install/upgrade smoke,
+version parity, core command smoke, `ao init --hooks`, `ao hooks show`,
+`ao rpi status`, and runtime/help surfaces in a temporary HOME and repository.
+Fast mode runs a lightweight subset when the binary is available and records
+`skipped` when it is not. A digital-twin waiver is explicit evidence, not an
+implicit pass.
+
 ## Release Artifacts
 
 `release-artifacts.json` records these fields when the local gate runs:

--- a/docs/release-e2e-checklist.md
+++ b/docs/release-e2e-checklist.md
@@ -53,9 +53,11 @@ Expect:
   - `security_report`
   - `eval_fast_report` and `eval_baseline_audit`
   - `release_readiness`
+  - `sil_evidence`
   - `hil_evidence`
   - `vil_evidence` and `digital_twin_evidence`
 - `.agents/releases/local-ci/<timestamp>/release-readiness.json` has `release_status: pass` and `release_readiness_score >= 8`
+- `.agents/releases/local-ci/<timestamp>/sil-evidence.json` has `status: pass`, matching `release_version`, and the same run's local CI error count before readiness
 - `.agents/releases/local-ci/<timestamp>/hil-evidence.json` has `status: pass` or `status: waived`; passing targets record OS/architecture/runtime identity, workflow checks, command fingerprint, and release-version verification
 - `.agents/releases/local-ci/<timestamp>/digital-twin-evidence.json` has `status: pass` and `dimensions.vil.status: pass`
 - `.agents/releases/local-ci/<timestamp>/eval-agentops-fast.json` has `status: pass`, and `eval-baseline-audit.json` has no `stale_suite_hashes`

--- a/docs/release-e2e-checklist.md
+++ b/docs/release-e2e-checklist.md
@@ -59,7 +59,7 @@ Expect:
 - `.agents/releases/local-ci/<timestamp>/release-readiness.json` has `release_status: pass` and `release_readiness_score >= 8`
 - `.agents/releases/local-ci/<timestamp>/sil-evidence.json` has `status: pass`, matching `release_version`, and the same run's local CI error count before readiness
 - `.agents/releases/local-ci/<timestamp>/hil-evidence.json` has `status: pass` or `status: waived`; passing targets record OS/architecture/runtime identity, workflow checks, command fingerprint, and release-version verification
-- `.agents/releases/local-ci/<timestamp>/digital-twin-evidence.json` has `status: pass` and `dimensions.vil.status: pass`
+- `.agents/releases/local-ci/<timestamp>/digital-twin-evidence.json` has `status: pass`, `workflow_strength: full`, matching `release_version`, and passing install/upgrade, hook install, RPI, plugin runtime, and version-parity dimensions
 - `.agents/releases/local-ci/<timestamp>/eval-agentops-fast.json` has `status: pass`, and `eval-baseline-audit.json` has no `stale_suite_hashes`
 
 If the fast gate passes but this full gate fails, stop. The release is not ready to tag. Use the failing section in the full-gate output, rerun the official local gate until it passes, and if a tag or publish already happened, follow the failure-mode steps in [RELEASING](RELEASING.md#failure-modes) before retrying anything else.

--- a/schemas/release-readiness.v1.schema.json
+++ b/schemas/release-readiness.v1.schema.json
@@ -13,6 +13,7 @@
     "release_status",
     "dimensions",
     "hil_evidence",
+    "evidence_errors",
     "recommendations"
   ],
   "additionalProperties": false,
@@ -91,6 +92,12 @@
       "items": {
         "type": "string"
       }
+    },
+    "evidence_errors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "$defs": {
@@ -110,6 +117,9 @@
         "points": {
           "type": "number",
           "minimum": 0
+        },
+        "evidence_artifact": {
+          "type": ["string", "null"]
         }
       }
     }

--- a/scripts/check-release-digital-twin.sh
+++ b/scripts/check-release-digital-twin.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT=""
+MODE="${AGENTOPS_RELEASE_DIGITAL_TWIN_MODE:-official}"
+AO_BIN="${AGENTOPS_RELEASE_AO_BIN:-}"
+EXPECTED_VERSION="${AGENTOPS_RELEASE_VERSION:-}"
+WAIVER="${AGENTOPS_RELEASE_DIGITAL_TWIN_WAIVER:-}"
+TIMEOUT_SECONDS="${AGENTOPS_RELEASE_DIGITAL_TWIN_TIMEOUT:-30}"
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/check-release-digital-twin.sh [options]
+
+Capture release digital-twin/VIL evidence in a disposable local environment.
+
+Options:
+  --out PATH              Write JSON evidence to PATH
+  --mode MODE             official|advisory|fast (default: official)
+  --ao-bin PATH           ao binary to exercise (default: cli/bin/ao, then PATH)
+  --expected-version V    Require ao version output to mention this version
+  --waiver TEXT           Record an explicit digital-twin waiver
+  --timeout SECONDS       Per-check timeout when timeout(1) is available (default: 30)
+  -h, --help              Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --out)
+            OUT="${2:-}"
+            shift 2
+            ;;
+        --mode)
+            MODE="${2:-}"
+            shift 2
+            ;;
+        --ao-bin)
+            AO_BIN="${2:-}"
+            shift 2
+            ;;
+        --expected-version)
+            EXPECTED_VERSION="${2:-}"
+            shift 2
+            ;;
+        --waiver)
+            WAIVER="${2:-}"
+            shift 2
+            ;;
+        --timeout)
+            TIMEOUT_SECONDS="${2:-}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required for digital-twin evidence" >&2
+    exit 1
+fi
+
+if [[ "$MODE" != "official" && "$MODE" != "advisory" && "$MODE" != "fast" ]]; then
+    echo "--mode must be official, advisory, or fast" >&2
+    exit 1
+fi
+
+if [[ ! "$TIMEOUT_SECONDS" =~ ^[0-9]+$ || "$TIMEOUT_SECONDS" -eq 0 ]]; then
+    echo "--timeout must be a positive integer" >&2
+    exit 1
+fi
+
+timestamp() {
+    date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+normalize_version() {
+    local version="$1"
+    printf '%s\n' "${version#v}"
+}
+
+json_array_add() {
+    local current_json="$1"
+    local value="$2"
+
+    jq -c --arg value "$value" '. + [$value]' <<<"$current_json"
+}
+
+runtime_identity() {
+    jq -n \
+        --arg os "$(uname -s 2>/dev/null || true)" \
+        --arg arch "$(uname -m 2>/dev/null || true)" \
+        --arg kernel "$(uname -r 2>/dev/null || true)" \
+        --arg hostname "$(hostname 2>/dev/null || true)" \
+        '{os: $os, arch: $arch, kernel: $kernel, hostname: $hostname}'
+}
+
+if [[ -z "$AO_BIN" ]]; then
+    if [[ -x "cli/bin/ao" ]]; then
+        AO_BIN="cli/bin/ao"
+    elif command -v ao >/dev/null 2>&1; then
+        AO_BIN="$(command -v ao)"
+    fi
+fi
+
+CHECKS='[]'
+FAILURE_REASONS='[]'
+DIM_VIL="pass"
+DIM_RELEASE_SMOKE="pass"
+DIM_INSTALL_UPGRADE="pass"
+DIM_HOOK_INSTALL="pass"
+DIM_RPI="pass"
+DIM_PLUGIN_RUNTIME="pass"
+DIM_VERSION_PARITY="pass"
+STATUS="pass"
+EXIT_CODE=0
+WORKFLOW_STRENGTH="full"
+TMP_ROOT=""
+
+set_dimension_fail() {
+    local dimension="$1"
+
+    case "$dimension" in
+        vil) DIM_VIL="fail" ;;
+        release_smoke) DIM_RELEASE_SMOKE="fail" ;;
+        install_upgrade) DIM_INSTALL_UPGRADE="fail" ;;
+        hook_install_smoke) DIM_HOOK_INSTALL="fail" ;;
+        rpi_smoke) DIM_RPI="fail" ;;
+        plugin_runtime) DIM_PLUGIN_RUNTIME="fail" ;;
+        version_parity) DIM_VERSION_PARITY="fail"; DIM_VIL="fail" ;;
+    esac
+}
+
+append_check() {
+    local name="$1"
+    local dimension="$2"
+    local status="$3"
+    local exit_code="$4"
+    local duration_seconds="$5"
+    local output_preview="$6"
+    local command_label="$7"
+
+    CHECKS="$(jq -c \
+        --arg name "$name" \
+        --arg dimension "$dimension" \
+        --arg status "$status" \
+        --arg output_preview "$output_preview" \
+        --arg command "$command_label" \
+        --argjson exit_code "$exit_code" \
+        --argjson duration_seconds "$duration_seconds" \
+        '. + [{
+          name: $name,
+          dimension: $dimension,
+          status: $status,
+          exit_code: $exit_code,
+          duration_seconds: $duration_seconds,
+          command: $command,
+          output_preview: $output_preview
+        }]' <<<"$CHECKS")"
+}
+
+write_document() {
+    local generated_at
+    local artifact_dir
+
+    generated_at="$(timestamp)"
+    artifact_dir=""
+    if [[ -n "$OUT" ]]; then
+        artifact_dir="$(dirname "$OUT")"
+    fi
+
+    DOCUMENT="$(jq -n \
+        --arg generated_at "$generated_at" \
+        --arg artifact_dir "$artifact_dir" \
+        --arg mode "$MODE" \
+        --arg status "$STATUS" \
+        --arg workflow_strength "$WORKFLOW_STRENGTH" \
+        --arg release_version "$(normalize_version "$EXPECTED_VERSION")" \
+        --arg ao_bin "$AO_BIN" \
+        --arg waiver "$WAIVER" \
+        --arg vil_status "$DIM_VIL" \
+        --arg release_smoke_status "$DIM_RELEASE_SMOKE" \
+        --arg install_upgrade_status "$DIM_INSTALL_UPGRADE" \
+        --arg hook_install_status "$DIM_HOOK_INSTALL" \
+        --arg rpi_status "$DIM_RPI" \
+        --arg plugin_runtime_status "$DIM_PLUGIN_RUNTIME" \
+        --arg version_parity_status "$DIM_VERSION_PARITY" \
+        --argjson timeout_seconds "$TIMEOUT_SECONDS" \
+        --argjson checks "$CHECKS" \
+        --argjson runtime "$(runtime_identity)" \
+        --argjson failure_reasons "$FAILURE_REASONS" \
+        '{
+          schema_version: 1,
+          evidence_kind: "digital_twin",
+          generated_at: $generated_at,
+          artifact_dir: (if $artifact_dir == "" then null else $artifact_dir end),
+          mode: $mode,
+          status: $status,
+          workflow_strength: $workflow_strength,
+          release_version: (if $release_version == "" then null else $release_version end),
+          ao_bin: (if $ao_bin == "" then null else $ao_bin end),
+          waiver: (if $waiver == "" then null else $waiver end),
+          timeout_seconds: $timeout_seconds,
+          runtime: $runtime,
+          dimensions: {
+            vil: {status: $vil_status},
+            release_smoke: {status: $release_smoke_status},
+            install_upgrade: {status: $install_upgrade_status},
+            hook_install_smoke: {status: $hook_install_status},
+            rpi_smoke: {status: $rpi_status},
+            plugin_runtime: {status: $plugin_runtime_status},
+            version_parity: {status: $version_parity_status}
+          },
+          checks: $checks,
+          failure_reasons: $failure_reasons
+        }')"
+
+    if [[ -n "$OUT" ]]; then
+        mkdir -p "$(dirname "$OUT")"
+        printf '%s\n' "$DOCUMENT" >"$OUT"
+    fi
+    printf '%s\n' "$DOCUMENT"
+}
+
+finish_unavailable() {
+    local reason="$1"
+
+    FAILURE_REASONS="$(json_array_add "$FAILURE_REASONS" "$reason")"
+    DIM_VIL="skipped"
+    DIM_RELEASE_SMOKE="skipped"
+    DIM_INSTALL_UPGRADE="skipped"
+    DIM_HOOK_INSTALL="skipped"
+    DIM_RPI="skipped"
+    DIM_PLUGIN_RUNTIME="skipped"
+    DIM_VERSION_PARITY="skipped"
+
+    if [[ -n "$WAIVER" ]]; then
+        STATUS="waived"
+        EXIT_CODE=0
+    elif [[ "$MODE" == "official" ]]; then
+        STATUS="fail"
+        DIM_VIL="fail"
+        EXIT_CODE=1
+    else
+        STATUS="skipped"
+        EXIT_CODE=0
+    fi
+
+    write_document
+    exit "$EXIT_CODE"
+}
+
+if [[ -n "$WAIVER" ]]; then
+    finish_unavailable "waived"
+fi
+
+if [[ -z "$AO_BIN" || ! -x "$AO_BIN" ]]; then
+    finish_unavailable "ao_binary_unavailable"
+fi
+
+TMP_ROOT="$(mktemp -d)"
+cleanup() {
+    [[ -n "$TMP_ROOT" ]] && rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+TMP_HOME="$TMP_ROOT/home"
+TMP_REPO="$TMP_ROOT/repo"
+INSTALL_DIR="$TMP_ROOT/bin"
+mkdir -p "$TMP_HOME" "$TMP_REPO" "$INSTALL_DIR"
+if command -v git >/dev/null 2>&1; then
+    git -C "$TMP_REPO" init -q
+fi
+
+INSTALLED_AO="$INSTALL_DIR/ao"
+cp "$AO_BIN" "$INSTALLED_AO"
+chmod +x "$INSTALLED_AO"
+
+run_command() {
+    local command_string="$1"
+
+    if command -v timeout >/dev/null 2>&1; then
+        HOME="$TMP_HOME" timeout "$TIMEOUT_SECONDS" bash -lc "$command_string"
+    else
+        HOME="$TMP_HOME" bash -lc "$command_string"
+    fi
+}
+
+run_check() {
+    local name="$1"
+    local dimension="$2"
+    local command_string="$3"
+    local started_epoch
+    local duration_seconds
+    local tmp_output
+    local rc=0
+    local output_preview
+
+    started_epoch="$(date +%s)"
+    tmp_output="$(mktemp)"
+    set +e
+    (
+        cd "$TMP_REPO"
+        run_command "$command_string"
+    ) >"$tmp_output" 2>&1
+    rc=$?
+    set -e
+    duration_seconds=$(( $(date +%s) - started_epoch ))
+    output_preview="$(tail -20 "$tmp_output")"
+    rm -f "$tmp_output"
+
+    if [[ "$rc" -eq 0 ]]; then
+        append_check "$name" "$dimension" "pass" "$rc" "$duration_seconds" "$output_preview" "$name"
+    else
+        append_check "$name" "$dimension" "fail" "$rc" "$duration_seconds" "$output_preview" "$name"
+        FAILURE_REASONS="$(json_array_add "$FAILURE_REASONS" "workflow_failed")"
+        set_dimension_fail "$dimension"
+        STATUS="fail"
+        EXIT_CODE=1
+    fi
+}
+
+if [[ "$MODE" == "fast" ]]; then
+    WORKFLOW_STRENGTH="lightweight"
+fi
+
+run_check "install" "install_upgrade" "test -x '$INSTALLED_AO' && '$INSTALLED_AO' version"
+run_check "version" "version_parity" "'$INSTALLED_AO' version"
+run_check "core-help" "release_smoke" "'$INSTALLED_AO' --help"
+run_check "rpi-help" "rpi_smoke" "'$INSTALLED_AO' rpi --help"
+
+if [[ "$MODE" != "fast" ]]; then
+    run_check "upgrade" "install_upgrade" "cp '$AO_BIN' '$INSTALL_DIR/ao.next' && chmod +x '$INSTALL_DIR/ao.next' && mv '$INSTALL_DIR/ao.next' '$INSTALLED_AO' && '$INSTALLED_AO' version"
+    run_check "init-hooks" "hook_install_smoke" "'$INSTALLED_AO' init --hooks && '$INSTALLED_AO' hooks show"
+    run_check "rpi-status" "rpi_smoke" "'$INSTALLED_AO' rpi status"
+    run_check "plugin-runtime" "plugin_runtime" "'$INSTALLED_AO' hooks --help && '$INSTALLED_AO' doctor --help"
+fi
+
+if [[ -n "$EXPECTED_VERSION" ]]; then
+    version_output="$(HOME="$TMP_HOME" "$INSTALLED_AO" version 2>/dev/null || true)"
+    if ! grep -Fq "$(normalize_version "$EXPECTED_VERSION")" <<<"$version_output"; then
+        FAILURE_REASONS="$(json_array_add "$FAILURE_REASONS" "version_mismatch")"
+        set_dimension_fail "version_parity"
+        STATUS="fail"
+        EXIT_CODE=1
+    fi
+fi
+
+if [[ "$STATUS" == "fail" && "$MODE" == "advisory" ]]; then
+    EXIT_CODE=0
+fi
+
+write_document
+exit "$EXIT_CODE"

--- a/scripts/check-release-readiness.sh
+++ b/scripts/check-release-readiness.sh
@@ -5,6 +5,15 @@ MODE="${AGENTOPS_RELEASE_READINESS_MODE:-official}"
 THRESHOLD="${AGENTOPS_RELEASE_READINESS_THRESHOLD:-8}"
 OUT=""
 ARTIFACT_DIR=""
+EVIDENCE_DIR="${AGENTOPS_RELEASE_EVIDENCE_DIR:-}"
+RELEASE_VERSION="${AGENTOPS_RELEASE_VERSION:-}"
+MAX_EVIDENCE_AGE_SECONDS="${AGENTOPS_RELEASE_MAX_EVIDENCE_AGE_SECONDS:-86400}"
+SIL_EVIDENCE_FILE="${AGENTOPS_RELEASE_SIL_EVIDENCE_FILE:-}"
+VIL_EVIDENCE_FILE="${AGENTOPS_RELEASE_VIL_EVIDENCE_FILE:-}"
+DIGITAL_TWIN_EVIDENCE_FILE="${AGENTOPS_RELEASE_DIGITAL_TWIN_EVIDENCE_FILE:-}"
+SECURITY_EVIDENCE_FILE="${AGENTOPS_RELEASE_SECURITY_EVIDENCE_FILE:-}"
+EVAL_EVIDENCE_FILE="${AGENTOPS_RELEASE_EVAL_EVIDENCE_FILE:-}"
+EVAL_BASELINE_FILE="${AGENTOPS_RELEASE_EVAL_BASELINE_FILE:-}"
 SIL_STATUS="${AGENTOPS_RELEASE_SIL_STATUS:-pass}"
 VIL_STATUS="${AGENTOPS_RELEASE_VIL_STATUS:-pass}"
 HIL_STATUS="${AGENTOPS_RELEASE_HIL_STATUS:-}"
@@ -23,6 +32,20 @@ Write a scored release-readiness artifact.
 Options:
   --out PATH              Write JSON readiness artifact to PATH
   --artifact-dir PATH     Artifact directory recorded in the JSON
+  --evidence-dir PATH     Directory containing official evidence JSON files
+  --release-version V     Expected release version for official evidence
+  --max-evidence-age-seconds N
+                          Maximum official evidence age (default: 86400)
+  --sil-evidence-file PATH
+                          SIL evidence JSON (default: evidence-dir/sil-evidence.json)
+  --vil-evidence-file PATH
+                          VIL evidence JSON (default: evidence-dir/digital-twin-evidence.json)
+  --digital-twin-file PATH
+                          Digital-twin evidence JSON (alias for --vil-evidence-file)
+  --security-file PATH    Security gate JSON (default: evidence-dir/security-gate-full.json)
+  --eval-file PATH        Eval fast JSON (default: evidence-dir/eval-agentops-fast.json)
+  --eval-baseline-file PATH
+                          Eval baseline audit JSON (default: evidence-dir/eval-baseline-audit.json)
   --mode MODE             official|advisory|fast (default: official)
   --threshold NUMBER      Minimum score for pass (default: 8)
   --sil STATUS            pass|fail|skipped (default: pass)
@@ -45,6 +68,42 @@ while [[ $# -gt 0 ]]; do
             ;;
         --artifact-dir)
             ARTIFACT_DIR="${2:-}"
+            shift 2
+            ;;
+        --evidence-dir)
+            EVIDENCE_DIR="${2:-}"
+            shift 2
+            ;;
+        --release-version)
+            RELEASE_VERSION="${2:-}"
+            shift 2
+            ;;
+        --max-evidence-age-seconds)
+            MAX_EVIDENCE_AGE_SECONDS="${2:-}"
+            shift 2
+            ;;
+        --sil-evidence-file)
+            SIL_EVIDENCE_FILE="${2:-}"
+            shift 2
+            ;;
+        --vil-evidence-file)
+            VIL_EVIDENCE_FILE="${2:-}"
+            shift 2
+            ;;
+        --digital-twin-file)
+            DIGITAL_TWIN_EVIDENCE_FILE="${2:-}"
+            shift 2
+            ;;
+        --security-file)
+            SECURITY_EVIDENCE_FILE="${2:-}"
+            shift 2
+            ;;
+        --eval-file)
+            EVAL_EVIDENCE_FILE="${2:-}"
+            shift 2
+            ;;
+        --eval-baseline-file)
+            EVAL_BASELINE_FILE="${2:-}"
             shift 2
             ;;
         --mode)
@@ -114,6 +173,11 @@ if ! awk -v threshold="$THRESHOLD" 'BEGIN { exit !(threshold + 0 == threshold &&
     exit 1
 fi
 
+if [[ ! "$MAX_EVIDENCE_AGE_SECONDS" =~ ^[0-9]+$ || "$MAX_EVIDENCE_AGE_SECONDS" -eq 0 ]]; then
+    echo "--max-evidence-age-seconds must be a positive integer" >&2
+    exit 1
+fi
+
 validate_status() {
     local label="$1"
     local status="$2"
@@ -136,7 +200,235 @@ validate_status() {
     exit 1
 }
 
-if [[ -n "$HIL_FILE" ]]; then
+timestamp() {
+    date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+EVIDENCE_ERRORS='[]'
+OFFICIAL_ARTIFACTS_OK=true
+SIL_ARTIFACT=""
+VIL_ARTIFACT=""
+HIL_ARTIFACT=""
+ARTIFACTS_ARTIFACT=""
+SECURITY_ARTIFACT=""
+EVAL_ARTIFACT=""
+
+add_evidence_error() {
+    local item="$1"
+    EVIDENCE_ERRORS="$(jq -c --arg item "$item" '. + [$item]' <<<"$EVIDENCE_ERRORS")"
+}
+
+artifact_name() {
+    local path="$1"
+
+    if [[ -z "$path" ]]; then
+        printf ''
+    else
+        basename "$path"
+    fi
+}
+
+resolve_evidence_path() {
+    local candidate="$1"
+    local default_name="$2"
+    local base_dir="$EVIDENCE_DIR"
+
+    [[ -z "$base_dir" ]] && base_dir="$ARTIFACT_DIR"
+
+    if [[ -n "$candidate" ]]; then
+        if [[ "$candidate" == /* || -z "$base_dir" ]]; then
+            printf '%s\n' "$candidate"
+        else
+            printf '%s/%s\n' "${base_dir%/}" "$candidate"
+        fi
+    elif [[ -n "$base_dir" ]]; then
+        printf '%s/%s\n' "${base_dir%/}" "$default_name"
+    else
+        printf '%s\n' "$default_name"
+    fi
+}
+
+first_existing_evidence_path() {
+    local candidate
+
+    for candidate in "$@"; do
+        [[ -n "$candidate" && -f "$candidate" ]] && {
+            printf '%s\n' "$candidate"
+            return 0
+        }
+    done
+
+    printf '%s\n' "${1:-}"
+}
+
+normalize_version() {
+    local version="$1"
+    printf '%s\n' "${version#v}"
+}
+
+json_timestamp_epoch() {
+    local value="$1"
+
+    date -u -d "$value" +%s 2>/dev/null || \
+        date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$value" +%s 2>/dev/null || \
+        return 1
+}
+
+validate_evidence_common() {
+    local label="$1"
+    local file="$2"
+    local require_version="${3:-false}"
+    local generated_at
+    local generated_epoch
+    local now_epoch
+    local age_seconds
+    local expected_version
+    local evidence_version
+
+    if [[ -z "$file" || ! -f "$file" ]]; then
+        add_evidence_error "missing ${label} evidence: $(artifact_name "$file")"
+        OFFICIAL_ARTIFACTS_OK=false
+        return 1
+    fi
+
+    if ! jq empty "$file" >/dev/null 2>&1; then
+        add_evidence_error "malformed ${label} evidence: $(artifact_name "$file")"
+        OFFICIAL_ARTIFACTS_OK=false
+        return 1
+    fi
+
+    generated_at="$(jq -r '.generated_at // empty' "$file")"
+    if [[ -z "$generated_at" ]]; then
+        add_evidence_error "missing ${label} generated_at: $(artifact_name "$file")"
+        OFFICIAL_ARTIFACTS_OK=false
+        return 1
+    fi
+    if ! generated_epoch="$(json_timestamp_epoch "$generated_at")"; then
+        add_evidence_error "invalid ${label} generated_at: $(artifact_name "$file")"
+        OFFICIAL_ARTIFACTS_OK=false
+        return 1
+    fi
+    now_epoch="$(date -u +%s)"
+    age_seconds=$((now_epoch - generated_epoch))
+    if (( age_seconds < -300 || age_seconds > MAX_EVIDENCE_AGE_SECONDS )); then
+        add_evidence_error "stale ${label} evidence: $(artifact_name "$file")"
+        OFFICIAL_ARTIFACTS_OK=false
+        return 1
+    fi
+
+    expected_version="$(normalize_version "$RELEASE_VERSION")"
+    if [[ "$require_version" == "true" && -n "$expected_version" ]]; then
+        evidence_version="$(jq -r '.release_version // .expected_version // empty' "$file")"
+        evidence_version="$(normalize_version "$evidence_version")"
+        if [[ -z "$evidence_version" ]]; then
+            add_evidence_error "missing ${label} release version: $(artifact_name "$file")"
+            OFFICIAL_ARTIFACTS_OK=false
+            return 1
+        fi
+        if [[ "$evidence_version" != "$expected_version" ]]; then
+            add_evidence_error "version mismatch in ${label} evidence: expected ${expected_version}, got ${evidence_version}"
+            OFFICIAL_ARTIFACTS_OK=false
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
+derive_official_evidence() {
+    local sil_file
+    local vil_file
+    local security_file
+    local eval_file
+    local baseline_file
+    local security_full
+    local security_summary
+    local security_quick
+
+    [[ -z "$EVIDENCE_DIR" ]] && EVIDENCE_DIR="$ARTIFACT_DIR"
+    [[ -n "$DIGITAL_TWIN_EVIDENCE_FILE" && -z "$VIL_EVIDENCE_FILE" ]] && \
+        VIL_EVIDENCE_FILE="$DIGITAL_TWIN_EVIDENCE_FILE"
+
+    sil_file="$(resolve_evidence_path "$SIL_EVIDENCE_FILE" "sil-evidence.json")"
+    vil_file="$(resolve_evidence_path "$VIL_EVIDENCE_FILE" "digital-twin-evidence.json")"
+    HIL_FILE="$(resolve_evidence_path "$HIL_FILE" "hil-evidence.json")"
+    eval_file="$(resolve_evidence_path "$EVAL_EVIDENCE_FILE" "eval-agentops-fast.json")"
+    baseline_file="$(resolve_evidence_path "$EVAL_BASELINE_FILE" "eval-baseline-audit.json")"
+
+    security_full="$(resolve_evidence_path "$SECURITY_EVIDENCE_FILE" "security-gate-full.json")"
+    security_summary="$(resolve_evidence_path "$SECURITY_EVIDENCE_FILE" "security-gate-summary.json")"
+    security_quick="$(resolve_evidence_path "$SECURITY_EVIDENCE_FILE" "security-gate-quick.json")"
+    security_file="$(first_existing_evidence_path "$security_full" "$security_summary" "$security_quick")"
+
+    SIL_ARTIFACT="$(artifact_name "$sil_file")"
+    VIL_ARTIFACT="$(artifact_name "$vil_file")"
+    HIL_ARTIFACT="$(artifact_name "$HIL_FILE")"
+    SECURITY_ARTIFACT="$(artifact_name "$security_file")"
+    EVAL_ARTIFACT="$(artifact_name "$eval_file")"
+    ARTIFACTS_ARTIFACT="$(artifact_name "$EVIDENCE_DIR")"
+
+    SIL_STATUS="fail"
+    if validate_evidence_common "SIL" "$sil_file" true && \
+        jq -e '.schema_version == 1 and .evidence_kind == "software_in_loop" and .status == "pass"' "$sil_file" >/dev/null; then
+        SIL_STATUS="pass"
+    else
+        add_evidence_error "SIL evidence did not pass: $(artifact_name "$sil_file")"
+    fi
+
+    VIL_STATUS="fail"
+    if validate_evidence_common "digital twin" "$vil_file" true && \
+        jq -e '.schema_version == 1 and .evidence_kind == "digital_twin" and .status == "pass" and .dimensions.vil.status == "pass"' "$vil_file" >/dev/null; then
+        VIL_STATUS="pass"
+    else
+        add_evidence_error "digital twin/VIL evidence did not pass: $(artifact_name "$vil_file")"
+    fi
+
+    HIL_STATUS="fail"
+    HIL_WAIVER=""
+    if validate_evidence_common "HIL" "$HIL_FILE" true; then
+        HIL_STATUS="$(jq -r '.status // "fail"' "$HIL_FILE")"
+        HIL_WAIVER="$(jq -r '.waiver // empty' "$HIL_FILE")"
+        if [[ "$HIL_STATUS" == "pass" ]]; then
+            :
+        elif [[ "$HIL_STATUS" == "waived" && -n "$HIL_WAIVER" ]]; then
+            :
+        else
+            add_evidence_error "HIL evidence did not pass or carry a waiver: $(artifact_name "$HIL_FILE")"
+            HIL_STATUS="fail"
+        fi
+    else
+        add_evidence_error "HIL evidence did not pass: $(artifact_name "$HIL_FILE")"
+    fi
+
+    SECURITY_STATUS="fail"
+    if validate_evidence_common "security" "$security_file" true && \
+        jq -e '((.gate_status // "") | ascii_downcase) == "pass"' "$security_file" >/dev/null; then
+        SECURITY_STATUS="pass"
+    else
+        add_evidence_error "security evidence did not pass: $(artifact_name "$security_file")"
+    fi
+
+    EVAL_STATUS="fail"
+    if validate_evidence_common "eval" "$eval_file" true && \
+        validate_evidence_common "eval baseline" "$baseline_file" true && \
+        jq -e --arg baseline "$(artifact_name "$baseline_file")" \
+            '.schema_version == 1 and .evidence_kind == "agentops_eval_fast" and .status == "pass" and .baseline_audit == $baseline' \
+            "$eval_file" >/dev/null && \
+        jq -e '(.policy_mismatch_count | type == "number") and (((.stale_suite_hashes // []) | length) == 0)' "$baseline_file" >/dev/null; then
+        EVAL_STATUS="pass"
+    else
+        add_evidence_error "eval evidence did not pass: $(artifact_name "$eval_file")"
+    fi
+
+    ARTIFACT_STATUS="pass"
+    if [[ "$OFFICIAL_ARTIFACTS_OK" != "true" ]]; then
+        ARTIFACT_STATUS="fail"
+    fi
+}
+
+if [[ "$MODE" == "official" ]]; then
+    derive_official_evidence
+elif [[ -n "$HIL_FILE" ]]; then
     if [[ -f "$HIL_FILE" ]]; then
         HIL_STATUS="$(jq -r '.status // "fail"' "$HIL_FILE")"
         if [[ -z "$HIL_WAIVER" ]]; then
@@ -147,7 +439,7 @@ if [[ -n "$HIL_FILE" ]]; then
     fi
 fi
 
-if [[ -z "$HIL_STATUS" ]]; then
+if [[ "$MODE" != "official" && -z "$HIL_STATUS" ]]; then
     if [[ -n "$HIL_WAIVER" ]]; then
         HIL_STATUS="waived"
     else
@@ -234,14 +526,7 @@ fi
 [[ "$SECURITY_STATUS" == "pass" ]] || add_recommendation "Run the full security gate and include its JSON report."
 [[ "$EVAL_STATUS" == "pass" ]] || add_recommendation "Run release smoke/eval checks and attach the result."
 
-timestamp() {
-    date -u +%Y-%m-%dT%H:%M:%SZ
-}
-
-HIL_ARTIFACT=""
-if [[ -n "$HIL_FILE" ]]; then
-    HIL_ARTIFACT="$(basename "$HIL_FILE")"
-fi
+[[ -z "$HIL_ARTIFACT" && -n "$HIL_FILE" ]] && HIL_ARTIFACT="$(artifact_name "$HIL_FILE")"
 
 DOCUMENT="$(jq -n \
     --arg generated_at "$(timestamp)" \
@@ -254,7 +539,12 @@ DOCUMENT="$(jq -n \
     --arg artifact_status "$ARTIFACT_STATUS" \
     --arg security_status "$SECURITY_STATUS" \
     --arg eval_status "$EVAL_STATUS" \
+    --arg sil_artifact "$SIL_ARTIFACT" \
+    --arg vil_artifact "$VIL_ARTIFACT" \
     --arg hil_artifact "$HIL_ARTIFACT" \
+    --arg artifacts_artifact "$ARTIFACTS_ARTIFACT" \
+    --arg security_artifact "$SECURITY_ARTIFACT" \
+    --arg eval_artifact "$EVAL_ARTIFACT" \
     --arg hil_waiver "$HIL_WAIVER" \
     --argjson threshold "$THRESHOLD" \
     --argjson release_readiness_score "$SCORE" \
@@ -264,6 +554,7 @@ DOCUMENT="$(jq -n \
     --argjson artifact_points "$ARTIFACT_POINTS" \
     --argjson security_points "$SECURITY_POINTS" \
     --argjson eval_points "$EVAL_POINTS" \
+    --argjson evidence_errors "$EVIDENCE_ERRORS" \
     --argjson recommendations "$RECOMMENDATIONS" \
     '{
       schema_version: 1,
@@ -274,18 +565,19 @@ DOCUMENT="$(jq -n \
       release_status: $release_status,
       artifact_dir: (if $artifact_dir == "" then null else $artifact_dir end),
       dimensions: {
-        sil: {status: $sil_status, weight: 2, points: $sil_points},
-        vil: {status: $vil_status, weight: 2, points: $vil_points},
-        hil: {status: $hil_status, weight: 2, points: $hil_points},
-        artifacts: {status: $artifact_status, weight: 1.5, points: $artifact_points},
-        security: {status: $security_status, weight: 1.5, points: $security_points},
-        evals: {status: $eval_status, weight: 1, points: $eval_points}
+        sil: {status: $sil_status, weight: 2, points: $sil_points, evidence_artifact: (if $sil_artifact == "" then null else $sil_artifact end)},
+        vil: {status: $vil_status, weight: 2, points: $vil_points, evidence_artifact: (if $vil_artifact == "" then null else $vil_artifact end)},
+        hil: {status: $hil_status, weight: 2, points: $hil_points, evidence_artifact: (if $hil_artifact == "" then null else $hil_artifact end)},
+        artifacts: {status: $artifact_status, weight: 1.5, points: $artifact_points, evidence_artifact: (if $artifacts_artifact == "" then null else $artifacts_artifact end)},
+        security: {status: $security_status, weight: 1.5, points: $security_points, evidence_artifact: (if $security_artifact == "" then null else $security_artifact end)},
+        evals: {status: $eval_status, weight: 1, points: $eval_points, evidence_artifact: (if $eval_artifact == "" then null else $eval_artifact end)}
       },
       hil_evidence: {
         status: $hil_status,
         artifact: (if $hil_artifact == "" then null else $hil_artifact end),
         waiver: (if $hil_waiver == "" then null else $hil_waiver end)
       },
+      evidence_errors: $evidence_errors,
       recommendations: $recommendations
     }')"
 

--- a/scripts/ci-local-release.sh
+++ b/scripts/ci-local-release.sh
@@ -736,46 +736,25 @@ write_release_sil_evidence() {
 }
 
 write_release_digital_twin_evidence() {
-    local generated_at
-    local status="pass"
-    local reason="release smoke, hook install smoke, and ao init/rpi smoke completed before this artifact was written"
+    local mode
     local version
+    local args
 
-    generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    mode="$(release_readiness_mode)"
     version="$(release_version)"
-    if [[ "$FAST_MODE" == "true" ]]; then
-        status="skipped"
-        reason="fast mode skips the full release digital-twin/VIL proof"
-    elif [[ "$errors" -ne 0 ]]; then
-        status="fail"
-        reason="one or more preceding local release gates failed before digital-twin evidence was written"
+    args=(
+        "--out" "$ARTIFACT_DIR/digital-twin-evidence.json"
+        "--mode" "$mode"
+        "--ao-bin" "$REPO_ROOT/cli/bin/ao"
+    )
+    if [[ -n "$version" ]]; then
+        args+=("--expected-version" "$version")
+    fi
+    if [[ -n "${AGENTOPS_RELEASE_DIGITAL_TWIN_WAIVER:-}" ]]; then
+        args+=("--waiver" "$AGENTOPS_RELEASE_DIGITAL_TWIN_WAIVER")
     fi
 
-    jq -n \
-        --arg generated_at "$generated_at" \
-        --arg artifact_dir "$(artifact_dir_rel)" \
-        --arg release_version "$version" \
-        --arg status "$status" \
-        --arg reason "$reason" \
-        --argjson errors_before_artifact "$errors" \
-        '{
-          schema_version: 1,
-          evidence_kind: "digital_twin",
-          generated_at: $generated_at,
-          artifact_dir: $artifact_dir,
-          release_version: $release_version,
-          status: $status,
-          reason: $reason,
-          dimensions: {
-            vil: {status: $status, evidence: "local release digital twin"},
-            release_smoke: {status: $status},
-            hook_install_smoke: {status: $status},
-            rpi_smoke: {status: $status}
-          },
-          errors_before_artifact: $errors_before_artifact
-        }' > "$ARTIFACT_DIR/digital-twin-evidence.json"
-
-    [[ "$status" != "fail" ]]
+    ./scripts/check-release-digital-twin.sh "${args[@]}"
 }
 
 run_release_eval_evidence() {

--- a/scripts/ci-local-release.sh
+++ b/scripts/ci-local-release.sh
@@ -462,6 +462,7 @@ write_release_artifact_manifest() {
     local sbom_spdx=""
     local security_report=""
     local release_readiness=""
+    local sil_evidence=""
     local hil_evidence=""
     local vil_evidence=""
     local digital_twin_evidence=""
@@ -490,6 +491,9 @@ write_release_artifact_manifest() {
     if [[ -f "$ARTIFACT_DIR/release-readiness.json" ]]; then
         release_readiness="release-readiness.json"
     fi
+    if [[ -f "$ARTIFACT_DIR/sil-evidence.json" ]]; then
+        sil_evidence="sil-evidence.json"
+    fi
     if [[ -f "$ARTIFACT_DIR/hil-evidence.json" ]]; then
         hil_evidence="hil-evidence.json"
     fi
@@ -516,6 +520,7 @@ write_release_artifact_manifest() {
         --arg sbom_spdx "$sbom_spdx" \
         --arg security_report "$security_report" \
         --arg release_readiness "$release_readiness" \
+        --arg sil_evidence "$sil_evidence" \
         --arg hil_evidence "$hil_evidence" \
         --arg vil_evidence "$vil_evidence" \
         --arg digital_twin_evidence "$digital_twin_evidence" \
@@ -536,6 +541,7 @@ write_release_artifact_manifest() {
           sbom_spdx: (if $sbom_spdx == "" then null else $sbom_spdx end),
           security_report: (if $security_report == "" then null else $security_report end),
           release_readiness: (if $release_readiness == "" then null else $release_readiness end),
+          sil_evidence: (if $sil_evidence == "" then null else $sil_evidence end),
           hil_evidence: (if $hil_evidence == "" then null else $hil_evidence end),
           vil_evidence: (if $vil_evidence == "" then null else $vil_evidence end),
           digital_twin_evidence: (if $digital_twin_evidence == "" then null else $digital_twin_evidence end),
@@ -590,7 +596,11 @@ run_security_gate() {
     local output_file="$ARTIFACT_DIR/security-gate-${SECURITY_MODE}.json"
     local security_dir="$SECURITY_TMP_BASE/security"
     local tooling_dir="$SECURITY_TMP_BASE/tooling"
+    local tmp_file
+    local version
     mkdir -p "$security_dir" "$tooling_dir"
+    tmp_file="$(mktemp)"
+    version="$(release_version)"
 
     SECURITY_GATE_OUTPUT_DIR="$security_dir" \
     TOOLCHAIN_OUTPUT_DIR="$tooling_dir" \
@@ -598,6 +608,16 @@ run_security_gate() {
     TOOLCHAIN_GITLEAKS_RANGE="${TOOLCHAIN_GITLEAKS_RANGE:-origin/main..HEAD}" \
     TOOLCHAIN_GITLEAKS_GOMAXPROCS="${TOOLCHAIN_GITLEAKS_GOMAXPROCS:-2}" \
     ./scripts/security-gate.sh --mode "$SECURITY_MODE" --json > "$output_file"
+    jq \
+        --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --arg artifact_dir "$(artifact_dir_rel)" \
+        --arg release_version "$version" \
+        '. + {
+          generated_at: $generated_at,
+          artifact_dir: $artifact_dir,
+          release_version: $release_version
+        }' "$output_file" > "$tmp_file"
+    mv "$tmp_file" "$output_file"
     jq -e '.gate_status' "$output_file" >/dev/null
     echo "Security report:  $output_file"
     echo "Security artifacts: $security_dir"
@@ -681,12 +701,48 @@ run_release_hil_evidence() {
     ./scripts/check-release-hil.sh "${args[@]}"
 }
 
+write_release_sil_evidence() {
+    local generated_at
+    local status="pass"
+    local reason="all local release CI checks before readiness passed"
+    local version
+
+    generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    version="$(release_version)"
+    if [[ "$errors" -ne 0 ]]; then
+        status="fail"
+        reason="one or more local release CI checks failed before readiness"
+    fi
+
+    jq -n \
+        --arg generated_at "$generated_at" \
+        --arg artifact_dir "$(artifact_dir_rel)" \
+        --arg release_version "$version" \
+        --arg status "$status" \
+        --arg reason "$reason" \
+        --argjson errors_before_readiness "$errors" \
+        '{
+          schema_version: 1,
+          evidence_kind: "software_in_loop",
+          generated_at: $generated_at,
+          artifact_dir: $artifact_dir,
+          release_version: $release_version,
+          status: $status,
+          reason: $reason,
+          errors_before_readiness: $errors_before_readiness
+        }' > "$ARTIFACT_DIR/sil-evidence.json"
+
+    return 0
+}
+
 write_release_digital_twin_evidence() {
     local generated_at
     local status="pass"
     local reason="release smoke, hook install smoke, and ao init/rpi smoke completed before this artifact was written"
+    local version
 
     generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    version="$(release_version)"
     if [[ "$FAST_MODE" == "true" ]]; then
         status="skipped"
         reason="fast mode skips the full release digital-twin/VIL proof"
@@ -698,6 +754,7 @@ write_release_digital_twin_evidence() {
     jq -n \
         --arg generated_at "$generated_at" \
         --arg artifact_dir "$(artifact_dir_rel)" \
+        --arg release_version "$version" \
         --arg status "$status" \
         --arg reason "$reason" \
         --argjson errors_before_artifact "$errors" \
@@ -706,6 +763,7 @@ write_release_digital_twin_evidence() {
           evidence_kind: "digital_twin",
           generated_at: $generated_at,
           artifact_dir: $artifact_dir,
+          release_version: $release_version,
           status: $status,
           reason: $reason,
           dimensions: {
@@ -721,20 +779,27 @@ write_release_digital_twin_evidence() {
 }
 
 run_release_eval_evidence() {
+    local version
+    version="$(release_version)"
+
     if [[ "$FAST_MODE" == "true" ]]; then
         jq -n \
             --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg artifact_dir "$(artifact_dir_rel)" \
+            --arg release_version "$version" \
             '{
               schema_version: 1,
               evidence_kind: "agentops_eval_fast",
               generated_at: $generated_at,
               artifact_dir: $artifact_dir,
+              release_version: $release_version,
               status: "skipped",
               reason: "fast mode skips release eval evidence"
             }' > "$ARTIFACT_DIR/eval-agentops-fast.json"
         jq -n \
-            '{suite_count: 0, baseline_count: 0, policy_mismatch_count: 0, stale_suite_hashes: []}' \
+            --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg release_version "$version" \
+            '{generated_at: $generated_at, release_version: $release_version, suite_count: 0, baseline_count: 0, policy_mismatch_count: 0, stale_suite_hashes: []}' \
             > "$ARTIFACT_DIR/eval-baseline-audit.json"
         return 0
     fi
@@ -751,10 +816,16 @@ run_release_eval_evidence() {
 
     run_dir="$(find "$run_root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort | tail -1)"
     if [[ -n "$run_dir" && -f "$run_dir/baseline-audit.json" ]]; then
-        cp "$run_dir/baseline-audit.json" "$ARTIFACT_DIR/eval-baseline-audit.json"
+        jq \
+            --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg release_version "$version" \
+            '. + {generated_at: $generated_at, release_version: $release_version}' \
+            "$run_dir/baseline-audit.json" > "$ARTIFACT_DIR/eval-baseline-audit.json"
     else
         jq -n \
-            '{suite_count: 0, baseline_count: 0, policy_mismatch_count: 0, stale_suite_hashes: []}' \
+            --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg release_version "$version" \
+            '{generated_at: $generated_at, release_version: $release_version, suite_count: 0, baseline_count: 0, policy_mismatch_count: 0, stale_suite_hashes: []}' \
             > "$ARTIFACT_DIR/eval-baseline-audit.json"
         rc=1
     fi
@@ -765,6 +836,7 @@ run_release_eval_evidence() {
     jq -n \
         --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
         --arg artifact_dir "$(artifact_dir_rel)" \
+        --arg release_version "$version" \
         --arg status "$status" \
         --arg command "scripts/eval-agentops.sh --fast" \
         --arg run_dir "${run_dir#"$REPO_ROOT"/}" \
@@ -776,6 +848,7 @@ run_release_eval_evidence() {
           evidence_kind: "agentops_eval_fast",
           generated_at: $generated_at,
           artifact_dir: $artifact_dir,
+          release_version: $release_version,
           status: $status,
           command: $command,
           exit_code: $exit_code,
@@ -793,9 +866,11 @@ check_release_readiness() {
     local artifact_status="pass"
     local vil_status="pass"
     local eval_status="pass"
+    local version
     local args
 
     mode="$(release_readiness_mode)"
+    version="$(release_version)"
     if [[ "$FAST_MODE" == "true" ]]; then
         security_status="skipped"
         artifact_status="skipped"
@@ -816,19 +891,26 @@ check_release_readiness() {
         "--out" "$ARTIFACT_DIR/release-readiness.json"
         "--mode" "$mode"
         "--threshold" "8"
-        "--sil" "pass"
-        "--vil" "$vil_status"
-        "--artifacts" "$artifact_status"
-        "--security" "$security_status"
-        "--eval" "$eval_status"
     )
 
-    if [[ -f "$ARTIFACT_DIR/hil-evidence.json" ]]; then
-        args+=("--hil-file" "$ARTIFACT_DIR/hil-evidence.json")
-    elif [[ -n "$RELEASE_HIL_WAIVER" ]]; then
-        args+=("--hil-status" "waived" "--hil-waiver" "$RELEASE_HIL_WAIVER")
+    if [[ "$mode" == "official" ]]; then
+        args+=("--evidence-dir" "$ARTIFACT_DIR" "--release-version" "$version")
     else
-        args+=("--hil-status" "skipped")
+        args+=(
+            "--sil" "pass"
+            "--vil" "$vil_status"
+            "--artifacts" "$artifact_status"
+            "--security" "$security_status"
+            "--eval" "$eval_status"
+        )
+
+        if [[ -f "$ARTIFACT_DIR/hil-evidence.json" ]]; then
+            args+=("--hil-file" "$ARTIFACT_DIR/hil-evidence.json")
+        elif [[ -n "$RELEASE_HIL_WAIVER" ]]; then
+            args+=("--hil-status" "waived" "--hil-waiver" "$RELEASE_HIL_WAIVER")
+        else
+            args+=("--hil-status" "skipped")
+        fi
     fi
 
     ./scripts/check-release-readiness.sh "${args[@]}"
@@ -998,6 +1080,7 @@ run_step "Agents-hub content-hash gate" check_agents_hash_gate
 # ── Phase 7: Release readiness evidence ──
 # Official release audits (--release-version) require HIL evidence or an
 # explicit waiver. Normal local runs and --fast runs still write advisory JSON.
+run_step "SIL release evidence" write_release_sil_evidence
 run_step "HIL release evidence" run_release_hil_evidence
 run_step "Release readiness score gate" check_release_readiness
 

--- a/scripts/resolve-release-artifacts.sh
+++ b/scripts/resolve-release-artifacts.sh
@@ -37,6 +37,7 @@ while IFS= read -r manifest; do
         (.sbom_spdx | type == "string" and length > 0) and
         (.security_report | type == "string" and length > 0) and
         (.release_readiness | type == "string" and length > 0) and
+        (.sil_evidence | type == "string" and length > 0) and
         (.hil_evidence | type == "string" and length > 0) and
         (.vil_evidence | type == "string" and length > 0) and
         (.digital_twin_evidence | type == "string" and length > 0) and
@@ -51,6 +52,7 @@ while IFS= read -r manifest; do
     sbom_spdx="$(jq -r '.sbom_spdx' "$manifest")"
     security_report="$(jq -r '.security_report' "$manifest")"
     release_readiness="$(jq -r '.release_readiness' "$manifest")"
+    sil_evidence="$(jq -r '.sil_evidence' "$manifest")"
     hil_evidence="$(jq -r '.hil_evidence' "$manifest")"
     vil_evidence="$(jq -r '.vil_evidence' "$manifest")"
     digital_twin_evidence="$(jq -r '.digital_twin_evidence' "$manifest")"
@@ -61,6 +63,7 @@ while IFS= read -r manifest; do
           -f "$REPO_ROOT/$artifact_dir/$sbom_spdx" && \
           -f "$REPO_ROOT/$artifact_dir/$security_report" && \
           -f "$REPO_ROOT/$artifact_dir/$release_readiness" && \
+          -f "$REPO_ROOT/$artifact_dir/$sil_evidence" && \
           -f "$REPO_ROOT/$artifact_dir/$hil_evidence" && \
           -f "$REPO_ROOT/$artifact_dir/$vil_evidence" && \
           -f "$REPO_ROOT/$artifact_dir/$digital_twin_evidence" && \
@@ -74,6 +77,7 @@ while IFS= read -r manifest; do
           .dimensions.vil.status == "pass" and
           (.dimensions.hil.status == "pass" or .dimensions.hil.status == "waived")
         ' "$REPO_ROOT/$artifact_dir/$release_readiness" >/dev/null 2>&1 && \
+        jq -e '.schema_version == 1 and .evidence_kind == "software_in_loop" and .status == "pass"' "$REPO_ROOT/$artifact_dir/$sil_evidence" >/dev/null 2>&1 && \
         jq -e '((.gate_status // "") | ascii_downcase) == "pass"' "$REPO_ROOT/$artifact_dir/$security_report" >/dev/null 2>&1 && \
         jq -e '.schema_version == 1 and .status == "pass"' "$REPO_ROOT/$artifact_dir/$eval_fast_report" >/dev/null 2>&1 && \
         jq -e '(.policy_mismatch_count | type == "number") and (((.stale_suite_hashes // []) | length) == 0)' "$REPO_ROOT/$artifact_dir/$eval_baseline_audit" >/dev/null 2>&1 && \

--- a/scripts/validate-release-audit-artifacts.sh
+++ b/scripts/validate-release-audit-artifacts.sh
@@ -111,6 +111,7 @@ validate_manifest_artifacts() {
     local sbom_spdx
     local security_report
     local release_readiness
+    local sil_evidence
     local hil_evidence
     local vil_evidence
     local digital_twin_evidence
@@ -125,6 +126,7 @@ validate_manifest_artifacts() {
     sbom_spdx="$(jq -r '.sbom_spdx // empty' "$manifest")"
     security_report="$(jq -r '.security_report // empty' "$manifest")"
     release_readiness="$(jq -r '.release_readiness // empty' "$manifest")"
+    sil_evidence="$(jq -r '.sil_evidence // empty' "$manifest")"
     hil_evidence="$(jq -r '.hil_evidence // empty' "$manifest")"
     vil_evidence="$(jq -r '.vil_evidence // empty' "$manifest")"
     digital_twin_evidence="$(jq -r '.digital_twin_evidence // empty' "$manifest")"
@@ -161,9 +163,10 @@ validate_manifest_artifacts() {
         return 1
     fi
 
-    if [[ "$strict_readiness" == "true" || -n "$release_readiness" || -n "$hil_evidence" || \
+    if [[ "$strict_readiness" == "true" || -n "$release_readiness" || -n "$sil_evidence" || -n "$hil_evidence" || \
           -n "$vil_evidence" || -n "$digital_twin_evidence" || -n "$eval_fast_report" || -n "$eval_baseline_audit" ]]; then
         require_artifact_file "$audit" "$artifact_dir" "release readiness" "$release_readiness" || return 1
+        require_artifact_file "$audit" "$artifact_dir" "SIL evidence" "$sil_evidence" || return 1
         require_artifact_file "$audit" "$artifact_dir" "HIL evidence" "$hil_evidence" || return 1
         require_artifact_file "$audit" "$artifact_dir" "VIL evidence" "$vil_evidence" || return 1
         require_artifact_file "$audit" "$artifact_dir" "digital twin evidence" "$digital_twin_evidence" || return 1
@@ -180,6 +183,14 @@ validate_manifest_artifacts() {
             (.dimensions.hil.status == "pass" or .dimensions.hil.status == "waived")
         ' "$REPO_ROOT/$artifact_dir/$release_readiness" >/dev/null; then
             printf '%s: release readiness artifact did not pass >=8 SIL/VIL/HIL gate: %s/%s\n' "$audit" "$artifact_dir" "$release_readiness"
+            return 1
+        fi
+        if ! jq -e '
+            .schema_version == 1 and
+            .evidence_kind == "software_in_loop" and
+            .status == "pass"
+        ' "$REPO_ROOT/$artifact_dir/$sil_evidence" >/dev/null; then
+            printf '%s: SIL evidence did not pass: %s/%s\n' "$audit" "$artifact_dir" "$sil_evidence"
             return 1
         fi
         if ! jq -e '

--- a/tests/scripts/ci-local-release.bats
+++ b/tests/scripts/ci-local-release.bats
@@ -131,9 +131,13 @@ teardown() {
 }
 
 @test "script wires HIL and release readiness gates" {
+    run grep -q 'write_release_sil_evidence' "$SCRIPT"
+    [ "$status" -eq 0 ]
     run grep -q 'check-release-hil.sh' "$SCRIPT"
     [ "$status" -eq 0 ]
     run grep -q 'check-release-readiness.sh' "$SCRIPT"
+    [ "$status" -eq 0 ]
+    run grep -q -- '--evidence-dir' "$SCRIPT"
     [ "$status" -eq 0 ]
 }
 
@@ -145,6 +149,8 @@ teardown() {
     run grep -q 'eval_fast_report:' "$SCRIPT"
     [ "$status" -eq 0 ]
     run grep -q 'digital_twin_evidence:' "$SCRIPT"
+    [ "$status" -eq 0 ]
+    run grep -q 'release_version: $release_version' "$SCRIPT"
     [ "$status" -eq 0 ]
 }
 

--- a/tests/scripts/ci-local-release.bats
+++ b/tests/scripts/ci-local-release.bats
@@ -144,6 +144,8 @@ teardown() {
 @test "script wires eval and digital twin evidence into release artifacts" {
     run grep -q 'run_step "Digital twin/VIL evidence" write_release_digital_twin_evidence' "$SCRIPT"
     [ "$status" -eq 0 ]
+    run grep -q 'check-release-digital-twin.sh' "$SCRIPT"
+    [ "$status" -eq 0 ]
     run grep -q 'run_step "AgentOps eval evidence" run_release_eval_evidence' "$SCRIPT"
     [ "$status" -eq 0 ]
     run grep -q 'eval_fast_report:' "$SCRIPT"

--- a/tests/scripts/release-artifacts.bats
+++ b/tests/scripts/release-artifacts.bats
@@ -54,6 +54,7 @@ write_manifest() {
   "sbom_spdx": "sbom-v$version.spdx.json",
   "security_report": "security-gate-full.json",
   "release_readiness": "release-readiness.json",
+  "sil_evidence": "sil-evidence.json",
   "hil_evidence": "hil-evidence.json",
   "vil_evidence": "digital-twin-evidence.json",
   "digital_twin_evidence": "digital-twin-evidence.json",
@@ -70,6 +71,7 @@ write_artifact_files() {
     printf '{"bomFormat":"CycloneDX"}\n' > "$dir/sbom-v$version.cyclonedx.json"
     printf '{"spdxVersion":"SPDX-2.3"}\n' > "$dir/sbom-v$version.spdx.json"
     printf '{"gate_status":"PASS"}\n' > "$dir/security-gate-full.json"
+    printf '{"schema_version":1,"evidence_kind":"software_in_loop","status":"pass"}\n' > "$dir/sil-evidence.json"
     cat > "$dir/release-readiness.json" <<'EOF'
 {
   "schema_version": 1,
@@ -207,6 +209,17 @@ EOF
     run "$FAKE_REPO/scripts/resolve-release-artifacts.sh" "2.29.0"
     [ "$status" -eq 1 ]
     [[ "$output" == *"no full local CI artifacts found for release version 2.29.0"* ]]
+}
+
+@test "validate-release-audit-artifacts rejects missing SIL evidence for release audits" {
+    write_manifest "20260322T212222Z" "2.29.0" false
+    write_artifact_files "20260322T212222Z" "2.29.0"
+    rm "$FAKE_REPO/.agents/releases/local-ci/20260322T212222Z/sil-evidence.json"
+    write_audit "2.29.0" "20260322T212222Z" "2026-05-02"
+
+    run "$FAKE_REPO/scripts/validate-release-audit-artifacts.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing SIL evidence artifact sil-evidence.json"* ]]
 }
 
 @test "resolve-release-artifacts rejects manifests without eval evidence" {

--- a/tests/scripts/release-digital-twin.bats
+++ b/tests/scripts/release-digital-twin.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/check-release-digital-twin.sh"
+    TMP_DIR="$(mktemp -d)"
+    VERSION="2.29.0"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+write_fake_ao() {
+    local path="$TMP_DIR/ao"
+    cat > "$path" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+    version)
+        echo "ao version ${AO_FAKE_VERSION:-2.29.0}"
+        ;;
+    init)
+        if [[ "${2:-}" == "--hooks" ]]; then
+            mkdir -p .agentops-init
+            echo "hooks initialized"
+        else
+            echo "init help"
+        fi
+        ;;
+    hooks)
+        echo "hooks ok"
+        ;;
+    rpi)
+        if [[ "${AO_FAKE_FAIL_RPI:-0}" == "1" ]]; then
+            echo "rpi failed" >&2
+            exit 12
+        fi
+        echo "rpi ok"
+        ;;
+    doctor)
+        echo "doctor ok"
+        ;;
+    --help|-h)
+        echo "ao help"
+        ;;
+    *)
+        echo "unknown command: ${1:-}" >&2
+        exit 2
+        ;;
+esac
+SH
+    chmod +x "$path"
+    printf '%s\n' "$path"
+}
+
+@test "fast digital twin skips when ao binary is unavailable" {
+    out="$TMP_DIR/digital-twin-evidence.json"
+
+    run bash "$SCRIPT" --mode fast --ao-bin "$TMP_DIR/missing-ao" --out "$out"
+
+    [ "$status" -eq 0 ]
+    jq -e '.status == "skipped" and .dimensions.vil.status == "skipped"' "$out"
+}
+
+@test "official digital twin fails when ao binary is unavailable" {
+    out="$TMP_DIR/digital-twin-evidence.json"
+
+    run bash "$SCRIPT" --mode official --ao-bin "$TMP_DIR/missing-ao" --out "$out"
+
+    [ "$status" -eq 1 ]
+    jq -e '.status == "fail" and (.failure_reasons | index("ao_binary_unavailable"))' "$out"
+}
+
+@test "official digital twin can be explicitly waived" {
+    out="$TMP_DIR/digital-twin-evidence.json"
+
+    run bash "$SCRIPT" \
+        --mode official \
+        --ao-bin "$TMP_DIR/missing-ao" \
+        --waiver "disposable runner unavailable" \
+        --out "$out"
+
+    [ "$status" -eq 0 ]
+    jq -e '.status == "waived" and .waiver == "disposable runner unavailable"' "$out"
+}
+
+@test "official digital twin passes with full workflow evidence" {
+    out="$TMP_DIR/digital-twin-evidence.json"
+    ao_bin="$(write_fake_ao)"
+
+    run bash "$SCRIPT" \
+        --mode official \
+        --ao-bin "$ao_bin" \
+        --expected-version "$VERSION" \
+        --out "$out"
+
+    [ "$status" -eq 0 ]
+    jq -e '
+      .schema_version == 1 and
+      .evidence_kind == "digital_twin" and
+      .status == "pass" and
+      .release_version == "2.29.0" and
+      .workflow_strength == "full" and
+      .dimensions.vil.status == "pass" and
+      .dimensions.install_upgrade.status == "pass" and
+      .dimensions.hook_install_smoke.status == "pass" and
+      .dimensions.rpi_smoke.status == "pass" and
+      (.checks | length) >= 6
+    ' "$out"
+}
+
+@test "official digital twin fails on version mismatch" {
+    out="$TMP_DIR/digital-twin-evidence.json"
+    ao_bin="$(AO_FAKE_VERSION=2.30.0 write_fake_ao)"
+
+    run env AO_FAKE_VERSION=2.30.0 bash "$SCRIPT" \
+        --mode official \
+        --ao-bin "$ao_bin" \
+        --expected-version "$VERSION" \
+        --out "$out"
+
+    [ "$status" -eq 1 ]
+    jq -e '.status == "fail" and (.failure_reasons | index("version_mismatch"))' "$out"
+}
+
+@test "official digital twin fails when a required workflow check fails" {
+    out="$TMP_DIR/digital-twin-evidence.json"
+    ao_bin="$(write_fake_ao)"
+
+    run env AO_FAKE_FAIL_RPI=1 bash "$SCRIPT" \
+        --mode official \
+        --ao-bin "$ao_bin" \
+        --expected-version "$VERSION" \
+        --out "$out"
+
+    [ "$status" -eq 1 ]
+    jq -e '.status == "fail" and (.failure_reasons | index("workflow_failed")) and .dimensions.rpi_smoke.status == "fail"' "$out"
+}

--- a/tests/scripts/release-readiness.bats
+++ b/tests/scripts/release-readiness.bats
@@ -4,18 +4,109 @@ setup() {
     REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
     SCRIPT="$REPO_ROOT/scripts/check-release-readiness.sh"
     TMP_DIR="$(mktemp -d)"
+    VERSION="2.29.0"
 }
 
 teardown() {
     rm -rf "$TMP_DIR"
 }
 
-@test "official readiness passes with complete SIL/VIL/HIL evidence" {
+write_official_evidence() {
+    local generated_at="${1:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+    local version="${2:-$VERSION}"
+
+    jq -n \
+        --arg generated_at "$generated_at" \
+        --arg version "$version" \
+        '{schema_version:1,evidence_kind:"software_in_loop",generated_at:$generated_at,release_version:$version,status:"pass",errors_before_readiness:0}' \
+        > "$TMP_DIR/sil-evidence.json"
+    jq -n \
+        --arg generated_at "$generated_at" \
+        --arg version "$version" \
+        '{schema_version:1,evidence_kind:"digital_twin",generated_at:$generated_at,release_version:$version,status:"pass",dimensions:{vil:{status:"pass"},release_smoke:{status:"pass"},hook_install_smoke:{status:"pass"},rpi_smoke:{status:"pass"}}}' \
+        > "$TMP_DIR/digital-twin-evidence.json"
+    jq -n \
+        --arg generated_at "$generated_at" \
+        --arg version "$version" \
+        '{schema_version:1,generated_at:$generated_at,status:"pass",expected_version:$version,waiver:null,targets:[{name:"loop",status:"pass",workflow_strength:"strong"}]}' \
+        > "$TMP_DIR/hil-evidence.json"
+    jq -n \
+        --arg generated_at "$generated_at" \
+        --arg version "$version" \
+        '{generated_at:$generated_at,release_version:$version,gate_status:"PASS"}' \
+        > "$TMP_DIR/security-gate-full.json"
+    jq -n \
+        --arg generated_at "$generated_at" \
+        --arg version "$version" \
+        '{schema_version:1,evidence_kind:"agentops_eval_fast",generated_at:$generated_at,release_version:$version,status:"pass",baseline_audit:"eval-baseline-audit.json"}' \
+        > "$TMP_DIR/eval-agentops-fast.json"
+    jq -n \
+        --arg generated_at "$generated_at" \
+        --arg version "$version" \
+        '{generated_at:$generated_at,release_version:$version,suite_count:1,baseline_count:0,policy_mismatch_count:0,stale_suite_hashes:[]}' \
+        > "$TMP_DIR/eval-baseline-audit.json"
+}
+
+run_official_readiness() {
+    local out="$1"
+
+    bash "$SCRIPT" \
+        --mode official \
+        --out "$out" \
+        --artifact-dir "$TMP_DIR" \
+        --evidence-dir "$TMP_DIR" \
+        --release-version "$VERSION"
+}
+
+@test "official readiness passes with complete evidence artifacts" {
+    out="$TMP_DIR/release-readiness.json"
+    write_official_evidence
+
+    run run_official_readiness "$out"
+
+    [ "$status" -eq 0 ]
+    jq -e '
+        .release_status == "pass" and
+        .release_readiness_score == 10 and
+        .dimensions.sil.evidence_artifact == "sil-evidence.json" and
+        .dimensions.vil.evidence_artifact == "digital-twin-evidence.json" and
+        .dimensions.hil.evidence_artifact == "hil-evidence.json" and
+        .dimensions.security.evidence_artifact == "security-gate-full.json" and
+        .dimensions.evals.evidence_artifact == "eval-agentops-fast.json"
+    ' "$out"
+}
+
+@test "official readiness fails when required evidence is missing" {
+    out="$TMP_DIR/release-readiness.json"
+    write_official_evidence
+    rm "$TMP_DIR/hil-evidence.json"
+
+    run run_official_readiness "$out"
+
+    [ "$status" -eq 1 ]
+    jq -e '.release_status == "fail" and .dimensions.hil.status == "fail" and (.evidence_errors | index("missing HIL evidence: hil-evidence.json"))' "$out"
+}
+
+@test "official readiness accepts evidence-backed HIL waiver above threshold" {
+    out="$TMP_DIR/release-readiness.json"
+    write_official_evidence
+    jq --arg waiver "bench unavailable" '.status = "waived" | .waiver = $waiver | .targets = []' \
+        "$TMP_DIR/hil-evidence.json" > "$TMP_DIR/hil-evidence.json.tmp"
+    mv "$TMP_DIR/hil-evidence.json.tmp" "$TMP_DIR/hil-evidence.json"
+
+    run run_official_readiness "$out"
+
+    [ "$status" -eq 0 ]
+    jq -e '.release_status == "pass" and .release_readiness_score == 9 and .hil_evidence.waiver == "bench unavailable"' "$out"
+}
+
+@test "official readiness rejects caller status strings without evidence artifacts" {
     out="$TMP_DIR/release-readiness.json"
 
     run bash "$SCRIPT" \
         --mode official \
         --out "$out" \
+        --artifact-dir "$TMP_DIR" \
         --sil pass \
         --vil pass \
         --hil-status pass \
@@ -23,43 +114,28 @@ teardown() {
         --security pass \
         --eval pass
 
-    [ "$status" -eq 0 ]
-    jq -e '.release_status == "pass" and .release_readiness_score == 10 and .dimensions.hil.status == "pass"' "$out"
+    [ "$status" -eq 1 ]
+    jq -e '.release_status == "fail" and .dimensions.sil.status == "fail"' "$out"
 }
 
-@test "official readiness fails when HIL is missing" {
+@test "official readiness rejects stale evidence" {
     out="$TMP_DIR/release-readiness.json"
+    write_official_evidence "2000-01-01T00:00:00Z"
 
-    run bash "$SCRIPT" \
-        --mode official \
-        --out "$out" \
-        --sil pass \
-        --vil pass \
-        --hil-status skipped \
-        --artifacts pass \
-        --security pass \
-        --eval pass
+    run run_official_readiness "$out"
 
     [ "$status" -eq 1 ]
-    jq -e '.release_status == "fail" and .release_readiness_score == 8 and .dimensions.hil.status == "skipped"' "$out"
+    jq -e '.release_status == "fail" and any(.evidence_errors[]; contains("stale"))' "$out"
 }
 
-@test "official readiness accepts an explicit HIL waiver above threshold" {
+@test "official readiness rejects mismatched release version evidence" {
     out="$TMP_DIR/release-readiness.json"
+    write_official_evidence "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "2.30.0"
 
-    run bash "$SCRIPT" \
-        --mode official \
-        --out "$out" \
-        --sil pass \
-        --vil pass \
-        --hil-status waived \
-        --hil-waiver "bench unavailable" \
-        --artifacts pass \
-        --security pass \
-        --eval pass
+    run run_official_readiness "$out"
 
-    [ "$status" -eq 0 ]
-    jq -e '.release_status == "pass" and .release_readiness_score == 9 and .hil_evidence.waiver == "bench unavailable"' "$out"
+    [ "$status" -eq 1 ]
+    jq -e '.release_status == "fail" and any(.evidence_errors[]; contains("version mismatch"))' "$out"
 }
 
 @test "advisory readiness records warning without failing the command" {
@@ -79,13 +155,13 @@ teardown() {
     jq -e '.release_status == "warn" and .release_readiness_score == 3' "$out"
 }
 
-@test "readiness reads HIL status from a HIL evidence file" {
+@test "advisory readiness reads HIL status from a HIL evidence file" {
     hil="$TMP_DIR/hil-evidence.json"
     out="$TMP_DIR/release-readiness.json"
     jq -n '{schema_version:1,status:"pass",waiver:null,targets:[{name:"loop",status:"pass"}]}' > "$hil"
 
     run bash "$SCRIPT" \
-        --mode official \
+        --mode advisory \
         --out "$out" \
         --hil-file "$hil" \
         --sil pass \

--- a/tests/scripts/release-workflow.bats
+++ b/tests/scripts/release-workflow.bats
@@ -51,4 +51,21 @@ line_of() {
     [ "$status" -eq 0 ]
     run grep -Fq 'gh release upload "$VERSION" release-artifacts/security-gate-summary.json --clobber' "$WORKFLOW"
     [ "$status" -eq 0 ]
+    run grep -Fq 'gh release upload "$VERSION" release-artifacts/sil-evidence.json --clobber' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}
+
+@test "release readiness uses evidence files instead of caller status strings" {
+    run grep -Fq -- '--evidence-dir release-artifacts' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+    run grep -Fq 'sil-evidence.json' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+    run grep -Fq 'digital-twin-evidence.json' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+    run grep -Fq 'eval-agentops-fast.json' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+    run grep -Fq -- '--sil pass' "$WORKFLOW"
+    [ "$status" -eq 1 ]
+    run grep -Fq -- '--security pass' "$WORKFLOW"
+    [ "$status" -eq 1 ]
 }

--- a/tests/scripts/release-workflow.bats
+++ b/tests/scripts/release-workflow.bats
@@ -62,6 +62,8 @@ line_of() {
     [ "$status" -eq 0 ]
     run grep -Fq 'digital-twin-evidence.json' "$WORKFLOW"
     [ "$status" -eq 0 ]
+    run grep -Fq 'check-release-digital-twin.sh' "$WORKFLOW"
+    [ "$status" -eq 0 ]
     run grep -Fq 'eval-agentops-fast.json' "$WORKFLOW"
     [ "$status" -eq 0 ]
     run grep -Fq -- '--sil pass' "$WORKFLOW"


### PR DESCRIPTION
## Summary
- Make official release readiness derive SIL/VIL/HIL/security/eval/artifact status from evidence JSON files instead of caller-supplied status strings.
- Add SIL evidence into local release manifests, resolver/audit validation, and release publisher evidence upload/attestation.
- Update release docs/schema and BATS coverage for missing, stale, and version-mismatched evidence.

## Validation
- bash -n scripts/check-release-readiness.sh scripts/ci-local-release.sh scripts/resolve-release-artifacts.sh scripts/validate-release-audit-artifacts.sh
- shellcheck --severity=error scripts/check-release-readiness.sh scripts/ci-local-release.sh scripts/resolve-release-artifacts.sh scripts/validate-release-audit-artifacts.sh
- bats tests/scripts/release-hil.bats tests/scripts/release-readiness.bats tests/scripts/ci-local-release.bats tests/scripts/release-artifacts.bats tests/scripts/release-workflow.bats
- markdownlint docs/RELEASING.md docs/release-e2e-checklist.md docs/contracts/release-readiness.md docs/CI-CD.md
- bash tests/docs/validate-doc-release.sh
- bash scripts/check-contract-compatibility.sh
- bash scripts/validate-ci-policy-parity.sh
- python3 YAML parse of .github/workflows/release.yml
- git diff --check
- scripts/pre-push-gate.sh --fast (passes; existing warn-only executable-spec unknown-flag warnings remain)