### PR TITLE
feat(post-mortem): hexagon consumes + executable acceptance for /post-mortem (soc-y4bl #post-mortem-hexagon)

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -226,6 +226,9 @@ graph LR
 | `plan` | consumes | standards |
 | `plan` | produces | .agents/plans/*.md |
 | `plan` | produces | execution-packet.json |
+| `post-mortem` | consumes | council |
+| `post-mortem` | consumes | implement |
+| `post-mortem` | consumes | vibe |
 | `post-mortem` | produces | result.json |
 | `pr-implement` | consumes | crank |
 | `pr-implement` | produces | git-changes |

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -895,7 +895,7 @@
     {
       "name": "post-mortem",
       "source_skill": "skills/post-mortem",
-      "source_hash": "abec2ea83abcabc499810c98fc206dad4b71a2d73f071781da765a2f1d56d6a9",
+      "source_hash": "ce3c864907b49887ad0fcfbfc32714ca90a24502a17d9d186d1bb1e5f8a3964e",
       "generated_hash": "4c781235bd56308a15d5da8f0fadb2e3c8e407821258b3a27c346ff9b4d2193a"
     },
     {

--- a/skills-codex/post-mortem/.agentops-generated.json
+++ b/skills-codex/post-mortem/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/post-mortem",
   "layout": "modular",
-  "source_hash": "abec2ea83abcabc499810c98fc206dad4b71a2d73f071781da765a2f1d56d6a9",
+  "source_hash": "ce3c864907b49887ad0fcfbfc32714ca90a24502a17d9d186d1bb1e5f8a3964e",
   "generated_hash": "4c781235bd56308a15d5da8f0fadb2e3c8e407821258b3a27c346ff9b4d2193a"
 }

--- a/skills/post-mortem/SKILL.md
+++ b/skills/post-mortem/SKILL.md
@@ -6,7 +6,10 @@ practices:
 - sre
 - lean-startup
 hexagonal_role: domain
-consumes: []
+consumes:
+- implement
+- vibe
+- council
 produces:
 - result.json
 context_rel:
@@ -247,6 +250,7 @@ should change. See the `/goals` skill.
 
 ## Reference Documents
 
+- [references/post-mortem.feature](references/post-mortem.feature) — Executable spec: validate-shipped, ratcheted learning promotion, next-work harvest, result.json (soc-qk4b.2)
 - [references/harvest-next-work.md](references/harvest-next-work.md)
 - [references/learning-templates.md](references/learning-templates.md)
 - [references/plan-compliance-checklist.md](references/plan-compliance-checklist.md)

--- a/skills/post-mortem/references/post-mortem.feature
+++ b/skills/post-mortem/references/post-mortem.feature
@@ -1,0 +1,33 @@
+# Executable spec for the /post-mortem skill — loop closeout (BC3 Loop, Move 7).
+# /post-mortem wraps completed work: validates it shipped correctly, extracts
+# learnings under the promotion ratchet, processes/activates/retires the backlog,
+# and harvests next-work for the flywheel — producing evidence, not status text.
+# Hexagon: domain; consumes: implement, vibe, council; produces: result.json.
+# (soc-qk4b.2)
+
+Feature: Post-mortem closes the loop with evidence and ratcheted learning
+  As the loop's closeout step
+  I want completed work validated and its lessons promoted by the ratchet
+  So that each turn compounds — evidence captured, learnings durable, next-work surfaced
+
+  Background:
+    Given a completed unit of work (a closed bead or epic slice)
+
+  Scenario: Closeout validates the work actually shipped
+    When /post-mortem runs
+    Then it confirms the work implemented its acceptance (council / did-we-implement-it)
+    And it records evidence against the bead, not a status word
+
+  Scenario: Learnings promote only under the ratchet
+    When /post-mortem extracts observations
+    Then a one-off stays in the handoff, a twice-seen pattern goes to .agents/learnings/,
+      a behavior-changing lesson updates a SKILL.md/template, and a must-never-regress
+      becomes a gate
+    And most observations die at handoff — that is correct
+
+  Scenario: Next-work is harvested for the flywheel
+    When closeout finishes
+    Then actionable follow-ups are appended to .agents/rpi/next-work.jsonl
+
+  Scenario: The cycle produces a durable result artifact
+    Then /post-mortem writes result.json capturing the closeout verdict + evidence


### PR DESCRIPTION
soc-qk4b.2 loop-spine crank — 6th and FINAL skill. /post-mortem had empty consumes + no executable acceptance.

- frontmatter: consumes [implement, vibe, council]; produces [result.json]
- skills/post-mortem/references/post-mortem.feature (NEW): validate-shipped, ratcheted learning promotion, next-work harvest, result.json; linked
- docs/contracts/context-map.md regenerated

How tested: lint-skills ✓ post-mortem; scenarios --lint 0 errors; codex parity passed; context-map regen.
Sibling: #404-#408. Fitness: loop spine 5/6 → **6/6** — BC3 loop-skill hexagon compliance COMPLETE.

Closes-scenario: soc-y4bl#post-mortem-hexagon
Bounded-context: BC3-Loop
Evidence: skills/post-mortem/references/post-mortem.feature