### PR TITLE
feat(implement): executable acceptance for the /implement loop hexagon (soc-g0vx #implement-hexagon)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -847,7 +847,7 @@
     {
       "name": "implement",
       "source_skill": "skills/implement",
-      "source_hash": "bd805840819e2189e528cf17ae8a4acbf26d521515ce70286157eef44a9f3f35",
+      "source_hash": "8f72272440a4fa4df69bf41d370a7dfe7feab10c956c800fbfa2ca33577a8cd8",
       "generated_hash": "a71a281c6d41263fcaff338a910a92d44fd72ba15e6d37b1e483e5af0c0ce732"
     },
     {

--- a/skills-codex/implement/.agentops-generated.json
+++ b/skills-codex/implement/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/implement",
   "layout": "modular",
-  "source_hash": "bd805840819e2189e528cf17ae8a4acbf26d521515ce70286157eef44a9f3f35",
+  "source_hash": "8f72272440a4fa4df69bf41d370a7dfe7feab10c956c800fbfa2ca33577a8cd8",
   "generated_hash": "a71a281c6d41263fcaff338a910a92d44fd72ba15e6d37b1e483e5af0c0ce732"
 }

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -162,6 +162,7 @@ Remaining: <what's left>
 - [references/binary-deployment-gate.md](references/binary-deployment-gate.md) — CLI/hook binary-deployment gate spec
 - [references/gate-checks.md](references/gate-checks.md) — Ratchet and pre-mortem gate checks
 - [references/green-mode.md](references/green-mode.md) — GREEN mode test-first implementation rules
+- [references/implement.feature](references/implement.feature) — Executable spec: the /implement done-state (first-failing-test → green → refactor → verified close) (soc-qk4b.2)
 - [references/quality-loop.md](references/quality-loop.md) — Pre-commit autonomous quality loop
 - [references/resume-protocol.md](references/resume-protocol.md) — Resume protocol for interrupted sessions
 - [references/workflow.md](references/workflow.md) — Full execution workflow (Steps 0 through 8)

--- a/skills/implement/references/implement.feature
+++ b/skills/implement/references/implement.feature
@@ -1,0 +1,34 @@
+# Executable spec for the /implement skill — the loop's slice executor (BC3 Loop).
+# /implement takes ONE tracked issue (a bounded slice carrying domain intent) and
+# produces verified git-changes via TDD: a first failing test, then the minimal
+# change to green, then refactor — never claiming done without a passing build.
+# Hexagon: driving-adapter; consumes: domain; produces: git-changes. (soc-qk4b.2)
+
+Feature: Implement one tracked issue via TDD
+  As the loop's slice executor
+  I want each issue implemented test-first with a verified build before close
+  So that every slice ships as evidence-backed git-changes, never status text
+
+  Background:
+    Given a single tracked issue with a bounded scope and stated acceptance
+    And a clean worktree at the slice's base SHA
+
+  Scenario: First failing test precedes implementation
+    When /implement starts the slice
+    Then it writes or identifies a failing test for the acceptance first
+    And no implementation code is written before that test fails
+
+  Scenario: Minimal change to green, then refactor
+    Given a first failing test
+    When /implement makes the change
+    Then the test passes with the smallest sufficient change
+    And any refactor happens only after green, with the test still passing
+
+  Scenario: Verification iron law gates close
+    When /implement believes the slice is done
+    Then build, tests, and lint pass (go build/vet/test or the per-language equivalent)
+    And the issue closes only after verification passes — never from status text alone
+
+  Scenario: Output is verified git-changes with closure evidence
+    Then /implement produces committed git-changes (produces: git-changes)
+    And it records ratchet / closure evidence against the issue


### PR DESCRIPTION
## Why

**First productive cycle of the substrate-governed evolve cron.** A child of `soc-qk4b.2` (loop-spine hexagon crank): `/implement` had complete hexagon frontmatter (driving-adapter; consumes `domain`; produces `git-changes`) but **no executable acceptance** — the universal gap across all 9 loop skills. This adds the Gherkin done-state spec and links it.

## What changed
- `skills/implement/references/implement.feature` (NEW) — executable spec: first-failing-test → minimal-green → refactor → verification-iron-law gates close → verified git-changes + closure evidence.
- `skills/implement/SKILL.md` — link the `.feature` in Reference Documents (linkage gate).

## How tested
- `lint-skills.sh` → ✓ implement (linkage + frontmatter)
- `ao goals scenarios --lint` → 0 errors (13 pre-existing warnings, unrelated)
- `audit-codex-parity.sh --skill implement` → passed; `regen-codex-hashes` clean

Sibling pattern: mirrors `skills/council/references/council-modes.feature` (the executable-spec `.feature` convention).

Fitness: loop-skill executable acceptance 0 → 1; soc-qk4b.2 wave 0 → 1 cranked.

Closes-scenario: soc-g0vx#implement-hexagon
Bounded-context: BC3-Loop
Evidence: skills/implement/references/implement.feature