### PR TITLE
feat(skills): add canonical .feature acceptance to readme skill (soc-qk4b #readme-feature)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T12:47:22Z",
+  "generated_at": "2026-05-23T14:27:48Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -973,7 +973,7 @@
     {
       "name": "readme",
       "source_skill": "skills/readme",
-      "source_hash": "d7a676b7099a85eeee76b87f8ec190e8c9a341d84427130a9de17cca6e93d56c",
+      "source_hash": "5d539d8d92c03d9a7f82adc07e9b5f11f760f428263086c2ede77bd58978790b",
       "generated_hash": "c9050bc20a6e1d64c1beb1f39f17ee343dafee18df7f3c172735c0f0ab2b2d83"
     },
     {

--- a/skills-codex/readme/.agentops-generated.json
+++ b/skills-codex/readme/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/readme",
   "layout": "modular",
-  "source_hash": "d7a676b7099a85eeee76b87f8ec190e8c9a341d84427130a9de17cca6e93d56c",
+  "source_hash": "5d539d8d92c03d9a7f82adc07e9b5f11f760f428263086c2ede77bd58978790b",
   "generated_hash": "c9050bc20a6e1d64c1beb1f39f17ee343dafee18df7f3c172735c0f0ab2b2d83"
 }

--- a/skills/readme/SKILL.md
+++ b/skills/readme/SKILL.md
@@ -372,6 +372,10 @@ When rewriting or validating, flag these:
 | Interview keeps asking questions the project manifest already answers | The manifest file format is not recognized by the context-gathering step | Ensure your project has a standard manifest (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`) in the repo root |
 | Anti-pattern detection flags false positives on rewrite | Some content patterns trigger heuristic detection even when intentional | Review each finding during the council step and select "Ship it" for intentional choices. The detection is heuristic, not absolute |
 
+## Reference Documents
+
+- [references/readme.feature](references/readme.feature) — Executable spec: mode detection, problem-first lead, trust block near install, collapse-don't-delete depth, the council gate, anti-pattern detection (soc-qk4b)
+
 ## See Also
 
 - `skills/product/SKILL.md` — PRODUCT.md generation (feeds into README context)

--- a/skills/readme/references/readme.feature
+++ b/skills/readme/references/readme.feature
@@ -1,0 +1,46 @@
+# Executable spec for the /readme skill — gold-standard README generation (BC1 Corpus).
+# /readme drafts or improves a README that converts skimmers into users and satisfies
+# deep readers, enforcing 8 non-negotiable patterns (problem-first lead, trust block
+# near install, collapse-don't-delete depth, adoption-ordered sections), then validates
+# the result with a council before reporting. Hexagon: generic; consumes: project files
+# + interview answers; produces: documentation (README.md), council-validated. (soc-qk4b)
+
+Feature: README generation converts skimmers into users and survives a council
+  As an author publishing a tool
+  I want a README that leads with the problem, proves it works, and earns trust
+  So that both skimmers and deep readers adopt instead of bouncing
+
+  Background:
+    Given a repository with manifest files and an optional existing README.md
+
+  Scenario: Mode detection routes by flags and existing README
+    When /readme runs
+    Then "--validate" with an existing README skips to council validation only
+    And "--rewrite" with an existing README reuses it as rewrite context
+    And no README and no flags generates from scratch after an interview
+
+  Scenario: The lead states the problem before the framework
+    When the README is generated
+    Then the opening line names the user's pain in one plain sentence
+    And methodology or framework names do not appear before the problem statement
+
+  Scenario: A trust block sits near the install command
+    Given the author reports that the tool runs hooks, modifies config, or makes network calls
+    When the README is generated
+    Then a trust block stating what it touches, exfiltration posture, and how to uninstall
+      appears near the install command, not buried in an FAQ
+
+  Scenario: Depth is collapsed, never deleted
+    When deep architecture, theory, or reference material is included
+    Then it is placed inside <details> blocks with a blank line after <summary>
+    And the skimmer path stays short while deep readers can expand
+
+  Scenario: A council validates before the skill reports complete
+    When generation or rewrite finishes
+    Then /readme runs a council over the README
+    And reports a PASS, WARN, or FAIL verdict rather than claiming done unvalidated
+
+  Scenario: Anti-patterns are flagged on rewrite or validate
+    When /readme reviews an existing README
+    Then it flags flywheel-echo, framework-first, guru tone, buried trust info,
+      install scatter, and theory-before-try with a concrete fix for each


### PR DESCRIPTION
W2 of the 3.0 reconciliation — **hexagon crank tail** (full Gherkin acceptance is a 3.0-ready criterion). 48/80 skills had a `.feature`; this adds readme's.

- **skills/readme/references/readme.feature (NEW)** — 6 scenarios from the real contract: mode detection, problem-first lead, trust block near install, collapse-depth, council gate, anti-pattern detection.
- SKILL.md: linked under Reference Documents.
- registry.json + codex hashes: regenerated deterministically.

No behavior/frontmatter change. **W2 scope note:** `hexagonal_role` is already 100% (80/80) — the tail is the `.feature` axis; `expert-council` is excluded (deprecated alias).

Gates: registry --check OK, codex-parity passed, heal --strict clean, check-skill-size 0/0.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-qk4b#readme-feature
Bounded-context: BC1-Corpus
Evidence: skills/readme/references/readme.feature