### PR TITLE
feat(eval): gate #3 write-side refuse on exhausted holdout quota (ag-62g68 #gate3-write-refuse)

### DIFF
--- a/cli/cmd/ao/eval_outcomes_burn_test.go
+++ b/cli/cmd/ao/eval_outcomes_burn_test.go
@@ -24,7 +24,10 @@ func TestEvalOutcomesIngest_HoldoutRegistersBurn(t *testing.T) {
 		Aggregate:          0.9,
 		Threshold:          0.8,
 	}
-	after := registerOutcomesBurn(led, holdout)
+	after, err := registerOutcomesBurn(led, holdout)
+	if err != nil {
+		t.Fatalf("first holdout burn under budget must not refuse: %v", err)
+	}
 	if got := after.Spent("suite-x", "gt-1"); got != 1 {
 		t.Fatalf("holdout grade must register exactly +1 burn, Spent=%d want 1", got)
 	}
@@ -33,10 +36,14 @@ func TestEvalOutcomesIngest_HoldoutRegistersBurn(t *testing.T) {
 		t.Errorf("burn record identity wrong: %+v", rec)
 	}
 
-	// A second distinct holdout run burns again (+1 each, no silent bypass).
+	// A second distinct holdout run burns again (+1 each, no silent bypass) —
+	// still under the budget of 5, so it is allowed.
 	holdout2 := holdout
 	holdout2.RunID = "run-cloud-2"
-	after2 := registerOutcomesBurn(after, holdout2)
+	after2, err := registerOutcomesBurn(after, holdout2)
+	if err != nil {
+		t.Fatalf("second holdout burn under budget must not refuse: %v", err)
+	}
 	if got := after2.Spent("suite-x", "gt-1"); got != 2 {
 		t.Errorf("each holdout ingest burns once: Spent=%d want 2", got)
 	}
@@ -54,7 +61,10 @@ func TestEvalOutcomesIngest_DevSplitNoBurn(t *testing.T) {
 		GroundTruthVersion: "gt-1",
 		RunID:              "run-dev-1",
 	}
-	after := registerOutcomesBurn(led, dev)
+	after, err := registerOutcomesBurn(led, dev)
+	if err != nil {
+		t.Fatalf("dev-split ingest must never refuse: %v", err)
+	}
 	if got := after.Spent("suite-x", "gt-1"); got != 0 {
 		t.Errorf("dev-split grade must register NO burn, Spent=%d want 0", got)
 	}
@@ -68,8 +78,60 @@ func TestEvalOutcomesIngest_DevSplitNoBurn(t *testing.T) {
 // #3 only fires on an explicit holdout split anyway.
 func TestRegisterOutcomesBurn_EmptySplitNoBurn(t *testing.T) {
 	led := evalsubstrate.HoldoutBurnLedger{Budget: 5}
-	after := registerOutcomesBurn(led, outcomesScore{SourceTaskID: "t", SuiteRef: "s", GroundTruthVersion: "g"})
+	after, err := registerOutcomesBurn(led, outcomesScore{SourceTaskID: "t", SuiteRef: "s", GroundTruthVersion: "g"})
+	if err != nil {
+		t.Fatalf("empty-split ingest must never refuse: %v", err)
+	}
 	if len(after.Records) != 0 {
 		t.Errorf("empty split must register no burn, got %d records", len(after.Records))
+	}
+}
+
+// TestRegisterOutcomesBurn_RefusesWhenQuotaExhausted is the gate #3 write-side
+// guard (ag-62g68): once the (suite_ref, gt_version) holdout quota is spent, a
+// further holdout ingest is REFUSED — symmetric with the read-side gate #3
+// (gates.go), which refuses a local run on the same condition. Without this, a
+// cloud/Codex Outcomes run could silently re-burn an exhausted holdout split,
+// the exact statistical leak the burn ledger exists to prevent (Managed Agents
+// are not ZDR). The ledger is left unmutated on refusal (no partial append).
+func TestRegisterOutcomesBurn_RefusesWhenQuotaExhausted(t *testing.T) {
+	// Budget 1, one burn already spent for (suite-x, gt-1).
+	led := evalsubstrate.HoldoutBurnLedger{
+		Budget:  1,
+		Records: []evalsubstrate.BurnRecord{{SuiteRef: "suite-x", GTVersion: "gt-1", RunID: "run-prior"}},
+	}
+	second := outcomesScore{
+		SourceTaskID:       "task-x",
+		Split:              "holdout",
+		SuiteRef:           "suite-x",
+		GroundTruthVersion: "gt-1",
+		RunID:              "run-cloud-2",
+		Aggregate:          0.9,
+		Threshold:          0.8,
+	}
+	after, err := registerOutcomesBurn(led, second)
+	if err == nil {
+		t.Fatal("gate #3 write-side must refuse a holdout burn once the quota is exhausted")
+	}
+	if got := after.Spent("suite-x", "gt-1"); got != 1 {
+		t.Errorf("refused burn must not mutate the ledger, Spent=%d want 1", got)
+	}
+}
+
+// TestRegisterOutcomesBurn_NoCeilingWhenBudgetUnset: a non-positive Budget means
+// no enforceable ceiling is configured (Day-4 input absent → gate #3 is a
+// no-op), so holdout burns are recorded without refusal — exactly the read-side
+// gate #3 posture.
+func TestRegisterOutcomesBurn_NoCeilingWhenBudgetUnset(t *testing.T) {
+	led := evalsubstrate.HoldoutBurnLedger{
+		Records: []evalsubstrate.BurnRecord{{SuiteRef: "suite-x", GTVersion: "gt-1", RunID: "r0"}},
+	}
+	s := outcomesScore{Split: "holdout", SuiteRef: "suite-x", GroundTruthVersion: "gt-1", RunID: "r1"}
+	after, err := registerOutcomesBurn(led, s)
+	if err != nil {
+		t.Fatalf("unset budget must not enforce a ceiling: %v", err)
+	}
+	if got := after.Spent("suite-x", "gt-1"); got != 2 {
+		t.Errorf("unset-budget holdout burn must append, Spent=%d want 2", got)
 	}
 }

--- a/cli/cmd/ao/eval_outcomes_ingest.go
+++ b/cli/cmd/ao/eval_outcomes_ingest.go
@@ -76,22 +76,38 @@ func ingestOutcomesScore(s outcomesScore) outcomesVerdict {
 
 // registerOutcomesBurn is the write-side of the holdout burn ledger (ag-hdqu0.5),
 // the counterpart to gate #3's read-side (#607). When an Outcomes grade was
-// produced against the holdout split, ingest unconditionally appends exactly one
-// BurnRecord to the global ledger — so a cloud/async/Codex Outcomes run cannot
-// silently bypass holdout quota the way a local holdout run cannot. Dev-split
-// (and absent-split) grades register no burn, since the dev split is reusable.
+// produced against the holdout split, ingest appends exactly one BurnRecord to
+// the global ledger — so a cloud/async/Codex Outcomes run cannot silently bypass
+// holdout quota the way a local holdout run cannot. Dev-split (and absent-split)
+// grades register no burn, since the dev split is reusable.
+//
+// Gate #3 write-side enforcement (ag-62g68): if the (suite_ref, gt_version)
+// holdout quota is already spent (Spent >= Budget, with a positive Budget), the
+// burn is REFUSED and the ledger is returned unmutated — symmetric with the
+// read-side gate #3 in gates.go, which refuses a local run on the same
+// condition. Without this, a cloud/Codex Outcomes run could re-burn an exhausted
+// holdout split, the exact statistical leak the ledger exists to prevent
+// (Managed Agents are not ZDR). A non-positive Budget means no ceiling is
+// configured (Day-4 input absent → no-op), so burns are recorded without refusal.
+//
 // Returns the updated ledger for the caller to persist; the global-Dolt store is
 // a separate adapter concern, exactly as gate #3 reads an injected ledger.
-func registerOutcomesBurn(led evalsubstrate.HoldoutBurnLedger, s outcomesScore) evalsubstrate.HoldoutBurnLedger {
+func registerOutcomesBurn(led evalsubstrate.HoldoutBurnLedger, s outcomesScore) (evalsubstrate.HoldoutBurnLedger, error) {
 	if s.Split != "holdout" {
-		return led
+		return led, nil
+	}
+	if led.Budget > 0 {
+		if spent := led.Spent(s.SuiteRef, s.GroundTruthVersion); spent >= led.Budget {
+			return led, fmt.Errorf("outcomes ingest: holdout burn refused — quota for (suite=%q, gt_version=%q) is exhausted (%d/%d spent); the holdout split is statistically spent and may not be re-observed (gate #3, no escape)",
+				s.SuiteRef, s.GroundTruthVersion, spent, led.Budget)
+		}
 	}
 	led.Records = append(led.Records, evalsubstrate.BurnRecord{
 		SuiteRef:  s.SuiteRef,
 		GTVersion: s.GroundTruthVersion,
 		RunID:     s.RunID,
 	})
-	return led
+	return led, nil
 }
 
 var evalOutcomesIngestCmd = &cobra.Command{


### PR DESCRIPTION
## What

`registerOutcomesBurn` — the write-side of the Outcomes-ingest holdout burn ledger — appended a holdout `BurnRecord` **unconditionally**, with no `Budget`/`Spent()` ceiling. Meanwhile the **read-side** gate #3 (`cli/internal/evalsubstrate/gates.go`) refuses a local run once `Spent >= Budget`. This makes the write side **symmetric**: it now returns `(ledger, error)` and **refuses** a holdout burn when the `(suite_ref, gt_version)` quota is exhausted, leaving the ledger unmutated.

## Why (security)

The asymmetry was a real hole: a cloud/Codex Outcomes run could **silently re-burn an exhausted holdout split** — the exact statistical leak the burn ledger exists to prevent. **Managed Agents are not ZDR**, so an over-observed holdout can't be walked back. The function's own doc comment already *claimed* the burn "cannot silently bypass holdout quota the way a local holdout run cannot" — this makes that claim true.

A non-positive `Budget` means no ceiling is configured (Day-4 input absent → gate #3 no-op), so burns record without refusal — matching the read-side posture exactly.

## Scope

Bounded slice of **ag-62g68** — the *"second holdout score in a quarter refuses with the gate #3 structured message"* acceptance scenario, implemented at the burn primitive. Two files, no new CLI command/flag, no skill, no embedded surfaces. **Follow-on slices stay open on the bead:** the `--score/--suite/--bead` flag interface, the rc3 Run-manifest write into the eval-verdict-compiler pipeline, global-Dolt ledger persistence, and the `judge_content_hash` parity assertion (gate #2).

## Evidence
- TDD: `TestRegisterOutcomesBurn_RefusesWhenQuotaExhausted` (red→green) + `TestRegisterOutcomesBurn_NoCeilingWhenBudgetUnset`; existing burn tests updated for the `(ledger, error)` signature and stay green (2 burns < budget 5).
- `go build ./...` success · `go test ./cmd/ao/` 9219 pass · `go vet ./cmd/ao/` clean · gocyclo: no findings >15.

Closes-scenario: ag-62g68#gate3-write-side-refuse
Bounded-context: BC4-Evaluation
Evidence: cli/cmd/ao/eval_outcomes_ingest.go