### PR TITLE
docs(corpus): cold-start orientation coherence after hook removal (soc-qh2g1 #hookless-cold-start)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get sta
 
 **Gas City (`gc`)** is the optional out-of-session orchestration substrate that runs whole `ao rpi`/`ao evolve` loops (mayor + refinery agents over the reference City at `packs/agentops/`). `ao` does NOT wrap `gc` — it is a guided dependency, just like `bd`. See the [`using-gc`](skills/using-gc/SKILL.md) skill for the workflow and [docs/dependencies.md](docs/dependencies.md) for the full tool list.
 
-> **Spawning an agent? Run this first:** `ao session bootstrap` (when [soc-vuu6.25](https://github.com/boshu2/agentops/issues?q=soc-vuu6.25) lands) — the universal init prompt that orients every agent identically regardless of model. Until then, follow the read order below.
+> **Spawning an agent? Run this first:** `ao session bootstrap` — the universal init prompt that orients every agent identically regardless of model. AgentOps 3.0 is hookless, so nothing auto-injects this: run it explicitly, then `ao inject` / `ao corpus inject --query "<topic>"` to pull decay-ranked prior context. Then follow the read order below.
 
 ## Session Start (Zero-Context Agent)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ AgentOps compiles and compounds the context that feeds your software factory. It
 
 ## Zero-Context Startup (Read First)
 
-If this is your first message in a fresh session, orient in this order:
+AgentOps 3.0 is hookless: nothing auto-injects orientation at session start. Run `ao session bootstrap` (the universal init prompt) to get the standard orientation report, then `ao inject` / `ao corpus inject --query "<topic>"` to pull decay-ranked prior context — this is the explicit replacement for the SessionStart context the runtime used to inject. Then, on your first message in a fresh session, read in this order:
 
 1. `docs/newcomer-guide.md` for a practical repo orientation and learning path.
 2. `docs/index.md` (MkDocs landing) and `docs/documentation-index.md` (full catalog) for navigation.

--- a/docs/architecture/primitive-chains.md
+++ b/docs/architecture/primitive-chains.md
@@ -117,14 +117,25 @@ session start -> phased handoff -> handoff / recover -> session end -> next sess
 
 | Continuity Surface | Role |
 |--------------------|------|
-| `hooks/session-start.sh` | Injects lightweight repo context and points at durable artifacts |
+| `ao session bootstrap` / `ao inject` | Explicitly loads repo context and points at durable artifacts at session start |
 | `ao rpi phased` + phase manifests | Keeps each phase context-bounded and disk-backed |
 | `/handoff` | Leaves a structured continuation packet for the next operator |
 | `/recover` | Rehydrates in-progress work after compaction or interruption |
-| `hooks/session-end-maintenance.sh` | Extracts and curates end-of-session knowledge |
-| `hooks/ao-flywheel-close.sh` | Closes the loop at stop time |
+| `ao forge transcript` + `ao flywheel close-loop` | Extracts end-of-session knowledge and closes the loop at stop time |
 
-This is the stigmergic memory layer. No agent has to remember yesterday if the environment was updated correctly.
+This is the stigmergic memory layer. No agent has to remember yesterday if the environment was updated correctly. AgentOps 3.0 is hookless, so every surface above is an explicit command an agent runs — nothing fires automatically at session start or stop.
+
+### Removed hooks → replacement
+
+AgentOps 3.0 ships no hooks. Every behavior a lifecycle hook used to fire automatically is now an explicit command, an always-on CI gate, or opt-in (author-it-yourself via the `hooks-authoring` skill). Audited by user-facing behavior, none of the removed value is lost:
+
+| Removed hook behavior | What fired automatically | Hookless replacement |
+|-----------------------|--------------------------|----------------------|
+| Cold-start context injection (`session-start.sh`) | Injected lightweight repo context at session start | `ao session bootstrap`, then `ao inject` / `ao corpus inject --query "<topic>"` |
+| End-of-session curation (`session-end-maintenance.sh`, `ao-flywheel-close.sh`) | Curated end-of-session knowledge and closed the flywheel loop at stop | `ao forge transcript` (capture) → `ao flywheel close-loop` (curate + close) |
+| Standards surfacing (edit-time standards injector) | Surfaced coding standards on edit | The `standards` skill plus `.claude/rules/*.md`, referenced from CLAUDE.md and read on demand |
+| Validation reminders (edit / commit guardrails) | Reminded the agent to run gates | CI is the authoritative gate (`.github/workflows/validate.yml`); run the per-tool checks locally and the `vibe` skill before pushing |
+| Prompt nudges (`prompt-nudge.sh`, `intent-echo.sh`, `new-user-welcome.sh`) | Injected prompt-time nudges and a welcome banner | Confirmed noise — removed first as pure context bloat; no replacement |
 
 ## Terminology Drift Ledger
 

--- a/docs/newcomer-guide.md
+++ b/docs/newcomer-guide.md
@@ -4,14 +4,14 @@ If you're new to this repository, this guide gives you a practical mental model,
 
 ## What this repo is
 
-AgentOps is the **operational layer for coding agents**: a skills + hooks + CLI system that provides bookkeeping, validation, primitives, and flows so sessions compound instead of restarting from zero.
+AgentOps is the **operational layer for coding agents**: a skills + CLI system (with opt-in hooks) that provides bookkeeping, validation, primitives, and flows so sessions compound instead of restarting from zero.
 
 At a high level:
 
 1. Run primitives and flows with skills (`/research`, `/implement`, `/validation`, `/rpi`)
 2. Persist bookkeeping in `.agents/`
 3. Inject the best prior learnings into the next session
-4. Enforce quality through hooks and CI gates
+4. Enforce quality through CI gates (AgentOps 3.0 is hookless — CI is the authoritative gate; hooks are opt-in)
 
 See also:
 

--- a/scripts/check-hookless-cold-start.sh
+++ b/scripts/check-hookless-cold-start.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# check-hookless-cold-start.sh — scenario-2 regression gate for soc-qh2g1.
+#
+# AgentOps 3.0 is hookless: no SessionStart/Stop hook ships, so no cold-start or
+# continuity doc/skill may present a `hooks/<name>.sh` path as a CURRENTLY ACTIVE
+# surface. A hook path is allowed only on a line that hedges it as opt-in /
+# author-it-yourself / historical / removed (the hooks-authoring escape hatch).
+#
+# Scope is a FIXED list of cold-start / continuity surfaces. It deliberately does
+# NOT scan all of docs/+skills/ (release notes, the hooks-authoring skill, and
+# scope guards legitimately name hook paths) and deliberately excludes the repo
+# CLAUDE.md (its workflow-discipline `session-pr-counter.sh` reference is tracked
+# separately, out of cold-start scope).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+FILES=(
+  "AGENTS.md"
+  "docs/architecture/primitive-chains.md"
+  "skills/session-bootstrap/SKILL.md"
+  "skills-codex/session-bootstrap/SKILL.md"
+  "docs/newcomer-guide.md"
+)
+
+# A hook path is "hedged" (allowed) when its line also carries one of these.
+# These hedge ARTIFACT EXISTENCE (opt-in / author-it-yourself / historical /
+# removed). "When supported" is deliberately NOT here: it hedges harness
+# capability, not whether AgentOps ships the hook (it does not).
+HEDGE='opt-in|optional|author|if you author|hooks-authoring|historical|removed|no such hook|ships no|example|if installed|when hooks are installed|when installed'
+HOOK_PATH='hooks/[A-Za-z0-9_.-]+\.sh'
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+violations=0
+scanned=0
+for rel in "${FILES[@]}"; do
+  file="$ROOT/$rel"
+  [[ -f "$file" ]] || continue
+  scanned=$((scanned + 1))
+  while IFS= read -r match; do
+    [[ -n "$match" ]] || continue
+    lineno="${match%%:*}"
+    content="${match#*:}"
+    if ! grep -qiE "$HEDGE" <<<"$content"; then
+      printf 'FAIL: %s:%s presents a hook path as an active surface without an opt-in/historical hedge\n' \
+        "$rel" "$lineno" >&2
+      printf '      %s\n' "$content" >&2
+      violations=$((violations + 1))
+    fi
+  done < <(grep -nE "$HOOK_PATH" "$file" || true)
+done
+
+[[ "$scanned" -gt 0 ]] || fail "no cold-start surfaces found under $ROOT"
+
+if [[ "$violations" -gt 0 ]]; then
+  fail "$violations stale hook promise(s) in cold-start/continuity surfaces. Reframe as explicit \`ao\` commands or hedge as opt-in (author via the hooks-authoring skill)."
+fi
+
+printf 'PASS: no stale hook-context promises in %d cold-start/continuity surface(s)\n' "$scanned"

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1003,8 +1003,8 @@
     {
       "name": "session-bootstrap",
       "source_skill": "skills/session-bootstrap",
-      "source_hash": "6888a26aadff0e14118cbbaaa36761caaaf43af9b1dcf8690bf219dc0dc3f966",
-      "generated_hash": "4620320eb1d8b6c724956e566ba5a3c5663a14e1010f9a693f3143326c55d8c4"
+      "source_hash": "96f95918d13f28d0fbf82836df3c3423d2fd0ff279797530ba23e5f8a5b0edad",
+      "generated_hash": "f91092f706a0f196e8f787a75208e1b71a86d57eae112f156cd9b0b3fe0819cb"
     },
     {
       "name": "shared",

--- a/skills-codex/session-bootstrap/.agentops-generated.json
+++ b/skills-codex/session-bootstrap/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/session-bootstrap",
   "layout": "modular",
-  "source_hash": "6888a26aadff0e14118cbbaaa36761caaaf43af9b1dcf8690bf219dc0dc3f966",
-  "generated_hash": "4620320eb1d8b6c724956e566ba5a3c5663a14e1010f9a693f3143326c55d8c4"
+  "source_hash": "96f95918d13f28d0fbf82836df3c3423d2fd0ff279797530ba23e5f8a5b0edad",
+  "generated_hash": "f91092f706a0f196e8f787a75208e1b71a86d57eae112f156cd9b0b3fe0819cb"
 }

--- a/skills-codex/session-bootstrap/SKILL.md
+++ b/skills-codex/session-bootstrap/SKILL.md
@@ -14,7 +14,7 @@ description: Agent init prompt.
 Triggers:
 
 - **Manual spawn** — operator just spawned a fresh agent into the repo: `ao session bootstrap`.
-- **SessionStart hook** — fail-open auto-fire when supported: `hooks/session-start-bootstrap.sh` runs `ao session bootstrap --robot` and discards exit code.
+- **SessionStart hook (opt-in)** — AgentOps 3.0 ships no SessionStart hook. If you author one via the `hooks-authoring` skill, it can fail-open auto-fire `ao session bootstrap --robot` and discard the exit code.
 - **Pipeline submit** — `agentopsd` and headless CI agents call `ao session bootstrap --json` before claiming work.
 
 If you spawned without running it: stop, run it, then resume.

--- a/skills/session-bootstrap/SKILL.md
+++ b/skills/session-bootstrap/SKILL.md
@@ -39,7 +39,7 @@ context_rel:
 Triggers:
 
 - **Manual spawn** — operator just spawned a fresh agent into the repo: `ao session bootstrap`.
-- **SessionStart hook** — fail-open auto-fire when supported: `hooks/session-start-bootstrap.sh` runs `ao session bootstrap --robot` and discards exit code.
+- **SessionStart hook (opt-in)** — AgentOps 3.0 ships no SessionStart hook. If you author one via the `hooks-authoring` skill, it can fail-open auto-fire `ao session bootstrap --robot` and discard the exit code.
 - **Pipeline submit** — the orchestration substrate (the reference Gas City City) and headless CI agents call `ao session bootstrap --json` before claiming work.
 
 If you spawned without running it: stop, run it, then resume.

--- a/tests/scripts/check-hookless-cold-start.bats
+++ b/tests/scripts/check-hookless-cold-start.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-hookless-cold-start.sh (soc-qh2g1 scenario 2).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/check-hookless-cold-start.sh"
+    TMP_DIR="$(mktemp -d)"
+    FAKE_REPO="$TMP_DIR/repo"
+    mkdir -p "$FAKE_REPO/scripts" "$FAKE_REPO/docs/architecture"
+    /bin/cp "$SCRIPT" "$FAKE_REPO/scripts/check-hookless-cold-start.sh"
+    chmod +x "$FAKE_REPO/scripts/check-hookless-cold-start.sh"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "real cold-start surfaces carry no un-hedged hook promises" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"* ]]
+}
+
+@test "fails when a scoped surface presents a hook path as a current surface" {
+    cat > "$FAKE_REPO/docs/architecture/primitive-chains.md" <<'EOF'
+# Primitive Chains
+
+| Continuity Surface | Role |
+|--------------------|------|
+| `hooks/session-start.sh` | Injects lightweight repo context |
+EOF
+
+    run "$FAKE_REPO/scripts/check-hookless-cold-start.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"primitive-chains.md:5"* ]]
+    [[ "$output" == *"without an opt-in/historical hedge"* ]]
+}
+
+@test "passes when a hook path is hedged as opt-in / author-it-yourself" {
+    cat > "$FAKE_REPO/docs/architecture/primitive-chains.md" <<'EOF'
+# Primitive Chains
+
+Startup context loads via `ao session bootstrap` / `ao inject` (run explicitly).
+A `hooks/session-start.sh` is opt-in only (author one via the hooks-authoring skill).
+EOF
+
+    run "$FAKE_REPO/scripts/check-hookless-cold-start.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"* ]]
+}
+
+@test "passes when no hook paths appear at all" {
+    cat > "$FAKE_REPO/docs/architecture/primitive-chains.md" <<'EOF'
+# Primitive Chains
+
+Startup orientation: run `ao session bootstrap`. Nothing auto-injects in 3.0.
+EOF
+
+    run "$FAKE_REPO/scripts/check-hookless-cold-start.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"* ]]
+}
+
+@test "errors when no scoped surface exists under root" {
+    run "$FAKE_REPO/scripts/check-hookless-cold-start.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no cold-start surfaces found"* ]]
+}


### PR DESCRIPTION
## Summary

Hookless AgentOps 3.0 ships no SessionStart/Stop hooks, but several cold-start surfaces still named hook scripts as live context-injectors — misleading a fresh agent into expecting auto-injection. This is a pure doc/skill reconciliation pass (BC1 Corpus); **no command logic changed**.

- **Scenario 1 (orientation reachable without a hook):** `CLAUDE.md` + `AGENTS.md` Zero-Context startup now name the explicit orientation command — `ao session bootstrap` → `ao inject` / `ao corpus inject --query "<topic>"`. `AGENTS.md` drops the stale "when soc-vuu6.25 lands / until then" hedge: bootstrap shipped in PR #390 (soc-vuu6.25 is closed).
- **Scenario 2 (no doc/skill promises hook-provided context):** `docs/architecture/primitive-chains.md` Chain 6, `skills/session-bootstrap/SKILL.md` (+ codex twin), and `docs/newcomer-guide.md` no longer present hook scripts as active surfaces; remaining hook mentions are reframed opt-in (author via the `hooks-authoring` skill). New `scripts/check-hookless-cold-start.sh` + bats lock the regression.
- **Scenario 3 (each removed hook accounted for):** a disposition table in `primitive-chains.md` maps each removed hook *behavior* (context injection, end-of-session curation, standards surfacing, validation reminders) → an explicit replacement or "confirmed noise".

## Design notes

- The new gate rides the existing `bats tests/scripts/*.bats` CI lane (no new `validate.yml` job, per plan). It scans a **fixed** list of cold-start surfaces and flags any `hooks/<name>.sh` path presented without an opt-in/historical hedge — deliberately *not* a broad `docs/`+`skills/` grep (release notes / `hooks-authoring` / scope guards legitimately name hook paths).
- `CLAUDE.md` is **hand-maintained**: `build-claude.py` is vestigial (its `--check` reports STALE on clean `main` and it's absent from CI), so `CLAUDE.md` was edited directly rather than regenerated — running the generator would have clobbered it.
- Scenario-3's disposition was folded into the `primitive-chains.md` Chain 6 reframe rather than a new doc (co-located, no catalogue-gate or mkdocs-nav churn).
- Scope held tight: broader hook-taxonomy drift in `primitive-chains.md` (Terminology Ledger / Audit Snapshot "7 hook event sections") and the out-of-scope `CLAUDE.md:145` `session-pr-counter.sh` (workflow-discipline, soc-waxr) are left for follow-up beads.

## Test plan

- [x] `bash scripts/check-hookless-cold-start.sh` → PASS (5 surfaces)
- [x] `bats tests/scripts/check-hookless-cold-start.bats` → 5/5
- [x] `shellcheck scripts/check-hookless-cold-start.sh` → clean
- [x] `bash scripts/audit-codex-parity.sh --skill session-bootstrap` → passed
- [x] `bash skills/heal-skill/scripts/heal.sh --strict` → clean
- [x] `cd cli && make sync-hooks` → no embedded drift
- [x] `bash scripts/validate-agents-split.sh` → PASS (99 lines)
- [x] `markdownlint --config .markdownlint.json` on changed files → clean
- [x] No Go changes (build/test unaffected)

Closes-scenario: soc-qh2g1#hookless-cold-start
Bounded-context: BC1-Corpus
Evidence: bash scripts/check-hookless-cold-start.sh; bats tests/scripts/check-hookless-cold-start.bats