### PR TITLE
chore(codex): regen 8 drifted codex hashes from #503-#508 (soc-z5mbz #regen-8-codex-hashes)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -679,7 +679,7 @@
     {
       "name": "autodev",
       "source_skill": "skills/autodev",
-      "source_hash": "67bb1293051a57e371462b97f4d8c9c80870bdc798e54aa929f5072e4959410c",
+      "source_hash": "4ad1828489b40ea336c593c1b04054b5c0faa1cc194ce2bc29c49fa8aa8cd9ec",
       "generated_hash": "7fe2526d5e4792cb4b52e59745010fb752547b5163495e59904a13e4535f4024"
     },
     {
@@ -799,7 +799,7 @@
     {
       "name": "flywheel",
       "source_skill": "skills/flywheel",
-      "source_hash": "d61e244b8196a28aa70a80e19f2527285cec8e777422c7b5605eb5ddc348eac3",
+      "source_hash": "52cdad7e9e2d83dbb5fb43fb163b0c14a2b20bde7e7af904f08e4712b2804f68",
       "generated_hash": "e60b091d03fd2c5d12f9e608f869bdfb776dedc392397d9df249b687ae97cbfb"
     },
     {
@@ -811,7 +811,7 @@
     {
       "name": "goals",
       "source_skill": "skills/goals",
-      "source_hash": "3e3aa6b0a3e98cbfed40c919acba4c290205cd75c0ff51d5fd4888d6c8163754",
+      "source_hash": "d8c3c5421217f885f047295f18c88bdd06d8f98bd9db8f8eb54f05a61559f3b5",
       "generated_hash": "dc9b388da75af17c85440fa0481c9c69b16b9641b1832269e302856dd48ded8d"
     },
     {
@@ -835,7 +835,7 @@
     {
       "name": "heal-skill",
       "source_skill": "skills/heal-skill",
-      "source_hash": "9f3ce2fe334237343ad6cf87cf5ec063e4bf01ef74814821e3671cb70f02c9ae",
+      "source_hash": "bd0513fa1d1f40828099749757c21ae4c2ed31acfdcf0477bf403fa707d23d17",
       "generated_hash": "0a4b01de799212b1c33f718aba85c1ea0e03a033542a8e81929ddbd52425ab4b"
     },
     {
@@ -853,7 +853,7 @@
     {
       "name": "inject",
       "source_skill": "skills/inject",
-      "source_hash": "2491b940d1df03543bf149293fe3cb9c149710e5740336070dd1c3ffe6757892",
+      "source_hash": "716e2b773fe4eaef5b5437d0d723478826d79948c6b73749d8904cf0eece581d",
       "generated_hash": "07131ae2abbad03022f18d765c5d22da13dfa98a1e8df2272ea46e783a12a6cc"
     },
     {
@@ -961,7 +961,7 @@
     {
       "name": "quickstart",
       "source_skill": "skills/quickstart",
-      "source_hash": "c127f1576b2590c95f159cddacd8bd88f07d8b4b911765ca5e4fb0e86ba894e9",
+      "source_hash": "7dd822ebe5f7ecfb349c478ccd5bc40511413ae323d21850d10afe3bf4b2ec4f",
       "generated_hash": "6881a31264d27e57de858a5e842297d35dc82dc1c2456b0e8192e8d165b8bf67"
     },
     {
@@ -1027,7 +1027,7 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "441cdc759c0cc75a656790077ade6d9aaaa144a74da721556359869d72ed6202",
+      "source_hash": "b18cd7bfd15fe2895dd25a6ab549a146b7de2dbb0477c407aa4c5a0b0618d92e",
       "generated_hash": "c8f439c27965aa992f1dd9c94d0f80ddc8c2aff5f8b864c8a2a6d0820c1c814d"
     },
     {
@@ -1039,7 +1039,7 @@
     {
       "name": "scenario",
       "source_skill": "skills/scenario",
-      "source_hash": "42ba309f3f2d1e1b806b99e7b3b0d9ace87e1af5802a4ae823d202c7c555fcdd",
+      "source_hash": "46ed0481b2606231a22899550eb5d60ed041fe81fed103eb9d5c117cd06c2d6f",
       "generated_hash": "1736927301013e0f0aa5492ac60c2b909caee1a7ec232752998d85f1c9767de5"
     },
     {

--- a/skills-codex/autodev/.agentops-generated.json
+++ b/skills-codex/autodev/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/autodev",
   "layout": "modular",
-  "source_hash": "67bb1293051a57e371462b97f4d8c9c80870bdc798e54aa929f5072e4959410c",
+  "source_hash": "4ad1828489b40ea336c593c1b04054b5c0faa1cc194ce2bc29c49fa8aa8cd9ec",
   "generated_hash": "7fe2526d5e4792cb4b52e59745010fb752547b5163495e59904a13e4535f4024"
 }

--- a/skills-codex/flywheel/.agentops-generated.json
+++ b/skills-codex/flywheel/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/flywheel",
   "layout": "modular",
-  "source_hash": "d61e244b8196a28aa70a80e19f2527285cec8e777422c7b5605eb5ddc348eac3",
+  "source_hash": "52cdad7e9e2d83dbb5fb43fb163b0c14a2b20bde7e7af904f08e4712b2804f68",
   "generated_hash": "e60b091d03fd2c5d12f9e608f869bdfb776dedc392397d9df249b687ae97cbfb"
 }

--- a/skills-codex/goals/.agentops-generated.json
+++ b/skills-codex/goals/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/goals",
   "layout": "modular",
-  "source_hash": "3e3aa6b0a3e98cbfed40c919acba4c290205cd75c0ff51d5fd4888d6c8163754",
+  "source_hash": "d8c3c5421217f885f047295f18c88bdd06d8f98bd9db8f8eb54f05a61559f3b5",
   "generated_hash": "dc9b388da75af17c85440fa0481c9c69b16b9641b1832269e302856dd48ded8d"
 }

--- a/skills-codex/heal-skill/.agentops-generated.json
+++ b/skills-codex/heal-skill/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/heal-skill",
   "layout": "modular",
-  "source_hash": "9f3ce2fe334237343ad6cf87cf5ec063e4bf01ef74814821e3671cb70f02c9ae",
+  "source_hash": "bd0513fa1d1f40828099749757c21ae4c2ed31acfdcf0477bf403fa707d23d17",
   "generated_hash": "0a4b01de799212b1c33f718aba85c1ea0e03a033542a8e81929ddbd52425ab4b"
 }

--- a/skills-codex/inject/.agentops-generated.json
+++ b/skills-codex/inject/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/inject",
   "layout": "modular",
-  "source_hash": "2491b940d1df03543bf149293fe3cb9c149710e5740336070dd1c3ffe6757892",
+  "source_hash": "716e2b773fe4eaef5b5437d0d723478826d79948c6b73749d8904cf0eece581d",
   "generated_hash": "07131ae2abbad03022f18d765c5d22da13dfa98a1e8df2272ea46e783a12a6cc"
 }

--- a/skills-codex/quickstart/.agentops-generated.json
+++ b/skills-codex/quickstart/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/quickstart",
   "layout": "modular",
-  "source_hash": "c127f1576b2590c95f159cddacd8bd88f07d8b4b911765ca5e4fb0e86ba894e9",
+  "source_hash": "7dd822ebe5f7ecfb349c478ccd5bc40511413ae323d21850d10afe3bf4b2ec4f",
   "generated_hash": "6881a31264d27e57de858a5e842297d35dc82dc1c2456b0e8192e8d165b8bf67"
 }

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "441cdc759c0cc75a656790077ade6d9aaaa144a74da721556359869d72ed6202",
+  "source_hash": "b18cd7bfd15fe2895dd25a6ab549a146b7de2dbb0477c407aa4c5a0b0618d92e",
   "generated_hash": "c8f439c27965aa992f1dd9c94d0f80ddc8c2aff5f8b864c8a2a6d0820c1c814d"
 }

--- a/skills-codex/scenario/.agentops-generated.json
+++ b/skills-codex/scenario/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual",
   "source_skill": "skills/scenario",
   "layout": "modular",
-  "source_hash": "42ba309f3f2d1e1b806b99e7b3b0d9ace87e1af5802a4ae823d202c7c555fcdd",
+  "source_hash": "46ed0481b2606231a22899550eb5d60ed041fe81fed103eb9d5c117cd06c2d6f",
   "generated_hash": "1736927301013e0f0aa5492ac60c2b909caee1a7ec232752998d85f1c9767de5"
 }


### PR DESCRIPTION
Skill-dir edits across #503-#508 (.feature additions, SKILL.md links, heal.sh) changed source dirs but the regenerated codex source_hashes were never committed; CI codex gate is --scope-head so cross-PR accumulation slipped through. `regen-codex-hashes.sh` → 'All hashes up to date'. 9 files, hash strings only.

NOTE: claude-review infra-red (weekly limit) — operator-authorized bypass when sole red.

Closes-scenario: soc-z5mbz#regen-8-codex-hashes
Bounded-context: BC1-Corpus
Evidence: skills-codex/.agentops-manifest.json