### PR TITLE
fix(eval): unstale pre-push-gate-governance canary positional assertion (ag-teb1)

### DIFF
--- a/evals/agentops-core/pre-push-gate-governance.json
+++ b/evals/agentops-core/pre-push-gate-governance.json
@@ -45,7 +45,7 @@
         {"type": "stdout_contains", "value": "ok 6 pre-push-gate.sh passes when no Go changes"},
         {"type": "stdout_contains", "value": "ok 21 pre-push-gate.sh clears GIT env for skill CLI snippets"},
         {"type": "stdout_contains", "value": "ok 22 pre-push-gate.sh clears GIT env for CLI docs parity"},
-        {"type": "stdout_contains", "value": "ok 45 pre-push-gate.sh test-home-isolation lint stub exists in fake repo (paired stub guard)"}
+        {"type": "stdout_contains", "value": "ok 46 pre-push-gate.sh test-home-isolation lint stub exists in fake repo (paired stub guard)"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "safety"],
       "critical": true


### PR DESCRIPTION
## What

The `agentops-core.pre-push-gate-governance` contract canary (case `pre-push-bats-suite`) hardcodes the positional assertion `ok 45 pre-push-gate.sh test-home-isolation lint stub exists in fake repo (paired stub guard)`. A bats test was inserted before it, shifting that paired-guard test to **`ok 46`**. This bumps the expectation 45 → 46.

## Why it was latent (not caught earlier)

The contract-canaries step is gated `if: changes.outputs.contracts || shell || ci`. Main's recent pushes didn't touch those paths, so the step was **skipped** (latent green at a5ecfa78 — verified via the jobs API). PR #624 (which adds a schema + contract + validator) triggers the step and surfaced the drift as a `contracts-sync` FAIL. **This blocks every contract/shell-touching PR until fixed.**

## Scope / safety

- One-line change to one repo CI fixture. `evals/agentops-core/` is a **repo CI fixture, NOT** the locked `~/.agents/evals/` holdout substrate — a positional bump is sanctioned maintenance, not relitigating the locked schema.
- The other three positional assertions (`ok 6/21/22`) are unchanged and confirmed still correct against current bats numbering.
- `tests/scripts/pre-push-gate.bats` and `scripts/pre-push-gate.sh` are **not** touched.

## Evidence
- Before: governance canary `status=fail aggregate=0.9549` (`stdout does not contain "ok 45 ...stub exists..."`)
- After: `scripts/test-agentops-contract-canaries.sh --suite-list <gov-only>` → `status=pass verdict=pass aggregate=1` (failures=0)
- `jq -e .` → valid JSON; diff is 1 insertion / 1 deletion

Closes-scenario: ag-teb1#canary-positional-assertion-45-to-46
Bounded-context: BC4-Evaluation
Evidence: evals/agentops-core/pre-push-gate-governance.json
