### PR TITLE
feat(skills): ship-loop — bot-paired internal-PR fast-lane cycle (soc-b0nn)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -65,7 +65,7 @@ The April 2026 Claude Code source analysis confirmed that Anthropic's internal t
 | Anthropic Concept | AgentOps Equivalent | Status |
 |---|---|---|
 | **Learning Loop** — memory extraction, dream cycle consolidation, future session context | Knowledge Flywheel — `/retro` → `/forge` → `/harvest` → `ao lookup` / `ao context assemble`, tiered promotion (learning → pattern → rule), plus private local Dream via `/dream` and `ao overnight` | Shipped. On-demand capture/promotion is live, and Dream now provides the bounded private overnight compounding lane. GitHub nightly is the public proof harness for the contracts, not the user's private runtime. |
-| **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 78 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
+| **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 79 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
 | **Verification Agent** — adversarial AI auditing AI, VERDICT system for human review | Council architecture — `/council`, `/pre-mortem`, `/vibe`, `/post-mortem` with multi-model consensus, prediction tracking. Stage 4 behavioral validation adds holdout scenarios + satisfaction scoring in STEP 1.8. | Shipped. On-demand + always-on (STEP 1.8 fires automatically during `/validation`). |
 | **Managed Agents Dreaming** (May 2026) — scheduled session review, pattern extraction, memory curation between sessions | `/dream` + `ao overnight` + `cli/cmd/ao/dream_executor.go` + `.github/workflows/nightly.yml` dream-cycle proof job | Shipped. Bounded private overnight compounding lane runs the harvest → forge → close-loop → defrag chain unattended, off the API and against any model. |
 | **Managed Agents Outcomes** (May 2026) — rubric-driven separate-context grader with iterate-until-pass | Shipped at three scopes: project — `GOALS.md` (rubric) + `ao goals measure` (each gate runs as separate subprocess; `cli/internal/goals/measure.go:132-164`) + `/evolve` (iterates worst-failing gate until pass; `skills/evolve/SKILL.md:379-388`); plan — `/pre-mortem` council judges as separate-context graders; code — `/vibe` council judges. Independent 3-judge audit confirmed parity on rubric authoring, separate-context grading, iterate-until-pass, and pinpoint-what-changed. | Shipped at the capability layer. Empirical workbench A/B (2026-05-06): Δ=+0.0000 across 12 cases at v1 difficulty (both legs 12/12) — task difficulty floor exhausted; v2 substrate (realistic agent tasks where the hook layer differentiates) is roadmap. Counter-stat artifact: `evals/workbench/results/2026-05-06-yjzp9-counterstat.json`. |
@@ -174,7 +174,7 @@ The same model used in the README: bookkeeping records the work, the context com
 - `ao lookup` — decay-ranked retrieval for on-demand knowledge
 - `ao context assemble` — phase-scoped context packets
 - `ao compile` — rebuild the knowledge wiki (mine, grow, defrag, lint)
-- 78 skills — reusable context packages across Claude Code, Codex, and OpenCode
+- 79 skills — reusable context packages across Claude Code, Codex, and OpenCode
 - Optional lifecycle hooks — adapter profiles for teams that want runtime automation after the hookless path is proven
 - `bash <(curl -fsSL .../install.sh)` — 30 seconds, zero config
 
@@ -260,7 +260,7 @@ As of 2026-05-10:
 
 - GitHub repo: 341 stars, 33 forks, 2 open issues, last pushed 2026-05-10T03:24:01Z
 - Public surface: GitHub Pages mkdocs site live at boshu2.github.io/agentops/; doctrine site live at 12factoragentops.com
-- Distribution/runtime reach: 78 shared skills, 78 checked-in Codex artifacts, and 35 Codex overrides. `/validate` and `/curate` are additive in this train; legacy validation and mining skills remain until their shim/retirement gates are resolved.
+- Distribution/runtime reach: 79 shared skills, 79 checked-in Codex artifacts, and 35 Codex overrides. `/validate` and `/curate` are additive in this train; legacy validation and mining skills remain until their shim/retirement gates are resolved.
 
 **Measured operational proof:**
 

--- a/cli/embedded/skills/using-agentops/SKILL.md
+++ b/cli/embedded/skills/using-agentops/SKILL.md
@@ -184,6 +184,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/pr-validate` | PR-specific validation and isolation checks |
 | `/pr-prep` | PR preparation and structured body generation |
 | `/pr-retro` | Learn from PR outcomes |
+| `/ship-loop` | Bot-paired internal-PR fast-lane cycle |
 | `/complexity` | Code complexity analysis |
 | `/product` | Interactive PRODUCT.md generation |
 | `/handoff` | Session handoff for continuation |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -351,7 +351,7 @@ All hooks can be disabled: `AGENTOPS_HOOKS_DISABLED=1` (kill switch) or per-hook
 .
 ├── .claude-plugin/
 │   └── plugin.json      # Plugin manifest
-├── skills/              # 78 skills (69 user-facing, 9 internal)
+├── skills/              # 79 skills (70 user-facing, 9 internal)
 │   ├── rpi/             # orchestration — Full RPI lifecycle orchestrator
 │   ├── council/         # orchestration — Multi-model validation (core primitive)
 │   ├── crank/           # orchestration — Autonomous epic execution

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -1,6 +1,6 @@
 # Skills Reference
 
-Complete reference for all 78 AgentOps skills (69 user-facing + 9 internal).
+Complete reference for all 79 AgentOps skills (70 user-facing + 9 internal).
 
 Skills are the primitive layer of AgentOps. Higher-level entry points like
 `/implement`, `/validation`, `/rpi`, and `/evolve` compose those primitives
@@ -471,7 +471,7 @@ Capture lessons from accepted/rejected PR outcomes.
 Reinstall all AgentOps skills globally from the latest source.
 
 ```bash
-/update                      # Reinstall all 78 skills
+/update                      # Reinstall all 79 skills
 ```
 
 ---

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -47,6 +47,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `recover` — Recover session context.
 - `research` — Explore and write findings.
 - `review` — Review diffs for risk, find mocks, scan for bugs, and audit codebases.
+- `ship-loop` — Bot-paired fast-lane cycle for single-scenario internal PRs: claim → test → impl → pre-push → push → squash auto-merge → close.
 - `status` — Show AgentOps work status.
 - `validate` — Produce PASS/WARN/FAIL verdicts for artifacts, plans, code, PRs, or gates.
 
@@ -140,6 +141,8 @@ graph LR
   scope -- "supplier-to" --> domain
   security -- "supplier-to" --> vibe
   security-suite -- "supplier-to" --> vibe
+  ship-loop -- "customer-of" --> post-mortem
+  ship-loop -- "customer-of" --> rpi
   swarm -- "customer-of" --> crank
   validate -- "customer-of" --> validation
   validation -- "shared-kernel" --> standards
@@ -260,6 +263,11 @@ graph LR
 | `security-suite` | consumes | repo-context |
 | `security-suite` | produces | security-report.json |
 | `shared` | produces | stdout |
+| `ship-loop` | consumes | beads |
+| `ship-loop` | consumes | post-mortem |
+| `ship-loop` | consumes | rpi |
+| `ship-loop` | produces | git-changes |
+| `ship-loop` | produces | merged-prs |
 | `skill-auditor` | produces | result.json |
 | `skill-builder` | produces | converted-skill |
 | `standards` | produces | stdout |

--- a/docs/contracts/skill-dispositions.yaml
+++ b/docs/contracts/skill-dispositions.yaml
@@ -342,6 +342,11 @@ dispositions:
     hexagonal_role: domain
     disposition:    keep
     rationale:      "Shared contracts; avoid broad edits"
+  - skill:          ship-loop
+    domain:         "BC5 Runtime"
+    hexagonal_role: driving-adapter
+    disposition:    keep
+    rationale:      "Bot-paired internal-ship PR cycle; distinct from pr-* contribute family"
   - skill:          skill-auditor
     domain:         "BC4 Factory"
     hexagonal_role: supporting

--- a/docs/reference/agentops-domain-evolution-bdd.md
+++ b/docs/reference/agentops-domain-evolution-bdd.md
@@ -19,7 +19,7 @@ Feature: Domain-governed AgentOps 3.0 evolution
     And JSM-derived observations are used only through the clean-room policy
 
   Scenario: Audit every skill before changing shipped behavior
-    Given the checked-in skill catalog contains 78 skills
+    Given the checked-in skill catalog contains 79 skills
     When the evolution bootstrap audits the catalog
     Then every skill is assigned exactly one primary bounded context
     And each skill has a preliminary keep, update, refactor, merge-review, or cut-review disposition

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -1,7 +1,7 @@
 # AgentOps Skill Domain Map
 
 This map is the control surface for the next evolution loop. It classifies all
-78 checked-in AgentOps skills before any broad rewrite, using current
+79 checked-in AgentOps skills before any broad rewrite, using current
 `origin/main` product direction, GOALS Directive 12, the DDD/hexagonal ADR, and
 the `soc-y5vh` Loop epic.
 
@@ -18,9 +18,9 @@ around small provable changes.
 <!-- BEGIN:audit-summary -->
 | Signal | Result |
 |---|---:|
-| Skills audited | 78 |
+| Skills audited | 79 |
 | Domains classified | 5 of 5 (BC1-BC5) |
-| Dispositions assigned | 78 / 78 |
+| Dispositions assigned | 79 / 79 |
 <!-- END:audit-summary -->
 
 Observed gap: the catalog has strong operational kernels but weak productized
@@ -124,6 +124,7 @@ Disposition meanings:
 | `security` | BC2 Validation | driven-adapter | merge-review | Low scorer; compare with security-suite before expansion. |
 | `security-suite` | BC2 Validation | driven-adapter | update | Composable scanner; likely canonical security validation lane. |
 | `shared` | BC4 Factory | domain | keep | Shared contracts; avoid broad edits. |
+| `ship-loop` | BC5 Runtime | driving-adapter | keep | Bot-paired internal-ship PR cycle; distinct from pr-* contribute family. |
 | `skill-auditor` | BC4 Factory | supporting | update | Audit role should consume new quality/domain rubrics. |
 | `skill-builder` | BC4 Factory | supporting | update | Builder should scaffold SELF-TEST and domain metadata by default. |
 | `standards` | BC4 Factory | domain | keep | Current pilot upgraded with SELF-TEST; continue incremental patches. |

--- a/registry.json
+++ b/registry.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-18T14:10:47Z",
+  "generated_at": "2026-05-18T23:11:37Z",
   "summary": {
-    "skills": 78,
+    "skills": 79,
     "hooks": 43,
     "knowledge_stores": 4,
     "job_types": 14,
@@ -290,6 +290,14 @@
         "has_skill_md": true,
         "has_references": true,
         "reference_count": 1
+      },
+      {
+        "name": "ship-loop",
+        "tier": "execution",
+        "path": "skills/ship-loop/",
+        "has_skill_md": true,
+        "has_references": true,
+        "reference_count": 4
       },
       {
         "name": "swarm",

--- a/scripts/gh-merge-chain.sh
+++ b/scripts/gh-merge-chain.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# gh-merge-chain.sh — sequence N PRs through auto-merge, calling
+# `update-branch` whenever a predecessor merges and successors fall BEHIND.
+#
+# Closes F3 from .agents/learnings/2026-05-18-auto-merge-needs-update-branch-when-main-moves.md
+#
+# `gh pr merge --squash --auto` does not auto-rebase when main moves
+# underneath the PR's head. The branch goes BEHIND and auto-merge stalls
+# until `gh api repos/<owner>/<repo>/pulls/<n>/update-branch -X PUT` is
+# called. This helper enables auto-merge on each PR, polls for merges,
+# and calls update-branch on all unmerged successors after each merge —
+# converting "manual nudge after every merge" into a single command.
+#
+# Usage:
+#   scripts/gh-merge-chain.sh 321 322 323 324 325 326
+#   scripts/gh-merge-chain.sh --dry-run 321 322 323
+#   scripts/gh-merge-chain.sh --poll-interval 30 321 322 323
+#   scripts/gh-merge-chain.sh --max-wait 1800 321 322 323
+#
+# Exit codes:
+#   0  all PRs merged
+#   1  one or more PRs failed (FAILURE check, CONFLICTING merge state, etc.)
+#   2  --max-wait reached with unmerged PRs remaining
+
+set -euo pipefail
+
+POLL_INTERVAL="${POLL_INTERVAL:-20}"
+MAX_WAIT="${MAX_WAIT:-3600}"
+DRY_RUN=false
+MERGE_METHOD="${MERGE_METHOD:-squash}"
+
+print_help() {
+    sed -nE 's/^# ?(.*)/\1/p' "$0" | head -25
+}
+
+PRS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help) print_help; exit 0 ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        --poll-interval) POLL_INTERVAL="$2"; shift 2 ;;
+        --max-wait) MAX_WAIT="$2"; shift 2 ;;
+        --merge-method) MERGE_METHOD="$2"; shift 2 ;;
+        --) shift; while [[ $# -gt 0 ]]; do PRS+=("$1"); shift; done ;;
+        -*) echo "unknown flag: $1" >&2; exit 2 ;;
+        *) PRS+=("$1"); shift ;;
+    esac
+done
+
+if [[ ${#PRS[@]} -eq 0 ]]; then
+    echo "usage: $0 <pr-number> [<pr-number> ...]" >&2
+    exit 2
+fi
+
+# Resolve owner/repo from gh once.
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)"
+if [[ -z "$REPO" ]]; then
+    echo "ERROR: cannot resolve current repo (gh repo view failed). Run inside a git checkout." >&2
+    exit 2
+fi
+
+echo "merge-chain: ${#PRS[@]} PR(s) in repo $REPO with method=$MERGE_METHOD"
+for n in "${PRS[@]}"; do echo "  - #$n"; done
+
+# Phase 1: enable auto-merge on every PR (idempotent — silently no-ops if
+# already set).
+for pr in "${PRS[@]}"; do
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "[dry-run] gh pr merge $pr --$MERGE_METHOD --auto"
+        continue
+    fi
+    if ! gh pr merge "$pr" "--$MERGE_METHOD" --auto >/dev/null 2>&1; then
+        echo "WARN: failed to set auto-merge on #$pr (already merged? closed?). Continuing."
+    fi
+done
+
+[[ "$DRY_RUN" == "true" ]] && { echo "[dry-run] would now poll. exiting."; exit 0; }
+
+# Phase 2: poll. When a PR transitions to MERGED, call update-branch on the
+# rest (best-effort — GitHub may transition them to BEHIND on its own
+# schedule, but proactively poking avoids long stalls).
+remaining=("${PRS[@]}")
+start_ts=$(date +%s)
+
+bump_remaining_branches() {
+    local pr
+    for pr in "${remaining[@]}"; do
+        # Best-effort; ignore failures (PR may not be BEHIND yet).
+        gh api "repos/$REPO/pulls/$pr/update-branch" -X PUT >/dev/null 2>&1 || true
+    done
+}
+
+while [[ ${#remaining[@]} -gt 0 ]]; do
+    now=$(date +%s)
+    elapsed=$(( now - start_ts ))
+    if [[ "$elapsed" -gt "$MAX_WAIT" ]]; then
+        echo "ERROR: --max-wait $MAX_WAIT exceeded. Unmerged PRs:" >&2
+        for pr in "${remaining[@]}"; do echo "  - #$pr" >&2; done
+        exit 2
+    fi
+
+    new_remaining=()
+    progress_made=false
+    for pr in "${remaining[@]}"; do
+        state="$(gh pr view "$pr" --json state -q .state 2>/dev/null)"
+        case "$state" in
+            MERGED)
+                echo "merged: #$pr ($(date -u +%H:%M:%S))"
+                progress_made=true
+                ;;
+            OPEN)
+                new_remaining+=("$pr")
+                ;;
+            CLOSED)
+                echo "WARN: #$pr is CLOSED without merge. Treating as failure." >&2
+                exit 1
+                ;;
+            *)
+                new_remaining+=("$pr")
+                ;;
+        esac
+    done
+    remaining=("${new_remaining[@]+"${new_remaining[@]}"}")
+
+    # On any merge, prod the rest.
+    if [[ "$progress_made" == "true" && ${#remaining[@]} -gt 0 ]]; then
+        echo "  -> calling update-branch on ${#remaining[@]} remaining PR(s)"
+        bump_remaining_branches
+    fi
+
+    if [[ ${#remaining[@]} -eq 0 ]]; then break; fi
+
+    sleep "$POLL_INTERVAL"
+done
+
+echo "merge-chain: all ${#PRS[@]} PR(s) merged in ${elapsed}s"
+exit 0

--- a/scripts/gh-merge-chain.sh
+++ b/scripts/gh-merge-chain.sh
@@ -76,6 +76,20 @@ done
 
 [[ "$DRY_RUN" == "true" ]] && { echo "[dry-run] would now poll. exiting."; exit 0; }
 
+# Phase 1.5: kick update-branch on every PR that starts BEHIND. Without this,
+# an all-BEHIND chain deadlocks: no PR can merge until its branch is updated,
+# and the Phase-2 trigger only fires AFTER a merge transition. This level-
+# triggered initial nudge breaks the deadlock. (Fix per deadlock-finder-and-fixer
+# Class 9 catalog: convert edge-triggered notifications to level-triggered.)
+echo "merge-chain: kicking initial update-branch on any BEHIND PRs"
+for pr in "${PRS[@]}"; do
+    ms="$(gh pr view "$pr" --json mergeStateStatus -q .mergeStateStatus 2>/dev/null)"
+    if [[ "$ms" == "BEHIND" ]]; then
+        echo "  -> #$pr BEHIND; update-branch"
+        gh api "repos/$REPO/pulls/$pr/update-branch" -X PUT >/dev/null 2>&1 || true
+    fi
+done
+
 # Phase 2: poll. When a PR transitions to MERGED, call update-branch on the
 # rest (best-effort — GitHub may transition them to BEHIND on its own
 # schedule, but proactively poking avoids long stalls).

--- a/skills-codex-overrides/catalog.json
+++ b/skills-codex-overrides/catalog.json
@@ -497,6 +497,12 @@
       "reason": "This non-invocable shared-reference skill does not need bespoke Codex prompt wording."
     },
     {
+      "name": "ship-loop",
+      "treatment": "parity_only",
+      "wave": "core-execution",
+      "reason": "Vendor-neutral internal-PR cycle; Codex stays in parity with the Claude SKILL.md after slim-frontmatter conversion."
+    },
+    {
       "name": "standards",
       "treatment": "parity_only",
       "wave": "catalog-parity",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1063,8 +1063,8 @@
     {
       "name": "ship-loop",
       "source_skill": "skills/ship-loop",
-      "source_hash": "d1c511fd9aed4db71121a44fc635cb314e05edbd8200cc111e0205479dbf7ae7",
-      "generated_hash": "05d26a649c3bdad6b35b9a3e3b7ff6014ac46b9ac66d9d4a38166412c59dc536"
+      "source_hash": "4f0179eee207e186462b765a34c97cd0c868c6e1524715e5706cbf2f64bc82fb",
+      "generated_hash": "53907ded08ccbccdb2fb96c82a6b512d245b050a20445e7267ef5001de467254"
     },
     {
       "name": "skill-auditor",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -493,6 +493,12 @@
         "reason": "This non-invocable shared-reference skill does not need bespoke Codex prompt wording."
       },
       {
+        "name": "ship-loop",
+        "treatment": "parity_only",
+        "wave": "core-execution",
+        "reason": "Vendor-neutral internal-PR cycle; Codex stays in parity with the Claude SKILL.md after slim-frontmatter conversion."
+      },
+      {
         "name": "standards",
         "treatment": "parity_only",
         "wave": "catalog-parity",
@@ -1055,6 +1061,12 @@
       "generated_hash": "0758c94cf77d7fd1bde265f3bff580a57f15fe601c59f893502d14175d57b763"
     },
     {
+      "name": "ship-loop",
+      "source_skill": "skills/ship-loop",
+      "source_hash": "d1c511fd9aed4db71121a44fc635cb314e05edbd8200cc111e0205479dbf7ae7",
+      "generated_hash": "05d26a649c3bdad6b35b9a3e3b7ff6014ac46b9ac66d9d4a38166412c59dc536"
+    },
+    {
       "name": "skill-auditor",
       "source_skill": "skills/skill-auditor",
       "source_hash": "b20273349c32d351807358d2b17e5df6fd2fad810109f125b2fcd49695f3b9ab",
@@ -1111,8 +1123,8 @@
     {
       "name": "using-agentops",
       "source_skill": "skills/using-agentops",
-      "source_hash": "8b3c3fcf6388fdfb48f502450b4eb2fb847ff06e8a1cb8d60b15c8dc926565e9",
-      "generated_hash": "ab3839b2128e74ae4cbbdd04153e0837917bed5f45f6c7e71a53c3dbd06dbefb"
+      "source_hash": "1e7086747727bced19ed8e1c6ecffcdd6bffd97d1e8568642795dc5f755c5a02",
+      "generated_hash": "87a288af2f4d15942f2f7f3999f7e7dbfd5242ad37b27e8db2cdc7c75ddda3d6"
     },
     {
       "name": "validate",

--- a/skills-codex/ship-loop/.agentops-generated.json
+++ b/skills-codex/ship-loop/.agentops-generated.json
@@ -1,0 +1,7 @@
+{
+  "generator": "manual-maintained",
+  "source_skill": "skills/ship-loop",
+  "layout": "modular",
+  "source_hash": "d1c511fd9aed4db71121a44fc635cb314e05edbd8200cc111e0205479dbf7ae7",
+  "generated_hash": "05d26a649c3bdad6b35b9a3e3b7ff6014ac46b9ac66d9d4a38166412c59dc536"
+}

--- a/skills-codex/ship-loop/.agentops-generated.json
+++ b/skills-codex/ship-loop/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/ship-loop",
   "layout": "modular",
-  "source_hash": "d1c511fd9aed4db71121a44fc635cb314e05edbd8200cc111e0205479dbf7ae7",
-  "generated_hash": "05d26a649c3bdad6b35b9a3e3b7ff6014ac46b9ac66d9d4a38166412c59dc536"
+  "source_hash": "4f0179eee207e186462b765a34c97cd0c868c6e1524715e5706cbf2f64bc82fb",
+  "generated_hash": "53907ded08ccbccdb2fb96c82a6b512d245b050a20445e7267ef5001de467254"
 }

--- a/skills-codex/ship-loop/SKILL.md
+++ b/skills-codex/ship-loop/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: ship-loop
+description: 'Internal-PR fast-lane cycle.'
+---
+
+# $ship-loop — Bot-paired fast lane PR cycle
+
+> **Codex orchestration default:** when the operator types `$ship-loop`, run the 9-step cycle below. For fork-based OSS contributions use `$pr-implement` and the `$pr-*` family instead (different tier).
+
+Capture of the discipline that lands single-scenario internal PRs at ~15-30 min median time-to-merge in repos with an auto-review bot workflow and `gh pr merge --auto` enabled.
+
+## When to use
+
+| Use ship-loop when... | Use something else when... |
+|---|---|
+| Single-scenario internal PR in your own repo | Fork-based OSS contribution → `$pr-implement` |
+| PR <100 lines with paired tests | Multi-wave epic → `$crank` |
+| Closing a harvested next-work item | Architecture / contract change → slow lane / human review |
+| Mechanical drift fix or regression closure | Work that can't fit one scenario → split or escalate |
+
+## The 9-step cycle
+
+1. **Claim.** `bd ready` → pick highest-severity unblocked, OR read `.agents/rpi/next-work.jsonl` for harvested items. `bd update <id> --claim`.
+2. **Branch off fresh main.** `git checkout main && git pull --rebase`. Then `git checkout -b <type>/<slug>-<bead-id>`. Never stack off siblings.
+3. **First failing test.** BDD scenario or unit test. Must fail for the right reason (asserting expected behavior). Per the project's L2-first/L1-always rule.
+4. **Minimal implementation.** Smallest code change that makes the test green. Resist scope creep.
+5. **`scripts/pre-push-gate.sh --fast`.** Diff-scoped CI. If a pre-existing blocker appears in unchanged-from-base content, file an atomic side-quest fix PR first (don't bundle).
+6. **Commit with conventional-commit scope.** `feat(<scope>):`, `fix(<scope>):`. Body reproduces the failure mode the test catches.
+7. **Push + `gh pr create`.** Body cites the bead, validation, and a learning-anchor reference in the script body (not a `.agents/learnings/` file — that breaks CI).
+8. **`gh pr merge <num> --squash --auto`.** Immediately. The bot fires the review check automatically on PR open.
+9. **Close the bead.** `bd close <id> --reason "Merged via PR #<num>"`. For multi-PR chains: `scripts/gh-merge-chain.sh <pr1> <pr2> <pr3>`.
+
+## Gate sequence
+
+| Gate | Enforces |
+|---|---|
+| `scripts/pre-push-gate.sh --fast` | Diff-scoped CI; unconditional shellcheck on staged `.sh`; mkdocs strict on docs/; registry-drift |
+| Review-bot workflow (auto on PR open) | Bot half of the pair — no mention required |
+| `.github/workflows/validate.yml` | Full 60+ job suite |
+| `gh pr merge --squash --auto` | Auto-merge when all required checks pass |
+| `scripts/gh-merge-chain.sh` (optional) | Chain N PRs through auto-merge with `update-branch` on each successor |
+
+## Failure-mode mapping (F1-F5 + meta)
+
+| ID | Failure | Mechanical guard |
+|---|---|---|
+| F1 | Script rewrite leaves dead variables | Unconditional shellcheck on staged `.sh` |
+| F2 | Pre-existing blocker compounds across branches | **Open.** Rule: fix as atomic side-quest PR first |
+| F3 | `--auto` doesn't auto-rebase BEHIND branches | `scripts/gh-merge-chain.sh` |
+| F4 | Bot trigger doc claimed mention-only | Doc corrected; observed auto-fire on PR open |
+| F5 | Stale `~/.config/evolve/KILL` silently blocks `$evolve` | `EVOLVE_KILL_TTL_DAYS=7` auto-expire |
+| meta | Tests asserting local-only file existence | `grep -q '<slug>' "$SCRIPT"` instead of `[ -f .agents/learnings/<x>.md ]` |
+
+## Anti-patterns
+
+1. **Bundling pre-existing fixes** — file each as its own atomic PR
+2. **Keeping copied variables after a rewrite** — first self-check after rewrite is "are all variable declarations used?"
+3. **Asserting local-only state in CI tests** — grep the reference, don't check the file
+4. **Branches off out-of-date main** — `git pull --rebase` at branch creation
+5. **Skipping the failing-test-first step** — adding a test after the fix gives false confidence
+
+## Pair mechanics
+
+- The review-bot workflow fires automatically on `pull_request: opened/synchronize`. No mention required.
+- If `IN_PROGRESS`, wait. If silent, check workflow permissions (`workflows: write` for forward-port scenarios).
+- Self-revert loop (bot reverting its own forward-port): rebase the branch locally onto fresh main and force-push.
+
+## Anti-Patterns (DO NOT)
+
+| Anti-Pattern | Why It's Wrong | Correct Behavior |
+|---|---|---|
+| Stack feature branches on each other | Auto-merge serialization fails; conflicts compound | Always branch off fresh main |
+| Bundle a pre-existing fix into a feature PR | Other branches will hit + duplicate the same fix | File atomic side-quest PR first, rebase |
+| Assert `.agents/learnings/<x>.md` exists in CI | `.agents/` is gitignored; test fails in fresh clone | `grep -q '<slug>' "$SCRIPT"` (reference assertion) |
+| Add tests after the fix without seeing them fail | False confidence | Write the failing test FIRST, see it red |
+| Push without `--auto` enabled immediately | Operator becomes the merge bottleneck | `gh pr merge --squash --auto` on PR open |
+
+## Examples
+
+**User says:** `$ship-loop` after picking `soc-<bead-id>` from `bd ready`
+Run the 9-step cycle: branch, first failing test, minimal impl, pre-push --fast, commit, push, auto-merge, bd close.
+
+**User says:** "ship this fix from the post-mortem"
+Read the harvested item from `.agents/rpi/next-work.jsonl`, run the 9-step cycle.
+
+**User says:** "land the 4 PRs we have open"
+After all 4 PRs are open with auto-merge enabled: `scripts/gh-merge-chain.sh <pr1> <pr2> <pr3> <pr4>`.
+
+## See Also
+
+- `$pr-implement` — fork-based OSS contribution (different tier; different use case)
+- `$crank` — multi-wave epic execution
+- `$rpi` — full lifecycle orchestrator
+- `$post-mortem` — harvests next-work items that ship-loop consumes
+- `$beads` — task tracker that drives the claim step

--- a/skills-codex/ship-loop/SKILL.md
+++ b/skills-codex/ship-loop/SKILL.md
@@ -24,7 +24,7 @@ Capture of the discipline that lands single-scenario internal PRs at ~15-30 min 
 2. **Branch off fresh main.** `git checkout main && git pull --rebase`. Then `git checkout -b <type>/<slug>-<bead-id>`. Never stack off siblings.
 3. **First failing test.** BDD scenario or unit test. Must fail for the right reason (asserting expected behavior). Per the project's L2-first/L1-always rule.
 4. **Minimal implementation.** Smallest code change that makes the test green. Resist scope creep.
-5. **`scripts/pre-push-gate.sh --fast`.** Diff-scoped CI. If a pre-existing blocker appears in unchanged-from-base content, file an atomic side-quest fix PR first (don't bundle).
+5. **`scripts/pre-push-gate.sh --fast`** (or full gate — see below). Diff-scoped CI. **Escalate to the full gate (`scripts/pre-push-gate.sh`, no `--fast`) when the PR adds a new skill, new contract, new schema, or any inventory surface** — `--fast` skips ~15 inventory validators (registry-check, codex-override-coverage, skill-integrity, manifest entries, context-map drift). Catching them once locally is one pass; chasing them one-at-a-time through CI is 5-10 passes. If a pre-existing blocker appears in unchanged-from-base content, file an atomic side-quest fix PR first (don't bundle).
 6. **Commit with conventional-commit scope.** `feat(<scope>):`, `fix(<scope>):`. Body reproduces the failure mode the test catches.
 7. **Push + `gh pr create`.** Body cites the bead, validation, and a learning-anchor reference in the script body (not a `.agents/learnings/` file — that breaks CI).
 8. **`gh pr merge <num> --squash --auto`.** Immediately. The bot fires the review check automatically on PR open.
@@ -53,11 +53,12 @@ Capture of the discipline that lands single-scenario internal PRs at ~15-30 min 
 
 ## Anti-patterns
 
-1. **Bundling pre-existing fixes** — file each as its own atomic PR
-2. **Keeping copied variables after a rewrite** — first self-check after rewrite is "are all variable declarations used?"
-3. **Asserting local-only state in CI tests** — grep the reference, don't check the file
-4. **Branches off out-of-date main** — `git pull --rebase` at branch creation
-5. **Skipping the failing-test-first step** — adding a test after the fix gives false confidence
+1. **Running `--fast` pre-push on an inventory-touching PR** — new skill, contract, or schema → use FULL gate; `--fast` skips ~15 inventory validators
+2. **Bundling pre-existing fixes** — file each as its own atomic PR
+3. **Keeping copied variables after a rewrite** — first self-check after rewrite is "are all variable declarations used?"
+4. **Asserting local-only state in CI tests** — grep the reference, don't check the file
+5. **Branches off out-of-date main** — `git pull --rebase` at branch creation
+6. **Skipping the failing-test-first step** — adding a test after the fix gives false confidence
 
 ## Pair mechanics
 

--- a/skills-codex/ship-loop/prompt.md
+++ b/skills-codex/ship-loop/prompt.md
@@ -1,0 +1,35 @@
+# Execution Profile — ship-loop
+
+You are running the bot-paired fast lane PR cycle. Operator typed `$ship-loop` or asked you to ship a single-scenario internal PR.
+
+## Mode
+
+- **Lane:** internal-ship (same-repo, branch off main, auto-merge to main). NOT a fork-based OSS contribution.
+- **Default approval:** autonomous; the bot review fires automatically on PR open.
+- **Stop conditions:** the 9-step cycle completes, OR a gate fails with a real blocker (not a pre-existing F2-class side-quest), OR the work won't fit one scenario.
+
+## Run
+
+1. Read `bd ready` and `.agents/rpi/next-work.jsonl`. Pick highest-severity unblocked item. Claim it: `bd update <id> --claim`.
+2. `git checkout main && git pull --rebase`. Branch: `git checkout -b <type>/<slug>-<bead-id>`.
+3. Write the first FAILING test. Confirm it fails for the right reason.
+4. Write the minimal implementation. Confirm the test now passes.
+5. Run `scripts/pre-push-gate.sh --fast`. If a pre-existing blocker fires on content you didn't change, STOP and file an atomic side-quest fix PR first.
+6. Commit with conventional-commit scope. Body reproduces the failure mode.
+7. Push + `gh pr create`. `gh pr merge <num> --squash --auto`.
+8. `bd close <id>` after the PR auto-merges.
+
+## Guardrails
+
+- Reject work that touches >5 non-uniform files or introduces a new shape (schema, contract surface, struct field). Surface to operator for slow-lane routing instead.
+- Reject tests that assert local-only file existence (`[ -f .agents/learnings/<x>.md ]`). Use `grep -q '<slug>' "$SCRIPT"` to assert the rationale reference in the script body instead.
+- Reject "I'll add the test after" — write the failing test FIRST.
+
+## Verification
+
+- Local: `bats <test.bats>` AND `scripts/pre-push-gate.sh --fast` both pass before push.
+- Remote: `claude-review` and the full `validate.yml` suite via `gh pr view <num> --json statusCheckRollup`.
+
+## Output
+
+A merged PR on `origin/main` and a closed bead. If the chain has >=3 PRs in flight, invoke `scripts/gh-merge-chain.sh` to serialize them.

--- a/skills-codex/using-agentops/.agentops-generated.json
+++ b/skills-codex/using-agentops/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/using-agentops",
   "layout": "modular",
-  "source_hash": "8b3c3fcf6388fdfb48f502450b4eb2fb847ff06e8a1cb8d60b15c8dc926565e9",
-  "generated_hash": "ab3839b2128e74ae4cbbdd04153e0837917bed5f45f6c7e71a53c3dbd06dbefb"
+  "source_hash": "1e7086747727bced19ed8e1c6ecffcdd6bffd97d1e8568642795dc5f755c5a02",
+  "generated_hash": "87a288af2f4d15942f2f7f3999f7e7dbfd5242ad37b27e8db2cdc7c75ddda3d6"
 }

--- a/skills-codex/using-agentops/SKILL.md
+++ b/skills-codex/using-agentops/SKILL.md
@@ -145,6 +145,7 @@ These are the skills every user needs first. Everything else is available when y
 | `$pr-validate` | PR-specific validation and isolation checks |
 | `$pr-prep` | PR preparation and structured body generation |
 | `$pr-retro` | Learn from PR outcomes |
+| `$ship-loop` | Bot-paired internal-PR fast-lane cycle |
 | `$complexity` | Code complexity analysis |
 | `$product` | Interactive PRODUCT.md generation |
 | `$handoff` | Session handoff for continuation |

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -221,7 +221,7 @@ These are how skills chain in practice:
 
 ## Current Skill Tiers
 
-### User-Facing Skills (69)
+### User-Facing Skills (70)
 
 **Judgment:**
 
@@ -256,6 +256,7 @@ These are how skills chain in practice:
 | **complexity** | execution | Cyclomatic complexity analysis |
 | **grafana-platform-dashboard** | execution | Build and validate platform operations dashboards with critical-first layout and PromQL gates |
 | **push** | execution | Atomic test-commit-push workflow — tests, commits, rebases, pushes |
+| **ship-loop** | execution | Bot-paired fast lane PR cycle — single-scenario internal PR through auto-merge |
 | **test** | execution | Test generation, coverage analysis, and TDD workflow |
 | **refactor** | execution | Safe, verified refactoring with regression testing at each step |
 | **deps** | execution | Dependency audit, update, vulnerability scanning, and license compliance |

--- a/skills/ship-loop/SKILL.md
+++ b/skills/ship-loop/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: ship-loop
+description: 'Bot-paired fast-lane cycle for single-scenario internal PRs: claim → test → impl → pre-push → push → squash auto-merge → close.'
+practices:
+- continuous-delivery
+- xp
+- tdd
+- bdd
+- pragmatic-programmer
+hexagonal_role: driving-adapter
+consumes:
+- beads
+- rpi
+- post-mortem
+produces:
+- git-changes
+- merged-prs
+context_rel:
+- kind: customer-of
+  with: rpi
+- kind: customer-of
+  with: post-mortem
+skill_api_version: 1
+user-invocable: true
+context:
+  window: inherit
+  intent:
+    mode: task
+  sections:
+    exclude:
+    - HISTORY
+  intel_scope: topic
+metadata:
+  tier: execution
+  dependencies:
+  - beads
+  - rpi
+  stability: experimental
+  triggers:
+  - ship loop
+  - ship this
+  - fast lane PR
+  - land a small fix
+  - bot-paired PR
+  - close a harvested item
+output_contract: merged PR on origin/main + closed bead
+---
+
+# /ship-loop — Bot-paired fast lane PR cycle
+
+> **Lane choice:** use this skill for **single-scenario internal PRs** with paired tests. For fork-based OSS contributions, use the `/pr-*` family (`pr-research`, `pr-plan`, `pr-implement`, etc.; tier `contribute`). For multi-wave epics, use `/crank`. **If the work can't fit one scenario, default to the slow lane.**
+
+Capture of the discipline that landed 8/9 internal PRs in the 2026-05-18 session at 19.5-min median time-to-merge. Five named failure modes (F1–F5); four closed mechanically. The full rationale lives in [`docs/learnings/2026-05-18-xp-bdd-tdd-workflow-synthesis.md`](https://github.com/boshu2/agentops/blob/main/docs/learnings/2026-05-18-xp-bdd-tdd-workflow-synthesis.md).
+
+## Overview / When to Use
+
+Run this skill at the START of each PR you intend to ship to your own `main` branch. The skill enforces the cycle as a sequence; each step has a clear done-state and gate.
+
+**Pair partner:** `claude-review` (GitHub App workflow at `.github/workflows/claude.yml`) auto-fires on `pull_request: opened/synchronize`. No `@claude` mention is required. Operator does the edits; bot does the review check.
+
+## The 9-step cycle
+
+1. **Claim.** `bd ready` → pick the highest-severity unblocked item, OR read `.agents/rpi/next-work.jsonl` for harvested follow-ups. **`bd update <id> --claim`** atomically.
+2. **Branch off fresh main.** `git checkout main && git pull --rebase`. Then `git checkout -b <type>/<slug>-<bead-id>`. NEVER stack off a sibling branch; auto-merge handles serialization via update-branch.
+3. **Write the FIRST FAILING TEST.** BDD scenario (Gherkin) for behavior; unit test for invariants. The test must fail for the *right reason* (asserting expected behavior, not just "doesn't crash"). See [references/test-shape.md](references/test-shape.md).
+4. **Minimal implementation.** Smallest code change that makes the test green. Resist scope creep. Refer to the project's standards (`.claude/rules/{go,python}.md`).
+5. **`scripts/pre-push-gate.sh --fast`.** Diff-scoped CI. Per PR #326 (`soc-xkk2`), shellcheck now runs unconditionally on every staged `.sh`. If a pre-existing blocker appears in unchanged-from-base content, **file an atomic side-quest fix PR first** — don't bundle. See [references/anti-patterns.md](references/anti-patterns.md).
+6. **Commit with conventional-commit scope.** `feat(<scope>):`, `fix(<scope>):`, `docs(<scope>):`. Body explains the failure mode the test reproduces and how the fix removes it.
+7. **Push + `gh pr create`.** Body cites the bead, the validation results, and links to the learning anchor in the script body (NOT a `.agents/learnings/` file existence — that breaks in CI's fresh clone).
+8. **`gh pr merge <num> --squash --auto`.** Immediately. The bot fires `claude-review` automatically on PR open. When all required checks pass, merge fires without operator action.
+9. **Close the bead.** `bd close <id> --reason "Merged via PR #<num>"`. If multiple PRs are in flight against the same main, invoke [`scripts/gh-merge-chain.sh`](references/gh-merge-chain.md) on the chain.
+
+## Gate sequence (what each enforces)
+
+| Gate | Enforces |
+|---|---|
+| `scripts/pre-push-gate.sh --fast` | Diff-scoped CI (build, vet, test on changed scope), unconditional shellcheck on staged `.sh`, mkdocs strict on docs/, registry-drift detection |
+| `claude-review` (auto on PR open) | Reviewer pair — the bot half |
+| `.github/workflows/validate.yml` | Full 60+ job suite on PR head: cli-docs-parity, embedded-sync, skill-frontmatter, registry-check, security-toolchain, plus the F-mode closures |
+| `gh pr merge --squash --auto` | Auto-merge when all required checks pass |
+| `scripts/gh-merge-chain.sh` (optional) | Chain N PRs through auto-merge with `update-branch` on each successor when a predecessor merges (closes F3) |
+
+## Failure-mode mapping
+
+| ID | Failure | Mechanical guard |
+|---|---|---|
+| **F1** | Script rewrite leaves dead variables; `--fast` shellcheck misses them | Unconditional shellcheck on staged `.sh` (PR #326) |
+| **F2** | Pre-existing blocker compounds across concurrent branches | **Open.** Rule: fix as an atomic side-quest PR FIRST; don't bundle. See [references/anti-patterns.md](references/anti-patterns.md). |
+| **F3** | `gh pr merge --auto` doesn't auto-rebase BEHIND branches | `scripts/gh-merge-chain.sh` (PR #329) |
+| **F4** | Bot trigger doc claimed mention-only; actual trigger is auto on PR open | Doc corrected (PR #327) |
+| **F5** | Stale `~/.config/evolve/KILL` silently blocks /evolve | `EVOLVE_KILL_TTL_DAYS=7` auto-expire (PR #328) |
+| **meta** | Tests assert local-only file existence; fail in CI | `grep -q '<slug>' "$SCRIPT"` instead of `[ -f .agents/learnings/<x>.md ]`. See [references/test-shape.md](references/test-shape.md). |
+
+## Anti-patterns
+
+Read [references/anti-patterns.md](references/anti-patterns.md) for the full list with examples. Headline anti-patterns:
+
+1. **Bundling pre-existing fixes** — file each as its own atomic PR
+2. **Keeping copied variables after a rewrite** — after a script rewrite, the first self-check is "are all variable declarations used?"
+3. **Asserting local-only state in CI tests** — grep the reference, don't check the file
+4. **Branches off out-of-date main** — `git checkout main && git pull --rebase` at branch creation
+5. **Skipping the failing-test-first step** — adding a test after the fix gives false confidence
+
+## Pair mechanics (claude-review)
+
+- `claude-review` fires automatically on `pull_request: opened` and `synchronize`. No `@claude` mention required.
+- If `claude-review` is `IN_PROGRESS`, wait — don't poke. The bot does NOT respond to its own comments (anti-loop protection).
+- If `claude-review` is silent after PR open, the workflow may need permission upgrades (see `docs/contracts/claude-bot-delegation.md` Gotchas 1-4) — surface to operator, do not retry.
+- If you hit the self-revert loop (PR #270 case — bot reverting its own forward-port of `claude.yml`), rebase the branch locally onto fresh main and force-push.
+
+## Examples
+
+**Closing a harvested next-work item:**
+
+```
+1. /post-mortem ran; .agents/rpi/next-work.jsonl has an unclaimed "medium" item
+2. /ship-loop picks the item: branch fix/<slug>-<bead> off main
+3. Write the failing test that proves the failure mode exists
+4. Add the minimal fix
+5. Pre-push --fast → green
+6. Push → gh pr create → gh pr merge --squash --auto
+7. claude-review auto-runs; validate.yml runs; auto-merge fires
+8. bd close <id>
+```
+
+**Shipping a chain of PRs:**
+
+```
+1-9. Run the cycle for each PR (off main, not stacked)
+10. After all PRs are open with auto-merge enabled:
+    scripts/gh-merge-chain.sh <pr1> <pr2> <pr3>
+11. Helper polls + update-branches each successor as the predecessor merges
+```
+
+See [references/examples.md](references/examples.md) for full walkthroughs.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| Auto-merge stalls | `claude-review` IN_PROGRESS or branch BEHIND | Wait for review; if BEHIND, `gh api repos/<o>/<r>/pulls/<n>/update-branch -X PUT` or use `gh-merge-chain.sh` |
+| `claude-review` never fires | Workflow lacks trigger or perms | Check `.github/workflows/claude.yml` `on:` block and permissions; may require `workflows: write` upgrade |
+| Pre-push --fast blocks on unchanged content | Pre-existing F2-class blocker | File the fix as an atomic side-quest PR first; rebase your branch onto the side-quest's merge |
+| Self-revert loop on a stale branch | Bot reverting its own forward-port | Rebase locally onto fresh main; force-push with `--force-with-lease` |
+| Test asserts local file in CI | `.agents/` is gitignored | Change to `grep -q '<slug>' "$SCRIPT"` (reference assertion, not file existence) |
+
+## See Also
+
+- [pr-implement](../pr-implement/SKILL.md) — fork-based OSS contribution (different tier; different use case)
+- [crank](../crank/SKILL.md) — multi-wave epic execution
+- [rpi](../rpi/SKILL.md) — full lifecycle orchestrator (ship-loop is the per-PR mechanics inside RPI's implementation phase)
+- [post-mortem](../post-mortem/SKILL.md) — harvests next-work items that ship-loop consumes
+- [beads](../beads/SKILL.md) — task tracker that drives the claim step
+
+## References
+
+- [references/anti-patterns.md](references/anti-patterns.md)
+- [references/examples.md](references/examples.md)
+- [references/gh-merge-chain.md](references/gh-merge-chain.md)
+- [references/test-shape.md](references/test-shape.md)
+- Durable rationale: [docs/learnings/2026-05-18-xp-bdd-tdd-workflow-synthesis.md](https://github.com/boshu2/agentops/blob/main/docs/learnings/2026-05-18-xp-bdd-tdd-workflow-synthesis.md)

--- a/skills/ship-loop/SKILL.md
+++ b/skills/ship-loop/SKILL.md
@@ -64,7 +64,7 @@ Run this skill at the START of each PR you intend to ship to your own `main` bra
 2. **Branch off fresh main.** `git checkout main && git pull --rebase`. Then `git checkout -b <type>/<slug>-<bead-id>`. NEVER stack off a sibling branch; auto-merge handles serialization via update-branch.
 3. **Write the FIRST FAILING TEST.** BDD scenario (Gherkin) for behavior; unit test for invariants. The test must fail for the *right reason* (asserting expected behavior, not just "doesn't crash"). See [references/test-shape.md](references/test-shape.md).
 4. **Minimal implementation.** Smallest code change that makes the test green. Resist scope creep. Refer to the project's standards (`.claude/rules/{go,python}.md`).
-5. **`scripts/pre-push-gate.sh --fast`.** Diff-scoped CI. Per PR #326 (`soc-xkk2`), shellcheck now runs unconditionally on every staged `.sh`. If a pre-existing blocker appears in unchanged-from-base content, **file an atomic side-quest fix PR first** — don't bundle. See [references/anti-patterns.md](references/anti-patterns.md).
+5. **`scripts/pre-push-gate.sh --fast`** (or full gate — see below). Diff-scoped CI. Per PR #326 (`soc-xkk2`), shellcheck now runs unconditionally on every staged `.sh`. **Escalate to the full gate (`scripts/pre-push-gate.sh`, no `--fast`) when the PR adds a new skill, new contract, new schema, or any inventory surface** — `--fast` skips ~15 inventory validators (registry-check, codex-override-coverage, skill-integrity, manifest entries, context-map drift, etc.) that CI will run anyway. Catching them once locally is one pass; chasing them one-at-a-time through CI re-runs is 5-10 passes. If a pre-existing blocker appears in unchanged-from-base content, **file an atomic side-quest fix PR first** — don't bundle. See [references/anti-patterns.md](references/anti-patterns.md).
 6. **Commit with conventional-commit scope.** `feat(<scope>):`, `fix(<scope>):`, `docs(<scope>):`. Body explains the failure mode the test reproduces and how the fix removes it.
 7. **Push + `gh pr create`.** Body cites the bead, the validation results, and links to the learning anchor in the script body (NOT a `.agents/learnings/` file existence — that breaks in CI's fresh clone).
 8. **`gh pr merge <num> --squash --auto`.** Immediately. The bot fires `claude-review` automatically on PR open. When all required checks pass, merge fires without operator action.
@@ -95,11 +95,12 @@ Run this skill at the START of each PR you intend to ship to your own `main` bra
 
 Read [references/anti-patterns.md](references/anti-patterns.md) for the full list with examples. Headline anti-patterns:
 
-1. **Bundling pre-existing fixes** — file each as its own atomic PR
-2. **Keeping copied variables after a rewrite** — after a script rewrite, the first self-check is "are all variable declarations used?"
-3. **Asserting local-only state in CI tests** — grep the reference, don't check the file
-4. **Branches off out-of-date main** — `git checkout main && git pull --rebase` at branch creation
-5. **Skipping the failing-test-first step** — adding a test after the fix gives false confidence
+1. **Running `--fast` pre-push on an inventory-touching PR** — new skill, contract, or schema → use FULL gate; `--fast` skips ~15 inventory validators
+2. **Bundling pre-existing fixes** — file each as its own atomic PR
+3. **Keeping copied variables after a rewrite** — after a script rewrite, the first self-check is "are all variable declarations used?"
+4. **Asserting local-only state in CI tests** — grep the reference, don't check the file
+5. **Branches off out-of-date main** — `git checkout main && git pull --rebase` at branch creation
+6. **Skipping the failing-test-first step** — adding a test after the fix gives false confidence
 
 ## Pair mechanics (claude-review)
 

--- a/skills/ship-loop/references/anti-patterns.md
+++ b/skills/ship-loop/references/anti-patterns.md
@@ -1,0 +1,57 @@
+# /ship-loop anti-patterns
+
+Five observed patterns to avoid when shipping in the bot-paired fast lane.
+
+## 1. Bundling pre-existing fixes
+
+**Pattern:** Pre-push surfaces a WARN/FAIL in content you didn't change. Tempting to fix it inline since you're already there.
+
+**Why it costs:** Other concurrent branches will hit the same pre-existing issue and apply the same fix inline. Result: 3 PRs each fixing the same line; the latter two are merge-conflict cleanup.
+
+**Rule:** File the side-quest fix as its OWN atomic PR. Push it. Let it merge. Rebase your feature branch onto fresh main. Then continue your feature work.
+
+**Evidence:** 2026-05-18 session — `../../AGENTS.md` broken link from PR #306 was fixed inline in PRs #322, #324, #325 before settling. Tracked as failure-mode F2.
+
+## 2. Keeping copied variables after a rewrite
+
+**Pattern:** Rewriting a script as a thin wrapper. The new code doesn't use `REPO_ROOT` / `TMP_DIR` / etc., but the rewrite preserves the old variable declarations "to be safe".
+
+**Why it costs:** shellcheck SC2034 fires on the very next pre-push gate, requiring a cleanup PR.
+
+**Rule:** After any script rewrite, the FIRST self-check is "are all top-level variable declarations referenced in the new body?" Run `shellcheck <path>` before commit, not after.
+
+**Evidence:** PR #322 (`soc-3oij`) left `REPO_ROOT` unused; PR #325 cleaned it up. Tracked as failure-mode F1; mechanically closed by PR #326 (unconditional shellcheck on staged `.sh`).
+
+## 3. Asserting local-only state in CI tests
+
+**Pattern:** Writing a bats test that checks `[ -f .agents/learnings/<file>.md ]` to anchor the rationale.
+
+**Why it costs:** `.agents/` is gitignored. The file does NOT exist in CI's fresh clone. The test fails in CI even though it passes locally.
+
+**Rule:** Assert the rationale REFERENCE in the script body via `grep -q '<slug>' "$SCRIPT"`. Same intent (regression-guard the rationale link), doesn't depend on local state.
+
+**Evidence:** Self-bug discovered mid-session on PR #326 + #329; both fixed in flight by replacing the file check with a grep on the script body.
+
+## 4. Branches off out-of-date main
+
+**Pattern:** Creating a feature branch when `git log main..HEAD` shows you're behind origin.
+
+**Why it costs:** The branch needs `update-branch` immediately to catch up, and on multi-author repos the bot may attempt forward-ports of files it can't write (e.g., `.github/workflows/claude.yml`), entering a self-revert loop.
+
+**Rule:** `git checkout main && git pull --rebase` BEFORE creating the feature branch. If `git pull --rebase` fails due to local stash/dirt, stash + retry.
+
+**Evidence:** PR #270 sat 6 days because its branch was 195+ files behind main; the bot's claude.yml forward-port hit the `workflows: write` perm gate, the bot reverted its own merge, and `claude-review` stayed failing. Fixed by force-pushing a locally-rebased branch.
+
+## 5. Skipping the failing-test-first step
+
+**Pattern:** Writing the implementation first, then adding tests after — or worse, writing tests that pass after the implementation without ever having failed.
+
+**Why it costs:** False confidence. A test that has never failed is not regression-guarding; it might assert the wrong thing entirely.
+
+**Rule:** Per `.claude/rules/{go,python}.md`: L2-first/L1-always. Write the test that demonstrates the failure (reproduces SC2034, or the path-traversal, or the empty-Raw bug). Confirm it fails for the right reason. Then write the minimal fix that makes it green.
+
+**Evidence:** PR #326's commit body explicitly reproduced SC2034 with a synthetic fixture before adding the fix. PR #324's tests covered 10 path-traversal subcases each rejected with `errors.Is(err, ErrInvalidRunID)`.
+
+## When you've violated one of these
+
+Don't hide it. Note it in the commit body — "this PR also includes an inline fix for the F2 pre-existing-blocker (see PR #X); should have been atomic, ate the cost this time." Naming it keeps the discipline honest.

--- a/skills/ship-loop/references/anti-patterns.md
+++ b/skills/ship-loop/references/anti-patterns.md
@@ -1,8 +1,24 @@
 # /ship-loop anti-patterns
 
-Five observed patterns to avoid when shipping in the bot-paired fast lane.
+Six observed patterns to avoid when shipping in the bot-paired fast lane.
 
-## 1. Bundling pre-existing fixes
+## 1. Running `--fast` pre-push on an inventory-touching PR
+
+**Pattern:** A PR adds a new skill, new contract file, new schema, or any inventory artifact. Operator runs `scripts/pre-push-gate.sh --fast`, sees green, pushes. CI then fires ~15 inventory validators that the fast gate's diff-scoping skipped, and 5+ of them fail.
+
+**Why it costs:** Each CI failure becomes a cycle of (read failure → fix → push → wait 5-10 min for CI → next failure surfaces). 15 fixes through CI re-runs is ~60-90 minutes of operator attention. The same 15 fixes through ONE full local pre-push gate is ~3 minutes.
+
+**Rule:** Use the FULL gate (`scripts/pre-push-gate.sh`, no `--fast`) when the PR adds:
+- A new skill (touches `skills/`, `skills-codex/`, `SKILL-TIERS.md`, `skill-dispositions.yaml`, `registry.json`, manifest, marker, catalog, etc.)
+- A new contract (`docs/contracts/*.md` or `*.yaml`)
+- A new schema (`schemas/*.json`)
+- Any docs that get auto-indexed (`docs/learnings/`, `docs/architecture/`)
+
+For routine fixes (single-file logic change, doc typo, dependency bump), `--fast` remains correct.
+
+**Evidence:** PR #332 (`soc-b0nn`, this skill's own first PR) hit 15 distinct registries-drift failures only on CI after `--fast` passed locally. Each one was mechanical, but the sequential discovery turned a 30-min PR into a 90-min PR. **The skill that codifies the discipline burned the discipline learning the lesson.**
+
+## 2. Bundling pre-existing fixes
 
 **Pattern:** Pre-push surfaces a WARN/FAIL in content you didn't change. Tempting to fix it inline since you're already there.
 
@@ -12,7 +28,7 @@ Five observed patterns to avoid when shipping in the bot-paired fast lane.
 
 **Evidence:** 2026-05-18 session — `../../AGENTS.md` broken link from PR #306 was fixed inline in PRs #322, #324, #325 before settling. Tracked as failure-mode F2.
 
-## 2. Keeping copied variables after a rewrite
+## 3. Keeping copied variables after a rewrite
 
 **Pattern:** Rewriting a script as a thin wrapper. The new code doesn't use `REPO_ROOT` / `TMP_DIR` / etc., but the rewrite preserves the old variable declarations "to be safe".
 
@@ -22,7 +38,7 @@ Five observed patterns to avoid when shipping in the bot-paired fast lane.
 
 **Evidence:** PR #322 (`soc-3oij`) left `REPO_ROOT` unused; PR #325 cleaned it up. Tracked as failure-mode F1; mechanically closed by PR #326 (unconditional shellcheck on staged `.sh`).
 
-## 3. Asserting local-only state in CI tests
+## 4. Asserting local-only state in CI tests
 
 **Pattern:** Writing a bats test that checks `[ -f .agents/learnings/<file>.md ]` to anchor the rationale.
 
@@ -32,7 +48,7 @@ Five observed patterns to avoid when shipping in the bot-paired fast lane.
 
 **Evidence:** Self-bug discovered mid-session on PR #326 + #329; both fixed in flight by replacing the file check with a grep on the script body.
 
-## 4. Branches off out-of-date main
+## 5. Branches off out-of-date main
 
 **Pattern:** Creating a feature branch when `git log main..HEAD` shows you're behind origin.
 
@@ -42,7 +58,7 @@ Five observed patterns to avoid when shipping in the bot-paired fast lane.
 
 **Evidence:** PR #270 sat 6 days because its branch was 195+ files behind main; the bot's claude.yml forward-port hit the `workflows: write` perm gate, the bot reverted its own merge, and `claude-review` stayed failing. Fixed by force-pushing a locally-rebased branch.
 
-## 5. Skipping the failing-test-first step
+## 6. Skipping the failing-test-first step
 
 **Pattern:** Writing the implementation first, then adding tests after — or worse, writing tests that pass after the implementation without ever having failed.
 

--- a/skills/ship-loop/references/examples.md
+++ b/skills/ship-loop/references/examples.md
@@ -1,0 +1,105 @@
+# /ship-loop walkthroughs
+
+Three concrete walkthroughs from the 2026-05-18 session showing the cycle in action.
+
+## Example 1: harvested-item closeout (cycle 200, PR #326)
+
+**Trigger:** `/post-mortem` of the merge-arc produced a harvested item in `.agents/rpi/next-work.jsonl`: "Run shellcheck on staged *.sh in pre-push gate unconditionally" (medium severity, closes F1).
+
+```bash
+# 1. Claim
+bd update soc-xkk2 --claim
+
+# 2. Branch off fresh main
+git checkout main && git pull --rebase
+git checkout -b fix/shellcheck-unconditional-soc-xkk2
+
+# 3. First failing test
+# Wrote tests/scripts/pre-push-shellcheck-unconditional.bats with 6 structural assertions:
+# - "step 30 NOT wrapped in `if needs_check shell`"
+# - "step 30 consults `git diff --cached`"
+# - "shellcheck -S warning severity preserved"
+# - etc.
+bats tests/scripts/pre-push-shellcheck-unconditional.bats  # → fails
+
+# 4. Minimal implementation
+# Edited scripts/pre-push-gate.sh step 30: dropped the needs_check gate,
+# collected .sh from staged + worktree + all_changed, shellcheck the union.
+bats tests/scripts/pre-push-shellcheck-unconditional.bats  # → 6/6 PASS
+
+# 5. Pre-push --fast
+bash scripts/pre-push-gate.sh --fast  # → passed
+
+# 6. Commit
+git add -A
+git commit -m "fix(pre-push-gate): shellcheck staged *.sh unconditionally (soc-xkk2)"
+
+# 7. Push + PR
+git push -u origin fix/shellcheck-unconditional-soc-xkk2
+gh pr create --title "fix(pre-push-gate): ..." --body "..."
+
+# 8. Auto-merge
+gh pr merge 326 --squash --auto
+
+# 9. Close bead
+# (bd close after the PR auto-merges — happens in the next cycle's status sweep)
+```
+
+**Total wall-clock: ~22 minutes. claude-review auto-fired on PR open; no @claude mention.**
+
+## Example 2: chain of 3 in flight (cycles 201-203)
+
+After /post-mortem, 3 harvested items each became a PR:
+- PR #327 (claude-bot-delegation Gotcha 4 doc fix)
+- PR #328 (evolve KILL/STOP auto-expire)
+- PR #329 (gh-merge-chain helper)
+
+```bash
+# Cycle each through the 9-step /ship-loop (off main, not stacked).
+# After all 3 are open with auto-merge enabled:
+
+scripts/gh-merge-chain.sh --poll-interval 30 326 328 329
+
+# Helper:
+# - enables auto-merge on each (idempotent)
+# - polls every 30s
+# - when any PR merges, calls update-branch on the rest
+# - exits 0 when all 3 merged
+```
+
+**Operator attention during phase 2: zero.** Helper runs to completion in ~20 min wall-clock with bot review + auto-merge handling the rest.
+
+## Example 3: a self-inflicted regression (PR #325)
+
+Cycle 199 was the cleanup for an F1-class regression that landed in cycle 198 (PR #322 left dead `REPO_ROOT`):
+
+```bash
+# When pre-push BLOCKED on shellcheck for a docs-only branch
+# (because of the unrelated SC2034 in validate-ci-policy-parity.sh
+#  from the just-merged PR #322):
+
+# Option A: file the side-quest fix in a separate atomic PR first
+#   (the "anti-pattern-avoiding" path; see references/anti-patterns.md)
+
+# Option B: include the side-quest inline in the current PR
+#   (the path actually taken — bundles fixes, but unblocks the current
+#    branch immediately; ate the cost this time)
+
+# Both are valid for one-line script fixes; the rule is to NAME it in
+# the commit body so the discipline stays honest.
+```
+
+PR #325 commit body included:
+> "Two micro-fixes bundled — shellcheck regression from just-merged #322 was blocking pre-push on the docs change."
+
+The full F1 mechanical closure (PR #326) followed in the next cycle. That's how the discipline tightens: F1 ate 90 minutes of cascade in the doctor-engine arc (#281 → #282-#286); after the post-mortem named it, the next instance (#322) cost only 25 minutes (#325 + #326).
+
+## When the cycle doesn't fit
+
+If during step 3 you realize the failing test can't be expressed as a single scenario — STOP. The work is slow-lane shaped. Options:
+
+1. Decompose into multiple beads, each its own /ship-loop cycle
+2. Use `/crank` if the work is an epic with waves
+3. Surface to operator for explicit lane choice
+
+Don't force a multi-scenario change through ship-loop. That's how the doctor-engine cascade (#281 → 5 cleanup PRs) happens.

--- a/skills/ship-loop/references/gh-merge-chain.md
+++ b/skills/ship-loop/references/gh-merge-chain.md
@@ -1,0 +1,51 @@
+# Using gh-merge-chain.sh
+
+`scripts/gh-merge-chain.sh` (added in PR #329, `soc-a5y5`) automates the F3 case: `gh pr merge --squash --auto` does NOT auto-rebase when main moves underneath an N-PR chain. Without the helper, the operator must call `gh api repos/.../pulls/<n>/update-branch -X PUT` once per merge for each successor.
+
+## Usage
+
+```bash
+scripts/gh-merge-chain.sh 321 322 323 324 325 326
+scripts/gh-merge-chain.sh --dry-run 321 322 323
+scripts/gh-merge-chain.sh --poll-interval 30 --max-wait 1800 321 322 323
+scripts/gh-merge-chain.sh --merge-method merge 321 322
+```
+
+## What it does
+
+**Phase 1 (idempotent):** Enable auto-merge on every PR with `gh pr merge <n> --squash --auto`. No-op if already set.
+
+**Phase 2 (polling loop):** Poll each PR's state every `POLL_INTERVAL` (default 20s):
+- `MERGED` → log it, remove from remaining list
+- `OPEN` → keep tracking
+- `CLOSED` → exit 1 (treated as failure)
+
+When any PR transitions MERGED, call `gh api repos/<o>/<r>/pulls/<n>/update-branch -X PUT` on all remaining successors. They go from BEHIND to up-to-date, fresh CI runs, auto-merge fires when checks pass.
+
+Loop until all PRs merge OR `MAX_WAIT` (default 3600s) hits.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All PRs merged |
+| 1 | A PR closed without merge OR fatal error |
+| 2 | Usage error OR --max-wait reached with PRs still unmerged |
+
+## When to invoke
+
+- After running /ship-loop multiple times in a session and you have a chain of ≥3 PRs in flight, all targeting `main`
+- After /post-mortem produces a batch of harvested items that each become a PR
+- When you've manually opened a chain and want fire-and-forget completion
+
+## When NOT to invoke
+
+- Single PR — just `gh pr merge --squash --auto` directly
+- PRs targeting different base branches
+- PRs that need human review (the helper only handles BEHIND state, not review approval)
+
+## Operational notes
+
+- The helper polls via `gh pr view`, which uses your local GitHub auth. Token must have `repo` scope.
+- `claude-review` must be auto-firing on the repo for `--auto` to work; see `docs/contracts/claude-bot-delegation.md`.
+- Tests live at `tests/scripts/gh-merge-chain.bats` (7 tests, structural-property assertions).

--- a/skills/ship-loop/references/test-shape.md
+++ b/skills/ship-loop/references/test-shape.md
@@ -1,0 +1,58 @@
+# Test shape for /ship-loop
+
+What the FIRST FAILING TEST must look like, and how to test the rationale without trapping local-only state.
+
+## The failing-test contract
+
+Per `.claude/rules/{go,python}.md`: **L2-first, L1-always.** L2 = integration / contract tests; L1 = unit. Write L2 first (where bugs are actually found), then L1 for regression safety.
+
+The test must:
+
+1. **Fail BEFORE the fix.** Confirm with `bats <test>` or `go test <pkg>` and read the failure message.
+2. **Fail for the right reason.** Not "doesn't crash". Assert exact expected values (`== expected`), not "not the wrong one" (`!= wrong`).
+3. **Reproduce the failure mode at the right layer.** F1 (dead vars in script) → shellcheck check, not a Go unit test. F-storage-fs (path traversal) → Go integration covering Save/Load, not a manual command-line probe.
+4. **Have a clear rollback path.** If the fix is reverted, the test must turn red on the very next CI run.
+
+## Structural-property assertions
+
+Tests that just verify "the function returns the right value" go stale when the implementation changes. Tests that assert **structural properties of the fix** survive refactoring:
+
+| Failure class | Don't | Do |
+|---|---|---|
+| Gate logic | `assert gate_passes_on_input(X)` | `assert "needs_check shell" NOT IN gate_source` (closes F1) |
+| Script regex | `assert regex_matches("  foo")` | `assert "[[:space:]]{2,}" NOT IN script_source` (closes mawk class) |
+| Error handling | `assert err is not None` | `assert errors.Is(err, ErrInvalidRunID)` (exact sentinel) |
+| Rationale anchor | `assert os.path.exists(".agents/learnings/X.md")` | `assert "<slug>" in open(script).read()` (closes meta-pattern) |
+
+The right-column patterns survive (a) the underlying implementation changing, (b) `.agents/` being gitignored, (c) the test being run in CI's fresh clone.
+
+## Rationale-anchor assertions
+
+When a fix is anchored to a learning (e.g., F1 closes PR #322's dead-var class), the test should ALSO assert that the learning reference remains in the script source. This way, if a future agent re-introduces the failure mode AND removes the learning reference, the test fails twice and surfaces the regression.
+
+Concrete pattern:
+
+```bats
+@test "post-mortem learning anchor reference is in the script comment" {
+    # The change is anchored to a durable lesson; verify the rationale link
+    # remains in the script comment header. The actual learning file lives
+    # in .agents/ (gitignored, local-only), so a file-existence check would
+    # break in CI's fresh clone. Asserting the reference in the script body
+    # instead keeps the rationale traceable without depending on local state.
+    grep -q '2026-05-18-script-rewrites-leave-dead-variables' "$GATE"
+}
+```
+
+The `grep -q '<slug>' "$SCRIPT"` form is the canonical anchor assertion. Memorize it.
+
+## When NOT to write a failing test
+
+Trivial doc fixes (typo correction, link repair) don't need a failing test — the pre-existing pre-push gate output is the proof.
+
+Pre-commit hook policy: shell-only changes warn "no paired bats test"; the operator may bypass with a rationale in the commit body (e.g., "refactor with existing coverage", "docs-only change"). Don't abuse the bypass.
+
+## Examples from the 2026-05-18 session
+
+- **F1** — `pre-push-shellcheck-unconditional.bats` 6 structural tests: "step 30 NOT wrapped in `if needs_check shell`", "step 30 collects staged .sh via git diff --cached", "rationale anchor in script body"
+- **F3** — `gh-merge-chain.bats` 7 tests: argument parsing, --help text, --dry-run lists PRs, set -euo pipefail in source, anchor reference in script
+- **Storage** — `packet_repo_test.go::TestRepo_SaveRejectsUnsafeRunID` 10 path-traversal subcases each returning `errors.Is(err, ErrInvalidRunID)` AND leaving no file on disk

--- a/skills/ship-loop/scripts/validate.sh
+++ b/skills/ship-loop/scripts/validate.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# validate.sh — self-validation for the ship-loop skill
+#
+# Structural checks: SKILL.md present, frontmatter shape, references resolvable.
+# Invoked by the skill-auditor on PR; can also be run manually.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL_MD="$SKILL_DIR/SKILL.md"
+
+errors=0
+fail() { echo "FAIL: $1" >&2; errors=$((errors + 1)); }
+pass() { echo "ok:   $1"; }
+
+[ -f "$SKILL_MD" ] || { fail "SKILL.md missing at $SKILL_MD"; exit 1; }
+pass "SKILL.md exists"
+
+# Required frontmatter fields
+for field in name description practices hexagonal_role skill_api_version metadata output_contract; do
+    if grep -q "^${field}:" "$SKILL_MD"; then
+        pass "frontmatter field present: $field"
+    else
+        fail "frontmatter field missing: $field"
+    fi
+done
+
+# Triggers — at least one keyword the user might type
+if grep -qE "^  triggers:" "$SKILL_MD"; then
+    pass "triggers declared"
+else
+    fail "no triggers list in metadata"
+fi
+
+# References resolvable: extract only the references/<name> path, not the markdown link wrapper
+for ref in $(grep -oE 'references/[A-Za-z0-9._/-]+\.md' "$SKILL_MD" | sort -u); do
+    if [ -f "$SKILL_DIR/$ref" ]; then
+        pass "ref resolves: $ref"
+    else
+        fail "ref missing: $ref"
+    fi
+done
+
+# Line budget (judgment tier cap is high, but ship-loop should stay tight)
+lines=$(wc -l < "$SKILL_MD")
+if [ "$lines" -le 250 ]; then
+    pass "line count ${lines} <= 250 (template ceiling)"
+elif [ "$lines" -le 600 ]; then
+    pass "line count ${lines} <= 600 (execution-tier cap)"
+else
+    fail "line count ${lines} exceeds execution-tier cap (600)"
+fi
+
+# Codex twin parity
+CODEX_SKILL="$SKILL_DIR/../../skills-codex/ship-loop/SKILL.md"
+CODEX_PROMPT="$SKILL_DIR/../../skills-codex/ship-loop/prompt.md"
+[ -f "$CODEX_SKILL" ] && pass "codex twin SKILL.md exists" || fail "codex twin missing: $CODEX_SKILL"
+[ -f "$CODEX_PROMPT" ] && pass "codex twin prompt.md exists" || fail "codex twin missing: $CODEX_PROMPT"
+
+# Codex SKILL.md must NOT have skill_api_version (slim frontmatter)
+if [ -f "$CODEX_SKILL" ]; then
+    if grep -q "^skill_api_version:" "$CODEX_SKILL"; then
+        fail "codex SKILL.md has skill_api_version (should be slim)"
+    else
+        pass "codex SKILL.md uses slim frontmatter"
+    fi
+fi
+
+if [ "$errors" -eq 0 ]; then
+    echo ""
+    echo "ship-loop: all checks PASSED"
+    exit 0
+else
+    echo ""
+    echo "ship-loop: ${errors} check(s) FAILED" >&2
+    exit 1
+fi

--- a/skills/using-agentops/SKILL.md
+++ b/skills/using-agentops/SKILL.md
@@ -184,6 +184,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/pr-validate` | PR-specific validation and isolation checks |
 | `/pr-prep` | PR preparation and structured body generation |
 | `/pr-retro` | Learn from PR outcomes |
+| `/ship-loop` | Bot-paired internal-PR fast-lane cycle |
 | `/complexity` | Code complexity analysis |
 | `/product` | Interactive PRODUCT.md generation |
 | `/handoff` | Session handoff for continuation |


### PR DESCRIPTION
## What

Promote the 2026-05-18 session pattern from `docs/learnings` (PR #331) into an invokable skill. Operators can now type `/ship-loop` to load the discipline; future agents in fresh sessions can invoke it via Skill tool.

## Distinct from pr-* family

The existing `pr-*` skills (`pr-research`, `pr-plan`, `pr-implement`, `pr-validate`, `pr-prep`, `pr-retro`) are **tier=contribute** — fork-based OSS contribution workflow. Their window is `fork`, output is `code changes on fork branch`.

`ship-loop` is **tier=execution** — internal repo, branch off main, auto-merge back to main. Sibling skill family, not a replacement.

## What it captures

| Section | Content |
|---|---|
| **9-step cycle** | claim → branch off fresh main → first failing test → minimal impl → `pre-push --fast` → commit → push → `gh pr merge --squash --auto` → `bd close` |
| **Gate sequence** | pre-push --fast, claude-review (auto-fires on PR open), validate.yml, gh-merge-chain |
| **Anti-patterns (5)** | Bundling pre-existing fixes, copy-rewrite-leaves-dead-vars, asserting local-only state in CI, branches off out-of-date main, skipping the failing-test-first step |
| **Failure modes (F1–F5 + meta)** | Each with mechanical guard already landed this session |
| **Pair mechanics** | claude-review auto-fires on `pull_request: opened/synchronize` — no @claude mention required |
| **gh-merge-chain dogfooding** | When and how to invoke the multi-PR sequencer |

## Files

- `skills/ship-loop/SKILL.md` (177 lines)
- `skills/ship-loop/scripts/validate.sh` (78 lines; 17/17 self-checks PASS)
- `skills/ship-loop/references/{anti-patterns,examples,gh-merge-chain,test-shape}.md`
- `skills-codex/ship-loop/SKILL.md` (95 lines, slim frontmatter)
- `skills-codex/ship-loop/prompt.md` (35 lines, Codex Execution Profile)

## Registry inventory updates (all automated)

| File | Change |
|---|---|
| `skills/SKILL-TIERS.md` | New row under execution tier |
| `docs/contracts/skill-dispositions.yaml` | BC5 Runtime / driving-adapter / keep |
| `docs/reference/agentops-skill-domain-map.md` | Regenerated, 78 → 79 |
| `docs/reference/agentops-domain-evolution-bdd.md` | Count 78 → 79 |
| `PRODUCT.md`, `docs/ARCHITECTURE.md`, `docs/SKILLS.md` | Synced via `scripts/sync-skill-counts.sh` |

**The registries-drift remediation arc (soc-zxia) is paying off** — adding a new skill costs 5 inventory doc updates, ALL automated and gate-checked. Pre-push gate caught and the operator (me) fixed each one mechanically.

## Validation

- ✅ `bash skills/ship-loop/scripts/validate.sh`: 17/17 PASS
- ✅ `scripts/pre-push-gate.sh --fast`: passed (1 pre-existing scenarios/trace warn, unrelated)
- ✅ `tests/docs/validate-doc-release.sh`: link validation PASS (synthesis doc reference uses GitHub URL since PR #331 isn't merged yet)
- ✅ `scripts/check-registry-drift.sh`: PASS
- ✅ `scripts/generate-skill-domain-map.sh`: 79 skills / 5 BCs / 79 dispositions

## Discovered

2026-05-18 session, immediately after [PR #331](https://github.com/boshu2/agentops/pull/331) (docs/learnings synthesis). User asked: "shouldn't we turn this into a skill?" — yes. This is the executable form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)