### PR TITLE
chore(ci): retire 2 zero-signal CI validators (soc-n3gh)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -772,40 +772,11 @@ jobs:
           path: evals/workbench/scorecard-latest.json
           if-no-files-found: warn
 
-  practice-citations:
-    # Non-blocking strict advisory gate: walks repo Primitives (skills, hooks,
-    # evals, CLI commands, schemas, and scripts with declarations) and reports
-    # missing or invalid `practices: [slug, ...]` citations derived from
-    # PRACTICE.md. Promotes to required after one clean backfill cycle.
-    needs: [changes]
-    if: needs.changes.outputs.skills == 'true' || needs.changes.outputs.hooks == 'true' || needs.changes.outputs.eval == 'true' || needs.changes.outputs.go == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.markdown == 'true'
-    name: practice-citations (advisory)
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Run practice citation report
-        run: |
-          chmod +x scripts/validate-practice-citations.sh
-          set +e
-          ./scripts/validate-practice-citations.sh --strict --json > practice-citations.json
-          json_rc=$?
-          ./scripts/validate-practice-citations.sh --strict
-          text_rc=$?
-          if [ "$json_rc" -ne 0 ]; then
-            exit "$json_rc"
-          fi
-          exit "$text_rc"
-
-      - name: Upload practice citation report
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: practice-citations-report
-          path: practice-citations.json
-          retention-days: 14
-          if-no-files-found: warn
+  # practice-citations RETIRED 2026-05-19. Advisory job with 79% failure rate
+  # across 19 recent runs (15/19 fail); blocked zero merges; trained
+  # operators to ignore CI red. The underlying validator script remains
+  # available at scripts/validate-practice-citations.sh for ad-hoc local
+  # use. Audit rationale: see "CI Validator Audit" session 2026-05-18.
 
   factory-claim-ledger-strict:
     # Wave 1C of epic soc-e4ulx (Reconciliation Engine).
@@ -1663,17 +1634,13 @@ jobs:
           chmod +x tests/skills/run-all.sh
           bash tests/skills/run-all.sh
 
-  learning-coherence:
-    needs: [changes]
-    if: needs.changes.outputs.learning == 'true' || needs.changes.outputs.ci == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Validate learning file quality
-        run: |
-          chmod +x scripts/validate-learning-coherence.sh
-          bash scripts/validate-learning-coherence.sh .agents/learnings
+  # learning-coherence RETIRED 2026-05-19. Dead-by-design: triggered only by
+  # changes to .agents/learnings/** paths, which are gitignored — the path
+  # filter can never match in a PR diff. 19/19 runs in the audit window
+  # were "skipped"; zero positive signal across the validator's lifetime.
+  # The validator script remains at scripts/validate-learning-coherence.sh
+  # for ad-hoc local use against the operator's .agents/learnings/ corpus.
+  # Audit rationale: see "CI Validator Audit" session 2026-05-18.
 
   bats-tests:
     needs: [changes]
@@ -1768,7 +1735,7 @@ jobs:
           cli/bin/ao goals trace --orphans || echo "WARN: trace --orphans found issues (warn-only, F1.6 / soc-58nt.1.9)"
 
   summary:
-    needs: [changes, doc-release-gate, smoke-test, hook-preflight, pre-push-gate-wired, agentops-eval-baseline-audit, standards-injector-completeness, validate-hooks-doc-parity, hook-output-schema-lint, validate-ci-policy-parity, validate-codex-runtime-sections, validate-codex-generated-artifacts, validate-codex-backbone-prompts, validate-codex-override-coverage, validate-codex-rpi-contract, validate-codex-lifecycle-guards, validate-codex-parity-drift, validate-quarantine-empty, validate-registry-drift, validate-bounded-contexts-drift, validate-skill-domain-map-golden, validate-flywheel-proof, validate-goals-validate, validate-wiring-closure, validate-corpus-freshness, validate-flywheel-compounding-snapshot, validate-factory-yield-ledger, validate-finding-registry, validate-factory-admission, validate-contracts-structural-floor, validate-docs-learning-references, validate-three-gap-supergate, validate-headless-runtime-skills, validate-skill-frontmatter, validate-context-map-drift, embedded-sync, cli-docs-parity, registry-check, agentops-contract-canaries, eval-workbench-verify, factory-claim-ledger-strict, practice-citations, eval-skill-delta, shellcheck, markdownlint, security-scan, security-toolchain-gate, skill-integrity, skill-schema, skill-dependency-check, contract-compatibility-gate, memrl-health, plugin-load-test, retrieval-quality, go-build, windows-smoke, cli-integration, json-flag-consistency, file-manifest-overlap, doctor-check, skill-lint, learning-coherence, bats-tests, check-test-staleness, swarm-evidence, executable-spec-link-integrity]
+    needs: [changes, doc-release-gate, smoke-test, hook-preflight, pre-push-gate-wired, agentops-eval-baseline-audit, standards-injector-completeness, validate-hooks-doc-parity, hook-output-schema-lint, validate-ci-policy-parity, validate-codex-runtime-sections, validate-codex-generated-artifacts, validate-codex-backbone-prompts, validate-codex-override-coverage, validate-codex-rpi-contract, validate-codex-lifecycle-guards, validate-codex-parity-drift, validate-quarantine-empty, validate-registry-drift, validate-bounded-contexts-drift, validate-skill-domain-map-golden, validate-flywheel-proof, validate-goals-validate, validate-wiring-closure, validate-corpus-freshness, validate-flywheel-compounding-snapshot, validate-factory-yield-ledger, validate-finding-registry, validate-factory-admission, validate-contracts-structural-floor, validate-docs-learning-references, validate-three-gap-supergate, validate-headless-runtime-skills, validate-skill-frontmatter, validate-context-map-drift, embedded-sync, cli-docs-parity, registry-check, agentops-contract-canaries, eval-workbench-verify, factory-claim-ledger-strict, eval-skill-delta, shellcheck, markdownlint, security-scan, security-toolchain-gate, skill-integrity, skill-schema, skill-dependency-check, contract-compatibility-gate, memrl-health, plugin-load-test, retrieval-quality, go-build, windows-smoke, cli-integration, json-flag-consistency, file-manifest-overlap, doctor-check, skill-lint, bats-tests, check-test-staleness, swarm-evidence, executable-spec-link-integrity]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -1815,7 +1782,6 @@ jobs:
           echo "agentops-contract-canaries: ${{ needs.agentops-contract-canaries.result }}"
           echo "eval-workbench-verify: ${{ needs.eval-workbench-verify.result }}"
           echo "factory-claim-ledger-strict: ${{ needs.factory-claim-ledger-strict.result }}"
-          echo "practice-citations: ${{ needs.practice-citations.result }}"
           echo "eval-skill-delta: ${{ needs.eval-skill-delta.result }}"
           echo "shellcheck: ${{ needs.shellcheck.result }}"
           echo "markdownlint: ${{ needs.markdownlint.result }}"
@@ -1835,7 +1801,6 @@ jobs:
           echo "file-manifest-overlap: ${{ needs.file-manifest-overlap.result }}"
           echo "doctor-check: ${{ needs.doctor-check.result }}"
           echo "skill-lint: ${{ needs.skill-lint.result }}"
-          echo "learning-coherence: ${{ needs.learning-coherence.result }}"
           echo "bats-tests: ${{ needs.bats-tests.result }}"
           echo "check-test-staleness: ${{ needs.check-test-staleness.result }}"
           echo "swarm-evidence: ${{ needs.swarm-evidence.result }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,7 +324,6 @@ This repo has a canonical root worktree. It owns the common `.git` directory and
 | **agentops-contract-canaries** | Runs the official deterministic AgentOps contract canary test list in `tests/canaries/agentops-core-official.txt` | Stable contract canary regression, selected suite failure, or missing canary dependency |
 | **eval-workbench-verify** | Behavioral eval workbench golden state, task scoring scripts, and suite structure | Broken workbench fixture, failing golden-state tests, or malformed eval suite JSON |
 | **factory-claim-ledger-strict** | Runs `bash scripts/check-factory-claim-ledger.sh` and emits a structured observation artifact mapping verdict + surfaces_touched per PR (soc-lmww1, Wave 1C) | Non-blocking (`continue-on-error: true`); claim-ledger drift surfaces in observation JSON. Promotion to blocking is the Wave 1E concern documented in-job |
-| **practice-citations** (non-blocking) | Walks Primitives (skills/hooks/evals/CLI/schemas and scripts with declarations) for `practices: [slug,...]` derivation from PRACTICE-REGISTRY.md; reports missing or invalid slug citations | Non-blocking (`continue-on-error: true`); strict advisory initially. Promotes to required after one clean backfill cycle |
 | **eval-skill-delta** | Eval skill-delta CI gate validates skill-on vs skill-off delta infrastructure | Broken delta scorecard, missing harness, or malformed A/B config |
 | **shellcheck** | All `.sh` files pass ShellCheck at error severity | Unquoted variables, missing `set -euo pipefail` |
 | **markdownlint** | Markdown style/lint rules pass for repository docs | Docs formatting regressions not caught by link checks |
@@ -344,7 +343,6 @@ This repo has a canonical root worktree. It owns the common `.git` directory and
 | **file-manifest-overlap** | No file path conflicts between workers/skills | Two skills claim the same output file |
 | **doctor-check** (non-blocking) | `ao doctor` runs without error on built binary | Non-blocking (`continue-on-error: true`) |
 | **skill-lint** | Skill line limits, required sections, Claude feature coverage | Judgment-tier skill exceeds 600 lines; missing `## Examples` in user-facing skill |
-| **learning-coherence** | Learning files have valid frontmatter and are not garbage/hallucinated | Auto-extracted learnings with no recognized fields or boilerplate content |
 | **bats-tests** | BATS integration tests for shell scripts pass | Hook or script behavioral regression |
 | **check-test-staleness** (non-blocking) | Detects stale/abandoned test files | Non-blocking (`continue-on-error: true`) |
 | **swarm-evidence** (non-blocking) | Swarm evidence files and file manifests are valid | Non-blocking (`continue-on-error: true`); informational artifact validation only |

--- a/docs/contracts/ci-jobs.yaml
+++ b/docs/contracts/ci-jobs.yaml
@@ -41,9 +41,6 @@ jobs:
 - name: hook-output-schema-lint
   reason: Hooks emit only the safely-portable PreToolUse output subset both Claude and Codex CLI accept
   failure: Using `hookSpecificOutput.updatedInput` (silently dropped by Codex CLI 0.128.0+)
-- name: learning-coherence
-  reason: Learning files have valid frontmatter and are not garbage/hallucinated
-  failure: Auto-extracted learnings with no recognized fields or boilerplate content
 - name: markdownlint
   reason: Markdown style/lint rules pass for repository docs
   failure: Docs formatting regressions not caught by link checks
@@ -53,9 +50,6 @@ jobs:
 - name: plugin-load-test
   reason: No symlinks anywhere in the repo; manifests valid; plugin structure correct
   failure: Creating symlinks instead of real file copies
-- name: practice-citations
-  reason: 'Walks Primitives (skills/hooks/evals/CLI/schemas and scripts with declarations) for `practices: [slug,...]` derivation from PRACTICE-REGISTRY.md; reports missing or invalid slug citations'
-  failure: 'Non-blocking (`continue-on-error: true`); strict advisory initially. Promotes to required after one clean backfill cycle'
 - name: pre-push-gate-wired
   reason: '`.githooks/pre-push` invokes `scripts/pre-push-gate.sh`; sandbox push smoke proves the hook fires as a single fast pass, replays refspec stdin, and updates the remote ref'
   failure: Editing the hook chain without re-running `scripts/check-pre-push-gate-wired.sh --dry-run-smoke`
@@ -194,5 +188,3 @@ jobs:
 - name: json-flag-consistency
   reason: All `--json` flags produce valid JSON with consistent format
   failure: Missing `--json` support on a new command
-# extracted 65 jobs
-


### PR DESCRIPTION
## What

First execution of the **CI Validator Audit** from this session (post #346 ship.sh wrapper). Retires 2 of 67 validators identified as zero-positive-signal across 19 recent runs.

## Retiring

| Job | Why |
|---|---|
| **`practice-citations`** (advisory) | 15/19 failure rate (79%); advisory so blocks zero merges. Trains operators to ignore CI red — actively harmful to signal hygiene. Same retirement class as `agentops-eval-advisory` (PR #300). |
| **`learning-coherence`** | 0/19 runs in audit window. Dead-by-design: path filter requires `.agents/learnings/**` but `.agents/` is gitignored — filter can never match in PR diffs. |

## Not retiring (yet)

- **`contract-compatibility-gate`** — 17/19 skipped but 2/2 success when run; investigate consolidation later
- **`registry-check`** — 63% failure rate but catches real drift; `ship.sh` (PR #346) auto-regen should drop the rate. Re-audit in 30 days.

## Changes

- Delete both job blocks from `.github/workflows/validate.yml` (replaced with comment tombstones citing the audit rationale)
- Remove names from `summary.needs` list
- Remove `echo` lines from summary step
- Remove entries from `docs/contracts/ci-jobs.yaml` (65 → 63 jobs)
- Regenerate `AGENTS.md` CI Jobs table via `scripts/generate-ci-jobs-table.sh --write` (63 + 2 header = 65 rows)

Underlying validator scripts remain at `scripts/validate-practice-citations.sh` and `scripts/validate-learning-coherence.sh` for ad-hoc local use.

## Validation

- ✅ `scripts/generate-ci-jobs-table.sh --check`: PASS (65 rows)
- ✅ `scripts/pre-push-gate.sh --fast`: passed
- ⚠️ Full pre-push gate: 3 failures — all in pre-existing flake surfaces (`worktree disposition` rule on non-main branch, `agentops-eval-canaries` flake, transient `skill-lint-suite` interaction). **None caused by this PR.** Itself evidence of the audit's correctness — the noise this PR identifies is the same noise blocking this PR.

## Net

67 → 65 jobs (~3% reduction). Conservative first cut. Bigger wins in the 5-validator inventory-consistency consolidation (separate PR, to follow).

🤖 First execution of the CI Validator Audit from session 2026-05-18