### PR TITLE
feat(install): install.sh per-runtime detection + informative degrade (soc-vuu6.31 #install-single-runtime)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -98,13 +98,32 @@ echo "Installing AgentOps..."
 
 # Check prerequisites
 command -v curl >/dev/null 2>&1 || { echo "Error: curl required."; exit 1; }
-command -v claude >/dev/null 2>&1 || command -v codex >/dev/null 2>&1 || {
+
+# Per-runtime detection (soc-vuu6.31). The old `claude || codex` test bounced
+# only on zero runtimes — single-runtime users got the README mixed-model
+# example silently. Detect each runtime explicitly so we can: (a) report
+# yes/no per runtime, (b) name the mode AgentOps will operate in, and
+# (c) point single-runtime users at the install link for the other.
+HAS_CLAUDE=no
+HAS_CODEX=no
+command -v claude >/dev/null 2>&1 && HAS_CLAUDE=yes
+command -v codex >/dev/null 2>&1 && HAS_CODEX=yes
+echo "Detected Claude Code: $HAS_CLAUDE. Detected Codex CLI: $HAS_CODEX."
+if [ "$HAS_CLAUDE" = "yes" ] && [ "$HAS_CODEX" = "yes" ]; then
+    echo "AgentOps will use mixed-model mode (cross-vendor council, parallel /rpi)."
+elif [ "$HAS_CLAUDE" = "yes" ]; then
+    echo "AgentOps will use single-runtime mode (Claude Code only)."
+    echo "To unlock mixed-model judging, install Codex CLI: https://github.com/openai/codex"
+elif [ "$HAS_CODEX" = "yes" ]; then
+    echo "AgentOps will use single-runtime mode (Codex CLI only)."
+    echo "To unlock mixed-model judging, install Claude Code: https://docs.anthropic.com/en/docs/claude-code"
+else
     echo "Warning: No supported coding agent found (claude, codex)."
     echo "AgentOps requires Claude Code or Codex CLI. Install one first:"
     echo "  Claude Code: https://docs.anthropic.com/en/docs/claude-code"
     echo "  Codex CLI:   https://github.com/openai/codex"
     echo "Continuing anyway — you can install an agent later."
-}
+fi
 
 # Step 1: Install Codex plugin
 echo "Step 1/3: Installing Codex plugin..."

--- a/tests/scripts/install-sh-runtime-detection.bats
+++ b/tests/scripts/install-sh-runtime-detection.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# Regression tests for scripts/install.sh runtime-detection block (soc-vuu6.31).
+#
+# We can't run install.sh end-to-end in CI — it expects network access and
+# rewrites ~/.claude. Instead we stub `claude`, `codex`, and `curl` on PATH
+# and run the real install.sh; the script exits at the curl call once it
+# moves past the detection block, so we capture stdout up to that point.
+#
+# What we assert: the script prints runtime-by-runtime detection lines and
+# the correct mode line for each combination (both / claude-only /
+# codex-only / neither).
+
+setup() {
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  INSTALL_SH="$REPO_ROOT/scripts/install.sh"
+  TMP="$(mktemp -d)"
+  ORIG_PATH="$PATH"
+  ORIG_DIR="$PWD"
+  mkdir -p "$TMP/bin"
+  # Stub curl so the script exits after the detection block without
+  # touching the network. Returning 1 causes set -e + pipefail to bail.
+  cat >"$TMP/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "[stubbed-curl] $*" >&2
+exit 1
+EOF
+  chmod +x "$TMP/bin/curl"
+  # Keep coreutils on PATH (sed/awk/cat/etc). We add stubs at the front.
+  COREUTILS_PATH="$ORIG_PATH"
+}
+
+teardown() {
+  cd "$ORIG_DIR" 2>/dev/null || true
+  export PATH="$ORIG_PATH"
+  rm -rf "$TMP"
+}
+
+stub_runtime() {
+  local name="$1"
+  cat >"$TMP/bin/$name" <<EOF
+#!/usr/bin/env bash
+echo "[stubbed-$name] \$*"
+exit 0
+EOF
+  chmod +x "$TMP/bin/$name"
+}
+
+run_install_with_path() {
+  cd "$TMP"
+  export PATH="$1"
+  # The script's `set -e` will exit non-zero at curl; that's fine.
+  run bash "$INSTALL_SH"
+}
+
+@test "both claude and codex present: mixed-model mode" {
+  stub_runtime claude
+  stub_runtime codex
+  run_install_with_path "$TMP/bin:$COREUTILS_PATH"
+  [[ "$output" == *"Detected Claude Code: yes"* ]]
+  [[ "$output" == *"Detected Codex CLI: yes"* ]]
+  [[ "$output" == *"mixed-model mode"* ]]
+}
+
+@test "claude only: single-runtime + Codex install suggestion" {
+  stub_runtime claude
+  # Do NOT stub codex; absent in $TMP/bin → also absent in PATH after we
+  # restrict to $TMP/bin + a coreutils-only shim.
+  mkdir -p "$TMP/coreutils-only"
+  for cmd in bash sh sed awk grep tr sort cat mkdir mv rm cp ls wc dirname basename head tail printf jq mktemp tar id chmod; do
+    full="$(command -v "$cmd" 2>/dev/null || true)"
+    [ -n "$full" ] && ln -sf "$full" "$TMP/coreutils-only/$cmd"
+  done
+  run_install_with_path "$TMP/bin:$TMP/coreutils-only"
+  [[ "$output" == *"Detected Claude Code: yes"* ]]
+  [[ "$output" == *"Detected Codex CLI: no"* ]]
+  [[ "$output" == *"single-runtime mode (Claude Code only)"* ]]
+  [[ "$output" == *"install Codex CLI: https://github.com/openai/codex"* ]]
+}
+
+@test "codex only: single-runtime + Claude install suggestion" {
+  stub_runtime codex
+  mkdir -p "$TMP/coreutils-only"
+  for cmd in bash sh sed awk grep tr sort cat mkdir mv rm cp ls wc dirname basename head tail printf jq mktemp tar id chmod; do
+    full="$(command -v "$cmd" 2>/dev/null || true)"
+    [ -n "$full" ] && ln -sf "$full" "$TMP/coreutils-only/$cmd"
+  done
+  run_install_with_path "$TMP/bin:$TMP/coreutils-only"
+  [[ "$output" == *"Detected Claude Code: no"* ]]
+  [[ "$output" == *"Detected Codex CLI: yes"* ]]
+  [[ "$output" == *"single-runtime mode (Codex CLI only)"* ]]
+  [[ "$output" == *"install Claude Code: https://docs.anthropic.com/en/docs/claude-code"* ]]
+}
+
+@test "neither present: warning + both install links" {
+  # No runtime stubs; PATH points only at coreutils + curl stub.
+  mkdir -p "$TMP/coreutils-only"
+  for cmd in bash sh sed awk grep tr sort cat mkdir mv rm cp ls wc dirname basename head tail printf jq mktemp tar id chmod; do
+    full="$(command -v "$cmd" 2>/dev/null || true)"
+    [ -n "$full" ] && ln -sf "$full" "$TMP/coreutils-only/$cmd"
+  done
+  run_install_with_path "$TMP/bin:$TMP/coreutils-only"
+  [[ "$output" == *"Detected Claude Code: no"* ]]
+  [[ "$output" == *"Detected Codex CLI: no"* ]]
+  [[ "$output" == *"No supported coding agent found"* ]]
+  [[ "$output" == *"docs.anthropic.com/en/docs/claude-code"* ]]
+  [[ "$output" == *"github.com/openai/codex"* ]]
+  [[ "$output" == *"Continuing anyway"* ]]
+}
+
+@test "detection lines appear before any 'Step 1' install banner" {
+  stub_runtime claude
+  stub_runtime codex
+  run_install_with_path "$TMP/bin:$COREUTILS_PATH"
+  detect_line="$(printf '%s\n' "$output" | grep -n 'Detected Claude Code' | head -1 | cut -d: -f1)"
+  step_line="$(printf '%s\n' "$output" | grep -n 'Step 1' | head -1 | cut -d: -f1)"
+  [ -n "$detect_line" ]
+  [ -n "$step_line" ]
+  [ "$detect_line" -lt "$step_line" ]
+}


### PR DESCRIPTION
## Why

`install.sh` line 100 used `command -v claude || command -v codex` — failing only when ZERO runtimes are present. Single-runtime users got the warning skipped, then ran straight at the README mixed-model example and hit failures. Council non-negotiable #3 + GOALS.md North Star line 13 ("install to first validated flow in under 5 minutes") both name this. Codex auth model-mismatch (gpt-5.2-codex unsupported by ChatGPT account) hit it for real earlier this session.

## What

Replace the single-line OR-detect with per-runtime detection:

```text
Detected Claude Code: yes/no. Detected Codex CLI: yes/no.
AgentOps will use [mixed-model | single-runtime] mode.
To unlock mixed-model judging, install [other]: [link]
```

Four cases handled:
- both present → mixed-model mode
- Claude only → single-runtime mode + Codex install link
- Codex only → single-runtime mode + Claude install link
- neither → existing warning preserved + both links

Total diff: 20 lines added, 5 changed in `scripts/install.sh`.

## Test

5 bats tests, all passing. Cover each runtime combination by stubbing `claude` / `codex` / `curl` on PATH; assert detection lines + mode line + correct install link. Stub `curl` exits 1 so script bails at the network step after the detection block runs, capturing the output we want without touching the network.

Self-dogfood: re-run install.sh from this worktree → "Detected Claude Code: yes. Detected Codex CLI: yes. AgentOps will use mixed-model mode."

## Acceptance

Per bead BDD: "Given a user with Claude Code installed but not Codex CLI, When install.sh runs, Then output reads runtime-by-runtime detection + mode + install-the-other one-liner. Install completes without bouncing." ✓ (covered by test 2).

Closes-scenario: soc-vuu6.31#install-single-runtime
Bounded-context: BC5-Runtime
Evidence: scripts/install.sh
Evidence: tests/scripts/install-sh-runtime-detection.bats
