### PR TITLE
docs(3.0): canonical 3.0 north star + weave into sources of truth (soc-25sgs #3.0-north-star)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ Source of truth: append-only JSONL at `docs/provenance/ledger.jsonl` (schema `ag
 
 ### Doctrine altitudes
 
+- **North star:** [`docs/3.0.md`](docs/3.0.md) — what AgentOps 3.0 is (hookless-first CDLC, the SDLC↔CDLC loop, the four-practice waist). The single source of truth; everything below is consistent with it.
 - **Spine:** [`docs/architecture/operating-loop.md`](docs/architecture/operating-loop.md) — 7-move agent doctrine. **Primary navigation.**
 - **One turn's executor:** `/rpi` skill. NOT primary.
 - **Architecture:** 5 Bounded Contexts (BC1 Corpus → BC5 Runtime). Where code lives.

--- a/GOALS.md
+++ b/GOALS.md
@@ -2,6 +2,8 @@
 
 An SDLC control plane for agentic software development, backed by a repo-native wiki for your agents that turns context into the durable moat under any model or harness.
 
+> Canonical 3.0 definition: [docs/3.0.md](docs/3.0.md). The directives below are measured against it.
+
 ## North Stars
 
 <!-- agentops:claim:AOP-CLAIM-GOALS-DREAM-VALIDATED -->

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -8,6 +8,8 @@ last_reviewed: 2026-05-15
 
 **AgentOps is an SDLC control plane for agentic software development.** It automates the discipline of building a wiki for your agents: markdown in `.agents/` next to your code, produced and consumed by the agents that work there. The compounded corpus is the moat. The internal lifecycle is the CDLC: context is developed, tested, delivered, observed, and improved because context is what LLM agents consume.
 
+> The canonical definition of what 3.0 is — the hookless-first CDLC loop and the four-practice waist — lives in [docs/3.0.md](docs/3.0.md). This file is consistent with it.
+
 ## Product Identity
 
 AgentOps is the SDLC control plane for agent teams: software-engineering practice encoded for LLM agents under token scarcity.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ AgentOps sits on top of the coding harness you already use (Claude Code, Codex, 
 
 *This repo was built with AgentOps. As of 2026-05-04 its `.agents/` held ~1,842 learnings, ~186 patterns, ~80 planning rules, and ~3,867 cited decisions captured during development. Re-run anytime: `bash scripts/corpus-stats.sh`.*
 
+**New here? Start with [what AgentOps 3.0 is](docs/3.0.md) — the hookless-first CDLC north star.**
+
 </div>
 
 ---
@@ -296,6 +298,7 @@ Full reference: [CLI Commands](cli/docs/COMMANDS.md).
 
 | Topic | Where |
 |-------|-------|
+| **What 3.0 is (north star)** | [docs/3.0.md](docs/3.0.md) |
 | Published site | [boshu2.github.io/agentops](https://boshu2.github.io/agentops/) |
 | Start navigating | [Docs index](docs/documentation-index.md) |
 | New contributor orientation | [Newcomer guide](docs/newcomer-guide.md) |

--- a/docs/3.0.md
+++ b/docs/3.0.md
@@ -1,0 +1,87 @@
+# AgentOps 3.0: the north star
+
+> **This is the single source of truth for what AgentOps 3.0 is.** Decision record: [ADR-0002](adr/ADR-0002-agentops-3-hookless-cdlc-rearchitecture.md). Mechanism: [docs/cdlc.md](cdlc.md). Execution discipline: [operating-loop.md](architecture/operating-loop.md). Seams: [ports-and-adapters.md](architecture/ports-and-adapters.md). Everything else in the repo should be consistent with this page; when a doc disagrees, this page and the executable behavior win.
+
+AgentOps 3.0 encodes the best of software engineering into **compact, verifiable, reusable agent context**. The core product is software-engineering practice turned into context an agent carries across sessions, models, and harnesses, not a hook bundle.
+
+---
+
+## The 3.0 loop (the whole product, in one picture)
+
+The SDLC is a loop for producing reliable **code** from non-deterministic humans. The **CDLC** (Context Development Life Cycle) is the same loop for producing reliable **context** for non-deterministic agents. 3.0 runs that loop:
+
+```
+SDLC (code)  ─────────────  CDLC (context — the same loop)
+
+intent  ──▶  behavior, written as BDD / Gherkin     ← behavior-driven PLANNING
+            (Given / When / Then is the plan)
+        ──▶  tests derived from the behavior          ← TDD: the behavior's executable proof
+        ──▶  implement inside ONE bounded context     ← DDD vocabulary + boundaries
+             through explicit ports                    ← hexagonal seams (domain never imports the shell)
+        ──▶  validate BOTH ENDS against behaviors + contracts
+               entry: does the planned behavior hold up?   (/pre-mortem, /council)
+               exit:  does the implementation satisfy it?   (/vibe, CI gates)
+        ──▶  feedback: pass/fail on behavior + contract IS "is it good?"
+        ──▶  ratchet the learning back into the corpus  ← compounding, dense
+        └───────────────────────── loop ──────────────────────────┘
+```
+
+**Behavior is the plan. Tests come from behavior. Contracts and behaviors are what you validate on each end of an implementation; that is how the system feeds back whether the work is good.** Between every step, **context density** is the rule: every high-value token carries intent, a boundary, evidence, a decision, a constraint, or a next action, and nothing else, so the loop stays cheap.
+
+---
+
+## The four load-bearing practices (the narrow waist)
+
+3.0 introduces **no new methodology**. It composes four proven practices into a small, executable waist, and everything else attaches to it:
+
+| Practice | What it gives the agent |
+|---|---|
+| **BDD / Gherkin** | Observable intent as behavior; the densest signal-per-token planning channel there is |
+| **DDD** | Shared vocabulary and bounded contexts humans and agents both use |
+| **Hexagonal (ports & adapters)** | Explicit seams: the domain core never imports the runtime; tools, vendors, and hooks live outside as adapters |
+| **TDD** | A local, executable done-condition for every slice |
+
+Around the waist: CI/CD repeats the proof, SRE/DORA measure fitness, ADRs and provenance preserve why-memory, the wiki and ratchet preserve durable learning, Agile/XP keeps work in vertical slices. The atomic unit is **one behavior, one bounded context, one failing test, one write scope, one acceptance proof**. A new learning is added only when it would change a future run.
+
+---
+
+## Hookless-first: density over noise
+
+"Hookless-first" is the most misunderstood part, so be precise:
+
+**It does not mean "no hooks." It means context flows through explicit, bounded channels instead of being injected as noise.**
+
+- **The 2.x failure mode:** hooks were the architecture. Dozens fired on every event and *pushed* context into the window: standards for files you weren't touching, learnings that didn't apply, warnings that didn't fire. Resident context stacked (a real RPI run hit ~10.35M tokens at 97.6% cache-read), and the A/B eval showed the injected context made **no difference (Δ = 0)**. The problem was never hooks; it was **noise stacking in the prompt**.
+- **The 3.0 model:** context is *pulled* through explicit channels: **BDD/Gherkin** for intent, **execution/context packets through ports** for the phase-scoped working set, **hexagonal boundaries** for the seams. Dense and just-in-time, not stacked.
+- **Hooks are demoted from architectural primitive to optional adapter.** They stay for the bounded, intentional jobs they are good at: a gate that blocks a dangerous operation, a fail-open session bootstrap, a parity check. What they stop doing is spraying noise into every prompt. The default install works with **zero** hooks; when hooks are present, they help quietly.
+
+The rule in one line: **hooks may help, but they must not inject random noise.**
+
+---
+
+## What "3.0-ready" means
+
+3.0-ready is **reconciled, hardened, and grounded**: the repo matches reality and the doctrine is encoded end-to-end.
+
+- [ ] This north star is the single referenced source of truth; the sources of truth (README, PRODUCT, GOALS, docs index) point here.
+- [ ] **Docs match reality:** no aspirational claims in live docs, no dead code, no stale paths or counts, no unsubstantiated market claims.
+- [ ] **Hexagon complete:** every skill carries `hexagonal_role` plus accurate `consumes`/`produces` plus canonical `.feature` acceptance (the `soc-qk4b` crank).
+- [ ] **Hooks audited for noise:** every hook is a bounded adapter or a gate, none a noise-injector.
+- [ ] **The loop is executable:** BDD intent → tests → bounded build → both-ends validation → ratchet, demonstrable end-to-end.
+- [ ] Every AgentOps bead is worked or closed against this north star.
+
+**Follow-on (not a blocker for the 3.0 close):** the full hookless default-install plus hookless RPI lift (ADR-0002 S2–S5), tracked separately.
+
+---
+
+## Non-goals (settled)
+
+- No new practices or methodology; 3.0 is composition, not invention.
+- No coupling to a consumer's domain vocabulary; bounded contexts are named by the consuming repo.
+- No new required tooling; `bd`, the ratchet, and existing gates carry the load.
+- No required cloud, telemetry, or hosted control plane; state lives in `.agents/` in your repo and is portable across model and harness.
+- Hooks-as-default-primitive: abandoned (the A/B Δ = 0 result).
+
+---
+
+*Canonical references: [ADR-0002](adr/ADR-0002-agentops-3-hookless-cdlc-rearchitecture.md) · [cdlc.md](cdlc.md) · [operating-loop.md](architecture/operating-loop.md) · [ports-and-adapters.md](architecture/ports-and-adapters.md) · [PRODUCT.md](../PRODUCT.md) · [GOALS.md](../GOALS.md)*

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -9,6 +9,7 @@
 - [README](https://github.com/boshu2/agentops/blob/main/README.md) — Project overview and quick start
 - [Getting Started](getting-started/index.md) — Install + first command landing page
 - [PRACTICE-REGISTRY.md](https://github.com/boshu2/agentops/blob/main/PRACTICE-REGISTRY.md) — Practice lineage and canonical `practices: [slug]` registry
+- [AgentOps 3.0 — the north star](3.0.md) — The single source of truth for what 3.0 is: the hookless-first CDLC loop, the four-practice waist (BDD/DDD/Hexagonal/TDD), and what "3.0-ready" means
 - [AgentOps 3.0 Explainer Kit](agentops-3-explainer-kit.md) — Public gist/launch copy for the council-first 3.0 story
 - [AgentOps 3.0 First-Value Path](first-value-path.md) — First-session path from install to domain packet, council verdict, tracked work, and optional daemon lane
 - [AgentOps 3.0 YouTube Starter Series](agentops-3-youtube-starter-series.md) — Launch video plan, scripts, clip hooks, CTAs, and PMF measurement fields

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
   - Home: index.md
   - Getting Started:
       - getting-started/index.md
+      - "AgentOps 3.0 (North Star)": 3.0.md
       - Newcomer Guide: newcomer-guide.md
       - Create Your First Skill: create-your-first-skill.md
       - Behavioral Discipline: behavioral-discipline.md


### PR DESCRIPTION
W0 of the 3.0 reconciliation (operator-ratified). Grounds the repo before reconciliation work.

- **docs/3.0.md (NEW)** — single source of truth: the SDLC↔CDLC loop (BDD/Gherkin planning → tests → bounded build through ports → both-ends behavior+contract validation → feedback → ratchet), the BDD/DDD/Hexagonal/TDD waist, context density, and a precise hookless-first explanation (hooks = quiet adapters, not noise-injectors). + 3.0-ready acceptance + non-goals.
- Woven into README, PRODUCT.md, GOALS.md, CLAUDE.md, docs/documentation-index.md, mkdocs.yml nav.

Pure grounding: no code, no bead closes, no features. Links verified; additions-only.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-25sgs#3.0-north-star
Bounded-context: BC1-Corpus
Evidence: docs/3.0.md