### PR TITLE
fix(ci): cover gate-target files in path filters (ag-nl1u #pathfilter-coverage)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,6 +37,7 @@ jobs:
       bats: ${{ steps.release.outputs.release == 'true' || steps.filter.outputs.bats }}
       ci: ${{ steps.release.outputs.release == 'true' || steps.filter.outputs.ci }}
       contracts: ${{ steps.release.outputs.release == 'true' || steps.filter.outputs.contracts }}
+      goals: ${{ steps.release.outputs.release == 'true' || steps.filter.outputs.goals }}
       learning: ${{ steps.release.outputs.release == 'true' || steps.filter.outputs.learning }}
       markdown: ${{ steps.release.outputs.release == 'true' || steps.filter.outputs.markdown }}
     steps:
@@ -92,6 +93,32 @@ jobs:
             contracts:
               - 'schemas/**'
               - 'docs/contracts/**'
+              # redteam-pack target globs (ag-nl1u): every file the
+              # security-suite redteam pack
+              # (skills/security-suite/references/agentops-redteam-pack.json)
+              # asserts behavioral contracts against MUST re-run the
+              # contracts-sync canaries when edited — otherwise a break to a
+              # guarded file lands without the canary that guards it (the #634
+              # regression). The guard test
+              # tests/scripts/test-pathfilter-gate-coverage.sh asserts this
+              # list stays a superset of the pack's target globs.
+              - 'AGENTS.md'
+              - 'docs/ARCHITECTURE.md'
+              - 'docs/CI-CD.md'
+              - 'docs/strategic-direction.md'
+              - 'docs/standards/shell-script-standards.md'
+              - 'skills/security/**'
+              - 'skills/security-suite/**'
+            goals:
+              # correctness/doctrine gates that police GOALS.md + the executable
+              # spec scenarios (ag-n4m7): a GOALS.md-only or scenario-only edit
+              # must trigger the directive↔scenario link gates, which previously
+              # ran only on go/docs/ci and silently SKIPPED on these paths (the
+              # #591/#593 phantom-scenario regression). docs/** already covers
+              # the ADR; GOALS.md + spec/scenarios/** are added explicitly here.
+              - 'GOALS.md'
+              - 'spec/scenarios/**'
+              - 'docs/adr/ADR-0003*'
             learning:
               - '.agents/learnings/**'
             markdown:
@@ -1025,7 +1052,7 @@ jobs:
       needs.changes.outputs.hooks == 'true' || needs.changes.outputs.shell == 'true' ||
       needs.changes.outputs.eval == 'true' || needs.changes.outputs.ci == 'true' ||
       needs.changes.outputs.docs == 'true' || needs.changes.outputs.contracts == 'true' ||
-      needs.changes.outputs.learning == 'true'
+      needs.changes.outputs.learning == 'true' || needs.changes.outputs.goals == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -1036,14 +1063,14 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        if: needs.changes.outputs.go == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.hooks == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.eval == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true'
+        if: needs.changes.outputs.go == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.hooks == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.eval == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.goals == 'true'
         uses: actions/setup-go@v6
         with:
           go-version: '1.26.3'
           cache-dependency-path: cli/go.sum
 
       - name: Build ao binary
-        if: needs.changes.outputs.go == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.hooks == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.eval == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true'
+        if: needs.changes.outputs.go == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.hooks == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.eval == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.goals == 'true'
         run: |
           cd cli && go build -o bin/ao ./cmd/ao
 
@@ -1060,18 +1087,18 @@ jobs:
           ./scripts/check-flywheel-compounding-snapshot.sh
 
       - name: Validate GOALS.md structure (GOALS.md gate id goals-validate, weight 5)
-        if: needs.changes.outputs.go == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true'
+        if: needs.changes.outputs.go == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.goals == 'true'
         run: |
           cli/bin/ao goals validate --json | jq -e '.valid == true'
 
       - name: F1 executable-spec link e2e (epic soc-58nt)
-        if: needs.changes.outputs.go == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true'
+        if: needs.changes.outputs.go == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.goals == 'true'
         run: |
           chmod +x tests/e2e/goals-scenarios-link.sh
           bash tests/e2e/goals-scenarios-link.sh
 
       - name: F2 scenario-satisfaction gate e2e (epic soc-58nt)
-        if: needs.changes.outputs.go == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true'
+        if: needs.changes.outputs.go == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.goals == 'true'
         run: |
           chmod +x tests/e2e/goals-measure-scenarios.sh
           bash tests/e2e/goals-measure-scenarios.sh
@@ -1171,13 +1198,13 @@ jobs:
         # T1 (≤5min). Blocking (soc-x7y9f): the directive↔scenario link lint
         # fails the job on any broken edge. The broader whole-chain orphan/gap
         # audit (ao goals trace --orphans) stays warn-only below.
-        if: needs.changes.outputs.go == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true'
+        if: needs.changes.outputs.go == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.goals == 'true'
         run: |
           echo "=== ao goals scenarios --lint ==="
           cli/bin/ao goals scenarios --lint
 
       - name: Whole-chain orphan/gap audit (ao goals trace --orphans, warn-only)
-        if: needs.changes.outputs.go == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true'
+        if: needs.changes.outputs.go == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.goals == 'true'
         run: |
           echo "=== ao goals trace --orphans ==="
           cli/bin/ao goals trace --orphans || echo "WARN: trace --orphans found issues (warn-only, F1.6 / soc-58nt.1.9; out of soc-x7y9f scope, tracked under soc-gqhrz)"
@@ -1185,7 +1212,7 @@ jobs:
       - name: Scenario→test linkage gate (scripts/check-scenario-test-linkage.sh)
         # T1 (≤5min, soc-63xfx). Every Gherkin Scenario in skills/*/references/*.feature
         # must carry a @covered-by:<test-path> tag OR be allowlisted (doc-only).
-        if: needs.changes.outputs.skills == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.ci == 'true'
+        if: needs.changes.outputs.skills == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.goals == 'true'
         run: |
           chmod +x scripts/check-scenario-test-linkage.sh
           ./scripts/check-scenario-test-linkage.sh

--- a/tests/scripts/test-pathfilter-gate-coverage.bats
+++ b/tests/scripts/test-pathfilter-gate-coverage.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+#
+# Drift-blocking test for the path-filter <-> gate coverage invariant in
+# .github/workflows/validate.yml. A correctness/contract gate that reads a
+# specific set of files MUST be triggered by a change-filter that covers those
+# files; otherwise an edit to a guarded file SKIPS the very gate that guards it,
+# and `summary` (a required branch-protection check) goes green-but-incomplete.
+#
+# Two concrete gaps this guards (both real regressions):
+#
+#  ag-nl1u (#634): the security-suite redteam pack
+#    (skills/security-suite/references/agentops-redteam-pack.json) asserts
+#    behavioral contracts against AGENTS.md + several docs/ + skills/security*
+#    files via the contracts-sync canaries. The `contracts` filter previously
+#    only matched schemas/** + docs/contracts/**, so editing a guarded file
+#    skipped the canary that guards it. INVARIANT: every redteam-pack target
+#    glob must be covered by the `contracts` filter.
+#
+#  ag-n4m7 (#591/#593): the directive<->scenario correctness gates police
+#    GOALS.md + spec/scenarios/**, but ran only on go/docs/ci -> a GOALS.md-only
+#    edit citing a phantom scenario merged with the gate SKIPPED. INVARIANT: a
+#    `goals` filter exists (GOALS.md + spec/scenarios/**) and the spec-link
+#    gates trigger on it.
+#
+# Sibling pattern: tests/scripts/test-bats-path-filter-wiring.bats — grep/parse
+# the artifact-under-test and assert the expected wiring is present.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    WORKFLOW_PATH="$REPO_ROOT/.github/workflows/validate.yml"
+    PACK_PATH="$REPO_ROOT/skills/security-suite/references/agentops-redteam-pack.json"
+}
+
+# ── ag-nl1u: redteam-pack targets are all covered by the `contracts` filter ──
+
+@test "contracts filter is a superset of every redteam-pack target glob" {
+    run python3 - "$WORKFLOW_PATH" "$PACK_PATH" <<'PY'
+import json, sys, fnmatch, yaml
+
+workflow_path, pack_path = sys.argv[1], sys.argv[2]
+
+with open(pack_path) as f:
+    pack = json.load(f)
+targets = set()
+for case in pack.get("cases", []):
+    for tgt in case.get("targets", []):
+        for g in tgt.get("globs", []):
+            targets.add(g)
+
+with open(workflow_path) as f:
+    doc = yaml.safe_load(f)
+filt_step = next(
+    s for s in doc["jobs"]["changes"]["steps"] if s.get("id") == "filter"
+)
+filters = yaml.safe_load(filt_step["with"]["filters"])
+contracts = filters["contracts"]
+
+def covered(target, patterns):
+    # A pack target is covered if some contracts glob equals it OR a
+    # directory-glob pattern (foo/**) is a prefix of the target path.
+    for p in patterns:
+        if p == target:
+            return True
+        if p.endswith("/**"):
+            base = p[:-3]
+            if target == base or target.startswith(base + "/"):
+                return True
+        if fnmatch.fnmatch(target, p):
+            return True
+    return False
+
+uncovered = sorted(t for t in targets if not covered(t, contracts))
+if uncovered:
+    print("UNCOVERED redteam-pack targets:", uncovered)
+    sys.exit(1)
+print("ok: all redteam-pack targets covered by contracts filter:", sorted(targets))
+PY
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok: all redteam-pack targets covered"* ]]
+}
+
+@test "contracts-sync job triggers on needs.changes.outputs.contracts" {
+    run bash -c "awk '/^  contracts-sync:/{inblock=1} inblock && /needs.changes.outputs.contracts/{print; exit}' '$WORKFLOW_PATH'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"needs.changes.outputs.contracts"* ]]
+}
+
+# ── ag-n4m7: a `goals` filter exists and the spec-link gates trigger on it ──
+
+@test "validate.yml declares a goals: filter under the changes job" {
+    run grep -E "^            goals:" "$WORKFLOW_PATH"
+    [ "$status" -eq 0 ]
+}
+
+@test "goals filter covers GOALS.md and spec/scenarios" {
+    run python3 - "$WORKFLOW_PATH" <<'PY'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    doc = yaml.safe_load(f)
+filt_step = next(
+    s for s in doc["jobs"]["changes"]["steps"] if s.get("id") == "filter"
+)
+filters = yaml.safe_load(filt_step["with"]["filters"])
+goals = filters.get("goals", [])
+required = {"GOALS.md", "spec/scenarios/**"}
+missing = sorted(required - set(goals))
+if missing:
+    print("MISSING goals globs:", missing)
+    sys.exit(1)
+print("ok: goals filter covers", sorted(goals))
+PY
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok: goals filter covers"* ]]
+}
+
+@test "changes job exposes goals output" {
+    run grep -F "      goals: \${{ steps.release.outputs.release == 'true' || steps.filter.outputs.goals }}" "$WORKFLOW_PATH"
+    [ "$status" -eq 0 ]
+}
+
+@test "directive-to-scenario link lint triggers on needs.changes.outputs.goals" {
+    run bash -c "awk '/name: Directive-to-scenario link lint/{inblock=1} inblock && /^        if:/{print; exit}' '$WORKFLOW_PATH'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"needs.changes.outputs.goals == 'true'"* ]]
+}
+
+@test "scenario-test linkage gate triggers on needs.changes.outputs.goals" {
+    run bash -c "awk '/name: Scenario.*linkage gate/{inblock=1} inblock && /^        if:/{print; exit}' '$WORKFLOW_PATH'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"needs.changes.outputs.goals == 'true'"* ]]
+}


### PR DESCRIPTION
## What

Closes both **ag-nl1u** and **ag-n4m7** — same class of bug (CI path-filter gap) on the same surface (`.github/workflows/validate.yml`), folded into one coherent-arc PR so they don't collide.

A gate that reads a specific set of files must be triggered by a change-filter covering those files. When it isn't, an edit to a guarded file SKIPS the gate that guards it, and the required `summary` branch-protection check goes green-but-incomplete — the regression reaches `main` and surfaces only on a later unrelated PR.

### ag-nl1u — contracts filter omits redteam-pack targets (#634)
The security-suite redteam pack (`skills/security-suite/references/agentops-redteam-pack.json`) asserts behavioral contracts against `AGENTS.md`, `docs/ARCHITECTURE.md`, `docs/CI-CD.md`, `docs/strategic-direction.md`, `docs/standards/shell-script-standards.md`, `skills/security/SKILL.md`, `skills/security-suite/SKILL.md`. The `contracts` filter only matched `schemas/**` + `docs/contracts/**`, so editing any guarded file skipped the contracts-sync canaries that guard it (the #634 break, fixed reactively). **Fix:** extend `contracts` to a superset of every redteam-pack target glob.

### ag-n4m7 — correctness gates skip on GOALS.md/scenarios (#591/#593)
The directive-to-scenario correctness gates police `GOALS.md` + `spec/scenarios/**` but ran only on `go || docs || ci`. A GOALS.md-only edit citing a phantom scenario merged with the gate skipped. **Fix:** add a `goals` filter (`GOALS.md`, `spec/scenarios/**`, `docs/adr/ADR-0003*`) and wire `|| needs.changes.outputs.goals` into goals-validate, F1/F2 spec-link e2e, directive-to-scenario lint, trace-orphans, scenario-to-test linkage (and the Go setup/build steps those depend on, since they invoke `cli/bin/ao`).

## Guard test
`tests/scripts/test-pathfilter-gate-coverage.bats` (7 tests) parses the pack JSON + the validate.yml filters and asserts the `contracts` filter is a superset of the pack targets and the `goals` filter + gate wiring stay in place. Prevents this class from regressing.

## Verification
- `python3 + PyYAML` parse of validate.yml: valid; both filters present.
- `bats tests/scripts/test-pathfilter-gate-coverage.bats` -> 7/7 pass.
- `scripts/validate-ci-policy-parity.sh` -> PASS (job blocking classification unchanged).
- Sibling `test-bats-path-filter-wiring.bats` + `test-strict-coverage-ci-wiring.bats` -> 8/8 pass (no regression).

## Scope
Only `.github/workflows/validate.yml` + one new guard test under `tests/`. No other surface touched.

Closes-scenario: ag-nl1u#pathfilter-coverage
Bounded-context: BC2-Validation
Evidence: .github/workflows/validate.yml