### PR TITLE
feat(lib): bats-common.bash shared fixture helpers (soc-jhq6 #bats-common-helpers)

### DIFF
--- a/lib/bats-common.bash
+++ b/lib/bats-common.bash
@@ -1,0 +1,46 @@
+# shellcheck shell=bash
+# lib/bats-common.bash — shared fixture helpers for tests/**/*.bats (soc-jhq6).
+#
+# Every script-test bats file re-derived the same fixture boilerplate (mktemp,
+# git init + identity, bin-stubbing), which drifted between files (e.g. one
+# forgetting a `git config` and failing only on a commit). These helpers
+# centralize it. Source it from a bats setup():
+#
+#   source "$(git rev-parse --show-toplevel)/lib/bats-common.bash"
+#   REPO_ROOT="$(bats_repo_root)"
+#   TMP="$(mktemp -d)"
+#   bats_init_repo "$TMP"
+#
+# Functions only — no top-level shell options, so sourcing never alters the
+# caller's `set -e`/`set -u` state.
+
+# bats_repo_root — absolute path to the repository root.
+bats_repo_root() {
+  git rev-parse --show-toplevel
+}
+
+# bats_init_repo <dir> — turn <dir> into a fresh committable git repo and cd into
+# it, with a deterministic identity so commits/rebases never prompt for one.
+bats_init_repo() {
+  local dir="${1:?bats_init_repo: <dir> required}"
+  cd "$dir" || return 1
+  git init -q
+  git config user.email "bats@test.local"
+  git config user.name "bats-fixture"
+}
+
+# bats_stub_bin <bindir> <name> <body> — create an executable stub command
+# <name> in <bindir> with <body> as its script body (after the shebang). The
+# caller is responsible for prepending <bindir> to PATH. Returns non-zero if
+# <bindir> or <name> is missing.
+bats_stub_bin() {
+  local bindir="${1:?bats_stub_bin: <bindir> required}"
+  local name="${2:?bats_stub_bin: <name> required}"
+  local body="${3:-}"
+  mkdir -p "$bindir"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf '%s\n' "$body"
+  } >"$bindir/$name"
+  chmod +x "$bindir/$name"
+}

--- a/tests/scripts/bats-common.bats
+++ b/tests/scripts/bats-common.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# Self-test for lib/bats-common.bash (soc-jhq6) — the shared bats fixture helpers.
+
+setup() {
+  source "$(git rev-parse --show-toplevel)/lib/bats-common.bash"
+  TMP="$(mktemp -d)"
+}
+
+teardown() { rm -rf "$TMP"; }
+
+@test "bats_repo_root returns the git toplevel directory" {
+  run bats_repo_root
+  [ "$status" -eq 0 ]
+  [ -d "$output" ]
+  # .git is a dir in a normal checkout, a file in a worktree — -e matches both.
+  [ -e "$output/.git" ]
+}
+
+@test "bats_init_repo makes a committable repo with an identity" {
+  bats_init_repo "$TMP"
+  [ "$PWD" = "$TMP" ]
+  [ -d "$TMP/.git" ]
+  [ "$(git config user.email)" = "bats@test.local" ]
+  echo x > f && git add f
+  run git commit -qm "commit works without prompting"
+  [ "$status" -eq 0 ]
+}
+
+@test "bats_init_repo fails clearly on a missing dir arg" {
+  run bats_init_repo
+  [ "$status" -ne 0 ]
+}
+
+@test "bats_stub_bin creates an executable stub that runs" {
+  bats_stub_bin "$TMP/bin" faketool 'echo stubbed-output; exit 0'
+  [ -x "$TMP/bin/faketool" ]
+  run "$TMP/bin/faketool"
+  [ "$status" -eq 0 ]
+  [ "$output" = "stubbed-output" ]
+}
+
+@test "bats_stub_bin honors a non-zero exit body" {
+  bats_stub_bin "$TMP/bin" failtool 'exit 3'
+  run "$TMP/bin/failtool"
+  [ "$status" -eq 3 ]
+}

--- a/tests/scripts/verified-rebase.bats
+++ b/tests/scripts/verified-rebase.bats
@@ -3,13 +3,11 @@
 # checks that catch the `git rebase --continue` silent-failure pathology.
 
 setup() {
-  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  source "$(git rev-parse --show-toplevel)/lib/bats-common.bash"
+  REPO_ROOT="$(bats_repo_root)"
   SCRIPT="$REPO_ROOT/scripts/verified-rebase.sh"
   TMP="$(mktemp -d)"
-  cd "$TMP"
-  git init -q
-  git config user.email t@t.co
-  git config user.name tester
+  bats_init_repo "$TMP"   # cd + git init + deterministic identity
 }
 
 teardown() { rm -rf "$TMP"; }


### PR DESCRIPTION
P2 agentops-core fix. 15 script-test bats files re-derive the same fixture boilerplate (mktemp, git init + identity, bin-stubbing) → setup-drift bugs. Centralized.

- lib/bats-common.bash (NEW): bats_repo_root, bats_init_repo, bats_stub_bin — functions only, no top-level shell opts
- tests/scripts/bats-common.bats (NEW): 5 self-tests
- verified-rebase.bats: refactored to use the lib (proof-of-adoption)

Bounded: lib + self-test + 1 adoption. Broader adoption (~14 files) is incremental follow-up.

How tested: shellcheck clean; bats 5/5 + 4/4 under CI-like env (EDITOR unset). Caught + fixed the worktree-.git-is-a-file gotcha locally.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-jhq6#bats-common-helpers
Bounded-context: BC5-Runtime
Evidence: lib/bats-common.bash