### PR TITLE
feat(cli): ao mcp serve live JSON-RPC transport — completes ag-3ucpd (#mcp-transport)

### DIFF
--- a/cli/cmd/ao/mcp_serve.go
+++ b/cli/cmd/ao/mcp_serve.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -78,20 +80,61 @@ func runMCPServePrintTools(w io.Writer) error {
 // mcpServeOptions is the resolved input to runMCPServe.
 type mcpServeOptions struct {
 	PrintTools bool
-	Out        io.Writer
+	In         io.Reader       // live transport input (default os.Stdin)
+	Out        io.Writer       // print-tools / live transport output (default os.Stdout)
+	Exec       mcpToolExecutor // tool executor (default realMCPExecutor)
 }
 
 // runMCPServe handles `ao mcp serve`. Slice 1 supports --print-tools only; the
 // live JSON-RPC transport is the ag-3ucpd follow-up and errors loudly until then.
 func runMCPServe(opts mcpServeOptions) error {
-	if !opts.PrintTools {
-		return fmt.Errorf("live MCP transport is not yet implemented (follow-up ag-3ucpd); use `ao mcp serve --print-tools` to emit the tool surface")
+	if opts.PrintTools {
+		out := opts.Out
+		if out == nil {
+			return fmt.Errorf("runMCPServe: print-tools requires a non-nil writer")
+		}
+		return runMCPServePrintTools(out)
+	}
+	// Live MCP JSON-RPC stdio transport (ag-3ucpd).
+	in := opts.In
+	if in == nil {
+		in = os.Stdin
 	}
 	out := opts.Out
 	if out == nil {
-		return fmt.Errorf("runMCPServe: print-tools requires a non-nil writer")
+		out = os.Stdout
 	}
-	return runMCPServePrintTools(out)
+	exec := opts.Exec
+	if exec == nil {
+		exec = realMCPExecutor
+	}
+	return serveMCP(in, out, exec)
+}
+
+// realMCPExecutor shells the curated tool's underlying `ao` subcommand. Each
+// tool is read-mostly and deterministic. `standards` has no standalone command
+// — the standards checklist is enforced through `ao validate`, so it routes
+// there. Only reachable for non-denied calls (mcpToolDenied runs first).
+func realMCPExecutor(name string, args map[string]string) (string, error) {
+	var argv []string
+	switch name {
+	case "session_bootstrap":
+		argv = []string{"session", "bootstrap"}
+	case "inject":
+		argv = []string{"inject", "--query", args["query"]}
+	case "corpus_inject":
+		argv = []string{"corpus", "inject", "--query", args["query"]}
+	case "validate":
+		argv = []string{"validate", "--gate", "--changes", args["target"]}
+	case "standards":
+		argv = []string{"validate", "--gate"} // standards checklist runs via validate
+	case "goals_measure":
+		argv = []string{"goals", "measure"}
+	default:
+		return "", fmt.Errorf("unknown tool %q", name)
+	}
+	out, err := exec.Command("ao", argv...).CombinedOutput()
+	return string(out), err
 }
 
 // --- cobra wiring ---

--- a/cli/cmd/ao/mcp_serve_test.go
+++ b/cli/cmd/ao/mcp_serve_test.go
@@ -74,14 +74,21 @@ func TestRunMCPServePrintTools_JSON(t *testing.T) {
 	}
 }
 
-func TestMCPServe_LiveTransportNotYet(t *testing.T) {
-	// Slice 1 ships only the descriptor surface; bare `serve` must fail loudly,
-	// pointing at the live-transport follow-up — never silently no-op.
-	err := runMCPServe(mcpServeOptions{PrintTools: false})
-	if err == nil {
-		t.Fatal("bare `ao mcp serve` (no --print-tools) must error in slice 1")
+func TestRunMCPServe_LiveTransportWired(t *testing.T) {
+	// ag-3ucpd: bare `ao mcp serve` now runs the live JSON-RPC transport.
+	// runMCPServe must drive serveMCP over the injected reader/writer/executor.
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}` + "\n")
+	var out strings.Builder
+	err := runMCPServe(mcpServeOptions{
+		PrintTools: false,
+		In:         in,
+		Out:        &out,
+		Exec:       func(string, map[string]string) (string, error) { return "", nil },
+	})
+	if err != nil {
+		t.Fatalf("live serve: %v", err)
 	}
-	if !strings.Contains(err.Error(), "--print-tools") {
-		t.Errorf("error should point users at --print-tools, got %q", err.Error())
+	if !strings.Contains(out.String(), `"tools"`) {
+		t.Errorf("live transport did not answer tools/list: %s", out.String())
 	}
 }

--- a/cli/cmd/ao/mcp_transport.go
+++ b/cli/cmd/ao/mcp_transport.go
@@ -1,0 +1,120 @@
+// practices: [hexagonal-architecture, design-by-contract]
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// MCP JSON-RPC 2.0 stdio transport (ag-3ucpd). Newline-delimited JSON: one
+// request object per line, one response object per line. Serves the curated tool
+// surface from mcp_serve.go (mcpToolDescriptors / mcpToolDenied) so a hosted /
+// SDK Claude loop can orient and self-check.
+
+type mcpRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+type mcpRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type mcpResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *mcpRPCError    `json:"error,omitempty"`
+}
+
+// mcpToolExecutor runs a curated tool by name and returns its structured text
+// output. The production executor shells the wrapped `ao` subcommand; tests
+// inject a deterministic fake (the protocol/dispatch/refusal is what we gate).
+type mcpToolExecutor func(name string, args map[string]string) (string, error)
+
+// serveMCP reads newline-delimited JSON-RPC requests from r, dispatches each,
+// and writes one response line per request to w. A request with no id is a
+// notification and gets no response. Returns on EOF.
+func serveMCP(r io.Reader, w io.Writer, exec mcpToolExecutor) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	enc := json.NewEncoder(w)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var req mcpRequest
+		if err := json.Unmarshal(line, &req); err != nil {
+			if encErr := enc.Encode(parseErrorResponse()); encErr != nil {
+				return encErr
+			}
+			continue
+		}
+		if len(req.ID) == 0 {
+			continue // notification — no response
+		}
+		result, rpcErr := dispatchMCP(req, exec)
+		resp := mcpResponse{JSONRPC: "2.0", ID: req.ID, Result: result, Error: rpcErr}
+		if err := enc.Encode(resp); err != nil {
+			return err
+		}
+	}
+	return scanner.Err()
+}
+
+func parseErrorResponse() mcpResponse {
+	return mcpResponse{JSONRPC: "2.0", ID: json.RawMessage("null"), Error: &mcpRPCError{Code: -32700, Message: "parse error"}}
+}
+
+// dispatchMCP routes one request to its handler.
+func dispatchMCP(req mcpRequest, exec mcpToolExecutor) (any, *mcpRPCError) {
+	switch req.Method {
+	case "initialize":
+		return handleInitialize(), nil
+	case "tools/list":
+		return map[string]any{"tools": mcpToolDescriptors()}, nil
+	case "tools/call":
+		return handleToolsCall(req.Params, exec)
+	default:
+		return nil, &mcpRPCError{Code: -32601, Message: fmt.Sprintf("method not found: %s", req.Method)}
+	}
+}
+
+func handleInitialize() map[string]any {
+	return map[string]any{
+		"protocolVersion": "2024-11-05",
+		"capabilities":    map[string]any{"tools": map[string]any{}},
+		"serverInfo":      map[string]any{"name": "ao-mcp", "version": "1"},
+	}
+}
+
+// handleToolsCall enforces the NOT-ZDR holdout refusal, then dispatches to the
+// executor and wraps the output in MCP `content` shape.
+func handleToolsCall(params json.RawMessage, exec mcpToolExecutor) (any, *mcpRPCError) {
+	var call struct {
+		Name      string            `json:"name"`
+		Arguments map[string]string `json:"arguments"`
+	}
+	if err := json.Unmarshal(params, &call); err != nil {
+		return nil, &mcpRPCError{Code: -32602, Message: "invalid tools/call params"}
+	}
+	if denied, reason := mcpToolDenied(call.Name, call.Arguments); denied {
+		return nil, &mcpRPCError{Code: -32001, Message: reason}
+	}
+	if exec == nil {
+		return nil, &mcpRPCError{Code: -32603, Message: "no tool executor configured"}
+	}
+	out, err := exec(call.Name, call.Arguments)
+	if err != nil {
+		return nil, &mcpRPCError{Code: -32000, Message: fmt.Sprintf("tool %q failed: %v", call.Name, err)}
+	}
+	return map[string]any{
+		"content": []map[string]any{{"type": "text", "text": out}},
+	}, nil
+}

--- a/cli/cmd/ao/mcp_transport_test.go
+++ b/cli/cmd/ao/mcp_transport_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// driveMCP feeds newline-delimited JSON-RPC requests through serveMCP with the
+// given executor and returns the decoded responses, one per request line.
+func driveMCP(t *testing.T, exec mcpToolExecutor, requests ...string) []mcpResponse {
+	t.Helper()
+	in := strings.NewReader(strings.Join(requests, "\n") + "\n")
+	var out bytes.Buffer
+	if err := serveMCP(in, &out, exec); err != nil {
+		t.Fatalf("serveMCP: %v", err)
+	}
+	var resps []mcpResponse
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var r mcpResponse
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			t.Fatalf("decoding response %q: %v", line, err)
+		}
+		resps = append(resps, r)
+	}
+	return resps
+}
+
+func okExec(name string, _ map[string]string) (string, error) {
+	return "RESULT:" + name, nil
+}
+
+func TestServeMCP_Initialize(t *testing.T) {
+	resps := driveMCP(t, okExec, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resps))
+	}
+	if resps[0].Error != nil {
+		t.Fatalf("initialize errored: %v", resps[0].Error)
+	}
+	res, _ := json.Marshal(resps[0].Result)
+	if !strings.Contains(string(res), "capabilities") || !strings.Contains(string(res), "serverInfo") {
+		t.Errorf("initialize result missing capabilities/serverInfo: %s", res)
+	}
+}
+
+func TestServeMCP_ToolsList(t *testing.T) {
+	resps := driveMCP(t, okExec, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
+	res, _ := json.Marshal(resps[0].Result)
+	var doc struct {
+		Tools []mcpToolDescriptor `json:"tools"`
+	}
+	if err := json.Unmarshal(res, &doc); err != nil {
+		t.Fatalf("tools/list result not decodable: %v", err)
+	}
+	if len(doc.Tools) != 6 {
+		t.Errorf("tools/list returned %d tools, want 6", len(doc.Tools))
+	}
+}
+
+func TestServeMCP_ToolsCall_DispatchesToExecutor(t *testing.T) {
+	var calledWith string
+	exec := func(name string, args map[string]string) (string, error) {
+		calledWith = name + ":" + args["target"]
+		return "PASS", nil
+	}
+	resps := driveMCP(t, exec,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"validate","arguments":{"target":"plan.md"}}}`)
+	if resps[0].Error != nil {
+		t.Fatalf("tools/call errored: %v", resps[0].Error)
+	}
+	if calledWith != "validate:plan.md" {
+		t.Errorf("executor called with %q, want validate:plan.md", calledWith)
+	}
+	res, _ := json.Marshal(resps[0].Result)
+	if !strings.Contains(string(res), "PASS") {
+		t.Errorf("tools/call result should carry executor output, got %s", res)
+	}
+}
+
+func TestServeMCP_ToolsCall_HoldoutDenied(t *testing.T) {
+	called := false
+	exec := func(string, map[string]string) (string, error) { called = true; return "", nil }
+	resps := driveMCP(t, exec,
+		`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"corpus_inject","arguments":{"query":"the holdout ground_truth"}}}`)
+	if resps[0].Error == nil {
+		t.Fatal("a holdout-surfacing tool call must return a JSON-RPC error")
+	}
+	if called {
+		t.Error("executor must NOT run for a denied holdout call (NOT-ZDR)")
+	}
+	low := strings.ToLower(resps[0].Error.Message)
+	if !strings.Contains(low, "holdout") && !strings.Contains(low, "zdr") {
+		t.Errorf("denial message must name the holdout/ZDR boundary, got %q", resps[0].Error.Message)
+	}
+}
+
+func TestServeMCP_UnknownMethod(t *testing.T) {
+	resps := driveMCP(t, okExec, `{"jsonrpc":"2.0","id":5,"method":"does/not/exist"}`)
+	if resps[0].Error == nil || resps[0].Error.Code != -32601 {
+		t.Errorf("unknown method must return JSON-RPC -32601, got %+v", resps[0].Error)
+	}
+}
+
+func TestServeMCP_MultiRequestRoundTrip(t *testing.T) {
+	// The acceptance: a session round-trips initialize + tool calls over the
+	// transport and gets structured responses back.
+	resps := driveMCP(t, okExec,
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"session_bootstrap","arguments":{}}}`,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"validate","arguments":{"target":"x"}}}`,
+	)
+	if len(resps) != 3 {
+		t.Fatalf("got %d responses, want 3", len(resps))
+	}
+	for i, r := range resps {
+		if r.Error != nil {
+			t.Errorf("response %d errored: %v", i, r.Error)
+		}
+	}
+}


### PR DESCRIPTION
## What

Completes **ag-3ucpd** (the last child of epic ag-7s9fo) — after ag-h1mk (#619) shipped the descriptor surface, this adds the **live MCP JSON-RPC stdio transport**. Bare `ao mcp serve` now runs a server over the curated tool surface so a Managed Agent / Agent SDK loop can orient and self-check.

- `cli/cmd/ao/mcp_transport.go` — NDJSON JSON-RPC 2.0: `initialize` (capabilities + serverInfo), `tools/list` (the 6 `mcpToolDescriptors`), `tools/call` (dispatch → injectable executor → MCP `content` shape). Notifications (no id) → no response; unknown method → `-32601`; parse error → `-32700`.
- **HARD REFUSAL (NOT-ZDR):** `tools/call` runs `mcpToolDenied` **first** — a holdout/eval-surfacing call returns a JSON-RPC error and the executor **never runs**.
- `realMCPExecutor` shells the wrapped `ao` subcommand (`standards` routes through `ao validate` — there is no `ao standards` command). The executor is **injectable**, so the protocol/dispatch/refusal is tested deterministically without shelling real `ao` (repo mock-externals rule).

## Tests (TDD-first)

`cli/cmd/ao/mcp_transport_test.go` — 6 cases: `initialize`, `tools/list` (6 tools), `tools/call` dispatch-to-executor, **holdout-denied + executor-not-run**, unknown-method `-32601`, and a **multi-request round-trip** (the bead's acceptance: a session round-trips initialize + tool calls over the transport and gets structured responses). Plus the updated `runMCPServe`-live-wired test. All funcs CC < 15 · `go vet` clean · full `cmd/ao` suite **9217 pass**.

## Scope

4 Go files only (+308/−13). **No command-surface change** (same `ao mcp serve`) — COMMANDS.md / registry / cli-command-surface-matrix fixtures all unchanged (verified: registry diff was timestamp-only, reverted).

---

🏁 **This completes epic ag-7s9fo** — the full hookless-Agent-native stack: `/agent-native` skill + `agent-output-validate.yml` CI gate + `ao agent bundle` + `ao mcp serve` (descriptor + live transport) + optional SDK adapter.

Closes-scenario: ag-3ucpd#mcp-transport
Bounded-context: BC5-Runtime
Evidence: cli/cmd/ao/mcp_transport_test.go