### PR TITLE
feat(skills): add SELF-TEST.md to research/plan/validation pilots (soc-ekvwh #pilot-selftests)

### DIFF
--- a/skills/plan/SELF-TEST.md
+++ b/skills/plan/SELF-TEST.md
@@ -1,0 +1,52 @@
+# Plan Skill Self-Test
+
+## Trigger Cases
+
+- User says: `/plan "add user authentication"` (or any `/plan <goal>`).
+  - Expected: load `plan`, read prior research if present, decompose into issues/waves, and write `.agents/plans/YYYY-MM-DD-<slug>.md`.
+
+- User passes a bead ID: `/plan soc-1234`.
+  - Expected: run the Step 0 stale-scope pre-flight (`ao beads verify`) before decomposition when the bead is full-complexity, older than 7 days, or filed by a prior session.
+
+- User says: `/plan --auto "refactor payment module"`.
+  - Expected: load `plan` and run decomposition without the Gate-2 human approval step.
+
+## Non-Trigger Cases
+
+- User asks an open investigation question with no goal to decompose ("how does X work?").
+  - Expected: route to `/research`, not `plan`.
+
+- User asks to validate already-implemented work or run gates.
+  - Expected: route to `/validation`, not `plan`.
+
+## Behavior Checks
+
+These map to the four scenarios in [references/plan.feature](references/plan.feature):
+
+- Plan consumes Discovery output: each slice carries acceptance criteria, write scope, test levels, and ownership, and no slice depends on raw Discovery chat context.
+- One slice per Given/When/Then row: a BDD intent issue with N rows yields N vertical slices, each with a first-failing-test target.
+- Wave-validity gate before parallelization: a wave passes only when every row holds — distinct write scopes, no shared migration/contract/CLI surface, declared integration order, an owner per slice, and a discard path per slice; otherwise slices default to sequential.
+- Durable slice-validation artifact: Plan writes a slice plan to `.agents/plans/*.md` plus an `execution-packet.json`, and a fresh agent can execute the slices from those artifacts alone.
+
+Worker latitude: Plan may create small mechanical files (templates, fixtures, generated companions) when they are required to satisfy a slice's acceptance criteria — these belong in the file dependency matrix as `write` ownership claims.
+
+## Validation Commands
+
+Run from the repo root:
+
+```bash
+bash skills/heal-skill/scripts/heal.sh --strict skills/plan
+bash scripts/validate-skill-frontmatter.sh --strict
+```
+
+For JSM-style export readiness, run:
+
+```bash
+scripts/check-jsm-export.sh --json skills/plan
+```
+
+## Failure Cases
+
+- Plan written without a baseline audit (file/section/LOC counts): fail the Baseline Audit Gate and quantify ground truth before decomposing (`--skip-audit-gate` for documentation-only plans).
+- Acceptance criteria missing the fenced YAML `acceptance_criteria` block: contract violation — add the block to every issue body.
+- Two same-wave slices claiming `write` on the same file: serialize with `blockedBy` or merge the slices; do not ship the wave.

--- a/skills/research/SELF-TEST.md
+++ b/skills/research/SELF-TEST.md
@@ -1,0 +1,50 @@
+# Research Skill Self-Test
+
+## Trigger Cases
+
+- User says: `/research "authentication system"` (or any `/research <topic>`).
+  - Expected: load `research`, create `.agents/research/`, search prior art first, then dispatch an explore agent.
+
+- User says: "investigate how the cache layer works and write up the findings."
+  - Expected: load `research` and produce a cited `.agents/research/YYYY-MM-DD-<slug>.md` artifact.
+
+- User says: `/research "payment processing flow" --auto`.
+  - Expected: load `research` and run the full workflow without the Gate-1 human approval step.
+
+## Non-Trigger Cases
+
+- User asks to implement or change code directly with no investigation request.
+  - Expected: do not load `research`; route to `/implement` or `/plan`.
+
+- User asks for session/handoff history ("what did we decide last session?").
+  - Expected: use `/trace`, not `research` — `research` reads git commit history, not session history.
+
+## Behavior Checks
+
+These map to the four scenarios in [references/research.feature](references/research.feature):
+
+- Prior art is searched before fresh exploration: `ao inject`/`lookup` plus the `.agents/` knowledge dirs run first, and applicable learnings are cited in the output (not just loaded passively).
+- An explore agent is actually dispatched (not merely described) using the detected backend, and it uses iterative retrieval — score results, extract new terms from high-relevance hits, refine over up to 3 cycles.
+- Findings are written to `.agents/research/YYYY-MM-DD-<slug>.md`, and every claim carries a `file:line` citation.
+- Interactive runs request human approval (Gate 1) before reporting completion; `--auto` proceeds without the gate.
+
+## Validation Commands
+
+Run from the repo root:
+
+```bash
+bash skills/heal-skill/scripts/heal.sh --strict skills/research
+bash scripts/validate-skill-frontmatter.sh --strict
+```
+
+For JSM-style export readiness, run:
+
+```bash
+scripts/check-jsm-export.sh --json skills/research
+```
+
+## Failure Cases
+
+- Explore agent only described, never dispatched: re-run and dispatch the agent (or perform the exploration inline if no spawn backend is available) — see the Key Rules in `SKILL.md`.
+- Findings written without `file:line` citations: fail the artifact and re-cite every claim before reporting.
+- Missing reference file linked from `SKILL.md`: fail heal validation and restore the file or remove the link.

--- a/skills/validation/SELF-TEST.md
+++ b/skills/validation/SELF-TEST.md
@@ -1,0 +1,50 @@
+# Validation Skill Self-Test
+
+## Trigger Cases
+
+- User says: `/validation soc-1234` (validate an epic with full close-out).
+  - Expected: load `validation`, run the vibe → lifecycle → post-mortem → retro → forge DAG by strict delegation, and roll every acceptance criterion into a verdict.
+
+- User says: `/validation` (validate recent work, no epic).
+  - Expected: load `validation` and run the DAG against the recent changes.
+
+- User says: "validate this work before we close the bead" or `/rpi --quality` reaches the validation phase.
+  - Expected: load `validation`; `--strict-surfaces` is passed automatically by `/rpi --quality`, making the four closure surfaces blocking.
+
+## Non-Trigger Cases
+
+- User asks for a quick lint or readiness check on uncommitted code only.
+  - Expected: route to `/vibe` directly — `validation` orchestrates the full phase, not a single quick check.
+
+- User asks to decompose a goal or estimate scope.
+  - Expected: route to `/plan`, not `validation`.
+
+## Behavior Checks
+
+These map to the four scenarios in [references/validation.feature](references/validation.feature):
+
+- Every acceptance criterion maps to a passing test: each Given/When/Then from the intent maps to a passing test, and an unmapped or failing criterion blocks the verdict.
+- Strict delegation across the DAG: `validation` delegates to `/vibe`, the lifecycle skills, `/post-mortem`, `/retro`, and `/forge` as separate `Skill(...)` invocations, and does not compress or skip those steps.
+- The verdict is proof, not an activity log: `validation` produces `verdict.json` capturing the per-criterion verdict; an activity log alone never closes a bead.
+- Surface failures block under strict mode: with `--strict-surfaces` set, any of the four closure surfaces failing makes the verdict FAIL, not WARN.
+
+## Validation Commands
+
+Run from the repo root:
+
+```bash
+bash skills/heal-skill/scripts/heal.sh --strict skills/validation
+bash scripts/validate-skill-frontmatter.sh --strict
+```
+
+For JSM-style export readiness, run:
+
+```bash
+scripts/check-jsm-export.sh --json skills/validation
+```
+
+## Failure Cases
+
+- Judges spawned via `Agent()` in place of `/vibe`, or post-mortem/forge inlined: reject the compression and re-run via separate `Skill(...)` invocations per the strict delegation contract.
+- An acceptance criterion has no mapped passing test: block the verdict and either add the test or mark the criterion explicitly cancelled in bead metadata.
+- Completion marker emitted without `verdict.json`: re-run — the per-criterion verdict artifact is the exit signal, not a stdout summary.


### PR DESCRIPTION
Adds trigger/behavior proof harnesses (`SELF-TEST.md`) to the three JSM pilot skills — `research`, `plan`, `validation` — per the JSM-informed pilot upgrade backlog (`docs/reference/jsm-pilot-upgrade-backlog.md`).

Each SELF-TEST matches the format of the existing `skills/standards/SELF-TEST.md` (Trigger Cases / Non-Trigger Cases / Behavior Checks / Validation Commands / Failure Cases) and grounds its Behavior Checks in the skill's `.feature` scenarios:

- `skills/research/SELF-TEST.md` → references `references/research.feature` (prior-art-first, explore agent + iterative retrieval, cited artifact, Gate-1 unless --auto)
- `skills/plan/SELF-TEST.md` → references `references/plan.feature` (Discovery consumption, one slice per Given/When/Then, wave-validity gate, durable slice-validation artifact)
- `skills/validation/SELF-TEST.md` → references `references/validation.feature` (criterion→test roll-up, strict delegation, verdict.json, strict-surface blocking)

Gates run locally (in worktree):
- `bash skills/heal-skill/scripts/heal.sh --strict skills/research skills/plan skills/validation` → All clean
- `bash scripts/generate-registry.sh --check` → registry up to date
- `bash scripts/audit-codex-parity.sh --skill {research,plan,validation}` → all passed

Scope is SELF-TEST.md only — no SKILL.md body / hooks / cli / GOALS changes, so no codex hash regen needed.

Closes-scenario: soc-ekvwh#pilot-selftests
Bounded-context: BC1-Corpus
Evidence: skills/research/SELF-TEST.md