### PR TITLE
feat(scripts): gh-merge-chain.sh — sequence N PRs through auto-merge (soc-a5y5)

### DIFF
--- a/scripts/gh-merge-chain.sh
+++ b/scripts/gh-merge-chain.sh
@@ -52,11 +52,18 @@ if [[ ${#PRS[@]} -eq 0 ]]; then
     exit 2
 fi
 
-# Resolve owner/repo from gh once.
-REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)"
+# Resolve owner/repo from gh once. In --dry-run we tolerate failure: the dry
+# path doesn't call `gh api` for update-branch, so it can run in sandboxed
+# CI environments where `gh repo view` can't authenticate. Real (non-dry)
+# runs still require a resolvable repo.
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
 if [[ -z "$REPO" ]]; then
-    echo "ERROR: cannot resolve current repo (gh repo view failed). Run inside a git checkout." >&2
-    exit 2
+    if [[ "$DRY_RUN" == "true" ]]; then
+        REPO="(dry-run: repo unresolved)"
+    else
+        echo "ERROR: cannot resolve current repo (gh repo view failed). Run inside a git checkout." >&2
+        exit 2
+    fi
 fi
 
 echo "merge-chain: ${#PRS[@]} PR(s) in repo $REPO with method=$MERGE_METHOD"

--- a/tests/scripts/gh-merge-chain.bats
+++ b/tests/scripts/gh-merge-chain.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# Tests for scripts/gh-merge-chain.sh (soc — F3 closer).
+#
+# Exercises argument parsing and --dry-run paths. The live-poll loop is
+# not unit-testable without a live gh + GitHub fixture; covered by manual
+# usage on real merge chains.
+
+setup() {
+    ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$ROOT/scripts/gh-merge-chain.sh"
+    [ -x "$SCRIPT" ] || skip "script not executable: $SCRIPT"
+}
+
+@test "exits 2 when called with no PR numbers" {
+    run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage:"* ]]
+}
+
+@test "exits 2 on unknown flag" {
+    run "$SCRIPT" --nonexistent-flag 321
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"unknown flag:"* ]]
+}
+
+@test "--help prints the leading comment block" {
+    run "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"gh-merge-chain"* ]]
+    [[ "$output" == *"update-branch"* ]]
+}
+
+@test "--dry-run lists PR numbers without invoking gh pr merge" {
+    if ! command -v gh >/dev/null 2>&1; then
+        skip "gh not installed"
+    fi
+    # gh repo view will be called; we tolerate failure by bypassing the
+    # cwd-requires-gh-repo branch using a fake repo env if needed.
+    # On a normal repo checkout this succeeds.
+    run "$SCRIPT" --dry-run 321 322 323
+    # In a non-repo, status=2 with the cannot-resolve message.
+    if [[ "$status" -eq 2 && "$output" == *"cannot resolve current repo"* ]]; then
+        skip "no gh-resolvable repo context"
+    fi
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"3 PR(s)"* ]]
+    [[ "$output" == *"#321"* ]]
+    [[ "$output" == *"#322"* ]]
+    [[ "$output" == *"#323"* ]]
+    [[ "$output" == *"[dry-run]"* ]]
+}
+
+@test "uses set -euo pipefail" {
+    # The directive lives after the multi-line comment header.
+    grep -qE '^set -euo pipefail$' "$SCRIPT"
+}
+
+@test "quotes the PR numbers when passing to gh" {
+    # Defense against the unquoted-expansion class. The hot loop must use
+    # \"\$pr\" / \"\$REPO\" — flag with shellcheck and grep.
+    if command -v shellcheck >/dev/null 2>&1; then
+        shellcheck -S warning "$SCRIPT"
+    fi
+}
+
+@test "anchors to the F3 post-mortem learning reference" {
+    # Asserting the rationale REFERENCE in the script body, not the local
+    # learning file: .agents/ is gitignored, so a file-existence check would
+    # fail in CI's fresh clone (caught on the rebased SHA of this PR).
+    grep -q '2026-05-18-auto-merge-needs-update-branch-when-main-moves.md' "$SCRIPT"
+}


### PR DESCRIPTION
## What

New `scripts/gh-merge-chain.sh` closes **F3** from 2026-05-18 merge-arc post-mortem. Reduces `N-1` manual `update-branch` calls for an N-PR chain to a single command.

## Problem

`gh pr merge --squash --auto` does not auto-rebase when main moves underneath the PR's head. Branch goes BEHIND → auto-merge stalls → operator must call `gh api repos/.../update-branch -X PUT`. This session's 5-PR chain (#321 → #326) required 4 manual nudges.

## Usage

```bash
scripts/gh-merge-chain.sh 321 322 323 324 325 326
scripts/gh-merge-chain.sh --dry-run 321 322 323
scripts/gh-merge-chain.sh --poll-interval 30 --max-wait 1800 321 322 323
```

Phase 1: enable auto-merge on every PR (idempotent). Phase 2: poll. When a PR merges, call `update-branch` on all remaining successors. Loop until all merge.

## Tests

`tests/scripts/gh-merge-chain.bats` (7 tests, **7/7 PASS**):

| # | Test |
|---|---|
| 1 | Exits 2 with no PRs (usage) |
| 2 | Exits 2 on unknown flag |
| 3 | `--help` renders the leading comment block |
| 4 | `--dry-run` lists PR numbers without calling `gh pr merge` |
| 5 | Uses `set -euo pipefail` |
| 6 | shellcheck clean (regression guard for the quote-vars discipline) |
| 7 | Anchors to the F3 learning file (regression guard for the rationale link) |

## Validation

- ✅ `shellcheck -S warning scripts/gh-merge-chain.sh`: clean
- ✅ `bats tests/scripts/gh-merge-chain.bats`: 7/7 PASS
- ✅ `scripts/pre-push-gate.sh --fast`: passed
- ✅ Self-test: `scripts/gh-merge-chain.sh --help` and `--dry-run 321 322 323` both work

Learning anchor: [`2026-05-18-auto-merge-needs-update-branch-when-main-moves.md`](.agents/learnings/2026-05-18-auto-merge-needs-update-branch-when-main-moves.md)

🤖 cycle 203 /evolve