### PR TITLE
fix(release): pre-publish gate accepts WARN_QUALITY — unblock v3.0.0 publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,16 +74,17 @@ jobs:
           ./scripts/security-gate.sh --mode full --json > release-artifacts/security-gate-summary.json
           SECURITY_RC=$?
           set -e
-          # [v3.0.0 release-block debug] surface the gate finding to the log — the summary
-          # is not uploaded when this step fails, so print it + the per-tool detail before the gate check.
-          echo "::group::security-gate-summary.json"
-          jq . release-artifacts/security-gate-summary.json 2>/dev/null || cat release-artifacts/security-gate-summary.json
-          echo "::endgroup::"
-          echo "::group::toolchain-findings-detail"
-          find "${TMPDIR:-/tmp}/agentops-tooling" "${TMPDIR:-/tmp}/agentops-security" -type f 2>/dev/null | while read -r _ff; do echo "=== ${_ff} ==="; sed -n '1,60p' "${_ff}"; done | head -400
-          echo "::endgroup::"
           jq empty release-artifacts/security-gate-summary.json
-          jq -e '((.gate_status // "") | ascii_downcase) == "pass"' release-artifacts/security-gate-summary.json
+          # The toolchain grades quality-lint findings as WARN_QUALITY — explicitly non-blocking
+          # ("Gate: PASS (quality warnings, non-blocking)" in scripts/toolchain-validate.sh). This
+          # pre-publish SECURITY gate blocks only on actual security findings (BLOCKED_HIGH /
+          # BLOCKED_CRITICAL), so accept pass + warn_quality and print the summary on a real block.
+          GATE_STATUS="$(jq -r '(.gate_status // "") | ascii_downcase' release-artifacts/security-gate-summary.json)"
+          if [[ "$GATE_STATUS" != "pass" && "$GATE_STATUS" != "warn_quality" ]]; then
+            echo "ERROR: pre-publish security gate blocked: gate_status=${GATE_STATUS}"
+            jq . release-artifacts/security-gate-summary.json 2>/dev/null || cat release-artifacts/security-gate-summary.json
+            exit 1
+          fi
           if [[ "$SECURITY_RC" -ne 0 ]]; then
             echo "ERROR: pre-publish security gate failed with exit code $SECURITY_RC"
             exit "$SECURITY_RC"


### PR DESCRIPTION
The v3.0.0 release blocked at pre-publish-evidence: gate_status=WARN_QUALITY (golangci-lint quality_high=3; security_high=0, critical=0). The toolchain explicitly grades WARN_QUALITY as non-blocking PASS (toolchain-validate.sh:969-970); the release gate erroneously required ==pass. A release SECURITY gate must block only on security findings (BLOCKED_HIGH/CRITICAL). Now accepts pass + warn_quality; prints summary on a real block. Removes the temporary #535 debug. The 3 quality findings are tracked in ag-x0d for a 3.0.x patch.

Bounded-context: BC5-Runtime
Evidence: scripts/toolchain-validate.sh