### PR TITLE
feat(skills): wrap idea-wizard generate-winnow into /brainstorm + /discovery (ag-yw0)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-24T21:21:05Z",
+  "generated_at": "2026-05-24T22:58:57Z",
   "summary": {
     "skills": 80,
     "hooks": 0,
@@ -145,7 +145,7 @@
         "path": "skills/brainstorm/",
         "has_skill_md": true,
         "has_references": true,
-        "reference_count": 1
+        "reference_count": 4
       },
       {
         "name": "bug-hunt",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -697,8 +697,8 @@
     {
       "name": "brainstorm",
       "source_skill": "skills/brainstorm",
-      "source_hash": "009cb68fb190eb1575a4f58267e82deafa16cb93909a6c878d04c979af79f50e",
-      "generated_hash": "feeffc5414cb28ad45c1e0ff182be1e96a65cbc134de889d2fcff5045658454e"
+      "source_hash": "19af5b72dc69e8dfefb83e19983dbe863ba999166e917fa852addf1ca5a293d6",
+      "generated_hash": "d8a1a648f987d6ac2b14c992aca7f166cdc5994676ef1b7c10ecc68fe0753d5c"
     },
     {
       "name": "bug-hunt",
@@ -763,8 +763,8 @@
     {
       "name": "discovery",
       "source_skill": "skills/discovery",
-      "source_hash": "daf64b6c71cd257f4211fa55f699225b3f9e3a2ee6e545ccaa46f52981d39053",
-      "generated_hash": "b8cfabc0511ff22e356756ec32257d760d7aa26326a0eb5eb23f21b2cdac11ab"
+      "source_hash": "dee7a65b6457abe66c3a7397b140827ed3ec65c00da03aa6f486b50fbb34fae2",
+      "generated_hash": "6c307529f6519b93745a4f410641b4991c0676a5f564de7f2b53d8d9cffe6b48"
     },
     {
       "name": "doc",

--- a/skills-codex/brainstorm/.agentops-generated.json
+++ b/skills-codex/brainstorm/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/brainstorm",
   "layout": "modular",
-  "source_hash": "009cb68fb190eb1575a4f58267e82deafa16cb93909a6c878d04c979af79f50e",
-  "generated_hash": "feeffc5414cb28ad45c1e0ff182be1e96a65cbc134de889d2fcff5045658454e"
+  "source_hash": "19af5b72dc69e8dfefb83e19983dbe863ba999166e917fa852addf1ca5a293d6",
+  "generated_hash": "d8a1a648f987d6ac2b14c992aca7f166cdc5994676ef1b7c10ecc68fe0753d5c"
 }

--- a/skills-codex/brainstorm/SKILL.md
+++ b/skills-codex/brainstorm/SKILL.md
@@ -6,7 +6,16 @@ description: 'Separate goals from implementation.'
 
 > **Purpose:** Separate WHAT from HOW. Explore the problem space before committing to a solution.
 
-Four phases:
+## Two modes
+
+`$brainstorm` runs in one of two modes (complementary, not exclusive):
+
+| Mode | Use when | Shape |
+|------|----------|-------|
+| **Goal-clarification** (default; the four phases below) | The goal names ONE specific capability (`"add JWT auth"`, `"fix the login bug"`) | Sharpen the WHAT, explore the HOW for that single goal. |
+| **Ideation** (open-ended; see below) | The goal is open-ended (`"improve the project"`, `"what should we build next"`) OR Phase 1 returns `exploring` with no single goal OR `--ideate` is passed | Generate MANY candidate improvements, winnow ruthlessly, operationalize the survivors. |
+
+Four phases (goal-clarification mode):
 1. **Assess clarity** — Is the goal specific enough?
 2. **Understand idea** — What problem, who benefits, what exists?
 3. **Explore approaches** — Generate options, compare tradeoffs
@@ -114,6 +123,43 @@ date: YYYY-MM-DD
 All five sections must be populated. The "Next Step" section should contain a concrete `$plan` invocation suggestion with the selected approach as context.
 
 Create the `.agents/brainstorm/` directory if it does not exist.
+
+---
+
+## Ideation Mode (open-ended generate-winnow)
+
+> **Additive to the four-phase flow above — it does not replace it.** Ideation mode is for "improve the project"-style goals where the WHAT is unknown and you must generate a portfolio and select, rather than clarify ONE known goal.
+
+**Trigger:** the `exploring` clarity path (Phase 1) when no single goal emerges, OR an explicit `--ideate` flag, OR an open-ended goal string.
+
+The methodology is **generate → winnow → expand → operationalize → refine**. Steps 1-3 belong to `$brainstorm`; steps 4-5 are handed to `$discovery` on its open-ended path.
+
+### Step 1 — Ground in reality
+
+```bash
+cat AGENTS.md                      # or CLAUDE.md — rules, constraints, non-goals
+bd list --json                     # open work — don't duplicate
+bd list --status closed --json     # closed work — don't re-propose cut ideas
+bd ready --json                    # what is actionable now
+```
+
+### Step 2 — Generate 30, winnow to 5 (ranked, with rationale)
+
+Generate **30** candidate improvements (criteria = the rubric dimensions: robust, reliable, performant, intuitive, user-friendly, ergonomic, useful, compelling, while staying obviously **accretive** and **pragmatic**). Think each one through: **how it works**, **how users perceive it**, **how we implement it**. Then **winnow ruthlessly to the VERY best 5**, presented **ranked best-to-worst** with full rationale and rubric scores. Stress-test survivors with the red team questions (Phase 3b). Do NOT stop at the first 5 — generate the full 30 first.
+
+### Step 3 — Expand with the next 10 (→ 15)
+
+Generate the **next best 10** (each with rationale) for a ranked portfolio of **15** — #6-15 are often complementary to the top 5.
+
+### Steps 4-5 — Operationalize + refine (handed to `$discovery`)
+
+Carry the ranked 15 (with how/perceive/implement notes + rubric scores + red-team findings) forward. `$discovery` operationalizes them into self-documenting `bd` beads (deps + explicit test tasks) and refines 4-5x in plan space.
+
+### Output
+
+Standalone (`$brainstorm --ideate`): write the ranked portfolio to `.agents/brainstorm/YYYY-MM-DD-<slug>-ideation.md`. Invoked by `$discovery`: return the ranked portfolio inline for the operationalize step.
+
+> **Tracking is `bd`, never `br`/`bv`** — this is AgentOps.
 
 ---
 

--- a/skills-codex/discovery/.agentops-generated.json
+++ b/skills-codex/discovery/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/discovery",
   "layout": "modular",
-  "source_hash": "daf64b6c71cd257f4211fa55f699225b3f9e3a2ee6e545ccaa46f52981d39053",
-  "generated_hash": "b8cfabc0511ff22e356756ec32257d760d7aa26326a0eb5eb23f21b2cdac11ab"
+  "source_hash": "dee7a65b6457abe66c3a7397b140827ed3ec65c00da03aa6f486b50fbb34fae2",
+  "generated_hash": "6c307529f6519b93745a4f410641b4991c0676a5f564de7f2b53d8d9cffe6b48"
 }

--- a/skills-codex/discovery/SKILL.md
+++ b/skills-codex/discovery/SKILL.md
@@ -76,6 +76,19 @@ Feature: Discovery hands dense intent to planning
     And it does not inline the Plan decomposition in Discovery prose
 ```
 
+## Open-Ended Path (generate-winnow → operationalize → refine)
+
+> **Additive to the default flow — it does not replace the strict-delegation contract or the artifact-first DAG.** This path activates for open-ended "improve the project"-style goals (`"improve the project"`, `"what should we build next"`, `"make X more robust"`) OR when `--ideate` is passed. For a specific goal, the default flow (brainstorm-clarify → research → plan → pre-mortem) is unchanged.
+
+On the open-ended path, Discovery prepends the generate-winnow methodology before research/plan and adds two steps after planning:
+
+1. **Ideate (delegate to `$brainstorm --ideate`).** Invoke `$brainstorm` in **ideation mode** as a separate skill invocation — strict delegation still applies; do NOT inline the 30-idea generation. It returns a ranked portfolio of **15** ideas (top 5 + next 10) with how/perceive/implement notes, rubric scores, and red-team findings.
+2. **Research + Plan + Pre-mortem.** Run the normal artifact-first DAG over the selected portfolio, scoped to the winnowed ideas rather than a single goal.
+3. **Operationalize.** Turn the ranked portfolio into a comprehensive, granular set of **self-documenting `bd` beads** — tasks, subtasks, dependency structure (`bd dep add`), and **explicit test tasks** (unit + e2e with detailed logging). Each bead carries what/why/how/risks/success so the original plan markdown never needs to be consulted again. Overlap-check against existing beads (`bd list --json`) before creating — merge, don't duplicate.
+4. **Refine in plan space (4-5 passes).** Before handing the packet to `$crank`, run **4-5 refinement passes** over the bead set. Each pass: **re-read AGENTS.md** (especially after compaction), check every bead for sense and optimality, and **DO NOT OVERSIMPLIFY / DO NOT LOSE FEATURES OR FUNCTIONALITY**. Validate between passes (no dependency cycles; every leaf actionable via `bd ready`).
+
+> Tracking is **`bd`**, never `br`/`bv` — this is AgentOps.
+
 ## Execution
 
 Run the artifact-first DAG in [references/dag.md](references/dag.md). That
@@ -89,6 +102,7 @@ and the acceptance-criteria YAML contract.
 | `--auto` | on | Fully autonomous; inverse of `--interactive`. Passed through to `$research` and `$plan`. |
 | `--interactive` | off | Human gates in research and plan. Does not affect pre-mortem. |
 | `--skip-brainstorm` | auto | Skip brainstorm when the goal is already specific. |
+| `--ideate` | auto | Force the open-ended generate-winnow path: delegate to `$brainstorm --ideate` (30→5→15), then operationalize into self-documenting `bd` beads and refine 4-5x in plan space. Auto-on for open-ended goals. |
 | `--complexity=<level>` | auto | Force `fast`, `standard`, or `full`. |
 | `--no-budget` | off | Disable phase time budgets. |
 | `--no-scaffold` | off | Skip scaffold auto-invocation. |

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -37,7 +37,18 @@ output_contract: skills/research/schemas/findings.json
 
 Upstream of move **1 (shape intent as BDD)** of the [operating loop](../../docs/architecture/operating-loop.md). Consumes a free-text goal; produces Given/When/Then-shaped acceptance examples that `/discovery` can fold into a [BDD intent issue](../../docs/templates/intent-issue.md). The Capture step (phase 4 below) is not complete until at least one happy path and one critical edge are written as testable Gherkin — "it should work" is not a captured example.
 
-Four phases:
+## Two modes
+
+`/brainstorm` runs in one of two modes. They are complementary, not exclusive — a session may start in ideation mode, pick one idea, and hand it to goal-clarification for HOW-exploration.
+
+| Mode | Use when | Shape |
+|------|----------|-------|
+| **Goal-clarification** (default; the four phases below) | The goal names ONE specific capability (`"add JWT auth"`, `"fix the login bug"`) | Sharpen the WHAT, explore the HOW for that single goal. |
+| **Ideation** (open-ended; see [Ideation Mode](#ideation-mode-open-ended-generate-winnow)) | The goal is open-ended (`"improve the project"`, `"what should we build next"`) OR Phase 1 returns `exploring` with no single goal emerging OR `--ideate` is passed | Generate MANY candidate improvements, winnow ruthlessly, operationalize the survivors. |
+
+The full mode-selection table lives in [references/ideation-mode.md](references/ideation-mode.md).
+
+Four phases (goal-clarification mode):
 1. **Assess clarity** — Is the goal specific enough?
 2. **Understand idea** — What problem, who benefits, what exists?
 3. **Explore approaches** — Generate options, compare tradeoffs, adversarial critique
@@ -132,6 +143,45 @@ Create the `.agents/brainstorm/` directory if it does not exist.
 
 ---
 
+## Ideation Mode (open-ended generate-winnow)
+
+> **Additive to the four-phase flow above — it does not replace it.** Ideation mode is for "improve the project"-style goals where the WHAT is unknown and you must generate a portfolio and select, rather than clarify ONE known goal. Full detail: [references/ideation-mode.md](references/ideation-mode.md).
+
+**Trigger:** the `exploring` clarity path (Phase 1) when no single goal emerges after follow-up, OR an explicit `--ideate` flag, OR an open-ended goal string (`"improve the project"`, `"what should we build next"`, `"make X more robust"`).
+
+The methodology is **generate → winnow → expand → operationalize → refine**. Steps 1-3 belong to `/brainstorm`; steps 4-5 are handed to `/discovery` on its open-ended path (see [references/bead-operationalization.md](references/bead-operationalization.md)).
+
+### Step 1 — Ground in reality
+
+Read project state so ideas align and don't duplicate work:
+
+```bash
+cat AGENTS.md                      # or CLAUDE.md — rules, constraints, non-goals
+bd list --json                     # open work — don't duplicate
+bd list --status closed --json     # closed work — don't re-propose cut ideas
+bd ready --json                    # what is actionable now
+```
+
+### Step 2 — Generate 30, winnow to 5 (ranked, with rationale)
+
+Generate **30** candidate improvements (criteria = the rubric dimensions: robust, reliable, performant, intuitive, user-friendly, ergonomic, useful, compelling, while staying obviously **accretive** and **pragmatic**). Think each one through: **how it works**, **how users perceive it**, **how we implement it**. Then **winnow ruthlessly to the VERY best 5**, presented **ranked best-to-worst** with full rationale and rubric scores. Apply the winnowing rounds and scoring from [references/idea-rubric.md](references/idea-rubric.md), and stress-test survivors with [references/red-team-checklist.md](references/red-team-checklist.md). Do NOT stop at the first 5 you think of — generate the full 30 first.
+
+### Step 3 — Expand with the next 10 (→ 15)
+
+Generate the **next best 10** (each with rationale) for a ranked portfolio of **15** — #6-15 are often complementary to the top 5.
+
+### Steps 4-5 — Operationalize + refine (handed to `/discovery`)
+
+Carry the ranked 15 (with how/perceive/implement notes + rubric scores + red-team findings) forward. `/discovery` operationalizes them into self-documenting `bd` beads (deps + explicit test tasks) and refines 4-5x in plan space. See [references/bead-operationalization.md](references/bead-operationalization.md).
+
+### Output
+
+Standalone (`/brainstorm --ideate`): write the ranked portfolio to `.agents/brainstorm/YYYY-MM-DD-<slug>-ideation.md` (template in [references/ideation-mode.md](references/ideation-mode.md)). Invoked by `/discovery`: return the ranked portfolio inline for the operationalize step.
+
+> **Tracking is `bd`, never `br`/`bv`** — this is AgentOps.
+
+---
+
 ## Termination
 
 Phase 4 output written = done. No further phases, no loops.
@@ -195,3 +245,9 @@ Phase 4: Writes .agents/brainstorm/2026-02-17-search-performance.md
 - [references/brainstorm.feature](references/brainstorm.feature) — Executable spec: WHAT-not-HOW 4-phase clarification, options+tradeoffs, capture Gherkin (happy + edge) for /plan (soc-qk4b)
 
 - [references/red-team-checklist.md](references/red-team-checklist.md) — Adversarial critique template for Phase 3b
+
+- [references/ideation-mode.md](references/ideation-mode.md) — Open-ended generate-winnow methodology: mode-selection table, generate-30 → winnow-5 → expand-15, output template (ag-yw0)
+
+- [references/idea-rubric.md](references/idea-rubric.md) — Ten-dimension evaluation rubric (robust/reliable/performant/intuitive/user-friendly/ergonomic/useful/compelling/accretive/pragmatic) + winnowing rounds (ag-yw0)
+
+- [references/bead-operationalization.md](references/bead-operationalization.md) — Operationalize the ranked portfolio into self-documenting `bd` beads (deps + test tasks) and refine 4-5x in plan space (ag-yw0)

--- a/skills/brainstorm/references/bead-operationalization.md
+++ b/skills/brainstorm/references/bead-operationalization.md
@@ -1,0 +1,153 @@
+# Operationalizing Ideas Into Self-Documenting Beads
+
+> The fourth and fifth steps of the generate-winnow methodology
+> (`ideation-mode.md`): turn a ranked portfolio of ideas into a comprehensive,
+> granular, self-documenting set of `bd` beads, then refine them 4-5x in "plan
+> space" before any implementation begins.
+>
+> This is primarily a `/discovery` responsibility on the open-ended path, but it
+> consumes ideation-mode output and uses the same `bd`-only discipline.
+>
+> **Tracking is `bd` (beads).** This is AgentOps — do NOT use `br`/`bv`.
+
+## Step 4 — Comprehensive bead creation
+
+Take ALL of the ranked ideas (top 5 + next 10 = 15) and elaborate them into a
+comprehensive, granular set of beads with tasks, subtasks, and a dependency
+structure overlaid. The beads must be **self-documenting**: so detailed that the
+original markdown plan never needs to be consulted again.
+
+Each bead's description should answer, for our "future self":
+
+1. **What** — What specifically needs to be done?
+2. **Why** — Why it matters; how it serves the project's overarching goals.
+3. **How** — Key implementation approach.
+4. **Risks** — What could go wrong (carry the red-team findings forward).
+5. **Success criteria** — How we know it's done.
+
+Include relevant background, reasoning/justification, and considerations — the
+goals, intentions, and thought process that produced the idea.
+
+### Bead structure
+
+```bash
+bd create "Epic: <Feature Name>" -p 1 -t epic --description "
+## Background
+[Why this feature matters; which ideation idea(s) it came from]
+
+## Goals
+- [Goal 1]
+- [Goal 2]
+
+## Non-Goals
+- [What we are explicitly NOT doing]
+
+## Considerations
+[Technical constraints, user expectations, rubric scores, red-team findings]
+"
+```
+
+### Subtask + dependency pattern
+
+```bash
+# Create the epic, then tasks under it
+bd create "Design <component> interface" -p 1 -t task --description "..."
+bd create "Implement <component> logic"  -p 2 -t task --description "..."
+bd create "Tests for <component>"         -p 2 -t task --description "..."
+
+# Wire dependencies (child depends on parent)
+bd dep add <impl-id> <epic-id>      # impl depends on epic
+bd dep add <test-id> <impl-id>      # tests depend on implementation
+```
+
+### Explicit test tasks (mandatory, with detailed logging)
+
+Every feature gets companion test beads — unit AND e2e — with detailed logging
+so we can confirm everything works after implementation:
+
+```bash
+bd create "Unit tests for <component>" -p 2 -t task --description "
+## Coverage Requirements
+- Core behavior
+- Error handling for invalid input
+- Edge cases (empty, unicode, concurrent)
+
+## Logging
+- Log inputs and outputs
+- Log timing for performance tracking
+"
+
+bd create "E2E tests for <component>" -p 2 -t task --description "
+## Scenarios
+- Happy path
+- Error path
+- Integration with existing surfaces
+
+## Logging
+- Full command and response capture
+- Timing and resource usage
+"
+```
+
+### Overlap check before creating
+
+Compare against existing beads so ideas enhance rather than duplicate:
+
+```bash
+bd list --json | jq '.issues[]?.title'
+```
+
+| Overlap type | Action |
+|--------------|--------|
+| Direct duplicate | Skip; reference the existing bead |
+| Complementary | Merge into the existing bead |
+| Conflicts | Note explicitly; flag an architectural decision (`bd human`) |
+
+## Step 5 — Refine in plan space (4-5 passes)
+
+It is far easier and faster to operate in **plan space** before implementing.
+Run **4-5 refinement passes** over the bead set. Each pass:
+
+1. **Re-read AGENTS.md / CLAUDE.md** so the project's rules are fresh (especially
+   after any context compaction).
+2. Check every bead carefully: Does it make sense? Is it optimal? Could anything
+   change to make the system work better for users? Revise in place.
+3. **DO NOT OVERSIMPLIFY.** Resist the urge to collapse complexity — complexity
+   usually exists for a reason.
+4. **DO NOT LOSE FEATURES OR FUNCTIONALITY.** Every capability in the portfolio
+   must survive the refinement.
+5. Ensure comprehensive unit tests AND e2e test scripts with detailed logging are
+   part of the bead set.
+
+Suggested per-pass focus:
+
+| Pass | Focus |
+|------|-------|
+| 1 | Structural issues, missing tasks |
+| 2 | Dependency sanity, cycle detection |
+| 3 | Test coverage gaps |
+| 4 | Comment quality, self-documentation completeness |
+| 5 | Final optimization |
+
+### Validation between passes
+
+```bash
+bd dep cycles --json     # dependency cycles MUST be empty
+bd ready --json | jq 'length'   # confirm actionable work exists
+bd lint                  # hygiene: orphans, missing fields
+```
+
+> If `bd` lacks a direct cycle-detection subcommand in your install, inspect the
+> dependency graph with `bd dep tree <id>` and `bd blocked --json`. The
+> invariant is the same: no cycles, every leaf actionable.
+
+## Anti-patterns
+
+| Don't | Do |
+|-------|-----|
+| Single-pass beads | 4-5 passes — the first draft is never optimal |
+| Beads that need the markdown plan | Self-documenting beads — what/why/how/risks/success |
+| Omit tests | Explicit unit + e2e test beads with detailed logging |
+| Oversimplify on refinement | Preserve complexity that exists for a reason |
+| Lose features when refining | Every portfolio capability survives |
+| `br`/`bv` | `bd` — this is AgentOps |

--- a/skills/brainstorm/references/brainstorm.feature
+++ b/skills/brainstorm/references/brainstorm.feature
@@ -22,3 +22,26 @@ Feature: Brainstorm separates goals from implementation before planning
     When the capture phase completes
     Then it produces Given/When/Then acceptance examples for /plan and /discovery
     And capture is not complete until at least one happy path and one critical edge are written
+
+  # Ideation mode — open-ended generate-winnow methodology (ag-yw0). Additive to
+  # the goal-clarification flow above; documentation-only spec (this file is
+  # allowlisted in scripts/.scenario-linkage-allow). Wiring is asserted by the
+  # bats regression test tests/scripts/brainstorm-discovery-ideation.bats.
+
+  Scenario: an open-ended goal triggers ideation mode
+    Given a goal like "improve the project" or the --ideate flag or an exploring clarity path with no single goal
+    When /brainstorm runs
+    Then it enters ideation mode instead of the single-goal four-phase flow
+    And the goal-clarification four-phase flow remains available for specific goals
+
+  Scenario: ideation mode generates many and winnows ruthlessly to a ranked five
+    When ideation mode runs
+    Then it grounds in reality by reading AGENTS.md and open and closed bd beads
+    And it generates 30 candidate ideas thought through for how-it-works, user-perception, and implementation
+    And it winnows to the very best 5 ranked best-to-worst with full rationale
+    And it scores survivors against the ten-dimension rubric
+
+  Scenario: ideation mode expands the portfolio to fifteen
+    When the top 5 are selected
+    Then it generates the next best 10 with rationale for a ranked portfolio of 15
+    And it carries how-it-works, user-perception, implementation notes, and rubric scores forward to operationalize

--- a/skills/brainstorm/references/idea-rubric.md
+++ b/skills/brainstorm/references/idea-rubric.md
@@ -1,0 +1,103 @@
+# Idea Evaluation Rubric
+
+> The ten-dimension rubric for scoring and winnowing ideas in ideation mode
+> (`ideation-mode.md`). Adapted for AgentOps — tracking is `bd`, not `br`/`bv`.
+
+Ideas are evaluated on: **robust, reliable, performant, intuitive, user-friendly,
+ergonomic, useful, compelling, accretive, pragmatic.** A good idea makes the
+project obviously better while staying obviously accretive and pragmatic.
+
+## Quick Score Card
+
+Rate each idea 1-5 on each criterion:
+
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| **Robust** | Breaks on edge cases | Handles common cases | Handles all cases gracefully |
+| **Reliable** | Intermittent failures | Usually works | Always works |
+| **Performant** | Noticeably slow | Acceptable speed | Imperceptibly fast |
+| **Intuitive** | Confusing UX | Learnable | Obvious immediately |
+| **User-friendly** | Frustrating | Neutral | Delightful |
+| **Ergonomic** | Adds friction | No change | Reduces friction |
+| **Useful** | Solves nothing | Solves minor pain | Solves major pain |
+| **Compelling** | Nobody wants | Nice to have | Must have |
+| **Accretive** | Negative value | Marginal value | Clear value |
+| **Pragmatic** | Impossible | Difficult | Straightforward |
+
+**Threshold:** Ideas scoring <3 average should be cut.
+
+## Detailed Criteria
+
+### Robust
+Does it handle empty input, malformed input, unicode, concurrent access? Does it
+fail gracefully?
+
+### Reliable
+Does it work the first time and the 1000th time? Under load? Offline? Does it
+recover from errors?
+
+### Performant
+Is latency acceptable (<100ms for interactive)? Is throughput sufficient? Does it
+scale with data size and use resources efficiently?
+
+### Intuitive
+Can users predict behavior? Are defaults sensible? Is naming clear? Do errors
+explain themselves?
+
+### User-friendly
+Is the happy path smooth? Are error messages helpful? Is recovery easy? Is help
+accessible?
+
+### Ergonomic
+How many steps to accomplish the goal? How much typing? Are shortcuts available?
+Does it reduce cognitive load?
+
+### Useful
+What problem does it solve? How often does the problem occur and how painful is
+it? Does it create new problems?
+
+### Compelling
+Would users request it, switch for it, recommend it, miss it?
+
+### Accretive
+Does it add capability, reduce complexity, improve existing features, open new
+possibilities? Is the value measurable?
+
+### Pragmatic
+Is the technology mature? Is the scope clear? Are dependencies manageable? Is the
+timeline reasonable?
+
+## Winnowing Process (30 → 5)
+
+### Round 1: Hard Cuts
+Remove any idea that scores 1 on ANY criterion.
+
+### Round 2: Threshold
+Remove any idea scoring <3 average.
+
+### Round 3: Ranking
+Sort remaining by weighted average:
+
+- Useful: 2x weight
+- Pragmatic: 2x weight
+- Accretive: 1.5x weight
+- Others: 1x weight
+
+### Round 4: Synergy
+Consider which ideas complement each other. A weaker idea that enables a stronger
+idea may be worth keeping in the expanded 15.
+
+## Red Flags (immediate disqualification)
+
+- "Users will figure it out"
+- "We'll document it later"
+- "It's technically correct"
+- "Nobody does it differently"
+- "We've always done it this way"
+
+## Relationship to the red-team checklist
+
+The rubric scores how GOOD an idea is. The `red-team-checklist.md` stress-tests
+how an idea BREAKS. Run both: rubric for ranking, red team for risk
+classification. An idea that scores high on the rubric but fails 2+ red-team
+questions is HIGH RISK and needs a mitigation plan before it survives the winnow.

--- a/skills/brainstorm/references/ideation-mode.md
+++ b/skills/brainstorm/references/ideation-mode.md
@@ -1,0 +1,125 @@
+# Ideation Mode — Generate-Winnow Methodology
+
+> Open-ended idea generation for "improve the project"-style goals.
+> Distinct from the four-phase goal-clarification flow, which sharpens ONE
+> specific goal. Ideation mode generates MANY candidate improvements, winnows
+> ruthlessly, and operationalizes the survivors.
+
+## When to use which mode
+
+| Signal | Mode | Why |
+|--------|------|-----|
+| Goal names ONE specific capability ("add JWT auth", "fix the login bug") | Goal-clarification (Phases 1-4) | The WHAT is known; explore HOW. |
+| Goal is open-ended ("improve the project", "what should we build next", "make X more robust") | **Ideation mode** | The WHAT is unknown; generate a portfolio and select. |
+| `--ideate` flag is passed | **Ideation mode** | Explicit operator override. |
+| Phase 1 clarity assessment returns `exploring` AND no single goal emerges after follow-up | **Ideation mode** | The user has a direction, not a target. |
+
+The two modes share the same evaluation rubric (`idea-rubric.md`) and the same
+adversarial discipline (`red-team-checklist.md`). Ideation mode is **additive**:
+it does not replace the goal-clarification flow. A session may start in ideation
+mode, select one idea, and hand that single idea to the goal-clarification flow
+for HOW-exploration.
+
+## The methodology: generate → winnow → expand → operationalize → refine
+
+Five steps, each with an explicit artifact. The discipline is "generate many,
+keep few, document everything."
+
+### Step 1 — Ground in reality (research context)
+
+Before generating, read the project's current state so ideas align with reality
+and don't duplicate existing work.
+
+```bash
+cat AGENTS.md                # or CLAUDE.md — project rules + constraints
+bd list --json              # open work — avoid duplicating
+bd list --status closed --json   # closed work — lessons learned, don't re-propose
+bd ready --json             # what is actionable right now
+```
+
+Checklist before generating:
+
+- [ ] Read AGENTS.md / CLAUDE.md completely (constraints, non-goals, conventions)
+- [ ] Reviewed open beads (don't propose what's already tracked)
+- [ ] Reviewed closed beads (don't re-propose what was tried and cut)
+- [ ] Understand the current architecture and where the project is headed
+
+### Step 2 — Generate 30, winnow to 5 (ranked, with rationale)
+
+Generate **30** candidate ideas for improving the project. The criteria are the
+rubric dimensions: more robust, reliable, performant, intuitive, user-friendly,
+ergonomic, useful, compelling — while staying **obviously accretive and
+pragmatic**.
+
+For each of the 30, think it through carefully:
+
+1. **How it would work** — the mechanism, concretely.
+2. **How users would perceive it** — first impression, learning curve, delight.
+3. **How we would implement it** — rough approach, surfaces touched, scope.
+
+Then **winnow ruthlessly to the VERY best 5**. Apply the winnowing rounds in
+`idea-rubric.md` (hard cuts → threshold → weighted ranking → synergy).
+
+Present the 5 **ranked best-to-worst**, each with full, detailed rationale: how
+and why it makes the project obviously better, and why you are confident in that
+assessment. Score each survivor against the rubric (see `idea-rubric.md`).
+
+> The 30→5 funnel is the core discipline. Generating many before filtering
+> prevents premature commitment to a mediocre first idea; the ruthless cut
+> forces quality. Do NOT stop at the first 5 you think of — generate the full 30.
+
+### Step 3 — Expand with the next 10 (→ 15 total)
+
+The #6-15 ideas frequently have unique strengths that complement the top 5.
+Generate the **next best 10**, each with its rationale, for a ranked portfolio
+of **15**. Together the 15 form a more complete improvement package than the top
+5 alone.
+
+### Step 4 — Operationalize into self-documenting beads
+
+This step belongs to `/discovery` on the open-ended path (see
+`bead-operationalization.md`), but ideation mode produces its input: a ranked,
+rationale-bearing list of 15 ideas with how/perceive/implement notes and rubric
+scores. Hand that forward — do not lose the rationale.
+
+### Step 5 — Refine in plan space (4-5 passes)
+
+Also a `/discovery` responsibility (see `bead-operationalization.md`): re-read
+AGENTS.md each pass, check every bead for sense and optimality, and resist
+oversimplification. "It's a lot easier and faster to operate in plan space
+before we start implementing."
+
+## Output of ideation mode
+
+When run standalone (`/brainstorm --ideate`), ideation mode writes its portfolio
+to `.agents/brainstorm/YYYY-MM-DD-<slug>-ideation.md` with:
+
+```markdown
+---
+id: brainstorm-YYYY-MM-DD-<slug>-ideation
+type: brainstorm-ideation
+date: YYYY-MM-DD
+---
+# Ideation: <Open-Ended Goal>
+## Grounding (AGENTS.md + open/closed beads reviewed)
+## Top 5 (ranked best-to-worst, with rationale + rubric scores)
+## Next 10 (ranked, with rationale) — portfolio of 15
+## Synergies and dependencies
+## Next Step: /discovery --ideate (operationalize into beads)
+```
+
+When invoked BY `/discovery` on the open-ended path, ideation mode returns the
+ranked portfolio inline for the operationalize step rather than writing a
+standalone file.
+
+## Anti-patterns
+
+| Don't | Do |
+|-------|-----|
+| Skip grounding | Read AGENTS.md + beads first — prevents duplicates |
+| Generate 5 and stop | Generate the full 30, then winnow |
+| Keep all 30 | Winnow ruthlessly to 5; quality over quantity |
+| Stop at 5 | Expand to 15 — #6-15 are often complementary |
+| Present unranked | Rank best-to-worst with full rationale |
+| Drop rationale on handoff | Carry how/perceive/implement + rubric scores into operationalize |
+| Use `br`/`bv` | This is AgentOps — use `bd` for all tracking |

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -96,6 +96,21 @@ for the boundary between Discovery and Plan:
 
 Executable acceptance: [references/discovery.feature](references/discovery.feature) — Discovery hands dense intent across the `plan_slices` port (promoted from inline; soc-qk4b.2).
 
+## Open-Ended Path (generate-winnow → operationalize → refine)
+
+> **Additive to the default flow — it does not replace the strict-delegation contract or the artifact-first DAG.** This path activates for open-ended "improve the project"-style goals (`"improve the project"`, `"what should we build next"`, `"make X more robust"`) OR when `--ideate` is passed. For a specific goal, the default flow (brainstorm-clarify → research → plan → pre-mortem) is unchanged.
+
+On the open-ended path, Discovery prepends the generate-winnow methodology before research/plan and adds two steps after planning. Full detail lives in [`../brainstorm/references/bead-operationalization.md`](../brainstorm/references/bead-operationalization.md) and [`../brainstorm/references/ideation-mode.md`](../brainstorm/references/ideation-mode.md).
+
+1. **Ideate (delegate to `/brainstorm --ideate`).** Invoke `/brainstorm` in **ideation mode** (a real skill invocation — strict delegation still applies; do NOT inline the 30-idea generation). It returns a ranked portfolio of **15** ideas (top 5 + next 10) with how/perceive/implement notes, rubric scores, and red-team findings.
+2. **Research + Plan + Pre-mortem.** Run the normal artifact-first DAG over the selected portfolio, scoped to the winnowed ideas rather than a single goal.
+3. **Operationalize.** Turn the ranked portfolio into a comprehensive, granular set of **self-documenting `bd` beads** — tasks, subtasks, dependency structure (`bd dep add`), and **explicit test tasks** (unit + e2e with detailed logging). Each bead carries what/why/how/risks/success so the original plan markdown never needs to be consulted again. Overlap-check against existing beads (`bd list --json`) before creating — merge, don't duplicate.
+4. **Refine in plan space (4-5 passes).** Before handing the packet to `/crank`, run **4-5 refinement passes** over the bead set. Each pass: **re-read AGENTS.md** (especially after compaction), check every bead for sense and optimality, and **DO NOT OVERSIMPLIFY / DO NOT LOSE FEATURES OR FUNCTIONALITY**. Validate between passes (no dependency cycles; every leaf actionable via `bd ready`).
+
+> Tracking is **`bd`**, never `br`/`bv` — this is AgentOps. The operationalize and refine steps consume `/brainstorm`'s ideation output; see [`../brainstorm/references/bead-operationalization.md`](../brainstorm/references/bead-operationalization.md).
+
+Executable acceptance for this path: [references/discovery.feature](references/discovery.feature) (ideation/operationalize/refine scenarios, ag-yw0).
+
 ## Execution
 
 Run the artifact-first DAG in [references/dag.md](references/dag.md). That
@@ -109,6 +124,7 @@ and the acceptance-criteria YAML contract.
 | `--auto` | on | Fully autonomous (no human gates). Inverse of `--interactive`. Passed through to `/research` and `/plan`. |
 | `--interactive` | off | Human gates in research and plan (STEP 3, STEP 4). Does NOT affect pre-mortem gate. |
 | `--skip-brainstorm` | auto | Skip STEP 1 brainstorm when goal is already specific |
+| `--ideate` | auto | Force the open-ended generate-winnow path: delegate to `/brainstorm --ideate` (30→5→15), then operationalize into self-documenting `bd` beads and refine 4-5x in plan space. Auto-on for open-ended goals. See [Open-Ended Path](#open-ended-path-generate-winnow--operationalize--refine). |
 | `--complexity=<level>` | auto | Force complexity level (`fast` / `standard` / `full`) |
 | `--no-budget` | off | Disable phase time budgets |
 | `--no-scaffold` | off | Skip scaffold auto-invocation in STEP 4.5 (canonical name) |

--- a/skills/discovery/references/discovery.feature
+++ b/skills/discovery/references/discovery.feature
@@ -19,3 +19,30 @@ Feature: Discovery hands dense intent to planning
     When the discovery DAG completes
     Then it writes a JSON execution packet on disk for the next loop phase
     And the packet carries the goal, research, and design artifact references
+
+  # Open-ended path — generate-winnow → operationalize → refine (ag-yw0).
+  # Additive to the default flow above; strict delegation is preserved.
+  # Documentation-only spec (this file is allowlisted in
+  # scripts/.scenario-linkage-allow); wiring is asserted by the bats regression
+  # test tests/scripts/brainstorm-discovery-ideation.bats.
+
+  Scenario: an open-ended goal takes the generate-winnow path
+    Given an open-ended goal like "improve the project" or the --ideate flag
+    When /discovery runs
+    Then it delegates to /brainstorm in ideation mode as a separate skill invocation
+    And it does not inline the 30-idea generation in Discovery prose
+    And the default specific-goal flow remains unchanged
+
+  Scenario: Discovery operationalizes the winnowed portfolio into self-documenting beads
+    Given a ranked portfolio of 15 ideas from ideation mode
+    When the operationalize step runs
+    Then it creates self-documenting bd beads with dependency structure and explicit test tasks
+    And each bead carries what, why, how, risks, and success criteria
+    And it uses bd for all tracking, never br or bv
+
+  Scenario: Discovery refines beads in plan space before crank
+    Given operationalized beads exist
+    When the refine step runs
+    Then it makes 4-5 refinement passes re-reading AGENTS.md each pass
+    And it does not oversimplify or lose features or functionality
+    And it validates no dependency cycles before handing the packet to /crank

--- a/tests/scripts/brainstorm-discovery-ideation.bats
+++ b/tests/scripts/brainstorm-discovery-ideation.bats
@@ -1,0 +1,151 @@
+#!/usr/bin/env bats
+
+# Regression tests for the idea-wizard generate-winnow methodology wrapped into
+# /brainstorm + /discovery (ag-yw0).
+#
+# This is a documentation/wiring gate: the generate-winnow methodology lives in
+# SKILL.md prose + references + .feature scenarios (skills are markdown contracts,
+# not executable code), so these tests assert the methodology is present and wired
+# across the Claude skills, the ported references, and the Codex twins.
+#
+# Detailed logging (per the operationalize discipline being documented): each test
+# echoes what it is checking before asserting, so a failure log names the exact
+# missing surface.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    BRAINSTORM="$REPO_ROOT/skills/brainstorm/SKILL.md"
+    DISCOVERY="$REPO_ROOT/skills/discovery/SKILL.md"
+    CODEX_BRAINSTORM="$REPO_ROOT/skills-codex/brainstorm/SKILL.md"
+    CODEX_DISCOVERY="$REPO_ROOT/skills-codex/discovery/SKILL.md"
+    REF_IDEATION="$REPO_ROOT/skills/brainstorm/references/ideation-mode.md"
+    REF_RUBRIC="$REPO_ROOT/skills/brainstorm/references/idea-rubric.md"
+    REF_BEADS="$REPO_ROOT/skills/brainstorm/references/bead-operationalization.md"
+    FEAT_BRAINSTORM="$REPO_ROOT/skills/brainstorm/references/brainstorm.feature"
+    FEAT_DISCOVERY="$REPO_ROOT/skills/discovery/references/discovery.feature"
+}
+
+# Assert a file contains a literal substring, logging the probe first.
+assert_has() {
+    local file="$1" needle="$2"
+    echo "# checking: $(basename "$(dirname "$file")")/$(basename "$file") contains: $needle" >&3
+    grep -qF -- "$needle" "$file"
+}
+
+# Assert a file does NOT match an extended-regex pattern (anti-leak guard).
+# Uses `run` + status so it fails the test on any bats version (no `run !`).
+assert_lacks_regex() {
+    local file="$1" pattern="$2"
+    echo "# anti-leak: $(basename "$(dirname "$file")")/$(basename "$file") must NOT match: $pattern" >&3
+    run grep -qE -- "$pattern" "$file"
+    [ "$status" -ne 0 ]
+}
+
+# Assert a file does NOT contain a literal substring (anti-leak guard).
+assert_lacks() {
+    local file="$1" needle="$2"
+    echo "# anti-leak: $(basename "$(dirname "$file")")/$(basename "$file") must NOT contain: $needle" >&3
+    run grep -qF -- "$needle" "$file"
+    [ "$status" -ne 0 ]
+}
+
+@test "all four SKILL.md surfaces and three ported references exist" {
+    for f in "$BRAINSTORM" "$DISCOVERY" "$CODEX_BRAINSTORM" "$CODEX_DISCOVERY" \
+             "$REF_IDEATION" "$REF_RUBRIC" "$REF_BEADS"; do
+        echo "# exists? $f" >&3
+        [ -f "$f" ]
+    done
+}
+
+@test "brainstorm SKILL documents ideation mode with the generate-winnow funnel" {
+    assert_has "$BRAINSTORM" "Ideation Mode"
+    assert_has "$BRAINSTORM" "--ideate"
+    assert_has "$BRAINSTORM" "Generate 30"
+    assert_has "$BRAINSTORM" "best 5"
+    assert_has "$BRAINSTORM" "next best 10"
+    assert_has "$BRAINSTORM" "portfolio of "
+    assert_has "$BRAINSTORM" "ranked best-to-worst"
+}
+
+@test "brainstorm SKILL preserves the existing four-phase goal-clarification flow" {
+    # Additive guarantee: the original phases must remain present unchanged.
+    assert_has "$BRAINSTORM" "Phase 1: Assess Clarity"
+    assert_has "$BRAINSTORM" "Phase 2: Understand the Idea"
+    assert_has "$BRAINSTORM" "Phase 3: Explore Approaches"
+    assert_has "$BRAINSTORM" "Phase 4: Capture Design"
+    assert_has "$BRAINSTORM" "Phase 3b: Adversarial Critique"
+}
+
+@test "brainstorm SKILL links all three ported references" {
+    assert_has "$BRAINSTORM" "references/ideation-mode.md"
+    assert_has "$BRAINSTORM" "references/idea-rubric.md"
+    assert_has "$BRAINSTORM" "references/bead-operationalization.md"
+}
+
+@test "idea-rubric reference carries all ten evaluation dimensions" {
+    for dim in Robust Reliable Performant Intuitive User-friendly Ergonomic \
+               Useful Compelling Accretive Pragmatic; do
+        assert_has "$REF_RUBRIC" "$dim"
+    done
+}
+
+@test "bead-operationalization reference uses bd and bans br/bv tracker refs" {
+    assert_has "$REF_BEADS" "bd create"
+    assert_has "$REF_BEADS" "bd dep add"
+    assert_has "$REF_BEADS" "DO NOT OVERSIMPLIFY"
+    assert_has "$REF_BEADS" "DO NOT LOSE FEATURES"
+    # idea-wizard's br/bv tracker must NOT leak into the ported repo-native docs.
+    assert_lacks_regex "$REF_BEADS"    '\b(br|bv)\s+(list|create|dep|ready|--robot)'
+    assert_lacks_regex "$REF_IDEATION" '\b(br|bv)\s+(list|create|dep|ready|--robot)'
+    assert_lacks_regex "$REF_RUBRIC"   '\b(br|bv)\s+(list|create|dep|ready|--robot)'
+}
+
+@test "ideation-mode reference documents the mode-selection rule and grounding" {
+    assert_has "$REF_IDEATION" "When to use which mode"
+    assert_has "$REF_IDEATION" "AGENTS.md"
+    assert_has "$REF_IDEATION" "bd list --json"
+    assert_has "$REF_IDEATION" "bd list --status closed --json"
+}
+
+@test "discovery SKILL wires the open-ended ideate path with operationalize and refine" {
+    assert_has "$DISCOVERY" "Open-Ended Path"
+    assert_has "$DISCOVERY" "--ideate"
+    assert_has "$DISCOVERY" "/brainstorm --ideate"
+    assert_has "$DISCOVERY" "Operationalize"
+    assert_has "$DISCOVERY" "self-documenting"
+    assert_has "$DISCOVERY" "Refine in plan space"
+    assert_has "$DISCOVERY" "4-5 refinement passes"
+}
+
+@test "discovery SKILL preserves the strict-delegation contract" {
+    # Additive guarantee: the contract that predates this change must remain.
+    assert_has "$DISCOVERY" "Strict Delegation Contract"
+    assert_has "$DISCOVERY" "strict-delegation-contract.md"
+    # The new path must explicitly keep delegation (no inlining the 30-idea gen).
+    assert_has "$DISCOVERY" "do NOT inline the 30-idea generation"
+}
+
+@test "codex twins mirror ideation mode with codex notation and no Claude primitives" {
+    assert_has "$CODEX_BRAINSTORM" "Ideation Mode"
+    assert_has "$CODEX_BRAINSTORM" '$brainstorm --ideate'
+    assert_has "$CODEX_DISCOVERY" "Open-Ended Path"
+    assert_has "$CODEX_DISCOVERY" '$brainstorm --ideate'
+    # Codex bodies must not leak Claude-era primitives (parity rule).
+    assert_lacks "$CODEX_BRAINSTORM" "AskUserQuestion"
+    assert_lacks "$CODEX_DISCOVERY" "AskUserQuestion"
+    # Codex must use $skill notation, not /skill, for the new content.
+    assert_lacks "$CODEX_BRAINSTORM" "/brainstorm --ideate"
+    assert_lacks "$CODEX_DISCOVERY" "/brainstorm --ideate"
+}
+
+@test "feature specs add ideation and operationalize scenarios additively" {
+    assert_has "$FEAT_BRAINSTORM" "triggers ideation mode"
+    assert_has "$FEAT_BRAINSTORM" "winnows ruthlessly to a ranked five"
+    assert_has "$FEAT_BRAINSTORM" "expands the portfolio to fifteen"
+    assert_has "$FEAT_DISCOVERY" "generate-winnow path"
+    assert_has "$FEAT_DISCOVERY" "operationalizes the winnowed portfolio"
+    assert_has "$FEAT_DISCOVERY" "refines beads in plan space"
+    # The original scenarios must survive untouched (scenario-hash stability).
+    assert_has "$FEAT_BRAINSTORM" "a goal is clarified through the four phases"
+    assert_has "$FEAT_DISCOVERY" "Discovery delegates to Plan"
+}


### PR DESCRIPTION
## Summary

Operator override of the 3.0 freeze (ag-yw0) — the LAST 3.0 feature before the v3.0.0 tag. Builds the idea-wizard **generate-winnow** methodology INTO `/brainstorm` + `/discovery` as an **additive** open-ended ideation mode. Existing behavior is fully preserved.

## What was added

**`/brainstorm` — new Ideation Mode (open-ended):**
- Trigger: open-ended goal (`"improve the project"`, `"what should we build next"`), the `exploring` clarity path with no single goal, or `--ideate`.
- Methodology: ground in reality (AGENTS.md + bd beads) → generate **30** → winnow to **5 ranked best-to-worst** with full rationale + rubric scores → expand with the **next 10** (→ 15).
- The existing four-phase goal-clarification flow (Phases 1-4 + 3b adversarial critique) is untouched. A "Two modes" table documents when to use which.

**`/discovery` — new Open-Ended Path:**
- Delegates to `/brainstorm --ideate` (strict delegation preserved — no inlining the 30-idea generation), runs research/plan/pre-mortem over the winnowed portfolio, then:
  - **Operationalize:** ranked portfolio → self-documenting `bd` beads (deps via `bd dep add` + explicit unit/e2e **test tasks** with detailed logging; what/why/how/risks/success).
  - **Refine in plan space (4-5 passes):** re-read AGENTS.md each pass, DO NOT OVERSIMPLIFY / DO NOT LOSE FEATURES, validate no dep cycles before `/crank`.
- The strict-delegation contract and artifact-first DAG are unchanged; `--ideate` flag added.

**Ported references (COPY, not symlink; `bd` everywhere, never `br`/`bv`):**
- `skills/brainstorm/references/ideation-mode.md` — mode-selection + the 5-step methodology.
- `skills/brainstorm/references/idea-rubric.md` — ten-dimension rubric (robust/reliable/performant/intuitive/user-friendly/ergonomic/useful/compelling/accretive/pragmatic) + winnowing rounds.
- `skills/brainstorm/references/bead-operationalization.md` — operationalize + refine-in-plan-space.

**Codex twins:** mirrored into `skills-codex/{brainstorm,discovery}/SKILL.md` (`$skill` notation, no Claude primitives), hashes regenerated.

**Acceptance + tests:** additive scenarios in both `.feature` files (existing scenario text untouched); new `tests/scripts/brainstorm-discovery-ideation.bats` (11 tests, detailed logging) asserting the methodology is documented/wired across all four SKILL.md surfaces, the three references, and the feature specs, with anti-leak guards (no `br`/`bv`, no `AskUserQuestion` in codex).

## Gates (all green locally)

heal.sh --strict · scenario-test-linkage · ao goals scenarios --lint · codex-parity (brainstorm + discovery) · codex-parity-drift · regen-codex-hashes --check · generate-registry --check · registry-drift · context-map-drift · skill-schema · codex-backbone-prompts · markdownlint · new bats (11/11).

Frontmatter (`hexagonal_role`/`consumes`/`produces`) untouched; no skill-count change; no `cli/`, CHANGELOG, version files, or `docs/3.0.md` touched. Diff: 726 insertions / 12 deletions (deletions are generated hash/count lines only).

Closes-scenario: ag-yw0#idea-wizard-wrap
Bounded-context: BC1-Corpus
Evidence: skills/brainstorm/SKILL.md