### PR TITLE
chore(rules): gosec+semgrep crypto-suppression convention (ag-v7tk #security-lint-suppressions)

### DIFF
--- a/.claude/rules/go.md
+++ b/.claude/rules/go.md
@@ -41,6 +41,24 @@ Or equivalently: `cd cli && make build && make test`
 - When adding a field, grep all `StructName{` literals and verify each sets the new field.
 - Check factory functions and synthesized/summary instances.
 
+## Security-Lint Suppressions (gosec + semgrep)
+
+Suppressing a security-lint finding on intentional crypto (e.g. SHA-1 for git object IDs) needs TWO independent annotations on the SAME line — the two scanners run separately and ignore each other's directives:
+
+- **gosec** ignores `//nolint:gosec`. Use a `// #nosec G<NN>` directive (e.g. `// #nosec G401 G505`).
+- **semgrep** is suppressed only by a **bare** `// nosemgrep`. A qualified `nosemgrep: <rule-id>` does **NOT** suppress.
+- Put the combined comment on **both** the import line and the usage/call site — they are flagged independently.
+
+```go
+import (
+    "crypto/sha1" // #nosec G505 nosemgrep -- git object IDs are SHA-1 by definition; not a security primitive here.
+)
+// ...
+h := sha1.New() // #nosec G401 nosemgrep -- git blob IDs are SHA-1; matching git.
+```
+
+Canonical example: `cli/internal/drrebuild/drrebuild.go`.
+
 ## Style
 
 - `gofmt` is automatic. All exported symbols must have godoc comments.

--- a/cli/embedded/skills/standards/references/go.md
+++ b/cli/embedded/skills/standards/references/go.md
@@ -385,6 +385,32 @@ span.textContent = userInput;
 el.appendChild(span);
 ```
 
+## Security-Lint Suppressions (gosec + semgrep)
+
+When a security-lint finding is a false positive on intentional crypto (e.g. SHA-1 used for git object IDs, not as a security primitive), the suppression needs TWO independent annotations on the SAME line. gosec and semgrep run as separate scanners and each ignores the other's directives.
+
+| Scanner | What it ignores | What suppresses it |
+|---------|-----------------|--------------------|
+| gosec (standalone) | `//nolint:gosec` (golangci-lint-only) | `// #nosec G<NN>` directive, e.g. `// #nosec G401 G505` |
+| semgrep | qualified `nosemgrep: <rule-id>` (does NOT suppress) | a **bare** `// nosemgrep` |
+
+Combine both into one comment and place it on **both** the import line and the usage/call site — each is flagged independently:
+
+```go
+import (
+    "crypto/sha1" // #nosec G505 nosemgrep -- git object IDs are SHA-1 by definition; not a security primitive here.
+)
+
+func gitBlobID(content []byte) string {
+    h := sha1.New() // #nosec G401 nosemgrep -- git blob IDs are SHA-1; matching git.
+    // ...
+}
+```
+
+The `G<NN>` codes differ by site: G505 flags the `crypto/sha1` import (blocklisted import), G401 flags the `sha1.New()` call (weak crypto primitive). Pass every code that fires on a given line.
+
+Canonical example in this repo: `cli/internal/drrebuild/drrebuild.go`.
+
 ## Future Features (Go 1.24+)
 
 This section tracks features by first-supported Go version and can be used to plan future target upgrades.

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1087,7 +1087,7 @@
     {
       "name": "standards",
       "source_skill": "skills/standards",
-      "source_hash": "13b4bc9584723ee4fad55caa8c969a7b349bd92b878ada2213353149e8105d8a",
+      "source_hash": "f9046b2822250f82670fd93ccdf60deb96a81bd1299150a5c74ddc052a05d1eb",
       "generated_hash": "f6a7cadda9928b92bb1a59da3a34c6b9d5aa9132d5bc17a1bd770ebd3efc220c"
     },
     {

--- a/skills-codex/standards/.agentops-generated.json
+++ b/skills-codex/standards/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/standards",
   "layout": "modular",
-  "source_hash": "13b4bc9584723ee4fad55caa8c969a7b349bd92b878ada2213353149e8105d8a",
+  "source_hash": "f9046b2822250f82670fd93ccdf60deb96a81bd1299150a5c74ddc052a05d1eb",
   "generated_hash": "f6a7cadda9928b92bb1a59da3a34c6b9d5aa9132d5bc17a1bd770ebd3efc220c"
 }

--- a/skills/standards/references/go.md
+++ b/skills/standards/references/go.md
@@ -385,6 +385,32 @@ span.textContent = userInput;
 el.appendChild(span);
 ```
 
+## Security-Lint Suppressions (gosec + semgrep)
+
+When a security-lint finding is a false positive on intentional crypto (e.g. SHA-1 used for git object IDs, not as a security primitive), the suppression needs TWO independent annotations on the SAME line. gosec and semgrep run as separate scanners and each ignores the other's directives.
+
+| Scanner | What it ignores | What suppresses it |
+|---------|-----------------|--------------------|
+| gosec (standalone) | `//nolint:gosec` (golangci-lint-only) | `// #nosec G<NN>` directive, e.g. `// #nosec G401 G505` |
+| semgrep | qualified `nosemgrep: <rule-id>` (does NOT suppress) | a **bare** `// nosemgrep` |
+
+Combine both into one comment and place it on **both** the import line and the usage/call site — each is flagged independently:
+
+```go
+import (
+    "crypto/sha1" // #nosec G505 nosemgrep -- git object IDs are SHA-1 by definition; not a security primitive here.
+)
+
+func gitBlobID(content []byte) string {
+    h := sha1.New() // #nosec G401 nosemgrep -- git blob IDs are SHA-1; matching git.
+    // ...
+}
+```
+
+The `G<NN>` codes differ by site: G505 flags the `crypto/sha1` import (blocklisted import), G401 flags the `sha1.New()` call (weak crypto primitive). Pass every code that fires on a given line.
+
+Canonical example in this repo: `cli/internal/drrebuild/drrebuild.go`.
+
 ## Future Features (Go 1.24+)
 
 This section tracks features by first-supported Go version and can be used to plan future target upgrades.


### PR DESCRIPTION
Document the security-lint suppression convention discovered the expensive way (3 pushes on #646).

## What
Add a `## Security-Lint Suppressions (gosec + semgrep)` section to both `.claude/rules/go.md` (tight) and `skills/standards/references/go.md` (full table + example), capturing:

- **gosec** ignores `//nolint:gosec` — use `// #nosec G<NN>` (e.g. `// #nosec G401 G505`).
- **semgrep** is suppressed only by a **bare** `// nosemgrep`; a qualified `nosemgrep: <rule-id>` does NOT suppress.
- The comment must sit on **both** the import line and the usage/call site (flagged independently).
- Canonical example: `cli/internal/drrebuild/drrebuild.go`.

## Derived surfaces
Ran `scripts/regen-all.sh --skills standards` (the #664 scoping) + scoped `regen-codex-hashes --check --only standards` (PASS). Regenerated the embedded twin (`cli/embedded/skills/standards/references/go.md`) and the standards codex hash manifests. The 9 unrelated codex-hash drifts the no-scope `--check` reports (deps, post-mortem, provenance, red-team, release, scenario, ship-loop, skill-builder, trace) are pre-existing on main and out of scope.

Closes-scenario: ag-v7tk#security-lint-suppressions
Bounded-context: BC2-Validation
Evidence: .claude/rules/go.md