### PR TITLE
fix(evals): drop deleted validate-hooks-doc-parity.sh ref from docs-release-governance canary (ag-jov #eval-references-only-existing-scripts)

### DIFF
--- a/cli/internal/eval/governance_refs_test.go
+++ b/cli/internal/eval/governance_refs_test.go
@@ -1,0 +1,83 @@
+package eval
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// docsReleaseGovernanceSuitePath is the suite under test, relative to this
+// package directory (cli/internal/eval).
+const docsReleaseGovernanceSuitePath = "../../../evals/agentops-core/docs-release-governance.json"
+
+var shellScriptTokenRE = regexp.MustCompile(`[\w./-]+\.sh`)
+
+// loadDocsReleaseGovernanceSuite loads the canary suite and returns it along
+// with its directory (for resolving suite-relative reference paths).
+func loadDocsReleaseGovernanceSuite(t *testing.T) (*Suite, string) {
+	t.Helper()
+	suite, _, err := LoadSuite(docsReleaseGovernanceSuitePath)
+	if err != nil {
+		t.Fatalf("load %s: %v", docsReleaseGovernanceSuitePath, err)
+	}
+	return suite, filepath.Dir(docsReleaseGovernanceSuitePath)
+}
+
+// TestDocsReleaseGovernanceEval_ReferencedPathsExist asserts that every script
+// path invoked in a shell case and every artifact_contains target resolves to a
+// file that exists on disk. A dangling reference (e.g. a script deleted by a
+// prior cleanup) makes the canary fail when run, so it must fail this gate too.
+func TestDocsReleaseGovernanceEval_ReferencedPathsExist(t *testing.T) {
+	suite, suiteDir := loadDocsReleaseGovernanceSuite(t)
+
+	for _, c := range suite.Cases {
+		// Shell script tokens: resolve relative to the case cwd, which is
+		// itself relative to the suite directory.
+		if shell, ok := c.Inputs["shell"].(string); ok {
+			cwd, _ := c.Inputs["cwd"].(string)
+			base := filepath.Join(suiteDir, cwd)
+			for _, tok := range shellScriptTokenRE.FindAllString(shell, -1) {
+				p := filepath.Join(base, tok)
+				if _, err := os.Stat(p); err != nil {
+					t.Errorf("case %q: shell references missing script %q (resolved %q): %v", c.ID, tok, p, err)
+				}
+			}
+		}
+
+		// artifact_contains targets: resolve relative to the suite directory.
+		for _, exp := range c.Expectations {
+			if exp.Type != "artifact_contains" || exp.Target == "" {
+				continue
+			}
+			p := filepath.Join(suiteDir, exp.Target)
+			if _, err := os.Stat(p); err != nil {
+				t.Errorf("case %q: artifact_contains target missing %q (resolved %q): %v", c.ID, exp.Target, p, err)
+			}
+		}
+	}
+}
+
+// TestDocsReleaseGovernanceEval_NoDeletedHooksParityRefs asserts the canary no
+// longer references the validate-hooks-doc-parity.sh script (deleted when hooks
+// were removed in 3.0) nor expects its HOOKS_DOC_PARITY: PASS marker.
+func TestDocsReleaseGovernanceEval_NoDeletedHooksParityRefs(t *testing.T) {
+	suite, _ := loadDocsReleaseGovernanceSuite(t)
+
+	for _, c := range suite.Cases {
+		if shell, ok := c.Inputs["shell"].(string); ok {
+			if strings.Contains(shell, "validate-hooks-doc-parity.sh") {
+				t.Errorf("case %q: shell still references deleted validate-hooks-doc-parity.sh", c.ID)
+			}
+		}
+		for _, exp := range c.Expectations {
+			if strings.Contains(exp.Target, "validate-hooks-doc-parity.sh") {
+				t.Errorf("case %q: artifact_contains target still references deleted validate-hooks-doc-parity.sh", c.ID)
+			}
+			if v, ok := exp.Value.(string); ok && strings.Contains(v, "HOOKS_DOC_PARITY") {
+				t.Errorf("case %q: expectation still expects removed HOOKS_DOC_PARITY marker", c.ID)
+			}
+		}
+	}
+}

--- a/evals/agentops-core/docs-release-governance.json
+++ b/evals/agentops-core/docs-release-governance.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "id": "agentops-core.docs-release-governance",
   "name": "AgentOps Docs and Release Governance Canary",
-  "description": "Offline public canary for documentation governance: doc-release stabilization, skill-count sync, CLI-skills map parity, hook/docs parity, CI policy parity, source-backed doc/readme contracts, and OSS docs audit behavior.",
+  "description": "Offline public canary for documentation governance: doc-release stabilization, skill-count sync, CLI-skills map parity, CI policy parity, source-backed doc/readme contracts, and OSS docs audit behavior.",
   "practices": ["llm-eval-harness", "wiki-knowledge-surface"],
   "domain": "docs",
   "visibility": "public_canary",
@@ -54,16 +54,15 @@
       "id": "docs-policy-parity-gates",
       "title": "docs policy parity gates pass",
       "kind": "command",
-      "objective": "Keep hook/docs parity, CI blocking policy parity, CLI-skills map generation count, and skill-count sync directly protected as eval canaries.",
+      "objective": "Keep CI blocking policy parity, CLI-skills map generation count, and skill-count sync directly protected as eval canaries.",
       "runtime": "shell",
       "timeout_seconds": 120,
       "inputs": {
         "cwd": "../..",
-        "shell": "bash scripts/validate-hooks-doc-parity.sh && bash scripts/validate-ci-policy-parity.sh && bash scripts/validate-cli-skills-map.sh && scripts/sync-skill-counts.sh --check"
+        "shell": "bash scripts/validate-ci-policy-parity.sh && bash scripts/validate-cli-skills-map.sh && scripts/sync-skill-counts.sh --check"
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "HOOKS_DOC_PARITY: PASS"},
         {"type": "stdout_contains", "value": "CI_POLICY_PARITY: PASS"},
         {"type": "stdout_contains", "value": "CLI_SKILLS_MAP: PASS"},
         {"type": "stdout_contains", "value": "DONE: All counts already in sync."}
@@ -128,7 +127,7 @@
       "id": "doc-release-script-contracts",
       "title": "doc-release scripts preserve fail-closed parity contracts",
       "kind": "artifact_check",
-      "objective": "Ensure documentation release scripts keep their fail-closed checks for release notes, skill counts, CLI mapping, hooks docs, and CI blocking policy.",
+      "objective": "Ensure documentation release scripts keep their fail-closed checks for release notes, skill counts, CLI mapping, and CI blocking policy.",
       "expectations": [
         {"type": "artifact_contains", "target": "../../tests/docs/validate-doc-release.sh", "value": "run_check \"Link validation\""},
         {"type": "artifact_contains", "target": "../../tests/docs/validate-doc-release.sh", "value": "run_check \"Skill count sync check\""},
@@ -136,7 +135,6 @@
         {"type": "artifact_contains", "target": "../../tests/docs/validate-doc-release.sh", "value": "run_check \"Release message freeze validation\""},
         {"type": "artifact_contains", "target": "../../scripts/sync-skill-counts.sh", "value": "pattern not found (fail-closed)"},
         {"type": "artifact_contains", "target": "../../scripts/validate-cli-skills-map.sh", "value": "top audit line must declare '<N> generated CLI command headings'"},
-        {"type": "artifact_contains", "target": "../../scripts/validate-hooks-doc-parity.sh", "value": "Runtime manifest active hook events"},
         {"type": "artifact_contains", "target": "../../scripts/validate-ci-policy-parity.sh", "value": "CI_POLICY_PARITY: PASS"}
       ],
       "dimensions": ["process_adherence", "artifact_quality", "safety"],


### PR DESCRIPTION
## Summary
- Hooks were removed in 3.0 and `scripts/validate-hooks-doc-parity.sh` was deleted. `ag-s3z` removed the Nightly workflow step that ran it but the critical eval `evals/agentops-core/docs-release-governance.json` still referenced the deleted script in 3 spots: a shell command (`docs-policy-parity-gates`), a `HOOKS_DOC_PARITY: PASS` stdout expectation, and an `artifact_contains` target (`doc-release-script-contracts`) — so the canary fails when run.
- Removed those 3 references plus the now-inaccurate "hook/docs parity" prose in the suite description and two case objectives.
- Added `cli/internal/eval/governance_refs_test.go`: a regression gate that loads this suite and asserts every shell script token and every `artifact_contains` target resolves on disk, and that no reference to the deleted script / `HOOKS_DOC_PARITY` marker remains.

## Test plan
- [x] `cd cli && go test ./internal/eval/ -run TestDocsReleaseGovernanceEval` — both new tests fail on `main` (dangling ref) and pass after the edit (test-first verified)
- [x] `cd cli && go build ./... && go vet ./internal/eval/`
- [x] `cd cli && go test ./internal/eval/... ./cmd/ao/`
- [x] JSON re-validated (`python3 -m json.tool`); `LoadSuite` strict-decode + `ValidateSuite` pass

Out-of-scope dangling refs (different bounded context: docs + local gate) tracked in `ag-c2i` (discovered-from `ag-jov`).

Closes-scenario: ag-jov#eval-references-only-existing-scripts
Bounded-context: BC1-Corpus
Evidence: cd cli && go test ./internal/eval/ -run TestDocsReleaseGovernanceEval