### PR TITLE
docs(release): curated release notes for v3.0.0 + v3.0.1

### DIFF
--- a/docs/releases/2026-05-24-v3.0.0-notes.md
+++ b/docs/releases/2026-05-24-v3.0.0-notes.md
@@ -1,0 +1,59 @@
+## Highlights
+
+AgentOps v3.0.0 is the **hookless, in-session-only** major. The thesis sharpened: AgentOps is what runs **inside a session** — skills, the `ao` CLI, the RPI / evolve / crank / swarm loops, and the `.agents/` context-compiler. Everything that tried to be an always-on orchestration runtime is removed. Out-of-session orchestration (when work runs, who supervises it, how agents coordinate) is delegated to a substrate you choose: Gas City (a reference City ships in this release) or Mount Olympus. `docs/3.0.md` is the north star.
+
+The headline number is roughly **117K LOC removed** across a five-wave rip: all hooks (#511), the daemon and `agentopsd` (#515), the scheduler / `plans` / `watch` / `overnight` lane (#514), the `factory` command and its contract corpus (#512), and the `runtime=gc` phased-engine bridge (#513). The default install now registers **zero hooks**; the lifecycle is guided by skills and enforced by CI gates, which are the authoritative push gate.
+
+This release also tightens the surface that remains: real hexagonal port adapters (corpus / tracker / workspace), a BDD acceptance layer with scenario→test linkage as a CI gate, the AgentOps reference Gas City (`city.toml` + `packs/agentops`), `ao validate --gate` as the deterministic retry hook for Gas City and CI, and a skill consolidation that took the catalog to **75 skills**.
+
+## Upgrade Notes
+
+- **Hooks are gone by default.** `ao hooks install`, `--with-hooks`, and the embedded hook surface are removed. What a PreToolUse/PostToolUse hook enforced locally, a CI job now enforces on push (`.github/workflows/validate.yml`). If you authored your own gates, the `hooks-authoring` skill still lets you build bounded ones.
+- **No out-of-session runtime.** `ao daemon` / `agentopsd`, `ao schedule`, `ao plans`, `ao watch`, and `ao overnight` are deleted. For always-on work, run the **reference Gas City** (`city.toml` + `packs/agentops`) or Mount Olympus. In-session, run the loop directly: `ao rpi` (one cycle), `ao evolve` (many), `crank`/`swarm` for agent waves. Migration guide: `docs/MIGRATION-3.0.md`.
+- **`runtime=gc` is no longer valid.** `ao rpi` keeps its non-gc backends (`auto` / `direct` / `stream` / `tmux`); Gas City now dispatches whole `ao rpi` loops as one unit rather than driving the phased engine through a bridge.
+- **Gas City dispatch is mayor-driven today.** The reference City works end-to-end for start / agent-spawn / skills-overlay / loop-entry / corpus; order-level *autonomous* dispatch is a labeled upstream-maturity gap (`soc-5jwah`). Use a long-lived mayor agent (`bd ready` → `gc sling`) plus cron exec orders for maintenance.
+- **Nothing you ran in-session changed.** `ao rpi`, `ao evolve`, `crank`, `swarm`, `ao harvest`, `ao forge`, `ao mine`, `ao compile`, `ao wiki`, `ao doctor`, `ao goals`, and the `.agents/` corpus are all unchanged.
+
+## At a Glance
+
+| Area | Added | Changed | Removed |
+|---|---:|---:|---:|
+| Hooks | 0 | 0 | all (53 runtime hooks) |
+| Daemon / scheduler / factory / gc-bridge | 0 | 0 | 4 subsystems (~117K LOC) |
+| Reference Gas City (`city.toml` + pack) | 1 | 0 | 0 |
+| Hexagonal port adapters (corpus / tracker / workspace) | 3 | 0 | 0 |
+| `ao validate --gate` | 1 | 0 | 0 |
+| BDD acceptance layer (scenario→test gate) | 1 | 0 | 0 |
+| Doctrine (`docs/3.0.md`, ADR-0009, migration guide) | 3 | 0 | 0 |
+| Skills | 0 | consolidated → 75 | several merged |
+
+## Product Areas
+
+### The Rip (BREAKING)
+
+- **Hookless by default** (`soc-57b7f`, #511) — 53 runtime hooks audited and removed; capabilities that lived in hooks (standards injection, commit-review gating) are now CLI ports + CI gates.
+- **Daemon carved out** (`soc-2rtm0`, #515) — `internal/daemon` + the `agentopsd` binary deleted. No out-of-session runtime ships.
+- **Scheduling removed** (`soc-2rtm0`, #514) — `ao schedule` / `plans` / `watch` / `overnight` deleted; Gas City owns scheduling.
+- **`factory` retired** (`soc-2rtm0`, #512) — the `ao factory` command and its contract corpus removed; the factory is the loop.
+- **gc-bridge severed** (`soc-2rtm0`, #513) — the CLI gc-bridge glue deleted; `runtime=gc` removed.
+
+### What's New
+
+- **AgentOps reference Gas City** — a turnkey City (`city.toml` + `agentops` pack + skills overlay) demonstrating out-of-session orchestration on AgentOps skills.
+- **`ao validate --gate`** — PASS/WARN/FAIL collapsed to a process exit code; the retry hook for Gas City `check` and CI, no network or LLM.
+- **Real hexagonal port adapters** — `corpus_fs` reader/writer, a bd-backed TrackerPort, a git-backed WorkspacePort, each wired to its core consumer.
+- **BDD acceptance layer** — scenario→test linkage runner + CI gate (`soc-63xfx`); canonical `.feature` acceptance across skills.
+- **The 3.0 doctrine** — `docs/3.0.md` north star, `ADR-0009` (daemon deletion / in-session-only), the canonical-loop model, and `docs/MIGRATION-3.0.md`.
+
+### Tightened
+
+- **Honest doctrine reconciliation** — README, PRODUCT, and docs reframed to the in-session core; the out-of-session autonomous-dispatch gap explicitly labeled (`soc-5jwah`).
+- **Skill consolidation → 75** — overlapping skills merged into mode flags (e.g. `council`, `doc`, `post-mortem`); the catalog is the leaner 3.0 surface.
+
+## See Also
+
+- Full per-commit detail: `CHANGELOG.md` (entry `[3.0.0]`)
+- North star: `docs/3.0.md`
+- Migration guide: `docs/MIGRATION-3.0.md`
+- Daemon-deletion decision: `docs/adr/ADR-0009-daemon-deletion-in-session-only.md`
+- Follow-up patch: `docs/releases/2026-05-25-v3.0.1-notes.md` (v3.0.1)

--- a/docs/releases/2026-05-25-v3.0.1-notes.md
+++ b/docs/releases/2026-05-25-v3.0.1-notes.md
@@ -1,0 +1,26 @@
+## Highlights
+
+AgentOps v3.0.1 is a **release-engineering patch** for v3.0.0. It makes one user-visible thing work and greens one CI lane — no product behavior changes.
+
+The user-visible fix: existing v3.0.0 plugin installs can now `claude plugin update` to the latest content. The `3.0.0` version label was set early (at PR #522) and never moved across the 15 commits that landed the skill consolidation and doc reconciliation, so `claude plugin update` compared `3.0.0 == 3.0.0` and reported "already at latest" — leaving early installs pinned to a stale commit. Bumping to `3.0.1` gives the marketplace a new version to advertise.
+
+The CI fix: the **Nightly Static Validation** lane was red on `main` from two pieces of 3.0-rip fallout that the per-PR `validate.yml` gate never exercised — a Nightly step still ran the deleted `validate-hooks-doc-parity.sh`, and the skill-count checker still grepped `PRODUCT.md` for hook-era phrasing the 3.0 restructure removed.
+
+## Upgrade Notes
+
+- **Existing v3.0.0 installs:** run `claude plugin update agentops@agentops-marketplace` to pick up 3.0.1. If a plain update still reports "already latest" (you installed 3.0.0 at an early commit), `uninstall --keep-data` then `install` once — after 3.0.1 the version-based update path works normally.
+- **The v3.0.0 GitHub Release remains as published.** v3.0.1 is the clean, fully-consolidated release; new installs should use v3.0.1.
+- No CLI or behavioral changes from v3.0.0.
+
+## Fixed
+
+- **`claude plugin update` stayed stale for early 3.0.0 installs.** The plugin/marketplace version never advanced past `3.0.0` across the post-#522 consolidation commits, so the version-string update check was a no-op. Bumped to `3.0.1` across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (metadata + plugin), and the City pack's pinned `AO_VERSION` (`packs/agentops/assets/scripts/install-ao.sh`).
+- **Nightly Static Validation was red on `main`.** Two stale references to surfaces deleted in the 3.0 rip:
+  - The Nightly workflow still `chmod +x`/ran `scripts/validate-hooks-doc-parity.sh`, deleted with the hooks rip (#511). Step removed — AgentOps is hookless, so there is no hooks/docs parity to validate.
+  - `tests/docs/validate-skill-count.sh` extracted skill counts from `PRODUCT.md` via patterns that grepped hook-era phrasing the 3.0 restructure removed ("N skills, M runtime hook event sections" and the "### 1. Skills (N across 4 runtimes)" heading) → two `MISSING_PATTERN` fail-closed errors (warn-tolerated in `validate.yml`, fail-closed in Nightly). Repointed `product_total` to the four-layers skill-count line; retired the obsolete `product_layer_total` check.
+
+## See Also
+
+- Full per-commit detail: `CHANGELOG.md` (entry `[3.0.1]`)
+- v3.0.0 notes: `docs/releases/2026-05-24-v3.0.0-notes.md`
+- Follow-ups: bd `ag-728` (reconcile PRODUCT.md prose to hookless/daemonless reality), bd `ag-x0d` (3 golangci-lint quality findings the release security gate surfaced)


### PR DESCRIPTION
Audit finding: extract-release-notes.sh builds the GitHub release body from a curated docs/releases/<date>-v<ver>-notes.md (Highlights / Upgrade Notes / Product Areas / See Also) and tucks the raw CHANGELOG into a collapsed <details>. v3.0.0 and v3.0.1 shipped WITHOUT that file, so the script silently fell back to dumping the raw CHANGELOG — the published pages did not follow the curated format.

Adds both curated files: major-release style for 3.0.0 (At a Glance + Product Areas + The Rip breaking section), patch style for 3.0.1 (matches v2.41.1). Verified both regenerate with curated highlights + collapsed full-changelog. Published v3.0.0/v3.0.1 release bodies updated to match.

Bounded-context: BC5-Runtime
Evidence: scripts/extract-release-notes.sh