### PR TITLE
chore(registry): regenerate registry.json — session-pr-counter hook drift (soc-h1cr #registry-regen)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-19T16:15:57Z",
+  "generated_at": "2026-05-20T02:41:03Z",
   "summary": {
     "skills": 79,
-    "hooks": 43,
+    "hooks": 44,
     "knowledge_stores": 4,
     "job_types": 14,
     "eval_files": 62,
@@ -859,6 +859,14 @@
         "matcher": "Skill",
         "timeout": 30,
         "path": "hooks/pre-mortem-gate.sh",
+        "type": "command"
+      },
+      {
+        "name": "session-pr-counter",
+        "lifecycle": "PreToolUse",
+        "matcher": "Bash",
+        "timeout": 10,
+        "path": "hooks/session-pr-counter.sh",
         "type": "command"
       },
       {


### PR DESCRIPTION
## Summary

Regenerate `registry.json` to add the `session-pr-counter` hook entry added by PR #362 (soc-1aou). The registry was stale on main because PR #362's path filter skipped the `registry-check` job, masking the drift.

Closes: soc-h1cr
Discovered-from: soc-1aou (PR #362) via soc-1nsx (PR #364 CI dogfood — registry-check failed on the YAML-touching PR and surfaced the pre-existing drift)

## Fix

```
bash scripts/generate-registry.sh
```

Generator output:
> Wrote registry.json (79 skills, **44 hooks**, 4 stores, 14 job types, 62 evals, 171 CLI commands)

The diff matches the `registry-check` job's CI-emitted expected diff line-for-line: hooks count `43 → 44` and the `session-pr-counter` entry (PreToolUse / Bash matcher / 10s timeout) added to the hooks array.

## #trivial

Single mechanical regen of a generated file. No behavior change. Carve-out per CLAUDE.md: "Carve-out: `type=chore` with `#trivial` label for tiny work."

## Verification

- `bash scripts/generate-registry.sh` ran cleanly
- Diff matches CI-expected diff verbatim
- `jq -e . registry.json` clean (valid JSON)

Bounded-context: BC0-foundations
Evidence: registry.json