### PR TITLE
feat(skills): discovery+plan emit Gherkin scenarios by default (ag-9jle.2 #scenarios-by-default)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -775,8 +775,8 @@
     {
       "name": "discovery",
       "source_skill": "skills/discovery",
-      "source_hash": "da99e855580351e6dc3155cf73b6e5669eb70d6774ca55f624cb7f84785f46fe",
-      "generated_hash": "6c307529f6519b93745a4f410641b4991c0676a5f564de7f2b53d8d9cffe6b48"
+      "source_hash": "b9db5932d003bfc3d015a5c9ccd01d62284c68f2e106850d5dc9a71c473386d9",
+      "generated_hash": "279fece7b28692dc9be477ea7adbaad390ad6c7e976959fc3c1a97de59882004"
     },
     {
       "name": "doc",
@@ -901,8 +901,8 @@
     {
       "name": "plan",
       "source_skill": "skills/plan",
-      "source_hash": "1bcc4c2f196a0b9257bb3a5a19bb3aaddef6c4e184000444e113ce28f4da1a99",
-      "generated_hash": "f6395785b5ce80bcfc621358a7f223632363d64387afcc76b3dcfeb8067e6f04"
+      "source_hash": "a5892f446e959fe8e08eea92432b99da6c2474986849dfab4a16c0b6c74e598c",
+      "generated_hash": "d988d0f966aaccacd94b0a0a9eb9dc5e3ecc27648a8805d1569059d4c2c1c063"
     },
     {
       "name": "post-mortem",

--- a/skills-codex/discovery/.agentops-generated.json
+++ b/skills-codex/discovery/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/discovery",
   "layout": "modular",
-  "source_hash": "da99e855580351e6dc3155cf73b6e5669eb70d6774ca55f624cb7f84785f46fe",
-  "generated_hash": "6c307529f6519b93745a4f410641b4991c0676a5f564de7f2b53d8d9cffe6b48"
+  "source_hash": "b9db5932d003bfc3d015a5c9ccd01d62284c68f2e106850d5dc9a71c473386d9",
+  "generated_hash": "279fece7b28692dc9be477ea7adbaad390ad6c7e976959fc3c1a97de59882004"
 }

--- a/skills-codex/discovery/references/dag.md
+++ b/skills-codex/discovery/references/dag.md
@@ -124,12 +124,19 @@ The plan artifact is the source of slice detail. Discovery extracts only:
 - `plan_path`
 - `epic_id` when one exists
 - issue count and wave count
+- the `## Scenarios` Gherkin block per bead
 - acceptance criteria YAML fences
 - next `$crank` target
 
-The plan output MUST include `acceptance_criteria` fenced YAML at two levels:
-the parent epic body and each child bead body. Criterion shape is canonical in
-`schemas/execution-packet.schema.json` (`#/$defs/Criterion`).
+Every bead `$plan` emits MUST carry an embedded `## Scenarios` Gherkin block
+(Given/When/Then) by default — this is the behavior layer and is non-optional.
+Free-text-only acceptance is invalid (AGENTS.md). The plan output MUST also
+include `acceptance_criteria` fenced YAML at two levels (the machine-checkable
+layer): the parent epic body and each child bead body. Criterion shape is
+canonical in `schemas/execution-packet.schema.json` (`#/$defs/Criterion`).
+Discovery does NOT relax this requirement; if a returned bead lacks a
+`## Scenarios` block, send it back to `$plan` to be promoted before compiling
+the packet.
 
 ### STEP 4.5 - Optional Scaffold
 
@@ -177,9 +184,15 @@ Emit:
 
 ## Acceptance Criteria Contract
 
-Both the epic and each child bead carry an `acceptance_criteria` fenced YAML
-block. STEP 6 lifts these into the execution packet as `epic_criteria` and
-`bead_criteria`.
+Both the epic and each child bead carry, by default:
+
+1. An embedded `## Scenarios` Gherkin block (Given/When/Then) — the behavior
+   layer, mandatory and non-optional for every bead.
+2. An `acceptance_criteria` fenced YAML block — the machine-checkable layer.
+
+STEP 6 lifts the criteria into the execution packet as `epic_criteria` and
+`bead_criteria`. The `## Scenarios` block stays in the bead body and feeds the
+`scenario-hash-stability` CI gate.
 
 ```yaml
 acceptance_criteria:

--- a/skills-codex/plan/.agentops-generated.json
+++ b/skills-codex/plan/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/plan",
   "layout": "modular",
-  "source_hash": "1bcc4c2f196a0b9257bb3a5a19bb3aaddef6c4e184000444e113ce28f4da1a99",
-  "generated_hash": "f6395785b5ce80bcfc621358a7f223632363d64387afcc76b3dcfeb8067e6f04"
+  "source_hash": "a5892f446e959fe8e08eea92432b99da6c2474986849dfab4a16c0b6c74e598c",
+  "generated_hash": "d988d0f966aaccacd94b0a0a9eb9dc5e3ecc27648a8805d1569059d4c2c1c063"
 }

--- a/skills-codex/plan/SKILL.md
+++ b/skills-codex/plan/SKILL.md
@@ -80,11 +80,15 @@ Feature: Plan converts dense intent into executable slices
 8. **Decompose into issues.** Each issue needs title, file ownership,
    dependencies, acceptance criteria, test levels, and at least one mechanical
    conformance check (`files_exist`, `content_check`, `command`, `tests`, or
-   `lint`). Feature, bug, and product-facing behavior issues also need a
-   fenced `gherkin` block or a link to the upstream intent issue scenario.
-   Non-trivial plans and bead bodies should include the `hexagon:` boundary
-   block: inbound port, bounded context, adapters, context packet, and done
-   state.
+   `lint`). **Every bead MUST also carry an embedded `## Scenarios` Gherkin
+   block (Given/When/Then) — by default, without being asked.** Free-text-only
+   acceptance is invalid (AGENTS.md); promote any free text to scenarios before
+   creating the bead. The `## Scenarios` block is the behavior layer and sits
+   above the `acceptance_criteria` YAML (the machine-checkable layer); they are
+   complementary, never substitutes. One scenario per distinct Given/When/Then
+   behavior. Non-trivial plans and bead bodies should include the `hexagon:`
+   boundary block: inbound port, bounded context, adapters, context packet, and
+   done state.
 9. **Compute waves.** Group independent issues by dependency. Serialize or
    merge same-file writes. Include generated artifacts, docs, schemas, fixtures,
    Codex companions, manifests, and hash markers in ownership.

--- a/skills-codex/plan/references/decomposition.md
+++ b/skills-codex/plan/references/decomposition.md
@@ -9,6 +9,7 @@ Before finalizing issue decomposition, verify the plan avoids these confirmed fa
 
 | Anti-Pattern | Detection Question | Gate |
 |---|---|---|
+| **Free-text-only acceptance** | Does every bead carry an embedded `## Scenarios` Gherkin block by default? | FAIL if any bead ships free-text-only acceptance with no `## Scenarios` (Given/When/Then) block — promote it to scenarios before creating the bead |
 | **Brainstorm masquerading as plan** | Does every issue have mechanically verifiable acceptance criteria? | FAIL if any issue lacks `files_exist`, `content_check`, `tests`, or `command` conformance checks |
 | **Dead infrastructure** | Does the plan provision anything without an activation test? | WARN if infrastructure is created without a corresponding smoke test issue |
 | **Propagation surface blindness** | Has the full propagation surface been enumerated for renames/refactors? | FAIL if structural changes lack a propagation surface table |

--- a/skills/discovery/references/dag.md
+++ b/skills/discovery/references/dag.md
@@ -135,12 +135,19 @@ The plan artifact is the source of slice detail. Discovery extracts only:
 - `plan_path`
 - `epic_id` when one exists
 - issue count and wave count
+- the `## Scenarios` Gherkin block per bead
 - acceptance criteria YAML fences
 - next `/crank` target
 
-The plan output MUST include `acceptance_criteria` fenced YAML at two levels:
-the parent epic body and each child bead body. Criterion shape is canonical in
-`schemas/execution-packet.schema.json` (`#/$defs/Criterion`).
+Every bead `/plan` emits MUST carry an embedded `## Scenarios` Gherkin block
+(Given/When/Then) by default — this is the behavior layer and is non-optional.
+Free-text-only acceptance is invalid (AGENTS.md). The plan output MUST also
+include `acceptance_criteria` fenced YAML at two levels (the machine-checkable
+layer): the parent epic body and each child bead body. Criterion shape is
+canonical in `schemas/execution-packet.schema.json` (`#/$defs/Criterion`).
+Discovery does NOT relax this requirement; if a returned bead lacks a
+`## Scenarios` block, send it back to `/plan` to be promoted before compiling
+the packet.
 
 ### STEP 4.5 - Optional Scaffold
 
@@ -195,9 +202,15 @@ Emit:
 
 ## Acceptance Criteria Contract
 
-Both the epic and each child bead carry an `acceptance_criteria` fenced YAML
-block. STEP 6 lifts these into the execution packet as `epic_criteria` and
-`bead_criteria`.
+Both the epic and each child bead carry, by default:
+
+1. An embedded `## Scenarios` Gherkin block (Given/When/Then) — the behavior
+   layer, mandatory and non-optional for every bead.
+2. An `acceptance_criteria` fenced YAML block — the machine-checkable layer.
+
+STEP 6 lifts the criteria into the execution packet as `epic_criteria` and
+`bead_criteria`. The `## Scenarios` block stays in the bead body and feeds the
+`scenario-hash-stability` CI gate.
 
 ```yaml
 acceptance_criteria:

--- a/skills/discovery/references/discovery.feature
+++ b/skills/discovery/references/discovery.feature
@@ -20,6 +20,13 @@ Feature: Discovery hands dense intent to planning
     Then it writes a JSON execution packet on disk for the next loop phase
     And the packet carries the goal, research, and design artifact references
 
+  # Gherkin acceptance is emitted by default — the operator never hand-specifies BDD (ag-9jle.2).
+  Scenario: Discovery requires every planned bead to carry Gherkin scenarios by default
+    Given Discovery crosses the plan_slices port to /plan
+    When /plan returns beads at STEP 4
+    Then every bead carries an embedded ## Scenarios (Given/When/Then) block
+    And Discovery sends any bead with free-text-only acceptance back to /plan before compiling the packet
+
   # Open-ended path — generate-winnow → operationalize → refine (ag-yw0).
   # Additive to the default flow above; strict delegation is preserved.
   # Documentation-only spec (this file is allowlisted in

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -167,16 +167,41 @@ Analyze the goal and break it into discrete, implementable issues. For each issu
 - **Title**: Clear action verb (e.g., "Add authentication middleware")
 - **Description**: What needs to be done
 - **Dependencies**: Which issues must complete first (if any)
+- **Scenarios**: A Gherkin `## Scenarios` block (Given/When/Then) — **mandatory by default** for every bead (see Scenarios contract below)
 - **Acceptance criteria**: How to verify it's done — emitted as a fenced YAML `acceptance_criteria` block (see contract below)
 - **Test levels**: Which pyramid levels (L0–L3) this issue's tests cover
 
+#### Gherkin Scenarios Contract (mandatory, default)
+
+**Every bead this skill creates MUST carry an embedded `## Scenarios` block in Gherkin (Given/When/Then) — by default, without being asked.** Free-text-only acceptance is invalid (AGENTS.md: "Free-text acceptance is invalid — promote it to scenarios before work begins"). The operator never hand-specifies BDD: planning emits behavior-based acceptance as scenarios automatically.
+
+Each bead body (and the parent epic body) carries a `## Scenarios` block of one or more scenarios:
+
+```markdown
+## Scenarios
+Scenario: <behavior named as an observable outcome>
+  Given <precondition / starting state>
+  When <action / event>
+  Then <expected observable result>
+  And <additional assertion>   # optional
+```
+
+Rules:
+- One scenario per distinct Given/When/Then behavior; a bead with N behaviors carries N scenarios.
+- Scenarios describe **observable behavior**, not implementation steps.
+- The `## Scenarios` block sits in the bead description ABOVE the `acceptance_criteria` YAML; the YAML is the machine-checkable layer, Gherkin is the behavior layer (they are complementary, not substitutes).
+- A bead emitted without a `## Scenarios` block is a contract violation — promote any free-text acceptance to scenarios before creating the bead.
+
+This is the same `## Scenarios` block the bead-embedded acceptance model expects (`scenario-hash-stability` CI gate) and that `/discovery` lifts into the execution packet.
+
 #### Acceptance Criteria Contract (mandatory)
 
-Every issue body MUST contain an `acceptance_criteria` fenced YAML block. The block lives BELOW the issue's textual description and ABOVE any "Reference" or "Notes" trailer. The parent epic body carries its own `acceptance_criteria` block (epic-level criteria); each child bead carries its own. `/discovery` STEP 6 lifts both into the execution packet under `epic_criteria` and `bead_criteria`. Canonical shape: [`schemas/execution-packet.schema.json`](../../schemas/execution-packet.schema.json) (`#/$defs/Criterion`).
+Every issue body MUST contain an `acceptance_criteria` fenced YAML block. The block lives BELOW the issue's `## Scenarios` block and ABOVE any "Reference" or "Notes" trailer. The parent epic body carries its own `acceptance_criteria` block (epic-level criteria); each child bead carries its own. `/discovery` STEP 6 lifts both into the execution packet under `epic_criteria` and `bead_criteria`. Canonical shape: [`schemas/execution-packet.schema.json`](../../schemas/execution-packet.schema.json) (`#/$defs/Criterion`).
 
-Every feature, bug, or product-facing behavior issue MUST also carry either a
-fenced `gherkin` block or a link to the upstream intent issue scenario it
-implements. Every non-trivial plan and bead body SHOULD include the `hexagon:`
+The `## Scenarios` Gherkin block above is the behavior layer and is mandatory by
+default for every bead; the `acceptance_criteria` YAML is the machine-checkable
+layer. They are complementary, never substitutes. Every non-trivial plan and
+bead body SHOULD also include the `hexagon:`
 boundary block from `docs/architecture/intent-to-loop-hexagon.md` so the next
 agent knows the inbound port, bounded context, adapters, context packet, and
 done state.

--- a/skills/plan/references/decomposition.md
+++ b/skills/plan/references/decomposition.md
@@ -9,6 +9,7 @@ Before finalizing issue decomposition, verify the plan avoids these confirmed fa
 
 | Anti-Pattern | Detection Question | Gate |
 |---|---|---|
+| **Free-text-only acceptance** | Does every bead carry an embedded `## Scenarios` Gherkin block by default? | FAIL if any bead ships free-text-only acceptance with no `## Scenarios` (Given/When/Then) block — promote it to scenarios before creating the bead |
 | **Brainstorm masquerading as plan** | Does every issue have mechanically verifiable acceptance criteria? | FAIL if any issue lacks `files_exist`, `content_check`, `tests`, or `command` conformance checks |
 | **Dead infrastructure** | Does the plan provision anything without an activation test? | WARN if infrastructure is created without a corresponding smoke test issue |
 | **Propagation surface blindness** | Has the full propagation surface been enumerated for renames/refactors? | FAIL if structural changes lack a propagation surface table |

--- a/skills/plan/references/plan.feature
+++ b/skills/plan/references/plan.feature
@@ -33,3 +33,11 @@ Feature: Plan converts dense intent into executable slices
   Scenario: Plan produces a durable slice-validation artifact
     Then Plan writes a slice plan to .agents/plans/*.md and an execution-packet.json
     And a fresh agent can execute the slices from those artifacts alone
+
+  # Gherkin acceptance is emitted by default — the operator never hand-specifies BDD (ag-9jle.2).
+  Scenario: Every emitted bead carries a Gherkin Scenarios block by default
+    Given Plan decomposing a goal into beads
+    When a bead is created without the operator asking for BDD
+    Then the bead body carries an embedded ## Scenarios (Given/When/Then) block
+    And it never ships free-text-only acceptance
+    And the ## Scenarios block sits above the acceptance_criteria YAML as the behavior layer


### PR DESCRIPTION
## What

Makes `/discovery` and `/plan` emit an embedded `## Scenarios` (Given/When/Then) Gherkin block per bead **by default** — the operator never hand-specifies BDD. Free-text-only acceptance is a contract violation; planning promotes it to scenarios automatically before creating the bead.

Implements `ag-9jle.2`, a child of the BDD-Gherkin-wave core-loop epic `ag-9jle`.

## Changes

- **`skills/plan/SKILL.md`** — new "Gherkin Scenarios Contract (mandatory, default)": every bead carries a `## Scenarios` block above the `acceptance_criteria` YAML; Gherkin is the behavior layer, YAML the machine-checkable layer (complementary, not substitutes).
- **`skills/discovery/references/dag.md`** STEP 4 + Acceptance Criteria Contract — every bead `/plan` returns MUST carry `## Scenarios`; discovery sends free-text-only beads back to `/plan` before compiling the execution packet.
- **`skills/plan/references/decomposition.md`** — new "Free-text-only acceptance" anti-pattern (FAIL gate) in the decomposition pre-flight table.
- **`discovery.feature` + `plan.feature`** — scenarios-by-default executable specs (documentation-only, allowlisted).
- Mirrored to the **skills-codex** twins (dag.md, SKILL.md, decomposition.md); regenerated discovery + plan codex hashes (manifest + per-skill markers).

## Gates

- `tests/skills/run-all.sh` — 87/87 PASS
- `scripts/audit-codex-parity.py --skill discovery --skill plan` — passed
- `tests/skills/lint-skills.sh` — discovery + plan PASS (81 skills, 0 failed)
- `scripts/validate-codex-generated-artifacts.sh` — passed
- `scripts/check-scenario-test-linkage.sh` — PASS

Diff scope is limited to `skills/{discovery,plan}`, their `skills-codex` twins, and the codex hash manifest. Pre-existing codex hash drift in 7 unrelated skills was left untouched.

Closes-scenario: ag-9jle.2#scenarios-by-default
Bounded-context: BC3-Loop
Evidence: skills/plan/SKILL.md