### PR TITLE
feat(discovery): promote inline acceptance to canonical .feature (soc-9xs4 #discovery-hexagon)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -763,7 +763,7 @@
     {
       "name": "discovery",
       "source_skill": "skills/discovery",
-      "source_hash": "f789b340a74c049017196792dc43ebcf8a5ca4bd990759abc843271ed6f7f271",
+      "source_hash": "daf64b6c71cd257f4211fa55f699225b3f9e3a2ee6e545ccaa46f52981d39053",
       "generated_hash": "b8cfabc0511ff22e356756ec32257d760d7aa26326a0eb5eb23f21b2cdac11ab"
     },
     {

--- a/skills-codex/discovery/.agentops-generated.json
+++ b/skills-codex/discovery/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/discovery",
   "layout": "modular",
-  "source_hash": "f789b340a74c049017196792dc43ebcf8a5ca4bd990759abc843271ed6f7f271",
+  "source_hash": "daf64b6c71cd257f4211fa55f699225b3f9e3a2ee6e545ccaa46f52981d39053",
   "generated_hash": "b8cfabc0511ff22e356756ec32257d760d7aa26326a0eb5eb23f21b2cdac11ab"
 }

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -94,14 +94,7 @@ for the boundary between Discovery and Plan:
 | Context packet | density block, artifact links, acceptance examples, non-goals, constraints |
 | Guard adapter | `/pre-mortem` verdict before packet handoff |
 
-```gherkin
-Feature: Discovery hands dense intent to planning
-  Scenario: Discovery delegates to Plan
-    Given Discovery has a goal, research path, and design or brainstorm evidence
-    When it crosses the `plan_slices` port
-    Then it sends density fields and artifact links
-    And it does not inline the Plan decomposition in Discovery prose
-```
+Executable acceptance: [references/discovery.feature](references/discovery.feature) — Discovery hands dense intent across the `plan_slices` port (promoted from inline; soc-qk4b.2).
 
 ## Execution
 

--- a/skills/discovery/references/discovery.feature
+++ b/skills/discovery/references/discovery.feature
@@ -1,0 +1,21 @@
+# Executable spec for the /discovery skill — front-of-loop intent densifier (BC3 Loop).
+# /discovery runs the artifact-first research → plan DAG and hands dense intent across
+# the plan_slices port, producing an execution packet — it never inlines the Plan
+# decomposition in its own prose. Promoted from the inline Feature block in SKILL.md.
+# (soc-qk4b.2)
+
+Feature: Discovery hands dense intent to planning
+  As the front of the loop
+  I want research and design densified and handed cleanly to Plan
+  So that planning receives artifact links + density fields, not re-derived prose
+
+  Scenario: Discovery delegates to Plan
+    Given Discovery has a goal, research path, and design or brainstorm evidence
+    When it crosses the `plan_slices` port
+    Then it sends density fields and artifact links
+    And it does not inline the Plan decomposition in Discovery prose
+
+  Scenario: Discovery produces a durable execution packet
+    When the discovery DAG completes
+    Then it writes a JSON execution packet on disk for the next loop phase
+    And the packet carries the goal, research, and design artifact references


### PR DESCRIPTION
soc-qk4b.2 loop spine 7/9. /discovery's acceptance lived as inline gherkin in SKILL.md.

- skills/discovery/references/discovery.feature (NEW): promoted from inline — dense intent across plan_slices port + execution-packet scenario
- skills/discovery/SKILL.md: inline gherkin block → link

How tested: lint-skills ✓ discovery; scenarios --lint 0 errors; codex parity passed.
Sibling: /plan #405. Fitness: loop spine 6/9 → 7/9.

Closes-scenario: soc-9xs4#discovery-hexagon
Bounded-context: BC3-Loop
Evidence: skills/discovery/references/discovery.feature