### PR TITLE
feat(cli): ao skills find <intent> skill discovery (ag-a97 #find-ranks)

### DIFF
--- a/cli/cmd/ao/skills_find.go
+++ b/cli/cmd/ao/skills_find.go
@@ -1,0 +1,119 @@
+// practices: [design-by-contract, code-complete]
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/boshu2/agentops/cli/internal/skills"
+)
+
+var (
+	skillsFindJSON  bool
+	skillsFindLimit int
+)
+
+var skillsFindCmd = &cobra.Command{
+	Use:   "find <intent>",
+	Short: "Rank skills by how well they match a free-text intent",
+	Long: `Score every skills/<name>/SKILL.md against a free-text intent and
+print the best matches by name, description, and score. Turns the skill
+catalog from oral tradition into a queryable surface — give an agent a
+discovery API instead of memorizing every skill name.
+
+Scoring is a transparent token-overlap: a query word hitting the skill
+name counts most, a declared trigger next, a description word least, with
+light plural/stem tolerance. Scores are normalized to [0,1]. The catalog
+is read from the tree on every run, so a newly added skill is found with
+no index rebuild.
+
+Examples:
+  ao skills find "close the loop"
+  ao skills find autonomous improvement loop --limit 3
+  ao skills find "release validation" --json`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: runSkillsFind,
+}
+
+func init() {
+	skillsCmd.AddCommand(skillsFindCmd)
+	skillsFindCmd.Flags().BoolVar(&skillsFindJSON, "json", false, "Emit machine-readable JSON on stdout")
+	skillsFindCmd.Flags().IntVar(&skillsFindLimit, "limit", 5, "Maximum number of results to return")
+}
+
+func runSkillsFind(cmd *cobra.Command, args []string) error {
+	if skillsFindLimit < 1 {
+		cmd.SilenceUsage = true
+		return fmt.Errorf("--limit must be >= 1 (got %d); rerun with e.g. --limit 5", skillsFindLimit)
+	}
+
+	query := joinArgs(args)
+	skillsDir, _ := resolveSkillsRoots()
+	metas, err := skills.Load(skillsDir)
+	if err != nil {
+		cmd.SilenceUsage = true
+		return fmt.Errorf("load skills from %s: %w; run `ao skills check` to inspect the tree", skillsDir, err)
+	}
+
+	ranked := skills.Score(query, metas)
+	top := capResults(ranked, skillsFindLimit)
+
+	if skillsFindJSON {
+		return renderFindJSON(cmd, top)
+	}
+	return renderFindText(cmd, query, top)
+}
+
+// joinArgs concatenates positional args into a single query string so both
+// quoted ("close the loop") and bare (close the loop) forms work.
+func joinArgs(args []string) string {
+	out := ""
+	for i, a := range args {
+		if i > 0 {
+			out += " "
+		}
+		out += a
+	}
+	return out
+}
+
+// capResults returns at most limit matches.
+func capResults(matches []skills.Match, limit int) []skills.Match {
+	if len(matches) > limit {
+		return matches[:limit]
+	}
+	return matches
+}
+
+// renderFindJSON writes the matches as a JSON array on stdout (data only;
+// diagnostics, if any, go to stderr).
+func renderFindJSON(cmd *cobra.Command, top []skills.Match) error {
+	if top == nil {
+		top = []skills.Match{}
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(top)
+}
+
+// renderFindText prints the positive-score matches as a ranked list on stdout.
+// When nothing scores above zero it reports gracefully on stderr and exits 0 —
+// an unmatched intent is not an error.
+func renderFindText(cmd *cobra.Command, query string, top []skills.Match) error {
+	shown := 0
+	out := cmd.OutOrStdout()
+	for _, m := range top {
+		if m.Score <= 0 {
+			continue
+		}
+		shown++
+		fmt.Fprintf(out, "%d. %-28s %.3f  %s\n", shown, m.Name, m.Score, m.Description)
+	}
+	if shown == 0 {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"no strong matches for %q — try a broader intent or fewer words\n", query)
+	}
+	return nil
+}

--- a/cli/cmd/ao/skills_find_test.go
+++ b/cli/cmd/ao/skills_find_test.go
@@ -1,0 +1,118 @@
+// practices: [design-by-contract, code-complete]
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/boshu2/agentops/cli/internal/skills"
+)
+
+// runFind invokes runSkillsFind with separate stdout/stderr buffers so tests
+// can assert the stdout-as-data / stderr-as-diagnostics contract. It resolves
+// skills/ from the live tree (test cwd walks up to the repo root).
+func runFind(t *testing.T, jsonMode bool, limit int, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	prevJSON, prevLimit := skillsFindJSON, skillsFindLimit
+	defer func() { skillsFindJSON, skillsFindLimit = prevJSON, prevLimit }()
+	skillsFindJSON = jsonMode
+	skillsFindLimit = limit
+
+	var out, errb bytes.Buffer
+	c := &cobra.Command{}
+	c.SetOut(&out)
+	c.SetErr(&errb)
+	err = runSkillsFind(c, args)
+	return out.String(), errb.String(), err
+}
+
+func TestSkillsFind_JSONIsSortedArrayOnStdout(t *testing.T) {
+	stdout, stderr, err := runFind(t, true, 5, "close", "the", "loop")
+	if err != nil {
+		t.Fatalf("runSkillsFind: %v", err)
+	}
+	if stderr != "" {
+		t.Errorf("expected no diagnostics on stderr in JSON mode, got %q", stderr)
+	}
+	var got []skills.Match
+	if jerr := json.Unmarshal([]byte(stdout), &got); jerr != nil {
+		t.Fatalf("stdout is not a JSON array: %v\noutput: %s", jerr, stdout)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected at least one match for 'close the loop' against the live tree")
+	}
+	if len(got) > 5 {
+		t.Errorf("expected at most 5 results (default limit), got %d", len(got))
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i-1].Score < got[i].Score {
+			t.Errorf("results not sorted descending at %d: %v < %v", i, got[i-1].Score, got[i].Score)
+		}
+	}
+}
+
+func TestSkillsFind_TextRanksOnStdout(t *testing.T) {
+	stdout, _, err := runFind(t, false, 5, "close the loop")
+	if err != nil {
+		t.Fatalf("runSkillsFind: %v", err)
+	}
+	if !strings.Contains(stdout, "1.") {
+		t.Errorf("expected a ranked list on stdout, got %q", stdout)
+	}
+}
+
+func TestSkillsFind_UnmatchedReportsGracefully(t *testing.T) {
+	stdout, stderr, err := runFind(t, false, 5, "zzqqxx-nonsense-token")
+	if err != nil {
+		t.Fatalf("unmatched intent must exit 0, got error: %v", err)
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Errorf("expected empty stdout for unmatched intent, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "no strong matches") {
+		t.Errorf("expected a 'no strong matches' note on stderr, got %q", stderr)
+	}
+}
+
+func TestSkillsFind_LimitCapsResultCount(t *testing.T) {
+	stdout, _, err := runFind(t, true, 3, "run")
+	if err != nil {
+		t.Fatalf("runSkillsFind: %v", err)
+	}
+	var got []skills.Match
+	if jerr := json.Unmarshal([]byte(stdout), &got); jerr != nil {
+		t.Fatalf("stdout is not a JSON array: %v", jerr)
+	}
+	if len(got) > 3 {
+		t.Errorf("expected at most 3 results with --limit 3, got %d", len(got))
+	}
+}
+
+func TestSkillsFind_InvalidLimitNamesCorrection(t *testing.T) {
+	_, _, err := runFind(t, false, 0, "anything")
+	if err == nil {
+		t.Fatal("expected an error for --limit 0")
+	}
+	if !strings.Contains(err.Error(), "--limit") {
+		t.Errorf("error should name the --limit flag, got %q", err.Error())
+	}
+}
+
+func TestSkillsFind_RegisteredUnderSkills(t *testing.T) {
+	found := false
+	for _, c := range skillsCmd.Commands() {
+		if c.Name() == "find" {
+			found = true
+			if !c.Flags().HasAvailableFlags() {
+				t.Error("skills find has no flags; expected --json and --limit")
+			}
+		}
+	}
+	if !found {
+		t.Error("`find` is not registered under `skills`")
+	}
+}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -3875,5 +3875,21 @@ ao skills check [flags]
       --strict         Exit non-zero on any finding (CI mode)
 ```
 
+#### `ao skills find`
+
+Score every skills/<name>/SKILL.md against a free-text intent and
+
+```
+ao skills find <intent> [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help        help for find
+      --json        Emit machine-readable JSON on stdout
+      --limit int   Maximum number of results to return (default 5)
+```
+
 ---
 

--- a/cli/internal/skills/find.go
+++ b/cli/internal/skills/find.go
@@ -1,0 +1,139 @@
+// Package skills scores the skills/ catalog against a free-text intent so the
+// CLI can answer "which skill handles X?" without relying on oral tradition.
+//
+// The scoring engine (Score) is pure: it takes an already-loaded slice of
+// SkillMeta and never touches the filesystem, which keeps it table-testable.
+// Loading SKILL.md frontmatter from disk lives in load.go.
+package skills
+
+import (
+	"math"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// SkillMeta is the scoring input for one skill: its name, one-line
+// description, optional triggers, and source path. Triggers are best-effort —
+// most SKILL.md files carry intent as prose in Description, so Description is
+// the primary signal and Triggers an optional boost.
+type SkillMeta struct {
+	Name        string
+	Description string
+	Triggers    []string
+	Path        string
+}
+
+// Match is one scored result. Score is normalized to [0,1], where 1.0 means
+// every query token matched a skill-name token.
+type Match struct {
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	Path        string  `json:"path"`
+	Score       float64 `json:"score"`
+}
+
+// Field weights: a query token that hits the skill name is the strongest
+// signal, a trigger hit is next, and a description hit is the baseline. The
+// trigger weight is deliberately below 2×weightDesc so that covering two query
+// tokens via the description outranks a single trigger hit — broad coverage of
+// the intent beats one narrow signal.
+const (
+	weightName    = 3.0
+	weightTrigger = 1.5
+	weightDesc    = 1.0
+)
+
+// stopwords are dropped from both the query and the skill haystack so common
+// connective words do not inflate scores.
+var stopwords = map[string]bool{
+	"the": true, "a": true, "an": true, "and": true, "or": true, "of": true,
+	"to": true, "in": true, "on": true, "for": true, "is": true, "it": true,
+	"with": true, "by": true, "at": true, "as": true, "be": true, "this": true,
+}
+
+// Score ranks every skill in metas against query, returning Matches sorted by
+// score descending with ties broken by name ascending (stable, deterministic).
+// An empty query yields all-zero scores. The score is normalized so results
+// are comparable across queries of different lengths.
+func Score(query string, metas []SkillMeta) []Match {
+	qTokens := tokenize(query)
+	matches := make([]Match, 0, len(metas))
+	for _, m := range metas {
+		nameToks := tokenize(m.Name)
+		trigToks := tokenize(strings.Join(m.Triggers, " "))
+		descToks := tokenize(m.Description)
+
+		var raw float64
+		for _, qt := range qTokens {
+			switch {
+			case tokenMatches(qt, nameToks):
+				raw += weightName
+			case tokenMatches(qt, trigToks):
+				raw += weightTrigger
+			case tokenMatches(qt, descToks):
+				raw += weightDesc
+			}
+		}
+
+		score := 0.0
+		if len(qTokens) > 0 {
+			score = raw / (float64(len(qTokens)) * weightName)
+		}
+		matches = append(matches, Match{
+			Name:        m.Name,
+			Description: m.Description,
+			Path:        m.Path,
+			Score:       roundScore(score),
+		})
+	}
+
+	sort.SliceStable(matches, func(i, j int) bool {
+		if matches[i].Score != matches[j].Score {
+			return matches[i].Score > matches[j].Score
+		}
+		return matches[i].Name < matches[j].Name
+	})
+	return matches
+}
+
+// tokenize lowercases, splits on non-alphanumeric runes, and drops stopwords
+// and single-character tokens, returning a deduplicated, order-preserving
+// slice of meaningful tokens.
+func tokenize(s string) []string {
+	fields := strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+	seen := make(map[string]bool, len(fields))
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if len(f) < 2 || stopwords[f] || seen[f] {
+			continue
+		}
+		seen[f] = true
+		out = append(out, f)
+	}
+	return out
+}
+
+// tokenMatches reports whether query token qt hits any token in toks. A hit is
+// an exact match or a prefix-stem match (one token is a prefix of the other and
+// both are at least 4 runes), which tolerates plurals and simple suffixes
+// ("loop" ↔ "loops") without a full stemmer.
+func tokenMatches(qt string, toks []string) bool {
+	for _, t := range toks {
+		if t == qt {
+			return true
+		}
+		if len(qt) >= 4 && len(t) >= 4 && (strings.HasPrefix(t, qt) || strings.HasPrefix(qt, t)) {
+			return true
+		}
+	}
+	return false
+}
+
+// roundScore clamps float noise to 4 decimal places for stable output and
+// deterministic comparisons.
+func roundScore(f float64) float64 {
+	return math.Round(f*10000) / 10000
+}

--- a/cli/internal/skills/find_test.go
+++ b/cli/internal/skills/find_test.go
@@ -1,0 +1,117 @@
+package skills
+
+import "testing"
+
+// fixtureSkills is a fixed in-memory catalog so ranking assertions are stable
+// and independent of the live skills/ tree (which churns).
+func fixtureSkills() []SkillMeta {
+	return []SkillMeta{
+		{Name: "evolve", Description: "Run autonomous improvement loops that close the loop on agent work", Path: "skills/evolve/SKILL.md"},
+		{Name: "rpi", Description: "Run discovery, crank, validation — one turn of the operating loop", Path: "skills/rpi/SKILL.md"},
+		{Name: "release", Description: "Run release validation and cut a versioned release", Path: "skills/release/SKILL.md"},
+		{Name: "crank", Description: "Execute epics through waves of parallel workers", Triggers: []string{"loop", "wave"}, Path: "skills/crank/SKILL.md"},
+	}
+}
+
+func TestScore_RanksByIntent(t *testing.T) {
+	matches := Score("close the loop", fixtureSkills())
+	if len(matches) != 4 {
+		t.Fatalf("expected 4 matches (one per skill), got %d", len(matches))
+	}
+
+	// evolve hits both "close" and "loop" in its description; it must rank top.
+	if matches[0].Name != "evolve" {
+		t.Errorf("expected evolve ranked first, got %q (scores: %+v)", matches[0].Name, matches)
+	}
+	// release matches neither "close" nor "loop" -> must rank last with score 0.
+	last := matches[len(matches)-1]
+	if last.Name != "release" {
+		t.Errorf("expected release ranked last, got %q", last.Name)
+	}
+	if last.Score != 0 {
+		t.Errorf("expected release score 0 (no token overlap), got %v", last.Score)
+	}
+	// Scores must be sorted descending.
+	for i := 1; i < len(matches); i++ {
+		if matches[i-1].Score < matches[i].Score {
+			t.Errorf("results not sorted descending at %d: %v < %v", i, matches[i-1].Score, matches[i].Score)
+		}
+	}
+}
+
+func TestScore_NormalizedToUnitRange(t *testing.T) {
+	// A query whose every token is a skill name token scores exactly 1.0.
+	metas := []SkillMeta{{Name: "evolve loop", Description: "x"}}
+	got := Score("evolve loop", metas)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(got))
+	}
+	if got[0].Score != 1.0 {
+		t.Errorf("expected full name match to score 1.0, got %v", got[0].Score)
+	}
+	for _, m := range Score("close the loop", fixtureSkills()) {
+		if m.Score < 0 || m.Score > 1 {
+			t.Errorf("score %v for %q out of [0,1]", m.Score, m.Name)
+		}
+	}
+}
+
+func TestScore_TriggerBeatsDescription(t *testing.T) {
+	metas := []SkillMeta{
+		{Name: "alpha", Description: "mentions wave somewhere"},
+		{Name: "beta", Triggers: []string{"wave"}, Description: "unrelated text here"},
+	}
+	got := Score("wave", metas)
+	if got[0].Name != "beta" {
+		t.Errorf("expected trigger hit (beta) to outrank description hit (alpha), got %q", got[0].Name)
+	}
+	if !(got[0].Score > got[1].Score) {
+		t.Errorf("expected beta score (%v) > alpha score (%v)", got[0].Score, got[1].Score)
+	}
+}
+
+func TestScore_NoMatchIsZero(t *testing.T) {
+	got := Score("zzqqxx-nonsense", fixtureSkills())
+	for _, m := range got {
+		if m.Score != 0 {
+			t.Errorf("expected score 0 for nonsense query, got %v for %q", m.Score, m.Name)
+		}
+	}
+}
+
+func TestScore_EmptyQueryYieldsZeroScores(t *testing.T) {
+	got := Score("", fixtureSkills())
+	if len(got) != 4 {
+		t.Fatalf("expected all skills returned for empty query, got %d", len(got))
+	}
+	for _, m := range got {
+		if m.Score != 0 {
+			t.Errorf("expected zero score for empty query, got %v for %q", m.Score, m.Name)
+		}
+	}
+}
+
+func TestScore_TieBrokenByNameAscending(t *testing.T) {
+	// Two skills with identical signal for "test" must order by name.
+	metas := []SkillMeta{
+		{Name: "zeta", Description: "test harness"},
+		{Name: "alpha", Description: "test harness"},
+	}
+	got := Score("test", metas)
+	if got[0].Name != "alpha" || got[1].Name != "zeta" {
+		t.Errorf("expected tie broken alpha before zeta, got %q then %q", got[0].Name, got[1].Name)
+	}
+}
+
+func TestTokenize_DropsStopwordsAndShortTokens(t *testing.T) {
+	got := tokenize("Close THE a loop-validation")
+	want := []string{"close", "loop", "validation"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("token %d: expected %q, got %q", i, want[i], got[i])
+		}
+	}
+}

--- a/cli/internal/skills/load.go
+++ b/cli/internal/skills/load.go
@@ -1,0 +1,157 @@
+package skills
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Load reads every skills/<name>/SKILL.md under skillsDir, parses its
+// frontmatter, and returns the catalog as SkillMeta sorted by name. Directories
+// without a readable SKILL.md are skipped. There is no static index file — the
+// catalog is derived from the tree on every call, so a newly added skill is
+// discovered on the next invocation.
+func Load(skillsDir string) ([]SkillMeta, error) {
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return nil, fmt.Errorf("read skills dir %s: %w", skillsDir, err)
+	}
+	metas := make([]SkillMeta, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		path := filepath.Join(skillsDir, e.Name(), "SKILL.md")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		meta := parseSkillMeta(string(data))
+		meta.Path = path
+		if meta.Name == "" {
+			meta.Name = e.Name()
+		}
+		metas = append(metas, meta)
+	}
+	sort.Slice(metas, func(i, j int) bool { return metas[i].Name < metas[j].Name })
+	return metas, nil
+}
+
+// parseSkillMeta extracts name, description, and best-effort triggers from a
+// SKILL.md frontmatter block. It is line-based rather than a full YAML parser
+// because SKILL.md frontmatter is conventionally flat key:value with simple
+// lists; triggers may appear top-level or nested under metadata, as a block
+// list or an inline [a, b] list.
+func parseSkillMeta(content string) SkillMeta {
+	lines := frontmatterLines(content)
+	var meta SkillMeta
+	for i := 0; i < len(lines); i++ {
+		raw := lines[i]
+		trimmed := strings.TrimSpace(raw)
+		switch {
+		case indentOf(raw) == 0 && strings.HasPrefix(trimmed, "name:"):
+			meta.Name = unquoteScalar(strings.TrimPrefix(trimmed, "name:"))
+		case indentOf(raw) == 0 && strings.HasPrefix(trimmed, "description:"):
+			meta.Description = unquoteScalar(strings.TrimPrefix(trimmed, "description:"))
+		case trimmed == "triggers:" || strings.HasPrefix(trimmed, "triggers:"):
+			val := strings.TrimSpace(strings.TrimPrefix(trimmed, "triggers:"))
+			if val != "" {
+				meta.Triggers = append(meta.Triggers, parseInlineList(val)...)
+			} else {
+				meta.Triggers = append(meta.Triggers, collectBlockListItems(lines, i+1, indentOf(raw))...)
+			}
+		}
+	}
+	return meta
+}
+
+// frontmatterLines returns the lines inside the leading `---` fenced YAML block,
+// or nil if there is no frontmatter.
+func frontmatterLines(content string) []string {
+	lines := strings.Split(content, "\n")
+	start := -1
+	for i, ln := range lines {
+		t := strings.TrimSpace(ln)
+		if t == "" {
+			continue
+		}
+		if t == "---" {
+			start = i
+		}
+		break
+	}
+	if start < 0 {
+		return nil
+	}
+	for i := start + 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			return lines[start+1 : i]
+		}
+	}
+	return nil
+}
+
+// indentOf returns the count of leading space/tab runes.
+func indentOf(s string) int {
+	n := 0
+	for _, r := range s {
+		if r != ' ' && r != '\t' {
+			break
+		}
+		n++
+	}
+	return n
+}
+
+// unquoteScalar trims surrounding whitespace and a single layer of matching
+// quotes from a YAML scalar value.
+func unquoteScalar(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+// parseInlineList parses a YAML inline list "[a, b, c]" into its items. A value
+// that is not bracketed is treated as a single scalar item.
+func parseInlineList(val string) []string {
+	val = strings.TrimSpace(val)
+	if strings.HasPrefix(val, "[") && strings.HasSuffix(val, "]") {
+		val = val[1 : len(val)-1]
+	}
+	var out []string
+	for _, part := range strings.Split(val, ",") {
+		if item := unquoteScalar(part); item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+// collectBlockListItems reads consecutive YAML block-list items ("- item")
+// that are indented deeper than parentIndent, starting at line index from.
+func collectBlockListItems(lines []string, from, parentIndent int) []string {
+	var out []string
+	for i := from; i < len(lines); i++ {
+		raw := lines[i]
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "- ") {
+			break
+		}
+		if indentOf(raw) <= parentIndent {
+			break
+		}
+		if item := unquoteScalar(strings.TrimPrefix(trimmed, "- ")); item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
+}

--- a/cli/internal/skills/load_test.go
+++ b/cli/internal/skills/load_test.go
@@ -1,0 +1,139 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseSkillMeta_NameDescriptionAndBlockTriggers(t *testing.T) {
+	content := `---
+name: evolve
+description: "Run autonomous improvement loops."
+metadata:
+  triggers:
+    - autonomous loop
+    - keep improving
+practices:
+- lean-startup
+---
+
+# body
+`
+	meta := parseSkillMeta(content)
+	if meta.Name != "evolve" {
+		t.Errorf("name: got %q want evolve", meta.Name)
+	}
+	if meta.Description != "Run autonomous improvement loops." {
+		t.Errorf("description: got %q", meta.Description)
+	}
+	if len(meta.Triggers) != 2 || meta.Triggers[0] != "autonomous loop" || meta.Triggers[1] != "keep improving" {
+		t.Errorf("triggers: got %v want [autonomous loop, keep improving]", meta.Triggers)
+	}
+}
+
+func TestParseSkillMeta_InlineTriggers(t *testing.T) {
+	content := "---\nname: foo\ndescription: bar\ntriggers: [alpha, \"beta gamma\"]\n---\n"
+	meta := parseSkillMeta(content)
+	if len(meta.Triggers) != 2 || meta.Triggers[0] != "alpha" || meta.Triggers[1] != "beta gamma" {
+		t.Errorf("inline triggers: got %v", meta.Triggers)
+	}
+}
+
+func TestParseSkillMeta_NoFrontmatter(t *testing.T) {
+	meta := parseSkillMeta("# just a heading\nno frontmatter here\n")
+	if meta.Name != "" || meta.Description != "" || len(meta.Triggers) != 0 {
+		t.Errorf("expected empty meta for frontmatter-less content, got %+v", meta)
+	}
+}
+
+func TestLoad_TempTreeFallsBackToDirName(t *testing.T) {
+	dir := t.TempDir()
+	// A skill whose frontmatter omits name: should fall back to the dir name.
+	mk := func(name, body string) {
+		sd := filepath.Join(dir, name)
+		if err := os.MkdirAll(sd, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(sd, "SKILL.md"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("named", "---\nname: named\ndescription: a described skill\n---\n")
+	mk("anon", "---\ndescription: no name field\n---\n")
+	// A directory without SKILL.md must be skipped, not error.
+	if err := os.MkdirAll(filepath.Join(dir, "empty"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	metas, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(metas) != 2 {
+		t.Fatalf("expected 2 skills (empty dir skipped), got %d: %+v", len(metas), metas)
+	}
+	// Sorted by name: "anon" (fallback) before "named".
+	if metas[0].Name != "anon" {
+		t.Errorf("expected dir-name fallback 'anon' first, got %q", metas[0].Name)
+	}
+	if metas[1].Name != "named" || metas[1].Description != "a described skill" {
+		t.Errorf("named skill parsed wrong: %+v", metas[1])
+	}
+}
+
+func TestLoad_MissingDirErrors(t *testing.T) {
+	if _, err := Load(filepath.Join(t.TempDir(), "does-not-exist")); err == nil {
+		t.Error("expected error for missing skills dir, got nil")
+	}
+}
+
+// TestLoad_LiveTreeNonEmpty asserts the loader reads the real skills/ tree when
+// run from the repo. Per the pre-mortem, it does NOT assert exact skill names
+// (the tree churns) — only that loading succeeds and finds skills.
+func TestLoad_LiveTreeNonEmpty(t *testing.T) {
+	root := repoSkillsDir(t)
+	if root == "" {
+		t.Skip("skills/ not found relative to test working dir")
+	}
+	metas, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load(%s): %v", root, err)
+	}
+	if len(metas) == 0 {
+		t.Errorf("expected the live skills/ tree to yield >0 skills, got 0")
+	}
+	for _, m := range metas {
+		if m.Name == "" {
+			t.Errorf("skill at %s has empty name", m.Path)
+		}
+	}
+}
+
+// repoSkillsDir walks up from the test working directory to locate skills/.
+func repoSkillsDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for i := 0; i < 8; i++ {
+		cand := filepath.Join(dir, "skills")
+		// Require a skills-codex sibling to disambiguate the repo-root skills/
+		// tree from this Go package directory (cli/internal/skills).
+		if isDirTest(cand) && isDirTest(filepath.Join(dir, "skills-codex")) {
+			return cand
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return ""
+}
+
+func isDirTest(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && info.IsDir()
+}

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=69 sub=172 all=241"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=69 sub=173 all=242"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,4} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "69" || "$sub_count" != "172" || "$all_count" != "241" ]]; then
+if [[ "$top_count" != "69" || "$sub_count" != "173" || "$all_count" != "242" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 241 ]]; then
+if [[ "${#commands[@]}" -ne 242 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

Turns the 75-skill catalog from oral tradition into a queryable surface.
`ao skills find <intent>` scores every `skills/*/SKILL.md` against a free-text
intent and returns the top matches (name, one-line description, score) — so an
agent gets a discovery API instead of memorizing skill names.

- **Scoring engine** (`cli/internal/skills/find.go`) — pure, deterministic
  token-overlap. A query word hitting the skill **name** counts most, a declared
  **trigger** next, a **description** word least, with light plural/stem
  tolerance (`loop` ↔ `loops`). Scores normalized to `[0,1]`; ties broken by
  name. No filesystem access, so it is fully table-testable.
- **Loader** (`cli/internal/skills/load.go`) — reads `skills/*/SKILL.md`, parses
  frontmatter (`name`, `description`, best-effort top-level / `metadata`
  triggers). No static index file: a newly added skill is found on the next run.
- **Command** (`cli/cmd/ao/skills_find.go`) — `--json` / `--limit` (default 5),
  stdout-as-data / stderr-as-diagnostics. An unmatched intent **exits 0** with a
  stderr note, not an error. Unknown-flag typo hints inherited from the root
  cobra config; `--limit < 1` returns a usage error naming the fix.
- Regenerated `cli/docs/COMMANDS.md`.

### Notes / corrections

- The bead's premise ("each SKILL.md has a populated `triggers:` array") is
  inaccurate — phase-1 discovery found **0/75** top-level `triggers:` arrays;
  intent lives as prose in `description`, with `metadata.triggers` in ~10 skills.
  Scoring therefore treats name+description as the primary signal and triggers as
  an optional boost.
- Bounded context: the slice reads the **skills corpus** (SKILL.md content), so
  `BC1-Corpus` (the plan's draft `BC4-Practice` does not exist — BC4 is Evidence).
- Deferred to follow-ups: `ao skills list --by-trigger` / `--list-triggers`
  (ag-0r0) and backfilling structured triggers across SKILL.md (ag-piv).

## Test plan

- [x] `cd cli && go test ./internal/skills/... ./cmd/ao` (green)
- [x] `cd cli && go build ./... && go vet ./internal/skills/... ./cmd/ao`
- [x] `scripts/generate-cli-reference.sh` (COMMANDS.md in conformance)
- [x] `bash skills/heal-skill/scripts/heal.sh --strict` (All clean)
- [x] `ao autodev validate --file PROGRAM.md --json` → `valid: true`
- [x] Manual smoke: `ao skills find "close the loop"`, `--json --limit 3`, unmatched intent

Closes-scenario: ag-a97#find-ranks-relevant-skills
Bounded-context: BC1-Corpus
Evidence: cli/internal/skills/find_test.go + go test ./internal/skills/... ./cmd/ao