### PR TITLE
fix(test): canonicalize chdirTemp paths for macOS symlink resolution (ag-vcu4 #chdir-temp-macos-symlink)

### DIFF
--- a/cli/cmd/ao/testutil_test.go
+++ b/cli/cmd/ao/testutil_test.go
@@ -509,7 +509,12 @@ func chdirTemp(t *testing.T) string {
 		t.Fatalf("chdir: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chdir(prev) })
-	return tmp
+	// Match os.Getwd() canonicalization (macOS /var → /private/var symlinks).
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd after chdir: %v", err)
+	}
+	return cwd
 }
 
 // chdirTo changes to the specified directory, registers a cleanup to restore


### PR DESCRIPTION
## Summary

- Return `os.Getwd()` from `chdirTemp()` instead of the raw `t.TempDir()` path so test fixture paths match production `Getwd()` output on macOS (`/var` → `/private/var` symlink resolution)
- Fixes `TestCronSelfAdjust_RoundTrip` failure where `RenderedTemplate` in cron history did not match the expected path
- Central fix in the shared test helper benefits all 30+ callers; full `go test ./...` green locally (12109 tests)

## Test plan

- [x] `go test -count=1 -run TestCronSelfAdjust ./cmd/ao/` — 5 passed
- [x] `go test -count=1 ./...` — 12109 passed, 66 packages
- [x] `go vet ./...` — clean
- [ ] CI validate workflow green on push

Closes-scenario: ag-vcu4#chdir-temp-macos-symlink
Bounded-context: BC5-Runtime
Evidence: cli/cmd/ao/testutil_test.go


Made with [Cursor](https://cursor.com)