### PR TITLE
feat(evolve): encode orchestrator-drive-to-completion into the skill + ADR-0008 (soc-2drk #drive-to-completion)

### DIFF
--- a/docs/adr/ADR-0008-evolve-intelligent-agile-operating-model.md
+++ b/docs/adr/ADR-0008-evolve-intelligent-agile-operating-model.md
@@ -30,6 +30,12 @@ Before implementing a candidate, apply the Primitive Test: does the bead name fi
 - "Looks done" (green per-unit gates) is not "is done" — the consumer-calls-the-primitive L2 test is the close-gate, not unit-green alone.
 - Decisions made mid-execution are captured as ADRs here, so the doctrine compounds.
 
+## Drive to completion (orchestrator-merge)
+
+The loop is the orchestrator: it drives every PR it opens to *merged*, not to "PR opened." A productive cycle ships its bead as a PR (worktree-per-bead, bead trailers), waits for CI, and **squash-merges to main once CI is green** (`gh pr merge --squash --admin`), then closes the bead and cleans the worktree. **Green CI is the only merge gate** — never merge on a quality/test red (fix-and-repush or revert). The loop may dispatch sub-agents to implement and drives their PRs to merge as well.
+
+This **supersedes** the earlier "operator is the merge gate / 0 humans + required claude-code-review" framing **for the autonomous loop**: the operator stays *on* the loop (intent edits + a STOP marker), not *in* it (per-PR merge approval). The "PR opened, await human merge" bottleneck defeats unattended evolution; the loop only compounds if it closes the full Research → Plan → Implement → **merge** arc itself. Guardrails that remain: the halt-check pre-cycle gate ([ADR-0007](ADR-0007-deterministic-loop-only-operator-stops.md)), the scope-precondition audit above, the idempotency lock (no overlapping cycles), and green-only merge. (soc-2drk; operator directive 2026-05-22.)
+
 ## Evidence
 
 mt-olympus's loop sustained a 10-cycle marathon (cycles 123–129) shipping 6 critical-path hops + 14 filed sub-beads with the operator confirming intent once — because this model let it shape within a locked contract while re-reading intent each cycle. agentops lacked the model on 2026-05-21 and drifted. See `.agents/research/2026-05-21-mt-olympus-evolve-loop.md`.

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -787,7 +787,7 @@
     {
       "name": "evolve",
       "source_skill": "skills/evolve",
-      "source_hash": "02eb42c8b20078841fa20e85538527130961ab26f866e223b5fd046b1e0c8260",
+      "source_hash": "ecfc27d86c3660cbd64b3455265ac89250a1cdf733a2dcadaa1d236c9f53318a",
       "generated_hash": "5c8274c6606089b1a2854015f0f0f5176ed49806e3a6e9fce10749eeabffd01f"
     },
     {

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/evolve",
   "layout": "modular",
-  "source_hash": "02eb42c8b20078841fa20e85538527130961ab26f866e223b5fd046b1e0c8260",
+  "source_hash": "ecfc27d86c3660cbd64b3455265ac89250a1cdf733a2dcadaa1d236c9f53318a",
   "generated_hash": "5c8274c6606089b1a2854015f0f0f5176ed49806e3a6e9fce10749eeabffd01f"
 }

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -359,6 +359,8 @@ if [ $((PRODUCTIVE_THIS_SESSION % 5)) -eq 0 ] && [ "$PRODUCTIVE_THIS_SESSION" -g
 fi
 ```
 
+**Drive to completion (orchestrator-merge model, soc-2drk).** Where the repo requires PRs (branch protection rejects direct `main` pushes), a productive cycle does not stop at "PR opened" — the loop is the orchestrator that drives each bead to *merged*. Ship the bead from its per-bead worktree as a PR (trailers `Closes-scenario` / `Bounded-context` / `Evidence`), wait for CI, and **squash-merge to main yourself once CI is green** (`gh pr merge <N> --squash --admin`), then `bd close` the bead and remove the worktree. **Green CI is the only merge gate** — on a quality/test red, fix-and-repush or revert; never merge red. The loop may dispatch sub-agents to implement and drives their PRs to merge too. The operator stays *on* the loop (intent + STOP marker), not *in* it (per-PR approval). This **supersedes "operator is the merge gate"** for the autonomous loop — see [ADR-0008](../../docs/adr/ADR-0008-evolve-intelligent-agile-operating-model.md).
+
 ### Teardown
 
 Read `references/knowledge-loop-integration.md` for the full teardown learning extraction procedure (commit staged artifacts, run `/post-mortem`, push, report summary).


### PR DESCRIPTION
The 'loop drives every PR to merge; CI-green is the gate' model lived only in the cron prompt + a memory. This makes it durable doctrine.

- skills/evolve/SKILL.md Step 7: 'Drive to completion (orchestrator-merge model)' subsection — PR per bead → wait CI → squash-merge on green → bd close → clean; green CI is the only merge gate; loop drives sub-agents' PRs too; operator on the loop, not in it
- docs/adr/ADR-0008: new section recording the model + that it **supersedes** 'operator is the merge gate' for the autonomous loop; surviving guardrails listed
- skills-codex/evolve regenerated

How tested: lint-skills ✓ evolve (473 lines, 8337<10000 tokens); scenarios --lint 0 errors; codex parity passed; both new ADR doc-links resolve.
Fitness: orchestrator-merge model cron-prompt+memory → durable skill+ADR.

NOTE: claude-review will be infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-2drk#drive-to-completion
Bounded-context: BC3-Loop
Evidence: docs/adr/ADR-0008-evolve-intelligent-agile-operating-model.md