### PR TITLE
feat(skills): add canonical .feature acceptance to handoff skill (soc-qk4b #handoff-feature)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T14:27:48Z",
+  "generated_at": "2026-05-23T14:47:45Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -823,7 +823,7 @@
     {
       "name": "handoff",
       "source_skill": "skills/handoff",
-      "source_hash": "b56b2e4084e8ecb7e5f488cae5de8bce7d95fbd902aa054909da6655bf1e5fc5",
+      "source_hash": "4348117b261d6ce46531d251a9d6d46ecbe2fd985f707b4de11c8d406075ff47",
       "generated_hash": "29cb132dfb1a21937e7a0c4d4ccccabae72a5f69ecee8007aab027a667bce654"
     },
     {

--- a/skills-codex/handoff/.agentops-generated.json
+++ b/skills-codex/handoff/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/handoff",
   "layout": "modular",
-  "source_hash": "b56b2e4084e8ecb7e5f488cae5de8bce7d95fbd902aa054909da6655bf1e5fc5",
+  "source_hash": "4348117b261d6ce46531d251a9d6d46ecbe2fd985f707b4de11c8d406075ff47",
   "generated_hash": "29cb132dfb1a21937e7a0c4d4ccccabae72a5f69ecee8007aab027a667bce654"
 }

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -351,6 +351,10 @@ If ao CLI not available:
 
 ---
 
+## Reference Documents
+
+- [references/handoff.feature](references/handoff.feature) — Executable spec: topic derivation, evidence-based accomplishments, pause-point + in-progress capture, next-files list, structured doc + continuation prompt (soc-qk4b)
+
 ## See Also
 
 - `skills/post-mortem/SKILL.md` — Full validation + knowledge lifecycle (council + extraction + activation + retirement)

--- a/skills/handoff/references/handoff.feature
+++ b/skills/handoff/references/handoff.feature
@@ -1,0 +1,38 @@
+# Executable spec for the /handoff skill — compact session handoff (BC5 Runtime).
+# /handoff captures the end-of-session state so the next session resumes without
+# re-discovery: it derives a topic, gathers what was accomplished, pinpoints where
+# work paused (including in-progress beads), lists the files to read first, and
+# writes a structured handoff document plus a continuation prompt. Hexagon:
+# supporting; consumes: git/bd/ratchet session signals; produces: a handoff doc. (soc-qk4b)
+
+Feature: Handoff captures session state for seamless continuation
+  As an agent ending a work session
+  I want the pause point, accomplishments, and next-files recorded compactly
+  So that the next session resumes without re-discovering context
+
+  Background:
+    Given a session with recent commits, beads activity, and artifacts
+
+  Scenario: Topic is taken from the argument or derived from recent activity
+    When /handoff runs
+    Then a provided topic is used as the handoff identifier
+    And with no topic it derives one from recent commits, the current bead, or ratchet state
+    And it falls back to a timestamped slug when no descriptive source exists
+
+  Scenario: Accomplishments are gathered from session evidence, not memory
+    When the handoff is assembled
+    Then it reviews recent commits, changed files, research/plans produced, and closed issues
+
+  Scenario: The pause point and in-progress work are recorded
+    When the handoff identifies where work stopped
+    Then it states the last action, the intended next action, and any pending blockers
+    And it lists beads still in progress so the next session can reclaim them
+
+  Scenario: The next session is told which files to read first
+    When the handoff is written
+    Then it lists recently modified core files and the key research/plan artifacts
+
+  Scenario: Output is a structured document plus a continuation prompt
+    When /handoff completes
+    Then it writes a dated handoff document under the handoff directory
+    And it emits a continuation prompt the next session can act on directly


### PR DESCRIPTION
W2 of the 3.0 reconciliation — **hexagon crank tail** (50/80 after this). Adds handoff's executable spec; no behavior/frontmatter change.

- **skills/handoff/references/handoff.feature (NEW)** — 5 scenarios from the real contract: topic derivation, evidence-based accomplishments, pause-point + in-progress capture, next-files list, structured doc + continuation prompt.
- SKILL.md: linked under Reference Documents.
- registry.json + codex hashes: regenerated deterministically.

Gates: registry --check OK, codex-parity passed, heal --strict clean, check-skill-size 0/0.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-qk4b#handoff-feature
Bounded-context: BC5-Runtime
Evidence: skills/handoff/references/handoff.feature