### PR TITLE
feat(skills): heal --strict checks skill-dispositions coverage (ag-cw2y item 1)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -811,7 +811,7 @@
     {
       "name": "heal-skill",
       "source_skill": "skills/heal-skill",
-      "source_hash": "bae0dc8ce6e916ad059776627ce2f94a42ed1ef15ff9c169f07ecd3cfb2f8c5e",
+      "source_hash": "901f981bf69ce82bfc7535b38241c672c0465978c6aaaa3f91cc5176c47a1b91",
       "generated_hash": "0a4b01de799212b1c33f718aba85c1ea0e03a033542a8e81929ddbd52425ab4b"
     },
     {

--- a/skills-codex/heal-skill/.agentops-generated.json
+++ b/skills-codex/heal-skill/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/heal-skill",
   "layout": "modular",
-  "source_hash": "bae0dc8ce6e916ad059776627ce2f94a42ed1ef15ff9c169f07ecd3cfb2f8c5e",
+  "source_hash": "901f981bf69ce82bfc7535b38241c672c0465978c6aaaa3f91cc5176c47a1b91",
   "generated_hash": "0a4b01de799212b1c33f718aba85c1ea0e03a033542a8e81929ddbd52425ab4b"
 }

--- a/skills/heal-skill/scripts/heal.sh
+++ b/skills/heal-skill/scripts/heal.sh
@@ -20,9 +20,11 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Find repo root (location of skills/ directory)
+# Find repo root (location of skills/ directory). HEAL_REPO_ROOT overrides for
+# fixture-driven tests (tests/scripts/heal-dispositions.bats); production derives
+# it from the script location.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+REPO_ROOT="${HEAL_REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 SKILLS_ROOT="$REPO_ROOT/skills"
 
 # If no targets, scan all skill dirs (skills/ and skills-codex/)
@@ -458,6 +460,25 @@ for skill_check in "$SKILLS_ROOT"/*/SKILL.md; do
     fi
   fi
 done
+
+# Check 12: Dispositions coverage (global, not per-skill). Every user-invocable
+# skills/<n> must have a row in docs/contracts/skill-dispositions.yaml. This is
+# the gate that silently passed when /burndown (ag-3yl8 #600) was added, costing
+# a CI round — heal --strict now catches it locally (ag-cw2y item 1).
+DISPOSITIONS_FILE="$REPO_ROOT/docs/contracts/skill-dispositions.yaml"
+if [[ -f "$DISPOSITIONS_FILE" ]]; then
+  for skill_check in "$SKILLS_ROOT"/*/SKILL.md; do
+    [[ -f "$skill_check" ]] || continue
+    check_dir="$(dirname "$skill_check")"
+    check_name="$(basename "$check_dir")"
+    # Skip internal/non-invocable skills (same exemptions as catalog check).
+    if grep -q 'user-invocable: false' "$skill_check" 2>/dev/null; then continue; fi
+    if grep -q 'internal: true' "$skill_check" 2>/dev/null; then continue; fi
+    if ! grep -qE "^[[:space:]]*-[[:space:]]+skill:[[:space:]]+${check_name}[[:space:]]*$" "$DISPOSITIONS_FILE" 2>/dev/null; then
+      report "MISSING_DISPOSITION" "$check_dir" "user-invocable but has no row in docs/contracts/skill-dispositions.yaml"
+    fi
+  done
+fi
 
 if [[ $FINDINGS -gt 0 ]]; then
   echo ""

--- a/tests/scripts/heal-dispositions.bats
+++ b/tests/scripts/heal-dispositions.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# Regression for ag-cw2y item 1: heal --strict must flag a user-invocable skill
+# that has no row in docs/contracts/skill-dispositions.yaml. This is the exact
+# gate that silently passed when /burndown (ag-3yl8 #600) was added, costing a
+# CI round. The check is fixture-driven via the HEAL_REPO_ROOT override.
+
+setup() {
+  HEAL="$BATS_TEST_DIRNAME/../../skills/heal-skill/scripts/heal.sh"
+  FIX="$(mktemp -d)"
+  mkdir -p "$FIX/skills/foo" "$FIX/docs/contracts"
+  cat > "$FIX/skills/foo/SKILL.md" <<'EOF'
+---
+name: foo
+description: A fixture skill for the dispositions coverage check.
+skill_api_version: 1
+---
+# foo
+EOF
+  cat > "$FIX/docs/contracts/skill-dispositions.yaml" <<'EOF'
+dispositions:
+  - skill:          bar
+    domain:         "BC1 Corpus"
+    hexagonal_role: domain
+    disposition:    keep
+    rationale:      "unrelated existing row"
+EOF
+}
+
+teardown() { rm -rf "$FIX"; }
+
+@test "heal flags a user-invocable skill missing from skill-dispositions.yaml" {
+  run env HEAL_REPO_ROOT="$FIX" bash "$HEAL" --check skills/foo
+  [[ "$output" == *"MISSING_DISPOSITION"* ]]
+  [[ "$output" == *"foo"* ]]
+}
+
+@test "heal does NOT flag a skill that has a dispositions row" {
+  cat >> "$FIX/docs/contracts/skill-dispositions.yaml" <<'EOF'
+  - skill:          foo
+    domain:         "BC1 Corpus"
+    hexagonal_role: domain
+    disposition:    keep
+    rationale:      "now covered"
+EOF
+  run env HEAL_REPO_ROOT="$FIX" bash "$HEAL" --check skills/foo
+  [[ "$output" != *"MISSING_DISPOSITION"* ]]
+}
+
+@test "heal --strict exits non-zero and names the missing disposition" {
+  run env HEAL_REPO_ROOT="$FIX" bash "$HEAL" --check --strict skills/foo
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"MISSING_DISPOSITION"* ]]
+}


### PR DESCRIPTION
## What

First slice of **`ag-cw2y`** (make adding a skill one-shot-green). Adding `/burndown` (ag-3yl8 #600) cost a CI round because a new user-invocable skill with **no row in `docs/contracts/skill-dispositions.yaml`** passed every local check (`audit-codex-parity --skill`, `heal --strict`, `sync-skill-counts`) silently — the miss only surfaced in CI.

This adds the local catch: **`heal.sh` Check 12 — dispositions coverage.** Every user-invocable `skills/<n>` must have a dispositions row, else `MISSING_DISPOSITION` (exit 1 under `--strict`). Same internal/non-invocable exemptions as the existing catalog check (Check 10).

## How
- `heal.sh`: new Check 12 (global), plus a `HEAL_REPO_ROOT` env override so the check is fixture-testable; production still derives `REPO_ROOT` from script location.
- Verified **no `MISSING_DISPOSITION` on the real repo** — all current skills are covered, so this is a pure tightening with zero false positives.

## Tests (TDD, red→green)
`tests/scripts/heal-dispositions.bats` — fixture skill missing a row → flagged; with a row → clean; `--strict` exits 1 and names the miss. All 3 green.

## Codex artifact note
Editing `skills/heal-skill/` requires a paired `skills-codex/heal-skill/` update (the source-hash). I refreshed **only heal-skill's** `.agentops-generated.json` + its manifest entry. The 6 unrelated pre-existing codex-hash drifts on `main` (deps/trace/scenario/provenance/red-team/release) are **left untouched** — out of this PR's scope. PR-diff-scoped `validate-codex-generated-artifacts.sh --scope head` passes.

## Remaining ag-cw2y items (follow-on)
Item 1 (dispositions) is the check half done here. Items 2 (domain-map narrative counts), 3 (codex desc budget / ag-vzbt), 4 (codex override-catalog scaffold) + the skill-builder *scaffold* halves remain — they fully unblock `ag-hdqu0.8` and `/burndown` #600 one-shot-green.

Closes-scenario: ag-cw2y#dispositions-coverage-check
Bounded-context: BC2-validation
Evidence: tests/scripts/heal-dispositions.bats