### PR TITLE
feat(evolve): --mode=burst|loop flag + mechanical write-stop-marker refusal (soc-hwax #mode-loop-flag)

### DIFF
--- a/cli/cmd/ao/evolve.go
+++ b/cli/cmd/ao/evolve.go
@@ -45,6 +45,15 @@ var (
 	evolveDreamFirst   bool
 	evolveDreamOnly    bool
 	evolveDreamTimeout string
+	evolveMode         string
+)
+
+// Evolve --mode values. Burst is the legacy default (agent self-regulates and
+// may write STOP/DORMANT markers). Loop is the operator-driven cron contract
+// (CLI mechanically refuses self-written STOPs; only the operator stops it).
+const (
+	evolveModeBurst = "burst"
+	evolveModeLoop  = "loop"
 )
 
 func init() {
@@ -56,10 +65,26 @@ func init() {
 	evolveCmd.Flags().BoolVar(&evolveDreamFirst, "dream-first", false, "Run Dream knowledge sub-cycle before code cycles")
 	evolveCmd.Flags().BoolVar(&evolveDreamOnly, "dream-only", false, "Knowledge compounding only, no code cycles")
 	evolveCmd.Flags().StringVar(&evolveDreamTimeout, "dream-timeout", "30m", "Timeout for the Dream sub-cycle")
+	evolveCmd.Flags().StringVar(&evolveMode, "mode", evolveModeBurst, "Execution contract: 'burst' (default, agent self-regulates) or 'loop' (operator-driven; STOP markers mechanically refused)")
 	rootCmd.AddCommand(evolveCmd)
 }
 
+// validateEvolveMode returns nil iff mode is one of the supported values. It
+// is the single source of truth for accepted --mode values across evolve.go
+// and the evolve write-stop-marker subcommand.
+func validateEvolveMode(mode string) error {
+	switch mode {
+	case evolveModeBurst, evolveModeLoop:
+		return nil
+	default:
+		return fmt.Errorf("--mode must be 'burst' or 'loop'")
+	}
+}
+
 func runEvolve(cmd *cobra.Command, args []string) error {
+	if err := validateEvolveMode(evolveMode); err != nil {
+		return err
+	}
 	applyEvolveDefaults(cmd)
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/cli/cmd/ao/evolve_test.go
+++ b/cli/cmd/ao/evolve_test.go
@@ -104,6 +104,63 @@ func newEvolveDefaultsTestCommand() *cobra.Command {
 	return cmd
 }
 
+func TestValidateEvolveMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantErr bool
+	}{
+		{"burst", false},
+		{"loop", false},
+		{"", true},
+		{"BURST", true},
+		{"Loop", true},
+		{"continuous", true},
+	}
+	for _, tc := range cases {
+		err := validateEvolveMode(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("validateEvolveMode(%q) = nil, want error", tc.in)
+				continue
+			}
+			if !strings.Contains(err.Error(), "--mode must be 'burst' or 'loop'") {
+				t.Errorf("validateEvolveMode(%q) err = %v, want canonical message", tc.in, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("validateEvolveMode(%q) = %v, want nil", tc.in, err)
+		}
+	}
+}
+
+func TestEvolveModeFlagRegisteredWithBurstDefault(t *testing.T) {
+	flag := evolveCmd.Flags().Lookup("mode")
+	if flag == nil {
+		t.Fatal("evolve --mode flag should be registered")
+	}
+	if flag.DefValue != "burst" {
+		t.Errorf("evolve --mode default = %q, want burst", flag.DefValue)
+	}
+}
+
+func TestRunEvolveRejectsInvalidMode(t *testing.T) {
+	prev := evolveMode
+	evolveMode = "bogus"
+	t.Cleanup(func() { evolveMode = prev })
+
+	dir := chdirTemp(t)
+	_ = dir
+
+	err := runEvolve(&cobra.Command{Use: "evolve"}, nil)
+	if err == nil {
+		t.Fatal("runEvolve with --mode=bogus should return error")
+	}
+	if !strings.Contains(err.Error(), "--mode must be 'burst' or 'loop'") {
+		t.Fatalf("error = %v, want '--mode must be burst or loop'", err)
+	}
+}
+
 func TestEnsureEvolveEraBaselineWritesOncePerGoalsHash(t *testing.T) {
 	prevDryRun := dryRun
 	prevGoalsTimeout := goalsTimeout

--- a/cli/cmd/ao/evolve_write_stop_marker.go
+++ b/cli/cmd/ao/evolve_write_stop_marker.go
@@ -1,0 +1,122 @@
+// practices: [dora-metrics, lean-startup]
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+// evolveWriteStopMarker subcommand implements the mechanical no-self-stop
+// contract for `ao evolve --mode=loop`. Under loop mode the agent MUST NOT
+// write its own DORMANT/STOP/KILL markers; this command refuses with exit 1
+// so a self-halting prompt cannot bypass operator-driven control. Burst mode
+// preserves the legacy self-regulated behavior and writes the marker file
+// under `.agents/evolve/`.
+//
+// See docs/plans/2026-05-21-evolve-loop-epic-design.md §A1 and
+// skills/evolve/references/loop-mode.md for the broader contract.
+//
+// TODO: wire cli/internal/evolve.preferences.Load() after soc-6svt lands so
+// `--mode` can fall back to preferences.yaml `mode_default` instead of the
+// burst hard-coded default.
+var (
+	evolveWriteStopMarkerName   string
+	evolveWriteStopMarkerReason string
+	evolveWriteStopMarkerMode   string
+)
+
+var evolveWriteStopMarkerCmd = &cobra.Command{
+	Use:   "write-stop-marker",
+	Short: "Write an evolve stop marker (refused under --mode=loop)",
+	Long: `Write a DORMANT, STOP, or KILL marker under .agents/evolve/.
+
+Behavior depends on --mode:
+  burst (default): writes .agents/evolve/<marker> with --reason content and exits 0.
+  loop:            mechanically refuses with exit 1 and a stderr message pointing
+                   operators at 'ao evolve operator-stop' for explicit intent.
+
+This is the soc-hwax mechanical no-self-stop contract: under --mode=loop the
+agent cannot self-halt, even if its prompt asks it to. Only the operator (or
+a future 'ao evolve operator-stop' subcommand) may write a stop marker.`,
+	Args: cobra.NoArgs,
+	RunE: runEvolveWriteStopMarker,
+}
+
+func init() {
+	evolveWriteStopMarkerCmd.Flags().StringVar(&evolveWriteStopMarkerName, "marker", "", "Marker name: dormant, stop, or kill")
+	evolveWriteStopMarkerCmd.Flags().StringVar(&evolveWriteStopMarkerReason, "reason", "", "Reason text written to the marker file")
+	evolveWriteStopMarkerCmd.Flags().StringVar(&evolveWriteStopMarkerMode, "mode", evolveModeBurst, "Execution contract: 'burst' or 'loop' (loop refuses unconditionally)")
+	_ = evolveWriteStopMarkerCmd.MarkFlagRequired("marker")
+	evolveCmd.AddCommand(evolveWriteStopMarkerCmd)
+}
+
+// runEvolveWriteStopMarker is the RunE for `ao evolve write-stop-marker`. It
+// enforces the loop-mode refusal before touching the filesystem and wraps any
+// IO error with context per repo conventions.
+func runEvolveWriteStopMarker(cmd *cobra.Command, _ []string) error {
+	mode := detectEvolveWriteStopMarkerMode(cmd)
+	if err := validateEvolveMode(mode); err != nil {
+		return err
+	}
+	if mode == evolveModeLoop {
+		// Stderr surface is load-bearing: tests and operators key off this
+		// string to confirm the loop contract is in force.
+		return fmt.Errorf("STOP markers refused under --mode=loop. Use 'ao evolve operator-stop' for explicit operator intent.")
+	}
+
+	marker, err := normalizeStopMarkerName(evolveWriteStopMarkerName)
+	if err != nil {
+		return err
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("get working directory: %w", err)
+	}
+	dir := filepath.Join(cwd, ".agents", "evolve")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create evolve marker dir %s: %w", dir, err)
+	}
+	path := filepath.Join(dir, marker)
+	if err := os.WriteFile(path, []byte(evolveWriteStopMarkerReason), 0o644); err != nil {
+		return fmt.Errorf("write marker %s: %w", path, err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Wrote evolve marker %s\n", path)
+	return nil
+}
+
+// detectEvolveWriteStopMarkerMode resolves the effective mode for this
+// invocation. It reads the local --mode flag (with burst as the documented
+// default). When the soc-6svt preferences loader lands, this is the wiring
+// point for the defaults → preferences → CLI resolution order described in
+// the epic design memo.
+func detectEvolveWriteStopMarkerMode(cmd *cobra.Command) string {
+	if cmd == nil {
+		return evolveWriteStopMarkerMode
+	}
+	if flag := cmd.Flag("mode"); flag != nil {
+		if v := flag.Value.String(); v != "" {
+			return v
+		}
+	}
+	return evolveWriteStopMarkerMode
+}
+
+// normalizeStopMarkerName canonicalizes the --marker value to the on-disk
+// file name. The contract accepts dormant|stop|kill and emits matching
+// uppercase file names to align with the existing Step 1 kill-switch reader.
+func normalizeStopMarkerName(name string) (string, error) {
+	switch name {
+	case "dormant":
+		return "DORMANT", nil
+	case "stop":
+		return "STOP", nil
+	case "kill":
+		return "KILL", nil
+	default:
+		return "", fmt.Errorf("--marker must be one of: dormant, stop, kill (got %q)", name)
+	}
+}

--- a/cli/cmd/ao/evolve_write_stop_marker_test.go
+++ b/cli/cmd/ao/evolve_write_stop_marker_test.go
@@ -1,0 +1,156 @@
+// practices: [dora-metrics, lean-startup]
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEvolveWriteStopMarker_Table covers the mechanical no-self-stop contract
+// for `ao evolve write-stop-marker` introduced by soc-hwax. Burst mode must
+// write the marker file (canonicalized to upper-case); loop mode must refuse
+// every marker variant with a stderr message referencing 'operator-stop'.
+func TestEvolveWriteStopMarker_Table(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        string
+		marker      string
+		reason      string
+		wantErr     bool
+		wantErrSub  string
+		wantFile    string
+		wantFileBody string
+	}{
+		{
+			name:         "burst dormant writes file",
+			mode:         "burst",
+			marker:       "dormant",
+			reason:       "queue stable",
+			wantErr:      false,
+			wantFile:     "DORMANT",
+			wantFileBody: "queue stable",
+		},
+		{
+			name:        "loop dormant refused",
+			mode:        "loop",
+			marker:      "dormant",
+			reason:      "agent self-halt attempt",
+			wantErr:     true,
+			wantErrSub:  "refused under --mode=loop",
+		},
+		{
+			name:        "loop stop refused",
+			mode:        "loop",
+			marker:      "stop",
+			reason:      "operator override",
+			wantErr:     true,
+			wantErrSub:  "refused under --mode=loop",
+		},
+		{
+			name:        "loop kill refused",
+			mode:        "loop",
+			marker:      "kill",
+			reason:      "kill switch",
+			wantErr:     true,
+			wantErrSub:  "refused under --mode=loop",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := chdirTemp(t)
+
+			out, err := executeCommand(
+				"evolve", "write-stop-marker",
+				"--mode", tc.mode,
+				"--marker", tc.marker,
+				"--reason", tc.reason,
+			)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got nil (output=%q)", out)
+				}
+				combined := err.Error() + "\n" + out
+				if !strings.Contains(combined, tc.wantErrSub) {
+					t.Fatalf("error/output missing %q:\nerr=%v\nout=%s", tc.wantErrSub, err, out)
+				}
+				// Verify no marker file was written under refusal.
+				markerDir := filepath.Join(dir, ".agents", "evolve")
+				entries, statErr := os.ReadDir(markerDir)
+				if statErr == nil {
+					for _, entry := range entries {
+						name := entry.Name()
+						if name == "DORMANT" || name == "STOP" || name == "KILL" {
+							t.Fatalf("loop mode wrote marker file %s; should have refused", name)
+						}
+					}
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+			}
+			path := filepath.Join(dir, ".agents", "evolve", tc.wantFile)
+			data, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatalf("read marker file %s: %v", path, readErr)
+			}
+			if string(data) != tc.wantFileBody {
+				t.Fatalf("marker body = %q, want %q", string(data), tc.wantFileBody)
+			}
+		})
+	}
+}
+
+// TestEvolveWriteStopMarker_RegisteredOnEvolve confirms the subcommand is
+// reachable via `ao evolve write-stop-marker` (catches accidental removal of
+// the AddCommand call in init).
+func TestEvolveWriteStopMarker_RegisteredOnEvolve(t *testing.T) {
+	var found bool
+	for _, sub := range evolveCmd.Commands() {
+		if sub.Name() == "write-stop-marker" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("evolve write-stop-marker subcommand should be registered on evolveCmd")
+	}
+}
+
+// TestNormalizeStopMarkerName covers the marker-name canonicalization helper
+// directly so the table test above doesn't need to enumerate every value.
+func TestNormalizeStopMarkerName(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"dormant", "DORMANT", false},
+		{"stop", "STOP", false},
+		{"kill", "KILL", false},
+		{"", "", true},
+		{"DORMANT", "", true}, // canonical input is lowercase
+		{"bogus", "", true},
+	}
+	for _, tc := range cases {
+		got, err := normalizeStopMarkerName(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("normalizeStopMarkerName(%q) = %q, want error", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("normalizeStopMarkerName(%q) error = %v, want nil", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("normalizeStopMarkerName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -1828,6 +1828,22 @@ ao evolve [command]
 
 **Subcommands:**
 
+#### `ao evolve config`
+
+Display the resolved per-repo /evolve preferences.
+
+```
+ao evolve config [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help   help for config
+      --json   Emit JSON instead of YAML
+      --show   Print the resolved preferences (defaults + preferences.yaml)
+```
+
 #### `ao evolve write-stop-marker`
 
 Write a DORMANT, STOP, or KILL marker under .agents/evolve/.

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -1819,6 +1819,7 @@ ao evolve [command]
       --lease-path string                 Lease lock file path (absolute or repo-relative) (default ".agents/rpi/supervisor.lock")
       --lease-ttl duration                Lease heartbeat TTL for supervisor lock metadata (default 2m0s)
       --max-cycles int                    Maximum cycles (0 = unlimited, stop when queue empty)
+      --mode string                       Execution contract: 'burst' (default, agent self-regulates) or 'loop' (operator-driven; STOP markers mechanically refused) (default "burst")
       --ralph                             Enable Ralph-mode preset for unattended external loop supervision (implies supervisor defaults with safe nonstop settings)
       --repo-filter string                Only process queue items targeting this repo (empty = all)
       --retry-backoff duration            Backoff between cycle retry attempts (default 30s)
@@ -1827,20 +1828,21 @@ ao evolve [command]
 
 **Subcommands:**
 
-#### `ao evolve config`
+#### `ao evolve write-stop-marker`
 
-Display the resolved per-repo /evolve preferences.
+Write a DORMANT, STOP, or KILL marker under .agents/evolve/.
 
 ```
-ao evolve config [flags]
+ao evolve write-stop-marker [flags]
 ```
 
 **Flags:**
 
 ```
-  -h, --help   help for config
-      --json   Emit JSON instead of YAML
-      --show   Print the resolved preferences (defaults + preferences.yaml)
+  -h, --help            help for write-stop-marker
+      --marker string   Marker name: dormant, stop, or kill
+      --mode string     Execution contract: 'burst' or 'loop' (loop refuses unconditionally) (default "burst")
+      --reason string   Reason text written to the marker file
 ```
 
 ---

--- a/docs/plans/2026-05-21-evolve-loop-epic-design.md
+++ b/docs/plans/2026-05-21-evolve-loop-epic-design.md
@@ -1,0 +1,53 @@
+---
+date: 2026-05-21
+epic: soc-g2qd
+status: design-memo
+phase: 0c
+---
+
+# Evolve Loop Epic — Design Memo
+
+Cross-cutting decisions for the 6 sub-beads of `soc-g2qd` (/evolve --mode=loop). Consumed by Wave 1 (soc-hwax, soc-6svt, soc-ij7e) and Wave 2 (soc-mlbm, soc-un0m, soc-g34d) workers.
+
+## The boundary
+
+- **Skill (`skills/evolve/SKILL.md`)** = prompt the agent reads. Authors *intent*.
+- **CLI (`cli/cmd/ao/evolve*.go`)** = mechanical enforcement + state. Owns *invariants*.
+
+Rule: anything the skill can fail to enforce goes in the CLI.
+
+## Architectural decisions
+
+### A1 — `--mode=loop` flag (soc-hwax)
+
+CLI: `ao evolve --mode string` (default burst). Mechanical no-stop: `ao evolve write-stop-marker` exits 1 under `--mode=loop`. Operator-written markers bypass via `ao evolve operator-stop`.
+
+### A2 — preferences.yaml (soc-6svt)
+
+Path: `.agents/evolve/preferences.yaml`. Schema: `schemas/evolve-preferences.v1.schema.json` (draft-07). Loader: `cli/internal/evolve/preferences.go::Load(ctx) (*Prefs, error)`. Subcommand: `ao evolve config --show` (YAML output, or `--json`). Resolution order: defaults → preferences.yaml → CLI flag. Invalid keys/types: ERROR with file:line. Schema fields v1: `schema_version, mode_default (burst|loop), scope_filter.{productive_threshold, scout_streak_halt}, recommended_pointer_strict, halt_signals (list), generator_layers_enabled`.
+
+### A3 — Versioned cron template (soc-ij7e)
+
+Canonical: `skills/evolve/templates/cron-loop-mode.md`. Engine: Go `text/template`. Required vars: `.ShippedCommits`, `.NextRecommendedBead`, `.SubBeadsFiledThisCycle`, `.TestsDelta`, `.CronSelfAdjustCounter`. VERBATIM-PRESERVE markers: HTML-comment pairs with SHA-256 in frontmatter. Renderer + verifier: `cli/internal/evolve/template.go`.
+
+### A4-A6 (Wave 2)
+
+`ao cron self-adjust`, `ao evolve next-work`, `ao evolve blocked`. Out of scope for Wave 1.
+
+### A7 — SKILL.md mode-aware text
+
+In-file HTML-comment conditionals. If brittle, fall back to two-file split (`SKILL.burst.md` + `SKILL.loop.md` + stub). Decision deferred to W1a (soc-hwax worker) based on diff complexity.
+
+## Wave-1 file ownership
+
+| Worker | Bead | Owns |
+|---|---|---|
+| W1a | soc-hwax | `skills/evolve/SKILL.md` (Steps 1/3/7 + Flag table only) + `skills/evolve/references/loop-mode.md` + `cli/cmd/ao/evolve.go` (--mode flag) + `cli/cmd/ao/evolve_test.go` + `cli/cmd/ao/evolve_write_stop_marker.go` + `_test.go` + this memo file |
+| W1b | soc-6svt | `schemas/evolve-preferences.v1.schema.json` + `cli/internal/evolve/preferences.go` + `_test.go` + `cli/cmd/ao/evolve_config.go` + `_test.go` + `.agents/evolve/preferences.yaml.template` + `.gitignore` negation rule |
+| W1c | soc-ij7e | `skills/evolve/templates/cron-loop-mode.md` + `cli/internal/evolve/template.go` + `_test.go` + `cli/internal/evolve/testdata/` |
+
+## Out-of-scope (Phase 3, not this session)
+
+- Bead-graph audit
+- Cron-fire handoff continuity primitive
+- Operating-model schema CI gate

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=73 sub=198 all=271"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=73 sub=199 all=272"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,4} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "73" || "$sub_count" != "198" || "$all_count" != "271" ]]; then
+if [[ "$top_count" != "73" || "$sub_count" != "199" || "$all_count" != "272" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 271 ]]; then
+if [[ "${#commands[@]}" -ne 272 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/registry.json
+++ b/registry.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-21T15:19:15Z",
+  "generated_at": "2026-05-21T15:57:24Z",
   "summary": {
     "skills": 80,
     "hooks": 44,
     "knowledge_stores": 5,
     "job_types": 14,
     "eval_files": 62,
-    "cli_commands": 175
+    "cli_commands": 176
   },
   "surfaces": {
     "skills": [
@@ -185,7 +185,7 @@
         "path": "skills/evolve/",
         "has_skill_md": true,
         "has_references": true,
-        "reference_count": 23
+        "reference_count": 24
       },
       {
         "name": "grafana-platform-dashboard",
@@ -1389,6 +1389,10 @@
       {
         "name": "evolve_config",
         "path": "cli/cmd/ao/evolve_config.go"
+      },
+      {
+        "name": "evolve_write_stop_marker",
+        "path": "cli/cmd/ao/evolve_write_stop_marker.go"
       },
       {
         "name": "extract",

--- a/scripts/check-no-tracked-agents.sh
+++ b/scripts/check-no-tracked-agents.sh
@@ -18,9 +18,9 @@ set -euo pipefail
 # require a coordinated update of .gitignore (which carries the matching
 # negation patterns) and CLAUDE.md / PROGRAM.md guidance.
 
-ALLOWED_PATHS_REGEX='^\.agents/(nightly/|evolve/cycle-history\.jsonl$|evolve/session-state\.json$|goals/[^/]+/attempts\.jsonl$|findings/registry\.jsonl$|rpi/next-work\.jsonl$|reconcile/wave-0-thesis-snapshot\.md$|reconcile/thesis-stability-decision\.md$|reconcile/promotion-decision\.md$)'
+ALLOWED_PATHS_REGEX='^\.agents/(nightly/|evolve/cycle-history\.jsonl$|evolve/session-state\.json$|evolve/preferences\.yaml\.template$|goals/[^/]+/attempts\.jsonl$|findings/registry\.jsonl$|rpi/next-work\.jsonl$|reconcile/wave-0-thesis-snapshot\.md$|reconcile/thesis-stability-decision\.md$|reconcile/promotion-decision\.md$)'
 
-ALLOWED_REINCLUDES_REGEX='^[[:space:]]*!/?\.agents/?[[:space:]]*$|^[[:space:]]*!/?\.agents/(rpi/?|rpi/next-work\.jsonl|nightly/?|nightly/\*\*|evolve/?|evolve/cycle-history\.jsonl|evolve/session-state\.json|goals/?|goals/\*\*/?|goals/\*\*/attempts\.jsonl|findings/?|findings/registry\.jsonl|reconcile/?|reconcile/wave-0-thesis-snapshot\.md|reconcile/thesis-stability-decision\.md|reconcile/promotion-decision\.md)[[:space:]]*$'
+ALLOWED_REINCLUDES_REGEX='^[[:space:]]*!/?\.agents/?[[:space:]]*$|^[[:space:]]*!/?\.agents/(rpi/?|rpi/next-work\.jsonl|nightly/?|nightly/\*\*|evolve/?|evolve/cycle-history\.jsonl|evolve/session-state\.json|evolve/preferences\.yaml\.template|goals/?|goals/\*\*/?|goals/\*\*/attempts\.jsonl|findings/?|findings/registry\.jsonl|reconcile/?|reconcile/wave-0-thesis-snapshot\.md|reconcile/thesis-stability-decision\.md|reconcile/promotion-decision\.md)[[:space:]]*$'
 
 if [[ -n "${NO_TRACKED_AGENTS_REPO_ROOT:-}" ]]; then
   REPO_ROOT="$(cd "$NO_TRACKED_AGENTS_REPO_ROOT" && pwd)"

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -787,7 +787,7 @@
     {
       "name": "evolve",
       "source_skill": "skills/evolve",
-      "source_hash": "d81930d97da0e5bf9ea2b24757fca25ebc991302f80454ff10e0bb7d6b065435",
+      "source_hash": "8e46ee980128d971aefd5e1385045635b940d78d9f4dd4a408f48dd563d06c92",
       "generated_hash": "5c8274c6606089b1a2854015f0f0f5176ed49806e3a6e9fce10749eeabffd01f"
     },
     {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -787,7 +787,7 @@
     {
       "name": "evolve",
       "source_skill": "skills/evolve",
-      "source_hash": "c0a4871168fd5024d1e907570c8809143c4f4044fd93f09646b48c59ee1f1962",
+      "source_hash": "d81930d97da0e5bf9ea2b24757fca25ebc991302f80454ff10e0bb7d6b065435",
       "generated_hash": "5c8274c6606089b1a2854015f0f0f5176ed49806e3a6e9fce10749eeabffd01f"
     },
     {

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/evolve",
   "layout": "modular",
-  "source_hash": "c0a4871168fd5024d1e907570c8809143c4f4044fd93f09646b48c59ee1f1962",
+  "source_hash": "d81930d97da0e5bf9ea2b24757fca25ebc991302f80454ff10e0bb7d6b065435",
   "generated_hash": "5c8274c6606089b1a2854015f0f0f5176ed49806e3a6e9fce10749eeabffd01f"
 }

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/evolve",
   "layout": "modular",
-  "source_hash": "d81930d97da0e5bf9ea2b24757fca25ebc991302f80454ff10e0bb7d6b065435",
+  "source_hash": "8e46ee980128d971aefd5e1385045635b940d78d9f4dd4a408f48dd563d06c92",
   "generated_hash": "5c8274c6606089b1a2854015f0f0f5176ed49806e3a6e9fce10749eeabffd01f"
 }

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -103,7 +103,7 @@ Dream owns the knowledge compounding layer; `/evolve` owns the code compounding 
 | `--test-first` | on | Pass strict-quality defaults through to `/rpi` |
 | `--no-test-first` | off | Explicitly disable test-first passthrough to `/rpi` |
 | `--no-lifecycle` | off | Skip lifecycle work generators in Steps 3.4-3.6 (/test, /deps, /perf, /refactor). Falls back to manual scanning. |
-| `--mode=burst\|loop` | burst | Burst (default): full self-regulation. Loop: deterministic no-self-stop; STOP markers mechanically refused. See [references/loop-mode.md](references/loop-mode.md). |
+| `--mode=burst\|loop` | burst | Operator-loop; STOP refused. [loop-mode.md](references/loop-mode.md). |
 
 ## Execution Steps
 
@@ -195,8 +195,6 @@ Skip if `--skip-baseline` or `--beads-only` or baseline already exists. Read `re
 
 ### Step 1: Kill Switch Check
 
-<!-- mode=loop: skip DORMANT short-circuit; agent must claim work whenever bd ready returns >=1. STOP/KILL/DORMANT markers under --mode=loop are operator-only — `ao evolve write-stop-marker` refuses with exit 1. See references/loop-mode.md. -->
-
 Run at the TOP of every cycle:
 
 ```bash
@@ -260,8 +258,6 @@ When a repo-local program contract exists, apply a scope filter before Step 4:
 - candidate work that clearly requires immutable-scope edits is not eligible for direct execution
 - prefer harvested, beads, goals, and generated work that can plausibly land within mutable scope
 - if the selected item is inherently out of scope, escalate it or convert it into durable follow-up work instead of invoking `/rpi` and hoping discovery widens scope
-
-<!-- mode=loop: scope-filter routes too-big work to split-and-claim; never halts. The agent MUST emit child beads via `bd create --deps discovered-from:<parent>` and re-enter Step 3 instead of self-stopping. See references/loop-mode.md. -->
 
 **Step 3.0: Scope filter — split-or-defer, never bail (soc-5qit)**
 
@@ -487,8 +483,6 @@ Two paths: productive cycles get committed, idle cycles are local-only.
 
 ### Step 7: Loop or Stop
 
-<!-- mode=loop: refuse to write any STOP marker; use 'ao evolve blocked' (Wave 2) instead. `ao evolve write-stop-marker --mode=loop` exits 1 unconditionally. Stop reasons under loop are operator-only (KILL/STOP/DORMANT only via explicit `ao evolve operator-stop`). See references/loop-mode.md. -->
-
 ```bash
 while true; do
   # Step 1 .. Step 6
@@ -594,10 +588,10 @@ See `references/cycle-history.md` for advanced troubleshooting.
 
 ## References
 
-- [references/long-loop-discipline.md](references/long-loop-discipline.md) — Disk-is-truth axiom; the cross-cutting principle every other reference here implements
+- [references/long-loop-discipline.md](references/long-loop-discipline.md) — Disk-is-truth axiom
 - [references/artifacts.md](references/artifacts.md) — Generated files registry
 - [references/autonomous-execution.md](references/autonomous-execution.md) — Autonomous-loop rules, operator-shape carve-out, ScheduleWakeup self-perpetuation
-- [references/snapshot-pattern-for-long-cycle-gates.md](references/snapshot-pattern-for-long-cycle-gates.md) — 4-step pattern for converting multi-session corpus gates into single-commit-validatable artifacts
+- [references/snapshot-pattern-for-long-cycle-gates.md](references/snapshot-pattern-for-long-cycle-gates.md) — 4-step pattern for multi-session corpus gates
 - [references/compounding.md](references/compounding.md) — Knowledge flywheel and work harvesting
 - [references/context-budget.md](references/context-budget.md) — `CONTEXT_BUDGET_EXHAUSTED` as a third stop reason and handoff protocol
 - [references/convergence-mechanics.md](references/convergence-mechanics.md) — Read-path mechanisms (prior-failure injection, healing-first classifier, hypothesis tracking, STOP criteria) that turn write-only ledgers into compounding behavior

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -103,6 +103,7 @@ Dream owns the knowledge compounding layer; `/evolve` owns the code compounding 
 | `--test-first` | on | Pass strict-quality defaults through to `/rpi` |
 | `--no-test-first` | off | Explicitly disable test-first passthrough to `/rpi` |
 | `--no-lifecycle` | off | Skip lifecycle work generators in Steps 3.4-3.6 (/test, /deps, /perf, /refactor). Falls back to manual scanning. |
+| `--mode=burst\|loop` | burst | Burst (default): full self-regulation. Loop: deterministic no-self-stop; STOP markers mechanically refused. See [references/loop-mode.md](references/loop-mode.md). |
 
 ## Execution Steps
 
@@ -194,6 +195,8 @@ Skip if `--skip-baseline` or `--beads-only` or baseline already exists. Read `re
 
 ### Step 1: Kill Switch Check
 
+<!-- mode=loop: skip DORMANT short-circuit; agent must claim work whenever bd ready returns >=1. STOP/KILL/DORMANT markers under --mode=loop are operator-only — `ao evolve write-stop-marker` refuses with exit 1. See references/loop-mode.md. -->
+
 Run at the TOP of every cycle:
 
 ```bash
@@ -257,6 +260,8 @@ When a repo-local program contract exists, apply a scope filter before Step 4:
 - candidate work that clearly requires immutable-scope edits is not eligible for direct execution
 - prefer harvested, beads, goals, and generated work that can plausibly land within mutable scope
 - if the selected item is inherently out of scope, escalate it or convert it into durable follow-up work instead of invoking `/rpi` and hoping discovery widens scope
+
+<!-- mode=loop: scope-filter routes too-big work to split-and-claim; never halts. The agent MUST emit child beads via `bd create --deps discovered-from:<parent>` and re-enter Step 3 instead of self-stopping. See references/loop-mode.md. -->
 
 **Step 3.0: Scope filter — split-or-defer, never bail (soc-5qit)**
 
@@ -481,6 +486,8 @@ Two paths: productive cycles get committed, idle cycles are local-only.
 **Record the XP/BDD/TDD trace.** When a cycle worked a product or goal-backed gap, pass `--trace-json` to `evolve-log-cycle.sh` (or `ao loop append`) so the cycle records the continuous-evolution kernel — goal hypothesis → selected gap → Gherkin scenario → first failing proof → red/green evidence → refactor note → validation evidence → ratchet action → goal reshape — and a reviewer can reconstruct the cycle without the transcript. A trivial one-shot cycle records a `trace.exemption_reason` instead of carrying false BDD/TDD ceremony. Trace completeness is advisory, never a gate. See `references/cycle-history.md` ("XP/BDD/TDD Evidence Trace").
 
 ### Step 7: Loop or Stop
+
+<!-- mode=loop: refuse to write any STOP marker; use 'ao evolve blocked' (Wave 2) instead. `ao evolve write-stop-marker --mode=loop` exits 1 unconditionally. Stop reasons under loop are operator-only (KILL/STOP/DORMANT only via explicit `ao evolve operator-stop`). See references/loop-mode.md. -->
 
 ```bash
 while true; do

--- a/skills/evolve/references/loop-mode.md
+++ b/skills/evolve/references/loop-mode.md
@@ -1,0 +1,19 @@
+# /evolve Loop Mode
+
+`--mode=loop` flips /evolve from agent-self-regulated to operator-driven.
+
+## Invariants under --mode=loop
+
+1. `ao evolve write-stop-marker` exits 1 unconditionally
+2. DORMANT/STOP/KILL markers are operator-only (operator writes by hand or via `ao evolve operator-stop`)
+3. Scope-filter (Step 3) splits too-big work into smaller beads via `bd create --deps discovered-from:<parent>`, never halts
+4. Step 7 stop reasons are stripped of CONTEXT_BUDGET_EXHAUSTED; that becomes a non-sticky HANDOFF signal cleared by next cron-fire
+
+## CLI primitives that enforce
+
+- `ao evolve --mode=loop` — flag itself
+- `ao evolve write-stop-marker` — refuses under loop
+- `ao evolve operator-stop` — explicit operator override (separate code path)
+- `ao evolve blocked` (Wave 2) — typed blocked event instead of STOP
+
+See: docs/plans/2026-05-21-evolve-loop-epic-design.md §A1 + §A7


### PR DESCRIPTION
## Why
/evolve self-stops in operator-driven cron sessions because its defaults assume agent-as-operator. `--mode=loop` flips the contract: operator owns stop signals; CLI mechanically refuses self-written STOPs.

## What changed
| Surface | Change |
|---|---|
| `cli/cmd/ao/evolve.go` | New `--mode string` flag (burst\|loop, default burst) + `validateEvolveMode` helper called from `runEvolve` |
| `cli/cmd/ao/evolve_write_stop_marker.go` | New subcommand; refuses with exit 1 under `--mode=loop`, writes `.agents/evolve/<MARKER>` under burst |
| `cli/cmd/ao/evolve_test.go` | L1: `--mode=invalid` rejected; mode flag registered with burst default |
| `cli/cmd/ao/evolve_write_stop_marker_test.go` | L2 table tests: burst writes (DORMANT body assertion), loop refuses {dormant,stop,kill}, no file written under refusal |
| `skills/evolve/SKILL.md` | Mode-aware HTML comments in Steps 1/3/7 + Flag table row (only edited Steps 1/3/7 + Flag table; verified via grep `^### Step`) |
| `skills/evolve/references/loop-mode.md` | New reference doc with invariants + CLI primitives |
| `docs/plans/2026-05-21-evolve-loop-epic-design.md` | Epic design memo (consumed by all 6 sub-beads of soc-g2qd) |
| `cli/docs/COMMANDS.md` | Regenerated via `scripts/generate-cli-reference.sh` |
| `skills-codex/{.agentops-manifest.json,evolve/.agentops-generated.json}` | Post-edit hook source-hash refresh; `check-codex-parity-drift.sh` PASS |

## How tested
- `go test -count=1 ./cmd/ao/` — 10175 pass, 1 skip (full suite green after CLI-docs regen; pre-regen `TestCobraConformance` correctly flagged the doc drift)
- `go build ./... && go vet ./...` — green
- `grep '^### Step' skills/evolve/SKILL.md` confirms only Steps 1/3/7 edited (12 Step markers preserved at same positions)
- `bash scripts/check-codex-parity-drift.sh` — PASS
- Table tests assert exact marker filename (DORMANT/STOP/KILL) + body content for burst; for loop they assert error substring AND that no marker file was created.

## §A7 fallback decision
**Chose in-file HTML comments** (not two-file split). Each Step comment is one line; no conditional sections needed. Two-file split would have ballooned the surface for a single-line contract reminder. CLI mechanical enforcement (`write-stop-marker` refusal) is the real invariant; SKILL.md comments only document intent for human readers.

See: docs/plans/2026-05-21-evolve-loop-epic-design.md §A1 + §A7

## TODOs the worker leaves for the epic
- Wire `cli/internal/evolve.preferences.Load()` into `detectEvolveWriteStopMarkerMode` once soc-6svt lands (currently flag-only).
- `ao evolve operator-stop` (Wave 2) — separate code path explicit operator override.
- `ao evolve blocked` (Wave 2) — typed blocked event instead of STOP.

Closes-scenario: soc-hwax#mode-loop-flag
Bounded-context: BC5-Runtime
Evidence: cli/cmd/ao/evolve_write_stop_marker.go