### PR TITLE
docs(skills): autodev reads as config not loop (soc-ozoqh #autodev-config)

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -65,7 +65,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 
 ### supporting
 
-- `autodev` — Manage bounded autonomous dev loops.
+- `autodev` — Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer the Evolve and Factory drivers read each tick, not a loop it runs.
 - `codex-team` — Coordinate multiple Codex agents.
 - `compile` — Compile .agents knowledge wiki.
 - `curate` — Mine transcripts, .agents, bd, and git for skill diffs, bd updates, or rare wiki entries.

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-05-26T22:58:05Z",
+  "generated_at": "2026-05-28T10:48:57Z",
   "summary": {
     "skills": 75,
     "hooks": 0,
@@ -1425,7 +1425,7 @@
       "bounded_context": "BC3",
       "hex_role": "supporting",
       "tier": "execution",
-      "purpose": "Manage bounded autonomous dev loops.",
+      "purpose": "Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer the Evolve and Factory drivers read each tick, not a loop it runs.",
       "status": "active",
       "disposition": "refactor",
       "consumes": [

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -649,8 +649,8 @@
     {
       "name": "autodev",
       "source_skill": "skills/autodev",
-      "source_hash": "4ad1828489b40ea336c593c1b04054b5c0faa1cc194ce2bc29c49fa8aa8cd9ec",
-      "generated_hash": "7fe2526d5e4792cb4b52e59745010fb752547b5163495e59904a13e4535f4024"
+      "source_hash": "8b7b7c6dd2d79b745608a9c7ee60c503589f9953a61f6980c25b9bc8901dc901",
+      "generated_hash": "8d43e8d6c0542593918a5d43badec8759d91edc4768dfcaa793bbfc96c397378"
     },
     {
       "name": "beads",

--- a/skills-codex/autodev/.agentops-generated.json
+++ b/skills-codex/autodev/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/autodev",
   "layout": "modular",
-  "source_hash": "4ad1828489b40ea336c593c1b04054b5c0faa1cc194ce2bc29c49fa8aa8cd9ec",
-  "generated_hash": "7fe2526d5e4792cb4b52e59745010fb752547b5163495e59904a13e4535f4024"
+  "source_hash": "8b7b7c6dd2d79b745608a9c7ee60c503589f9953a61f6980c25b9bc8901dc901",
+  "generated_hash": "8d43e8d6c0542593918a5d43badec8759d91edc4768dfcaa793bbfc96c397378"
 }

--- a/skills-codex/autodev/SKILL.md
+++ b/skills-codex/autodev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autodev
-description: 'Manage bounded autonomous dev loops.'
+description: 'Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer the Evolve and Factory drivers read each tick, not a loop it runs.'
 ---
 # $autodev
 

--- a/skills/autodev/SKILL.md
+++ b/skills/autodev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autodev
-description: Manage bounded autonomous dev loops.
+description: Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer the Evolve and Factory drivers read each tick, not a loop it runs.
 practices:
 - cmm-process-maturity
 - ai-assisted-dev
@@ -33,7 +33,7 @@ It does not replace `/evolve` or `/rpi`.
 
 ## Loop position
 
-Bounded executor of the full [operating loop](../../docs/architecture/operating-loop.md): BDD intent → vertical slices → conflict-free wave → bead acceptance → evidence. `/autodev` runs the loop unattended within the contract declared in `PROGRAM.md`/`AUTODEV.md` — mutable scope, immutable scope, validation commands, escalation rules, stop conditions. Loop discipline still applies under autonomy: no parallel wave without the wave-validity check; no slice closes without a passing test mapped to a Given/When/Then; capture goes through the promotion ratchet, not into a landfill.
+The config/intent layer that drives the [operating loop](../../docs/architecture/operating-loop.md) — BDD intent → vertical slices → conflict-free wave → bead acceptance → evidence — NOT a loop it runs. `/autodev` manages the contract declared in `PROGRAM.md`/`AUTODEV.md` — mutable scope, immutable scope, validation commands, escalation rules, stop conditions — that the loop reads every tick. The drivers (Evolve and Factory) consume that contract each tick; autodev is the highest-leverage antecedent, so arranging it well makes the loop's behavior follow. Loop discipline still applies under autonomy: no parallel wave without the wave-validity check; no slice closes without a passing test mapped to a Given/When/Then; capture goes through the promotion ratchet, not into a landfill.
 
 - `PROGRAM.md` or `AUTODEV.md` defines the contract: mutable scope, immutable
   scope, experiment unit, validation commands, decision policy, escalation rules,

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-25T02:39:14Z",
+  "generated_at": "2026-05-28T10:48:57Z",
   "skill_count": 75,
   "skills": [
     {
       "name": "autodev",
-      "description": "Manage bounded autonomous dev loops.",
+      "description": "Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer the Evolve and Factory drivers read each tick, not a loop it runs.",
       "hexagonal_role": "supporting",
       "user_invocable": true,
       "consumes": [

--- a/tests/scripts/autodev-skill-positioning.bats
+++ b/tests/scripts/autodev-skill-positioning.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# Regression tests for autodev skill positioning (soc-ozoqh, scenario 1).
+#
+# The canonical model in skills/domain/references/autodev.md:9,13 prescribes that
+# autodev reads as the *config/intent layer that drives the loop*, NEVER as
+# "bounded autonomous dev loops" (that phrasing implies a loop and was the source
+# of the original sprawl). These tests pin the autodev SKILL.md to that model:
+# the description leads with the PROGRAM.md/AUTODEV.md contract framing, names
+# autodev as the config layer the Evolve/Factory drivers consume, and the banned
+# phrase appears nowhere in the skill.
+
+setup() {
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  SKILL="$REPO_ROOT/skills/autodev/SKILL.md"
+}
+
+# Extract the single-line frontmatter `description:` value.
+description_line() {
+  grep -m1 '^description:' "$SKILL"
+}
+
+@test "skill exists with autodev frontmatter" {
+  [ -f "$SKILL" ]
+  grep -q '^name: autodev$' "$SKILL"
+}
+
+@test "description drops the banned 'bounded autonomous dev loops' phrasing" {
+  run description_line
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"bounded autonomous dev loops"* ]]
+}
+
+@test "description leads with the PROGRAM.md/AUTODEV.md contract framing" {
+  run description_line
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PROGRAM.md"* ]]
+  [[ "$output" == *"AUTODEV.md"* ]]
+  [[ "$output" == *"contract"* ]]
+}
+
+@test "the banned phrase appears nowhere in the skill body" {
+  run grep -ci 'bounded autonomous dev loops' "$SKILL"
+  [ "$output" -eq 0 ]
+}
+
+@test "skill names autodev as config that drives the loop, not a loop it runs" {
+  # Config-layer framing, per skills/domain/references/autodev.md.
+  grep -qi 'config' "$SKILL"
+  grep -qi 'drives the loop' "$SKILL"
+  # Names both drivers that consume the contract.
+  grep -q 'Evolve' "$SKILL"
+  grep -q 'Factory' "$SKILL"
+  # No longer claims autodev itself runs the loop unattended.
+  ! grep -qi 'runs the loop unattended' "$SKILL"
+}


### PR DESCRIPTION
## Summary

Reposition the `/autodev` skill so it reads as the **config/intent layer that drives the loop**, not a loop it runs. Drops the banned "bounded autonomous dev loops" phrasing (description + body) and leads with the PROGRAM.md/AUTODEV.md contract framing, naming autodev as the config the Evolve and Factory drivers consume each tick.

Grounded in the canonical rule the prior prose violated: `skills/domain/references/autodev.md:9,13` ("lead with 'the PROGRAM.md/AUTODEV.md contract that drives the loop', never with 'bounded autonomous dev loops'"). The CLI help (`cli/cmd/ao/autodev.go:22`) was already compliant; this fixes the skill prose + derived mirrors.

## Changes

- `skills/autodev/SKILL.md` — description (frontmatter) + "Loop position" section reframed as config, not executor.
- Regenerated derived catalogs: `skills/catalog.json`, `registry.json`, `docs/contracts/context-map.md`.
- Synced hand-maintained codex mirror: `skills-codex/autodev/SKILL.md` + its `.agentops-generated.json` marker + manifest entry (autodev only).
- New regression test `tests/scripts/autodev-skill-positioning.bats` pins the config framing and bans the phrase.

Scope is surgical (autodev only). Scenario 2 (factory-noun de-collision) was re-sliced to `ag-0qz` in discovery — not touched here.

## Test plan

- [x] `bats tests/scripts/autodev-skill-positioning.bats` (5/5 green; failed first for the right reason pre-fix)
- [x] `scripts/check-skill-catalog-drift.sh`, `scripts/check-registry-drift.sh`, `scripts/validate-context-map-drift.sh` (post-commit) — no drift
- [x] `scripts/audit-codex-parity.sh` + `scripts/validate-codex-generated-artifacts.sh --scope worktree` — pass
- [x] `skills/heal-skill/scripts/heal.sh --strict` — all clean
- [x] `cd cli && go build ./...` — success

Closes-scenario: soc-ozoqh#autodev-reads-as-config-not-loop
Bounded-context: BC1-Corpus
Evidence: bats tests/scripts/autodev-skill-positioning.bats; skills/domain/references/autodev.md:13