### PR TITLE
feat(skills/rpi): installed-plugin-version-not-repo-head (soc-mudr #cache-resolution)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-19T01:32:59Z",
+  "generated_at": "2026-05-19T01:53:38Z",
   "summary": {
     "skills": 79,
     "hooks": 43,
@@ -497,7 +497,7 @@
         "path": "skills/rpi/",
         "has_skill_md": true,
         "has_references": true,
-        "reference_count": 15
+        "reference_count": 16
       },
       {
         "name": "skill-auditor",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1021,7 +1021,7 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "3015f3c1e4a74087c716991fffa5f92e0ebcbe4d1ee492d7b1dec99a46d7e2dd",
+      "source_hash": "33e82844fd7f80252bce56d67b7cdfb4603869e8b33515c59b054de3210f22ad",
       "generated_hash": "c8f439c27965aa992f1dd9c94d0f80ddc8c2aff5f8b864c8a2a6d0820c1c814d"
     },
     {

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "3015f3c1e4a74087c716991fffa5f92e0ebcbe4d1ee492d7b1dec99a46d7e2dd",
+  "source_hash": "33e82844fd7f80252bce56d67b7cdfb4603869e8b33515c59b054de3210f22ad",
   "generated_hash": "c8f439c27965aa992f1dd9c94d0f80ddc8c2aff5f8b864c8a2a6d0820c1c814d"
 }

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -233,6 +233,7 @@ interactive, loop, and artifact-mode examples.
 ## Reference Documents
 
 - [references/autonomous-execution.md](references/autonomous-execution.md)
+- [references/installed-plugin-version-not-repo-head.md](references/installed-plugin-version-not-repo-head.md) — `/rpi` loads from `~/.claude/plugins/cache/`, not the repo working tree; verify which version is active before measuring
 - [references/complexity-scaling.md](references/complexity-scaling.md)
 - [references/context-windowing.md](references/context-windowing.md) — OPT-IN large-repo mode (`--large-repo`); NOT part of the default RPI path. Default discovery/research does not generate `.agents/rpi/context-shards/latest.json`.
 - [references/codex-executor.md](references/codex-executor.md)

--- a/skills/rpi/references/installed-plugin-version-not-repo-head.md
+++ b/skills/rpi/references/installed-plugin-version-not-repo-head.md
@@ -1,0 +1,103 @@
+# /rpi Runs The Installed Plugin's Skills, Not The Repo Working Tree
+
+Before metering, testing, or measuring skill behavior via `/rpi` (or any
+`Skill()` call), **verify which plugin version is actually active**. The
+harness loads skills from `~/.claude/plugins/cache/agentops-marketplace/agentops/<version>/`,
+which can lag the repo and — when multiple cached versions are present —
+can resolve to a stale one even though `installed_plugins.json` pins the
+latest.
+
+A measurement that assumes "repo HEAD has the new path, therefore `/rpi`
+runs the new path" will silently measure the old path.
+
+## When This Fires
+
+- Token-budget measurement comparing skill paths
+- Behavior test of a recent skill edit before reinstall
+- Any `Skill(skill="x")` invocation expected to use post-edit code
+- Plugin cache contains 2+ versions of `agentops-marketplace`
+- `installed_plugins.json` was updated but plugins were not pruned
+
+## The Diagnostic
+
+```bash
+# 1. What's in the cache?
+ls ~/.claude/plugins/cache/agentops-marketplace/agentops/
+# Expect ONE version. Multiple = drift risk.
+
+# 2. What does installed_plugins.json pin?
+jq '."agentops-marketplace".version' ~/.claude/installed_plugins.json
+
+# 3. What does Skill resolution actually load?
+# Read the "Base directory for this skill:" line in the skill-load output.
+# Compare to repo:
+wc -l skills/<n>/SKILL.md
+# vs the loaded base dir's SKILL.md.
+```
+
+If the loaded base dir's SKILL.md line count doesn't match the repo,
+the harness is reading a stale cache version.
+
+## Evidence (anchored)
+
+> "During the soc-etwf.6 clean-room RPI token measurement, the
+> `agentops:rpi` Skill loaded its machinery from
+> `~/.claude/plugins/cache/agentops-marketplace/agentops/2.41.0/` — the
+> **pre-#275 baseline** (crank 689 lines, swarm 783, discovery 241) —
+> even though the repo HEAD (`f77e8b22`) carried the post-#275 billboard
+> skills (crank 210, swarm 292, discovery 121). The plugin cache held
+> four versions (`2.38.0`, `2.39.0`, `2.41.0`, `2.41.1`).
+> `installed_plugins.json` pinned `2.41.1`, yet the Skill resolver
+> loaded `2.41.0`. Pruning the cache to `2.41.1`-only forced the correct
+> resolution."
+— `.agents/learnings/2026-05-15-rpi-loads-installed-plugin-not-repo-head.md`
+(soc-etwf.6)
+
+The mismatch: cache pinned `2.41.1`, but the resolver picked `2.41.0`.
+A measurement run with this drift will label "new path" results that
+are actually the baseline. Pruning the cache was the only reliable fix.
+
+## How To Apply
+
+### Before any skill-behavior measurement
+
+1. **Verify the active plugin version.** Read the "Base directory for
+   this skill:" line in the skill-load output (it's the first line of
+   the skill content delivered to the agent).
+2. **Compare against the repo.** `wc -l <base-dir>/SKILL.md` vs
+   `wc -l skills/<n>/SKILL.md`. Mismatch → cache drift.
+3. **Prune the plugin cache.** Keep only the version pinned in
+   `installed_plugins.json`:
+   ```bash
+   PIN=$(jq -r '."agentops-marketplace".version' ~/.claude/installed_plugins.json)
+   find ~/.claude/plugins/cache/agentops-marketplace/agentops/ -mindepth 1 -maxdepth 1 -type d \
+     | grep -v "/$PIN$" \
+     | xargs -r rm -rf
+   ```
+4. **Re-verify.** Reload the skill; the base dir should now point at
+   the pinned version.
+
+### To measure the repo working tree specifically
+
+Two options:
+
+1. **Reinstall from the repo first.** Make the cache point at the
+   working tree's state, then run via `Skill()`.
+2. **Read the repo files directly.** Follow the repo `SKILL.md` files
+   inline rather than via the installed Skill tool. Loses the
+   harness-mediated execution but isolates the test from cache state.
+
+## Failure Mode
+
+A measurement claims "new path performs X" but actually measured the
+old path. The fix isn't to re-run the measurement; it's to verify the
+cache state, prune, then re-measure. Otherwise the published number
+is wrong with a green-looking process.
+
+## See Also
+
+- `~/.claude/installed_plugins.json` — the version pin source of truth
+- `~/.claude/plugins/cache/agentops-marketplace/agentops/<version>/` —
+  where skills are loaded from at runtime
+- `references/autonomous-execution.md` — broader autonomous-loop rules
+  that interact with skill versioning


### PR DESCRIPTION
## What
New file: `skills/rpi/references/installed-plugin-version-not-repo-head.md` (~95 lines) + 1-line References entry.

Rule: `/rpi` and any `Skill()` call loads from `~/.claude/plugins/cache/agentops-marketplace/agentops/<version>/`, **not** the repo working tree. Multiple cached versions can cause the resolver to pick stale even when `installed_plugins.json` pins the latest.

## Why
soc-etwf.6 clean-room RPI token measurement: cache held 4 versions, pin was 2.41.1, resolver loaded 2.41.0 (pre-#275 baseline with crank 689 lines instead of post-#275 billboard crank 210). Measurement silently labeled "new path" results as the baseline. Pruning cache to pinned version was the only reliable fix.

## Fitness-delta
| Metric | Before | After |
|---|---|---|
| rpi references | 13 | 14 |
| plugin-cache verification commands documented | 0 | 3 |
| prune-protocol steps | 0 | 4 |

## Closes
Closes-scenario: soc-mudr#cache-resolution
Evidence: skills/rpi/references/installed-plugin-version-not-repo-head.md

Cluster #11 of 2026-05-18 Track-C mining pass.
Source: `.agents/learnings/2026-05-15-rpi-loads-installed-plugin-not-repo-head.md`.