### PR TITLE
feat(skills): add rubric-scoring Pass 3 to skill-auditor (soc-ads5v #rubric-pass)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1075,8 +1075,8 @@
     {
       "name": "skill-auditor",
       "source_skill": "skills/skill-auditor",
-      "source_hash": "1cded02f750fa58595d8c109c17553067223c0c488fc56a19436df582abdec84",
-      "generated_hash": "d4b6b96a99ee41c85d3997df8572d081cd3d42d10664ef66a8700bb2090660db"
+      "source_hash": "4544b80346783cfc41fa9c070aa5712ece619cdd8f341088ffe3ee8807440b26",
+      "generated_hash": "b7edf1d077b4b7f13d04901facc416f18a1d07e08b830080be4212d7dbc19573"
     },
     {
       "name": "skill-builder",

--- a/skills-codex/skill-auditor/.agentops-generated.json
+++ b/skills-codex/skill-auditor/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/skill-auditor",
   "layout": "modular",
-  "source_hash": "1cded02f750fa58595d8c109c17553067223c0c488fc56a19436df582abdec84",
-  "generated_hash": "d4b6b96a99ee41c85d3997df8572d081cd3d42d10664ef66a8700bb2090660db"
+  "source_hash": "4544b80346783cfc41fa9c070aa5712ece619cdd8f341088ffe3ee8807440b26",
+  "generated_hash": "b7edf1d077b4b7f13d04901facc416f18a1d07e08b830080be4212d7dbc19573"
 }

--- a/skills-codex/skill-auditor/SKILL.md
+++ b/skills-codex/skill-auditor/SKILL.md
@@ -2,13 +2,15 @@
 name: skill-auditor
 description: 'Audit a SKILL.md (15 checks).'
 ---
-# $skill-auditor — Two-pass skill quality audit
+# $skill-auditor — Three-pass skill quality audit
 
 Validates a skill's SKILL.md against the unified AgentOps template. Pass 1
 wraps `heal-skill` for structural hygiene; Pass 2 adds 8 content-discipline
-checks not covered by heal. The report also includes an advisory Context
-Density Rule block for intent, boundary, evidence, decision, constraint, and
-next action coverage.
+checks not covered by heal; Pass 3 folds the 10-category Skill Quality Rubric
+(`docs/reference/skill-quality-rubric.md`) into the report as a deterministic
+0-30 productization score (advisory). The report also includes an advisory
+Context Density Rule block for intent, boundary, evidence, decision,
+constraint, and next action coverage.
 
 ## ⚠️ Critical Constraints
 
@@ -57,17 +59,21 @@ The JSON report includes a separate `density` block with six report-only fields:
 Read [references/context-density-checks.md](references/context-density-checks.md)
 for detection rules, limits, and false-positive handling.
 
-### Productization score overlay
+### Pass 3 — rubric scoring (10 categories, advisory)
 
-For AgentOps skill-factory work, run the clean-room score overlay after the
-two-pass audit:
+`audit.sh` runs `scripts/score_agentops_skill.py --audit-block` and folds the
+result into `audit-report.json` under a `rubric` key. The 10 categories come
+verbatim from `docs/reference/skill-quality-rubric.md`: `trigger_quality`,
+`kernel_clarity`, `progressive_disclosure`, `helper_scripts`, `validation`,
+`self_test`, `assets_templates`, `subagents_roles`, `safety_boundaries`,
+`packaging`. Each scores 0-3 with a reason; total 0-30, rating C/B/A/S. The
+score is **advisory** — it never changes the PASS/WARN/FAIL verdict.
+
+Standalone markdown for picking the smallest productization patch:
 
 ```bash
 python3 skills-codex/skill-auditor/scripts/score_agentops_skill.py skills/<name> --markdown
 ```
-
-The score is advisory. Use it to pick the smallest productization patch, then
-re-run this auditor and `$heal-skill`.
 
 ## Execution Steps
 
@@ -85,7 +91,15 @@ For each `check_*` function in `scripts/audit.sh`, run against `<target>/SKILL.m
 
 **Checkpoint:** Pass 2 must run independently of Pass 1 (no shared state); a heal.sh failure does NOT short-circuit Pass 2.
 
-### Step 3: Aggregate verdict
+### Step 3: Pass 3 (rubric scoring)
+
+`audit.sh` runs `python3 scripts/score_agentops_skill.py <target> --audit-block`
+and embeds the result under the report's `rubric` key (10 categories, 0-3 each,
+0-30 total, C/B/A/S rating). Emitted as `null` if `python3`/scorer is missing.
+
+**Checkpoint:** Pass 3 is advisory — its score is computed but NOT counted in the verdict.
+
+### Step 4: Aggregate verdict
 
 ```
 fails > 0  → FAIL
@@ -93,9 +107,9 @@ warns > 0  → WARN
 otherwise  → PASS
 ```
 
-Density coverage is computed before emission but is not counted in the verdict.
+Density coverage and the Pass-3 rubric are computed before emission but are NOT counted in the verdict.
 
-### Step 4: Emit report
+### Step 5: Emit report
 
 JSON conforming to `schemas/audit-report.json` to stdout (or to file with `--json <path>`); markdown summary to stderr.
 

--- a/skills-codex/skill-auditor/scripts/audit.sh
+++ b/skills-codex/skill-auditor/scripts/audit.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 HEAL_SH="$REPO_ROOT/skills/heal-skill/scripts/heal.sh"
+SCORE_PY="$SCRIPT_DIR/score_agentops_skill.py"
 
 STRICT=0
 JSON_OUT=""
@@ -254,6 +255,27 @@ else
   DENSITY_STATUS="warn"
 fi
 
+# --- Pass 3: rubric scoring (advisory) -----------------------------------
+# Folds the 10-category Skill Quality Rubric (docs/reference/skill-quality-rubric.md)
+# into the report via score_agentops_skill.py --audit-block. Each category gets a
+# deterministic 0-3 score plus an explainable reason; total is 0-30 with a C/B/A/S
+# rating band. Advisory-only: it never changes the PASS/WARN/FAIL verdict — the
+# rubric measures market-facing maturity, not template conformance (which Pass 1+2
+# already gate). Reason: a low rubric score on a structurally-clean skill is a
+# productization backlog signal, not a ship blocker.
+RUBRIC_JSON="null"
+RUBRIC_SUMMARY=""
+RUBRIC_SCORE="n/a"
+RUBRIC_RATING="?"
+if [[ -f "$SCORE_PY" ]] && command -v python3 >/dev/null 2>&1; then
+  if rubric_out="$(python3 "$SCORE_PY" "$TARGET" --audit-block 2>/dev/null)"; then
+    RUBRIC_JSON="$rubric_out"
+    RUBRIC_SCORE="$(printf '%s' "$rubric_out" | awk -F': ' '/"total_score"/{gsub(/[, ]/,"",$2); print $2; exit}')"
+    RUBRIC_RATING="$(printf '%s' "$rubric_out" | awk -F'"' '/"rating"/{print $4; exit}')"
+    RUBRIC_SUMMARY=" Rubric: ${RUBRIC_SCORE}/30 (${RUBRIC_RATING}) [advisory]."
+  fi
+fi
+
 # --- Aggregate verdict ---------------------------------------------------
 fails=0
 warns=0
@@ -304,8 +326,9 @@ emit_json() {
   printf '\n    ],\n'
   printf '    "summary": "%d/6 density signals present; advisory-only and not execution-packet enforcement."\n' "$density_present_count"
   printf '  },\n'
-  printf '  "summary": "Pass1: %d findings (%d autofixable). Pass2: %d fails, %d warns. Verdict: %s."\n' \
-    "$(echo "$PASS1_FINDINGS_JSON" | grep -c '"code":' | head -1)" "$PASS1_AUTOFIXABLE" "$fails" "$warns" "$VERDICT"
+  printf '  "rubric": %s,\n' "$RUBRIC_JSON"
+  printf '  "summary": "Pass1: %d findings (%d autofixable). Pass2: %d fails, %d warns.%s Verdict: %s."\n' \
+    "$(echo "$PASS1_FINDINGS_JSON" | grep -c '"code":' | head -1)" "$PASS1_AUTOFIXABLE" "$fails" "$warns" "$RUBRIC_SUMMARY" "$VERDICT"
   printf '}\n'
 }
 
@@ -322,6 +345,7 @@ fi
     printf "  [%-4s] %s\n" "${CHECK_STATUS[$id]}" "$id"
   done
   echo "Density advisory: $density_present_count/6 fields present ($DENSITY_STATUS)"
+  echo "Pass 3 rubric (advisory): ${RUBRIC_SCORE}/30 (${RUBRIC_RATING})"
   echo "VERDICT: $VERDICT"
 } >&2
 

--- a/skills-codex/skill-auditor/scripts/score_agentops_skill.py
+++ b/skills-codex/skill-auditor/scripts/score_agentops_skill.py
@@ -239,6 +239,10 @@ def score_skill(path: Path) -> dict:
         "rating": rating,
         "scores": scores,
         "notes": notes,
+        "categories": [
+            {"category": category, "score": scores[category], "reason": notes[category]}
+            for category in CATEGORIES
+        ],
         "gaps": gaps,
         "metrics": {
             "total_files": metrics["total_files"],
@@ -251,6 +255,22 @@ def score_skill(path: Path) -> dict:
             "symlinks": metrics["symlinks"],
             "executable_scripts": metrics["executable_scripts"],
         },
+    }
+
+
+def audit_block(report: dict) -> dict:
+    """Compact rubric object for embedding in skill-auditor's audit-report.json (Pass 3).
+
+    Mirrors the rubric schema block: per-category 0-3 score plus an explainable
+    reason, the 0-30 total, max, and the C/B/A/S rating band. Deterministic —
+    derived only from the skill directory contents.
+    """
+    return {
+        "total_score": report["total_score"],
+        "max_score": report["max_score"],
+        "rating": report["rating"],
+        "advisory": True,
+        "categories": report["categories"],
     }
 
 
@@ -282,12 +302,20 @@ def markdown_report(report: dict) -> str:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("skill_path")
-    parser.add_argument("--markdown", action="store_true")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--markdown", action="store_true", help="Emit a markdown report.")
+    group.add_argument(
+        "--audit-block",
+        action="store_true",
+        help="Emit the compact rubric block consumed by skill-auditor Pass 3.",
+    )
     args = parser.parse_args()
 
     report = score_skill(Path(args.skill_path).expanduser().resolve())
     if args.markdown:
         print(markdown_report(report))
+    elif args.audit_block:
+        print(json.dumps(audit_block(report), indent=2))
     else:
         print(json.dumps(report, indent=2))
     return 0

--- a/skills-codex/skill-auditor/scripts/validate.sh
+++ b/skills-codex/skill-auditor/scripts/validate.sh
@@ -9,7 +9,7 @@ REPO_ROOT="$(cd "$SKILL_DIR/../.." && pwd)"
 bash "$REPO_ROOT/skills/heal-skill/scripts/heal.sh" --check "$SKILL_DIR"
 
 # Required artifacts
-for f in SKILL.md scripts/audit.sh references/skill-template.md references/audit-checks.md references/context-density-checks.md; do
+for f in SKILL.md scripts/audit.sh references/skill-template.md references/audit-checks.md references/context-density-checks.md schemas/audit-report.json; do
   [[ -f "$SKILL_DIR/$f" ]] || { echo "validate.sh: missing $SKILL_DIR/$f" >&2; exit 1; }
 done
 
@@ -46,6 +46,21 @@ if grep -q "check_description_multiline" "$SKILL_DIR/scripts/audit.sh"; then
   echo "validate.sh: audit.sh contains stale 'check_description_multiline' (must be 'check_description_has_triggers' per pre-mortem F1)" >&2
   exit 1
 fi
+
+# Pass 3: audit.sh must fold the rubric block in, and the scorer must support
+# --audit-block. The rubric must be advisory (not in the Pass-2 verdict loop).
+grep -q 'score_agentops_skill.py' "$SKILL_DIR/scripts/audit.sh" || {
+  echo "validate.sh: scripts/audit.sh missing Pass-3 rubric invocation (score_agentops_skill.py)" >&2
+  exit 1
+}
+grep -q '"rubric": %s' "$SKILL_DIR/scripts/audit.sh" || {
+  echo "validate.sh: scripts/audit.sh does not emit a rubric block in audit-report.json" >&2
+  exit 1
+}
+grep -q -- '--audit-block' "$SKILL_DIR/scripts/score_agentops_skill.py" || {
+  echo "validate.sh: scripts/score_agentops_skill.py missing --audit-block mode for Pass 3" >&2
+  exit 1
+}
 
 # Make scripts executable
 for s in scripts/audit.sh scripts/validate.sh; do

--- a/skills/skill-auditor/SKILL.md
+++ b/skills/skill-auditor/SKILL.md
@@ -30,13 +30,15 @@ metadata:
 output_contract: skills/skill-auditor/schemas/audit-report.json
 ---
 
-# /skill-auditor — Two-pass skill quality audit
+# /skill-auditor — Three-pass skill quality audit
 
 Validates a skill's SKILL.md against the unified AgentOps template. Pass 1
 wraps `heal-skill` for structural hygiene; Pass 2 adds 8 content-discipline
-checks not covered by heal. The report also includes an advisory Context
-Density Rule block for intent, boundary, evidence, decision, constraint, and
-next action coverage.
+checks not covered by heal; Pass 3 folds the 10-category Skill Quality Rubric
+(`docs/reference/skill-quality-rubric.md`) into the report as a deterministic
+0-30 productization score (advisory). The report also includes an advisory
+Context Density Rule block for intent, boundary, evidence, decision,
+constraint, and next action coverage.
 
 ## ⚠️ Critical Constraints
 
@@ -48,6 +50,16 @@ next action coverage.
   the PASS/WARN/FAIL verdict and does not satisfy packet-boundary enforcement
   in `soc-2c1p.1`. **Why:** the hard Context Density Rule belongs at execution
   packet boundaries; this skill only helps reviewers find low-signal prose.
+- **Pass 3 rubric is advisory-only.** The 0-30 rubric score never changes the
+  PASS/WARN/FAIL verdict. **Why:** Pass 1+2 gate *template conformance* (does
+  this ship); the rubric measures *market-facing maturity* (is this
+  product-grade) — a low rubric score on a structurally-clean skill is a
+  productization backlog signal, not a ship blocker (soc-ads5v).
+- **Pass 3 scoring is deterministic and rubric-sourced.** The 10 categories
+  come verbatim from `docs/reference/skill-quality-rubric.md`; each gets a 0-3
+  score plus an explainable reason derived only from the skill directory
+  contents. **Why:** an explainable, reproducible score is auditable; an
+  LLM-graded one is not.
 
 ## What It Detects
 
@@ -85,18 +97,30 @@ The JSON report includes a separate `density` block with six report-only fields:
 Read [references/context-density-checks.md](references/context-density-checks.md)
 for detection rules, limits, and false-positive handling.
 
-### Productization score overlay
+### Pass 3 — rubric scoring (10 categories, advisory)
 
-For AgentOps skill-factory work, run the clean-room score overlay after the
-two-pass audit:
+`audit.sh` runs `scripts/score_agentops_skill.py --audit-block` and folds the
+result into `audit-report.json` under a `rubric` key. The 10 categories come
+verbatim from [`docs/reference/skill-quality-rubric.md`](../../docs/reference/skill-quality-rubric.md)
+(read it for the per-score `0/1/2/3` definitions): `trigger_quality`,
+`kernel_clarity`, `progressive_disclosure`, `helper_scripts`, `validation`,
+`self_test`, `assets_templates`, `subagents_roles`, `safety_boundaries`,
+`packaging`.
+
+Each category scores 0-3 (`0` missing/unsafe → `3` product-grade and
+mechanically validated) with an explainable `reason`. Total 0-30 maps to a
+rating band: `C` (0-10), `B` (11-20), `A` (21-26), `S` (27-30). The score is
+**advisory** — it never changes the PASS/WARN/FAIL verdict.
+
+Standalone (markdown) for picking the smallest productization patch:
 
 ```bash
 python3 skills/skill-auditor/scripts/score_agentops_skill.py skills/<name> --markdown
 ```
 
-The score is advisory. Use it to pick the smallest productization patch
-(`SELF-TEST.md`, linked references, helper scripts, assets, subagents, safety
-boundaries, or validation), then re-run this auditor and `heal-skill`.
+Use it to pick the smallest patch (`SELF-TEST.md`, linked references, helper
+scripts, assets, subagents, safety boundaries, or validation), then re-run this
+auditor and `heal-skill`.
 
 ## Execution Steps
 
@@ -114,7 +138,20 @@ For each `check_*` function in `scripts/audit.sh`, run against `<target>/SKILL.m
 
 **Checkpoint:** Pass 2 must run independently of Pass 1 (no shared state); a heal.sh failure does NOT short-circuit Pass 2.
 
-### Step 3: Aggregate verdict
+### Step 3: Pass 3 (rubric scoring)
+
+```bash
+python3 scripts/score_agentops_skill.py <target> --audit-block
+```
+
+`audit.sh` calls this and embeds the result under the report's `rubric` key.
+Each of the 10 rubric categories gets a 0-3 score + reason; total 0-30, rating
+band C/B/A/S. If `python3` or the scorer is unavailable, `rubric` is emitted as
+`null` (fail-open) and the JSON stays valid.
+
+**Checkpoint:** Pass 3 is advisory — its score is computed but NOT counted in the verdict.
+
+### Step 4: Aggregate verdict
 
 ```
 fails > 0  → FAIL
@@ -122,11 +159,11 @@ warns > 0  → WARN
 otherwise  → PASS
 ```
 
-Density coverage is computed before emission but is not counted in the verdict.
+Density coverage and the Pass-3 rubric are computed before emission but are NOT counted in the verdict.
 
-### Step 4: Emit report
+### Step 5: Emit report
 
-JSON conforming to `schemas/audit-report.json` to stdout (or to file with `--json <path>`); markdown summary to stderr.
+JSON conforming to `schemas/audit-report.json` to stdout (or to file with `--json <path>`); markdown summary (including the Pass-3 rubric line) to stderr.
 
 ## Output Specification
 
@@ -137,6 +174,11 @@ JSON conforming to `schemas/audit-report.json` to stdout (or to file with `--jso
 **Density advisory:** JSON includes `density.status`, `density.fields[]`, and
 `density.summary`. Treat missing fields as review prompts, not gates.
 
+**Rubric (Pass 3):** JSON includes `rubric.total_score`, `rubric.max_score`,
+`rubric.rating`, `rubric.advisory` (always `true`), and `rubric.categories[]`
+(10 entries, each `{category, score, reason}`). Emitted as `null` if the scorer
+is unavailable. Treat the score as a productization backlog signal, not a gate.
+
 ## Quality Rubric
 
 - [ ] Auditor never modifies target SKILL.md or any other file
@@ -145,6 +187,7 @@ JSON conforming to `schemas/audit-report.json` to stdout (or to file with `--jso
 - [ ] `description-has-triggers` accepts all three valid forms (verified by running auditor against AgentOps' existing single-line-description skills like `forge`, `heal-skill`, `council`)
 - [ ] Aggregate verdict applies max-severity rule (no silent downgrade)
 - [ ] Density advisory reports all six fields without changing the aggregate verdict
+- [ ] Pass 3 emits all 10 rubric categories (0-3 + reason) under `rubric` without changing the aggregate verdict
 - [ ] Report JSON validates against `schemas/audit-report.json`
 
 ## Examples

--- a/skills/skill-auditor/schemas/audit-report.json
+++ b/skills/skill-auditor/schemas/audit-report.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Skill Audit Report",
-  "description": "Output contract for skill-auditor. Two passes: Pass 1 wraps heal-skill structural checks; Pass 2 adds 8 NEW content-discipline checks beyond heal-skill.",
+  "description": "Output contract for skill-auditor. Three passes: Pass 1 wraps heal-skill structural checks; Pass 2 adds 8 NEW content-discipline checks beyond heal-skill; Pass 3 folds the 10-category Skill Quality Rubric (docs/reference/skill-quality-rubric.md) in as an advisory 0-30 productization score.",
   "type": "object",
   "required": ["target", "verdict", "pass1", "pass2"],
   "properties": {
@@ -124,6 +124,77 @@
         "summary": {"type": "string"}
       },
       "additionalProperties": false
+    },
+    "rubric": {
+      "description": "Advisory-only Pass-3 Skill Quality Rubric score (docs/reference/skill-quality-rubric.md). Folded in from score_agentops_skill.py --audit-block. Never affects the aggregate verdict. Emitted as null when python3 or the scorer is unavailable (fail-open).",
+      "oneOf": [
+        {"type": "null"},
+        {
+          "type": "object",
+          "required": ["total_score", "max_score", "rating", "advisory", "categories"],
+          "properties": {
+            "total_score": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 30,
+              "description": "Sum of the 10 category scores (0-30)."
+            },
+            "max_score": {
+              "type": "integer",
+              "const": 30
+            },
+            "rating": {
+              "type": "string",
+              "enum": ["C", "B", "A", "S"],
+              "description": "Rating band: C (0-10), B (11-20), A (21-26), S (27-30)."
+            },
+            "advisory": {
+              "type": "boolean",
+              "const": true,
+              "description": "Always true. The rubric score is report-only and never gates the verdict."
+            },
+            "categories": {
+              "type": "array",
+              "minItems": 10,
+              "maxItems": 10,
+              "description": "The 10 rubric categories, each scored 0-3 with an explainable reason. Category ids come verbatim from the rubric doc.",
+              "items": {
+                "type": "object",
+                "required": ["category", "score", "reason"],
+                "properties": {
+                  "category": {
+                    "type": "string",
+                    "enum": [
+                      "trigger_quality",
+                      "kernel_clarity",
+                      "progressive_disclosure",
+                      "helper_scripts",
+                      "validation",
+                      "self_test",
+                      "assets_templates",
+                      "subagents_roles",
+                      "safety_boundaries",
+                      "packaging"
+                    ]
+                  },
+                  "score": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                    "description": "0 missing/unsafe, 1 present-but-weak, 2 solid, 3 product-grade and mechanically validated."
+                  },
+                  "reason": {
+                    "type": "string",
+                    "description": "Deterministic explanation derived from the skill directory contents."
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "summary": {
       "type": "string",

--- a/skills/skill-auditor/scripts/audit.sh
+++ b/skills/skill-auditor/scripts/audit.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 HEAL_SH="$REPO_ROOT/skills/heal-skill/scripts/heal.sh"
+SCORE_PY="$SCRIPT_DIR/score_agentops_skill.py"
 
 STRICT=0
 JSON_OUT=""
@@ -254,6 +255,27 @@ else
   DENSITY_STATUS="warn"
 fi
 
+# --- Pass 3: rubric scoring (advisory) -----------------------------------
+# Folds the 10-category Skill Quality Rubric (docs/reference/skill-quality-rubric.md)
+# into the report via score_agentops_skill.py --audit-block. Each category gets a
+# deterministic 0-3 score plus an explainable reason; total is 0-30 with a C/B/A/S
+# rating band. Advisory-only: it never changes the PASS/WARN/FAIL verdict — the
+# rubric measures market-facing maturity, not template conformance (which Pass 1+2
+# already gate). Reason: a low rubric score on a structurally-clean skill is a
+# productization backlog signal, not a ship blocker.
+RUBRIC_JSON="null"
+RUBRIC_SUMMARY=""
+RUBRIC_SCORE="n/a"
+RUBRIC_RATING="?"
+if [[ -f "$SCORE_PY" ]] && command -v python3 >/dev/null 2>&1; then
+  if rubric_out="$(python3 "$SCORE_PY" "$TARGET" --audit-block 2>/dev/null)"; then
+    RUBRIC_JSON="$rubric_out"
+    RUBRIC_SCORE="$(printf '%s' "$rubric_out" | awk -F': ' '/"total_score"/{gsub(/[, ]/,"",$2); print $2; exit}')"
+    RUBRIC_RATING="$(printf '%s' "$rubric_out" | awk -F'"' '/"rating"/{print $4; exit}')"
+    RUBRIC_SUMMARY=" Rubric: ${RUBRIC_SCORE}/30 (${RUBRIC_RATING}) [advisory]."
+  fi
+fi
+
 # --- Aggregate verdict ---------------------------------------------------
 fails=0
 warns=0
@@ -304,8 +326,9 @@ emit_json() {
   printf '\n    ],\n'
   printf '    "summary": "%d/6 density signals present; advisory-only and not execution-packet enforcement."\n' "$density_present_count"
   printf '  },\n'
-  printf '  "summary": "Pass1: %d findings (%d autofixable). Pass2: %d fails, %d warns. Verdict: %s."\n' \
-    "$(echo "$PASS1_FINDINGS_JSON" | grep -c '"code":' | head -1)" "$PASS1_AUTOFIXABLE" "$fails" "$warns" "$VERDICT"
+  printf '  "rubric": %s,\n' "$RUBRIC_JSON"
+  printf '  "summary": "Pass1: %d findings (%d autofixable). Pass2: %d fails, %d warns.%s Verdict: %s."\n' \
+    "$(echo "$PASS1_FINDINGS_JSON" | grep -c '"code":' | head -1)" "$PASS1_AUTOFIXABLE" "$fails" "$warns" "$RUBRIC_SUMMARY" "$VERDICT"
   printf '}\n'
 }
 
@@ -322,6 +345,7 @@ fi
     printf "  [%-4s] %s\n" "${CHECK_STATUS[$id]}" "$id"
   done
   echo "Density advisory: $density_present_count/6 fields present ($DENSITY_STATUS)"
+  echo "Pass 3 rubric (advisory): ${RUBRIC_SCORE}/30 (${RUBRIC_RATING})"
   echo "VERDICT: $VERDICT"
 } >&2
 

--- a/skills/skill-auditor/scripts/score_agentops_skill.py
+++ b/skills/skill-auditor/scripts/score_agentops_skill.py
@@ -239,6 +239,10 @@ def score_skill(path: Path) -> dict:
         "rating": rating,
         "scores": scores,
         "notes": notes,
+        "categories": [
+            {"category": category, "score": scores[category], "reason": notes[category]}
+            for category in CATEGORIES
+        ],
         "gaps": gaps,
         "metrics": {
             "total_files": metrics["total_files"],
@@ -251,6 +255,22 @@ def score_skill(path: Path) -> dict:
             "symlinks": metrics["symlinks"],
             "executable_scripts": metrics["executable_scripts"],
         },
+    }
+
+
+def audit_block(report: dict) -> dict:
+    """Compact rubric object for embedding in skill-auditor's audit-report.json (Pass 3).
+
+    Mirrors the rubric schema block: per-category 0-3 score plus an explainable
+    reason, the 0-30 total, max, and the C/B/A/S rating band. Deterministic —
+    derived only from the skill directory contents.
+    """
+    return {
+        "total_score": report["total_score"],
+        "max_score": report["max_score"],
+        "rating": report["rating"],
+        "advisory": True,
+        "categories": report["categories"],
     }
 
 
@@ -282,12 +302,20 @@ def markdown_report(report: dict) -> str:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("skill_path")
-    parser.add_argument("--markdown", action="store_true")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--markdown", action="store_true", help="Emit a markdown report.")
+    group.add_argument(
+        "--audit-block",
+        action="store_true",
+        help="Emit the compact rubric block consumed by skill-auditor Pass 3.",
+    )
     args = parser.parse_args()
 
     report = score_skill(Path(args.skill_path).expanduser().resolve())
     if args.markdown:
         print(markdown_report(report))
+    elif args.audit_block:
+        print(json.dumps(audit_block(report), indent=2))
     else:
         print(json.dumps(report, indent=2))
     return 0

--- a/skills/skill-auditor/scripts/validate.sh
+++ b/skills/skill-auditor/scripts/validate.sh
@@ -47,6 +47,21 @@ if grep -q "check_description_multiline" "$SKILL_DIR/scripts/audit.sh"; then
   exit 1
 fi
 
+# Pass 3: audit.sh must fold the rubric block in, and the scorer must support
+# --audit-block. The rubric must be advisory (not in the Pass-2 verdict loop).
+grep -q 'score_agentops_skill.py' "$SKILL_DIR/scripts/audit.sh" || {
+  echo "validate.sh: scripts/audit.sh missing Pass-3 rubric invocation (score_agentops_skill.py)" >&2
+  exit 1
+}
+grep -q '"rubric": %s' "$SKILL_DIR/scripts/audit.sh" || {
+  echo "validate.sh: scripts/audit.sh does not emit a rubric block in audit-report.json" >&2
+  exit 1
+}
+grep -q -- '--audit-block' "$SKILL_DIR/scripts/score_agentops_skill.py" || {
+  echo "validate.sh: scripts/score_agentops_skill.py missing --audit-block mode for Pass 3" >&2
+  exit 1
+}
+
 # Make scripts executable
 for s in scripts/audit.sh scripts/validate.sh; do
   [[ -x "$SKILL_DIR/$s" ]] || chmod +x "$SKILL_DIR/$s"

--- a/tests/scripts/skill-auditor-rubric-pass.bats
+++ b/tests/scripts/skill-auditor-rubric-pass.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+
+# Regression test for skill-auditor Pass 3 (rubric scoring) — soc-ads5v.
+# Pass 3 folds the 10-category Skill Quality Rubric
+# (docs/reference/skill-quality-rubric.md) into audit-report.json via
+# score_agentops_skill.py --audit-block. The score is advisory: it must NOT
+# change the PASS/WARN/FAIL verdict. Scoring must be deterministic + explainable
+# (each category gets a 0-3 score and a reason).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    AUDIT="$REPO_ROOT/skills/skill-auditor/scripts/audit.sh"
+    SCORE="$REPO_ROOT/skills/skill-auditor/scripts/score_agentops_skill.py"
+
+    # The 10 rubric categories, verbatim from docs/reference/skill-quality-rubric.md.
+    EXPECTED_CATEGORIES=(
+        trigger_quality kernel_clarity progressive_disclosure helper_scripts
+        validation self_test assets_templates subagents_roles safety_boundaries
+        packaging
+    )
+
+    TMP_DIR="$(mktemp -d)"
+    FIXTURE="$TMP_DIR/sample-skill"
+    mkdir -p "$FIXTURE"
+    cat > "$FIXTURE/SKILL.md" <<'EOF'
+---
+name: sample-skill
+description: 'Do a thing. Use when you need to validate a sample.'
+---
+# /sample-skill — sample
+
+## ⚠️ Critical Constraints
+
+- **Never** mutate the target. **Why:** read-only contract.
+
+## Output Specification
+
+**Format:** JSON written to a file. **Filename:** result.json
+EOF
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "scorer exposes --audit-block mode for Pass 3" {
+    run python3 "$SCORE" "$FIXTURE" --audit-block
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"total_score"'* ]]
+    [[ "$output" == *'"max_score": 30'* ]]
+    [[ "$output" == *'"advisory": true'* ]]
+}
+
+@test "audit.sh folds a rubric block with all 10 categories into the report" {
+    run bash "$AUDIT" "$FIXTURE" --json "$TMP_DIR/report.json"
+    [ "$status" -eq 0 ]
+
+    python3 - "$TMP_DIR/report.json" <<PY
+import json, sys
+report = json.load(open(sys.argv[1]))
+rubric = report["rubric"]
+assert rubric is not None, "rubric must be present"
+assert rubric["max_score"] == 30, rubric["max_score"]
+assert rubric["advisory"] is True
+expected = "${EXPECTED_CATEGORIES[*]}".split()
+got = [c["category"] for c in rubric["categories"]]
+assert got == expected, f"category drift: {got} != {expected}"
+for c in rubric["categories"]:
+    assert 0 <= c["score"] <= 3, c
+    assert c["reason"], f"missing reason for {c['category']}"
+assert 0 <= rubric["total_score"] <= 30
+assert rubric["rating"] in ("C", "B", "A", "S")
+print("rubric block OK")
+PY
+}
+
+@test "rubric scoring is deterministic across runs" {
+    run python3 "$SCORE" "$FIXTURE" --audit-block
+    [ "$status" -eq 0 ]
+    first="$output"
+    run python3 "$SCORE" "$FIXTURE" --audit-block
+    [ "$status" -eq 0 ]
+    [ "$output" = "$first" ]
+}
+
+@test "Pass 3 rubric is advisory and does not change the verdict" {
+    # Fixture has a single-line description without Triggers markers -> Pass 2
+    # description/trigger checks WARN. Verdict should be WARN regardless of the
+    # rubric score.
+    run bash "$AUDIT" "$FIXTURE" --json "$TMP_DIR/report.json"
+    [ "$status" -eq 0 ]
+    verdict="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['verdict'])" "$TMP_DIR/report.json")"
+    [ "$verdict" = "WARN" ]
+
+    # The rubric score for this minimal fixture is low (no scripts/refs/self-test)
+    # but the verdict is driven only by Pass 1+2.
+    rating="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['rubric']['rating'])" "$TMP_DIR/report.json")"
+    [ "$rating" = "C" ]
+}
+
+@test "report stays valid JSON when the rubric block is emitted" {
+    run bash "$AUDIT" "$FIXTURE" --json "$TMP_DIR/report.json"
+    [ "$status" -eq 0 ]
+    run python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$TMP_DIR/report.json"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## What

skill-auditor was a 2-pass auditor (Pass 1 = heal-skill delegation, Pass 2 = 8 content-discipline checks) plus a *separate* productization score overlay that was never folded into the report. The `skill-auditor.feature` spec already claimed "a productization score in audit-report.json" — this PR makes that real by adding **Pass 3: rubric scoring**.

## How

Pass 3 folds the 10-category Skill Quality Rubric (`docs/reference/skill-quality-rubric.md`) into `audit-report.json` (the skill's `output_contract`):

- **`score_agentops_skill.py`** — new `--audit-block` mode emits a compact rubric block; added a `categories[]` projection (10 categories, each `{category, score 0-3, reason}`). Scoring is deterministic, derived only from the skill directory contents.
- **`audit.sh`** — Pass 3 invokes the scorer and embeds the result under a `rubric` key. **Advisory-only** — never changes the PASS/WARN/FAIL verdict (Pass 1+2 gate *template conformance*; the rubric measures *market-facing maturity*). Fail-open: emits `"rubric": null` when python3/scorer is unavailable, JSON stays valid.
- **`schemas/audit-report.json`** — added the `rubric` block (`oneOf` null|object) with bounded scores (0-3 per category, 0-30 total, C/B/A/S rating).
- **`validate.sh`** — self-check that Pass 3 is wired.
- **SKILL.md** (canonical + codex) — documents Pass 3, the 10 categories, advisory semantics. Trimmed to 242 lines (meta-tier 250 cap).
- **`tests/scripts/skill-auditor-rubric-pass.bats`** — 5 tests.

## The 10 categories (verbatim from the rubric doc)

`trigger_quality`, `kernel_clarity`, `progressive_disclosure`, `helper_scripts`, `validation`, `self_test`, `assets_templates`, `subagents_roles`, `safety_boundaries`, `packaging`.

## Gates (local)

- `python3 -m py_compile score_agentops_skill.py` — OK
- `bats tests/scripts/skill-auditor-rubric-pass.bats` — 5/5 pass
- `validate.sh` (skill self-test) — PASS
- `generate-registry.sh --check` — up to date
- `audit-codex-parity.sh --skill skill-auditor` — passed
- `validate-codex-generated-artifacts.sh --scope head` — passed
- `heal.sh --strict skills/skill-auditor` — clean
- `lint-skills.sh` — 80/80 pass
- Pass 3 run against `skills/forge` — rubric 12/30 (B), verdict FAIL (proving advisory independence)

Closes-scenario: soc-ads5v#rubric-pass
Bounded-context: BC1-Corpus
Evidence: skills/skill-auditor/SKILL.md