### PR TITLE
ci(claude-review): soft-fail only on Claude usage-limit (ag-d2e5 #usage-limit-soft-fail)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,6 +43,11 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
+        # Soft-fail ONLY on a Claude usage-limit (ag-d2e5): the action calls
+        # core.setFailed() when the account weekly limit is hit, which would
+        # otherwise fail this required check on every PR until the limit resets.
+        # continue-on-error lets the gate step below decide pass/skip/block.
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -51,4 +56,43 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+
+      - name: Enforce review (skip only on Claude usage limit)
+        # The required check IS this job's conclusion. We re-derive it from the
+        # action's outcome so a usage-limit run does not block merges, while a
+        # genuine review/execution failure still does. Branch protection keeps
+        # claude-review required; this only narrows WHAT counts as a failure.
+        env:
+          OUTCOME: ${{ steps.claude-review.outcome }}
+          EXEC_FILE: ${{ steps.claude-review.outputs.execution_file }}
+        run: |
+          set -uo pipefail
+
+          if [ "$OUTCOME" = "success" ]; then
+            echo "claude-review: action succeeded — gate passes."
+            exit 0
+          fi
+
+          echo "claude-review: action outcome=$OUTCOME — inspecting for usage-limit signature."
+
+          # Distinctive Claude usage-limit phrases emitted in the SDK error
+          # result (preserved in execution_file even on failure). Deliberately
+          # NOT generic "rate limit" — a PR whose diff discusses rate-limiting
+          # must NOT be skipped.
+          LIMIT_RE='hit your (weekly|usage|[0-9]+-hour) limit|usage limit reached|Claude (AI|Code) usage limit|reach(ed)? your usage limit'
+
+          if [ -n "${EXEC_FILE:-}" ] && [ -f "$EXEC_FILE" ]; then
+            if grep -qiE "$LIMIT_RE" "$EXEC_FILE"; then
+              echo "::notice title=claude-review skipped::Claude usage limit hit — not blocking merge. Review re-runs on the next push after the limit resets."
+              exit 0
+            fi
+            echo "::error title=claude-review failed::Review did not pass and the failure is NOT a usage limit. Blocking merge. See execution_file in the step summary."
+            exit 1
+          fi
+
+          # No execution_file on failure = early/infra failure we cannot confirm
+          # as a usage limit. Block (conservative + re-runnable) rather than
+          # silently skipping a review that never ran.
+          echo "::error title=claude-review failed::Action failed with no execution_file to inspect (early/infra failure, not a confirmed usage limit). Blocking merge; re-run the job."
+          exit 1
 


### PR DESCRIPTION
## What

Keep `claude-review` a **required** check, but stop it from blocking merges when the failure is a **Claude account usage limit** (weekly/5-hour). Real review/execution failures still block.

## Why

When the weekly limit is hit, `anthropics/claude-code-action@v1` calls `core.setFailed("…You've hit your weekly limit · resets …(UTC)")`, failing the required check on **every** PR until the limit resets — forcing `--admin` merges (hit this session on #631/#634).

## How

- `continue-on-error: true` on the action step.
- A gate step re-derives the job conclusion:
  - action `success` → **pass**
  - action `failure` + `execution_file` matches the usage-limit signature → **skip** (exit 0, `::notice`)
  - any other failure (incl. no `execution_file`) → **block** (exit 1)
- `execution_file` is preserved on error (`run.ts` catch-block) and carries the SDK error-result text.
- Signature matches `hit your (weekly|usage|N-hour) limit` / `usage limit reached` / `Claude AI usage limit` — **not** generic `rate limit`, so a PR whose diff discusses rate-limiting is **not** false-skipped.

Branch protection is **unchanged** — `claude-review` stays required.

## Evidence

Local unit-sim of the gate (5 cases, all expected): `success→pass`, `limit→skip`, `real-fail→block`, `no-file→block`, `rate-limit-prose→block`. shellcheck clean; `validate-ci-policy-parity.sh` PASS. This PR's own `claude-review` run is the live dogfood — under the active weekly limit it should **skip cleanly** instead of blocking.

Closes-scenario: ag-d2e5#usage-limit-soft-fail
Bounded-context: BC2-Validation
Evidence: .github/workflows/claude-code-review.yml