### PR TITLE
fix(goals): ao goals steer --json persists the mutation (was emit-without-write) (soc-3z69s #steer-json-persists)

### DIFF
--- a/cli/internal/goals/commands.go
+++ b/cli/internal/goals/commands.go
@@ -694,12 +694,15 @@ func RunSteerAdd(opts SteerAddOptions) error {
 	}
 	newNum := maxNum + 1
 
-	if opts.JSON {
-		enc := json.NewEncoder(opts.Stdout)
-		enc.SetIndent("", "  ")
-		return enc.Encode(Directive{Number: newNum, Title: opts.Title, Description: opts.Description, Steer: opts.Steer})
-	}
+	// --dry-run previews without writing (either output format). --json is an
+	// output-format flag, NOT a no-write flag — a write command must persist
+	// under --json and emit the result as JSON (soc-3z69s).
 	if opts.DryRun {
+		if opts.JSON {
+			enc := json.NewEncoder(opts.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(Directive{Number: newNum, Title: opts.Title, Description: opts.Description, Steer: opts.Steer})
+		}
 		fmt.Fprintf(opts.Stdout, "Would add directive #%d: %s\n", newNum, opts.Title)
 		return nil
 	}
@@ -719,6 +722,11 @@ func RunSteerAdd(opts SteerAddOptions) error {
 	}
 	if err := p.WriteFile(resolvedPath); err != nil {
 		return err
+	}
+	if opts.JSON {
+		enc := json.NewEncoder(opts.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(Directive{Number: num, Title: opts.Title, Description: opts.Description, Steer: opts.Steer})
 	}
 	fmt.Fprintf(opts.Stdout, "Added directive #%d: %s (steer: %s)\n", num, opts.Title, opts.Steer)
 	return nil
@@ -760,12 +768,14 @@ func RunSteerRemove(opts SteerRemoveOptions) error {
 	}
 	gf.Directives = remaining
 
-	if opts.JSON {
-		enc := json.NewEncoder(opts.Stdout)
-		enc.SetIndent("", "  ")
-		return enc.Encode(gf.Directives)
-	}
+	// --dry-run previews without writing (either format); --json is output
+	// format, not a no-write flag (soc-3z69s).
 	if opts.DryRun {
+		if opts.JSON {
+			enc := json.NewEncoder(opts.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(gf.Directives)
+		}
 		fmt.Fprintf(opts.Stdout, "Would remove directive #%d and renumber %d remaining\n", opts.Number, len(remaining))
 		return nil
 	}
@@ -782,6 +792,11 @@ func RunSteerRemove(opts SteerRemoveOptions) error {
 	}
 	if err := p.WriteFile(resolvedPath); err != nil {
 		return err
+	}
+	if opts.JSON {
+		enc := json.NewEncoder(opts.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(gf.Directives)
 	}
 	fmt.Fprintf(opts.Stdout, "Removed directive #%d, renumbered %d remaining\n", opts.Number, len(remaining))
 	return nil
@@ -842,12 +857,14 @@ func RunSteerPrioritize(opts SteerPrioritizeOptions) error {
 	}
 	gf.Directives = result
 
-	if opts.JSON {
-		enc := json.NewEncoder(opts.Stdout)
-		enc.SetIndent("", "  ")
-		return enc.Encode(gf.Directives)
-	}
+	// --dry-run previews without writing (either format); --json is output
+	// format, not a no-write flag (soc-3z69s).
 	if opts.DryRun {
+		if opts.JSON {
+			enc := json.NewEncoder(opts.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(gf.Directives)
+		}
 		fmt.Fprintf(opts.Stdout, "Would move directive %q to position %d\n", moving.Title, opts.NewPosition)
 		return nil
 	}
@@ -862,6 +879,11 @@ func RunSteerPrioritize(opts SteerPrioritizeOptions) error {
 	}
 	if err := p.WriteFile(resolvedPath); err != nil {
 		return err
+	}
+	if opts.JSON {
+		enc := json.NewEncoder(opts.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(gf.Directives)
 	}
 	fmt.Fprintf(opts.Stdout, "Moved directive %q to position %d\n", moving.Title, opts.NewPosition)
 	return nil

--- a/cli/internal/goals/commands_test.go
+++ b/cli/internal/goals/commands_test.go
@@ -622,6 +622,72 @@ func TestRunSteerPrioritize_PreservesNonDirectiveContent(t *testing.T) {
 	}
 }
 
+// soc-3z69s regressions: steer mutations under --json must PERSIST (not just
+// emit). Previously --json returned before WriteFile, so the change was lost.
+func TestRunSteerAdd_JSONPersists(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	writeGoalsMD(t, "GOALS.md", "")
+	var buf bytes.Buffer
+	if err := RunSteerAdd(SteerAddOptions{Title: "Persisted", Description: "d", Steer: "increase", GoalsFile: "GOALS.md", JSON: true, Stdout: &buf}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "Persisted") {
+		t.Errorf("json output missing directive: %q", buf.String())
+	}
+	data, _ := os.ReadFile("GOALS.md")
+	if !strings.Contains(string(data), "Persisted") {
+		t.Errorf("--json did not persist to GOALS.md:\n%s", string(data))
+	}
+}
+
+func TestRunSteerRemove_JSONPersists(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	writeGoalsMD(t, "GOALS.md", "")
+	var buf bytes.Buffer
+	_ = RunSteerAdd(SteerAddOptions{Title: "Doomed", Description: "d", Steer: "increase", GoalsFile: "GOALS.md", Stdout: &buf})
+	buf.Reset()
+	if err := RunSteerRemove(SteerRemoveOptions{Number: 2, GoalsFile: "GOALS.md", JSON: true, Stdout: &buf}); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile("GOALS.md")
+	if strings.Contains(string(data), "Doomed") {
+		t.Errorf("--json remove did not persist (directive still present):\n%s", string(data))
+	}
+}
+
+func TestRunSteerPrioritize_JSONPersists(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	writeGoalsMD(t, "GOALS.md", "")
+	var buf bytes.Buffer
+	_ = RunSteerAdd(SteerAddOptions{Title: "Mover", Description: "d", Steer: "increase", GoalsFile: "GOALS.md", Stdout: &buf})
+	buf.Reset()
+	if err := RunSteerPrioritize(SteerPrioritizeOptions{Number: 2, NewPosition: 1, GoalsFile: "GOALS.md", JSON: true, Stdout: &buf}); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile("GOALS.md")
+	if !strings.Contains(string(data), "### 1. Mover") {
+		t.Errorf("--json prioritize did not persist the move:\n%s", string(data))
+	}
+}
+
+func TestRunSteerAdd_DryRunJSONStillNoWrite(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	writeGoalsMD(t, "GOALS.md", "")
+	before, _ := os.ReadFile("GOALS.md")
+	var buf bytes.Buffer
+	if err := RunSteerAdd(SteerAddOptions{Title: "Ghost", Description: "d", Steer: "hold", GoalsFile: "GOALS.md", JSON: true, DryRun: true, Stdout: &buf}); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := os.ReadFile("GOALS.md")
+	if string(before) != string(after) {
+		t.Errorf("--dry-run --json wrote to the file; should preview only")
+	}
+}
+
 func TestRunValidate_ValidFile(t *testing.T) {
 	tmp := t.TempDir()
 	t.Chdir(tmp)


### PR DESCRIPTION
Harden-mission slice (target #5). RunSteerAdd/Remove/Prioritize each did `if opts.JSON { encode; return }` BEFORE WriteFile — so `ao goals steer ... --json` emitted JSON but never persisted. A separate --dry-run flag already exists for preview, so --json conflating output-format with no-write was a footgun.

- commands.go: all three RunSteer* restructured — --dry-run previews (no write, either format); otherwise WRITE then emit. --json is now purely output-format.
- commands_test.go: 4 L2 regressions (add/remove/prioritize --json persist; --dry-run --json previews-only).

How tested: full ./internal/goals + ./cmd/ao goals suites green; the 3 JSON-persist tests fail on old code; vet+gofmt clean. No command-surface change.
Fitness: silently-no-write steer --json paths 3 → 0.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-3z69s#steer-json-persists
Bounded-context: BC5-Runtime
Evidence: cli/internal/goals/commands.go