### PR TITLE
fix(scripts): clean 3 more pre-existing shellcheck warnings (round 2, soc-ruvk)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`scripts/ship.sh`** (#346, `soc-33uy`) — single-command wrapper that auto-detects inventory-touching diffs and routes through the full pre-push gate (no `--fast` skip on skill/contract changes), preemptively running the regen sweep (sync-skill-counts, codex-hashes, domain-map, context-map, registry, sync-hooks). Mechanical fix for ship-loop anti-pattern #1.
+
+### Changed
+
+- **Coherent-arc PR rule** (#348, `soc-1lp1`) — replaces "one scenario per PR" default in `CLAUDE.md` + `AGENTS.md`. The unit of a PR is one closable bead (or small-epic slice) with a single rollback semantic. Small epics (≤5 child beads, same surface) ship as one PR with N commits; large epics ship as N PRs sliced by scenario or wave. Updates `ship-loop` skill (Claude + Codex twins). Derived from the 2026-05-19 8-PR merge-arc burn-through.
+
+### Fixed
+
+- **6 pre-existing shellcheck warnings** (#349, `soc-j026`) cleaned across `validate-codex-api-conformance.sh`, `goal-failure-taxonomy.sh`, `purge-global-garbage.sh`, `nightly-pr-digest.sh`, `add-validate-job.sh`, `check-skill-size.sh`. All in scripts unchanged from base — atomic side-quest per anti-pattern #2.
+- **Local pre-push gate eval-canary strictness mismatch** (#350, `soc-nmhp`) — full-mode eval-canaries now respect the same path filter as CI's `eval-workbench-verify` (`HAS_EVAL=1 || is_ci_env`). Previously `needs_check eval` short-circuited to true in full mode, producing 5 spurious FAILs on doc/script PRs against a baseline-less local env. Closes the "Local-vs-CI environment drift" learning (`docs/learnings/2026-05-07-ci-push-gate-toil-pattern.md`).
+
 ## [2.41.1] - 2026-05-15
 
 ### Fixed

--- a/scripts/cleanup-global-agents.sh
+++ b/scripts/cleanup-global-agents.sh
@@ -18,12 +18,11 @@ ARCHIVE_DIR="${GLOBAL_DIR}/.archive"
 # Directories that SHOULD exist at global level
 ALLOWED_DIRS=("learnings" "patterns")
 
-# Known repo-specific dirs that should NOT be global
-LEAKED_DIRS=(
-    "brainstorm" "council" "crank" "doc" "handoff"
-    "knowledge" "plans" "products" "research" "retros"
-    "rpi" "vibecheck" "ao"
-)
+# Known repo-specific dirs that should NOT be global. Kept as documentation
+# only; the loop below uses ALLOWED_DIRS as a positive whitelist (anything
+# outside it is reported as leaked), so an explicit LEAKED_DIRS list is dead.
+#   leaked examples: brainstorm council crank doc handoff knowledge plans
+#                    products research retros rpi vibecheck ao
 
 MODE="dry-run"
 

--- a/scripts/rpi-stream.sh
+++ b/scripts/rpi-stream.sh
@@ -174,6 +174,7 @@ if [[ "$FOLLOW" -eq 1 ]]; then
     stream_file "$file" &
     pids+=("$!")
   done
+  # shellcheck disable=SC2154  # 'p' is the loop variable inside the trap body
   trap 'for p in "${pids[@]}"; do kill "$p" 2>/dev/null || true; done' EXIT INT TERM
   wait
 else

--- a/scripts/smoke-test-codex-skills.sh
+++ b/scripts/smoke-test-codex-skills.sh
@@ -122,6 +122,7 @@ static_check() {
   fi
 
   # Check 3: Claude paths
+  # shellcheck disable=SC2088  # intentional literal match of the documented path
   if grep -q '~/\.claude/' "$skill_md" 2>/dev/null; then
     issues+=("claude-paths")
   fi
@@ -138,6 +139,7 @@ static_check() {
       if grep -qE "\b($primitives)\b" "$ref_file" 2>/dev/null; then
         issues+=("ref-primitives:$(basename "$ref_file")")
       fi
+      # shellcheck disable=SC2088  # intentional literal match of the documented path
       if grep -q '~/\.claude/' "$ref_file" 2>/dev/null; then
         issues+=("ref-claude-paths:$(basename "$ref_file")")
       fi


### PR DESCRIPTION
## Summary

Round 2 of pre-existing shellcheck cleanup. PR #349 (soc-j026) cleaned 6 files; the full pre-push gate's broader shellcheck step caught 3 more pre-existing warnings on canonical post-#350.

Closes: soc-ruvk
Discovered-from: soc-j026

## Fixes

| File | Warning | Fix |
|---|---|---|
| `rpi-stream.sh:177` | SC2154 'p referenced but not assigned' inside trap body | disable directive (`p` is the loop variable in the single-quoted trap, not an outer reference) |
| `smoke-test-codex-skills.sh:125,141` | SC2088 tilde-in-quotes | disable directives (intentional literal pattern match of the documented path) |
| `cleanup-global-agents.sh:22` | SC2034 `LEAKED_DIRS` unused | convert dead array to comment (script uses `ALLOWED_DIRS` whitelist; LEAKED_DIRS was orphaned documentation) |

## Bundled sync

Includes `cp CHANGELOG.md docs/CHANGELOG.md` — same pre-existing sync drift from PR #351 that PR #352 also fixes. Bundling lets this PR's gate pass independently of #352's merge order. If #352 lands first, this becomes a trivial conflict-resolve.

## Validation

- `shellcheck -S warning` clean on all 3 named files.
- `scripts/ship.sh` fast gate: PASSED.
- This is the same coherent-arc shape as PR #349 — different file set, identical disposition (atomic, mechanical, no behavioral change).

Bounded-context: BC0-foundations (scripts)
Evidence: `shellcheck -S warning scripts/{rpi-stream,smoke-test-codex-skills,cleanup-global-agents}.sh` (clean)