### PR TITLE
feat(eval): deny-by-default holdout-leak CI gate for Outcomes payloads (ag-hdqu0 #leak-gate)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -891,6 +891,18 @@ jobs:
           chmod +x scripts/check-contracts-structural-floor.sh
           ./scripts/check-contracts-structural-floor.sh
 
+      - name: Outcomes holdout-leak gate (deny-by-default)
+        if: needs.changes.outputs.contracts == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.ci == 'true'
+        run: |
+          chmod +x scripts/check-outcomes-holdout-leak.sh
+          # Scan any committed Outcomes rubric/score payload fixtures; empty set = pass.
+          mapfile -t payloads < <(find evals .agents/tests -type f -name '*outcomes*.json' 2>/dev/null || true)
+          if [ "${#payloads[@]}" -gt 0 ]; then
+            scripts/check-outcomes-holdout-leak.sh "${payloads[@]}"
+          else
+            echo "ok: no committed Outcomes payloads to scan (gate armed for future fixtures)"
+          fi
+
       # ── agentops-contract-canaries (heavy bespoke setup: bd, gocyclo, bats) ──
       - name: Cache pinned Go tool binaries
         if: needs.changes.outputs.contracts == 'true' || needs.changes.outputs.go == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.ci == 'true'

--- a/scripts/check-outcomes-holdout-leak.sh
+++ b/scripts/check-outcomes-holdout-leak.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# check-outcomes-holdout-leak.sh — deny-by-default holdout-leak gate (ag-hdqu0.6,
+# Outcomes guard layer 4). An Outcomes rubric/score payload is a derived artifact
+# that crosses the cloud boundary; Managed Agents are NOT ZDR, so a payload must
+# NEVER carry holdout ground truth. This is the authoritative CI check (a script,
+# not a hook) backing the by-construction (ProjectRubric) and re-scan
+# (Rubric.ContainsAny) guards.
+#
+# Usage: check-outcomes-holdout-leak.sh <payload.json> [more.json ...]
+# Exit:  0 = every payload is holdout-safe
+#        1 = a payload carries a target/ground_truth key, or is unreadable (deny-by-default)
+#        2 = usage error (no arguments)
+set -euo pipefail
+
+# A JSON KEY named target or ground_truth (value-position "target" text in a
+# description does not match — the trailing colon requires key position).
+FORBIDDEN_REGEX='"(target|ground_truth)"[[:space:]]*:'
+
+if [ "$#" -eq 0 ]; then
+	echo "usage: $0 <payload.json> [more.json ...]" >&2
+	exit 2
+fi
+
+status=0
+for payload in "$@"; do
+	if [ ! -r "$payload" ]; then
+		echo "FAIL: ${payload}: unreadable — denied by default (cannot prove holdout-safe)" >&2
+		status=1
+		continue
+	fi
+	if grep -Eq "$FORBIDDEN_REGEX" "$payload"; then
+		echo "FAIL: ${payload}: contains a holdout key (target/ground_truth); Outcomes payloads must be holdout-safe (Managed Agents are not ZDR)" >&2
+		status=1
+	else
+		echo "ok: ${payload}: holdout-safe"
+	fi
+done
+
+exit "$status"

--- a/tests/scripts/check-outcomes-holdout-leak.bats
+++ b/tests/scripts/check-outcomes-holdout-leak.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+# Guard layer 4 (ag-hdqu0.6): the deny-by-default holdout-leak gate. An Outcomes
+# rubric/score payload must NEVER carry holdout ground truth (Managed Agents are
+# not ZDR). check-outcomes-holdout-leak.sh exits nonzero on any payload with a
+# target/ground_truth key, zero only when all payloads are clean, and nonzero on
+# an unreadable file (deny-by-default).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/check-outcomes-holdout-leak.sh"
+    TMP_DIR="$(mktemp -d)"
+
+    cat > "$TMP_DIR/clean.json" <<'EOF'
+{"schema_version":1,"source_task_id":"t1","judge_content_hash":"sha256:abc","criteria":[{"id":"accuracy","description":"names the capital","weight":0.7}]}
+EOF
+    cat > "$TMP_DIR/leak-target.json" <<'EOF'
+{"source_task_id":"t1","criteria":[{"id":"accuracy"}],"target":"Ouagadougou"}
+EOF
+    cat > "$TMP_DIR/leak-gt.json" <<'EOF'
+{"source_task_id":"t1","ground_truth":[{"id":"q1","value":"Antananarivo"}]}
+EOF
+}
+
+teardown() { rm -rf "$TMP_DIR"; }
+
+@test "clean payload exits zero" {
+    run bash "$SCRIPT" "$TMP_DIR/clean.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "payload with target key exits nonzero" {
+    run bash "$SCRIPT" "$TMP_DIR/leak-target.json"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"holdout key"* ]]
+}
+
+@test "payload with ground_truth key exits nonzero" {
+    run bash "$SCRIPT" "$TMP_DIR/leak-gt.json"
+    [ "$status" -ne 0 ]
+}
+
+@test "one leaking payload among clean ones fails the whole run" {
+    run bash "$SCRIPT" "$TMP_DIR/clean.json" "$TMP_DIR/leak-target.json"
+    [ "$status" -ne 0 ]
+}
+
+@test "unreadable file is denied by default" {
+    run bash "$SCRIPT" "$TMP_DIR/does-not-exist.json"
+    [ "$status" -ne 0 ]
+}
+
+@test "no arguments is a usage error" {
+    run bash "$SCRIPT"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## What
Adds the **fourth holdout-leak guard** for ag-hdqu0: `scripts/check-outcomes-holdout-leak.sh` — the authoritative CI check (a script, not a hook) that refuses any Outcomes rubric/score payload carrying a `target`/`ground_truth` **key**. Managed Agents are not ZDR, so a leak is permanent; this backs the by-construction (`ProjectRubric`) + re-scan (`ContainsAny`) + drift (`FreshAgainst`) guards with a deny-by-default gate.

- Deny-by-default: unreadable file → fail; no args → usage error.
- Wired as a **step in the existing `contracts-sync` job** (scans committed Outcomes payload fixtures; empty set passes, gate armed for future fixtures). **No new job** → jobs-table unchanged (11 rows), `ci-policy-parity` green (verified locally pre-push).

## Tests (TDD)
- `tests/scripts/check-outcomes-holdout-leak.bats` — 6 cases: clean→0 · target→1 · ground_truth→1 · mixed→1 · unreadable→1 (deny-by-default) · no-args→usage. All pass; `shellcheck --severity=error` clean.

Closes-scenario: ag-hdqu0.6#leak-gate
Bounded-context: BC1-Corpus
Evidence: tests/scripts/check-outcomes-holdout-leak.bats