### PR TITLE
feat(evolve): wire 3 soc-g2qd primitives into the skill (next-work, write-stop-marker, blocked) (soc-g2qd #wire-primitives)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -787,7 +787,7 @@
     {
       "name": "evolve",
       "source_skill": "skills/evolve",
-      "source_hash": "ba103869c4c961dba31004ea3f07f8a302fa4436aad491f7f69747d8bbf0ea8b",
+      "source_hash": "b6903edd93cd9dac1124b913153fe80b67e43062997726e8f766bff02cb26dc5",
       "generated_hash": "5c8274c6606089b1a2854015f0f0f5176ed49806e3a6e9fce10749eeabffd01f"
     },
     {

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/evolve",
   "layout": "modular",
-  "source_hash": "ba103869c4c961dba31004ea3f07f8a302fa4436aad491f7f69747d8bbf0ea8b",
+  "source_hash": "b6903edd93cd9dac1124b913153fe80b67e43062997726e8f766bff02cb26dc5",
   "generated_hash": "5c8274c6606089b1a2854015f0f0f5176ed49806e3a6e9fce10749eeabffd01f"
 }

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -226,9 +226,9 @@ fi
 
 ### Step 1.5: Healing-first classifier
 
-Before fitness or work selection, classify the cycle: `ao ci recent --limit 1 2>/dev/null | jq -r '.Conclusion // empty'`. The command routes through the typed BC2 `CIStatusPort` (`cli/cmd/ao/ci_status_adapter.go`, cycle 117 productionCIStatus) — no inline `gh` shell-outs in the evolve hot path (soc-y5vh.2). If the last push CI was `failure`, this cycle is **restorative-only** — Step 3 selection MUST take only work that reduces CI red (bug-type harvested items, gate-failure-fix beads, or generator output typed bug). No PG4 promotions, feature additions, or new shape work allowed until CI is green. The cycle-history.jsonl `gate` field of any FAIL cycle automatically triggers this mode for cycle N+1. See `references/convergence-mechanics.md`.
+Before fitness or work selection, classify the cycle: `ao ci recent --limit 1 2>/dev/null | jq -r '.Conclusion // empty'` (typed BC2 `CIStatusPort`, soc-y5vh.2). If the last push CI was `failure`, this cycle is **restorative-only** — Step 3 takes only CI-red-reducing work (bug-type harvested items, gate-failure-fix beads, generator bug output); no promotions, features, or new-shape work until green. A `gate=FAIL` in cycle-history.jsonl auto-triggers this for cycle N+1 (and `halt-check.sh` surfaces it as `prior_cycle_fail`). See `references/convergence-mechanics.md`.
 
-**Convergence check:** evaluate the STOP predicate through the typed BC3 `ConvergenceCheckPort` — `ao loop converged --green-streak <n> --unconsumed-high-medium <n> [--fitness-baseline]` (soc-y5vh.8). It emits `{converged, ci_green_streak, unconsumed_high_medium, fitness_baseline_captured, reasons}`; branch on `.converged` instead of hand-parsing `.agents/evolve/session-convergence.json`. If `converged` is true (default criteria: CI green streak ≥ 3, outstanding HIGH+MEDIUM next-work ≤ 1, fitness baseline captured), emit teardown and DO NOT re-arm wakeup.
+**Convergence check:** evaluate the STOP predicate via the typed BC3 `ConvergenceCheckPort` — `ao loop converged --green-streak <n> --unconsumed-high-medium <n> [--fitness-baseline]` (soc-y5vh.8). Branch on `.converged` (default: CI green streak ≥ 3, HIGH+MEDIUM next-work ≤ 1, fitness baseline captured); if true, emit teardown and do NOT re-arm wakeup.
 
 ### Step 2: Measure Fitness
 
@@ -237,6 +237,12 @@ Skip if `--beads-only`. Run `scripts/evolve-measure-fitness.sh` to produce a rol
 ### Step 3: Select Work
 
 Selection is a ladder, not a one-shot check. After every productive cycle, return to the TOP of this step and re-read the queue before considering dormancy.
+
+**Programmatic recommendation (soc-g2qd wire):** when present, consult the ladder primitive first and prefer its `.recommended_bead`; the rungs below are the cross-check + fallback.
+
+```bash
+ao evolve next-work --help >/dev/null 2>&1 && RECO_BEAD=$(ao evolve next-work --json 2>/dev/null | jq -r '.recommended_bead // empty')
+```
 
 When a repo-local program contract exists, apply a scope filter before Step 4:
 - candidate work that clearly requires immutable-scope edits is not eligible for direct execution
@@ -253,7 +259,7 @@ Before claiming a candidate, gate scope vs session budget. If the work touches >
 
 Scout NEVER returns "no work done." If `bd ready` ≥1, the loop MUST claim one this cycle. See `references/scout-mode.md` and `references/mechanical-batches.md`.
 
-**Metronome gate:** read `mode_repeat_streak` from `session-state.json` (kept current by `scripts/evolve-update-session-state.sh`). If `mode_repeat_streak >= 3` AND the candidate work would produce the same `mode` value as the trailing run, BLOCK selection at this rung and force a jump to the NEXT rung in the ladder. If `mode_repeat_streak >= 5`, file a `bd remember "metronome-N: <mode>"` and require operator override before continuing on that rung. See `references/metronome-gate.md` for the detection rule and the cycles 144-154 retrospective.
+**Metronome gate:** read `mode_repeat_streak` from `session-state.json`. If `>= 3` AND the candidate would repeat the trailing run's `mode`, BLOCK this rung and jump to the next. If `>= 5`, `bd remember "metronome-N: <mode>"` and require operator override. See `references/metronome-gate.md`.
 
 **Step 3.1: Harvested work first**
 
@@ -387,7 +393,14 @@ if [ "$READY_BEADS" -gt 0 ] || [ "$HARVESTED" -gt 0 ] || [ "$FAILING_GOALS" -gt 
   continue  # work exists — loop back to Step 3 (agile invariant)
 fi
 if [ "${GENERATOR_EMPTY_STREAK:-0}" -ge 2 ] && [ "${IDLE_STREAK:-0}" -ge 2 ]; then
-  printf '%s\n%s\n%s\n' "cycle $CYCLE" "$(date -u +%FT%TZ)" "stagnation: all sources empty x3" > .agents/evolve/DORMANT
+  REASON="stagnation: all sources empty x3"
+  # soc-g2qd wire: under loop, write-stop-marker refuses → log blocked + operator-wait, never self-halt (ADR-0007).
+  if ao evolve write-stop-marker --help >/dev/null 2>&1; then
+    ao evolve write-stop-marker --marker dormant --reason "$REASON" --mode loop 2>/dev/null \
+      || ao evolve blocked --reason "$REASON" --needed-context "queue empty; operator adds work or marker" 2>/dev/null || true
+  else
+    printf '%s\n%s\n%s\n' "cycle $CYCLE" "$(date -u +%FT%TZ)" "$REASON" > .agents/evolve/DORMANT  # fallback
+  fi
 fi
 ```
 

--- a/tests/scripts/evolve-primitive-wiring.bats
+++ b/tests/scripts/evolve-primitive-wiring.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+# Consumer-wiring proof for the soc-g2qd /evolve CLI primitives.
+#
+# The soc-g2qd epic shipped six primitives the skill never called (the failure
+# this guards against). These tests assert that skills/evolve/SKILL.md actually
+# invokes the three primitives that were wired (write-stop-marker, next-work,
+# blocked) at their real decision sites. If a future edit drops a wire, the
+# corresponding test fails — the orphaned-primitive regression guard.
+#
+# Behavior of each primitive is covered by its own Go tests
+# (cli/cmd/ao/evolve_*_test.go); these tests are wiring-only.
+
+setup() {
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  SKILL="$REPO_ROOT/skills/evolve/SKILL.md"
+}
+
+@test "SKILL.md Step 3 invokes 'ao evolve next-work' for work selection" {
+  run bash -c "sed -n '/### Step 3: Select Work/,/### Step 4/p' '$SKILL' | grep -F 'ao evolve next-work'"
+  [ "$status" -eq 0 ]
+}
+
+@test "SKILL.md routes the stagnation marker write through 'ao evolve write-stop-marker'" {
+  run grep -F 'ao evolve write-stop-marker --marker dormant' "$SKILL"
+  [ "$status" -eq 0 ]
+}
+
+@test "SKILL.md logs a typed blocked event via 'ao evolve blocked' instead of halting" {
+  run grep -F 'ao evolve blocked --reason' "$SKILL"
+  [ "$status" -eq 0 ]
+}
+
+@test "the write-stop-marker wire passes --mode loop (deterministic no-self-stop)" {
+  run grep -F 'ao evolve write-stop-marker --marker dormant --reason "$REASON" --mode loop' "$SKILL"
+  [ "$status" -eq 0 ]
+}
+
+@test "each wire keeps a fallback for ao without the subcommand (--help probe)" {
+  # write-stop-marker + next-work both guard their call behind a --help probe so
+  # an older ao falls back instead of erroring.
+  run grep -F 'ao evolve write-stop-marker --help >/dev/null 2>&1' "$SKILL"
+  [ "$status" -eq 0 ]
+  run grep -F 'ao evolve next-work --help >/dev/null 2>&1' "$SKILL"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Why

Completes the `soc-g2qd` intent the original epic missed: the primitives are now **called** by `/evolve`, not just shipped. Scope-audited per **ADR-0008** (the guardrail whose absence caused the original failure) — wired the 3 that map to real decision sites; left 3 unwired (`cron self-adjust` = the dead end you rejected; `--mode` = redundant with the halt-check substrate; `config` = marginal), tracked in **soc-epc2**.

## What changed (`skills/evolve/SKILL.md` only — no Go/CLI surface change)

| Wire | Site | Effect |
|---|---|---|
| `ao evolve next-work --json` | Step 3 Select Work | Prefer the ladder primitive's `.recommended_bead`; rungs remain cross-check + fallback |
| `ao evolve write-stop-marker --mode loop` | stagnation site (was a direct `> .agents/evolve/DORMANT`) | Routes the marker **write** through mechanical refusal; under loop it refuses (ADR-0007) |
| `ao evolve blocked --reason` | stagnation site | On refusal, log a typed blocked event + operator-wait instead of self-halting |

Each wire is guarded behind a `--help` probe so an **older `ao`** (without the subcommand) falls back to prior behavior — no hard dependency on the unreleased CLI.

## Tests

- `tests/scripts/evolve-primitive-wiring.bats` (NEW, 5): asserts SKILL.md invokes each primitive at its site, passes `--mode loop`, and keeps the `--help` fallback. **The orphaned-primitive regression guard the original epic lacked** — fails if a future edit drops a wire.
- `tests/scripts/evolve-halt-check.bats` — still 11/11 (substrate intact).

## Token budget

Wiring + offsetting trims (metronome / convergence / Step-1.5 prose tightened; detail already in references): 9966 → **9999** (< 10000). The chronic ceiling itself is filed as **soc-opq5** (refactor prose → references).

Sibling pattern: mirrors the soc-sfjx substrate wire (`--help`-probe + fallback + bats consumer-proof) from PR #399.

Fitness: soc-g2qd primitives wired into consumer 0 → 3; wiring-proof tests 0 → 5.

Closes-scenario: soc-g2qd#wire-primitives
Bounded-context: BC5-Runtime
Evidence: tests/scripts/evolve-primitive-wiring.bats