### PR TITLE
test(cli): add 165 tests for 3 zero-coverage internal packages (ag-gox, ag-19y, ag-gl4)

### DIFF
--- a/cli/internal/bench/bench_test.go
+++ b/cli/internal/bench/bench_test.go
@@ -1,0 +1,187 @@
+package bench
+
+import (
+	"math"
+	"testing"
+)
+
+func TestNormalizeSplit(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Train", "train"},
+		{"  TEST  ", "test"},
+		{"val", "val"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := NormalizeSplit(tt.input); got != tt.want {
+			t.Errorf("NormalizeSplit(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestNormalizeSection(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"## Summary", "summary"},
+		{"### Detailed Analysis", "detailed analysis"},
+		{"  # Title  ", "# title"},
+		{"## Plain", "plain"},
+		{"No Hash", "no hash"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := NormalizeSection(tt.input); got != tt.want {
+			t.Errorf("NormalizeSection(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestStripFrontMatter(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "strips frontmatter",
+			input: "---\ntitle: Hello\n---\nBody content",
+			want:  "Body content",
+		},
+		{
+			name:  "no frontmatter",
+			input: "Just content\nMore content",
+			want:  "Just content\nMore content",
+		},
+		{
+			name:  "unclosed frontmatter",
+			input: "---\ntitle: Hello\nno closing delimiter",
+			want:  "---\ntitle: Hello\nno closing delimiter",
+		},
+		{
+			name:  "empty content",
+			input: "",
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StripFrontMatter(tt.input); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSectionHeading(t *testing.T) {
+	tests := []struct {
+		name    string
+		section string
+		want    string
+	}{
+		{"h2 heading", "## Summary\n\nContent here", "Summary"},
+		{"h1 heading", "# Title\n\nBody", "Title"},
+		{"no heading", "Just text\nMore text", ""},
+		{"heading after blank", "\n\n## Found It", "Found It"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SectionHeading(tt.section); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScoreResults(t *testing.T) {
+	expected := map[string]bool{"a": true, "b": true, "c": true}
+
+	tests := []struct {
+		name      string
+		results   []string
+		expected  map[string]bool
+		bestID    string
+		k         int
+		wantPAtK  float64
+		wantMRR   float64
+	}{
+		{
+			name:     "perfect precision",
+			results:  []string{"a", "b", "c"},
+			expected: expected,
+			bestID:   "a",
+			k:        3,
+			wantPAtK: 1.0,
+			wantMRR:  1.0,
+		},
+		{
+			name:     "half precision",
+			results:  []string{"a", "x", "b", "y"},
+			expected: expected,
+			bestID:   "a",
+			k:        4,
+			wantPAtK: 0.5,
+			wantMRR:  1.0,
+		},
+		{
+			name:     "best at position 3",
+			results:  []string{"x", "y", "a"},
+			expected: expected,
+			bestID:   "a",
+			k:        3,
+			wantPAtK: 1.0 / 3.0,
+			wantMRR:  1.0 / 3.0,
+		},
+		{
+			name:     "k=0 returns zero",
+			results:  []string{"a"},
+			expected: expected,
+			bestID:   "a",
+			k:        0,
+			wantPAtK: 0,
+			wantMRR:  0,
+		},
+		{
+			name:     "empty results",
+			results:  nil,
+			expected: expected,
+			bestID:   "a",
+			k:        5,
+			wantPAtK: 0,
+			wantMRR:  0,
+		},
+		{
+			name:     "k larger than results",
+			results:  []string{"a"},
+			expected: expected,
+			bestID:   "a",
+			k:        5,
+			wantPAtK: 0.2,
+			wantMRR:  1.0,
+		},
+		{
+			name:     "best not in results",
+			results:  []string{"x", "y"},
+			expected: expected,
+			bestID:   "a",
+			k:        2,
+			wantPAtK: 0,
+			wantMRR:  0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pAtK, mrr := ScoreResults(tt.results, tt.expected, tt.bestID, tt.k)
+			if math.Abs(pAtK-tt.wantPAtK) > 1e-9 {
+				t.Errorf("P@K: got %f, want %f", pAtK, tt.wantPAtK)
+			}
+			if math.Abs(mrr-tt.wantMRR) > 1e-9 {
+				t.Errorf("MRR: got %f, want %f", mrr, tt.wantMRR)
+			}
+		})
+	}
+}

--- a/cli/internal/bridge/bridge_test.go
+++ b/cli/internal/bridge/bridge_test.go
@@ -1,0 +1,395 @@
+package bridge
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeCodexLifecyclePath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"empty string", "", ""},
+		{"whitespace only", "   ", ""},
+		{"cleans path", "/tmp/../tmp/file.txt", "/tmp/file.txt"},
+		{"trims whitespace", "  /tmp/file.txt  ", "/tmp/file.txt"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeCodexLifecyclePath(tt.path)
+			if tt.want != "" && got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+			if tt.want == "" && got != "" {
+				t.Errorf("got %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestFirstNonEmptyTrimmed(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []string
+		want   string
+	}{
+		{"first non-empty", []string{"", "  ", "hello", "world"}, "hello"},
+		{"all empty", []string{"", "  "}, ""},
+		{"no values", nil, ""},
+		{"first is valid", []string{"first", "second"}, "first"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FirstNonEmptyTrimmed(tt.values...)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodexStopAlreadyClosed(t *testing.T) {
+	tests := []struct {
+		name                  string
+		lastStopSessionID     string
+		lastStopTranscript    string
+		sessionID             string
+		transcriptPath        string
+		want                  bool
+	}{
+		{
+			name:               "matching transcripts same session",
+			lastStopSessionID:  "s1",
+			lastStopTranscript: "/tmp/transcript.md",
+			sessionID:          "s1",
+			transcriptPath:     "/tmp/transcript.md",
+			want:               true,
+		},
+		{
+			name:               "matching transcripts no session ID",
+			lastStopSessionID:  "",
+			lastStopTranscript: "/tmp/transcript.md",
+			sessionID:          "",
+			transcriptPath:     "/tmp/transcript.md",
+			want:               true,
+		},
+		{
+			name:               "different transcripts",
+			lastStopSessionID:  "s1",
+			lastStopTranscript: "/tmp/old.md",
+			sessionID:          "s1",
+			transcriptPath:     "/tmp/new.md",
+			want:               false,
+		},
+		{
+			name:               "session ID match no transcripts",
+			lastStopSessionID:  "s1",
+			lastStopTranscript: "",
+			sessionID:          "s1",
+			transcriptPath:     "",
+			want:               true,
+		},
+		{
+			name:               "different session IDs no transcripts",
+			lastStopSessionID:  "s1",
+			lastStopTranscript: "",
+			sessionID:          "s2",
+			transcriptPath:     "",
+			want:               false,
+		},
+		{
+			name:               "no session IDs no transcripts",
+			lastStopSessionID:  "",
+			lastStopTranscript: "",
+			sessionID:          "",
+			transcriptPath:     "",
+			want:               false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CodexStopAlreadyClosed(tt.lastStopSessionID, tt.lastStopTranscript, tt.sessionID, tt.transcriptPath)
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnsureStopReason(t *testing.T) {
+	if got := EnsureStopReason("already_closed"); !strings.Contains(got, "already recorded") {
+		t.Errorf("unexpected reason for already_closed: %q", got)
+	}
+	if got := EnsureStopReason("new_close"); !strings.Contains(got, "recorded") {
+		t.Errorf("unexpected reason for new_close: %q", got)
+	}
+}
+
+func TestFactoryRecommendedCommands(t *testing.T) {
+	noGoal := FactoryRecommendedCommands("")
+	if len(noGoal) == 0 {
+		t.Fatal("expected commands for empty goal")
+	}
+	if !strings.Contains(noGoal[0], "Set a concrete goal") {
+		t.Errorf("first command should suggest setting a goal, got %q", noGoal[0])
+	}
+
+	withGoal := FactoryRecommendedCommands("ship v3")
+	if len(withGoal) == 0 {
+		t.Fatal("expected commands with goal")
+	}
+	if !strings.Contains(withGoal[0], "ship v3") {
+		t.Errorf("first command should contain goal, got %q", withGoal[0])
+	}
+}
+
+func TestParseSemverParts(t *testing.T) {
+	tests := []struct {
+		version string
+		want    [3]int
+	}{
+		{"1.2.3", [3]int{1, 2, 3}},
+		{"v1.2.3", [3]int{1, 2, 3}},
+		{"0.13.0", [3]int{0, 13, 0}},
+		{"1.0.0-beta.1", [3]int{1, 0, 0}},
+		{"2.0", [3]int{2, 0, 0}},
+		{"", [3]int{0, 0, 0}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			got := ParseSemverParts(tt.version)
+			if got != tt.want {
+				t.Errorf("ParseSemverParts(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareSemver(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0", "1.0.0", 0},
+		{"1.0.0", "2.0.0", -1},
+		{"2.0.0", "1.0.0", 1},
+		{"0.13.0", "0.12.0", 1},
+		{"0.12.0", "0.13.0", -1},
+		{"v1.0.0", "1.0.0", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.a+"_vs_"+tt.b, func(t *testing.T) {
+			got := CompareSemver(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("CompareSemver(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGCBridgeCompatible(t *testing.T) {
+	if !GCBridgeCompatible("0.13.0") {
+		t.Error("min version should be compatible")
+	}
+	if !GCBridgeCompatible("1.0.0") {
+		t.Error("higher version should be compatible")
+	}
+	if GCBridgeCompatible("0.12.0") {
+		t.Error("lower version should not be compatible")
+	}
+}
+
+func TestParseGCStatus(t *testing.T) {
+	valid := `{
+		"city": "test-city",
+		"controller": {"running": true, "pid": 1234, "mode": "active"},
+		"agents": [{"name": "worker", "running": true, "state": "running"}],
+		"summary": {"running": 1, "stopped": 0, "total": 1}
+	}`
+	status, err := ParseGCStatus([]byte(valid))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status.City != "test-city" {
+		t.Errorf("city: got %q", status.City)
+	}
+	if !status.Controller.Running {
+		t.Error("controller should be running")
+	}
+	if len(status.Agents) != 1 {
+		t.Errorf("agents: got %d", len(status.Agents))
+	}
+	if status.Summary.Running != 1 {
+		t.Errorf("summary running: got %d", status.Summary.Running)
+	}
+
+	_, err = ParseGCStatus([]byte(`{"controller": null, "agents": [], "summary": {}}`))
+	if err == nil {
+		t.Error("expected error for null controller")
+	}
+
+	_, err = ParseGCStatus([]byte(`not json`))
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestParseGCSessions(t *testing.T) {
+	valid := `[
+		{"alias": "main", "state": "running", "id": "s1", "template": "worker"},
+		{"Alias": "backup", "State": "stopped", "ID": "s2", "Template": "helper", "Closed": true}
+	]`
+	sessions, err := ParseGCSessions([]byte(valid))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("got %d sessions", len(sessions))
+	}
+	if sessions[0].Alias != "main" {
+		t.Errorf("session 0 alias: got %q", sessions[0].Alias)
+	}
+	if sessions[1].Alias != "backup" {
+		t.Errorf("session 1 alias (uppercase): got %q", sessions[1].Alias)
+	}
+	if !sessions[1].Closed {
+		t.Error("session 1 should be closed")
+	}
+
+	_, err = ParseGCSessions([]byte(`[{"state": "running"}]`))
+	if err == nil {
+		t.Error("expected error for missing alias field")
+	}
+}
+
+func TestGCStatusSummaryUnmarshal(t *testing.T) {
+	oldShape := `{"running": 2, "stopped": 1, "total": 3}`
+	var s1 GCStatusSummary
+	if err := json.Unmarshal([]byte(oldShape), &s1); err != nil {
+		t.Fatal(err)
+	}
+	if s1.Running != 2 || s1.Stopped != 1 || s1.Total != 3 {
+		t.Errorf("old shape: got %+v", s1)
+	}
+
+	newShape := `{"running_agents": 4, "stopped_agents": 2, "total_agents": 6}`
+	var s2 GCStatusSummary
+	if err := json.Unmarshal([]byte(newShape), &s2); err != nil {
+		t.Fatal(err)
+	}
+	if s2.Running != 4 || s2.Stopped != 2 || s2.Total != 6 {
+		t.Errorf("new shape: got %+v", s2)
+	}
+}
+
+func TestGCSessionNewArgs(t *testing.T) {
+	args := GCSessionNewArgs("worker", "my-session")
+	if len(args) != 6 {
+		t.Fatalf("got %d args: %v", len(args), args)
+	}
+	if args[0] != "session" || args[1] != "new" || args[2] != "worker" {
+		t.Errorf("prefix: %v", args[:3])
+	}
+	if args[3] != "--alias" || args[4] != "my-session" {
+		t.Errorf("alias: %v", args[3:5])
+	}
+	if args[5] != "--no-attach" {
+		t.Errorf("missing --no-attach: %v", args)
+	}
+
+	noAlias := GCSessionNewArgs("worker", "")
+	if len(noAlias) != 4 {
+		t.Fatalf("no-alias got %d args: %v", len(noAlias), noAlias)
+	}
+}
+
+func TestGCNudgeArgs(t *testing.T) {
+	args := GCNudgeArgs("agent-1", "wake up")
+	expected := []string{"session", "nudge", "agent-1", "--delivery", "immediate", "wake up"}
+	if len(args) != len(expected) {
+		t.Fatalf("got %v, want %v", args, expected)
+	}
+	for i, a := range args {
+		if a != expected[i] {
+			t.Errorf("arg %d: got %q, want %q", i, a, expected[i])
+		}
+	}
+}
+
+func TestGCPeekArgs(t *testing.T) {
+	args := GCPeekArgs("agent-1", 50)
+	if args[0] != "session" || args[1] != "peek" || args[2] != "agent-1" || args[4] != "50" {
+		t.Errorf("unexpected args: %v", args)
+	}
+}
+
+func TestGCEventEmitArgs(t *testing.T) {
+	args := GCEventEmitArgs("test.event", `{"key":"val"}`)
+	if args[0] != "event" || args[1] != "emit" || args[2] != "test.event" {
+		t.Errorf("prefix: %v", args[:3])
+	}
+	if args[3] != "--payload" {
+		t.Errorf("missing --payload: %v", args)
+	}
+
+	noPayload := GCEventEmitArgs("test.event", "")
+	if len(noPayload) != 3 {
+		t.Errorf("expected 3 args without payload, got %d: %v", len(noPayload), noPayload)
+	}
+}
+
+func TestGCEventEmitArgsWithFields(t *testing.T) {
+	args := GCEventEmitArgsWithFields("test.event", "actor1", "subject1", "hello", `{"k":"v"}`)
+	if len(args) != 11 {
+		t.Fatalf("got %d args: %v", len(args), args)
+	}
+
+	minimal := GCEventEmitArgsWithFields("test.event", "", "", "", "")
+	if len(minimal) != 3 {
+		t.Errorf("minimal got %d args: %v", len(minimal), minimal)
+	}
+}
+
+func TestGCEventsArgs(t *testing.T) {
+	full := GCEventsArgs(GCEventsArgsConfig{
+		Type:        "rpi.cycle",
+		Since:       "1h",
+		After:       "evt-123",
+		AfterCursor: "cursor-456",
+		Watch:       true,
+		Follow:      true,
+	})
+	joined := strings.Join(full, " ")
+	for _, want := range []string{"--type", "rpi.cycle", "--since", "1h", "--after", "evt-123", "--after-cursor", "cursor-456", "--watch", "--follow"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("missing %q in %v", want, full)
+		}
+	}
+
+	empty := GCEventsArgs(GCEventsArgsConfig{})
+	if len(empty) != 1 || empty[0] != "events" {
+		t.Errorf("empty config: got %v", empty)
+	}
+}
+
+func TestGCSessionListArgs(t *testing.T) {
+	args := GCSessionListArgs()
+	if len(args) != 3 || args[0] != "session" || args[2] != "--json" {
+		t.Errorf("unexpected: %v", args)
+	}
+}
+
+func TestGCStatusArgs(t *testing.T) {
+	noCity := GCStatusArgs("")
+	if len(noCity) != 2 || noCity[0] != "status" {
+		t.Errorf("no city: %v", noCity)
+	}
+
+	withCity := GCStatusArgs("/path/to/city")
+	if withCity[0] != "--city" || withCity[1] != "/path/to/city" {
+		t.Errorf("with city: %v", withCity)
+	}
+}

--- a/cli/internal/knowledge/native_test.go
+++ b/cli/internal/knowledge/native_test.go
@@ -1,0 +1,472 @@
+package knowledge
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTokens(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{
+			name: "basic tokenization",
+			text: "Hello World Testing",
+			want: []string{"hello", "world", "testing"},
+		},
+		{
+			name: "short tokens dropped",
+			text: "go is a lang",
+			want: []string{"lang"},
+		},
+		{
+			name: "deduplicates",
+			text: "hello hello world",
+			want: []string{"hello", "world"},
+		},
+		{
+			name: "strips non-alphanumeric",
+			text: "foo-bar_baz (qux)",
+			want: []string{"foo", "bar", "baz", "qux"},
+		},
+		{
+			name: "empty input",
+			text: "",
+			want: []string{},
+		},
+		{
+			name: "numeric tokens",
+			text: "abc 123 def456",
+			want: []string{"abc", "123", "def456"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Tokens(tt.text)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i, g := range got {
+				if g != tt.want[i] {
+					t.Errorf("token %d: got %q, want %q", i, g, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestHealthRank(t *testing.T) {
+	tests := []struct {
+		health string
+		want   int
+	}{
+		{"healthy", 2},
+		{"Healthy", 2},
+		{"thin", 1},
+		{"THIN", 1},
+		{"unknown", 0},
+		{"", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.health, func(t *testing.T) {
+			got := HealthRank(tt.health)
+			if got != tt.want {
+				t.Errorf("HealthRank(%q) = %d, want %d", tt.health, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChunkRank(t *testing.T) {
+	tests := []struct {
+		chunkType string
+		want      int
+	}{
+		{"decision", 3},
+		{"Decision", 3},
+		{"pattern", 2},
+		{"overview", 1},
+		{"other", 0},
+		{"", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.chunkType, func(t *testing.T) {
+			got := ChunkRank(tt.chunkType)
+			if got != tt.want {
+				t.Errorf("ChunkRank(%q) = %d, want %d", tt.chunkType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppendCandidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		items     []string
+		candidate string
+		wantLen   int
+	}{
+		{"adds new", []string{"a"}, "b", 2},
+		{"skips duplicate", []string{"a", "b"}, "b", 2},
+		{"normalizes whitespace dedup", []string{"hello world"}, "hello  world", 1},
+		{"normalizes whitespace new", []string{"other"}, "hello  world", 2},
+		{"skips empty", []string{"a"}, "", 1},
+		{"skips whitespace-only", []string{"a"}, "   ", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AppendCandidate(tt.items, tt.candidate)
+			if len(got) != tt.wantLen {
+				t.Errorf("got len %d, want %d: %v", len(got), tt.wantLen, got)
+			}
+		})
+	}
+}
+
+func TestContainsTopic(t *testing.T) {
+	topics := []TopicDetail{
+		{TopicState: TopicState{ID: "alpha"}},
+		{TopicState: TopicState{ID: "beta"}},
+	}
+	if !ContainsTopic(topics, "alpha") {
+		t.Error("expected true for existing topic")
+	}
+	if ContainsTopic(topics, "gamma") {
+		t.Error("expected false for missing topic")
+	}
+	if ContainsTopic(nil, "alpha") {
+		t.Error("expected false for nil topics")
+	}
+}
+
+func TestFieldValue(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{"standard field", "- Type: decision", "decision"},
+		{"backtick value", "- Status: `draft`", "draft"},
+		{"no colon", "no-field-here", ""},
+		{"empty value", "- Key: ", ""},
+		{"value with colon", "- URL: http://example.com", "http://example.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FieldValue(tt.line)
+			if got != tt.want {
+				t.Errorf("FieldValue(%q) = %q, want %q", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuilderGoal(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"found", []string{"--verbose", "--goal", "test coverage"}, "test coverage"},
+		{"not present", []string{"--verbose"}, ""},
+		{"at end without value", []string{"--goal"}, ""},
+		{"empty args", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuilderGoal(tt.args)
+			if got != tt.want {
+				t.Errorf("BuilderGoal(%v) = %q, want %q", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSlicesContain(t *testing.T) {
+	items := []string{"apple", "banana", "cherry"}
+	if !SlicesContain(items, "banana") {
+		t.Error("expected true for existing item")
+	}
+	if SlicesContain(items, "Banana") {
+		t.Error("expected false for case mismatch")
+	}
+	if SlicesContain(nil, "apple") {
+		t.Error("expected false for nil slice")
+	}
+}
+
+func TestStringSliceContainsFold(t *testing.T) {
+	items := []string{"Apple", "Banana"}
+	if !StringSliceContainsFold(items, "apple") {
+		t.Error("expected true for case-insensitive match")
+	}
+	if StringSliceContainsFold(items, "cherry") {
+		t.Error("expected false for missing item")
+	}
+}
+
+func TestYesNo(t *testing.T) {
+	if YesNo(true) != "yes" {
+		t.Error("expected yes for true")
+	}
+	if YesNo(false) != "no" {
+		t.Error("expected no for false")
+	}
+}
+
+func TestSectionText(t *testing.T) {
+	doc := `## Summary
+
+This is the summary
+with multiple lines.
+
+## Next
+
+Other content here.
+`
+	got := SectionText(doc, "## Summary")
+	if !strings.Contains(got, "summary") {
+		t.Errorf("expected summary text, got %q", got)
+	}
+	if strings.Contains(got, "Other") {
+		t.Error("should not include next section")
+	}
+
+	empty := SectionText(doc, "## Missing")
+	if empty != "" {
+		t.Errorf("expected empty for missing heading, got %q", empty)
+	}
+}
+
+func TestFrontmatterStringList(t *testing.T) {
+	tests := []struct {
+		name string
+		fm   map[string]any
+		key  string
+		want []string
+	}{
+		{
+			name: "string slice",
+			fm:   map[string]any{"tags": []string{"a", "b", "a"}},
+			key:  "tags",
+			want: []string{"a", "b"},
+		},
+		{
+			name: "any slice",
+			fm:   map[string]any{"items": []any{"x", "y"}},
+			key:  "items",
+			want: []string{"x", "y"},
+		},
+		{
+			name: "scalar fallback",
+			fm:   map[string]any{"single": "only"},
+			key:  "single",
+			want: []string{"only"},
+		},
+		{
+			name: "missing key",
+			fm:   map[string]any{},
+			key:  "nope",
+			want: nil,
+		},
+		{
+			name: "nil map",
+			fm:   nil,
+			key:  "any",
+			want: nil,
+		},
+		{
+			name: "nil value in any slice",
+			fm:   map[string]any{"items": []any{nil, "real"}},
+			key:  "items",
+			want: []string{"real"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FrontmatterStringList(tt.fm, tt.key)
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("expected nil, got %v", got)
+				}
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i, g := range got {
+				if g != tt.want[i] {
+					t.Errorf("item %d: got %q, want %q", i, g, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFrontmatterNestedInt(t *testing.T) {
+	fm := map[string]any{
+		"stats": map[string]any{
+			"count":   42,
+			"float":   3.14,
+			"text":    "7",
+			"invalid": "abc",
+		},
+	}
+	tests := []struct {
+		name   string
+		fm     map[string]any
+		parent string
+		key    string
+		want   int
+	}{
+		{"int value", fm, "stats", "count", 42},
+		{"float truncated", fm, "stats", "float", 3},
+		{"string parsed", fm, "stats", "text", 7},
+		{"invalid string", fm, "stats", "invalid", 0},
+		{"missing parent", fm, "nope", "count", 0},
+		{"missing key", fm, "stats", "nope", 0},
+		{"nil map", nil, "stats", "count", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FrontmatterNestedInt(tt.fm, tt.parent, tt.key)
+			if got != tt.want {
+				t.Errorf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseChunks(t *testing.T) {
+	doc := `## Knowledge Chunks
+
+### Chunk 1
+
+- Chunk ID: chunk-001
+- Type: decision
+- Confidence: high
+- Claim: Always test your code
+
+### Chunk 2
+
+- Chunk ID: chunk-002
+- Type: pattern
+- Confidence: medium
+- Claim: Table-driven tests are best
+
+## Next Section
+`
+	chunks := ParseChunks(doc)
+	if len(chunks) != 2 {
+		t.Fatalf("got %d chunks, want 2", len(chunks))
+	}
+	if chunks[0].ID != "chunk-001" {
+		t.Errorf("chunk 0 ID: got %q", chunks[0].ID)
+	}
+	if chunks[0].Type != "decision" {
+		t.Errorf("chunk 0 Type: got %q", chunks[0].Type)
+	}
+	if chunks[0].Confidence != "high" {
+		t.Errorf("chunk 0 Confidence: got %q", chunks[0].Confidence)
+	}
+	if chunks[0].Claim != "Always test your code" {
+		t.Errorf("chunk 0 Claim: got %q", chunks[0].Claim)
+	}
+	if chunks[1].ID != "chunk-002" {
+		t.Errorf("chunk 1 ID: got %q", chunks[1].ID)
+	}
+
+	empty := ParseChunks("no chunks here")
+	if len(empty) != 0 {
+		t.Errorf("expected 0 chunks for non-chunk doc, got %d", len(empty))
+	}
+}
+
+func TestWhenToUse(t *testing.T) {
+	topic := TopicDetail{
+		TopicState: TopicState{Title: "Testing"},
+		Aliases:    []string{"Quality Assurance", "Validation"},
+	}
+	got := WhenToUse(topic)
+	if !strings.Contains(got, "quality assurance") {
+		t.Errorf("expected alias in output, got %q", got)
+	}
+	if !strings.Contains(got, "bounded operator loop") {
+		t.Errorf("expected template text, got %q", got)
+	}
+
+	noAliases := TopicDetail{TopicState: TopicState{Title: "Deployment"}}
+	got2 := WhenToUse(noAliases)
+	if !strings.Contains(got2, "deployment") {
+		t.Errorf("expected title fallback, got %q", got2)
+	}
+}
+
+func TestPrimitivesForTopic(t *testing.T) {
+	topic := TopicDetail{
+		TopicState: TopicState{Title: "CI Gate Validation"},
+		Summary:    "Runs acceptance tests and validates gate policies for releases",
+	}
+	primitives := PrimitivesForTopic(topic)
+	if len(primitives) < 2 {
+		t.Fatalf("expected at least 2 primitives, got %d: %v", len(primitives), primitives)
+	}
+	if primitives[0] != "stateful environment" {
+		t.Errorf("first primitive should always be 'stateful environment', got %q", primitives[0])
+	}
+}
+
+func TestRenderPlaybooksIndex(t *testing.T) {
+	rows := []PlaybookRow{
+		{Topic: "Beta", Path: "beta.md", Health: "thin", Canonical: false},
+		{Topic: "Alpha", Path: "alpha.md", Health: "healthy", Canonical: true},
+	}
+	got := RenderPlaybooksIndex(rows)
+	if !strings.Contains(got, "# Playbook Candidates") {
+		t.Error("missing header")
+	}
+	if !strings.Contains(got, "| [Alpha](alpha.md)") {
+		t.Error("missing alpha row")
+	}
+	alphaIdx := strings.Index(got, "Alpha")
+	betaIdx := strings.Index(got, "Beta")
+	if alphaIdx > betaIdx {
+		t.Error("healthy topics should sort before thin")
+	}
+}
+
+func TestRenderBeliefBook(t *testing.T) {
+	got := RenderBeliefBook(
+		"/tmp/beliefs.md",
+		"/tmp/source",
+		[]string{"Belief 1", "Belief 2"},
+		[]string{"Principle A"},
+		[]string{"Thin Topic X"},
+		[]string{".agents/topics/"},
+	)
+	if !strings.Contains(got, "# Book Of Beliefs") {
+		t.Error("missing title")
+	}
+	if !strings.Contains(got, "Belief 1") {
+		t.Error("missing belief")
+	}
+	if !strings.Contains(got, "Principle A") {
+		t.Error("missing principle")
+	}
+	if !strings.Contains(got, "Thin Topic X") {
+		t.Error("missing thin topic")
+	}
+	if !strings.Contains(got, "type: principle-book") {
+		t.Error("missing frontmatter type")
+	}
+
+	empty := RenderBeliefBook("/tmp/b.md", "", nil, nil, nil, nil)
+	if !strings.Contains(empty, "No operating principles") {
+		t.Error("expected empty-state message for principles")
+	}
+	if !strings.Contains(empty, "None surfaced") {
+		t.Error("expected empty-state message for thin topics")
+	}
+}

--- a/cli/internal/knowledge/parse_test.go
+++ b/cli/internal/knowledge/parse_test.go
@@ -1,0 +1,294 @@
+package knowledge
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseBuilderMetadata(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		want   map[string]string
+		isNil  bool
+	}{
+		{
+			name:  "key=value pairs",
+			input: "output_path=/tmp/out.md\nstatus=ok\n",
+			want:  map[string]string{"output_path": "/tmp/out.md", "status": "ok"},
+		},
+		{
+			name:  "skips lines without equals",
+			input: "some log line\nkey=val\nanother line\n",
+			want:  map[string]string{"key": "val"},
+		},
+		{
+			name:  "trims whitespace",
+			input: "  key = value  \n",
+			want:  map[string]string{"key": "value"},
+		},
+		{
+			name:  "empty input returns nil",
+			input: "",
+			isNil: true,
+		},
+		{
+			name:  "no valid pairs returns nil",
+			input: "just text\nmore text\n",
+			isNil: true,
+		},
+		{
+			name:  "empty key skipped",
+			input: "=value\nreal=data\n",
+			want:  map[string]string{"real": "data"},
+		},
+		{
+			name:  "empty value skipped",
+			input: "key=\nreal=data\n",
+			want:  map[string]string{"real": "data"},
+		},
+		{
+			name:  "value with equals sign preserved",
+			input: "expr=a=b=c\n",
+			want:  map[string]string{"expr": "a=b=c"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseBuilderMetadata(tt.input)
+			if tt.isNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %v", got)
+				}
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("length mismatch: got %d, want %d (%v)", len(got), len(tt.want), got)
+			}
+			for k, wantV := range tt.want {
+				if got[k] != wantV {
+					t.Errorf("key %q: got %q, want %q", k, got[k], wantV)
+				}
+			}
+		})
+	}
+}
+
+func TestParseFrontmatter(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		isNil bool
+		check func(t *testing.T, m map[string]any)
+	}{
+		{
+			name:  "valid frontmatter",
+			input: "---\ntitle: Hello\nstatus: draft\n---\n\nBody text",
+			check: func(t *testing.T, m map[string]any) {
+				if m["title"] != "Hello" {
+					t.Errorf("title: got %v", m["title"])
+				}
+				if m["status"] != "draft" {
+					t.Errorf("status: got %v", m["status"])
+				}
+			},
+		},
+		{
+			name:  "no frontmatter returns nil",
+			input: "Just a markdown document\n\nWith paragraphs.",
+			isNil: true,
+		},
+		{
+			name:  "empty string returns nil",
+			input: "",
+			isNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseFrontmatter(tt.input)
+			if tt.isNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil map")
+			}
+			if tt.check != nil {
+				tt.check(t, got)
+			}
+		})
+	}
+}
+
+func TestFrontmatterString(t *testing.T) {
+	fm := map[string]any{
+		"title":  "Hello",
+		"empty":  "",
+		"nilval": nil,
+	}
+	tests := []struct {
+		name     string
+		fm       map[string]any
+		key      string
+		fallback string
+		want     string
+	}{
+		{"existing key", fm, "title", "default", "Hello"},
+		{"missing key uses fallback", fm, "missing", "default", "default"},
+		{"empty value uses fallback", fm, "empty", "default", "default"},
+		{"nil map uses fallback", nil, "title", "default", "default"},
+		{"nil value uses fallback", fm, "nilval", "default", "default"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FrontmatterString(tt.fm, tt.key, tt.fallback)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractBullets(t *testing.T) {
+	doc := `## Open Gaps
+
+- Gap one
+- Gap two
+
+## Next Section
+
+- Not this one
+`
+	tests := []struct {
+		name    string
+		text    string
+		heading string
+		want    []string
+	}{
+		{
+			name:    "extracts bullets under heading",
+			text:    doc,
+			heading: "## Open Gaps",
+			want:    []string{"Gap one", "Gap two"},
+		},
+		{
+			name:    "stops at next heading",
+			text:    doc,
+			heading: "## Next Section",
+			want:    []string{"Not this one"},
+		},
+		{
+			name:    "missing heading returns empty",
+			text:    doc,
+			heading: "## Nonexistent",
+			want:    []string{},
+		},
+		{
+			name:    "non-bullet lines skipped",
+			text:    "## Section\n\nParagraph text\n- Bullet\nMore text\n",
+			heading: "## Section",
+			want:    []string{"Bullet"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractBullets(tt.text, tt.heading)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d items, want %d: %v", len(got), len(tt.want), got)
+			}
+			for i, g := range got {
+				if g != tt.want[i] {
+					t.Errorf("item %d: got %q, want %q", i, g, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFilterOpenGaps(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{
+			name:  "removes sentinel",
+			input: []string{"No open gaps recorded.", "Real gap"},
+			want:  []string{"Real gap"},
+		},
+		{
+			name:  "case-insensitive sentinel",
+			input: []string{"no open gaps recorded.", "Real gap"},
+			want:  []string{"Real gap"},
+		},
+		{
+			name:  "no sentinel passes through",
+			input: []string{"Gap A", "Gap B"},
+			want:  []string{"Gap A", "Gap B"},
+		},
+		{
+			name:  "empty input",
+			input: []string{},
+			want:  []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterOpenGaps(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d, want %d: %v", len(got), len(tt.want), got)
+			}
+			for i, g := range got {
+				if g != tt.want[i] {
+					t.Errorf("item %d: got %q, want %q", i, g, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDedupeStrings(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{"removes duplicates", []string{"a", "b", "a", "c"}, []string{"a", "b", "c"}},
+		{"trims whitespace", []string{" a ", "a"}, []string{"a"}},
+		{"drops empty strings", []string{"", "a", "", "b"}, []string{"a", "b"}},
+		{"empty input", []string{}, []string{}},
+		{"nil input", nil, []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DedupeStrings(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d, want %d: %v", len(got), len(tt.want), got)
+			}
+			for i, g := range got {
+				if g != tt.want[i] {
+					t.Errorf("item %d: got %q, want %q", i, g, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestPathExists(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "exists.txt")
+	if err := os.WriteFile(existing, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !PathExists(existing) {
+		t.Error("expected true for existing file")
+	}
+	if PathExists(filepath.Join(dir, "nope.txt")) {
+		t.Error("expected false for missing file")
+	}
+}


### PR DESCRIPTION
## Summary
- Add 100 tests for `cli/internal/knowledge/` — covers all exported functions in parse.go (frontmatter, metadata, bullets, dedup) and native.go (tokens, ranking, chunks, rendering)
- Add 45 tests for `cli/internal/bridge/` — covers codex lifecycle, GC status/session parsing, semver comparison, argument builders
- Add 20 tests for `cli/internal/bench/` — covers normalization, frontmatter stripping, P@K/MRR scoring

Eliminates all 3 remaining zero-coverage internal packages. Full suite: 11,930 tests, 65 packages, 0 failures.

## Test plan
- [x] `go test ./internal/knowledge/` — 100 pass
- [x] `go test ./internal/bridge/` — 45 pass
- [x] `go test ./internal/bench/` — 20 pass
- [x] `go vet` clean on all 3 packages
- [x] Full `go test ./...` — 11,930 pass, no regressions