### PR TITLE
chore(ci): regen-codex-hashes --only scoping + regen-all passthrough (ag-fbe9 #regen-scoping)

### DIFF
--- a/scripts/regen-all.sh
+++ b/scripts/regen-all.sh
@@ -8,8 +8,10 @@
 # that runs the matching drift validators as a pre-push gate.
 #
 # Usage:
-#   scripts/regen-all.sh            # regenerate all derived artifacts (writes)
-#   scripts/regen-all.sh --check    # run all drift validators (no writes); exit 1 on drift
+#   scripts/regen-all.sh                      # regenerate all derived artifacts (writes)
+#   scripts/regen-all.sh --check              # run all drift validators (no writes); exit 1 on drift
+#   scripts/regen-all.sh --skills foo,bar     # scope the codex-hash step to foo,bar
+#   REGEN_SKILLS=foo,bar scripts/regen-all.sh # same scoping via env
 #
 # NOTE: Codex twins (skills-codex/<name>/{SKILL.md,prompt.md}) are MANUAL — this
 # refreshes their hashes but cannot author a missing twin. Create twins by hand
@@ -20,8 +22,16 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 MODE="regen"
-[[ "${1:-}" == "--check" ]] && MODE="check"
-[[ -n "${1:-}" && "$MODE" == "regen" ]] && { echo "usage: $0 [--check]" >&2; exit 2; }
+REGEN_SKILLS="${REGEN_SKILLS:-}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check) MODE="check" ;;
+    --skills) shift; [[ $# -gt 0 ]] || { echo "--skills requires a value" >&2; exit 2; }; REGEN_SKILLS="$1" ;;
+    --skills=*) REGEN_SKILLS="${1#--skills=}" ;;
+    *) echo "usage: $0 [--check] [--skills <skill[,skill,...]>]" >&2; exit 2 ;;
+  esac
+  shift
+done
 
 fail=0
 step() { # label cmd...
@@ -43,11 +53,13 @@ if [[ "$MODE" == "regen" ]]; then
   step "embedded skills"       make -C cli sync-hooks
   step "cli reference (COMMANDS.md)" bash scripts/generate-cli-reference.sh
   step "cli-surface inventory" bash scripts/check-cmdao-surface-parity.sh --write-surface
-  step "codex hashes"          bash scripts/regen-codex-hashes.sh
+  step "codex hashes"          bash scripts/regen-codex-hashes.sh ${REGEN_SKILLS:+--only "$REGEN_SKILLS"}
   echo
   echo "Regenerated. Review 'git status', then run: scripts/regen-all.sh --check"
   echo "Reminder: new skills also need MANUAL skills-codex/<name>/ twins +"
   echo "  the cobra expectedCmds list + cli-help-matrix golden when adding ao commands."
+  echo "Scope tip: changed only some skills? Re-run with --skills a,b (or REGEN_SKILLS=a,b)"
+  echo "  so the codex-hash step skips unrelated pre-existing drift instead of sweeping it in."
 else
   echo "== drift / gate sweep (no writes) =="
   step "registry drift"        bash scripts/check-registry-drift.sh
@@ -55,7 +67,7 @@ else
   step "write-surfaces"        bash scripts/check-agents-write-surfaces.sh
   step "codex parity"          bash scripts/audit-codex-parity.sh
   step "codex runtime sections" bash scripts/validate-codex-runtime-sections.sh
-  step "codex hashes (no drift)" bash scripts/regen-codex-hashes.sh --check
+  step "codex hashes (no drift)" bash scripts/regen-codex-hashes.sh --check ${REGEN_SKILLS:+--only "$REGEN_SKILLS"}
   step "SKU catalog drift"     bash scripts/validate-sku-catalog-drift.sh
   step "context-map drift"     bash scripts/validate-context-map-drift.sh
   step "doc-release gate"      bash tests/docs/validate-doc-release.sh

--- a/scripts/regen-codex-hashes.sh
+++ b/scripts/regen-codex-hashes.sh
@@ -5,27 +5,42 @@ set -euo pipefail
 # Run after any change to skills-codex/ files to fix artifact metadata drift.
 #
 # Usage:
-#   scripts/regen-codex-hashes.sh              # update all drifted hashes
-#   scripts/regen-codex-hashes.sh --check      # dry-run: report drift without fixing
+#   scripts/regen-codex-hashes.sh                    # update all drifted hashes
+#   scripts/regen-codex-hashes.sh --check            # dry-run: report drift without fixing
+#   scripts/regen-codex-hashes.sh --only foo,bar     # only touch skills foo and bar
+#
+# --only scopes the per-skill loop to the named skills (comma- and/or
+# repeat-separated). Skills outside the set are skipped entirely, so a PR that
+# changes one skill no longer sweeps unrelated pre-existing hash drift into its
+# diff. Combine with --check to scope the drift report the same way.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-SKILLS_ROOT="$REPO_ROOT/skills-codex"
+SKILLS_ROOT="${SKILLS_ROOT:-$REPO_ROOT/skills-codex}"
 CHECK_ONLY=false
+ONLY_SKILLS=""
 
-for arg in "$@"; do
-  case "$arg" in
+while [[ $# -gt 0 ]]; do
+  case "$1" in
     --check) CHECK_ONLY=true ;;
+    --only)
+      shift
+      [[ $# -gt 0 ]] || { echo "--only requires a skill list" >&2; exit 2; }
+      ONLY_SKILLS="${ONLY_SKILLS:+$ONLY_SKILLS,}$1"
+      ;;
+    --only=*) ONLY_SKILLS="${ONLY_SKILLS:+$ONLY_SKILLS,}${1#--only=}" ;;
     -h|--help)
-      echo "Usage: scripts/regen-codex-hashes.sh [--check]"
-      echo "  --check  Report drift without fixing"
+      echo "Usage: scripts/regen-codex-hashes.sh [--check] [--only <skill[,skill,...]>]"
+      echo "  --check               Report drift without fixing"
+      echo "  --only <skill,...>    Limit to the named skills (scope a single-skill PR)"
       exit 0
       ;;
     *)
-      echo "Unknown arg: $arg" >&2
+      echo "Unknown arg: $1" >&2
       exit 2
       ;;
   esac
+  shift
 done
 
 [[ -d "$SKILLS_ROOT" ]] || {
@@ -33,7 +48,7 @@ done
   exit 1
 }
 
-export SKILLS_ROOT CHECK_ONLY
+export SKILLS_ROOT CHECK_ONLY ONLY_SKILLS
 python3 - <<'PY'
 import hashlib
 import json
@@ -43,6 +58,7 @@ import sys
 
 skills_root = pathlib.Path(os.environ["SKILLS_ROOT"]).resolve()
 check_only = os.environ.get("CHECK_ONLY") == "true"
+scope = {s for s in os.environ.get("ONLY_SKILLS", "").split(",") if s.strip()}
 manifest_path = skills_root / ".agentops-manifest.json"
 marker_name = ".agentops-generated.json"
 
@@ -86,6 +102,8 @@ for skill_dir in sorted(p for p in skills_root.iterdir() if p.is_dir()):
         continue
 
     name = skill_dir.name
+    if scope and name not in scope:
+        continue
     new_hash = hash_tree(skill_dir)
 
     # Source-side hash: tree-hash skills/<name>/ if it exists. A codex skill

--- a/tests/scripts/regen-codex-hashes-only.bats
+++ b/tests/scripts/regen-codex-hashes-only.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# regen-codex-hashes-only.bats — the --only scoping flag (ag-fbe9).
+#
+# Behavior under test: `regen-codex-hashes.sh --only <skill>` rewrites ONLY the
+# named skill's generated_hash and leaves every other (possibly pre-existing-
+# drifted) skill's manifest entry + marker untouched, so a single-skill PR no
+# longer sweeps unrelated codex drift into its diff. No --only = regenerate all.
+#
+# Hermetic: the script honors a SKILLS_ROOT env override, so we point it at a
+# throwaway fixture tree with no source twins (skills/<name>/ absent), which
+# keeps source_hash empty and isolates the generated_hash behavior.
+
+setup() {
+  source "$(git rev-parse --show-toplevel)/lib/bats-common.bash"
+  SCRIPT="$(bats_repo_root)/scripts/regen-codex-hashes.sh"
+  TMP="$(mktemp -d)"
+  export SKILLS_ROOT="$TMP/skills-codex"
+  mkdir -p "$SKILLS_ROOT"
+
+  # Two codex skills, each with a deliberately WRONG (drifted) generated_hash.
+  _make_skill foo
+  _make_skill bar
+
+  cat >"$SKILLS_ROOT/.agentops-manifest.json" <<'JSON'
+{
+  "skills": [
+    { "name": "foo", "generated_hash": "STALE_foo", "source_hash": "" },
+    { "name": "bar", "generated_hash": "STALE_bar", "source_hash": "" }
+  ]
+}
+JSON
+}
+
+teardown() { rm -rf "$TMP"; }
+
+# _make_skill <name> — a codex skill dir with content + a stale marker.
+_make_skill() {
+  local name="$1"
+  mkdir -p "$SKILLS_ROOT/$name"
+  printf 'content for %s\n' "$name" >"$SKILLS_ROOT/$name/SKILL.md"
+  cat >"$SKILLS_ROOT/$name/.agentops-generated.json" <<JSON
+{ "generated_hash": "STALE_${name}", "source_hash": "" }
+JSON
+}
+
+# _hash_of <name> — the JSON value of "generated_hash" for a manifest entry.
+_manifest_hash() {
+  python3 - "$1" <<'PY'
+import json, os, sys
+m = json.load(open(os.path.join(os.environ["SKILLS_ROOT"], ".agentops-manifest.json")))
+name = sys.argv[1]
+print(next(e["generated_hash"] for e in m["skills"] if e["name"] == name))
+PY
+}
+
+_marker_hash() {
+  python3 - "$1" <<'PY'
+import json, os, sys
+p = os.path.join(os.environ["SKILLS_ROOT"], sys.argv[1], ".agentops-generated.json")
+print(json.load(open(p))["generated_hash"])
+PY
+}
+
+@test "--only foo regenerates only foo; bar stays at its pre-existing drift" {
+  run bash "$SCRIPT" --only foo
+  [ "$status" -eq 0 ]
+
+  # foo updated away from the stale value...
+  local foo; foo="$(_manifest_hash foo)"
+  [ "$foo" != "STALE_foo" ]
+  [ -n "$foo" ]
+  # ...and its marker matches the manifest entry.
+  [ "$(_marker_hash foo)" = "$foo" ]
+
+  # bar left completely untouched (manifest + marker still the stale value).
+  [ "$(_manifest_hash bar)" = "STALE_bar" ]
+  [ "$(_marker_hash bar)" = "STALE_bar" ]
+}
+
+@test "no --only regenerates every skill" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  [ "$(_manifest_hash foo)" != "STALE_foo" ]
+  [ "$(_manifest_hash bar)" != "STALE_bar" ]
+  # foo and bar have distinct content, so distinct hashes.
+  [ "$(_manifest_hash foo)" != "$(_manifest_hash bar)" ]
+}
+
+@test "--only bar with --check reports drift for bar only and exits 1" {
+  run bash "$SCRIPT" --check --only bar
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bar"* ]]
+  [[ "$output" != *"foo"* ]]
+  # --check must not mutate anything.
+  [ "$(_manifest_hash bar)" = "STALE_bar" ]
+  [ "$(_manifest_hash foo)" = "STALE_foo" ]
+}
+
+@test "--only with a comma list scopes to all listed skills" {
+  run bash "$SCRIPT" --only foo,bar
+  [ "$status" -eq 0 ]
+  [ "$(_manifest_hash foo)" != "STALE_foo" ]
+  [ "$(_manifest_hash bar)" != "STALE_bar" ]
+}
+
+@test "--only requires an argument" {
+  run bash "$SCRIPT" --only
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"requires a skill list"* ]]
+}


### PR DESCRIPTION
## What

Adds `--only <skill[,skill,...]>` to `scripts/regen-codex-hashes.sh` and threads it through `scripts/regen-all.sh` (`--skills` arg / `REGEN_SKILLS` env), so an agent can regenerate codex hashes for **only the skills it touched**.

## Why

From `.agents/retro/2026-05-31-bead-crank-postmortem.md` §5 (#1-2): the codex hash regen rewrites every drifted manifest entry, sweeping ~8-9 pre-existing drifts into every skill PR and forcing a manual `jq`-splice. Scoping the loop kills that toil.

## Changes

- **`regen-codex-hashes.sh`**: `--only` parses a skill set; the per-skill loop `continue`s when a skill isn't in the set. `--check` honors the same scope. Default (no flag) = all skills, unchanged. `SKILLS_ROOT` is now env-overridable (enables hermetic testing).
- **`regen-all.sh`**: `--skills a,b` / `REGEN_SKILLS=a,b` threads `--only` into the codex-hash step in both regen and `--check` modes; trailing NOTE instructs passing scope when only some skills changed.
- **`tests/scripts/regen-codex-hashes-only.bats`**: hermetic — `--only foo` regenerates only foo and leaves a simulated pre-existing-drift sibling untouched; no-`--only` regenerates all; `--check` scoping; comma-list; arg-required.

## Verification

- `bats tests/scripts/regen-codex-hashes-only.bats` — 5/5 pass
- `shellcheck -S warning` clean on both scripts
- `git diff origin/main --stat` scope-only (2 scripts + 1 bats)
- The 9 manifest drifts on `main` (deps, post-mortem, provenance, red-team, release, scenario, ship-loop, skill-builder, trace) are **pre-existing**; this PR touches zero `skills-codex/` files.

Closes-scenario: ag-fbe9#regen-scoping
Bounded-context: BC2-Validation
Evidence: scripts/regen-codex-hashes.sh