### PR TITLE
docs(agent-native): optional SDK PreToolUse/Stop hook adapter reference (ag-50m3 #sdk-adapter)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-05-30T05:37:14Z",
+  "generated_at": "2026-05-30T05:58:17Z",
   "summary": {
     "skills": 81,
     "hooks": 0,
@@ -473,8 +473,8 @@
         "tier": "meta",
         "path": "skills/agent-native/",
         "has_skill_md": true,
-        "has_references": false,
-        "reference_count": 0
+        "has_references": true,
+        "reference_count": 1
       },
       {
         "name": "automation-shape-routing",
@@ -1521,7 +1521,7 @@
         "ao validate"
       ],
       "path": "skills/agent-native/",
-      "references": 0
+      "references": 1
     },
     {
       "sku": "skill:autodev",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -673,7 +673,7 @@
     {
       "name": "agent-native",
       "source_skill": "skills/agent-native",
-      "source_hash": "2ed77882574f752f4070a09d5f25aef85509286ab94fa4cc6d5749103bda9503",
+      "source_hash": "0954334c8c9455712baca97f5168ee1355fb372213587e39d4f60cca54c16bae",
       "generated_hash": "314b9cc76584601464e2bf70c1356f8e8a7f6d8c557c29e0e2abf6c45cffa51f"
     },
     {

--- a/skills-codex/agent-native/.agentops-generated.json
+++ b/skills-codex/agent-native/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/agent-native",
   "layout": "modular",
-  "source_hash": "2ed77882574f752f4070a09d5f25aef85509286ab94fa4cc6d5749103bda9503",
+  "source_hash": "0954334c8c9455712baca97f5168ee1355fb372213587e39d4f60cca54c16bae",
   "generated_hash": "314b9cc76584601464e2bf70c1356f8e8a7f6d8c557c29e0e2abf6c45cffa51f"
 }

--- a/skills/agent-native/SKILL.md
+++ b/skills/agent-native/SKILL.md
@@ -79,7 +79,7 @@ A reusable workflow (`agent-output-validate.yml`) runs `ao validate` + the stand
 
 ### Optional: SDK hook adapter
 
-For Agent SDK users who *want* in-loop interception, a documented `PreToolUse`/`Stop` adapter shells out to `ao validate` (with the `standards` checklist loaded). **Clearly optional — the default path is CI, never hooks.**
+For Agent SDK users who *want* in-loop interception, a documented `PreToolUse`/`Stop` adapter shells out to `ao validate` (with the `standards` checklist loaded). **Clearly optional — the default path is CI, never hooks.** Reference samples (TypeScript + Python, wired into no runtime by default): [references/sdk-hook-adapter.md](references/sdk-hook-adapter.md).
 
 ## Output Specification
 

--- a/skills/agent-native/references/sdk-hook-adapter.md
+++ b/skills/agent-native/references/sdk-hook-adapter.md
@@ -1,0 +1,76 @@
+# Optional Agent SDK hook adapter — `PreToolUse` / `Stop`
+
+> **OPTIONAL. The authoritative gate is CI** (`agent-output-validate.yml`, ag-mptr).
+> Use this only if your team wants *in-loop* interception in an Agent SDK loop.
+> AgentOps 3.0 is **hookless-first** — this adapter is a convenience sample, **not**
+> a dependency, **not** a hook revival, and **not** required for an agent to be
+> AgentOps-native. A bypassed in-loop hook must never mean unvalidated work merges;
+> that is why CI — not this adapter — is the enforcement boundary.
+
+## What it is
+
+A tiny reference adapter that an Agent SDK loop can register as a `PreToolUse`
+and/or `Stop` callback. It shells out to the `ao` CLI — `ao validate --gate`
+(with the `standards` checklist loaded into the agent's instructions) — and lets
+the agent surface the verdict in-loop. It wires into **no runtime by default**;
+copy it into your own SDK harness if you want it.
+
+**Default path (recommended):** do nothing here — let the agent run, open a PR,
+and let `agent-output-validate.yml` run `ao validate` in CI. The adapter only
+adds an *earlier, advisory* signal; it does not replace the CI gate.
+
+## Reference samples
+
+These type-check (`tsc` / `mypy`) but are intentionally not wired into any
+runtime. They are illustration, not infrastructure.
+
+### TypeScript (`PreToolUse`)
+
+```ts
+import { execFileSync } from "node:child_process";
+
+// OPTIONAL in-loop advisory check. The authoritative gate is CI, not this hook.
+export function preToolUseValidate(changedFiles: string[]): {
+  ok: boolean;
+  verdict: string;
+} {
+  try {
+    execFileSync("ao", ["validate", "--gate", "--changes", ...changedFiles], {
+      stdio: "pipe",
+    });
+    return { ok: true, verdict: "PASS" };
+  } catch (err: unknown) {
+    // exit 1 = FAIL, exit 2 = could-not-run. Advisory only — never block merge
+    // on this; CI (agent-output-validate.yml) is the real boundary.
+    const code = (err as { status?: number }).status ?? 1;
+    return { ok: false, verdict: code === 2 ? "ERROR" : "FAIL" };
+  }
+}
+```
+
+### Python (`Stop`)
+
+```python
+import subprocess
+
+def stop_validate(changed_files: list[str]) -> tuple[bool, str]:
+    """OPTIONAL in-loop advisory check. CI is the default gate, not this hook."""
+    proc = subprocess.run(
+        ["ao", "validate", "--gate", "--changes", *changed_files],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode == 0:
+        return True, "PASS"
+    # Advisory only — do NOT hard-block on this; agent-output-validate.yml is the
+    # authoritative CI boundary (Managed Agents are not ZDR; never inline holdout).
+    return False, "ERROR" if proc.returncode == 2 else "FAIL"
+```
+
+## Boundaries
+
+- **Never** register an always-on hook anywhere in this repo; this stays a sample.
+- The adapter calls only `ao validate` / the `standards` checklist — it does not
+  read holdout/eval corpus, and it must not be used to smuggle one in.
+- If you adopt it, document in your harness that **CI remains the merge gate**.


### PR DESCRIPTION
## What

**5th and final epic deliverable of ag-7s9fo.** New `skills/agent-native/references/sdk-hook-adapter.md` — a clearly-**OPTIONAL** Agent SDK `PreToolUse`/`Stop` adapter (TypeScript + Python samples) that shells `ao validate --gate` for teams wanting *in-loop* interception.

The framing is hammered throughout (header + boundaries section):
- **CI (`agent-output-validate.yml`, ag-mptr) is the authoritative gate.** This adapter is convenience, **not** a dependency, **not** a hook revival, wired into **no runtime by default**.
- Advisory-only — never hard-block on it; CI is the merge boundary.
- Never inline holdout/eval corpus (Managed Agents are NOT ZDR).

Linked from SKILL.md's existing "Optional: SDK hook adapter" section (heal --strict ref-linked).

## Acceptance (doc-shaped bead — gates are the verification)

- ✅ Adapter documented as OPTIONAL with explicit "CI is the default, not this" framing.
- ✅ Shells to `ao validate` / the `standards` checklist.
- ✅ No claim that hooks are required; no always-on hook registered.
- ✅ Example adapter (TS + Py).

## Skill-modification regen (surgical)

Editing the skill shifts its content hash, so: `registry.json` content-hash + `skills-codex/agent-native` source_hash + the manifest's agent-native entry. The 6 pre-existing-main codex drifts (deps/provenance/red-team/release/scenario/trace) were **reverted to origin/main** (not swept in). Evidence: heal --strict exit 0 · codex-artifacts `--scope worktree` PASS · registry-drift PASS · parity PASS · skill audit WARN(exit 0). Scope-only diff (5 files).

Closes-scenario: ag-50m3#sdk-adapter
Bounded-context: BC5-Runtime
Evidence: skills/agent-native/references/sdk-hook-adapter.md