### PR TITLE
feat(bug-hunt): executable acceptance for root-cause investigation (soc-09ryv #bug-hunt-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T05:25:07Z",
+  "generated_at": "2026-05-23T05:40:44Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -703,7 +703,7 @@
     {
       "name": "bug-hunt",
       "source_skill": "skills/bug-hunt",
-      "source_hash": "98889eded88dc03aad4ad37e41d7adbfbafe9de2f70a9b55f5cd16f18eb3d31c",
+      "source_hash": "13b4521092a906611f5b016f0512bf9ed61ee5a6bac58d7a194cdfe371d35d54",
       "generated_hash": "3031f2f0b7472856f03b27e9cc298606d6c509a1f7f234bd2918f1d8c18182bb"
     },
     {

--- a/skills-codex/bug-hunt/.agentops-generated.json
+++ b/skills-codex/bug-hunt/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/bug-hunt",
   "layout": "modular",
-  "source_hash": "98889eded88dc03aad4ad37e41d7adbfbafe9de2f70a9b55f5cd16f18eb3d31c",
+  "source_hash": "13b4521092a906611f5b016f0512bf9ed61ee5a6bac58d7a194cdfe371d35d54",
   "generated_hash": "3031f2f0b7472856f03b27e9cc298606d6c509a1f7f234bd2918f1d8c18182bb"
 }

--- a/skills/bug-hunt/SKILL.md
+++ b/skills/bug-hunt/SKILL.md
@@ -409,6 +409,8 @@ Common bug patterns to check:
 
 ## Reference Documents
 
+- [references/bug-hunt.feature](references/bug-hunt.feature) — Executable spec: 4-phase root-cause investigation, fix-the-cause-not-symptom, --audit sweep, cited artifact (soc-qk4b)
+
 - [references/audit-report-template.md](references/audit-report-template.md)
 - [references/bug-report-template.md](references/bug-report-template.md)
 - [references/failure-categories.md](references/failure-categories.md)

--- a/skills/bug-hunt/references/bug-hunt.feature
+++ b/skills/bug-hunt/references/bug-hunt.feature
@@ -1,0 +1,28 @@
+# Executable spec for the /bug-hunt skill — root-cause investigation (domain role).
+# /bug-hunt finds the ACTUAL cause of a bug (not the symptom) through a 4-phase
+# investigation, or proactively audits a scope for hidden bugs. It writes a cited
+# investigation artifact. Hexagon: domain; consumes beads + standards; produces
+# .agents/research/YYYY-MM-DD-bug-*.md. (soc-qk4b)
+
+Feature: Bug-hunt finds root cause and designs a complete fix
+  As the bug investigator
+  I want the real root cause located and a complete fix designed
+  So that the bug is fixed at its source, not patched at the symptom
+
+  Scenario: investigation mode runs the 4-phase structure
+    When /bug-hunt runs on a known symptom
+    Then it works through Root Cause → Pattern → Hypothesis → Fix
+    And the root cause is located at a specific file:line (and originating commit when known)
+
+  Scenario: the fix addresses the cause, not the symptom
+    When the investigation produces a fix
+    Then the fix targets the root cause
+    And it is not a symptom-level patch that leaves the cause in place
+
+  Scenario: audit mode sweeps a scope for hidden bugs
+    When /bug-hunt --audit runs on a scope
+    Then it proactively sweeps for latent bugs before they surface
+
+  Scenario: the investigation is written as a cited artifact
+    When the investigation completes
+    Then findings are written to .agents/research/YYYY-MM-DD-bug-*.md with file:line evidence


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — high-traffic peripheral skill. /bug-hunt (domain, consumes beads + standards) lacked a .feature.

- skills/bug-hunt/references/bug-hunt.feature (NEW): 4-phase (Root Cause→Pattern→Hypothesis→Fix) at file:line; fix-the-cause-not-symptom; --audit sweep; cited artifact
- linked in SKILL.md; registry regenerated

consumes [beads, standards] already filled — acceptance-only.

How tested: lint-skills ✓ bug-hunt (426 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /review #437.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-09ryv#bug-hunt-hexagon
Bounded-context: BC4-Validation
Evidence: skills/bug-hunt/references/bug-hunt.feature