### PR TITLE
feat(swarm): executable acceptance for the /swarm wave-fork (soc-ttqck #swarm-hexagon)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1105,7 +1105,7 @@
     {
       "name": "swarm",
       "source_skill": "skills/swarm",
-      "source_hash": "3ff99264fc0befaa8830cb91fc7941d4bbe2962c417fc5b9e12af973ccbcb20f",
+      "source_hash": "63cbe4f3a413575a20293c0ea65d37426a92c08fcf34c57a598e3279d0837fb2",
       "generated_hash": "cecb9fed1aaff7fc85958163aa2cb34d6a4b448eafd16494aa3661aa7f01a95b"
     },
     {

--- a/skills-codex/swarm/.agentops-generated.json
+++ b/skills-codex/swarm/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/swarm",
   "layout": "modular",
-  "source_hash": "3ff99264fc0befaa8830cb91fc7941d4bbe2962c417fc5b9e12af973ccbcb20f",
+  "source_hash": "63cbe4f3a413575a20293c0ea65d37426a92c08fcf34c57a598e3279d0837fb2",
   "generated_hash": "cecb9fed1aaff7fc85958163aa2cb34d6a4b448eafd16494aa3661aa7f01a95b"
 }

--- a/skills/swarm/SKILL.md
+++ b/skills/swarm/SKILL.md
@@ -209,6 +209,7 @@ Read [references/ol-wave-integration.md](references/ol-wave-integration.md) when
 
 ## References
 
+- **Executable acceptance:** [references/swarm.feature](references/swarm.feature) — wave-validity gate, fresh-context workers, conflict-free ownership, results+cleanup (soc-qk4b)
 - **Local Mode Details:** `skills/swarm/references/local-mode.md`
 - **Validation Contract:** `skills/swarm/references/validation-contract.md`
 

--- a/skills/swarm/references/swarm.feature
+++ b/skills/swarm/references/swarm.feature
@@ -1,0 +1,34 @@
+# Executable spec for the /swarm skill — wave-execution parallel-fork (BC3 Loop, Move 5).
+# /swarm is the primitive /crank invokes to run a wave. It spawns fresh-context workers
+# in parallel ONLY when the wave is conflict-free (the wave-validity check is all-green);
+# otherwise it runs sequential. Parallelism is explicit ownership, not chaos. Hexagon:
+# supporting; consumes: implement, vibe; produces: .agents/swarm/results/*.json;
+# customer-of crank. (soc-qk4b)
+
+Feature: Swarm executes a wave in parallel only when ownership is conflict-free
+  As the loop's wave-execution fork
+  I want parallel workers spawned only on a verified-disjoint wave
+  So that parallelism is explicit ownership, never a colliding free-for-all
+
+  Background:
+    Given a wave of slices handed down by /crank
+
+  Scenario: the wave-validity check gates parallel spawn
+    When /swarm prepares to run the wave
+    Then it spawns parallel workers only if every wave-validity row is green
+      (disjoint write scopes, no shared migration/contract/CLI surface,
+       integration order declared, one owner per slice, a discard path per slice)
+    And it defaults to sequential when any row is not green
+
+  Scenario: each worker runs in fresh, isolated context
+    When workers are spawned
+    Then each receives one pre-assigned atomic task and executes it in fresh context (Ralph pattern)
+    And no two workers share a write scope
+
+  Scenario: results are captured and the backend is cleaned up
+    When the wave completes
+    Then per-worker results are written under .agents/swarm/results/*.json
+    And spawned backend resources are released
+
+  Scenario: swarm is the wave primitive crank invokes
+    Then /crank drives wave execution through /swarm rather than spawning agents directly


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank. /swarm (the wave-execution primitive /crank invokes) had filled frontmatter but no .feature.

- skills/swarm/references/swarm.feature (NEW): wave-validity gate (parallel only when conflict-free, else sequential), fresh-context workers (Ralph), per-worker results + cleanup, customer-of crank
- linked in SKILL.md

How tested: lint-skills ✓ swarm (299 lines); scenarios --lint 0 errors; codex parity passed.
Sibling: acceptance-only crank like /vibe #426.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-ttqck#swarm-hexagon
Bounded-context: BC3-Loop
Evidence: skills/swarm/references/swarm.feature