### PR TITLE
feat(validation): executable acceptance for the /validation roll-up (soc-vadw #validation-hexagon)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1147,7 +1147,7 @@
     {
       "name": "validation",
       "source_skill": "skills/validation",
-      "source_hash": "7e717c1f437f102c53ef8a69249a3461dbc4ca5a22bc640de7083165eecb9b8b",
+      "source_hash": "a34f1de21ab46b01be6fce975694a0f9aecdd2accd488142f6c8ae82aafb558a",
       "generated_hash": "353b7a5dcc7e4720f355dbe37e63259482812f10605a9189c8a5e6eabcf6e851"
     },
     {

--- a/skills-codex/validation/.agentops-generated.json
+++ b/skills-codex/validation/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/validation",
   "layout": "modular",
-  "source_hash": "7e717c1f437f102c53ef8a69249a3461dbc4ca5a22bc640de7083165eecb9b8b",
+  "source_hash": "a34f1de21ab46b01be6fce975694a0f9aecdd2accd488142f6c8ae82aafb558a",
   "generated_hash": "353b7a5dcc7e4720f355dbe37e63259482812f10605a9189c8a5e6eabcf6e851"
 }

--- a/skills/validation/SKILL.md
+++ b/skills/validation/SKILL.md
@@ -118,6 +118,7 @@ See [references/troubleshooting.md](references/troubleshooting.md).
 
 ## Reference Documents
 
+- [references/validation.feature](references/validation.feature) — Executable spec: criterion→test roll-up, strict delegation, verdict.json, strict-surface blocking (soc-qk4b.2)
 - [references/dag.md](references/dag.md) — executable workflow, gate detail, blocking conditions, phase summary format, phase budgets, expensive-command policy
 - [references/per-criterion-rubric.md](references/per-criterion-rubric.md) — per-criterion verdict rubric and runner contract
 - [references/step-1.8-behavioral-validation.md](references/step-1.8-behavioral-validation.md) — STEP 1.8 holdout + agent-spec evaluator council

--- a/skills/validation/references/validation.feature
+++ b/skills/validation/references/validation.feature
@@ -1,0 +1,35 @@
+# Executable spec for the /validation skill — slice + bead acceptance roll-up (BC3 Loop, Move 6).
+# /validation rolls every Given/When/Then of the intent into a verdict: it runs the
+# vibe → lifecycle → post-mortem → retro → forge DAG by STRICT DELEGATION (separate
+# Skill invocations, no compression) and produces verdict.json — activity logs never
+# close beads. Hexagon: consumes forge, post-mortem, retro, shared, vibe;
+# produces verdict.json. (soc-qk4b.2)
+
+Feature: Validation rolls slice and bead acceptance into a verdict
+  As the loop's acceptance gate
+  I want every acceptance criterion mapped to a passing test and rolled into a verdict
+  So that a bead closes on proof, not on an activity log
+
+  Background:
+    Given completed wave outputs for an intent issue with Given/When/Then acceptance
+
+  Scenario: Every acceptance criterion maps to a passing test
+    When /validation runs the slice-acceptance roll-up
+    Then each Given/When/Then from the intent maps to a passing test
+    And an unmapped or failing criterion blocks the verdict
+
+  Scenario: Strict delegation across the validation DAG
+    When /validation executes its DAG
+    Then it delegates to /vibe, lifecycle skills, /post-mortem, /retro, and /forge
+      as separate Skill invocations
+    And it does not compress or skip those steps
+
+  Scenario: The verdict is proof, not an activity log
+    When validation completes
+    Then it produces verdict.json capturing the per-criterion verdict
+    And an activity log alone never closes a bead
+
+  Scenario: Surface failures block under strict mode
+    Given --strict-surfaces is set
+    When any of the four closure surfaces fails
+    Then the verdict is FAIL, not WARN


### PR DESCRIPTION
soc-qk4b.2 loop spine 8/9. /validation had filled frontmatter but no executable acceptance.

- skills/validation/references/validation.feature (NEW): criterion→test roll-up, strict delegation (vibe/lifecycle/post-mortem/retro/forge), verdict.json not activity-logs, strict-surface blocking
- linked in Reference Documents

How tested: lint-skills ✓ validation (128 lines); scenarios --lint 0 errors; codex parity passed.
Fitness: loop spine 7/9 → 8/9.

Closes-scenario: soc-vadw#validation-hexagon
Bounded-context: BC3-Loop
Evidence: skills/validation/references/validation.feature