### PR TITLE
feat(session-bootstrap): executable acceptance for the universal init prompt (soc-ho3qh #session-bootstrap-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T09:25:18Z",
+  "generated_at": "2026-05-23T09:40:08Z",
   "summary": {
     "skills": 80,
     "hooks": 44,
@@ -632,7 +632,7 @@
         "tier": "session",
         "path": "skills/session-bootstrap/",
         "has_skill_md": true,
-        "has_references": false,
+        "has_references": true,
         "reference_count": 0
       },
       {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1087,7 +1087,7 @@
     {
       "name": "session-bootstrap",
       "source_skill": "skills/session-bootstrap",
-      "source_hash": "948290e6927e9b1e74204731e5984947b68541343197b064994d269039b2332f",
+      "source_hash": "63812cb95987806f14110b1b1e7e95acc66f95f71b71e54e39693987a75abe1f",
       "generated_hash": "4620320eb1d8b6c724956e566ba5a3c5663a14e1010f9a693f3143326c55d8c4"
     },
     {

--- a/skills-codex/session-bootstrap/.agentops-generated.json
+++ b/skills-codex/session-bootstrap/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/session-bootstrap",
   "layout": "modular",
-  "source_hash": "948290e6927e9b1e74204731e5984947b68541343197b064994d269039b2332f",
+  "source_hash": "63812cb95987806f14110b1b1e7e95acc66f95f71b71e54e39693987a75abe1f",
   "generated_hash": "4620320eb1d8b6c724956e566ba5a3c5663a14e1010f9a693f3143326c55d8c4"
 }

--- a/skills/session-bootstrap/SKILL.md
+++ b/skills/session-bootstrap/SKILL.md
@@ -110,3 +110,7 @@ The [agent-fungibility-philosophy](https://github.com/boshu2/agentops/issues?q=l
 - [`AGENTS.md`](../../AGENTS.md) — orientation entry-point that points here.
 - [`AGENTS-WORKFLOW.md`](../../AGENTS-WORKFLOW.md) — what to do after bootstrap reports.
 - [`schemas/session-bootstrap.v1.schema.json`](../../schemas/session-bootstrap.v1.schema.json) — full output contract.
+
+## Reference Documents
+
+- [references/session-bootstrap.feature](references/session-bootstrap.feature) — Executable spec: every agent runs first, identical model-fungible frame, fail-open SessionStart hook, --json for pipeline (soc-qk4b)

--- a/skills/session-bootstrap/references/session-bootstrap.feature
+++ b/skills/session-bootstrap/references/session-bootstrap.feature
@@ -1,0 +1,24 @@
+# Executable spec for the /session-bootstrap skill — universal init prompt (driving-adapter).
+# Every agent spawned into an AgentOps repo runs `ao session bootstrap` FIRST, getting the same
+# orientation report regardless of model — the contract that makes model fungibility operational.
+# Hexagon: driving-adapter; consumes bd + onboard; produces stdout + json; customer-of AGENTS.md.
+# (soc-qk4b)
+
+Feature: Session-bootstrap gives every agent the same orientation frame
+  As the universal init step for any agent in the repo
+  I want every agent to start from one identical orientation report
+  So that a Claude agent and a Codex agent can be swapped on any bead without re-orienting
+
+  Scenario: every agent runs bootstrap first and gets an identical frame
+    When an agent is spawned into an AgentOps repository
+    Then it runs `ao session bootstrap` before claiming work
+    And the orientation report is identical regardless of which model is running
+
+  Scenario: the SessionStart hook fires fail-open
+    When the SessionStart hook runs bootstrap automatically
+    Then it runs `ao session bootstrap --robot` and discards the exit code
+    And a bootstrap failure never blocks the session from starting
+
+  Scenario: pipeline and headless agents get machine-readable output
+    When a headless or pipeline agent bootstraps
+    Then `ao session bootstrap --json` provides the orientation as structured JSON before it claims work


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — high-traffic peripheral skill. /session-bootstrap (driving-adapter, customer-of AGENTS.md) lacked a .feature.

- skills/session-bootstrap/references/session-bootstrap.feature (NEW): every agent runs it first → model-identical orientation frame; SessionStart hook fail-open (--robot, discards exit); --json for pipeline/headless before claiming
- linked in SKILL.md; registry regenerated

consumes [bd, onboard] already filled — acceptance-only.

How tested: lint-skills ✓ session-bootstrap (116 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /security-suite #453.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-ho3qh#session-bootstrap-hexagon
Bounded-context: BC5-Runtime
Evidence: skills/session-bootstrap/references/session-bootstrap.feature