### PR TITLE
docs(release): v3.0.1 notes = combined 3.0 + 3.0.1 story

### DIFF
--- a/docs/releases/2026-05-25-v3.0.1-notes.md
+++ b/docs/releases/2026-05-25-v3.0.1-notes.md
@@ -1,34 +1,81 @@
 ## Highlights
 
-AgentOps v3.0.1 is a **release-engineering patch** for v3.0.0 — no product behavior changes. It makes `claude plugin update` actually move existing v3.0.0 installs forward (the version label never advanced past `3.0.0` across the consolidation commits, so the update check was a no-op), and it greens the Nightly Static Validation lane, which was red from two stale references to surfaces the 3.0 rip deleted.
+AgentOps v3.0.1 is the clean, recommended cut of the **3.0 major** — use it for new installs. 3.0 is the hookless, in-session-only release: AgentOps is what runs inside a session — skills, the `ao` CLI, the RPI / evolve / crank / swarm loops, and the `.agents/` context-compiler — while out-of-session orchestration (when work runs, who supervises it, how agents coordinate) is delegated to a substrate you choose: Gas City (a reference City ships here) or Mount Olympus. Roughly 117K lines were removed across a five-wave rip, the default install registers zero hooks, and CI is the authoritative gate. 3.0.1 itself is a release-engineering patch over 3.0.0: it makes `claude plugin update` move existing installs forward and greens the Nightly validation lane. `docs/3.0.md` is the north star.
 
 ## Upgrade Notes
 
-- Existing v3.0.0 installs: run `claude plugin update agentops@agentops-marketplace` to pick up 3.0.1. If a plain update still reports "already latest" (you installed 3.0.0 at an early commit), `uninstall --keep-data` then `install` once; after 3.0.1 the version-based path works normally.
-- The v3.0.0 GitHub Release remains as published; new installs should use v3.0.1.
-- No CLI or behavioral changes from v3.0.0.
+- New installs should use v3.0.1 (the clean cut). Existing v3.0.0 installs: run `claude plugin update agentops@agentops-marketplace`; if a plain update still reports "already latest", `uninstall --keep-data` then `install` once.
+- If you ran AgentOps **in a session**, nothing you rely on changed — `ao rpi`, `ao evolve`, `crank`, `swarm`, and the `.agents/` corpus are unchanged.
+- If you ran the **daemon, scheduler, or hooks**, those are removed; see Breaking Changes below.
+- See `docs/MIGRATION-3.0.md` for the full breaking-change migration.
+
+## Breaking Changes
+
+- Hooks are removed (`soc-57b7f`). The default install registers no hooks; `ao hooks install`, `--with-hooks`, and the embedded hook surface are gone. What a hook enforced locally, a CI job in `.github/workflows/validate.yml` now enforces; author bounded gates with the `hooks-authoring` skill.
+- The daemon is removed (`soc-2rtm0`). `ao daemon` / `agentopsd` no longer exist. For always-on work, run the reference Gas City (`city.toml` + `packs/agentops`) or Mount Olympus.
+- Scheduling is removed (`soc-2rtm0`). `ao schedule`, `ao plans`, `ao watch`, and `ao overnight` are gone; Gas City Orders own out-of-session scheduling.
+- The `factory` command is removed (`soc-2rtm0`). `ao factory` and its contract corpus are gone; the factory is the loop (`crank` / `swarm` in-session, or a mayor-driven City).
+- `runtime=gc` is removed (`soc-2rtm0`). `ao rpi` keeps its `auto` / `direct` / `stream` / `tmux` backends; Gas City now dispatches whole `ao rpi` loops as one unit.
 
 ## At a Glance
 
 | Product Area | Added | Changed | Refactored | Fixed | Deprecated/Removed |
 |---|---:|---:|---:|---:|---:|
 | Install, Upgrade, and Distribution | 0 | 1 | 0 | 1 | 0 |
-| Eval, Validation, and Release Gates | 0 | 0 | 0 | 2 | 0 |
+| CLI and Operator Commands | 1 | 0 | 0 | 0 | 3 |
+| Daemon, Scheduling, and Factory | 0 | 0 | 0 | 0 | 4 |
+| Skills and Workflows | 1 | 1 | 0 | 0 | 0 |
+| Hooks and Lifecycle | 0 | 0 | 0 | 0 | 1 |
+| Knowledge Flywheel, Search, and Memory | 0 | 0 | 3 | 0 | 0 |
+| Eval, Validation, and Release Gates | 2 | 0 | 0 | 2 | 0 |
+| Docs and Onboarding | 3 | 1 | 0 | 0 | 0 |
 
 ## Product Areas
 
 ### Install, Upgrade, and Distribution
 
-- Changed: version bumped to 3.0.1 across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (metadata + plugin), and the City pack's pinned `AO_VERSION`.
-- Fixed: `claude plugin update` stayed stale for early 3.0.0 installs because the version label never advanced past `3.0.0`; the bump gives the marketplace a new version to serve.
+- Changed: version set across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (metadata + plugin), and the City pack's pinned `AO_VERSION` — 3.0.0, then bumped to 3.0.1.
+- Fixed: `claude plugin update` stayed stale for early 3.0.0 installs because the version label never advanced past `3.0.0`; the 3.0.1 bump gives the marketplace a new version to serve.
+
+### CLI and Operator Commands
+
+- Added: `ao validate --gate` collapses PASS/WARN/FAIL to a process exit code — the retry hook for Gas City `check` and CI, no network or LLM.
+- Removed: `ao daemon`, `ao schedule` / `plans` / `watch` / `overnight`, and `ao factory` (see Breaking Changes).
+- Removed: the `runtime=gc` phased-engine mode.
+
+### Daemon, Scheduling, and Factory
+
+- Removed: `internal/daemon` + the `agentopsd` binary, the scheduler lane, the factory command + contract corpus, and the CLI gc-bridge glue (`soc-2rtm0`, ~117K LOC). AgentOps ships no out-of-session runtime; Gas City or Olympus owns that surface.
+
+### Skills and Workflows
+
+- Added: the AgentOps reference Gas City — a turnkey City (`city.toml` + `packs/agentops` + skills overlay) demonstrating out-of-session orchestration on AgentOps skills.
+- Changed: skill consolidation merged overlapping skills into mode flags, taking the catalog to 75 skills.
+
+### Hooks and Lifecycle
+
+- Removed: all 53 runtime hooks. The lifecycle is guided by skills and enforced by CI gates (see Breaking Changes).
+
+### Knowledge Flywheel, Search, and Memory
+
+- Refactored: real hexagonal port adapters wired to their core consumers — a filesystem CorpusReader/Writer, a bd-backed TrackerPort, and a git-backed WorkspacePort.
 
 ### Eval, Validation, and Release Gates
 
-- Fixed: Nightly Static Validation ran the deleted `scripts/validate-hooks-doc-parity.sh` (removed with the hooks rip); the dead step is gone — AgentOps is hookless, so there is no hooks/docs parity to check.
-- Fixed: `tests/docs/validate-skill-count.sh` extracted `PRODUCT.md` counts via hook-era patterns the 3.0 restructure removed; repointed the total to the four-layers skill-count line and retired the obsolete heading check.
+- Added: a BDD acceptance layer — scenario→test linkage runner plus a CI gate (`soc-63xfx`), with canonical `.feature` acceptance across skills.
+- Added: `ao validate --gate` as a deterministic exit-code verdict for CI and Gas City retry loops.
+- Fixed: Nightly Static Validation ran the deleted `scripts/validate-hooks-doc-parity.sh`; the dead step is gone (AgentOps is hookless).
+- Fixed: `tests/docs/validate-skill-count.sh` extracted `PRODUCT.md` counts via hook-era patterns the 3.0 restructure removed; repointed to the four-layers skill-count line.
+
+### Docs and Onboarding
+
+- Added: the 3.0 doctrine — `docs/3.0.md` north star, `docs/adr/ADR-0009-daemon-deletion-in-session-only.md`, and the canonical-loop model.
+- Added: `docs/MIGRATION-3.0.md`, the breaking-change migration guide.
+- Changed: README and PRODUCT reconciled to the in-session core, with the out-of-session autonomous-dispatch gap explicitly labeled (`soc-5jwah`).
 
 ## Known Issues
 
-- No release-blocking known issues. Follow-ups tracked as bd `ag-728` (reconcile PRODUCT.md prose to hookless/daemonless reality) and bd `ag-x0d` (3 golangci-lint quality findings surfaced by the release security gate).
+- Gas City order-level autonomous dispatch is still maturing upstream (`soc-5jwah`); today the reference City dispatches via a long-lived mayor agent (`bd ready` → `gc sling`) plus cron exec orders for maintenance.
+- Follow-ups tracked as bd `ag-728` (reconcile PRODUCT.md prose to hookless/daemonless reality) and bd `ag-x0d` (3 golangci-lint quality findings surfaced by the release security gate).
 
 [Full changelog](../CHANGELOG.md)


### PR DESCRIPTION
v3.0.1 is the recommended cut, so its release page should carry the full 3.0 story rather than just the patch delta. Fold the 3.0.0 major content (Highlights theme, Breaking Changes, full At-a-Glance + Product Areas) into the v3.0.1 curated notes, with the 3.0.1 release-engineering fixes merged into the Install and Eval/Validation areas. v3.0.0 keeps its own standalone notes. Conforms to the standard (validate-release-notes.sh passes).

Bounded-context: BC5-Runtime
Evidence: docs/releases/2026-05-25-v3.0.1-notes.md