### PR TITLE
fix(evals): drop deleted validate-hooks-doc-parity.sh ref from docs-release-governance canary (ag-cmg #eval-references-only-existing-scripts)

### DIFF
--- a/cli/internal/eval/governance_refs_test.go
+++ b/cli/internal/eval/governance_refs_test.go
@@ -1,0 +1,67 @@
+package eval
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+// shellScriptToken matches repo-relative shell script paths (foo/bar.sh) inside
+// a case's shell command string, so we can assert each referenced script exists.
+var shellScriptToken = regexp.MustCompile(`[A-Za-z0-9_./-]+\.sh`)
+
+// TestDocsReleaseGovernanceEval_ReferencedPathsExist guards the public
+// docs-release-governance canary against dangling references: every shell
+// script it invokes and every artifact_contains target it checks must resolve
+// to a file on disk. Hooks were removed in 3.0 and
+// scripts/validate-hooks-doc-parity.sh was deleted; this test fails until the
+// suite stops referencing it.
+func TestDocsReleaseGovernanceEval_ReferencedPathsExist(t *testing.T) {
+	const suiteRel = "../../../evals/agentops-core/docs-release-governance.json"
+	suiteDir := filepath.Dir(suiteRel)
+
+	suite, _, err := LoadSuite(suiteRel)
+	if err != nil {
+		t.Fatalf("load suite %s: %v", suiteRel, err)
+	}
+
+	var missing []string
+	check := func(caseID, field, resolved, raw string) {
+		if _, statErr := os.Stat(resolved); statErr != nil {
+			missing = append(missing, fmt.Sprintf("case %q %s references %q (resolved %q): %v", caseID, field, raw, resolved, statErr))
+		}
+	}
+
+	for _, c := range suite.Cases {
+		// Shell commands resolve script tokens relative to the case cwd.
+		cwd := suiteDir
+		if rel, ok := c.Inputs["cwd"].(string); ok && rel != "" {
+			cwd = filepath.Join(suiteDir, rel)
+		}
+		if shell, ok := c.Inputs["shell"].(string); ok {
+			for _, tok := range shellScriptToken.FindAllString(shell, -1) {
+				check(c.ID, "shell script", filepath.Join(cwd, tok), tok)
+			}
+		}
+		// artifact_contains targets resolve relative to the suite directory.
+		for _, e := range c.Expectations {
+			if e.Type == "artifact_contains" && e.Target != "" {
+				check(c.ID, "artifact_contains target", filepath.Join(suiteDir, e.Target), e.Target)
+			}
+		}
+	}
+
+	if len(missing) > 0 {
+		t.Fatalf("docs-release-governance canary references %d missing path(s):\n%s", len(missing), joinLines(missing))
+	}
+}
+
+func joinLines(s []string) string {
+	out := ""
+	for _, line := range s {
+		out += "  - " + line + "\n"
+	}
+	return out
+}

--- a/evals/agentops-core/docs-release-governance.json
+++ b/evals/agentops-core/docs-release-governance.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "id": "agentops-core.docs-release-governance",
   "name": "AgentOps Docs and Release Governance Canary",
-  "description": "Offline public canary for documentation governance: doc-release stabilization, skill-count sync, CLI-skills map parity, hook/docs parity, CI policy parity, source-backed doc/readme contracts, and OSS docs audit behavior.",
+  "description": "Offline public canary for documentation governance: doc-release stabilization, skill-count sync, CLI-skills map parity, CI policy parity, source-backed doc/readme contracts, and OSS docs audit behavior.",
   "practices": ["llm-eval-harness", "wiki-knowledge-surface"],
   "domain": "docs",
   "visibility": "public_canary",
@@ -54,16 +54,15 @@
       "id": "docs-policy-parity-gates",
       "title": "docs policy parity gates pass",
       "kind": "command",
-      "objective": "Keep hook/docs parity, CI blocking policy parity, CLI-skills map generation count, and skill-count sync directly protected as eval canaries.",
+      "objective": "Keep CI blocking policy parity, CLI-skills map generation count, and skill-count sync directly protected as eval canaries.",
       "runtime": "shell",
       "timeout_seconds": 120,
       "inputs": {
         "cwd": "../..",
-        "shell": "bash scripts/validate-hooks-doc-parity.sh && bash scripts/validate-ci-policy-parity.sh && bash scripts/validate-cli-skills-map.sh && scripts/sync-skill-counts.sh --check"
+        "shell": "bash scripts/validate-ci-policy-parity.sh && bash scripts/validate-cli-skills-map.sh && scripts/sync-skill-counts.sh --check"
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "HOOKS_DOC_PARITY: PASS"},
         {"type": "stdout_contains", "value": "CI_POLICY_PARITY: PASS"},
         {"type": "stdout_contains", "value": "CLI_SKILLS_MAP: PASS"},
         {"type": "stdout_contains", "value": "DONE: All counts already in sync."}
@@ -128,7 +127,7 @@
       "id": "doc-release-script-contracts",
       "title": "doc-release scripts preserve fail-closed parity contracts",
       "kind": "artifact_check",
-      "objective": "Ensure documentation release scripts keep their fail-closed checks for release notes, skill counts, CLI mapping, hooks docs, and CI blocking policy.",
+      "objective": "Ensure documentation release scripts keep their fail-closed checks for release notes, skill counts, CLI mapping, and CI blocking policy.",
       "expectations": [
         {"type": "artifact_contains", "target": "../../tests/docs/validate-doc-release.sh", "value": "run_check \"Link validation\""},
         {"type": "artifact_contains", "target": "../../tests/docs/validate-doc-release.sh", "value": "run_check \"Skill count sync check\""},
@@ -136,7 +135,6 @@
         {"type": "artifact_contains", "target": "../../tests/docs/validate-doc-release.sh", "value": "run_check \"Release message freeze validation\""},
         {"type": "artifact_contains", "target": "../../scripts/sync-skill-counts.sh", "value": "pattern not found (fail-closed)"},
         {"type": "artifact_contains", "target": "../../scripts/validate-cli-skills-map.sh", "value": "top audit line must declare '<N> generated CLI command headings'"},
-        {"type": "artifact_contains", "target": "../../scripts/validate-hooks-doc-parity.sh", "value": "Runtime manifest active hook events"},
         {"type": "artifact_contains", "target": "../../scripts/validate-ci-policy-parity.sh", "value": "CI_POLICY_PARITY: PASS"}
       ],
       "dimensions": ["process_adherence", "artifact_quality", "safety"],


### PR DESCRIPTION
## Summary
- The critical public canary `evals/agentops-core/docs-release-governance.json` still referenced the deleted `scripts/validate-hooks-doc-parity.sh` (hooks removed in 3.0). `ag-s3z` removed the Nightly workflow step that ran it but missed this canary, so the suite fails if run.
- Drop all three dangling references: the `docs-policy-parity-gates` shell command token, its `HOOKS_DOC_PARITY: PASS` stdout expectation, and the `doc-release-script-contracts` `artifact_contains` target — plus the now-inaccurate "hook/docs parity" / "hooks docs" prose in the suite description and two objectives.
- Add a first-failing-test guard (`TestDocsReleaseGovernanceEval_ReferencedPathsExist`) that loads the suite and asserts every shell script token and every `artifact_contains` target resolves to a file on disk, so this class of dangling reference can't regress.

## Test plan
- [x] `cd cli && go test ./internal/eval/ -run TestDocsReleaseGovernanceEval_ReferencedPathsExist` — red before the JSON edit (2 missing paths), green after.
- [x] `cd cli && go build ./... && go vet ./internal/eval/... ./cmd/ao && go test ./internal/eval/... ./cmd/ao` — clean.
- [x] `ao eval baseline-audit` — no new drift introduced (missing-baseline count is pre-existing repo-wide state; baseline policy untouched).
- [x] `jq -e . evals/agentops-core/docs-release-governance.json` — JSON valid.

Closes-scenario: ag-cmg#eval-references-only-existing-scripts
Bounded-context: BC1-Corpus
Evidence: cli go test ./internal/eval/ -run TestDocsReleaseGovernanceEval_ReferencedPathsExist