### PR TITLE
fix(evals): unstale 3 release-gate eval hard-fails behind legit refactors (soc-2gd6 #eval-hard-fails)

### DIFF
--- a/AGENTS-WORKFLOW.md
+++ b/AGENTS-WORKFLOW.md
@@ -164,6 +164,8 @@ This moves the tag to HEAD, pushes, rebuilds the GitHub release, updates the Hom
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
 - NEVER leave a foreign branch-attached worktree without a recorded disposition
+- Keep the canonical root clean and attached to `main`.
+- Run `bash scripts/check-worktree-disposition.sh` before push and session close.
 - If `bd dolt push` says no remote is configured, do not treat that as a
   session failure. Record it as unavailable, then continue with the mandatory
   Git push. See [bd server-mode tracker closeout](docs/runbooks/bd-server-mode-closeout.md).

--- a/evals/agentops-core/fixtures/security-toolchain-governance-smoke.sh
+++ b/evals/agentops-core/fixtures/security-toolchain-governance-smoke.sh
@@ -275,7 +275,6 @@ job_start = workflow.index("  security-toolchain-gate:")
 job_end = workflow.index("\n  skill-integrity:", job_start)
 job = workflow[job_start:job_end]
 required_job_bits = [
-    "continue-on-error: true",
     "./scripts/security-gate.sh --mode quick",
     "uses: actions/upload-artifact@",
     "if: always()",

--- a/evals/agentops-core/hook-manifest-runtime-contracts.json
+++ b/evals/agentops-core/hook-manifest-runtime-contracts.json
@@ -116,7 +116,7 @@
       "timeout_seconds": 60,
       "inputs": {
         "cwd": "../..",
-        "shell": "jq -e '[.. | .command? // empty] as $cmds | ($cmds | length == 43) and ($cmds | map(capture(\"(?<script>[^/ ]+\\\\.sh)$\").script) | unique | length == 36) and (($cmds | map(select(test(\"ao-inject\\\\.sh\"))) | length) == 0)' hooks/hooks.json >/dev/null && echo hook-manifest-counts-ok"
+        "shell": "jq -e '[.. | .command? // empty] as $cmds | ($cmds | length == 44) and ($cmds | map(capture(\"(?<script>[^/ ]+\\\\.sh)$\").script) | unique | length == 37) and (($cmds | map(select(test(\"ao-inject\\\\.sh\"))) | length) == 0)' hooks/hooks.json >/dev/null && echo hook-manifest-counts-ok"
       },
       "expectations": [
         {"type": "exit_code", "value": 0},

--- a/evals/agentops-core/push-worktree-closeout.json
+++ b/evals/agentops-core/push-worktree-closeout.json
@@ -108,13 +108,13 @@
       "kind": "artifact_check",
       "objective": "Keep AGENTS closeout policy explicit that a session is not complete until changes are committed, pushed, remotely confirmed, and foreign worktrees have a recorded disposition.",
       "expectations": [
-        {"type": "artifact_contains", "target": "../../AGENTS.md", "value": "## Landing the Plane (Session Completion)"},
-        {"type": "artifact_contains", "target": "../../AGENTS.md", "value": "Work is NOT complete until `git push` succeeds."},
-        {"type": "artifact_contains", "target": "../../AGENTS.md", "value": "git status  # MUST show \"up to date with origin\""},
-        {"type": "artifact_contains", "target": "../../AGENTS.md", "value": "NEVER stop before pushing - that leaves work stranded locally"},
-        {"type": "artifact_contains", "target": "../../AGENTS.md", "value": "NEVER leave a foreign branch-attached worktree without a recorded disposition"},
-        {"type": "artifact_contains", "target": "../../AGENTS.md", "value": "Keep the canonical root clean and attached to `main`."},
-        {"type": "artifact_contains", "target": "../../AGENTS.md", "value": "Run `bash scripts/check-worktree-disposition.sh` before push and session close."}
+        {"type": "artifact_contains", "target": "../../AGENTS-WORKFLOW.md", "value": "## Landing the Plane (Session Completion)"},
+        {"type": "artifact_contains", "target": "../../AGENTS-WORKFLOW.md", "value": "Work is NOT complete until `git push` succeeds."},
+        {"type": "artifact_contains", "target": "../../AGENTS-WORKFLOW.md", "value": "git status  # MUST show \"up to date with origin\""},
+        {"type": "artifact_contains", "target": "../../AGENTS-WORKFLOW.md", "value": "NEVER stop before pushing - that leaves work stranded locally"},
+        {"type": "artifact_contains", "target": "../../AGENTS-WORKFLOW.md", "value": "NEVER leave a foreign branch-attached worktree without a recorded disposition"},
+        {"type": "artifact_contains", "target": "../../AGENTS-WORKFLOW.md", "value": "Keep the canonical root clean and attached to `main`."},
+        {"type": "artifact_contains", "target": "../../AGENTS-WORKFLOW.md", "value": "Run `bash scripts/check-worktree-disposition.sh` before push and session close."}
       ],
       "dimensions": ["process_adherence", "artifact_quality", "safety"],
       "critical": true


### PR DESCRIPTION
## Why

The v2.42.0 release gate (`scripts/ci-local-release.sh`) was red on 8 evals. The 3 score-0/near-0 hard fails are all **eval-staleness behind legitimate recent refactors** — verified, not gaming or security weakening. Operator decision: update eval to match source of truth (executable > contract).

| Eval | Was | Cause | Fix |
|---|---|---|---|
| `hook-manifest-command-counts` | 0 | `session-pr-counter.sh` (PR #362) is the legit 37th hook script; eval hardcoded 43/36 | bump expected counts 43→44, 36→37 |
| `push-worktree landing-plane` | 0.14 | #387 tiered-AGENTS split moved "Landing the Plane" to `AGENTS-WORKFLOW.md` (+ dropped 2 lines) | redirect eval target `AGENTS.md`→`AGENTS-WORKFLOW.md` + restore the 2 dropped policy lines |
| `security-toolchain ci-soft-gate-policy` | 0 | gate is intentionally **HARD** (no `continue-on-error`); job already runs `security-gate.sh --mode quick` + uploads artifacts | drop the stale `continue-on-error` requirement (security stays HARD) |

**Security note:** `security-toolchain-gate` stays a HARD blocking gate. Only the stale "soft gate" assertion was removed from the eval; the actual scan + artifact upload + summary-blocking are unchanged.

## How tested
- hook-manifest jq → `hook-manifest-counts-ok`
- security smoke `ci-policy` → `security-toolchain-ci-policy-ok`
- all 7 landing-plane strings present in `AGENTS-WORKFLOW.md`
- shellcheck clean on edited smoke

## Scope honesty
This fixes the 3 **hard** fails only. The release gate still has **5 minor evals (0.71–0.99)** + the **vil/release-smoke** lane — a separate remediation, deliberately NOT in this PR (no green-washing).

Sibling pattern: same "update eval to match legitimately-changed source of truth" move as the cli-command-surface canary bumps in #396/#397.

Fitness: release-gate eval hard-fails 3 → 0.

Closes-scenario: soc-2gd6#eval-hard-fails
Bounded-context: BC4-Validation
Evidence: evals/agentops-core/fixtures/security-toolchain-governance-smoke.sh