### PR TITLE
feat(evolve): versioned cron template + Go renderer with VERBATIM-PRESERVE drift detection (soc-ij7e #cron-template)

### DIFF
--- a/cli/internal/evolve/template.go
+++ b/cli/internal/evolve/template.go
@@ -1,0 +1,249 @@
+// Package evolve renders the /evolve loop-mode cron prompt from a versioned
+// template at skills/evolve/templates/cron-loop-mode.md.
+//
+// Load-bearing prompt sections (3-ADR cite, 7-step unblock ladder, Layer-3
+// authority, no-self-stop) drift when manually rebuilt every cycle. This
+// package externalizes the template and guards drift mechanically via
+// VERBATIM-PRESERVE markers whose SHA-256 hashes are stored in the
+// frontmatter and re-checked on every render.
+//
+// Marker syntax:
+//
+//	<!-- VERBATIM-PRESERVE:start name="<name>" -->
+//	... inner content ...
+//	<!-- VERBATIM-PRESERVE:end -->
+//
+// SHA-256 input definition: the renderer hashes the raw bytes strictly
+// between the closing "-->" of the start marker and the opening "<!--" of
+// the end marker — i.e., the substring excluding both comment delimiters.
+// Operators who intentionally edit a marker MUST recompute its hash and
+// update the frontmatter's verbatim_markers map; one-off recomputation:
+//
+//	go run ./cli/cmd/ao evolve template-hash <path>   (future surface)
+//
+// or simply call ComputeMarkerSHA on the extracted inner content.
+package evolve
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
+)
+
+// CronContext is the data passed into the loop-mode cron template. All
+// fields are required to be set by the caller (zero values render as empty
+// strings / empty lists, which is acceptable for the first cycle).
+type CronContext struct {
+	// ShippedCommits enumerates commits landed since the last cycle. Each
+	// entry renders as "<Sha> (<Bead>[ #<Scenario>]);" — joined into a
+	// single line. Empty list → empty rendering.
+	ShippedCommits []ShippedCommit
+
+	// NextRecommendedBead is the bead-id the prior cycle's tail suggested
+	// the operator queue next. Advisory; Layer-3 authority may override.
+	NextRecommendedBead string
+
+	// SubBeadsFiledThisCycle is the list of bead-ids the agent filed via
+	// `bd create` during this cycle (typically discovered-from links).
+	SubBeadsFiledThisCycle []string
+
+	// TestsDelta is a human-readable summary of test-suite movement, e.g.
+	// "+3 passing, 0 new failures" or "no test changes".
+	TestsDelta string
+
+	// CronSelfAdjustCounter is the cycle number, incremented each time the
+	// cron template is rendered for a new tick. Used in the prompt header.
+	CronSelfAdjustCounter int
+}
+
+// ShippedCommit describes a single commit landed during the prior cycle.
+type ShippedCommit struct {
+	Sha      string
+	Bead     string
+	Scenario string
+}
+
+// templateFrontmatter mirrors the YAML head of the cron template.
+type templateFrontmatter struct {
+	TemplateVersion int               `yaml:"template_version"`
+	VerbatimMarkers map[string]string `yaml:"verbatim_markers"`
+}
+
+// markerRegexp matches a VERBATIM-PRESERVE block and captures (name, inner).
+// Inner content is the substring strictly between the closing "-->" of the
+// start marker and the opening "<!--" of the end marker.
+var markerRegexp = regexp.MustCompile(
+	`<!--\s*VERBATIM-PRESERVE:start\s+name="([^"]+)"\s*-->` +
+		`([\s\S]*?)` +
+		`<!--\s*VERBATIM-PRESERVE:end\s*-->`,
+)
+
+// frontmatterRegexp matches a leading YAML frontmatter block.
+var frontmatterRegexp = regexp.MustCompile(`\A---\r?\n([\s\S]*?)\r?\n---\r?\n`)
+
+// Render parses the template at templatePath, validates VERBATIM-PRESERVE
+// markers against the stored SHA-256 map, then renders with ctx using
+// text/template. Returns the rendered output and any error.
+//
+// On marker drift, returns the error from VerifyMarkers without rendering.
+func Render(templatePath string, ctx CronContext) (string, error) {
+	raw, err := os.ReadFile(templatePath)
+	if err != nil {
+		return "", fmt.Errorf("evolve: reading template %q: %w", templatePath, err)
+	}
+	if err := verifyMarkersFromBytes(raw); err != nil {
+		return "", err
+	}
+
+	body, err := stripFrontmatter(raw)
+	if err != nil {
+		return "", fmt.Errorf("evolve: stripping frontmatter in %q: %w", templatePath, err)
+	}
+
+	tmpl, err := template.New("cron-loop-mode").Parse(string(body))
+	if err != nil {
+		return "", fmt.Errorf("evolve: parsing template %q: %w", templatePath, err)
+	}
+
+	var out bytes.Buffer
+	if err := tmpl.Execute(&out, ctx); err != nil {
+		return "", fmt.Errorf("evolve: executing template %q: %w", templatePath, err)
+	}
+	return out.String(), nil
+}
+
+// VerifyMarkers parses the template at templatePath, recomputes the SHA-256
+// of each VERBATIM-PRESERVE block's inner content, and compares each to
+// the frontmatter's verbatim_markers map. Returns nil on full match.
+//
+// On any drift, returns an error whose message lists each drifted marker in
+// the form:
+//
+//	VERBATIM-PRESERVE drift detected: marker '<name>' has SHA <got>, expected <want>
+//
+// Errors stack one-per-line if multiple markers drifted.
+func VerifyMarkers(templatePath string) error {
+	raw, err := os.ReadFile(templatePath)
+	if err != nil {
+		return fmt.Errorf("evolve: reading template %q: %w", templatePath, err)
+	}
+	return verifyMarkersFromBytes(raw)
+}
+
+// verifyMarkersFromBytes is the shared implementation between Render and
+// VerifyMarkers; pulled out to avoid double file reads.
+func verifyMarkersFromBytes(raw []byte) error {
+	fm, err := parseFrontmatter(raw)
+	if err != nil {
+		return fmt.Errorf("evolve: parsing frontmatter: %w", err)
+	}
+	if fm.VerbatimMarkers == nil {
+		fm.VerbatimMarkers = map[string]string{}
+	}
+
+	found := extractMarkers(raw)
+
+	// Build sorted union of marker names so error output is deterministic.
+	names := unionNames(fm.VerbatimMarkers, found)
+
+	var drifts []string
+	for _, name := range names {
+		want, wantOK := fm.VerbatimMarkers[name]
+		gotInner, gotOK := found[name]
+		switch {
+		case wantOK && !gotOK:
+			drifts = append(drifts, fmt.Sprintf(
+				"VERBATIM-PRESERVE drift detected: marker %q declared in frontmatter but missing from body",
+				name,
+			))
+		case !wantOK && gotOK:
+			drifts = append(drifts, fmt.Sprintf(
+				"VERBATIM-PRESERVE drift detected: marker %q present in body but not declared in frontmatter (got SHA %s)",
+				name, ComputeMarkerSHA(gotInner),
+			))
+		default:
+			got := ComputeMarkerSHA(gotInner)
+			if got != want {
+				drifts = append(drifts, fmt.Sprintf(
+					"VERBATIM-PRESERVE drift detected: marker '%s' has SHA %s, expected %s",
+					name, got, want,
+				))
+			}
+		}
+	}
+	if len(drifts) > 0 {
+		return errors.New(strings.Join(drifts, "\n"))
+	}
+	return nil
+}
+
+// ComputeMarkerSHA returns the lowercase hex SHA-256 of the marker's inner
+// content, exactly as the verifier hashes it. The input is the raw bytes
+// strictly between the "-->" of the start marker and the "<!--" of the
+// end marker; ComputeMarkerSHA does NOT trim or normalize.
+func ComputeMarkerSHA(inner string) string {
+	sum := sha256.Sum256([]byte(inner))
+	return hex.EncodeToString(sum[:])
+}
+
+// parseFrontmatter extracts and decodes the leading YAML frontmatter block
+// from raw. Returns an error if the block is missing or malformed.
+func parseFrontmatter(raw []byte) (templateFrontmatter, error) {
+	var fm templateFrontmatter
+	m := frontmatterRegexp.FindSubmatch(raw)
+	if m == nil {
+		return fm, errors.New("missing leading --- frontmatter block")
+	}
+	if err := yaml.Unmarshal(m[1], &fm); err != nil {
+		return fm, fmt.Errorf("yaml decode: %w", err)
+	}
+	return fm, nil
+}
+
+// stripFrontmatter returns raw with the leading frontmatter block removed.
+// If no frontmatter is present, returns raw unchanged.
+func stripFrontmatter(raw []byte) ([]byte, error) {
+	m := frontmatterRegexp.FindIndex(raw)
+	if m == nil {
+		return raw, nil
+	}
+	return raw[m[1]:], nil
+}
+
+// extractMarkers scans raw for every VERBATIM-PRESERVE block and returns a
+// map from marker name → inner content (verbatim, no trim).
+func extractMarkers(raw []byte) map[string]string {
+	out := map[string]string{}
+	for _, m := range markerRegexp.FindAllSubmatch(raw, -1) {
+		name := string(m[1])
+		inner := string(m[2])
+		out[name] = inner
+	}
+	return out
+}
+
+// unionNames returns the sorted union of keys from a and b.
+func unionNames(a map[string]string, b map[string]string) []string {
+	set := map[string]struct{}{}
+	for k := range a {
+		set[k] = struct{}{}
+	}
+	for k := range b {
+		set[k] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cli/internal/evolve/template_test.go
+++ b/cli/internal/evolve/template_test.go
@@ -1,0 +1,225 @@
+package evolve
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// canonicalTemplatePath returns the path to the canonical cron template
+// relative to this _test.go file. The skills/ tree lives two directories
+// up from cli/internal/evolve/.
+func canonicalTemplatePath(t *testing.T) string {
+	t.Helper()
+	// cli/internal/evolve/template_test.go → ../../../skills/...
+	p, err := filepath.Abs(filepath.Join("..", "..", "..", "skills", "evolve", "templates", "cron-loop-mode.md"))
+	if err != nil {
+		t.Fatalf("resolving canonical template path: %v", err)
+	}
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("canonical template not found at %s: %v", p, err)
+	}
+	return p
+}
+
+var updateGolden = flag.Bool("update", false, "rewrite golden files instead of asserting against them")
+
+// loadContextFixture decodes the JSON fixture at path into a CronContext.
+func loadContextFixture(t *testing.T, path string) CronContext {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading fixture %s: %v", path, err)
+	}
+	var ctx CronContext
+	if err := json.Unmarshal(raw, &ctx); err != nil {
+		t.Fatalf("decoding fixture %s: %v", path, err)
+	}
+	return ctx
+}
+
+// TestRender_GoldenFixture is the primary L2 test: load the fixture
+// context, render the canonical template, byte-compare against the golden.
+func TestRender_GoldenFixture(t *testing.T) {
+	tmpl := canonicalTemplatePath(t)
+	ctx := loadContextFixture(t, filepath.Join("testdata", "cron-fixture-1.json"))
+
+	got, err := Render(tmpl, ctx)
+	if err != nil {
+		t.Fatalf("Render() returned error: %v", err)
+	}
+
+	goldenPath := filepath.Join("testdata", "cron-fixture-1.golden.md")
+	if *updateGolden {
+		if err := os.WriteFile(goldenPath, []byte(got), 0o644); err != nil {
+			t.Fatalf("writing golden: %v", err)
+		}
+		t.Logf("updated golden at %s", goldenPath)
+		return
+	}
+
+	wantBytes, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("reading golden: %v", err)
+	}
+	want := string(wantBytes)
+	if got != want {
+		t.Fatalf("Render() output does not match golden.\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// TestRender_DriftedMarker asserts that Render rejects a template whose
+// VERBATIM-PRESERVE marker content has been tampered with.
+func TestRender_DriftedMarker(t *testing.T) {
+	ctx := loadContextFixture(t, filepath.Join("testdata", "cron-fixture-1.json"))
+	drifted := filepath.Join("testdata", "cron-template-drifted.md")
+
+	_, err := Render(drifted, ctx)
+	if err == nil {
+		t.Fatal("Render() on drifted template returned nil error; want drift error")
+	}
+	if !strings.Contains(err.Error(), "VERBATIM-PRESERVE drift detected: marker 'no-self-stop'") {
+		t.Fatalf("Render() error does not name the drifted marker; got: %v", err)
+	}
+}
+
+// TestVerifyMarkers_Clean verifies the canonical template passes.
+func TestVerifyMarkers_Clean(t *testing.T) {
+	if err := VerifyMarkers(canonicalTemplatePath(t)); err != nil {
+		t.Fatalf("VerifyMarkers() on canonical template: %v", err)
+	}
+}
+
+// TestVerifyMarkers_Drift verifies the drifted fixture is rejected and the
+// specific marker name appears in the error message.
+func TestVerifyMarkers_Drift(t *testing.T) {
+	err := VerifyMarkers(filepath.Join("testdata", "cron-template-drifted.md"))
+	if err == nil {
+		t.Fatal("VerifyMarkers() on drifted template returned nil; want error")
+	}
+	if !strings.Contains(err.Error(), "marker 'no-self-stop'") {
+		t.Fatalf("error did not name the drifted marker; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "VERBATIM-PRESERVE drift detected") {
+		t.Fatalf("error missing drift sentinel; got: %v", err)
+	}
+}
+
+// TestParseFrontmatter is an L1 unit covering valid + malformed YAML heads.
+func TestParseFrontmatter(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+		check   func(t *testing.T, fm templateFrontmatter)
+	}{
+		{
+			name: "valid full",
+			input: "---\n" +
+				"template_version: 1\n" +
+				"verbatim_markers:\n" +
+				"  alpha: deadbeef\n" +
+				"  beta: cafef00d\n" +
+				"---\nbody here\n",
+			check: func(t *testing.T, fm templateFrontmatter) {
+				if fm.TemplateVersion != 1 {
+					t.Errorf("template_version = %d, want 1", fm.TemplateVersion)
+				}
+				if fm.VerbatimMarkers["alpha"] != "deadbeef" {
+					t.Errorf("alpha = %q, want deadbeef", fm.VerbatimMarkers["alpha"])
+				}
+				if fm.VerbatimMarkers["beta"] != "cafef00d" {
+					t.Errorf("beta = %q, want cafef00d", fm.VerbatimMarkers["beta"])
+				}
+			},
+		},
+		{
+			name:    "missing frontmatter block",
+			input:   "no frontmatter here\nbody\n",
+			wantErr: true,
+		},
+		{
+			name: "malformed yaml",
+			input: "---\n" +
+				"template_version: : :\n" +
+				"---\nbody\n",
+			wantErr: true,
+		},
+		{
+			name: "empty markers map",
+			input: "---\n" +
+				"template_version: 2\n" +
+				"---\nbody\n",
+			check: func(t *testing.T, fm templateFrontmatter) {
+				if fm.TemplateVersion != 2 {
+					t.Errorf("template_version = %d, want 2", fm.TemplateVersion)
+				}
+				if len(fm.VerbatimMarkers) != 0 {
+					t.Errorf("verbatim_markers should be empty; got %v", fm.VerbatimMarkers)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fm, err := parseFrontmatter([]byte(tc.input))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error; got fm=%+v", fm)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.check != nil {
+				tc.check(t, fm)
+			}
+		})
+	}
+}
+
+// TestComputeMarkerSHA is an L1 unit covering hashing of known inputs.
+func TestComputeMarkerSHA(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			// sha256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+			want: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		{
+			name: "newline only",
+			in:   "\n",
+			want: "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+		},
+		{
+			name: "abc",
+			in:   "abc",
+			want: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+		},
+		{
+			name: "with surrounding whitespace not trimmed",
+			in:   "  abc  ",
+			// must NOT equal sha256("abc") = ba7816bf...; trimming would break drift detection
+			want: "e1df0bfff7ba8ed81085b91ad7dde5d31777855835b80db6d99b56ef9f3aaa6b",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := ComputeMarkerSHA(tc.in)
+			if got != tc.want {
+				t.Errorf("ComputeMarkerSHA(%q) = %s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/internal/evolve/testdata/cron-fixture-1.golden.md
+++ b/cli/internal/evolve/testdata/cron-fixture-1.golden.md
@@ -1,0 +1,56 @@
+
+# /evolve loop-mode cron prompt (cycle 7)
+
+You are in /evolve --mode=loop. This is cycle 7.
+
+## Last cycle outcome
+
+Shipped: abc1234 (soc-ij7e #cron-template); def5678 (soc-hwax); 
+Tests delta: +4 passing, 0 new failures
+
+## Sub-beads filed this cycle
+
+- soc-zzz1
+- soc-zzz2
+
+
+## Recommended next work
+
+soc-6svt (advisory; Layer-3 authority may override)
+
+<!-- VERBATIM-PRESERVE:start name="3-adr-cite" -->
+Load-bearing context: docs/plans/2026-05-21-evolve-loop-epic-design.md (this epic's design memo) and the bead's per-cycle acceptance refinements.
+<!-- VERBATIM-PRESERVE:end -->
+
+<!-- VERBATIM-PRESERVE:start name="unblock-ladder" -->
+## 7-step unblock ladder
+
+If `bd ready` returns ≥1 unblocked bead, claim and work one.
+If you feel "blocked": log via `ao evolve blocked --reason '<text>'` (Wave 2). NEVER write a STOP marker.
+The ladder (programmatic enforcement: soc-mlbm Wave 2):
+1. Shape-compatible ready bead exists → pick it
+2. Sibling pattern in another bead's description → surface match
+3. Decomposable epic → recommend smaller child
+4. Cross-Hop pickup → traverse discovered-from chain
+5. Bug-fix fallback → smallest-surface bug
+6. Still nothing? Log blocked event, pick smallest available P1 anyway
+7. NEVER write STOP. Operator owns stop signals.
+<!-- VERBATIM-PRESERVE:end -->
+
+<!-- VERBATIM-PRESERVE:start name="layer-3-authority" -->
+## Layer-3 shaping authority
+
+The agent can:
+- File new beads as discoveries land (`bd create` + `discovered-from`)
+- Restructure the DAG
+- Update the cron's recommended-next pointer
+- Write ADRs for emergent precedents in `docs/decisions/`
+
+Bounded by: bead-graph coherence, operator-set scope (preferences.yaml), no-self-stop principle.
+<!-- VERBATIM-PRESERVE:end -->
+
+<!-- VERBATIM-PRESERVE:start name="no-self-stop" -->
+## The no-self-stop principle
+
+In `--mode=loop`, the agent NEVER writes a STOP/DORMANT/KILL marker. `ao evolve write-stop-marker` mechanically refuses (exit 1). When stuck: log via `ao evolve blocked`, pick smallest-available P1 anyway. Stop signals come from the operator, never the agent.
+<!-- VERBATIM-PRESERVE:end -->

--- a/cli/internal/evolve/testdata/cron-fixture-1.json
+++ b/cli/internal/evolve/testdata/cron-fixture-1.json
@@ -1,0 +1,10 @@
+{
+  "ShippedCommits": [
+    {"Sha": "abc1234", "Bead": "soc-ij7e", "Scenario": "cron-template"},
+    {"Sha": "def5678", "Bead": "soc-hwax", "Scenario": ""}
+  ],
+  "NextRecommendedBead": "soc-6svt",
+  "SubBeadsFiledThisCycle": ["soc-zzz1", "soc-zzz2"],
+  "TestsDelta": "+4 passing, 0 new failures",
+  "CronSelfAdjustCounter": 7
+}

--- a/cli/internal/evolve/testdata/cron-template-drifted.md
+++ b/cli/internal/evolve/testdata/cron-template-drifted.md
@@ -1,0 +1,63 @@
+---
+template_version: 1
+verbatim_markers:
+  3-adr-cite: 5bfa1c52a93edff9316b65025a0cc75a97169c61266470cc58037f9a168cf9ba
+  unblock-ladder: 745c8de8f69085fc2b5050192de8179ac203e4402a4b78071ef109a015c00bc1
+  layer-3-authority: 8a4478939885980823d49ac156d27553c4a42258af5399b6e04f6d7f96016f1b
+  no-self-stop: 0d46faf33d696a78fc276b8757e786a3ae72a9e5e894e1038b26757f3eb95f0a
+---
+
+# /evolve loop-mode cron prompt (cycle {{.CronSelfAdjustCounter}})
+
+You are in /evolve --mode=loop. This is cycle {{.CronSelfAdjustCounter}}.
+
+## Last cycle outcome
+
+Shipped: {{range .ShippedCommits}}{{.Sha}} ({{.Bead}}{{if .Scenario}} #{{.Scenario}}{{end}}); {{end}}
+Tests delta: {{.TestsDelta}}
+
+## Sub-beads filed this cycle
+
+{{range .SubBeadsFiledThisCycle}}- {{.}}
+{{else}}(none){{end}}
+
+## Recommended next work
+
+{{.NextRecommendedBead}} (advisory; Layer-3 authority may override)
+
+<!-- VERBATIM-PRESERVE:start name="3-adr-cite" -->
+Load-bearing context: docs/plans/2026-05-21-evolve-loop-epic-design.md (this epic's design memo) and the bead's per-cycle acceptance refinements.
+<!-- VERBATIM-PRESERVE:end -->
+
+<!-- VERBATIM-PRESERVE:start name="unblock-ladder" -->
+## 7-step unblock ladder
+
+If `bd ready` returns ≥1 unblocked bead, claim and work one.
+If you feel "blocked": log via `ao evolve blocked --reason '<text>'` (Wave 2). NEVER write a STOP marker.
+The ladder (programmatic enforcement: soc-mlbm Wave 2):
+1. Shape-compatible ready bead exists → pick it
+2. Sibling pattern in another bead's description → surface match
+3. Decomposable epic → recommend smaller child
+4. Cross-Hop pickup → traverse discovered-from chain
+5. Bug-fix fallback → smallest-surface bug
+6. Still nothing? Log blocked event, pick smallest available P1 anyway
+7. NEVER write STOP. Operator owns stop signals.
+<!-- VERBATIM-PRESERVE:end -->
+
+<!-- VERBATIM-PRESERVE:start name="layer-3-authority" -->
+## Layer-3 shaping authority
+
+The agent can:
+- File new beads as discoveries land (`bd create` + `discovered-from`)
+- Restructure the DAG
+- Update the cron's recommended-next pointer
+- Write ADRs for emergent precedents in `docs/decisions/`
+
+Bounded by: bead-graph coherence, operator-set scope (preferences.yaml), no-self-stop principle.
+<!-- VERBATIM-PRESERVE:end -->
+
+<!-- VERBATIM-PRESERVE:start name="no-self-stop" -->
+## The no-self-stop principle
+
+In `--mode=loop`, the agent NEVER writes a STOP/DORMANT/KILL marker. `ao evolve write-stop-marker` mechanically refuses (exit 1). When stuck: log via `ao evolve blocked`, pick smallest-available P1 anyway. Stop signals come from the operator, never the agent. TAMPERED INSERTION.
+<!-- VERBATIM-PRESERVE:end -->

--- a/skills/evolve/templates/cron-loop-mode.md
+++ b/skills/evolve/templates/cron-loop-mode.md
@@ -1,0 +1,63 @@
+---
+template_version: 1
+verbatim_markers:
+  3-adr-cite: 5bfa1c52a93edff9316b65025a0cc75a97169c61266470cc58037f9a168cf9ba
+  unblock-ladder: 745c8de8f69085fc2b5050192de8179ac203e4402a4b78071ef109a015c00bc1
+  layer-3-authority: 8a4478939885980823d49ac156d27553c4a42258af5399b6e04f6d7f96016f1b
+  no-self-stop: 0d46faf33d696a78fc276b8757e786a3ae72a9e5e894e1038b26757f3eb95f0a
+---
+
+# /evolve loop-mode cron prompt (cycle {{.CronSelfAdjustCounter}})
+
+You are in /evolve --mode=loop. This is cycle {{.CronSelfAdjustCounter}}.
+
+## Last cycle outcome
+
+Shipped: {{range .ShippedCommits}}{{.Sha}} ({{.Bead}}{{if .Scenario}} #{{.Scenario}}{{end}}); {{end}}
+Tests delta: {{.TestsDelta}}
+
+## Sub-beads filed this cycle
+
+{{range .SubBeadsFiledThisCycle}}- {{.}}
+{{else}}(none){{end}}
+
+## Recommended next work
+
+{{.NextRecommendedBead}} (advisory; Layer-3 authority may override)
+
+<!-- VERBATIM-PRESERVE:start name="3-adr-cite" -->
+Load-bearing context: docs/plans/2026-05-21-evolve-loop-epic-design.md (this epic's design memo) and the bead's per-cycle acceptance refinements.
+<!-- VERBATIM-PRESERVE:end -->
+
+<!-- VERBATIM-PRESERVE:start name="unblock-ladder" -->
+## 7-step unblock ladder
+
+If `bd ready` returns ≥1 unblocked bead, claim and work one.
+If you feel "blocked": log via `ao evolve blocked --reason '<text>'` (Wave 2). NEVER write a STOP marker.
+The ladder (programmatic enforcement: soc-mlbm Wave 2):
+1. Shape-compatible ready bead exists → pick it
+2. Sibling pattern in another bead's description → surface match
+3. Decomposable epic → recommend smaller child
+4. Cross-Hop pickup → traverse discovered-from chain
+5. Bug-fix fallback → smallest-surface bug
+6. Still nothing? Log blocked event, pick smallest available P1 anyway
+7. NEVER write STOP. Operator owns stop signals.
+<!-- VERBATIM-PRESERVE:end -->
+
+<!-- VERBATIM-PRESERVE:start name="layer-3-authority" -->
+## Layer-3 shaping authority
+
+The agent can:
+- File new beads as discoveries land (`bd create` + `discovered-from`)
+- Restructure the DAG
+- Update the cron's recommended-next pointer
+- Write ADRs for emergent precedents in `docs/decisions/`
+
+Bounded by: bead-graph coherence, operator-set scope (preferences.yaml), no-self-stop principle.
+<!-- VERBATIM-PRESERVE:end -->
+
+<!-- VERBATIM-PRESERVE:start name="no-self-stop" -->
+## The no-self-stop principle
+
+In `--mode=loop`, the agent NEVER writes a STOP/DORMANT/KILL marker. `ao evolve write-stop-marker` mechanically refuses (exit 1). When stuck: log via `ao evolve blocked`, pick smallest-available P1 anyway. Stop signals come from the operator, never the agent.
+<!-- VERBATIM-PRESERVE:end -->


### PR DESCRIPTION
## Why

Load-bearing cron prompt sections (3-ADR cite, 7-step unblock ladder, Layer-3 authority, no-self-stop) drift when manually rebuilt every cycle. The mt-olympus session 2026-05-21 rewrote ~150-line cron prompts 6+ times; load-bearing sections drifted across cycles despite verbatim-preservation effort. Externalize the template + mechanically guard against drift via SHA-256 markers stored in frontmatter.

## What changed

| Surface | Change |
|---|---|
| `skills/evolve/templates/cron-loop-mode.md` | New canonical loop-mode cron template with frontmatter (`template_version: 1`, `verbatim_markers` SHA-256 map) and 4 VERBATIM-PRESERVE blocks |
| `cli/internal/evolve/template.go` | New Go package: `Render(path, ctx)` + `VerifyMarkers(path)` + `parseFrontmatter` + `computeMarkerSHA` helpers |
| `cli/internal/evolve/testdata/` | Fixture JSON (`cron-fixture-1.json`), golden render (`cron-fixture-1.golden.md`), drifted-marker fixture (`cron-template-drifted.md`) |

## Template variables

`.ShippedCommits` (list), `.NextRecommendedBead` (string), `.SubBeadsFiledThisCycle` (list), `.TestsDelta` (string), `.CronSelfAdjustCounter` (int)

## How tested

- L2 golden-render: fixture context → output diff vs golden (exact byte match)
- L2 drift-detection: tampered marker rejected with `VERBATIM-PRESERVE drift detected: marker '<name>'` error
- L1 unit tests: frontmatter parsing + SHA-256 computation table tests
- Fitness: 0 → 14 tests passing; `go test ./cli/internal/evolve/...` green

## Notes

[no-sibling] First-of-kind work: no prior text/template renderer with frontmatter-hashed VERBATIM-PRESERVE markers exists in this repo. The SHA-256-stored-in-frontmatter pattern is novel here.

See: `docs/plans/2026-05-21-evolve-loop-epic-design.md §A3` (created by parallel worker W1a in soc-hwax PR)

Closes-scenario: soc-ij7e#cron-template
Bounded-context: BC5-Runtime
Evidence: cli/internal/evolve/template.go