### PR TITLE
fix(ci): trigger bats-tests on skills/ + docs/ changes (soc-xrdwp #bats-path-filter)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1738,7 +1738,11 @@ jobs:
 
   bats-tests:
     needs: [changes]
-    if: needs.changes.outputs.hooks == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.bats == 'true' || needs.changes.outputs.ci == 'true'
+    # skills + docs included because several bats tests assert SKILL.md / reference
+    # content (e.g. evolve-primitive-wiring.bats); a skills/docs-only change that
+    # breaks such an assertion must trigger bats, not merge undetected (soc-xrdwp;
+    # #413's wiring move hid for 11 PRs because skills/ did not trigger this job).
+    if: needs.changes.outputs.hooks == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.bats == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
bats-tests only triggered on hooks/shell/bats/ci. But several bats tests assert SKILL.md / reference content — so a skills/docs-only PR that breaks one didn't trigger bats and merged undetected (how #413's wiring move hid for 11 PRs until #424 surfaced it).

- validate.yml: add `skills == 'true' || docs == 'true'` to the bats-tests `if:` (both outputs already defined; matches other jobs' idiom).

CI half of the #424 wiring-drift fix; aligns with the path-filter-landmine learning.

How tested: validate.yml parses; +5/-1; this PR is a ci change so bats-tests runs + confirms green.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-xrdwp#bats-path-filter
Bounded-context: BC4-Validation
Evidence: .github/workflows/validate.yml