### PR TITLE
feat(hex): real bd-backed TrackerPort adapter + wire core consumer (soc-ebgjk #trackerport-bd)

### DIFF
--- a/cli/cmd/ao/session_bootstrap.go
+++ b/cli/cmd/ao/session_bootstrap.go
@@ -36,6 +36,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/boshu2/agentops/cli/internal/adapters/tracker_bd"
+
 	"github.com/spf13/cobra"
 )
 
@@ -204,20 +206,15 @@ func runOnboardSubprocess(ctx context.Context, cwd string) string {
 	return payload.Phase
 }
 
-// sessionBootstrapReadyBeads shells out to `bd ready --json` and returns the
-// count of returned items. Returns (0, false) when bd is missing or errors.
+// sessionBootstrapReadyBeads queries ready beads via the IssueTracker port
+// (tracker_bd, `bd ready --json`) and returns the count of returned items.
+// Returns (0, false) when bd is missing or errors.
 func sessionBootstrapReadyBeads(ctx context.Context, cwd string) (int, bool) {
-	cmd := exec.CommandContext(ctx, "bd", "ready", "--json")
-	cmd.Dir = cwd
-	out, err := cmd.Output()
+	issues, err := tracker_bd.New(cwd).Ready(ctx)
 	if err != nil {
 		return 0, false
 	}
-	var items []map[string]any
-	if err := json.Unmarshal(out, &items); err != nil {
-		return 0, false
-	}
-	return len(items), true
+	return len(issues), true
 }
 
 // sessionBootstrapMailUnread is a soft probe for mcp-agent-mail. The current

--- a/cli/internal/adapters/tracker_bd/tracker_bd.go
+++ b/cli/internal/adapters/tracker_bd/tracker_bd.go
@@ -1,0 +1,289 @@
+// Package tracker_bd is a real adapter for the IssueTracker port, backed by the
+// `bd` (beads) binary.
+//
+// It absorbs the issue-tracker coupling that the CLI previously reached by
+// building its own exec.Command("bd", ...) at each callsite. The read paths map
+// to:
+//
+//   - Ready  → `bd ready --json`
+//   - List   → `bd list [--type T] [--status S] [--all] [--metadata-field K=V] [--limit N] --json`
+//   - Show   → `bd show <id> --json`
+//
+// The create paths map to:
+//
+//   - CreateEpic  → `bd create <title> --type epic --description <body> --json`
+//   - CreateIssue → `bd create <title> --description <body> [--deps parent-child:<epicID>] --json`
+//
+// Command construction is split from execution (see buildArgs/parse*) so the
+// argv and parse logic can be tested directly without a live `bd` binary, per
+// the repo's Go testing rules.
+package tracker_bd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/boshu2/agentops/cli/internal/ports"
+)
+
+// Adapter satisfies ports.IssueTracker using the `bd` binary. WorkDir, when set,
+// is the working directory for every bd invocation so the adapter operates
+// against a known repository regardless of process cwd.
+type Adapter struct {
+	// WorkDir is the directory bd commands run in. Empty means the current
+	// process working directory.
+	WorkDir string
+}
+
+// New returns an Adapter rooted at workDir. Pass "" to run bd against the
+// process working directory.
+func New(workDir string) *Adapter {
+	return &Adapter{WorkDir: workDir}
+}
+
+// Compile-time interface check.
+var _ ports.IssueTracker = (*Adapter)(nil)
+
+// Mode reports the backend identity.
+func (a *Adapter) Mode() string { return "beads" }
+
+// bdIssue mirrors the subset of `bd … --json` fields the port exposes. JSON tags
+// match bd's snake_case output.
+type bdIssue struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	Status    string `json:"status"`
+	Type      string `json:"type"`
+	Priority  int    `json:"priority"`
+	Assignee  string `json:"assignee"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+func (b bdIssue) toPort() ports.Issue {
+	return ports.Issue{
+		ID:        b.ID,
+		Title:     b.Title,
+		Status:    b.Status,
+		Type:      b.Type,
+		Priority:  b.Priority,
+		Assignee:  b.Assignee,
+		UpdatedAt: b.UpdatedAt,
+	}
+}
+
+// readyArgs returns the argv for `bd ready --json`.
+func readyArgs() []string { return []string{"ready", "--json"} }
+
+// listArgs builds the argv for `bd list` from filter. Order is deterministic so
+// it can be asserted in tests.
+func listArgs(filter ports.IssueFilter) []string {
+	args := []string{"list"}
+	if filter.Type != "" {
+		args = append(args, "--type", filter.Type)
+	}
+	if filter.Status != "" {
+		args = append(args, "--status", filter.Status)
+	}
+	if filter.MetadataField != "" {
+		args = append(args, "--metadata-field", filter.MetadataField)
+	}
+	if filter.All {
+		args = append(args, "--all")
+	}
+	if filter.Limit > 0 {
+		args = append(args, "--limit", strconv.Itoa(filter.Limit))
+	}
+	args = append(args, "--json")
+	return args
+}
+
+// showArgs returns the argv for `bd show <id> --json`.
+func showArgs(id string) []string { return []string{"show", id, "--json"} }
+
+// createEpicArgs returns the argv for creating an epic.
+func createEpicArgs(title, body string) []string {
+	args := []string{"create", title, "--type", "epic"}
+	if body != "" {
+		args = append(args, "--description", body)
+	}
+	args = append(args, "--json")
+	return args
+}
+
+// createIssueArgs returns the argv for creating an issue, optionally linked to a
+// parent epic via a parent-child dependency.
+func createIssueArgs(epicID, title, body string) []string {
+	args := []string{"create", title}
+	if body != "" {
+		args = append(args, "--description", body)
+	}
+	if epicID != "" {
+		args = append(args, "--deps", "parent-child:"+epicID)
+	}
+	args = append(args, "--json")
+	return args
+}
+
+// parseIssueList decodes `bd list/ready --json` output, tolerating either a bare
+// array or an {"issues": [...]} / {"beads": [...]} envelope (bd output has
+// varied across versions). Empty input yields an empty slice.
+func parseIssueList(data []byte) ([]ports.Issue, error) {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return []ports.Issue{}, nil
+	}
+	if strings.HasPrefix(trimmed, "[") {
+		var arr []bdIssue
+		if err := json.Unmarshal([]byte(trimmed), &arr); err != nil {
+			return nil, fmt.Errorf("tracker_bd: parse list array: %w", err)
+		}
+		return toPortSlice(arr), nil
+	}
+	var env struct {
+		Issues []bdIssue `json:"issues"`
+		Beads  []bdIssue `json:"beads"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &env); err != nil {
+		return nil, fmt.Errorf("tracker_bd: parse list envelope: %w", err)
+	}
+	if len(env.Issues) > 0 {
+		return toPortSlice(env.Issues), nil
+	}
+	return toPortSlice(env.Beads), nil
+}
+
+// parseIssueShow decodes `bd show <id> --json`, which may emit a single object
+// or a 1-element array. An empty array yields a not-found error.
+func parseIssueShow(id string, data []byte) (ports.Issue, error) {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return ports.Issue{}, fmt.Errorf("tracker_bd: show %q: empty output", id)
+	}
+	if strings.HasPrefix(trimmed, "[") {
+		var arr []bdIssue
+		if err := json.Unmarshal([]byte(trimmed), &arr); err != nil {
+			return ports.Issue{}, fmt.Errorf("tracker_bd: parse show array: %w", err)
+		}
+		if len(arr) == 0 {
+			return ports.Issue{}, fmt.Errorf("tracker_bd: show %q: not found", id)
+		}
+		return arr[0].toPort(), nil
+	}
+	var rec bdIssue
+	if err := json.Unmarshal([]byte(trimmed), &rec); err != nil {
+		return ports.Issue{}, fmt.Errorf("tracker_bd: parse show object: %w", err)
+	}
+	return rec.toPort(), nil
+}
+
+// parseCreateID extracts the created id from `bd create … --json`, tolerating a
+// bare object, a 1-element array, or a plain-id string fallback.
+func parseCreateID(data []byte) (string, error) {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return "", errors.New("tracker_bd: create: empty output")
+	}
+	if strings.HasPrefix(trimmed, "[") {
+		var arr []bdIssue
+		if err := json.Unmarshal([]byte(trimmed), &arr); err == nil && len(arr) > 0 && arr[0].ID != "" {
+			return arr[0].ID, nil
+		}
+	}
+	if strings.HasPrefix(trimmed, "{") {
+		var rec bdIssue
+		if err := json.Unmarshal([]byte(trimmed), &rec); err == nil && rec.ID != "" {
+			return rec.ID, nil
+		}
+	}
+	// Fallback: bd may print just the id (possibly quoted).
+	id := strings.Trim(trimmed, "\"")
+	if id == "" {
+		return "", fmt.Errorf("tracker_bd: create: no id in output %q", trimmed)
+	}
+	return id, nil
+}
+
+func toPortSlice(in []bdIssue) []ports.Issue {
+	out := make([]ports.Issue, 0, len(in))
+	for _, b := range in {
+		out = append(out, b.toPort())
+	}
+	return out
+}
+
+// Ready returns ready (unblocked) issues via `bd ready --json`.
+func (a *Adapter) Ready(ctx context.Context) ([]ports.Issue, error) {
+	out, err := a.run(ctx, readyArgs()...)
+	if err != nil {
+		return nil, err
+	}
+	return parseIssueList(out)
+}
+
+// List returns issues matching filter via `bd list … --json`.
+func (a *Adapter) List(ctx context.Context, filter ports.IssueFilter) ([]ports.Issue, error) {
+	out, err := a.run(ctx, listArgs(filter)...)
+	if err != nil {
+		return nil, err
+	}
+	return parseIssueList(out)
+}
+
+// Show returns one issue via `bd show <id> --json`.
+func (a *Adapter) Show(ctx context.Context, id string) (ports.Issue, error) {
+	if strings.TrimSpace(id) == "" {
+		return ports.Issue{}, errors.New("tracker_bd: Show id required")
+	}
+	out, err := a.run(ctx, showArgs(id)...)
+	if err != nil {
+		return ports.Issue{}, err
+	}
+	return parseIssueShow(id, out)
+}
+
+// CreateEpic creates an epic via `bd create … --type epic --json`.
+func (a *Adapter) CreateEpic(ctx context.Context, title, body string) (string, error) {
+	if strings.TrimSpace(title) == "" {
+		return "", errors.New("tracker_bd: CreateEpic title required")
+	}
+	out, err := a.run(ctx, createEpicArgs(title, body)...)
+	if err != nil {
+		return "", err
+	}
+	return parseCreateID(out)
+}
+
+// CreateIssue creates an issue (optionally linked to epicID) via `bd create … --json`.
+func (a *Adapter) CreateIssue(ctx context.Context, epicID, title, body string) (string, error) {
+	if strings.TrimSpace(title) == "" {
+		return "", errors.New("tracker_bd: CreateIssue title required")
+	}
+	out, err := a.run(ctx, createIssueArgs(epicID, title, body)...)
+	if err != nil {
+		return "", err
+	}
+	return parseCreateID(out)
+}
+
+// run invokes bd with args, returning stdout. The working directory is
+// a.WorkDir when set. On failure it surfaces bd's stderr in the wrapped error.
+func (a *Adapter) run(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "bd", args...)
+	if a.WorkDir != "" {
+		cmd.Dir = a.WorkDir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, fmt.Errorf("tracker_bd: bd %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(exitErr.Stderr)), err)
+		}
+		return nil, fmt.Errorf("tracker_bd: bd %s: %w", strings.Join(args, " "), err)
+	}
+	return out, nil
+}

--- a/cli/internal/adapters/tracker_bd/tracker_bd_test.go
+++ b/cli/internal/adapters/tracker_bd/tracker_bd_test.go
@@ -1,0 +1,281 @@
+package tracker_bd
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/ports"
+)
+
+func TestNew_Mode(t *testing.T) {
+	a := New("/tmp/repo")
+	if a.WorkDir != "/tmp/repo" {
+		t.Errorf("WorkDir = %q, want %q", a.WorkDir, "/tmp/repo")
+	}
+	if got := a.Mode(); got != "beads" {
+		t.Errorf("Mode() = %q, want %q", got, "beads")
+	}
+}
+
+func TestReadyArgs(t *testing.T) {
+	got := readyArgs()
+	want := []string{"ready", "--json"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("readyArgs() = %v, want %v", got, want)
+	}
+}
+
+func TestListArgs(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter ports.IssueFilter
+		want   []string
+	}{
+		{
+			name:   "empty filter",
+			filter: ports.IssueFilter{},
+			want:   []string{"list", "--json"},
+		},
+		{
+			name:   "type only",
+			filter: ports.IssueFilter{Type: "epic"},
+			want:   []string{"list", "--type", "epic", "--json"},
+		},
+		{
+			name:   "status with limit",
+			filter: ports.IssueFilter{Status: "in_progress", Limit: 500},
+			want:   []string{"list", "--status", "in_progress", "--limit", "500", "--json"},
+		},
+		{
+			name:   "metadata field with all",
+			filter: ports.IssueFilter{MetadataField: "dream_packet_id=p1", All: true, Limit: 10},
+			want:   []string{"list", "--metadata-field", "dream_packet_id=p1", "--all", "--limit", "10", "--json"},
+		},
+		{
+			name:   "zero and negative limit omitted",
+			filter: ports.IssueFilter{Type: "task", Limit: -1},
+			want:   []string{"list", "--type", "task", "--json"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := listArgs(tt.filter)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("listArgs(%+v) = %v, want %v", tt.filter, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShowArgs(t *testing.T) {
+	got := showArgs("soc-123")
+	want := []string{"show", "soc-123", "--json"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("showArgs() = %v, want %v", got, want)
+	}
+}
+
+func TestCreateEpicArgs(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		body  string
+		want  []string
+	}{
+		{
+			name:  "with body",
+			title: "Big epic",
+			body:  "context",
+			want:  []string{"create", "Big epic", "--type", "epic", "--description", "context", "--json"},
+		},
+		{
+			name:  "no body",
+			title: "Bare epic",
+			body:  "",
+			want:  []string{"create", "Bare epic", "--type", "epic", "--json"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := createEpicArgs(tt.title, tt.body)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("createEpicArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateIssueArgs(t *testing.T) {
+	tests := []struct {
+		name   string
+		epicID string
+		title  string
+		body   string
+		want   []string
+	}{
+		{
+			name:   "linked to epic",
+			epicID: "epic-9",
+			title:  "child",
+			body:   "do it",
+			want:   []string{"create", "child", "--description", "do it", "--deps", "parent-child:epic-9", "--json"},
+		},
+		{
+			name:   "standalone, no body",
+			epicID: "",
+			title:  "loose",
+			body:   "",
+			want:   []string{"create", "loose", "--json"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := createIssueArgs(tt.epicID, tt.title, tt.body)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("createIssueArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseIssueList(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []ports.Issue
+	}{
+		{
+			name: "empty input",
+			in:   "",
+			want: []ports.Issue{},
+		},
+		{
+			name: "bare array",
+			in:   `[{"id":"a-1","title":"T1","status":"open","type":"task","priority":2,"assignee":"bo","updated_at":"2026-05-23"}]`,
+			want: []ports.Issue{{ID: "a-1", Title: "T1", Status: "open", Type: "task", Priority: 2, Assignee: "bo", UpdatedAt: "2026-05-23"}},
+		},
+		{
+			name: "issues envelope",
+			in:   `{"issues":[{"id":"a-2","status":"in_progress"}]}`,
+			want: []ports.Issue{{ID: "a-2", Status: "in_progress"}},
+		},
+		{
+			name: "beads envelope fallback",
+			in:   `{"beads":[{"id":"a-3"}]}`,
+			want: []ports.Issue{{ID: "a-3"}},
+		},
+		{
+			name: "empty array",
+			in:   `[]`,
+			want: []ports.Issue{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseIssueList([]byte(tt.in))
+			if err != nil {
+				t.Fatalf("parseIssueList() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseIssueList(%q) = %+v, want %+v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseIssueList_Invalid(t *testing.T) {
+	if _, err := parseIssueList([]byte(`{not json`)); err == nil {
+		t.Error("parseIssueList(invalid) expected error, got nil")
+	}
+}
+
+func TestParseIssueShow(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want ports.Issue
+	}{
+		{
+			name: "object",
+			in:   `{"id":"s-1","title":"Show","status":"open"}`,
+			want: ports.Issue{ID: "s-1", Title: "Show", Status: "open"},
+		},
+		{
+			name: "single-element array",
+			in:   `[{"id":"s-2","status":"closed"}]`,
+			want: ports.Issue{ID: "s-2", Status: "closed"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseIssueShow(tt.want.ID, []byte(tt.in))
+			if err != nil {
+				t.Fatalf("parseIssueShow() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseIssueShow(%q) = %+v, want %+v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseIssueShow_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantSub string
+	}{
+		{name: "empty", in: "", wantSub: "empty output"},
+		{name: "empty array", in: `[]`, wantSub: "not found"},
+		{name: "invalid object", in: `{bad`, wantSub: "parse show object"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseIssueShow("x-1", []byte(tt.in))
+			if err == nil {
+				t.Fatalf("parseIssueShow(%q) expected error", tt.in)
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestParseCreateID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "object", in: `{"id":"c-1"}`, want: "c-1"},
+		{name: "array", in: `[{"id":"c-2"}]`, want: "c-2"},
+		{name: "bare quoted id", in: `"c-3"`, want: "c-3"},
+		{name: "bare unquoted id", in: `c-4`, want: "c-4"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCreateID([]byte(tt.in))
+			if err != nil {
+				t.Fatalf("parseCreateID() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("parseCreateID(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCreateID_Empty(t *testing.T) {
+	if _, err := parseCreateID([]byte("")); err == nil {
+		t.Error("parseCreateID(empty) expected error, got nil")
+	}
+}
+
+func TestInterfaceSatisfied(t *testing.T) {
+	var tracker ports.IssueTracker = New("")
+	if tracker.Mode() != "beads" {
+		t.Errorf("Mode() = %q, want %q", tracker.Mode(), "beads")
+	}
+}

--- a/cli/internal/ports/inmemory_tracker.go
+++ b/cli/internal/ports/inmemory_tracker.go
@@ -1,0 +1,118 @@
+// practices: [hexagonal-architecture, ddd-bounded-context]
+package ports
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// InMemoryTracker is an IssueTracker test double. It records create calls and
+// serves a fixed set of issues for the read paths so consumers can be exercised
+// without a real `bd` binary. It is not safe for concurrent use.
+type InMemoryTracker struct {
+	// Issues backs Ready/List/Show. ReadyStatuses gates which issues Ready
+	// returns; an empty set means every issue is ready.
+	Issues        []Issue
+	ReadyStatuses map[string]bool
+
+	// CreatedEpics and CreatedIssues record create calls in order.
+	CreatedEpics  []Issue
+	CreatedIssues []Issue
+
+	nextID int
+}
+
+// NewInMemoryTracker returns an empty in-memory tracker.
+func NewInMemoryTracker() *InMemoryTracker {
+	return &InMemoryTracker{
+		ReadyStatuses: map[string]bool{},
+	}
+}
+
+// Mode reports the in-memory backend identity.
+func (t *InMemoryTracker) Mode() string { return "memory" }
+
+// CreateEpic records an epic and returns a synthetic id.
+func (t *InMemoryTracker) CreateEpic(ctx context.Context, title, body string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(title) == "" {
+		return "", errors.New("ports: InMemoryTracker.CreateEpic title required")
+	}
+	t.nextID++
+	id := fmt.Sprintf("epic-%d", t.nextID)
+	issue := Issue{ID: id, Title: title, Type: "epic", Status: "open"}
+	t.CreatedEpics = append(t.CreatedEpics, issue)
+	t.Issues = append(t.Issues, issue)
+	return id, nil
+}
+
+// CreateIssue records an issue under epicID and returns a synthetic id.
+func (t *InMemoryTracker) CreateIssue(ctx context.Context, epicID, title, body string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(title) == "" {
+		return "", errors.New("ports: InMemoryTracker.CreateIssue title required")
+	}
+	t.nextID++
+	id := fmt.Sprintf("issue-%d", t.nextID)
+	issue := Issue{ID: id, Title: title, Type: "task", Status: "open"}
+	t.CreatedIssues = append(t.CreatedIssues, issue)
+	t.Issues = append(t.Issues, issue)
+	return id, nil
+}
+
+// Ready returns the recorded issues whose status is in ReadyStatuses (or all
+// issues when ReadyStatuses is empty).
+func (t *InMemoryTracker) Ready(ctx context.Context) ([]Issue, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	out := make([]Issue, 0, len(t.Issues))
+	for _, issue := range t.Issues {
+		if len(t.ReadyStatuses) == 0 || t.ReadyStatuses[issue.Status] {
+			out = append(out, issue)
+		}
+	}
+	return out, nil
+}
+
+// List returns the recorded issues that match filter.
+func (t *InMemoryTracker) List(ctx context.Context, filter IssueFilter) ([]Issue, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	out := make([]Issue, 0, len(t.Issues))
+	for _, issue := range t.Issues {
+		if filter.Type != "" && issue.Type != filter.Type {
+			continue
+		}
+		if filter.Status != "" && issue.Status != filter.Status {
+			continue
+		}
+		out = append(out, issue)
+		if filter.Limit > 0 && len(out) >= filter.Limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+// Show returns the recorded issue with the given id, or an error when absent.
+func (t *InMemoryTracker) Show(ctx context.Context, id string) (Issue, error) {
+	if err := ctx.Err(); err != nil {
+		return Issue{}, err
+	}
+	for _, issue := range t.Issues {
+		if issue.ID == id {
+			return issue, nil
+		}
+	}
+	return Issue{}, fmt.Errorf("ports: InMemoryTracker.Show: issue %q not found", id)
+}
+
+var _ IssueTracker = (*InMemoryTracker)(nil)

--- a/cli/internal/ports/inmemory_tracker_test.go
+++ b/cli/internal/ports/inmemory_tracker_test.go
@@ -1,0 +1,148 @@
+package ports
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInMemoryTracker_Mode(t *testing.T) {
+	tr := NewInMemoryTracker()
+	if got := tr.Mode(); got != "memory" {
+		t.Errorf("Mode() = %q, want %q", got, "memory")
+	}
+}
+
+func TestInMemoryTracker_CreateAndShow(t *testing.T) {
+	tr := NewInMemoryTracker()
+	ctx := context.Background()
+
+	epicID, err := tr.CreateEpic(ctx, "Epic A", "body")
+	if err != nil {
+		t.Fatalf("CreateEpic() error = %v", err)
+	}
+	if epicID != "epic-1" {
+		t.Errorf("epicID = %q, want %q", epicID, "epic-1")
+	}
+
+	issueID, err := tr.CreateIssue(ctx, epicID, "Task 1", "body")
+	if err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+	if issueID != "issue-2" {
+		t.Errorf("issueID = %q, want %q", issueID, "issue-2")
+	}
+
+	if len(tr.CreatedEpics) != 1 || len(tr.CreatedIssues) != 1 {
+		t.Fatalf("recorded epics=%d issues=%d, want 1/1", len(tr.CreatedEpics), len(tr.CreatedIssues))
+	}
+
+	got, err := tr.Show(ctx, epicID)
+	if err != nil {
+		t.Fatalf("Show() error = %v", err)
+	}
+	if got.Title != "Epic A" || got.Type != "epic" {
+		t.Errorf("Show() = %+v, want title=Epic A type=epic", got)
+	}
+}
+
+func TestInMemoryTracker_CreateEmptyTitle(t *testing.T) {
+	tr := NewInMemoryTracker()
+	ctx := context.Background()
+	if _, err := tr.CreateEpic(ctx, "  ", "body"); err == nil {
+		t.Error("CreateEpic(empty title) expected error, got nil")
+	}
+	if _, err := tr.CreateIssue(ctx, "", "", "body"); err == nil {
+		t.Error("CreateIssue(empty title) expected error, got nil")
+	}
+}
+
+func TestInMemoryTracker_ShowNotFound(t *testing.T) {
+	tr := NewInMemoryTracker()
+	if _, err := tr.Show(context.Background(), "missing"); err == nil {
+		t.Error("Show(missing) expected error, got nil")
+	}
+}
+
+func TestInMemoryTracker_Ready(t *testing.T) {
+	tr := NewInMemoryTracker()
+	tr.Issues = []Issue{
+		{ID: "a", Status: "open"},
+		{ID: "b", Status: "blocked"},
+		{ID: "c", Status: "open"},
+	}
+	tr.ReadyStatuses = map[string]bool{"open": true}
+
+	got, err := tr.Ready(context.Background())
+	if err != nil {
+		t.Fatalf("Ready() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("Ready() returned %d, want 2", len(got))
+	}
+	if got[0].ID != "a" || got[1].ID != "c" {
+		t.Errorf("Ready() ids = %q,%q, want a,c", got[0].ID, got[1].ID)
+	}
+}
+
+func TestInMemoryTracker_ReadyAllWhenNoStatuses(t *testing.T) {
+	tr := NewInMemoryTracker()
+	tr.Issues = []Issue{{ID: "a", Status: "open"}, {ID: "b", Status: "x"}}
+	got, err := tr.Ready(context.Background())
+	if err != nil {
+		t.Fatalf("Ready() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("Ready() returned %d, want 2 (no status filter)", len(got))
+	}
+}
+
+func TestInMemoryTracker_List(t *testing.T) {
+	tr := NewInMemoryTracker()
+	tr.Issues = []Issue{
+		{ID: "e1", Type: "epic", Status: "open"},
+		{ID: "t1", Type: "task", Status: "in_progress"},
+		{ID: "t2", Type: "task", Status: "in_progress"},
+	}
+
+	tests := []struct {
+		name    string
+		filter  IssueFilter
+		wantIDs []string
+	}{
+		{name: "by type", filter: IssueFilter{Type: "epic"}, wantIDs: []string{"e1"}},
+		{name: "by status", filter: IssueFilter{Status: "in_progress"}, wantIDs: []string{"t1", "t2"}},
+		{name: "with limit", filter: IssueFilter{Status: "in_progress", Limit: 1}, wantIDs: []string{"t1"}},
+		{name: "no filter", filter: IssueFilter{}, wantIDs: []string{"e1", "t1", "t2"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tr.List(context.Background(), tt.filter)
+			if err != nil {
+				t.Fatalf("List() error = %v", err)
+			}
+			if len(got) != len(tt.wantIDs) {
+				t.Fatalf("List() returned %d, want %d", len(got), len(tt.wantIDs))
+			}
+			for i, id := range tt.wantIDs {
+				if got[i].ID != id {
+					t.Errorf("List()[%d].ID = %q, want %q", i, got[i].ID, id)
+				}
+			}
+		})
+	}
+}
+
+func TestInMemoryTracker_ContextCancelled(t *testing.T) {
+	tr := NewInMemoryTracker()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := tr.Ready(ctx); err == nil {
+		t.Error("Ready(cancelled ctx) expected error, got nil")
+	}
+	if _, err := tr.List(ctx, IssueFilter{}); err == nil {
+		t.Error("List(cancelled ctx) expected error, got nil")
+	}
+	if _, err := tr.Show(ctx, "x"); err == nil {
+		t.Error("Show(cancelled ctx) expected error, got nil")
+	}
+}

--- a/cli/internal/ports/tracker.go
+++ b/cli/internal/ports/tracker.go
@@ -1,11 +1,53 @@
+// practices: [hexagonal-architecture, ddd-bounded-context]
 package ports
 
 import "context"
 
-// IssueTracker is the driven port for epic/issue creation.
-// Implementations: beads (when bd is available), tasklist (filesystem fallback).
+// Issue is the driven-port view of one tracker issue (a bead). It carries the
+// subset of fields the CLI's read paths consume; adapters populate what their
+// backend exposes and leave the rest zero-valued.
+type Issue struct {
+	ID        string
+	Title     string
+	Status    string
+	Type      string
+	Priority  int
+	Assignee  string
+	UpdatedAt string
+}
+
+// IssueFilter narrows a List query. Zero-valued fields are not applied, so an
+// empty filter lists everything the backend returns. Limit <= 0 means no limit.
+type IssueFilter struct {
+	Type          string // e.g. "epic", "bug", "task"
+	Status        string // e.g. "in_progress", "open"
+	Limit         int    // max items to return; <= 0 disables the cap
+	All           bool   // include closed/all states when the backend supports it
+	MetadataField string // "key=value" filter (bd: --metadata-field)
+}
+
+// IssueTracker is the driven port for epic/issue lifecycle operations.
+//
+// Implementations: tracker_bd (real, shells out to the `bd` binary),
+// InMemoryTracker (in-memory test double). The previous create-only surface was
+// widened (soc-ebgjk) to cover the read paths the CLI actually depends on —
+// Ready/List/Show — which were reaching `bd` via scattered exec.Command calls.
+//
+// Contract:
+//
+//   - Mode reports the backend identity ("beads" | "tasklist" | "memory").
+//   - Read methods (Ready/List/Show) are side-effect free.
+//   - Show on a missing id returns a non-nil error.
+//   - Context cancellation MUST be honored on a best-effort basis.
 type IssueTracker interface {
-	Mode() string // "beads" | "tasklist"
+	Mode() string // "beads" | "tasklist" | "memory"
+
+	// Create paths.
 	CreateEpic(ctx context.Context, title, body string) (epicID string, err error)
 	CreateIssue(ctx context.Context, epicID, title, body string) (issueID string, err error)
+
+	// Read paths.
+	Ready(ctx context.Context) ([]Issue, error)
+	List(ctx context.Context, filter IssueFilter) ([]Issue, error)
+	Show(ctx context.Context, id string) (Issue, error)
 }


### PR DESCRIPTION
## What

The `IssueTracker` port (`cli/internal/ports/tracker.go`) was **create-only** (`Mode`/`CreateEpic`/`CreateIssue`) with **zero implementations** — no real adapter and no in-memory double — while the CLI reached `bd` via ~10 scattered `exec.Command` callsites, the majority of which are READ paths (`bd ready` / `bd list` / `bd show`). Per `docs/architecture/hexagon-port-realness-audit.md` (the port is "bypassed → bd reached directly").

This slice gives the port its first real adapter, mirroring the just-merged `workspace_git` / `storage_fs` pattern.

## Changes

- **Widen the port (minimally).** Added the read paths the CLI actually depends on — `Ready(ctx)`, `List(ctx, IssueFilter)`, `Show(ctx, id)` — plus an `Issue` value type and an `IssueFilter`. The create surface is unchanged. The audit explicitly recommends widening for read paths rather than shipping a create-only adapter.
- **In-memory double.** New `ports.InMemoryTracker` satisfies the widened interface (keeps the build + existing tests green; it is also the port's first test seam).
- **Real adapter.** New `cli/internal/adapters/tracker_bd/` shells out to `bd` with `--json` and parses, tolerating bd's array-vs-`{"issues":…}`-envelope output variance (observed across the existing callsites). Command construction (`readyArgs`/`listArgs`/`showArgs`/`create*Args`) is split from exec so argv + parse logic test directly without a live `bd`.
- **Wired ONE core consumer.** `session_bootstrap.go`'s `bd ready --json` path now routes through `tracker_bd.New(cwd).Ready(ctx)` instead of a hand-rolled `exec.Command`.

## Port shape (widened)

Before: `Mode() / CreateEpic / CreateIssue` (create-only, no impls).
After: adds `Ready() / List(IssueFilter) / Show(id)` + `Issue` + `IssueFilter`.

## Verification

- `cd cli && gofmt -l` clean, `go build ./...`, `go vet ./...` clean
- `go test ./...` green (touched packages: 10473 tests pass)
- `bash scripts/check-hook-port-replacements.sh` → PASS (ports still resolve)
- Tests do **not** depend on a live `bd` binary (per `.claude/rules/go.md`).

## Follow-up: un-migrated bd callsites (deferred, not in scope for this coherent arc)

This is a focused first slice (one consumer). The remaining direct `bd` callsites should migrate through `tracker_bd` in follow-up slices:
- `cmd/ao/beads_resume.go:66` — `bd show <id> --json` → `Show`
- `cmd/ao/beads_stale.go:140` — `bd list --status in_progress --json` → `List`
- `cmd/ao/plans.go:710` — `bd list --type epic --json` → `List`
- `cmd/ao/overnight_packets.go:961,995,1025` — `bd list --metadata-field … --json` → `List`
- `internal/goalstrace/beads.go:66,69` — `bd list --json [--all]` → `List`
- `internal/ratchet/gate.go:247` — `bd list --type epic --status …` → `List`
- `cmd/ao/quickstart.go:474` (`bd init`), `cmd/ao/beads.go:42` (generic passthrough) — out of the read/create surface; evaluate separately.

Each has its own test seam today; migrating them is mechanical but touches independent surfaces, so they ship-or-revert separately from this arc.

Closes-scenario: soc-ebgjk#trackerport-bd
Bounded-context: BC5-Runtime
Evidence: cli/internal/adapters/tracker_bd/