### PR TITLE
feat(skills): queryable skill catalog JSON + ao skills (soc-vuu6.4 #skill-catalog-json)

### DIFF
--- a/cli/cmd/ao/skills_query.go
+++ b/cli/cmd/ao/skills_query.go
@@ -1,0 +1,206 @@
+// practices: [design-by-contract, code-complete]
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/boshu2/agentops/cli/internal/skills"
+)
+
+var (
+	skillsListJSON          bool
+	skillsListRole          string
+	skillsListProduces      string
+	skillsListConsumes      string
+	skillsListPractice      string
+	skillsListUserInvocable string // tri-state: "", "true", "false"
+
+	skillsConsumersJSON bool
+	skillsProducersJSON bool
+
+	skillsGraphFormat string
+)
+
+var skillsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Query the generated skill catalog (skills/catalog.json)",
+	Long: `Filter the generated skill catalog by hexagonal role, produced or
+consumed port, declared practice, or user-invocability. Reads
+skills/catalog.json (emitted by scripts/generate-skill-catalog.sh and kept
+in sync by CI), so queries are fast and never re-parse SKILL.md frontmatter.
+
+Examples:
+  ao skills list --role domain
+  ao skills list --produces verdict-ledger --json
+  ao skills list --practice tdd --user-invocable true`,
+	RunE: runSkillsList,
+}
+
+var skillsConsumersCmd = &cobra.Command{
+	Use:   "consumers <skill>",
+	Short: "List skills that consume the named skill",
+	Long: `Print the skills whose consumes[] list includes <skill> — i.e. who
+depends on it. Reads skills/catalog.json.
+
+Examples:
+  ao skills consumers rpi
+  ao skills consumers discovery --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSkillsConsumers,
+}
+
+var skillsProducersCmd = &cobra.Command{
+	Use:   "producers <output>",
+	Short: "List skills that produce the named port/artifact",
+	Long: `Print the skills whose produces[] list includes <output> — i.e. who
+writes that port or artifact. Reads skills/catalog.json.
+
+Examples:
+  ao skills producers verdict-ledger
+  ao skills producers handoff --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSkillsProducers,
+}
+
+var skillsGraphCmd = &cobra.Command{
+	Use:   "graph",
+	Short: "Render the skill consumes-graph",
+	Long: `Render the skill dependency graph (A --> B means A consumes B) from
+skills/catalog.json. Only the Mermaid flowchart format is supported.
+
+Examples:
+  ao skills graph
+  ao skills graph --format mermaid`,
+	RunE: runSkillsGraph,
+}
+
+func init() {
+	skillsCmd.AddCommand(skillsListCmd)
+	skillsCmd.AddCommand(skillsConsumersCmd)
+	skillsCmd.AddCommand(skillsProducersCmd)
+	skillsCmd.AddCommand(skillsGraphCmd)
+
+	skillsListCmd.Flags().BoolVar(&skillsListJSON, "json", false, "Emit machine-readable JSON")
+	skillsListCmd.Flags().StringVar(&skillsListRole, "role", "", "Filter by hexagonal_role (domain, driving-adapter, ...)")
+	skillsListCmd.Flags().StringVar(&skillsListProduces, "produces", "", "Filter to skills that produce this port/artifact")
+	skillsListCmd.Flags().StringVar(&skillsListConsumes, "consumes", "", "Filter to skills that consume this port/sibling")
+	skillsListCmd.Flags().StringVar(&skillsListPractice, "practice", "", "Filter to skills that apply this practice")
+	skillsListCmd.Flags().StringVar(&skillsListUserInvocable, "user-invocable", "", "Filter by user-invocability (true|false)")
+
+	skillsConsumersCmd.Flags().BoolVar(&skillsConsumersJSON, "json", false, "Emit machine-readable JSON")
+	skillsProducersCmd.Flags().BoolVar(&skillsProducersJSON, "json", false, "Emit machine-readable JSON")
+
+	skillsGraphCmd.Flags().StringVar(&skillsGraphFormat, "format", "mermaid", "Graph output format (mermaid)")
+}
+
+// loadCatalogOrErr loads skills/catalog.json with a remediation hint on failure.
+func loadCatalogOrErr(cmd *cobra.Command) (*skills.Catalog, error) {
+	skillsDir, _ := resolveSkillsRoots()
+	cat, err := skills.LoadCatalog(skillsDir)
+	if err != nil {
+		cmd.SilenceUsage = true
+		return nil, fmt.Errorf("%w; run `scripts/generate-skill-catalog.sh` to (re)build it", err)
+	}
+	return cat, nil
+}
+
+func runSkillsList(cmd *cobra.Command, _ []string) error {
+	cat, err := loadCatalogOrErr(cmd)
+	if err != nil {
+		return err
+	}
+
+	filter := skills.ListFilter{
+		Role:     skillsListRole,
+		Produces: skillsListProduces,
+		Consumes: skillsListConsumes,
+		Practice: skillsListPractice,
+	}
+	switch skillsListUserInvocable {
+	case "":
+		// no filter
+	case "true":
+		v := true
+		filter.UserInvocable = &v
+	case "false":
+		v := false
+		filter.UserInvocable = &v
+	default:
+		cmd.SilenceUsage = true
+		return fmt.Errorf("--user-invocable must be true or false (got %q)", skillsListUserInvocable)
+	}
+
+	matches := skills.List(cat.Skills, filter)
+
+	out := cmd.OutOrStdout()
+	if skillsListJSON {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(matches)
+	}
+	for _, e := range matches {
+		fmt.Fprintf(out, "%-28s %-16s %s\n", e.Name, e.HexagonalRole, e.Description)
+	}
+	if len(matches) == 0 {
+		fmt.Fprintln(cmd.ErrOrStderr(), "no skills match the given filters")
+	}
+	return nil
+}
+
+func runSkillsConsumers(cmd *cobra.Command, args []string) error {
+	cat, err := loadCatalogOrErr(cmd)
+	if err != nil {
+		return err
+	}
+	got := skills.Consumers(cat.Skills, args[0])
+	return renderNameList(cmd, got, skillsConsumersJSON,
+		fmt.Sprintf("no skills consume %q", args[0]))
+}
+
+func runSkillsProducers(cmd *cobra.Command, args []string) error {
+	cat, err := loadCatalogOrErr(cmd)
+	if err != nil {
+		return err
+	}
+	got := skills.Producers(cat.Skills, args[0])
+	return renderNameList(cmd, got, skillsProducersJSON,
+		fmt.Sprintf("no skills produce %q", args[0]))
+}
+
+func runSkillsGraph(cmd *cobra.Command, _ []string) error {
+	if skillsGraphFormat != "mermaid" {
+		cmd.SilenceUsage = true
+		return fmt.Errorf("unsupported --format %q (only 'mermaid' is supported)", skillsGraphFormat)
+	}
+	cat, err := loadCatalogOrErr(cmd)
+	if err != nil {
+		return err
+	}
+	fmt.Fprint(cmd.OutOrStdout(), skills.Mermaid(cat.Skills))
+	return nil
+}
+
+// renderNameList prints a sorted slice of skill names as JSON or one-per-line
+// text, with a stderr note when the list is empty (an empty result is not an
+// error — the query simply matched nothing).
+func renderNameList(cmd *cobra.Command, names []string, asJSON bool, emptyNote string) error {
+	out := cmd.OutOrStdout()
+	if asJSON {
+		if names == nil {
+			names = []string{}
+		}
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(names)
+	}
+	for _, n := range names {
+		fmt.Fprintln(out, n)
+	}
+	if len(names) == 0 {
+		fmt.Fprintln(cmd.ErrOrStderr(), emptyNote)
+	}
+	return nil
+}

--- a/cli/cmd/ao/skills_query_test.go
+++ b/cli/cmd/ao/skills_query_test.go
@@ -1,0 +1,185 @@
+// practices: [design-by-contract, code-complete]
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/boshu2/agentops/cli/internal/skills"
+)
+
+// newCmd returns a cobra command with captured stdout/stderr.
+func newCmd() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	var out, errb bytes.Buffer
+	c := &cobra.Command{}
+	c.SetOut(&out)
+	c.SetErr(&errb)
+	return c, &out, &errb
+}
+
+func TestSkillsList_JSONShapeFromLiveCatalog(t *testing.T) {
+	prev := skillsListJSON
+	defer func() { skillsListJSON = prev }()
+	skillsListJSON = true
+	resetListFilters()
+
+	c, out, errb := newCmd()
+	if err := runSkillsList(c, nil); err != nil {
+		t.Fatalf("runSkillsList: %v", err)
+	}
+	if errb.Len() != 0 {
+		t.Errorf("expected no stderr in JSON mode, got %q", errb.String())
+	}
+	var got []skills.CatalogEntry
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not a CatalogEntry array: %v\n%s", err, out.String())
+	}
+	if len(got) == 0 {
+		t.Fatal("live catalog yielded zero skills; expected the full inventory")
+	}
+	// sorted by name ascending
+	for i := 1; i < len(got); i++ {
+		if got[i-1].Name > got[i].Name {
+			t.Errorf("list not sorted at %d: %q > %q", i, got[i-1].Name, got[i].Name)
+		}
+	}
+	// every entry carries a name and a non-empty hexagonal_role
+	for _, e := range got {
+		if e.Name == "" {
+			t.Errorf("entry with empty name: %+v", e)
+		}
+		if e.HexagonalRole == "" {
+			t.Errorf("skill %q has empty hexagonal_role", e.Name)
+		}
+	}
+}
+
+func TestSkillsList_RoleFilterIsSubsetAndAllMatch(t *testing.T) {
+	prev := skillsListJSON
+	defer func() { skillsListJSON = prev }()
+	skillsListJSON = true
+
+	resetListFilters()
+	skillsListRole = "domain"
+	defer func() { skillsListRole = "" }()
+
+	c, out, _ := newCmd()
+	if err := runSkillsList(c, nil); err != nil {
+		t.Fatalf("runSkillsList: %v", err)
+	}
+	var got []skills.CatalogEntry
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("not a JSON array: %v", err)
+	}
+	for _, e := range got {
+		if !strings.EqualFold(e.HexagonalRole, "domain") {
+			t.Errorf("role=domain returned %q with role %q", e.Name, e.HexagonalRole)
+		}
+	}
+}
+
+func TestSkillsList_RejectsBadUserInvocable(t *testing.T) {
+	resetListFilters()
+	skillsListUserInvocable = "maybe"
+	defer func() { skillsListUserInvocable = "" }()
+
+	c, _, _ := newCmd()
+	err := runSkillsList(c, nil)
+	if err == nil {
+		t.Fatal("expected error for --user-invocable=maybe, got nil")
+	}
+	if !strings.Contains(err.Error(), "user-invocable") {
+		t.Errorf("error should mention the offending flag, got %q", err.Error())
+	}
+}
+
+func TestSkillsConsumers_JSONArrayOfNames(t *testing.T) {
+	prev := skillsConsumersJSON
+	defer func() { skillsConsumersJSON = prev }()
+	skillsConsumersJSON = true
+
+	c, out, _ := newCmd()
+	if err := runSkillsConsumers(c, []string{"rpi"}); err != nil {
+		t.Fatalf("runSkillsConsumers: %v", err)
+	}
+	var got []string
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not a JSON string array: %v\n%s", err, out.String())
+	}
+	// names are sorted and never equal to the query target itself
+	for i := 1; i < len(got); i++ {
+		if got[i-1] > got[i] {
+			t.Errorf("consumers not sorted at %d: %q > %q", i, got[i-1], got[i])
+		}
+	}
+	for _, n := range got {
+		if n == "rpi" {
+			t.Errorf("a skill should not be listed as its own consumer: %q", n)
+		}
+	}
+}
+
+func TestSkillsProducers_EmptyMatchIsEmptyJSONArray(t *testing.T) {
+	prev := skillsProducersJSON
+	defer func() { skillsProducersJSON = prev }()
+	skillsProducersJSON = true
+
+	c, out, errb := newCmd()
+	if err := runSkillsProducers(c, []string{"definitely-not-a-real-port-xyz"}); err != nil {
+		t.Fatalf("runSkillsProducers: %v", err)
+	}
+	got := strings.TrimSpace(out.String())
+	if got != "[]" {
+		t.Errorf("empty producers JSON: want %q, got %q", "[]", got)
+	}
+	if errb.Len() != 0 {
+		t.Errorf("expected no stderr in JSON mode, got %q", errb.String())
+	}
+}
+
+func TestSkillsGraph_MermaidHeaderAndNodes(t *testing.T) {
+	prev := skillsGraphFormat
+	defer func() { skillsGraphFormat = prev }()
+	skillsGraphFormat = "mermaid"
+
+	c, out, _ := newCmd()
+	if err := runSkillsGraph(c, nil); err != nil {
+		t.Fatalf("runSkillsGraph: %v", err)
+	}
+	s := out.String()
+	if !strings.HasPrefix(s, "graph LR\n") {
+		t.Errorf("mermaid output should start with 'graph LR', got:\n%s", s[:min(40, len(s))])
+	}
+	if !strings.Contains(s, "s_rpi[rpi]") {
+		t.Errorf("expected a node for the rpi skill, got:\n%s", s)
+	}
+}
+
+func TestSkillsGraph_RejectsUnknownFormat(t *testing.T) {
+	prev := skillsGraphFormat
+	defer func() { skillsGraphFormat = prev }()
+	skillsGraphFormat = "dot"
+
+	c, _, _ := newCmd()
+	err := runSkillsGraph(c, nil)
+	if err == nil {
+		t.Fatal("expected error for --format=dot, got nil")
+	}
+	if !strings.Contains(err.Error(), "mermaid") {
+		t.Errorf("error should name the supported format, got %q", err.Error())
+	}
+}
+
+// resetListFilters clears all package-level list flag state so tests don't
+// leak filter values into one another.
+func resetListFilters() {
+	skillsListRole = ""
+	skillsListProduces = ""
+	skillsListConsumes = ""
+	skillsListPractice = ""
+	skillsListUserInvocable = ""
+}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -4066,6 +4066,21 @@ ao skills check [flags]
       --strict         Exit non-zero on any finding (CI mode)
 ```
 
+#### `ao skills consumers`
+
+Print the skills whose consumes[] list includes <skill> — i.e. who
+
+```
+ao skills consumers <skill> [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help   help for consumers
+      --json   Emit machine-readable JSON
+```
+
 #### `ao skills find`
 
 Score every skills/<name>/SKILL.md against a free-text intent and
@@ -4080,6 +4095,56 @@ ao skills find <intent> [flags]
   -h, --help        help for find
       --json        Emit machine-readable JSON on stdout
       --limit int   Maximum number of results to return (default 5)
+```
+
+#### `ao skills graph`
+
+Render the skill dependency graph (A --> B means A consumes B) from
+
+```
+ao skills graph [flags]
+```
+
+**Flags:**
+
+```
+      --format string   Graph output format (mermaid) (default "mermaid")
+  -h, --help            help for graph
+```
+
+#### `ao skills list`
+
+Filter the generated skill catalog by hexagonal role, produced or
+
+```
+ao skills list [flags]
+```
+
+**Flags:**
+
+```
+      --consumes string         Filter to skills that consume this port/sibling
+  -h, --help                    help for list
+      --json                    Emit machine-readable JSON
+      --practice string         Filter to skills that apply this practice
+      --produces string         Filter to skills that produce this port/artifact
+      --role string             Filter by hexagonal_role (domain, driving-adapter, ...)
+      --user-invocable string   Filter by user-invocability (true|false)
+```
+
+#### `ao skills producers`
+
+Print the skills whose produces[] list includes <output> — i.e. who
+
+```
+ao skills producers <output> [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help   help for producers
+      --json   Emit machine-readable JSON
 ```
 
 ---

--- a/cli/internal/skills/catalog.go
+++ b/cli/internal/skills/catalog.go
@@ -1,0 +1,181 @@
+// catalog.go — load and query the generated skills/catalog.json.
+//
+// The catalog is the queryable inventory emitted by
+// scripts/generate-skill-catalog.sh (slice 1 of soc-vuu6.4). This file is
+// slice 2: a pure, table-testable query engine plus a thin disk loader so the
+// `ao skills list|consumers|producers|graph` commands never re-parse SKILL.md
+// frontmatter — they read the committed catalog, which CI keeps in sync.
+//
+// Source of truth for the JSON shape is schemas/skill-catalog.schema.json.
+package skills
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Catalog is the top-level skills/catalog.json document.
+type Catalog struct {
+	SchemaVersion string         `json:"schema_version"`
+	GeneratedAt   string         `json:"generated_at"`
+	SkillCount    int            `json:"skill_count"`
+	Skills        []CatalogEntry `json:"skills"`
+}
+
+// CatalogEntry is one skill's generated metadata. Field tags mirror
+// schemas/skill-catalog.schema.json exactly.
+type CatalogEntry struct {
+	Name                 string       `json:"name"`
+	Description          string       `json:"description"`
+	HexagonalRole        string       `json:"hexagonal_role"`
+	Consumes             []string     `json:"consumes"`
+	Produces             []string     `json:"produces"`
+	ContextRel           []ContextRel `json:"context_rel"`
+	Practices            []string     `json:"practices"`
+	UserInvocable        bool         `json:"user_invocable"`
+	CodexOverridePresent bool         `json:"codex_override_present"`
+	ReferencesCount      int          `json:"references_count"`
+}
+
+// ContextRel is one hex relationship (customer-of, shared-kernel, alias-of).
+type ContextRel struct {
+	Kind string `json:"kind"`
+	With string `json:"with"`
+}
+
+// LoadCatalog reads and decodes skills/catalog.json from the given skills
+// directory. It returns a clear error if the file is missing (the caller
+// should suggest regenerating it) or malformed.
+func LoadCatalog(skillsDir string) (*Catalog, error) {
+	path := filepath.Join(skillsDir, "catalog.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var cat Catalog
+	if err := json.Unmarshal(data, &cat); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return &cat, nil
+}
+
+// ListFilter narrows a List query. A zero-value filter matches every entry.
+// String filters are case-insensitive exact matches; UserInvocable is a
+// tri-state via a pointer (nil = don't filter).
+type ListFilter struct {
+	Role          string // hexagonal_role
+	Produces      string // an entry in produces[]
+	Consumes      string // an entry in consumes[]
+	Practice      string // an entry in practices[]
+	UserInvocable *bool  // user_invocable, tri-state
+}
+
+// List returns the entries matching filter, sorted by name ascending. The
+// result is never nil (empty slice on no match) so JSON callers emit `[]`.
+func List(entries []CatalogEntry, filter ListFilter) []CatalogEntry {
+	out := make([]CatalogEntry, 0, len(entries))
+	for _, e := range entries {
+		if filter.Role != "" && !strings.EqualFold(e.HexagonalRole, filter.Role) {
+			continue
+		}
+		if filter.Produces != "" && !containsFold(e.Produces, filter.Produces) {
+			continue
+		}
+		if filter.Consumes != "" && !containsFold(e.Consumes, filter.Consumes) {
+			continue
+		}
+		if filter.Practice != "" && !containsFold(e.Practices, filter.Practice) {
+			continue
+		}
+		if filter.UserInvocable != nil && e.UserInvocable != *filter.UserInvocable {
+			continue
+		}
+		out = append(out, e)
+	}
+	sortByName(out)
+	return out
+}
+
+// Consumers returns the names of skills that declare `name` in their
+// consumes[] list — i.e. who depends on this skill. Sorted, never nil.
+func Consumers(entries []CatalogEntry, name string) []string {
+	out := make([]string, 0)
+	for _, e := range entries {
+		if containsFold(e.Consumes, name) {
+			out = append(out, e.Name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Producers returns the names of skills that declare `output` in their
+// produces[] list — i.e. who writes this port/artifact. Sorted, never nil.
+func Producers(entries []CatalogEntry, output string) []string {
+	out := make([]string, 0)
+	for _, e := range entries {
+		if containsFold(e.Produces, output) {
+			out = append(out, e.Name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Mermaid renders the consumes graph as a Mermaid flowchart. Each skill is a
+// node; an edge A-->B means A consumes B. Output is deterministic: nodes and
+// edges are emitted in sorted order. Only edges whose target is a known skill
+// are drawn, so the diagram stays inside the catalog.
+func Mermaid(entries []CatalogEntry) string {
+	known := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		known[e.Name] = true
+	}
+	sorted := append([]CatalogEntry(nil), entries...)
+	sortByName(sorted)
+
+	var b strings.Builder
+	b.WriteString("graph LR\n")
+	for _, e := range sorted {
+		b.WriteString(fmt.Sprintf("  %s[%s]\n", mermaidID(e.Name), e.Name))
+	}
+	for _, e := range sorted {
+		deps := append([]string(nil), e.Consumes...)
+		sort.Strings(deps)
+		for _, dep := range deps {
+			if !known[dep] {
+				continue
+			}
+			b.WriteString(fmt.Sprintf("  %s --> %s\n", mermaidID(e.Name), mermaidID(dep)))
+		}
+	}
+	return b.String()
+}
+
+// mermaidID sanitizes a skill name into a Mermaid-safe node id (Mermaid node
+// ids may not safely contain dots, hyphens, or colons unescaped).
+func mermaidID(name string) string {
+	r := strings.NewReplacer("-", "_", ".", "_", ":", "_")
+	return "s_" + r.Replace(name)
+}
+
+// containsFold reports whether haystack contains target (case-insensitive).
+func containsFold(haystack []string, target string) bool {
+	for _, h := range haystack {
+		if strings.EqualFold(h, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// sortByName sorts entries in place by Name ascending.
+func sortByName(entries []CatalogEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].Name < entries[j].Name
+	})
+}

--- a/cli/internal/skills/catalog_test.go
+++ b/cli/internal/skills/catalog_test.go
@@ -1,0 +1,261 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// fixture builds a small, deterministic catalog for query tests.
+func fixture() []CatalogEntry {
+	return []CatalogEntry{
+		{
+			Name:          "evolve",
+			Description:   "Run autonomous improvement loops.",
+			HexagonalRole: "driving-adapter",
+			Consumes:      []string{"rpi", "goals"},
+			Produces:      []string{"verdict-ledger"},
+			Practices:     []string{"tdd", "dora-metrics"},
+			UserInvocable: true,
+		},
+		{
+			Name:          "rpi",
+			Description:   "Run discovery, crank, validation.",
+			HexagonalRole: "domain",
+			Consumes:      []string{"discovery"},
+			Produces:      []string{"verdict-ledger", "handoff"},
+			Practices:     []string{"tdd"},
+			UserInvocable: true,
+		},
+		{
+			Name:          "goals",
+			Description:   "Maintain AgentOps goals.",
+			HexagonalRole: "supporting",
+			Consumes:      []string{},
+			Produces:      []string{"goals-doc"},
+			Practices:     []string{"bdd-gherkin"},
+			UserInvocable: false,
+		},
+	}
+}
+
+func TestList_FilterByRole(t *testing.T) {
+	got := List(fixture(), ListFilter{Role: "domain"})
+	if len(got) != 1 {
+		t.Fatalf("role=domain: want 1 entry, got %d", len(got))
+	}
+	if got[0].Name != "rpi" {
+		t.Errorf("role=domain: want rpi, got %q", got[0].Name)
+	}
+}
+
+func TestList_FilterByRoleCaseInsensitive(t *testing.T) {
+	got := List(fixture(), ListFilter{Role: "DOMAIN"})
+	if len(got) != 1 || got[0].Name != "rpi" {
+		t.Errorf("role=DOMAIN: want [rpi], got %v", names(got))
+	}
+}
+
+func TestList_FilterByProduces(t *testing.T) {
+	got := names(List(fixture(), ListFilter{Produces: "verdict-ledger"}))
+	want := []string{"evolve", "rpi"} // sorted by name
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("produces=verdict-ledger: want %v, got %v", want, got)
+	}
+}
+
+func TestList_FilterByConsumes(t *testing.T) {
+	got := names(List(fixture(), ListFilter{Consumes: "rpi"}))
+	want := []string{"evolve"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("consumes=rpi: want %v, got %v", want, got)
+	}
+}
+
+func TestList_FilterByPractice(t *testing.T) {
+	got := names(List(fixture(), ListFilter{Practice: "tdd"}))
+	want := []string{"evolve", "rpi"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("practice=tdd: want %v, got %v", want, got)
+	}
+}
+
+func TestList_FilterByUserInvocable(t *testing.T) {
+	yes := true
+	got := names(List(fixture(), ListFilter{UserInvocable: &yes}))
+	want := []string{"evolve", "rpi"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("user_invocable=true: want %v, got %v", want, got)
+	}
+
+	no := false
+	got = names(List(fixture(), ListFilter{UserInvocable: &no}))
+	want = []string{"goals"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("user_invocable=false: want %v, got %v", want, got)
+	}
+}
+
+func TestList_CombinedFilters(t *testing.T) {
+	got := names(List(fixture(), ListFilter{Produces: "verdict-ledger", Role: "domain"}))
+	want := []string{"rpi"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("produces+role: want %v, got %v", want, got)
+	}
+}
+
+func TestList_NoFilterReturnsAllSortedNonNil(t *testing.T) {
+	got := List(fixture(), ListFilter{})
+	want := []string{"evolve", "goals", "rpi"}
+	if !reflect.DeepEqual(names(got), want) {
+		t.Errorf("no filter: want %v, got %v", want, names(got))
+	}
+}
+
+func TestList_NoMatchReturnsEmptyNotNil(t *testing.T) {
+	got := List(fixture(), ListFilter{Role: "nonexistent"})
+	if got == nil {
+		t.Fatal("no-match List returned nil; want non-nil empty slice for JSON []")
+	}
+	if len(got) != 0 {
+		t.Errorf("no-match: want 0 entries, got %d", len(got))
+	}
+}
+
+func TestConsumers_Exact(t *testing.T) {
+	got := Consumers(fixture(), "rpi")
+	want := []string{"evolve"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("consumers(rpi): want %v, got %v", want, got)
+	}
+}
+
+func TestConsumers_DiscoveryHasOne(t *testing.T) {
+	got := Consumers(fixture(), "discovery")
+	want := []string{"rpi"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("consumers(discovery): want %v, got %v", want, got)
+	}
+}
+
+func TestConsumers_NoneReturnsEmptyNotNil(t *testing.T) {
+	// "evolve" is consumed by nobody in the fixture.
+	got := Consumers(fixture(), "evolve")
+	if got == nil {
+		t.Fatal("consumers(evolve) returned nil; want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("consumers(evolve): want 0, got %v", got)
+	}
+}
+
+func TestProducers_VerdictLedger(t *testing.T) {
+	got := Producers(fixture(), "verdict-ledger")
+	want := []string{"evolve", "rpi"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("producers(verdict-ledger): want %v, got %v", want, got)
+	}
+}
+
+func TestProducers_Unique(t *testing.T) {
+	got := Producers(fixture(), "goals-doc")
+	want := []string{"goals"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("producers(goals-doc): want %v, got %v", want, got)
+	}
+}
+
+func TestMermaid_Deterministic(t *testing.T) {
+	want := "graph LR\n" +
+		"  s_evolve[evolve]\n" +
+		"  s_goals[goals]\n" +
+		"  s_rpi[rpi]\n" +
+		"  s_evolve --> s_goals\n" +
+		"  s_evolve --> s_rpi\n"
+	got := Mermaid(fixture())
+	if got != want {
+		t.Errorf("Mermaid mismatch:\nwant:\n%q\ngot:\n%q", want, got)
+	}
+}
+
+func TestMermaid_OmitsUnknownEdges(t *testing.T) {
+	// rpi consumes "discovery", which is not a node in the fixture, so no
+	// edge from rpi should appear.
+	got := Mermaid(fixture())
+	if contains(got, "discovery") {
+		t.Errorf("Mermaid drew edge to unknown skill 'discovery':\n%s", got)
+	}
+}
+
+func TestLoadCatalog_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	const body = `{
+  "schema_version": "1",
+  "generated_at": "2026-05-31T00:00:00Z",
+  "skill_count": 1,
+  "skills": [
+    {
+      "name": "evolve",
+      "description": "loops",
+      "hexagonal_role": "driving-adapter",
+      "consumes": ["rpi"],
+      "produces": ["verdict-ledger"],
+      "context_rel": [],
+      "practices": ["tdd"],
+      "user_invocable": true,
+      "codex_override_present": false,
+      "references_count": 2
+    }
+  ]
+}`
+	if err := os.WriteFile(filepath.Join(dir, "catalog.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cat, err := LoadCatalog(dir)
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	if cat.SchemaVersion != "1" {
+		t.Errorf("schema_version: want 1, got %q", cat.SchemaVersion)
+	}
+	if cat.SkillCount != 1 || len(cat.Skills) != 1 {
+		t.Fatalf("skill_count: want 1/1, got %d/%d", cat.SkillCount, len(cat.Skills))
+	}
+	e := cat.Skills[0]
+	if e.Name != "evolve" || e.HexagonalRole != "driving-adapter" || e.ReferencesCount != 2 {
+		t.Errorf("entry mismatch: %+v", e)
+	}
+	if !reflect.DeepEqual(e.Consumes, []string{"rpi"}) {
+		t.Errorf("consumes: want [rpi], got %v", e.Consumes)
+	}
+}
+
+func TestLoadCatalog_MissingFileErrors(t *testing.T) {
+	_, err := LoadCatalog(t.TempDir())
+	if err == nil {
+		t.Fatal("LoadCatalog on missing file: want error, got nil")
+	}
+}
+
+// names projects entries to a sorted-by-construction slice of names.
+func names(entries []CatalogEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Name)
+	}
+	return out
+}
+
+func contains(s, sub string) bool {
+	return len(sub) > 0 && len(s) >= len(sub) && (indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=73 sub=179 all=252"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=73 sub=183 all=256"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,4} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "73" || "$sub_count" != "179" || "$all_count" != "252" ]]; then
+if [[ "$top_count" != "73" || "$sub_count" != "183" || "$all_count" != "256" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 252 ]]; then
+if [[ "${#commands[@]}" -ne 256 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi


### PR DESCRIPTION
## What

Slice 2 of the skill-catalog bead (soc-vuu6.4): the **queryable surface** over the generated `skills/catalog.json`. Slice 1 (the generator, schema, drift gate, and `catalog.json` itself) landed in PR #379; this adds the `ao skills` query commands the bead's acceptance criterion calls for.

- New `cli/internal/skills/catalog.go` — loads `skills/catalog.json` and a **pure, table-tested** query engine (`List`/`Consumers`/`Producers`/`Mermaid`). No SKILL.md re-parsing; reads the committed, CI-synced catalog.
- New `cli/cmd/ao/skills_query.go` — four cobra subcommands:
  - `ao skills list [--role --produces --consumes --practice --user-invocable] [--json]`
  - `ao skills consumers <skill> [--json]`
  - `ao skills producers <output> [--json]`
  - `ao skills graph [--format mermaid]`
- Regenerated `cli/docs/COMMANDS.md`; bumped the cli-command-surface fixtures (`sub` 179→183, `all` 252→256) for the 4 new subcommands.

## Why

`registry.json` and `catalog.json` existed but had no query API — agents grepping "which skill produces X?" had to scan markdown. This turns the catalog into a queryable surface (the bead blocks `ao skill new`, which needs sibling-skill defaults).

## Acceptance

> `ao skills list ... --json` returns the matching skill set in <100ms.

Verified: `ao skills list --produces result.json --json` → `[beads, discovery]`; `ao skills consumers rpi` → 5 skills; `ao skills graph` emits deterministic Mermaid. Latency well under 100ms.

## Scope notes

- Did **not** regenerate `skills/catalog.json` — it carries pre-existing drift on `main` (the `check-skill-catalog-drift` gate is I0/advisory). This PR only *consumes* the catalog; regenerating would sweep in unrelated drift.
- The bead's illustrative `--tier judge` example does not map to the real generated schema (which has no `tier` field — it uses `hexagonal_role`, `produces`, `consumes`, `practices`). Filters implemented against the actual catalog fields.

## Tests

`cli/internal/skills/catalog_test.go` (engine, exact-value table tests + load round-trip) and `cli/cmd/ao/skills_query_test.go` (JSON shape, sort invariants, flag validation, mermaid header) — all green. `go build`/`go vet`/`go test ./...` pass; conformance + command-surface smoke pass.

Closes-scenario: soc-vuu6.4#skill-catalog-json
Bounded-context: BC1-Corpus
Evidence: cli/internal/skills/catalog.go
