### PR TITLE
docs(ci): align policy docs after eval advisory removal (soc-fbtx #docs-match-validate-yml)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,15 +125,16 @@ Blocking policy list (must match the validate summary failset): every job in the
 
 #### Advisory Job Triage SLAs (post-merge advisory policy, soc-z7qq)
 
-Advisory jobs run on every PR but their failure does NOT block merge. They surface a `(advisory)` suffix on the GitHub check name. Each advisory job has a triage SLA — when the job has been red for longer than its SLA, follow the escalation rule.
+Advisory and warn-only jobs run on every PR but their failure does NOT block merge. Most surface a `(advisory)` suffix on the GitHub check name; `executable-spec-link-integrity` surfaces as `(warn-only, F1.6)`. Each listed job has a triage SLA or explicit info-only handling — when the job has been red for longer than its SLA, follow the escalation rule.
 
-| Advisory job | Triage SLA | Escalation rule |
+| Job | Triage SLA | Escalation rule |
 |---|---|---|
 | **doctor-check** | 30d | Open a `bd` issue tracking the stale CLI reference; prioritize when the next `cli/cmd/ao/**` PR lands. |
 | **factory-claim-ledger-strict** | 14d | soc-lmww1: validates `docs/contracts/factory-claim-ledger.json` against source-set anchors. Open a `bd` issue tagged `ci-advisory` when red for >14d; promotion to blocking is a Wave 1E concern. |
 | **practice-citations** | 14d | Non-blocking strict walk of Primitives (skills/hooks/evals/CLI/schemas and scripts with declarations) for `practices: [slug,...]` derivation from PRACTICE-REGISTRY.md. Backfill in slices; promote to required after one clean cycle. Open a `bd` issue tagged `ci-advisory` when red for >14d with no backfill progress. |
 | **check-test-staleness** | none (info-only) | Read the report; no merge or release impact. Item 33 — drift signal, not a gate. |
 | **swarm-evidence** | none (info-only) | Read the report; no merge or release impact. Item 34 — informational artifact validation. |
+| **executable-spec-link-integrity** | none (warn-only) | Read the directive/scenario lint and trace output; no merge or release impact until the F1.6 promotion criterion is met. |
 
 The `retrieval-bench` job (nightly, see `.github/workflows/nightly.yml`) is currently warn-only with a deferred promotion gate. Promotion criterion: `nightly_p_at_5 ≥ baseline_p_at_5` for **14 consecutive nightlies**, where `baseline_p_at_5 = 0.30` is pinned in `docs/CI-CD.md` §"Retrieval-bench ratchet" until a durable non-`.agents` baseline artifact is introduced. The 14-consecutive-nightly observation window is intentionally observational — not yet wired into a counter — so flips to blocking remain a manual decision after the window is documented green.
 
@@ -214,9 +215,6 @@ find skills -type l  # must be empty — zero symlinks allowed
 
  # 15. AgentOps contract canaries (official deterministic test gate)
  scripts/test-agentops-contract-canaries.sh
-
- # 16. AgentOps eval advisory corpus
- scripts/eval-agentops.sh --fast
 
 # Full gate (runs everything above and more):
 scripts/ci-local-release.sh

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -49,16 +49,17 @@ The validate workflow runs many focused jobs across 4 tiers of parallelism. Most
 
 ```text
                     ┌───────────────────────────────────────────────┐
-                    │         27 independent parallel jobs          │
+                    │   independent validate jobs, path-filtered    │
                     │                                               │
                     │  doc-release-gate    smoke-test               │
                     │  hook-preflight      validate-hooks-doc-parity│
                     │  validate-ci-policy-parity                    │
-                    │  codex-runtime-sections                       │
+                    │  validate-codex-* runtime/parity checks       │
+                    │  validate-goals/registry/flywheel gates       │
                     │  embedded-sync       cli-docs-parity          │
                     │  agentops-contract-canaries                  │
                     │  eval-workbench-verify                       │
-                    │  agentops-eval-advisory                      │
+                    │  factory/practice advisory observations       │
                     │  shellcheck          markdownlint             │
                     │  security-scan       security-toolchain-gate  │
                     │  skill-integrity     skill-schema             │
@@ -90,9 +91,9 @@ The validate workflow runs many focused jobs across 4 tiers of parallelism. Most
 
 ### The `summary` Aggregator Pattern
 
-The final `summary` job lists every other job in its `needs` array and runs with `if: always()`. It checks each job's result and fails if any **blocking** job did not succeed. This single aggregator is the branch protection target -- repository settings only need to require `summary` to pass, not every individual job.
+The final `summary` job lists every other job in its `needs` array and runs with `if: always()`. It fails when any `needs.*.result` is `failure`. Advisory and warn-only jobs avoid blocking through `continue-on-error: true` at the job or step level, so their findings remain visible without producing a failing `needs` result. This single aggregator is the branch protection target -- repository settings only need to require `summary` to pass, not every individual job.
 
-Notably, `summary` excludes `agentops-eval-advisory`, `security-toolchain-gate`, `doctor-check`, `check-test-staleness`, and `swarm-evidence` from its failure condition (these are soft gates), while still listing them in `needs` so they appear in the summary output. `agentops-contract-canaries` is the blocking deterministic test gate for the stable public canary subset.
+Current non-blocking validate jobs are `doctor-check`, `factory-claim-ledger-strict`, `practice-citations`, `check-test-staleness`, `swarm-evidence`, and `executable-spec-link-integrity`. `security-toolchain-gate` is blocking. The old `agentops-eval-advisory` job is no longer part of `validate.yml`; `agentops-contract-canaries` remains the blocking deterministic test gate for the stable public canary subset.
 
 For normal `main` pushes and PRs, the `changes` job path-filters expensive lanes.
 For `refs/tags/v*` pushes, `changes` forces every category output to `true` and
@@ -104,15 +105,16 @@ for the exact tagged SHA; skipped is not treated as passed for releases.
 
 ### Soft Gates (continue-on-error: true)
 
-These jobs run but their failure does **not** block merges. Each carries an `(advisory)` suffix in its GitHub check name. Triage SLAs and escalation rules are codified in root `AGENTS.md` §Advisory Job Triage SLAs — keep that table and this one in sync (`scripts/validate-ci-policy-parity.sh`).
+These jobs run but their failure does **not** block merges. Advisory jobs carry an `(advisory)` suffix in the GitHub check name; `executable-spec-link-integrity` is named `(warn-only, F1.6)`. Triage SLAs and escalation rules are codified in root `AGENTS.md` §Advisory Job Triage SLAs — keep that table and this one in sync (`scripts/validate-ci-policy-parity.sh`).
 
 | Job | Triage SLA | Reason |
 |-----|------------|--------|
-| `agentops-eval-advisory` | 7d (release-blocking when stale) | The broad eval/canary corpus still runs on every PR, but brittle exact-string checks and baseline ratchets stay advisory until promoted |
-| `security-toolchain-gate` | 14d | External scanner tools may be unavailable; pattern scan (`security-scan`) is the blocking check. Install steps use 3-attempt exponential-backoff retry to absorb transient trivy/hadolint network timeouts (item 40, soc-z7qq) |
 | `doctor-check` | 30d | Reports stale CLI references; CI environment lacks some expected tools |
+| `factory-claim-ledger-strict` | 14d | Advisory claim-ledger drift observation for Wave 1E promotion evidence |
+| `practice-citations` | 14d | Advisory strict walk for missing or invalid `practices: [slug,...]` citations |
 | `check-test-staleness` | none (info-only) | Advisory -- flags tests that may need updating (item 33) |
 | `swarm-evidence` | none (info-only) | Advisory -- validates swarm evidence artifact shape; missing/malformed swarm artifacts are informational, not blocking (item 34) |
+| `executable-spec-link-integrity` | none (warn-only) | Warn-only directive/scenario link lint and orphan/gap trace until the F1.6 promotion criterion is met |
 
 ### Retrieval-bench ratchet (nightly)
 


### PR DESCRIPTION
## Summary
- remove stale current-job references to the removed `agentops-eval-advisory` validate job
- align CI/CD prose with the current non-blocking validate jobs and blocking `security-toolchain-gate`
- remove the obsolete local eval advisory checklist item from AGENTS.md

## Validation
- `bash scripts/validate-ci-policy-parity.sh`
- `bash scripts/validate-hooks-doc-parity.sh`
- `bash tests/docs/validate-doc-release.sh`
- `markdownlint AGENTS.md docs/CI-CD.md`
- `git diff --check`
- `scripts/pre-push-gate.sh --fast` (passed; warn-only executable-spec link integrity still reports existing unsupported `ao goals --lint/--orphans` flags)

Closes-scenario: soc-fbtx#docs-match-validate-yml
Bounded-context: BC2-Validation
Evidence: docs/CI-CD.md