### PR TITLE
feat(skills): operating-loop-workflow skill ships the workflow to plugin users (agentops-7m7a #plugin-deliver-operating-loop)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -67,7 +67,7 @@ The April 2026 Claude Code source analysis confirmed that Anthropic's internal t
 | Anthropic Concept | AgentOps Equivalent | Status |
 |---|---|---|
 | **Learning Loop** — memory extraction, dream cycle consolidation, future session context | Knowledge Flywheel — `/retro` → `/forge` → `/harvest` → `ao lookup` / `ao context assemble`, tiered promotion (learning → pattern → rule), plus bounded Dream via `/dream` | Live with bounds. On-demand capture/promotion works, and Dream provides an operator-started compounding lane. GitHub nightly is the public proof harness for the contracts, not the user's private runtime. |
-| **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 75 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
+| **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 76 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
 | **Verification Agent** — adversarial AI auditing AI, VERDICT system for human review | Council architecture — `/council`, `/pre-mortem`, `/vibe`, `/post-mortem` with multi-model consensus, prediction tracking. Stage 4 behavioral validation adds holdout scenarios + satisfaction scoring in STEP 1.8. | Live on demand. STEP 1.8 fires automatically inside `/validation` when that skill is invoked. |
 | **Managed Agents Dreaming** (May 2026) — scheduled session review, pattern extraction, memory curation between sessions | `/dream` + `.github/workflows/nightly.yml` proof jobs + substrate-driven scheduling when needed | Live with operator setup. The bounded private Dream lane runs harvest → forge → close-loop → defrag when the operator or substrate starts it. AgentOps itself no longer ships the daemon executor. |
 | **Managed Agents Outcomes** (May 2026) — rubric-driven separate-context grader with iterate-until-pass | Live at three scopes: project — `GOALS.md` (rubric) + `ao goals measure` (each gate runs as separate subprocess; `cli/internal/goals/measure.go:132-164`) + `/evolve` (can iterate a worst-failing gate under operator limits; `skills/evolve/SKILL.md:379-388`); plan — `/pre-mortem` council judges as separate-context graders; code — `/vibe` council judges. An internal council review (2026-05-06) found these capabilities present across rubric authoring, separate-context grading, iterate-until-pass, and pinpoint-what-changed; this is an internal finding, not an audited external-parity claim. | Live at the capability layer. Empirical workbench A/B (2026-05-06): Δ=+0.0000 across 12 cases at v1 difficulty (both legs 12/12) — task difficulty floor exhausted; v2 substrate (realistic agent tasks where the hook layer differentiates) is roadmap. Counter-stat artifact: `evals/workbench/results/2026-05-06-yjzp9-counterstat.json`. |
@@ -176,7 +176,7 @@ The same model used in the README: bookkeeping records the work, the context com
 - `ao lookup` — decay-ranked retrieval for on-demand knowledge
 - `ao context assemble` — phase-scoped context packets
 - `ao compile` — rebuild the knowledge wiki (mine, grow, defrag, lint)
-- 75 skills — reusable context packages across Claude Code, Codex, and OpenCode
+- 76 skills — reusable context packages across Claude Code, Codex, and OpenCode
 - `bash <(curl -fsSL .../install.sh)` — 30 seconds, zero config
 
 #### Layer 3: Validation Gates
@@ -261,7 +261,7 @@ As of 2026-05-10:
 
 - GitHub repo: 341 stars, 33 forks, 2 open issues, last pushed 2026-05-10T03:24:01Z
 - Public surface: GitHub Pages mkdocs site live at boshu2.github.io/agentops/; doctrine site live at 12factoragentops.com
-- Distribution/runtime reach: 75 shared skills, 75 checked-in Codex artifacts, and 32 Codex overrides. `/validate` and `/curate` are additive in this train; legacy validation and mining skills remain until their shim/retirement gates are resolved.
+- Distribution/runtime reach: 76 shared skills, 76 checked-in Codex artifacts, and 32 Codex overrides. `/validate` and `/curate` are additive in this train; legacy validation and mining skills remain until their shim/retirement gates are resolved.
 
 **Measured operational proof:**
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -351,7 +351,7 @@ All hooks can be disabled: `AGENTOPS_HOOKS_DISABLED=1` (kill switch) or per-hook
 .
 ├── .claude-plugin/
 │   └── plugin.json      # Plugin manifest
-├── skills/              # 75 skills (65 user-facing, 10 internal)
+├── skills/              # 76 skills (66 user-facing, 10 internal)
 │   ├── rpi/             # orchestration — Full RPI lifecycle orchestrator
 │   ├── council/         # orchestration — Multi-model validation (core primitive)
 │   ├── crank/           # orchestration — Autonomous epic execution

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -1,6 +1,6 @@
 # Skills Reference
 
-Complete reference for all 75 AgentOps skills (65 user-facing + 10 internal).
+Complete reference for all 76 AgentOps skills (66 user-facing + 10 internal).
 
 Skills are the primitive layer of AgentOps. Higher-level entry points like
 `/implement`, `/validation`, `/rpi`, and `/evolve` compose those primitives

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -38,6 +38,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `bootstrap` — Initialize AgentOps project files.
 - `implement` — Implement one tracked issue.
 - `inject` — Load relevant .agents context.
+- `operating-loop-workflow` — Install and run the operating-loop multi-agent Workflow (the seven-move loop) for AgentOps plugin users.
 - `pr-implement` — Implement a scoped OSS PR.
 - `pr-prep` — Prepare PR commits and body.
 - `pr-validate` — Validate PR scope and quality.
@@ -219,6 +220,7 @@ graph LR
 | `implement` | produces | git-changes |
 | `llm-wiki` | produces | documentation |
 | `openai-docs` | consumes | external-api |
+| `operating-loop-workflow` | produces | git-changes |
 | `perf` | consumes | repo-context |
 | `perf` | produces | result.json |
 | `plan` | consumes | standards |

--- a/docs/contracts/skill-dispositions.yaml
+++ b/docs/contracts/skill-dispositions.yaml
@@ -177,6 +177,11 @@ dispositions:
     hexagonal_role: driven-adapter
     disposition:    keep
     rationale:      "External API documentation adapter with clear scope"
+  - skill:          operating-loop-workflow
+    domain:         "BC3 Loop"
+    hexagonal_role: driving-adapter
+    disposition:    keep
+    rationale:      "Installs + invokes the operating-loop Workflow so plugin users get the seven-move loop"
   - skill:          perf
     domain:         "BC2 Validation"
     hexagonal_role: domain

--- a/docs/reference/agentops-domain-evolution-bdd.md
+++ b/docs/reference/agentops-domain-evolution-bdd.md
@@ -19,7 +19,7 @@ Feature: Domain-governed AgentOps 3.0 evolution
     And external-corpus-derived observations are used only through the clean-room policy
 
   Scenario: Audit every skill before changing shipped behavior
-    Given the checked-in skill catalog contains 75 skills
+    Given the checked-in skill catalog contains 76 skills
     When the evolution bootstrap audits the catalog
     Then every skill is assigned exactly one primary bounded context
     And each skill has a preliminary keep, update, refactor, merge-review, or cut-review disposition

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -1,7 +1,7 @@
 # AgentOps Skill Domain Map
 
 This map is the control surface for the next evolution loop. It classifies all
-75 checked-in AgentOps skills before any broad rewrite, using current
+76 checked-in AgentOps skills before any broad rewrite, using current
 `origin/main` product direction, GOALS Directive 12, the DDD/hexagonal ADR, and
 the `soc-y5vh` Loop epic.
 
@@ -18,9 +18,9 @@ around small provable changes.
 <!-- BEGIN:audit-summary -->
 | Signal | Result |
 |---|---:|
-| Skills audited | 75 |
+| Skills audited | 76 |
 | Domains classified | 5 of 5 (BC1-BC5) |
-| Dispositions assigned | 75 / 75 |
+| Dispositions assigned | 76 / 76 |
 <!-- END:audit-summary -->
 
 Observed gap: the catalog has strong operational kernels but weak productized
@@ -91,6 +91,7 @@ Disposition meanings:
 | `knowledge-activation` | BC1 Corpus | supporting | keep | Outer-loop operationalization (beliefs/playbooks/briefings) — write/promote surface downstream of inject/compile/flywheel, not a duplicate (resolved KEEP 2026-05-24). |
 | `llm-wiki` | BC1 Corpus | supporting | update | External wiki builder; align with Corpus compiler contracts. |
 | `openai-docs` | BC5 Runtime | driven-adapter | keep | External API documentation adapter with clear scope. |
+| `operating-loop-workflow` | BC3 Loop | driving-adapter | keep | Installs + invokes the operating-loop Workflow so plugin users get the seven-move loop. |
 | `perf` | BC2 Validation | domain | update | Performance generator; add thresholds and proof examples. |
 | `plan` | BC3 Loop | domain | update | Must output vertical slices and wave-validity checks. |
 | `post-mortem` | BC3 Loop | domain | update | Loop closeout; connect to next-work and ratchet evidence. |

--- a/registry.json
+++ b/registry.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-05-28T10:23:15Z",
+  "generated_at": "2026-05-29T02:10:24Z",
   "summary": {
-    "skills": 75,
+    "skills": 76,
     "hooks": 0,
     "knowledge_stores": 5,
     "job_types": 0,
     "eval_files": 56,
     "cli_commands": 67,
-    "capabilities": 211
+    "capabilities": 212
   },
   "surfaces": {
     "skills": [
@@ -187,6 +187,14 @@
         "has_skill_md": true,
         "has_references": true,
         "reference_count": 7
+      },
+      {
+        "name": "operating-loop-workflow",
+        "tier": "execution",
+        "path": "skills/operating-loop-workflow/",
+        "has_skill_md": true,
+        "has_references": false,
+        "reference_count": 0
       },
       {
         "name": "perf",
@@ -1342,8 +1350,8 @@
     ]
   },
   "capability_summary": {
-    "total": 211,
-    "skills": 75,
+    "total": 212,
+    "skills": 76,
     "cli_commands": 67,
     "gates": 66,
     "reference_impls": 3
@@ -2153,6 +2161,24 @@
       "produces": [],
       "drives_commands": [],
       "path": "skills/openai-docs/",
+      "references": 0
+    },
+    {
+      "sku": "skill:operating-loop-workflow",
+      "name": "operating-loop-workflow",
+      "type": "skill",
+      "bounded_context": "BC3",
+      "hex_role": "driving-adapter",
+      "tier": "execution",
+      "purpose": "Install and run the operating-loop multi-agent Workflow (the seven-move loop) for AgentOps plugin users.",
+      "status": "active",
+      "disposition": "keep",
+      "consumes": [],
+      "produces": [
+        "git-changes"
+      ],
+      "drives_commands": [],
+      "path": "skills/operating-loop-workflow/",
       "references": 0
     },
     {

--- a/skills-codex-overrides/catalog.json
+++ b/skills-codex-overrides/catalog.json
@@ -652,6 +652,12 @@
       "treatment": "parity_only",
       "wave": "catalog-parity",
       "reason": "Guide to running AgentOps on the Gas City (gc) substrate; gc-specific shell idioms and out-of-session orchestration vocabulary."
+    },
+    {
+      "name": "operating-loop-workflow",
+      "treatment": "parity_only",
+      "wave": "catalog-parity",
+      "reason": "Ship operating-loop Workflow to plugin users via installer skill; Codex twin redirects to the $rpi chain since Codex lacks the Workflow tool"
     }
   ]
 }

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -2,7 +2,7 @@
   "generator": "manual-maintained",
   "source_root": "skills",
   "layout": "modular",
-  "codex_override_catalog_hash": "4b7376af85273d2df0dfec3b3a027b43d34789e6af2eecfe424158c978c18507",
+  "codex_override_catalog_hash": "aef940bdfe26c2955145f7338854b193e9ef2b3baf7448e4fadebfbb26bb8fa1",
   "codex_override_catalog": {
     "version": 1,
     "description": "Machine-readable Codex treatment map for the full skill catalog.",
@@ -642,6 +642,12 @@
         "treatment": "parity_only",
         "wave": "catalog-parity",
         "reason": "Guide to running AgentOps on the Gas City (gc) substrate; gc-specific shell idioms and out-of-session orchestration vocabulary."
+      },
+      {
+        "name": "operating-loop-workflow",
+        "treatment": "parity_only",
+        "wave": "catalog-parity",
+        "reason": "Ship operating-loop Workflow to plugin users via installer skill; Codex twin redirects to the $rpi chain since Codex lacks the Workflow tool"
       }
     ]
   },
@@ -655,7 +661,7 @@
     {
       "name": "beads",
       "source_skill": "skills/beads",
-      "source_hash": "85281e81a770ff1f081b37664ded15efca08acbe3cb9e9e402666ba0afc31321",
+      "source_hash": "ed5f5d242b6bb903c7ba3120e7ffe82a8c2a7bd7f21b21d9c6274de205d710e1",
       "generated_hash": "51db26466d4646eddfc2132ea521508fe2ced556ef0ab69db41acd363afba770"
     },
     {
@@ -733,7 +739,7 @@
     {
       "name": "discovery",
       "source_skill": "skills/discovery",
-      "source_hash": "fc6873f7e0d7bb541e9ee6f85ac00179d88c30e9ad879fcea6d654696c286347",
+      "source_hash": "da99e855580351e6dc3155cf73b6e5669eb70d6774ca55f624cb7f84785f46fe",
       "generated_hash": "6c307529f6519b93745a4f410641b4991c0676a5f564de7f2b53d8d9cffe6b48"
     },
     {
@@ -757,7 +763,7 @@
     {
       "name": "evolve",
       "source_skill": "skills/evolve",
-      "source_hash": "ecfc27d86c3660cbd64b3455265ac89250a1cdf733a2dcadaa1d236c9f53318a",
+      "source_hash": "a82ec266a2f22a2d6a065695f365cbf778efc063baea7aa01541f0291b1cffcb",
       "generated_hash": "5c8274c6606089b1a2854015f0f0f5176ed49806e3a6e9fce10749eeabffd01f"
     },
     {
@@ -839,6 +845,12 @@
       "generated_hash": "897d7a15f493cf6e64262e0ff44e5083bffee62787bead5fd106658cd9c09e18"
     },
     {
+      "name": "operating-loop-workflow",
+      "source_skill": "skills/operating-loop-workflow",
+      "source_hash": "a5101f268118143a999e8b95601e71a9fa844bf53d0b65572730c9fd928966cb",
+      "generated_hash": "26ea2810425effbed57406c48138ac8f906165b961f3d9ee0c593cf11b8bef42"
+    },
+    {
       "name": "perf",
       "source_skill": "skills/perf",
       "source_hash": "76369d06999ce6adb4b4f37e62fecf0663bf10c8a22337299a91132486b53dee",
@@ -853,7 +865,7 @@
     {
       "name": "post-mortem",
       "source_skill": "skills/post-mortem",
-      "source_hash": "16ace03ff20aa116ac02077be568a0d1f44fe99eac9a5b0b394cfb02cab7e47d",
+      "source_hash": "629f0c1d95807d58e251bf26e3b864906598435ea772857749b74fcedc33d7f9",
       "generated_hash": "960c599da43c3a8167fbb2a766cfc88a45fe1f8fb29295f5ccd006b8f52442bb"
     },
     {
@@ -907,7 +919,7 @@
     {
       "name": "quickstart",
       "source_skill": "skills/quickstart",
-      "source_hash": "8ef0d01365670314f08d3c334fe1bdbb832390dbfa5a2539250b72c419bae35c",
+      "source_hash": "70c965d7efee46753e3eb5be858ddcf76ef9844ea0191fae2fcb4d6f85c871e5",
       "generated_hash": "d84dba4d4b56458c7777aa073920992e32e45ee3a58bd6196967eb676c12addf"
     },
     {
@@ -937,7 +949,7 @@
     {
       "name": "release",
       "source_skill": "skills/release",
-      "source_hash": "84e3cc2973070840ad30014bf0e37bf05f4c340761ed676896db48a4a109edb5",
+      "source_hash": "de0db99fec8d814411fcdb57772fb6a2b4e4bbba6c0aed2bc25e52e561fdcbbb",
       "generated_hash": "5b3075bdee6aeed794ad7841e990f0cc94dbad414506c57f8cb4f42515c4e465"
     },
     {
@@ -1039,7 +1051,7 @@
     {
       "name": "status",
       "source_skill": "skills/status",
-      "source_hash": "31124196d17cb64f0676d7747943ec1df897d84eddbe2795ca5ef4ca3a7763e7",
+      "source_hash": "9f9a3dcdaedf9bb1f98257b169436bada82f173e6fe0230f18920cb9e9d0fe46",
       "generated_hash": "54b1562de6d9c7beb832214ffe14c5fb1d3caf702487151145a80092063d7600"
     },
     {
@@ -1069,7 +1081,7 @@
     {
       "name": "using-agentops",
       "source_skill": "skills/using-agentops",
-      "source_hash": "42195225b231377bc99e3969970bcd233b22c8b304904b8867620015ed089fb8",
+      "source_hash": "3687114d95f67041a24c2cf04bc21ea5dd8e18c8208e8ee56d3fdcf9a489f890",
       "generated_hash": "80119493d38739d5ca4d9377c97c7e4f6e5766365525c965297c1cd78029e74b"
     },
     {

--- a/skills-codex/beads/.agentops-generated.json
+++ b/skills-codex/beads/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/beads",
   "layout": "modular",
-  "source_hash": "85281e81a770ff1f081b37664ded15efca08acbe3cb9e9e402666ba0afc31321",
+  "source_hash": "ed5f5d242b6bb903c7ba3120e7ffe82a8c2a7bd7f21b21d9c6274de205d710e1",
   "generated_hash": "51db26466d4646eddfc2132ea521508fe2ced556ef0ab69db41acd363afba770"
 }

--- a/skills-codex/discovery/.agentops-generated.json
+++ b/skills-codex/discovery/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/discovery",
   "layout": "modular",
-  "source_hash": "fc6873f7e0d7bb541e9ee6f85ac00179d88c30e9ad879fcea6d654696c286347",
+  "source_hash": "da99e855580351e6dc3155cf73b6e5669eb70d6774ca55f624cb7f84785f46fe",
   "generated_hash": "6c307529f6519b93745a4f410641b4991c0676a5f564de7f2b53d8d9cffe6b48"
 }

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/evolve",
   "layout": "modular",
-  "source_hash": "ecfc27d86c3660cbd64b3455265ac89250a1cdf733a2dcadaa1d236c9f53318a",
+  "source_hash": "a82ec266a2f22a2d6a065695f365cbf778efc063baea7aa01541f0291b1cffcb",
   "generated_hash": "5c8274c6606089b1a2854015f0f0f5176ed49806e3a6e9fce10749eeabffd01f"
 }

--- a/skills-codex/operating-loop-workflow/.agentops-generated.json
+++ b/skills-codex/operating-loop-workflow/.agentops-generated.json
@@ -1,0 +1,7 @@
+{
+  "generator": "manual-maintained",
+  "source_skill": "skills/operating-loop-workflow",
+  "layout": "modular",
+  "source_hash": "a5101f268118143a999e8b95601e71a9fa844bf53d0b65572730c9fd928966cb",
+  "generated_hash": "26ea2810425effbed57406c48138ac8f906165b961f3d9ee0c593cf11b8bef42"
+}

--- a/skills-codex/operating-loop-workflow/SKILL.md
+++ b/skills-codex/operating-loop-workflow/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: operating-loop-workflow
+description: 'Install and run the operating-loop multi-agent Workflow (the seven-move loop) for AgentOps plugin users.'
+---
+# $operating-loop-workflow
+
+> **One job:** Run the operating-loop seven-move loop (shape → plan → pre-flight → implement → capture) in Codex.
+
+**YOU MUST EXECUTE THIS WORKFLOW. Do not just describe it.**
+
+In the Codex runtime the operating-loop seven moves ARE the `$rpi` skill chain — there is no
+separate engine to install. `$rpi` composes the loop end to end.
+
+## Execution
+
+1. Run `$rpi --auto "<the capability/intent to drive through the loop>"`.
+   - `$rpi` chains `$discovery` (shape → plan → pre-mortem) → `$crank` (TDD per slice across
+     conflict-free waves) → `$validation` (acceptance roll-up + capture).
+   - For the plan-only half (shape → plan → pre-flight, no implementation), run
+     `$discovery "<intent>"` and stop after `$pre-mortem`.
+2. Report the resulting plan, the `$pre-mortem` verdict, and the `$validation` outcome.
+
+## Guardrails
+
+1. Treat `$rpi` as the canonical seven-move loop in Codex.
+2. Preserve each move's evidence (plan, pre-mortem verdict, validation result) before advancing.

--- a/skills-codex/operating-loop-workflow/prompt.md
+++ b/skills-codex/operating-loop-workflow/prompt.md
@@ -1,0 +1,14 @@
+# operating-loop-workflow
+
+Run the operating-loop seven-move loop (shape → plan → pre-flight → implement → capture) in Codex.
+
+## Codex Execution Profile
+
+1. In Codex, the operating-loop seven moves ARE the `$rpi` chain (`$discovery` → `$crank` → `$validation`); there is no separate engine to install.
+2. Run `$rpi --auto "<intent>"` for the full loop, or `$discovery "<intent>"` stopping after `$pre-mortem` for the plan-only half.
+3. Keep cross-runtime references brief and non-blocking.
+
+## Guardrails
+
+1. Treat `$rpi` as the canonical seven-move loop in Codex.
+2. Preserve each move's evidence (plan, pre-mortem verdict, validation result) before advancing.

--- a/skills-codex/post-mortem/.agentops-generated.json
+++ b/skills-codex/post-mortem/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/post-mortem",
   "layout": "modular",
-  "source_hash": "16ace03ff20aa116ac02077be568a0d1f44fe99eac9a5b0b394cfb02cab7e47d",
+  "source_hash": "629f0c1d95807d58e251bf26e3b864906598435ea772857749b74fcedc33d7f9",
   "generated_hash": "960c599da43c3a8167fbb2a766cfc88a45fe1f8fb29295f5ccd006b8f52442bb"
 }

--- a/skills-codex/quickstart/.agentops-generated.json
+++ b/skills-codex/quickstart/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/quickstart",
   "layout": "modular",
-  "source_hash": "8ef0d01365670314f08d3c334fe1bdbb832390dbfa5a2539250b72c419bae35c",
+  "source_hash": "70c965d7efee46753e3eb5be858ddcf76ef9844ea0191fae2fcb4d6f85c871e5",
   "generated_hash": "d84dba4d4b56458c7777aa073920992e32e45ee3a58bd6196967eb676c12addf"
 }

--- a/skills-codex/release/.agentops-generated.json
+++ b/skills-codex/release/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/release",
   "layout": "modular",
-  "source_hash": "84e3cc2973070840ad30014bf0e37bf05f4c340761ed676896db48a4a109edb5",
+  "source_hash": "de0db99fec8d814411fcdb57772fb6a2b4e4bbba6c0aed2bc25e52e561fdcbbb",
   "generated_hash": "5b3075bdee6aeed794ad7841e990f0cc94dbad414506c57f8cb4f42515c4e465"
 }

--- a/skills-codex/status/.agentops-generated.json
+++ b/skills-codex/status/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/status",
   "layout": "modular",
-  "source_hash": "31124196d17cb64f0676d7747943ec1df897d84eddbe2795ca5ef4ca3a7763e7",
+  "source_hash": "9f9a3dcdaedf9bb1f98257b169436bada82f173e6fe0230f18920cb9e9d0fe46",
   "generated_hash": "54b1562de6d9c7beb832214ffe14c5fb1d3caf702487151145a80092063d7600"
 }

--- a/skills-codex/using-agentops/.agentops-generated.json
+++ b/skills-codex/using-agentops/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/using-agentops",
   "layout": "modular",
-  "source_hash": "42195225b231377bc99e3969970bcd233b22c8b304904b8867620015ed089fb8",
+  "source_hash": "3687114d95f67041a24c2cf04bc21ea5dd8e18c8208e8ee56d3fdcf9a489f890",
   "generated_hash": "80119493d38739d5ca4d9377c97c7e4f6e5766365525c965297c1cd78029e74b"
 }

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -221,7 +221,7 @@ These are how skills chain in practice:
 
 ## Current Skill Tiers
 
-### User-Facing Skills (65)
+### User-Facing Skills (66)
 
 **Judgment:**
 
@@ -250,6 +250,7 @@ These are how skills chain in practice:
 | **swarm** | execution | Parallelize any skill — fresh context per agent |
 | **rpi** | meta | Thin wrapper: /discovery → /crank → /validation with complexity classification and loop |
 | **evolve** | execution | Autonomous fitness-scored improvement loop |
+| **operating-loop-workflow** | execution | Install + run the operating-loop multi-agent Workflow (seven-move loop) for plugin users |
 | **autodev** | execution | PROGRAM.md autonomous development contract setup and validation |
 | **bug-hunt** | execution | Investigate bugs with git archaeology |
 | **complexity** | execution | Cyclomatic complexity analysis |

--- a/skills/operating-loop-workflow/SKILL.md
+++ b/skills/operating-loop-workflow/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: operating-loop-workflow
+description: Install and run the operating-loop multi-agent Workflow (the seven-move loop) for AgentOps plugin users.
+practices:
+- pragmatic-programmer
+- agile-manifesto
+hexagonal_role: driving-adapter
+consumes: []
+produces:
+- git-changes
+context_rel: []
+skill_api_version: 1
+context:
+  window: inherit
+  intent:
+    mode: task
+  intel_scope: none
+metadata:
+  tier: execution
+  dependencies: []
+output_contract: 'installs ~/.claude/workflows/operating-loop.js, then invokes the operating-loop Workflow; returns its structured result'
+---
+# /operating-loop-workflow
+
+> **One job:** Make the `operating-loop` multi-agent Workflow available to this install, then run it.
+
+**YOU MUST EXECUTE THIS WORKFLOW. Do not just describe it.**
+
+The seven-move operating loop (shape → plan → pre-flight → implement → capture) ships as a
+Claude Code **Workflow-tool** script at `.claude/workflows/operating-loop.js`. Claude Code
+plugins do **not** auto-load `.claude/workflows/` from an install — workflows resolve only from
+the project cwd or `~/.claude/workflows/`. So this skill installs the bundled script into the
+user workflows directory, then invokes it.
+
+## Steps — run in order
+
+1. **Install the workflow (idempotent — only copies when the bundled script is newer or missing):**
+   ```bash
+   mkdir -p "$HOME/.claude/workflows"
+   src="${CLAUDE_PLUGIN_ROOT}/.claude/workflows/operating-loop.js"
+   dst="$HOME/.claude/workflows/operating-loop.js"
+   if [ -f "$src" ] && { [ ! -f "$dst" ] || [ "$src" -nt "$dst" ]; }; then
+     cp "$src" "$dst" && echo "installed operating-loop workflow -> $dst"
+   else
+     echo "operating-loop workflow already current (or bundle not found)"
+   fi
+   ```
+2. **Run it** via the Workflow tool, passing the user's capability/intent as `args`:
+   - Full loop: `Workflow({ name: "operating-loop", args: "<the capability/intent to drive through the loop>" })`
+   - Plan-only (the safe Shape → Plan → Pre-flight half, no implementation):
+     `Workflow({ name: "operating-loop", args: { mode: "plan", intent: "<intent>" } })`
+3. **Report** the returned `intent`, `plan`, pre-flight `verdicts`, and `closeout` to the user.
+
+## Notes
+
+- After step 1 succeeds once, the workflow is invocable directly via the Workflow tool (`Workflow({name:'operating-loop'})`) in future sessions — this skill is the installer + first-run entry point.
+- The script is a leaf Workflow (it does not nest other workflows). Source of truth: `.claude/workflows/operating-loop.js`.
+- Re-running step 1 is safe and cheap; it copies only when the bundled script is newer.

--- a/skills/using-agentops/SKILL.md
+++ b/skills/using-agentops/SKILL.md
@@ -145,6 +145,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/crank` | Autonomous epic loop (uses swarm for each wave) |
 | `/swarm` | Fresh-context parallel execution (Ralph pattern) |
 | `/evolve` | Goal-driven fitness-scored improvement loop |
+| `/operating-loop-workflow` | Install + run the operating-loop multi-agent Workflow (seven-move loop) |
 | `/autodev` | PROGRAM.md autonomous development contract setup and validation |
 | `/dream` | Interactive Dream operator surface for setup, bedtime runs, and morning reports |
 | `/doc` | Documentation generation — repo docs (default), gold-standard README (`--mode=readme`), OSS doc packs (`--mode=oss`) |


### PR DESCRIPTION
## What
Adds a `operating-loop-workflow` skill that delivers the `operating-loop` Workflow-tool script to **installed plugin users** and invokes it.

## Why
Claude Code plugins do **not** load `.claude/workflows/*.js` (recognized components are `skills/`, `commands/`, `agents/`, `hooks/`, …). PR #594 force-added the script so it *ships in the plugin cache*, but an installed user still wouldn't see `/operating-loop`. This skill is the delivery vehicle.

## How
On `/operating-loop-workflow`, the skill:
1. Idempotently copies `${CLAUDE_PLUGIN_ROOT}/.claude/workflows/operating-loop.js` → `~/.claude/workflows/operating-loop.js` (copy-if-newer; never clobbers user edits).
2. Invokes `Workflow({name:'operating-loop', args})` (supports `{mode:'plan'}` for the plan-only half).

Named `operating-loop-workflow` (not `operating-loop`) to avoid colliding with the workflow's own auto-surfaced `/operating-loop` in the dev repo.

## Registries updated
- `skills/SKILL-TIERS.md` row + `sync-skill-counts.sh` (→ 76 total, 66 user-facing)
- `docs/contracts/skill-dispositions.yaml` + regenerated `docs/reference/agentops-skill-domain-map.md` (76/76)
- `docs/contracts/context-map.md`, `docs/reference/agentops-domain-evolution-bdd.md` count

## Validation
- `scripts/pre-push-gate.sh --fast` passed (registry-drift, skill-domain-map golden gate, domain-evolution plan all green)
- `generate-skill-domain-map.sh`: 76 skills, 76 dispositions, clean

Closes-scenario: agentops-7m7a#plugin-deliver-operating-loop
Bounded-context: BC3-Loop
Evidence: docs/reference/agentops-skill-domain-map.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)