### PR TITLE
fix(daemon): validate job payload shape before ledger append (soc-qra05 #payload-validation)

### DIFF
--- a/cli/internal/daemon/jobs.go
+++ b/cli/internal/daemon/jobs.go
@@ -172,6 +172,11 @@ func (q *Queue) SubmitJob(input SubmitJobInput, opts QueueMutationOptions) (Queu
 	if err := ValidateJobType(input.JobType); err != nil {
 		return QueueJobState{}, err
 	}
+	// Shape-validate the payload BEFORE any ledger append so a malformed payload
+	// for a known JobType never contaminates the ledger (soc-qra05).
+	if err := validateJobPayload(input.JobType, input.Payload); err != nil {
+		return QueueJobState{}, err
+	}
 	if strings.TrimSpace(input.JobID) == "" {
 		input.JobID = q.nextID("job", string(input.JobType))
 	}

--- a/cli/internal/daemon/server.go
+++ b/cli/internal/daemon/server.go
@@ -660,6 +660,9 @@ func isQueueValidationError(err error) bool {
 	if err == nil {
 		return false
 	}
+	if errors.Is(err, ErrInvalidJobPayload) {
+		return true
+	}
 	msg := err.Error()
 	return strings.HasPrefix(msg, "invalid job type ") ||
 		strings.HasPrefix(msg, "request_id ") ||

--- a/cli/internal/daemon/validate_payload.go
+++ b/cli/internal/daemon/validate_payload.go
@@ -1,0 +1,91 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrInvalidJobPayload marks a submitted job payload that does not match the
+// structural shape of its JobType. It is wrapped by validateJobPayload so the
+// HTTP submit path can classify the failure as a 4xx (client error) rather than
+// a 5xx, and so callers can branch with errors.Is.
+var ErrInvalidJobPayload = errors.New("daemon queue: invalid job payload")
+
+// validateJobPayload performs a structural shape check on a submitted job's
+// payload BEFORE it is appended to the ledger. It is the submit-time companion
+// to the execute-time *JobSpecFromPayload validators: the executors already run
+// the full parse (mapToStruct + semantic Validate) at claim time, but by then a
+// malformed payload has already been durably written to the ledger, polluting
+// it. On replay the projection builder silently degrades unparseable events, so
+// the contamination is otherwise invisible until execution.
+//
+// This guard runs only the STRUCTURAL parse (mapToStruct), not the full
+// semantic Validate(). That is deliberate: minimal-but-valid direct submissions
+// historically omit fields the schema later defaults (no schema_version, no
+// run_id, empty payload), and rejecting those would change long-standing valid
+// behavior. The structural parse rejects exactly the contaminating case — a
+// payload whose fields carry the wrong JSON type for the JobType's schema
+// (e.g. a string where an int is expected, an object where a string is
+// expected) — which is precisely what makes an event unparseable on replay.
+//
+// JobTypes without a typed payload schema (e.g. eval/llmwiki/openclaw lanes)
+// pass through unchanged: there is nothing to structurally reject.
+func validateJobPayload(jobType JobType, payload map[string]any) error {
+	if err := structurallyParseJobPayload(jobType, payload); err != nil {
+		return fmt.Errorf("%w: %s payload: %v", ErrInvalidJobPayload, jobType, err)
+	}
+	return nil
+}
+
+// structurallyParseJobPayload dispatches on jobType to the matching spec
+// struct's structural unmarshal. It mirrors the JobType→spec mapping used by
+// validateRecurringMaterializedPayload and the executors, but stops at the
+// mapToStruct boundary so it never rejects a structurally-sound payload that
+// merely lacks defaulted fields.
+func structurallyParseJobPayload(jobType JobType, payload map[string]any) error {
+	if len(payload) == 0 {
+		return nil
+	}
+	switch jobType {
+	case JobTypeRPIRun:
+		var spec RPIRunJobSpec
+		return mapToStruct(payload, &spec)
+	case JobTypeRPIPhase:
+		var spec RPIPhaseJobSpec
+		return mapToStruct(payload, &spec)
+	case JobTypeDreamRun:
+		var spec DreamRunJobSpec
+		return mapToStruct(payload, &spec)
+	case JobTypeDreamStage:
+		var spec DreamStageJobSpec
+		return mapToStruct(payload, &spec)
+	case JobTypeWikiForge:
+		var spec WikiForgeJobSpec
+		return mapToStruct(payload, &spec)
+	case JobTypeFactoryAdmission:
+		var spec FactoryAdmissionJobSpec
+		return mapToStruct(payload, &spec)
+	case JobTypeFactoryLocalPilot:
+		var spec FactoryLocalPilotJobSpec
+		return mapToStruct(payload, &spec)
+	case JobTypePlansProjection:
+		var spec PlansProjectionJobSpec
+		return mapToStruct(payload, &spec)
+	case JobTypeSkillInvoke:
+		// SkillInvoke parses args out-of-band (string or list), so structural
+		// validation must mirror that or it would reject valid string-args.
+		raw := make(map[string]any, len(payload))
+		for k, v := range payload {
+			raw[k] = v
+		}
+		if _, err := parseSkillInvokeArgs(raw["args"]); err != nil {
+			return err
+		}
+		delete(raw, "args")
+		var spec SkillInvokeJobSpec
+		return mapToStruct(raw, &spec)
+	default:
+		// JobTypes with no typed payload schema: nothing to structurally reject.
+		return nil
+	}
+}

--- a/cli/internal/daemon/validate_payload_test.go
+++ b/cli/internal/daemon/validate_payload_test.go
@@ -1,0 +1,170 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestSubmitJob_RejectsMalformedPayloadBeforeAppend is the L2 contract for
+// soc-qra05: a payload whose fields carry the wrong JSON type for a known
+// JobType's schema must be rejected BEFORE the ledger append, so the malformed
+// payload never contaminates the ledger.
+func TestSubmitJob_RejectsMalformedPayloadBeforeAppend(t *testing.T) {
+	now := projectionTestTime(t, 0)
+	queue := newTestQueue(t, &now, QueueOptions{LeaseDuration: time.Minute, MaxAttempts: 3})
+
+	// start_phase is an int field in RPIRunJobSpec; a string there is a shape
+	// violation that would make the event unparseable on replay.
+	_, err := queue.SubmitJob(SubmitJobInput{
+		RequestID: "req-malformed",
+		JobID:     "job-malformed",
+		JobType:   JobTypeRPIRun,
+		Actor:     "ao",
+		Payload:   map[string]any{"goal": "x", "start_phase": "not-a-number"},
+	}, QueueMutationOptions{})
+	if err == nil {
+		t.Fatalf("SubmitJob with malformed payload returned nil error, want rejection")
+	}
+	if !errors.Is(err, ErrInvalidJobPayload) {
+		t.Fatalf("error = %v, want errors.Is(ErrInvalidJobPayload)", err)
+	}
+
+	// The ledger must be untouched: no event was appended for the rejected
+	// submission.
+	events := readTestQueueEvents(t, queue)
+	if len(events) != 0 {
+		t.Fatalf("rejected SubmitJob appended %d events, want 0: %+v", len(events), events)
+	}
+}
+
+// TestSubmitJob_AcceptsValidPayloadAndProcesses pins that a structurally-valid
+// (and historically-minimal) payload still appends exactly one accepted event
+// and remains claimable — i.e. the new guard preserves existing valid behavior.
+func TestSubmitJob_AcceptsValidPayloadAndProcesses(t *testing.T) {
+	now := projectionTestTime(t, 0)
+	queue := newTestQueue(t, &now, QueueOptions{LeaseDuration: time.Minute, MaxAttempts: 3})
+
+	submitted, err := queue.SubmitJob(SubmitJobInput{
+		RequestID: "req-valid",
+		JobID:     "job-valid",
+		JobType:   JobTypeRPIRun,
+		Actor:     "ao",
+		Payload:   map[string]any{"goal": "ship daemon"},
+	}, QueueMutationOptions{})
+	if err != nil {
+		t.Fatalf("SubmitJob with valid payload returned error: %v", err)
+	}
+	if submitted.Status != JobStatusQueued {
+		t.Fatalf("submitted status = %q, want %q", submitted.Status, JobStatusQueued)
+	}
+
+	events := readTestQueueEvents(t, queue)
+	if len(events) != 1 {
+		t.Fatalf("valid SubmitJob appended %d events, want 1: %+v", len(events), events)
+	}
+	if events[0].EventType != EventJobAccepted {
+		t.Fatalf("appended event type = %q, want %q", events[0].EventType, EventJobAccepted)
+	}
+
+	// And it is still processable end-to-end: it can be claimed.
+	claim, err := queue.ClaimNext("worker-1", QueueMutationOptions{})
+	if err != nil {
+		t.Fatalf("ClaimNext after valid submit: %v", err)
+	}
+	if claim.Job.JobID != "job-valid" || claim.Job.Status != JobStatusRunning {
+		t.Fatalf("claim = %#v, want running job-valid", claim.Job)
+	}
+}
+
+// TestMutationSubmitMalformedPayloadReturnsBadRequest is the HTTP-path sibling:
+// a malformed payload for a known JobType returns 400 and leaves the ledger
+// empty. Mirrors TestMutationSubmitInvalidJobTypeReturnsBadRequest.
+func TestMutationSubmitMalformedPayloadReturnsBadRequest(t *testing.T) {
+	now := projectionTestTime(t, 0)
+	store := NewStore(t.TempDir())
+	router := mutationRouter(t, store, &now)
+
+	resp := postJob(t, router,
+		`{"request_id":"req-bad","job_id":"job-bad","job_type":"rpi.run","payload":{"goal":"x","start_phase":"not-a-number"}}`,
+		"secret-token", "")
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("malformed payload status = %d body=%s, want 400", resp.Code, resp.Body.String())
+	}
+
+	events, err := store.ReadLedger()
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("malformed payload wrote %d events, want 0", len(events))
+	}
+}
+
+// TestMutationSubmitValidPayloadStillAppends pins that the HTTP path keeps
+// accepting a valid payload after the guard: 202 and exactly one accepted event.
+func TestMutationSubmitValidPayloadStillAppends(t *testing.T) {
+	now := projectionTestTime(t, 0)
+	store := NewStore(t.TempDir())
+	router := mutationRouter(t, store, &now)
+
+	resp := postJob(t, router,
+		`{"request_id":"req-ok","job_id":"job-ok","job_type":"rpi.run","payload":{"goal":"daemon"}}`,
+		"secret-token", "")
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("valid payload status = %d body=%s, want 202", resp.Code, resp.Body.String())
+	}
+	var body SubmitJobResponse
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode submit response: %v", err)
+	}
+	if !body.Accepted || body.JobID != "job-ok" {
+		t.Fatalf("submit response = %#v, want accepted job-ok", body)
+	}
+
+	events, err := store.ReadLedger()
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	if len(events) != 1 || events[0].EventType != EventJobAccepted {
+		t.Fatalf("ledger events = %#v, want one accepted event", events)
+	}
+}
+
+// TestValidateJobPayload_ShapeMatrix locks the structural-vs-semantic boundary:
+// minimal/empty payloads pass (no behavior change), type-mismatched fields are
+// rejected, and JobTypes without a typed schema pass through.
+func TestValidateJobPayload_ShapeMatrix(t *testing.T) {
+	cases := []struct {
+		name    string
+		jobType JobType
+		payload map[string]any
+		wantErr bool
+	}{
+		{"rpi.run empty payload", JobTypeRPIRun, nil, false},
+		{"rpi.run minimal goal", JobTypeRPIRun, map[string]any{"goal": "x"}, false},
+		{"rpi.run bad start_phase", JobTypeRPIRun, map[string]any{"start_phase": "abc"}, true},
+		{"rpi.run object goal", JobTypeRPIRun, map[string]any{"goal": map[string]any{"k": 1}}, true},
+		{"dream.run bad max_iterations", JobTypeDreamRun, map[string]any{"max_iterations": "lots"}, true},
+		{"dream.run minimal", JobTypeDreamRun, map[string]any{"dream_run_id": "d1"}, false},
+		{"skill.invoke bad args element", JobTypeSkillInvoke, map[string]any{"args": []any{1, 2}}, true},
+		{"skill.invoke string args", JobTypeSkillInvoke, map[string]any{"skill_name": "evolve", "args": "a b c"}, false},
+		{"unknown-schema type passes", JobTypeEvalSuite, map[string]any{"anything": []any{1, "x", true}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateJobPayload(tc.jobType, tc.payload)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validateJobPayload(%s) = nil, want error", tc.jobType)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateJobPayload(%s) = %v, want nil", tc.jobType, err)
+			}
+			if tc.wantErr && !errors.Is(err, ErrInvalidJobPayload) {
+				t.Fatalf("validateJobPayload(%s) error = %v, want errors.Is(ErrInvalidJobPayload)", tc.jobType, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Job payloads were appended to the ledger (`AppendLedgerEvent`) with **no shape validation**. A payload whose fields carry the wrong JSON type for its `JobType`'s schema contaminated the append-only ledger; on replay the projection builder silently degrades the unparseable event, so the pollution stayed invisible until execution.

## Fix

Added `validateJobPayload(jobType, payload) error` invoked in `Queue.SubmitJob` **before any ledger append** (`cli/internal/daemon/jobs.go`). It dispatches per `JobType` and runs only the structural `mapToStruct` parse — the same parse the executors already run at claim time — **not** the full semantic `Validate()`. This is deliberate:

- Minimal-but-valid direct submissions (no `schema_version`, empty payload) keep working **exactly** as before.
- Type-mismatched payloads (e.g. a string where an int is expected, an object where a string is expected) are rejected before they reach the ledger.
- `JobType`s without a typed payload schema (eval/llmwiki/openclaw lanes) pass through unchanged.

The HTTP submit path returns **400** by having `isQueueValidationError` recognise the wrapped `ErrInvalidJobPayload` sentinel (`cli/internal/daemon/server.go`). The ledger/replay format is unchanged.

## Tests (L2-first)

`cli/internal/daemon/validate_payload_test.go`:
- `TestSubmitJob_RejectsMalformedPayloadBeforeAppend` — malformed payload rejected, **0 events** appended.
- `TestSubmitJob_AcceptsValidPayloadAndProcesses` — valid payload appends exactly 1 `job.accepted` event and remains claimable.
- `TestMutationSubmitMalformedPayloadReturnsBadRequest` — HTTP path returns 400, ledger empty.
- `TestMutationSubmitValidPayloadStillAppends` — HTTP path returns 202, 1 accepted event.
- `TestValidateJobPayload_ShapeMatrix` — structural-vs-semantic boundary across rpi/dream/skill + unknown-schema pass-through.

Verification: `gofmt -l` clean, `go build ./...`, `go vet ./internal/daemon/...`, full daemon suite (369 pass), `go test ./...` (11870 pass, 65 packages) — all green.

Closes-scenario: soc-qra05#payload-validation
Bounded-context: BC5-Runtime
Evidence: cli/internal/daemon/validate_payload_test.go