### PR TITLE
fix(docs): purge dangling validate-hooks-doc-parity.sh refs from operational docs (ag-c2i #operational-docs-no-dangling-hooks-parity-ref)

### DIFF
--- a/AGENTS-WORKFLOW.md
+++ b/AGENTS-WORKFLOW.md
@@ -84,33 +84,30 @@ cd cli && make build && make test
 # 6. Contract compatibility
 ./scripts/check-contract-compatibility.sh
 
-# 7. Hook/docs parity
-bash scripts/validate-hooks-doc-parity.sh
-
-# 8. CI policy/docs parity
+# 7. CI policy/docs parity
 bash scripts/validate-ci-policy-parity.sh
 
-# 9. Worktree disposition
+# 8. Worktree disposition
 bash scripts/check-worktree-disposition.sh
 
-# 10. Plugin structure (symlinks, manifests)
+# 9. Plugin structure (symlinks, manifests)
 ./scripts/validate-manifests.sh --repo-root .
 find skills -type l  # must be empty — zero symlinks allowed
 
- # 11. Headless runtime skill smoke (local Claude/Codex sessions; skips missing CLIs)
+ # 10. Headless runtime skill smoke (local Claude/Codex sessions; skips missing CLIs)
  bash scripts/validate-headless-runtime-skills.sh
 
- # 12. Codex-first override coverage (full skill catalog is classified and covered)
+ # 11. Codex-first override coverage (full skill catalog is classified and covered)
  bash scripts/validate-codex-override-coverage.sh
 
- # 13. Codex RPI contract and lifecycle guard checks
+ # 12. Codex RPI contract and lifecycle guard checks
  bash scripts/validate-codex-rpi-contract.sh
  bash scripts/validate-codex-lifecycle-guards.sh
 
- # 14. Codex semantic parity audit (generated skills still match Codex-native tool/runtime semantics)
+ # 13. Codex semantic parity audit (generated skills still match Codex-native tool/runtime semantics)
  bash scripts/audit-codex-parity.sh
 
- # 15. AgentOps contract canaries (official deterministic test gate)
+ # 14. AgentOps contract canaries (official deterministic test gate)
  scripts/test-agentops-contract-canaries.sh
 
 # Full gate (runs everything above and more):

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -53,7 +53,7 @@ The validate workflow runs many focused jobs across 4 tiers of parallelism. Most
                     │   independent validate jobs, path-filtered    │
                     │                                               │
                     │  doc-release-gate    smoke-test               │
-                    │  hook-preflight      validate-hooks-doc-parity│
+                    │  hook-preflight                               │
                     │  validate-ci-policy-parity                    │
                     │  validate-codex-* runtime/parity checks       │
                     │  validate-goals/registry/flywheel gates       │

--- a/docs/LOOP-BUDGET.md
+++ b/docs/LOOP-BUDGET.md
@@ -83,7 +83,6 @@ scripts/pre-push-gate.sh --single-pass         # Full single-pass (old behavior)
 | embedded-sync | hooks | Outer |
 | hook-preflight | hooks | Outer |
 | hook-output-schema-lint | hooks | Outer |
-| validate-hooks-doc-parity | hooks | Outer |
 | bats-tests | hooks | Outer |
 | skill-integrity | skills | Outer |
 | skill-lint | skills | Outer |

--- a/docs/cli-skills-map.md
+++ b/docs/cli-skills-map.md
@@ -251,8 +251,7 @@ When skills, hooks, or command usage changes, refresh this map as follows:
 
 1. Re-scan source invocations in: `skills/*/SKILL.md`, `skills-codex/*/SKILL.md`, `hooks/*.sh`, `hooks/hooks.json`.
 2. Update the relevant rows in this document, keeping hidden/subcommands aligned with the live command tree (`ao anti-patterns`, `ao context assemble`, etc.).
-3. Run `bash scripts/validate-hooks-doc-parity.sh` and ensure no stale hook-count wording remains.
-4. Update the audit header date above.
+3. Update the audit header date above.
 
 ## Maintaining This Document
 

--- a/docs/release-e2e-checklist.md
+++ b/docs/release-e2e-checklist.md
@@ -93,7 +93,6 @@ When changing CI workflow policy, hook/runtime docs, or required gate wording, r
 
 ```bash
 bash scripts/validate-ci-policy-parity.sh
-bash scripts/validate-hooks-doc-parity.sh
 bash scripts/validate-skill-runtime-parity.sh
 bash scripts/validate-codex-runtime-sections.sh
 bash scripts/validate-codex-generated-artifacts.sh --scope worktree

--- a/tests/scripts/docs-no-dangling-hooks-doc-parity.bats
+++ b/tests/scripts/docs-no-dangling-hooks-doc-parity.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+
+# Regression guard (ag-c2i): AgentOps 3.0 removed hooks and deleted
+# scripts/validate-hooks-doc-parity.sh. Operational docs must not instruct a
+# reader to run the deleted script. Historical records (docs/CHANGELOG.md and
+# docs/releases/*) legitimately describe the removal and are excluded. The
+# retired scripts/pre-push-gate.sh and its bats stub keep their references until
+# the soc-g2r9 deletion waves remove those files wholesale, so they are out of
+# this guard's scope (see docs/contracts/local-pre-push-gate-retirement.md).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+@test "operational docs do not reference deleted validate-hooks-doc-parity.sh" {
+    cd "$REPO_ROOT"
+    run grep -rn --include='*.md' 'validate-hooks-doc-parity' docs AGENTS-WORKFLOW.md
+    filtered="$(printf '%s\n' "$output" | grep -Ev '^docs/(CHANGELOG\.md|releases/)' | grep -v '^$' || true)"
+    if [ -n "$filtered" ]; then
+        echo "Dangling references to deleted scripts/validate-hooks-doc-parity.sh in operational docs:"
+        printf '%s\n' "$filtered"
+        return 1
+    fi
+}


### PR DESCRIPTION
## Summary

Hooks were removed in AgentOps 3.0 and `scripts/validate-hooks-doc-parity.sh` was deleted. ag-jov (PR #575) fixed the `docs-release-governance` eval canary; this PR completes the cleanup for **operational docs** that still instructed readers to run the deleted script.

- `AGENTS-WORKFLOW.md` — drop the "Hook/docs parity" pre-push checklist item; renumber 8–15 → 7–14.
- `docs/cli-skills-map.md` — drop the regenerate step that ran the deleted script; renumber.
- `docs/release-e2e-checklist.md` — drop the parity-check line.
- `docs/CI-CD.md` — remove the `validate-hooks-doc-parity` node from the CI job-graph diagram (box width preserved).
- `docs/LOOP-BUDGET.md` — remove the `validate-hooks-doc-parity` loop-budget row.

Adds `tests/scripts/docs-no-dangling-hooks-doc-parity.bats` as a regression guard over `docs/` + `AGENTS-WORKFLOW.md`, excluding historical records (`docs/CHANGELOG.md`, `docs/releases/*`).

## Scope / out of scope

In scope: operational doc references to the deleted script (docs bounded context).

Out of scope (owned by the **soc-g2r9** local-pre-push-gate retirement arc, whose orphaned files are deleted *wholesale* by its deletion waves — not hand-patched): `scripts/pre-push-gate.sh` and `tests/scripts/pre-push-gate.bats` references. See `docs/contracts/local-pre-push-gate-retirement.md`.

## Test plan

- [x] `bats tests/scripts/docs-no-dangling-hooks-doc-parity.bats` — fails before the doc edits (5 refs), passes after.
- [x] `bash tests/docs/validate-links.sh` — 2788 links checked, 0 broken.
- [x] `markdownlint` on all 5 edited docs — clean.
- [x] `bats tests/scripts/validate-agents-split.bats` — 7/7 pass (AGENTS-WORKFLOW.md edit safe).

Closes-scenario: ag-c2i#operational-docs-no-dangling-hooks-parity-ref
Bounded-context: BC1-Corpus
Evidence: bats tests/scripts/docs-no-dangling-hooks-doc-parity.bats