### PR TITLE
fix(docs): behavior-science is a lens, not the product spine (soc-e92s1 #headline-not-spine)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -6,7 +6,7 @@ last_reviewed: 2026-05-15
 
 ## Mission
 
-**AgentOps is an SDLC control plane for agentic software development.** It works by **behavior shaping**: arranging the environment and reinforcement so agents reliably perform the behaviors you and they agree on — the operant-conditioning model of Antecedent → Behavior → Consequence (see [Behavior-Shaping Environment](docs/architecture/behavior-shaping-environment.md)). Concretely, it automates the discipline of building a wiki for your agents: markdown in `.agents/` next to your code, produced and consumed by the agents that work there — the antecedent the next behavior is shaped against. The compounded corpus is the moat. The internal lifecycle is the CDLC: context is developed, tested, delivered, observed, and improved because context is what LLM agents consume.
+**AgentOps is an SDLC control plane for agentic software development.** It automates the discipline of building a wiki for your agents: markdown in `.agents/` next to your code, produced and consumed by the agents that work there. The compounded corpus is the moat. The internal lifecycle is the CDLC: context is developed, tested, delivered, observed, and improved because context is what LLM agents consume.
 
 ## Product Identity
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### The SDLC control plane for agentic software development.
 
-AgentOps shapes how coding agents behave: it arranges the environment they work in — context, standards, goals, a corpus of past decisions — so the behavior you and the agent agree on is the likely one, then reinforces it with gates between phases. That's behavior shaping, the operant-conditioning way you'd build any capable agent ([the full frame](docs/architecture/behavior-shaping-environment.md)). It sits on top of the coding harness you already use — Claude Code, Codex, Cursor, OpenCode — adds the parts an engineering team would notice missing (a record of what was tried, gates between phases, a corpus of learnings that survives the next session), keeps state in `.agents/` next to your code, and lets you mix Claude, Codex, or any model per phase.
+AgentOps sits on top of the coding harness you already use — Claude Code, Codex, Cursor, OpenCode — and adds the parts an engineering team would notice missing: a record of what was tried, gates between phases, and a corpus of learnings that survives the next session. State lives in `.agents/` next to your code, and you can mix Claude, Codex, or any model per phase.
 
 *This repo was built with AgentOps. As of 2026-05-04 its `.agents/` held ~1,842 learnings, ~186 patterns, ~80 planning rules, and ~3,867 cited decisions captured during development. Re-run anytime: `bash scripts/corpus-stats.sh`.*
 

--- a/docs/architecture/behavior-shaping-environment.md
+++ b/docs/architecture/behavior-shaping-environment.md
@@ -1,6 +1,6 @@
 # Behavior-Shaping Environment
 
-> The *why* beneath the loop. AgentOps is an environment that arranges antecedents and reinforcement so AI agents reliably perform the behaviors the operator and agent agree upon. Companion to [Operating Loop](operating-loop.md) (the moves), [Intent-to-Loop Hexagon](intent-to-loop-hexagon.md) (the ports), and [Ports and Adapters](ports-and-adapters.md) (the seams). Doctrine source: operator framing 2026-05-22 ("working with agents is like shaping a dog's behavior — arrange the environment, then reward/stop"); promote changes to that framing first.
+> A behavioral lens on the loop — **not** the product's spine. The spine is the [Operating Loop](operating-loop.md) inside the SDLC control plane; this is a complementary frame: many AgentOps mechanisms can be read as operant conditioning — arranging antecedents and reinforcement so agents reliably perform the behaviors the operator and agent agree upon. Companion to [Intent-to-Loop Hexagon](intent-to-loop-hexagon.md) (the ports) and [Ports and Adapters](ports-and-adapters.md) (the seams). Doctrine source: operator framing 2026-05-22 ("working with agents is like shaping a dog's behavior — arrange the environment, then reward/stop"); promote changes to that framing first.
 
 You cannot compile a behavior into a non-deterministic model the way you specify a deterministic system. A prose spec assumes you can *dictate* behavior. You can't — a stochastic learner only acquires behavior through **observable examples and reinforcement**. So AgentOps does not try to specify what an agent will do; it **shapes** what an agent does, using the mechanics of operant conditioning. This is why behavior-driven development works so well here: a `.feature` scenario is not a description, it is a behavior added to a repertoire and reinforced until it is reliably exhibited.
 
@@ -16,7 +16,7 @@ Operant conditioning runs on three terms — **Antecedent → Behavior → Conse
 | **Consequence: reinforcement** (reward) | what makes the behavior more likely next time | passing gates (`/vibe`, `validation`, CI green), merge to main, citation/confidence feedback; the **ratchet** locks a reinforced behavior permanently (`can't un-ratchet` = a fixed habit) |
 | **Consequence: stop / extinction** (punishment / non-reward) | what makes a behavior less likely or removes it | PreToolUse hook denials, halt-check STOP/kill markers, holdout-isolation gates, reverts (behavior not reinforced → not merged); **extinction** = deleting a scenario or gate so the behavior is no longer cued or rewarded |
 
-## Why this is the spine, not a metaphor
+## Why the lens is useful, not just a metaphor
 
 - **Behavior is the unit of work** ([Operating Loop](operating-loop.md) principle 2) because behavior is the unit of *learning*. A vertical slice demonstrates one behavior; a layer demonstrates nothing an agent can be reinforced on.
 - **The first failing test is the slice's contract** because red→green *is* shaping: the failing scenario is the target behavior, and the agent reinforces toward it through successive approximations until it is exhibited (green).


### PR DESCRIPTION
Operator correction (2026-05-22): *"behavior science is not the spine. fix the headline."* PR #416 over-rotated — it led the README + PRODUCT headlines with behavior-shaping and the doctrine doc called itself "the spine." The spine is the SDLC control plane / operating loop; behavior-shaping is a complementary lens.

- README.md lead: restored to SDLC-control-plane framing; behavior-shaping removed from the headline
- PRODUCT.md Mission: restored to wiki-for-agents + corpus-moat + CDLC; behavior-shaping removed from the lead
- docs/architecture/behavior-shaping-environment.md: demoted to "a behavioral lens — NOT the product's spine; the spine is the operating loop"; heading "Why this is the spine" → "Why the lens is useful"

Content kept as a lens (doctrine doc, domain vocab, GOALS directive #14); only the spine/headline positioning is corrected.

How tested: diff 4/4 balanced swaps (no collateral); sync-skill-counts no drift; doctrine-doc links resolve.

NOTE: claude-review will be infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-e92s1#headline-not-spine
Bounded-context: BC1-Corpus
Evidence: README.md