### PR TITLE
feat(schemas): stale-claim-event.v1 schema (soc-vuu6.27 slice 1 #stale-claim-event-schema)

### DIFF
--- a/schemas/stale-claim-event.v1.schema.json
+++ b/schemas/stale-claim-event.v1.schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentops.dev/schemas/stale-claim-event.v1.schema.json",
+  "title": "Stale Claim Event",
+  "description": "Event emitted when a stale bead claim is detected or transferred under the fungibility doctrine (soc-vuu6.27). Consumed by `ao beads stale-claims` (read-only listing) and `ao beads resume` (atomic transfer). Persisted to docs/provenance/ledger.jsonl by the transfer code so the bd audit trail records who picked up whose work and why. Schema lands FIRST (slice 1) so subsequent Go code (slices 2 + 3) and the daemon job (slice 4) all consume the same shape.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "event_type",
+    "bead_id",
+    "detected_at",
+    "original_claimant",
+    "evidence"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Bumped when shape changes; consumers gate on this."
+    },
+    "event_type": {
+      "type": "string",
+      "enum": ["stale_detected", "claim_transferred"],
+      "description": "stale_detected = `ao beads stale-claims` surfaced this in its listing. claim_transferred = `ao beads resume` performed an atomic transfer. Both forms ship as the same record so consumers don't branch on shape."
+    },
+    "bead_id": {
+      "type": "string",
+      "pattern": "^[a-z]{2,6}-[0-9a-z.]+$",
+      "description": "The bead whose claim is stale (or just transferred)."
+    },
+    "detected_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC ISO-8601 timestamp of detection or transfer."
+    },
+    "original_claimant": {
+      "$ref": "#/$defs/Agent",
+      "description": "The agent identity that originally claimed the bead and is now considered stale."
+    },
+    "new_claimant": {
+      "$ref": "#/$defs/Agent",
+      "description": "REQUIRED for event_type == claim_transferred. The agent that picked up the work. OMITTED for stale_detected."
+    },
+    "evidence": {
+      "type": "object",
+      "description": "Why this claim was deemed stale. At least one of last_touch_ts / worktree_quiet_since / heartbeat_expired_at must be present; multiple signals strengthen the determination.",
+      "additionalProperties": false,
+      "properties": {
+        "last_touch_ts": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last bd activity (update, comment, status change) attributed to the original claimant on this bead."
+        },
+        "claim_age_hours": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Hours between the claim being taken and detected_at."
+        },
+        "worktree_quiet_since": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Most recent commit or file-change timestamp under the worktree associated with this bead. Absent = no worktree association or no commits yet."
+        },
+        "heartbeat_expired_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the agent's session-bootstrap heartbeat (vuu6.25) was last seen, if heartbeats are wired."
+        },
+        "threshold_hours": {
+          "type": "number",
+          "minimum": 0,
+          "description": "The staleness threshold in hours that the detector applied. Defaults to 4 if absent."
+        },
+        "last_evidence_event": {
+          "type": "string",
+          "description": "Free-text descriptor of the most recent operationally-meaningful event (e.g. 'commit cce097cf', 'bd update notes', 'gh pr push'). Used in human-readable listings."
+        }
+      },
+      "anyOf": [
+        { "required": ["last_touch_ts"] },
+        { "required": ["worktree_quiet_since"] },
+        { "required": ["heartbeat_expired_at"] }
+      ]
+    },
+    "transfer": {
+      "type": "object",
+      "description": "REQUIRED for event_type == claim_transferred. Captures the atomic-update fingerprint so concurrent transfer attempts are auditable.",
+      "additionalProperties": false,
+      "required": ["prior_revision", "new_revision"],
+      "properties": {
+        "prior_revision": {
+          "type": "string",
+          "description": "The bead's revision/etag/version at the moment the transfer was attempted. Used for optimistic-concurrency control."
+        },
+        "new_revision": {
+          "type": "string",
+          "description": "Post-transfer revision/etag/version."
+        },
+        "notes_appended": {
+          "type": "boolean",
+          "description": "True when the transferring command also wrote a bd note crediting both agents."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "event_type": { "const": "claim_transferred" } } },
+      "then": {
+        "required": ["new_claimant", "transfer"]
+      }
+    }
+  ],
+  "$defs": {
+    "Agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable agent identity. Convention: `<runtime>:<model>:<short-token>` (e.g. `claude:opus-4-7:s2k4d`)."
+        },
+        "runtime": {
+          "type": "string",
+          "enum": ["claude-code", "codex", "openclaw", "agentopsd", "unknown"],
+          "description": "Optional. Which runtime the agent ran in."
+        },
+        "model": {
+          "type": "string",
+          "description": "Optional. Model id (e.g. claude-opus-4-7, gpt-5.5-codex)."
+        }
+      }
+    }
+  }
+}

--- a/tests/scripts/stale-claim-event-schema.bats
+++ b/tests/scripts/stale-claim-event-schema.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+# Regression tests for schemas/stale-claim-event.v1.schema.json (soc-vuu6.27 slice 1).
+#
+# ajv is not in the test environment, so we exercise the schema structurally
+# via jq: check the schema itself is valid JSON with the expected required
+# fields, and validate fixtures by deriving required-field presence from the
+# schema. This catches "the schema and the fixtures disagree" — exactly the
+# class of bug schemas exist to prevent.
+
+setup() {
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  SCHEMA="$REPO_ROOT/schemas/stale-claim-event.v1.schema.json"
+  TMP="$(mktemp -d)"
+  ORIG_DIR="$PWD"
+}
+
+teardown() {
+  cd "$ORIG_DIR" 2>/dev/null || true
+  rm -rf "$TMP"
+}
+
+@test "schema file is valid JSON" {
+  run jq . "$SCHEMA"
+  [ "$status" -eq 0 ]
+}
+
+@test "schema declares the right \$id and draft" {
+  jq -e '.["$schema"] == "https://json-schema.org/draft/2020-12/schema"' "$SCHEMA" >/dev/null
+  jq -e '.["$id"] | endswith("stale-claim-event.v1.schema.json")' "$SCHEMA" >/dev/null
+}
+
+@test "schema requires the six core fields" {
+  for field in schema_version event_type bead_id detected_at original_claimant evidence; do
+    jq -e --arg f "$field" '.required | index($f) != null' "$SCHEMA" >/dev/null
+  done
+}
+
+@test "schema constrains schema_version to const 1" {
+  jq -e '.properties.schema_version.const == 1' "$SCHEMA" >/dev/null
+}
+
+@test "event_type enum has exactly stale_detected + claim_transferred" {
+  jq -e '.properties.event_type.enum == ["stale_detected", "claim_transferred"]' "$SCHEMA" >/dev/null
+}
+
+@test "bead_id pattern matches soc-* shape" {
+  pattern="$(jq -r '.properties.bead_id.pattern' "$SCHEMA")"
+  [ "$pattern" = '^[a-z]{2,6}-[0-9a-z.]+$' ]
+  # Spot-check on real-shaped bead ids
+  echo "soc-vuu6.27" | grep -qE "$pattern"
+  echo "soc-m6v5.9.4.1" | grep -qE "$pattern"
+  # Counter-spot
+  ! echo "Soc-VUU6.27" | grep -qE "$pattern"
+}
+
+@test "evidence allows any single staleness signal (anyOf clause)" {
+  jq -e '.properties.evidence.anyOf | length == 3' "$SCHEMA" >/dev/null
+  jq -e '.properties.evidence.anyOf[0].required[0] == "last_touch_ts"' "$SCHEMA" >/dev/null
+  jq -e '.properties.evidence.anyOf[1].required[0] == "worktree_quiet_since"' "$SCHEMA" >/dev/null
+  jq -e '.properties.evidence.anyOf[2].required[0] == "heartbeat_expired_at"' "$SCHEMA" >/dev/null
+}
+
+@test "claim_transferred event_type requires new_claimant + transfer (allOf if/then)" {
+  # The allOf if/then enforces conditional required fields.
+  jq -e '.allOf[0].then.required | contains(["new_claimant", "transfer"])' "$SCHEMA" >/dev/null
+}
+
+@test "Agent \$def requires only id" {
+  jq -e '.["$defs"].Agent.required == ["id"]' "$SCHEMA" >/dev/null
+  jq -e '.["$defs"].Agent.properties.id.minLength == 1' "$SCHEMA" >/dev/null
+}
+
+@test "Agent runtime enum covers the documented runtimes" {
+  for rt in claude-code codex openclaw agentopsd unknown; do
+    jq -e --arg r "$rt" '.["$defs"].Agent.properties.runtime.enum | index($r) != null' "$SCHEMA" >/dev/null
+  done
+}
+
+@test "fixture: minimal stale_detected record satisfies the required-field gate" {
+  cat > "$TMP/sample.json" <<'EOF'
+{
+  "schema_version": 1,
+  "event_type": "stale_detected",
+  "bead_id": "soc-test.1",
+  "detected_at": "2026-05-20T23:00:00Z",
+  "original_claimant": { "id": "claude:opus-4-7:abc123" },
+  "evidence": {
+    "last_touch_ts": "2026-05-20T18:00:00Z"
+  }
+}
+EOF
+  jq -e . "$TMP/sample.json" >/dev/null
+  # Each top-level required field must be present in the fixture.
+  for field in schema_version event_type bead_id detected_at original_claimant evidence; do
+    jq -e --arg f "$field" 'has($f)' "$TMP/sample.json" >/dev/null
+  done
+}
+
+@test "fixture: minimal claim_transferred record carries new_claimant + transfer" {
+  cat > "$TMP/sample.json" <<'EOF'
+{
+  "schema_version": 1,
+  "event_type": "claim_transferred",
+  "bead_id": "soc-test.2",
+  "detected_at": "2026-05-20T23:00:00Z",
+  "original_claimant": { "id": "claude:opus-4-7:abc" },
+  "new_claimant": { "id": "codex:gpt-5.5:def" },
+  "evidence": {
+    "last_touch_ts": "2026-05-20T18:00:00Z",
+    "claim_age_hours": 5.0
+  },
+  "transfer": {
+    "prior_revision": "rev-001",
+    "new_revision": "rev-002",
+    "notes_appended": true
+  }
+}
+EOF
+  jq -e 'has("new_claimant") and has("transfer")' "$TMP/sample.json" >/dev/null
+  jq -e '.transfer | has("prior_revision") and has("new_revision")' "$TMP/sample.json" >/dev/null
+}
+
+@test "additionalProperties: false at root, evidence, transfer, and Agent" {
+  jq -e '.additionalProperties == false' "$SCHEMA" >/dev/null
+  jq -e '.properties.evidence.additionalProperties == false' "$SCHEMA" >/dev/null
+  jq -e '.properties.transfer.additionalProperties == false' "$SCHEMA" >/dev/null
+  jq -e '.["$defs"].Agent.additionalProperties == false' "$SCHEMA" >/dev/null
+}


### PR DESCRIPTION
## Why

The fungibility doctrine ("Dead agent? Start another.") needs an operational primitive: detect stale claims, transfer them atomically. Without it, a 30-agent overnight swarm degrades to a halt every time an agent dies mid-bead. soc-vuu6.27 is the M2 fungibility primitive; it also unblocks soc-vuu6.29 (Fungibility Charter) which CANNOT land until at least vuu6.25 and vuu6.27 ship per the Charter bead's own risk gate.

Per the soc-vuu6.4 slicing pattern proven this session, ship the contract slice first so subsequent code (list cmd, resume cmd, daemon job) can be built against a stable shape.

## What

Slice 1 of soc-vuu6.27 ships only the schema:

- **`schemas/stale-claim-event.v1.schema.json`** — JSON Schema Draft 2020-12 for the event written when a claim is detected stale or atomically transferred. One shape covers both event types (`stale_detected` and `claim_transferred`); `allOf if/then` enforces that `claim_transferred` carries `new_claimant` + `transfer` fields. Evidence object uses `anyOf` so at least one staleness signal (`last_touch_ts`, `worktree_quiet_since`, or `heartbeat_expired_at`) is required.

3 follow-up beads filed for slices 2-4:
- Slice 2: `ao beads stale-claims` list command
- Slice 3: `ao beads resume <id>` atomic transfer
- Slice 4: agentopsd auto-resume background job

All three block on this slice.

## Test

13 bats tests, all passing. Cover: schema is valid JSON, $id+draft are right, six core required fields present, `schema_version` const 1, `event_type` enum exact, `bead_id` regex matches real-shaped IDs and rejects mis-cased ones, evidence `anyOf` allows any single signal, `allOf if/then` enforces conditional fields for `claim_transferred`, Agent $def shape, runtime enum coverage, minimal fixtures of both event types satisfy the schema, `additionalProperties: false` at every object boundary.

(ajv isn't in the test env; structural validation via jq + fixtures catches the schema/fixture-drift class without the new dep.)

Closes-scenario: soc-vuu6.27#stale-claim-event-schema
Bounded-context: BC1-Corpus
Evidence: schemas/stale-claim-event.v1.schema.json
Evidence: tests/scripts/stale-claim-event-schema.bats
