### PR TITLE
chore(scripts): CI script hygiene — portable paths + generator quoting (#trivial)

### DIFF
--- a/scripts/add-validate-job.sh
+++ b/scripts/add-validate-job.sh
@@ -138,8 +138,8 @@ WORKFLOW_JOB="  ${JOB_NAME}:
 ${PY_SETUP}
       - name: ${REASON}
         run: |
-          chmod +x ${HELPER_SCRIPT}
-          ./${HELPER_SCRIPT}
+          chmod +x \"${HELPER_SCRIPT}\"
+          \"./${HELPER_SCRIPT}\"
 "
 
 # 2. pre-push section (numbered 22z+, but use a marker not a fixed letter)
@@ -147,8 +147,8 @@ PREPUSH_SECTION="
 # --- ${JOB_NAME} (scaffolded by add-validate-job.sh) ---
 # ${REASON}
 # Always runs (no needs_check guard).
-if [[ -f ${HELPER_SCRIPT} ]]; then
-    if scaffold_${JOB_NAME//-/_}_output=\"\$(bash ${HELPER_SCRIPT} 2>&1)\"; then
+if [[ -f \"${HELPER_SCRIPT}\" ]]; then
+    if scaffold_${JOB_NAME//-/_}_output=\"\$(bash \"${HELPER_SCRIPT}\" 2>&1)\"; then
         pass \"${JOB_NAME}\"
     else
         fail \"${JOB_NAME}\"

--- a/scripts/inventory-jsm-skills.sh
+++ b/scripts/inventory-jsm-skills.sh
@@ -3,8 +3,8 @@
 #
 # Usage:
 #   scripts/inventory-jsm-skills.sh
-#   scripts/inventory-jsm-skills.sh --root /Users/bo/.claude/skills --json
-#   scripts/inventory-jsm-skills.sh --backup-root /Users/bo/backups/jsm-skills-YYYYMMDD-HHMMSS --markdown
+#   scripts/inventory-jsm-skills.sh --root "$HOME/.claude/skills" --json
+#   scripts/inventory-jsm-skills.sh --backup-root "$HOME/backups/jsm-skills-YYYYMMDD-HHMMSS" --markdown
 set -euo pipefail
 
 FORMAT="json"
@@ -197,8 +197,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ "${#ROOTS[@]}" -eq 0 ]]; then
-    [[ -d /Users/bo/.claude/skills ]] && ROOTS+=("/Users/bo/.claude/skills")
-    [[ -d /Users/bo/.codex/skills ]] && ROOTS+=("/Users/bo/.codex/skills")
+    [[ -d "${HOME}/.claude/skills" ]] && ROOTS+=("${HOME}/.claude/skills")
+    [[ -d "${HOME}/.codex/skills" ]] && ROOTS+=("${HOME}/.codex/skills")
 fi
 
 objects=$(mktemp)


### PR DESCRIPTION
## What

Two small CI-script hygiene fixes from the v2.41.1→main audit (Wave 0, PR-1 of the 3.0-alignment plan):

1. **`inventory-jsm-skills.sh`** — replace hardcoded `/Users/bo` macOS paths with `$HOME`, so the inventory resolves skills on Linux/CI instead of silently returning an empty result. (bead `agentops-yxid`)
2. **`add-validate-job.sh`** — quote `${HELPER_SCRIPT}` in the generated workflow + pre-push bash so scaffolded jobs are shellcheck-clean. Uses escaped quotes inside the double-quoted templates (the bare-quote first attempt broke the template string — caught by shellcheck SC2027/SC1078). (bead `agentops-obef`)

## Test plan

- `shellcheck --severity=error` clean on both files (CI parity)
- full `shellcheck` clean on both files
- `bash -n` syntax OK
- `add-validate-job.sh ... --dry-run` shows correctly quoted generated output:
  `chmod +x "scripts/..."`, `[[ -f "scripts/..." ]]`, `bash "scripts/..."`
- `scripts/pre-push-gate.sh --fast` passed

Closes-scenario: agentops-yxid#ci-portable-paths
Closes-scenario: agentops-obef#ci-genbash-quoting
Bounded-context: BC5-Runtime
Evidence: pre-push-gate --fast passed; shellcheck clean; dry-run quoted output verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)