### PR TITLE
feat(beads): ao beads scenarios extract --write — operator-confirmed write-back (ag-3gm #write-confirm)

### DIFF
--- a/cli/cmd/ao/beads_scenarios.go
+++ b/cli/cmd/ao/beads_scenarios.go
@@ -8,16 +8,20 @@
 //
 // extract fetches the bead via `bd show <id> --json`, deterministically
 // converts the acceptance bullets into Given/When/Then triples, and prints a
-// candidate "## Scenarios" block to stdout. It is a dry-run: the bead is never
-// modified. validate parses an authored "## Scenarios" block and exits non-zero
-// when it is missing or malformed. Operator-confirmed write-back and an LLM
-// fallback are tracked as later slices of the parent feature (ag-dwq).
+// candidate "## Scenarios" block to stdout. By default it is a dry-run: the
+// bead is never modified. With --write it appends the block to the bead's
+// description via `bd update`, but only after an operator y/N confirmation.
+// validate parses an authored "## Scenarios" block and exits non-zero when it
+// is missing or malformed. An LLM fallback for unparseable acceptance is
+// tracked as a later slice of the parent feature (ag-dwq).
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -28,6 +32,7 @@ import (
 var (
 	beadsScenariosJSON         bool
 	beadsScenariosForce        bool
+	beadsScenariosWrite        bool
 	beadsScenariosValidateJSON bool
 )
 
@@ -71,9 +76,11 @@ var beadsScenariosExtractCmd = &cobra.Command{
 free-text bullets into Given/When/Then scenarios using deterministic rules,
 and print a candidate '## Scenarios' block to stdout.
 
-This is a dry-run — the bead is never modified. Review the output and author
-it into the bead manually. With --json the scenarios are emitted as structured
-data on stdout instead of a Gherkin block.
+By default this is a dry-run — the bead is never modified. Review the output
+and author it into the bead manually. With --json the scenarios are emitted as
+structured data on stdout instead of a Gherkin block. With --write the block is
+appended to the bead's description via 'bd update', but only after you confirm
+the printed block at a y/N prompt; declining leaves the bead unchanged.
 
 If the bead already carries a '## Scenarios' block, extract refuses (nothing to
 do) unless --force is passed, to avoid generating noise over already-shaped
@@ -105,6 +112,8 @@ func init() {
 		"Emit extracted scenarios as JSON (data on stdout) instead of a Gherkin block")
 	beadsScenariosExtractCmd.Flags().BoolVar(&beadsScenariosForce, "force", false,
 		"Extract even when the bead already has a '## Scenarios' block")
+	beadsScenariosExtractCmd.Flags().BoolVar(&beadsScenariosWrite, "write", false,
+		"After printing the block and an operator y/N confirmation, append it to the bead via 'bd update'")
 	beadsScenariosValidateCmd.Flags().BoolVar(&beadsScenariosValidateJSON, "json", false,
 		"Emit a structured validation verdict as JSON on stdout")
 }
@@ -137,6 +146,10 @@ func runBeadsScenariosExtract(cmd *cobra.Command, args []string) error {
 			id, err)
 	}
 
+	if beadsScenariosWrite {
+		return writeExtractedScenarios(cmd, id, bead, extracted)
+	}
+
 	if beadsScenariosJSON {
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
@@ -148,6 +161,55 @@ func runBeadsScenariosExtract(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprint(cmd.OutOrStdout(), scenarios.Render(extracted))
 	return nil
+}
+
+// writeExtractedScenarios prints the candidate block, asks the operator for a
+// y/N confirmation on stdin, and — only when confirmed — appends the block to
+// the bead's description via `bd update`. Declining leaves the bead unchanged.
+// The block is appended (not replacing the description) so the original
+// acceptance prose is preserved.
+func writeExtractedScenarios(cmd *cobra.Command, id string, bead fetchedBead, extracted []scenarios.Scenario) error {
+	rendered := scenarios.Render(extracted)
+	fmt.Fprintf(cmd.ErrOrStderr(),
+		"About to append this block to %s's description:\n\n%s\nProceed? [y/N]: ", id, rendered)
+
+	if !confirmScenarioWrite(cmd.InOrStdin()) {
+		fmt.Fprintf(cmd.ErrOrStderr(), "aborted; %s left unchanged\n", id)
+		return nil
+	}
+
+	newDesc := composeDescriptionWithScenarios(bead.Description, rendered)
+	if _, err := execBD("update", id, "--description", newDesc); err != nil {
+		return fmt.Errorf("write '## Scenarios' into %s: %w (inspect with 'bd show %s')", id, err, id)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "%s updated with %d scenario(s)\n", id, len(extracted))
+	return nil
+}
+
+// confirmScenarioWrite reads a single line and treats "y"/"yes"
+// (case-insensitive) as confirmation. Any other input — including EOF or an
+// empty line — is a decline, so the default is the safe no-op.
+func confirmScenarioWrite(r io.Reader) bool {
+	line, _ := bufio.NewReader(r).ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+// composeDescriptionWithScenarios appends the rendered block to the existing
+// description with a blank-line separator, preserving the original text. When
+// the description is empty the block stands alone.
+func composeDescriptionWithScenarios(desc, rendered string) string {
+	block := strings.TrimRight(rendered, "\n")
+	base := strings.TrimRight(desc, "\n")
+	if base == "" {
+		return block + "\n"
+	}
+	return base + "\n\n" + block + "\n"
 }
 
 func runBeadsScenariosValidate(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/ao/beads_scenarios_test.go
+++ b/cli/cmd/ao/beads_scenarios_test.go
@@ -59,6 +59,89 @@ func runScenariosValidate(t *testing.T, jsonOut bool, id string) (stdout, stderr
 	return out.String(), errBuf.String(), err
 }
 
+// runScenariosExtractWrite runs extract in --write mode with a canned stdin
+// response for the y/N confirmation prompt.
+func runScenariosExtractWrite(t *testing.T, id, stdin string) (stdout, stderr string, err error) {
+	t.Helper()
+	beadsScenariosWrite = true
+	t.Cleanup(func() { beadsScenariosWrite = false })
+
+	var out, errBuf bytes.Buffer
+	beadsScenariosExtractCmd.SetOut(&out)
+	beadsScenariosExtractCmd.SetErr(&errBuf)
+	beadsScenariosExtractCmd.SetIn(strings.NewReader(stdin))
+	t.Cleanup(func() {
+		beadsScenariosExtractCmd.SetOut(nil)
+		beadsScenariosExtractCmd.SetErr(nil)
+		beadsScenariosExtractCmd.SetIn(nil)
+	})
+
+	err = runBeadsScenariosExtract(beadsScenariosExtractCmd, []string{id})
+	return out.String(), errBuf.String(), err
+}
+
+func TestRunBeadsScenariosExtract_WriteUpdatesBeadAfterConfirmation(t *testing.T) {
+	var updateDesc string
+	calls := withStubbedBD(t, true, func(args ...string) ([]byte, error) {
+		switch {
+		case len(args) >= 1 && args[0] == "show":
+			return []byte(`[{"id":"ag-x","acceptance_criteria":"Given a bead when extract runs then a block is written","description":"original prose"}]`), nil
+		case len(args) >= 1 && args[0] == "update":
+			for i := 0; i+1 < len(args); i++ {
+				if args[i] == "--description" || args[i] == "-d" {
+					updateDesc = args[i+1]
+				}
+			}
+			return []byte("ok"), nil
+		}
+		return nil, fmt.Errorf("unexpected bd call: %v", args)
+	})
+
+	_, _, err := runScenariosExtractWrite(t, "ag-x", "y\n")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var updated bool
+	for _, c := range *calls {
+		if len(c) > 0 && c[0] == "update" {
+			updated = true
+		}
+	}
+	if !updated {
+		t.Fatal("expected 'bd update' after confirmation; bead was not written")
+	}
+	if !strings.Contains(updateDesc, "## Scenarios") {
+		t.Errorf("written description must carry the '## Scenarios' block, got %q", updateDesc)
+	}
+	// Lossless write: the original description text must be preserved.
+	if !strings.Contains(updateDesc, "original prose") {
+		t.Errorf("written description must preserve the original prose, got %q", updateDesc)
+	}
+}
+
+func TestRunBeadsScenariosExtract_WriteAbortsWithoutConfirmation(t *testing.T) {
+	calls := withStubbedBD(t, true, func(args ...string) ([]byte, error) {
+		if len(args) >= 1 && args[0] == "show" {
+			return []byte(`[{"id":"ag-x","acceptance_criteria":"Given a bead when extract runs then a block is written","description":"original prose"}]`), nil
+		}
+		return nil, fmt.Errorf("unexpected bd call: %v", args)
+	})
+
+	_, stderr, err := runScenariosExtractWrite(t, "ag-x", "n\n")
+	if err != nil {
+		t.Fatalf("declining the prompt should exit gracefully, got error: %v", err)
+	}
+	for _, c := range *calls {
+		if len(c) > 0 && c[0] == "update" {
+			t.Errorf("without confirmation the bead must be unchanged; 'bd update' was called: %v", c)
+		}
+	}
+	if !strings.Contains(stderr, "unchanged") {
+		t.Errorf("stderr should report the bead was left unchanged, got %q", stderr)
+	}
+}
+
 func TestRunBeadsScenariosValidate_WellFormedExitsZero(t *testing.T) {
 	calls := withStubbedBD(t, true, func(args ...string) ([]byte, error) {
 		if len(args) >= 1 && args[0] == "show" {

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -2803,6 +2803,7 @@ ao beads scenarios extract <bead-id> [flags]
       --force   Extract even when the bead already has a '## Scenarios' block
   -h, --help    help for extract
       --json    Emit extracted scenarios as JSON (data on stdout) instead of a Gherkin block
+      --write   After printing the block and an operator y/N confirmation, append it to the bead via 'bd update'
 ```
 
 ##### `ao beads scenarios validate`


### PR DESCRIPTION
## Summary

Slice 2 of **ag-dwq** (the bead-acceptance → Gherkin extractor line). Adds `--write` to `ao beads scenarios extract <id>`:

- After printing the candidate block and a `y/N` prompt, appends the rendered `## Scenarios` block to the bead's description via `bd update` — **only on confirmation**.
- Declining (or EOF / empty input) leaves the bead unchanged (safe default).
- The block is **appended**, not replacing the description, so the original acceptance prose is preserved (lossless).
- `--write` short-circuits behind the existing already-has-block guard, so it won't duplicate an authored block unless `--force` is also passed.

Read-only `extract` (dry-run) and `validate` behavior are untouched. Closes the `--write` slice of the extractor; the LLM-prose fallback remains a separate later slice of ag-dwq.

## Test plan

- [x] Test-first: 2 new L2 tests map to the bead's single Given/When/Then — confirm → lossless write (`bd update` carries `## Scenarios` + preserves original prose); decline → no `bd update` (bead unchanged).
- [x] `cd cli && go build ./... && go vet ./cmd/ao` clean.
- [x] `cd cli && go test ./cmd/ao` green (full package).
- [x] `scripts/generate-cli-reference.sh` regenerated `COMMANDS.md` (only the `--write` flag line added).

Closes-scenario: ag-3gm#write-confirm
Bounded-context: BC1-Corpus
Evidence: cd cli && go test ./cmd/ao -run 'TestRunBeadsScenariosExtract_Write'