### PR TITLE
fix(goals): ao goals steer add preserves non-directive content (soc-byt52 #steer-add-lossless)

### DIFF
--- a/cli/internal/goals/commands.go
+++ b/cli/internal/goals/commands.go
@@ -679,6 +679,8 @@ func RunSteerAdd(opts SteerAddOptions) error {
 		return fmt.Errorf("invalid steer value %q (valid: increase, decrease, hold, explore)", opts.Steer)
 	}
 
+	// LoadMDGoals enforces the GOALS.md-format guard (YAML is rejected) and
+	// gives the current directive numbering.
 	gf, resolvedPath, err := LoadMDGoals(opts.GoalsFile)
 	if err != nil {
 		return err
@@ -690,23 +692,35 @@ func RunSteerAdd(opts SteerAddOptions) error {
 			maxNum = d.Number
 		}
 	}
-
-	newDirective := Directive{Number: maxNum + 1, Title: opts.Title, Description: opts.Description, Steer: opts.Steer}
-	gf.Directives = append(gf.Directives, newDirective)
+	newNum := maxNum + 1
 
 	if opts.JSON {
 		enc := json.NewEncoder(opts.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(newDirective)
+		return enc.Encode(Directive{Number: newNum, Title: opts.Title, Description: opts.Description, Steer: opts.Steer})
 	}
 	if opts.DryRun {
-		fmt.Fprintf(opts.Stdout, "Would add directive #%d: %s\n", newDirective.Number, newDirective.Title)
+		fmt.Fprintf(opts.Stdout, "Would add directive #%d: %s\n", newNum, opts.Title)
 		return nil
 	}
-	if err := WriteMDGoals(gf, resolvedPath); err != nil {
+
+	// Persist through GoalsPatcher, NOT WriteMDGoals: the latter re-renders
+	// GOALS.md from the GoalFile model and silently drops the "## Three-Gap
+	// Contract Proof Surface" section, the Gates table, prose, and
+	// agentops:claim comments. The patcher appends the new directive block and
+	// preserves every other byte (soc-byt52).
+	p, _, err := LoadGoalsPatcher(opts.GoalsFile)
+	if err != nil {
 		return err
 	}
-	fmt.Fprintf(opts.Stdout, "Added directive #%d: %s (steer: %s)\n", newDirective.Number, newDirective.Title, newDirective.Steer)
+	num, err := p.AppendDirective(opts.Title, opts.Description, opts.Steer)
+	if err != nil {
+		return err
+	}
+	if err := p.WriteFile(resolvedPath); err != nil {
+		return err
+	}
+	fmt.Fprintf(opts.Stdout, "Added directive #%d: %s (steer: %s)\n", num, opts.Title, opts.Steer)
 	return nil
 }
 

--- a/cli/internal/goals/commands_test.go
+++ b/cli/internal/goals/commands_test.go
@@ -427,6 +427,58 @@ func TestRunSteerAdd_DryRun(t *testing.T) {
 	}
 }
 
+// TestRunSteerAdd_PreservesNonDirectiveContent is the soc-byt52 regression:
+// `ao goals steer add` must append the directive WITHOUT dropping sections the
+// GoalFile model does not represent (Three-Gap section, Gates rows, claim
+// comments). The old LoadMDGoals→WriteMDGoals round-trip silently deleted them.
+func TestRunSteerAdd_PreservesNonDirectiveContent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	extra := `| flywheel-proof | bash scripts/proof-run.sh | 7 | proof |
+
+## Three-Gap Contract Proof Surface
+
+<!-- agentops:claim:AOP-CLAIM-GOALS-PRESERVE -->
+A doctrine section the GoalFile model does not represent.
+`
+	writeGoalsMD(t, "GOALS.md", extra)
+
+	var buf bytes.Buffer
+	opts := SteerAddOptions{
+		Title: "New reinforcement directive", Description: "First line.\n\nSecond paragraph.",
+		Steer: "increase", GoalsFile: "GOALS.md", Stdout: &buf,
+	}
+	if err := RunSteerAdd(opts); err != nil {
+		t.Fatalf("RunSteerAdd: %v", err)
+	}
+
+	data, err := os.ReadFile("GOALS.md")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got := string(data)
+
+	if !strings.Contains(got, "### 2. New reinforcement directive") {
+		t.Errorf("new directive #2 missing from:\n%s", got)
+	}
+	if !strings.Contains(got, "Second paragraph.") {
+		t.Errorf("multi-paragraph description not preserved")
+	}
+	if !strings.Contains(got, "### 1. Establish baseline") {
+		t.Errorf("original directive #1 lost")
+	}
+	for _, must := range []string{
+		"## Three-Gap Contract Proof Surface",
+		"<!-- agentops:claim:AOP-CLAIM-GOALS-PRESERVE -->",
+		"A doctrine section the GoalFile model does not represent.",
+		"flywheel-proof",
+	} {
+		if !strings.Contains(got, must) {
+			t.Errorf("non-directive content dropped (soc-byt52 regression): %q missing from:\n%s", must, got)
+		}
+	}
+}
+
 func TestRunSteerRemove_NotFound(t *testing.T) {
 	tmp := t.TempDir()
 	t.Chdir(tmp)

--- a/cli/internal/goals/patcher.go
+++ b/cli/internal/goals/patcher.go
@@ -299,6 +299,53 @@ func (p *GoalsPatcher) SetAttribute(number int, key, value string) error {
 	return nil
 }
 
+// AppendDirective inserts a new directive block at the end of the Directives
+// section, surgically: every other byte of the file — including non-directive
+// sections such as "## Three-Gap Contract Proof Surface", the Gates table, and
+// agentops:claim comments — is preserved. It returns the assigned display
+// number. This replaces the lossy RenderGoalsMD round-trip that `ao goals steer
+// add` used to perform (soc-byt52).
+func (p *GoalsPatcher) AppendDirective(title, description, steer string) (int, error) {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return 0, fmt.Errorf("directive title must not be empty")
+	}
+	if strings.ContainsAny(title, "\r\n") {
+		return 0, fmt.Errorf("directive title must be a single line")
+	}
+	if strings.TrimSpace(description) == "" {
+		return 0, fmt.Errorf("directive description must not be empty")
+	}
+	steer = strings.TrimSpace(steer)
+	if steer == "" {
+		steer = "increase"
+	}
+
+	dirs := p.Directives()
+	num := 1
+	at := -1
+	if len(dirs) > 0 {
+		for _, d := range dirs {
+			if d.Number >= num {
+				num = d.Number + 1
+			}
+		}
+		at = lastContentIdx(p.lines, dirs[len(dirs)-1]) + 1
+	} else {
+		start := directiveSectionStart(p.lines)
+		if start < 0 {
+			return 0, fmt.Errorf("no \"## Directives\" section found in GOALS.md")
+		}
+		at = start
+	}
+
+	block := []string{"", fmt.Sprintf("### %d. %s", num, title), ""}
+	block = append(block, strings.Split(strings.TrimRight(description, "\n"), "\n")...)
+	block = append(block, "", fmt.Sprintf("**Steer:** %s", steer))
+	p.lines = insertLines(p.lines, at, block...)
+	return num, nil
+}
+
 // attrRank returns the canonical sort rank for an attribute key.
 func attrRank(key string) int {
 	if r, ok := attrOrder[key]; ok {


### PR DESCRIPTION
`ao goals steer add` re-rendered GOALS.md from the GoalFile model (WriteMDGoals), silently dropping the **Three-Gap section, Gates table, prose, and claim comments** — a one-directive add gave a 40+/61- diff. The patcher's own contract already said directive mutations must go through GoalsPatcher; add was the violator.

- patcher.go: new `GoalsPatcher.AppendDirective` — surgical block insert, preserves every other byte
- commands.go `RunSteerAdd`: persist via patcher; LoadMDGoals kept only as the GOALS.md-format guard + numbering; JSON/dry-run unchanged
- commands_test.go: L2 regression proving non-directive content survives (fails on old code)

Scope: add only. remove/prioritize share the lossy path (need surgical+renumber) → filed **soc-5335b**.

How tested: 392 goals + 170 cmd tests ok; end-to-end repro shows additions-only diff; gofmt+vet clean.
Sibling: mirrors GoalsPatcher.SetAttribute (scenario_create.go).

NOTE: claude-review will be infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-byt52#steer-add-lossless
Bounded-context: BC5-Runtime
Evidence: cli/internal/goals/patcher.go