### PR TITLE
feat(perf): hexagon consumes + executable acceptance for the profiler (soc-lyyff #perf-hexagon)

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -225,6 +225,7 @@ graph LR
 | `openai-docs` | consumes | external-api |
 | `oss-docs` | consumes | repo-context |
 | `oss-docs` | produces | documentation |
+| `perf` | consumes | repo-context |
 | `perf` | produces | result.json |
 | `plan` | consumes | standards |
 | `plan` | produces | .agents/plans/*.md |

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T11:10:34Z",
+  "generated_at": "2026-05-23T11:25:30Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -883,7 +883,7 @@
     {
       "name": "perf",
       "source_skill": "skills/perf",
-      "source_hash": "a92e5bc81a85021cd6551879eb96408571863f449ce7534c7466a03fb79131cb",
+      "source_hash": "7544f3db66a25fe598ab82f83de1d32bba12d6581d4f117695c79cbfc717dbaf",
       "generated_hash": "b69c1095b3e8e7e2a30844642ac4c64defa7980e14bb5d5e8a71ab13405c23c4"
     },
     {

--- a/skills-codex/perf/.agentops-generated.json
+++ b/skills-codex/perf/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/perf",
   "layout": "modular",
-  "source_hash": "a92e5bc81a85021cd6551879eb96408571863f449ce7534c7466a03fb79131cb",
+  "source_hash": "7544f3db66a25fe598ab82f83de1d32bba12d6581d4f117695c79cbfc717dbaf",
   "generated_hash": "b69c1095b3e8e7e2a30844642ac4c64defa7980e14bb5d5e8a71ab13405c23c4"
 }

--- a/skills/perf/SKILL.md
+++ b/skills/perf/SKILL.md
@@ -6,7 +6,8 @@ practices:
 - sre
 - code-complete
 hexagonal_role: domain
-consumes: []
+consumes:
+- repo-context
 produces:
 - result.json
 context_rel:
@@ -339,6 +340,8 @@ COMPARISON: baseline vs candidate
 - [vibe](../vibe/SKILL.md) — Validate optimized code quality
 
 ## Reference Documents
+
+- [references/perf.feature](references/perf.feature) — Executable spec: profile hotspots with metrics, bench, compare-regression, optimize (soc-qk4b)
 
 - [references/profiling-playbook.md](references/profiling-playbook.md)
 - [references/system-pressure-triage.md](references/system-pressure-triage.md)

--- a/skills/perf/references/perf.feature
+++ b/skills/perf/references/perf.feature
@@ -1,0 +1,23 @@
+# Executable spec for the /perf skill — profiling + optimization (domain role).
+# /perf profiles a target's execution to find hotspots, benchmarks it, detects regressions
+# between a baseline and candidate, and recommends/applies optimizations — producing actionable
+# metrics, not vague advice. Hexagon: domain; consumes repo-context (it profiles the repo's
+# code/runtime); produces result.json; shared-kernel with standards. (soc-qk4b)
+
+Feature: Perf profiles and optimizes hotspots with actionable metrics
+  As the performance analyzer
+  I want a target profiled for hotspots and optimizations grounded in measurements
+  So that performance work targets real bottlenecks, not guesses
+
+  Scenario: profile finds hotspots with metrics
+    When /perf profile <target> runs
+    Then it profiles the target's execution and reports the hotspots with measured metrics
+    And the output is actionable metrics, not vague advice
+
+  Scenario: compare detects a regression between baseline and candidate
+    When /perf compare <baseline> <candidate> runs
+    Then it reports the performance delta and flags a regression when the candidate is slower
+
+  Scenario: optimize recommends or applies changes
+    When /perf optimize <target> runs
+    Then it analyzes the hotspots and recommends (or applies) optimizations grounded in the profile


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — full crank. /perf had EMPTY consumes despite profiling a target in the repo.

- frontmatter: consumes [] → [repo-context] (evidence: profiles a <target>, detects language from manifests, profiles the code)
- skills/perf/references/perf.feature (NEW): profile→hotspots+metrics; compare→regression; optimize→profile-grounded changes
- context-map.md regenerated (perf←repo-context edge; deterministic); SKILL.md linked

How tested: lint-skills ✓ perf (348 lines, under cap); scenarios --lint 0 errors; codex parity passed; registry up to date; diff-stat clean.
Sibling: full crank like /deps #460.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-lyyff#perf-hexagon
Bounded-context: BC4-Validation
Evidence: skills/perf/references/perf.feature