### PR TITLE
feat(skills): encode orchestrator-merge + sequential-chain + stale-guard + worktree-reap + epic-close gate (ag-7gmv #encode-crank-wins)

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -751,7 +751,7 @@
     {
       "name": "crank",
       "source_skill": "skills/crank",
-      "source_hash": "96897f552e614ef9a4ed36557e8287262c5000775364c9dae3f5be31a0a04ecd",
+      "source_hash": "62e56f00f102262df1e81067c3305db9c8dd8fd34ef8b8f972545e0ddc61d02f",
       "generated_hash": "d1f156a392be40cb5f72a424de9a7c165df4c1677c984a963cf20ad1cbd15c6f"
     },
     {
@@ -805,7 +805,7 @@
     {
       "name": "evolve",
       "source_skill": "skills/evolve",
-      "source_hash": "249a0da42df98dbdcd912223724d699806f658e397951225870a9b323a957a42",
+      "source_hash": "4ddc83f7903e0a0a6d684ee2fa00f8e0164b014caeaae27625c294ffa507e3fa",
       "generated_hash": "4c291f25cfc6e9ee2547e8140488a75097c6fa38615282742d375f603f5daae5"
     },
     {
@@ -1099,7 +1099,7 @@
     {
       "name": "swarm",
       "source_skill": "skills/swarm",
-      "source_hash": "15c7dce353269b78c0d51e5eb82685e8c9d1e5bd64e3f6cabaebea67c401e4a6",
+      "source_hash": "ae39b48066361c02f1417f0205fbacf4b1442d9eaddec7a1253b3d19736feaf8",
       "generated_hash": "093b9bb120ff3b2804b753ff69c80430d8738095ced1ef0e7a03c1fc8ca112d6"
     },
     {

--- a/skills-codex/crank/.agentops-generated.json
+++ b/skills-codex/crank/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/crank",
   "layout": "modular",
-  "source_hash": "96897f552e614ef9a4ed36557e8287262c5000775364c9dae3f5be31a0a04ecd",
+  "source_hash": "62e56f00f102262df1e81067c3305db9c8dd8fd34ef8b8f972545e0ddc61d02f",
   "generated_hash": "d1f156a392be40cb5f72a424de9a7c165df4c1677c984a963cf20ad1cbd15c6f"
 }

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/evolve",
   "layout": "modular",
-  "source_hash": "249a0da42df98dbdcd912223724d699806f658e397951225870a9b323a957a42",
+  "source_hash": "4ddc83f7903e0a0a6d684ee2fa00f8e0164b014caeaae27625c294ffa507e3fa",
   "generated_hash": "4c291f25cfc6e9ee2547e8140488a75097c6fa38615282742d375f603f5daae5"
 }

--- a/skills-codex/swarm/.agentops-generated.json
+++ b/skills-codex/swarm/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/swarm",
   "layout": "modular",
-  "source_hash": "15c7dce353269b78c0d51e5eb82685e8c9d1e5bd64e3f6cabaebea67c401e4a6",
+  "source_hash": "ae39b48066361c02f1417f0205fbacf4b1442d9eaddec7a1253b3d19736feaf8",
   "generated_hash": "093b9bb120ff3b2804b753ff69c80430d8738095ced1ef0e7a03c1fc8ca112d6"
 }

--- a/skills/crank/SKILL.md
+++ b/skills/crank/SKILL.md
@@ -46,7 +46,7 @@ output_contract: code changes across wave execution, .agents/swarm/results/*.jso
 
 ## Loop position
 
-Move **5 (wave execution)** of the [operating loop](../../docs/architecture/operating-loop.md). Consumes the [slice validation plan](../../docs/templates/slice-validation.md); produces wave-by-wave slice completion via `/swarm` + `/implement`. Hard gate at wave start: every row of the wave-validity check must pass (distinct write scopes, no shared migration/contract/CLI surface, declared integration order, owner per slice, discard path per slice). Any failed row → run those slices sequential, not parallel. Parallelism is explicit ownership, not swarm chaos.
+Move **5 (wave execution)** of the [operating loop](../../docs/architecture/operating-loop.md). Consumes the [slice validation plan](../../docs/templates/slice-validation.md); produces wave-by-wave slice completion via `/swarm` + `/implement`. Hard gate at wave start: every row of the wave-validity check must pass (distinct write scopes, no shared migration/contract/CLI surface, declared integration order, owner per slice, discard path per slice). Any failed row → run those slices sequential, not parallel. **Coupled-chain rule:** two slices that both regenerate a shared *derived* surface (`cli-command-surface` / `registry.json` / `context-map` / codex manifest) collide even with disjoint source files — run them as a sequential chain, each link branched off the freshly-MERGED prior link. Parallelism is explicit ownership, not swarm chaos.
 
 Autonomous execution: implement all issues until the epic is DONE.
 
@@ -142,6 +142,17 @@ Reason: <global limit reached | unresolvable blockers>
 Issues remaining: N
 Iterations: M/50
 ```
+
+## Orchestrator-Merge + Reconcile Loop
+
+When crank drives PRs to `main` itself (orchestrator-merge model), reconcile each PR mechanically:
+
+1. **Poll** `gh pr checks <pr>` until all checks are terminal.
+2. **Block only on substantive fails.** A failing `claude-review` on a usage-limit message is non-blocking; only substantive non-`claude-review` failures block the merge.
+3. **Fix-forward stale/transient reds — never revert green work.** `correctness (ubuntu-latest)` tar-cache-restore exit-2 → `gh run rerun` **once**, then believe. `registry.json` / derived-surface or `contracts-sync` drift from another PR → `make regen-all` (scoped via `--skills` when only some skills changed), commit, push.
+4. **Merge when green:** `gh pr merge --squash --admin`.
+5. **Close on confirmed-MERGED only.** `bd close` a child bead ONLY after `gh pr view <pr> --json state -q .state` returns `MERGED` — never on a log line or batch `bd --json` query (those flake to null/0).
+6. **Epic-close gate.** **NEVER close a parent epic before EVERY child PR is independently confirmed `MERGED`** — re-query `gh pr view --json state` per child first. One non-merged child aborts the close. (Post-mortem governance checkpoint: this is a hard gate, not advisory.)
 
 ## The FIRE Loop
 

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -127,7 +127,10 @@ skill-factory guardrails.
 
 ### Step 0: Setup
 
+**Stale-checkout survey guard (run FIRST).** Before any tree-reading survey: `git fetch origin && git status -sb`. If the checkout is behind/diverged AND it is a throwaway orchestration tree with no un-pushed work, `git reset --hard origin/main`. **BAN `git pull --rebase` on the survey path** — it silently no-ops against a diverged local `main`, so merged files appear "missing" and the survey investigates already-merged work.
+
 ```bash
+git fetch origin && git status -sb              # survey guard — never `git pull --rebase` here
 mkdir -p .agents/evolve
 ao corpus inject --query "autonomous improvement cycle" --limit 5 2>/dev/null || true
 bash scripts/evolve-update-session-state.sh 2>/dev/null || true  # refresh derived idle_streak + mode_repeat_streak
@@ -362,6 +365,8 @@ fi
 ```
 
 **Drive to completion (orchestrator-merge model, soc-2drk).** Where the repo requires PRs (branch protection rejects direct `main` pushes), a productive cycle does not stop at "PR opened" — the loop is the orchestrator that drives each bead to *merged*. Ship the bead from its per-bead worktree as a PR (trailers `Closes-scenario` / `Bounded-context` / `Evidence`), wait for CI, and **squash-merge to main yourself once CI is green** (`gh pr merge <N> --squash --admin`), then `bd close` the bead and remove the worktree. **Green CI is the only merge gate** — on a quality/test red, fix-and-repush or revert; never merge red. The loop may dispatch sub-agents to implement and drives their PRs to merge too. The operator stays *on* the loop (intent + STOP marker), not *in* it (per-PR approval). This **supersedes "operator is the merge gate"** for the autonomous loop — see [ADR-0008](../../docs/adr/ADR-0008-evolve-intelligent-agile-operating-model.md).
+
+**Confirmed-MERGED gate before `bd close` (hard, not advisory).** Re-confirm `gh pr view <N> --json state -q .state` returns `MERGED` *before* `bd close` — never close on a `gh pr merge` exit code, a log line, or a batch `bd --json` query (those flake to null/0). **Close a parent epic ONLY after every child PR is independently confirmed `MERGED`**; re-query per child first, and one non-merged child aborts the epic close. (Caught two premature epic-closes in the 2026-05-31 crank session — this gate is the governance checkpoint, applied here too.)
 
 ### Teardown
 

--- a/skills/swarm/SKILL.md
+++ b/skills/swarm/SKILL.md
@@ -38,6 +38,8 @@ Spawn isolated agents to execute tasks in parallel. Fresh context per agent (Ral
 
 Move **5 (wave execution)** of the [operating loop](../../docs/architecture/operating-loop.md), specifically the parallel-fork primitive `/crank` invokes. Refuses to spawn parallel agents on a wave that has not cleared the wave-validity check in the [slice validation plan](../../docs/templates/slice-validation.md): write scopes must be disjoint, no shared migration/contract/CLI surface, integration order declared when it matters, one owner per slice, discard path per slice. Parallelism is explicit ownership, not swarm chaos. Default to sequential when the wave-validity rows are not all green.
 
+**Coupled-chain rule (DERIVED-surface collision).** Two slices that both regenerate a shared *derived* surface — `cli-command-surface`, `registry.json`, `context-map`, or the codex manifest — **collide even if their source files are disjoint**. Such a coupled chain (`schema→write-model→export→gate→tests`) MUST run sequential: each link branches off the freshly-**MERGED** prior link's SHA, never a pre-fan snapshot. Reserve parallel waves for provably-disjoint surfaces, cap **4–6**.
+
 **Integration modes:**
 - **Direct** - Create TaskList tasks, invoke `/swarm`
 - **Via Crank** - `/crank` creates tasks from beads, invokes `/swarm` for each wave
@@ -252,6 +254,8 @@ Read [references/ol-wave-integration.md](references/ol-wave-integration.md) when
 Read [references/shared-checkout-discipline.md](references/shared-checkout-discipline.md) **first** when the target checkout (`~/dev/<repo>`) is shared with peer agents — it documents when worktrees are mandatory (vs. optional) and the three failure modes (branch-deletion data loss, swarm attribution confounded, destructive-recovery temptation) that motivate the discipline.
 
 Read [references/worktree-isolation.md](references/worktree-isolation.md) when you need to dispatch workers across multiple epics or run waves with overlapping files — covers isolation semantics per backend, effort levels, post-spawn verification, manual worktree creation/routing/merge-back, the Merge Arbiter Protocol, cleanup, and the `--worktrees` / `--no-worktrees` parameters.
+
+**Worktree reaping (teardown).** After a worker's PR is confirmed **MERGED** (`gh pr view --json state` = `MERGED`), reap its tree: `git worktree remove <path> --force` then `git worktree prune`. **Leave unmerged-PR worktrees intact.** Target zero orphaned worktrees — bound the live count to in-flight PRs. (The committed disposition gate scans the tracked file set, not live on-disk worktrees, so this teardown is the operational backstop.)
 
 ---
 


### PR DESCRIPTION
## What

Encode the 2026-05-31 bead-crank post-mortem's durable wins (§5 #5-8, §7 #4) into the orchestration skills so the next session doesn't relearn them.

- **swarm**: coupled-chain rule (two slices that both regenerate a shared *derived* surface — `cli-command-surface`/`registry.json`/`context-map`/codex manifest — collide even with disjoint sources → sequential, each link off the freshly-MERGED prior link; parallel only for disjoint, cap 4-6) + worktree-reaping teardown after confirmed MERGED.
- **crank**: coupled-chain clause in wave-validity + new `## Orchestrator-Merge + Reconcile Loop` section (poll `gh pr checks`; block only on substantive non-`claude-review` fails; fix-forward transient reds — tar-cache flake rerun-once, derived drift `make regen-all` — never revert green; `gh pr merge --squash --admin` when green; `bd close` only on confirmed `MERGED`; never close a parent epic before every child PR is confirmed merged).
- **evolve**: Step 0 stale-checkout survey guard (`git fetch && git status -sb`, `git reset --hard origin/main` on throwaway diverged trees, ban `git pull --rebase` on the survey path) + confirmed-MERGED-before-`bd close` gate incl. all-children gate for epics.

## Scope

3 SKILL.md edits + their codex generated-hash twins + manifest (scoped `--skills swarm,crank,evolve`, no pre-existing drift sweep). registry.json/cli-surface reverted (timestamp-only / pre-existing drift).

## Gates

- `regen-all.sh --check --skills swarm,crank,evolve`: ALL GATES GREEN
- `tests/skills/run-all.sh`: 87/87 PASS, token budgets within limits
- `audit-codex-parity.sh --skill {swarm,crank,evolve}`: all passed

Closes-scenario: ag-7gmv#encode-crank-wins
Bounded-context: BC3-Loop
Evidence: skills/crank/SKILL.md