### PR TITLE
feat(ratchet): hexagon consumes + executable acceptance for /ratchet (soc-x5oy #ratchet-hexagon)

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -249,6 +249,9 @@ graph LR
 | `push` | produces | git-changes |
 | `quickstart` | consumes | rpi |
 | `quickstart` | produces | stdout |
+| `ratchet` | consumes | post-mortem |
+| `ratchet` | consumes | validation |
+| `ratchet` | consumes | vibe |
 | `ratchet` | produces | .agents/rpi/*.md |
 | `readme` | produces | documentation |
 | `recover` | produces | .agents/rpi/*.md |

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -967,7 +967,7 @@
     {
       "name": "ratchet",
       "source_skill": "skills/ratchet",
-      "source_hash": "f2d8018482179adff1b55698dc2910ee4aef178231f4964961ab89f66ca4040c",
+      "source_hash": "7cf8abefd68edfd5a0570dd3503acc1b4b97c5e86bf8a339086fbdfe389ed9df",
       "generated_hash": "2b62557007d2bd62d15db827a4f1a148ebb0e7d6f66035bfddb30f1f6bf08455"
     },
     {

--- a/skills-codex/ratchet/.agentops-generated.json
+++ b/skills-codex/ratchet/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/ratchet",
   "layout": "modular",
-  "source_hash": "f2d8018482179adff1b55698dc2910ee4aef178231f4964961ab89f66ca4040c",
+  "source_hash": "7cf8abefd68edfd5a0570dd3503acc1b4b97c5e86bf8a339086fbdfe389ed9df",
   "generated_hash": "2b62557007d2bd62d15db827a4f1a148ebb0e7d6f66035bfddb30f1f6bf08455"
 }

--- a/skills/ratchet/SKILL.md
+++ b/skills/ratchet/SKILL.md
@@ -6,7 +6,10 @@ practices:
 - refactoring
 - continuous-integration
 hexagonal_role: domain
-consumes: []
+consumes:
+- validation
+- vibe
+- post-mortem
 produces:
 - .agents/rpi/*.md
 context_rel:
@@ -151,3 +154,7 @@ Progress stored in `.agents/ao/chain.jsonl`:
 | Step already completed error | Attempting to re-ratchet locked step | Use `ao ratchet status` to check state; skip if already done |
 | chain.jsonl corrupted | Malformed JSON entries | Manually edit to fix JSON; validate each line with `jq -c '.' <file>` |
 | Out-of-order steps | Implementing before planning | Follow RPI order strictly; use `--skip` only with explicit reason |
+
+## Reference Documents
+
+- [references/ratchet.feature](references/ratchet.feature) — Executable spec: Chaos×Filter→Ratchet, record/check loop-step gates, monotonic chain (soc-qk4b.2)

--- a/skills/ratchet/references/ratchet.feature
+++ b/skills/ratchet/references/ratchet.feature
@@ -1,0 +1,28 @@
+# Executable spec for the /ratchet skill — permanent progress gates (BC3 Loop).
+# /ratchet is the Brownian Ratchet: Chaos × Filter → Ratchet. It records passed
+# loop-step gates to .agents/ao/chain.jsonl so progress is locked and monotonic —
+# you cannot un-ratchet. Hexagon: domain; consumes validation, vibe, post-mortem
+# (the filter outputs it locks); produces .agents/rpi/*.md + chain entries. (soc-qk4b.2)
+
+Feature: Ratchet locks loop progress permanently
+  As the loop's progress lock
+  I want passed gates recorded to a monotonic chain
+  So that progress is permanent — chaos is filtered, then ratcheted, never undone
+
+  Scenario: Chaos is filtered, then ratcheted
+    Given multiple attempts (chaos) that pass their validation gate (filter)
+    When the gate result is ratcheted
+    Then the progress is locked permanently in the chain
+
+  Scenario: A passed gate is recorded to the chain
+    When /ratchet records a completed step (research, plan, implement, vibe, post-mortem)
+    Then a chain entry is appended to .agents/ao/chain.jsonl with step, status, and output
+
+  Scenario: Gate state is checkable before advancing
+    When /ratchet checks a step
+    Then it reports whether that gate is satisfied
+    And the loop does not advance past an unsatisfied required gate
+
+  Scenario: A recorded gate cannot be un-ratcheted
+    Given a step already recorded as completed in the chain
+    Then progress is monotonic — the recorded gate is not reversed


### PR DESCRIPTION
soc-qk4b.2 loop spine 9/9 — FINAL skill, epic complete. /ratchet had empty consumes + no executable acceptance.

- frontmatter: consumes [validation, vibe, post-mortem] (the filter outputs it locks)
- skills/ratchet/references/ratchet.feature (NEW): Chaos×Filter→Ratchet, record/check loop-step gates, monotonic chain
- Reference Documents section added; docs/contracts/context-map.md regenerated

How tested: lint-skills ✓ ratchet (160 lines); scenarios --lint 0 errors; codex parity passed; context-map regen.
Fitness: loop spine 8/9 → **9/9** — soc-qk4b.2 loop-skill hexagon crank COMPLETE.

Closes-scenario: soc-x5oy#ratchet-hexagon
Bounded-context: BC3-Loop
Evidence: skills/ratchet/references/ratchet.feature