### PR TITLE
fix(ci): skill-contract reference check runs on skills-only PRs (soc-oemfm #skill-contract-gate)

### DIFF
--- a/skills/heal-skill/scripts/heal.sh
+++ b/skills/heal-skill/scripts/heal.sh
@@ -266,7 +266,7 @@ for skill_dir in "${TARGETS[@]}"; do
     fi
   fi
 
-  # Check 4: Unlinked references
+  # Check 4: Unlinked references (.md files — strict markdown-link / Read form)
   if [[ -d "$skill_dir/references" ]]; then
     for ref_file in "$skill_dir"/references/*.md; do
       [[ -f "$ref_file" ]] || continue
@@ -277,6 +277,35 @@ for skill_dir in "${TARGETS[@]}"; do
         if [[ "$MODE" == "fix" ]]; then
           fix_unlinked_ref "$skill_md" "$ref_rel"
         fi
+      fi
+    done
+  fi
+
+  # Check 4b: Unreferenced non-.md references (.feature, .json, .txt, etc.)
+  #
+  # Mirrors the Go contract test TestSkillContract_ReferencesLinkedInSKILLMD
+  # (cli/cmd/ao/skill_contract_test.go): EVERY top-level file in references/
+  # (any extension, excluding dotfiles and subdirectories) must have its
+  # basename appear somewhere in SKILL.md. The Go test gates go-build, which is
+  # path-filtered to cli/** — so a skills-only PR that adds an unreferenced
+  # .feature file (e.g. PRs #504/#505) skipped go-build and merged the breakage
+  # onto main, only surfacing on the next cli/ PR (soc-oemfm).
+  #
+  # heal.sh (skill-integrity job) runs on skills/** changes, so checking the
+  # same invariant here closes the gap on the right trigger. The rule mirrors
+  # the Go test's permissive basename containment (NOT the stricter markdown-link
+  # form used for .md above) so this gate and the Go test agree exactly.
+  if [[ -d "$skill_dir/references" ]]; then
+    for ref_file in "$skill_dir"/references/*; do
+      [[ -f "$ref_file" ]] || continue
+      ref_basename="$(basename "$ref_file")"
+      # Skip dotfiles and .md files (.md handled by Check 4 above).
+      [[ "$ref_basename" == .* ]] && continue
+      [[ "$ref_basename" == *.md ]] && continue
+      ref_rel="references/$ref_basename"
+      # Mirror the Go test: basename must appear anywhere in SKILL.md.
+      if ! grep -qF "$ref_basename" "$skill_md" 2>/dev/null; then
+        report "UNREFERENCED_REF" "$skill_dir" "$ref_rel not referenced in SKILL.md"
       fi
     done
   fi


### PR DESCRIPTION
## Problem (gap hit live)

`TestSkillContract_ReferencesLinkedInSKILLMD` (`cli/cmd/ao/skill_contract_test.go`) asserts that **every** top-level file in `skills/<name>/references/` — any extension, excluding dotfiles and subdirectories — has its basename appear in that skill's `SKILL.md`.

That Go test only gates the **`go-build`** CI job, which is path-filtered (via the `changes` job / dorny-paths-filter, soc-dorz) to run **only when `cli/**` changes**. So a skills-only PR that adds an unreferenced `references/*.feature` file (e.g. PRs #504/#505) skips `go-build` entirely and merges the skill-contract breakage onto `main` — it only surfaces red on the *next* `cli/` PR.

## Why neither existing skills-triggered gate caught it

- `skill-integrity` (heal.sh `--strict`) — runs on `skills/** || ci`, but Check 4 only globbed `references/*.md`, **missing `.feature`/`.json`/`.txt`**.
- `validate-scenario-test-linkage` — checks scenario→test `@covered-by` tags, a *different* invariant.
- `executable-spec-link-integrity` — gated on `go || docs || ci` (not skills), and checks directive→scenario links.

## Fix — Option A (preferred, cheap)

Extended `heal.sh` with **Check 4b**: every top-level non-`.md` reference file (any extension, excluding dotfiles/dirs) must have its basename appear in `SKILL.md` — mirroring the Go test's permissive `strings.Contains` rule **exactly**, so the heal.sh gate and the Go contract test agree. Existing `.md` handling (strict markdown-link / `Read` form, Check 4) is unchanged.

`heal.sh` runs in the **`skill-integrity`** job, which is already gated on `skills/** || ci` — so the same invariant is now live on the correct trigger.

**Why A over B:** Option B (adding `skills/**`+`skills-codex/**` to the `go-build` path filter) would run the full ~50s Go suite on every skill-only PR. Option A puts the *same* check on a job that already triggers on skill changes, with no added Go-suite cost. The Go test stays as the cli-lane backstop.

## Proof the gate closes the gap

| State | Result |
|---|---|
| Baseline (75 `.feature` + json/tmpl/txt refs) | `heal.sh --strict` exit **0**, clean — no false positives (Go contract test also passes) |
| Add unreferenced `skills/doc/references/_gap_probe.feature` | `[UNREFERENCED_REF] skills/doc: references/_gap_probe.feature not referenced in SKILL.md`, exit **1** — **caught** |
| Remove probe | exit **0** — clean again |

## Verification

- `shellcheck skills/heal-skill/scripts/heal.sh` — only 2 pre-existing SC2016 *info* findings (lines 403/418, untouched); CI runs `--severity=error` so they don't gate. New code clean.
- `bash -n` syntax OK.
- `go test -run TestSkillContract_ReferencesLinkedInSKILLMD` — passes (501).
- `heal-skill` is not embedded in `cli/embedded/skills/`, so no `make sync-hooks` needed.
- No `validate.yml`/`ci-jobs.yaml` change (reused existing `skill-integrity` job), so no CI-policy-parity / catalog update needed.

Closes-scenario: soc-oemfm#skill-contract-gate
Bounded-context: BC4-Evidence
Evidence: .github/workflows/validate.yml