### PR TITLE
feat(openai-docs): executable acceptance for official-docs grounding (soc-7z3r3 #openai-docs-hexagon)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T10:10:11Z",
+  "generated_at": "2026-05-23T10:25:04Z",
   "summary": {
     "skills": 80,
     "hooks": 44,
@@ -128,7 +128,7 @@
         "tier": "cross-vendor",
         "path": "skills/openai-docs/",
         "has_skill_md": true,
-        "has_references": false,
+        "has_references": true,
         "reference_count": 0
       },
       {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -871,7 +871,7 @@
     {
       "name": "openai-docs",
       "source_skill": "skills/openai-docs",
-      "source_hash": "21ced6a1fd006a3343e8968d33d1dbe42e3ff532643b9e0654f1ce2e9289bfe6",
+      "source_hash": "e0f575f3da7521aa976736a7e31e78bccec4509027ac268d6c23f9410bff6b7d",
       "generated_hash": "897d7a15f493cf6e64262e0ff44e5083bffee62787bead5fd106658cd9c09e18"
     },
     {

--- a/skills-codex/openai-docs/.agentops-generated.json
+++ b/skills-codex/openai-docs/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/openai-docs",
   "layout": "modular",
-  "source_hash": "21ced6a1fd006a3343e8968d33d1dbe42e3ff532643b9e0654f1ce2e9289bfe6",
+  "source_hash": "e0f575f3da7521aa976736a7e31e78bccec4509027ac268d6c23f9410bff6b7d",
   "generated_hash": "897d7a15f493cf6e64262e0ff44e5083bffee62787bead5fd106658cd9c09e18"
 }

--- a/skills/openai-docs/SKILL.md
+++ b/skills/openai-docs/SKILL.md
@@ -118,3 +118,7 @@ If MCP tools fail or no OpenAI docs resources are available:
 | Results are stale/unclear | Query too broad | Narrow query by product + feature, then fetch exact page section |
 | Need citation-ready answer | Source not fetched | Fetch specific doc section before answering |
 | Docs do not cover question | Gap in official docs | State gap explicitly and provide safe best-effort guidance |
+
+## Reference Documents
+
+- [references/openai-docs.feature](references/openai-docs.feature) — Executable spec: search official docs, fetch+quote exact sections, doc-grounded not from-memory (soc-qk4b)

--- a/skills/openai-docs/references/openai-docs.feature
+++ b/skills/openai-docs/references/openai-docs.feature
@@ -1,0 +1,22 @@
+# Executable spec for the /openai-docs skill — official-docs grounding (driven-adapter).
+# /openai-docs answers OpenAI-API questions from the OFFICIAL docs (via the openaiDeveloperDocs
+# MCP search/fetch/list tools), quoting exact sections rather than recalling from memory.
+# Hexagon: driven-adapter; consumes external-api. (soc-qk4b)
+
+Feature: Openai-docs grounds answers in official OpenAI documentation
+  As the OpenAI-docs grounding skill
+  I want answers pulled from the official docs and quoted from exact sections
+  So that OpenAI API details are accurate and current, not hallucinated from memory
+
+  Scenario: a query is answered from searched docs
+    When /openai-docs answers an OpenAI-API question
+    Then it searches the official OpenAI docs for the most relevant pages
+    And it fetches the exact section to quote or paraphrase from
+
+  Scenario: answers are doc-grounded, not from memory
+    When the relevant doc section is available
+    Then the answer is grounded in that fetched section, not recalled API details
+
+  Scenario: browsing is the fallback, not the default
+    When there is no clear query
+    Then listing docs is used only to discover pages, not as the primary path


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — peripheral skill. /openai-docs (driven-adapter, consumes external-api) lacked a .feature.

- skills/openai-docs/references/openai-docs.feature (NEW): search official docs + fetch exact section to quote; doc-grounded not from-memory; listing is discovery fallback
- linked in SKILL.md; registry regenerated

consumes [external-api] already filled — acceptance-only.

How tested: lint-skills ✓ openai-docs (124 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: acceptance-only crank like /bootstrap #456.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-7z3r3#openai-docs-hexagon
Bounded-context: BC2-Knowledge
Evidence: skills/openai-docs/references/openai-docs.feature