### PR TITLE
docs(standards): add Adapter Recursion-Guard pattern to rust.md

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1069,7 +1069,7 @@
     {
       "name": "standards",
       "source_skill": "skills/standards",
-      "source_hash": "8ff1944f2ba02848c1f0a07cb5d5ca217d644684909d3193b3c6081b7ce5c36a",
+      "source_hash": "19c52f640b72b13707070dc088d2290023bdd247e08b5a2f0786cb2b81322c5b",
       "generated_hash": "8961489e751db2be073ca3364f62a9c24a506337a3134c101b31deb28191d296"
     },
     {

--- a/skills-codex/standards/.agentops-generated.json
+++ b/skills-codex/standards/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/standards",
   "layout": "modular",
-  "source_hash": "8ff1944f2ba02848c1f0a07cb5d5ca217d644684909d3193b3c6081b7ce5c36a",
+  "source_hash": "19c52f640b72b13707070dc088d2290023bdd247e08b5a2f0786cb2b81322c5b",
   "generated_hash": "8961489e751db2be073ca3364f62a9c24a506337a3134c101b31deb28191d296"
 }

--- a/skills-codex/standards/references/rust.md
+++ b/skills-codex/standards/references/rust.md
@@ -49,3 +49,47 @@
 - `cargo test --doc` (doc tests)
 - Use `#[cfg(test)]` modules
 - `cargo bench` for benchmarks
+
+## Adapter Recursion-Guard
+
+When a kernel adapter spawns subprocesses that **could re-enter the kernel**
+(e.g. a `ShellEvalRunner` that runs eval scripts which might themselves call
+the same CLI that owns the runner), the adapter MUST set a guard env var on
+every subprocess AND the kernel's entry function MUST refuse to run when it
+observes that var set. Without this pattern the adapter recurses infinitely
+and burns the build lock. In-band comments in eval scripts ("do not shell
+out to me from here") do not scale across N authors — make the kernel
+enforce what the comment asks for.
+
+```rust
+// Convention: <TOOL>_IN_PROGRESS=1 on every subprocess this adapter spawns;
+// the kernel entry function refuses to run when it observes the var set.
+pub const GUARD_ENV: &str = "MY_KERNEL_IN_PROGRESS";
+
+fn build_command(repo_root: &Path, command: &str) -> Command {
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg(command)
+        .current_dir(repo_root)
+        .env(GUARD_ENV, "1");  // propagate to children
+    cmd
+}
+
+pub fn kernel_entry(...) -> Result<..., KernelError> {
+    if std::env::var(GUARD_ENV).is_ok() {
+        return Err(KernelError::Adapter(format!(
+            "refusing recursion: {GUARD_ENV} is set"
+        )));
+    }
+    // ... real work
+}
+```
+
+**Test both ends** with a hermetic pair:
+- `kernel_entry()` returns the recursion error when the env var is set.
+- The subprocess `Command` carries `GUARD_ENV=1` (assert via
+  `cmd.get_envs()` — no spawn needed, no test-parallelism hazard).
+
+**Evidence:** mt-olympus commit `97e16fe` shipped this pattern after a
+two-agent strategic duel surfaced the recursion bug in a
+shipped-this-session adapter. The eval scripts had warned each other
+manually; the kernel adapter had no enforcement.

--- a/skills/standards/references/rust.md
+++ b/skills/standards/references/rust.md
@@ -49,3 +49,47 @@
 - `cargo test --doc` (doc tests)
 - Use `#[cfg(test)]` modules
 - `cargo bench` for benchmarks
+
+## Adapter Recursion-Guard
+
+When a kernel adapter spawns subprocesses that **could re-enter the kernel**
+(e.g. a `ShellEvalRunner` that runs eval scripts which might themselves call
+the same CLI that owns the runner), the adapter MUST set a guard env var on
+every subprocess AND the kernel's entry function MUST refuse to run when it
+observes that var set. Without this pattern the adapter recurses infinitely
+and burns the build lock. In-band comments in eval scripts ("do not shell
+out to me from here") do not scale across N authors — make the kernel
+enforce what the comment asks for.
+
+```rust
+// Convention: <TOOL>_IN_PROGRESS=1 on every subprocess this adapter spawns;
+// the kernel entry function refuses to run when it observes the var set.
+pub const GUARD_ENV: &str = "MY_KERNEL_IN_PROGRESS";
+
+fn build_command(repo_root: &Path, command: &str) -> Command {
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg(command)
+        .current_dir(repo_root)
+        .env(GUARD_ENV, "1");  // propagate to children
+    cmd
+}
+
+pub fn kernel_entry(...) -> Result<..., KernelError> {
+    if std::env::var(GUARD_ENV).is_ok() {
+        return Err(KernelError::Adapter(format!(
+            "refusing recursion: {GUARD_ENV} is set"
+        )));
+    }
+    // ... real work
+}
+```
+
+**Test both ends** with a hermetic pair:
+- `kernel_entry()` returns the recursion error when the env var is set.
+- The subprocess `Command` carries `GUARD_ENV=1` (assert via
+  `cmd.get_envs()` — no spawn needed, no test-parallelism hazard).
+
+**Evidence:** mt-olympus commit `97e16fe` shipped this pattern after a
+two-agent strategic duel surfaced the recursion bug in a
+shipped-this-session adapter. The eval scripts had warned each other
+manually; the kernel adapter had no enforcement.


### PR DESCRIPTION
## Summary

Adds a new "Adapter Recursion-Guard" section to `skills/standards/references/rust.md` (and its `skills-codex/` mirror) capturing the pattern that surfaced during a 2026-05-17 mt-olympus session.

## Context

Mt-olympus shipped a `ShellEvalRunner` adapter (the kernel adapter that runs skill eval scripts) without a recursion guard. Any skill whose eval shelled out to `mto skill audit` could recurse indefinitely, burning the repo's build lock. A two-agent strategic duel (Claude Opus 4.5 + GPT-5.5 codex via NTM) caught the bug in shipped-this-session code — neither the operator's plan, 87 passing tests, nor either agent's first pass had surfaced it.

Fix landed in mt-olympus commit [`97e16fe`](https://github.com/boshu2/mt-olympus/commit/97e16fe): `MTO_SKILL_AUDIT_IN_PROGRESS=1` set on every eval subprocess; `audit_repo` refuses re-entry when it observes the var set. After the fix, the live audit finishes deterministically in <30s with a recursive-eval skill in tree (was: infinite loop).

The pattern is general — any Rust adapter that spawns subprocesses that could re-enter its own kernel surface should follow it. In-band warning comments in eval scripts (\"do not shell out to me from here\") don't scale across N skill authors; the kernel adapter has to enforce what the comment asks for.

## What's in this PR

- `skills/standards/references/rust.md`: new \"## Adapter Recursion-Guard\" section with motivation, ~15 LoC code template, the two-end test pattern (kernel-entry error + `Command::get_envs()` assertion), evidence reference.
- `skills-codex/standards/references/rust.md`: identical mirror per existing skills/skills-codex parity convention.
- Auto-updated `source_hash` fields in `skills-codex/.agentops-manifest.json` and `skills-codex/standards/.agentops-generated.json`.

## Validation

- Pre-edit: skills/ and skills-codex/ rust.md were byte-identical (51 lines each). Post-edit: still byte-identical (95 lines each).
- Section count: 8 → 9 (Adapter Recursion-Guard added).

## Cross-repo lineage

Tracked in mt-olympus's bd as bead `mo-od5j1c`. The 2026-05-18 post-mortem (in mt-olympus) named this as promotion candidate #1 from the operating-loop ratchet (\`noticed twice → changes future behavior → SKILL.md edit\`).

## Why agentops, not mt-olympus

The standards skill is part of agentops's reference architecture (mt-olympus uses it via the agentops marketplace plugin). Encoding the pattern here propagates it to every project that uses the standards skill, not just mt-olympus.