### PR TITLE
chore(schemas): Phase 1/3 — require hexagonal_role + practices in SKILL.md frontmatter (soc-zxia.1)

### DIFF
--- a/schemas/skill-frontmatter.v2.schema.json
+++ b/schemas/skill-frontmatter.v2.schema.json
@@ -3,7 +3,7 @@
   "$id": "agentops:skill-frontmatter.v2",
   "practices": ["data-contracts", "design-by-contract"],
   "type": "object",
-  "required": ["name", "description"],
+  "required": ["name", "description", "hexagonal_role", "practices"],
   "properties": {
     "schema_version": {
       "type": "integer",
@@ -11,10 +11,16 @@
     },
     "name": {"type": "string"},
     "description": {"type": "string"},
-    "practices": {"type": "array", "items": {"type": "string"}},
+    "practices": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1,
+      "description": "REQUIRED: at least one practice citation (e.g. 'data-contracts', 'design-by-contract'). Every skill must declare which engineering practices it embodies."
+    },
     "hexagonal_role": {
       "type": "string",
-      "enum": ["domain", "driving-adapter", "driven-adapter", "supporting", "generic"]
+      "enum": ["domain", "driving-adapter", "driven-adapter", "supporting", "generic"],
+      "description": "REQUIRED: which hexagonal-architecture role this skill plays. Enforces the DDD/hex layer cannot drift silently (registries-drift lesson, 2026-05-17)."
     },
     "consumes": {
       "type": "array",


### PR DESCRIPTION
## What

**Phase 1 of 3 — Domain-tightening epic ([soc-zxia](https://github.com/boshu2/agentops/issues))**.

Promotes \`hexagonal_role\` and \`practices\` from optional-with-strict-mode-warning to **schema-required** in \`schemas/skill-frontmatter.v2.schema.json\`.

## Why

The \`registries-drift\` lesson (2026-05-17) said: hand-maintained inventory docs drift silently. Today's drift detector ([soc-ry4a / #308](https://github.com/boshu2/agentops/pull/308)) catches drift *after* it appears. This PR prevents one class of drift at the *source* — making it impossible to land a SKILL.md without declaring its hexagonal role.

Before this PR:
- \`schema.required = [\"name\", \"description\"]\` — every other field optional
- \`hexagonal_role\` checked only by strict-mode warning (validator emits WARN but exit 0)
- \`expert-council\` shipped multiple releases without it (caught by drift detector, not the schema)

After this PR:
- \`schema.required = [\"name\", \"description\", \"hexagonal_role\", \"practices\"]\`
- \`practices\` also gets \`minItems: 1\` (every skill must cite at least one practice)
- Default-mode validator now fails non-zero on missing fields (no \`--strict\` needed)
- CI's \`validate-skill-frontmatter\` job already invokes the validator → automatically tightens

## Verification

\`\`\`text
$ bash scripts/validate-skill-frontmatter.sh
... 78 OK lines ...
validate-skill-frontmatter: 78/78 ok (0 missing hexagonal_role, ...)
exit 0

$ # Remove hexagonal_role from a test skill:
$ sed -i '/^hexagonal_role:/d' skills/council/SKILL.md
$ bash scripts/validate-skill-frontmatter.sh
FAIL  skills/council/SKILL.md  (schema violation at <root>: 'hexagonal_role' is a required property)
validate-skill-frontmatter: FAIL — 1 schema violation(s)
exit 1
\`\`\`

## Phase plan

| # | Bead | Scope |
|---|---|---|
| 0 | [soc-ry4a / #308](https://github.com/boshu2/agentops/pull/308) | Drift detector (after-the-fact catch) |
| 1 | **soc-zxia.1 — this PR** | Schema-gate frontmatter (prevent drift at source) |
| 2 | soc-zxia.2 (next) | Extract BC1-BC5 definitions to \`docs/contracts/bounded-contexts.yaml\` |
| 3 | soc-zxia.3 (last) | Replace hand-edited reference docs with generated outputs |

## Stack

Based on \`chore/soc-ry4a-registry-drift-detector\` (PR #308). Will retarget to \`main\` automatically when #308 lands.

Closes-scenario: phase1-schema-gate
Bounded-context: schemas/ + validate-skill-frontmatter
Evidence: schema diff, 78/78 pass, exit-1 on missing field

🤖 Generated with [Claude Code](https://claude.com/claude-code)