### PR TITLE
docs(contracts): fix mkdocs-strict break from out-of-tree AGENTS.md link (#trivial)

### DIFF
--- a/docs/contracts/claude-bot-delegation.md
+++ b/docs/contracts/claude-bot-delegation.md
@@ -137,6 +137,6 @@ In this repo, `claude-review` is a required check. If the `@claude` workflow is 
 - Lesson `claude-app-default-readonly` (local-only: `.agents/learnings/2026-05-17-claude-app-default-readonly.md`) — the install-perm gotcha as a one-rule lesson
 - Lesson `dogfood-install-pr` (local-only: `.agents/learnings/2026-05-17-dogfood-install-pr.md`) — the install PR must itself follow the discipline it installs
 - [Lesson Format](lesson-format.md) — schema for `.agents/learnings/` entries
-- [AGENTS.md `## Workflow`](../../AGENTS.md) — PR-only discipline this bot operates inside
+- `AGENTS.md` `## Workflow` (repo root) — PR-only discipline this bot operates inside
 
 > `.agents/learnings/` is repo-local (gitignored). Search local lessons with `bd memories <keyword>` or via the [Lesson Format](lesson-format.md) contract.


### PR DESCRIPTION
## Summary

PR #306 added `docs/contracts/claude-bot-delegation.md` with a markdown link to `../../AGENTS.md`. `AGENTS.md` lives at the repo root, outside `docs/`, so MkDocs strict mode refuses to resolve it and aborts. The `Deploy Docs (MkDocs Material)` workflow has been red on `main` since 2026-05-18 14:32 UTC.

Every other `docs/**/*.md` reference to `AGENTS.md` uses plain text or code formatting, not a hyperlink. This change matches that convention.

## Scope (#trivial chore carve-out)

One-line markdown edit. No code, no contracts, no behavior change.

## Test plan

- [x] `scripts/pre-push-gate.sh --fast` — passed, `mkdocs strict build: ok` for this change
- [ ] CI `validate.yml` summary check
- [ ] `claude-review` check
- [ ] On merge: `Deploy Docs (MkDocs Material)` returns to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)