### PR TITLE
feat(plan): promote /plan executable acceptance to canonical references/plan.feature (soc-phr9 #plan-hexagon)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -889,7 +889,7 @@
     {
       "name": "plan",
       "source_skill": "skills/plan",
-      "source_hash": "cbde267e8094eafcd887a667e9184f52d8847d8c160c515463846a3a90a00524",
+      "source_hash": "59b47c42c32601f5e0d83521f757db62bb91ba97efbbfa4c3e514237b167a941",
       "generated_hash": "98f259c86afd2e462b62f4971af70c028963d1e617b38f856274d9e230c19209"
     },
     {

--- a/skills-codex/plan/.agentops-generated.json
+++ b/skills-codex/plan/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/plan",
   "layout": "modular",
-  "source_hash": "cbde267e8094eafcd887a667e9184f52d8847d8c160c515463846a3a90a00524",
+  "source_hash": "59b47c42c32601f5e0d83521f757db62bb91ba97efbbfa4c3e514237b167a941",
   "generated_hash": "98f259c86afd2e462b62f4971af70c028963d1e617b38f856274d9e230c19209"
 }

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -57,14 +57,7 @@ for the boundary from Discovery into Plan:
 | Context packet | slice plan, file dependency matrix, acceptance criteria, test levels |
 | Guard adapter | stale-scope verification, symbol verification, wave-validity check |
 
-```gherkin
-Feature: Plan converts dense intent into executable slices
-  Scenario: Plan consumes Discovery output
-    Given Discovery provides density fields and artifact links
-    When Plan receives the `plan_slices` port request
-    Then each slice has acceptance criteria, write scope, test levels, and ownership
-    And no slice depends on raw Discovery chat context
-```
+Executable acceptance: [references/plan.feature](references/plan.feature) — consumes Discovery output, one slice per Given/When/Then row, wave-validity gate, durable slice-validation artifact.
 
 ## Flags
 

--- a/skills/plan/references/plan.feature
+++ b/skills/plan/references/plan.feature
@@ -1,0 +1,35 @@
+# Executable spec for the /plan skill — vertical-slice decomposition (BC3 Loop).
+# /plan consumes dense BDD intent (Discovery output, a bead, or research artifact)
+# on the `plan_slices` inbound port and produces a slice-validation plan: one slice
+# per Given/When/Then row, each with a first-failing-test target, write scope,
+# bounded context, and ownership. Slices group into a wave only when the
+# wave-validity check passes. Hexagon: domain; consumes: standards;
+# produces: .agents/plans/*.md + execution-packet.json. (soc-qk4b.2)
+
+Feature: Plan converts dense intent into executable slices
+  As the loop's decomposition step
+  I want dense intent turned into self-contained, validated slices
+  So that implementation runs from the plan alone, never from raw chat context
+
+  Scenario: Plan consumes Discovery output
+    Given Discovery provides density fields and artifact links
+    When Plan receives the `plan_slices` port request
+    Then each slice has acceptance criteria, write scope, test levels, and ownership
+    And no slice depends on raw Discovery chat context
+
+  Scenario: One slice per Given/When/Then row
+    Given a BDD intent issue with N Given/When/Then rows
+    When Plan decomposes it
+    Then it emits N vertical slices, each with a first-failing-test target
+
+  Scenario: Wave-validity gate before parallelization
+    Given a set of candidate slices
+    When Plan groups them into a wave
+    Then the wave passes only if every row holds: distinct write scopes, no shared
+      migration/contract/CLI surface, a declared integration order, an owner per slice,
+      and a discard path per slice
+    And slices default to sequential when any row fails
+
+  Scenario: Plan produces a durable slice-validation artifact
+    Then Plan writes a slice plan to .agents/plans/*.md and an execution-packet.json
+    And a fresh agent can execute the slices from those artifacts alone


### PR DESCRIPTION
## Why

`soc-qk4b.2` loop-spine crank, cycle 2 (substrate cron). `/plan` had a *seed* — an inline 1-scenario gherkin block in SKILL.md — but not the canonical `references/*.feature` the skill-factory standard requires. This promotes + expands it.

## What changed
- `skills/plan/references/plan.feature` (NEW): full done-state — consumes Discovery output; one slice per Given/When/Then row (first-failing-test target); **wave-validity gate** (distinct write scopes / no shared migration-contract-CLI / declared integration order / owner+discard path per slice; sequential default); durable slice-validation artifact (`.agents/plans/*.md` + `execution-packet.json`).
- `skills/plan/SKILL.md`: replaced the inline 1-scenario block with a pointer to the canonical `.feature` (single source of truth; linkage gate satisfied).

## How tested
- `lint-skills.sh` → ✓ plan
- `ao goals scenarios --lint` → 0 errors (13 pre-existing warnings, unrelated)
- `audit-codex-parity.sh --skill plan` → passed; `regen-codex-hashes` clean

Sibling pattern: mirrors `skills/implement/references/implement.feature` (PR #404) — same promote-to-canonical crank.

Fitness: loop-skill canonical executable acceptance 1 → 2; soc-qk4b.2 wave 2/6.

Closes-scenario: soc-phr9#plan-hexagon
Bounded-context: BC3-Loop
Evidence: skills/plan/references/plan.feature