### PR TITLE
feat(eval): warn when judge_content_hash parity goes unchecked on ingest (ag-ejet)

### DIFF
--- a/cli/cmd/ao/eval_outcomes_gate2_warn_test.go
+++ b/cli/cmd/ao/eval_outcomes_gate2_warn_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestUncheckedJudgeHashWarning is the gate #2 advisory unit (council
+// 2026-05-30 caveat #2): a score that carries a judge_content_hash but no
+// configured --expect-judge-hash warns; a configured expected hash (parity
+// enforced by requireJudgeHashParity) or a hashless score does not.
+func TestUncheckedJudgeHashWarning(t *testing.T) {
+	cases := []struct {
+		name      string
+		scoreHash string
+		expected  string
+		wantWarn  bool
+	}{
+		{"hash present, no expect → warn", "sha256:abc", "", true},
+		{"hash present, expect set → no warn (parity enforced)", "sha256:abc", "sha256:abc", false},
+		{"no hash, no expect → no warn", "", "", false},
+		{"no hash, expect set → no warn", "", "sha256:abc", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := uncheckedJudgeHashWarning(c.scoreHash, c.expected)
+			if c.wantWarn && got == "" {
+				t.Errorf("uncheckedJudgeHashWarning(%q,%q) = \"\", want a warning", c.scoreHash, c.expected)
+			}
+			if !c.wantWarn && got != "" {
+				t.Errorf("uncheckedJudgeHashWarning(%q,%q) = %q, want \"\"", c.scoreHash, c.expected, got)
+			}
+		})
+	}
+}
+
+// TestRunEvalOutcomesIngest_WarnsWhenParityUnchecked exercises gate #2's advisory
+// end-to-end through the command: a score carrying a judge_content_hash ingested
+// WITHOUT --expect-judge-hash still succeeds (the warning is non-fatal) but emits
+// a visible gate #2 warning to stderr, so the unenforced-parity gap is not
+// silent. With --expect-judge-hash matching, no warning is emitted.
+func TestRunEvalOutcomesIngest_WarnsWhenParityUnchecked(t *testing.T) {
+	dir := t.TempDir()
+	scorePath := filepath.Join(dir, "score.json")
+	if err := os.WriteFile(scorePath, []byte(`{"source_task_id":"t","judge_content_hash":"sha256:aaa","aggregate":0.9,"threshold":0.8}`), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	origHash, origLedger := evalOutcomesIngestExpectHash, evalOutcomesIngestBurnLedger
+	t.Cleanup(func() {
+		evalOutcomesIngestExpectHash = origHash
+		evalOutcomesIngestBurnLedger = origLedger
+	})
+	evalOutcomesIngestBurnLedger = ""
+
+	// No --expect-judge-hash → warns on stderr, still ingests.
+	evalOutcomesIngestExpectHash = ""
+	var stderr, stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	if err := runEvalOutcomesIngest(cmd, []string{scorePath}); err != nil {
+		t.Fatalf("ingest without --expect-judge-hash must still succeed (warning is non-fatal): %v", err)
+	}
+	if !strings.Contains(stderr.String(), "gate #2") || !strings.Contains(stderr.String(), "sha256:aaa") {
+		t.Errorf("expected a gate #2 unchecked-parity warning naming the hash on stderr, got: %q", stderr.String())
+	}
+	if stdout.Len() == 0 {
+		t.Error("a verdict must still be emitted to stdout despite the warning")
+	}
+
+	// With matching --expect-judge-hash → parity enforced, no warning.
+	evalOutcomesIngestExpectHash = "sha256:aaa"
+	var stderr2 bytes.Buffer
+	cmd2 := &cobra.Command{}
+	cmd2.SetOut(&cobraDiscard{})
+	cmd2.SetErr(&stderr2)
+	if err := runEvalOutcomesIngest(cmd2, []string{scorePath}); err != nil {
+		t.Fatalf("matching --expect-judge-hash must ingest cleanly: %v", err)
+	}
+	if stderr2.Len() != 0 {
+		t.Errorf("no gate #2 warning expected when parity is configured, got: %q", stderr2.String())
+	}
+}

--- a/cli/cmd/ao/eval_outcomes_ingest.go
+++ b/cli/cmd/ao/eval_outcomes_ingest.go
@@ -126,6 +126,21 @@ func requireJudgeHashParity(scoreHash, expected string) error {
 		scoreHash, expected)
 }
 
+// uncheckedJudgeHashWarning returns a gate #2 advisory (council 2026-05-30
+// caveat #2) for the case where a score carries a judge_content_hash but no
+// --expect-judge-hash was configured: parity is then silently unenforced, so a
+// stale drifted-rubric score would ingest with no signal. The warning makes the
+// gap VISIBLE without requiring the operator to remember the flag. It returns ""
+// when parity is configured (requireJudgeHashParity handles the refuse) or the
+// score carries no hash to check.
+func uncheckedJudgeHashWarning(scoreHash, expected string) string {
+	if expected != "" || scoreHash == "" {
+		return ""
+	}
+	return fmt.Sprintf("WARN outcomes ingest: score carries judge_content_hash %q but --expect-judge-hash was not provided; rubric-drift parity (gate #2) was NOT checked — pass --expect-judge-hash <active-rubric-hash> to enforce it",
+		scoreHash)
+}
+
 // loadBurnLedger reads a HoldoutBurnLedger JSON file. A missing file is an empty
 // ledger (Budget 0 → no enforceable ceiling, gate #3 no-op), so a first ingest
 // against a fresh path does not error — the operator seeds Budget by writing the
@@ -206,6 +221,9 @@ func runEvalOutcomesIngest(cmd *cobra.Command, args []string) error {
 	var s outcomesScore
 	if err := json.Unmarshal(raw, &s); err != nil {
 		return fmt.Errorf("parse %s: %w", args[0], err)
+	}
+	if w := uncheckedJudgeHashWarning(s.JudgeContentHash, evalOutcomesIngestExpectHash); w != "" {
+		fmt.Fprintln(cmd.ErrOrStderr(), w)
 	}
 	if err := requireJudgeHashParity(s.JudgeContentHash, evalOutcomesIngestExpectHash); err != nil {
 		return err


### PR DESCRIPTION
## What

Closes the **second and last open caveat from the 2026-05-30 council post-mortem (WARN)**: `--expect-judge-hash` (gate #2, #627) is fully opt-in, so a score graded against a **drifted rubric** ingests **silently** if the caller omits the flag.

Now, when a score carries a non-empty `judge_content_hash` but no `--expect-judge-hash` was configured, `ao eval outcomes ingest` emits a **gate #2 advisory to stderr** (non-fatal) naming the hash and how to enforce parity. The unenforced-parity gap is **loud instead of silent** — the council's sanctioned minimum bar — without requiring the operator to remember a flag.

Full auto-resolution of the active suite hash (so parity enforces automatically, not just warns) remains a follow-on — it needs a suite-hash resolution path, tracked on ag-62g68.

## Scope

Behavior-only — **no new flag**, so `COMMANDS.md`/registry are unchanged. Two files (impl + test).

## Evidence
- `TestUncheckedJudgeHashWarning` (4 cases: hash+no-expect warns; hash+expect / no-hash / no-hash+expect do not).
- `TestRunEvalOutcomesIngest_WarnsWhenParityUnchecked` — command-level: warns on stderr, still emits a verdict; matching `--expect-judge-hash` → no warning.
- `go build ./...` ✓ · `go test ./cmd/ao/` 9235 pass ✓ · `go vet` clean · gocyclo no findings.

Council caveats now both retired: #1 (gate #3 unwired → #628) and #2 (gate #2 silent → this PR). Verdict: `.agents/council/2026-05-30-evolve-624-627-postmortem/verdict.md`.

Closes-scenario: ag-ejet#gate2-warn-when-parity-unchecked
Bounded-context: BC4-Evaluation
Evidence: cli/cmd/ao/eval_outcomes_ingest.go