### PR TITLE
feat(pre-mortem): executable acceptance for the pre-implementation plan gate (soc-6hqny #pre-mortem-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T05:40:44Z",
+  "generated_at": "2026-05-23T06:10:29Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -937,7 +937,7 @@
     {
       "name": "pre-mortem",
       "source_skill": "skills/pre-mortem",
-      "source_hash": "0d10d177d7fdba600bff8cc157885504c74172507fad1be7e0cdb957e658e056",
+      "source_hash": "4c710c16546e6f5313c56a45f3a24ce209f6a8847cd7d00260323132ca2bc6b6",
       "generated_hash": "76c803dbb09ebd1f9833a1ca852d366c48f6a2956141b8b9245bfd816e93155c"
     },
     {

--- a/skills-codex/pre-mortem/.agentops-generated.json
+++ b/skills-codex/pre-mortem/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/pre-mortem",
   "layout": "modular",
-  "source_hash": "0d10d177d7fdba600bff8cc157885504c74172507fad1be7e0cdb957e658e056",
+  "source_hash": "4c710c16546e6f5313c56a45f3a24ce209f6a8847cd7d00260323132ca2bc6b6",
   "generated_hash": "76c803dbb09ebd1f9833a1ca852d366c48f6a2956141b8b9245bfd816e93155c"
 }

--- a/skills/pre-mortem/SKILL.md
+++ b/skills/pre-mortem/SKILL.md
@@ -224,6 +224,8 @@ See [references/examples.md](references/examples.md) for the troubleshooting tab
 
 ## Reference Documents
 
+- [references/pre-mortem.feature](references/pre-mortem.feature) — Executable spec: plan PASS/WARN/FAIL verdict before work, wave-validity gates parallelism, --quick inline default (soc-qk4b)
+
 - [references/compiled-prevention.md](references/compiled-prevention.md)
 - [references/scope-mode.md](references/scope-mode.md)
 - [references/mandatory-checks.md](references/mandatory-checks.md)

--- a/skills/pre-mortem/references/pre-mortem.feature
+++ b/skills/pre-mortem/references/pre-mortem.feature
@@ -1,0 +1,26 @@
+# Executable spec for the /pre-mortem skill — pre-implementation plan gate (domain role).
+# /pre-mortem stress-tests a plan BEFORE work starts: it returns a PASS/WARN/FAIL verdict on
+# the plan and on the wave-validity rows, so a bad plan is sent back to /plan rather than
+# executed. It runs inline (--quick) by default; --deep/--mixed widen the council. Hexagon:
+# domain; consumes standards; produces result.json + verdict.json. (soc-qk4b)
+
+Feature: Pre-mortem stress-tests a plan before implementation
+  As the pre-flight gate between slice-planning and TDD
+  I want a plan reviewed for failure modes before any code is written
+  So that a flawed plan is caught and re-sliced instead of executed
+
+  Scenario: a plan is reviewed and gets a verdict before work starts
+    When /pre-mortem runs on a plan or spec
+    Then it returns a PASS/WARN/FAIL verdict on the plan's failure modes
+    And the verdict is written to verdict.json (council schema)
+
+  Scenario: wave-validity gates parallelism
+    When the plan proposes a parallel wave
+    Then pre-mortem checks the wave-validity rows (distinct write scopes, owner per slice, discard path)
+    And a wave may run parallel only if every row is conflict-free
+    And a FAIL sends the plan back to /plan to re-slice (or run sequential)
+
+  Scenario: quick mode is the inline default
+    When /pre-mortem runs without --deep/--mixed/--debate
+    Then it runs inline (--quick) as a single-agent structured review, no council spawning
+    And --deep/--mixed/--debate widen the council fan-out


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — high-traffic peripheral skill. /pre-mortem (domain, consumes standards) lacked a .feature.

- skills/pre-mortem/references/pre-mortem.feature (NEW): plan PASS/WARN/FAIL verdict before work; wave-validity gates parallelism (FAIL → back to /plan); --quick inline default
- linked in SKILL.md; registry regenerated

consumes [standards] already filled — acceptance-only.

How tested: lint-skills ✓ pre-mortem (243 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /bug-hunt #438.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-6hqny#pre-mortem-hexagon
Bounded-context: BC4-Validation
Evidence: skills/pre-mortem/references/pre-mortem.feature