### PR TITLE
fix(agentopsd): harden AI smell surfaces (soc-0l5z #ai-smell-hardening)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -64,11 +64,11 @@ The April 2026 Claude Code source analysis confirmed that Anthropic's internal t
 
 | Anthropic Concept | AgentOps Equivalent | Status |
 |---|---|---|
-| **Learning Loop** — memory extraction, dream cycle consolidation, future session context | Knowledge Flywheel — `/retro` → `/forge` → `/harvest` → `ao lookup` / `ao context assemble`, tiered promotion (learning → pattern → rule), plus private local Dream via `/dream` and `ao overnight` | Shipped. On-demand capture/promotion is live, and Dream now provides the bounded private overnight compounding lane. GitHub nightly is the public proof harness for the contracts, not the user's private runtime. |
+| **Learning Loop** — memory extraction, dream cycle consolidation, future session context | Knowledge Flywheel — `/retro` → `/forge` → `/harvest` → `ao lookup` / `ao context assemble`, tiered promotion (learning → pattern → rule), plus private local Dream via `/dream` and `ao overnight` | Live with bounds. On-demand capture/promotion works, and Dream provides an operator-started overnight compounding lane. GitHub nightly is the public proof harness for the contracts, not the user's private runtime. |
 | **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 79 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
-| **Verification Agent** — adversarial AI auditing AI, VERDICT system for human review | Council architecture — `/council`, `/pre-mortem`, `/vibe`, `/post-mortem` with multi-model consensus, prediction tracking. Stage 4 behavioral validation adds holdout scenarios + satisfaction scoring in STEP 1.8. | Shipped. On-demand + always-on (STEP 1.8 fires automatically during `/validation`). |
-| **Managed Agents Dreaming** (May 2026) — scheduled session review, pattern extraction, memory curation between sessions | `/dream` + `ao overnight` + `cli/cmd/ao/dream_executor.go` + `.github/workflows/nightly.yml` dream-cycle proof job | Shipped. Bounded private overnight compounding lane runs the harvest → forge → close-loop → defrag chain unattended, off the API and against any model. |
-| **Managed Agents Outcomes** (May 2026) — rubric-driven separate-context grader with iterate-until-pass | Shipped at three scopes: project — `GOALS.md` (rubric) + `ao goals measure` (each gate runs as separate subprocess; `cli/internal/goals/measure.go:132-164`) + `/evolve` (iterates worst-failing gate until pass; `skills/evolve/SKILL.md:379-388`); plan — `/pre-mortem` council judges as separate-context graders; code — `/vibe` council judges. Independent 3-judge audit confirmed parity on rubric authoring, separate-context grading, iterate-until-pass, and pinpoint-what-changed. | Shipped at the capability layer. Empirical workbench A/B (2026-05-06): Δ=+0.0000 across 12 cases at v1 difficulty (both legs 12/12) — task difficulty floor exhausted; v2 substrate (realistic agent tasks where the hook layer differentiates) is roadmap. Counter-stat artifact: `evals/workbench/results/2026-05-06-yjzp9-counterstat.json`. |
+| **Verification Agent** — adversarial AI auditing AI, VERDICT system for human review | Council architecture — `/council`, `/pre-mortem`, `/vibe`, `/post-mortem` with multi-model consensus, prediction tracking. Stage 4 behavioral validation adds holdout scenarios + satisfaction scoring in STEP 1.8. | Live on demand. STEP 1.8 fires automatically inside `/validation` when that skill is invoked. |
+| **Managed Agents Dreaming** (May 2026) — scheduled session review, pattern extraction, memory curation between sessions | `/dream` + `ao overnight` + `cli/cmd/ao/dream_executor.go` + `.github/workflows/nightly.yml` dream-cycle proof job | Live with operator setup. The bounded private overnight lane runs harvest → forge → close-loop → defrag on the cadence and model runtime the operator configures. |
+| **Managed Agents Outcomes** (May 2026) — rubric-driven separate-context grader with iterate-until-pass | Live at three scopes: project — `GOALS.md` (rubric) + `ao goals measure` (each gate runs as separate subprocess; `cli/internal/goals/measure.go:132-164`) + `/evolve` (can iterate a worst-failing gate under operator limits; `skills/evolve/SKILL.md:379-388`); plan — `/pre-mortem` council judges as separate-context graders; code — `/vibe` council judges. Independent 3-judge audit confirmed parity on rubric authoring, separate-context grading, iterate-until-pass, and pinpoint-what-changed. | Live at the capability layer. Empirical workbench A/B (2026-05-06): Δ=+0.0000 across 12 cases at v1 difficulty (both legs 12/12) — task difficulty floor exhausted; v2 substrate (realistic agent tasks where the hook layer differentiates) is roadmap. Counter-stat artifact: `evals/workbench/results/2026-05-06-yjzp9-counterstat.json`. |
 
 Read the convergence table the right way: AgentOps and every harness like it gets absorbed into the model layer over time — Anthropic's 2026-05-06 Managed Agents launch is the textbook example. Memory primitives, learning loops, even validation gates — frontier vendors will ship them natively. What stays yours is the corpus. AgentOps is the bridge tool that helps you build the moat *now*, with current models, before the harness layer commoditizes.
 
@@ -129,7 +129,7 @@ The same substrate, reached three ways:
 
 - **In-harness plugin** — skills for Claude Code, Codex, Cursor, OpenCode, with optional hook adapters for runtimes that want them. Context moves through explicit packets and skill workflows first. Install via `claude plugin install`, `install-codex.sh`, or the skills.sh package.
 - **`ao` CLI** — the terminal and CI control plane. `ao context assemble`, `ao lookup`, `ao compile`, `ao goals measure`, `ao flywheel close-loop` — the same compiler, scriptable. Repo-native, with no required AgentOps cloud control plane.
-- **Scheduling daemon** — off-API, off-vendor. `ao schedule` + `ao daemon` run dream, evolve, compile, defrag, forge, and feedback-drain on whatever cadence you set, against whichever local subscription you already pay for. The always-on lane.
+- **Scheduling daemon** — off-API, off-vendor. `ao schedule` + `ao daemon` can run dream, evolve, compile, defrag, forge, and feedback-drain jobs on the cadence you set, against whichever local subscription you already pay for. Worker execution defaults to `cli-fallback`; the synthetic `fake` policy is explicit test/demo mode.
 
 ### Domain and practice layer
 
@@ -199,7 +199,7 @@ The same model used in the README: bookkeeping records the work, the context com
 - `/forge` — extract structured learnings from completed sessions
 - `ao flywheel close-loop` — score, promote, curate automatically
 <!-- agentops:claim:AOP-CLAIM-PRODUCT-EVOLVE-RECONCILE -->
-- `/evolve` — autonomous reconciliation: reads goals, fixes the worst gap, validates, repeats
+- `/evolve` — bounded reconciliation: reads goals, targets the worst gap, validates, and can repeat under operator limits
 - `/dream` and `ao overnight` — bounded private compounding lane
 - `ao schedule` + `ao daemon` — operator-owned cadence for dream, evolve, compile, defrag, forge, and feedback-drain
 - `.github/workflows/nightly.yml` — public proof harness for the contracts (not your private runtime)
@@ -249,7 +249,7 @@ Full profile: [docs/assurance-profile.md](docs/assurance-profile.md).
 - **Context as a boundary.** Research, planning, implementation, and validation receive different context. Workers get fresh windows. Validators get evidence packets instead of the implementer's accumulated chat.
 - **Bookkeeping by default.** RPI packets, council verdicts, citations, ratchet records, post-mortems, handoffs, and schedule outputs leave file-backed traces that can be inspected, diffed, archived, or excluded from source control.
 - **Policy gates over advice.** Hooks, pre-push checks, security scans, goal fitness gates, and pre-mortems encode process as executable constraints instead of relying on the agent to remember a runbook.
-- **Variable autonomy.** The same factory can run interactive, supervised, scheduled, or unattended loops. High-risk environments can keep humans in the loop for planning, validation, release, and promotion while still using agents for bounded work.
+- **Variable autonomy.** The same factory can run interactive, supervised, or scheduled loops. High-risk environments can keep humans in the loop for planning, validation, release, and promotion while still using agents for bounded work.
 - **Constrained-network fit.** The design favors repo-local state, explicit artifacts, no required cloud control plane, and operator-owned scheduling. Formal deployment into classified, export-controlled, or safety-critical environments still requires the local authority's security controls, model approvals, supply-chain process, and accreditation work.
 
 ## Evidence
@@ -314,7 +314,7 @@ The internal lineage that produced this product, and the parallels we are *not* 
 - **Olympus** was the predecessor runtime. Power-user daemon, run ledger, context compilation, constraint injection. Archived as a live system; its patterns survived as skills inside AgentOps.
 - **AgentOps** (this repository) is the coding-agent implementation. Skills + execution packets + optional hooks + `ao` CLI + scheduling daemon. It applies the context-compounding model to software work.
 <!-- agentops:claim:AOP-CLAIM-PRODUCT-MT-OLYMPUS-PROOF -->
-- **Mt. Olympus** is the forkable Gas City runtime proof — the empirical demonstration that the substrate runs, autonomously, against a real codebase under operator control.
+- **Mt. Olympus** is the forkable Gas City runtime proof — the empirical demonstration that the substrate can run scheduled and supervised loops against a real codebase under operator control.
 
 ### Why Meadows, foregrounded
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Four layers. Each solves a different problem. All four compound.
 | **Bookkeeping** | Agents forget what they tried, why they changed course, and what evidence mattered | `.agents/` captures run packets, handoffs, findings, citations, decisions, verdicts, retros, and post-mortems. *The work leaves a trace.* |
 | **Context Compiler** | Every session starts from zero | `ao context assemble` builds phase-scoped packets. `ao lookup` retrieves decay-ranked knowledge on demand. Skills and execution packets make context explicit; hooks are optional adapters. *Your agent starts loaded, not cold.* |
 | **Validation Gates** | Agents ship confident garbage | `/pre-mortem`, `/vibe`, `/council` — multi-model consensus validates plans before build and code before commit. Gates block, not advise. *Three fresh judges catch what one agent can't.* |
-| **Knowledge Flywheel** | Lessons disappear between sessions | `/forge` extracts learnings from the bookkeeping trail. `ao flywheel close-loop` scores and promotes. `/evolve` fixes the worst gap autonomously. `/dream` compounds overnight. *Session 15 starts with everything session 1 learned.* |
+| **Knowledge Flywheel** | Lessons disappear between sessions | `/forge` extracts learnings from the bookkeeping trail. `ao flywheel close-loop` scores and promotes. `/evolve` can run one bounded reconciliation loop. `/dream` prepares overnight compounding runs. *Session 15 starts with everything session 1 learned.* |
 
 All state lives in local `.agents/` — plain text you can grep, diff, and review. No AgentOps-managed telemetry or hosted control plane. Runtime-neutral across Claude Code, Codex CLI, Cursor, and OpenCode.
 
@@ -295,7 +295,7 @@ ao search "query"                         # Search session history and local kno
 ao lookup --query "topic"                 # Retrieve curated learnings and findings
 ao context assemble                       # Build a task briefing
 ao rpi phased "fix auth startup"          # Run the phased lifecycle from the terminal
-ao evolve --max-cycles 1                  # Run one autonomous improvement cycle
+ao evolve --max-cycles 1                  # Run one bounded improvement cycle
 ao overnight setup                        # Prepare private Dream runs
 ao metrics health                         # Show flywheel health
 ```
@@ -309,13 +309,13 @@ Full reference: [CLI Commands](cli/docs/COMMANDS.md).
 | Surface | When to use it | What it looks like | Operator role |
 |---------|---------------|-------------------|---------------|
 | **Hand agents** (skills surface) | Active work, exploration, high-stakes decisions, ambiguous scope | `/research`, `/plan`, `/pre-mortem`, `/council`, `/rpi` invoked from chat | Driving — agents respond, you steer |
-| **Software factory** (daemon) | Vetted, well-defined work; overnight compounding; bulk processing | `ao schedule` + `ao daemon` running dream / evolve / compile / defrag / forge unattended; mix-and-match councils per phase | Operator — you set cadence and quality bars; the factory runs |
+| **Software factory** (daemon) | Vetted, well-defined work; overnight compounding; bulk processing | `ao schedule` + `ao daemon` running operator-approved dream / evolve / compile / defrag / forge jobs; mix-and-match councils per phase | Operator — you set cadence and quality bars; the factory executes the queue |
 
 **Hand agents** — when you're driving. Skills (`/rpi`, `/council`, `/pre-mortem`, `/vibe`) work in chat. Different rigor levels available — light skills for exploratory work, full RPI loop for everything that should be tracked, council validation before shipping.
 
 <!-- agentops:claim:AOP-CLAIM-README-AUTONOMOUS-FLYWHEEL -->
 
-**Software factory** — when work is vetted and ready. The `ao daemon` runs scheduled jobs against your local subscription on your hardware. Mix and match models per phase: Claude for discovery, Codex for implementation, a fresh Claude for validation, an open-weights local model for overnight defrag. Run Dream overnight, then Evolve in the morning against a fresher corpus.
+**Software factory** — when work is vetted and ready. The `ao daemon` runs scheduled jobs against your local subscription on your hardware. The default worker policy uses real CLI fallback execution; the synthetic fake executor is explicit test/demo mode. Mix and match models per phase: Claude for discovery, Codex for implementation, a fresh Claude for validation, an open-weights local model for overnight defrag. Queue Dream overnight, then run Evolve against a fresher corpus.
 
 → [scheduling reference](docs/scheduling.md) · [example schedules](examples/schedules/).
 

--- a/cli/cmd/ao/agentopsd.go
+++ b/cli/cmd/ao/agentopsd.go
@@ -27,6 +27,12 @@ import (
 
 const daemonActivationRelPath = ".agents/daemon/activation.json"
 
+const (
+	daemonExecutorPolicyFake        = "fake"
+	daemonExecutorPolicyGasCity     = "gascity"
+	daemonExecutorPolicyCLIFallback = "cli-fallback"
+)
+
 var (
 	daemonAddr              string
 	daemonURL               string
@@ -148,7 +154,7 @@ func init() {
 	daemonRunCmd.Flags().StringVar(&daemonTokenFile, "token-file", "", "Path to mutation token file")
 	daemonRunCmd.Flags().IntVar(&daemonWorkers, "workers", 0, "Number of daemon worker loops to run in the foreground")
 	daemonRunCmd.Flags().BoolVar(&daemonWorkerOnce, "worker-once", false, "Exit after each worker makes one claim attempt")
-	daemonRunCmd.Flags().StringVar(&daemonExecutorPolicy, "executor-policy", "fake", "Daemon executor policy for workers (fake, gascity, cli-fallback)")
+	daemonRunCmd.Flags().StringVar(&daemonExecutorPolicy, "executor-policy", daemonExecutorPolicyCLIFallback, "Daemon executor policy for workers (cli-fallback, gascity, fake; fake is explicit test/demo mode)")
 	daemonRunCmd.Flags().DurationVar(&daemonWorkerTimeout, "worker-timeout", 0, "Per-job worker wall-clock cap (0 disables)")
 	daemonRunCmd.Flags().Int64Var(&daemonWorkerMemoryMax, "worker-memory-max-bytes", 0, "Linux cgroup v2 memory.max cap for CLI fallback workers in bytes (0 disables)")
 	daemonRunCmd.Flags().StringVar(&daemonWorkerCgroupRoot, "worker-cgroup-root", "", "Linux cgroup v2 root for worker caps (default /sys/fs/cgroup)")
@@ -264,6 +270,9 @@ func serveAgentOpsDaemon(ctx context.Context, cwd string, opts agentopsDaemonRun
 	}
 	defer func() { _ = listener.Close() }()
 	fmt.Fprintf(out, "agentopsd ready: %s\n", activation.URL)
+	if opts.Workers > 0 && effectiveAgentOpsDaemonExecutorPolicy(opts.ExecutorPolicy) == daemonExecutorPolicyFake {
+		fmt.Fprintln(out, "agentopsd warning: --executor-policy=fake is deterministic test/demo mode and emits synthetic completion artifacts.")
+	}
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- server.Serve(listener)
@@ -392,14 +401,11 @@ func firstAgentOpsDaemonError(errs ...error) error {
 }
 
 func buildAgentOpsDaemonSupervisor(cwd string, opts agentopsDaemonRunOptions) (*daemonpkg.Supervisor, error) {
-	policy := opts.ExecutorPolicy
-	if policy == "" {
-		policy = "fake"
-	}
+	policy := effectiveAgentOpsDaemonExecutorPolicy(opts.ExecutorPolicy)
 	llmwikiExecutor := buildAgentOpsDaemonLLMWikiExecutor()
 	var executors []daemonpkg.JobExecutor
 	switch policy {
-	case "fake":
+	case daemonExecutorPolicyFake:
 		wikiExecutor, err := buildAgentOpsDaemonFakeWikiExecutor(cwd)
 		if err != nil {
 			return nil, err
@@ -413,7 +419,7 @@ func buildAgentOpsDaemonSupervisor(cwd string, opts agentopsDaemonRunOptions) (*
 			return nil, err
 		}
 		executors = []daemonpkg.JobExecutor{daemonFakeOpenClawSnapshotExecutor{}, wikiExecutor, dreamExecutor, rpiExecutor, llmwikiExecutor}
-	case "gascity":
+	case daemonExecutorPolicyGasCity:
 		wikiExecutor, err := buildAgentOpsDaemonGasCityWikiExecutor(cwd, opts)
 		if err != nil {
 			return nil, err
@@ -427,7 +433,7 @@ func buildAgentOpsDaemonSupervisor(cwd string, opts agentopsDaemonRunOptions) (*
 			return nil, err
 		}
 		executors = []daemonpkg.JobExecutor{wikiExecutor, dreamExecutor, rpiExecutor, llmwikiExecutor}
-	case "cli-fallback":
+	case daemonExecutorPolicyCLIFallback:
 		wikiExecutor, err := buildAgentOpsDaemonCLIFallbackWikiExecutor(cwd, opts)
 		if err != nil {
 			return nil, err
@@ -457,7 +463,7 @@ func buildAgentOpsDaemonSupervisor(cwd string, opts agentopsDaemonRunOptions) (*
 	// dbBdSource lazy-init: nil here means tests don't open a Dolt connection;
 	// production callers can call NewDbBdSource and re-register. atom-2 ships
 	// with executors that need bd connectivity gated by opts.PlansBdSource.
-	if policy == "fake" || policy == "gascity" {
+	if policy == daemonExecutorPolicyFake || policy == daemonExecutorPolicyGasCity {
 		if opts.PlansBdSource != nil {
 			plansExec, err := daemonpkg.NewPlansProjectionExecutor(daemonpkg.PlansProjectionExecutorOptions{
 				Store:    daemonpkg.NewStore(cwd),
@@ -484,12 +490,20 @@ func buildAgentOpsDaemonSupervisor(cwd string, opts agentopsDaemonRunOptions) (*
 	})
 }
 
+func effectiveAgentOpsDaemonExecutorPolicy(policy string) string {
+	policy = strings.TrimSpace(policy)
+	if policy == "" {
+		return daemonExecutorPolicyCLIFallback
+	}
+	return policy
+}
+
 // buildAgentOpsDaemonLLMWikiExecutor wires the Karpathy llmwiki loop executor
 // with its four stage handlers. The PROMOTE stage's HarvestPromoter is the
 // adapter in llmwiki_adapter.go that bridges to the harvest package's
-// catalog-based API. Registered under all three policies (fake/gascity/cli-fallback)
-// because the stages are deterministic and policy-agnostic — actual LLM
-// extraction is stubbed inside the stage handlers and lands in a follow-up.
+// catalog-based API. Registered under all three policies
+// (fake/gascity/cli-fallback) so schedules keep resolving, but placeholder
+// stage outputs are skipped unless the job payload explicitly opts in.
 func buildAgentOpsDaemonLLMWikiExecutor() daemonpkg.JobExecutor {
 	return &llmwiki.LLMWikiLoopExecutor{
 		Ingest:  &llmwiki.IngestStage{},
@@ -504,7 +518,7 @@ func buildAgentOpsDaemonFactoryExecutor(cwd, policy string, opts agentopsDaemonR
 		Store:            daemonpkg.NewStore(cwd),
 		Root:             cwd,
 		Clock:            opts.Now,
-		EnableRPIHandoff: policy == "fake" || policy == "gascity" || policy == "cli-fallback",
+		EnableRPIHandoff: policy == daemonExecutorPolicyFake || policy == daemonExecutorPolicyGasCity || policy == daemonExecutorPolicyCLIFallback,
 	})
 }
 

--- a/cli/cmd/ao/agentopsd_test.go
+++ b/cli/cmd/ao/agentopsd_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/boshu2/agentops/cli/internal/agentworker"
 	daemonpkg "github.com/boshu2/agentops/cli/internal/daemon"
+	"github.com/boshu2/agentops/cli/internal/llmwiki"
 	"github.com/boshu2/agentops/cli/internal/wikiworker"
 	"github.com/spf13/cobra"
 )
@@ -674,6 +675,56 @@ func TestAgentOpsDaemonCLIFallbackExecutorPolicyBuilds(t *testing.T) {
 	}
 }
 
+func TestAgentOpsDaemonDefaultExecutorPolicyCompletesRPIRunViaCLIFallback(t *testing.T) {
+	cwd := t.TempDir()
+	queue := daemonpkg.NewQueue(daemonpkg.NewStore(cwd), daemonpkg.QueueOptions{LeaseDuration: time.Minute})
+	spec := daemonpkg.NewRPIRunJobSpec("run-daemon-default", "validate daemon default rpi run")
+	jobSpec, err := spec.ToJobSpec("job-rpi-default")
+	if err != nil {
+		t.Fatalf("rpi run job spec: %v", err)
+	}
+	if _, err := queue.SubmitJob(daemonpkg.SubmitJobInput{
+		RequestID: "req-rpi-default",
+		JobID:     jobSpec.ID,
+		JobType:   jobSpec.Type,
+		Payload:   jobSpec.Payload,
+	}, daemonpkg.QueueMutationOptions{}); err != nil {
+		t.Fatalf("submit rpi run job: %v", err)
+	}
+
+	var runnerCalls int
+	fakeRun := func(_ context.Context, req daemonpkg.RPIRunRequest) (daemonpkg.RPIRunResult, error) {
+		runnerCalls++
+		if req.Spec.RunID != "run-daemon-default" {
+			t.Errorf("runner run_id = %q, want run-daemon-default", req.Spec.RunID)
+		}
+		return daemonpkg.RPIRunResult{Artifacts: map[string]string{"runner_marker": "default-cli-fallback"}}, nil
+	}
+
+	supervisor, err := buildAgentOpsDaemonSupervisor(cwd, agentopsDaemonRunOptions{
+		CLIFallbackRPIRunFunc: fakeRun,
+	})
+	if err != nil {
+		t.Fatalf("build supervisor: %v", err)
+	}
+	result, err := supervisor.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("run once: %v", err)
+	}
+	if !result.Claimed || result.Job.Status != daemonpkg.JobStatusCompleted {
+		t.Fatalf("result = %#v, want completed rpi.run job", result)
+	}
+	if runnerCalls != 1 {
+		t.Fatalf("runner called %d times, want 1", runnerCalls)
+	}
+	if got := result.Job.Artifacts["executor_policy"]; got != "in-process" {
+		t.Fatalf("executor_policy artifact = %q, want in-process (default must not be fake)", got)
+	}
+	if got := result.Job.Artifacts["runner_marker"]; got != "default-cli-fallback" {
+		t.Fatalf("runner_marker = %q, want default-cli-fallback", got)
+	}
+}
+
 func TestAgentOpsDaemonCLIFallbackExecutorPolicyCompletesRPIRunJob(t *testing.T) {
 	cwd := t.TempDir()
 	queue := daemonpkg.NewQueue(daemonpkg.NewStore(cwd), daemonpkg.QueueOptions{LeaseDuration: time.Minute})
@@ -935,6 +986,9 @@ func TestAgentOpsDaemonWorkerFlagsRegistered(t *testing.T) {
 			t.Fatalf("daemon run missing --%s flag", flag)
 		}
 	}
+	if got := daemonRunCmd.Flags().Lookup("executor-policy").DefValue; got != daemonExecutorPolicyCLIFallback {
+		t.Fatalf("--executor-policy default = %q, want %q", got, daemonExecutorPolicyCLIFallback)
+	}
 }
 
 type recordingWikiForgeWorker struct {
@@ -1059,6 +1113,12 @@ func TestAgentopsdRegistersLLMWikiLoopExecutor(t *testing.T) {
 			}
 			if got := result.Job.Artifacts["stage"]; got != "lint" {
 				t.Fatalf("stage artifact = %q, want lint", got)
+			}
+			if got := result.Job.Artifacts["skipped"]; got != "true" {
+				t.Fatalf("skipped artifact = %q, want true while placeholder stages are gated", got)
+			}
+			if got := result.Job.Artifacts["skip_reason"]; got != llmwiki.SkipReasonPlaceholderOutputDisabled {
+				t.Fatalf("skip_reason = %q, want %q", got, llmwiki.SkipReasonPlaceholderOutputDisabled)
 			}
 		})
 	}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -1455,7 +1455,7 @@ ao daemon run [flags]
 
 ```
       --addr string                   Loopback address for foreground daemon (default "127.0.0.1:8765")
-      --executor-policy string        Daemon executor policy for workers (fake, gascity, cli-fallback) (default "fake")
+      --executor-policy string        Daemon executor policy for workers (cli-fallback, gascity, fake; fake is explicit test/demo mode) (default "cli-fallback")
       --gascity-city string           GasCity city name for gascity executor policy
       --gascity-endpoint string       GasCity API endpoint for gascity executor policy
       --gascity-token string          GasCity mutation token for gascity executor policy

--- a/cli/internal/daemon/plans_executor.go
+++ b/cli/internal/daemon/plans_executor.go
@@ -89,7 +89,8 @@ func (e *PlansProjectionExecutor) RunJob(ctx context.Context, claim QueueLease) 
 	if err := ctx.Err(); err != nil {
 		return JobExecutionResult{}, err
 	}
-	rebuiltAt := e.now().UTC().Format(time.RFC3339Nano)
+	now := e.now().UTC()
+	rebuiltAt := now.Format(time.RFC3339Nano)
 	projection := DaemonPlansProjection{
 		SchemaVersion: DaemonPlansProjectionSchemaVersion,
 		ProjectID:     spec.ProjectID,
@@ -104,11 +105,22 @@ func (e *PlansProjectionExecutor) RunJob(ctx context.Context, claim QueueLease) 
 	if err != nil {
 		return JobExecutionResult{}, err
 	}
+	set, err := e.store.RebuildProjections(ProjectionRebuildOptions{RebuiltAt: now})
+	if err != nil {
+		return JobExecutionResult{}, fmt.Errorf("plans.projection projection snapshot rebuild: %w", err)
+	}
+	projection.LastEventID = set.LastEventID
+	applyDaemonPlansProjectionToSet(&set, projection, snapshotPath)
+	projectionSnapshotPath, err := e.store.WriteProjectionSnapshot(set)
+	if err != nil {
+		return JobExecutionResult{}, fmt.Errorf("plans.projection projection snapshot write: %w", err)
+	}
 	artifacts := map[string]string{
-		"manifest_jsonl": snapshotPath,
-		"manifest_count": strconv.Itoa(len(projection.Entries)),
-		"rebuilt_at":     rebuiltAt,
-		"trigger":        string(spec.RefreshTrigger),
+		"manifest_jsonl":      snapshotPath,
+		"manifest_count":      strconv.Itoa(len(projection.Entries)),
+		"projection_snapshot": projectionSnapshotPath,
+		"rebuilt_at":          rebuiltAt,
+		"trigger":             string(spec.RefreshTrigger),
 	}
 	return JobExecutionResult{Artifacts: artifacts}, nil
 }

--- a/cli/internal/daemon/plans_executor_test.go
+++ b/cli/internal/daemon/plans_executor_test.go
@@ -164,6 +164,21 @@ func assertPlansProjectionExecutorPopulatedState(t *testing.T, clock func() time
 	}
 	readBack := loadManifestEntries(t, result.Artifacts["manifest_jsonl"])
 	assertPlansProjectionEntriesSorted(t, readBack, []string{"soc-aaa", "soc-mmm", "soc-zzz"})
+	snapshotPath := result.Artifacts["projection_snapshot"]
+	if snapshotPath == "" {
+		t.Fatalf("projection_snapshot artifact missing: %#v", result.Artifacts)
+	}
+	if _, err := os.Stat(snapshotPath); err != nil {
+		t.Fatalf("projection snapshot stat: %v", err)
+	}
+	snapshot, latestPath, err := NewStore(dir).LoadLatestProjectionSnapshot()
+	if err != nil {
+		t.Fatalf("load latest projection snapshot: %v", err)
+	}
+	if latestPath != snapshotPath {
+		t.Fatalf("latest projection snapshot = %q, want artifact path %q", latestPath, snapshotPath)
+	}
+	assertPlansProjectionEntriesSorted(t, snapshot.Plans.Entries, []string{"soc-aaa", "soc-mmm", "soc-zzz"})
 }
 
 func assertPlansProjectionExecutorTransientFailure(t *testing.T, clock func() time.Time) {

--- a/cli/internal/daemon/plans_projection.go
+++ b/cli/internal/daemon/plans_projection.go
@@ -44,10 +44,7 @@ type DaemonPlansProjection struct {
 // events because plans.projection is a pull-from-bd projection, not an
 // event-sourced one — the source of truth is bd, not the daemon ledger.
 func RebuildDaemonPlansProjection(events []LedgerEvent) (DaemonPlansProjection, error) {
-	projection := DaemonPlansProjection{
-		SchemaVersion: DaemonPlansProjectionSchemaVersion,
-		Entries:       []PlansProjectionEntry{},
-	}
+	projection := emptyDaemonPlansProjection("")
 	for _, event := range events {
 		if err := ValidateLedgerEvent(event); err != nil {
 			return DaemonPlansProjection{}, err
@@ -55,6 +52,47 @@ func RebuildDaemonPlansProjection(events []LedgerEvent) (DaemonPlansProjection, 
 		projection.LastEventID = event.EventID
 	}
 	return projection, nil
+}
+
+func emptyDaemonPlansProjection(rebuiltAt string) DaemonPlansProjection {
+	return DaemonPlansProjection{
+		SchemaVersion: DaemonPlansProjectionSchemaVersion,
+		Entries:       []PlansProjectionEntry{},
+		RebuiltAt:     rebuiltAt,
+	}
+}
+
+func cloneDaemonPlansProjection(in DaemonPlansProjection) DaemonPlansProjection {
+	if in.SchemaVersion == 0 {
+		return emptyDaemonPlansProjection("")
+	}
+	out := in
+	out.Entries = append([]PlansProjectionEntry{}, in.Entries...)
+	if out.Entries == nil {
+		out.Entries = []PlansProjectionEntry{}
+	}
+	sort.Slice(out.Entries, func(i, j int) bool { return out.Entries[i].BeadsID < out.Entries[j].BeadsID })
+	return out
+}
+
+func applyDaemonPlansProjectionToSet(set *ProjectionSet, projection DaemonPlansProjection, manifestPath string) {
+	set.Plans = cloneDaemonPlansProjection(projection)
+	if set.Plans.LastEventID == "" {
+		set.Plans.LastEventID = set.LastEventID
+	}
+	manifest, ok := set.Manifests[ProjectionPlansManifest]
+	if !ok {
+		return
+	}
+	manifest.Status = ProjectionStatusCurrent
+	manifest.LastEventID = set.LastEventID
+	if projection.RebuiltAt != "" {
+		manifest.RebuiltAt = projection.RebuiltAt
+	}
+	if manifestPath != "" {
+		manifest.OutputPaths = []string{manifestPath}
+	}
+	set.Manifests[ProjectionPlansManifest] = manifest
 }
 
 // WriteDaemonPlansProjection writes the plans manifest snapshot atomically:

--- a/cli/internal/daemon/projections.go
+++ b/cli/internal/daemon/projections.go
@@ -447,6 +447,7 @@ func RebuildProjections(events []LedgerEvent, opts ProjectionRebuildOptions) (Pr
 			RebuiltAt:     rebuiltAt,
 			SourceLedger:  opts.SourceLedger,
 			Manifests:     defaultProjectionManifests(opts.SourceLedger, rebuiltAt),
+			Plans:         emptyDaemonPlansProjection(rebuiltAt),
 		}
 		jobsByID = map[string]*JobProjection{}
 		_, err = applyEventsToState(events, &set, jobsByID, &jobOrder)
@@ -458,6 +459,7 @@ func RebuildProjections(events []LedgerEvent, opts ProjectionRebuildOptions) (Pr
 	collectJobsIntoSet(jobsByID, jobOrder, &set)
 	finalizeFactoryProjection(&set)
 	finalizeManifests(&set)
+	finalizePlansProjection(&set)
 	finalizeOpenClawSnapshot(&set, opts.SourceLedger, rebuiltAt)
 	set.Schedules = ScheduleStateFromEvents(events)
 	return set, nil
@@ -493,6 +495,7 @@ func initStateFromSnapshot(snapshot ProjectionSet, sourceLedger, rebuiltAt strin
 		SourceLedger:  sourceLedger,
 		LastEventID:   snapshot.LastEventID,
 		Manifests:     defaultProjectionManifests(sourceLedger, rebuiltAt),
+		Plans:         cloneDaemonPlansProjection(snapshot.Plans),
 		Factory:       cloneFactoryProjection(snapshot.Factory),
 	}
 	jobsByID := make(map[string]*JobProjection, len(snapshot.Jobs))
@@ -725,6 +728,19 @@ func finalizeManifests(set *ProjectionSet) {
 	for name, manifest := range set.Manifests {
 		manifest.LastEventID = set.LastEventID
 		set.Manifests[name] = manifest
+	}
+}
+
+func finalizePlansProjection(set *ProjectionSet) {
+	if set.Plans.SchemaVersion == 0 {
+		set.Plans.SchemaVersion = DaemonPlansProjectionSchemaVersion
+	}
+	if set.Plans.Entries == nil {
+		set.Plans.Entries = []PlansProjectionEntry{}
+	}
+	set.Plans.LastEventID = set.LastEventID
+	if set.Plans.RebuiltAt == "" {
+		set.Plans.RebuiltAt = set.RebuiltAt
 	}
 }
 
@@ -2030,6 +2046,7 @@ func allProjectionNames() []ProjectionName {
 		ProjectionOpenClaw,
 		ProjectionDaemonStatus,
 		ProjectionDaemonJobStatus,
+		ProjectionPlansManifest,
 	}
 }
 
@@ -2047,6 +2064,8 @@ func defaultProjectionOutputPaths(name ProjectionName) []string {
 		return []string{".agents/daemon/projections/status.json"}
 	case ProjectionDaemonJobStatus:
 		return []string{".agents/daemon/projections/jobs.json"}
+	case ProjectionPlansManifest:
+		return []string{".agents/plans/*/manifest.jsonl"}
 	default:
 		return nil
 	}

--- a/cli/internal/daemon/server.go
+++ b/cli/internal/daemon/server.go
@@ -260,13 +260,12 @@ func (s *ReadOnlyServer) handlePlansManifest(w http.ResponseWriter, r *http.Requ
 	if !requireMethod(w, r, http.MethodGet) {
 		return
 	}
-	// atom-1 stub: the Plans field on ProjectionSet is added in atom-2. Until
-	// then, return an empty manifest envelope so callers can wire against the
-	// shape without depending on the executor.
-	writeJSON(w, http.StatusOK, map[string]any{
-		"schema_version": ProjectionSchemaVersion,
-		"entries":        []any{},
-	})
+	state, err := s.readState()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, state.Projections.Plans)
 }
 
 func (s *ReadOnlyServer) handlePlansDiff(w http.ResponseWriter, r *http.Request) {

--- a/cli/internal/daemon/server_test.go
+++ b/cli/internal/daemon/server_test.go
@@ -574,17 +574,42 @@ func TestDaemonRouter_PlansRoutes(t *testing.T) {
 	store := NewStore(t.TempDir())
 	router := NewDaemonRouter(store, ServerOptions{Now: func() time.Time { return now }})
 
-	var manifest map[string]any
+	var manifest DaemonPlansProjection
 	getJSON(t, router, "/v1/plans/manifest", &manifest)
-	entries, ok := manifest["entries"].([]any)
-	if !ok {
-		t.Fatalf("manifest entries field type = %T, want []any (atom-1 stub envelope)", manifest["entries"])
+	if manifest.SchemaVersion != DaemonPlansProjectionSchemaVersion {
+		t.Fatalf("schema_version = %d, want %d", manifest.SchemaVersion, DaemonPlansProjectionSchemaVersion)
 	}
-	if len(entries) != 0 {
-		t.Fatalf("manifest entries len = %d, want 0 (atom-1 stub returns empty until atom-2)", len(entries))
+	if len(manifest.Entries) != 0 {
+		t.Fatalf("manifest entries len = %d, want 0", len(manifest.Entries))
 	}
-	if _, ok := manifest["schema_version"]; !ok {
-		t.Fatalf("manifest missing schema_version key: %#v", manifest)
+
+	set := ProjectionSet{
+		SchemaVersion: ProjectionSchemaVersion,
+		RebuiltAt:     now.Format(time.RFC3339Nano),
+		LastEventID:   "evt-plans-snapshot",
+		Manifests:     defaultProjectionManifests(store.LedgerPath(), now.Format(time.RFC3339Nano)),
+		Plans: DaemonPlansProjection{
+			SchemaVersion: DaemonPlansProjectionSchemaVersion,
+			LastEventID:   "evt-plans-snapshot",
+			ProjectID:     "proj-1",
+			IssuePrefix:   "soc",
+			Entries: []PlansProjectionEntry{{
+				BeadsID:   "soc-plan-1",
+				Title:     "Populated plan",
+				Status:    "open",
+				IssueType: "epic",
+				UpdatedAt: now,
+			}},
+			RebuiltAt: now.Format(time.RFC3339Nano),
+		},
+	}
+	if _, err := store.WriteProjectionSnapshot(set); err != nil {
+		t.Fatalf("write projection snapshot: %v", err)
+	}
+	var populated DaemonPlansProjection
+	getJSON(t, router, "/v1/plans/manifest", &populated)
+	if len(populated.Entries) != 1 || populated.Entries[0].BeadsID != "soc-plan-1" {
+		t.Fatalf("populated entries = %#v, want soc-plan-1 from projection snapshot", populated.Entries)
 	}
 
 	var diff map[string]any

--- a/cli/internal/llmwiki/executor.go
+++ b/cli/internal/llmwiki/executor.go
@@ -22,6 +22,8 @@ const (
 	StagePromote Stage = "promote"
 )
 
+const SkipReasonPlaceholderOutputDisabled = "placeholder-output-disabled"
+
 // DefaultLintIntervalHours is the default interval between LINT runs when the
 // LoopJobSpec does not specify one. Karpathy's pattern runs lint roughly daily.
 const DefaultLintIntervalHours = 24
@@ -35,6 +37,10 @@ type LoopJobSpec struct {
 	Stages []Stage `json:"stages,omitempty"`
 	// LintIntervalHours controls when LINT becomes eligible. 0 → use default.
 	LintIntervalHours int `json:"lint_interval_hours,omitempty"`
+	// AllowPlaceholderOutputs is an explicit test/experimental opt-in for the
+	// current stubbed stage bodies. Production schedules should leave this
+	// false until the real extraction/query/lint implementations replace them.
+	AllowPlaceholderOutputs bool `json:"allow_placeholder_outputs,omitempty"`
 }
 
 // StageHandler executes a single stage against a vault. Implementations MUST be
@@ -122,6 +128,15 @@ func (e *LLMWikiLoopExecutor) RunJob(ctx context.Context, claim daemon.QueueLeas
 		}
 		return execResult(result), nil
 	}
+	if placeholderStageRequiresOptIn(stage) && !spec.AllowPlaceholderOutputs {
+		result := StageResult{
+			Stage:      stage,
+			Attempt:    attempt,
+			Skipped:    true,
+			SkipReason: SkipReasonPlaceholderOutputDisabled,
+		}
+		return execResult(result), nil
+	}
 
 	result, err := handler.Run(ctx, spec.Vault, attempt)
 	if err != nil {
@@ -185,6 +200,15 @@ func (e *LLMWikiLoopExecutor) now() time.Time {
 func isKnownStage(s Stage) bool {
 	switch s {
 	case StageIngest, StageQuery, StageLint, StagePromote:
+		return true
+	default:
+		return false
+	}
+}
+
+func placeholderStageRequiresOptIn(stage Stage) bool {
+	switch stage {
+	case StageIngest, StageQuery, StageLint:
 		return true
 	default:
 		return false

--- a/cli/internal/llmwiki/executor_test.go
+++ b/cli/internal/llmwiki/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -124,7 +125,7 @@ func TestLLMWikiLoopExecutor_AttemptCounterPropagates(t *testing.T) {
 	h := &fakeHandler{stage: StageIngest}
 	exec := &LLMWikiLoopExecutor{Ingest: h}
 
-	payload := map[string]any{"vault": vault}
+	payload := map[string]any{"vault": vault, "allow_placeholder_outputs": true}
 	if _, err := exec.RunJob(context.Background(), mkClaim(daemon.JobTypeLLMWikiLoop, payload, 1)); err != nil {
 		t.Fatalf("RunJob attempt 1: %v", err)
 	}
@@ -169,6 +170,70 @@ func TestLLMWikiLoopExecutor_NilHandlerSkipsCleanly(t *testing.T) {
 	}
 }
 
+func TestLLMWikiLoopExecutor_DisablesPlaceholderStagesByDefault(t *testing.T) {
+	vault := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(vault, "raw"), 0o755); err != nil {
+		t.Fatalf("mkdir raw: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(vault, "wiki"), 0o755); err != nil {
+		t.Fatalf("mkdir wiki: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(vault, "raw", "source.md"), []byte("raw"), 0o644); err != nil {
+		t.Fatalf("seed raw: %v", err)
+	}
+	exec := &LLMWikiLoopExecutor{Ingest: &IngestStage{}}
+
+	res, err := exec.RunJob(context.Background(), mkClaim(daemon.JobTypeLLMWikiLoop, map[string]any{"vault": vault}, 1))
+	if err != nil {
+		t.Fatalf("RunJob: %v", err)
+	}
+	if res.Artifacts["skipped"] != "true" {
+		t.Fatalf("artifacts[skipped] = %q, want true", res.Artifacts["skipped"])
+	}
+	if res.Artifacts["skip_reason"] != SkipReasonPlaceholderOutputDisabled {
+		t.Fatalf("skip_reason = %q, want %q", res.Artifacts["skip_reason"], SkipReasonPlaceholderOutputDisabled)
+	}
+	if _, ok := res.Artifacts["artifact_0"]; ok {
+		t.Fatalf("placeholder-disabled run should not emit artifacts: %#v", res.Artifacts)
+	}
+	if _, err := os.Stat(filepath.Join(vault, "wiki", "sources", "source-md.md")); !os.IsNotExist(err) {
+		t.Fatalf("placeholder-disabled run created source artifact, stat err=%v", err)
+	}
+}
+
+func TestLLMWikiLoopExecutor_AllowsPlaceholderStagesWithExplicitOptIn(t *testing.T) {
+	vault := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(vault, "raw"), 0o755); err != nil {
+		t.Fatalf("mkdir raw: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(vault, "wiki"), 0o755); err != nil {
+		t.Fatalf("mkdir wiki: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(vault, "raw", "source.md"), []byte("raw"), 0o644); err != nil {
+		t.Fatalf("seed raw: %v", err)
+	}
+	exec := &LLMWikiLoopExecutor{Ingest: &IngestStage{}}
+
+	res, err := exec.RunJob(context.Background(), mkClaim(daemon.JobTypeLLMWikiLoop, map[string]any{
+		"vault":                     vault,
+		"allow_placeholder_outputs": true,
+	}, 1))
+	if err != nil {
+		t.Fatalf("RunJob: %v", err)
+	}
+	artifact := res.Artifacts["artifact_0"]
+	if artifact == "" {
+		t.Fatalf("artifact_0 missing from opt-in run: %#v", res.Artifacts)
+	}
+	data, err := os.ReadFile(artifact)
+	if err != nil {
+		t.Fatalf("read artifact: %v", err)
+	}
+	if !strings.Contains(string(data), "Distilled placeholder") {
+		t.Fatalf("artifact body did not contain expected placeholder marker:\n%s", data)
+	}
+}
+
 func TestLLMWikiLoopExecutor_StageWhitelistRespected(t *testing.T) {
 	// Vault state would prefer Ingest (raw/ has new content), but the spec
 	// pins Stages=[Lint] — executor must run Lint, not Ingest.
@@ -188,8 +253,9 @@ func TestLLMWikiLoopExecutor_StageWhitelistRespected(t *testing.T) {
 	exec := &LLMWikiLoopExecutor{Ingest: ingest, Lint: lint}
 
 	payload := map[string]any{
-		"vault":  vault,
-		"stages": []string{"lint"},
+		"vault":                     vault,
+		"stages":                    []string{"lint"},
+		"allow_placeholder_outputs": true,
 	}
 	if _, err := exec.RunJob(context.Background(), mkClaim(daemon.JobTypeLLMWikiLoop, payload, 1)); err != nil {
 		t.Fatalf("RunJob: %v", err)
@@ -247,7 +313,11 @@ func TestLLMWikiLoopExecutor_NowInjectable(t *testing.T) {
 	frozen := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC) // 96h later
 	lint := &fakeHandler{stage: StageLint}
 	exec := &LLMWikiLoopExecutor{Lint: lint, Now: func() time.Time { return frozen }}
-	if _, err := exec.RunJob(context.Background(), mkClaim(daemon.JobTypeLLMWikiLoop, map[string]any{"vault": vault, "lint_interval_hours": 24}, 1)); err != nil {
+	if _, err := exec.RunJob(context.Background(), mkClaim(daemon.JobTypeLLMWikiLoop, map[string]any{
+		"vault":                     vault,
+		"lint_interval_hours":       24,
+		"allow_placeholder_outputs": true,
+	}, 1)); err != nil {
 		t.Fatalf("RunJob: %v", err)
 	}
 	if got := atomic.LoadInt32(&lint.calls); got != 1 {

--- a/docs/code-map/agentopsd-codebase-map.md
+++ b/docs/code-map/agentopsd-codebase-map.md
@@ -1,27 +1,22 @@
 ---
-id: code-map-agentopsd-2026-04-29
+id: code-map-agentopsd-2026-05-20
 type: code-map
-date: 2026-04-29
-status: initial — to be expanded as agentopsd CLI surface stabilizes (post-Wave 4-5)
+date: 2026-05-20
+status: current navigation aid
 ---
 
 # agentopsd Codebase Map
 
-> **Status:** Initial draft, modeled on `olympus/docs/code-map/olympus-codebase-map.md`.
-> Many sections are placeholders; populate as the agentopsd extraction stabilizes
-> (post-Wave 4 / Wave 5 of the `agentops-tqc` epic). The current binary name is
-> still `ao` — the rename to `agentopsd` lands later in the epic.
->
 > **Primary goal:** Help operators and contributors find the right subsystem quickly.
-> **Canonical architecture contract:** TODO — there is no `docs/specs/index.md` yet
-> for agentopsd. See `docs/ARCHITECTURE.md`, `docs/agentops-system-map.md`,
-> `docs/cli-surface.md`, and `docs/HOOKS.md` until the spec set lands.
+> **Canonical architecture contracts:** Start with `docs/ARCHITECTURE.md`,
+> `docs/agentops-system-map.md`, `docs/contracts/agentops-daemon.md`,
+> `docs/contracts/agentopsd-control-plane.md`, and `docs/contracts/context-map.md`.
 
 ## At A Glance
 
 agentopsd is a CLI-first knowledge-flywheel daemon extracted from the legacy
-AgentOps tree. The `ao` binary (planned rename: `agentopsd`) drives the RPI
-lifecycle (Research → Plan → Implement), runs overnight curation/Dream cycles,
+AgentOps tree. The `ao` binary drives the RPI lifecycle
+(Research → Plan → Implement), runs overnight curation/Dream cycles,
 serves a local daemon for hooks and job execution, and harvests learnings
 into the `.agents/` flywheel.
 
@@ -54,7 +49,7 @@ Module path: `github.com/boshu2/agentops/cli` (Go 1.26).
 
 ## Runtime Control Flow
 
-> TODO — flesh out once Wave 4-5 stabilizes the entrypoints. Today the typical paths are:
+Typical operator paths:
 
 1. `ao rpi <phase>` — execute one RPI phase (research/plan/implement/etc.); state under `.agents/rpi/`.
 2. `ao overnight run` — full overnight cycle (close-loop → defrag → metrics → retrieval-bench → knowledge brief → Dream Council → runner passes → synthesis → morning packet → bead sync). Driven by `cli/internal/overnight/`.
@@ -67,8 +62,8 @@ Module path: `github.com/boshu2/agentops/cli` (Go 1.26).
 | Entrypoint | Why you start here |
 |-----------|--------------------|
 | `cli/cmd/ao/main.go` | CLI process entry — calls `Execute()` |
-| `cli/cmd/ao/app.go` | Cobra root command and global flag wiring (TODO: confirm split with `agentopsd.go`) |
-| `cli/cmd/ao/agentopsd.go` | Future-binary command surface (precursor to the `agentopsd` rename) |
+| `cli/cmd/ao/root.go` | Cobra root command, command groups, and version wiring |
+| `cli/cmd/ao/agentopsd.go` | AgentOps daemon/control-plane command surface |
 | `cli/cmd/ao/daemon_jobs.go` | Daemon job dispatch from the CLI side |
 | `cli/internal/rpi/` (multiple) | RPI phase executors, cleanup, registry — wired into `cli/cmd/ao/rpi*.go` |
 | `cli/internal/overnight/` (multiple) | Overnight engine — wired into `cli/cmd/ao/overnight*.go` |
@@ -93,9 +88,9 @@ Top packages by file count (non-test source under `cli/internal/`):
 | `cli/internal/llm` | 10 | 2,079 | LLM client abstraction, chunker, forge tier-1 extraction. |
 | `cli/internal/eval` | 9 | 3,002 | Eval engine: baseline/compare, coverage, runtime, scorecard. |
 | `cli/internal/quality` | 8 | 2,358 | Repo-quality doctor: golden metrics, health/ops metrics, codex-skills lint, stale-refs. |
-| `cli/internal/gascity` | 6 | 1,581 | TODO — placeholder summary; gascity is the energy/budget accounting subsystem. |
+| `cli/internal/gascity` | 6 | 1,581 | GasCity remote-compute integration types, compatibility checks, and adapter budget/accounting support. |
 | `cli/internal/storage` | 6 | 1,224 | Filesystem helpers: locked file IO, search index. |
-| `cli/internal/agentworker`, `wikiworker`, `bridge`, `openclaw`, `knowledge`, `formatter`, `types`, … | 3-4 each | 0.4-1.5k each | Smaller leaf packages — TODO: per-package summaries. |
+| `cli/internal/agentworker`, `wikiworker`, `bridge`, `openclaw`, `knowledge`, `formatter`, `types`, … | 3-4 each | 0.4-1.5k each | Focused adapters and leaf libraries for worker sessions, wiki/OpenClaw integration, knowledge parsing, formatting, and shared structs. |
 
 ### Top 3 packages — detail
 
@@ -107,17 +102,17 @@ Top packages by file count (non-test source under `cli/internal/`):
   - `ProcessInfo` — parsed process metadata from `ps`-style introspection (used by cancel/cleanup).
   - `StaleRunEntry` — describes a stale RPI run discovered during cleanup scanning.
 - **Imports from internal:** `cli/internal/types` only — `rpi` is intentionally near the bottom of the dependency graph.
-- **Imported by:** `cli/internal/daemon` (rpi_runner, rpi_registry, reconcile), `cli/internal/eval` (runtime), `cli/internal/overnight` (runner passes). Heaviest re-user is `cli/cmd/ao/rpi*.go`.
+- **Used by:** `cli/internal/daemon` (rpi_runner, rpi_registry, reconcile), `cli/internal/eval` (runtime), `cli/internal/overnight` (runner passes). Heaviest re-user is `cli/cmd/ao/rpi*.go`.
 
 #### `cli/internal/overnight/` (24 files, 7,151 LOC)
 
 - **Purpose:** Drives the nightly curator/Dream pipeline: checkpoints (with Darwin `clonefile` fast path + cross-platform fallback), ingest, REDUCE/Dream Council stages, morning-packet rendering.
-- **Key public types/functions (sample, TODO confirm with API freeze):**
+- **Key public types/functions (sample):**
   - Checkpoint clone helpers split by platform (`checkpoint_clone_darwin.go` vs `checkpoint_clone_fallback.go`).
   - Boundary-test harness (`withExecShim`) for swapping `ExecCommand` in tests.
   - `seedAgents` test helper that builds a fake `.agents/` tree (used widely by overnight tests).
 - **Imports from internal:** `cli/internal/{corpus, daemon, forge, harvest, lifecycle, mine, pool, provenance, rpi, search}` — overnight is the highest-level orchestrator and the densest internal-import node.
-- **Imported by:** `cli/cmd/ao/overnight*.go` and (transitively) the daemon's Dream executor.
+- **Used by:** `cli/cmd/ao/overnight*.go` and (transitively) the daemon's Dream executor.
 
 #### `cli/internal/daemon/` (17 files, 5,816 LOC)
 
@@ -127,7 +122,7 @@ Top packages by file count (non-test source under `cli/internal/`):
   - `DreamRunLoopOptions` and `DreamMode` — typed run-loop config for the Dream executor.
   - RPI registry/runner pair that owns in-flight RPI runs and reconciles their state.
 - **Imports from internal:** `cli/internal/{agentworker, gascity, openclaw, rpi, wikiworker}`.
-- **Imported by:** `cli/cmd/ao/daemon*.go` and `cli/internal/overnight` (Dream stage hands work to the daemon executor).
+- **Used by:** `cli/cmd/ao/daemon*.go` and `cli/internal/overnight` (Dream stage hands work to the daemon executor).
 
 ## Cross-references (internal package import graph)
 
@@ -163,13 +158,11 @@ Observations:
 | Knowledge flywheel | `.agents/{learnings,patterns,findings,research,retros,…}/` | Read-many surfaces for `cli/internal/{search,lifecycle,context}` |
 | Constraint index | `.agents/constraints/index.json` | `cli/internal/search/constraint.go` schema owner |
 | Beads | `.beads/` (bd CLI) | External to this repo's Go code; consumed by `cli/internal/search/bead_context.go` and `cli/cmd/ao` bead helpers |
-| Daemon state | TODO — confirm path; appears under `.agents/daemon/` and possibly `~/.agentops/` |
-| Ratchet chain | TODO — confirm path under `.agents/ratchet/` |
+| Daemon state | `.agents/daemon/` plus per-user token material under `~/.agents/daemon/` when configured | Owned by `cli/internal/daemon` and `cli/cmd/ao/daemon*.go` |
+| Ratchet chain | `.agents/ao/chain.jsonl` | Loaded and updated by `cli/internal/ratchet` and `ao ratchet *` commands |
 | Goals | `GOALS.yaml`, `GOALS.md` (repo root) + history under `.agents/goals/` |
 
 ## Operator Navigation Notes
-
-> TODO — write real runbooks once the agentopsd binary lands. Until then:
 
 When debugging an RPI run:
 
@@ -185,13 +178,12 @@ When debugging an overnight cycle:
 
 When debugging the daemon:
 
-1. `ao daemon status`, then tail daemon logs (TODO: confirm path).
+1. `ao daemon status`, then inspect daemon state and event output with `ao daemon events tail`.
 2. Inspect `cli/internal/daemon/reconcile.go` and `rpi_registry.go` for state transitions.
 
 ## Scope Notes
 
-- This map describes the **current repository state** as of 2026-04-29 (Wave 4 of `agentops-tqc`).
-- The binary is still `ao`; the `agentopsd` rename and corresponding directory split are tracked under the parent extraction epic.
+- This map describes the **current repository state** as of 2026-05-20.
+- The user-facing binary is `ao`; agentopsd is the daemon/control-plane surface behind that CLI.
 - LOC counts are non-test source only (`*.go` minus `*_test.go`) measured at write time. Recount before any release.
-- Cross-reference graph was sampled with `grep`, not built from `go list -deps`. Treat it as a navigation aid, not a complete graph. TODO: replace with a `go list`-driven generator and check it in CI.
-- Several `cli/internal/` packages (e.g. `gascity`, `bridge`, `harvest`, `mine`, `pool`, `provenance`, `safety`, `state`, `taxonomy`) carry no per-package summary yet — flagged as TODO above.
+- Cross-reference graph was sampled with `grep`, not built from `go list -deps`. Treat it as a navigation aid, not a complete graph.

--- a/docs/contracts/agentops-daemon.md
+++ b/docs/contracts/agentops-daemon.md
@@ -182,17 +182,26 @@ Initial job families:
   and the foundation §6 site 3 (alt) carve-out for read-side endpoints
   (`.agents/plans/2026-05-01-daemon-absorption-spec/00-foundation-contract.md`).
 
-Executor policies route these families differently. `fake` and `gascity`
-handle `rpi.run` through the daemon phase runner; `cli-fallback` handles
-`rpi.run` in-process via `RPIRunExecutor` (`cli/internal/daemon/rpi_run.go`),
-which calls `runPhasedEngine` through the function-pointer pattern, and does
-not claim standalone `rpi.phase` jobs. The previous shell-out wrapper under
-`scripts/` was retired in soc-bcrn.3.7.
+Executor policies route these families differently. The foreground worker
+default is `cli-fallback`, which handles `rpi.run` in-process via
+`RPIRunExecutor` (`cli/internal/daemon/rpi_run.go`) and calls
+`runPhasedEngine` through the function-pointer pattern. The `gascity` policy
+routes through the GasCity adapter. The `fake` policy is explicit test/demo
+mode; when selected for worker loops, the CLI prints a warning that it emits
+synthetic completion artifacts. `cli-fallback` does not claim standalone
+`rpi.phase` jobs. The previous shell-out wrapper under `scripts/` was retired
+in soc-bcrn.3.7.
+
+`plans.projection` is projection-backed in the read-side API. It appears in
+`GET /v1/plans/manifest` after a plans executor with a configured bd source
+writes the projection snapshot; before that, the endpoint returns the current
+empty projection envelope rather than a shape-only stub.
 
 ### Read-Side Endpoints — `plans.projection` curl example (F-PM-3)
 
 ```sh
-# Manifest snapshot (atom-1 stub: empty entries until atom-2 fills the projection)
+# Manifest snapshot from the daemon projection state. Entries are empty until
+# the plans.projection job writes a projection snapshot.
 curl -s http://localhost:7077/v1/plans/manifest | jq .
 # {"entries": [{"beads_id": "soc-aaa", "title": "...", "status": "open", ...}],
 #  "schema_version": 1}
@@ -218,8 +227,9 @@ jobs.
 which keeps local validation deterministic while exercising the same queue
 claim, heartbeat, and terminal event path as the long-running worker loop.
 
-The fake policy supports `openclaw.snapshot`, `wiki.forge`, and `dream.run`.
-`wiki.forge` uses the shared `AgentWorker` contract with an in-memory worker.
+The explicit `fake` policy supports `openclaw.snapshot`, `wiki.forge`, and
+`dream.run` for deterministic local tests and demos. `wiki.forge` uses the
+shared `AgentWorker` contract with an in-memory worker.
 `dream.run` executes the existing Dream loop, writes terminal artifacts
 (`summary_json`, `summary_markdown`, `overnight_log`, and `failure_report` on
 failure), and fails the daemon job if the job execution timeout is exhausted.

--- a/docs/contracts/agentopsd-schedule.md
+++ b/docs/contracts/agentopsd-schedule.md
@@ -314,6 +314,12 @@ before token validation.
 
 ### Nightly llmwiki.loop
 
+This remains an experimental registration example. With the default payload,
+placeholder-producing stages complete as skipped with
+`skip_reason=placeholder-output-disabled`; test fixtures may set
+`allow_placeholder_outputs: true` to exercise the stub writers until real
+stage bodies land.
+
 ```yaml
 schedules:
   - name: nightly-llmwiki-loop
@@ -322,6 +328,7 @@ schedules:
     timeout: 30m
     payload:
       vault: ~/wiki
+      # allow_placeholder_outputs: true  # test/experimental stub opt-in only
     backpressure:
       skip_if_running: true
       max_queue_depth: 3
@@ -554,7 +561,7 @@ boundary rather than a skip-and-log.
 
 ## Executor Idempotency Contract
 
-> ⚠️ **Status: experimental — stubs only.** The `llmwiki.loop` job type's stage handlers (Ingest, Query, Lint, Promote) ship as stubs in v1.0; they produce frontmatter-only output until the real-bodies follow-up lands (see `f-2026-05-01-011` in `.agents/findings/registry.jsonl`). For production schedules in v1.0, use `dream.run` (real-bodied via `overnight.RunLoop`) and `wiki.forge` (real-bodied via `wikiworker.Worker`).
+> ⚠️ **Status: experimental — placeholder outputs are default-disabled.** The `llmwiki.loop` job type's Ingest, Query, and Lint handlers still contain stub body logic in v1.0. The daemon executor skips those stages unless the job payload explicitly sets `allow_placeholder_outputs: true`, which is intended for tests and experimental vault fixtures only. For production schedules in v1.0, use `dream.run` (real-bodied via `overnight.RunLoop`) and `wiki.forge` (real-bodied via `wikiworker.Worker`).
 
 `JobTypeLLMWikiLoop` (`llmwiki.loop`) materializes the Karpathy LLM-Wiki
 pattern as a daemon job. The executor at
@@ -590,10 +597,10 @@ If the daemon crashes mid-stage:
 3. Because writes are atomic (tmp+rename), there is no torn-frontmatter
    case at steady state — only "absent" or "complete".
 
-The contract is locked in at the executor; the stage logic itself (NLP
-quality, extraction heuristics) is intentionally a stub in the initial
-landing and gets replaced by real forge / harvest / knowledge calls in
-follow-up issues.
+The contract is locked in at the executor. The NLP quality and extraction
+heuristics are still placeholder-stage logic in v1.0, so placeholder-producing
+stages are gated by `allow_placeholder_outputs` until real forge / harvest /
+knowledge calls replace them in follow-up issues.
 
 ## Migration Recipe
 
@@ -655,6 +662,7 @@ schedules:
     payload:
       vault: ".agents/wiki/vault"
       stages: [ingest, lint, promote]
+      # allow_placeholder_outputs: true  # test/experimental stub opt-in only
     timeout: 30m
     backpressure:
       skip_if_running: true

--- a/docs/contracts/hook-lease-classification.v1.json
+++ b/docs/contracts/hook-lease-classification.v1.json
@@ -235,6 +235,15 @@
       "side_effects": ["runs session-end maintenance"],
       "rationale": "Session closeout should be explicit and reproducible."
     },
+    "session-pr-counter.sh": {
+      "owner_bubble": "Work Lifecycle",
+      "disposition": "gate",
+      "replacement": "GateRunnerPort session-scope PR counter lane",
+      "evidence_status": "deterministic-safety",
+      "context_injection": true,
+      "side_effects": ["warns or blocks when a session exceeds the PR-count threshold"],
+      "rationale": "Session-scope limits are deterministic factory safety policy and should be enforced through an explicit gate port."
+    },
     "session-start.sh": {
       "owner_bubble": "Context Compiler",
       "disposition": "explicit-command",

--- a/docs/contracts/hook-lease-inventory.md
+++ b/docs/contracts/hook-lease-inventory.md
@@ -12,11 +12,11 @@ path required before hook defaults can be removed.
 
 ## Summary
 
-- Manifest hook entries: 43
-- Unique hook files in manifest: 36
+- Manifest hook entries: 44
+- Unique hook files in manifest: 37
 - Additional hook surfaces outside main manifest: 2
 - `remove`: 0
-- `gate`: 25
+- `gate`: 26
 - `event-subscriber`: 9
 - `explicit-command`: 9
 - `optional-adapter`: 0
@@ -64,6 +64,7 @@ This inventory uses concrete migration dispositions. For the
 | PreToolUse | Bash | `check-test-pair-on-commit.sh` | 5 | Evidence and Trust | `gate` | `deterministic-safety` | yes | GateRunnerPort commit-review validation lane |
 | PreToolUse | Bash | `check-sibling-citation-on-commit.sh` | 5 | Evidence and Trust | `gate` | `deterministic-safety` | yes | GateRunnerPort commit-review validation lane |
 | PreToolUse | Bash | `git-worker-guard.sh` | 5 | Evidence and Trust | `gate` | `deterministic-safety` | no | SafetyPolicyPort worker-git lane |
+| PreToolUse | Bash | `session-pr-counter.sh` | 10 | Work Lifecycle | `gate` | `deterministic-safety` | yes | GateRunnerPort session-scope PR counter lane |
 | PreToolUse | Bash | `lead-only-worker-git-guard.sh` | 5 | Evidence and Trust | `gate` | `deterministic-safety` | no | SafetyPolicyPort lead-only git lane |
 | PreToolUse | Edit | `standards-injector.sh` | 3 | Context Compiler | `explicit-command` | `token-risk-needs-remeasure` | yes | Skill-scoped standards lookup via ContextCompilerPort |
 | PreToolUse | Write | `standards-injector.sh` | 3 | Context Compiler | `explicit-command` | `token-risk-needs-remeasure` | yes | Skill-scoped standards lookup via ContextCompilerPort |
@@ -206,6 +207,12 @@ surfaces that are not wired by the active manifests.
 - **Summary:** git-worker-guard.sh - PreToolUse hook: block git write operations for swarm workers
 - **Side effects:** blocks git writes from worker contexts
 - **Rationale:** Worker authority is a safety policy.
+
+### `session-pr-counter.sh`
+
+- **Summary:** shellcheck shell=bash
+- **Side effects:** warns or blocks when a session exceeds the PR-count threshold
+- **Rationale:** Session-scope limits are deterministic factory safety policy and should be enforced through an explicit gate port.
 
 ### `lead-only-worker-git-guard.sh`
 

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -258,9 +258,9 @@ Bridge / framing docs:
 - [Skill Router](SKILL-ROUTER.md) — Which skill to use for which task
 - [Troubleshooting](troubleshooting.md) — Common issues and quick fixes
 - [Incident Runbook](INCIDENT-RUNBOOK.md) — Operational runbook for incidents and recovery
-- [Autonomy Runtime Cycle-1 Runbook](runbooks/autonomy-runtime-cycle-1.md) — Safe activation/rollback/evidence checks for cycle-1 autonomy runtime work (ported from olympus)
+- [Autonomy Runtime Cycle-1 Runbook](runbooks/autonomy-runtime-cycle-1.md) — Safe activation/rollback/evidence checks for RPI, evolve, and daemon-backed autonomy work
 - [bd Server-Mode Tracker Closeout](runbooks/bd-server-mode-closeout.md) — Distinguish Git push, local bd durability, and conditional Dolt remote push for server-mode trackers
-- [Release Process Runbook](runbooks/release-process.md) — Step-by-step release runbook (gates, version bump, goreleaser, post-release; ported from olympus and complements `RELEASING.md`)
+- [Release Process Runbook](runbooks/release-process.md) — Step-by-step release runbook for gates, version injection, goreleaser, and post-release checks; complements `RELEASING.md`
 - [Factory Manual Merge Runbook](runbooks/factory-manual-merge.md) — Operator recovery and manual merge procedure for factory worktrees and validation evidence
 - [Daemon Factory Admission Runbook](runbooks/daemon-factory-admission.md) — Rehearsal procedure for daemon-native factory admission, blocked decisions, RPI handoff, and schedule payloads
 - [Cloud-Frontier Factory Pilot Runbook](runbooks/cloud-frontier-pilot.md) — Bounded one-versus-two worker pilot procedure using cloud/frontier coding lanes and manual merge
@@ -339,7 +339,7 @@ Bridge / framing docs:
 - [Hook Runtime Contract](contracts/hook-runtime-contract.md) — Canonical event mapping across Claude, Codex, and manual runtimes
 - [Multi-Runtime Tier Charter](contracts/multi-runtime-tier-charter.md) — Explicit Tier S/I/E declaration: Tier S structural blocks CI; Tier E live execution is opt-in (Directive D1)
 - [v2.39.0 README claim evidence manifest](releases/v2.39.0-claims/README.md) — Maps each `AOP-CLAIM-README-*` marker to its evidence file and verification gate (PG4)
-- [AgentOps 3.0 PMF Scenario — exported evidence](releases/v3.0/pmf-scenario.md) — Single-day autonomous /evolve drain record: 11 P1 closures, 11 commits, friction modes, exported artifacts (PG2)
+- [AgentOps 3.0 PMF Scenario — evidence bundle](releases/v3.0/pmf-scenario.md) — Single-day autonomous /evolve drain record: 11 P1 closures, 11 commits, friction modes, durable artifacts (PG2)
 - [Scope Escape Report](contracts/scope-escape-report.md) — Structured template for agent scope-escape reporting
 - [Dream Run Contract](contracts/dream-run-contract.md) — Process model, locking, keep-awake, and artifact floor for private overnight runs
 - [Dream Report Contract](contracts/dream-report.md) — Canonical `summary.json` and `summary.md` schema for Dream outputs

--- a/docs/runbooks/autonomy-runtime-cycle-1.md
+++ b/docs/runbooks/autonomy-runtime-cycle-1.md
@@ -1,12 +1,8 @@
 # Autonomy Runtime Cycle-1 Runbook
 
-> **Status:** Ported from olympus 2026-04-29. Commands/paths adapted for agentops. Where olympus terms have no agentops equivalent, TODO callouts mark the gap.
-
-**Date:** 2026-02-12 (originally authored in olympus)
-**Scope:** Safe activation of cycle-1 actor runtime foundations (spec + runtime scaffold + temporal actor-context threading).
-
-> **TODO: olympus actor-runtime / temporal workflow equivalent in agentops?**
-> The cycle-1 work in olympus targeted a Temporal-based quest workflow with `ActorPool` threading. agentops's autonomy surface is `ao rpi` / `ao evolve` (supervisor mode + RPI phased runs). The structure of this runbook is preserved so the activation/rollback shape can be reused; concrete spec paths and test names will need to be re-pointed at the agentops equivalents (likely `cli/internal/rpi/...` and `ao rpi serve` / `ao daemon run` surfaces) once the analog is implemented.
+**Date:** 2026-05-20
+**Scope:** Safe activation of AgentOps cycle-1 autonomy surfaces: RPI phased runs,
+`ao evolve` supervisor loops, and daemon-backed job execution.
 
 ## Activation
 
@@ -15,43 +11,38 @@
    - `cd cli && make build` (produces `cli/bin/ao`)
    - `cd cli && go test ./internal/rpi/...`
    - `cd cli && go test ./internal/daemon/...`
-
-   > **TODO: olympus `internal/runtime/` / `internal/temporal/` equivalent in agentops?**
-   > In olympus the runtime + temporal packages are the test surface. In agentops the closest equivalents live under `cli/internal/rpi/` and `cli/internal/daemon/`. Confirm exact package paths before executing.
 3. Verify required specs and index references exist:
-   - `docs/contracts/agentops-daemon.md` (daemon contract — closest analog to olympus's `docs/specs/autonomy-runtime.md`)
-   - `docs/documentation-index.md` references the daemon contract and any new autonomy spec.
-
-   > **TODO: olympus `docs/specs/autonomy-runtime.md` equivalent in agentops?**
-   > agentops doesn't ship a `docs/specs/` tree; contracts live under `docs/contracts/` and are listed in `docs/documentation-index.md`. Replace the precise filename when an autonomy-runtime spec lands.
+   - `docs/contracts/agentops-daemon.md`
+   - `docs/contracts/agentopsd-control-plane.md`
+   - `docs/contracts/rpi-run-registry.md`
+   - `docs/documentation-index.md` references the daemon and RPI contracts.
 4. Execute the target RPI run in dry/safe mode first and confirm no regressions in run artifacts and the bead ledger:
-   - `ao rpi phased --dry-run --goal <goal>` (or equivalent: `ao evolve --dream-only` for knowledge-only cycles)
+   - `ao rpi phased --dry-run "<goal>"` for one explicit run
+   - `ao evolve --dry-run --max-cycles 1 "<goal>"` for the supervisor loop surface
+   - `ao evolve --dream-only` for knowledge-only cycles
    - `ao rpi status` to inspect produced artifacts.
 
 ## Feature Flags
 
-Cycle-1 runtime fields are additive and optional (kept here as the original olympus shape; map to agentops opt-in flags as the analog ships):
+Cycle-1 runtime controls are command flags and daemon job payloads:
 
-- `QuestWorkflowInput.ActorPool`
-- `HeroWaveInput.ActorPool`
-- `DemigodActivityInput.ActorPool`
-
-> **TODO: olympus `ActorPool` / `HeroWaveInput` / `DemigodActivityInput` equivalent in agentops?**
-> agentops's RPI lifecycle does not have a Temporal workflow input surface. The analogous "additive opt-in" knob is likely an `ao rpi`/`ao evolve` flag (e.g. `--supervisor`, `--ralph`, or a future `--actor-pool`). Replace these field names once the agentops equivalent is defined.
+- `ao evolve --supervisor=true` is the default supervised loop posture.
+- `ao evolve --max-cycles <n>` bounds autonomous iterations.
+- `ao evolve --dream-first` / `--dream-only` limits work to knowledge compounding before or instead of code cycles.
+- `ao rpi phased --runtime <name>` and `--runtime-cmd <cmd>` select the worker runtime for phased execution.
+- `ao daemon jobs submit --type <type> --payload @payload.json` activates daemon-backed work explicitly.
 
 Activation rule:
 
-- Start with the legacy path (no opt-in flag set).
-- Introduce the new opt-in flag only in controlled test runs.
+- Start with `--dry-run` and `--max-cycles 1`.
+- Introduce daemon-backed job submission only after the local RPI and evolve dry runs are clean.
+- Keep manual merge/review in the loop until the release-readiness contract says otherwise.
 
 ## Rollback Trigger
 
 Rollback immediately when any of the following occurs:
 
 1. RPI run determinism / replay errors appear (deterministic-mode smoke regressions, run-ledger inconsistencies).
-
-   > **TODO: olympus Temporal workflow determinism/replay equivalent in agentops?**
-   > Temporal-style replay determinism does not have a 1:1 analog in agentops. The closest signal is RPI phased-run reproducibility plus daemon job ledger integrity (`ao daemon jobs list`, `ao daemon events tail`).
 2. Quality gate behavior deviates from the expected non-bypassable flow (`scripts/pre-push-gate.sh`, `scripts/ci-local-release.sh`, `ao goals validate`).
 3. RPI run artifacts or bead evidence become incomplete for ratchet-relevant steps (`ao ratchet check`, `ao ratchet status`).
 
@@ -66,33 +57,31 @@ Rollback steps:
 Verify lifecycle and orchestration evidence via:
 
 1. RPI / bead events include the relevant lifecycle markers and payload fields.
-
-   > **TODO: olympus quest-event types (`hero_hunt`, `hero_embark`, `hero_ratchet`) equivalent in agentops?**
-   > agentops emits daemon events (`ao daemon events tail`) and RPI phased lifecycle markers; there is no direct rename map for the olympus HERO event types. Re-derive the watchlist from `cli/internal/daemon/events` once the cycle-1 analog ships.
+   - RPI phased state and artifacts live under `.agents/rpi/`.
+   - Daemon jobs and events are inspectable with `ao daemon jobs list` and `ao daemon events show`.
 2. RPI run ledger / bead store contains attempt records for affected beads (`bd show <id>`, `ao rpi status`).
 3. Daemon / RPI tests pass:
-   - `cd cli && go test ./internal/rpi/... -run TestPhasedRunActorThreading` (rename when the agentops test exists)
-
-   > **TODO: olympus `TestQuestWorkflowActorPoolThreading` equivalent in agentops?**
+   - `cd cli && go test ./internal/rpi/...`
+   - `cd cli && go test ./internal/daemon/...`
 4. Autonomy smoke remains green:
-   - `cd cli && go test ./cmd/ao/... -run TestAutopilotSmoke` (or the agentops smoke equivalent in `cli/cmd/ao/`).
-
-   > **TODO: olympus `TestAutopilotSmoke` equivalent in agentops?**
+   - `cd cli && go test ./cmd/ao/... -run 'Test.*(RPI|Evolve|Daemon|Factory)'`
+   - `bash scripts/ci-local-release.sh --fast --jobs 4` before promoting the activation.
 
 ## Operator Notes
 
-- This runbook does not enable daemon/fleet orchestration beyond what the cycle-1 opt-in flag exposes.
+- This runbook does not enable daemon/fleet orchestration beyond explicit `ao daemon jobs submit` activation.
 - This runbook does not relax validation boundaries (`/vibe`, `/council`, `ao goals validate`, gate scripts all still apply).
 - This runbook is cycle-1 only; fleet/autopilot runtime expansion is a follow-on cycle.
 
-## Adaptation map (olympus → agentops)
+## AgentOps Runtime Surface
 
-| Olympus | agentops |
+| Concern | AgentOps surface |
 |---|---|
-| `ol <cmd>` | `ao <cmd>` |
-| `zeus step` / `zeus run --quest <id>` | `ao rpi phased` / `ao rpi loop` (per-cycle vs. supervised loop) |
-| `apollo claim <bead>` | `bd update --claim <id>` (bd-flavored claim) |
-| `athena validate <bead>` | `/vibe`, `/council`, or `ao goals validate` (per package mapping) |
-| `hephaestus extract` | `ao forge` (transcript / batch / markdown subcommands) |
-| `docs/specs/*` | `docs/contracts/*` + `docs/documentation-index.md` |
-| `internal/runtime/`, `internal/temporal/` | `cli/internal/rpi/`, `cli/internal/daemon/` (closest analogs; verify per package) |
+| CLI | `ao <cmd>` |
+| One bounded autonomy run | `ao rpi phased "<goal>"` |
+| Supervised loop | `ao evolve --max-cycles <n> "<goal>"` or `ao rpi loop` |
+| Work claim | `bd update <id> --claim` |
+| Validation | `/vibe`, `/council`, `ao goals validate`, `scripts/ci-local-release.sh` |
+| Knowledge extraction | `ao forge` |
+| Contracts | `docs/contracts/*` + `docs/documentation-index.md` |
+| Runtime packages | `cli/internal/rpi/`, `cli/internal/daemon/`, `cli/cmd/ao/` |

--- a/docs/runbooks/release-process.md
+++ b/docs/runbooks/release-process.md
@@ -1,10 +1,8 @@
 # Release Process
 
-> **Status:** Ported from olympus 2026-04-29. Commands/paths adapted for agentops. Where olympus terms have no agentops equivalent, TODO callouts mark the gap.
-
 How to cut a release of `ao` (the AgentOps CLI).
 
-> See also: [`RELEASING.md`](../RELEASING.md) for the canonical agentops release doc and [`release-e2e-checklist.md`](../release-e2e-checklist.md) for the full local gate sequence. This runbook is the runbook-shaped port from the olympus equivalent and may overlap with both.
+> See also: [`RELEASING.md`](../RELEASING.md) for the canonical AgentOps release doc and [`release-e2e-checklist.md`](../release-e2e-checklist.md) for the full local gate sequence. This runbook is the operator checklist view of those release contracts.
 
 ## Prerequisites
 
@@ -31,9 +29,6 @@ ao goals measure
 ao goals validate
 ```
 
-> **TODO: olympus `bash scripts/run-commit-lane.sh` equivalent in agentops?**
-> The closest analog is `scripts/pre-push-gate.sh` (smart) or `scripts/ci-local-release.sh` (full). Confirm the agentops "commit lane" surface lives in `scripts/` and update if a dedicated commit-lane script ships later.
-
 ### Goal Gate Pack (Timeout-Prone Gates)
 
 Run this bundle explicitly before release to validate the stabilized gate path:
@@ -42,35 +37,29 @@ Run this bundle explicitly before release to validate the stabilized gate path:
 timeout 300 bash -c 'cd cli && go test ./... -count=1'
 ```
 
-> **TODO: olympus `scripts/check-coverage-floors.sh` / `scripts/check-checkpoint-fidelity.sh` / `scripts/smoke-test.sh` equivalents in agentops?**
-> agentops has `scripts/pre-push-gate.sh` (33 checks) and `scripts/ci-local-release.sh`, but no 1:1 named scripts for coverage-floor ratcheting, checkpoint fidelity, or a single smoke harness. Re-point this section once the analogs are identified (or confirm the pre-push gate covers them).
-
-Gate semantics (preserved from olympus shape; map to the agentops equivalents above):
+AgentOps release gate semantics:
 
 - `go-test`: hard gate on full test suite within a 300s budget.
-- `coverage-floors`: ratchet enforcement for package coverage floors.
-- `checkpoint-fidelity`: minimum RPI / quest-equivalent test-count authority floor.
-- `smoke-test`: CRUD + RPI step/run + CLI help in deterministic mode.
+- `ci-local-release`: full local release validation, including doc, shell, contract, CLI, and release-surface checks.
+- `pre-push-fast`: smart changed-file gate for PR iteration before the full release gate.
+- `release-e2e`: optional HIL/SIL/VIL release smoke path from `docs/release-e2e-checklist.md`.
 
 ### Dogfood Hardening Pack
 
-> **TODO: olympus `make dogfood` / `make dogfood-quick` equivalents in agentops?**
-> agentops does not currently ship a `dogfood` make target. The conceptual equivalent — running `ao` against this repo's own `.agents/` and validating end-to-end — is partially covered by `scripts/ci-local-release.sh` plus `ao rpi phased` smoke runs. Add a dedicated `make dogfood` / `make dogfood-quick` target and re-point this section if/when it lands.
+AgentOps dogfood means running `ao` against this repo's own `.agents/` state and release contracts:
 
-Smoke test determinism notes (carried over for shape):
-
-- The smoke harness should build a local `ao` binary from repo source (`cd cli && make build`).
-- The harness should install a temporary mock LLM/runner binary in script-local `PATH` to avoid host-environment model dependencies during gate execution.
-- Each smoke command should be bounded by a per-command timeout (mirror olympus's `SMOKE_CMD_TIMEOUT_SECONDS` default of `45`).
+- Build a local `ao` binary from repo source (`cd cli && make build`).
+- Run `scripts/ci-local-release.sh` before tagging.
+- For explicit release smoke coverage, use `bash scripts/ci-local-release.sh --fast --jobs 4` and the HIL/SIL/VIL targets in `docs/release-e2e-checklist.md`.
+- Bound any manual smoke command with `timeout` so model or daemon dependencies cannot hang a release shell.
 
 ## Version Bump
 
 1. The version constant lives in the `ao` root command file.
 
-   > **TODO: olympus `cmd/ol/root.go` exact equivalent in agentops?**
-   > agentops's CLI entrypoint is `cli/cmd/ao/`. Confirm the file (e.g., `cli/cmd/ao/root.go` or `cli/cmd/ao/version.go`) that holds the goreleaser-overridable `version` constant before tagging.
-
-   The actual binary version is injected by goreleaser from the git tag (see
+   The default `version` variable lives in `cli/cmd/ao/main.go`; root command
+   wiring lives in `cli/cmd/ao/root.go`, and `ao version` output lives in
+   `cli/cmd/ao/version.go`. The actual binary version is injected by goreleaser from the git tag (see
    `-X main.version={{.Version}}` in `.goreleaser.yml`), so no source change is
    needed unless you want `go install` builds to carry the version.
 
@@ -124,7 +113,7 @@ curl -sL https://github.com/boshu2/agentops/releases/download/vX.Y.Z/ao_X.Y.Z_da
 ./ao version
 ```
 
-2. Update install docs if paths or supported platforms changed.
+2. Update install docs if paths or platform support changed.
 3. Close the release bead/epic in beads (`bd close <id>`).
 
 ## Quick Reference
@@ -137,22 +126,21 @@ curl -sL https://github.com/boshu2/agentops/releases/download/vX.Y.Z/ao_X.Y.Z_da
 | Smart pre-push gate | `scripts/pre-push-gate.sh --fast` |
 | Full pre-push gate | `scripts/pre-push-gate.sh` |
 | Local release gate | `scripts/ci-local-release.sh` |
-| Dogfood quick | _TODO: agentops equivalent_ |
-| Dogfood full | _TODO: agentops equivalent_ |
-| Throughput gate | _TODO: agentops equivalent_ |
+| Dogfood quick | `bash scripts/ci-local-release.sh --fast --jobs 4` |
+| Dogfood full | `scripts/ci-local-release.sh` |
+| Throughput gate | `docs/release-e2e-checklist.md` HIL/SIL/VIL smoke path |
 | Release (full) | `goreleaser release --clean` |
 | Release (dry run) | `goreleaser release --clean --snapshot --skip=publish` |
 | Retag | `scripts/retag-release.sh vX.Y.Z` |
 
-## Adaptation map (olympus → agentops)
+## AgentOps Release Surface
 
-| Olympus | agentops |
+| Surface | Current AgentOps path |
 |---|---|
-| `ol` binary | `ao` binary |
-| `cmd/ol/` | `cli/cmd/ao/` |
-| `make ol-build` / `make ol-install` / `make ol-test` | `cd cli && make build` / `make install` / `make test` |
-| `scripts/run-commit-lane.sh` | `scripts/pre-push-gate.sh` (smart, diff-aware) — see TODO above |
-| `make dogfood` / `make dogfood-quick` | _TODO: not yet ported_ |
-| `scripts/smoke-test.sh` | _TODO: closest is parts of `scripts/ci-local-release.sh`_ |
-| Release artifact prefix `ol_X.Y.Z_*` | `ao_X.Y.Z_*` |
-| Release repo path `boshu2/olympus` | `boshu2/agentops` |
+| Binary | `ao` |
+| CLI source | `cli/cmd/ao/` |
+| Build/test targets | `cd cli && make build` / `make install` / `make test` |
+| Smart commit gate | `scripts/pre-push-gate.sh --fast` |
+| Full release gate | `scripts/ci-local-release.sh` |
+| Release artifact prefix | `ao_X.Y.Z_*` |
+| Release repo path | `boshu2/agentops` |

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -130,7 +130,9 @@ files designed to be picked up à la carte.
 
 - **What it does:** Registers the daemon-side vault maintenance pack:
   Tier 1 `wiki.forge` over session evidence, Tier 2 `skill.invoke` for
-  `ao forge review --reviewer-model gemma2:9b`, and Tier 3 `llmwiki.loop`.
+  `ao forge review --reviewer-model gemma2:9b`, and Tier 3 experimental
+  `llmwiki.loop`. Placeholder-producing `llmwiki.loop` stages are skipped by
+  default unless a test fixture opts in with `allow_placeholder_outputs=true`.
 - **Why schedule it:** It replaces scattered operator-local timers with
   daemon-owned recurrence, backpressure, and ledger evidence.
 - **Cadence:** Tier 1 at 22:00, Tier 2 at 01:30, Tier 3 at 02:00. Tier 4 stays

--- a/docs/sovereignty-proof/evidence/2026-05-15-rpi-leanness-codex-reframe.md
+++ b/docs/sovereignty-proof/evidence/2026-05-15-rpi-leanness-codex-reframe.md
@@ -1,6 +1,6 @@
 # Council verdict — RPI-leanness reframe (2026-05-15)
 
-> **Provenance.** Excerpt from the original local council verdict at `.agents/council/2026-05-15-rpi-leanness-council.md` (gitignored — runtime corpus). Committed here so the [sovereignty proof page](../index.md#case-study-1--rpi-leanness-reframe-2026-05-15) has a falsifiable, in-repo source.
+> **Provenance.** Excerpt from the original local council verdict at `.agents/council/2026-05-15-rpi-leanness-council.md` (gitignored — runtime corpus). Committed here so the [sovereignty proof page](../index.md#case-study-1-rpi-leanness-reframe-2026-05-15) has a falsifiable, in-repo source.
 
 **Date:** 2026-05-15
 **Mode:** mixed · deep (5 voices: Codex gpt-5.5, Claude agile-coach, Claude DDD-architect, Claude token-economist, Claude skeptic)

--- a/docs/sovereignty-proof/evidence/2026-05-16-cdlc-f6-f7-codex-findings.md
+++ b/docs/sovereignty-proof/evidence/2026-05-16-cdlc-f6-f7-codex-findings.md
@@ -1,6 +1,6 @@
 # Council verdict — CDLC F6 + F7 findings (2026-05-16)
 
-> **Provenance.** Excerpt from the original local council verdict at `.agents/council/2026-05-16-research-cdlc-claims.md` (gitignored — runtime corpus). Committed here so the [sovereignty proof page](../index.md#case-study-2--f6--f7-codex-trio-findings-the-claude-trio-missed-2026-05-16) has a falsifiable, in-repo source.
+> **Provenance.** Excerpt from the original local council verdict at `.agents/council/2026-05-16-research-cdlc-claims.md` (gitignored — runtime corpus). Committed here so the [sovereignty proof page](../index.md#case-study-2-f6-f7-codex-trio-findings-the-claude-trio-missed-2026-05-16) has a falsifiable, in-repo source.
 
 **Date:** 2026-05-16
 **Mode:** research · mixed · deep (6 judges: 3 Claude-runtime + 3 Codex-runtime, independent / no preset)

--- a/docs/sovereignty-proof/index.md
+++ b/docs/sovereignty-proof/index.md
@@ -36,13 +36,13 @@ The skeptic seat agreed. The other three Claude voices then aligned. **Without t
 | `ao inject` is deprecated (v3.0.0 removal target) | [cli/cmd/ao/inject.go:155][inject-deprecation] |
 | `trustTierWeight` is additive (soft prior, not gate) | [cli/cmd/ao/context_relevance.go:217][trust-tier] |
 
-[plan-112]: ../../skills/plan/SKILL.md
-[plan-160]: ../../skills/plan/SKILL.md
-[plan-166]: ../../skills/plan/SKILL.md
-[plan-170]: ../../skills/plan/SKILL.md
-[crank-skill]: ../../skills/crank/SKILL.md
-[inject-deprecation]: ../../cli/cmd/ao/inject.go
-[trust-tier]: ../../cli/cmd/ao/context_relevance.go
+[plan-112]: https://github.com/boshu2/agentops/blob/main/skills/plan/SKILL.md#L112
+[plan-160]: https://github.com/boshu2/agentops/blob/main/skills/plan/SKILL.md#L160
+[plan-166]: https://github.com/boshu2/agentops/blob/main/skills/plan/SKILL.md#L166
+[plan-170]: https://github.com/boshu2/agentops/blob/main/skills/plan/SKILL.md#L170
+[crank-skill]: https://github.com/boshu2/agentops/blob/main/skills/crank/SKILL.md
+[inject-deprecation]: https://github.com/boshu2/agentops/blob/main/cli/cmd/ao/inject.go#L155
+[trust-tier]: https://github.com/boshu2/agentops/blob/main/cli/cmd/ao/context_relevance.go#L217
 
 **Full verdict (committed):** [evidence/2026-05-15-rpi-leanness-codex-reframe.md](evidence/2026-05-15-rpi-leanness-codex-reframe.md).
 
@@ -70,9 +70,9 @@ The Claude trio's emphasis was framing ("reconcile the docs to the code"). The C
 | `skill_loaded` citation type | [cli/cmd/ao/flywheel_citation_feedback.go:599][f6-skill-loaded] |
 | Real hard gate the prior model omitted | [cli/cmd/ao/inject_learnings.go:387][quality-gate] |
 
-[f6-feedback]: ../../cli/cmd/ao/flywheel_citation_feedback.go
-[f6-skill-loaded]: ../../cli/cmd/ao/flywheel_citation_feedback.go
-[quality-gate]: ../../cli/cmd/ao/inject_learnings.go
+[f6-feedback]: https://github.com/boshu2/agentops/blob/main/cli/cmd/ao/flywheel_citation_feedback.go#L591
+[f6-skill-loaded]: https://github.com/boshu2/agentops/blob/main/cli/cmd/ao/flywheel_citation_feedback.go#L599
+[quality-gate]: https://github.com/boshu2/agentops/blob/main/cli/cmd/ao/inject_learnings.go#L387
 
 **F7 — hook manifest asymmetry between runtimes.** All three Codex judges noted that `hooks/citation-tracker.sh` exists but is *not* wired into `hooks/hooks.json` PostToolUse(Read), so the documented "passive read-citation tracking" is inactive. They also flagged that the Codex manifest omits SessionEnd / context-guard / context-monitor — so the unified lifecycle is asymmetric across runtimes.
 
@@ -82,9 +82,9 @@ The Claude trio's emphasis was framing ("reconcile the docs to the code"). The C
 | Not wired in `hooks/hooks.json` (grep yields zero matches) | [hooks/hooks.json][hooks-json] |
 | Codex manifest exists separately | [hooks/codex-hooks.json][codex-hooks] |
 
-[citation-tracker]: ../../hooks/citation-tracker.sh
-[hooks-json]: ../../hooks/hooks.json
-[codex-hooks]: ../../hooks/codex-hooks.json
+[citation-tracker]: https://github.com/boshu2/agentops/blob/main/hooks/citation-tracker.sh
+[hooks-json]: https://github.com/boshu2/agentops/blob/main/hooks/hooks.json
+[codex-hooks]: https://github.com/boshu2/agentops/blob/main/hooks/codex-hooks.json
 
 **Full verdict (committed):** [evidence/2026-05-16-cdlc-f6-f7-codex-findings.md](evidence/2026-05-16-cdlc-f6-f7-codex-findings.md).
 
@@ -112,6 +112,6 @@ The CI gate `validate-sovereignty-proof-citations` scans this page and the commi
 
 ## See also
 
-- [Council skill](../../skills/council/SKILL.md) — how to invoke `/council --mixed --deep`
-- [Expert council skill](../../skills/expert-council/SKILL.md) — persona-debate variant for fungibility decisions
+- [Council skill](https://github.com/boshu2/agentops/blob/main/skills/council/SKILL.md) — how to invoke `/council --mixed --deep`
+- [Expert council skill](https://github.com/boshu2/agentops/blob/main/skills/expert-council/SKILL.md) — persona-debate variant for fungibility decisions
 - [Operating loop](../architecture/operating-loop.md) — where council fits in the 7-move doctrine

--- a/docs/templates/schedule.yaml.example
+++ b/docs/templates/schedule.yaml.example
@@ -10,8 +10,9 @@
 #   - dream.run    overnight knowledge consolidation
 #   - wiki.forge   forge patterns from session corpus
 #
-# llmwiki.loop is intentionally excluded: its stage handlers are stubs in
-# v1.0 (see f-2026-05-01-011); enable once the real-bodies follow-up lands.
+# llmwiki.loop is intentionally excluded from the safe set: its placeholder
+# outputs are default-disabled and require allow_placeholder_outputs=true for
+# test/experimental fixtures until the real-bodies follow-up lands.
 #
 # Hermetic mirror lives at cli/internal/schedule/testdata/example-validation.yaml
 # for parser tests — keep them in sync (see scripts/check-schedule-example.sh).

--- a/examples/schedules/vault-four-tier.yaml
+++ b/examples/schedules/vault-four-tier.yaml
@@ -3,7 +3,9 @@
 # What it does:
 #   Replaces three operator-local timers with daemon-owned schedules:
 #   Tier 1 mines recent session evidence, Tier 2 reviews draft session pages,
-#   and Tier 3 runs the llmwiki vault loop. Tier 4 remains manual by design.
+#   and Tier 3 registers the experimental llmwiki vault loop. Its placeholder
+#   output stages are skipped by default unless a test fixture opts in with
+#   allow_placeholder_outputs=true. Tier 4 remains manual by design.
 #   The portable Tier 2 recipe uses `ao forge review --reviewer-model`; replace
 #   that `skill.invoke` payload with an operator-specific Morai bridge command
 #   only after that bridge is installed and validated on the host.
@@ -55,6 +57,7 @@ schedules:
         - ingest
         - lint
         - promote
+      # allow_placeholder_outputs: true  # test/experimental stub opt-in only
     timeout: "30m"
     backpressure:
       skip_if_running: true

--- a/scripts/check-schedule-example.sh
+++ b/scripts/check-schedule-example.sh
@@ -17,8 +17,9 @@
 # gitignored per the no-tracked-agents policy and only exists post-init on
 # operator hosts.
 #
-# llmwiki.loop is intentionally excluded — its stage handlers are stubs in v1.0;
-# wait for the real-bodies follow-up (f-2026-05-01-011) before scheduling.
+# llmwiki.loop is intentionally excluded from the starter safe-set: placeholder
+# outputs are default-disabled and require allow_placeholder_outputs=true for
+# test/experimental fixtures until the real-bodies follow-up lands.
 #
 # Exit codes:
 #   0 - PASS
@@ -105,7 +106,7 @@ fi
 # Robust against YAML formatting variations (quoted/unquoted values).
 if ! grep -qE 'job_type:[[:space:]]*"?(dream\.run|wiki\.forge)"?' "$EXAMPLE_PATH"; then
     echo "FAIL: $EXAMPLE_PATH must contain at least one schedule with job_type = dream.run or wiki.forge (real-bodied v1.0 safe-set)" >&2
-    echo "llmwiki.loop has stub stage handlers in v1.0 — exclude until f-2026-05-01-011 lands." >&2
+    echo "llmwiki.loop placeholder outputs are default-disabled; keep the starter safe-set to dream.run/wiki.forge." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Replace the plans manifest shape-only stub with projection-backed daemon state.
- Gate llmwiki placeholder outputs behind explicit opt-in and make fake daemon execution test/demo-only.
- Refresh stale Olympus-ported docs and tune README/PRODUCT claims to default-safe runtime behavior.
- Repair strict docs-site and hook-lease inventory drift surfaced by the merge gate.

## Validation
- `scripts/pre-push-gate.sh --fast`
- `go test ./internal/daemon ./internal/llmwiki ./cmd/ao`
- `bash tests/docs/validate-doc-release.sh`
- `scripts/docs-build.sh --check`
- `bash scripts/validate-sovereignty-proof-citations.sh`
- `bash scripts/check-hook-lease-inventory.sh`

Closes-scenario: soc-0l5z#ai-smell-hardening
Bounded-context: BC5-Runtime
Evidence: validate-sovereignty-proof-citations: scanned 3 pages, 16 citations
