### PR TITLE
feat(release): tiered release-notes + coverage gate — end the release churn (ag-nc9)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,8 +196,11 @@ jobs:
       - name: Validate curated release notes (hard gate)
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${VERSION}$" | head -1)
           chmod +x scripts/validate-release-notes.sh
-          scripts/validate-release-notes.sh "$VERSION"
+          # --since runs the coverage gate: every product area the release actually
+          # touched must be documented (guards against an under-scoped major).
+          scripts/validate-release-notes.sh "$VERSION" --since "$PREV_TAG"
 
       - name: Extract release notes from CHANGELOG.md
         run: |

--- a/docs/releases/2026-05-25-v3.0.1-notes.md
+++ b/docs/releases/2026-05-25-v3.0.1-notes.md
@@ -27,6 +27,7 @@ The release removes hooks, the daemon, the scheduler, and the factory command (~
 | CLI and Operator Commands | 6 | 1 | 0 | 2 | 4 |
 | Daemon, Scheduling, and Factory | 0 | 0 | 0 | 0 | 4 |
 | Skills and Workflows | 3 | 2 | 0 | 0 | 0 |
+| Codex and Runtime Integrations | 0 | 1 | 0 | 0 | 0 |
 | Hooks and Lifecycle | 0 | 0 | 0 | 0 | 1 |
 | Knowledge Flywheel, Search, and Memory | 0 | 0 | 3 | 0 | 0 |
 | Eval, Validation, and Release Gates | 5 | 2 | 0 | 2 | 0 |
@@ -65,6 +66,10 @@ The release removes hooks, the daemon, the scheduler, and the factory command (~
 - Added: the `idea-wizard` generate-and-winnow flow folded into `/brainstorm` and the `/discovery` phase.
 - Changed: skill consolidation 81→75 — merged 4 skills into mode flags, cut 2, resolved 6 keep-flags.
 - Changed: `/evolve` hardening — `--mode=burst|loop` with cron self-adjust and typed blocked events, orchestrator-drive-to-completion (ADR-0008), never-sticky-dormancy while beads exist, auto-expiring KILL/STOP switches.
+
+### Codex and Runtime Integrations
+
+- Changed: the Codex skill twins (`skills-codex/`) and `.codex-plugin` manifest stayed in lockstep with the rip + consolidation, with hashes regenerated and parity audited across every skill change.
 
 ### Hooks and Lifecycle
 

--- a/scripts/scaffold-release-notes.sh
+++ b/scripts/scaffold-release-notes.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Scaffold a curated release-notes draft from the git range, in the correct
+# tier shape, so notes start comprehensive instead of hand-mined from scratch.
+#
+# Usage: scripts/scaffold-release-notes.sh <version> [--since <prev-tag>] [--force]
+#   <version>          release version (with or without leading "v")
+#   --since <prev-tag> the previous release tag; defaults to the latest tag that
+#                      is not <version> (i.e. the prior release)
+#   --force            overwrite an existing notes file
+#
+# Output: docs/releases/<today>-v<version>-notes.md, pre-populated with:
+#   - the tier-correct section skeleton (major adds "## Breaking Changes")
+#   - one "### <product area>" per area the range touched (>= threshold files),
+#     each seeded with the conventional-commit subjects for that area as
+#     "- Changed: <subject>" stubs to curate.
+# The result is a DRAFT — curate the prose, fix action labels, then run
+# scripts/validate-release-notes.sh to confirm it conforms.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+COVERAGE_THRESHOLD="${RELEASE_NOTES_COVERAGE_THRESHOLD:-3}"
+
+VERSION=""
+SINCE=""
+FORCE=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since) SINCE="${2:-}"; shift 2 ;;
+    --force) FORCE=1; shift ;;
+    -*) echo "Unknown flag: $1" >&2; exit 2 ;;
+    *) VERSION="$1"; shift ;;
+  esac
+done
+[[ -n "$VERSION" ]] || { echo "Usage: scaffold-release-notes.sh <version> [--since <prev-tag>] [--force]" >&2; exit 2; }
+VERSION="${VERSION#v}"
+
+if [[ "$VERSION" =~ ^[0-9]+\.0\.0$ ]]; then TIER="major"
+elif [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.0$ ]]; then TIER="minor"
+elif [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then TIER="hotfix"
+else echo "ERROR: version '${VERSION}' is not X.Y.Z" >&2; exit 1; fi
+
+if [[ -z "$SINCE" ]]; then
+  SINCE="$(git tag --sort=-version:refname | grep -v "^v${VERSION}$" | head -1)"
+fi
+[[ -n "$SINCE" ]] || { echo "ERROR: could not determine --since tag" >&2; exit 1; }
+
+endpoint="HEAD"
+git rev-parse "v${VERSION}^{commit}" >/dev/null 2>&1 && endpoint="v${VERSION}"
+
+OUT="docs/releases/$(date -u +%Y-%m-%d)-v${VERSION}-notes.md"
+if [[ -e "$OUT" && "$FORCE" -ne 1 ]]; then
+  echo "ERROR: $OUT exists (use --force to overwrite)" >&2
+  exit 1
+fi
+
+map_path_to_area() {
+  case "$1" in
+    .codex-plugin/*|scripts/install-codex*|scripts/validate-codex*) echo "Codex and Runtime Integrations" ;;
+    scripts/install*|.goreleaser*|.github/workflows/release.yml|packs/*install*) echo "Install, Upgrade, and Distribution" ;;
+    cli/cmd/ao/*|cli/docs/COMMANDS.md) echo "CLI and Operator Commands" ;;
+    cli/internal/daemon/*|cli/internal/schedule/*|cli/internal/agentworker/*|cli/internal/gascity/*) echo "Daemon, Scheduling, and Factory" ;;
+    skills/*|skills-codex*) echo "Skills and Workflows" ;;
+    hooks/*|cli/embedded/hooks/*) echo "Hooks and Lifecycle" ;;
+    cli/internal/knowledge/*|cli/internal/harvest/*|cli/internal/pool/*|cli/internal/lifecycle/*|cli/internal/search/*) echo "Knowledge Flywheel, Search, and Memory" ;;
+    cli/internal/eval/*|evals/*|tests/*|.github/workflows/validate.yml) echo "Eval, Validation, and Release Gates" ;;
+    scripts/security*|scripts/toolchain-validate*|*sbom*) echo "Security, Privacy, and Supply Chain" ;;
+    README.md|docs/*|PRODUCT.md) echo "Docs and Onboarding" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Tally touched files per area.
+declare -A area_hits=()
+while IFS= read -r f; do
+  [[ -n "$f" ]] || continue
+  a="$(map_path_to_area "$f")"
+  [[ -n "$a" ]] && area_hits["$a"]=$(( ${area_hits["$a"]:-0} + 1 ))
+done < <(git diff --name-only "${SINCE}..${endpoint}" 2>/dev/null || true)
+
+ncommits="$(git rev-list --count --no-merges "${SINCE}..${endpoint}" 2>/dev/null || echo "?")"
+
+{
+  echo "## Highlights"
+  echo ""
+  echo "<!-- ${TIER} release. ${ncommits} commits since ${SINCE}. 2-4 sentences: theme + biggest outcomes. -->"
+  echo ""
+  echo "## Upgrade Notes"
+  echo ""
+  echo "- <required action, or \"No manual action required\">"
+  [[ "$TIER" == "major" ]] && echo "- See \`docs/MIGRATION-${VERSION%%.*}.0.md\` for the full migration."
+  echo ""
+  if [[ "$TIER" == "major" ]]; then
+    echo "## Breaking Changes"
+    echo ""
+    echo "- <each breaking change: what changed, what to use instead, migration pointer>"
+    echo ""
+  fi
+  echo "## At a Glance"
+  echo ""
+  echo "| Product Area | Added | Changed | Refactored | Fixed | Deprecated/Removed |"
+  echo "|---|---:|---:|---:|---:|---:|"
+  for a in "${!area_hits[@]}"; do
+    [[ "${area_hits[$a]}" -ge "$COVERAGE_THRESHOLD" ]] && echo "| $a | 0 | 0 | 0 | 0 | 0 |"
+  done
+  echo ""
+  echo "## Product Areas"
+  echo ""
+  # One section per touched area, seeded with that area's commit subjects.
+  for a in "${!area_hits[@]}"; do
+    [[ "${area_hits[$a]}" -ge "$COVERAGE_THRESHOLD" ]] || continue
+    echo "### $a"
+    echo ""
+    # Seed bullets from commit subjects whose changed files map to this area.
+    git log --no-merges --pretty='%H %s' "${SINCE}..${endpoint}" 2>/dev/null | while IFS= read -r line; do
+      sha="${line%% *}"; subj="${line#* }"
+      files="$(git diff --name-only "${sha}~1..${sha}" 2>/dev/null || true)"
+      while IFS= read -r f; do
+        [[ -n "$f" ]] || continue
+        if [[ "$(map_path_to_area "$f")" == "$a" ]]; then
+          clean="$(printf '%s' "$subj" | sed -E 's/ \(#[0-9]+\)$//; s/^[a-z]+\([a-z0-9_-]+\)!?: //')"
+          echo "- Changed: ${clean}"
+          break
+        fi
+      done <<< "$files"
+    done | sort -u | head -12
+    echo ""
+  done
+  echo "## Known Issues"
+  echo ""
+  echo "- <known risk/limitation, or \"No release-blocking known issues.\">"
+  echo ""
+  echo "[Full changelog](../CHANGELOG.md)"
+} > "$OUT"
+
+echo "Scaffolded $OUT (tier $TIER, ${ncommits} commits since ${SINCE})"
+echo "Next: curate prose + action labels, then: scripts/validate-release-notes.sh v${VERSION} --since ${SINCE}"

--- a/scripts/validate-release-notes.sh
+++ b/scripts/validate-release-notes.sh
@@ -2,26 +2,58 @@
 # Validate a curated release-notes file against the standard in
 # skills/release/references/release-notes.md.
 #
-# Usage: scripts/validate-release-notes.sh <version>
-#   <version> = release version, with or without leading "v" (e.g. v3.0.1 or 3.0.1)
+# Usage: scripts/validate-release-notes.sh <version> [--since <prev-tag>] [--changed-files <file>]
+#   <version>          release version, with or without leading "v" (e.g. v3.0.1 or 3.0.1)
+#   --since <prev-tag> run the COVERAGE gate against git diff <prev-tag>..<version|HEAD>
+#   --changed-files F  run the COVERAGE gate against a newline-separated path list in F
+#                      (test seam; avoids needing git history)
 #
-# Enforces (hard fail, exit 1, on any violation):
-#   - a curated docs/releases/*-v<version>-notes.md file exists (no silent
-#     fallback to the raw CHANGELOG)
+# Release tiers (derived from the version):
+#   major   X.0.0   requires "## Breaking Changes"; notes cover the whole
+#                   last-release..HEAD delta (the entire major), not one stanza
+#   minor   X.Y.0   standard sections; Breaking Changes only if actually breaking
+#   hotfix  X.Y.Z   standard sections; narrow patch delta
+#
+# Enforces (hard fail, exit 1):
+#   - a curated docs/releases/*-v<version>-notes.md file exists (no raw-CHANGELOG fallback)
 #   - the required section skeleton is present
-#   - major releases (X.0.0) carry a "## Breaking Changes" section
+#   - major (X.0.0) carries a "## Breaking Changes" section
 #   - every "### " product-area heading is from the canonical taxonomy
-#   - every top-level bullet under a product area uses a canonical action label
-#
-# This is the mechanical backstop for the failure where 3.0.0/3.0.1 shipped
-# with no curated notes and the generator silently dumped the raw CHANGELOG.
+#   - every top-level product-area bullet uses a canonical action label
+#   - COVERAGE: every product area the release actually touched (>= threshold files)
+#     appears as a "### " section — this is the mechanical guard against an
+#     under-scoped major (the v3.0.x churn root cause).
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+COVERAGE_THRESHOLD="${RELEASE_NOTES_COVERAGE_THRESHOLD:-3}"
 
-VERSION="${1:?Usage: validate-release-notes.sh <version>}"
+VERSION=""
+COVERAGE_SINCE=""
+COVERAGE_FILES=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since) COVERAGE_SINCE="${2:-}"; shift 2 ;;
+    --changed-files) COVERAGE_FILES="${2:-}"; shift 2 ;;
+    -*) echo "Unknown flag: $1" >&2; exit 2 ;;
+    *) VERSION="$1"; shift ;;
+  esac
+done
+[[ -n "$VERSION" ]] || { echo "Usage: validate-release-notes.sh <version> [--since <prev-tag>] [--changed-files <file>]" >&2; exit 2; }
 VERSION="${VERSION#v}"
+
+# --- Tier classification ---
+if [[ "$VERSION" =~ ^[0-9]+\.0\.0$ ]]; then
+  TIER="major"
+elif [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
+  TIER="minor"
+elif [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  TIER="hotfix"
+else
+  echo "FAIL: version '${VERSION}' is not X.Y.Z" >&2
+  exit 1
+fi
 
 errors=0
 fail() {
@@ -34,11 +66,11 @@ fail() {
 NOTES_FILE="$(find "$REPO_ROOT/docs/releases" -name "*-v${VERSION}-notes.md" 2>/dev/null | head -1 || true)"
 if [[ -z "$NOTES_FILE" || ! -f "$NOTES_FILE" ]]; then
   echo "FAIL: no curated release-notes file docs/releases/*-v${VERSION}-notes.md" >&2
-  echo "      Write one per the standard in skills/release/references/release-notes.md" >&2
-  echo "      before tagging. The raw CHANGELOG is not an acceptable release body." >&2
+  echo "      Scaffold one with: scripts/scaffold-release-notes.sh v${VERSION} --since <prev-tag>" >&2
+  echo "      then curate per skills/release/references/release-notes.md before tagging." >&2
   exit 1
 fi
-echo "Validating $NOTES_FILE (version $VERSION)"
+echo "Validating $NOTES_FILE (version $VERSION, tier $TIER)"
 
 # --- Required top-level sections ---
 
@@ -57,7 +89,7 @@ grep -Fq "Full changelog" "$NOTES_FILE" || fail "missing the [Full changelog] li
 
 # --- Major releases (X.0.0) require a Breaking Changes section ---
 
-if [[ "$VERSION" =~ ^[0-9]+\.0\.0$ ]]; then
+if [[ "$TIER" == "major" ]]; then
   grep -Fxq "## Breaking Changes" "$NOTES_FILE" \
     || fail "major release ${VERSION} must include a '## Breaking Changes' section"
 fi
@@ -78,28 +110,42 @@ canonical_areas=(
   "Contributor/Internal Refactors"
 )
 is_canonical_area() {
-  local candidate="$1"
-  local area
+  local candidate="$1" area
   for area in "${canonical_areas[@]}"; do
     [[ "$candidate" == "$area" ]] && return 0
   done
   return 1
 }
 
-# Canonical action labels for product-area bullets.
-LABEL_RE='^- (Added|Changed|Refactored|Fixed|Deprecated|Removed|Security|Docs): '
+# Map a changed path to its product area (first match wins). Echoes the area
+# name, or nothing for paths that don't map to a release-facing area. Mirrors
+# the Coverage Workflow table in skills/release/references/release-notes.md.
+map_path_to_area() {
+  local p="$1"
+  case "$p" in
+    .codex-plugin/*|scripts/install-codex*|scripts/validate-codex*) echo "Codex and Runtime Integrations" ;;
+    scripts/install*|.goreleaser*|.github/workflows/release.yml|packs/*install*) echo "Install, Upgrade, and Distribution" ;;
+    cli/cmd/ao/*|cli/docs/COMMANDS.md) echo "CLI and Operator Commands" ;;
+    cli/internal/daemon/*|cli/internal/schedule/*|cli/internal/agentworker/*|cli/internal/gascity/*) echo "Daemon, Scheduling, and Factory" ;;
+    skills/*|skills-codex*) echo "Skills and Workflows" ;;
+    hooks/*|cli/embedded/hooks/*) echo "Hooks and Lifecycle" ;;
+    cli/internal/knowledge/*|cli/internal/harvest/*|cli/internal/pool/*|cli/internal/lifecycle/*|cli/internal/search/*) echo "Knowledge Flywheel, Search, and Memory" ;;
+    cli/internal/eval/*|evals/*|tests/*|.github/workflows/validate.yml) echo "Eval, Validation, and Release Gates" ;;
+    scripts/security*|scripts/toolchain-validate*|*sbom*) echo "Security, Privacy, and Supply Chain" ;;
+    README.md|docs/*|PRODUCT.md) echo "Docs and Onboarding" ;;
+    *) echo "" ;;
+  esac
+}
 
 # --- Walk the Product Areas region: validate ### headings + bullet labels ---
 
+LABEL_RE='^- (Added|Changed|Refactored|Fixed|Deprecated|Removed|Security|Docs): '
+declare -A present_areas=()
 in_product_areas=0
 current_area=""
 while IFS= read -r line; do
   if [[ "$line" == "## "* ]]; then
-    if [[ "$line" == "## Product Areas" ]]; then
-      in_product_areas=1
-    else
-      in_product_areas=0
-    fi
+    in_product_areas=$([[ "$line" == "## Product Areas" ]] && echo 1 || echo 0)
     current_area=""
     continue
   fi
@@ -107,14 +153,13 @@ while IFS= read -r line; do
 
   if [[ "$line" == "### "* ]]; then
     current_area="${line:4}"  # strip the literal "### " prefix (4 chars)
+    present_areas["$current_area"]=1
     if ! is_canonical_area "$current_area"; then
       fail "non-canonical product-area heading: '### ${current_area}' (see skills/release/references/release-notes.md taxonomy)"
     fi
     continue
   fi
 
-  # Top-level bullets (not indented sub-bullets) under a product area must
-  # start with a canonical action label.
   if [[ "$line" == "- "* ]]; then
     if [[ -z "$current_area" ]]; then
       fail "bullet outside any '### <product area>' heading: ${line}"
@@ -124,10 +169,50 @@ while IFS= read -r line; do
   fi
 done < "$NOTES_FILE"
 
+# --- COVERAGE gate: touched areas must appear in the notes ---
+
+CHANGED=""
+if [[ -n "$COVERAGE_FILES" ]]; then
+  if [[ -f "$COVERAGE_FILES" ]]; then
+    CHANGED="$(cat "$COVERAGE_FILES")"
+  else
+    fail "--changed-files not found: $COVERAGE_FILES"
+  fi
+elif [[ -n "$COVERAGE_SINCE" ]] && git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  endpoint="HEAD"
+  git -C "$REPO_ROOT" rev-parse "v${VERSION}^{commit}" >/dev/null 2>&1 && endpoint="v${VERSION}"
+  if git -C "$REPO_ROOT" rev-parse "${COVERAGE_SINCE}^{commit}" >/dev/null 2>&1; then
+    CHANGED="$(git -C "$REPO_ROOT" diff --name-only "${COVERAGE_SINCE}..${endpoint}" 2>/dev/null || true)"
+  else
+    echo "  coverage: --since '${COVERAGE_SINCE}' does not resolve; skipping coverage gate" >&2
+  fi
+fi
+
+if [[ -n "$CHANGED" ]]; then
+  declare -A area_hits=()
+  while IFS= read -r f; do
+    [[ -n "$f" ]] || continue
+    a="$(map_path_to_area "$f")"
+    [[ -n "$a" ]] && area_hits["$a"]=$(( ${area_hits["$a"]:-0} + 1 ))
+  done <<< "$CHANGED"
+
+  echo "  coverage: touched areas (>= ${COVERAGE_THRESHOLD} files must be documented):"
+  for a in "${!area_hits[@]}"; do
+    n="${area_hits[$a]}"
+    if [[ "$n" -ge "$COVERAGE_THRESHOLD" ]]; then
+      if [[ -n "${present_areas[$a]:-}" ]]; then
+        echo "    ok  ($n) $a"
+      else
+        fail "release touched '${a}' (${n} files) but the notes have no '### ${a}' section"
+      fi
+    fi
+  done
+fi
+
 if [[ "$errors" -gt 0 ]]; then
   echo "" >&2
   echo "FAIL: ${errors} release-notes standard violation(s) in $NOTES_FILE" >&2
   exit 1
 fi
 
-echo "PASS: $NOTES_FILE conforms to the release-notes standard"
+echo "PASS: $NOTES_FILE conforms to the release-notes standard (tier $TIER)"

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -937,8 +937,8 @@
     {
       "name": "release",
       "source_skill": "skills/release",
-      "source_hash": "388c158c268fcca84f03759bc0e2440fdaa3bb8eafa801970d5ff5f1493b1507",
-      "generated_hash": "11f136dba806c932ad2d26d7b6a8f70967f432300cf102d1411f84451fa116e1"
+      "source_hash": "84e3cc2973070840ad30014bf0e37bf05f4c340761ed676896db48a4a109edb5",
+      "generated_hash": "5b3075bdee6aeed794ad7841e990f0cc94dbad414506c57f8cb4f42515c4e465"
     },
     {
       "name": "research",

--- a/skills-codex/release/.agentops-generated.json
+++ b/skills-codex/release/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/release",
   "layout": "modular",
-  "source_hash": "388c158c268fcca84f03759bc0e2440fdaa3bb8eafa801970d5ff5f1493b1507",
-  "generated_hash": "11f136dba806c932ad2d26d7b6a8f70967f432300cf102d1411f84451fa116e1"
+  "source_hash": "84e3cc2973070840ad30014bf0e37bf05f4c340761ed676896db48a4a109edb5",
+  "generated_hash": "5b3075bdee6aeed794ad7841e990f0cc94dbad414506c57f8cb4f42515c4e465"
 }

--- a/skills-codex/release/references/release-notes.md
+++ b/skills-codex/release/references/release-notes.md
@@ -5,6 +5,24 @@ developer-facing. `docs/releases/YYYY-MM-DD-v<version>-notes.md` is the public
 GitHub Release body: scannable, product-area-first, and curated for users who
 want to know whether a release touches the part of AgentOps they care about.
 
+## Scope rule (read this first)
+
+**The notes cover the git range since the previous release — `git log <prev-tag>..HEAD` — not the single `## [version]` CHANGELOG stanza.** This is the rule that prevents under-scoped notes. For a major, the previous release is the last minor/patch, so the range *is the entire major* (every product area the major touched). Derive scope from `git diff --name-only <prev-tag>..HEAD`, never from one changelog entry.
+
+Don't hand-mine from scratch — run `scripts/scaffold-release-notes.sh v<version> --since <prev-tag>` to emit a tier-correct draft (one `### ` per touched area, seeded with that area's commit subjects), then curate. `scripts/validate-release-notes.sh v<version> --since <prev-tag>` enforces both the shape and **coverage** (every area the range touched must appear), and runs as a hard gate in `release.yml`.
+
+## Release tiers
+
+The version determines the tier and the shape:
+
+| Tier | Version | Scope (git range) | `## Breaking Changes` |
+|---|---|---|---|
+| **major** | `X.0.0` | last release → HEAD (the whole major) | **required** |
+| **minor** | `X.Y.0` | last minor/patch → HEAD | only if actually breaking |
+| **hotfix** | `X.Y.Z` (Z>0) | last patch → HEAD (narrow) | only if actually breaking |
+
+All tiers use the same required section skeleton below; only `## Breaking Changes` (required for majors) and the breadth of `## Product Areas` differ. A hotfix typically has one or two areas; a major has many.
+
 ## Audience
 
 Write for people scrolling a GitHub release page, not for contributors reading

--- a/skills/release/references/release-notes.md
+++ b/skills/release/references/release-notes.md
@@ -5,6 +5,24 @@ developer-facing. `docs/releases/YYYY-MM-DD-v<version>-notes.md` is the public
 GitHub Release body: scannable, product-area-first, and curated for users who
 want to know whether a release touches the part of AgentOps they care about.
 
+## Scope rule (read this first)
+
+**The notes cover the git range since the previous release — `git log <prev-tag>..HEAD` — not the single `## [version]` CHANGELOG stanza.** This is the rule that prevents under-scoped notes. For a major, the previous release is the last minor/patch, so the range *is the entire major* (every product area the major touched). Derive scope from `git diff --name-only <prev-tag>..HEAD`, never from one changelog entry.
+
+Don't hand-mine from scratch — run `scripts/scaffold-release-notes.sh v<version> --since <prev-tag>` to emit a tier-correct draft (one `### ` per touched area, seeded with that area's commit subjects), then curate. `scripts/validate-release-notes.sh v<version> --since <prev-tag>` enforces both the shape and **coverage** (every area the range touched must appear), and runs as a hard gate in `release.yml`.
+
+## Release tiers
+
+The version determines the tier and the shape:
+
+| Tier | Version | Scope (git range) | `## Breaking Changes` |
+|---|---|---|---|
+| **major** | `X.0.0` | last release → HEAD (the whole major) | **required** |
+| **minor** | `X.Y.0` | last minor/patch → HEAD | only if actually breaking |
+| **hotfix** | `X.Y.Z` (Z>0) | last patch → HEAD (narrow) | only if actually breaking |
+
+All tiers use the same required section skeleton below; only `## Breaking Changes` (required for majors) and the breadth of `## Product Areas` differ. A hotfix typically has one or two areas; a major has many.
+
 ## Audience
 
 Write for people scrolling a GitHub release page, not for contributors reading

--- a/tests/scripts/validate-release-notes.bats
+++ b/tests/scripts/validate-release-notes.bats
@@ -132,3 +132,46 @@ EOF
   [ "$status" -ne 0 ]
   [[ "$output" == *"canonical action label"* ]]
 }
+
+@test "reports the tier (hotfix) for an X.Y.Z version" {
+  write_patch_notes "9.9.9"
+  run "$SANDBOX/scripts/validate-release-notes.sh" v9.9.9
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tier hotfix"* ]]
+}
+
+@test "reports the tier (minor) for an X.Y.0 version" {
+  write_patch_notes "9.9.0"
+  run "$SANDBOX/scripts/validate-release-notes.sh" v9.9.0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tier minor"* ]]
+}
+
+@test "minor (X.Y.0) does NOT require a Breaking Changes section" {
+  write_patch_notes "9.9.0"
+  run "$SANDBOX/scripts/validate-release-notes.sh" v9.9.0
+  [ "$status" -eq 0 ]
+}
+
+@test "coverage gate FAILS when a touched area is missing from the notes" {
+  write_patch_notes "9.9.9"   # notes document only "Eval, Validation, and Release Gates"
+  printf 'cli/cmd/ao/a.go\ncli/cmd/ao/b.go\ncli/cmd/ao/c.go\n' > "$SANDBOX/changed.txt"
+  run "$SANDBOX/scripts/validate-release-notes.sh" v9.9.9 --changed-files "$SANDBOX/changed.txt"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"CLI and Operator Commands"* ]]
+  [[ "$output" == *"no '### CLI and Operator Commands' section"* ]]
+}
+
+@test "coverage gate PASSES when all touched areas are documented" {
+  write_patch_notes "9.9.9"   # documents "Eval, Validation, and Release Gates"
+  printf 'tests/scripts/x.bats\ntests/scripts/y.bats\nevals/z.json\n' > "$SANDBOX/changed.txt"
+  run "$SANDBOX/scripts/validate-release-notes.sh" v9.9.9 --changed-files "$SANDBOX/changed.txt"
+  [ "$status" -eq 0 ]
+}
+
+@test "coverage gate ignores areas below the file threshold" {
+  write_patch_notes "9.9.9"
+  printf 'cli/cmd/ao/just-one.go\n' > "$SANDBOX/changed.txt"   # 1 file < threshold 3
+  run "$SANDBOX/scripts/validate-release-notes.sh" v9.9.9 --changed-files "$SANDBOX/changed.txt"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Makes release-notes scope mechanical per tier so a release can never again under-scope its notes and burn the re-mining churn (root cause of the v3.0.x rewrites).

- **Scope rule + tiers** in the standard (+ codex twin): notes = git range since the previous release (a major = the whole major), with a major/minor/hotfix table.
- **Coverage gate** in validate-release-notes.sh: maps the diff to product areas, FAILS if a heavily-touched area (>=3 files) is undocumented. Wired into release.yml via --since. It immediately caught a real gap (v3.0.1 missing the Codex area — fixed here).
- **scaffold-release-notes.sh**: mines the range into a tier-correct draft so notes start comprehensive.
- 6 new bats (14 total), shellcheck clean, codex parity green. v3.0.1 notes verified to PASS coverage over the real v2.41.1..v3.0.1 diff.

Closes-scenario: ag-nc9#tiers-coverage-gate
Bounded-context: BC5-Runtime
Evidence: scripts/validate-release-notes.sh