### PR TITLE
chore(codex): regen drifted codex hashes for plan/research/validation (soc-uz3x2 #regen-codex-hashes)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -889,7 +889,7 @@
     {
       "name": "plan",
       "source_skill": "skills/plan",
-      "source_hash": "59b47c42c32601f5e0d83521f757db62bb91ba97efbbfa4c3e514237b167a941",
+      "source_hash": "188f87ecf362fe6282988dacb176a848acc188dc3f784453389da0c98f5f3300",
       "generated_hash": "98f259c86afd2e462b62f4971af70c028963d1e617b38f856274d9e230c19209"
     },
     {
@@ -1003,7 +1003,7 @@
     {
       "name": "research",
       "source_skill": "skills/research",
-      "source_hash": "f9bb3b3bf8455c2340093b4aab1bb9a4ca93b63a2a2f92a18baa50d256c5e3a6",
+      "source_hash": "c420cf9a59a7516458c32eade9d412fc51082138a31fc6c6006d866cee11425a",
       "generated_hash": "0cefcd8d49ff88736cf177b61a5b43b6d866389fbd2cf4afd3bd36335647160e"
     },
     {
@@ -1147,7 +1147,7 @@
     {
       "name": "validation",
       "source_skill": "skills/validation",
-      "source_hash": "a34f1de21ab46b01be6fce975694a0f9aecdd2accd488142f6c8ae82aafb558a",
+      "source_hash": "0a9113d84fefae41f36313cc3e791429c8ba78f72470abd7781af3efa46795e1",
       "generated_hash": "353b7a5dcc7e4720f355dbe37e63259482812f10605a9189c8a5e6eabcf6e851"
     },
     {

--- a/skills-codex/plan/.agentops-generated.json
+++ b/skills-codex/plan/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/plan",
   "layout": "modular",
-  "source_hash": "59b47c42c32601f5e0d83521f757db62bb91ba97efbbfa4c3e514237b167a941",
+  "source_hash": "188f87ecf362fe6282988dacb176a848acc188dc3f784453389da0c98f5f3300",
   "generated_hash": "98f259c86afd2e462b62f4971af70c028963d1e617b38f856274d9e230c19209"
 }

--- a/skills-codex/research/.agentops-generated.json
+++ b/skills-codex/research/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/research",
   "layout": "modular",
-  "source_hash": "f9bb3b3bf8455c2340093b4aab1bb9a4ca93b63a2a2f92a18baa50d256c5e3a6",
+  "source_hash": "c420cf9a59a7516458c32eade9d412fc51082138a31fc6c6006d866cee11425a",
   "generated_hash": "0cefcd8d49ff88736cf177b61a5b43b6d866389fbd2cf4afd3bd36335647160e"
 }

--- a/skills-codex/validation/.agentops-generated.json
+++ b/skills-codex/validation/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/validation",
   "layout": "modular",
-  "source_hash": "a34f1de21ab46b01be6fce975694a0f9aecdd2accd488142f6c8ae82aafb558a",
+  "source_hash": "0a9113d84fefae41f36313cc3e791429c8ba78f72470abd7781af3efa46795e1",
   "generated_hash": "353b7a5dcc7e4720f355dbe37e63259482812f10605a9189c8a5e6eabcf6e851"
 }


### PR DESCRIPTION
PR #490's SELF-TEST.md additions left the codex source_hash drifted for plan/research/validation (hash_tree is over the whole skill dir; CI checks --scope head so it merged green). `regen-codex-hashes.sh` → "All hashes up to date". Scoped diff (3 generated.json + manifest).

NOTE: claude-review infra-red (weekly limit) — operator-authorized bypass when sole red.

Closes-scenario: soc-uz3x2#regen-codex-hashes
Bounded-context: BC1-Corpus
Evidence: skills-codex/.agentops-manifest.json