### PR TITLE
build(go): enforce copyloopvar + usestdlibvars; trim golangci debt (agentops-fr9 #go-lint-config)

### DIFF
--- a/cli/.golangci.yml
+++ b/cli/.golangci.yml
@@ -3,11 +3,19 @@ version: "2"
 linters:
   default: none
   enable:
+    - copyloopvar
     - errcheck
     - gocyclo
     - govet
     - misspell
     - staticcheck
+    - usestdlibvars
+    # Deferred to their fix beads (enabling whole-tree today surfaces a backlog
+    # and/or findings in deprecated files we don't touch):
+    #   - errorlint  -> agentops-bs8 (after %w/errors.Is backlog cleared)
+    #   - unconvert  -> agentops-0l9 (rpi_c2_events.go is deprecated; needs path exclusion)
+    #   - unused     -> agentops-0l9 (~37 backlog; risky auto-removal)
+    # errcheck already covers json.Marshal/Unmarshal (not excluded) -> satisfies agentops-tqc.3.
   settings:
     gocyclo:
       min-complexity: 25

--- a/cli/cmd/ao/beads_resume.go
+++ b/cli/cmd/ao/beads_resume.go
@@ -118,7 +118,7 @@ var beadsResumeAppendLedger = func(ledgerPath string, event any) error {
 	if err != nil {
 		return fmt.Errorf("open ledger: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	enc := json.NewEncoder(f)
 	if err := enc.Encode(event); err != nil {
 		return fmt.Errorf("encode event: %w", err)

--- a/cli/cmd/ao/cron_self_adjust.go
+++ b/cli/cmd/ao/cron_self_adjust.go
@@ -226,7 +226,7 @@ func appendCronHistoryRow(path string, row cronSelfAdjustHistoryRow) error {
 	if err != nil {
 		return fmt.Errorf("open history %s: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	data, err := json.Marshal(row)
 	if err != nil {
 		return fmt.Errorf("marshal history row: %w", err)
@@ -257,7 +257,7 @@ func cronHistoryReadRows(path string) ([]cronSelfAdjustHistoryRow, error) {
 		}
 		return nil, fmt.Errorf("open %s: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	var rows []cronSelfAdjustHistoryRow

--- a/cli/cmd/ao/evolve_blocked.go
+++ b/cli/cmd/ao/evolve_blocked.go
@@ -293,12 +293,12 @@ func rewriteBlockedEvents(path string, events []BlockedEvent) error {
 		data, err := json.Marshal(ev)
 		if err != nil {
 			f.Close()
-			os.Remove(tmp)
+			_ = os.Remove(tmp)
 			return fmt.Errorf("marshal blocked event: %w", err)
 		}
 		if _, err := f.Write(append(data, '\n')); err != nil {
 			f.Close()
-			os.Remove(tmp)
+			_ = os.Remove(tmp)
 			return fmt.Errorf("write tmp: %w", err)
 		}
 	}

--- a/cli/cmd/ao/evolve_write_stop_marker.go
+++ b/cli/cmd/ao/evolve_write_stop_marker.go
@@ -64,7 +64,7 @@ func runEvolveWriteStopMarker(cmd *cobra.Command, _ []string) error {
 	if mode == evolveModeLoop {
 		// Stderr surface is load-bearing: tests and operators key off this
 		// string to confirm the loop contract is in force.
-		return fmt.Errorf("STOP markers refused under --mode=loop. Use 'ao evolve operator-stop' for explicit operator intent.")
+		return fmt.Errorf("STOP markers refused under --mode=loop. Use 'ao evolve operator-stop' for explicit operator intent")
 	}
 
 	marker, err := normalizeStopMarkerName(evolveWriteStopMarkerName)

--- a/cli/cmd/ao/rpi_loop_test.go
+++ b/cli/cmd/ao/rpi_loop_test.go
@@ -1333,7 +1333,7 @@ func TestMarkItemClaimedConcurrentSingleWinner(t *testing.T) {
 	errs := make(chan error, len(claimers))
 
 	for _, claimer := range claimers {
-		claimer := claimer
+
 		go func() {
 			<-start
 			errs <- markItemClaimed(path, 0, 0, claimer)

--- a/cli/cmd/ao/rpi_phased_domain_coverage_test.go
+++ b/cli/cmd/ao/rpi_phased_domain_coverage_test.go
@@ -37,7 +37,7 @@ func TestNormalizeAuditPath(t *testing.T) {
 		{"whitespace + dot-slash", "  ./cli/x.go  ", "cli/x.go"},
 	}
 	for _, tc := range cases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := normalizeAuditPath(tc.in)
@@ -250,7 +250,7 @@ func TestDomainManifestPath(t *testing.T) {
 		{"a", filepath.Join("docs", "domains", "a", "manifest.yaml")},
 	}
 	for _, tc := range cases {
-		tc := tc
+
 		t.Run(tc.domain, func(t *testing.T) {
 			t.Parallel()
 			got := domainManifestPath(tc.domain)

--- a/cli/cmd/ao/rpi_serve_test.go
+++ b/cli/cmd/ao/rpi_serve_test.go
@@ -184,7 +184,7 @@ func TestSetCORSHeaders(t *testing.T) {
 
 	// With localhost origin, echoes it back
 	rr = httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Origin", "http://localhost:3000")
 	setCORSHeaders(rr, req)
 	if v := rr.Header().Get("Access-Control-Allow-Origin"); v != "http://localhost:3000" {
@@ -193,7 +193,7 @@ func TestSetCORSHeaders(t *testing.T) {
 
 	// With non-localhost origin, does not set origin header
 	rr = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/", nil)
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Origin", "http://evil.example.com")
 	setCORSHeaders(rr, req)
 	if v := rr.Header().Get("Access-Control-Allow-Origin"); v != "" {

--- a/cli/cmd/ao/skill_contract_test.go
+++ b/cli/cmd/ao/skill_contract_test.go
@@ -58,7 +58,7 @@ func TestCouncilVerdictHeadingContract(t *testing.T) {
 	const requiredHeading = "## Council Verdict:"
 
 	for _, skill := range wrapperSkills {
-		skill := skill // capture loop variable
+		// capture loop variable
 		t.Run(skill, func(t *testing.T) {
 			// Billboard architecture: a skill's detail may live in references/.
 			// The verdict-heading contract holds if SKILL.md OR any

--- a/cli/cmd/ao/temper_test.go
+++ b/cli/cmd/ao/temper_test.go
@@ -450,7 +450,7 @@ func TestTemperCoverage_ValidateArtifact(t *testing.T) {
 	tmp := t.TempDir()
 
 	for _, tc := range temperValidateArtifactCases() {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			tc.run(t, tmp)
 		})

--- a/cli/internal/daemon/recurrence_test.go
+++ b/cli/internal/daemon/recurrence_test.go
@@ -64,7 +64,7 @@ func TestRecurrence_BackpressureDecision_PureFunction(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			fire, reason := shouldFire(tc.template, tc.queueDepth, tc.hasInFlight)
 			if fire != tc.wantFire {

--- a/cli/internal/daemon/rpi_run_test.go
+++ b/cli/internal/daemon/rpi_run_test.go
@@ -313,7 +313,7 @@ func TestRPIRunEmitsAgentUpdates(t *testing.T) {
 			// Verify boilerplate (JobID, Actor, RequestID) and payload (run_id, phase_name)
 			// on the phase_start event so we know the wrapper carries claim metadata.
 			start := events[0]
-			if start.JobID != "job-emit" || string(start.RequestID) != "req-emit" || start.Actor != "test-actor" {
+			if start.JobID != "job-emit" || start.RequestID != "req-emit" || start.Actor != "test-actor" {
 				t.Errorf("phase_start boilerplate = %+v", start)
 			}
 			if start.Payload["run_id"] != "run-emit" || start.Payload["phase_name"] != "rpi.run" {

--- a/cli/internal/daemon/store_test.go
+++ b/cli/internal/daemon/store_test.go
@@ -381,7 +381,7 @@ func TestRotateWhileAppendingDoesNotLoseEvents(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(writers)
 	for w := 0; w < writers; w++ {
-		w := w
+
 		go func() {
 			defer wg.Done()
 			for i := 0; i < perWriter; i++ {

--- a/cli/internal/daemon/telemetry_test.go
+++ b/cli/internal/daemon/telemetry_test.go
@@ -26,7 +26,7 @@ func TestPhaseLatencyHistogram(t *testing.T) {
 		t.Fatalf("discovery histogram = %#v, want count=2 p50=10s p99=21s", discovery)
 	}
 	implementation := histograms["implementation"]
-	if implementation.Count != 1 || implementation.P50Millis != int64((3*time.Second).Milliseconds()) || implementation.P99Millis != int64((3*time.Second).Milliseconds()) {
+	if implementation.Count != 1 || implementation.P50Millis != (3*time.Second).Milliseconds() || implementation.P99Millis != (3*time.Second).Milliseconds() {
 		t.Fatalf("implementation histogram = %#v, want count=1 p50/p99=3s", implementation)
 	}
 }

--- a/cli/internal/daemon/wiki_jobs_test.go
+++ b/cli/internal/daemon/wiki_jobs_test.go
@@ -235,8 +235,7 @@ func TestWikiJobs_RejectsTraversalSourcePaths(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		tc := tc
-		i := i
+
 		t.Run(tc.name, func(t *testing.T) {
 			store := NewStore(root)
 			queue := NewQueue(store, QueueOptions{})

--- a/cli/internal/domainslice/manifest_test.go
+++ b/cli/internal/domainslice/manifest_test.go
@@ -304,7 +304,7 @@ func TestParse_BadDirectiveIDPattern(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			y := strings.ReplaceAll(validManifestYAML(), "d-myapp-core", tc.id)
@@ -432,7 +432,7 @@ func TestParse_ValidDirectiveIDs(t *testing.T) {
 		"d-abc123",
 	}
 	for _, id := range cases {
-		id := id
+
 		t.Run(id, func(t *testing.T) {
 			t.Parallel()
 			y := strings.ReplaceAll(validManifestYAML(), "d-myapp-core", id)

--- a/cli/internal/evolve/ladder/ladder.go
+++ b/cli/internal/evolve/ladder/ladder.go
@@ -116,7 +116,7 @@ func Run(ctx context.Context, br BeadRunner, gr GrepRunner, cfg Config) (Recomme
 			}
 			return rec, nil
 		}
-		rationale := fmt.Sprintf("shape-compatible ready bead at step 1")
+		rationale := "shape-compatible ready bead at step 1"
 		if len(grepHits) > 0 {
 			rationale += "; sibling refs: " + strings.Join(grepHits, ", ")
 		}

--- a/cli/internal/evolve/template_test.go
+++ b/cli/internal/evolve/template_test.go
@@ -164,7 +164,7 @@ func TestParseFrontmatter(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			fm, err := parseFrontmatter([]byte(tc.input))
 			if tc.wantErr {
@@ -214,7 +214,7 @@ func TestComputeMarkerSHA(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			got := ComputeMarkerSHA(tc.in)
 			if got != tc.want {

--- a/cli/internal/llm/ollama_client.go
+++ b/cli/internal/llm/ollama_client.go
@@ -227,7 +227,7 @@ func (c *OllamaClient) fetchTags() (*tagsResponse, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("status %d", resp.StatusCode)
 	}
 	var out tagsResponse
@@ -245,7 +245,7 @@ func (c *OllamaClient) fetchContextBudget() (int, bool) {
 		return 0, false
 	}
 	resp, err := c.httpClient.Post(c.endpoint+"/api/show", "application/json", bytes.NewReader(body))
-	if err != nil || resp.StatusCode != 200 {
+	if err != nil || resp.StatusCode != http.StatusOK {
 		if resp != nil {
 			_ = resp.Body.Close()
 		}

--- a/cli/internal/llm/ollama_client_test.go
+++ b/cli/internal/llm/ollama_client_test.go
@@ -207,7 +207,7 @@ func TestOllamaClient_Generate_RetriesOn5xx(t *testing.T) {
 		"/api/generate": func(w http.ResponseWriter, r *http.Request) {
 			calls++
 			if calls < 2 {
-				w.WriteHeader(503)
+				w.WriteHeader(http.StatusServiceUnavailable)
 				return
 			}
 			_, _ = io.WriteString(w, `{"response":"ok"}`)

--- a/cli/internal/overnight/ingest.go
+++ b/cli/internal/overnight/ingest.go
@@ -496,7 +496,7 @@ func (r *ingestRunner) runFindingGenerators() error {
 	}
 	results := make(chan findingGeneratorRunResult, len(generators))
 	for _, generator := range generators {
-		generator := generator
+
 		go func() {
 			results <- runFindingGenerator(r.ctx, r.opts, generator)
 		}()

--- a/cli/internal/overnight/live_tree_hash_invariant_test.go
+++ b/cli/internal/overnight/live_tree_hash_invariant_test.go
@@ -79,7 +79,7 @@ type liveTreeHashInvariantCase struct {
 // regression coverage of the single-case shape.
 func TestRunLoop_LiveTreeHashInvariant_AllStatuses(t *testing.T) {
 	for _, tc := range liveTreeHashInvariantCases() {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			runLiveTreeHashInvariantCase(t, tc)
 		})

--- a/cli/internal/ratchet/validate_test.go
+++ b/cli/internal/ratchet/validate_test.go
@@ -1123,7 +1123,7 @@ func TestValidateForPromotion(t *testing.T) {
 	v, tmpDir := helperNewValidator(t)
 
 	for _, tc := range validateForPromotionCases() {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			tc.run(t, v, tmpDir)
 		})

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -206,7 +206,7 @@ func TestIsAllowed_Predicate(t *testing.T) {
 		{"exact-dir-allows", []string{"cli/cmd/ao"}, "cli/cmd/ao", true},
 	}
 	for _, tc := range cases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			lock := &Lock{FrozenDirs: tc.frozen}
 			if tc.frozen == nil {
@@ -238,7 +238,7 @@ func TestWrite_AtomicityUnderConcurrency(t *testing.T) {
 	wg.Add(N)
 	errs := make(chan error, N)
 	for i := 0; i < N; i++ {
-		i := i
+
 		go func() {
 			defer wg.Done()
 			if err := Freeze(path, []string{"dir/" + itoa(i)}); err != nil {

--- a/cli/internal/wiki/conformance_test.go
+++ b/cli/internal/wiki/conformance_test.go
@@ -12,7 +12,7 @@
 //   - ports.FrontmatterCodecPort   adapter: wiki.PortCodec
 //   - ports.WikiIndexPort          adapter: wiki.WikiIndex
 //   - ports.FreshnessPolicyPort    adapter: freshnessPortAdapter (test-local;
-//                                  see its doc comment)
+//     see its doc comment)
 //
 // Each port has exactly one production adapter today, so each conformance
 // table currently has one row. The contract functions (conformFrontmatterCodec,
@@ -110,7 +110,7 @@ var frontmatterCodecContract = []frontmatterCodecCase{
 func conformFrontmatterCodec(t *testing.T, adapter ports.FrontmatterCodecPort) {
 	t.Helper()
 	for _, tc := range frontmatterCodecContract {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			// Contract: Decode returns a non-nil Fields map on every input.
 			doc := adapter.Decode(tc.text)
@@ -464,7 +464,7 @@ var freshnessPolicyContract = []freshnessCase{
 func conformFreshnessPolicy(t *testing.T, adapter ports.FreshnessPolicyPort) {
 	t.Helper()
 	for _, tc := range freshnessPolicyContract {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			verdict := adapter.Evaluate(tc.volatility, tc.authority, tc.signal, tc.verifiedAt)
 
@@ -520,7 +520,7 @@ func TestConformance(t *testing.T) {
 			{name: "wiki.PortCodec", adapter: NewPortCodec()},
 		}
 		for _, a := range adapters {
-			a := a
+
 			t.Run(a.name, func(t *testing.T) {
 				conformFrontmatterCodec(t, a.adapter)
 			})
@@ -535,7 +535,7 @@ func TestConformance(t *testing.T) {
 			{name: "wiki.WikiIndex", make: newWikiIndexUnderTest},
 		}
 		for _, a := range adapters {
-			a := a
+
 			t.Run(a.name, func(t *testing.T) {
 				adapter, makeFile, touchFile := a.make(t)
 				conformWikiIndex(t, adapter, makeFile, touchFile)
@@ -551,7 +551,7 @@ func TestConformance(t *testing.T) {
 			{name: "wiki.freshnessPortAdapter", make: newFreshnessPortAdapter},
 		}
 		for _, a := range adapters {
-			a := a
+
 			t.Run(a.name, func(t *testing.T) {
 				conformFreshnessPolicy(t, a.make())
 			})

--- a/cli/internal/wiki/freshness_test.go
+++ b/cli/internal/wiki/freshness_test.go
@@ -245,7 +245,7 @@ func TestFreshnessState_Valid(t *testing.T) {
 		}
 	}
 	for _, s := range []FreshnessState{"", "expired", "unknown", "FRESH"} {
-		if FreshnessState(s).Valid() {
+		if s.Valid() {
 			t.Errorf("FreshnessState %q should be invalid", s)
 		}
 	}


### PR DESCRIPTION
## What (Wave 1, PR-4 of the 3.0-alignment plan — partial of agentops-fr9)

Mechanizes more of the Go standard (`skills/standards/references/go.md`) into the enforced `cli/.golangci.yml`, and trims pre-existing lint debt that CI currently severity-tolerates.

**Linters enabled (both 0 findings after `--fix`):**
- `copyloopvar` — drop redundant Go 1.22+ loop-variable copies
- `usestdlibvars` — use `http.Method*` / `http.Status*` constants instead of magic strings/ints

**Debt trimmed (already-enabled linters):**
- `errcheck`: wrapped safe `defer Close` / best-effort `os.Remove` sites → errcheck findings 11 → 6
- `staticcheck`: fixed S1039 (redundant `Sprintf`) + ST1005 (error string punctuation)
- `unconvert`: removed redundant conversions in tests

## Agile decisions (not waterfall)
- `errcheck` already covers `json.Marshal/Unmarshal` (not in `exclude-functions`) → **satisfies `agentops-tqc.3`** (no code needed; closing it).
- **Deferred** to their fix beads, with reasons:
  - `errorlint` → `agentops-bs8` (after the `%w`/`errors.Is` backlog is cleared)
  - `unconvert` + `unused` → `agentops-0l9` (`unused` ~37 backlog is risky to auto-remove; `unconvert` has a finding in the **deprecated** `rpi_c2_events.go` which we don't touch — needs a path exclusion first)
- The 6 residual `errcheck` findings are pre-existing atomic-write `Close` calls where a blind `_ =` could hide data loss — left for the careful errcheck cleanup, not silenced here.

## Test plan
- `golangci-lint v2.11.4` (CI's pinned version): `copyloopvar=0`, `usestdlibvars=0`
- `go build ./...`, `go vet ./...`, `go test ./...` — all green (59 packages)
- `scripts/pre-push-gate.sh --fast` — passed

Bounded-context: BC5-Runtime
Evidence: golangci-lint copyloopvar=0 + usestdlibvars=0; go build/vet/test ./... green; pre-push-gate --fast passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)