### PR TITLE
test(evolve): cover the global KILL switch in halt-check (soc-7f82q #kill-switch-coverage)

### DIFF
--- a/tests/scripts/evolve-halt-check.bats
+++ b/tests/scripts/evolve-halt-check.bats
@@ -56,6 +56,28 @@ teardown() {
   [[ "$output" == *"STALE"* ]]
 }
 
+# --- operator-GLOBAL kill switch (~/.config/evolve/KILL), checked before STOP --
+# HOME is redirected to $TMP so the test never touches a real global KILL.
+
+@test "fresh global KILL marker halts as kill (operator emergency stop)" {
+  mkdir -p "$TMP/.config/evolve"
+  touch "$TMP/.config/evolve/KILL"
+  run env HOME="$TMP" EVOLVE_DIR="$TMP/.agents/evolve" bash "$GATE" --json
+  [ "$status" -eq 1 ]
+  [ "$output" = '{"halt":true,"halt_reason":"kill"}' ]
+}
+
+@test "stale global KILL marker is bypassed, loop continues" {
+  mkdir -p "$TMP/.config/evolve"
+  touch "$TMP/.config/evolve/KILL"
+  # Backdate 10 days; TTL set to 7.
+  touch -d "10 days ago" "$TMP/.config/evolve/KILL" 2>/dev/null || touch -A -240000 "$TMP/.config/evolve/KILL"
+  run env HOME="$TMP" EVOLVE_DIR="$TMP/.agents/evolve" EVOLVE_KILL_TTL_DAYS=7 bash "$GATE" --json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'{"halt":false,"halt_reason":null}'* ]]
+  [[ "$output" == *"STALE"* ]]
+}
+
 @test "DORMANT with no ready work halts as dormant" {
   # Hermetic: cd to a dir with no .beads (bd ready -> 0) + point harvested ledger
   # at an empty file so neither real repo state leaks in.

--- a/tests/scripts/evolve-primitive-wiring.bats
+++ b/tests/scripts/evolve-primitive-wiring.bats
@@ -13,6 +13,12 @@
 setup() {
   REPO_ROOT="$(git rev-parse --show-toplevel)"
   SKILL="$REPO_ROOT/skills/evolve/SKILL.md"
+  # Step 3's selection ladder — incl. the write-stop-marker / blocked / next-work
+  # wiring — was extracted to this reference in #413 to keep SKILL.md under the
+  # 10000-token ceiling. SKILL.md links it and the agent reads it as Step 3, so
+  # the wiring content is asserted against the ladder; SKILL.md's LINK to it is
+  # asserted separately (the reachability half of the consumer-wiring proof).
+  LADDER="$REPO_ROOT/skills/evolve/references/work-selection-ladder.md"
 }
 
 @test "SKILL.md Step 3 invokes 'ao evolve next-work' for work selection" {
@@ -20,26 +26,31 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-@test "SKILL.md routes the stagnation marker write through 'ao evolve write-stop-marker'" {
-  run grep -F 'ao evolve write-stop-marker --marker dormant' "$SKILL"
+@test "SKILL.md links the work-selection-ladder reference (wiring reachable)" {
+  run grep -F 'references/work-selection-ladder.md' "$SKILL"
   [ "$status" -eq 0 ]
 }
 
-@test "SKILL.md logs a typed blocked event via 'ao evolve blocked' instead of halting" {
-  run grep -F 'ao evolve blocked --reason' "$SKILL"
+@test "the ladder routes the stagnation marker write through 'ao evolve write-stop-marker'" {
+  run grep -F 'ao evolve write-stop-marker --marker dormant' "$LADDER"
+  [ "$status" -eq 0 ]
+}
+
+@test "the ladder logs a typed blocked event via 'ao evolve blocked' instead of halting" {
+  run grep -F 'ao evolve blocked --reason' "$LADDER"
   [ "$status" -eq 0 ]
 }
 
 @test "the write-stop-marker wire passes --mode loop (deterministic no-self-stop)" {
-  run grep -F 'ao evolve write-stop-marker --marker dormant --reason "$REASON" --mode loop' "$SKILL"
+  run grep -F 'ao evolve write-stop-marker --marker dormant --reason "$REASON" --mode loop' "$LADDER"
   [ "$status" -eq 0 ]
 }
 
 @test "each wire keeps a fallback for ao without the subcommand (--help probe)" {
   # write-stop-marker + next-work both guard their call behind a --help probe so
   # an older ao falls back instead of erroring.
-  run grep -F 'ao evolve write-stop-marker --help >/dev/null 2>&1' "$SKILL"
+  run grep -F 'ao evolve write-stop-marker --help >/dev/null 2>&1' "$LADDER"
   [ "$status" -eq 0 ]
-  run grep -F 'ao evolve next-work --help >/dev/null 2>&1' "$SKILL"
+  run grep -F 'ao evolve next-work --help >/dev/null 2>&1' "$LADDER"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Harden-mission target #3. halt-check.sh honors an operator-GLOBAL kill switch (`~/.config/evolve/KILL`, reason "kill") checked before the repo STOP — but it had ZERO tests while repo-STOP had 2. Closes the safety-critical gap.

- evolve-halt-check.bats: + fresh-KILL-halts + stale-KILL-bypassed (HOME redirected to $TMP, never touches a real global KILL).

No halt-check.sh change (behavior was already correct). Targets #2 + #4 assessed SOLID this cycle — skipped, no manufactured tests.

How tested: bats → 13/13 (was 11).
Fitness: marker coverage STOP-only → STOP+KILL.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-7f82q#kill-switch-coverage
Bounded-context: BC3-Loop
Evidence: tests/scripts/evolve-halt-check.bats