### PR TITLE
Harden .agents policy hook handling

### DIFF
--- a/cli/embedded/hooks/dangerous-git-guard.sh
+++ b/cli/embedded/hooks/dangerous-git-guard.sh
@@ -72,6 +72,20 @@ git_push_uses_force() {
   return 1
 }
 
+staged_runtime_agents_path() {
+  local path
+
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    if git check-ignore --no-index -q -- "$path" 2>/dev/null; then
+      printf '%s\n' "$path"
+      return 0
+    fi
+  done < <(git diff --cached --name-only --diff-filter=ACMR -- .agents 2>/dev/null)
+
+  return 1
+}
+
 # Extract tool_input.command from JSON
 COMMAND="$(extract_command)"
 
@@ -83,9 +97,14 @@ echo "$COMMAND" | grep -q "git" || exit 0
 if echo "$COMMAND" | grep -qE 'git\s+add' && echo "$COMMAND" | grep -qE '\.agents/|\s\.\s*$|\s-A'; then
     echo "Warning: repo-root .agents/ is local runtime state and must stay gitignored. Review: git status .agents/" >&2
 fi
-if echo "$COMMAND" | grep -qE 'git\s+commit' && git diff --cached --name-only --diff-filter=ACMR -- .agents 2>/dev/null | grep -q '^\.agents/'; then
+AGENTS_RUNTIME_PATH=""
+if echo "$COMMAND" | grep -qE 'git\s+commit'; then
+    AGENTS_RUNTIME_PATH="$(staged_runtime_agents_path || true)"
+fi
+if [ -n "$AGENTS_RUNTIME_PATH" ]; then
     write_failure "dangerous_git" "git commit .agents" 2 "repo-root .agents commit blocked"
-    echo "Blocked: repo-root .agents/ is local runtime state. Use: git restore --staged .agents/" >&2
+    echo "Blocked: repo-root .agents/ runtime path is ignored by local policy: $AGENTS_RUNTIME_PATH" >&2
+    echo "Use: git restore --staged -- '$AGENTS_RUNTIME_PATH'" >&2
     exit 2
 fi
 

--- a/cli/embedded/hooks/session-start.sh
+++ b/cli/embedded/hooks/session-start.sh
@@ -19,10 +19,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 ROOT="$(cd "$ROOT" 2>/dev/null && pwd -P 2>/dev/null || printf '%s' "$ROOT")"
 AO_DIR="$ROOT/.agents/ao"
-FRESH_REPO=0
-if [ ! -e "$ROOT/.agents" ]; then
-    FRESH_REPO=1
-fi
 
 HOOK_ERROR_LOG="$AO_DIR/hook-errors.log"
 if [ -f "$SCRIPT_DIR/../lib/hook-helpers.sh" ]; then
@@ -148,11 +144,14 @@ if [ "${AGENTOPS_STARTUP_CLOSE_LOOP:-0}" = "1" ] && command -v ao &>/dev/null; t
     ao flywheel close-loop --quiet >/dev/null 2>&1 || true
 fi
 
-# Always gitignore repo-root .agents/. It is local agent runtime state and must
-# not be committed. AGENTOPS_GITIGNORE_AUTO is retained only as a legacy no-op.
+# Gitignore repo-root .agents/ when no co-located .agents/.gitignore policy is
+# present. A root blanket shadows nested allowlists, so repos that own their
+# .agents policy locally must not receive the blanket.
 if [ -d "$ROOT/.git" ]; then
     GITIGNORE="$ROOT/.gitignore"
-    if [ -f "$GITIGNORE" ]; then
+    if [ -f "$ROOT/.agents/.gitignore" ]; then
+        :
+    elif [ -f "$GITIGNORE" ]; then
         # Match the modern anchored shapes (/.agents/, /.agents/*,
         # /.agents/**/*) AND any allowlist re-include (!/.agents/...).
         # The original `^/\.agents/$` was too narrow and double-appended

--- a/hooks/dangerous-git-guard.sh
+++ b/hooks/dangerous-git-guard.sh
@@ -72,6 +72,20 @@ git_push_uses_force() {
   return 1
 }
 
+staged_runtime_agents_path() {
+  local path
+
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    if git check-ignore --no-index -q -- "$path" 2>/dev/null; then
+      printf '%s\n' "$path"
+      return 0
+    fi
+  done < <(git diff --cached --name-only --diff-filter=ACMR -- .agents 2>/dev/null)
+
+  return 1
+}
+
 # Extract tool_input.command from JSON
 COMMAND="$(extract_command)"
 
@@ -83,9 +97,14 @@ echo "$COMMAND" | grep -q "git" || exit 0
 if echo "$COMMAND" | grep -qE 'git\s+add' && echo "$COMMAND" | grep -qE '\.agents/|\s\.\s*$|\s-A'; then
     echo "Warning: repo-root .agents/ is local runtime state and must stay gitignored. Review: git status .agents/" >&2
 fi
-if echo "$COMMAND" | grep -qE 'git\s+commit' && git diff --cached --name-only --diff-filter=ACMR -- .agents 2>/dev/null | grep -q '^\.agents/'; then
+AGENTS_RUNTIME_PATH=""
+if echo "$COMMAND" | grep -qE 'git\s+commit'; then
+    AGENTS_RUNTIME_PATH="$(staged_runtime_agents_path || true)"
+fi
+if [ -n "$AGENTS_RUNTIME_PATH" ]; then
     write_failure "dangerous_git" "git commit .agents" 2 "repo-root .agents commit blocked"
-    echo "Blocked: repo-root .agents/ is local runtime state. Use: git restore --staged .agents/" >&2
+    echo "Blocked: repo-root .agents/ runtime path is ignored by local policy: $AGENTS_RUNTIME_PATH" >&2
+    echo "Use: git restore --staged -- '$AGENTS_RUNTIME_PATH'" >&2
     exit 2
 fi
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -19,10 +19,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 ROOT="$(cd "$ROOT" 2>/dev/null && pwd -P 2>/dev/null || printf '%s' "$ROOT")"
 AO_DIR="$ROOT/.agents/ao"
-FRESH_REPO=0
-if [ ! -e "$ROOT/.agents" ]; then
-    FRESH_REPO=1
-fi
 
 HOOK_ERROR_LOG="$AO_DIR/hook-errors.log"
 if [ -f "$SCRIPT_DIR/../lib/hook-helpers.sh" ]; then
@@ -148,11 +144,14 @@ if [ "${AGENTOPS_STARTUP_CLOSE_LOOP:-0}" = "1" ] && command -v ao &>/dev/null; t
     ao flywheel close-loop --quiet >/dev/null 2>&1 || true
 fi
 
-# Always gitignore repo-root .agents/. It is local agent runtime state and must
-# not be committed. AGENTOPS_GITIGNORE_AUTO is retained only as a legacy no-op.
+# Gitignore repo-root .agents/ when no co-located .agents/.gitignore policy is
+# present. A root blanket shadows nested allowlists, so repos that own their
+# .agents policy locally must not receive the blanket.
 if [ -d "$ROOT/.git" ]; then
     GITIGNORE="$ROOT/.gitignore"
-    if [ -f "$GITIGNORE" ]; then
+    if [ -f "$ROOT/.agents/.gitignore" ]; then
+        :
+    elif [ -f "$GITIGNORE" ]; then
         # Match the modern anchored shapes (/.agents/, /.agents/*,
         # /.agents/**/*) AND any allowlist re-include (!/.agents/...).
         # The original `^/\.agents/$` was too narrow and double-appended

--- a/tests/hooks/test-hooks.bats
+++ b/tests/hooks/test-hooks.bats
@@ -127,6 +127,26 @@ GIT
     grep -qx '*' "$mock/.agents/.gitignore"
 }
 
+@test "session-start: existing child gitignore owns .agents policy without root blanket" {
+    # A co-located child policy can allowlist durable .agents artifacts. A root
+    # `/.agents/` blanket would shadow that nested policy by preventing Git from
+    # descending into the directory.
+    local mock="$TMP_TEST_DIR/mock-child-policy-session"
+    mkdir -p "$mock/.agents/findings"
+    git -C "$mock" init -q >/dev/null 2>&1
+    cat > "$mock/.agents/.gitignore" <<'GIT'
+*
+!.gitignore
+!findings/
+!findings/**
+GIT
+    (cd "$mock" && bash "$HOOKS_DIR/session-start.sh" >/dev/null 2>&1 || true)
+    if [ -f "$mock/.gitignore" ]; then
+        ! grep -qE '^/?\.agents(/|$)' "$mock/.gitignore"
+    fi
+    grep -qx '!findings/\*\*' "$mock/.agents/.gitignore"
+}
+
 @test "session-start: does not double-append /.agents/* when already present" {
     # The hook's pre-existing grep for `^/\.agents/$` was too narrow and
     # double-appended `/.agents/` whenever the repo's gitignore used the
@@ -498,14 +518,34 @@ EOF
 }
 
 @test "dangerous-git-guard: staged .agents add blocks commit" {
+    cat > "$MOCK_REPO/.agents/.gitignore" <<'GIT'
+*
+!.gitignore
+GIT
     mkdir -p "$MOCK_REPO/.agents/rpi"
     printf '{}\n' > "$MOCK_REPO/.agents/rpi/execution-packet.json"
-    git -C "$MOCK_REPO" add .agents/rpi/execution-packet.json
+    git -C "$MOCK_REPO" add -f .agents/rpi/execution-packet.json
 
     run bash -c 'cd "$1" && printf "%s" "$2" | bash "$3" 2>&1' \
         -- "$MOCK_REPO" '{"tool_input":{"command":"git commit -m leak"}}' "$HOOKS_DIR/dangerous-git-guard.sh"
     [ "$status" -eq 2 ]
-    [[ "$output" == *"repo-root .agents/ is local runtime state"* ]]
+    [[ "$output" == *".agents/rpi/execution-packet.json"* ]]
+}
+
+@test "dangerous-git-guard: staged .agents allowlist path is commit-eligible" {
+    mkdir -p "$MOCK_REPO/.agents/findings"
+    cat > "$MOCK_REPO/.agents/.gitignore" <<'GIT'
+*
+!.gitignore
+!findings/
+!findings/**
+GIT
+    printf '{"ok":true}\n' > "$MOCK_REPO/.agents/findings/registry.jsonl"
+    git -C "$MOCK_REPO" add .agents/.gitignore .agents/findings/registry.jsonl
+
+    run bash -c 'cd "$1" && printf "%s" "$2" | bash "$3" 2>&1' \
+        -- "$MOCK_REPO" '{"tool_input":{"command":"git commit -m findings"}}' "$HOOKS_DIR/dangerous-git-guard.sh"
+    [ "$status" -eq 0 ]
 }
 
 @test "dangerous-git-guard: staged .agents deletion allows cleanup commit" {


### PR DESCRIPTION
## Summary
- make `dangerous-git-guard.sh` block staged `.agents/` additions only when Git ignore policy marks the path as runtime state
- make `session-start.sh` avoid injecting a root `/.agents/` blanket when a co-located `.agents/.gitignore` already owns the local policy
- sync embedded hook copies and add BATS coverage for ignored runtime paths and child-policy allowlists

Tracked from Mt Olympus bead `mo-a1enre`.

## Validation
- `bats --filter 'session-start|dangerous-git-guard' tests/hooks/test-hooks.bats`
- `bats --filter 'dangerous-git-guard' tests/hooks/hook-stdin-contracts.bats`
- `shellcheck -S warning hooks/dangerous-git-guard.sh hooks/session-start.sh cli/embedded/hooks/dangerous-git-guard.sh cli/embedded/hooks/session-start.sh`
- `bash scripts/validate-hooks-doc-parity.sh`
- `bash scripts/test-hooks-output.sh`
- `scripts/validate-embedded-sync.sh`
- `git diff --check`
- `scripts/pre-push-gate.sh --fast` (passed; known warn-only executable-spec messages for `scenarios --lint` and `trace --orphans`)
