### PR TITLE
docs(product): lead README + PRODUCT with the behavior-shaping thesis (soc-wub1y #reposition-behavior-shaping)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -6,7 +6,7 @@ last_reviewed: 2026-05-15
 
 ## Mission
 
-**AgentOps is an SDLC control plane for agentic software development.** It automates the discipline of building a wiki for your agents: markdown in `.agents/` next to your code, produced and consumed by the agents that work there. The compounded corpus is the moat. The internal lifecycle is the CDLC: context is developed, tested, delivered, observed, and improved because context is what LLM agents consume.
+**AgentOps is an SDLC control plane for agentic software development.** It works by **behavior shaping**: arranging the environment and reinforcement so agents reliably perform the behaviors you and they agree on — the operant-conditioning model of Antecedent → Behavior → Consequence (see [Behavior-Shaping Environment](docs/architecture/behavior-shaping-environment.md)). Concretely, it automates the discipline of building a wiki for your agents: markdown in `.agents/` next to your code, produced and consumed by the agents that work there — the antecedent the next behavior is shaped against. The compounded corpus is the moat. The internal lifecycle is the CDLC: context is developed, tested, delivered, observed, and improved because context is what LLM agents consume.
 
 ## Product Identity
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### The SDLC control plane for agentic software development.
 
-AgentOps sits on top of the coding harness you already use — Claude Code, Codex, Cursor, OpenCode — and adds the parts an engineering team would notice missing: a record of what was tried, gates between phases, and a corpus of learnings that survives the next session. State lives in `.agents/` next to your code, and you can mix Claude, Codex, or any model per phase.
+AgentOps shapes how coding agents behave: it arranges the environment they work in — context, standards, goals, a corpus of past decisions — so the behavior you and the agent agree on is the likely one, then reinforces it with gates between phases. That's behavior shaping, the operant-conditioning way you'd build any capable agent ([the full frame](docs/architecture/behavior-shaping-environment.md)). It sits on top of the coding harness you already use — Claude Code, Codex, Cursor, OpenCode — adds the parts an engineering team would notice missing (a record of what was tried, gates between phases, a corpus of learnings that survives the next session), keeps state in `.agents/` next to your code, and lets you mix Claude, Codex, or any model per phase.
 
 *This repo was built with AgentOps. As of 2026-05-04 its `.agents/` held ~1,842 learnings, ~186 patterns, ~80 planning rules, and ~3,867 cited decisions captured during development. Re-run anytime: `bash scripts/corpus-stats.sh`.*
 


### PR DESCRIPTION
soc-tk1d behavior-science frame, **surface 3/4**. Surgical reposition (not a rewrite): lead the outward framing with behavior shaping as the *how* — 'arrange the environment + reinforce the behaviors you agree on' — keeping the 'SDLC control plane' category + 'sovereignty, not features' bet.

- README.md lead: opens with the behavior-shaping mechanism + doctrine link; preserves harness list, .agents/ state, per-phase model mixing
- PRODUCT.md Mission: leads with the ABC model + doctrine link; corpus-as-moat + CDLC kept

Reviewer note: claude-review is rate-limited, so I ran the adversarial pass myself — doctrine link resolves, 4 AOP-CLAIM markers untouched, skill-counts no drift, validate-doc-links clean, no substance dropped.

Fitness: behavior-science surfaces 2/4 → 3/4.

Closes-scenario: soc-wub1y#reposition-behavior-shaping
Bounded-context: BC1-Corpus
Evidence: README.md