### PR TITLE
feat(skills): add canonical .feature acceptance to 5 skills — batch 3 (soc-qk4b #crank-batch3)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-23T20:18:40Z",
+  "generated_at": "2026-05-23T20:33:37Z",
   "summary": {
     "skills": 80,
     "hooks": 44,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -835,13 +835,13 @@
     {
       "name": "heal-skill",
       "source_skill": "skills/heal-skill",
-      "source_hash": "ee1fe30876171d1e314c48d6b60b1870e32f9f5a683096fed7fa7c7ddd7e66a3",
+      "source_hash": "9f3ce2fe334237343ad6cf87cf5ec063e4bf01ef74814821e3671cb70f02c9ae",
       "generated_hash": "0a4b01de799212b1c33f718aba85c1ea0e03a033542a8e81929ddbd52425ab4b"
     },
     {
       "name": "hooks-authoring",
       "source_skill": "skills/hooks-authoring",
-      "source_hash": "96993f1b4ace90e05661e4c02f4ee9f95da28bd08e435bdb6537675e627012eb",
+      "source_hash": "7f74f159c6fb955ebfc707abc1063cfc08658f3ab2ce90a6e4b1211d910fdb2a",
       "generated_hash": "d0af71012da70768cd4ebc38297f3dcf6bc72b3fb6e5af0b202224bc999ca177"
     },
     {
@@ -1075,13 +1075,13 @@
     {
       "name": "skill-auditor",
       "source_skill": "skills/skill-auditor",
-      "source_hash": "b20273349c32d351807358d2b17e5df6fd2fad810109f125b2fcd49695f3b9ab",
+      "source_hash": "1cded02f750fa58595d8c109c17553067223c0c488fc56a19436df582abdec84",
       "generated_hash": "d4b6b96a99ee41c85d3997df8572d081cd3d42d10664ef66a8700bb2090660db"
     },
     {
       "name": "skill-builder",
       "source_skill": "skills/skill-builder",
-      "source_hash": "a445c06557c008cdfc7901c198b386d4c8c18a581d8c66592a6ccb5b96a7b70f",
+      "source_hash": "9e5893b6be6648f018750d964d6f897852284917ad8056be3c84ab25234afe34",
       "generated_hash": "d43759463b9acf0b05e1fe386939e2df9c8d847537cce42f846f1d22177ea1c7"
     },
     {
@@ -1111,7 +1111,7 @@
     {
       "name": "system-tuning",
       "source_skill": "skills/system-tuning",
-      "source_hash": "aaa2b3f3606f0a1cb3866a516485322401a34f41f82428d31bb49d3ab6497a47",
+      "source_hash": "70a4f25145c6a7cb67b1d615016dc7ee30e9e7c47c1fb201892e159c457c96d7",
       "generated_hash": "f43aad025c7a7b89b7b5c2bc7376ef973b24a454d0f32fa6e40bd19195b845c7"
     },
     {

--- a/skills-codex/heal-skill/.agentops-generated.json
+++ b/skills-codex/heal-skill/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/heal-skill",
   "layout": "modular",
-  "source_hash": "ee1fe30876171d1e314c48d6b60b1870e32f9f5a683096fed7fa7c7ddd7e66a3",
+  "source_hash": "9f3ce2fe334237343ad6cf87cf5ec063e4bf01ef74814821e3671cb70f02c9ae",
   "generated_hash": "0a4b01de799212b1c33f718aba85c1ea0e03a033542a8e81929ddbd52425ab4b"
 }

--- a/skills-codex/hooks-authoring/.agentops-generated.json
+++ b/skills-codex/hooks-authoring/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/hooks-authoring",
   "layout": "modular",
-  "source_hash": "96993f1b4ace90e05661e4c02f4ee9f95da28bd08e435bdb6537675e627012eb",
+  "source_hash": "7f74f159c6fb955ebfc707abc1063cfc08658f3ab2ce90a6e4b1211d910fdb2a",
   "generated_hash": "d0af71012da70768cd4ebc38297f3dcf6bc72b3fb6e5af0b202224bc999ca177"
 }

--- a/skills-codex/skill-auditor/.agentops-generated.json
+++ b/skills-codex/skill-auditor/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/skill-auditor",
   "layout": "modular",
-  "source_hash": "b20273349c32d351807358d2b17e5df6fd2fad810109f125b2fcd49695f3b9ab",
+  "source_hash": "1cded02f750fa58595d8c109c17553067223c0c488fc56a19436df582abdec84",
   "generated_hash": "d4b6b96a99ee41c85d3997df8572d081cd3d42d10664ef66a8700bb2090660db"
 }

--- a/skills-codex/skill-builder/.agentops-generated.json
+++ b/skills-codex/skill-builder/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/skill-builder",
   "layout": "modular",
-  "source_hash": "a445c06557c008cdfc7901c198b386d4c8c18a581d8c66592a6ccb5b96a7b70f",
+  "source_hash": "9e5893b6be6648f018750d964d6f897852284917ad8056be3c84ab25234afe34",
   "generated_hash": "d43759463b9acf0b05e1fe386939e2df9c8d847537cce42f846f1d22177ea1c7"
 }

--- a/skills-codex/system-tuning/.agentops-generated.json
+++ b/skills-codex/system-tuning/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/system-tuning",
   "layout": "modular",
-  "source_hash": "aaa2b3f3606f0a1cb3866a516485322401a34f41f82428d31bb49d3ab6497a47",
+  "source_hash": "70a4f25145c6a7cb67b1d615016dc7ee30e9e7c47c1fb201892e159c457c96d7",
   "generated_hash": "f43aad025c7a7b89b7b5c2bc7376ef973b24a454d0f32fa6e40bd19195b845c7"
 }

--- a/skills/heal-skill/SKILL.md
+++ b/skills/heal-skill/SKILL.md
@@ -184,3 +184,4 @@ One line per finding:
 
 - [references/skill-stocktake.md](references/skill-stocktake.md)
 - [references/codex-parity.md](references/codex-parity.md)
+- [references/heal-skill.feature](references/heal-skill.feature) — Executable spec: detect hygiene issues, flag Codex-parity drift, auto-fix + report, --strict fails on remaining findings (soc-qk4b)

--- a/skills/heal-skill/references/heal-skill.feature
+++ b/skills/heal-skill/references/heal-skill.feature
@@ -1,0 +1,28 @@
+# Executable spec for the /heal-skill skill — skill hygiene repair (BC1 Corpus / Skill Catalog).
+# /heal-skill detects and auto-fixes common SKILL.md hygiene issues across skills/ (including
+# unlinked references and Codex-parity drift), then reports what it changed. Hexagon:
+# supporting; consumes: the skills/ tree; produces: a heal report + auto-fixed skill files. (soc-qk4b)
+
+Feature: Heal-skill repairs skill hygiene across the catalog
+  As a catalog maintainer
+  I want common hygiene issues detected and auto-fixed
+  So that skills stay well-formed without manual sweeps
+
+  Background:
+    Given the skills/ directory with one or more skills
+
+  Scenario: The heal script detects hygiene issues
+    When /heal-skill runs
+    Then it scans skills for hygiene issues including unlinked references
+
+  Scenario: Codex parity drift is flagged
+    When the Codex bundle looks wrong
+    Then it audits and reports Codex-parity drift
+
+  Scenario: Fixable issues are auto-fixed and reported
+    When issues are found
+    Then it auto-fixes the fixable ones and reports what changed
+
+  Scenario: Strict mode fails on remaining findings
+    When run with --strict
+    Then it reports a non-clean result when unresolved findings remain

--- a/skills/hooks-authoring/SKILL.md
+++ b/skills/hooks-authoring/SKILL.md
@@ -92,3 +92,4 @@ Use this skill when work touches `hooks/hooks.json`, `hooks/*.sh`,
 - [references/event-taxonomy.md](references/event-taxonomy.md)
 - [references/matcher-patterns.md](references/matcher-patterns.md)
 - [references/test-harness.md](references/test-harness.md)
+- [references/hooks-authoring.feature](references/hooks-authoring.feature) — Executable spec: author event-bound hook script, register in manifest, ship tests + evidence, review-mode portability check (soc-qk4b)

--- a/skills/hooks-authoring/references/hooks-authoring.feature
+++ b/skills/hooks-authoring/references/hooks-authoring.feature
@@ -1,0 +1,29 @@
+# Executable spec for the /hooks-authoring skill — runtime hook authoring (BC5 Runtime).
+# /hooks-authoring creates or reviews AgentOps runtime hooks with portable behavior: a hook
+# script, its manifest entry, tests, and validation evidence — so a hook is a bounded,
+# tested adapter rather than ad-hoc glue. Hexagon: domain; consumes: a hook intent + the
+# hooks manifest contract; produces: hook script + manifest entry + tests + evidence. (soc-qk4b)
+
+Feature: Hooks-authoring produces bounded, tested runtime hooks
+  As an author extending the runtime
+  I want a hook delivered with its manifest entry, tests, and evidence
+  So that hooks are bounded adapters, not unaudited glue
+
+  Background:
+    Given a hook intent and the hooks manifest contract
+
+  Scenario: A hook script is authored for the right event
+    When /hooks-authoring creates a hook
+    Then it produces a hook script bound to the correct lifecycle event
+
+  Scenario: The hook is registered in the manifest
+    When the hook script exists
+    Then a matching manifest entry is added so the runtime loads it
+
+  Scenario: The hook ships with tests and validation evidence
+    When authoring completes
+    Then it produces tests and validation evidence for the hook's behavior
+
+  Scenario: Review mode checks an existing hook for portability
+    When /hooks-authoring reviews an existing hook
+    Then it checks portability and bounded behavior rather than re-authoring it

--- a/skills/skill-auditor/SKILL.md
+++ b/skills/skill-auditor/SKILL.md
@@ -190,6 +190,7 @@ bash skills/skill-auditor/scripts/audit.sh --strict skills/my-skill
 - [references/skill-template.md](references/skill-template.md) — canonical SKILL.md template (copy of skill-builder's; per CLAUDE.md no-symlinks rule)
 - [references/audit-checks.md](references/audit-checks.md) — per-check detection logic + accepted forms + PRODUCT.md mapping
 - [references/context-density-checks.md](references/context-density-checks.md) — advisory density coverage logic and false-positive handling
+- [references/skill-auditor.feature](references/skill-auditor.feature) — Executable spec: Pass 1 heal-skill delegation, Pass 2 structural checks, density report + productization score (soc-qk4b)
 
 ## Scripts
 

--- a/skills/skill-auditor/references/skill-auditor.feature
+++ b/skills/skill-auditor/references/skill-auditor.feature
@@ -1,0 +1,25 @@
+# Executable spec for the /skill-auditor skill — skill template audit (BC1 Corpus / Skill Catalog).
+# /skill-auditor audits an existing SKILL.md against the unified template: Pass 1 delegates
+# to heal-skill for hygiene, Pass 2 runs additional structural checks, then it emits a
+# density report and a productization score. Hexagon: supporting; consumes: a SKILL.md +
+# the template; produces: audit-report.json. (soc-qk4b)
+
+Feature: Skill-auditor scores a skill against the unified template
+  As a catalog maintainer
+  I want each skill audited for hygiene and structure
+  So that drift from the template is caught before it ships
+
+  Background:
+    Given an existing SKILL.md and the unified template
+
+  Scenario: Pass 1 delegates hygiene to heal-skill
+    When /skill-auditor runs
+    Then Pass 1 delegates the hygiene checks to heal-skill
+
+  Scenario: Pass 2 runs the additional structural checks
+    When Pass 1 completes
+    Then Pass 2 runs the additional template-conformance checks
+
+  Scenario: A density report and productization score are emitted
+    When both passes complete
+    Then it emits an advisory density report and a productization score in audit-report.json

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -169,3 +169,4 @@ skills-codex/<name>/
 
 - [references/skill-template.md](references/skill-template.md) — canonical SKILL.md template + auditor checklist + PRODUCT.md alignment
 - [references/agentops-skill-factory.md](references/agentops-skill-factory.md) — clean-room factory workflow and productization rules
+- [references/skill-builder.feature](references/skill-builder.feature) — Executable spec: mode dispatch, materialize from template, Codex parity bundle, self-audit + factory score (soc-qk4b)

--- a/skills/skill-builder/references/skill-builder.feature
+++ b/skills/skill-builder/references/skill-builder.feature
@@ -1,0 +1,29 @@
+# Executable spec for the /skill-builder skill — skill scaffolding (BC1 Corpus / Skill Catalog).
+# /skill-builder scaffolds a new SKILL.md (or absorbs an existing one) against the unified
+# AgentOps template, then generates the Codex parity bundle, self-audits, and overlays a
+# factory score. Hexagon: supporting; consumes: a build request + the unified template;
+# produces: a new skill + build-report.json. (soc-qk4b)
+
+Feature: Skill-builder materializes template-conformant skills
+  As an author adding a skill to the catalog
+  I want it scaffolded from the unified template and parity-checked
+  So that every new skill is well-formed and Codex-mirrored from the start
+
+  Background:
+    Given the unified AgentOps SKILL.md template
+
+  Scenario: A mode is dispatched for build or absorb
+    When /skill-builder runs
+    Then it dispatches the requested mode (scaffold a new skill or absorb an existing one)
+
+  Scenario: The skill is materialized from the template
+    When the build proceeds
+    Then it produces a SKILL.md conformant to the unified template
+
+  Scenario: The Codex parity bundle is generated
+    When the skill is materialized
+    Then it generates the matching skills-codex bundle and hashes
+
+  Scenario: The build self-audits and scores before reporting
+    When materialization completes
+    Then it self-audits the result and overlays a factory score in build-report.json

--- a/skills/system-tuning/SKILL.md
+++ b/skills/system-tuning/SKILL.md
@@ -148,6 +148,7 @@ Run reports go to `.agents/system-tuning/YYYY-MM-DD-triage.md`. Each report incl
 - [references/kill-hierarchy.md](references/kill-hierarchy.md)
 - [references/whack-a-mole-anti-pattern.md](references/whack-a-mole-anti-pattern.md)
 - [references/agent-swarm-cleanup.md](references/agent-swarm-cleanup.md)
+- [references/system-tuning.feature](references/system-tuning.feature) — Executable spec: diagnose-first, ordered safe cleanup hierarchy, protect in-flight processes, verify + report (soc-qk4b)
 
 ## Attribution
 

--- a/skills/system-tuning/references/system-tuning.feature
+++ b/skills/system-tuning/references/system-tuning.feature
@@ -1,0 +1,29 @@
+# Executable spec for the /system-tuning skill — safe responsiveness triage (BC5 Runtime).
+# /system-tuning restores a sluggish dev box through a safe, ordered process cleanup —
+# diagnose first, then clean zombies and exited sessions, kill stuck children, fix confused
+# parents, renice survivors, and verify — without nuking work in flight. Hexagon: supporting;
+# consumes: process/system state; produces: a triage report + protected-process warnings. (soc-qk4b)
+
+Feature: System-tuning restores responsiveness without nuking work in flight
+  As an operator on a sluggish dev box
+  I want an ordered, safe cleanup that spares live work
+  So that responsiveness returns without losing in-flight sessions
+
+  Background:
+    Given a sluggish development host with mixed live and stale processes
+
+  Scenario: Diagnosis happens before any process is touched
+    When /system-tuning runs
+    Then it diagnoses the load before killing anything
+
+  Scenario: Cleanup follows a safe ordered hierarchy
+    When cleanup proceeds
+    Then it cleans zombies and exited sessions, kills stuck children, fixes confused parents, then renices survivors
+
+  Scenario: Protected processes are warned, not killed
+    When a protected or in-flight process is encountered
+    Then it is spared and a warning is emitted rather than terminating it
+
+  Scenario: The result is verified and reported
+    When cleanup completes
+    Then it verifies responsiveness and emits a triage report


### PR DESCRIPTION
W2 of the 3.0 reconciliation — **hexagon crank tail, batch 3** (66/80 cranked after this). Skill/hook authoring + tuning cluster. No behavior/frontmatter change.

| Skill | Acceptance added |
|---|---|
| skill-builder | mode dispatch, materialize from template, Codex parity, self-audit + factory score |
| skill-auditor | Pass 1 heal delegation, Pass 2 structural checks, density + productization score |
| heal-skill | detect hygiene, flag parity drift, auto-fix + report, --strict |
| hooks-authoring | event-bound hook script, manifest entry, tests + evidence, review mode |
| system-tuning | diagnose-first, ordered safe cleanup, protect in-flight, verify + report |

Each .feature linked in SKILL.md; registry + codex hashes regenerated deterministically.

Gates: registry --check OK; codex-parity ✓×5; heal --strict clean ×5; check-skill-size 0/0.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-qk4b#crank-batch3
Bounded-context: BC1-Corpus
Evidence: skills/skill-builder/references/skill-builder.feature