### PR TITLE
feat(turn): ao turn verify Evidenced-Turn DoD predicate (ag-lmdx.5 #ao-turn-verify)

### DIFF
--- a/cli/cmd/ao/cobra_commands_test.go
+++ b/cli/cmd/ao/cobra_commands_test.go
@@ -374,7 +374,7 @@ func TestCobraCommandTreeRegistration(t *testing.T) {
 		"pool", "provenance", "quick-start", "ratchet", "reconcile", "retrieval-bench", "robot-docs", "rpi",
 		"registry", "scenario", "scope", "search", "seed", "session", "session-outcome", "sessions", "skills", "status",
 		"store", "task-feedback", "task-status", "task-sync", "temper",
-		"trace", "validate", "version", "vibe-check", "wiki", "worktree",
+		"trace", "turn", "validate", "version", "vibe-check", "wiki", "worktree",
 	}
 	cmdSet := make(map[string]bool)
 	for _, name := range cmdNames {
@@ -433,7 +433,7 @@ func TestCobraExpectedCmdsMatchRegistration(t *testing.T) {
 		"pool", "provenance", "quick-start", "ratchet", "reconcile", "retrieval-bench", "robot-docs", "rpi",
 		"registry", "scenario", "scope", "search", "seed", "session", "session-outcome", "sessions", "skills", "status",
 		"store", "task-feedback", "task-status", "task-sync", "temper",
-		"trace", "validate", "version", "vibe-check", "wiki", "worktree",
+		"trace", "turn", "validate", "version", "vibe-check", "wiki", "worktree",
 	}
 
 	// Every expected command must be registered

--- a/cli/cmd/ao/turn_verify.go
+++ b/cli/cmd/ao/turn_verify.go
@@ -1,0 +1,229 @@
+// practices: [design-by-contract, in-toto-provenance]
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/boshu2/agentops/cli/internal/evidencedturn"
+	"github.com/boshu2/agentops/cli/internal/provenancegraph"
+	"github.com/boshu2/agentops/cli/internal/turnstate"
+)
+
+var (
+	turnVerifyInput  string
+	turnVerifyLedger string
+	turnVerifyGraph  string
+	turnVerifyJSON   bool
+)
+
+// turnCmd is the parent group for Evidenced-Turn operations (ag-lmdx). A "turn"
+// is one unit of context-work; its done-ness is an enforced assurance contract.
+var turnCmd = &cobra.Command{
+	Use:   "turn",
+	Short: "Evidenced-Turn operations (the enforced unit-of-work definition-of-done)",
+	Long: `The 'turn' command group operates on Evidenced Turns — the ag-lmdx
+unit of work. An Evidenced Turn is the assurance contract that lets a bead
+legally transition validated->closed: a hash-chained state log, covered
+scenarios, resolving Evidence, a provenance event, and no orphan.`,
+}
+
+// turnInputFile is the on-disk shape consumed by `ao turn verify --input`. It
+// carries the facts that are NOT in the committed provenance ledger: the bead's
+// state_transition log and its Closes-scenario coverage. Provenance edges and
+// orphans are read from the ledger (or --ledger) so they stay the audit
+// authority, not a hand-supplied claim.
+type turnInputFile struct {
+	BeadID      string                   `json:"bead_id"`
+	Transitions []turnstate.Transition   `json:"transitions"`
+	Scenarios   []evidencedturn.Scenario `json:"scenarios"`
+}
+
+var turnVerifyCmd = &cobra.Command{
+	Use:   "verify <bead>",
+	Short: "Verify a bead's Evidenced-Turn definition-of-done (legible pass/fail)",
+	Long: `Evaluate the legible Definition-of-Done predicate for one bead's
+Evidenced Turn and report a single done/not-done verdict with a per-predicate
+breakdown. This is the sufficiency check the live AP#7 gate omits: AP#7 verifies
+an Evidence trailer is PRESENT; this verifies the turn is actually DONE.
+
+A turn is DONE iff every predicate passes (validated->closed is legal):
+
+  chain_intact       the bead's state_transition log hash-verifies and folds
+                     (cli/internal/turnstate FoldVerified)
+  terminal_state     the folded lifecycle state is at the validated->closed
+                     boundary
+  scenarios_covered  every Closes-scenario claim has a passing test
+  evidence_resolves  every Evidence line resolves to a gate log that exercised
+                     THAT scenario (presence->sufficiency)
+  provenance_event   a provenance edge in the ledger references the bead
+  no_orphan          no artifact the turn produced is a provenance orphan
+
+Inputs:
+  --input   turn-input JSON file: the bead's state_transition log + its
+            Closes-scenario coverage (the facts not in the committed ledger).
+  --ledger  the provenance EDGE ledger (schema agentops-sdlc-provenance.v1);
+            defaults to docs/provenance/ledger.jsonl. Used for provenance_event.
+  --graph   an OPTIONAL provenance trace-graph projection (node/edge "record"
+            JSONL, the shape ao provenance trace reads). Used for no_orphan.
+            Without it, no_orphan is reported as not-yet-checked and fails.
+
+Exit is non-zero when the turn is NOT done, so this is usable as a
+validated->closed transition guard.
+
+Output:
+  default   a legible checklist with one line per predicate and a verdict.
+  --json    the full Verdict object (schema agentops-evidenced-turn.v1).
+
+Examples:
+  ao turn verify ag-lmdx.5 --input turn.json
+  ao turn verify ag-lmdx.5 --input turn.json --json
+  ao turn verify ag-lmdx.5 --input turn.json --graph graph.jsonl`,
+	Args: cobra.ExactArgs(1),
+	RunE: runTurnVerify,
+}
+
+func init() {
+	rootCmd.AddCommand(turnCmd)
+	turnCmd.AddCommand(turnVerifyCmd)
+
+	turnVerifyCmd.Flags().StringVar(&turnVerifyInput, "input", "", "Path to the turn-input JSON file (state log + scenario coverage) (required)")
+	turnVerifyCmd.Flags().StringVar(&turnVerifyLedger, "ledger", "", "Path to the provenance EDGE ledger JSONL (default: docs/provenance/ledger.jsonl)")
+	turnVerifyCmd.Flags().StringVar(&turnVerifyGraph, "graph", "", "Path to the provenance trace-graph JSONL (node/edge records) for orphan detection")
+	turnVerifyCmd.Flags().BoolVar(&turnVerifyJSON, "json", false, "Emit the full Verdict object as JSON")
+}
+
+func runTurnVerify(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
+	beadID := strings.TrimSpace(args[0])
+	if beadID == "" {
+		return fmt.Errorf("a non-empty <bead> is required")
+	}
+	if turnVerifyInput == "" {
+		return fmt.Errorf("ao turn verify requires --input <turn-input.json>")
+	}
+
+	tf, err := readTurnInputFile(turnVerifyInput)
+	if err != nil {
+		return err
+	}
+	// The positional bead is authoritative; an input file declaring a different
+	// bead is a mistake worth surfacing rather than silently overriding.
+	if tf.BeadID != "" && tf.BeadID != beadID {
+		return fmt.Errorf("input file bead_id %q does not match <bead> %q", tf.BeadID, beadID)
+	}
+
+	ledgerPath := turnVerifyLedger
+	if ledgerPath == "" {
+		ledgerPath = resolveLedgerPath()
+	}
+	edges, err := readLedgerEdges(ledgerPath)
+	if err != nil {
+		return err
+	}
+
+	var orphans []provenancegraph.OrphanFinding
+	orphanChecked := false
+	if turnVerifyGraph != "" {
+		graph, gerr := provenancegraph.ReadGraphRecords(turnVerifyGraph)
+		if gerr != nil {
+			return fmt.Errorf("read provenance trace-graph: %w", gerr)
+		}
+		// Any orphan in the turn's trace-graph means its provenance is
+		// incomplete — mirrors the repo-wide `ao provenance trace --orphans`
+		// no-orphan gate. A turn with a dangling artifact is not provably done.
+		orphans = provenancegraph.FindOrphans(graph)
+		orphanChecked = true
+	}
+
+	v, err := evidencedturn.Evaluate(evidencedturn.Input{
+		BeadID:          beadID,
+		Transitions:     tf.Transitions,
+		Scenarios:       tf.Scenarios,
+		ProvenanceEdges: edges,
+		OrphanFindings:  orphans,
+		OrphanChecked:   orphanChecked,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := renderVerdict(cmd, v); err != nil {
+		return err
+	}
+	if !v.Done {
+		// Non-zero exit makes this usable as a validated->closed transition
+		// guard. SilenceUsage is set, so cobra won't print usage on this.
+		return fmt.Errorf("turn %s is NOT done: %d gap(s)", v.BeadID, len(v.Gaps))
+	}
+	return nil
+}
+
+// readTurnInputFile loads and decodes the turn-input JSON file, rejecting
+// unknown fields so a malformed contract fails loudly.
+func readTurnInputFile(path string) (turnInputFile, error) {
+	b, err := os.ReadFile(path) // #nosec G304 -- operator-supplied input path, same trust model as --graph
+	if err != nil {
+		return turnInputFile{}, fmt.Errorf("read turn-input file %q: %w", path, err)
+	}
+	dec := json.NewDecoder(strings.NewReader(string(b)))
+	dec.DisallowUnknownFields()
+	var tf turnInputFile
+	if err := dec.Decode(&tf); err != nil {
+		return turnInputFile{}, fmt.Errorf("parse turn-input file %q: %w", path, err)
+	}
+	return tf, nil
+}
+
+// readLedgerEdges reads the provenance ledger edges. A missing ledger is not a
+// hard error here: the evidencedturn evaluator will simply fail the
+// provenance_event predicate with a legible reason rather than crash.
+func readLedgerEdges(path string) ([]provenancegraph.Edge, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat provenance ledger %q: %w", path, err)
+	}
+	store := provenancegraph.NewStore(path)
+	edges, err := store.Read()
+	if err != nil {
+		return nil, fmt.Errorf("read provenance ledger: %w", err)
+	}
+	return edges, nil
+}
+
+// renderVerdict prints the legible checklist (or JSON). The text form is the
+// agent-facing default: a status glyph, the predicate, and its reason.
+func renderVerdict(cmd *cobra.Command, v evidencedturn.Verdict) error {
+	out := cmd.OutOrStdout()
+	if turnVerifyJSON {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(v)
+	}
+
+	fmt.Fprintf(out, "Evidenced-Turn DoD for %s\n", v.BeadID)
+	for _, p := range v.Predicates {
+		glyph := "FAIL"
+		if p.Passed {
+			glyph = "PASS"
+		}
+		fmt.Fprintf(out, "  [%s] %-18s %s\n", glyph, p.Name, p.Reason)
+	}
+	fmt.Fprintln(out)
+	if v.Done {
+		fmt.Fprintf(out, "VERDICT: DONE — validated->closed is legal for %s\n", v.BeadID)
+	} else {
+		fmt.Fprintf(out, "VERDICT: NOT DONE — %d gap(s):\n", len(v.Gaps))
+		for _, g := range v.Gaps {
+			fmt.Fprintf(out, "  - %s\n", g)
+		}
+	}
+	return nil
+}

--- a/cli/cmd/ao/turn_verify_test.go
+++ b/cli/cmd/ao/turn_verify_test.go
@@ -1,0 +1,289 @@
+// practices: [design-by-contract, in-toto-provenance]
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/evidencedturn"
+	"github.com/boshu2/agentops/cli/internal/turnstate"
+)
+
+// resetTurnVerifyFlags restores the turn-verify flags to a known baseline so
+// flag state does not leak across tests.
+func resetTurnVerifyFlags() {
+	turnVerifyInput = ""
+	turnVerifyLedger = ""
+	turnVerifyJSON = false
+}
+
+// closedTransitionsJSON builds a sealed ""->in_progress->validated->closed log
+// for the bead and returns it as the transitions field for the input file.
+func closedTransitions(t *testing.T, bead string) []turnstate.Transition {
+	t.Helper()
+	steps := []struct{ from, to, ts string }{
+		{turnstate.InitialState, "in_progress", "2026-05-31T00:00:00Z"},
+		{"in_progress", "validated", "2026-05-31T01:00:00Z"},
+		{"validated", "closed", "2026-05-31T02:00:00Z"},
+	}
+	var log []turnstate.Transition
+	for _, s := range steps {
+		var err error
+		log, err = turnstate.Append(log, turnstate.Transition{
+			ArtifactID: bead, FromState: s.from, ToState: s.to, TS: s.ts,
+		})
+		if err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+	return log
+}
+
+// writeTurnInput marshals a turn-input file to a temp path and returns it.
+func writeTurnInput(t *testing.T, bead string, transitions []turnstate.Transition, scenarios []evidencedturn.Scenario) string {
+	t.Helper()
+	tf := turnInputFile{BeadID: bead, Transitions: transitions, Scenarios: scenarios}
+	b, err := json.Marshal(tf)
+	if err != nil {
+		t.Fatalf("marshal turn input: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "turn.json")
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatalf("write turn input: %v", err)
+	}
+	return path
+}
+
+// writeLedger writes a provenance ledger JSONL fixture (raw lines) to a temp
+// path and returns it. Each line is an already-formed JSON object.
+func writeLedger(t *testing.T, lines []string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ledger.jsonl")
+	content := strings.Join(lines, "\n")
+	if content != "" {
+		content += "\n"
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write ledger: %v", err)
+	}
+	return path
+}
+
+// beadEdgeLine builds a sealed provenance-edge ledger line referencing the bead
+// as to_id (a "commit implements" edge). It is a node/edge graph line too:
+// FindOrphans reads "record"-tagged lines, while the Edge store reads the
+// schema_version-tagged form. We emit the schema_version Edge form for the
+// provenance_event predicate; orphan tests use the record/graph form separately.
+func beadEdgeLine(t *testing.T, bead string) string {
+	t.Helper()
+	// A minimal valid Edge JSON (the store only needs to parse + the evaluator
+	// only matches from_id/to_id). We bypass Seal here and hand-write a line
+	// the store reads; the evaluator does not re-verify the ledger chain.
+	obj := map[string]any{
+		"schema_version": "agentops-sdlc-provenance.v1",
+		"from_id":        "commit:abc123",
+		"from_type":      "commit",
+		"to_id":          bead,
+		"to_type":        "bead",
+		"relation":       "commit_implements_decision",
+		"evidence_ref":   "deadbeef",
+		"trust_tier":     "inferred",
+		"ts":             "2026-05-31T03:00:00Z",
+		"prev_hash":      "",
+		"payload_hash":   "x",
+		"hash":           "y",
+	}
+	b, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("marshal edge: %v", err)
+	}
+	return string(b)
+}
+
+// writeCleanGraph writes a node/edge trace-graph where the bead's produced
+// artifact HAS an inbound edge (so it is not an orphan).
+func writeCleanGraph(t *testing.T, bead string) string {
+	t.Helper()
+	artifact := "cli/internal/evidencedturn/evidencedturn.go"
+	lines := []string{
+		`{"record":"node","id":"` + bead + `","type":"bead"}`,
+		`{"record":"node","id":"` + artifact + `","type":"artifact","path":"` + artifact + `"}`,
+		`{"record":"edge","edge_type":"bead_produces_artifact","from_id":"` + bead + `","to_id":"` + artifact + `"}`,
+	}
+	return writeLedger(t, lines) // same JSONL writer; distinct temp dir per call
+}
+
+// writeOrphanGraph writes a node/edge trace-graph containing an artifact node
+// with NO inbound edge (an orphan).
+func writeOrphanGraph(t *testing.T, bead string) string {
+	t.Helper()
+	artifact := "cli/orphan.go"
+	lines := []string{
+		`{"record":"node","id":"` + bead + `","type":"bead"}`,
+		`{"record":"node","id":"` + artifact + `","type":"artifact","path":"` + artifact + `"}`,
+	}
+	return writeLedger(t, lines)
+}
+
+func TestTurnVerify_CompleteTurnVerifies(t *testing.T) {
+	resetTurnVerifyFlags()
+	bead := "ag-lmdx.5"
+	input := writeTurnInput(t, bead, closedTransitions(t, bead),
+		[]evidencedturn.Scenario{{Slug: "ao-turn-verify", HasPassingTest: true, EvidenceResolved: true}})
+	ledger := writeLedger(t, []string{beadEdgeLine(t, bead)})
+	graph := writeCleanGraph(t, bead)
+
+	out, err := executeCommand("turn", "verify", bead, "--input", input, "--ledger", ledger, "--graph", graph)
+	if err != nil {
+		t.Fatalf("turn verify of a complete turn should succeed, got err=%v\noutput=%s", err, out)
+	}
+	if !strings.Contains(out, "VERDICT: DONE") {
+		t.Errorf("output missing DONE verdict:\n%s", out)
+	}
+	if !strings.Contains(out, "[PASS] chain_intact") {
+		t.Errorf("output missing chain_intact PASS:\n%s", out)
+	}
+}
+
+func TestTurnVerify_IncompleteTurnIsNotDone(t *testing.T) {
+	resetTurnVerifyFlags()
+	bead := "ag-lmdx.5"
+	// Scenario has no passing test -> not done; the uncovered scenario is named.
+	input := writeTurnInput(t, bead, closedTransitions(t, bead),
+		[]evidencedturn.Scenario{{Slug: "ao-turn-verify", HasPassingTest: false, EvidenceResolved: true}})
+	ledger := writeLedger(t, []string{beadEdgeLine(t, bead)})
+
+	out, err := executeCommand("turn", "verify", bead, "--input", input, "--ledger", ledger)
+	if err == nil {
+		t.Fatalf("turn verify of an incomplete turn must exit non-zero\noutput=%s", out)
+	}
+	if !strings.Contains(out, "VERDICT: NOT DONE") {
+		t.Errorf("output missing NOT DONE verdict:\n%s", out)
+	}
+	if !strings.Contains(out, "ao-turn-verify") {
+		t.Errorf("output should name the uncovered scenario ao-turn-verify:\n%s", out)
+	}
+	if !strings.Contains(out, "[FAIL] scenarios_covered") {
+		t.Errorf("output missing scenarios_covered FAIL:\n%s", out)
+	}
+}
+
+func TestTurnVerify_JSONShape(t *testing.T) {
+	resetTurnVerifyFlags()
+	bead := "ag-lmdx.5"
+	input := writeTurnInput(t, bead, closedTransitions(t, bead),
+		[]evidencedturn.Scenario{{Slug: "ao-turn-verify", HasPassingTest: true, EvidenceResolved: true}})
+	ledger := writeLedger(t, []string{beadEdgeLine(t, bead)})
+	graph := writeCleanGraph(t, bead)
+
+	out, err := executeCommand("turn", "verify", bead, "--input", input, "--ledger", ledger, "--graph", graph, "--json")
+	if err != nil {
+		t.Fatalf("turn verify --json should succeed, got err=%v\noutput=%s", err, out)
+	}
+	// The JSON object may be preceded by nothing; find the first '{'.
+	idx := strings.Index(out, "{")
+	if idx < 0 {
+		t.Fatalf("no JSON object in output:\n%s", out)
+	}
+	var v evidencedturn.Verdict
+	if err := json.Unmarshal([]byte(out[idx:]), &v); err != nil {
+		t.Fatalf("output is not valid Verdict JSON: %v\n%s", err, out)
+	}
+	if v.SchemaVersion != evidencedturn.SchemaVersion {
+		t.Errorf("schema_version = %q, want %q", v.SchemaVersion, evidencedturn.SchemaVersion)
+	}
+	if v.BeadID != bead {
+		t.Errorf("bead_id = %q, want %q", v.BeadID, bead)
+	}
+	if v.Done != true {
+		t.Errorf("done = %v, want true", v.Done)
+	}
+	if len(v.Predicates) != 6 {
+		t.Errorf("len(predicates) = %d, want 6", len(v.Predicates))
+	}
+}
+
+func TestTurnVerify_NoProvenanceEventFails(t *testing.T) {
+	resetTurnVerifyFlags()
+	bead := "ag-lmdx.5"
+	input := writeTurnInput(t, bead, closedTransitions(t, bead),
+		[]evidencedturn.Scenario{{Slug: "ao-turn-verify", HasPassingTest: true, EvidenceResolved: true}})
+	// Empty ledger -> no provenance edge references the bead.
+	ledger := writeLedger(t, nil)
+
+	out, err := executeCommand("turn", "verify", bead, "--input", input, "--ledger", ledger)
+	if err == nil {
+		t.Fatalf("missing provenance event must exit non-zero\noutput=%s", out)
+	}
+	if !strings.Contains(out, "[FAIL] provenance_event") {
+		t.Errorf("output missing provenance_event FAIL:\n%s", out)
+	}
+}
+
+func TestTurnVerify_OrphanArtifactFails(t *testing.T) {
+	resetTurnVerifyFlags()
+	bead := "ag-lmdx.5"
+	input := writeTurnInput(t, bead, closedTransitions(t, bead),
+		[]evidencedturn.Scenario{{Slug: "ao-turn-verify", HasPassingTest: true, EvidenceResolved: true}})
+	ledger := writeLedger(t, []string{beadEdgeLine(t, bead)})
+	graph := writeOrphanGraph(t, bead)
+
+	out, err := executeCommand("turn", "verify", bead, "--input", input, "--ledger", ledger, "--graph", graph)
+	if err == nil {
+		t.Fatalf("orphan artifact must exit non-zero\noutput=%s", out)
+	}
+	if !strings.Contains(out, "[FAIL] no_orphan") {
+		t.Errorf("output missing no_orphan FAIL:\n%s", out)
+	}
+	if !strings.Contains(out, "cli/orphan.go") {
+		t.Errorf("output should name the orphan artifact cli/orphan.go:\n%s", out)
+	}
+}
+
+func TestTurnVerify_NoGraphLeavesOrphanUnchecked(t *testing.T) {
+	resetTurnVerifyFlags()
+	bead := "ag-lmdx.5"
+	input := writeTurnInput(t, bead, closedTransitions(t, bead),
+		[]evidencedturn.Scenario{{Slug: "ao-turn-verify", HasPassingTest: true, EvidenceResolved: true}})
+	ledger := writeLedger(t, []string{beadEdgeLine(t, bead)})
+
+	out, err := executeCommand("turn", "verify", bead, "--input", input, "--ledger", ledger)
+	if err == nil {
+		t.Fatalf("missing --graph leaves no_orphan unchecked -> not done\noutput=%s", out)
+	}
+	if !strings.Contains(out, "[FAIL] no_orphan") {
+		t.Errorf("output missing no_orphan FAIL:\n%s", out)
+	}
+	if !strings.Contains(out, "orphan audit not run") {
+		t.Errorf("output should explain orphan audit not run:\n%s", out)
+	}
+}
+
+func TestTurnVerify_RequiresInputFlag(t *testing.T) {
+	resetTurnVerifyFlags()
+	out, err := executeCommand("turn", "verify", "ag-lmdx.5")
+	if err == nil {
+		t.Fatalf("turn verify without --input must error\noutput=%s", out)
+	}
+	if !strings.Contains(err.Error(), "--input") {
+		t.Errorf("error = %q, want it to mention --input", err.Error())
+	}
+}
+
+func TestTurnVerify_InputBeadMismatchErrors(t *testing.T) {
+	resetTurnVerifyFlags()
+	input := writeTurnInput(t, "ag-other", closedTransitions(t, "ag-other"),
+		[]evidencedturn.Scenario{{Slug: "s", HasPassingTest: true, EvidenceResolved: true}})
+	ledger := writeLedger(t, nil)
+
+	out, err := executeCommand("turn", "verify", "ag-lmdx.5", "--input", input, "--ledger", ledger)
+	if err == nil {
+		t.Fatalf("mismatched bead must error\noutput=%s", out)
+	}
+	if !strings.Contains(err.Error(), "does not match") {
+		t.Errorf("error = %q, want it to mention the bead mismatch", err.Error())
+	}
+}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -4233,3 +4233,33 @@ ao skills producers <output> [flags]
 
 ---
 
+### `ao turn`
+
+The 'turn' command group operates on Evidenced Turns — the ag-lmdx
+
+```
+ao turn [command]
+```
+
+**Subcommands:**
+
+#### `ao turn verify`
+
+Evaluate the legible Definition-of-Done predicate for one bead's
+
+```
+ao turn verify <bead> [flags]
+```
+
+**Flags:**
+
+```
+      --graph string    Path to the provenance trace-graph JSONL (node/edge records) for orphan detection
+  -h, --help            help for verify
+      --input string    Path to the turn-input JSON file (state log + scenario coverage) (required)
+      --json            Emit the full Verdict object as JSON
+      --ledger string   Path to the provenance EDGE ledger JSONL (default: docs/provenance/ledger.jsonl)
+```
+
+---
+

--- a/cli/internal/evidencedturn/evidencedturn.go
+++ b/cli/internal/evidencedturn/evidencedturn.go
@@ -1,0 +1,302 @@
+// Package evidencedturn computes the legible Definition-of-Done predicate for
+// an "Evidenced Turn" (ag-lmdx.5) — the parent epic's unit of work.
+//
+// An Evidenced Turn is the assurance contract that lets a bead legally
+// transition validated->closed. Per ag-lmdx.5, turn-done is a 5-piece puzzle
+// (bead close + Evidence trailer + ledger + next-work flag + CI) and the live
+// AP#7 gate only checks Evidence *presence*, never *sufficiency*. This package
+// rolls those pieces into ONE predicate — "can this bead legally transition
+// validated->closed?" — and, crucially, makes the verdict LEGIBLE: a clear
+// pass/fail per predicate with a human-readable reason for every gap.
+//
+// It builds directly on the ag-lmdx substrate that already landed:
+//
+//   - cli/internal/turnstate (#654): the append-only, hash-chained
+//     state_transition log whose Fold is the artifact's lifecycle state. We
+//     reuse FoldVerified (hash-chain integrity + ordered replay) so the
+//     terminal-state predicate is true by construction, not by trusting a
+//     mutable column.
+//   - cli/internal/provenancegraph (ag-x31t): the provenance edge ledger and
+//     the orphan finder. We reuse those to assert a provenance event exists
+//     for the bead and that nothing the bead produced is an orphan.
+//
+// This is a pure, in-memory predicate core (no Dolt, no file I/O, no bd shell
+// out): it is the testable kernel that defines what "done" MEANS. The cmd
+// layer (cli/cmd/ao/turn_verify.go) wires real inputs into it.
+//
+// Extension point: ag-lmdx.4 (the author!=validator guard) is a SEPARATE
+// concern and is deliberately NOT implemented here. A follow-up can add a
+// PredicateAuthorNeqValidator row without reshaping the verdict; see the TODO
+// on Evaluate.
+package evidencedturn
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/boshu2/agentops/cli/internal/provenancegraph"
+	"github.com/boshu2/agentops/cli/internal/turnstate"
+)
+
+// SchemaVersion stamps the verdict so a serialized DoD report is self-describing.
+const SchemaVersion = "agentops-evidenced-turn.v1"
+
+// terminalStates are the lifecycle states from which validated->closed is the
+// legal next move, i.e. the states an Evidenced Turn must have folded into.
+// "validated" is the pre-close state; "closed" is the post-close state. A bead
+// folded into either is "at or past the done boundary"; anything earlier
+// (e.g. "in_progress") is not done.
+var terminalStates = map[string]bool{
+	"validated": true,
+	"closed":    true,
+}
+
+// Predicate names — the legible DoD checklist. Each appears in every verdict so
+// the report shape is stable (a missing predicate never silently drops a row).
+const (
+	// PredicateChainIntact: the bead's state_transition log hash-verifies and
+	// folds without a gap (turnstate.FoldVerified). Tamper or out-of-order
+	// replay fails this first.
+	PredicateChainIntact = "chain_intact"
+	// PredicateTerminalState: the folded lifecycle state is at/past the
+	// validated->closed boundary.
+	PredicateTerminalState = "terminal_state"
+	// PredicateScenariosCovered: every Closes-scenario the turn claims has a
+	// passing test (the sufficiency half AP#7 omits).
+	PredicateScenariosCovered = "scenarios_covered"
+	// PredicateEvidenceResolves: every Evidence line resolves to a gate log
+	// that exercised THAT scenario (not merely "an Evidence trailer exists").
+	PredicateEvidenceResolves = "evidence_resolves"
+	// PredicateProvenanceEvent: at least one provenance edge in the ledger
+	// references the bead (a witnessed event exists).
+	PredicateProvenanceEvent = "provenance_event"
+	// PredicateNoOrphan: no artifact the turn produced is a provenance orphan.
+	PredicateNoOrphan = "no_orphan"
+)
+
+// orderedPredicates is the canonical report order so JSON/text output is stable
+// across runs regardless of map iteration.
+var orderedPredicates = []string{
+	PredicateChainIntact,
+	PredicateTerminalState,
+	PredicateScenariosCovered,
+	PredicateEvidenceResolves,
+	PredicateProvenanceEvent,
+	PredicateNoOrphan,
+}
+
+// Scenario is one Closes-scenario claim a turn makes, with the two sufficiency
+// facts AP#7 does not check: whether a passing test covers it, and whether its
+// Evidence line resolves to a gate log that exercised it.
+type Scenario struct {
+	// Slug is the scenario token (e.g. "ao-turn-verify" in
+	// "Closes-scenario: ag-lmdx.5#ao-turn-verify").
+	Slug string `json:"slug"`
+	// HasPassingTest is true when a test exercising this scenario passes.
+	HasPassingTest bool `json:"has_passing_test"`
+	// EvidenceResolved is true when this scenario's Evidence line resolves to a
+	// gate log that exercised THIS scenario (presence->sufficiency).
+	EvidenceResolved bool `json:"evidence_resolved"`
+}
+
+// Input is the complete set of facts the DoD predicate folds over. Everything
+// is supplied by the caller; this package shells out to nothing.
+type Input struct {
+	// BeadID is the turn's bead (e.g. "ag-lmdx.5"). Required.
+	BeadID string
+	// Transitions is the bead's append-only state_transition log (turnstate).
+	// May contain multiple artifacts; only BeadID's transitions are folded.
+	Transitions []turnstate.Transition
+	// Scenarios are the turn's Closes-scenario claims with coverage facts.
+	Scenarios []Scenario
+	// ProvenanceEdges is the provenance ledger (provenancegraph.Edge). A
+	// provenance event "references the bead" when from_id or to_id == BeadID.
+	ProvenanceEdges []provenancegraph.Edge
+	// OrphanFindings are provenance orphans detected for the bead's produced
+	// artifacts (provenancegraph.FindOrphans output). Empty == no orphan.
+	OrphanFindings []provenancegraph.OrphanFinding
+	// OrphanChecked records whether an orphan audit actually ran. When false
+	// (e.g. no trace-graph was supplied), no_orphan fails as "not-yet-checked"
+	// rather than passing vacuously — a turn is not provably done if its
+	// orphan status was never audited.
+	OrphanChecked bool
+}
+
+// PredicateResult is one row of the legible DoD checklist.
+type PredicateResult struct {
+	Name   string `json:"name"`
+	Passed bool   `json:"passed"`
+	// Reason is human-readable: WHY it passed, or precisely WHAT gap fails it.
+	Reason string `json:"reason"`
+}
+
+// Verdict is the rolled-up DoD result: the single done/not-done answer plus the
+// per-predicate breakdown that makes it legible.
+type Verdict struct {
+	SchemaVersion string            `json:"schema_version"`
+	BeadID        string            `json:"bead_id"`
+	Done          bool              `json:"done"`
+	Predicates    []PredicateResult `json:"predicates"`
+	// Gaps is the ordered list of failing predicate reasons — the actionable
+	// "what's missing" summary. Empty when Done.
+	Gaps []string `json:"gaps"`
+}
+
+// Evaluate folds the Input into the Evidenced-Turn Verdict. The turn is Done
+// iff EVERY predicate passes (validated->closed is legal). A missing input is a
+// failing predicate with a legible reason, never a silent pass.
+//
+// TODO(ag-lmdx.4): the author!=validator guard is a separate concern. When it
+// lands, add a PredicateAuthorNeqValidator row here (and a field on Input);
+// the verdict shape already accommodates an extra predicate without change.
+func Evaluate(in Input) (Verdict, error) {
+	if strings.TrimSpace(in.BeadID) == "" {
+		return Verdict{}, fmt.Errorf("bead_id is required")
+	}
+
+	results := map[string]PredicateResult{
+		PredicateChainIntact:      evalChainIntact(in),
+		PredicateTerminalState:    evalTerminalState(in),
+		PredicateScenariosCovered: evalScenariosCovered(in),
+		PredicateEvidenceResolves: evalEvidenceResolves(in),
+		PredicateProvenanceEvent:  evalProvenanceEvent(in),
+		PredicateNoOrphan:         evalNoOrphan(in),
+	}
+
+	v := Verdict{
+		SchemaVersion: SchemaVersion,
+		BeadID:        in.BeadID,
+		Done:          true,
+		Predicates:    make([]PredicateResult, 0, len(orderedPredicates)),
+	}
+	for _, name := range orderedPredicates {
+		r := results[name]
+		v.Predicates = append(v.Predicates, r)
+		if !r.Passed {
+			v.Done = false
+			v.Gaps = append(v.Gaps, fmt.Sprintf("%s: %s", r.Name, r.Reason))
+		}
+	}
+	return v, nil
+}
+
+// evalChainIntact verifies the bead's transition log hash-chains and folds.
+func evalChainIntact(in Input) PredicateResult {
+	r := PredicateResult{Name: PredicateChainIntact}
+	if _, err := turnstate.FoldVerified(in.Transitions); err != nil {
+		r.Reason = fmt.Sprintf("state_transition log does not verify/fold: %v", err)
+		return r
+	}
+	r.Passed = true
+	r.Reason = "state_transition log hash-verifies and folds cleanly"
+	return r
+}
+
+// evalTerminalState requires the bead's folded state to be at/past the
+// validated->closed boundary. An absent bead (no transitions) is not done.
+func evalTerminalState(in Input) PredicateResult {
+	r := PredicateResult{Name: PredicateTerminalState}
+	state, found, err := turnstate.StateOf(in.Transitions, in.BeadID)
+	if err != nil {
+		r.Reason = fmt.Sprintf("cannot fold state for %q: %v", in.BeadID, err)
+		return r
+	}
+	if !found {
+		r.Reason = fmt.Sprintf("bead %q has no state_transition log (never transitioned)", in.BeadID)
+		return r
+	}
+	if !terminalStates[state] {
+		r.Reason = fmt.Sprintf("folded state %q is not at the validated->closed boundary", state)
+		return r
+	}
+	r.Passed = true
+	r.Reason = fmt.Sprintf("folded state is %q (validated->closed is legal)", state)
+	return r
+}
+
+// evalScenariosCovered requires at least one Closes-scenario, each with a
+// passing test. It names the uncovered scenarios so the gap is actionable.
+func evalScenariosCovered(in Input) PredicateResult {
+	r := PredicateResult{Name: PredicateScenariosCovered}
+	if len(in.Scenarios) == 0 {
+		r.Reason = "no Closes-scenario claims (a turn must close at least one scenario)"
+		return r
+	}
+	var uncovered []string
+	for _, s := range in.Scenarios {
+		if !s.HasPassingTest {
+			uncovered = append(uncovered, s.Slug)
+		}
+	}
+	if len(uncovered) > 0 {
+		sort.Strings(uncovered)
+		r.Reason = fmt.Sprintf("scenario(s) with no passing test: %s", strings.Join(uncovered, ", "))
+		return r
+	}
+	r.Passed = true
+	r.Reason = fmt.Sprintf("all %d scenario(s) have a passing test", len(in.Scenarios))
+	return r
+}
+
+// evalEvidenceResolves requires every claimed scenario's Evidence line to
+// resolve to a gate log that exercised THAT scenario (presence->sufficiency).
+func evalEvidenceResolves(in Input) PredicateResult {
+	r := PredicateResult{Name: PredicateEvidenceResolves}
+	if len(in.Scenarios) == 0 {
+		r.Reason = "no scenarios, so no Evidence to resolve"
+		return r
+	}
+	var unresolved []string
+	for _, s := range in.Scenarios {
+		if !s.EvidenceResolved {
+			unresolved = append(unresolved, s.Slug)
+		}
+	}
+	if len(unresolved) > 0 {
+		sort.Strings(unresolved)
+		r.Reason = fmt.Sprintf("scenario(s) whose Evidence does not resolve to a gate log that exercised it: %s",
+			strings.Join(unresolved, ", "))
+		return r
+	}
+	r.Passed = true
+	r.Reason = fmt.Sprintf("all %d scenario(s) have Evidence resolving to an exercising gate log", len(in.Scenarios))
+	return r
+}
+
+// evalProvenanceEvent requires at least one provenance edge referencing the
+// bead (as from_id or to_id) — a witnessed event exists.
+func evalProvenanceEvent(in Input) PredicateResult {
+	r := PredicateResult{Name: PredicateProvenanceEvent}
+	for _, e := range in.ProvenanceEdges {
+		if e.FromID == in.BeadID || e.ToID == in.BeadID {
+			r.Passed = true
+			r.Reason = fmt.Sprintf("provenance edge present (%s %s %s)", e.FromID, e.Relation, e.ToID)
+			return r
+		}
+	}
+	r.Reason = fmt.Sprintf("no provenance edge references bead %q", in.BeadID)
+	return r
+}
+
+// evalNoOrphan requires no provenance orphan among the bead's produced
+// artifacts. It names the orphans so the gap is actionable.
+func evalNoOrphan(in Input) PredicateResult {
+	r := PredicateResult{Name: PredicateNoOrphan}
+	if !in.OrphanChecked {
+		r.Reason = "orphan audit not run (supply a provenance trace-graph to check no_orphan)"
+		return r
+	}
+	if len(in.OrphanFindings) > 0 {
+		ids := make([]string, 0, len(in.OrphanFindings))
+		for _, f := range in.OrphanFindings {
+			ids = append(ids, f.OrphanArtifactID)
+		}
+		sort.Strings(ids)
+		r.Reason = fmt.Sprintf("orphan artifact(s) with no inbound provenance edge: %s", strings.Join(ids, ", "))
+		return r
+	}
+	r.Passed = true
+	r.Reason = "no provenance orphans"
+	return r
+}

--- a/cli/internal/evidencedturn/evidencedturn_test.go
+++ b/cli/internal/evidencedturn/evidencedturn_test.go
@@ -1,0 +1,304 @@
+package evidencedturn
+
+import (
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/provenancegraph"
+	"github.com/boshu2/agentops/cli/internal/turnstate"
+)
+
+// wellFormedTransitions builds a verifying, sealed log that folds the bead into
+// the "closed" state: ""->in_progress->validated->closed.
+func wellFormedTransitions(t *testing.T, beadID string) []turnstate.Transition {
+	t.Helper()
+	steps := []struct {
+		from, to, ts string
+	}{
+		{turnstate.InitialState, "in_progress", "2026-05-31T00:00:00Z"},
+		{"in_progress", "validated", "2026-05-31T01:00:00Z"},
+		{"validated", "closed", "2026-05-31T02:00:00Z"},
+	}
+	var log []turnstate.Transition
+	for _, s := range steps {
+		var err error
+		log, err = turnstate.Append(log, turnstate.Transition{
+			ArtifactID: beadID,
+			FromState:  s.from,
+			ToState:    s.to,
+			TS:         s.ts,
+		})
+		if err != nil {
+			t.Fatalf("Append(%s->%s): %v", s.from, s.to, err)
+		}
+	}
+	return log
+}
+
+func provEdge(t *testing.T, from, to string) provenancegraph.Edge {
+	t.Helper()
+	e := provenancegraph.Edge{
+		FromID:   from,
+		FromType: "commit",
+		ToID:     to,
+		ToType:   "bead",
+		Relation: "commit_implements_decision",
+		EvidenceRef: "deadbeef",
+		TrustTier: "inferred",
+		TS:        "2026-05-31T03:00:00Z",
+	}
+	sealed, err := provenancegraph.Seal(e, "")
+	if err != nil {
+		t.Fatalf("Seal edge: %v", err)
+	}
+	return sealed
+}
+
+// wellFormedInput is a complete Evidenced Turn that should evaluate Done.
+func wellFormedInput(t *testing.T) Input {
+	t.Helper()
+	bead := "ag-lmdx.5"
+	return Input{
+		BeadID:      bead,
+		Transitions: wellFormedTransitions(t, bead),
+		Scenarios: []Scenario{
+			{Slug: "ao-turn-verify", HasPassingTest: true, EvidenceResolved: true},
+		},
+		ProvenanceEdges: []provenancegraph.Edge{provEdge(t, "commit:abc123", bead)},
+		OrphanFindings:  nil,
+		OrphanChecked:   true,
+	}
+}
+
+// predicate looks up a predicate row by name; fails the test if absent.
+func predicate(t *testing.T, v Verdict, name string) PredicateResult {
+	t.Helper()
+	for _, p := range v.Predicates {
+		if p.Name == name {
+			return p
+		}
+	}
+	t.Fatalf("verdict missing predicate %q", name)
+	return PredicateResult{}
+}
+
+func TestEvaluate_CompleteTurnIsDone(t *testing.T) {
+	v, err := Evaluate(wellFormedInput(t))
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if v.Done != true {
+		t.Errorf("Done = %v, want true (gaps: %v)", v.Done, v.Gaps)
+	}
+	if v.SchemaVersion != SchemaVersion {
+		t.Errorf("SchemaVersion = %q, want %q", v.SchemaVersion, SchemaVersion)
+	}
+	if v.BeadID != "ag-lmdx.5" {
+		t.Errorf("BeadID = %q, want %q", v.BeadID, "ag-lmdx.5")
+	}
+	if len(v.Gaps) != 0 {
+		t.Errorf("Gaps = %v, want empty", v.Gaps)
+	}
+	if len(v.Predicates) != len(orderedPredicates) {
+		t.Errorf("len(Predicates) = %d, want %d", len(v.Predicates), len(orderedPredicates))
+	}
+	for _, p := range v.Predicates {
+		if !p.Passed {
+			t.Errorf("predicate %q should pass; reason=%q", p.Name, p.Reason)
+		}
+	}
+}
+
+func TestEvaluate_PredicateOrderIsStable(t *testing.T) {
+	v, err := Evaluate(wellFormedInput(t))
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	for i, want := range orderedPredicates {
+		if v.Predicates[i].Name != want {
+			t.Errorf("Predicates[%d].Name = %q, want %q", i, v.Predicates[i].Name, want)
+		}
+	}
+}
+
+func TestEvaluate_MissingPredicateFailsWithLegibleReason(t *testing.T) {
+	tests := []struct {
+		name          string
+		mutate        func(in *Input)
+		wantPredicate string
+		wantReason    string // substring the failing reason must contain
+		wantState     bool   // expected Passed value for the named predicate
+	}{
+		{
+			name: "uncovered scenario",
+			mutate: func(in *Input) {
+				in.Scenarios = []Scenario{
+					{Slug: "ao-turn-verify", HasPassingTest: false, EvidenceResolved: true},
+				}
+			},
+			wantPredicate: PredicateScenariosCovered,
+			wantReason:    "scenario(s) with no passing test: ao-turn-verify",
+			wantState:     false,
+		},
+		{
+			name: "evidence does not resolve",
+			mutate: func(in *Input) {
+				in.Scenarios = []Scenario{
+					{Slug: "ao-turn-verify", HasPassingTest: true, EvidenceResolved: false},
+				}
+			},
+			wantPredicate: PredicateEvidenceResolves,
+			wantReason:    "Evidence does not resolve to a gate log that exercised it: ao-turn-verify",
+			wantState:     false,
+		},
+		{
+			name: "no scenarios at all",
+			mutate: func(in *Input) {
+				in.Scenarios = nil
+			},
+			wantPredicate: PredicateScenariosCovered,
+			wantReason:    "no Closes-scenario claims",
+			wantState:     false,
+		},
+		{
+			name: "no provenance event",
+			mutate: func(in *Input) {
+				in.ProvenanceEdges = nil
+			},
+			wantPredicate: PredicateProvenanceEvent,
+			wantReason:    `no provenance edge references bead "ag-lmdx.5"`,
+			wantState:     false,
+		},
+		{
+			name: "orphan artifact",
+			mutate: func(in *Input) {
+				in.OrphanFindings = []provenancegraph.OrphanFinding{
+					{OrphanArtifactID: "cli/orphan.go", Code: "ORPHAN_ARTIFACT", Message: "no inbound edge"},
+				}
+			},
+			wantPredicate: PredicateNoOrphan,
+			wantReason:    "orphan artifact(s) with no inbound provenance edge: cli/orphan.go",
+			wantState:     false,
+		},
+		{
+			name: "orphan audit not run",
+			mutate: func(in *Input) {
+				in.OrphanChecked = false
+			},
+			wantPredicate: PredicateNoOrphan,
+			wantReason:    "orphan audit not run",
+			wantState:     false,
+		},
+		{
+			name: "not at terminal state",
+			mutate: func(in *Input) {
+				// Only the genesis step: folds to "in_progress", not terminal.
+				log, err := turnstate.Append(nil, turnstate.Transition{
+					ArtifactID: in.BeadID,
+					FromState:  turnstate.InitialState,
+					ToState:    "in_progress",
+					TS:         "2026-05-31T00:00:00Z",
+				})
+				if err != nil {
+					t.Fatalf("Append: %v", err)
+				}
+				in.Transitions = log
+			},
+			wantPredicate: PredicateTerminalState,
+			wantReason:    `folded state "in_progress" is not at the validated->closed boundary`,
+			wantState:     false,
+		},
+		{
+			name: "no transitions for bead",
+			mutate: func(in *Input) {
+				in.Transitions = nil
+			},
+			wantPredicate: PredicateTerminalState,
+			wantReason:    "has no state_transition log",
+			wantState:     false,
+		},
+		{
+			name: "tampered chain",
+			mutate: func(in *Input) {
+				// Corrupt the tip's hash so FoldVerified fails.
+				in.Transitions[len(in.Transitions)-1].Hash = "deadbeef"
+			},
+			wantPredicate: PredicateChainIntact,
+			wantReason:    "does not verify/fold",
+			wantState:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := wellFormedInput(t)
+			tt.mutate(&in)
+			v, err := Evaluate(in)
+			if err != nil {
+				t.Fatalf("Evaluate: %v", err)
+			}
+			if v.Done != false {
+				t.Errorf("Done = %v, want false", v.Done)
+			}
+			p := predicate(t, v, tt.wantPredicate)
+			if p.Passed != tt.wantState {
+				t.Errorf("predicate %q Passed = %v, want %v (reason=%q)", tt.wantPredicate, p.Passed, tt.wantState, p.Reason)
+			}
+			if !contains(p.Reason, tt.wantReason) {
+				t.Errorf("predicate %q reason = %q, want substring %q", tt.wantPredicate, p.Reason, tt.wantReason)
+			}
+			// The failing predicate's reason must surface in Gaps verbatim.
+			wantGap := tt.wantPredicate + ": " + p.Reason
+			if !sliceContains(v.Gaps, wantGap) {
+				t.Errorf("Gaps = %v, want it to contain %q", v.Gaps, wantGap)
+			}
+		})
+	}
+}
+
+func TestEvaluate_EmptyBeadIDErrors(t *testing.T) {
+	_, err := Evaluate(Input{BeadID: "   "})
+	if err == nil {
+		t.Fatal("Evaluate with blank bead_id: want error, got nil")
+	}
+	if !contains(err.Error(), "bead_id is required") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "bead_id is required")
+	}
+}
+
+func TestEvaluate_MultipleGapsAllReported(t *testing.T) {
+	in := wellFormedInput(t)
+	in.Scenarios = nil      // fails scenarios_covered + evidence_resolves
+	in.ProvenanceEdges = nil // fails provenance_event
+	v, err := Evaluate(in)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if v.Done != false {
+		t.Errorf("Done = %v, want false", v.Done)
+	}
+	if len(v.Gaps) != 3 {
+		t.Errorf("len(Gaps) = %d, want 3 (gaps=%v)", len(v.Gaps), v.Gaps)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func sliceContains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/cli-skills-map.md
+++ b/docs/cli-skills-map.md
@@ -2,7 +2,7 @@
 
 > Which `ao` commands are called by which skills and hooks — and vice versa.
 
-Auto-audited 2026-04-24; targeted runtime-proof update 2026-04-28. 74 generated CLI command headings, 69 source skills, 12 runtime hook event sections.
+Auto-audited 2026-04-24; targeted runtime-proof update 2026-04-28. 75 generated CLI command headings, 69 source skills, 12 runtime hook event sections.
 
 Source-of-truth note: `hooks/hooks.json` currently declares the full Claude runtime event surface. `hooks/codex-hooks.json` declares the Codex-native subset that runtime can support.
 

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=74 sub=187 all=261"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=75 sub=188 all=263"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,4} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "74" || "$sub_count" != "187" || "$all_count" != "261" ]]; then
+if [[ "$top_count" != "75" || "$sub_count" != "188" || "$all_count" != "263" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 261 ]]; then
+if [[ "${#commands[@]}" -ne 263 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/registry.json
+++ b/registry.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-05-31T16:54:58Z",
+  "generated_at": "2026-05-31T18:33:01Z",
   "summary": {
     "skills": 81,
     "hooks": 0,
     "knowledge_stores": 5,
     "job_types": 0,
     "eval_files": 56,
-    "cli_commands": 72,
-    "capabilities": 167
+    "cli_commands": 73,
+    "capabilities": 168
   },
   "surfaces": {
     "skills": [
@@ -1392,6 +1392,13 @@
         "driven_by_skills": []
       },
       {
+        "name": "ao turn",
+        "path": "cli/cmd/ao/",
+        "purpose": "Evidenced-Turn operations (the enforced unit-of-work definition-of-done)",
+        "bounded_context": "",
+        "driven_by_skills": []
+      },
+      {
         "name": "ao validate",
         "path": "cli/cmd/ao/",
         "purpose": "Umbrella validation gate (exit-code-as-verdict with --gate)",
@@ -1428,9 +1435,9 @@
     ]
   },
   "capability_summary": {
-    "total": 167,
+    "total": 168,
     "skills": 81,
-    "cli_commands": 72,
+    "cli_commands": 73,
     "gates": 11,
     "reference_impls": 3
   },
@@ -1503,6 +1510,7 @@
     "skills",
     "status",
     "trace",
+    "turn",
     "validate",
     "version",
     "vibe-check",
@@ -4836,6 +4844,23 @@
         "--config",
         "--dry-run",
         "--graph",
+        "--json",
+        "--output",
+        "--verbose"
+      ],
+      "path": "cli/cmd/ao/"
+    },
+    {
+      "sku": "cmd:ao.turn",
+      "name": "ao turn",
+      "type": "cli-command",
+      "bounded_context": "",
+      "purpose": "Evidenced-Turn operations (the enforced unit-of-work definition-of-done)",
+      "status": "active",
+      "driven_by_skills": [],
+      "flags": [
+        "--config",
+        "--dry-run",
         "--json",
         "--output",
         "--verbose"


### PR DESCRIPTION
## What

Adds `ao turn verify <bead>` — a legible Definition-of-Done predicate for an **Evidenced Turn** (ag-lmdx.5). Where the live AP#7 gate checks Evidence *presence*, this checks turn *sufficiency*: one verdict answering "can this bead legally transition validated->closed?" with a clear pass/fail per predicate and a reason for every gap (`--json` too).

## Definition of "Evidenced Turn"

A turn is DONE iff all six predicates pass:

| predicate | meaning |
|---|---|
| `chain_intact` | the bead's state_transition log hash-verifies and folds (turnstate `FoldVerified`) |
| `terminal_state` | the folded lifecycle state is at the validated->closed boundary |
| `scenarios_covered` | every Closes-scenario claim has a passing test |
| `evidence_resolves` | every Evidence line resolves to a gate log that exercised THAT scenario (presence->sufficiency) |
| `provenance_event` | a provenance edge in the ledger references the bead |
| `no_orphan` | no artifact in the turn's trace-graph is a provenance orphan |

## How

- New pure, in-memory predicate core `cli/internal/evidencedturn` (no Dolt / no shell-out) — the testable kernel that defines what "done" MEANS.
- Builds directly on **#654** `cli/internal/turnstate` (`Seal/Append/Fold/FoldVerified/VerifyChain`) and `cli/internal/provenancegraph` (edges + `FindOrphans`).
- `cli/cmd/ao/turn_verify.go` wires `--input` (turn-input JSON: state log + scenario coverage), `--ledger` (provenance EDGE ledger), and `--graph` (optional trace-graph for orphan audit). Non-zero exit on not-done makes it usable as a transition guard.

## Scope note (ag-lmdx.4)

The author!=validator guard is a **separate** concern and is NOT implemented. It is left as a documented extension point (TODO on `Evaluate`); the verdict shape already accommodates an extra predicate row without a reshape.

## Tests

`cli/internal/evidencedturn` (14 cases: complete-turn-done, each missing predicate fails with a legible reason, multi-gap, blank-bead error) + `cli/cmd/ao/turn_verify_test.go` (complete/incomplete/json/orphan/no-graph/missing-input/bead-mismatch). `go build ./...`, `go vet`, full `cmd/ao`+`evidencedturn` suites (9288) green.

## Derived surfaces regenerated

COMMANDS.md, cobra `expectedCmds`, command-surface smoke (top=75 sub=188 all=263) + matrix.json, registry.json (cli_commands 72->73), cli-skills-map.

Closes-scenario: ag-lmdx.5#ao-turn-verify
Bounded-context: BC4-Factory
Evidence: cli/internal/evidencedturn/evidencedturn.go