### PR TITLE
chore(release): v3.0.1 — plugin version bump + Nightly Static Validation fix (ag-s3z)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "The operational layer for coding agents. Bookkeeping, validation, and flows that compound knowledge between sessions.",
-    "version": "3.0.0"
+    "version": "3.0.1"
   },
   "plugins": [
     {
       "name": "agentops",
       "description": "The operational layer for coding agents. Bookkeeping, validation, and flows that compound knowledge between sessions.",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "source": "./",
       "author": {
         "name": "Boden Fuller",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentops",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The operational layer for coding agents. Bookkeeping, validation, and flows that compound knowledge between sessions.",
   "author": {
     "name": "Boden Fuller",

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,11 +54,6 @@ jobs:
           chmod +x tests/docs/validate-doc-release.sh
           ./tests/docs/validate-doc-release.sh
 
-      - name: Validate hooks/docs parity
-        run: |
-          chmod +x scripts/validate-hooks-doc-parity.sh
-          ./scripts/validate-hooks-doc-parity.sh
-
   retrieval-bench:
     name: Retrieval Quality Bench
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1] - 2026-05-25
+
+Patch release. No runtime behavior change — it advances the plugin/marketplace version so existing `3.0.0` installs can `claude plugin update` cleanly (the `3.0.0` version label never moved across the 15 commits that landed the skill consolidation and doc reconciliation, so a plain update reported "already latest"). Also reconciles two release-engineering surfaces the per-PR gate did not exercise:
+
+- **`claude plugin update` now works for early 3.0.0 installs.** Version bumped to 3.0.1 across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (metadata + plugin), and the `install-ao.sh` pin.
+- **Nightly Static Validation is green again.** Removed the Nightly step that ran the deleted `scripts/validate-hooks-doc-parity.sh` (hooks were removed in 3.0). Repointed/retired two stale `tests/docs/validate-skill-count.sh` extraction patterns that grepped PRODUCT.md for hook-era phrasing ("runtime hook event sections", the "### 1. Skills (N across 4 runtimes)" heading) that the 3.0 restructure removed.
+
 ## [3.0.0] - 2026-05-24
 
 AgentOps 3.0 is the **hookless-first** major. The headline: AgentOps is what runs **in-session** — skills + the `ao` CLI + the RPI/evolve/crank/swarm loops + the context-compiler. Out-of-session orchestration (scheduling, daemons, autonomous dispatch) is delegated to Gas City (a reference City ships in this release) or Olympus. The default install registers **zero hooks**; the lifecycle is driven by skills and CI gates. See `docs/3.0.md` for the north star.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1] - 2026-05-25
+
+Patch release. No runtime behavior change — it advances the plugin/marketplace version so existing `3.0.0` installs can `claude plugin update` cleanly (the `3.0.0` version label never moved across the 15 commits that landed the skill consolidation and doc reconciliation, so a plain update reported "already latest"). Also reconciles two release-engineering surfaces the per-PR gate did not exercise:
+
+- **`claude plugin update` now works for early 3.0.0 installs.** Version bumped to 3.0.1 across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (metadata + plugin), and the `install-ao.sh` pin.
+- **Nightly Static Validation is green again.** Removed the Nightly step that ran the deleted `scripts/validate-hooks-doc-parity.sh` (hooks were removed in 3.0). Repointed/retired two stale `tests/docs/validate-skill-count.sh` extraction patterns that grepped PRODUCT.md for hook-era phrasing ("runtime hook event sections", the "### 1. Skills (N across 4 runtimes)" heading) that the 3.0 restructure removed.
+
 ## [3.0.0] - 2026-05-24
 
 AgentOps 3.0 is the **hookless-first** major. The headline: AgentOps is what runs **in-session** — skills + the `ao` CLI + the RPI/evolve/crank/swarm loops + the context-compiler. Out-of-session orchestration (scheduling, daemons, autonomous dispatch) is delegated to Gas City (a reference City ships in this release) or Olympus. The default install registers **zero hooks**; the lifecycle is driven by skills and CI gates. See `docs/3.0.md` for the north star.

--- a/packs/agentops/assets/scripts/install-ao.sh
+++ b/packs/agentops/assets/scripts/install-ao.sh
@@ -26,7 +26,7 @@
 set -eu
 
 # Pinned AgentOps release. Override per-deploy with AO_VERSION in the env.
-AO_VERSION="${AO_VERSION:-v3.0.0}"
+AO_VERSION="${AO_VERSION:-v3.0.1}"
 AO_REPO="${AO_REPO:-boshu2/agentops}"
 
 WORK_DIR="${1:?usage: install-ao.sh <work-dir>}"

--- a/tests/docs/validate-skill-count.sh
+++ b/tests/docs/validate-skill-count.sh
@@ -133,8 +133,11 @@ check_numeric_match "docs/ARCHITECTURE.md internal" "$architecture_internal" "$a
 
 # --- Extract counts from PRODUCT.md ---
 
-product_total=$(extract_number 's|.*[^0-9]\([0-9][0-9]*\) skills, [0-9][0-9]* runtime hook event sections,.*|\1|' "$REPO_ROOT/PRODUCT.md" "PRODUCT.md zero-setup value proposition total")
-product_layer_total=$(extract_number 's|^### 1[.] Skills (\([0-9][0-9]*\) skills across 4 runtimes).*|\1|' "$REPO_ROOT/PRODUCT.md" "PRODUCT.md skill layer heading")
+# 3.0 removed hooks and restructured PRODUCT.md, so the old anchors
+# ("N skills, M runtime hook event sections" and the "### 1. Skills (N across 4 runtimes)"
+# heading) no longer exist. product_total now anchors on the four-layers skill-count line;
+# the former product_layer_total check is retired (no equivalent heading post-rip).
+product_total=$(extract_number 's|^- \([0-9][0-9]*\) skills .*reusable context packages.*|\1|' "$REPO_ROOT/PRODUCT.md" "PRODUCT.md four-layers skill count")
 product_convergence_total=$(extract_number 's|.*Skills system — \([0-9][0-9]*\) skills,.*|\1|' "$REPO_ROOT/PRODUCT.md" "PRODUCT.md convergence skill count")
 product_distribution_shared=$(extract_number 's|.*Distribution/runtime reach: \([0-9][0-9]*\) shared skills, [0-9][0-9]* checked-in Codex artifacts, and [0-9][0-9]* Codex overrides.*|\1|' "$REPO_ROOT/PRODUCT.md" "PRODUCT.md distribution shared skill count")
 product_distribution_codex=$(extract_number 's|.*Distribution/runtime reach: [0-9][0-9]* shared skills, \([0-9][0-9]*\) checked-in Codex artifacts, and [0-9][0-9]* Codex overrides.*|\1|' "$REPO_ROOT/PRODUCT.md" "PRODUCT.md distribution Codex artifact count")
@@ -142,7 +145,6 @@ product_distribution_overrides=$(extract_number 's|.*Distribution/runtime reach:
 
 echo "=== PRODUCT.md claims ==="
 echo "  Total: $product_total"
-echo "  Skill layer heading: $product_layer_total"
 echo "  Convergence skill count: $product_convergence_total"
 echo "  Distribution shared skills: $product_distribution_shared"
 echo "  Distribution Codex artifacts: $product_distribution_codex"
@@ -150,7 +152,6 @@ echo "  Distribution Codex overrides: $product_distribution_overrides"
 echo ""
 
 check_numeric_match "PRODUCT.md total" "$product_total" "$actual_total"
-check_numeric_match "PRODUCT.md skill layer heading" "$product_layer_total" "$actual_total"
 check_numeric_match "PRODUCT.md convergence skill count" "$product_convergence_total" "$actual_total"
 check_numeric_match "PRODUCT.md distribution shared skill count" "$product_distribution_shared" "$actual_total"
 check_numeric_match "PRODUCT.md distribution Codex artifact count" "$product_distribution_codex" "$actual_codex_total"
@@ -168,7 +169,6 @@ internals=()
 [[ "$skills_doc_total" != "NOT_FOUND" ]] && totals+=("docs/SKILLS-header:$skills_doc_total")
 [[ "$architecture_total" != "NOT_FOUND" ]] && totals+=("docs/ARCHITECTURE:$architecture_total")
 [[ "$product_total" != "NOT_FOUND" ]] && totals+=("PRODUCT:$product_total")
-[[ "$product_layer_total" != "NOT_FOUND" ]] && totals+=("PRODUCT-layer:$product_layer_total")
 [[ "$product_convergence_total" != "NOT_FOUND" ]] && totals+=("PRODUCT-convergence:$product_convergence_total")
 [[ "$product_distribution_shared" != "NOT_FOUND" ]] && totals+=("PRODUCT-distribution-shared:$product_distribution_shared")
 


### PR DESCRIPTION
Two release-engineering surfaces the per-PR validate.yml gate never exercised:

1. **Plugin updatability.** The 3.0.0 version label never moved across the 15 commits that landed the skill consolidation + doc reconciliation, so existing installs got "already at latest version" from `claude plugin update` and stayed stale. Bump 3.0.0 → 3.0.1 (plugin.json, marketplace.json metadata+plugin, install-ao.sh) + CHANGELOG 3.0.1 entry (root + docs, byte-identical).

2. **Nightly Static Validation (red on main).** The hooks rip (#511) deleted `scripts/validate-hooks-doc-parity.sh` but Nightly still ran it; `tests/docs/validate-skill-count.sh` greps PRODUCT.md for hook-era phrasing the 3.0 restructure removed → 2 MISSING_PATTERN fails (warn-tolerated in validate.yml, fail-closed in Nightly). Removed the dead step; repointed product_total to the four-layers line; retired product_layer_total.

Verified locally: validate-skill-count.sh + validate-doc-release.sh pass (total=75); version-consistency = 3.0.1 across all 3 manifest fields.

Follow-ups: ag-728 (PRODUCT.md daemon/hook prose), ag-x0d (3 golangci quality findings).

Closes-scenario: ag-s3z#v3-0-1-release-readiness
Bounded-context: BC5-Runtime
Evidence: tests/docs/validate-skill-count.sh