### PR TITLE
feat(skills): add canonical .feature acceptance to 5 skills — batch 2 (soc-qk4b #crank-batch2)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T20:01:26Z",
+  "generated_at": "2026-05-23T20:18:40Z",
   "summary": {
     "skills": 80,
     "hooks": 44,
@@ -72,7 +72,7 @@
         "tier": "contribute",
         "path": "skills/pr-plan/",
         "has_skill_md": true,
-        "has_references": false,
+        "has_references": true,
         "reference_count": 0
       },
       {
@@ -96,7 +96,7 @@
         "tier": "contribute",
         "path": "skills/pr-retro/",
         "has_skill_md": true,
-        "has_references": false,
+        "has_references": true,
         "reference_count": 0
       },
       {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -859,7 +859,7 @@
     {
       "name": "knowledge-activation",
       "source_skill": "skills/knowledge-activation",
-      "source_hash": "d4d1d689b41948f79ceab7f729d319d37db1bfb17ee7cee7affbfc7434109b77",
+      "source_hash": "a51afc2ae186ccf18f94e581bd7ec67aa31a0ca540f6994ec583ccd9b66fa8de",
       "generated_hash": "2a9c9973fd6d21cd725717c4624f358a41072b2c6ca535580abfddd2cf613985"
     },
     {
@@ -907,7 +907,7 @@
     {
       "name": "pr-plan",
       "source_skill": "skills/pr-plan",
-      "source_hash": "151c98b645383412ee9d3ca1afbff19d381c675b6ac1ec33ebf43cad74f56f06",
+      "source_hash": "e9774059e07eeb4388bf394afded5f39c636a0df097cbd20ce2e1c4c62908739",
       "generated_hash": "9c642fd106e24221a2120219fcba2da62202a0686d3978c01d94660a6222f336"
     },
     {
@@ -925,7 +925,7 @@
     {
       "name": "pr-retro",
       "source_skill": "skills/pr-retro",
-      "source_hash": "a382be41def73b78e6f97164829c5dd46fce6aa4d1852dfef357c4469131049e",
+      "source_hash": "6a1a37e38195feed50fb041dd519199fc42224870588ca5437b9a1c23ffa5b2c",
       "generated_hash": "f17bcb9512aaef9e5cffce80a6712146ec1498565e3ee71b2ba9d80a861cee4a"
     },
     {
@@ -943,7 +943,7 @@
     {
       "name": "product",
       "source_skill": "skills/product",
-      "source_hash": "a6e7985e9ae544e5e5303a5f1e4e33c282f75b51c1449f40bcac325982f35456",
+      "source_hash": "a2f51a7e71f2ff23025dc6b6cf806096cd6c2fb4324d426bd180ab256061e9d5",
       "generated_hash": "3c2a4840bedac960a309c4e9a68e5691a654f1d0e610be4379762abf14aafb45"
     },
     {
@@ -1039,7 +1039,7 @@
     {
       "name": "scenario",
       "source_skill": "skills/scenario",
-      "source_hash": "7c14ca7bf2632a1130611d391899ea45862d7aa9bbe6c582fd0f3087a9ee8193",
+      "source_hash": "42ba309f3f2d1e1b806b99e7b3b0d9ace87e1af5802a4ae823d202c7c555fcdd",
       "generated_hash": "1736927301013e0f0aa5492ac60c2b909caee1a7ec232752998d85f1c9767de5"
     },
     {

--- a/skills-codex/knowledge-activation/.agentops-generated.json
+++ b/skills-codex/knowledge-activation/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/knowledge-activation",
   "layout": "modular",
-  "source_hash": "d4d1d689b41948f79ceab7f729d319d37db1bfb17ee7cee7affbfc7434109b77",
+  "source_hash": "a51afc2ae186ccf18f94e581bd7ec67aa31a0ca540f6994ec583ccd9b66fa8de",
   "generated_hash": "2a9c9973fd6d21cd725717c4624f358a41072b2c6ca535580abfddd2cf613985"
 }

--- a/skills-codex/pr-plan/.agentops-generated.json
+++ b/skills-codex/pr-plan/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/pr-plan",
   "layout": "modular",
-  "source_hash": "151c98b645383412ee9d3ca1afbff19d381c675b6ac1ec33ebf43cad74f56f06",
+  "source_hash": "e9774059e07eeb4388bf394afded5f39c636a0df097cbd20ce2e1c4c62908739",
   "generated_hash": "9c642fd106e24221a2120219fcba2da62202a0686d3978c01d94660a6222f336"
 }

--- a/skills-codex/pr-retro/.agentops-generated.json
+++ b/skills-codex/pr-retro/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/pr-retro",
   "layout": "modular",
-  "source_hash": "a382be41def73b78e6f97164829c5dd46fce6aa4d1852dfef357c4469131049e",
+  "source_hash": "6a1a37e38195feed50fb041dd519199fc42224870588ca5437b9a1c23ffa5b2c",
   "generated_hash": "f17bcb9512aaef9e5cffce80a6712146ec1498565e3ee71b2ba9d80a861cee4a"
 }

--- a/skills-codex/product/.agentops-generated.json
+++ b/skills-codex/product/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/product",
   "layout": "modular",
-  "source_hash": "a6e7985e9ae544e5e5303a5f1e4e33c282f75b51c1449f40bcac325982f35456",
+  "source_hash": "a2f51a7e71f2ff23025dc6b6cf806096cd6c2fb4324d426bd180ab256061e9d5",
   "generated_hash": "3c2a4840bedac960a309c4e9a68e5691a654f1d0e610be4379762abf14aafb45"
 }

--- a/skills-codex/scenario/.agentops-generated.json
+++ b/skills-codex/scenario/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual",
   "source_skill": "skills/scenario",
   "layout": "modular",
-  "source_hash": "7c14ca7bf2632a1130611d391899ea45862d7aa9bbe6c582fd0f3087a9ee8193",
+  "source_hash": "42ba309f3f2d1e1b806b99e7b3b0d9ace87e1af5802a4ae823d202c7c555fcdd",
   "generated_hash": "1736927301013e0f0aa5492ac60c2b909caee1a7ec232752998d85f1c9767de5"
 }

--- a/skills/knowledge-activation/SKILL.md
+++ b/skills/knowledge-activation/SKILL.md
@@ -199,3 +199,4 @@ ao knowledge gaps
 - [references/dag.md](references/dag.md)
 - [references/script-contracts.md](references/script-contracts.md)
 - [references/output-surfaces.md](references/output-surfaces.md)
+- [references/knowledge-activation.feature](references/knowledge-activation.feature) — Executable spec: consolidate evidence, distill beliefs/playbooks, compile goal-time briefing, surface gaps (soc-qk4b)

--- a/skills/knowledge-activation/references/knowledge-activation.feature
+++ b/skills/knowledge-activation/references/knowledge-activation.feature
@@ -1,0 +1,29 @@
+# Executable spec for the /knowledge-activation skill — mature-knowledge activation (BC1 Corpus).
+# /knowledge-activation promotes mature .agents knowledge into the operator layer:
+# it consolidates evidence, distills durable beliefs and playbooks, compiles a goal-time
+# briefing, and surfaces gaps. Hexagon: supporting; consumes: mature .agents knowledge;
+# produces: .agents/beliefs.md, .agents/playbooks/*.md, .agents/briefings/*.md. (soc-qk4b)
+
+Feature: Knowledge-activation promotes mature knowledge into operator surfaces
+  As the knowledge flywheel's activation step
+  I want mature, repeated knowledge distilled into beliefs, playbooks, and briefings
+  So that durable insight shapes execution instead of decaying in the backlog
+
+  Background:
+    Given .agents knowledge that has matured past the promotion threshold
+
+  Scenario: Evidence is consolidated before distillation
+    When /knowledge-activation runs
+    Then it consolidates the supporting evidence for candidate knowledge
+
+  Scenario: Durable knowledge is distilled into operator surfaces
+    When consolidation completes
+    Then it distills beliefs and playbooks into the operator layer
+
+  Scenario: A goal-time briefing is compiled
+    When activation targets current goals
+    Then it compiles a goal-time briefing under .agents/briefings/
+
+  Scenario: Gaps are surfaced rather than silently skipped
+    When activation finishes
+    Then it reports knowledge gaps that still need evidence

--- a/skills/pr-plan/SKILL.md
+++ b/skills/pr-plan/SKILL.md
@@ -222,3 +222,7 @@ $pr-research <repo> -> $pr-plan <research> -> implement -> $pr-prep
 | Scope too broad | Multiple concerns mixed | Split by user-visible change or subsystem boundary |
 | Risk section is weak | Missing failure-mode analysis | Add integration, review, and rollback risks explicitly |
 | Plan conflicts with repo norms | Research artifact incomplete | Re-run `$pr-research` and refresh constraints |
+
+## Reference Documents
+
+- [references/pr-plan.feature](references/pr-plan.feature) — Executable spec: bound scope, capture project quality bar + PR requirements, write a plan with a pre-implementation checklist (soc-qk4b)

--- a/skills/pr-plan/references/pr-plan.feature
+++ b/skills/pr-plan/references/pr-plan.feature
@@ -1,0 +1,25 @@
+# Executable spec for the /pr-plan skill — external-contribution planning (BC3 Loop).
+# /pr-plan scopes a focused open-source pull request before any code is written: it pins
+# down scope, the target project's quality bar and PR requirements, the approach, and a
+# pre-implementation checklist, then writes a plan. Hexagon: supporting; consumes: the
+# target repo's contribution norms; produces: .agents/plans/YYYY-MM-DD-pr-*.md. (soc-qk4b)
+
+Feature: PR-plan scopes a focused external contribution before implementation
+  As a contributor to an external project
+  I want scope, quality bar, and approach pinned down before coding
+  So that the PR is focused, accepted, and not a wasted round trip
+
+  Background:
+    Given a target open-source project and a contribution idea
+
+  Scenario: Scope is bounded before approach
+    When /pr-plan runs
+    Then it captures the contribution scope and what is explicitly out of scope
+
+  Scenario: The target project's bar and requirements are captured
+    When planning the contribution
+    Then it records the project's code-quality bar and PR requirements
+
+  Scenario: A plan with a pre-implementation checklist is written
+    When planning completes
+    Then it writes a plan under .agents/plans/ including a pre-implementation checklist

--- a/skills/pr-retro/SKILL.md
+++ b/skills/pr-retro/SKILL.md
@@ -256,3 +256,7 @@ Write to `.agents/learnings/YYYY-MM-DD-pr-{repo}-{outcome}.md`
 | No clear lesson extracted | Analysis stayed descriptive | Convert observations into behavior changes |
 | Maintainer signal is mixed | Contradictory review comments | Separate hard blockers from preference feedback |
 | Process changes not adopted | Lessons not operationalized | Add explicit updates to prep/plan/validate workflow |
+
+## Reference Documents
+
+- [references/pr-retro.feature](references/pr-retro.feature) — Executable spec: categorize PR feedback, extract success/failure patterns by outcome, write a dated PR learning (soc-qk4b)

--- a/skills/pr-retro/references/pr-retro.feature
+++ b/skills/pr-retro/references/pr-retro.feature
@@ -1,0 +1,26 @@
+# Executable spec for the /pr-retro skill — learning from PR outcomes (BC1 Corpus).
+# /pr-retro turns a merged or rejected pull request into durable lessons: it categorizes
+# the feedback, extracts success patterns when merged and failure patterns when rejected,
+# and writes a learning. Hexagon: supporting; consumes: PR feedback + outcome; produces:
+# .agents/learnings/YYYY-MM-DD-pr-*.md. (soc-qk4b)
+
+Feature: PR-retro extracts durable lessons from a PR outcome
+  As an agent compounding review feedback
+  I want each PR's outcome turned into a categorized lesson
+  So that future PRs avoid past rejections and repeat what got merged
+
+  Background:
+    Given a pull request that was merged or rejected, with its feedback
+
+  Scenario: Feedback is categorized by type
+    When /pr-retro runs
+    Then it categorizes the feedback (positive, requested changes, rejection reasons)
+
+  Scenario: Outcome selects success or failure patterns
+    When the PR was merged
+    Then it extracts success patterns
+    And when the PR was rejected it extracts failure patterns
+
+  Scenario: A learning is written to the learnings surface
+    When the retro completes
+    Then it writes a dated PR learning under .agents/learnings/

--- a/skills/product/SKILL.md
+++ b/skills/product/SKILL.md
@@ -374,3 +374,7 @@ Tell the user:
 | No usage data available | Pre-launch or private project | Write "Pre-traction" with a list of metrics to track once launched. The section's presence reminds future updates to fill it in. |
 | `gh api` fails or no GitHub remote | Private repo, no auth, or non-GitHub host | Skip auto-gather gracefully. Ask user to provide metrics manually. |
 | No .agents/ directory for principles | Project doesn't use AgentOps | Skip the validated principles section entirely. Include user-stated design principles instead. |
+
+## Reference Documents
+
+- [references/product.feature](references/product.feature) — Executable spec: context gather, interview-driven PRODUCT.md, product-aware council unlock, quick-mode inline (soc-qk4b)

--- a/skills/product/references/product.feature
+++ b/skills/product/references/product.feature
@@ -1,0 +1,29 @@
+# Executable spec for the /product skill — PRODUCT.md authoring (BC1 Corpus).
+# /product guides the user through creating or refining a PRODUCT.md (problem, audience,
+# differentiator, market position) that unlocks product-aware reviews in /pre-mortem
+# and /vibe. Hexagon: domain; consumes: project context + interview answers; produces:
+# PRODUCT.md. (soc-qk4b)
+
+Feature: Product authors a PRODUCT.md that unlocks product-aware review
+  As a maintainer framing a product
+  I want a structured PRODUCT.md derived from real project context
+  So that /pre-mortem and /vibe can judge changes against product intent
+
+  Background:
+    Given a repository with optional existing PRODUCT.md and manifest files
+
+  Scenario: Context is gathered before the interview
+    When /product runs
+    Then it reads existing product framing and project manifests as context
+
+  Scenario: An interview drives the generated PRODUCT.md
+    When the interview completes
+    Then it generates a PRODUCT.md covering problem, audience, and differentiator
+
+  Scenario: PRODUCT.md unlocks product-aware council review
+    Given a PRODUCT.md exists
+    Then /pre-mortem and /vibe judge changes against the stated product intent
+
+  Scenario: Quick mode produces inline framing without a full interview
+    When quick mode is used
+    Then a concise PRODUCT.md is produced through the default inline path

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -173,6 +173,7 @@ is the weighted average across all vectors.
 
 - [Scenario Schema Reference](references/scenario-schema.md) -- full field
   documentation and example JSON for the scenario schema
+- [references/scenario.feature](references/scenario.feature) — Executable spec: author holdout scenarios, schema-validate, list + link to GOALS directives, feed /validation (soc-qk4b)
 
 ## Troubleshooting
 

--- a/skills/scenario/references/scenario.feature
+++ b/skills/scenario/references/scenario.feature
@@ -1,0 +1,29 @@
+# Executable spec for the /scenario skill — holdout scenario management (BC4 Evidence & Trust).
+# /scenario creates, validates, and lists holdout scenarios under .agents/holdout/, links
+# them to GOALS.md directives, and feeds them into /validation's behavioral checks. Hexagon:
+# supporting; consumes: scenario definitions + the scenario schema; produces: validated
+# holdout scenario artifacts in .agents/holdout/*.json. (soc-qk4b)
+
+Feature: Scenario manages holdout scenarios for behavioral validation
+  As an agent guarding against regressions
+  I want holdout scenarios authored, schema-validated, and linked to goals
+  So that /validation can score behavior against a held-out set
+
+  Background:
+    Given a holdout directory under .agents/holdout/
+
+  Scenario: Scenarios are authored into the holdout directory
+    When /scenario authors a scenario
+    Then it writes a scenario artifact under .agents/holdout/
+
+  Scenario: Scenarios are validated against the schema
+    When /scenario validates
+    Then each scenario is checked against the scenario schema and failures are reported
+
+  Scenario: Scenarios are listable and linkable to GOALS directives
+    When /scenario lists
+    Then it shows the holdout scenarios and their links to GOALS.md directives
+
+  Scenario: Holdout scenarios feed validation
+    When /validation runs
+    Then it consumes the holdout scenarios for behavioral scoring


### PR DESCRIPTION
W2 of the 3.0 reconciliation — **hexagon crank tail, batch 2** (61/80 cranked after this). No behavior/frontmatter change.

| Skill | Acceptance added |
|---|---|
| product | interview-driven PRODUCT.md, product-aware council unlock, quick-mode |
| scenario | author/validate/list holdout scenarios, GOALS links, feed /validation |
| knowledge-activation | consolidate evidence, distill beliefs/playbooks, goal-time briefing, gaps |
| pr-plan | bound scope, capture quality bar + PR reqs, plan + pre-impl checklist |
| pr-retro | categorize feedback, success/failure patterns by outcome, dated learning |

Each .feature linked in SKILL.md; registry + codex hashes regenerated deterministically.

Gates: registry --check OK; codex-parity ✓×5; heal --strict clean ×5; check-skill-size 0/0.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-qk4b#crank-batch2
Bounded-context: BC1-Corpus
Evidence: skills/product/references/product.feature