### PR TITLE
feat(validate): generate+check tests-from-scenarios coverage (ag-9jle.4 #tests-from-scenarios)

### DIFF
--- a/scripts/check-bead-scenario-coverage.sh
+++ b/scripts/check-bead-scenario-coverage.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# check-bead-scenario-coverage.sh — leaf-validator scenario→test coverage check.
+#
+# The C2 "tests-from-scenarios" leaf gate (ag-9jle.4). Sibling — but NOT a
+# duplicate — of scripts/check-scenario-test-linkage.sh:
+#
+#   check-scenario-test-linkage.sh   CI/corpus gate. Walks EVERY .feature under
+#                                    skills/*/references/ and asserts each has a
+#                                    @covered-by tag or is allowlisted. Static,
+#                                    repo-wide, file-existence only.
+#
+#   check-bead-scenario-coverage.sh  LEAF gate (this script). Runs at /vibe and
+#   (this file)                      /test time on the ONE slice/bead being
+#                                    validated. Takes the bead's scenarios
+#                                    (a .feature file, a bead body containing a
+#                                    `## Scenarios` block, or stdin), and FAILS
+#                                    if any scenario lacks a covering test. With
+#                                    --run it requires the covering test to
+#                                    actually PASS, not merely exist — the
+#                                    distinction ag-9jle.4 calls out: leaf
+#                                    validators must not accept "tests exist" or
+#                                    a coverage %, they must prove every scenario
+#                                    maps to a passing test.
+#
+# This is the FORWARD direction: input = behavior (Gherkin scenarios), the gate
+# demands a test per scenario. It does not work backward from coverage gaps.
+#
+# Convention (identical to the corpus gate, so a scenario authored once carries
+# its linkage to both gates):
+#
+#   @covered-by:<test-path>            tag the whole source as the cover, OR
+#   @covered-by:<test-path>::<Name>    name a specific test function (Go etc.)
+#
+# Place the tag on its own line directly above the `Scenario:` it covers (the
+# standard Gherkin tag position). Tags above `Feature:` (in a .feature file) or
+# above the `## Scenarios` heading (in a bead body) apply to every scenario.
+#
+# Coverage gate: PASS iff M >= N where N = scenarios found and M = scenarios that
+# resolve to an existing (and, with --run, passing) test. Override the threshold
+# with --min-covered=<int> to require at least that many covered (default = N,
+# i.e. all scenarios must be covered).
+#
+# Usage:
+#   bash scripts/check-bead-scenario-coverage.sh <source>        # .feature or bead-body file
+#   bash scripts/check-bead-scenario-coverage.sh -                # read source from stdin
+#   bash scripts/check-bead-scenario-coverage.sh --bead <id>      # fetch bead body via `bd show`
+#   bash scripts/check-bead-scenario-coverage.sh --run <source>   # also EXECUTE each test, require pass
+#   bash scripts/check-bead-scenario-coverage.sh --min-covered=N <source>
+#   bash scripts/check-bead-scenario-coverage.sh --json <source>  # machine-readable summary
+#   bash scripts/check-bead-scenario-coverage.sh --warn-only <source>
+#
+# Exits 0 on pass, 1 on fail (unless --warn-only), 2 on misuse.
+#
+# practices: [continuous-integration, design-by-contract, tdd, bdd-gherkin]
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WARN_ONLY=0
+JSON=0
+RUN=0
+MIN_COVERED=""   # empty = "all scenarios" (=N)
+SOURCE=""
+BEAD_ID=""
+
+usage() { grep '^#' "$0" | sed 's/^# \?//'; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --warn-only) WARN_ONLY=1; shift;;
+        --json)      JSON=1; shift;;
+        --run)       RUN=1; shift;;
+        --min-covered=*) MIN_COVERED="${1#--min-covered=}"; shift;;
+        --bead)      BEAD_ID="${2:-}"; shift 2;;
+        -h|--help)   usage; exit 0;;
+        -)           SOURCE="-"; shift;;
+        --*)         echo "Unknown flag: $1" >&2; exit 2;;
+        *)           SOURCE="$1"; shift;;
+    esac
+done
+
+if [[ -n "$MIN_COVERED" && ! "$MIN_COVERED" =~ ^[0-9]+$ ]]; then
+    echo "--min-covered must be a non-negative integer" >&2
+    exit 2
+fi
+
+# Resolve the raw scenarios text into $RAW.
+RAW=""
+if [[ -n "$BEAD_ID" ]]; then
+    if ! command -v bd >/dev/null 2>&1; then
+        echo "--bead given but bd is not on PATH" >&2
+        exit 2
+    fi
+    RAW="$(bd show "$BEAD_ID" 2>/dev/null || true)"
+    if [[ -z "$RAW" ]]; then
+        echo "bd show $BEAD_ID returned no content" >&2
+        exit 2
+    fi
+elif [[ "$SOURCE" == "-" ]]; then
+    RAW="$(cat)"
+elif [[ -n "$SOURCE" ]]; then
+    if [[ ! -f "$SOURCE" ]]; then
+        echo "source file does not exist: $SOURCE" >&2
+        exit 2
+    fi
+    RAW="$(cat "$SOURCE")"
+else
+    echo "no source given (pass a .feature/bead-body file, '-' for stdin, or --bead <id>)" >&2
+    exit 2
+fi
+
+# Execute a covering test. Dispatches by extension. Optional $2 = test name to
+# scope the run. Returns the test runner's exit code.
+run_test() {
+    local abs="$1" name="${2:-}"
+    case "$abs" in
+        *_test.go)
+            local dir; dir="$(dirname "$abs")"
+            if [[ -n "$name" ]]; then
+                ( cd "$dir" && go test -run "$name" . )
+            else
+                ( cd "$dir" && go test . )
+            fi
+            ;;
+        *.bats)
+            if [[ -n "$name" ]]; then
+                bats -f "$name" "$abs"
+            else
+                bats "$abs"
+            fi
+            ;;
+        *.sh)
+            bash "$abs"
+            ;;
+        *.py)
+            if [[ -n "$name" ]]; then
+                python3 -m pytest -q -k "$name" "$abs"
+            else
+                python3 -m pytest -q "$abs"
+            fi
+            ;;
+        *)
+            # Unknown runner: presence already verified by the caller; treat as covered.
+            return 0
+            ;;
+    esac
+}
+
+# Resolve a @covered-by target. Echoes an error string, or empty on success.
+# With RUN=1, also executes the test and requires exit 0.
+# Arg: target spec after "@covered-by:" — "path" or "path::Name".
+resolve_target() {
+    local target="$1" path name abs
+    if [[ "$target" == *"::"* ]]; then
+        path="${target%%::*}"
+        name="${target##*::}"
+    else
+        path="$target"
+        name=""
+    fi
+
+    abs="$REPO_ROOT/$path"
+    if [[ ! -f "$abs" ]]; then
+        printf 'test path does not exist: %s' "$path"
+        return
+    fi
+    if [[ -n "$name" ]]; then
+        if ! grep -qF "$name" "$abs"; then
+            printf 'test "%s" not found in %s' "$name" "$path"
+            return
+        fi
+    fi
+
+    if [[ $RUN -eq 1 ]]; then
+        local rc=0
+        run_test "$abs" "$name" >/dev/null 2>&1 || rc=$?
+        if [[ $rc -ne 0 ]]; then
+            printf 'covering test did not pass: %s (exit %d)' "$path" "$rc"
+            return
+        fi
+    fi
+    printf ''  # success
+}
+
+errors=0
+scenarios_total=0
+scenarios_covered=0
+declare -a ERROR_LINES=()
+declare -a UNCOVERED=()
+
+# Parse. When a bead body is the source, scenarios live under a `## Scenarios`
+# markdown heading; we only count `Scenario:` lines once we've entered it. A
+# bare .feature file has a `Feature:` line and no `## Scenarios` heading — in
+# that case scenarios are in scope from the start.
+file_tags=""
+pending_tags=""
+in_scenarios=0
+has_scenarios_heading=0
+
+# Pre-scan: does the source carry a `## Scenarios` heading? If so, only count
+# scenarios inside it (a bead body). Otherwise treat the whole text as scenarios
+# (a .feature file).
+if printf '%s\n' "$RAW" | grep -qE '^[[:space:]]*##[[:space:]]+Scenarios[[:space:]]*$'; then
+    has_scenarios_heading=1
+else
+    in_scenarios=1
+fi
+
+while IFS= read -r line; do
+    trimmed="$(printf '%s' "$line" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+
+    # Enter/exit the `## Scenarios` block (bead-body mode).
+    if [[ $has_scenarios_heading -eq 1 ]]; then
+        if [[ "$trimmed" =~ ^##[[:space:]]+Scenarios[[:space:]]*$ ]]; then
+            in_scenarios=1
+            file_tags="$pending_tags"   # tags directly above the heading apply to all
+            pending_tags=""
+            continue
+        fi
+        # A new H2 section other than Scenarios ends the block.
+        if [[ $in_scenarios -eq 1 && "$trimmed" =~ ^##[[:space:]] ]]; then
+            in_scenarios=0
+            pending_tags=""
+            continue
+        fi
+    fi
+
+    if [[ "$trimmed" == @* ]]; then
+        for tok in $trimmed; do
+            if [[ "$tok" == @covered-by:* ]]; then
+                pending_tags+="${tok#@covered-by:} "
+            fi
+        done
+        continue
+    fi
+
+    # In .feature mode, a Feature: line promotes pending tags to file-level.
+    if [[ $has_scenarios_heading -eq 0 && "$trimmed" == Feature:* ]]; then
+        file_tags="$pending_tags"
+        pending_tags=""
+        continue
+    fi
+
+    if [[ $in_scenarios -eq 1 && ( "$trimmed" == Scenario:* || "$trimmed" == "Scenario Outline:"* ) ]]; then
+        scenarios_total=$((scenarios_total + 1))
+        scen_name="${trimmed#Scenario: }"
+        scen_name="${scen_name#Scenario Outline: }"
+
+        effective="$file_tags $pending_tags"
+        pending_tags=""
+        effective="$(printf '%s' "$effective" | xargs || true)"
+
+        if [[ -z "$effective" ]]; then
+            UNCOVERED+=("$scen_name")
+            continue
+        fi
+
+        scenario_ok=1
+        for tgt in $effective; do
+            err="$(resolve_target "$tgt")"
+            if [[ -n "$err" ]]; then
+                ERROR_LINES+=("scenario \"$scen_name\": dangling @covered-by:$tgt — $err")
+                errors=$((errors + 1))
+                scenario_ok=0
+            fi
+        done
+        if [[ $scenario_ok -eq 1 ]]; then
+            scenarios_covered=$((scenarios_covered + 1))
+        else
+            UNCOVERED+=("$scen_name")
+        fi
+        continue
+    fi
+
+    # Any other non-blank line clears pending scenario-level tags (Gherkin: a tag
+    # must be immediately above the Scenario it annotates).
+    if [[ -n "$trimmed" && "$trimmed" != @* ]]; then
+        pending_tags=""
+    fi
+done < <(printf '%s\n' "$RAW")
+
+# Threshold: default = all scenarios (N). Override via --min-covered.
+threshold="${MIN_COVERED:-$scenarios_total}"
+
+# Record uncovered scenarios as errors. A scenario with no @covered-by tag is
+# the headline ag-9jle.4 failure: "tests exist" / coverage% is NOT enough —
+# every scenario needs an explicit covering test.
+for scen in "${UNCOVERED[@]:-}"; do
+    [[ -z "$scen" ]] && continue
+    ERROR_LINES+=("scenario \"$scen\": no covering test — add '@covered-by:<test-path>' directly above it (forward from the scenario)")
+done
+
+covered_meets_threshold=0
+if [[ $scenarios_covered -ge $threshold ]]; then
+    covered_meets_threshold=1
+fi
+
+result="pass"
+if [[ $errors -gt 0 || $covered_meets_threshold -eq 0 ]]; then
+    result="fail"
+fi
+
+if [[ $JSON -eq 1 ]]; then
+    printf '{"scenarios_total":%d,"scenarios_covered":%d,"threshold":%d,"errors":%d,"run":%s,"result":"%s"}\n' \
+        "$scenarios_total" "$scenarios_covered" "$threshold" "$errors" \
+        "$([[ $RUN -eq 1 ]] && echo true || echo false)" "$result"
+fi
+
+if [[ "$result" == "pass" ]]; then
+    [[ $JSON -eq 0 ]] && echo "check-bead-scenario-coverage: PASS (${scenarios_covered}/${scenarios_total} scenarios covered$([[ $RUN -eq 1 ]] && echo ' & passing'); threshold ${threshold})"
+    exit 0
+fi
+
+if [[ $JSON -eq 0 ]]; then
+    for e in "${ERROR_LINES[@]:-}"; do
+        [[ -z "$e" ]] && continue
+        echo "$e" >&2
+    done
+    echo "check-bead-scenario-coverage: ${scenarios_covered}/${scenarios_total} covered, threshold ${threshold}" >&2
+fi
+
+if [[ "$WARN_ONLY" -eq 1 ]]; then
+    [[ $JSON -eq 0 ]] && echo "check-bead-scenario-coverage: WARN (below threshold or dangling links; --warn-only)" >&2
+    exit 0
+fi
+
+[[ $JSON -eq 0 ]] && echo "check-bead-scenario-coverage: FAIL" >&2
+exit 1

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1111,8 +1111,8 @@
     {
       "name": "test",
       "source_skill": "skills/test",
-      "source_hash": "04f0b05a580c0d89307302d723827c2da337365a5a7bd6b69d0ae201b36c8cd3",
-      "generated_hash": "9c2547ad936fbe0289c0fbe7c322e8c2418a09516594edfd4461547c94bb35fb"
+      "source_hash": "c269a74fee173b40849ab3908e11715b1398b4b0a6a74eb9b9c87934cfda5566",
+      "generated_hash": "100b04302b947d970b6d3158e0879248c42cbc3c565b8ad66bf8e6808b8495be"
     },
     {
       "name": "trace",
@@ -1147,8 +1147,8 @@
     {
       "name": "vibe",
       "source_skill": "skills/vibe",
-      "source_hash": "3de4aa35036213350fac4ea144186579ddf40753cff3247fd7e6c60d65aa80ea",
-      "generated_hash": "c0a5605f01736725d021050b32ea966ccd1a3e6296b4e8d4995d0f2c4e95e365"
+      "source_hash": "26612fcfa3570444f0c19db6ace2e28b6b1ebb8a1bffc174c6c38adc8c0b1cc0",
+      "generated_hash": "5d634b66e1b976630d41dc97bdff520930b0f4da2220096e61ca8a4f0762169e"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/test/.agentops-generated.json
+++ b/skills-codex/test/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/test",
   "layout": "modular",
-  "source_hash": "04f0b05a580c0d89307302d723827c2da337365a5a7bd6b69d0ae201b36c8cd3",
-  "generated_hash": "9c2547ad936fbe0289c0fbe7c322e8c2418a09516594edfd4461547c94bb35fb"
+  "source_hash": "c269a74fee173b40849ab3908e11715b1398b4b0a6a74eb9b9c87934cfda5566",
+  "generated_hash": "100b04302b947d970b6d3158e0879248c42cbc3c565b8ad66bf8e6808b8495be"
 }

--- a/skills-codex/test/SKILL.md
+++ b/skills-codex/test/SKILL.md
@@ -21,6 +21,22 @@ Generate real tests, run them, verify they pass, and produce coverage artifacts.
 
 Default mode is `generate` when unspecified. Detect from user intent.
 
+## Step 0a: Scenarios-First (when the work has acceptance scenarios)
+
+When the task is tied to a bead or `.feature` file, **author tests FORWARD from the Gherkin scenarios** — not backward from a coverage gap. This is the C2 contract (ag-9jle.4): the unit of test authoring is one scenario, one covering test.
+
+1. Read the scenarios: the bead's `## Scenarios` block (`bd show <bead-id>`) or a `.feature` under `skills/<skill>/references/`.
+2. For each `Scenario:`, locate or write the test that exercises its `Given/When/Then`. Name it after the behavior.
+3. Declare the linkage by adding `@covered-by:<test-path>` (optionally `::<TestName>`) directly above the scenario in its source — so the leaf coverage gate can prove the mapping.
+4. Run the leaf coverage gate and require it to pass before considering the slice tested:
+
+```bash
+bash scripts/check-bead-scenario-coverage.sh --bead <bead-id> --run      # every scenario -> a PASSING test
+bash scripts/check-bead-scenario-coverage.sh skills/<skill>/references/<name>.feature --run
+```
+
+A scenario with no covering test is a FAIL — "tests exist" or a coverage percentage is not sufficient. Then continue with coverage gap-fill (Steps 1–5) for everything the scenarios don't reach. When there are no scenarios, skip this step and use the coverage-driven flow below.
+
 ## Step 0: Detect Language and Load Standards
 
 Scan the project root for language markers. Stop at the first match:

--- a/skills-codex/vibe/.agentops-generated.json
+++ b/skills-codex/vibe/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/vibe",
   "layout": "modular",
-  "source_hash": "3de4aa35036213350fac4ea144186579ddf40753cff3247fd7e6c60d65aa80ea",
-  "generated_hash": "c0a5605f01736725d021050b32ea966ccd1a3e6296b4e8d4995d0f2c4e95e365"
+  "source_hash": "26612fcfa3570444f0c19db6ace2e28b6b1ebb8a1bffc174c6c38adc8c0b1cc0",
+  "generated_hash": "5d634b66e1b976630d41dc97bdff520930b0f4da2220096e61ca8a4f0762169e"
 }

--- a/skills-codex/vibe/SKILL.md
+++ b/skills-codex/vibe/SKILL.md
@@ -408,6 +408,20 @@ This is the same value — just labeled for the satisfaction scoring pipeline.
 
 When coverage gaps are found, run `$test <module>` to generate test candidates for uncovered code.
 
+### Scenario→Test Coverage (MANDATORY when the slice has scenarios)
+
+The test-pyramid inventory checks that tests *exist* and are well-shaped — it does NOT check that each of the slice's acceptance scenarios maps to a test. The leaf gate for that is `scripts/check-bead-scenario-coverage.sh` (C2, ag-9jle.4). It parses the bead's `## Scenarios` block (or a `.feature` file) and FAILS if any scenario lacks a `@covered-by:<test-path>` link — it works *forward from behavior*, not backward from coverage %.
+
+```bash
+# When validating a tracked bead with a ## Scenarios block:
+bash scripts/check-bead-scenario-coverage.sh --bead <bead-id> --json
+
+# When validating a .feature directly:
+bash scripts/check-bead-scenario-coverage.sh skills/<skill>/references/<name>.feature --json
+```
+
+A FAIL here is a vibe blocker, not a WARN: "tests exist" or a coverage percentage is NOT sufficient — every scenario must declare a covering test. Add `@covered-by:<test-path>` (optionally `::<TestName>`) directly above each uncovered `Scenario:`. Skip only when the slice has no scenarios (free-text acceptance must be promoted to scenarios first). When the covering tests are runnable in this checkout, prefer `--run` to require they actually PASS, not merely exist.
+
 ### Step 2g: Check for Product Context
 
 **Skip if `--quick` as a separate judge-fanout step.** In quick mode, the same DX expectations are still loaded inline during review. In non-quick modes, add the dedicated `developer-experience` perspective.

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -47,6 +47,22 @@ Generate real tests, run them, verify they pass, and produce coverage artifacts.
 
 Default mode is `generate` when unspecified. Detect from user intent.
 
+## Step 0a: Scenarios-First (when the work has acceptance scenarios)
+
+When the task is tied to a bead or `.feature` file, **author tests FORWARD from the Gherkin scenarios** — not backward from a coverage gap. This is the C2 contract (ag-9jle.4): the unit of test authoring is one scenario, one covering test.
+
+1. Read the scenarios: the bead's `## Scenarios` block (`bd show <bead-id>`) or a `.feature` under `skills/<skill>/references/`.
+2. For each `Scenario:`, locate or write the test that exercises its `Given/When/Then`. Name it after the behavior.
+3. Declare the linkage by adding `@covered-by:<test-path>` (optionally `::<TestName>`) directly above the scenario in its source — so the leaf coverage gate can prove the mapping.
+4. Run the leaf coverage gate and require it to pass before considering the slice tested:
+
+```bash
+bash scripts/check-bead-scenario-coverage.sh --bead <bead-id> --run      # every scenario -> a PASSING test
+bash scripts/check-bead-scenario-coverage.sh skills/<skill>/references/<name>.feature --run
+```
+
+A scenario with no covering test is a FAIL — "tests exist" or a coverage percentage is not sufficient. Then continue with coverage gap-fill (Steps 1–5) for everything the scenarios don't reach. When there are no scenarios, skip this step and use the coverage-driven flow below.
+
 ## Step 0: Detect Language and Load Standards
 
 Scan the project root for language markers. Stop at the first match:

--- a/skills/vibe/SKILL.md
+++ b/skills/vibe/SKILL.md
@@ -218,6 +218,20 @@ Run proactive bug-hunt audit on target files.
 
 Read [references/test-pyramid-inventory.md](references/test-pyramid-inventory.md) when you need the full inventory procedure: per-module L0–L3 coverage checks, BF1–BF5 boundary checks, the `weighted_score` formula, satisfaction-score exposure, the council-packet `test_pyramid` JSON shape, and verdict rules. Runs in both `--quick` and full modes — file existence checks are cheap. Weight L0–L1 at 1x, L2 at 3x, L3+ at 5x; `weighted_score < 0.3` with L0–L1 only is a WARN.
 
+### Step 2g.1: Scenario→Test Coverage (MANDATORY when the slice has scenarios)
+
+Test-pyramid inventory (2g) checks that tests *exist* and are well-shaped — it does NOT check that each of the slice's acceptance scenarios maps to a test. The leaf gate for that is `scripts/check-bead-scenario-coverage.sh` (C2, ag-9jle.4). It parses the bead's `## Scenarios` block (or a `.feature` file) and FAILS if any scenario lacks a `@covered-by:<test-path>` link — i.e. it works *forward from behavior*, not backward from coverage %.
+
+```bash
+# When validating a tracked bead with a ## Scenarios block:
+bash scripts/check-bead-scenario-coverage.sh --bead <bead-id> --json
+
+# When validating a .feature directly:
+bash scripts/check-bead-scenario-coverage.sh skills/<skill>/references/<name>.feature --json
+```
+
+A FAIL here is a vibe blocker, not a WARN: "tests exist" or a coverage percentage is NOT sufficient — every scenario must declare a covering test. Add `@covered-by:<test-path>` (optionally `::<TestName>`) directly above each uncovered `Scenario:`. Skip only when the slice has no scenarios (free-text acceptance must be promoted to scenarios first — see the workflow contract). When the covering tests are runnable in this checkout, prefer `--run` to require they actually PASS, not merely exist.
+
 ### Step 4: Run Council Validation
 
 **With spec found — use code-review preset:**

--- a/tests/scripts/check-bead-scenario-coverage.bats
+++ b/tests/scripts/check-bead-scenario-coverage.bats
@@ -1,0 +1,219 @@
+#!/usr/bin/env bats
+
+# Regression tests for scripts/check-bead-scenario-coverage.sh (ag-9jle.4).
+#
+# This is the LEAF-validator, per-bead scenario->test coverage gate — the
+# forward-from-Gherkin sibling of the corpus-wide check-scenario-test-linkage.sh.
+# The script resolves REPO_ROOT relative to its own location, so we copy it into
+# a self-contained fake repo and resolve @covered-by targets there.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/check-bead-scenario-coverage.sh"
+
+    TMP_DIR="$(mktemp -d)"
+    FAKE_REPO="$TMP_DIR/repo"
+    mkdir -p "$FAKE_REPO/scripts" "$FAKE_REPO/tests/e2e" "$FAKE_REPO/work"
+    /bin/cp "$SCRIPT" "$FAKE_REPO/scripts/check-bead-scenario-coverage.sh"
+    chmod +x "$FAKE_REPO/scripts/check-bead-scenario-coverage.sh"
+    FAKE_SCRIPT="$FAKE_REPO/scripts/check-bead-scenario-coverage.sh"
+
+    # A passing covering test (exit 0) with a named function.
+    cat > "$FAKE_REPO/tests/e2e/pass.sh" <<'EOF'
+#!/usr/bin/env bash
+TestCoversScenario() { :; }
+exit 0
+EOF
+    # A failing covering test (exit 1) — present but not passing.
+    cat > "$FAKE_REPO/tests/e2e/fail.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+# Write a bead-body file with a `## Scenarios` block. $1=outfile; rest = lines
+# of the form "TAG|||SCENARIO_NAME" (TAG may be empty).
+write_bead() {
+    local out="$1"; shift
+    {
+        printf '## Background\nWhy this matters.\n\n## Scenarios\n'
+        for pair in "$@"; do
+            local tag="${pair%%|||*}" name="${pair##*|||}"
+            [ -n "$tag" ] && printf '  %s\n' "$tag"
+            printf 'Scenario: %s\n  Given a thing\n  When it runs\n  Then it works\n\n' "$name"
+        done
+        printf '## Logging\nLog it.\n'
+    } > "$out"
+}
+
+# Write a bare .feature file. $1=outfile; rest = "TAG|||SCENARIO_NAME".
+write_feature() {
+    local out="$1"; shift
+    {
+        printf '# fake spec\n\nFeature: leaf coverage\n\n'
+        for pair in "$@"; do
+            local tag="${pair%%|||*}" name="${pair##*|||}"
+            [ -n "$tag" ] && printf '  %s\n' "$tag"
+            printf '  Scenario: %s\n    When x\n    Then y\n\n' "$name"
+        done
+    } > "$out"
+}
+
+@test "script exists and is executable" {
+    [ -f "$SCRIPT" ]
+    [ -x "$SCRIPT" ]
+}
+
+@test "PASS: all scenarios in a bead body covered (M==N)" {
+    write_bead "$FAKE_REPO/work/bead.md" \
+        "@covered-by:tests/e2e/pass.sh|||first scenario" \
+        "@covered-by:tests/e2e/pass.sh|||second scenario"
+    run bash "$FAKE_SCRIPT" "$FAKE_REPO/work/bead.md"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"* ]]
+    [[ "$output" == *"2/2"* ]]
+}
+
+@test "FAIL: a scenario lacks any covering test (M<N), not merely 'tests exist'" {
+    write_bead "$FAKE_REPO/work/bead.md" \
+        "@covered-by:tests/e2e/pass.sh|||covered scenario" \
+        "|||uncovered scenario"
+    run bash "$FAKE_SCRIPT" "$FAKE_REPO/work/bead.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no covering test"* ]]
+    [[ "$output" == *"uncovered scenario"* ]]
+}
+
+@test "FAIL: dangling @covered-by (test file missing)" {
+    write_bead "$FAKE_REPO/work/bead.md" \
+        "@covered-by:tests/e2e/missing.sh|||scenario one"
+    run bash "$FAKE_SCRIPT" "$FAKE_REPO/work/bead.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"dangling"* ]]
+    [[ "$output" == *"test path does not exist"* ]]
+}
+
+@test "FAIL: dangling @covered-by path::Name (name missing in file)" {
+    write_bead "$FAKE_REPO/work/bead.md" \
+        "@covered-by:tests/e2e/pass.sh::TestDoesNotExist|||named dangling"
+    run bash "$FAKE_SCRIPT" "$FAKE_REPO/work/bead.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not found in"* ]]
+}
+
+@test "PASS: @covered-by path::Name resolves when the name exists" {
+    write_bead "$FAKE_REPO/work/bead.md" \
+        "@covered-by:tests/e2e/pass.sh::TestCoversScenario|||named cover"
+    run bash "$FAKE_SCRIPT" "$FAKE_REPO/work/bead.md"
+    [ "$status" -eq 0 ]
+}
+
+@test "--run PASS: covering test present AND exits 0" {
+    write_bead "$FAKE_REPO/work/bead.md" \
+        "@covered-by:tests/e2e/pass.sh|||runnable scenario"
+    run bash "$FAKE_SCRIPT" --run "$FAKE_REPO/work/bead.md"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"passing"* ]]
+}
+
+@test "--run FAIL: covering test present but exits non-zero (not passing)" {
+    write_bead "$FAKE_REPO/work/bead.md" \
+        "@covered-by:tests/e2e/fail.sh|||failing scenario"
+    run bash "$FAKE_SCRIPT" --run "$FAKE_REPO/work/bead.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"did not pass"* ]]
+}
+
+@test "without --run, a present-but-failing test still counts as covered" {
+    write_bead "$FAKE_REPO/work/bead.md" \
+        "@covered-by:tests/e2e/fail.sh|||present scenario"
+    run bash "$FAKE_SCRIPT" "$FAKE_REPO/work/bead.md"
+    [ "$status" -eq 0 ]
+}
+
+@test "bare .feature file: scenarios are in scope without a ## Scenarios heading" {
+    write_feature "$FAKE_REPO/work/x.feature" \
+        "@covered-by:tests/e2e/pass.sh|||feature scenario one" \
+        "@covered-by:tests/e2e/pass.sh|||feature scenario two"
+    run bash "$FAKE_SCRIPT" "$FAKE_REPO/work/x.feature"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"2/2"* ]]
+}
+
+@test "scenarios outside the ## Scenarios block are not counted" {
+    # A Scenario: line under a later H2 must not be counted.
+    {
+        printf '## Scenarios\n'
+        printf '@covered-by:tests/e2e/pass.sh\n'
+        printf 'Scenario: real scenario\n  Then y\n\n'
+        printf '## Notes\n'
+        printf 'Scenario: not a real scenario, just prose\n'
+    } > "$FAKE_REPO/work/bead.md"
+    run bash "$FAKE_SCRIPT" --json "$FAKE_REPO/work/bead.md"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"scenarios_total":1'* ]]
+}
+
+@test "--min-covered threshold below N still passes when met" {
+    write_bead "$FAKE_REPO/work/bead.md" \
+        "@covered-by:tests/e2e/pass.sh|||covered scenario" \
+        "|||uncovered scenario"
+    run bash "$FAKE_SCRIPT" --min-covered=1 "$FAKE_REPO/work/bead.md"
+    [ "$status" -eq 0 ]
+}
+
+@test "--json emits a machine-readable summary" {
+    write_bead "$FAKE_REPO/work/bead.md" \
+        "@covered-by:tests/e2e/pass.sh|||covered scenario"
+    run bash "$FAKE_SCRIPT" --json "$FAKE_REPO/work/bead.md"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"result":"pass"'* ]]
+    [[ "$output" == *'"scenarios_covered":1'* ]]
+}
+
+@test "--json reports fail with covered<total" {
+    write_bead "$FAKE_REPO/work/bead.md" \
+        "@covered-by:tests/e2e/pass.sh|||covered scenario" \
+        "|||uncovered scenario"
+    run bash "$FAKE_SCRIPT" --json "$FAKE_REPO/work/bead.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"result":"fail"'* ]]
+    [[ "$output" == *'"scenarios_total":2'* ]]
+    [[ "$output" == *'"scenarios_covered":1'* ]]
+}
+
+@test "--warn-only downgrades a failure to exit 0" {
+    write_bead "$FAKE_REPO/work/bead.md" "|||uncovered scenario"
+    run bash "$FAKE_SCRIPT" --warn-only "$FAKE_REPO/work/bead.md"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARN"* ]]
+}
+
+@test "stdin source via '-'" {
+    write_bead "$FAKE_REPO/work/bead.md" \
+        "@covered-by:tests/e2e/pass.sh|||piped scenario"
+    run bash -c "cat '$FAKE_REPO/work/bead.md' | bash '$FAKE_SCRIPT' -"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"1/1"* ]]
+}
+
+@test "misuse: missing source exits 2" {
+    run bash "$FAKE_SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"no source given"* ]]
+}
+
+@test "misuse: nonexistent source file exits 2" {
+    run bash "$FAKE_SCRIPT" "$FAKE_REPO/work/nope.md"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"does not exist"* ]]
+}
+
+@test "misuse: unknown flag exits 2" {
+    run bash "$FAKE_SCRIPT" --bogus "$FAKE_REPO/work/bead.md"
+    [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## What

Adds the C2 "tests-from-scenarios" leaf gate (ag-9jle.4): a per-bead, forward-from-Gherkin scenario→test coverage check, plus wiring into the leaf validators `/vibe` and `/test`.

`scripts/check-bead-scenario-coverage.sh` parses a bead's `## Scenarios` block (via `--bead <id>`), a `.feature` file, or stdin, and **FAILS if any scenario lacks a `@covered-by:<test-path>` link**. With `--run` it also executes each covering test and requires it to PASS — not merely exist. This is the distinction the bead calls out: "tests exist" or a coverage percentage is not sufficient.

This is the **per-slice sibling** of the existing corpus-wide `scripts/check-scenario-test-linkage.sh` (which sweeps every `.feature` under `skills/*/references/` in CI). They share the `@covered-by:` convention so a scenario authored once carries linkage to both. No new `ao` subcommand (avoids cli-command-surface churn); no symlinks (codex twins copied).

## Why

Audit ag-9jle.1 found C2 weak: vibe/validate check test-pyramid *presence*, `test` checks coverage %, review uses a checkbox; only `/validation` enforced scenario→passing-test mapping and only at the bypassable roll-up. This makes the check mechanical and moves it to the leaf (vibe Step 2g.1, test Step 0a), working forward from behavior.

## How it's tested

`tests/scripts/check-bead-scenario-coverage.bats` — 19 hermetic cases: M>=N gate, bead-body + `.feature` inputs, `--run` pass vs fail, dangling `@covered-by`, `::Name` resolution, threshold override, `--json`, stdin, `## Scenarios`-block scoping, misuse exits. The gate is dogfooded: it passes on its own bead ag-9jle.4 (`--run` executes this very bats file).

## Gates

- `bats tests/scripts/check-bead-scenario-coverage.bats` — 19/19 pass
- `shellcheck scripts/check-bead-scenario-coverage.sh` — clean
- `bash scripts/check-codex-parity-drift.sh` — no drift (codex twins mirrored)
- `bash tests/skills/run-all.sh` — 87/0 pass

Closes-scenario: ag-9jle.4#tests-from-scenarios
Bounded-context: BC2-Validation
Evidence: scripts/check-bead-scenario-coverage.sh
