### PR TITLE
feat(eval): gate #3 holdout-burn ledger — refuse re-grading spent holdout (ag-hdqu0 #gate3-burn-ledger)

### DIFF
--- a/cli/internal/evalsubstrate/gates.go
+++ b/cli/internal/evalsubstrate/gates.go
@@ -6,29 +6,35 @@ import (
 	"strings"
 )
 
-// GateInputs aggregates everything needed to run the Day-2 manifest-checkable
-// gates. Day 4 will extend with Judge calibration + holdout-burn-ledger inputs.
+// GateInputs aggregates everything needed to run the manifest-checkable gates.
+// Day-4 gate #3 (holdout burn) reads BurnLedger; Judge calibration + ModelSpec
+// drift (gates 2/4/5) remain deferred to later Day-4 surfaces.
 type GateInputs struct {
 	Suite             *Suite
 	Task              *Task
-	Harness           *Harness         // declared content_hash from harness.yaml
-	HarnessLock       *HarnessLock     // computed lock file
-	HarnessDir        string           // source dir for re-verification (gate #8)
-	GroundTruth       []GroundTruthRow // current GT rows
-	GTRequested       string           // ground_truth_id requested by the run
-	AllowWeak         bool             // --allow-weak-labels passthrough
-	NRequiredOverride int              // Day-3 power-derived n_required (overrides Task.stats.min_n_samples)
+	Harness           *Harness           // declared content_hash from harness.yaml
+	HarnessLock       *HarnessLock       // computed lock file
+	HarnessDir        string             // source dir for re-verification (gate #8)
+	GroundTruth       []GroundTruthRow   // current GT rows
+	GTRequested       string             // ground_truth_id requested by the run
+	AllowWeak         bool               // --allow-weak-labels passthrough
+	NRequiredOverride int                // Day-3 power-derived n_required (overrides Task.stats.min_n_samples)
+	BurnLedger        *HoldoutBurnLedger // Day-4 gate #3 input: projected global holdout-burn state; nil when not wired
 }
 
-// RunGates executes Day-2 gates 1, 6, 7, 8, 9 in §6 order.
+// RunGates executes gates 1, 3, 6, 7, 8, 9 in §6 order.
 // Returns the populated Refusals; callers proceed iff Empty().
 //
-// Day-2 scope: gates that need only manifest-time inputs (Suite + Task +
-// Harness + GT). Gates 2/3/4/5 (Judge calibration, holdout burn, ModelSpec
-// drift, self-grading) require Day-4 surfaces.
+// Manifest-time gates (1, 6, 7, 8, 9) need only Suite + Task + Harness + GT.
+// Gate 3 (holdout burn) additionally consults the projected BurnLedger when one
+// is wired (Day-4); it is a no-op otherwise. Gates 2/4/5 (Judge calibration,
+// ModelSpec drift, self-grading) remain deferred to later Day-4 surfaces.
 func RunGates(in GateInputs) Refusals {
 	var rs Refusals
 	if r := gate1NoHeldConstant(in); r != nil {
+		rs = append(rs, *r)
+	}
+	if r := gate3HoldoutBurn(in); r != nil {
 		rs = append(rs, *r)
 	}
 	if r := gate6Underpowered(in); r != nil {
@@ -61,6 +67,48 @@ func gate1NoHeldConstant(in GateInputs) *Refusal {
 		Evidence:   fmt.Sprintf("suite_id=%s held_constant={}", in.Suite.ID),
 		Fix:        "Add a held_constant block to the Suite (task, harness, judge, ground_truth_version, decoding) or change kind to 'calibration'.",
 	}
+}
+
+// gate3HoldoutBurn: §6 #3 — a run that grades against the holdout split when the
+// global burn ledger shows the (suite, gt_version) quota is already exhausted must
+// refuse. Once a holdout observation budget is spent, reusing the split lets the
+// iteration loop overfit to held-out answers, voiding the split's statistical
+// guarantee — the load-bearing eval invariant at every boundary. Dev-split runs
+// never consume the budget, so this never fires for them (the dev-split-only
+// escape valve). When no ledger is wired (Day-2 manifest-only runs) or no budget
+// is configured, the gate is a no-op.
+func gate3HoldoutBurn(in GateInputs) *Refusal {
+	if in.BurnLedger == nil || in.BurnLedger.Budget <= 0 {
+		return nil // Day-4 input absent or no ceiling configured
+	}
+	if in.Suite == nil || in.GTRequested == "" {
+		return nil
+	}
+	if !requestedSplitIsHoldout(in) {
+		return nil // dev split (or unknown) never burns holdout budget
+	}
+	spent := in.BurnLedger.Spent(in.Suite.ID, in.GTRequested)
+	if spent < in.BurnLedger.Budget {
+		return nil
+	}
+	return &Refusal{
+		GateNumber: 3,
+		GateName:   "holdout_burn_exhausted",
+		Why:        "Holdout-split grading budget for this (suite, ground_truth_version) is already spent; reusing the holdout lets the loop overfit to held-out answers and voids the split's statistical guarantee.",
+		Evidence:   fmt.Sprintf("suite_id=%s ground_truth_ref=%s spent=%d budget=%d split=holdout", in.Suite.ID, in.GTRequested, spent, in.BurnLedger.Budget),
+		Fix:        "Re-run against the dev split, or mint a fresh holdout ground-truth version (resets the per-version burn budget). Do NOT re-grade spent holdout.",
+	}
+}
+
+// requestedSplitIsHoldout reports whether the run's requested ground-truth row is
+// on the holdout split. Mirrors gate7's id-matching against GroundTruth rows.
+func requestedSplitIsHoldout(in GateInputs) bool {
+	for _, row := range in.GroundTruth {
+		if row.ID == in.GTRequested && row.Split == "holdout" {
+			return true
+		}
+	}
+	return false
 }
 
 // gate6Underpowered: §6 #6 — n_samples < n_required.

--- a/cli/internal/evalsubstrate/holdout_burn.go
+++ b/cli/internal/evalsubstrate/holdout_burn.go
@@ -1,0 +1,37 @@
+package evalsubstrate
+
+// BurnRecord is one consumption of holdout-split observation: a single run that
+// graded against a suite's holdout ground-truth version. The canonical store is
+// the global Dolt holdout-burn ledger (SCHEMA §6 gate 3); this is the projected
+// row gate #3 reasons over. The Dolt read/write adapter is a separate concern —
+// gate #3 takes the projected records the same way the other gates take injected
+// GroundTruth rows rather than reading a backend directly.
+type BurnRecord struct {
+	SuiteRef   string `json:"suite_ref"`  // suite the holdout was burned against
+	GTVersion  string `json:"gt_version"` // ground-truth version/id whose holdout split was observed
+	RunID      string `json:"run_id"`     // run that consumed the budget
+	BurnedAtMs int64  `json:"burned_at_ms,omitempty"`
+}
+
+// HoldoutBurnLedger is the projection of global burn state that gate #3 checks
+// against. Budget is the maximum number of distinct holdout observations
+// permitted for a given (suite_ref, gt_version) before the holdout split is
+// statistically spent; a non-positive Budget means no enforceable ceiling is
+// configured (Day-4 input absent → gate #3 is a no-op).
+type HoldoutBurnLedger struct {
+	Budget  int          `json:"budget"`
+	Records []BurnRecord `json:"records,omitempty"`
+}
+
+// Spent returns how many burns the ledger already records for the given
+// (suiteRef, gtVersion) pair. The ledger is global, so burns against other
+// suites or other ground-truth versions never count toward this pair's quota.
+func (l HoldoutBurnLedger) Spent(suiteRef, gtVersion string) int {
+	n := 0
+	for _, r := range l.Records {
+		if r.SuiteRef == suiteRef && r.GTVersion == gtVersion {
+			n++
+		}
+	}
+	return n
+}

--- a/cli/internal/evalsubstrate/holdout_burn_test.go
+++ b/cli/internal/evalsubstrate/holdout_burn_test.go
@@ -1,0 +1,108 @@
+package evalsubstrate
+
+import "testing"
+
+// TestHoldoutBurnLedger_Spent counts only burns matching the (suite, gt_version)
+// pair under test — the ledger is global, so a burn against a different suite or
+// a different ground-truth version must not consume this run's quota.
+func TestHoldoutBurnLedger_Spent(t *testing.T) {
+	led := HoldoutBurnLedger{
+		Budget: 3,
+		Records: []BurnRecord{
+			{SuiteRef: "s1", GTVersion: "gt-v1", RunID: "r1"},
+			{SuiteRef: "s1", GTVersion: "gt-v1", RunID: "r2"},
+			{SuiteRef: "s1", GTVersion: "gt-v2", RunID: "r3"}, // different version
+			{SuiteRef: "s2", GTVersion: "gt-v1", RunID: "r4"}, // different suite
+		},
+	}
+	if got := led.Spent("s1", "gt-v1"); got != 2 {
+		t.Errorf("Spent(s1,gt-v1) = %d, want 2 (other suite/version excluded)", got)
+	}
+	if got := led.Spent("s1", "gt-v2"); got != 1 {
+		t.Errorf("Spent(s1,gt-v2) = %d, want 1", got)
+	}
+	if got := led.Spent("nope", "gt-v1"); got != 0 {
+		t.Errorf("Spent(nope,gt-v1) = %d, want 0", got)
+	}
+}
+
+// holdoutGateInputs builds GateInputs whose requested GT row is on the given split,
+// with a burn ledger of the given budget and prior-spent count for (suite, gt).
+func holdoutGateInputs(split string, budget, alreadySpent int) GateInputs {
+	recs := make([]BurnRecord, alreadySpent)
+	for i := range recs {
+		recs[i] = BurnRecord{SuiteRef: "suite-x", GTVersion: "gt-1"}
+	}
+	return GateInputs{
+		Suite:       &Suite{ID: "suite-x"},
+		GTRequested: "gt-1",
+		GroundTruth: []GroundTruthRow{{ID: "gt-1", Split: split}},
+		BurnLedger:  &HoldoutBurnLedger{Budget: budget, Records: recs},
+	}
+}
+
+// TestGate3_HoldoutBurnExhausted_Refuses: §6 #3 — a holdout-split run whose
+// (suite, gt_version) quota is already spent must refuse. Reusing spent holdout
+// invalidates the split's statistical guarantee (the load-bearing eval invariant).
+func TestGate3_HoldoutBurnExhausted_Refuses(t *testing.T) {
+	in := holdoutGateInputs("holdout", 2, 2) // budget 2, already spent 2
+	r := gate3HoldoutBurn(in)
+	if r == nil {
+		t.Fatal("gate3 must refuse when holdout burn quota is exhausted")
+	}
+	if r.GateNumber != 3 {
+		t.Errorf("GateNumber = %d, want 3", r.GateNumber)
+	}
+	if r.GateName != "holdout_burn_exhausted" {
+		t.Errorf("GateName = %q, want holdout_burn_exhausted", r.GateName)
+	}
+}
+
+// TestGate3_HoldoutWithinBudget_Passes: a holdout run with quota remaining passes.
+func TestGate3_HoldoutWithinBudget_Passes(t *testing.T) {
+	in := holdoutGateInputs("holdout", 3, 1) // budget 3, spent 1 → 2 remain
+	if r := gate3HoldoutBurn(in); r != nil {
+		t.Errorf("gate3 must pass with quota remaining, got refusal: %s", r.GateName)
+	}
+}
+
+// TestGate3_DevSplit_NeverBurns: dev-split runs never consume holdout budget, so
+// gate3 never fires even when the budget is fully spent. This is the dev-split-only
+// escape valve the substrate-gap bead called out.
+func TestGate3_DevSplit_NeverBurns(t *testing.T) {
+	in := holdoutGateInputs("dev", 1, 5) // budget 1, "spent" 5 — but split is dev
+	if r := gate3HoldoutBurn(in); r != nil {
+		t.Errorf("gate3 must not fire on dev split, got refusal: %s", r.GateName)
+	}
+}
+
+// TestGate3_NoLedger_Skips: when no burn ledger is wired (Day-4 input absent),
+// gate3 is a no-op rather than a hard failure — preserves Day-2 manifest-only runs.
+func TestGate3_NoLedger_Skips(t *testing.T) {
+	in := GateInputs{
+		Suite:       &Suite{ID: "suite-x"},
+		GTRequested: "gt-1",
+		GroundTruth: []GroundTruthRow{{ID: "gt-1", Split: "holdout"}},
+		BurnLedger:  nil,
+	}
+	if r := gate3HoldoutBurn(in); r != nil {
+		t.Errorf("gate3 must skip when no ledger is wired, got refusal: %s", r.GateName)
+	}
+}
+
+// TestRunGates_IncludesGate3: gate3 is wired into RunGates in §6 order, so an
+// exhausted-holdout run is refused through the aggregate entrypoint, not just the
+// private function.
+func TestRunGates_IncludesGate3(t *testing.T) {
+	in := holdoutGateInputs("holdout", 1, 1)
+	rs := RunGates(in)
+	found := false
+	for _, r := range rs {
+		if r.GateNumber == 3 {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("RunGates must surface gate3 holdout-burn refusal")
+	}
+}


### PR DESCRIPTION
## What

Builds the **remaining half of `ag-hdqu0.9`** — SCHEMA §6 **gate #3, the holdout-burn ledger** — deferred in `gates.go` since Day-2 (`// Day 4 will extend with … holdout-burn-ledger`). The rubric-model half landed in #599; this completes the operator-chosen substrate prereq that unblocks `ag-hdqu0.5`.

## How

- **`holdout_burn.go`** — `HoldoutBurnLedger` + `BurnRecord` projection model. `Spent(suiteRef, gtVersion)` counts only burns matching that pair (the ledger is global, so other suites/versions never consume this run's quota).
- **`gate3HoldoutBurn`** — refuses a holdout-split run once the `(suite, gt_version)` budget is spent (reusing spent holdout lets the loop overfit to held-out answers, voiding the split's statistical guarantee). **Dev-split runs never burn**; **no-op** when no ledger is wired or no budget is configured.
- Wired into `RunGates` in §6 order (`1, 3, 6, 7, 8, 9`); `GateInputs` gains `BurnLedger *HoldoutBurnLedger` — a pointer with `nil` default, so the live `ao eval task run` path (`eval_task.go`) keeps compiling and gate #3 is dormant there until the Dolt read-adapter wires it.

## Boundaries respected
- **EXTENDS** the locked substrate (`internal/evalsubstrate`); `~/.agents/evals/SCHEMA.md` untouched — gate #3 is a slice the SCHEMA already specifies (§6 #3), not a relitigation.
- Gate takes the **projected** ledger the same way other gates take injected `GroundTruth`; the global-Dolt read/write adapter stays a separate concern — the **write-side is `ag-hdqu0.5`**.
- Holdout integrity: this is the *enforcement* side of NOT-ZDR holdout isolation — no holdout values are emitted anywhere.

## Tests (TDD, red→green)
`cli/internal/evalsubstrate/holdout_burn_test.go` — 6 cases: ledger `Spent` scoping, exhausted→refuse, within-budget→pass, dev-split-never-burns, no-ledger-skips, and `RunGates` surfaces gate #3. Full package **78 pass**, `go vet` clean, `go build ./...` success, fast pre-push gate passed.

Closes-scenario: ag-hdqu0.9#gate3-burn-ledger
Bounded-context: BC4-eval
Evidence: cli/internal/evalsubstrate/holdout_burn_test.go