### PR TITLE
feat(pr-prep): executable acceptance for PR preparation (soc-hvfiv #pr-prep-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T07:40:09Z",
+  "generated_at": "2026-05-23T07:55:08Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -913,7 +913,7 @@
     {
       "name": "pr-prep",
       "source_skill": "skills/pr-prep",
-      "source_hash": "e775213a19ef21c699fc0306d886962bb15b2c1e1ecd1ef1e2fbe893cbc38b62",
+      "source_hash": "9ccb475fa34fad42db9c9d42bd378d708ba59a3aa5aadbed6e64e26c3a00fc72",
       "generated_hash": "770164da8ea495b1dbf1e10b81fff8aeeb8fa38cd13ea8d2f43260d7cd4fbf1d"
     },
     {

--- a/skills-codex/pr-prep/.agentops-generated.json
+++ b/skills-codex/pr-prep/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/pr-prep",
   "layout": "modular",
-  "source_hash": "e775213a19ef21c699fc0306d886962bb15b2c1e1ecd1ef1e2fbe893cbc38b62",
+  "source_hash": "9ccb475fa34fad42db9c9d42bd378d708ba59a3aa5aadbed6e64e26c3a00fc72",
   "generated_hash": "770164da8ea495b1dbf1e10b81fff8aeeb8fa38cd13ea8d2f43260d7cd4fbf1d"
 }

--- a/skills/pr-prep/SKILL.md
+++ b/skills/pr-prep/SKILL.md
@@ -265,6 +265,8 @@ gh pr create --title "type(scope): brief description" \
 
 ## Reference Documents
 
+- [references/pr-prep.feature](references/pr-prep.feature) — Executable spec: analyze repo conventions/history, validate tests first, generate PR body + branch (soc-qk4b)
+
 - [references/case-study-historical-context.md](references/case-study-historical-context.md)
 - [references/lessons-learned.md](references/lessons-learned.md)
 - [references/package-extraction.md](references/package-extraction.md)

--- a/skills/pr-prep/references/pr-prep.feature
+++ b/skills/pr-prep/references/pr-prep.feature
@@ -1,0 +1,24 @@
+# Executable spec for the /pr-prep skill — PR preparation (driving-adapter).
+# /pr-prep prepares a contribution: it learns the target repo's conventions, validates the
+# tests, and generates a properly-formatted PR body on a branch. It is convention-matching,
+# not boilerplate. Hexagon: driving-adapter; consumes domain; produces git-changes;
+# customer-of domain. (soc-qk4b)
+
+Feature: PR-prep produces a convention-matching PR body and branch
+  As the PR-preparation step
+  I want the target repo's conventions learned and tests validated before a PR body is written
+  So that the contribution matches the repo and is backed by passing tests
+
+  Scenario: the target repo's conventions are analyzed
+    When /pr-prep runs against a repo
+    Then it analyzes the repo's git history and commit/PR conventions
+    And the generated PR body and commits follow those conventions
+
+  Scenario: tests are validated before the PR body is generated
+    When /pr-prep prepares the contribution
+    Then it validates the tests first
+    And it does not generate the PR body as if tests passed when they did not
+
+  Scenario: a PR body and branch are produced
+    When preparation completes
+    Then it produces a properly-formatted PR body (markdown) on a git branch


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — peripheral skill. /pr-prep (driving-adapter, customer-of domain) lacked a .feature.

- skills/pr-prep/references/pr-prep.feature (NEW): analyze repo conventions/history; validate tests first; produce PR body + branch
- linked in SKILL.md; registry regenerated

consumes [domain] already filled — acceptance-only.

How tested: lint-skills ✓ pr-prep (273 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /brainstorm #446.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-hvfiv#pr-prep-hexagon
Bounded-context: BC5-Runtime
Evidence: skills/pr-prep/references/pr-prep.feature