### PR TITLE
feat(forge): executable acceptance for the transcript-mining funnel (soc-ej18n #forge-hexagon)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -805,7 +805,7 @@
     {
       "name": "forge",
       "source_skill": "skills/forge",
-      "source_hash": "cd51cac0f83d703270581397f571c6ff3d4a685959c66223dce666aee0b7be3a",
+      "source_hash": "cea35b58bc86259e28792b8a8f5d0392f6d453b81c753a2e7971aafbf984ba9e",
       "generated_hash": "904e242f85fd5256c578b5c559d23845d6fc934dfafeb9215f4971c0293d5cb6"
     },
     {

--- a/skills-codex/forge/.agentops-generated.json
+++ b/skills-codex/forge/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/forge",
   "layout": "modular",
-  "source_hash": "cd51cac0f83d703270581397f571c6ff3d4a685959c66223dce666aee0b7be3a",
+  "source_hash": "cea35b58bc86259e28792b8a8f5d0392f6d453b81c753a2e7971aafbf984ba9e",
   "generated_hash": "904e242f85fd5256c578b5c559d23845d6fc934dfafeb9215f4971c0293d5cb6"
 }

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -241,5 +241,6 @@ invocation walkthrough and manual transcript-mining walkthrough.
 
 ## Reference Documents
 
+- [references/forge.feature](references/forge.feature) — Executable spec: mine transcripts → queued candidates, funnel-not-filter, --promote, consumes-transcripts-not-skills (soc-qk4b)
 - [references/uncaptured-lesson-patterns.md](references/uncaptured-lesson-patterns.md) — signal patterns and 26 known uncaptured lesson categories for transcript mining
 - [references/feedback-compiler-drafts.md](references/feedback-compiler-drafts.md) — auto-drafted learning workflow (F5.4 fail->pass ledger transitions, `cli/internal/feedbackcompiler`)

--- a/skills/forge/references/forge.feature
+++ b/skills/forge/references/forge.feature
@@ -1,0 +1,26 @@
+# Executable spec for the /forge skill — transcript→learning capture funnel (BC1 Corpus, loop Move 7 capture).
+# /forge mines raw transcripts into CANDIDATE learnings and queues them — it is the funnel,
+# not the filter: the promotion ratchet (not forge) decides which survive (one-offs die at
+# handoff; repeats promote to .agents/learnings/). It consumes transcripts (raw input), not
+# skills, so consumes:[] is correct. Hexagon: domain; produces .agents/research/*.md; shared-
+# kernel with standards. (soc-qk4b)
+
+Feature: Forge mines transcripts into candidate learnings
+  As the capture funnel of the knowledge flywheel
+  I want raw transcripts mined into queued candidate learnings
+  So that the ratchet has a stream of candidates to promote or let die
+
+  Scenario: a transcript is mined into queued candidates
+    When /forge runs over a session transcript
+    Then candidate learnings are extracted and queued for review
+    And forge does not itself decide which are durable — it is the funnel, not the filter
+
+  Scenario: promotion is the ratchet's call, applied by --promote
+    Given a reviewed candidate worth keeping
+    When /forge --promote runs
+    Then the learning is written to .agents/learnings/ and its pending source is removed
+    And one-offs that were not promoted simply die at handoff (correct)
+
+  Scenario: forge consumes transcripts, not skills
+    Then /forge's hexagon consumes no other skill (consumes:[] is correct — it mines raw transcripts)
+    And it relates to standards as a shared kernel


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank. /forge (capture funnel of move 7) lacked a .feature.

- skills/forge/references/forge.feature (NEW): mine transcripts → queued candidates, funnel-not-filter, --promote, consumes-transcripts-not-skills
- linked in SKILL.md; consumes:[] confirmed correct (acceptance-only)

How tested: lint-skills ✓ forge; scenarios --lint 0 errors; codex parity passed.
Sibling: acceptance-only crank like /domain #428.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-ej18n#forge-hexagon
Bounded-context: BC1-Corpus
Evidence: skills/forge/references/forge.feature