### PR TITLE
fix(docs): codex-hookless-lifecycle — Codex CLI has native hooks (soc-isewi #codex-cli-has-hooks)

### DIFF
--- a/docs/architecture/codex-hookless-lifecycle.md
+++ b/docs/architecture/codex-hookless-lifecycle.md
@@ -2,7 +2,7 @@
 
 > **Note:** Codex supports native hooks, but AgentOps installs hookless by default. Native hooks are an optional `scripts/install-codex-plugin.sh --with-hooks` / `scripts/install-codex.sh --with-hooks` profile. The hookless lifecycle remains the first-value path because packets, explicit gates, and closeout artifacts are portable across runtimes.
 
-AgentOps originally assumed a hook-capable runtime lifecycle such as Claude/OpenCode `session-start`, `session-end`, and `stop`. Codex Desktop does not expose that lifecycle surface under `~/.codex`, so the Codex runtime needs an explicit fallback that keeps the flywheel working without pretending hooks exist.
+AgentOps originally assumed a hook-capable runtime lifecycle such as Claude/OpenCode `session-start`, `session-end`, and `stop`. Codex CLI (0.115.0+) *does* expose native hooks — AgentOps wires the same hook scripts via `hooks/codex-hooks.json` under the optional `--with-hooks` profile — but installs **hookless by default** for portability, and the Codex **Desktop** app exposes no `~/.codex` hook surface at all. So the Codex runtime needs an explicit lifecycle path that keeps the flywheel working whether or not native hooks are present, rather than assuming them.
 
 ## Why This Exists
 
@@ -14,8 +14,8 @@ AgentOps originally assumed a hook-capable runtime lifecycle such as Claude/Open
 
 | Mode | Detection | Start path | Closeout path | Guarantees |
 |------|-----------|------------|---------------|------------|
-| `hook-capable` | Claude/OpenCode runtime plus installed hook surfaces | SessionStart hook or explicit `ao inject` | SessionEnd/Stop hooks or explicit `ao forge transcript` + `ao flywheel close-loop` | Startup injection and close-loop maintenance can be automatic when hooks are installed |
-| `codex-hookless-fallback` | Codex env/session metadata and no hook surface under `~/.codex` | `ao codex start` or skill-driven `ao codex ensure-start` | `ao codex stop` or skill-driven `ao codex ensure-stop` | Explicit startup context, transcript discovery fallback, citation capture, session-end-equivalent maintenance, and persisted lifecycle state |
+| `hook-capable` | Claude/OpenCode, or Codex CLI 0.115.0+ installed with `--with-hooks`, plus installed hook surfaces | SessionStart hook or explicit `ao inject` | SessionEnd/Stop hooks or explicit `ao forge transcript` + `ao flywheel close-loop` | Startup injection and close-loop maintenance can be automatic when hooks are installed |
+| `codex-hookless-fallback` | Codex env/session metadata with no native-hook profile installed (Desktop app, or CLI installed hookless) | `ao codex start` or skill-driven `ao codex ensure-start` | `ao codex stop` or skill-driven `ao codex ensure-stop` | Explicit startup context, transcript discovery fallback, citation capture, session-end-equivalent maintenance, and persisted lifecycle state |
 | `manual` | No hooks and no Codex-specific runtime detection | `ao inject` / `ao lookup` | `ao forge transcript` + `ao flywheel close-loop` | Portable low-level workflow with no hidden lifecycle assumptions |
 
 ## Command Responsibilities


### PR DESCRIPTION
Docs-match-reality fix (same bug class as the W1 reconciliation). The doc implied Codex is hookless *because it lacks a hook surface* — contradicting its own top Note ("Codex supports native hooks"), docs/HOOKS.md (Codex CLI 0.115.0+ native hooks; 0.128.0 same PreToolUse schema as Claude), and hooks/codex-hooks.json (wires the same scripts under `--with-hooks`).

- **Intro:** Codex CLI (0.115.0+) *does* expose native hooks; AgentOps installs hookless **by default for portability**; the Codex **Desktop** app has no `~/.codex` hook surface. Lifecycle path works hooks-or-not.
- **Runtime Modes table:** hook-capable row includes Codex CLI 0.115.0+ `--with-hooks`; fallback detection reframed to "no native-hook profile installed (Desktop, or CLI installed hookless)".

Now consistent with the top Note + HOOKS.md. Surfaced when this doc caused a wrong answer about Codex hook capability.

NOTE: claude-review infra-red (weekly limit, resets May 25) — operator-authorized bypass when sole red.

Closes-scenario: soc-isewi#codex-cli-has-hooks
Bounded-context: BC5-Runtime
Evidence: docs/architecture/codex-hookless-lifecycle.md