### PR TITLE
docs(roadmap): move aspirational claims into docs/ROADMAP.md (soc-icvff #w1b-roadmap)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,25 @@
+# Roadmap (planned, not committed)
+
+> Features designed or discussed but **not yet implemented**. Nothing here has a committed timeline; items may change or be dropped. If a command or capability is documented elsewhere as available, that doc is the source of truth — this page is only for what is *not* built yet. The 3.0 north star is [docs/3.0.md](3.0.md).
+
+## CLI — designed, not implemented
+
+| Command | Intent | Status |
+|---|---|---|
+| `gt convoy` | Convoy monitoring (track a group of related runs/worktrees) | designed, not implemented |
+| `bd mol` | Structured workflow "molecule" pour (see `bd formula`/`bd mol` design) | designed, not implemented |
+| `bd cook` | Batch/recipe execution over beads | designed, not implemented |
+
+If you hit an error invoking one of these, it does not exist yet — that is expected.
+
+## Curation pipeline — later stages
+
+The curation pipeline is a six-stage design: CATALOG, VERIFY, INDEX, SCORE, REJECT, CONSTRAIN. Today **CATALOG and VERIFY** ship as CLI commands (`ao curate catalog`, `ao curate verify`, `ao curate status`). The later stages (INDEX, SCORE, REJECT, CONSTRAIN) are roadmap, not built. The orthogonal, currently-active prevention lane is the finding-compiler (`.agents/findings/registry.jsonl` → constraints + planning rules), which is separate from this pipeline. See [docs/curation-pipeline.md](curation-pipeline.md).
+
+## Hookless default install (ADR-0002 S2–S5)
+
+The 3.0 north star demotes hooks to optional adapters ([docs/3.0.md](3.0.md)). The remaining lift — a default install path that requires **zero** hooks, and an RPI lifecycle that runs discovery→validation hookless — is tracked as ADR-0002 stages S2–S5. It is a follow-on, not part of the 3.0 reconciliation close.
+
+## Legacy RPI lane removal
+
+The legacy RPI lane (`rpi_parallel`, `rpi_loop_supervisor`, `rpi_phased_tmux` + the `ao rpi parallel` / supervised-loop surfaces) is superseded by the gc bridge but still load-bearing (live code references its helpers). Removing it requires a caller-migration refactor, tracked as `soc-1gbpz`.

--- a/docs/brownian-ratchet.md
+++ b/docs/brownian-ratchet.md
@@ -123,14 +123,12 @@ Monitor for completion. When polecats finish, validate their work:
 
 Valid completions get merged. **Merge is the ratchet**—once in main, it's permanent.
 
-<!-- FUTURE: gt convoy not yet implemented -->
-> **Not yet implemented:** `gt convoy` — convoy monitoring is planned but not yet available.
-
 ```bash
-gt convoy status <id>         # Monitor
 # Polecat runs: gt done → push → merge queue
 git merge origin/polecat/...  # Ratchet
 ```
+
+> Convoy monitoring (`gt convoy`) is designed but not yet implemented; see [ROADMAP.md](ROADMAP.md).
 
 ### ESCALATE - Handle Failures
 

--- a/docs/curation-pipeline.md
+++ b/docs/curation-pipeline.md
@@ -10,7 +10,7 @@ Without curation, the flywheel stores everything and retrieves whatever fits the
 
 The curation pipeline fixes this by applying six stages -- CATALOG, VERIFY, INDEX, SCORE, REJECT, CONSTRAIN -- that progressively filter and strengthen knowledge before it re-enters agent context windows.
 
-> **Current Implementation (v1):** Only CATALOG and VERIFY stages are implemented as CLI commands (`ao curate catalog`, `ao curate verify`, `ao curate status`). Stages 3-6 are planned for future releases.
+> **Current Implementation (v1):** Only CATALOG and VERIFY stages are implemented as CLI commands (`ao curate catalog`, `ao curate verify`, `ao curate status`). The later stages (INDEX, SCORE, REJECT, CONSTRAIN) are on the [roadmap](ROADMAP.md), not yet built.
 
 **This is NOT the knowledge flywheel.** The flywheel is the loop: extract, store, retrieve, apply, compound. The curation pipeline is what happens between "store" and "retrieve" -- the quality control that determines whether the flywheel compounds signal or noise.
 

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -10,6 +10,7 @@
 - [Getting Started](getting-started/index.md) — Install + first command landing page
 - [PRACTICE-REGISTRY.md](https://github.com/boshu2/agentops/blob/main/PRACTICE-REGISTRY.md) — Practice lineage and canonical `practices: [slug]` registry
 - [AgentOps 3.0 — the north star](3.0.md) — The single source of truth for what 3.0 is: the hookless-first CDLC loop, the four-practice waist (BDD/DDD/Hexagonal/TDD), and what "3.0-ready" means
+- [Roadmap](ROADMAP.md) — Designed-but-not-built features (planned, not committed): CLI roadmap, curation pipeline later stages, hookless default-install
 - [AgentOps 3.0 Explainer Kit](agentops-3-explainer-kit.md) — Public gist/launch copy for the council-first 3.0 story
 - [AgentOps 3.0 First-Value Path](first-value-path.md) — First-session path from install to domain packet, council verdict, tracked work, and optional daemon lane
 - [AgentOps 3.0 YouTube Starter Series](agentops-3-youtube-starter-series.md) — Launch video plan, scripts, clip hooks, CTAs, and PMF measurement fields

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -276,7 +276,7 @@ This is expected behavior in the **lead-only commit** pattern used by `/crank` a
 
 ## Phantom command error
 
-If you see errors for commands like `bd mol`, `gt convoy`, or `bd cook`, these are **planned future features** that do not exist yet.
+If you see an error for a command that is documented as planned, it does not exist yet. Designed-but-unbuilt commands are tracked in [ROADMAP.md](ROADMAP.md).
 
 **How to identify:** Look for `FUTURE` markers in skill documentation. These indicate commands or features that are designed but not yet implemented.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
   - Getting Started:
       - getting-started/index.md
       - "AgentOps 3.0 (North Star)": 3.0.md
+      - Roadmap: ROADMAP.md
       - Newcomer Guide: newcomer-guide.md
       - Create Your First Skill: create-your-first-skill.md
       - Behavioral Discipline: behavioral-discipline.md


### PR DESCRIPTION
W1b of the 3.0 reconciliation (match reality). Designed-but-unbuilt features were scattered through live docs; consolidated into one roadmap so live docs describe only what exists.

- **docs/ROADMAP.md (NEW)**: gt convoy / bd mol / bd cook, curation later stages, hookless default-install (ADR-0002 S2–S5), legacy-RPI removal (soc-1gbpz) — non-committed framing
- troubleshooting.md / brownian-ratchet.md / curation-pipeline.md: removed inline unbuilt-command examples → ROADMAP pointers
- documentation-index.md + mkdocs nav: cataloged

No code. grep confirms no unbuilt-as-available language left in live docs.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-icvff#w1b-roadmap
Bounded-context: BC1-Corpus
Evidence: docs/ROADMAP.md