### PR TITLE
feat(provenance): agentops-sdlc-provenance.v1 ledger-event schema (ag-x31t.2 #provenance-schema)

### DIFF
--- a/schemas/agentops-sdlc-provenance.v1.schema.json
+++ b/schemas/agentops-sdlc-provenance.v1.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://agentops.dev/schemas/agentops-sdlc-provenance.v1.schema.json",
+  "title": "AgentOps SDLC Provenance Ledger Event (v1)",
+  "description": "One append-only event in the committed, per-record hash-chained provenance ledger at docs/provenance/ledger.jsonl (one JSON object per line). Each event records a single provenance edge — a typed, evidence-backed relation between two SDLC nodes (e.g. a decision and the artifact it produced) — plus the export-time hash-chain fields that make the ledger offline/CI/fresh-clone verifiable. Per CLAUDE.md the committed ledger is the AUDIT authority and wins on disagreement with the Dolt provenance_edges write model. Council architecture: .agents/council/2026-05-30-debate-provenance-substrate.md. Trust tiers are monotonic (authored > inferred > mined) per the in-toto (min,x) semiring. Hash fields reuse the hashing discipline in cli/internal/rpi/ledger.go: payload_hash = sha256 over the canonical edge payload (every field EXCEPT prev_hash/payload_hash/hash); hash = sha256(payload_hash + \"\\n\" + prev_hash); prev_hash links to the previous record's hash (empty string for the first record).",
+  "practices": ["adr", "in-toto-provenance", "dora-metrics"],
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "from_id",
+    "from_type",
+    "to_id",
+    "to_type",
+    "relation",
+    "trust_tier",
+    "ts",
+    "prev_hash",
+    "payload_hash",
+    "hash"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "agentops-sdlc-provenance.v1",
+      "description": "Schema discriminator. Pins the event shape so consumers can branch on version."
+    },
+    "from_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable identifier of the source node of the edge (e.g. a bead/decision id like 'ag-x31t.2' or a ledger event_id)."
+    },
+    "from_type": {
+      "$ref": "#/$defs/node_type",
+      "description": "Type of the source node."
+    },
+    "to_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable identifier of the target node of the edge (e.g. an artifact path or commit sha)."
+    },
+    "to_type": {
+      "$ref": "#/$defs/node_type",
+      "description": "Type of the target node."
+    },
+    "relation": {
+      "$ref": "#/$defs/relation",
+      "description": "The typed provenance relation from source to target (PROV-DM-aligned vocabulary)."
+    },
+    "evidence_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Optional pointer to the evidence backing this edge — a repo-relative path, a CI run URL, a commit sha, or a ledger event_id. Required in practice for inferred/mined edges to remain auditable, but optional at the schema level so authored edges asserted from a bead need not duplicate the bead id."
+    },
+    "trust_tier": {
+      "type": "string",
+      "enum": ["authored", "inferred", "mined"],
+      "description": "Monotonic trust tier of the edge assertion. 'authored' = a human/agent explicitly asserted it (highest); 'inferred' = derived deterministically from a tracked source (e.g. a commit trailer); 'mined' = recovered heuristically from chat/transcript history (lowest). Combine along a path with the (min,x) semiring: a path is only as trusted as its weakest edge."
+    },
+    "ts": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC3339/RFC3339Nano UTC timestamp when the edge was recorded."
+    },
+    "prev_hash": {
+      "$ref": "#/$defs/hash_or_empty",
+      "description": "Hash-chain link: the `hash` of the immediately previous ledger record, or the empty string for the first record. Reuses cli/internal/rpi/ledger.go chaining semantics."
+    },
+    "payload_hash": {
+      "$ref": "#/$defs/sha256_hex",
+      "description": "sha256 (lowercase hex) over the canonical JSON of the edge payload — every field of this record EXCEPT prev_hash, payload_hash, and hash."
+    },
+    "hash": {
+      "$ref": "#/$defs/sha256_hex",
+      "description": "sha256 (lowercase hex) of (payload_hash + \"\\n\" + prev_hash). The committed chain anchor for this record."
+    }
+  },
+  "$defs": {
+    "node_type": {
+      "type": "string",
+      "enum": [
+        "decision",
+        "artifact",
+        "bead",
+        "scenario",
+        "commit",
+        "pr",
+        "ci_run",
+        "verdict",
+        "learning",
+        "agent"
+      ],
+      "description": "Kind of SDLC node an edge endpoint refers to."
+    },
+    "relation": {
+      "type": "string",
+      "enum": [
+        "decision_produces_artifact",
+        "decision_authorizes",
+        "artifact_derived_from",
+        "scenario_covers_artifact",
+        "verdict_attests_artifact",
+        "bead_scopes_decision",
+        "commit_implements_decision",
+        "learning_revises_decision"
+      ],
+      "description": "Typed provenance relation. PROV-DM-aligned: produces≈wasGeneratedBy, authorizes≈wasAuthorizedBy, derived_from≈wasDerivedFrom, attests≈wasAttributedTo."
+    },
+    "sha256_hex": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$",
+      "description": "Lowercase hex-encoded sha256 digest (64 chars)."
+    },
+    "hash_or_empty": {
+      "type": "string",
+      "pattern": "^([a-f0-9]{64})?$",
+      "description": "A lowercase hex sha256 digest, or the empty string (used by prev_hash for the genesis record)."
+    }
+  }
+}

--- a/scripts/validate-provenance-ledger.sh
+++ b/scripts/validate-provenance-ledger.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# validate-provenance-ledger.sh — Validate provenance ledger events against
+# schemas/agentops-sdlc-provenance.v1.schema.json (ag-x31t.2).
+#
+# The committed, per-record hash-chained provenance ledger
+# (docs/provenance/ledger.jsonl) is the AUDIT authority for the SDLC
+# provenance/intent graph (council: .agents/council/2026-05-30-debate-provenance-substrate.md).
+# This validator is the schema's structural acceptance surface: each ledger
+# event (one JSON object per line) must carry a typed provenance edge plus the
+# export-time hash-chain fields, so a malformed edge — e.g. one missing a
+# trust_tier — FAILS validation, not merely a code review.
+#
+# Usage:
+#   scripts/validate-provenance-ledger.sh <event.json> [<event.json>...]
+#       Validate each single-event JSON file. Exit 0 only if EVERY file is
+#       schema-valid.
+#   scripts/validate-provenance-ledger.sh --jsonl <ledger.jsonl> [...]
+#       Validate every non-blank line of each JSONL ledger file as one event.
+#   scripts/validate-provenance-ledger.sh --selftest
+#       Validate the tracked fixtures with expected pass/fail and exit 0 only if
+#       all match expectations.
+#
+# Gating validator: python `jsonschema` (Draft7), mirroring
+# scripts/validate-outcomes-rubric.sh. If python3/jsonschema is unavailable the
+# script SKIPs (exit 0 with a notice) so it never blocks an environment without
+# the tool — the bats suite's structural-JSON checks are the always-on guard.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCHEMA="$REPO_ROOT/schemas/agentops-sdlc-provenance.v1.schema.json"
+FIXTURES="$REPO_ROOT/tests/fixtures/provenance"
+
+if [[ ! -f "$SCHEMA" ]]; then
+    echo "FAIL: schema not found: $SCHEMA" >&2
+    exit 2
+fi
+
+if ! command -v python3 >/dev/null 2>&1 || ! python3 -c 'import jsonschema' >/dev/null 2>&1; then
+    echo "SKIP: python3 + jsonschema not available; structural validation skipped" >&2
+    exit 0
+fi
+
+# validate_one <file> -> exit 0 if schema-valid, 1 if invalid, 2 on read error.
+validate_one() {
+    python3 - "$SCHEMA" "$1" <<'PY'
+import json, sys
+from jsonschema import Draft7Validator
+
+schema_path, data_path = sys.argv[1], sys.argv[2]
+try:
+    with open(schema_path) as f:
+        schema = json.load(f)
+    with open(data_path) as f:
+        doc = json.load(f)
+except Exception as e:
+    print(f"read error: {e}", file=sys.stderr)
+    sys.exit(2)
+
+errors = sorted(Draft7Validator(schema).iter_errors(doc), key=lambda e: list(e.path))
+if errors:
+    for e in errors:
+        loc = "/".join(str(p) for p in e.path) or "(root)"
+        print(f"  invalid at {loc}: {e.message}", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+}
+
+# validate_jsonl <file> -> exit 0 if EVERY non-blank line validates.
+validate_jsonl() {
+    python3 - "$SCHEMA" "$1" <<'PY'
+import json, sys
+from jsonschema import Draft7Validator
+
+schema_path, data_path = sys.argv[1], sys.argv[2]
+with open(schema_path) as f:
+    schema = json.load(f)
+validator = Draft7Validator(schema)
+bad = 0
+with open(data_path) as f:
+    for n, line in enumerate(f, 1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            doc = json.loads(line)
+        except json.JSONDecodeError as e:
+            print(f"  line {n}: not valid JSON: {e}", file=sys.stderr)
+            bad += 1
+            continue
+        errors = sorted(validator.iter_errors(doc), key=lambda e: list(e.path))
+        if errors:
+            for e in errors:
+                loc = "/".join(str(p) for p in e.path) or "(root)"
+                print(f"  line {n} invalid at {loc}: {e.message}", file=sys.stderr)
+            bad += 1
+sys.exit(1 if bad else 0)
+PY
+}
+
+if [[ "${1:-}" == "--selftest" ]]; then
+    rc=0
+    declare -A EXPECT=(
+        [valid-decision-produces-artifact.json]=0
+        [invalid-missing-trust-tier.json]=1
+    )
+    for name in valid-decision-produces-artifact.json invalid-missing-trust-tier.json; do
+        want="${EXPECT[$name]}"
+        if validate_one "$FIXTURES/$name" >/dev/null 2>&1; then got=0; else got=1; fi
+        if [[ "$got" == "$want" ]]; then
+            echo "PASS: $name (expected $([[ $want == 0 ]] && echo valid || echo invalid))"
+        else
+            echo "FAIL: $name (expected $([[ $want == 0 ]] && echo valid || echo invalid), got $([[ $got == 0 ]] && echo valid || echo invalid))" >&2
+            rc=1
+        fi
+    done
+    exit "$rc"
+fi
+
+if [[ "${1:-}" == "--jsonl" ]]; then
+    shift
+    if [[ $# -lt 1 ]]; then
+        echo "usage: $(basename "$0") --jsonl <ledger.jsonl> [...]" >&2
+        exit 2
+    fi
+    overall=0
+    for f in "$@"; do
+        if validate_jsonl "$f"; then
+            echo "PASS: $f"
+        else
+            echo "FAIL: $f (one or more events schema-invalid)" >&2
+            overall=1
+        fi
+    done
+    exit "$overall"
+fi
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: $(basename "$0") <event.json> [...] | --jsonl <ledger.jsonl> [...] | --selftest" >&2
+    exit 2
+fi
+
+overall=0
+for f in "$@"; do
+    if validate_one "$f"; then
+        echo "PASS: $f"
+    else
+        echo "FAIL: $f (schema-invalid)" >&2
+        overall=1
+    fi
+done
+exit "$overall"

--- a/tests/fixtures/provenance/invalid-missing-trust-tier.json
+++ b/tests/fixtures/provenance/invalid-missing-trust-tier.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "agentops-sdlc-provenance.v1",
+  "from_id": "ag-x31t.2",
+  "from_type": "decision",
+  "to_id": "schemas/agentops-sdlc-provenance.v1.schema.json",
+  "to_type": "artifact",
+  "relation": "decision_produces_artifact",
+  "evidence_ref": ".agents/council/2026-05-30-debate-provenance-substrate.md",
+  "ts": "2026-05-31T00:00:00Z",
+  "prev_hash": "",
+  "payload_hash": "cd137deeb225f94ee884b3703485a0effd56937b57f191a10981cc3cc4d4dcee",
+  "hash": "0e7224e46af26b3e7b35cfcad9b4bc9838629ae084e48fe024045ea51a5c9ada"
+}

--- a/tests/fixtures/provenance/valid-decision-produces-artifact.json
+++ b/tests/fixtures/provenance/valid-decision-produces-artifact.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "agentops-sdlc-provenance.v1",
+  "from_id": "ag-x31t.2",
+  "from_type": "decision",
+  "to_id": "schemas/agentops-sdlc-provenance.v1.schema.json",
+  "to_type": "artifact",
+  "relation": "decision_produces_artifact",
+  "evidence_ref": ".agents/council/2026-05-30-debate-provenance-substrate.md",
+  "trust_tier": "authored",
+  "ts": "2026-05-31T00:00:00Z",
+  "prev_hash": "",
+  "payload_hash": "cd137deeb225f94ee884b3703485a0effd56937b57f191a10981cc3cc4d4dcee",
+  "hash": "0e7224e46af26b3e7b35cfcad9b4bc9838629ae084e48fe024045ea51a5c9ada"
+}

--- a/tests/scripts/validate-provenance-ledger.bats
+++ b/tests/scripts/validate-provenance-ledger.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+# Acceptance surface for ag-x31t.2: the provenance ledger event contract +
+# schema (schemas/agentops-sdlc-provenance.v1.schema.json). The validator
+# enforces the committed JSON Schema over the tracked fixtures — a
+# decision_produces_artifact edge VALIDATES, and an otherwise-identical edge
+# missing trust_tier is REJECTED (the bead's named pass/fail case). Each event
+# is one line of the hash-chained audit ledger at docs/provenance/ledger.jsonl;
+# the committed ledger is the audit authority (council 2026-05-30).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/validate-provenance-ledger.sh"
+    SCHEMA="$REPO_ROOT/schemas/agentops-sdlc-provenance.v1.schema.json"
+    FIX="$REPO_ROOT/tests/fixtures/provenance"
+    if ! command -v python3 >/dev/null 2>&1 || ! python3 -c 'import jsonschema' >/dev/null 2>&1; then
+        HAVE_JSONSCHEMA=0
+    else
+        HAVE_JSONSCHEMA=1
+    fi
+}
+
+@test "validator and schema exist" {
+    [ -f "$SCRIPT" ]
+    [ -x "$SCRIPT" ]
+    [ -f "$SCHEMA" ]
+}
+
+@test "schema is valid JSON and forbids extra properties at the event level" {
+    run python3 -c "import json,sys; s=json.load(open('$SCHEMA')); sys.exit(0 if s.get('additionalProperties') is False else 1)"
+    [ "$status" -eq 0 ]
+}
+
+@test "schema requires the edge + hash-chain fields" {
+    run python3 -c "import json,sys; s=json.load(open('$SCHEMA')); req=set(s['required']); need={'from_id','from_type','to_id','to_type','relation','trust_tier','ts','prev_hash','payload_hash','hash'}; sys.exit(0 if need <= req else 1)"
+    [ "$status" -eq 0 ]
+}
+
+@test "trust_tier enum is exactly authored|inferred|mined" {
+    run python3 -c "import json,sys; s=json.load(open('$SCHEMA')); sys.exit(0 if sorted(s['properties']['trust_tier']['enum'])==['authored','inferred','mined'] else 1)"
+    [ "$status" -eq 0 ]
+}
+
+@test "decision_produces_artifact is a valid relation" {
+    run python3 -c "import json,sys; s=json.load(open('$SCHEMA')); sys.exit(0 if 'decision_produces_artifact' in s['\$defs']['relation']['enum'] else 1)"
+    [ "$status" -eq 0 ]
+}
+
+@test "fixtures exist (valid decision edge + invalid missing-trust_tier)" {
+    [ -f "$FIX/valid-decision-produces-artifact.json" ]
+    [ -f "$FIX/invalid-missing-trust-tier.json" ]
+}
+
+@test "selftest validates the fixtures pass/fail" {
+    if [ "$HAVE_JSONSCHEMA" -eq 0 ]; then skip "python3 jsonschema unavailable"; fi
+    run "$SCRIPT" --selftest
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS: valid-decision-produces-artifact.json"* ]]
+    [[ "$output" == *"PASS: invalid-missing-trust-tier.json"* ]]
+}
+
+@test "decision_produces_artifact edge validates" {
+    if [ "$HAVE_JSONSCHEMA" -eq 0 ]; then skip "python3 jsonschema unavailable"; fi
+    run "$SCRIPT" "$FIX/valid-decision-produces-artifact.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "an edge missing trust_tier is rejected" {
+    if [ "$HAVE_JSONSCHEMA" -eq 0 ]; then skip "python3 jsonschema unavailable"; fi
+    run "$SCRIPT" "$FIX/invalid-missing-trust-tier.json"
+    [ "$status" -ne 0 ]
+}
+
+@test "an edge with an unknown trust_tier value is rejected" {
+    if [ "$HAVE_JSONSCHEMA" -eq 0 ]; then skip "python3 jsonschema unavailable"; fi
+    tmp="$BATS_TEST_TMPDIR/badtier.json"
+    cat > "$tmp" <<'JSON'
+{"schema_version":"agentops-sdlc-provenance.v1","from_id":"ag-x31t.2","from_type":"decision","to_id":"schemas/x.json","to_type":"artifact","relation":"decision_produces_artifact","trust_tier":"guessed","ts":"2026-05-31T00:00:00Z","prev_hash":"","payload_hash":"cd137deeb225f94ee884b3703485a0effd56937b57f191a10981cc3cc4d4dcee","hash":"0e7224e46af26b3e7b35cfcad9b4bc9838629ae084e48fe024045ea51a5c9ada"}
+JSON
+    run "$SCRIPT" "$tmp"
+    [ "$status" -ne 0 ]
+}
+
+@test "an event carrying an unknown extra property is rejected" {
+    if [ "$HAVE_JSONSCHEMA" -eq 0 ]; then skip "python3 jsonschema unavailable"; fi
+    tmp="$BATS_TEST_TMPDIR/extra.json"
+    cat > "$tmp" <<'JSON'
+{"schema_version":"agentops-sdlc-provenance.v1","from_id":"ag-x31t.2","from_type":"decision","to_id":"schemas/x.json","to_type":"artifact","relation":"decision_produces_artifact","trust_tier":"authored","ts":"2026-05-31T00:00:00Z","prev_hash":"","payload_hash":"cd137deeb225f94ee884b3703485a0effd56937b57f191a10981cc3cc4d4dcee","hash":"0e7224e46af26b3e7b35cfcad9b4bc9838629ae084e48fe024045ea51a5c9ada","smuggled":"x"}
+JSON
+    run "$SCRIPT" "$tmp"
+    [ "$status" -ne 0 ]
+}
+
+@test "a non-hex hash is rejected (chain-field guard)" {
+    if [ "$HAVE_JSONSCHEMA" -eq 0 ]; then skip "python3 jsonschema unavailable"; fi
+    tmp="$BATS_TEST_TMPDIR/badhash.json"
+    cat > "$tmp" <<'JSON'
+{"schema_version":"agentops-sdlc-provenance.v1","from_id":"ag-x31t.2","from_type":"decision","to_id":"schemas/x.json","to_type":"artifact","relation":"decision_produces_artifact","trust_tier":"authored","ts":"2026-05-31T00:00:00Z","prev_hash":"","payload_hash":"not-a-sha","hash":"0e7224e46af26b3e7b35cfcad9b4bc9838629ae084e48fe024045ea51a5c9ada"}
+JSON
+    run "$SCRIPT" "$tmp"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## What

Adds `schemas/agentops-sdlc-provenance.v1.schema.json` — the JSON Schema (draft-07) that formally defines one event of the committed, per-record hash-chained provenance ledger at `docs/provenance/ledger.jsonl` (schema id `agentops-sdlc-provenance.v1`, referenced by CLAUDE.md and the ag-x31t council architecture).

Each event = one typed provenance edge `{from_id, from_type, to_id, to_type, relation, evidence_ref, trust_tier(authored|inferred|mined), ts}` plus export-time hash-chain fields `{prev_hash, payload_hash, hash}` mirroring `cli/internal/rpi/ledger.go` chaining semantics (`payload_hash` = sha256 over the edge payload; `hash` = sha256(payload_hash + "\n" + prev_hash)).

## Acceptance (ag-x31t.2)

> First failing test: validates a `decision_produces_artifact` edge, rejects one missing `trust_tier`.

- `scripts/validate-provenance-ledger.sh` — python `jsonschema` (Draft7) validator with `--selftest` and `--jsonl` modes, mirroring `validate-outcomes-rubric.sh`; SKIPs gracefully when jsonschema is unavailable.
- `tests/scripts/validate-provenance-ledger.bats` — 12 checks. A `decision_produces_artifact` edge VALIDATES; an otherwise-identical edge missing `trust_tier` is REJECTED. Structural-JSON checks are the always-on guard (run without jsonschema).
- `tests/fixtures/provenance/{valid-decision-produces-artifact,invalid-missing-trust-tier}.json` — fixtures with real sha256 chain hashes.

TDD verified: the selftest FAILS when the schema is edited to drop the `trust_tier` requirement, PASSES when restored.

## Scope

Schema + validator + test only. Does **not** create/edit `docs/provenance/ledger.jsonl`, the write-model (ag-x31t.4), export (ag-x31t.5), or gate (ag-x31t.6). No symlinks. No holdout data.

```
gates: validator --selftest pass · bats 12/12 pass
```

Closes-scenario: ag-x31t.2#provenance-schema
Bounded-context: BC4-Factory
Evidence: schemas/agentops-sdlc-provenance.v1.schema.json