### PR TITLE
fix(gc): overlay_dir resolves to packs/agentops/overlay not repo-root (ag-2mi #overlay-dir-resolution)

### DIFF
--- a/packs/agentops/agents/mayor/agent.toml
+++ b/packs/agentops/agents/mayor/agent.toml
@@ -20,6 +20,9 @@ max_active_sessions = 1
 # /pr-validate, /post-mortem. overlay_dir is the canonical "ship files into the
 # agent workdir" mechanism (config.md:106); the skills primitive is a tombstone
 # (config.md:209-212), so AgentOps brings its own runtime in the overlay.
-overlay_dir = "../../overlay"
+# Resolved relative to the PACK ROOT (packs/agentops), so the value is the
+# pack-relative "overlay" → packs/agentops/overlay (verified via gc doctor; a
+# "../../overlay" value climbs to repo-root/overlay which does not exist — ag-2mi).
+overlay_dir = "overlay"
 install_agent_hooks = ["claude"]
 append_fragments = ["agentops-doctrine", "operating-loop"]

--- a/packs/agentops/agents/refinery/agent.toml
+++ b/packs/agentops/agents/refinery/agent.toml
@@ -36,7 +36,10 @@ pre_start = [
 # Copy the skill corpus + harness hook config into the working dir (additive).
 # overlay_dir is the canonical provisioning mechanism (config.md:106) — the
 # skills primitive is a tombstone (config.md:209-212).
-overlay_dir = "../../overlay"
+# Resolved relative to the PACK ROOT (packs/agentops): "overlay" →
+# packs/agentops/overlay (verified via gc doctor; "../../overlay" climbed to the
+# nonexistent repo-root/overlay — ag-2mi).
+overlay_dir = "overlay"
 install_agent_hooks = ["claude"]
 
 idle_timeout = "2h"


### PR DESCRIPTION
## What

The mayor and refinery agents in the reference city set `overlay_dir = "../../overlay"`. GC resolves `overlay_dir` relative to the **pack root** (`packs/agentops`), so `../../overlay` climbs to **repo-root/`overlay`** — which does not exist. The real overlay (the full `.claude/skills` corpus the workers need) lives at **`packs/agentops/overlay`**.

Impact: `gc doctor` reported a `config-refs` warning, and any spawned refinery/dog worker would be provisioned **without** the AgentOps skills overlay — a latent dispatch bug (not yet hit only because the dog pool idles at `min=0`).

## Fix

`overlay_dir = "../../overlay"` → `overlay_dir = "overlay"` (pack-root-relative) in both `packs/agentops/agents/mayor/agent.toml` and `packs/agentops/agents/refinery/agent.toml`, with an explanatory comment on each.

## Verification

GC's resolution base was confirmed empirically (not guessed) with `gc doctor` against an isolated worktree:

```
BEFORE: ⚠ config-refs — agent "agentops.mayor": overlay_dir "<root>/overlay" not found
AFTER:  ✓ config-refs — all config references valid
        → resolves to packs/agentops/overlay/.claude/skills/  (exists)
```

No other `overlay_dir = "../../overlay"` instances remain in the pack; no test asserts the old value. `gc doctor` is not part of CI (GC is a guided dependency, not run in the validate workflow), so this is verified locally rather than via a CI gate — hence no `Evidence:` trailer (AP#7 verifies Evidence lines against CI logs).

Closes-scenario: ag-2mi#overlay-dir-resolution
Bounded-context: BC5-Runtime