### PR TITLE
docs(release): v3.0.1 notes = full v2->v3 transformation

### DIFF
--- a/docs/releases/2026-05-25-v3.0.1-notes.md
+++ b/docs/releases/2026-05-25-v3.0.1-notes.md
@@ -1,6 +1,8 @@
 ## Highlights
 
-AgentOps v3.0.1 is the clean, recommended cut of the **3.0 major** — use it for new installs. 3.0 is the hookless, in-session-only release: AgentOps is what runs inside a session — skills, the `ao` CLI, the RPI / evolve / crank / swarm loops, and the `.agents/` context-compiler — while out-of-session orchestration (when work runs, who supervises it, how agents coordinate) is delegated to a substrate you choose: Gas City (a reference City ships here) or Mount Olympus. Roughly 117K lines were removed across a five-wave rip, the default install registers zero hooks, and CI is the authoritative gate. 3.0.1 itself is a release-engineering patch over 3.0.0: it makes `claude plugin update` move existing installs forward and greens the Nightly validation lane. `docs/3.0.md` is the north star.
+AgentOps v3.0.1 is the recommended cut of the **3.0 major** — the largest release in the project's history (~320 commits and a net rewrite, ~138K insertions / ~133K deletions since v2.41). 3.0 is the **hookless, in-session-only** rearchitecture: AgentOps is what runs inside a session — skills, the `ao` CLI, the RPI / evolve / crank / swarm loops, and the `.agents/` context-compiler — and out-of-session orchestration (when work runs, who supervises it, how agents coordinate) is delegated to a substrate you choose: Gas City (a reference City ships here) or Mount Olympus.
+
+The release removes hooks, the daemon, the scheduler, and the factory command (~117K LOC); consolidates the skill catalog 81→75 and gives every loop skill executable BDD acceptance; lands real hexagonal port adapters; ships an `ao doctor` repair engine and a much larger `ao goals` / `ao evolve` surface; and reconciles all doctrine to a single in-session north star (`docs/3.0.md`). 3.0.1 itself is the release-engineering patch that makes the plugin updatable and greens the nightly validation lane.
 
 ## Upgrade Notes
 
@@ -12,8 +14,8 @@ AgentOps v3.0.1 is the clean, recommended cut of the **3.0 major** — use it fo
 ## Breaking Changes
 
 - Hooks are removed (`soc-57b7f`). The default install registers no hooks; `ao hooks install`, `--with-hooks`, and the embedded hook surface are gone. What a hook enforced locally, a CI job in `.github/workflows/validate.yml` now enforces; author bounded gates with the `hooks-authoring` skill.
-- The daemon is removed (`soc-2rtm0`). `ao daemon` / `agentopsd` no longer exist. For always-on work, run the reference Gas City (`city.toml` + `packs/agentops`) or Mount Olympus.
-- Scheduling is removed (`soc-2rtm0`). `ao schedule`, `ao plans`, `ao watch`, and `ao overnight` are gone; Gas City Orders own out-of-session scheduling.
+- The daemon is removed (`soc-2rtm0`). `ao daemon` / `agentopsd` and `internal/daemon` no longer exist. For always-on work, run the reference Gas City (`city.toml` + `packs/agentops`) or Mount Olympus.
+- Scheduling is removed (`soc-2rtm0`). `ao schedule`, `ao plans`, `ao watch`, and `ao overnight` (commands + engines) are gone; Gas City Orders own out-of-session scheduling.
 - The `factory` command is removed (`soc-2rtm0`). `ao factory` and its contract corpus are gone; the factory is the loop (`crank` / `swarm` in-session, or a mayor-driven City).
 - `runtime=gc` is removed (`soc-2rtm0`). `ao rpi` keeps its `auto` / `direct` / `stream` / `tmux` backends; Gas City now dispatches whole `ao rpi` loops as one unit.
 
@@ -22,35 +24,47 @@ AgentOps v3.0.1 is the clean, recommended cut of the **3.0 major** — use it fo
 | Product Area | Added | Changed | Refactored | Fixed | Deprecated/Removed |
 |---|---:|---:|---:|---:|---:|
 | Install, Upgrade, and Distribution | 0 | 1 | 0 | 1 | 0 |
-| CLI and Operator Commands | 1 | 0 | 0 | 0 | 3 |
+| CLI and Operator Commands | 6 | 1 | 0 | 2 | 4 |
 | Daemon, Scheduling, and Factory | 0 | 0 | 0 | 0 | 4 |
-| Skills and Workflows | 1 | 1 | 0 | 0 | 0 |
+| Skills and Workflows | 3 | 2 | 0 | 0 | 0 |
 | Hooks and Lifecycle | 0 | 0 | 0 | 0 | 1 |
 | Knowledge Flywheel, Search, and Memory | 0 | 0 | 3 | 0 | 0 |
-| Eval, Validation, and Release Gates | 2 | 0 | 0 | 2 | 0 |
-| Docs and Onboarding | 3 | 1 | 0 | 0 | 0 |
+| Eval, Validation, and Release Gates | 5 | 2 | 0 | 2 | 0 |
+| Docs and Onboarding | 4 | 2 | 0 | 0 | 0 |
+| Security, Privacy, and Supply Chain | 1 | 1 | 0 | 0 | 0 |
+| Contributor/Internal Refactors | 2 | 0 | 2 | 0 | 0 |
 
 ## Product Areas
 
 ### Install, Upgrade, and Distribution
 
-- Changed: version set across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (metadata + plugin), and the City pack's pinned `AO_VERSION` — 3.0.0, then bumped to 3.0.1.
+- Changed: version set across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and the City pack's pinned `AO_VERSION` — 3.0.0, then bumped to 3.0.1.
 - Fixed: `claude plugin update` stayed stale for early 3.0.0 installs because the version label never advanced past `3.0.0`; the 3.0.1 bump gives the marketplace a new version to serve.
 
 ### CLI and Operator Commands
 
-- Added: `ao validate --gate` collapses PASS/WARN/FAIL to a process exit code — the retry hook for Gas City `check` and CI, no network or LLM.
-- Removed: `ao daemon`, `ao schedule` / `plans` / `watch` / `overnight`, and `ao factory` (see Breaking Changes).
-- Removed: the `runtime=gc` phased-engine mode.
+- Added: `ao doctor` — a shared diagnose-and-repair engine with subsystem detectors/fixers (cliconfig, daemon, bridges), a single `--json` Report, and offline-safe `--fix` / `--dry-run` exit codes.
+- Added: `ao goals scenarios` (`--create` / `--lint` / `--list`) for executable-spec links, plus `ao goals steer --json` now persists the mutation and `steer add` preserves non-directive content.
+- Added: `ao validate --gate` — an exit-code verdict (PASS/WARN/FAIL → process exit) for Gas City retry loops and CI.
+- Added: `ao evolve config --show` + a per-repo `preferences.yaml` schema/loader for the loop.
+- Added: `ao loop` surfaces for the HypothesisLedger and ConvergenceCheck ports.
+- Added: top-level capabilities + robot-docs agent surfaces, JSON subcommand listings, and `--json` on `plans list` / `search` / `diff`.
+- Changed: clearer error messages that name the corrective command (autodev `PROGRAM.md`, constraint/claim lookups).
+- Fixed: `goals trace --orphans` parser rejects bead prose and matches real orphans.
+- Fixed: a filesystem `PacketRepository` adapter behind the hexagonal packet seam.
+- Removed: `ao daemon`, `ao schedule` / `plans` / `watch` / `overnight`, `ao factory`, and the `runtime=gc` mode (see Breaking Changes).
 
 ### Daemon, Scheduling, and Factory
 
-- Removed: `internal/daemon` + the `agentopsd` binary, the scheduler lane, the factory command + contract corpus, and the CLI gc-bridge glue (`soc-2rtm0`, ~117K LOC). AgentOps ships no out-of-session runtime; Gas City or Olympus owns that surface.
+- Removed: `internal/daemon` + the `agentopsd` binary, the scheduler/overnight engines, the factory command + contract corpus, and the CLI gc-bridge glue (`soc-2rtm0`, ~117K LOC). AgentOps ships no out-of-session runtime; Gas City or Olympus owns that surface.
 
 ### Skills and Workflows
 
-- Added: the AgentOps reference Gas City — a turnkey City (`city.toml` + `packs/agentops` + skills overlay) demonstrating out-of-session orchestration on AgentOps skills.
-- Changed: skill consolidation merged overlapping skills into mode flags, taking the catalog to 75 skills.
+- Added: the AgentOps reference Gas City — `city.toml` + the `agentops` pack (mayor + refinery agents, skills overlay, Orders) + the `using-gc` agent guide and a complete tool-dependency declaration.
+- Added: canonical `.feature` acceptance across ~25 skills (research/plan/validation/crank/swarm/rpi/handoff/readme/flywheel/inject and more) plus `SELF-TEST.md` pilots.
+- Added: the `idea-wizard` generate-and-winnow flow folded into `/brainstorm` and the `/discovery` phase.
+- Changed: skill consolidation 81→75 — merged 4 skills into mode flags, cut 2, resolved 6 keep-flags.
+- Changed: `/evolve` hardening — `--mode=burst|loop` with cron self-adjust and typed blocked events, orchestrator-drive-to-completion (ADR-0008), never-sticky-dormancy while beads exist, auto-expiring KILL/STOP switches.
 
 ### Hooks and Lifecycle
 
@@ -58,20 +72,42 @@ AgentOps v3.0.1 is the clean, recommended cut of the **3.0 major** — use it fo
 
 ### Knowledge Flywheel, Search, and Memory
 
-- Refactored: real hexagonal port adapters wired to their core consumers — a filesystem CorpusReader/Writer, a bd-backed TrackerPort, and a git-backed WorkspacePort.
+- Refactored: a real `corpus_fs` CorpusReader/Writer adapter wired to its core consumer.
+- Refactored: a real bd-backed TrackerPort adapter wired to its core consumer.
+- Refactored: a real git-backed WorkspacePort adapter wired to the core worktree lifecycle.
 
 ### Eval, Validation, and Release Gates
 
-- Added: a BDD acceptance layer — scenario→test linkage runner plus a CI gate (`soc-63xfx`), with canonical `.feature` acceptance across skills.
-- Added: `ao validate --gate` as a deterministic exit-code verdict for CI and Gas City retry loops.
-- Fixed: Nightly Static Validation ran the deleted `scripts/validate-hooks-doc-parity.sh`; the dead step is gone (AgentOps is hookless).
-- Fixed: `tests/docs/validate-skill-count.sh` extracted `PRODUCT.md` counts via hook-era patterns the 3.0 restructure removed; repointed to the four-layers skill-count line.
+- Added: a BDD acceptance layer — a scenario→test linkage runner plus a CI gate (`soc-63xfx`), with CLI-command and daemon-lifecycle Gherkin linked to tests.
+- Added: the SKU capability catalog (`registry.json` schema v2 — the generated skill×command×BC join) with a drift gate.
+- Added: a `context-map` drift gate and a `validate-skill-body-refs` gate for inline `ao` references in prose.
+- Added: `validate-release-notes.sh` as a hard release gate (curated notes must exist and conform to the standard).
+- Added: `ci-local-release.sh --quick` — the fast code-correctness subset for iterative pre-tag work.
+- Changed: `executable-spec-link-integrity` promoted warn→blocking; the scenario→test link gate is now required.
+- Changed: CI path-filters so `validate-*` and `security-*` jobs skip when irrelevant.
+- Fixed: Nightly Static Validation — removed the deleted `validate-hooks-doc-parity.sh` step and the hook-era `PRODUCT.md` skill-count patterns.
+- Fixed: pre-existing shellcheck warnings and post-merge CI failures cleared across the DDD/hex arc.
 
 ### Docs and Onboarding
 
-- Added: the 3.0 doctrine — `docs/3.0.md` north star, `docs/adr/ADR-0009-daemon-deletion-in-session-only.md`, and the canonical-loop model.
-- Added: `docs/MIGRATION-3.0.md`, the breaking-change migration guide.
-- Changed: README and PRODUCT reconciled to the in-session core, with the out-of-session autonomous-dispatch gap explicitly labeled (`soc-5jwah`).
+- Added: `docs/3.0.md` — the canonical 3.0 north star, woven into the sources of truth.
+- Added: `ADR-0009` (daemon deletion / in-session-only), `ADR-0008` (orchestrator drive-to-completion), and the canonical-loop model.
+- Added: `docs/MIGRATION-3.0.md` — the breaking-change migration guide.
+- Added: the tiered `AGENTS.md` split, the sovereignty-proof page, and the release-notes standard (with a major-release variant).
+- Changed: README cut of AI-slop and restructure; PRODUCT and peripheral docs reconciled to the in-session core.
+- Changed: stale daemon / schedule / hook prose swept across narrative docs, with the out-of-session autonomous-dispatch gap explicitly labeled (`soc-5jwah`).
+
+### Security, Privacy, and Supply Chain
+
+- Added: executable acceptance for the repository security scans (security hexagon).
+- Changed: the pre-publish release evidence lane (CycloneDX SBOM + provenance attestation + the security-gate summary) now gates GoReleaser, blocking only on real security findings.
+
+### Contributor/Internal Refactors
+
+- Added: `scripts/ship.sh` (one-knob ship loop), the `add-validate-job` CI scaffolder, `cron-tune-cadence`, `export-session-summary`, and `doctor-evolve` preflight tooling.
+- Added: the `domain` ubiquitous-language register (architecture terms + behavior-shaping ABC vocabulary).
+- Refactored: the DDD / hexagonal architecture rescope across the bounded contexts.
+- Refactored: generated-artifact regeneration (registry, context-map, codex hashes) wired behind drift gates.
 
 ## Known Issues
 


### PR DESCRIPTION
v3.0.1 is the 3.0 GA/Latest page, so it must tell the entire v2.41.1->v3.0 transformation (~320 commits, ~138K/133K lines), not a patch-framed summary. Earlier passes captured a fraction (the rip + 3.0.1 fixes) and dropped whole capabilities — ao doctor, the expanded goals/evolve surface, hex ports, the BDD/gates layer, the reference Gas City, the consolidation, the docs reconciliation. Mined the full delta and rewrote the curated notes to cover every touched product area, conforming to the standard (validate-release-notes.sh passes). v3.0.0 keeps its narrower .0 notes.

Bounded-context: BC5-Runtime
Evidence: docs/releases/2026-05-25-v3.0.1-notes.md