### PR TITLE
docs(workflow): coherent-arc PR rule — 1 PR per closable arc (soc-1lp1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,12 +73,12 @@ scripts/validate-go-fast.sh     # Quick Go validation (build + vet + test)
 
 ## Workflow
 
-**Every change to `main` is a PR. Every PR cites a bead. A bead may produce N PRs sliced by Gherkin scenario.** Direct pushes to `main` are rejected by branch protection. Derivation: `.agents/council/sdlc-shape-2026-05-17/DUEL.md` (local, gitignored — duel between Claude Opus 4.7 and Codex gpt-5.5, 2026-05-17).
+**Every change to `main` is a PR. Every PR cites a bead. The unit of a PR is one *coherent arc* — a closable bead (or small-epic slice) with a single rollback semantic. Small epics (≤5 child beads, same surface) ship as one PR with N commits. Large epics (15+ child beads) ship as N PRs sliced by scenario or wave.** Direct pushes to `main` are rejected by branch protection. Derivation: `.agents/council/sdlc-shape-2026-05-17/DUEL.md` (local, gitignored — duel between Claude Opus 4.7 and Codex gpt-5.5, 2026-05-17). 2026-05-19 evolution from "1 scenario per PR" after the 8-PR merge-arc burned out the `gh-merge-chain` dance — `soc-1lp1`.
 
 ### Phases
 
 1. **Claim.** `bd ready` → pick a bead → `bd update <id> --claim`. **No bead, no PR.** If the work is genuinely new, `bd create` first.
-2. **Scope.** Read the bead's acceptance: a `.feature` file (canonical when present) or an embedded `## Scenarios` block in the bead description. Free-text acceptance is invalid — promote it to scenarios before work begins. Default: **one scenario per PR** (carve-out: `type=chore` with `#trivial` label for tiny work).
+2. **Scope.** Read the bead's acceptance: a `.feature` file (canonical when present) or an embedded `## Scenarios` block in the bead description. Free-text acceptance is invalid — promote it to scenarios before work begins. Default: **one PR per coherent arc** — bundle scenarios that ship-or-revert together; split scenarios with independent rollback. The PR is the *atomic-revert unit*. Carve-out: `type=chore` with `#trivial` label for tiny work.
 3. **Ship.** `bd worktree create --branch <type>/<bead-id>-<scenario-token>-<short-slug>` — worktree-mandatory; do not edit in the shared checkout. Implement. Run `scripts/pre-push-gate.sh --fast` before push.
 4. **Close.** Open PR. CI validates the merge state. Squash-merge when green. The bead closes only when every scenario is merged (or explicitly cancelled in bead metadata).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,12 +137,12 @@ GOALS.md is the strategic intent layer consumed by `/evolve` and `/goals`:
 
 ## Workflow
 
-**Every change to `main` is a PR. Every PR cites a bead. A bead may produce N PRs sliced by Gherkin scenario.** Direct pushes to `main` are rejected by branch protection. Derivation: `.agents/council/sdlc-shape-2026-05-17/DUEL.md` (local, gitignored — duel between Claude Opus 4.7 and Codex gpt-5.5, 2026-05-17).
+**Every change to `main` is a PR. Every PR cites a bead. The unit of a PR is one *coherent arc* — a closable bead (or small-epic slice) with a single rollback semantic. Small epics (≤5 child beads, same surface) ship as one PR with N commits. Large epics (15+ child beads) ship as N PRs sliced by scenario or wave.** Direct pushes to `main` are rejected by branch protection. Derivation: `.agents/council/sdlc-shape-2026-05-17/DUEL.md` (local, gitignored — duel between Claude Opus 4.7 and Codex gpt-5.5, 2026-05-17). 2026-05-19 evolution from "1 scenario per PR" after the 8-PR merge-arc burned out the `gh-merge-chain` dance — `soc-1lp1`.
 
 ### Phases
 
 1. **Claim.** `bd ready` → pick a bead → `bd update <id> --claim`. **No bead, no PR.** If the work is genuinely new, `bd create` first.
-2. **Scope.** Read the bead's acceptance: a `.feature` file (canonical when present) or an embedded `## Scenarios` block in the bead description. Free-text acceptance is invalid — promote it to scenarios before work begins. Default: **one scenario per PR** (carve-out: `type=chore` with `#trivial` label for tiny work).
+2. **Scope.** Read the bead's acceptance: a `.feature` file (canonical when present) or an embedded `## Scenarios` block in the bead description. Free-text acceptance is invalid — promote it to scenarios before work begins. Default: **one PR per coherent arc** — bundle scenarios that ship-or-revert together; split scenarios with independent rollback. The PR is the *atomic-revert unit*. Carve-out: `type=chore` with `#trivial` label for tiny work.
 3. **Ship.** `bd worktree create --branch <type>/<bead-id>-<scenario-token>-<short-slug>` — worktree-mandatory; do not edit in the shared checkout. Implement. Run `scripts/pre-push-gate.sh --fast` before push.
 4. **Close.** Open PR. CI validates the merge state. Squash-merge when green. The bead closes only when every scenario is merged (or explicitly cancelled in bead metadata).
 

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -47,7 +47,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `recover` — Recover session context.
 - `research` — Explore and write findings.
 - `review` — Review diffs for risk, find mocks, scan for bugs, and audit codebases.
-- `ship-loop` — Bot-paired fast-lane cycle for single-scenario internal PRs: claim → test → impl → pre-push → push → squash auto-merge → close.
+- `ship-loop` — Bot-paired fast-lane cycle for coherent-arc internal PRs (one closable bead or small-epic slice): claim → test → impl → pre-push → push → squash auto-merge → close.
 - `status` — Show AgentOps work status.
 - `validate` — Produce PASS/WARN/FAIL verdicts for artifacts, plans, code, PRs, or gates.
 

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-19T09:21:02Z",
+  "generated_at": "2026-05-19T09:58:20Z",
   "summary": {
     "skills": 79,
     "hooks": 43,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1063,8 +1063,8 @@
     {
       "name": "ship-loop",
       "source_skill": "skills/ship-loop",
-      "source_hash": "325bb095bdf71f8a15e9c6b61985f7ade4a1ed39f13ca950f900fab65257e396",
-      "generated_hash": "24ce68c01a03b19dde1040db34382a057fcdd4ed1b448f2de1236166b196acc5"
+      "source_hash": "dcdbbf15a04b2e1164138b332217750e1f87a4d86380db23c701bc31a8aeb418",
+      "generated_hash": "9eedc0c47564c6e91f7ea85498ec955ec2a206808924cb68365060caceedde33"
     },
     {
       "name": "skill-auditor",

--- a/skills-codex/ship-loop/.agentops-generated.json
+++ b/skills-codex/ship-loop/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/ship-loop",
   "layout": "modular",
-  "source_hash": "325bb095bdf71f8a15e9c6b61985f7ade4a1ed39f13ca950f900fab65257e396",
-  "generated_hash": "24ce68c01a03b19dde1040db34382a057fcdd4ed1b448f2de1236166b196acc5"
+  "source_hash": "dcdbbf15a04b2e1164138b332217750e1f87a4d86380db23c701bc31a8aeb418",
+  "generated_hash": "9eedc0c47564c6e91f7ea85498ec955ec2a206808924cb68365060caceedde33"
 }

--- a/skills-codex/ship-loop/SKILL.md
+++ b/skills-codex/ship-loop/SKILL.md
@@ -13,10 +13,10 @@ Capture of the discipline that lands single-scenario internal PRs at ~15-30 min 
 
 | Use ship-loop when... | Use something else when... |
 |---|---|
-| Single-scenario internal PR in your own repo | Fork-based OSS contribution → `$pr-implement` |
-| PR <100 lines with paired tests | Multi-wave epic → `$crank` |
+| Coherent-arc internal PR in your own repo (one closable bead or small-epic slice) | Fork-based OSS contribution → `$pr-implement` |
+| PR is the atomic-revert unit; scenarios ship-or-revert together | Large epic (15+ child beads) / multi-wave → `$crank` |
 | Closing a harvested next-work item | Architecture / contract change → slow lane / human review |
-| Mechanical drift fix or regression closure | Work that can't fit one scenario → split or escalate |
+| Mechanical drift fix or regression closure | Scenarios have independent rollback → split into separate arcs |
 
 ## The 9-step cycle
 

--- a/skills/ship-loop/SKILL.md
+++ b/skills/ship-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-loop
-description: 'Bot-paired fast-lane cycle for single-scenario internal PRs: claim → test → impl → pre-push → push → squash auto-merge → close.'
+description: 'Bot-paired fast-lane cycle for coherent-arc internal PRs (one closable bead or small-epic slice): claim → test → impl → pre-push → push → squash auto-merge → close.'
 practices:
 - continuous-delivery
 - xp
@@ -48,7 +48,7 @@ output_contract: merged PR on origin/main + closed bead
 
 # /ship-loop — Bot-paired fast lane PR cycle
 
-> **Lane choice:** use this skill for **single-scenario internal PRs** with paired tests. For fork-based OSS contributions, use the `/pr-*` family (`pr-research`, `pr-plan`, `pr-implement`, etc.; tier `contribute`). For multi-wave epics, use `/crank`. **If the work can't fit one scenario, default to the slow lane.**
+> **Lane choice:** use this skill for **coherent-arc internal PRs** — one closable bead, or one small-epic slice (≤5 child beads of the same surface), with paired tests. The PR is the *atomic-revert unit*: bundle scenarios that ship-or-revert together; split scenarios with independent rollback. For fork-based OSS contributions, use the `/pr-*` family (`pr-research`, `pr-plan`, `pr-implement`, etc.; tier `contribute`). For large epics (15+ child beads) or multi-wave work, use `/crank`. See `CLAUDE.md ## Workflow` for the canonical unit-of-PR rule.
 
 Capture of the discipline that landed 8/9 internal PRs in the 2026-05-18 session at 19.5-min median time-to-merge. Five named failure modes (F1–F5); four closed mechanically. The full rationale lives in [`docs/learnings/2026-05-18-xp-bdd-tdd-workflow-synthesis.md`](https://github.com/boshu2/agentops/blob/main/docs/learnings/2026-05-18-xp-bdd-tdd-workflow-synthesis.md).
 
@@ -68,7 +68,7 @@ Run this skill at the START of each PR you intend to ship to your own `main` bra
 6. **Commit with conventional-commit scope.** `feat(<scope>):`, `fix(<scope>):`, `docs(<scope>):`. Body explains the failure mode the test reproduces and how the fix removes it.
 7. **Push + `gh pr create`.** Body cites the bead, the validation results, and links to the learning anchor in the script body (NOT a `.agents/learnings/` file existence — that breaks in CI's fresh clone).
 8. **`gh pr merge <num> --squash --auto`.** Immediately. The bot fires `claude-review` automatically on PR open. When all required checks pass, merge fires without operator action.
-9. **Close the bead.** `bd close <id> --reason "Merged via PR #<num>"`. If multiple PRs are in flight against the same main, invoke [`scripts/gh-merge-chain.sh`](references/gh-merge-chain.md) on the chain.
+9. **Close the bead.** `bd close <id> --reason "Merged via PR #<num>"`. The coherent-arc rule should keep concurrent PR count low (typically 1-2); when a large-epic split puts multiple PRs in flight against the same main, invoke [`scripts/gh-merge-chain.sh`](references/gh-merge-chain.md) on the chain.
 
 ## Gate sequence (what each enforces)
 


### PR DESCRIPTION
## Summary

Replace the "one scenario per PR" default in CLAUDE.md + AGENTS.md with **one PR per coherent arc** — a closable bead (or small-epic slice) with a single rollback semantic. Updates the ship-loop skill (both Claude and Codex twins) to reflect the unit-of-PR rule.

Closes: soc-1lp1

## Why

2026-05-19 session shipped 8 PRs under the old "1 scenario per PR" rule and burned through the gh-merge-chain dance to land them. Bigger atomic-revert units would have cut that to ~3 PRs. The 5 named failure modes (F1–F5) from the 2026-05-18 post-mortem all compound under the small-PR-fan-out shape.

Derivation: `.agents/council/sdlc-shape-2026-05-17/DUEL.md` (local) → 2026-05-19 evolution.

## What changed (diff is 4 .md edits + 4 regen artifacts)

| File | Change |
|---|---|
| `CLAUDE.md` | Workflow rule + Scope phase rewritten |
| `AGENTS.md` | Same rewrites mirrored |
| `skills/ship-loop/SKILL.md` | Description + lane-choice + close step updated |
| `skills-codex/ship-loop/SKILL.md` | Codex twin parity |
| `docs/contracts/context-map.md` | Regen (description mirror) |
| `registry.json` | Regen (timestamp + description) |
| `skills-codex/.agentops-manifest.json` | Regen (parity hash) |
| `skills-codex/ship-loop/.agentops-generated.json` | Regen (parity hash) |

## Dogfood

**This PR is itself a coherent arc.** 4 tracked .md edits + 4 generated parity artifacts = single rollback semantic. Shipped as 1 PR, not 4 scenario PRs.

## Known drift NOT bundled (per anti-pattern #2)

Surfaced during this PR's full pre-push gate run, all in unchanged-from-base content. Filed as `soc-l4n8`:

- 5 eval canary FAILs: `converter-update-runtime-parity`, `docs-release-governance`, `goals-management-lifecycle`, `security-toolchain-governance`, `workbench-behavioral-v1`
- 6 shellcheck warnings (SC2034/SC2088/SC2089/SC2090) in 6 untouched scripts
- agents-hub content-hash gate snapshot timeout
- retrieval quality ratchet 0/4 (local-lexical warm-up)
- eval baseline-audit policy_mismatch_count=56 (substrate-info, non-blocking)

**Root cause hypothesis:** `--fast` pre-push mode has been bypassing the full gate, allowing this drift to accumulate. The coherent-arc rule + `ship.sh` routing to full gate on inventory PRs (soc-33uy, merged) is the mechanical fix. **This PR is the first artifact of that fix catching real drift.**

## Validation

- ✅ Worktree off fresh `origin/main` (`4d7ac763`).
- ✅ Pre-push gate **full** mode run (not `--fast`). All failures are pre-existing in unchanged content, named in `soc-l4n8`.
- ✅ Codex parity hashes regenerated.
- ✅ Single coherent arc — single rollback semantic.

Bounded-context: BC1-corpus (skill/doc surface)
Evidence: `/tmp/gate-full.log` (local, 329 lines, summary failures=5 pre-existing)