### PR TITLE
docs(3.0): mark none-a-noise-injector met — 7 noise hooks deleted (soc-cul67 #hookless-docs)

### DIFF
--- a/docs/3.0-readiness.md
+++ b/docs/3.0-readiness.md
@@ -14,7 +14,7 @@ The operator-directed 3.0 reconciliation (2026-05-23) ran as a cron-paced `/evol
 | W1c | `soc-sb5r1` | Workbench Δ=0 claim kept (artifact exists); unsubstantiated 3-judge-parity claim downgraded to internal finding | #471 |
 | W1d | `soc-onfm1` | Stale `dream_executor.go` path fixed; 3 of 4 flagged items were already correct | #472 |
 | W2 | `soc-qk4b` | Hexagon crank tail: **71/80 skills** now carry canonical `.feature` acceptance (`hexagonal_role` already 100%) | #473-479 |
-| W3 | `soc-6zihw` | Hook-noise audit: 53 hooks → 14 gate / 25 bounded-adapter / 14 noise-injector ([hook-noise-audit.md](architecture/hook-noise-audit.md)) | #480 |
+| W3 | `soc-6zihw` | Hook-noise audit: 53 hooks → 14 gate / 25 bounded-adapter / 14 noise-injector ([hook-noise-audit.md](architecture/hook-noise-audit.md)). The 7 true noise-injectors then **deleted** (`soc-e2ju0` S1–S3) → 46 hooks, 0 noise-injectors | #480, #483, #488, #494 |
 | W4 | `soc-hplds` | This level-set | — |
 
 A recurring pattern: the discovery **over-stated scope**, and verify-before-acting caught it every time (W1a dead-code was live; W1c only one of two claims was unbacked; W1d 3 of 4 already correct). That is the reconciliation working as intended — match what reality *is*, not what the gap report assumed.
@@ -24,11 +24,11 @@ A recurring pattern: the discovery **over-stated scope**, and verify-before-acti
 - **[x] North star is the single referenced source of truth** — `docs/3.0.md` authored (W0); README, PRODUCT, GOALS, docs-index, mkdocs nav, and CLAUDE.md all point to it.
 - **[x] Docs match reality** — the dead-code claim, aspirational-feature claims, unsubstantiated market claim, and stale path that the audit found are all corrected (W1a-d). Aspirational items live in `docs/ROADMAP.md`; market claims are artifact-gated.
 - **[x] Hexagon complete (stable surface)** — every skill carries `hexagonal_role`; 71/80 carry canonical `.feature` acceptance. The 9 without are intentionally exempt, not skipped: `expert-council` + `inject` (deprecated/removal-target), `shared` + `standards` + `using-agentops` + `converter` + `provenance` + `flywheel` (meta/internal/not user-invocable), `llm-wiki` (open proposal, no implementation — a `.feature` would assert unbuilt behavior).
-- **[ ] Hooks audited for noise → none a noise-injector** — audit **complete** (W3, `docs/architecture/hook-noise-audit.md`); 14 noise-injectors identified. Flipping them to opt-in-by-default so the *default* experience is quiet is tracked in **`soc-e2ju0`**. The audit clause is met; the "none a noise-injector" end-state lands with that bead.
+- **[x] Hooks audited for noise → none a noise-injector** — audit **complete** (W3, `docs/architecture/hook-noise-audit.md`); the 14 flagged entries split into 7 true noise-injectors (**deleted** across `soc-e2ju0` S1–S3) and 7 conditional injectors (reclassified as kept-gates). **46 hooks remain, all gates or bounded adapters — none a noise-injector** (`soc-cul67`). The separate default-install-zero-hooks lift is `soc-e2ju0` S4, still open and not a 3.0-close blocker.
 - **[x] The loop is executable** — the operating loop (discovery → plan → implement → validate → ratchet) is documented in [operating-loop.md](architecture/operating-loop.md) and was exercised end-to-end across this reconciliation's 13 PRs via `/discovery`, `/crank`, worktree-per-bead, CI validation, and squash-merge ratchet.
 - **[ ] Every AgentOps bead worked or closed** — the reconciliation waves (W0-W4) and the off-3.0 beads are closed; remaining agentops-scoped 3.0-aligned beads (coherence/ledger hardening: `soc-ficdw`, `iha27`, `v3y80`, et al.) are **open and tracked**, not abandoned. Fleet/other-repo `soc-*` beads (personal-site, mt-olympus, bushido-infra, showcase, platform-lab) are out of scope per the ratified content-scoping decision.
 
-**Net:** 4 of 6 acceptance boxes met; the 2 open boxes have named tracking beads, not unknowns.
+**Net:** 5 of 6 acceptance boxes met; the 1 open box (every AgentOps bead worked or closed) has named tracking beads, not unknowns.
 
 ## Fitness snapshot (`ao goals measure`, 2026-05-23)
 
@@ -40,7 +40,7 @@ Neither blocks PRs; both are tracked signals, not reconciliation regressions.
 
 ## Remaining work (named, not blocking the 3.0-reconciliation close)
 
-- `soc-e2ju0` — flip the 14 hook noise-injectors to opt-in-default (satisfies the open hooks box).
+- `soc-e2ju0` S4 — default install goes to zero hooks (the hooks-noise box is already met by S1–S3 deleting the 7 noise-injectors; S4 is the remaining default-install lift, not a 3.0-close blocker).
 - `soc-1gbpz` — migrate-or-remove the legacy RPI lane (caller-migration refactor; the code is live, not dead).
 - Coherence/ledger hardening beads (`soc-ficdw` et al.) — agentops 3.0-aligned, open.
 - ADR-0002 S2-S5 — hookless default-install + hookless RPI; explicitly a **follow-on, not a 3.0-close blocker** (docs/3.0.md).

--- a/docs/3.0.md
+++ b/docs/3.0.md
@@ -66,7 +66,7 @@ The rule in one line: **hooks may help, but they must not inject random noise.**
 - [x] This north star is the single referenced source of truth; the sources of truth (README, PRODUCT, GOALS, docs index) point here.
 - [x] **Docs match reality:** no aspirational claims in live docs, no dead code, no stale paths or counts, no unsubstantiated market claims.
 - [x] **Hexagon complete:** every skill carries `hexagonal_role` plus accurate `consumes`/`produces` plus canonical `.feature` acceptance (the `soc-qk4b` crank) — 71/80 cranked, the 9 exceptions are deprecated/internal/meta/proposal skills (enumerated in the readiness level-set).
-- [ ] **Hooks audited for noise:** every hook is a bounded adapter or a gate, none a noise-injector. *(Audit complete — [hook-noise-audit.md](architecture/hook-noise-audit.md); flipping the 14 noise-injectors to opt-in-default is tracked in `soc-e2ju0`.)*
+- [x] **Hooks audited for noise:** every hook is a bounded adapter or a gate, none a noise-injector. *(Audit complete — [hook-noise-audit.md](architecture/hook-noise-audit.md). The 7 noise-injectors were **deleted outright** — not quieted — across `soc-e2ju0` S1–S3 (they were value-negative: A/B Δ=0). 46 hooks remain, all gates or bounded adapters.)*
 - [x] **The loop is executable:** BDD intent → tests → bounded build → both-ends validation → ratchet — documented in [operating-loop.md](architecture/operating-loop.md) and exercised end-to-end across the 2026-05-23 reconciliation.
 - [ ] Every AgentOps bead is worked or closed against this north star. *(Reconciliation waves W0–W4 closed; remaining 3.0-aligned coherence/ledger beads are open and tracked.)*
 

--- a/docs/architecture/hook-noise-audit.md
+++ b/docs/architecture/hook-noise-audit.md
@@ -1,8 +1,8 @@
 # Hook-Noise Audit (3.0 reconciliation)
 
-> **Bead:** `soc-6zihw` (W3 of the 3.0 reconciliation). **Criterion:** [docs/3.0.md](../3.0.md) — "hooks may help, but they must not inject random noise"; the 3.0-ready acceptance is *"every hook is a bounded adapter or a gate, none a noise-injector."* This audit classifies all 53 hook scripts against that criterion. Edits to hook behavior are tracked separately (see Follow-on).
+> **Bead:** `soc-6zihw` (W3 of the 3.0 reconciliation), resolved through `soc-e2ju0` S1–S3. **Criterion:** [docs/3.0.md](../3.0.md) — "hooks may help, but they must not inject random noise"; the 3.0-ready acceptance is *"every hook is a bounded adapter or a gate, none a noise-injector."* This audit originally classified all 53 hook scripts against that criterion; the noise-injectors have since been deleted, leaving **46 hooks, all gates or bounded adapters — none a noise-injector**. The acceptance box is met.
 >
-> **Status (go-hookless epic `soc-e2ju0`):** operator chose to **delete** the noise-injectors outright, not quiet them (they are value-negative: A/B Δ=0). S1 (`soc-s1i3b`) deleted 5 — `research-loop-detector`, `context-monitor`, `write-time-quality`, `edit-knowledge-surface`, `go-vet-post-edit` — leaving 48 hooks. S2 (`soc-khev6`) deleted `standards-injector` and retired its dedicated `standards-injector-completeness` CI gate, leaving 47 hooks. S3 (`soc-vpmzg`) deleted `commit-review-gate` — the value-negative noise-injector that injected the staged diff + a "SELF-REVIEW" prompt on every `git commit` (never blocked, always exited 0) — leaving 46 hooks. The "+7 conditional injectors" the audit originally grouped with it were reclassified as kept-gates (they speak only on a real violation), so S3 deletes only `commit-review-gate`. Default install goes to zero hooks in S4.
+> **Status (go-hookless epic `soc-e2ju0`) — RESOLVED, all 7 noise-injectors deleted:** the operator chose to **delete** the noise-injectors outright, not quiet them (they are value-negative: A/B Δ=0). S1 (`soc-s1i3b`) deleted 5 — `research-loop-detector`, `context-monitor`, `write-time-quality`, `edit-knowledge-surface`, `go-vet-post-edit` — leaving 48 hooks. S2 (`soc-khev6`) deleted `standards-injector` and retired its dedicated `standards-injector-completeness` CI gate, leaving 47 hooks. S3 (`soc-vpmzg`) deleted `commit-review-gate` — the value-negative noise-injector that injected the staged diff + a "SELF-REVIEW" prompt on every `git commit` (never blocked, always exited 0) — leaving **46 hooks**. The "+7 conditional injectors" the audit originally grouped with the noise-injectors were reclassified as kept-gates (they speak only on a real violation), so S3 deleted only `commit-review-gate`. **No noise-injector remains; the docs/3.0.md "none a noise-injector" box is now met (`soc-cul67`).** The separate default-install-zero-hooks lift is S4 (ADR-0002), still open and not a 3.0-close blocker.
 
 ## Method
 
@@ -16,39 +16,50 @@ The discriminator: *does the hook speak only when it blocks or detects a real pr
 
 ## Summary
 
-| Category | Count | Disposition |
+**Original audit (53 hooks, before deletion):**
+
+| Category | Count | Original disposition |
 |---|---|---|
 | GATE | 14 | keep |
 | BOUNDED-ADAPTER | 25 | keep |
-| NOISE-INJECTOR | 14 | quiet (flip to opt-in default) or raise thresholds |
+| NOISE-INJECTOR | 14 | cut or quiet |
 
-39 of 53 hooks (74%) already meet the 3.0 criterion. The 14 noise-injectors all already honor a per-hook disable env var and `AGENTOPS_HOOKS_DISABLED`; the reconciliation is to flip their **default** from opt-out to opt-in (or raise their thresholds) so the default experience is quiet.
+**Current state (46 hooks, after `soc-e2ju0` S1–S3 deleted the 7 true noise-injectors):**
 
-## Noise-injectors (cut/quiet candidates)
+| Category | Count | Disposition |
+|---|---|---|
+| GATE | 20 | keep — 13 original gates + the 7 conditional injectors reclassified as gates (speak only on a real violation) |
+| BOUNDED-ADAPTER | 26 | keep |
+| NOISE-INJECTOR | 0 | **all 7 deleted** |
 
-Ranked by injection frequency × unconditionality. Each cites the emission site and the existing disable flag.
+The shift: the 14 entries originally bucketed as "noise-injectors" split into **7 true unconditional noise-injectors (deleted)** and **7 conditional injectors that only speak on a real violation (kept, reclassified as gates)**. `go-vet-post-edit` left the gate column too — it was one of the 7 deleted hooks, not a surviving blocking-path gate. **All 46 surviving hooks meet the 3.0 criterion: every one is a bounded adapter or a gate, none a noise-injector.**
 
-| Hook | Event | Emits additionalContext | Disable flag (exists) | Verdict |
-|---|---|---|---|---|
-| `standards-injector.sh` | PreToolUse:Edit/Write (6 file types) | always — JIT language standards on every edit | (removed) | **DELETED in S2 (`soc-khev6`)** — replaced by the standards skill, read on demand |
-| `commit-review-gate.sh` | PreToolUse:Bash (`git commit`) | always — staged diff + "SELF-REVIEW" every commit (misnamed: never blocks, line 4 "Non-blocking, always exit 0") | (removed) | **DELETED in S3 (`soc-vpmzg`)** — value-negative noise-injector, no replacement |
-| `edit-knowledge-surface.sh` | PreToolUse:Edit | always — greps `.agents/learnings/` + "Relevant learnings" on every edit | `AGENTOPS_EDIT_KNOWLEDGE_DISABLED` | quiet: opt-in default or filename-filter |
-| `research-loop-detector.sh` | PostToolUse:Read/Grep/Glob/Web* | escalating "you have made N read-only calls" from 8 reads | `AGENTOPS_RESEARCH_LOOP_DISABLED` | quiet: raise thresholds (8→16) or opt-in |
-| `context-monitor.sh` | PostToolUse | context warnings at 35%/25% remaining (fires 3-5×/session) | (threshold env) | quiet: raise to ~15% remaining |
-| `write-time-quality.sh` | PostToolUse:Edit/Write | advisory quality warnings on routine writes | (per-lang) | quiet: opt-in default |
-| `go-vet-post-edit.sh` | PostToolUse (Go) | density warnings on every Go edit | (always-on by design) | quiet: only on real vet failure |
-| (+7 lower-frequency conditional injectors) | various | conditional advisory prose | per-hook flags | quiet/monitor |
+## Noise-injectors (all 7 deleted)
 
-**Kept despite the "gate"/"warn" name (conditional, gated on a real violation — NOT noise):** `session-pr-counter.sh` (fires once at the 5-PR threshold), `check-test-pair-on-commit.sh`, `check-sibling-citation-on-commit.sh`, `update-principles-check.sh`, `codex-parity-warn.sh` (only on actual skills/ parity drift), `config-change-monitor.sh`, `context-guard.sh` (only on CRITICAL context). These speak only when a real condition holds, so they are bounded gates, not noise.
+The 7 true noise-injectors — those that emitted `additionalContext`/advisory stdout on **every** matching event regardless of relevance — were deleted outright across `soc-e2ju0` S1–S3. None survive. Listed below for the historical record, each with the stage that removed it.
 
-## Gates (14, keep)
+| Hook | Event | Emitted additionalContext | Verdict |
+|---|---|---|---|
+| `research-loop-detector.sh` | PostToolUse:Read/Grep/Glob/Web* | escalating "you have made N read-only calls" from 8 reads | **DELETED in S1 (`soc-s1i3b`)** |
+| `context-monitor.sh` | PostToolUse | context warnings at 35%/25% remaining (fired 3-5×/session) | **DELETED in S1 (`soc-s1i3b`)** |
+| `write-time-quality.sh` | PostToolUse:Edit/Write | advisory quality warnings on routine writes | **DELETED in S1 (`soc-s1i3b`)** |
+| `edit-knowledge-surface.sh` | PreToolUse:Edit | always — greps `.agents/learnings/` + "Relevant learnings" on every edit | **DELETED in S1 (`soc-s1i3b`)** |
+| `go-vet-post-edit.sh` | PostToolUse (Go) | density warnings on every Go edit | **DELETED in S1 (`soc-s1i3b`)** |
+| `standards-injector.sh` | PreToolUse:Edit/Write (6 file types) | always — JIT language standards on every edit | **DELETED in S2 (`soc-khev6`)** — replaced by the standards skill, read on demand; its `standards-injector-completeness` CI gate retired with it |
+| `commit-review-gate.sh` | PreToolUse:Bash (`git commit`) | always — staged diff + "SELF-REVIEW" every commit (misnamed: never blocked, line 4 "Non-blocking, always exit 0") | **DELETED in S3 (`soc-vpmzg`)** — value-negative, no replacement |
 
-`dangerous-git-guard`, `edit-scope-guard`, `go-test-precommit`, `go-complexity-precommit`, `holdout-isolation-gate`, `lead-only-worker-git-guard`, `git-worker-guard`, `pre-mortem-gate`, `stop-team-guard`, `task-validation-gate`, `skill-lint-gate`, `ao-agents-check`, `constraint-compiler`, `go-vet-post-edit`(blocking path) — all block on a real violation and inject nothing on the happy path.
+The original audit grouped "+7 lower-frequency conditional injectors" with these. On closer inspection they only speak on a real violation, so they were **reclassified as kept-gates, not deleted** (see below).
 
-## Bounded adapters (25, keep)
+**Reclassified as kept-gates (conditional, gated on a real violation — NOT noise):** `session-pr-counter.sh` (fires once at the 5-PR threshold), `check-test-pair-on-commit.sh`, `check-sibling-citation-on-commit.sh`, `update-principles-check.sh`, `codex-parity-warn.sh` (only on actual skills/ parity drift), `config-change-monitor.sh`, `context-guard.sh` (only on CRITICAL context). These speak only when a real condition holds, so they are bounded gates, not noise.
 
-Silent or diagnostic side-effects: `session-start`, `ao-inject`, `ao-extract`, `ao-forge`, `ao-flywheel-close`, `ao-maturity-scan`, `ao-ratchet-status`, `ao-session-outcome`, `ao-task-sync`, `ao-feedback-loop`, `citation-tracker`, `compile-session-defrag`, `edit-audit`, `factory-router`, `finding-compiler`, `pending-cleaner`, `postedit-codex-refresh`, `precompact-snapshot`, `quality-signals`, `ratchet-advance`, `session-end-maintenance`, `subagent-stop`, `worktree-setup`, `worktree-cleanup`, `config-change-monitor`(bounded path).
+## Gates (20, keep)
 
-## Follow-on (behavior change, tracked separately)
+The 13 original gates — `dangerous-git-guard`, `edit-scope-guard`, `go-test-precommit`, `go-complexity-precommit`, `holdout-isolation-gate`, `lead-only-worker-git-guard`, `git-worker-guard`, `pre-mortem-gate`, `stop-team-guard`, `task-validation-gate`, `skill-lint-gate`, `ao-agents-check`, `constraint-compiler` — plus the 7 reclassified conditional gates: `session-pr-counter`, `check-test-pair-on-commit`, `check-sibling-citation-on-commit`, `update-principles-check`, `codex-parity-warn`, `config-change-monitor`, `context-guard`. All block or speak only on a real violation and inject nothing on the happy path. (`go-vet-post-edit` was previously listed here for its blocking path — it was one of the 7 deleted hooks and no longer exists.)
 
-This audit is the analysis deliverable. Flipping the 14 noise-injectors to opt-in-by-default (or raising thresholds) is a behavior change to the operator's hook environment, tracked as a follow-on so the default-quiet transition is deliberate and reviewable. It satisfies the docs/3.0.md acceptance box once landed. The default-install-zero-hooks lift is ADR-0002 S2–S5 (separate, not a 3.0-close blocker).
+## Bounded adapters (26, keep)
+
+Silent or diagnostic side-effects: `session-start`, `ao-inject`, `ao-extract`, `ao-forge`, `ao-flywheel-close`, `ao-maturity-scan`, `ao-ratchet-status`, `ao-session-outcome`, `ao-task-sync`, `ao-feedback-loop`, `citation-tracker`, `compile-session-defrag`, `edit-audit`, `eval-verdict-compiler`, `factory-router`, `finding-compiler`, `pending-cleaner`, `postedit-codex-refresh`, `precompact-snapshot`, `quality-signals`, `ratchet-advance`, `session-end-maintenance`, `stop-auto-handoff`, `subagent-stop`, `worktree-setup`, `worktree-cleanup`.
+
+## Resolution + follow-on
+
+This audit was the analysis deliverable; the behavior change has since landed. Rather than flip the noise-injectors to opt-in-by-default, the operator deleted the 7 true noise-injectors outright (`soc-e2ju0` S1–S3) — they were value-negative (A/B Δ=0), so quieting them would have kept dead weight. With them gone, all 46 surviving hooks are gates or bounded adapters, and the docs/3.0.md "none a noise-injector" acceptance box is **met** (`soc-cul67`). The remaining default-install-zero-hooks lift is `soc-e2ju0` S4 (ADR-0002) — separate, still open, and not a 3.0-close blocker.

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -51,7 +51,7 @@ Bridge / framing docs:
 - [Architecture Folder Index](architecture/index.md) — Architecture subdocs overview
 - [Codex Hookless Lifecycle](architecture/codex-hookless-lifecycle.md) — Runtime-aware lifecycle fallback for Codex when hooks are unavailable
 - [Primitive Chains](architecture/primitive-chains.md) — Audited primitive set, lifecycle chains, and terminology drift ledger
-- [Hook-Noise Audit](architecture/hook-noise-audit.md) — 3.0 classification of all 53 hooks (gate / bounded-adapter / noise-injector) against the docs/3.0.md no-noise criterion
+- [Hook-Noise Audit](architecture/hook-noise-audit.md) — 3.0 classification of the hooks against the docs/3.0.md no-noise criterion; the 7 noise-injectors were deleted (`soc-e2ju0` S1–S3), leaving 46 hooks, all gates or bounded adapters
 - [Ports and Adapters](architecture/ports-and-adapters.md) — Hexagonal seam: inner-hexagon domain, driving/driven adapters, ports, and how to add a new adapter
 - [Hexagon Port-Realness Audit](architecture/hexagon-port-realness-audit.md) — Empirical 2026-05-23 inventory of all 26 declared ports (real vs in-memory vs bypassed), direct-coupling hotspots (git/bd/loop/corpus) with file:line, and the recommended adapter build order for epic soc-zvhsl
 - [Operating Loop](architecture/operating-loop.md) — Operational discipline every process skill executes: BDD intent → vertical slices → conflict-free wave → bead acceptance → evidence (cleanroom companion to ports-and-adapters)

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -841,7 +841,7 @@
     {
       "name": "hooks-authoring",
       "source_skill": "skills/hooks-authoring",
-      "source_hash": "7f74f159c6fb955ebfc707abc1063cfc08658f3ab2ce90a6e4b1211d910fdb2a",
+      "source_hash": "fc504994af5c2383886d57a8e985f89ea6fd8475f8655854005d727ae61a1fb1",
       "generated_hash": "d0af71012da70768cd4ebc38297f3dcf6bc72b3fb6e5af0b202224bc999ca177"
     },
     {

--- a/skills-codex/hooks-authoring/.agentops-generated.json
+++ b/skills-codex/hooks-authoring/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/hooks-authoring",
   "layout": "modular",
-  "source_hash": "7f74f159c6fb955ebfc707abc1063cfc08658f3ab2ce90a6e4b1211d910fdb2a",
+  "source_hash": "fc504994af5c2383886d57a8e985f89ea6fd8475f8655854005d727ae61a1fb1",
   "generated_hash": "d0af71012da70768cd4ebc38297f3dcf6bc72b3fb6e5af0b202224bc999ca177"
 }

--- a/skills/hooks-authoring/SKILL.md
+++ b/skills/hooks-authoring/SKILL.md
@@ -80,6 +80,7 @@ Use this skill when work touches `hooks/hooks.json`, `hooks/*.sh`,
 
 ## Guardrails
 
+- **Hookless-first: a hook must be a gate or a bounded adapter, never a noise-injector.** Under AgentOps 3.0 ([docs/3.0.md](../../docs/3.0.md)), hooks are a demoted adapter, not the architecture. A hook may *block on a real violation* (gate) or *do a bounded side-effect and stay silent unless it has a real result* (bounded adapter). It must **not** push `additionalContext`/advisory prose into the prompt window on every matching event regardless of relevance — that is the 2.x failure mode the [hook-noise audit](../../docs/architecture/hook-noise-audit.md) deleted 7 hooks for (A/B Δ=0). Context flows through explicit pulled channels (`ao lookup`, factory briefings, `/inject`), not unconditional injection.
 - Do not broaden a matcher to hide a missing case; add a second hook entry.
 - Do not rely on hook output fields that Codex ignores.
 - Do not store session secrets, transcripts, or local runtime state in tracked


### PR DESCRIPTION
## What

Flips the docs/3.0.md **"Hooks audited for noise"** acceptance box from `[ ]` to `[x]`. The 7 noise-injector hooks were **deleted outright** across `soc-e2ju0` S1–S3 (they were value-negative: A/B Δ=0) — not flipped to opt-in. 46 hooks remain, all gates or bounded adapters, none a noise-injector.

## Changes

- **docs/3.0.md** — acceptance box `[ ]` → `[x]`; note now states the 7 noise-injectors were deleted (S1–S3), 46 hooks remain. The "Every AgentOps bead worked or closed" box intentionally left `[ ]`. The doctrine "default install works with zero hooks" line and the S2–S5 follow-on note are untouched (S4 default-install is not done yet).
- **docs/architecture/hook-noise-audit.md** — summary reframed: original 53-hook audit (14 gate / 25 bounded-adapter / 14 noise) → current 46-hook reality (20 gate / 26 bounded-adapter / **0 noise**). The 14 "noise" entries split into 7 true noise-injectors (deleted) + 7 conditional injectors (reclassified as gates). Noise-injector table → all 7 deleted with their stage; gates list 14→20 (`go-vet-post-edit` removed — it was deleted, not a surviving gate); bounded-adapters 25→26; resolution note replaces the pending follow-on.
- **docs/3.0-readiness.md** — hooks box `[ ]` → `[x]`; net 4/6 → 5/6 boxes met; W3 row and remaining-work refreshed.
- **docs/documentation-index.md** — audit one-liner refreshed (no longer implies noise-injectors exist).
- **skills/hooks-authoring/SKILL.md** — added a hookless-first guardrail: hooks are gates/bounded-adapters, never noise-injectors. Codex artifact + manifest source_hash regenerated for this skill only.

## Gates (all green)

- `validate-hooks-doc-parity.sh` — PASS
- `validate-codex-generated-artifacts.sh` — PASS (was failing on the SKILL.md edit; fixed via scoped hash regen)
- `check-codex-parity-drift.sh` — PASS; `audit-codex-parity.sh --skill hooks-authoring` — PASS
- `markdownlint` on all 6 touched md — PASS
- `heal.sh --strict skills/hooks-authoring` — clean
- Deleted-hook grep on docs/3.0.md + docs/HOOKS.md — empty (only historical mentions remain in the audit doc)

Closes-scenario: soc-cul67#hookless-docs
Bounded-context: BC1-Corpus
Evidence: docs/3.0.md