### PR TITLE
fix(evolve): dup-work guard catches same-surface beads, not just exact open titles (ag-6jt #dup-bead-guard)

### DIFF
--- a/skills/evolve/references/work-selection-ladder.md
+++ b/skills/evolve/references/work-selection-ladder.md
@@ -51,6 +51,22 @@ FAILING=$(jq -r '.goals[] | select(.result=="fail") | .id' .agents/evolve/fitnes
 
 **Oscillation check:** Before working a failing goal, check if it has oscillated (improved-to-fail transitions >= 3 times). If so, quarantine it and try the next goal. See `references/oscillation.md` and `references/fitness-scoring.md` for the detection procedure.
 
+**Duplicate-work guard (mandatory before every generator `bd create`).** The
+generators below (3.4–3.7) and the Step-4 Split rung all create beads. A stale
+phase-1 handoff repeatedly re-seeded beads for work already covered by an
+existing bead or merged PR (ag-b8m≈ag-jov, ag-6kw≈ag-c2i — ag-6jt). Before
+`bd create`, run the guard; skip creation when it reports a duplicate:
+
+```bash
+skills/evolve/scripts/duplicate-work-guard.sh "<candidate title>" || {
+  echo "skip: existing work already covers this surface"; }
+# exit 1 + "DUPLICATE: <id> [<status>] <title>" → an open/closed bead already
+# covers it (exact title OR significant-token overlap). exit 0 → safe to create.
+```
+
+This complements the loop's origin/main fast-forward (the cron syncs local
+`main` to `origin/main` before discovery so already-merged work is not re-seen).
+
 **Step 3.4: Testing improvements**
 
 When queues and goals are empty, generate concrete testing work via `/test`:

--- a/skills/evolve/scripts/duplicate-work-guard.sh
+++ b/skills/evolve/scripts/duplicate-work-guard.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# duplicate-work-guard.sh — before the evolve-cron-rpi discovery loop creates a
+# tracking bead, check whether an existing OPEN or CLOSED bead already covers the
+# same work. Exits 1 (with the matching bead) when a duplicate is found, 0 when
+# the candidate is genuinely new.
+#
+# Why this exists (ag-6jt/ag-2je): a stale phase-1 handoff kept re-seeding beads
+# for work already merged or already tracked. The prior guard only matched EXACT
+# OPEN-bead titles, so same-surface, different-wording dups slipped through
+# (ag-b8m≈ag-jov, ag-6kw≈ag-c2i — 4th recurrence). This guard matches on:
+#   1. exact normalized title (lowercased, punctuation-stripped), OR
+#   2. significant-token overlap (Jaccard-style: shared / candidate tokens),
+# across both open and closed beads.
+#
+# Usage:  duplicate-work-guard.sh "<candidate bead title>"
+# Exit:   0 no match · 1 duplicate found · 2 usage error
+# Env:    DUP_GUARD_THRESHOLD (default 0.6) overlap ratio to call it a dup
+#         DUP_GUARD_MIN_SHARED (default 3)  min shared significant tokens
+#         BD_BIN (default "bd")             bd binary (override for tests)
+set -euo pipefail
+
+THRESHOLD="${DUP_GUARD_THRESHOLD:-0.6}"
+MIN_SHARED="${DUP_GUARD_MIN_SHARED:-3}"
+BD_BIN="${BD_BIN:-bd}"
+
+usage() {
+  echo "usage: duplicate-work-guard.sh \"<candidate bead title>\"" >&2
+  exit 2
+}
+
+[ "$#" -ge 1 ] || usage
+candidate="$1"
+# Reject empty / whitespace-only titles.
+[ -n "${candidate//[[:space:]]/}" ] || usage
+
+# All issues including closed (the dup-seeding failure spans merged/closed work).
+beads_json="$("$BD_BIN" list --all --limit 0 --json 2>/dev/null || true)"
+[ -n "$beads_json" ] || beads_json='[]'
+
+match="$(
+  printf '%s' "$beads_json" | jq -r \
+    --arg cand "$candidate" \
+    --argjson threshold "$THRESHOLD" \
+    --argjson min "$MIN_SHARED" '
+    # Normalize a title to a set of significant (>=3 char) tokens.
+    def norm: (. // "")
+      | ascii_downcase
+      | gsub("[^a-z0-9]+"; " ")
+      | split(" ")
+      | map(select(length >= 3))
+      | unique;
+    ($cand | norm) as $c
+    | ($c | length) as $cn
+    | [ .[]
+        | . as $b
+        | ($b.title | norm) as $t
+        | ([ $t[] | select(. as $x | $c | index($x) != null) ] | length) as $shared
+        | { id: $b.id, status: $b.status, title: $b.title,
+            exact: ($cn > 0 and $t == $c),
+            shared: $shared,
+            ratio: (if $cn > 0 then ($shared / $cn) else 0 end) } ]
+    | map(select(.exact or (.shared >= $min and .ratio >= $threshold)))
+    | if length == 0 then empty
+      else (max_by(.ratio)) | "DUPLICATE: \(.id) [\(.status)] \(.title)"
+      end
+'
+)"
+
+if [ -n "$match" ]; then
+  echo "$match"
+  exit 1
+fi
+
+echo "OK: no existing work matches \"$candidate\""
+exit 0

--- a/tests/scripts/duplicate-work-guard.bats
+++ b/tests/scripts/duplicate-work-guard.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+# Regression tests for skills/evolve/scripts/duplicate-work-guard.sh (ag-6jt/ag-2je).
+#
+# The evolve-cron-rpi discovery loop kept re-seeding tracking beads for work
+# already covered by an existing bead or merged PR (ag-b8m≈ag-jov, ag-6kw≈ag-c2i)
+# because the only prior guard matched EXACT open-bead titles. These tests pin
+# the guard's behavior: it must catch (a) exact normalized title matches and
+# (b) same-surface, different-wording matches by significant-token overlap,
+# across open AND closed beads — while NOT blocking genuinely novel work.
+#
+# `bd` is PATH-stubbed to return a fixed bead set so tests are hermetic.
+
+setup() {
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  SCRIPT="$REPO_ROOT/skills/evolve/scripts/duplicate-work-guard.sh"
+  TMP="$(mktemp -d)"
+  ORIG_PATH="$PATH"
+
+  # Fixture bead set the stubbed `bd list --all --json` returns.
+  cat > "$TMP/beads.json" <<'JSON'
+[
+  {"id":"ag-jov","status":"closed","title":"Fix dangling validate-hooks-doc-parity.sh ref in docs-release-governance eval canary"},
+  {"id":"ag-x1","status":"open","title":"Add dark mode toggle to settings page"},
+  {"id":"ag-open1","status":"open","title":"Implement origin main diff in evolve cron rpi discovery"}
+]
+JSON
+
+  # Stub `bd`: any `list ... --json` invocation prints the fixture array.
+  mkdir -p "$TMP/bin"
+  cat > "$TMP/bin/bd" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "list" ]; then cat "$TMP/beads.json"; else echo "[]"; fi
+EOF
+  chmod +x "$TMP/bin/bd"
+  PATH="$TMP/bin:$PATH"
+}
+
+teardown() {
+  PATH="$ORIG_PATH"
+  rm -rf "$TMP"
+}
+
+@test "exact normalized title match is flagged as duplicate (exit 1)" {
+  run "$SCRIPT" "Implement origin main diff in evolve cron rpi discovery"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"DUPLICATE"* ]]
+  [[ "$output" == *"ag-open1"* ]]
+}
+
+@test "same-surface different-wording match is flagged via token overlap (the ag-b8m≈ag-jov class)" {
+  run "$SCRIPT" "Repair docs-release-governance eval canary dangling hooks-doc-parity reference"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ag-jov"* ]]
+}
+
+@test "closed beads are checked, not only open ones" {
+  # ag-jov is closed; a near-duplicate of it must still be caught.
+  run "$SCRIPT" "docs-release-governance eval canary dangling parity hooks doc ref"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ag-jov [closed]"* ]]
+}
+
+@test "genuinely novel work is NOT flagged (exit 0, no false positive)" {
+  run "$SCRIPT" "Configure Prometheus alerting for GPU temperature thresholds"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "missing title argument is a usage error (exit 2)" {
+  run "$SCRIPT"
+  [ "$status" -eq 2 ]
+}
+
+@test "blank title argument is a usage error (exit 2)" {
+  run "$SCRIPT" "   "
+  [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## What

The evolve-cron-rpi discovery loop kept re-seeding tracking beads for work already covered by an existing bead or merged PR (`ag-b8m`≈`ag-jov`, `ag-6kw`≈`ag-c2i` — **4th recurrence**, per `ag-6jt`). The only prior guard (`bd list --status=open | jq 'select(.title==$t)'`) matched **exact titles among open beads**, so same-surface, different-wording dups — and already-merged/closed work — slipped through.

## Change

New `skills/evolve/scripts/duplicate-work-guard.sh`: given a candidate bead title, it flags a duplicate when an existing **open OR closed** bead matches by:
1. exact normalized title (lowercased, punctuation-stripped), or
2. significant-token overlap (Jaccard ratio ≥ `0.6` and ≥ `3` shared ≥3-char tokens).

Exit `1` + `DUPLICATE: <id> [<status>] <title>` on a hit; exit `0` when genuinely new. Thresholds are env-overridable; `bd` binary is injectable (`BD_BIN`) for hermetic tests.

Wired as a **mandatory pre-`bd create` gate** in `skills/evolve/references/work-selection-ladder.md`, covering generators 3.4–3.7 and the Step-4 Split rung — so the primitive has a consumer (not an orphan).

## Acceptance (ag-2je / ag-6jt)
- **Scenario 1 — discovery diffs origin/main, not stale local main:** already satisfied by the cron's pre-fire `git branch -f main origin/main` sync; the ladder now documents it.
- **Scenario 2 — dup-bead guard before create:** this change. Covered by 6 bats cases: exact match, token-overlap same-surface match, closed-bead match, no-false-positive on novel work, and two usage-error guards.

## Scope boundary
Merged-PR coverage is **transitive** — merged work closes its bead, and the guard checks closed beads. A direct `gh pr list` title check isn't hermetic in CI and is deferred (the acceptance `Then` is bead-grep based).

## Verification
```
bats tests/scripts/duplicate-work-guard.bats   → 6/6 ok
shellcheck skills/evolve/scripts/duplicate-work-guard.sh   → clean
```

Closes-scenario: ag-2je#dup-bead-guard
Bounded-context: BC5-Runtime
Evidence: bats tests/scripts/duplicate-work-guard.bats