### PR TITLE
feat(pr-research): executable acceptance for upstream repo research (soc-5cpp9 #pr-research-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T08:09:57Z",
+  "generated_at": "2026-05-23T08:24:57Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -919,7 +919,7 @@
     {
       "name": "pr-research",
       "source_skill": "skills/pr-research",
-      "source_hash": "a80947acde9537aa141882512a6fde2a5eb8579cecf78837b957db14dc1c6b76",
+      "source_hash": "d380ca03ca98079af750d26cda87616e7abcd4a91d225760f22859afd92686be",
       "generated_hash": "d2da34d258effceab5c0f0f81ce2cbc4df30c6ad55295484abd96eec43ef8a65"
     },
     {

--- a/skills-codex/pr-research/.agentops-generated.json
+++ b/skills-codex/pr-research/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/pr-research",
   "layout": "modular",
-  "source_hash": "a80947acde9537aa141882512a6fde2a5eb8579cecf78837b957db14dc1c6b76",
+  "source_hash": "d380ca03ca98079af750d26cda87616e7abcd4a91d225760f22859afd92686be",
   "generated_hash": "d2da34d258effceab5c0f0f81ce2cbc4df30c6ad55295484abd96eec43ef8a65"
 }

--- a/skills/pr-research/SKILL.md
+++ b/skills/pr-research/SKILL.md
@@ -233,4 +233,6 @@ $pr-research <repo> -> $pr-plan <research> -> implement -> $pr-prep
 
 ## Reference Documents
 
+- [references/pr-research.feature](references/pr-research.feature) — Executable spec: explore upstream conventions/structure, write cited upstream artifact, first-step-before-plan (soc-qk4b)
+
 - [references/upstream-research-checklist.md](references/upstream-research-checklist.md)

--- a/skills/pr-research/references/pr-research.feature
+++ b/skills/pr-research/references/pr-research.feature
@@ -1,0 +1,23 @@
+# Executable spec for the /pr-research skill — upstream repo research (driven-adapter).
+# /pr-research is the FIRST step before contributing to an external repo: it explores the
+# upstream codebase's conventions, structure, and contribution process and writes a cited
+# research artifact, before any planning or implementation. Hexagon: driven-adapter; consumes
+# external-api; produces result.json (+ .agents/research/YYYY-MM-DD-upstream-*.md). (soc-qk4b)
+
+Feature: PR-research explores an upstream repo before contributing
+  As the first step of an open-source contribution
+  I want the upstream repo's conventions and contribution process understood and recorded
+  So that planning and implementation start from how the upstream actually works
+
+  Scenario: the upstream repo is explored and recorded
+    When /pr-research runs on an upstream repo
+    Then it explores the repo's structure, conventions, and contribution process
+    And it writes the findings to .agents/research/YYYY-MM-DD-upstream-*.md
+
+  Scenario: it runs before planning or implementation
+    When a contribution to an external repo begins
+    Then /pr-research is the first step, before /pr-plan or /pr-implement
+
+  Scenario: findings are cited
+    When the research artifact is written
+    Then claims about the upstream repo carry references to the upstream source


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — peripheral skill. /pr-research (driven-adapter, consumes external-api) lacked a .feature.

- skills/pr-research/references/pr-research.feature (NEW): explore upstream structure/conventions/contribution-process → cited .agents/research/upstream artifact; FIRST step before /pr-plan or /pr-implement
- linked in SKILL.md; registry regenerated

consumes [external-api] already filled — acceptance-only.

How tested: lint-skills ✓ pr-research (238 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /push #448.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-5cpp9#pr-research-hexagon
Bounded-context: BC5-Runtime
Evidence: skills/pr-research/references/pr-research.feature