### PR TITLE
feat(skills): add canonical .feature acceptance to trace skill (soc-qk4b #trace-feature)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T14:47:45Z",
+  "generated_at": "2026-05-23T15:02:58Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1123,7 +1123,7 @@
     {
       "name": "trace",
       "source_skill": "skills/trace",
-      "source_hash": "b88dbe53721fd0308f5d667a2cf08efc76cdabd8bcc5620c1fdb91566ca52c83",
+      "source_hash": "f13d70a293bccbea9a5fd55922c2df28b37d9af1f0a668c9ba306caa1bccaaf8",
       "generated_hash": "c0a7ce3beb038f142c9ad8ef0eef4a9072eb2a2c6c90b4f1e0f39699462f4cec"
     },
     {

--- a/skills-codex/trace/.agentops-generated.json
+++ b/skills-codex/trace/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/trace",
   "layout": "modular",
-  "source_hash": "b88dbe53721fd0308f5d667a2cf08efc76cdabd8bcc5620c1fdb91566ca52c83",
+  "source_hash": "f13d70a293bccbea9a5fd55922c2df28b37d9af1f0a668c9ba306caa1bccaaf8",
   "generated_hash": "c0a7ce3beb038f142c9ad8ef0eef4a9072eb2a2c6c90b4f1e0f39699462f4cec"
 }

--- a/skills/trace/SKILL.md
+++ b/skills/trace/SKILL.md
@@ -175,3 +175,10 @@ Use `/trace` for: "How did we decide on this architecture?"
 | Timeline has gaps | Not all decisions documented in searchable artifacts | Note gaps in report. Suggest interviewing team members or checking Slack/email archives for missing context. |
 | Too many results (>50 matches) | Very broad concept or high-frequency term | Read `references/edge-cases.md` for ambiguous concept handling. Narrow query or filter by date range. Ask user for more specific aspect to trace. |
 | Empty trace report (all sources failed) | Concept genuinely undocumented or typo | Verify spelling. Try synonyms. Report to user: "No documented history found. This may be a new concept or may need different search terms." |
+
+## Reference Documents
+
+- [references/trace.feature](references/trace.feature) — Executable spec: target-type routing, parallel multi-source search, cited chronological timeline, key-decision extraction, report + graceful gaps (soc-qk4b)
+- [references/discovery-patterns.md](references/discovery-patterns.md) — Search-agent definitions and git-based tracing commands
+- [references/report-template.md](references/report-template.md) — Trace report format and deduplication rules
+- [references/edge-cases.md](references/edge-cases.md) — Empty/ambiguous source handling

--- a/skills/trace/references/trace.feature
+++ b/skills/trace/references/trace.feature
@@ -1,0 +1,39 @@
+# Executable spec for the /trace skill — decision provenance tracing (BC1 Corpus).
+# /trace reconstructs HOW a design decision evolved by searching across CASS sessions,
+# handoffs, git history, and research artifacts, then merges the hits into one
+# chronological timeline with a source citation per claim and writes a trace report.
+# It routes file paths to /provenance and git refs to git-based tracing. Hexagon:
+# supporting; consumes: session/handoff/git/research sources; produces: a trace report. (soc-qk4b)
+
+Feature: Trace reconstructs how a decision evolved, with cited provenance
+  As an agent recovering design rationale
+  I want a cited, chronological trace across every source
+  So that I understand when a concept appeared and why it was decided
+
+  Background:
+    Given a concept, file path, or git ref to trace
+
+  Scenario: Target type selects the tracing strategy
+    When /trace classifies its target
+    Then a file path routes to /provenance for artifact lineage
+    And a git ref uses git-based tracing
+    And a keyword or concept uses design-decision tracing
+
+  Scenario: Design-decision tracing searches every source in parallel
+    When a concept is traced
+    Then it searches CASS sessions, handoffs, git history, and research artifacts
+    And it continues with the remaining sources when one is unavailable
+
+  Scenario: Results merge into one chronological, cited timeline
+    When the sources return
+    Then events are merged oldest-first and same-day/same-session duplicates collapsed
+    And every event carries a source citation
+
+  Scenario: Each event records what changed, why, who, and the evidence
+    When key decisions are extracted
+    Then each lists the change, the reasoning if available, the author or session, and a source link
+
+  Scenario: A trace report is written and gaps are noted, not hidden
+    When /trace completes
+    Then it writes a dated trace report under .agents/research/
+    And it records which sources were empty rather than failing the trace


### PR DESCRIPTION
W2 of the 3.0 reconciliation — **hexagon crank tail** (51/80 after this). Adds trace's executable spec; no behavior/frontmatter change.

- **skills/trace/references/trace.feature (NEW)** — 5 scenarios from the real contract: target-type routing, parallel multi-source search (CASS/handoff/git/research), cited chronological timeline, key-decision extraction, report + graceful gaps.
- SKILL.md: added a Reference Documents section (links the .feature + the 3 existing references that were inline-only).
- registry.json + codex hashes: regenerated deterministically.

Gates: registry --check OK, codex-parity passed, heal --strict clean, check-skill-size 0/0.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-qk4b#trace-feature
Bounded-context: BC1-Corpus
Evidence: skills/trace/references/trace.feature