### PR TITLE
test(cli): expand thin tests for ratchet and eval packages (ag-8f6)

### DIFF
--- a/cli/internal/eval/types_test.go
+++ b/cli/internal/eval/types_test.go
@@ -100,6 +100,125 @@ func TestEnvironmentRecordRoundTripPreservesHooksDisabled(t *testing.T) {
 	}
 }
 
+func TestTierConstants(t *testing.T) {
+	tiers := []Tier{TierDeterministic, TierHeadless, TierLive, TierRelease}
+	seen := make(map[Tier]bool)
+	for _, tier := range tiers {
+		if tier == "" {
+			t.Error("empty tier constant")
+		}
+		if seen[tier] {
+			t.Errorf("duplicate tier: %q", tier)
+		}
+		seen[tier] = true
+	}
+}
+
+func TestStatusConstants(t *testing.T) {
+	statuses := []Status{StatusPass, StatusFail, StatusError, StatusSkipped, StatusInconclusive}
+	seen := make(map[Status]bool)
+	for _, s := range statuses {
+		if s == "" {
+			t.Error("empty status constant")
+		}
+		if seen[s] {
+			t.Errorf("duplicate status: %q", s)
+		}
+		seen[s] = true
+	}
+}
+
+func TestVerdictConstants(t *testing.T) {
+	verdicts := []Verdict{VerdictPass, VerdictFail, VerdictImprovement, VerdictRegression, VerdictAdvisory, VerdictInconclusive}
+	seen := make(map[Verdict]bool)
+	for _, v := range verdicts {
+		if v == "" {
+			t.Error("empty verdict constant")
+		}
+		if seen[v] {
+			t.Errorf("duplicate verdict: %q", v)
+		}
+		seen[v] = true
+	}
+}
+
+func TestCaseResultRoundTrip(t *testing.T) {
+	original := CaseResult{
+		ID:     "case-1",
+		Status: StatusPass,
+		Score:  0.95,
+		DimensionScores: map[Dimension]float64{
+			DimensionCorrectness: 1.0,
+			DimensionSafety:      0.9,
+		},
+		DurationMS:     1500,
+		Critical:       true,
+		FailureMessage: "",
+		Diagnostics:    []string{"note1"},
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded CaseResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.ID != original.ID {
+		t.Errorf("ID: got %q, want %q", decoded.ID, original.ID)
+	}
+	if decoded.Status != original.Status {
+		t.Errorf("Status: got %q, want %q", decoded.Status, original.Status)
+	}
+	if decoded.Score != original.Score {
+		t.Errorf("Score: got %f, want %f", decoded.Score, original.Score)
+	}
+	if decoded.DimensionScores[DimensionCorrectness] != 1.0 {
+		t.Errorf("DimensionScores[correctness]: got %f", decoded.DimensionScores[DimensionCorrectness])
+	}
+	if decoded.DurationMS != 1500 {
+		t.Errorf("DurationMS: got %d", decoded.DurationMS)
+	}
+	if !decoded.Critical {
+		t.Error("Critical should be true")
+	}
+}
+
+func TestBaselineComparisonRoundTrip(t *testing.T) {
+	original := BaselineComparison{
+		Verdict:        VerdictRegression,
+		BaselineRunID:  "run-001",
+		BaselineScore:  0.85,
+		AggregateDelta: -0.05,
+		DimensionDelta: map[Dimension]float64{
+			DimensionCorrectness: -0.1,
+		},
+		Regressions: []ComparisonItem{
+			{CaseID: "case-1", Dimension: DimensionCorrectness, Delta: -0.1, Reason: "score dropped"},
+		},
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded BaselineComparison
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Verdict != VerdictRegression {
+		t.Errorf("Verdict: got %q", decoded.Verdict)
+	}
+	if decoded.AggregateDelta != -0.05 {
+		t.Errorf("AggregateDelta: got %f", decoded.AggregateDelta)
+	}
+	if len(decoded.Regressions) != 1 {
+		t.Fatalf("Regressions count: got %d", len(decoded.Regressions))
+	}
+	if decoded.Regressions[0].CaseID != "case-1" {
+		t.Errorf("Regression CaseID: got %q", decoded.Regressions[0].CaseID)
+	}
+}
+
 func containsKey(data []byte, key string) bool {
 	var m map[string]json.RawMessage
 	if err := json.Unmarshal(data, &m); err != nil {

--- a/cli/internal/ratchet/skill_drafts_test.go
+++ b/cli/internal/ratchet/skill_drafts_test.go
@@ -8,6 +8,94 @@ import (
 	"testing"
 )
 
+func TestDraftSlug(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"strips date prefix", "/tmp/2026-04-09-test-pattern.md", "test"},
+		{"strips -pattern suffix", "/tmp/2026-01-01-my-cool-pattern.md", "my-cool"},
+		{"no date prefix", "/tmp/my-skill.md", "my-skill"},
+		{"underscores to hyphens", "/tmp/2026-01-01-my_cool_thing.md", "my-cool-thing"},
+		{"lowercases", "/tmp/2026-01-01-MyPattern.md", "mypattern"},
+		{"pattern alone stays", "/tmp/2026-01-01-pattern.md", "pattern"},
+		{"actually empty", "/tmp/2026-01-01-.md", "generated-skill-draft"},
+		{"plain name", "/tmp/testing.md", "testing"},
+		{"trims leading/trailing hyphens", "/tmp/2026-01-01--extra--pattern.md", "extra"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := draftSlug(tt.path)
+			if got != tt.want {
+				t.Errorf("draftSlug(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSuggestDraftTier(t *testing.T) {
+	tests := []struct {
+		slug string
+		want string
+	}{
+		{"research-methods", "knowledge"},
+		{"knowledge-base", "knowledge"},
+		{"trace-analysis", "knowledge"},
+		{"status-report", "session"},
+		{"handoff-protocol", "session"},
+		{"recover-state", "session"},
+		{"release-process", "product"},
+		{"readme-update", "product"},
+		{"product-launch", "product"},
+		{"build-optimization", "execution"},
+		{"testing-harness", "execution"},
+		{"unknown-thing", "execution"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.slug, func(t *testing.T) {
+			got := suggestDraftTier(tt.slug)
+			if got != tt.want {
+				t.Errorf("suggestDraftTier(%q) = %q, want %q", tt.slug, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderSkillDraft(t *testing.T) {
+	got := renderSkillDraft("/tmp/patterns/test.md", "test-skill", "execution")
+	if !strings.Contains(got, "name: test-skill") {
+		t.Error("missing skill name in frontmatter")
+	}
+	if !strings.Contains(got, "tier: execution") {
+		t.Error("missing tier in frontmatter")
+	}
+	if !strings.Contains(got, "# test-skill") {
+		t.Error("missing heading")
+	}
+	if !strings.Contains(got, "/tmp/patterns/test.md") {
+		t.Error("missing pattern path reference")
+	}
+	if !strings.Contains(got, "skill_api_version: 1") {
+		t.Error("missing skill_api_version")
+	}
+}
+
+func TestSkillDraftResult_EmptyPatterns(t *testing.T) {
+	baseDir := t.TempDir()
+	patternsDir := filepath.Join(baseDir, ".agents", "patterns")
+	if err := os.MkdirAll(patternsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	result, err := GenerateSkillDrafts(baseDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Evaluated != 0 || result.Generated != 0 {
+		t.Errorf("expected zero evaluated/generated for empty patterns dir, got %+v", result)
+	}
+}
+
 func TestGenerateSkillDrafts_RequiresThreeSessionRefs(t *testing.T) {
 	baseDir := t.TempDir()
 	patternsDir := filepath.Join(baseDir, ".agents", "patterns")


### PR DESCRIPTION
## Summary
- Expand `ratchet/skill_drafts_test.go` from 1 test to 26 — adds unit tests for `draftSlug()` (9 cases), `suggestDraftTier()` (12 cases), `renderSkillDraft()`, and empty-patterns edge case
- Expand `eval/types_test.go` from 2 tests to 7 — adds constant uniqueness invariants for Tier/Status/Verdict enums, plus CaseResult and BaselineComparison round-trip serialization

## Test plan
- [x] `go test ./internal/ratchet/` — 26 pass (was 1)
- [x] `go test ./internal/eval/` — 7 pass (was 2)
- [x] Full `go test ./...` — 11,945 pass, no regressions