### PR TITLE
perf(ci): cache pinned Go tool binaries in agentops-contract-canaries (ag-56y #canary-cache)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -730,13 +730,31 @@ jobs:
           go-version: '1.26.3'
           cache-dependency-path: cli/go.sum
 
+      # Cache the version-pinned tool binaries this job installs from outside
+      # the cli module (gocyclo, bd). setup-go's module/build cache covers
+      # cli/go.sum dependencies but doesn't cache `go install` outputs to
+      # GOBIN. See ag-56y / .agents/research/2026-05-26-ci-pr-bottleneck-diagnosis.md.
+      - name: Cache pinned Go tool binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/bin
+            ~/.local/bin
+          key: canary-tools-${{ runner.os }}-gocyclo-v0.6.0-bd-v1.0.3
+
       - name: Install AgentOps contract canary dependencies
         run: |
           sudo apt-get install -y jq ripgrep
           sudo npm install -g bats@1.12.0
-          GOBIN="$HOME/go/bin" go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
+          # Skip `go install` on cache hit — binaries are version-pinned and
+          # the cache key encodes both versions, so any pin bump invalidates.
+          if [ ! -x "$HOME/go/bin/gocyclo" ]; then
+            GOBIN="$HOME/go/bin" go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
+          fi
           echo "$HOME/go/bin" >> "$GITHUB_PATH"
-          GOBIN="$HOME/.local/bin" go install github.com/steveyegge/beads/cmd/bd@v1.0.3
+          if [ ! -x "$HOME/.local/bin/bd" ]; then
+            GOBIN="$HOME/.local/bin" go install github.com/steveyegge/beads/cmd/bd@v1.0.3
+          fi
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           bd_eval_root="$RUNNER_TEMP/agentops-bd"
           mkdir -p "$bd_eval_root"


### PR DESCRIPTION
## Summary

Cache the version-pinned Go tool binaries that `agentops-contract-canaries` rebuilds on every CI run. Tier-2 fix from the bottleneck diagnosis. Single file change, +20/-2 LOC.

## What changed

`.github/workflows/validate.yml::agentops-contract-canaries` — added an `actions/cache@v4` step between `Set up Go` and `Install AgentOps contract canary dependencies`, and modified the install step to skip `go install` on cache hit.

- **Cache path:** `~/go/bin` (gocyclo) + `~/.local/bin` (bd)
- **Cache key:** `canary-tools-${{ runner.os }}-gocyclo-v0.6.0-bd-v1.0.3` — version-pinned, so any pin bump auto-invalidates
- **Skip logic:** `if [ ! -x "$HOME/.../tool" ]; then go install ...; fi` — restores idempotent semantics

## Why

`setup-go@v6`'s module/build cache covers dependencies inside `cli/go.sum` but NOT `go install` outputs to GOBIN. The two pinned Go binaries (`gocyclo`, `bd`) rebuild from source on every CI run.

This job is the critical-path of the entire validate workflow at ~393s (measured on main run #26480320480, confirmed again on PR #554's clean run at 6m4s — even the post-flake-fix run is bottlenecked here).

## Fitness delta

| Metric | Before | After (expected) |
|---|---|---|
| `agentops-contract-canaries` wall-clock | **393s** | **~275s (-30%)** |
| Per-PR validate critical path | ~7 min | ~5 min |
| Cache hits on this PR | 0 (first run, expected) | n/a |
| Cache hits on next PR after merge | 0 | 1 (full benefit) |

First post-merge run is a cache MISS — no speedup visible. Speedup shows from the second run onward. A follow-up measurement after a few PRs land will confirm the 30% target.

## Sibling pattern

Matches the `actions/cache@v4` shape used by other Go projects on GitHub. None of the existing validate.yml jobs cache GOBIN today — this is the first. If it works, the pattern can extend to other Go-tool-installing jobs in a follow-up.

## Out of scope (deferred, not bundled)

- Caching apt packages (jq, ripgrep) — lower leverage, apt cache handling in CI is fragile.
- Caching the global bats install — smaller win, npm cache less clean.
- Pre-built container image with tools baked in — bigger change. Revisit only if this cache approach proves insufficient.

## Validation

```
python3 -c "import yaml; data=yaml.safe_load(...)" → YAML parses
agentops-contract-canaries steps: 5 (was 4) in correct order
diff stat: +20 / -2 (≤300 PR budget)
```

True end-to-end validation comes from CI: this PR's first run is a cache miss (proves the install path still works); a later PR's run is the cache hit that proves the speedup.

## Trailers

Closes-scenario: ag-56y#first-run-populates-cache
Closes-scenario: ag-56y#subsequent-runs-use-cached-binaries
Closes-scenario: ag-56y#version-bump-invalidates-cache
Bounded-context: BC5-Runtime
Evidence: .agents/research/2026-05-26-ci-pr-bottleneck-diagnosis.md
Evidence: .github/workflows/validate.yml (steps reordered, 1 step added, 1 modified)

Sibling pattern: standard actions/cache@v4 + version-pinned key shape.