### PR TITLE
feat(eval): holdout grades register a burn on ingest — no silent quota bypass (ag-hdqu0 #burn-registration)

### DIFF
--- a/cli/cmd/ao/eval_outcomes_burn_test.go
+++ b/cli/cmd/ao/eval_outcomes_burn_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/evalsubstrate"
+)
+
+// TestEvalOutcomesIngest_HoldoutRegistersBurn proves the burn write-side
+// (ag-hdqu0.5): ingesting a grade produced against the holdout split registers
+// exactly one burn in the global ledger, so a cloud/Codex Outcomes run cannot
+// silently bypass holdout quota the way a local holdout run cannot. A dev-split
+// grade registers NO burn. The registered burn is what gate #3 (the read-side,
+// #607) later refuses against once the budget is spent.
+func TestEvalOutcomesIngest_HoldoutRegistersBurn(t *testing.T) {
+	led := evalsubstrate.HoldoutBurnLedger{Budget: 5}
+
+	holdout := outcomesScore{
+		SourceTaskID:       "task-x",
+		Split:              "holdout",
+		SuiteRef:           "suite-x",
+		GroundTruthVersion: "gt-1",
+		RunID:              "run-cloud-1",
+		Aggregate:          0.9,
+		Threshold:          0.8,
+	}
+	after := registerOutcomesBurn(led, holdout)
+	if got := after.Spent("suite-x", "gt-1"); got != 1 {
+		t.Fatalf("holdout grade must register exactly +1 burn, Spent=%d want 1", got)
+	}
+	rec := after.Records[len(after.Records)-1]
+	if rec.SuiteRef != "suite-x" || rec.GTVersion != "gt-1" || rec.RunID != "run-cloud-1" {
+		t.Errorf("burn record identity wrong: %+v", rec)
+	}
+
+	// A second distinct holdout run burns again (+1 each, no silent bypass).
+	holdout2 := holdout
+	holdout2.RunID = "run-cloud-2"
+	after2 := registerOutcomesBurn(after, holdout2)
+	if got := after2.Spent("suite-x", "gt-1"); got != 2 {
+		t.Errorf("each holdout ingest burns once: Spent=%d want 2", got)
+	}
+}
+
+// TestEvalOutcomesIngest_DevSplitNoBurn: a dev-split grade registers no burn —
+// the dev split is reusable, so ingesting against it must never consume holdout
+// quota.
+func TestEvalOutcomesIngest_DevSplitNoBurn(t *testing.T) {
+	led := evalsubstrate.HoldoutBurnLedger{Budget: 5}
+	dev := outcomesScore{
+		SourceTaskID:       "task-x",
+		Split:              "dev",
+		SuiteRef:           "suite-x",
+		GroundTruthVersion: "gt-1",
+		RunID:              "run-dev-1",
+	}
+	after := registerOutcomesBurn(led, dev)
+	if got := after.Spent("suite-x", "gt-1"); got != 0 {
+		t.Errorf("dev-split grade must register NO burn, Spent=%d want 0", got)
+	}
+	if len(after.Records) != 0 {
+		t.Errorf("dev-split ingest must not append records, got %d", len(after.Records))
+	}
+}
+
+// TestRegisterOutcomesBurn_EmptySplitNoBurn: an unset split is treated as
+// non-holdout (no burn) — fail safe toward not over-consuming quota, since gate
+// #3 only fires on an explicit holdout split anyway.
+func TestRegisterOutcomesBurn_EmptySplitNoBurn(t *testing.T) {
+	led := evalsubstrate.HoldoutBurnLedger{Budget: 5}
+	after := registerOutcomesBurn(led, outcomesScore{SourceTaskID: "t", SuiteRef: "s", GroundTruthVersion: "g"})
+	if len(after.Records) != 0 {
+		t.Errorf("empty split must register no burn, got %d records", len(after.Records))
+	}
+}

--- a/cli/cmd/ao/eval_outcomes_ingest.go
+++ b/cli/cmd/ao/eval_outcomes_ingest.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/boshu2/agentops/cli/internal/evalsubstrate"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +18,15 @@ type outcomesScore struct {
 	Aggregate        float64            `json:"aggregate"`
 	Threshold        float64            `json:"threshold"`
 	CriterionScores  map[string]float64 `json:"criterion_scores"`
+
+	// Burn-ledger carriers (ag-hdqu0.5). Split is the eval split the candidate
+	// was graded against; only "holdout" consumes quota. SuiteRef +
+	// GroundTruthVersion key the burn; RunID identifies the consuming run.
+	// Absent on dev-split or pre-.5 payloads (→ no burn).
+	Split              string `json:"split,omitempty"`
+	SuiteRef           string `json:"suite_ref,omitempty"`
+	GroundTruthVersion string `json:"ground_truth_version,omitempty"`
+	RunID              string `json:"run_id,omitempty"`
 }
 
 // outcomesVerdict is the one verdict record (skills/council/schemas/verdict.json
@@ -62,6 +72,26 @@ func ingestOutcomesScore(s outcomesScore) outcomesVerdict {
 		SatisfactionBreakdown: s.CriterionScores,
 		Findings:              []map[string]any{},
 	}
+}
+
+// registerOutcomesBurn is the write-side of the holdout burn ledger (ag-hdqu0.5),
+// the counterpart to gate #3's read-side (#607). When an Outcomes grade was
+// produced against the holdout split, ingest unconditionally appends exactly one
+// BurnRecord to the global ledger — so a cloud/async/Codex Outcomes run cannot
+// silently bypass holdout quota the way a local holdout run cannot. Dev-split
+// (and absent-split) grades register no burn, since the dev split is reusable.
+// Returns the updated ledger for the caller to persist; the global-Dolt store is
+// a separate adapter concern, exactly as gate #3 reads an injected ledger.
+func registerOutcomesBurn(led evalsubstrate.HoldoutBurnLedger, s outcomesScore) evalsubstrate.HoldoutBurnLedger {
+	if s.Split != "holdout" {
+		return led
+	}
+	led.Records = append(led.Records, evalsubstrate.BurnRecord{
+		SuiteRef:  s.SuiteRef,
+		GTVersion: s.GroundTruthVersion,
+		RunID:     s.RunID,
+	})
+	return led
 }
 
 var evalOutcomesIngestCmd = &cobra.Command{


### PR DESCRIPTION
## What

Completes **`ag-hdqu0.5`** — the **write-side** of the holdout burn ledger, counterpart to gate #3's read-side (#607). An Outcomes grade produced against the **holdout split** now registers exactly **one** burn in the global ledger on ingest, so a cloud/async/Codex run cannot silently bypass holdout quota the way a local holdout run cannot. This is the load-bearing "no silent quota bypass" invariant.

## How

- **`outcomesScore`** gains burn carriers — `Split`, `SuiteRef`, `GroundTruthVersion`, `RunID` (all `omitempty`): dev-split and pre-`.5` payloads register **no** burn.
- **`registerOutcomesBurn(ledger, score)`** — appends one `BurnRecord` when `Split == "holdout"`, no-op otherwise; returns the updated ledger for the caller to persist.
- Reuses `evalsubstrate.HoldoutBurnLedger`/`BurnRecord` from #607 — the burn registered here is exactly what **gate #3 refuses against** once the budget is spent. Read-side and write-side now close the loop.

## Boundaries respected
- The **global-Dolt store is a separate adapter concern**, exactly as gate #3 reads an *injected* ledger — same projection-not-backend split the operator endorsed for `.9`.
- **EXTENDS** the locked substrate; `~/.agents/evals/SCHEMA.md` untouched; no holdout `target`/`ground_truth` carried (NOT-ZDR safe — the carriers are split/suite/version/run identifiers only).
- No new cobra command → no `COMMANDS.md` regen needed.

## Tests (TDD, red→green)
`cli/cmd/ao/eval_outcomes_burn_test.go` — holdout grade registers +1 (exact, with correct record identity), second distinct run burns again (+1 each), dev-split registers 0, empty-split registers 0. Full `cmd/ao` package green, `go vet` clean, `go build ./...` success, fast pre-push gate passed.

Closes-scenario: ag-hdqu0.5#burn-registration
Bounded-context: BC4-eval
Evidence: cli/cmd/ao/eval_outcomes_burn_test.go