### PR TITLE
feat(security): executable acceptance for repository security scans (soc-0spv6 #security-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T06:25:03Z",
+  "generated_at": "2026-05-23T06:40:08Z",
   "summary": {
     "skills": 80,
     "hooks": 44,
@@ -584,7 +584,7 @@
         "tier": "product",
         "path": "skills/security/",
         "has_skill_md": true,
-        "has_references": false,
+        "has_references": true,
         "reference_count": 0
       },
       {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1051,7 +1051,7 @@
     {
       "name": "security",
       "source_skill": "skills/security",
-      "source_hash": "7764db59fccc213376f82a12fb988c63b17bf508b6a23eedaf43324f6c552c16",
+      "source_hash": "e4917726d54c03940094630cbc68190015695c09f68f53f0e022d481f40a2c7f",
       "generated_hash": "d7d5f43538bd938c054d255f95eeb02558a43c96ab38d87c6961382a21dadbac"
     },
     {

--- a/skills-codex/security/.agentops-generated.json
+++ b/skills-codex/security/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/security",
   "layout": "modular",
-  "source_hash": "7764db59fccc213376f82a12fb988c63b17bf508b6a23eedaf43324f6c552c16",
+  "source_hash": "e4917726d54c03940094630cbc68190015695c09f68f53f0e022d481f40a2c7f",
   "generated_hash": "d7d5f43538bd938c054d255f95eeb02558a43c96ab38d87c6961382a21dadbac"
 }

--- a/skills/security/SKILL.md
+++ b/skills/security/SKILL.md
@@ -143,3 +143,7 @@ Actions:
 | False positive blocking the gate | Scanner flags a non-issue as high/critical severity | Add a scanner-specific inline suppression comment (e.g., `# nosemgrep: rule-id`) or update the scanner config to exclude the pattern, then document the suppression reason. |
 | Artifacts directory `$TMPDIR/agentops-security/` not created | Script lacks write permissions or `$TMPDIR` is not writable | Verify `$TMPDIR` is set and writable; the script auto-creates subdirectories on each run. |
 | Nightly scan not detecting regressions | Nightly workflow is not configured or is pointing at stale branch | Verify `.github/workflows/nightly.yml` runs `scripts/security-gate.sh --mode full` against the correct branch (typically `main`). |
+
+## Reference Documents
+
+- [references/security.feature](references/security.feature) — Executable spec: run scanners, fail on high/critical, gate release, retain audit artifacts (soc-qk4b)

--- a/skills/security/references/security.feature
+++ b/skills/security/references/security.feature
@@ -1,0 +1,25 @@
+# Executable spec for the /security skill — repository security scans (driven-adapter).
+# /security runs the available scanners over the repo, gates on high/critical findings, and
+# retains artifacts for audit. Its report feeds vibe's verdict. Hexagon: driven-adapter;
+# consumes repo-context; produces security-report.json; supplier-to vibe. (soc-qk4b)
+
+Feature: Security scans the repository and gates on severity
+  As the repository security scanner
+  I want the available scanners run and high/critical findings to fail the scan
+  So that severe vulnerabilities block the release path
+
+  Scenario: scanners run over the repository
+    When /security runs
+    Then it runs the available scanners over the repo and writes security-report.json
+
+  Scenario: high or critical findings fail the scan
+    When a scanner reports a high or critical finding
+    Then /security fails (it does not pass with severe findings outstanding)
+
+  Scenario: a clean full pass gates the release path
+    When the full scanner pass reports no high/critical findings
+    Then the release workflow may continue
+
+  Scenario: artifacts are retained for audit
+    When a scan completes
+    Then its artifacts are retained for audit and incident response


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — high-value peripheral skill. /security (driven-adapter, supplier-to vibe) lacked a .feature + had no References section.

- skills/security/references/security.feature (NEW): run scanners → security-report.json; high/critical FAIL; clean pass gates release; artifacts retained for audit
- added Reference Documents section; registry regenerated

consumes [repo-context] already filled — acceptance-only.

How tested: lint-skills ✓ security (149 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /validate #441.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-0spv6#security-hexagon
Bounded-context: BC4-Validation
Evidence: skills/security/references/security.feature