### PR TITLE
fix(ci): unbreak claude-review (timeout+cancel) and executable-spec-link-integrity (missing scenario s-...-015) gates (ag-1kcr)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,12 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+# Auto-cancel a superseded review when a new commit is pushed to the same PR so a
+# hung/stuck run does not linger and block the required check indefinitely.
+concurrency:
+  group: claude-review-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Optional: Filter by PR author
@@ -19,6 +25,10 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    # Bound the LLM review so a hung claude-code-action call FAILS fast (visible,
+    # re-runnable) instead of sitting in_progress to GitHub's 6h default and
+    # blocking the required merge gate. Observed: PR #591 stuck ~17min (ag-1kcr).
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,10 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    # Bound on-demand @claude runs so a hung call fails fast instead of burning a
+    # runner to GitHub's 6h default (same hang class as the review gate, ag-1kcr).
+    # More generous than the review gate since @claude may commit fixes / iterate.
+    timeout-minutes: 30
     permissions:
       contents: write       # @claude commits fixes to PR branches
       pull-requests: write  # @claude updates PR description, labels, comments, marks ready

--- a/spec/scenarios/s-2026-05-24-015.json
+++ b/spec/scenarios/s-2026-05-24-015.json
@@ -1,0 +1,12 @@
+{
+  "id": "s-2026-05-24-015",
+  "directive_id": "d-teardown-removed-apparatus-stays-removed",
+  "version": 1,
+  "date": "2026-05-24",
+  "goal": "Given a surface the teardown (epic ag-097) explicitly removed and recorded in scripts/removed-apparatus.txt, when an /evolve cycle or any change reintroduces that surface, then the no-apparatus-regrowth gate fails — teardown-removed apparatus stays removed.",
+  "narrative": "A user or evaluator exercises the system behavior for this goal: Given a surface the teardown (epic ag-097) explicitly removed and recorded in scripts/removed-apparatus.txt, when an /evolve cycle or any change reintroduces that surface, then the no-apparatus-regrowth gate fails — teardown-removed apparatus stays removed..",
+  "expected_outcome": "The implementation satisfies the goal in observable behavior: Given a surface the teardown (epic ag-097) explicitly removed and recorded in scripts/removed-apparatus.txt, when an /evolve cycle or any change reintroduces that surface, then the no-apparatus-regrowth gate fails — teardown-removed apparatus stays removed..",
+  "satisfaction_threshold": 0.85,
+  "source": "human",
+  "status": "active"
+}


### PR DESCRIPTION
Restores two CI gates the 2026-05-29 evolve session left broken/flaky.

## Fix 1 — claude-review hang (the gate you flagged)
`claude-code-review.yml` (required merge gate) + `claude.yml` (`@claude`) ran `anthropics/claude-code-action@v1` with **no `timeout-minutes`**. A hung LLM call ran to GitHub's **6h default** → required check stuck `pending` forever → merge blocked → forced 3× `--admin` bypass this session (#591 stuck ~17min).
- `claude-code-review.yml`: `timeout-minutes: 20` (hung review → **fast fail**, re-runnable, not stuck) + `concurrency` (`cancel-in-progress`) to supersede lingering runs.
- `claude.yml`: `timeout-minutes: 30` (same hang class).

A timed-out required check still blocks merge but is now *actionable*. Changing required-ness / the 6h default is out of scope (branch-protection policy).

## Fix 2 — executable-spec-link-integrity RED on main (regression from #591)
#591 (ag-8ok) added directive **D15** with `**Scenarios:** s-2026-05-24-015` but never created the scenario file. The lint gate (`ao goals scenarios --lint`) was **path-filter-skipped** on #591's CI, so the phantom reference merged and left **main red** (this also blocks #593's own copy of the gate). Fix: add `spec/scenarios/s-2026-05-24-015.json` (mirrors -013/-014), properly linking D15. Lint now: *"No executable-spec link defects found."*

## Note on this PR's own claude-review
`claude-code-action` requires the workflow file to be byte-identical to main's (anti-tamper). Because this PR *modifies* `claude-code-review.yml`, its own `claude-review` check fails by design (the action's error says this is "normal"). This PR must be admin-merged — the **last** bypass before the timeout protects future PRs. All deterministic gates (Validate, 65 jobs) are the merge signal.

Closes-scenario: ag-1kcr#claude-review-timeout
Bounded-context: BC5-Runtime
