### PR TITLE
docs(3.0): honest 'docs match reality' claim — north-star truthful about the doc-prose tail (1 stale claim → 1 accurate claim)

### DIFF
--- a/docs/3.0.md
+++ b/docs/3.0.md
@@ -147,7 +147,7 @@ The difference in daemon posture is deliberate and is the crux of the deletion d
 3.0-ready is **reconciled, hardened, and grounded**: the repo matches reality and the doctrine is encoded end-to-end.
 
 - [x] This north star is the single referenced source of truth; README, PRODUCT, GOALS, and the docs index point here.
-- [x] **Docs match reality:** no aspirational claims in live docs, no dead code, no stale paths or counts, no unsubstantiated market claims. The standalone daemon/scheduler/overnight-runner surfaces are gone from the CLI and from live doc prose.
+- [x] **Docs match reality:** no aspirational claims in the north-star or primary surfaces, no dead code, no stale paths or counts, no unsubstantiated market claims. The standalone daemon/scheduler/overnight-runner surfaces are gone from the CLI, the skill snippets, and the core docs. A long tail of narrative-doc prose references is still being reconciled (tracked in `ag-p7j`); the `validate-sku-catalog-drift` linkage gate now blocks any *new* skill→command rot.
 - [x] **Hexagon complete:** every skill carries `hexagonal_role` plus accurate `consumes`/`produces` plus canonical `.feature` acceptance, with the deprecated/internal/meta exceptions enumerated in the readiness level-set.
 - [x] **Hookless by default:** AgentOps 3.0 ships zero hooks. Workflow is guided by skills plus the `ao` CLI, and CI is the authoritative gate. Author your own via the `hooks-authoring` skill if you want them.
 - [x] **The loop is executable in session:** BDD intent → tests → bounded build → both-ends validation → ratchet, documented in [operating-loop.md](architecture/operating-loop.md) and exercised end-to-end.


### PR DESCRIPTION
docs/3.0.md:150 claimed daemon prose was gone from ALL live docs; ~10 narrative docs still reference it (tracked ag-p7j). Reworded to claim what is true (CLI + skill snippets + core docs clean) + point at the tracked tail and the validate-sku-catalog-drift linkage gate. Surfaced by the cc/cod release-readiness duel.

Closes-scenario: ag-p7j#north-star-honesty
Bounded-context: BC1-Corpus
Evidence: docs/3.0.md