### PR TITLE
feat(skills): blind sub-agent judge in /vibe + /validation (ag-9jle.5 #blind-judge)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-05-31T19:01:29Z",
+  "generated_at": "2026-05-31T19:49:44Z",
   "summary": {
     "skills": 81,
     "hooks": 0,
@@ -3328,7 +3328,8 @@
         "ao lookup",
         "ao metrics cite",
         "ao ratchet",
-        "ao scenario list"
+        "ao scenario list",
+        "ao turn verify"
       ],
       "path": "skills/validation/",
       "references": 13

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1141,14 +1141,14 @@
     {
       "name": "validation",
       "source_skill": "skills/validation",
-      "source_hash": "0064844872348f5b4ffc47577475069172375754316cf69527157d422a676106",
-      "generated_hash": "2be5f94c87f7f35e56c76d2a06e025224d298ac633a56342135f361b4dc2cdfe"
+      "source_hash": "7a19016c7b41fb1d81c05d751a2bd84509961617d6bf538c108f755d34cc7ad5",
+      "generated_hash": "205fc9ab951b8a75912fb2cb41740fad8a99505f22e33ba8cb0b820a81e92665"
     },
     {
       "name": "vibe",
       "source_skill": "skills/vibe",
-      "source_hash": "290429fcf63d5a7c72a3ede2f488409b3f8d10c2ba7fa4b0fb39a5d98e3c89a0",
-      "generated_hash": "7e54f739cc2d35f014825b27237a2aac9300582a0815d1c0dce43f59ae68dbe9"
+      "source_hash": "d862c33eba293de05b479d8daae4bf2f18eafaf6d611e2913fbf045a835cb5fc",
+      "generated_hash": "271f92ad96a487577489f1e233a7a8121b132590d6aa1c49c8275230f67f221a"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/validation/.agentops-generated.json
+++ b/skills-codex/validation/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/validation",
   "layout": "modular",
-  "source_hash": "0064844872348f5b4ffc47577475069172375754316cf69527157d422a676106",
-  "generated_hash": "2be5f94c87f7f35e56c76d2a06e025224d298ac633a56342135f361b4dc2cdfe"
+  "source_hash": "7a19016c7b41fb1d81c05d751a2bd84509961617d6bf538c108f755d34cc7ad5",
+  "generated_hash": "205fc9ab951b8a75912fb2cb41740fad8a99505f22e33ba8cb0b820a81e92665"
 }

--- a/skills-codex/validation/SKILL.md
+++ b/skills-codex/validation/SKILL.md
@@ -52,9 +52,18 @@ Skip silently if ao is unavailable or returns no results.
 ```
 STEP 1  ──  $vibe recent [--quick]
               Use --quick for fast/standard. Full council for full.
+              Blind-judge requirement (ag-9jle.5): vibe's verdict MUST come from a
+              context-isolated sub-agent judge (its Step 4.5 spawns one, given only the
+              diff + acceptance scenarios, recording judge_id != author_id). Even
+              same-session validation routes acceptance through that blind judge — never
+              an inline self-review by this orchestrator.
               PASS/WARN? → continue
               FAIL?      → write summary, output <promise>FAIL</promise>, stop
                            (validation cannot fix code — caller decides retry)
+              judge_id == author_id (no blind judge spawned)?
+                         → refuse to certify: write summary, output <promise>FAIL</promise>,
+                           stop. Re-run the verdict through a blind sub-agent judge
+                           (only escape: $vibe --allow-self, which marks it self-graded).
 
 STEP 1.5 ── Four-Surface Closure (mandatory)
               Read `skills/validation/references/four-surface-closure.md` for the mandatory four-surface closure check.
@@ -251,6 +260,13 @@ On budget expiry: allow in-flight calls to complete, write `[TIME-BOXED]` marker
 | `--release-context` | auto | Force STEP 1.7.5 release-readiness gates on. Auto-detected from branch name. |
 | `--skip-release-gates` | off | Bypass STEP 1.7.5 (operator-acknowledged risk) |
 | `--allow-critical-deps` | off | Allow shipping with CVSS >= 9.0 vulnerabilities (acknowledged risk acceptance) |
+
+## Blind Sub-Agent Judge (author ≠ validator, same-session OK)
+
+The acceptance verdict this phase certifies MUST be produced by a context that did not author the code (`ag-9jle.5`, the no-self-grading invariant from `ag-lmdx.4`). Validation MAY run inside the authoring session, but the judge MUST be a **blind sub-agent**: a fresh, context-isolated agent given **only** the diff/artifact + the acceptance scenarios (the bead's `## Scenarios` block or the `.feature` file) — **never** the authoring conversation, plan, or reasoning.
+
+- STEP 1 delegates to `$vibe`, whose council judges are context-isolated sub-agents and whose Step 4.5 spawns the blind judge and records `judge_id` (sub-agent context) distinct from `author_id` (authoring context). This is the acceptance judge — do NOT replace it with an inline self-review by the authoring orchestrator.
+- **Refuse** to certify acceptance (output `<promise>DONE</promise>`) when no context-isolated judge produced the verdict — i.e. when `judge_id == author_id`. Re-run the verdict through a blind sub-agent judge instead. The only escape is `$vibe --allow-self` (inline fallback when no sub-agent runtime is available), which stamps the verdict as self-graded; `ao turn verify` then reports it as waived, not independently validated.
 
 ## Expensive Command Policy
 

--- a/skills-codex/vibe/.agentops-generated.json
+++ b/skills-codex/vibe/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/vibe",
   "layout": "modular",
-  "source_hash": "290429fcf63d5a7c72a3ede2f488409b3f8d10c2ba7fa4b0fb39a5d98e3c89a0",
-  "generated_hash": "7e54f739cc2d35f014825b27237a2aac9300582a0815d1c0dce43f59ae68dbe9"
+  "source_hash": "d862c33eba293de05b479d8daae4bf2f18eafaf6d611e2913fbf045a835cb5fc",
+  "generated_hash": "271f92ad96a487577489f1e233a7a8121b132590d6aa1c49c8275230f67f221a"
 }

--- a/skills-codex/vibe/SKILL.md
+++ b/skills-codex/vibe/SKILL.md
@@ -523,7 +523,21 @@ The acceptance verdict must NOT be graded by the artifact's own author. A verdic
 
 **Rule:** the judge context MUST be distinct from the author context. Validation MAY run inside the authoring session, but the judge MUST be a **blind sub-agent** — a fresh, context-isolated agent acting as if it has no authoring context. Record `judge_id` (the isolated sub-agent context) distinct from `author_id` (the authoring context). The council judges spawned in Step 4 satisfy this when they are context-isolated sub-agents; an inline self-review by the authoring agent does NOT.
 
-**Refuse** to emit a PASS verdict when the judge context equals the author context (`judge_id == author_id`) — re-run the verdict through a blind sub-agent judge instead.
+**Blind sub-agent judge spawn (the mechanism, MANDATORY when validating in the authoring session):**
+
+When the verdict is being produced inside the session that authored the code, you MUST spawn the acceptance judge as a fresh-context sub-agent — do NOT grade inline. Concretely:
+
+1. Spawn the judge via the Codex sub-agent mechanism (the same context-isolated sub-agents Step 4's council uses). The sub-agent is the judge; the orchestrating authoring agent is NOT.
+2. Hand the blind judge **ONLY** the acceptance inputs — never the authoring conversation, plan, or reasoning:
+   - the **diff/artifact** under review (changed files + `git diff`),
+   - the **acceptance scenarios** (the bead's `## Scenarios` block or the `.feature` file) and any spec, complexity hotspots, and domain checklists,
+   - the verdict contract (`skills/council/schemas/verdict.json`).
+   Do NOT pass the authoring transcript, intermediate design notes, or "here's why I think it's correct" framing. The judge acts as if it has no authoring context.
+3. Use the sub-agent's PASS/WARN/FAIL as the acceptance verdict. Record `judge_id` = the isolated sub-agent context, `author_id` = the authoring context, into the turn-input consumed by `ao turn verify` (Enforcement below).
+
+This is what makes same-session validation trustworthy: the verdict is produced by a context that did not author the artifact, so the author's blind spots do not pass it.
+
+**Refuse** to emit a PASS verdict when the judge context equals the author context (`judge_id == author_id`) — i.e. when no blind sub-agent was spawned and the authoring agent graded itself. Re-run the verdict through a blind sub-agent judge instead.
 
 **Escape:** `--allow-self` (default OFF) waives the invariant for the inline fallback only (e.g. no sub-agent runtime available). Using it stamps the verdict as self-graded; downstream `ao turn verify` reports it as waived, not independently validated.
 

--- a/skills/validation/SKILL.md
+++ b/skills/validation/SKILL.md
@@ -81,6 +81,13 @@ Run the DAG in [references/dag.md](references/dag.md) — STEP 1 (vibe) → 1.5 
 
 See [references/flags.md](references/flags.md) for flag interactions, precedence, and combined-flag examples.
 
+## Blind Sub-Agent Judge (author ≠ validator, same-session OK)
+
+The acceptance verdict this phase certifies MUST be produced by a context that did not author the code (`ag-9jle.5`, the no-self-grading invariant from `ag-lmdx.4`). Validation MAY run inside the authoring session, but the judge MUST be a **blind sub-agent**: a fresh, context-isolated agent given **only** the diff/artifact + the acceptance scenarios (the bead's `## Scenarios` block or the `.feature` file) — **never** the authoring conversation, plan, or reasoning.
+
+- STEP 1 delegates to `/vibe`, whose council judges are context-isolated sub-agents and whose Step 4.5 spawns the blind judge and records `judge_id` (sub-agent context) distinct from `author_id` (authoring context). This is the acceptance judge — do NOT replace it with an inline self-review by the authoring orchestrator.
+- **Refuse** to certify acceptance (output `<promise>DONE</promise>`) when no context-isolated judge produced the verdict — i.e. when `judge_id == author_id`. Re-run the verdict through a blind sub-agent judge instead. The only escape is `/vibe --allow-self` (inline fallback when no sub-agent runtime is available), which stamps the verdict as self-graded; `ao turn verify` then reports it as waived, not independently validated.
+
 ## Expensive Command Policy
 
 Routine validation is targeted by default. Broad proof commands such as

--- a/skills/validation/references/dag.md
+++ b/skills/validation/references/dag.md
@@ -25,9 +25,18 @@ fi
 ```
 STEP 1  ──  Skill(skill="vibe", args="recent [--quick]")
               Use --quick for fast/standard. Full council for full.
+              Blind-judge requirement (ag-9jle.5): /vibe's verdict MUST come from a
+              context-isolated sub-agent judge (its Step 4.5 spawns one, given only the
+              diff + acceptance scenarios, recording judge_id != author_id). Even
+              same-session validation routes acceptance through that blind judge — never
+              an inline self-review by this orchestrator.
               PASS/WARN? → continue
               FAIL?      → write summary, output <promise>FAIL</promise>, stop
                            (validation cannot fix code — caller decides retry)
+              judge_id == author_id (no blind judge spawned)?
+                         → refuse to certify: write summary, output <promise>FAIL</promise>,
+                           stop. Re-run the verdict through a blind sub-agent judge
+                           (only escape: /vibe --allow-self, which marks it self-graded).
 
 STEP 1.5 ── Four-Surface Closure (mandatory)
               Read `skills/validation/references/four-surface-closure.md` for the mandatory four-surface closure check.

--- a/skills/validation/references/validation.feature
+++ b/skills/validation/references/validation.feature
@@ -33,3 +33,14 @@ Feature: Validation rolls slice and bead acceptance into a verdict
     Given --strict-surfaces is set
     When any of the four closure surfaces fails
     Then the verdict is FAIL, not WARN
+
+  Scenario: Self-validation still gets an independent judge
+    Given an artifact authored in session S
+    When /validation validates it in the same session S
+    Then the acceptance verdict is produced by a fresh-context sub-agent with no authoring context
+    And judge_id != author_id is recorded
+
+  Scenario: Missing blind judge is refused
+    Given /validation runs without a context-isolated judge producing the verdict
+    When it attempts to certify acceptance
+    Then it refuses because the judge context must differ from the author context

--- a/skills/vibe/SKILL.md
+++ b/skills/vibe/SKILL.md
@@ -265,7 +265,21 @@ The acceptance verdict must NOT be graded by the artifact's own author. A verdic
 
 **Rule:** the judge context MUST be distinct from the author context. Validation MAY run inside the authoring session, but the judge MUST be a **blind sub-agent** — a fresh, context-isolated agent acting as if it has no authoring context. Record `judge_id` (the isolated sub-agent context) distinct from `author_id` (the authoring context). The council judges spawned in Step 4 satisfy this when they are context-isolated sub-agents; an inline self-review by the authoring agent does NOT.
 
-**Refuse** to emit a PASS verdict when the judge context equals the author context (`judge_id == author_id`) — re-run the verdict through a blind sub-agent judge instead.
+**Blind sub-agent judge spawn (the mechanism, MANDATORY when validating in the authoring session):**
+
+When the verdict is being produced inside the session that authored the code, you MUST spawn the acceptance judge as a fresh-context sub-agent — do NOT grade inline. Concretely:
+
+1. Spawn the judge via the `Agent`/`Task` tool (the same context-isolated sub-agents Step 4's council uses). The sub-agent is the judge; the orchestrating authoring agent is NOT.
+2. Hand the blind judge **ONLY** the acceptance inputs — never the authoring conversation, plan, or reasoning:
+   - the **diff/artifact** under review (changed files + `git diff`),
+   - the **acceptance scenarios** (the bead's `## Scenarios` block or the `.feature` file) and any spec, complexity hotspots, and domain checklists,
+   - the verdict contract (`skills/council/schemas/verdict.json`).
+   Do NOT pass the authoring transcript, intermediate design notes, or "here's why I think it's correct" framing. The judge acts as if it has no authoring context.
+3. Use the sub-agent's PASS/WARN/FAIL as the acceptance verdict. Record `judge_id` = the isolated sub-agent context, `author_id` = the authoring context, into the turn-input consumed by `ao turn verify` (Enforcement below).
+
+This is what makes same-session validation trustworthy: the verdict is produced by a context that did not author the artifact, so the author's blind spots do not pass it.
+
+**Refuse** to emit a PASS verdict when the judge context equals the author context (`judge_id == author_id`) — i.e. when no blind sub-agent was spawned and the authoring agent graded itself. Re-run the verdict through a blind sub-agent judge instead.
 
 **Escape:** `--allow-self` (default OFF) waives the invariant for the inline fallback only (e.g. no sub-agent runtime available). Using it stamps the verdict as self-graded; downstream `ao turn verify` reports it as waived, not independently validated.
 

--- a/skills/vibe/references/vibe.feature
+++ b/skills/vibe/references/vibe.feature
@@ -29,3 +29,14 @@ Feature: Vibe judges a slice's code quality before it counts
   Scenario: deep-audit mode widens the review
     Given /vibe --sweep recent
     Then per-file explorers feed the council for a deeper audit over the recent changes
+
+  Scenario: same-session validation still gets a blind sub-agent judge
+    Given the slice was authored in the current session
+    When /vibe produces the acceptance verdict in that same session
+    Then it spawns a fresh-context sub-agent as the judge, given only the diff and acceptance scenarios
+    And the sub-agent's verdict is the acceptance verdict, with judge_id != author_id recorded
+
+  Scenario: a self-graded verdict is refused
+    Given no blind sub-agent judge was spawned and the authoring agent graded itself
+    When /vibe attempts to emit a PASS verdict with judge_id == author_id
+    Then it refuses and re-runs the verdict through a blind sub-agent judge unless --allow-self is set


### PR DESCRIPTION
## What

Adds the concrete **blind sub-agent judge** spawn mechanism in `/vibe` and `/validation`, building on ag-lmdx.4 (#658) which added the author!=validator refusal contract + `ao turn verify --allow-self`.

Per operator mechanism (Bo 2026-05-30): validation MAY run in the authoring session, but the JUDGE must be a fresh-context sub-agent acting as if it has no authoring context. lmdx.4 supplied the invariant/refusal + the CLI guard; this bead supplies the actual spawn instruction.

## Changes

- **`skills/vibe/SKILL.md` Step 4.5** — adds the MANDATORY blind sub-agent judge spawn: when validating in the authoring session, spawn the acceptance judge via Agent/Task tool, hand it ONLY the diff/artifact + acceptance scenarios + verdict contract (never the authoring conversation), use its verdict, record `judge_id` != `author_id`. Keeps lmdx.4's refusal + `--allow-self` escape + `ao turn verify` enforcement.
- **`skills/validation/SKILL.md`** — new "Blind Sub-Agent Judge" section + **`references/dag.md` STEP 1** guard that refuses to certify acceptance (`<promise>DONE</promise>`) when `judge_id == author_id`.
- **`vibe.feature` + `validation.feature`** — testable scenarios matching the bead acceptance (self-validation still gets an independent judge; missing blind judge is refused).
- **Codex twins** mirrored verbatim (no symlinks); manifest hashes spliced to vibe+validation only (8 pre-existing codex drifts left untouched).

## Gates

- `tests/skills/run-all.sh`: PASS (87/0/0)
- `scripts/audit-codex-parity.sh --skill {vibe,validation}`: PASS
- `scripts/check-codex-parity-drift.sh`: PASS
- `scripts/validate-codex-generated-manifest.sh`: OK (81 skills)
- `scripts/check-scenario-test-linkage.sh`: PASS (both .feature files allowlisted doc-only)
- No Go touched.

Closes-scenario: ag-9jle.5#blind-judge
Bounded-context: BC2-Validation
Evidence: skills/vibe/SKILL.md