### PR TITLE
feat(complexity): executable acceptance for the refactor-hotspot finder (soc-cve7s #complexity-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T06:55:08Z",
+  "generated_at": "2026-05-23T07:10:06Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -721,7 +721,7 @@
     {
       "name": "complexity",
       "source_skill": "skills/complexity",
-      "source_hash": "3f21c3ad443b3b9d4a503a62af36ddb342fdc67a1acc5c4ce3ebb356fa0471f9",
+      "source_hash": "f5840d49ae8da97b069da5eb03f6e5b7379a212ac202c1a138306bcb8dd5e30a",
       "generated_hash": "3b82646905d8303aab277e62a66b767d80e08d8e080eb40dad28c44837564972"
     },
     {

--- a/skills-codex/complexity/.agentops-generated.json
+++ b/skills-codex/complexity/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/complexity",
   "layout": "modular",
-  "source_hash": "3f21c3ad443b3b9d4a503a62af36ddb342fdc67a1acc5c4ce3ebb356fa0471f9",
+  "source_hash": "f5840d49ae8da97b069da5eb03f6e5b7379a212ac202c1a138306bcb8dd5e30a",
   "generated_hash": "3b82646905d8303aab277e62a66b767d80e08d8e080eb40dad28c44837564972"
 }

--- a/skills/complexity/SKILL.md
+++ b/skills/complexity/SKILL.md
@@ -208,3 +208,7 @@ Tell the user:
 | No complexity issues found | Threshold too high or genuinely simple code | Lower threshold: try `gocyclo -over 5` or check if path includes actual implementation files vs tests. |
 | Report shows functions without recommendations | Generic analysis without codebase context | Read the high-CC functions to understand structure, then provide specific refactoring suggestions based on actual code patterns. |
 | Mixed language project | Multiple languages in target path | Run analysis separately per language: `/complexity src/python/` then `/complexity src/go/`, combine reports manually. |
+
+## Reference Documents
+
+- [references/complexity.feature](references/complexity.feature) — Executable spec: rank functions by cyclomatic complexity, scope to recent changes by default, focused hotspot list (soc-qk4b)

--- a/skills/complexity/references/complexity.feature
+++ b/skills/complexity/references/complexity.feature
@@ -1,0 +1,22 @@
+# Executable spec for the /complexity skill — refactor-hotspot finder (domain role).
+# /complexity analyzes code complexity and surfaces a FOCUSED set of refactor hotspots ranked
+# by cyclomatic complexity, rather than dumping every function. With no path it scopes to recent
+# changes. Hexagon: domain; consumes doc + standards; produces stdout; shared-kernel with
+# standards. (soc-qk4b)
+
+Feature: Complexity finds focused refactor hotspots
+  As the refactor-targeting analyzer
+  I want the most complex functions surfaced and ranked
+  So that refactoring effort goes where complexity is highest
+
+  Scenario: a path is analyzed for complexity hotspots
+    When /complexity runs on a path
+    Then it reports functions ranked by cyclomatic complexity (highest first)
+
+  Scenario: no path scopes to recent changes
+    When /complexity runs without a path argument
+    Then it scopes the analysis to recently changed source files
+
+  Scenario: the output is a focused hotspot list, not a full dump
+    When the analysis completes
+    Then it surfaces a focused set of refactor targets, not every function in the tree


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — peripheral skill. /complexity (domain, consumes doc + standards) lacked a .feature.

- skills/complexity/references/complexity.feature (NEW): rank by cyclomatic complexity; no-path → recent changes; focused hotspot list
- added Reference Documents section; registry regenerated

consumes [doc, standards] already filled — acceptance-only.

How tested: lint-skills ✓ complexity (214 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /design #443.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-cve7s#complexity-hexagon
Bounded-context: BC4-Validation
Evidence: skills/complexity/references/complexity.feature