### PR TITLE
feat(autodev): executable acceptance for the bounded autonomous loop (soc-s1nhu #autodev-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T08:55:07Z",
+  "generated_at": "2026-05-23T09:10:23Z",
   "summary": {
     "skills": 80,
     "hooks": 44,
@@ -136,7 +136,7 @@
         "tier": "execution",
         "path": "skills/autodev/",
         "has_skill_md": true,
-        "has_references": false,
+        "has_references": true,
         "reference_count": 0
       },
       {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -679,7 +679,7 @@
     {
       "name": "autodev",
       "source_skill": "skills/autodev",
-      "source_hash": "0f66a0371628a4612eaa1a86ddbff2cdf4c97d3a87a080ce39b1600ed9bf0838",
+      "source_hash": "67bb1293051a57e371462b97f4d8c9c80870bdc798e54aa929f5072e4959410c",
       "generated_hash": "7fe2526d5e4792cb4b52e59745010fb752547b5163495e59904a13e4535f4024"
     },
     {

--- a/skills-codex/autodev/.agentops-generated.json
+++ b/skills-codex/autodev/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/autodev",
   "layout": "modular",
-  "source_hash": "0f66a0371628a4612eaa1a86ddbff2cdf4c97d3a87a080ce39b1600ed9bf0838",
+  "source_hash": "67bb1293051a57e371462b97f4d8c9c80870bdc798e54aa929f5072e4959410c",
   "generated_hash": "7fe2526d5e4792cb4b52e59745010fb752547b5163495e59904a13e4535f4024"
 }

--- a/skills/autodev/SKILL.md
+++ b/skills/autodev/SKILL.md
@@ -140,3 +140,7 @@ ao evolve --max-cycles 1
 | validation reports missing sections | Patch the missing required sections, then rerun `ao autodev validate --json`. |
 | requested work is outside immutable scope | Stop direct edits and create a bead or ask for an explicit contract change. |
 | user asks "is this evolve?" | Answer: `autodev` defines the loop contract; `evolve` runs the loop. |
+
+## Reference Documents
+
+- [references/autodev.feature](references/autodev.feature) — Executable spec: contract-bounded unattended loop, manages-not-replaces evolve/rpi, loop-discipline-under-autonomy (soc-qk4b)

--- a/skills/autodev/references/autodev.feature
+++ b/skills/autodev/references/autodev.feature
@@ -1,0 +1,27 @@
+# Executable spec for the /autodev skill — bounded autonomous dev loop (supporting role).
+# /autodev runs the full operating loop UNATTENDED within a declared contract (PROGRAM.md /
+# AUTODEV.md): mutable/immutable scope, validation commands, escalation, stop conditions. It
+# manages the contract — it does not replace /evolve or /rpi, which it delegates to. Loop
+# discipline still applies under autonomy. Hexagon: supporting; consumes evolve + rpi. (soc-qk4b)
+
+Feature: Autodev runs the operating loop unattended within a declared contract
+  As the bounded autonomous-development manager
+  I want the loop to run unattended only inside an explicit contract
+  So that autonomy stays scoped, validated, and stoppable
+
+  Scenario: a contract bounds the unattended loop
+    Given a PROGRAM.md or AUTODEV.md declaring mutable/immutable scope, validation commands,
+      escalation rules, and stop conditions
+    When /autodev runs
+    Then it executes the loop only within that contract
+
+  Scenario: it manages the contract, it does not replace evolve or rpi
+    When /autodev operates
+    Then it creates/inspects/validates the contract and delegates execution to /evolve and /rpi
+    And it does not reimplement the evolve or rpi loops
+
+  Scenario: loop discipline holds under autonomy
+    When /autodev runs a wave unattended
+    Then no parallel wave runs without the wave-validity check
+    And no slice closes without a passing test mapped to a Given/When/Then
+    And captured learnings go through the promotion ratchet, not a landfill


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — peripheral skill. /autodev (supporting, consumes evolve + rpi) lacked a .feature.

- skills/autodev/references/autodev.feature (NEW): contract-bounded unattended loop (PROGRAM.md/AUTODEV.md); manages-not-replaces /evolve + /rpi (delegates); loop discipline holds under autonomy
- linked in SKILL.md; registry regenerated

consumes [evolve, rpi] already filled — acceptance-only (produces:[] is defensible: orchestrator, artifacts come from delegated loops).

How tested: lint-skills ✓ autodev (146 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /pr-validate #451.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-s1nhu#autodev-hexagon
Bounded-context: BC3-Loop
Evidence: skills/autodev/references/autodev.feature