### PR TITLE
feat(rpi): executable acceptance for the /rpi loop hexagon (soc-20kt #rpi-hexagon)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1027,7 +1027,7 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "ca77f279bcb7b4709991021ccf340ef2caf5cb5d360f92e99982a14bfde55e18",
+      "source_hash": "09bae621310bcb4b8061c4ed14c8f3caf41507ce7478f05536065d7e023bf881",
       "generated_hash": "c8f439c27965aa992f1dd9c94d0f80ddc8c2aff5f8b864c8a2a6d0820c1c814d"
     },
     {

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "ca77f279bcb7b4709991021ccf340ef2caf5cb5d360f92e99982a14bfde55e18",
+  "source_hash": "09bae621310bcb4b8061c4ed14c8f3caf41507ce7478f05536065d7e023bf881",
   "generated_hash": "c8f439c27965aa992f1dd9c94d0f80ddc8c2aff5f8b864c8a2a6d0820c1c814d"
 }

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -232,6 +232,7 @@ interactive, loop, and artifact-mode examples.
 
 ## Reference Documents
 
+- [references/rpi.feature](references/rpi.feature) — Executable spec: strict ordered phases, validation-never-skipped, context-density across handoffs (soc-qk4b.2)
 - [references/orchestrator-compression-anti-pattern.md](references/orchestrator-compression-anti-pattern.md) — Phase-skipping failure mode; rationalizations to reject
 - [references/autonomous-execution.md](references/autonomous-execution.md)
 - [references/installed-plugin-version-not-repo-head.md](references/installed-plugin-version-not-repo-head.md) — `/rpi` loads from `~/.claude/plugins/cache/`, not the repo working tree; verify which version is active before measuring

--- a/skills/rpi/references/rpi.feature
+++ b/skills/rpi/references/rpi.feature
@@ -1,0 +1,34 @@
+# Executable spec for the /rpi skill — one turn's lifecycle executor (BC3 Loop).
+# /rpi runs Research → Plan → Implement as strict, non-compressing phases that
+# preserve the lifecycle objective end to end: phases never skip, validation is
+# never bypassed, and context density survives every phase handoff. Hexagon:
+# supporting; consumes: crank, discovery, domain, ratchet, validation;
+# produces: .agents/rpi/*.md. (soc-qk4b.2)
+
+Feature: RPI runs one turn's lifecycle without skipping moves
+  As the loop's lifecycle orchestrator
+  I want Research, Plan, and Implement run as strict ordered phases
+  So that the objective is preserved across the whole turn, with validation enforced
+
+  Background:
+    Given a goal, bead, or execution packet entering the rpi lifecycle
+
+  Scenario: Phases run in order and never compress
+    When /rpi executes
+    Then it runs Research, then Plan, then Implement in order
+    And no phase is skipped or merged into another (strict delegation is on by default)
+
+  Scenario: Validation cannot be skipped
+    When /rpi reaches the end of Implement
+    Then validation runs before the turn is considered done
+    And the lifecycle objective is preserved, not silently dropped at a phase boundary
+
+  Scenario: Context density survives phase handoffs
+    When one phase hands off to the next
+    Then intent, boundary, evidence, decision, constraint, and next-action carry forward
+    And anything else is omitted or linked, not pasted wholesale
+
+  Scenario: Autonomous run produces durable phase artifacts
+    Given /rpi --auto
+    Then the full lifecycle runs without per-phase human approval
+    And it writes phase artifacts under .agents/rpi/*.md


### PR DESCRIPTION
soc-qk4b.2 loop-spine crank cycle 4. New skills/rpi/references/rpi.feature: strict ordered phases (Research→Plan→Implement, no compression), validation-never-skipped, context-density across handoffs, --auto → .agents/rpi/*.md; linked in SKILL.md. Gates: lint-skills rpi ✓, scenarios --lint 0 errors, codex parity passed. Sibling: #404/#405/#406. Fitness: loop executable acceptance 3→4 (wave 4/6).

Closes-scenario: soc-20kt#rpi-hexagon
Bounded-context: BC3-Loop
Evidence: skills/rpi/references/rpi.feature