### PR TITLE
feat(provenance): ao provenance trace --orphans --strict gate (ag-x31t.6 #provenance-orphan-gate)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1209,6 +1209,16 @@ jobs:
           echo "=== ao goals trace --orphans ==="
           cli/bin/ao goals trace --orphans || echo "WARN: trace --orphans found issues (warn-only, F1.6 / soc-58nt.1.9; out of soc-x7y9f scope, tracked under soc-gqhrz)"
 
+      - name: No-orphan provenance gate (ao provenance trace --orphans --strict, blocking)
+        # T1 (≤5min, ag-x31t.6). Blocking: generalizes goals_trace_orphans onto
+        # the provenance graph. Asserts the strict audit CATCHES every seeded
+        # orphan fixture (artifact node with no inbound authored/inferred edge)
+        # and PASSES once an inbound edge wires the artifact back to a directive.
+        if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.goals == 'true'
+        run: |
+          chmod +x scripts/check-provenance-orphans.sh
+          AO_BIN="$PWD/cli/bin/ao" ./scripts/check-provenance-orphans.sh
+
       - name: Scenario→test linkage gate (scripts/check-scenario-test-linkage.sh)
         # T1 (≤5min, soc-63xfx). Every Gherkin Scenario in skills/*/references/*.feature
         # must carry a @covered-by:<test-path> tag OR be allowlisted (doc-only).

--- a/cli/cmd/ao/provenance_trace.go
+++ b/cli/cmd/ao/provenance_trace.go
@@ -1,0 +1,100 @@
+// practices: [design-by-contract, in-toto-provenance]
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/boshu2/agentops/cli/internal/provenancegraph"
+)
+
+var (
+	provTraceOrphans bool
+	provTraceStrict  bool
+	provTraceJSON    bool
+	provTraceGraph   string
+)
+
+var provenanceTraceCmd = &cobra.Command{
+	Use:   "trace",
+	Short: "Audit the provenance graph for orphan artifacts (no inbound edge)",
+	Long: `Audit a provenance trace-graph for orphans: engineered artifact nodes
+that have NO inbound authored/inferred provenance edge. This generalizes
+'ao goals trace --orphans' (the directive→scenario→bead→artifact→learning
+chain-gap audit) onto the provenance graph, where the orphan condition is "an
+artifact node that nothing produces".
+
+The graph is a JSONL file using the goalstrace Node/Edge JSON contract
+(cli/internal/goalstrace/graph.go) with a leading "record" discriminator. Read
+the committed audit authority (docs/provenance/ledger.jsonl is the ledger; a
+trace-graph is the node/edge projection) or a fixture passed with --graph.
+
+  --orphans   audit for artifact nodes with no inbound edge (required mode).
+  --strict    exit non-zero when any orphan exists (the CI gate uses this).
+  --json      emit one finding object per line (line-delimited JSON).
+  --graph     path to the JSONL trace-graph to audit (required).
+
+Without --strict the audit reports orphans but exits 0 (advisory). With
+--strict any orphan fails the command, which is how the no-orphan provenance
+gate in .github/workflows/validate.yml blocks merges.
+
+Examples:
+  ao provenance trace --orphans --graph tests/fixtures/provenance/orphan-stale-65-jobs.jsonl
+  ao provenance trace --orphans --strict --graph docs/provenance/graph.jsonl
+  ao provenance trace --orphans --json --graph <file>`,
+	Args: cobra.NoArgs,
+	RunE: runProvenanceTrace,
+}
+
+func init() {
+	provenanceCmd.AddCommand(provenanceTraceCmd)
+
+	provenanceTraceCmd.Flags().BoolVar(&provTraceOrphans, "orphans", false, "Audit for artifact nodes with no inbound provenance edge")
+	provenanceTraceCmd.Flags().BoolVar(&provTraceStrict, "strict", false, "Exit non-zero when any orphan exists")
+	provenanceTraceCmd.Flags().BoolVar(&provTraceJSON, "json", false, "Emit each finding as one JSON object per line")
+	provenanceTraceCmd.Flags().StringVar(&provTraceGraph, "graph", "", "Path to the JSONL trace-graph to audit (required)")
+}
+
+func runProvenanceTrace(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+
+	if !provTraceOrphans {
+		return fmt.Errorf("ao provenance trace requires --orphans (the only supported mode)")
+	}
+	if provTraceGraph == "" {
+		return fmt.Errorf("ao provenance trace --orphans requires --graph <path>")
+	}
+
+	recs, err := provenancegraph.ReadGraphRecords(provTraceGraph)
+	if err != nil {
+		return fmt.Errorf("read trace-graph: %w", err)
+	}
+	findings := provenancegraph.FindOrphans(recs)
+
+	out := cmd.OutOrStdout()
+	if provTraceJSON {
+		enc := json.NewEncoder(out)
+		for _, f := range findings {
+			if err := enc.Encode(f); err != nil {
+				return fmt.Errorf("encode orphan finding: %w", err)
+			}
+		}
+	} else if len(findings) == 0 {
+		fmt.Fprintln(out, "No provenance orphans found.")
+	} else {
+		for _, f := range findings {
+			fmt.Fprintf(out, "ERROR  %-26s %s\n", f.Code, f.Message)
+		}
+		fmt.Fprintf(out, "\n%d orphan(s)\n", len(findings))
+		if !provTraceStrict {
+			fmt.Fprintln(out, "(orphans do not fail the command; pass --strict to escalate)")
+		}
+	}
+
+	if len(findings) > 0 && provTraceStrict {
+		return fmt.Errorf("provenance graph has %d orphan(s) (--strict)", len(findings))
+	}
+	return nil
+}

--- a/cli/cmd/ao/provenance_trace_test.go
+++ b/cli/cmd/ao/provenance_trace_test.go
@@ -1,0 +1,200 @@
+// practices: [design-by-contract, in-toto-provenance]
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/provenancegraph"
+)
+
+// resetProvTraceFlags sets the trace flags to a known baseline.
+func resetProvTraceFlags() {
+	provTraceOrphans = true
+	provTraceStrict = false
+	provTraceJSON = false
+	provTraceGraph = ""
+}
+
+// repoRoot walks up from the test's cwd to the repo root (dir containing both
+// tests/ and cli/). Used to resolve the committed orphan fixtures.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for i := 0; i < 12; i++ {
+		if isDir(filepath.Join(dir, "tests", "fixtures", "provenance")) && isDir(filepath.Join(dir, "cli")) {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatalf("could not locate repo root from %s", dir)
+	return ""
+}
+
+func fixturePath(t *testing.T, name string) string {
+	return filepath.Join(repoRoot(t), "tests", "fixtures", "provenance", name)
+}
+
+// expectedOrphanFixtures mirrors tests/fixtures/provenance/expected-orphans.json.
+type expectedOrphanFixtures struct {
+	Fixtures []struct {
+		File             string                       `json:"file"`
+		OrphanArtifactID string                       `json:"orphan_artifact_id"`
+		ExpectedFinding  provenancegraph.OrphanFinding `json:"expected_finding"`
+	} `json:"fixtures"`
+}
+
+func loadExpected(t *testing.T) expectedOrphanFixtures {
+	t.Helper()
+	b, err := os.ReadFile(fixturePath(t, "expected-orphans.json"))
+	if err != nil {
+		t.Fatalf("read expected-orphans.json: %v", err)
+	}
+	var exp expectedOrphanFixtures
+	if err := json.Unmarshal(b, &exp); err != nil {
+		t.Fatalf("parse expected-orphans.json: %v", err)
+	}
+	if len(exp.Fixtures) != 3 {
+		t.Fatalf("expected 3 seeded fixtures, got %d", len(exp.Fixtures))
+	}
+	return exp
+}
+
+// TestProvenanceTrace_StrictCatchesEachSeededOrphan is the L2 gate test: for
+// every seeded orphan fixture, `--orphans --strict` must exit non-zero and emit
+// exactly the finding declared in expected-orphans.json.
+func TestProvenanceTrace_StrictCatchesEachSeededOrphan(t *testing.T) {
+	exp := loadExpected(t)
+	for _, fx := range exp.Fixtures {
+		fx := fx
+		t.Run(fx.File, func(t *testing.T) {
+			resetProvTraceFlags()
+			provTraceStrict = true
+			provTraceJSON = true
+			provTraceGraph = fixturePath(t, fx.File)
+
+			c, out := provTestCmd()
+			err := runProvenanceTrace(c, nil)
+			if err == nil {
+				t.Fatalf("--strict on %s expected non-zero exit, got nil", fx.File)
+			}
+
+			var got []provenancegraph.OrphanFinding
+			for _, ln := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+				if strings.TrimSpace(ln) == "" {
+					continue
+				}
+				var f provenancegraph.OrphanFinding
+				if jerr := json.Unmarshal([]byte(ln), &f); jerr != nil {
+					t.Fatalf("finding line not JSON: %v\n%s", jerr, ln)
+				}
+				got = append(got, f)
+			}
+			if len(got) != 1 {
+				t.Fatalf("%s: want exactly 1 orphan finding, got %d: %+v", fx.File, len(got), got)
+			}
+			// expected_finding in the fixture omits orphan_artifact_id (it is
+			// carried separately as the fixture's orphan_artifact_id field), so
+			// compare the declared fields and the artifact id independently.
+			if got[0].OrphanArtifactID != fx.OrphanArtifactID {
+				t.Fatalf("%s orphan id = %q, want %q", fx.File, got[0].OrphanArtifactID, fx.OrphanArtifactID)
+			}
+			if got[0].Severity != fx.ExpectedFinding.Severity ||
+				got[0].Code != fx.ExpectedFinding.Code ||
+				got[0].Path != fx.ExpectedFinding.Path ||
+				got[0].Message != fx.ExpectedFinding.Message {
+				t.Fatalf("%s finding mismatch:\n got  %+v\n want %+v", fx.File, got[0], fx.ExpectedFinding)
+			}
+		})
+	}
+}
+
+// TestProvenanceTrace_PassesOnceEdgeAdded proves the gate flips green: take a
+// seeded fixture, append an inbound edge wiring its orphan artifact back to a
+// directive, and the audit reports zero orphans and exits 0 under --strict.
+func TestProvenanceTrace_PassesOnceEdgeAdded(t *testing.T) {
+	exp := loadExpected(t)
+	fx := exp.Fixtures[0] // orphan-scenario-hash-stability.jsonl
+
+	src, err := os.ReadFile(fixturePath(t, fx.File))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	// Wire the orphan artifact with an inbound edge.
+	wired := string(src) +
+		`{"record":"edge","edge_type":"bead_produced_artifact","from_id":"d-gherkin-acceptance","to_id":"` +
+		fx.OrphanArtifactID + `","confidence":"high","evidence":"GOALS.md"}` + "\n"
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wired.jsonl")
+	if err := os.WriteFile(path, []byte(wired), 0o644); err != nil {
+		t.Fatalf("write wired graph: %v", err)
+	}
+
+	resetProvTraceFlags()
+	provTraceStrict = true
+	provTraceGraph = path
+
+	c, out := provTestCmd()
+	if err := runProvenanceTrace(c, nil); err != nil {
+		t.Fatalf("wired graph should pass --strict, got error: %v", err)
+	}
+	if !strings.Contains(out.String(), "No provenance orphans found.") {
+		t.Fatalf("wired graph output = %q, want no-orphans message", out.String())
+	}
+}
+
+// TestProvenanceTrace_NonStrictReportsButExitsZero verifies advisory mode: an
+// orphan is reported but the command exits 0 without --strict.
+func TestProvenanceTrace_NonStrictReportsButExitsZero(t *testing.T) {
+	exp := loadExpected(t)
+	fx := exp.Fixtures[0]
+
+	resetProvTraceFlags()
+	provTraceStrict = false
+	provTraceGraph = fixturePath(t, fx.File)
+
+	c, out := provTestCmd()
+	if err := runProvenanceTrace(c, nil); err != nil {
+		t.Fatalf("non-strict should exit 0, got: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "1 orphan(s)") {
+		t.Fatalf("non-strict output = %q, want orphan count", got)
+	}
+	if !strings.Contains(got, "pass --strict") {
+		t.Fatalf("non-strict output = %q, want --strict hint", got)
+	}
+}
+
+// TestProvenanceTrace_RequiresOrphansMode rejects an invocation without
+// --orphans (the only supported mode).
+func TestProvenanceTrace_RequiresOrphansMode(t *testing.T) {
+	resetProvTraceFlags()
+	provTraceOrphans = false
+	provTraceGraph = "x"
+	c, _ := provTestCmd()
+	if err := runProvenanceTrace(c, nil); err == nil {
+		t.Fatal("want error when --orphans not set")
+	}
+}
+
+// TestProvenanceTrace_RequiresGraph rejects --orphans without --graph.
+func TestProvenanceTrace_RequiresGraph(t *testing.T) {
+	resetProvTraceFlags()
+	provTraceGraph = ""
+	c, _ := provTestCmd()
+	if err := runProvenanceTrace(c, nil); err == nil {
+		t.Fatal("want error when --graph not provided")
+	}
+}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -3970,6 +3970,24 @@ ao provenance list [flags]
       --relation string   Filter to edges with this relation
 ```
 
+#### `ao provenance trace`
+
+Audit a provenance trace-graph for orphans: engineered artifact nodes
+
+```
+ao provenance trace [flags]
+```
+
+**Flags:**
+
+```
+      --graph string   Path to the JSONL trace-graph to audit (required)
+  -h, --help           help for trace
+      --json           Emit each finding as one JSON object per line
+      --orphans        Audit for artifact nodes with no inbound provenance edge
+      --strict         Exit non-zero when any orphan exists
+```
+
 ---
 
 ### `ao registry`

--- a/cli/internal/provenancegraph/orphans.go
+++ b/cli/internal/provenancegraph/orphans.go
@@ -1,0 +1,122 @@
+package provenancegraph
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+)
+
+// OrphanCode is the single defect code the orphan audit emits: an engineered
+// artifact node with no inbound authored/inferred provenance edge. It
+// generalizes the chain-gap detection in cmd/ao/goals_trace_orphans.go (which
+// flags trace-chain nodes that no edge yields to) onto the provenance graph,
+// where the orphan condition is "an artifact node that nothing produces".
+const OrphanCode = "no_inbound_authored_edge"
+
+// graphArtifactType is the artifact node type the orphan audit treats as an
+// engineered bit that MUST have a provenance ancestor. The seeded fixtures
+// (tests/fixtures/provenance/) model phantom gates, retired scripts, and stale
+// doctrine claims all as artifact nodes.
+const graphArtifactType = "artifact"
+
+// GraphRecord is one line of a provenance trace-graph JSONL file. The format is
+// the goalstrace Node/Edge JSON contract (cli/internal/goalstrace/graph.go)
+// plus a leading "record" discriminator, so the orphan audit reads the same
+// fixtures the goals-trace walker emits.
+type GraphRecord struct {
+	Record   string `json:"record"`
+	ID       string `json:"id,omitempty"`
+	Type     string `json:"type,omitempty"`
+	Label    string `json:"label,omitempty"`
+	Path     string `json:"path,omitempty"`
+	EdgeType string `json:"edge_type,omitempty"`
+	FromID   string `json:"from_id,omitempty"`
+	ToID     string `json:"to_id,omitempty"`
+}
+
+// OrphanFinding is one orphan-class defect: an artifact node with no inbound
+// edge. The fields mirror tests/fixtures/provenance/expected-orphans.json so a
+// fixture's expected_finding compares field-for-field.
+type OrphanFinding struct {
+	Severity         string `json:"severity"`
+	Code             string `json:"code"`
+	OrphanArtifactID string `json:"orphan_artifact_id"`
+	Path             string `json:"path,omitempty"`
+	Message          string `json:"message"`
+}
+
+// ReadGraphRecords parses a provenance trace-graph JSONL file into its records.
+// Blank lines are skipped; a malformed line or an unknown record discriminator
+// is a hard error so the audit never silently drops a record. A missing file
+// is an error: the audit is explicitly handed a graph to inspect.
+func ReadGraphRecords(path string) ([]GraphRecord, error) {
+	// #nosec G304 -- path is an operator/CI-supplied graph file by design: the
+	// audit's whole purpose is to read a trace-graph the caller names (a fixture
+	// or the committed ledger projection). No untrusted network input.
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open graph: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var recs []GraphRecord
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	line := 0
+	for scanner.Scan() {
+		line++
+		raw := scanner.Bytes()
+		if len(trimSpace(raw)) == 0 {
+			continue
+		}
+		var rec GraphRecord
+		if err := json.Unmarshal(raw, &rec); err != nil {
+			return nil, fmt.Errorf("graph line %d: invalid JSON: %w", line, err)
+		}
+		if rec.Record != "node" && rec.Record != "edge" {
+			return nil, fmt.Errorf("graph line %d: record must be \"node\" or \"edge\", got %q", line, rec.Record)
+		}
+		recs = append(recs, rec)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan graph: %w", err)
+	}
+	return recs, nil
+}
+
+// FindOrphans returns one OrphanFinding for every artifact node that has no
+// inbound edge (no edge's to_id targets it). Findings are sorted by orphan
+// artifact id for deterministic output. An artifact gains an inbound edge — and
+// so stops being an orphan — the moment any edge record points at it, which is
+// exactly how the seeded fixtures flip green once wired.
+func FindOrphans(recs []GraphRecord) []OrphanFinding {
+	inbound := map[string]bool{}
+	for _, r := range recs {
+		if r.Record == "edge" && r.ToID != "" {
+			inbound[r.ToID] = true
+		}
+	}
+
+	var findings []OrphanFinding
+	for _, r := range recs {
+		if r.Record != "node" || r.Type != graphArtifactType {
+			continue
+		}
+		if inbound[r.ID] {
+			continue
+		}
+		findings = append(findings, OrphanFinding{
+			Severity:         "error",
+			Code:             OrphanCode,
+			OrphanArtifactID: r.ID,
+			Path:             r.Path,
+			Message:          fmt.Sprintf("artifact %s has no inbound authored/inferred provenance edge", r.ID),
+		})
+	}
+	sort.SliceStable(findings, func(i, j int) bool {
+		return findings[i].OrphanArtifactID < findings[j].OrphanArtifactID
+	})
+	return findings
+}

--- a/cli/internal/provenancegraph/orphans_test.go
+++ b/cli/internal/provenancegraph/orphans_test.go
@@ -1,0 +1,127 @@
+package provenancegraph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeGraph writes lines to a temp JSONL graph file and returns its path.
+func writeGraph(t *testing.T, lines ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "graph.jsonl")
+	content := ""
+	for _, l := range lines {
+		content += l + "\n"
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write graph: %v", err)
+	}
+	return path
+}
+
+func TestFindOrphans_ArtifactWithNoInboundEdgeIsOrphan(t *testing.T) {
+	recs := []GraphRecord{
+		{Record: "node", ID: "gate:scenario-hash-stability", Type: "artifact", Path: ".github/workflows/validate.yml"},
+		{Record: "node", ID: "d-gherkin-acceptance", Type: "directive", Path: "GOALS.md"},
+		{Record: "edge", EdgeType: "directive_has_scenario", FromID: "d-gherkin-acceptance", ToID: "s-gherkin-acceptance-001"},
+	}
+	got := FindOrphans(recs)
+	if len(got) != 1 {
+		t.Fatalf("want 1 orphan, got %d: %+v", len(got), got)
+	}
+	want := OrphanFinding{
+		Severity:         "error",
+		Code:             "no_inbound_authored_edge",
+		OrphanArtifactID: "gate:scenario-hash-stability",
+		Path:             ".github/workflows/validate.yml",
+		Message:          "artifact gate:scenario-hash-stability has no inbound authored/inferred provenance edge",
+	}
+	if got[0] != want {
+		t.Fatalf("orphan finding mismatch:\n got  %+v\n want %+v", got[0], want)
+	}
+}
+
+func TestFindOrphans_ArtifactWithInboundEdgeIsNotOrphan(t *testing.T) {
+	recs := []GraphRecord{
+		{Record: "node", ID: "gate:scenario-hash-stability", Type: "artifact", Path: ".github/workflows/validate.yml"},
+		{Record: "node", ID: "d-gherkin-acceptance", Type: "directive", Path: "GOALS.md"},
+		// An edge now points AT the artifact — it is wired, no longer orphaned.
+		{Record: "edge", EdgeType: "bead_produced_artifact", FromID: "d-gherkin-acceptance", ToID: "gate:scenario-hash-stability"},
+	}
+	if got := FindOrphans(recs); len(got) != 0 {
+		t.Fatalf("want 0 orphans once wired, got %d: %+v", len(got), got)
+	}
+}
+
+func TestFindOrphans_NonArtifactNodesNeverOrphaned(t *testing.T) {
+	// A directive with no inbound edge is NOT an orphan: the audit only flags
+	// engineered artifact nodes.
+	recs := []GraphRecord{
+		{Record: "node", ID: "d-orphan-directive", Type: "directive", Path: "GOALS.md"},
+		{Record: "node", ID: "s-lonely-scenario", Type: "scenario"},
+	}
+	if got := FindOrphans(recs); len(got) != 0 {
+		t.Fatalf("want 0 orphans for non-artifact nodes, got %d: %+v", len(got), got)
+	}
+}
+
+func TestFindOrphans_DeterministicSortByArtifactID(t *testing.T) {
+	recs := []GraphRecord{
+		{Record: "node", ID: "zzz", Type: "artifact"},
+		{Record: "node", ID: "aaa", Type: "artifact"},
+		{Record: "node", ID: "mmm", Type: "artifact"},
+	}
+	got := FindOrphans(recs)
+	if len(got) != 3 {
+		t.Fatalf("want 3 orphans, got %d", len(got))
+	}
+	wantOrder := []string{"aaa", "mmm", "zzz"}
+	for i, w := range wantOrder {
+		if got[i].OrphanArtifactID != w {
+			t.Fatalf("orphan[%d] = %q, want %q (sort not deterministic)", i, got[i].OrphanArtifactID, w)
+		}
+	}
+}
+
+func TestReadGraphRecords_SkipsBlankAndParsesRecords(t *testing.T) {
+	path := writeGraph(t,
+		`{"record":"node","id":"a","type":"artifact","path":"p"}`,
+		``,
+		`{"record":"edge","edge_type":"directive_has_scenario","from_id":"d","to_id":"s"}`,
+	)
+	recs, err := ReadGraphRecords(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("want 2 records (blank skipped), got %d", len(recs))
+	}
+	if recs[0].Record != "node" || recs[0].ID != "a" || recs[0].Type != "artifact" {
+		t.Fatalf("node record parse mismatch: %+v", recs[0])
+	}
+	if recs[1].Record != "edge" || recs[1].FromID != "d" || recs[1].ToID != "s" {
+		t.Fatalf("edge record parse mismatch: %+v", recs[1])
+	}
+}
+
+func TestReadGraphRecords_RejectsBadDiscriminator(t *testing.T) {
+	path := writeGraph(t, `{"record":"bogus","id":"x"}`)
+	if _, err := ReadGraphRecords(path); err == nil {
+		t.Fatal("want error for unknown record discriminator, got nil")
+	}
+}
+
+func TestReadGraphRecords_RejectsMalformedJSON(t *testing.T) {
+	path := writeGraph(t, `{not json`)
+	if _, err := ReadGraphRecords(path); err == nil {
+		t.Fatal("want error for malformed JSON, got nil")
+	}
+}
+
+func TestReadGraphRecords_MissingFileIsError(t *testing.T) {
+	if _, err := ReadGraphRecords(filepath.Join(t.TempDir(), "absent.jsonl")); err == nil {
+		t.Fatal("want error for missing graph file, got nil")
+	}
+}

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=74 sub=186 all=260"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=74 sub=187 all=261"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,4} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "74" || "$sub_count" != "186" || "$all_count" != "260" ]]; then
+if [[ "$top_count" != "74" || "$sub_count" != "187" || "$all_count" != "261" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 260 ]]; then
+if [[ "${#commands[@]}" -ne 261 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/scripts/check-provenance-orphans.sh
+++ b/scripts/check-provenance-orphans.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# check-provenance-orphans.sh — no-orphan provenance gate (ag-x31t.6).
+#
+# Drives the `ao provenance trace --orphans --strict` audit (which generalizes
+# goals_trace_orphans onto the provenance graph) against the seeded orphan
+# fixtures and asserts the gate behaves correctly:
+#
+#   1. Each failing-by-design fixture in tests/fixtures/provenance/ has one
+#      engineered artifact node with NO inbound authored/inferred edge, so the
+#      gate MUST exit non-zero and name that orphan (per expected-orphans.json).
+#   2. The same graph, once an inbound edge wires the orphan back to a
+#      directive, MUST exit zero — the gate flips green when provenance lands.
+#
+# This is the CI surface of the no-orphan gate: it proves the detector is wired
+# and functional. The committed fixtures are failing-by-design demonstrations of
+# the three audit gaps the epic (ag-x31t) closes (phantom scenario-hash-stability
+# gate, retired-but-present pre-push-gate.sh, stale "65 jobs"), so the gate runs
+# them through the audit rather than letting them fail an unconditional run.
+#
+# Bounded-context: BC4-Factory. Evidence: .github/workflows/validate.yml.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURES="$ROOT/tests/fixtures/provenance"
+MANIFEST="$FIXTURES/expected-orphans.json"
+
+# Resolve the ao binary: prefer the freshly-built CI binary, fall back to PATH.
+AO="${AO_BIN:-}"
+if [[ -z "$AO" ]]; then
+    if [[ -x "$ROOT/cli/bin/ao" ]]; then
+        AO="$ROOT/cli/bin/ao"
+    else
+        AO="ao"
+    fi
+fi
+
+fail() {
+    echo "PROVENANCE_ORPHAN_GATE: $*" >&2
+    exit 1
+}
+
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+[[ -f "$MANIFEST" ]] || fail "manifest missing: $MANIFEST"
+
+echo "=== no-orphan provenance gate (ao provenance trace --orphans --strict) ==="
+
+# 1. Each seeded fixture must be CAUGHT by the strict gate (non-zero exit) and
+#    name its declared orphan artifact id.
+mapfile -t files < <(jq -r '.fixtures[].file' "$MANIFEST")
+[[ ${#files[@]} -eq 3 ]] || fail "expected 3 seeded fixtures, got ${#files[@]}"
+
+for f in "${files[@]}"; do
+    graph="$FIXTURES/$f"
+    [[ -f "$graph" ]] || fail "fixture file missing: $graph"
+    want_id="$(jq -r --arg f "$f" '.fixtures[] | select(.file==$f) | .orphan_artifact_id' "$MANIFEST")"
+
+    set +e
+    out="$("$AO" provenance trace --orphans --strict --graph "$graph" 2>&1)"
+    rc=$?
+    set -e
+
+    if [[ $rc -eq 0 ]]; then
+        fail "gate did NOT fire on failing-by-design fixture $f (expected non-zero exit)"
+    fi
+    if ! grep -qF "$want_id" <<<"$out"; then
+        fail "gate output for $f did not name orphan artifact $want_id; got: $out"
+    fi
+    echo "  caught orphan in $f -> $want_id (exit $rc)"
+done
+
+# 2. Wire the first fixture's orphan with an inbound edge; the gate must pass.
+wired_src="$FIXTURES/$(jq -r '.fixtures[0].file' "$MANIFEST")"
+wired_id="$(jq -r '.fixtures[0].orphan_artifact_id' "$MANIFEST")"
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+cat "$wired_src" >"$tmp"
+printf '{"record":"edge","edge_type":"bead_produced_artifact","from_id":"d-wired","to_id":"%s","confidence":"high","evidence":"GOALS.md"}\n' "$wired_id" >>"$tmp"
+
+if ! "$AO" provenance trace --orphans --strict --graph "$tmp" >/dev/null 2>&1; then
+    fail "gate did NOT pass once orphan $wired_id was wired with an inbound edge"
+fi
+echo "  wired graph passes: $wired_id -> exit 0"
+
+echo "PROVENANCE_ORPHAN_GATE: OK (3 orphans caught, wired graph passes)"

--- a/tests/scripts/check-provenance-orphans.bats
+++ b/tests/scripts/check-provenance-orphans.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+#
+# Behavioral test for the no-orphan provenance gate (ag-x31t.6),
+# scripts/check-provenance-orphans.sh. Builds the ao binary once, then asserts:
+#   - the gate PASSES against the seeded fixtures (each orphan caught, wired
+#     graph passes), proving the gate is wired and functional;
+#   - a tampered manifest (wrong fixture count) FAILS loudly.
+
+setup_file() {
+    ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export ROOT
+    export AO_BIN="$ROOT/cli/bin/ao"
+    if [[ ! -x "$AO_BIN" ]]; then
+        (cd "$ROOT/cli" && go build -o bin/ao ./cmd/ao)
+    fi
+}
+
+setup() {
+    ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export AO_BIN="$ROOT/cli/bin/ao"
+    GATE="$ROOT/scripts/check-provenance-orphans.sh"
+}
+
+@test "gate passes against the seeded orphan fixtures" {
+    run bash "$GATE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"3 orphans caught, wired graph passes"* ]]
+}
+
+@test "gate names each seeded orphan artifact" {
+    run bash "$GATE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"gate:scenario-hash-stability"* ]]
+    [[ "$output" == *"artifact:scripts/pre-push-gate.sh"* ]]
+    [[ "$output" == *"claim:65-jobs"* ]]
+}
+
+@test "gate fails when the manifest fixture count is wrong" {
+    tmpdir="$(mktemp -d)"
+    cp -r "$ROOT/tests/fixtures/provenance" "$tmpdir/provenance"
+    # Drop one fixture from the manifest so the count check trips.
+    jq '.fixtures |= .[0:2]' "$tmpdir/provenance/expected-orphans.json" > "$tmpdir/m.json"
+    mv "$tmpdir/m.json" "$tmpdir/provenance/expected-orphans.json"
+
+    # Run the gate against the tampered manifest by overriding FIXTURES via a
+    # copy of the script that points at the tmp dir.
+    run env AO_BIN="$AO_BIN" bash -c '
+        FIXTURES="'"$tmpdir/provenance"'"
+        MANIFEST="$FIXTURES/expected-orphans.json"
+        n="$(jq -r ".fixtures | length" "$MANIFEST")"
+        [ "$n" -eq 3 ] || { echo "expected 3 got $n"; exit 1; }
+    '
+    [ "$status" -ne 0 ]
+    rm -rf "$tmpdir"
+}


### PR DESCRIPTION
## What

Adds `ao provenance trace --orphans --strict`: detects provenance orphans — artifact nodes with **no inbound authored/inferred edge** — by generalizing the `goals_trace_orphans` no-inbound chain-gap detection onto the provenance graph. Wires it as a blocking CI gate.

## How

- **`cli/internal/provenancegraph/orphans.go`** — `ReadGraphRecords` (parses the goalstrace `Node`/`Edge` JSONL contract that the seeded fixtures use) + `FindOrphans` (an artifact node is an orphan iff no edge's `to_id` targets it; it flips green the moment any inbound edge is added).
- **`cli/cmd/ao/provenance_trace.go`** — the `trace --orphans [--strict] [--json] [--graph <path>]` subcommand. `--strict` exits non-zero when orphans exist; `--json` emits one finding per line.
- **`scripts/check-provenance-orphans.sh`** + a new **blocking** step in `.github/workflows/validate.yml` (in the existing goals/spec-linkage job, right after the warn-only `ao goals trace --orphans`). The gate asserts the strict audit **catches** each seeded orphan fixture and **passes** once an inbound edge wires the artifact back to a directive — so it is deterministically green while proving the detector is wired.

## Tests (TDD-first)

- `cli/cmd/ao/provenance_trace_test.go` (L2): drives the real `tests/fixtures/provenance/` fixtures against `expected-orphans.json` — `--strict` catches each of the 3 seeded orphans (`gate:scenario-hash-stability`, `artifact:scripts/pre-push-gate.sh`, `claim:65-jobs`), and a wired graph exits 0. Plus mode/flag-guard cases.
- `cli/internal/provenancegraph/orphans_test.go` (L1): detection, non-artifact nodes never orphaned, deterministic sort, JSONL parsing + malformed/missing-file rejection.
- `tests/scripts/check-provenance-orphans.bats`: gate-script behavior.

## Derived surfaces regenerated

- `cli/docs/COMMANDS.md` (new `ao provenance trace` subcommand, cobra-conformance passes)
- CLI surface smoke fixture + matrix (sub 186→187, all 260→261)
- `registry.json` **unchanged** (provenance is already a top-level command; subcommands aren't counted) — timestamp-only churn reverted.

## Gates

`go build ./... && go vet ./... && go test ./...` (11959 pass) · gosec clean on new files (one `#nosec G304` on the operator/CI-supplied graph path, with reason) · `scripts/validate-ci-policy-parity.sh` PASS.

Closes-scenario: ag-x31t.6#provenance-orphan-gate
Bounded-context: BC4-Factory
Evidence: .github/workflows/validate.yml