### PR TITLE
feat(compile): hexagon produces + executable acceptance for the wiki compiler (soc-2d14k #compile-hexagon)

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -174,6 +174,7 @@ graph LR
 | `bug-hunt` | consumes | beads |
 | `bug-hunt` | consumes | standards |
 | `codex-team` | produces | .agents/swarm/results/*.json |
+| `compile` | produces | .agents/compiled/lint-report.md |
 | `complexity` | consumes | doc |
 | `complexity` | consumes | standards |
 | `complexity` | produces | stdout |

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -715,7 +715,7 @@
     {
       "name": "compile",
       "source_skill": "skills/compile",
-      "source_hash": "fdbd282f1027fada4a12052202e80e4e76f6d3ee4a0f4cf07106bc9a89a2a70b",
+      "source_hash": "e57a008bbd891c3b566a5f6b7f2b15e12141855efdebf07ba559644cd6570062",
       "generated_hash": "5c06a81ebd8edc6d72b39260818b54034b85f3b4337b12753461495691f0f9a8"
     },
     {

--- a/skills-codex/compile/.agentops-generated.json
+++ b/skills-codex/compile/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/compile",
   "layout": "modular",
-  "source_hash": "fdbd282f1027fada4a12052202e80e4e76f6d3ee4a0f4cf07106bc9a89a2a70b",
+  "source_hash": "e57a008bbd891c3b566a5f6b7f2b15e12141855efdebf07ba559644cd6570062",
   "generated_hash": "5c06a81ebd8edc6d72b39260818b54034b85f3b4337b12753461495691f0f9a8"
 }

--- a/skills/compile/SKILL.md
+++ b/skills/compile/SKILL.md
@@ -6,7 +6,8 @@ practices:
 - ddd-bounded-context
 hexagonal_role: supporting
 consumes: []
-produces: []
+produces:
+- .agents/compiled/lint-report.md
 context_rel: []
 skill_api_version: 1
 user-invocable: true
@@ -198,6 +199,8 @@ For unattended runs, `bash skills/compile/scripts/compile.sh` supports:
 | Hash file missing | First compilation | Normal — full compile runs, hashes saved after |
 
 ## Reference Documents
+
+- [references/compile.feature](references/compile.feature) — Executable spec: Mine→Grow→Lint→Defrag rebuild, lint-not-autofix, incremental batching, evolve warmup (soc-qk4b)
 
 - [references/phases.md](references/phases.md) — full per-phase procedure (mine → grow → compile → lint → defrag → report)
 - [references/confidence-scoring.md](references/confidence-scoring.md)

--- a/skills/compile/references/compile.feature
+++ b/skills/compile/references/compile.feature
@@ -1,0 +1,29 @@
+# Executable spec for the /compile skill — knowledge-wiki rebuild (BC1 Corpus).
+# /compile rebuilds the .agents knowledge wiki through Mine → Grow → Compile → Lint → Defrag,
+# producing the interlinked wiki + a lint report. It is the corpus warmup /evolve --compile invokes before
+# a cycle. Hexagon: supporting; consumes:[] (runs ao mine/defrag CLI ops, not skills);
+# produces .agents/compiled/lint-report.md. (soc-qk4b)
+
+Feature: Compile rebuilds the .agents knowledge wiki
+  As the corpus-compile warmup
+  I want the wiki mined, grown, linted, and defragged into a fresh compiled state
+  So that a cycle starts against a current, contradiction-checked corpus
+
+  Scenario: the Mine → Grow → Compile → Lint → Defrag pipeline runs
+    When /compile runs
+    Then it mines sources, grows learnings (validation/synthesis/gap detection),
+      compiles raw artifacts into interlinked wiki articles (the core step),
+      lints the compiled wiki, and defrags stale/duplicate artifacts
+    And it writes .agents/compiled/lint-report.md
+
+  Scenario: lint surfaces problems but does not auto-fix
+    When the lint step finds contradictions, orphans, or gaps
+    Then they are reported in the lint report
+    And /compile does not silently rewrite authored content to "fix" them
+
+  Scenario: large corpora are processed incrementally
+    Given a 2000+ file corpus
+    Then /compile batches changed files per prompt rather than loading the whole corpus at once
+
+  Scenario: compile is the warmup /evolve consumes
+    Then /evolve --compile runs this rebuild before its first cycle


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank. /compile had EMPTY produces:[] despite producing the compiled wiki + lint report.

- frontmatter: produces [.agents/compiled/lint-report.md] (consumes:[] stays correct — CLI ops, not skill calls)
- skills/compile/references/compile.feature (NEW): Mine→Grow→Compile→Lint→Defrag, lint-not-autofix, incremental batching, evolve warmup
- linked in SKILL.md; context-map regenerated

How tested: lint-skills ✓ compile (208 lines); scenarios --lint 0 errors; codex parity passed; context-map regen.
Sibling: frontmatter+feature crank like /ratchet #412.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-2d14k#compile-hexagon
Bounded-context: BC1-Corpus
Evidence: skills/compile/references/compile.feature