### PR TITLE
fix(cli/test): goals_measure tests flake under -race -shuffle (soc-n6vb #cobra-writer-leak)

### DIFF
--- a/cli/cmd/ao/cobra_commands_test.go
+++ b/cli/cmd/ao/cobra_commands_test.go
@@ -376,16 +376,30 @@ func executeCommand(args ...string) (string, error) {
 	rootCmd.SetErr(cmdBuf)
 	rootCmd.SetArgs(args)
 
+	// Always restore rootCmd output writers even if rootCmd.Execute() panics.
+	// Without this defer, a panicking Execute() leaves rootCmd.outWriter pointing
+	// at the now-out-of-scope cmdBuf; subsequent tests that invoke a subcommand's
+	// RunE directly (e.g. goalsMeasureCmd.RunE) will have cobra's OutOrStdout()
+	// resolve to the leaked buffer via parent-walking, silently swallowing their
+	// output and breaking tests that capture os.Stdout. (soc-n6vb)
+	defer func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	}()
+
 	// Also capture os.Stdout for commands that use fmt.Printf directly
 	oldStdout := os.Stdout
 	r, w, pipeErr := os.Pipe()
 	if pipeErr != nil {
-		rootCmd.SetOut(nil)
-		rootCmd.SetErr(nil)
-		rootCmd.SetArgs(nil)
 		return "", pipeErr
 	}
 	os.Stdout = w
+	// Restore os.Stdout even if Execute panics; otherwise subsequent tests
+	// inherit a stale (possibly closed) pipe writer as os.Stdout. (soc-n6vb)
+	defer func() {
+		os.Stdout = oldStdout
+	}()
 
 	var stdoutBuf bytes.Buffer
 	copyDone := make(chan struct{})
@@ -400,10 +414,6 @@ func executeCommand(args ...string) (string, error) {
 	w.Close()
 	os.Stdout = oldStdout
 	<-copyDone
-
-	rootCmd.SetOut(nil)
-	rootCmd.SetErr(nil)
-	rootCmd.SetArgs(nil)
 
 	// Combine cmd buffer and stdout capture
 	combined := cmdBuf.String() + stdoutBuf.String()

--- a/cli/cmd/ao/goals_measure_scenarios_test.go
+++ b/cli/cmd/ao/goals_measure_scenarios_test.go
@@ -106,6 +106,18 @@ func setupMeasureScenarioProject(t *testing.T, goalsMD string, withArtifact bool
 	goalsMeasureTotalTimeout = 0
 	dryRun = false
 	goalsFile = "GOALS.md"
+	// soc-n6vb: defensively clear cobra command writers so RunE invocations
+	// resolve cmd.OutOrStdout()/ErrOrStderr() to the current os.Stdout/os.Stderr
+	// (which the test's captureJSONStdout has redirected). Without this, an
+	// earlier test that leaked a writer on rootCmd or any ancestor (e.g. a
+	// panicking executeCommand caller) would have RunE write into a stale
+	// buffer and our captured stdout would be empty.
+	rootCmd.SetOut(nil)
+	rootCmd.SetErr(nil)
+	goalsCmd.SetOut(nil)
+	goalsCmd.SetErr(nil)
+	goalsMeasureCmd.SetOut(nil)
+	goalsMeasureCmd.SetErr(nil)
 	return dir
 }
 


### PR DESCRIPTION
## Summary

Fix main CI red on PR #362 — two `goals_measure` tests in `cli/cmd/ao` flake under
`go test -race -shuffle=on`:

- `TestGoalsMeasure_FullModeJSONCarriesSnapshotAndScenarios`
- `TestGoalsMeasure_MissingArtifactYieldsUnknownNotError`

Both fail with `unmarshal payload: unexpected end of JSON input` + empty raw stdout.

Closes: soc-n6vb

## Root cause

Both tests call `goalsMeasureCmd.RunE(goalsMeasureCmd, nil)` directly. Inside RunE,
output is written via `cmd.OutOrStdout()`, which walks the cobra command tree until
it finds a non-nil `outWriter`:

```
goalsMeasureCmd.outWriter -> nil
goalsCmd.outWriter        -> nil
rootCmd.outWriter         -> ??? (if stale: writes here; test's os.Stdout redirect misses it)
fallback                  -> os.Stdout
```

Under `-shuffle=on`, some earlier test leaves `rootCmd.outWriter` pointing at a
buffer that's gone out of scope but whose pointer is still live. The failing
tests' `captureJSONStdout` redirects `os.Stdout`, but cobra writes to the leaked
buffer instead — empty captured payload.

The likely vector is `executeCommand` in `cobra_commands_test.go`: it sets
`rootCmd.SetOut(cmdBuf)` and restores inline at the end. If `rootCmd.Execute()`
panics or `os.Pipe()` fails mid-flight, restoration is skipped.

Reproducible locally with:
```
cd cli && go test -race -shuffle=1779241411657363775 -count=1 ./cmd/ao/...
```

## Fix

**Two layers** — root-cause hardening plus defensive belt-and-suspenders.

### Root cause (`cobra_commands_test.go`)

Wrap `executeCommand`'s restoration in `defer` so it always runs even if
`rootCmd.Execute()` panics:

```go
defer func() {
    rootCmd.SetOut(nil)
    rootCmd.SetErr(nil)
    rootCmd.SetArgs(nil)
}()
// ...
defer func() {
    os.Stdout = oldStdout
}()
```

This removes the inline restoration that was vulnerable to panics, and consolidates
the cleanup at one site.

### Defensive (`goals_measure_scenarios_test.go`)

`setupMeasureScenarioProject` already saved/restored 8 package-level globals
(soc-hwgm/soc-xyt1). Add cobra writer reset on entry so future flakes from any
upstream leaker can't reach these tests:

```go
rootCmd.SetOut(nil)
rootCmd.SetErr(nil)
goalsCmd.SetOut(nil)
goalsCmd.SetErr(nil)
goalsMeasureCmd.SetOut(nil)
goalsMeasureCmd.SetErr(nil)
```

## Verification

- `cd cli && go test -race -shuffle=1779241411657363775 -count=1 ./cmd/ao/...` — PASSES (was the failing seed).
- Test of both targeted functions in isolation — PASSES.
- `gofmt -l` clean. `go vet ./cmd/ao/...` clean.

## Why this isn't masking a real bug

The user-facing `ao goals measure` command always runs through `goalsMeasureCmd`
under `rootCmd.Execute()`, where cobra's writer-walking lands at the real
`os.Stdout`. The flake only affects direct `RunE(cmd, nil)` test invocations that
bypass `Execute()` — pure test infrastructure.

Bounded-context: BC5-runtime (test infrastructure for CLI command surface)
Evidence: `cd cli && go test -race -shuffle=1779241411657363775 -count=1 ./cmd/ao/...`