### PR TITLE
feat(eval): Codex/NTM offline grading path for Outcomes (ag-hdqu0 #codex-path)

### DIFF
--- a/cli/cmd/ao/eval_outcomes_codex.go
+++ b/cli/cmd/ao/eval_outcomes_codex.go
@@ -1,0 +1,37 @@
+package main
+
+import "github.com/boshu2/agentops/cli/internal/evalsubstrate"
+
+// gradeLocally is the Codex/NTM offline grading path (ag-hdqu0.7). Codex has no
+// Managed Agents loop and no Workflow tool, so it calls the SAME
+// `ao eval outcomes compile` to get a holdout-safe Rubric, grades the candidate
+// locally — Inspect AI over the dev split, or the bushido llama.cpp Qwen3.6 grader
+// over tailnet — and writes through the SAME ingestOutcomesScore. This function is
+// the output adapter for that local grade: it folds per-criterion scores into the
+// weight-normalized outcomesScore that ingest consumes, so the Codex path yields a
+// verdict byte-identical in shape to the cloud path with ZERO outbound cloud calls.
+//
+// perCriterion maps Criterion.ID -> [0,1] score; criteria the grader did not score
+// count as 0. The aggregate is the weight-normalized mean over the rubric's own
+// criteria (so a rubric and its grade can never disagree on which criteria exist).
+func gradeLocally(r evalsubstrate.Rubric, perCriterion map[string]float64, threshold float64) outcomesScore {
+	scores := make(map[string]float64, len(r.Criteria))
+	var weighted, weightSum float64
+	for _, c := range r.Criteria {
+		s := perCriterion[c.ID]
+		scores[c.ID] = s
+		weighted += s * c.Weight
+		weightSum += c.Weight
+	}
+	aggregate := 0.0
+	if weightSum > 0 {
+		aggregate = weighted / weightSum
+	}
+	return outcomesScore{
+		SourceTaskID:     r.SourceTaskID,
+		JudgeContentHash: r.JudgeContentHash,
+		Aggregate:        aggregate,
+		Threshold:        threshold,
+		CriterionScores:  scores,
+	}
+}

--- a/cli/cmd/ao/eval_outcomes_codex_test.go
+++ b/cli/cmd/ao/eval_outcomes_codex_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/evalsubstrate"
+)
+
+// TestEvalOutcomesCodexPath_LocalGradeProducesVerdict proves the Codex/NTM
+// offline grading path (ag-hdqu0.7): the SAME compile (ProjectRubric) and ingest
+// (ingestOutcomesScore) serve a locally-graded run with ZERO cloud dependency,
+// producing a verdict identical in shape to the cloud Outcomes path. The local
+// grader (gradeLocally) stands in for the Inspect AI dev-split / bushido Qwen3.6
+// graders — all offline, all funnelling through the one verdict format.
+func TestEvalOutcomesCodexPath_LocalGradeProducesVerdict(t *testing.T) {
+	rubric := evalsubstrate.ProjectRubric(
+		evalsubstrate.Task{ID: "task-capital-cities", Description: "answer accurately"},
+		[]evalsubstrate.Criterion{
+			{ID: "accuracy", Description: "names the correct capital", Weight: 0.7},
+			{ID: "concision", Description: "one short sentence", Weight: 0.3},
+		},
+		"sha256:judge1",
+	)
+
+	// Local grader output (Inspect AI dev-split / Qwen3.6 stand-in) — offline.
+	score := gradeLocally(rubric, map[string]float64{"accuracy": 1.0, "concision": 1.0}, 0.8)
+	if score.SourceTaskID != rubric.SourceTaskID {
+		t.Errorf("score.SourceTaskID = %q, want %q", score.SourceTaskID, rubric.SourceTaskID)
+	}
+	if score.JudgeContentHash != rubric.JudgeContentHash {
+		t.Errorf("local grade must carry the rubric judge hash, got %q", score.JudgeContentHash)
+	}
+	if score.Aggregate != 1.0 {
+		t.Errorf("weighted aggregate of all-1.0 criteria = %v, want 1.0", score.Aggregate)
+	}
+
+	// Same ingest path as the cloud Outcomes run → one verdict format.
+	v := ingestOutcomesScore(score)
+	if v.Verdict != "PASS" {
+		t.Errorf("Verdict = %q, want PASS", v.Verdict)
+	}
+	if v.SatisfactionScore == nil || *v.SatisfactionScore != 1.0 {
+		t.Errorf("SatisfactionScore = %v, want 1.0", v.SatisfactionScore)
+	}
+	if v.SatisfactionBreakdown["accuracy"] != 1.0 {
+		t.Errorf("breakdown[accuracy] = %v, want 1.0", v.SatisfactionBreakdown["accuracy"])
+	}
+}
+
+// TestGradeLocally_WeightedAggregate: the local grader computes a weight-normalized
+// aggregate over exactly the rubric's criteria (unknown criteria score 0).
+func TestGradeLocally_WeightedAggregate(t *testing.T) {
+	rubric := evalsubstrate.ProjectRubric(
+		evalsubstrate.Task{ID: "t"},
+		[]evalsubstrate.Criterion{{ID: "a", Weight: 3}, {ID: "b", Weight: 1}},
+		"sha256:j",
+	)
+	score := gradeLocally(rubric, map[string]float64{"a": 1.0, "b": 0.0}, 0.5)
+	// (1.0*3 + 0.0*1) / (3+1) = 0.75
+	if score.Aggregate != 0.75 {
+		t.Errorf("weighted aggregate = %v, want 0.75", score.Aggregate)
+	}
+	if ingestOutcomesScore(score).Verdict != "PASS" { // 0.75 >= 0.5
+		t.Error("0.75 vs threshold 0.5 should be PASS")
+	}
+}


### PR DESCRIPTION
## What
Adds `gradeLocally` — the **Codex/NTM offline grade adapter**. Codex has no Managed Agents loop / Workflow tool, so it calls the *same* `ao eval outcomes compile`, grades locally (Inspect AI dev-split or bushido Qwen3.6 slot in here), and writes through the *same* `ingestOutcomesScore`. Result: a verdict **byte-identical in shape to the cloud path with ZERO outbound cloud calls** — dual-runtime parity, one verdict format, no second bar.

`gradeLocally` folds per-criterion scores into a weight-normalized `outcomesScore` over the rubric's own criteria (rubric and grade can't disagree on which criteria exist).

## Tests (TDD)
- `TestEvalOutcomesCodexPath_LocalGradeProducesVerdict` — full offline compile→gradeLocally→ingest → PASS verdict, hash propagated, breakdown populated.
- `TestGradeLocally_WeightedAggregate` — weight normalization (3:1 → 0.75).
- 9188 `cmd/ao` tests pass, vet/build clean. No new CLI surface → no canary.

Closes-scenario: ag-hdqu0.7#codex-path
Bounded-context: BC1-Corpus
Evidence: cli/cmd/ao/eval_outcomes_codex_test.go