### PR TITLE
docs(3.0): ag-p7j W3 — reframe peripheral docs to in-session (ag-p7j)

### DIFF
--- a/docs/agentops-3-explainer-kit.md
+++ b/docs/agentops-3-explainer-kit.md
@@ -7,7 +7,8 @@ section, launch post, or video description.
 
 AgentOps is the engineering operating system for agent teams: a disciplined
 engineering layer that gives coding agents shared domain context, review
-verdicts, tracked follow-up work, and optional scheduled compounding.
+verdicts, tracked follow-up work, and optional out-of-session compounding (the
+loop dispatched on the Gas City reference City).
 
 ## Problem Statement
 
@@ -111,19 +112,24 @@ The important shape:
 | Re-explain intent at every phase. | Hand the packet lineage through briefing, verdict, execution, validation, and handoff artifacts. |
 | Automation starts as a giant promise. | Automation is second-stage, after the packet and verdict earn trust. |
 
-## Daemon Expansion Path
+## Out-Of-Session Expansion Path
 
-The daemon is the deeper lane, not the first proof.
+Out-of-session orchestration is the deeper lane, not the first proof.
+AgentOps ships no daemon or scheduler of its own — the loop runs in session,
+and unattended runs are delegated to the Gas City reference City (see
+[ADR-0009](adr/ADR-0009-daemon-deletion-in-session-only.md)).
 
 After the user sees one packet and one verdict:
 
 ```bash
-ao init --with-schedule
-ao daemon run --schedule-file .agents/schedule.yaml
-ao schedule list
+# In the reference City, a long-lived mayor agent slings the next ready bead
+# to a refinery worker, which runs the loop as one invocable unit:
+ao rpi <bead-id>
+# Scheduled maintenance (Dream reports, wiki curation, release checks) runs as
+# Gas City cron Orders. See docs/dependencies.md and the using-gc skill.
 ```
 
-Use the daemon for approved recurring work such as Dream reports, wiki
+Use the Gas City lane for approved recurring work such as Dream reports, wiki
 curation, release checks, or other compounding jobs where the operator has
 already accepted the artifact shape.
 

--- a/docs/brainstorms/2026-04-12-compiled-knowledge-workspace-requirements.md
+++ b/docs/brainstorms/2026-04-12-compiled-knowledge-workspace-requirements.md
@@ -5,6 +5,8 @@ topic: compiled-knowledge-workspace
 
 # Compiled Knowledge Workspace
 
+> **Historical (2026-04-12).** A dated brainstorm retained for provenance. It predates the AgentOps 3.0 rearchitecture, which removed the standalone `ao overnight` / daemon / scheduler surfaces ([ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)): AgentOps is in-session only, the Dream maintenance loop runs as the `/dream` skill, and unattended runs are dispatched on the Gas City reference City. Where the requirements below name `ao overnight` as the scheduled-maintenance home, read it as "the `/dream` skill, dispatched out of session via a Gas City Order." Read for intent, not as a current task list.
+
 ## Problem Frame
 
 Karpathy's LLM Wiki pattern is a strong fit for AgentOps because it names the same product problem AgentOps already solves: agents should not re-derive useful context from raw material every session. The useful product move is not to clone a second-brain app. AgentOps already has a repo-native bookkeeping flywheel, `/compile`, `ao search`, `ao lookup`, `ao curate`, `ao mind`, and `ao overnight`. The gap is that the compiled wiki layer is still mostly skill-led instead of a first-class CLI and lifecycle surface.
@@ -46,7 +48,7 @@ flowchart LR
 
 - R7. `ao search` and retrieval-oriented flows must be able to include compiled knowledge results without hiding whether a result came from raw session history, promoted learnings, findings, or compiled synthesis.
 - R8. `ao lookup` or context assembly must be able to retrieve compiled synthesis when it is the best task-level context, while still preferring verified learnings and findings for rule-like guidance.
-- R9. `ao overnight start` must have a path to run compile/lint as an optional knowledge-maintenance lane inside the existing no-source-mutation Dream boundary.
+- R9. The Dream maintenance lane (the `/dream` skill, dispatched out of session via a Gas City Order) must have a path to run compile/lint as an optional knowledge-maintenance lane inside the existing no-source-mutation Dream boundary.
 - R10. Lint output must be machine-readable enough for Dream reports, CI gates, or future `bd` follow-up creation, while still producing a human-readable markdown report.
 
 **Health and Safety**
@@ -84,7 +86,7 @@ flowchart LR
 - Extend existing `/compile` instead of creating a separate second-brain feature: the skill already contains the Karpathy-aligned behavior and output contract.
 - Treat `skills/llm-wiki/` as a candidate external-vault skill, not the primary CLI foundation: it is useful product exploration, but the first CLI milestone should graduate the existing internal compiler because that is already wired to AgentOps' core flywheel.
 - Put the CLI entry point in the knowledge command group: this matches `ao search`, `ao lookup`, `ao curate`, `ao mind`, `ao store`, and `ao temper`.
-- Use `ao overnight` for scheduled maintenance: it already represents the no-source-mutation night loop and avoids inventing a parallel scheduler.
+- Use the Dream maintenance loop (the `/dream` skill, dispatched out of session via a Gas City Order) for scheduled maintenance: it already represents the no-source-mutation night loop and avoids inventing a parallel scheduler.
 - Keep `.agents/compiled/` as the repo-local default: AgentOps' core product is repo-native agent work, while raw/wiki vault mode should be explicit.
 
 ## Alternatives Considered
@@ -97,7 +99,7 @@ flowchart LR
 
 - `skills/compile/scripts/compile.sh` remains the canonical headless implementation unless planning finds it too brittle for CLI wrapping.
 - `skills/llm-wiki/SKILL.md` is treated as unmerged user/proposal work unless explicitly accepted into scope.
-- `ao overnight` can add an optional compile/lint step without violating Dream anti-goals.
+- The Dream maintenance loop (the `/dream` skill) can add an optional compile/lint step without violating Dream anti-goals.
 - CLI docs must be regenerated if a command or flags are added.
 - Codex artifacts and overrides must be updated if the compile skill behavior or CLI references change.
 

--- a/docs/comparisons/competition-rpi-memory-pipelines.md
+++ b/docs/comparisons/competition-rpi-memory-pipelines.md
@@ -23,7 +23,7 @@ for Superpowers, Compound Engineer, GSD, Claude-Flow/Ruflo, GitHub Spec Kit, and
 | Superpowers | Strongest small-surface workflow discipline and skill TDD posture. | Use it as a skill-quality bar, not a memory benchmark. |
 | Karpathy LLM Wiki pattern | Best framing for external knowledge accumulation: raw inputs become a navigable synthesized wiki. | AgentOps' `llm-wiki` should stay distinct from `.agents` repo memory but connect through forge, compile, and inject. |
 
-AgentOps' current differentiation is the combination of repo-native `.agents` memory, scored promotion, citations, validation gates, and a private overnight Dream contract. Competitors usually have one or two of those pieces, not the full closed loop.
+AgentOps' current differentiation is the combination of repo-native `.agents` memory, scored promotion, citations, validation gates, and the in-session `/dream` maintenance cycle (run out of session on the Gas City reference City). Competitors usually have one or two of those pieces, not the full closed loop.
 
 ## Comparison Matrix
 
@@ -32,7 +32,7 @@ AgentOps' current differentiation is the combination of repo-native `.agents` me
 | Memory substrate | Specs, plans, worktrees, optional conversation search | `docs/solutions/`, YAML frontmatter, session history, auto-memory | `.planning/` files, `STATE.md`, threads, graph artifacts | `.swarm/memory.db`, AgentDB, ReasoningBank, namespaces, vector search | Specs, plans, tasks, constitution; community memory extensions | `.kiro/steering`, `brief.md`, specs, tasks, implementation notes | `.agents` markdown, JSONL, compiled context, citations, bd |
 | Compounding loop | Skill use and skill authoring discipline | `compound` captures solutions; `compound-refresh` maintains corpus | `extract_learnings`, threads, spike/sketch wrap-up into project skills | Retrieve -> judge -> distill -> consolidate | Spec feedback loop; memory mostly extensions | Implementation notes injected into later tasks | Forge -> score -> promote -> inject; post-mortem and Dream loops |
 | Wiki shape | None | Solution library, not raw-to-wiki | Planning tree and optional graph, not wiki | Database/vector memory, not wiki | Extension ecosystem, not core wiki | Spec workspace, not wiki | `llm-wiki`: raw sources -> synthesized wiki -> lint/promote |
-| Dream/offline cycle | None found | Refresh/autofix, but no explicit overnight cycle | No; "dream extraction" is project-init wording | Periodic/nightly consolidation is closest analog | None in core | None found | `ao overnight` Dream contract with safe staging and morning packet |
+| Dream/offline cycle | None found | Refresh/autofix, but no explicit overnight cycle | No; "dream extraction" is project-init wording | Periodic/nightly consolidation is closest analog | None in core | None found | `/dream` maintenance cycle with safe staging and morning packet; run out of session on the Gas City reference City |
 | Automated pruning | None found | Keep, update, consolidate, replace, delete; uncertain docs marked stale | Cleanup/archive and health repair | Cleanup by days/namespace; consolidation reports pruned items | Not core; community optimize/memory lint concepts | No corpus pruning found | Maturity decay, dedup, contradictions, prune/evict, defrag |
 | Skill suite | 14 skills, 3 commands, 1 agent in clone | Docs claim 42+ skills and 50+ agents; clone showed 36 skill dirs and 51 agent files | 85 GSD command files and 33 agents in clone | v2 docs claim 25 skills and 100+ MCP tools; clone showed 38 `.claude/skills`, 168 command docs, 7 top-level agents | Command templates and extensions rather than a skill suite | Docs claim 17 skills across 8 agents; public repo stores an installer skill plus templates/docs | 73 skills plus CLI, hooks, contracts, schemas |
 | Primary pipeline | Brainstorm -> worktree -> plan -> subagent dev -> TDD -> review -> finish branch | Ideate -> brainstorm -> plan -> work -> review -> compound -> refresh | New project -> discuss/research -> plan -> execute waves -> verify/UAT -> ship -> extract learnings | Swarm/hive-mind -> hooks -> shared memory -> post-command memory -> session restore/consolidation | Constitution -> specify -> plan -> tasks -> implement | Discovery -> spec init -> requirements -> design -> tasks -> impl -> validate | Research -> plan -> pre-mortem -> crank -> vibe -> post-mortem -> flywheel |
@@ -61,9 +61,9 @@ Work -> Forge -> Pool -> Promote -> Learnings -> Inject -> Better Work
 
 The curation path includes catalog, verify, index, score, reject, and constrain stages. Current docs note that catalog/verify are implemented as CLI checks, while later scoring/rejection/constraining stages remain staged work.
 
-Dream is a separate contract. `ao overnight` runs a private local maintenance loop that ingests knowledge, reduces it through defrag/dedup/compile/prune, measures health, and commits only improved staged artifacts. It never mutates source code, never invokes RPI, and emits a morning packet.
+Dream is a separate contract. The `/dream` skill runs a private local maintenance loop that ingests knowledge, reduces it through defrag/dedup/compile/prune, measures health, and commits only improved staged artifacts. It never mutates source code, never invokes RPI, and emits a morning packet. It runs in session; to run it out of session, unattended, dispatch it on the Gas City reference City (AgentOps ships no daemon or scheduler of its own — see [ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)).
 
-Sources: [README](https://github.com/boshu2/agentops/blob/main/README.md), [PRODUCT](https://github.com/boshu2/agentops/blob/main/PRODUCT.md), [knowledge flywheel](../knowledge-flywheel.md), [curation pipeline](../curation-pipeline.md), [dream run contract](../contracts/dream-run-contract.md), [dream report contract](../contracts/dream-report.md).
+Sources: [README](https://github.com/boshu2/agentops/blob/main/README.md), [PRODUCT](https://github.com/boshu2/agentops/blob/main/PRODUCT.md), [knowledge flywheel](../knowledge-flywheel.md), [curation pipeline](../curation-pipeline.md), [dream report contract](../contracts/dream-report.md).
 
 ## Superpowers
 
@@ -402,7 +402,7 @@ Capability mapping against AgentOps:
 
 | Managed Agents | AgentOps equivalent | Status |
 |---|---|---|
-| Dreaming | `/dream` + `ao overnight` + nightly CI dream-cycle proof job | Shipped |
+| Dreaming | `/dream` skill (in session) + Gas City out-of-session dispatch + nightly CI dream-cycle proof job | Shipped |
 | Outcomes (rubric → grader → iterate) | Shipped at three scopes: project (`GOALS.md` + `ao goals measure` per-gate subprocesses + `/evolve` retry loop), plan (`/pre-mortem` council judges), code (`/vibe` council judges). Each judge/gate runs in a separate context; `/evolve` iterates worst-failing gate until pass. Empirical workbench A/B (2026-05-06): Δ=+0.0000 across 12 cases (skill-on 12/12, skill-off 12/12) — at v1 task difficulty the hook layer is non-differentiating; substrate v2 is roadmap. Counter-stat: `evals/workbench/results/2026-05-06-yjzp9-counterstat.json`. | Shipped at the capability layer; v2 eval substrate is roadmap. |
 | Multiagent orchestration | `/swarm` + `/crank` + `/rpi` + worktree isolation | Shipped (per-worker tool isolation in flight) |
 | Webhooks (completion notification) | GitHub Actions / git hooks; pattern doc shipped at `docs/patterns/completion-notifications.md` | Shipped via existing CI substrate (off-API users already have the infrastructure) |

--- a/docs/comparisons/competitive-radar.md
+++ b/docs/comparisons/competitive-radar.md
@@ -43,8 +43,8 @@ them on) and what AgentOps wins on against them. Sourced from the
 
 | Competitor | Lane | What they win on | What AgentOps wins on |
 |------------|------|------------------|------------------------|
-| [obra/superpowers](https://github.com/obra/superpowers) | Methodology | Official Anthropic marketplace placement, ~29K stars, Jesse Vincent brand, TDD red-green-refactor as a sharp methodology hook | Persistent corpus accumulating across sessions; cross-session memory in `.agents/`; multi-model council as a commit gate; off-API daemon on your hardware |
-| [EveryInc/compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) | Methodology | 10-target runtime conversion CLI; configurable per-project reviewer routing; ideation-to-compound surface area; closest philosophical neighbor | Model-independent **per-phase** routing (Claude for discovery, Codex for implementation, fresh Claude for validation, local model for overnight defrag — in one workflow); persistent corpus that lives in your repo, not the tool |
+| [obra/superpowers](https://github.com/obra/superpowers) | Methodology | Official Anthropic marketplace placement, ~29K stars, Jesse Vincent brand, TDD red-green-refactor as a sharp methodology hook | Persistent corpus accumulating across sessions; cross-session memory in `.agents/`; multi-model council as a commit gate; off-API operation on your hardware (in-session loop, with out-of-session dispatch on the Gas City reference City) |
+| [EveryInc/compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) | Methodology | 10-target runtime conversion CLI; configurable per-project reviewer routing; ideation-to-compound surface area; closest philosophical neighbor | Model-independent **per-phase** routing (Claude for discovery, Codex for implementation, fresh Claude for validation, local model for unattended defrag — in one workflow); persistent corpus that lives in your repo, not the tool |
 | [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official) | Curation | First-party authority; default discovery channel; "trust before installing" posture | Operates underneath any harness — Claude Code, Codex, Cursor, OpenCode — turning sessions into a context library you own. AgentOps is not a coding harness; it sits on top of whichever harness you already use |
 | [jeremylongshore/claude-code-plugins-plus-skills](https://github.com/jeremylongshore/claude-code-plugins-plus-skills) | Volume marketplace | 425 plugins / 2,810 skills inventory; CCPI package manager; sponsored placement; daily download metrics | Compounding context vs. static inventory: skills don't accumulate, a wiki does. AgentOps ships a bookkeeping schema that grows; volume marketplaces ship an inventory that doesn't |
 | [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | Volume + breadth | ~5,200+ stars; 235 skills × 12 platforms; 305 stdlib Python tools; multi-domain coverage (engineering + marketing + compliance) | Same persistent-corpus argument plus model-independent phase routing inside one session — breadth of skills doesn't replace cross-session memory |
@@ -118,13 +118,17 @@ discipline that turns sessions into a wiki. Receipts: as of 2026-05-04, this
 repo's `.agents/` contained ~1,842 learnings, ~186 patterns, ~80 planning
 rules, and ~3,867 cited decisions captured by the system on itself.
 
-### 2. Off-API daemon
+### 2. Off-API, off-vendor operation
 
-`ao schedule` + `ao daemon` runs dream / evolve / compile / defrag / forge
-overnight, off-vendor, on your hardware, against your subscription. All seven
-competitors are in-session plugins. The daemon is the structural answer to
-"what if a frontier vendor ships native equivalents in 12 months" — your
-corpus and your scheduler keep running regardless.
+The whole loop — dream / evolve / compile / defrag / forge — runs in session
+on your hardware, against your subscription, off any vendor's API. To run it
+unattended, dispatch it on the Gas City reference City (a long-lived mayor
+agent slings beads to refinery workers that run `ao rpi`); AgentOps ships no
+daemon or scheduler of its own (see [ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)).
+All seven competitors are in-session plugins with no off-vendor out-of-session
+story. Off-API operation is the structural answer to "what if a frontier
+vendor ships native equivalents in 12 months" — your corpus and your loop keep
+running regardless.
 
 ### 3. Multi-model council
 
@@ -136,7 +140,7 @@ multi-model commit gate is the strongest validation primitive in the set.
 ### 4. Model-independent phase routing
 
 Pick Claude for ideation, Codex for validation, an open-weights local model
-for overnight defrag — *per phase, in one workflow,* with state preserved
+for unattended defrag — *per phase, in one workflow,* with state preserved
 across the boundaries. Cross-harness *distribution* (everything-claude-code,
 Compound Engineer's 10-target conversion) is multi-runtime spread of one
 workflow shape; per-phase routing is mixing models inside one workflow.
@@ -149,8 +153,9 @@ AgentOps owns "wiki for agents" + "context library" + "context compiler"
 table (source code → context, SDLC → CDLC, libraries → context libraries,
 compilers → context compilers, code review → multi-model councils, CI/CD →
 validation gates, postmortems → automated postmortems, runbooks → skills +
-planning rules, software factories → software factory daemon, Markdown/Git
-/Linux → LLM Wiki of Markdown, open-source corpus → your private corpus).
+planning rules, software factories → the in-session operating loop (with an
+orchestration substrate for out-of-session runs), Markdown/Git/Linux → LLM
+Wiki of Markdown, open-source corpus → your private corpus).
 Vocabulary ownership is durable; Superpowers owns "TDD," AgentOps can own
 "context engineering."
 

--- a/docs/comparisons/vs-everything-claude-code.md
+++ b/docs/comparisons/vs-everything-claude-code.md
@@ -30,7 +30,7 @@ last_reviewed: 2026-05-07
 | **Inventory** | 182 skills, 48 subagents | 73 skills + your accumulated corpus |
 | **Persistence** | In-session | Cross-session via `.agents/` corpus |
 | **Discipline mechanism** | DRY parity tooling | Multi-model councils + RPI phase contracts |
-| **Off-API surface** | None (in-session only) | `ao daemon` runs dream / evolve / compile overnight |
+| **Off-API surface** | None (in-session only) | In-session loop runs off-vendor on your hardware; out-of-session dispatch via the Gas City reference City |
 | **Open source** | Yes | Yes (forever) |
 
 The two products optimize for different axes. everything-claude-code optimizes
@@ -136,11 +136,14 @@ above: pick the model that is best for each phase, with state preserved
 across the boundaries. This is a workflow-level capability that is
 orthogonal to (and does not depend on) cross-harness parity.
 
-**Off-API daemon on your hardware.** `ao schedule` and `ao daemon` run
-dream / evolve / compile / defrag / forge passes against your subscription,
-off-vendor, overnight. The corpus compounds while you sleep.
-everything-claude-code is in-session by design; the off-API surface is not
-part of its category.
+**Off-API, off-vendor operation on your hardware.** The whole loop —
+dream / evolve / compile / defrag / forge — runs in session against your
+subscription, off any vendor's API. To run it unattended, dispatch it on the
+Gas City reference City (a mayor agent slings beads to refinery workers that
+run `ao rpi`); AgentOps ships no daemon or scheduler of its own (see
+[ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)). The corpus
+compounds while you sleep. everything-claude-code is in-session by design with
+no off-vendor out-of-session story.
 
 ---
 

--- a/docs/comparisons/vs-tons-of-skills.md
+++ b/docs/comparisons/vs-tons-of-skills.md
@@ -61,7 +61,7 @@ This is the cleanest framing: a marketplace and a context library are complement
 
 **Model-independent phase routing.** Inside a single RPI loop, AgentOps runs Claude for research, Codex for implementation, fresh Claude for validation, with state preserved across the boundaries. Skills in any marketplace inherit the harness's model — they don't compose model choices per phase. This is a workflow-level capability, orthogonal to skill inventory.
 
-**Off-API daemon.** `ao schedule` and `ao daemon` run dream / evolve / compile / defrag / forge passes on your hardware against your subscription, off-vendor, overnight. The corpus compounds while you sleep. Tons-of-Skills is in-session by design; the off-API surface is not part of its category.
+**Off-API, off-vendor operation.** The whole loop — dream / evolve / compile / defrag / forge — runs in session on your hardware against your subscription, off any vendor's API. To run it unattended, dispatch it on the Gas City reference City (a mayor agent slings beads to refinery workers that run `ao rpi`); AgentOps ships no daemon or scheduler of its own (see [ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)). The corpus compounds while you sleep. Tons-of-Skills is in-session by design with no off-vendor out-of-session story.
 
 ---
 

--- a/docs/examples/agentops-3-council-demo-storyboard.md
+++ b/docs/examples/agentops-3-council-demo-storyboard.md
@@ -9,8 +9,9 @@ AgentOps makes agents work like a disciplined engineering team.
 
 In the demo, the operator gives Claude and Codex the same domain/practice
 packet. They judge the same product/design/engineering decision, produce one
-verdict artifact, and turn that verdict into tracked work. The daemon appears
-only after first trust, as the second-stage compounding lane.
+verdict artifact, and turn that verdict into tracked work. Out-of-session
+automation (the loop dispatched on the Gas City reference City) appears only
+after first trust, as the second-stage compounding lane.
 
 ## Repo, Task, And Setup
 
@@ -20,7 +21,7 @@ only after first trust, as the second-stage compounding lane.
 | Demo branch | Any clean 3.0 worktree rebased on current `main` |
 | Demo profile | `product-council` from `docs/activation-profiles.md` |
 | Domain packet | `docs/examples/agentops-3-domain-practice-packet.md` |
-| Decision | Should the 3.0 launch demo lead with council-first engineering judgment instead of daemon-first automation? |
+| Decision | Should the 3.0 launch demo lead with council-first engineering judgment instead of automation-first out-of-session orchestration? |
 | Target issue | `soc-m6v5.9.7.8` after packet/profile/storyboard work closes |
 
 Pre-flight:
@@ -42,7 +43,7 @@ Screen setup:
 
 Show the problem without AgentOps:
 
-1. One agent says "lead with daemon because automation is differentiated."
+1. One agent says "lead with out-of-session automation because it is differentiated."
 2. Another agent says "lead with council because it is easier to understand."
 3. Neither answer cites product posture, goals, evidence rules, or release
    constraints.
@@ -108,13 +109,13 @@ Narration:
 Primary command:
 
 ```text
-/council --mixed validate "Given docs/examples/agentops-3-domain-practice-packet.md, should the AgentOps 3.0 launch demo lead with council-first engineering judgment instead of daemon-first automation?"
+/council --mixed validate "Given docs/examples/agentops-3-domain-practice-packet.md, should the AgentOps 3.0 launch demo lead with council-first engineering judgment instead of automation-first out-of-session orchestration?"
 ```
 
 Fallback command:
 
 ```text
-/council --quick validate "Given docs/examples/agentops-3-domain-practice-packet.md, should the AgentOps 3.0 launch demo lead with council-first engineering judgment instead of daemon-first automation?"
+/council --quick validate "Given docs/examples/agentops-3-domain-practice-packet.md, should the AgentOps 3.0 launch demo lead with council-first engineering judgment instead of automation-first out-of-session orchestration?"
 ```
 
 The fallback is acceptable for docs or offline recording only. A public
@@ -130,7 +131,7 @@ The demo should not require a predetermined PASS. The expected shape is:
 | Claude engineering-practice judge | The packet encodes DDD/TDD/BDD/release discipline into the decision context. |
 | Codex implementation judge | The demo is feasible with existing `ao context`, `/council`, bd, and `.agents` surfaces. |
 | Codex release-risk judge | WARN unless public copy avoids PMF/productivity claims without exported evidence. |
-| Consolidated verdict | PASS or WARN: lead with council-first, keep daemon as second-stage, and gate launch claims on exported evidence. |
+| Consolidated verdict | PASS or WARN: lead with council-first, keep out-of-session automation as second-stage, and gate launch claims on exported evidence. |
 
 Expected artifact:
 
@@ -168,19 +169,26 @@ Narration:
 
 ## Act 5: Show The Deeper Automation Lane
 
-Only after the verdict:
+Only after the verdict, show how the same loop runs out of session on the Gas
+City reference City. AgentOps ships no daemon or scheduler of its own (see
+[ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)); out-of-session
+execution is delegated to a substrate, and the loop is dispatched as one
+invocable unit:
 
 ```bash
-ao init --with-schedule
-ao daemon run --schedule-file .agents/schedule.yaml
-ao schedule list
+# In the reference City, a long-lived mayor agent slings the next ready bead
+# to a refinery worker, which runs the loop:
+ao rpi soc-m6v5.9.7.8
+# Scheduled maintenance (ao compile, ao maturity --scan) runs as Gas City
+# cron Orders. See docs/dependencies.md and the using-gc skill.
 ```
 
 Narration:
 
 > Once you trust the packet, verdict, and evidence trail, the same operating
-> layer can run on a schedule. That is the factory lane, not the first thing you
-> need to understand.
+> layer can run unattended out of session — dispatched on the Gas City
+> reference City, not an AgentOps daemon. That is the orchestration lane, not
+> the first thing you need to understand.
 
 ## Engineering Practice On Screen
 
@@ -220,7 +228,7 @@ Do not use:
 | 3:15 | Run `/council --mixed`. |
 | 5:00 | Inspect the verdict artifact. |
 | 6:00 | Show the verdict becoming bd work. |
-| 7:00 | Show schedule/Dream as second-stage automation. |
+| 7:00 | Show out-of-session dispatch on Gas City / Dream as second-stage automation. |
 | 8:00 | Close with the install or gist CTA. |
 
 ## PMF Evidence Fields
@@ -243,5 +251,5 @@ This storyboard is ready for the `ao demo` rebuild when:
 - The packet path is stable.
 - `product-council` is the named first-value profile.
 - The expected verdict shape is accepted.
-- The daemon lane is second-stage.
+- The out-of-session (Gas City) lane is second-stage.
 - Claim boundaries are copied into README/docs/demo work.

--- a/docs/examples/agentops-3-domain-practice-packet.md
+++ b/docs/examples/agentops-3-domain-practice-packet.md
@@ -59,8 +59,9 @@ weak review evidence, and cold starts between sessions.
 - The consolidated verdict should land in `.agents/council/` for local work.
 - Any public claim about PMF, productivity, or user outcomes needs exported
   evidence under `docs/releases/` or `evals/workbench/results/`.
-- The daemon/schedule lane is proof of deeper automation, not a prerequisite
-  for first value.
+- The out-of-session orchestration lane (the loop dispatched on the Gas City
+  reference City) is proof of deeper automation, not a prerequisite for first
+  value.
 
 ## Runtime Path
 
@@ -85,11 +86,15 @@ Run council:
 /council --mixed validate "Given docs/examples/agentops-3-domain-practice-packet.md, should the 3.0 launch demo lead with council-first engineering judgment?"
 ```
 
-Optional second-stage automation:
+Optional second-stage automation (out of session, on the Gas City reference
+City — AgentOps ships no daemon or scheduler of its own; see
+[ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)):
 
 ```bash
-ao init --with-schedule
-ao daemon run --schedule-file .agents/schedule.yaml
+# A long-lived mayor agent slings the next ready bead to a refinery worker,
+# which runs the loop as one invocable unit:
+ao rpi <bead-id>
+# Scheduled maintenance runs as Gas City cron Orders. See the using-gc skill.
 ```
 
 ## Expected Outputs
@@ -103,7 +108,7 @@ ao daemon run --schedule-file .agents/schedule.yaml
 
 ## Non-Goals
 
-- Do not lead with daemon/factory setup as the first proof.
+- Do not lead with out-of-session orchestration setup (Gas City) as the first proof.
 - Do not frame the product as generic multi-agent orchestration.
 - Do not use stale reliability-framed agent copy as public launch language.
 - Do not claim PMF or productivity improvements from local `.agents` notes

--- a/docs/patterns/completion-notifications.md
+++ b/docs/patterns/completion-notifications.md
@@ -11,7 +11,7 @@ Three patterns cover the common cases using infrastructure you already have.
 ## Pattern A — GitHub Actions issue creation
 
 Use when: the work is being run inside a GitHub Actions workflow (nightly
-dream cycle, scheduled `ao daemon` run, release proof harness).
+dream cycle, scheduled out-of-session run, release proof harness).
 
 The repo's `.github/workflows/nightly.yml` already does this for the dream-cycle
 proof job — when the run completes, a step opens or updates a GitHub issue
@@ -71,21 +71,26 @@ Trade-off: scoped to the local clone (only fires on the developer / runner
 that ran the commit), but reaches any HTTP endpoint and runs synchronously
 on commit so debugging is easy.
 
-## Pattern C — `ao daemon` log tailing
+## Pattern C — substrate event tailing (Gas City)
 
-Use when: the work runs as a long-lived job inside `ao daemon` (scheduled
-overnight Dream, recurring `ao goals measure`, scheduled wiki forge) and you
-want a downstream consumer to react to specific job events.
+Use when: the work runs unattended out of session on an orchestration
+substrate (the loop dispatched on the Gas City reference City — a scheduled
+Dream Order, a recurring `ao goals measure` Order, a wiki-forge Order) and you
+want a downstream consumer to react to specific job events. AgentOps ships no
+daemon of its own; out-of-session execution is delegated to the substrate (see
+[ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)), and the
+substrate is where the event stream lives.
 
-The daemon writes one JSON line per job event to its log. A consumer process
-(systemd unit, tmux pane, container sidecar) tails the log and forwards the
-events it cares about.
+The substrate writes one JSON line per Order/job event to its event log. A
+consumer process (systemd unit, tmux pane, container sidecar) tails that log
+and forwards the events it cares about.
 
 Skeleton:
 
 ```bash
-# Consumer running alongside the daemon
-tail -F ~/.local/state/agentops/daemon.log \
+# Consumer running alongside the Gas City substrate.
+# Point the tail at your substrate's event log (path varies by deployment).
+tail -F "$GC_EVENT_LOG" \
   | jq -c --unbuffered 'select(.event == "job.completed" and .job.kind == "dream.run")' \
   | while read -r line; do
       url=$(echo "$line" | jq -r '.job.report_url // empty')
@@ -95,9 +100,9 @@ tail -F ~/.local/state/agentops/daemon.log \
     done
 ```
 
-Trade-off: needs a long-running consumer process and the daemon to be running,
-but is the closest analog to a real webhook stream — every job event is
-visible, including failures and partial runs, with no GitHub or commit
+Trade-off: needs a long-running consumer process and the substrate to be
+running, but is the closest analog to a real webhook stream — every job event
+is visible, including failures and partial runs, with no GitHub or commit
 dependency.
 
 ## Decision matrix
@@ -106,7 +111,7 @@ dependency.
 |---|---|
 | Work runs in GitHub Actions; you watch issues | A — GitHub Actions issue creation |
 | Work writes a tracked artifact; you have a chat webhook URL | B — git post-commit → curl |
-| Work runs continuously under `ao daemon`; you want real-time events | C — daemon log tailing |
+| Work runs unattended on the substrate (Gas City); you want real-time events | C — substrate event tailing |
 | You think you need a webhook server | You probably don't — start with A or B; reach for C only if you genuinely need event streaming |
 
 ## What this is NOT

--- a/docs/plans/2026-05-11-evolution-roadmap.md
+++ b/docs/plans/2026-05-11-evolution-roadmap.md
@@ -14,6 +14,8 @@ research_refs:
 
 # Evolution Road Map — 2026-05-11
 
+> **Historical (2026-05-11).** A dated planning snapshot retained for provenance. Some surfaces it names have since changed — notably the standalone daemon (`agentopsd`) and its code map were removed in the AgentOps 3.0 rearchitecture ([ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)); AgentOps is in-session only, with out-of-session orchestration delegated to the Gas City reference City. Read for intent, not as a current task list.
+
 ## Purpose
 
 The 13-cycle /evolve session on 2026-05-11 shipped the practice-citation epic (756/756) and surfaced a structural friction: /evolve's Step 3 ladder picks from `bd ready` or `next-work.jsonl` but neither captures the **largest source of work in this repo** — the gap between aspirational docs (`PRODUCT.md`, `GOALS.md`, `PRACTICE-REGISTRY.md`, `docs/contracts/`, `docs/code-map/`, `docs/plans/`) and what the code actually does.
@@ -188,7 +190,7 @@ Currently enforced. Bead is to ratchet stricter: add `council-coverage` gate tha
 
 ## A3: Code-Map Drift Audit (1 audit bead + N follow-ups)
 
-`docs/code-map/` has `agentopsd-codebase-map.md` and `eval-lid-primitives.md`. Audit cycle:
+`docs/code-map/` has `eval-lid-primitives.md` (the `agentopsd` code map was removed with the daemon in 3.0 — see [ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)). Audit cycle:
 
 1. For each code map, extract claimed file structure / module layout / function names.
 2. Diff against actual repo via `find`, `ls`, and `grep`.

--- a/docs/runbooks/autonomy-runtime-cycle-1.md
+++ b/docs/runbooks/autonomy-runtime-cycle-1.md
@@ -1,8 +1,18 @@
 # Autonomy Runtime Cycle-1 Runbook
 
 **Date:** 2026-05-20
-**Scope:** Safe activation of AgentOps cycle-1 autonomy surfaces: RPI phased runs,
-`ao evolve` supervisor loops, and daemon-backed job execution.
+**Scope:** Safe activation of AgentOps cycle-1 in-session autonomy surfaces: RPI
+phased runs and `ao evolve` supervisor loops.
+
+> **3.0 note:** the daemon-backed job-execution lane this runbook originally
+> covered (`ao daemon jobs submit`, the `agentopsd` control plane) was **removed**
+> in the AgentOps 3.0 rearchitecture — AgentOps is in-session only and ships no
+> daemon of its own (see
+> [ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)). The in-session
+> loop (`ao rpi`, `ao evolve`) runs end-to-end in a plain session; to run it
+> unattended out of session, dispatch it on the **Gas City reference City** (a
+> mayor agent slings ready beads to refinery workers that run `ao rpi`). This
+> runbook now covers the in-session surfaces only.
 
 ## Activation
 
@@ -10,12 +20,9 @@
 2. Run baseline quality gates:
    - `cd cli && make build` (produces `cli/bin/ao`)
    - `cd cli && go test ./internal/rpi/...`
-   - `cd cli && go test ./internal/daemon/...`
 3. Verify required specs and index references exist:
-   - `docs/contracts/agentops-daemon.md`
-   - `docs/contracts/agentopsd-control-plane.md`
    - `docs/contracts/rpi-run-registry.md`
-   - `docs/documentation-index.md` references the daemon and RPI contracts.
+   - `docs/documentation-index.md` references the RPI contracts.
 4. Execute the target RPI run in dry/safe mode first and confirm no regressions in run artifacts and the bead ledger:
    - `ao rpi phased --dry-run "<goal>"` for one explicit run
    - `ao evolve --dry-run --max-cycles 1 "<goal>"` for the supervisor loop surface
@@ -24,18 +31,17 @@
 
 ## Feature Flags
 
-Cycle-1 runtime controls are command flags and daemon job payloads:
+Cycle-1 runtime controls are in-session command flags:
 
 - `ao evolve --supervisor=true` is the default supervised loop posture.
 - `ao evolve --max-cycles <n>` bounds autonomous iterations.
 - `ao evolve --dream-first` / `--dream-only` limits work to knowledge compounding before or instead of code cycles.
 - `ao rpi phased --runtime <name>` and `--runtime-cmd <cmd>` select the worker runtime for phased execution.
-- `ao daemon jobs submit --type <type> --payload @payload.json` activates daemon-backed work explicitly.
 
 Activation rule:
 
 - Start with `--dry-run` and `--max-cycles 1`.
-- Introduce daemon-backed job submission only after the local RPI and evolve dry runs are clean.
+- For unattended out-of-session runs, dispatch the loop on the Gas City reference City only after the local RPI and evolve dry runs are clean.
 - Keep manual merge/review in the loop until the release-readiness contract says otherwise.
 
 ## Rollback Trigger
@@ -58,18 +64,17 @@ Verify lifecycle and orchestration evidence via:
 
 1. RPI / bead events include the relevant lifecycle markers and payload fields.
    - RPI phased state and artifacts live under `.agents/rpi/`.
-   - Daemon jobs and events are inspectable with `ao daemon jobs list` and `ao daemon events show`.
+   - Out-of-session job events (when dispatched on Gas City) are inspectable through the substrate's own event surface, not an AgentOps daemon.
 2. RPI run ledger / bead store contains attempt records for affected beads (`bd show <id>`, `ao rpi status`).
-3. Daemon / RPI tests pass:
+3. RPI tests pass:
    - `cd cli && go test ./internal/rpi/...`
-   - `cd cli && go test ./internal/daemon/...`
 4. Autonomy smoke remains green:
-   - `cd cli && go test ./cmd/ao/... -run 'Test.*(RPI|Evolve|Daemon|Factory)'`
+   - `cd cli && go test ./cmd/ao/... -run 'Test.*(RPI|Evolve)'`
    - `bash scripts/ci-local-release.sh --fast --jobs 4` before promoting the activation.
 
 ## Operator Notes
 
-- This runbook does not enable daemon/fleet orchestration beyond explicit `ao daemon jobs submit` activation.
+- This runbook covers the in-session loop only; out-of-session/fleet orchestration is delegated to the Gas City reference City, not an AgentOps daemon.
 - This runbook does not relax validation boundaries (`/vibe`, `/council`, `ao goals validate`, gate scripts all still apply).
 - This runbook is cycle-1 only; fleet/autopilot runtime expansion is a follow-on cycle.
 
@@ -84,4 +89,4 @@ Verify lifecycle and orchestration evidence via:
 | Validation | `/vibe`, `/council`, `ao goals validate`, `scripts/ci-local-release.sh` |
 | Knowledge extraction | `ao forge` |
 | Contracts | `docs/contracts/*` + `docs/documentation-index.md` |
-| Runtime packages | `cli/internal/rpi/`, `cli/internal/daemon/`, `cli/cmd/ao/` |
+| Runtime packages | `cli/internal/rpi/`, `cli/cmd/ao/` |

--- a/docs/runbooks/nightly-evolution.md
+++ b/docs/runbooks/nightly-evolution.md
@@ -1,5 +1,17 @@
 # Nightly Evolution Runbook
 
+> **3.0 note:** the daemon-backed handoff this runbook originally described
+> (`ao daemon jobs submit`, `agentopsd`, `ao overnight`) was **removed** in the
+> AgentOps 3.0 rearchitecture — AgentOps is in-session only and ships no daemon,
+> scheduler, or overnight runner of its own (see
+> [ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)). The loop
+> (`ao rpi` / `ao evolve`, the `/dream` skill) runs in session; to run it
+> unattended out of session, dispatch it on the **Gas City reference City** (a
+> long-lived mayor agent slings ready beads to refinery workers that run
+> `ao rpi`; scheduled maintenance runs as Gas City cron Orders). This runbook is
+> retained for the repo-owned run-contract and digest mechanics; treat the
+> orchestration surface as Gas City, not an AgentOps daemon.
+
 This runbook describes the private local nightly automation lane. It is separate
 from GitHub Actions.
 
@@ -9,18 +21,18 @@ from GitHub Actions.
 |---------|------|
 | GitHub Nightly | Public proof harness over repo-visible state |
 | Nightly RPI Brief | Evidence packet and prompt issue |
-| Bushido scheduler | Local execution host for private runs |
+| Gas City reference City | Out-of-session orchestration substrate (mayor + refinery agents) for unattended runs |
 | `scripts/nightly-evolution.sh` | Repo-owned run contract and digest writer |
-| `ao daemon jobs submit --type dream.run` | Private Dream/wiki knowledge compounding handoff |
-| `ao rpi` / `ao evolve` | Code-mutating implementation cycles |
+| `/dream` skill | Private Dream/wiki knowledge compounding (in session; dispatched out of session via a Gas City Order) |
+| `ao rpi` / `ao evolve` | Code-mutating implementation cycles, dispatched as one invocable unit |
 | Claude Code | Headless worker/reviewer via local CLI or GitHub companion action |
 | Codex | Headless worker/reviewer via `codex exec` or local AgentOps runtime |
-| Mt. Olympus / Gas City | Future durable orchestration backend |
+| Mt. Olympus | Sovereign full-custom runtime (keeps its own Rust daemon) — alternate out-of-session driver |
 
-Bushido is a private dogfood target, not a public AgentOps namespace. The first
-production scheduler is a host user timer or cron entry that calls the repo
-script. Mt. Olympus can later run the same contract through Gas City once
-provider readiness and replay are proven.
+Bushido is a private dogfood target, not a public AgentOps namespace. Out-of-
+session runs are dispatched on the Gas City reference City; AgentOps ships no
+scheduler of its own. Mt. Olympus can run the same contract through its sovereign
+Rust core once provider readiness and replay are proven.
 
 ## First Safe Run
 
@@ -36,9 +48,11 @@ Run only the private Dream/wiki lane:
 scripts/nightly-evolution.sh --execute --run-dream
 ```
 
-This submits a typed `dream.run` daemon job. If daemon submission fails, the
-wrapper falls back to the legacy `ao overnight start` subprocess for operator
-compatibility unless `--skip-dream-subprocess` is supplied.
+In 3.0 the Dream lane runs the `/dream` skill in session; to run it unattended,
+dispatch it as a Gas City Order. The daemon-backed `dream.run` job submission
+this flag historically used was removed with the daemon
+([ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)); the run
+contract and digest mechanics below are unaffected.
 
 Run one bounded evolve cycle with Codex as the runtime command:
 
@@ -57,7 +71,12 @@ Run both lanes after the dry-run and Dream-only pilot have passed:
 scripts/nightly-evolution.sh --execute --run-dream --run-evolve --max-cycles 1
 ```
 
-## Scheduling
+## Host-OS timing (not an AgentOps scheduler)
+
+AgentOps ships no scheduler; recurring runs are driven by host-OS timing (a
+systemd user timer or cron) calling the repo script, or by a Gas City cron
+Order. The helper below installs a **host systemd user timer** — operator
+infrastructure, not an AgentOps-managed surface.
 
 ### Automated Install
 
@@ -81,7 +100,8 @@ scripts/install-nightly-scheduler.sh --uninstall
 ```
 
 Options: `--schedule`, `--runners`, `--runtime-cmd`, `--max-cycles`. See
-`scripts/install-nightly-scheduler.sh --help` for full reference.
+`scripts/install-nightly-scheduler.sh --help` for full reference. (These are
+flags of the host-timer install helper, not of any AgentOps CLI command.)
 
 ### Manual Install (alternative)
 
@@ -119,15 +139,17 @@ systemctl --user enable --now agentops-nightly-evolution.timer
 
 Use Claude and Codex differently until eval evidence says mixed mode is stable:
 
-- Dream daemon handoff: submit `dream.run` through `agentopsd`. The legacy
-  subprocess fallback still honors the configured Claude/Codex runner list.
+- Dream handoff: run the `/dream` skill in session; dispatch it out of session
+  as a Gas City Order (no AgentOps daemon — see
+  [ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)). The run
+  contract still honors the configured Claude/Codex runner list.
 - Planning/review: prefer Claude or mixed mode for synthesis-heavy work.
 - Implementation: use Codex when local shell/code execution is the primary
   burden.
 - CI/GitHub companion: use Claude Code GitHub Actions for repo-visible reviews
   or reports, not private `.agents` mutation.
-- Gas City: use `runtime=gc` only after provider readiness and replay are
-  proven.
+- Gas City: dispatch whole `ao rpi` / `ao evolve` loops as one invocable unit
+  only after provider readiness and replay are proven.
 
 ## Safety Controls
 


### PR DESCRIPTION
## What

Worker 3 of the ag-p7j 3-way swarm reconciling stale daemon/scheduler references for AgentOps 3.0. This worker owns the **peripheral docs** (comparisons, examples, runbooks, plans, brainstorms, the daemon-jobspec RFC) — pure prose edits only.

The standalone daemon (`ao daemon` / `agentopsd`), scheduler (`ao schedule`), and overnight runner (`ao overnight`) were **deleted** in the 3.0 rearchitecture ([ADR-0009](https://github.com/boshu2/agentops/blob/main/docs/adr/ADR-0009-daemon-deletion-in-session-only.md)). AgentOps is **in-session only**; out-of-session orchestration is delegated to the **Gas City reference City**. This PR mirrors `docs/3.0.md` across the peripheral surface.

## Files changed (12)

- **Comparisons** — reframe the "off-API daemon" *feature* claim to off-API/off-vendor **in-session operation + Gas City out-of-session dispatch**; drop the deleted `dream-run-contract` link:
  - `docs/comparisons/competition-rpi-memory-pipelines.md`
  - `docs/comparisons/competitive-radar.md`
  - `docs/comparisons/vs-everything-claude-code.md`
  - `docs/comparisons/vs-tons-of-skills.md`
- **Examples** — replace `ao daemon`/`ao schedule` snippets with mayor-driven `ao rpi` dispatch on the reference City; reframe "daemon-first" → "automation-first out-of-session orchestration":
  - `docs/examples/agentops-3-council-demo-storyboard.md`
  - `docs/examples/agentops-3-domain-practice-packet.md`
  - `docs/agentops-3-explainer-kit.md`
- **Patterns** — rewrite Pattern C from `ao daemon` log tailing to **substrate (Gas City) event tailing**:
  - `docs/patterns/completion-notifications.md`
- **Runbooks** — add 3.0 historical banners, neutralize `ao daemon jobs submit`/`agentopsd`/`ao overnight` instructions, drop deleted daemon-contract refs; host systemd timer reframed as host-OS timing (not an AgentOps scheduler):
  - `docs/runbooks/nightly-evolution.md`
  - `docs/runbooks/autonomy-runtime-cycle-1.md`
- **Plans / Brainstorms** — dated historical artifacts: one-line historical note + neutralize only active "use `ao overnight`" instructions; remove the deleted `agentopsd` code-map reference:
  - `docs/plans/2026-05-11-evolution-roadmap.md`
  - `docs/brainstorms/2026-04-12-compiled-knowledge-workspace-requirements.md`

`docs/rfcs/0002-jobspec-openapi-v0.md` already carried the requested superseded/historical banner (body retained), so it needed no change.

## Gate results

- `markdownlint --config .markdownlint.json` (12 changed files): **PASS**
- `tests/docs/validate-doc-release.sh`: **PASS**
- `mkdocs build --strict`: **PASS** (0 warnings/errors attributable to changed files)
- All 13 new ADR/contract relative links resolve; **no links to deleted daemon contracts** remain.
- Grep of changed files for `ao daemon|agentopsd|ao schedule|ao overnight|ao plans|ao watch`: only historical banners, explicit disavowals ("no AgentOps daemon"), surviving real script names (`scripts/install-nightly-scheduler.sh`), and dated-brainstorm descriptive context covered by its banner. No active "use X" instructions remain.
- diff stat: 164 insertions / 101 deletions — proportionate, no anomalous data loss.

Closes-scenario: ag-p7j#w3-peripheral
Bounded-context: BC1-Corpus
Evidence: docs/comparisons/competitive-radar.md