### PR TITLE
chore(ci): enforce worktree-disposition discipline + prune gate (ag-4oj9.2 #worktree-disposition)

### DIFF
--- a/scripts/gc-stale-worktrees.sh
+++ b/scripts/gc-stale-worktrees.sh
@@ -19,8 +19,18 @@
 #   scripts/gc-stale-worktrees.sh --ref origin/develop # different upstream
 #   scripts/gc-stale-worktrees.sh --json               # machine-readable summary
 #   scripts/gc-stale-worktrees.sh --verbose            # per-worktree decision trace
+#   scripts/gc-stale-worktrees.sh --check-committed    # CI gate: fail if a tmp
+#                                                        worktree got committed
 #
-# Exit codes: 0 = success (may include removals); 1 = usage/internal error.
+# --check-committed is the CI-runnable disposition gate. Live linked worktrees
+# are invisible to a fresh CI checkout, but an *undisposed* tmp worktree that
+# was accidentally `git add`-ed (its nested `.git` gitdir pointer file plus its
+# checked-out tree) IS visible as tracked files. This mode scans `git ls-files`
+# for those artifacts and exits non-zero so the entropy can never land on main.
+# It never touches the working tree and never removes anything.
+#
+# Exit codes: 0 = success (may include removals / clean gate); 1 = usage,
+# internal error, OR (in --check-committed mode) committed tmp-worktree artifacts.
 
 set -euo pipefail
 
@@ -29,6 +39,7 @@ APPLY=0
 FORCE=0
 JSON=0
 VERBOSE=0
+CHECK_COMMITTED=0
 
 usage() {
   sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
@@ -41,12 +52,43 @@ while [ $# -gt 0 ]; do
     --force) FORCE=1 ;;
     --json) JSON=1 ;;
     --verbose|-v) VERBOSE=1 ;;
+    --check-committed) CHECK_COMMITTED=1 ;;
     --ref) shift; REF="${1:-origin/main}" ;;
     -h|--help) usage 0 ;;
     *) echo "gc-stale-worktrees: unknown arg: $1" >&2; usage 1 ;;
   esac
   shift || true
 done
+
+# --check-committed mode: the CI-runnable disposition gate. Scan the tracked
+# file set (NOT the live worktree list, which is empty on a fresh checkout) for
+# committed tmp-worktree artifacts and fail if any are found. Runs before the
+# ref check below because CI shallow checkouts may lack origin/main, and this
+# gate does not need merged-ness — it only inspects tracked paths.
+if [ "$CHECK_COMMITTED" -eq 1 ]; then
+  # An undisposed tmp worktree leaks into the repo when its *checked-out tree*
+  # is `git add`-ed under a tmp-worktree-style directory. (Git itself refuses
+  # to track a literal `.git` path, so the only visible signature is the dir
+  # name carrying tracked content.)
+  #
+  # Patterns are anchored to the tmp-worktree naming this repo produces:
+  # `bd worktree create` siblings and the historical /tmp/agentops-* and *-wt
+  # checkouts called out in ag-4oj9.2 (e.g. agentops-pr290-merge,
+  # agentops-rpi-fix, *-wt, .codex/worktrees/).
+  offenders="$(git ls-files | grep -E \
+    '(^|/)agentops-[^/]*-(merge|rpi[^/]*|wt)(/|$)|(^|/)[^/]*-wt/|(^|/)\.codex/worktrees/' \
+    || true)"
+  if [ -n "$offenders" ]; then
+    echo "gc-stale-worktrees: FAIL — committed tmp-worktree artifacts detected (undisposed worktree)." >&2
+    echo "A worktree must end as merged / preserved / exported / deleted — never committed." >&2
+    echo "Offending tracked paths:" >&2
+    printf '  - %s\n' $offenders >&2
+    echo "Dispose with: scripts/gc-stale-worktrees.sh --apply  (and git rm the tracked copy)." >&2
+    exit 1
+  fi
+  echo "gc-stale-worktrees: PASS — no committed tmp-worktree artifacts tracked"
+  exit 0
+fi
 
 # Verify ref exists; without it we can't determine merged-ness.
 if ! git rev-parse --verify --quiet "$REF" >/dev/null; then

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -830,6 +830,22 @@ else
 fi
 
 # --- 7. Worktree disposition ---
+# 7a. Committed-tmp-worktree gate (ag-4oj9.2). Cheap, read-only, and CI-safe:
+# it inspects only tracked paths (not the live worktree list, which is empty on
+# a fresh CI checkout), so it runs unconditionally even in fast mode — an
+# undisposed worktree that got committed is never acceptable to push.
+if [[ -x scripts/gc-stale-worktrees.sh ]]; then
+    if committed_wt_output="$(scripts/gc-stale-worktrees.sh --check-committed 2>&1)"; then
+        pass "no committed tmp-worktree artifacts"
+    else
+        fail "committed tmp-worktree artifacts"
+        indent_output "$committed_wt_output"
+    fi
+else
+    fail "missing executable: scripts/gc-stale-worktrees.sh"
+fi
+
+# 7b. Live worktree disposition.
 # Full/release gates still enforce repository worktree governance. Local fast
 # pre-push skips it by default because stale unrelated worktrees should not
 # block pushing a scoped commit; opt in with PRE_PUSH_STRICT_WORKTREE=1.

--- a/tests/scripts/gc-stale-worktrees.bats
+++ b/tests/scripts/gc-stale-worktrees.bats
@@ -206,3 +206,62 @@ run_script() {
   [ "$status" -eq 0 ]
   [[ "$output" != *"REMOVE: $TMP/main"* ]]
 }
+
+# ── --check-committed: the CI-runnable disposition gate (ag-4oj9.2). It must
+# detect tmp-worktree artifacts that landed as *tracked* files, pass on a clean
+# repo, and never touch the main checkout's working tree.
+
+@test "check-committed passes on a clean repo" {
+  run_script --check-committed
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
+  [[ "$output" == *"no committed tmp-worktree artifacts"* ]]
+}
+
+@test "check-committed fails on a committed agentops tmp-worktree tree" {
+  cd "$TMP/main"
+  # The /tmp/agentops-pr290-merge family called out in the bead, committed.
+  mkdir -p agentops-pr290-merge
+  echo "leftover" > agentops-pr290-merge/file.txt
+  git add -f agentops-pr290-merge/file.txt
+  run_script --check-committed
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"agentops-pr290-merge/file.txt"* ]]
+}
+
+@test "check-committed fails on a committed *-wt sibling worktree tree" {
+  cd "$TMP/main"
+  mkdir -p ag-1234-wt
+  echo "leftover" > ag-1234-wt/scratch.txt
+  git add -f ag-1234-wt/scratch.txt
+  run_script --check-committed
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"ag-1234-wt/scratch.txt"* ]]
+}
+
+@test "check-committed does NOT flag ordinary tracked source files" {
+  cd "$TMP/main"
+  # A normal repo file (no .git basename, no tmp-worktree dir) must not trip.
+  mkdir -p scripts
+  echo "echo ok" > scripts/regular.sh
+  git add -f scripts/regular.sh
+  run_script --check-committed
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
+}
+
+@test "check-committed never removes or mutates the main checkout" {
+  cd "$TMP/main"
+  mkdir -p agentops-pr290-merge
+  echo "leftover" > agentops-pr290-merge/file.txt
+  git add -f agentops-pr290-merge/file.txt
+  run_script --check-committed
+  [ "$status" -eq 1 ]
+  # The gate is read-only: the main checkout dir and its files survive intact.
+  [ -d "$TMP/main" ]
+  [ -f "$TMP/main/agentops-pr290-merge/file.txt" ]
+  # And it reported no removals.
+  [[ "$output" != *"REMOVE:"* ]]
+}


### PR DESCRIPTION
## What

Closes the CI-gate gap in the worktree-disposition discipline (ag-4oj9.2). The repo's `bd worktree create` flow accumulates abandoned tmp worktrees; detection + prune already existed (`gc-stale-worktrees.sh --apply`, live `check-worktree-disposition.sh`), but nothing **gated** against an undisposed worktree that gets *committed* into the tree.

- **New `--check-committed` mode** on `scripts/gc-stale-worktrees.sh`: scans tracked paths (`git ls-files`) for committed tmp-worktree artifacts — `agentops-*-{merge,rpi*,wt}`, `*-wt/`, `.codex/worktrees/` — and fails non-zero. Read-only: never touches the working tree, never removes anything. Uses the existing `--git-common-dir` parent (never `--show-toplevel`) for main-checkout safety.
- **Wired into `scripts/pre-push-gate.sh`** (step 7a), unconditionally — it inspects only tracked paths so it is cheap and CI-safe (the live worktree list is empty on a fresh CI checkout; this catches what CI *can* see). Auto-runs in CI via the existing `bats tests/scripts/*.bats` step.
- **Bats coverage**: pass-on-clean, fail-on-committed-tmp-tree (two naming families), no-false-positive on ordinary source, and a read-only/no-mutation assertion against the main checkout.

## Why

Undisposed worktrees are statelessness entropy — branch state no agent owns. The disposition contract (AGENTS-RUNTIME.md) was documented but not gated against the committed-artifact case. This makes it impossible for a tmp worktree to land on `main`.

## Gates
- `shellcheck -S warning` — PASS (both scripts)
- `bats tests/scripts/gc-stale-worktrees.bats` — 18/18 PASS
- `scripts/validate-ci-policy-parity.sh` — PASS (no validate.yml/manifest change; new bats picked up by existing step)
- `git diff origin/main --stat` — scope-only (3 files)

Closes-scenario: ag-4oj9.2#worktree-disposition
Bounded-context: BC5-Runtime
Evidence: scripts/gc-stale-worktrees.sh