### PR TITLE
chore(docs): correct inverted ledger-vs-Dolt dependency line (ag-x31t.3 #ledger-dolt-doctrine)

### DIFF
--- a/packs/agentops/template-fragments/operating-loop.template.md
+++ b/packs/agentops/template-fragments/operating-loop.template.md
@@ -28,5 +28,7 @@ Context compounds through the rig's `.agents/` corpus, not chat history:
 - `ao maturity --scan` — find stale entries; `--evict` archives low-utility knowledge.
 
 Durable decisions/attempts/verdicts also land on the bead (`gc bd update
---set-metadata ...`) — the bead/Dolt substrate is the cross-session memory.
+--set-metadata ...`) — the bead/Dolt metadata is the write-model projection of
+the cross-session memory; the append-only `docs/provenance/ledger.jsonl` is the
+source of truth and wins on disagreement.
 {{ end }}


### PR DESCRIPTION
## What

`packs/agentops/template-fragments/operating-loop.template.md` framed `the bead/Dolt substrate is the cross-session memory` — inverting the provenance doctrine by making Dolt the canonical store.

Corrected to the CQRS split per the canonical provenance section in `CLAUDE.md` and `AGENTS-WORKFLOW.md`:
- bead/Dolt metadata = write-model **projection**
- append-only `docs/provenance/ledger.jsonl` = **source of truth**, wins on disagreement

## Scope

One doc file, 3 insertions / 1 deletion. No code, no tests, no generated artifacts (this is the only source of the inverted line).

Closes-scenario: ag-x31t.3#ledger-dolt-doctrine
Bounded-context: BC4-Factory
Evidence: packs/agentops/template-fragments/operating-loop.template.md