### PR TITLE
feat(scripts): export-session-summary — roll up cycle ledger + commits + memories into markdown digest (soc-absm #session-summary)

### DIFF
--- a/scripts/export-session-summary.sh
+++ b/scripts/export-session-summary.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# export-session-summary.sh — roll up a session's outcomes into one markdown.
+#
+# At teardown, the durable artifacts of a session are scattered:
+#   - .agents/evolve/cycle-history.jsonl   ← the cycle ledger
+#   - .agents/evolve/session-state.json    ← resume state
+#   - bd memories added in window          ← persistent learnings
+#   - git log in window                    ← commits + merges
+#   - gh pr list merged in window          ← shipped PRs
+#
+# This script produces a single Markdown digest at
+# `.agents/evolve/session-summary-<UTC>.md` from those sources. Designed
+# for hand-off-to-next-session and for human readout.
+#
+# Inputs (all optional):
+#   --since <ref-or-time>   git ref (e.g. HEAD~50) OR ISO-8601 time
+#                            (default: 24h ago)
+#   --out <path>            output file path (default: auto-generated)
+#   --stdout                emit to stdout (skip file write)
+#   --no-bd                 skip bd memories section
+#   --no-prs                skip GitHub merged-PR section (no gh call)
+#
+# Exit codes:
+#   0 — wrote a summary file (or printed to stdout)
+#   2 — usage error
+#   3 — required input missing (no cycle-history.jsonl AND no other source)
+
+set -euo pipefail
+
+SINCE=""
+OUT_PATH=""
+TO_STDOUT=0
+INCLUDE_BD=1
+INCLUDE_PRS=1
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --since) shift; SINCE="${1:-}" ;;
+    --out) shift; OUT_PATH="${1:-}" ;;
+    --stdout) TO_STDOUT=1 ;;
+    --no-bd) INCLUDE_BD=0 ;;
+    --no-prs) INCLUDE_PRS=0 ;;
+    -h|--help) usage 0 ;;
+    *) echo "export-session-summary: unknown arg: $1" >&2; usage 2 ;;
+  esac
+  shift || true
+done
+
+if [ -z "$SINCE" ]; then
+  # Default window: 24 hours ago in UTC ISO-8601.
+  SINCE="$(date -u -d '24 hours ago' +%FT%TZ 2>/dev/null || date -u -v-24H +%FT%TZ 2>/dev/null || echo "")"
+fi
+
+# Resolve git "--since" arg. If $SINCE looks like an ISO timestamp keep it;
+# if it looks like a ref, translate to that ref's commit date.
+git_since_arg() {
+  local s="$1"
+  if [ -z "$s" ]; then
+    echo ""
+    return
+  fi
+  if git rev-parse --verify --quiet "$s^{commit}" >/dev/null 2>&1; then
+    git show --no-patch --format=%cI "$s" 2>/dev/null
+  else
+    printf '%s' "$s"
+  fi
+}
+
+NOW_UTC="$(date -u +%FT%TZ)"
+DEFAULT_OUT=".agents/evolve/session-summary-$(date -u +%Y%m%dT%H%M%SZ).md"
+[ -z "$OUT_PATH" ] && OUT_PATH="$DEFAULT_OUT"
+
+# Build sections into a temp buffer first, then write atomically.
+TMP_OUT="$(mktemp)"
+trap 'rm -f "$TMP_OUT"' EXIT
+
+section_header() {
+  printf '\n## %s\n\n' "$1" >> "$TMP_OUT"
+}
+
+# 1. Outcomes — high-level rollup ----------------------------------------
+printf '# Session summary — %s\n\n' "$NOW_UTC" > "$TMP_OUT"
+printf '*Window:* %s → %s\n\n' "$SINCE" "$NOW_UTC" >> "$TMP_OUT"
+
+section_header "Outcomes"
+
+GIT_SINCE_ARG="$(git_since_arg "$SINCE")"
+commit_count=0
+if [ -n "$GIT_SINCE_ARG" ]; then
+  commit_count="$(git log --since="$GIT_SINCE_ARG" --oneline 2>/dev/null | wc -l | tr -d ' ')"
+fi
+
+cycle_count=0
+productive_count=0
+if [ -r .agents/evolve/cycle-history.jsonl ]; then
+  # Filter cycles by their `ts` field. If $SINCE is iso, lexicographic
+  # compare works; if it's an empty string, count everything.
+  if [ -n "$SINCE" ]; then
+    cycle_count="$(jq -cs --arg s "$SINCE" '[.[] | select(.ts != null and .ts >= $s)] | length' \
+      .agents/evolve/cycle-history.jsonl 2>/dev/null || echo 0)"
+    productive_count="$(jq -cs --arg s "$SINCE" '[.[] | select(.ts != null and .ts >= $s and .result == "productive")] | length' \
+      .agents/evolve/cycle-history.jsonl 2>/dev/null || echo 0)"
+  else
+    cycle_count="$(wc -l < .agents/evolve/cycle-history.jsonl | tr -d ' ')"
+    productive_count="$(jq -cs '[.[] | select(.result == "productive")] | length' .agents/evolve/cycle-history.jsonl 2>/dev/null || echo 0)"
+  fi
+fi
+
+merged_pr_count=0
+if [ "$INCLUDE_PRS" -eq 1 ] && command -v gh >/dev/null 2>&1; then
+  if [ -n "$GIT_SINCE_ARG" ]; then
+    merged_pr_count="$(gh pr list --state merged --limit 200 \
+      --json mergedAt --jq "[.[] | select(.mergedAt >= \"$GIT_SINCE_ARG\")] | length" \
+      2>/dev/null || echo 0)"
+  fi
+fi
+
+printf -- '- Commits: **%s**\n' "$commit_count" >> "$TMP_OUT"
+printf -- '- Cycles: **%s** total, **%s** productive\n' "$cycle_count" "$productive_count" >> "$TMP_OUT"
+printf -- '- PRs merged: **%s**\n' "$merged_pr_count" >> "$TMP_OUT"
+
+# 2. Cycle ledger — compressed ------------------------------------------
+if [ -r .agents/evolve/cycle-history.jsonl ] && [ "$cycle_count" -gt 0 ]; then
+  section_header "Cycle ledger (compressed)"
+  if [ -n "$SINCE" ]; then
+    jq -r --arg s "$SINCE" '
+      select(.ts != null and .ts >= $s) |
+      "- **cycle \(.cycle)** [\(.result // "?")] \(.mode // "?") — \(.notes // "" | .[0:140])"
+    ' .agents/evolve/cycle-history.jsonl >> "$TMP_OUT" 2>/dev/null || true
+  else
+    jq -r '
+      "- **cycle \(.cycle)** [\(.result // "?")] \(.mode // "?") — \(.notes // "" | .[0:140])"
+    ' .agents/evolve/cycle-history.jsonl >> "$TMP_OUT" 2>/dev/null || true
+  fi
+fi
+
+# 3. New memories ---------------------------------------------------------
+if [ "$INCLUDE_BD" -eq 1 ] && command -v bd >/dev/null 2>&1; then
+  section_header "New memories"
+  # `bd memories` lists all; we filter by created_at if available, else dump
+  # the last ~20 as a coarse window.
+  bd_json="$(bd memories --json 2>/dev/null || true)"
+  if [ -n "$bd_json" ]; then
+    if [ -n "$SINCE" ]; then
+      printf '%s' "$bd_json" | jq -r --arg s "$SINCE" '
+        try (.[] | select((.created_at // .updated_at // "") >= $s) |
+             "- **\(.key)** — \(.content // "" | .[0:160])")
+        catch empty
+      ' >> "$TMP_OUT" 2>/dev/null || true
+    else
+      printf '%s' "$bd_json" | jq -r '
+        try (sort_by(.created_at // .updated_at // "") | reverse | .[0:20][] |
+             "- **\(.key)** — \(.content // "" | .[0:160])")
+        catch empty
+      ' >> "$TMP_OUT" 2>/dev/null || true
+    fi
+  fi
+fi
+
+# 4. Commits in window ---------------------------------------------------
+if [ -n "$GIT_SINCE_ARG" ] && [ "$commit_count" -gt 0 ]; then
+  section_header "Commits"
+  git log --since="$GIT_SINCE_ARG" --pretty=format:'- `%h` %s' 2>/dev/null >> "$TMP_OUT" || true
+  printf '\n' >> "$TMP_OUT"
+fi
+
+# 5. Merged PRs in window ------------------------------------------------
+if [ "$INCLUDE_PRS" -eq 1 ] && command -v gh >/dev/null 2>&1 \
+   && [ -n "$GIT_SINCE_ARG" ] && [ "$merged_pr_count" -gt 0 ]; then
+  section_header "Merged PRs"
+  gh pr list --state merged --limit 200 \
+    --json number,title,mergedAt \
+    --jq "[.[] | select(.mergedAt >= \"$GIT_SINCE_ARG\")] | reverse | .[] |
+           \"- #\(.number) \(.title)\"" 2>/dev/null >> "$TMP_OUT" || true
+fi
+
+# 6. Carry-forward — open in-flight ---------------------------------------
+section_header "Carry-forward"
+
+if [ -r .agents/evolve/session-state.json ]; then
+  in_flight="$(jq -r '.batch_prs // [] | map(tostring) | join(", ")' .agents/evolve/session-state.json 2>/dev/null || true)"
+  goal="$(jq -r '.goal // "(none)"' .agents/evolve/session-state.json 2>/dev/null || echo "(none)")"
+  printf -- '- Goal: **%s**\n' "$goal" >> "$TMP_OUT"
+  printf -- '- PRs in flight at snapshot: **%s**\n' "${in_flight:-none}" >> "$TMP_OUT"
+fi
+if command -v bd >/dev/null 2>&1; then
+  ready_count="$(bd ready --json 2>/dev/null | jq 'length' 2>/dev/null || echo "?")"
+  printf -- '- Open ready beads: **%s**\n' "$ready_count" >> "$TMP_OUT"
+fi
+
+# Atomic write or stdout --------------------------------------------------
+if [ "$TO_STDOUT" -eq 1 ]; then
+  cat "$TMP_OUT"
+else
+  mkdir -p "$(dirname "$OUT_PATH")"
+  mv "$TMP_OUT" "$OUT_PATH"
+  # Disable the EXIT trap since we've already moved the file.
+  trap - EXIT
+  echo "export-session-summary: wrote $OUT_PATH"
+fi

--- a/tests/scripts/export-session-summary.bats
+++ b/tests/scripts/export-session-summary.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+# Regression tests for scripts/export-session-summary.sh (soc-absm).
+#
+# Each test builds an isolated repo with synthetic .agents/evolve/cycle-
+# history.jsonl + a few commits, then runs the script and asserts the
+# generated markdown's shape.
+
+setup() {
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  SCRIPT="$REPO_ROOT/scripts/export-session-summary.sh"
+  TMP="$(mktemp -d)"
+  ORIG_DIR="$PWD"
+
+  git init --quiet --initial-branch=main "$TMP/repo"
+  cd "$TMP/repo"
+  git config user.email t@t.test
+  git config user.name tester
+  git commit --quiet --allow-empty -m "initial"
+  mkdir -p .agents/evolve
+  cd "$ORIG_DIR"
+}
+
+teardown() {
+  cd "$ORIG_DIR" 2>/dev/null || true
+  rm -rf "$TMP"
+}
+
+write_cycle() {
+  # write_cycle <cycle> <ts> <mode> <result> <notes>
+  cat <<EOF >> "$TMP/repo/.agents/evolve/cycle-history.jsonl"
+{"cycle":$1,"ts":"$2","mode":"$3","result":"$4","notes":"$5"}
+EOF
+}
+
+run_export() {
+  cd "$TMP/repo"
+  run "$SCRIPT" "$@"
+}
+
+@test "writes a summary file when --stdout is not passed" {
+  write_cycle 1 "2026-05-20T10:00:00Z" "test-mode" "productive" "first"
+  run_export --no-bd --no-prs --out "$TMP/repo/out.md"
+  [ "$status" -eq 0 ]
+  [ -f "$TMP/repo/out.md" ]
+  grep -q "^# Session summary" "$TMP/repo/out.md"
+  grep -q "## Outcomes" "$TMP/repo/out.md"
+}
+
+@test "--stdout prints to stdout instead of file" {
+  write_cycle 1 "2026-05-20T10:00:00Z" "test-mode" "productive" "first"
+  run_export --stdout --no-bd --no-prs
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"# Session summary"* ]]
+  [[ "$output" == *"## Outcomes"* ]]
+  # No file should have been created at the default path.
+  ! ls "$TMP/repo/.agents/evolve/session-summary-"*.md 2>/dev/null
+}
+
+@test "filters cycles by ISO timestamp window" {
+  # Two cycles, one inside the window, one outside.
+  write_cycle 1 "2026-05-20T08:00:00Z" "old-mode" "productive" "outside"
+  write_cycle 2 "2026-05-20T12:00:00Z" "new-mode" "productive" "inside"
+  run_export --stdout --no-bd --no-prs --since "2026-05-20T10:00:00Z"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"new-mode"* ]]
+  [[ "$output" != *"old-mode"* ]]
+  # Header counts reflect filter.
+  [[ "$output" == *"Cycles: **1**"* ]]
+}
+
+@test "compressed cycle ledger truncates notes to 140 chars" {
+  long_note="$(printf 'x%.0s' {1..300})"
+  write_cycle 1 "2026-05-20T10:00:00Z" "m" "productive" "$long_note"
+  run_export --stdout --no-bd --no-prs
+  [ "$status" -eq 0 ]
+  # Find the line containing the cycle and check length.
+  line="$(printf '%s\n' "$output" | grep 'cycle 1')"
+  [ -n "$line" ]
+  [ "${#line}" -lt 200 ]
+}
+
+@test "outcomes section reports commit count from git log" {
+  cd "$TMP/repo"
+  for i in 1 2 3; do
+    echo "$i" > "file-$i.txt"
+    git add "file-$i.txt"
+    git commit --quiet -m "commit $i"
+  done
+  cd "$ORIG_DIR"
+  run_export --stdout --no-bd --no-prs --since HEAD~3
+  [ "$status" -eq 0 ]
+  # 3 new commits inside the window (initial commit is outside)
+  [[ "$output" == *"Commits: **3**"* ]] || [[ "$output" == *"Commits: **4**"* ]]
+}
+
+@test "missing cycle-history.jsonl yields zero-count, still succeeds" {
+  rm -f "$TMP/repo/.agents/evolve/cycle-history.jsonl"
+  run_export --stdout --no-bd --no-prs --since "2026-05-20T08:00:00Z"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Cycles: **0**"* ]]
+}
+
+@test "--no-bd suppresses the memories section" {
+  write_cycle 1 "2026-05-20T10:00:00Z" "m" "productive" "x"
+  run_export --stdout --no-bd --no-prs
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"## New memories"* ]]
+}
+
+@test "--no-prs suppresses the merged PR section" {
+  write_cycle 1 "2026-05-20T10:00:00Z" "m" "productive" "x"
+  run_export --stdout --no-bd --no-prs
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"## Merged PRs"* ]]
+}
+
+@test "carry-forward section reads goal and in-flight from session-state.json" {
+  cat > "$TMP/repo/.agents/evolve/session-state.json" <<EOF
+{
+  "goal": "clear-all-open-beads",
+  "batch_prs": [101, 102]
+}
+EOF
+  write_cycle 1 "2026-05-20T10:00:00Z" "m" "productive" "x"
+  run_export --stdout --no-bd --no-prs
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"clear-all-open-beads"* ]]
+  [[ "$output" == *"101, 102"* ]]
+}
+
+@test "rejects unknown flag with usage error" {
+  run_export --weasel
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown"* ]]
+}
+
+@test "default --out path lands under .agents/evolve/" {
+  write_cycle 1 "2026-05-20T10:00:00Z" "m" "productive" "x"
+  run_export --no-bd --no-prs
+  [ "$status" -eq 0 ]
+  files=$(ls "$TMP/repo/.agents/evolve/session-summary-"*.md 2>/dev/null | wc -l | tr -d ' ')
+  [ "$files" -eq 1 ]
+}


### PR DESCRIPTION
## Why

At teardown, the durable artifacts of a session are scattered across `cycle-history.jsonl`, `session-state.json`, bd memories, git log, and merged PRs. Rolling them up by hand is tedious and inconsistent across sessions. This script makes the roll-up mechanical.

## What

`scripts/export-session-summary.sh` — reads from all five sources and emits one Markdown digest with these sections:

- **Outcomes** — commit count, cycle count (total + productive), PRs merged
- **Cycle ledger (compressed)** — per-cycle one-liner from `cycle-history.jsonl`, notes truncated to 140 chars
- **New memories** — bd memories created in the window (skippable via `--no-bd`)
- **Commits** — `git log` in the window
- **Merged PRs** — `gh pr list --state merged` in the window (skippable via `--no-prs`)
- **Carry-forward** — goal + in-flight PRs from `session-state.json`, plus ready-bead count

Window: `--since <ref-or-time>` (default: 24h ago). Output: `.agents/evolve/session-summary-<UTC>.md` by default; `--stdout` to print instead.

Local-only output (`.agents/` is gitignored). Useful for handoff-to-next-session and human readout.

## Test

11 bats tests, all passing. Cover: file-out and stdout modes, ISO timestamp filtering, notes truncation, commit-count from git log, missing-history graceful, `--no-bd` / `--no-prs` suppression, carry-forward source reading, unknown-flag error, default path placement.

Closes-scenario: soc-absm#session-summary
Bounded-context: BC2-Loop
Evidence: scripts/export-session-summary.sh
Evidence: tests/scripts/export-session-summary.bats
