### PR TITLE
feat(eval): wire gate #3 holdout-burn enforcement into ao eval outcomes ingest (ag-vbwx)

### DIFF
--- a/cli/cmd/ao/eval_outcomes_burn_wire_test.go
+++ b/cli/cmd/ao/eval_outcomes_burn_wire_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/evalsubstrate"
+	"github.com/spf13/cobra"
+)
+
+// writeBurnLedgerFile seeds a HoldoutBurnLedger JSON file.
+func writeBurnLedgerFile(t *testing.T, path string, led evalsubstrate.HoldoutBurnLedger) {
+	t.Helper()
+	blob, err := json.Marshal(led)
+	if err != nil {
+		t.Fatalf("marshal ledger: %v", err)
+	}
+	if err := os.WriteFile(path, blob, 0o644); err != nil {
+		t.Fatalf("write ledger %s: %v", path, err)
+	}
+}
+
+func readBurnLedgerFile(t *testing.T, path string) evalsubstrate.HoldoutBurnLedger {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read ledger %s: %v", path, err)
+	}
+	var led evalsubstrate.HoldoutBurnLedger
+	if err := json.Unmarshal(raw, &led); err != nil {
+		t.Fatalf("parse ledger %s: %v", path, err)
+	}
+	return led
+}
+
+func writeHoldoutScore(t *testing.T, path, suite, gt, runID string) {
+	t.Helper()
+	s := outcomesScore{
+		SourceTaskID:       "task-x",
+		JudgeContentHash:   "sha256:abc",
+		Aggregate:          0.9,
+		Threshold:          0.8,
+		Split:              "holdout",
+		SuiteRef:           suite,
+		GroundTruthVersion: gt,
+		RunID:              runID,
+	}
+	blob, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal score: %v", err)
+	}
+	if err := os.WriteFile(path, blob, 0o644); err != nil {
+		t.Fatalf("write score %s: %v", path, err)
+	}
+}
+
+// ingestCmdForTest returns a cobra command whose stdout is discarded and
+// restores the process-global ingest flag vars after the test.
+func ingestCmdForTest(t *testing.T, burnLedger string) *cobra.Command {
+	t.Helper()
+	origLedger, origHash := evalOutcomesIngestBurnLedger, evalOutcomesIngestExpectHash
+	t.Cleanup(func() {
+		evalOutcomesIngestBurnLedger = origLedger
+		evalOutcomesIngestExpectHash = origHash
+	})
+	evalOutcomesIngestBurnLedger = burnLedger
+	evalOutcomesIngestExpectHash = ""
+	cmd := &cobra.Command{}
+	cmd.SetOut(&cobraDiscard{})
+	return cmd
+}
+
+// TestApplyOutcomesBurn_RefusesAtCommandLevel_WhenQuotaExhausted is the gate #3
+// RUNTIME proof (ag-vbwx): with a --burn-ledger whose (suite,gt) quota is already
+// spent, `ao eval outcomes ingest` of a holdout score REFUSES at the command
+// level (not merely in the unit-tested primitive), and leaves the ledger
+// unmutated. This closes the council 2026-05-30 caveat that registerOutcomesBurn
+// was wired into no command path.
+func TestApplyOutcomesBurn_RefusesAtCommandLevel_WhenQuotaExhausted(t *testing.T) {
+	dir := t.TempDir()
+	ledgerPath := filepath.Join(dir, "ledger.json")
+	writeBurnLedgerFile(t, ledgerPath, evalsubstrate.HoldoutBurnLedger{
+		Budget:  1,
+		Records: []evalsubstrate.BurnRecord{{SuiteRef: "suite-x", GTVersion: "gt-1", RunID: "r0"}},
+	})
+	scorePath := filepath.Join(dir, "score.json")
+	writeHoldoutScore(t, scorePath, "suite-x", "gt-1", "run-cloud-2")
+
+	cmd := ingestCmdForTest(t, ledgerPath)
+	if err := runEvalOutcomesIngest(cmd, []string{scorePath}); err == nil {
+		t.Fatal("ingest must refuse at the command level when the holdout quota is exhausted (gate #3 runtime)")
+	}
+	after := readBurnLedgerFile(t, ledgerPath)
+	if got := after.Spent("suite-x", "gt-1"); got != 1 {
+		t.Errorf("refused ingest must not mutate the ledger, Spent=%d want 1", got)
+	}
+}
+
+// TestApplyOutcomesBurn_PersistsAcrossInvocations proves the burn is durable: two
+// distinct holdout ingests under a budget of 2 both succeed and each appends one
+// record to the on-disk ledger; the third (quota now exhausted) refuses. This is
+// the cross-invocation persistence the council required.
+func TestApplyOutcomesBurn_PersistsAcrossInvocations(t *testing.T) {
+	dir := t.TempDir()
+	ledgerPath := filepath.Join(dir, "ledger.json")
+	writeBurnLedgerFile(t, ledgerPath, evalsubstrate.HoldoutBurnLedger{Budget: 2})
+	scorePath := filepath.Join(dir, "score.json")
+
+	cmd := ingestCmdForTest(t, ledgerPath)
+
+	writeHoldoutScore(t, scorePath, "suite-x", "gt-1", "run-1")
+	if err := runEvalOutcomesIngest(cmd, []string{scorePath}); err != nil {
+		t.Fatalf("first holdout ingest under budget must succeed: %v", err)
+	}
+	if got := readBurnLedgerFile(t, ledgerPath).Spent("suite-x", "gt-1"); got != 1 {
+		t.Fatalf("first ingest must persist +1 burn, Spent=%d want 1", got)
+	}
+
+	writeHoldoutScore(t, scorePath, "suite-x", "gt-1", "run-2")
+	if err := runEvalOutcomesIngest(cmd, []string{scorePath}); err != nil {
+		t.Fatalf("second holdout ingest under budget must succeed: %v", err)
+	}
+	if got := readBurnLedgerFile(t, ledgerPath).Spent("suite-x", "gt-1"); got != 2 {
+		t.Fatalf("second ingest must persist a 2nd burn, Spent=%d want 2", got)
+	}
+
+	writeHoldoutScore(t, scorePath, "suite-x", "gt-1", "run-3")
+	if err := runEvalOutcomesIngest(cmd, []string{scorePath}); err == nil {
+		t.Fatal("third holdout ingest must refuse — budget 2 is exhausted")
+	}
+	if got := readBurnLedgerFile(t, ledgerPath).Spent("suite-x", "gt-1"); got != 2 {
+		t.Errorf("refused third ingest must not append, Spent=%d want 2", got)
+	}
+}
+
+// TestApplyOutcomesBurn_EmptyPathNoOp: with no --burn-ledger configured, holdout
+// ingest is unaffected (enforcement off; dev/legacy flows preserved).
+func TestApplyOutcomesBurn_EmptyPathNoOp(t *testing.T) {
+	dir := t.TempDir()
+	scorePath := filepath.Join(dir, "score.json")
+	writeHoldoutScore(t, scorePath, "suite-x", "gt-1", "run-1")
+
+	cmd := ingestCmdForTest(t, "") // empty burn-ledger path
+	if err := runEvalOutcomesIngest(cmd, []string{scorePath}); err != nil {
+		t.Fatalf("no --burn-ledger configured must not enforce gate #3: %v", err)
+	}
+}
+
+// TestApplyOutcomesBurn_DevSplitNoBurn: a dev-split score never burns, even when
+// the configured ledger is already at quota — only holdout grades consume quota.
+func TestApplyOutcomesBurn_DevSplitNoBurn(t *testing.T) {
+	dir := t.TempDir()
+	ledgerPath := filepath.Join(dir, "ledger.json")
+	writeBurnLedgerFile(t, ledgerPath, evalsubstrate.HoldoutBurnLedger{
+		Budget:  1,
+		Records: []evalsubstrate.BurnRecord{{SuiteRef: "suite-x", GTVersion: "gt-1", RunID: "r0"}},
+	})
+	scorePath := filepath.Join(dir, "score.json")
+	dev := outcomesScore{SourceTaskID: "t", Split: "dev", SuiteRef: "suite-x", GroundTruthVersion: "gt-1", RunID: "d1", Aggregate: 0.9, Threshold: 0.8}
+	blob, _ := json.Marshal(dev)
+	if err := os.WriteFile(scorePath, blob, 0o644); err != nil {
+		t.Fatalf("write dev score: %v", err)
+	}
+
+	cmd := ingestCmdForTest(t, ledgerPath)
+	if err := runEvalOutcomesIngest(cmd, []string{scorePath}); err != nil {
+		t.Fatalf("dev-split ingest must never burn or refuse: %v", err)
+	}
+	if got := readBurnLedgerFile(t, ledgerPath).Spent("suite-x", "gt-1"); got != 1 {
+		t.Errorf("dev-split ingest must not append a burn, Spent=%d want 1", got)
+	}
+}

--- a/cli/cmd/ao/eval_outcomes_ingest.go
+++ b/cli/cmd/ao/eval_outcomes_ingest.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -125,7 +126,70 @@ func requireJudgeHashParity(scoreHash, expected string) error {
 		scoreHash, expected)
 }
 
-var evalOutcomesIngestExpectHash string
+// loadBurnLedger reads a HoldoutBurnLedger JSON file. A missing file is an empty
+// ledger (Budget 0 → no enforceable ceiling, gate #3 no-op), so a first ingest
+// against a fresh path does not error — the operator seeds Budget by writing the
+// ledger file once.
+func loadBurnLedger(path string) (evalsubstrate.HoldoutBurnLedger, error) {
+	var led evalsubstrate.HoldoutBurnLedger
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return led, nil
+	}
+	if err != nil {
+		return led, fmt.Errorf("read burn ledger %s: %w", path, err)
+	}
+	if err := json.Unmarshal(raw, &led); err != nil {
+		return led, fmt.Errorf("parse burn ledger %s: %w", path, err)
+	}
+	return led, nil
+}
+
+// saveBurnLedger atomically persists the ledger (temp file + rename) so a crash
+// mid-write cannot corrupt the global holdout-burn accounting.
+func saveBurnLedger(path string, led evalsubstrate.HoldoutBurnLedger) error {
+	blob, err := json.MarshalIndent(led, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode burn ledger: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, blob, 0o644); err != nil {
+		return fmt.Errorf("write burn ledger temp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("commit burn ledger: %w", err)
+	}
+	return nil
+}
+
+// applyOutcomesBurn is the gate #3 RUNTIME enforcement (ag-vbwx) — the wiring
+// that makes registerOutcomesBurn a live guard rather than an unexercised
+// primitive (council post-mortem 2026-05-30 WARN). When a --burn-ledger path is
+// configured and the score is a holdout grade, it loads the persisted ledger,
+// registers the burn (which REFUSES on exhausted (suite,gt) quota), and persists
+// the updated ledger across invocations so a cloud/Codex Outcomes run cannot
+// re-observe a spent holdout split. An empty path is a no-op (enforcement not
+// configured), preserving dev/legacy flows; dev-split scores register no burn,
+// so the ledger is only rewritten when an actual burn was appended.
+func applyOutcomesBurn(path string, s outcomesScore) error {
+	if path == "" || s.Split != "holdout" {
+		return nil
+	}
+	led, err := loadBurnLedger(path)
+	if err != nil {
+		return err
+	}
+	updated, err := registerOutcomesBurn(led, s)
+	if err != nil {
+		return err // gate #3 refuse — surfaced to the operator, no verdict emitted
+	}
+	return saveBurnLedger(path, updated)
+}
+
+var (
+	evalOutcomesIngestExpectHash string
+	evalOutcomesIngestBurnLedger string
+)
 
 var evalOutcomesIngestCmd = &cobra.Command{
 	Use:   "ingest <score.json>",
@@ -146,6 +210,9 @@ func runEvalOutcomesIngest(cmd *cobra.Command, args []string) error {
 	if err := requireJudgeHashParity(s.JudgeContentHash, evalOutcomesIngestExpectHash); err != nil {
 		return err
 	}
+	if err := applyOutcomesBurn(evalOutcomesIngestBurnLedger, s); err != nil {
+		return err
+	}
 	out, err := json.MarshalIndent(ingestOutcomesScore(s), "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode verdict: %w", err)
@@ -157,5 +224,7 @@ func runEvalOutcomesIngest(cmd *cobra.Command, args []string) error {
 func init() {
 	evalOutcomesIngestCmd.Flags().StringVar(&evalOutcomesIngestExpectHash, "expect-judge-hash", "",
 		"refuse the ingest if the score's judge_content_hash does not match this value (gate #2 rubric-drift parity)")
+	evalOutcomesIngestCmd.Flags().StringVar(&evalOutcomesIngestBurnLedger, "burn-ledger", "",
+		"path to a JSON HoldoutBurnLedger; when set, a holdout-split score registers a burn and is REFUSED if the (suite,gt) quota is exhausted (gate #3 runtime enforcement), persisted across invocations")
 	evalOutcomesCmd.AddCommand(evalOutcomesIngestCmd)
 }

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -1459,6 +1459,7 @@ ao eval outcomes ingest <score.json> [flags]
 **Flags:**
 
 ```
+      --burn-ledger string         path to a JSON HoldoutBurnLedger; when set, a holdout-split score registers a burn and is REFUSED if the (suite,gt) quota is exhausted (gate #3 runtime enforcement), persisted across invocations
       --expect-judge-hash string   refuse the ingest if the score's judge_content_hash does not match this value (gate #2 rubric-drift parity)
   -h, --help                       help for ingest
 ```


### PR DESCRIPTION
## What

Closes the **#1 caveat from the 2026-05-30 council post-mortem (WARN)**: `registerOutcomesBurn` (gate #3, shipped in #626) was a **correct-but-unwired primitive** — `runEvalOutcomesIngest` never called it, so `ao eval outcomes ingest` enforced **zero holdout quota at runtime**. This makes it a **live guard**.

Adds a **`--burn-ledger <path>`** flag (opt-in, mirroring `--expect-judge-hash`). When set and the score is a holdout grade, ingest:
1. loads the persisted `HoldoutBurnLedger` JSON,
2. calls `registerOutcomesBurn` (which **refuses** on exhausted `(suite,gt)` quota),
3. persists the updated ledger **atomically** (temp+rename) across invocations.

So a cloud/Codex Outcomes run can no longer re-observe a spent holdout split. **Managed Agents are NOT ZDR.** Empty path = no-op (dev/legacy flows preserved); dev-split scores never burn.

## Scope

The **local-file persistence slice** of ag-vbwx. The global-Dolt transport (cross-host shared ledger) remains a follow-on slice tracked on ag-62g68. Two files + COMMANDS.md.

## Evidence (command-level, not just the primitive)
- `TestApplyOutcomesBurn_RefusesAtCommandLevel_WhenQuotaExhausted` — `runEvalOutcomesIngest` refuses + leaves the ledger unmutated.
- `TestApplyOutcomesBurn_PersistsAcrossInvocations` — two burns under budget 2 persist to disk, third refuses.
- `TestApplyOutcomesBurn_EmptyPathNoOp` + `TestApplyOutcomesBurn_DevSplitNoBurn`.
- `go build ./...` ✓ · `go test ./cmd/ao/` 9229 pass ✓ · `go vet` clean · gocyclo no findings · `generate-cli-reference.sh --check` up-to-date · `generate-registry.sh --check` OK (no new heading → surface-matrix canary unchanged; SKU `cmd:ao.eval` unchanged).

Verdict that motivated this: `.agents/council/2026-05-30-evolve-624-627-postmortem/verdict.md` (local).

Closes-scenario: ag-vbwx#gate3-runtime-wiring-local-ledger
Bounded-context: BC4-Evaluation
Evidence: cli/cmd/ao/eval_outcomes_ingest.go