### PR TITLE
feat(skills): add /agent-native — make out-of-session agents AgentOps-native, hooklessly (ag-2wln #agent-native)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -67,7 +67,7 @@ The April 2026 Claude Code source analysis confirmed that Anthropic's internal t
 | Anthropic Concept | AgentOps Equivalent | Status |
 |---|---|---|
 | **Learning Loop** — memory extraction, dream cycle consolidation, future session context | Knowledge Flywheel — `/retro` → `/forge` → `/harvest` → `ao lookup` / `ao context assemble`, tiered promotion (learning → pattern → rule), plus bounded Dream via `/dream` | Live with bounds. On-demand capture/promotion works, and Dream provides an operator-started compounding lane. GitHub nightly is the public proof harness for the contracts, not the user's private runtime. |
-| **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 80 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
+| **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 81 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
 | **Verification Agent** — adversarial AI auditing AI, VERDICT system for human review | Council architecture — `/council`, `/pre-mortem`, `/vibe`, `/post-mortem` with multi-model consensus, prediction tracking. Stage 4 behavioral validation adds holdout scenarios + satisfaction scoring in STEP 1.8. | Live on demand. STEP 1.8 fires automatically inside `/validation` when that skill is invoked. |
 | **Managed Agents Dreaming** (May 2026) — scheduled session review, pattern extraction, memory curation between sessions | `/dream` + `.github/workflows/nightly.yml` proof jobs + substrate-driven scheduling when needed | Live with operator setup. The bounded private Dream lane runs harvest → forge → close-loop → defrag when the operator or substrate starts it. AgentOps itself no longer ships the daemon executor. |
 | **Managed Agents Outcomes** (May 2026) — rubric-driven separate-context grader with iterate-until-pass | Live at three scopes: project — `GOALS.md` (rubric) + `ao goals measure` (each gate runs as separate subprocess; `cli/internal/goals/measure.go:132-164`) + `/evolve` (can iterate a worst-failing gate under operator limits; `skills/evolve/SKILL.md:379-388`); plan — `/pre-mortem` council judges as separate-context graders; code — `/vibe` council judges. An internal council review (2026-05-06) found these capabilities present across rubric authoring, separate-context grading, iterate-until-pass, and pinpoint-what-changed; this is an internal finding, not an audited external-parity claim. | Live at the capability layer. Empirical workbench A/B (2026-05-06): Δ=+0.0000 across 12 cases at v1 difficulty (both legs 12/12) — task difficulty floor exhausted; v2 substrate (realistic agent tasks where the hook layer differentiates) is roadmap. Counter-stat artifact: `evals/workbench/results/2026-05-06-yjzp9-counterstat.json`. |
@@ -176,7 +176,7 @@ The same model used in the README: bookkeeping records the work, the context com
 - `ao lookup` — decay-ranked retrieval for on-demand knowledge
 - `ao context assemble` — phase-scoped context packets
 - `ao compile` — rebuild the knowledge wiki (mine, grow, defrag, lint)
-- 80 skills — reusable context packages across Claude Code, Codex, and OpenCode
+- 81 skills — reusable context packages across Claude Code, Codex, and OpenCode
 - `bash <(curl -fsSL .../install.sh)` — 30 seconds, zero config
 
 #### Layer 3: Validation Gates
@@ -261,7 +261,7 @@ As of 2026-05-10:
 
 - GitHub repo: 341 stars, 33 forks, 2 open issues, last pushed 2026-05-10T03:24:01Z
 - Public surface: GitHub Pages mkdocs site live at boshu2.github.io/agentops/; doctrine site live at 12factoragentops.com
-- Distribution/runtime reach: 80 shared skills, 80 checked-in Codex artifacts, and 32 Codex overrides. `/validate` and `/curate` are additive in this train; legacy validation and mining skills remain until their shim/retirement gates are resolved.
+- Distribution/runtime reach: 81 shared skills, 81 checked-in Codex artifacts, and 32 Codex overrides. `/validate` and `/curate` are additive in this train; legacy validation and mining skills remain until their shim/retirement gates are resolved.
 
 **Measured operational proof:**
 

--- a/cli/embedded/skills/using-agentops/SKILL.md
+++ b/cli/embedded/skills/using-agentops/SKILL.md
@@ -171,6 +171,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/skill-builder` | Scaffold or absorb new SKILL.md files against the unified template |
 | `/automation-shape-routing` | Front door for building agent automation — decide the SHAPE (Workflow vs NTM swarm vs plain skill), then hand off to the right builder |
 | `/workflow-builder` | Scaffold a new Claude Workflow script (`.claude/workflows/*.js`) — deterministic multi-agent orchestration |
+| `/agent-native` | Make out-of-session agents AgentOps-native via skills + ao CLI + CI, not hooks |
 
 ## Expert Skills (specialized workflows)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -351,7 +351,7 @@ All hooks can be disabled: `AGENTOPS_HOOKS_DISABLED=1` (kill switch) or per-hook
 .
 ├── .claude-plugin/
 │   └── plugin.json      # Plugin manifest
-├── skills/              # 80 skills (70 user-facing, 10 internal)
+├── skills/              # 81 skills (71 user-facing, 10 internal)
 │   ├── rpi/             # orchestration — Full RPI lifecycle orchestrator
 │   ├── council/         # orchestration — Multi-model validation (core primitive)
 │   ├── crank/           # orchestration — Autonomous epic execution

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -1,6 +1,6 @@
 # Skills Reference
 
-Complete reference for all 80 AgentOps skills (70 user-facing + 10 internal).
+Complete reference for all 81 AgentOps skills (71 user-facing + 10 internal).
 
 Skills are the primitive layer of AgentOps. Higher-level entry points like
 `/implement`, `/validation`, `/rpi`, and `/evolve` compose those primitives

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -67,6 +67,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 
 ### supporting
 
+- `agent-native` — Make an out-of-session Claude (Managed Agent or Agent SDK loop) AgentOps-native — via skills + the ao CLI + CI, not hooks.
 - `autodev` — Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer Evolve and Factory read each tick, not a loop itself.
 - `automation-shape-routing` — Front door for agent automation — decide the SHAPE (Workflow vs NTM vs skill), then hand off. Triggers: "build automation", "convert skills to workflows", "which shape".
 - `codex-team` — Coordinate multiple Codex agents.
@@ -176,6 +177,10 @@ graph LR
 
 | Skill | Direction | Artifact |
 |-------|-----------|----------|
+| `agent-native` | consumes | converter |
+| `agent-native` | consumes | standards |
+| `agent-native` | consumes | validation |
+| `agent-native` | produces | docs/contracts/agent-runtime-profile.md |
 | `autodev` | consumes | evolve |
 | `autodev` | consumes | rpi |
 | `beads` | consumes | bd-issue |

--- a/docs/contracts/skill-dispositions.yaml
+++ b/docs/contracts/skill-dispositions.yaml
@@ -417,3 +417,8 @@ dispositions:
     hexagonal_role: supporting
     disposition:    keep
     rationale:      "Holdout-safe Outcomes grading transport projecting the locked eval substrate; extends validation+ratchet, emits the one council verdict — never an alternate bar"
+  - skill:          agent-native
+    domain:         "BC5 Runtime"
+    hexagonal_role: supporting
+    disposition:    keep
+    rationale:      "Hookless reframe: makes out-of-session agents (Managed/SDK/sandbox) AgentOps-native via skills + ao CLI + CI; extends standards+converter, never a hook revival"

--- a/docs/reference/agentops-domain-evolution-bdd.md
+++ b/docs/reference/agentops-domain-evolution-bdd.md
@@ -19,7 +19,7 @@ Feature: Domain-governed AgentOps 3.0 evolution
     And external-corpus-derived observations are used only through the clean-room policy
 
   Scenario: Audit every skill before changing shipped behavior
-    Given the checked-in skill catalog contains 80 skills
+    Given the checked-in skill catalog contains 81 skills
     When the evolution bootstrap audits the catalog
     Then every skill is assigned exactly one primary bounded context
     And each skill has a preliminary keep, update, refactor, merge-review, or cut-review disposition

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -1,7 +1,7 @@
 # AgentOps Skill Domain Map
 
 This map is the control surface for the next evolution loop. It classifies all
-80 checked-in AgentOps skills before any broad rewrite, using current
+81 checked-in AgentOps skills before any broad rewrite, using current
 `origin/main` product direction, GOALS Directive 12, the DDD/hexagonal ADR, and
 the `soc-y5vh` Loop epic.
 
@@ -18,9 +18,9 @@ around small provable changes.
 <!-- BEGIN:audit-summary -->
 | Signal | Result |
 |---|---:|
-| Skills audited | 80 |
+| Skills audited | 81 |
 | Domains classified | 5 of 5 (BC1-BC5) |
-| Dispositions assigned | 80 / 80 |
+| Dispositions assigned | 81 / 81 |
 <!-- END:audit-summary -->
 
 Observed gap: the catalog has strong operational kernels but weak productized
@@ -59,6 +59,7 @@ Disposition meanings:
 <!-- BEGIN:full-skill-map -->
 | Skill | Domain | Hex role | First disposition | Rationale |
 |---|---|---|---|---|
+| `agent-native` | BC5 Runtime | supporting | keep | Hookless reframe: makes out-of-session agents (Managed/SDK/sandbox) AgentOps-native via skills + ao CLI + CI; extends standards+converter, never a hook revival. |
 | `autodev` | BC3 Loop | supporting | refactor | Must compose with PROGRAM.md and RPI as one vertical-slice executor. |
 | `automation-shape-routing` | BC4 Factory | supporting | keep | Front-door router: decides Workflow vs NTM swarm vs plain skill, hands off to the right builder. |
 | `beads` | BC3 Loop | driven-adapter | update | Tracker adapter is core; add BDD/slice acceptance self-test. |

--- a/registry.json
+++ b/registry.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-05-30T02:15:34Z",
+  "generated_at": "2026-05-30T03:03:07Z",
   "summary": {
-    "skills": 80,
+    "skills": 81,
     "hooks": 0,
     "knowledge_stores": 5,
     "job_types": 0,
     "eval_files": 56,
     "cli_commands": 68,
-    "capabilities": 162
+    "capabilities": 163
   },
   "surfaces": {
     "skills": [
@@ -467,6 +467,14 @@
         "has_skill_md": true,
         "has_references": true,
         "reference_count": 23
+      },
+      {
+        "name": "agent-native",
+        "tier": "meta",
+        "path": "skills/agent-native/",
+        "has_skill_md": true,
+        "has_references": false,
+        "reference_count": 0
       },
       {
         "name": "automation-shape-routing",
@@ -1012,6 +1020,7 @@
         "purpose": "Fitness goal measurement and validation",
         "bounded_context": "BC3",
         "driven_by_skills": [
+          "agent-native",
           "dream",
           "evolve",
           "goals",
@@ -1063,6 +1072,7 @@
         "purpose": "Output relevant knowledge for explicit or JIT injection",
         "bounded_context": "BC1",
         "driven_by_skills": [
+          "agent-native",
           "domain",
           "harvest",
           "inject",
@@ -1359,6 +1369,7 @@
         "purpose": "Umbrella validation gate (exit-code-as-verdict with --gate)",
         "bounded_context": "BC2",
         "driven_by_skills": [
+          "agent-native",
           "using-gc"
         ]
       },
@@ -1389,8 +1400,8 @@
     ]
   },
   "capability_summary": {
-    "total": 162,
-    "skills": 80,
+    "total": 163,
+    "skills": 81,
     "cli_commands": 68,
     "gates": 11,
     "reference_impls": 3
@@ -1466,6 +1477,34 @@
     "wiki"
   ],
   "capabilities": [
+    {
+      "sku": "skill:agent-native",
+      "name": "agent-native",
+      "type": "skill",
+      "bounded_context": "BC5",
+      "hex_role": "supporting",
+      "tier": "meta",
+      "purpose": "Make an out-of-session Claude (Managed Agent or Agent SDK loop) AgentOps-native — via skills + the ao CLI + CI, not hooks.",
+      "status": "active",
+      "disposition": "keep",
+      "consumes": [
+        "standards",
+        "converter",
+        "validation"
+      ],
+      "produces": [
+        "docs/contracts/agent-runtime-profile.md"
+      ],
+      "drives_commands": [
+        "ao corpus inject",
+        "ao goals",
+        "ao inject",
+        "ao session bootstrap",
+        "ao validate"
+      ],
+      "path": "skills/agent-native/",
+      "references": 0
+    },
     {
       "sku": "skill:autodev",
       "name": "autodev",
@@ -3925,6 +3964,7 @@
       "purpose": "Fitness goal measurement and validation",
       "status": "active",
       "driven_by_skills": [
+        "agent-native",
         "dream",
         "evolve",
         "goals",
@@ -4043,6 +4083,7 @@
       "purpose": "Output relevant knowledge for explicit or JIT injection",
       "status": "active",
       "driven_by_skills": [
+        "agent-native",
         "domain",
         "harvest",
         "inject",
@@ -4706,6 +4747,7 @@
       "purpose": "Umbrella validation gate (exit-code-as-verdict with --gate)",
       "status": "active",
       "driven_by_skills": [
+        "agent-native",
         "using-gc"
       ],
       "flags": [

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-05-30T03:03:07Z",
+  "generated_at": "2026-05-30T03:15:58Z",
   "summary": {
     "skills": 81,
     "hooks": 0,

--- a/scripts/skill-body-refs-allowlist.txt
+++ b/scripts/skill-body-refs-allowlist.txt
@@ -20,3 +20,10 @@ skills/standards/references/cli-wireup-template.md
 # existed at a past release (e.g. `ao daemon status` from the daemon era).
 skills/release/references/release-notes.md
 skills-codex/release/references/release-notes.md
+
+# agent-native doctrine skill: names two PLANNED subcommands as forward-refs —
+# `ao agent bundle` (ag-jspr) and `ao mcp serve` (ag-higd), open ready beads
+# under epic ag-7s9fo. The doctrine layer lands first; the commands follow.
+# REMOVE this entry when ag-jspr and ag-higd ship (the skill's "Mechanism
+# status" note tracks the same condition).
+skills/agent-native/SKILL.md

--- a/skills-codex-overrides/catalog.json
+++ b/skills-codex-overrides/catalog.json
@@ -682,6 +682,12 @@
       "treatment": "parity_only",
       "wave": "catalog-parity",
       "reason": "TODO: confirm parity_only or flip to bespoke (+scaffold override dir) for eval-outcomes"
+    },
+    {
+      "name": "agent-native",
+      "treatment": "parity_only",
+      "wave": "catalog-parity",
+      "reason": "TODO: confirm parity_only or flip to bespoke (+scaffold override dir) for agent-native"
     }
   ]
 }

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -2,7 +2,7 @@
   "generator": "manual-maintained",
   "source_root": "skills",
   "layout": "modular",
-  "codex_override_catalog_hash": "aa61d52a460da3e5e6f122c340830a2667c88f2198ae138cbb45ee5141552b8d",
+  "codex_override_catalog_hash": "391a3d1bc2aae59453208361f11612fad2ab840739ec7489612a0ee5ebec018d",
   "codex_override_catalog": {
     "version": 1,
     "description": "Machine-readable Codex treatment map for the full skill catalog.",
@@ -660,10 +660,22 @@
         "treatment": "parity_only",
         "wave": "catalog-parity",
         "reason": "Documents ao eval outcomes as a holdout-safe grading transport; codex form is canonical-derived (no bespoke shell idioms)."
+      },
+      {
+        "name": "agent-native",
+        "treatment": "parity_only",
+        "wave": "catalog-parity",
+        "reason": "Hookless Agent-native pattern; codex form is canonical-derived (no bespoke shell idioms)."
       }
     ]
   },
   "skills": [
+    {
+      "name": "agent-native",
+      "source_skill": "skills/agent-native",
+      "source_hash": "69d47e41db52fc872e263fec2510f08819ecb7a3581859b898056c2537c3a183",
+      "generated_hash": "314b9cc76584601464e2bf70c1356f8e8a7f6d8c557c29e0e2abf6c45cffa51f"
+    },
     {
       "name": "autodev",
       "source_skill": "skills/autodev",
@@ -1111,7 +1123,7 @@
     {
       "name": "using-agentops",
       "source_skill": "skills/using-agentops",
-      "source_hash": "fa900a3758b9e440253e83918f99319c0dadd1f388bd6feb4d529bffced76e97",
+      "source_hash": "0590d919e318a9e99e2f819e10150875640ab3c46af8a4ec2fe82b58718df738",
       "generated_hash": "80119493d38739d5ca4d9377c97c7e4f6e5766365525c965297c1cd78029e74b"
     },
     {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -673,7 +673,7 @@
     {
       "name": "agent-native",
       "source_skill": "skills/agent-native",
-      "source_hash": "69d47e41db52fc872e263fec2510f08819ecb7a3581859b898056c2537c3a183",
+      "source_hash": "2ed77882574f752f4070a09d5f25aef85509286ab94fa4cc6d5749103bda9503",
       "generated_hash": "314b9cc76584601464e2bf70c1356f8e8a7f6d8c557c29e0e2abf6c45cffa51f"
     },
     {

--- a/skills-codex/agent-native/.agentops-generated.json
+++ b/skills-codex/agent-native/.agentops-generated.json
@@ -1,0 +1,7 @@
+{
+  "generator": "manual-maintained",
+  "source_skill": "skills/agent-native",
+  "layout": "modular",
+  "source_hash": "69d47e41db52fc872e263fec2510f08819ecb7a3581859b898056c2537c3a183",
+  "generated_hash": "314b9cc76584601464e2bf70c1356f8e8a7f6d8c557c29e0e2abf6c45cffa51f"
+}

--- a/skills-codex/agent-native/.agentops-generated.json
+++ b/skills-codex/agent-native/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/agent-native",
   "layout": "modular",
-  "source_hash": "69d47e41db52fc872e263fec2510f08819ecb7a3581859b898056c2537c3a183",
+  "source_hash": "2ed77882574f752f4070a09d5f25aef85509286ab94fa4cc6d5749103bda9503",
   "generated_hash": "314b9cc76584601464e2bf70c1356f8e8a7f6d8c557c29e0e2abf6c45cffa51f"
 }

--- a/skills-codex/agent-native/SKILL.md
+++ b/skills-codex/agent-native/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: agent-native
+description: 'Make an out-of-session agent AgentOps-native via skills + ao CLI + CI, not hooks.'
+---
+
+# $agent-native — Make Out-of-Session Agents AgentOps-Native (Codex Native)
+
+> **Quick Ref:** Run a Claude/Codex loop *outside* an interactive session (Managed Agent, Agent SDK, or self-hosted sandbox) under the same AgentOps guardrails — hooklessly. Guardrails = skills + the `ao` CLI + CI, never ported hooks. Bundle skills into the agent definition, expose `ao` as a callable tool so the loop self-bootstraps + self-validates, and gate the output through the SAME CI as interactive work.
+
+## Codex/NTM path
+
+Codex (gpt-5.3-codex) has NO Managed Agents API, NO Workflow tool, NO Task subagent. It orchestrates via NTM (tmux pane swarms + agent-mail) + skills + the `ao` CLI + ssh to bushido. So an out-of-session Codex loop becomes AgentOps-native the same way: load the AgentOps skills, call `ao session bootstrap` / `ao inject` / `ao validate` directly (no MCP needed — Codex shells out), and gate outputs through CI (`agent-output-validate.yml`). `ao` does not wrap `gc`; a whole loop needing a mayor/refinery still routes through `gc`.
+
+## Instructions
+
+Load and follow the skill instructions from the sibling `SKILL.md` — OR read `skills/agent-native/SKILL.md` in the host repo for the canonical specification. Honor the Critical Constraints: this is a reframe of "port hooks", NOT a hook revival; no skill fork (load the same `skills/` files); Managed Agents are NOT ZDR (no holdout/PII in the agent definition); CI is the enforcement boundary, not the optional in-loop adapter.

--- a/skills-codex/agent-native/prompt.md
+++ b/skills-codex/agent-native/prompt.md
@@ -1,0 +1,7 @@
+# agent-native
+
+Make an out-of-session agent (Managed Agent / Agent SDK / sandbox loop) AgentOps-native via skills + the `ao` CLI + CI — not hooks.
+
+## Instructions
+
+Load and follow the skill instructions from the sibling `SKILL.md` file for this skill. Apply the hookless reframe: bundle AgentOps skills into the agent definition, expose `ao` as a callable tool (or shell it directly for Codex) so the loop self-bootstraps + self-validates, and gate every output through the SAME CI as interactive work. This is NOT a hook revival; no skill fork; Managed Agents are NOT ZDR (no holdout/PII in the definition); CI is the enforcement boundary.

--- a/skills-codex/using-agentops/.agentops-generated.json
+++ b/skills-codex/using-agentops/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/using-agentops",
   "layout": "modular",
-  "source_hash": "fa900a3758b9e440253e83918f99319c0dadd1f388bd6feb4d529bffced76e97",
+  "source_hash": "0590d919e318a9e99e2f819e10150875640ab3c46af8a4ec2fe82b58718df738",
   "generated_hash": "80119493d38739d5ca4d9377c97c7e4f6e5766365525c965297c1cd78029e74b"
 }

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -221,7 +221,7 @@ These are how skills chain in practice:
 
 ## Current Skill Tiers
 
-### User-Facing Skills (70)
+### User-Facing Skills (71)
 
 **Judgment:**
 
@@ -327,6 +327,7 @@ These are how skills chain in practice:
 | **skill-builder** | meta | Scaffold or absorb new SKILL.md files against the unified template |
 | **automation-shape-routing** | meta | Front door for building automation: route to Workflow vs NTM swarm vs plain skill, then hand off |
 | **workflow-builder** | meta | Scaffold a new Claude Workflow script (.claude/workflows/*.js) from the operating-loop.js template |
+| **agent-native** | meta | Make out-of-session agents (Managed/SDK/sandbox) AgentOps-native via skills + ao CLI + CI, not hooks |
 
 ### Internal Skills (10) — `metadata.internal: true`
 

--- a/skills/agent-native/SKILL.md
+++ b/skills/agent-native/SKILL.md
@@ -40,6 +40,8 @@ Run a Claude loop *outside* an interactive Claude Code / Codex session — an An
 
 So an out-of-session agent becomes AgentOps-native by: **(a)** loading AgentOps skills into the Agent definition, **(b)** exposing the `ao` CLI as a callable tool (MCP or shell-tool) so the agent can `ao session bootstrap` / `ao inject` / `ao validate` itself, and **(c)** running the same CI-style validation gate on its outputs before the work is accepted. The Agent SDK's own hooks become an **optional thin adapter** for teams wanting in-loop interception — never the primary mechanism.
 
+> **Mechanism status (planned, not yet shipped).** This skill is the **doctrine layer** and lands first; the two concrete commands it names — `ao agent bundle` (ag-jspr) and `ao mcp serve` (ag-higd) — are open, ready beads under epic ag-7s9fo, not yet in the live CLI. The `ao session bootstrap` / `ao inject` / `ao corpus inject` / `ao validate` / `ao goals measure` commands the bundled agent calls are real today. When ag-jspr and ag-higd land, remove this skill's entry from `scripts/skill-body-refs-allowlist.txt`.
+
 This is an **extension of two existing skills**, not a rewrite:
 - [standards](../standards/SKILL.md) — gains an Agent-runtime profile: how the standards/behavioral-discipline checklists get loaded by a non-interactive Claude and enforced via CI rather than `/vibe`.
 - [converter](../converter/SKILL.md) + the `skills/` ↔ `skills-codex/` parity machinery — reused as-is to keep the bundle dual-runtime.
@@ -81,7 +83,7 @@ For Agent SDK users who *want* in-loop interception, a documented `PreToolUse`/`
 
 ## Output Specification
 
-**Format:** JSON Agent definition (`agent-def.json`) + a validated PR/artifact. **Structure:** model, instructions (stitched skills), `skills` array, `ao` MCP descriptor; the output is accepted only on a green CI run.
+**Format:** a JSON Agent definition plus a validated PR/artifact. **Path:** the Agent definition is written to `agent-def.json` at the repo root; the runtime profile is written to `docs/contracts/agent-runtime-profile.md` (the frontmatter `produces` path). **Structure:** model, instructions (stitched skills), `skills` array, `ao` MCP descriptor; the output is accepted only on a green CI run.
 
 ## Quality Rubric
 

--- a/skills/agent-native/SKILL.md
+++ b/skills/agent-native/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: agent-native
+description: Make an out-of-session Claude (Managed Agent or Agent SDK loop) AgentOps-native — via skills + the ao CLI + CI, not hooks.
+skill_api_version: 1
+practices:
+- continuous-delivery
+- ddd
+hexagonal_role: supporting
+consumes:
+- standards
+- converter
+- validation
+produces:
+- docs/contracts/agent-runtime-profile.md
+context:
+  window: fork
+  intent:
+    mode: task
+  sections:
+    exclude: [HISTORY]
+  intel_scope: topic
+metadata:
+  tier: meta
+  dependencies: [standards, converter]
+  stability: experimental
+output_contract: "An AgentOps-native Agent definition (skills + ao tool surface) graded by the same CI gate as interactive work"
+---
+
+# /agent-native — Make Out-of-Session Agents AgentOps-Native (Hookless)
+
+Run a Claude loop *outside* an interactive Claude Code / Codex session — an Anthropic **Managed Agent**, an **Agent SDK** loop, or a self-hosted sandbox job — and keep it under the same AgentOps guardrails. The old reflex ("port the ~50 marketplace hooks into the new runtime") is **wrong for AgentOps 3.0**. This skill is the hookless reframe.
+
+## Overview
+
+**AgentOps 3.0 is hookless.** Guardrails come from three things, never hooks:
+
+1. **Skills** — `skills/<name>/SKILL.md` progressive-disclosure contracts (standards, behavioral-discipline, council, validation, trace, provenance).
+2. **The `ao` CLI** — the deterministic tool surface (`ao session bootstrap`, `ao inject`, `ao corpus inject --query`, `ao validate`, `ao goals measure`) plus the `standards` skill loaded into the agent's instructions.
+3. **CI as the authoritative gate** — `.github/workflows/validate.yml` runs the standards/scenario checks as CI jobs, NOT as a PreToolUse hook.
+
+So an out-of-session agent becomes AgentOps-native by: **(a)** loading AgentOps skills into the Agent definition, **(b)** exposing the `ao` CLI as a callable tool (MCP or shell-tool) so the agent can `ao session bootstrap` / `ao inject` / `ao validate` itself, and **(c)** running the same CI-style validation gate on its outputs before the work is accepted. The Agent SDK's own hooks become an **optional thin adapter** for teams wanting in-loop interception — never the primary mechanism.
+
+This is an **extension of two existing skills**, not a rewrite:
+- [standards](../standards/SKILL.md) — gains an Agent-runtime profile: how the standards/behavioral-discipline checklists get loaded by a non-interactive Claude and enforced via CI rather than `/vibe`.
+- [converter](../converter/SKILL.md) + the `skills/` ↔ `skills-codex/` parity machinery — reused as-is to keep the bundle dual-runtime.
+
+## ⚠️ Critical Constraints
+
+- **This is a reframe of the retired "port hooks" idea, NOT a hook revival.** **Why:** hooks are runtime-coupled and fork the guardrail surface; skills + `ao` + CI are the portable 3.0 waist that works in any runtime.
+- **Single source of truth — no skill fork.** The cloud/SDK agent loads the *same* `skills/` files an interactive session uses. **Why:** a forked guardrail set drifts and defeats the corpus moat.
+- **Managed Agents are NOT ZDR.** Never bundle holdout `target`/`ground_truth`/PII into an Agent definition or its MCP tool responses. **Why:** anything sent to the cloud agent leaves the boundary permanently. For holdout-touching work see [eval-outcomes](../eval-outcomes/SKILL.md).
+- **CI is the gate, not the adapter.** The optional SDK hook adapter is convenience, never the enforcement boundary. **Why:** a bypassed in-loop hook must not mean unvalidated work merges; CI is unconditional.
+
+## Workflow
+
+### Phase 1: Bundle skills into an Agent definition
+
+```bash
+ao agent bundle --runtime managed > agent-def.json
+```
+
+Stitches the selected AgentOps skills (default: `session-bootstrap`, `standards`, `behavioral-discipline`, `validation`, `provenance`) into a Managed Agents API payload — model + instructions + `skills` array + an MCP descriptor for the `ao` tool surface. POST-able with the `managed-agents-2026-04-01` beta header.
+
+**Checkpoint:** the payload carries the skills + the `ao` MCP descriptor, and contains no holdout values.
+
+### Phase 2: Expose `ao` as a tool
+
+Run a thin MCP server (`ao mcp serve`) — or a documented shell-tool spec — exposing `session_bootstrap`, `inject`, `corpus_inject`, `validate`, `goals_measure` so the hosted loop can orient and self-check. For self-hosted sandboxes (bushido), the MCP server runs **inside** the sandbox boundary with tailnet access to Dolt.
+
+**Checkpoint:** the agent can call `ao session bootstrap` + `ao inject` itself before doing work.
+
+### Phase 3: Gate the output via CI
+
+A reusable workflow (`agent-output-validate.yml`) runs `ao validate` + the standards/scenario gates against whatever the agent produced (PR branch or artifact bundle) — the **same** authoritative gate as interactive work. Green CI is the merge gate.
+
+**Checkpoint:** the agent's output passed the identical CI gate; nothing merges red.
+
+### Optional: SDK hook adapter
+
+For Agent SDK users who *want* in-loop interception, a documented `PreToolUse`/`Stop` adapter shells out to `ao validate` (with the `standards` checklist loaded). **Clearly optional — the default path is CI, never hooks.**
+
+## Output Specification
+
+**Format:** JSON Agent definition (`agent-def.json`) + a validated PR/artifact. **Structure:** model, instructions (stitched skills), `skills` array, `ao` MCP descriptor; the output is accepted only on a green CI run.
+
+## Quality Rubric
+
+- [ ] Agent definition loads the *same* `skills/` files as interactive sessions (no fork).
+- [ ] `ao` is callable by the agent (MCP/shell-tool); it can self-bootstrap + self-validate.
+- [ ] Outputs pass the same CI gate as interactive work (CI is the boundary, not a hook).
+- [ ] No holdout `target`/`ground_truth`/PII in the Agent definition or tool responses.
+
+## Examples
+
+```bash
+# Bundle, serve the ao tool surface, and let CI gate the output
+ao agent bundle --runtime managed > agent-def.json
+ao mcp serve &   # exposes session_bootstrap/inject/validate/goals_measure as MCP tools
+# (submit agent-def.json to the Managed Agents API; its PR is gated by agent-output-validate.yml)
+```
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| Tempted to port the hooks | Old runtime-coupled reflex | Don't — bundle skills + expose `ao` + gate via CI. Hooks are the optional adapter only |
+| Agent can't orient | `ao` not exposed as a tool | Run `ao mcp serve` (or the shell-tool spec) so the loop can `ao session bootstrap` |
+| Unvalidated work merged | Relied on the optional in-loop adapter | CI (`agent-output-validate.yml`) is the gate — never the adapter |
+
+## See Also
+
+- [standards](../standards/SKILL.md) — the checklists the agent loads + CI enforces
+- [converter](../converter/SKILL.md) — keeps the bundle dual-runtime (skills ↔ skills-codex)
+- [eval-outcomes](../eval-outcomes/SKILL.md) — holdout-safe grading for cloud/out-of-session agents
+- [using-gc](../using-gc/SKILL.md) — running a whole out-of-session loop (gc owns orchestration; `ao agent bundle` produces the definition)
+- [skill-auditor](../skill-auditor/SKILL.md) — audit this skill before declaring stable

--- a/skills/agent-native/scripts/validate.sh
+++ b/skills/agent-native/scripts/validate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# validate.sh — minimal self-validation
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../.." && pwd)"
+exec bash "$REPO_ROOT/skills/skill-auditor/scripts/audit.sh" "$SKILL_DIR"

--- a/skills/using-agentops/SKILL.md
+++ b/skills/using-agentops/SKILL.md
@@ -171,6 +171,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/skill-builder` | Scaffold or absorb new SKILL.md files against the unified template |
 | `/automation-shape-routing` | Front door for building agent automation — decide the SHAPE (Workflow vs NTM swarm vs plain skill), then hand off to the right builder |
 | `/workflow-builder` | Scaffold a new Claude Workflow script (`.claude/workflows/*.js`) — deterministic multi-agent orchestration |
+| `/agent-native` | Make out-of-session agents AgentOps-native via skills + ao CLI + CI, not hooks |
 
 ## Expert Skills (specialized workflows)
 


### PR DESCRIPTION
## What

First child of **ag-7s9fo** (Make Managed/SDK agents AgentOps-native). Adds the **/agent-native** dual-runtime skill documenting the **hookless reframe** of the retired "port the ~50 hooks" idea.

An out-of-session Claude (Managed Agent / Agent SDK loop / self-hosted sandbox) becomes AgentOps-native via three things — **never hooks**:
1. **Bundle AgentOps skills** into the Agent definition (same `skills/` files, no fork).
2. **Expose the `ao` CLI as a callable tool** (MCP/shell-tool) so the loop self-bootstraps + self-validates.
3. **Gate outputs through the SAME CI** as interactive work.

Extends `standards` + `converter`. The SDK hooks become an *optional thin adapter*, never the enforcement boundary. Managed Agents are NOT ZDR → no holdout/PII in the agent definition.

## How

Built through the hardened scaffold (ag-cw2y → ag-ekyq → ag-j4l1) — all 6 derived surfaces regenerated in one shot (registry, domain-map, context-map, counts, codex twin+manifest+marker, dispositions BC5-Runtime, SKILL-TIERS, using-agentops catalog, embedded sync). Reverted the swept-in pre-existing drift (6 codex hashes + cli-surface) per the changed-files-scoped triage.

Caught + fixed an `INVALID_AO_CMD` heal finding: `ao standards` isn't a command — `standards` is a loaded checklist enforced via `ao validate` + CI (corrected the references).

## Scope note

The skill documents the *intended* `ao agent bundle` / `ao mcp serve` / `agent-output-validate.yml` surfaces — those are the sibling child beads (ag-jspr, ag-higd, ag-mptr). This PR is the skill-doc slice only.

## Evidence

- `heal.sh --strict skills/agent-native` → clean
- `audit-codex-parity.sh --skill agent-native` → pass
- `validate-codex-generated-artifacts.sh --scope worktree` → pass
- `generate-{registry,skill-domain-map}.sh --check` → clean; `check-registry-drift.sh` → no drift

Closes-scenario: ag-2wln#agent-native
Bounded-context: BC5-Runtime
Evidence: skills/agent-native/SKILL.md