### PR TITLE
feat(skills/swarm): shared-checkout-discipline reference (soc-akob #shared-checkout-discipline-cluster1)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-18T23:11:37Z",
+  "generated_at": "2026-05-19T01:32:59Z",
   "summary": {
     "skills": 79,
     "hooks": 43,
@@ -305,7 +305,7 @@
         "path": "skills/swarm/",
         "has_skill_md": true,
         "has_references": true,
-        "reference_count": 19
+        "reference_count": 20
       },
       {
         "name": "test",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1093,7 +1093,7 @@
     {
       "name": "swarm",
       "source_skill": "skills/swarm",
-      "source_hash": "28449f5f6d3148c25682e5ceff1b488b613c7a0226a459725bd05dbc00991d0f",
+      "source_hash": "1a88221c6b8856c19b29d24fa44811e518bfd1d51c6b0423fa6364520a3186e2",
       "generated_hash": "cecb9fed1aaff7fc85958163aa2cb34d6a4b448eafd16494aa3661aa7f01a95b"
     },
     {

--- a/skills-codex/swarm/.agentops-generated.json
+++ b/skills-codex/swarm/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/swarm",
   "layout": "modular",
-  "source_hash": "28449f5f6d3148c25682e5ceff1b488b613c7a0226a459725bd05dbc00991d0f",
+  "source_hash": "1a88221c6b8856c19b29d24fa44811e518bfd1d51c6b0423fa6364520a3186e2",
   "generated_hash": "cecb9fed1aaff7fc85958163aa2cb34d6a4b448eafd16494aa3661aa7f01a95b"
 }

--- a/skills/swarm/SKILL.md
+++ b/skills/swarm/SKILL.md
@@ -248,6 +248,8 @@ Read [references/ol-wave-integration.md](references/ol-wave-integration.md) when
 
 ## Worktree Isolation (Multi-Epic Dispatch)
 
+Read [references/shared-checkout-discipline.md](references/shared-checkout-discipline.md) **first** when the target checkout (`~/dev/<repo>`) is shared with peer agents — it documents when worktrees are mandatory (vs. optional) and the three failure modes (branch-deletion data loss, swarm attribution confounded, destructive-recovery temptation) that motivate the discipline.
+
 Read [references/worktree-isolation.md](references/worktree-isolation.md) when you need to dispatch workers across multiple epics or run waves with overlapping files — covers isolation semantics per backend, effort levels, post-spawn verification, manual worktree creation/routing/merge-back, the Merge Arbiter Protocol, cleanup, and the `--worktrees` / `--no-worktrees` parameters.
 
 ---
@@ -268,6 +270,7 @@ Read [references/troubleshooting.md](references/troubleshooting.md) for full dia
 
 ## Reference Documents
 
+- [references/shared-checkout-discipline.md](references/shared-checkout-discipline.md)
 - [references/conflict-recovery.md](references/conflict-recovery.md)
 - [references/cold-start-contexts.md](references/cold-start-contexts.md)
 - [references/backend-background-tasks.md](references/backend-background-tasks.md)

--- a/skills/swarm/references/shared-checkout-discipline.md
+++ b/skills/swarm/references/shared-checkout-discipline.md
@@ -1,0 +1,109 @@
+# Shared-Checkout Discipline
+
+When `~/dev/<repo>` is contended — peer Codex agent in the same directory,
+NTM swarm pane, background `agentopsd` job, scheduled cron, or operator
+parallel session — **never edit in the shared tree and never leave work
+uncommitted between turns.** Use a `git worktree`. Commit-or-stash
+incrementally with explicit paths. Verify a clean baseline before spawning
+a swarm.
+
+This is the prerequisite check that justifies [worktree-isolation.md](worktree-isolation.md).
+worktree-isolation tells you *how* to isolate; this doc tells you *when*
+you must — and what fails if you don't.
+
+## When This Fires
+
+| Signal | Action |
+|---|---|
+| `git status --short` returns foreign files you did not create | Switch to a worktree before any edit |
+| Handoff or memory mentions "another session was here" | Worktree, even if `git status` is clean now |
+| About to spawn a swarm (`/swarm`, `/crank`, NTM panes) | `git worktree add` first; point the session symlink at the worktree |
+| About to run a destructive git command (`reset --hard`, `clean -fd`, `checkout -- .`) on a dirty tree | Stop. The "dirt" may be a peer's work |
+| Multi-hour session about to end with uncommitted edits | Commit explicit paths now; do not leave work hostage to the next agent |
+
+## Failure Modes (Why The Rule Exists)
+
+**1. Branch-deletion data loss.** A full session's deliverables — README revision, a new skill, a Gherkin spec — left uncommitted on an ephemeral branch in the shared checkout. A concurrent session merged and deleted that branch, stashing the loose files to clean its own tree. The work survived only because the other session *stashed* rather than `git clean`-ed: luck, not discipline. Recovery required `git checkout stash@{N}^3 -- <paths>` across two stashes to reassemble.
+
+> "in a shared or agent-contended checkout, commit (or at least branch) work **incrementally as each piece completes**, never at session end. A session-long pile of uncommitted edits is hostage to every other agent's branch operations — checkout switches, merges, `reset`, `clean`, branch deletion."
+— `.agents/learnings/2026-05-17-quick-commit-early-in-contended-checkouts.md`
+
+**2. Swarm attribution confounded.** A 4-pane duel swarm spawned directly into the live shared checkout. A concurrent co-tenant agent was also working there. The co-tenant's untracked file bleed and ~6 off-scope commits got attributed — in the orchestrator's own retro — to swarm scope-drift. They were not. Root cause: every committer in the shared checkout shows as the same git author, so swarm-pane work and co-tenant work are indistinguishable after the fact.
+
+> "before spawning any swarm — `git worktree add` a dedicated directory and point the `ntm` session symlink at *that*, not at a live shared checkout. Also run `git status --untracked-files=all` at spawn; a non-clean tree means either stash the unrelated state or pick a different worktree."
+— `.agents/learnings/2026-05-17-quick-swarm-isolated-worktree-or-attribution-confounds.md`
+
+**3. Destructive recovery temptation.** Throughout the 2026-05-17 cascade session, 33+ foreign files persisted in the shared checkout. Every git operation had to either dodge them (via worktrees, used 8+ times: `/tmp/ao-rebase`, `/tmp/ao-int2`, `/tmp/ao-fix`, `/tmp/ao-full`, `/tmp/mo-sdlc`, `/tmp/ao-ci2`, `/tmp/ao-wiki-merge`, `/tmp/ao-fmt`) or risk destroying another agent's work via `git clean -fd` or `git checkout -- .`.
+
+> "Worktrees were the only safe path. Used 8+ times … Each was cheap to create; the collisions they avoided were not."
+— `.agents/learnings/2026-05-17-shared-checkout-discipline.md`
+
+## How To Apply
+
+### Pre-edit check (every turn)
+
+```bash
+git status --short
+# If non-empty and you did not create those files → worktree required.
+```
+
+### Real work — use a worktree
+
+```bash
+# Project convention: bd worktree create handles the dance for you.
+bd worktree create --branch <type>/<bead-id>-<slug>
+
+# Or manually, off fresh main:
+git fetch origin main
+git worktree add -b <type>/<bead-id>-<slug> /tmp/<repo>-<slug> origin/main
+cd /tmp/<repo>-<slug>
+# do work, commit, push from here
+```
+
+### Pre-swarm — verify clean baseline
+
+```bash
+# In the target worktree (NOT the shared checkout):
+git status --untracked-files=all
+# Empty → safe to spawn the swarm here.
+# Non-empty → either stash with a labeled message, or pick a different worktree.
+```
+
+### Committing in a shared tree (when worktree is unavailable)
+
+```bash
+# Stage explicit paths only. Foreign WIP must not ride along.
+git add path/a path/b path/c
+git commit -m "..."
+
+# NEVER:
+git add -A      # adds everything, including peer's WIP
+git add .       # same
+```
+
+### Commit cadence
+
+Commit as each piece completes, not at session end. A 3-hour session with
+zero commits is 3 hours of work hostage to the next destructive git command
+any peer agent runs.
+
+## What This Doc Does NOT Cover
+
+- **`mcp-agent-mail` file reservations.** That is an orthogonal application-
+  level lock layer (Agent Mail's `file_reservation_paths` tool). It does not
+  replace git-level discipline; it complements it. See the `agent-mail`
+  skill.
+- **The proposed `check-worktree-disposition.sh` CI gate.** Filed as a
+  follow-up; this doc documents the operator-level rule, not the gate.
+- **Worktree mechanics in detail.** See [worktree-isolation.md](worktree-isolation.md)
+  for the per-backend isolation semantics, sparse-checkout config, and
+  post-spawn verification.
+
+## See Also
+
+- [worktree-isolation.md](worktree-isolation.md) — backend-specific worktree
+  mechanics; this doc is the prerequisite "when to use" rule.
+- [pre-spawn-friction-gates.md](pre-spawn-friction-gates.md) — broader
+  pre-spawn gate inventory; clean-baseline is one such gate.
+- [conflict-recovery.md](conflict-recovery.md) — recovery once contention
+  has already produced a conflict.


### PR DESCRIPTION
## What

Adds `skills/swarm/references/shared-checkout-discipline.md` (109 lines) + 2-line wiring in `skills/swarm/SKILL.md`. Codifies the rule:

> When `~/dev/<repo>` is shared with peer agents (codex-ao, NTM swarm panes, agentopsd jobs), never edit in the shared tree and never leave work uncommitted between turns. Use git worktrees, commit-or-stash with explicit paths, verify a clean baseline before spawning a swarm.

## Why

3 authored learnings on 2026-05-17 all encountered the same failure mode (branch-deletion data loss, swarm attribution confounded, destructive-recovery temptation) — no skill captured the rule. The doc anchors verbatim quotes from each source learning so the provenance is durable; the .agents/ source files themselves are gitignored.

## Sibling pattern

Follows `references/worktree-isolation.md` shape (When → Failure Modes → How To Apply → See Also). Same tier=orchestration constraints. The two docs are paired: this one is the **when**; worktree-isolation is the **how**.

## Fitness-delta

| Metric | Before | After |
|---|---|---|
| swarm references | 19 | 20 |
| failure modes documented w/ recovery | 0 | 3 |
| anchored verbatim quotes in swarm corpus | 0 | 3 |

## Validation

- `scripts/pre-push-gate.sh --fast`: **passed** (43 skipped; pre-existing executable-spec link warnings unrelated to this change)
- `scripts/audit-codex-parity.sh --skill swarm`: **passed**
- `tests/skills/lint-skills.sh` line-limit for tier=orchestration is 1050; this PR is 297/1050 (PreToolUse hook's 248-line nudge is a soft warning, not a CI block)
- No symlinks added
- shellcheck: green

## Closes

Closes-scenario: soc-akob#shared-checkout-discipline-cluster1
Bounded-context: BC2-Skill-Knowledge-Operator-Library
Evidence: skills/swarm/references/shared-checkout-discipline.md

## Provenance

Derived from chat session 2026-05-18 Track-C session-mining pass over 25+ authored learnings (cluster #1 of 5). Other clusters captured as drafts in `.agents/skill-drafts/`:
- `.agents/skill-drafts/2026-05-18-multi-agent-file-contention.md` (cluster #1 — landed here)
- `.agents/skill-drafts/2026-05-18-long-loop-degradation.md` (cluster #2 — unhomed, awaits operator placement decision)