### PR TITLE
feat(refactor): hexagon consumes + executable acceptance for safe refactoring (soc-ntzpd #refactor-hexagon)

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -261,6 +261,8 @@ graph LR
 | `recover` | produces | .agents/rpi/*.md |
 | `red-team` | consumes | repo-context |
 | `red-team` | produces | result.json |
+| `refactor` | consumes | complexity |
+| `refactor` | consumes | repo-context |
 | `refactor` | produces | git-changes |
 | `release` | produces | result.json |
 | `research` | consumes | inject |

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T11:40:40Z",
+  "generated_at": "2026-05-23T11:56:29Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -991,7 +991,7 @@
     {
       "name": "refactor",
       "source_skill": "skills/refactor",
-      "source_hash": "b158612457dd86eb0f546b2f8a0b865f29b80990dcd2de4bbd8d4ff20c178296",
+      "source_hash": "8fbe28a9e7800948415df827620a867a7dca40580ed5c37d8031c24832e61136",
       "generated_hash": "50b2fe5acbb2e6266f1bd15f3f2eb065e7d1ead4d3dc144cc167094062666663"
     },
     {

--- a/skills-codex/refactor/.agentops-generated.json
+++ b/skills-codex/refactor/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/refactor",
   "layout": "modular",
-  "source_hash": "b158612457dd86eb0f546b2f8a0b865f29b80990dcd2de4bbd8d4ff20c178296",
+  "source_hash": "8fbe28a9e7800948415df827620a867a7dca40580ed5c37d8031c24832e61136",
   "generated_hash": "50b2fe5acbb2e6266f1bd15f3f2eb065e7d1ead4d3dc144cc167094062666663"
 }

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -6,7 +6,9 @@ practices:
 - legacy-code-seams
 - design-patterns
 hexagonal_role: supporting
-consumes: []
+consumes:
+- complexity
+- repo-context
 produces:
 - git-changes
 context_rel: []
@@ -446,5 +448,7 @@ explicitly excluded with `--exclude` and justified in the closeout.
 - `/implement` -- if refactoring requires new code
 
 ## Reference Documents
+
+- [references/refactor.feature](references/refactor.feature) — Executable spec: one transformation/one test/one commit, target + hotspot (complexity-first) modes, revert on test fail (soc-qk4b)
 
 - [references/behavior-preserving-simplification.md](references/behavior-preserving-simplification.md)

--- a/skills/refactor/references/refactor.feature
+++ b/skills/refactor/references/refactor.feature
@@ -1,0 +1,27 @@
+# Executable spec for the /refactor skill — safe incremental refactoring (supporting role).
+# /refactor transforms code one step at a time with test verification — one transformation, one
+# test run, one commit, never batched — preserving behavior. Target mode refactors a chosen unit;
+# sweep mode (--sweep) runs /complexity first to pick targets. Hexagon: supporting; consumes
+# complexity (sweep targeting) + repo-context (the code it transforms); produces git-changes. (soc-qk4b)
+
+Feature: Refactor executes safe incremental transformations
+  As the safe-refactoring step
+  I want each transformation verified by tests before the next
+  So that refactors never silently change behavior
+
+  Scenario: one transformation, one test run, one commit
+    When /refactor applies a transformation
+    Then it runs the tests, then commits that single transformation
+    And transformations are not batched together
+
+  Scenario: a failing test reverts the transformation
+    When a transformation makes a test fail
+    Then that transformation is reverted and behavior is preserved
+
+  Scenario: sweep mode targets by complexity
+    When /refactor --sweep runs over a directory
+    Then it runs /complexity first to identify targets and works highest-complexity first
+
+  Scenario: target mode refactors a chosen unit
+    When /refactor runs on a specific file, function, or class
+    Then it refactors that unit directly, step by step


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — full crank. /refactor had EMPTY consumes despite reading code + running /complexity in sweep mode.

- frontmatter: consumes [] → [complexity, repo-context] (evidence: --sweep runs /complexity first; all modes read/transform the code)
- skills/refactor/references/refactor.feature (NEW): one-transform/one-test/one-commit, revert-on-fail, --sweep complexity-first, target mode
- context-map.md regenerated (refactor←complexity + refactor←repo-context; deterministic); SKILL.md linked

How tested: lint-skills ✓ refactor (454 lines, under cap); scenarios --lint 0 errors; codex parity passed; registry up to date; diff-stat clean.
Sibling: full crank like /red-team #462.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-ntzpd#refactor-hexagon
Bounded-context: BC5-Runtime
Evidence: skills/refactor/references/refactor.feature