### PR TITLE
feat(hooks): session-pr-counter — mechanical session-scope enforcement (soc-1aou)

### DIFF
--- a/cli/embedded/hooks/hooks.json
+++ b/cli/embedded/hooks/hooks.json
@@ -141,6 +141,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-pr-counter.sh",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/lead-only-worker-git-guard.sh",
             "timeout": 5
           }

--- a/cli/embedded/hooks/session-pr-counter.sh
+++ b/cli/embedded/hooks/session-pr-counter.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# shellcheck shell=bash
+set -uo pipefail
+# session-pr-counter.sh — PreToolUse hook: mechanical session-scope enforcement (soc-1aou)
+#
+# Strict-mode choice: -uo pipefail (catches typos and mid-pipe failures); we
+# intentionally omit `-e` because advisory hooks must fail open on command
+# failures (e.g., `gh` unreachable, parse errors) per the existing pattern
+# in commit-review-gate.sh and the shell-standards "advisory = fail open" rule.
+#
+# Sister rule to coherent-arc (soc-waxr, PR #361). Counts PRs the current user
+# opened in the last 24 hours; if that count is >=4 (so the about-to-be-created
+# PR would make 5+), injects a post-mortem reminder as additionalContext.
+#
+# Non-blocking by design: the reminder shows up in the agent's context, the
+# agent decides whether to proceed. Mechanical means "always-on visible signal",
+# not "hard block". Hard-block via $AGENTOPS_SESSION_PR_BLOCK=1 (opt-in).
+#
+# Kill switches:
+#   AGENTOPS_HOOKS_DISABLED=1          — all hooks off
+#   AGENTOPS_SESSION_PR_COUNTER_DISABLED=1 — this hook off
+#
+# Triggers: Bash with `gh pr create` substring. No-op for everything else.
+
+[ "${AGENTOPS_HOOKS_DISABLED:-}" = "1" ] && exit 0
+[ "${AGENTOPS_SESSION_PR_COUNTER_DISABLED:-}" = "1" ] && exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$SCRIPT_DIR/../lib/hook-helpers.sh" ]; then
+    # shellcheck source=../lib/hook-helpers.sh
+    . "$SCRIPT_DIR/../lib/hook-helpers.sh"
+elif [ -f "$SCRIPT_DIR/hook-helpers.sh" ]; then
+    # shellcheck source=../lib/hook-helpers.sh
+    . "$SCRIPT_DIR/hook-helpers.sh"
+fi
+
+INPUT=$(cat)
+if declare -F try_managed_hook_backend >/dev/null 2>&1; then
+    try_managed_hook_backend "session-pr-counter" "$INPUT" && exit 0
+fi
+
+# Resolve tool name + command (env var first, jq fallback).
+TOOL_NAME="${CLAUDE_TOOL_NAME:-}"
+COMMAND="${CLAUDE_TOOL_INPUT_COMMAND:-}"
+if [ -z "$TOOL_NAME" ] || [ -z "$COMMAND" ]; then
+    if command -v jq >/dev/null 2>&1; then
+        IFS=$'\t' read -r _jq_tool _jq_cmd < <(echo "$INPUT" | jq -r '[.tool_name // "", .tool_input.command // ""] | @tsv' 2>/dev/null) || exit 0
+        [ -z "$TOOL_NAME" ] && TOOL_NAME="$_jq_tool"
+        [ -z "$COMMAND" ] && COMMAND="$_jq_cmd"
+    fi
+fi
+
+# Only fire on Bash + `gh pr create`.
+[ "$TOOL_NAME" = "Bash" ] || exit 0
+echo "$COMMAND" | grep -q 'gh pr create' || exit 0
+
+# Bail if `gh` itself isn't available — can't count.
+command -v gh >/dev/null 2>&1 || exit 0
+
+# Window for "current session" — last N hours. Default 24h matches the
+# operational definition of an autonomous session (cron-loop spans, etc.).
+WINDOW_HOURS="${AGENTOPS_SESSION_PR_WINDOW_HOURS:-24}"
+THRESHOLD="${AGENTOPS_SESSION_PR_THRESHOLD:-5}"
+
+# Count my PRs (any state) opened in the window.
+# `gh pr list --search` honors the current repo; state:all includes merged.
+SINCE_ISO="$(date -u -d "${WINDOW_HOURS} hours ago" +%FT%TZ 2>/dev/null || date -u +%FT%TZ)"
+PR_COUNT="$(gh pr list \
+    --search "author:@me created:>=${SINCE_ISO}" \
+    --state all \
+    --limit 50 \
+    --json number 2>/dev/null | jq -r 'length' 2>/dev/null)"
+
+# If we can't get a count, fail open (no notice).
+case "$PR_COUNT" in
+    ''|*[!0-9]*) exit 0 ;;
+esac
+
+# The PR about to be created is PR #(PR_COUNT + 1). At PR_COUNT >= THRESHOLD-1
+# (e.g., 4), the next one tips into post-mortem territory.
+NEXT_PR_NUMBER=$((PR_COUNT + 1))
+if [ "$NEXT_PR_NUMBER" -lt "$THRESHOLD" ]; then
+    exit 0
+fi
+
+# Hard-block mode for operators who want the gate to refuse.
+if [ "${AGENTOPS_SESSION_PR_BLOCK:-0}" = "1" ]; then
+    cat >&2 <<EOF
+BLOCKED: session-pr-counter detected ${PR_COUNT} PRs created in the last ${WINDOW_HOURS}h.
+This would be PR #${NEXT_PR_NUMBER} in the session window — past the post-mortem
+threshold (${THRESHOLD}). Per the session-scope rule (soc-waxr, see CLAUDE.md
+"Workflow"), stop and run a 1-2 sentence post-mortem before continuing:
+
+  - Which PRs were planned vs reactive?
+  - How many self-corrections so far?
+  - Is the marginal PR discovery or churn?
+
+To proceed anyway: set AGENTOPS_SESSION_PR_BLOCK=0 (default), or set
+AGENTOPS_SESSION_PR_COUNTER_DISABLED=1 to skip the check entirely.
+EOF
+    exit 2
+fi
+
+# Informational mode (default): inject as additionalContext.
+REMINDER="SESSION-SCOPE NOTICE (soc-waxr): ${PR_COUNT} PR(s) opened in the last ${WINDOW_HOURS}h; this would be #${NEXT_PR_NUMBER} (threshold: ${THRESHOLD}).
+
+Per the session-scope rule (CLAUDE.md \"Workflow\"), >=5 PRs triggers a mandatory post-mortem before continuing. Run a 1-2 sentence post-mortem first:
+- Which PRs were planned vs reactive?
+- How many self-corrections so far?
+- Is the marginal PR discovery or churn?
+
+Then proceed if the marginal PR survives the post-mortem. Set AGENTOPS_SESSION_PR_BLOCK=1 for a hard block, or AGENTOPS_SESSION_PR_COUNTER_DISABLED=1 to silence."
+
+if declare -F emit_hook_context >/dev/null 2>&1; then
+    emit_hook_context "PreToolUse" "$REMINDER"
+elif command -v jq >/dev/null 2>&1; then
+    jq -n --arg ctx "$REMINDER" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":$ctx}}'
+else
+    safe_msg=${REMINDER//\\/\\\\}
+    safe_msg=${safe_msg//\"/\\\"}
+    safe_msg=$(echo "$safe_msg" | tr '\n' ' ')
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"$safe_msg\"}}"
+fi
+
+exit 0

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -141,6 +141,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-pr-counter.sh",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/lead-only-worker-git-guard.sh",
             "timeout": 5
           }

--- a/hooks/session-pr-counter.sh
+++ b/hooks/session-pr-counter.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# shellcheck shell=bash
+set -uo pipefail
+# session-pr-counter.sh — PreToolUse hook: mechanical session-scope enforcement (soc-1aou)
+#
+# Strict-mode choice: -uo pipefail (catches typos and mid-pipe failures); we
+# intentionally omit `-e` because advisory hooks must fail open on command
+# failures (e.g., `gh` unreachable, parse errors) per the existing pattern
+# in commit-review-gate.sh and the shell-standards "advisory = fail open" rule.
+#
+# Sister rule to coherent-arc (soc-waxr, PR #361). Counts PRs the current user
+# opened in the last 24 hours; if that count is >=4 (so the about-to-be-created
+# PR would make 5+), injects a post-mortem reminder as additionalContext.
+#
+# Non-blocking by design: the reminder shows up in the agent's context, the
+# agent decides whether to proceed. Mechanical means "always-on visible signal",
+# not "hard block". Hard-block via $AGENTOPS_SESSION_PR_BLOCK=1 (opt-in).
+#
+# Kill switches:
+#   AGENTOPS_HOOKS_DISABLED=1          — all hooks off
+#   AGENTOPS_SESSION_PR_COUNTER_DISABLED=1 — this hook off
+#
+# Triggers: Bash with `gh pr create` substring. No-op for everything else.
+
+[ "${AGENTOPS_HOOKS_DISABLED:-}" = "1" ] && exit 0
+[ "${AGENTOPS_SESSION_PR_COUNTER_DISABLED:-}" = "1" ] && exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$SCRIPT_DIR/../lib/hook-helpers.sh" ]; then
+    # shellcheck source=../lib/hook-helpers.sh
+    . "$SCRIPT_DIR/../lib/hook-helpers.sh"
+elif [ -f "$SCRIPT_DIR/hook-helpers.sh" ]; then
+    # shellcheck source=../lib/hook-helpers.sh
+    . "$SCRIPT_DIR/hook-helpers.sh"
+fi
+
+INPUT=$(cat)
+if declare -F try_managed_hook_backend >/dev/null 2>&1; then
+    try_managed_hook_backend "session-pr-counter" "$INPUT" && exit 0
+fi
+
+# Resolve tool name + command (env var first, jq fallback).
+TOOL_NAME="${CLAUDE_TOOL_NAME:-}"
+COMMAND="${CLAUDE_TOOL_INPUT_COMMAND:-}"
+if [ -z "$TOOL_NAME" ] || [ -z "$COMMAND" ]; then
+    if command -v jq >/dev/null 2>&1; then
+        IFS=$'\t' read -r _jq_tool _jq_cmd < <(echo "$INPUT" | jq -r '[.tool_name // "", .tool_input.command // ""] | @tsv' 2>/dev/null) || exit 0
+        [ -z "$TOOL_NAME" ] && TOOL_NAME="$_jq_tool"
+        [ -z "$COMMAND" ] && COMMAND="$_jq_cmd"
+    fi
+fi
+
+# Only fire on Bash + `gh pr create`.
+[ "$TOOL_NAME" = "Bash" ] || exit 0
+echo "$COMMAND" | grep -q 'gh pr create' || exit 0
+
+# Bail if `gh` itself isn't available — can't count.
+command -v gh >/dev/null 2>&1 || exit 0
+
+# Window for "current session" — last N hours. Default 24h matches the
+# operational definition of an autonomous session (cron-loop spans, etc.).
+WINDOW_HOURS="${AGENTOPS_SESSION_PR_WINDOW_HOURS:-24}"
+THRESHOLD="${AGENTOPS_SESSION_PR_THRESHOLD:-5}"
+
+# Count my PRs (any state) opened in the window.
+# `gh pr list --search` honors the current repo; state:all includes merged.
+SINCE_ISO="$(date -u -d "${WINDOW_HOURS} hours ago" +%FT%TZ 2>/dev/null || date -u +%FT%TZ)"
+PR_COUNT="$(gh pr list \
+    --search "author:@me created:>=${SINCE_ISO}" \
+    --state all \
+    --limit 50 \
+    --json number 2>/dev/null | jq -r 'length' 2>/dev/null)"
+
+# If we can't get a count, fail open (no notice).
+case "$PR_COUNT" in
+    ''|*[!0-9]*) exit 0 ;;
+esac
+
+# The PR about to be created is PR #(PR_COUNT + 1). At PR_COUNT >= THRESHOLD-1
+# (e.g., 4), the next one tips into post-mortem territory.
+NEXT_PR_NUMBER=$((PR_COUNT + 1))
+if [ "$NEXT_PR_NUMBER" -lt "$THRESHOLD" ]; then
+    exit 0
+fi
+
+# Hard-block mode for operators who want the gate to refuse.
+if [ "${AGENTOPS_SESSION_PR_BLOCK:-0}" = "1" ]; then
+    cat >&2 <<EOF
+BLOCKED: session-pr-counter detected ${PR_COUNT} PRs created in the last ${WINDOW_HOURS}h.
+This would be PR #${NEXT_PR_NUMBER} in the session window — past the post-mortem
+threshold (${THRESHOLD}). Per the session-scope rule (soc-waxr, see CLAUDE.md
+"Workflow"), stop and run a 1-2 sentence post-mortem before continuing:
+
+  - Which PRs were planned vs reactive?
+  - How many self-corrections so far?
+  - Is the marginal PR discovery or churn?
+
+To proceed anyway: set AGENTOPS_SESSION_PR_BLOCK=0 (default), or set
+AGENTOPS_SESSION_PR_COUNTER_DISABLED=1 to skip the check entirely.
+EOF
+    exit 2
+fi
+
+# Informational mode (default): inject as additionalContext.
+REMINDER="SESSION-SCOPE NOTICE (soc-waxr): ${PR_COUNT} PR(s) opened in the last ${WINDOW_HOURS}h; this would be #${NEXT_PR_NUMBER} (threshold: ${THRESHOLD}).
+
+Per the session-scope rule (CLAUDE.md \"Workflow\"), >=5 PRs triggers a mandatory post-mortem before continuing. Run a 1-2 sentence post-mortem first:
+- Which PRs were planned vs reactive?
+- How many self-corrections so far?
+- Is the marginal PR discovery or churn?
+
+Then proceed if the marginal PR survives the post-mortem. Set AGENTOPS_SESSION_PR_BLOCK=1 for a hard block, or AGENTOPS_SESSION_PR_COUNTER_DISABLED=1 to silence."
+
+if declare -F emit_hook_context >/dev/null 2>&1; then
+    emit_hook_context "PreToolUse" "$REMINDER"
+elif command -v jq >/dev/null 2>&1; then
+    jq -n --arg ctx "$REMINDER" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":$ctx}}'
+else
+    safe_msg=${REMINDER//\\/\\\\}
+    safe_msg=${safe_msg//\"/\\\"}
+    safe_msg=$(echo "$safe_msg" | tr '\n' ' ')
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"$safe_msg\"}}"
+fi
+
+exit 0

--- a/tests/hooks/test-session-pr-counter.bats
+++ b/tests/hooks/test-session-pr-counter.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+#
+# Tests for hooks/session-pr-counter.sh — verifies the session-scope post-mortem
+# reminder (soc-1aou, mechanical enforcement of the soc-waxr rule).
+#
+# Sibling pattern: tests/hooks/test-check-test-pair-on-commit.bats — synthesize
+# PreToolUse JSON input, mock `gh` via PATH stub, assert exit code + emitted
+# additionalContext.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    HOOK="$REPO_ROOT/hooks/session-pr-counter.sh"
+    [ -x "$HOOK" ] || skip "hook not executable"
+
+    TMP_DIR="$(mktemp -d)"
+    MOCK_BIN="$TMP_DIR/bin"
+    mkdir -p "$MOCK_BIN"
+    # Always ensure our mock bin is in front of real PATH.
+    export ORIG_PATH="$PATH"
+    export PATH="$MOCK_BIN:$PATH"
+}
+
+teardown() {
+    export PATH="${ORIG_PATH:-$PATH}"
+    if [ -n "${TMP_DIR:-}" ] && [ -d "$TMP_DIR" ]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+# Stub `gh` to return a JSON array of length N (zero or more PRs).
+mock_gh_pr_count() {
+    local n="$1"
+    cat >"$MOCK_BIN/gh" <<EOF
+#!/bin/bash
+# Emit JSON array of N empty objects; mimics gh pr list --json output.
+python3 -c "import json,sys; print(json.dumps([{} for _ in range($n)]))"
+EOF
+    chmod +x "$MOCK_BIN/gh"
+}
+
+# Synthesize the PreToolUse JSON the hook receives on stdin.
+input_json() {
+    local cmd="${1:-gh pr create -t foo -b bar}"
+    jq -nc --arg c "$cmd" '{tool_name: "Bash", tool_input: {command: $c}}'
+}
+
+# ---- early-exit / no-fire cases (exit 0, no context emitted) ----
+
+@test "no-op when AGENTOPS_HOOKS_DISABLED=1" {
+    mock_gh_pr_count 10
+    run env AGENTOPS_HOOKS_DISABLED=1 bash -c "echo '$(input_json)' | $HOOK"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "no-op when AGENTOPS_SESSION_PR_COUNTER_DISABLED=1" {
+    mock_gh_pr_count 10
+    run env AGENTOPS_SESSION_PR_COUNTER_DISABLED=1 bash -c "echo '$(input_json)' | $HOOK"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "no-op when tool is not Bash" {
+    mock_gh_pr_count 10
+    local non_bash
+    non_bash=$(jq -nc '{tool_name: "Edit", tool_input: {file_path: "/tmp/x"}}')
+    run bash -c "echo '$non_bash' | $HOOK"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "no-op when Bash command is not gh pr create" {
+    mock_gh_pr_count 10
+    run bash -c "echo '$(input_json "ls -la")' | $HOOK"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "fails open when gh returns malformed output (non-numeric count)" {
+    # Mock gh to return garbage; hook should fail open (exit 0, no context).
+    # This exercises the case-statement number-validation guard.
+    cat >"$MOCK_BIN/gh" <<'EOF'
+#!/bin/bash
+echo "not-json garbage"
+EOF
+    chmod +x "$MOCK_BIN/gh"
+    run bash -c "echo '$(input_json)' | $HOOK"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ---- under-threshold cases (exit 0, no context) ----
+
+@test "under threshold: 0 PRs in window → silent" {
+    mock_gh_pr_count 0
+    run bash -c "echo '$(input_json)' | $HOOK"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "under threshold: 3 PRs in window → silent (next would be #4, threshold 5)" {
+    mock_gh_pr_count 3
+    run bash -c "echo '$(input_json)' | $HOOK"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ---- at-or-over threshold cases (exit 0, advisory context emitted) ----
+
+@test "at threshold: 4 PRs → emits notice (next would be #5)" {
+    mock_gh_pr_count 4
+    run bash -c "echo '$(input_json)' | $HOOK"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SESSION-SCOPE NOTICE"* ]]
+    [[ "$output" == *"soc-waxr"* ]]
+    [[ "$output" == *"post-mortem"* ]]
+}
+
+@test "over threshold: 7 PRs → emits notice with the count" {
+    mock_gh_pr_count 7
+    run bash -c "echo '$(input_json)' | $HOOK"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"7 PR"* ]]
+    [[ "$output" == *"#8"* ]]
+}
+
+@test "custom threshold via env: AGENTOPS_SESSION_PR_THRESHOLD=3 fires at 2 PRs" {
+    mock_gh_pr_count 2
+    run env AGENTOPS_SESSION_PR_THRESHOLD=3 bash -c "echo '$(input_json)' | $HOOK"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SESSION-SCOPE NOTICE"* ]]
+    [[ "$output" == *"#3"* ]]
+}
+
+# ---- hard-block mode (exit 2 with clear reason) ----
+
+@test "hard-block mode: 5 PRs + AGENTOPS_SESSION_PR_BLOCK=1 → exit 2" {
+    mock_gh_pr_count 5
+    run env AGENTOPS_SESSION_PR_BLOCK=1 bash -c "echo '$(input_json)' | $HOOK"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"BLOCKED"* ]]
+    [[ "$output" == *"post-mortem"* ]]
+}
+
+@test "hard-block mode under threshold: 3 PRs + block=1 → exit 0 (no fire)" {
+    mock_gh_pr_count 3
+    run env AGENTOPS_SESSION_PR_BLOCK=1 bash -c "echo '$(input_json)' | $HOOK"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}


### PR DESCRIPTION
## Summary

Mechanical follow-through for **soc-waxr (PR #361)** — the session-scope doctrine. soc-waxr encoded "2-4 PRs/session default; ≥5 triggers mandatory post-mortem" as documentation; this PR makes that rule fire mechanically as a PreToolUse hook on `gh pr create`.

Closes: soc-1aou · Discovered-from: soc-waxr

## Fitness delta

- Doc-only rules with mechanical backstop: **+1** (session-scope joins AP#1→ship.sh and AP#7→verify-gate-claim.sh)
- Session-scope recurrence prevention: **0 → 1** (would have fired on PR #5 of yesterday's 7-PR session)
- New bats: **0 → 12** (kill switches, tool matching, threshold logic, hard-block mode, fail-open on malformed output)

## What it does

- PreToolUse on Bash + `gh pr create`
- Counts the operator's PRs (any state, last 24h via `gh pr list --search`)
- At `count >= threshold-1`, emits `additionalContext` with post-mortem prompts:
  - Which PRs were planned vs reactive?
  - How many self-corrections so far?
  - Is the marginal PR discovery or churn?
- Hard-block mode (`AGENTOPS_SESSION_PR_BLOCK=1`) exits 2 with clear reason instead

## Configuration

| Variable | Default | Purpose |
|---|---|---|
| `AGENTOPS_SESSION_PR_THRESHOLD` | 5 | PR count that triggers the reminder |
| `AGENTOPS_SESSION_PR_WINDOW_HOURS` | 24 | Window for "current session" |
| `AGENTOPS_SESSION_PR_BLOCK` | 0 | 1 = hard block (exit 2) instead of advisory |
| `AGENTOPS_SESSION_PR_COUNTER_DISABLED` | 0 | 1 = bypass this hook |
| `AGENTOPS_HOOKS_DISABLED` | 0 | 1 = bypass all AgentOps hooks |

## Sibling pattern

Hook structure mirrors `hooks/commit-review-gate.sh` — same PreToolUse Bash matcher, same kill-switch chain, same jq+env fallback for tool input parsing, same `emit_hook_context` → `jq -n` → escape-fallback emission chain. Standards discipline matches (set -uo pipefail without -e, fail-open advisory shape). Sibling pattern: `hooks/commit-review-gate.sh`.

## Files

| File | Change |
|---|---|
| `hooks/session-pr-counter.sh` | New, 133 lines |
| `hooks/hooks.json` | New PreToolUse Bash entry (timeout 10s) |
| `cli/embedded/hooks/*` | Auto-synced via `make sync-hooks` |
| `tests/hooks/test-session-pr-counter.bats` | New, 12 tests, all green |

## Dogfood: what would have fired

Yesterday's 7-PR session (#356 through #361 + #320) would have triggered this hook at PR #5 (`#359` soc-bbvw — the FIRST self-correction PR). The hook's reminder would have been visible to the agent before opening #359, prompting "is this churn or discovery?". The answer was "churn — fixing my own regression from #357", which exactly fits the failure mode soc-waxr names.

## What's NOT in this PR

The soc-waxr doctrine surfaces (CLAUDE.md, AGENTS.md, ship-loop SKILL, anti-patterns.md) still say "mechanical enforcement is a successor concern". Updating those will be a tiny follow-up PR once soc-waxr (#361) itself merges — editing the same lines now would conflict on rebase.

## Verification

- `bats tests/hooks/test-session-pr-counter.bats` → 12 ok
- `shellcheck hooks/session-pr-counter.sh` clean (SC1091 info-only on hook-helpers source, matching `commit-review-gate.sh`)
- `jq -e . hooks/hooks.json` clean
- `cd cli && make sync-hooks` clean

Bounded-context: BC0-foundations + BC5-runtime (hook plumbing)
Evidence: shellcheck