### PR TITLE
fix(daemon): bound heartbeat goroutine lifecycle to prevent leak (soc-yyrrq #heartbeat-leak)

### DIFF
--- a/cli/internal/daemon/supervisor.go
+++ b/cli/internal/daemon/supervisor.go
@@ -186,15 +186,30 @@ func (s *Supervisor) runExecutorWithHeartbeat(ctx context.Context, executor JobE
 	if s.executionTimeout > 0 {
 		execCtx, cancel = context.WithTimeout(ctx, s.executionTimeout)
 	}
-	defer cancel()
 	type execution struct {
 		result JobExecutionResult
 		err    error
 	}
+	// Buffered (cap 1) so the worker's send never blocks even after an early
+	// return leaves no receiver — the worker can always complete and exit.
 	done := make(chan execution, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		result, err := safeRunJob(execCtx, executor, claim)
 		done <- execution{result: result, err: err}
+	}()
+	// Single deferred teardown so the worker goroutine has a guaranteed
+	// lifecycle on EVERY exit path: cancel() first to signal the worker to
+	// stop, then wg.Wait() to join it so the goroutine is reaped rather than
+	// leaked. Ordering matters — cancel must precede the wait or the join
+	// would block, so they live in one closure instead of two LIFO defers. A
+	// context-respecting executor returns promptly once cancelled, so the join
+	// does not stall the supervisor.
+	defer func() {
+		cancel()
+		wg.Wait()
 	}()
 
 	ticker := time.NewTicker(s.heartbeatInterval)

--- a/cli/internal/daemon/supervisor_test.go
+++ b/cli/internal/daemon/supervisor_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"errors"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -170,6 +171,119 @@ func TestSupervisor_KillsHungWorker(t *testing.T) {
 	}
 	if result.Job.Failure == nil || !strings.Contains(result.Job.Failure.Message, "executor timed out") {
 		t.Fatalf("failure = %#v, want timeout failure", result.Job.Failure)
+	}
+}
+
+// TestSupervisor_HeartbeatGoroutineDoesNotLeak asserts that
+// runExecutorWithHeartbeat reaps its spawned executor goroutine on every exit
+// path — the fast/normal completion path, the mid-run context-cancel path, and
+// the execution-timeout path — so the daemon does not accumulate leaked
+// goroutines over its long lifetime.
+//
+// The cancel and timeout sub-tests use slowCleanupExecutor, which observes ctx
+// cancellation but then spends a real cleanup window before returning. Without
+// the worker join, runExecutorWithHeartbeat would return while that goroutine
+// is still alive (a transient-but-real leak that accumulates under load); with
+// the join, the goroutine is guaranteed dead before the call returns, so the
+// count is back at baseline *immediately* — no settle window required. Each
+// sub-test uses sync signals (started/released channels) rather than bare
+// sleeps to stay non-flaky.
+func TestSupervisor_HeartbeatGoroutineDoesNotLeak(t *testing.T) {
+	t.Run("fast executor completes and reaps goroutine", func(t *testing.T) {
+		now := projectionTestTime(t, 0)
+		queue := newTestQueue(t, &now, QueueOptions{LeaseDuration: time.Minute})
+		if _, err := queue.SubmitJob(SubmitJobInput{RequestID: "req-fast", JobID: "job-fast", JobType: JobTypeOpenClawSnapshot}, QueueMutationOptions{}); err != nil {
+			t.Fatalf("submit job: %v", err)
+		}
+		supervisor := newTestSupervisor(t, queue, testOpenClawSnapshotExecutor{})
+
+		runtime.GC()
+		baseline := runtime.NumGoroutine()
+		result, err := supervisor.RunOnce(context.Background())
+		if err != nil {
+			t.Fatalf("run once: %v", err)
+		}
+		if result.Job.Status != JobStatusCompleted {
+			t.Fatalf("job status = %q, want completed", result.Job.Status)
+		}
+		assertGoroutinesAtBaseline(t, baseline)
+	})
+
+	t.Run("context cancel mid-run reaps goroutine before return", func(t *testing.T) {
+		now := projectionTestTime(t, 0)
+		queue := newTestQueue(t, &now, QueueOptions{LeaseDuration: time.Minute})
+		if _, err := queue.SubmitJob(SubmitJobInput{RequestID: "req-cancel", JobID: "job-cancel", JobType: JobTypeOpenClawSnapshot}, QueueMutationOptions{}); err != nil {
+			t.Fatalf("submit job: %v", err)
+		}
+		executor := &slowCleanupExecutor{started: make(chan struct{}), cleanup: 80 * time.Millisecond}
+		supervisor := newTestSupervisor(t, queue, executor)
+
+		runtime.GC()
+		baseline := runtime.NumGoroutine()
+		ctx, cancel := context.WithCancel(context.Background())
+		returned := make(chan struct{})
+		go func() {
+			_, _ = supervisor.RunOnce(ctx)
+			close(returned)
+		}()
+		// Wait for the worker to be running, then cancel mid-run so we exercise
+		// the cancel exit path while the executor is still in its cleanup window.
+		select {
+		case <-executor.started:
+		case <-time.After(time.Second):
+			t.Fatal("executor did not start")
+		}
+		cancel()
+		select {
+		case <-returned:
+		case <-time.After(2 * time.Second):
+			t.Fatal("RunOnce did not return after context cancellation")
+		}
+		// No settle window: the join must already have reaped the worker by the
+		// time RunOnce returned, even though its cleanup window outlasts cancel.
+		assertGoroutinesAtBaseline(t, baseline)
+	})
+
+	t.Run("execution timeout reaps goroutine before return", func(t *testing.T) {
+		now := projectionTestTime(t, 0)
+		queue := newTestQueue(t, &now, QueueOptions{LeaseDuration: time.Minute})
+		if _, err := queue.SubmitJob(SubmitJobInput{RequestID: "req-timeout", JobID: "job-timeout", JobType: JobTypeOpenClawSnapshot}, QueueMutationOptions{}); err != nil {
+			t.Fatalf("submit job: %v", err)
+		}
+		executor := &slowCleanupExecutor{started: make(chan struct{}), cleanup: 80 * time.Millisecond}
+		supervisor := newTestSupervisor(t, queue, executor)
+		supervisor.executionTimeout = 20 * time.Millisecond
+
+		runtime.GC()
+		baseline := runtime.NumGoroutine()
+		result, err := supervisor.RunOnce(context.Background())
+		if err != nil {
+			t.Fatalf("run once: %v", err)
+		}
+		if result.Job.Status != JobStatusFailed {
+			t.Fatalf("job status = %q, want failed", result.Job.Status)
+		}
+		if result.Job.Failure == nil || !strings.Contains(result.Job.Failure.Message, "executor timed out") {
+			t.Fatalf("failure = %#v, want timeout failure", result.Job.Failure)
+		}
+		assertGoroutinesAtBaseline(t, baseline)
+	})
+}
+
+// assertGoroutinesAtBaseline fails if the current goroutine count exceeds the
+// pre-run baseline. A single short retry absorbs scheduler jitter from
+// runtime-internal goroutines without masking a genuine leak (a leaked worker
+// never returns to baseline; transient runtime goroutines do within one tick).
+func assertGoroutinesAtBaseline(t *testing.T, baseline int) {
+	t.Helper()
+	runtime.GC()
+	if after := runtime.NumGoroutine(); after > baseline {
+		// One brief retry for runtime/GC bookkeeping goroutines.
+		time.Sleep(20 * time.Millisecond)
+		runtime.GC()
+		if after = runtime.NumGoroutine(); after > baseline {
+			t.Fatalf("goroutine leak: baseline=%d after=%d (%d leaked) — executor goroutine outlived runExecutorWithHeartbeat", baseline, after, after-baseline)
+		}
 	}
 }
 
@@ -347,6 +461,27 @@ func (e *oneShotPanicExecutor) RunJob(_ context.Context, _ QueueLease) (JobExecu
 		panic(e.panicValue)
 	}
 	return JobExecutionResult{Artifacts: map[string]string{"executor_policy": "recovered"}}, nil
+}
+
+// slowCleanupExecutor observes context cancellation but then spends a real
+// cleanup window before returning, modelling a well-behaved executor whose
+// teardown outlasts the cancel signal. It is used to prove that
+// runExecutorWithHeartbeat joins its worker goroutine before returning rather
+// than leaving it running during that window.
+type slowCleanupExecutor struct {
+	started chan struct{}
+	cleanup time.Duration
+}
+
+func (e *slowCleanupExecutor) JobTypes() []JobType {
+	return []JobType{JobTypeOpenClawSnapshot}
+}
+
+func (e *slowCleanupExecutor) RunJob(ctx context.Context, _ QueueLease) (JobExecutionResult, error) {
+	close(e.started)
+	<-ctx.Done()
+	time.Sleep(e.cleanup) // simulated post-cancel teardown
+	return JobExecutionResult{}, ctx.Err()
 }
 
 type blockingOpenClawExecutor struct {


### PR DESCRIPTION
## Summary

`runExecutorWithHeartbeat` (BC5-Runtime daemon supervisor) spawned the executor goroutine but **abandoned it on the cancel and timeout exit paths**: the function returned while the worker was still running. A well-behaved executor whose teardown outlasts the cancel signal — or any executor slow to observe cancellation — left its goroutine alive past the call. The daemon is long-running, so these accumulate.

### The leak (file:line)
`cli/internal/daemon/supervisor.go` — the `for`/`select` in `runExecutorWithHeartbeat` had three early-return paths (`<-ctx.Done()`, `<-execCtx.Done()`, heartbeat error) that returned without joining the worker goroutine spawned at the top of the function. `defer cancel()` signalled the worker but nothing waited for it to exit. Empirically: **1 leaked goroutine** per cancel/timeout return against a context-respecting executor with a post-cancel teardown window.

### The fix
- Wrap the worker in a `sync.WaitGroup`.
- Replace bare `defer cancel()` with a single deferred teardown closure: `cancel()` first (signal the worker to stop), then `wg.Wait()` (join it) — ordered inside one closure so the cancel always precedes the wait.
- The worker is now reaped **before** `runExecutorWithHeartbeat` returns on every exit path. The buffered `done` channel (cap 1) already guarantees the worker can complete its send when no receiver remains.
- `ticker.Stop()` stays deferred; normal-path behavior (heartbeats at interval, executor result/error including the `safeRunJob` panic path, timeout wrapping) is **unchanged**.

Builds on soc-as401 (`safeRunJob` panic recovery, #484) in the same function — does not revert it.

### Test
`TestSupervisor_HeartbeatGoroutineDoesNotLeak` asserts goroutine count returns to baseline **immediately** after `RunOnce` returns, on three paths: fast completion, context-cancel mid-run, and execution timeout. `slowCleanupExecutor` models a post-cancel teardown window so the assertion distinguishes "joined" from "abandoned". Sync signals (started channel), not bare sleeps.

**Verified as a real detector:** fails on origin/main (`1 leaked` goroutine on the cancel + timeout sub-tests), passes with the fix.

### Validation
- `gofmt -l`: clean
- `go build ./...`: success
- `go vet ./internal/daemon/...`: no issues
- `go test ./internal/daemon/ -race -count=3`: 1077 passed (non-flaky)
- `go test ./...`: 11860 passed in 65 packages

Diff: `supervisor.go` +16/-1, `supervisor_test.go` +135.

Closes-scenario: soc-yyrrq#heartbeat-leak
Bounded-context: BC5-Runtime
Evidence: cli/internal/daemon/supervisor_test.go