### PR TITLE
feat(red-team): hexagon consumes + executable acceptance for usability probing (soc-k37pg #red-team-hexagon)

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -259,6 +259,7 @@ graph LR
 | `ratchet` | produces | .agents/rpi/*.md |
 | `readme` | produces | documentation |
 | `recover` | produces | .agents/rpi/*.md |
+| `red-team` | consumes | repo-context |
 | `red-team` | produces | result.json |
 | `refactor` | produces | git-changes |
 | `release` | produces | result.json |

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T11:25:30Z",
+  "generated_at": "2026-05-23T11:40:40Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -985,7 +985,7 @@
     {
       "name": "red-team",
       "source_skill": "skills/red-team",
-      "source_hash": "ac333fdea9c2517d8e9dd86a10fecd6aa0e0ee277690222917b2285c707f553a",
+      "source_hash": "db0a03ef08c3e97f7085ac3bd0622752010304777b20fcabf9a043192d385038",
       "generated_hash": "5b154a7fa29e162df34f7e765a75cfe8a9335e65e1fd13d388d6b46c514bef1d"
     },
     {

--- a/skills-codex/red-team/.agentops-generated.json
+++ b/skills-codex/red-team/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/red-team",
   "layout": "modular",
-  "source_hash": "ac333fdea9c2517d8e9dd86a10fecd6aa0e0ee277690222917b2285c707f553a",
+  "source_hash": "db0a03ef08c3e97f7085ac3bd0622752010304777b20fcabf9a043192d385038",
   "generated_hash": "5b154a7fa29e162df34f7e765a75cfe8a9335e65e1fd13d388d6b46c514bef1d"
 }

--- a/skills/red-team/SKILL.md
+++ b/skills/red-team/SKILL.md
@@ -6,7 +6,8 @@ practices:
 - design-by-contract
 - sre
 hexagonal_role: supporting
-consumes: []
+consumes:
+- repo-context
 produces:
 - result.json
 context_rel: []
@@ -334,6 +335,8 @@ Instead:
 - [skills/bug-hunt/SKILL.md](../bug-hunt/SKILL.md) — Systematic audit (closest cousin)
 
 ## Reference Documents
+
+- [references/red-team.feature](references/red-team.feature) — Executable spec: persona attempts real tasks against a surface, reports what breaks, distinct from council/vibe, --surface selects target (soc-qk4b)
 
 - [references/persona-format.md](references/persona-format.md) — Persona YAML schema with context restriction fields
 - [references/scenario-format.md](references/scenario-format.md) — Scenario YAML schema with pass/fail criteria

--- a/skills/red-team/references/red-team.feature
+++ b/skills/red-team/references/red-team.feature
@@ -1,0 +1,23 @@
+# Executable spec for the /red-team skill — usability probing (supporting role).
+# /red-team adopts constrained personas and ATTEMPTS REAL TASKS against a surface (a doc or a
+# skill) to find where it breaks in actual use — distinct from /council (expert judgment) and
+# /vibe (code quality). Hexagon: supporting; consumes repo-context (it probes the repo's docs/
+# skills); produces result.json. (soc-qk4b)
+
+Feature: Red-team probes whether docs and skills actually work in use
+  As a usability adversary
+  I want a surface attempted by a constrained persona doing real tasks
+  So that gaps that only appear when someone TRIES to use it are found
+
+  Scenario: a persona attempts real tasks against a surface
+    When /red-team --surface=docs <target> runs
+    Then it adopts a constrained persona and attempts the real tasks the surface claims to support
+    And it reports what breaks (result.json)
+
+  Scenario: it tests usability, not judgment or code quality
+    Then /red-team tests whether the surface actually WORKS when used
+    And this is distinct from /council (expert judgment) and /vibe (code quality)
+
+  Scenario: the surface selects the probe target
+    When --surface is given
+    Then the probe targets that surface type (docs, skills) rather than guessing


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — full crank. /red-team had EMPTY consumes despite probing a surface (docs/skills = repo files).

- frontmatter: consumes [] → [repo-context] (evidence: probes docs/ or a skill's SKILL.md — repo files; --surface=docs <target>)
- skills/red-team/references/red-team.feature (NEW): persona attempts real tasks → reports what breaks; usability-not-judgment/code-quality; --surface selects target
- context-map.md regenerated (red-team←repo-context edge; deterministic); SKILL.md linked

How tested: lint-skills ✓ red-team (344 lines, under cap); scenarios --lint 0 errors; codex parity passed; registry up to date; diff-stat clean.
Sibling: full crank like /perf #461.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-k37pg#red-team-hexagon
Bounded-context: BC4-Validation
Evidence: skills/red-team/references/red-team.feature