### PR TITLE
feat(architecture): intent-to-loop hexagon doc + BDD skill scaffolding (soc-4d0r)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -458,7 +458,7 @@ This moves the tag to HEAD, pushes, rebuilds the GitHub release, updates the Hom
   session failure. Record it as unavailable, then continue with the mandatory
   Git push. See [bd server-mode tracker closeout](docs/runbooks/bd-server-mode-closeout.md).
 
-<!-- BEGIN BEADS INTEGRATION -->
+<!-- BEGIN BEADS INTEGRATION v:1 profile:full hash:f65d5d33 -->
 ## Issue Tracking with bd (beads)
 
 **IMPORTANT**: This project uses **bd (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.
@@ -466,7 +466,7 @@ This moves the tag to HEAD, pushes, rebuilds the GitHub release, updates the Hom
 ### Why bd?
 
 - Dependency-aware: Track blockers and relationships between issues
-- Git-friendly: Auto-syncs to JSONL for version control
+- Git-friendly: Dolt-powered version control with native sync
 - Agent-optimized: JSON output, ready work detection, discovered-from links
 - Prevents duplicate tracking systems and confusion
 
@@ -488,7 +488,7 @@ bd create "Issue title" --description="What this issue is about" -p 1 --deps dis
 **Claim and update:**
 
 ```bash
-bd update bd-42 --status in_progress --json
+bd update <id> --claim --json
 bd update bd-42 --priority 1 --json
 ```
 
@@ -517,18 +517,28 @@ bd close bd-42 --reason "Completed" --json
 ### Workflow for AI Agents
 
 1. **Check ready work**: `bd ready` shows unblocked issues
-2. **Claim your task**: `bd update <id> --status in_progress`
+2. **Claim your task atomically**: `bd update <id> --claim`
 3. **Work on it**: Implement, test, document
 4. **Discover new work?** Create linked issue:
    - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`
 5. **Complete**: `bd close <id> --reason "Done"`
 
+### Quality
+- Use `--acceptance` and `--design` fields when creating issues
+- Use `--validate` to check description completeness
+
+### Lifecycle
+- `bd defer <id>` / `bd supersede <id>` for issue management
+- `bd stale` / `bd orphans` / `bd lint` for hygiene
+- `bd human <id>` to flag for human decisions
+- `bd formula list` / `bd mol pour <name>` for structured workflows
+
 ### Auto-Sync
 
-bd automatically syncs with git:
+bd automatically syncs via Dolt:
 
-- Exports to `.beads/issues.jsonl` after changes (5s debounce)
-- Imports from JSONL when newer (e.g., after `git pull`)
+- Each write auto-commits to Dolt history
+- Use `bd dolt push`/`bd dolt pull` for remote sync
 - No manual export/import needed!
 
 ### Important Rules
@@ -542,5 +552,31 @@ bd automatically syncs with git:
 - ❌ Do NOT duplicate tracking systems
 
 For more details, see README.md and docs/QUICKSTART.md.
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd dolt push   # only if a bd remote is configured (skip silently otherwise)
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
 
 <!-- END BEADS INTEGRATION -->

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -7,6 +7,7 @@ Read in this order if you're new:
 1. **[How It Works](../how-it-works.md)** — start here for the mental model (Brownian Ratchet, context windowing, backends).
 2. **[System Overview](../ARCHITECTURE.md)** — then zoom out to see where every component sits.
 3. **[Primitive Chains](primitive-chains.md)** — then drill into the audited primitive set and lifecycle chains.
+4. **[Intent-to-Loop Hexagon](intent-to-loop-hexagon.md)** — then trace one idea through BDD intent, beads, slices, validation, and ratchet evidence.
 
 The rest are specialized references. Skim titles and jump in when a topic becomes relevant.
 
@@ -37,6 +38,12 @@ The rest are specialized references. Skim titles and jump in when a topic become
     ---
 
     Audited primitive set, lifecycle chains, and terminology drift ledger.
+
+-   :material-hexagon-multiple: **[Intent-to-Loop Hexagon](intent-to-loop-hexagon.md)**
+
+    ---
+
+    Process-level ports and adapters from BDD intent through evidence ratchet.
 
 -   :material-link-variant: **[Codex Hookless Lifecycle](codex-hookless-lifecycle.md)**
 

--- a/docs/architecture/intent-to-loop-hexagon.md
+++ b/docs/architecture/intent-to-loop-hexagon.md
@@ -1,0 +1,126 @@
+# Intent-to-Loop Hexagon
+
+> The process-level hexagon for AgentOps work: one operator intent enters the
+> loop, crosses named ports as dense artifacts, and exits only after acceptance
+> evidence and learning disposition are recorded.
+
+This page connects the structural hexagon in
+[Ports and Adapters](ports-and-adapters.md) to the execution discipline in the
+[Operating Loop](operating-loop.md). It is the contract agents use when turning
+an idea into BDD/Gherkin, beads, vertical slices, implementation work, validation
+verdicts, and ratcheted evidence.
+
+## Inner Hexagon
+
+The inner domain is not a CLI command or a specific agent runtime. It is the
+behavior contract for one loop turn:
+
+```text
+Intent
+  -> AcceptanceExample
+  -> WorkItem / Bead
+  -> Slice
+  -> Wave
+  -> CriterionVerdict
+  -> Evidence
+  -> LearningDisposition
+```
+
+These domain objects may be represented by Markdown, JSON, bd/br rows, Go
+aggregates, or `.agents/` artifacts, but the names above are the stable language.
+Adapters may change; the domain contract does not.
+
+## Port Chain
+
+| Loop move | Inbound port | Required artifact crossing the port | Driving adapter | Driven / guard adapters | Done state |
+|---|---|---|---|---|---|
+| 1. Shape intent | `shape_intent` | Intent issue with `Feature` and testable `Scenario` blocks | `/discovery`, `/brainstorm`, `/design`, operator prompt | domain register, GOALS directives, scenario schema | Every scenario is testable, bounded context is named, non-goals and evidence are explicit |
+| 2. Track as bead | `persist_intent` | Bead body carrying the Gherkin or linking to the intent issue | `/beads`, `bd create`, `br create` | bd/br, `bv --robot-*`, dependency graph checks | Bead is self-contained, dependency-linked, and has validation commands |
+| 3. Slice vertically | `plan_slices` | Slice validation plan, one row per scenario or behavior | `/plan` | symbol verification, file matrix, planning rules | Every slice has a first failing proof, write scope, owner, and bounded context |
+| 4. Execute slice | `execute_slice` | Worker brief with slice, proof, scope, and rollback path | `/implement`, `/crank`, `/swarm` | git, test runners, scope guard, runtime agents | Failing proof failed for the right reason, then passes after the smallest implementation |
+| 5. Execute wave | `execute_wave` | Wave packet with independent slice ownership | `/crank`, `/swarm`, `/autodev` | file-conflict matrix, worktrees, agent messaging | Same-wave writes do not collide, integration order is declared |
+| 6. Validate acceptance | `validate_acceptance` | Criterion verdicts and roll-up validation report | `/validation`, `/validate`, `/vibe`, `/council`, `/scenario` | tests, evals, GOALS measure, completion-claim kernel | Every Given/When/Then maps to fresh passing evidence; no test theater |
+| 7. Record evidence | `record_evidence` | Ratchet entry, evidence index, residual-gap disposition | `/ratchet`, `/post-mortem`, `/retro`, `/forge` | `.agents/ratchet/`, learning promotion gates, findings registry | Evidence is cited, residual gaps have next-step beads or accepted disposition |
+| 8. Steer loop | `steer_goal` | Goal trace, learning, or next-work packet | `/goals`, `/flywheel`, `/harvest`, `/dream` | GOALS.md, scenarios, knowledge compile, scheduler | Durable behavior changed, or the observation dies at handoff |
+
+## BDD and Done-State Rules
+
+1. **Every behavior bead starts from Gherkin.** A feature, bug, or product-facing
+   behavior must carry a fenced `gherkin` block or link to an intent issue that
+   does. Chores may omit Gherkin only when their acceptance criteria are
+   explicitly mechanical.
+2. **Every scenario becomes a slice row.** `/plan` maps each Scenario to at
+   least one slice with a first failing proof/test and a write scope.
+3. **Every slice has one owner.** If ownership or write scope is shared, the
+   work is sequential or re-sliced.
+4. **Every close claim has fresh proof.** Closed/DONE/green status is a claim
+   until `/validation` or `/validate` records command output, test names,
+   file:line evidence, and parent/dependency reconciliation.
+5. **Every residual gap is routed.** A gap becomes a new bead, learning,
+   planning rule, gate proposal, or explicit accepted risk. It does not vanish
+   into the report prose.
+
+## Adapter Responsibilities
+
+| Adapter class | Examples | Responsibility |
+|---|---|---|
+| Driving adapters | slash skills, `$` Codex skills, `ao` commands, operator prompts, scheduled jobs | Translate outside requests into the current inbound port without smuggling raw chat context |
+| Driven adapters | bd/br, git, filesystem, search, eval runners, model providers, GitHub | Persist, retrieve, execute, or observe through narrow outbound ports |
+| Guard adapters | scope guard, schema validation, pre-push gates, CI, pre-mortem, wave-validity matrix | Warn or block when a boundary contract is not met |
+| Runtime adapters | `skills/`, `skills-codex/`, OpenCode skill bundles, hooks | Package the same domain contract for a specific agent runtime |
+
+## Agent Output Contract
+
+When an agent produces an artifact for the loop, it should make the hexagon
+visible enough for the next agent to continue without chat memory:
+
+```yaml
+hexagon:
+  inbound_port: shape_intent | persist_intent | plan_slices | execute_slice | execute_wave | validate_acceptance | record_evidence | steer_goal
+  bounded_context: bc-corpus | bc-validation | bc-loop | bc-factory | bc-runtime | <repo-specific>
+  driving_adapter: "<skill, command, prompt, or scheduler that initiated this>"
+  driven_adapters:
+    - "<bd/br/git/test/eval/filesystem/model/etc. used behind the port>"
+  guard_adapters:
+    - "<pre-mortem/scope/schema/CI/completion-claim-kernel/etc.>"
+  context_packet: "<artifact path or bead id crossing the boundary>"
+  done_state: "<specific proof required before the next port may accept it>"
+```
+
+This block is not required for every small note, but it is required in durable
+plans, execution packets, substantial beads, and validation reports that future
+agents are expected to consume.
+
+## Skill Responsibilities
+
+| Skill | Hexagonal responsibility |
+|---|---|
+| `/discovery` | Owns `shape_intent`, emits the dense execution packet, and preserves BDD/Gherkin acceptance examples |
+| `/beads` | Owns `persist_intent`, makes work self-contained, dependency-linked, and proof-bearing |
+| `/plan` | Owns `plan_slices`, maps scenarios to vertical slices, file ownership, and wave validity |
+| `/pre-mortem` and `/council` | Guard intent and plan quality before implementation starts |
+| `/implement` | Owns `execute_slice`, runs first failing proof then smallest green implementation |
+| `/crank` and `/swarm` | Own `execute_wave`, coordinate workers without collapsing ownership boundaries |
+| `/validation`, `/validate`, `/vibe`, `/scenario`, `/goals` | Own `validate_acceptance`, prove claims with fresh evidence |
+| `/ratchet`, `/post-mortem`, `/retro`, `/forge` | Own `record_evidence`, promote only reusable learnings |
+| `/rpi` | Orchestrates the port chain without replacing the phase skills that own each port |
+
+## Failure Modes
+
+| Failure mode | Corrective action |
+|---|---|
+| Bead has prose acceptance but no Gherkin or mechanical criteria | Send back to `shape_intent` / `/discovery` |
+| Slice touches multiple bounded contexts | Split the slice before `/crank` |
+| Same-wave slices write the same file | Serialize, merge, or re-slice |
+| Agent marks DONE from stale CI or summary text | Apply the completion-claim kernel and rerun proof |
+| Validation finds a real gap | Re-crank the same objective or create/reopen completion-debt beads |
+| Learning is interesting but not reusable | Keep it in handoff; do not promote |
+
+## See Also
+
+- [Operating Loop](operating-loop.md)
+- [Ports and Adapters](ports-and-adapters.md)
+- [Skill Ports and Adapters](../contracts/skill-ports-and-adapters.md)
+- [Intent Issue Template](../templates/intent-issue.md)
+- [Slice Validation Plan Template](../templates/slice-validation.md)
+- [Context Map](../contracts/context-map.md)

--- a/docs/architecture/operating-loop.md
+++ b/docs/architecture/operating-loop.md
@@ -1,6 +1,6 @@
 # Operating Loop
 
-> One-page spine. The operational discipline every AgentOps process skill executes. Companion to [Ports and Adapters](ports-and-adapters.md) (the architectural seams) and [CDLC](../cdlc.md) (the context lifecycle inside the SDLC control plane).
+> One-page spine. The operational discipline every AgentOps process skill executes. Companion to [Ports and Adapters](ports-and-adapters.md) (the runtime seams), [Intent-to-Loop Hexagon](intent-to-loop-hexagon.md) (the process-level ports), and [CDLC](../cdlc.md) (the context lifecycle inside the SDLC control plane).
 
 AgentOps' execution discipline is one repeatable loop inside the SDLC control plane, not a phased waterfall of documents. Every process skill is one move within it. No artifact exists unless it advances the loop.
 
@@ -151,6 +151,7 @@ The loop is operational discipline. The architectural seams are structural. They
 
 - [`.agents/research/2026-05-15-cdlc-dojo-doctrine.md`](https://github.com/boshu2/agentops/blob/main/.agents/research/2026-05-15-cdlc-dojo-doctrine.md) — doctrine source (promote changes here first)
 - [Ports and Adapters](ports-and-adapters.md) — architectural seams the loop runs through
+- [Intent-to-Loop Hexagon](intent-to-loop-hexagon.md) — process-level ports/adapters from BDD intent through evidence ratchet
 - [ADR-0001](../adr/ADR-0001-ddd-hexagonal-adoption.md) — DDD + Hexagonal adoption
 - [CDLC](../cdlc.md) — conceptual seven phases this loop runs inside
 - [Context Map](../contracts/context-map.md) — bounded contexts and skill roles

--- a/docs/architecture/ports-and-adapters.md
+++ b/docs/architecture/ports-and-adapters.md
@@ -1,6 +1,6 @@
 # Ports and Adapters
 
-> One-page overview of AgentOps's hexagonal seam. Companion to [ADR-0001: Adopt DDD + Hexagonal Architecture](../adr/ADR-0001-ddd-hexagonal-adoption.md).
+> One-page overview of AgentOps's runtime hexagonal seam. Companion to [ADR-0001: Adopt DDD + Hexagonal Architecture](../adr/ADR-0001-ddd-hexagonal-adoption.md) and [Intent-to-Loop Hexagon](intent-to-loop-hexagon.md).
 
 AgentOps adopts Alistair Cockburn's 2005 *Hexagonal Architecture* (a.k.a. Ports and Adapters) as the load-bearing structural style for the Go runtime. The inner hexagon — the domain — is the only thing the rest of the system is allowed to depend on. Everything that talks to a runtime, a filesystem, a tracker, an LLM, or a CI workflow is an adapter, plugging into a port the domain declares.
 
@@ -87,5 +87,6 @@ A new driven adapter is a four-step recipe.
 
 - Alistair Cockburn, 2005. *Hexagonal Architecture* — <https://alistair.cockburn.us/hexagonal-architecture/>.
 - [ADR-0001: Adopt DDD + Hexagonal Architecture](../adr/ADR-0001-ddd-hexagonal-adoption.md) — the decision record this page operationalizes.
+- [Intent-to-Loop Hexagon](intent-to-loop-hexagon.md) — process-level ports/adapters from BDD intent through validation and ratchet evidence.
 - [`PRACTICE-REGISTRY.md`](https://github.com/boshu2/agentops/blob/main/PRACTICE-REGISTRY.md) — canonical slugs for `ddd-bounded-context` and `hexagonal-architecture`.
 - [Context Map](../contracts/context-map.md) — auto-generated bounded-context view of all skills by hexagonal role.

--- a/docs/contracts/skill-ports-and-adapters.md
+++ b/docs/contracts/skill-ports-and-adapters.md
@@ -53,6 +53,28 @@ carry context without dragging the whole session forward.
 Raw child-skill prose is not a boundary artifact. Link to it when needed; pass
 one of the artifacts above when another skill needs to act.
 
+## Intent-to-Loop Port Chain
+
+The full process-level hexagon is documented in
+[Intent-to-Loop Hexagon](../architecture/intent-to-loop-hexagon.md). Use this
+table as the short contract when editing skills:
+
+| Port | Owned by | Artifact crossing the boundary | Next port |
+|---|---|---|---|
+| `shape_intent` | `/discovery`, `/brainstorm`, `/design` | BDD intent issue with Gherkin scenarios | `persist_intent` |
+| `persist_intent` | `/beads` | Self-contained bead with scenario or linked intent issue | `plan_slices` |
+| `plan_slices` | `/plan` | Slice validation plan with first failing proofs | `execute_slice` / `execute_wave` |
+| `execute_slice` | `/implement` | Commit-ready slice result and proof output | `validate_acceptance` |
+| `execute_wave` | `/crank`, `/swarm`, `/autodev` | Wave result, worker evidence, phase handoff | `validate_acceptance` |
+| `validate_acceptance` | `/validation`, `/validate`, `/vibe`, `/scenario`, `/goals` | Criterion verdicts and acceptance roll-up | `record_evidence` |
+| `record_evidence` | `/ratchet`, `/post-mortem`, `/retro`, `/forge` | Ratchet entry, learning disposition, residual gaps | `steer_goal` |
+| `steer_goal` | `/goals`, `/flywheel`, `/harvest`, `/dream` | Updated directive, learning, or next-work packet | `shape_intent` |
+
+Every non-trivial boundary artifact should name its inbound port, bounded
+context, context packet, guard adapters, and done state. A behavior bead that
+lacks Gherkin or a linked intent issue is not ready for implementation unless it
+is explicitly a mechanical chore.
+
 ## Adapter Classes
 
 ### Driving Adapters
@@ -171,7 +193,7 @@ Feature: Crank executes a validated wave
 ## Naming Rules
 
 - Prefer behavior verbs for ports: `shape_intent`, `plan_slices`,
-  `execute_wave`, `validate_acceptance`, `record_learning`.
+  `execute_wave`, `validate_acceptance`, `record_evidence`.
 - Prefer concrete nouns for adapters: `bd`, `git`, `ao lookup`,
   `skills-codex/discovery/SKILL.md`, `hooks/scope-guard.sh`.
 - Do not use `BC1`, `BC2`, or similar abbreviations as the main prose name.

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -50,6 +50,7 @@ Bridge / framing docs:
 - [Primitive Chains](architecture/primitive-chains.md) — Audited primitive set, lifecycle chains, and terminology drift ledger
 - [Ports and Adapters](architecture/ports-and-adapters.md) — Hexagonal seam: inner-hexagon domain, driving/driven adapters, ports, and how to add a new adapter
 - [Operating Loop](architecture/operating-loop.md) — Operational discipline every process skill executes: BDD intent → vertical slices → conflict-free wave → bead acceptance → evidence (cleanroom companion to ports-and-adapters)
+- [Intent-to-Loop Hexagon](architecture/intent-to-loop-hexagon.md) — Process-level ports/adapters from BDD intent through beads, slices, validation, ratchet evidence, and loop steering
 - [ADR-0001: Adopt DDD + Hexagonal Architecture](adr/ADR-0001-ddd-hexagonal-adoption.md) — Decision record for encoding DDD + Hexagonal with `ExecutionPacket` as the tracer-bullet aggregate
 - [ADR-0002: AgentOps 3.0 Hookless-First CDLC Rearchitecture](adr/ADR-0002-agentops-3-hookless-cdlc-rearchitecture.md) — Proposed 3.0 direction: demote hooks to optional runtime adapters and center CDLC bounded contexts
 - [ADR-0003: Executable-Spec Artifact Durability](adr/ADR-0003-executable-spec-artifact-durability.md) — Where executable-spec scenarios and domain manifests live: promoted spec scenarios in tracked `spec/scenarios/`, ad hoc holdout scenarios stay in `.agents/holdout/`

--- a/docs/templates/intent-issue.md
+++ b/docs/templates/intent-issue.md
@@ -17,6 +17,23 @@
 > Which bounded context from [`docs/contracts/context-map.md`](../contracts/context-map.md) does this work belong to? If it crosses contexts, this is two issues, not one.
 > The bead must carry exactly one matching label: `bc-corpus`, `bc-validation`, `bc-loop`, `bc-factory`, or `bc-runtime`.
 
+## Hexagonal boundary
+
+> Fill this from [`docs/architecture/intent-to-loop-hexagon.md`](../architecture/intent-to-loop-hexagon.md). This is the handoff contract for the next agent.
+
+```yaml
+hexagon:
+  inbound_port: shape_intent
+  bounded_context: <bc-* label>
+  driving_adapter: <operator prompt | /discovery | /brainstorm | /design>
+  driven_adapters:
+    - <bd/br/filesystem/search/etc.>
+  guard_adapters:
+    - <pre-mortem/schema/scope/etc.>
+  context_packet: <intent issue path or bead id>
+  done_state: "all scenarios testable; evidence list concrete; non-goals explicit"
+```
+
 ## Domain terms
 
 > Domain terms used below, each anchored to the ubiquitous-language register at [`skills/domain/references/`](../../skills/domain/references/) or [`skills/standards/references/architecture-terms.md`](../../skills/standards/references/architecture-terms.md). New terms must be added to the register before they are used here.
@@ -90,6 +107,7 @@ Feature: <feature name from above>
 A `/pre-mortem` or `/council` must verify these before the issue leaves discovery:
 
 - [ ] Acceptance examples are written in Given/When/Then and each is testable as written
+- [ ] Hexagonal boundary block names the inbound port, bounded context, adapters, context packet, and done state
 - [ ] Bounded context is named, present in the context map, and represented by exactly one `bc-*` label
 - [ ] All domain terms used are registered in the ubiquitous-language register
 - [ ] Non-goals are explicit

--- a/docs/templates/slice-validation.md
+++ b/docs/templates/slice-validation.md
@@ -12,6 +12,27 @@
 - **Intent issue:** `<path to filled-in intent-issue.md or bd issue url>`
 - **Bounded context:** `<from intent issue>`
 
+## Hexagonal boundary
+
+> Fill this from [`docs/architecture/intent-to-loop-hexagon.md`](../architecture/intent-to-loop-hexagon.md). This is the port contract from planning into execution and validation.
+
+```yaml
+hexagon:
+  inbound_port: plan_slices
+  bounded_context: <bc-* label>
+  driving_adapter: /plan
+  driven_adapters:
+    - bd/br
+    - git
+    - test runner
+  guard_adapters:
+    - wave-validity matrix
+    - symbol verification
+    - completion-claim kernel
+  context_packet: <execution packet path or bead id>
+  done_state: "each slice has first failing proof, owner, write scope, and validation lane"
+```
+
 ## Slice-level validation
 
 > One row per slice from the intent issue's slice candidates. Each slice must have a **first failing test** before any implementation begins (the TDD discipline of move 4 in the operating loop).
@@ -83,6 +104,7 @@
 ## Closing checklist
 
 - [ ] Every slice has a first failing proof/test linked, and that proof failed before implementation began
+- [ ] Hexagonal boundary block is filled in and matches the intent issue bounded context
 - [ ] Every slice's evidence row is filled in with a concrete artifact, not a description
 - [ ] If any slices ran in parallel, every wave-validity row was checked at the time of wave start
 - [ ] Every acceptance example from the intent issue maps to at least one passing test

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -174,6 +174,7 @@ nav:
       - How It Works: how-it-works.md
       - Architecture Overview: ARCHITECTURE.md
       - Software Factory: software-factory.md
+      - Intent-to-Loop Hexagon: architecture/intent-to-loop-hexagon.md
       - Codex Hookless Lifecycle: architecture/codex-hookless-lifecycle.md
       - Primitive Chains: architecture/primitive-chains.md
       - PDC Framework: architecture/pdc-framework.md

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -673,8 +673,8 @@
     {
       "name": "beads",
       "source_skill": "skills/beads",
-      "source_hash": "f8c4dc1bea40b11b49378e5106d0f818ee5003f0da6af70c735af301be35321b",
-      "generated_hash": "dd11ff257a092cd3d2d5e93524bd91d6afa9edac1bf9cf5f3d34d2990446961e"
+      "source_hash": "13720553f7e45574d0f4abc6d08525aaa80d9470a8b5be2045ad9fcd3f426ac5",
+      "generated_hash": "03a281fe283a103d67a668622f8d53ea786801f4bdf239a62b12025bb7c7b492"
     },
     {
       "name": "bootstrap",
@@ -751,8 +751,8 @@
     {
       "name": "discovery",
       "source_skill": "skills/discovery",
-      "source_hash": "13571cf69999a8f494c03decaaf18c1da53d69fffb019f33e9a5a2762838f249",
-      "generated_hash": "686a8b634487ecadb38c6971ed3e97673749e96354be1c1eec49d7ac64b02b4c"
+      "source_hash": "f789b340a74c049017196792dc43ebcf8a5ca4bd990759abc843271ed6f7f271",
+      "generated_hash": "b8cfabc0511ff22e356756ec32257d760d7aa26326a0eb5eb23f21b2cdac11ab"
     },
     {
       "name": "doc",
@@ -877,8 +877,8 @@
     {
       "name": "plan",
       "source_skill": "skills/plan",
-      "source_hash": "3744e9ad96c836a3f25df2c0c09b58ffb51a33ab41c97e41d5a3455beeb7d53b",
-      "generated_hash": "9c19e377394c3cbeda1536a683f7ad6f2e39e6f971d3baaffa351253e28a6fb8"
+      "source_hash": "cbde267e8094eafcd887a667e9184f52d8847d8c160c515463846a3a90a00524",
+      "generated_hash": "98f259c86afd2e462b62f4971af70c028963d1e617b38f856274d9e230c19209"
     },
     {
       "name": "post-mortem",
@@ -1015,8 +1015,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "c555c28f7a184e3c5ece9322ebd3cb1a7f19605475a7c149df1ecf76d30496e3",
-      "generated_hash": "93c42675016e1ce97a66f221884a56f964d1e70e4992db8ed4f5e0ae30adb354"
+      "source_hash": "3015f3c1e4a74087c716991fffa5f92e0ebcbe4d1ee492d7b1dec99a46d7e2dd",
+      "generated_hash": "c8f439c27965aa992f1dd9c94d0f80ddc8c2aff5f8b864c8a2a6d0820c1c814d"
     },
     {
       "name": "scaffold",
@@ -1051,8 +1051,8 @@
     {
       "name": "shared",
       "source_skill": "skills/shared",
-      "source_hash": "203eda1b6558dcf65c3fecba46505f402e82f81bef2185c90934e6f7023f70fa",
-      "generated_hash": "3ccc9e98714bb19d3c27ada5fc55be040290b5e92baa0d02851806539236767d"
+      "source_hash": "4256885a364331916753754e092e7e3dc490d4b05bade2dff7e6d1bc5ff1d54e",
+      "generated_hash": "0758c94cf77d7fd1bde265f3bff580a57f15fe601c59f893502d14175d57b763"
     },
     {
       "name": "skill-auditor",
@@ -1117,14 +1117,14 @@
     {
       "name": "validate",
       "source_skill": "skills/validate",
-      "source_hash": "ea6fb882cb0d9ee3717d7064dfdf1616247fe04476221acea7520c93cc16cfbe",
-      "generated_hash": "ea7a8797f288541ed91c3b060c7c0bdb29de9ec7e9ffd5acd40ccf4bf4f53e5d"
+      "source_hash": "58e0d601fa098d63359b7eca1d48efa117bf20e4e32427d303b921940da6b8fe",
+      "generated_hash": "eab1216146dff716bd142a5caf66ec72b66286855b21e5b95f6046e360f3af42"
     },
     {
       "name": "validation",
       "source_skill": "skills/validation",
-      "source_hash": "91ab8fe0a5a31c12b3979cf34d765c8cc1b623985a8c7136375352bcfb4a721f",
-      "generated_hash": "f0d71e4e851b217768dd99fb1a124cb76849d5ed9bdb3d0cca6600a72244d420"
+      "source_hash": "7e717c1f437f102c53ef8a69249a3461dbc4ca5a22bc640de7083165eecb9b8b",
+      "generated_hash": "353b7a5dcc7e4720f355dbe37e63259482812f10605a9189c8a5e6eabcf6e851"
     },
     {
       "name": "vibe",

--- a/skills-codex/beads/.agentops-generated.json
+++ b/skills-codex/beads/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/beads",
   "layout": "modular",
-  "source_hash": "f8c4dc1bea40b11b49378e5106d0f818ee5003f0da6af70c735af301be35321b",
-  "generated_hash": "dd11ff257a092cd3d2d5e93524bd91d6afa9edac1bf9cf5f3d34d2990446961e"
+  "source_hash": "13720553f7e45574d0f4abc6d08525aaa80d9470a8b5be2045ad9fcd3f426ac5",
+  "generated_hash": "03a281fe283a103d67a668622f8d53ea786801f4bdf239a62b12025bb7c7b492"
 }

--- a/skills-codex/beads/SKILL.md
+++ b/skills-codex/beads/SKILL.md
@@ -124,14 +124,28 @@ NEVER run bare `bv`. Always use `--robot-*` flags.
 
 Convert a markdown plan into fully dependency-wired beads:
 
-1. Read the plan file
-2. Create beads with `br create` for each issue, including full context in the description
-3. Wire dependencies with `br dep add`
-4. Polish iteratively (run polish prompt 6-9 times until steady-state)
-5. Validate: `br dep cycles` must be empty, `bv --robot-insights` for graph health
-6. Begin: `bv --robot-next` for first bead
+1. Read the full plan, AGENTS.md, README, linked intent issue, and acceptance criteria.
+2. Create beads with `br create` for each issue, including full context in the description.
+3. For every feature, bug, or product-facing behavior, include a fenced `gherkin`
+   block or link to a filled intent issue. Mechanical chores may omit Gherkin
+   only when their acceptance criteria are fully command/file based.
+4. Include the `hexagon:` boundary block from
+   `docs/architecture/intent-to-loop-hexagon.md` for substantial beads:
+   inbound port, bounded context, adapters, context packet, and done state.
+5. Wire dependencies with `br dep add` / `bd dep add`. Do not hand-edit JSONL or
+   database files.
+6. Polish iteratively (usually 6-9 passes) until steady-state. Check for lost
+   features, oversimplification, missing tests, unclear boundaries, missing e2e
+   coverage, and weak logging.
+7. Validate: `br dep cycles` must be empty; run `bv --robot-insights` for graph
+   health; use `bv --robot-next` for the first bead. Never run bare `bv`.
+8. Sync explicitly before commit: `br sync --flush-only`, then `git add .beads/`
+   and commit tracker changes when appropriate.
 
-Beads should be so detailed that a fresh agent can implement without consulting the original plan.
+Beads should be so detailed that a fresh agent can implement without consulting
+the original plan. Ready-to-implement beads have clear scope, explicit
+dependencies, BDD or mechanical acceptance, unit/e2e test expectations, detailed
+logging expectations, a named done state, and no dependency cycles.
 
 ## Troubleshooting
 

--- a/skills-codex/discovery/.agentops-generated.json
+++ b/skills-codex/discovery/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/discovery",
   "layout": "modular",
-  "source_hash": "13571cf69999a8f494c03decaaf18c1da53d69fffb019f33e9a5a2762838f249",
-  "generated_hash": "686a8b634487ecadb38c6971ed3e97673749e96354be1c1eec49d7ac64b02b4c"
+  "source_hash": "f789b340a74c049017196792dc43ebcf8a5ca4bd990759abc843271ed6f7f271",
+  "generated_hash": "b8cfabc0511ff22e356756ec32257d760d7aa26326a0eb5eb23f21b2cdac11ab"
 }

--- a/skills-codex/discovery/SKILL.md
+++ b/skills-codex/discovery/SKILL.md
@@ -37,7 +37,9 @@ Leave `ao codex ensure-stop` to closeout skills; discovery owns startup only.
 ## Narrow Waist
 
 Discovery does not carry raw child-skill output forward. It records artifact
-paths, verdicts, and the six Context Density Rule fields:
+paths, verdicts, the `hexagon:` boundary block from
+[`docs/architecture/intent-to-loop-hexagon.md`](../../docs/architecture/intent-to-loop-hexagon.md),
+and the six Context Density Rule fields:
 
 | Field | Meaning |
 |-------|---------|
@@ -53,7 +55,8 @@ Everything else stays in child artifacts and is linked by path.
 ## Discovery To Plan Port
 
 Use the [Skill Ports and Adapters](../../docs/contracts/skill-ports-and-adapters.md)
-vocabulary for the boundary between Discovery and Plan:
+vocabulary and the [Intent-to-Loop Hexagon](../../docs/architecture/intent-to-loop-hexagon.md)
+for the boundary between Discovery and Plan:
 
 | Boundary piece | Discovery contract |
 |---|---|

--- a/skills-codex/plan/.agentops-generated.json
+++ b/skills-codex/plan/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/plan",
   "layout": "modular",
-  "source_hash": "3744e9ad96c836a3f25df2c0c09b58ffb51a33ab41c97e41d5a3455beeb7d53b",
-  "generated_hash": "9c19e377394c3cbeda1536a683f7ad6f2e39e6f971d3baaffa351253e28a6fb8"
+  "source_hash": "cbde267e8094eafcd887a667e9184f52d8847d8c160c515463846a3a90a00524",
+  "generated_hash": "98f259c86afd2e462b62f4971af70c028963d1e617b38f856274d9e230c19209"
 }

--- a/skills-codex/plan/SKILL.md
+++ b/skills-codex/plan/SKILL.md
@@ -80,7 +80,11 @@ Feature: Plan converts dense intent into executable slices
 8. **Decompose into issues.** Each issue needs title, file ownership,
    dependencies, acceptance criteria, test levels, and at least one mechanical
    conformance check (`files_exist`, `content_check`, `command`, `tests`, or
-   `lint`).
+   `lint`). Feature, bug, and product-facing behavior issues also need a
+   fenced `gherkin` block or a link to the upstream intent issue scenario.
+   Non-trivial plans and bead bodies should include the `hexagon:` boundary
+   block: inbound port, bounded context, adapters, context packet, and done
+   state.
 9. **Compute waves.** Group independent issues by dependency. Serialize or
    merge same-file writes. Include generated artifacts, docs, schemas, fixtures,
    Codex companions, manifests, and hash markers in ownership.

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "c555c28f7a184e3c5ece9322ebd3cb1a7f19605475a7c149df1ecf76d30496e3",
-  "generated_hash": "93c42675016e1ce97a66f221884a56f964d1e70e4992db8ed4f5e0ae30adb354"
+  "source_hash": "3015f3c1e4a74087c716991fffa5f92e0ebcbe4d1ee492d7b1dec99a46d7e2dd",
+  "generated_hash": "c8f439c27965aa992f1dd9c94d0f80ddc8c2aff5f8b864c8a2a6d0820c1c814d"
 }

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -56,6 +56,10 @@ packet objective. A child bead or one ready slice is context, not a replacement
 objective. `<promise>PARTIAL</promise>` from `$crank` means retry Phase 2 on the
 same objective.
 
+Preserve the [Intent-to-Loop Hexagon](../../docs/architecture/intent-to-loop-hexagon.md)
+boundary as the objective crosses `shape_intent`, `persist_intent`,
+`plan_slices`, `execute_wave`, `validate_acceptance`, and `record_evidence`.
+
 ## Route And Classify
 
 1. Create `.agents/rpi/`.

--- a/skills-codex/shared/.agentops-generated.json
+++ b/skills-codex/shared/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/shared",
   "layout": "modular",
-  "source_hash": "203eda1b6558dcf65c3fecba46505f402e82f81bef2185c90934e6f7023f70fa",
-  "generated_hash": "3ccc9e98714bb19d3c27ada5fc55be040290b5e92baa0d02851806539236767d"
+  "source_hash": "4256885a364331916753754e092e7e3dc490d4b05bade2dff7e6d1bc5ff1d54e",
+  "generated_hash": "0758c94cf77d7fd1bde265f3bff580a57f15fe601c59f893502d14175d57b763"
 }

--- a/skills-codex/shared/validation-contract.md
+++ b/skills-codex/shared/validation-contract.md
@@ -18,6 +18,31 @@ CORRECT (new):
 
 ---
 
+## Completion-Claim Kernel
+
+Apply this kernel whenever an artifact says a bead, task, epic, gate, or phase is
+`DONE`, `closed`, `complete`, `green`, or ready to ship:
+
+1. Treat status fields and agent summaries as claims until fresh evidence proves
+   the contract is satisfied.
+2. Rerun the narrowest checks that prove the acceptance criteria now, and keep
+   command, exit code, and relevant output in the verdict or linked evidence.
+3. Separate test existence, command success, and non-trivial assertions against
+   production paths. Flag skipped tests, `assert true`, hardcoded success paths,
+   disabled code, and mocks where the spec required real integration.
+4. Map each claimed acceptance criterion to file:line evidence, named tests, raw
+   logs, or explicit no-file evidence.
+5. Check parent/child reconciliation, dependency graph health, orphaned
+   acceptance criteria, and cross-bead contract drift.
+6. Label deterministic suspicion as `flagged-for-review` until rerun evidence
+   proves a true failure.
+
+The evidence minimum for a completion claim is: claimed scope, acceptance
+criterion, proof artifact, rerun command when applicable, and parent/dependency
+reconciliation outcome.
+
+---
+
 ## Specifying Validation Requirements
 
 

--- a/skills-codex/validate/.agentops-generated.json
+++ b/skills-codex/validate/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/validate",
   "layout": "modular",
-  "source_hash": "ea6fb882cb0d9ee3717d7064dfdf1616247fe04476221acea7520c93cc16cfbe",
-  "generated_hash": "ea7a8797f288541ed91c3b060c7c0bdb29de9ec7e9ffd5acd40ccf4bf4f53e5d"
+  "source_hash": "58e0d601fa098d63359b7eca1d48efa117bf20e4e32427d303b921940da6b8fe",
+  "generated_hash": "eab1216146dff716bd142a5caf66ec72b66286855b21e5b95f6046e360f3af42"
 }

--- a/skills-codex/validate/SKILL.md
+++ b/skills-codex/validate/SKILL.md
@@ -9,6 +9,14 @@ description: 'Produce PASS/WARN/FAIL verdicts.'
 
 > **Status (2026-05-08):** introduced ADDITIVE in Phase 1 (m6v5.D.1 / soc-78s2v). Existing validators (council, vibe, pre-mortem, red-team, pr-validate, validation, review, scenario) stay until Phase 2 shim conversion (m6v5.D.2). Fix-C smoke (`soc-wb2aa`) gates Phase 2.
 
+`$validate` is a driving adapter for the `validate_acceptance` port in the
+[Intent-to-Loop Hexagon](../../docs/architecture/intent-to-loop-hexagon.md).
+When the artifact contains a `hexagon:` block, preserve the bounded context,
+context packet, guard adapters, and done state in the verdict.
+When the artifact claims DONE/closed/green, apply the
+[Completion-Claim Kernel](../shared/validation-contract.md#completion-claim-kernel)
+before returning PASS.
+
 ## Modes (≤8 per Fix-F mode-flag budget)
 
 | Mode | Purpose | Replaces (post-Phase 2) |

--- a/skills-codex/validation/.agentops-generated.json
+++ b/skills-codex/validation/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/validation",
   "layout": "modular",
-  "source_hash": "91ab8fe0a5a31c12b3979cf34d765c8cc1b623985a8c7136375352bcfb4a721f",
-  "generated_hash": "f0d71e4e851b217768dd99fb1a124cb76849d5ed9bdb3d0cca6600a72244d420"
+  "source_hash": "7e717c1f437f102c53ef8a69249a3461dbc4ca5a22bc640de7083165eecb9b8b",
+  "generated_hash": "353b7a5dcc7e4720f355dbe37e63259482812f10605a9189c8a5e6eabcf6e851"
 }

--- a/skills-codex/validation/SKILL.md
+++ b/skills-codex/validation/SKILL.md
@@ -14,6 +14,13 @@ Validation delegates to `$vibe`, `$post-mortem`, `$retro`, and `$forge` (plus li
 
 See [`docs/learnings/orchestrator-compression-anti-pattern.md`](../../docs/learnings/orchestrator-compression-anti-pattern.md) for the live compression signature.
 
+Validation owns the `validate_acceptance` port in the
+[Intent-to-Loop Hexagon](../../docs/architecture/intent-to-loop-hexagon.md).
+The roll-up must preserve bounded context, context packet, guard adapters, done
+state, and fresh proof for each accepted scenario. Apply the
+[Completion-Claim Kernel](../shared/validation-contract.md#completion-claim-kernel)
+before accepting DONE/closed/green claims.
+
 ## DAG — Execute This Sequentially
 
 ### Step 0: Load Prior Validation Context

--- a/skills/beads/SKILL.md
+++ b/skills/beads/SKILL.md
@@ -150,14 +150,28 @@ NEVER run bare `bv`. Always use `--robot-*` flags.
 
 Convert a markdown plan into fully dependency-wired beads:
 
-1. Read the plan file
-2. Create beads with `br create` for each issue, including full context in the description
-3. Wire dependencies with `br dep add`
-4. Polish iteratively (run polish prompt 6-9 times until steady-state)
-5. Validate: `br dep cycles` must be empty, `bv --robot-insights` for graph health
-6. Begin: `bv --robot-next` for first bead
+1. Read the full plan, AGENTS.md, README, linked intent issue, and acceptance criteria.
+2. Create beads with `br create` for each issue, including full context in the description.
+3. For every feature, bug, or product-facing behavior, include a fenced `gherkin`
+   block or link to a filled intent issue. Mechanical chores may omit Gherkin
+   only when their acceptance criteria are fully command/file based.
+4. Include the `hexagon:` boundary block from
+   `docs/architecture/intent-to-loop-hexagon.md` for substantial beads:
+   inbound port, bounded context, adapters, context packet, and done state.
+5. Wire dependencies with `br dep add` / `bd dep add`. Do not hand-edit JSONL or
+   database files.
+6. Polish iteratively (usually 6-9 passes) until steady-state. Check for lost
+   features, oversimplification, missing tests, unclear boundaries, missing e2e
+   coverage, and weak logging.
+7. Validate: `br dep cycles` must be empty; run `bv --robot-insights` for graph
+   health; use `bv --robot-next` for the first bead. Never run bare `bv`.
+8. Sync explicitly before commit: `br sync --flush-only`, then `git add .beads/`
+   and commit tracker changes when appropriate.
 
-Beads should be so detailed that a fresh agent can implement without consulting the original plan.
+Beads should be so detailed that a fresh agent can implement without consulting
+the original plan. Ready-to-implement beads have clear scope, explicit
+dependencies, BDD or mechanical acceptance, unit/e2e test expectations, detailed
+logging expectations, a named done state, and no dependency cycles.
 
 ## Troubleshooting
 

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -64,7 +64,9 @@ See [`references/isolation-contract.md`](references/isolation-contract.md) for t
 ## Narrow Waist
 
 Discovery does not carry raw child-skill output forward. It records artifact
-paths, verdicts, and the six Context Density Rule fields:
+paths, verdicts, the `hexagon:` boundary block from
+[`docs/architecture/intent-to-loop-hexagon.md`](../../docs/architecture/intent-to-loop-hexagon.md),
+and the six Context Density Rule fields:
 
 | Field | Meaning |
 |-------|---------|
@@ -80,7 +82,8 @@ Everything else stays in child artifacts and is linked by path.
 ## Discovery To Plan Port
 
 Use the [Skill Ports and Adapters](../../docs/contracts/skill-ports-and-adapters.md)
-vocabulary for the boundary between Discovery and Plan:
+vocabulary and the [Intent-to-Loop Hexagon](../../docs/architecture/intent-to-loop-hexagon.md)
+for the boundary between Discovery and Plan:
 
 | Boundary piece | Discovery contract |
 |---|---|

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -45,7 +45,8 @@ Moves **3 (vertical slice decomposition)** and **5 (wave validity check)** of th
 ## Discovery Boundary
 
 Use the [Skill Ports and Adapters](../../docs/contracts/skill-ports-and-adapters.md)
-vocabulary for the boundary from Discovery into Plan:
+vocabulary and the [Intent-to-Loop Hexagon](../../docs/architecture/intent-to-loop-hexagon.md)
+for the boundary from Discovery into Plan:
 
 | Boundary piece | Plan contract |
 |---|---|
@@ -179,6 +180,13 @@ Analyze the goal and break it into discrete, implementable issues. For each issu
 #### Acceptance Criteria Contract (mandatory)
 
 Every issue body MUST contain an `acceptance_criteria` fenced YAML block. The block lives BELOW the issue's textual description and ABOVE any "Reference" or "Notes" trailer. The parent epic body carries its own `acceptance_criteria` block (epic-level criteria); each child bead carries its own. `/discovery` STEP 6 lifts both into the execution packet under `epic_criteria` and `bead_criteria`. Canonical shape: [`schemas/execution-packet.schema.json`](../../schemas/execution-packet.schema.json) (`#/$defs/Criterion`).
+
+Every feature, bug, or product-facing behavior issue MUST also carry either a
+fenced `gherkin` block or a link to the upstream intent issue scenario it
+implements. Every non-trivial plan and bead body SHOULD include the `hexagon:`
+boundary block from `docs/architecture/intent-to-loop-hexagon.md` so the next
+agent knows the inbound port, bounded context, adapters, context packet, and
+done state.
 
 ```yaml
 acceptance_criteria:

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -69,6 +69,10 @@ Codex direct checks before declaring a source-level regression.
 - **No move-skipping.** Strict delegation is on by default; phases never compress, and validation cannot be skipped. The lifecycle objective is preserved across the whole loop.
 - **The first failing test is the bead's contract.** With `--test-first` on (the default), `/crank` is invoked with the TDD-per-slice discipline; `--no-test-first` is an explicit opt-out, not a fast path.
 - **Acceptance examples close the bead, not activity.** Validation FAIL re-cranks on the same objective up to 3 attempts; DONE requires the acceptance roll-up in the [slice-validation template](../../docs/templates/slice-validation.md) to be fully green.
+- **Ports stay visible.** Preserve the
+  [Intent-to-Loop Hexagon](../../docs/architecture/intent-to-loop-hexagon.md)
+  boundary as the objective crosses `shape_intent`, `persist_intent`,
+  `plan_slices`, `execute_wave`, `validate_acceptance`, and `record_evidence`.
 - **Context density survives phase boundaries.** Apply the [Context Density Rule](../domain/references/context-density-rule.md) to every phase handoff and final report: keep intent, boundary, evidence, decision, constraint, and next action; omit or link anything else.
 
 ## Core Contract

--- a/skills/shared/validation-contract.md
+++ b/skills/shared/validation-contract.md
@@ -19,6 +19,31 @@ CORRECT (new):
 
 ---
 
+## Completion-Claim Kernel
+
+Apply this kernel whenever an artifact says a bead, task, epic, gate, or phase is
+`DONE`, `closed`, `complete`, `green`, or ready to ship:
+
+1. Treat status fields and agent summaries as claims until fresh evidence proves
+   the contract is satisfied.
+2. Rerun the narrowest checks that prove the acceptance criteria now, and keep
+   command, exit code, and relevant output in the verdict or linked evidence.
+3. Separate test existence, command success, and non-trivial assertions against
+   production paths. Flag skipped tests, `assert true`, hardcoded success paths,
+   disabled code, and mocks where the spec required real integration.
+4. Map each claimed acceptance criterion to file:line evidence, named tests, raw
+   logs, or explicit no-file evidence.
+5. Check parent/child reconciliation, dependency graph health, orphaned
+   acceptance criteria, and cross-bead contract drift.
+6. Label deterministic suspicion as `flagged-for-review` until rerun evidence
+   proves a true failure.
+
+The evidence minimum for a completion claim is: claimed scope, acceptance
+criterion, proof artifact, rerun command when applicable, and parent/dependency
+reconciliation outcome.
+
+---
+
 ## Specifying Validation Requirements
 
 ### TaskCreate Metadata

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -34,6 +34,14 @@ output_contract: schemas/verdict.v1.schema.json
 
 > **Status (2026-05-08):** introduced ADDITIVE in Phase 1 (m6v5.D.1 / soc-78s2v). Existing validators (council/vibe/pre-mortem/red-team/pr-validate/validation/review/scenario) stay until Phase 2 shim conversion (m6v5.D.2). Fix-C smoke (`soc-wb2aa`) gates Phase 2.
 
+`/validate` is a driving adapter for the `validate_acceptance` port in the
+[Intent-to-Loop Hexagon](../../docs/architecture/intent-to-loop-hexagon.md).
+When the artifact contains a `hexagon:` block, preserve the bounded context,
+context packet, guard adapters, and done state in the verdict.
+When the artifact claims DONE/closed/green, apply the
+[Completion-Claim Kernel](../shared/validation-contract.md#completion-claim-kernel)
+before returning PASS.
+
 ## Modes (≤8 per Fix-F mode-flag budget)
 
 | Mode | Purpose | Replaces (post-Phase 2) |

--- a/skills/validation/SKILL.md
+++ b/skills/validation/SKILL.md
@@ -54,6 +54,13 @@ Validation delegates to `/vibe`, `/post-mortem`, `/retro`, and `/forge` (plus li
 See [`docs/learnings/orchestrator-compression-anti-pattern.md`](../../docs/learnings/orchestrator-compression-anti-pattern.md) for the live compression signature.
 See [`references/isolation-contract.md`](references/isolation-contract.md) for the four-lever model and the compression patterns `scripts/check-skill-isolation.sh` flags in phase-skill SKILL.md bodies. See [`references/best-practices.md`](references/best-practices.md) for the lifecycle principle + anti-pattern citation table.
 
+Validation owns the `validate_acceptance` port in the
+[Intent-to-Loop Hexagon](../../docs/architecture/intent-to-loop-hexagon.md).
+The roll-up must preserve bounded context, context packet, guard adapters, done
+state, and fresh proof for each accepted scenario. Apply the
+[Completion-Claim Kernel](../shared/validation-contract.md#completion-claim-kernel)
+before accepting DONE/closed/green claims.
+
 ## Execution
 
 Run the DAG in [references/dag.md](references/dag.md) — STEP 1 (vibe) → 1.5 (four-surface closure) → 1.6 (test pyramid) → 1.6b (validation-lane budget guard) → 1.7 (lifecycle: test/deps/review/perf) → 1.8 (behavioral) → 2 (post-mortem) → 3 (retro) → 4 (forge) → 5 (phase summary), no stopping between steps. That file owns the executable workflow, gate detail, blocking conditions, phase summary format, phase budgets, and the expensive-command policy.


### PR DESCRIPTION
## What

Foundation slice for the **soc-qk4b** epic ('TDD-crank all skills into intent-to-loop hexagons'). The epic description listed these artifacts as 'What already exists' — but they were never committed to main. Without them, the 6 sub-issues (`soc-qk4b.1` through `.6`) cannot start.

## New

`docs/architecture/intent-to-loop-hexagon.md` — process-level hexagon connecting [Ports and Adapters](../blob/main/docs/architecture/ports-and-adapters.md) (structure) to [Operating Loop](../blob/main/docs/architecture/operating-loop.md) (execution). Defines the 8-port chain with driving/driven/guard adapters and done-state rules:

```
Intent
  -> shape_intent      -> AcceptanceExample
  -> persist_intent    -> WorkItem / Bead
  -> plan_slices       -> Slice
  -> execute_slice     -> implementation
  -> execute_wave      -> wave packet
  -> validate_acceptance -> CriterionVerdict
  -> record_evidence   -> Evidence
  -> steer_goal        -> LearningDisposition
```

## Skill changes

Source-of-truth in `skills/`, mirrored to `skills-codex/` (re-hashed via `scripts/regen-codex-hashes.sh`):

| Skill | Change |
|---|---|
| `plan` | Require Gherkin block or upstream-scenario link for feature/bug/product-facing behavior issues; `hexagon:` boundary block for non-trivial plans and beads. |
| `discovery`, `rpi`, `validate`, `validation`, `beads`, `shared/validation-contract` | Reference the intent-to-loop hexagon as the boundary contract. |

## Doc plumbing

- `docs/architecture/{index,operating-loop,ports-and-adapters}.md` + `docs/contracts/skill-ports-and-adapters.md`: cross-link to new hexagon.
- `docs/templates/{intent-issue,slice-validation}.md`: carry hexagon block into intent issues and slice validation plans.
- `mkdocs.yml`, `docs/documentation-index.md`: register new doc in nav.

## AGENTS.md

- bd integration block regenerated (`v:1 profile:full hash:f65d5d33`).
- Session Completion section added with **conditional** `bd dolt push` wording — passes `scripts/validate-bd-closeout-contract.sh`.

## Validation

- ✅ `scripts/pre-push-gate.sh --fast`: passed (1 pre-existing warn on `scenarios/trace` executable-spec link integrity, unrelated)
- ✅ `scripts/validate-bd-closeout-contract.sh`: passes
- ✅ `scripts/regen-codex-hashes.sh`: 7 manifest hashes updated for parity
- ✅ All 8 codex JSON files: syntactically valid
- ✅ Self-review per pre-commit hook: no removed error handling, no changed defaults, no silent data loss

## Origin

Discovered during analysis of merged branch `refactor/council-mode-taxonomy-soc-ml4l` (PR #293) on 2026-05-18 — the BDD/hexagon scaffolding sat uncommitted in the worktree after #293 merged. Filed as `soc-4d0r` with `discovered-from: soc-qk4b`. This PR lands the work cleanly off fresh `main`.

## Unblocks

- soc-qk4b (epic)
- soc-qk4b.1 — Control ledger for 77-skill hexagon crank
- soc-qk4b.2 — Loop priority skills (hexagon/TDD crank)
- soc-qk4b.3 — Factory priority skills
- soc-qk4b.4 — Corpus priority skills
- soc-qk4b.5 — Validation priority skills
- soc-qk4b.6 — Runtime priority skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)