### PR TITLE
feat(retro): executable acceptance for the lightest learning-capture (soc-jjz0v #retro-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-22T19:29:37Z",
+  "generated_at": "2026-05-23T04:08:26Z",
   "summary": {
     "skills": 80,
     "hooks": 44,
@@ -440,7 +440,7 @@
         "tier": "knowledge",
         "path": "skills/retro/",
         "has_skill_md": true,
-        "has_references": false,
+        "has_references": true,
         "reference_count": 0
       },
       {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1009,7 +1009,7 @@
     {
       "name": "retro",
       "source_skill": "skills/retro",
-      "source_hash": "0dae74ee3f30ae371dfefb12e24fc2ad3b89e4817e1134b7155c27c6ff44e691",
+      "source_hash": "3ba73c29c2dbb094e77360ec9c2a26eb92e355563322a75e3256e3b4736a3ed8",
       "generated_hash": "5b276604e92d31c331385096dfec9c7e7a321a68dd8eab601fcfc6f4a1657ecd"
     },
     {

--- a/skills-codex/retro/.agentops-generated.json
+++ b/skills-codex/retro/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/retro",
   "layout": "modular",
-  "source_hash": "0dae74ee3f30ae371dfefb12e24fc2ad3b89e4817e1134b7155c27c6ff44e691",
+  "source_hash": "3ba73c29c2dbb094e77360ec9c2a26eb92e355563322a75e3256e3b4736a3ed8",
   "generated_hash": "5b276604e92d31c331385096dfec9c7e7a321a68dd8eab601fcfc6f4a1657ecd"
 }

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -108,3 +108,7 @@ utility: 0.5
 | Learning too generic | Surface-level capture | Be specific: "auth tokens expire after 1h" not "learned about auth" |
 | Duplicate learnings | Same insight captured twice | Check existing learnings with grep before writing |
 | Need full retrospective | Quick capture isn't enough | Use `/post-mortem` for comprehensive extraction + processing |
+
+## Reference Documents
+
+- [references/retro.feature](references/retro.feature) — Executable spec: single-observation capture to .agents/learnings/, candidate-under-ratchet, lightest move-7 surface (soc-qk4b)

--- a/skills/retro/references/retro.feature
+++ b/skills/retro/references/retro.feature
@@ -1,0 +1,24 @@
+# Executable spec for the /retro skill — lightest learning capture (BC1 Corpus, loop Move 7).
+# /retro quick-captures a SINGLE observation into .agents/learnings/ — for an insight too small
+# to warrant a full /post-mortem but too useful to leave in the handoff. The captured entry is a
+# candidate; the promotion ratchet still decides whether it becomes a pattern/rule. Hexagon:
+# domain; consumes: standards; produces: result.json. (soc-qk4b)
+
+Feature: Retro is the lightest single-observation learning capture
+  As the move-7 quick-capture surface
+  I want a single insight written to the learnings store with minimal ceremony
+  So that small-but-useful observations are not lost in the handoff
+
+  Scenario: a single observation is captured to the learnings store
+    Given an insight too small for a full /post-mortem but worth keeping
+    When /retro runs
+    Then the observation is written to .agents/learnings/ (result.json records the capture)
+
+  Scenario: a captured entry is a candidate, not yet promoted
+    When a retro entry is captured
+    Then the promotion ratchet still applies — it is a candidate learning, not yet a pattern or rule
+    And promotion to a pattern/rule happens later under the ratchet, not at capture time
+
+  Scenario: retro is lighter than post-mortem and forge
+    Then /retro captures one observation directly (no council, no transcript mining)
+    And it is the lightest of the move-7 capture surfaces


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank. /retro (move-7 single-observation capture) lacked a .feature + had no References section.

- skills/retro/references/retro.feature (NEW): single-observation capture to .agents/learnings/, candidate-under-ratchet, lightest move-7 surface
- skills/retro/SKILL.md: added Reference Documents section linking it

consumes [standards] already filled — acceptance-only.

How tested: lint-skills ✓ retro (114 lines); scenarios --lint 0 errors; codex parity passed.
Sibling: acceptance-only crank like /vibe #426.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-jjz0v#retro-hexagon
Bounded-context: BC1-Corpus
Evidence: skills/retro/references/retro.feature