### PR TITLE
feat(evolve): port mt-olympus guardrail substrate — mechanical pre-cycle halt gate + doctrine ADRs (soc-sfjx #substrate)

### DIFF
--- a/docs/adr/ADR-0007-deterministic-loop-only-operator-stops.md
+++ b/docs/adr/ADR-0007-deterministic-loop-only-operator-stops.md
@@ -1,0 +1,29 @@
+# ADR-0007: Deterministic `/evolve` Loop — Only the Operator Stops It
+
+- **Status:** Accepted (2026-05-22)
+- **Author:** AgentOps maintainers
+- **Tracking:** bead `soc-sfjx`
+- **Origin:** ported from the mt-olympus unbounded-evolve substrate (`docs/decisions/2026-05-21-deterministic-loop-only-operator-stops.md`), which has driven ~245 cycles without self-halting.
+
+## Context
+
+`/evolve` is meant to run continuously while open work exists, with the operator **on** the loop (curating intent in `GOALS.md`, `PRODUCT.md`, ADRs, and the `bd ready` queue) rather than **in** it. Its self-regulation defaults were written assuming the agent IS the operator in a single burst session — so several defaults let any cycle's agent self-halt the loop on heuristics the operator never sanctioned (`CONTEXT_BUDGET_EXHAUSTED`, scout-streak halt, "honest stop"). `soc-5qit` already removed sticky `DORMANT`. This ADR makes the no-self-stop rule doctrine the loop re-reads every cycle, and — load-bearing — **mechanical**, not prose the agent can rationalize past.
+
+## Decision
+
+1. **The agent MAY NOT self-halt.** The only stop signals are operator-written:
+   - `~/.config/evolve/KILL` (global), `.agents/evolve/STOP` (repo) — honored within `EVOLVE_KILL_TTL_DAYS` (default 7); stale markers are surfaced and bypassed.
+   - `.agents/evolve/DORMANT` — non-sticky: auto-cleared whenever `bd ready` or harvested next-work has items (`soc-5qit`).
+   - Explicit operator removal of the driving cron / session.
+2. **The check is mechanical.** `scripts/evolve/halt-check.sh` runs before every cycle (Step 1 of the skill calls it). Marker checks, goal-regression, and prior-cycle-FAIL are evaluated in code, not in skill prose the agent might skip. `goal_regression` (latest `goals_passing` < prior productive cycle, read from `cycle-history.jsonl`) halts the loop for operator attention — revert-on-red, enforced.
+3. **When blocked, reason — don't stop.** The unblock ladder is mandatory: re-read the bead, grep for the sibling pattern, decompose into a smaller primitive, scout productively, pick a different ready bead or a bug-fix, file a discovered-from sub-bead, log via `ao evolve blocked`. NEVER write a STOP marker as an escape hatch.
+
+## Consequences
+
+- An empty claimable queue produces honest **operator-wait** (idle/sanity cycles), never false dormancy.
+- A genuine regression halts the loop so a human looks — the loop never papers over red.
+- The guarantee is testable: `tests/scripts/evolve-halt-check.bats` asserts both the gate's behavior and that the skill actually invokes it (no orphaned-primitive regression).
+
+## Evidence this is needed
+
+The `soc-g2qd` epic (2026-05-21) shipped six `/evolve` CLI primitives whose enforcement was *prose in the skill* — and the skill called none of them. An unsupervised session built the wrong thing for ~10 hours because its only gate was green CI. Mechanical, doctrine-anchored guardrails read every cycle are what keep mt-olympus's loop honest across hundreds of cycles; this ADR ports that property. See `.agents/research/2026-05-21-mt-olympus-evolve-loop.md`.

--- a/docs/adr/ADR-0008-evolve-intelligent-agile-operating-model.md
+++ b/docs/adr/ADR-0008-evolve-intelligent-agile-operating-model.md
@@ -1,0 +1,35 @@
+# ADR-0008: `/evolve` Operating Model — Intelligent-Agile, Not Waterfall
+
+- **Status:** Accepted (2026-05-22)
+- **Author:** AgentOps maintainers
+- **Tracking:** bead `soc-sfjx`
+- **Builds on:** [ADR-0007](ADR-0007-deterministic-loop-only-operator-stops.md)
+- **Origin:** ported from mt-olympus (`docs/decisions/2026-05-21-operating-model-intelligent-agile-not-waterfall.md`).
+
+## Context
+
+An autonomous loop fails in two opposite ways: it halts the moment work gets hard (over-cautious waterfall), or it confidently builds the wrong thing because nothing re-anchors it to operator intent (unanchored drift). The `soc-g2qd` session (2026-05-21) hit the second failure — it executed a bead queue as if it were validated spec, never re-derived the operator's actual goal, and shipped primitives no consumer used. This ADR defines the operating contract that prevents both.
+
+## Decision
+
+Three layers, read every cycle:
+
+1. **Intent (operator-owned, durable, re-read each cycle).** `GOALS.md`, `PRODUCT.md`, `PROGRAM.md`, the ADRs in this directory, and `bd ready`. The operator signals by editing these + by git commit + by bead-status change — not by chat. Each cycle the loop checks for new operator signal (`git log --oneline -1`, `bd ready`) before selecting work. **The bead queue is a hypothesis, not validated spec** — every cycle re-confirms the work still serves the stated goal.
+
+2. **Contract (locked before execution).** The architectural guardrail — agentops's 5 Bounded Contexts + the hexagonal `consumes`/`produces` skill frontmatter — is fixed up front. The loop shapes *within* the contract; it does not redraw it autonomously.
+
+3. **Execution + shaping authority (agent-owned, within the contract).** The loop may: pick atomic primitives, file discovered-from sub-beads, decompose monolithic beads via scout-mode, update the recommended-next pointer, and write ADRs documenting decisions made during execution. **Bounded: one slice per cycle**, gated (build + test holds-or-rises + lint), reverted on red.
+
+## The scope-precondition audit (anti-drift)
+
+Before implementing a candidate, apply the Primitive Test: does the bead name files, have observable acceptance, and cite a sibling/predecessor pattern? **If the candidate is really an architecture decision disguised as bounded work, file a bead instead of implementing it.** This is the guardrail that would have caught `soc-g2qd`: "build six CLI primitives" was architecture masquerading as bounded beads, and no audit flagged that the consumer never wired up. An integration slice with an L2 test exercising the *consumer* is mandatory for any "build a primitive" arc.
+
+## Consequences
+
+- The loop ships continuously without halting, but cannot autonomously redirect outside operator-set intent.
+- "Looks done" (green per-unit gates) is not "is done" — the consumer-calls-the-primitive L2 test is the close-gate, not unit-green alone.
+- Decisions made mid-execution are captured as ADRs here, so the doctrine compounds.
+
+## Evidence
+
+mt-olympus's loop sustained a 10-cycle marathon (cycles 123–129) shipping 6 critical-path hops + 14 filed sub-beads with the operator confirming intent once — because this model let it shape within a locked contract while re-reading intent each cycle. agentops lacked the model on 2026-05-21 and drifted. See `.agents/research/2026-05-21-mt-olympus-evolve-loop.md`.

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -57,6 +57,8 @@ Bridge / framing docs:
 - [ADR-0004: Domain-Slice Manifest Contract](adr/ADR-0004-domain-slice-manifest-contract.md) — Schema and resolution rules for `docs/domains/<name>/manifest.yaml`, the domain-scoped boundary contract consumed by `ao rpi phased --domain`
 - [ADR-0005: Trace-Link Convention](adr/ADR-0005-trace-link-convention.md) — The directive→scenario→bead→verdict→learning link grammar that `ao goals trace` renders and audits, including warning/error defect classes and `--strict` escalation
 - [ADR-0006: Re-Steer Policy and Mutation Safety](adr/ADR-0006-re-steer-policy-and-mutation-safety.md) — The `docs/re-steer-policy.json` engine, human-gate, and non-lossy GOALS.md patcher that govern `ao goals steer recommend`/`apply`
+- [ADR-0007: Deterministic /evolve Loop — Only the Operator Stops It](adr/ADR-0007-deterministic-loop-only-operator-stops.md) — Mechanical pre-cycle gate (`scripts/evolve/halt-check.sh`): operator-only markers, goal-regression halt, revert-on-red; ported from the mt-olympus unbounded-evolve substrate
+- [ADR-0008: /evolve Operating Model — Intelligent-Agile, Not Waterfall](adr/ADR-0008-evolve-intelligent-agile-operating-model.md) — Three-layer loop contract (intent re-read each cycle / locked architecture / bounded shaping authority) + the scope-precondition audit that prevents building-the-wrong-thing drift
 - [PDC Framework](architecture/pdc-framework.md) — Prevent, Detect, Correct quality control approach
 - [FAAFO Alignment](architecture/faafo-alignment.md) — FAAFO promise framework for vibe coding value
 - [Failure Patterns](architecture/failure-patterns.md) — The 12 failure patterns reference guide

--- a/scripts/evolve/halt-check.sh
+++ b/scripts/evolve/halt-check.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Mechanical pre-cycle halt gate for the autonomous /evolve loop.
+#
+# Externalizes the marker + regression checks that previously lived as inline
+# prose in skills/evolve/SKILL.md Step 1 / Step 1.5. Prose the agent might skip
+# becomes a script the agent MUST run: the skill calls this before every cycle
+# and exits the cycle when it returns non-zero. Adapted from the mt-olympus
+# unbounded-evolve substrate (scripts/evolve/halt-check.sh) to agentops marker
+# semantics (soc-5qit: non-sticky DORMANT, TTL on KILL/STOP) plus the
+# goal-regression gate agentops lacked.
+#
+# Usage:
+#   scripts/evolve/halt-check.sh          # human-readable (1 line on stdout)
+#   scripts/evolve/halt-check.sh --json   # {"halt":bool,"halt_reason":str|null}
+#
+# Env:
+#   EVOLVE_DIR             evolve state dir (default <repo>/.agents/evolve)
+#   EVOLVE_NEXTWORK        harvested next-work ledger (default <repo>/.agents/rpi/next-work.jsonl)
+#   EVOLVE_KILL_TTL_DAYS   KILL/STOP staleness window in days (default 7)
+#   EVOLVE_HALT_TIMEOUT    per-probe timeout seconds (default 30)
+#
+# Halt priority (highest first):
+#   1. ~/.config/evolve/KILL (fresh)        -> kill           (operator global)
+#   2. .agents/evolve/STOP   (fresh)        -> user_halt      (operator repo)
+#   3. .agents/evolve/DORMANT + no ready    -> dormant        (auto-clears if ready>0)
+#   4. cycle-history goals_passing dropped  -> goal_regression (last < prior productive)
+#   5. cycle-history latest result FAIL     -> prior_cycle_fail (restorative signal)
+#
+# Non-sticky HANDOFF is always cleared (context-handoff, not a halt).
+# Stale KILL/STOP (older than TTL) are surfaced loudly and NOT honored.
+#
+# Exit: 0 = continue (halt_reason=""), 1 = halt (halt_reason set).
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EVOLVE_DIR="${EVOLVE_DIR:-$ROOT/.agents/evolve}"
+NEXTWORK="${EVOLVE_NEXTWORK:-$ROOT/.agents/rpi/next-work.jsonl}"
+KILL_TTL_DAYS="${EVOLVE_KILL_TTL_DAYS:-7}"
+PROBE_TIMEOUT="${EVOLVE_HALT_TIMEOUT:-30}"
+
+json_mode=0
+[[ "${1:-}" == "--json" ]] && json_mode=1
+
+emit_result() {
+  local halt="$1" reason="$2"
+  if [[ "$json_mode" == "1" ]]; then
+    if [[ -z "$reason" ]]; then
+      printf '{"halt":%s,"halt_reason":null}\n' "$halt"
+    else
+      printf '{"halt":%s,"halt_reason":"%s"}\n' "$halt" "$reason"
+    fi
+  elif [[ "$halt" == "true" ]]; then
+    echo "HALT: $reason"
+  else
+    echo "OK: continue"
+  fi
+}
+
+# Returns 0 if the marker exists AND is fresh (within TTL); 1 otherwise.
+# A stale marker is surfaced on stderr and treated as not-blocking.
+marker_is_fresh() {
+  local path="$1" ttl_days="$2"
+  [[ -f "$path" ]] || return 1
+  local mtime now age
+  mtime="$(stat -c %Y "$path" 2>/dev/null || stat -f %m "$path" 2>/dev/null || echo 0)"
+  now="$(date +%s)"
+  age=$(( (now - mtime) / 86400 ))
+  if (( age > ttl_days )); then
+    echo "WARN: ${path} is ${age}d old (> ${ttl_days}d); STALE, proceeding. Re-touch it or raise EVOLVE_KILL_TTL_DAYS to keep blocking." >&2
+    return 1
+  fi
+  return 0
+}
+
+# 1. Operator global KILL (fresh)
+if marker_is_fresh "$HOME/.config/evolve/KILL" "$KILL_TTL_DAYS"; then
+  emit_result true "kill"
+  exit 1
+fi
+
+# 2. Operator repo STOP (fresh)
+if marker_is_fresh "$EVOLVE_DIR/STOP" "$KILL_TTL_DAYS"; then
+  emit_result true "user_halt"
+  exit 1
+fi
+
+# 3. DORMANT — non-sticky (soc-5qit). Auto-clear if real work exists; else halt.
+if [[ -f "$EVOLVE_DIR/DORMANT" ]]; then
+  ready="$(timeout "$PROBE_TIMEOUT" bd ready --json 2>/dev/null | jq -r 'length // 0' 2>/dev/null || echo 0)"
+  harvested="$(jq -r 'select(.consumed==false) | .severity' "$NEXTWORK" 2>/dev/null | wc -l | tr -d ' ')"
+  if [[ "${ready:-0}" -gt 0 || "${harvested:-0}" -gt 0 ]]; then
+    rm -f "$EVOLVE_DIR/DORMANT"  # stale: ready beads exist, loop resumes
+  else
+    emit_result true "dormant"
+    exit 1
+  fi
+fi
+
+# HANDOFF is non-sticky context-handoff, never a halt — always clear it.
+[[ -f "$EVOLVE_DIR/HANDOFF" ]] && rm -f "$EVOLVE_DIR/HANDOFF"
+
+# The canonical cycle ledger written by scripts/evolve-log-cycle.sh / `ao loop
+# append`. Each line carries `result` and, on productive cycles, `goals_passing`
+# + `goals_total`. We read the last two productive entries to detect regression
+# and the last entry's `result` for the restorative signal — no parallel report
+# writer needed.
+history="$EVOLVE_DIR/cycle-history.jsonl"
+if [[ ! -r "$history" ]]; then
+  emit_result false ""   # bootstrap: no ledger yet → nothing to regress against
+  exit 0
+fi
+
+# 4. Goal regression: latest productive goals_passing < the prior productive one.
+mapfile -t gp < <(
+  timeout "$PROBE_TIMEOUT" jq -r 'select(.goals_passing != null) | .goals_passing' "$history" 2>/dev/null \
+    | tail -2
+)
+if [[ ${#gp[@]} -eq 2 && "${gp[1]}" =~ ^[0-9]+$ && "${gp[0]}" =~ ^[0-9]+$ ]] && (( gp[1] < gp[0] )); then
+  emit_result true "goal_regression"
+  exit 1
+fi
+
+# 5. Prior-cycle FAIL → restorative signal (next cycle must reduce red, not add
+#    features). The skill reads this and sets restorative mode; not terminal.
+last_result="$(timeout "$PROBE_TIMEOUT" jq -r 'select(.result != null) | .result' "$history" 2>/dev/null | tail -1 || echo "")"
+case "$last_result" in
+  *FAIL*|*BLOCKED*) emit_result true "prior_cycle_fail"; exit 1 ;;  # *FAIL* also matches FAILED
+esac
+
+emit_result false ""
+exit 0

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -787,7 +787,7 @@
     {
       "name": "evolve",
       "source_skill": "skills/evolve",
-      "source_hash": "8e46ee980128d971aefd5e1385045635b940d78d9f4dd4a408f48dd563d06c92",
+      "source_hash": "ba103869c4c961dba31004ea3f07f8a302fa4436aad491f7f69747d8bbf0ea8b",
       "generated_hash": "5c8274c6606089b1a2854015f0f0f5176ed49806e3a6e9fce10749eeabffd01f"
     },
     {

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/evolve",
   "layout": "modular",
-  "source_hash": "8e46ee980128d971aefd5e1385045635b940d78d9f4dd4a408f48dd563d06c92",
+  "source_hash": "ba103869c4c961dba31004ea3f07f8a302fa4436aad491f7f69747d8bbf0ea8b",
   "generated_hash": "5c8274c6606089b1a2854015f0f0f5176ed49806e3a6e9fce10749eeabffd01f"
 }

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -142,6 +142,7 @@ Before cycle recovery, load the repo execution profile contract when it exists. 
 - Read the ordered `startup_reads` and bootstrap from those repo paths before selecting work.
 - Cache repo `validation_commands`, `tracker_commands`, and `definition_of_done` into session state.
 - If the repo execution profile is present but missing required fields, stop or downgrade with an explicit warning before cycle 1. Do not silently invent repo policy.
+- Read operating-doctrine ADRs (`docs/adr/` or `docs/decisions/`) when present — intent the loop re-reads each cycle: only operator markers stop the loop; the bead queue is a hypothesis re-confirmed against the goal, not spec; file-a-bead when a candidate is architecture disguised as bounded work.
 
 Then load the repo-local autodev program contract when it exists. The execution profile remains the repo bootstrap and landing-policy layer; `PROGRAM.md` or `AUTODEV.md` is the repo-local execution layer for the current improvement loop.
 
@@ -199,46 +200,29 @@ Run at the TOP of every cycle:
 
 ```bash
 CYCLE_START_SHA=$(git rev-parse HEAD)
-# Kill-switch with auto-expiration: a KILL file older than EVOLVE_KILL_TTL_DAYS
-# (default 7) days is treated as STALE — surface it loudly and continue, do not
-# silently block. Operator must re-touch the file to keep blocking. Closes F5
-# from the 2026-05-18 merge-arc post-mortem.
-EVOLVE_KILL_TTL_DAYS="${EVOLVE_KILL_TTL_DAYS:-7}"
-check_stale_kill() {
-    local path="$1"
-    local ttl_days="$2"
-    [ -f "$path" ] || return 1
-    local mtime_epoch now_epoch age_days
-    mtime_epoch=$(stat -c %Y "$path" 2>/dev/null || stat -f %m "$path" 2>/dev/null)
-    now_epoch=$(date +%s)
-    age_days=$(( (now_epoch - mtime_epoch) / 86400 ))
-    if [ "$age_days" -gt "$ttl_days" ]; then
-        echo "WARN: ${path} is ${age_days} days old (> ${ttl_days}); treating as STALE and proceeding. Re-touch the file or set EVOLVE_KILL_TTL_DAYS to keep blocking." >&2
-        return 1  # stale -> not a real block
+# Mechanical pre-cycle gate (soc-sfjx): markers (KILL/STOP/DORMANT/HANDOFF with
+# TTL + soc-5qit non-sticky semantics), goal-regression, and prior-cycle-FAIL.
+# This is a SCRIPT the loop MUST run, not prose it can skip — externalized from
+# the old inline block so the kill-switch + revert-on-red are enforced, not
+# advisory. Adapted from the mt-olympus unbounded-evolve substrate.
+if [ -x scripts/evolve/halt-check.sh ]; then
+  if ! HALT_OUT=$(bash scripts/evolve/halt-check.sh --json); then
+    REASON=$(printf '%s' "$HALT_OUT" | jq -r '.halt_reason // "unknown"')
+    if [ "$REASON" = "prior_cycle_fail" ]; then
+      export EVOLVE_RESTORATIVE=1   # not terminal: Step 1.5 restricts scope to CI-red reduction
+    else
+      echo "halt: $REASON"; exit 0  # kill/user_halt/dormant/goal_regression -> stop this cycle
     fi
-    return 0  # fresh -> honor the block
-}
-if check_stale_kill ~/.config/evolve/KILL "$EVOLVE_KILL_TTL_DAYS"; then
-    echo "KILL: $(cat ~/.config/evolve/KILL)"
-    exit 0
-fi
-if check_stale_kill .agents/evolve/STOP "$EVOLVE_KILL_TTL_DAYS"; then
-    echo "STOP: $(cat .agents/evolve/STOP 2>/dev/null)"
-    exit 0
-fi
-if [ -f .agents/evolve/DORMANT ]; then
-  READY=$(bd ready --json 2>/dev/null | jq -r 'length // 0' 2>/dev/null || echo 0)
-  HARVESTED=$(jq -r 'select(.consumed==false) | .severity' .agents/rpi/next-work.jsonl 2>/dev/null | wc -l | tr -d ' ')
-  if [ "$READY" -gt 0 ] || [ "$HARVESTED" -gt 0 ]; then
-    rm -f .agents/evolve/DORMANT  # stale: real work exists, loop resumes
-  else
-    echo "Dormant since $(head -1 .agents/evolve/DORMANT 2>/dev/null)."; exit 0
   fi
+else
+  # Fallback for repos without the substrate: minimal inline marker check.
+  for m in "$HOME/.config/evolve/KILL" .agents/evolve/STOP; do [ -f "$m" ] && { echo "halt: $m"; exit 0; }; done
+  [ -f .agents/evolve/DORMANT ] && { [ "$(bd ready --json 2>/dev/null | jq -r 'length // 0')" -gt 0 ] && rm -f .agents/evolve/DORMANT || { echo dormant; exit 0; }; }
+  [ -f .agents/evolve/HANDOFF ] && rm -f .agents/evolve/HANDOFF
 fi
-[ -f .agents/evolve/HANDOFF ] && rm -f .agents/evolve/HANDOFF  # non-sticky: cleared on fresh fire
 ```
 
-**Agile-first dormancy (soc-5qit):** `DORMANT` is NEVER sticky while ready beads exist; Step 1 re-validates every fire and auto-clears stale markers. KILL/STOP honor `EVOLVE_KILL_TTL_DAYS` (default 7). Heavy-context sessions write non-sticky HANDOFF and exit the turn; the next fire (compacted/fresh) clears HANDOFF and resumes — the loop is continuous across compactions.
+**Agile-first dormancy (soc-5qit):** `DORMANT` is NEVER sticky while ready beads exist — `halt-check.sh` auto-clears it when `bd ready`/harvested work exists. KILL/STOP honor `EVOLVE_KILL_TTL_DAYS` (default 7); stale markers are surfaced and bypassed. `goal_regression` (latest cycle report `goals_passing_after < before`) halts the loop for operator attention. Heavy-context sessions write non-sticky HANDOFF; the next fire clears it and resumes. The gate is mechanical: see `scripts/evolve/halt-check.sh`.
 
 ### Step 1.5: Healing-first classifier
 

--- a/tests/scripts/evolve-halt-check.bats
+++ b/tests/scripts/evolve-halt-check.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# L2 tests for scripts/evolve/halt-check.sh + the skill wiring (soc-sfjx).
+#
+# halt-check.sh is the mechanical pre-cycle gate ported from the mt-olympus
+# unbounded-evolve substrate. These tests prove (a) the gate's behavior across
+# markers / goal-regression / prior-fail, and — load-bearing — (b) that
+# skills/evolve/SKILL.md actually CALLS the gate. (b) is the regression guard
+# against the soc-g2qd failure mode: shipping a primitive no consumer invokes.
+
+setup() {
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  GATE="$REPO_ROOT/scripts/evolve/halt-check.sh"
+  SKILL="$REPO_ROOT/skills/evolve/SKILL.md"
+  TMP="$(mktemp -d)"
+  mkdir -p "$TMP/.agents/evolve"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+# --- (b) consumer-wiring proof: the skill MUST call the gate -----------------
+
+@test "SKILL.md invokes scripts/evolve/halt-check.sh (no orphaned primitive)" {
+  run grep -F 'scripts/evolve/halt-check.sh' "$SKILL"
+  [ "$status" -eq 0 ]
+  # And it is run in Step 1 (the kill-switch step), not merely mentioned in prose.
+  run bash -c "sed -n '/### Step 1: Kill Switch Check/,/### Step 1.5/p' '$SKILL' | grep -F 'bash scripts/evolve/halt-check.sh'"
+  [ "$status" -eq 0 ]
+}
+
+# --- (a) gate behavior -------------------------------------------------------
+
+@test "clean state continues (exit 0, halt false)" {
+  run env EVOLVE_DIR="$TMP/.agents/evolve" bash "$GATE" --json
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"halt":false,"halt_reason":null}' ]
+}
+
+@test "fresh repo STOP marker halts as user_halt" {
+  touch "$TMP/.agents/evolve/STOP"
+  run env EVOLVE_DIR="$TMP/.agents/evolve" bash "$GATE" --json
+  [ "$status" -eq 1 ]
+  [ "$output" = '{"halt":true,"halt_reason":"user_halt"}' ]
+}
+
+@test "stale STOP marker (older than TTL) is bypassed, loop continues" {
+  touch "$TMP/.agents/evolve/STOP"
+  # Backdate the marker 10 days; TTL set to 7.
+  touch -d "10 days ago" "$TMP/.agents/evolve/STOP" 2>/dev/null || touch -A -240000 "$TMP/.agents/evolve/STOP"
+  # WARN about staleness goes to stderr (bats merges it into $output); assert the
+  # gate continues (exit 0) and the no-halt JSON is present.
+  run env EVOLVE_DIR="$TMP/.agents/evolve" EVOLVE_KILL_TTL_DAYS=7 bash "$GATE" --json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'{"halt":false,"halt_reason":null}'* ]]
+  [[ "$output" == *"STALE"* ]]
+}
+
+@test "DORMANT with no ready work halts as dormant" {
+  # Hermetic: cd to a dir with no .beads (bd ready -> 0) + point harvested ledger
+  # at an empty file so neither real repo state leaks in.
+  touch "$TMP/.agents/evolve/DORMANT"
+  : > "$TMP/empty-next-work.jsonl"
+  cd "$TMP"
+  run env EVOLVE_DIR="$TMP/.agents/evolve" EVOLVE_NEXTWORK="$TMP/empty-next-work.jsonl" bash "$GATE" --json
+  [ "$status" -eq 1 ]
+  [ "$output" = '{"halt":true,"halt_reason":"dormant"}' ]
+}
+
+@test "DORMANT auto-clears when harvested work exists (soc-5qit non-sticky)" {
+  touch "$TMP/.agents/evolve/DORMANT"
+  printf '%s\n' '{"consumed":false,"severity":"high"}' > "$TMP/next-work.jsonl"
+  cd "$TMP"
+  run env EVOLVE_DIR="$TMP/.agents/evolve" EVOLVE_NEXTWORK="$TMP/next-work.jsonl" bash "$GATE" --json
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"halt":false,"halt_reason":null}' ]
+  [ ! -f "$TMP/.agents/evolve/DORMANT" ]   # auto-cleared
+}
+
+@test "HANDOFF is cleared and never halts" {
+  touch "$TMP/.agents/evolve/HANDOFF"
+  run env EVOLVE_DIR="$TMP/.agents/evolve" bash "$GATE" --json
+  [ "$status" -eq 0 ]
+  [ ! -f "$TMP/.agents/evolve/HANDOFF" ]
+}
+
+@test "goal regression (goals_passing drops) halts" {
+  printf '%s\n' '{"result":"productive","goals_passing":10,"goals_total":12}' >> "$TMP/.agents/evolve/cycle-history.jsonl"
+  printf '%s\n' '{"result":"productive","goals_passing":8,"goals_total":12}'  >> "$TMP/.agents/evolve/cycle-history.jsonl"
+  run env EVOLVE_DIR="$TMP/.agents/evolve" bash "$GATE" --json
+  [ "$status" -eq 1 ]
+  [ "$output" = '{"halt":true,"halt_reason":"goal_regression"}' ]
+}
+
+@test "goals_passing rising or flat does NOT halt" {
+  printf '%s\n' '{"result":"productive","goals_passing":8,"goals_total":12}'  >> "$TMP/.agents/evolve/cycle-history.jsonl"
+  printf '%s\n' '{"result":"productive","goals_passing":9,"goals_total":12}'  >> "$TMP/.agents/evolve/cycle-history.jsonl"
+  run env EVOLVE_DIR="$TMP/.agents/evolve" bash "$GATE" --json
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"halt":false,"halt_reason":null}' ]
+}
+
+@test "prior-cycle FAIL result emits restorative signal" {
+  printf '%s\n' '{"result":"FAIL: gate red","goals_passing":9,"goals_total":12}' >> "$TMP/.agents/evolve/cycle-history.jsonl"
+  run env EVOLVE_DIR="$TMP/.agents/evolve" bash "$GATE" --json
+  [ "$status" -eq 1 ]
+  [ "$output" = '{"halt":true,"halt_reason":"prior_cycle_fail"}' ]
+}
+
+@test "human-readable mode prints OK on clean state" {
+  run env EVOLVE_DIR="$TMP/.agents/evolve" bash "$GATE"
+  [ "$status" -eq 0 ]
+  [ "$output" = "OK: continue" ]
+}


### PR DESCRIPTION
## Why

`soc-g2qd` built six `/evolve` CLI primitives the skill never called; an unsupervised session then drifted for ~10h on green CI alone. Research (`.agents/research/2026-05-21-mt-olympus-evolve-loop.md`) showed mt-olympus runs the **same** `/evolve` skill non-stop (~245 cycles) because its guardrails are **mechanical** — a `halt-check.sh` that *runs before every cycle* — not prose the agent can skip. This ports that property to agentops.

## What changed

| Surface | Change |
|---|---|
| `scripts/evolve/halt-check.sh` (NEW) | Mechanical pre-cycle gate: operator markers (KILL/STOP/DORMANT/HANDOFF) with soc-5qit non-sticky + TTL semantics, goal-regression (cycle-history `goals_passing` drop), prior-cycle-FAIL restorative signal. `--json` + human modes. shellcheck-clean. |
| `skills/evolve/SKILL.md` Step 1 | **Wired**: replaces the 40-line inline marker block with `bash scripts/evolve/halt-check.sh` (graceful inline fallback for repos lacking it). Step 0 now reads `docs/adr`/`docs/decisions` doctrine each cycle. |
| `docs/adr/ADR-0007`, `ADR-0008` (NEW) | Deterministic-no-self-stop + intelligent-agile operating-model doctrine, adapted to agentops conventions (numbered `docs/adr/`) from mt-olympus's `docs/decisions/` ADRs. |
| `docs/documentation-index.md` | Catalogue ADR-0007/0008. |
| `tests/scripts/evolve-halt-check.bats` (NEW) | L2: gate behavior (markers/TTL/regression/fail/auto-clear) **AND** proves SKILL.md actually invokes the gate. |

## Lessons from soc-g2qd applied (so this isn't a repeat)

- **Adapt, not blind-copy:** halt-check reads agentops's existing `cycle-history.jsonl` schema (not mt-olympus's `cycle-*-report.json`); ADRs follow the `docs/adr/ADR-NNNN` convention (not `docs/decisions/`). Dropped `emit-cycle-report.sh` + `validate-cycle-closeout.sh` mid-build — agentops already has `scripts/evolve-log-cycle.sh`; parallel writers would duplicate infra.
- **Wire + test the consumer:** bats test 1 fails if SKILL.md stops calling the gate — the orphaned-primitive regression guard the prior epic lacked.

## How tested

- `shellcheck scripts/evolve/halt-check.sh` — clean
- `bats tests/scripts/evolve-halt-check.bats` — 11/11 (incl. consumer-wiring proof)
- `test-token-budgets.sh` — skills/evolve 9966 < 10000 (the Step 1 rewrite netted negative)
- `markdownlint` ADR-0007/0008 — 0 errors

Sibling pattern: mirrors mt-olympus `scripts/evolve/halt-check.sh` (priority-ordered marker/regression checks, `--json` contract), adapted to agentops markers.

Fitness: evolve guardrails 0 mechanical → 1 enforced pre-cycle; tests 0 → 11 passing; skill budget 9989 → 9966.

Closes-scenario: soc-sfjx#substrate
Bounded-context: BC5-Runtime
Evidence: scripts/evolve/halt-check.sh