### PR TITLE
feat(turn): enforce author!=validator no-self-grading invariant (ag-lmdx.4 #author-validator-guard)

### DIFF
--- a/cli/cmd/ao/turn_verify.go
+++ b/cli/cmd/ao/turn_verify.go
@@ -15,10 +15,11 @@ import (
 )
 
 var (
-	turnVerifyInput  string
-	turnVerifyLedger string
-	turnVerifyGraph  string
-	turnVerifyJSON   bool
+	turnVerifyInput     string
+	turnVerifyLedger    string
+	turnVerifyGraph     string
+	turnVerifyJSON      bool
+	turnVerifyAllowSelf bool
 )
 
 // turnCmd is the parent group for Evidenced-Turn operations (ag-lmdx). A "turn"
@@ -41,6 +42,14 @@ type turnInputFile struct {
 	BeadID      string                   `json:"bead_id"`
 	Transitions []turnstate.Transition   `json:"transitions"`
 	Scenarios   []evidencedturn.Scenario `json:"scenarios"`
+	// AuthorID and JudgeID carry the no-self-grading invariant (ag-lmdx.4):
+	// the identity of the context that AUTHORED the artifact vs. the context
+	// that PRODUCED the acceptance verdict. The author_neq_validator predicate
+	// fails when they are equal (a self-graded, autocorrelated verdict) unless
+	// --allow-self waives it. Empty judge_id also fails: independence that was
+	// never recorded cannot be asserted.
+	AuthorID string `json:"author_id,omitempty"`
+	JudgeID  string `json:"judge_id,omitempty"`
 }
 
 var turnVerifyCmd = &cobra.Command{
@@ -62,6 +71,12 @@ A turn is DONE iff every predicate passes (validated->closed is legal):
                      THAT scenario (presence->sufficiency)
   provenance_event   a provenance edge in the ledger references the bead
   no_orphan          no artifact the turn produced is a provenance orphan
+  author_neq_validator
+                     the acceptance verdict came from a judge context distinct
+                     from the author context (author_id != judge_id) — the
+                     no-self-grading invariant (ag-lmdx.4). A self-graded
+                     verdict is autocorrelated and fails; --allow-self waives it
+                     for the inline fallback (default OFF).
 
 Inputs:
   --input   turn-input JSON file: the bead's state_transition log + its
@@ -71,6 +86,11 @@ Inputs:
   --graph   an OPTIONAL provenance trace-graph projection (node/edge "record"
             JSONL, the shape ao provenance trace reads). Used for no_orphan.
             Without it, no_orphan is reported as not-yet-checked and fails.
+
+  --allow-self  waive the no-self-grading invariant (author_neq_validator),
+            permitting a self-graded verdict (judge_id == author_id) on the
+            inline fallback path. Default OFF: the default requires an
+            independent judge context.
 
 Exit is non-zero when the turn is NOT done, so this is usable as a
 validated->closed transition guard.
@@ -95,6 +115,7 @@ func init() {
 	turnVerifyCmd.Flags().StringVar(&turnVerifyLedger, "ledger", "", "Path to the provenance EDGE ledger JSONL (default: docs/provenance/ledger.jsonl)")
 	turnVerifyCmd.Flags().StringVar(&turnVerifyGraph, "graph", "", "Path to the provenance trace-graph JSONL (node/edge records) for orphan detection")
 	turnVerifyCmd.Flags().BoolVar(&turnVerifyJSON, "json", false, "Emit the full Verdict object as JSON")
+	turnVerifyCmd.Flags().BoolVar(&turnVerifyAllowSelf, "allow-self", false, "Waive the no-self-grading invariant (permit judge_id == author_id) for the inline fallback; default OFF")
 }
 
 func runTurnVerify(cmd *cobra.Command, args []string) error {
@@ -148,6 +169,9 @@ func runTurnVerify(cmd *cobra.Command, args []string) error {
 		ProvenanceEdges: edges,
 		OrphanFindings:  orphans,
 		OrphanChecked:   orphanChecked,
+		AuthorID:        tf.AuthorID,
+		JudgeID:         tf.JudgeID,
+		AllowSelf:       turnVerifyAllowSelf,
 	})
 	if err != nil {
 		return err

--- a/cli/cmd/ao/turn_verify_test.go
+++ b/cli/cmd/ao/turn_verify_test.go
@@ -18,6 +18,7 @@ func resetTurnVerifyFlags() {
 	turnVerifyInput = ""
 	turnVerifyLedger = ""
 	turnVerifyJSON = false
+	turnVerifyAllowSelf = false
 }
 
 // closedTransitionsJSON builds a sealed ""->in_progress->validated->closed log
@@ -42,10 +43,21 @@ func closedTransitions(t *testing.T, bead string) []turnstate.Transition {
 	return log
 }
 
-// writeTurnInput marshals a turn-input file to a temp path and returns it.
+// writeTurnInput marshals a turn-input file to a temp path and returns it. It
+// records a distinct author/judge by default so the no-self-grading invariant
+// (author_neq_validator, ag-lmdx.4) passes for the otherwise-complete fixtures;
+// tests exercising the guard set author_id/judge_id explicitly via
+// writeTurnInputGraded.
 func writeTurnInput(t *testing.T, bead string, transitions []turnstate.Transition, scenarios []evidencedturn.Scenario) string {
 	t.Helper()
-	tf := turnInputFile{BeadID: bead, Transitions: transitions, Scenarios: scenarios}
+	return writeTurnInputGraded(t, bead, transitions, scenarios, "session:author", "session:judge")
+}
+
+// writeTurnInputGraded is writeTurnInput with explicit author/judge identities,
+// for tests of the author_neq_validator predicate.
+func writeTurnInputGraded(t *testing.T, bead string, transitions []turnstate.Transition, scenarios []evidencedturn.Scenario, authorID, judgeID string) string {
+	t.Helper()
+	tf := turnInputFile{BeadID: bead, Transitions: transitions, Scenarios: scenarios, AuthorID: authorID, JudgeID: judgeID}
 	b, err := json.Marshal(tf)
 	if err != nil {
 		t.Fatalf("marshal turn input: %v", err)
@@ -201,8 +213,48 @@ func TestTurnVerify_JSONShape(t *testing.T) {
 	if v.Done != true {
 		t.Errorf("done = %v, want true", v.Done)
 	}
-	if len(v.Predicates) != 6 {
-		t.Errorf("len(predicates) = %d, want 6", len(v.Predicates))
+	if len(v.Predicates) != 7 {
+		t.Errorf("len(predicates) = %d, want 7", len(v.Predicates))
+	}
+}
+
+// TestTurnVerify_SelfGradedRefused: a verdict whose judge_id equals author_id
+// is refused (the no-self-grading invariant, ag-lmdx.4) and exits non-zero.
+func TestTurnVerify_SelfGradedRefused(t *testing.T) {
+	resetTurnVerifyFlags()
+	bead := "ag-lmdx.5"
+	input := writeTurnInputGraded(t, bead, closedTransitions(t, bead),
+		[]evidencedturn.Scenario{{Slug: "ao-turn-verify", HasPassingTest: true, EvidenceResolved: true}},
+		"session:same", "session:same")
+	ledger := writeLedger(t, []string{beadEdgeLine(t, bead)})
+	graph := writeCleanGraph(t, bead)
+
+	out, err := executeCommand("turn", "verify", bead, "--input", input, "--ledger", ledger, "--graph", graph)
+	if err == nil {
+		t.Fatalf("self-graded verdict must exit non-zero\noutput=%s", out)
+	}
+	if !strings.Contains(out, "[FAIL] author_neq_validator") {
+		t.Errorf("output missing author_neq_validator FAIL:\n%s", out)
+	}
+}
+
+// TestTurnVerify_AllowSelfPasses: --allow-self waives the no-self-grading guard
+// for the inline fallback path; an otherwise-complete self-graded turn is DONE.
+func TestTurnVerify_AllowSelfPasses(t *testing.T) {
+	resetTurnVerifyFlags()
+	bead := "ag-lmdx.5"
+	input := writeTurnInputGraded(t, bead, closedTransitions(t, bead),
+		[]evidencedturn.Scenario{{Slug: "ao-turn-verify", HasPassingTest: true, EvidenceResolved: true}},
+		"session:same", "session:same")
+	ledger := writeLedger(t, []string{beadEdgeLine(t, bead)})
+	graph := writeCleanGraph(t, bead)
+
+	out, err := executeCommand("turn", "verify", bead, "--input", input, "--ledger", ledger, "--graph", graph, "--allow-self")
+	if err != nil {
+		t.Fatalf("turn verify --allow-self should succeed, got err=%v\noutput=%s", err, out)
+	}
+	if !strings.Contains(out, "VERDICT: DONE") {
+		t.Errorf("output missing DONE verdict with --allow-self:\n%s", out)
 	}
 }
 

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -4254,6 +4254,7 @@ ao turn verify <bead> [flags]
 **Flags:**
 
 ```
+      --allow-self      Waive the no-self-grading invariant (permit judge_id == author_id) for the inline fallback; default OFF
       --graph string    Path to the provenance trace-graph JSONL (node/edge records) for orphan detection
   -h, --help            help for verify
       --input string    Path to the turn-input JSON file (state log + scenario coverage) (required)

--- a/cli/internal/evidencedturn/evidencedturn.go
+++ b/cli/internal/evidencedturn/evidencedturn.go
@@ -73,6 +73,13 @@ const (
 	PredicateProvenanceEvent = "provenance_event"
 	// PredicateNoOrphan: no artifact the turn produced is a provenance orphan.
 	PredicateNoOrphan = "no_orphan"
+	// PredicateAuthorNeqValidator: the no-self-grading invariant (ag-lmdx.4).
+	// The acceptance verdict was produced by a judge context distinct from the
+	// author context (author_id != judge_id). A verdict graded by its own
+	// author is autocorrelated; the independent-trust-domain check is the guard
+	// on the evidenced->validated transition. The documented, default-OFF
+	// --allow-self escape permits a self-graded verdict for the inline fallback.
+	PredicateAuthorNeqValidator = "author_neq_validator"
 )
 
 // orderedPredicates is the canonical report order so JSON/text output is stable
@@ -84,6 +91,7 @@ var orderedPredicates = []string{
 	PredicateEvidenceResolves,
 	PredicateProvenanceEvent,
 	PredicateNoOrphan,
+	PredicateAuthorNeqValidator,
 }
 
 // Scenario is one Closes-scenario claim a turn makes, with the two sufficiency
@@ -121,6 +129,19 @@ type Input struct {
 	// rather than passing vacuously — a turn is not provably done if its
 	// orphan status was never audited.
 	OrphanChecked bool
+	// AuthorID is the identity of the session/context that AUTHORED the
+	// artifact under verdict (the "who built it"). Empty means unknown.
+	AuthorID string
+	// JudgeID is the identity of the session/context that PRODUCED the
+	// acceptance verdict (the "who graded it"). For the no-self-grading
+	// invariant the judge must be a context distinct from the author — a
+	// blind sub-agent context, not the same session. Empty means no
+	// independent judge identity was recorded.
+	JudgeID string
+	// AllowSelf is the documented, default-OFF escape hatch that permits a
+	// self-graded verdict (JudgeID == AuthorID). It exists for the inline
+	// fallback path only; the default requires an independent judge.
+	AllowSelf bool
 }
 
 // PredicateResult is one row of the legible DoD checklist.
@@ -147,9 +168,10 @@ type Verdict struct {
 // iff EVERY predicate passes (validated->closed is legal). A missing input is a
 // failing predicate with a legible reason, never a silent pass.
 //
-// TODO(ag-lmdx.4): the author!=validator guard is a separate concern. When it
-// lands, add a PredicateAuthorNeqValidator row here (and a field on Input);
-// the verdict shape already accommodates an extra predicate without change.
+// The author!=validator guard (ag-lmdx.4) is one of those predicates: a verdict
+// graded by its own author is autocorrelated, so an Evidenced Turn is not done
+// unless an independent judge context produced the verdict (or --allow-self
+// explicitly waives it for the inline fallback).
 func Evaluate(in Input) (Verdict, error) {
 	if strings.TrimSpace(in.BeadID) == "" {
 		return Verdict{}, fmt.Errorf("bead_id is required")
@@ -160,8 +182,9 @@ func Evaluate(in Input) (Verdict, error) {
 		PredicateTerminalState:    evalTerminalState(in),
 		PredicateScenariosCovered: evalScenariosCovered(in),
 		PredicateEvidenceResolves: evalEvidenceResolves(in),
-		PredicateProvenanceEvent:  evalProvenanceEvent(in),
-		PredicateNoOrphan:         evalNoOrphan(in),
+		PredicateProvenanceEvent:    evalProvenanceEvent(in),
+		PredicateNoOrphan:           evalNoOrphan(in),
+		PredicateAuthorNeqValidator: evalAuthorNeqValidator(in),
 	}
 
 	v := Verdict{
@@ -298,5 +321,37 @@ func evalNoOrphan(in Input) PredicateResult {
 	}
 	r.Passed = true
 	r.Reason = "no provenance orphans"
+	return r
+}
+
+// evalAuthorNeqValidator enforces the no-self-grading invariant (ag-lmdx.4):
+// the acceptance verdict must come from a judge context distinct from the
+// author context. A self-graded verdict (author_id == judge_id) is
+// autocorrelated and fails unless --allow-self explicitly waives it. A missing
+// judge identity also fails: independence that was never recorded cannot be
+// asserted.
+func evalAuthorNeqValidator(in Input) PredicateResult {
+	r := PredicateResult{Name: PredicateAuthorNeqValidator}
+	author := strings.TrimSpace(in.AuthorID)
+	judge := strings.TrimSpace(in.JudgeID)
+	if in.AllowSelf {
+		r.Passed = true
+		r.Reason = "self-grading explicitly waived via --allow-self (inline fallback)"
+		return r
+	}
+	if author == "" {
+		r.Reason = "no author_id recorded (cannot prove the judge is independent of the author)"
+		return r
+	}
+	if judge == "" {
+		r.Reason = "no judge_id recorded (independent judge context required; use --allow-self to waive)"
+		return r
+	}
+	if judge == author {
+		r.Reason = fmt.Sprintf("verdict self-graded: judge_id == author_id (%q); an independent judge context is required (use --allow-self to waive)", author)
+		return r
+	}
+	r.Passed = true
+	r.Reason = fmt.Sprintf("independent judge: judge_id %q != author_id %q", judge, author)
 	return r
 }

--- a/cli/internal/evidencedturn/evidencedturn_test.go
+++ b/cli/internal/evidencedturn/evidencedturn_test.go
@@ -66,6 +66,8 @@ func wellFormedInput(t *testing.T) Input {
 		ProvenanceEdges: []provenancegraph.Edge{provEdge(t, "commit:abc123", bead)},
 		OrphanFindings:  nil,
 		OrphanChecked:   true,
+		AuthorID:        "session:author-abc",
+		JudgeID:         "session:judge-xyz",
 	}
 }
 
@@ -278,6 +280,91 @@ func TestEvaluate_MultipleGapsAllReported(t *testing.T) {
 	}
 	if len(v.Gaps) != 3 {
 		t.Errorf("len(Gaps) = %d, want 3 (gaps=%v)", len(v.Gaps), v.Gaps)
+	}
+}
+
+// TestEvaluate_SelfGradedVerdictRefused is the core no-self-grading invariant
+// (ag-lmdx.4): when the judge context equals the author context, the
+// author_neq_validator predicate must fail and the turn is not done.
+func TestEvaluate_SelfGradedVerdictRefused(t *testing.T) {
+	in := wellFormedInput(t)
+	in.AuthorID = "session:same"
+	in.JudgeID = "session:same"
+	v, err := Evaluate(in)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if v.Done != false {
+		t.Errorf("Done = %v, want false (self-graded verdict must be refused)", v.Done)
+	}
+	p := predicate(t, v, PredicateAuthorNeqValidator)
+	if p.Passed != false {
+		t.Errorf("%s.Passed = %v, want false", PredicateAuthorNeqValidator, p.Passed)
+	}
+	if !contains(p.Reason, "self-graded") {
+		t.Errorf("reason = %q, want substring %q", p.Reason, "self-graded")
+	}
+}
+
+// TestEvaluate_IndependentVerdictAccepted: a distinct judge context passes.
+func TestEvaluate_IndependentVerdictAccepted(t *testing.T) {
+	in := wellFormedInput(t)
+	in.AuthorID = "session:author"
+	in.JudgeID = "session:blind-judge"
+	v, err := Evaluate(in)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	p := predicate(t, v, PredicateAuthorNeqValidator)
+	if p.Passed != true {
+		t.Errorf("%s.Passed = %v, want true (distinct judge=%q author=%q); reason=%q",
+			PredicateAuthorNeqValidator, p.Passed, in.JudgeID, in.AuthorID, p.Reason)
+	}
+	if v.Done != true {
+		t.Errorf("Done = %v, want true (gaps: %v)", v.Done, v.Gaps)
+	}
+}
+
+// TestEvaluate_AllowSelfWaivesGuard: --allow-self is the documented, default-off
+// escape that permits a self-graded verdict on the inline fallback path.
+func TestEvaluate_AllowSelfWaivesGuard(t *testing.T) {
+	in := wellFormedInput(t)
+	in.AuthorID = "session:same"
+	in.JudgeID = "session:same"
+	in.AllowSelf = true
+	v, err := Evaluate(in)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	p := predicate(t, v, PredicateAuthorNeqValidator)
+	if p.Passed != true {
+		t.Errorf("%s.Passed = %v, want true with --allow-self; reason=%q",
+			PredicateAuthorNeqValidator, p.Passed, p.Reason)
+	}
+	if !contains(p.Reason, "allow-self") {
+		t.Errorf("reason = %q, want substring %q", p.Reason, "allow-self")
+	}
+	if v.Done != true {
+		t.Errorf("Done = %v, want true with --allow-self (gaps: %v)", v.Done, v.Gaps)
+	}
+}
+
+// TestEvaluate_MissingJudgeRefused: an unrecorded judge identity cannot assert
+// independence, so the guard fails (use --allow-self to waive).
+func TestEvaluate_MissingJudgeRefused(t *testing.T) {
+	in := wellFormedInput(t)
+	in.AuthorID = "session:author"
+	in.JudgeID = ""
+	v, err := Evaluate(in)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	p := predicate(t, v, PredicateAuthorNeqValidator)
+	if p.Passed != false {
+		t.Errorf("%s.Passed = %v, want false when judge_id is empty", PredicateAuthorNeqValidator, p.Passed)
+	}
+	if !contains(p.Reason, "no judge_id") {
+		t.Errorf("reason = %q, want substring %q", p.Reason, "no judge_id")
 	}
 }
 

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-05-31T18:33:01Z",
+  "generated_at": "2026-05-31T19:01:29Z",
   "summary": {
     "skills": 81,
     "hooks": 0,
@@ -2552,7 +2552,8 @@
         "ao metrics cite",
         "ao ratchet",
         "ao rpi phased",
-        "ao search"
+        "ao search",
+        "ao turn verify"
       ],
       "path": "skills/pre-mortem/",
       "references": 14
@@ -3353,7 +3354,8 @@
         "ao lookup",
         "ao metrics cite",
         "ao ratchet",
-        "ao search"
+        "ao search",
+        "ao turn verify"
       ],
       "path": "skills/vibe/",
       "references": 22

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -937,8 +937,8 @@
     {
       "name": "pre-mortem",
       "source_skill": "skills/pre-mortem",
-      "source_hash": "4c710c16546e6f5313c56a45f3a24ce209f6a8847cd7d00260323132ca2bc6b6",
-      "generated_hash": "76c803dbb09ebd1f9833a1ca852d366c48f6a2956141b8b9245bfd816e93155c"
+      "source_hash": "54b97fbb1ff8722c5488e83004b16d4c6652678976544034d23c1959a415f62a",
+      "generated_hash": "f98f6d4ad93124bdbe08cf728f218626e59ae4538621b03351138f593ee17b42"
     },
     {
       "name": "product",
@@ -1147,8 +1147,8 @@
     {
       "name": "vibe",
       "source_skill": "skills/vibe",
-      "source_hash": "26612fcfa3570444f0c19db6ace2e28b6b1ebb8a1bffc174c6c38adc8c0b1cc0",
-      "generated_hash": "5d634b66e1b976630d41dc97bdff520930b0f4da2220096e61ca8a4f0762169e"
+      "source_hash": "290429fcf63d5a7c72a3ede2f488409b3f8d10c2ba7fa4b0fb39a5d98e3c89a0",
+      "generated_hash": "7e54f739cc2d35f014825b27237a2aac9300582a0815d1c0dce43f59ae68dbe9"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/pre-mortem/.agentops-generated.json
+++ b/skills-codex/pre-mortem/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/pre-mortem",
   "layout": "modular",
-  "source_hash": "4c710c16546e6f5313c56a45f3a24ce209f6a8847cd7d00260323132ca2bc6b6",
-  "generated_hash": "76c803dbb09ebd1f9833a1ca852d366c48f6a2956141b8b9245bfd816e93155c"
+  "source_hash": "54b97fbb1ff8722c5488e83004b16d4c6652678976544034d23c1959a415f62a",
+  "generated_hash": "f98f6d4ad93124bdbe08cf728f218626e59ae4538621b03351138f593ee17b42"
 }

--- a/skills-codex/pre-mortem/SKILL.md
+++ b/skills-codex/pre-mortem/SKILL.md
@@ -330,6 +330,18 @@ When the plan introduces or modifies fields with a bounded set of valid values (
 
 **Auto-triggered** when the plan introduces struct fields with comments mentioning valid values, config fields with bounded options, or string fields parsed from user input.
 
+### Step 2.9: No-self-grading invariant (author ≠ validator)
+
+The pre-mortem verdict must NOT be graded by the plan's own author. A verdict produced by the authoring context is autocorrelated — the same assumptions that shaped the plan pass it. This is the no-self-grading invariant (`ag-lmdx.4`): the independent-trust-domain check on the plan-acceptance verdict.
+
+**Rule:** the judge context MUST be distinct from the author context. Validation MAY run inside the authoring session, but the judge MUST be a **blind sub-agent** — a fresh, context-isolated agent acting as if it has no authoring context. Record `judge_id` (the isolated sub-agent context) distinct from `author_id` (the planning context). The `--deep`/`--mixed` council judges satisfy this when they are context-isolated sub-agents; an inline self-review by the planning agent does NOT.
+
+**Refuse** to emit a PASS verdict when the judge context equals the author context (`judge_id == author_id`) — re-run the verdict through a blind sub-agent judge instead.
+
+**Escape:** `--allow-self` (default OFF) waives the invariant for the inline fallback only (e.g. no sub-agent runtime available). Using it stamps the verdict as self-graded; downstream `ao turn verify` reports it as waived, not independently validated.
+
+**Enforcement:** `ao turn verify <bead>` evaluates the `author_neq_validator` predicate from the turn-input file's `author_id`/`judge_id` and fails the Evidenced-Turn DoD on a self-graded verdict unless `--allow-self` is passed.
+
 ### Step 3: Interpret Council Verdict
 
 | Council Verdict | Pre-Mortem Result | Action |

--- a/skills-codex/vibe/.agentops-generated.json
+++ b/skills-codex/vibe/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/vibe",
   "layout": "modular",
-  "source_hash": "26612fcfa3570444f0c19db6ace2e28b6b1ebb8a1bffc174c6c38adc8c0b1cc0",
-  "generated_hash": "5d634b66e1b976630d41dc97bdff520930b0f4da2220096e61ca8a4f0762169e"
+  "source_hash": "290429fcf63d5a7c72a3ede2f488409b3f8d10c2ba7fa4b0fb39a5d98e3c89a0",
+  "generated_hash": "7e54f739cc2d35f014825b27237a2aac9300582a0815d1c0dce43f59ae68dbe9"
 }

--- a/skills-codex/vibe/SKILL.md
+++ b/skills-codex/vibe/SKILL.md
@@ -517,6 +517,18 @@ $council validate <target>
 
 All council flags pass through: `--quick` (inline), `--mixed` (cross-vendor), `--preset=<name>` (override perspectives), `--explorers=N`, `--debate` (adversarial 2-round). See Quick Start examples and `$council` docs.
 
+### Step 4.5: No-self-grading invariant (author ≠ validator)
+
+The acceptance verdict must NOT be graded by the artifact's own author. A verdict produced by the authoring context is autocorrelated — the same blind spots that shipped the bug pass it. This is the no-self-grading invariant (`ag-lmdx.4`): the independent-trust-domain check that guards the `evidenced->validated` transition.
+
+**Rule:** the judge context MUST be distinct from the author context. Validation MAY run inside the authoring session, but the judge MUST be a **blind sub-agent** — a fresh, context-isolated agent acting as if it has no authoring context. Record `judge_id` (the isolated sub-agent context) distinct from `author_id` (the authoring context). The council judges spawned in Step 4 satisfy this when they are context-isolated sub-agents; an inline self-review by the authoring agent does NOT.
+
+**Refuse** to emit a PASS verdict when the judge context equals the author context (`judge_id == author_id`) — re-run the verdict through a blind sub-agent judge instead.
+
+**Escape:** `--allow-self` (default OFF) waives the invariant for the inline fallback only (e.g. no sub-agent runtime available). Using it stamps the verdict as self-graded; downstream `ao turn verify` reports it as waived, not independently validated.
+
+**Enforcement:** `ao turn verify <bead>` evaluates the `author_neq_validator` predicate from the turn-input file's `author_id`/`judge_id` and fails the Evidenced-Turn DoD on a self-graded verdict unless `--allow-self` is passed. The `evidenced->validated` guard rejects a self-graded verdict.
+
 ### Step 5: Council Checks
 
 Each judge reviews for:

--- a/skills/pre-mortem/SKILL.md
+++ b/skills/pre-mortem/SKILL.md
@@ -157,6 +157,18 @@ Five mandatory checks run during council validation — temporal interrogation, 
 
 When a plan introduces a regex, grep, glob, or similar scope predicate, also apply [references/scope-predicate-positive-negative-cases.md](references/scope-predicate-positive-negative-cases.md): require positive and negative examples before approval.
 
+### Step 2.9: No-self-grading invariant (author ≠ validator)
+
+The pre-mortem verdict must NOT be graded by the plan's own author. A verdict produced by the authoring context is autocorrelated — the same assumptions that shaped the plan pass it. This is the no-self-grading invariant (`ag-lmdx.4`): the independent-trust-domain check on the plan-acceptance verdict.
+
+**Rule:** the judge context MUST be distinct from the author context. Validation MAY run inside the authoring session, but the judge MUST be a **blind sub-agent** — a fresh, context-isolated agent acting as if it has no authoring context. Record `judge_id` (the isolated sub-agent context) distinct from `author_id` (the planning context). The `--deep`/`--mixed` council judges satisfy this when they are context-isolated sub-agents; an inline self-review by the planning agent does NOT.
+
+**Refuse** to emit a PASS verdict when the judge context equals the author context (`judge_id == author_id`) — re-run the verdict through a blind sub-agent judge instead.
+
+**Escape:** `--allow-self` (default OFF) waives the invariant for the inline fallback only (e.g. no sub-agent runtime available). Using it stamps the verdict as self-graded; downstream `ao turn verify` reports it as waived, not independently validated.
+
+**Enforcement:** `ao turn verify <bead>` evaluates the `author_neq_validator` predicate from the turn-input file's `author_id`/`judge_id` and fails the Evidenced-Turn DoD on a self-graded verdict unless `--allow-self` is passed.
+
 ### Step 3: Interpret Council Verdict
 
 | Council Verdict | Pre-Mortem Result | Action |

--- a/skills/vibe/SKILL.md
+++ b/skills/vibe/SKILL.md
@@ -259,6 +259,18 @@ The spec content is injected into the council packet context so the `spec-compli
 
 All council flags pass through: `--quick` (inline), `--mixed` (cross-vendor), `--preset=<name>` (override perspectives), `--explorers=N`, `--debate` (adversarial 2-round), `--tier=<name>` (model cost tier: quality/balanced/budget). See Quick Start examples and `/council` docs.
 
+### Step 4.5: No-self-grading invariant (author ≠ validator)
+
+The acceptance verdict must NOT be graded by the artifact's own author. A verdict produced by the authoring context is autocorrelated — the same blind spots that shipped the bug pass it. This is the no-self-grading invariant (`ag-lmdx.4`): the independent-trust-domain check that guards the `evidenced->validated` transition.
+
+**Rule:** the judge context MUST be distinct from the author context. Validation MAY run inside the authoring session, but the judge MUST be a **blind sub-agent** — a fresh, context-isolated agent acting as if it has no authoring context. Record `judge_id` (the isolated sub-agent context) distinct from `author_id` (the authoring context). The council judges spawned in Step 4 satisfy this when they are context-isolated sub-agents; an inline self-review by the authoring agent does NOT.
+
+**Refuse** to emit a PASS verdict when the judge context equals the author context (`judge_id == author_id`) — re-run the verdict through a blind sub-agent judge instead.
+
+**Escape:** `--allow-self` (default OFF) waives the invariant for the inline fallback only (e.g. no sub-agent runtime available). Using it stamps the verdict as self-graded; downstream `ao turn verify` reports it as waived, not independently validated.
+
+**Enforcement:** `ao turn verify <bead>` evaluates the `author_neq_validator` predicate from the turn-input file's `author_id`/`judge_id` and fails the Evidenced-Turn DoD on a self-graded verdict unless `--allow-self` is passed. The `evidenced->validated` guard rejects a self-graded verdict.
+
 ### Step 5: Council Checks
 
 Each judge reviews for:


### PR DESCRIPTION
## What

Enforce the no-self-grading invariant (`ag-lmdx.4`): a Turn graded by its own author is autocorrelated, so an Evidenced Turn is not done unless an independent judge context produced the acceptance verdict.

- **`cli/internal/evidencedturn`** — new `author_neq_validator` predicate + `AuthorID`/`JudgeID`/`AllowSelf` fields on `Input`. The predicate FAILS when `judge_id == author_id` (self-graded) or when no judge identity was recorded (independence that was never recorded cannot be asserted); the documented, default-OFF `--allow-self` waives it for the inline fallback. This fills the `TODO(ag-lmdx.4)` extension point the #657 author left.
- **`cli/cmd/ao/turn verify`** — `--allow-self` flag + `author_id`/`judge_id` on the turn-input file, wired into the DoD predicate so a self-graded verdict fails the `validated->closed` guard.
- **`/pre-mortem` + `/vibe` SKILL.md** (and `skills-codex` twins) — refuse a self-graded PASS verdict; require the judge to be a blind, context-isolated sub-agent (`judge_id != author_id`); document `--allow-self` as the default-OFF escape and point at `ao turn verify` as the enforcement predicate.

## Tests (TDD-first)

`evidencedturn`: self-graded refused / independent accepted / `--allow-self` waives / missing-judge refused. `cmd/ao`: `turn verify` self-graded exits non-zero, `--allow-self` passes.

## Gates

`go build ./...` + `go vet` + `go test ./...` green (11845 pass). gosec: 0 new findings in touched files. Codex parity audit + generated-manifest/artifacts validators pass. `tests/skills/run-all.sh`: 87/87. COMMANDS.md regenerated (the one `--allow-self` line); codex manifest spliced to pre-mortem+vibe only (no drift-sweep).

## Dedup note (ag-9jle.5)

This bead is the **invariant/guard** (data shape + predicate + skill refusal). The skill text states the blind-sub-agent requirement, but the actual blind-judge SPAWNING MECHANISM in `/vibe` + `/validation` (ag-9jle.5) is NOT implemented here. Partial overlap on the skill contract; the runtime mechanism remains for ag-9jle.5.

Closes-scenario: ag-lmdx.4#author-validator-guard
Bounded-context: BC2-Validation
Evidence: cli/internal/evidencedturn/evidencedturn.go