### PR TITLE
feat(beads): idempotent '## Scenarios' guard + --force for scenarios extract (ag-kyn #scenarios-guard)

### DIFF
--- a/cli/cmd/ao/beads_scenarios.go
+++ b/cli/cmd/ao/beads_scenarios.go
@@ -23,16 +23,28 @@ import (
 	"github.com/boshu2/agentops/cli/internal/scenarios"
 )
 
-var beadsScenariosJSON bool
+var (
+	beadsScenariosJSON  bool
+	beadsScenariosForce bool
+)
 
-// beadsScenariosFetchAcceptance fetches a bead's acceptance text. It is a
+// fetchedBead is the subset of a bead the scenarios command needs: the
+// acceptance text it extracts from, and the description it guards against. A
+// bead whose description already carries a "## Scenarios" block is not
+// re-extracted over unless --force is passed.
+type fetchedBead struct {
+	Acceptance  string
+	Description string
+}
+
+// beadsScenariosFetch fetches a bead's acceptance and description text. It is a
 // package var so tests can inject a fake without shelling out to bd.
-var beadsScenariosFetchAcceptance = func(id string) (string, error) {
+var beadsScenariosFetch = func(id string) (fetchedBead, error) {
 	out, err := execBD("show", id, "--json")
 	if err != nil {
-		return "", fmt.Errorf("bd show %s --json: %w", id, err)
+		return fetchedBead{}, fmt.Errorf("bd show %s --json: %w", id, err)
 	}
-	return parseAcceptanceFromBDJSON(out)
+	return parseBeadFromBDJSON(out)
 }
 
 var beadsScenariosCmd = &cobra.Command{
@@ -56,7 +68,11 @@ and print a candidate '## Scenarios' block to stdout.
 
 This is a dry-run — the bead is never modified. Review the output and author
 it into the bead manually. With --json the scenarios are emitted as structured
-data on stdout instead of a Gherkin block.`,
+data on stdout instead of a Gherkin block.
+
+If the bead already carries a '## Scenarios' block, extract refuses (nothing to
+do) unless --force is passed, to avoid generating noise over already-shaped
+acceptance.`,
 	RunE: runBeadsScenariosExtract,
 }
 
@@ -65,6 +81,8 @@ func init() {
 	beadsScenariosCmd.AddCommand(beadsScenariosExtractCmd)
 	beadsScenariosExtractCmd.Flags().BoolVar(&beadsScenariosJSON, "json", false,
 		"Emit extracted scenarios as JSON (data on stdout) instead of a Gherkin block")
+	beadsScenariosExtractCmd.Flags().BoolVar(&beadsScenariosForce, "force", false,
+		"Extract even when the bead already has a '## Scenarios' block")
 }
 
 func runBeadsScenariosExtract(cmd *cobra.Command, args []string) error {
@@ -76,12 +94,19 @@ func runBeadsScenariosExtract(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	acceptance, err := beadsScenariosFetchAcceptance(id)
+	bead, err := beadsScenariosFetch(id)
 	if err != nil {
 		return fmt.Errorf("fetch acceptance for %s: %w (inspect with 'bd show %s --json')", id, err, id)
 	}
 
-	extracted, err := scenarios.Extract(acceptance)
+	if !beadsScenariosForce &&
+		(scenarios.HasScenariosBlock(bead.Description) || scenarios.HasScenariosBlock(bead.Acceptance)) {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"bead %s already has a '## Scenarios' block; nothing to extract. Re-run with --force to extract anyway.\n", id)
+		return nil
+	}
+
+	extracted, err := scenarios.Extract(bead.Acceptance)
 	if err != nil {
 		return fmt.Errorf(
 			"extract scenarios from %s: %w; author a '## Scenarios' block manually (see CLAUDE.md acceptance doctrine)",
@@ -101,11 +126,14 @@ func runBeadsScenariosExtract(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// parseAcceptanceFromBDJSON extracts the acceptance text from the output of
-// `bd show <id> --json`. bd emits a JSON array of bead objects; older versions
-// may emit a single object, so both shapes are handled. The acceptance_criteria
-// field is preferred, falling back to the description when it is empty.
-func parseAcceptanceFromBDJSON(out []byte) (string, error) {
+// parseBeadFromBDJSON extracts the acceptance and description text from the
+// output of `bd show <id> --json`. bd emits a JSON array of bead objects; older
+// versions may emit a single object, so both shapes are handled. The
+// acceptance field used for extraction prefers acceptance_criteria, falling
+// back to the description when it is empty; the raw description is returned
+// separately so the caller can guard against an already-present scenarios
+// block.
+func parseBeadFromBDJSON(out []byte) (fetchedBead, error) {
 	type bead struct {
 		AcceptanceCriteria string `json:"acceptance_criteria"`
 		Description        string `json:"description"`
@@ -116,22 +144,23 @@ func parseAcceptanceFromBDJSON(out []byte) (string, error) {
 	if len(trimmed) > 0 && trimmed[0] == '[' {
 		var arr []bead
 		if err := json.Unmarshal(trimmed, &arr); err != nil {
-			return "", fmt.Errorf("parse bd json array: %w", err)
+			return fetchedBead{}, fmt.Errorf("parse bd json array: %w", err)
 		}
 		if len(arr) == 0 {
-			return "", fmt.Errorf("bead not found")
+			return fetchedBead{}, fmt.Errorf("bead not found")
 		}
 		b = arr[0]
 	} else if err := json.Unmarshal(trimmed, &b); err != nil {
-		return "", fmt.Errorf("parse bd json: %w", err)
+		return fetchedBead{}, fmt.Errorf("parse bd json: %w", err)
 	}
 
+	desc := strings.TrimSpace(b.Description)
 	acc := strings.TrimSpace(b.AcceptanceCriteria)
 	if acc == "" {
-		acc = strings.TrimSpace(b.Description)
+		acc = desc
 	}
 	if acc == "" {
-		return "", fmt.Errorf("bead has no acceptance_criteria or description text")
+		return fetchedBead{}, fmt.Errorf("bead has no acceptance_criteria or description text")
 	}
-	return acc, nil
+	return fetchedBead{Acceptance: acc, Description: desc}, nil
 }

--- a/cli/cmd/ao/beads_scenarios_test.go
+++ b/cli/cmd/ao/beads_scenarios_test.go
@@ -134,27 +134,30 @@ func TestRunBeadsScenariosExtract_BDUnavailableWarnsAndSucceeds(t *testing.T) {
 	}
 }
 
-func TestParseAcceptanceFromBDJSON(t *testing.T) {
+func TestParseBeadFromBDJSON(t *testing.T) {
 	tests := []struct {
-		name    string
-		in      string
-		want    string
-		wantErr bool
+		name        string
+		in          string
+		wantAccept  string
+		wantDescrip string
+		wantErr     bool
 	}{
 		{
-			name: "array form prefers acceptance_criteria",
-			in:   `[{"acceptance_criteria":"crit text","description":"desc text"}]`,
-			want: "crit text",
+			name:        "array form prefers acceptance_criteria and keeps description",
+			in:          `[{"acceptance_criteria":"crit text","description":"desc text"}]`,
+			wantAccept:  "crit text",
+			wantDescrip: "desc text",
 		},
 		{
-			name: "single object form",
-			in:   `{"acceptance_criteria":"crit text"}`,
-			want: "crit text",
+			name:       "single object form",
+			in:         `{"acceptance_criteria":"crit text"}`,
+			wantAccept: "crit text",
 		},
 		{
-			name: "falls back to description when acceptance empty",
-			in:   `[{"acceptance_criteria":"  ","description":"desc text"}]`,
-			want: "desc text",
+			name:        "falls back to description when acceptance empty",
+			in:          `[{"acceptance_criteria":"  ","description":"desc text"}]`,
+			wantAccept:  "desc text",
+			wantDescrip: "desc text",
 		},
 		{
 			name:    "empty array is an error",
@@ -174,19 +177,68 @@ func TestParseAcceptanceFromBDJSON(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseAcceptanceFromBDJSON([]byte(tt.in))
+			got, err := parseBeadFromBDJSON([]byte(tt.in))
 			if tt.wantErr {
 				if err == nil {
-					t.Fatalf("parseAcceptanceFromBDJSON(%q) = %q, want error", tt.in, got)
+					t.Fatalf("parseBeadFromBDJSON(%q) = %+v, want error", tt.in, got)
 				}
 				return
 			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
+			if got.Acceptance != tt.wantAccept {
+				t.Errorf("Acceptance = %q, want %q", got.Acceptance, tt.wantAccept)
+			}
+			if got.Description != tt.wantDescrip {
+				t.Errorf("Description = %q, want %q", got.Description, tt.wantDescrip)
 			}
 		})
+	}
+}
+
+func TestRunBeadsScenariosExtract_RefusesWhenScenariosExist(t *testing.T) {
+	calls := withStubbedBD(t, true, func(args ...string) ([]byte, error) {
+		// acceptance_criteria is parseable, but the description already carries
+		// an authored '## Scenarios' block — the guard must short-circuit.
+		return []byte(`[{"id":"ag-x","acceptance_criteria":"Given a bead when extract runs then a block prints","description":"## Scenarios\nScenario: existing\n  Given a\n  When b\n  Then c"}]`), nil
+	})
+
+	stdout, stderr, err := runScenariosExtract(t, false, "ag-x")
+	if err != nil {
+		t.Fatalf("guard should refuse gracefully, got error: %v", err)
+	}
+	if stdout != "" {
+		t.Errorf("expected no stdout when scenarios already exist, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--force") {
+		t.Errorf("stderr should name --force as the corrective action, got %q", stderr)
+	}
+	for _, c := range *calls {
+		if len(c) > 0 && c[0] == "update" {
+			t.Errorf("dry-run violated: bd update was called: %v", c)
+		}
+	}
+}
+
+func TestRunBeadsScenariosExtract_ForceReExtractsOverExisting(t *testing.T) {
+	withStubbedBD(t, true, func(args ...string) ([]byte, error) {
+		return []byte(`[{"id":"ag-x","acceptance_criteria":"Given a bead when extract runs then a block prints","description":"## Scenarios\nScenario: existing\n  Given a\n  When b\n  Then c"}]`), nil
+	})
+
+	beadsScenariosForce = true
+	t.Cleanup(func() { beadsScenariosForce = false })
+
+	stdout, _, err := runScenariosExtract(t, false, "ag-x")
+	if err != nil {
+		t.Fatalf("unexpected error with --force: %v", err)
+	}
+	if !strings.Contains(stdout, "## Scenarios") {
+		t.Errorf("--force should print a freshly extracted block, got %q", stdout)
+	}
+	// The printed block is extracted from acceptance_criteria, not the bead's
+	// pre-existing description block.
+	if !strings.Contains(stdout, "When extract runs") {
+		t.Errorf("--force output should reflect the acceptance text, got %q", stdout)
 	}
 }

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -2800,8 +2800,9 @@ ao beads scenarios extract <bead-id> [flags]
 **Flags:**
 
 ```
-  -h, --help   help for extract
-      --json   Emit extracted scenarios as JSON (data on stdout) instead of a Gherkin block
+      --force   Extract even when the bead already has a '## Scenarios' block
+  -h, --help    help for extract
+      --json    Emit extracted scenarios as JSON (data on stdout) instead of a Gherkin block
 ```
 
 #### `ao beads stale-claims`

--- a/cli/internal/scenarios/guard.go
+++ b/cli/internal/scenarios/guard.go
@@ -1,0 +1,29 @@
+package scenarios
+
+import "strings"
+
+// HasScenariosBlock reports whether text already carries an authored Gherkin
+// scenarios section — a markdown heading line whose first word is "Scenarios"
+// (case-insensitive), e.g. "## Scenarios". It is the idempotency guard for the
+// extractor: a bead that already has a "## Scenarios" block should not be
+// re-extracted over without an explicit override.
+//
+// A singular "## Scenario:" heading or a bare "Scenario:" line does not match;
+// only the plural section heading that opens a scenarios block does.
+func HasScenariosBlock(text string) bool {
+	for _, line := range strings.Split(text, "\n") {
+		t := strings.TrimSpace(line)
+		if !strings.HasPrefix(t, "#") {
+			continue
+		}
+		heading := strings.TrimSpace(strings.TrimLeft(t, "#"))
+		word := heading
+		if i := strings.IndexAny(heading, " \t"); i >= 0 {
+			word = heading[:i]
+		}
+		if strings.EqualFold(word, "Scenarios") {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/scenarios/guard_test.go
+++ b/cli/internal/scenarios/guard_test.go
@@ -1,0 +1,74 @@
+package scenarios
+
+import "testing"
+
+func TestHasScenariosBlock(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{
+			name: "canonical heading with scenario body",
+			in:   "Some intro.\n\n## Scenarios\nScenario: x\n  Given a\n  When b\n  Then c",
+			want: true,
+		},
+		{
+			name: "heading only",
+			in:   "## Scenarios",
+			want: true,
+		},
+		{
+			name: "level-three heading",
+			in:   "### Scenarios",
+			want: true,
+		},
+		{
+			name: "case-insensitive heading word",
+			in:   "## scenarios",
+			want: true,
+		},
+		{
+			name: "heading with trailing parenthetical",
+			in:   "## Scenarios (draft)",
+			want: true,
+		},
+		{
+			name: "indented and trailing whitespace heading",
+			in:   "   ## Scenarios   ",
+			want: true,
+		},
+		{
+			name: "no heading, plain acceptance bullets",
+			in:   "- Given a bead, when extract runs, then a block prints",
+			want: false,
+		},
+		{
+			name: "singular Scenario line is not the block heading",
+			in:   "Scenario: foo\n  Given a\n  When b\n  Then c",
+			want: false,
+		},
+		{
+			name: "level-two singular Scenario heading does not match plural block",
+			in:   "## Scenario: foo",
+			want: false,
+		},
+		{
+			name: "the word scenarios in prose is not a heading",
+			in:   "This bead describes several scenarios in prose form.",
+			want: false,
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasScenariosBlock(tt.in); got != tt.want {
+				t.Errorf("HasScenariosBlock(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Next slice of the open epic **ag-dwq** (Gherkin scenarios extractor). Slice 1 (`ag-ljd`, the dry-run `extract` command) merged in #567; this adds the **idempotent guard** (ag-dwq scenario 3):

`ao beads scenarios extract <id>` now **refuses** when the bead already carries a `## Scenarios` block — prints a diagnostic to stderr naming `--force` as the corrective action, exits 0, emits nothing on stdout — **unless `--force`** is passed, in which case it re-extracts and prints normally.

- New pure `scenarios.HasScenariosBlock(text)`: detects a markdown `## Scenarios` section heading (plural-only, case-insensitive). A bare `Scenario:` line or singular `## Scenario:` heading does **not** match.
- Fetch now returns the bead's acceptance **and** description (`fetchedBead`) so the guard can inspect the description, where authored scenario blocks live.
- Stays a **dry-run**; no bead mutation on any path.

Out of scope (remain in parent ag-dwq): `--write`, `validate` subcommand + Gherkin parser dep, LLM fallback.

> **Bead note:** the canonical follow-up bead for this work is **ag-kyn** (filed by a concurrent RPI cycle as a child of ag-dwq). A duplicate bead `ag-gam` was created before ag-kyn was visible; `ag-gam` is closed as duplicate-of `ag-kyn`. Branch name retains the `ag-gam` token but the work closes `ag-kyn`.

## Test plan
- [x] `cd cli && go build ./... && go vet ./... && go test ./...` — clean (66 pkg ok, 0 fail)
- [x] `go test ./internal/scenarios/ ./cmd/ao` — targeted, incl. new `TestHasScenariosBlock` (11 cases) + 2 new L2 guard tests
- [x] Real binary: refuses on `ag-ljd` (has block), extracts on `ag-dwq` (free-text bullets)
- [x] `cli/docs/COMMANDS.md` regenerated; `cli-command-surface-matrix` smoke passes (69/174/243 — flags aren't headings)

Closes-scenario: ag-kyn#scenarios-guard
Bounded-context: BC1-Corpus
Evidence: cd cli && go test ./internal/scenarios/ ./cmd/ao