### PR TITLE
docs(3.0): final daemon-prose stragglers (dream-report + UPGRADING)

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -68,6 +68,8 @@ The AO↔Olympus bridge has been archived. Removed surfaces:
 
 ### Daemon mode is available as an opt-in product runtime
 
+> **⚠ Superseded in AgentOps 3.0:** the standalone daemon (`agentopsd`) was **removed** in the 3.0 rearchitecture — AgentOps is in-session only, and out-of-session orchestration is delegated to the Gas City reference City. See [`MIGRATION-3.0.md`](MIGRATION-3.0.md) and [ADR-0009](adr/ADR-0009-daemon-deletion-in-session-only.md). The entry below is retained as historical record of the (now-removed) v2.x daemon.
+
 **Affects:** anyone migrating RPI, Dream, wiki/forge, or OpenClaw integrations
 from foreground command ownership to `agentopsd`.
 

--- a/docs/contracts/dream-report.md
+++ b/docs/contracts/dream-report.md
@@ -106,7 +106,7 @@ Minimum sections:
 
 Future consumers of this contract:
 
-- `ao overnight report`
+- the in-session `/dream` report (the standalone overnight runner was removed in 3.0)
 - Dream Setup validation
 - Dream Council synthesis
 - DreamScape terrain visualization


### PR DESCRIPTION
Clears the last 2 active stale daemon refs after the ag-p7j swarm (grep 48 → 3 → 0 live):
- docs/contracts/dream-report.md: ao overnight report consumer → in-session /dream report
- docs/UPGRADING.md: Superseded-in-3.0 banner on the v2.x daemon entry (migration record, historical refs retained by design)
The 3rd file (plans/2026-05-11 roadmap) already has a Historical banner.

Closes-scenario: ag-p7j#final-stragglers
Bounded-context: BC1-Corpus
Evidence: docs/UPGRADING.md