### PR TITLE
feat(ci): agent-output-validate.yml — reusable authoritative gate on agent output (ag-mptr #agent-output-validate)

### DIFF
--- a/.github/workflows/agent-output-validate.yml
+++ b/.github/workflows/agent-output-validate.yml
@@ -1,0 +1,67 @@
+name: agent-output-validate
+
+# Reusable, authoritative CI gate over agent-produced output (ag-mptr, epic
+# ag-7s9fo "Make Managed/SDK agents AgentOps-native").
+#
+# AgentOps 3.0 is hookless: the guardrail on an out-of-session agent (Claude
+# Managed Agent, Agent SDK loop, or NTM/Codex swarm) is NOT a ported PreToolUse
+# hook — it is this CI job running `ao validate --gate`, the SAME authoritative
+# gate interactive work hits in validate.yml. Runtime-agnostic: it gates both
+# Managed-Agent PRs and NTM-swarm PRs because both target a PR branch.
+#
+# Wired as `workflow_call` so an overnight Managed Agent job or an NTM lead pane
+# can invoke it against the branch/artifact it produced. The optional in-loop
+# SDK hook adapter (ag-50m3) is convenience only — this gate is the boundary.
+
+on:
+  workflow_call:
+    inputs:
+      changes:
+        description: >-
+          Optional space-separated files to scope the gate to (maps to
+          `ao validate --gate --changes`). Empty gates the RPI artifacts in cwd.
+        required: false
+        type: string
+        default: ''
+      strict:
+        description: 'Promote WARN to FAIL (ao validate --gate --strict).'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  agent-output-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - name: Build ao
+        run: |
+          set -euo pipefail
+          GOBIN="$HOME/.local/bin" go -C cli install ./cmd/ao
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Gate agent-produced output (ao validate --gate)
+        env:
+          GATE_CHANGES: ${{ inputs.changes }}
+          GATE_STRICT: ${{ inputs.strict }}
+        run: |
+          set -euo pipefail
+          chmod +x scripts/agent-output-validate.sh
+          args=()
+          if [ -n "$GATE_CHANGES" ]; then
+            # shellcheck disable=SC2206
+            args+=(--changes $GATE_CHANGES)
+          fi
+          if [ "$GATE_STRICT" = "true" ]; then
+            args+=(--strict)
+          fi
+          ./scripts/agent-output-validate.sh "${args[@]}"

--- a/scripts/agent-output-validate.sh
+++ b/scripts/agent-output-validate.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# agent-output-validate.sh — the authoritative gate over agent-produced output.
+#
+# Runs `ao validate --gate` (the umbrella that composes the ratchet / standards /
+# scenario validators) against whatever an out-of-session agent produced — a PR
+# branch checkout or an artifact bundle — and propagates the PASS/WARN/FAIL
+# verdict to this process's exit code. This is the SAME authoritative gate
+# interactive work hits in validate.yml; CI is the gate, not a hook (AgentOps
+# 3.0 is hookless). Called by .github/workflows/agent-output-validate.yml and
+# usable directly by an NTM lead pane or a self-hosted sandbox.
+#
+# Usage:
+#   agent-output-validate.sh [ao validate flags...]
+#   agent-output-validate.sh --changes plan.md
+#   agent-output-validate.sh --bead ag-123 --strict
+#
+# Exit codes (mirrors `ao validate --gate`):
+#   0  PASS or WARN (gate passes)
+#   1  FAIL (gate fails — a violation was found)
+#   2  internal/usage error (could not run the gate, e.g. ao not found)
+#
+# Env:
+#   AO_BIN  override the `ao` binary (default: `ao` on PATH). Lets CI point at a
+#           freshly built binary and lets tests inject a fixture.
+set -euo pipefail
+
+AO_BIN="${AO_BIN:-ao}"
+
+# Resolve the ao binary loudly — a missing gate must never read as a clean pass.
+if ! command -v "$AO_BIN" >/dev/null 2>&1 && [ ! -x "$AO_BIN" ]; then
+  echo "agent-output-validate: ao binary not found (AO_BIN=$AO_BIN). Build it first (cd cli && go install ./cmd/ao) or set AO_BIN." >&2
+  exit 2
+fi
+
+echo "agent-output-validate: running the authoritative gate on agent-produced output"
+echo "agent-output-validate: \$ $AO_BIN validate --gate $*"
+
+rc=0
+"$AO_BIN" validate --gate "$@" || rc=$?
+
+case "$rc" in
+  0) echo "agent-output-validate: PASS — agent output cleared the gate" ;;
+  1) echo "agent-output-validate: FAIL — agent output violated the gate (not mergeable)" >&2 ;;
+  *) echo "agent-output-validate: ERROR — gate could not run (exit $rc)" >&2 ;;
+esac
+
+exit "$rc"

--- a/tests/scripts/agent-output-validate.bats
+++ b/tests/scripts/agent-output-validate.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# ag-mptr: agent-output-validate.sh is the gate logic behind the reusable
+# .github/workflows/agent-output-validate.yml — it runs `ao validate --gate`
+# against an agent-produced PR/artifact and propagates the verdict to a process
+# exit code (the SAME authoritative gate as interactive work; CI is the gate,
+# not a hook). These cases are the passing+failing fixture evidence required by
+# the bead's acceptance, exercised deterministically via an injectable fake ao
+# (AO_BIN) so they don't depend on constructing real ratchet-failing artifacts.
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../../scripts/agent-output-validate.sh"
+  WORKFLOW="$BATS_TEST_DIRNAME/../../.github/workflows/agent-output-validate.yml"
+  FIX="$(mktemp -d)"
+  # Fake ao binaries: each echoes its invocation and exits with a fixed code,
+  # matching `ao validate --gate` semantics (0 PASS/WARN, 1 FAIL, 2 error).
+  for name in pass fail err; do
+    case "$name" in
+      pass) code=0 ;;
+      fail) code=1 ;;
+      err)  code=2 ;;
+    esac
+    cat > "$FIX/ao-$name" <<EOF
+#!/usr/bin/env bash
+echo "FAKE ao \$*"
+exit $code
+EOF
+    chmod +x "$FIX/ao-$name"
+  done
+}
+
+teardown() { rm -rf "$FIX"; }
+
+@test "PASS fixture: a clean gate (ao exits 0) makes the script exit 0" {
+  run env AO_BIN="$FIX/ao-pass" bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"validate --gate"* ]]
+}
+
+@test "FAIL fixture: a violating gate (ao exits 1) makes the script exit 1" {
+  run env AO_BIN="$FIX/ao-fail" bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+}
+
+@test "internal error (ao exits 2) is propagated, not swallowed as a pass" {
+  run env AO_BIN="$FIX/ao-err" bash "$SCRIPT"
+  [ "$status" -eq 2 ]
+}
+
+@test "missing ao binary fails loudly (does not silently pass)" {
+  run env AO_BIN="$FIX/does-not-exist" bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ao"* ]]
+}
+
+@test "forwards scope flags (--changes) through to ao validate --gate" {
+  run env AO_BIN="$FIX/ao-pass" bash "$SCRIPT" --changes plan.md
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--changes plan.md"* ]]
+}
+
+@test "script is executable and uses strict bash mode" {
+  [ -x "$SCRIPT" ]
+  grep -qE "set -euo pipefail" "$SCRIPT"
+}
+
+@test "reusable workflow exists, is workflow_call, and runs the script" {
+  [ -f "$WORKFLOW" ]
+  grep -qE "^\s*workflow_call:" "$WORKFLOW"
+  grep -q "agent-output-validate.sh" "$WORKFLOW"
+}


### PR DESCRIPTION
## What

Reusable, authoritative CI gate over **agent-produced output** — the hookless guardrail for out-of-session agents (Claude Managed Agent, Agent SDK loop, or NTM/Codex swarm). A `workflow_call` job runs `ao validate --gate` (the umbrella composing ratchet/standards/scenario) against an agent's PR/artifact and propagates PASS/WARN/FAIL to the job exit code. **CI is the gate, not a ported hook** (AgentOps 3.0 is hookless).

Second child of epic **ag-7s9fo** (Make Managed/SDK agents AgentOps-native), after ag-2wln `/agent-native` (#616). Inherits the richer spec absorbed from superseded ag-toat4; the optional SDK hook adapter was split out to ag-50m3.

## Files (3, +184/−0)

- `scripts/agent-output-validate.sh` — testable gate logic. Resolves `ao` (`AO_BIN` override), runs `ao validate --gate "$@"`, propagates exit (0 pass/warn, 1 fail, 2 error). **Fails loudly if `ao` is missing** — a missing gate never reads as a clean pass.
- `.github/workflows/agent-output-validate.yml` — `workflow_call` wrapper (inputs: `changes`, `strict`); builds `ao`, runs the script. Runtime-agnostic (serves Managed-Agent + NTM-swarm PRs). `workflow_call`-only **by design** — it's adopted by a caller, not triggered standalone, so it does not run on this PR.
- `tests/scripts/agent-output-validate.bats` — 7 cases. The **passing+failing fixture evidence** the bead requires, exercised deterministically via an injectable fake `ao` (exit 0/1/2), plus scope-flag forwarding, missing-binary, strict-mode, and workflow-wiring assertions.

## Evidence

- `bats tests/scripts/agent-output-validate.bats` → **7/7 green**
- `shellcheck scripts/agent-output-validate.sh` → clean (severity=error)
- Real-`ao` smoke: against the live binary the script faithfully propagates the gate verdict (an empty dir yields ao's exit-2 "no artifacts" → ERROR, proving no silent pass)
- yaml parses valid

## Note for review

The workflow is `workflow_call`-only, so CI here can't execute it (nothing `uses:` it yet). The **bats suite is the regression proof** for the gate logic; the yaml is the thin Actions wrapper a caller adopts. Bare invocation (no `changes`/`bead`) intentionally surfaces ao's exit-2 — callers scope the gate via the `changes` input.

Closes-scenario: ag-mptr#agent-output-validate
Bounded-context: BC5-Runtime
Evidence: tests/scripts/agent-output-validate.bats