### PR TITLE
fix(skill-builder): scaffold regenerates registry.json — the 5th one-shot-green surface (ag-ekyq #scaffold-registry-regen)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1069,7 +1069,7 @@
     {
       "name": "skill-builder",
       "source_skill": "skills/skill-builder",
-      "source_hash": "941104f935c7d69640bcc42dcd83768f634c6150502746110c1028861e802b0b",
+      "source_hash": "09ca51bcec58dd8d144bf8a244deec9f716178bc0fc3ebd444b6ccbe314cdfe2",
       "generated_hash": "4d8b01766df9b10099f4f669e60c74dede37bd604e70d7b6a9a732cb5b2a5c05"
     },
     {

--- a/skills-codex/skill-builder/.agentops-generated.json
+++ b/skills-codex/skill-builder/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/skill-builder",
   "layout": "modular",
-  "source_hash": "941104f935c7d69640bcc42dcd83768f634c6150502746110c1028861e802b0b",
+  "source_hash": "09ca51bcec58dd8d144bf8a244deec9f716178bc0fc3ebd444b6ccbe314cdfe2",
   "generated_hash": "4d8b01766df9b10099f4f669e60c74dede37bd604e70d7b6a9a732cb5b2a5c05"
 }

--- a/skills/skill-builder/scripts/init.sh
+++ b/skills/skill-builder/scripts/init.sh
@@ -271,6 +271,15 @@ if [[ -f "$REPO_ROOT/scripts/append-codex-override-entry.sh" ]]; then
   bash "$REPO_ROOT/scripts/append-codex-override-entry.sh" "$SKILL_NAME" "$REPO_ROOT" \
     || echo "init.sh: WARN could not add codex override catalog entry — add one manually" >&2
 fi
+# 4. registry.json SKU catalog — else contracts-sync + correctness(ubuntu) BOTH
+#    fail ("registry.json is stale" / "SKU_CATALOG: DRIFT"). This is the 5th
+#    one-shot-green surface ag-cw2y missed; it cost /burndown #600 a 2nd
+#    fix-and-repush (ag-ekyq). MUST run last — it scans the whole skills/ tree,
+#    so the new skeleton must already exist on disk.
+if [[ -f "$REPO_ROOT/scripts/generate-registry.sh" ]]; then
+  bash "$REPO_ROOT/scripts/generate-registry.sh" >/dev/null 2>&1 \
+    || echo "init.sh: WARN could not regen registry.json — run scripts/generate-registry.sh manually" >&2
+fi
 
 echo "init.sh: created skill skeleton at $NEW_DIR"
 echo "init.sh: codex parity at $CODEX_DIR"

--- a/tests/scripts/scaffold-registry-regen.bats
+++ b/tests/scripts/scaffold-registry-regen.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+# ag-ekyq: skill-builder init.sh must regenerate registry.json (the SKU catalog)
+# as part of new-skill scaffolding — the 5th one-shot-green surface ag-cw2y missed.
+# A stale registry.json trips contracts-sync ("registry.json is stale") AND
+# correctness(ubuntu) ("SKU_CATALOG: DRIFT") together; it cost /burndown #600 a
+# 2nd fix-and-repush. generate-registry.sh scans the whole skills/ tree (not
+# repo-root-injectable), so the contract we lock here is the WIRING + ORDERING:
+# init.sh must invoke the canonical generator, AFTER the skeleton + the other
+# three plumbing surfaces exist on disk.
+
+INIT="$BATS_TEST_DIRNAME/../../skills/skill-builder/scripts/init.sh"
+
+@test "init.sh invokes the canonical generate-registry.sh during scaffolding" {
+  run grep -E 'scripts/generate-registry\.sh' "$INIT"
+  [ "$status" -eq 0 ]
+}
+
+@test "the registry regen is guarded with a WARN fallback like its sibling steps" {
+  # Must not hard-fail the scaffold if regen has trouble — same || echo WARN shape
+  # as the dispositions / counts / override-catalog steps.
+  run grep -E 'generate-registry\.sh.*>/dev/null|WARN could not regen registry' "$INIT"
+  [ "$status" -eq 0 ]
+}
+
+@test "registry regen runs AFTER the codex override-catalog step (skeleton must exist first)" {
+  override_line=$(grep -n 'append-codex-override-entry\.sh' "$INIT" | head -1 | cut -d: -f1)
+  registry_line=$(grep -n 'generate-registry\.sh' "$INIT" | head -1 | cut -d: -f1)
+  [ -n "$override_line" ]
+  [ -n "$registry_line" ]
+  # registry regen must come later in the file (it scans the whole tree, so every
+  # other artifact — skill dir, dispositions, counts, codex catalog — must be in
+  # place first).
+  [ "$registry_line" -gt "$override_line" ]
+}
+
+@test "registry regen runs BEFORE the final 'created skill skeleton' echo (inside the plumbing block)" {
+  registry_line=$(grep -n 'generate-registry\.sh' "$INIT" | head -1 | cut -d: -f1)
+  echo_line=$(grep -n 'created skill skeleton at' "$INIT" | head -1 | cut -d: -f1)
+  [ -n "$registry_line" ]
+  [ -n "$echo_line" ]
+  [ "$registry_line" -lt "$echo_line" ]
+}


### PR DESCRIPTION
## What

skill-builder's `init.sh` new-skill plumbing (ag-cw2y) wired **4 of 5** derived surfaces — dispositions, narrative counts, codex override-catalog — but **not** the `registry.json` SKU catalog. A stale `registry.json` trips `contracts-sync` ("registry.json is stale") AND `correctness(ubuntu)` ("SKU_CATALOG: DRIFT") together.

This was the **most-missed surface** this session: it cost `/burndown` #600 a 2nd fix-and-repush (`22a0af2f`) and was a manual `generate-registry.sh` step for `/eval-outcomes` (#613).

## How

Adds `generate-registry.sh` as plumbing **step 4** in `init.sh`, positioned **last** (it scans the whole `skills/` tree, so the skeleton + the other 3 surfaces must exist on disk first), guarded with a `WARN` fallback like its siblings. A new skill is now one-shot-green across all 5 surfaces with zero manual regen.

## TDD

`tests/scripts/scaffold-registry-regen.bats` (4/4 green) locks the wiring + ordering contract: init.sh invokes the canonical generator, guarded, after the override-catalog step and before the final skeleton echo. `generate-registry.sh` is not repo-root-injectable (it reads hooks/types.go/schedule across the tree), so the contract is the wiring+ordering; the end-to-end behavior was empirically validated this session running `generate-registry.sh` on the freshly-scaffolded `/eval-outcomes` (#613, registry included the new skill).

## Scope

Reverted the 7 pre-existing-main codex `.agentops-generated.json` drifts that `regen-codex-hashes` swept in; surgically rebuilt the manifest to skill-builder's hash delta only (changing init.sh refreshes skill-builder's codex twin hash — a real consequence of this diff).

Closes-scenario: ag-ekyq#scaffold-registry-regen
Bounded-context: BC4-Factory
Evidence: tests/scripts/scaffold-registry-regen.bats