### PR TITLE
feat(swarm): wave pre-gate node-state ownership disjoint (ag-lmdx.6 #wave-ownership-disjoint)

### DIFF
--- a/scripts/check-wave-ownership-disjoint.sh
+++ b/scripts/check-wave-ownership-disjoint.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-wave-ownership-disjoint.sh — Wave PRE-gate: assert node-state ownership is
+# pairwise-disjoint BEFORE a parallel wave of agents is spawned (ag-lmdx.6).
+#
+# WHY: the real convergence invariant (ag-lmdx, Dolt-expert review 2026-05-30) is
+# that two agents must NEVER concurrently own the same artifact's STATE — that is a
+# genuine Dolt cell conflict on the context_artifact state projection / the
+# append-only state_transition log. File-disjointness
+# (scripts/check-file-manifest-overlap.sh, an advisory post-merge shadow) is the
+# weak textual shadow of this. This gate is the BLOCKING node-ownership form: it
+# runs before any worker starts and refuses to launch the wave on any overlap.
+#
+# INPUT: a wave manifest — a JSON array of slices, each:
+#   { "id": "<slice-id>", "subject": "<text>", "owns": ["<node-state-key>", ...] }
+# A node-state key names the artifact whose lifecycle state the slice transitions
+# (e.g. an artifact_id, optionally "<artifact_id>:<state>"). Two slices that both
+# declare ownership of the same key would concurrently transition that artifact's
+# state — the conflict this gate blocks.
+#
+# Read from a file argument or stdin ("-" or no arg).
+#
+# EXIT CODES:
+#   0  ownership is pairwise-disjoint (or nothing to check) — wave may spawn
+#   1  overlapping node-state ownership detected — wave is BLOCKED
+#   2  usage / unparseable input (missing jq is a soft skip, exit 0)
+
+usage() {
+  cat >&2 <<'EOF'
+usage: check-wave-ownership-disjoint.sh [WAVE_MANIFEST_JSON | -]
+
+Wave pre-gate: assert each slice's owned node-state set is pairwise-disjoint
+before spawning a parallel wave. Reads a JSON array of {id, subject, owns[]}
+from the given file or stdin. Exit 0 = disjoint (proceed), 1 = overlap (blocked),
+2 = bad usage/input.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+# Requires bash 4+ for associative arrays.
+if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+  echo "WARN: bash 4+ required (have ${BASH_VERSION}) — skipping wave ownership pre-gate"
+  exit 0
+fi
+
+INPUT="${1:--}"
+if [[ "$INPUT" == "-" ]]; then
+  INPUT="/dev/stdin"
+elif [[ ! -e "$INPUT" ]]; then
+  echo "ERROR: manifest not found: $INPUT" >&2
+  usage
+  exit 2
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "WARN: jq not found — skipping wave ownership pre-gate"
+  exit 0
+fi
+
+# Slurp once so stdin is consumed a single time and we can validate structure.
+MANIFEST="$(cat "$INPUT")"
+
+# Structure: must be a JSON array. Anything else is an input error (exit 2).
+if ! TYPE="$(jq -r 'type' <<<"$MANIFEST" 2>/dev/null)"; then
+  echo "ERROR: input is not valid JSON" >&2
+  exit 2
+fi
+if [[ "$TYPE" != "array" ]]; then
+  echo "ERROR: wave manifest must be a JSON array of slices (got: $TYPE)" >&2
+  exit 2
+fi
+
+SLICE_COUNT="$(jq -r 'length' <<<"$MANIFEST")"
+if [[ "$SLICE_COUNT" -eq 0 ]]; then
+  echo "SKIP: empty wave manifest — no slices to check"
+  exit 0
+fi
+
+# A slice declaring no owned node-states cannot be proven disjoint. That is a
+# planning gap the wave operator must close before launch, so it is a hard fail
+# (a wave pre-gate that silently passes un-declared ownership would be useless).
+MISSING="$(jq -r '.[] | select(.owns == null or (.owns | length) == 0) | .id // "unknown"' <<<"$MANIFEST")"
+if [[ -n "$MISSING" ]]; then
+  while IFS= read -r slice_id; do
+    echo "BLOCKED: slice $slice_id declares no node-state ownership — cannot prove disjointness"
+  done <<<"$MISSING"
+  echo "Wave pre-gate FAILED: every slice must declare its owned node-state set"
+  exit 1
+fi
+
+CONFLICTS=0
+declare -A NODE_OWNER
+
+# Emit (slice_id, node-state-key) pairs and detect the first claimant of each key.
+# A second claimant of any key is a genuine node-state ownership conflict.
+while IFS=$'\t' read -r slice_id node; do
+  [[ -z "$node" ]] && continue
+  if [[ -n "${NODE_OWNER[$node]:-}" ]]; then
+    if [[ "${NODE_OWNER[$node]}" == "$slice_id" ]]; then
+      # Same slice listing the same node twice is a duplicate, not a cross-slice
+      # conflict — note it but do not block the wave on it.
+      echo "WARN: slice $slice_id lists node-state '$node' more than once"
+      continue
+    fi
+    echo "CONFLICT: node-state '$node' owned by both slice ${NODE_OWNER[$node]} and slice $slice_id"
+    CONFLICTS=$((CONFLICTS + 1))
+  else
+    NODE_OWNER["$node"]="$slice_id"
+  fi
+done < <(jq -r '.[] | .id as $id | .owns[]? | [$id, .] | @tsv' <<<"$MANIFEST")
+
+if [[ $CONFLICTS -gt 0 ]]; then
+  echo "Wave pre-gate FAILED: $CONFLICTS overlapping node-state ownership conflict(s) — wave NOT spawned"
+  exit 1
+fi
+
+echo "Wave pre-gate PASSED: $SLICE_COUNT slice(s) own pairwise-disjoint node-state sets — wave may spawn"
+exit 0

--- a/tests/scripts/check-wave-ownership-disjoint.bats
+++ b/tests/scripts/check-wave-ownership-disjoint.bats
@@ -1,0 +1,127 @@
+#!/usr/bin/env bats
+
+# Tests for scripts/check-wave-ownership-disjoint.sh — the ag-lmdx.6 wave pre-gate
+# that asserts each slice's owned node-state set is pairwise-disjoint BEFORE a
+# parallel wave of agents spawns. Hermetic: builds manifests in a tmpdir, no
+# network, no git, no live ao/bd.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/check-wave-ownership-disjoint.sh"
+    TMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+# Scenario: Overlapping node ownership blocks the wave.
+@test "overlapping node-state ownership FAILS naming the contended artifact" {
+    cat > "$TMP_DIR/wave.json" <<'JSON'
+[
+  {"id": "slice-1", "subject": "advance A", "owns": ["artifact-A", "artifact-B"]},
+  {"id": "slice-2", "subject": "advance A too", "owns": ["artifact-A", "artifact-C"]}
+]
+JSON
+    run bash "$SCRIPT" "$TMP_DIR/wave.json"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"CONFLICT: node-state 'artifact-A'"* ]]
+    [[ "$output" == *"slice-1"* ]]
+    [[ "$output" == *"slice-2"* ]]
+    [[ "$output" == *"wave NOT spawned"* ]]
+}
+
+# Scenario: Disjoint ownership proceeds.
+@test "disjoint node-state ownership PASSES and wave may spawn" {
+    cat > "$TMP_DIR/wave.json" <<'JSON'
+[
+  {"id": "slice-1", "subject": "advance A", "owns": ["artifact-A", "artifact-B"]},
+  {"id": "slice-2", "subject": "advance C", "owns": ["artifact-C", "artifact-D"]}
+]
+JSON
+    run bash "$SCRIPT" "$TMP_DIR/wave.json"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Wave pre-gate PASSED"* ]]
+    [[ "$output" == *"2 slice(s)"* ]]
+}
+
+@test "reads the manifest from stdin" {
+    run bash -c "printf '%s' '[{\"id\":\"s1\",\"owns\":[\"x\"]},{\"id\":\"s2\",\"owns\":[\"x\"]}]' | bash '$SCRIPT' -"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"CONFLICT: node-state 'x'"* ]]
+}
+
+@test "stdin disjoint passes" {
+    run bash -c "printf '%s' '[{\"id\":\"s1\",\"owns\":[\"x\"]},{\"id\":\"s2\",\"owns\":[\"y\"]}]' | bash '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Wave pre-gate PASSED"* ]]
+}
+
+@test "empty manifest array is a no-op skip (exit 0)" {
+    echo '[]' > "$TMP_DIR/wave.json"
+    run bash "$SCRIPT" "$TMP_DIR/wave.json"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SKIP: empty wave manifest"* ]]
+}
+
+@test "slice with no declared ownership is BLOCKED (cannot prove disjointness)" {
+    cat > "$TMP_DIR/wave.json" <<'JSON'
+[
+  {"id": "slice-1", "subject": "advance A", "owns": ["artifact-A"]},
+  {"id": "slice-2", "subject": "undeclared"}
+]
+JSON
+    run bash "$SCRIPT" "$TMP_DIR/wave.json"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"BLOCKED: slice slice-2 declares no node-state ownership"* ]]
+}
+
+@test "non-array JSON is an input error (exit 2)" {
+    echo '{"id":"s1","owns":["x"]}' > "$TMP_DIR/wave.json"
+    run bash "$SCRIPT" "$TMP_DIR/wave.json"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"must be a JSON array"* ]]
+}
+
+@test "unparseable input is an input error (exit 2)" {
+    echo 'not json' > "$TMP_DIR/wave.json"
+    run bash "$SCRIPT" "$TMP_DIR/wave.json"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"not valid JSON"* ]]
+}
+
+@test "missing manifest file is an input error (exit 2)" {
+    run bash "$SCRIPT" "$TMP_DIR/does-not-exist.json"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"manifest not found"* ]]
+}
+
+@test "duplicate node within the same slice WARNs but does not block" {
+    cat > "$TMP_DIR/wave.json" <<'JSON'
+[
+  {"id": "slice-1", "subject": "dup", "owns": ["artifact-A", "artifact-A"]},
+  {"id": "slice-2", "subject": "other", "owns": ["artifact-B"]}
+]
+JSON
+    run bash "$SCRIPT" "$TMP_DIR/wave.json"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARN: slice slice-1 lists node-state 'artifact-A' more than once"* ]]
+    [[ "$output" == *"Wave pre-gate PASSED"* ]]
+}
+
+@test "three-slice wave with a single overlapping pair FAILS" {
+    cat > "$TMP_DIR/wave.json" <<'JSON'
+[
+  {"id": "a", "owns": ["n1", "n2"]},
+  {"id": "b", "owns": ["n3"]},
+  {"id": "c", "owns": ["n2", "n4"]}
+]
+JSON
+    run bash "$SCRIPT" "$TMP_DIR/wave.json"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"CONFLICT: node-state 'n2'"* ]]
+    [[ "$output" == *"slice a"* ]]
+    [[ "$output" == *"slice c"* ]]
+}


### PR DESCRIPTION
## What

Adds `scripts/check-wave-ownership-disjoint.sh` — a wave **pre-gate** that, before spawning a parallel wave of agents, asserts each slice's owned **node-state** set is pairwise-disjoint. Overlap means two agents would concurrently transition the same artifact's state — a genuine Dolt cell conflict on the `context_artifact` state projection / append-only `state_transition` log (the real convergence invariant from the ag-lmdx Dolt-expert review). File-disjointness (`check-file-manifest-overlap.sh`) is only the weak textual shadow of this.

## Behavior

Input: JSON array of `{id, subject, owns[]}` slices (file arg or stdin).
- **Overlap** → exit 1, names the contended node-state and the conflicting slice pair, "wave NOT spawned" (Scenario: *Overlapping node ownership blocks the wave*).
- **Disjoint** → exit 0, "wave may spawn" (Scenario: *Disjoint ownership proceeds*).
- Slice with no declared ownership → blocked (cannot prove disjointness).
- Bad usage/input → exit 2. Missing `jq`/old bash → soft skip.

## Tests / gates

- `tests/scripts/check-wave-ownership-disjoint.bats` — 11 hermetic tests (both scenarios + exact exit codes 0/1/2, stdin, empty, undeclared, duplicate-within-slice, three-slice).
- `shellcheck -S warning` clean; `bash -n` clean.

Scope is two new files; no `validate.yml`/skill wiring (follow-up).

Closes-scenario: ag-lmdx.6#wave-ownership-disjoint
Bounded-context: BC5-Runtime
Evidence: scripts/check-wave-ownership-disjoint.sh