### PR TITLE
feat(ao beads): resume — atomic claim transfer + provenance event (soc-vuu6.27 slice 3 #beads-resume)

### DIFF
--- a/cli/cmd/ao/beads.go
+++ b/cli/cmd/ao/beads.go
@@ -135,7 +135,8 @@ func init() {
 	beadsCmd.AddCommand(beadsVerifyCmd)
 	beadsCmd.AddCommand(beadsLintCmd)
 	beadsCmd.AddCommand(beadsHarvestCmd)
-	beadsCmd.AddCommand(beadsStaleCmd) // soc-vuu6.27 slice 2
+	beadsCmd.AddCommand(beadsStaleCmd)  // soc-vuu6.27 slice 2
+	beadsCmd.AddCommand(beadsResumeCmd) // soc-vuu6.27 slice 3
 
 	beadsVerifyCmd.Flags().BoolVar(&beadsVerifyJSON, "json", false,
 		"Emit verification report as JSON instead of human-readable text")

--- a/cli/cmd/ao/beads_resume.go
+++ b/cli/cmd/ao/beads_resume.go
@@ -1,0 +1,303 @@
+// `ao beads resume <id>` — slice 3 of soc-vuu6.27 (fungible-swarm death
+// recovery). Atomically transfers an in_progress claim from a previous
+// (likely stale) agent to the current one via `bd update <id> --claim`,
+// then appends a stale-claim-event (event_type="claim_transferred") to
+// docs/provenance/ledger.jsonl so the audit trail records who picked up
+// whose work.
+//
+// Slice 2 (`stale-claims`) surfaces candidates. This slice acts on them.
+// Slice 4 (daemon job) will wrap both for periodic re-dispatch.
+//
+// practices: [agile-manifesto, continuous-delivery, dora-metrics]
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	beadsResumeAgentID     string
+	beadsResumeLedgerPath  string
+	beadsResumeJSON        bool
+	beadsResumeNowOverride string // test seam
+)
+
+var beadsResumeCmd = &cobra.Command{
+	Use:   "resume <bead-id>",
+	Short: "Atomically transfer an in_progress claim from a stale agent to this one",
+	Long: `Transfers a stale claim via 'bd update <bead-id> --claim', then appends a
+claim_transferred event (matching schemas/stale-claim-event.v1.schema.json)
+to docs/provenance/ledger.jsonl. The bead's prior + new revision (assignee
+and updated_at hash) is captured in the event for audit.
+
+Use 'ao beads stale-claims' (slice 2) to find candidates first.
+
+--agent: explicit new claimant id. Defaults to BEADS_ACTOR env var, else "ao-beads-resume".
+--ledger: provenance ledger path (default docs/provenance/ledger.jsonl).
+--json: emit the event to stdout in addition to the ledger.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runBeadsResume,
+}
+
+func init() {
+	beadsResumeCmd.Flags().StringVar(&beadsResumeAgentID, "agent", "",
+		"New claimant id (defaults to BEADS_ACTOR env var, else ao-beads-resume).")
+	beadsResumeCmd.Flags().StringVar(&beadsResumeLedgerPath, "ledger",
+		"docs/provenance/ledger.jsonl",
+		"Path to the provenance ledger (relative to repo root).")
+	beadsResumeCmd.Flags().BoolVar(&beadsResumeJSON, "json", false,
+		"Emit the claim_transferred event to stdout (always written to ledger).")
+}
+
+// beadsResumeShowFunc is the test seam for fetching a bead's current state
+// (assignee + updated_at) BEFORE the claim transfer, so we can record the
+// prior revision. Production: shells out to `bd show <id> --json`.
+var beadsResumeShowFunc = func(ctx context.Context, beadID string) (staleBeadRecord, error) {
+	out, err := exec.CommandContext(ctx, "bd", "show", beadID, "--json").Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return staleBeadRecord{}, fmt.Errorf("bd show %s exited %d: %s", beadID, exitErr.ExitCode(), string(exitErr.Stderr))
+		}
+		return staleBeadRecord{}, err
+	}
+	// bd show <id> --json may emit either an object or a 1-element array.
+	trimmed := bytes_trim_leading_ws(out)
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		var arr []staleBeadRecord
+		if err := json.Unmarshal(out, &arr); err != nil {
+			return staleBeadRecord{}, fmt.Errorf("parse bd show array: %w", err)
+		}
+		if len(arr) == 0 {
+			return staleBeadRecord{}, fmt.Errorf("bd show %s returned empty array", beadID)
+		}
+		return arr[0], nil
+	}
+	var rec staleBeadRecord
+	if err := json.Unmarshal(out, &rec); err != nil {
+		return staleBeadRecord{}, fmt.Errorf("parse bd show object: %w", err)
+	}
+	return rec, nil
+}
+
+// beadsResumeClaimFunc is the test seam for performing the atomic update.
+// Production: `bd update <id> --claim --actor <agent>`.
+var beadsResumeClaimFunc = func(ctx context.Context, beadID, agent string) error {
+	args := []string{"update", beadID, "--claim"}
+	if agent != "" {
+		args = append(args, "--actor", agent)
+	}
+	cmd := exec.CommandContext(ctx, "bd", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("bd update --claim failed: %w: %s", err, string(out))
+	}
+	return nil
+}
+
+// beadsResumeAppendLedger is the test seam for writing the provenance event.
+// Production: appends one JSON object per line to the ledger file. Accepts
+// `any` so the caller can pass the full claim_transferred shape (which
+// extends staleEvent with new_claimant + transfer) without us introducing
+// an interface.
+var beadsResumeAppendLedger = func(ledgerPath string, event any) error {
+	if err := os.MkdirAll(filepath.Dir(ledgerPath), 0o755); err != nil {
+		return fmt.Errorf("mkdir ledger dir: %w", err)
+	}
+	f, err := os.OpenFile(ledgerPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open ledger: %w", err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	if err := enc.Encode(event); err != nil {
+		return fmt.Errorf("encode event: %w", err)
+	}
+	return nil
+}
+
+func runBeadsResume(cmd *cobra.Command, args []string) error {
+	beadID := args[0]
+	if beadID == "" {
+		return fmt.Errorf("bead id is required")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// 1. Capture prior revision via `bd show`.
+	prior, err := beadsResumeShowFunc(ctx, beadID)
+	if err != nil {
+		return fmt.Errorf("fetch prior state: %w", err)
+	}
+	if prior.Status != "in_progress" {
+		return fmt.Errorf("bead %s is %q, not in_progress — resume only handles in_progress claims", beadID, prior.Status)
+	}
+
+	// 2. Compute now (test override OK).
+	now := time.Now().UTC()
+	if beadsResumeNowOverride != "" {
+		parsed, err := time.Parse(time.RFC3339, beadsResumeNowOverride)
+		if err != nil {
+			return fmt.Errorf("invalid now-override: %w", err)
+		}
+		now = parsed.UTC()
+	}
+
+	// 3. Resolve the new claimant id.
+	agent := beadsResumeAgentID
+	if agent == "" {
+		agent = os.Getenv("BEADS_ACTOR")
+	}
+	if agent == "" {
+		agent = "ao-beads-resume"
+	}
+
+	// 4. Perform the atomic claim transfer.
+	if err := beadsResumeClaimFunc(ctx, beadID, agent); err != nil {
+		return fmt.Errorf("claim transfer: %w", err)
+	}
+
+	// 5. Fetch posterior revision for the audit trail.
+	posterior, err := beadsResumeShowFunc(ctx, beadID)
+	if err != nil {
+		// Claim succeeded but we can't read back — record what we know.
+		posterior = staleBeadRecord{ID: beadID, Status: "in_progress", Assignee: agent, UpdatedAt: now.Format(time.RFC3339)}
+	}
+
+	// 6. Build + write the event.
+	priorAgent := prior.Assignee
+	if priorAgent == "" {
+		priorAgent = "unknown"
+	}
+	event := staleEvent{
+		SchemaVersion:    1,
+		EventType:        "claim_transferred",
+		BeadID:           beadID,
+		DetectedAt:       now.Format(time.RFC3339),
+		OriginalClaimant: staleAgent{ID: priorAgent},
+		Evidence: staleEvidence{
+			LastTouchTS:       prior.UpdatedAt,
+			LastEvidenceEvent: "bd update --claim",
+		},
+	}
+	// Extra fields for the transferred variant are emitted via a wrapper —
+	// stale_detected and claim_transferred share the same Go type plus
+	// these post-fields.
+	transferred := struct {
+		staleEvent
+		NewClaimant staleAgent   `json:"new_claimant"`
+		Transfer    transferInfo `json:"transfer"`
+	}{
+		staleEvent:  event,
+		NewClaimant: staleAgent{ID: agent},
+		Transfer: transferInfo{
+			PriorRevision: fingerprint(prior),
+			NewRevision:   fingerprint(posterior),
+			NotesAppended: false,
+		},
+	}
+
+	// 7. Resolve ledger path relative to repo root.
+	root, err := repoRootForBeads()
+	if err != nil {
+		return fmt.Errorf("resolve repo root: %w", err)
+	}
+	ledger := beadsResumeLedgerPath
+	if !filepath.IsAbs(ledger) {
+		ledger = filepath.Join(root, ledger)
+	}
+
+	// Write the full claim_transferred shape (with new_claimant + transfer).
+	if err := beadsResumeAppendLedger(ledger, transferred); err != nil {
+		// Best-effort: include extra context but don't roll back the claim.
+		return fmt.Errorf("append ledger (claim already transferred): %w", err)
+	}
+
+	// 8. Optional JSON-to-stdout.
+	if beadsResumeJSON {
+		raw, _ := json.Marshal(transferred)
+		fmt.Fprintln(cmd.OutOrStdout(), string(raw))
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"ao beads resume: %s transferred from %q to %q (prior_rev=%s, new_rev=%s)\n",
+			beadID, priorAgent, agent, transferred.Transfer.PriorRevision, transferred.Transfer.NewRevision)
+	}
+	return nil
+}
+
+// transferInfo mirrors the `transfer` sub-object in stale-claim-event.v1.
+type transferInfo struct {
+	PriorRevision string `json:"prior_revision"`
+	NewRevision   string `json:"new_revision"`
+	NotesAppended bool   `json:"notes_appended"`
+}
+
+// fingerprint produces a compact, stable revision token from (assignee,
+// updated_at). bd itself does not expose an etag; (assignee, updated_at)
+// changes on every claim/update so it serves as the audit fingerprint.
+func fingerprint(r staleBeadRecord) string {
+	if r.Assignee == "" && r.UpdatedAt == "" {
+		return "unset"
+	}
+	a := r.Assignee
+	if a == "" {
+		a = "_"
+	}
+	u := r.UpdatedAt
+	if u == "" {
+		u = "_"
+	}
+	return a + "@" + u
+}
+
+// repoRootForBeads finds the git repo root, falling back to cwd. Kept local
+// so this file doesn't depend on internal helpers being in scope.
+func repoRootForBeads() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		cwd, cwdErr := os.Getwd()
+		if cwdErr != nil {
+			return "", cwdErr
+		}
+		return cwd, nil
+	}
+	return string(bytes_trim_trailing_ws(out)), nil
+}
+
+// bytes_trim_leading_ws / trailing_ws — tiny local helpers to avoid pulling
+// extra packages. Whitespace-trim only (no full unicode).
+func bytes_trim_leading_ws(b []byte) []byte {
+	i := 0
+	for i < len(b) {
+		c := b[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			i++
+			continue
+		}
+		break
+	}
+	return b[i:]
+}
+func bytes_trim_trailing_ws(b []byte) []byte {
+	j := len(b)
+	for j > 0 {
+		c := b[j-1]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			j--
+			continue
+		}
+		break
+	}
+	return b[:j]
+}

--- a/cli/cmd/ao/beads_resume_test.go
+++ b/cli/cmd/ao/beads_resume_test.go
@@ -1,0 +1,269 @@
+// Tests for ao beads resume (soc-vuu6.27 slice 3).
+//
+// Exercise the runBeadsResume flow via the three seams (show / claim /
+// append-ledger) so tests never depend on a real bd binary or the live
+// provenance ledger.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// resumeFixture sets up the three seams + a temp ledger path. Returns a
+// pointer to the captured ledger appends so the test can assert on them.
+type capturedAppend struct {
+	path  string
+	event any
+}
+
+func resumeFixture(t *testing.T, prior, posterior staleBeadRecord, claimErr error) (*[]capturedAppend, func()) {
+	t.Helper()
+	prevShow := beadsResumeShowFunc
+	prevClaim := beadsResumeClaimFunc
+	prevAppend := beadsResumeAppendLedger
+	prevAgent := beadsResumeAgentID
+	prevLedger := beadsResumeLedgerPath
+	prevJSON := beadsResumeJSON
+	prevNow := beadsResumeNowOverride
+
+	showCallCount := 0
+	beadsResumeShowFunc = func(_ context.Context, _ string) (staleBeadRecord, error) {
+		showCallCount++
+		if showCallCount == 1 {
+			return prior, nil
+		}
+		return posterior, nil
+	}
+	beadsResumeClaimFunc = func(_ context.Context, _, _ string) error { return claimErr }
+
+	appends := []capturedAppend{}
+	beadsResumeAppendLedger = func(p string, e any) error {
+		appends = append(appends, capturedAppend{path: p, event: e})
+		return nil
+	}
+
+	beadsResumeNowOverride = "2026-05-20T12:00:00Z"
+
+	teardown := func() {
+		beadsResumeShowFunc = prevShow
+		beadsResumeClaimFunc = prevClaim
+		beadsResumeAppendLedger = prevAppend
+		beadsResumeAgentID = prevAgent
+		beadsResumeLedgerPath = prevLedger
+		beadsResumeJSON = prevJSON
+		beadsResumeNowOverride = prevNow
+	}
+	return &appends, teardown
+}
+
+func TestRunBeadsResume_HappyPath_WritesClaimTransferredEvent(t *testing.T) {
+	prior := staleBeadRecord{ID: "x", Status: "in_progress", Assignee: "alice", UpdatedAt: "2026-05-20T03:00:00Z"}
+	posterior := staleBeadRecord{ID: "x", Status: "in_progress", Assignee: "bob", UpdatedAt: "2026-05-20T12:00:00Z"}
+	appends, teardown := resumeFixture(t, prior, posterior, nil)
+	defer teardown()
+
+	beadsResumeAgentID = "bob"
+	beadsResumeJSON = true
+
+	buf := &bytes.Buffer{}
+	beadsResumeCmd.SetOut(buf)
+	defer beadsResumeCmd.SetOut(nil)
+
+	if err := runBeadsResume(beadsResumeCmd, []string{"x"}); err != nil {
+		t.Fatalf("runBeadsResume: %v", err)
+	}
+	if len(*appends) != 1 {
+		t.Fatalf("expected 1 ledger append; got %d", len(*appends))
+	}
+
+	// Marshal the event back to JSON and inspect shape.
+	raw, err := json.Marshal((*appends)[0].event)
+	if err != nil {
+		t.Fatalf("marshal captured event: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["event_type"] != "claim_transferred" {
+		t.Errorf("event_type = %v; want claim_transferred", got["event_type"])
+	}
+	if got["bead_id"] != "x" {
+		t.Errorf("bead_id = %v; want x", got["bead_id"])
+	}
+	orig := got["original_claimant"].(map[string]any)
+	if orig["id"] != "alice" {
+		t.Errorf("original_claimant.id = %v; want alice", orig["id"])
+	}
+	newC := got["new_claimant"].(map[string]any)
+	if newC["id"] != "bob" {
+		t.Errorf("new_claimant.id = %v; want bob", newC["id"])
+	}
+	tr := got["transfer"].(map[string]any)
+	if tr["prior_revision"] != "alice@2026-05-20T03:00:00Z" {
+		t.Errorf("transfer.prior_revision = %v; want alice@2026-05-20T03:00:00Z", tr["prior_revision"])
+	}
+	if tr["new_revision"] != "bob@2026-05-20T12:00:00Z" {
+		t.Errorf("transfer.new_revision = %v; want bob@2026-05-20T12:00:00Z", tr["new_revision"])
+	}
+	// Stdout JSON also emitted.
+	if !strings.Contains(buf.String(), "claim_transferred") {
+		t.Errorf("stdout missing claim_transferred; got %q", buf.String())
+	}
+}
+
+func TestRunBeadsResume_RefusesNonInProgress(t *testing.T) {
+	prior := staleBeadRecord{ID: "x", Status: "open", Assignee: "alice", UpdatedAt: "2026-05-20T03:00:00Z"}
+	appends, teardown := resumeFixture(t, prior, prior, nil)
+	defer teardown()
+
+	beadsResumeAgentID = "bob"
+	err := runBeadsResume(beadsResumeCmd, []string{"x"})
+	if err == nil {
+		t.Fatalf("expected error on non-in-progress bead")
+	}
+	if !strings.Contains(err.Error(), "not in_progress") {
+		t.Errorf("error = %v; want substring 'not in_progress'", err)
+	}
+	if len(*appends) != 0 {
+		t.Errorf("expected no ledger appends; got %d", len(*appends))
+	}
+}
+
+func TestRunBeadsResume_ClaimErrorBubblesUp(t *testing.T) {
+	prior := staleBeadRecord{ID: "x", Status: "in_progress", Assignee: "alice", UpdatedAt: "2026-05-20T03:00:00Z"}
+	appends, teardown := resumeFixture(t, prior, prior, errors.New("bd unavailable"))
+	defer teardown()
+
+	beadsResumeAgentID = "bob"
+	err := runBeadsResume(beadsResumeCmd, []string{"x"})
+	if err == nil {
+		t.Fatalf("expected error when bd claim fails")
+	}
+	if !strings.Contains(err.Error(), "claim transfer") {
+		t.Errorf("error = %v; want wrapping 'claim transfer'", err)
+	}
+	if len(*appends) != 0 {
+		t.Errorf("expected no ledger append on claim failure; got %d", len(*appends))
+	}
+}
+
+func TestRunBeadsResume_AgentResolution_FlagWinsOverEnv(t *testing.T) {
+	prior := staleBeadRecord{ID: "x", Status: "in_progress", Assignee: "alice", UpdatedAt: "2026-05-20T03:00:00Z"}
+	posterior := staleBeadRecord{ID: "x", Status: "in_progress", Assignee: "from-flag", UpdatedAt: "2026-05-20T12:00:00Z"}
+	appends, teardown := resumeFixture(t, prior, posterior, nil)
+	defer teardown()
+
+	t.Setenv("BEADS_ACTOR", "from-env")
+	beadsResumeAgentID = "from-flag"
+
+	if err := runBeadsResume(beadsResumeCmd, []string{"x"}); err != nil {
+		t.Fatalf("runBeadsResume: %v", err)
+	}
+	raw, _ := json.Marshal((*appends)[0].event)
+	var got map[string]any
+	json.Unmarshal(raw, &got)
+	newC := got["new_claimant"].(map[string]any)
+	if newC["id"] != "from-flag" {
+		t.Errorf("new_claimant.id = %v; want from-flag", newC["id"])
+	}
+}
+
+func TestRunBeadsResume_AgentResolution_EnvWhenNoFlag(t *testing.T) {
+	prior := staleBeadRecord{ID: "x", Status: "in_progress", Assignee: "alice", UpdatedAt: "2026-05-20T03:00:00Z"}
+	posterior := staleBeadRecord{ID: "x", Status: "in_progress", Assignee: "from-env", UpdatedAt: "2026-05-20T12:00:00Z"}
+	appends, teardown := resumeFixture(t, prior, posterior, nil)
+	defer teardown()
+
+	t.Setenv("BEADS_ACTOR", "from-env")
+	beadsResumeAgentID = ""
+
+	if err := runBeadsResume(beadsResumeCmd, []string{"x"}); err != nil {
+		t.Fatalf("runBeadsResume: %v", err)
+	}
+	raw, _ := json.Marshal((*appends)[0].event)
+	var got map[string]any
+	json.Unmarshal(raw, &got)
+	newC := got["new_claimant"].(map[string]any)
+	if newC["id"] != "from-env" {
+		t.Errorf("new_claimant.id = %v; want from-env (BEADS_ACTOR fallback)", newC["id"])
+	}
+}
+
+func TestRunBeadsResume_AgentResolution_DefaultWhenNothingSet(t *testing.T) {
+	prior := staleBeadRecord{ID: "x", Status: "in_progress", Assignee: "alice", UpdatedAt: "2026-05-20T03:00:00Z"}
+	posterior := staleBeadRecord{ID: "x", Status: "in_progress", Assignee: "ao-beads-resume", UpdatedAt: "2026-05-20T12:00:00Z"}
+	appends, teardown := resumeFixture(t, prior, posterior, nil)
+	defer teardown()
+
+	t.Setenv("BEADS_ACTOR", "")
+	beadsResumeAgentID = ""
+
+	if err := runBeadsResume(beadsResumeCmd, []string{"x"}); err != nil {
+		t.Fatalf("runBeadsResume: %v", err)
+	}
+	raw, _ := json.Marshal((*appends)[0].event)
+	var got map[string]any
+	json.Unmarshal(raw, &got)
+	newC := got["new_claimant"].(map[string]any)
+	if newC["id"] != "ao-beads-resume" {
+		t.Errorf("new_claimant.id = %v; want ao-beads-resume (default)", newC["id"])
+	}
+}
+
+func TestFingerprint(t *testing.T) {
+	tests := []struct {
+		name string
+		in   staleBeadRecord
+		want string
+	}{
+		{"both set", staleBeadRecord{Assignee: "a", UpdatedAt: "2026-05-20T00:00:00Z"}, "a@2026-05-20T00:00:00Z"},
+		{"no assignee", staleBeadRecord{Assignee: "", UpdatedAt: "2026-05-20T00:00:00Z"}, "_@2026-05-20T00:00:00Z"},
+		{"no updated", staleBeadRecord{Assignee: "a", UpdatedAt: ""}, "a@_"},
+		{"neither", staleBeadRecord{}, "unset"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fingerprint(tc.in)
+			if got != tc.want {
+				t.Errorf("fingerprint(%+v) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBeadsResumeAppendLedger_RealFileSink(t *testing.T) {
+	// Restore the real append function so we exercise the actual file IO,
+	// then point the ledger at a tempdir.
+	dir := t.TempDir()
+	ledger := filepath.Join(dir, "ledger.jsonl")
+
+	// Two appends to the same file should produce two lines, each valid JSON.
+	if err := beadsResumeAppendLedger(ledger, map[string]any{"a": 1}); err != nil {
+		t.Fatalf("append 1: %v", err)
+	}
+	if err := beadsResumeAppendLedger(ledger, map[string]any{"b": 2}); err != nil {
+		t.Fatalf("append 2: %v", err)
+	}
+	data, err := os.ReadFile(ledger)
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines; got %d (%q)", len(lines), string(data))
+	}
+	for i, l := range lines {
+		if !json.Valid([]byte(l)) {
+			t.Errorf("line %d not valid JSON: %q", i, l)
+		}
+	}
+}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -3290,6 +3290,23 @@ ao beads lint [flags]
       --status string   bd status filter (open, closed, all) (default "open")
 ```
 
+#### `ao beads resume`
+
+Transfers a stale claim via 'bd update <bead-id> --claim', then appends a
+
+```
+ao beads resume <bead-id> [flags]
+```
+
+**Flags:**
+
+```
+      --agent string    New claimant id (defaults to BEADS_ACTOR env var, else ao-beads-resume).
+  -h, --help            help for resume
+      --json            Emit the claim_transferred event to stdout (always written to ledger).
+      --ledger string   Path to the provenance ledger (relative to repo root). (default "docs/provenance/ledger.jsonl")
+```
+
 #### `ao beads stale-claims`
 
 Lists in_progress beads whose claim activity is older than --threshold.

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=73 sub=195 all=268"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=73 sub=196 all=269"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,4} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "73" || "$sub_count" != "195" || "$all_count" != "268" ]]; then
+if [[ "$top_count" != "73" || "$sub_count" != "196" || "$all_count" != "269" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 268 ]]; then
+if [[ "${#commands[@]}" -ne 269 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/registry.json
+++ b/registry.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-20T23:51:51Z",
+  "generated_at": "2026-05-20T23:52:53Z",
   "summary": {
     "skills": 79,
     "hooks": 44,
     "knowledge_stores": 4,
     "job_types": 14,
     "eval_files": 62,
-    "cli_commands": 172
+    "cli_commands": 173
   },
   "surfaces": {
     "skills": [
@@ -1231,6 +1231,10 @@
       {
         "name": "beads_audit_cluster",
         "path": "cli/cmd/ao/beads_audit_cluster.go"
+      },
+      {
+        "name": "beads_resume",
+        "path": "cli/cmd/ao/beads_resume.go"
       },
       {
         "name": "beads_stale",


### PR DESCRIPTION
## Why

Slice 3 of soc-vuu6.27 (fungible-swarm death recovery). Slice 2 (#383) lists stale claims; this slice acts on them — atomically transfers a claim from a stale agent to the current one and records the transfer in the provenance ledger. Closes the operational primitive that the Fungibility Charter (soc-vuu6.29) depends on.

**This PR is stacked on slice 2's branch** so the staleBeadRecord and staleEvent types remain colocated. When #383 merges, this branch rebases cleanly onto main.

## What

`ao beads resume <bead-id> [--agent <id>] [--ledger <path>] [--json]` — fetches the prior revision via `bd show`, calls `bd update <id> --claim` for the atomic transfer, fetches the posterior revision, then appends a `claim_transferred` event (matching schemas/stale-claim-event.v1.schema.json) to `docs/provenance/ledger.jsonl`.

Files:
- `cli/cmd/ao/beads_resume.go` — cobra command, three exec seams (show / claim / append-ledger), revision fingerprinting via `assignee@updated_at`, agent-id resolution (--agent → BEADS_ACTOR → `ao-beads-resume` default)
- `cli/cmd/ao/beads_resume_test.go` — happy path, refusal on non-in-progress, claim-error bubbling, agent resolution precedence (flag > env > default), fingerprint helper, real-file ledger sink
- `cli/cmd/ao/beads.go` — one-line registration

Idempotency: bd's `update --claim` enforces atomicity. If the claim has moved since we read it, bd rejects; our error wrapping surfaces that.

## Test

`cd cli && go test ./cmd/ao -run 'TestRunBeadsResume|TestFingerprint|TestBeadsResumeAppendLedger'`:

- TestRunBeadsResume_HappyPath_WritesClaimTransferredEvent
- TestRunBeadsResume_RefusesNonInProgress
- TestRunBeadsResume_ClaimErrorBubblesUp (claim failure → no ledger write)
- TestRunBeadsResume_AgentResolution_FlagWinsOverEnv
- TestRunBeadsResume_AgentResolution_EnvWhenNoFlag
- TestRunBeadsResume_AgentResolution_DefaultWhenNothingSet
- TestFingerprint (4 sub-cases)
- TestBeadsResumeAppendLedger_RealFileSink

All passing. `gofmt -l` clean, `go vet ./...` clean, `go build ./...` clean.

## Follow-up

- Slice 4 — agentopsd auto-resume daemon job (blocked on this PR)

Closes-scenario: soc-vuu6.27#beads-resume
Bounded-context: BC5-Runtime
Evidence: cli/cmd/ao/beads_resume.go
Evidence: cli/cmd/ao/beads_resume_test.go
