### PR TITLE
feat(eval): gate #2 judge_content_hash parity on outcomes ingest (ag-62g68 #gate2-hash-parity)

### DIFF
--- a/cli/cmd/ao/eval_outcomes_hash_parity_test.go
+++ b/cli/cmd/ao/eval_outcomes_hash_parity_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestRequireJudgeHashParity is the gate #2 (rubric-drift parity) unit: a score
+// graded against a different judge_content_hash than the active rubric is
+// refused; a matching hash passes; an empty expected hash is a no-op (parity not
+// configured), so legacy/dev flows are unaffected.
+func TestRequireJudgeHashParity(t *testing.T) {
+	cases := []struct {
+		name      string
+		scoreHash string
+		expected  string
+		wantErr   bool
+	}{
+		{"match", "sha256:abc", "sha256:abc", false},
+		{"mismatch refuses", "sha256:abc", "sha256:def", true},
+		{"empty expected is no-op", "sha256:abc", "", false},
+		{"empty score vs configured expected refuses", "", "sha256:def", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := requireJudgeHashParity(c.scoreHash, c.expected)
+			if c.wantErr && err == nil {
+				t.Errorf("requireJudgeHashParity(%q,%q) = nil, want error", c.scoreHash, c.expected)
+			}
+			if !c.wantErr && err != nil {
+				t.Errorf("requireJudgeHashParity(%q,%q) = %v, want nil", c.scoreHash, c.expected, err)
+			}
+		})
+	}
+}
+
+// TestRunEvalOutcomesIngest_RefusesOnHashMismatch exercises gate #2 end-to-end
+// through the command: with --expect-judge-hash set to a value that differs from
+// the score's judge_content_hash, ingest refuses and emits NO verdict (a stale
+// rubric must not feed the Knowledge Flywheel). With a matching hash, it ingests.
+func TestRunEvalOutcomesIngest_RefusesOnHashMismatch(t *testing.T) {
+	dir := t.TempDir()
+	scorePath := filepath.Join(dir, "score.json")
+	if err := os.WriteFile(scorePath, []byte(`{"source_task_id":"t","judge_content_hash":"sha256:aaa","aggregate":0.9,"threshold":0.8}`), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	// Restore the package flag var after the test (it is process-global).
+	orig := evalOutcomesIngestExpectHash
+	t.Cleanup(func() { evalOutcomesIngestExpectHash = orig })
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&cobraDiscard{})
+
+	// Mismatch → refuse.
+	evalOutcomesIngestExpectHash = "sha256:bbb"
+	if err := runEvalOutcomesIngest(cmd, []string{scorePath}); err == nil {
+		t.Fatal("ingest must refuse when judge_content_hash mismatches --expect-judge-hash (gate #2)")
+	}
+
+	// Match → ingest succeeds.
+	evalOutcomesIngestExpectHash = "sha256:aaa"
+	if err := runEvalOutcomesIngest(cmd, []string{scorePath}); err != nil {
+		t.Fatalf("matching judge_content_hash must ingest cleanly: %v", err)
+	}
+
+	// Unset → no parity check (legacy/dev path).
+	evalOutcomesIngestExpectHash = ""
+	if err := runEvalOutcomesIngest(cmd, []string{scorePath}); err != nil {
+		t.Fatalf("unset --expect-judge-hash must not enforce parity: %v", err)
+	}
+}
+
+// cobraDiscard is an io.Writer that drops the verdict JSON the command prints.
+type cobraDiscard struct{}
+
+func (cobraDiscard) Write(p []byte) (int, error) { return len(p), nil }

--- a/cli/cmd/ao/eval_outcomes_ingest.go
+++ b/cli/cmd/ao/eval_outcomes_ingest.go
@@ -110,6 +110,23 @@ func registerOutcomesBurn(led evalsubstrate.HoldoutBurnLedger, s outcomesScore) 
 	return led, nil
 }
 
+// requireJudgeHashParity is the gate #2 (rubric-drift parity) guard for ingest.
+// An Outcomes score carries the judge_content_hash of the rubric it was graded
+// against (SCHEMA rc2 drift key). If the caller supplies the active Suite's
+// current judge hash and it differs from the score's, the rubric drifted between
+// projection and grading — the score is stale and MUST be refused, exactly as a
+// stale local judge self-invalidates. An empty expected hash means the caller
+// did not configure a parity check (no-op), so legacy/dev flows are unaffected.
+func requireJudgeHashParity(scoreHash, expected string) error {
+	if expected == "" || scoreHash == expected {
+		return nil
+	}
+	return fmt.Errorf("outcomes ingest: judge_content_hash mismatch — score was graded against %q but the active rubric is %q; the rubric drifted and this score is stale (gate #2 parity, refused)",
+		scoreHash, expected)
+}
+
+var evalOutcomesIngestExpectHash string
+
 var evalOutcomesIngestCmd = &cobra.Command{
 	Use:   "ingest <score.json>",
 	Short: "Ingest an Outcomes score payload into the one council verdict record",
@@ -126,6 +143,9 @@ func runEvalOutcomesIngest(cmd *cobra.Command, args []string) error {
 	if err := json.Unmarshal(raw, &s); err != nil {
 		return fmt.Errorf("parse %s: %w", args[0], err)
 	}
+	if err := requireJudgeHashParity(s.JudgeContentHash, evalOutcomesIngestExpectHash); err != nil {
+		return err
+	}
 	out, err := json.MarshalIndent(ingestOutcomesScore(s), "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode verdict: %w", err)
@@ -135,5 +155,7 @@ func runEvalOutcomesIngest(cmd *cobra.Command, args []string) error {
 }
 
 func init() {
+	evalOutcomesIngestCmd.Flags().StringVar(&evalOutcomesIngestExpectHash, "expect-judge-hash", "",
+		"refuse the ingest if the score's judge_content_hash does not match this value (gate #2 rubric-drift parity)")
 	evalOutcomesCmd.AddCommand(evalOutcomesIngestCmd)
 }

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -1456,6 +1456,13 @@ Ingest an Outcomes score payload into the one council verdict record
 ao eval outcomes ingest <score.json> [flags]
 ```
 
+**Flags:**
+
+```
+      --expect-judge-hash string   refuse the ingest if the score's judge_content_hash does not match this value (gate #2 rubric-drift parity)
+  -h, --help                       help for ingest
+```
+
 #### `ao eval run`
 
 Run a deterministic eval suite


### PR DESCRIPTION
## What

`ao eval outcomes ingest` ignored the score's `judge_content_hash` entirely — so a score graded against a **drifted rubric** would still ingest into the council verdict and feed the Knowledge Flywheel. Gate #2 (SCHEMA rc2 drift key): a stale rubric must **self-invalidate**, exactly as a stale local judge does.

Adds an optional **`--expect-judge-hash`** flag: when set, ingest **refuses** (emits no verdict) if the score's `judge_content_hash` differs from the active rubric's hash. Empty (default) = parity not configured → legacy/dev flows unaffected.

## Scope

Second of **ag-62g68**'s gate scenarios (gate #3 write-side refuse landed in #626). Pure guard `requireJudgeHashParity` is unit-tested; the flag is exercised end-to-end through `runEvalOutcomesIngest`. **Remaining bead slices stay open:** the rc3 Run-manifest write into the eval-verdict-compiler pipeline, the `--score/--suite/--bead` interface, and global-Dolt ledger persistence (wiring `registerOutcomesBurn` into the command).

**Flag-only CLI change** — `COMMANDS.md` regenerated; the flag adds **no new `###`/`####` heading**, so the `cli-command-surface-matrix` canary counts are unchanged and the registry SKU (`cmd:ao.eval`) is unchanged (verified `generate-registry.sh --check` green).

## Evidence
- `TestRequireJudgeHashParity` (match / mismatch-refuses / empty-no-op / empty-score-vs-configured) + `TestRunEvalOutcomesIngest_RefusesOnHashMismatch` (command-level: mismatch refuses & emits no verdict, match ingests, unset = no check).
- `go build ./...` ✓ · `go test ./cmd/ao/` 9225 pass ✓ · `go vet` clean · gocyclo no findings · `generate-cli-reference.sh --check` up-to-date · `generate-registry.sh --check` OK.

Closes-scenario: ag-62g68#gate2-judge-hash-parity
Bounded-context: BC4-Evaluation
Evidence: cli/cmd/ao/eval_outcomes_ingest.go