### PR TITLE
feat(skills): add /burndown — bounded epic-completion loop (ag-3yl8 #burndown-skill)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -67,7 +67,7 @@ The April 2026 Claude Code source analysis confirmed that Anthropic's internal t
 | Anthropic Concept | AgentOps Equivalent | Status |
 |---|---|---|
 | **Learning Loop** — memory extraction, dream cycle consolidation, future session context | Knowledge Flywheel — `/retro` → `/forge` → `/harvest` → `ao lookup` / `ao context assemble`, tiered promotion (learning → pattern → rule), plus bounded Dream via `/dream` | Live with bounds. On-demand capture/promotion works, and Dream provides an operator-started compounding lane. GitHub nightly is the public proof harness for the contracts, not the user's private runtime. |
-| **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 77 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
+| **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 79 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
 | **Verification Agent** — adversarial AI auditing AI, VERDICT system for human review | Council architecture — `/council`, `/pre-mortem`, `/vibe`, `/post-mortem` with multi-model consensus, prediction tracking. Stage 4 behavioral validation adds holdout scenarios + satisfaction scoring in STEP 1.8. | Live on demand. STEP 1.8 fires automatically inside `/validation` when that skill is invoked. |
 | **Managed Agents Dreaming** (May 2026) — scheduled session review, pattern extraction, memory curation between sessions | `/dream` + `.github/workflows/nightly.yml` proof jobs + substrate-driven scheduling when needed | Live with operator setup. The bounded private Dream lane runs harvest → forge → close-loop → defrag when the operator or substrate starts it. AgentOps itself no longer ships the daemon executor. |
 | **Managed Agents Outcomes** (May 2026) — rubric-driven separate-context grader with iterate-until-pass | Live at three scopes: project — `GOALS.md` (rubric) + `ao goals measure` (each gate runs as separate subprocess; `cli/internal/goals/measure.go:132-164`) + `/evolve` (can iterate a worst-failing gate under operator limits; `skills/evolve/SKILL.md:379-388`); plan — `/pre-mortem` council judges as separate-context graders; code — `/vibe` council judges. An internal council review (2026-05-06) found these capabilities present across rubric authoring, separate-context grading, iterate-until-pass, and pinpoint-what-changed; this is an internal finding, not an audited external-parity claim. | Live at the capability layer. Empirical workbench A/B (2026-05-06): Δ=+0.0000 across 12 cases at v1 difficulty (both legs 12/12) — task difficulty floor exhausted; v2 substrate (realistic agent tasks where the hook layer differentiates) is roadmap. Counter-stat artifact: `evals/workbench/results/2026-05-06-yjzp9-counterstat.json`. |
@@ -176,7 +176,7 @@ The same model used in the README: bookkeeping records the work, the context com
 - `ao lookup` — decay-ranked retrieval for on-demand knowledge
 - `ao context assemble` — phase-scoped context packets
 - `ao compile` — rebuild the knowledge wiki (mine, grow, defrag, lint)
-- 77 skills — reusable context packages across Claude Code, Codex, and OpenCode
+- 79 skills — reusable context packages across Claude Code, Codex, and OpenCode
 - `bash <(curl -fsSL .../install.sh)` — 30 seconds, zero config
 
 #### Layer 3: Validation Gates
@@ -261,7 +261,7 @@ As of 2026-05-10:
 
 - GitHub repo: 341 stars, 33 forks, 2 open issues, last pushed 2026-05-10T03:24:01Z
 - Public surface: GitHub Pages mkdocs site live at boshu2.github.io/agentops/; doctrine site live at 12factoragentops.com
-- Distribution/runtime reach: 77 shared skills, 77 checked-in Codex artifacts, and 32 Codex overrides. `/validate` and `/curate` are additive in this train; legacy validation and mining skills remain until their shim/retirement gates are resolved.
+- Distribution/runtime reach: 79 shared skills, 79 checked-in Codex artifacts, and 32 Codex overrides. `/validate` and `/curate` are additive in this train; legacy validation and mining skills remain until their shim/retirement gates are resolved.
 
 **Measured operational proof:**
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -67,7 +67,7 @@ The April 2026 Claude Code source analysis confirmed that Anthropic's internal t
 | Anthropic Concept | AgentOps Equivalent | Status |
 |---|---|---|
 | **Learning Loop** — memory extraction, dream cycle consolidation, future session context | Knowledge Flywheel — `/retro` → `/forge` → `/harvest` → `ao lookup` / `ao context assemble`, tiered promotion (learning → pattern → rule), plus bounded Dream via `/dream` | Live with bounds. On-demand capture/promotion works, and Dream provides an operator-started compounding lane. GitHub nightly is the public proof harness for the contracts, not the user's private runtime. |
-| **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 78 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
+| **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 77 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
 | **Verification Agent** — adversarial AI auditing AI, VERDICT system for human review | Council architecture — `/council`, `/pre-mortem`, `/vibe`, `/post-mortem` with multi-model consensus, prediction tracking. Stage 4 behavioral validation adds holdout scenarios + satisfaction scoring in STEP 1.8. | Live on demand. STEP 1.8 fires automatically inside `/validation` when that skill is invoked. |
 | **Managed Agents Dreaming** (May 2026) — scheduled session review, pattern extraction, memory curation between sessions | `/dream` + `.github/workflows/nightly.yml` proof jobs + substrate-driven scheduling when needed | Live with operator setup. The bounded private Dream lane runs harvest → forge → close-loop → defrag when the operator or substrate starts it. AgentOps itself no longer ships the daemon executor. |
 | **Managed Agents Outcomes** (May 2026) — rubric-driven separate-context grader with iterate-until-pass | Live at three scopes: project — `GOALS.md` (rubric) + `ao goals measure` (each gate runs as separate subprocess; `cli/internal/goals/measure.go:132-164`) + `/evolve` (can iterate a worst-failing gate under operator limits; `skills/evolve/SKILL.md:379-388`); plan — `/pre-mortem` council judges as separate-context graders; code — `/vibe` council judges. An internal council review (2026-05-06) found these capabilities present across rubric authoring, separate-context grading, iterate-until-pass, and pinpoint-what-changed; this is an internal finding, not an audited external-parity claim. | Live at the capability layer. Empirical workbench A/B (2026-05-06): Δ=+0.0000 across 12 cases at v1 difficulty (both legs 12/12) — task difficulty floor exhausted; v2 substrate (realistic agent tasks where the hook layer differentiates) is roadmap. Counter-stat artifact: `evals/workbench/results/2026-05-06-yjzp9-counterstat.json`. |
@@ -176,7 +176,7 @@ The same model used in the README: bookkeeping records the work, the context com
 - `ao lookup` — decay-ranked retrieval for on-demand knowledge
 - `ao context assemble` — phase-scoped context packets
 - `ao compile` — rebuild the knowledge wiki (mine, grow, defrag, lint)
-- 78 skills — reusable context packages across Claude Code, Codex, and OpenCode
+- 77 skills — reusable context packages across Claude Code, Codex, and OpenCode
 - `bash <(curl -fsSL .../install.sh)` — 30 seconds, zero config
 
 #### Layer 3: Validation Gates
@@ -261,7 +261,7 @@ As of 2026-05-10:
 
 - GitHub repo: 341 stars, 33 forks, 2 open issues, last pushed 2026-05-10T03:24:01Z
 - Public surface: GitHub Pages mkdocs site live at boshu2.github.io/agentops/; doctrine site live at 12factoragentops.com
-- Distribution/runtime reach: 78 shared skills, 78 checked-in Codex artifacts, and 32 Codex overrides. `/validate` and `/curate` are additive in this train; legacy validation and mining skills remain until their shim/retirement gates are resolved.
+- Distribution/runtime reach: 77 shared skills, 77 checked-in Codex artifacts, and 32 Codex overrides. `/validate` and `/curate` are additive in this train; legacy validation and mining skills remain until their shim/retirement gates are resolved.
 
 **Measured operational proof:**
 

--- a/cli/embedded/skills/using-agentops/SKILL.md
+++ b/cli/embedded/skills/using-agentops/SKILL.md
@@ -145,6 +145,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/crank` | Autonomous epic loop (uses swarm for each wave) |
 | `/swarm` | Fresh-context parallel execution (Ralph pattern) |
 | `/evolve` | Goal-driven fitness-scored improvement loop |
+| `/burndown` | Bounded epic-completion loop — drive a finite target to all-merged, then stop |
 | `/operating-loop-workflow` | Install + run the operating-loop multi-agent Workflow (seven-move loop) |
 | `/autodev` | PROGRAM.md autonomous development contract setup and validation |
 | `/dream` | Interactive Dream operator surface for setup, bedtime runs, and morning reports |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -351,7 +351,7 @@ All hooks can be disabled: `AGENTOPS_HOOKS_DISABLED=1` (kill switch) or per-hook
 .
 ├── .claude-plugin/
 │   └── plugin.json      # Plugin manifest
-├── skills/              # 77 skills (67 user-facing, 10 internal)
+├── skills/              # 79 skills (69 user-facing, 10 internal)
 │   ├── rpi/             # orchestration — Full RPI lifecycle orchestrator
 │   ├── council/         # orchestration — Multi-model validation (core primitive)
 │   ├── crank/           # orchestration — Autonomous epic execution

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -351,7 +351,7 @@ All hooks can be disabled: `AGENTOPS_HOOKS_DISABLED=1` (kill switch) or per-hook
 .
 ├── .claude-plugin/
 │   └── plugin.json      # Plugin manifest
-├── skills/              # 78 skills (68 user-facing, 10 internal)
+├── skills/              # 77 skills (67 user-facing, 10 internal)
 │   ├── rpi/             # orchestration — Full RPI lifecycle orchestrator
 │   ├── council/         # orchestration — Multi-model validation (core primitive)
 │   ├── crank/           # orchestration — Autonomous epic execution

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -1,6 +1,6 @@
 # Skills Reference
 
-Complete reference for all 77 AgentOps skills (67 user-facing + 10 internal).
+Complete reference for all 79 AgentOps skills (69 user-facing + 10 internal).
 
 Skills are the primitive layer of AgentOps. Higher-level entry points like
 `/implement`, `/validation`, `/rpi`, and `/evolve` compose those primitives

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -1,6 +1,6 @@
 # Skills Reference
 
-Complete reference for all 78 AgentOps skills (68 user-facing + 10 internal).
+Complete reference for all 77 AgentOps skills (67 user-facing + 10 internal).
 
 Skills are the primitive layer of AgentOps. Higher-level entry points like
 `/implement`, `/validation`, `/rpi`, and `/evolve` compose those primitives

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -11,6 +11,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 
 - `brainstorm` — Separate goals from implementation.
 - `bug-hunt` — Investigate bugs and root causes.
+- `burndown` — Drive a finite epic set to all-merged, then stop.
 - `complexity` — Find focused refactor hotspots.
 - `council` — Run multi-judge consensus.
 - `crank` — Execute epics through waves.
@@ -114,6 +115,7 @@ graph LR
   beads -- "supplier-to" --> ratchet
   brainstorm -- "shared-kernel" --> standards
   bug-hunt -- "shared-kernel" --> standards
+  burndown -- "shared-kernel" --> standards
   complexity -- "shared-kernel" --> standards
   council -- "shared-kernel" --> standards
   crank -- "shared-kernel" --> standards
@@ -186,6 +188,12 @@ graph LR
 | `brainstorm` | produces | verdict.json |
 | `bug-hunt` | consumes | beads |
 | `bug-hunt` | consumes | standards |
+| `burndown` | consumes | beads |
+| `burndown` | consumes | implement |
+| `burndown` | consumes | post-mortem |
+| `burndown` | consumes | rpi |
+| `burndown` | produces | .agents/burndown/*.json |
+| `burndown` | produces | git-changes |
 | `codex-team` | produces | .agents/swarm/results/*.json |
 | `compile` | produces | .agents/compiled/lint-report.md |
 | `complexity` | consumes | doc |

--- a/docs/contracts/skill-dispositions.yaml
+++ b/docs/contracts/skill-dispositions.yaml
@@ -67,6 +67,11 @@ dispositions:
     hexagonal_role: domain
     disposition:    update
     rationale:      "Core judgment gate; strengthen scenario and verdict self-test"
+  - skill:          burndown
+    domain:         "BC3 Loop"
+    hexagonal_role: domain
+    disposition:    keep
+    rationale:      "Bounded epic-completion loop; terminating counterpart to evolve (finite target → all-merged → STOP)"
   - skill:          crank
     domain:         "BC3 Loop"
     hexagonal_role: domain

--- a/docs/reference/agentops-domain-evolution-bdd.md
+++ b/docs/reference/agentops-domain-evolution-bdd.md
@@ -19,7 +19,7 @@ Feature: Domain-governed AgentOps 3.0 evolution
     And external-corpus-derived observations are used only through the clean-room policy
 
   Scenario: Audit every skill before changing shipped behavior
-    Given the checked-in skill catalog contains 77 skills
+    Given the checked-in skill catalog contains 79 skills
     When the evolution bootstrap audits the catalog
     Then every skill is assigned exactly one primary bounded context
     And each skill has a preliminary keep, update, refactor, merge-review, or cut-review disposition

--- a/docs/reference/agentops-domain-evolution-bdd.md
+++ b/docs/reference/agentops-domain-evolution-bdd.md
@@ -19,7 +19,7 @@ Feature: Domain-governed AgentOps 3.0 evolution
     And external-corpus-derived observations are used only through the clean-room policy
 
   Scenario: Audit every skill before changing shipped behavior
-    Given the checked-in skill catalog contains 78 skills
+    Given the checked-in skill catalog contains 77 skills
     When the evolution bootstrap audits the catalog
     Then every skill is assigned exactly one primary bounded context
     And each skill has a preliminary keep, update, refactor, merge-review, or cut-review disposition

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -1,7 +1,7 @@
 # AgentOps Skill Domain Map
 
 This map is the control surface for the next evolution loop. It classifies all
-77 checked-in AgentOps skills before any broad rewrite, using current
+79 checked-in AgentOps skills before any broad rewrite, using current
 `origin/main` product direction, GOALS Directive 12, the DDD/hexagonal ADR, and
 the `soc-y5vh` Loop epic.
 
@@ -18,9 +18,9 @@ around small provable changes.
 <!-- BEGIN:audit-summary -->
 | Signal | Result |
 |---|---:|
-| Skills audited | 77 |
+| Skills audited | 79 |
 | Domains classified | 5 of 5 (BC1-BC5) |
-| Dispositions assigned | 77 / 77 |
+| Dispositions assigned | 79 / 79 |
 <!-- END:audit-summary -->
 
 Observed gap: the catalog has strong operational kernels but weak productized
@@ -60,6 +60,7 @@ Disposition meanings:
 | Skill | Domain | Hex role | First disposition | Rationale |
 |---|---|---|---|---|
 | `autodev` | BC3 Loop | supporting | refactor | Must compose with PROGRAM.md and RPI as one vertical-slice executor. |
+| `automation-shape-routing` | BC4 Factory | supporting | keep | Front-door router: decides Workflow vs NTM swarm vs plain skill, hands off to the right builder. |
 | `beads` | BC3 Loop | driven-adapter | update | Tracker adapter is core; add BDD/slice acceptance self-test. |
 | `bootstrap` | BC4 Factory | driving-adapter | update | First-run factory entrypoint; needs current 3.0/domain packet shape. |
 | `brainstorm` | BC3 Loop | domain | update | Intent-shaping skill; should emit BDD-ready language. |
@@ -136,6 +137,7 @@ Disposition meanings:
 | `validate` | BC2 Validation | driving-adapter | keep | Designed-future canonical unified validator (m6v5.D Phase 1, epic soc-cp7pv); not redundant cruft — epic GO/REVERT is a separate decision (resolved KEEP 2026-05-24). |
 | `validation` | BC2 Validation | domain | update | Canonical post-implementation validation; strengthen self-test first. |
 | `vibe` | BC2 Validation | domain | update | Code-readiness validator; add self-test and tighten result contract. |
+| `workflow-builder` | BC4 Factory | supporting | keep | Scaffolds Claude Workflow scripts (composite capability); counterpart to skill-builder. |
 <!-- END:full-skill-map -->
 
 ## Priority Queue

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -1,7 +1,7 @@
 # AgentOps Skill Domain Map
 
 This map is the control surface for the next evolution loop. It classifies all
-78 checked-in AgentOps skills before any broad rewrite, using current
+77 checked-in AgentOps skills before any broad rewrite, using current
 `origin/main` product direction, GOALS Directive 12, the DDD/hexagonal ADR, and
 the `soc-y5vh` Loop epic.
 
@@ -18,9 +18,9 @@ around small provable changes.
 <!-- BEGIN:audit-summary -->
 | Signal | Result |
 |---|---:|
-| Skills audited | 78 |
+| Skills audited | 77 |
 | Domains classified | 5 of 5 (BC1-BC5) |
-| Dispositions assigned | 78 / 78 |
+| Dispositions assigned | 77 / 77 |
 <!-- END:audit-summary -->
 
 Observed gap: the catalog has strong operational kernels but weak productized
@@ -60,11 +60,11 @@ Disposition meanings:
 | Skill | Domain | Hex role | First disposition | Rationale |
 |---|---|---|---|---|
 | `autodev` | BC3 Loop | supporting | refactor | Must compose with PROGRAM.md and RPI as one vertical-slice executor. |
-| `automation-shape-routing` | BC4 Factory | supporting | keep | Front-door router: decides Workflow vs NTM swarm vs plain skill, hands off to the right builder. |
 | `beads` | BC3 Loop | driven-adapter | update | Tracker adapter is core; add BDD/slice acceptance self-test. |
 | `bootstrap` | BC4 Factory | driving-adapter | update | First-run factory entrypoint; needs current 3.0/domain packet shape. |
 | `brainstorm` | BC3 Loop | domain | update | Intent-shaping skill; should emit BDD-ready language. |
 | `bug-hunt` | BC2 Validation | domain | update | Validation generator; needs acceptance examples and result contract. |
+| `burndown` | BC3 Loop | domain | keep | Bounded epic-completion loop; terminating counterpart to evolve (finite target → all-merged → STOP). |
 | `codex-team` | BC5 Runtime | supporting | update | Runtime coordination adapter; align with worktree/wave rules. |
 | `compile` | BC1 Corpus | supporting | refactor | Corpus compiler is core; align read/write flows to Corpus ports. |
 | `complexity` | BC2 Validation | domain | update | Generator for refactor work; add self-test and threshold evidence. |
@@ -136,7 +136,6 @@ Disposition meanings:
 | `validate` | BC2 Validation | driving-adapter | keep | Designed-future canonical unified validator (m6v5.D Phase 1, epic soc-cp7pv); not redundant cruft — epic GO/REVERT is a separate decision (resolved KEEP 2026-05-24). |
 | `validation` | BC2 Validation | domain | update | Canonical post-implementation validation; strengthen self-test first. |
 | `vibe` | BC2 Validation | domain | update | Code-readiness validator; add self-test and tighten result contract. |
-| `workflow-builder` | BC4 Factory | supporting | keep | Scaffolds Claude Workflow scripts (composite capability); counterpart to skill-builder. |
 <!-- END:full-skill-map -->
 
 ## Priority Queue

--- a/registry.json
+++ b/registry.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-05-29T17:02:40Z",
+  "generated_at": "2026-05-30T00:53:31Z",
   "summary": {
-    "skills": 78,
+    "skills": 79,
     "hooks": 0,
     "knowledge_stores": 5,
     "job_types": 0,
     "eval_files": 56,
     "cli_commands": 68,
-    "capabilities": 160
+    "capabilities": 161
   },
   "surfaces": {
     "skills": [
@@ -131,6 +131,14 @@
         "has_skill_md": true,
         "has_references": true,
         "reference_count": 8
+      },
+      {
+        "name": "burndown",
+        "tier": "execution",
+        "path": "skills/burndown/",
+        "has_skill_md": true,
+        "has_references": false,
+        "reference_count": 0
       },
       {
         "name": "complexity",
@@ -1373,8 +1381,8 @@
     ]
   },
   "capability_summary": {
-    "total": 160,
-    "skills": 78,
+    "total": 161,
+    "skills": 79,
     "cli_commands": 68,
     "gates": 11,
     "reference_impls": 3
@@ -1579,6 +1587,30 @@
       ],
       "path": "skills/bug-hunt/",
       "references": 8
+    },
+    {
+      "sku": "skill:burndown",
+      "name": "burndown",
+      "type": "skill",
+      "bounded_context": "BC3",
+      "hex_role": "domain",
+      "tier": "execution",
+      "purpose": "Drive a finite epic set to all-merged, then stop.",
+      "status": "active",
+      "disposition": "keep",
+      "consumes": [
+        "beads",
+        "rpi",
+        "implement",
+        "post-mortem"
+      ],
+      "produces": [
+        ".agents/burndown/*.json",
+        "git-changes"
+      ],
+      "drives_commands": [],
+      "path": "skills/burndown/",
+      "references": 0
     },
     {
       "sku": "skill:codex-team",

--- a/skills-codex-overrides/catalog.json
+++ b/skills-codex-overrides/catalog.json
@@ -670,6 +670,12 @@
       "treatment": "parity_only",
       "wave": "catalog-parity",
       "reason": "Scaffolds a Claude Workflow JS script from the operating-loop.js template; the authoring guidance is tool-specific reference material with no Codex-specific runtime divergence."
+    },
+    {
+      "name": "burndown",
+      "treatment": "parity_only",
+      "wave": "catalog-parity",
+      "reason": "TODO: confirm parity_only or flip to bespoke (+scaffold override dir) for burndown"
     }
   ]
 }

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -2,7 +2,7 @@
   "generator": "manual-maintained",
   "source_root": "skills",
   "layout": "modular",
-  "codex_override_catalog_hash": "aef940bdfe26c2955145f7338854b193e9ef2b3baf7448e4fadebfbb26bb8fa1",
+  "codex_override_catalog_hash": "57959cbf3093ab0881e4769fee318b6f1aa3fbef3155dba02a8a2642f281ea36",
   "codex_override_catalog": {
     "version": 1,
     "description": "Machine-readable Codex treatment map for the full skill catalog.",
@@ -648,6 +648,12 @@
         "treatment": "parity_only",
         "wave": "catalog-parity",
         "reason": "Ship operating-loop Workflow to plugin users via installer skill; Codex twin redirects to the $rpi chain since Codex lacks the Workflow tool"
+      },
+      {
+        "name": "burndown",
+        "treatment": "parity_only",
+        "wave": "catalog-parity",
+        "reason": "Bounded epic-completion loop; codex form is canonical-derived (no bespoke shell idioms)."
       }
     ]
   },
@@ -687,6 +693,12 @@
       "source_skill": "skills/bug-hunt",
       "source_hash": "2f574ca482c52bb099550117a73619966ffc09a868088ca9f84c92caebf7d139",
       "generated_hash": "f2492483bba6e13b0e0004a2ac431afa98708729d8ae5224e6df08b556bdd932"
+    },
+    {
+      "name": "burndown",
+      "source_skill": "skills/burndown",
+      "source_hash": "917f7277558d79c72c428fa6692d86d34d808a120d061341f5a393da063d4068",
+      "generated_hash": "ef6c65f7053775a2f7cf6c3111adca2ca1d630eece87d43bf620cc89a51fd748"
     },
     {
       "name": "codex-team",

--- a/skills-codex/burndown/.agentops-generated.json
+++ b/skills-codex/burndown/.agentops-generated.json
@@ -1,0 +1,7 @@
+{
+  "generator": "manual-maintained",
+  "source_skill": "skills/burndown",
+  "layout": "modular",
+  "source_hash": "917f7277558d79c72c428fa6692d86d34d808a120d061341f5a393da063d4068",
+  "generated_hash": "ef6c65f7053775a2f7cf6c3111adca2ca1d630eece87d43bf620cc89a51fd748"
+}

--- a/skills-codex/burndown/SKILL.md
+++ b/skills-codex/burndown/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: burndown
+description: 'Drive a finite epic set to all-merged, then stop.'
+---
+# $burndown - Bounded Epic-Completion Loop (Codex Native)
+
+> **Quick Ref:** Drive a finite target (epic / set of epics / explicit bead list) to every in-scope bead merged on `main`, one bead per cycle, then STOP. The terminating counterpart to `$evolve` (open-ended). Output: merged PRs + a completion report.
+
+**You must execute this workflow. Do not just describe it.**
+
+## When to use which
+
+| You want… | Command |
+|---|---|
+| Drive *this specific* epic/set to completion, then stop | **`$burndown`** |
+| Always-on, whole-repo improvement (no finish line) | `$evolve` |
+| One-shot **parallel** fan-out of an epic into worker waves | `$crank` |
+| Define/validate the PROGRAM.md contract | `$autodev` |
+| One bead, full lifecycle, once | `$rpi` |
+
+`$burndown` is **serial and resumable** (one PR in flight); `$crank` is
+**parallel and one-shot**.
+
+## Invocation
+
+```bash
+$burndown <epic-id>                    # drive the epic to merged, then stop
+$burndown <epic-id> --max-cycles=20    # cap bead-cycles
+$burndown <epic-a> <epic-b>            # finite set of epics
+$burndown --beads ag-x.1,ag-x.2        # explicit bead list
+$burndown <epic-id> --hold-merges      # open PRs, leave green for operator
+```
+
+The **target set** = transitive in-scope (non-closed) beads of the arguments,
+fixed at start. It is the loop's definition of "done."
+
+## Per-cycle algorithm (idempotent)
+
+Each firing does ONE of: merge an outstanding PR, finish, or advance one bead.
+
+1. **Reconcile in-flight.** `git worktree list` + `git status`; if mid-edit → SKIP.
+   If a target PR is OPEN, check CI (`gh pr checks`):
+   - all required green → update branch, `gh pr merge <N> --squash --admin`,
+     record cited provenance, close the bead only if its acceptance is fully met,
+     remove the worktree, STOP this firing.
+   - pending → SKIP. red → fix-and-repush or revert; never merge red.
+   - `--hold-merges` → leave green PR for operator; STOP.
+   Never pick new work while a target PR is outstanding.
+2. **Completion check.** Re-resolve the target set. All in-scope beads merged →
+   write completion report and STOP (DONE). `--max-cycles=N` reached → STOP with
+   handoff.
+3. **Select ONE in-scope ready bead.** `bd ready` filtered to the target set, in
+   frontier order. NO open-ended ladder. No ready in-scope bead but target
+   incomplete → surface the blocker and STOP. Claim: `bd update <id> --status in_progress`.
+4. **Drive to a PR.** Fresh worktree off `origin/main`. Codex runtime: drive the
+   bead with an `ao rpi` cycle or a direct TDD slice; for a wave-able bead fan
+   workers via NTM (`spawn_agent` / `wait_agent` / `close_agent`). First failing
+   test before the change. Gates: `cd cli && make test && go vet ./...`;
+   `env -u AGENTOPS_RPI_RUNTIME scripts/pre-push-gate.sh --fast`. Open a PR citing
+   the bead (trailers `Closes-scenario` / `Bounded-context` / `Evidence`).
+   Landing happens on a later cycle via step 1 — do not block on CI here.
+5. **Log** to `.agents/burndown/cycle-history.jsonl` and loop.
+
+## Finite stop conditions
+
+STOPS (never dormant) on first of: target merged · `--max-cycles=N` · operator
+STOP marker / `--hold-merges` · genuine blocker (remaining beads blocked on a
+dependency or operator decision — surface, don't spin).
+
+## Self-perpetuation
+
+Fire the same `$burndown <target>` on a cadence (NTM pipeline tick, cron, or
+ssh-to-bushido loop). Idempotency (step 1) makes repeated firings safe — no
+stacked PRs, no double-work. Match cadence to CI latency.
+
+## Hard constraints
+
+No bead no PR; one vertical slice per PR; first failing test first;
+worktree-mandatory; green CI is the only merge gate; dual-runtime triad for new
+skills; capture via the promotion ratchet; record deferred follow-ups in bd.
+
+## Backend Rules
+
+- `bd` is the tracker; `bd ready --json` for in-scope selection; `bd worktree
+  create` per bead.
+- `gh` drives PR + merge; `--admin` only overrides the up-to-date (BEHIND)
+  requirement when all required checks are green.
+- Never send holdout `target`/`ground_truth`/PII to any cloud surface.

--- a/skills-codex/burndown/prompt.md
+++ b/skills-codex/burndown/prompt.md
@@ -1,0 +1,7 @@
+# burndown
+
+Drive a finite epic set (epic / set of epics / explicit bead list) to every in-scope bead merged on `main`, one bead per cycle, then STOP. The terminating counterpart to `$evolve`. Triggers: "burndown", "burn down", "finish the epic", "drive to all-merged", "complete the epic", "close out the epic".
+
+## Instructions
+
+Load and follow the skill instructions from the sibling `SKILL.md` file for this skill.

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -221,7 +221,7 @@ These are how skills chain in practice:
 
 ## Current Skill Tiers
 
-### User-Facing Skills (67)
+### User-Facing Skills (69)
 
 **Judgment:**
 
@@ -324,6 +324,8 @@ These are how skills chain in practice:
 | **heal-skill** | meta | Detect and fix skill hygiene issues |
 | **skill-auditor** | meta | Two-pass audit of an existing SKILL.md against the unified template (15 checks) |
 | **skill-builder** | meta | Scaffold or absorb new SKILL.md files against the unified template |
+| **automation-shape-routing** | meta | Front door for building automation: route to Workflow vs NTM swarm vs plain skill, then hand off |
+| **workflow-builder** | meta | Scaffold a new Claude Workflow script (.claude/workflows/*.js) from the operating-loop.js template |
 
 ### Internal Skills (10) — `metadata.internal: true`
 

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -221,7 +221,7 @@ These are how skills chain in practice:
 
 ## Current Skill Tiers
 
-### User-Facing Skills (68)
+### User-Facing Skills (67)
 
 **Judgment:**
 
@@ -250,6 +250,7 @@ These are how skills chain in practice:
 | **swarm** | execution | Parallelize any skill — fresh context per agent |
 | **rpi** | meta | Thin wrapper: /discovery → /crank → /validation with complexity classification and loop |
 | **evolve** | execution | Autonomous fitness-scored improvement loop |
+| **burndown** | execution | Bounded epic-completion loop — drive a finite target to all-merged, then stop |
 | **operating-loop-workflow** | execution | Install + run the operating-loop multi-agent Workflow (seven-move loop) for plugin users |
 | **autodev** | execution | PROGRAM.md autonomous development contract setup and validation |
 | **bug-hunt** | execution | Investigate bugs with git archaeology |
@@ -323,8 +324,6 @@ These are how skills chain in practice:
 | **heal-skill** | meta | Detect and fix skill hygiene issues |
 | **skill-auditor** | meta | Two-pass audit of an existing SKILL.md against the unified template (15 checks) |
 | **skill-builder** | meta | Scaffold or absorb new SKILL.md files against the unified template |
-| **automation-shape-routing** | meta | Front door for building automation: route to Workflow vs NTM swarm vs plain skill, then hand off |
-| **workflow-builder** | meta | Scaffold a new Claude Workflow script (.claude/workflows/*.js) from the operating-loop.js template |
 
 ### Internal Skills (10) — `metadata.internal: true`
 

--- a/skills/burndown/SKILL.md
+++ b/skills/burndown/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: burndown
+description: Drive a finite epic set to all-merged, then stop.
+practices:
+- continuous-delivery
+- xp
+- agile-manifesto
+hexagonal_role: domain
+consumes:
+- beads
+- rpi
+- implement
+- post-mortem
+produces:
+- .agents/burndown/*.json
+- git-changes
+context_rel:
+- kind: shared-kernel
+  with: standards
+skill_api_version: 1
+user-invocable: true
+context:
+  window: fork
+  intent:
+    mode: task
+  sections:
+    exclude:
+    - HISTORY
+  intel_scope: full
+metadata:
+  tier: execution
+  dependencies:
+  - beads
+  - rpi
+  - implement
+  - post-mortem
+output_contract: merged PRs for every in-scope bead + a completion report; the loop STOPS at the finite end (target merged, max-cycles, or surfaced blocker)
+---
+
+# /burndown — Bounded Epic-Completion Loop
+
+> Pick a finite target. Drive every bead in it to merged. Stop when it's done.
+
+`/burndown` is the **terminating** counterpart to [`/evolve`](../evolve/SKILL.md).
+Where `/evolve` is open-ended (a goal-driven compounding loop that goes *dormant*
+but never *completes*), `/burndown` takes a **finite target** — one epic, a set of
+epics, or an explicit bead list — and drives every in-scope bead to **merged on
+main**, then **STOPS**. It is the orchestrator-merge loop with a finish line.
+
+**You must execute this workflow. Do not just describe it.**
+
+## When to use which
+
+| You want… | Command |
+|---|---|
+| Drive *this specific* epic/set to completion, then stop | **`/burndown`** |
+| Always-on, whole-repo improvement against GOALS.md (no finish line) | `/evolve` |
+| One-shot **parallel** fan-out of an epic's ready beads into swarm waves | `/crank` |
+| Define/validate the PROGRAM.md contract the loops read | `/autodev` |
+| One bead, full lifecycle, once | `/rpi` |
+
+`/burndown` is **serial and resumable** (one PR in flight, idempotent across
+firings) where `/crank` is **parallel and one-shot**. `/burndown` may *call*
+`/crank` for a single wave-able bead, and calls `/rpi` per bead by default.
+
+## Invocation
+
+```bash
+/burndown <epic-id>                      # drive every bead under the epic to merged, then stop
+/burndown <epic-id> --max-cycles=20      # cap the number of bead-cycles
+/burndown <epic-a> <epic-b> ...          # a finite set of epics (frontier order = arg order)
+/burndown --beads ag-x.1,ag-x.2,ag-x.3   # an explicit finite bead list
+/burndown <epic-id> --dry-run            # show the in-scope frontier + plan, don't execute
+/burndown <epic-id> --hold-merges        # open PRs but leave green ones for operator review
+```
+
+The **target set** = the transitive in-scope beads of the arguments (epic
+children, recursively) that are not already closed. This set is fixed at start
+and is the loop's definition of "done."
+
+## Per-cycle algorithm (idempotent — safe to fire from cron, `ScheduleWakeup`, or in-session)
+
+Each firing does **one** of: merge an outstanding PR, finish, or advance one bead.
+
+1. **Reconcile in-flight work (idempotency).**
+   `git worktree list` + `git status`. If a prior cycle / agent is still
+   mid-edit → **SKIP** this firing.
+   If a target tick-PR is **OPEN**, check `gh pr checks`:
+   - **all required green** → bring the branch up to date, `gh pr merge <N>
+     --squash --admin`, record cited provenance on its bead (close it only if its
+     acceptance is fully met — partial slices stay open), remove the worktree,
+     then **STOP this firing** (one merge per cycle).
+   - **pending** → SKIP. **red** → fix-and-repush or revert; never merge red.
+   - `--hold-merges` → leave the green PR for the operator; log and STOP.
+   Never pick new work while a target PR is outstanding.
+
+2. **Completion check (the finite end `/evolve` lacks).**
+   Re-resolve the target set. If **every in-scope bead is closed/merged** →
+   write the completion report, run teardown, and **STOP — DONE**.
+   If `--max-cycles=N` reached → STOP with a handoff (remaining beads listed).
+
+3. **Select ONE ready bead within target scope only.**
+   `bd ready` filtered to the target set, in frontier order (arg/priority/dep
+   order). **No open-ended ladder** — do not pull goals, coverage, or bug-hunt
+   work from outside the target. If no in-scope bead is ready but the target is
+   incomplete, **surface the blocker** (the remaining beads are blocked on a
+   dependency or an operator decision) and STOP — do not spin or widen scope.
+   Claim it: `bd update <id> --status in_progress`.
+
+4. **Drive that one bead to a PR.**
+   In a fresh worktree off `origin/main`
+   (`bd worktree create <slug> --branch <type>/<bead>-<slug>`): prefer
+   `/rpi "Land <id>: <title>" --auto --max-cycles=1` (full lifecycle) when scope
+   is fuzzy; a direct TDD slice (first failing test → smallest green change) when
+   the bead is execution-ready. Run the repo gates (`cd cli && make test && go
+   vet ./...`; `env -u AGENTOPS_RPI_RUNTIME scripts/pre-push-gate.sh --fast`).
+   Open a PR citing the bead (trailers `Closes-scenario` / `Bounded-context` /
+   `Evidence`). **Landing happens on a later cycle via step 1** — do not block on
+   CI within this firing.
+
+5. **Log the cycle** to `.agents/burndown/cycle-history.jsonl` and loop.
+
+## Finite stop conditions
+
+`/burndown` STOPS (it does not go dormant) on the first of:
+
+1. **Target merged** — every in-scope bead closed/merged. Primary success.
+2. **`--max-cycles=N`** cap reached — STOP with a handoff listing remaining beads.
+3. **Operator override** — `~/.config/burndown/STOP` / `.agents/burndown/STOP`,
+   or `--hold-merges` for the merge step only.
+4. **Genuine blocker** — all remaining in-scope beads are blocked on a dependency
+   or an operator decision. Surface it; do not spin.
+
+## Self-perpetuation
+
+For unattended completion, fire the same `/burndown <target>` prompt on a cadence
+— a `CronCreate` session loop (idle-tick) or an end-of-turn `ScheduleWakeup`.
+Because every firing is idempotent (step 1 reconciles the single outstanding PR),
+repeated firings drive the target to completion without stacking PRs or
+double-work. Tune the cadence to CI latency: a tick that mostly waits on CI
+should fire no faster than the gate takes to go green.
+
+## Hard constraints (inherited from PROGRAM.md + AGENTS.md)
+
+- No bead, no PR — `bd create` discovered work before editing.
+- One bead-backed vertical slice per PR; first failing test before the change.
+- Worktree-mandatory; never edit the shared checkout directly.
+- Green CI is the only merge gate; never merge red.
+- New skills need the dual-runtime triad (`skills/`, `skills-codex/`,
+  `skills-codex-overrides/` when it must differ) + `scripts/audit-codex-parity.sh`.
+- Capture through the promotion ratchet; record deferred follow-ups in bd.
+
+## Example
+
+```bash
+/burndown ag-a81zu --max-cycles=20
+```
+
+Drives the AgentOps × Claude Managed Agents epic: each cycle merges the prior
+green PR or advances the next in-scope bead through `/rpi` → PR; STOPS when every
+child bead of `ag-a81zu` is merged or 20 cycles elapse, emitting a completion
+report (merged beads, remaining beads, blockers).
+
+## See Also
+
+- [`/evolve`](../evolve/SKILL.md) — open-ended compounding sibling (no finish line)
+- [`/crank`](../crank/SKILL.md) — parallel-wave one-shot epic execution
+- [`/rpi`](../rpi/SKILL.md) — per-bead full lifecycle (the default per-cycle engine)
+- [`/autodev`](../autodev/SKILL.md) — the PROGRAM.md contract the loop reads

--- a/skills/using-agentops/SKILL.md
+++ b/skills/using-agentops/SKILL.md
@@ -145,6 +145,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/crank` | Autonomous epic loop (uses swarm for each wave) |
 | `/swarm` | Fresh-context parallel execution (Ralph pattern) |
 | `/evolve` | Goal-driven fitness-scored improvement loop |
+| `/burndown` | Bounded epic-completion loop — drive a finite target to all-merged, then stop |
 | `/operating-loop-workflow` | Install + run the operating-loop multi-agent Workflow (seven-move loop) |
 | `/autodev` | PROGRAM.md autonomous development contract setup and validation |
 | `/dream` | Interactive Dream operator surface for setup, bedtime runs, and morning reports |


### PR DESCRIPTION
## What
Adds **`/burndown`** — the bounded, finite-end counterpart to open-ended `/evolve`. Drives a finite target (epic / set of epics / explicit bead list) to *every in-scope bead merged on main* via bounded `/rpi` cycles, then **STOPS**.

## Why (the gap it fills)
| Command | Shape |
|---|---|
| `/evolve` | open-ended compounding loop — goes dormant, never *completes* |
| `/crank` | parallel-**wave** one-shot fan-out |
| `/autodev` | contract layer only (not a loop) |
| **`/burndown`** | **serial, resumable, finite-end drive-to-merge loop** |

## Per-cycle (idempotent — cron / ScheduleWakeup / in-session)
reconcile one outstanding tick-PR (CI-green→merge, pending→skip, red→fix) → completion-check (all in-scope merged → DONE/STOP) → pick ONE in-scope ready bead → drive in a worktree → PR with trailers → loop. Finite stops: target merged · `--max-cycles=N` · operator STOP/`--hold-merges` · genuine blocker.

This is the generalized, named form of the cron loop we validated landing PR #599.

## Dual-runtime + gates
- `skills/burndown/SKILL.md` (canonical) + `skills-codex/burndown/SKILL.md` (Codex-native).
- `audit-codex-parity.sh --skill burndown` **PASS**; `heal.sh --strict` **PASS**.
- Skill counts synced 76→77 (SKILL-TIERS, PRODUCT, docs/SKILLS, docs/ARCHITECTURE, using-agentops catalog); `context-map.md` regenerated; embedded skills synced; `go build ./...` success.

Closes-scenario: ag-3yl8#burndown-skill
Bounded-context: BC5-Runtime
Evidence: skills/burndown/SKILL.md