### PR TITLE
feat(evolve): hexagon frontmatter + executable acceptance for /evolve (soc-edgv #evolve-hexagon)

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -119,6 +119,7 @@ graph LR
   crank -- "shared-kernel" --> standards
   design -- "shared-kernel" --> standards
   discovery -- "shared-kernel" --> standards
+  evolve -- "customer-of" --> rpi
   flywheel -- "shared-kernel" --> standards
   forge -- "shared-kernel" --> standards
   goals -- "shared-kernel" --> standards
@@ -203,6 +204,12 @@ graph LR
 | `doc` | produces | documentation |
 | `domain` | produces | stdout |
 | `dream` | produces | .agents/research/*.md |
+| `evolve` | consumes | compile |
+| `evolve` | consumes | goals |
+| `evolve` | consumes | post-mortem |
+| `evolve` | consumes | rpi |
+| `evolve` | produces | git-changes |
+| `evolve` | produces | goals-fitness-delta |
 | `flywheel` | produces | .agents/learnings/*.md |
 | `forge` | produces | .agents/research/*.md |
 | `goals` | produces | result.json |

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -787,7 +787,7 @@
     {
       "name": "evolve",
       "source_skill": "skills/evolve",
-      "source_hash": "b6903edd93cd9dac1124b913153fe80b67e43062997726e8f766bff02cb26dc5",
+      "source_hash": "f48e77311d48ad956620d6e05d96e65616622ee1ccc1c1554d2b1f4875ce8f05",
       "generated_hash": "5c8274c6606089b1a2854015f0f0f5176ed49806e3a6e9fce10749eeabffd01f"
     },
     {
@@ -1027,7 +1027,7 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "09bae621310bcb4b8061c4ed14c8f3caf41507ce7478f05536065d7e023bf881",
+      "source_hash": "441cdc759c0cc75a656790077ade6d9aaaa144a74da721556359869d72ed6202",
       "generated_hash": "c8f439c27965aa992f1dd9c94d0f80ddc8c2aff5f8b864c8a2a6d0820c1c814d"
     },
     {

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/evolve",
   "layout": "modular",
-  "source_hash": "b6903edd93cd9dac1124b913153fe80b67e43062997726e8f766bff02cb26dc5",
+  "source_hash": "f48e77311d48ad956620d6e05d96e65616622ee1ccc1c1554d2b1f4875ce8f05",
   "generated_hash": "5c8274c6606089b1a2854015f0f0f5176ed49806e3a6e9fce10749eeabffd01f"
 }

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "09bae621310bcb4b8061c4ed14c8f3caf41507ce7478f05536065d7e023bf881",
+  "source_hash": "441cdc759c0cc75a656790077ade6d9aaaa144a74da721556359869d72ed6202",
   "generated_hash": "c8f439c27965aa992f1dd9c94d0f80ddc8c2aff5f8b864c8a2a6d0820c1c814d"
 }

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -6,9 +6,17 @@ practices:
 - dora-metrics
 - agile-manifesto
 hexagonal_role: supporting
-consumes: []
-produces: []
-context_rel: []
+consumes:
+- rpi
+- goals
+- post-mortem
+- compile
+produces:
+- git-changes
+- goals-fitness-delta
+context_rel:
+- kind: customer-of
+  with: rpi
 skill_api_version: 1
 user-invocable: true
 context:
@@ -585,14 +593,15 @@ See `references/cycle-history.md` for advanced troubleshooting.
 
 ## References
 
+- [references/evolve.feature](references/evolve.feature) — Executable spec: gated cycles, ladder, bounded slice, never-self-halt
 - [references/long-loop-discipline.md](references/long-loop-discipline.md) — Disk-is-truth axiom
 - [references/artifacts.md](references/artifacts.md) — Generated files registry
-- [references/autonomous-execution.md](references/autonomous-execution.md) — Autonomous-loop rules, operator-shape carve-out, ScheduleWakeup self-perpetuation
-- [references/snapshot-pattern-for-long-cycle-gates.md](references/snapshot-pattern-for-long-cycle-gates.md) — 4-step pattern for multi-session corpus gates
+- [references/autonomous-execution.md](references/autonomous-execution.md) — Autonomous-loop rules + operator-shape carve-out
+- [references/snapshot-pattern-for-long-cycle-gates.md](references/snapshot-pattern-for-long-cycle-gates.md) — Snapshot pattern for long-cycle gates
 - [references/compounding.md](references/compounding.md) — Knowledge flywheel and work harvesting
 - [references/context-budget.md](references/context-budget.md) — `CONTEXT_BUDGET_EXHAUSTED` as a third stop reason and handoff protocol
-- [references/convergence-mechanics.md](references/convergence-mechanics.md) — Read-path mechanisms (prior-failure injection, healing-first classifier, hypothesis tracking, STOP criteria) that turn write-only ledgers into compounding behavior
-- [references/domain-evolution-bootstrap.md](references/domain-evolution-bootstrap.md) — BDD/DDD/Hexagonal/TDD/XP control surface for AgentOps 3.0 skill/domain evolution
+- [references/convergence-mechanics.md](references/convergence-mechanics.md) — Read-path mechanisms for compounding
+- [references/domain-evolution-bootstrap.md](references/domain-evolution-bootstrap.md) — BDD/DDD/Hexagonal/TDD/XP control surface for skill/domain evolution
 - [references/cycle-history.md](references/cycle-history.md) — JSONL format, recovery protocol, kill switch
 - [references/examples.md](references/examples.md) — Detailed usage examples
 - [references/fitness-scoring.md](references/fitness-scoring.md) — Baseline capture, regression detection, revert procedure
@@ -600,10 +609,10 @@ See `references/cycle-history.md` for advanced troubleshooting.
 - [references/goals-schema.md](references/goals-schema.md) — GOALS.yaml format and continuous metrics
 - [references/knowledge-loop-integration.md](references/knowledge-loop-integration.md) — Claim/release semantics and harvest re-read
 - [references/mechanical-batches.md](references/mechanical-batches.md) — Script-first vs per-file Edit for > 20-file uniform batches
-- [references/metronome-gate.md](references/metronome-gate.md) — Cross-cycle detector that blocks the same-mode-repeated failure mode (cycles 144-154)
+- [references/metronome-gate.md](references/metronome-gate.md) — Cross-cycle same-mode-repeat blocker
 - [references/oscillation.md](references/oscillation.md) — Oscillation detection and quarantine
 - [references/pre-flight-schema-check.md](references/pre-flight-schema-check.md) — Cheap field-fit check before architectural migration cycles
-- [references/postmortem-checkpoint.md](references/postmortem-checkpoint.md) — Stop reason #6: session-PR threshold mandatory `/post-mortem --deep` checkpoint (soc-n75z)
+- [references/postmortem-checkpoint.md](references/postmortem-checkpoint.md) — Stop reason #6: session-PR post-mortem checkpoint (soc-n75z)
 - [references/parallel-execution.md](references/parallel-execution.md) — Parallel /swarm architecture
 - [references/quality-mode.md](references/quality-mode.md) — Quality-first mode: scoring, priority cascade, artifacts
 - [references/scout-mode.md](references/scout-mode.md) — Scout-mode as a first-class cycle result; scope filter procedure

--- a/skills/evolve/references/evolve.feature
+++ b/skills/evolve/references/evolve.feature
@@ -1,0 +1,34 @@
+# Executable spec for the /evolve skill — the goal-driven compounding loop (BC3 Loop).
+# /evolve runs autonomously over /rpi: each cycle a mechanical pre-cycle gate decides
+# continue/halt, the work-selection ladder picks the highest-value bounded item, one
+# slice ships gated (revert on red), and the loop NEVER self-halts — only operator
+# markers stop it. Hexagon: supporting; consumes: rpi, goals, post-mortem, compile;
+# produces: git-changes + goals-fitness-delta. (soc-qk4b.2; see ADR-0007/ADR-0008)
+
+Feature: Evolve runs a goal-driven compounding loop
+  As the autonomous improvement loop
+  I want each cycle gated, work-selected by ladder, and shipped as a bounded slice
+  So that the repo compounds toward GOALS.md without the agent ever self-halting
+
+  Background:
+    Given an operator-set intent (GOALS.md, ADRs, the bead queue)
+
+  Scenario: A mechanical pre-cycle gate decides continue or halt
+    When a cycle starts
+    Then scripts/evolve/halt-check.sh runs first
+    And the loop continues unless an operator marker / goal-regression / prior-FAIL fires
+
+  Scenario: Work selection walks the ladder
+    When the loop selects work
+    Then it prefers harvested next-work, then ready beads, then failing goals, then generators
+    And it declines operator-shape work (epics/release/decisions) per ADR-0008
+
+  Scenario: One bounded slice per cycle, reverted on red
+    When the loop works a selected item
+    Then it ships a single bounded slice via /rpi, gated by build + test + lint
+    And it reverts the slice rather than landing red
+
+  Scenario: The loop never self-halts
+    When the loop is blocked or out of bounded work
+    Then it logs `ao evolve blocked` and continues or operator-waits
+    And it never writes a STOP/DORMANT marker itself (operator-only, ADR-0007)


### PR DESCRIPTION
soc-qk4b.2 loop-spine crank — FINAL skill (6/6). /evolve had empty hexagon frontmatter + no executable acceptance (the loop's own skill was least compliant).

## What changed
- frontmatter: consumes [rpi, goals, post-mortem, compile], produces [git-changes, goals-fitness-delta], context_rel [customer-of rpi]
- skills/evolve/references/evolve.feature (NEW): gated cycles, work-selection ladder, bounded slice + revert-on-red, never-self-halt (ADR-0007/0008); linked in References
- trimmed ~6 verbose reference descriptions to stay under the 10000-token ceiling (soc-opq5 = proper refactor)
- docs/contracts/context-map.md regenerated (new evolve edges)
- skills-codex/rpi/.agentops-generated.json: corrects a stale source_hash left by #407's amend (codex-parity drift fix)

## How tested
lint-skills ✓ evolve (631 lines); scenarios --lint 0 errors; audit-codex-parity --skill evolve passed; context-map regenerated; token budget 9991<10000.

Sibling: #404-#407. Fitness: loop spine 5/6 → **6/6** (BC3 loop-skill hexagon compliance complete).

Closes-scenario: soc-edgv#evolve-hexagon
Bounded-context: BC3-Loop
Evidence: skills/evolve/references/evolve.feature