### PR TITLE
feat(release): add digital twin evidence runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,8 @@ jobs:
 
           # Build a pre-publish binary for VIL/eval evidence before GoReleaser
           # publishes the official archives.
-          (cd cli && go build -o ../release-artifacts/ao ./cmd/ao)
+          (cd cli && make build VERSION="$VERSION")
+          cp cli/bin/ao release-artifacts/ao
           release-artifacts/ao version > release-artifacts/ao-version.txt
           release-artifacts/ao init --help > /dev/null
           release-artifacts/ao rpi --help > /dev/null
@@ -110,11 +111,12 @@ jobs:
             --arg release_version "$VERSION" \
             '{schema_version:1,evidence_kind:"software_in_loop",generated_at:$generated_at,release_version:$release_version,status:"pass",reason:"release publisher pre-publish checks completed",errors_before_readiness:0}' \
             > release-artifacts/sil-evidence.json
-          jq -n \
-            --arg generated_at "$GENERATED_AT" \
-            --arg release_version "$VERSION" \
-            '{schema_version:1,evidence_kind:"digital_twin",generated_at:$generated_at,release_version:$release_version,status:"pass",reason:"pre-publish ao build, version, init, and rpi smoke completed",dimensions:{vil:{status:"pass"},release_smoke:{status:"pass"},hook_install_smoke:{status:"pass"},rpi_smoke:{status:"pass"}}}' \
-            > release-artifacts/digital-twin-evidence.json
+          chmod +x scripts/check-release-digital-twin.sh
+          scripts/check-release-digital-twin.sh \
+            --mode official \
+            --ao-bin "$PWD/release-artifacts/ao" \
+            --expected-version "$VERSION" \
+            --out release-artifacts/digital-twin-evidence.json
           jq -n \
             --arg generated_at "$GENERATED_AT" \
             --arg release_version "$VERSION" \

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -192,7 +192,7 @@ Release validation is local-first and enforced by:
 ./scripts/ci-local-release.sh
 ```
 
-This local gate runs doc checks, manifest/schema checks, smoke/integration checks, hook and `ao rpi` smoke paths, binary validation, SBOM generation, security scans, AgentOps eval evidence, digital-twin/VIL evidence, and the release readiness score. Official release audits require fresh SIL/VIL/security/eval evidence JSON plus workflow-rich HIL evidence or an explicit HIL waiver; status strings alone do not satisfy official readiness.
+This local gate runs doc checks, manifest/schema checks, smoke/integration checks, hook and `ao rpi` smoke paths, binary validation, SBOM generation, security scans, AgentOps eval evidence, executable digital-twin/VIL evidence, and the release readiness score. Official release audits require fresh SIL/VIL/security/eval evidence JSON plus workflow-rich HIL evidence or an explicit HIL waiver; status strings alone do not satisfy official readiness.
 For command variants and expected release-E2E smoke markers, see [Release E2E Checklist](release-e2e-checklist.md).
 
 ## Failure Modes

--- a/docs/contracts/release-readiness.md
+++ b/docs/contracts/release-readiness.md
@@ -73,6 +73,22 @@ must pass `--hil-waiver "reason"` so the waiver is visible in both the HIL and
 readiness artifacts. A waiver is acceptable release evidence, but it scores only
 half of the HIL dimension.
 
+## Digital-Twin / VIL Evidence
+
+`scripts/check-release-digital-twin.sh` captures the disposable local workflow
+artifact:
+
+```text
+.agents/releases/local-ci/<run-id>/digital-twin-evidence.json
+```
+
+Official mode requires a real `ao` binary and records install/upgrade smoke,
+version parity, core command smoke, `ao init --hooks`, `ao hooks show`,
+`ao rpi status`, and runtime/help surfaces in a temporary HOME and repository.
+Fast mode runs a lightweight subset when the binary is available and records
+`skipped` when it is not. A digital-twin waiver is explicit evidence, not an
+implicit pass.
+
 ## Release Artifacts
 
 `release-artifacts.json` records these fields when the local gate runs:

--- a/docs/release-e2e-checklist.md
+++ b/docs/release-e2e-checklist.md
@@ -59,7 +59,7 @@ Expect:
 - `.agents/releases/local-ci/<timestamp>/release-readiness.json` has `release_status: pass` and `release_readiness_score >= 8`
 - `.agents/releases/local-ci/<timestamp>/sil-evidence.json` has `status: pass`, matching `release_version`, and the same run's local CI error count before readiness
 - `.agents/releases/local-ci/<timestamp>/hil-evidence.json` has `status: pass` or `status: waived`; passing targets record OS/architecture/runtime identity, workflow checks, command fingerprint, and release-version verification
-- `.agents/releases/local-ci/<timestamp>/digital-twin-evidence.json` has `status: pass` and `dimensions.vil.status: pass`
+- `.agents/releases/local-ci/<timestamp>/digital-twin-evidence.json` has `status: pass`, `workflow_strength: full`, matching `release_version`, and passing install/upgrade, hook install, RPI, plugin runtime, and version-parity dimensions
 - `.agents/releases/local-ci/<timestamp>/eval-agentops-fast.json` has `status: pass`, and `eval-baseline-audit.json` has no `stale_suite_hashes`
 
 If the fast gate passes but this full gate fails, stop. The release is not ready to tag. Use the failing section in the full-gate output, rerun the official local gate until it passes, and if a tag or publish already happened, follow the failure-mode steps in [RELEASING](RELEASING.md#failure-modes) before retrying anything else.

--- a/scripts/check-release-digital-twin.sh
+++ b/scripts/check-release-digital-twin.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT=""
+MODE="${AGENTOPS_RELEASE_DIGITAL_TWIN_MODE:-official}"
+AO_BIN="${AGENTOPS_RELEASE_AO_BIN:-}"
+EXPECTED_VERSION="${AGENTOPS_RELEASE_VERSION:-}"
+WAIVER="${AGENTOPS_RELEASE_DIGITAL_TWIN_WAIVER:-}"
+TIMEOUT_SECONDS="${AGENTOPS_RELEASE_DIGITAL_TWIN_TIMEOUT:-30}"
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/check-release-digital-twin.sh [options]
+
+Capture release digital-twin/VIL evidence in a disposable local environment.
+
+Options:
+  --out PATH              Write JSON evidence to PATH
+  --mode MODE             official|advisory|fast (default: official)
+  --ao-bin PATH           ao binary to exercise (default: cli/bin/ao, then PATH)
+  --expected-version V    Require ao version output to mention this version
+  --waiver TEXT           Record an explicit digital-twin waiver
+  --timeout SECONDS       Per-check timeout when timeout(1) is available (default: 30)
+  -h, --help              Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --out)
+            OUT="${2:-}"
+            shift 2
+            ;;
+        --mode)
+            MODE="${2:-}"
+            shift 2
+            ;;
+        --ao-bin)
+            AO_BIN="${2:-}"
+            shift 2
+            ;;
+        --expected-version)
+            EXPECTED_VERSION="${2:-}"
+            shift 2
+            ;;
+        --waiver)
+            WAIVER="${2:-}"
+            shift 2
+            ;;
+        --timeout)
+            TIMEOUT_SECONDS="${2:-}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required for digital-twin evidence" >&2
+    exit 1
+fi
+
+if [[ "$MODE" != "official" && "$MODE" != "advisory" && "$MODE" != "fast" ]]; then
+    echo "--mode must be official, advisory, or fast" >&2
+    exit 1
+fi
+
+if [[ ! "$TIMEOUT_SECONDS" =~ ^[0-9]+$ || "$TIMEOUT_SECONDS" -eq 0 ]]; then
+    echo "--timeout must be a positive integer" >&2
+    exit 1
+fi
+
+timestamp() {
+    date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+normalize_version() {
+    local version="$1"
+    printf '%s\n' "${version#v}"
+}
+
+json_array_add() {
+    local current_json="$1"
+    local value="$2"
+
+    jq -c --arg value "$value" '. + [$value]' <<<"$current_json"
+}
+
+runtime_identity() {
+    jq -n \
+        --arg os "$(uname -s 2>/dev/null || true)" \
+        --arg arch "$(uname -m 2>/dev/null || true)" \
+        --arg kernel "$(uname -r 2>/dev/null || true)" \
+        --arg hostname "$(hostname 2>/dev/null || true)" \
+        '{os: $os, arch: $arch, kernel: $kernel, hostname: $hostname}'
+}
+
+if [[ -z "$AO_BIN" ]]; then
+    if [[ -x "cli/bin/ao" ]]; then
+        AO_BIN="cli/bin/ao"
+    elif command -v ao >/dev/null 2>&1; then
+        AO_BIN="$(command -v ao)"
+    fi
+fi
+
+CHECKS='[]'
+FAILURE_REASONS='[]'
+DIM_VIL="pass"
+DIM_RELEASE_SMOKE="pass"
+DIM_INSTALL_UPGRADE="pass"
+DIM_HOOK_INSTALL="pass"
+DIM_RPI="pass"
+DIM_PLUGIN_RUNTIME="pass"
+DIM_VERSION_PARITY="pass"
+STATUS="pass"
+EXIT_CODE=0
+WORKFLOW_STRENGTH="full"
+TMP_ROOT=""
+
+set_dimension_fail() {
+    local dimension="$1"
+
+    case "$dimension" in
+        vil) DIM_VIL="fail" ;;
+        release_smoke) DIM_RELEASE_SMOKE="fail" ;;
+        install_upgrade) DIM_INSTALL_UPGRADE="fail" ;;
+        hook_install_smoke) DIM_HOOK_INSTALL="fail" ;;
+        rpi_smoke) DIM_RPI="fail" ;;
+        plugin_runtime) DIM_PLUGIN_RUNTIME="fail" ;;
+        version_parity) DIM_VERSION_PARITY="fail"; DIM_VIL="fail" ;;
+    esac
+}
+
+append_check() {
+    local name="$1"
+    local dimension="$2"
+    local status="$3"
+    local exit_code="$4"
+    local duration_seconds="$5"
+    local output_preview="$6"
+    local command_label="$7"
+
+    CHECKS="$(jq -c \
+        --arg name "$name" \
+        --arg dimension "$dimension" \
+        --arg status "$status" \
+        --arg output_preview "$output_preview" \
+        --arg command "$command_label" \
+        --argjson exit_code "$exit_code" \
+        --argjson duration_seconds "$duration_seconds" \
+        '. + [{
+          name: $name,
+          dimension: $dimension,
+          status: $status,
+          exit_code: $exit_code,
+          duration_seconds: $duration_seconds,
+          command: $command,
+          output_preview: $output_preview
+        }]' <<<"$CHECKS")"
+}
+
+write_document() {
+    local generated_at
+    local artifact_dir
+
+    generated_at="$(timestamp)"
+    artifact_dir=""
+    if [[ -n "$OUT" ]]; then
+        artifact_dir="$(dirname "$OUT")"
+    fi
+
+    DOCUMENT="$(jq -n \
+        --arg generated_at "$generated_at" \
+        --arg artifact_dir "$artifact_dir" \
+        --arg mode "$MODE" \
+        --arg status "$STATUS" \
+        --arg workflow_strength "$WORKFLOW_STRENGTH" \
+        --arg release_version "$(normalize_version "$EXPECTED_VERSION")" \
+        --arg ao_bin "$AO_BIN" \
+        --arg waiver "$WAIVER" \
+        --arg vil_status "$DIM_VIL" \
+        --arg release_smoke_status "$DIM_RELEASE_SMOKE" \
+        --arg install_upgrade_status "$DIM_INSTALL_UPGRADE" \
+        --arg hook_install_status "$DIM_HOOK_INSTALL" \
+        --arg rpi_status "$DIM_RPI" \
+        --arg plugin_runtime_status "$DIM_PLUGIN_RUNTIME" \
+        --arg version_parity_status "$DIM_VERSION_PARITY" \
+        --argjson timeout_seconds "$TIMEOUT_SECONDS" \
+        --argjson checks "$CHECKS" \
+        --argjson runtime "$(runtime_identity)" \
+        --argjson failure_reasons "$FAILURE_REASONS" \
+        '{
+          schema_version: 1,
+          evidence_kind: "digital_twin",
+          generated_at: $generated_at,
+          artifact_dir: (if $artifact_dir == "" then null else $artifact_dir end),
+          mode: $mode,
+          status: $status,
+          workflow_strength: $workflow_strength,
+          release_version: (if $release_version == "" then null else $release_version end),
+          ao_bin: (if $ao_bin == "" then null else $ao_bin end),
+          waiver: (if $waiver == "" then null else $waiver end),
+          timeout_seconds: $timeout_seconds,
+          runtime: $runtime,
+          dimensions: {
+            vil: {status: $vil_status},
+            release_smoke: {status: $release_smoke_status},
+            install_upgrade: {status: $install_upgrade_status},
+            hook_install_smoke: {status: $hook_install_status},
+            rpi_smoke: {status: $rpi_status},
+            plugin_runtime: {status: $plugin_runtime_status},
+            version_parity: {status: $version_parity_status}
+          },
+          checks: $checks,
+          failure_reasons: $failure_reasons
+        }')"
+
+    if [[ -n "$OUT" ]]; then
+        mkdir -p "$(dirname "$OUT")"
+        printf '%s\n' "$DOCUMENT" >"$OUT"
+    fi
+    printf '%s\n' "$DOCUMENT"
+}
+
+finish_unavailable() {
+    local reason="$1"
+
+    FAILURE_REASONS="$(json_array_add "$FAILURE_REASONS" "$reason")"
+    DIM_VIL="skipped"
+    DIM_RELEASE_SMOKE="skipped"
+    DIM_INSTALL_UPGRADE="skipped"
+    DIM_HOOK_INSTALL="skipped"
+    DIM_RPI="skipped"
+    DIM_PLUGIN_RUNTIME="skipped"
+    DIM_VERSION_PARITY="skipped"
+
+    if [[ -n "$WAIVER" ]]; then
+        STATUS="waived"
+        EXIT_CODE=0
+    elif [[ "$MODE" == "official" ]]; then
+        STATUS="fail"
+        DIM_VIL="fail"
+        EXIT_CODE=1
+    else
+        STATUS="skipped"
+        EXIT_CODE=0
+    fi
+
+    write_document
+    exit "$EXIT_CODE"
+}
+
+if [[ -n "$WAIVER" ]]; then
+    finish_unavailable "waived"
+fi
+
+if [[ -z "$AO_BIN" || ! -x "$AO_BIN" ]]; then
+    finish_unavailable "ao_binary_unavailable"
+fi
+
+TMP_ROOT="$(mktemp -d)"
+cleanup() {
+    [[ -n "$TMP_ROOT" ]] && rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+TMP_HOME="$TMP_ROOT/home"
+TMP_REPO="$TMP_ROOT/repo"
+INSTALL_DIR="$TMP_ROOT/bin"
+mkdir -p "$TMP_HOME" "$TMP_REPO" "$INSTALL_DIR"
+if command -v git >/dev/null 2>&1; then
+    git -C "$TMP_REPO" init -q
+fi
+
+INSTALLED_AO="$INSTALL_DIR/ao"
+cp "$AO_BIN" "$INSTALLED_AO"
+chmod +x "$INSTALLED_AO"
+
+run_command() {
+    local command_string="$1"
+
+    if command -v timeout >/dev/null 2>&1; then
+        HOME="$TMP_HOME" timeout "$TIMEOUT_SECONDS" bash -lc "$command_string"
+    else
+        HOME="$TMP_HOME" bash -lc "$command_string"
+    fi
+}
+
+run_check() {
+    local name="$1"
+    local dimension="$2"
+    local command_string="$3"
+    local started_epoch
+    local duration_seconds
+    local tmp_output
+    local rc=0
+    local output_preview
+
+    started_epoch="$(date +%s)"
+    tmp_output="$(mktemp)"
+    set +e
+    (
+        cd "$TMP_REPO"
+        run_command "$command_string"
+    ) >"$tmp_output" 2>&1
+    rc=$?
+    set -e
+    duration_seconds=$(( $(date +%s) - started_epoch ))
+    output_preview="$(tail -20 "$tmp_output")"
+    rm -f "$tmp_output"
+
+    if [[ "$rc" -eq 0 ]]; then
+        append_check "$name" "$dimension" "pass" "$rc" "$duration_seconds" "$output_preview" "$name"
+    else
+        append_check "$name" "$dimension" "fail" "$rc" "$duration_seconds" "$output_preview" "$name"
+        FAILURE_REASONS="$(json_array_add "$FAILURE_REASONS" "workflow_failed")"
+        set_dimension_fail "$dimension"
+        STATUS="fail"
+        EXIT_CODE=1
+    fi
+}
+
+if [[ "$MODE" == "fast" ]]; then
+    WORKFLOW_STRENGTH="lightweight"
+fi
+
+run_check "install" "install_upgrade" "test -x '$INSTALLED_AO' && '$INSTALLED_AO' version"
+run_check "version" "version_parity" "'$INSTALLED_AO' version"
+run_check "core-help" "release_smoke" "'$INSTALLED_AO' --help"
+run_check "rpi-help" "rpi_smoke" "'$INSTALLED_AO' rpi --help"
+
+if [[ "$MODE" != "fast" ]]; then
+    run_check "upgrade" "install_upgrade" "cp '$AO_BIN' '$INSTALL_DIR/ao.next' && chmod +x '$INSTALL_DIR/ao.next' && mv '$INSTALL_DIR/ao.next' '$INSTALLED_AO' && '$INSTALLED_AO' version"
+    run_check "init-hooks" "hook_install_smoke" "'$INSTALLED_AO' init --hooks && '$INSTALLED_AO' hooks show"
+    run_check "rpi-status" "rpi_smoke" "'$INSTALLED_AO' rpi status"
+    run_check "plugin-runtime" "plugin_runtime" "'$INSTALLED_AO' hooks --help && '$INSTALLED_AO' doctor --help"
+fi
+
+if [[ -n "$EXPECTED_VERSION" ]]; then
+    version_output="$(HOME="$TMP_HOME" "$INSTALLED_AO" version 2>/dev/null || true)"
+    if ! grep -Fq "$(normalize_version "$EXPECTED_VERSION")" <<<"$version_output"; then
+        FAILURE_REASONS="$(json_array_add "$FAILURE_REASONS" "version_mismatch")"
+        set_dimension_fail "version_parity"
+        STATUS="fail"
+        EXIT_CODE=1
+    fi
+fi
+
+if [[ "$STATUS" == "fail" && "$MODE" == "advisory" ]]; then
+    EXIT_CODE=0
+fi
+
+write_document
+exit "$EXIT_CODE"

--- a/scripts/ci-local-release.sh
+++ b/scripts/ci-local-release.sh
@@ -736,46 +736,25 @@ write_release_sil_evidence() {
 }
 
 write_release_digital_twin_evidence() {
-    local generated_at
-    local status="pass"
-    local reason="release smoke, hook install smoke, and ao init/rpi smoke completed before this artifact was written"
+    local mode
     local version
+    local args
 
-    generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    mode="$(release_readiness_mode)"
     version="$(release_version)"
-    if [[ "$FAST_MODE" == "true" ]]; then
-        status="skipped"
-        reason="fast mode skips the full release digital-twin/VIL proof"
-    elif [[ "$errors" -ne 0 ]]; then
-        status="fail"
-        reason="one or more preceding local release gates failed before digital-twin evidence was written"
+    args=(
+        "--out" "$ARTIFACT_DIR/digital-twin-evidence.json"
+        "--mode" "$mode"
+        "--ao-bin" "$REPO_ROOT/cli/bin/ao"
+    )
+    if [[ -n "$version" ]]; then
+        args+=("--expected-version" "$version")
+    fi
+    if [[ -n "${AGENTOPS_RELEASE_DIGITAL_TWIN_WAIVER:-}" ]]; then
+        args+=("--waiver" "$AGENTOPS_RELEASE_DIGITAL_TWIN_WAIVER")
     fi
 
-    jq -n \
-        --arg generated_at "$generated_at" \
-        --arg artifact_dir "$(artifact_dir_rel)" \
-        --arg release_version "$version" \
-        --arg status "$status" \
-        --arg reason "$reason" \
-        --argjson errors_before_artifact "$errors" \
-        '{
-          schema_version: 1,
-          evidence_kind: "digital_twin",
-          generated_at: $generated_at,
-          artifact_dir: $artifact_dir,
-          release_version: $release_version,
-          status: $status,
-          reason: $reason,
-          dimensions: {
-            vil: {status: $status, evidence: "local release digital twin"},
-            release_smoke: {status: $status},
-            hook_install_smoke: {status: $status},
-            rpi_smoke: {status: $status}
-          },
-          errors_before_artifact: $errors_before_artifact
-        }' > "$ARTIFACT_DIR/digital-twin-evidence.json"
-
-    [[ "$status" != "fail" ]]
+    ./scripts/check-release-digital-twin.sh "${args[@]}"
 }
 
 run_release_eval_evidence() {

--- a/tests/scripts/ci-local-release.bats
+++ b/tests/scripts/ci-local-release.bats
@@ -144,6 +144,8 @@ teardown() {
 @test "script wires eval and digital twin evidence into release artifacts" {
     run grep -q 'run_step "Digital twin/VIL evidence" write_release_digital_twin_evidence' "$SCRIPT"
     [ "$status" -eq 0 ]
+    run grep -q 'check-release-digital-twin.sh' "$SCRIPT"
+    [ "$status" -eq 0 ]
     run grep -q 'run_step "AgentOps eval evidence" run_release_eval_evidence' "$SCRIPT"
     [ "$status" -eq 0 ]
     run grep -q 'eval_fast_report:' "$SCRIPT"

--- a/tests/scripts/release-digital-twin.bats
+++ b/tests/scripts/release-digital-twin.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/check-release-digital-twin.sh"
+    TMP_DIR="$(mktemp -d)"
+    VERSION="2.29.0"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+write_fake_ao() {
+    local path="$TMP_DIR/ao"
+    cat > "$path" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+    version)
+        echo "ao version ${AO_FAKE_VERSION:-2.29.0}"
+        ;;
+    init)
+        if [[ "${2:-}" == "--hooks" ]]; then
+            mkdir -p .agentops-init
+            echo "hooks initialized"
+        else
+            echo "init help"
+        fi
+        ;;
+    hooks)
+        echo "hooks ok"
+        ;;
+    rpi)
+        if [[ "${AO_FAKE_FAIL_RPI:-0}" == "1" ]]; then
+            echo "rpi failed" >&2
+            exit 12
+        fi
+        echo "rpi ok"
+        ;;
+    doctor)
+        echo "doctor ok"
+        ;;
+    --help|-h)
+        echo "ao help"
+        ;;
+    *)
+        echo "unknown command: ${1:-}" >&2
+        exit 2
+        ;;
+esac
+SH
+    chmod +x "$path"
+    printf '%s\n' "$path"
+}
+
+@test "fast digital twin skips when ao binary is unavailable" {
+    out="$TMP_DIR/digital-twin-evidence.json"
+
+    run bash "$SCRIPT" --mode fast --ao-bin "$TMP_DIR/missing-ao" --out "$out"
+
+    [ "$status" -eq 0 ]
+    jq -e '.status == "skipped" and .dimensions.vil.status == "skipped"' "$out"
+}
+
+@test "official digital twin fails when ao binary is unavailable" {
+    out="$TMP_DIR/digital-twin-evidence.json"
+
+    run bash "$SCRIPT" --mode official --ao-bin "$TMP_DIR/missing-ao" --out "$out"
+
+    [ "$status" -eq 1 ]
+    jq -e '.status == "fail" and (.failure_reasons | index("ao_binary_unavailable"))' "$out"
+}
+
+@test "official digital twin can be explicitly waived" {
+    out="$TMP_DIR/digital-twin-evidence.json"
+
+    run bash "$SCRIPT" \
+        --mode official \
+        --ao-bin "$TMP_DIR/missing-ao" \
+        --waiver "disposable runner unavailable" \
+        --out "$out"
+
+    [ "$status" -eq 0 ]
+    jq -e '.status == "waived" and .waiver == "disposable runner unavailable"' "$out"
+}
+
+@test "official digital twin passes with full workflow evidence" {
+    out="$TMP_DIR/digital-twin-evidence.json"
+    ao_bin="$(write_fake_ao)"
+
+    run bash "$SCRIPT" \
+        --mode official \
+        --ao-bin "$ao_bin" \
+        --expected-version "$VERSION" \
+        --out "$out"
+
+    [ "$status" -eq 0 ]
+    jq -e '
+      .schema_version == 1 and
+      .evidence_kind == "digital_twin" and
+      .status == "pass" and
+      .release_version == "2.29.0" and
+      .workflow_strength == "full" and
+      .dimensions.vil.status == "pass" and
+      .dimensions.install_upgrade.status == "pass" and
+      .dimensions.hook_install_smoke.status == "pass" and
+      .dimensions.rpi_smoke.status == "pass" and
+      (.checks | length) >= 6
+    ' "$out"
+}
+
+@test "official digital twin fails on version mismatch" {
+    out="$TMP_DIR/digital-twin-evidence.json"
+    ao_bin="$(AO_FAKE_VERSION=2.30.0 write_fake_ao)"
+
+    run env AO_FAKE_VERSION=2.30.0 bash "$SCRIPT" \
+        --mode official \
+        --ao-bin "$ao_bin" \
+        --expected-version "$VERSION" \
+        --out "$out"
+
+    [ "$status" -eq 1 ]
+    jq -e '.status == "fail" and (.failure_reasons | index("version_mismatch"))' "$out"
+}
+
+@test "official digital twin fails when a required workflow check fails" {
+    out="$TMP_DIR/digital-twin-evidence.json"
+    ao_bin="$(write_fake_ao)"
+
+    run env AO_FAKE_FAIL_RPI=1 bash "$SCRIPT" \
+        --mode official \
+        --ao-bin "$ao_bin" \
+        --expected-version "$VERSION" \
+        --out "$out"
+
+    [ "$status" -eq 1 ]
+    jq -e '.status == "fail" and (.failure_reasons | index("workflow_failed")) and .dimensions.rpi_smoke.status == "fail"' "$out"
+}

--- a/tests/scripts/release-workflow.bats
+++ b/tests/scripts/release-workflow.bats
@@ -62,6 +62,8 @@ line_of() {
     [ "$status" -eq 0 ]
     run grep -Fq 'digital-twin-evidence.json' "$WORKFLOW"
     [ "$status" -eq 0 ]
+    run grep -Fq 'check-release-digital-twin.sh' "$WORKFLOW"
+    [ "$status" -eq 0 ]
     run grep -Fq 'eval-agentops-fast.json' "$WORKFLOW"
     [ "$status" -eq 0 ]
     run grep -Fq -- '--sil pass' "$WORKFLOW"


### PR DESCRIPTION
## Summary
- Add scripts/check-release-digital-twin.sh to run disposable install/upgrade, version, init/hooks, rpi, and runtime smoke checks against a release ao binary.
- Wire ci-local-release and the release publisher workflow to produce digital-twin/VIL evidence through the runner instead of inline JSON.
- Document the digital-twin evidence contract and add BATS coverage for pass, fail, skipped, waived, and version-mismatch cases.

## Validation
- bash -n scripts/check-release-digital-twin.sh scripts/ci-local-release.sh scripts/check-release-readiness.sh
- shellcheck --severity=error scripts/check-release-digital-twin.sh scripts/ci-local-release.sh scripts/check-release-readiness.sh
- bats tests/scripts/release-hil.bats tests/scripts/release-digital-twin.bats tests/scripts/release-readiness.bats tests/scripts/ci-local-release.bats tests/scripts/release-artifacts.bats tests/scripts/release-workflow.bats
- markdownlint docs/RELEASING.md docs/release-e2e-checklist.md docs/contracts/release-readiness.md docs/CI-CD.md
- bash tests/docs/validate-doc-release.sh
- bash scripts/check-contract-compatibility.sh
- bash scripts/validate-ci-policy-parity.sh
- python3 YAML parse of .github/workflows/release.yml
- git diff --check
- scripts/pre-push-gate.sh --fast (passes; existing warn-only executable-spec unknown-flag warnings remain)