### PR TITLE
feat(review): executable acceptance for diff/codebase review (soc-ucoss #review-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T05:10:43Z",
+  "generated_at": "2026-05-23T05:25:07Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1021,7 +1021,7 @@
     {
       "name": "review",
       "source_skill": "skills/review",
-      "source_hash": "a6d58f40831dcf434604e01db206b3c3140886170ad7cf42e2469ff13120c684",
+      "source_hash": "289fab923400c4e7913f223254dd37af23042590a547dda7bb069095d044c89b",
       "generated_hash": "ca1c883233c86af14a0b4399946e06b2c64847d7c344ed4cc8e35e48de349df3"
     },
     {

--- a/skills-codex/review/.agentops-generated.json
+++ b/skills-codex/review/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/review",
   "layout": "modular",
-  "source_hash": "a6d58f40831dcf434604e01db206b3c3140886170ad7cf42e2469ff13120c684",
+  "source_hash": "289fab923400c4e7913f223254dd37af23042590a547dda7bb069095d044c89b",
   "generated_hash": "ca1c883233c86af14a0b4399946e06b2c64847d7c344ed4cc8e35e48de349df3"
 }

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -340,6 +340,8 @@ Merge council findings into the review document under a "## Council Findings" se
 
 ## Reference Documents
 
+- [references/review.feature](references/review.feature) — Executable spec: risk-ranked diff review, mock/stub detection, bug scan, result.json (soc-qk4b)
+
 - [references/MOCK_FINDER.md](references/MOCK_FINDER.md) — Find stubs, mocks, placeholders, TODOs
 - [references/BUG_SCANNER.md](references/BUG_SCANNER.md) — Bug scanner: null derefs, leaks, security
 - [references/DOMAIN_AUDIT.md](references/DOMAIN_AUDIT.md) — Domain-parameterized audit (security, perf, UX, API, CLI)

--- a/skills/review/references/review.feature
+++ b/skills/review/references/review.feature
@@ -1,0 +1,26 @@
+# Executable spec for the /review skill — diff/codebase review (driving-adapter).
+# /review reads a diff or codebase and surfaces what a careful reviewer would: risk-ranked
+# findings, mock/stub implementations masquerading as real code, and latent bugs. It judges
+# the code, not the agent's process. Hexagon: driving-adapter; consumes github-pr +
+# validation; produces result.json; customer-of validation. (soc-qk4b)
+
+Feature: Review surfaces risk, mocks, and bugs in a diff or codebase
+  As the diff/codebase reviewer
+  I want risk-ranked findings, mock detection, and a bug scan over the change
+  So that risky or fake code is caught before it merges
+
+  Scenario: a diff is reviewed for risk
+    When /review runs on a diff or PR
+    Then it reports findings ranked by risk, not an undifferentiated list
+
+  Scenario: mock and stub implementations are flagged
+    When the reviewed code contains a mock, stub, or hardcoded fake standing in for real logic
+    Then /review flags it as a mock-not-implementation finding
+
+  Scenario: the change is scanned for bugs
+    When /review inspects the changed code
+    Then it scans for latent bugs (wrong references, swallowed errors, missing edge cases)
+
+  Scenario: findings are emitted as a structured result
+    When the review completes
+    Then the findings are written to result.json for downstream consumers


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — high-traffic peripheral skill. /review (driving-adapter, customer-of validation) lacked a .feature.

- skills/review/references/review.feature (NEW): risk-ranked diff review; mock/stub-not-implementation detection; bug scan; result.json
- linked in SKILL.md; registry regenerated

consumes [github-pr, validation] already filled — acceptance-only.

How tested: lint-skills ✓ review (357 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /research #436.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-ucoss#review-hexagon
Bounded-context: BC4-Validation
Evidence: skills/review/references/review.feature