### PR TITLE
feat(bdd): CLI command Gherkin (autodev/flywheel/inject), linked to tests (soc-jnfgi #cli-command-gherkin)

### DIFF
--- a/skills/autodev/references/autodev-cli.feature
+++ b/skills/autodev/references/autodev-cli.feature
@@ -1,0 +1,64 @@
+# Executable spec for the `ao autodev` CLI command — the PROGRAM.md contract surface.
+# Distinct from autodev.feature (which specs the /autodev SKILL loop): this file specs the
+# observable behavior of the `ao autodev {init,validate,show}` subcommands — flags, output
+# contract (human + JSON), and error paths. Each scenario links to the Go test in
+# cli/cmd/ao/ that proves it. (soc-jnfgi)
+
+Feature: ao autodev manages the PROGRAM.md operational contract
+  As an operator bounding autonomous development
+  I want to create, validate, and inspect the repo-local PROGRAM.md contract
+  So that autonomy stays scoped to a declared, machine-checkable contract
+
+  @covered-by:cli/cmd/ao/autodev_integration_test.go::TestAutodev_Integration_InitCreatesFile
+  Scenario: init writes a PROGRAM.md template
+    Given no PROGRAM.md exists in the working directory
+    When I run `ao autodev init`
+    Then a PROGRAM.md file is created with the contract section scaffold
+
+  @covered-by:cli/cmd/ao/autodev_integration_test.go::TestAutodev_Integration_InitRefusesOverwrite
+  Scenario: init refuses to clobber an existing contract without --force
+    Given a PROGRAM.md already exists
+    When I run `ao autodev init`
+    Then the command fails and reports that the file already exists
+
+  @covered-by:cli/cmd/ao/autodev_integration_test.go::TestAutodev_Integration_ValidateValidProgram
+  Scenario: validate accepts a well-formed contract
+    Given a PROGRAM.md declaring objective, mutable/immutable scope, validation commands, and stop conditions
+    When I run `ao autodev validate`
+    Then the command exits zero and reports the contract as VALID
+
+  @covered-by:cli/cmd/ao/autodev_integration_test.go::TestAutodev_Integration_ValidateInvalidProgram
+  Scenario: validate rejects a contract missing required sections
+    Given a PROGRAM.md with no contract sections
+    When I run `ao autodev validate`
+    Then the command exits non-zero and the output reports INVALID with ERROR lines
+
+  @covered-by:cli/cmd/ao/autodev_integration_test.go::TestAutodev_Integration_ValidateNoProgram
+  Scenario: validate errors when no contract file is found
+    Given neither PROGRAM.md nor AUTODEV.md exists
+    When I run `ao autodev validate`
+    Then the command exits non-zero with guidance to run `ao autodev init`
+
+  @covered-by:cli/cmd/ao/autodev_integration_test.go::TestAutodev_Integration_ValidateJSON
+  Scenario: validate emits a structured JSON result under --output json
+    Given a valid PROGRAM.md
+    When I run `ao --output json autodev validate`
+    Then the output is JSON carrying valid=true, the objective, and the scope counts
+
+  @covered-by:cli/cmd/ao/autodev_test.go::TestCobraAutodevValidateFallsBackToAUTODEVJSON
+  Scenario: validate auto-detects AUTODEV.md when PROGRAM.md is absent
+    Given only an AUTODEV.md contract exists
+    When I run `ao autodev validate`
+    Then the command resolves and validates the AUTODEV.md file
+
+  @covered-by:cli/cmd/ao/autodev_integration_test.go::TestAutodev_Integration_ShowProgram
+  Scenario: show prints the parsed contract
+    Given a PROGRAM.md with scope and validation entries
+    When I run `ao autodev show`
+    Then the output lists the objective, mutable/immutable scope, validation commands, and stop conditions
+
+  @covered-by:cli/cmd/ao/autodev_test.go::TestCobraAutodevShowPrefersPROGRAMOverAUTODEV
+  Scenario: show prefers PROGRAM.md when both contract files exist
+    Given both PROGRAM.md and AUTODEV.md exist
+    When I run `ao autodev show`
+    Then the parsed contract is sourced from PROGRAM.md

--- a/skills/flywheel/references/flywheel-cli.feature
+++ b/skills/flywheel/references/flywheel-cli.feature
@@ -1,0 +1,56 @@
+# Executable spec for the `ao flywheel` CLI command — the knowledge-flywheel health surface.
+# Specs the observable behavior of `ao flywheel {status,compare,gate}`: the health verdict
+# (COMPOUNDING / NEAR ESCAPE / DECAYING), the JSON output contract, namespace comparison +
+# promotion rule, and the post-structural release-readiness gate. Each scenario links to the
+# Go test in cli/cmd/ao/ that proves it. (soc-jnfgi)
+
+Feature: ao flywheel reports knowledge-compounding health and release readiness
+  As an operator steering the knowledge flywheel
+  I want flywheel health, namespace comparison, and a release-readiness gate
+  So that I can tell whether knowledge is compounding and safe to expand on
+
+  @covered-by:cli/cmd/ao/metrics_flywheel_test.go::TestPrintFlywheelStatus_Compounding
+  Scenario: status reports COMPOUNDING when escape velocity is positive
+    Given metrics whose net velocity clears the escape threshold
+    When I run `ao flywheel status`
+    Then the output reports the COMPOUNDING status
+
+  @covered-by:cli/cmd/ao/metrics_flywheel_test.go::TestPrintFlywheelStatus_Decaying
+  Scenario: status reports DECAYING when knowledge is not compounding
+    Given metrics whose net velocity is below the escape threshold
+    When I run `ao flywheel status`
+    Then the output reports the DECAYING status
+
+  @covered-by:cli/cmd/ao/metrics_flywheel_test.go::TestPrintFlywheelStatus_ContainsEquation
+  Scenario: status surfaces the flywheel equation and its terms
+    When I run `ao flywheel status`
+    Then the output includes the flywheel equation with delta, sigma, and rho terms
+
+  @covered-by:cli/cmd/ao/metrics_flywheel_test.go::TestRunFlywheelStatus_JSONOutput
+  Scenario: status emits a structured JSON contract under --output json
+    When I run `ao --output json flywheel status`
+    Then the JSON carries status, delta, sigma, rho, velocity, compounding, scorecard, and metrics fields
+
+  @covered-by:cli/cmd/ao/metrics_flywheel_test.go::TestBuildNamespaceComparison_PromotionReady
+  Scenario: compare flags the shadow namespace as promotion-ready when it beats primary
+    Given a shadow namespace that beats primary on sigma with non-regressing rho
+    When I run `ao flywheel compare`
+    Then the comparison marks the shadow namespace promotion-ready
+
+  @covered-by:cli/cmd/ao/metrics_flywheel_test.go::TestBuildNamespaceComparison_NotReady_RhoRegressed
+  Scenario: compare withholds promotion when shadow rho regresses
+    Given a shadow namespace whose rho regresses below primary
+    When I run `ao flywheel compare`
+    Then the comparison reports the shadow namespace as not promotion-ready
+
+  @covered-by:cli/cmd/ao/flywheel_gate_test.go::TestEvaluateFlywheelGate
+  Scenario: gate passes when closure, rho, and holdout retrieval all clear their thresholds
+    Given research closure has exited unmined, rho is at least 0.55, and holdout precision meets baseline
+    When the flywheel gate is evaluated
+    Then the gate result is PASS with no reasons
+
+  @covered-by:cli/cmd/ao/flywheel_gate_test.go::TestEvaluateFlywheelGate_FailsOnThresholds
+  Scenario: gate fails and lists each unmet threshold as a reason
+    Given closure is still unmined, rho is below 0.55, or holdout precision is below baseline
+    When the flywheel gate is evaluated
+    Then the gate result is FAIL and each unmet condition is reported as a reason

--- a/skills/inject/references/inject-cli.feature
+++ b/skills/inject/references/inject-cli.feature
@@ -1,0 +1,46 @@
+# Executable spec for the `ao inject` CLI command — the JIT knowledge-injection surface.
+# Specs the observable behavior of `ao inject`: the markdown/JSON output contract, the
+# empty-corpus header guarantee, skill-scoped filtering via --for (including the unknown-skill
+# error path), and the quality-gate filter on candidate learnings. Each scenario links to the
+# Go test in cli/cmd/ao/ that proves it. (soc-jnfgi)
+
+Feature: ao inject outputs relevant knowledge for explicit or JIT context
+  As an agent assembling task context
+  I want injected learnings, patterns, and sessions in a budgeted, scoped form
+  So that prior knowledge is surfaced at the point of work in a stable contract
+
+  @covered-by:cli/cmd/ao/inject_integration_test.go::TestInject_Integration_WithLearnings
+  Scenario: inject surfaces local learnings under a stable markdown header
+    Given the local .agents directory holds a learning and a pattern
+    When I run `ao inject`
+    Then the markdown output carries the "Injected Knowledge" header
+
+  @covered-by:cli/cmd/ao/inject_integration_test.go::TestInject_Integration_EmptyLearningsDir
+  Scenario: inject still emits the header and timestamp when no local learnings exist
+    Given the local .agents corpus has no learnings or patterns
+    When I run `ao inject`
+    Then the output still contains the "Injected Knowledge" header and a "Last injection:" timestamp
+
+  @covered-by:cli/cmd/ao/inject_integration_test.go::TestInject_Integration_JSONFormat
+  Scenario: inject emits a structured JSON contract under --output json
+    Given the local .agents corpus holds a learning
+    When I run `ao --output json inject`
+    Then the JSON output carries a "timestamp" field
+
+  @covered-by:cli/cmd/ao/inject_test.go::TestInjectForFlag_ResearchSkill
+  Scenario: --for filters output by the named skill's context declaration
+    Given a skill whose context declaration excludes the HISTORY section
+    When I run `ao inject --for=<skill>`
+    Then the excluded section (Recent Sessions) is absent from the output
+
+  @covered-by:cli/cmd/ao/inject_test.go::TestInjectForFlag_UnknownSkill
+  Scenario: --for with an unknown skill is a hard error
+    Given no skill matching the requested name exists
+    When I run `ao inject --for=<nonexistent-skill>`
+    Then the command fails with a "not found" error
+
+  @covered-by:cli/cmd/ao/inject_test.go::TestProcessLearningFile_QualityGateFilters
+  Scenario: the quality gate drops candidate learnings below the threshold
+    Given a candidate learning whose quality is below the injection gate threshold
+    When inject assembles its candidates
+    Then the sub-threshold learning is filtered out of the result


### PR DESCRIPTION
Adds new `.feature` executable specs for the `ao autodev`, `ao flywheel`, and `ao inject` CLI commands. 23 scenarios total, each linked via `@covered-by:` to an existing Go test in `cli/cmd/ao/` that proves the observable behavior (flags, output contract, error paths). Scenarios verified against actual CLI behavior; no test was invented and no allowlist entry was touched.

- `skills/autodev/references/autodev-cli.feature` — 9 scenarios for `init`/`validate`/`show` (template creation, overwrite refusal, valid/invalid/missing contract, JSON contract, AUTODEV.md fallback, PROGRAM.md preference).
- `skills/flywheel/references/flywheel-cli.feature` — 8 scenarios for `status`/`compare`/`gate` (COMPOUNDING/DECAYING verdict, equation surfacing, JSON contract, promotion-ready / rho-regression comparison, gate pass + per-threshold fail reasons).
- `skills/inject/references/inject-cli.feature` — 6 scenarios for `inject` (header guarantee with/without local learnings, JSON contract, `--for` skill-scoped filtering, `--for` unknown-skill error, quality-gate filtering).

Gate: `scripts/check-scenario-test-linkage.sh` → PASS (279 scenarios, 34 linked). All 23 linked tests pass (`go test ./cmd/ao/...`).

Closes-scenario: soc-jnfgi#cli-command-gherkin
Bounded-context: BC5-Runtime
Evidence: skills/autodev/references/autodev-cli.feature