### PR TITLE
feat(test): hexagon consumes + executable acceptance for test generation (soc-5c5ds #test-hexagon)

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -306,6 +306,8 @@ graph LR
 | `swarm` | consumes | implement |
 | `swarm` | consumes | vibe |
 | `swarm` | produces | .agents/swarm/results/*.json |
+| `test` | consumes | repo-context |
+| `test` | consumes | standards |
 | `test` | produces | result.json |
 | `trace` | produces | result.json |
 | `using-agentops` | produces | documentation |

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T11:56:29Z",
+  "generated_at": "2026-05-23T12:13:59Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -991,7 +991,7 @@
     {
       "name": "refactor",
       "source_skill": "skills/refactor",
-      "source_hash": "8fbe28a9e7800948415df827620a867a7dca40580ed5c37d8031c24832e61136",
+      "source_hash": "b63658e56a390ccfb975aa323ba31010b2f90f4f37fca7fe0b16896e10013e4a",
       "generated_hash": "50b2fe5acbb2e6266f1bd15f3f2eb065e7d1ead4d3dc144cc167094062666663"
     },
     {
@@ -1117,7 +1117,7 @@
     {
       "name": "test",
       "source_skill": "skills/test",
-      "source_hash": "18e07d8d479701e7676f8fc1cd98a5f35c77e0a2de50c30a4097d2f7e2d52cb4",
+      "source_hash": "af67a4b2deb93603a63042248339912e700ab78466ba296967498d2b40abae5b",
       "generated_hash": "510f4eb94d65818d57b432f8a7396f98a7732aa66bae54310375d48386f9a892"
     },
     {

--- a/skills-codex/refactor/.agentops-generated.json
+++ b/skills-codex/refactor/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/refactor",
   "layout": "modular",
-  "source_hash": "8fbe28a9e7800948415df827620a867a7dca40580ed5c37d8031c24832e61136",
+  "source_hash": "b63658e56a390ccfb975aa323ba31010b2f90f4f37fca7fe0b16896e10013e4a",
   "generated_hash": "50b2fe5acbb2e6266f1bd15f3f2eb065e7d1ead4d3dc144cc167094062666663"
 }

--- a/skills-codex/test/.agentops-generated.json
+++ b/skills-codex/test/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/test",
   "layout": "modular",
-  "source_hash": "18e07d8d479701e7676f8fc1cd98a5f35c77e0a2de50c30a4097d2f7e2d52cb4",
+  "source_hash": "af67a4b2deb93603a63042248339912e700ab78466ba296967498d2b40abae5b",
   "generated_hash": "510f4eb94d65818d57b432f8a7396f98a7732aa66bae54310375d48386f9a892"
 }

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -6,7 +6,9 @@ practices:
 - property-based-testing
 - bdd-gherkin
 hexagonal_role: supporting
-consumes: []
+consumes:
+- standards
+- repo-context
 produces:
 - result.json
 context_rel: []
@@ -397,3 +399,7 @@ All artifacts are written to `.agents/test/`:
 | `summary.md` | Before/after coverage delta and test inventory |
 | `tdd-log.md` | TDD cycle log (tdd mode only) |
 | `strategy.md` | Test architecture recommendations (strategy mode only) |
+
+## Reference Documents
+
+- [references/test.feature](references/test.feature) — Executable spec: load standards + detect language, generate real passing tests (not a plan), coverage gap-fill, artifacts in .agents/test/ (soc-qk4b)

--- a/skills/test/references/test.feature
+++ b/skills/test/references/test.feature
@@ -1,0 +1,23 @@
+# Executable spec for the /test skill — test generation + coverage (supporting role).
+# /test loads the language's test standards, generates REAL tests for existing code, runs them to
+# verify they pass (it does not stop at a plan), and fills coverage gaps — writing artifacts to
+# .agents/test/. Hexagon: supporting; consumes standards (test conventions) + repo-context (the
+# code under test); produces result.json. (soc-qk4b)
+
+Feature: Test generates real, passing tests and coverage
+  As the test-generation step
+  I want tests generated to the project's standards and verified by running them
+  So that coverage improves with real passing tests, not a plan
+
+  Scenario: standards and language are loaded before generating
+    When /test runs
+    Then it detects the language and loads the test standards (AI-native test shape) for it
+
+  Scenario: generate produces real tests that are run and verified
+    When /test generate runs on existing code
+    Then it writes real tests, runs them, and verifies they pass
+    And it does not output a plan and stop
+
+  Scenario: coverage analyzes and fills gaps
+    When /test coverage runs
+    Then it analyzes coverage gaps and fills them, writing a coverage report to .agents/test/


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — full crank. /test had EMPTY consumes despite loading standards + reading code.

- frontmatter: consumes [] → [standards, repo-context] (evidence: Step 0 loads /standards; generate reads existing code)
- skills/test/references/test.feature (NEW): load-standards-first; generate real passing tests (not a plan); coverage gap-fill → .agents/test/
- context-map.md regenerated (test←standards + test←repo-context); SKILL.md linked

Incidental: regen also fixed /refactor's stale codex source_hash (#463 follow-on, .feature edited after final regen). Deterministic across 2 checkouts; needed for codex-drift gate.

How tested: lint-skills ✓ test (405 lines); scenarios --lint 0 errors; regen --check all up to date; registry up to date.
Sibling: full crank like /refactor #463.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-5c5ds#test-hexagon
Bounded-context: BC4-Validation
Evidence: skills/test/references/test.feature