### PR TITLE
feat(goals): executable acceptance for the fitness/directive control surface (soc-id46k #goals-hexagon)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -811,7 +811,7 @@
     {
       "name": "goals",
       "source_skill": "skills/goals",
-      "source_hash": "8a386eff82a8f0eca27d1940277d00187e83582c2146652f67487521b848a4d6",
+      "source_hash": "3e3aa6b0a3e98cbfed40c919acba4c290205cd75c0ff51d5fd4888d6c8163754",
       "generated_hash": "dc9b388da75af17c85440fa0481c9c69b16b9641b1832269e302856dd48ded8d"
     },
     {

--- a/skills-codex/goals/.agentops-generated.json
+++ b/skills-codex/goals/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/goals",
   "layout": "modular",
-  "source_hash": "8a386eff82a8f0eca27d1940277d00187e83582c2146652f67487521b848a4d6",
+  "source_hash": "3e3aa6b0a3e98cbfed40c919acba4c290205cd75c0ff51d5fd4888d6c8163754",
   "generated_hash": "dc9b388da75af17c85440fa0481c9c69b16b9641b1832269e302856dd48ded8d"
 }

--- a/skills/goals/SKILL.md
+++ b/skills/goals/SKILL.md
@@ -443,6 +443,7 @@ ao goals render --out spec.feature     # write Gherkin to a file
 
 ## Reference Documents
 
+- [references/goals.feature](references/goals.feature) — Executable spec: measure gates → verdict, directives steering, GOALS.md source-of-truth, measurement-root (soc-qk4b)
 - [references/generation-heuristics.md](references/generation-heuristics.md)
 - [references/goals-schema.md](references/goals-schema.md)
 - [references/executable-spec-chain.md](references/executable-spec-chain.md)

--- a/skills/goals/references/goals.feature
+++ b/skills/goals/references/goals.feature
@@ -1,0 +1,25 @@
+# Executable spec for the /goals skill — the fitness + directive control surface (BC4/BC5).
+# /goals maintains and measures the GOALS.md fitness specification: `measure` runs the declared
+# gates into a PASS/FAIL verdict; `steer` manages the strategic directives /evolve measures
+# against. GOALS.md is the source of truth (output_contract). It consumes no skill — it is the
+# measurement root that /evolve consumes. Hexagon: domain; produces result.json; shared-kernel
+# with standards. (soc-qk4b)
+
+Feature: Goals maintains and measures the fitness specification
+  As the fitness + directive control surface
+  I want declared gates measured and directives steered against GOALS.md
+  So that the loop has an objective, operator-owned target to compound toward
+
+  Scenario: measure runs the declared fitness gates into a verdict
+    When /goals measure runs
+    Then each declared gate is evaluated to PASS or FAIL
+    And the result is written to result.json
+
+  Scenario: directives are the steering layer the loop measures against
+    When directives are managed via /goals steer (add/remove/prioritize)
+    Then they live in GOALS.md and surface through `ao goals measure --directives`
+    And /evolve selects work against the failing goals + directive gaps
+
+  Scenario: GOALS.md is the source of truth
+    Then /goals reads and writes GOALS.md (output_contract: GOALS.md)
+    And it consumes no other skill — it is the measurement root that /evolve consumes


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank. /goals (consumed by evolve) lacked a .feature.

- skills/goals/references/goals.feature (NEW): measure gates → verdict, directives steering /evolve measures against, GOALS.md source-of-truth, measurement-root
- linked in SKILL.md; consumes:[] confirmed correct (acceptance-only)

How tested: lint-skills ✓ goals (449 lines); scenarios --lint 0 errors; codex parity passed.
Sibling: acceptance-only crank like /domain #428, /forge #429.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-id46k#goals-hexagon
Bounded-context: BC5-Runtime
Evidence: skills/goals/references/goals.feature