### PR TITLE
docs(release): correct extract-release-notes.sh header to match killed fallback (ag-d0f #fallback-comment)

### DIFF
--- a/scripts/extract-release-notes.sh
+++ b/scripts/extract-release-notes.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
-# Extract release notes for a given version from CHANGELOG.md.
-# Generates user-facing highlights + full changelog for GitHub Release page.
+# Assemble the GitHub Release body for a given version.
+# Body = curated highlights + the version's CHANGELOG section embedded in <details>.
 #
 # Usage: scripts/extract-release-notes.sh v2.9.2 [v2.9.0]
 #   $1 = current tag (required)
 #   $2 = previous tag (optional, for footer link)
 #
-# Expects: docs/releases/YYYY-MM-DD-v<version>-notes.md for curated highlights.
-# Falls back to CHANGELOG.md extraction if no curated notes exist.
+# Requires: docs/releases/YYYY-MM-DD-v<version>-notes.md curated highlights AND a
+# matching CHANGELOG.md section. There is NO fallback to a raw CHANGELOG dump — a
+# missing curated file or CHANGELOG entry is a hard error (3.0.0/3.0.1 shipped raw
+# dumps precisely because this used to fall back). Structure is enforced by
+# scripts/validate-release-notes.sh.
 #
 # Output: writes release-notes.md to repo root
 


### PR DESCRIPTION
## Summary
- The `ag-d0f` "kill the silent fallback" change made `scripts/extract-release-notes.sh` hard-error when no curated `docs/releases/*-notes.md` exists (lines 50–60), but the file header still advertised *"Falls back to CHANGELOG.md extraction if no curated notes exist."*
- That comment contradicted the implemented behavior and could mislead a maintainer about release-pipeline behavior (the exact class of silent-fallback confusion that shipped raw CHANGELOG dumps as the 3.0.0/3.0.1 release bodies).
- Rewrites the header docstring to state the no-fallback contract: curated notes + matching CHANGELOG section are required; a missing file is a hard error; structure is enforced by `scripts/validate-release-notes.sh`.

Comment-only change — no behavior change.

## Test plan
- [x] `shellcheck scripts/extract-release-notes.sh` — clean
- [x] `bats tests/scripts/validate-release-notes.bats` — 14/14 green
- [x] `git diff --stat` — 7/-4, comment lines only

Closes-scenario: ag-d0f#fallback-comment
Bounded-context: BC5-Runtime
Evidence: scripts/extract-release-notes.sh; bats tests/scripts/validate-release-notes.bats (14/14)