### PR TITLE
feat(scripts): skill catalog generator + drift gate (soc-vuu6.4 slice 1 #catalog-generator)

### DIFF
--- a/schemas/skill-catalog.schema.json
+++ b/schemas/skill-catalog.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/boshu2/agentops/blob/main/schemas/skill-catalog.schema.json",
+  "title": "AgentOps Skill Catalog",
+  "description": "Generated inventory of skills/*/SKILL.md with queryable metadata. Source of truth: scripts/generate-skill-catalog.sh. Regenerate on every SKILL.md edit; CI gate validate-skill-catalog-drift refuses drift.",
+  "type": "object",
+  "required": ["schema_version", "generated_at", "skill_count", "skills"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": "1",
+      "description": "Bumped when schema changes; consumers gate on this."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC ISO-8601 timestamp from the generator run that emitted this file."
+    },
+    "skill_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of entries in `skills`. Must match `skills | length`."
+    },
+    "skills": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/skill" }
+    }
+  },
+  "definitions": {
+    "skill": {
+      "type": "object",
+      "required": ["name", "description", "hexagonal_role", "consumes", "produces", "context_rel", "user_invocable", "references_count", "codex_override_present"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Skill slug = directory name under skills/."
+        },
+        "description": {
+          "type": "string",
+          "description": "One-line summary lifted from SKILL.md frontmatter."
+        },
+        "hexagonal_role": {
+          "type": "string",
+          "enum": ["domain", "driving-adapter", "driven-adapter", "supporting", "generic"],
+          "description": "Hex role per soc-e8pj/PR #376 enum."
+        },
+        "consumes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Port / sibling-skill names this skill reads from."
+        },
+        "produces": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Port / artifact names this skill writes."
+        },
+        "context_rel": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "kind": { "type": "string" },
+              "with": { "type": "string" }
+            }
+          },
+          "description": "Hex relationships (customer-of, shared-kernel, alias-of, ...)."
+        },
+        "practices": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Optional engineering practices the skill applies (tdd, bdd-gherkin, ...)."
+        },
+        "user_invocable": {
+          "type": "boolean",
+          "description": "True when the skill is meant to be invoked directly by an operator (`user-invocable: true` in frontmatter)."
+        },
+        "codex_override_present": {
+          "type": "boolean",
+          "description": "True when skills-codex/<name>/SKILL.md or skills-codex-overrides/<name>/ exists."
+        },
+        "references_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of files under skills/<name>/references/."
+        }
+      }
+    }
+  }
+}

--- a/scripts/check-skill-catalog-drift.sh
+++ b/scripts/check-skill-catalog-drift.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# check-skill-catalog-drift.sh — CI gate that fails if skills/catalog.json
+# is out of sync with skills/*/SKILL.md frontmatter.
+#
+# Thin wrapper over generate-skill-catalog.sh --check so the workflow has a
+# stable, named entry point and any future drift checks (catalog vs schema,
+# catalog vs codex parity) can be added here without changing the workflow.
+#
+# Exit codes:
+#   0 — catalog up-to-date
+#   1 — drift detected
+#   2 — wrapper or upstream tool error
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+GEN="$ROOT/scripts/generate-skill-catalog.sh"
+
+if [ ! -x "$GEN" ]; then
+  echo "check-skill-catalog-drift: $GEN missing or not executable" >&2
+  exit 2
+fi
+
+"$GEN" --check

--- a/scripts/generate-skill-catalog.sh
+++ b/scripts/generate-skill-catalog.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# generate-skill-catalog.sh — emit skills/catalog.json from SKILL.md frontmatter.
+#
+# Walks every skills/*/SKILL.md, parses YAML frontmatter, and emits a single
+# queryable JSON file conforming to schemas/skill-catalog.schema.json. Slice
+# 1 of soc-vuu6.4 (skill catalog as queryable JSON). Subsequent slices add
+# `ao skills list/consumers/producers/graph` (slice 2) and consumers in the
+# showcase (slice 3).
+#
+# Modes:
+#   default      Regenerate skills/catalog.json from scratch.
+#   --check      Regenerate to a tmp file and diff against the committed
+#                catalog. Exit 1 if drift detected (CI gate).
+#   --stdout     Emit JSON to stdout; do not write any file.
+#   --out PATH   Custom output path (default: skills/catalog.json).
+#
+# Exit codes:
+#   0 — wrote / matched
+#   1 — drift detected in --check mode, OR generator failure
+#   2 — usage error
+#   3 — required tool missing (jq, awk) or skills/ dir absent
+
+set -euo pipefail
+
+MODE="write"
+OUT_PATH=""
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check) MODE="check" ;;
+    --stdout) MODE="stdout" ;;
+    --out) shift; OUT_PATH="${1:-}" ;;
+    -h|--help) usage 0 ;;
+    *) echo "generate-skill-catalog: unknown arg: $1" >&2; usage 2 ;;
+  esac
+  shift || true
+done
+
+for cmd in jq awk; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "generate-skill-catalog: required tool missing: $cmd" >&2
+    exit 3
+  fi
+done
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+SKILLS_DIR="$ROOT/skills"
+CODEX_DIR="$ROOT/skills-codex"
+OVERRIDES_DIR="$ROOT/skills-codex-overrides"
+[ -z "$OUT_PATH" ] && OUT_PATH="$ROOT/skills/catalog.json"
+
+if [ ! -d "$SKILLS_DIR" ]; then
+  echo "generate-skill-catalog: skills/ not found at $SKILLS_DIR" >&2
+  exit 3
+fi
+
+# Extract YAML frontmatter (between the first two `---` lines) of a file.
+extract_frontmatter() {
+  awk '/^---$/{c++; if(c==2) exit; next} c==1' "$1"
+}
+
+# Convert a YAML block into JSON via the smallest, dependency-free path:
+# write to a temp file, then use awk to translate into a JSON object
+# preserving lists. We only handle the subset of YAML our SKILL.md
+# frontmatter actually uses — scalar key:value, lists (`- item`), and
+# nested object lists for `context_rel` (kind: / with:). Anything more
+# exotic is reported as `null` and skipped.
+# Returns JSON object with only the fields we project into the catalog.
+parse_frontmatter() {
+  local fm="$1"
+  awk -v fm="$fm" '
+    function trim(s){ sub(/^[[:space:]]+/,"",s); sub(/[[:space:]]+$/,"",s); return s }
+    function jstr(s) {
+      gsub(/\\/, "\\\\", s)
+      gsub(/"/, "\\\"", s)
+      gsub(/\t/, "\\t", s)
+      gsub(/\r/, "\\r", s)
+      return "\"" s "\""
+    }
+    BEGIN {
+      n = split(fm, lines, "\n")
+      cur_key = ""
+      in_list = 0
+      list_buf = ""
+      ctx_in = 0
+      ctx_buf = ""
+      ctx_kind = ""; ctx_with = ""
+      out["name"] = ""; out["description"] = ""
+      out["hexagonal_role"] = ""; out["user_invocable"] = "false"
+      list_vals["consumes"] = ""
+      list_vals["produces"] = ""
+      list_vals["practices"] = ""
+      ctx_list = ""
+    }
+    {
+      # Re-iterate over the lines stored in `lines[]`.
+    }
+    END {
+      for (i = 1; i <= n; i++) {
+        line = lines[i]
+        if (line ~ /^[[:space:]]*$/) { continue }
+        # Top-level scalar (key: value)
+        if (line ~ /^[A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*[^[:space:]].*$/) {
+          # Flush any pending list state, including a half-built context_rel
+          # entry — without this, the LAST entry in a context_rel block is
+          # silently dropped when we transition to the next scalar key.
+          if (ctx_in && ctx_kind != "") {
+            ctx_list = ctx_list (ctx_list == "" ? "" : ",") "{" jstr("kind") ":" jstr(ctx_kind) "," jstr("with") ":" jstr(ctx_with) "}"
+            ctx_kind = ""; ctx_with = ""
+          }
+          in_list = 0; cur_key = ""
+          ctx_in = 0
+          key = line; sub(/:.*/, "", key)
+          val = line; sub(/^[^:]*:[[:space:]]*/, "", val); val = trim(val)
+          # Strip surrounding quotes if quoted
+          if (val ~ /^".*"$/) { val = substr(val, 2, length(val) - 2) }
+          if (val ~ /^'\''.*'\''$/) { val = substr(val, 2, length(val) - 2) }
+          if (key == "name") out["name"] = val
+          else if (key == "description") out["description"] = val
+          else if (key == "hexagonal_role") out["hexagonal_role"] = val
+          else if (key == "user-invocable" || key == "user_invocable") {
+            out["user_invocable"] = (val == "true" ? "true" : "false")
+          }
+          continue
+        }
+        # Top-level key with no value (list opener: `consumes:`)
+        if (line ~ /^[A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*$/) {
+          key = line; sub(/:.*/, "", key)
+          # Reset state for new list/section
+          if (ctx_in && ctx_kind != "") {
+            ctx_list = ctx_list (ctx_list == "" ? "" : ",") "{" jstr("kind") ":" jstr(ctx_kind) "," jstr("with") ":" jstr(ctx_with) "}"
+            ctx_kind = ""; ctx_with = ""
+          }
+          ctx_in = (key == "context_rel" ? 1 : 0)
+          if (ctx_in) { cur_key = "" ; in_list = 0; continue }
+          in_list = (key == "consumes" || key == "produces" || key == "practices") ? 1 : 0
+          cur_key = key
+          continue
+        }
+        # List item — `- value` (simple scalar)
+        if (in_list && line ~ /^-[[:space:]]+[^[:space:]]/) {
+          item = line; sub(/^-[[:space:]]+/, "", item); item = trim(item)
+          if (list_vals[cur_key] == "") list_vals[cur_key] = jstr(item)
+          else list_vals[cur_key] = list_vals[cur_key] "," jstr(item)
+          continue
+        }
+        # context_rel item kickoff: `- kind: alias-of` (one entry start)
+        if (ctx_in && line ~ /^-[[:space:]]+kind:/) {
+          if (ctx_kind != "") {
+            ctx_list = ctx_list (ctx_list == "" ? "" : ",") "{" jstr("kind") ":" jstr(ctx_kind) "," jstr("with") ":" jstr(ctx_with) "}"
+          }
+          ctx_kind = line; sub(/^-[[:space:]]+kind:[[:space:]]*/, "", ctx_kind); ctx_kind = trim(ctx_kind)
+          ctx_with = ""
+          continue
+        }
+        # context_rel continuation: `  with: foo`
+        if (ctx_in && line ~ /^[[:space:]]+with:[[:space:]]*/) {
+          ctx_with = line; sub(/^[[:space:]]+with:[[:space:]]*/, "", ctx_with); ctx_with = trim(ctx_with)
+          continue
+        }
+      }
+      if (ctx_in && ctx_kind != "") {
+        ctx_list = ctx_list (ctx_list == "" ? "" : ",") "{" jstr("kind") ":" jstr(ctx_kind) "," jstr("with") ":" jstr(ctx_with) "}"
+      }
+      printf "{"
+      printf "%s:%s,", jstr("name"), jstr(out["name"])
+      printf "%s:%s,", jstr("description"), jstr(out["description"])
+      printf "%s:%s,", jstr("hexagonal_role"), jstr(out["hexagonal_role"])
+      printf "%s:%s,", jstr("user_invocable"), out["user_invocable"]
+      printf "%s:[%s],", jstr("consumes"), list_vals["consumes"]
+      printf "%s:[%s],", jstr("produces"), list_vals["produces"]
+      printf "%s:[%s],", jstr("practices"), list_vals["practices"]
+      printf "%s:[%s]", jstr("context_rel"), ctx_list
+      printf "}"
+    }
+  '
+}
+
+# Build the catalog payload.
+TMP_PAYLOAD="$(mktemp)"
+trap 'rm -f "$TMP_PAYLOAD"' EXIT
+
+skill_count=0
+printf '[' > "$TMP_PAYLOAD"
+first=1
+for sd in "$SKILLS_DIR"/*/SKILL.md; do
+  [ -r "$sd" ] || continue
+  name="$(basename "$(dirname "$sd")")"
+  fm="$(extract_frontmatter "$sd")"
+  base="$(parse_frontmatter "$fm")"
+  # Compute reference count + codex override presence.
+  refs_dir="$SKILLS_DIR/$name/references"
+  ref_count=0
+  [ -d "$refs_dir" ] && ref_count="$(find "$refs_dir" -maxdepth 1 -type f -name '*.md' | wc -l | tr -d ' ')"
+  codex_present="false"
+  [ -d "$CODEX_DIR/$name" ] || [ -d "$OVERRIDES_DIR/$name" ] && codex_present="true"
+  # Merge generator-only fields into base JSON via jq.
+  entry="$(printf '%s' "$base" | jq -c --arg n "$name" --argjson rc "$ref_count" --argjson cp "$codex_present" '
+    .name = (if .name == "" then $n else .name end) |
+    .references_count = $rc |
+    .codex_override_present = $cp
+  ')"
+  if [ "$first" -eq 1 ]; then first=0; else printf ',' >> "$TMP_PAYLOAD"; fi
+  printf '%s' "$entry" >> "$TMP_PAYLOAD"
+  skill_count=$((skill_count + 1))
+done
+printf ']' >> "$TMP_PAYLOAD"
+
+NOW="$(date -u +%FT%TZ)"
+CATALOG_JSON="$(jq -c \
+  --arg ts "$NOW" \
+  --argjson count "$skill_count" \
+  --slurpfile skills "$TMP_PAYLOAD" \
+  -n '{schema_version:"1", generated_at:$ts, skill_count:$count, skills:$skills[0]}')"
+
+case "$MODE" in
+  stdout)
+    printf '%s\n' "$CATALOG_JSON" | jq .
+    ;;
+  check)
+    if [ ! -r "$OUT_PATH" ]; then
+      echo "generate-skill-catalog: catalog not committed at $OUT_PATH (run without --check to generate)" >&2
+      exit 1
+    fi
+    # Compare ignoring generated_at (timestamp drifts every run).
+    new_norm="$(printf '%s' "$CATALOG_JSON" | jq 'del(.generated_at)')"
+    old_norm="$(jq 'del(.generated_at)' "$OUT_PATH")"
+    if [ "$new_norm" = "$old_norm" ]; then
+      echo "generate-skill-catalog: catalog up-to-date ($skill_count skills)"
+      exit 0
+    fi
+    echo "generate-skill-catalog: DRIFT — committed catalog differs from regeneration" >&2
+    diff <(printf '%s' "$old_norm") <(printf '%s' "$new_norm") | head -40 >&2 || true
+    exit 1
+    ;;
+  write)
+    mkdir -p "$(dirname "$OUT_PATH")"
+    printf '%s\n' "$CATALOG_JSON" | jq . > "$OUT_PATH"
+    echo "generate-skill-catalog: wrote $OUT_PATH ($skill_count skills)"
+    ;;
+esac

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,0 +1,1681 @@
+{
+  "schema_version": "1",
+  "generated_at": "2026-05-20T22:21:21Z",
+  "skill_count": 79,
+  "skills": [
+    {
+      "name": "autodev",
+      "description": "Manage bounded autonomous dev loops.",
+      "hexagonal_role": "supporting",
+      "user_invocable": true,
+      "consumes": [
+        "evolve",
+        "rpi"
+      ],
+      "produces": [],
+      "practices": [
+        "cmm-process-maturity",
+        "ai-assisted-dev",
+        "dora-metrics"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "beads",
+      "description": "Track issues with bd/br, triage with bv, and convert plans to beads.",
+      "hexagonal_role": "driven-adapter",
+      "user_invocable": false,
+      "consumes": [
+        "bd-issue"
+      ],
+      "produces": [
+        "bd-issue"
+      ],
+      "practices": [
+        "agile-manifesto",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [
+        {
+          "kind": "supplier-to",
+          "with": "crank"
+        },
+        {
+          "kind": "supplier-to",
+          "with": "ratchet"
+        }
+      ],
+      "references_count": 19,
+      "codex_override_present": true
+    },
+    {
+      "name": "bootstrap",
+      "description": "Initialize AgentOps project files.",
+      "hexagonal_role": "driving-adapter",
+      "user_invocable": true,
+      "consumes": [
+        "goals",
+        "product",
+        "readme",
+        "shared"
+      ],
+      "produces": [],
+      "practices": [
+        "containers",
+        "hermetic-builds",
+        "code-complete"
+      ],
+      "context_rel": [],
+      "references_count": 1,
+      "codex_override_present": true
+    },
+    {
+      "name": "brainstorm",
+      "description": "Separate goals from implementation.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [
+        "standards"
+      ],
+      "produces": [
+        "result.json",
+        "verdict.json"
+      ],
+      "practices": [
+        "lean-startup",
+        "mythical-man-month"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 1,
+      "codex_override_present": true
+    },
+    {
+      "name": "bug-hunt",
+      "description": "Investigate bugs and root causes.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [
+        "beads",
+        "standards"
+      ],
+      "produces": [],
+      "practices": [
+        "refactoring",
+        "property-based-testing",
+        "code-complete"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 8,
+      "codex_override_present": true
+    },
+    {
+      "name": "codex-team",
+      "description": "Coordinate multiple Codex agents.",
+      "hexagonal_role": "supporting",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        ".agents/swarm/results/*.json"
+      ],
+      "practices": [
+        "team-topologies",
+        "ai-assisted-dev"
+      ],
+      "context_rel": [],
+      "references_count": 2,
+      "codex_override_present": true
+    },
+    {
+      "name": "compile",
+      "description": "Compile .agents knowledge wiki.",
+      "hexagonal_role": "supporting",
+      "user_invocable": true,
+      "consumes": [],
+      "produces": [],
+      "practices": [
+        "wiki-knowledge-surface",
+        "ddd-bounded-context"
+      ],
+      "context_rel": [],
+      "references_count": 4,
+      "codex_override_present": true
+    },
+    {
+      "name": "complexity",
+      "description": "Find focused refactor hotspots.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [
+        "doc",
+        "standards"
+      ],
+      "produces": [
+        "stdout"
+      ],
+      "practices": [
+        "code-complete",
+        "refactoring"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "converter",
+      "description": "Convert AgentOps skill formats.",
+      "hexagonal_role": "generic",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "converted-skill"
+      ],
+      "practices": [
+        "refactoring",
+        "design-patterns"
+      ],
+      "context_rel": [],
+      "references_count": 1,
+      "codex_override_present": true
+    },
+    {
+      "name": "council",
+      "description": "Run multi-judge consensus.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [
+        "standards"
+      ],
+      "produces": [
+        "result.json",
+        "verdict.json"
+      ],
+      "practices": [
+        "llm-eval-harness",
+        "ai-assisted-dev",
+        "design-by-contract"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 33,
+      "codex_override_present": true
+    },
+    {
+      "name": "crank",
+      "description": "Execute epics through waves.",
+      "hexagonal_role": "domain",
+      "user_invocable": true,
+      "consumes": [
+        "beads",
+        "implement",
+        "post-mortem",
+        "swarm",
+        "vibe"
+      ],
+      "produces": [
+        ".agents/swarm/results/*.json",
+        "git-changes"
+      ],
+      "practices": [
+        "continuous-delivery",
+        "xp",
+        "agile-manifesto"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 30,
+      "codex_override_present": true
+    },
+    {
+      "name": "curate",
+      "description": "Mine transcripts, .agents, bd, and git for skill diffs, bd updates, or",
+      "hexagonal_role": "supporting",
+      "user_invocable": true,
+      "consumes": [],
+      "produces": [
+        ".agents/research/*.md"
+      ],
+      "practices": [
+        "wiki-knowledge-surface",
+        "lean-startup"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "deps",
+      "description": "Audit dependency risks and updates.",
+      "hexagonal_role": "driven-adapter",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "supply-chain-integrity",
+        "continuous-delivery",
+        "sre"
+      ],
+      "context_rel": [],
+      "references_count": 1,
+      "codex_override_present": true
+    },
+    {
+      "name": "design",
+      "description": "Validate product fit before discovery.",
+      "hexagonal_role": "domain",
+      "user_invocable": true,
+      "consumes": [
+        "standards"
+      ],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "lean-startup",
+        "ddd-bounded-context",
+        "mythical-man-month"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 3,
+      "codex_override_present": true
+    },
+    {
+      "name": "discovery",
+      "description": "Create dense execution packets.",
+      "hexagonal_role": "domain",
+      "user_invocable": true,
+      "consumes": [
+        "brainstorm",
+        "design",
+        "plan",
+        "pre-mortem",
+        "research",
+        "shared"
+      ],
+      "produces": [
+        ".agents/plans/*.md",
+        "bd-issue",
+        "execution-packet.json"
+      ],
+      "practices": [
+        "adr",
+        "lean-startup",
+        "mythical-man-month"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 9,
+      "codex_override_present": true
+    },
+    {
+      "name": "doc",
+      "description": "Generate and validate repo docs.",
+      "hexagonal_role": "supporting",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "documentation"
+      ],
+      "practices": [
+        "wiki-knowledge-surface",
+        "code-complete",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [],
+      "references_count": 6,
+      "codex_override_present": true
+    },
+    {
+      "name": "domain",
+      "description": "Canonical vocabulary for human-AI software work.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "stdout"
+      ],
+      "practices": [
+        "ddd-bounded-context",
+        "wiki-knowledge-surface",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [],
+      "references_count": 9,
+      "codex_override_present": true
+    },
+    {
+      "name": "dream",
+      "description": "Run overnight compounding sessions.",
+      "hexagonal_role": "supporting",
+      "user_invocable": true,
+      "consumes": [],
+      "produces": [
+        ".agents/research/*.md"
+      ],
+      "practices": [
+        "lean-startup",
+        "wiki-knowledge-surface",
+        "sre"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "evolve",
+      "description": "Run autonomous improvement loops.",
+      "hexagonal_role": "supporting",
+      "user_invocable": true,
+      "consumes": [],
+      "produces": [],
+      "practices": [
+        "lean-startup",
+        "dora-metrics",
+        "agile-manifesto"
+      ],
+      "context_rel": [],
+      "references_count": 23,
+      "codex_override_present": true
+    },
+    {
+      "name": "expert-council",
+      "description": "Alias for /council --mode=debate — adversarial named-persona debate. Triggers: \"expert council\", \"dueling council\", \"council of <names>\". Kept one release.",
+      "hexagonal_role": "domain",
+      "user_invocable": true,
+      "consumes": [],
+      "produces": [],
+      "practices": [
+        "llm-eval-harness"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "flywheel",
+      "description": "Check knowledge flywheel health.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        ".agents/learnings/*.md"
+      ],
+      "practices": [
+        "wiki-knowledge-surface",
+        "lean-startup",
+        "dora-metrics"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 4,
+      "codex_override_present": true
+    },
+    {
+      "name": "forge",
+      "description": "Mine transcripts into learnings.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        ".agents/research/*.md"
+      ],
+      "practices": [
+        "wiki-knowledge-surface",
+        "lean-startup"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 3,
+      "codex_override_present": true
+    },
+    {
+      "name": "goals",
+      "description": "Maintain AgentOps goals.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "dora-metrics",
+        "lean-startup",
+        "agile-manifesto"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 3,
+      "codex_override_present": true
+    },
+    {
+      "name": "grafana-platform-dashboard",
+      "description": "Validate OpenShift Grafana dashboards.",
+      "hexagonal_role": "driven-adapter",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "dashboard-validation-report"
+      ],
+      "practices": [
+        "sre",
+        "distributed-tracing",
+        "dora-metrics"
+      ],
+      "context_rel": [],
+      "references_count": 3,
+      "codex_override_present": true
+    },
+    {
+      "name": "handoff",
+      "description": "Write compact session handoffs.",
+      "hexagonal_role": "supporting",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        ".agents/research/*.md"
+      ],
+      "practices": [
+        "adr",
+        "wiki-knowledge-surface",
+        "code-complete"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "harvest",
+      "description": "Promote .agents knowledge.",
+      "hexagonal_role": "supporting",
+      "user_invocable": true,
+      "consumes": [],
+      "produces": [
+        ".agents/research/*.md"
+      ],
+      "practices": [
+        "wiki-knowledge-surface",
+        "lean-startup"
+      ],
+      "context_rel": [],
+      "references_count": 1,
+      "codex_override_present": true
+    },
+    {
+      "name": "heal-skill",
+      "description": "Repair skill hygiene.",
+      "hexagonal_role": "supporting",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [],
+      "practices": [
+        "refactoring",
+        "code-complete"
+      ],
+      "context_rel": [],
+      "references_count": 2,
+      "codex_override_present": true
+    },
+    {
+      "name": "hooks-authoring",
+      "description": "Author AgentOps runtime hooks.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "design-by-contract",
+        "code-complete",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 3,
+      "codex_override_present": true
+    },
+    {
+      "name": "implement",
+      "description": "Implement one tracked issue.",
+      "hexagonal_role": "driving-adapter",
+      "user_invocable": false,
+      "consumes": [
+        "domain"
+      ],
+      "produces": [
+        "git-changes"
+      ],
+      "practices": [
+        "tdd",
+        "refactoring",
+        "code-complete"
+      ],
+      "context_rel": [
+        {
+          "kind": "customer-of",
+          "with": "domain"
+        }
+      ],
+      "references_count": 7,
+      "codex_override_present": true
+    },
+    {
+      "name": "inject",
+      "description": "Load relevant .agents context.",
+      "hexagonal_role": "driving-adapter",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [],
+      "practices": [
+        "wiki-knowledge-surface",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "knowledge-activation",
+      "description": "Activate mature .agents knowledge.",
+      "hexagonal_role": "supporting",
+      "user_invocable": true,
+      "consumes": [],
+      "produces": [],
+      "practices": [
+        "wiki-knowledge-surface",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [],
+      "references_count": 3,
+      "codex_override_present": true
+    },
+    {
+      "name": "llm-wiki",
+      "description": "Build external-knowledge wikis.",
+      "hexagonal_role": "supporting",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "documentation"
+      ],
+      "practices": [
+        "wiki-knowledge-surface",
+        "ddd-bounded-context",
+        "prompt-as-spec"
+      ],
+      "context_rel": [],
+      "references_count": 2,
+      "codex_override_present": true
+    },
+    {
+      "name": "openai-docs",
+      "description": "Use official OpenAI docs.",
+      "hexagonal_role": "driven-adapter",
+      "user_invocable": false,
+      "consumes": [
+        "external-api"
+      ],
+      "produces": [],
+      "practices": [
+        "prompt-as-spec",
+        "ai-assisted-dev"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "oss-docs",
+      "description": "Scaffold or audit OSS docs.",
+      "hexagonal_role": "generic",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "documentation"
+      ],
+      "practices": [
+        "code-complete",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [],
+      "references_count": 3,
+      "codex_override_present": true
+    },
+    {
+      "name": "perf",
+      "description": "Profile and optimize hotspots.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "dora-metrics",
+        "sre",
+        "code-complete"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 3,
+      "codex_override_present": true
+    },
+    {
+      "name": "plan",
+      "description": "Decompose goals into issue plans.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [
+        "standards"
+      ],
+      "produces": [
+        ".agents/plans/*.md",
+        "execution-packet.json"
+      ],
+      "practices": [
+        "adr",
+        "agile-manifesto",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 14,
+      "codex_override_present": true
+    },
+    {
+      "name": "post-mortem",
+      "description": "Review completed work and learn.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "dora-metrics",
+        "sre",
+        "lean-startup"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 21,
+      "codex_override_present": true
+    },
+    {
+      "name": "pr-implement",
+      "description": "Implement a scoped OSS PR.",
+      "hexagonal_role": "driving-adapter",
+      "user_invocable": false,
+      "consumes": [
+        "crank"
+      ],
+      "produces": [
+        "git-changes"
+      ],
+      "practices": [
+        "continuous-delivery",
+        "xp",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [
+        {
+          "kind": "customer-of",
+          "with": "crank"
+        }
+      ],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "pr-plan",
+      "description": "Plan an open source PR.",
+      "hexagonal_role": "supporting",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "agile-manifesto",
+        "adr",
+        "lean-startup"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "pr-prep",
+      "description": "Prepare PR commits and body.",
+      "hexagonal_role": "driving-adapter",
+      "user_invocable": false,
+      "consumes": [
+        "domain"
+      ],
+      "produces": [
+        "git-changes"
+      ],
+      "practices": [
+        "continuous-integration",
+        "continuous-delivery",
+        "gitops"
+      ],
+      "context_rel": [
+        {
+          "kind": "customer-of",
+          "with": "domain"
+        }
+      ],
+      "references_count": 4,
+      "codex_override_present": true
+    },
+    {
+      "name": "pr-research",
+      "description": "Research an upstream repo.",
+      "hexagonal_role": "driven-adapter",
+      "user_invocable": false,
+      "consumes": [
+        "external-api"
+      ],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "wiki-knowledge-surface",
+        "legacy-code-seams",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [],
+      "references_count": 1,
+      "codex_override_present": true
+    },
+    {
+      "name": "pr-retro",
+      "description": "Learn from PR outcomes.",
+      "hexagonal_role": "supporting",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        ".agents/research/*.md"
+      ],
+      "practices": [
+        "dora-metrics",
+        "sre",
+        "lean-startup"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "pr-validate",
+      "description": "Validate PR scope and quality.",
+      "hexagonal_role": "driving-adapter",
+      "user_invocable": false,
+      "consumes": [
+        "validation"
+      ],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "continuous-integration",
+        "code-complete",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [
+        {
+          "kind": "customer-of",
+          "with": "validation"
+        }
+      ],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "pre-mortem",
+      "description": "Stress-test plans before work.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [
+        "standards"
+      ],
+      "produces": [
+        "result.json",
+        "verdict.json"
+      ],
+      "practices": [
+        "adr",
+        "mythical-man-month",
+        "design-by-contract"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 14,
+      "codex_override_present": true
+    },
+    {
+      "name": "product",
+      "description": "Create or refine PRODUCT.md.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "lean-startup",
+        "mythical-man-month",
+        "ddd-bounded-context"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "provenance",
+      "description": "Trace artifact provenance.",
+      "hexagonal_role": "driven-adapter",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "supply-chain-integrity",
+        "adr",
+        "hermetic-builds"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "push",
+      "description": "Validate, commit, and push.",
+      "hexagonal_role": "driving-adapter",
+      "user_invocable": true,
+      "consumes": [
+        "git-changes"
+      ],
+      "produces": [
+        "git-changes"
+      ],
+      "practices": [
+        "continuous-delivery",
+        "gitops",
+        "dora-metrics"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "quickstart",
+      "description": "Show AgentOps next action.",
+      "hexagonal_role": "driving-adapter",
+      "user_invocable": false,
+      "consumes": [
+        "rpi"
+      ],
+      "produces": [
+        "stdout"
+      ],
+      "practices": [
+        "pragmatic-programmer",
+        "agile-manifesto"
+      ],
+      "context_rel": [
+        {
+          "kind": "customer-of",
+          "with": "rpi"
+        }
+      ],
+      "references_count": 3,
+      "codex_override_present": true
+    },
+    {
+      "name": "ratchet",
+      "description": "Record Brownian Ratchet gates.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        ".agents/rpi/*.md"
+      ],
+      "practices": [
+        "dora-metrics",
+        "refactoring",
+        "continuous-integration"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "readme",
+      "description": "Draft or improve README docs.",
+      "hexagonal_role": "generic",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "documentation"
+      ],
+      "practices": [
+        "code-complete",
+        "wiki-knowledge-surface",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "recover",
+      "description": "Recover session context.",
+      "hexagonal_role": "driving-adapter",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        ".agents/rpi/*.md"
+      ],
+      "practices": [
+        "sre",
+        "legacy-code-seams",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "red-team",
+      "description": "Probe docs and skills.",
+      "hexagonal_role": "supporting",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "ai-assisted-dev",
+        "design-by-contract",
+        "sre"
+      ],
+      "context_rel": [],
+      "references_count": 4,
+      "codex_override_present": true
+    },
+    {
+      "name": "refactor",
+      "description": "Execute safe refactors.",
+      "hexagonal_role": "supporting",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "git-changes"
+      ],
+      "practices": [
+        "refactoring",
+        "legacy-code-seams",
+        "design-patterns"
+      ],
+      "context_rel": [],
+      "references_count": 1,
+      "codex_override_present": true
+    },
+    {
+      "name": "release",
+      "description": "Run release validation.",
+      "hexagonal_role": "supporting",
+      "user_invocable": true,
+      "consumes": [],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "continuous-delivery",
+        "gitops",
+        "supply-chain-integrity"
+      ],
+      "context_rel": [],
+      "references_count": 8,
+      "codex_override_present": true
+    },
+    {
+      "name": "research",
+      "description": "Explore and write findings.",
+      "hexagonal_role": "driving-adapter",
+      "user_invocable": false,
+      "consumes": [
+        "inject",
+        "repo-context"
+      ],
+      "produces": [
+        ".agents/research/*.md",
+        "result.json"
+      ],
+      "practices": [
+        "wiki-knowledge-surface",
+        "pragmatic-programmer",
+        "ddd-bounded-context"
+      ],
+      "context_rel": [],
+      "references_count": 17,
+      "codex_override_present": true
+    },
+    {
+      "name": "retro",
+      "description": "Capture a session learning.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [
+        "standards"
+      ],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "sre",
+        "lean-startup",
+        "dora-metrics"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "reverse-engineer-rpi",
+      "description": "Reverse-engineer product specs.",
+      "hexagonal_role": "supporting",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        ".agents/research/*.md"
+      ],
+      "practices": [
+        "legacy-code-seams",
+        "ddd-bounded-context",
+        "adr"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "review",
+      "description": "Review diffs for risk, find mocks, scan for bugs, and audit codebases.",
+      "hexagonal_role": "driving-adapter",
+      "user_invocable": false,
+      "consumes": [
+        "github-pr",
+        "validation"
+      ],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "code-complete",
+        "refactoring",
+        "design-by-contract"
+      ],
+      "context_rel": [
+        {
+          "kind": "customer-of",
+          "with": "validation"
+        }
+      ],
+      "references_count": 5,
+      "codex_override_present": true
+    },
+    {
+      "name": "rpi",
+      "description": "Run discovery, crank, validation.",
+      "hexagonal_role": "supporting",
+      "user_invocable": true,
+      "consumes": [
+        "crank",
+        "discovery",
+        "domain",
+        "ratchet",
+        "validation"
+      ],
+      "produces": [
+        ".agents/rpi/*.md"
+      ],
+      "practices": [
+        "bdd-gherkin",
+        "ddd-bounded-context",
+        "hexagonal-architecture",
+        "tdd",
+        "continuous-delivery",
+        "dora-metrics",
+        "agile-manifesto",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [
+        {
+          "kind": "customer-of",
+          "with": "crank"
+        },
+        {
+          "kind": "customer-of",
+          "with": "discovery"
+        },
+        {
+          "kind": "customer-of",
+          "with": "validation"
+        }
+      ],
+      "references_count": 17,
+      "codex_override_present": true
+    },
+    {
+      "name": "scaffold",
+      "description": "Create project, component, or boilerplate scaffolds.",
+      "hexagonal_role": "supporting",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "converted-skill"
+      ],
+      "practices": [
+        "pragmatic-programmer",
+        "design-patterns",
+        "hexagonal-architecture"
+      ],
+      "context_rel": [],
+      "references_count": 2,
+      "codex_override_present": true
+    },
+    {
+      "name": "scenario",
+      "description": "Manage holdout scenarios.",
+      "hexagonal_role": "supporting",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "property-based-testing",
+        "snapshot-testing",
+        "llm-eval-harness"
+      ],
+      "context_rel": [],
+      "references_count": 1,
+      "codex_override_present": true
+    },
+    {
+      "name": "scope",
+      "description": "Hard-block edits outside declared frozen directories via PreToolUse hook.",
+      "hexagonal_role": "driven-adapter",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "filesystem-gate"
+      ],
+      "practices": [
+        "ddd-bounded-context",
+        "design-by-contract",
+        "mythical-man-month"
+      ],
+      "context_rel": [
+        {
+          "kind": "supplier-to",
+          "with": "domain"
+        }
+      ],
+      "references_count": 3,
+      "codex_override_present": true
+    },
+    {
+      "name": "security-suite",
+      "description": "Run composable security analysis.",
+      "hexagonal_role": "driven-adapter",
+      "user_invocable": false,
+      "consumes": [
+        "repo-context"
+      ],
+      "produces": [
+        "security-report.json"
+      ],
+      "practices": [
+        "supply-chain-integrity",
+        "design-by-contract",
+        "sre"
+      ],
+      "context_rel": [
+        {
+          "kind": "supplier-to",
+          "with": "vibe"
+        }
+      ],
+      "references_count": 1,
+      "codex_override_present": true
+    },
+    {
+      "name": "security",
+      "description": "Run repository security scans.",
+      "hexagonal_role": "driven-adapter",
+      "user_invocable": false,
+      "consumes": [
+        "repo-context"
+      ],
+      "produces": [
+        "security-report.json"
+      ],
+      "practices": [
+        "supply-chain-integrity",
+        "sre"
+      ],
+      "context_rel": [
+        {
+          "kind": "supplier-to",
+          "with": "vibe"
+        }
+      ],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "shared",
+      "description": "Shared AgentOps skill contracts.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "stdout"
+      ],
+      "practices": [
+        "design-by-contract",
+        "pragmatic-programmer",
+        "twelve-factor-app"
+      ],
+      "context_rel": [],
+      "references_count": 16,
+      "codex_override_present": true
+    },
+    {
+      "name": "ship-loop",
+      "description": "Bot-paired fast-lane cycle for coherent-arc internal PRs (one closable bead or small-epic slice): claim → test → impl → pre-push → push → squash auto-merge → close.",
+      "hexagonal_role": "driving-adapter",
+      "user_invocable": true,
+      "consumes": [
+        "beads",
+        "rpi",
+        "post-mortem"
+      ],
+      "produces": [
+        "git-changes",
+        "merged-prs"
+      ],
+      "practices": [
+        "continuous-delivery",
+        "xp",
+        "tdd",
+        "bdd",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [
+        {
+          "kind": "customer-of",
+          "with": "rpi"
+        },
+        {
+          "kind": "customer-of",
+          "with": "post-mortem"
+        }
+      ],
+      "references_count": 4,
+      "codex_override_present": true
+    },
+    {
+      "name": "skill-auditor",
+      "description": "'Audit an existing SKILL.md against the unified AgentOps template (15",
+      "hexagonal_role": "supporting",
+      "user_invocable": true,
+      "consumes": [],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "code-complete",
+        "cmm-process-maturity",
+        "design-by-contract"
+      ],
+      "context_rel": [],
+      "references_count": 3,
+      "codex_override_present": true
+    },
+    {
+      "name": "skill-builder",
+      "description": "'Scaffold or absorb new SKILL.md files against the unified AgentOps template.",
+      "hexagonal_role": "supporting",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "converted-skill"
+      ],
+      "practices": [
+        "code-complete",
+        "pragmatic-programmer",
+        "design-patterns"
+      ],
+      "context_rel": [],
+      "references_count": 2,
+      "codex_override_present": true
+    },
+    {
+      "name": "standards",
+      "description": "Provide repo coding standards.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "stdout"
+      ],
+      "practices": [
+        "code-complete",
+        "design-patterns",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [],
+      "references_count": 23,
+      "codex_override_present": true
+    },
+    {
+      "name": "status",
+      "description": "Show AgentOps work status.",
+      "hexagonal_role": "driving-adapter",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "stdout"
+      ],
+      "practices": [
+        "dora-metrics",
+        "sre"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "swarm",
+      "description": "Dispatch parallel agents.",
+      "hexagonal_role": "supporting",
+      "user_invocable": false,
+      "consumes": [
+        "implement",
+        "vibe"
+      ],
+      "produces": [
+        ".agents/swarm/results/*.json"
+      ],
+      "practices": [
+        "microservices",
+        "team-topologies",
+        "mythical-man-month"
+      ],
+      "context_rel": [
+        {
+          "kind": "customer-of",
+          "with": "crank"
+        }
+      ],
+      "references_count": 21,
+      "codex_override_present": true
+    },
+    {
+      "name": "system-tuning",
+      "description": "Restore system responsiveness via safe, ordered process cleanup and agent-swarm",
+      "hexagonal_role": "supporting",
+      "user_invocable": true,
+      "consumes": [],
+      "produces": [],
+      "practices": [
+        "sre",
+        "resilience-patterns",
+        "ebpf-observability"
+      ],
+      "context_rel": [],
+      "references_count": 3,
+      "codex_override_present": true
+    },
+    {
+      "name": "test",
+      "description": "Generate tests and coverage plans.",
+      "hexagonal_role": "supporting",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "tdd",
+        "property-based-testing",
+        "bdd-gherkin"
+      ],
+      "context_rel": [],
+      "references_count": 6,
+      "codex_override_present": true
+    },
+    {
+      "name": "trace",
+      "description": "Trace decisions through artifacts.",
+      "hexagonal_role": "supporting",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "distributed-tracing",
+        "adr",
+        "ebpf-observability"
+      ],
+      "context_rel": [],
+      "references_count": 3,
+      "codex_override_present": true
+    },
+    {
+      "name": "update",
+      "description": "Sync AgentOps skills.",
+      "hexagonal_role": "supporting",
+      "user_invocable": true,
+      "consumes": [],
+      "produces": [],
+      "practices": [
+        "gitops",
+        "continuous-delivery",
+        "infrastructure-as-code"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "using-agentops",
+      "description": "Explain AgentOps workflows.",
+      "hexagonal_role": "generic",
+      "user_invocable": false,
+      "consumes": [],
+      "produces": [
+        "documentation"
+      ],
+      "practices": [
+        "wiki-knowledge-surface",
+        "pragmatic-programmer",
+        "agile-manifesto"
+      ],
+      "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "validate",
+      "description": "Produce PASS/WARN/FAIL verdicts for artifacts, plans, code, PRs, or gates.",
+      "hexagonal_role": "driving-adapter",
+      "user_invocable": true,
+      "consumes": [
+        "validation"
+      ],
+      "produces": [
+        "result.json"
+      ],
+      "practices": [
+        "design-by-contract",
+        "llm-eval-harness"
+      ],
+      "context_rel": [
+        {
+          "kind": "customer-of",
+          "with": "validation"
+        }
+      ],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "validation",
+      "description": "Run post-implementation validation.",
+      "hexagonal_role": "domain",
+      "user_invocable": true,
+      "consumes": [
+        "forge",
+        "post-mortem",
+        "retro",
+        "shared",
+        "vibe"
+      ],
+      "produces": [
+        ".agents/research/*.md",
+        "result.json",
+        "verdict.json"
+      ],
+      "practices": [
+        "llm-eval-harness",
+        "dora-metrics",
+        "sre"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 13,
+      "codex_override_present": true
+    },
+    {
+      "name": "vibe",
+      "description": "Validate code readiness.",
+      "hexagonal_role": "domain",
+      "user_invocable": false,
+      "consumes": [
+        "standards"
+      ],
+      "produces": [
+        "result.json",
+        "verdict.json"
+      ],
+      "practices": [
+        "ai-assisted-dev",
+        "llm-eval-harness",
+        "code-complete",
+        "pragmatic-programmer"
+      ],
+      "context_rel": [
+        {
+          "kind": "shared-kernel",
+          "with": "standards"
+        }
+      ],
+      "references_count": 22,
+      "codex_override_present": true
+    }
+  ]
+}

--- a/tests/scripts/generate-skill-catalog.bats
+++ b/tests/scripts/generate-skill-catalog.bats
@@ -1,0 +1,265 @@
+#!/usr/bin/env bats
+# Regression tests for scripts/generate-skill-catalog.sh (soc-vuu6.4).
+#
+# Builds isolated fixture repos with small skills/ trees, then runs the
+# generator and asserts structure + drift detection. We avoid touching the
+# real repo's catalog by always running inside $TMP.
+
+setup() {
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  SCRIPT="$REPO_ROOT/scripts/generate-skill-catalog.sh"
+  DRIFT_SCRIPT="$REPO_ROOT/scripts/check-skill-catalog-drift.sh"
+  TMP="$(mktemp -d)"
+  ORIG_DIR="$PWD"
+
+  git init --quiet --initial-branch=main "$TMP/repo"
+  cd "$TMP/repo"
+  git config user.email t@t.test
+  git config user.name tester
+  git commit --quiet --allow-empty -m "initial"
+  mkdir -p skills schemas
+  # The drift check script needs to find the generator at the same repo path
+  # so we install both into the fixture's `scripts/` dir.
+  mkdir -p scripts
+  cp "$SCRIPT" scripts/generate-skill-catalog.sh
+  cp "$DRIFT_SCRIPT" scripts/check-skill-catalog-drift.sh
+  chmod +x scripts/generate-skill-catalog.sh scripts/check-skill-catalog-drift.sh
+  cd "$ORIG_DIR"
+}
+
+teardown() {
+  cd "$ORIG_DIR" 2>/dev/null || true
+  rm -rf "$TMP"
+}
+
+# Write a skill SKILL.md with a given frontmatter body.
+write_skill() {
+  local name="$1" fm="$2"
+  mkdir -p "$TMP/repo/skills/$name"
+  {
+    echo "---"
+    printf '%s\n' "$fm"
+    echo "---"
+    echo
+    echo "# $name"
+  } > "$TMP/repo/skills/$name/SKILL.md"
+}
+
+run_gen() {
+  cd "$TMP/repo"
+  run scripts/generate-skill-catalog.sh "$@"
+}
+
+run_drift() {
+  cd "$TMP/repo"
+  run scripts/check-skill-catalog-drift.sh "$@"
+}
+
+@test "generator emits valid JSON with required envelope fields" {
+  write_skill alpha "name: alpha
+description: first skill
+hexagonal_role: domain
+consumes: []
+produces: []
+context_rel: []"
+  run_gen --stdout
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.schema_version == "1"' >/dev/null
+  echo "$output" | jq -e '.skill_count == 1' >/dev/null
+  echo "$output" | jq -e '.skills | length == 1' >/dev/null
+  echo "$output" | jq -e '.generated_at | startswith("20")' >/dev/null
+}
+
+@test "extracts name/description/hexagonal_role from frontmatter" {
+  write_skill alpha "name: alpha
+description: hello world
+hexagonal_role: supporting
+consumes: []
+produces: []
+context_rel: []"
+  run_gen --stdout
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.skills[0].name == "alpha"' >/dev/null
+  echo "$output" | jq -e '.skills[0].description == "hello world"' >/dev/null
+  echo "$output" | jq -e '.skills[0].hexagonal_role == "supporting"' >/dev/null
+}
+
+@test "consumes/produces/practices lists round-trip into arrays" {
+  write_skill beta "name: beta
+description: lists test
+hexagonal_role: domain
+practices:
+- tdd
+- bdd-gherkin
+consumes:
+- standards
+- domain
+produces:
+- result.json
+- verdict.json
+context_rel: []"
+  run_gen --stdout
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.skills[0].consumes == ["standards","domain"]' >/dev/null
+  echo "$output" | jq -e '.skills[0].produces == ["result.json","verdict.json"]' >/dev/null
+  echo "$output" | jq -e '.skills[0].practices == ["tdd","bdd-gherkin"]' >/dev/null
+}
+
+@test "context_rel captures all entries including the last one (the parser-bug regression)" {
+  write_skill gamma "name: gamma
+description: context-rel test
+hexagonal_role: domain
+consumes: []
+produces: []
+context_rel:
+- kind: customer-of
+  with: alpha
+- kind: customer-of
+  with: beta
+- kind: customer-of
+  with: delta
+skill_api_version: 1"
+  run_gen --stdout
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.skills[0].context_rel | length == 3' >/dev/null
+  echo "$output" | jq -e '.skills[0].context_rel[2].with == "delta"' >/dev/null
+}
+
+@test "user_invocable is true only when explicitly set" {
+  write_skill u1 "name: u1
+description: invocable
+hexagonal_role: domain
+user-invocable: true
+consumes: []
+produces: []
+context_rel: []"
+  write_skill u2 "name: u2
+description: not invocable
+hexagonal_role: domain
+consumes: []
+produces: []
+context_rel: []"
+  run_gen --stdout
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.skills[] | select(.name=="u1") | .user_invocable == true' >/dev/null
+  echo "$output" | jq -e '.skills[] | select(.name=="u2") | .user_invocable == false' >/dev/null
+}
+
+@test "references_count reflects skills/<name>/references/*.md count" {
+  write_skill withrefs "name: withrefs
+description: x
+hexagonal_role: domain
+consumes: []
+produces: []
+context_rel: []"
+  mkdir -p "$TMP/repo/skills/withrefs/references"
+  touch "$TMP/repo/skills/withrefs/references/a.md" \
+        "$TMP/repo/skills/withrefs/references/b.md"
+  run_gen --stdout
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.skills[] | select(.name=="withrefs") | .references_count == 2' >/dev/null
+}
+
+@test "codex_override_present is true when skills-codex/<name>/ exists" {
+  write_skill swithcodex "name: swithcodex
+description: x
+hexagonal_role: domain
+consumes: []
+produces: []
+context_rel: []"
+  mkdir -p "$TMP/repo/skills-codex/swithcodex"
+  touch "$TMP/repo/skills-codex/swithcodex/SKILL.md"
+  run_gen --stdout
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.skills[] | select(.name=="swithcodex") | .codex_override_present == true' >/dev/null
+}
+
+@test "default --out writes skills/catalog.json and prints summary" {
+  write_skill alpha "name: alpha
+description: x
+hexagonal_role: domain
+consumes: []
+produces: []
+context_rel: []"
+  run_gen
+  [ "$status" -eq 0 ]
+  [ -f "$TMP/repo/skills/catalog.json" ]
+  [[ "$output" == *"wrote"* ]]
+}
+
+@test "--check passes when committed catalog matches regeneration" {
+  write_skill alpha "name: alpha
+description: x
+hexagonal_role: domain
+consumes: []
+produces: []
+context_rel: []"
+  run_gen
+  [ "$status" -eq 0 ]
+  run_gen --check
+  [ "$status" -eq 0 ]
+}
+
+@test "--check fails (exit 1) when committed catalog drifts from source" {
+  write_skill alpha "name: alpha
+description: x
+hexagonal_role: domain
+consumes: []
+produces: []
+context_rel: []"
+  run_gen
+  [ "$status" -eq 0 ]
+  # Mutate a SKILL.md without regenerating the catalog.
+  write_skill alpha "name: alpha
+description: x CHANGED
+hexagonal_role: domain
+consumes: []
+produces: []
+context_rel: []"
+  run_gen --check
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"DRIFT"* ]]
+}
+
+@test "drift wrapper exits 0 when in sync" {
+  write_skill alpha "name: alpha
+description: x
+hexagonal_role: domain
+consumes: []
+produces: []
+context_rel: []"
+  run_gen
+  run_drift
+  [ "$status" -eq 0 ]
+}
+
+@test "drift wrapper exits 1 when out of sync" {
+  write_skill alpha "name: alpha
+description: x
+hexagonal_role: domain
+consumes: []
+produces: []
+context_rel: []"
+  run_gen
+  write_skill alpha "name: alpha
+description: drifted
+hexagonal_role: domain
+consumes: []
+produces: []
+context_rel: []"
+  run_drift
+  [ "$status" -eq 1 ]
+}
+
+@test "empty skills/ produces a valid empty catalog" {
+  run_gen --stdout
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.skill_count == 0' >/dev/null
+  echo "$output" | jq -e '.skills | length == 0' >/dev/null
+}
+
+@test "unknown flag exits 2" {
+  run_gen --weasel
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown"* ]]
+}


### PR DESCRIPTION
## Why

`registry.json` (47KB) is too coarse — agents grepping for "which skill produces a ratchet?" have to scan markdown. Hand-curated /skills tables drift. Future `ao skill new` scaffolders need a queryable inventory. This is slice 1 of soc-vuu6.4 (the generator + schema + CI gate). Go CLI subcommands and showcase consumer are filed as follow-up beads.

## What

Three artifacts:

1. `schemas/skill-catalog.schema.json` — JSON Schema for the catalog. Required fields: name, description, hexagonal_role, consumes, produces, context_rel, user_invocable, references_count, codex_override_present. hexagonal_role enum mirrors soc-e8pj/PR #376.

2. `scripts/generate-skill-catalog.sh` — walks every `skills/*/SKILL.md`, parses YAML frontmatter via awk, emits `skills/catalog.json` with all 79 skills. Modes: default (write), `--check` (CI drift gate, exits 1 on drift), `--stdout`, `--out PATH`.

3. `scripts/check-skill-catalog-drift.sh` — thin wrapper over `--check` so the future workflow has a stable, named entry point.

4. `skills/catalog.json` — generated artifact, committed. 79 skills, 40KB.

The parser handles the SKILL.md frontmatter subset we actually use: scalar key:value, lists (`- item`), and `context_rel` nested objects (`- kind:` / `with:`). A regression test covers the "last context_rel entry dropped on transition to next scalar" parser bug caught during development.

## Test

14 bats tests, all passing. Cover: envelope fields, name/description extraction, list round-trip, context_rel parsing (incl. the regression for the dropped-last-entry bug), user_invocable boolean, references_count, codex_override_present, default file-write, `--check` pass + drift detection, drift wrapper exit codes, empty-skills case, unknown-flag error.

Self-dogfood: real skills/ tree → 79 skills generated, all 4 keys validated by lint-skill-frontmatter (#376), drift check green.

## Follow-up beads filed

- Slice 2 — `ao skills list/consumers/producers/graph` (Go CLI subcommands, blocks on this PR)
- Slice 3 — Showcase consumes catalog.json instead of hand tables

Closes-scenario: soc-vuu6.4#catalog-generator
Bounded-context: BC1-Corpus
Evidence: scripts/generate-skill-catalog.sh
Evidence: scripts/check-skill-catalog-drift.sh
Evidence: tests/scripts/generate-skill-catalog.bats
