### PR TITLE
fix(ci): suppress false-positive SC2088 in lint-codex-native.sh (ag-nrn7 #shellcheck-sc2088)

### DIFF
--- a/scripts/lint-codex-native.sh
+++ b/scripts/lint-codex-native.sh
@@ -142,6 +142,9 @@ check_skill() {
 
     # --- Check 3: ~/.claude/ paths ---
     local path_hits
+    # The tilde here is a literal grep PATTERN (matching the string "~/.claude/"
+    # in skill files), not a path meant to expand — SC2088 is a false positive.
+    # shellcheck disable=SC2088
     path_hits=$(grep -n '~/\.claude/' "$skill_file" | grep -v 'Portability\|non-Codex\|appendix' || true)
     if [[ -n "$path_hits" ]]; then
         local count


### PR DESCRIPTION
## What

`scripts/lint-codex-native.sh` line 145 (`Check 3`) runs `grep -n '~/\.claude/' "$skill_file"` — the `~/.claude/` is a **literal grep pattern** (the check detects non-portable `~/.claude/` strings inside codex skill files), not a path meant to expand. shellcheck SC2088 flags it as a non-expanding tilde, which is a false positive here. This was 1 of the 8 `pre-push-gate.sh` failures triaged in ag-nrn7.

## Fix

Add a scoped `# shellcheck disable=SC2088` with a rationale comment directly above the line. 3 lines, single file.

## Test

- `shellcheck scripts/lint-codex-native.sh` → **exit 0, 0 findings** (was: 1 SC2088 warning → gate FAIL).
- `bash -n` syntax OK; the grep pattern is unchanged so Check 3 behavior is identical.
- `bats tests/scripts/pre-push-shellcheck-unconditional.bats` → green (no regression).

Closes the **last actionable** item in ag-nrn7's full-gate triage. The remaining ag-nrn7 failures are tolerate (mkdocs-venv; CI venv passes), elsewhere (distribution-install-update canary → soc-3csze), or local-state only — none blocks CI.

Closes-scenario: ag-nrn7#shellcheck-sc2088
Bounded-context: BC5-Runtime
Evidence: shellcheck scripts/lint-codex-native.sh