### PR TITLE
fix(scripts): clean 6 pre-existing shellcheck warnings (soc-j026)

### DIFF
--- a/scripts/add-validate-job.sh
+++ b/scripts/add-validate-job.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2089,SC2090
+# This script builds bash/yaml template strings (PY_SETUP, PREPUSH_SECTION,
+# BATS_STUB) whose literal backslashes and quotes are intentional — a Python
+# block at the bottom of the file substitutes them verbatim into target
+# workflow/pre-push files. SC2089/SC2090 advise switching to arrays, which
+# would defeat the multi-line template approach.
 # scripts/add-validate-job.sh
 #
 # CI integration scaffolder: atomically add a new validate-* job across

--- a/scripts/check-skill-size.sh
+++ b/scripts/check-skill-size.sh
@@ -31,7 +31,6 @@ printf -- "---\n"
 
 while IFS= read -r skill_md; do
     lines=$(wc -l < "$skill_md")
-    name=$(basename "$(dirname "$skill_md")")
     if [[ "$lines" -gt "$FAIL_LINES" ]]; then
         printf "FAIL  %4d lines  %s  (move reference material to %s/references/)\n" \
             "$lines" "$skill_md" "$(dirname "$skill_md")"

--- a/scripts/goal-failure-taxonomy.sh
+++ b/scripts/goal-failure-taxonomy.sh
@@ -27,7 +27,7 @@ fi
 classify() {
   local id="${1:-}"
   case "$id" in
-    *security*|*secret*|*hook-preflight*|*toolchain-security*|*release-security*|*ci-security*)
+    *security*|*secret*|*hook-preflight*)
       echo "security"
       ;;
     *build*|*test*|*vet*|*wiring*|*evolve*|*rpi*|*session-start*|*kill-switch*)

--- a/scripts/nightly-pr-digest.sh
+++ b/scripts/nightly-pr-digest.sh
@@ -310,10 +310,9 @@ build_admission_context() {
     return
   fi
 
-  local ci_status blocker_count landing_policy
+  local ci_status blocker_count
   ci_status="$(jq -r '.admission_context.main_ci_baseline.status // "unknown"' "$DIGEST_JSON")"
   blocker_count="$(jq -r '.admission_context.blocker_matrix.prs | length' "$DIGEST_JSON" 2>/dev/null || echo 0)"
-  landing_policy="$(jq -r '.admission_context.main_ci_baseline // {} | .landing_policy // "unknown"' "$DIGEST_JSON" 2>/dev/null || echo "unknown")"
 
   printf '| Field | Value |\n|---|---|\n'
   printf '| GitHub evidence | %s |\n' "$gh_evidence"

--- a/scripts/purge-global-garbage.sh
+++ b/scripts/purge-global-garbage.sh
@@ -21,7 +21,6 @@ while IFS= read -r -d '' file; do
     total=$((total + 1))
     # Extract body after YAML frontmatter (everything after second ---)
     body=$(awk '/^---$/{c++;next} c>=2{print}' "$file" 2>/dev/null || true)
-    bodylen=${#body}
 
     # Strip whitespace for length check
     stripped=$(echo "$body" | tr -d '[:space:]')

--- a/scripts/validate-codex-api-conformance.sh
+++ b/scripts/validate-codex-api-conformance.sh
@@ -56,6 +56,7 @@ echo "=== Check 3: Claude-specific paths ==="
 while IFS= read -r skill_md; do
   skill_name="$(basename "$(dirname "$skill_md")")"
 
+  # shellcheck disable=SC2088  # intentional literal match of the documented path
   matches=$(grep -n '~/\.claude/' "$skill_md" 2>/dev/null || true)
   if [[ -n "$matches" ]]; then
     count=$(echo "$matches" | wc -l | tr -d ' ')


### PR DESCRIPTION
## Summary

Child arc of `soc-l4n8` (drift surfaced during #348). Mechanical cleanup of 6 pre-existing shellcheck warnings in scripts I did not previously touch — all SC2034 unused-vars, SC2088 intended-literal, SC2089/SC2090 template-string, SC2221/SC2222 redundant-case.

Per anti-pattern #2 (no bundling pre-existing fixes), filed as an atomic side-quest off the #348 `soc-1lp1` PR rather than bundled into it.

Closes: soc-j026
Discovered-from: soc-l4n8

## Diff

| File | Fix |
|---|---|
| `validate-codex-api-conformance.sh:59` | SC2088 disable directive — grep is intentionally matching the literal documented path |
| `goal-failure-taxonomy.sh:30` | Trim redundant case patterns (`*toolchain-security*`, `*release-security*`, `*ci-security*` all already matched by `*security*`) |
| `purge-global-garbage.sh:24` | Remove unused `bodylen` |
| `nightly-pr-digest.sh:316` | Remove unused `landing_policy` (local + assignment) |
| `add-validate-job.sh` | File-level SC2089/SC2090 disable for the template-string section |
| `check-skill-size.sh:34` | Remove unused `name` |

## Validation

- `shellcheck -S warning` clean on all 6 files.
- `scripts/ship.sh` routes to `--fast` (no inventory touched).
- Pre-push gate (fast): PASSED, 31 skipped, 1 advisory WARN (executable-spec, unrelated).

Bounded-context: BC0-foundations (scripts)
Evidence: `shellcheck -S warning scripts/*` (clean for the 6 files)