### PR TITLE
feat(recover): hexagon consumes + executable acceptance for session recovery (soc-nc7mj #recover-hexagon)

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -259,6 +259,8 @@ graph LR
 | `ratchet` | consumes | vibe |
 | `ratchet` | produces | .agents/rpi/*.md |
 | `readme` | produces | documentation |
+| `recover` | consumes | bd |
+| `recover` | consumes | rpi |
 | `recover` | produces | .agents/rpi/*.md |
 | `red-team` | consumes | repo-context |
 | `red-team` | produces | result.json |

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T12:30:26Z",
+  "generated_at": "2026-05-23T12:47:22Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -979,7 +979,7 @@
     {
       "name": "recover",
       "source_skill": "skills/recover",
-      "source_hash": "1c9495b656485e996d272adf21aef28c439c18ebdae0dbde2f84bf46d77c2ca5",
+      "source_hash": "706e8f620cd75317a0a5decc29d17e7d98aa4d82623ff4211219845bf63e2d25",
       "generated_hash": "97e2e5a925565c378fa29fdc730b6a28ec539eb5710bc564ac69a6c991398b0b"
     },
     {

--- a/skills-codex/recover/.agentops-generated.json
+++ b/skills-codex/recover/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/recover",
   "layout": "modular",
-  "source_hash": "1c9495b656485e996d272adf21aef28c439c18ebdae0dbde2f84bf46d77c2ca5",
+  "source_hash": "706e8f620cd75317a0a5decc29d17e7d98aa4d82623ff4211219845bf63e2d25",
   "generated_hash": "97e2e5a925565c378fa29fdc730b6a28ec539eb5710bc564ac69a6c991398b0b"
 }

--- a/skills/recover/SKILL.md
+++ b/skills/recover/SKILL.md
@@ -6,7 +6,9 @@ practices:
 - legacy-code-seams
 - pragmatic-programmer
 hexagonal_role: driving-adapter
-consumes: []
+consumes:
+- bd
+- rpi
 produces:
 - .agents/rpi/*.md
 context_rel: []
@@ -360,3 +362,7 @@ Render this with a single code block. No visual dashboard when `--json` is activ
 | Knowledge injection fails silently | ao CLI not installed or no knowledge artifacts | Ensure ao installed: `brew install ao`. If no learnings exist, run `/validation` to seed the knowledge base. |
 | Suggested action doesn't match context | State-aware rules didn't capture edge case | Use `--json` to inspect raw state and verify which condition matched. Review priority table in Step 5. |
 | JSON output malformed | Parallel bash calls returned unexpected format | Check each bash call individually. Ensure jq parsing works on actual data. Validate JSON structure before returning to user. |
+
+## Reference Documents
+
+- [references/recover.feature](references/recover.feature) — Executable spec: detect rpi phase from phased-state, surface claimed/ready bd work, recent git, --json dashboard (soc-qk4b)

--- a/skills/recover/references/recover.feature
+++ b/skills/recover/references/recover.feature
@@ -1,0 +1,26 @@
+# Executable spec for the /recover skill — session-context recovery (driving-adapter).
+# /recover reconstructs where a session left off: the rpi lifecycle phase from
+# .agents/rpi/phased-state.json, the claimed/ready work from bd, and recent git state — rendered
+# as a recovery dashboard (or JSON). Hexagon: driving-adapter; consumes bd + rpi; produces
+# .agents/rpi/*.md. (soc-qk4b)
+
+Feature: Recover reconstructs in-progress session context
+  As an agent resuming after a break or compaction
+  I want the prior session's lifecycle phase and claimed work surfaced
+  So that I continue where I left off instead of starting cold
+
+  Scenario: the rpi lifecycle phase is detected
+    When /recover runs
+    Then it reads .agents/rpi/phased-state.json (when present) and reports the current phase
+
+  Scenario: claimed and ready work is surfaced from bd
+    When /recover runs
+    Then it reports in-progress and ready issues from bd
+
+  Scenario: recent git state is included
+    When /recover runs
+    Then it shows the current branch, recent commits, and uncommitted changes
+
+  Scenario: machine-readable output on demand
+    When /recover --json runs
+    Then it emits the recovery state as structured JSON


### PR DESCRIPTION
soc-qk4b skill-hexagon-crank — full crank. /recover had EMPTY consumes despite reading rpi phased-state + bd work queue.

- frontmatter: consumes [] → [bd, rpi] (evidence: Call 1 reads .agents/rpi/phased-state.json; Call 4 reads bd in-progress/ready)
- skills/recover/references/recover.feature (NEW): detect rpi phase; surface bd work; recent git; --json
- context-map.md regenerated (recover←bd + recover←rpi edges; deterministic); SKILL.md linked

How tested: lint-skills ✓ recover (368 lines); scenarios --lint 0 errors; codex parity passed; registry up to date.
Sibling: full crank like /doc #466.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-nc7mj#recover-hexagon
Bounded-context: BC5-Runtime
Evidence: skills/recover/references/recover.feature