### PR TITLE
Document Rust adapter recursion guard

### DIFF
--- a/cli/embedded/skills/standards/references/rust.md
+++ b/cli/embedded/skills/standards/references/rust.md
@@ -11,6 +11,32 @@
 - Never `unwrap()` in library code (OK in tests/bins)
 - Use `?` operator for error propagation
 
+## Adapter Recursion Guard
+- Subprocess adapters that can invoke their own kernel must set a guard env var
+  on every child command: `<TOOL>_IN_PROGRESS=1`.
+- Kernel entry must reject re-entry when that env var is already present.
+- This is a two-end check: set-on-spawn plus check-at-entry. One end alone is
+  not enough.
+- Source pattern: commit `97e16fe`, bead `mo-l1tyqp.23`, and
+  `MTO_SKILL_AUDIT_IN_PROGRESS` from the Mt Olympus skill-audit adapter fix.
+
+```rust
+pub const GUARD_ENV: &str = "MY_TOOL_IN_PROGRESS";
+
+fn command() -> std::process::Command {
+    let mut cmd = std::process::Command::new("sh");
+    cmd.env(GUARD_ENV, "1");
+    cmd
+}
+
+fn entry() -> Result<(), MyError> {
+    if std::env::var_os(GUARD_ENV).is_some() {
+        return Err(MyError::Recursion);
+    }
+    Ok(())
+}
+```
+
 ## Ownership & Borrowing
 - Prefer references over cloning
 - Use `&str` in function params over `String`

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1069,8 +1069,8 @@
     {
       "name": "standards",
       "source_skill": "skills/standards",
-      "source_hash": "8ff1944f2ba02848c1f0a07cb5d5ca217d644684909d3193b3c6081b7ce5c36a",
-      "generated_hash": "8961489e751db2be073ca3364f62a9c24a506337a3134c101b31deb28191d296"
+      "source_hash": "5bdf316297b4fb68241d9bcfb500a3c4b6cc139fc673333610ce2497b948cc5e",
+      "generated_hash": "c20ac53fb99d0b6a950dd1bec3eceb87e49ec7e468b1441cfc933d32b93c2001"
     },
     {
       "name": "status",

--- a/skills-codex/standards/.agentops-generated.json
+++ b/skills-codex/standards/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/standards",
   "layout": "modular",
-  "source_hash": "8ff1944f2ba02848c1f0a07cb5d5ca217d644684909d3193b3c6081b7ce5c36a",
-  "generated_hash": "8961489e751db2be073ca3364f62a9c24a506337a3134c101b31deb28191d296"
+  "source_hash": "5bdf316297b4fb68241d9bcfb500a3c4b6cc139fc673333610ce2497b948cc5e",
+  "generated_hash": "c20ac53fb99d0b6a950dd1bec3eceb87e49ec7e468b1441cfc933d32b93c2001"
 }

--- a/skills-codex/standards/references/rust.md
+++ b/skills-codex/standards/references/rust.md
@@ -11,6 +11,32 @@
 - Never `unwrap()` in library code (OK in tests/bins)
 - Use `?` operator for error propagation
 
+## Adapter Recursion Guard
+- Subprocess adapters that can invoke their own kernel must set a guard env var
+  on every child command: `<TOOL>_IN_PROGRESS=1`.
+- Kernel entry must reject re-entry when that env var is already present.
+- This is a two-end check: set-on-spawn plus check-at-entry. One end alone is
+  not enough.
+- Source pattern: commit `97e16fe`, bead `mo-l1tyqp.23`, and
+  `MTO_SKILL_AUDIT_IN_PROGRESS` from the Mt Olympus skill-audit adapter fix.
+
+```rust
+pub const GUARD_ENV: &str = "MY_TOOL_IN_PROGRESS";
+
+fn command() -> std::process::Command {
+    let mut cmd = std::process::Command::new("sh");
+    cmd.env(GUARD_ENV, "1");
+    cmd
+}
+
+fn entry() -> Result<(), MyError> {
+    if std::env::var_os(GUARD_ENV).is_some() {
+        return Err(MyError::Recursion);
+    }
+    Ok(())
+}
+```
+
 ## Ownership & Borrowing
 - Prefer references over cloning
 - Use `&str` in function params over `String`

--- a/skills/standards/references/rust.md
+++ b/skills/standards/references/rust.md
@@ -11,6 +11,32 @@
 - Never `unwrap()` in library code (OK in tests/bins)
 - Use `?` operator for error propagation
 
+## Adapter Recursion Guard
+- Subprocess adapters that can invoke their own kernel must set a guard env var
+  on every child command: `<TOOL>_IN_PROGRESS=1`.
+- Kernel entry must reject re-entry when that env var is already present.
+- This is a two-end check: set-on-spawn plus check-at-entry. One end alone is
+  not enough.
+- Source pattern: commit `97e16fe`, bead `mo-l1tyqp.23`, and
+  `MTO_SKILL_AUDIT_IN_PROGRESS` from the Mt Olympus skill-audit adapter fix.
+
+```rust
+pub const GUARD_ENV: &str = "MY_TOOL_IN_PROGRESS";
+
+fn command() -> std::process::Command {
+    let mut cmd = std::process::Command::new("sh");
+    cmd.env(GUARD_ENV, "1");
+    cmd
+}
+
+fn entry() -> Result<(), MyError> {
+    if std::env::var_os(GUARD_ENV).is_some() {
+        return Err(MyError::Recursion);
+    }
+    Ok(())
+}
+```
+
 ## Ownership & Borrowing
 - Prefer references over cloning
 - Use `&str` in function params over `String`


### PR DESCRIPTION
## Summary
- add an Adapter Recursion Guard section to the Rust standards reference
- name the `<TOOL>_IN_PROGRESS=1` convention and two-end set-on-spawn/check-at-entry shape
- sync the Codex standards copy, embedded standards copy, and Codex hash metadata

## Validation
- `rg -n 'Adapter Recursion Guard|<TOOL>_IN_PROGRESS|MTO_SKILL_AUDIT_IN_PROGRESS|97e16fe|mo-l1tyqp\.23|re-entry|set-on-spawn|check-at-entry' skills/standards/references/rust.md skills-codex/standards/references/rust.md`
- `cd cli && make sync-hooks`
- `bash skills/standards/scripts/validate.sh`
- `scripts/validate-embedded-sync.sh`
- `scripts/check-standards-injector-completeness.sh`
- `bash skills/heal-skill/scripts/heal.sh --strict`
- `./tests/docs/validate-doc-release.sh`
- `bash scripts/refresh-codex-artifacts.sh --scope worktree`
- `scripts/pre-push-gate.sh --fast`
- `git diff --check`

Tracked from Mt Olympus bead `mo-od5j1c`.