### PR TITLE
docs(contracts): add @claude bot delegation runbook (soc-22wa)

### DIFF
--- a/docs/contracts/claude-bot-delegation.md
+++ b/docs/contracts/claude-bot-delegation.md
@@ -134,7 +134,9 @@ In this repo, `claude-review` is a required check. If the `@claude` workflow is 
 
 ## See also
 
-- [Lesson `claude-app-default-readonly`](../../.agents/learnings/2026-05-17-claude-app-default-readonly.md) — the install-perm gotcha as a one-rule lesson
-- [Lesson `dogfood-install-pr`](../../.agents/learnings/2026-05-17-dogfood-install-pr.md) — the install PR must itself follow the discipline it installs
+- Lesson `claude-app-default-readonly` (local-only: `.agents/learnings/2026-05-17-claude-app-default-readonly.md`) — the install-perm gotcha as a one-rule lesson
+- Lesson `dogfood-install-pr` (local-only: `.agents/learnings/2026-05-17-dogfood-install-pr.md`) — the install PR must itself follow the discipline it installs
 - [Lesson Format](lesson-format.md) — schema for `.agents/learnings/` entries
 - [AGENTS.md `## Workflow`](../../AGENTS.md) — PR-only discipline this bot operates inside
+
+> `.agents/learnings/` is repo-local (gitignored). Search local lessons with `bd memories <keyword>` or via the [Lesson Format](lesson-format.md) contract.

--- a/docs/contracts/claude-bot-delegation.md
+++ b/docs/contracts/claude-bot-delegation.md
@@ -1,0 +1,140 @@
+# @claude Bot Delegation Runbook
+
+> Operational contract for the `@claude` GitHub App in this repo.
+> Source of truth for workflow + permissions: `.github/workflows/claude.yml`.
+
+## What @claude is
+
+A GitHub App that watches the repo for `@claude` mentions and, when one fires the workflow, spawns a Claude Code session against the current PR/issue context. The session can read CI results, edit files, commit to the PR branch, mark PRs ready for review, and comment.
+
+It is **not** an autonomous agent that monitors PRs on a schedule. It only acts on mention.
+
+## What it is not
+
+- Not a substitute for branch protection (CI still gates merges)
+- Not a `workflows: write` actor — it cannot edit files under `.github/workflows/` by default (see [Gotcha 2](#gotcha-2-workflow-files-fail-silently))
+- Not a reviewer in the GitHub "Required reviewers" sense — the required check is the `claude-review` *status check*, not a human-style review
+
+## Install
+
+Run `/install-github-app` from the Claude Code CLI. This:
+
+1. Installs the Anthropic-published GitHub App on the repo
+2. Adds `.github/workflows/claude.yml`
+3. Stores `CLAUDE_CODE_OAUTH_TOKEN` as a repo secret
+
+## Permissions
+
+The installed `claude.yml` defaults to **read-only** for `contents`, `pull-requests`, and `issues`. With those defaults the bot can see context, post review-style comments, and… that's it. No commits, no PR updates, no issue closes.
+
+**Required for active delegation:**
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+```
+
+After `/install-github-app`, verify the workflow contains these. If not, ship a PR upgrading them (PR #301 in this repo did exactly this). See lesson `claude-app-default-readonly`.
+
+**Permissions that are intentionally not granted** in this repo: `workflows: write`. See [Gotcha 2](#gotcha-2-workflow-files-fail-silently).
+
+## What triggers the bot
+
+The `if:` condition in `claude.yml` fires on the substring `@claude` in:
+
+| Event | Where |
+|---|---|
+| `issue_comment.created` | Issue/PR comment body |
+| `pull_request_review_comment.created` | PR review comment body |
+| `pull_request_review.submitted` | PR review body |
+| `issues.opened` / `issues.assigned` | Issue title or body |
+
+A `@claude` in a commit message, PR description, code, or markdown file does **not** trigger it.
+
+## Status decoding
+
+`gh run list --workflow=claude.yml` shows:
+
+| `status` | `conclusion` | Meaning |
+|---|---|---|
+| `in_progress` | (empty) | Bot is actively working |
+| `completed` | `success` | Bot finished its turn (may or may not have pushed; check commits) |
+| `completed` | `skipped` | The `if:` condition matched the event but anti-loop logic suppressed the run (almost always: the comment came from the bot itself) |
+| `completed` | `failure` | Bot errored; check run logs |
+| `completed` | `cancelled` | Workflow was cancelled (rare) |
+
+"Skipped" runs are normal: the bot ignores its own comments to avoid loops. They're not a problem — they're the protocol working.
+
+## What @claude can and can't do
+
+| Action | Works? |
+|---|---|
+| Commit to existing PR branch | yes |
+| Open new branches/PRs | yes |
+| Resolve merge conflicts | yes (often; not always) |
+| Mark draft PR ready for review | yes |
+| Close issues | yes |
+| Edit `.github/workflows/*.yml` | **no** — see Gotcha 2 |
+| Edit repo settings, branch protection | no |
+| Push directly to `main` | no — branch protection blocks |
+| Merge a PR | only via auto-merge (it can enable auto-merge, then CI must go green) |
+
+## Gotchas
+
+### Gotcha 1: Default install is read-only
+
+`/install-github-app` ships `contents/pull-requests/issues: read`. The bot will respond to mentions, but every push attempt silently fails (you'll see a `success` run with no commits, or a confused comment). Upgrade to `write` before promising delegation works.
+
+### Gotcha 2: Workflow files fail silently
+
+The bot does not have `workflows: write` and cannot edit anything under `.github/workflows/`. In PR #270 (this repo, 2026-05-18) a forward-merge from main pulled in `claude.yml` changes; the bot detected the perm gap and **reverted that subset of its own merge** with the commit message *"revert: undo claude.yml forward-port (requires workflows permission)"*.
+
+Treat workflow-file forward-ports as human-only operations. If you need the bot to update workflow files, ship a separate PR that elevates the perm, or upgrade the App's repo-level workflow permission.
+
+### Gotcha 3: Anti-loop = silent stop on follow-up
+
+Once the bot posts a comment, every subsequent comment on that PR by the bot itself is `skipped`. New `@claude` comments from a human resume work. If a PR looks stuck after the bot's first pass, post a fresh `@claude` comment with sharper guidance — don't expect the bot to "notice" it should try again.
+
+### Gotcha 4: Auto-merge cascades need green required checks
+
+Setting `auto_merge: true` on a PR doesn't merge it — it merges it once **all required status checks** pass on the *current* head. If `main` moves and your PR goes BEHIND, required checks may be stale or marked failed; the PR will sit unmerged until you trigger a branch update (`gh api repos/<owner>/<repo>/pulls/<n>/update-branch -X PUT`). The bot does not auto-trigger this.
+
+In this repo, `claude-review` is a required check. If the `@claude` workflow is silent (no mention fired), the check is never set — auto-merge will sit waiting.
+
+## When to use @claude
+
+| Situation | Delegate? |
+|---|---|
+| Routine rebase + push | yes |
+| Mark draft ready after CI passes | yes |
+| Address known-mechanical conflict (e.g. counts, registry drift) | yes |
+| Catch up a long-lived branch to main | yes |
+| Semantic refactor across multiple files | maybe — give it a tight scope |
+| Architecture decision | no — use `/council --mode=debate` instead |
+| Anything requiring `workflows: write` | no — human PR |
+
+## How to delegate well
+
+1. **One comment per intent.** Multiple `@claude` mentions in fast succession dilute the prompt; the bot reads them all but applies the most recent.
+2. **Cite file paths and line numbers.** "Fix the test on `cli/internal/foo/foo_test.go:42`" beats "fix the failing test."
+3. **State the success criterion.** "Mark this PR ready when CI is green" gives the bot a stop condition.
+4. **Don't ask for opinions.** The bot is best at execution. Architecture/design decisions go through `/council`.
+5. **Verify with `gh run watch`.** Don't trust "I'll fix it" — confirm the run was `success` and a commit landed.
+
+## Operating contract
+
+- **Default required check:** `claude-review` (this repo's branch protection requires it on `main`).
+- **Workflow file:** `.github/workflows/claude.yml`.
+- **Bot identity:** commits authored by `github-actions[bot]` with co-author `Claude`.
+- **OAuth secret:** `CLAUDE_CODE_OAUTH_TOKEN` (rotate via `/install-github-app` re-run if compromised).
+
+## See also
+
+- [Lesson `claude-app-default-readonly`](../../.agents/learnings/2026-05-17-claude-app-default-readonly.md) — the install-perm gotcha as a one-rule lesson
+- [Lesson `dogfood-install-pr`](../../.agents/learnings/2026-05-17-dogfood-install-pr.md) — the install PR must itself follow the discipline it installs
+- [Lesson Format](lesson-format.md) — schema for `.agents/learnings/` entries
+- [AGENTS.md `## Workflow`](../../AGENTS.md) — PR-only discipline this bot operates inside

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -267,6 +267,7 @@ Bridge / framing docs:
 - [Lesson Format](contracts/lesson-format.md) — Schema for `.agents/learnings/` entries with frontmatter (id/severity/trigger/verifiable/rule/falsified_by/practice/related) and graduation path (unassigned → proposed → accepted → encoded)
 - [Bounded Contexts (yaml)](contracts/bounded-contexts.yaml) — Canonical BC1-BC5 definitions (id/name/responsibility/ports/center-of-gravity); registry doc prose must match this yaml (drift-checked by `scripts/check-bounded-contexts-drift.sh`, soc-zxia.2)
 - [add-validate-job scaffolder](https://github.com/boshu2/agentops/blob/main/scripts/add-validate-job.sh) — CI integration scaffolder; emits all 5 touch-points (workflow + summary needs + summary echo + pre-push + bats stub + AGENTS table) atomically when adding a new `validate-*` job (soc-3oij)
+- [@claude Bot Delegation](contracts/claude-bot-delegation.md) — Operational runbook for the `@claude` GitHub App: permissions, triggers, status decoding, gotchas, when to delegate
 - [Context Map](contracts/context-map.md) — Auto-generated bounded-context map of skills by hexagonal role with relationship and data-flow views (see ADR-0001)
 - [Skill Domain Map](contracts/skill-domain-map.md) — V0 DDD map assigning every shared skill to one explicit skill domain with ports, artifacts, and adapters
 - [Skill Ports and Adapters](contracts/skill-ports-and-adapters.md) — V0 skill-boundary vocabulary for inbound ports, outbound ports, adapters, context packets, and guard surfaces


### PR DESCRIPTION
## What

Adds `docs/contracts/claude-bot-delegation.md` — operational runbook for the `@claude` GitHub App.

## Why

Session 2026-05-17 (the PR-discipline cascade) uncovered four gotchas with `@claude` that lived in scattered learning-store entries but had no single canonical contract:

| # | Gotcha | Evidence this session |
|---|---|---|
| 1 | Default install ships read-only perms | PR #301 upgraded `contents/pull-requests/issues` to `write` |
| 2 | Bot has no `workflows: write` — workflow-file edits fail | PR #270 revert: *"undo claude.yml forward-port (requires workflows permission)"* |
| 3 | `skipped` conclusion is anti-loop, not failure | All bot runs at 09:27:41–45 on its own follow-up comments |
| 4 | Auto-merge needs green required checks on current head | #295/#291 sat MERGEABLE/BEHIND with failed `go-build` until `update-branch` re-ran CI |

The runbook captures all four with table-based decoding (status, can/can't, when-to-delegate) and cross-references the existing lessons (`claude-app-default-readonly`, `dogfood-install-pr`).

## Acceptance

- [x] `docs/contracts/claude-bot-delegation.md` exists with sections: install, permissions, triggers, can/can't, status decoding, four gotchas, when-to-use, how-to-delegate-well, operating contract
- [x] Linked from `docs/documentation-index.md` per "Contracts must be catalogued"
- [x] Cross-references existing lessons + `AGENTS.md`
- [x] Lands via PR (governed by branch protection — dogfoods the discipline this repo just installed)

Closes-scenario: bot-runbook-encoded
Bounded-context: docs/contracts
Evidence: docs/contracts/claude-bot-delegation.md, docs/documentation-index.md
Closes: soc-22wa

🤖 Generated with [Claude Code](https://claude.com/claude-code)