### PR TITLE
fix(daemon): bound idempotency key + harden request decode guards (soc-scg3h #request-hardening)

### DIFF
--- a/cli/internal/daemon/server.go
+++ b/cli/internal/daemon/server.go
@@ -29,6 +29,15 @@ type ServerOptions struct {
 // larger lines than submission so daemon-emitted events have headroom).
 const MaxJobSubmissionBytes = 1 * 1024 * 1024
 
+// MaxIdempotencyKeyBytes bounds the caller-supplied idempotency key. The key is
+// stored verbatim in the JobAccepted ledger event payload (jobs.go writes
+// payload["idempotency_key"]) and echoed into every job projection, so an
+// unbounded key bloats the append-only ledger and every downstream projection
+// for the lifetime of the job. 256 bytes is far above any legitimate UUID /
+// request-hash key while keeping the per-event overhead negligible. Submissions
+// with a longer key are rejected with 400 before any ledger write.
+const MaxIdempotencyKeyBytes = 256
+
 const maxReadOnlyEventsLimit = 1000
 
 type ReadOnlyServer struct {
@@ -446,6 +455,9 @@ func (s *ReadOnlyServer) handleOpenClawTriggerJob(w http.ResponseWriter, r *http
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "job_type is not allowlisted for OpenClaw trigger"})
 		return
 	}
+	if !validateIdempotencyKey(w, req.IdempotencyKey) {
+		return
+	}
 	queue := NewQueue(s.store, s.queueOptions())
 	job, err := queue.SubmitJob(SubmitJobInput{
 		RequestID:      RequestID(req.RequestID),
@@ -493,6 +505,9 @@ func (s *ReadOnlyServer) handleSubmitJob(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	if !validateIdempotencyKey(w, req.IdempotencyKey) {
 		return
 	}
 	queue := NewQueue(s.store, s.queueOptions())
@@ -633,6 +648,21 @@ func (s *ReadOnlyServer) cancelJob(w http.ResponseWriter, r *http.Request, req C
 	})
 }
 
+// validateIdempotencyKey rejects an over-long caller-supplied idempotency key
+// before it reaches the queue. On rejection it writes a 400 with the offending
+// length and returns false, so callers short-circuit before any ledger append.
+func validateIdempotencyKey(w http.ResponseWriter, key string) bool {
+	if len(key) > MaxIdempotencyKeyBytes {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"error":     "idempotency_key exceeds MaxIdempotencyKeyBytes",
+			"max_bytes": MaxIdempotencyKeyBytes,
+			"got_bytes": len(key),
+		})
+		return false
+	}
+	return true
+}
+
 func queueSubmitErrorStatus(err error) int {
 	if errors.Is(err, ErrFailpoint) {
 		return http.StatusServiceUnavailable
@@ -698,10 +728,22 @@ func (s *ReadOnlyServer) handlePostSchedule(w http.ResponseWriter, r *http.Reque
 	if !requireMethod(w, r, http.MethodPost) {
 		return
 	}
+	// Apply the same body-size cap as the other mutation routes so an oversized
+	// schedule template is short-circuited to 413 instead of being fully
+	// buffered into memory and decoded (soc-scg3h).
+	r.Body = http.MaxBytesReader(w, r.Body, MaxJobSubmissionBytes)
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
 	var template RecurringJobTemplate
 	if err := dec.Decode(&template); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]any{
+				"error":     "request body exceeds MaxJobSubmissionBytes",
+				"max_bytes": MaxJobSubmissionBytes,
+			})
+			return
+		}
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json: " + err.Error()})
 		return
 	}

--- a/cli/internal/daemon/server_mutation_test.go
+++ b/cli/internal/daemon/server_mutation_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -411,5 +412,125 @@ func TestCancelJobRejectsBodyOverMaxBytes(t *testing.T) {
 	resp := postCancel(t, router, body, "secret-token", "")
 	if resp.Code != http.StatusRequestEntityTooLarge {
 		t.Fatalf("oversized cancel status = %d, want 413; body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+// TestSubmitJobRejectsOverlongIdempotencyKey asserts that an idempotency key
+// longer than MaxIdempotencyKeyBytes is rejected with 400 before any ledger
+// write. Without the bound an unbounded key is stored verbatim in the
+// JobAccepted ledger event payload and echoed into every job projection,
+// bloating the append-only ledger for the job's lifetime (soc-scg3h).
+func TestSubmitJobRejectsOverlongIdempotencyKey(t *testing.T) {
+	now := projectionTestTime(t, 0)
+	store := NewStore(t.TempDir())
+	router := mutationRouter(t, store, &now)
+
+	// Key one byte over the cap; the body itself stays well under
+	// MaxJobSubmissionBytes so this exercises the key bound, not the body cap.
+	overlong := strings.Repeat("k", MaxIdempotencyKeyBytes+1)
+	payload := `{"request_id":"req-idem","job_id":"job-idem","job_type":"rpi.run","idempotency_key":"` + overlong + `"}`
+
+	resp := postJob(t, router, payload, "secret-token", "")
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("overlong idempotency key status = %d, want 400; body=%s", resp.Code, resp.Body.String())
+	}
+	var responseBody map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &responseBody); err != nil {
+		t.Fatalf("decode 400 body: %v", err)
+	}
+	if got, ok := responseBody["max_bytes"].(float64); !ok || int(got) != MaxIdempotencyKeyBytes {
+		t.Fatalf("400 body max_bytes = %v, want %d", responseBody["max_bytes"], MaxIdempotencyKeyBytes)
+	}
+
+	events, err := store.ReadLedger()
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("overlong idempotency key wrote %d events, want 0 (bound must reject before ledger append)", len(events))
+	}
+}
+
+// TestSubmitJobAcceptsMaxLengthIdempotencyKey is the boundary companion: a key
+// exactly at MaxIdempotencyKeyBytes must still be accepted (202) and append one
+// ledger event, so the bound is behavior-preserving for valid requests.
+func TestSubmitJobAcceptsMaxLengthIdempotencyKey(t *testing.T) {
+	now := projectionTestTime(t, 0)
+	store := NewStore(t.TempDir())
+	router := mutationRouter(t, store, &now)
+
+	maxKey := strings.Repeat("k", MaxIdempotencyKeyBytes)
+	payload := `{"request_id":"req-idem-ok","job_id":"job-idem-ok","job_type":"rpi.run","idempotency_key":"` + maxKey + `"}`
+
+	resp := postJob(t, router, payload, "secret-token", "")
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("max-length idempotency key status = %d, want 202; body=%s", resp.Code, resp.Body.String())
+	}
+	var body SubmitJobResponse
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode 202 body: %v", err)
+	}
+	if !body.Accepted || body.IdempotencyKey != maxKey {
+		t.Fatalf("response = %#v, want accepted with the max-length key echoed back", body)
+	}
+
+	events, err := store.ReadLedger()
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	if len(events) != 1 || events[0].EventType != EventJobAccepted {
+		t.Fatalf("ledger events = %#v, want one accepted event", events)
+	}
+}
+
+// TestOpenClawTriggerRejectsOverlongIdempotencyKey mirrors the submit-side key
+// bound on the OpenClaw trigger route — both accept caller-supplied keys that
+// flow into the ledger, so the bound lives on both entry-points (soc-scg3h).
+func TestOpenClawTriggerRejectsOverlongIdempotencyKey(t *testing.T) {
+	now := projectionTestTime(t, 0)
+	store := NewStore(t.TempDir())
+	router := openClawTriggerRouter(t, store, &now)
+
+	overlong := strings.Repeat("k", MaxIdempotencyKeyBytes+1)
+	payload := `{"request_id":"req-oc","job_id":"job-oc","job_type":"openclaw.snapshot","idempotency_key":"` + overlong + `"}`
+
+	resp := postOpenClawTrigger(t, router, payload, "secret-token", "")
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("overlong trigger idempotency key status = %d, want 400; body=%s", resp.Code, resp.Body.String())
+	}
+	events, err := store.ReadLedger()
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("overlong trigger idempotency key wrote %d events, want 0", len(events))
+	}
+}
+
+// TestPostScheduleRejectsBodyOverMaxBytes asserts the schedule create route
+// shares the body-size cap with the other mutation routes: an oversized body
+// must return 413, not be fully buffered and decoded into a 500/OOM. Regression
+// for the one decode path that previously lacked MaxBytesReader (soc-scg3h).
+func TestPostScheduleRejectsBodyOverMaxBytes(t *testing.T) {
+	now := projectionTestTime(t, 0)
+	store := NewStore(t.TempDir())
+	router := schedulesRouter(t, store, &now)
+
+	// Valid-shaped template with the cron string padded past the cap.
+	prefix := `{"name":"big","job_type":"rpi.run","cron":"`
+	suffix := `"}`
+	pad := strings.Repeat("x", MaxJobSubmissionBytes+1024)
+	body := prefix + pad + suffix
+
+	resp := postSchedule(t, router, body, "secret-token")
+	if resp.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized schedule status = %d, want 413 (not 500); body=%s", resp.Code, resp.Body.String())
+	}
+	var responseBody map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &responseBody); err != nil {
+		t.Fatalf("decode 413 body: %v", err)
+	}
+	if got := responseBody["max_bytes"]; got == nil {
+		t.Fatalf("413 body missing max_bytes hint: %s", resp.Body.String())
 	}
 }


### PR DESCRIPTION
## What

HTTP request hardening for the daemon mutation surface (`cli/internal/daemon/server.go`).

### Gap 1 — unbounded idempotency key
`handleSubmitJob` and `handleOpenClawTriggerJob` passed the caller-supplied `IdempotencyKey` straight into `queue.SubmitJob` with **no length limit**. The key is stored verbatim in the `JobAccepted` ledger event payload (`jobs.go` writes `payload["idempotency_key"]`) and echoed into every job projection, so a multi-KB/MB key bloats the append-only ledger and downstream projections for the job's lifetime.

**Fix:** `MaxIdempotencyKeyBytes = 256`, enforced via a shared `validateIdempotencyKey` helper in both handlers — reject with **400** before any ledger write.

### Gap 2 — schedule decode path missing the size guard
Audited every `json.NewDecoder(r.Body).Decode(...)` call: submit (line 486), trigger (432), cancel (578) all already had `MaxBytesReader` applied. **`handlePostSchedule` (was line 701) did not** — an oversized schedule body was fully buffered + decoded (500/OOM risk).

**Fix:** apply the same `MaxJobSubmissionBytes` cap + `MaxBytesError` → **413** mapping, matching the other mutation routes.

## Tests (L2, exact assertions)
- over-long key → 400 + **0 ledger events** (submit path), asserts `max_bytes == 256`
- over-long key → 400 + 0 ledger events (OpenClaw trigger path)
- max-length key (exactly 256) → **202 + 1 ledger event**, key echoed back (behavior-preserving boundary)
- oversized schedule body → **413 not 500**, with `max_bytes` hint

## Verification
- `gofmt -l` clean · `go build ./...` ✓ · `go vet ./internal/daemon/...` ✓
- `go test ./internal/daemon/...` → 377 passed
- `go test ./...` → **11878 passed in 65 packages**, zero failures
- `scripts/check-mutation-route-coverage.sh` → OK
- Diff stat: 163 insertions, 0 deletions, only the 2 in-scope files

Closes-scenario: soc-scg3h#request-hardening
Bounded-context: BC5-Runtime
Evidence: cli/internal/daemon/server_test.go