### PR TITLE
fix(ci): pre-push-gate skips intentionally-removed hookless-3.0 scripts (ag-nrn7 #hookless-gate-skips)

### DIFF
--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -586,7 +586,7 @@ run_codex_hook_manifest_parity() {
                 skip "codex hook manifest parity (no $codex_home_path/hooks.json)"
             fi
         else
-            fail "missing executable: scripts/audit-codex-hooks.sh"
+            skip "codex hook manifest parity (hookless 3.0: scripts/audit-codex-hooks.sh removed in #511)"
         fi
     else
         skip "codex hook manifest parity"
@@ -1740,7 +1740,7 @@ if needs_check hook; then
             indent_output "$hook_preflight_output"
         fi
     else
-        fail "missing executable: scripts/validate-hook-preflight.sh"
+        skip "hook preflight (hookless 3.0: scripts/validate-hook-preflight.sh removed in #511)"
     fi
 else
     skip "hook preflight"
@@ -1756,7 +1756,7 @@ if needs_check hook; then
             indent_output "$hooks_doc_output"
         fi
     else
-        fail "missing executable: scripts/validate-hooks-doc-parity.sh"
+        skip "hooks/docs parity (hookless 3.0: scripts/validate-hooks-doc-parity.sh removed in #511)"
     fi
 else
     skip "hooks/docs parity"

--- a/tests/scripts/pre-push-gate.bats
+++ b/tests/scripts/pre-push-gate.bats
@@ -1088,6 +1088,32 @@ GIT
     [[ "$output" == *"codex hook manifest parity (AGENTOPS_PREPUSH_SKIP_CODEX_HOOKS=1)"* ]]
 }
 
+@test "pre-push-gate.sh skips hook checks when hook scripts are absent (hookless 3.0, ag-nrn7)" {
+    # In hookless-first 3.0 the hook-validation scripts were intentionally
+    # removed (#511). When a hook diff triggers `needs_check hook` but the
+    # scripts are absent, the gate must SKIP — not fail "missing executable".
+    # Before ag-nrn7 the `else fail` branches turned pristine-main full runs red.
+    rm -f "$FAKE_REPO/scripts/audit-codex-hooks.sh" \
+          "$FAKE_REPO/scripts/validate-hook-preflight.sh" \
+          "$FAKE_REPO/scripts/validate-hooks-doc-parity.sh"
+    cat > "$MOCK_BIN/git" <<'GIT'
+#!/usr/bin/env bash
+if [[ "$*" == *"diff --name-only"* ]]; then echo "hooks/hooks.json"; fi
+if [[ "$*" == *"rev-parse"* ]]; then echo "/tmp"; fi
+exit 0
+GIT
+    chmod +x "$MOCK_BIN/git"
+
+    cd "$FAKE_REPO"
+    export PATH="$MOCK_BIN:$PATH"
+
+    run env -u CI -u GITHUB_ACTIONS bash "$GATE" --fast --scope upstream --accumulate --single-pass
+    # The removed hook scripts must NOT produce "missing executable" failures.
+    [[ "$output" != *"missing executable: scripts/audit-codex-hooks.sh"* ]]
+    [[ "$output" != *"missing executable: scripts/validate-hook-preflight.sh"* ]]
+    [[ "$output" != *"missing executable: scripts/validate-hooks-doc-parity.sh"* ]]
+}
+
 @test "pre-push-gate.sh skips codex hook manifest parity when CODEX_HOME has no hooks.json" {
     cat > "$MOCK_BIN/git" <<'GIT'
 #!/usr/bin/env bash


### PR DESCRIPTION
## What

The full (non-fast) `scripts/pre-push-gate.sh` exits BLOCKED on pristine origin/main, partly because 3 hook-validation scripts it references were **intentionally deleted in the hookless-first migration** (#511): `audit-codex-hooks.sh`, `validate-hook-preflight.sh`, `validate-hooks-doc-parity.sh`. Their gate branches still ran `fail "missing executable"` when a hook diff triggered `needs_check hook` — 3 of the 8 failures in the release-readiness gate (ag-nrn7 triage).

## Fix

Convert each `else fail` → `skip` with a hookless-3.0 rationale. **Forward-compatible** (if a script is ever restored, the `[[ -x ]]` branch still runs it) and **honest** (intentionally-absent ≠ broken). 3 lines changed.

## Test

Added a regression test: the bats setup stubs every helper script present (per f-2026-04-27-002), masking the absent-script path. The new `ag-nrn7` case removes the 3 stubs, triggers a hook diff, and asserts the gate **skips** (no `missing executable`) rather than fails.

- `bats tests/scripts/pre-push-gate.bats` → 56/56 ok (new case green; red before the fix on the `audit-codex-hooks.sh` assertion).
- `shellcheck -S error scripts/pre-push-gate.sh` → clean.

Removes 3 of the 8 `pre-push-gate.sh` failures triaged in ag-nrn7; advances soc-z3jft 3.0 release readiness.

Closes-scenario: ag-nrn7#hookless-gate-skips
Bounded-context: BC5-Runtime
Evidence: tests/scripts/pre-push-gate.bats