### PR TITLE
fix(cmd/ao): close goals-globals leak in resetCommandState (ag-pah #goals-flake-fix)

### DIFF
--- a/cli/cmd/ao/testutil_test.go
+++ b/cli/cmd/ao/testutil_test.go
@@ -228,6 +228,21 @@ func resetCommandState(t *testing.T) {
 	origNoBeads := noBeads
 	origMinimal := minimal
 	origGoalsJSON := output
+	// Goals subcommand flag globals (ag-pah): cli/cmd/ao/goals_*.go
+	// declares these as package-level vars bound to cobra flags. Tests
+	// that mutate them must save+restore here or a panic in one test
+	// leaks state into the next. This was the root cause of the
+	// TestGoals_Integration_* flake family observed on PRs #551 and #553.
+	origGoalsFile := goalsFile
+	origGoalsTimeout := goalsTimeout
+	origGoalsMeasureGoalID := goalsMeasureGoalID
+	origGoalsMeasureDirectives := goalsMeasureDirectives
+	origGoalsMeasureExcludeTag := goalsMeasureExcludeTag
+	origGoalsMeasureTotalTimeout := goalsMeasureTotalTimeout
+	origGoalsMeasureScenariosOnly := goalsMeasureScenariosOnly
+	origGoalsInitNonInteractive := goalsInitNonInteractive
+	origGoalsInitTemplate := goalsInitTemplate
+	origGoalsRenderOut := goalsRenderOut
 	origMemorySyncQuiet := memorySyncQuiet
 	origMemorySyncMaxEntries := memorySyncMaxEntries
 	origMemorySyncOutput := memorySyncOutput
@@ -299,6 +314,17 @@ func resetCommandState(t *testing.T) {
 		noBeads = origNoBeads
 		minimal = origMinimal
 		output = origGoalsJSON
+		// Goals subcommand flag globals (ag-pah): paired with saves above.
+		goalsFile = origGoalsFile
+		goalsTimeout = origGoalsTimeout
+		goalsMeasureGoalID = origGoalsMeasureGoalID
+		goalsMeasureDirectives = origGoalsMeasureDirectives
+		goalsMeasureExcludeTag = origGoalsMeasureExcludeTag
+		goalsMeasureTotalTimeout = origGoalsMeasureTotalTimeout
+		goalsMeasureScenariosOnly = origGoalsMeasureScenariosOnly
+		goalsInitNonInteractive = origGoalsInitNonInteractive
+		goalsInitTemplate = origGoalsInitTemplate
+		goalsRenderOut = origGoalsRenderOut
 		memorySyncQuiet = origMemorySyncQuiet
 		memorySyncMaxEntries = origMemorySyncMaxEntries
 		memorySyncOutput = origMemorySyncOutput
@@ -370,6 +396,20 @@ func resetCommandState(t *testing.T) {
 	seedForce = false
 	noBeads = false
 	minimal = false
+	// Goals subcommand flag globals (ag-pah): explicit reset to flag defaults
+	// so a polluted prior-test state doesn't carry into the current test.
+	// Save+restore above handles after-test cleanup; this handles before-test
+	// hygiene.
+	goalsFile = ""
+	goalsTimeout = defaultGoalsTimeoutSeconds
+	goalsMeasureGoalID = ""
+	goalsMeasureDirectives = false
+	goalsMeasureExcludeTag = ""
+	goalsMeasureTotalTimeout = 0
+	goalsMeasureScenariosOnly = false
+	goalsInitNonInteractive = false
+	goalsInitTemplate = ""
+	goalsRenderOut = ""
 	output = "table"
 	memorySyncQuiet = false
 	memorySyncMaxEntries = 10


### PR DESCRIPTION
## Summary

Closes the goals-globals leak in `cli/cmd/ao/testutil_test.go::resetCommandState` that caused `TestGoals_Integration_*` to flake on **100% of this session's code PRs** (#551 and #553). One file, 40 insertions, no production code changes.

## What changed

`cli/cmd/ao/testutil_test.go::resetCommandState` saved + restored ~70 cobra-flag-bound package-level vars but missed the 10 goals-prefixed ones. Tests in this package mutate them, and a t.Fatal or order-dependent state-leak surfaced as a flake.

Three inserts (saves block, restores block, reset-to-defaults block), all goals-* package-level vars now properly isolated:

- `goalsFile`, `goalsTimeout`
- `goalsMeasureGoalID`, `goalsMeasureDirectives`, `goalsMeasureExcludeTag`, `goalsMeasureTotalTimeout`, `goalsMeasureScenariosOnly`
- `goalsInitNonInteractive`, `goalsInitTemplate`
- `goalsRenderOut`

Sibling pattern: matches the existing save → t.Cleanup → reset-default shape used for all the other ~70 flag globals in this function. Just plumbing the missing ones in.

## Verification (run locally; both green)

```bash
# Previously-flaky tests, 10× each, shuffled
go test -count=10 -shuffle=on -run 'TestGoals_Integration' ./cmd/ao/
# Result: ok 0.333s

# Full cmd/ao package, 3× shuffled — catches OTHER cross-test pollution
go test -count=3 -shuffle=on ./cmd/ao/
# Result: ok 375.321s
```

50 invocations of the previously-flaky family, all PASS. Full package 3× shuffled, no regression.

## Diagnosis context

This is the Tier-1 fix from `.agents/research/2026-05-26-ci-pr-bottleneck-diagnosis.md`. The diagnosis named CI flakes in this exact file as the dominant felt-bottleneck for code PRs in this session — each flake costs a full CI rerun cycle (~7 min). With this fix, the rerun amplifier should disappear.

## Fitness delta

- Goals-globals saved by `resetCommandState`: **1 → 11** (the prior `origGoalsJSON` was actually a redundant alias for `output`, not goals-specific)
- This-session flake rate: **100% (2/2) → 0%** (expected; pending CI confirmation on this PR)

## Out of scope (deferred, all NOT bundled)

- The `origGoalsJSON = output` line is a redundant save (output is already saved as `origOutput`). Harmless; leave for a separate cleanup PR.
- The `defer { goalsInitNonInteractive = false }` lines in `goals_integration_test.go` are now redundant with `resetCommandState` handling them. Defense-in-depth; leave.
- `cli/cmd/ao/goals_steer_auto.go:71 goalsPath` is a struct field on `steerEvalContext`, NOT a package-level var. Confirmed during validate.

## Trailers

Closes-scenario: ag-pah#reset-command-state-saves-all-goals-globals
Closes-scenario: ag-pah#goals-integration-tests-stable-under-shuffle
Bounded-context: BC5-Runtime
Evidence: .agents/research/2026-05-26-ci-pr-bottleneck-diagnosis.md
Evidence: cli/cmd/ao/testutil_test.go (40 insertions, 3 inserts)

Sibling pattern: mirrors the existing save → t.Cleanup → reset-default shape from resetCommandState (cli/cmd/ao/testutil_test.go).