### PR TITLE
feat(pr-validate): executable acceptance for PR submission-readiness (soc-qi6yh #pr-validate-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T08:40:02Z",
+  "generated_at": "2026-05-23T08:55:07Z",
   "summary": {
     "skills": 80,
     "hooks": 44,
@@ -104,7 +104,7 @@
         "tier": "contribute",
         "path": "skills/pr-validate/",
         "has_skill_md": true,
-        "has_references": false,
+        "has_references": true,
         "reference_count": 0
       },
       {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -931,7 +931,7 @@
     {
       "name": "pr-validate",
       "source_skill": "skills/pr-validate",
-      "source_hash": "6a292a24bf36c107e769f489c4123521ad8a4d3aec859095316a411c9c060f3d",
+      "source_hash": "c624c9fbca3700a187e7dbd6025c765f2886f79d3ba0499abe96afdece9e8802",
       "generated_hash": "a5fcd1c7214d0fb9651f32bcccdf0c00b683a47a2a703f8cc7f39006dfea3d24"
     },
     {

--- a/skills-codex/pr-validate/.agentops-generated.json
+++ b/skills-codex/pr-validate/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/pr-validate",
   "layout": "modular",
-  "source_hash": "6a292a24bf36c107e769f489c4123521ad8a4d3aec859095316a411c9c060f3d",
+  "source_hash": "c624c9fbca3700a187e7dbd6025c765f2886f79d3ba0499abe96afdece9e8802",
   "generated_hash": "a5fcd1c7214d0fb9651f32bcccdf0c00b683a47a2a703f8cc7f39006dfea3d24"
 }

--- a/skills/pr-validate/SKILL.md
+++ b/skills/pr-validate/SKILL.md
@@ -208,3 +208,7 @@ git rebase origin/main
 | Scope creep detected | Extra files or mixed objectives | Split unrelated changes into follow-up PR |
 | Alignment check fails | Branch diverged from target expectations | Reconcile base branch and acceptance criteria |
 | Output unclear | Findings not prioritized | Sort findings by blocker vs non-blocker severity |
+
+## Reference Documents
+
+- [references/pr-validate.feature](references/pr-validate.feature) — Executable spec: isolation + upstream-alignment + scope-containment + quality-gate checks → submission-readiness verdict (soc-qk4b)

--- a/skills/pr-validate/references/pr-validate.feature
+++ b/skills/pr-validate/references/pr-validate.feature
@@ -1,0 +1,22 @@
+# Executable spec for the /pr-validate skill — PR submission-readiness (driving-adapter).
+# /pr-validate checks that a PR branch is clean, focused, and ready to submit: isolation,
+# upstream alignment, scope containment, and quality gates. Hexagon: driving-adapter; consumes
+# validation; produces result.json; customer-of validation. (soc-qk4b)
+
+Feature: PR-validate checks a PR branch is submission-ready
+  As the pre-submission PR check
+  I want a branch verified for isolation, upstream alignment, scope, and quality
+  So that only clean, focused PRs reach the upstream
+
+  Scenario: a PR branch is validated across the readiness dimensions
+    When /pr-validate runs on a branch
+    Then it checks isolation, upstream alignment, scope containment, and quality gates
+    And it produces a PR validation report
+
+  Scenario: scope creep is flagged
+    When the branch contains changes outside the contribution's scope
+    Then /pr-validate flags the scope-containment failure as not-ready
+
+  Scenario: a failing quality gate blocks readiness
+    When a quality gate fails on the branch
+    Then /pr-validate reports the branch as not submission-ready


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — peripheral skill. /pr-validate (driving-adapter, customer-of validation) lacked a .feature.

- skills/pr-validate/references/pr-validate.feature (NEW): isolation + upstream-alignment + scope-containment + quality-gate checks → readiness verdict; scope creep flagged; failing gate blocks readiness
- linked in SKILL.md; registry regenerated

consumes [validation] already filled — acceptance-only.

How tested: lint-skills ✓ pr-validate (214 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /pr-implement #450.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-qi6yh#pr-validate-hexagon
Bounded-context: BC4-Validation
Evidence: skills/pr-validate/references/pr-validate.feature