### PR TITLE
Recommend duel gate in plan skill

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -877,8 +877,8 @@
     {
       "name": "plan",
       "source_skill": "skills/plan",
-      "source_hash": "d8aad99dc400db198f99cb648be3901837c595d424695d65533462f0aa9094dd",
-      "generated_hash": "5a6ffb424793834d09d6c8aa652923b5b18ed0f5175448a74c2197babfceb4ea"
+      "source_hash": "3744e9ad96c836a3f25df2c0c09b58ffb51a33ab41c97e41d5a3455beeb7d53b",
+      "generated_hash": "9c19e377394c3cbeda1536a683f7ad6f2e39e6f971d3baaffa351253e28a6fb8"
     },
     {
       "name": "post-mortem",

--- a/skills-codex/plan/.agentops-generated.json
+++ b/skills-codex/plan/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/plan",
   "layout": "modular",
-  "source_hash": "d8aad99dc400db198f99cb648be3901837c595d424695d65533462f0aa9094dd",
-  "generated_hash": "5a6ffb424793834d09d6c8aa652923b5b18ed0f5175448a74c2197babfceb4ea"
+  "source_hash": "3744e9ad96c836a3f25df2c0c09b58ffb51a33ab41c97e41d5a3455beeb7d53b",
+  "generated_hash": "9c19e377394c3cbeda1536a683f7ad6f2e39e6f971d3baaffa351253e28a6fb8"
 }

--- a/skills-codex/plan/SKILL.md
+++ b/skills-codex/plan/SKILL.md
@@ -61,20 +61,27 @@ Feature: Plan converts dense intent into executable slices
    to `.agents/findings/registry.jsonl`. Treat active findings as hard
    planning context. Record applied finding IDs in the plan with an
    `Applied findings:` line, even when the value is `none`.
-4. **Explore only as needed.** If prior research does not provide enough file
+4. **Recommend a strategic duel when warranted.** If the plan spans more than
+   one execution session and has at least one contested operator-default
+   decision, recommend the dueling-idea-wizards route
+   (`$council --mode=debate --focus=ideas`) before decomposition. Keep it
+   advisory, not mandatory. Skip it for single-session or non-contested plans.
+   Evidence from the 2026-05-17 Mt Olympus run: roughly 22 min wall-clock,
+   3/5 operator defaults flipped, and one already-shipped adapter bug surfaced.
+5. **Explore only as needed.** If prior research does not provide enough file
    and symbol detail, inspect the codebase or dispatch a bounded explorer.
    Demand file inventory, symbol names, reuse points with `file:line`, test
    locations, and package/import relationships.
-5. **Baseline audit.** Mechanically count the current state before making
+6. **Baseline audit.** Mechanically count the current state before making
    quantitative claims: files, sections, LOC, tests, fixtures, schemas, and
    any SKILL.md files near size limits. Record commands and results.
-6. **Choose detail level.** Minimal for 1-2 simple issues, Standard for 3-6
+7. **Choose detail level.** Minimal for 1-2 simple issues, Standard for 3-6
    issues, Deep for 7+ issues, broad refactors, or `--deep`.
-7. **Decompose into issues.** Each issue needs title, file ownership,
+8. **Decompose into issues.** Each issue needs title, file ownership,
    dependencies, acceptance criteria, test levels, and at least one mechanical
    conformance check (`files_exist`, `content_check`, `command`, `tests`, or
    `lint`).
-8. **Compute waves.** Group independent issues by dependency. Serialize or
+9. **Compute waves.** Group independent issues by dependency. Serialize or
    merge same-file writes. Include generated artifacts, docs, schemas, fixtures,
    Codex companions, manifests, and hash markers in ownership.
    Generated Artifact Companion Scope is mandatory: list every touched file,
@@ -82,12 +89,12 @@ Feature: Plan converts dense intent into executable slices
    and generated Codex artifacts. If skill behavior or runtime UX
    changes, include `bash scripts/refresh-codex-artifacts.sh --scope worktree`
    in verification.
-9. **Write the plan.** Use `.agents/plans/YYYY-MM-DD-<goal-slug>.md` and the
+10. **Write the plan.** Use `.agents/plans/YYYY-MM-DD-<goal-slug>.md` and the
    template in [references/plan-document-template.md](references/plan-document-template.md).
-10. **Create tracking tasks.** Prefer bd issues with validation blocks and
+11. **Create tracking tasks.** Prefer bd issues with validation blocks and
     dependency edges. If bd is missing, leave the markdown plan as the durable
     handoff.
-11. **Approval gate.** Skip only with `--auto`; otherwise ask whether to
+12. **Approval gate.** Skip only with `--auto`; otherwise ask whether to
     proceed, revise, or return to research.
 
 ## Required Plan Sections

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -122,6 +122,17 @@ Active findings from `.agents/findings/registry.jsonl` are a fallback planning i
 
 If research files exist, read the most recent one and verify it contains substantive sections (Summary, Findings, Architecture, Executive Summary, Recommendations) before proceeding. See [references/pre-decomposition.md](references/pre-decomposition.md) for the validation grep and warning behavior.
 
+### Step 2.3: Optional Strategic Duel Gate
+
+When the plan is likely to span more than one execution session AND it contains
+at least one contested operator-default decision, recommend the
+dueling-idea-wizards route (`/council --mode=debate --focus=ideas`) on the
+strategic question before decomposition. Treat it as advisory, not a hard
+prerequisite: skip it for single-session plans or plans with no meaningful
+contested default. Evidence from the 2026-05-17 Mt Olympus run: a roughly
+22 minute duel flipped 3/5 operator defaults and surfaced one already-shipped
+adapter bug that ordinary review and passing tests had missed.
+
 ### Step 3: Explore the Codebase (if needed)
 
 Dispatch an Explore sub-agent (Task tool) with a prompt that demands symbol-level detail: file inventory, function/method signatures, struct/type definitions, reuse points with `file:line`, test file locations and naming conventions, import paths. Read [references/pre-decomposition.md](references/pre-decomposition.md) for the canonical explore prompt.


### PR DESCRIPTION
## Summary
- add an optional dueling-idea-wizards recommendation to the source plan skill when a plan is multi-session and has contested operator-default decisions
- mirror the behavior in the Codex plan skill via `$council --mode=debate --focus=ideas`
- refresh plan Codex hash metadata

## Validation
- `bash skills/plan/scripts/validate.sh`
- `bash skills-codex/plan/scripts/validate.sh`
- `scripts/regen-codex-hashes.sh --check`
- `./tests/docs/validate-doc-release.sh`
- `bash scripts/refresh-codex-artifacts.sh --scope worktree`
- `scripts/pre-push-gate.sh --fast`

Tracked from Mt Olympus bead `mo-c4lze1`.