### PR TITLE
feat(oss-docs): hexagon consumes + executable acceptance for OSS doc scaffolder (soc-mqb49 #oss-docs-hexagon)

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -222,6 +222,7 @@ graph LR
 | `implement` | produces | git-changes |
 | `llm-wiki` | produces | documentation |
 | `openai-docs` | consumes | external-api |
+| `oss-docs` | consumes | repo-context |
 | `oss-docs` | produces | documentation |
 | `perf` | produces | result.json |
 | `plan` | consumes | standards |

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T10:25:04Z",
+  "generated_at": "2026-05-23T10:41:18Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -877,7 +877,7 @@
     {
       "name": "oss-docs",
       "source_skill": "skills/oss-docs",
-      "source_hash": "5986b7b8841fb7d6e11635e2f47964d3aa077690c305ed0066552f45c7e870c4",
+      "source_hash": "65feb5b9a853c238b3456c4d3c8eb374f73f5499445485ac3d6298aca4a92fff",
       "generated_hash": "dc48da2244b8584404f97852b961e645e6aa13085fb3275c2545fbe3fa16cf33"
     },
     {

--- a/skills-codex/oss-docs/.agentops-generated.json
+++ b/skills-codex/oss-docs/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/oss-docs",
   "layout": "modular",
-  "source_hash": "5986b7b8841fb7d6e11635e2f47964d3aa077690c305ed0066552f45c7e870c4",
+  "source_hash": "65feb5b9a853c238b3456c4d3c8eb374f73f5499445485ac3d6298aca4a92fff",
   "generated_hash": "dc48da2244b8584404f97852b961e645e6aa13085fb3275c2545fbe3fa16cf33"
 }

--- a/skills/oss-docs/SKILL.md
+++ b/skills/oss-docs/SKILL.md
@@ -5,7 +5,8 @@ practices:
 - code-complete
 - pragmatic-programmer
 hexagonal_role: generic
-consumes: []
+consumes:
+- repo-context
 produces:
 - documentation
 context_rel: []
@@ -222,6 +223,8 @@ This project uses **<tool>** for <purpose>. Run `<onboard-cmd>` to get started.
 | Open-source handoff incomplete | Session-end workflow not reflected | Add landing-the-plane and release hygiene steps |
 
 ## Reference Documents
+
+- [references/oss-docs.feature](references/oss-docs.feature) — Executable spec: audit existing/missing OSS docs (reads repo), scaffold missing without overwrite, project-type-tailored (soc-qk4b)
 
 - [references/beads-patterns.md](references/beads-patterns.md)
 - [references/documentation-tiers.md](references/documentation-tiers.md)

--- a/skills/oss-docs/references/oss-docs.feature
+++ b/skills/oss-docs/references/oss-docs.feature
@@ -1,0 +1,23 @@
+# Executable spec for the /oss-docs skill — OSS documentation scaffold/audit (generic role).
+# /oss-docs prepares a repo for open-source release: it AUDITS which standard docs exist/are
+# missing (reading the repo), SCAFFOLDS the missing ones without clobbering, and tailors content
+# to the project type. Hexagon: generic; consumes repo-context (audit reads the repo); produces
+# documentation. (soc-qk4b)
+
+Feature: OSS-docs audits and scaffolds open-source documentation
+  As open-source release prep
+  I want the standard docs audited and the missing ones scaffolded to project type
+  So that a repo reaches OSS-release doc completeness without overwriting existing work
+
+  Scenario: audit reports which standard docs exist or are missing
+    When /oss-docs audit runs
+    Then it reads the repo and reports which standard OSS docs exist and which are missing
+
+  Scenario: scaffold creates only the missing standard files
+    When /oss-docs scaffold runs
+    Then it creates the missing standard files
+    And it does not overwrite docs that already exist
+
+  Scenario: generated content is tailored to the project type
+    When /oss-docs generates a doc
+    Then the content is tailored to the detected project type, not a generic stub


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — first FULL crank (frontmatter + .feature). /oss-docs had EMPTY consumes despite audit reading the repo.

- frontmatter: consumes [] → [repo-context] (evidence: audit reads repo doc-state); produces [documentation] already correct
- skills/oss-docs/references/oss-docs.feature (NEW): audit exists/missing, scaffold-no-overwrite, project-type-tailored
- context-map.md regenerated (oss-docs←repo-context edge; deterministic); SKILL.md linked

How tested: lint-skills ✓ oss-docs; scenarios --lint 0 errors; codex parity passed; registry up to date; context-map regen deterministic + committed.
Sibling: full crank like /compile #431.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-mqb49#oss-docs-hexagon
Bounded-context: BC5-Runtime
Evidence: skills/oss-docs/references/oss-docs.feature