### PR TITLE
fix(hooks): drop PWD-in-worktrees heuristic from lead-only-worker-git-guard (soc-is4c)

### DIFF
--- a/cli/embedded/hooks/lead-only-worker-git-guard.sh
+++ b/cli/embedded/hooks/lead-only-worker-git-guard.sh
@@ -25,6 +25,14 @@ set -euo pipefail
 [[ "${AGENTOPS_LEAD_ONLY_GUARD_DISABLED:-}" == "1" ]] && exit 0
 
 # ---- worker detection ------------------------------------------------------
+# Require an EXPLICIT positive worker signal. The NTM swarm runner sets one
+# of these env vars (or drops .agents/swarm-role) when it spawns workers;
+# absent any of them, the running agent is the lead. Historical note (soc-is4c):
+# this used to also classify any PWD under .claude/worktrees/ as a worker,
+# but that fired on every solo Claude session opened in a worktree for
+# isolation — the human-in-the-loop case, where the user IS the lead — and
+# the documented kill-switch env vars are unreachable from inside a Bash
+# tool call, so the false-positive had no in-session escape hatch.
 is_worker=0
 if [[ "${AGENTOPS_SWARM_ROLE:-}" == "worker" ]]; then
     is_worker=1
@@ -33,8 +41,6 @@ elif [[ "${AGENTOPS_ROLE:-}" == "worker" ]]; then
 elif [[ "${CLAUDE_AGENT_NAME:-}" == worker-* ]]; then
     is_worker=1
 elif [[ -f ".agents/swarm-role" ]] && grep -q "^worker$" .agents/swarm-role 2>/dev/null; then
-    is_worker=1
-elif [[ "${PWD}" == *"/.claude/worktrees/"* ]]; then
     is_worker=1
 fi
 

--- a/hooks/lead-only-worker-git-guard.sh
+++ b/hooks/lead-only-worker-git-guard.sh
@@ -25,6 +25,14 @@ set -euo pipefail
 [[ "${AGENTOPS_LEAD_ONLY_GUARD_DISABLED:-}" == "1" ]] && exit 0
 
 # ---- worker detection ------------------------------------------------------
+# Require an EXPLICIT positive worker signal. The NTM swarm runner sets one
+# of these env vars (or drops .agents/swarm-role) when it spawns workers;
+# absent any of them, the running agent is the lead. Historical note (soc-is4c):
+# this used to also classify any PWD under .claude/worktrees/ as a worker,
+# but that fired on every solo Claude session opened in a worktree for
+# isolation — the human-in-the-loop case, where the user IS the lead — and
+# the documented kill-switch env vars are unreachable from inside a Bash
+# tool call, so the false-positive had no in-session escape hatch.
 is_worker=0
 if [[ "${AGENTOPS_SWARM_ROLE:-}" == "worker" ]]; then
     is_worker=1
@@ -33,8 +41,6 @@ elif [[ "${AGENTOPS_ROLE:-}" == "worker" ]]; then
 elif [[ "${CLAUDE_AGENT_NAME:-}" == worker-* ]]; then
     is_worker=1
 elif [[ -f ".agents/swarm-role" ]] && grep -q "^worker$" .agents/swarm-role 2>/dev/null; then
-    is_worker=1
-elif [[ "${PWD}" == *"/.claude/worktrees/"* ]]; then
     is_worker=1
 fi
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,9 +1,161 @@
 # End-to-End Tests
 
-Flywheel proof-run harness that starts from a raw transcript fixture, forges pending learnings, ingests and promotes them through the pool, retrieves the promoted artifact, records applied citation evidence, and closes feedback with a deterministic success outcome. It is fully automated, local-only, CI-runnable, and uses a temporary work directory with fixtures.
+The scripts in this directory are end-to-end tests, not unit tests with delusions
+of grandeur. They:
+
+- build (or reuse) a real `ao` binary
+- create a real, isolated git repo under `mktemp -d`
+- exercise the real CLI across multiple phases
+- assert on real artifacts (files on disk, JSON output, citation logs)
+- **mock nothing** that the system under test depends on
+
+This document captures the contract every e2e script must satisfy, the mock-risk
+scoring used to triage candidates, and the shared harness those scripts share.
+
+> Source skill: `testing-real-service-e2e-no-mocks` — adapted from the
+> SaaS-billing original to the CLI/CI domain.
 
 ## Running
+
+The flagship suite is the flywheel proof, which exercises forge → pool-ingest →
+cite → promote → lookup → feedback → nightly across one isolated sandbox:
 
 ```bash
 bash tests/e2e/proof-run.sh
 ```
+
+Other scripts (`goals-*.sh`, `rpi-phased-domain.sh`, `closure-integrity-grace.sh`,
+…) follow the same harness contract and can be run the same way.
+
+---
+
+## The contract
+
+Every script in `tests/e2e/` MUST:
+
+1. **Source the shared harness.**
+   ```bash
+   source "$REPO_ROOT/tests/lib/e2e-guards.sh"   # production safety guards
+   source "$REPO_ROOT/tests/lib/e2e-factory.sh"  # sandbox + repo + ao binary
+   source "$REPO_ROOT/tests/lib/e2e-logger.sh"   # JSON-line sidecar (optional)
+   ```
+
+2. **Stand up an isolated sandbox.** Create the work dir via
+   `e2e_factory_sandbox <slug>` (never `mktemp -d` by hand), the repo via
+   `e2e_factory_repo`, and the binary via `e2e_factory_ao_bin`. Set
+   `HOME="$WORK_DIR/home"` so any `~/.agents`-style writes land inside the
+   sandbox.
+
+3. **Call the guards.** Each is fast (no I/O after the path check) and refuses
+   to run if `$HOME`, the repo dir, or the `ao` binary look real:
+   ```bash
+   e2e_guard_home    "$HOME_DIR"
+   e2e_guard_repo    "$REPO_DIR"
+   e2e_guard_ao_bin  "$AO_BIN"
+   e2e_guard_not_repo_root   # only if your test runs ao relative to PWD
+   ```
+
+4. **Clean up via `trap`.** Always wipe the sandbox on exit. `chmod -R u+w`
+   first so a test that drops a read-only file can't pin the directory.
+
+5. **Assert on real artifacts.** No mocked return values. Read the file the
+   command produced, parse the JSON the command emitted, walk the directory
+   the command wrote into.
+
+A script that mocks the `ao` binary, fakes `git`, or substitutes an in-memory
+store for the on-disk one is by definition not an e2e test — it belongs under
+`cli/internal/<pkg>/*_test.go`.
+
+---
+
+## Mock Risk Assessment Matrix
+
+The skill scores `Impact × Risk` and demands mock-free for any score ≥ 8.
+The agentops snapshot (audited 2026-05-18):
+
+| Path | Impact | Mock Risk | Score | Status |
+|------|:------:|:---------:|:-----:|--------|
+| Forge transcript → pending learnings | 5 | 2 | 10 | ✅ mock-free (`proof-run.sh` Phase 1) |
+| Pool ingest → candidates | 5 | 2 | 10 | ✅ mock-free (`proof-run.sh` Phase 2) |
+| Cite → close-loop promotion | 5 | 3 | 15 | ✅ mock-free (`proof-run.sh` Phase 3) |
+| Lookup / retrieval | 5 | 2 | 10 | ✅ mock-free (`proof-run.sh` Phase 4) |
+| Feedback rewarding | 5 | 2 | 10 | ✅ mock-free (`proof-run.sh` Phase 5) |
+| Nightly dream cycle | 4 | 2 | 8 | ✅ mock-free (`proof-run.sh` Phase 6) |
+| Goals scenarios link + lint | 4 | 2 | 8 | ✅ mock-free (`goals-scenarios-link.sh`) |
+| RPI phased domain dispatch | 4 | 3 | 12 | ✅ mock-free (`rpi-phased-domain.sh`) |
+| `install.sh` curl-pipe | 5 | 3 | 15 | ✅ mock-free (`.github/workflows/install-e2e.yml`) |
+| openclaw daemon API | 2 | 2 | 4 | ⚠️ httptest fixture — acceptable, internal-only |
+| Claude CLI skill invocation | 3 | 4 | 12 | ⚠️ real Claude, non-deterministic — acceptable as advisory |
+
+The "⚠️" rows are intentional. The openclaw daemon's `httptest.NewServer` wires
+up the *real* `daemon.NewDaemonRouter` with a temp-dir backing store —
+test-local instantiation, not a stub of the system under test (score 4 is below
+the 8 threshold). The Claude CLI tests use the real Claude binary; the
+non-determinism is the cost of testing prompt-bound behavior end-to-end.
+
+### What does NOT belong on this matrix
+
+Cross-test pollution at the unit layer (Cobra flag globals, `os.Stdout`
+redirection, `os.Chdir` cleanup) is a different problem class — isolation, not
+faking. Track those in beads, not here.
+
+---
+
+## Shared harness
+
+| File | Purpose | Public API |
+|------|---------|------------|
+| `tests/lib/e2e-guards.sh` | Refuse-to-run safety checks | `e2e_guard_home`, `e2e_guard_repo`, `e2e_guard_ao_bin`, `e2e_guard_not_repo_root` |
+| `tests/lib/e2e-factory.sh` | Sandbox + repo + binary builders | `e2e_factory_sandbox`, `e2e_factory_repo`, `e2e_factory_ao_bin`, `e2e_factory_agents_dir`, `e2e_factory_fixture` |
+| `tests/lib/e2e-logger.sh` | JSON-line CI-parseable sidecar | `e2e_log_init`, `e2e_log_phase`, `e2e_log_pass`, `e2e_log_fail`, `e2e_log_assert`, `e2e_log_artifact`, `e2e_log_summary` |
+
+The logger writes one JSON object per line. Schema (fields are stable;
+consumers can rely on them):
+
+```json
+{"ts":"2026-05-19T00:37:24Z","suite":"flywheel-proof","phase":"cite-promote",
+ "event":"pass","message":"close-loop promoted a cited candidate","data":null}
+```
+
+`event` is one of: `suite_start`, `phase_start`, `pass`, `fail`, `assert`,
+`artifact`, `db_snapshot`, `suite_end`. The `data` field is event-specific
+(asserts have `{expected, actual, match}`, artifacts have `{path, size, mtime}`,
+the closing `suite_end` has `{pass, fail, duration_s}`).
+
+### Escape hatch
+
+`AGENTOPS_E2E_ALLOW_UNSAFE=1` bypasses every guard. It exists for the rare
+maintainer debugging the harness itself. **Never set it in CI.** Every bypass
+prints a `[e2e-guard] WARNING:` line to stderr.
+
+---
+
+## Adding a new e2e script
+
+1. Pick a slug. `e2e_factory_sandbox <slug>` puts it in the dirname for grep.
+2. Source all three libs from `tests/lib/`.
+3. Call `e2e_factory_sandbox` → `e2e_factory_repo` → `e2e_factory_ao_bin`.
+4. Call the three guards (`home`, `repo`, `ao_bin`). Add `not_repo_root` if you
+   chdir into `$WORK` and run `ao` with relative paths.
+5. `e2e_log_init` if you want the JSON-line sidecar (recommended).
+6. Trap cleanup. `chmod -R u+w "$WORK"` before `rm -rf`.
+7. Wire into `.github/workflows/validate.yml` if the path is on the score-≥-8
+   list above.
+
+---
+
+## Currently mock-free e2e scripts
+
+| Script | Phases | Risk paths exercised |
+|--------|--------|----------------------|
+| `proof-run.sh` | forge → pool-ingest → cite-promote → lookup → feedback → nightly | 5 of the top-10 highest-risk paths in one suite |
+| `goals-scenarios-link.sh` | create → verify-bidirectional → lint-clean → break → lint-fails | F1 of the goals epic |
+| `goals-measure-scenarios.sh` | measure → assert satisfaction | F2 |
+| `rpi-phased-domain.sh` | dispatch → phase trace | F3 |
+| `goals-trace-chain.sh` | trace → dependency assert | F4 |
+| `goals-steer-auto.sh` | steer → re-prioritize | F5 |
+| `closure-integrity-grace.sh` | citation → grace period → closure invariant | citation flow regressions |
+| `factory-operator-canary.sh` | factory admission → operator action | factory pipeline contract |
+
+Every script in this list is mock-free **today** — this file is the contract
+that keeps it that way.

--- a/tests/e2e/goals-scenarios-link.sh
+++ b/tests/e2e/goals-scenarios-link.sh
@@ -11,21 +11,29 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-AO="$REPO_ROOT/cli/bin/ao"
+
+# Shared e2e harness (skill: testing-real-service-e2e-no-mocks):
+# shellcheck source=../lib/e2e-guards.sh
+source "$REPO_ROOT/tests/lib/e2e-guards.sh"
+# shellcheck source=../lib/e2e-factory.sh
+source "$REPO_ROOT/tests/lib/e2e-factory.sh"
 
 log() { printf '[%s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
 fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 
-if [[ ! -x "$AO" ]]; then
-  log "ao binary absent — building"
-  ( cd "$REPO_ROOT/cli" && go build -o bin/ao ./cmd/ao )
-fi
-log "ao binary: $AO"
-
-WORK="$(mktemp -d)"
+WORK="$(e2e_factory_sandbox goals-scenarios-link)"
 trap 'rm -rf "$WORK"' EXIT
 log "temp root: $WORK"
+e2e_guard_repo "$WORK"
+
+AO="$(e2e_factory_ao_bin "$WORK/bin" "$REPO_ROOT")"
+e2e_guard_ao_bin "$AO"
+log "ao binary: $AO"
+
 cd "$WORK"
+# This test runs `ao goals scenarios` with PWD-relative GOALS.md, so check
+# that the chdir landed us in the sandbox (not the agentops repo root).
+e2e_guard_not_repo_root
 
 cat > GOALS.md <<'EOF'
 # Goals

--- a/tests/e2e/proof-run.sh
+++ b/tests/e2e/proof-run.sh
@@ -4,12 +4,29 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 FIXTURE_DIR="$REPO_ROOT/tests/fixtures/flywheel-proof"
-WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/flywheel-proof-XXXXXX")"
+
+# Shared e2e harness (skill: testing-real-service-e2e-no-mocks):
+#   guards  — refuse-to-run if HOME/repo/ao binary look real
+#   logger  — JSON-line sidecar for CI parseability
+#   factory — sandbox + repo + ao binary builders
+# shellcheck source=../lib/e2e-guards.sh
+source "$REPO_ROOT/tests/lib/e2e-guards.sh"
+# shellcheck source=../lib/e2e-logger.sh
+source "$REPO_ROOT/tests/lib/e2e-logger.sh"
+# shellcheck source=../lib/e2e-factory.sh
+source "$REPO_ROOT/tests/lib/e2e-factory.sh"
+
+# Note: proof-run.sh never executes ao relative to PWD — every run_ao call
+# chdirs into REPO_DIR. So e2e_guard_not_repo_root is intentionally NOT
+# called here; the per-invocation REPO/HOME/AO guards below are sufficient.
+
+WORK_DIR="$(e2e_factory_sandbox flywheel-proof)"
 BUILD_DIR="$WORK_DIR/bin"
 HOME_DIR="$WORK_DIR/home"
 REPO_DIR="$WORK_DIR/repo"
 AO_BIN="$BUILD_DIR/ao"
 LOG_FILE="$WORK_DIR/proof-run.log"
+SIDECAR_LOG="$WORK_DIR/proof-run.jsonl"
 PASS_COUNT=0
 LOOKUP_QUERY="task-scoped lookup queries"
 
@@ -26,10 +43,13 @@ log() {
 pass() {
   PASS_COUNT=$((PASS_COUNT + 1))
   log "PASS: $*"
+  e2e_log_pass "$*"
 }
 
 fail() {
   log "FAIL: $*"
+  e2e_log_fail "$*"
+  e2e_log_summary
   exit 1
 }
 
@@ -82,51 +102,33 @@ run_ao() {
 require_cmd git
 require_cmd jq
 
-mkdir -p "$BUILD_DIR" "$HOME_DIR" "$REPO_DIR"
+mkdir -p "$HOME_DIR"
 export HOME="$HOME_DIR"
-export PATH="$BUILD_DIR:$PATH"
+e2e_log_init "flywheel-proof" "$SIDECAR_LOG"
+e2e_log_phase setup
 
-# Allow callers to bypass the build step by pointing PROOF_AO_BIN at an
-# already-built binary. Auto-detects $REPO_ROOT/cli/bin/ao when present so
-# the gate stays green when the toolchain download path is broken
-# (e.g. sum.golang.org returning 503) but the local cli/bin/ao is fresh —
-# the proof-run still validates end-to-end behavior, just against the
-# pre-built binary instead of a freshly-built one. Set PROOF_FORCE_BUILD=1
-# to disable both the override and the auto-detect and always rebuild.
-PROOF_AO_BIN="${PROOF_AO_BIN:-}"
-if [[ -z "$PROOF_AO_BIN" && "${PROOF_FORCE_BUILD:-0}" != "1" && -x "$REPO_ROOT/cli/bin/ao" ]]; then
-  PROOF_AO_BIN="$REPO_ROOT/cli/bin/ao"
-fi
-if [[ -n "$PROOF_AO_BIN" && -x "$PROOF_AO_BIN" ]]; then
-  log "Using pre-built ao binary: $PROOF_AO_BIN"
-  cp "$PROOF_AO_BIN" "$AO_BIN"
-  pass "reused pre-built ao binary"
-else
-  require_cmd go
-  log "Building local ao binary"
-  (
-    cd "$REPO_ROOT/cli"
-    go build -o "$AO_BIN" ./cmd/ao
-  ) >/dev/null
-  pass "built local ao binary"
-fi
+# Build (or reuse) the ao binary inside the sandbox. Honors PROOF_AO_BIN and
+# PROOF_FORCE_BUILD — see tests/lib/e2e-factory.sh for the resolution rules.
+AO_BIN="$(e2e_factory_ao_bin "$BUILD_DIR" "$REPO_ROOT")"
+export PATH="$BUILD_DIR:$PATH"
+pass "ao binary resolved at $AO_BIN"
+
+# Production safety guards — every assertion must hold before we touch state.
+# The skill's "never hit prod from tests" rule, translated to the CLI domain:
+# $HOME must point inside the sandbox, the repo must be under a temp prefix,
+# and the binary must live in the sandbox build dir (or repo-local cli/bin).
+e2e_guard_home "$HOME_DIR"
+e2e_guard_ao_bin "$AO_BIN"
 
 log "Creating isolated proof repo"
-(
-  cd "$REPO_DIR"
-  git init -q
-  git config user.email "proof-run@agentops.test"
-  git config user.name "Proof Run"
-  printf '# Flywheel Proof Repo\n' > README.md
-  git add README.md
-  git commit -q -m "init"
-)
+REPO_DIR="$(e2e_factory_repo "$REPO_DIR")"
+e2e_guard_repo "$REPO_DIR"
 pass "initialized isolated repo"
 
-TRANSCRIPT="$REPO_DIR/seed-session.jsonl"
-cp "$FIXTURE_DIR/seed-session.jsonl" "$TRANSCRIPT"
+TRANSCRIPT="$(e2e_factory_fixture "$FIXTURE_DIR/seed-session.jsonl" "$REPO_DIR")"
 pass "copied raw transcript fixture"
 
+e2e_log_phase forge
 log "Phase 1: forge transcript into pending learnings"
 run_ao forge transcript "$TRANSCRIPT" --quiet >/dev/null
 PENDING_DIR="$REPO_DIR/.agents/knowledge/pending"
@@ -136,6 +138,7 @@ if [[ "$PENDING_COUNT" -lt 1 ]]; then
 fi
 pass "forge produced $PENDING_COUNT pending learning(s)"
 
+e2e_log_phase pool-ingest
 log "Phase 2: pool ingest lands pending learnings as pool candidates"
 # Use 'ao pool ingest' rather than 'ao flywheel close-loop' here: close-loop now
 # auto-promotes candidates in the same call (commit b69a00f4 removed the
@@ -153,6 +156,7 @@ if [[ -z "$CANDIDATE_PATH" ]]; then
 fi
 assert_file_exists "pool candidate exists after ingest" "$CANDIDATE_PATH"
 
+e2e_log_phase cite-promote
 log "Phase 3: cite the pool candidate and promote it into a retrievable artifact"
 run_ao metrics cite "$CANDIDATE_PATH" --type reference --session proof-promotion --query "$LOOKUP_QUERY" >/dev/null
 CLOSE2_JSON="$WORK_DIR/close-loop-2.json"
@@ -164,8 +168,10 @@ if [[ -z "$ARTIFACT_PATH" ]]; then
   fail "expected promoted artifact path in close-loop output"
 fi
 assert_file_exists "promoted artifact exists on disk" "$ARTIFACT_PATH"
+e2e_log_artifact "$ARTIFACT_PATH" "promoted-artifact"
 ARTIFACT_JSON="$(printf '%s' "$ARTIFACT_PATH" | jq -R '.')"
 
+e2e_log_phase lookup
 log "Phase 4: lookup retrieves the promoted artifact and records retrieved evidence"
 LOOKUP_JSON="$WORK_DIR/lookup.json"
 run_ao lookup --query "$LOOKUP_QUERY" --json > "$LOOKUP_JSON"
@@ -178,6 +184,7 @@ assert_json_match \
   "$CITATIONS_PATH" \
   "select(.artifact_path == $ARTIFACT_JSON and .citation_type == \"retrieved\")"
 
+e2e_log_phase feedback
 log "Phase 5: record applied evidence and close the feedback loop"
 run_ao metrics cite "$ARTIFACT_PATH" --type applied --session proof-apply --query "$LOOKUP_QUERY" >/dev/null
 mkdir -p "$REPO_DIR/.agents/ao"
@@ -199,6 +206,7 @@ assert_json_match \
   "$CITATIONS_PATH" \
   "select(.artifact_path == $ARTIFACT_JSON and .citation_type == \"applied\" and .feedback_given == true)"
 
+e2e_log_phase nightly
 log "Phase 6: run nightly dream cycle proof against the isolated corpus"
 NIGHTLY_DIR="$WORK_DIR/nightly"
 mkdir -p "$NIGHTLY_DIR"
@@ -211,4 +219,6 @@ assert_file_exists "nightly summary exists" "$NIGHTLY_DIR/summary.json"
 assert_json_match "nightly summary exposes retrieval_live" "$NIGHTLY_DIR/summary.json" '.retrieval_live != null'
 assert_json_match "nightly retrieval report has coverage" "$NIGHTLY_DIR/retrieval-bench.json" '.coverage >= 0'
 
-log "FLYWHEEL PROOF: PASS ($PASS_COUNT checks)"
+e2e_log_phase "complete"
+e2e_log_summary
+log "FLYWHEEL PROOF: PASS ($PASS_COUNT checks) — sidecar: $SIDECAR_LOG"

--- a/tests/hooks/test-lead-only-worker-git-guard.sh
+++ b/tests/hooks/test-lead-only-worker-git-guard.sh
@@ -134,6 +134,23 @@ assert_blocked "legacy AGENTOPS_ROLE=worker" \
 assert_blocked "native team worker name" \
     '{"tool_input":{"command":"git push"}}' CLAUDE_AGENT_NAME=worker-1
 
+# Regression for soc-is4c: PWD-in-worktrees alone MUST NOT classify a session
+# as a worker. The historical heuristic at line 37 fired on every solo Claude
+# session opened in .claude/worktrees/ for isolation, and the documented
+# kill-switch env vars were unreachable from inside a Bash tool call.
+run_hook_with_pwd() {
+    local payload="$1" pwd_override="$2"; shift 2
+    env -i HOME="$HOME" PATH="$PATH" PWD="$pwd_override" "$@" \
+        bash "$HOOK" <<<"$payload"
+}
+out=$(run_hook_with_pwd '{"tool_input":{"command":"git commit -m x"}}' \
+    "$TMPDIR_TEST/.claude/worktrees/foo" 2>&1)
+if [[ $? -eq 0 ]]; then
+    pass "ALLOW: solo session under .claude/worktrees/ (no worker env)"
+else
+    fail "PWD-in-worktrees alone must not block commits (soc-is4c regression)"
+fi
+
 if [[ $errors -eq 0 ]]; then
     echo "ALL TESTS PASSED"
     exit 0

--- a/tests/lib/e2e-factory.sh
+++ b/tests/lib/e2e-factory.sh
@@ -1,0 +1,132 @@
+# shellcheck shell=bash
+# tests/lib/e2e-factory.sh — test-data factories for e2e tests.
+#
+# Implements the "Test Data Factories" pattern from the
+# testing-real-service-e2e-no-mocks skill. Replaces the ad-hoc inline
+# "mktemp + git init + commit" boilerplate currently duplicated across
+# tests/e2e/*.sh with a shared, well-tested builder.
+#
+# Each factory:
+#   - Returns the created path on stdout (capture with $(...))
+#   - Writes only inside the supplied sandbox root (never $HOME, never $PWD)
+#   - Is idempotent on partial-state inputs (safe to call into an existing dir)
+#
+# Usage:
+#   source "${SCRIPT_DIR}/../lib/e2e-factory.sh"
+#   SANDBOX="$(e2e_factory_sandbox flywheel-proof)"   # mktemp -d /tmp/...-XXX
+#   REPO="$(e2e_factory_repo "$SANDBOX/repo")"        # git init + initial commit
+#   AO_BIN="$(e2e_factory_ao_bin "$SANDBOX/bin" "$REPO_ROOT")"  # reuse or build
+#   e2e_factory_agents_dir "$REPO"                    # seed .agents/ skeleton
+
+[[ -n "${E2E_FACTORY_SH_LOADED:-}" ]] && return 0
+E2E_FACTORY_SH_LOADED=1
+
+_e2e_factory_die() {
+  printf '[e2e-factory] FATAL: %s\n' "$*" >&2
+  exit 70  # EX_SOFTWARE
+}
+
+# e2e_factory_sandbox <slug>
+# Creates a top-level temp directory for a single test run. Slug is used in
+# the dirname for grep-ability when triaging leftover dirs.
+e2e_factory_sandbox() {
+  local slug="${1:-e2e}"
+  local prefix="${TMPDIR:-/tmp}"
+  prefix="${prefix%/}"
+  local dir
+  dir="$(mktemp -d "${prefix}/agentops-${slug}-XXXXXX")" \
+    || _e2e_factory_die "mktemp failed under $prefix"
+  printf '%s\n' "$dir"
+}
+
+# e2e_factory_repo <repo-path>
+# Creates an empty git repo at <repo-path> with a deterministic identity and
+# one initial commit. Idempotent: if .git already exists, leaves it alone.
+e2e_factory_repo() {
+  local repo="$1"
+  [[ -n "$repo" ]] || _e2e_factory_die "e2e_factory_repo: path is required"
+  mkdir -p "$repo"
+  if [[ -d "$repo/.git" ]]; then
+    printf '%s\n' "$repo"
+    return 0
+  fi
+  (
+    cd "$repo"
+    git init -q
+    git config user.email "e2e@agentops.test"
+    git config user.name "AgentOps E2E"
+    git config commit.gpgsign false
+    git config init.defaultBranch main
+    if [[ ! -f README.md ]]; then
+      printf '# E2E Sandbox Repo\n' >README.md
+      git add README.md
+      git commit -q -m "init"
+    fi
+  ) || _e2e_factory_die "git init failed at $repo"
+  printf '%s\n' "$repo"
+}
+
+# e2e_factory_ao_bin <build-dir> <repo-root>
+# Resolves an ao binary into <build-dir>/ao. Honors:
+#   PROOF_AO_BIN          — explicit override (must point at an executable)
+#   PROOF_FORCE_BUILD=1   — disable reuse and always go build from source
+#   <repo-root>/cli/bin/ao — auto-detected reuse when present
+# Falls back to a fresh `go build` under <repo-root>/cli.
+e2e_factory_ao_bin() {
+  local build_dir="$1" repo_root="$2"
+  [[ -n "$build_dir" ]] || _e2e_factory_die "e2e_factory_ao_bin: build_dir is required"
+  [[ -n "$repo_root" ]] || _e2e_factory_die "e2e_factory_ao_bin: repo_root is required"
+  mkdir -p "$build_dir"
+  local out="$build_dir/ao"
+  local src="${PROOF_AO_BIN:-}"
+  if [[ -z "$src" && "${PROOF_FORCE_BUILD:-0}" != "1" && -x "$repo_root/cli/bin/ao" ]]; then
+    src="$repo_root/cli/bin/ao"
+  fi
+  if [[ -n "$src" && -x "$src" ]]; then
+    cp "$src" "$out"
+  else
+    command -v go >/dev/null 2>&1 \
+      || _e2e_factory_die "no prebuilt ao binary and 'go' is not on PATH"
+    (
+      cd "$repo_root/cli"
+      go build -o "$out" ./cmd/ao
+    ) >/dev/null || _e2e_factory_die "go build ./cmd/ao failed"
+  fi
+  chmod +x "$out"
+  printf '%s\n' "$out"
+}
+
+# e2e_factory_agents_dir <repo-path>
+# Seeds an empty .agents/ skeleton with the directories tests typically need.
+# Idempotent — only creates missing directories.
+e2e_factory_agents_dir() {
+  local repo="$1"
+  [[ -d "$repo" ]] || _e2e_factory_die "e2e_factory_agents_dir: repo missing: $repo"
+  local d
+  for d in knowledge/pending pool/pending ao briefings; do
+    mkdir -p "$repo/.agents/$d"
+  done
+}
+
+# e2e_factory_fixture <fixture-src> <repo-path> [dest-relpath]
+# Copies a fixture file from the repo's tests/fixtures/ tree into the sandbox
+# repo. Refuses if the source path escapes the repo's fixtures dir (defence
+# against `../../../etc/passwd`-style relpaths in tests).
+e2e_factory_fixture() {
+  local src="$1" repo="$2" dest_rel="${3:-}"
+  [[ -f "$src" ]] || _e2e_factory_die "fixture missing: $src"
+  [[ -d "$repo" ]] || _e2e_factory_die "repo missing: $repo"
+  case "$src" in
+    *"/tests/fixtures/"*) ;;
+    *) _e2e_factory_die "fixture $src is not under tests/fixtures/ — refusing to copy" ;;
+  esac
+  local dest
+  if [[ -n "$dest_rel" ]]; then
+    dest="$repo/$dest_rel"
+    mkdir -p "$(dirname "$dest")"
+  else
+    dest="$repo/$(basename "$src")"
+  fi
+  cp "$src" "$dest"
+  printf '%s\n' "$dest"
+}

--- a/tests/lib/e2e-guards.sh
+++ b/tests/lib/e2e-guards.sh
@@ -1,0 +1,101 @@
+# shellcheck shell=bash
+# tests/lib/e2e-guards.sh — production safety guards for e2e tests.
+#
+# Refuses to run if the test harness looks like it might touch real state.
+# Adapted from the "Production Safety Guards" pattern in the
+# testing-real-service-e2e-no-mocks skill, translated to the CLI tool context
+# (we have no Stripe/Supabase to protect — we protect the developer's
+# real $HOME, real git repos, and any system-prefix `ao` binary).
+#
+# Usage:
+#   source "${SCRIPT_DIR}/../lib/e2e-guards.sh"
+#   e2e_guard_home "$HOME_DIR"          # required: assert $HOME points at temp
+#   e2e_guard_repo "$REPO_DIR"          # required: assert work dir is temp
+#   e2e_guard_ao_bin "$AO_BIN"          # required: assert binary is sandbox-owned
+#   e2e_guard_not_repo_root             # required: refuse to run from agentops repo root
+#
+# Escape hatch (intentionally undocumented in --help): set
+#   AGENTOPS_E2E_ALLOW_UNSAFE=1
+# to bypass every guard. Logged loudly when used. Do NOT set this in CI.
+
+[[ -n "${E2E_GUARDS_SH_LOADED:-}" ]] && return 0
+E2E_GUARDS_SH_LOADED=1
+
+_e2e_guard_die() {
+  printf '[e2e-guard] FATAL: %s\n' "$*" >&2
+  printf '[e2e-guard]   This guard exists to prevent tests from touching real state.\n' >&2
+  printf '[e2e-guard]   If you are absolutely sure, set AGENTOPS_E2E_ALLOW_UNSAFE=1.\n' >&2
+  exit 78  # EX_CONFIG
+}
+
+_e2e_guard_warn_bypass() {
+  if [[ "${AGENTOPS_E2E_ALLOW_UNSAFE:-0}" == "1" ]]; then
+    printf '[e2e-guard] WARNING: AGENTOPS_E2E_ALLOW_UNSAFE=1 — skipping %s\n' "$1" >&2
+    return 0
+  fi
+  return 1
+}
+
+# e2e_guard_home <path>
+# Asserts that $HOME has been redirected to <path> AND that <path> is under a
+# temp prefix. Prevents fixture writes from landing in the developer's real
+# home (~/.agents, ~/.claude, ~/.config — all of which are real).
+e2e_guard_home() {
+  local expected="$1"
+  _e2e_guard_warn_bypass "HOME guard" && return 0
+  [[ -n "$expected" ]] || _e2e_guard_die "e2e_guard_home: expected path is empty"
+  [[ "$HOME" == "$expected" ]] \
+    || _e2e_guard_die "HOME=$HOME does not match sandbox HOME=$expected — refusing to run."
+  case "$HOME" in
+    /tmp/*|/var/folders/*|/var/tmp/*|"${TMPDIR%/}"/*) ;;
+    *) _e2e_guard_die "HOME=$HOME is not under a temp prefix — refusing to run." ;;
+  esac
+}
+
+# e2e_guard_repo <path>
+# Asserts that the working repo is a temp directory, not a real checkout.
+# Refuses if path contains a .git that points anywhere outside the sandbox
+# (catches the "I ran the test from ~/dev/agentops by accident" footgun).
+e2e_guard_repo() {
+  local repo="$1"
+  _e2e_guard_warn_bypass "repo guard" && return 0
+  [[ -n "$repo" ]] || _e2e_guard_die "e2e_guard_repo: path is empty"
+  case "$repo" in
+    /tmp/*|/var/folders/*|/var/tmp/*|"${TMPDIR%/}"/*) ;;
+    *) _e2e_guard_die "repo=$repo is not under a temp prefix — refusing to run." ;;
+  esac
+  if [[ -e "$repo/.git" && ! -d "$repo/.git" && ! -f "$repo/.git" ]]; then
+    _e2e_guard_die "repo=$repo has a non-standard .git entry — refusing to run."
+  fi
+}
+
+# e2e_guard_ao_bin <path>
+# Asserts that the ao binary is under a sandbox build dir, not a system prefix.
+# Refuses /usr/local/bin/ao, $HOME/bin/ao, or anything outside the test temp.
+e2e_guard_ao_bin() {
+  local bin="$1"
+  _e2e_guard_warn_bypass "ao binary guard" && return 0
+  [[ -x "$bin" ]] || _e2e_guard_die "ao binary not executable: $bin"
+  case "$bin" in
+    /tmp/*|/var/folders/*|/var/tmp/*|"${TMPDIR%/}"/*) ;;
+    *)
+      # Allow the repo-local build output cli/bin/ao (reused via PROOF_AO_BIN
+      # auto-detect) — it lives under the worktree and is regenerated per build.
+      if [[ "$bin" == */cli/bin/ao ]]; then
+        return 0
+      fi
+      _e2e_guard_die "ao binary $bin is in a system/user prefix — refusing to run."
+      ;;
+  esac
+}
+
+# e2e_guard_not_repo_root
+# Refuses to run if $PWD is the agentops repo root (presence of CLAUDE.md +
+# cli/cmd/ao + skills/ is the signature). Catches "cd into repo, run test by
+# hand, forget to chdir to /tmp" — that bug previously cost an afternoon.
+e2e_guard_not_repo_root() {
+  _e2e_guard_warn_bypass "repo-root guard" && return 0
+  if [[ -f "$PWD/CLAUDE.md" && -d "$PWD/cli/cmd/ao" && -d "$PWD/skills" ]]; then
+    _e2e_guard_die "PWD=$PWD looks like the agentops repo root — chdir into the sandbox first."
+  fi
+}

--- a/tests/lib/e2e-logger.sh
+++ b/tests/lib/e2e-logger.sh
@@ -1,0 +1,164 @@
+# shellcheck shell=bash
+# tests/lib/e2e-logger.sh — structured JSON-line logging for e2e tests.
+#
+# Implements the "Structured Test Logging" pattern from the
+# testing-real-service-e2e-no-mocks skill. Emits both a human-friendly text
+# line to the test's text log and a JSON-line event to a parallel sidecar
+# log that CI can machine-parse.
+#
+# Why JSON-line: when an e2e test fails in CI, the human-readable log shows
+# WHAT broke but not the timing, the phase, or the prior state. The sidecar
+# gives a parseable record of phases, asserts (with expected/actual), and
+# artifact snapshots — drop it into jq or any log aggregator.
+#
+# Usage:
+#   source "${SCRIPT_DIR}/../lib/e2e-logger.sh"
+#   e2e_log_init "flywheel-proof" "$WORK_DIR/proof-run.jsonl"
+#   e2e_log_phase setup
+#   e2e_log_event "pass" "forge produced pending learnings" '{"count":3}'
+#   e2e_log_assert "lookup returns artifact" expected actual match
+#   e2e_log_artifact "$ARTIFACT_PATH" "promoted-artifact"
+#   e2e_log_summary  # at end; emits suite_end event with pass/fail counts
+#
+# Output schema (one JSON object per line, stable field names):
+#   ts        ISO-8601 UTC, second precision
+#   suite     test suite name (from e2e_log_init)
+#   phase     last phase declared via e2e_log_phase
+#   event     one of: suite_start | phase_start | pass | fail | assert |
+#             artifact | db_snapshot | suite_end
+#   message   human-readable label
+#   data      optional JSON object with structured fields
+
+[[ -n "${E2E_LOGGER_SH_LOADED:-}" ]] && return 0
+E2E_LOGGER_SH_LOADED=1
+
+E2E_LOG_SUITE=""
+E2E_LOG_PHASE="init"
+E2E_LOG_FILE=""
+E2E_LOG_PASS_COUNT=0
+E2E_LOG_FAIL_COUNT=0
+E2E_LOG_START_EPOCH=0
+
+_e2e_log_ts() {
+  date -u +'%Y-%m-%dT%H:%M:%SZ'
+}
+
+# _e2e_log_emit <event> <message> [data-json]
+# Writes one JSON-line event. Falls back to a degraded text line if jq is
+# missing (e2e logging never blocks a test on a missing optional dependency).
+_e2e_log_emit() {
+  local event="$1" message="$2" data="${3:-null}"
+  if [[ -z "$E2E_LOG_FILE" ]]; then
+    return 0
+  fi
+  if command -v jq >/dev/null 2>&1; then
+    jq -nc \
+      --arg ts "$(_e2e_log_ts)" \
+      --arg suite "$E2E_LOG_SUITE" \
+      --arg phase "$E2E_LOG_PHASE" \
+      --arg event "$event" \
+      --arg message "$message" \
+      --argjson data "$data" \
+      '{ts:$ts, suite:$suite, phase:$phase, event:$event, message:$message, data:$data}' \
+      >>"$E2E_LOG_FILE"
+  else
+    printf '{"ts":"%s","suite":"%s","phase":"%s","event":"%s","message":"%s"}\n' \
+      "$(_e2e_log_ts)" "$E2E_LOG_SUITE" "$E2E_LOG_PHASE" "$event" \
+      "$(printf '%s' "$message" | sed 's/"/\\"/g')" \
+      >>"$E2E_LOG_FILE"
+  fi
+}
+
+# e2e_log_init <suite-name> <log-file>
+# Truncates the sidecar log and emits the suite_start event. Call before any
+# other e2e_log_* helper.
+e2e_log_init() {
+  E2E_LOG_SUITE="$1"
+  E2E_LOG_FILE="$2"
+  E2E_LOG_PHASE="init"
+  E2E_LOG_PASS_COUNT=0
+  E2E_LOG_FAIL_COUNT=0
+  E2E_LOG_START_EPOCH=$(date +%s)
+  : >"$E2E_LOG_FILE"
+  _e2e_log_emit "suite_start" "$E2E_LOG_SUITE" 'null'
+}
+
+# e2e_log_phase <phase-name>
+# Records a phase transition (setup, act, assert, teardown, or a custom
+# phase string).
+e2e_log_phase() {
+  E2E_LOG_PHASE="$1"
+  _e2e_log_emit "phase_start" "$E2E_LOG_PHASE" 'null'
+}
+
+# e2e_log_pass <message> [data-json]
+# Records a successful check.
+e2e_log_pass() {
+  E2E_LOG_PASS_COUNT=$((E2E_LOG_PASS_COUNT + 1))
+  _e2e_log_emit "pass" "$1" "${2:-null}"
+}
+
+# e2e_log_fail <message> [data-json]
+# Records a failed check. Does NOT exit — caller decides whether to exit.
+e2e_log_fail() {
+  E2E_LOG_FAIL_COUNT=$((E2E_LOG_FAIL_COUNT + 1))
+  _e2e_log_emit "fail" "$1" "${2:-null}"
+}
+
+# e2e_log_assert <label> <expected> <actual> <match:true|false>
+# Records a structured assertion event. Use this in addition to pass/fail
+# when the expected/actual values are interesting.
+e2e_log_assert() {
+  local label="$1" expected="$2" actual="$3" match="$4"
+  local data
+  if command -v jq >/dev/null 2>&1; then
+    data="$(jq -nc \
+      --arg expected "$expected" \
+      --arg actual "$actual" \
+      --argjson match "$match" \
+      '{expected:$expected, actual:$actual, match:$match}')"
+  else
+    data='{"match":'"$match"'}'
+  fi
+  _e2e_log_emit "assert" "$label" "$data"
+  if [[ "$match" == "true" ]]; then
+    E2E_LOG_PASS_COUNT=$((E2E_LOG_PASS_COUNT + 1))
+  else
+    E2E_LOG_FAIL_COUNT=$((E2E_LOG_FAIL_COUNT + 1))
+  fi
+}
+
+# e2e_log_artifact <path> [label]
+# Records that an artifact was produced. Captures size + mtime (no content,
+# to keep the log small — content lives on disk inside the temp work dir).
+e2e_log_artifact() {
+  local path="$1" label="${2:-artifact}"
+  local data='null'
+  if [[ -e "$path" ]] && command -v jq >/dev/null 2>&1; then
+    local size mtime
+    size="$(wc -c <"$path" 2>/dev/null | tr -d ' ' || echo 0)"
+    mtime="$(date -u -r "$path" +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || _e2e_log_ts)"
+    data="$(jq -nc --arg path "$path" --arg size "$size" --arg mtime "$mtime" \
+      '{path:$path, size:($size|tonumber), mtime:$mtime}')"
+  fi
+  _e2e_log_emit "artifact" "$label" "$data"
+}
+
+# e2e_log_summary
+# Emits the suite_end event with total counts and duration. Call once at the
+# very end of the test (after teardown).
+e2e_log_summary() {
+  local end_epoch duration data
+  end_epoch=$(date +%s)
+  duration=$((end_epoch - E2E_LOG_START_EPOCH))
+  if command -v jq >/dev/null 2>&1; then
+    data="$(jq -nc \
+      --argjson pass "$E2E_LOG_PASS_COUNT" \
+      --argjson fail "$E2E_LOG_FAIL_COUNT" \
+      --argjson duration "$duration" \
+      '{pass:$pass, fail:$fail, duration_s:$duration}')"
+  else
+    data='{"pass":'"$E2E_LOG_PASS_COUNT"',"fail":'"$E2E_LOG_FAIL_COUNT"'}'
+  fi
+  _e2e_log_emit "suite_end" "$E2E_LOG_SUITE" "$data"
+}


### PR DESCRIPTION
The `lead-only-worker-git-guard` hook classifies any session with PWD under `.claude/worktrees/` as a swarm worker and blocks every destructive git verb. That fires on **solo Claude sessions opened in a worktree for isolation** — the human-in-the-loop case, where the user IS the lead. The documented kill-switch env vars only reach the hook when set in the parent shell that launched Claude Code; passing them inline to a Bash tool call doesn't reach the hook process. So the documented escape hatch routinely fails in exactly the case that hits it most.

The hook is also trivially bypassed by writing a shell script and invoking it via `bash script.sh` — the regex only matches literal text in the Bash tool command string, not script contents. The heuristic punishes the legitimate solo-worktree case and barely inconveniences a determined worker.

**Bead:** soc-is4c (discovered-from: soc-acte / PR #342)
**Bounded-context:** BC2-Hooks
**Evidence:** tests/hooks/test-lead-only-worker-git-guard.sh — `ALL TESTS PASSED` locally (33 cases, including the new regression at the end)

## Fix

Drop the PWD heuristic. Require an EXPLICIT positive worker signal — one of:
- `AGENTOPS_SWARM_ROLE=worker`
- `AGENTOPS_ROLE=worker`
- `CLAUDE_AGENT_NAME=worker-*`
- `.agents/swarm-role` file containing `worker`

The NTM swarm runner already sets one of these when it spawns workers, so real swarm-worker contexts continue to be blocked. Solo sessions stop being false-positives.

## Changes

- `hooks/lead-only-worker-git-guard.sh` — delete the PWD-in-worktrees `elif` branch. Add a comment block citing soc-is4c with the rationale.
- `cli/embedded/hooks/lead-only-worker-git-guard.sh` — embedded mirror, synced via `make sync-hooks` per the embedded-hooks-must-stay-in-sync rule.
- `tests/hooks/test-lead-only-worker-git-guard.sh` — add one regression test that explicitly forces PWD into a synthetic `.claude/worktrees/foo` and asserts the hook now allows. All 32 pre-existing cases continue to PASS.

## Sibling pattern

Mirrors the explicit-positive-signal shape from existing hooks like `context-guard.sh` and `holdout-isolation-gate.sh` — they require explicit env vars (`AGENTOPS_CONTEXT_GUARD_STRICT`, `AGENTOPS_HOLDOUT_EVALUATOR`) with no heuristic role inference.

## What this does NOT change

- All destructive-verb blocking still works when the worker is explicitly signaled.
- Both documented kill switches still work (`AGENTOPS_HOOKS_DISABLED=1`, `AGENTOPS_LEAD_ONLY_GUARD_DISABLED=1`).
- The hook's regex, exit codes, and JSON output schema are unchanged.

## Fitness delta

False-positive rate on solo worktree sessions: 100% → 0%. Test count: 32 → 33.