### PR TITLE
feat(pr-implement): executable acceptance for fork-based OSS contribution (soc-exo5l #pr-implement-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T08:24:57Z",
+  "generated_at": "2026-05-23T08:40:02Z",
   "summary": {
     "skills": 80,
     "hooks": 44,
@@ -64,7 +64,7 @@
         "tier": "contribute",
         "path": "skills/pr-implement/",
         "has_skill_md": true,
-        "has_references": false,
+        "has_references": true,
         "reference_count": 0
       },
       {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -901,7 +901,7 @@
     {
       "name": "pr-implement",
       "source_skill": "skills/pr-implement",
-      "source_hash": "3f0bc36acac61b4c1638d821782ecf1c2516e716cfb31ddfcccbe674a0ceb47a",
+      "source_hash": "7fdabf4c57f4087c2eb61f8264c02eacc5ea4fe7a2feb2780af3f9e74c70453d",
       "generated_hash": "c379a9da99b11ec263a4390ac0eb12468245bc47b2eb0df8d2367eca81ebd009"
     },
     {

--- a/skills-codex/pr-implement/.agentops-generated.json
+++ b/skills-codex/pr-implement/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/pr-implement",
   "layout": "modular",
-  "source_hash": "3f0bc36acac61b4c1638d821782ecf1c2516e716cfb31ddfcccbe674a0ceb47a",
+  "source_hash": "7fdabf4c57f4087c2eb61f8264c02eacc5ea4fe7a2feb2780af3f9e74c70453d",
   "generated_hash": "c379a9da99b11ec263a4390ac0eb12468245bc47b2eb0df8d2367eca81ebd009"
 }

--- a/skills/pr-implement/SKILL.md
+++ b/skills/pr-implement/SKILL.md
@@ -198,3 +198,7 @@ Next step: $pr-prep
 | Commits mix concerns | Implementation drifted from plan | Re-split commits by concern and revalidate |
 | Scope keeps expanding | Weak boundaries in plan | Re-anchor to `Out of Scope` and stop additional changes |
 | Hard to hand off | Missing summary/test context | Add concise change summary and verification notes |
+
+## Reference Documents
+
+- [references/pr-implement.feature](references/pr-implement.feature) — Executable spec: execute plan on fork branch, mandatory isolation before+during, scoped/focused PR (soc-qk4b)

--- a/skills/pr-implement/references/pr-implement.feature
+++ b/skills/pr-implement/references/pr-implement.feature
@@ -1,0 +1,23 @@
+# Executable spec for the /pr-implement skill — fork-based OSS contribution (driving-adapter).
+# /pr-implement executes a contribution plan on a fork branch with a MANDATORY isolation check
+# before and during implementation, keeping the PR clean and scoped. Hexagon: driving-adapter;
+# consumes crank; produces git-changes; customer-of crank. (soc-qk4b)
+
+Feature: PR-implement executes a scoped contribution on a fork with isolation
+  As the fork-based OSS implementation step
+  I want a contribution plan executed on a fork branch under isolation checks
+  So that the resulting PR is clean, focused, and free of unrelated changes
+
+  Scenario: a contribution plan is implemented on a fork branch
+    Given a plan artifact from /pr-plan (or a repo URL)
+    When /pr-implement runs
+    Then it produces the code changes on a fork branch
+
+  Scenario: the isolation check is mandatory before and during
+    When /pr-implement implements the change
+    Then it runs an isolation check before and during implementation
+    And changes outside the contribution's scope are kept out of the PR
+
+  Scenario: the output stays focused
+    When implementation completes
+    Then the fork branch contains only the scoped contribution, not unrelated edits


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — peripheral skill. /pr-implement (driving-adapter, customer-of crank) lacked a .feature.

- skills/pr-implement/references/pr-implement.feature (NEW): execute /pr-plan artifact on fork branch; mandatory isolation before+during; scoped/focused PR
- linked in SKILL.md; registry regenerated

consumes [crank] already filled — acceptance-only.

How tested: lint-skills ✓ pr-implement (204 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /pr-research #449.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-exo5l#pr-implement-hexagon
Bounded-context: BC5-Runtime
Evidence: skills/pr-implement/references/pr-implement.feature