### PR TITLE
fix(test): eliminate global-state leaks in TestRunInit* + TestGoalsMeasure_* (soc-hwgm + soc-xyt1)

### DIFF
--- a/cli/cmd/ao/goals_measure_scenarios_test.go
+++ b/cli/cmd/ao/goals_measure_scenarios_test.go
@@ -70,13 +70,41 @@ func setupMeasureScenarioProject(t *testing.T, goalsMD string, withArtifact bool
 	if err := os.Chdir(dir); err != nil {
 		t.Fatalf("chdir: %v", err)
 	}
+	// soc-hwgm/soc-xyt1: save+restore EVERY goalsMeasure package-level
+	// global the command body reads. Previously only goalsFile and
+	// goalsMeasureScenariosOnly were saved, leaving the other 4 measure
+	// globals + the `output` global open to leak across tests under
+	// -shuffle on. Symptom: TestGoalsMeasure_MissingArtifactYieldsUnknown
+	// got empty stdout (unmarshal error) because prior test left
+	// goalsMeasureDirectives=true, which made goalsMeasureCmd.RunE skip
+	// the scenario-only branch and call into a different code path.
 	oldGoalsFile := goalsFile
 	oldScenariosOnly := goalsMeasureScenariosOnly
+	oldGoalID := goalsMeasureGoalID
+	oldDirectives := goalsMeasureDirectives
+	oldExcludeTag := goalsMeasureExcludeTag
+	oldTotalTimeout := goalsMeasureTotalTimeout
+	oldOutput := output
+	oldDryRun := dryRun
 	t.Cleanup(func() {
 		_ = os.Chdir(wd)
 		goalsFile = oldGoalsFile
 		goalsMeasureScenariosOnly = oldScenariosOnly
+		goalsMeasureGoalID = oldGoalID
+		goalsMeasureDirectives = oldDirectives
+		goalsMeasureExcludeTag = oldExcludeTag
+		goalsMeasureTotalTimeout = oldTotalTimeout
+		output = oldOutput
+		dryRun = oldDryRun
 	})
+	// Zero out all measure globals on entry so a leaked value from a
+	// prior test cannot taint this test's read.
+	goalsMeasureScenariosOnly = false
+	goalsMeasureGoalID = ""
+	goalsMeasureDirectives = false
+	goalsMeasureExcludeTag = ""
+	goalsMeasureTotalTimeout = 0
+	dryRun = false
 	goalsFile = "GOALS.md"
 	return dir
 }

--- a/cli/cmd/ao/init_test.go
+++ b/cli/cmd/ao/init_test.go
@@ -22,9 +22,27 @@ func resetInitFlags() {
 	initFull = false
 	initMinimalHooks = false
 	initWithSchedule = false
+	dryRun = false
+}
+
+// setupInitTest is the canonical entry point for tests that mutate the
+// package-level init globals (initStealth/initHooks/initFull/initMinimalHooks/
+// initWithSchedule/dryRun). It resets all globals to their zero value AND
+// registers a Cleanup so the next test under `-shuffle on` starts clean.
+//
+// Encodes soc-hwgm fix: TestRunInit* used to flake under -shuffle because
+// individual tests reset only the 2-3 globals they touched, leaking the
+// other ~4 globals across test boundaries. Belt-and-suspenders: reset on
+// entry (defense against leak from prior test) + reset on exit (defense
+// for next test).
+func setupInitTest(t *testing.T) {
+	t.Helper()
+	resetInitFlags()
+	t.Cleanup(resetInitFlags)
 }
 
 func TestRunInitCreatesDirs(t *testing.T) {
+	setupInitTest(t)
 	tmp := t.TempDir()
 	// Create a fake .git so it's treated as a git repo
 	if err := os.MkdirAll(filepath.Join(tmp, ".git"), 0755); err != nil {
@@ -73,6 +91,7 @@ func TestRunInitCreatesDirs(t *testing.T) {
 }
 
 func TestRunInitGitignoreAppend(t *testing.T) {
+	setupInitTest(t)
 	tmp := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmp, ".git"), 0755); err != nil {
 		t.Fatal(err)
@@ -99,6 +118,7 @@ func TestRunInitGitignoreAppend(t *testing.T) {
 }
 
 func TestRunInitGitignoreCreate(t *testing.T) {
+	setupInitTest(t)
 	tmp := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmp, ".git"), 0755); err != nil {
 		t.Fatal(err)
@@ -122,6 +142,7 @@ func TestRunInitGitignoreCreate(t *testing.T) {
 }
 
 func TestRunInitIdempotent(t *testing.T) {
+	setupInitTest(t)
 	tmp := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmp, ".git"), 0755); err != nil {
 		t.Fatal(err)
@@ -149,6 +170,7 @@ func TestRunInitIdempotent(t *testing.T) {
 }
 
 func TestRunInitNonGitRepo(t *testing.T) {
+	setupInitTest(t)
 	tmp := t.TempDir()
 	// No .git directory
 
@@ -174,6 +196,7 @@ func TestRunInitNonGitRepo(t *testing.T) {
 }
 
 func TestRunInitStealth(t *testing.T) {
+	setupInitTest(t)
 	tmp := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmp, ".git", "info"), 0755); err != nil {
 		t.Fatal(err)
@@ -203,6 +226,7 @@ func TestRunInitStealth(t *testing.T) {
 }
 
 func TestRunInitDryRun(t *testing.T) {
+	setupInitTest(t)
 	tmp := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmp, ".git"), 0755); err != nil {
 		t.Fatal(err)
@@ -255,6 +279,7 @@ func TestNestedGitignoreContent(t *testing.T) {
 }
 
 func TestRunInitGitignoreNoTrailingNewline(t *testing.T) {
+	setupInitTest(t)
 	tmp := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmp, ".git"), 0755); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## What

`TestRunInit*` tests in `cli/cmd/ao/init_test.go` flaked under `-shuffle=on` because each test set 2-3 of the package-level init flags but didn't reset the rest. State leaked across test boundaries.

## Why

Caught **twice** in CI cycles during the 2026-05-18 session (soc-zxia epic). Symptom: `TestRunInitStealth: runInit: read /tmp/.../.agents/schedule.yaml.example: open: no such file or directory` — a prior test set `initWithSchedule=true` and that state leaked into TestRunInitStealth, which then tried to copy a schedule example from a temp dir that didn't have one.

Pattern documented in the `go-shuffle-flakes` learning.

## Fix

Belt-and-suspenders `setupInitTest(t)` helper:

```go
func setupInitTest(t *testing.T) {
    t.Helper()
    resetInitFlags()              // defense against leak from prior test
    t.Cleanup(resetInitFlags)     // defense for next test
}
```

`resetInitFlags()` now covers all 6 globals (initStealth/initHooks/initFull/initMinimalHooks/initWithSchedule/dryRun).

Applied to all 8 TestRunInit functions.

## Verification

```text
$ go test -shuffle=on -count=10 ./cmd/ao/ -run TestRunInit
Go test: 120 passed in 1 packages

$ go vet ./cmd/ao/
(no output)
```

## Companion

Last of the 4 follow-up beads filed after the soc-zxia Domain-tightening epic:
- soc-3oij — add-validate-job scaffolder (#315, merged)
- soc-xban — bats auto-discovery (#316, in flight)
- soc-m6tp — generate AGENTS CI table (future)
- **soc-hwgm — this PR** — TestRunInit flake fix

Closes: soc-hwgm

🤖 Generated with [Claude Code](https://claude.com/claude-code)