### PR TITLE
fix(goals): steer remove/prioritize preserve non-directive content (soc-5335b #steer-remove-prioritize-lossless)

### DIFF
--- a/cli/internal/goals/commands.go
+++ b/cli/internal/goals/commands.go
@@ -769,7 +769,18 @@ func RunSteerRemove(opts SteerRemoveOptions) error {
 		fmt.Fprintf(opts.Stdout, "Would remove directive #%d and renumber %d remaining\n", opts.Number, len(remaining))
 		return nil
 	}
-	if err := WriteMDGoals(gf, resolvedPath); err != nil {
+	// Persist via GoalsPatcher, not WriteMDGoals: the latter re-renders from
+	// the model and drops non-directive sections (Three-Gap, Gates, claim
+	// comments). The patcher deletes the block + renumbers, preserving every
+	// other byte (soc-5335b).
+	p, _, err := LoadGoalsPatcher(opts.GoalsFile)
+	if err != nil {
+		return err
+	}
+	if err := p.RemoveDirective(opts.Number); err != nil {
+		return err
+	}
+	if err := p.WriteFile(resolvedPath); err != nil {
 		return err
 	}
 	fmt.Fprintf(opts.Stdout, "Removed directive #%d, renumbered %d remaining\n", opts.Number, len(remaining))
@@ -840,7 +851,16 @@ func RunSteerPrioritize(opts SteerPrioritizeOptions) error {
 		fmt.Fprintf(opts.Stdout, "Would move directive %q to position %d\n", moving.Title, opts.NewPosition)
 		return nil
 	}
-	if err := WriteMDGoals(gf, resolvedPath); err != nil {
+	// Persist via GoalsPatcher, not WriteMDGoals: preserves non-directive
+	// sections while reordering + renumbering the directive blocks (soc-5335b).
+	p, _, err := LoadGoalsPatcher(opts.GoalsFile)
+	if err != nil {
+		return err
+	}
+	if err := p.MoveDirective(opts.Number, opts.NewPosition); err != nil {
+		return err
+	}
+	if err := p.WriteFile(resolvedPath); err != nil {
 		return err
 	}
 	fmt.Fprintf(opts.Stdout, "Moved directive %q to position %d\n", moving.Title, opts.NewPosition)

--- a/cli/internal/goals/commands_test.go
+++ b/cli/internal/goals/commands_test.go
@@ -554,6 +554,74 @@ func TestRunSteerPrioritize_Moves(t *testing.T) {
 	}
 }
 
+// soc-5335b regressions: remove/prioritize must preserve non-directive content
+// (Three-Gap section, claim comments) while renumbering — the old
+// LoadMDGoals→WriteMDGoals round-trip dropped them.
+func TestRunSteerRemove_PreservesNonDirectiveContent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	extra := "<!-- agentops:claim:AOP-CLAIM-KEEP -->\n\n## Three-Gap Contract Proof Surface\n\nPreserved doctrine section.\n"
+	writeGoalsMD(t, "GOALS.md", extra)
+	var buf bytes.Buffer
+	_ = RunSteerAdd(SteerAddOptions{Title: "Second", Description: "two", Steer: "increase", GoalsFile: "GOALS.md", Stdout: &buf})
+	_ = RunSteerAdd(SteerAddOptions{Title: "Third", Description: "three", Steer: "hold", GoalsFile: "GOALS.md", Stdout: &buf})
+
+	buf.Reset()
+	if err := RunSteerRemove(SteerRemoveOptions{Number: 2, GoalsFile: "GOALS.md", Stdout: &buf}); err != nil {
+		t.Fatalf("RunSteerRemove: %v", err)
+	}
+	data, _ := os.ReadFile("GOALS.md")
+	got := string(data)
+
+	if strings.Contains(got, "### 2. Second") || strings.Contains(got, "two") {
+		t.Errorf("removed directive 'Second' still present:\n%s", got)
+	}
+	if !strings.Contains(got, "### 2. Third") {
+		t.Errorf("Third not renumbered 3 -> 2:\n%s", got)
+	}
+	if !strings.Contains(got, "### 1. Establish baseline") {
+		t.Errorf("directive #1 lost:\n%s", got)
+	}
+	for _, must := range []string{"## Three-Gap Contract Proof Surface", "AOP-CLAIM-KEEP", "Preserved doctrine section."} {
+		if !strings.Contains(got, must) {
+			t.Errorf("non-directive content dropped (soc-5335b): %q missing:\n%s", must, got)
+		}
+	}
+}
+
+func TestRunSteerPrioritize_PreservesNonDirectiveContent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	extra := "<!-- agentops:claim:AOP-CLAIM-KEEP -->\n\n## Three-Gap Contract Proof Surface\n\nPreserved doctrine section.\n"
+	writeGoalsMD(t, "GOALS.md", extra)
+	var buf bytes.Buffer
+	_ = RunSteerAdd(SteerAddOptions{Title: "Second", Description: "two", Steer: "increase", GoalsFile: "GOALS.md", Stdout: &buf})
+	_ = RunSteerAdd(SteerAddOptions{Title: "Third", Description: "three", Steer: "hold", GoalsFile: "GOALS.md", Stdout: &buf})
+
+	buf.Reset()
+	// Move #3 (Third) to position 1 → order: Third(1), Establish baseline(2), Second(3)
+	if err := RunSteerPrioritize(SteerPrioritizeOptions{Number: 3, NewPosition: 1, GoalsFile: "GOALS.md", Stdout: &buf}); err != nil {
+		t.Fatalf("RunSteerPrioritize: %v", err)
+	}
+	data, _ := os.ReadFile("GOALS.md")
+	got := string(data)
+
+	if !strings.Contains(got, "### 1. Third") {
+		t.Errorf("Third not moved+renumbered to #1:\n%s", got)
+	}
+	if !strings.Contains(got, "### 2. Establish baseline") {
+		t.Errorf("Establish baseline not renumbered to #2:\n%s", got)
+	}
+	if !strings.Contains(got, "### 3. Second") {
+		t.Errorf("Second not renumbered to #3:\n%s", got)
+	}
+	for _, must := range []string{"## Three-Gap Contract Proof Surface", "AOP-CLAIM-KEEP", "Preserved doctrine section."} {
+		if !strings.Contains(got, must) {
+			t.Errorf("non-directive content dropped (soc-5335b): %q missing:\n%s", must, got)
+		}
+	}
+}
+
 func TestRunValidate_ValidFile(t *testing.T) {
 	tmp := t.TempDir()
 	t.Chdir(tmp)

--- a/cli/internal/goals/patcher.go
+++ b/cli/internal/goals/patcher.go
@@ -346,6 +346,104 @@ func (p *GoalsPatcher) AppendDirective(title, description, steer string) (int, e
 	return num, nil
 }
 
+// splitDirectiveBlocks decomposes the buffer into the lines before the first
+// directive (prefix), one line slice per directive block in source order, and
+// the lines after the last directive block (suffix). prefix+blocks+suffix
+// reconstructs the file, so the suffix — which holds non-directive sections
+// like "## Three-Gap Contract Proof Surface" and the Gates table — is carried
+// byte-for-byte across remove/reorder. ok is false when there are no directives.
+func (p *GoalsPatcher) splitDirectiveBlocks() (prefix []string, blocks [][]string, suffix []string, ok bool) {
+	dirs := p.Directives()
+	if len(dirs) == 0 {
+		return nil, nil, nil, false
+	}
+	prefix = p.lines[:dirs[0].headingIdx]
+	suffix = p.lines[dirs[len(dirs)-1].endIdx:]
+	for _, d := range dirs {
+		blocks = append(blocks, p.lines[d.headingIdx:d.endIdx])
+	}
+	return prefix, blocks, suffix, true
+}
+
+// assembleDirectives reassembles the buffer from prefix + directive blocks +
+// suffix, renumbering each block's "### N. Title" heading to its 1-based
+// position. Block bodies, attributes, and blank lines are copied verbatim;
+// only the heading number changes.
+func assembleDirectives(prefix []string, blocks [][]string, suffix []string) []string {
+	out := make([]string, 0, len(prefix)+len(suffix)+len(blocks)*8)
+	out = append(out, prefix...)
+	for i, b := range blocks {
+		nb := make([]string, len(b))
+		copy(nb, b)
+		if len(nb) > 0 {
+			if m := directiveHeadingRe.FindStringSubmatch(strings.TrimSpace(nb[0])); m != nil {
+				nb[0] = fmt.Sprintf("### %d. %s", i+1, m[2])
+			}
+		}
+		out = append(out, nb...)
+	}
+	return append(out, suffix...)
+}
+
+// directiveIndexByNumber returns the source-order index of the directive with
+// the given display number, or -1.
+func directiveIndexByNumber(dirs []ParsedDirective, number int) int {
+	for i, d := range dirs {
+		if d.Number == number {
+			return i
+		}
+	}
+	return -1
+}
+
+// RemoveDirective deletes the directive with the given display number and
+// renumbers the remaining directives sequentially, preserving every
+// non-directive byte of the file (soc-5335b). Replaces the lossy
+// LoadMDGoals→WriteMDGoals round-trip.
+func (p *GoalsPatcher) RemoveDirective(number int) error {
+	prefix, blocks, suffix, ok := p.splitDirectiveBlocks()
+	if !ok {
+		return fmt.Errorf("no directives to remove")
+	}
+	idx := directiveIndexByNumber(p.Directives(), number)
+	if idx < 0 {
+		return fmt.Errorf("directive #%d not found", number)
+	}
+	kept := make([][]string, 0, len(blocks)-1)
+	kept = append(kept, blocks[:idx]...)
+	kept = append(kept, blocks[idx+1:]...)
+	p.lines = assembleDirectives(prefix, kept, suffix)
+	return nil
+}
+
+// MoveDirective moves the directive with the given display number to newPos
+// (1-based) and renumbers all directives sequentially, preserving every
+// non-directive byte of the file (soc-5335b).
+func (p *GoalsPatcher) MoveDirective(number, newPos int) error {
+	prefix, blocks, suffix, ok := p.splitDirectiveBlocks()
+	if !ok {
+		return fmt.Errorf("no directives to prioritize")
+	}
+	if newPos < 1 || newPos > len(blocks) {
+		return fmt.Errorf("new position must be between 1 and %d", len(blocks))
+	}
+	idx := directiveIndexByNumber(p.Directives(), number)
+	if idx < 0 {
+		return fmt.Errorf("directive #%d not found", number)
+	}
+	moving := blocks[idx]
+	rest := make([][]string, 0, len(blocks)-1)
+	rest = append(rest, blocks[:idx]...)
+	rest = append(rest, blocks[idx+1:]...)
+	insertIdx := newPos - 1
+	reordered := make([][]string, 0, len(blocks))
+	reordered = append(reordered, rest[:insertIdx]...)
+	reordered = append(reordered, moving)
+	reordered = append(reordered, rest[insertIdx:]...)
+	p.lines = assembleDirectives(prefix, reordered, suffix)
+	return nil
+}
+
 // attrRank returns the canonical sort rank for an attribute key.
 func attrRank(key string) int {
 	if r, ok := attrOrder[key]; ok {


### PR DESCRIPTION
Completes the steer-mutation lossless trilogy (soc-byt52 fixed add). `RunSteerRemove`/`RunSteerPrioritize` still re-rendered via WriteMDGoals, dropping the Three-Gap section, Gates table, and claim comments. They **renumber**, so they need surgical block ops.

- patcher.go: `splitDirectiveBlocks` (prefix + block slices + suffix — suffix carries non-directive sections byte-for-byte) + `assembleDirectives` (renumbers `### N.` headings, bodies verbatim) + `RemoveDirective` + `MoveDirective`
- commands.go: both ops persist via the patcher; LoadMDGoals kept as format guard + JSON/dry-run preview
- commands_test.go: 2 L2 regressions (preserve doctrine + renumber correctly)

How tested: full goals + cmd goals suites green; end-to-end repro — remove→`1. Alpha / 2. Gamma`, prioritize→`1. Gamma / 2. Alpha`, doctrine 3/3 preserved both; gofmt+vet clean.
Sibling: extends AppendDirective (#418). Fitness: lossy steer mutations 2 → **0**.

NOTE: claude-review will be infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-5335b#steer-remove-prioritize-lossless
Bounded-context: BC5-Runtime
Evidence: cli/internal/goals/patcher.go