### PR TITLE
docs(skills): autodev reads as config not loop (soc-ozoqh #autodev-config)

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -65,7 +65,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 
 ### supporting
 
-- `autodev` — Manage bounded autonomous dev loops.
+- `autodev` — Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer Evolve and Factory read each tick, not a loop itself.
 - `codex-team` — Coordinate multiple Codex agents.
 - `compile` — Compile .agents knowledge wiki.
 - `curate` — Mine transcripts, .agents, bd, and git for skill diffs, bd updates, or rare wiki entries.

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-05-28T03:04:05Z",
+  "generated_at": "2026-05-28T10:23:15Z",
   "summary": {
     "skills": 75,
     "hooks": 0,
@@ -1425,7 +1425,7 @@
       "bounded_context": "BC3",
       "hex_role": "supporting",
       "tier": "execution",
-      "purpose": "Manage bounded autonomous dev loops.",
+      "purpose": "Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer Evolve and Factory read each tick, not a loop itself.",
       "status": "active",
       "disposition": "refactor",
       "consumes": [

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -649,8 +649,8 @@
     {
       "name": "autodev",
       "source_skill": "skills/autodev",
-      "source_hash": "4ad1828489b40ea336c593c1b04054b5c0faa1cc194ce2bc29c49fa8aa8cd9ec",
-      "generated_hash": "7fe2526d5e4792cb4b52e59745010fb752547b5163495e59904a13e4535f4024"
+      "source_hash": "9b4ecf0399c67b1d55675b293ec382b7b7e4e6cafccec40eda2c7b6da16437b6",
+      "generated_hash": "14c906b0518abe580eea344c034d466efa92f138f2a85f3465dec2e70b609ff9"
     },
     {
       "name": "beads",

--- a/skills-codex/autodev/.agentops-generated.json
+++ b/skills-codex/autodev/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/autodev",
   "layout": "modular",
-  "source_hash": "4ad1828489b40ea336c593c1b04054b5c0faa1cc194ce2bc29c49fa8aa8cd9ec",
-  "generated_hash": "7fe2526d5e4792cb4b52e59745010fb752547b5163495e59904a13e4535f4024"
+  "source_hash": "9b4ecf0399c67b1d55675b293ec382b7b7e4e6cafccec40eda2c7b6da16437b6",
+  "generated_hash": "14c906b0518abe580eea344c034d466efa92f138f2a85f3465dec2e70b609ff9"
 }

--- a/skills-codex/autodev/SKILL.md
+++ b/skills-codex/autodev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autodev
-description: 'Manage bounded autonomous dev loops.'
+description: 'Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer Evolve and Factory read each tick, not a loop itself.'
 ---
 # $autodev
 

--- a/skills/autodev/SKILL.md
+++ b/skills/autodev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autodev
-description: Manage bounded autonomous dev loops.
+description: Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer Evolve and Factory read each tick, not a loop itself.
 practices:
 - cmm-process-maturity
 - ai-assisted-dev
@@ -33,7 +33,7 @@ It does not replace `/evolve` or `/rpi`.
 
 ## Loop position
 
-Bounded executor of the full [operating loop](../../docs/architecture/operating-loop.md): BDD intent → vertical slices → conflict-free wave → bead acceptance → evidence. `/autodev` runs the loop unattended within the contract declared in `PROGRAM.md`/`AUTODEV.md` — mutable scope, immutable scope, validation commands, escalation rules, stop conditions. Loop discipline still applies under autonomy: no parallel wave without the wave-validity check; no slice closes without a passing test mapped to a Given/When/Then; capture goes through the promotion ratchet, not into a landfill.
+The config/intent layer the [operating loop](../../docs/architecture/operating-loop.md) reads each tick — NOT a loop itself. `/autodev` defines and validates the contract declared in `PROGRAM.md`/`AUTODEV.md` — mutable scope, immutable scope, validation commands, escalation rules, stop conditions. The drivers ([`/evolve`](../evolve/SKILL.md) and Factory, the daemon) consume that contract and run the loop; autodev does not run it. Loop discipline still applies under autonomy: no parallel wave without the wave-validity check; no slice closes without a passing test mapped to a Given/When/Then; capture goes through the promotion ratchet, not into a landfill.
 
 - `PROGRAM.md` or `AUTODEV.md` defines the contract: mutable scope, immutable
   scope, experiment unit, validation commands, decision policy, escalation rules,

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-25T02:39:14Z",
+  "generated_at": "2026-05-28T10:23:15Z",
   "skill_count": 75,
   "skills": [
     {
       "name": "autodev",
-      "description": "Manage bounded autonomous dev loops.",
+      "description": "Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer Evolve and Factory read each tick, not a loop itself.",
       "hexagonal_role": "supporting",
       "user_invocable": true,
       "consumes": [

--- a/tests/scripts/autodev-skill-positioning.bats
+++ b/tests/scripts/autodev-skill-positioning.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+#
+# soc-ozoqh scenario 1: "autodev reads as config not loop".
+#
+# The canonical vocabulary rule skills/domain/references/autodev.md:9,13 says
+# autodev is the config/intent layer the loop reads — NOT a loop — and that its
+# positioning must "never lead with 'bounded autonomous dev loops'". This gate
+# pins the autodev skill description + its generated mirrors to that rule so the
+# corpus cannot drift back to loop-framing.
+#
+# Scoped to the autodev skill + generated catalogs. The style guide
+# skills/domain/references/autodev.md is intentionally NOT checked: it QUOTES the
+# banned phrase as the anti-pattern it forbids, so banning it there is self-defeating.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export REPO_ROOT
+    SKILL="$REPO_ROOT/skills/autodev/SKILL.md"
+    DESC_LINE="$(grep -m1 '^description:' "$SKILL")"
+}
+
+BANNED="bounded autonomous dev loops"
+
+@test "autodev skill description drops the loop-framing phrase" {
+    [[ "$DESC_LINE" != *"$BANNED"* ]]
+}
+
+@test "autodev skill description leads with the PROGRAM.md/AUTODEV.md contract" {
+    [[ "$DESC_LINE" == *"PROGRAM.md"* || "$DESC_LINE" == *"AUTODEV.md"* ]]
+    [[ "$DESC_LINE" == *"contract"* ]]
+}
+
+@test "autodev skill body never frames autodev as running the loop unattended" {
+    run grep -c "$BANNED" "$SKILL"
+    [ "$output" -eq 0 ]
+    # canonical rule: "The loop consumes it; it does not run it."
+    run grep -n "runs the loop unattended" "$SKILL"
+    [ "$status" -ne 0 ]
+}
+
+@test "autodev skill body names it as the config layer the loop reads" {
+    run grep -niE "config(/intent)? layer" "$SKILL"
+    [ "$status" -eq 0 ]
+}
+
+@test "derived skill catalogs drop the loop-framing phrase for autodev" {
+    for f in skills/catalog.json registry.json docs/contracts/context-map.md; do
+        run grep -c "$BANNED" "$REPO_ROOT/$f"
+        [ "$output" -eq 0 ]
+    done
+}
+
+@test "the codex autodev mirror drops the loop-framing phrase" {
+    run grep -c "$BANNED" "$REPO_ROOT/skills-codex/autodev/SKILL.md"
+    [ "$output" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Reposition the `/autodev` skill so it reads as **config, not a loop**, per the canonical vocabulary rule `skills/domain/references/autodev.md:9,13` — autodev is the config/intent layer the loop reads each tick, and its description must never lead with "bounded autonomous dev loops".

- `skills/autodev/SKILL.md`: new `description:` leads with managing the PROGRAM.md/AUTODEV.md contract and names autodev as the config layer Evolve and Factory read; "Loop position" prose reframed so the drivers run the loop, autodev does not.
- `skills-codex/autodev/SKILL.md`: codex mirror description synced.
- Regenerated derived artifacts: `skills/catalog.json`, `registry.json`, `docs/contracts/context-map.md`, codex hash manifest/marker (autodev only).
- No command logic changes. Scenario 2 (factory-noun de-collision) re-sliced to `ag-0qz` (premise drifted — no `ao factory` command exists).

## Test plan

- [x] `bats tests/scripts/autodev-skill-positioning.bats` (new gate, 6/6 — pins the description + body + derived catalogs + codex mirror to the config-not-loop rule; written failing-first)
- [x] `scripts/validate-codex-generated-artifacts.sh --scope head` (parity + manifest)
- [x] `scripts/validate-context-map-drift.sh`, `scripts/check-skill-catalog-drift.sh`, `scripts/check-registry-drift.sh`
- [x] `skills/heal-skill/scripts/heal.sh --strict` (autodev clean)

Closes-scenario: soc-ozoqh#autodev-reads-as-config-not-loop
Bounded-context: BC1-Corpus
Evidence: bats tests/scripts/autodev-skill-positioning.bats; skills/domain/references/autodev.md:13