### PR TITLE
docs+fix: mkdocs venv note + shellcheck SC2034 (soc-u35g + post-merge)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,10 @@ cd cli && make build && make test         # If you changed Go code
 cd cli && make sync-hooks                 # If you changed hooks/ or lib/hook-helpers.sh
 scripts/regen-codex-hashes.sh            # If you changed skills-codex/ files
 scripts/pre-push-gate.sh                 # Full gate (all 33 checks, ~3min)
+
+# If you touched docs/ and need the mkdocs strict check locally:
+# (system mkdocs ≤1.1.2 cannot parse the modern mkdocs.yml — needs material plugins)
+python3 -m venv .venv-mkdocs && .venv-mkdocs/bin/pip install -r requirements-docs.txt && .venv-mkdocs/bin/mkdocs build --strict
 ```
 
 ### Rules That Break CI

--- a/scripts/validate-ci-policy-parity.sh
+++ b/scripts/validate-ci-policy-parity.sh
@@ -18,7 +18,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 GENERATOR="$SCRIPT_DIR/generate-ci-jobs-table.sh"
 


### PR DESCRIPTION
## What

Two micro-fixes bundled — shellcheck regression from just-merged #322 was blocking pre-push on the docs change.

## docs(CLAUDE.md) — mkdocs venv one-liner

Harvested item #7 from `.agents/rpi/next-work.jsonl` (`discovery-2026-05-12-ddd-hexagonal`). Add the venv snippet to **Quick Local Validation** so operators don't have to discover it by trial-and-error.

```bash
python3 -m venv .venv-mkdocs && .venv-mkdocs/bin/pip install -r requirements-docs.txt && .venv-mkdocs/bin/mkdocs build --strict
```

System mkdocs ≤1.1.2 (Ubuntu default) cannot parse the modern `mkdocs.yml` — it needs the material-plugin Python tags. The venv install gives you a working strict build locally.

## fix(scripts) — drop unused REPO_ROOT (SC2034)

PR #322 (just merged) rewrote `scripts/validate-ci-policy-parity.sh` as a 30-line wrapper around the new generator. The rewrite kept `REPO_ROOT` from the old 190-line version but **never uses it** (the wrapper only needs `SCRIPT_DIR` to locate `generate-ci-jobs-table.sh`).

```diff
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

 GENERATOR="$SCRIPT_DIR/generate-ci-jobs-table.sh"
```

shellcheck SC2034 was firing on every pre-push gate. Dead-code removal, behavior unchanged. The script still runs `CI_JOBS_TABLE: PASS (67 rows)` post-change. Underlying logic remains covered by the 11-test `generate-ci-jobs-table.bats` from #322.

## Validation

- ✅ `shellcheck scripts/validate-ci-policy-parity.sh`: clean
- ✅ `bash scripts/validate-ci-policy-parity.sh`: PASS (67 rows)
- ✅ `scripts/pre-push-gate.sh --fast`: passed

## Discovered

Cycle 199 of /evolve loop. Self-inflicted regression from #322 (which just merged 5 minutes earlier) — caught locally on the next branch's pre-push gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)