### PR TITLE
feat(cli): ao validate --gate — exit-code verdict for GC retry + CI (#ao-validate-gate)

### DIFF
--- a/cli/cmd/ao/cobra_commands_test.go
+++ b/cli/cmd/ao/cobra_commands_test.go
@@ -374,7 +374,7 @@ func TestCobraCommandTreeRegistration(t *testing.T) {
 		"pool", "quick-start", "ratchet", "retrieval-bench", "robot-docs", "rpi",
 		"registry", "scenario", "scope", "search", "seed", "session", "session-outcome", "sessions", "skills", "status",
 		"store", "task-feedback", "task-status", "task-sync", "temper",
-		"trace", "version", "vibe-check", "wiki", "worktree",
+		"trace", "validate", "version", "vibe-check", "wiki", "worktree",
 	}
 	cmdSet := make(map[string]bool)
 	for _, name := range cmdNames {
@@ -434,7 +434,7 @@ func TestCobraExpectedCmdsMatchRegistration(t *testing.T) {
 		"pool", "quick-start", "ratchet", "retrieval-bench", "robot-docs", "rpi",
 		"registry", "scenario", "scope", "search", "seed", "session", "session-outcome", "sessions", "skills", "status",
 		"store", "task-feedback", "task-status", "task-sync", "temper",
-		"trace", "version", "vibe-check", "wiki", "worktree",
+		"trace", "validate", "version", "vibe-check", "wiki", "worktree",
 	}
 
 	// Every expected command must be registered

--- a/cli/cmd/ao/root.go
+++ b/cli/cmd/ao/root.go
@@ -97,6 +97,16 @@ func Execute() {
 			}
 			os.Exit(docErr.ExitCode())
 		}
+		var gateErr *gateExitError
+		if errors.As(err, &gateErr) {
+			// The exit code IS the verdict in `ao validate --gate`. A FAIL (1)
+			// carries no stderr noise (detail already went to stderr); an
+			// internal error (2) surfaces its reason.
+			if gateErr.ExitCode() == gateExitInternal && gateErr.Error() != "" {
+				fmt.Fprintln(os.Stderr, "ao validate: "+gateErr.Error())
+			}
+			os.Exit(gateErr.ExitCode())
+		}
 		printRequiredFlagHint(executedCmd, err)
 		os.Exit(1)
 	}

--- a/cli/cmd/ao/validate.go
+++ b/cli/cmd/ao/validate.go
@@ -1,0 +1,318 @@
+// practices: [continuous-delivery, dora-metrics]
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/boshu2/agentops/cli/internal/ratchet"
+)
+
+// Verdict is the AgentOps validation verdict vocabulary (same as the
+// `agentops:validate` skill and `ao ratchet`).
+type verdict string
+
+const (
+	verdictPass verdict = "PASS"
+	verdictWarn verdict = "WARN"
+	verdictFail verdict = "FAIL"
+)
+
+// Gate exit codes. The exit code IS the verdict in --gate mode, deliberately
+// distinguishing a clean FAIL (1) from a broken gate (2) so retry loops
+// (GC check.max_attempts, CI, ao rpi's internal validate phase) never read a
+// setup error as a passing or failing gate.
+const (
+	gateExitPass     = 0 // PASS or WARN (gate passes)
+	gateExitFail     = 1 // FAIL (gate fails)
+	gateExitInternal = 2 // internal/usage error (could not run the gate)
+)
+
+// gateExitError carries a gate exit code out through cobra's RunE so Execute()
+// can map it to os.Exit. Reuses the typed-error + errors.As pattern
+// (see doctorExitError, AgentsLintError).
+type gateExitError struct {
+	code int
+	msg  string
+}
+
+func (e *gateExitError) Error() string { return e.msg }
+
+// ExitCode returns the process exit code this error maps to.
+func (e *gateExitError) ExitCode() int { return e.code }
+
+// validateGateResult is the aggregated, machine-readable gate verdict.
+type validateGateResult struct {
+	Verdict  verdict  `json:"verdict"`
+	Issues   []string `json:"issues"`
+	Warnings []string `json:"warnings"`
+	GateExit int      `json:"gate_exit"`
+}
+
+// validate command flags.
+var (
+	validateGate          bool
+	validateBead          string
+	validateChanges       []string
+	validateStrict        bool
+	validateWarnAsFail    bool
+	validateJSONOut       bool
+	validateLenient       bool
+	validateLenientExpiry int
+)
+
+func init() {
+	validateCmd := &cobra.Command{
+		Use:     "validate",
+		GroupID: "workflow",
+		Short:   "Umbrella validation gate (exit-code-as-verdict with --gate)",
+		Long: `Run a deterministic validation gate over RPI artifacts and emit a single
+PASS / WARN / FAIL verdict.
+
+This is the umbrella gate; the existing sub-surfaces (ao ratchet validate,
+ao scenario validate, ao goals validate) stay and can be delegated to. ao validate
+composes the ratchet validator, aggregates to one verdict, and (with --gate) maps
+that verdict onto the process exit code.
+
+Deterministic: no network, no LLM. Safe as a GC check script, a CI step, or
+ao rpi's internal validate phase.
+
+Exit codes with --gate:
+  0  PASS or WARN (gate passes)
+  1  FAIL (gate fails)
+  2  internal/usage error (could not run the gate — distinct from a clean FAIL)
+
+WARN exits 0 by default (advisory). --strict / --warn-as-fail promotes WARN to
+exit 1 for callers that want zero-warning gates.
+
+Examples:
+  ao validate --gate                       # gate the RPI artifacts in cwd
+  ao validate --gate --changes plan.md     # gate explicit files
+  ao validate --gate --bead soc-123        # gate a bead's artifacts
+  ao validate --gate --strict              # WARN -> FAIL (exit 1)
+  ao validate --json                       # structured verdict, exit 0`,
+		Args: cobra.NoArgs,
+		// The exit code carries the verdict; we map gateExitError in Execute().
+		// Silence cobra's own error print so a FAIL/internal verdict doesn't emit
+		// a spurious "Error:" line on top of our verdict output.
+		SilenceErrors: true,
+		RunE:          runValidate,
+	}
+	f := validateCmd.Flags()
+	f.BoolVar(&validateGate, "gate", false, "Exit-code mode: 0=PASS/WARN, 1=FAIL, 2=error")
+	f.StringVar(&validateBead, "bead", "", "Validate artifacts bound to a bead id")
+	f.StringSliceVar(&validateChanges, "changes", nil, "Explicit files to validate")
+	f.BoolVar(&validateStrict, "strict", false, "Promote WARN to FAIL (exit 1)")
+	f.BoolVar(&validateWarnAsFail, "warn-as-fail", false, "Alias for --strict")
+	f.BoolVar(&validateJSONOut, "json", false, "Structured verdict (honored in both modes)")
+	f.BoolVar(&validateLenient, "lenient", false, "Allow legacy artifacts without schema_version")
+	f.IntVar(&validateLenientExpiry, "lenient-expiry", 90, "Days until lenient bypass expires")
+	rootCmd.AddCommand(validateCmd)
+}
+
+// runValidate executes the umbrella validation gate.
+func runValidate(cmd *cobra.Command, _ []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return &gateExitError{code: gateExitInternal, msg: fmt.Sprintf("get working directory: %v", err)}
+	}
+
+	validator, err := ratchet.NewValidator(cwd)
+	if err != nil {
+		return &gateExitError{code: gateExitInternal, msg: fmt.Sprintf("create validator: %v", err)}
+	}
+
+	targets, err := resolveGateTargets(cwd)
+	if err != nil {
+		return &gateExitError{code: gateExitInternal, msg: err.Error()}
+	}
+	if len(targets) == 0 {
+		return &gateExitError{code: gateExitInternal,
+			msg: "no artifacts to validate (use --changes, --bead, or run from a directory with RPI outputs)"}
+	}
+
+	result := runGateValidation(validator, targets)
+	return emitGateResult(cmd, result)
+}
+
+// gateTarget pairs a file path with the ratchet step that validates it.
+type gateTarget struct {
+	step ratchet.Step
+	path string
+}
+
+// resolveGateTargets determines which (step, file) pairs to validate.
+// Precedence: explicit --changes, then --bead, then auto-locate RPI outputs.
+func resolveGateTargets(cwd string) ([]gateTarget, error) {
+	if len(validateChanges) > 0 {
+		return targetsFromChanges(cwd, validateChanges), nil
+	}
+	// --bead and the auto-locate path both walk the standard RPI steps and keep
+	// whichever expected outputs exist on disk. --bead is reserved for future
+	// bead-scoped narrowing; today both resolve via the ratchet locator, which is
+	// deterministic and network-free.
+	return locateRPITargets(cwd), nil
+}
+
+// targetsFromChanges maps explicit files onto inferred steps.
+func targetsFromChanges(cwd string, files []string) []gateTarget {
+	targets := make([]gateTarget, 0, len(files))
+	for _, f := range files {
+		targets = append(targets, gateTarget{step: inferStepForPath(cwd, f), path: f})
+	}
+	return targets
+}
+
+// locateRPITargets finds the expected RPI artifacts that exist on disk.
+func locateRPITargets(cwd string) []gateTarget {
+	locator, _ := ratchet.NewLocator(cwd)
+	var targets []gateTarget
+	for _, step := range ratchet.AllSteps() {
+		pattern := ratchet.GetExpectedOutput(step)
+		if strings.HasPrefix(pattern, "epic:") || strings.HasPrefix(pattern, "issue:") {
+			continue
+		}
+		if path, _, err := locator.FindFirst(pattern); err == nil {
+			targets = append(targets, gateTarget{step: step, path: path})
+		}
+	}
+	return targets
+}
+
+// inferStepForPath picks the ratchet step whose expected-output pattern best
+// matches a given path; falls back to the research step.
+func inferStepForPath(cwd, path string) ratchet.Step {
+	locator, _ := ratchet.NewLocator(cwd)
+	for _, step := range ratchet.AllSteps() {
+		pattern := ratchet.GetExpectedOutput(step)
+		if strings.HasPrefix(pattern, "epic:") || strings.HasPrefix(pattern, "issue:") {
+			continue
+		}
+		if found, _, err := locator.FindFirst(pattern); err == nil && found == path {
+			return step
+		}
+	}
+	return ratchet.StepResearch
+}
+
+// runGateValidation validates each target and aggregates to a single verdict.
+func runGateValidation(validator *ratchet.Validator, targets []gateTarget) validateGateResult {
+	opts := buildGateValidateOptions()
+	// Non-nil slices so --json emits [] not null for a clean machine contract.
+	issues := []string{}
+	warnings := []string{}
+	hasFail := false
+
+	for _, t := range targets {
+		res, err := validator.ValidateWithOptions(t.step, t.path, opts)
+		if err != nil {
+			hasFail = true
+			issues = append(issues, fmt.Sprintf("%s: validate error: %v", t.path, err))
+			continue
+		}
+		if !res.Valid {
+			hasFail = true
+		}
+		for _, i := range res.Issues {
+			issues = append(issues, t.path+": "+i)
+		}
+		for _, w := range res.Warnings {
+			warnings = append(warnings, t.path+": "+w)
+		}
+	}
+
+	v := aggregateVerdict(hasFail, len(warnings) > 0)
+	return validateGateResult{
+		Verdict:  v,
+		Issues:   issues,
+		Warnings: warnings,
+		GateExit: gateExitForVerdict(v, validateStrict || validateWarnAsFail),
+	}
+}
+
+// aggregateVerdict maps (hasFail, hasWarn) onto the PASS/WARN/FAIL vocabulary.
+func aggregateVerdict(hasFail, hasWarn bool) verdict {
+	switch {
+	case hasFail:
+		return verdictFail
+	case hasWarn:
+		return verdictWarn
+	default:
+		return verdictPass
+	}
+}
+
+// gateExitForVerdict maps a verdict onto a gate exit code. In strict mode WARN
+// is promoted to FAIL (exit 1).
+func gateExitForVerdict(v verdict, strict bool) int {
+	switch v {
+	case verdictFail:
+		return gateExitFail
+	case verdictWarn:
+		if strict {
+			return gateExitFail
+		}
+		return gateExitPass
+	default: // PASS
+		return gateExitPass
+	}
+}
+
+// buildGateValidateOptions builds ratchet options from the validate flags.
+func buildGateValidateOptions() *ratchet.ValidateOptions {
+	opts := &ratchet.ValidateOptions{Lenient: validateLenient}
+	if validateLenient && validateLenientExpiry > 0 {
+		t := time.Now().AddDate(0, 0, validateLenientExpiry)
+		opts.LenientExpiryDate = &t
+	}
+	return opts
+}
+
+// emitGateResult writes output and, in --gate mode, returns a gateExitError so
+// the exit code carries the verdict.
+func emitGateResult(cmd *cobra.Command, result validateGateResult) error {
+	wantJSON := validateJSONOut || GetOutput() == "json"
+	if wantJSON {
+		writeGateJSON(cmd.OutOrStdout(), result)
+	} else if validateGate {
+		writeGateTerse(cmd, result)
+	} else {
+		writeGateReport(cmd.OutOrStdout(), result)
+	}
+
+	if validateGate && result.GateExit != gateExitPass {
+		return &gateExitError{code: result.GateExit, msg: ""}
+	}
+	return nil
+}
+
+// writeGateJSON emits the structured verdict.
+func writeGateJSON(w io.Writer, result validateGateResult) {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(result)
+}
+
+// writeGateTerse emits one verdict line to stdout, detail to stderr (--gate text).
+func writeGateTerse(cmd *cobra.Command, result validateGateResult) {
+	fmt.Fprintln(cmd.OutOrStdout(), string(result.Verdict))
+	writeGateDetail(cmd.ErrOrStderr(), result)
+}
+
+// writeGateReport emits the human verdict report (default, non-gate text mode).
+func writeGateReport(w io.Writer, result validateGateResult) {
+	fmt.Fprintf(w, "Verdict: %s\n", result.Verdict)
+	writeGateDetail(w, result)
+}
+
+// writeGateDetail prints the issues/warnings blocks.
+func writeGateDetail(w io.Writer, result validateGateResult) {
+	formatStringList(w, "Issues", result.Issues)
+	formatStringList(w, "Warnings", result.Warnings)
+}

--- a/cli/cmd/ao/validate_test.go
+++ b/cli/cmd/ao/validate_test.go
@@ -1,0 +1,280 @@
+// practices: [continuous-delivery, dora-metrics]
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// --- L1: pure verdict + exit-code mapping ------------------------------------
+
+func TestAggregateVerdict(t *testing.T) {
+	tests := []struct {
+		name    string
+		hasFail bool
+		hasWarn bool
+		want    verdict
+	}{
+		{"clean is PASS", false, false, verdictPass},
+		{"warnings only is WARN", false, true, verdictWarn},
+		{"failure is FAIL", true, false, verdictFail},
+		{"failure dominates warnings", true, true, verdictFail},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := aggregateVerdict(tt.hasFail, tt.hasWarn); got != tt.want {
+				t.Errorf("aggregateVerdict(%v,%v) = %q, want %q", tt.hasFail, tt.hasWarn, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGateExitForVerdict(t *testing.T) {
+	tests := []struct {
+		name   string
+		v      verdict
+		strict bool
+		want   int
+	}{
+		{"PASS -> 0", verdictPass, false, gateExitPass},
+		{"PASS strict -> 0", verdictPass, true, gateExitPass},
+		{"WARN -> 0", verdictWarn, false, gateExitPass},
+		{"WARN strict -> 1", verdictWarn, true, gateExitFail},
+		{"FAIL -> 1", verdictFail, false, gateExitFail},
+		{"FAIL strict -> 1", verdictFail, true, gateExitFail},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gateExitForVerdict(tt.v, tt.strict); got != tt.want {
+				t.Errorf("gateExitForVerdict(%q, strict=%v) = %d, want %d", tt.v, tt.strict, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGateExitError_ExitCode(t *testing.T) {
+	e := &gateExitError{code: gateExitInternal, msg: "boom"}
+	if e.ExitCode() != gateExitInternal {
+		t.Errorf("ExitCode() = %d, want %d", e.ExitCode(), gateExitInternal)
+	}
+	if e.Error() != "boom" {
+		t.Errorf("Error() = %q, want %q", e.Error(), "boom")
+	}
+}
+
+// --- L2: full command via runValidate over real artifacts --------------------
+
+// gateTestHarness resets the validate flags and points the validator at a temp
+// dir with the given artifact. Returns a configured cobra command + buffers.
+func gateTestHarness(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+
+	// Reset all package-level validate flags between cases.
+	validateGate = true
+	validateBead = ""
+	validateChanges = nil
+	validateStrict = false
+	validateWarnAsFail = false
+	validateJSONOut = false
+	validateLenient = false
+	validateLenientExpiry = 90
+	t.Cleanup(func() {
+		validateGate = false
+		validateChanges = nil
+		validateStrict = false
+		validateJSONOut = false
+		output = "table"
+	})
+
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	return cmd, &stdout, &stderr, tmp
+}
+
+// writeArtifact creates a file under the temp dir, returning its relative path.
+func writeArtifact(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return name
+}
+
+const passArtifact = `---
+schema_version: 1
+---
+# Research: composed gate
+
+## Summary
+A deterministic validation gate composed from the existing ratchet validator.
+
+## Key Findings
+The investigation surfaced concrete, repository-grounded findings cross-checked
+against the existing implementation so the conclusions hold across the surfaces
+that matter for downstream consumers and for the validation gate itself.
+
+## Recommendations
+Proceed with the composed-validator approach: it reuses the ratchet validator,
+confines the new logic to verdict aggregation and exit-code mapping, and stays
+well under the cyclomatic complexity budget while remaining fully deterministic.
+The gate performs no network calls and invokes no language model, which makes it
+safe to run inside the GC check retry loop, inside continuous integration, and
+inside the internal validate phase of the ao rpi loop without any flakiness or
+external dependency. Each validated artifact contributes its issues and warnings
+to a single aggregated verdict, and that verdict is mapped deterministically onto
+the process exit code so that any orchestrator can branch on the exit status.
+
+## Sources
+- cli/internal/ratchet/validate.go
+- cli/cmd/ao/ratchet_validate.go
+`
+
+// warnArtifact has schema_version (so it validates) but is short and missing
+// recommended sections -> warnings, no hard issues.
+const warnArtifact = `---
+schema_version: 1
+---
+# Research: thin
+
+## Summary
+Short.
+`
+
+// failArtifact lacks schema_version -> strict-mode hard issue -> Valid=false.
+const failArtifact = `no frontmatter, no schema_version, no sections
+`
+
+func assertGateExit(t *testing.T, err error, want int) {
+	t.Helper()
+	if want == gateExitPass {
+		if err != nil {
+			t.Fatalf("expected nil error (exit 0), got %v", err)
+		}
+		return
+	}
+	var ge *gateExitError
+	if !errors.As(err, &ge) {
+		t.Fatalf("expected *gateExitError, got %T: %v", err, err)
+	}
+	if ge.ExitCode() != want {
+		t.Errorf("gate exit = %d, want %d", ge.ExitCode(), want)
+	}
+}
+
+func TestRunValidate_PassExits0(t *testing.T) {
+	cmd, stdout, _, dir := gateTestHarness(t)
+	validateChanges = []string{writeArtifact(t, dir, "research.md", passArtifact)}
+
+	err := runValidate(cmd, nil)
+	assertGateExit(t, err, gateExitPass)
+	if got := stdout.String(); got != "PASS\n" {
+		t.Errorf("stdout = %q, want %q", got, "PASS\n")
+	}
+}
+
+func TestRunValidate_WarnExits0(t *testing.T) {
+	cmd, stdout, _, dir := gateTestHarness(t)
+	validateChanges = []string{writeArtifact(t, dir, "research.md", warnArtifact)}
+
+	err := runValidate(cmd, nil)
+	assertGateExit(t, err, gateExitPass)
+	if got := stdout.String(); got != "WARN\n" {
+		t.Errorf("stdout = %q, want %q", got, "WARN\n")
+	}
+}
+
+func TestRunValidate_StrictFlipsWarnToFail(t *testing.T) {
+	cmd, _, _, dir := gateTestHarness(t)
+	validateChanges = []string{writeArtifact(t, dir, "research.md", warnArtifact)}
+	validateStrict = true
+
+	err := runValidate(cmd, nil)
+	assertGateExit(t, err, gateExitFail)
+}
+
+func TestRunValidate_WarnAsFailAlias(t *testing.T) {
+	cmd, _, _, dir := gateTestHarness(t)
+	validateChanges = []string{writeArtifact(t, dir, "research.md", warnArtifact)}
+	validateWarnAsFail = true
+
+	err := runValidate(cmd, nil)
+	assertGateExit(t, err, gateExitFail)
+}
+
+func TestRunValidate_FailExits1(t *testing.T) {
+	cmd, stdout, _, dir := gateTestHarness(t)
+	validateChanges = []string{writeArtifact(t, dir, "plan.md", failArtifact)}
+
+	err := runValidate(cmd, nil)
+	assertGateExit(t, err, gateExitFail)
+	if got := stdout.String(); got != "FAIL\n" {
+		t.Errorf("stdout = %q, want %q", got, "FAIL\n")
+	}
+}
+
+func TestRunValidate_NoTargetsExits2(t *testing.T) {
+	cmd, _, _, _ := gateTestHarness(t)
+	// No --changes, empty temp dir -> nothing to validate -> internal error.
+
+	err := runValidate(cmd, nil)
+	assertGateExit(t, err, gateExitInternal)
+}
+
+func TestRunValidate_JSONOutputContract(t *testing.T) {
+	cmd, stdout, _, dir := gateTestHarness(t)
+	validateChanges = []string{writeArtifact(t, dir, "plan.md", failArtifact)}
+	validateJSONOut = true
+
+	err := runValidate(cmd, nil)
+	assertGateExit(t, err, gateExitFail)
+
+	var got validateGateResult
+	if e := json.Unmarshal(stdout.Bytes(), &got); e != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", e, stdout.String())
+	}
+	if got.Verdict != verdictFail {
+		t.Errorf("verdict = %q, want %q", got.Verdict, verdictFail)
+	}
+	if got.GateExit != gateExitFail {
+		t.Errorf("gate_exit = %d, want %d", got.GateExit, gateExitFail)
+	}
+	if len(got.Issues) == 0 {
+		t.Error("expected issues in FAIL JSON, got none")
+	}
+}
+
+func TestRunValidate_DefaultModeNoGateNoExitError(t *testing.T) {
+	cmd, stdout, _, dir := gateTestHarness(t)
+	validateGate = false // default (report) mode
+	validateChanges = []string{writeArtifact(t, dir, "plan.md", failArtifact)}
+
+	// Default mode prints the verdict but never carries it in the exit code.
+	err := runValidate(cmd, nil)
+	if err != nil {
+		t.Fatalf("default mode should not return a gate error, got %v", err)
+	}
+	if got := stdout.String(); got == "" || got[:8] != "Verdict:" {
+		t.Errorf("default report should start with 'Verdict:', got %q", got)
+	}
+}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -2769,6 +2769,30 @@ ao session close [flags]
 
 ---
 
+### `ao validate`
+
+Run a deterministic validation gate over RPI artifacts and emit a single
+
+```
+ao validate [flags]
+```
+
+**Flags:**
+
+```
+      --bead string          Validate artifacts bound to a bead id
+      --changes strings      Explicit files to validate
+      --gate                 Exit-code mode: 0=PASS/WARN, 1=FAIL, 2=error
+  -h, --help                 help for validate
+      --json                 Structured verdict (honored in both modes)
+      --lenient              Allow legacy artifacts without schema_version
+      --lenient-expiry int   Days until lenient bypass expires (default 90)
+      --strict               Promote WARN to FAIL (exit 1)
+      --warn-as-fail         Alias for --strict
+```
+
+---
+
 ### `ao completion`
 
 Generate shell completion scripts for ao.

--- a/docs/cli-skills-map.md
+++ b/docs/cli-skills-map.md
@@ -2,7 +2,7 @@
 
 > Which `ao` commands are called by which skills and hooks — and vice versa.
 
-Auto-audited 2026-04-24; targeted runtime-proof update 2026-04-28. 68 generated CLI command headings, 69 source skills, 12 runtime hook event sections.
+Auto-audited 2026-04-24; targeted runtime-proof update 2026-04-28. 69 generated CLI command headings, 69 source skills, 12 runtime hook event sections.
 
 Source-of-truth note: `hooks/hooks.json` currently declares the full Claude runtime event surface. `hooks/codex-hooks.json` declares the Codex-native subset that runtime can support.
 

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=68 sub=179 all=247"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=69 sub=179 all=248"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,4} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "68" || "$sub_count" != "179" || "$all_count" != "247" ]]; then
+if [[ "$top_count" != "69" || "$sub_count" != "179" || "$all_count" != "248" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 247 ]]; then
+if [[ "${#commands[@]}" -ne 248 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/registry.json
+++ b/registry.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-24T18:01:28Z",
+  "generated_at": "2026-05-24T19:34:35Z",
   "summary": {
     "skills": 80,
     "hooks": 0,
     "knowledge_stores": 5,
     "job_types": 14,
     "eval_files": 56,
-    "cli_commands": 165
+    "cli_commands": 166
   },
   "surfaces": {
     "skills": [
@@ -1477,6 +1477,10 @@
       {
         "name": "trace",
         "path": "cli/cmd/ao/trace.go"
+      },
+      {
+        "name": "validate",
+        "path": "cli/cmd/ao/validate.go"
       },
       {
         "name": "version",

--- a/scripts/release-smoke-test.sh
+++ b/scripts/release-smoke-test.sh
@@ -505,6 +505,7 @@ test_help "ao memory --help" "$AO" memory --help
 test_help "ao notebook --help" "$AO" notebook --help
 test_help "ao trace --help" "$AO" trace --help
 test_help "ao findings --help" "$AO" findings --help
+test_help "ao validate --help" "$AO" validate --help
 
 # ═══════════════════════════════════════════════════════
 #  Flag Testing (verify key flags produce valid output)
@@ -582,7 +583,7 @@ EXPECTED_COMMANDS=(
     config hooks memory notebook
     demo init seed quick-start
     badge constraint contradict dedup curate
-    anti-patterns vibe-check extract
+    anti-patterns vibe-check extract validate
 )
 
 for cmd in "${EXPECTED_COMMANDS[@]}"; do


### PR DESCRIPTION
## What

New top-level `ao validate` umbrella command with `--gate` (exit-code-as-verdict) mode. This is the dependency the GC reference City needs — GC's `check={max_attempts}` retry, CI steps, and `ao rpi`'s internal validate phase can run one command and branch on the exit code.

Spec: `.agents/discovery/2026-05-24-gvkj6-finalize-runbook.md` ("`ao validate --gate` — SPEC" section).

## Exit-code contract (`--gate`)

| Code | Meaning |
|---|---|
| `0` | PASS or WARN (gate passes) |
| `1` | FAIL (gate fails) |
| `2` | internal/setup error (distinct so a broken gate is never read as a clean pass) |

- WARN exits `0` by default (advisory); `--strict` / `--warn-as-fail` promotes WARN → exit `1`.
- Deterministic: **no network, no LLM**. Safe for GC `check.max_attempts`, CI, and `ao rpi`.
- `--json` emits `{"verdict","issues","warnings","gate_exit"}` in both modes.

## How (composed, not reinvented)

Reuses the existing `ratchet.Validator` (`ValidateWithOptions`) over the resolved file set (`--changes`, `--bead`, or auto-located RPI outputs); aggregates each result's `Valid`/`Issues`/`Warnings` into a single PASS/WARN/FAIL verdict; maps verdict → exit code via a `gateExitError` typed error caught in `Execute()` (same pattern as `doctorExitError`/`AgentsLintError`). The existing `ao ratchet/scenario/goals validate` sub-surfaces are untouched. New logic is just the aggregation + mapping (well under the complexity budget).

## Residue handled (command-surface +1)

- Regenerated `cli/docs/COMMANDS.md`, `registry.json` (166 commands), `docs/cli-skills-map.md`.
- Bumped `cli-command-surface` canary (`cli-command-surface-matrix.json`) + smoke fixture heading counts: top 68→69, all 247→248 (sub unchanged — flat command).
- Added `validate` to release-smoke `EXPECTED_COMMANDS` + a `test_help "ao validate --help"` line.
- Registered `validate` in `cobra_commands_test.go` `expectedCmds` (both lists).

## Tests

L1 (`aggregateVerdict`, `gateExitForVerdict`, `gateExitError`) + L2 (full `runValidate` over real temp-dir artifacts) asserting exact exit codes: PASS=0, WARN=0, WARN+`--strict`=1, FAIL=1, internal=2, and the `--json` contract.

## Verified green

`gofmt` clean · `go build`/`go vet`/`go test ./cmd/ao ./internal/ratchet` · manual exit-code check (0/1/2) · `release-smoke-test.sh` (0 failed) · `test-json-flag-consistency.sh` (0 errors) · `validate-cli-skills-map.sh` (PASS) · `cli-command-surface` canary (failures=0) · `regen-codex-hashes.sh --check` clean · `validate-ci-policy-parity.sh` PASS.

Closes-scenario: soc-ba1un#ao-validate-gate
Bounded-context: BC4-Evidence
Evidence: .agents/discovery/2026-05-24-gvkj6-finalize-runbook.md