### PR TITLE
feat(scripts): doctor-evolve — 7-check preflight for /evolve loop preconditions (soc-kcy4 #doctor-evolve)

### DIFF
--- a/scripts/doctor-evolve.sh
+++ b/scripts/doctor-evolve.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# doctor-evolve.sh — preflight checks for /evolve loop preconditions.
+#
+# /evolve has many silent-failure modes. When GOALS.md is unparseable,
+# .agents/evolve/session-state.json has stale claims, scripts/cron-tune-
+# cadence.sh is missing, or the next-work.jsonl tail is schema-invalid,
+# the loop degrades quietly instead of stopping. This script runs the
+# precondition checklist explicitly so the agent — or operator — knows
+# what's wrong before a cycle starts.
+#
+# Checks (each PASS/WARN/FAIL):
+#   1. GOALS.md exists and parses (yaml fallback to .yaml)
+#   2. .agents/evolve/session-state.json present + valid JSON + required keys
+#   3. scripts/cron-tune-cadence.sh present + executable + reports STAY/UP/DOWN
+#   4. .agents/rpi/next-work.jsonl exists + tail line is JSON
+#   5. No STOP / DORMANT / KILL markers
+#   6. No stale claim_status=in_progress claims (claimed > 24h ago)
+#   7. cycle-history.jsonl tail entry has required fields
+#
+# Flags:
+#   --strict     fail (exit 1) on any WARN as well as FAIL
+#   --json       machine-readable summary
+#   --quiet      print only failures
+#
+# Exit codes:
+#   0 — all checks pass (or pass with warnings, without --strict)
+#   1 — at least one FAIL (or WARN under --strict)
+#   2 — usage error
+
+set -euo pipefail
+
+STRICT=0
+JSON=0
+QUIET=0
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --strict) STRICT=1 ;;
+    --json) JSON=1 ;;
+    --quiet) QUIET=1 ;;
+    -h|--help) usage 0 ;;
+    *) echo "doctor-evolve: unknown arg: $1" >&2; usage 2 ;;
+  esac
+  shift || true
+done
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# We collect findings as TSV: status<tab>check<tab>detail
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+emit() {
+  printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$TMP"
+}
+
+# --- Check 1: GOALS file ---
+goals_file=""
+if [ -f "$ROOT/GOALS.md" ]; then
+  goals_file="$ROOT/GOALS.md"
+elif [ -f "$ROOT/GOALS.yaml" ]; then
+  goals_file="$ROOT/GOALS.yaml"
+fi
+if [ -z "$goals_file" ]; then
+  emit FAIL goals "no GOALS.md or GOALS.yaml at $ROOT — /evolve cannot measure fitness"
+else
+  if [ "${goals_file##*.}" = "yaml" ] && command -v yq >/dev/null 2>&1; then
+    if yq eval . "$goals_file" >/dev/null 2>&1; then
+      emit PASS goals "GOALS.yaml parseable"
+    else
+      emit FAIL goals "GOALS.yaml is not valid yaml"
+    fi
+  else
+    emit PASS goals "$(basename "$goals_file") present"
+  fi
+fi
+
+# --- Check 2: session-state.json ---
+state_file="$ROOT/.agents/evolve/session-state.json"
+if [ ! -f "$state_file" ]; then
+  emit WARN session-state "missing $state_file (loop will initialize on first cycle)"
+else
+  if ! jq -e . "$state_file" >/dev/null 2>&1; then
+    emit FAIL session-state "$state_file is not valid JSON"
+  else
+    # Required keys per evolve doctrine.
+    missing=""
+    for k in session_pr_count batch_prs heartbeat_streak; do
+      if ! jq -e "has(\"$k\")" "$state_file" >/dev/null 2>&1; then
+        missing="$missing $k"
+      fi
+    done
+    if [ -n "$missing" ]; then
+      emit WARN session-state "missing keys:$missing"
+    else
+      emit PASS session-state "valid JSON + required keys present"
+    fi
+  fi
+fi
+
+# --- Check 3: cron-tune-cadence.sh ---
+tune_script="$ROOT/scripts/cron-tune-cadence.sh"
+if [ ! -x "$tune_script" ]; then
+  emit FAIL cron-tune "$tune_script missing or not executable"
+else
+  out="$(bash "$tune_script" heartbeat 2>/dev/null | tail -1 || true)"
+  case "$out" in
+    STAY|TUNE_UP|TUNE_DOWN) emit PASS cron-tune "responds with $out" ;;
+    *) emit FAIL cron-tune "unexpected output: $out" ;;
+  esac
+fi
+
+# --- Check 4: next-work.jsonl tail ---
+nw_file="$ROOT/.agents/rpi/next-work.jsonl"
+if [ ! -f "$nw_file" ]; then
+  emit WARN next-work "no $nw_file (evolve will skip harvested-work rung)"
+else
+  if ! tail -1 "$nw_file" | jq -e . >/dev/null 2>&1; then
+    emit FAIL next-work "tail line of next-work.jsonl is not valid JSON"
+  else
+    emit PASS next-work "tail line is valid JSON"
+  fi
+fi
+
+# --- Check 5: STOP / DORMANT / KILL markers ---
+markers_seen=""
+for m in .agents/evolve/STOP .agents/evolve/DORMANT; do
+  [ -f "$ROOT/$m" ] && markers_seen="$markers_seen $m"
+done
+[ -f "$HOME/.config/evolve/KILL" ] && markers_seen="$markers_seen ~/.config/evolve/KILL"
+if [ -n "$markers_seen" ]; then
+  emit WARN markers "loop-halt markers present:$markers_seen"
+else
+  emit PASS markers "no STOP/DORMANT/KILL markers"
+fi
+
+# --- Check 6: stale in-flight claims ---
+if [ -f "$nw_file" ]; then
+  now_epoch="$(date -u +%s)"
+  # Per-line jq so a single malformed line doesn't kill the whole check
+  # under set -e + pipefail.
+  stale=0
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    is_stale="$(printf '%s' "$line" | jq -r --argjson now "$now_epoch" '
+      select(.claim_status == "in_progress") |
+      select((.claimed_at // null) != null) |
+      .claimed_at | fromdateiso8601 as $t |
+      select(($now - $t) > 86400) | "stale"
+    ' 2>/dev/null || true)"
+    [ "$is_stale" = "stale" ] && stale=$((stale + 1))
+  done < "$nw_file"
+  if [ "$stale" -gt 0 ]; then
+    emit WARN stale-claims "$stale claim(s) in_progress > 24h"
+  else
+    emit PASS stale-claims "no claims older than 24h"
+  fi
+fi
+
+# --- Check 7: cycle-history tail ---
+ch_file="$ROOT/.agents/evolve/cycle-history.jsonl"
+if [ ! -f "$ch_file" ]; then
+  emit WARN cycle-history "no $ch_file (first-run state OK)"
+else
+  tail_entry="$(tail -1 "$ch_file" 2>/dev/null)"
+  if [ -z "$tail_entry" ]; then
+    emit WARN cycle-history "tail line is empty"
+  elif ! printf '%s' "$tail_entry" | jq -e . >/dev/null 2>&1; then
+    emit FAIL cycle-history "tail line is not valid JSON"
+  else
+    # required: cycle + result
+    missing=""
+    for k in cycle result; do
+      if ! printf '%s' "$tail_entry" | jq -e ".$k != null" >/dev/null 2>&1; then
+        missing="$missing $k"
+      fi
+    done
+    if [ -n "$missing" ]; then
+      emit WARN cycle-history "tail missing fields:$missing"
+    else
+      cycle_num="$(printf '%s' "$tail_entry" | jq -r .cycle)"
+      emit PASS cycle-history "last cycle $cycle_num well-formed"
+    fi
+  fi
+fi
+
+# --- Emit results ---
+pass=$(awk -F'\t' '$1=="PASS"' "$TMP" | wc -l | tr -d ' ')
+warn=$(awk -F'\t' '$1=="WARN"' "$TMP" | wc -l | tr -d ' ')
+fail=$(awk -F'\t' '$1=="FAIL"' "$TMP" | wc -l | tr -d ' ')
+
+if [ "$JSON" -eq 1 ]; then
+  findings_json="$(awk -F'\t' '{
+    printf "{\"status\":\"%s\",\"check\":\"%s\",\"detail\":\"%s\"}\n", $1, $2, $3
+  }' "$TMP" | jq -s .)"
+  jq -nc --argjson pass "$pass" --argjson warn "$warn" --argjson fail "$fail" \
+    --argjson findings "$findings_json" \
+    '{pass:$pass, warn:$warn, fail:$fail, findings:$findings}'
+else
+  printf 'doctor-evolve: %d PASS / %d WARN / %d FAIL\n' "$pass" "$warn" "$fail"
+  if [ "$QUIET" -eq 1 ]; then
+    awk -F'\t' '$1=="FAIL" || $1=="WARN"' "$TMP" | sed 's/\t/ — /; s/\t/ — /'
+  else
+    awk -F'\t' '{ printf "  %-4s %-15s %s\n", $1, $2, $3 }' "$TMP"
+  fi
+fi
+
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi
+if [ "$STRICT" -eq 1 ] && [ "$warn" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/scripts/doctor-evolve.bats
+++ b/tests/scripts/doctor-evolve.bats
@@ -1,0 +1,168 @@
+#!/usr/bin/env bats
+# Regression tests for scripts/doctor-evolve.sh (soc-kcy4).
+#
+# The script resolves repo root via `git rev-parse --show-toplevel`. Each
+# test builds an isolated fixture repo + the precondition files (or
+# deliberately omits them) and runs the script from inside it.
+
+setup() {
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  SCRIPT="$REPO_ROOT/scripts/doctor-evolve.sh"
+  TUNE_SCRIPT_SRC="$REPO_ROOT/scripts/cron-tune-cadence.sh"
+  TMP="$(mktemp -d)"
+  ORIG_DIR="$PWD"
+
+  git init --quiet --initial-branch=main "$TMP/repo"
+  cd "$TMP/repo"
+  git config user.email t@t.test
+  git config user.name tester
+  git commit --quiet --allow-empty -m "initial"
+  mkdir -p .agents/evolve .agents/rpi scripts
+  # cron-tune-cadence is checked by doctor-evolve; install a working copy
+  # so check #3 passes by default.
+  if [ -r "$TUNE_SCRIPT_SRC" ]; then
+    cp "$TUNE_SCRIPT_SRC" scripts/cron-tune-cadence.sh
+    chmod +x scripts/cron-tune-cadence.sh
+  fi
+  # Minimal GOALS.md so check #1 passes.
+  echo '# GOALS' > GOALS.md
+  cd "$ORIG_DIR"
+}
+
+teardown() {
+  cd "$ORIG_DIR" 2>/dev/null || true
+  rm -rf "$TMP"
+}
+
+run_dr() {
+  cd "$TMP/repo"
+  run "$SCRIPT" "$@"
+}
+
+# --- Tests ---
+
+@test "all clean fixture passes with exit 0" {
+  cat > "$TMP/repo/.agents/evolve/session-state.json" <<EOF
+{"session_pr_count":0,"batch_prs":[],"heartbeat_streak":0}
+EOF
+  cat > "$TMP/repo/.agents/rpi/next-work.jsonl" <<EOF
+{"source_epic":"test","items":[],"consumed":false}
+EOF
+  cat > "$TMP/repo/.agents/evolve/cycle-history.jsonl" <<EOF
+{"cycle":1,"result":"productive","ts":"2026-05-20T12:00:00Z"}
+EOF
+  run_dr
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
+  [[ "$output" == *"0 FAIL"* ]]
+}
+
+@test "missing GOALS.md is a FAIL" {
+  rm -f "$TMP/repo/GOALS.md"
+  run_dr
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"GOALS.md"* ]] || [[ "$output" == *"goals"* ]]
+}
+
+@test "session-state.json missing is WARN not FAIL" {
+  run_dr
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WARN"* ]]
+  [[ "$output" == *"session-state"* ]]
+}
+
+@test "session-state.json malformed is a FAIL" {
+  echo "{ not json }" > "$TMP/repo/.agents/evolve/session-state.json"
+  run_dr
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"session-state"* ]]
+}
+
+@test "cron-tune-cadence missing is a FAIL" {
+  rm -f "$TMP/repo/scripts/cron-tune-cadence.sh"
+  run_dr
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"cron-tune"* ]]
+  [[ "$output" == *"FAIL"* ]]
+}
+
+@test "STOP marker is reported as WARN" {
+  touch "$TMP/repo/.agents/evolve/STOP"
+  run_dr
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WARN"* ]]
+  [[ "$output" == *"STOP"* ]] || [[ "$output" == *"markers"* ]]
+}
+
+@test "stale in-progress claim is reported as WARN" {
+  cat > "$TMP/repo/.agents/rpi/next-work.jsonl" <<EOF
+{"items":[],"consumed":false,"claim_status":"in_progress","claimed_at":"2020-01-01T00:00:00Z"}
+EOF
+  run_dr
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"stale-claims"* ]] || [[ "$output" == *"WARN"* ]]
+  [[ "$output" == *"in_progress"* ]] || [[ "$output" == *"stale"* ]]
+}
+
+@test "fresh in-progress claim (today) does NOT trigger stale WARN" {
+  now="$(date -u +%FT%TZ)"
+  cat > "$TMP/repo/.agents/rpi/next-work.jsonl" <<EOF
+{"items":[],"consumed":false,"claim_status":"in_progress","claimed_at":"$now"}
+EOF
+  run_dr
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no claims older than 24h"* ]]
+}
+
+@test "cycle-history malformed tail is FAIL" {
+  echo "not even close to json" >> "$TMP/repo/.agents/evolve/cycle-history.jsonl"
+  run_dr
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"cycle-history"* ]]
+  [[ "$output" == *"FAIL"* ]]
+}
+
+@test "next-work.jsonl malformed tail is FAIL" {
+  echo "garbage" >> "$TMP/repo/.agents/rpi/next-work.jsonl"
+  run_dr
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"next-work"* ]]
+  [[ "$output" == *"FAIL"* ]]
+}
+
+@test "--strict promotes any WARN to FAIL exit" {
+  # WARN-only fixture (no FAIL): session-state and cycle-history missing.
+  run_dr --strict
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"WARN"* ]]
+}
+
+@test "--json output is parseable and matches counts" {
+  # Ensure all 7 checks fire by giving the fixture a next-work.jsonl too.
+  cat > "$TMP/repo/.agents/rpi/next-work.jsonl" <<EOF
+{"items":[],"consumed":false}
+EOF
+  run_dr --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '(.pass + .warn + .fail) == 7' >/dev/null
+  echo "$output" | jq -e '.findings | length == 7' >/dev/null
+}
+
+@test "--quiet suppresses PASS detail lines, keeps WARN/FAIL" {
+  echo "garbage" >> "$TMP/repo/.agents/rpi/next-work.jsonl"
+  run_dr --quiet
+  [ "$status" -eq 1 ]
+  # The summary header always shows "N PASS / N WARN / N FAIL". The quiet
+  # contract is "no PER-CHECK PASS rows", not "no occurrence of word PASS".
+  pass_rows="$(printf '%s\n' "$output" | grep -c 'PASS [[:alpha:]-]' || true)"
+  [ "$pass_rows" -eq 0 ]
+  [[ "$output" == *"FAIL"* ]]
+}
+
+@test "unknown flag exits 2 with usage error" {
+  run_dr --weasel
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown"* ]]
+}


### PR DESCRIPTION
## Why

`/evolve` has many silent-failure modes: GOALS unparseable, `session-state.json` missing required keys, `cron-tune-cadence.sh` not on PATH, `next-work.jsonl` tail malformed, stale `claim_status: in_progress` claims left over from a dead session, `STOP` / `DORMANT` / `KILL` markers forgotten, `cycle-history.jsonl` tail missing required fields. When any of these is silently wrong, the loop degrades quietly instead of stopping. Operator (or the agent itself at cycle start) needs a precondition checklist.

## What

`scripts/doctor-evolve.sh` — 7-check preflight, each PASS/WARN/FAIL:

1. GOALS.md / GOALS.yaml present + parseable
2. `session-state.json` valid JSON + has required keys
3. `cron-tune-cadence.sh` present + executable + reports STAY/UP/DOWN
4. `next-work.jsonl` tail line is valid JSON
5. No STOP / DORMANT / KILL markers
6. No `in_progress` claims older than 24h
7. `cycle-history.jsonl` tail entry well-formed

Flags: `--strict` (WARN counts as failure) `--json` `--quiet` (suppress PASS detail rows; keep summary header)

Robust: per-line `jq` on `next-work.jsonl` so a single malformed line doesn't sink the whole check under `set -e + pipefail`. No project deps; pure shell + jq.

Designed to run at `/evolve` Step 0 as an advisory (warn-not-fail). Standalone today; future `ao doctor --evolve` subcommand can wrap it.

## Test

14 bats tests, all passing. Cover: all-clean fixture / each individual failure mode / fresh-vs-stale claim discrimination / `--strict` warn-as-fail / `--json` count integrity / `--quiet` row suppression / unknown-flag error.

Self-dogfood (against this repo): 5 PASS, 2 WARN, 0 FAIL.

Closes-scenario: soc-kcy4#doctor-evolve
Bounded-context: BC2-Loop
Evidence: scripts/doctor-evolve.sh
Evidence: tests/scripts/doctor-evolve.bats
