### PR TITLE
feat(bootstrap): executable acceptance for idempotent project initialization (soc-d54om #bootstrap-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T09:55:02Z",
+  "generated_at": "2026-05-23T10:10:11Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -691,7 +691,7 @@
     {
       "name": "bootstrap",
       "source_skill": "skills/bootstrap",
-      "source_hash": "f34fe77e90829e2655a2aa95785a7d9514e8f634900bd7b5d710216928f4d992",
+      "source_hash": "c0e66f963797ac424c41f3781d13148537b2d3a1b7eba81329a44621cf8b2531",
       "generated_hash": "5d1601251f1b2bba8eb27f4a527e700bc516a984e4f4e48e74129842454e13f8"
     },
     {

--- a/skills-codex/bootstrap/.agentops-generated.json
+++ b/skills-codex/bootstrap/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/bootstrap",
   "layout": "modular",
-  "source_hash": "f34fe77e90829e2655a2aa95785a7d9514e8f634900bd7b5d710216928f4d992",
+  "source_hash": "c0e66f963797ac424c41f3781d13148537b2d3a1b7eba81329a44621cf8b2531",
   "generated_hash": "5d1601251f1b2bba8eb27f4a527e700bc516a984e4f4e48e74129842454e13f8"
 }

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -265,3 +265,7 @@ Repo is now AgentOps-ready. Next: /rpi "your first goal"
 - [readme](../readme/SKILL.md) -- README generation
 - [quickstart](../quickstart/SKILL.md) -- New user onboarding (lighter than bootstrap)
 - [related operator runbooks](references/related-runbooks.md) -- host-hygiene runbooks (PATH rationalization, etc.)
+
+## Reference Documents
+
+- [references/bootstrap.feature](references/bootstrap.feature) — Executable spec: bare repo gets golden path, existing repo fills gaps only, idempotent never-overwrite (soc-qk4b)

--- a/skills/bootstrap/references/bootstrap.feature
+++ b/skills/bootstrap/references/bootstrap.feature
@@ -1,0 +1,24 @@
+# Executable spec for the /bootstrap skill — project initialization (driving-adapter).
+# /bootstrap is the product/operations layer around the `ao quick-start` seed: it initializes
+# AgentOps project files PROGRESSIVELY (a bare repo gets the golden path; an existing repo only
+# fills gaps) and IDEMPOTENTLY (it never overwrites an existing artifact). Hexagon:
+# driving-adapter; consumes goals + product + readme + shared. (soc-qk4b)
+
+Feature: Bootstrap initializes AgentOps project files idempotently
+  As repo setup
+  I want the project files seeded progressively and without clobbering anything
+  So that both bare and established repos reach a complete AgentOps baseline safely
+
+  Scenario: a bare repo gets the golden path
+    Given a repo with no AgentOps project files
+    When /bootstrap runs
+    Then it seeds the golden-path project files
+
+  Scenario: an existing repo only fills gaps
+    Given a repo that already has some AgentOps artifacts
+    When /bootstrap runs
+    Then it adds only the missing artifacts and leaves existing ones untouched
+
+  Scenario: bootstrap is idempotent
+    When /bootstrap runs twice
+    Then the second run overwrites nothing and produces no spurious changes


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — peripheral skill. /bootstrap (driving-adapter, consumes goals/product/readme/shared) lacked a .feature.

- skills/bootstrap/references/bootstrap.feature (NEW): bare repo → golden path; existing repo → fills gaps only (untouched existing); idempotent (2nd run overwrites nothing)
- linked in SKILL.md; registry regenerated

consumes filled — acceptance-only (produces:[] defensible: seeds a progressive scaffold set, not one artifact).

How tested: lint-skills ✓ bootstrap (271 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /quickstart #455.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-d54om#bootstrap-hexagon
Bounded-context: BC5-Runtime
Evidence: skills/bootstrap/references/bootstrap.feature