### PR TITLE
feat(skills/council): cross-vendor duel — when-to-use (soc-k68w #cross-vendor-triage)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-20T13:30:06Z",
+  "generated_at": "2026-05-20T13:42:03Z",
   "summary": {
     "skills": 79,
     "hooks": 44,
@@ -321,7 +321,7 @@
         "path": "skills/council/",
         "has_skill_md": true,
         "has_references": true,
-        "reference_count": 32
+        "reference_count": 33
       },
       {
         "name": "design",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -727,7 +727,7 @@
     {
       "name": "council",
       "source_skill": "skills/council",
-      "source_hash": "a1d6fb7e62eb7fa4e4b483fd4617e03215f42cbc94f26840112edf0bb05b47cd",
+      "source_hash": "b1ea8ee2e039dba422beee52f621e67542bf1084f808680ec5c5ad6e386a8914",
       "generated_hash": "6b5ce56f36cb10393e921e524539c3dd41d28a5bdce5eac645075050864222ef"
     },
     {

--- a/skills-codex/council/.agentops-generated.json
+++ b/skills-codex/council/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/council",
   "layout": "modular",
-  "source_hash": "a1d6fb7e62eb7fa4e4b483fd4617e03215f42cbc94f26840112edf0bb05b47cd",
+  "source_hash": "b1ea8ee2e039dba422beee52f621e67542bf1084f808680ec5c5ad6e386a8914",
   "generated_hash": "6b5ce56f36cb10393e921e524539c3dd41d28a5bdce5eac645075050864222ef"
 }

--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -204,6 +204,7 @@ See [references/multi-agent-architecture.md](references/multi-agent-architecture
 - [references/modes.md](references/modes.md)
 - [references/council-modes.feature](references/council-modes.feature)
 - [references/dueling-route.md](references/dueling-route.md)
+- [references/cross-vendor-duel-when-to-use.md](references/cross-vendor-duel-when-to-use.md) — Strategic call (when Opus+Codex is worth the cost) + score-symmetry diagnostic
 - [references/architecture-flow.md](references/architecture-flow.md)
 - [references/packet-format.md](references/packet-format.md)
 - [references/flags-reference.md](references/flags-reference.md)

--- a/skills/council/references/cross-vendor-duel-when-to-use.md
+++ b/skills/council/references/cross-vendor-duel-when-to-use.md
@@ -84,26 +84,26 @@ surfaced naturally under adversarial cross-scoring.
 
 ## Failure Modes To Watch
 
-- **Models too aligned.** If Opus and Codex agree on everything for
++ **Models too aligned.** If Opus and Codex agree on everything for
   your domain, the duel produces no friction (love-fest scoring). The
   fix is to pick personas that have real disagreements, not to bigger
   the model gap.
-- **Briefing without tension.** A briefing that frames the choice
++ **Briefing without tension.** A briefing that frames the choice
   neutrally ("which option is better?") lets both models hedge. Frame
   the contestable claim: "I'm going to do X; tell me why I'm wrong."
-- **Skipping the reveal.** This is the one rule with no exception. The
++ **Skipping the reveal.** This is the one rule with no exception. The
   reveal is where each model confronts how the other scored *its* work;
   concessions only happen here.
-- **Orchestrator editorializing.** Report scores faithfully. The
++ **Orchestrator editorializing.** Report scores faithfully. The
   orchestrator's opinion goes only in the meta-analysis section.
 
 ## See Also
 
-- [dueling-route.md](dueling-route.md) — the mechanics this doc layers
++ [dueling-route.md](dueling-route.md) — the mechanics this doc layers
   on top of
-- [adversarial-protocol.md](adversarial-protocol.md) — the
++ [adversarial-protocol.md](adversarial-protocol.md) — the
   cross-scoring protocol used in Phase 5
-- [multi-agent-architecture.md](multi-agent-architecture.md) — pane
++ [multi-agent-architecture.md](multi-agent-architecture.md) — pane
   orchestration shape
-- Empirical reference: `.agents/council/sdlc-shape-2026-05-17/DUEL.md`
++ Empirical reference: `.agents/council/sdlc-shape-2026-05-17/DUEL.md`
   (local, gitignored) — the 632/620 SDLC-shape result this doc anchors

--- a/skills/council/references/cross-vendor-duel-when-to-use.md
+++ b/skills/council/references/cross-vendor-duel-when-to-use.md
@@ -1,0 +1,109 @@
+# Cross-Vendor Duel — When To Use It
+
+[dueling-route.md](dueling-route.md) covers the **mechanics** of
+`/council --mode=debate`. This doc covers the **strategic call**: when
+the cross-vendor variant (Opus + Codex, not all-Claude) is worth the
+~30-minute model cost, plus the score-symmetry diagnostic that tells you
+the duel itself worked.
+
+## When To Use The Cross-Vendor Variant
+
+| Decision shape | All-Claude (persona-only)? | Cross-vendor (Opus + Codex)? |
+|---|---|---|
+| Naming, tone, copy | ✓ Sufficient | overkill |
+| Implementation pattern with established precedent | ✓ Sufficient | overkill |
+| Contested **design** decision, two capable models would plausibly disagree | weak | **✓ Worth it** |
+| AGENTS.md / CLAUDE.md / branch-protection edits | weak | **✓ Worth it** |
+| Architecture trade-off with no obvious right answer | weak | **✓ Worth it** |
+| Domain where one model is decisively more capable | one-sided | wasted spend |
+| Already aligned with operator's preference | confirmation theater | confirmation theater |
+
+The rule: single-model proposals embed the model's bias unexamined.
+Cross-vendor cross-scoring forces each model to defend specifics,
+surfaces real misses (model A invents something B catches as
+fictitious; B literalizes a failure mode A named in the briefing), and
+produces a verdict no single proposal could have.
+
+## The Score-Symmetry Diagnostic
+
+When you run a cross-vendor duel, the **whole-ballot scores** tell you
+whether the duel itself worked:
+
+| Score pattern | Interpretation |
+|---|---|
+| Both ballots within **12 points** of each other (e.g., 632/620) | **Healthy** — neither model dominated; mutual concessions happened |
+| Both ballots above **800** | **Love-fest** — re-score with explicit candor instruction; current scores embed politeness, not adversarial judgment |
+| Gap **> 200 points** | One model was decisively more capable for this domain, OR the briefing was biased toward one. Re-read the briefing's "tension to confront" section |
+| Symmetric **kills** (each model kills ≥2 of the other's recommendations) | **Healthy** — real adversarial engagement |
+| Zero mutual kills | Suspicion: tribal defensiveness or shared blind spot. Probe the reveal harder |
+
+## Evidence (anchored)
+
+> "The 2026-05-17 SDLC-shape council ran Opus 4.7 vs Codex gpt-5.5 in 3
+> rounds: independent proposals, adversarial cross-scoring 0-1000 per
+> recommendation, then reveal + concessions. Whole-ballots came in at
+> 632/1000 (Codex→Opus) and 620/1000 (Opus→Codex) — symmetric, neither
+> dominated."
+— `.agents/learnings/2026-05-17-cross-vendor-duel-converges.md`
+
+> "The central tension (one canonical doc vs three thin docs) converged
+> in Round 3: both moved to 'one short pocket doc + operating-loop
+> spine for agents; three axis owners generated or schema-gated as
+> sources.' Codex caught Opus's invented `bd lease`. Opus caught
+> Codex's 'three thin docs' as the literal failure mode the briefing
+> named. The synthesis is in DUEL.md."
+— `.agents/learnings/2026-05-17-cross-vendor-duel-converges.md`
+
+The concrete proof: Codex caught a fabrication (Opus's `bd lease` —
+not a real command). Opus caught a literalization mistake (Codex
+proposing exactly the failure mode the briefing named as a thing to
+avoid). Neither would have surfaced under a single-model run; both
+surfaced naturally under adversarial cross-scoring.
+
+## How To Apply
+
+1. **Triage the decision.** Is it on the "Worth it" row above? If not,
+   default to all-Claude personas (faster, cheaper, fine for most
+   things).
+2. **Write the briefing with explicit tensions.** The duel's fuel is the
+   "tension you must confront" section in BRIEFING.md. Without a
+   contestable claim, the duel converges politely and produces nothing.
+   See [dueling-route.md](dueling-route.md) Phase 3.
+3. **Spawn one Opus pane + one Codex pane.** Codex needs a real API key
+   (NTM rejects `gpt-*-codex` on ChatGPT-billed accounts — see
+   `dueling-route.md` NTM gotchas). If unavailable, fall back to
+   all-Claude.
+4. **Run all 3 rounds.** Independent verdicts → adversarial cross-score
+   → reveal + blind-spot probe. **Don't skip the reveal** — that's
+   where concessions happen.
+5. **Read the score-symmetry diagnostic above.** If healthy, the
+   synthesis is binding. If love-fest or one-sided, re-score with
+   explicit candor or re-write the briefing.
+6. **Synthesize the binding `DUEL.md`** from both ballots + mutual kills
+   + blind-spot answers. Persist to `.agents/council/<topic>-<date>/`.
+
+## Failure Modes To Watch
+
+- **Models too aligned.** If Opus and Codex agree on everything for
+  your domain, the duel produces no friction (love-fest scoring). The
+  fix is to pick personas that have real disagreements, not to bigger
+  the model gap.
+- **Briefing without tension.** A briefing that frames the choice
+  neutrally ("which option is better?") lets both models hedge. Frame
+  the contestable claim: "I'm going to do X; tell me why I'm wrong."
+- **Skipping the reveal.** This is the one rule with no exception. The
+  reveal is where each model confronts how the other scored *its* work;
+  concessions only happen here.
+- **Orchestrator editorializing.** Report scores faithfully. The
+  orchestrator's opinion goes only in the meta-analysis section.
+
+## See Also
+
+- [dueling-route.md](dueling-route.md) — the mechanics this doc layers
+  on top of
+- [adversarial-protocol.md](adversarial-protocol.md) — the
+  cross-scoring protocol used in Phase 5
+- [multi-agent-architecture.md](multi-agent-architecture.md) — pane
+  orchestration shape
+- Empirical reference: `.agents/council/sdlc-shape-2026-05-17/DUEL.md`
+  (local, gitignored) — the 632/620 SDLC-shape result this doc anchors


### PR DESCRIPTION
## What
New file: `skills/council/references/cross-vendor-duel-when-to-use.md` (109 lines) + 1-line References entry in `skills/council/SKILL.md`.

Layers **strategic guidance** on top of the existing `dueling-route.md` mechanics — when the cross-vendor (Opus + Codex) variant is worth the ~30-minute model cost, plus the score-symmetry diagnostic that tells you whether the duel itself worked.

## Why
`dueling-route.md` is a thorough operator handbook for the **how**. It doesn't tell you when to bother with the cross-vendor variant vs all-Claude personas. The 2026-05-17 SDLC-shape council produced the empirical proof (632/620 symmetric ballots, Codex caught Opus's invented `bd lease`, Opus caught Codex's literalized failure mode) — but that proof was sitting in a single `.agents/learnings/` file with no skill link.

## Sibling pattern
Follows `skills/swarm/references/shared-checkout-discipline.md` (PR #333) shape: triage table → score-symmetry diagnostic → anchored evidence → how to apply → failure modes → see also.

## Fitness-delta
| Metric | Before | After |
|---|---|---|
| council references | 33 | 34 |
| decision-triage rows for when to cross-vendor | 0 | 7 |
| score-symmetry diagnostic rows | 0 | 5 |
| anchored empirical proofs | 0 | 1 |

## Validation
- pre-push-gate.sh --fast: **passed (43 skipped)**
- council tier=judgment, CI limit=1050, current=243 lines (well under)

## Closes
Closes-scenario: soc-k68w#cross-vendor-triage
Evidence: skills/council/references/cross-vendor-duel-when-to-use.md

## Provenance
Cluster #7 of 2026-05-18 Track-C mining pass.
Source: `.agents/learnings/2026-05-17-cross-vendor-duel-converges.md`.