### PR TITLE
fix(evolve): never sticky-dormancy while beads exist; context exhaustion is handoff, not stop (soc-5qit #agile-invariant)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -787,8 +787,8 @@
     {
       "name": "evolve",
       "source_skill": "skills/evolve",
-      "source_hash": "9c61b897ebb3feb7c3e97daf46607c0271dc53d65942843b6cfd14e4f27b2e21",
-      "generated_hash": "80e31259757aa9a5fe5176980e7599c45c233fd63f60d627cf6a5d64c55b77e9"
+      "source_hash": "c0a4871168fd5024d1e907570c8809143c4f4044fd93f09646b48c59ee1f1962",
+      "generated_hash": "5c8274c6606089b1a2854015f0f0f5176ed49806e3a6e9fce10749eeabffd01f"
     },
     {
       "name": "expert-council",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -787,8 +787,8 @@
     {
       "name": "evolve",
       "source_skill": "skills/evolve",
-      "source_hash": "5333d71c0b335c625985e56f14c689e46c5e06600d925c07fe2211f1c82cfcb3",
-      "generated_hash": "6d6c681737a53627db803b36ffe3e0fcfcf82e788d65794ae1300e74894fef29"
+      "source_hash": "9c61b897ebb3feb7c3e97daf46607c0271dc53d65942843b6cfd14e4f27b2e21",
+      "generated_hash": "80e31259757aa9a5fe5176980e7599c45c233fd63f60d627cf6a5d64c55b77e9"
     },
     {
       "name": "expert-council",

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/evolve",
   "layout": "modular",
-  "source_hash": "5333d71c0b335c625985e56f14c689e46c5e06600d925c07fe2211f1c82cfcb3",
-  "generated_hash": "6d6c681737a53627db803b36ffe3e0fcfcf82e788d65794ae1300e74894fef29"
+  "source_hash": "9c61b897ebb3feb7c3e97daf46607c0271dc53d65942843b6cfd14e4f27b2e21",
+  "generated_hash": "80e31259757aa9a5fe5176980e7599c45c233fd63f60d627cf6a5d64c55b77e9"
 }

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/evolve",
   "layout": "modular",
-  "source_hash": "9c61b897ebb3feb7c3e97daf46607c0271dc53d65942843b6cfd14e4f27b2e21",
-  "generated_hash": "80e31259757aa9a5fe5176980e7599c45c233fd63f60d627cf6a5d64c55b77e9"
+  "source_hash": "c0a4871168fd5024d1e907570c8809143c4f4044fd93f09646b48c59ee1f1962",
+  "generated_hash": "5c8274c6606089b1a2854015f0f0f5176ed49806e3a6e9fce10749eeabffd01f"
 }

--- a/skills-codex/evolve/SKILL.md
+++ b/skills-codex/evolve/SKILL.md
@@ -435,31 +435,23 @@ When evolve picks a finding, claim it first in next-work.jsonl:
 
 See `references/quality-mode.md` for scoring and full details.
 
-**Nothing found?** HARD GATE — dormancy is only legal when ALL work sources are genuinely empty (soc-5qit):
+**Nothing found?** HARD GATE — dormancy only when ALL sources empty (soc-5qit):
 
 ```bash
-# Hard predicate: every source must be empty. Any one source with work => loop continues.
 READY_BEADS=$(bd ready --json 2>/dev/null | jq -r 'length // 0' 2>/dev/null || echo 0)
 HARVESTED=$(jq -r 'select(.consumed==false) | .severity' .agents/rpi/next-work.jsonl 2>/dev/null | wc -l | tr -d ' ')
 FAILING_GOALS=$(jq -r '.goals[] | select(.result=="fail") | .id' .agents/evolve/fitness-latest.json 2>/dev/null | wc -l | tr -d ' ')
 
 if [ "$READY_BEADS" -gt 0 ] || [ "$HARVESTED" -gt 0 ] || [ "$FAILING_GOALS" -gt 0 ]; then
-  echo "Hard-gate refused: ready=$READY_BEADS harvested=$HARVESTED failing-goals=$FAILING_GOALS. Loop back to Step 3."
-  # Agile invariant: open beads => $evolve runs.
-  continue
+  continue  # work exists — loop back to Step 3 (agile invariant)
 fi
-
-# Count trailing idle/unchanged entries in cycle-history.jsonl (portable, no tac)
-IDLE_STREAK=$(awk '/"result"\s*:\s*"(idle|unchanged)"/{streak++; next} {streak=0} END{print streak+0}' \
-  .agents/evolve/cycle-history.jsonl 2>/dev/null)
-
+IDLE_STREAK=$(awk '/"result"\s*:\s*"(idle|unchanged)"/{streak++; next} {streak=0} END{print streak+0}' .agents/evolve/cycle-history.jsonl 2>/dev/null)
 if [ "$GENERATOR_EMPTY_STREAK" -ge 2 ] && [ "$IDLE_STREAK" -ge 2 ]; then
-  # Work layers AND producer layers empty for 3 consecutive passes — STOP
-  echo "Genuine stagnation: nothing actionable across every source. Operator can create work."
+  echo "Genuine stagnation: all sources empty x3."
 fi
 ```
 
-**Agile invariant (soc-5qit):** if `bd ready` returns ≥1 unblocked bead, the loop NEVER stops — it loops back to Step 3 and claims one. The only path to stagnation-STOP is a fully empty backlog AND fully empty generator output. Context exhaustion is NOT in this predicate (see `references/context-budget.md` for HANDOFF semantics — a non-sticky session-handoff that the next cron-fire clears).
+**Agile invariant (soc-5qit):** `bd ready ≥ 1` ⇒ loop NEVER stops. Only path to stagnation-STOP is fully empty backlog + dry generators. Context exhaustion → write non-sticky `.agents/evolve/HANDOFF`, exit turn; next fire (compacted/fresh) clears HANDOFF in Step 1 and continues.
 
 If the work layers were empty but a generator pass has not been exhausted 3 times yet, persist the new generator streak in `session-state.json` and loop back to Step 1. Empty pre-cycle work sources are not a stop reason by themselves.
 

--- a/skills-codex/evolve/SKILL.md
+++ b/skills-codex/evolve/SKILL.md
@@ -435,19 +435,31 @@ When evolve picks a finding, claim it first in next-work.jsonl:
 
 See `references/quality-mode.md` for scoring and full details.
 
-**Nothing found?** HARD GATE — only consider dormancy after the generator layers also came up empty:
+**Nothing found?** HARD GATE — dormancy is only legal when ALL work sources are genuinely empty (soc-5qit):
 
 ```bash
+# Hard predicate: every source must be empty. Any one source with work => loop continues.
+READY_BEADS=$(bd ready --json 2>/dev/null | jq -r 'length // 0' 2>/dev/null || echo 0)
+HARVESTED=$(jq -r 'select(.consumed==false) | .severity' .agents/rpi/next-work.jsonl 2>/dev/null | wc -l | tr -d ' ')
+FAILING_GOALS=$(jq -r '.goals[] | select(.result=="fail") | .id' .agents/evolve/fitness-latest.json 2>/dev/null | wc -l | tr -d ' ')
+
+if [ "$READY_BEADS" -gt 0 ] || [ "$HARVESTED" -gt 0 ] || [ "$FAILING_GOALS" -gt 0 ]; then
+  echo "Hard-gate refused: ready=$READY_BEADS harvested=$HARVESTED failing-goals=$FAILING_GOALS. Loop back to Step 3."
+  # Agile invariant: open beads => $evolve runs.
+  continue
+fi
+
 # Count trailing idle/unchanged entries in cycle-history.jsonl (portable, no tac)
 IDLE_STREAK=$(awk '/"result"\s*:\s*"(idle|unchanged)"/{streak++; next} {streak=0} END{print streak+0}' \
   .agents/evolve/cycle-history.jsonl 2>/dev/null)
 
 if [ "$GENERATOR_EMPTY_STREAK" -ge 2 ] && [ "$IDLE_STREAK" -ge 2 ]; then
-  # Work layers are empty AND producer layers were empty for the 3rd consecutive pass — STOP
-  echo "Stagnation reached after repeated empty work + generator passes. Dormancy is the last-resort outcome."
-  # go to Teardown — do NOT log another idle entry
+  # Work layers AND producer layers empty for 3 consecutive passes — STOP
+  echo "Genuine stagnation: nothing actionable across every source. Operator can create work."
 fi
 ```
+
+**Agile invariant (soc-5qit):** if `bd ready` returns ≥1 unblocked bead, the loop NEVER stops — it loops back to Step 3 and claims one. The only path to stagnation-STOP is a fully empty backlog AND fully empty generator output. Context exhaustion is NOT in this predicate (see `references/context-budget.md` for HANDOFF semantics — a non-sticky session-handoff that the next cron-fire clears).
 
 If the work layers were empty but a generator pass has not been exhausted 3 times yet, persist the new generator streak in `session-state.json` and loop back to Step 1. Empty pre-cycle work sources are not a stop reason by themselves.
 

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -225,12 +225,34 @@ if check_stale_kill .agents/evolve/STOP "$EVOLVE_KILL_TTL_DAYS"; then
     echo "STOP: $(cat .agents/evolve/STOP 2>/dev/null)"
     exit 0
 fi
-[ -f .agents/evolve/DORMANT ] && echo "Dormant since $(head -1 .agents/evolve/DORMANT 2>/dev/null)." && exit 0
+if [ -f .agents/evolve/DORMANT ]; then
+  # DORMANT is honored only if the work queues that triggered it are STILL empty.
+  # Stale DORMANT (from a previous session) auto-clears the moment real work exists,
+  # because evolution is agile: open beads => /evolve runs. No exceptions.
+  READY=$(bd ready --json 2>/dev/null | jq -r 'length // 0' 2>/dev/null || echo 0)
+  HARVESTED=$(jq -r 'select(.consumed==false) | .severity' .agents/rpi/next-work.jsonl 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$READY" -gt 0 ] || [ "$HARVESTED" -gt 0 ]; then
+    echo "DORMANT auto-clearing: ready=$READY harvested=$HARVESTED — work exists, loop resumes."
+    rm -f .agents/evolve/DORMANT
+  else
+    echo "Dormant since $(head -1 .agents/evolve/DORMANT 2>/dev/null) — bd ready and next-work.jsonl both empty."
+    exit 0
+  fi
+fi
+[ -f .agents/evolve/HANDOFF ] && {
+  # HANDOFF is a non-sticky signal: prior session's context was heavy and asked for
+  # a fresh-context handoff. If we're here, this turn IS the fresh context (harness
+  # compaction or new session). Clear the signal and continue normally.
+  echo "HANDOFF cleared: $(head -1 .agents/evolve/HANDOFF 2>/dev/null)"
+  rm -f .agents/evolve/HANDOFF
+}
 ```
 
-**Sticky dormancy:** the `DORMANT` marker is written once when the Step 3 hard-gate fires (see "Nothing found?" section). Subsequent cycles short-circuit here with zero further tool calls — no fitness measurement, no work selection, no inference burn. Operator clears it by `rm .agents/evolve/DORMANT` when new scope arrives, or by editing it to indicate why. The marker is local-only (gitignored under `.agents/`).
+**Agile-first dormancy (soc-5qit):** `DORMANT` is NEVER sticky while open ready beads exist. Step 1 re-validates the dormancy predicate (`bd ready` empty AND harvested queue empty) every cron-fire — if either has work, DORMANT auto-clears and the loop resumes. The only way DORMANT actually short-circuits is if there is *genuinely nothing to do* AND the operator hasn't created new work. This replaces the prior "sticky-until-operator-clears" behavior that was waterfall, not evolutionary.
 
-**Stale-kill auto-expiration:** the KILL and STOP markers honor an EVOLVE_KILL_TTL_DAYS (default 7) age window. A KILL older than the window is logged as STALE and the loop continues — caught the F5 failure mode on 2026-05-18 where a 5-day-old KILL silently blocked /evolve. DORMANT does NOT auto-expire (it represents a deliberate "queue exhausted" state and should persist until the operator clears it).
+**Stale-kill auto-expiration:** the KILL and STOP markers honor an EVOLVE_KILL_TTL_DAYS (default 7) age window. A KILL older than the window is logged as STALE and the loop continues — caught the F5 failure mode on 2026-05-18 where a 5-day-old KILL silently blocked /evolve.
+
+**Context exhaustion is not a stop (soc-5qit):** when a session's context is too heavy to safely execute available work, /evolve writes a non-sticky `.agents/evolve/HANDOFF` marker and exits the current turn cleanly. The next cron-fire — running on harness-compacted context or a fresh session — automatically clears HANDOFF in Step 1 and resumes normal work selection. HANDOFF NEVER writes DORMANT; the loop is continuous across compactions.
 
 ### Step 1.5: Healing-first classifier
 
@@ -251,9 +273,19 @@ When a repo-local program contract exists, apply a scope filter before Step 4:
 - prefer harvested, beads, goals, and generated work that can plausibly land within mutable scope
 - if the selected item is inherently out of scope, escalate it or convert it into durable follow-up work instead of invoking `/rpi` and hoping discovery widens scope
 
-**Step 3.0: Scope filter — route wrong-shape work to scout-mode**
+**Step 3.0: Scope filter — split-or-defer, never bail (soc-5qit)**
 
-Before claiming a harvested item, gate scope vs session budget. If the work touches > 5 non-uniform files, introduces a new shape (schema field, struct field, validator rule, contract surface), is operator-level epic work, OR `PRODUCTIVE_THIS_SESSION > 5` and the work would extend an implementation arc rather than close one — route to **scout-mode** (read + annotate the queue entry, no execution). See `references/scout-mode.md` for the procedure and `references/mechanical-batches.md` for when a >5-file batch is uniform enough to bypass.
+Before claiming a candidate work item, gate scope vs session budget. If the work touches > 5 non-uniform files, introduces a new shape (schema field, struct field, validator rule, contract surface), is operator-level epic work, OR `PRODUCTIVE_THIS_SESSION > 5` and the work would extend an implementation arc rather than close one — route to **scout-mode**.
+
+Scout-mode is **work**, not a stop. The scout cycle MUST produce one of:
+
+1. **Split** — run `bd create` to decompose the too-big candidate into 2-N smaller child beads (each ≤5 files, single-shape) with `--deps discovered-from:<parent-id>`, annotate the parent with the disposition, then **re-enter Step 3** so the smallest new child (or another ready bead) gets claimed THIS cycle.
+2. **Defer** — annotate the candidate with disposition `defer:<reason>`, then **re-enter Step 3** so the next-priority ready bead gets claimed THIS cycle. The big candidate stays available for a future cycle.
+3. **Park** (rare) — operator-level epic with no obvious split; `bd update <id> --status blocked --notes "scope-too-big: <why>"` and re-enter Step 3 for the next ready bead.
+
+Scout NEVER returns "no work done." If `bd ready` returns ≥1 unblocked bead, the loop MUST claim and work one of them this cycle — either the smaller child it just created, or a smaller-scope sibling already in the queue.
+
+See `references/scout-mode.md` for the split/defer procedure and `references/mechanical-batches.md` for when a >5-file batch is uniform enough to bypass scope-filter entirely.
 
 **Metronome gate:** read `mode_repeat_streak` from `session-state.json` (kept current by `scripts/evolve-update-session-state.sh`). If `mode_repeat_streak >= 3` AND the candidate work would produce the same `mode` value as the trailing run, BLOCK selection at this rung and force a jump to the NEXT rung in the ladder. If `mode_repeat_streak >= 5`, file a `bd remember "metronome-N: <mode>"` and require operator override before continuing on that rung. See `references/metronome-gate.md` for the detection rule and the cycles 144-154 retrospective.
 
@@ -377,17 +409,31 @@ When evolve picks a finding, claim it first in next-work.jsonl:
 
 See `references/quality-mode.md` for scoring and full details.
 
-**Nothing found?** HARD GATE — only consider dormancy after the generator layers also came up empty:
+**Nothing found?** HARD GATE — dormancy is only legal when ALL work sources are genuinely empty (soc-5qit):
 
 ```bash
+# Hard predicate: every source must be empty. Any one source with work => loop continues.
+READY_BEADS=$(bd ready --json 2>/dev/null | jq -r 'length // 0' 2>/dev/null || echo 0)
+HARVESTED=$(jq -r 'select(.consumed==false) | .severity' .agents/rpi/next-work.jsonl 2>/dev/null | wc -l | tr -d ' ')
+FAILING_GOALS=$(jq -r '.goals[] | select(.result=="fail") | .id' .agents/evolve/fitness-latest.json 2>/dev/null | wc -l | tr -d ' ')
 IDLE_STREAK=$(jq -r '.idle_streak // 0' .agents/evolve/session-state.json 2>/dev/null)
+
+if [ "$READY_BEADS" -gt 0 ] || [ "$HARVESTED" -gt 0 ] || [ "$FAILING_GOALS" -gt 0 ]; then
+  echo "Hard-gate refused: ready=$READY_BEADS harvested=$HARVESTED failing-goals=$FAILING_GOALS. Loop back to Step 3."
+  # MUST loop back to Step 3 — work exists. This is the agile invariant: open beads => /evolve runs.
+  continue
+fi
+
 if [ "${GENERATOR_EMPTY_STREAK:-0}" -ge 2 ] && [ "${IDLE_STREAK:-0}" -ge 2 ]; then
-  printf '%s\n%s\n%s\n' "cycle $CYCLE" "$(date -u +%FT%TZ)" "stagnation: queue+generator empty x3" \
+  printf '%s\n%s\n%s\n' "cycle $CYCLE" "$(date -u +%FT%TZ)" \
+    "stagnation: bd ready=0, harvested=0, failing-goals=0, generators dry x3" \
     > .agents/evolve/DORMANT
-  echo "Stagnation reached after repeated empty work + generator passes. Dormancy is the last-resort outcome."
-  # go to Teardown — do NOT log another idle entry. The DORMANT marker short-circuits Step 1 next fire.
+  echo "Genuine stagnation: nothing actionable across every source. Operator can create work."
+  # DORMANT auto-clears in Step 1 next fire if `bd create` adds a new ready bead.
 fi
 ```
+
+**Agile invariant (soc-5qit):** if `bd ready` returns ≥1 unblocked bead, the loop NEVER writes DORMANT and NEVER exits — it loops back to Step 3 and claims one. The only path to DORMANT is a fully empty backlog AND fully empty generator output. Context exhaustion is not in this predicate (see Step 7 / `references/context-budget.md` for HANDOFF semantics).
 
 If the work layers were empty but a generator pass has not been exhausted 3 times yet, persist the new generator streak in `session-state.json` and loop back to Step 1. Empty pre-cycle work sources are not a stop reason by themselves.
 
@@ -466,19 +512,28 @@ Two paths: productive cycles get committed, idle cycles are local-only.
 ```bash
 while true; do
   # Step 1 .. Step 6
-  # Stop if kill switch, max-cycles, dormancy, or CONTEXT_BUDGET_EXHAUSTED
-  # Otherwise increment cycle and re-enter selection
+  # Stop ONLY if: operator override (KILL/STOP), max-cycles, regression-breaker,
+  # or genuine stagnation (bd ready=0 AND harvested=0 AND failing-goals=0 AND
+  # generators dry across 3 passes). Context exhaustion is NOT a stop — it's a
+  # session-handoff signal (HANDOFF marker) that the next cron-fire clears.
   CYCLE=$((CYCLE + 1))
 done
 ```
 
-**Stop reasons (any one terminates the loop):**
+**Stop reasons (soc-5qit, ALL require genuine reason — never just context size):**
 
-1. KILL/STOP file present.
-2. `--max-cycles=N` cap reached.
-3. **Dormancy** — `IDLE_STREAK >= 2 AND GENERATOR_EMPTY_STREAK >= 2` (queue layers AND generator layers both empty across 3 consecutive passes).
-4. **CONTEXT_BUDGET_EXHAUSTED** — `context_streak >= 2` (two consecutive cycles forced into scout-mode or harvested-as-defer because the current context is too heavy to safely execute available work). See `references/context-budget.md`.
-5. Regression breaker after a revert.
+1. **KILL/STOP file present** — operator override.
+2. **`--max-cycles=N` cap reached** — explicit operator-set limit.
+3. **Genuine stagnation** — `bd ready=0 AND harvested-unconsumed=0 AND failing-goals=0 AND GENERATOR_EMPTY_STREAK>=2 AND IDLE_STREAK>=2`. Writes DORMANT, which auto-clears in Step 1 the moment `bd create` adds a new ready bead.
+4. **Regression breaker after a revert** — the cycle reverted real damage; next cycle waits for operator to acknowledge.
+
+**Context exhaustion is NOT a stop reason (soc-5qit).** When a session's context grows too heavy for safe execution, /evolve:
+1. Writes `.agents/evolve/HANDOFF` (non-sticky, name only — not a marker file like DORMANT)
+2. Logs the parked work refs in `cycle-history.jsonl` with `result: "context-handoff"`
+3. Exits THIS cron-fire turn cleanly (no `ScheduleWakeup` re-arm needed — cron does it)
+4. The next cron-fire (running on harness-compacted context or a fresh session) clears HANDOFF in Step 1 and claims work normally
+
+The loop is continuous across compactions. If you're tempted to write DORMANT because "context is full," you're wrong — write HANDOFF and let the next cron-fire pick up where you left off. See `references/context-budget.md`.
 
 **Mandatory checkpoint #6 — session-PR threshold (NOT terminal, gates next cycle):** at `session_pr_count >= 5` (soc-waxr default), invoke `/post-mortem --deep`, wait for verdict file. PASS → continue. WARN → continue with caveat in next cycle's `notes`. FAIL or non-convergence → write STOP. Agent MUST NOT self-grade or self-write STOP. Full procedure in `references/postmortem-checkpoint.md` (soc-n75z).
 

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -226,33 +226,18 @@ if check_stale_kill .agents/evolve/STOP "$EVOLVE_KILL_TTL_DAYS"; then
     exit 0
 fi
 if [ -f .agents/evolve/DORMANT ]; then
-  # DORMANT is honored only if the work queues that triggered it are STILL empty.
-  # Stale DORMANT (from a previous session) auto-clears the moment real work exists,
-  # because evolution is agile: open beads => /evolve runs. No exceptions.
   READY=$(bd ready --json 2>/dev/null | jq -r 'length // 0' 2>/dev/null || echo 0)
   HARVESTED=$(jq -r 'select(.consumed==false) | .severity' .agents/rpi/next-work.jsonl 2>/dev/null | wc -l | tr -d ' ')
   if [ "$READY" -gt 0 ] || [ "$HARVESTED" -gt 0 ]; then
-    echo "DORMANT auto-clearing: ready=$READY harvested=$HARVESTED — work exists, loop resumes."
-    rm -f .agents/evolve/DORMANT
+    rm -f .agents/evolve/DORMANT  # stale: real work exists, loop resumes
   else
-    echo "Dormant since $(head -1 .agents/evolve/DORMANT 2>/dev/null) — bd ready and next-work.jsonl both empty."
-    exit 0
+    echo "Dormant since $(head -1 .agents/evolve/DORMANT 2>/dev/null)."; exit 0
   fi
 fi
-[ -f .agents/evolve/HANDOFF ] && {
-  # HANDOFF is a non-sticky signal: prior session's context was heavy and asked for
-  # a fresh-context handoff. If we're here, this turn IS the fresh context (harness
-  # compaction or new session). Clear the signal and continue normally.
-  echo "HANDOFF cleared: $(head -1 .agents/evolve/HANDOFF 2>/dev/null)"
-  rm -f .agents/evolve/HANDOFF
-}
+[ -f .agents/evolve/HANDOFF ] && rm -f .agents/evolve/HANDOFF  # non-sticky: cleared on fresh fire
 ```
 
-**Agile-first dormancy (soc-5qit):** `DORMANT` is NEVER sticky while open ready beads exist. Step 1 re-validates the dormancy predicate (`bd ready` empty AND harvested queue empty) every cron-fire — if either has work, DORMANT auto-clears and the loop resumes. The only way DORMANT actually short-circuits is if there is *genuinely nothing to do* AND the operator hasn't created new work. This replaces the prior "sticky-until-operator-clears" behavior that was waterfall, not evolutionary.
-
-**Stale-kill auto-expiration:** the KILL and STOP markers honor an EVOLVE_KILL_TTL_DAYS (default 7) age window. A KILL older than the window is logged as STALE and the loop continues — caught the F5 failure mode on 2026-05-18 where a 5-day-old KILL silently blocked /evolve.
-
-**Context exhaustion is not a stop (soc-5qit):** when a session's context is too heavy to safely execute available work, /evolve writes a non-sticky `.agents/evolve/HANDOFF` marker and exits the current turn cleanly. The next cron-fire — running on harness-compacted context or a fresh session — automatically clears HANDOFF in Step 1 and resumes normal work selection. HANDOFF NEVER writes DORMANT; the loop is continuous across compactions.
+**Agile-first dormancy (soc-5qit):** `DORMANT` is NEVER sticky while ready beads exist; Step 1 re-validates every fire and auto-clears stale markers. KILL/STOP honor `EVOLVE_KILL_TTL_DAYS` (default 7). Heavy-context sessions write non-sticky HANDOFF and exit the turn; the next fire (compacted/fresh) clears HANDOFF and resumes — the loop is continuous across compactions.
 
 ### Step 1.5: Healing-first classifier
 
@@ -275,17 +260,13 @@ When a repo-local program contract exists, apply a scope filter before Step 4:
 
 **Step 3.0: Scope filter — split-or-defer, never bail (soc-5qit)**
 
-Before claiming a candidate work item, gate scope vs session budget. If the work touches > 5 non-uniform files, introduces a new shape (schema field, struct field, validator rule, contract surface), is operator-level epic work, OR `PRODUCTIVE_THIS_SESSION > 5` and the work would extend an implementation arc rather than close one — route to **scout-mode**.
+Before claiming a candidate, gate scope vs session budget. If the work touches > 5 non-uniform files, introduces a new shape (schema field, validator, contract surface), is operator-level epic work, OR `PRODUCTIVE_THIS_SESSION > 5` and would extend an arc rather than close one — route to **scout-mode**, which MUST produce one of:
 
-Scout-mode is **work**, not a stop. The scout cycle MUST produce one of:
+1. **Split** — `bd create` 2-N child beads (each ≤5 files, single-shape) with `--deps discovered-from:<parent-id>`, annotate parent, then **re-enter Step 3** so the smallest child (or another ready bead) gets claimed THIS cycle.
+2. **Defer** — annotate the candidate with `defer:<reason>` and re-enter Step 3 so the next-priority ready bead gets claimed.
+3. **Park** (rare) — `bd update <id> --status blocked --notes "scope-too-big"` and re-enter Step 3.
 
-1. **Split** — run `bd create` to decompose the too-big candidate into 2-N smaller child beads (each ≤5 files, single-shape) with `--deps discovered-from:<parent-id>`, annotate the parent with the disposition, then **re-enter Step 3** so the smallest new child (or another ready bead) gets claimed THIS cycle.
-2. **Defer** — annotate the candidate with disposition `defer:<reason>`, then **re-enter Step 3** so the next-priority ready bead gets claimed THIS cycle. The big candidate stays available for a future cycle.
-3. **Park** (rare) — operator-level epic with no obvious split; `bd update <id> --status blocked --notes "scope-too-big: <why>"` and re-enter Step 3 for the next ready bead.
-
-Scout NEVER returns "no work done." If `bd ready` returns ≥1 unblocked bead, the loop MUST claim and work one of them this cycle — either the smaller child it just created, or a smaller-scope sibling already in the queue.
-
-See `references/scout-mode.md` for the split/defer procedure and `references/mechanical-batches.md` for when a >5-file batch is uniform enough to bypass scope-filter entirely.
+Scout NEVER returns "no work done." If `bd ready` ≥1, the loop MUST claim one this cycle. See `references/scout-mode.md` and `references/mechanical-batches.md`.
 
 **Metronome gate:** read `mode_repeat_streak` from `session-state.json` (kept current by `scripts/evolve-update-session-state.sh`). If `mode_repeat_streak >= 3` AND the candidate work would produce the same `mode` value as the trailing run, BLOCK selection at this rung and force a jump to the NEXT rung in the ladder. If `mode_repeat_streak >= 5`, file a `bd remember "metronome-N: <mode>"` and require operator override before continuing on that rung. See `references/metronome-gate.md` for the detection rule and the cycles 144-154 retrospective.
 
@@ -409,33 +390,25 @@ When evolve picks a finding, claim it first in next-work.jsonl:
 
 See `references/quality-mode.md` for scoring and full details.
 
-**Nothing found?** HARD GATE — dormancy is only legal when ALL work sources are genuinely empty (soc-5qit):
+**Nothing found?** HARD GATE — dormancy only when ALL sources empty (soc-5qit):
 
 ```bash
-# Hard predicate: every source must be empty. Any one source with work => loop continues.
 READY_BEADS=$(bd ready --json 2>/dev/null | jq -r 'length // 0' 2>/dev/null || echo 0)
 HARVESTED=$(jq -r 'select(.consumed==false) | .severity' .agents/rpi/next-work.jsonl 2>/dev/null | wc -l | tr -d ' ')
 FAILING_GOALS=$(jq -r '.goals[] | select(.result=="fail") | .id' .agents/evolve/fitness-latest.json 2>/dev/null | wc -l | tr -d ' ')
 IDLE_STREAK=$(jq -r '.idle_streak // 0' .agents/evolve/session-state.json 2>/dev/null)
 
 if [ "$READY_BEADS" -gt 0 ] || [ "$HARVESTED" -gt 0 ] || [ "$FAILING_GOALS" -gt 0 ]; then
-  echo "Hard-gate refused: ready=$READY_BEADS harvested=$HARVESTED failing-goals=$FAILING_GOALS. Loop back to Step 3."
-  # MUST loop back to Step 3 — work exists. This is the agile invariant: open beads => /evolve runs.
-  continue
+  continue  # work exists — loop back to Step 3 (agile invariant)
 fi
-
 if [ "${GENERATOR_EMPTY_STREAK:-0}" -ge 2 ] && [ "${IDLE_STREAK:-0}" -ge 2 ]; then
-  printf '%s\n%s\n%s\n' "cycle $CYCLE" "$(date -u +%FT%TZ)" \
-    "stagnation: bd ready=0, harvested=0, failing-goals=0, generators dry x3" \
-    > .agents/evolve/DORMANT
-  echo "Genuine stagnation: nothing actionable across every source. Operator can create work."
-  # DORMANT auto-clears in Step 1 next fire if `bd create` adds a new ready bead.
+  printf '%s\n%s\n%s\n' "cycle $CYCLE" "$(date -u +%FT%TZ)" "stagnation: all sources empty x3" > .agents/evolve/DORMANT
 fi
 ```
 
-**Agile invariant (soc-5qit):** if `bd ready` returns ≥1 unblocked bead, the loop NEVER writes DORMANT and NEVER exits — it loops back to Step 3 and claims one. The only path to DORMANT is a fully empty backlog AND fully empty generator output. Context exhaustion is not in this predicate (see Step 7 / `references/context-budget.md` for HANDOFF semantics).
+**Agile invariant (soc-5qit):** `bd ready ≥ 1` ⇒ loop NEVER writes DORMANT, NEVER exits. The only path to DORMANT is fully empty backlog + dry generators. Context exhaustion → HANDOFF, not DORMANT.
 
-If the work layers were empty but a generator pass has not been exhausted 3 times yet, persist the new generator streak in `session-state.json` and loop back to Step 1. Empty pre-cycle work sources are not a stop reason by themselves.
+If work layers were empty but generators haven't exhausted 3 passes yet, persist `GENERATOR_EMPTY_STREAK` and loop back to Step 1.
 
 A cycle is idle only if NO work source returned actionable work and every generator layer also came up empty. A cycle that targeted an oscillating goal and skipped it counts as idle only after the remaining ladder was exhausted.
 
@@ -523,17 +496,11 @@ done
 **Stop reasons (soc-5qit, ALL require genuine reason — never just context size):**
 
 1. **KILL/STOP file present** — operator override.
-2. **`--max-cycles=N` cap reached** — explicit operator-set limit.
+2. **`--max-cycles=N` cap reached**.
 3. **Genuine stagnation** — `bd ready=0 AND harvested-unconsumed=0 AND failing-goals=0 AND GENERATOR_EMPTY_STREAK>=2 AND IDLE_STREAK>=2`. Writes DORMANT, which auto-clears in Step 1 the moment `bd create` adds a new ready bead.
-4. **Regression breaker after a revert** — the cycle reverted real damage; next cycle waits for operator to acknowledge.
+4. **Regression breaker after a revert**.
 
-**Context exhaustion is NOT a stop reason (soc-5qit).** When a session's context grows too heavy for safe execution, /evolve:
-1. Writes `.agents/evolve/HANDOFF` (non-sticky, name only — not a marker file like DORMANT)
-2. Logs the parked work refs in `cycle-history.jsonl` with `result: "context-handoff"`
-3. Exits THIS cron-fire turn cleanly (no `ScheduleWakeup` re-arm needed — cron does it)
-4. The next cron-fire (running on harness-compacted context or a fresh session) clears HANDOFF in Step 1 and claims work normally
-
-The loop is continuous across compactions. If you're tempted to write DORMANT because "context is full," you're wrong — write HANDOFF and let the next cron-fire pick up where you left off. See `references/context-budget.md`.
+**Context exhaustion is NOT a stop (soc-5qit).** Heavy-context sessions write `.agents/evolve/HANDOFF` (non-sticky), log `result: "context-handoff"` to cycle-history, and exit the turn cleanly. The next cron-fire (compacted/fresh context) clears HANDOFF in Step 1 and resumes. The loop is continuous across compactions; never write DORMANT for context size. See `references/context-budget.md`.
 
 **Mandatory checkpoint #6 — session-PR threshold (NOT terminal, gates next cycle):** at `session_pr_count >= 5` (soc-waxr default), invoke `/post-mortem --deep`, wait for verdict file. PASS → continue. WARN → continue with caveat in next cycle's `notes`. FAIL or non-convergence → write STOP. Agent MUST NOT self-grade or self-write STOP. Full procedure in `references/postmortem-checkpoint.md` (soc-n75z).
 

--- a/skills/evolve/references/context-budget.md
+++ b/skills/evolve/references/context-budget.md
@@ -1,17 +1,21 @@
-# Context Budget — A Third Stop Reason
+# Context Budget — Session Handoff, Not a Stop (soc-5qit)
 
-The skill's two declared stop reasons (kill switch / dormancy) don't catch the failure mode where the loop has actionable work but the work is the wrong shape for the current cycle's context budget. This reference defines `CONTEXT_BUDGET_EXHAUSTED` as a third stop reason.
+**Prior framing (deprecated):** context exhaustion was a third stop reason that wrote sticky `DORMANT` and ended the run.
 
-## Why it's a real failure mode
+**Current framing (soc-5qit, 2026-05-21):** context exhaustion is a *session-handoff signal*. The loop is continuous across compactions; a heavy session writes a non-sticky `HANDOFF` marker, exits the current cron-fire turn cleanly, and the NEXT cron-fire (running on harness-compacted or fresh context) automatically clears HANDOFF in Step 1 and resumes.
 
-A long session that has shipped 10+ productive cycles accumulates context: read files cache, tool-result trails, prior `/rpi` discovery findings. When cycle 11 selects an item that requires a fresh deep read of unfamiliar surfaces, the cycle either:
+This change was forced by an operator failure mode (2026-05-20→21): a cron-driven /evolve session shipped 6 PRs, accumulated context, then sticky-DORMANT'd despite 10+ unblocked P1 beads in `bd ready`. The prior design treated "this Claude session can't safely take on more work" as "the work itself is done" — a category error. The cron loop spans many sessions; one session's context is irrelevant to whether the backlog has work.
 
-- Forces a scout-mode return because the context is too heavy to execute (correct outcome, but the skill doesn't currently classify this as anything but `harvested` or `idle`).
+## Why it's a real failure mode (still true)
+
+A long session that has shipped 5+ productive cycles accumulates context: read files cache, tool-result trails, prior `/rpi` discovery findings. When cycle N+1 selects an item that requires a fresh deep read of unfamiliar surfaces, the cycle either:
+
+- Forces a scout-mode return because the context is too heavy to execute (correct outcome, but the skill must not treat this as terminal).
 - Attempts execution and produces shallow work that the regression gate or self-review catches (recovery cost > the cycle's value).
 
-Neither path is captured by the existing dormancy gate (`IDLE_STREAK >= 2 AND GENERATOR_EMPTY_STREAK >= 2`). Work IS found; it just can't be safely executed.
+The fix is to surface this as a handoff to the next session, not stop the loop.
 
-## The counter and the gate
+## The counter and the signal
 
 Maintain `context_streak` in `.agents/evolve/session-state.json`. Increment when ANY of these are true at end-of-cycle:
 
@@ -25,25 +29,34 @@ Reset to 0 when a productive `improved` cycle lands.
 context_streak=$(jq -r '.context_streak // 0' .agents/evolve/session-state.json)
 
 if [ "$context_streak" -ge 2 ]; then
-  echo "CONTEXT_BUDGET_EXHAUSTED after $context_streak consecutive heavy-context cycles."
-  echo "Parked work:"
-  jq -r '.parked_work[] // empty' .agents/evolve/session-state.json
-  # Hand off via cycle-history.jsonl with result: "context-budget-exit"
+  echo "CONTEXT_BUDGET_EXHAUSTED after $context_streak heavy-context cycles."
+  echo "Writing HANDOFF (non-sticky) and exiting this cron-fire turn."
+  # HANDOFF carries ONLY the parked work refs and the timestamp.
+  # It is NOT a sticky stop. Step 1 of the next cron-fire clears it automatically.
+  cat > .agents/evolve/HANDOFF <<EOF
+$(date -u +%FT%TZ)
+context_streak=$context_streak (this session's context grew too heavy)
+parked_work: $(jq -c '.parked_work // []' .agents/evolve/session-state.json)
+next-action: cron-fire will resume on compacted/fresh context
+EOF
+  # Hand off via cycle-history.jsonl with result: "context-handoff"
   exit 0
 fi
 ```
 
-## Handoff message
+**Critical:** the HANDOFF marker does NOT block future cron-fires. Step 1 of the next /evolve turn clears it and continues normal work selection.
 
-When the gate fires, write a handoff entry that names the parked work concretely:
+## Handoff message (logged, not gated)
+
+When the context-handoff fires, write a cycle-history entry that names the parked work concretely:
 
 ```json
-{"cycle": N, "result": "context-budget-exit",
+{"cycle": N, "result": "context-handoff",
  "selected_source": "<source>", "work_ref": "<ref>",
- "milestone": "CONTEXT_BUDGET_EXHAUSTED after 2 heavy-context cycles. Parked: <work refs>. Resume in a fresh session."}
+ "milestone": "Context-handoff after 2 heavy cycles. Parked: <work refs>. Next cron-fire (compacted/fresh) resumes."}
 ```
 
-The next operator session reads this entry, knows what was parked, and can either continue manually or fire a fresh `/evolve` with cleared context.
+The next operator session reads this entry, knows what was parked, and can either continue manually or wait for the next cron-fire to handle it.
 
 ## Configurable threshold
 
@@ -51,4 +64,16 @@ Default `context_streak` threshold is 2. Override with `EVOLVE_CONTEXT_STREAK_LI
 
 ## ScheduleWakeup interaction
 
-When running the Claude-Code-harness self-perpetuation mode (see `references/autonomous-execution.md`), a context-budget exit MUST NOT call `ScheduleWakeup`. The loop terminates and surfaces the handoff message. Re-firing would re-load the heavy context and repeat the failure.
+When running the Claude-Code-harness self-perpetuation mode (see `references/autonomous-execution.md`), a context-handoff exit MUST NOT call `ScheduleWakeup` from the same heavy-context turn — re-firing would re-load the heavy context. The cron schedule (or operator's external trigger) handles the re-fire. By the time the next cron-fire runs, the harness has compacted or the session has rolled, and HANDOFF auto-clears.
+
+## What this is NOT
+
+- **Not a stop reason.** Stop reasons are operator override, max-cycles cap, regression-breaker, and genuine stagnation (bd ready=0 AND harvested=0 AND failing-goals=0 AND generators dry).
+- **Not a sticky marker.** DORMANT is sticky-with-auto-clear-on-new-work; HANDOFF is fully non-sticky and clears on next read.
+- **Not a "the work is done" signal.** It explicitly says "this session can't safely continue; the work is parked." The next session does the work.
+
+## Cross-reference
+
+- `SKILL.md` Step 1 — HANDOFF auto-clear on cron-fire-N+1
+- `SKILL.md` Step 7 — context exhaustion explicitly removed from stop reasons list
+- `references/scout-mode.md` — scope-filter splits or defers; never bails

--- a/skills/evolve/references/scout-mode.md
+++ b/skills/evolve/references/scout-mode.md
@@ -13,21 +13,40 @@ Use scout-mode whenever a Step 3 selection meets any of these criteria:
 
 The scope-filter step (Step 3.0 in `SKILL.md`) consults these heuristics before any work is claimed.
 
-## What a scout cycle does
+## What a scout cycle does (soc-5qit: split-or-defer, never bail)
 
-A productive scout cycle MUST:
+A scout cycle is **work**, not a stop. It MUST produce exactly one of:
+
+### Path A: Split (preferred when the queue is light and the work is decomposable)
 
 1. Read the target file(s) named in the work item (no edits).
 2. Map the **current shape** at the relevant boundary (what fields exist, what callers read it, what validators enforce).
-3. Identify the **smallest landable slice** — usually a producer-side change OR a consumer-side change, not both.
-4. Append a `disposition:` block to the work item's `description` in `.agents/rpi/next-work.jsonl` summarizing the finding, with timestamp.
-5. If the scope is genuinely epic-level (operator decision needed), explicitly recommend `bd create` for each sub-slice and either `park` or annotate the bead for operator-driven `/rpi`.
+3. Run `bd create` to decompose the candidate into 2-N child beads, each ≤5 files and single-shape:
+   ```bash
+   bd create "Slice 1 of <parent-title>: <smaller-scope>" \
+     --description="Carved from <parent-id> by scout-mode. Scope: <files/contract>" \
+     --deps discovered-from:<parent-id> -t task -p <inherit> --json
+   ```
+4. Update the parent bead with `bd update <parent-id> --notes "scout-split into: <child-ids>"`.
+5. **Re-enter Step 3** so the smallest new child OR another ready bead gets claimed THIS cycle.
+
+### Path B: Defer (preferred when the queue has other ready beads)
+
+1. Read the target file(s) briefly to confirm the scope assessment.
+2. Append a `disposition: defer:<reason>` block to the work item.
+3. **Re-enter Step 3** so the next-priority ready bead gets claimed THIS cycle. The big candidate stays available for a future session with lighter context.
+
+### Path C: Park (operator-level epic, no obvious split)
+
+1. `bd update <id> --status blocked --notes "scope-too-big: <why>; needs operator triage"`.
+2. **Re-enter Step 3** for the next ready bead.
 
 A scout cycle does NOT:
 
-- Run `/rpi` against the target.
-- Edit any source file.
-- Commit (the appended `disposition` lives in `.agents/rpi/next-work.jsonl` which is the standard append-only ledger; commit it as part of the next productive cycle's harvest if appropriate).
+- Run `/rpi` against the original too-big candidate.
+- Edit any source file outside `.agents/rpi/next-work.jsonl` and bd metadata.
+- Commit code (bd updates land in Dolt automatically).
+- **Exit the loop** — if `bd ready` returns ≥1 unblocked bead, the cycle MUST claim and work one of them after the scout decision. (soc-5qit invariant.)
 
 ## Logging a scout cycle
 


### PR DESCRIPTION
## Why

The `/evolve` skill wrote a sticky `DORMANT` marker on `CONTEXT_BUDGET_EXHAUSTED` (Step 7 stop reason #4), short-circuiting every subsequent cron-fire in Step 1 — even while `bd ready` returned 10+ unblocked P1 beads. Two consecutive scout-mode cycles auto-triggered this, and scout-mode itself fires whenever `PRODUCTIVE_THIS_SESSION>5` or work touches >5 files. Net effect: the loop stopped after ~5 productive PRs in a session, despite a full backlog. Waterfall, not agile.

Operator intent: `/evolve` runs continuously while open beads exist. Context exhaustion is a per-session limitation that relies on harness compaction (or fresh-session re-fire) to clear — it is NOT a property of the backlog.

## What changed

| Surface | Change |
|---|---|
| `skills/evolve/SKILL.md` Step 1 | DORMANT auto-clears when `bd ready` or harvested queue has work. HANDOFF (non-sticky context-handoff marker) auto-clears every cron-fire. |
| `skills/evolve/SKILL.md` Step 3.0 | Scope-filter on too-big work MUST split-via-`bd create` OR defer-to-next-ready-bead; never bails. Re-enters Step 3 so the loop claims the smaller child or sibling THIS cycle. |
| `skills/evolve/SKILL.md` Step 3 hard-gate | Now requires `bd ready=0 AND harvested=0 AND failing-goals=0` before stagnation is even considered. Any source with work => continue. |
| `skills/evolve/SKILL.md` Step 7 | `CONTEXT_BUDGET_EXHAUSTED` removed from stop reasons. Replaced with non-sticky HANDOFF signal that next cron-fire clears on compacted/fresh context. |
| `skills/evolve/references/context-budget.md` | Reframed from 'third stop reason' to 'session-handoff signal'. |
| `skills/evolve/references/scout-mode.md` | Scout cycles produce one of split/defer/park, then re-enter Step 3. Never exit while ready beads exist. |
| `skills-codex/evolve/SKILL.md` | Parity-synced agile-invariant on hard-gate. |
| `skills-codex/.agentops-manifest.json` + `.agentops-generated.json` | Regenerated via `scripts/regen-codex-hashes.sh`. |

## Agile invariant

> If `bd ready` returns ≥1 unblocked bead, `/evolve` MUST claim and work one. DORMANT is only legal when every source is genuinely empty.

## Observed failure mode

Cron-driven /evolve session on 2026-05-20→21 shipped 6 PRs (#383, #385-#388, #390), then sticky-DORMANT'd at cycle 13. `bd ready` at that moment returned 10+ unblocked P1 beads (soc-rcsz, soc-dspz, soc-vuu6.33, soc-wb2aa, soc-m6v5.1, soc-51no, soc-9zwe, psite-mto.{31,29,28,...}). The cron kept firing every 30m; each fire hit the sticky marker and exited without doing any work. Operator caught it.

## How this is testable

- After merge, any `/evolve` invocation with `bd ready` non-empty should claim and execute a bead (no DORMANT short-circuit).
- A heavy session that hits context-budget should write `.agents/evolve/HANDOFF` (not DORMANT), and the next cron-fire should clear HANDOFF in Step 1.
- The Step 3 hard-gate refusal path should be observable in cycle-history.jsonl as 'Hard-gate refused: ready=N harvested=N ...' before any DORMANT consideration.

Closes-scenario: soc-5qit#agile-invariant
Bounded-context: BC5-Runtime
Evidence: skills/evolve/SKILL.md
