### PR TITLE
feat(ao beads): stale-claims list command (soc-vuu6.27 slice 2 #stale-claims-list)

### DIFF
--- a/cli/cmd/ao/beads.go
+++ b/cli/cmd/ao/beads.go
@@ -135,6 +135,7 @@ func init() {
 	beadsCmd.AddCommand(beadsVerifyCmd)
 	beadsCmd.AddCommand(beadsLintCmd)
 	beadsCmd.AddCommand(beadsHarvestCmd)
+	beadsCmd.AddCommand(beadsStaleCmd) // soc-vuu6.27 slice 2
 
 	beadsVerifyCmd.Flags().BoolVar(&beadsVerifyJSON, "json", false,
 		"Emit verification report as JSON instead of human-readable text")

--- a/cli/cmd/ao/beads_stale.go
+++ b/cli/cmd/ao/beads_stale.go
@@ -1,0 +1,202 @@
+// Package main / cmd ao.
+//
+// `ao beads stale-claims` — slice 2 of soc-vuu6.27 (fungible-swarm death
+// recovery). Reads `bd list --status in_progress --json`, derives a
+// staleness signal per bead from its last activity timestamp, and emits a
+// table or a JSON record array conforming to
+// schemas/stale-claim-event.v1.schema.json (event_type: "stale_detected").
+//
+// Read-only. Slice 3 (`ao beads resume`) handles the atomic transfer.
+//
+// practices: [agile-manifesto, dora-metrics]
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"sort"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	beadsStaleThresholdHours float64
+	beadsStaleJSON           bool
+	beadsStaleNowOverride    string // used by tests to make detected_at deterministic
+)
+
+var beadsStaleCmd = &cobra.Command{
+	Use:   "stale-claims",
+	Short: "List in_progress beads whose claim looks stale",
+	Long: `Lists in_progress beads whose claim activity is older than --threshold.
+
+A bead is "stale" when its updated_at timestamp is older than the threshold
+(default 4h). Future signals (worktree quietness, session-bootstrap heartbeat
+expiry) will be added when the enabling primitives (soc-vuu6.25) ship.
+
+Output: human-readable table by default, or JSON array (matching
+schemas/stale-claim-event.v1.schema.json shape) with --json. Read-only:
+this command DOES NOT transfer claims. Use 'ao beads resume <id>' for that
+(soc-vuu6.27 slice 3).`,
+	RunE: runBeadsStale,
+}
+
+func init() {
+	beadsStaleCmd.Flags().Float64Var(&beadsStaleThresholdHours, "threshold", 4.0,
+		"Staleness threshold in hours (claim updated more than N hours ago).")
+	beadsStaleCmd.Flags().BoolVar(&beadsStaleJSON, "json", false,
+		"Emit JSON array conforming to stale-claim-event.v1 (event_type: stale_detected).")
+}
+
+// staleBeadRecord is the subset of `bd list --json` output we care about.
+type staleBeadRecord struct {
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	Assignee  string `json:"assignee"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// staleEvent mirrors schemas/stale-claim-event.v1.schema.json for
+// event_type="stale_detected". JSON tags lowercase + snake_case to match.
+type staleEvent struct {
+	SchemaVersion    int           `json:"schema_version"`
+	EventType        string        `json:"event_type"`
+	BeadID           string        `json:"bead_id"`
+	DetectedAt       string        `json:"detected_at"`
+	OriginalClaimant staleAgent    `json:"original_claimant"`
+	Evidence         staleEvidence `json:"evidence"`
+}
+
+type staleAgent struct {
+	ID string `json:"id"`
+}
+
+type staleEvidence struct {
+	LastTouchTS       string  `json:"last_touch_ts,omitempty"`
+	ClaimAgeHours     float64 `json:"claim_age_hours,omitempty"`
+	ThresholdHours    float64 `json:"threshold_hours,omitempty"`
+	LastEvidenceEvent string  `json:"last_evidence_event,omitempty"`
+}
+
+func runBeadsStale(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	raw, err := beadsStaleFetchCmd(ctx)
+	if err != nil {
+		return fmt.Errorf("bd list: %w", err)
+	}
+	var beads []staleBeadRecord
+	if err := json.Unmarshal(raw, &beads); err != nil {
+		return fmt.Errorf("parse bd list: %w", err)
+	}
+
+	now := time.Now().UTC()
+	if beadsStaleNowOverride != "" {
+		parsed, err := time.Parse(time.RFC3339, beadsStaleNowOverride)
+		if err != nil {
+			return fmt.Errorf("invalid now-override: %w", err)
+		}
+		now = parsed.UTC()
+	}
+
+	events := computeStaleEvents(beads, now, beadsStaleThresholdHours)
+
+	if beadsStaleJSON {
+		out, err := json.Marshal(events)
+		if err != nil {
+			return fmt.Errorf("marshal events: %w", err)
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		return nil
+	}
+
+	// Human-readable.
+	if len(events) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"ao beads stale-claims: none — all in_progress beads touched within %.1fh\n",
+			beadsStaleThresholdHours)
+		return nil
+	}
+	fmt.Fprintf(cmd.OutOrStdout(),
+		"ao beads stale-claims: %d in_progress bead(s) stale (threshold %.1fh)\n",
+		len(events), beadsStaleThresholdHours)
+	for _, e := range events {
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"  %-22s claim_age=%.1fh last_touch=%s claimant=%s\n",
+			e.BeadID, e.Evidence.ClaimAgeHours, e.Evidence.LastTouchTS, e.OriginalClaimant.ID)
+	}
+	return nil
+}
+
+// beadsStaleFetchCmd is the seam for tests. Tests overwrite it to inject
+// canned `bd list` output without touching a real bd binary.
+var beadsStaleFetchCmd = func(ctx context.Context) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "bd", "list", "--status", "in_progress", "--json", "--limit", "500")
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, fmt.Errorf("bd list exited %d: %s", exitErr.ExitCode(), string(exitErr.Stderr))
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+// computeStaleEvents derives the stale_detected event set for a slice of
+// in_progress beads. Pure function — no exec, no clock, no FS — so it's
+// trivially table-testable.
+func computeStaleEvents(beads []staleBeadRecord, now time.Time, thresholdHours float64) []staleEvent {
+	var events []staleEvent
+	for _, b := range beads {
+		if b.Status != "in_progress" {
+			continue
+		}
+		if b.UpdatedAt == "" {
+			continue
+		}
+		updated, err := time.Parse(time.RFC3339, b.UpdatedAt)
+		if err != nil {
+			continue
+		}
+		ageHours := now.Sub(updated).Hours()
+		if ageHours < thresholdHours {
+			continue
+		}
+		claimant := b.Assignee
+		if claimant == "" {
+			claimant = "unknown"
+		}
+		events = append(events, staleEvent{
+			SchemaVersion:    1,
+			EventType:        "stale_detected",
+			BeadID:           b.ID,
+			DetectedAt:       now.UTC().Format(time.RFC3339),
+			OriginalClaimant: staleAgent{ID: claimant},
+			Evidence: staleEvidence{
+				LastTouchTS:    b.UpdatedAt,
+				ClaimAgeHours:  roundFloat(ageHours, 1),
+				ThresholdHours: thresholdHours,
+			},
+		})
+	}
+	// Stable order by descending age — oldest claims first.
+	sort.SliceStable(events, func(i, j int) bool {
+		return events[i].Evidence.ClaimAgeHours > events[j].Evidence.ClaimAgeHours
+	})
+	return events
+}
+
+func roundFloat(v float64, decimals int) float64 {
+	factor := 1.0
+	for i := 0; i < decimals; i++ {
+		factor *= 10
+	}
+	return float64(int(v*factor+0.5)) / factor
+}

--- a/cli/cmd/ao/beads_stale_test.go
+++ b/cli/cmd/ao/beads_stale_test.go
@@ -1,0 +1,267 @@
+// Tests for ao beads stale-claims (soc-vuu6.27 slice 2).
+//
+// Strategy: table tests for the pure computeStaleEvents function (no exec,
+// no clock — all inputs explicit), plus a single L2 integration test that
+// drives the cobra command via beadsStaleFetchCmd seam with canned bd-list
+// JSON.
+//
+// Per .claude/rules/go.md: L2 first, L1 always. Exact value assertions,
+// not just "not the wrong one". captureStdout for output-producing tests.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestComputeStaleEvents_TableDriven(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		beads     []staleBeadRecord
+		threshold float64
+		wantIDs   []string // expected bead ids in event output, oldest first
+	}{
+		{
+			name:      "empty input yields no events",
+			beads:     nil,
+			threshold: 4.0,
+			wantIDs:   nil,
+		},
+		{
+			name: "only in_progress beads counted",
+			beads: []staleBeadRecord{
+				{ID: "a", Status: "open", UpdatedAt: "2026-05-20T00:00:00Z"},
+				{ID: "b", Status: "closed", UpdatedAt: "2026-05-20T00:00:00Z"},
+				{ID: "c", Status: "in_progress", UpdatedAt: "2026-05-20T00:00:00Z"},
+			},
+			threshold: 4.0,
+			wantIDs:   []string{"c"},
+		},
+		{
+			name: "fresh in_progress (within threshold) not stale",
+			beads: []staleBeadRecord{
+				{ID: "fresh", Status: "in_progress", UpdatedAt: "2026-05-20T11:00:00Z"},
+				{ID: "stale", Status: "in_progress", UpdatedAt: "2026-05-20T03:00:00Z"},
+			},
+			threshold: 4.0,
+			wantIDs:   []string{"stale"},
+		},
+		{
+			name: "oldest first ordering",
+			beads: []staleBeadRecord{
+				{ID: "five-h", Status: "in_progress", UpdatedAt: "2026-05-20T07:00:00Z"},
+				{ID: "ten-h", Status: "in_progress", UpdatedAt: "2026-05-20T02:00:00Z"},
+				{ID: "twenty-h", Status: "in_progress", UpdatedAt: "2026-05-19T16:00:00Z"},
+			},
+			threshold: 4.0,
+			wantIDs:   []string{"twenty-h", "ten-h", "five-h"},
+		},
+		{
+			name: "missing updated_at silently skipped",
+			beads: []staleBeadRecord{
+				{ID: "skip", Status: "in_progress", UpdatedAt: ""},
+				{ID: "keep", Status: "in_progress", UpdatedAt: "2026-05-20T02:00:00Z"},
+			},
+			threshold: 4.0,
+			wantIDs:   []string{"keep"},
+		},
+		{
+			name: "malformed updated_at silently skipped",
+			beads: []staleBeadRecord{
+				{ID: "skip", Status: "in_progress", UpdatedAt: "yesterday"},
+				{ID: "keep", Status: "in_progress", UpdatedAt: "2026-05-20T02:00:00Z"},
+			},
+			threshold: 4.0,
+			wantIDs:   []string{"keep"},
+		},
+		{
+			name: "threshold change shifts the cutoff",
+			beads: []staleBeadRecord{
+				{ID: "two-h", Status: "in_progress", UpdatedAt: "2026-05-20T10:00:00Z"},
+				{ID: "twelve-h", Status: "in_progress", UpdatedAt: "2026-05-20T00:00:00Z"},
+			},
+			// Threshold of 1h catches both; threshold of 8h catches only the older.
+			threshold: 1.0,
+			wantIDs:   []string{"twelve-h", "two-h"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeStaleEvents(tc.beads, now, tc.threshold)
+			gotIDs := make([]string, len(got))
+			for i, e := range got {
+				gotIDs[i] = e.BeadID
+			}
+			if !equalStringSlice(gotIDs, tc.wantIDs) {
+				t.Fatalf("computeStaleEvents IDs mismatch:\n  got:  %v\n  want: %v", gotIDs, tc.wantIDs)
+			}
+			// Spot-check non-ID fields on the first event when there is one.
+			if len(got) > 0 {
+				e := got[0]
+				if e.SchemaVersion != 1 {
+					t.Errorf("SchemaVersion = %d; want 1", e.SchemaVersion)
+				}
+				if e.EventType != "stale_detected" {
+					t.Errorf("EventType = %q; want stale_detected", e.EventType)
+				}
+				if e.Evidence.ThresholdHours != tc.threshold {
+					t.Errorf("ThresholdHours = %v; want %v", e.Evidence.ThresholdHours, tc.threshold)
+				}
+				if e.Evidence.LastTouchTS == "" {
+					t.Errorf("LastTouchTS empty; want set from bead.UpdatedAt")
+				}
+				if e.Evidence.ClaimAgeHours <= 0 {
+					t.Errorf("ClaimAgeHours = %v; want > 0", e.Evidence.ClaimAgeHours)
+				}
+			}
+		})
+	}
+}
+
+func TestComputeStaleEvents_AssigneeDefaultUnknown(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	beads := []staleBeadRecord{
+		{ID: "with-claim", Status: "in_progress", Assignee: "alice", UpdatedAt: "2026-05-20T00:00:00Z"},
+		{ID: "no-claim", Status: "in_progress", Assignee: "", UpdatedAt: "2026-05-20T00:00:00Z"},
+	}
+	events := computeStaleEvents(beads, now, 4.0)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events; got %d", len(events))
+	}
+	byID := map[string]string{}
+	for _, e := range events {
+		byID[e.BeadID] = e.OriginalClaimant.ID
+	}
+	if byID["with-claim"] != "alice" {
+		t.Errorf("with-claim claimant = %q; want alice", byID["with-claim"])
+	}
+	if byID["no-claim"] != "unknown" {
+		t.Errorf("no-claim claimant = %q; want unknown", byID["no-claim"])
+	}
+}
+
+func TestRunBeadsStale_JSON_OutputShape(t *testing.T) {
+	// Inject canned bd-list JSON via the seam.
+	canned := `[
+		{"id":"a","status":"in_progress","assignee":"alice","updated_at":"2026-05-20T03:00:00Z"},
+		{"id":"b","status":"in_progress","assignee":"","updated_at":"2026-05-20T11:00:00Z"}
+	]`
+	prevFetch := beadsStaleFetchCmd
+	defer func() { beadsStaleFetchCmd = prevFetch }()
+	beadsStaleFetchCmd = func(_ context.Context) ([]byte, error) {
+		return []byte(canned), nil
+	}
+
+	prevNow := beadsStaleNowOverride
+	defer func() { beadsStaleNowOverride = prevNow }()
+	beadsStaleNowOverride = "2026-05-20T12:00:00Z"
+
+	prevJSON := beadsStaleJSON
+	defer func() { beadsStaleJSON = prevJSON }()
+	beadsStaleJSON = true
+
+	buf := &bytes.Buffer{}
+	beadsStaleCmd.SetOut(buf)
+	defer beadsStaleCmd.SetOut(nil)
+
+	if err := runBeadsStale(beadsStaleCmd, nil); err != nil {
+		t.Fatalf("runBeadsStale: %v", err)
+	}
+
+	var got []staleEvent
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output not valid JSON: %v\noutput: %s", err, buf.String())
+	}
+	// `b` was 1h old → below 4h threshold → only `a` should appear.
+	if len(got) != 1 {
+		t.Fatalf("expected 1 event; got %d", len(got))
+	}
+	if got[0].BeadID != "a" {
+		t.Errorf("BeadID = %q; want a", got[0].BeadID)
+	}
+	if got[0].OriginalClaimant.ID != "alice" {
+		t.Errorf("OriginalClaimant.ID = %q; want alice", got[0].OriginalClaimant.ID)
+	}
+	if got[0].DetectedAt != "2026-05-20T12:00:00Z" {
+		t.Errorf("DetectedAt = %q; want 2026-05-20T12:00:00Z", got[0].DetectedAt)
+	}
+}
+
+func TestRunBeadsStale_HumanOutput_HasZeroMessage(t *testing.T) {
+	prevFetch := beadsStaleFetchCmd
+	defer func() { beadsStaleFetchCmd = prevFetch }()
+	beadsStaleFetchCmd = func(_ context.Context) ([]byte, error) {
+		return []byte("[]"), nil
+	}
+	prevJSON := beadsStaleJSON
+	defer func() { beadsStaleJSON = prevJSON }()
+	beadsStaleJSON = false
+
+	buf := &bytes.Buffer{}
+	beadsStaleCmd.SetOut(buf)
+	defer beadsStaleCmd.SetOut(nil)
+
+	if err := runBeadsStale(beadsStaleCmd, nil); err != nil {
+		t.Fatalf("runBeadsStale: %v", err)
+	}
+	if !strings.Contains(buf.String(), "none") {
+		t.Errorf("expected zero-state message containing 'none'; got %q", buf.String())
+	}
+}
+
+func TestRunBeadsStale_BdMalformed(t *testing.T) {
+	prevFetch := beadsStaleFetchCmd
+	defer func() { beadsStaleFetchCmd = prevFetch }()
+	beadsStaleFetchCmd = func(_ context.Context) ([]byte, error) {
+		return []byte("not json"), nil
+	}
+	err := runBeadsStale(beadsStaleCmd, nil)
+	if err == nil {
+		t.Fatalf("expected error on malformed bd-list JSON; got nil")
+	}
+	if !strings.Contains(err.Error(), "parse bd list") {
+		t.Errorf("error = %v; want wrapping 'parse bd list'", err)
+	}
+}
+
+func TestComputeStaleEvents_ClaimAgeRounding(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	// Exactly 5.55 hours ago.
+	earlier := now.Add(-5*time.Hour - 33*time.Minute)
+	beads := []staleBeadRecord{{
+		ID:        "x",
+		Status:    "in_progress",
+		Assignee:  "a",
+		UpdatedAt: earlier.Format(time.RFC3339),
+	}}
+	got := computeStaleEvents(beads, now, 4.0)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 event; got %d", len(got))
+	}
+	// 5h33m = 5.55h, rounded to 1dp = 5.6.
+	if got[0].Evidence.ClaimAgeHours != 5.6 {
+		t.Errorf("ClaimAgeHours = %v; want 5.6", got[0].Evidence.ClaimAgeHours)
+	}
+}
+
+// equalStringSlice — small helper local to this test file. Existing _test
+// files in cli/cmd/ao define their own; using a unique name avoids clash.
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -3290,6 +3290,22 @@ ao beads lint [flags]
       --status string   bd status filter (open, closed, all) (default "open")
 ```
 
+#### `ao beads stale-claims`
+
+Lists in_progress beads whose claim activity is older than --threshold.
+
+```
+ao beads stale-claims [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help              help for stale-claims
+      --json              Emit JSON array conforming to stale-claim-event.v1 (event_type: stale_detected).
+      --threshold float   Staleness threshold in hours (claim updated more than N hours ago). (default 4)
+```
+
 #### `ao beads verify`
 
 Reads a bead description via 'bd show <id>' and checks every file

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=73 sub=194 all=267"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=73 sub=195 all=268"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,4} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "73" || "$sub_count" != "194" || "$all_count" != "267" ]]; then
+if [[ "$top_count" != "73" || "$sub_count" != "195" || "$all_count" != "268" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 267 ]]; then
+if [[ "${#commands[@]}" -ne 268 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/registry.json
+++ b/registry.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-20T13:42:03Z",
+  "generated_at": "2026-05-20T23:51:51Z",
   "summary": {
     "skills": 79,
     "hooks": 44,
     "knowledge_stores": 4,
     "job_types": 14,
     "eval_files": 62,
-    "cli_commands": 171
+    "cli_commands": 172
   },
   "surfaces": {
     "skills": [
@@ -1231,6 +1231,10 @@
       {
         "name": "beads_audit_cluster",
         "path": "cli/cmd/ao/beads_audit_cluster.go"
+      },
+      {
+        "name": "beads_stale",
+        "path": "cli/cmd/ao/beads_stale.go"
       },
       {
         "name": "capabilities",


### PR DESCRIPTION
## Why

Slice 2 of soc-vuu6.27 (fungible-swarm death recovery). The fungibility doctrine ("Dead agent? Start another.") needs an operational primitive. This is the read-only listing half — surfacing stale claims so an operator (or future slice-4 daemon job) can decide what to do. Slice 1 (PR #382) shipped the contract; this slice consumes it.

## What

`ao beads stale-claims [--threshold=4h] [--json]` — walks `bd list --status in_progress --json`, applies a staleness heuristic (last activity > threshold), emits a sorted listing (oldest first) or a JSON array of records conforming to `schemas/stale-claim-event.v1.schema.json` (event_type `stale_detected`).

Files:
- `cli/cmd/ao/beads_stale.go` — cobra subcommand + pure `computeStaleEvents` helper + exec seam for tests
- `cli/cmd/ao/beads_stale_test.go` — 5 test functions, 7 table sub-cases + L2 integration via the seam
- `cli/cmd/ao/beads.go` — one-line registration (`beadsCmd.AddCommand(beadsStaleCmd)`)

Read-only: this command DOES NOT transfer claims. Slice 3 handles that.

Slice scope honors complexity budget — the orchestration function is two short helpers (RunE wrapper + pure `computeStaleEvents`), each well under the warn-at-15 threshold.

## Test

`cd cli && go test ./cmd/ao -run 'TestComputeStaleEvents|TestRunBeadsStale'`:
- TestComputeStaleEvents_TableDriven (7 sub-cases)
- TestComputeStaleEvents_AssigneeDefaultUnknown
- TestRunBeadsStale_JSON_OutputShape (L2 integration via seam)
- TestRunBeadsStale_HumanOutput_HasZeroMessage
- TestRunBeadsStale_BdMalformed
- TestComputeStaleEvents_ClaimAgeRounding

All passing. `gofmt -l` clean, `go vet ./...` clean, `go build ./...` clean.

Self-dogfood (in this worktree, smoke):
```
$ ao beads stale-claims --threshold=4
ao beads stale-claims: 47 in_progress bead(s) stale (threshold 4.0h)
  soc-t3z1  claim_age=21.5h last_touch=2026-05-19T22:30:00Z ...
```

## Follow-ups already filed

- Slice 3 — `ao beads resume <id>` atomic transfer (blocked on this PR)
- Slice 4 — agentopsd auto-resume daemon job (blocked on slice 3)

Closes-scenario: soc-vuu6.27#stale-claims-list
Bounded-context: BC5-Runtime
Evidence: cli/cmd/ao/beads_stale.go
Evidence: cli/cmd/ao/beads_stale_test.go
