### PR TITLE
feat(security-suite): executable acceptance for composable security primitives (soc-1sf0h #security-suite-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T09:10:23Z",
+  "generated_at": "2026-05-23T09:25:18Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1057,7 +1057,7 @@
     {
       "name": "security-suite",
       "source_skill": "skills/security-suite",
-      "source_hash": "85977b5c2b8ea211d095a7217a261e5e7df77721dfb793c54c5805db3ae72ea5",
+      "source_hash": "756150b447c68b99a5f75b458cce8550406f043cb3292220c6f06300424ce285",
       "generated_hash": "76446e09f23255255d13e446628d37128984a345a5ecb4dd286ceab8b00d6f9c"
     },
     {

--- a/skills-codex/security-suite/.agentops-generated.json
+++ b/skills-codex/security-suite/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/security-suite",
   "layout": "modular",
-  "source_hash": "85977b5c2b8ea211d095a7217a261e5e7df77721dfb793c54c5805db3ae72ea5",
+  "source_hash": "756150b447c68b99a5f75b458cce8550406f043cb3292220c6f06300424ce285",
   "generated_hash": "76446e09f23255255d13e446628d37128984a345a5ecb4dd286ceab8b00d6f9c"
 }

--- a/skills/security-suite/SKILL.md
+++ b/skills/security-suite/SKILL.md
@@ -228,6 +228,8 @@ python3 skills/security-suite/scripts/prompt_redteam.py scan \
 
 ## Reference Documents
 
+- [references/security-suite.feature](references/security-suite.feature) — Executable spec: composable primitives (static/dynamic/contract) → security-report.json, authorization-bounded, supplier-to vibe (soc-qk4b)
+
 - [references/owasp-checklist.md](references/owasp-checklist.md)
 - [references/agentops-redteam-pack.json](references/agentops-redteam-pack.json)
 - [references/policy-example.json](references/policy-example.json)

--- a/skills/security-suite/references/security-suite.feature
+++ b/skills/security-suite/references/security-suite.feature
@@ -1,0 +1,24 @@
+# Executable spec for the /security-suite skill — composable security primitives (driven-adapter).
+# /security-suite provides repeatable, composable security/internal-testing primitives over
+# AUTHORIZED targets — separated into testable steps (collect-static, collect-dynamic,
+# collect-contract) that compose into a security report. Hexagon: driven-adapter; consumes
+# repo-context; produces security-report.json; supplier-to vibe. (soc-qk4b)
+
+Feature: Security-suite runs composable security primitives
+  As the composable security-analysis toolkit
+  I want separable primitives that compose into a security report over authorized targets
+  So that security workflows stay testable, reusable, and authorization-bounded
+
+  Scenario: composable primitives produce a security report
+    When /security-suite runs over a target
+    Then it composes primitives (collect-static, collect-dynamic, collect-contract)
+    And it writes a security-report.json
+
+  Scenario: analysis is authorization-bounded
+    When the target is a binary or surface
+    Then /security-suite is used only on owned or explicitly authorized targets
+    And it is not used to bypass legal restrictions or extract third-party proprietary content
+
+  Scenario: the report feeds the validator
+    When the suite completes
+    Then its report is available to /vibe as a supplier (supplier-to vibe)


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — peripheral skill (pairs with /security #442). /security-suite (driven-adapter, supplier-to vibe) lacked a .feature.

- skills/security-suite/references/security-suite.feature (NEW): composable primitives (static/dynamic/contract) → security-report.json; authorization-bounded; feeds /vibe
- linked in SKILL.md; registry regenerated

consumes [repo-context] already filled — acceptance-only.

How tested: lint-skills ✓ security-suite (235 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /security #442.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-1sf0h#security-suite-hexagon
Bounded-context: BC4-Validation
Evidence: skills/security-suite/references/security-suite.feature