### PR TITLE
feat(skills): add canonical .feature acceptance to 5 skills — batch 1 (soc-qk4b #crank-batch1)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T15:02:58Z",
+  "generated_at": "2026-05-23T20:01:26Z",
   "summary": {
     "skills": 80,
     "hooks": 44,
@@ -520,7 +520,7 @@
         "tier": "meta",
         "path": "skills/update/",
         "has_skill_md": true,
-        "has_references": false,
+        "has_references": true,
         "reference_count": 0
       },
       {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -829,7 +829,7 @@
     {
       "name": "harvest",
       "source_skill": "skills/harvest",
-      "source_hash": "0bd1d6201aa8d6f1752150abd1f4db6fe17fcfd0ab5c0752704bcda42415893f",
+      "source_hash": "e480b7d5995b3281f40fc6426af40b54c7047024c2c15541774444f0aa6e9bea",
       "generated_hash": "5b7493af237b1aa26c1628c34ba0cb70928b0dfd34964fcd1d42971d6e322fd1"
     },
     {
@@ -997,7 +997,7 @@
     {
       "name": "release",
       "source_skill": "skills/release",
-      "source_hash": "118c0e399aa6e0bf1695e9a5c71930c67ca94bb4194405a1e140eb9199ba1839",
+      "source_hash": "4c8d65dfa0e7ed41f103f34c6f598ce0bc1741622404b36f33ef87b048b875c4",
       "generated_hash": "41b4b08fccd2276087aa8ddfb56034c5fc437535036dbe534d6dbba0605a49a8"
     },
     {
@@ -1033,7 +1033,7 @@
     {
       "name": "scaffold",
       "source_skill": "skills/scaffold",
-      "source_hash": "ec683e3962683e9ff69e026f4729eafa232ec36ad778febf3ca4dbf8ad101204",
+      "source_hash": "15be80480554fdf0315daebaa7e265a04046b9705806ca959e54e9dc5b276ae7",
       "generated_hash": "800870469aab63a0445703a1019cbc0d382c1bb0865d1ceb03ae3a9c1a86ac75"
     },
     {
@@ -1045,7 +1045,7 @@
     {
       "name": "scope",
       "source_skill": "skills/scope",
-      "source_hash": "dca294faca51dee6c53e3ffff3e1d03a91417201ec9dd35ce458567637a7fc5c",
+      "source_hash": "9dc20d8bfa1060ba905fd5aa2d785eb7996fce42a1060ab29a3cbebd55075a9e",
       "generated_hash": "e75dcbe47b86525f87218941f0644fac7a5fac6559de09c9ed53f21292fbac78"
     },
     {
@@ -1129,7 +1129,7 @@
     {
       "name": "update",
       "source_skill": "skills/update",
-      "source_hash": "80b5793ca23e67d1f6ad80378dca034e182acd354f8f014f472075d58f19a81e",
+      "source_hash": "9592f3f9f7d06a9df037b5c62e395328a641220cbea2150dda10f9df12175f23",
       "generated_hash": "da2116a3e09a09731f3d9b8a11d8b425787861598a75132a2107e94154a16a42"
     },
     {

--- a/skills-codex/harvest/.agentops-generated.json
+++ b/skills-codex/harvest/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/harvest",
   "layout": "modular",
-  "source_hash": "0bd1d6201aa8d6f1752150abd1f4db6fe17fcfd0ab5c0752704bcda42415893f",
+  "source_hash": "e480b7d5995b3281f40fc6426af40b54c7047024c2c15541774444f0aa6e9bea",
   "generated_hash": "5b7493af237b1aa26c1628c34ba0cb70928b0dfd34964fcd1d42971d6e322fd1"
 }

--- a/skills-codex/release/.agentops-generated.json
+++ b/skills-codex/release/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/release",
   "layout": "modular",
-  "source_hash": "118c0e399aa6e0bf1695e9a5c71930c67ca94bb4194405a1e140eb9199ba1839",
+  "source_hash": "4c8d65dfa0e7ed41f103f34c6f598ce0bc1741622404b36f33ef87b048b875c4",
   "generated_hash": "41b4b08fccd2276087aa8ddfb56034c5fc437535036dbe534d6dbba0605a49a8"
 }

--- a/skills-codex/scaffold/.agentops-generated.json
+++ b/skills-codex/scaffold/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/scaffold",
   "layout": "modular",
-  "source_hash": "ec683e3962683e9ff69e026f4729eafa232ec36ad778febf3ca4dbf8ad101204",
+  "source_hash": "15be80480554fdf0315daebaa7e265a04046b9705806ca959e54e9dc5b276ae7",
   "generated_hash": "800870469aab63a0445703a1019cbc0d382c1bb0865d1ceb03ae3a9c1a86ac75"
 }

--- a/skills-codex/scope/.agentops-generated.json
+++ b/skills-codex/scope/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual",
   "source_skill": "skills/scope",
   "layout": "modular",
-  "source_hash": "dca294faca51dee6c53e3ffff3e1d03a91417201ec9dd35ce458567637a7fc5c",
+  "source_hash": "9dc20d8bfa1060ba905fd5aa2d785eb7996fce42a1060ab29a3cbebd55075a9e",
   "generated_hash": "e75dcbe47b86525f87218941f0644fac7a5fac6559de09c9ed53f21292fbac78"
 }

--- a/skills-codex/update/.agentops-generated.json
+++ b/skills-codex/update/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/update",
   "layout": "modular",
-  "source_hash": "80b5793ca23e67d1f6ad80378dca034e182acd354f8f014f472075d58f19a81e",
+  "source_hash": "9592f3f9f7d06a9df037b5c62e395328a641220cbea2150dda10f9df12175f23",
   "generated_hash": "da2116a3e09a09731f3d9b8a11d8b425787861598a75132a2107e94154a16a42"
 }

--- a/skills/harvest/SKILL.md
+++ b/skills/harvest/SKILL.md
@@ -133,3 +133,4 @@ size budgets, sweep frequency, staleness thresholds, and cross-rig synthesis tri
 ## Reference Documents
 
 - [references/governance.md](references/governance.md) — Governance model for ongoing knowledge consolidation
+- [references/harvest.feature](references/harvest.feature) — Executable spec: sweep .agents surfaces, consolidate + de-duplicate, write learnings, manual or via the dream loop (soc-qk4b)

--- a/skills/harvest/references/harvest.feature
+++ b/skills/harvest/references/harvest.feature
@@ -1,0 +1,29 @@
+# Executable spec for the /harvest skill — knowledge promotion (BC1 Corpus).
+# /harvest sweeps the .agents knowledge surfaces, consolidates and de-duplicates
+# promotable items, and writes consolidated learnings — runnable as a manual sweep
+# or as part of the nightly /dream compounding loop. Hexagon: supporting; consumes:
+# .agents knowledge surfaces; produces: consolidated .agents/learnings/*.md. (soc-qk4b)
+
+Feature: Harvest promotes scattered knowledge into consolidated learnings
+  As the knowledge flywheel
+  I want repeated, reusable knowledge consolidated and de-duplicated
+  So that the corpus compounds signal instead of accumulating fragments
+
+  Background:
+    Given .agents knowledge surfaces with candidate learnings
+
+  Scenario: A sweep gathers promotable knowledge
+    When /harvest runs
+    Then it scans the .agents knowledge surfaces for promotable items
+
+  Scenario: Promotable items are consolidated and de-duplicated
+    When candidates are gathered
+    Then near-duplicate items merge and only reusable knowledge is promoted
+
+  Scenario: Output is written to the learnings surface
+    When promotion completes
+    Then consolidated learnings are written under .agents/learnings/
+
+  Scenario: Harvest runs manually or inside the nightly dream loop
+    Then /harvest can be invoked directly for a manual sweep
+    And it also runs as a bounded step of the /dream compounding loop

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -179,3 +179,4 @@ When wiring or auditing the CI workflow that backs `--check` mode (or the tag-tr
 - [references/changelog-as-research-artifact.md](references/changelog-as-research-artifact.md)
 - [references/gh-actions-ci-patterns.md](references/gh-actions-ci-patterns.md)
 - [references/gh-actions-release-automation.md](references/gh-actions-release-automation.md)
+- [references/release.feature](references/release.feature) — Executable spec: --check readiness, curated notes + CHANGELOG reconcile, operator-performed tag/push, exact-SHA green verification (soc-qk4b)

--- a/skills/release/references/release.feature
+++ b/skills/release/references/release.feature
@@ -1,0 +1,30 @@
+# Executable spec for the /release skill — release validation + tag handoff (BC5 Runtime).
+# /release takes a project from "code is ready" to "tagged, pushed by the operator,
+# and verified green on the exact tagged SHA": it validates readiness (--check),
+# curates release notes and reconciles CHANGELOG.md, then leaves the tag/push to the
+# operator and verifies CI on the tagged SHA. Hexagon: supporting; consumes: repo +
+# CI state; produces: CHANGELOG update, curated notes, exact-SHA CI verdict. (soc-qk4b)
+
+Feature: Release validates readiness and verifies the tagged SHA
+  As a maintainer shipping a version
+  I want readiness validated and the tagged SHA verified green
+  So that a release is provably built from exactly what was tagged
+
+  Background:
+    Given a repository whose code is ready to release
+
+  Scenario: Check mode validates readiness without tagging
+    When /release runs in --check mode
+    Then it reports release readiness and does not create a tag
+
+  Scenario: Release notes are curated and the changelog reconciled
+    When release notes are produced
+    Then a curated notes file is generated and CHANGELOG.md drift is reconciled
+
+  Scenario: Tagging is the operator's action, not the skill's
+    When the release is ready
+    Then the skill prepares the release but the operator performs the tag and push
+
+  Scenario: CI is verified on the exact tagged SHA
+    When a tag is pushed
+    Then /release confirms the CI verdict is green on that exact SHA before declaring done

--- a/skills/scaffold/SKILL.md
+++ b/skills/scaffold/SKILL.md
@@ -443,3 +443,4 @@ Next steps:
 
 - [references/agent-facing-tool-scaffolds.md](references/agent-facing-tool-scaffolds.md)
 - [references/recommended-reading.md](references/recommended-reading.md) — forward-looking index of external skills (e.g., `mcp-server-design`) worth absorbing into scaffold when their trigger conditions arrive. Consult before designing a new scaffold mode that targets agent-facing tool surfaces.
+- [references/scaffold.feature](references/scaffold.feature) — Executable spec: project/component/CI scaffolding entry points + domain-slice routing through `ao rpi phased --scaffold-domain` (soc-qk4b)

--- a/skills/scaffold/references/scaffold.feature
+++ b/skills/scaffold/references/scaffold.feature
@@ -1,0 +1,29 @@
+# Executable spec for the /scaffold skill — project/component/CI scaffolding (BC3 Loop).
+# /scaffold generates new-project structure, components, and CI pipelines from a single
+# entry point, and backs domain-slice scaffolding with `ao rpi phased --scaffold-domain`
+# (there is no `ao scaffold` subcommand). Hexagon: supporting; consumes: a scaffold
+# target (language/component/CI/domain); produces: project files + directory structure. (soc-qk4b)
+
+Feature: Scaffold generates project, component, and CI structure
+  As a developer starting new work
+  I want consistent boilerplate generated from one command
+  So that new projects, components, and pipelines start from a known-good shape
+
+  Background:
+    Given a scaffold request naming a target
+
+  Scenario: A new project is scaffolded by language and name
+    When "/scaffold <language> <name>" runs
+    Then it creates the project files and directory structure for that language
+
+  Scenario: A component is generated into an existing project
+    When "/scaffold component <type> <name>" runs
+    Then it generates the component of that type
+
+  Scenario: A CI pipeline is scaffolded for a platform
+    When "/scaffold ci <platform>" runs
+    Then it sets up the CI pipeline for that platform
+
+  Scenario: Domain-slice scaffolding routes through the rpi flag
+    When domain scaffolding is requested
+    Then it drives "ao rpi phased --scaffold-domain" rather than a non-existent "ao scaffold" command

--- a/skills/scope/SKILL.md
+++ b/skills/scope/SKILL.md
@@ -131,3 +131,4 @@ Reserved for a follow-up skill that combines `freeze` + status + spawn-orchestra
 - [references/lock-file-format.md](references/lock-file-format.md)
 - [references/destructive-command-guard-patterns.md](references/destructive-command-guard-patterns.md)
 - [references/command-approval-and-hook-guardrails.md](references/command-approval-and-hook-guardrails.md)
+- [references/scope.feature](references/scope.feature) — Executable spec: declare in-scope dirs, allow in-scope edits, hard-block out-of-scope edits via PreToolUse hook, report/release scope state (soc-qk4b)

--- a/skills/scope/references/scope.feature
+++ b/skills/scope/references/scope.feature
@@ -1,0 +1,32 @@
+# Executable spec for the /scope skill — edit-scope guardrail (BC5 Runtime).
+# /scope declares which directories are in scope for the current work session and
+# hard-blocks edits outside them via a PreToolUse hook, so a session cannot drift
+# into files it never claimed. Hexagon: driven-adapter; consumes: a declared
+# directory set; produces: scope/lock state + blocked-edit reasons on stderr. (soc-qk4b)
+
+Feature: Scope hard-blocks edits outside the declared directories
+  As an agent working a bounded change
+  I want edits confined to directories I declared in scope
+  So that a session cannot silently modify files it never claimed
+
+  Background:
+    Given a work session that can declare an in-scope directory set
+
+  Scenario: Declaring scope records the allowed directories
+    When /scope declares one or more directories
+    Then those directories become the in-scope set and the lock state reflects them
+
+  Scenario: An edit inside scope proceeds
+    Given a declared in-scope directory
+    When a file inside it is edited
+    Then the edit is allowed
+
+  Scenario: An edit outside scope is hard-blocked with a reason
+    Given a declared scope
+    When a file outside the in-scope set is edited
+    Then the PreToolUse hook blocks the edit and reports the blocked-edit reason on stderr
+
+  Scenario: Scope state is reportable and releasable
+    When /scope is queried
+    Then it reports the current scope and lock state
+    And releasing scope removes the block on out-of-scope edits

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -93,3 +93,7 @@ Tell the user:
 | Individual skills fail | Permissions issue in the agent's install or plugin directory | Fix permissions on the target agent's install home, then re-run `/update` |
 | Skills not available after install | Agent session not restarted | Restart your agent session |
 | `EACCES: permission denied` | Restrictive permissions on the install target | Fix permissions on the install target, then re-run `/update` |
+
+## Reference Documents
+
+- [references/update.feature](references/update.feature) — Executable spec: pull latest skills from the repo, install across agent runtimes, idempotent re-run (soc-qk4b)

--- a/skills/update/references/update.feature
+++ b/skills/update/references/update.feature
@@ -1,0 +1,25 @@
+# Executable spec for the /update skill — skill sync + install (BC5 Runtime).
+# /update pulls the latest skills from the repo and installs them globally across
+# every agent runtime in one command, so all harnesses run the same current corpus.
+# Hexagon: supporting; consumes: the repo's skills/ source of truth; produces:
+# installed skill copies under the agent skills directories. (soc-qk4b)
+
+Feature: Update syncs the latest skills across every agent runtime
+  As an operator keeping agents current
+  I want one command to pull and install the latest skills everywhere
+  So that all harnesses share the same up-to-date skill corpus
+
+  Background:
+    Given a local AgentOps repo and one or more agent runtimes installed
+
+  Scenario: Latest skills are pulled from the repo source of truth
+    When /update runs
+    Then it fetches the latest skills from the repository
+
+  Scenario: Skills install globally across agent runtimes
+    When the pull completes
+    Then the skills are installed into the agent skills directories for each runtime
+
+  Scenario: Re-running update is idempotent
+    When /update runs again with no upstream change
+    Then the installed copies are unchanged and no spurious diffs are produced


### PR DESCRIPTION
W2 of the 3.0 reconciliation — **hexagon crank tail, batched 5/PR** (operator-approved cadence). 56/80 skills cranked after this. No behavior/frontmatter change.

| Skill | Acceptance added |
|---|---|
| scope | declare scope, allow in-scope edits, hard-block out-of-scope via PreToolUse hook |
| harvest | sweep .agents, consolidate/de-dup, write learnings, manual or dream-loop |
| release | --check readiness, curated notes + CHANGELOG, operator tag/push, exact-SHA verify |
| update | pull latest skills, install across runtimes, idempotent |
| scaffold | project/component/CI scaffolds + domain-slice via `ao rpi phased --scaffold-domain` |

Each .feature linked in SKILL.md; registry + codex hashes regenerated deterministically.

Gates: registry --check OK; codex-parity ✓×5; heal --strict clean ×5; check-skill-size 0/0.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-qk4b#crank-batch1
Bounded-context: BC1-Corpus
Evidence: skills/scope/references/scope.feature