### PR TITLE
feat(domain): executable acceptance for the vocabulary corpus skill (soc-j9m1t #domain-hexagon)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -775,7 +775,7 @@
     {
       "name": "domain",
       "source_skill": "skills/domain",
-      "source_hash": "9e03962151034a8b87eda559f32650806903dfacd9a1b578aea5ed79eb8bd01f",
+      "source_hash": "03ee3ce743d4a7a9b9f9666e2ea2036b31487c430d9e1e28f4af7b86f115dfe1",
       "generated_hash": "5de534737803c76fab3ad06e1a47dba85eb8f631a159cc6157ce4f932c2e99e4"
     },
     {

--- a/skills-codex/domain/.agentops-generated.json
+++ b/skills-codex/domain/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/domain",
   "layout": "modular",
-  "source_hash": "9e03962151034a8b87eda559f32650806903dfacd9a1b578aea5ed79eb8bd01f",
+  "source_hash": "03ee3ce743d4a7a9b9f9666e2ea2036b31487c430d9e1e28f4af7b86f115dfe1",
   "generated_hash": "5de534737803c76fab3ad06e1a47dba85eb8f631a159cc6157ce4f932c2e99e4"
 }

--- a/skills/domain/SKILL.md
+++ b/skills/domain/SKILL.md
@@ -68,6 +68,7 @@ structural primitives without operator consent.
 
 Structural primitives (the architecture):
 
+- [references/domain.feature](references/domain.feature) — Executable spec: load-on-demand corpus, draft→canonical ratchet, vocabulary root (soc-qk4b)
 - [`references/entry.md`](references/entry.md) — Entry: the atomic concept doc
 - [`references/index-primitive.md`](references/index-primitive.md) — Index: the discovery surface (concept)
 - [`references/citation.md`](references/citation.md) — Citation: how Entries reference each other and how agents claim use

--- a/skills/domain/references/domain.feature
+++ b/skills/domain/references/domain.feature
@@ -1,0 +1,27 @@
+# Executable spec for the /domain skill — the ubiquitous-language corpus (BC1 Corpus / inner hexagon).
+# /domain is the canonical vocabulary root: it curates the load-on-demand corpus of concept
+# entries every other skill anchors to. As the language source it consumes nothing (consumes:[]
+# is correct — it is the shared kernel others point at, not a consumer); it produces vocabulary.
+# Entries promote draft -> canonical only under operator approval (the growth ratchet). (soc-qk4b)
+
+Feature: Domain is the load-on-demand ubiquitous-language corpus
+  As the inner hexagon's vocabulary root
+  I want the shared language curated as on-demand, status-gated entries
+  So that every skill anchors to one canonical register without preloading the whole corpus
+
+  Scenario: vocabulary is loaded on demand, not preloaded
+    When an agent needs a term
+    Then it reads the specific entry (and references/INDEX.md to find it)
+    And it does not preload the entire corpus
+
+  Scenario: entries promote draft to canonical only under the ratchet
+    Given a new corpus entry
+    Then it starts as status: draft
+    And promotion to canonical requires operator approval (not self-promotion)
+
+  Scenario: domain is the language source, consuming nothing
+    Then /domain's hexagon consumes no other skill (consumes:[] is correct for the vocabulary root)
+    And other skills relate to it as the shared kernel
+
+  Scenario: the index catalogs every entry
+    Then references/INDEX.md lists each entry by slug, concept, status, and kind


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank. /domain (DDD ubiquitous-language root) lacked a .feature.

- skills/domain/references/domain.feature (NEW): load-on-demand corpus, draft→canonical ratchet (no self-promotion), vocabulary-root (consumes:[] correct), INDEX catalogs entries
- linked in SKILL.md

Assessed consumes:[] correct for the vocabulary root (acceptance-only, no frontmatter/context-map change).

How tested: lint-skills ✓ domain (128 lines); scenarios --lint 0 errors; codex parity passed.
Sibling: acceptance-only crank like /vibe #426, /swarm #427.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-j9m1t#domain-hexagon
Bounded-context: BC1-Corpus
Evidence: skills/domain/references/domain.feature