### PR TITLE
feat(push): executable acceptance for the atomic test-commit-push (soc-by6b8 #push-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T07:55:08Z",
+  "generated_at": "2026-05-23T08:09:57Z",
   "summary": {
     "skills": 80,
     "hooks": 44,
@@ -232,7 +232,7 @@
         "tier": "execution",
         "path": "skills/push/",
         "has_skill_md": true,
-        "has_references": false,
+        "has_references": true,
         "reference_count": 0
       },
       {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -955,7 +955,7 @@
     {
       "name": "push",
       "source_skill": "skills/push",
-      "source_hash": "b73693ceb892ecfccf72651c876b2fcfdbab6a98ae5e64aaa7255a94db7713de",
+      "source_hash": "9af3ec35904c38e53d7385419945a27a9bd5f2adcdc96477bcb0a03c300f8cd8",
       "generated_hash": "e7553330ff6a08510f47eeed97dc3c7bdeaa7790a5000b7d53320e6951dfd465"
     },
     {

--- a/skills-codex/push/.agentops-generated.json
+++ b/skills-codex/push/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/push",
   "layout": "modular",
-  "source_hash": "b73693ceb892ecfccf72651c876b2fcfdbab6a98ae5e64aaa7255a94db7713de",
+  "source_hash": "9af3ec35904c38e53d7385419945a27a9bd5f2adcdc96477bcb0a03c300f8cd8",
   "generated_hash": "e7553330ff6a08510f47eeed97dc3c7bdeaa7790a5000b7d53320e6951dfd465"
 }

--- a/skills/push/SKILL.md
+++ b/skills/push/SKILL.md
@@ -141,3 +141,7 @@ Output a summary:
 | Tests fail | Code has errors | Fix failing tests before retrying |
 | Push rejected | Remote has new commits | Pull and rebase, then retry |
 | No changes to commit | Working tree is clean | Make changes first |
+
+## Reference Documents
+
+- [references/push.feature](references/push.feature) — Executable spec: detect project type, run tests first, block push on failure, commit+push on green (soc-qk4b)

--- a/skills/push/references/push.feature
+++ b/skills/push/references/push.feature
@@ -1,0 +1,22 @@
+# Executable spec for the /push skill — atomic test-commit-push (driving-adapter).
+# /push runs the applicable test suites BEFORE committing and pushing, so a failure is caught
+# locally instead of reaching the remote. Hexagon: driving-adapter; consumes git-changes;
+# produces git-changes. (soc-qk4b)
+
+Feature: Push runs an atomic test-commit-push
+  As the validate-commit-push step
+  I want the applicable tests run before any commit reaches the remote
+  So that a broken change is caught locally, not on origin
+
+  Scenario: the applicable test suites run before committing
+    When /push runs
+    Then it detects the project type (Go, Python, ...) and runs the matching test suites first
+
+  Scenario: a test failure blocks the push
+    When a test suite fails
+    Then /push does not commit or push
+    And the failure is surfaced locally before it can reach the remote
+
+  Scenario: a clean run commits and pushes
+    When all applicable tests pass
+    Then /push commits the change and pushes it to the remote


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — peripheral skill. /push (driving-adapter, consumes git-changes) lacked a .feature.

- skills/push/references/push.feature (NEW): detect project type + run tests first; failing suite blocks commit/push (caught locally); clean run commits + pushes
- added Reference Documents section; registry regenerated

consumes [git-changes] already filled — acceptance-only.

How tested: lint-skills ✓ push (147 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /pr-prep #447.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-by6b8#push-hexagon
Bounded-context: BC5-Runtime
Evidence: skills/push/references/push.feature