### PR TITLE
feat(validate): executable acceptance for the unified validator (soc-sg44k #validate-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T06:10:29Z",
+  "generated_at": "2026-05-23T06:25:03Z",
   "summary": {
     "skills": 80,
     "hooks": 44,
@@ -376,7 +376,7 @@
         "tier": "judgment",
         "path": "skills/validate/",
         "has_skill_md": true,
-        "has_references": false,
+        "has_references": true,
         "reference_count": 0
       },
       {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1141,7 +1141,7 @@
     {
       "name": "validate",
       "source_skill": "skills/validate",
-      "source_hash": "58e0d601fa098d63359b7eca1d48efa117bf20e4e32427d303b921940da6b8fe",
+      "source_hash": "34ecede8c8a4a8cbffe3cfb9df366fba798df3f3ebe864adc050f94f2a630062",
       "generated_hash": "eab1216146dff716bd142a5caf66ec72b66286855b21e5b95f6046e360f3af42"
     },
     {

--- a/skills-codex/validate/.agentops-generated.json
+++ b/skills-codex/validate/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/validate",
   "layout": "modular",
-  "source_hash": "58e0d601fa098d63359b7eca1d48efa117bf20e4e32427d303b921940da6b8fe",
+  "source_hash": "34ecede8c8a4a8cbffe3cfb9df366fba798df3f3ebe864adc050f94f2a630062",
   "generated_hash": "eab1216146dff716bd142a5caf66ec72b66286855b21e5b95f6046e360f3af42"
 }

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -232,3 +232,7 @@ Each target has its own inline check rubric until Phase 2 extraction.
 - `skills/rpi/SKILL.md` — orchestrator that fires `/validate --mode=pre-impl` after `/plan`
 - `skills/curate/SKILL.md` — miner role (paired canonical skill)
 - `schemas/verdict.v1.schema.json` — output contract
+
+## Reference Documents
+
+- [references/validate.feature](references/validate.feature) — Executable spec: verdict.v1 PASS/WARN/FAIL for any artifact, --mode selects shape, 8-mode budget (soc-qk4b)

--- a/skills/validate/references/validate.feature
+++ b/skills/validate/references/validate.feature
@@ -1,0 +1,24 @@
+# Executable spec for the /validate skill — the unified validator (driving-adapter).
+# /validate takes any artifact (plan, spec, code, PR, fitness gate) and emits a verdict.v1:
+# PASS, WARN, or FAIL with rationale and findings. The artifact shape is selected by --mode,
+# and the mode set is budget-capped. Hexagon: driving-adapter; consumes validation; produces
+# result.json; customer-of validation. (soc-qk4b)
+
+Feature: Validate produces a PASS/WARN/FAIL verdict for any artifact
+  As the unified validator
+  I want any artifact judged to a verdict.v1 with rationale and findings
+  So that plans, code, PRs, and gates all share one verdict contract
+
+  Scenario: an artifact is validated to a verdict
+    When /validate runs on an artifact (plan, spec, code, PR, or fitness gate)
+    Then it emits a PASS, WARN, or FAIL verdict with rationale and findings
+    And the verdict conforms to the verdict.v1 schema
+
+  Scenario: the mode selects the validation shape
+    When /validate runs with --mode
+    Then --mode=pr produces a PR-shape verdict (diff review + acceptance check)
+    And --mode=pre-impl --target=fitness validates the fitness gate against GOALS.md
+
+  Scenario: the mode set is budget-capped
+    Then /validate exposes at most 8 modes
+    And adding a 9th requires demoting an existing mode or refusing the addition


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — high-traffic peripheral skill. /validate (driving-adapter, consumes validation) lacked a .feature + had no References section.

- skills/validate/references/validate.feature (NEW): any artifact → verdict.v1 PASS/WARN/FAIL; --mode selects shape; 8-mode budget
- added Reference Documents section linking it; registry regenerated

consumes [validation] already filled — acceptance-only.

How tested: lint-skills ✓ validate (238 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /pre-mortem #440.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-sg44k#validate-hexagon
Bounded-context: BC4-Validation
Evidence: skills/validate/references/validate.feature