### PR TITLE
feat(crank): executable acceptance for the /crank loop hexagon (soc-k4s9 #crank-hexagon)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -739,7 +739,7 @@
     {
       "name": "crank",
       "source_skill": "skills/crank",
-      "source_hash": "2aa5cdb991c180047d9fc2d663f7816f23eade7af03063ddb00d4af4b7326783",
+      "source_hash": "f29a32440a2537e0b936087329886e0dd422f61641d484212cf821c5a13e6057",
       "generated_hash": "67d8f2dbac5aebfcfaebb0c894d394f266299a13b10dee377eeb5f9469f4a90a"
     },
     {

--- a/skills-codex/crank/.agentops-generated.json
+++ b/skills-codex/crank/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/crank",
   "layout": "modular",
-  "source_hash": "2aa5cdb991c180047d9fc2d663f7816f23eade7af03063ddb00d4af4b7326783",
+  "source_hash": "f29a32440a2537e0b936087329886e0dd422f61641d484212cf821c5a13e6057",
   "generated_hash": "67d8f2dbac5aebfcfaebb0c894d394f266299a13b10dee377eeb5f9469f4a90a"
 }

--- a/skills/crank/SKILL.md
+++ b/skills/crank/SKILL.md
@@ -182,6 +182,7 @@ Crank runs as an isolated phase-2 execution context — discovery and validation
 
 ## Reference Documents
 
+- [references/crank.feature](references/crank.feature) — Executable spec: wave-validity hard gate, FIRE loop, mandatory completion marker, 50-wave cap (soc-qk4b.2)
 - [references/de-sloppify.md](references/de-sloppify.md)
 - [references/execution-preflight.md](references/execution-preflight.md)
 - [references/parallel-wave-isolation.md](references/parallel-wave-isolation.md)

--- a/skills/crank/references/crank.feature
+++ b/skills/crank/references/crank.feature
@@ -1,0 +1,37 @@
+# Executable spec for the /crank skill — wave execution (BC3 Loop, Move 5).
+# /crank consumes a slice-validation plan and drives an epic to DONE wave by wave,
+# dispatching /swarm + /implement per wave under a wave-validity hard gate, looping
+# FIRE (Find→Ignite→Reap→Vibe→Escalate) until every issue is closed — then it must
+# emit an explicit completion marker. Hexagon: domain; consumes: beads, implement,
+# post-mortem, swarm, vibe; produces: wave-by-wave slice completion. (soc-qk4b.2)
+
+Feature: Crank executes an epic through conflict-free waves to completion
+  As the loop's wave executor
+  I want each epic driven wave by wave under an explicit validity gate
+  So that parallelism is owned, not chaotic, and the epic provably reaches DONE
+
+  Background:
+    Given an epic (or plan) with ready issues and a slice-validation plan
+
+  Scenario: Wave-validity hard gate precedes parallel dispatch
+    When /crank assembles a wave
+    Then it dispatches in parallel only if every row holds: distinct write scopes,
+      no shared migration/contract/CLI surface, declared integration order,
+      owner per slice, and a discard path per slice
+    And any failed row forces those slices to run sequentially, not in parallel
+
+  Scenario: FIRE loop repeats per wave until issues close
+    When a wave runs
+    Then /crank executes Find → Ignite → Reap → Vibe → Escalate
+    And it loops to the next wave until all issues are closed or a blocker is hit
+
+  Scenario: A completion marker is mandatory
+    When /crank stops
+    Then it emits exactly one of <promise>DONE</promise>, <promise>BLOCKED</promise>,
+      or <promise>PARTIAL</promise>
+    And it never claims completion without one
+
+  Scenario: The global wave cap bounds the run
+    Given cascading failures or circular dependencies
+    Then /crank halts at MAX_EPIC_WAVES (50) rather than looping unbounded
+    And reports BLOCKED with the reason


### PR DESCRIPTION
## Why
`soc-qk4b.2` loop-spine crank, cycle 3 (orchestrator drive-to-completion). `/crank` had filled frontmatter but no executable acceptance.

## What changed
- `skills/crank/references/crank.feature` (NEW): wave-validity hard gate (sequential on conflict), FIRE loop per wave, mandatory completion marker (DONE/BLOCKED/PARTIAL), 50-wave cap.
- `skills/crank/SKILL.md`: link the `.feature` in Reference Documents.

## How tested
- `lint-skills.sh` ✓ crank; `ao goals scenarios --lint` 0 errors; `audit-codex-parity --skill crank` passed; `regen-codex-hashes` clean

Sibling pattern: mirrors `implement.feature` (#404) + `plan.feature` (#405).
Fitness: loop-skill canonical executable acceptance 2 → 3; soc-qk4b.2 wave 3/6.

Closes-scenario: soc-k4s9#crank-hexagon
Bounded-context: BC3-Loop
Evidence: skills/crank/references/crank.feature