### PR TITLE
feat(skills): skill-builder scaffolds dispositions row + narrative counts (ag-cw2y items 1-scaffold + 2)

### DIFF
--- a/scripts/append-skill-disposition.sh
+++ b/scripts/append-skill-disposition.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# append-skill-disposition.sh — ensure a new skill has a row in
+# docs/contracts/skill-dispositions.yaml (ag-cw2y item-1 scaffold-half).
+#
+# Idempotent: appends a placeholder row only if the skill has none, so a
+# newly-scaffolded skill is one-shot-green against heal.sh Check 12
+# (MISSING_DISPOSITION). The placeholder uses a real bounded context so
+# check-bounded-contexts-drift.sh passes; the author refines domain /
+# hexagonal_role / disposition / rationale during content fill (mirrors the
+# "manual content fill required" contract of the SKILL.md skeleton).
+#
+# Usage: append-skill-disposition.sh <skill-name> [repo-root]
+set -euo pipefail
+
+SKILL="${1:?usage: append-skill-disposition.sh <skill-name> [repo-root]}"
+REPO_ROOT="${2:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+FILE="$REPO_ROOT/docs/contracts/skill-dispositions.yaml"
+
+if [[ ! -f "$FILE" ]]; then
+  echo "append-skill-disposition: no dispositions file at $FILE" >&2
+  exit 1
+fi
+
+if grep -qE "^[[:space:]]*-[[:space:]]+skill:[[:space:]]+${SKILL}[[:space:]]*$" "$FILE"; then
+  echo "append-skill-disposition: '$SKILL' already present — no-op"
+  exit 0
+fi
+
+cat >> "$FILE" <<EOF
+  - skill:          $SKILL
+    domain:         "BC4 Factory"
+    hexagonal_role: supporting
+    disposition:    keep
+    rationale:      "TODO: refine BC/hexagonal_role/disposition/rationale for $SKILL"
+EOF
+echo "append-skill-disposition: added placeholder row for '$SKILL' (refine before finalizing)"

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1045,7 +1045,7 @@
     {
       "name": "skill-builder",
       "source_skill": "skills/skill-builder",
-      "source_hash": "6dd778f1556db4ebafd566a01a34d1f02004fe8ef10caf08242359de73b22c09",
+      "source_hash": "816d7c6f9f2e409c6568ef8a7d5d163917074a76f8931ccfd91cfcea96746b11",
       "generated_hash": "4d8b01766df9b10099f4f669e60c74dede37bd604e70d7b6a9a732cb5b2a5c05"
     },
     {

--- a/skills-codex/skill-builder/.agentops-generated.json
+++ b/skills-codex/skill-builder/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/skill-builder",
   "layout": "modular",
-  "source_hash": "6dd778f1556db4ebafd566a01a34d1f02004fe8ef10caf08242359de73b22c09",
+  "source_hash": "816d7c6f9f2e409c6568ef8a7d5d163917074a76f8931ccfd91cfcea96746b11",
   "generated_hash": "4d8b01766df9b10099f4f669e60c74dede37bd604e70d7b6a9a732cb5b2a5c05"
 }

--- a/skills/skill-builder/scripts/init.sh
+++ b/skills/skill-builder/scripts/init.sh
@@ -252,6 +252,21 @@ cat > "$BUILD_REPORT" <<EOF
 }
 EOF
 
+# --- New-skill plumbing (ag-cw2y): make the scaffold one-shot-green ----------
+# The local/CI gates that silently tripped /burndown #600 are pre-empted here:
+# 1. Dispositions row — else heal.sh Check 12 (MISSING_DISPOSITION).
+if [[ -f "$REPO_ROOT/scripts/append-skill-disposition.sh" ]]; then
+  bash "$REPO_ROOT/scripts/append-skill-disposition.sh" "$SKILL_NAME" "$REPO_ROOT" \
+    || echo "init.sh: WARN could not append dispositions row — add one manually" >&2
+fi
+# 2. Narrative skill counts — --fix-counts bumps the "N checked-in skills" tokens
+#    in the domain-map + bdd Gherkin so the new skill doesn't trip registry-drift.
+if [[ -x "$REPO_ROOT/scripts/check-registry-drift.sh" ]]; then
+  bash "$REPO_ROOT/scripts/check-registry-drift.sh" --fix-counts >/dev/null 2>&1 \
+    || echo "init.sh: WARN registry-drift --fix-counts could not run — bump counts manually" >&2
+fi
+
 echo "init.sh: created skill skeleton at $NEW_DIR"
 echo "init.sh: codex parity at $CODEX_DIR"
 echo "init.sh: build report at $BUILD_REPORT"
+echo "init.sh: dispositions row + narrative counts scaffolded (refine the placeholder row)"

--- a/tests/scripts/append-skill-disposition.bats
+++ b/tests/scripts/append-skill-disposition.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# ag-cw2y item-1 scaffold-half: skill-builder must append a skill-dispositions.yaml
+# row for a new skill so it is one-shot-green against heal.sh Check 12. The helper
+# is idempotent and repo-root-injectable (so init.sh can call it and tests can
+# fixture it).
+
+setup() {
+  HELPER="$BATS_TEST_DIRNAME/../../scripts/append-skill-disposition.sh"
+  FIX="$(mktemp -d)"
+  mkdir -p "$FIX/docs/contracts"
+  cat > "$FIX/docs/contracts/skill-dispositions.yaml" <<'EOF'
+dispositions:
+  - skill:          existing
+    domain:         "BC1 Corpus"
+    hexagonal_role: domain
+    disposition:    keep
+    rationale:      "already here"
+EOF
+}
+
+teardown() { rm -rf "$FIX"; }
+
+@test "appends a dispositions row for a new skill" {
+  run bash "$HELPER" newskill "$FIX"
+  [ "$status" -eq 0 ]
+  grep -qE "^[[:space:]]*-[[:space:]]+skill:[[:space:]]+newskill[[:space:]]*$" "$FIX/docs/contracts/skill-dispositions.yaml"
+}
+
+@test "appended row carries a valid BC domain and a TODO rationale" {
+  bash "$HELPER" newskill "$FIX"
+  # The row's domain must be a real bounded context (so check-bounded-contexts-drift passes)
+  run grep -A4 'skill:          newskill' "$FIX/docs/contracts/skill-dispositions.yaml"
+  [[ "$output" == *"BC4 Factory"* ]]
+  [[ "$output" == *"TODO"* ]]
+}
+
+@test "is idempotent — running twice does not duplicate the row" {
+  bash "$HELPER" newskill "$FIX"
+  bash "$HELPER" newskill "$FIX"
+  count=$(grep -cE "^[[:space:]]*-[[:space:]]+skill:[[:space:]]+newskill[[:space:]]*$" "$FIX/docs/contracts/skill-dispositions.yaml")
+  [ "$count" -eq 1 ]
+}
+
+@test "does not touch an already-present skill" {
+  run bash "$HELPER" existing "$FIX"
+  [ "$status" -eq 0 ]
+  count=$(grep -cE "^[[:space:]]*-[[:space:]]+skill:[[:space:]]+existing[[:space:]]*$" "$FIX/docs/contracts/skill-dispositions.yaml")
+  [ "$count" -eq 1 ]
+}


### PR DESCRIPTION
## What

Completes **ag-cw2y item 1's scaffold-half + item 2**. A newly-scaffolded skill is now one-shot-green against the two gates that silently tripped `/burndown` #600:
1. missing `skill-dispositions.yaml` row → `heal.sh` Check 12 (`MISSING_DISPOSITION`, shipped #609)
2. stale `"N checked-in skills"` narrative counts → `check-registry-drift`

## How
- **`scripts/append-skill-disposition.sh`** — idempotent helper that appends a dispositions row (valid `BC4 Factory` placeholder + TODO rationale, so `check-bounded-contexts-drift` passes; author refines during content fill). Repo-root-injectable → fixture-testable.
- **`init.sh`** — after scaffolding, calls the helper *and* runs `check-registry-drift.sh --fix-counts` to bump the narrative skill-count tokens. Both calls are guarded + WARN-on-failure so they never break the scaffold.

## Discovery (scope-narrowing)
Item 2's **check + `--fix-counts` already existed** and were wired into both the fast pre-push gate (line 1330) and CI (line 803). The only gap was that **skill-builder never invoked them** — so the fix is wiring, not a new check.

## Tests (TDD, red→green)
`tests/scripts/append-skill-disposition.bats` — appends row / valid BC + TODO / idempotent / no-dup-on-existing. 4/4 green. shellcheck clean.

## Codex artifact
Refreshed **only skill-builder's** source/generated hash (6 unrelated pre-existing `main` drifts left untouched). PR-scope `validate-codex-generated-artifacts --scope head` passes.

## ag-cw2y remaining
Item 1 (check #609 + scaffold here) ✅ · Item 2 (here) ✅ · **Item 3** (codex desc budget / `ag-vzbt`) and **Item 4** (override-catalog scaffold + `test-codex-override-coverage`) remain — then `ag-hdqu0.8` and `/burndown` #600 are fully one-shot-green.

Closes-scenario: ag-cw2y#skillbuilder-scaffold-dispositions-counts
Bounded-context: BC4-factory
Evidence: tests/scripts/append-skill-disposition.bats