### PR TITLE
chore(factory): regen-all finalizer for the derived-artifact gate surface (ag-jima #regen-all-finalizer)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /usr/bin/env bash
 
-.PHONY: local-ci local-ci-fast ci build test docs-check clean help
+.PHONY: local-ci local-ci-fast ci build test docs-check regen-all regen-check clean help
 
 # Default: run the release-grade local CI gate.
 # Note: scripts/ci-local-release.sh already includes build + test + release-binary validation.
@@ -24,6 +24,12 @@ docs-check: ## Run docs and hook safety drift checks
 	./scripts/generate-cli-reference.sh --check
 	./scripts/validate-hook-preflight.sh
 	./tests/docs/validate-doc-release.sh
+
+regen-all: ## Regenerate every derived artifact after adding a skill/command (one-command finalizer)
+	./scripts/regen-all.sh
+
+regen-check: ## Run the derived-artifact drift/gate sweep (no writes; pre-push gate)
+	./scripts/regen-all.sh --check
 
 clean: ## Clean CLI build artifacts
 	$(MAKE) -C cli clean

--- a/scripts/regen-all.sh
+++ b/scripts/regen-all.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# regen-all.sh — one-command finalizer for the derived-artifact gate surface.
+#
+# Adding a skill or `ao` command makes ~8 generated registries/goldens stale, each
+# guarded by an independent CI gate that stops at the first error. Discovering them
+# one CI round at a time is slow (see PR #598 / ag-nk67: 9 rounds, 0 feature-code
+# failures). This composes every generator into one local pass, with a --check mode
+# that runs the matching drift validators as a pre-push gate.
+#
+# Usage:
+#   scripts/regen-all.sh            # regenerate all derived artifacts (writes)
+#   scripts/regen-all.sh --check    # run all drift validators (no writes); exit 1 on drift
+#
+# NOTE: Codex twins (skills-codex/<name>/{SKILL.md,prompt.md}) are MANUAL — this
+# refreshes their hashes but cannot author a missing twin. Create twins by hand
+# (runtime-native: no `.claude/...` tokens), then re-run.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+MODE="regen"
+[[ "${1:-}" == "--check" ]] && MODE="check"
+[[ -n "${1:-}" && "$MODE" == "regen" ]] && { echo "usage: $0 [--check]" >&2; exit 2; }
+
+fail=0
+step() { # label cmd...
+  local label="$1"; shift
+  if "$@" >/tmp/regen-all.$$.log 2>&1; then
+    printf '  \033[0;32m✓\033[0m %s\n' "$label"
+  else
+    printf '  \033[0;31m✗\033[0m %s\n' "$label"; sed 's/^/      /' /tmp/regen-all.$$.log | tail -6
+    fail=1
+  fi
+}
+
+if [[ "$MODE" == "regen" ]]; then
+  echo "== regenerating derived artifacts (dependency order) =="
+  step "skill counts"          bash scripts/sync-skill-counts.sh
+  step "skill-domain-map"      bash scripts/generate-skill-domain-map.sh
+  step "SKU catalog (registry.json)" bash scripts/generate-registry.sh
+  step "context-map"           bash scripts/generate-context-map.sh
+  step "embedded skills"       make -C cli sync-hooks
+  step "cli reference (COMMANDS.md)" bash scripts/generate-cli-reference.sh
+  step "cli-surface inventory" bash scripts/check-cmdao-surface-parity.sh --write-surface
+  step "codex hashes"          bash scripts/regen-codex-hashes.sh
+  echo
+  echo "Regenerated. Review 'git status', then run: scripts/regen-all.sh --check"
+  echo "Reminder: new skills also need MANUAL skills-codex/<name>/ twins +"
+  echo "  the cobra expectedCmds list + cli-help-matrix golden when adding ao commands."
+else
+  echo "== drift / gate sweep (no writes) =="
+  step "registry drift"        bash scripts/check-registry-drift.sh
+  step "skill-domain-map golden" bash scripts/generate-skill-domain-map.sh --check
+  step "write-surfaces"        bash scripts/check-agents-write-surfaces.sh
+  step "codex parity"          bash scripts/audit-codex-parity.sh
+  step "codex runtime sections" bash scripts/validate-codex-runtime-sections.sh
+  step "codex hashes (no drift)" bash scripts/regen-codex-hashes.sh --check
+  step "SKU catalog drift"     bash scripts/validate-sku-catalog-drift.sh
+  step "context-map drift"     bash scripts/validate-context-map-drift.sh
+  step "doc-release gate"      bash tests/docs/validate-doc-release.sh
+  echo
+  [[ $fail -eq 0 ]] && echo "ALL GATES GREEN — safe to push" || echo "DRIFT DETECTED — run scripts/regen-all.sh (no flag) to fix, then commit"
+fi
+
+rm -f /tmp/regen-all.$$.log
+exit $fail


### PR DESCRIPTION
## What
A one-command finalizer for the ~8 derived registries/goldens a skill/command addition makes stale.

- `scripts/regen-all.sh` — regenerates every derived artifact in dependency order (skill counts → domain-map → SKU registry.json → context-map → embedded skills → COMMANDS.md → cli-surface → codex hashes).
- `scripts/regen-all.sh --check` — runs the matching drift validators (no writes) as a pre-push gate.
- `make regen-all` / `make regen-check` targets.

## Why
PR #598 (`ag-nk67`) took **9 CI rounds** to merge — zero feature-code failures; every red was a stale derived artifact discovered one CI round at a time (each gate stops at first error, jobs are independent). This composes the existing generators into one local pass so it's caught before the first push. Codex twins stay manual (cannot be auto-authored).

## Verification
`shellcheck --severity=error` clean; `make regen-check` → **all 9 gates green** on current main.

Closes-scenario: ag-jima#regen-all-finalizer
Bounded-context: BC4-Factory
Evidence: scripts/regen-all.sh