### PR TITLE
fix(evals): drop deleted validate-hooks-doc-parity.sh ref from docs-release-governance canary (ag-jta #eval-references-only-existing-scripts)

### DIFF
--- a/cli/internal/eval/governance_refs_test.go
+++ b/cli/internal/eval/governance_refs_test.go
@@ -1,0 +1,63 @@
+package eval
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// scriptPathPattern matches a whitespace-delimited shell field that is a
+// relative path to a `.sh` script (e.g. `scripts/foo.sh`,
+// `skills/doc/scripts/validate.sh`). Anchoring to the whole field avoids
+// matching a `scripts/` substring inside a longer path.
+var scriptPathPattern = regexp.MustCompile(`^[\w./-]+\.sh$`)
+
+// TestDocsReleaseGovernanceEval_ReferencedPathsExist guards the
+// docs-release-governance canary against dangling references: every
+// `scripts/*.sh` token in a shell input and every artifact_contains target must
+// resolve to a file that exists on disk. It is scoped to this one suite so it
+// catches references that outlive the files they point at (e.g. the
+// validate-hooks-doc-parity.sh canary removed when hooks left in 3.0) without
+// flagging unrelated drift in other suites.
+func TestDocsReleaseGovernanceEval_ReferencedPathsExist(t *testing.T) {
+	suitePath := filepath.Join("..", "..", "..", "evals", "agentops-core", "docs-release-governance.json")
+	suite, _, err := LoadSuite(suitePath)
+	if err != nil {
+		t.Fatalf("LoadSuite(%s): %v", suitePath, err)
+	}
+	suiteDir := filepath.Dir(suitePath)
+
+	for _, c := range suite.Cases {
+		// Shell command scripts resolve relative to the case cwd, which is
+		// itself relative to the suite directory.
+		if shell, ok := c.Inputs["shell"].(string); ok && shell != "" {
+			cwd := "."
+			if raw, ok := c.Inputs["cwd"].(string); ok && raw != "" {
+				cwd = raw
+			}
+			scriptRoot := filepath.Join(suiteDir, cwd)
+			for _, field := range strings.Fields(shell) {
+				if !scriptPathPattern.MatchString(field) {
+					continue
+				}
+				resolved := filepath.Join(scriptRoot, field)
+				if _, err := os.Stat(resolved); err != nil {
+					t.Errorf("case %q references missing script %q (resolved %q): %v", c.ID, field, resolved, err)
+				}
+			}
+		}
+
+		// artifact_contains targets resolve relative to the suite directory.
+		for _, exp := range c.Expectations {
+			if exp.Type != "artifact_contains" || exp.Target == "" {
+				continue
+			}
+			resolved := filepath.Join(suiteDir, exp.Target)
+			if _, err := os.Stat(resolved); err != nil {
+				t.Errorf("case %q artifact_contains target %q (resolved %q) does not exist: %v", c.ID, exp.Target, resolved, err)
+			}
+		}
+	}
+}

--- a/evals/agentops-core/docs-release-governance.json
+++ b/evals/agentops-core/docs-release-governance.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "id": "agentops-core.docs-release-governance",
   "name": "AgentOps Docs and Release Governance Canary",
-  "description": "Offline public canary for documentation governance: doc-release stabilization, skill-count sync, CLI-skills map parity, hook/docs parity, CI policy parity, source-backed doc/readme contracts, and OSS docs audit behavior.",
+  "description": "Offline public canary for documentation governance: doc-release stabilization, skill-count sync, CLI-skills map parity, CI policy parity, source-backed doc/readme contracts, and OSS docs audit behavior.",
   "practices": ["llm-eval-harness", "wiki-knowledge-surface"],
   "domain": "docs",
   "visibility": "public_canary",
@@ -54,16 +54,15 @@
       "id": "docs-policy-parity-gates",
       "title": "docs policy parity gates pass",
       "kind": "command",
-      "objective": "Keep hook/docs parity, CI blocking policy parity, CLI-skills map generation count, and skill-count sync directly protected as eval canaries.",
+      "objective": "Keep CI blocking policy parity, CLI-skills map generation count, and skill-count sync directly protected as eval canaries.",
       "runtime": "shell",
       "timeout_seconds": 120,
       "inputs": {
         "cwd": "../..",
-        "shell": "bash scripts/validate-hooks-doc-parity.sh && bash scripts/validate-ci-policy-parity.sh && bash scripts/validate-cli-skills-map.sh && scripts/sync-skill-counts.sh --check"
+        "shell": "bash scripts/validate-ci-policy-parity.sh && bash scripts/validate-cli-skills-map.sh && scripts/sync-skill-counts.sh --check"
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "HOOKS_DOC_PARITY: PASS"},
         {"type": "stdout_contains", "value": "CI_POLICY_PARITY: PASS"},
         {"type": "stdout_contains", "value": "CLI_SKILLS_MAP: PASS"},
         {"type": "stdout_contains", "value": "DONE: All counts already in sync."}
@@ -128,7 +127,7 @@
       "id": "doc-release-script-contracts",
       "title": "doc-release scripts preserve fail-closed parity contracts",
       "kind": "artifact_check",
-      "objective": "Ensure documentation release scripts keep their fail-closed checks for release notes, skill counts, CLI mapping, hooks docs, and CI blocking policy.",
+      "objective": "Ensure documentation release scripts keep their fail-closed checks for release notes, skill counts, CLI mapping, and CI blocking policy.",
       "expectations": [
         {"type": "artifact_contains", "target": "../../tests/docs/validate-doc-release.sh", "value": "run_check \"Link validation\""},
         {"type": "artifact_contains", "target": "../../tests/docs/validate-doc-release.sh", "value": "run_check \"Skill count sync check\""},
@@ -136,7 +135,6 @@
         {"type": "artifact_contains", "target": "../../tests/docs/validate-doc-release.sh", "value": "run_check \"Release message freeze validation\""},
         {"type": "artifact_contains", "target": "../../scripts/sync-skill-counts.sh", "value": "pattern not found (fail-closed)"},
         {"type": "artifact_contains", "target": "../../scripts/validate-cli-skills-map.sh", "value": "top audit line must declare '<N> generated CLI command headings'"},
-        {"type": "artifact_contains", "target": "../../scripts/validate-hooks-doc-parity.sh", "value": "Runtime manifest active hook events"},
         {"type": "artifact_contains", "target": "../../scripts/validate-ci-policy-parity.sh", "value": "CI_POLICY_PARITY: PASS"}
       ],
       "dimensions": ["process_adherence", "artifact_quality", "safety"],


### PR DESCRIPTION
## Summary
Hooks were removed in AgentOps 3.0 and `scripts/validate-hooks-doc-parity.sh` deleted. `ag-s3z` dropped the Nightly workflow step that ran it but missed the critical eval canary `evals/agentops-core/docs-release-governance.json`, which still referenced the deleted script in three places — so the suite fails on a missing file:

- the `docs-policy-parity-gates` shell command (`bash scripts/validate-hooks-doc-parity.sh && ...`)
- a `HOOKS_DOC_PARITY: PASS` `stdout_contains` expectation on that case
- a `doc-release-script-contracts` `artifact_contains` target pointing at the deleted script

This PR removes all three, plus the now-false "hook/docs parity" / "hooks docs" prose in the suite description and two case objectives (same removal cause, one-pass review). The remaining parity checks (CI policy parity, CLI-skills map, skill-count sync) are untouched.

It also adds `TestDocsReleaseGovernanceEval_ReferencedPathsExist`: it loads this one suite and asserts every `.sh` path referenced in a shell input and every `artifact_contains` target resolves on disk. Scoped to this suite to catch dangling references without flagging unrelated drift. The test fails on the pre-fix suite (two sites) and passes after.

## Test plan
- [x] `cd cli && go test ./internal/eval/... -run TestDocsReleaseGovernanceEval_ReferencedPathsExist` — fails pre-fix, passes post-fix
- [x] `cd cli && go build ./... && go vet ./internal/eval/... ./cmd/ao`
- [x] `cd cli && go test ./internal/eval/... ./cmd/ao` — green
- [x] `jq -e .` on the suite — valid JSON; `LoadSuite` schema validation passes
- [x] `ao eval baseline-audit` — RC 0 (pre-existing missing-baseline state only; this suite's `blocking_gate` is `none`)

Closes-scenario: ag-jta#eval-references-only-existing-scripts
Bounded-context: BC1-Corpus
Evidence: cd cli && go test ./internal/eval/... -run TestDocsReleaseGovernanceEval_ReferencedPathsExist