### PR TITLE
feat(ship-loop): executable acceptance for the coherent-arc fast lane (soc-uevg9 #ship-loop-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T07:10:06Z",
+  "generated_at": "2026-05-23T07:25:07Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1069,7 +1069,7 @@
     {
       "name": "ship-loop",
       "source_skill": "skills/ship-loop",
-      "source_hash": "6918bfe8421d633f58121f69d8ca12e5fa3bbd262d0271d5d5f9d1feb38b642e",
+      "source_hash": "87bcea7bbbd6fd777d92192fb3c73b881340e579cdfd26209b70ea99ed9e508d",
       "generated_hash": "a6b0df3d81b3680704b99b871fae44819cc7b05e7f3353877e4957e7fbbb97a6"
     },
     {

--- a/skills-codex/ship-loop/.agentops-generated.json
+++ b/skills-codex/ship-loop/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/ship-loop",
   "layout": "modular",
-  "source_hash": "6918bfe8421d633f58121f69d8ca12e5fa3bbd262d0271d5d5f9d1feb38b642e",
+  "source_hash": "87bcea7bbbd6fd777d92192fb3c73b881340e579cdfd26209b70ea99ed9e508d",
   "generated_hash": "a6b0df3d81b3680704b99b871fae44819cc7b05e7f3353877e4957e7fbbb97a6"
 }

--- a/skills/ship-loop/SKILL.md
+++ b/skills/ship-loop/SKILL.md
@@ -170,3 +170,7 @@ See [references/examples.md](references/examples.md) for full walkthroughs.
 - [references/gh-merge-chain.md](references/gh-merge-chain.md)
 - [references/test-shape.md](references/test-shape.md)
 - Durable rationale: [docs/learnings/2026-05-18-xp-bdd-tdd-workflow-synthesis.md](https://github.com/boshu2/agentops/blob/main/docs/learnings/2026-05-18-xp-bdd-tdd-workflow-synthesis.md)
+
+## Reference Documents
+
+- [references/ship-loop.feature](references/ship-loop.feature) — Executable spec: claim→test→impl→push→squash-merge→close, one coherent arc, gated merge + bead close (soc-qk4b)

--- a/skills/ship-loop/references/ship-loop.feature
+++ b/skills/ship-loop/references/ship-loop.feature
@@ -1,0 +1,24 @@
+# Executable spec for the /ship-loop skill — coherent-arc fast lane (driving-adapter).
+# /ship-loop drives ONE coherent arc (a closable bead or small-epic slice) from claim through
+# squash-merge: claim → test → impl → pre-push → push → squash auto-merge → close. It is the
+# bot-paired fast lane, not for large epics. Hexagon: driving-adapter; consumes beads + rpi +
+# post-mortem; produces git-changes + merged-prs; customer-of rpi. (soc-qk4b)
+
+Feature: Ship-loop drives a coherent-arc PR from claim to merge
+  As the fast-lane PR cycle
+  I want one coherent arc taken claim-to-merge with the gates enforced
+  So that small internal changes ship without manual step-by-step driving
+
+  Scenario: the full cycle runs end to end
+    When /ship-loop runs on a claimed bead
+    Then it proceeds claim → test → impl → pre-push → push → squash auto-merge → close
+
+  Scenario: scope is one coherent arc, not a large epic
+    Given a unit of work
+    Then /ship-loop accepts one closable bead or small-epic slice (a single rollback unit)
+    And a large epic is routed elsewhere (sliced into multiple PRs), not run as one ship-loop
+
+  Scenario: merge is gated and the bead is closed
+    When CI is green
+    Then the PR is squash auto-merged and the bead is closed
+    And the run produces git-changes and a merged PR


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — peripheral skill. /ship-loop (driving-adapter, customer-of rpi) lacked a .feature.

- skills/ship-loop/references/ship-loop.feature (NEW): claim→test→impl→push→squash-merge→close; one coherent arc (single rollback unit), large epics routed elsewhere; gated merge + bead close
- added Reference Documents section; registry regenerated

consumes [beads, rpi, post-mortem] already filled — acceptance-only.

How tested: lint-skills ✓ ship-loop (176 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /complexity #444.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-uevg9#ship-loop-hexagon
Bounded-context: BC3-Loop
Evidence: skills/ship-loop/references/ship-loop.feature