### PR TITLE
fix(goals): trace --orphans parser rejects bead prose, matches real scenario refs only (soc-bhu6w #trace-orphans-parser)

### DIFF
--- a/cli/internal/goalstrace/beads.go
+++ b/cli/internal/goalstrace/beads.go
@@ -22,6 +22,24 @@ var scenariosLineRe = regexp.MustCompile(`(?im)^\s*Scenarios:\s*(.+)$`)
 // hyphen, which the required inner "-[a-z0-9]+" group rejects.
 var scenarioTokenRe = regexp.MustCompile(`\b(s-\d{4}-\d{2}-\d{2}-\d{3}|auto-[a-z0-9]+-[a-z0-9][a-z0-9-]*)\b`)
 
+// scenarioIDRe is the anchored form of the scenario-ID grammar. It matches a
+// string that is *entirely* a scenario ID (the resolvable filename stem under
+// spec/scenarios/<id>.json or .agents/holdout/<id>.json), with no surrounding
+// prose. Unlike scenarioTokenRe (which scans free text for an embedded token),
+// this is applied to each comma/semicolon-split token of an explicit
+// "Scenarios:" line so that bead-description prose — frontmatter field lists,
+// "and section structure", "graduation path (...)", etc. — is rejected rather
+// than mis-claimed as a dangling scenario reference (soc-bhu6w).
+var scenarioIDRe = regexp.MustCompile(`^(s-\d{4}-\d{2}-\d{2}-\d{3}|auto-[a-z0-9]+-[a-z0-9][a-z0-9-]*)$`)
+
+// isScenarioID reports whether s is, in its entirety, a resolvable scenario ID
+// (human "s-YYYY-MM-DD-NNN" or auto "auto-<multi-segment-slug>"). Free-form
+// "## Scenarios" bullet slugs (e.g. "lesson-format-spec") and arbitrary prose
+// tokens are not scenario IDs in the trace-resolution model and return false.
+func isScenarioID(s string) bool {
+	return scenarioIDRe.MatchString(s)
+}
+
 // directiveTokenRe matches a stable directive ID token (d-<slug>) anywhere in
 // free text — used for the body-scan discovery path of directive_has_learning.
 var directiveTokenRe = regexp.MustCompile(`\bd-[a-z0-9][a-z0-9-]*\b`)
@@ -146,6 +164,15 @@ func claimedScenarios(b beadRecord) (explicit, heuristic []string) {
 	explicitSet := map[string]bool{}
 	for _, m := range scenariosLineRe.FindAllStringSubmatch(text, -1) {
 		for _, id := range splitIDList(m[1]) {
+			// A "Scenarios:" line whose first bullet is a "<slug>: <prose>"
+			// description (the canonical bead-embedded ## Scenarios form) reflows
+			// into one logical line, so the comma/semicolon split yields prose
+			// tokens (frontmatter field names, "and section structure", etc.).
+			// Only tokens that are, in full, a resolvable scenario ID are real
+			// claims; everything else is prose and must be dropped (soc-bhu6w).
+			if !isScenarioID(id) {
+				continue
+			}
 			if !explicitSet[id] {
 				explicitSet[id] = true
 				explicit = append(explicit, id)

--- a/cli/internal/goalstrace/beads_test.go
+++ b/cli/internal/goalstrace/beads_test.go
@@ -106,6 +106,67 @@ func TestClaimedScenarios_ExplicitScenariosLineIsHighConfidence(t *testing.T) {
 	}
 }
 
+// TestClaimedScenarios_ExplicitScenariosLineRejectsProse is the soc-bhu6w
+// regression: a bead whose "Scenarios:" line reflows into a free-form
+// "<slug>: <prose>" bullet (the canonical bead-embedded ## Scenarios form) must
+// NOT have its comma/semicolon-split prose tokens (frontmatter field names,
+// "and section structure", "graduation path (...)", etc.) mis-claimed as
+// explicit scenario IDs. Only tokens matching the real scenario-ID grammar are
+// claims; everything else is prose and must be dropped.
+func TestClaimedScenarios_ExplicitScenariosLineRejectsProse(t *testing.T) {
+	// Mirrors the real soc-4mc2 description that produced the 12 false
+	// broken_bead_scenario_claim errors: a Scenarios: line followed by a
+	// "<slug>: <prose>" bullet whose prose contains a comma-separated field
+	// list and English phrases.
+	b := beadRecord{
+		ID:    "soc-bhu6w.test",
+		Title: "prose scenarios bead",
+		Description: "Codify the lesson format.\n" +
+			"Scenarios: - lesson-format-spec: docs/contracts/lesson-format.md exists " +
+			"and defines frontmatter (id, date, severity, trigger, verifiable, rule, " +
+			"falsified_by, practice, related), file naming, graduation path " +
+			"(unassigned -> proposed -> accepted -> encoded), and section structure",
+		Status: "open",
+	}
+	explicit, heuristic := claimedScenarios(b)
+	if len(explicit) != 0 {
+		t.Errorf("explicit = %v, want none — every token is prose, not a scenario ID", explicit)
+	}
+	// The prose tokens (date, rule, trigger, ...) must not leak into the
+	// heuristic list either: none of them match the scenario-ID grammar.
+	for _, id := range heuristic {
+		for _, prose := range []string{"date", "rule", "trigger", "severity", "practice", "verifiable", "and section structure"} {
+			if id == prose {
+				t.Errorf("prose token %q leaked into heuristic claims %v", prose, heuristic)
+			}
+		}
+	}
+}
+
+// TestClaimedScenarios_ExplicitScenariosLineKeepsRealIDAmidProse verifies the
+// true-positive half of the soc-bhu6w fix: a genuine scenario ID on a
+// "Scenarios:" line is still extracted as an explicit claim even when the line
+// also carries prose tokens. A dangling-but-real-format ID must survive to be
+// flagged downstream; prose around it must not.
+func TestClaimedScenarios_ExplicitScenariosLineKeepsRealIDAmidProse(t *testing.T) {
+	b := beadRecord{
+		ID:          "soc-bhu6w.test2",
+		Title:       "mixed scenarios bead",
+		Description: "Scenarios: s-2026-05-17-001, file naming, auto-nightly-evolution-dry-run, and section structure",
+		Status:      "open",
+	}
+	explicit, _ := claimedScenarios(b)
+	want := map[string]bool{"s-2026-05-17-001": true, "auto-nightly-evolution-dry-run": true}
+	if len(explicit) != len(want) {
+		t.Fatalf("explicit = %v, want exactly the two real IDs %v", explicit, want)
+	}
+	for _, id := range explicit {
+		if !want[id] {
+			t.Errorf("explicit contains non-ID token %q", id)
+		}
+	}
+}
+
 // TestBeadClaimEdge_ExplicitMissingScenarioIsError verifies that a
 // broken_bead_scenario_claim from an explicit "Scenarios:" line (high
 // confidence) is classified as error severity — this is the true-defect case

--- a/skills/autodev/SKILL.md
+++ b/skills/autodev/SKILL.md
@@ -144,3 +144,4 @@ ao evolve --max-cycles 1
 ## Reference Documents
 
 - [references/autodev.feature](references/autodev.feature) — Executable spec: contract-bounded unattended loop, manages-not-replaces evolve/rpi, loop-discipline-under-autonomy (soc-qk4b)
+- [references/autodev-cli.feature](references/autodev-cli.feature) — Executable spec: `ao autodev` CLI command behavior, linked to cmd tests (soc-jnfgi)

--- a/skills/flywheel/SKILL.md
+++ b/skills/flywheel/SKILL.md
@@ -284,3 +284,4 @@ Phase 4 (soc-ytpq) governance for `~/.agents/learnings/` — all advisory, none 
 - [references/promotion-tiers.md](references/promotion-tiers.md)
 - [references/hub-budget.md](references/hub-budget.md)
 - [references/cache-eviction.md](references/cache-eviction.md)
+- [references/flywheel-cli.feature](references/flywheel-cli.feature) — Executable spec: `ao flywheel` CLI command behavior, linked to cmd tests (soc-jnfgi)

--- a/skills/inject/SKILL.md
+++ b/skills/inject/SKILL.md
@@ -198,3 +198,7 @@ Knowledge relevance decays over time (~17%/week). More recent learnings are weig
 | Irrelevant knowledge | Topic mismatch or stale artifacts dominate | Use `--context "<topic>"` to filter; prune stale artifacts |
 | Token budget exceeded | Too many high-relevance artifacts | Reduce `--max-tokens` or increase topic specificity |
 | Decay too aggressive | Recent learnings not prioritized | Check artifact modification times; verify `--apply-decay` flag |
+
+## Reference Documents
+
+- [references/inject-cli.feature](references/inject-cli.feature) — Executable spec: `ao inject` CLI command behavior (header, JSON contract, `--for` filtering), linked to cmd tests (soc-jnfgi)

--- a/skills/quickstart/SKILL.md
+++ b/skills/quickstart/SKILL.md
@@ -123,6 +123,7 @@ Starting a new project? Run `/scaffold <language> <name>` to generate project st
 - [references/getting-started.md](references/getting-started.md)
 - [references/troubleshooting.md](references/troubleshooting.md)
 - [references/full-catalog.md](references/full-catalog.md)
+- [references/daemon-lifecycle.feature](references/daemon-lifecycle.feature) — Executable spec: agentopsd lifecycle (start→submit→validate→panic-recovery→heartbeat→reap), linked to daemon tests (soc-6kf1t)
 
 ## See Also
 


### PR DESCRIPTION
## Problem

`ao goals trace --orphans` emitted 12 false `broken_bead_scenario_claim` ERROR findings (exit 1) on current main data, blocking promotion of `trace --orphans` to a blocking gate (the sibling `ao goals scenarios --lint` is already blocking). Surfaced by soc-x7y9f.

## Root cause

The explicit "Scenarios:" path in `claimedScenarios` (cli/internal/goalstrace/beads.go) fed **every** comma/semicolon-split token of the line straight into a scenario claim, with no validation against the real scenario-ID grammar.

Beads using the canonical bead-embedded `## Scenarios` bullet form — `Scenarios:` on its own line followed by `- <slug>: <prose>` bullets — reflow into one logical line in `bd list --json`. The regex `^\s*Scenarios:\s*(.+)$` then captured the first bullet's full prose, and `splitIDList` split it on commas, yielding prose tokens (frontmatter field names like date/rule/trigger/severity, English phrases like 'and section structure', 'graduation path (...)'). Each was mis-claimed as a dangling scenario reference (real example: bead soc-4mc2).

## Fix

Added an anchored `scenarioIDRe` / `isScenarioID` validating each explicit token against the real scenario-ID grammar (`s-YYYY-MM-DD-NNN` or `auto-<multi-segment-slug>` — the resolvable scenario filename stem). Non-ID tokens are dropped as prose. The heuristic free-text path is unchanged. True-positive detection preserved: a genuine dangling explicit ID still flags as an error.

## Before / after

| | Before | After |
|---|---|---|
| ERROR broken_bead_scenario_claim | 12 | 0 |
| exit code | 1 | 0 |

Remaining broken_bead_scenario_claim entries (38 warnings total) are pre-existing WARN-severity heuristic matches of genuine auto-<...> tokens in free text — intentionally warn-only, unrelated to this bug. No genuine explicit orphans were silenced (current data has zero real explicit scenario-ID claims).

## Tests

- `TestClaimedScenarios_ExplicitScenariosLineRejectsProse` — mirrors real soc-4mc2 prose, asserts 0 claims.
- `TestClaimedScenarios_ExplicitScenariosLineKeepsRealIDAmidProse` — real IDs survive amid prose tokens.

Low-level parser logic tested directly, no live bd/ao dependency.

## Verification

- `go build ./... && go vet ./... && go test ./...` — 11896 passed, 68 packages
- gofmt clean
- `ao goals scenarios --lint` still exits 0 (blocking gate not regressed)

Closes-scenario: soc-bhu6w#trace-orphans-parser
Bounded-context: BC4-Evidence
Evidence: cli/cmd/ao/