### PR TITLE
fix(pre-push-gate): shellcheck staged *.sh unconditionally (soc-xkk2)

### DIFF
--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -1775,42 +1775,54 @@ else
 fi
 
 # --- 30. ShellCheck on changed scripts ---
-if needs_check shell; then
-    if command -v shellcheck >/dev/null 2>&1; then
-        shell_errors=0
-        if [[ "$FAST_MODE" == "true" ]]; then
-            # Only check changed .sh files
-            changed_sh="$(echo "$all_changed" | grep '\.sh$' || true)"
-            if [[ -n "$changed_sh" ]]; then
-                while IFS= read -r f; do
-                    [[ -f "$f" ]] || continue
-                    if ! shellcheck_out="$(shellcheck -S warning "$f" 2>&1)"; then
-                        shell_errors=1
-                        indent_output "$shellcheck_out"
-                    fi
-                done <<< "$changed_sh"
-            fi
-        else
-            # Full mode: check all scripts with shebangs
+# UNCONDITIONAL in fast mode: shellcheck every staged or working-tree *.sh
+# file regardless of `needs_check shell`. The diff-based HAS_SHELL detection
+# can miss staged .sh files when `all_changed` is computed against the wrong
+# base (e.g. branch behind main mid-rebase). The cost is < 1s per file, so
+# always running it on the actual set of .sh files in the local diff is the
+# safer default. Full mode keeps the broader scripts/hooks/lib/bin walk.
+# History: F1 in 2026-05-18 merge-arc post-mortem
+# (.agents/learnings/2026-05-18-script-rewrites-leave-dead-variables.md):
+# PR #322 left an unused REPO_ROOT in a rewritten script; the SC2034 warning
+# only surfaced on the NEXT cycle, requiring PR #325 as cleanup. Closes the
+# class by removing the diff-detection gating.
+if command -v shellcheck >/dev/null 2>&1; then
+    shell_errors=0
+    if [[ "$FAST_MODE" == "true" ]]; then
+        # Collect all .sh files in the local diff (staged + working tree),
+        # independent of upstream-diff detection.
+        staged_sh="$(git diff --name-only --cached 2>/dev/null | grep '\.sh$' || true)"
+        worktree_sh="$(git diff --name-only 2>/dev/null | grep '\.sh$' || true)"
+        # Also include anything `needs_check shell` saw — defense in depth.
+        all_sh_files="$(printf '%s\n%s\n%s\n' "$staged_sh" "$worktree_sh" "$(echo "$all_changed" | grep '\.sh$' || true)" \
+            | sed '/^[[:space:]]*$/d' | sort -u)"
+        if [[ -n "$all_sh_files" ]]; then
             while IFS= read -r f; do
                 [[ -f "$f" ]] || continue
-                head -1 "$f" | grep -q '^#!' || continue
                 if ! shellcheck_out="$(shellcheck -S warning "$f" 2>&1)"; then
                     shell_errors=1
                     indent_output "$shellcheck_out"
                 fi
-            done < <(find scripts hooks lib bin -name '*.sh' -type f 2>/dev/null)
-        fi
-        if [[ "$shell_errors" -eq 0 ]]; then
-            pass "shellcheck"
-        else
-            fail "shellcheck"
+            done <<< "$all_sh_files"
         fi
     else
-        skip "shellcheck (not installed)"
+        # Full mode: check all scripts with shebangs
+        while IFS= read -r f; do
+            [[ -f "$f" ]] || continue
+            head -1 "$f" | grep -q '^#!' || continue
+            if ! shellcheck_out="$(shellcheck -S warning "$f" 2>&1)"; then
+                shell_errors=1
+                indent_output "$shellcheck_out"
+            fi
+        done < <(find scripts hooks lib bin -name '*.sh' -type f 2>/dev/null)
+    fi
+    if [[ "$shell_errors" -eq 0 ]]; then
+        pass "shellcheck"
+    else
+        fail "shellcheck"
     fi
 else
-    skip "shellcheck"
+    skip "shellcheck (not installed)"
 fi
 
 # --- 31. Plugin load test (symlinks + manifest) ---

--- a/tests/scripts/pre-push-shellcheck-unconditional.bats
+++ b/tests/scripts/pre-push-shellcheck-unconditional.bats
@@ -61,8 +61,11 @@ setup() {
         | grep -qE 'skip "shellcheck \(not installed\)"'
 }
 
-@test "post-mortem learning is in place for the F1 fix" {
-    # The change is anchored to a durable lesson — if the lesson file goes
-    # away, that's a signal the rationale was lost.
-    [ -f "$ROOT/.agents/learnings/2026-05-18-script-rewrites-leave-dead-variables.md" ]
+@test "post-mortem learning anchor reference is in the script comment" {
+    # The change is anchored to a durable lesson; verify the rationale link
+    # remains in the script comment header. The actual learning file lives
+    # in .agents/ (gitignored, local-only), so a file-existence check would
+    # break in CI's fresh clone. Asserting the reference in the script body
+    # instead keeps the rationale traceable without depending on local state.
+    grep -q '2026-05-18-script-rewrites-leave-dead-variables' "$GATE"
 }

--- a/tests/scripts/pre-push-shellcheck-unconditional.bats
+++ b/tests/scripts/pre-push-shellcheck-unconditional.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+# Tests for scripts/pre-push-gate.sh step 30 (ShellCheck) — verifies the
+# unconditional staged-shell shellcheck pass.
+#
+# History: 2026-05-18 merge-arc post-mortem F1. PR #322 left an unused
+# REPO_ROOT in a rewritten script; shellcheck SC2034 surfaced only on the
+# NEXT cycle's pre-push because the gate's `needs_check shell` and inner
+# `--fast` filter both depend on diff-based HAS_SHELL detection — when
+# `all_changed` is computed against the wrong base, staged .sh files can
+# slip through. The fix routes through `git diff --name-only --cached`
+# and `git diff --name-only` directly so staged/working-tree .sh files
+# always get shellchecked in fast mode.
+#
+# See: .agents/learnings/2026-05-18-script-rewrites-leave-dead-variables.md
+
+setup() {
+    ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    GATE="$ROOT/scripts/pre-push-gate.sh"
+    [ -f "$GATE" ] || skip "gate not found: $GATE"
+}
+
+@test "step 30 invokes shellcheck without HAS_SHELL gating" {
+    # Structural check: the step 30 block must not be wrapped in
+    # `if needs_check shell; then` — the staged-shell pass is unconditional
+    # in fast mode now. Grep the source.
+    sec=$(awk '
+        /^# --- 30\. ShellCheck/ { in_sec=1 }
+        in_sec && /^# --- 31\./ { in_sec=0 }
+        in_sec { print }
+    ' "$GATE")
+
+    if echo "$sec" | grep -qE '^if needs_check shell'; then
+        echo "Step 30 still gated by needs_check shell — diff-detection bypass missing"
+        echo "----"
+        echo "$sec" | head -10
+        return 1
+    fi
+}
+
+@test "step 30 collects staged .sh via git diff --cached" {
+    # The new pass must consult the staged set directly, not rely on
+    # all_changed (which has historically missed files).
+    grep -A 40 '^# --- 30\. ShellCheck' "$GATE" \
+        | grep -qE 'git diff --name-only --cached.*grep .*\.sh'
+}
+
+@test "step 30 collects working-tree .sh via git diff --name-only" {
+    grep -A 40 '^# --- 30\. ShellCheck' "$GATE" \
+        | grep -qE 'git diff --name-only.*grep .*\.sh'
+}
+
+@test "step 30 still uses shellcheck -S warning" {
+    # Severity threshold preserved (SC2034 is warning-level; lower thresholds
+    # would mask it).
+    grep -A 50 '^# --- 30\. ShellCheck' "$GATE" \
+        | grep -qE 'shellcheck -S warning'
+}
+
+@test "step 30 still skips gracefully when shellcheck is missing" {
+    grep -A 60 '^# --- 30\. ShellCheck' "$GATE" \
+        | grep -qE 'skip "shellcheck \(not installed\)"'
+}
+
+@test "post-mortem learning is in place for the F1 fix" {
+    # The change is anchored to a durable lesson — if the lesson file goes
+    # away, that's a signal the rationale was lost.
+    [ -f "$ROOT/.agents/learnings/2026-05-18-script-rewrites-leave-dead-variables.md" ]
+}


### PR DESCRIPTION
## What

Closes **F1** from the [2026-05-18 merge-arc post-mortem](.agents/learnings/2026-05-18-script-rewrites-leave-dead-variables.md). Highest-severity actionable item from `postmortem-merge-arc-2026-05-18` next-work batch.

## Root cause

PR #322 (`soc-3oij`, two PRs ago) rewrote `scripts/validate-ci-policy-parity.sh` and left an unused `REPO_ROOT` declaration. shellcheck SC2034 should have caught it locally, but step 30 in `pre-push-gate.sh` is gated by `needs_check shell` → `HAS_SHELL=1` → `.sh` in `$all_changed`. `$all_changed` is computed via `git diff @{upstream}...HEAD` (plus staged + worktree in some `SCOPE` modes), and that base can be stale mid-rebase. Result: shellcheck skipped locally, SC2034 reached main, PR #325 needed for cleanup.

## Fix

Drop the diff-detection gate. In fast mode, step 30 now collects `.sh` files from **three sources** and shellchecks the union:

```bash
staged_sh="$(git diff --name-only --cached 2>/dev/null | grep '\.sh$' || true)"
worktree_sh="$(git diff --name-only 2>/dev/null | grep '\.sh$' || true)"
# Plus the existing $all_changed filter as belt-and-suspenders.
all_sh_files="$(printf '%s\n%s\n%s\n' "$staged_sh" "$worktree_sh" "$(echo "$all_changed" | grep '\.sh$' || true)" | sed '/^[[:space:]]*$/d' | sort -u)"
```

Cost: shellcheck on a 50-line script takes <0.05s. Even 30 .sh files in flight add <2s to the gate. Full mode is unchanged (still walks `scripts/hooks/lib/bin`).

## Tests

`tests/scripts/pre-push-shellcheck-unconditional.bats` (6 tests, **6/6 PASS**):

| # | Assertion |
|---|---|
| 1 | Step 30 NOT wrapped in `if needs_check shell` |
| 2 | Step 30 consults `git diff --name-only --cached` directly |
| 3 | Step 30 consults `git diff --name-only` (working tree) |
| 4 | `shellcheck -S warning` severity preserved (SC2034 must surface) |
| 5 | Still skips gracefully when shellcheck is missing |
| 6 | The anchoring post-mortem learning file exists |

## Validation

- ✅ `bats tests/scripts/pre-push-shellcheck-unconditional.bats`: 6/6 PASS
- ✅ `shellcheck -S warning scripts/pre-push-gate.sh`: clean
- ✅ `scripts/pre-push-gate.sh --fast`: passed (1 pre-existing unrelated warn)
- ✅ Manual SC2034 reproduction: `shellcheck -S warning` on a synthetic `UNUSED_VAR="hello"` fixture fires the warning

## Discovered

Cycle 200 of /evolve loop, 2026-05-18 — first item from the post-mortem-generated batch. Closes the regression class that gave us PR #325 (`soc-u35g`).

Learning anchor: [`2026-05-18-script-rewrites-leave-dead-variables.md`](.agents/learnings/2026-05-18-script-rewrites-leave-dead-variables.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)