### PR TITLE
fix(evolve): sync local main to origin/main before discovery (ag-6jt #discovery-origin-main)

### DIFF
--- a/scripts/overnight-evolve.sh
+++ b/scripts/overnight-evolve.sh
@@ -48,6 +48,24 @@ if [ -n "$DIRTY" ]; then
     exit 1
 fi
 
+# Sync local `main` to origin/main BEFORE the loop's discovery phase (ag-6jt).
+# The rpi worktree's local main lags origin/main, so phase-1 discovery diffs
+# candidate slices against a stale base and re-seeds already-merged work as
+# "open". Fetch + fast-forward so discovery's diff base is origin/main. A
+# divergence is reported but non-fatal — the loop proceeds with origin/main as
+# the authoritative base either way (the script never force-moves local main).
+SYNC_SCRIPT="$HOME/dev/agentops/skills/evolve/scripts/sync-main-to-origin.sh"
+if [ -x "$SYNC_SCRIPT" ]; then
+    if SYNC_OUT="$("$SYNC_SCRIPT" 2>&1)"; then
+        echo "origin/main sync: $SYNC_OUT"
+    else
+        echo "WARN: origin/main sync reported an issue (proceeding):" >&2
+        printf '%s\n' "$SYNC_OUT" >&2
+    fi
+else
+    echo "WARN: $SYNC_SCRIPT missing or not executable; discovery may diff stale local main" >&2
+fi
+
 START_SHA="$(git rev-parse HEAD)"
 START_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 START_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/skills/evolve/references/work-selection-ladder.md
+++ b/skills/evolve/references/work-selection-ladder.md
@@ -64,8 +64,17 @@ skills/evolve/scripts/duplicate-work-guard.sh "<candidate title>" || {
 # covers it (exact title OR significant-token overlap). exit 0 → safe to create.
 ```
 
-This complements the loop's origin/main fast-forward (the cron syncs local
-`main` to `origin/main` before discovery so already-merged work is not re-seen).
+This complements the loop's origin/main fast-forward: the cron runs
+`skills/evolve/scripts/sync-main-to-origin.sh` before discovery (wired into
+`scripts/overnight-evolve.sh`), which fetches origin and fast-forwards local
+`main` to `origin/main` so discovery diffs candidate slices against the true
+merge base — already-merged work reports as done, not re-seen (ag-6jt). Run it
+manually in any rpi worktree whose local `main` may be stale:
+
+```bash
+skills/evolve/scripts/sync-main-to-origin.sh
+# → "DIFF_BASE: origin/main <sha>" — diff slices against THIS, not local main.
+```
 
 **Step 3.4: Testing improvements**
 

--- a/skills/evolve/scripts/sync-main-to-origin.sh
+++ b/skills/evolve/scripts/sync-main-to-origin.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# sync-main-to-origin.sh — before the evolve-cron-rpi discovery phase selects a
+# slice, fetch origin and fast-forward the local `main` to `origin/main` so that
+# discovery diffs candidate slices against the TRUE merge base, not a stale local
+# main.
+#
+# Why this exists (ag-6jt): the rpi worktree's local `main` lags `origin/main`
+# (e.g. local main=04b5d7cc vs origin/main=9e9caccb). Phase-1 discovery diffed
+# the candidate slice against the stale local `main`, so work already merged to
+# origin/main read as "open" — repeatedly re-seeding duplicate work/beads
+# (ag-b8m≈ag-jov, ag-6kw≈ag-c2i, 4th recurrence). The work-selection-ladder
+# reference claimed "the cron syncs local main to origin/main before discovery",
+# but no code actually did it. This script makes that claim real and testable,
+# and pairs with duplicate-work-guard.sh (the grep-existing-beads half).
+#
+# Behavior:
+#   1. `git fetch <remote>` (so refs/remotes/<remote>/main is current).
+#   2. Resolve the diff base to <remote>/main — ALWAYS, never local main.
+#   3. Fast-forward the LOCAL `main` ref to <remote>/main without forcing:
+#      - if `main` is checked out: `git merge --ff-only`,
+#      - otherwise: `git fetch <remote> main:main` (refuses a non-fast-forward).
+#   4. Print the resolved diff base SHA so callers/tests can assert discovery
+#      diffs against <remote>/main, not the previously-stale local main.
+#
+# Usage:  sync-main-to-origin.sh [<remote>]   (remote defaults to "origin")
+# Exit:   0 synced (or already up to date) · non-zero on fetch/ff failure
+# Output: final line is "DIFF_BASE: <remote>/main <sha>"
+# Env:    SYNC_MAIN_REMOTE (default "origin") overrides the remote name.
+set -euo pipefail
+
+REMOTE="${1:-${SYNC_MAIN_REMOTE:-origin}}"
+
+# 1. Refresh remote-tracking refs.
+if ! git fetch "$REMOTE" >/dev/null 2>&1; then
+  echo "FAIL: git fetch $REMOTE failed (offline or remote unreachable)" >&2
+  exit 1
+fi
+
+# The authoritative diff base after sync is ALWAYS <remote>/main, never local main.
+if ! ORIGIN_MAIN_SHA="$(git rev-parse --verify --quiet "refs/remotes/$REMOTE/main")"; then
+  echo "FAIL: $REMOTE/main does not exist after fetch" >&2
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$CURRENT_BRANCH" = "main" ]; then
+  # main is checked out — fast-forward only (never a merge commit, never force).
+  if ! git merge --ff-only "$REMOTE/main" >/dev/null 2>&1; then
+    echo "FAIL: local main is not a fast-forward of $REMOTE/main (diverged); resolve manually" >&2
+    exit 1
+  fi
+else
+  # main is not checked out — move the ref directly, fast-forward only.
+  # `git fetch <remote> main:main` refuses a non-fast-forward update (no force).
+  if ! git fetch "$REMOTE" main:main >/dev/null 2>&1; then
+    echo "FAIL: cannot fast-forward local main to $REMOTE/main (diverged); resolve manually" >&2
+    exit 1
+  fi
+fi
+
+# Emit the resolved diff base so discovery (and tests) can confirm it is
+# <remote>/main, not the previously-stale local main.
+echo "DIFF_BASE: $REMOTE/main $ORIGIN_MAIN_SHA"
+exit 0

--- a/tests/scripts/sync-main-to-origin.bats
+++ b/tests/scripts/sync-main-to-origin.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# Regression tests for skills/evolve/scripts/sync-main-to-origin.sh (ag-6jt).
+#
+# The evolve-cron-rpi discovery loop diffed candidate slices against a STALE
+# local `main` (the rpi worktree's local main lags origin/main), so work already
+# merged to origin/main read as "open" and was re-seeded. These tests pin the
+# fix: discovery's diff base must be origin/main AFTER a fetch, and local main
+# must be fast-forwarded to it — never forced past a divergence.
+#
+# Hermetic: a throwaway bare repo plays "origin"; we advance origin/main beyond
+# the local clone's main, then assert the script resolves the base to origin's
+# tip and fast-forwards local main to match.
+
+setup() {
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  SCRIPT="$REPO_ROOT/skills/evolve/scripts/sync-main-to-origin.sh"
+  TMP="$(mktemp -d)"
+
+  export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t \
+         GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t
+
+  # Bare "origin" remote.
+  git init -q --bare "$TMP/origin.git"
+
+  # A seed clone we use to publish commits to origin/main.
+  git clone -q "$TMP/origin.git" "$TMP/seed"
+  (
+    cd "$TMP/seed"
+    git checkout -q -b main
+    echo a > f.txt && git add f.txt && git commit -q -m "base commit"
+    git push -q origin main
+  )
+
+  # The "worktree" clone whose local main will go STALE.
+  git clone -q "$TMP/origin.git" "$TMP/work"
+  ( cd "$TMP/work" && git checkout -q main )
+  STALE_LOCAL_MAIN="$(cd "$TMP/work" && git rev-parse main)"
+
+  # Advance origin/main beyond the work clone's local main (simulates work
+  # merged to origin/main after the worktree last synced).
+  (
+    cd "$TMP/seed"
+    echo b >> f.txt && git commit -q -am "merged-after-stale commit"
+    git push -q origin main
+  )
+  NEW_ORIGIN_MAIN="$(cd "$TMP/seed" && git rev-parse main)"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+@test "DIFF_BASE is origin/main's tip after fetch, NOT the stale local main" {
+  # main is not the checked-out branch in the work clone.
+  ( cd "$TMP/work" && git checkout -q -b feature )
+  run bash -c "cd '$TMP/work' && '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DIFF_BASE: origin/main $NEW_ORIGIN_MAIN"* ]]
+  # The base must be the fresh origin tip, never the stale local main.
+  [[ "$output" != *"$STALE_LOCAL_MAIN"* ]]
+}
+
+@test "local main is fast-forwarded to origin/main when main is not checked out" {
+  ( cd "$TMP/work" && git checkout -q -b feature )
+  run bash -c "cd '$TMP/work' && '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  local after
+  after="$(cd "$TMP/work" && git rev-parse main)"
+  [ "$after" = "$NEW_ORIGIN_MAIN" ]
+  [ "$after" != "$STALE_LOCAL_MAIN" ]
+}
+
+@test "local main is fast-forwarded when main IS the checked-out branch" {
+  # work clone is on main (stale) before the sync.
+  run bash -c "cd '$TMP/work' && '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DIFF_BASE: origin/main $NEW_ORIGIN_MAIN"* ]]
+  local after
+  after="$(cd "$TMP/work" && git rev-parse HEAD)"
+  [ "$after" = "$NEW_ORIGIN_MAIN" ]
+}
+
+@test "a diverged local main is refused, never force-moved" {
+  # Create a divergent local main commit that is NOT an ancestor of origin/main.
+  (
+    cd "$TMP/work"
+    git checkout -q main
+    echo divergent > d.txt && git add d.txt && git commit -q -m "local-only divergent commit"
+  )
+  local diverged
+  diverged="$(cd "$TMP/work" && git rev-parse main)"
+  run bash -c "cd '$TMP/work' && '$SCRIPT'"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"fast-forward"* ]] || [[ "$output" == *"diverged"* ]]
+  # Local main must be untouched (no force/reset).
+  local after
+  after="$(cd "$TMP/work" && git rev-parse main)"
+  [ "$after" = "$diverged" ]
+}
+
+@test "respects a custom remote name via SYNC_MAIN_REMOTE" {
+  ( cd "$TMP/work" && git checkout -q -b feature && git remote rename origin upstream )
+  run bash -c "cd '$TMP/work' && SYNC_MAIN_REMOTE=upstream '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DIFF_BASE: upstream/main $NEW_ORIGIN_MAIN"* ]]
+}


### PR DESCRIPTION
## What

The evolve-cron-rpi loop's phase-1 discovery diffed candidate slices against a **stale local `main`** (the rpi worktree's local main lags `origin/main`), so work already merged to `origin/main` read as "open" and got re-seeded as duplicate beads/PRs (ag-b8m≈ag-jov, ag-6kw≈ag-c2i — 4th recurrence). The `work-selection-ladder` reference *claimed* "the cron syncs local main to origin/main before discovery" but no code actually did it.

## Change

- **`skills/evolve/scripts/sync-main-to-origin.sh`** (new): `git fetch origin`, then fast-forward local `main` to `origin/main` (never forced), emitting `DIFF_BASE: origin/main <sha>` as the authoritative diff base. A divergence is refused, never force-moved.
- **`scripts/overnight-evolve.sh`**: runs the sync before the loop's discovery phase. Non-fatal on warning (loop proceeds with origin/main as the base).
- **`skills/evolve/references/work-selection-ladder.md`**: the claimed sync now points at the real, runnable script.
- **`tests/scripts/sync-main-to-origin.bats`** (new): hermetic bare-repo tests pin the diff base = origin/main after fetch (not stale local main), local main fast-forwards, divergence is refused, and a custom remote is respected.

Pairs with the grep-existing-beads guard (`duplicate-work-guard.sh`, #582) to cover both halves of the bead.

## Gates
- `shellcheck --severity=error` clean on both modified scripts.
- `bats tests/scripts/sync-main-to-origin.bats` — 5/5 pass.
- `git diff origin/main --stat` — scope-only (4 files, evolve/rpi-discovery surface).

Closes-scenario: ag-6jt#discovery-origin-main
Bounded-context: BC3-Loop
Evidence: skills/evolve/scripts/sync-main-to-origin.sh