### PR TITLE
feat(beads): ao beads scenarios validate <id> — well-formedness check (ag-5cz #scenarios-validate)

### DIFF
--- a/cli/cmd/ao/beads_scenarios.go
+++ b/cli/cmd/ao/beads_scenarios.go
@@ -1,15 +1,17 @@
-// `ao beads scenarios` — convert a bead's free-text acceptance criteria into
+// `ao beads scenarios` — convert and check a bead's acceptance criteria as
 // Gherkin scenarios.
 //
-// This slice ships a single read-only subcommand:
+// This surface ships two read-only subcommands:
 //
-//	ao beads scenarios extract <bead-id>
+//	ao beads scenarios extract <bead-id>    convert acceptance -> candidate block
+//	ao beads scenarios validate <bead-id>   check an authored block is well-formed
 //
-// It fetches the bead via `bd show <id> --json`, deterministically converts
-// the acceptance bullets into Given/When/Then triples, and prints a candidate
-// "## Scenarios" block to stdout. It is a dry-run: the bead is never modified.
-// Operator-confirmed write-back, idempotent guards, a validate subcommand, and
-// an LLM fallback are tracked as later slices of the parent feature (ag-dwq).
+// extract fetches the bead via `bd show <id> --json`, deterministically
+// converts the acceptance bullets into Given/When/Then triples, and prints a
+// candidate "## Scenarios" block to stdout. It is a dry-run: the bead is never
+// modified. validate parses an authored "## Scenarios" block and exits non-zero
+// when it is missing or malformed. Operator-confirmed write-back and an LLM
+// fallback are tracked as later slices of the parent feature (ag-dwq).
 package main
 
 import (
@@ -24,8 +26,9 @@ import (
 )
 
 var (
-	beadsScenariosJSON  bool
-	beadsScenariosForce bool
+	beadsScenariosJSON         bool
+	beadsScenariosForce        bool
+	beadsScenariosValidateJSON bool
 )
 
 // fetchedBead is the subset of a bead the scenarios command needs: the
@@ -55,7 +58,9 @@ var beadsScenariosCmd = &cobra.Command{
 Given/When/Then scenarios.
 
 The 'extract' subcommand is a dry-run: it prints a candidate '## Scenarios'
-block to stdout for review and never modifies the bead.`,
+block to stdout for review and never modifies the bead. The 'validate'
+subcommand checks that an authored '## Scenarios' block is well-formed Gherkin
+and exits non-zero (naming the parse error) when it is not.`,
 }
 
 var beadsScenariosExtractCmd = &cobra.Command{
@@ -76,13 +81,32 @@ acceptance.`,
 	RunE: runBeadsScenariosExtract,
 }
 
+var beadsScenariosValidateCmd = &cobra.Command{
+	Use:   "validate <bead-id>",
+	Short: "Check that a bead's authored '## Scenarios' block is well-formed Gherkin",
+	Args:  cobra.ExactArgs(1),
+	Long: `Read a bead via 'bd show <id> --json' and validate its authored
+'## Scenarios' block. Each scenario must declare a name and a Given/When/Then
+step (in that order) with a non-empty body; And/But lines are accepted as
+continuations.
+
+Exits 0 when the block is well-formed. Exits non-zero, naming the parse error,
+when the block is missing or malformed. With --json a verdict object is emitted
+on stdout ({"bead_id","valid","scenarios"} on success, or
+{"bead_id","valid":false,"error"} on failure) while diagnostics go to stderr.`,
+	RunE: runBeadsScenariosValidate,
+}
+
 func init() {
 	beadsCmd.AddCommand(beadsScenariosCmd)
 	beadsScenariosCmd.AddCommand(beadsScenariosExtractCmd)
+	beadsScenariosCmd.AddCommand(beadsScenariosValidateCmd)
 	beadsScenariosExtractCmd.Flags().BoolVar(&beadsScenariosJSON, "json", false,
 		"Emit extracted scenarios as JSON (data on stdout) instead of a Gherkin block")
 	beadsScenariosExtractCmd.Flags().BoolVar(&beadsScenariosForce, "force", false,
 		"Extract even when the bead already has a '## Scenarios' block")
+	beadsScenariosValidateCmd.Flags().BoolVar(&beadsScenariosValidateJSON, "json", false,
+		"Emit a structured validation verdict as JSON on stdout")
 }
 
 func runBeadsScenariosExtract(cmd *cobra.Command, args []string) error {
@@ -123,6 +147,57 @@ func runBeadsScenariosExtract(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Fprint(cmd.OutOrStdout(), scenarios.Render(extracted))
+	return nil
+}
+
+func runBeadsScenariosValidate(cmd *cobra.Command, args []string) error {
+	id := args[0]
+
+	if !bdAvailable() {
+		fmt.Fprintln(cmd.ErrOrStderr(),
+			"warning: bd not found on PATH; cannot fetch bead. Install bd or author scenarios manually.")
+		return nil
+	}
+
+	bead, err := beadsScenariosFetch(id)
+	if err != nil {
+		return fmt.Errorf("fetch bead %s: %w (inspect with 'bd show %s --json')", id, err, id)
+	}
+
+	// The authored '## Scenarios' block lives in the description; fall back to
+	// the acceptance field when the description carries no block.
+	text := bead.Description
+	if !scenarios.HasScenariosBlock(text) && scenarios.HasScenariosBlock(bead.Acceptance) {
+		text = bead.Acceptance
+	}
+
+	parsed, vErr := scenarios.ParseBlock(text)
+	if vErr != nil {
+		if beadsScenariosValidateJSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(struct {
+				BeadID string `json:"bead_id"`
+				Valid  bool   `json:"valid"`
+				Error  string `json:"error"`
+			}{BeadID: id, Valid: false, Error: vErr.Error()})
+		}
+		return fmt.Errorf(
+			"validate scenarios for %s: %w; fix the block or regenerate it with 'ao beads scenarios extract %s --force'",
+			id, vErr, id)
+	}
+
+	if beadsScenariosValidateJSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(struct {
+			BeadID    string               `json:"bead_id"`
+			Valid     bool                 `json:"valid"`
+			Scenarios []scenarios.Scenario `json:"scenarios"`
+		}{BeadID: id, Valid: true, Scenarios: parsed})
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "%s: %d scenario(s) well-formed\n", id, len(parsed))
 	return nil
 }
 

--- a/cli/cmd/ao/beads_scenarios_test.go
+++ b/cli/cmd/ao/beads_scenarios_test.go
@@ -42,6 +42,142 @@ func runScenariosExtract(t *testing.T, jsonOut bool, id string) (stdout, stderr 
 	return out.String(), errBuf.String(), err
 }
 
+func runScenariosValidate(t *testing.T, jsonOut bool, id string) (stdout, stderr string, err error) {
+	t.Helper()
+	beadsScenariosValidateJSON = jsonOut
+	t.Cleanup(func() { beadsScenariosValidateJSON = false })
+
+	var out, errBuf bytes.Buffer
+	beadsScenariosValidateCmd.SetOut(&out)
+	beadsScenariosValidateCmd.SetErr(&errBuf)
+	t.Cleanup(func() {
+		beadsScenariosValidateCmd.SetOut(nil)
+		beadsScenariosValidateCmd.SetErr(nil)
+	})
+
+	err = runBeadsScenariosValidate(beadsScenariosValidateCmd, []string{id})
+	return out.String(), errBuf.String(), err
+}
+
+func TestRunBeadsScenariosValidate_WellFormedExitsZero(t *testing.T) {
+	calls := withStubbedBD(t, true, func(args ...string) ([]byte, error) {
+		if len(args) >= 1 && args[0] == "show" {
+			return []byte(`[{"id":"ag-x","description":"prose\n\n## Scenarios\nScenario: ok\n  Given a\n  When b\n  Then c\n"}]`), nil
+		}
+		return nil, fmt.Errorf("unexpected bd call: %v", args)
+	})
+
+	stdout, _, err := runScenariosValidate(t, false, "ag-x")
+	if err != nil {
+		t.Fatalf("expected exit 0 for well-formed scenarios, got error: %v", err)
+	}
+	if !strings.Contains(stdout, "well-formed") {
+		t.Errorf("stdout should confirm well-formedness, got %q", stdout)
+	}
+	// Read-only contract: validate must never mutate the bead.
+	for _, c := range *calls {
+		if len(c) > 0 && c[0] == "update" {
+			t.Errorf("validate must not call bd update: %v", c)
+		}
+	}
+}
+
+func TestRunBeadsScenariosValidate_MalformedIsError(t *testing.T) {
+	withStubbedBD(t, true, func(args ...string) ([]byte, error) {
+		// Missing the When step — malformed.
+		return []byte(`[{"id":"ag-x","description":"## Scenarios\nScenario: broken\n  Given a\n  Then c\n"}]`), nil
+	})
+
+	_, _, err := runScenariosValidate(t, false, "ag-x")
+	if err == nil {
+		t.Fatal("expected a non-nil error (non-zero exit) for malformed scenarios")
+	}
+	if !strings.Contains(err.Error(), "When") {
+		t.Errorf("error should name the parse problem (missing When), got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "extract") {
+		t.Errorf("error should name the corrective command, got: %v", err)
+	}
+}
+
+func TestRunBeadsScenariosValidate_NoBlockIsError(t *testing.T) {
+	withStubbedBD(t, true, func(args ...string) ([]byte, error) {
+		return []byte(`[{"id":"ag-x","description":"just free text","acceptance_criteria":"no block here"}]`), nil
+	})
+
+	_, _, err := runScenariosValidate(t, false, "ag-x")
+	if err == nil {
+		t.Fatal("expected an error when no '## Scenarios' block is present")
+	}
+	if !strings.Contains(err.Error(), "Scenarios") {
+		t.Errorf("error should mention the missing block, got: %v", err)
+	}
+}
+
+func TestRunBeadsScenariosValidate_JSONVerdict(t *testing.T) {
+	withStubbedBD(t, true, func(args ...string) ([]byte, error) {
+		return []byte(`[{"id":"ag-x","description":"## Scenarios\nScenario: ok\n  Given a\n  When b\n  Then c\n"}]`), nil
+	})
+
+	stdout, _, err := runScenariosValidate(t, true, "ag-x")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var payload struct {
+		BeadID    string `json:"bead_id"`
+		Valid     bool   `json:"valid"`
+		Scenarios []struct {
+			Name string `json:"name"`
+		} `json:"scenarios"`
+	}
+	if jErr := json.Unmarshal([]byte(stdout), &payload); jErr != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", jErr, stdout)
+	}
+	if !payload.Valid || payload.BeadID != "ag-x" || len(payload.Scenarios) != 1 {
+		t.Errorf("unexpected verdict: %+v", payload)
+	}
+}
+
+func TestRunBeadsScenariosValidate_JSONFailureVerdictOnStdout(t *testing.T) {
+	withStubbedBD(t, true, func(args ...string) ([]byte, error) {
+		return []byte(`[{"id":"ag-x","description":"## Scenarios\nScenario: broken\n  Given a\n  Then c\n"}]`), nil
+	})
+
+	stdout, _, err := runScenariosValidate(t, true, "ag-x")
+	if err == nil {
+		t.Fatal("expected a non-nil error (non-zero exit) for malformed scenarios")
+	}
+	var payload struct {
+		BeadID string `json:"bead_id"`
+		Valid  bool   `json:"valid"`
+		Error  string `json:"error"`
+	}
+	if jErr := json.Unmarshal([]byte(stdout), &payload); jErr != nil {
+		t.Fatalf("failure verdict on stdout is not valid JSON: %v\n%s", jErr, stdout)
+	}
+	if payload.Valid || payload.BeadID != "ag-x" || payload.Error == "" {
+		t.Errorf("unexpected failure verdict: %+v", payload)
+	}
+}
+
+func TestRunBeadsScenariosValidate_BDUnavailableWarnsAndSucceeds(t *testing.T) {
+	withStubbedBD(t, false, func(args ...string) ([]byte, error) {
+		t.Fatalf("execBD must not be called when bd is unavailable: %v", args)
+		return nil, nil
+	})
+
+	stdout, stderr, err := runScenariosValidate(t, false, "ag-x")
+	if err != nil {
+		t.Fatalf("expected graceful exit, got error: %v", err)
+	}
+	if stdout != "" {
+		t.Errorf("expected empty stdout when bd unavailable, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "bd not found") {
+		t.Errorf("expected a bd-not-found warning on stderr, got %q", stderr)
+	}
+}
+
 func TestRunBeadsScenariosExtract_PrintsGherkinToStdout(t *testing.T) {
 	calls := withStubbedBD(t, true, func(args ...string) ([]byte, error) {
 		if len(args) >= 1 && args[0] == "show" {

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -2805,6 +2805,21 @@ ao beads scenarios extract <bead-id> [flags]
       --json    Emit extracted scenarios as JSON (data on stdout) instead of a Gherkin block
 ```
 
+##### `ao beads scenarios validate`
+
+Read a bead via 'bd show <id> --json' and validate its authored
+
+```
+ao beads scenarios validate <bead-id> [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help   help for validate
+      --json   Emit a structured validation verdict as JSON on stdout
+```
+
 #### `ao beads stale-claims`
 
 Lists in_progress beads whose claim activity is older than --threshold.

--- a/cli/internal/scenarios/validate.go
+++ b/cli/internal/scenarios/validate.go
@@ -1,0 +1,223 @@
+package scenarios
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Validate reports whether text carries a well-formed "## Scenarios" Gherkin
+// block. It returns nil when every scenario parses cleanly, or an error naming
+// the first well-formedness problem (no block, no scenario, a scenario missing
+// its name or a Given/When/Then step, steps out of order, or an empty step
+// body). It is the inverse acceptance gate of Extract/Render: any block Render
+// produces passes Validate.
+func Validate(text string) error {
+	_, err := ParseBlock(text)
+	return err
+}
+
+// gherkinStep is one parsed step line: a canonical lowercase keyword
+// (given/when/then/and/but) and its body text.
+type gherkinStep struct {
+	kw   string
+	body string
+}
+
+// rawScenario is a scenario's heading name and its collected step lines before
+// well-formedness has been checked.
+type rawScenario struct {
+	name  string
+	steps []gherkinStep
+}
+
+// ParseBlock parses the authored "## Scenarios" block embedded in text — the
+// multi-line Gherkin form that Render produces — into structured scenarios. It
+// returns an error naming the first well-formedness problem. Each scenario must
+// declare a name and contain a Given, a When, and a Then step in that order,
+// each with a non-empty body; And/But lines are accepted as continuations of
+// the preceding primary step.
+func ParseBlock(text string) ([]Scenario, error) {
+	block, ok := scenariosBlock(text)
+	if !ok {
+		return nil, fmt.Errorf("no '## Scenarios' block found")
+	}
+	raws := groupScenarios(block)
+	if len(raws) == 0 {
+		return nil, fmt.Errorf("'## Scenarios' block contains no 'Scenario:' entries")
+	}
+	out := make([]Scenario, 0, len(raws))
+	for i, r := range raws {
+		s, err := r.assemble(i + 1)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// groupScenarios splits block lines into scenarios keyed by their "Scenario:"
+// headings. Blank lines, comments, and step-shaped lines before the first
+// heading are ignored — they belong to no scenario.
+func groupScenarios(block []string) []rawScenario {
+	var raws []rawScenario
+	curIdx := -1
+	for _, line := range block {
+		t := strings.TrimSpace(line)
+		if t == "" {
+			continue
+		}
+		if name, ok := scenarioHeading(t); ok {
+			raws = append(raws, rawScenario{name: name})
+			curIdx = len(raws) - 1
+			continue
+		}
+		if curIdx < 0 {
+			continue
+		}
+		if kw, body, ok := stepLine(t); ok {
+			raws[curIdx].steps = append(raws[curIdx].steps, gherkinStep{kw: kw, body: body})
+		}
+	}
+	return raws
+}
+
+// assemble validates one raw scenario and returns its structured form. n is the
+// 1-based position used to identify an unnamed scenario in errors.
+func (r rawScenario) assemble(n int) (Scenario, error) {
+	if r.name == "" {
+		return Scenario{}, fmt.Errorf("scenario #%d: missing name after 'Scenario:'", n)
+	}
+	var prevPrimary string
+	firstGiven, firstWhen, firstThen := -1, -1, -1
+	var givenBody, whenBody, thenBody string
+	for si, st := range r.steps {
+		phase := st.kw
+		if phase == "and" || phase == "but" {
+			if prevPrimary == "" {
+				return Scenario{}, fmt.Errorf("scenario %q: '%s' step before any Given/When/Then", r.name, st.kw)
+			}
+			phase = prevPrimary
+		} else {
+			prevPrimary = phase
+		}
+		if st.body == "" {
+			return Scenario{}, fmt.Errorf("scenario %q: empty %s step body", r.name, title(st.kw))
+		}
+		switch phase {
+		case "given":
+			if firstGiven < 0 {
+				firstGiven, givenBody = si, st.body
+			}
+		case "when":
+			if firstWhen < 0 {
+				firstWhen, whenBody = si, st.body
+			}
+		case "then":
+			if firstThen < 0 {
+				firstThen, thenBody = si, st.body
+			}
+		}
+	}
+	if err := checkStepOrder(r.name, firstGiven, firstWhen, firstThen); err != nil {
+		return Scenario{}, err
+	}
+	return Scenario{Name: r.name, Given: givenBody, When: whenBody, Then: thenBody}, nil
+}
+
+// checkStepOrder verifies a scenario has a Given, a When, and a Then step, in
+// that order. The arguments are the first-occurrence indices of each step type,
+// or -1 when absent.
+func checkStepOrder(name string, given, when, then int) error {
+	if given < 0 {
+		return fmt.Errorf("scenario %q: missing Given step", name)
+	}
+	if when < 0 {
+		return fmt.Errorf("scenario %q: missing When step", name)
+	}
+	if then < 0 {
+		return fmt.Errorf("scenario %q: missing Then step", name)
+	}
+	if !(given < when && when < then) {
+		return fmt.Errorf("scenario %q: steps out of order (expected Given before When before Then)", name)
+	}
+	return nil
+}
+
+// scenariosBlock returns the lines of the "## Scenarios" block — those after
+// the heading whose first word is "Scenarios" (case-insensitive), up to the
+// next markdown heading or end of text. ok is false when no such heading
+// exists.
+func scenariosBlock(text string) ([]string, bool) {
+	lines := strings.Split(text, "\n")
+	start := -1
+	for i, line := range lines {
+		t := strings.TrimSpace(line)
+		if !strings.HasPrefix(t, "#") {
+			continue
+		}
+		heading := strings.TrimSpace(strings.TrimLeft(t, "#"))
+		word := heading
+		if j := strings.IndexAny(heading, " \t"); j >= 0 {
+			word = heading[:j]
+		}
+		if strings.EqualFold(word, "Scenarios") {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return nil, false
+	}
+	var block []string
+	for _, line := range lines[start+1:] {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			break
+		}
+		block = append(block, line)
+	}
+	return block, true
+}
+
+// scenarioHeading reports whether a trimmed line opens a scenario and returns
+// its (possibly empty) name. It matches "Scenario:" and "Scenario Outline:"
+// case-insensitively.
+func scenarioHeading(t string) (string, bool) {
+	lower := strings.ToLower(t)
+	for _, prefix := range []string{"scenario outline:", "scenario:"} {
+		if strings.HasPrefix(lower, prefix) {
+			return strings.TrimSpace(t[len(prefix):]), true
+		}
+	}
+	return "", false
+}
+
+// stepLine reports whether a trimmed line is a Gherkin step and returns its
+// canonical lowercase keyword and body. The keyword must be a whole word
+// (Given/When/Then/And/But, case-insensitive) followed by whitespace or end of
+// line; the body is the remainder, trimmed. A keyword with no body returns an
+// empty body so the caller can flag it.
+func stepLine(t string) (kw, body string, ok bool) {
+	lower := strings.ToLower(t)
+	for _, k := range []string{"given", "when", "then", "and", "but"} {
+		if lower == k {
+			return k, "", true
+		}
+		if strings.HasPrefix(lower, k) {
+			rest := t[len(k):]
+			if rest != "" && (rest[0] == ' ' || rest[0] == '\t') {
+				return k, strings.TrimSpace(rest), true
+			}
+		}
+	}
+	return "", "", false
+}
+
+// title upper-cases the first letter of a step keyword for human-facing error
+// messages ("when" -> "When").
+func title(kw string) string {
+	if kw == "" {
+		return kw
+	}
+	return strings.ToUpper(kw[:1]) + kw[1:]
+}

--- a/cli/internal/scenarios/validate_test.go
+++ b/cli/internal/scenarios/validate_test.go
@@ -1,0 +1,147 @@
+package scenarios
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseBlock(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    string
+		wantN   int    // expected scenario count on success (ignored when wantErr set)
+		wantErr string // substring expected in the error; "" means expect no error
+		check   func(t *testing.T, got []Scenario)
+	}{
+		{
+			name:  "well-formed single scenario",
+			text:  "## Scenarios\n\nScenario: extract prints a block\n  Given a bead with free-text acceptance\n  When extract runs\n  Then a Gherkin block is printed\n",
+			wantN: 1,
+			check: func(t *testing.T, got []Scenario) {
+				if got[0].Name != "extract prints a block" {
+					t.Errorf("name = %q", got[0].Name)
+				}
+				if got[0].Given != "a bead with free-text acceptance" || got[0].When != "extract runs" || got[0].Then != "a Gherkin block is printed" {
+					t.Errorf("clauses = %+v", got[0])
+				}
+			},
+		},
+		{
+			name:  "well-formed multiple scenarios",
+			text:  "## Scenarios\nScenario: one\n  Given a\n  When b\n  Then c\nScenario: two\n  Given d\n  When e\n  Then f\n",
+			wantN: 2,
+		},
+		{
+			name:  "well-formed with And/But continuations",
+			text:  "## Scenarios\nScenario: with continuations\n  Given a precondition\n  And another precondition\n  When the action happens\n  Then a result\n  But not the other result\n",
+			wantN: 1,
+		},
+		{
+			name:  "block is bounded by a following markdown heading",
+			text:  "## Scenarios\nScenario: real\n  Given a\n  When b\n  Then c\n\n## Notes\nScenario: ghost\n  Given only-a-given\n",
+			wantN: 1,
+			check: func(t *testing.T, got []Scenario) {
+				if got[0].Name != "real" {
+					t.Errorf("expected only the in-block scenario, got %+v", got)
+				}
+			},
+		},
+		{
+			name:  "scenarios block lives after descriptive prose",
+			text:  "Slice 4 of ag-dwq. Adds a validator.\n\n## Scenarios\nScenario: parses after prose\n  Given a description with leading prose\n  When validate runs\n  Then it parses the block\n",
+			wantN: 1,
+		},
+		{
+			name:    "no scenarios block",
+			text:    "Just some free-text acceptance with no block.\n- bullet one\n- bullet two\n",
+			wantErr: "no '## Scenarios' block found",
+		},
+		{
+			name:    "block present but no Scenario entries",
+			text:    "## Scenarios\n\n(to be authored)\n",
+			wantErr: "no 'Scenario:' entries",
+		},
+		{
+			name:    "scenario missing a name",
+			text:    "## Scenarios\nScenario:\n  Given a\n  When b\n  Then c\n",
+			wantErr: "missing name",
+		},
+		{
+			name:    "scenario missing Given step",
+			text:    "## Scenarios\nScenario: no given\n  When b\n  Then c\n",
+			wantErr: "missing Given step",
+		},
+		{
+			name:    "scenario missing When step",
+			text:    "## Scenarios\nScenario: no when\n  Given a\n  Then c\n",
+			wantErr: "missing When step",
+		},
+		{
+			name:    "scenario missing Then step",
+			text:    "## Scenarios\nScenario: no then\n  Given a\n  When b\n",
+			wantErr: "missing Then step",
+		},
+		{
+			name:    "scenario steps out of order",
+			text:    "## Scenarios\nScenario: reversed\n  Given a\n  Then c\n  When b\n",
+			wantErr: "out of order",
+		},
+		{
+			name:    "scenario with an empty step body",
+			text:    "## Scenarios\nScenario: empty when\n  Given a\n  When\n  Then c\n",
+			wantErr: "empty When step",
+		},
+		{
+			name:    "And step before any primary keyword",
+			text:    "## Scenarios\nScenario: leading and\n  And a\n  Given b\n  When c\n  Then d\n",
+			wantErr: "before any Given/When/Then",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseBlock(tt.text)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ParseBlock() = %+v, want error containing %q", got, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != tt.wantN {
+				t.Fatalf("got %d scenarios, want %d: %+v", len(got), tt.wantN, got)
+			}
+			if tt.check != nil {
+				tt.check(t, got)
+			}
+		})
+	}
+}
+
+func TestValidate_WellFormedReturnsNil(t *testing.T) {
+	text := "## Scenarios\nScenario: ok\n  Given a\n  When b\n  Then c\n"
+	if err := Validate(text); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
+	}
+}
+
+func TestValidate_MalformedReturnsError(t *testing.T) {
+	text := "## Scenarios\nScenario: broken\n  Given a\n  Then c\n"
+	if err := Validate(text); err == nil {
+		t.Fatal("Validate() = nil, want error naming the missing When step")
+	}
+}
+
+func TestValidate_RoundTripRenderOutput(t *testing.T) {
+	// A block produced by Render must always pass Validate — the validator is
+	// the inverse acceptance gate of the extractor.
+	rendered := Render([]Scenario{{Name: "n", Given: "a", When: "b", Then: "c"}})
+	if err := Validate(rendered); err != nil {
+		t.Fatalf("Render output failed Validate: %v\n%s", err, rendered)
+	}
+}


### PR DESCRIPTION
## Summary

Slice 4 of **ag-dwq** (child bead **ag-5cz**). Adds `ao beads scenarios validate <bead-id>`: a read-only, **dependency-free** validator for an authored `## Scenarios` Gherkin block. It is the inverse acceptance gate of the `extract` slice (#567) — extract turns acceptance into a candidate block; validate confirms an authored block is well-formed.

- **`cli/internal/scenarios/validate.go`** (new, pure domain): `ParseBlock(text) ([]Scenario, error)` + `Validate(text) error`. A deterministic in-repo parser — **no `github.com/cucumber/gherkin-go` dependency** (the bead's open design question, resolved toward the repo's established dependency-free pattern). Each scenario must declare a name and a Given/When/Then step in that order with a non-empty body; `And`/`But` lines are accepted as continuations. Refactored into `groupScenarios`/`assemble`/`checkStepOrder` to stay under the cyclomatic-complexity budget (max 14 < 25).
- **`cli/cmd/ao/beads_scenarios.go`**: `validate` subcommand under the existing `ao beads scenarios` surface. Agent-ergonomic (Directive 13): exits 0 when well-formed, non-zero **naming the parse error** otherwise; `--json` emits a verdict object (`{bead_id,valid,scenarios}` on success / `{bead_id,valid:false,error}` on failure) on **stdout** with diagnostics on **stderr**; `bd`-unavailable degrades gracefully (warn + exit 0).
- **`cli/docs/COMMANDS.md`** regenerated. `capabilities` / `robot-docs` pick the command up automatically via the live command-tree walk. Surface heading counts are **unchanged** (validate is a `#####` leaf under the existing beads-scenarios group, so the `#{3,4}` command-surface canary is unaffected).

### Out of scope (remaining ag-dwq slices)
`--write` / operator-confirmed bead update (**ag-3gm**) · LLM fallback for non-deterministic prose. Parent **ag-dwq** stays OPEN.

## Test plan

- [x] `cd cli && go test ./internal/scenarios/...` — 14-case `TestParseBlock` table (well-formed single/multi, And/But continuations, block bounded by following heading, prose-prefixed block, no-block, no-Scenario, missing-name, missing Given/When/Then, out-of-order, empty-body, And-before-primary) + Validate nil/error + Render round-trip
- [x] `cd cli && go test ./cmd/ao -run Scenarios` — L2 with stubbed `bd`: well-formed exit 0, malformed error, no-block error, `--json` success/failure verdicts, bd-unavailable graceful, read-only contract (no `bd update`)
- [x] `cd cli && go build ./... && go vet ./... && go test ./...` — 11951 passed, 69 packages, 0 failures
- [x] Real binary: `ao beads scenarios validate ag-3gm` → exit 0 (1 scenario well-formed); `ag-dwq` (free-text) → exit 1 naming the missing block; `--json` verdicts valid
- [x] `gocyclo -over 15 internal/scenarios/` — clean; `scripts/generate-cli-reference.sh --check` — up to date; command-surface smoke — `top=69 sub=174 all=243`, exit 0

Closes-scenario: ag-5cz#scenarios-validate
Bounded-context: BC1-Corpus
Evidence: cd cli && go test ./internal/scenarios/... ./cmd/ao -run Scenarios