### PR TITLE
feat(vibe): executable acceptance for the /vibe quality gate (soc-ctbak #vibe-hexagon)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1153,7 +1153,7 @@
     {
       "name": "vibe",
       "source_skill": "skills/vibe",
-      "source_hash": "71707d5cd761ea914931babb7ba79817f14c2b9ab80d1fc3bae0b6b42ac0c1cc",
+      "source_hash": "3de4aa35036213350fac4ea144186579ddf40753cff3247fd7e6c60d65aa80ea",
       "generated_hash": "c0a5605f01736725d021050b32ea966ccd1a3e6296b4e8d4995d0f2c4e95e365"
     }
   ]

--- a/skills-codex/vibe/.agentops-generated.json
+++ b/skills-codex/vibe/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/vibe",
   "layout": "modular",
-  "source_hash": "71707d5cd761ea914931babb7ba79817f14c2b9ab80d1fc3bae0b6b42ac0c1cc",
+  "source_hash": "3de4aa35036213350fac4ea144186579ddf40753cff3247fd7e6c60d65aa80ea",
   "generated_hash": "c0a5605f01736725d021050b32ea966ccd1a3e6296b4e8d4995d0f2c4e95e365"
 }

--- a/skills/vibe/SKILL.md
+++ b/skills/vibe/SKILL.md
@@ -393,6 +393,7 @@ The hook is non-blocking (always exits 0) and outputs warnings via JSON. See [re
 
 ## Reference Documents
 
+- [references/vibe.feature](references/vibe.feature) — Executable spec: council verdict (complexity/architecture/security/intent-fit), block-on-CRITICAL, verdict.json (soc-qk4b)
 - [references/complexity-analysis.md](references/complexity-analysis.md)
 - [references/deep-checks.md](references/deep-checks.md)
 - [references/post-verdict-actions.md](references/post-verdict-actions.md)

--- a/skills/vibe/references/vibe.feature
+++ b/skills/vibe/references/vibe.feature
@@ -1,0 +1,31 @@
+# Executable spec for the /vibe skill — per-slice code-quality gate (BC4 Validation, loop Move 6).
+# /vibe runs a multi-model council over a slice's changes and returns a PASS/WARN/FAIL
+# verdict on complexity, architecture, security, and intent-fit — judging the code that
+# reaches the behavior, NOT replacing the slice's first failing test. CRITICAL findings
+# block. Hexagon: domain; consumes: standards; produces: result.json + verdict.json. (soc-qk4b)
+
+Feature: Vibe judges a slice's code quality before it counts
+  As the per-slice quality gate
+  I want a council verdict on the code a slice produced
+  So that a slice is only counted toward bead acceptance when its code is sound
+
+  Background:
+    Given a slice's code changes
+
+  Scenario: the council returns a per-dimension verdict
+    When /vibe runs
+    Then it produces a PASS/WARN/FAIL verdict over complexity, architecture, security, and intent-fit
+    And it writes verdict.json (the canonical council verdict contract)
+
+  Scenario: CRITICAL findings block the slice
+    When the council surfaces a CRITICAL finding
+    Then the verdict is FAIL and the slice is not ready to count against the roll-up
+    And it must be fixed and re-vibed before closing the bead
+
+  Scenario: vibe judges code, not behavior
+    Then /vibe complements the slice's first failing test (which proves behavior)
+    And it does not substitute for that test
+
+  Scenario: deep-audit mode widens the review
+    Given /vibe --sweep recent
+    Then per-file explorers feed the council for a deeper audit over the recent changes


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank ('keep going on agentops'). /vibe had filled frontmatter but no .feature; consumed by 4 cranked loop skills (highest-value uncranked loop dependency).

- skills/vibe/references/vibe.feature (NEW): council verdict (complexity/architecture/security/intent-fit), block-on-CRITICAL, judges-code-not-behavior, --sweep deep-audit, verdict.json
- linked in SKILL.md

How tested: lint-skills ✓ vibe (418 lines); scenarios --lint 0 errors; codex parity passed.
Sibling: acceptance-only crank like /crank #406, /rpi #407.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-ctbak#vibe-hexagon
Bounded-context: BC4-Validation
Evidence: skills/vibe/references/vibe.feature