### PR TITLE
fix(ci): allow PR-only skips in release tag validate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1887,19 +1887,45 @@ jobs:
           echo "executable-spec-link-integrity: ${{ needs.executable-spec-link-integrity.result }}"
           echo "validate-scenario-test-linkage: ${{ needs.validate-scenario-test-linkage.result }}"
 
-          # Fail on actual failures. On release tags, skipped jobs are also a
-          # failure because validate.yml must be a full exact-SHA release
-          # verdict, not a path-filtered partial signal.
+          # Fail on actual failures. On release tags, skipped release lanes are
+          # also failures because validate.yml must be a full exact-SHA release
+          # verdict, not a path-filtered partial signal. PR-only jobs are
+          # explicitly allowlisted because they cannot run for tag push events.
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
             echo ""
             echo "❌ Some checks failed (failure detected)"
             exit 1
           fi
 
-          if [[ "${GITHUB_REF}" == refs/tags/v* && "${{ contains(needs.*.result, 'skipped') }}" == "true" ]]; then
-            echo ""
-            echo "❌ Release-tag Validate had skipped jobs; skipped is not a release verdict"
-            exit 1
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            release_needs_json='${{ toJson(needs) }}'
+            release_skipped="$(
+              NEEDS_JSON="$release_needs_json" python3 - <<'PY'
+          import json
+          import os
+
+          allowed_skips = {
+              "lint-evidence-lines-advisory",
+              "validate-pr-evidence-claims",
+          }
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          unexpected = sorted(
+              name
+              for name, metadata in needs.items()
+              if metadata.get("result") == "skipped" and name not in allowed_skips
+          )
+
+          for name in unexpected:
+              print(name)
+          PY
+            )"
+            if [[ -n "$release_skipped" ]]; then
+              echo ""
+              echo "❌ Release-tag Validate had unexpected skipped jobs; skipped release lanes are not a release verdict"
+              printf '%s\n' "$release_skipped" | sed 's/^/- /'
+              exit 1
+            fi
           fi
 
           echo ""

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -99,8 +99,10 @@ Current non-blocking validate jobs are `doctor-check`, `factory-claim-ledger-str
 For normal `main` pushes and PRs, the `changes` job path-filters expensive lanes.
 For `refs/tags/v*` pushes, `changes` forces every category output to `true` and
 skips the path-filter step. The release-tag `summary` also fails if any job is
-skipped. A green release Validate run therefore means every blocking lane ran
-for the exact tagged SHA; skipped is not treated as passed for releases.
+unexpectedly skipped. PR-only evidence jobs are allowlisted because tag push
+events do not have a pull request body to inspect. A green release Validate run
+therefore means every blocking release lane ran for the exact tagged SHA;
+skipped is not treated as passed for releases.
 
 ## Blocking vs Soft Gates
 

--- a/tests/scripts/validate-release-tag-full-ci.bats
+++ b/tests/scripts/validate-release-tag-full-ci.bats
@@ -34,10 +34,26 @@ setup() {
     done
 }
 
-@test "summary fails release tags with skipped jobs" {
-    run grep -F "Release-tag Validate had skipped jobs" "$WORKFLOW_PATH"
+@test "summary fails release tags with unexpected skipped jobs" {
+    run grep -F "Release-tag Validate had unexpected skipped jobs" "$WORKFLOW_PATH"
     [ "$status" -eq 0 ]
 
+    run grep -F "skipped release lanes are not a release verdict" "$WORKFLOW_PATH"
+    [ "$status" -eq 0 ]
+}
+
+@test "summary does not fail release tags on every skipped job blindly" {
     run grep -F "contains(needs.*.result, 'skipped')" "$WORKFLOW_PATH"
+    [ "$status" -ne 0 ]
+}
+
+@test "summary allows explicitly PR-only jobs to skip on release tags" {
+    run grep -F "toJson(needs)" "$WORKFLOW_PATH"
+    [ "$status" -eq 0 ]
+
+    run grep -F '"validate-pr-evidence-claims"' "$WORKFLOW_PATH"
+    [ "$status" -eq 0 ]
+
+    run grep -F '"lint-evidence-lines-advisory"' "$WORKFLOW_PATH"
     [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary

- keep release-tag Validate strict for unexpected skipped release lanes
- explicitly allow PR-only evidence checks to skip on tag pushes
- update release-tag CI bats coverage and CI docs so the policy is locked

## Evidence

- `python3 - <<'PY' ... yaml.safe_load(.github/workflows/validate.yml)`
- `bats tests/scripts/validate-release-tag-full-ci.bats`
- `bash tests/scripts/test-ci-policy-parity.sh`
- `bash scripts/validate-ci-policy-parity.sh`
- `git diff --check`
- `scripts/pre-push-gate.sh --fast`

## Notes

This fixes the release-health contradiction where `v3.0.1` published successfully but tag Validate failed because PR-only AP#7 was skipped on a tag event.
