### PR TITLE
feat(eval): outcomes-rubric projection contract + schema (ag-hguuf #outcomes-rubric)

### DIFF
--- a/cli/internal/evalsubstrate/rubric_schema_test.go
+++ b/cli/internal/evalsubstrate/rubric_schema_test.go
@@ -1,0 +1,197 @@
+package evalsubstrate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// schemaRepoRoot climbs from this test file to the repo root.
+// file = .../cli/internal/evalsubstrate/rubric_schema_test.go
+func schemaRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(file), "..", "..", "..")
+}
+
+// loadOutcomesRubricSchema loads the committed Outcomes-rubric JSON Schema.
+func loadOutcomesRubricSchema(t *testing.T) map[string]any {
+	t.Helper()
+	p := filepath.Join(schemaRepoRoot(t), "schemas", "outcomes-rubric.v1.schema.json")
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read schema %s: %v", p, err)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+	return schema
+}
+
+// jsonFieldNames returns the JSON tag names (sans ",omitempty") for an
+// exported struct, so the schema's declared properties can be diffed against
+// the real emitted payload shape.
+func jsonFieldNames(t *testing.T, v any) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	rt := reflect.TypeOf(v)
+	for i := 0; i < rt.NumField(); i++ {
+		tag := rt.Field(i).Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if name != "" {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+func schemaPropNames(t *testing.T, props map[string]any) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	for k := range props {
+		out[k] = true
+	}
+	return out
+}
+
+// TestOutcomesRubricSchemaMatchesStruct is the schema<->struct drift guard. If
+// a field is added to Rubric or Criterion without updating the committed
+// schema (or vice versa), this fails — keeping the executable projection and
+// the published contract in lockstep. Mirrors verdictledger's
+// TestSchemaDeclaresADRFields posture.
+func TestOutcomesRubricSchemaMatchesStruct(t *testing.T) {
+	schema := loadOutcomesRubricSchema(t)
+
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("schema has no properties object")
+	}
+
+	// Root properties must exactly match the Rubric struct's JSON fields.
+	wantRoot := jsonFieldNames(t, Rubric{})
+	gotRoot := schemaPropNames(t, props)
+	if !reflect.DeepEqual(wantRoot, gotRoot) {
+		t.Errorf("root property drift: struct fields %v != schema properties %v", keys(wantRoot), keys(gotRoot))
+	}
+
+	// Criterion properties must exactly match the Criterion struct's JSON fields.
+	critSchema, ok := props["criteria"].(map[string]any)
+	if !ok {
+		t.Fatal("schema.properties.criteria missing")
+	}
+	items, ok := critSchema["items"].(map[string]any)
+	if !ok {
+		t.Fatal("schema.properties.criteria.items missing")
+	}
+	critProps, ok := items["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("criteria.items.properties missing")
+	}
+	wantCrit := jsonFieldNames(t, Criterion{})
+	gotCrit := schemaPropNames(t, critProps)
+	if !reflect.DeepEqual(wantCrit, gotCrit) {
+		t.Errorf("criterion property drift: struct fields %v != schema properties %v", keys(wantCrit), keys(gotCrit))
+	}
+}
+
+// TestOutcomesRubricSchemaForbidsExtraProps verifies additionalProperties:false
+// at every nesting level — the structural enforcement that a leak field
+// (target/ground_truth/expected_output) makes the payload fail validation, not
+// merely a code check. Managed Agents are not ZDR.
+func TestOutcomesRubricSchemaForbidsExtraProps(t *testing.T) {
+	schema := loadOutcomesRubricSchema(t)
+	if v, ok := schema["additionalProperties"].(bool); !ok || v {
+		t.Error("root additionalProperties must be false")
+	}
+	props := schema["properties"].(map[string]any)
+	items := props["criteria"].(map[string]any)["items"].(map[string]any)
+	if v, ok := items["additionalProperties"].(bool); !ok || v {
+		t.Error("criteria.items additionalProperties must be false")
+	}
+}
+
+// TestOutcomesRubricSchemaRequiredAndVersion pins the required set and the
+// schema_version const to the real projection (evalsubstrate.SchemaVersion).
+func TestOutcomesRubricSchemaRequiredAndVersion(t *testing.T) {
+	schema := loadOutcomesRubricSchema(t)
+
+	req := toStringSet(schema["required"])
+	for _, f := range []string{"schema_version", "source_task_id", "judge_content_hash", "criteria"} {
+		if !req[f] {
+			t.Errorf("schema required must include %q", f)
+		}
+	}
+	if req["instructions"] {
+		t.Error("instructions must be optional (omitempty), not required")
+	}
+
+	props := schema["properties"].(map[string]any)
+	sv := props["schema_version"].(map[string]any)
+	cst, ok := sv["const"]
+	if !ok {
+		t.Fatal("schema_version must declare a const")
+	}
+	if int(cst.(float64)) != SchemaVersion {
+		t.Errorf("schema_version const %v != evalsubstrate.SchemaVersion %d", cst, SchemaVersion)
+	}
+}
+
+// TestProjectRubricEmissionWithinSchema asserts every JSON key a real
+// ProjectRubric output emits is declared in the schema properties — the schema
+// can never lag the actual emitted payload.
+func TestProjectRubricEmissionWithinSchema(t *testing.T) {
+	schema := loadOutcomesRubricSchema(t)
+	props := schemaPropNames(t, schema["properties"].(map[string]any))
+
+	r := ProjectRubric(
+		Task{ID: "task-x", Description: "do the thing"},
+		[]Criterion{{ID: "c1", Description: "d", Weight: 1.0}},
+		"sha256:abc",
+	)
+	blob, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal rubric: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(blob, &m); err != nil {
+		t.Fatalf("unmarshal rubric: %v", err)
+	}
+	for k := range m {
+		if !props[k] {
+			t.Errorf("emitted key %q not declared in schema properties", k)
+		}
+	}
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func toStringSet(v any) map[string]bool {
+	out := map[string]bool{}
+	arr, ok := v.([]any)
+	if !ok {
+		return out
+	}
+	for _, e := range arr {
+		if s, ok := e.(string); ok {
+			out[s] = true
+		}
+	}
+	return out
+}

--- a/docs/contracts/eval-verdict-pipeline.md
+++ b/docs/contracts/eval-verdict-pipeline.md
@@ -71,6 +71,7 @@ Defined in SCHEMA.md §6 (rc3). Override via env or GOALS.md:
 ## Cross-links
 
 - Sibling: [Finding Registry Contract](finding-registry.md)
+- Upstream projection: [Outcomes Rubric Projection Contract](outcomes-rubric-projection.md) — holdout-safe rubric payloads whose ingested scores land in this verdict format (Flywheel close)
 - Schema: `~/.agents/evals/SCHEMA.md` §4 / §6 / §11 entry #18
 - Plan: `.agents/plans/2026-05-01-eval-as-self-pruning-corpus.md`
 - Pre-mortem: `.agents/council/2026-05-01-pre-mortem-eval-corpus*.md`

--- a/docs/contracts/outcomes-rubric-projection.md
+++ b/docs/contracts/outcomes-rubric-projection.md
@@ -1,0 +1,101 @@
+# Contract: Outcomes Rubric Projection
+
+> **Status: v1 (ag-hguuf).** Machine-checkable contract for the holdout-safe
+> projection of the locked eval substrate into an Outcomes-style grading payload.
+
+## Purpose
+
+[Anthropic Managed Agents Outcomes](https://www.anthropic.com/) grade an agent
+run against a **rubric** instead of an exact-match answer. AgentOps already
+owns the authoritative grading substrate at `~/.agents/evals/SCHEMA.md` (locked).
+This contract defines how a locked `ao eval` Task + its grading criteria
+**project** to an Outcomes rubric payload that can cross the cloud boundary.
+
+The projection is a **derived artifact**. `~/.agents/evals/SCHEMA.md` remains the
+sole authority; a projected rubric is **never an alternate bar**. The locked
+schema is EXTENDED by this projection, never relitigated.
+
+### The load-bearing invariant: holdout isolation
+
+**Managed Agents are not ZDR.** A rubric that crosses the cloud boundary must
+NEVER carry a ground-truth answer, a holdout value, a `target`, or an
+`expected_output`. A leak is permanent. The contract enforces this three ways:
+
+1. **By construction** — `evalsubstrate.ProjectRubric` copies only allowlisted
+   fields and does not accept ground-truth rows, so it *cannot* copy them
+   (`cli/internal/evalsubstrate/rubric.go`).
+2. **By re-scan** — `Rubric.ContainsAny` is the defense-in-depth guard every
+   caller runs against the run's holdout values before the payload leaves the
+   boundary (`ao eval outcomes compile` refuses on any hit).
+3. **By schema** — `schemas/outcomes-rubric.v1.schema.json` sets
+   `additionalProperties: false` at **every nesting level**, so a malformed
+   compiler emission that smuggles a leak field **fails schema validation**, not
+   merely a code check. This is the surface this contract adds.
+
+## Payload shape
+
+The payload is the JSON encoding of `evalsubstrate.Rubric` — the exact output of
+`ao eval outcomes compile`. Schema: [`schemas/outcomes-rubric.v1.schema.json`](../../schemas/outcomes-rubric.v1.schema.json).
+
+```json
+{
+  "schema_version": 1,
+  "source_task_id": "task-go-cc-budget",
+  "judge_content_hash": "sha256:…",
+  "instructions": "Grade whether the refactor keeps CC under 25.",
+  "criteria": [
+    { "id": "cc-under-25", "description": "…", "weight": 1.0 }
+  ]
+}
+```
+
+### Field mapping: locked substrate → Outcomes rubric
+
+| Outcomes field        | Source (locked substrate)                              | Notes |
+|-----------------------|--------------------------------------------------------|-------|
+| `schema_version`      | `evalsubstrate.SchemaVersion`                          | Pins the projected shape (=1). |
+| `source_task_id`      | `Task.ID`                                              | Provenance back-pointer; never a ground-truth id. |
+| `judge_content_hash`  | judge spec content hash (SCHEMA §rc2 drift key)        | Lets a stale rubric self-invalidate like a stale local judge. |
+| `instructions`        | `Task.Description` (optional)                          | Holdout rubrics SHOULD omit when the description could echo a holdout prompt. |
+| `criteria[].id`       | judge criterion id                                     | Allowlisted. |
+| `criteria[].description` | judge criterion description                         | Allowlisted. |
+| `criteria[].weight`   | judge criterion weight                                 | Allowlisted. |
+
+### Deliberately NOT projected (holdout-safety + minimal cloud surface)
+
+The earlier design sketch imagined a richer payload (`suite_id`, `metric`,
+`decision_rule`, `split`). The shipped projection deliberately omits them — a
+**smaller boundary surface is a smaller leak surface**, and the grader needs
+none of them to score a run:
+
+| Field considered          | Why it stays local |
+|---------------------------|--------------------|
+| `target` / `ground_truth` / `expected_output` / `samples-holdout` | The holdout answer itself. **Never crosses the boundary** — the whole point. Forbidden by `additionalProperties:false`. |
+| `metric` / `decision_rule` | Live in the locked `Suite.stats` and the ONE local council verdict. Score aggregation and accept/reject happen **server-side after ingest**, never in the cloud grader. |
+| `split` (dev/holdout)     | Tracked by the global Dolt **burn ledger** (`ao eval outcomes` gate#3), not by the payload. The grader is split-agnostic by design. |
+
+If a future Outcomes integration genuinely needs one of these, widen
+`evalsubstrate.Rubric` first (the Go schema↔struct drift test will then require
+the schema to be updated in lockstep) — never hand-add a property to the schema
+alone.
+
+## Validation
+
+- **Standalone validator:** [`scripts/validate-outcomes-rubric.sh`](../../scripts/validate-outcomes-rubric.sh)
+  `<payload.json>…` or `--selftest`. Gating structural pass is python
+  `jsonschema` (Draft7), mirroring `scripts/validate-next-work.sh`.
+- **Acceptance fixtures:** `tests/fixtures/outcomes-rubric/` —
+  `valid-dev` (pass), `valid-holdout-criteria-only` (pass, no instructions),
+  `invalid-contains-target` (fail — smuggles a `target`). Driven by
+  [`tests/scripts/validate-outcomes-rubric.bats`](../../tests/scripts/validate-outcomes-rubric.bats).
+- **Schema↔struct drift guard:** `TestOutcomesRubricSchemaMatchesStruct` and
+  siblings in `cli/internal/evalsubstrate/rubric_schema_test.go` keep the
+  committed schema and the `Rubric`/`Criterion` Go structs in lockstep.
+
+## See also
+
+- [Eval Verdict Pipeline](eval-verdict-pipeline.md) — where ingested Outcomes
+  scores land in the one verdict format (Flywheel close).
+- `~/.agents/evals/SCHEMA.md` §rc2 (judge content hash / drift key), §4 (verdict
+  record) — the locked authority this contract projects from, never replaces.
+- `cli/internal/evalsubstrate/rubric.go` — the executable projection.

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -303,6 +303,7 @@ Bridge / framing docs:
 - [Eval Baseline-A/B Contract](contracts/eval-baseline-ab.md) — `ao eval run --baseline-mode` semantics, `DeltaScorecard` schema, hook-suppression scope
 - [Context Usefulness Eval Contract](contracts/context-usefulness-eval.md) — Wave 0 deterministic `context_off` versus `context_on` evaluation, scorecard fields, hook-preservation boundaries
 - [Eval Verdict Pipeline Contract](contracts/eval-verdict-pipeline.md) — Verdict compiler pipeline from eval run manifests to learning utility and retirement signals
+- [Outcomes Rubric Projection Contract](contracts/outcomes-rubric-projection.md) — Holdout-safe projection of the locked eval substrate into an Outcomes-style grading payload (`schemas/outcomes-rubric.v1.schema.json`); `additionalProperties:false` at every level forbids target/ground_truth/expected_output (Managed Agents are not ZDR); validator `scripts/validate-outcomes-rubric.sh` + Go schema↔struct drift guard (ag-hguuf)
 - [Retrieval Comparison Contract](contracts/retrieval-comparison.md) — Deterministic search-eval backend comparison, promotion thresholds, optional rerank behavior, and deferred vector/graph-store policy
 - [Release Readiness Contract](contracts/release-readiness.md) — 8/10 release readiness score, SIL/VIL/HIL evidence, artifact manifest requirements, and HIL waiver policy
 - [MemRL Policy Schema](contracts/memrl-policy.schema.json) — Machine-readable retry/escalation policy profile for memory-reinforcement feedback loops

--- a/schemas/outcomes-rubric.v1.schema.json
+++ b/schemas/outcomes-rubric.v1.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://agentops.dev/schemas/outcomes-rubric.v1.schema.json",
+  "title": "Outcomes Rubric Projection (v1)",
+  "description": "Holdout-safe projection of a locked eval Task's grading criteria into an Outcomes-style grading payload (cloud Managed Agents, async jobs, or the local Codex/NTM path). DERIVED artifact: ~/.agents/evals/SCHEMA.md remains the sole authority; a rubric is never an alternate bar. The payload NEVER carries ground-truth answers, holdout values, targets, or expected outputs — that is the load-bearing holdout-isolation invariant at the cloud boundary, because Managed Agents are not ZDR. additionalProperties:false at every nesting level is the structural enforcement: any leak field (target, ground_truth, expected_output, samples-holdout) makes the document fail validation, not merely a code check. Mirrors cli/internal/evalsubstrate/rubric.go (Rubric, Criterion); schema_version pins evalsubstrate.SchemaVersion.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "source_task_id",
+    "judge_content_hash",
+    "criteria"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Pins evalsubstrate.SchemaVersion (=1). Bump only when the projected shape changes."
+    },
+    "source_task_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Locked Task.ID this rubric was projected from. Provenance back-pointer; never a ground-truth id."
+    },
+    "judge_content_hash": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Copied from the judge spec (SCHEMA rc2 drift key). Lets a stale rubric self-invalidate exactly like a stale local judge."
+    },
+    "instructions": {
+      "type": "string",
+      "description": "Optional grader-facing instructions, projected from Task.Description. Holdout rubrics SHOULD omit this when the task description could echo a holdout prompt (criteria-only projection)."
+    },
+    "criteria": {
+      "type": "array",
+      "description": "Allowlisted grading dimensions. Only id/description/weight ever cross the boundary — no target, value, or answer.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "description",
+          "weight"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string"
+          },
+          "weight": {
+            "type": "number"
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate-outcomes-rubric.sh
+++ b/scripts/validate-outcomes-rubric.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# validate-outcomes-rubric.sh — Validate Outcomes-rubric projection payloads
+# against schemas/outcomes-rubric.v1.schema.json (ag-hguuf).
+#
+# The Outcomes rubric is the holdout-safe projection of a locked eval Task's
+# grading criteria (cli/internal/evalsubstrate/rubric.go). This validator is the
+# bead's "standalone validator" acceptance surface: it enforces the committed
+# JSON Schema structurally, so a malformed compiler emission that smuggles a
+# leak field (target / ground_truth / expected_output) FAILS validation, not
+# merely a code check. Managed Agents are not ZDR — a leak is permanent.
+#
+# Usage:
+#   scripts/validate-outcomes-rubric.sh <payload.json> [<payload.json>...]
+#       Validate each file. Exit 0 only if EVERY file is schema-valid.
+#   scripts/validate-outcomes-rubric.sh --selftest
+#       Validate the three tracked fixtures with expected pass/pass/fail and
+#       exit 0 only if all three match expectations.
+#
+# Gating validator: python `jsonschema` (Draft7), mirroring the posture in
+# scripts/validate-next-work.sh. If python3/jsonschema is unavailable the script
+# SKIPs (exit 0 with a notice) so it never blocks an environment without the
+# tool — the bats suite and the Go schema↔struct drift test are the always-on
+# guards; CI provides python3+jsonschema for the gating structural pass.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCHEMA="$REPO_ROOT/schemas/outcomes-rubric.v1.schema.json"
+FIXTURES="$REPO_ROOT/tests/fixtures/outcomes-rubric"
+
+if [[ ! -f "$SCHEMA" ]]; then
+    echo "FAIL: schema not found: $SCHEMA" >&2
+    exit 2
+fi
+
+if ! command -v python3 >/dev/null 2>&1 || ! python3 -c 'import jsonschema' >/dev/null 2>&1; then
+    echo "SKIP: python3 + jsonschema not available; structural validation skipped" >&2
+    exit 0
+fi
+
+# validate_one <file> -> exit 0 if schema-valid, 1 if invalid, 2 on read error.
+validate_one() {
+    python3 - "$SCHEMA" "$1" <<'PY'
+import json, sys
+from jsonschema import Draft7Validator
+
+schema_path, data_path = sys.argv[1], sys.argv[2]
+try:
+    with open(schema_path) as f:
+        schema = json.load(f)
+    with open(data_path) as f:
+        doc = json.load(f)
+except Exception as e:
+    print(f"read error: {e}", file=sys.stderr)
+    sys.exit(2)
+
+errors = sorted(Draft7Validator(schema).iter_errors(doc), key=lambda e: e.path)
+if errors:
+    for e in errors:
+        loc = "/".join(str(p) for p in e.path) or "(root)"
+        print(f"  invalid at {loc}: {e.message}", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+}
+
+if [[ "${1:-}" == "--selftest" ]]; then
+    rc=0
+    declare -A EXPECT=(
+        [valid-dev.json]=0
+        [valid-holdout-criteria-only.json]=0
+        [invalid-contains-target.json]=1
+    )
+    for name in valid-dev.json valid-holdout-criteria-only.json invalid-contains-target.json; do
+        want="${EXPECT[$name]}"
+        if validate_one "$FIXTURES/$name" >/dev/null 2>&1; then got=0; else got=1; fi
+        if [[ "$got" == "$want" ]]; then
+            echo "PASS: $name (expected $([[ $want == 0 ]] && echo valid || echo invalid))"
+        else
+            echo "FAIL: $name (expected $([[ $want == 0 ]] && echo valid || echo invalid), got $([[ $got == 0 ]] && echo valid || echo invalid))" >&2
+            rc=1
+        fi
+    done
+    exit "$rc"
+fi
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: $(basename "$0") <payload.json> [<payload.json>...] | --selftest" >&2
+    exit 2
+fi
+
+overall=0
+for f in "$@"; do
+    if validate_one "$f"; then
+        echo "PASS: $f"
+    else
+        echo "FAIL: $f (schema-invalid)" >&2
+        overall=1
+    fi
+done
+exit "$overall"

--- a/tests/fixtures/outcomes-rubric/invalid-contains-target.json
+++ b/tests/fixtures/outcomes-rubric/invalid-contains-target.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "source_task_id": "task-leak-attempt",
+  "judge_content_hash": "sha256:deadbeef00000000000000000000000000000000000000000000000000000000",
+  "target": "the holdout ground-truth answer is 42",
+  "criteria": [
+    {
+      "id": "x",
+      "description": "A criterion that would be valid on its own.",
+      "weight": 1.0
+    }
+  ]
+}

--- a/tests/fixtures/outcomes-rubric/valid-dev.json
+++ b/tests/fixtures/outcomes-rubric/valid-dev.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "source_task_id": "task-go-cc-budget",
+  "judge_content_hash": "sha256:3f1a9c0e8b7d6a5f4e3c2b1a0908f7e6d5c4b3a2918273645f6e7d8c9b0a1f2e",
+  "instructions": "Grade whether the refactor keeps every modified function under cyclomatic complexity 25.",
+  "criteria": [
+    {
+      "id": "cc-under-25",
+      "description": "All modified functions have cyclomatic complexity strictly less than 25.",
+      "weight": 1.0
+    },
+    {
+      "id": "no-behavior-change",
+      "description": "The refactor preserves observable behavior (tests unchanged and green).",
+      "weight": 0.5
+    }
+  ]
+}

--- a/tests/fixtures/outcomes-rubric/valid-holdout-criteria-only.json
+++ b/tests/fixtures/outcomes-rubric/valid-holdout-criteria-only.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "source_task_id": "task-holdout-intent-classify",
+  "judge_content_hash": "sha256:a0b1c2d3e4f5061728394a5b6c7d8e9f00112233445566778899aabbccddeeff",
+  "criteria": [
+    {
+      "id": "label-match",
+      "description": "The predicted label matches the rubric category definition for the input.",
+      "weight": 1.0
+    },
+    {
+      "id": "calibrated-confidence",
+      "description": "Reported confidence is calibrated to the likelihood of correctness.",
+      "weight": 0.5
+    }
+  ]
+}

--- a/tests/scripts/validate-outcomes-rubric.bats
+++ b/tests/scripts/validate-outcomes-rubric.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# Acceptance surface for ag-hguuf: the Outcomes-rubric projection contract +
+# schema. The validator enforces the committed JSON Schema
+# (schemas/outcomes-rubric.v1.schema.json) over the three tracked fixtures with
+# the expected pass/pass/fail, and rejects any payload that smuggles a leak
+# field (target / ground_truth / expected_output) — the holdout-isolation
+# invariant at the cloud boundary (Managed Agents are not ZDR).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/validate-outcomes-rubric.sh"
+    SCHEMA="$REPO_ROOT/schemas/outcomes-rubric.v1.schema.json"
+    FIX="$REPO_ROOT/tests/fixtures/outcomes-rubric"
+    if ! command -v python3 >/dev/null 2>&1 || ! python3 -c 'import jsonschema' >/dev/null 2>&1; then
+        HAVE_JSONSCHEMA=0
+    else
+        HAVE_JSONSCHEMA=1
+    fi
+}
+
+@test "validator and schema exist" {
+    [ -f "$SCRIPT" ]
+    [ -x "$SCRIPT" ]
+    [ -f "$SCHEMA" ]
+}
+
+@test "schema is valid JSON and forbids extra properties at every level" {
+    run python3 -c "import json,sys; s=json.load(open('$SCHEMA')); sys.exit(0 if s.get('additionalProperties') is False and s['properties']['criteria']['items'].get('additionalProperties') is False else 1)"
+    [ "$status" -eq 0 ]
+}
+
+@test "three fixtures exist (valid-dev, valid-holdout-criteria-only, invalid-contains-target)" {
+    [ -f "$FIX/valid-dev.json" ]
+    [ -f "$FIX/valid-holdout-criteria-only.json" ]
+    [ -f "$FIX/invalid-contains-target.json" ]
+}
+
+@test "selftest validates the three fixtures pass/pass/fail" {
+    if [ "$HAVE_JSONSCHEMA" -eq 0 ]; then skip "python3 jsonschema unavailable"; fi
+    run "$SCRIPT" --selftest
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS: valid-dev.json"* ]]
+    [[ "$output" == *"PASS: valid-holdout-criteria-only.json"* ]]
+    [[ "$output" == *"PASS: invalid-contains-target.json"* ]]
+}
+
+@test "valid-dev fixture validates" {
+    if [ "$HAVE_JSONSCHEMA" -eq 0 ]; then skip "python3 jsonschema unavailable"; fi
+    run "$SCRIPT" "$FIX/valid-dev.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "valid-holdout-criteria-only fixture validates (no instructions)" {
+    if [ "$HAVE_JSONSCHEMA" -eq 0 ]; then skip "python3 jsonschema unavailable"; fi
+    run "$SCRIPT" "$FIX/valid-holdout-criteria-only.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "invalid-contains-target fixture is rejected (holdout leak field)" {
+    if [ "$HAVE_JSONSCHEMA" -eq 0 ]; then skip "python3 jsonschema unavailable"; fi
+    run "$SCRIPT" "$FIX/invalid-contains-target.json"
+    [ "$status" -ne 0 ]
+}
+
+@test "a payload smuggling ground_truth is rejected" {
+    if [ "$HAVE_JSONSCHEMA" -eq 0 ]; then skip "python3 jsonschema unavailable"; fi
+    tmp="$BATS_TEST_TMPDIR/leak.json"
+    cat > "$tmp" <<'JSON'
+{"schema_version":1,"source_task_id":"t","judge_content_hash":"sha256:aa","ground_truth":"secret","criteria":[{"id":"a","description":"d","weight":1.0}]}
+JSON
+    run "$SCRIPT" "$tmp"
+    [ "$status" -ne 0 ]
+}
+
+@test "a criterion smuggling expected_output is rejected (every-level guard)" {
+    if [ "$HAVE_JSONSCHEMA" -eq 0 ]; then skip "python3 jsonschema unavailable"; fi
+    tmp="$BATS_TEST_TMPDIR/leak2.json"
+    cat > "$tmp" <<'JSON'
+{"schema_version":1,"source_task_id":"t","judge_content_hash":"sha256:aa","criteria":[{"id":"a","description":"d","weight":1.0,"expected_output":"42"}]}
+JSON
+    run "$SCRIPT" "$tmp"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## What

Defines the machine-checkable contract for projecting the **locked eval substrate** into an **Outcomes-style grading payload** (Anthropic Managed Agents Outcomes analog) — holdout-safe by construction *and* by schema.

The schema validates the **actual** output of `ao eval outcomes compile` (`evalsubstrate.Rubric`), not the bead's pre-implementation prose sketch (which imagined `suite_id`/`metric`/`decision_rule`/`split`). Per source-of-truth precedence (executable > narrative), the shipped projection deliberately emits *fewer* fields — a smaller cloud boundary is a smaller leak surface. The "deliberately NOT projected" rationale is documented in the contract.

## The load-bearing invariant

**Managed Agents are not ZDR** — a rubric crossing the cloud boundary must never carry a ground-truth answer / holdout value / `target` / `expected_output`. Enforced three ways:
1. **By construction** — `ProjectRubric` can't copy ground truth (existing).
2. **By re-scan** — `Rubric.ContainsAny` guard (existing).
3. **By schema (this PR)** — `additionalProperties:false` at **every nesting level** → a malformed compiler emission that smuggles a leak field **fails schema validation**, not merely a code check.

## Files
- `schemas/outcomes-rubric.v1.schema.json` — the contract schema
- `tests/fixtures/outcomes-rubric/{valid-dev,valid-holdout-criteria-only,invalid-contains-target}.json`
- `scripts/validate-outcomes-rubric.sh` — standalone validator (python `jsonschema`, mirrors `validate-next-work.sh`); `--selftest` asserts pass/pass/fail
- `tests/scripts/validate-outcomes-rubric.bats` — 9 acceptance tests
- `cli/internal/evalsubstrate/rubric_schema_test.go` — Go schema↔struct drift guard (reflection)
- `docs/contracts/outcomes-rubric-projection.md` — SCHEMA-field→Outcomes-field mapping; catalogued in doc index; cross-linked from `eval-verdict-pipeline.md`

The contract **references** the LOCKED `~/.agents/evals/SCHEMA.md` §rc2/§4 — it never edits it. Substrate EXTENDED, never relitigated.

## Evidence
- `scripts/validate-outcomes-rubric.sh --selftest` → PASS/PASS/FAIL (exit 0)
- `bats tests/scripts/validate-outcomes-rubric.bats` → 9/9 ok
- `go test ./internal/evalsubstrate/` → 82 passed; `go vet` clean; `go build ./...` success
- `check-contract-compatibility.sh` → contract catalogued + schema reference OK
- `shellcheck scripts/validate-outcomes-rubric.sh` → clean

Closes-scenario: ag-hguuf#outcomes-rubric-projection-contract
Bounded-context: BC4-Evaluation
Evidence: schemas/outcomes-rubric.v1.schema.json
