### PR TITLE
feat(quickstart): executable acceptance for the next-action recommender (soc-9ew18 #quickstart-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T09:40:08Z",
+  "generated_at": "2026-05-23T09:55:02Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -961,7 +961,7 @@
     {
       "name": "quickstart",
       "source_skill": "skills/quickstart",
-      "source_hash": "e4b4981cf693d273120678c3f35a6bf1d2cf7a4c572345254cdcdd25467660ce",
+      "source_hash": "c127f1576b2590c95f159cddacd8bd88f07d8b4b911765ca5e4fb0e86ba894e9",
       "generated_hash": "6881a31264d27e57de858a5e842297d35dc82dc1c2456b0e8192e8d165b8bf67"
     },
     {

--- a/skills-codex/quickstart/.agentops-generated.json
+++ b/skills-codex/quickstart/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/quickstart",
   "layout": "modular",
-  "source_hash": "e4b4981cf693d273120678c3f35a6bf1d2cf7a4c572345254cdcdd25467660ce",
+  "source_hash": "c127f1576b2590c95f159cddacd8bd88f07d8b4b911765ca5e4fb0e86ba894e9",
   "generated_hash": "6881a31264d27e57de858a5e842297d35dc82dc1c2456b0e8192e8d165b8bf67"
 }

--- a/skills/quickstart/SKILL.md
+++ b/skills/quickstart/SKILL.md
@@ -118,6 +118,8 @@ Starting a new project? Run `/scaffold <language> <name>` to generate project st
 
 ## Reference Documents
 
+- [references/quickstart.feature](references/quickstart.feature) — Executable spec: detect setup (git/ao/bd/.agents), recommend a state-appropriate next action (soc-qk4b)
+
 - [references/getting-started.md](references/getting-started.md)
 - [references/troubleshooting.md](references/troubleshooting.md)
 - [references/full-catalog.md](references/full-catalog.md)

--- a/skills/quickstart/references/quickstart.feature
+++ b/skills/quickstart/references/quickstart.feature
@@ -1,0 +1,22 @@
+# Executable spec for the /quickstart skill — next-action recommender (driving-adapter).
+# /quickstart detects the current setup (git, ao, bd, .agents, codex) and recommends the single
+# most useful next AgentOps action for that state — orientation, not a fixed script. Hexagon:
+# driving-adapter; consumes rpi; produces stdout; customer-of rpi. (soc-qk4b)
+
+Feature: Quickstart shows the next AgentOps action
+  As a newcomer or freshly-spawned agent
+  I want the current setup detected and one clear next action recommended
+  So that I know what to do next without reading the whole repo
+
+  Scenario: setup state is detected
+    When /quickstart runs
+    Then it detects whether git, ao, bd, and .agents are present
+
+  Scenario: the next action fits the detected state
+    When setup detection completes
+    Then /quickstart recommends a next action appropriate to that state
+    And a repo missing a prerequisite is pointed at installing/initializing it, not at claiming work
+
+  Scenario: a ready repo is pointed at real work
+    Given a configured repo with ready beads
+    Then /quickstart points at the next concrete step (e.g. ready work via bd / an rpi lifecycle)


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — peripheral skill. /quickstart (driving-adapter, customer-of rpi) lacked a .feature.

- skills/quickstart/references/quickstart.feature (NEW): detect setup (git/ao/bd/.agents); state-appropriate next action; ready repo → next concrete step
- linked in SKILL.md; registry regenerated

consumes [rpi] already filled — acceptance-only.

How tested: lint-skills ✓ quickstart (129 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /session-bootstrap #454.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-9ew18#quickstart-hexagon
Bounded-context: BC5-Runtime
Evidence: skills/quickstart/references/quickstart.feature