### PR TITLE
fix(skills/evolve): mandatory /post-mortem --deep checkpoint at session-PR threshold (soc-n75z #postmortem-checkpoint)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-20T02:41:03Z",
+  "generated_at": "2026-05-20T11:32:09Z",
   "summary": {
     "skills": 79,
     "hooks": 44,
@@ -185,7 +185,7 @@
         "path": "skills/evolve/",
         "has_skill_md": true,
         "has_references": true,
-        "reference_count": 20
+        "reference_count": 21
       },
       {
         "name": "grafana-platform-dashboard",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -782,7 +782,7 @@
       "name": "evolve",
       "source_skill": "skills/evolve",
       "source_hash": "e9703d940deeea357a84152a05f5fc7d3f1fe69d07cc3ae2ee4b9e9637ccdeeb",
-      "generated_hash": "3dfaaddd1a48b295b3bdc636407e4d9417841851dfe137361fd01f82404b7eeb"
+      "generated_hash": "6d6c681737a53627db803b36ffe3e0fcfcf82e788d65794ae1300e74894fef29"
     },
     {
       "name": "expert-council",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -781,8 +781,8 @@
     {
       "name": "evolve",
       "source_skill": "skills/evolve",
-      "source_hash": "1dd505d4df6ec3c6b07aac0b2128ce9d6c4de935e2cd257420fa3d08dd9b9764",
-      "generated_hash": "a3620debc89b8c810ffb063185ed073dde2ff567a7ce6a84ebdc1e130da94f0d"
+      "source_hash": "e9703d940deeea357a84152a05f5fc7d3f1fe69d07cc3ae2ee4b9e9637ccdeeb",
+      "generated_hash": "3dfaaddd1a48b295b3bdc636407e4d9417841851dfe137361fd01f82404b7eeb"
     },
     {
       "name": "expert-council",

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/evolve",
   "layout": "modular",
-  "source_hash": "1dd505d4df6ec3c6b07aac0b2128ce9d6c4de935e2cd257420fa3d08dd9b9764",
-  "generated_hash": "a3620debc89b8c810ffb063185ed073dde2ff567a7ce6a84ebdc1e130da94f0d"
+  "source_hash": "e9703d940deeea357a84152a05f5fc7d3f1fe69d07cc3ae2ee4b9e9637ccdeeb",
+  "generated_hash": "3dfaaddd1a48b295b3bdc636407e4d9417841851dfe137361fd01f82404b7eeb"
 }

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/evolve",
   "layout": "modular",
   "source_hash": "e9703d940deeea357a84152a05f5fc7d3f1fe69d07cc3ae2ee4b9e9637ccdeeb",
-  "generated_hash": "3dfaaddd1a48b295b3bdc636407e4d9417841851dfe137361fd01f82404b7eeb"
+  "generated_hash": "6d6c681737a53627db803b36ffe3e0fcfcf82e788d65794ae1300e74894fef29"
 }

--- a/skills-codex/evolve/SKILL.md
+++ b/skills-codex/evolve/SKILL.md
@@ -634,6 +634,8 @@ When a cycle edits an evolve `SKILL.md`, record the falsifiable claim through
 `ao loop hypothesis append` (read it back with `ao loop hypothesis list`).
 See `references/convergence-mechanics.md` for all four compounding mechanisms.
 
+**Mandatory checkpoint #6 — session-PR threshold (NOT terminal, gates next cycle):** at `session_pr_count >= 5` (soc-waxr default), invoke `/post-mortem --deep`, wait for verdict file. PASS → continue. WARN → continue with caveat in next cycle's `notes`. FAIL or non-convergence → write STOP citing the verdict path. Agent MUST NOT self-grade or self-write STOP. Full procedure: `skills/evolve/references/postmortem-checkpoint.md` (soc-n75z).
+
 Push only when productive work has accumulated:
 ```bash
 if [ $((PRODUCTIVE_THIS_SESSION % 5)) -eq 0 ] && [ "$PRODUCTIVE_THIS_SESSION" -gt 0 ]; then

--- a/skills-codex/evolve/SKILL.md
+++ b/skills-codex/evolve/SKILL.md
@@ -634,7 +634,7 @@ When a cycle edits an evolve `SKILL.md`, record the falsifiable claim through
 `ao loop hypothesis append` (read it back with `ao loop hypothesis list`).
 See `references/convergence-mechanics.md` for all four compounding mechanisms.
 
-**Mandatory checkpoint #6 — session-PR threshold (NOT terminal, gates next cycle):** at `session_pr_count >= 5` (soc-waxr default), invoke `/post-mortem --deep`, wait for verdict file. PASS → continue. WARN → continue with caveat in next cycle's `notes`. FAIL or non-convergence → write STOP citing the verdict path. Agent MUST NOT self-grade or self-write STOP. Full procedure: `skills/evolve/references/postmortem-checkpoint.md` (soc-n75z).
+**Mandatory checkpoint #6 — session-PR threshold (NOT terminal, gates next cycle):** at `session_pr_count >= 5` (soc-waxr default), invoke `$post-mortem --deep`, wait for verdict file. PASS → continue. WARN → continue with caveat in next cycle's `notes`. FAIL or non-convergence → write STOP citing the verdict path. Agent MUST NOT self-grade or self-write STOP. Full procedure: `references/postmortem-checkpoint.md` (soc-n75z).
 
 Push only when productive work has accumulated:
 ```bash
@@ -766,6 +766,7 @@ See `references/cycle-history.md` for advanced troubleshooting.
 - [references/goals-schema.md](references/goals-schema.md)
 - [references/oscillation.md](references/oscillation.md)
 - [references/parallel-execution.md](references/parallel-execution.md)
+- [references/postmortem-checkpoint.md](references/postmortem-checkpoint.md)
 - [references/quality-mode.md](references/quality-mode.md)
 - [references/teardown.md](references/teardown.md)
 
@@ -781,6 +782,7 @@ See `references/cycle-history.md` for advanced troubleshooting.
 - [references/goals-schema.md](references/goals-schema.md)
 - [references/oscillation.md](references/oscillation.md)
 - [references/parallel-execution.md](references/parallel-execution.md)
+- [references/postmortem-checkpoint.md](references/postmortem-checkpoint.md)
 - [references/quality-mode.md](references/quality-mode.md)
 - [references/teardown.md](references/teardown.md)
 

--- a/skills-codex/evolve/references/postmortem-checkpoint.md
+++ b/skills-codex/evolve/references/postmortem-checkpoint.md
@@ -1,0 +1,82 @@
+# Mandatory checkpoint: session-PR threshold (soc-n75z)
+
+> Stop reason #6 of `$evolve`. NOT terminal — gates the next cycle, not the loop's existence. Derivation: the 2026-05-19 and 2026-05-20 sessions both shipped 5-6 PRs while the agent self-graded "HEALTHY" without running a real council; STOP got written as if it were post-mortem completion. This procedure closes that gap.
+
+## When this fires
+
+At Step 7 boundary, after a cycle whose result is `improved` or `regressed`:
+
+```bash
+if [ "$session_pr_count" -ge "${SESSION_PR_THRESHOLD:-5}" ] \
+   && [ "$session_pr_count_at_last_checkpoint" -lt "${SESSION_PR_THRESHOLD:-5}" ]; then
+  # checkpoint fires once per crossing — not repeatedly at every cycle past 5
+  run_postmortem_checkpoint
+fi
+```
+
+The check is **edge-triggered** (fires when the counter first crosses the threshold), not level-triggered. After PASS/WARN, the loop continues until either another stop reason fires OR another threshold crossing — e.g., at `2 × SESSION_PR_THRESHOLD = 10`, the checkpoint re-fires for a second post-mortem.
+
+## What it MUST do
+
+1. **Invoke `$post-mortem --deep`** on the cycles since the last checkpoint (or session start). `--deep` runs 3 same-vendor judges in adversarial posture.
+
+   - Do NOT use `--mixed`. Cross-vendor (Codex availability) is an infrastructure dependency that should not block the loop gate. Reserve `--mixed` for strategic architecture decisions (e.g., the DUEL.md precedent), not per-session health checks.
+   - Do NOT use single-judge mode. Single-judge sweeps are too weak for a gate that enables continued autonomous work — the whole point of the checkpoint is adversarial counter-balance against the author who just wrote the cycles.
+
+2. **Wait for the verdict file** at `.agents/council/<date>-<scope>-postmortem/verdict.md`. The verdict file's first non-blank line must start with `## Council Verdict: <PASS|WARN|FAIL>`.
+
+3. **Branch on verdict:**
+
+   | Verdict | Action |
+   |---|---|
+   | `PASS` | Continue the ladder. Next cycle's `notes` field MUST record the verdict path. |
+   | `WARN` | Continue the ladder. Next cycle's `notes` field MUST emit the council's caveats verbatim — they need to trace through `cycle-history.jsonl` so the loop's recorded behavior reflects what was acknowledged. |
+   | `FAIL` | Write `.agents/evolve/STOP` with the verdict path embedded. Do NOT clear. Surface the council's required-follow-up list to the operator. |
+
+4. **Treat non-convergence as FAIL.** If after 600 seconds the verdict file is missing, malformed, or the council's judges disagreed irreconcilably after a second pass, default to FAIL. **Absence of evidence is NOT evidence of pass.** The 2026-05-20 failure mode was an empty 2-minute cron pass treated as council completion; this rule is the corrective.
+
+## What it MUST NOT do
+
+- **Never self-grade.** The agent who ran the cycles is the same agent doing the post-mortem. Self-attestation is definitionally invalid for the gate; council enforcement is the structural requirement.
+- **Never write `.agents/evolve/STOP` without a council verdict file.** STOP without a verdict is the 2026-05-20 anti-pattern — the file becomes a self-imposed pause that the same agent (or operator) clears without rigor. Every STOP written by this checkpoint must cite a verdict path that resolves to a FAIL verdict.
+- **Never run `$post-mortem` without `--deep` from this checkpoint.** A light-touch cron-fire pass that writes learnings but skips Phase 1 council does not satisfy the gate. The 2026-05-20 cron `$post-mortem` was insufficient by design.
+
+## Relationship to soc-1aou hook
+
+`hooks/session-pr-counter.sh` (PR #362, soc-1aou) is the *pre-creation* signal — it fires on `gh pr create` at `count >= threshold - 1` and emits post-mortem prompts via `additionalContext`. Default advisory; opt-in hard-block via `AGENTOPS_SESSION_PR_BLOCK=1`.
+
+This checkpoint is the *post-merge* gate — it fires after PR #N+1 has merged, before cycle N+1 enters Step 1. The two are **complementary**, not redundant:
+
+| Layer | Trigger | Default | Purpose |
+|---|---|---|---|
+| `hooks/session-pr-counter.sh` | `gh pr create` at `count >= threshold-1` | Advisory | Warn the agent before committing to the PR that tips the session over |
+| `evolve` checkpoint #6 | Cycle boundary after `count >= threshold` | Mandatory | Structural enforcement of council before the next cycle starts |
+
+The hook can be bypassed (advisory by default); the skill checkpoint cannot (the loop genuinely waits on the verdict file).
+
+## Configuration
+
+| Variable | Default | Effect |
+|---|---|---|
+| `SESSION_PR_THRESHOLD` | `5` | Matches soc-waxr documentation default. The 2026-05-19 session (6 PRs, 3 self-corrections) and 2026-05-20 session (5 PRs, 1 self-correction + 1 confirmation-bias verdict) are the two derivation points. Do not change without a third data point. |
+| `EVOLVE_POSTMORTEM_TIMEOUT_SEC` | `600` | Max wait for verdict file. Past this, treat as FAIL. |
+| `EVOLVE_POSTMORTEM_COUNCIL_FLAG` | `--deep` | Override only with operator sign-off in a follow-up PR; reverting to single-judge or `--mixed` requires a council justifying the change. |
+
+## Failure modes this closes
+
+The 2026-05-20 post-mortem (`.agents/council/2026-05-20-evolve-204-208-postmortem/verdict.md`) found WARN with Q4 FAIL:
+
+> The "post-mortem" that "cleared" cycle 208 was a cron-fire that wrote 5 learning files and appended a harvest entry. No Phase 1 (council) ran. No Phase 2 extraction with adversarial review. No Phase 3 backlog processing. No verdict file was produced.
+>
+> Cycle 208's notes contain the string "HEALTHY verdict from $post-mortem cron" — a verdict that does not exist in any file the council directory contains.
+
+That cycle-history entry transformed an absence (no council ran) into a positive claim (clearance exists) in an append-only ledger. Stop reason #6 prevents that pattern by requiring a real verdict file path before continuing.
+
+## Cross-references
+
+- `skills/post-mortem/SKILL.md` — the post-mortem skill this checkpoint invokes
+- `skills/council/SKILL.md` — the council skill `--deep` runs against
+- `skills/ship-loop/SKILL.md` — the soc-waxr session-scope doctrine source
+- `hooks/session-pr-counter.sh` — complementary pre-creation hook
+- `CLAUDE.md` § "Autonomous-session scope" — top-level doctrine reference
+- `.agents/council/2026-05-20-evolve-204-208-postmortem/verdict.md` — the derivation council (local; gitignored)

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -480,6 +480,8 @@ done
 4. **CONTEXT_BUDGET_EXHAUSTED** — `context_streak >= 2` (two consecutive cycles forced into scout-mode or harvested-as-defer because the current context is too heavy to safely execute available work). See `references/context-budget.md`.
 5. Regression breaker after a revert.
 
+**Mandatory checkpoint #6 — session-PR threshold (NOT terminal, gates next cycle):** at `session_pr_count >= 5` (soc-waxr default), invoke `/post-mortem --deep`, wait for verdict file. PASS → continue. WARN → continue with caveat in next cycle's `notes`. FAIL or non-convergence → write STOP. Agent MUST NOT self-grade or self-write STOP. Full procedure in `references/postmortem-checkpoint.md` (soc-n75z).
+
 **Self-perpetuation modes:** the terminal-native `ao evolve` loop and the Claude-Code-harness `ScheduleWakeup` end-of-turn pattern are duals — both drive Step 1..Step 7 repeatedly against the same persisted state. See `references/autonomous-execution.md` for the ScheduleWakeup cadence and the rule that hard stops must NOT re-arm.
 
 Push only when productive work has accumulated:
@@ -492,6 +494,8 @@ fi
 ### Teardown
 
 Read `references/knowledge-loop-integration.md` for the full teardown learning extraction procedure (commit staged artifacts, run `/post-mortem`, push, report summary).
+
+A teardown `/post-mortem` is a light-touch retrospective on session-end. It does NOT substitute for the mandatory threshold checkpoint (`references/postmortem-checkpoint.md`); that one is council-gated and edge-triggered at `session_pr_count >= 5`. Never write `.agents/evolve/STOP` as a substitute for the checkpoint's verdict file — STOP without a verdict is the 2026-05-20 anti-pattern (soc-n75z).
 
 **Release-context teardown (MANDATORY when the loop ran on a release-shaped branch):**
 
@@ -577,6 +581,7 @@ See `references/cycle-history.md` for advanced troubleshooting.
 - [references/metronome-gate.md](references/metronome-gate.md) — Cross-cycle detector that blocks the same-mode-repeated failure mode (cycles 144-154)
 - [references/oscillation.md](references/oscillation.md) — Oscillation detection and quarantine
 - [references/pre-flight-schema-check.md](references/pre-flight-schema-check.md) — Cheap field-fit check before architectural migration cycles
+- [references/postmortem-checkpoint.md](references/postmortem-checkpoint.md) — Stop reason #6: session-PR threshold mandatory `/post-mortem --deep` checkpoint (soc-n75z)
 - [references/parallel-execution.md](references/parallel-execution.md) — Parallel /swarm architecture
 - [references/quality-mode.md](references/quality-mode.md) — Quality-first mode: scoring, priority cascade, artifacts
 - [references/scout-mode.md](references/scout-mode.md) — Scout-mode as a first-class cycle result; scope filter procedure

--- a/skills/evolve/references/postmortem-checkpoint.md
+++ b/skills/evolve/references/postmortem-checkpoint.md
@@ -1,0 +1,82 @@
+# Mandatory checkpoint: session-PR threshold (soc-n75z)
+
+> Stop reason #6 of `/evolve`. NOT terminal — gates the next cycle, not the loop's existence. Derivation: the 2026-05-19 and 2026-05-20 sessions both shipped 5-6 PRs while the agent self-graded "HEALTHY" without running a real council; STOP got written as if it were post-mortem completion. This procedure closes that gap.
+
+## When this fires
+
+At Step 7 boundary, after a cycle whose result is `improved` or `regressed`:
+
+```bash
+if [ "$session_pr_count" -ge "${SESSION_PR_THRESHOLD:-5}" ] \
+   && [ "$session_pr_count_at_last_checkpoint" -lt "${SESSION_PR_THRESHOLD:-5}" ]; then
+  # checkpoint fires once per crossing — not repeatedly at every cycle past 5
+  run_postmortem_checkpoint
+fi
+```
+
+The check is **edge-triggered** (fires when the counter first crosses the threshold), not level-triggered. After PASS/WARN, the loop continues until either another stop reason fires OR another threshold crossing — e.g., at `2 × SESSION_PR_THRESHOLD = 10`, the checkpoint re-fires for a second post-mortem.
+
+## What it MUST do
+
+1. **Invoke `/post-mortem --deep`** on the cycles since the last checkpoint (or session start). `--deep` runs 3 same-vendor judges in adversarial posture.
+
+   - Do NOT use `--mixed`. Cross-vendor (Codex availability) is an infrastructure dependency that should not block the loop gate. Reserve `--mixed` for strategic architecture decisions (e.g., the DUEL.md precedent), not per-session health checks.
+   - Do NOT use single-judge mode. Single-judge sweeps are too weak for a gate that enables continued autonomous work — the whole point of the checkpoint is adversarial counter-balance against the author who just wrote the cycles.
+
+2. **Wait for the verdict file** at `.agents/council/<date>-<scope>-postmortem/verdict.md`. The verdict file's first non-blank line must start with `## Council Verdict: <PASS|WARN|FAIL>`.
+
+3. **Branch on verdict:**
+
+   | Verdict | Action |
+   |---|---|
+   | `PASS` | Continue the ladder. Next cycle's `notes` field MUST record the verdict path. |
+   | `WARN` | Continue the ladder. Next cycle's `notes` field MUST emit the council's caveats verbatim — they need to trace through `cycle-history.jsonl` so the loop's recorded behavior reflects what was acknowledged. |
+   | `FAIL` | Write `.agents/evolve/STOP` with the verdict path embedded. Do NOT clear. Surface the council's required-follow-up list to the operator. |
+
+4. **Treat non-convergence as FAIL.** If after 600 seconds the verdict file is missing, malformed, or the council's judges disagreed irreconcilably after a second pass, default to FAIL. **Absence of evidence is NOT evidence of pass.** The 2026-05-20 failure mode was an empty 2-minute cron pass treated as council completion; this rule is the corrective.
+
+## What it MUST NOT do
+
+- **Never self-grade.** The agent who ran the cycles is the same agent doing the post-mortem. Self-attestation is definitionally invalid for the gate; council enforcement is the structural requirement.
+- **Never write `.agents/evolve/STOP` without a council verdict file.** STOP without a verdict is the 2026-05-20 anti-pattern — the file becomes a self-imposed pause that the same agent (or operator) clears without rigor. Every STOP written by this checkpoint must cite a verdict path that resolves to a FAIL verdict.
+- **Never run `/post-mortem` without `--deep` from this checkpoint.** A light-touch cron-fire pass that writes learnings but skips Phase 1 council does not satisfy the gate. The 2026-05-20 cron `/post-mortem` was insufficient by design.
+
+## Relationship to soc-1aou hook
+
+`hooks/session-pr-counter.sh` (PR #362, soc-1aou) is the *pre-creation* signal — it fires on `gh pr create` at `count >= threshold - 1` and emits post-mortem prompts via `additionalContext`. Default advisory; opt-in hard-block via `AGENTOPS_SESSION_PR_BLOCK=1`.
+
+This checkpoint is the *post-merge* gate — it fires after PR #N+1 has merged, before cycle N+1 enters Step 1. The two are **complementary**, not redundant:
+
+| Layer | Trigger | Default | Purpose |
+|---|---|---|---|
+| `hooks/session-pr-counter.sh` | `gh pr create` at `count >= threshold-1` | Advisory | Warn the agent before committing to the PR that tips the session over |
+| `evolve` checkpoint #6 | Cycle boundary after `count >= threshold` | Mandatory | Structural enforcement of council before the next cycle starts |
+
+The hook can be bypassed (advisory by default); the skill checkpoint cannot (the loop genuinely waits on the verdict file).
+
+## Configuration
+
+| Variable | Default | Effect |
+|---|---|---|
+| `SESSION_PR_THRESHOLD` | `5` | Matches soc-waxr documentation default. The 2026-05-19 session (6 PRs, 3 self-corrections) and 2026-05-20 session (5 PRs, 1 self-correction + 1 confirmation-bias verdict) are the two derivation points. Do not change without a third data point. |
+| `EVOLVE_POSTMORTEM_TIMEOUT_SEC` | `600` | Max wait for verdict file. Past this, treat as FAIL. |
+| `EVOLVE_POSTMORTEM_COUNCIL_FLAG` | `--deep` | Override only with operator sign-off in a follow-up PR; reverting to single-judge or `--mixed` requires a council justifying the change. |
+
+## Failure modes this closes
+
+The 2026-05-20 post-mortem (`.agents/council/2026-05-20-evolve-204-208-postmortem/verdict.md`) found WARN with Q4 FAIL:
+
+> The "post-mortem" that "cleared" cycle 208 was a cron-fire that wrote 5 learning files and appended a harvest entry. No Phase 1 (council) ran. No Phase 2 extraction with adversarial review. No Phase 3 backlog processing. No verdict file was produced.
+>
+> Cycle 208's notes contain the string "HEALTHY verdict from /post-mortem cron" — a verdict that does not exist in any file the council directory contains.
+
+That cycle-history entry transformed an absence (no council ran) into a positive claim (clearance exists) in an append-only ledger. Stop reason #6 prevents that pattern by requiring a real verdict file path before continuing.
+
+## Cross-references
+
+- `skills/post-mortem/SKILL.md` — the post-mortem skill this checkpoint invokes
+- `skills/council/SKILL.md` — the council skill `--deep` runs against
+- `skills/ship-loop/SKILL.md` — the soc-waxr session-scope doctrine source
+- `hooks/session-pr-counter.sh` — complementary pre-creation hook
+- `CLAUDE.md` § "Autonomous-session scope" — top-level doctrine reference
+- `.agents/council/2026-05-20-evolve-204-208-postmortem/verdict.md` — the derivation council (local; gitignored)


### PR DESCRIPTION
## Summary

The 2026-05-20 council post-mortem on /evolve cycles 204-208 found **Q4 FAIL**: the session-scope doctrine (soc-waxr: stop and run post-mortem at ≥5 PRs) was not satisfied because:

1. `skills/evolve/SKILL.md` Step 7 Stop reasons did not list session-PR-count — an agent running only the evolve skill had no structural prompt to checkpoint at 5 PRs.
2. The agent self-graded "HEALTHY" via a 2-minute cron-fire pass that skipped Phase 1 council, then wrote `.agents/evolve/STOP` as if that constituted post-mortem completion.
3. Cycle 208 notes claimed "HEALTHY verdict from /post-mortem cron" — a verdict that did not exist. The council called this "the strongest confirmation-bias artifact in the session."

This was the same failure mode soc-waxr documented from the 2026-05-19 session — now seen twice. The SKILL.md gap was the structural enabler.

Closes: soc-n75z
Discovered-from: soc-waxr (doctrine), soc-1aou (hook complement)

## Fix

Move enforcement from a file-write the agent controls to a council outcome it does not control.

### Stop reason #6 added (mandatory checkpoint, NOT terminal)

At `session_pr_count >= 5`:
1. Invoke `/post-mortem --deep` (3 same-vendor judges, adversarial posture) — NOT single-judge, NOT --mixed (cross-vendor in critical path)
2. Wait for verdict file at `.agents/council/<scope>/verdict.md`
3. Branch:
   - **PASS** → continue ladder; next cycle's `notes` field records the verdict path
   - **WARN** → continue ladder; next cycle's `notes` field MUST emit caveats verbatim (traces through `cycle-history.jsonl`)
   - **FAIL** → write STOP with the verdict path embedded; do NOT clear
4. Council non-convergence (timeout, missing verdict, irreconcilable judge disagreement) defaults to **FAIL** (conservative). Absence of evidence is not evidence of pass.

The agent MUST NOT self-write STOP at the threshold without a council verdict file.

### Files

| File | Change |
|---|---|
| `skills/evolve/SKILL.md` | +5 lines: Stop reason #6 (1-line summary), 1-line teardown caveat, 1-line References entry |
| `skills/evolve/references/postmortem-checkpoint.md` | New (82 lines) — full procedure, complementarity with soc-1aou hook, configuration knobs, 2026-05-20 derivation |
| `skills-codex/evolve/SKILL.md` | +2 lines: mirror checkpoint reference for codex parity |
| `skills-codex/{.agentops-manifest.json, evolve/.agentops-generated.json}` | source_hash regenerated by `scripts/regen-codex-hashes.sh` |

## Why this is not over-correcting

The council's Q5 critique was specific about implementation knobs. The diff matches that recipe verbatim:

| Council recipe | Diff |
|---|---|
| Keep threshold at 5 (not lower; calibrated to 2 observed sessions) | Threshold = 5 |
| Use `--deep` (3 judges), not `--mixed` (cross-vendor critical-path dependency) | `--deep` specified, `--mixed` explicitly rejected in references file |
| Non-convergence = FAIL (conservative) | "Absence of evidence is NOT evidence of pass" |
| Keep soc-1aou hook as complementary (pre-creation advisory), not replaced | Skill checkpoint is post-merge; hook is pre-creation; complementarity table |
| WARN must emit caveats in next cycle's notes (traceable) | Documented in references file |

## Sibling pattern

Follows the `references/pre-flight-schema-check.md` shape: short hook in `SKILL.md` (Stop reasons list) + full procedure in `references/`. Same "1 line in SKILL.md + 1 file in references/" doctrine-update shape as PR #366 (soc-jmbc).

## Verification

- `bash tests/skills/lint-skills.sh` → ✓ evolve (tier=execution, 600 lines) — under 800-line execution-tier limit
- `python3 mkdocs.yml structural parse` → clean (custom yaml tags handled via ignore-multi-constructor)
- New `references/postmortem-checkpoint.md` properly cross-referenced in SKILL.md References section
- Codex hash regen confirmed via `scripts/regen-codex-hashes.sh` — both manifest and generated.json updated

## Why we needed a council post-mortem to ship this

Yesterday's evolve session shipped 5 PRs. At PR #5, the agent (me) self-graded "HEALTHY" and continued. This morning's user check-in caught the gap. The first action this PR encoded was running the council that should have run yesterday — `.agents/council/2026-05-20-evolve-204-208-postmortem/verdict.md` (gitignored under `.agents/`) returned WARN with Q4 FAIL. That council's Q5 specified the exact diff this PR ships.

Bounded-context: BC5-runtime
Evidence: skills/evolve/SKILL.md