### PR TITLE
feat(status): hexagon consumes + executable acceptance for the work dashboard (soc-17wdq #status-hexagon)

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -296,6 +296,7 @@ graph LR
 | `skill-auditor` | produces | result.json |
 | `skill-builder` | produces | converted-skill |
 | `standards` | produces | stdout |
+| `status` | consumes | bd |
 | `status` | produces | stdout |
 | `swarm` | consumes | implement |
 | `swarm` | consumes | vibe |

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T10:41:18Z",
+  "generated_at": "2026-05-23T10:56:08Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1099,7 +1099,7 @@
     {
       "name": "status",
       "source_skill": "skills/status",
-      "source_hash": "2f9b3cb80ab0d3e42ca92d76c9103752f870ce2f07c1075879424156cd32c605",
+      "source_hash": "31124196d17cb64f0676d7747943ec1df897d84eddbe2795ca5ef4ca3a7763e7",
       "generated_hash": "54b1562de6d9c7beb832214ffe14c5fb1d3caf702487151145a80092063d7600"
     },
     {

--- a/skills-codex/status/.agentops-generated.json
+++ b/skills-codex/status/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/status",
   "layout": "modular",
-  "source_hash": "2f9b3cb80ab0d3e42ca92d76c9103752f870ce2f07c1075879424156cd32c605",
+  "source_hash": "31124196d17cb64f0676d7747943ec1df897d84eddbe2795ca5ef4ca3a7763e7",
   "generated_hash": "54b1562de6d9c7beb832214ffe14c5fb1d3caf702487151145a80092063d7600"
 }

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -5,7 +5,8 @@ practices:
 - dora-metrics
 - sre
 hexagonal_role: driving-adapter
-consumes: []
+consumes:
+- bd
 produces:
 - stdout
 context_rel: []
@@ -314,3 +315,7 @@ Render this with a single code block. No visual dashboard when `--json` is activ
 | Ratchet phase shows stale data | Old chain.jsonl not cleaned up | Check timestamp of `.agents/ao/chain.jsonl`. If stale, delete it or run `/validation` to complete cycle and reset state. |
 | Suggested action doesn't match intent | State-aware rules didn't capture edge case | Review priority table in Step 3. May need to refine conditions. Use `--json` to inspect raw state and debug rule matching. |
 | JSON output malformed | Parallel bash calls returned unexpected format | Check each bash call individually. Ensure jq parsing works on actual data. Validate JSON structure with `jq .` before returning to user. |
+
+## Reference Documents
+
+- [references/status.feature](references/status.feature) — Executable spec: work dashboard from bd (ready/in-progress/epics) + ratchet/flywheel/git, --json, fail-soft on missing tools (soc-qk4b)

--- a/skills/status/references/status.feature
+++ b/skills/status/references/status.feature
@@ -1,0 +1,23 @@
+# Executable spec for the /status skill — work-status dashboard (driving-adapter).
+# /status reports current AgentOps work state — its primary source is the bd tracker
+# (ready/in-progress/epics) augmented with ratchet, flywheel, and git state — as a human
+# dashboard or machine-readable JSON, degrading gracefully when a tool is missing. Hexagon:
+# driving-adapter; consumes bd; produces stdout. (soc-qk4b)
+
+Feature: Status shows the AgentOps work dashboard
+  As an agent or operator orienting in a repo
+  I want current work state surfaced from the tracker in one view
+  So that I can see ready/in-progress work and project health at a glance
+
+  Scenario: the dashboard reports work state from bd
+    When /status runs
+    Then it reports work state from bd (ready, in-progress, open epics)
+    And it augments that with ratchet, flywheel, and git state
+
+  Scenario: --json gives machine-readable output
+    When /status --json runs
+    Then it emits the same status as structured JSON
+
+  Scenario: missing tools degrade gracefully
+    When a data source (ratchet/flywheel) is unavailable
+    Then /status marks that section unavailable and still renders the rest, without crashing


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — full crank. /status had EMPTY consumes despite reading bd as primary source.

- frontmatter: consumes [] → [bd] (evidence: bd list/ready/epics dominate the dashboard; ratchet/flywheel/git secondary)
- skills/status/references/status.feature (NEW): dashboard from bd + augmentation; --json; graceful degradation on missing tools
- context-map.md regenerated (status←bd edge; deterministic); SKILL.md linked

How tested: lint-skills ✓ status (321 lines, under session cap); scenarios --lint 0 errors; codex parity passed; registry up to date; diff-stat clean.
Sibling: full crank like /oss-docs #458.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-17wdq#status-hexagon
Bounded-context: BC5-Runtime
Evidence: skills/status/references/status.feature