### PR TITLE
feat(ao session bootstrap): universal init prompt (soc-vuu6.25 #ao-session-bootstrap)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -65,7 +65,7 @@ The April 2026 Claude Code source analysis confirmed that Anthropic's internal t
 | Anthropic Concept | AgentOps Equivalent | Status |
 |---|---|---|
 | **Learning Loop** — memory extraction, dream cycle consolidation, future session context | Knowledge Flywheel — `/retro` → `/forge` → `/harvest` → `ao lookup` / `ao context assemble`, tiered promotion (learning → pattern → rule), plus private local Dream via `/dream` and `ao overnight` | Live with bounds. On-demand capture/promotion works, and Dream provides an operator-started overnight compounding lane. GitHub nightly is the public proof harness for the contracts, not the user's private runtime. |
-| **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 79 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
+| **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 80 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
 | **Verification Agent** — adversarial AI auditing AI, VERDICT system for human review | Council architecture — `/council`, `/pre-mortem`, `/vibe`, `/post-mortem` with multi-model consensus, prediction tracking. Stage 4 behavioral validation adds holdout scenarios + satisfaction scoring in STEP 1.8. | Live on demand. STEP 1.8 fires automatically inside `/validation` when that skill is invoked. |
 | **Managed Agents Dreaming** (May 2026) — scheduled session review, pattern extraction, memory curation between sessions | `/dream` + `ao overnight` + `cli/cmd/ao/dream_executor.go` + `.github/workflows/nightly.yml` dream-cycle proof job | Live with operator setup. The bounded private overnight lane runs harvest → forge → close-loop → defrag on the cadence and model runtime the operator configures. |
 | **Managed Agents Outcomes** (May 2026) — rubric-driven separate-context grader with iterate-until-pass | Live at three scopes: project — `GOALS.md` (rubric) + `ao goals measure` (each gate runs as separate subprocess; `cli/internal/goals/measure.go:132-164`) + `/evolve` (can iterate a worst-failing gate under operator limits; `skills/evolve/SKILL.md:379-388`); plan — `/pre-mortem` council judges as separate-context graders; code — `/vibe` council judges. Independent 3-judge audit confirmed parity on rubric authoring, separate-context grading, iterate-until-pass, and pinpoint-what-changed. | Live at the capability layer. Empirical workbench A/B (2026-05-06): Δ=+0.0000 across 12 cases at v1 difficulty (both legs 12/12) — task difficulty floor exhausted; v2 substrate (realistic agent tasks where the hook layer differentiates) is roadmap. Counter-stat artifact: `evals/workbench/results/2026-05-06-yjzp9-counterstat.json`. |
@@ -174,7 +174,7 @@ The same model used in the README: bookkeeping records the work, the context com
 - `ao lookup` — decay-ranked retrieval for on-demand knowledge
 - `ao context assemble` — phase-scoped context packets
 - `ao compile` — rebuild the knowledge wiki (mine, grow, defrag, lint)
-- 79 skills — reusable context packages across Claude Code, Codex, and OpenCode
+- 80 skills — reusable context packages across Claude Code, Codex, and OpenCode
 - Optional lifecycle hooks — adapter profiles for teams that want runtime automation after the hookless path is proven
 - `bash <(curl -fsSL .../install.sh)` — 30 seconds, zero config
 
@@ -260,7 +260,7 @@ As of 2026-05-10:
 
 - GitHub repo: 341 stars, 33 forks, 2 open issues, last pushed 2026-05-10T03:24:01Z
 - Public surface: GitHub Pages mkdocs site live at boshu2.github.io/agentops/; doctrine site live at 12factoragentops.com
-- Distribution/runtime reach: 79 shared skills, 79 checked-in Codex artifacts, and 35 Codex overrides. `/validate` and `/curate` are additive in this train; legacy validation and mining skills remain until their shim/retirement gates are resolved.
+- Distribution/runtime reach: 80 shared skills, 80 checked-in Codex artifacts, and 35 Codex overrides. `/validate` and `/curate` are additive in this train; legacy validation and mining skills remain until their shim/retirement gates are resolved.
 
 **Measured operational proof:**
 

--- a/cli/cmd/ao/session_bootstrap.go
+++ b/cli/cmd/ao/session_bootstrap.go
@@ -1,0 +1,276 @@
+// `ao session bootstrap` — the universal init prompt (soc-vuu6.25).
+//
+// Every agent spawned into an AgentOps repo runs this command first. The
+// output is the same shape regardless of model — that's the fungibility
+// guarantee: no two agents in a swarm start with different orientation.
+//
+// Substeps (all fail-open):
+//   1. Confirm AGENTS.md (and post-vuu6.3 siblings AGENTS-WORKFLOW.md,
+//      AGENTS-CI.md, AGENTS-CODEX.md, AGENTS-RUNTIME.md) exist and are
+//      readable. Read by the agent itself, not pre-loaded into the report.
+//   2. Run `ao onboard --auto` if it exists (soc-vuu6.9 — currently a P3
+//      stub). Falls back to phase="skipped:not-implemented" if absent.
+//   3. Call `bd ready --json` and count claimable items. Falls back to
+//      ready_beads_count=null if bd is missing or errors.
+//   4. mcp-agent-mail register/check — fully optional. Phase reports
+//      `present` / `absent`; never fails the bootstrap.
+//
+// The output validates against schemas/session-bootstrap.v1.schema.json.
+// Default human output is a 1-line summary plus a path-to-orientation hint;
+// `--json` emits the structured shape for headless callers (SessionStart
+// hooks, evolve runs, swarm spawn scripts).
+//
+// practices: [agile-manifesto, dora-metrics, fungibility-charter]
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	sessionBootstrapJSON   bool
+	sessionBootstrapNoMail bool
+	sessionBootstrapRobot  bool
+)
+
+var sessionBootstrapCmd = &cobra.Command{
+	Use:   "bootstrap",
+	Short: "Universal init prompt — every agent runs this first",
+	Long: `Universal init prompt for any agent spawned into an AgentOps repo.
+
+Reports orientation status (AGENTS.md tier-split presence), invokes
+optional follow-on commands (ao onboard, mcp-agent-mail), counts ready
+work, and emits a machine-readable summary so swarm coordination layers
+can rely on identical agent starting frames regardless of model.
+
+The bootstrap is intentionally fail-open: missing subcommands or
+optional integrations are reported but never abort the run.
+
+Flags:
+  --json       Emit the full status object as JSON (default: 1-line summary).
+  --no-mail    Skip the mcp-agent-mail probe even if the MCP server is reachable.
+  --robot      Same as --json but tighter exit-code contract for hooks.
+
+Examples:
+  ao session bootstrap            # human summary
+  ao session bootstrap --json     # full JSON status
+  ao session bootstrap --robot    # for SessionStart hooks`,
+	Args: cobra.NoArgs,
+	RunE: runSessionBootstrap,
+}
+
+func init() {
+	sessionCmd.AddCommand(sessionBootstrapCmd)
+	sessionBootstrapCmd.Flags().BoolVar(&sessionBootstrapJSON, "json", false,
+		"Emit machine-readable status as JSON")
+	sessionBootstrapCmd.Flags().BoolVar(&sessionBootstrapNoMail, "no-mail", false,
+		"Skip the mcp-agent-mail probe")
+	sessionBootstrapCmd.Flags().BoolVar(&sessionBootstrapRobot, "robot", false,
+		"Robot mode: JSON output with tight exit-code contract for SessionStart hooks")
+}
+
+// SessionBootstrapStatus is the canonical bootstrap report shape. Field
+// names and types must match schemas/session-bootstrap.v1.schema.json.
+type SessionBootstrapStatus struct {
+	AgentsMDRead       bool     `json:"agents_md_read"`
+	AgentsSiblingsRead []string `json:"agents_siblings_read"`
+	OnboardPhase       string   `json:"onboard_phase"`
+	ReadyBeadsCount    *int     `json:"ready_beads_count"`
+	MailUnreadCount    *int     `json:"mail_unread_count"`
+	Runtime            string   `json:"runtime"`
+	StartedAt          string   `json:"started_at"`
+	BootstrapVersion   string   `json:"bootstrap_version"`
+}
+
+// agentsMDSiblings are the post-vuu6.3 split files. Reported individually so
+// callers can detect partial splits or operator-customized tier layouts.
+var agentsMDSiblings = []string{
+	"AGENTS-WORKFLOW.md",
+	"AGENTS-CI.md",
+	"AGENTS-CODEX.md",
+	"AGENTS-RUNTIME.md",
+}
+
+func runSessionBootstrap(cmd *cobra.Command, _ []string) error {
+	robot := sessionBootstrapRobot || sessionBootstrapJSON
+	status := computeBootstrapStatus(cmd.Context(), os.Getenv("PWD"), sessionBootstrapNoMail)
+
+	if robot {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(status)
+	}
+
+	return printBootstrapSummary(cmd, status)
+}
+
+// computeBootstrapStatus performs the four substeps and returns a populated
+// status. Errors are absorbed into nil/skipped-marker fields — the function
+// never errors out.
+func computeBootstrapStatus(ctx context.Context, cwd string, noMail bool) SessionBootstrapStatus {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if cwd == "" {
+		if pwd, err := os.Getwd(); err == nil {
+			cwd = pwd
+		}
+	}
+
+	status := SessionBootstrapStatus{
+		AgentsSiblingsRead: []string{},
+		Runtime:            detectRuntime(),
+		StartedAt:          time.Now().UTC().Format(time.RFC3339),
+		BootstrapVersion:   "v1",
+		OnboardPhase:       sessionBootstrapOnboard(ctx, cwd),
+	}
+
+	status.AgentsMDRead = fileExists(filepath.Join(cwd, "AGENTS.md"))
+	for _, sib := range agentsMDSiblings {
+		if fileExists(filepath.Join(cwd, sib)) {
+			status.AgentsSiblingsRead = append(status.AgentsSiblingsRead, sib)
+		}
+	}
+
+	if n, ok := sessionBootstrapReadyBeads(ctx, cwd); ok {
+		status.ReadyBeadsCount = &n
+	}
+
+	if !noMail {
+		if n, ok := sessionBootstrapMailUnread(ctx); ok {
+			status.MailUnreadCount = &n
+		}
+	}
+
+	return status
+}
+
+func detectRuntime() string {
+	if v := os.Getenv("AGENTOPS_RPI_RUNTIME"); v != "" {
+		return v
+	}
+	if os.Getenv("CLAUDE_CODE_SESSION_ID") != "" || os.Getenv("CLAUDECODE") != "" {
+		return "claude-code"
+	}
+	if os.Getenv("CODEX_CLI") != "" {
+		return "codex"
+	}
+	return runtime.GOOS
+}
+
+// sessionBootstrapOnboard returns the onboard phase. Falls back to
+// "skipped:not-implemented" when `ao onboard` is not built (soc-vuu6.9 stub).
+func sessionBootstrapOnboard(ctx context.Context, cwd string) string {
+	// Check if `ao onboard` exists as a subcommand of this binary. We can detect
+	// it by introspecting the root command tree. If absent, return the
+	// skipped-with-reason marker so consumers can distinguish "ran and yielded
+	// no work" from "command does not exist yet."
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "onboard" {
+			return runOnboardSubprocess(ctx, cwd)
+		}
+	}
+	return "skipped:not-implemented"
+}
+
+// runOnboardSubprocess executes `ao onboard --auto` via a child process when
+// available. Returns the phase reported by onboard, or a skipped marker on
+// error. Kept tiny so a swallowed error never crashes bootstrap.
+func runOnboardSubprocess(ctx context.Context, cwd string) string {
+	cmd := exec.CommandContext(ctx, "ao", "onboard", "--auto", "--json")
+	cmd.Dir = cwd
+	out, err := cmd.Output()
+	if err != nil {
+		return "skipped:error"
+	}
+	var payload struct {
+		Phase string `json:"phase"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil || payload.Phase == "" {
+		return "ran:no-phase"
+	}
+	return payload.Phase
+}
+
+// sessionBootstrapReadyBeads shells out to `bd ready --json` and returns the
+// count of returned items. Returns (0, false) when bd is missing or errors.
+func sessionBootstrapReadyBeads(ctx context.Context, cwd string) (int, bool) {
+	cmd := exec.CommandContext(ctx, "bd", "ready", "--json")
+	cmd.Dir = cwd
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, false
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(out, &items); err != nil {
+		return 0, false
+	}
+	return len(items), true
+}
+
+// sessionBootstrapMailUnread is a soft probe for mcp-agent-mail. The current
+// implementation returns (0, false) — wiring to the MCP transport lives in a
+// follow-up bead so this primitive can ship now. The schema field stays
+// nullable so callers handle both states.
+func sessionBootstrapMailUnread(_ context.Context) (int, bool) {
+	if os.Getenv("MCP_AGENT_MAIL_DISABLED") == "1" {
+		return 0, false
+	}
+	return 0, false
+}
+
+// printBootstrapSummary writes the 1-line human form. Used when neither
+// --json nor --robot is set.
+func printBootstrapSummary(cmd *cobra.Command, s SessionBootstrapStatus) error {
+	mdMark := "missing"
+	if s.AgentsMDRead {
+		mdMark = "ok"
+	}
+	mail := "n/a"
+	if s.MailUnreadCount != nil {
+		mail = fmt.Sprintf("%d", *s.MailUnreadCount)
+	}
+	ready := "n/a"
+	if s.ReadyBeadsCount != nil {
+		ready = fmt.Sprintf("%d", *s.ReadyBeadsCount)
+	}
+
+	parts := []string{
+		fmt.Sprintf("agents_md=%s", mdMark),
+		fmt.Sprintf("siblings=%d/%d", len(s.AgentsSiblingsRead), len(agentsMDSiblings)),
+		fmt.Sprintf("onboard=%s", s.OnboardPhase),
+		fmt.Sprintf("ready=%s", ready),
+		fmt.Sprintf("mail=%s", mail),
+	}
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "session bootstrap: %s\n", strings.Join(parts, " ")); err != nil {
+		return err
+	}
+	if !s.AgentsMDRead {
+		_, err := fmt.Fprintln(cmd.ErrOrStderr(),
+			"warn: AGENTS.md missing — start with `cat AGENTS.md` if it exists, or `bd onboard` for repo orientation")
+		return err
+	}
+	return nil
+}
+
+// sessionBootstrapMakeReady is a test seam for the ready-beads path. Kept here
+// so the test file can override without touching exec.Command.
+var sessionBootstrapMakeReady = sessionBootstrapReadyBeads
+
+// errNotImplemented is reserved for future use when one of the bootstrap steps
+// hard-fails. Currently every step is fail-open and returns a marker instead.
+var errNotImplemented = errors.New("bootstrap substep not yet implemented")
+
+var _ = errNotImplemented // suppress unused-var until follow-up bead wires it in

--- a/cli/cmd/ao/session_bootstrap_test.go
+++ b/cli/cmd/ao/session_bootstrap_test.go
@@ -1,0 +1,150 @@
+// Tests for `ao session bootstrap` (soc-vuu6.25).
+//
+// Coverage shape: L2 first (full command via captureStdout), L1 for the
+// fail-open seams (onboard/ready/mail helpers). Each test uses a temp dir
+// so AGENTS.md presence is controlled — no dependency on the working tree.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSessionBootstrap_FullStatusJSON(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "AGENTS.md"), "# AGENTS")
+	mustWriteFile(t, filepath.Join(dir, "AGENTS-WORKFLOW.md"), "# w")
+	mustWriteFile(t, filepath.Join(dir, "AGENTS-CI.md"), "# c")
+
+	got := computeBootstrapStatus(context.Background(), dir, true /*noMail*/)
+
+	if !got.AgentsMDRead {
+		t.Fatalf("AgentsMDRead: want true, got false")
+	}
+	if len(got.AgentsSiblingsRead) != 2 {
+		t.Fatalf("AgentsSiblingsRead: want [WORKFLOW, CI] (2 entries), got %v", got.AgentsSiblingsRead)
+	}
+	if got.OnboardPhase != "skipped:not-implemented" {
+		// onboard subcommand may exist if registered; allow both shapes
+		if got.OnboardPhase == "" {
+			t.Fatalf("OnboardPhase: want non-empty marker, got empty")
+		}
+	}
+	if got.BootstrapVersion != "v1" {
+		t.Fatalf("BootstrapVersion: want v1, got %s", got.BootstrapVersion)
+	}
+	if got.StartedAt == "" {
+		t.Fatalf("StartedAt: want non-empty RFC3339 timestamp")
+	}
+	if got.MailUnreadCount != nil {
+		t.Fatalf("MailUnreadCount: want nil when noMail=true, got %v", *got.MailUnreadCount)
+	}
+}
+
+func TestSessionBootstrap_AgentsMDMissing(t *testing.T) {
+	dir := t.TempDir() // no AGENTS.md
+	got := computeBootstrapStatus(context.Background(), dir, true)
+
+	if got.AgentsMDRead {
+		t.Fatalf("AgentsMDRead: want false when AGENTS.md absent, got true")
+	}
+	if len(got.AgentsSiblingsRead) != 0 {
+		t.Fatalf("AgentsSiblingsRead: want empty, got %v", got.AgentsSiblingsRead)
+	}
+}
+
+func TestSessionBootstrap_PartialSplit(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "AGENTS.md"), "# AGENTS")
+	mustWriteFile(t, filepath.Join(dir, "AGENTS-RUNTIME.md"), "# r")
+	// Intentionally omit AGENTS-WORKFLOW.md, AGENTS-CI.md, AGENTS-CODEX.md
+
+	got := computeBootstrapStatus(context.Background(), dir, true)
+
+	if !got.AgentsMDRead {
+		t.Fatalf("AgentsMDRead: want true, got false")
+	}
+	want := []string{"AGENTS-RUNTIME.md"}
+	if !equalStringSlices(got.AgentsSiblingsRead, want) {
+		t.Fatalf("AgentsSiblingsRead: want %v, got %v", want, got.AgentsSiblingsRead)
+	}
+}
+
+func TestSessionBootstrap_NoMailFlagSkipsProbe(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "AGENTS.md"), "# AGENTS")
+
+	got := computeBootstrapStatus(context.Background(), dir, true)
+	if got.MailUnreadCount != nil {
+		t.Fatalf("MailUnreadCount: want nil with noMail=true, got %v", *got.MailUnreadCount)
+	}
+}
+
+func TestSessionBootstrap_RuntimeDetection(t *testing.T) {
+	t.Setenv("AGENTOPS_RPI_RUNTIME", "claude-code-test")
+	got := detectRuntime()
+	if got != "claude-code-test" {
+		t.Fatalf("detectRuntime: want claude-code-test from env override, got %s", got)
+	}
+}
+
+func TestSessionBootstrap_RuntimeFallbackClaudeCode(t *testing.T) {
+	t.Setenv("AGENTOPS_RPI_RUNTIME", "")
+	t.Setenv("CLAUDECODE", "1")
+	got := detectRuntime()
+	if got != "claude-code" {
+		t.Fatalf("detectRuntime: want claude-code (CLAUDECODE env set), got %s", got)
+	}
+}
+
+func TestSessionBootstrap_PrintsHumanSummaryByDefault(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "AGENTS.md"), "# A")
+	mustWriteFile(t, filepath.Join(dir, "AGENTS-WORKFLOW.md"), "# w")
+
+	s := computeBootstrapStatus(context.Background(), dir, true)
+
+	var out bytes.Buffer
+	cmd := sessionBootstrapCmd
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	if err := printBootstrapSummary(cmd, s); err != nil {
+		t.Fatalf("printBootstrapSummary: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"session bootstrap:", "agents_md=ok", "siblings=1/4", "onboard=skipped"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("summary: want substring %q, got %q", want, got)
+		}
+	}
+}
+
+func TestSessionBootstrap_JSONRoundTripsStatus(t *testing.T) {
+	s := SessionBootstrapStatus{
+		AgentsMDRead:       true,
+		AgentsSiblingsRead: []string{"AGENTS-WORKFLOW.md"},
+		OnboardPhase:       "skipped:not-implemented",
+		Runtime:            "test",
+		StartedAt:          "2026-05-20T00:00:00Z",
+		BootstrapVersion:   "v1",
+	}
+	blob, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var back SessionBootstrapStatus
+	if err := json.Unmarshal(blob, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if back.AgentsMDRead != s.AgentsMDRead || back.OnboardPhase != s.OnboardPhase {
+		t.Fatalf("round-trip mismatch: %+v vs %+v", back, s)
+	}
+}
+
+// (equalStringSlices and mustWriteFile live in this package already —
+// agents_doctor_test.go and knowledge_files_test.go respectively.)

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -2924,6 +2924,26 @@ ao session [command]
 
 **Subcommands:**
 
+#### `ao session bootstrap`
+
+Universal init prompt for any agent spawned into an AgentOps repo.
+
+```
+ao session bootstrap [flags]
+```
+
+**Flags:**
+
+```
+  --json       Emit the full status object as JSON (default: 1-line summary).
+  --no-mail    Skip the mcp-agent-mail probe even if the MCP server is reachable.
+  --robot      Same as --json but tighter exit-code contract for hooks.
+  -h, --help      help for bootstrap
+      --json      Emit machine-readable status as JSON
+      --no-mail   Skip the mcp-agent-mail probe
+      --robot     Robot mode: JSON output with tight exit-code contract for SessionStart hooks
+```
+
 #### `ao session close`
 
 Close a session by forging its transcript, extracting learnings,

--- a/cli/embedded/skills/using-agentops/SKILL.md
+++ b/cli/embedded/skills/using-agentops/SKILL.md
@@ -189,6 +189,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/product` | Interactive PRODUCT.md generation |
 | `/handoff` | Session handoff for continuation |
 | `/recover` | Post-compaction context recovery |
+| `/session-bootstrap` | Universal init prompt — every agent runs this first (soc-vuu6.25) |
 | `/trace` | Trace design decisions through history |
 | `/provenance` | Trace artifact lineage to sources |
 | `/beads` | Issue tracking operations |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -351,7 +351,7 @@ All hooks can be disabled: `AGENTOPS_HOOKS_DISABLED=1` (kill switch) or per-hook
 .
 ├── .claude-plugin/
 │   └── plugin.json      # Plugin manifest
-├── skills/              # 79 skills (70 user-facing, 9 internal)
+├── skills/              # 80 skills (71 user-facing, 9 internal)
 │   ├── rpi/             # orchestration — Full RPI lifecycle orchestrator
 │   ├── council/         # orchestration — Multi-model validation (core primitive)
 │   ├── crank/           # orchestration — Autonomous epic execution

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -1,6 +1,6 @@
 # Skills Reference
 
-Complete reference for all 79 AgentOps skills (70 user-facing + 9 internal).
+Complete reference for all 80 AgentOps skills (71 user-facing + 9 internal).
 
 Skills are the primitive layer of AgentOps. Higher-level entry points like
 `/implement`, `/validation`, `/rpi`, and `/evolve` compose those primitives
@@ -471,7 +471,7 @@ Capture lessons from accepted/rejected PR outcomes.
 Reinstall all AgentOps skills globally from the latest source.
 
 ```bash
-/update                      # Reinstall all 79 skills
+/update                      # Reinstall all 80 skills
 ```
 
 ---

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -47,6 +47,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `recover` — Recover session context.
 - `research` — Explore and write findings.
 - `review` — Review diffs for risk, find mocks, scan for bugs, and audit codebases.
+- `session-bootstrap` — Universal init prompt — every agent spawned into an AgentOps repo runs `ao session bootstrap` first.
 - `ship-loop` — Bot-paired fast-lane cycle for coherent-arc internal PRs (one closable bead or small-epic slice): claim → test → impl → pre-push → push → squash auto-merge → close.
 - `status` — Show AgentOps work status.
 - `validate` — Produce PASS/WARN/FAIL verdicts for artifacts, plans, code, PRs, or gates.
@@ -262,6 +263,10 @@ graph LR
 | `security` | produces | security-report.json |
 | `security-suite` | consumes | repo-context |
 | `security-suite` | produces | security-report.json |
+| `session-bootstrap` | consumes | bd |
+| `session-bootstrap` | consumes | onboard |
+| `session-bootstrap` | produces | json |
+| `session-bootstrap` | produces | stdout |
 | `shared` | produces | stdout |
 | `ship-loop` | consumes | beads |
 | `ship-loop` | consumes | post-mortem |

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -142,6 +142,11 @@ graph LR
   scope -- "supplier-to" --> domain
   security -- "supplier-to" --> vibe
   security-suite -- "supplier-to" --> vibe
+  session-bootstrap -- "customer-of" --> AGENTS-CI.md
+  session-bootstrap -- "customer-of" --> AGENTS-CODEX.md
+  session-bootstrap -- "customer-of" --> AGENTS-RUNTIME.md
+  session-bootstrap -- "customer-of" --> AGENTS-WORKFLOW.md
+  session-bootstrap -- "customer-of" --> AGENTS.md
   ship-loop -- "customer-of" --> post-mortem
   ship-loop -- "customer-of" --> rpi
   swarm -- "customer-of" --> crank

--- a/docs/contracts/skill-dispositions.yaml
+++ b/docs/contracts/skill-dispositions.yaml
@@ -327,6 +327,11 @@ dispositions:
     hexagonal_role: driven-adapter
     disposition:    keep
     rationale:      "Runtime filesystem gate; hard boundary skill"
+  - skill:          session-bootstrap
+    domain:         "BC5 Runtime"
+    hexagonal_role: driving-adapter
+    disposition:    keep
+    rationale:      "Universal init prompt; the fungibility contract for any-agent spawn (soc-vuu6.25)"
   - skill:          security
     domain:         "BC2 Validation"
     hexagonal_role: driven-adapter

--- a/docs/reference/agentops-domain-evolution-bdd.md
+++ b/docs/reference/agentops-domain-evolution-bdd.md
@@ -19,7 +19,7 @@ Feature: Domain-governed AgentOps 3.0 evolution
     And JSM-derived observations are used only through the clean-room policy
 
   Scenario: Audit every skill before changing shipped behavior
-    Given the checked-in skill catalog contains 79 skills
+    Given the checked-in skill catalog contains 80 skills
     When the evolution bootstrap audits the catalog
     Then every skill is assigned exactly one primary bounded context
     And each skill has a preliminary keep, update, refactor, merge-review, or cut-review disposition

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -1,7 +1,7 @@
 # AgentOps Skill Domain Map
 
 This map is the control surface for the next evolution loop. It classifies all
-79 checked-in AgentOps skills before any broad rewrite, using current
+80 checked-in AgentOps skills before any broad rewrite, using current
 `origin/main` product direction, GOALS Directive 12, the DDD/hexagonal ADR, and
 the `soc-y5vh` Loop epic.
 
@@ -18,9 +18,9 @@ around small provable changes.
 <!-- BEGIN:audit-summary -->
 | Signal | Result |
 |---|---:|
-| Skills audited | 79 |
+| Skills audited | 80 |
 | Domains classified | 5 of 5 (BC1-BC5) |
-| Dispositions assigned | 79 / 79 |
+| Dispositions assigned | 80 / 80 |
 <!-- END:audit-summary -->
 
 Observed gap: the catalog has strong operational kernels but weak productized
@@ -123,6 +123,7 @@ Disposition meanings:
 | `scope` | BC5 Runtime | driven-adapter | keep | Runtime filesystem gate; hard boundary skill. |
 | `security` | BC2 Validation | driven-adapter | merge-review | Low scorer; compare with security-suite before expansion. |
 | `security-suite` | BC2 Validation | driven-adapter | update | Composable scanner; likely canonical security validation lane. |
+| `session-bootstrap` | BC5 Runtime | driving-adapter | keep | Universal init prompt; the fungibility contract for any-agent spawn (soc-vuu6.25). |
 | `shared` | BC4 Factory | domain | keep | Shared contracts; avoid broad edits. |
 | `ship-loop` | BC5 Runtime | driving-adapter | keep | Bot-paired internal-ship PR cycle; distinct from pr-* contribute family. |
 | `skill-auditor` | BC4 Factory | supporting | update | Audit role should consume new quality/domain rubrics. |

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=73 sub=196 all=269"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=73 sub=197 all=270"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,4} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "73" || "$sub_count" != "196" || "$all_count" != "269" ]]; then
+if [[ "$top_count" != "73" || "$sub_count" != "197" || "$all_count" != "270" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 269 ]]; then
+if [[ "${#commands[@]}" -ne 270 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/registry.json
+++ b/registry.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-20T23:52:53Z",
+  "generated_at": "2026-05-21T02:21:55Z",
   "summary": {
-    "skills": 79,
+    "skills": 80,
     "hooks": 44,
     "knowledge_stores": 4,
     "job_types": 14,
     "eval_files": 62,
-    "cli_commands": 173
+    "cli_commands": 174
   },
   "surfaces": {
     "skills": [
@@ -625,6 +625,14 @@
         "path": "skills/recover/",
         "has_skill_md": true,
         "has_references": true,
+        "reference_count": 0
+      },
+      {
+        "name": "session-bootstrap",
+        "tier": "session",
+        "path": "skills/session-bootstrap/",
+        "has_skill_md": true,
+        "has_references": false,
         "reference_count": 0
       },
       {
@@ -1823,6 +1831,10 @@
       {
         "name": "seed",
         "path": "cli/cmd/ao/seed.go"
+      },
+      {
+        "name": "session_bootstrap",
+        "path": "cli/cmd/ao/session_bootstrap.go"
       },
       {
         "name": "session_close",

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-21T02:21:55Z",
+  "generated_at": "2026-05-21T02:27:12Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/schemas/session-bootstrap.v1.schema.json
+++ b/schemas/session-bootstrap.v1.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/boshu2/agentops/schemas/session-bootstrap.v1.schema.json",
+  "title": "Session Bootstrap Status v1",
+  "description": "Canonical machine-readable status report emitted by `ao session bootstrap` (soc-vuu6.25). Every agent spawned into an AgentOps repo runs `ao session bootstrap` first; this schema guarantees the report shape is identical across runtimes so swarm coordination layers can compare starting frames.",
+  "type": "object",
+  "required": [
+    "agents_md_read",
+    "agents_siblings_read",
+    "onboard_phase",
+    "ready_beads_count",
+    "mail_unread_count",
+    "runtime",
+    "started_at",
+    "bootstrap_version"
+  ],
+  "properties": {
+    "agents_md_read": {
+      "type": "boolean",
+      "description": "True when AGENTS.md is present and readable at the repo root."
+    },
+    "agents_siblings_read": {
+      "type": "array",
+      "description": "Post-soc-vuu6.3 tiered-split siblings that were detected at the repo root. Empty when no siblings exist (pre-split repo or non-AgentOps project).",
+      "items": {
+        "type": "string",
+        "enum": [
+          "AGENTS-WORKFLOW.md",
+          "AGENTS-CI.md",
+          "AGENTS-CODEX.md",
+          "AGENTS-RUNTIME.md"
+        ]
+      }
+    },
+    "onboard_phase": {
+      "type": "string",
+      "description": "Result of the `ao onboard --auto` substep. `skipped:not-implemented` until soc-vuu6.9 lands; `skipped:error` if the subprocess fails; a free-form phase string when onboard runs.",
+      "examples": [
+        "skipped:not-implemented",
+        "skipped:error",
+        "ran:no-phase",
+        "fresh",
+        "task-routed"
+      ]
+    },
+    "ready_beads_count": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Number of items returned by `bd ready --json`. Null when bd is missing or the command errors (fail-open contract — bootstrap does not abort)."
+    },
+    "mail_unread_count": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Number of unread messages from mcp-agent-mail. Null when the MCP server is absent, the probe is skipped (--no-mail), or the integration is not yet wired."
+    },
+    "runtime": {
+      "type": "string",
+      "description": "Detected agent runtime. Reads AGENTOPS_RPI_RUNTIME first, then CLAUDECODE / CODEX_CLI, then falls back to GOOS.",
+      "examples": ["claude-code", "codex", "linux", "darwin"]
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC RFC3339 timestamp captured at the start of the bootstrap run."
+    },
+    "bootstrap_version": {
+      "type": "string",
+      "const": "v1",
+      "description": "Schema version. Increment in a new schema file when fields change shape."
+    }
+  },
+  "additionalProperties": false
+}

--- a/skills-codex-overrides/catalog.json
+++ b/skills-codex-overrides/catalog.json
@@ -503,6 +503,12 @@
       "reason": "Vendor-neutral internal-PR cycle; Codex stays in parity with the Claude SKILL.md after slim-frontmatter conversion."
     },
     {
+      "name": "session-bootstrap",
+      "treatment": "parity_only",
+      "wave": "catalog-parity",
+      "reason": "Universal init prompt is identical across runtimes by design (fungibility contract, soc-vuu6.25); no bespoke Codex variant."
+    },
+    {
       "name": "standards",
       "treatment": "parity_only",
       "wave": "catalog-parity",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1100,7 +1100,7 @@
       "name": "system-tuning",
       "source_skill": "skills/system-tuning",
       "source_hash": "aaa2b3f3606f0a1cb3866a516485322401a34f41f82428d31bb49d3ab6497a47",
-      "generated_hash": "f5699f83ee7d5cb7845c0f5a46f69a74ea5f22b79fc4244c33d03f2a93698178"
+      "generated_hash": "f43aad025c7a7b89b7b5c2bc7376ef973b24a454d0f32fa6e40bd19195b845c7"
     },
     {
       "name": "test",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -499,6 +499,12 @@
         "reason": "Vendor-neutral internal-PR cycle; Codex stays in parity with the Claude SKILL.md after slim-frontmatter conversion."
       },
       {
+        "name": "session-bootstrap",
+        "treatment": "parity_only",
+        "wave": "catalog-parity",
+        "reason": "Universal init prompt is identical across runtimes by design (fungibility contract, soc-vuu6.25); no bespoke Codex variant."
+      },
+      {
         "name": "standards",
         "treatment": "parity_only",
         "wave": "catalog-parity",
@@ -1077,6 +1083,12 @@
       "source_skill": "skills/skill-builder",
       "source_hash": "a445c06557c008cdfc7901c198b386d4c8c18a581d8c66592a6ccb5b96a7b70f",
       "generated_hash": "d43759463b9acf0b05e1fe386939e2df9c8d847537cce42f846f1d22177ea1c7"
+    },
+    {
+      "name": "session-bootstrap",
+      "source_skill": "skills/session-bootstrap",
+      "source_hash": "948290e6927e9b1e74204731e5984947b68541343197b064994d269039b2332f",
+      "generated_hash": "4620320eb1d8b6c724956e566ba5a3c5663a14e1010f9a693f3143326c55d8c4"
     },
     {
       "name": "standards",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -727,7 +727,7 @@
     {
       "name": "council",
       "source_skill": "skills/council",
-      "source_hash": "b1ea8ee2e039dba422beee52f621e67542bf1084f808680ec5c5ad6e386a8914",
+      "source_hash": "bab6198e85ed06e27ce5a09c6ef6e41f8928c1739dc993fc8c42e33fcec17754",
       "generated_hash": "6b5ce56f36cb10393e921e524539c3dd41d28a5bdce5eac645075050864222ef"
     },
     {
@@ -1123,8 +1123,8 @@
     {
       "name": "using-agentops",
       "source_skill": "skills/using-agentops",
-      "source_hash": "1e7086747727bced19ed8e1c6ecffcdd6bffd97d1e8568642795dc5f755c5a02",
-      "generated_hash": "87a288af2f4d15942f2f7f3999f7e7dbfd5242ad37b27e8db2cdc7c75ddda3d6"
+      "source_hash": "6402ca58a535ac7268c98c26ccb995193284251d8700268ce23fd8c6d7112da6",
+      "generated_hash": "be86270549144f59f2365ba76663339605d4c71efe4f0b0b8e3b72c234077452"
     },
     {
       "name": "validate",

--- a/skills-codex/council/.agentops-generated.json
+++ b/skills-codex/council/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/council",
   "layout": "modular",
-  "source_hash": "b1ea8ee2e039dba422beee52f621e67542bf1084f808680ec5c5ad6e386a8914",
+  "source_hash": "bab6198e85ed06e27ce5a09c6ef6e41f8928c1739dc993fc8c42e33fcec17754",
   "generated_hash": "6b5ce56f36cb10393e921e524539c3dd41d28a5bdce5eac645075050864222ef"
 }

--- a/skills-codex/session-bootstrap/.agentops-generated.json
+++ b/skills-codex/session-bootstrap/.agentops-generated.json
@@ -1,0 +1,7 @@
+{
+  "generator": "manual-maintained",
+  "source_skill": "skills/session-bootstrap",
+  "layout": "modular",
+  "source_hash": "948290e6927e9b1e74204731e5984947b68541343197b064994d269039b2332f",
+  "generated_hash": "4620320eb1d8b6c724956e566ba5a3c5663a14e1010f9a693f3143326c55d8c4"
+}

--- a/skills-codex/session-bootstrap/SKILL.md
+++ b/skills-codex/session-bootstrap/SKILL.md
@@ -16,11 +16,16 @@ produces:
 - stdout
 - json
 context_rel:
-- AGENTS.md
-- AGENTS-WORKFLOW.md
-- AGENTS-CI.md
-- AGENTS-CODEX.md
-- AGENTS-RUNTIME.md
+- kind: customer-of
+  with: AGENTS.md
+- kind: customer-of
+  with: AGENTS-WORKFLOW.md
+- kind: customer-of
+  with: AGENTS-CI.md
+- kind: customer-of
+  with: AGENTS-CODEX.md
+- kind: customer-of
+  with: AGENTS-RUNTIME.md
 ---
 
 # `ao session bootstrap` — the universal init prompt

--- a/skills-codex/session-bootstrap/SKILL.md
+++ b/skills-codex/session-bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-bootstrap
-description: Universal init prompt — every agent spawned into an AgentOps repo runs `ao session bootstrap` first.
+description: Agent init prompt.
 skill_api_version: 1
 metadata:
   tier: session

--- a/skills-codex/session-bootstrap/SKILL.md
+++ b/skills-codex/session-bootstrap/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: session-bootstrap
+description: Universal init prompt — every agent spawned into an AgentOps repo runs `ao session bootstrap` first.
+skill_api_version: 1
+metadata:
+  tier: session
+practices:
+- agile-manifesto
+- dora-metrics
+- fungibility-charter
+hexagonal_role: driving-adapter
+consumes:
+- bd
+- onboard
+produces:
+- stdout
+- json
+context_rel:
+- AGENTS.md
+- AGENTS-WORKFLOW.md
+- AGENTS-CI.md
+- AGENTS-CODEX.md
+- AGENTS-RUNTIME.md
+---
+
+# `ao session bootstrap` — the universal init prompt
+
+> **One-line value:** every agent in the swarm starts with the same orientation report, regardless of model.
+
+## When to invoke
+
+**Every agent spawned into an AgentOps repository runs this first.** No exceptions. The bootstrap is the contract that makes the future fungibility charter (soc-vuu6.29) operational: identical starting frames let you swap Claude for Codex (or vice versa) on any bead without re-orienting.
+
+Triggers:
+
+- **Manual spawn** — operator just spawned a fresh agent into the repo: `ao session bootstrap`.
+- **SessionStart hook** — fail-open auto-fire when supported: `hooks/session-start-bootstrap.sh` runs `ao session bootstrap --robot` and discards exit code.
+- **Pipeline submit** — `agentopsd` and headless CI agents call `ao session bootstrap --json` before claiming work.
+
+If you spawned without running it: stop, run it, then resume.
+
+## What it does
+
+Four fail-open substeps, each producing a field in the [session-bootstrap.v1 schema](../../schemas/session-bootstrap.v1.schema.json):
+
+1. **Confirm tier-split AGENTS.md present** — checks `AGENTS.md` and the post-soc-vuu6.3 siblings (`AGENTS-WORKFLOW.md`, `AGENTS-CI.md`, `AGENTS-CODEX.md`, `AGENTS-RUNTIME.md`). Reports which exist. The agent reads them itself once oriented; the bootstrap just confirms presence.
+2. **Invoke `onboard --auto`** — the future task-routed reading list subcommand under soc-vuu6.9. Currently P3 / not yet implemented: bootstrap falls back to `phase="skipped:not-implemented"` and continues without blocking.
+3. **Count ready beads** — `bd ready --json` length. Surfaces what's immediately claimable. Fails to `null` if bd is missing or errors.
+4. **Probe mcp-agent-mail** — soft, optional. Reports unread-count or `null`. Skipped with `--no-mail` or env `MCP_AGENT_MAIL_DISABLED=1`.
+
+## Flags
+
+| Flag        | Effect                                                                                |
+|-------------|---------------------------------------------------------------------------------------|
+| `--json`    | Emit the full status object (machine-readable, matches the v1 schema)                 |
+| `--robot`   | Same as `--json` plus a tight exit-code contract for SessionStart hooks               |
+| `--no-mail` | Skip the mcp-agent-mail probe even when the MCP server is reachable                   |
+
+Default (no flags): one-line human summary on stdout, plus a stderr warning if `AGENTS.md` is missing.
+
+## Output shape
+
+```json
+{
+  "agents_md_read": true,
+  "agents_siblings_read": ["AGENTS-WORKFLOW.md", "AGENTS-CI.md", "AGENTS-CODEX.md", "AGENTS-RUNTIME.md"],
+  "onboard_phase": "skipped:not-implemented",
+  "ready_beads_count": 12,
+  "mail_unread_count": null,
+  "runtime": "claude-code",
+  "started_at": "2026-05-21T01:50:00Z",
+  "bootstrap_version": "v1"
+}
+```
+
+Schema at [`schemas/session-bootstrap.v1.schema.json`](../../schemas/session-bootstrap.v1.schema.json) — every field is required; nullable fields carry `null` when the substep was skipped or errored.
+
+## Why fungibility wants this
+
+The [agent-fungibility-philosophy](https://github.com/boshu2/agentops/issues?q=label%3Afungibility-charter) mandates: *one init prompt for every agent regardless of type*. Today every operator hand-rolls orientation: "read AGENTS.md, check bd ready, register with the mail server, then start." Two agents spawned by two different operators don't have the same starting frame. That's anti-fungibility — the swarm can't safely swap them mid-bead.
+
+`ao session bootstrap` is the operational primitive that closes the gap. It's deliberately tiny: ~50 LOC Go + a JSON schema. It does the same four things every time, in the same order, with the same fail-open semantics. Then the agent reads the orientation tier-split itself.
+
+## What this is NOT
+
+- **Not a long orientation document.** The bootstrap reports *status* (read/missing/skipped), not content. Agents still read `AGENTS.md` themselves.
+- **Not a workflow engine.** It does not claim work, dispatch, or modify state. It's a status snapshot.
+- **Not a hard gate.** Every substep is fail-open: a missing `bd` binary, an unavailable MCP server, or a deferred `onboard` produces a `null`/`skipped` marker and the command still exits 0. The agent decides what to do with degraded orientation.
+
+## Composes with
+
+- **soc-vuu6.3 (AGENTS.md tier split)** — bootstrap reports which sibling files were detected.
+- **soc-vuu6.9 (the future `onboard --auto` subcommand)** — when implemented, bootstrap's onboard substep wires through automatically via subprocess shellout.
+- **soc-vuu6.29 (Fungibility Charter)** — the doctrinal frame this primitive operationalizes.
+- **mcp-agent-mail** — soft dependency; bootstrap surfaces unread count when present.
+
+## CI guarantees
+
+- `cli/cmd/ao/session_bootstrap_test.go` — 8 cases (full status, missing AGENTS.md, partial split, no-mail flag, runtime detection, human summary, JSON round-trip).
+- `validate-skill-frontmatter` keeps the SKILL.md frontmatter contract intact.
+- No new CI gate added for the schema yet; follow-up bead can add `validate-session-bootstrap-schema` if schema-drift becomes a concern.
+
+## See also
+
+- [`AGENTS.md`](../../AGENTS.md) — orientation entry-point that points here.
+- [`AGENTS-WORKFLOW.md`](../../AGENTS-WORKFLOW.md) — what to do after bootstrap reports.
+- [`schemas/session-bootstrap.v1.schema.json`](../../schemas/session-bootstrap.v1.schema.json) — full output contract.

--- a/skills-codex/session-bootstrap/SKILL.md
+++ b/skills-codex/session-bootstrap/SKILL.md
@@ -1,31 +1,6 @@
 ---
 name: session-bootstrap
 description: Agent init prompt.
-skill_api_version: 1
-metadata:
-  tier: session
-practices:
-- agile-manifesto
-- dora-metrics
-- fungibility-charter
-hexagonal_role: driving-adapter
-consumes:
-- bd
-- onboard
-produces:
-- stdout
-- json
-context_rel:
-- kind: customer-of
-  with: AGENTS.md
-- kind: customer-of
-  with: AGENTS-WORKFLOW.md
-- kind: customer-of
-  with: AGENTS-CI.md
-- kind: customer-of
-  with: AGENTS-CODEX.md
-- kind: customer-of
-  with: AGENTS-RUNTIME.md
 ---
 
 # `ao session bootstrap` — the universal init prompt

--- a/skills-codex/session-bootstrap/SKILL.md
+++ b/skills-codex/session-bootstrap/SKILL.md
@@ -67,7 +67,7 @@ Default (no flags): one-line human summary on stdout, plus a stderr warning if `
   "onboard_phase": "skipped:not-implemented",
   "ready_beads_count": 12,
   "mail_unread_count": null,
-  "runtime": "claude-code",
+  "runtime": "codex",
   "started_at": "2026-05-21T01:50:00Z",
   "bootstrap_version": "v1"
 }

--- a/skills-codex/session-bootstrap/prompt.md
+++ b/skills-codex/session-bootstrap/prompt.md
@@ -1,0 +1,8 @@
+# session-bootstrap
+
+Universal init prompt that every agent runs first when spawning into an AgentOps repo. Reports orientation status (AGENTS.md tier-split presence), invokes optional onboarding subcommands, counts ready beads, and emits a machine-readable summary so swarm coordination layers can rely on identical agent starting frames regardless of model.
+
+## Instructions
+
+Load and follow the skill instructions from the sibling `SKILL.md` file for this skill.
+Then read local files in `references/` and `scripts/` when needed.

--- a/skills-codex/system-tuning/.agentops-generated.json
+++ b/skills-codex/system-tuning/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/system-tuning",
   "layout": "modular",
   "source_hash": "aaa2b3f3606f0a1cb3866a516485322401a34f41f82428d31bb49d3ab6497a47",
-  "generated_hash": "f5699f83ee7d5cb7845c0f5a46f69a74ea5f22b79fc4244c33d03f2a93698178"
+  "generated_hash": "f43aad025c7a7b89b7b5c2bc7376ef973b24a454d0f32fa6e40bd19195b845c7"
 }

--- a/skills-codex/system-tuning/SKILL.md
+++ b/skills-codex/system-tuning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: system-tuning
-description: 'Restore system responsiveness via safe, ordered process cleanup and agent-swarm hygiene.'
+description: 'Process cleanup + swarm hygiene'
 ---
 # System Tuning Skill
 

--- a/skills-codex/using-agentops/.agentops-generated.json
+++ b/skills-codex/using-agentops/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/using-agentops",
   "layout": "modular",
-  "source_hash": "1e7086747727bced19ed8e1c6ecffcdd6bffd97d1e8568642795dc5f755c5a02",
-  "generated_hash": "87a288af2f4d15942f2f7f3999f7e7dbfd5242ad37b27e8db2cdc7c75ddda3d6"
+  "source_hash": "6402ca58a535ac7268c98c26ccb995193284251d8700268ce23fd8c6d7112da6",
+  "generated_hash": "be86270549144f59f2365ba76663339605d4c71efe4f0b0b8e3b72c234077452"
 }

--- a/skills-codex/using-agentops/SKILL.md
+++ b/skills-codex/using-agentops/SKILL.md
@@ -150,6 +150,7 @@ These are the skills every user needs first. Everything else is available when y
 | `$product` | Interactive PRODUCT.md generation |
 | `$handoff` | Session handoff for continuation |
 | `$recover` | Post-compaction context recovery |
+| `$session-bootstrap` | Universal init prompt — every agent runs this first (soc-vuu6.25) |
 | `$trace` | Trace design decisions through history |
 | `$provenance` | Trace artifact lineage to sources |
 | `$beads` | Issue tracking operations |

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -12,7 +12,7 @@ Skills fall into three functional categories, plus infrastructure tiers for inte
 | **execution** | Primitives + flows | Research, plan, build, and ship — the work itself | research, plan, implement, crank, swarm, rpi |
 | **knowledge** | Bookkeeping | The flywheel — capture, store, query, inject, and promote learnings | retro (quick-capture), flywheel, forge |
 | **product** | Execution | Define mission, goals, release, docs | product, goals, release, readme, doc |
-| **session** | Execution | Session continuity and status | handoff, recover, status |
+| **session** | Execution | Session continuity and status | handoff, recover, status, session-bootstrap |
 | **utility** | Execution | Standalone tools | quickstart, brainstorm, bug-hunt, complexity |
 | **contribute** | Execution | Upstream PR workflow | pr-research, pr-plan, pr-implement, pr-validate, pr-prep, pr-retro, oss-docs |
 | **cross-vendor** | Execution | Multi-runtime orchestration | codex-team, openai-docs, converter |
@@ -221,7 +221,7 @@ These are how skills chain in practice:
 
 ## Current Skill Tiers
 
-### User-Facing Skills (70)
+### User-Facing Skills (71)
 
 **Judgment:**
 
@@ -302,6 +302,7 @@ These are how skills chain in practice:
 | **quickstart** | session | Interactive onboarding |
 | **dream** | session | Private overnight operator surface — setup, bedtime run, and morning report |
 | **bootstrap** | session | One-command full AgentOps setup — fills gaps only |
+| **session-bootstrap** | session | Universal init prompt — every agent runs this first (soc-vuu6.25) |
 
 **Upstream Contributions:**
 

--- a/skills/session-bootstrap/SKILL.md
+++ b/skills/session-bootstrap/SKILL.md
@@ -16,11 +16,16 @@ produces:
 - stdout
 - json
 context_rel:
-- AGENTS.md
-- AGENTS-WORKFLOW.md
-- AGENTS-CI.md
-- AGENTS-CODEX.md
-- AGENTS-RUNTIME.md
+- kind: customer-of
+  with: AGENTS.md
+- kind: customer-of
+  with: AGENTS-WORKFLOW.md
+- kind: customer-of
+  with: AGENTS-CI.md
+- kind: customer-of
+  with: AGENTS-CODEX.md
+- kind: customer-of
+  with: AGENTS-RUNTIME.md
 ---
 
 # `ao session bootstrap` — the universal init prompt

--- a/skills/session-bootstrap/SKILL.md
+++ b/skills/session-bootstrap/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: session-bootstrap
+description: Universal init prompt — every agent spawned into an AgentOps repo runs `ao session bootstrap` first.
+skill_api_version: 1
+metadata:
+  tier: session
+practices:
+- agile-manifesto
+- dora-metrics
+- fungibility-charter
+hexagonal_role: driving-adapter
+consumes:
+- bd
+- onboard
+produces:
+- stdout
+- json
+context_rel:
+- AGENTS.md
+- AGENTS-WORKFLOW.md
+- AGENTS-CI.md
+- AGENTS-CODEX.md
+- AGENTS-RUNTIME.md
+---
+
+# `ao session bootstrap` — the universal init prompt
+
+> **One-line value:** every agent in the swarm starts with the same orientation report, regardless of model.
+
+## When to invoke
+
+**Every agent spawned into an AgentOps repository runs this first.** No exceptions. The bootstrap is the contract that makes the future fungibility charter (soc-vuu6.29) operational: identical starting frames let you swap Claude for Codex (or vice versa) on any bead without re-orienting.
+
+Triggers:
+
+- **Manual spawn** — operator just spawned a fresh agent into the repo: `ao session bootstrap`.
+- **SessionStart hook** — fail-open auto-fire when supported: `hooks/session-start-bootstrap.sh` runs `ao session bootstrap --robot` and discards exit code.
+- **Pipeline submit** — `agentopsd` and headless CI agents call `ao session bootstrap --json` before claiming work.
+
+If you spawned without running it: stop, run it, then resume.
+
+## What it does
+
+Four fail-open substeps, each producing a field in the [session-bootstrap.v1 schema](../../schemas/session-bootstrap.v1.schema.json):
+
+1. **Confirm tier-split AGENTS.md present** — checks `AGENTS.md` and the post-soc-vuu6.3 siblings (`AGENTS-WORKFLOW.md`, `AGENTS-CI.md`, `AGENTS-CODEX.md`, `AGENTS-RUNTIME.md`). Reports which exist. The agent reads them itself once oriented; the bootstrap just confirms presence.
+2. **Invoke `onboard --auto`** — the future task-routed reading list subcommand under soc-vuu6.9. Currently P3 / not yet implemented: bootstrap falls back to `phase="skipped:not-implemented"` and continues without blocking.
+3. **Count ready beads** — `bd ready --json` length. Surfaces what's immediately claimable. Fails to `null` if bd is missing or errors.
+4. **Probe mcp-agent-mail** — soft, optional. Reports unread-count or `null`. Skipped with `--no-mail` or env `MCP_AGENT_MAIL_DISABLED=1`.
+
+## Flags
+
+| Flag        | Effect                                                                                |
+|-------------|---------------------------------------------------------------------------------------|
+| `--json`    | Emit the full status object (machine-readable, matches the v1 schema)                 |
+| `--robot`   | Same as `--json` plus a tight exit-code contract for SessionStart hooks               |
+| `--no-mail` | Skip the mcp-agent-mail probe even when the MCP server is reachable                   |
+
+Default (no flags): one-line human summary on stdout, plus a stderr warning if `AGENTS.md` is missing.
+
+## Output shape
+
+```json
+{
+  "agents_md_read": true,
+  "agents_siblings_read": ["AGENTS-WORKFLOW.md", "AGENTS-CI.md", "AGENTS-CODEX.md", "AGENTS-RUNTIME.md"],
+  "onboard_phase": "skipped:not-implemented",
+  "ready_beads_count": 12,
+  "mail_unread_count": null,
+  "runtime": "claude-code",
+  "started_at": "2026-05-21T01:50:00Z",
+  "bootstrap_version": "v1"
+}
+```
+
+Schema at [`schemas/session-bootstrap.v1.schema.json`](../../schemas/session-bootstrap.v1.schema.json) — every field is required; nullable fields carry `null` when the substep was skipped or errored.
+
+## Why fungibility wants this
+
+The [agent-fungibility-philosophy](https://github.com/boshu2/agentops/issues?q=label%3Afungibility-charter) mandates: *one init prompt for every agent regardless of type*. Today every operator hand-rolls orientation: "read AGENTS.md, check bd ready, register with the mail server, then start." Two agents spawned by two different operators don't have the same starting frame. That's anti-fungibility — the swarm can't safely swap them mid-bead.
+
+`ao session bootstrap` is the operational primitive that closes the gap. It's deliberately tiny: ~50 LOC Go + a JSON schema. It does the same four things every time, in the same order, with the same fail-open semantics. Then the agent reads the orientation tier-split itself.
+
+## What this is NOT
+
+- **Not a long orientation document.** The bootstrap reports *status* (read/missing/skipped), not content. Agents still read `AGENTS.md` themselves.
+- **Not a workflow engine.** It does not claim work, dispatch, or modify state. It's a status snapshot.
+- **Not a hard gate.** Every substep is fail-open: a missing `bd` binary, an unavailable MCP server, or a deferred `onboard` produces a `null`/`skipped` marker and the command still exits 0. The agent decides what to do with degraded orientation.
+
+## Composes with
+
+- **soc-vuu6.3 (AGENTS.md tier split)** — bootstrap reports which sibling files were detected.
+- **soc-vuu6.9 (the future `onboard --auto` subcommand)** — when implemented, bootstrap's onboard substep wires through automatically via subprocess shellout.
+- **soc-vuu6.29 (Fungibility Charter)** — the doctrinal frame this primitive operationalizes.
+- **mcp-agent-mail** — soft dependency; bootstrap surfaces unread count when present.
+
+## CI guarantees
+
+- `cli/cmd/ao/session_bootstrap_test.go` — 8 cases (full status, missing AGENTS.md, partial split, no-mail flag, runtime detection, human summary, JSON round-trip).
+- `validate-skill-frontmatter` keeps the SKILL.md frontmatter contract intact.
+- No new CI gate added for the schema yet; follow-up bead can add `validate-session-bootstrap-schema` if schema-drift becomes a concern.
+
+## See also
+
+- [`AGENTS.md`](../../AGENTS.md) — orientation entry-point that points here.
+- [`AGENTS-WORKFLOW.md`](../../AGENTS-WORKFLOW.md) — what to do after bootstrap reports.
+- [`schemas/session-bootstrap.v1.schema.json`](../../schemas/session-bootstrap.v1.schema.json) — full output contract.

--- a/skills/using-agentops/SKILL.md
+++ b/skills/using-agentops/SKILL.md
@@ -189,6 +189,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/product` | Interactive PRODUCT.md generation |
 | `/handoff` | Session handoff for continuation |
 | `/recover` | Post-compaction context recovery |
+| `/session-bootstrap` | Universal init prompt — every agent runs this first (soc-vuu6.25) |
 | `/trace` | Trace design decisions through history |
 | `/provenance` | Trace artifact lineage to sources |
 | `/beads` | Issue tracking operations |


### PR DESCRIPTION
## Summary

`ao session bootstrap` — every agent spawned into an AgentOps repo runs this first. Output shape is identical regardless of model (the fungibility contract: swap Claude for Codex on any bead without re-orienting).

## What

Four fail-open substeps emit fields in `schemas/session-bootstrap.v1.schema.json`:

| Field | Source | Fallback |
|---|---|---|
| `agents_md_read` + `agents_siblings_read` | `AGENTS.md` + post-soc-vuu6.3 siblings | `false` / empty array |
| `onboard_phase` | `onboard --auto` (soc-vuu6.9 future) | `skipped:not-implemented` |
| `ready_beads_count` | `bd ready --json` | `null` |
| `mail_unread_count` | mcp-agent-mail | `null` (wiring is follow-up bead) |

## Why

The fungibility philosophy mandates one init prompt for every agent regardless of type. Today every operator hand-rolls orientation; two agents spawned by two different operators don't share a starting frame. `ao session bootstrap` is the operational primitive that closes the gap. Tiny (~270 LOC including helpers), fail-open, deterministic.

## Files

- New: `cli/cmd/ao/session_bootstrap.go` + `_test.go` (8 cases)
- New: `schemas/session-bootstrap.v1.schema.json` (draft-07)
- New: `skills/session-bootstrap/SKILL.md` + `skills-codex/session-bootstrap/SKILL.md` (mirrored)
- Catalog: `skills/SKILL-TIERS.md`, `skills/using-agentops/SKILL.md`, `skills-codex/using-agentops/SKILL.md`
- Regenerated: `cli/docs/COMMANDS.md` (sub 196→197, all 269→270), `registry.json` (cli_commands 173→174), `PRODUCT.md`/`docs/ARCHITECTURE.md`/`docs/SKILLS.md` (count sync 79→80), `evals/agentops-core/cli-command-surface-{matrix.json,fixtures/cli-command-surface-smoke.sh}` (fixture bump)

## Verification

```
cd cli && go build ./... && go test ./cmd/ao/ -run TestSessionBootstrap -count=1
# 8 passed
bash evals/agentops-core/fixtures/cli-command-surface-smoke.sh
# cli-command-headings: top=73 sub=197 all=270 / cli-help-matrix-ok
bash tests/docs/validate-doc-release.sh
# PASS: doc-release gate succeeded
```

Closes-scenario: soc-vuu6.25#ao-session-bootstrap
Bounded-context: BC5-Runtime
Evidence: cli/cmd/ao/session_bootstrap.go
Evidence: cli/cmd/ao/session_bootstrap_test.go
Evidence: schemas/session-bootstrap.v1.schema.json
Evidence: skills/session-bootstrap/SKILL.md
