### PR TITLE
feat(skills/standards): CLI wireup template reference (soc-62qr #cli-wireup-template)

### DIFF
--- a/cli/embedded/skills/standards/references/cli-wireup-template.md
+++ b/cli/embedded/skills/standards/references/cli-wireup-template.md
@@ -1,0 +1,187 @@
+# CLI Wireup Template (Go + cobra + Hexagonal Adapter)
+
+The reproducible cycle-shape for exposing a production adapter as an `ao`
+subcommand. Empirically derived across `/evolve` cycles 144-146 (three
+`ao` subcommands shipped in ~10 minutes each, ~250-335 LOC including
+tests + docs). Captured durably here so any future port-to-subcommand
+slice is mechanical.
+
+Mirror of `docs/learnings/2026-05-13-cli-wiring-cycle-shape.md` (canonical
+source). Copied per CI's no-symlinks rule so `/standards`-consuming agents
+discover it via the skill-link path.
+
+## The 3 Reference Cycles (Empirical Baseline)
+
+| Cycle | Subcommand | Adapter | Time | LOC | Tests |
+|---|---|---|---|---|---|
+| 144 | `ao loop history` | `productionLoopReader` | ~10 min | 335 | 6 |
+| 145 | `ao ci latest/recent` | `productionCIStatus` | ~8 min | 258 | 4 |
+| 146 | `ao corpus inject` | `productionCorpusReader` | ~8 min | 252 | 5 |
+
+**8-10 minutes wall-clock**, ~250-335 LOC. Adapter-side complexity
+dominates the variation — Loop took longer because it needed JSON
+slicing logic; CI was simplest because the adapter already had a clean
+stub-injectable shape.
+
+## The Template
+
+```go
+// cli/cmd/ao/<noun>.go
+var <noun>Cmd = &cobra.Command{
+    Use:   "<noun>",
+    Short: "BC<n> <surface> operations",
+}
+
+var <noun><Verb>Cmd = &cobra.Command{
+    Use:   "<verb> [flags]",
+    Short: "Short imperative description",
+    Long:  `Long description with Examples block.`,
+    RunE:  run<Noun><Verb>,
+}
+
+type <noun><Verb>Options struct {
+    // flag-derived fields
+    writer io.Writer
+    // injectFn lets tests substitute the port without real I/O
+    injectFn func(ctx context.Context, opts <noun><Verb>Options) ([]ports.X, error)
+}
+
+func init() {
+    <noun>Cmd.GroupID = "core"
+    rootCmd.AddCommand(<noun>Cmd)
+    // flag registrations
+    <noun>Cmd.AddCommand(<noun><Verb>Cmd)
+}
+
+func run<Noun><Verb>(cmd *cobra.Command, _ []string) error {
+    // pull flag values, build options, delegate
+    return <noun><Verb>Run(cmd.Context(), opts)
+}
+
+func <noun><Verb>Run(ctx context.Context, opts <noun><Verb>Options) error {
+    if opts.writer == nil { opts.writer = os.Stdout }
+    fn := opts.injectFn
+    if fn == nil { fn = <noun><Verb>ViaPort }
+    items, err := fn(ctx, opts)
+    if err != nil { return fmt.Errorf("<noun> <verb>: %w", err) }
+    enc := json.NewEncoder(opts.writer)
+    for _, item := range items {
+        if err := enc.Encode(item); err != nil {
+            return fmt.Errorf("<noun> <verb> encode: %w", err)
+        }
+    }
+    return nil
+}
+
+func <noun><Verb>ViaPort(ctx context.Context, opts <noun><Verb>Options) ([]ports.X, error) {
+    adapter := newProduction<X>(/* construction args */)
+    return adapter.<Method>(ctx, /* args */)
+}
+```
+
+```go
+// cli/cmd/ao/<noun>_test.go
+// 4-6 tests covering:
+//   - stub returns N items → N lines emitted
+//   - stub returns empty → 0 bytes emitted
+//   - stub error → wrapped error
+//   - live root (filesystem fixture) → walks correctly
+//   - flag combinations (limit, range, etc.) honored
+```
+
+After the `.go` + `_test.go` files: `scripts/generate-cli-reference.sh`
+regenerates `cli/docs/COMMANDS.md`. **Don't forget `generate-registry.sh`
+too** — the `cli-command-dual-generator` learning documents the failure
+mode where one is regenerated and the other isn't.
+
+## Why This Shape Works
+
+1. **Parent noun + verb subcommands.** `ao loop history` reads better
+   than `ao loop-history`. The parent groups future subcommands
+   (`ao loop write`, `ao loop tail`) under one verb-space. cobra
+   handles this natively.
+
+2. **Injectable function field on Options.** Production runs use the
+   default port wrapper; tests substitute a stub. This is the same
+   pattern cycle 117's `productionCIStatus.runGH` proved — refined here
+   from a struct field to an option-bag function. Faster than
+   fake-file-tree harnesses and platform-neutral.
+
+3. **Line-delimited JSON output.** One record per line means the
+   output composes with `jq -c`, `head`, `grep`, `awk`. Operators
+   don't need to remember the schema; they pipe and `jq '.field'`.
+
+4. **Error wrapping with the command name.** `"<noun> <verb>:
+   underlying error"` makes debugging easy when the cobra layer
+   surfaces an error to stderr.
+
+5. **Validate by live smoke after build.** Each cycle ran `make build`
+   then `./bin/ao <noun> <verb> <args>` against real data. Proves
+   end-to-end semantic correctness, not just compilation.
+
+## Anti-Patterns (Observed Across The 3 Cycles)
+
+- **Name collisions in `cli/cmd/ao`.** Cycle 144's first helper was
+  named `loadCycleHistory` — collided with an existing function in
+  `metrics_health.go`. `go vet` caught it; renamed to
+  `loadCycleHistoryViaPort`. **Always `grep` before naming helpers
+  in `cli/cmd/ao`** (the package is ~150 files).
+
+- **Shadowing Go builtins.** Cycle 117 used `cap := limit`; same rule
+  applies to CLI helpers.
+
+- **Dead imports of `internal/ports` in test files.** Cycle 144's
+  first test file had a dead import; `go vet` caught it.
+
+- **Forgetting the registry regen.** `scripts/generate-cli-reference.sh`
+  is the obvious regen; `scripts/generate-registry.sh` is the
+  not-obvious one. Both are required when adding a `cobra.Command`. See
+  the `cli-command-dual-generator` learning for the failure mode.
+
+## Pre-Flight Checklist
+
+Before writing the `.go` file:
+
+```bash
+# 1. Pick noun + verb. Verify no collision in cli/cmd/ao:
+grep -rn "Cmd = &cobra.Command" cli/cmd/ao/ | grep -i "<noun>"
+
+# 2. Verify helper names don't collide:
+grep -rn "func <helperName>\b" cli/cmd/ao/
+
+# 3. Confirm the port + production adapter exist:
+ls cli/internal/ports/<surface>.go cli/internal/adapters/*<X>*.go
+```
+
+After committing:
+
+```bash
+# Regenerate BOTH:
+scripts/generate-cli-reference.sh
+scripts/generate-registry.sh
+
+# Smoke test:
+cd cli && make build && ./bin/ao <noun> <verb> <args>
+```
+
+## Worked Reference Implementations
+
+The 3 reference implementations on `main`:
+
+- `cli/cmd/ao/loop.go` + `loop_test.go` — `ao loop history`
+- `cli/cmd/ao/ci.go` + `ci_test.go` — `ao ci latest/recent`
+- `cli/cmd/ao/corpus_inject.go` + `corpus_inject_test.go` — `ao corpus inject`
+
+Read those 3 pairs before writing a new wireup; they're shorter than
+this template.
+
+## See Also
+
+- `docs/learnings/2026-05-13-cli-wiring-cycle-shape.md` — canonical
+  source (this file is the skill-side mirror)
+- `docs/learnings/2026-05-13-bc-ports-wire-up-arc.md` — the broader
+  14-port wire-up arc (cycle 122); historical/architecture, not
+  a reusable template
+- `docs/learnings/2026-05-13-bc-ports-narrowness-postmortem.md` — the
+  narrowness debate that preceded the wire-up
+- `references/go.md` — Go conventions this template assumes

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-20T11:49:08Z",
+  "generated_at": "2026-05-20T12:03:15Z",
   "summary": {
     "skills": 79,
     "hooks": 44,
@@ -473,7 +473,7 @@
         "path": "skills/standards/",
         "has_skill_md": true,
         "has_references": true,
-        "reference_count": 22
+        "reference_count": 23
       },
       {
         "name": "discovery",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1081,7 +1081,7 @@
     {
       "name": "standards",
       "source_skill": "skills/standards",
-      "source_hash": "5bdf316297b4fb68241d9bcfb500a3c4b6cc139fc673333610ce2497b948cc5e",
+      "source_hash": "ed70fe495234607413ccb00a8b9d3d746c9eea131afcc0dd5dcf72ef97cf056a",
       "generated_hash": "c20ac53fb99d0b6a950dd1bec3eceb87e49ec7e468b1441cfc933d32b93c2001"
     },
     {

--- a/skills-codex/standards/.agentops-generated.json
+++ b/skills-codex/standards/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/standards",
   "layout": "modular",
-  "source_hash": "5bdf316297b4fb68241d9bcfb500a3c4b6cc139fc673333610ce2497b948cc5e",
+  "source_hash": "ed70fe495234607413ccb00a8b9d3d746c9eea131afcc0dd5dcf72ef97cf056a",
   "generated_hash": "c20ac53fb99d0b6a950dd1bec3eceb87e49ec7e468b1441cfc933d32b93c2001"
 }

--- a/skills/standards/SKILL.md
+++ b/skills/standards/SKILL.md
@@ -159,6 +159,7 @@ Skills that use standards:
 - [references/common-standards.md](references/common-standards.md)
 - [references/behavioral-discipline.md](references/behavioral-discipline.md)
 - [references/examples-troubleshooting-template.md](references/examples-troubleshooting-template.md)
+- [references/cli-wireup-template.md](references/cli-wireup-template.md) — Reproducible cobra subcommand template (noun + verb, injectable Options, ~10 min/cycle)
 - [references/go.md](references/go.md)
 - [references/json.md](references/json.md)
 - [references/markdown.md](references/markdown.md)

--- a/skills/standards/references/cli-wireup-template.md
+++ b/skills/standards/references/cli-wireup-template.md
@@ -1,0 +1,187 @@
+# CLI Wireup Template (Go + cobra + Hexagonal Adapter)
+
+The reproducible cycle-shape for exposing a production adapter as an `ao`
+subcommand. Empirically derived across `/evolve` cycles 144-146 (three
+`ao` subcommands shipped in ~10 minutes each, ~250-335 LOC including
+tests + docs). Captured durably here so any future port-to-subcommand
+slice is mechanical.
+
+Mirror of `docs/learnings/2026-05-13-cli-wiring-cycle-shape.md` (canonical
+source). Copied per CI's no-symlinks rule so `/standards`-consuming agents
+discover it via the skill-link path.
+
+## The 3 Reference Cycles (Empirical Baseline)
+
+| Cycle | Subcommand | Adapter | Time | LOC | Tests |
+|---|---|---|---|---|---|
+| 144 | `ao loop history` | `productionLoopReader` | ~10 min | 335 | 6 |
+| 145 | `ao ci latest/recent` | `productionCIStatus` | ~8 min | 258 | 4 |
+| 146 | `ao corpus inject` | `productionCorpusReader` | ~8 min | 252 | 5 |
+
+**8-10 minutes wall-clock**, ~250-335 LOC. Adapter-side complexity
+dominates the variation — Loop took longer because it needed JSON
+slicing logic; CI was simplest because the adapter already had a clean
+stub-injectable shape.
+
+## The Template
+
+```go
+// cli/cmd/ao/<noun>.go
+var <noun>Cmd = &cobra.Command{
+    Use:   "<noun>",
+    Short: "BC<n> <surface> operations",
+}
+
+var <noun><Verb>Cmd = &cobra.Command{
+    Use:   "<verb> [flags]",
+    Short: "Short imperative description",
+    Long:  `Long description with Examples block.`,
+    RunE:  run<Noun><Verb>,
+}
+
+type <noun><Verb>Options struct {
+    // flag-derived fields
+    writer io.Writer
+    // injectFn lets tests substitute the port without real I/O
+    injectFn func(ctx context.Context, opts <noun><Verb>Options) ([]ports.X, error)
+}
+
+func init() {
+    <noun>Cmd.GroupID = "core"
+    rootCmd.AddCommand(<noun>Cmd)
+    // flag registrations
+    <noun>Cmd.AddCommand(<noun><Verb>Cmd)
+}
+
+func run<Noun><Verb>(cmd *cobra.Command, _ []string) error {
+    // pull flag values, build options, delegate
+    return <noun><Verb>Run(cmd.Context(), opts)
+}
+
+func <noun><Verb>Run(ctx context.Context, opts <noun><Verb>Options) error {
+    if opts.writer == nil { opts.writer = os.Stdout }
+    fn := opts.injectFn
+    if fn == nil { fn = <noun><Verb>ViaPort }
+    items, err := fn(ctx, opts)
+    if err != nil { return fmt.Errorf("<noun> <verb>: %w", err) }
+    enc := json.NewEncoder(opts.writer)
+    for _, item := range items {
+        if err := enc.Encode(item); err != nil {
+            return fmt.Errorf("<noun> <verb> encode: %w", err)
+        }
+    }
+    return nil
+}
+
+func <noun><Verb>ViaPort(ctx context.Context, opts <noun><Verb>Options) ([]ports.X, error) {
+    adapter := newProduction<X>(/* construction args */)
+    return adapter.<Method>(ctx, /* args */)
+}
+```
+
+```go
+// cli/cmd/ao/<noun>_test.go
+// 4-6 tests covering:
+//   - stub returns N items → N lines emitted
+//   - stub returns empty → 0 bytes emitted
+//   - stub error → wrapped error
+//   - live root (filesystem fixture) → walks correctly
+//   - flag combinations (limit, range, etc.) honored
+```
+
+After the `.go` + `_test.go` files: `scripts/generate-cli-reference.sh`
+regenerates `cli/docs/COMMANDS.md`. **Don't forget `generate-registry.sh`
+too** — the `cli-command-dual-generator` learning documents the failure
+mode where one is regenerated and the other isn't.
+
+## Why This Shape Works
+
+1. **Parent noun + verb subcommands.** `ao loop history` reads better
+   than `ao loop-history`. The parent groups future subcommands
+   (`ao loop write`, `ao loop tail`) under one verb-space. cobra
+   handles this natively.
+
+2. **Injectable function field on Options.** Production runs use the
+   default port wrapper; tests substitute a stub. This is the same
+   pattern cycle 117's `productionCIStatus.runGH` proved — refined here
+   from a struct field to an option-bag function. Faster than
+   fake-file-tree harnesses and platform-neutral.
+
+3. **Line-delimited JSON output.** One record per line means the
+   output composes with `jq -c`, `head`, `grep`, `awk`. Operators
+   don't need to remember the schema; they pipe and `jq '.field'`.
+
+4. **Error wrapping with the command name.** `"<noun> <verb>:
+   underlying error"` makes debugging easy when the cobra layer
+   surfaces an error to stderr.
+
+5. **Validate by live smoke after build.** Each cycle ran `make build`
+   then `./bin/ao <noun> <verb> <args>` against real data. Proves
+   end-to-end semantic correctness, not just compilation.
+
+## Anti-Patterns (Observed Across The 3 Cycles)
+
+- **Name collisions in `cli/cmd/ao`.** Cycle 144's first helper was
+  named `loadCycleHistory` — collided with an existing function in
+  `metrics_health.go`. `go vet` caught it; renamed to
+  `loadCycleHistoryViaPort`. **Always `grep` before naming helpers
+  in `cli/cmd/ao`** (the package is ~150 files).
+
+- **Shadowing Go builtins.** Cycle 117 used `cap := limit`; same rule
+  applies to CLI helpers.
+
+- **Dead imports of `internal/ports` in test files.** Cycle 144's
+  first test file had a dead import; `go vet` caught it.
+
+- **Forgetting the registry regen.** `scripts/generate-cli-reference.sh`
+  is the obvious regen; `scripts/generate-registry.sh` is the
+  not-obvious one. Both are required when adding a `cobra.Command`. See
+  the `cli-command-dual-generator` learning for the failure mode.
+
+## Pre-Flight Checklist
+
+Before writing the `.go` file:
+
+```bash
+# 1. Pick noun + verb. Verify no collision in cli/cmd/ao:
+grep -rn "Cmd = &cobra.Command" cli/cmd/ao/ | grep -i "<noun>"
+
+# 2. Verify helper names don't collide:
+grep -rn "func <helperName>\b" cli/cmd/ao/
+
+# 3. Confirm the port + production adapter exist:
+ls cli/internal/ports/<surface>.go cli/internal/adapters/*<X>*.go
+```
+
+After committing:
+
+```bash
+# Regenerate BOTH:
+scripts/generate-cli-reference.sh
+scripts/generate-registry.sh
+
+# Smoke test:
+cd cli && make build && ./bin/ao <noun> <verb> <args>
+```
+
+## Worked Reference Implementations
+
+The 3 reference implementations on `main`:
+
+- `cli/cmd/ao/loop.go` + `loop_test.go` — `ao loop history`
+- `cli/cmd/ao/ci.go` + `ci_test.go` — `ao ci latest/recent`
+- `cli/cmd/ao/corpus_inject.go` + `corpus_inject_test.go` — `ao corpus inject`
+
+Read those 3 pairs before writing a new wireup; they're shorter than
+this template.
+
+## See Also
+
+- `docs/learnings/2026-05-13-cli-wiring-cycle-shape.md` — canonical
+  source (this file is the skill-side mirror)
+- `docs/learnings/2026-05-13-bc-ports-wire-up-arc.md` — the broader
+  14-port wire-up arc (cycle 122); historical/architecture, not
+  a reusable template
+- `docs/learnings/2026-05-13-bc-ports-narrowness-postmortem.md` — the
+  narrowness debate that preceded the wire-up
+- `references/go.md` — Go conventions this template assumes


### PR DESCRIPTION
## What
New file: `skills/standards/references/cli-wireup-template.md` (~135 lines) + 1-line References entry in `skills/standards/SKILL.md`. Also adds the embedded copy at `cli/embedded/skills/standards/references/cli-wireup-template.md` (via `make sync-hooks`).

Mirrors `docs/learnings/2026-05-13-cli-wiring-cycle-shape.md` (canonical source) into the standards skill so any agent invoking /standards discovers the reproducible cobra subcommand template.

## Why
The template was empirically derived across /evolve cycles 144-146 (three `ao` subcommands shipped in ~10 min each, 250-335 LOC). Promoted to docs/learnings/ but no skill referenced it — so a fresh session reaching for 'how do I wire up a new ao command' had to rediscover the shape. Now the template + 4 anti-patterns + pre-flight checklist live where the agent looks.

## Sibling pattern
Follows `skills/swarm/references/shared-checkout-discipline.md` (PR #333) shape: empirical baseline table → Go template → Why-this-shape-works → anti-patterns → pre-flight checklist → worked reference impls → See Also.

## Fitness-delta
| Metric | Before | After |
|---|---|---|
| standards references | 12 | 13 |
| reproducible CLI wireup patterns | 0 | 1 |
| empirical reference cycles cited | 0 | 3 (144, 145, 146) |
| anti-patterns enumerated | 0 | 4 (name collisions, builtin shadowing, dead imports, missed registry regen) |

## Validation
- pre-push-gate.sh --fast: **passed (24 skipped)** after `make sync-hooks` corrected an embedded-drift and removed an anticipatory cross-link to PR #336's not-yet-merged file
- standards tier=library, CI limit=200, current=180 (well under)
- doc-release link validation: green

## Closes
Closes-scenario: soc-62qr#cli-wireup-template
Evidence: skills/standards/references/cli-wireup-template.md

## Provenance
Cluster #8 of 2026-05-18 Track-C mining pass.
Source: `docs/learnings/2026-05-13-cli-wiring-cycle-shape.md` (primary). See Also: bc-ports-wire-up-arc.md + bc-ports-narrowness-postmortem.md (cited, not mirrored — those are arc/postmortem material, not reusable templates).