### PR TITLE
fix(evals): clean fixtures referencing deleted hooks (soc-t40ai #eval-fixture-cleanup)

### DIFF
--- a/evals/agentops-core/fixtures/hook-context-value-smoke.sh
+++ b/evals/agentops-core/fixtures/hook-context-value-smoke.sh
@@ -55,16 +55,6 @@ byte_len() {
     printf '%s' "$1" | wc -c | tr -d ' '
 }
 
-assert_empty() {
-    local output="$1"
-    local label="$2"
-    if [[ -z "$output" ]]; then
-        pass "$label stays silent"
-    else
-        fail "$label stays silent"
-    fi
-}
-
 assert_contains() {
     local haystack="$1"
     local needle="$2"
@@ -129,62 +119,6 @@ test_precompact_snapshot() {
     assert_bytes_le "$ctx" 500 "precompact_bytes"
 }
 
-test_context_monitor() {
-    local session bridge output ctx quiet stale
-    session="hook-context-value-$$"
-    bridge="/tmp/claude-ctx-${session}.json"
-    printf '{"remaining_percent":20,"total_tokens":200000,"used_tokens":160000}\n' > "$bridge"
-    output="$(printf '{"tool_name":"Read"}\n' | CLAUDE_SESSION_ID="$session" bash "$HOOKS_DIR/context-monitor.sh" 2>&1 || true)"
-    json_event "$output" "PostToolUse" "context-monitor critical"
-    ctx="$(context_of "$output")"
-    assert_contains "$ctx" "20% remaining" "context-monitor critical"
-    assert_bytes_le "$ctx" 240 "context_monitor_bytes"
-
-    printf '{"remaining_percent":40}\n' > "$bridge"
-    quiet="$(printf '{"tool_name":"Read"}\n' | CLAUDE_SESSION_ID="$session" bash "$HOOKS_DIR/context-monitor.sh" 2>&1 || true)"
-    assert_empty "$quiet" "context-monitor above threshold"
-
-    printf '{"remaining_percent":20}\n' > "$bridge"
-    touch -t 202001010101 "$bridge"
-    stale="$(printf '{"tool_name":"Read"}\n' | CLAUDE_SESSION_ID="$session" bash "$HOOKS_DIR/context-monitor.sh" 2>&1 || true)"
-    assert_empty "$stale" "context-monitor stale bridge"
-    rm -f "$bridge"
-}
-
-test_edit_knowledge_surface() {
-    local repo file output ctx quiet
-    repo="$TMP_ROOT/edit-knowledge"
-    setup_git_repo "$repo"
-    mkdir -p "$repo/.agents/learnings" "$repo/pkg"
-    file="$repo/pkg/service.go"
-    printf 'package pkg\n' > "$file"
-    for i in 1 2 3 4; do
-        cat > "$repo/.agents/learnings/${i}-service.md" <<EOF
-# Service Learning $i
-
-pkg/service.go requires careful validation.
-EOF
-    done
-
-    output="$(cd "$repo" && jq -n --arg file "$file" '{"tool_name":"Edit","tool_input":{"file_path":$file}}' | bash "$HOOKS_DIR/edit-knowledge-surface.sh" 2>&1 || true)"
-    json_event "$output" "PreToolUse" "edit-knowledge-surface"
-    ctx="$(context_of "$output")"
-    assert_contains "$ctx" "Relevant learnings for service.go" "edit-knowledge-surface"
-    assert_contains "$ctx" "Review these before making changes" "edit-knowledge-surface"
-    local learning_count
-    learning_count="$(printf '%s\n' "$ctx" | grep -c '^- [0-9]-service.md:' || true)"
-    record_metric "edit_knowledge_learning_count" "$learning_count"
-    if [[ "$learning_count" -le 3 ]]; then
-        pass "edit-knowledge-surface emits at most three learning titles ($learning_count)"
-    else
-        fail "edit-knowledge-surface emits at most three learning titles ($learning_count)"
-    fi
-    assert_bytes_le "$ctx" 700 "edit_knowledge_bytes"
-
-    quiet="$(cd "$repo" && jq -n '{"tool_name":"Edit","tool_input":{"file_path":"pkg/other.go"}}' | bash "$HOOKS_DIR/edit-knowledge-surface.sh" 2>&1 || true)"
-    assert_empty "$quiet" "edit-knowledge-surface unrelated file"
-}
-
 main() {
     require_tool jq
     require_tool git
@@ -194,8 +128,6 @@ main() {
     trap 'rm -rf "$TMP_ROOT"' EXIT
 
     test_precompact_snapshot
-    test_context_monitor
-    test_edit_knowledge_surface
 
     printf 'hook-context-value metrics:'
     for metric in "${METRICS[@]}"; do

--- a/evals/agentops-core/hook-context-value.json
+++ b/evals/agentops-core/hook-context-value.json
@@ -72,14 +72,6 @@
         },
         {
           "type": "stdout_contains",
-          "value": "standards_go_bytes="
-        },
-        {
-          "type": "stdout_contains",
-          "value": "commit_review_bytes="
-        },
-        {
-          "type": "stdout_contains",
           "value": "precompact_bytes="
         }
       ],

--- a/evals/agentops-core/hook-manifest-runtime-contracts.json
+++ b/evals/agentops-core/hook-manifest-runtime-contracts.json
@@ -42,7 +42,7 @@
       "expectations": [
         {"type": "exit_code", "value": 0},
         {"type": "stdout_contains", "value": "Hook preflight PASSED"},
-        {"type": "stdout_contains", "value": "Registered: 32 of 47"},
+        {"type": "stdout_contains", "value": "Registered: 31 of 46"},
         {"type": "stdout_contains", "value": "Unregistered: 15"},
         {"type": "stdout_contains", "value": "JSON-emitting (WARNING): 0"},
         {"type": "stdout_contains", "value": "context-guard.sh"},
@@ -65,11 +65,11 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "1..104"},
-        {"type": "stdout_contains", "value": "ok 19 cross-check: all hooks.json registered hooks that emit JSON use hookSpecificOutput wrapper"},
-        {"type": "stdout_contains", "value": "ok 34 dangerous-git-guard: force push blocked with exit 2"},
-        {"type": "stdout_contains", "value": "ok 48 codex-parity-warn: shared skill edit emits parity warning"},
-        {"type": "stdout_contains", "value": "ok 104 task-validation-gate: empty stdin exits gracefully"}
+        {"type": "stdout_contains", "value": "1..75"},
+        {"type": "stdout_contains", "value": "ok 8 cross-check: all hooks.json registered hooks that emit JSON use hookSpecificOutput wrapper"},
+        {"type": "stdout_contains", "value": "ok 19 dangerous-git-guard: force push blocked with exit 2"},
+        {"type": "stdout_contains", "value": "ok 33 codex-parity-warn: shared skill edit emits parity warning"},
+        {"type": "stdout_contains", "value": "ok 75 task-validation-gate: empty stdin exits gracefully"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "safety"],
       "critical": true
@@ -96,10 +96,7 @@
         {"type": "artifact_contains", "target": "../../hooks/hooks.json", "value": "git-worker-guard.sh"},
         {"type": "artifact_contains", "target": "../../hooks/hooks.json", "value": "lead-only-worker-git-guard.sh"},
         {"type": "artifact_contains", "target": "../../hooks/hooks.json", "value": "holdout-isolation-gate.sh"},
-        {"type": "artifact_contains", "target": "../../hooks/hooks.json", "value": "write-time-quality.sh"},
         {"type": "artifact_contains", "target": "../../hooks/hooks.json", "value": "go-complexity-precommit.sh"},
-        {"type": "artifact_contains", "target": "../../hooks/hooks.json", "value": "go-vet-post-edit.sh"},
-        {"type": "artifact_contains", "target": "../../hooks/hooks.json", "value": "research-loop-detector.sh"},
         {"type": "artifact_contains", "target": "../../hooks/hooks.json", "value": "task-validation-gate.sh"}
       ],
       "dimensions": ["process_adherence", "artifact_quality", "safety"],
@@ -114,7 +111,7 @@
       "timeout_seconds": 60,
       "inputs": {
         "cwd": "../..",
-        "shell": "jq -e '[.. | .command? // empty] as $cmds | ($cmds | length == 44) and ($cmds | map(capture(\"(?<script>[^/ ]+\\\\.sh)$\").script) | unique | length == 37) and (($cmds | map(select(test(\"ao-inject\\\\.sh\"))) | length) == 0)' hooks/hooks.json >/dev/null && echo hook-manifest-counts-ok"
+        "shell": "jq -e '[.. | .command? // empty] as $cmds | ($cmds | length == 35) and ($cmds | map(capture(\"(?<script>[^/ ]+\\\\.sh)$\").script) | unique | length == 30) and (($cmds | map(select(test(\"ao-inject\\\\.sh\"))) | length) == 0)' hooks/hooks.json >/dev/null && echo hook-manifest-counts-ok"
       },
       "expectations": [
         {"type": "exit_code", "value": 0},


### PR DESCRIPTION
## Summary

S1-S3 deleted 7 noise-injector hooks (research-loop-detector, context-monitor, write-time-quality, edit-knowledge-surface, go-vet-post-edit, standards-injector, commit-review-gate) but left eval/test fixtures asserting on them. This cleans the three drifted fixtures to current reality.

## Changes

- **`evals/agentops-core/fixtures/hook-context-value-smoke.sh`**: removed `test_context_monitor` and `test_edit_knowledge_surface` (both hooks deleted) plus the now-dead `assert_empty` helper. Keeps the valid `test_precompact_snapshot`. Exit 1 -> exit 0.
- **`evals/agentops-core/hook-context-value.json`**: dropped stale `standards_go_bytes=` / `commit_review_bytes=` stdout expectations (those test functions were removed in S2/S3 deletion PRs); keeps `precompact_bytes=`.
- **`evals/agentops-core/hook-manifest-runtime-contracts.json`**: dropped the three deleted-hook `artifact_contains` (write-time-quality, go-vet-post-edit, research-loop-detector); refreshed counts to current `hooks.json` reality:
  - preflight `Registered: 32 of 47` -> `31 of 46`
  - manifest command counts `length==44 / unique==37` -> `35 / 30`
  - bats plan `1..104` -> `1..75`, renumbered ok-lines `19/34/48/104` -> `8/19/33/75`

## Verification

- `hook-context-value-smoke.sh`: exit 1 -> **exit 0**
- `hook-context-value` eval suite: **pass** (aggregate 1.0)
- `hook-manifest-runtime-contracts`: 5/6 cases pass (was failing 4 deleted-hook cases)
- CI gate `agentops-eval-baseline-audit`: `stale_suite_hashes=0` -> **passes**
- All edited JSON validates

## Out of scope (noted)

The `embedded-hook-inventory-parity` case still fails because `cli/embedded/hooks/` still contains the 5 deleted hook scripts (needs `cd cli && make sync-hooks`). This is pre-existing drift, fails identically on main, and lands in `cli/` which is owned by another worker. Not touched here.

Closes-scenario: soc-t40ai#eval-fixture-cleanup
Bounded-context: BC4-Evidence
Evidence: evals/agentops-core/hook-context-value-smoke.sh