### PR TITLE
feat(beads): executable acceptance for the issue-tracker adapter (soc-ut2qg #beads-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T04:08:26Z",
+  "generated_at": "2026-05-23T04:18:09Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -685,7 +685,7 @@
     {
       "name": "beads",
       "source_skill": "skills/beads",
-      "source_hash": "65f6674bebc6286d1e0b3d84d6c505feeed36148680bd4b6b307ce60ee29096d",
+      "source_hash": "8ff77353db8771be8ae62c109793a8589f4e6fd139e386bfc9f2a7f068f900f6",
       "generated_hash": "03a281fe283a103d67a668622f8d53ea786801f4bdf239a62b12025bb7c7b492"
     },
     {

--- a/skills-codex/beads/.agentops-generated.json
+++ b/skills-codex/beads/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/beads",
   "layout": "modular",
-  "source_hash": "65f6674bebc6286d1e0b3d84d6c505feeed36148680bd4b6b307ce60ee29096d",
+  "source_hash": "8ff77353db8771be8ae62c109793a8589f4e6fd139e386bfc9f2a7f068f900f6",
   "generated_hash": "03a281fe283a103d67a668622f8d53ea786801f4bdf239a62b12025bb7c7b492"
 }

--- a/skills/beads/SKILL.md
+++ b/skills/beads/SKILL.md
@@ -187,6 +187,8 @@ logging expectations, a named done state, and no dependency cycles.
 
 ## Reference Documents
 
+- [references/beads.feature](references/beads.feature) — Executable spec: bd-mandatory tracker, create-before-code, ready-detection, discovered-from links, live-reads-authoritative (soc-qk4b)
+
 - [references/ANTI_PATTERNS.md](references/ANTI_PATTERNS.md)
 - [references/BOUNDARIES.md](references/BOUNDARIES.md)
 - [references/composition-over-invention.md](references/composition-over-invention.md) — Run `bd <subcmd> --help` before specifying enforcement commands; compose primitives, don't invent

--- a/skills/beads/references/beads.feature
+++ b/skills/beads/references/beads.feature
@@ -1,0 +1,27 @@
+# Executable spec for the /beads skill — the mandatory issue tracker (BC, driven-adapter).
+# /beads is the bd-backed, dependency-aware tracker every process skill records work in — NOT
+# TaskCreate or markdown TODOs. Issues are created before code, ready-work is detected by
+# dependency, discovered work links back, and live bd reads are authoritative. Hexagon:
+# driven-adapter; consumes/produces bd-issue; supplier-to crank. (soc-qk4b)
+
+Feature: Beads is the mandatory dependency-aware issue tracker
+  As the work-tracking adapter
+  I want all issue tracking to go through bd, dependency-aware and Dolt-backed
+  So that work is created-before-code, unblocked work is detectable, and discovery is linked
+
+  Scenario: bd is the tracker, not TaskCreate or markdown
+    When work needs tracking
+    Then it is recorded as a bd issue (created before the code), not a TaskList or markdown TODO
+
+  Scenario: ready work is detected by dependency
+    When an agent asks what to work on
+    Then `bd ready` surfaces only unblocked issues
+    And the agent claims one atomically before starting
+
+  Scenario: discovered work links back to its origin
+    When new work is found mid-task
+    Then it is filed with a discovered-from dependency to the parent issue
+
+  Scenario: live bd reads are authoritative
+    Then `bd show`/`bd ready`/`bd list` are the decision source
+    And `.beads/issues.jsonl` is not treated as primary when live bd data is available


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — **completes the loop's hexagon consume-graph (8/8)**. /beads (driven-adapter, supplier-to crank) lacked a .feature.

- skills/beads/references/beads.feature (NEW): bd-mandatory tracker, create-before-code, ready-detection + atomic claim, discovered-from links, live-reads-authoritative
- linked in SKILL.md; registry.json regenerated proactively (it counts .feature refs)

consumes [bd-issue] already filled — acceptance-only.

How tested: lint-skills ✓ beads (210 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /retro #432. Fitness: loop-consumed 7/8 → 8/8.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-ut2qg#beads-hexagon
Bounded-context: BC3-Loop
Evidence: skills/beads/references/beads.feature