### PR TITLE
feat(turnstate): event-log canonical source of truth, state as fold (ag-lmdx.2 #eventlog-source-of-truth)

### DIFF
--- a/cli/internal/turnstate/turnstate.go
+++ b/cli/internal/turnstate/turnstate.go
@@ -1,0 +1,327 @@
+// Package turnstate is the state-machine PROJECTION half of the ag-lmdx
+// "event-log canonical, state is a rebuildable projection" inversion. Where
+// cli/internal/provenancegraph is the write model for the provenance *graph*
+// and cli/internal/drrebuild proves the *graph* rebuilds from the ledger, this
+// package establishes the same invariant for an artifact's lifecycle *state*:
+//
+//	context_artifact.state is NOT authored. It is a FOLD over the
+//	append-only, hash-chained state_transition log.
+//
+// The parent epic (ag-lmdx) frames the unit of work as an "Evidenced-Turn
+// state machine": an artifact advances through lifecycle states only by
+// appending an evidence-backed Transition to its log. The current state of any
+// artifact is then `Fold(log)` — derived by replaying transitions in canonical
+// order — never an independently-written column. This makes the
+// author!=judge and orphan-gate invariants true *by construction*: there is no
+// state to corrupt out-of-band, only a log to append to and replay.
+//
+// Hash discipline mirrors cli/internal/rpi/ledger.go ComputeLedgerHashes and
+// cli/internal/provenancegraph exactly, so a Transition chain is verifiable by
+// the same rules the rest of the provenance substrate uses:
+//
+//	payload_hash = sha256(canonical JSON of every field EXCEPT
+//	               prev_hash/payload_hash/hash)
+//	hash         = sha256(payload_hash + "\n" + prev_hash)
+//	prev_hash    = the previous record's hash, "" for the genesis record.
+//
+// This package is deliberately a pure, in-memory write+fold core (no Dolt, no
+// file I/O): it is the testable kernel that proves the projection is faithful
+// and deterministic. Wiring it to a durable ledger and forbidding direct
+// context_artifact.state writes at every existing call site is a follow-up
+// migration (a bounded slice beats a sprawling refactor — see ag-lmdx).
+package turnstate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// SchemaVersion is the const discriminator stamped on every transition so the
+// log is self-describing and a mis-versioned record fails validation.
+const SchemaVersion = "agentops-turnstate.v1"
+
+// InitialState is the sentinel "before any transition" state. A genesis
+// transition for an artifact must declare FromState == InitialState; folding an
+// empty log yields this state.
+const InitialState = ""
+
+// Transition is one append-only state_transition event: an artifact moves from
+// FromState to ToState, backed by evidence, at TS. The three hash fields are
+// populated by Seal; callers supplying a new transition leave them empty.
+//
+// Field order and json tags are fixed so the canonical JSON used for hashing is
+// deterministic and byte-stable across runs and machines.
+type Transition struct {
+	SchemaVersion string `json:"schema_version"`
+	ArtifactID    string `json:"artifact_id"`
+	FromState     string `json:"from_state"`
+	ToState       string `json:"to_state"`
+	EvidenceRef   string `json:"evidence_ref,omitempty"`
+	TS            string `json:"ts"`
+	PrevHash      string `json:"prev_hash"`
+	PayloadHash   string `json:"payload_hash"`
+	Hash          string `json:"hash"`
+}
+
+// transitionPayload is the hash-input subset of a Transition: every field
+// EXCEPT prev_hash (which enters only via the outer hash) and the two derived
+// hash fields. Field order is fixed for deterministic canonical JSON.
+type transitionPayload struct {
+	SchemaVersion string `json:"schema_version"`
+	ArtifactID    string `json:"artifact_id"`
+	FromState     string `json:"from_state"`
+	ToState       string `json:"to_state"`
+	EvidenceRef   string `json:"evidence_ref,omitempty"`
+	TS            string `json:"ts"`
+}
+
+// hashHex returns the lowercase hex sha256 of data. Mirrors the rpi ledger and
+// provenancegraph helpers so chains are cross-verifiable by the same rule.
+func hashHex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// ComputeHashes derives payload_hash and hash for a transition given its
+// prev_hash, reusing the rpi/ledger.go + provenancegraph chaining semantics.
+func ComputeHashes(t Transition) (payloadHash, hash string, err error) {
+	payload := transitionPayload{
+		SchemaVersion: t.SchemaVersion,
+		ArtifactID:    t.ArtifactID,
+		FromState:     t.FromState,
+		ToState:       t.ToState,
+		EvidenceRef:   t.EvidenceRef,
+		TS:            t.TS,
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", "", fmt.Errorf("marshal payload: %w", err)
+	}
+	payloadHash = hashHex(b)
+	hash = hashHex([]byte(payloadHash + "\n" + t.PrevHash))
+	return payloadHash, hash, nil
+}
+
+// ValidateFields checks a transition's non-hash fields. ToState must be
+// non-empty (you cannot transition *to* the genesis sentinel), ArtifactID is
+// required, the schema version must match, and TS must be UTC RFC3339. It does
+// NOT check the hash chain (see VerifyChain) or fold ordering (see Fold).
+func ValidateFields(t Transition) error {
+	if t.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("schema_version must be %q, got %q", SchemaVersion, t.SchemaVersion)
+	}
+	if strings.TrimSpace(t.ArtifactID) == "" {
+		return fmt.Errorf("artifact_id is required")
+	}
+	if strings.TrimSpace(t.ToState) == "" {
+		return fmt.Errorf("to_state is required (cannot transition to the genesis state)")
+	}
+	return validateTimestamp(t.TS)
+}
+
+// validateTimestamp requires a UTC RFC3339/RFC3339Nano timestamp, matching the
+// UTC-only discipline of the rpi ledger and provenancegraph.
+func validateTimestamp(ts string) error {
+	if strings.TrimSpace(ts) == "" {
+		return fmt.Errorf("ts is required")
+	}
+	t, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		return fmt.Errorf("invalid ts: %w", err)
+	}
+	if t.UTC().Format(time.RFC3339Nano) != ts {
+		return fmt.Errorf("ts must be UTC RFC3339")
+	}
+	return nil
+}
+
+// Seal validates the transition's fields, links it onto prevHash, and fills the
+// payload_hash and hash fields. The schema_version is forced to the const so a
+// caller cannot accidentally emit a mis-versioned record. This is the ONLY
+// supported way to add a transition to a chain — there is no setter for the
+// state itself, which is the point: state changes flow exclusively through an
+// appended, hash-linked transition.
+func Seal(t Transition, prevHash string) (Transition, error) {
+	t.SchemaVersion = SchemaVersion
+	if err := ValidateFields(t); err != nil {
+		return Transition{}, err
+	}
+	t.PrevHash = prevHash
+	payloadHash, hash, err := ComputeHashes(t)
+	if err != nil {
+		return Transition{}, err
+	}
+	t.PayloadHash = payloadHash
+	t.Hash = hash
+	return t, nil
+}
+
+// Append seals newTransition onto the tip of an existing, already-sealed log
+// and returns the extended log. The input log is not mutated. This is the
+// canonical append entry point: it derives prev_hash from the current tip so a
+// caller never hand-links the chain.
+func Append(log []Transition, newTransition Transition) ([]Transition, error) {
+	prevHash := ""
+	if len(log) > 0 {
+		prevHash = log[len(log)-1].Hash
+	}
+	sealed, err := Seal(newTransition, prevHash)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Transition, len(log)+1)
+	copy(out, log)
+	out[len(log)] = sealed
+	return out, nil
+}
+
+// VerifyChain validates that a single artifact's transitions form an intact
+// hash chain: each record is field-valid, its prev_hash links to the prior
+// record's hash, and its payload_hash/hash recompute. Returns the 1-based index
+// of the first broken record and a descriptive error, or (0, nil) when the
+// whole chain verifies. Mirrors provenancegraph.VerifyChain.
+func VerifyChain(log []Transition) (int, error) {
+	prevHash := ""
+	for i, rec := range log {
+		if err := ValidateFields(rec); err != nil {
+			return i + 1, fmt.Errorf("record %d: %w", i+1, err)
+		}
+		if rec.PrevHash != prevHash {
+			return i + 1, fmt.Errorf("record %d: prev_hash mismatch: got %q want %q", i+1, rec.PrevHash, prevHash)
+		}
+		payloadHash, hash, err := ComputeHashes(rec)
+		if err != nil {
+			return i + 1, fmt.Errorf("record %d: %w", i+1, err)
+		}
+		if rec.PayloadHash != payloadHash {
+			return i + 1, fmt.Errorf("record %d: payload_hash mismatch", i+1)
+		}
+		if rec.Hash != hash {
+			return i + 1, fmt.Errorf("record %d: hash mismatch", i+1)
+		}
+		prevHash = rec.Hash
+	}
+	return 0, nil
+}
+
+// FoldError reports a transition whose FromState does not match the artifact's
+// current folded state — i.e. an attempt to apply a transition out of order or
+// from a stale state. This is the in-band guard that replaces "trust the
+// state column": the only legal next state is the one the log produces.
+type FoldError struct {
+	ArtifactID string
+	Index      int    // 1-based index within the artifact's transition slice
+	Want       string // the current folded state the transition should have declared
+	Got        string // the FromState the transition actually declared
+}
+
+func (e *FoldError) Error() string {
+	return fmt.Sprintf("artifact %q transition %d: from_state %q does not match current state %q",
+		e.ArtifactID, e.Index, e.Got, e.Want)
+}
+
+// Fold derives the current state of every artifact by replaying the append-only
+// transition log. It is the pure projection function at the heart of the
+// inversion: given the log, state is computed, never read.
+//
+// Determinism: transitions are grouped by artifact_id and replayed in the
+// canonical order (ts, then hash as a total-order tie-breaker), so the result
+// is identical for the same set of transitions regardless of input slice order.
+//
+// In-band guard: within each artifact, every transition's FromState must equal
+// the state produced so far (genesis must declare InitialState). A mismatch is
+// a FoldError — there is no way to "jump" the state without a contiguous,
+// evidence-backed transition, which is how the state-machine invariants become
+// true by construction. Fold does NOT verify the hash chain; callers that need
+// tamper-evidence run VerifyChain first (FoldVerified does both).
+func Fold(log []Transition) (map[string]string, error) {
+	byArtifact := groupByArtifact(log)
+	states := make(map[string]string, len(byArtifact))
+	for _, id := range sortedKeys(byArtifact) {
+		transitions := canonicalSort(byArtifact[id])
+		current := InitialState
+		for i, t := range transitions {
+			if t.FromState != current {
+				return nil, &FoldError{
+					ArtifactID: id,
+					Index:      i + 1,
+					Want:       current,
+					Got:        t.FromState,
+				}
+			}
+			current = t.ToState
+		}
+		states[id] = current
+	}
+	return states, nil
+}
+
+// FoldVerified verifies each artifact's hash chain (in canonical replay order)
+// and then folds. It is the integrity-checked projection: a tampered or broken
+// chain fails before any state is derived, so a faithful rebuild is provable
+// rather than hoped-for. Returns the folded states or the first failure.
+func FoldVerified(log []Transition) (map[string]string, error) {
+	byArtifact := groupByArtifact(log)
+	for _, id := range sortedKeys(byArtifact) {
+		ordered := canonicalSort(byArtifact[id])
+		if idx, err := VerifyChain(ordered); err != nil {
+			return nil, fmt.Errorf("artifact %q: %w (broken at %d)", id, err, idx)
+		}
+	}
+	return Fold(log)
+}
+
+// StateOf folds the log and returns the current state of one artifact, plus
+// whether that artifact appears in the log at all. A known artifact whose log
+// is empty is reported as not-found rather than InitialState, so callers can
+// distinguish "never transitioned" from "absent".
+func StateOf(log []Transition, artifactID string) (state string, found bool, err error) {
+	states, err := Fold(log)
+	if err != nil {
+		return "", false, err
+	}
+	s, ok := states[artifactID]
+	return s, ok, nil
+}
+
+// groupByArtifact buckets transitions by artifact_id, preserving input order
+// within each bucket (canonicalSort imposes the replay order afterward).
+func groupByArtifact(log []Transition) map[string][]Transition {
+	out := make(map[string][]Transition)
+	for _, t := range log {
+		out[t.ArtifactID] = append(out[t.ArtifactID], t)
+	}
+	return out
+}
+
+// sortedKeys returns the map keys sorted, so Fold iterates artifacts in a
+// stable order (the per-artifact state is order-independent, but stable
+// iteration keeps any derived output deterministic).
+func sortedKeys(m map[string][]Transition) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// canonicalSort returns a new slice ordered by (ts, hash). TS is the primary
+// replay order; hash is a total-order tie-breaker so transitions sharing a
+// timestamp still replay deterministically. The input is not mutated.
+func canonicalSort(transitions []Transition) []Transition {
+	out := make([]Transition, len(transitions))
+	copy(out, transitions)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].TS != out[j].TS {
+			return out[i].TS < out[j].TS
+		}
+		return out[i].Hash < out[j].Hash
+	})
+	return out
+}

--- a/cli/internal/turnstate/turnstate_test.go
+++ b/cli/internal/turnstate/turnstate_test.go
@@ -1,0 +1,309 @@
+package turnstate
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// buildLog seals a sequence of (artifactID, from, to) steps into one chained
+// log so tests can describe a scenario without hand-linking prev_hash. The ts
+// is monotonically increasing per step so canonical replay order is the build
+// order.
+func buildLog(t *testing.T, steps [][3]string) []Transition {
+	t.Helper()
+	var log []Transition
+	tsBase := []string{
+		"2026-05-31T00:00:00Z",
+		"2026-05-31T00:00:01Z",
+		"2026-05-31T00:00:02Z",
+		"2026-05-31T00:00:03Z",
+		"2026-05-31T00:00:04Z",
+		"2026-05-31T00:00:05Z",
+	}
+	for i, s := range steps {
+		if i >= len(tsBase) {
+			t.Fatalf("buildLog: too many steps (%d), extend tsBase", len(steps))
+		}
+		var err error
+		log, err = Append(log, Transition{
+			ArtifactID: s[0],
+			FromState:  s[1],
+			ToState:    s[2],
+			TS:         tsBase[i],
+		})
+		if err != nil {
+			t.Fatalf("Append step %d: %v", i, err)
+		}
+	}
+	return log
+}
+
+func TestSeal_StampsSchemaAndHashes(t *testing.T) {
+	sealed, err := Seal(Transition{
+		ArtifactID: "art-1",
+		FromState:  InitialState,
+		ToState:    "drafted",
+		TS:         "2026-05-31T00:00:00Z",
+	}, "")
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	if sealed.SchemaVersion != SchemaVersion {
+		t.Errorf("schema_version = %q, want %q", sealed.SchemaVersion, SchemaVersion)
+	}
+	if sealed.PrevHash != "" {
+		t.Errorf("genesis prev_hash = %q, want empty", sealed.PrevHash)
+	}
+	wantPayload, wantHash, _ := ComputeHashes(sealed)
+	if sealed.PayloadHash != wantPayload {
+		t.Errorf("payload_hash = %q, want %q", sealed.PayloadHash, wantPayload)
+	}
+	if sealed.Hash != wantHash {
+		t.Errorf("hash = %q, want %q", sealed.Hash, wantHash)
+	}
+}
+
+func TestValidateFields_Rejects(t *testing.T) {
+	valid := Transition{
+		SchemaVersion: SchemaVersion,
+		ArtifactID:    "art-1",
+		ToState:       "drafted",
+		TS:            "2026-05-31T00:00:00Z",
+	}
+	tests := []struct {
+		name    string
+		mutate  func(Transition) Transition
+		wantErr bool
+	}{
+		{"valid", func(tr Transition) Transition { return tr }, false},
+		{"bad schema", func(tr Transition) Transition { tr.SchemaVersion = "v0"; return tr }, true},
+		{"empty artifact_id", func(tr Transition) Transition { tr.ArtifactID = "  "; return tr }, true},
+		{"empty to_state", func(tr Transition) Transition { tr.ToState = ""; return tr }, true},
+		{"empty ts", func(tr Transition) Transition { tr.TS = ""; return tr }, true},
+		{"non-utc ts", func(tr Transition) Transition { tr.TS = "2026-05-31T00:00:00+02:00"; return tr }, true},
+		{"unparseable ts", func(tr Transition) Transition { tr.TS = "yesterday"; return tr }, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateFields(tc.mutate(valid))
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ValidateFields err = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestFold_DerivesCurrentState(t *testing.T) {
+	log := buildLog(t, [][3]string{
+		{"art-1", InitialState, "drafted"},
+		{"art-1", "drafted", "reviewed"},
+		{"art-1", "reviewed", "merged"},
+		{"art-2", InitialState, "drafted"},
+	})
+	states, err := Fold(log)
+	if err != nil {
+		t.Fatalf("Fold: %v", err)
+	}
+	want := map[string]string{
+		"art-1": "merged",
+		"art-2": "drafted",
+	}
+	if !reflect.DeepEqual(states, want) {
+		t.Errorf("Fold = %v, want %v", states, want)
+	}
+}
+
+func TestFold_EmptyLogIsEmptyMap(t *testing.T) {
+	states, err := Fold(nil)
+	if err != nil {
+		t.Fatalf("Fold(nil): %v", err)
+	}
+	if len(states) != 0 {
+		t.Errorf("Fold(nil) = %v, want empty map", states)
+	}
+}
+
+// TestFold_DeterministicAcrossInputOrder is the core property: state is a fold,
+// so the same set of transitions yields identical state regardless of the order
+// the slice happens to be in. Reversed input must replay to the same state.
+func TestFold_DeterministicAcrossInputOrder(t *testing.T) {
+	log := buildLog(t, [][3]string{
+		{"art-1", InitialState, "drafted"},
+		{"art-1", "drafted", "reviewed"},
+		{"art-1", "reviewed", "merged"},
+	})
+	reversed := make([]Transition, len(log))
+	for i, tr := range log {
+		reversed[len(log)-1-i] = tr
+	}
+
+	forward, err := Fold(log)
+	if err != nil {
+		t.Fatalf("Fold forward: %v", err)
+	}
+	backward, err := Fold(reversed)
+	if err != nil {
+		t.Fatalf("Fold reversed: %v", err)
+	}
+	if !reflect.DeepEqual(forward, backward) {
+		t.Errorf("Fold not order-independent: forward=%v reversed=%v", forward, backward)
+	}
+	if forward["art-1"] != "merged" {
+		t.Errorf("art-1 state = %q, want merged", forward["art-1"])
+	}
+}
+
+// TestFold_RejectsBrokenStateChain proves the in-band guard: a transition whose
+// from_state does not match the current folded state is rejected, so state
+// cannot jump without a contiguous transition.
+func TestFold_RejectsBrokenStateChain(t *testing.T) {
+	// art-1 goes Initial->drafted, then a transition claims from "merged"
+	// which was never the current state.
+	t0, err := Seal(Transition{ArtifactID: "art-1", FromState: InitialState, ToState: "drafted", TS: "2026-05-31T00:00:00Z"}, "")
+	if err != nil {
+		t.Fatalf("seal t0: %v", err)
+	}
+	t1, err := Seal(Transition{ArtifactID: "art-1", FromState: "merged", ToState: "archived", TS: "2026-05-31T00:00:01Z"}, t0.Hash)
+	if err != nil {
+		t.Fatalf("seal t1: %v", err)
+	}
+	_, err = Fold([]Transition{t0, t1})
+	var fe *FoldError
+	if !errors.As(err, &fe) {
+		t.Fatalf("Fold err = %v, want *FoldError", err)
+	}
+	if fe.Want != "drafted" || fe.Got != "merged" {
+		t.Errorf("FoldError = {want:%q got:%q}, expected {want:drafted got:merged}", fe.Want, fe.Got)
+	}
+	if fe.Index != 2 {
+		t.Errorf("FoldError.Index = %d, want 2", fe.Index)
+	}
+}
+
+func TestFold_RejectsGenesisNotFromInitial(t *testing.T) {
+	t0, err := Seal(Transition{ArtifactID: "art-1", FromState: "drafted", ToState: "reviewed", TS: "2026-05-31T00:00:00Z"}, "")
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	_, err = Fold([]Transition{t0})
+	var fe *FoldError
+	if !errors.As(err, &fe) {
+		t.Fatalf("Fold err = %v, want *FoldError for non-Initial genesis", err)
+	}
+	if fe.Want != InitialState {
+		t.Errorf("FoldError.Want = %q, want InitialState", fe.Want)
+	}
+}
+
+func TestVerifyChain_DetectsTamper(t *testing.T) {
+	log := buildLog(t, [][3]string{
+		{"art-1", InitialState, "drafted"},
+		{"art-1", "drafted", "reviewed"},
+	})
+	if idx, err := VerifyChain(log); err != nil {
+		t.Fatalf("clean chain VerifyChain = (%d,%v), want (0,nil)", idx, err)
+	}
+
+	// Tamper with the second record's to_state without re-sealing.
+	tampered := append([]Transition(nil), log...)
+	tampered[1].ToState = "merged"
+	idx, err := VerifyChain(tampered)
+	if err == nil {
+		t.Fatal("VerifyChain accepted tampered chain")
+	}
+	if idx != 2 {
+		t.Errorf("VerifyChain first-broken index = %d, want 2", idx)
+	}
+}
+
+func TestVerifyChain_DetectsBrokenPrevHashLink(t *testing.T) {
+	log := buildLog(t, [][3]string{
+		{"art-1", InitialState, "drafted"},
+		{"art-1", "drafted", "reviewed"},
+	})
+	broken := append([]Transition(nil), log...)
+	broken[1].PrevHash = "deadbeef"
+	idx, err := VerifyChain(broken)
+	if err == nil {
+		t.Fatal("VerifyChain accepted broken prev_hash link")
+	}
+	if idx != 2 {
+		t.Errorf("first-broken index = %d, want 2", idx)
+	}
+}
+
+// TestFoldVerified_RejectsTamperBeforeFold proves the integrity-checked
+// projection refuses to derive state from a tampered chain.
+func TestFoldVerified_RejectsTamperBeforeFold(t *testing.T) {
+	log := buildLog(t, [][3]string{
+		{"art-1", InitialState, "drafted"},
+		{"art-1", "drafted", "reviewed"},
+	})
+	if _, err := FoldVerified(log); err != nil {
+		t.Fatalf("clean FoldVerified: %v", err)
+	}
+	tampered := append([]Transition(nil), log...)
+	tampered[1].ToState = "merged"
+	if _, err := FoldVerified(tampered); err == nil {
+		t.Fatal("FoldVerified accepted tampered chain")
+	}
+}
+
+func TestStateOf_FoundAndAbsent(t *testing.T) {
+	log := buildLog(t, [][3]string{
+		{"art-1", InitialState, "drafted"},
+	})
+	state, found, err := StateOf(log, "art-1")
+	if err != nil {
+		t.Fatalf("StateOf art-1: %v", err)
+	}
+	if !found || state != "drafted" {
+		t.Errorf("StateOf(art-1) = (%q,%v), want (drafted,true)", state, found)
+	}
+	_, found, err = StateOf(log, "art-missing")
+	if err != nil {
+		t.Fatalf("StateOf missing: %v", err)
+	}
+	if found {
+		t.Error("StateOf(art-missing) found = true, want false")
+	}
+}
+
+// TestAppend_DoesNotMutateInput guards the immutability contract: Append builds
+// a new slice and never writes through to the caller's log.
+func TestAppend_DoesNotMutateInput(t *testing.T) {
+	orig := buildLog(t, [][3]string{
+		{"art-1", InitialState, "drafted"},
+	})
+	before := len(orig)
+	_, err := Append(orig, Transition{ArtifactID: "art-1", FromState: "drafted", ToState: "reviewed", TS: "2026-05-31T00:00:01Z"})
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if len(orig) != before {
+		t.Errorf("Append mutated input length: %d != %d", len(orig), before)
+	}
+}
+
+// TestFold_TieBreakByHashIsDeterministic proves replay order is total even when
+// two transitions for the same artifact share a timestamp: the hash tie-break
+// must impose one stable order, so Fold either succeeds identically every run
+// or fails identically — never flaps.
+func TestFold_TieBreakByHashIsDeterministic(t *testing.T) {
+	// Two same-ts transitions from the same Initial state to different targets
+	// is an illegal fork; the point is that the OUTCOME is stable, not random.
+	a, err := Seal(Transition{ArtifactID: "art-1", FromState: InitialState, ToState: "alpha", TS: "2026-05-31T00:00:00Z"}, "")
+	if err != nil {
+		t.Fatalf("seal a: %v", err)
+	}
+	b, err := Seal(Transition{ArtifactID: "art-1", FromState: InitialState, ToState: "beta", TS: "2026-05-31T00:00:00Z"}, "")
+	if err != nil {
+		t.Fatalf("seal b: %v", err)
+	}
+	_, err1 := Fold([]Transition{a, b})
+	_, err2 := Fold([]Transition{b, a})
+	if (err1 == nil) != (err2 == nil) {
+		t.Errorf("Fold tie-break not deterministic: err1=%v err2=%v", err1, err2)
+	}
+}


### PR DESCRIPTION
## What

Establishes the **state-machine projection** half of the ag-lmdx inversion ("append-only event log canonical, state is a rebuildable projection"). Where `cli/internal/provenancegraph` is the write model for the provenance *graph* and `cli/internal/drrebuild` proves the *graph* rebuilds from the ledger, this PR establishes the same invariant for an artifact's lifecycle **state**:

> `context_artifact.state` is NOT authored. It is a FOLD over the append-only, hash-chained `state_transition` log.

## How

New pure, in-memory write+fold kernel `cli/internal/turnstate`, reusing the `rpi/ledger.go` + `provenancegraph` hash discipline verbatim (`payload_hash = sha256(canonical-JSON sans chain fields)`, `hash = sha256(payload_hash + "\n" + prev_hash)`):

- `Seal` / `Append` — the **only** path that advances state, via an appended, hash-linked transition. There is no setter for state itself.
- `VerifyChain` — tamper-evidence (mirrors `provenancegraph.VerifyChain`).
- `Fold` / `FoldVerified` — deterministic replay deriving current state per artifact, with an **in-band `from_state` guard** (a transition's `from_state` must equal the current folded state, so state cannot jump without a contiguous transition). This is what makes the author!=judge / orphan-gate invariants true *by construction*.
- `StateOf` — single-artifact projection.

Property tests cover: replay determinism, **order-independence** (`replay(events) == replay(reverse(events))`), tamper detection, broken-state-chain rejection, genesis-not-from-initial rejection, and tie-break determinism.

## Scope (bounded slice, single rollback semantic)

This is the smallest credible testable slice that establishes "state is a fold over the append-only log". Per ag-lmdx ("strangler-migrate, NO big-bang rewrite"), two pieces are **deferred to a follow-up migration bead**:
- Forbidding direct `context_artifact.state` writes at every existing call site.
- Wiring the kernel to a durable JSONL/Dolt ledger.

No `ao` subcommand, no schema, no skill changes -> no derived-surface regen.

## Gates
- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` -> 11949 passed / 69 packages; new package 20 tests
- gosec on the new package -> 0 issues

Closes-scenario: ag-lmdx.2#eventlog-source-of-truth
Bounded-context: BC4-Factory
Evidence: cli/internal/turnstate/turnstate.go