### PR TITLE
feat(design): executable acceptance for the product-validation gate (soc-7h0jm #design-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T06:40:08Z",
+  "generated_at": "2026-05-23T06:55:08Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -757,7 +757,7 @@
     {
       "name": "design",
       "source_skill": "skills/design",
-      "source_hash": "040840b36b20e89bc7e1a7d04a826ac9a6fe2c70c678b4341af20922ed140816",
+      "source_hash": "c2f0fab9fa91b72d31ad12a913f3f627184417720944975441e948da536509d7",
       "generated_hash": "9b5ee704843edae6524c28b0a29aec08c0286d754194cd78f8473684219e8227"
     },
     {

--- a/skills-codex/design/.agentops-generated.json
+++ b/skills-codex/design/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/design",
   "layout": "modular",
-  "source_hash": "040840b36b20e89bc7e1a7d04a826ac9a6fe2c70c678b4341af20922ed140816",
+  "source_hash": "c2f0fab9fa91b72d31ad12a913f3f627184417720944975441e948da536509d7",
   "generated_hash": "9b5ee704843edae6524c28b0a29aec08c0286d754194cd78f8473684219e8227"
 }

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -151,6 +151,8 @@ DESIGN VERDICT: <PASS|WARN|FAIL>
 
 ## Reference Documents
 
+- [references/design.feature](references/design.feature) — Executable spec: goal-vs-PRODUCT.md council verdict before discovery, --quick inline, --strict threshold (soc-qk4b)
+
 - [references/alignment-matrix.md](references/alignment-matrix.md) -- Scoring rubric for the five alignment dimensions
 - [references/project-reality-check.md](references/project-reality-check.md) -- Quick reality-check prompts before committing to a project direction
 - [references/product-council-preset.md](references/product-council-preset.md) -- Council `--preset=product` judge configuration and verdict rules

--- a/skills/design/references/design.feature
+++ b/skills/design/references/design.feature
@@ -1,0 +1,25 @@
+# Executable spec for the /design skill — product-validation gate (domain role).
+# /design checks that a proposed goal aligns with the product's strategic direction (PRODUCT.md)
+# BEFORE discovery commits major work, emitting a council verdict. It runs inline (--quick) or
+# council-gated (--preset=product), with --strict raising the bar. Hexagon: domain; consumes
+# standards; produces result.json (council verdict schema); shared-kernel with standards. (soc-qk4b)
+
+Feature: Design validates goal-to-product fit before discovery
+  As the pre-discovery product gate
+  I want a proposed goal judged against the product's strategic direction
+  So that off-strategy work is caught before discovery spends effort on it
+
+  Scenario: a goal is validated against PRODUCT.md
+    Given a PRODUCT.md in the repo
+    When /design runs on a proposed goal
+    Then it emits a council verdict on whether the goal aligns with the product direction
+    And this happens before discovery begins major work
+
+  Scenario: quick mode skips the council
+    When /design --quick runs
+    Then it does an inline check with no council spawning
+    And the default mode is council-gated with --preset=product
+
+  Scenario: strict mode raises the threshold
+    When /design --strict runs
+    Then it requires a higher alignment threshold (average score >= 2.5) to pass


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — peripheral skill. /design (domain, consumes standards) lacked a .feature.

- skills/design/references/design.feature (NEW): goal vs PRODUCT.md → council verdict before discovery; --quick inline; --strict threshold (avg >= 2.5)
- linked in SKILL.md; registry regenerated

consumes [standards] already filled — acceptance-only.

How tested: lint-skills ✓ design (167 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /security #442.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-7h0jm#design-hexagon
Bounded-context: BC4-Validation
Evidence: skills/design/references/design.feature