### PR TITLE
fix(bats): disable background gc in fixtures to kill the flaky teardown (soc-72gkw #bats-flaky-teardown)

### DIFF
--- a/lib/bats-common.bash
+++ b/lib/bats-common.bash
@@ -21,12 +21,18 @@ bats_repo_root() {
 
 # bats_init_repo <dir> — turn <dir> into a fresh committable git repo and cd into
 # it, with a deterministic identity so commits/rebases never prompt for one.
+# Background maintenance (auto-gc, fsmonitor) is disabled so a git daemon can't
+# hold a file in <dir>/.git when the test's teardown runs `rm -rf "<dir>"` — that
+# race made the rebase fixture flaky in CI (soc-72gkw).
 bats_init_repo() {
   local dir="${1:?bats_init_repo: <dir> required}"
   cd "$dir" || return 1
   git init -q
   git config user.email "bats@test.local"
   git config user.name "bats-fixture"
+  git config gc.auto 0
+  git config maintenance.auto false
+  git config core.fsmonitor false
 }
 
 # bats_stub_bin <bindir> <name> <body> — create an executable stub command

--- a/tests/scripts/verified-rebase.bats
+++ b/tests/scripts/verified-rebase.bats
@@ -10,7 +10,9 @@ setup() {
   bats_init_repo "$TMP"   # cd + git init + deterministic identity
 }
 
-teardown() { rm -rf "$TMP"; }
+# cd out of $TMP before removing it, and treat cleanup as best-effort, so a
+# transient hold on a file in $TMP never fails the test (soc-72gkw).
+teardown() { cd / 2>/dev/null || true; rm -rf "$TMP" 2>/dev/null || true; }
 
 @test "verified-rebase: missing arg exits 2 with usage" {
   run bash "$SCRIPT"


### PR DESCRIPTION
P2 agentops-core bug. verified-rebase.bats test 919 intermittently failed in teardown `rm -rf $TMP` — a git background process (auto-gc/fsmonitor) held a file in $TMP/.git when rm fired (failed on #438 run 1, passed on re-run). Would keep biting future PRs.

Root fix (shared helper, covers all fixtures):
- lib/bats-common.bash bats_init_repo: gc.auto 0 + maintenance.auto false + core.fsmonitor false
Defense-in-depth:
- verified-rebase.bats teardown: cd / before rm, best-effort rm

How tested: shellcheck clean; bats-common 5/5; verified-rebase 4/4 × 3 consecutive runs (was flaky).

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-72gkw#bats-flaky-teardown
Bounded-context: BC5-Runtime
Evidence: lib/bats-common.bash