### PR TITLE
feat(doc): hexagon consumes + executable acceptance for repo documentation (soc-vltp0 #doc-hexagon)

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -203,6 +203,7 @@ graph LR
 | `discovery` | produces | .agents/plans/*.md |
 | `discovery` | produces | bd-issue |
 | `discovery` | produces | execution-packet.json |
+| `doc` | consumes | repo-context |
 | `doc` | produces | documentation |
 | `domain` | produces | stdout |
 | `dream` | produces | .agents/research/*.md |

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T12:13:59Z",
+  "generated_at": "2026-05-23T12:30:26Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -769,7 +769,7 @@
     {
       "name": "doc",
       "source_skill": "skills/doc",
-      "source_hash": "2b1d5614b63e8f75224fa1e296319ca2ae9eeb2ca072a3e780b97100e2d941c8",
+      "source_hash": "12bbfa1935f187b3069b7d553cfd8fa4b55522c55cf60f2f70fc7ee5ecc04e2f",
       "generated_hash": "e0e17f12248492ce38b765675d8ca18de91ca47e12a59e4e4bed017b244beea6"
     },
     {

--- a/skills-codex/doc/.agentops-generated.json
+++ b/skills-codex/doc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/doc",
   "layout": "modular",
-  "source_hash": "2b1d5614b63e8f75224fa1e296319ca2ae9eeb2ca072a3e780b97100e2d941c8",
+  "source_hash": "12bbfa1935f187b3069b7d553cfd8fa4b55522c55cf60f2f70fc7ee5ecc04e2f",
   "generated_hash": "e0e17f12248492ce38b765675d8ca18de91ca47e12a59e4e4bed017b244beea6"
 }

--- a/skills/doc/SKILL.md
+++ b/skills/doc/SKILL.md
@@ -6,7 +6,8 @@ practices:
 - code-complete
 - pragmatic-programmer
 hexagonal_role: supporting
-consumes: []
+consumes:
+- repo-context
 produces:
 - documentation
 context_rel: []
@@ -265,6 +266,8 @@ Tell the user:
 | Validation shows docs out of sync | Code changed after docs written | Re-run `gen` command for affected features. Consider adding git hook to flag doc updates needed when code changes. |
 
 ## Reference Documents
+
+- [references/doc.feature](references/doc.feature) — Executable spec: detect project type, generate type-appropriate docs from the repo, validate existing docs against source (soc-qk4b)
 
 - [references/generation-templates.md](references/generation-templates.md)
 - [references/prose-and-report-workmanship.md](references/prose-and-report-workmanship.md)

--- a/skills/doc/references/doc.feature
+++ b/skills/doc/references/doc.feature
@@ -1,0 +1,22 @@
+# Executable spec for the /doc skill — repo documentation (supporting role).
+# /doc reads the project (source, existing docs) to detect its type, then generates and validates
+# documentation appropriate to that type — API docs for code projects, structure for informational
+# ones. Hexagon: supporting; consumes repo-context; produces documentation. (soc-qk4b)
+
+Feature: Doc generates and validates project documentation
+  As the documentation step
+  I want docs generated from the repo and existing docs validated against it
+  So that documentation matches the project's type and current state
+
+  Scenario: project type is detected before generating
+    When /doc runs
+    Then it inspects the repo and classifies it (coding project needing API docs vs informational)
+
+  Scenario: generated docs fit the project type
+    When /doc generates documentation
+    Then the output suits the detected type (API reference for code, structure for informational)
+    And it is drawn from the repo's actual source and existing docs
+
+  Scenario: validation checks docs against the repo
+    When /doc validates existing documentation
+    Then it reports gaps or staleness measured against the current source


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — full crank. /doc had EMPTY consumes despite reading source + existing docs.

- frontmatter: consumes [] → [repo-context] (evidence: Step 1 detects type from manifests; reads source to document)
- skills/doc/references/doc.feature (NEW): detect type; type-appropriate docs from source; validate existing docs vs source
- context-map.md regenerated (doc←repo-context edge; deterministic); SKILL.md linked

How tested: lint-skills ✓ doc (277 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: full crank like /test #464.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-vltp0#doc-hexagon
Bounded-context: BC1-Corpus
Evidence: skills/doc/references/doc.feature