### PR TITLE
fix(docs): correct the false "dead RPI code" claim — files are load-bearing (soc-furq8 #w1a-match-reality)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Source of truth: append-only JSONL at `docs/provenance/ledger.jsonl` (schema `ag
 - **Multi-phase work:** Route through `ao rpi` (enforces timeouts and stall detection).
 - **Before spawning workers:** Verify no file overlap across the wave. File collisions are the #1 swarm failure mode.
 - **Before proposing new capability:** Check `ao rpi serve --help`, `hooks/hooks.json`, and `GOALS.md` first.
-- **Gas City (gc) bridge:** `cli/cmd/ao/gc_bridge.go`, `gc_events.go`, `rpi_phased_gc.go`. Do not write new tests or features for deprecated files (`rpi_loop_supervisor.go`, `rpi_c2_events.go`, `rpi_phased_tmux.go`, `rpi_workers.go`, `rpi_parallel.go`, `fire.go`).
+- **Gas City (gc) bridge:** `cli/cmd/ao/gc_bridge.go`, `gc_events.go`, `rpi_phased_gc.go`. Do not write new tests or features for the legacy RPI lane (`rpi_loop_supervisor.go`, `rpi_c2_events.go`, `rpi_phased_tmux.go`, `rpi_parallel.go`) — but these are **load-bearing, not dead code**: live code references their symbols (`RPIC2Event`/`appendRPIC2Event` across 13+ `rpi_phased*` files + `mine`; `rpiLoopSupervisorConfig`/`runRPISupervisedCycle` in `rpi_loop`/`agentopsd`/`rpi_cancel`; `shellQuote` in `handoff`/`overnight_setup`; tmux helpers in `rpi_nudge`/`rpi_phased_stream`). Deleting any breaks the build; removal needs a caller-migration refactor (soc-1gbpz), not a delete. `rpi_workers.go` and `fire.go` were already removed.
 
 ### Execution Discipline
 


### PR DESCRIPTION
W1a of the 3.0 reconciliation. The discovery + CLAUDE.md claimed ~2,514 LOC of dead/deprecated RPI code. **Verified false by the build** — all 4 rpi_* files are load-bearing (RPIC2Event used by 13+ live files; rpiLoopSupervisorConfig by rpi_loop/agentopsd/rpi_cancel; shellQuote by handoff/overnight_setup; tmux helpers by rpi_nudge/rpi_phased_stream). Deleting any breaks `go build`.

So W1a is a **docs-match-reality fix, not a deletion**: corrected CLAUDE.md's deprecated-list to reflect that these are legacy-but-load-bearing (not dead), listed the live symbol refs, dropped the already-deleted rpi_workers.go/fire.go, and pointed real removal at the caller-migration refactor **soc-1gbpz**.

The green-gate caught this: the deletion attempt failed the build, which is exactly why we verify before deleting.

How tested: `cd cli && go build ./...` GREEN (nothing deleted).

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-furq8#w1a-match-reality
Bounded-context: BC1-Corpus
Evidence: CLAUDE.md