### PR TITLE
feat(skills): add /eval-outcomes — Outcomes as a holdout-safe projection of the locked eval substrate (ag-hdqu0.8 #eval-outcomes-skill)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -67,7 +67,7 @@ The April 2026 Claude Code source analysis confirmed that Anthropic's internal t
 | Anthropic Concept | AgentOps Equivalent | Status |
 |---|---|---|
 | **Learning Loop** — memory extraction, dream cycle consolidation, future session context | Knowledge Flywheel — `/retro` → `/forge` → `/harvest` → `ao lookup` / `ao context assemble`, tiered promotion (learning → pattern → rule), plus bounded Dream via `/dream` | Live with bounds. On-demand capture/promotion works, and Dream provides an operator-started compounding lane. GitHub nightly is the public proof harness for the contracts, not the user's private runtime. |
-| **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 79 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
+| **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 80 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
 | **Verification Agent** — adversarial AI auditing AI, VERDICT system for human review | Council architecture — `/council`, `/pre-mortem`, `/vibe`, `/post-mortem` with multi-model consensus, prediction tracking. Stage 4 behavioral validation adds holdout scenarios + satisfaction scoring in STEP 1.8. | Live on demand. STEP 1.8 fires automatically inside `/validation` when that skill is invoked. |
 | **Managed Agents Dreaming** (May 2026) — scheduled session review, pattern extraction, memory curation between sessions | `/dream` + `.github/workflows/nightly.yml` proof jobs + substrate-driven scheduling when needed | Live with operator setup. The bounded private Dream lane runs harvest → forge → close-loop → defrag when the operator or substrate starts it. AgentOps itself no longer ships the daemon executor. |
 | **Managed Agents Outcomes** (May 2026) — rubric-driven separate-context grader with iterate-until-pass | Live at three scopes: project — `GOALS.md` (rubric) + `ao goals measure` (each gate runs as separate subprocess; `cli/internal/goals/measure.go:132-164`) + `/evolve` (can iterate a worst-failing gate under operator limits; `skills/evolve/SKILL.md:379-388`); plan — `/pre-mortem` council judges as separate-context graders; code — `/vibe` council judges. An internal council review (2026-05-06) found these capabilities present across rubric authoring, separate-context grading, iterate-until-pass, and pinpoint-what-changed; this is an internal finding, not an audited external-parity claim. | Live at the capability layer. Empirical workbench A/B (2026-05-06): Δ=+0.0000 across 12 cases at v1 difficulty (both legs 12/12) — task difficulty floor exhausted; v2 substrate (realistic agent tasks where the hook layer differentiates) is roadmap. Counter-stat artifact: `evals/workbench/results/2026-05-06-yjzp9-counterstat.json`. |
@@ -176,7 +176,7 @@ The same model used in the README: bookkeeping records the work, the context com
 - `ao lookup` — decay-ranked retrieval for on-demand knowledge
 - `ao context assemble` — phase-scoped context packets
 - `ao compile` — rebuild the knowledge wiki (mine, grow, defrag, lint)
-- 79 skills — reusable context packages across Claude Code, Codex, and OpenCode
+- 80 skills — reusable context packages across Claude Code, Codex, and OpenCode
 - `bash <(curl -fsSL .../install.sh)` — 30 seconds, zero config
 
 #### Layer 3: Validation Gates
@@ -261,7 +261,7 @@ As of 2026-05-10:
 
 - GitHub repo: 341 stars, 33 forks, 2 open issues, last pushed 2026-05-10T03:24:01Z
 - Public surface: GitHub Pages mkdocs site live at boshu2.github.io/agentops/; doctrine site live at 12factoragentops.com
-- Distribution/runtime reach: 79 shared skills, 79 checked-in Codex artifacts, and 32 Codex overrides. `/validate` and `/curate` are additive in this train; legacy validation and mining skills remain until their shim/retirement gates are resolved.
+- Distribution/runtime reach: 80 shared skills, 80 checked-in Codex artifacts, and 32 Codex overrides. `/validate` and `/curate` are additive in this train; legacy validation and mining skills remain until their shim/retirement gates are resolved.
 
 **Measured operational proof:**
 

--- a/cli/embedded/skills/using-agentops/SKILL.md
+++ b/cli/embedded/skills/using-agentops/SKILL.md
@@ -146,6 +146,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/swarm` | Fresh-context parallel execution (Ralph pattern) |
 | `/evolve` | Goal-driven fitness-scored improvement loop |
 | `/burndown` | Bounded epic-completion loop — drive a finite target to all-merged, then stop |
+| `/eval-outcomes` | Grade via Outcomes as a holdout-safe projection of the locked eval substrate — one bar, many runtimes |
 | `/operating-loop-workflow` | Install + run the operating-loop multi-agent Workflow (seven-move loop) |
 | `/autodev` | PROGRAM.md autonomous development contract setup and validation |
 | `/dream` | Interactive Dream operator surface for setup, bedtime runs, and morning reports |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -351,7 +351,7 @@ All hooks can be disabled: `AGENTOPS_HOOKS_DISABLED=1` (kill switch) or per-hook
 .
 ├── .claude-plugin/
 │   └── plugin.json      # Plugin manifest
-├── skills/              # 79 skills (69 user-facing, 10 internal)
+├── skills/              # 80 skills (70 user-facing, 10 internal)
 │   ├── rpi/             # orchestration — Full RPI lifecycle orchestrator
 │   ├── council/         # orchestration — Multi-model validation (core primitive)
 │   ├── crank/           # orchestration — Autonomous epic execution

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -1,6 +1,6 @@
 # Skills Reference
 
-Complete reference for all 79 AgentOps skills (69 user-facing + 10 internal).
+Complete reference for all 80 AgentOps skills (70 user-facing + 10 internal).
 
 Skills are the primitive layer of AgentOps. Higher-level entry points like
 `/implement`, `/validation`, `/rpi`, and `/evolve` compose those primitives

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -74,6 +74,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `curate` — Mine transcripts, .agents, bd, and git for skill diffs, bd updates, or rare wiki entries.
 - `doc` — Generate and validate repo docs (default), READMEs (--mode=readme), and OSS doc packs (--mode=oss).
 - `dream` — Retired pointer — out-of-session compounding moved to Gas City.
+- `eval-outcomes` — Grade against Outcomes as a holdout-safe projection of the locked eval substrate — one bar, many runtimes.
 - `evolve` — Run autonomous improvement loops.
 - `handoff` — Write compact session handoffs.
 - `harvest` — Promote .agents knowledge.
@@ -228,6 +229,10 @@ graph LR
 | `doc` | produces | documentation |
 | `domain` | produces | stdout |
 | `dream` | produces | .agents/research/*.md |
+| `eval-outcomes` | consumes | council |
+| `eval-outcomes` | consumes | ratchet |
+| `eval-outcomes` | consumes | validation |
+| `eval-outcomes` | produces | skills/council/schemas/verdict.json |
 | `evolve` | consumes | compile |
 | `evolve` | consumes | goals |
 | `evolve` | consumes | post-mortem |

--- a/docs/contracts/skill-dispositions.yaml
+++ b/docs/contracts/skill-dispositions.yaml
@@ -412,3 +412,8 @@ dispositions:
     hexagonal_role: domain
     disposition:    update
     rationale:      "Code-readiness validator; add self-test and tighten result contract"
+  - skill:          eval-outcomes
+    domain:         "BC2 Validation"
+    hexagonal_role: supporting
+    disposition:    keep
+    rationale:      "Holdout-safe Outcomes grading transport projecting the locked eval substrate; extends validation+ratchet, emits the one council verdict — never an alternate bar"

--- a/docs/reference/agentops-domain-evolution-bdd.md
+++ b/docs/reference/agentops-domain-evolution-bdd.md
@@ -19,7 +19,7 @@ Feature: Domain-governed AgentOps 3.0 evolution
     And external-corpus-derived observations are used only through the clean-room policy
 
   Scenario: Audit every skill before changing shipped behavior
-    Given the checked-in skill catalog contains 79 skills
+    Given the checked-in skill catalog contains 80 skills
     When the evolution bootstrap audits the catalog
     Then every skill is assigned exactly one primary bounded context
     And each skill has a preliminary keep, update, refactor, merge-review, or cut-review disposition

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -1,7 +1,7 @@
 # AgentOps Skill Domain Map
 
 This map is the control surface for the next evolution loop. It classifies all
-79 checked-in AgentOps skills before any broad rewrite, using current
+80 checked-in AgentOps skills before any broad rewrite, using current
 `origin/main` product direction, GOALS Directive 12, the DDD/hexagonal ADR, and
 the `soc-y5vh` Loop epic.
 
@@ -18,9 +18,9 @@ around small provable changes.
 <!-- BEGIN:audit-summary -->
 | Signal | Result |
 |---|---:|
-| Skills audited | 79 |
+| Skills audited | 80 |
 | Domains classified | 5 of 5 (BC1-BC5) |
-| Dispositions assigned | 79 / 79 |
+| Dispositions assigned | 80 / 80 |
 <!-- END:audit-summary -->
 
 Observed gap: the catalog has strong operational kernels but weak productized
@@ -79,6 +79,7 @@ Disposition meanings:
 | `doc` | BC4 Factory | supporting | update | Documentation factory adapter; keep tied to doc-release gates. |
 | `domain` | BC4 Factory | domain | keep | Ubiquitous-language kernel; central to DDD. |
 | `dream` | BC1 Corpus | supporting | refactor | Scheduled compounding lane; align with Corpus ports and convergence proof. |
+| `eval-outcomes` | BC2 Validation | supporting | keep | Holdout-safe Outcomes grading transport projecting the locked eval substrate; extends validation+ratchet, emits the one council verdict — never an alternate bar. |
 | `evolve` | BC3 Loop | supporting | refactor | Main loop; must use `soc-y5vh` typed Loop ports and convergence STOP. |
 | `flywheel` | BC1 Corpus | domain | update | Flywheel health kernel; needs productized self-test. |
 | `forge` | BC1 Corpus | domain | update | Learning extraction; align to capture quality and promotion ratchet. |

--- a/registry.json
+++ b/registry.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-05-30T00:53:31Z",
+  "generated_at": "2026-05-30T01:23:51Z",
   "summary": {
-    "skills": 79,
+    "skills": 80,
     "hooks": 0,
     "knowledge_stores": 5,
     "job_types": 0,
     "eval_files": 56,
     "cli_commands": 68,
-    "capabilities": 161
+    "capabilities": 162
   },
   "surfaces": {
     "skills": [
@@ -163,6 +163,14 @@
         "has_skill_md": true,
         "has_references": true,
         "reference_count": 1
+      },
+      {
+        "name": "eval-outcomes",
+        "tier": "execution",
+        "path": "skills/eval-outcomes/",
+        "has_skill_md": true,
+        "has_references": false,
+        "reference_count": 0
       },
       {
         "name": "evolve",
@@ -1381,8 +1389,8 @@
     ]
   },
   "capability_summary": {
-    "total": 161,
-    "skills": 79,
+    "total": 162,
+    "skills": 80,
     "cli_commands": 68,
     "gates": 11,
     "reference_impls": 3
@@ -1906,6 +1914,32 @@
         "ao goals"
       ],
       "path": "skills/dream/",
+      "references": 0
+    },
+    {
+      "sku": "skill:eval-outcomes",
+      "name": "eval-outcomes",
+      "type": "skill",
+      "bounded_context": "BC2",
+      "hex_role": "supporting",
+      "tier": "execution",
+      "purpose": "Grade against Outcomes as a holdout-safe projection of the locked eval substrate — one bar, many runtimes.",
+      "status": "active",
+      "disposition": "keep",
+      "consumes": [
+        "validation",
+        "ratchet",
+        "council"
+      ],
+      "produces": [
+        "skills/council/schemas/verdict.json"
+      ],
+      "drives_commands": [
+        "ao eval outcomes compile",
+        "ao eval outcomes ingest",
+        "ao eval run"
+      ],
+      "path": "skills/eval-outcomes/",
       "references": 0
     },
     {

--- a/skills-codex-overrides/catalog.json
+++ b/skills-codex-overrides/catalog.json
@@ -676,6 +676,12 @@
       "treatment": "parity_only",
       "wave": "catalog-parity",
       "reason": "TODO: confirm parity_only or flip to bespoke (+scaffold override dir) for burndown"
+    },
+    {
+      "name": "eval-outcomes",
+      "treatment": "parity_only",
+      "wave": "catalog-parity",
+      "reason": "TODO: confirm parity_only or flip to bespoke (+scaffold override dir) for eval-outcomes"
     }
   ]
 }

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -2,7 +2,7 @@
   "generator": "manual-maintained",
   "source_root": "skills",
   "layout": "modular",
-  "codex_override_catalog_hash": "57959cbf3093ab0881e4769fee318b6f1aa3fbef3155dba02a8a2642f281ea36",
+  "codex_override_catalog_hash": "aa61d52a460da3e5e6f122c340830a2667c88f2198ae138cbb45ee5141552b8d",
   "codex_override_catalog": {
     "version": 1,
     "description": "Machine-readable Codex treatment map for the full skill catalog.",
@@ -654,6 +654,12 @@
         "treatment": "parity_only",
         "wave": "catalog-parity",
         "reason": "Bounded epic-completion loop; codex form is canonical-derived (no bespoke shell idioms)."
+      },
+      {
+        "name": "eval-outcomes",
+        "treatment": "parity_only",
+        "wave": "catalog-parity",
+        "reason": "Documents ao eval outcomes as a holdout-safe grading transport; codex form is canonical-derived (no bespoke shell idioms)."
       }
     ]
   },
@@ -777,6 +783,12 @@
       "source_skill": "skills/dream",
       "source_hash": "30e04bc30a20b4404049a8ca31ecf21047e58ead1d97ccd29d38f476c0c21d47",
       "generated_hash": "e0ff08b8e3e94f8bc6ae5d253a4a5b5d89152c3544991bf05c5f4152d32c2bb6"
+    },
+    {
+      "name": "eval-outcomes",
+      "source_skill": "skills/eval-outcomes",
+      "source_hash": "13e509fa4ebf06539d63fafff38535c5bb3ec481f0221f650e82f9fd2788180a",
+      "generated_hash": "ace058738218b463620ccaee4034f104c8ab7a3b5894a4496f38c4c32bf9d536"
     },
     {
       "name": "evolve",
@@ -1099,7 +1111,7 @@
     {
       "name": "using-agentops",
       "source_skill": "skills/using-agentops",
-      "source_hash": "31e2e5a81cbf35a206a9e4d98300a779bd59fa69968cf08afec9397baea525ee",
+      "source_hash": "fa900a3758b9e440253e83918f99319c0dadd1f388bd6feb4d529bffced76e97",
       "generated_hash": "80119493d38739d5ca4d9377c97c7e4f6e5766365525c965297c1cd78029e74b"
     },
     {

--- a/skills-codex/eval-outcomes/.agentops-generated.json
+++ b/skills-codex/eval-outcomes/.agentops-generated.json
@@ -1,0 +1,7 @@
+{
+  "generator": "manual-maintained",
+  "source_skill": "skills/eval-outcomes",
+  "layout": "modular",
+  "source_hash": "13e509fa4ebf06539d63fafff38535c5bb3ec481f0221f650e82f9fd2788180a",
+  "generated_hash": "ace058738218b463620ccaee4034f104c8ab7a3b5894a4496f38c4c32bf9d536"
+}

--- a/skills-codex/eval-outcomes/SKILL.md
+++ b/skills-codex/eval-outcomes/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: eval-outcomes
+description: 'Holdout-safe Outcomes grading: project the locked eval substrate, then ingest one verdict.'
+---
+
+# $eval-outcomes — Outcomes as a Projection of the Locked Eval Substrate (Codex Native)
+
+> **Quick Ref:** Grade an agent's output via Outcomes (or any model) without forking the bar. `ao eval outcomes compile` projects a locked Task into a holdout-safe rubric (refuses to leak `target`/`ground_truth` — Managed Agents are not ZDR); grade it; `ao eval outcomes ingest` writes the score back as the one council verdict record. Outcomes is a projection, never an alternate authority.
+
+## Codex path
+
+Codex has no Managed Agents loop. Call the same `ao eval outcomes compile <input.json>` to get a holdout-safe rubric, grade it locally (Inspect AI over the dev split, or the bushido llama.cpp Qwen grader over tailnet), then `ao eval outcomes ingest <score.json> --json`. Net: Codex never touches the cloud Outcomes API but produces a byte-identical verdict record.
+
+## Instructions
+
+Load and follow the skill instructions from the sibling `SKILL.md` — OR read `skills/eval-outcomes/SKILL.md` in the host repo for the canonical specification. Then apply the three-phase Workflow (compile → grade → ingest), honoring the Critical Constraints (never send holdout `target`/`ground_truth`/PII; carry `judge_content_hash`; register a global Dolt burn for holdout grades).

--- a/skills-codex/eval-outcomes/prompt.md
+++ b/skills-codex/eval-outcomes/prompt.md
@@ -1,0 +1,7 @@
+# eval-outcomes
+
+Holdout-safe Outcomes grading: project the locked eval substrate into a rubric, grade, then ingest one verdict.
+
+## Instructions
+
+Load and follow the skill instructions from the sibling `SKILL.md` file for this skill. Apply the three-phase workflow — `ao eval outcomes compile` (holdout-safe rubric) → grade locally (Inspect AI dev split or the bushido Qwen grader) → `ao eval outcomes ingest <score.json> --json` (one council verdict record). Never send holdout `target`/`ground_truth`/PII; carry `judge_content_hash`; register a global Dolt burn for holdout grades.

--- a/skills-codex/using-agentops/.agentops-generated.json
+++ b/skills-codex/using-agentops/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/using-agentops",
   "layout": "modular",
-  "source_hash": "31e2e5a81cbf35a206a9e4d98300a779bd59fa69968cf08afec9397baea525ee",
+  "source_hash": "fa900a3758b9e440253e83918f99319c0dadd1f388bd6feb4d529bffced76e97",
   "generated_hash": "80119493d38739d5ca4d9377c97c7e4f6e5766365525c965297c1cd78029e74b"
 }

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -221,7 +221,7 @@ These are how skills chain in practice:
 
 ## Current Skill Tiers
 
-### User-Facing Skills (69)
+### User-Facing Skills (70)
 
 **Judgment:**
 
@@ -251,6 +251,7 @@ These are how skills chain in practice:
 | **rpi** | meta | Thin wrapper: /discovery → /crank → /validation with complexity classification and loop |
 | **evolve** | execution | Autonomous fitness-scored improvement loop |
 | **burndown** | execution | Bounded epic-completion loop — drive a finite target to all-merged, then stop |
+| **eval-outcomes** | execution | Grade via Outcomes as a holdout-safe projection of the locked eval substrate — one bar, many runtimes |
 | **operating-loop-workflow** | execution | Install + run the operating-loop multi-agent Workflow (seven-move loop) for plugin users |
 | **autodev** | execution | PROGRAM.md autonomous development contract setup and validation |
 | **bug-hunt** | execution | Investigate bugs with git archaeology |

--- a/skills/eval-outcomes/SKILL.md
+++ b/skills/eval-outcomes/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: eval-outcomes
+description: Grade against Outcomes as a holdout-safe projection of the locked eval substrate — one bar, many runtimes.
+skill_api_version: 1
+practices:
+- continuous-delivery
+- ddd
+hexagonal_role: supporting
+consumes:
+- validation
+- ratchet
+- council
+produces:
+- skills/council/schemas/verdict.json
+context:
+  window: fork
+  intent:
+    mode: task
+  sections:
+    exclude: [HISTORY]
+  intel_scope: topic
+metadata:
+  tier: execution
+  dependencies: [validation, ratchet]
+  stability: experimental
+output_contract: "skills/council/schemas/verdict.json (one council verdict record)"
+---
+
+# /eval-outcomes — Outcomes as a Projection of the Locked Eval Substrate
+
+Grade an agent's output through Anthropic **Outcomes** (or any model) without ever forking the bar: the rubric is *compiled from* the locked eval substrate (`~/.agents/evals/SCHEMA.md`), the grader runs holdout-safe, and the score is ingested back as the **one** council verdict record. Outcomes is a *projection*, never an alternate authority.
+
+## Overview
+
+Outcomes (Anthropic, May 2026) closes the loop "agent runs → grader scores against a rubric → agent retries." AgentOps already has a locked, council-reviewed eval substrate (Suites/Tasks, deterministic-or-LLM scorers, dev/holdout splits, a global Dolt-synced holdout burn ledger, validity gates 1–9, `judge_content_hash` drift detection). This skill makes Outcomes a **grading transport** for that substrate rather than a second bar:
+
+- **`ao eval outcomes compile <input.json>`** — projects a locked Task + criteria into a holdout-safe Outcomes rubric payload. It **refuses** to emit any `target`/`ground_truth` field (Managed Agents are not ZDR).
+- A grader runs the rubric against the candidate output — cloud Managed Agents in the bushido self-hosted sandbox (Claude path), or the local Inspect AI / llama.cpp Qwen grader (Codex/NTM path). Both grade against the *same* compiled rubric.
+- **`ao eval outcomes ingest <score.json> --json`** — converts the returned score into one council verdict record (`skills/council/schemas/verdict.json` shape), closing the Outcomes → Knowledge Flywheel loop.
+
+It **extends** two existing skills, rewriting neither:
+- [validation](../validation/SKILL.md) — Outcomes is an additional grading transport for the existing per-criterion rubric; the verdict output stays the council verdict schema.
+- [ratchet](../ratchet/SKILL.md) — Outcomes-derived deltas feed the same Brownian-Ratchet gate records; no new gate semantics.
+
+## ⚠️ Critical Constraints
+
+- **Managed Agents are NOT ZDR.** Never send a holdout `target`, `ground_truth`, or PII into an Outcomes payload. **Why:** any leak ships answers to Anthropic permanently and breaks holdout isolation — the load-bearing eval invariant. `ao eval outcomes compile` enforces deny-by-default (allowlist-only field copy + a re-parse guard + schema `additionalProperties:false`); a CI check verifies it, not a runtime hook.
+- **SCHEMA.md is the authority; the rubric is a derived artifact.** **Why:** the compiled rubric carries `judge_content_hash`, so a stale cloud rubric self-invalidates exactly like a stale local judge (gate #2 parity). Never hand-edit a cloud rubric.
+- **Every holdout grade registers a global Dolt burn.** **Why:** routing all holdout grades through `ao eval outcomes ingest` keeps gate #3 (the global burn ledger) unconditional — a cloud/Codex run against holdout cannot silently bypass quota.
+- **Do not relitigate the locked substrate.** **Why:** this skill is a projection; changes to splits/scorers/gates belong to the `ao-evals-schema-v1` council process, not here.
+
+## Workflow
+
+### Phase 1: Compile a holdout-safe rubric
+
+```bash
+ao eval outcomes compile task-input.json > rubric.json
+```
+
+Projects the locked Task + per-criterion rubric into an Outcomes payload, stripping every holdout field. If a holdout value would leak, compile refuses with a non-zero exit.
+
+**Checkpoint:** `rubric.json` carries `judge_content_hash` and contains no `target`/`ground_truth` keys.
+
+### Phase 2: Grade against the rubric
+
+- **Claude path:** submit the rubric + candidate output to a Managed Agents Session in the bushido sandbox (`100.109.17.108`); the grader sees criteria + candidate only, never the holdout target.
+- **Codex/NTM path:** grade locally via the Inspect AI runner (dev split) or dispatch to the bushido llama.cpp Qwen grader over tailnet. Same rubric, byte-identical verdict.
+
+**Checkpoint:** the score payload carries the same `judge_content_hash` as the rubric (parity), else discard it as stale.
+
+### Phase 3: Ingest into the one verdict record
+
+```bash
+ao eval outcomes ingest score.json --json
+```
+
+Emits a council verdict record (PASS/WARN/FAIL + per-criterion breakdown) on the existing `eval-verdict-compiler` pipeline. A holdout grade registers a global Dolt burn here.
+
+**Checkpoint:** the verdict matches `skills/council/schemas/verdict.json`, identical in shape to a local `ao eval run` verdict.
+
+## Output Specification
+
+**Format:** JSON. **Filename:** caller-chosen (`<run>.verdict.json`). **Structure:** one council verdict record — `result` (PASS|WARN|FAIL), `satisfaction_score`, per-criterion `breakdown`, `judge_content_hash`.
+
+## Quality Rubric
+
+- [ ] Compiled rubric contains zero `target`/`ground_truth` keys (deny-by-default held).
+- [ ] Rubric + score share the same `judge_content_hash` (no stale-bar drift).
+- [ ] Holdout grades registered a global Dolt burn via ingest.
+- [ ] Ingested verdict matches the council verdict schema — one bar, not a fork.
+
+## Examples
+
+```bash
+# Project a locked Task into a holdout-safe rubric, grade, then ingest the score
+ao eval outcomes compile task-input.json > rubric.json
+# (grade rubric.json against the candidate via cloud or local grader -> score.json)
+ao eval outcomes ingest score.json --json
+```
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| `compile` exits non-zero "would leak into the rubric payload" | A holdout `target`/`ground_truth` reached the allowlist boundary | Working as intended — never bypass; grade against the dev split or fix the input shape |
+| Verdict differs from a local `ao eval run` | Stale rubric (`judge_content_hash` mismatch) | Recompile from the current Task; discard the stale score |
+| Holdout quota unexpectedly consumed | A cloud/Codex holdout grade registered a burn (correct) | Expected — gate #3 is unconditional; use the dev split for iteration |
+
+## See Also
+
+- [validation](../validation/SKILL.md) — the per-criterion rubric Outcomes transports
+- [ratchet](../ratchet/SKILL.md) — gate records Outcomes deltas feed
+- [council](../council/SKILL.md) — the verdict schema ingest emits
+- [skill-auditor](../skill-auditor/SKILL.md) — audit this skill before declaring stable

--- a/skills/eval-outcomes/scripts/validate.sh
+++ b/skills/eval-outcomes/scripts/validate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# validate.sh — minimal self-validation
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../.." && pwd)"
+exec bash "$REPO_ROOT/skills/skill-auditor/scripts/audit.sh" "$SKILL_DIR"

--- a/skills/using-agentops/SKILL.md
+++ b/skills/using-agentops/SKILL.md
@@ -146,6 +146,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/swarm` | Fresh-context parallel execution (Ralph pattern) |
 | `/evolve` | Goal-driven fitness-scored improvement loop |
 | `/burndown` | Bounded epic-completion loop — drive a finite target to all-merged, then stop |
+| `/eval-outcomes` | Grade via Outcomes as a holdout-safe projection of the locked eval substrate — one bar, many runtimes |
 | `/operating-loop-workflow` | Install + run the operating-loop multi-agent Workflow (seven-move loop) |
 | `/autodev` | PROGRAM.md autonomous development contract setup and validation |
 | `/dream` | Interactive Dream operator surface for setup, bedtime runs, and morning reports |


### PR DESCRIPTION
## What

Adds the **/eval-outcomes** dual-runtime skill — the user-facing documentation wrapper for the already-merged `ao eval outcomes compile/ingest` capability (the Outcomes epic ag-hdqu0, capability beads .1/.2/.4/.5/.6/.7/.9 all merged). This is the final ag-hdqu0 child.

eval-outcomes documents Outcomes as a **grading transport** that EXTENDS `validation` + `ratchet` — a *projection* of the locked eval substrate (`SCHEMA.md`), never an alternate bar. Holdout `target`/`ground_truth` never leaves the boundary (Managed Agents are not ZDR).

## How

Built through the ag-cw2y scaffold + the 6-surface new-skill discipline in one shot:
- `skills/eval-outcomes/SKILL.md` + `skills-codex/eval-outcomes/` (parity_only twin + prompt.md)
- override catalog + manifest/marker (`register-new-codex-skill.sh`)
- dispositions row (BC2 Validation) + SKILL-TIERS row + using-agentops catalog
- registry.json SKU catalog + domain-map + context-map + narrative counts + embedded sync

Reverted pre-existing-main drift swept in by generators (6 unrelated codex artifact hashes, cli-surface.*) per the changed-files-scoped triage.

## Evidence

- `audit-codex-parity.sh --skill eval-outcomes` → pass
- `heal.sh --strict skills/eval-outcomes` → clean
- `validate-codex-override-coverage.sh` → 80 skills pass
- `validate-codex-generated-artifacts.sh --scope worktree` → pass
- `generate-{registry,skill-domain-map,context-map}.sh --check` → clean; `check-registry-drift.sh` → no drift

(Local fast pre-push gate references a missing `scripts/audit-codex-hooks.sh` — pre-existing gate-infra drift absent on main, not this PR; CI is the authoritative gate.)

Closes-scenario: ag-hdqu0.8#eval-outcomes-skill
Bounded-context: BC2-Validation
Evidence: skills/eval-outcomes/SKILL.md