### PR TITLE
feat(deps): hexagon consumes + executable acceptance for dependency audit (soc-ok9m8 #deps-hexagon)

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -190,6 +190,7 @@ graph LR
 | `crank` | produces | .agents/swarm/results/*.json |
 | `crank` | produces | git-changes |
 | `curate` | produces | .agents/research/*.md |
+| `deps` | consumes | repo-context |
 | `deps` | produces | result.json |
 | `design` | consumes | standards |
 | `design` | produces | result.json |

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T10:56:08Z",
+  "generated_at": "2026-05-23T11:10:34Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -751,7 +751,7 @@
     {
       "name": "deps",
       "source_skill": "skills/deps",
-      "source_hash": "cbacfed7919633a25aa1ca0b2cf623d8dbdcd42f766d1415691ebbc6eee9116a",
+      "source_hash": "bf84d65688cd3cf6fa0612460cc4c93e473e1fac1e4e5b2a40c4051df378a629",
       "generated_hash": "949d68e69e261c25a2fe420580289135e99a800706f1a7b4ef06fcc1807ce29f"
     },
     {

--- a/skills-codex/deps/.agentops-generated.json
+++ b/skills-codex/deps/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/deps",
   "layout": "modular",
-  "source_hash": "cbacfed7919633a25aa1ca0b2cf623d8dbdcd42f766d1415691ebbc6eee9116a",
+  "source_hash": "bf84d65688cd3cf6fa0612460cc4c93e473e1fac1e4e5b2a40c4051df378a629",
   "generated_hash": "949d68e69e261c25a2fe420580289135e99a800706f1a7b4ef06fcc1807ce29f"
 }

--- a/skills/deps/SKILL.md
+++ b/skills/deps/SKILL.md
@@ -6,7 +6,8 @@ practices:
 - continuous-delivery
 - sre
 hexagonal_role: driven-adapter
-consumes: []
+consumes:
+- repo-context
 produces:
 - result.json
 context_rel: []
@@ -305,3 +306,7 @@ File name format: `YYYY-MM-DD-deps-<mode>.md`
 - `skills/security/SKILL.md` -- Broader security scanning
 - `skills/vibe/SKILL.md` -- Code quality validation
 - [references/library-update-ratchet.md](references/library-update-ratchet.md)
+
+## Reference Documents
+
+- [references/deps.feature](references/deps.feature) — Executable spec: scan manifests, audit vulns/outdated/licenses, vuln+license modes, multi-ecosystem, result.json (soc-qk4b)

--- a/skills/deps/references/deps.feature
+++ b/skills/deps/references/deps.feature
@@ -1,0 +1,25 @@
+# Executable spec for the /deps skill — dependency risk audit (driven-adapter).
+# /deps scans the working directory's dependency manifests (go.mod, package.json, ...) and
+# audits them for vulnerabilities, outdated versions, and license risk — across multiple
+# coexisting ecosystems. Hexagon: driven-adapter; consumes repo-context; produces result.json.
+# (soc-qk4b)
+
+Feature: Deps audits dependency risks across ecosystems
+  As the dependency-risk auditor
+  I want the repo's manifests scanned for vulnerabilities, staleness, and license risk
+  So that dependency risk is surfaced before it ships
+
+  Scenario: audit scans the manifests and reports risk
+    When /deps audit runs
+    Then it scans the working directory for manifest files (go.mod, package.json, ...)
+    And it reports vulnerabilities, outdated dependencies, and license issues to result.json
+
+  Scenario: focused modes narrow the audit
+    When /deps vuln runs
+    Then it focuses on vulnerabilities and remediation
+    And /deps license focuses on license compliance
+
+  Scenario: multiple ecosystems are handled together
+    Given a repo with manifests for more than one ecosystem
+    When /deps runs
+    Then it audits each ecosystem's manifest, not just the first one found


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — full crank. /deps had EMPTY consumes despite scanning the working dir for manifests.

- frontmatter: consumes [] → [repo-context] (evidence: Step 0 scans go.mod/package.json/... manifests)
- skills/deps/references/deps.feature (NEW): audit scans manifests → vulns/outdated/licenses; vuln+license modes; multi-ecosystem
- context-map.md regenerated (deps←repo-context edge; deterministic); SKILL.md linked

How tested: lint-skills ✓ deps (312 lines, under cap); scenarios --lint 0 errors; codex parity passed; registry up to date; diff-stat clean.
Sibling: full crank like /status #459.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-ok9m8#deps-hexagon
Bounded-context: BC4-Validation
Evidence: skills/deps/references/deps.feature