### PR TITLE
feat(brainstorm): executable acceptance for goal clarification (soc-p8k17 #brainstorm-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T07:25:07Z",
+  "generated_at": "2026-05-23T07:40:09Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -697,7 +697,7 @@
     {
       "name": "brainstorm",
       "source_skill": "skills/brainstorm",
-      "source_hash": "39aab950adcbd0c0399c3e72cc3de563b9e202441e11541ff16f72d7c12864ea",
+      "source_hash": "009cb68fb190eb1575a4f58267e82deafa16cb93909a6c878d04c979af79f50e",
       "generated_hash": "feeffc5414cb28ad45c1e0ff182be1e96a65cbc134de889d2fcff5045658454e"
     },
     {

--- a/skills-codex/brainstorm/.agentops-generated.json
+++ b/skills-codex/brainstorm/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/brainstorm",
   "layout": "modular",
-  "source_hash": "39aab950adcbd0c0399c3e72cc3de563b9e202441e11541ff16f72d7c12864ea",
+  "source_hash": "009cb68fb190eb1575a4f58267e82deafa16cb93909a6c878d04c979af79f50e",
   "generated_hash": "feeffc5414cb28ad45c1e0ff182be1e96a65cbc134de889d2fcff5045658454e"
 }

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -192,4 +192,6 @@ Phase 4: Writes .agents/brainstorm/2026-02-17-search-performance.md
 
 ## Reference Documents
 
+- [references/brainstorm.feature](references/brainstorm.feature) — Executable spec: WHAT-not-HOW 4-phase clarification, options+tradeoffs, capture Gherkin (happy + edge) for /plan (soc-qk4b)
+
 - [references/red-team-checklist.md](references/red-team-checklist.md) — Adversarial critique template for Phase 3b

--- a/skills/brainstorm/references/brainstorm.feature
+++ b/skills/brainstorm/references/brainstorm.feature
@@ -1,0 +1,24 @@
+# Executable spec for the /brainstorm skill — goal clarification (domain role).
+# /brainstorm separates WHAT from HOW: it explores the problem space and captures testable
+# Gherkin acceptance examples BEFORE planning commits to a solution. It runs upstream of loop
+# move 1 (shape intent as BDD). Hexagon: domain; consumes standards; produces result.json +
+# verdict.json; shared-kernel with standards. (soc-qk4b)
+
+Feature: Brainstorm separates goals from implementation before planning
+  As the pre-planning goal-clarification step
+  I want a free-text goal explored as a problem space, then captured as Gherkin
+  So that planning starts from clear, testable intent rather than a premature solution
+
+  Scenario: a goal is clarified through the four phases
+    When /brainstorm runs on a free-text goal
+    Then it works through assess-clarity → understand-idea → explore-approaches → capture-design
+
+  Scenario: approaches are explored as options, not a single solution
+    When the explore phase runs
+    Then it generates multiple options, compares tradeoffs, and applies adversarial critique
+    And it separates the problem (WHAT) from any one solution (HOW)
+
+  Scenario: capture writes testable Gherkin examples
+    When the capture phase completes
+    Then it produces Given/When/Then acceptance examples for /plan and /discovery
+    And capture is not complete until at least one happy path and one critical edge are written


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — peripheral skill. /brainstorm (domain, consumes standards, upstream of move 1) lacked a .feature.

- skills/brainstorm/references/brainstorm.feature (NEW): 4-phase clarification; explore = options+tradeoffs+adversarial (WHAT≠HOW); capture Gherkin (happy + edge) for /plan + /discovery
- linked in SKILL.md; registry regenerated

consumes [standards] already filled — acceptance-only.

How tested: lint-skills ✓ brainstorm (197 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /ship-loop #445.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-p8k17#brainstorm-hexagon
Bounded-context: BC2-Knowledge
Evidence: skills/brainstorm/references/brainstorm.feature