### PR TITLE
feat(eval): holdout-safe Rubric projection for Outcomes (ag-hdqu0 #rubric-model)

### DIFF
--- a/cli/internal/evalsubstrate/rubric.go
+++ b/cli/internal/evalsubstrate/rubric.go
@@ -1,0 +1,78 @@
+package evalsubstrate
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Rubric is the holdout-safe projection of a locked eval Task's grading criteria,
+// used as the payload for an Outcomes-style grading transport (cloud Managed
+// Agents, async jobs, or the local Codex/NTM path). It is a DERIVED artifact:
+// ~/.agents/evals/SCHEMA.md remains the sole authority and a Rubric is never an
+// alternate bar. A Rubric NEVER carries ground-truth answers (GroundTruthRow.Value)
+// — that is the load-bearing holdout-isolation invariant at the cloud boundary,
+// because Managed Agents are not ZDR. The projection enforces this by construction:
+// ProjectRubric does not accept ground-truth rows, so it cannot copy them.
+type Rubric struct {
+	SchemaVersion    int         `json:"schema_version"`
+	SourceTaskID     string      `json:"source_task_id"`
+	JudgeContentHash string      `json:"judge_content_hash"`
+	Instructions     string      `json:"instructions,omitempty"`
+	Criteria         []Criterion `json:"criteria"`
+}
+
+// Criterion is a single allowlisted grading dimension projected from the judge
+// spec. Only these fields ever cross the boundary — no target, value, or answer.
+type Criterion struct {
+	ID          string  `json:"id"`
+	Description string  `json:"description"`
+	Weight      float64 `json:"weight"`
+}
+
+// ProjectRubric builds a holdout-safe Rubric from a locked Task, its grading
+// criteria (sourced upstream from the judge spec), and the judge content hash
+// used for drift detection (SCHEMA rc2 parity). It copies ONLY the allowlisted
+// criterion fields and the task's id/description; it never reads or copies any
+// GroundTruthRow value. The judgeContentHash lets a stale rubric self-invalidate
+// exactly like a stale local judge.
+func ProjectRubric(task Task, criteria []Criterion, judgeContentHash string) Rubric {
+	out := make([]Criterion, 0, len(criteria))
+	for _, c := range criteria {
+		out = append(out, Criterion{
+			ID:          c.ID,
+			Description: c.Description,
+			Weight:      c.Weight,
+		})
+	}
+	return Rubric{
+		SchemaVersion:    SchemaVersion,
+		SourceTaskID:     task.ID,
+		JudgeContentHash: judgeContentHash,
+		Instructions:     task.Description,
+		Criteria:         out,
+	}
+}
+
+// ContainsAny is the defense-in-depth re-scan guard (ag-hdqu0 holdout-leak guard
+// layer 3). It reports the first forbidden substring (e.g. a holdout
+// GroundTruthRow.Value) found in the Rubric's JSON encoding, or ("", false) when
+// the payload is clean. Empty forbidden strings never match. Even though
+// ProjectRubric cannot copy ground truth by construction, every caller MUST
+// re-scan the emitted payload with the run's holdout values before it crosses
+// the cloud boundary.
+func (r Rubric) ContainsAny(forbidden []string) (string, bool) {
+	blob, err := json.Marshal(r)
+	if err != nil {
+		return "", false
+	}
+	payload := string(blob)
+	for _, f := range forbidden {
+		if f == "" {
+			continue
+		}
+		if strings.Contains(payload, f) {
+			return f, true
+		}
+	}
+	return "", false
+}

--- a/cli/internal/evalsubstrate/rubric_test.go
+++ b/cli/internal/evalsubstrate/rubric_test.go
@@ -1,0 +1,83 @@
+package evalsubstrate
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestProjectRubric_StripsHoldoutValues is the keystone holdout-isolation test
+// for the Outcomes projection (ag-hdqu0.9 / ag-hdqu0.1). It proves that a Rubric
+// built from a locked Task carries grading criteria but ZERO ground-truth answer
+// values — the load-bearing invariant at the cloud boundary (Managed Agents are
+// not ZDR).
+func TestProjectRubric_StripsHoldoutValues(t *testing.T) {
+	task := Task{
+		SchemaVersion: SchemaVersion,
+		ID:            "task-capital-cities",
+		Domain:        "geography",
+		Description:   "Answer the capital-city question accurately.",
+	}
+	criteria := []Criterion{
+		{ID: "accuracy", Description: "Names the correct capital city.", Weight: 0.7},
+		{ID: "concision", Description: "Answers in one short sentence.", Weight: 0.3},
+	}
+	// The holdout ground-truth answers that MUST NEVER appear in the rubric.
+	holdout := []GroundTruthRow{
+		{ID: "q1", Value: "Ouagadougou", Split: "holdout"},
+		{ID: "q2", Value: "Antananarivo", Split: "holdout"},
+	}
+	const judgeHash = "sha256:abc123"
+
+	r := ProjectRubric(task, criteria, judgeHash)
+
+	if r.SourceTaskID != task.ID {
+		t.Errorf("SourceTaskID = %q, want %q", r.SourceTaskID, task.ID)
+	}
+	if r.JudgeContentHash != judgeHash {
+		t.Errorf("JudgeContentHash = %q, want %q", r.JudgeContentHash, judgeHash)
+	}
+	if len(r.Criteria) != 2 {
+		t.Fatalf("len(Criteria) = %d, want 2", len(r.Criteria))
+	}
+	if r.Criteria[0].ID != "accuracy" || r.Criteria[0].Weight != 0.7 {
+		t.Errorf("Criteria[0] = %+v, want accuracy/0.7", r.Criteria[0])
+	}
+
+	// Holdout isolation: the marshaled rubric must contain none of the answers.
+	blob, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	payload := string(blob)
+	for _, gt := range holdout {
+		if strings.Contains(payload, gt.Value) {
+			t.Errorf("rubric payload leaked holdout value %q", gt.Value)
+		}
+	}
+}
+
+// TestRubric_ContainsAny is the defense-in-depth re-scan guard (layer 3): even
+// though ProjectRubric cannot copy ground truth by construction, callers MUST
+// re-scan the emitted payload before it crosses the cloud boundary. The guard
+// must (a) pass a clean rubric and (b) catch a planted forbidden value.
+func TestRubric_ContainsAny(t *testing.T) {
+	clean := ProjectRubric(
+		Task{ID: "t1"},
+		[]Criterion{{ID: "c1", Description: "be correct", Weight: 1.0}},
+		"sha256:deadbeef",
+	)
+	if hit, found := clean.ContainsAny([]string{"Ouagadougou", "Antananarivo"}); found {
+		t.Errorf("clean rubric falsely flagged for %q", hit)
+	}
+	// Empty forbidden strings must never match.
+	if _, found := clean.ContainsAny([]string{""}); found {
+		t.Error("empty forbidden string must not match")
+	}
+	// Plant a forbidden value in the instructions and confirm the guard catches it.
+	planted := clean
+	planted.Instructions = "The answer is Ouagadougou."
+	if hit, found := planted.ContainsAny([]string{"Ouagadougou"}); !found || hit != "Ouagadougou" {
+		t.Errorf("guard missed planted value: hit=%q found=%v", hit, found)
+	}
+}


### PR DESCRIPTION
## What
Adds `evalsubstrate.Rubric` + `Criterion` + `ProjectRubric()` — the holdout-safe projection `ao eval outcomes compile` will emit. The rubric-model half of the operator-chosen substrate prereq (ag-hdqu0.9).

## Holdout isolation (the load-bearing invariant; Managed Agents are NOT ZDR)
- **By construction:** `ProjectRubric` never receives ground-truth rows, so it physically cannot copy `GroundTruthRow.Value`.
- **Defense-in-depth:** `Rubric.ContainsAny` re-scan guard (holdout-leak guard layer 3) for callers to run on the emitted payload before any cloud boundary crossing.
- Carries `judge_content_hash` so a stale rubric self-invalidates like a stale local judge (SCHEMA rc2 parity).

EXTENDS the locked eval substrate; SCHEMA.md stays the sole authority.

## Tests (TDD)
- `TestProjectRubric_StripsHoldoutValues` — keystone: projected rubric leaks none of the holdout answers.
- `TestRubric_ContainsAny` — guard passes clean, catches a planted value, ignores empty strings.
- 71 pass in evalsubstrate, `go vet` clean, `go build ./...` success.

## Remaining for ag-hdqu0.9
The gate#3 global-Dolt holdout **burn ledger** is the other half (separate slice).

Closes-scenario: ag-hdqu0.9#rubric-model
Bounded-context: BC1-Corpus
Evidence: cli/internal/evalsubstrate/rubric_test.go