### PR TITLE
feat(hex): real WorkspacePort git adapter + wire core worktree lifecycle (soc-rg5z0 #workspaceport-adapter)

### DIFF
--- a/cli/cmd/ao/rpi_cleanup.go
+++ b/cli/cmd/ao/rpi_cleanup.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -9,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/boshu2/agentops/cli/internal/adapters/workspace_git"
+	"github.com/boshu2/agentops/cli/internal/ports"
 	"github.com/boshu2/agentops/cli/internal/rpi"
 	"github.com/spf13/cobra"
 )
@@ -460,14 +463,19 @@ func removeOrphanedWorktree(repoRoot, worktreePath, runID string) error {
 		fmt.Printf("Preserved worktree commit %s on branch codex/preserve-%s\n", preserved[:shortLen], runID)
 	}
 
-	// Force remove the worktree.
-	cmd := exec.Command("git", "worktree", "remove", "--force", worktreePath)
-	cmd.Dir = repoRoot
-	if out, err := cmd.CombinedOutput(); err != nil {
-		// If worktree remove fails (already pruned), just remove the directory.
-		if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
-			return fmt.Errorf("git worktree remove: %s; manual rm: %w", string(out), rmErr)
-		}
+	// Force remove the worktree via the WorkspacePort adapter. The adapter
+	// runs `git worktree remove --force` and, on failure (e.g. already pruned),
+	// falls back to a direct directory removal — preserving the prior behavior.
+	// WorkspaceID must be non-empty; fall back to the path when runID is blank.
+	workspaceID := strings.TrimSpace(runID)
+	if workspaceID == "" {
+		workspaceID = worktreePath
+	}
+	if _, err := workspace_git.New(repoRoot).Cleanup(context.Background(), ports.WorkspaceRequest{
+		WorkspaceID: workspaceID,
+		Path:        worktreePath,
+	}); err != nil {
+		return err
 	}
 
 	// Delete legacy branch marker if present.

--- a/cli/internal/adapters/workspace_git/workspace_git.go
+++ b/cli/internal/adapters/workspace_git/workspace_git.go
@@ -1,0 +1,183 @@
+// Package workspace_git is a real adapter for the WorkspacePort port,
+// backed by `git worktree` subprocess calls.
+//
+// It absorbs the worktree-lifecycle coupling that the CLI previously reached
+// by building its own exec.Command("git", "worktree", ...) at each callsite.
+// Setup maps to `git worktree add`; Cleanup maps to `git worktree remove`
+// (with optional branch delete + prune).
+//
+// Request contract (in addition to ports.WorkspacePort's WorkspaceID/Status
+// contract):
+//
+//   - Path is the absolute or repo-relative worktree path. Required for Setup
+//     and Cleanup (a worktree cannot be created or removed without a path).
+//   - Metadata["branch"]   — branch name. Setup uses `add -b <branch>` when set,
+//     plain `add <path>` otherwise. Cleanup deletes the branch when set.
+//   - Metadata["base"]     — base ref for Setup's new branch (e.g. "origin/main").
+//     Ignored when branch is empty.
+//   - Metadata["force"]    — "true" makes Cleanup pass --force (default true; an
+//     explicit "false" omits it).
+//   - Metadata["prune"]    — "true" runs `git worktree prune` after Cleanup.
+package workspace_git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/boshu2/agentops/cli/internal/ports"
+)
+
+// ErrMissingPath is returned when a WorkspaceRequest omits Path for an
+// operation that requires it. Setup cannot create and Cleanup cannot remove a
+// worktree without a path.
+var ErrMissingPath = errors.New("workspace_git: workspace path required")
+
+// Adapter satisfies ports.WorkspacePort using `git worktree` subprocess calls.
+// RepoRoot, when set, becomes the working directory for every git invocation so
+// the adapter operates against a known repository regardless of process cwd.
+type Adapter struct {
+	// RepoRoot is the directory git commands run in. Empty means the current
+	// process working directory (git discovers the repo from there).
+	RepoRoot string
+}
+
+// New returns an Adapter rooted at repoRoot. Pass "" to run git against the
+// process working directory.
+func New(repoRoot string) *Adapter {
+	return &Adapter{RepoRoot: repoRoot}
+}
+
+// Compile-time interface check.
+var _ ports.WorkspacePort = (*Adapter)(nil)
+
+// Setup creates a git worktree for req. WorkspaceID and Path are required.
+// When Metadata["branch"] is set, the worktree is created on a new branch
+// (`git worktree add -b <branch> <path> [<base>]`); otherwise a plain
+// `git worktree add <path>` is run.
+func (a *Adapter) Setup(ctx context.Context, req ports.WorkspaceRequest) (ports.WorkspaceResult, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.WorkspaceResult{}, err
+	}
+	if req.WorkspaceID == "" {
+		return ports.WorkspaceResult{}, errors.New("workspace_git: Setup workspace id required")
+	}
+	if req.Path == "" {
+		return ports.WorkspaceResult{}, fmt.Errorf("%w: Setup", ErrMissingPath)
+	}
+
+	branch := req.Metadata["branch"]
+	base := req.Metadata["base"]
+
+	args := []string{"worktree", "add"}
+	if branch != "" {
+		args = append(args, "-b", branch, req.Path)
+		if base != "" {
+			args = append(args, base)
+		}
+	} else {
+		args = append(args, req.Path)
+	}
+
+	if out, err := a.run(ctx, args...); err != nil {
+		return ports.WorkspaceResult{}, fmt.Errorf("workspace_git: git worktree add %s: %s: %w", req.Path, strings.TrimSpace(out), err)
+	}
+
+	return ports.WorkspaceResult{
+		WorkspaceID: req.WorkspaceID,
+		Path:        req.Path,
+		Status:      "setup",
+		Reason:      "git worktree created",
+	}, nil
+}
+
+// Cleanup removes the git worktree for req. WorkspaceID and Path are required.
+// It runs `git worktree remove [--force] <path>`; on failure it falls back to
+// removing the directory directly so cleanup is best-effort and not blocked by
+// an already-pruned worktree. When Metadata["branch"] is set it best-effort
+// deletes the branch, and when Metadata["prune"] is "true" it prunes
+// administrative worktree state afterward.
+func (a *Adapter) Cleanup(ctx context.Context, req ports.WorkspaceRequest) (ports.WorkspaceResult, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.WorkspaceResult{}, err
+	}
+	if req.WorkspaceID == "" {
+		return ports.WorkspaceResult{}, errors.New("workspace_git: Cleanup workspace id required")
+	}
+	if req.Path == "" {
+		return ports.WorkspaceResult{}, fmt.Errorf("%w: Cleanup", ErrMissingPath)
+	}
+
+	args := []string{"worktree", "remove"}
+	if req.Metadata["force"] != "false" {
+		args = append(args, "--force")
+	}
+	args = append(args, req.Path)
+
+	reason := "git worktree removed"
+	if out, err := a.run(ctx, args...); err != nil {
+		// Fall back to a direct directory removal so an already-pruned
+		// worktree does not leave the path on disk.
+		if rmErr := os.RemoveAll(req.Path); rmErr != nil {
+			return ports.WorkspaceResult{}, fmt.Errorf("workspace_git: git worktree remove %s: %s; manual rm: %w", req.Path, strings.TrimSpace(out), rmErr)
+		}
+		reason = "worktree directory removed (git worktree remove failed, fell back to rm)"
+	}
+
+	// Best-effort branch delete.
+	if branch := req.Metadata["branch"]; branch != "" {
+		_, _ = a.run(ctx, "branch", "-D", branch)
+	}
+
+	// Optional prune of administrative worktree state.
+	if req.Metadata["prune"] == "true" {
+		if out, err := a.run(ctx, "worktree", "prune"); err != nil {
+			return ports.WorkspaceResult{}, fmt.Errorf("workspace_git: git worktree prune: %s: %w", strings.TrimSpace(out), err)
+		}
+	}
+
+	return ports.WorkspaceResult{
+		WorkspaceID: req.WorkspaceID,
+		Path:        req.Path,
+		Status:      "cleanup",
+		Reason:      reason,
+	}, nil
+}
+
+// run invokes git with args, returning combined output. The working directory
+// is a.RepoRoot when set. GIT_DIR/GIT_WORK_TREE/GIT_COMMON_DIR are stripped from
+// the environment so git rediscovers the repository from RepoRoot/cwd rather
+// than inheriting a stale ambient pointer (mirrors cmd/ao's gitDiscoveryEnv).
+func (a *Adapter) run(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if a.RepoRoot != "" {
+		cmd.Dir = a.RepoRoot
+	}
+	cmd.Env = discoveryEnv()
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// discoveryEnv returns the current environment with git repo-discovery
+// overrides removed so git resolves the repo from the command's working
+// directory.
+func discoveryEnv() []string {
+	src := os.Environ()
+	env := make([]string, 0, len(src))
+	for _, entry := range src {
+		switch {
+		case strings.HasPrefix(entry, "GIT_DIR="):
+			continue
+		case strings.HasPrefix(entry, "GIT_WORK_TREE="):
+			continue
+		case strings.HasPrefix(entry, "GIT_COMMON_DIR="):
+			continue
+		default:
+			env = append(env, entry)
+		}
+	}
+	return env
+}

--- a/cli/internal/adapters/workspace_git/workspace_git_test.go
+++ b/cli/internal/adapters/workspace_git/workspace_git_test.go
@@ -1,0 +1,174 @@
+// practices: [hexagonal-architecture, tdd]
+package workspace_git
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/ports"
+)
+
+// initTestRepo creates a real git repo with one commit in a temp dir and
+// returns its root. It skips the test when git is unavailable.
+func initTestRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s: %v", args, out, err)
+		}
+	}
+	runGit("init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", ".")
+	runGit("commit", "-m", "seed")
+	return root
+}
+
+func TestAdapter_SetupCreatesWorktreeOnBranch(t *testing.T) {
+	root := initTestRepo(t)
+	wtPath := filepath.Join(t.TempDir(), "wt-feature")
+	a := New(root)
+
+	res, err := a.Setup(context.Background(), ports.WorkspaceRequest{
+		WorkspaceID: "run-1",
+		Path:        wtPath,
+		Metadata:    map[string]string{"branch": "feature/x"},
+	})
+	if err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	if res.Status != "setup" {
+		t.Fatalf("status = %q, want setup", res.Status)
+	}
+	if res.WorkspaceID != "run-1" || res.Path != wtPath {
+		t.Fatalf("result = %+v, want id=run-1 path=%s", res, wtPath)
+	}
+	// The worktree directory and a checkout of README must exist on disk.
+	if _, err := os.Stat(filepath.Join(wtPath, "README.md")); err != nil {
+		t.Fatalf("worktree checkout missing: %v", err)
+	}
+	// The new branch must exist.
+	if !branchExists(t, root, "feature/x") {
+		t.Fatal("branch feature/x was not created")
+	}
+}
+
+func TestAdapter_CleanupRemovesWorktreeAndBranch(t *testing.T) {
+	root := initTestRepo(t)
+	wtPath := filepath.Join(t.TempDir(), "wt-feature")
+	a := New(root)
+
+	if _, err := a.Setup(context.Background(), ports.WorkspaceRequest{
+		WorkspaceID: "run-1",
+		Path:        wtPath,
+		Metadata:    map[string]string{"branch": "feature/x"},
+	}); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+
+	res, err := a.Cleanup(context.Background(), ports.WorkspaceRequest{
+		WorkspaceID: "run-1",
+		Path:        wtPath,
+		Metadata:    map[string]string{"branch": "feature/x", "prune": "true"},
+	})
+	if err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if res.Status != "cleanup" {
+		t.Fatalf("status = %q, want cleanup", res.Status)
+	}
+	// Directory must be gone.
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Fatalf("worktree dir still present: err=%v", err)
+	}
+	// Branch must be deleted.
+	if branchExists(t, root, "feature/x") {
+		t.Fatal("branch feature/x was not deleted")
+	}
+}
+
+func TestAdapter_CleanupFallsBackWhenWorktreeUnknown(t *testing.T) {
+	root := initTestRepo(t)
+	// A directory git does not track as a worktree.
+	orphan := filepath.Join(t.TempDir(), "orphan")
+	if err := os.MkdirAll(orphan, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(orphan, "f"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a := New(root)
+
+	res, err := a.Cleanup(context.Background(), ports.WorkspaceRequest{
+		WorkspaceID: "run-1",
+		Path:        orphan,
+	})
+	if err != nil {
+		t.Fatalf("Cleanup fallback: %v", err)
+	}
+	if res.Status != "cleanup" {
+		t.Fatalf("status = %q, want cleanup", res.Status)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("orphan dir still present after fallback: err=%v", err)
+	}
+}
+
+func TestAdapter_RejectsEmptyWorkspaceID(t *testing.T) {
+	a := New("")
+	if _, err := a.Setup(context.Background(), ports.WorkspaceRequest{Path: "/tmp/x"}); err == nil {
+		t.Fatal("expected Setup error for empty workspace id")
+	}
+	if _, err := a.Cleanup(context.Background(), ports.WorkspaceRequest{Path: "/tmp/x"}); err == nil {
+		t.Fatal("expected Cleanup error for empty workspace id")
+	}
+}
+
+func TestAdapter_RejectsMissingPath(t *testing.T) {
+	a := New("")
+	_, err := a.Setup(context.Background(), ports.WorkspaceRequest{WorkspaceID: "run-1"})
+	if !errors.Is(err, ErrMissingPath) {
+		t.Fatalf("Setup err = %v, want ErrMissingPath", err)
+	}
+	_, err = a.Cleanup(context.Background(), ports.WorkspaceRequest{WorkspaceID: "run-1"})
+	if !errors.Is(err, ErrMissingPath) {
+		t.Fatalf("Cleanup err = %v, want ErrMissingPath", err)
+	}
+}
+
+func TestAdapter_HonorsContextCancellation(t *testing.T) {
+	a := New("")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := a.Setup(ctx, ports.WorkspaceRequest{WorkspaceID: "run-1", Path: "/tmp/x"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Setup err = %v, want context.Canceled", err)
+	}
+	if _, err := a.Cleanup(ctx, ports.WorkspaceRequest{WorkspaceID: "run-1", Path: "/tmp/x"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Cleanup err = %v, want context.Canceled", err)
+	}
+}
+
+// branchExists reports whether refs/heads/<name> resolves in root.
+func branchExists(t *testing.T, root, name string) bool {
+	t.Helper()
+	cmd := exec.Command("git", "show-ref", "--verify", "--quiet", "refs/heads/"+name)
+	cmd.Dir = root
+	return cmd.Run() == nil
+}


### PR DESCRIPTION
## What

First **real** adapter for `WorkspacePort` (`cli/internal/ports/workspace.go`), backed by `git worktree` subprocess calls. Per the merged [hexagon-port-realness-audit](../blob/main/docs/architecture/hexagon-port-realness-audit.md), `WorkspacePort` was the highest-leverage gap: declared + required-7, but with **only an in-memory double** and **constructed nowhere**, while ~35 direct `git worktree` callsites in `cli/cmd/ao` bypassed it.

## Adapter (`cli/internal/adapters/workspace_git/`)

Mirrors the `storage_fs` adapter pattern (package doc, compile-time `var _ ports.WorkspacePort` check, sentinel error, small named helpers).

- **`Setup`** → `git worktree add [-b <branch>] <path> [<base>]`. `branch`/`base` come from `WorkspaceRequest.Metadata`.
- **`Cleanup`** → `git worktree remove [--force] <path>`, with best-effort branch delete (`Metadata["branch"]`), optional `git worktree prune` (`Metadata["prune"]=="true"`), and a **direct-rm fallback** when the worktree is already pruned (preserves the prior callsite behavior).
- Strips `GIT_DIR`/`GIT_WORK_TREE`/`GIT_COMMON_DIR` so git rediscovers the repo from `RepoRoot` — mirrors `cmd/ao`'s `gitDiscoveryEnv`.
- Honors the port contract: rejects empty `WorkspaceID`, honors context cancellation, returns non-empty `Status`.

**Tests are L2 integration** — they create and remove real git worktrees in a temp repo and assert branch creation/deletion on disk, plus L1 contract tests (empty-id, missing-path, fallback, context cancel). 6 tests, all green.

## Wired (this PR)

- **`removeOrphanedWorktree`** (`cli/cmd/ao/rpi_cleanup.go`) — the load-bearing per-workspace Cleanup behind `ao worktree gc` (live, non-frozen lane) and `executeRPICleanup`. The `git worktree remove --force` subprocess + its already-pruned fallback now route through the port. **Behavior preserved**: the commit-preservation step and the legacy `rpi/<runID>` branch-marker delete stay in the caller.

## Follow-up: remaining direct-git callsites (NOT migrated)

Kept the PR coherent + reviewable — ~34 callsites remain, deferred:

- **`rpi_parallel.go`** (create/remove/merge worktrees, ~6 callsites) — the audit recommended this, but repo `CLAUDE.md` flags `rpi_parallel.go` as the **frozen legacy RPI lane** ("do not write new tests or features"). Migrating it needs the caller-migration refactor (`soc-1gbpz`), not a drive-by edit. **Intentionally left.**
- **Repo-wide `git worktree prune`** (`pruneWorktrees`, `rpi_cleanup.go`) — an administrative op with no per-workspace id, so it doesn't map to the `Setup`/`Cleanup`-keyed-on-`WorkspaceID` contract. The `prune` metadata field exists on the adapter for callers that cleanup+prune a single workspace; the repo-wide prune stays direct.
- **Read-only queries** — `git rev-parse --show-toplevel`, `git status --porcelain`, `show-ref`, `for-each-ref`, `rev-list`, etc. (`worktree.go`, `vibe_check.go`, `rpi_parallel.go`, and the ~10 scattered repo-root/status reads in the audit). The port only models lifecycle (`Setup`/`Cleanup`); these are deferred per the audit's "leave read-only `rev-parse` queries for a follow-up."

## Verification

- `gofmt -l` clean · `go build ./...` ✅ · `go vet ./...` ✅ · `go test ./...` → **11886 passed / 66 packages** ✅
- `scripts/check-hook-port-replacements.sh` → **PASS (7 required ports present)** — WorkspacePort still resolves.
- Diff stat: new adapter package + test + minimal wiring (24 lines in rpi_cleanup.go). No surprise churn.

Closes-scenario: soc-rg5z0#workspaceport-adapter
Bounded-context: BC5-Runtime
Evidence: cli/internal/adapters/workspace_git/