### PR TITLE
feat(research): executable acceptance for Move-1 investigation (soc-5by28 #research-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T04:18:09Z",
+  "generated_at": "2026-05-23T05:10:43Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1003,7 +1003,7 @@
     {
       "name": "research",
       "source_skill": "skills/research",
-      "source_hash": "350c7a909f9a4ccf3553b73e4d49f81a97e084531b3a7b44df1fb8c366102d12",
+      "source_hash": "f9bb3b3bf8455c2340093b4aab1bb9a4ca93b63a2a2f92a18baa50d256c5e3a6",
       "generated_hash": "0cefcd8d49ff88736cf177b61a5b43b6d866389fbd2cf4afd3bd36335647160e"
     },
     {

--- a/skills-codex/research/.agentops-generated.json
+++ b/skills-codex/research/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/research",
   "layout": "modular",
-  "source_hash": "350c7a909f9a4ccf3553b73e4d49f81a97e084531b3a7b44df1fb8c366102d12",
+  "source_hash": "f9bb3b3bf8455c2340093b4aab1bb9a4ca93b63a2a2f92a18baa50d256c5e3a6",
   "generated_hash": "0cefcd8d49ff88736cf177b61a5b43b6d866389fbd2cf4afd3bd36335647160e"
 }

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -381,6 +381,8 @@ For onboarding-style research ("what does this do?", new repo orientation), foll
 
 ## Reference Documents
 
+- [references/research.feature](references/research.feature) — Executable spec: prior-art-first, explore-agent + iterative retrieval, cited .agents/research/ artifact, Gate-1 unless --auto (soc-qk4b)
+
 - [references/iterative-retrieval.md](references/iterative-retrieval.md)
 - [references/deep-research-mcp.md](references/deep-research-mcp.md)
 - [references/backend-background-tasks.md](references/backend-background-tasks.md)

--- a/skills/research/references/research.feature
+++ b/skills/research/references/research.feature
@@ -1,0 +1,32 @@
+# Executable spec for the /research skill — Move 1 of the operating loop (driving-adapter).
+# /research investigates a topic prior-art-first, dispatches an explore agent that uses
+# iterative retrieval, and writes a cited artifact to .agents/research/ — every claim
+# carries a file:line reference. Interactive runs gate on human approval; --auto skips it.
+# Hexagon: driving-adapter; consumes inject + repo-context; produces .agents/research/*.md
+# + result.json. (soc-qk4b)
+
+Feature: Research produces a cited investigation artifact, prior-art first
+  As Move 1 of the operating loop
+  I want a topic investigated against existing knowledge before fresh exploration
+  So that findings are grounded, cited, and not redundant with what is already known
+
+  Scenario: prior art is searched before fresh exploration
+    When /research runs on a topic
+    Then it first searches existing knowledge (ao inject/lookup + the .agents/ knowledge dirs)
+    And applicable prior learnings are cited in the output, not just loaded passively
+
+  Scenario: an explore agent investigates with iterative retrieval
+    When the investigation runs
+    Then an explore agent is dispatched (not merely described)
+    And it uses iterative retrieval — score results, extract new terms from high-relevance
+      hits, refine over up to 3 cycles
+
+  Scenario: findings are written as a cited artifact
+    When the investigation completes
+    Then findings are written to .agents/research/YYYY-MM-DD-<slug>.md
+    And every claim carries a file:line citation
+
+  Scenario: interactive runs gate on approval, --auto does not
+    When /research runs without --auto
+    Then it requests human approval (Gate 1) before reporting completion
+    And with --auto it proceeds without the approval gate


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — first high-traffic peripheral skill after the loop graph + P2 fixes. /research (Move 1, driving-adapter) lacked a .feature.

- skills/research/references/research.feature (NEW): prior-art-first + cite; explore agent dispatched w/ iterative retrieval; cited .agents/research/ artifact (file:line); Gate-1 unless --auto
- linked in SKILL.md; registry regenerated

consumes [inject, repo-context] already filled — acceptance-only.

How tested: lint-skills ✓ research (408 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /retro #432.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-5by28#research-hexagon
Bounded-context: BC2-Knowledge
Evidence: skills/research/references/research.feature