### PR TITLE
feat(release): enforce release-notes standard + major variant (ag-d0f)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,12 @@ jobs:
           fi
           echo "Homebrew token validated"
 
+      - name: Validate curated release notes (hard gate)
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          chmod +x scripts/validate-release-notes.sh
+          scripts/validate-release-notes.sh "$VERSION"
+
       - name: Extract release notes from CHANGELOG.md
         run: |
           VERSION="${{ steps.version.outputs.version }}"

--- a/docs/releases/2026-05-24-v3.0.0-notes.md
+++ b/docs/releases/2026-05-24-v3.0.0-notes.md
@@ -1,59 +1,76 @@
 ## Highlights
 
-AgentOps v3.0.0 is the **hookless, in-session-only** major. The thesis sharpened: AgentOps is what runs **inside a session** — skills, the `ao` CLI, the RPI / evolve / crank / swarm loops, and the `.agents/` context-compiler. Everything that tried to be an always-on orchestration runtime is removed. Out-of-session orchestration (when work runs, who supervises it, how agents coordinate) is delegated to a substrate you choose: Gas City (a reference City ships in this release) or Mount Olympus. `docs/3.0.md` is the north star.
-
-The headline number is roughly **117K LOC removed** across a five-wave rip: all hooks (#511), the daemon and `agentopsd` (#515), the scheduler / `plans` / `watch` / `overnight` lane (#514), the `factory` command and its contract corpus (#512), and the `runtime=gc` phased-engine bridge (#513). The default install now registers **zero hooks**; the lifecycle is guided by skills and enforced by CI gates, which are the authoritative push gate.
-
-This release also tightens the surface that remains: real hexagonal port adapters (corpus / tracker / workspace), a BDD acceptance layer with scenario→test linkage as a CI gate, the AgentOps reference Gas City (`city.toml` + `packs/agentops`), `ao validate --gate` as the deterministic retry hook for Gas City and CI, and a skill consolidation that took the catalog to **75 skills**.
+AgentOps v3.0.0 is the **hookless, in-session-only** major. The thesis sharpened: AgentOps is what runs inside a session — skills, the `ao` CLI, the RPI / evolve / crank / swarm loops, and the `.agents/` context-compiler. Everything that tried to be an always-on orchestration runtime is gone, and out-of-session orchestration (when work runs, who supervises it, how agents coordinate) is delegated to a substrate you choose: Gas City (a reference City ships here) or Mount Olympus. Roughly 117K lines were removed across a five-wave rip, the default install now registers zero hooks, and CI is the authoritative gate. `docs/3.0.md` is the north star.
 
 ## Upgrade Notes
 
-- **Hooks are gone by default.** `ao hooks install`, `--with-hooks`, and the embedded hook surface are removed. What a PreToolUse/PostToolUse hook enforced locally, a CI job now enforces on push (`.github/workflows/validate.yml`). If you authored your own gates, the `hooks-authoring` skill still lets you build bounded ones.
-- **No out-of-session runtime.** `ao daemon` / `agentopsd`, `ao schedule`, `ao plans`, `ao watch`, and `ao overnight` are deleted. For always-on work, run the **reference Gas City** (`city.toml` + `packs/agentops`) or Mount Olympus. In-session, run the loop directly: `ao rpi` (one cycle), `ao evolve` (many), `crank`/`swarm` for agent waves. Migration guide: `docs/MIGRATION-3.0.md`.
-- **`runtime=gc` is no longer valid.** `ao rpi` keeps its non-gc backends (`auto` / `direct` / `stream` / `tmux`); Gas City now dispatches whole `ao rpi` loops as one unit rather than driving the phased engine through a bridge.
-- **Gas City dispatch is mayor-driven today.** The reference City works end-to-end for start / agent-spawn / skills-overlay / loop-entry / corpus; order-level *autonomous* dispatch is a labeled upstream-maturity gap (`soc-5jwah`). Use a long-lived mayor agent (`bd ready` → `gc sling`) plus cron exec orders for maintenance.
-- **Nothing you ran in-session changed.** `ao rpi`, `ao evolve`, `crank`, `swarm`, `ao harvest`, `ao forge`, `ao mine`, `ao compile`, `ao wiki`, `ao doctor`, `ao goals`, and the `.agents/` corpus are all unchanged.
+- If you ran AgentOps **in a session**, nothing you rely on changed — `ao rpi`, `ao evolve`, `crank`, `swarm`, and the `.agents/` corpus are unchanged.
+- If you ran the **daemon, scheduler, or hooks**, those are removed; see Breaking Changes below and the migration guide.
+- See `docs/MIGRATION-3.0.md` for the full breaking-change migration.
+
+## Breaking Changes
+
+- Hooks are removed (`soc-57b7f`). The default install registers no hooks; `ao hooks install`, `--with-hooks`, and the embedded hook surface are gone. What a hook enforced locally, a CI job in `.github/workflows/validate.yml` now enforces; author bounded gates with the `hooks-authoring` skill.
+- The daemon is removed (`soc-2rtm0`). `ao daemon` / `agentopsd` no longer exist. For always-on work, run the reference Gas City (`city.toml` + `packs/agentops`) or Mount Olympus.
+- Scheduling is removed (`soc-2rtm0`). `ao schedule`, `ao plans`, `ao watch`, and `ao overnight` are gone; Gas City Orders own out-of-session scheduling.
+- The `factory` command is removed (`soc-2rtm0`). `ao factory` and its contract corpus are gone; the factory is the loop (`crank` / `swarm` in-session, or a mayor-driven City).
+- `runtime=gc` is removed (`soc-2rtm0`). `ao rpi` keeps its `auto` / `direct` / `stream` / `tmux` backends; Gas City now dispatches whole `ao rpi` loops as one unit.
 
 ## At a Glance
 
-| Area | Added | Changed | Removed |
-|---|---:|---:|---:|
-| Hooks | 0 | 0 | all (53 runtime hooks) |
-| Daemon / scheduler / factory / gc-bridge | 0 | 0 | 4 subsystems (~117K LOC) |
-| Reference Gas City (`city.toml` + pack) | 1 | 0 | 0 |
-| Hexagonal port adapters (corpus / tracker / workspace) | 3 | 0 | 0 |
-| `ao validate --gate` | 1 | 0 | 0 |
-| BDD acceptance layer (scenario→test gate) | 1 | 0 | 0 |
-| Doctrine (`docs/3.0.md`, ADR-0009, migration guide) | 3 | 0 | 0 |
-| Skills | 0 | consolidated → 75 | several merged |
+| Product Area | Added | Changed | Refactored | Fixed | Deprecated/Removed |
+|---|---:|---:|---:|---:|---:|
+| Install, Upgrade, and Distribution | 0 | 1 | 0 | 0 | 0 |
+| CLI and Operator Commands | 1 | 0 | 0 | 0 | 3 |
+| Daemon, Scheduling, and Factory | 0 | 0 | 0 | 0 | 4 |
+| Skills and Workflows | 1 | 1 | 0 | 0 | 0 |
+| Hooks and Lifecycle | 0 | 0 | 0 | 0 | 1 |
+| Knowledge Flywheel, Search, and Memory | 0 | 0 | 3 | 0 | 0 |
+| Eval, Validation, and Release Gates | 2 | 0 | 0 | 0 | 0 |
+| Docs and Onboarding | 3 | 1 | 0 | 0 | 0 |
 
 ## Product Areas
 
-### The Rip (BREAKING)
+### Install, Upgrade, and Distribution
 
-- **Hookless by default** (`soc-57b7f`, #511) — 53 runtime hooks audited and removed; capabilities that lived in hooks (standards injection, commit-review gating) are now CLI ports + CI gates.
-- **Daemon carved out** (`soc-2rtm0`, #515) — `internal/daemon` + the `agentopsd` binary deleted. No out-of-session runtime ships.
-- **Scheduling removed** (`soc-2rtm0`, #514) — `ao schedule` / `plans` / `watch` / `overnight` deleted; Gas City owns scheduling.
-- **`factory` retired** (`soc-2rtm0`, #512) — the `ao factory` command and its contract corpus removed; the factory is the loop.
-- **gc-bridge severed** (`soc-2rtm0`, #513) — the CLI gc-bridge glue deleted; `runtime=gc` removed.
+- Changed: version synced to 3.0.0 across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and the City pack's pinned `AO_VERSION`.
 
-### What's New
+### CLI and Operator Commands
 
-- **AgentOps reference Gas City** — a turnkey City (`city.toml` + `agentops` pack + skills overlay) demonstrating out-of-session orchestration on AgentOps skills.
-- **`ao validate --gate`** — PASS/WARN/FAIL collapsed to a process exit code; the retry hook for Gas City `check` and CI, no network or LLM.
-- **Real hexagonal port adapters** — `corpus_fs` reader/writer, a bd-backed TrackerPort, a git-backed WorkspacePort, each wired to its core consumer.
-- **BDD acceptance layer** — scenario→test linkage runner + CI gate (`soc-63xfx`); canonical `.feature` acceptance across skills.
-- **The 3.0 doctrine** — `docs/3.0.md` north star, `ADR-0009` (daemon deletion / in-session-only), the canonical-loop model, and `docs/MIGRATION-3.0.md`.
+- Added: `ao validate --gate` collapses PASS/WARN/FAIL to a process exit code — the retry hook for Gas City `check` and CI, no network or LLM.
+- Removed: `ao daemon`, `ao schedule` / `plans` / `watch` / `overnight`, and `ao factory` (see Breaking Changes).
+- Removed: the `runtime=gc` phased-engine mode.
 
-### Tightened
+### Daemon, Scheduling, and Factory
 
-- **Honest doctrine reconciliation** — README, PRODUCT, and docs reframed to the in-session core; the out-of-session autonomous-dispatch gap explicitly labeled (`soc-5jwah`).
-- **Skill consolidation → 75** — overlapping skills merged into mode flags (e.g. `council`, `doc`, `post-mortem`); the catalog is the leaner 3.0 surface.
+- Removed: `internal/daemon` + the `agentopsd` binary, the scheduler lane, the factory command + contract corpus, and the CLI gc-bridge glue (`soc-2rtm0`, ~117K LOC). AgentOps ships no out-of-session runtime; Gas City or Olympus owns that surface.
 
-## See Also
+### Skills and Workflows
 
-- Full per-commit detail: `CHANGELOG.md` (entry `[3.0.0]`)
-- North star: `docs/3.0.md`
-- Migration guide: `docs/MIGRATION-3.0.md`
-- Daemon-deletion decision: `docs/adr/ADR-0009-daemon-deletion-in-session-only.md`
-- Follow-up patch: `docs/releases/2026-05-25-v3.0.1-notes.md` (v3.0.1)
+- Added: the AgentOps reference Gas City — a turnkey City (`city.toml` + `packs/agentops` + skills overlay) demonstrating out-of-session orchestration on AgentOps skills.
+- Changed: skill consolidation merged overlapping skills into mode flags, taking the catalog to 75 skills.
+
+### Hooks and Lifecycle
+
+- Removed: all 53 runtime hooks. The lifecycle is guided by skills and enforced by CI gates (see Breaking Changes).
+
+### Knowledge Flywheel, Search, and Memory
+
+- Refactored: real hexagonal port adapters wired to their core consumers — a filesystem CorpusReader/Writer, a bd-backed TrackerPort, and a git-backed WorkspacePort.
+
+### Eval, Validation, and Release Gates
+
+- Added: a BDD acceptance layer — scenario→test linkage runner plus a CI gate (`soc-63xfx`), with canonical `.feature` acceptance across skills.
+- Added: `ao validate --gate` as a deterministic exit-code verdict for CI and Gas City retry loops.
+
+### Docs and Onboarding
+
+- Added: the 3.0 doctrine — `docs/3.0.md` north star, `docs/adr/ADR-0009-daemon-deletion-in-session-only.md`, and the canonical-loop model.
+- Added: `docs/MIGRATION-3.0.md`, the breaking-change migration guide.
+- Changed: README and PRODUCT reconciled to the in-session core, with the out-of-session autonomous-dispatch gap explicitly labeled (`soc-5jwah`).
+
+## Known Issues
+
+- Gas City order-level autonomous dispatch is still maturing upstream (`soc-5jwah`); today the reference City dispatches via a long-lived mayor agent (`bd ready` → `gc sling`) plus cron exec orders for maintenance.
+
+[Full changelog](../CHANGELOG.md)

--- a/docs/releases/2026-05-25-v3.0.1-notes.md
+++ b/docs/releases/2026-05-25-v3.0.1-notes.md
@@ -1,26 +1,34 @@
 ## Highlights
 
-AgentOps v3.0.1 is a **release-engineering patch** for v3.0.0. It makes one user-visible thing work and greens one CI lane — no product behavior changes.
-
-The user-visible fix: existing v3.0.0 plugin installs can now `claude plugin update` to the latest content. The `3.0.0` version label was set early (at PR #522) and never moved across the 15 commits that landed the skill consolidation and doc reconciliation, so `claude plugin update` compared `3.0.0 == 3.0.0` and reported "already at latest" — leaving early installs pinned to a stale commit. Bumping to `3.0.1` gives the marketplace a new version to advertise.
-
-The CI fix: the **Nightly Static Validation** lane was red on `main` from two pieces of 3.0-rip fallout that the per-PR `validate.yml` gate never exercised — a Nightly step still ran the deleted `validate-hooks-doc-parity.sh`, and the skill-count checker still grepped `PRODUCT.md` for hook-era phrasing the 3.0 restructure removed.
+AgentOps v3.0.1 is a **release-engineering patch** for v3.0.0 — no product behavior changes. It makes `claude plugin update` actually move existing v3.0.0 installs forward (the version label never advanced past `3.0.0` across the consolidation commits, so the update check was a no-op), and it greens the Nightly Static Validation lane, which was red from two stale references to surfaces the 3.0 rip deleted.
 
 ## Upgrade Notes
 
-- **Existing v3.0.0 installs:** run `claude plugin update agentops@agentops-marketplace` to pick up 3.0.1. If a plain update still reports "already latest" (you installed 3.0.0 at an early commit), `uninstall --keep-data` then `install` once — after 3.0.1 the version-based update path works normally.
-- **The v3.0.0 GitHub Release remains as published.** v3.0.1 is the clean, fully-consolidated release; new installs should use v3.0.1.
+- Existing v3.0.0 installs: run `claude plugin update agentops@agentops-marketplace` to pick up 3.0.1. If a plain update still reports "already latest" (you installed 3.0.0 at an early commit), `uninstall --keep-data` then `install` once; after 3.0.1 the version-based path works normally.
+- The v3.0.0 GitHub Release remains as published; new installs should use v3.0.1.
 - No CLI or behavioral changes from v3.0.0.
 
-## Fixed
+## At a Glance
 
-- **`claude plugin update` stayed stale for early 3.0.0 installs.** The plugin/marketplace version never advanced past `3.0.0` across the post-#522 consolidation commits, so the version-string update check was a no-op. Bumped to `3.0.1` across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (metadata + plugin), and the City pack's pinned `AO_VERSION` (`packs/agentops/assets/scripts/install-ao.sh`).
-- **Nightly Static Validation was red on `main`.** Two stale references to surfaces deleted in the 3.0 rip:
-  - The Nightly workflow still `chmod +x`/ran `scripts/validate-hooks-doc-parity.sh`, deleted with the hooks rip (#511). Step removed — AgentOps is hookless, so there is no hooks/docs parity to validate.
-  - `tests/docs/validate-skill-count.sh` extracted skill counts from `PRODUCT.md` via patterns that grepped hook-era phrasing the 3.0 restructure removed ("N skills, M runtime hook event sections" and the "### 1. Skills (N across 4 runtimes)" heading) → two `MISSING_PATTERN` fail-closed errors (warn-tolerated in `validate.yml`, fail-closed in Nightly). Repointed `product_total` to the four-layers skill-count line; retired the obsolete `product_layer_total` check.
+| Product Area | Added | Changed | Refactored | Fixed | Deprecated/Removed |
+|---|---:|---:|---:|---:|---:|
+| Install, Upgrade, and Distribution | 0 | 1 | 0 | 1 | 0 |
+| Eval, Validation, and Release Gates | 0 | 0 | 0 | 2 | 0 |
 
-## See Also
+## Product Areas
 
-- Full per-commit detail: `CHANGELOG.md` (entry `[3.0.1]`)
-- v3.0.0 notes: `docs/releases/2026-05-24-v3.0.0-notes.md`
-- Follow-ups: bd `ag-728` (reconcile PRODUCT.md prose to hookless/daemonless reality), bd `ag-x0d` (3 golangci-lint quality findings the release security gate surfaced)
+### Install, Upgrade, and Distribution
+
+- Changed: version bumped to 3.0.1 across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (metadata + plugin), and the City pack's pinned `AO_VERSION`.
+- Fixed: `claude plugin update` stayed stale for early 3.0.0 installs because the version label never advanced past `3.0.0`; the bump gives the marketplace a new version to serve.
+
+### Eval, Validation, and Release Gates
+
+- Fixed: Nightly Static Validation ran the deleted `scripts/validate-hooks-doc-parity.sh` (removed with the hooks rip); the dead step is gone — AgentOps is hookless, so there is no hooks/docs parity to check.
+- Fixed: `tests/docs/validate-skill-count.sh` extracted `PRODUCT.md` counts via hook-era patterns the 3.0 restructure removed; repointed the total to the four-layers skill-count line and retired the obsolete heading check.
+
+## Known Issues
+
+- No release-blocking known issues. Follow-ups tracked as bd `ag-728` (reconcile PRODUCT.md prose to hookless/daemonless reality) and bd `ag-x0d` (3 golangci-lint quality findings surfaced by the release security gate).
+
+[Full changelog](../CHANGELOG.md)

--- a/scripts/extract-release-notes.sh
+++ b/scripts/extract-release-notes.sh
@@ -47,16 +47,23 @@ fi
 
 # Check for curated release notes (written by /release skill or manually).
 # These are plain-English highlights, not the raw changelog.
-CURATED_NOTES=""
+# Curated notes are REQUIRED — no silent fallback to the raw CHANGELOG. A missing
+# or non-conforming file is a hard error (3.0.0/3.0.1 shipped raw CHANGELOG dumps
+# precisely because this used to fall back). Structure is enforced separately by
+# scripts/validate-release-notes.sh; here we only require the file to exist.
 NOTES_FILE=$(find docs/releases -name "*-v${VERSION}-notes.md" 2>/dev/null | head -1 || true)
-if [[ -n "$NOTES_FILE" && -f "$NOTES_FILE" ]]; then
-  CURATED_NOTES=$(cat "$NOTES_FILE")
-  CURATED_NOTES="$(printf '%s' "$CURATED_NOTES" \
-    | sed \
-      -e "s#(../../CHANGELOG.md)#(https://github.com/${REPO}/blob/main/CHANGELOG.md)#g" \
-      -e "s#(../CHANGELOG.md)#(https://github.com/${REPO}/blob/main/docs/CHANGELOG.md)#g")"
-  echo "Using curated release notes from $NOTES_FILE" >&2
+if [[ -z "$NOTES_FILE" || ! -f "$NOTES_FILE" ]]; then
+  echo "ERROR: no curated release-notes file docs/releases/*-v${VERSION}-notes.md" >&2
+  echo "       Write one per skills/release/references/release-notes.md before tagging." >&2
+  echo "       The raw CHANGELOG is not an acceptable release body." >&2
+  exit 1
 fi
+CURATED_NOTES=$(cat "$NOTES_FILE")
+CURATED_NOTES="$(printf '%s' "$CURATED_NOTES" \
+  | sed \
+    -e "s#(../../CHANGELOG.md)#(https://github.com/${REPO}/blob/main/CHANGELOG.md)#g" \
+    -e "s#(../CHANGELOG.md)#(https://github.com/${REPO}/blob/main/docs/CHANGELOG.md)#g")"
+echo "Using curated release notes from $NOTES_FILE" >&2
 
 # Build the release notes file
 {
@@ -68,22 +75,17 @@ fi
 
 HEADER
 
-  # Curated highlights (if available)
-  if [[ -n "$CURATED_NOTES" ]]; then
-    echo "$CURATED_NOTES"
-    echo ""
-    echo "---"
-    echo ""
-    echo "<details>"
-    echo "<summary>Full changelog</summary>"
-    echo ""
-    echo "$CHANGELOG_SECTION"
-    echo ""
-    echo "</details>"
-  else
-    # No curated notes — use changelog directly
-    echo "$CHANGELOG_SECTION"
-  fi
+  # Curated highlights (required) + the full changelog tucked in a <details>.
+  echo "$CURATED_NOTES"
+  echo ""
+  echo "---"
+  echo ""
+  echo "<details>"
+  echo "<summary>Full changelog</summary>"
+  echo ""
+  echo "$CHANGELOG_SECTION"
+  echo ""
+  echo "</details>"
 
   echo ""
   echo "---"

--- a/scripts/validate-release-notes.sh
+++ b/scripts/validate-release-notes.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Validate a curated release-notes file against the standard in
+# skills/release/references/release-notes.md.
+#
+# Usage: scripts/validate-release-notes.sh <version>
+#   <version> = release version, with or without leading "v" (e.g. v3.0.1 or 3.0.1)
+#
+# Enforces (hard fail, exit 1, on any violation):
+#   - a curated docs/releases/*-v<version>-notes.md file exists (no silent
+#     fallback to the raw CHANGELOG)
+#   - the required section skeleton is present
+#   - major releases (X.0.0) carry a "## Breaking Changes" section
+#   - every "### " product-area heading is from the canonical taxonomy
+#   - every top-level bullet under a product area uses a canonical action label
+#
+# This is the mechanical backstop for the failure where 3.0.0/3.0.1 shipped
+# with no curated notes and the generator silently dumped the raw CHANGELOG.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+VERSION="${1:?Usage: validate-release-notes.sh <version>}"
+VERSION="${VERSION#v}"
+
+errors=0
+fail() {
+  echo "FAIL: $1" >&2
+  errors=$((errors + 1))
+}
+
+# --- Locate the curated notes file (no silent fallback) ---
+
+NOTES_FILE="$(find "$REPO_ROOT/docs/releases" -name "*-v${VERSION}-notes.md" 2>/dev/null | head -1 || true)"
+if [[ -z "$NOTES_FILE" || ! -f "$NOTES_FILE" ]]; then
+  echo "FAIL: no curated release-notes file docs/releases/*-v${VERSION}-notes.md" >&2
+  echo "      Write one per the standard in skills/release/references/release-notes.md" >&2
+  echo "      before tagging. The raw CHANGELOG is not an acceptable release body." >&2
+  exit 1
+fi
+echo "Validating $NOTES_FILE (version $VERSION)"
+
+# --- Required top-level sections ---
+
+require_section() {
+  local heading="$1"
+  grep -Fxq "$heading" "$NOTES_FILE" || fail "missing required section: $heading"
+}
+require_section "## Highlights"
+require_section "## Upgrade Notes"
+require_section "## At a Glance"
+require_section "## Product Areas"
+require_section "## Known Issues"
+
+# Full-changelog link must remain for archaeology.
+grep -Fq "Full changelog" "$NOTES_FILE" || fail "missing the [Full changelog] link"
+
+# --- Major releases (X.0.0) require a Breaking Changes section ---
+
+if [[ "$VERSION" =~ ^[0-9]+\.0\.0$ ]]; then
+  grep -Fxq "## Breaking Changes" "$NOTES_FILE" \
+    || fail "major release ${VERSION} must include a '## Breaking Changes' section"
+fi
+
+# --- Canonical product-area taxonomy (order not enforced, membership is) ---
+
+canonical_areas=(
+  "Install, Upgrade, and Distribution"
+  "CLI and Operator Commands"
+  "Daemon, Scheduling, and Factory"
+  "Skills and Workflows"
+  "Codex and Runtime Integrations"
+  "Hooks and Lifecycle"
+  "Knowledge Flywheel, Search, and Memory"
+  "Eval, Validation, and Release Gates"
+  "Docs and Onboarding"
+  "Security, Privacy, and Supply Chain"
+  "Contributor/Internal Refactors"
+)
+is_canonical_area() {
+  local candidate="$1"
+  local area
+  for area in "${canonical_areas[@]}"; do
+    [[ "$candidate" == "$area" ]] && return 0
+  done
+  return 1
+}
+
+# Canonical action labels for product-area bullets.
+LABEL_RE='^- (Added|Changed|Refactored|Fixed|Deprecated|Removed|Security|Docs): '
+
+# --- Walk the Product Areas region: validate ### headings + bullet labels ---
+
+in_product_areas=0
+current_area=""
+while IFS= read -r line; do
+  if [[ "$line" == "## "* ]]; then
+    if [[ "$line" == "## Product Areas" ]]; then
+      in_product_areas=1
+    else
+      in_product_areas=0
+    fi
+    current_area=""
+    continue
+  fi
+  [[ "$in_product_areas" -eq 1 ]] || continue
+
+  if [[ "$line" == "### "* ]]; then
+    current_area="${line:4}"  # strip the literal "### " prefix (4 chars)
+    if ! is_canonical_area "$current_area"; then
+      fail "non-canonical product-area heading: '### ${current_area}' (see skills/release/references/release-notes.md taxonomy)"
+    fi
+    continue
+  fi
+
+  # Top-level bullets (not indented sub-bullets) under a product area must
+  # start with a canonical action label.
+  if [[ "$line" == "- "* ]]; then
+    if [[ -z "$current_area" ]]; then
+      fail "bullet outside any '### <product area>' heading: ${line}"
+    elif ! [[ "$line" =~ $LABEL_RE ]]; then
+      fail "bullet missing a canonical action label (Added:/Changed:/Refactored:/Fixed:/Deprecated:/Removed:/Security:/Docs:): ${line}"
+    fi
+  fi
+done < "$NOTES_FILE"
+
+if [[ "$errors" -gt 0 ]]; then
+  echo "" >&2
+  echo "FAIL: ${errors} release-notes standard violation(s) in $NOTES_FILE" >&2
+  exit 1
+fi
+
+echo "PASS: $NOTES_FILE conforms to the release-notes standard"

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -937,8 +937,8 @@
     {
       "name": "release",
       "source_skill": "skills/release",
-      "source_hash": "67ba2963723d909c63d4c3e3e858728c14ca58ab746311bbe990a0e762ee5367",
-      "generated_hash": "9c66ecd9ba5672e61cf247bf7cd9114a39f2da0a81aed47f30aa8c247074454e"
+      "source_hash": "388c158c268fcca84f03759bc0e2440fdaa3bb8eafa801970d5ff5f1493b1507",
+      "generated_hash": "11f136dba806c932ad2d26d7b6a8f70967f432300cf102d1411f84451fa116e1"
     },
     {
       "name": "research",

--- a/skills-codex/release/.agentops-generated.json
+++ b/skills-codex/release/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/release",
   "layout": "modular",
-  "source_hash": "67ba2963723d909c63d4c3e3e858728c14ca58ab746311bbe990a0e762ee5367",
-  "generated_hash": "9c66ecd9ba5672e61cf247bf7cd9114a39f2da0a81aed47f30aa8c247074454e"
+  "source_hash": "388c158c268fcca84f03759bc0e2440fdaa3bb8eafa801970d5ff5f1493b1507",
+  "generated_hash": "11f136dba806c932ad2d26d7b6a8f70967f432300cf102d1411f84451fa116e1"
 }

--- a/skills-codex/release/references/release-notes.md
+++ b/skills-codex/release/references/release-notes.md
@@ -30,6 +30,15 @@ user/operator outcomes. Explain internal names the first time they appear.>
 - <Required operator action, migration note, deprecation, or "No manual action
   required" when that is genuinely useful. Omit only when the release has no
   upgrade implications.>
+- <Major releases: link the migration guide here, e.g. `See docs/MIGRATION-X.0.md`.>
+
+## Breaking Changes
+
+<!-- MAJOR releases (X.0.0) ONLY — required for them, omit entirely otherwise. -->
+
+- <Each breaking change as one bullet: what changed, what to use instead, and a
+  migration pointer. Surfacing breaking changes at the top is the whole point of
+  a major; do not bury them under a product-area `Removed:` bullet.>
 
 ## At a Glance
 
@@ -56,6 +65,21 @@ user/operator outcomes. Explain internal names the first time they appear.>
 
 [Full changelog](../CHANGELOG.md)
 ```
+
+## Major Releases (X.0.0)
+
+A major release adds one section to the shape above and tightens one rule:
+
+- **`## Breaking Changes` is required** (placed after `## Upgrade Notes`, before
+  `## At a Glance`). Every removed/renamed/behavior-breaking change gets a bullet
+  with its replacement and a migration pointer. This is in addition to — not a
+  replacement for — the per-area `Removed:` / `Deprecated:` bullets in
+  `## Product Areas`.
+- **`## Upgrade Notes` must link the migration guide** (`docs/MIGRATION-X.0.md`).
+- Highlights may run to the upper end of the 2-4 sentence range to frame the
+  release theme.
+
+Minor and patch releases omit `## Breaking Changes` entirely.
 
 ## Product-Area Taxonomy
 
@@ -212,3 +236,13 @@ docs/releases/YYYY-MM-DD-v<version>-notes.md
 This file must be committed before tagging. The CI release pipeline reads it
 from the tagged tree through `scripts/extract-release-notes.sh`, prepends the
 install/checksum/provenance header, and appends the full changelog details.
+
+**Enforced, not optional.** `scripts/validate-release-notes.sh <version>` checks
+that the curated file exists and conforms to this standard (required sections,
+canonical product-area taxonomy, action labels, and `## Breaking Changes` for
+majors). It runs as a hard gate in the `publish` job of
+`.github/workflows/release.yml` **before** notes are extracted, and
+`extract-release-notes.sh` itself now **fails** rather than falling back to the
+raw CHANGELOG when the curated file is missing. A release cannot publish with a
+missing or non-conforming notes file. (Root cause: 3.0.0/3.0.1 shipped raw
+CHANGELOG dumps because the generator used to fall back silently.)

--- a/skills/release/references/release-notes.md
+++ b/skills/release/references/release-notes.md
@@ -30,6 +30,15 @@ user/operator outcomes. Explain internal names the first time they appear.>
 - <Required operator action, migration note, deprecation, or "No manual action
   required" when that is genuinely useful. Omit only when the release has no
   upgrade implications.>
+- <Major releases: link the migration guide here, e.g. `See docs/MIGRATION-X.0.md`.>
+
+## Breaking Changes
+
+<!-- MAJOR releases (X.0.0) ONLY — required for them, omit entirely otherwise. -->
+
+- <Each breaking change as one bullet: what changed, what to use instead, and a
+  migration pointer. Surfacing breaking changes at the top is the whole point of
+  a major; do not bury them under a product-area `Removed:` bullet.>
 
 ## At a Glance
 
@@ -56,6 +65,21 @@ user/operator outcomes. Explain internal names the first time they appear.>
 
 [Full changelog](../CHANGELOG.md)
 ```
+
+## Major Releases (X.0.0)
+
+A major release adds one section to the shape above and tightens one rule:
+
+- **`## Breaking Changes` is required** (placed after `## Upgrade Notes`, before
+  `## At a Glance`). Every removed/renamed/behavior-breaking change gets a bullet
+  with its replacement and a migration pointer. This is in addition to — not a
+  replacement for — the per-area `Removed:` / `Deprecated:` bullets in
+  `## Product Areas`.
+- **`## Upgrade Notes` must link the migration guide** (`docs/MIGRATION-X.0.md`).
+- Highlights may run to the upper end of the 2-4 sentence range to frame the
+  release theme.
+
+Minor and patch releases omit `## Breaking Changes` entirely.
 
 ## Product-Area Taxonomy
 
@@ -212,3 +236,13 @@ docs/releases/YYYY-MM-DD-v<version>-notes.md
 This file must be committed before tagging. The CI release pipeline reads it
 from the tagged tree through `scripts/extract-release-notes.sh`, prepends the
 install/checksum/provenance header, and appends the full changelog details.
+
+**Enforced, not optional.** `scripts/validate-release-notes.sh <version>` checks
+that the curated file exists and conforms to this standard (required sections,
+canonical product-area taxonomy, action labels, and `## Breaking Changes` for
+majors). It runs as a hard gate in the `publish` job of
+`.github/workflows/release.yml` **before** notes are extracted, and
+`extract-release-notes.sh` itself now **fails** rather than falling back to the
+raw CHANGELOG when the curated file is missing. A release cannot publish with a
+missing or non-conforming notes file. (Root cause: 3.0.0/3.0.1 shipped raw
+CHANGELOG dumps because the generator used to fall back silently.)

--- a/tests/scripts/validate-release-notes.bats
+++ b/tests/scripts/validate-release-notes.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+# Tests for scripts/validate-release-notes.sh — the release-notes standard gate.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/validate-release-notes.sh"
+  # Sandbox repo so we can drop fixture notes into docs/releases/ without touching
+  # the real tree. The script resolves paths relative to its own location, so we
+  # copy it into the sandbox and run it there.
+  SANDBOX="$BATS_TEST_TMPDIR/repo"
+  mkdir -p "$SANDBOX/scripts" "$SANDBOX/docs/releases"
+  cp "$SCRIPT" "$SANDBOX/scripts/validate-release-notes.sh"
+  chmod +x "$SANDBOX/scripts/validate-release-notes.sh"
+}
+
+# A minimal conforming MINOR/PATCH notes file (no Breaking Changes section).
+write_patch_notes() {
+  cat > "$SANDBOX/docs/releases/2026-05-25-v$1-notes.md" <<'EOF'
+## Highlights
+
+A conforming patch release.
+
+## Upgrade Notes
+
+- No manual action required.
+
+## At a Glance
+
+| Product Area | Added | Changed | Refactored | Fixed | Deprecated/Removed |
+|---|---:|---:|---:|---:|---:|
+| Eval, Validation, and Release Gates | 0 | 0 | 0 | 1 | 0 |
+
+## Product Areas
+
+### Eval, Validation, and Release Gates
+
+- Fixed: a release gate no longer misfires.
+
+## Known Issues
+
+- No release-blocking known issues.
+
+[Full changelog](../CHANGELOG.md)
+EOF
+}
+
+@test "passes on a conforming patch notes file" {
+  write_patch_notes "9.9.9"
+  run "$SANDBOX/scripts/validate-release-notes.sh" v9.9.9
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"conforms to the release-notes standard"* ]]
+}
+
+@test "accepts a version with or without leading v" {
+  write_patch_notes "9.9.9"
+  run "$SANDBOX/scripts/validate-release-notes.sh" 9.9.9
+  [ "$status" -eq 0 ]
+}
+
+@test "fails when no curated notes file exists for the version" {
+  run "$SANDBOX/scripts/validate-release-notes.sh" v1.2.3
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no curated release-notes file"* ]]
+}
+
+@test "fails when a required section is missing" {
+  write_patch_notes "9.9.9"
+  # Remove the Known Issues section heading.
+  sed -i '/^## Known Issues$/d' "$SANDBOX/docs/releases/2026-05-25-v9.9.9-notes.md"
+  run "$SANDBOX/scripts/validate-release-notes.sh" v9.9.9
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"missing required section: ## Known Issues"* ]]
+}
+
+@test "fails a major release without a Breaking Changes section" {
+  write_patch_notes "4.0.0"
+  run "$SANDBOX/scripts/validate-release-notes.sh" v4.0.0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must include a '## Breaking Changes' section"* ]]
+}
+
+@test "passes a major release with a Breaking Changes section" {
+  cat > "$SANDBOX/docs/releases/2026-05-25-v4.0.0-notes.md" <<'EOF'
+## Highlights
+
+A conforming major.
+
+## Upgrade Notes
+
+- See docs/MIGRATION-4.0.md.
+
+## Breaking Changes
+
+- The old command is removed; use the new one.
+
+## At a Glance
+
+| Product Area | Added | Changed | Refactored | Fixed | Deprecated/Removed |
+|---|---:|---:|---:|---:|---:|
+| CLI and Operator Commands | 0 | 0 | 0 | 0 | 1 |
+
+## Product Areas
+
+### CLI and Operator Commands
+
+- Removed: the old command, replaced by the new one.
+
+## Known Issues
+
+- No release-blocking known issues.
+
+[Full changelog](../CHANGELOG.md)
+EOF
+  run "$SANDBOX/scripts/validate-release-notes.sh" v4.0.0
+  [ "$status" -eq 0 ]
+}
+
+@test "fails a non-canonical product-area heading" {
+  write_patch_notes "9.9.9"
+  sed -i 's/^### Eval, Validation, and Release Gates$/### Made Up Area/' \
+    "$SANDBOX/docs/releases/2026-05-25-v9.9.9-notes.md"
+  run "$SANDBOX/scripts/validate-release-notes.sh" v9.9.9
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"non-canonical product-area heading"* ]]
+}
+
+@test "fails a product-area bullet without a canonical action label" {
+  write_patch_notes "9.9.9"
+  sed -i 's/^- Fixed: a release gate no longer misfires.$/- a release gate no longer misfires./' \
+    "$SANDBOX/docs/releases/2026-05-25-v9.9.9-notes.md"
+  run "$SANDBOX/scripts/validate-release-notes.sh" v9.9.9
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"canonical action label"* ]]
+}


### PR DESCRIPTION
Fixes two compounding misses on the v3.0.x release notes and makes the failure mechanically impossible.

**Root cause:** extract-release-notes.sh silently fell back to dumping the raw CHANGELOG when no curated docs/releases/*-notes.md existed — so 3.0.0/3.0.1 shipped raw dumps, and the curated notes I then wrote did not follow skills/release/references/release-notes.md (invented headings, bold-lead-in bullets instead of action labels). The template also had no major-release variant.

**Standard (template + codex twin):** add a major-release (X.0.0) variant — required ## Breaking Changes section + migration link; document the hard gate.

**Conform:** rewrite both 3.0.x curated notes to the standard (major shape for 3.0.0 w/ Breaking Changes + canonical taxonomy + action labels; patch shape for 3.0.1).

**Enforce:** scripts/validate-release-notes.sh (existence + sections + taxonomy + action labels + Breaking-Changes-for-major) + 8 bats cases; wired as a hard gate in release.yml before notes extraction; extract-release-notes.sh now fails instead of silently dumping raw CHANGELOG.

Local: both notes PASS the validator, 8/8 bats, shellcheck clean, codex parity passes.

Closes-scenario: ag-d0f#release-notes-standard
Bounded-context: BC5-Runtime
Evidence: scripts/validate-release-notes.sh