### PR TITLE
feat(domain): add Behavior Shaping (ABC register) as a domain vocabulary entry (soc-zkqp3 #abc-domain-vocab)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-22T19:11:13Z",
+  "generated_at": "2026-05-22T19:29:37Z",
   "summary": {
     "skills": 80,
     "hooks": 44,
@@ -409,7 +409,7 @@
         "path": "skills/domain/",
         "has_skill_md": true,
         "has_references": true,
-        "reference_count": 9
+        "reference_count": 10
       },
       {
         "name": "harvest",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -775,7 +775,7 @@
     {
       "name": "domain",
       "source_skill": "skills/domain",
-      "source_hash": "c30d182d4035fd7fabda09f312e3ad31494f6eff0ab826a15af540232ef5336a",
+      "source_hash": "9e03962151034a8b87eda559f32650806903dfacd9a1b578aea5ed79eb8bd01f",
       "generated_hash": "5de534737803c76fab3ad06e1a47dba85eb8f631a159cc6157ce4f932c2e99e4"
     },
     {

--- a/skills-codex/domain/.agentops-generated.json
+++ b/skills-codex/domain/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/domain",
   "layout": "modular",
-  "source_hash": "c30d182d4035fd7fabda09f312e3ad31494f6eff0ab826a15af540232ef5336a",
+  "source_hash": "9e03962151034a8b87eda559f32650806903dfacd9a1b578aea5ed79eb8bd01f",
   "generated_hash": "5de534737803c76fab3ad06e1a47dba85eb8f631a159cc6157ce4f932c2e99e4"
 }

--- a/skills/domain/SKILL.md
+++ b/skills/domain/SKILL.md
@@ -85,6 +85,7 @@ Test entry:
 Operating discipline:
 
 - [`references/context-density-rule.md`](references/context-density-rule.md) — Context Density Rule: every context token carries intent, boundary, evidence, decision, constraint, or next action
+- [`references/behavior-shaping.md`](references/behavior-shaping.md) — Behavior Shaping: the ABC register (antecedent/behavior/consequence/reinforcement/extinction/shaping); building agent capability is operant conditioning, not specification
 
 Catalog:
 

--- a/skills/domain/references/INDEX.md
+++ b/skills/domain/references/INDEX.md
@@ -13,6 +13,7 @@ Load entries on demand; do not preload the whole corpus.
 6. `anti-pattern.md` — documented mistakes with the cost when ignored
 7. `tracer-bullet.md` — test entry; uses only citations to entries 1-6
 8. `context-density-rule.md` — CDLC compression rule for agent context
+9. `behavior-shaping.md` — the ABC register: building agent capability is operant conditioning, not specification
 
 ## Naming note
 
@@ -49,6 +50,7 @@ case-insensitive filesystems (macOS APFS default) do not collapse the two.
 | Slug                      | Concept              | Status     | Kind    |
 |---------------------------|----------------------|------------|---------|
 | `context-density-rule.md` | Context Density Rule | canonical  | concept |
+| `behavior-shaping.md`     | Behavior Shaping     | draft      | concept |
 
 ## Status legend
 

--- a/skills/domain/references/behavior-shaping.md
+++ b/skills/domain/references/behavior-shaping.md
@@ -1,0 +1,37 @@
+---
+name: Behavior Shaping
+kind: concept
+status: draft
+see-also: [slice, primitive, citation, context-density-rule, anti-pattern]
+---
+# Behavior Shaping
+
+Building agent capability is **operant conditioning, not specification**. You cannot compile a behavior into a non-deterministic model; you can only shape it through observable examples and reinforcement. This is the ubiquitous-language register for that frame — the fourth domain axis alongside DDD (vocabulary), Hexagonal (structure), and Gherkin (acceptance).
+
+Doctrine: [`docs/architecture/behavior-shaping-environment.md`](../../../docs/architecture/behavior-shaping-environment.md).
+
+## The ABC register
+
+Operant conditioning runs on **Antecedent → Behavior → Consequence**. Every working term maps to one of the three:
+
+| Term | Meaning | In this repo |
+|---|---|---|
+| **Antecedent** | the environment arranged *before* the behavior so the agreed one is the likely one — the highest-leverage lever | `CLAUDE.md`/`AGENTS.md`, `ao inject`, `GOALS.md`, the corpus, skill `consumes` |
+| **Discriminative stimulus** | the cue that signals *which* behavior to emit | skill trigger, the intent/issue, the loop's current move |
+| **Behavior** | a discrete, observable, composable action — added, never rewritten | a `.feature` scenario / bead `## Scenarios` (one Given/When/Then) |
+| **Reinforcement** | a consequence that strengthens the behavior | passing gates (`/vibe`, `validation`, CI green), merge; the **ratchet** locks it permanently |
+| **Extinction / Stop** | a consequence that weakens or removes the behavior | hook denial, halt-check STOP/kill marker, revert; deleting a scenario or gate |
+| **Shaping** | reinforcing successive approximations toward the target | red→green iteration; the `/evolve` loop run continuously |
+
+## When to use
+
+- When extending a [Primitive](primitive.md), name the **behavior** (a scenario), its **antecedent** (what context makes it likely), and its **reinforcer** (which gate proves it). A behavior with no consequence drifts.
+- Prefer **add-and-shape** over big top-down design: add a scenario and reinforce it to green, rather than rewriting prose. Behaviors compose; designs collide.
+- To remove a behavior, use **extinction** (delete its cue and reward), not a comment that says "don't."
+
+## Relationship to other entries
+
+- A [Slice](slice.md) demonstrates exactly one Behavior cutting vertically through Primitives.
+- A [Primitive](primitive.md) is reinforced into reliability through gates (its consequences).
+- An [Anti-Pattern](anti-pattern.md) is a behavior to keep extinguished — documented with the cost of letting it recur.
+- The [Context Density Rule](context-density-rule.md) governs what crosses a phase boundary: the antecedent for the next behavior.


### PR DESCRIPTION
soc-tk1d behavior-science frame, **surface 2/4**. Adds operant-conditioning ubiquitous language as the 4th domain axis (alongside DDD/Hex/Gherkin).

- skills/domain/references/behavior-shaping.md (NEW, concept, draft): ABC register mapped to AgentOps mechanisms; cites the merged doctrine doc (#414)
- INDEX.md reading-order + table (draft, per corpus growth rule); domain/SKILL.md links it; registry + codex regenerated

Left **draft** deliberately — promotion to canonical is the operator's reinforcement to apply (the discipline the entry describes).

How tested: lint-skills domain; scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: context-density-rule.md concept entry. Fitness: behavior-science surfaces 1/4 → 2/4.

NOTE: claude-review will be infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-zkqp3#abc-domain-vocab
Bounded-context: BC1-Corpus
Evidence: skills/domain/references/behavior-shaping.md