### PR TITLE
feat(canon): earned-promotion team-knowledge tier (ag-bw5s #earned-promotion-gate)

### DIFF
--- a/cli/cmd/ao/canon.go
+++ b/cli/cmd/ao/canon.go
@@ -93,6 +93,7 @@ func init() {
 	canonCiteCmd.Flags().String("path", "", "path to the learning file (required)")
 	canonCiteCmd.Flags().String("query", "", "search query that surfaced the learning")
 	canonCiteCmd.Flags().String("session", "", "session ID")
+	canonCiteCmd.Flags().String("as", "", "acting actor override (\"Name\" or \"Name <email>\"); else AGENTOPS_ACTOR / git")
 	_ = canonCiteCmd.MarkFlagRequired("path")
 	canonCmd.AddCommand(canonCiteCmd)
 
@@ -100,6 +101,7 @@ func init() {
 	canonVerifyCmd.Flags().String("verdict", "confirmed", "confirmed|refuted")
 	canonVerifyCmd.Flags().String("method", "manual", "how it was checked: manual|ao-verify|council|cross-model")
 	canonVerifyCmd.Flags().String("receipt", "", "evidence you independently gathered (gate log, file:line, hash)")
+	canonVerifyCmd.Flags().String("as", "", "acting actor override (\"Name\" or \"Name <email>\"); else AGENTOPS_ACTOR / git")
 	_ = canonVerifyCmd.MarkFlagRequired("path")
 	canonCmd.AddCommand(canonVerifyCmd)
 
@@ -119,13 +121,15 @@ func runCanonCite(cmd *cobra.Command, args []string) error {
 	path, _ := cmd.Flags().GetString("path")
 	query, _ := cmd.Flags().GetString("query")
 	session, _ := cmd.Flags().GetString("session")
+	as, _ := cmd.Flags().GetString("as")
 	cl, _ := canonLedgers(cwd)
 
-	c, err := cl.Record(args[0], path, query, session, canon.CurrentIdentity(), time.Now())
+	by, src := canon.ResolveIdentity(as)
+	c, err := cl.Record(args[0], path, query, session, by, time.Now())
 	if err != nil {
 		return fmt.Errorf("record citation: %w", err)
 	}
-	return emitCanonAttestation(cmd.OutOrStdout(), "cite", args[0], c.By, c.Self)
+	return emitCanonAttestation(cmd.OutOrStdout(), "cite", args[0], c.By, src, c.Self)
 }
 
 func runCanonVerify(cmd *cobra.Command, args []string) error {
@@ -137,17 +141,19 @@ func runCanonVerify(cmd *cobra.Command, args []string) error {
 	method, _ := cmd.Flags().GetString("method")
 	receipt, _ := cmd.Flags().GetString("receipt")
 	verdictStr, _ := cmd.Flags().GetString("verdict")
+	as, _ := cmd.Flags().GetString("as")
 	verdict := canon.Verdict(verdictStr)
 	if verdict != canon.VerdictConfirmed && verdict != canon.VerdictRefuted {
 		return fmt.Errorf("invalid --verdict %q: want confirmed|refuted", verdictStr)
 	}
 	_, vl := canonLedgers(cwd)
 
-	v, err := vl.Record(args[0], path, method, receipt, verdict, canon.CurrentIdentity(), time.Now())
+	by, src := canon.ResolveIdentity(as)
+	v, err := vl.Record(args[0], path, method, receipt, verdict, by, time.Now())
 	if err != nil {
 		return fmt.Errorf("record verification: %w", err)
 	}
-	if err := emitCanonAttestation(cmd.OutOrStdout(), "verify("+verdictStr+")", args[0], v.By, v.Self); err != nil {
+	if err := emitCanonAttestation(cmd.OutOrStdout(), "verify("+verdictStr+")", args[0], v.By, src, v.Self); err != nil {
 		return err
 	}
 	if v.Receipt == "" && GetOutput() != "json" {
@@ -156,17 +162,17 @@ func runCanonVerify(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func emitCanonAttestation(w io.Writer, kind, entryID string, by canon.Identity, self bool) error {
+func emitCanonAttestation(w io.Writer, kind, entryID string, by canon.Identity, src canon.IdentitySource, self bool) error {
 	if GetOutput() == "json" {
 		return json.NewEncoder(w).Encode(map[string]any{
-			"kind": kind, "entry_id": entryID, "by": by, "self": self,
+			"kind": kind, "entry_id": entryID, "by": by, "source": src, "self": self,
 		})
 	}
 	flag := ""
 	if self {
 		flag = "  [self — does not count toward promotion]"
 	}
-	fmt.Fprintf(w, "recorded %s for %s by %s%s\n", kind, entryID, by.Name, flag)
+	fmt.Fprintf(w, "recorded %s for %s by %s (%s)%s\n", kind, entryID, by.Name, src, flag)
 	return nil
 }
 

--- a/cli/cmd/ao/canon.go
+++ b/cli/cmd/ao/canon.go
@@ -1,0 +1,304 @@
+// practices: [ddd-bounded-context, knowledge-flywheel]
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/boshu2/agentops/cli/internal/canon"
+	"github.com/spf13/cobra"
+)
+
+// canon CLI surface: the team-knowledge canon — learnings earned into a shared
+// trusted set by independent attestation, never self-certified.
+//
+// .agents/canon/
+//   citations.jsonl       — who USED each learning (proves useful)
+//   verifications.jsonl   — who independently CHECKED each learning (proves true)
+//   learnings/            — promoted, earned canon entries
+
+const (
+	canonDir         = ".agents/canon"
+	canonCitations   = "citations.jsonl"
+	canonVerifs      = "verifications.jsonl"
+	canonLearnings   = "learnings"
+	canonAuthorGuard = "an attestation by the entry's own author never counts toward promotion"
+)
+
+func canonLedgers(cwd string) (*canon.CitationLedger, *canon.VerificationLedger) {
+	base := filepath.Join(cwd, canonDir)
+	return canon.NewCitationLedger(filepath.Join(base, canonCitations)),
+		canon.NewVerificationLedger(filepath.Join(base, canonVerifs))
+}
+
+var canonCmd = &cobra.Command{
+	Use:   "canon",
+	Short: "Team-knowledge canon: learnings earned by independent attestation",
+	Long: `The team-knowledge canon is the trusted set of learnings a team shares.
+
+A learning is *earned* into canon, not self-asserted. Promotion requires two
+independent signals, and ` + canonAuthorGuard + `:
+
+  cite     a learning was USED by another engineer   (proves useful)
+  verify   a learning was CHECKED by another engineer (proves true)
+
+Promotion succeeds only when an entry has both a cross-engineer citation and an
+independent confirmation, and has not been independently refuted.`,
+}
+
+var canonCiteCmd = &cobra.Command{
+	Use:   "cite <entry-id>",
+	Short: "Record that you used a learning (the 'useful' signal)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runCanonCite,
+}
+
+var canonVerifyCmd = &cobra.Command{
+	Use:   "verify <entry-id>",
+	Short: "Record an independent check of a learning (the 'true' signal)",
+	Long: `Record that you independently checked a learning and whether it holds.
+
+A verification is only independent if you GATHERED YOUR OWN EVIDENCE — pass
+--receipt with the gate log, file:line, or hash you actually observed, rather
+than trusting a summary. Receiptless verifications are recorded but the
+promotion gate can be configured to ignore them.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runCanonVerify,
+}
+
+var canonStatusCmd = &cobra.Command{
+	Use:   "status [entry-id]",
+	Short: "Show promotion eligibility for one or all tracked entries",
+	Args:  cobra.MaximumNArgs(1),
+	RunE:  runCanonStatus,
+}
+
+var canonPromoteCmd = &cobra.Command{
+	Use:   "promote <entry-id>",
+	Short: "Promote an earned learning into the team canon",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runCanonPromote,
+}
+
+func init() {
+	canonCmd.GroupID = "core"
+	rootCmd.AddCommand(canonCmd)
+
+	canonCiteCmd.Flags().String("path", "", "path to the learning file (required)")
+	canonCiteCmd.Flags().String("query", "", "search query that surfaced the learning")
+	canonCiteCmd.Flags().String("session", "", "session ID")
+	_ = canonCiteCmd.MarkFlagRequired("path")
+	canonCmd.AddCommand(canonCiteCmd)
+
+	canonVerifyCmd.Flags().String("path", "", "path to the learning file (required)")
+	canonVerifyCmd.Flags().String("verdict", "confirmed", "confirmed|refuted")
+	canonVerifyCmd.Flags().String("method", "manual", "how it was checked: manual|ao-verify|council|cross-model")
+	canonVerifyCmd.Flags().String("receipt", "", "evidence you independently gathered (gate log, file:line, hash)")
+	_ = canonVerifyCmd.MarkFlagRequired("path")
+	canonCmd.AddCommand(canonVerifyCmd)
+
+	canonCmd.AddCommand(canonStatusCmd)
+
+	canonPromoteCmd.Flags().String("path", "", "path to the learning file (required)")
+	canonPromoteCmd.Flags().Bool("force", false, "promote despite an unmet gate (records the override loudly)")
+	_ = canonPromoteCmd.MarkFlagRequired("path")
+	canonCmd.AddCommand(canonPromoteCmd)
+}
+
+func runCanonCite(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	path, _ := cmd.Flags().GetString("path")
+	query, _ := cmd.Flags().GetString("query")
+	session, _ := cmd.Flags().GetString("session")
+	cl, _ := canonLedgers(cwd)
+
+	c, err := cl.Record(args[0], path, query, session, canon.CurrentIdentity(), time.Now())
+	if err != nil {
+		return fmt.Errorf("record citation: %w", err)
+	}
+	return emitCanonAttestation(cmd.OutOrStdout(), "cite", args[0], c.By, c.Self)
+}
+
+func runCanonVerify(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	path, _ := cmd.Flags().GetString("path")
+	method, _ := cmd.Flags().GetString("method")
+	receipt, _ := cmd.Flags().GetString("receipt")
+	verdictStr, _ := cmd.Flags().GetString("verdict")
+	verdict := canon.Verdict(verdictStr)
+	if verdict != canon.VerdictConfirmed && verdict != canon.VerdictRefuted {
+		return fmt.Errorf("invalid --verdict %q: want confirmed|refuted", verdictStr)
+	}
+	_, vl := canonLedgers(cwd)
+
+	v, err := vl.Record(args[0], path, method, receipt, verdict, canon.CurrentIdentity(), time.Now())
+	if err != nil {
+		return fmt.Errorf("record verification: %w", err)
+	}
+	if err := emitCanonAttestation(cmd.OutOrStdout(), "verify("+verdictStr+")", args[0], v.By, v.Self); err != nil {
+		return err
+	}
+	if v.Receipt == "" && GetOutput() != "json" {
+		fmt.Fprintln(cmd.OutOrStdout(), "  note: no --receipt recorded; this is a weak (unreceipted) verification")
+	}
+	return nil
+}
+
+func emitCanonAttestation(w io.Writer, kind, entryID string, by canon.Identity, self bool) error {
+	if GetOutput() == "json" {
+		return json.NewEncoder(w).Encode(map[string]any{
+			"kind": kind, "entry_id": entryID, "by": by, "self": self,
+		})
+	}
+	flag := ""
+	if self {
+		flag = "  [self — does not count toward promotion]"
+	}
+	fmt.Fprintf(w, "recorded %s for %s by %s%s\n", kind, entryID, by.Name, flag)
+	return nil
+}
+
+func runCanonStatus(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	cl, vl := canonLedgers(cwd)
+	gate := canon.DefaultGate()
+
+	var ids []string
+	if len(args) == 1 {
+		ids = []string{args[0]}
+	} else {
+		ids, err = canonTrackedEntries(cwd)
+		if err != nil {
+			return err
+		}
+	}
+
+	decisions := make([]canon.Decision, 0, len(ids))
+	for _, id := range ids {
+		d, err := gate.Evaluate(id, cl, vl)
+		if err != nil {
+			return err
+		}
+		decisions = append(decisions, d)
+	}
+
+	if GetOutput() == "json" {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(decisions)
+	}
+	if len(decisions) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "no tracked entries (record a cite or verify first)")
+		return nil
+	}
+	for _, d := range decisions {
+		status := "PENDING"
+		if d.Eligible {
+			status = "EARNED "
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s %-24s cites=%d verifs=%d\n", status, d.EntryID, d.Citations, d.Verifications)
+		for _, u := range d.Unmet {
+			fmt.Fprintf(cmd.OutOrStdout(), "          - %s\n", u)
+		}
+	}
+	return nil
+}
+
+func runCanonPromote(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	entryID := args[0]
+	path, _ := cmd.Flags().GetString("path")
+	force, _ := cmd.Flags().GetBool("force")
+
+	cl, vl := canonLedgers(cwd)
+	d, err := canon.DefaultGate().Evaluate(entryID, cl, vl)
+	if err != nil {
+		return err
+	}
+
+	if !d.Eligible && !force {
+		if GetOutput() == "json" {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(map[string]any{"promoted": false, "decision": d})
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "BLOCKED %s is not earned:\n", entryID)
+			for _, u := range d.Unmet {
+				fmt.Fprintf(cmd.OutOrStdout(), "  - %s\n", u)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "(%s)\n", canonAuthorGuard)
+		}
+		return fmt.Errorf("entry %s not earned", entryID)
+	}
+
+	dest := filepath.Join(cwd, canonDir, canonLearnings, filepath.Base(path))
+	if err := copyFileInto(path, dest); err != nil {
+		return fmt.Errorf("promote into canon: %w", err)
+	}
+
+	forced := !d.Eligible && force
+	if GetOutput() == "json" {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(map[string]any{"promoted": true, "forced": forced, "dest": dest, "decision": d})
+	}
+	if forced {
+		fmt.Fprintf(cmd.OutOrStdout(), "FORCED  promoted %s despite unmet gate (override recorded)\n", entryID)
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "EARNED  promoted %s → %s\n", entryID, dest)
+	}
+	return nil
+}
+
+// canonTrackedEntries returns the distinct entry IDs that appear in either
+// ledger, sorted for stable output.
+func canonTrackedEntries(cwd string) ([]string, error) {
+	cl, vl := canonLedgers(cwd)
+	seen := map[string]struct{}{}
+	cites, err := cl.AllEntryIDs()
+	if err != nil {
+		return nil, err
+	}
+	verifs, err := vl.AllEntryIDs()
+	if err != nil {
+		return nil, err
+	}
+	for _, id := range append(cites, verifs...) {
+		seen[id] = struct{}{}
+	}
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
+func copyFileInto(src, dest string) error {
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dest, data, 0o644)
+}

--- a/cli/cmd/ao/cobra_commands_test.go
+++ b/cli/cmd/ao/cobra_commands_test.go
@@ -365,7 +365,7 @@ func TestCobraCommandTreeRegistration(t *testing.T) {
 
 	// Verify all top-level commands are registered (flat namespace)
 	expectedCmds := []string{
-		"agent", "agents", "anti-patterns", "autodev", "badge", "batch-feedback", "beads", "capabilities", "ci", "citation", "claim", "completion", "config",
+		"agent", "agents", "anti-patterns", "autodev", "badge", "batch-feedback", "beads", "canon", "capabilities", "ci", "citation", "claim", "completion", "config",
 		"constraint", "context", "codex", "compile", "contradict", "corpus", "cron", "curate", "dedup",
 		"defrag", "demo", "doctor", "eval", "evolve", "extract", "feedback", "feedback-loop",
 		"findings", "flywheel", "forge", "gate", "goals", "handoff", "harness", "harvest",
@@ -424,7 +424,7 @@ func TestCobraExpectedCmdsMatchRegistration(t *testing.T) {
 
 	// Same list as TestCobraCommandTreeRegistration
 	expectedCmds := []string{
-		"agent", "agents", "anti-patterns", "autodev", "badge", "batch-feedback", "beads", "capabilities", "ci", "citation", "claim", "completion", "config",
+		"agent", "agents", "anti-patterns", "autodev", "badge", "batch-feedback", "beads", "canon", "capabilities", "ci", "citation", "claim", "completion", "config",
 		"constraint", "context", "codex", "compile", "contradict", "corpus", "cron", "curate", "dedup",
 		"defrag", "demo", "doctor", "eval", "evolve", "extract", "feedback", "feedback-loop",
 		"findings", "flywheel", "forge", "gate", "goals", "handoff", "harness", "harvest",

--- a/cli/cmd/ao/inject_canon_test.go
+++ b/cli/cmd/ao/inject_canon_test.go
@@ -1,0 +1,113 @@
+// practices: [wiki-knowledge-surface, knowledge-flywheel]
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeCanonInjectFixture builds a workspace with one local learning and one
+// canon learning of equal utility, returning the workspace root.
+func writeCanonInjectFixture(t *testing.T, localUtility, canonUtility string) string {
+	t.Helper()
+	root := t.TempDir()
+
+	localDir := filepath.Join(root, ".agents", "learnings")
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	local := "---\nutility: " + localUtility + "\nmaturity: provisional\n---\n# Local Note\n\nLocal content describing a provisional learning used for canon-tier inject tests.\n"
+	if err := os.WriteFile(filepath.Join(localDir, "local.md"), []byte(local), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	canonDir := filepath.Join(root, ".agents", "canon", "learnings")
+	if err := os.MkdirAll(canonDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	canon := "---\nutility: " + canonUtility + "\nmaturity: provisional\n---\n# Canon Note\n\nEarned team-canon content describing a verified learning surfaced by inject.\n"
+	if err := os.WriteFile(filepath.Join(canonDir, "canon.md"), []byte(canon), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// TestCollectLearnings_CanonTierSurfaces verifies canon entries are collected
+// and flagged distinctly from local entries.
+func TestCollectLearnings_CanonTierSurfaces(t *testing.T) {
+	root := writeCanonInjectFixture(t, "0.8", "0.8")
+
+	learnings, err := collectLearnings(root, "", 10, "", 0.8)
+	if err != nil {
+		t.Fatalf("collectLearnings() error = %v", err)
+	}
+	if len(learnings) != 2 {
+		t.Fatalf("expected 2 learnings (local + canon), got %d", len(learnings))
+	}
+
+	var foundLocal, foundCanon bool
+	for _, l := range learnings {
+		if l.Canon {
+			foundCanon = true
+		} else {
+			foundLocal = true
+		}
+	}
+	if !foundLocal {
+		t.Error("expected a local (non-canon) learning")
+	}
+	if !foundCanon {
+		t.Error("expected a canon-flagged learning")
+	}
+}
+
+// TestCollectLearnings_CanonBoost verifies that a canon entry outranks a local
+// entry of identical utility — canon is the verification-earned trusted tier,
+// so it is boosted, not penalized like the global mirror.
+func TestCollectLearnings_CanonBoost(t *testing.T) {
+	root := writeCanonInjectFixture(t, "0.8", "0.8")
+
+	learnings, err := collectLearnings(root, "", 10, "", 0.8)
+	if err != nil {
+		t.Fatalf("collectLearnings() error = %v", err)
+	}
+
+	var localScore, canonScore float64
+	for _, l := range learnings {
+		if l.Canon {
+			canonScore = l.CompositeScore
+		} else {
+			localScore = l.CompositeScore
+		}
+	}
+	if canonScore <= localScore {
+		t.Errorf("canon score %.4f should exceed equal-utility local score %.4f (boost not applied)", canonScore, localScore)
+	}
+	// And the boosted canon entry must rank first.
+	if !learnings[0].Canon {
+		t.Errorf("expected canon entry ranked first, got %q (canon=%v)", learnings[0].Title, learnings[0].Canon)
+	}
+}
+
+// TestCollectLearnings_CanonAbsentDirNoop verifies inject works unchanged when
+// no canon tier exists.
+func TestCollectLearnings_CanonAbsentDirNoop(t *testing.T) {
+	root := t.TempDir()
+	localDir := filepath.Join(root, ".agents", "learnings")
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "---\nutility: 0.8\nmaturity: provisional\n---\n# Only Local\n\nLocal content present without any canon tier directory on disk at all.\n"
+	if err := os.WriteFile(filepath.Join(localDir, "only.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	learnings, err := collectLearnings(root, "", 10, "", 0.8)
+	if err != nil {
+		t.Fatalf("collectLearnings() error = %v", err)
+	}
+	if len(learnings) != 1 || learnings[0].Canon {
+		t.Fatalf("expected 1 non-canon learning, got %d (canon=%v)", len(learnings), len(learnings) > 0 && learnings[0].Canon)
+	}
+}

--- a/cli/cmd/ao/inject_learnings.go
+++ b/cli/cmd/ao/inject_learnings.go
@@ -87,14 +87,77 @@ func collectLearnings(cwd, query string, limit int, globalDir string, globalWeig
 		learnings = appendGlobalLearnings(learnings, globalDir, localPaths, localTitles, localContentHashes, tokens, now)
 	}
 
+	// Team canon: the verification-earned trusted tier (.agents/canon/learnings/).
+	// Appended after global so its entries dedupe against everything already
+	// collected, then boosted at ranking time (see applyCanonLearningWeight) —
+	// canon is earned/trusted knowledge, not penalized like the global mirror.
+	if canonPath := filepath.Join(cwd, canonLearningsDir); dirExists(canonPath) {
+		localPaths, localTitles, localContentHashes := localLearningDedupeSets(files, learnings)
+		learnings = appendCanonLearnings(learnings, canonPath, localPaths, localTitles, localContentHashes, tokens, now)
+	}
+
 	if len(learnings) == 0 {
 		return nil, nil
 	}
 
 	rankLearnings(learnings)
 	applyGlobalLearningWeight(learnings, globalWeight)
+	applyCanonLearningWeight(learnings, canonInjectWeight)
 
 	return limitCollectedLearnings(learnings, limit), nil
+}
+
+// canonLearningsDir is the repo-relative path to the team canon tier, derived
+// from the canon.go constants so the two never drift.
+var canonLearningsDir = filepath.Join(canonDir, canonLearnings)
+
+// canonInjectWeight boosts canon (verification-earned) learnings at ranking
+// time. >1.0 because the team canon is the trusted tier; a local TIL should not
+// outrank knowledge an engineer independently verified.
+const canonInjectWeight = 1.15
+
+// appendCanonLearnings adds team-canon learnings, deduped against everything
+// already collected (path, title, content-hash) exactly like the global tier.
+func appendCanonLearnings(learnings []learning, canonDir string, localPaths, localTitles, localContentHashes map[string]bool, tokens []string, now time.Time) []learning {
+	for _, file := range globLearningFiles(canonDir) {
+		if globalLearningDuplicate(file, localPaths) {
+			continue
+		}
+		l, ok := processLearningFile(file, tokens, now)
+		if !ok {
+			continue
+		}
+		if l.Title != "" && localTitles[strings.ToLower(l.Title)] {
+			continue
+		}
+		contentHash := learningDedupContentHash(l)
+		if contentHash != "" && localContentHashes[contentHash] {
+			continue
+		}
+		if contentHash != "" {
+			localContentHashes[contentHash] = true
+		}
+		l.Canon = true
+		learnings = append(learnings, l)
+	}
+	return learnings
+}
+
+// applyCanonLearningWeight scales the composite score of canon learnings by
+// canonWeight and re-sorts. Unlike the global weight (a <1 penalty), this is a
+// boost (>1): canon is the verification-earned trusted tier.
+func applyCanonLearningWeight(learnings []learning, canonWeight float64) {
+	if canonWeight == 1.0 || canonWeight <= 0 {
+		return
+	}
+	for i := range learnings {
+		if learnings[i].Canon {
+			learnings[i].CompositeScore *= canonWeight
+		}
+	}
+	slices.SortFunc(learnings, func(a, b learning) int {
+		return cmp.Compare(b.CompositeScore, a.CompositeScore)
+	})
 }
 
 func collectLocalLearnings(files []string, tokens []string, now time.Time) []learning {

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -114,6 +114,77 @@ ao badge [flags]
 
 ---
 
+### `ao canon`
+
+The team-knowledge canon is the trusted set of learnings a team shares.
+
+```
+ao canon [command]
+```
+
+**Subcommands:**
+
+#### `ao canon cite`
+
+Record that you used a learning (the 'useful' signal)
+
+```
+ao canon cite <entry-id> [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help             help for cite
+      --path string      path to the learning file (required)
+      --query string     search query that surfaced the learning
+      --session string   session ID
+```
+
+#### `ao canon promote`
+
+Promote an earned learning into the team canon
+
+```
+ao canon promote <entry-id> [flags]
+```
+
+**Flags:**
+
+```
+      --force         promote despite an unmet gate (records the override loudly)
+  -h, --help          help for promote
+      --path string   path to the learning file (required)
+```
+
+#### `ao canon status`
+
+Show promotion eligibility for one or all tracked entries
+
+```
+ao canon status [entry-id] [flags]
+```
+
+#### `ao canon verify`
+
+Record that you independently checked a learning and whether it holds.
+
+```
+ao canon verify <entry-id> [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help             help for verify
+      --method string    how it was checked: manual|ao-verify|council|cross-model (default "manual")
+      --path string      path to the learning file (required)
+      --receipt string   evidence you independently gathered (gate log, file:line, hash)
+      --verdict string   confirmed|refuted (default "confirmed")
+```
+
+---
+
 ### `ao capabilities`
 
 Print the machine-readable contract for the whole ao CLI as JSON.

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -135,6 +135,7 @@ ao canon cite <entry-id> [flags]
 **Flags:**
 
 ```
+      --as string        acting actor override ("Name" or "Name <email>"); else AGENTOPS_ACTOR / git
   -h, --help             help for cite
       --path string      path to the learning file (required)
       --query string     search query that surfaced the learning
@@ -176,6 +177,7 @@ ao canon verify <entry-id> [flags]
 **Flags:**
 
 ```
+      --as string        acting actor override ("Name" or "Name <email>"); else AGENTOPS_ACTOR / git
   -h, --help             help for verify
       --method string    how it was checked: manual|ao-verify|council|cross-model (default "manual")
       --path string      path to the learning file (required)

--- a/cli/internal/canon/canon.go
+++ b/cli/internal/canon/canon.go
@@ -56,9 +56,10 @@ func (i Identity) SameAs(other Identity) bool {
 	return strings.EqualFold(in, on)
 }
 
-// CurrentIdentity resolves the acting engineer from git config, falling back to
-// the OS user for the name when git is unconfigured.
-func CurrentIdentity() Identity {
+// gitIdentity resolves an identity from git config, falling back to the OS user
+// for the name when git is unconfigured. It is the lowest-precedence tier of
+// ResolveIdentity — the human fallback.
+func gitIdentity() Identity {
 	id := Identity{}
 	if out, err := exec.Command("git", "config", "user.name").Output(); err == nil {
 		id.Name = strings.TrimSpace(string(out))

--- a/cli/internal/canon/canon.go
+++ b/cli/internal/canon/canon.go
@@ -1,0 +1,114 @@
+// practices: [ddd-bounded-context, knowledge-flywheel]
+
+// Package canon implements the team-knowledge canon: the trusted set of
+// learnings a team shares, where an entry is *earned* into canon rather than
+// self-asserted.
+//
+// The moat thesis (ACFS deep dive, 2026-05-31): "reliability is a property of
+// the system, not the model" → the defensible asset is curated knowledge
+// earned by verification, not self-certification. A single engineer's
+// .agents/learnings/ are provisional; an entry becomes team canon only when it
+// is independently attested to by someone other than its author.
+//
+// Promotion is gated on TWO independent signals, and the same
+// anti-self-certification rule applies to both:
+//
+//   - Citation     — another engineer used the knowledge (proves it is useful).
+//   - Verification — another engineer independently checked that it holds
+//     (proves it is true).
+//
+// An attestation made by the entry's own author never counts toward promotion.
+// This generalizes the self-citation guard to every promotion signal: the
+// factory may not grade its own homework.
+package canon
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Identity is an engineer's attribution as recorded by git.
+type Identity struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+// IsZero reports whether the identity carries no usable attribution.
+func (i Identity) IsZero() bool {
+	return strings.TrimSpace(i.Name) == "" && strings.TrimSpace(i.Email) == ""
+}
+
+// SameAs reports whether two identities denote the same engineer. Email is the
+// strong key (matches when both sides carry a non-empty, equal email);
+// otherwise it falls back to an exact, case-insensitive name match. Two zero
+// identities are NOT considered the same engineer — absent attribution must
+// never silently satisfy the cross-engineer guard.
+func (i Identity) SameAs(other Identity) bool {
+	ie, oe := strings.TrimSpace(i.Email), strings.TrimSpace(other.Email)
+	if ie != "" && oe != "" {
+		return strings.EqualFold(ie, oe)
+	}
+	in, on := strings.TrimSpace(i.Name), strings.TrimSpace(other.Name)
+	if in == "" || on == "" {
+		return false
+	}
+	return strings.EqualFold(in, on)
+}
+
+// CurrentIdentity resolves the acting engineer from git config, falling back to
+// the OS user for the name when git is unconfigured.
+func CurrentIdentity() Identity {
+	id := Identity{}
+	if out, err := exec.Command("git", "config", "user.name").Output(); err == nil {
+		id.Name = strings.TrimSpace(string(out))
+	}
+	if out, err := exec.Command("git", "config", "user.email").Output(); err == nil {
+		id.Email = strings.TrimSpace(string(out))
+	}
+	if id.Name == "" {
+		if u := os.Getenv("USER"); u != "" {
+			id.Name = u
+		} else if u := os.Getenv("USERNAME"); u != "" {
+			id.Name = u
+		}
+	}
+	return id
+}
+
+// AuthorOf extracts the author identity from a learning file's YAML
+// frontmatter (author: / author_email: keys). A missing file or absent keys
+// yields a zero Identity, which by SameAs semantics can never satisfy the
+// cross-engineer guard — an unattributed entry cannot be promoted.
+func AuthorOf(path string) Identity {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return Identity{}
+	}
+	id := Identity{}
+	inFrontmatter := false
+	for _, line := range strings.Split(string(content), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "---" {
+			if !inFrontmatter {
+				inFrontmatter = true
+				continue
+			}
+			break // end of frontmatter
+		}
+		if !inFrontmatter {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(trimmed, "author_email:"):
+			id.Email = unquote(strings.TrimSpace(strings.TrimPrefix(trimmed, "author_email:")))
+		case strings.HasPrefix(trimmed, "author:"):
+			id.Name = unquote(strings.TrimSpace(strings.TrimPrefix(trimmed, "author:")))
+		}
+	}
+	return id
+}
+
+func unquote(s string) string {
+	return strings.Trim(s, "\"'")
+}

--- a/cli/internal/canon/canon_test.go
+++ b/cli/internal/canon/canon_test.go
@@ -1,0 +1,217 @@
+package canon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeLearning creates a learning file with the given author frontmatter and
+// returns its path.
+func writeLearning(t *testing.T, dir, name, authorName, authorEmail string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	content := "---\nauthor: " + authorName + "\nauthor_email: " + authorEmail + "\n---\n\nbody\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write learning: %v", err)
+	}
+	return path
+}
+
+var (
+	alice = Identity{Name: "Alice", Email: "alice@example.com"}
+	bob   = Identity{Name: "Bob", Email: "bob@example.com"}
+	carol = Identity{Name: "Carol", Email: "carol@example.com"}
+	clock = time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+)
+
+func TestIdentitySameAs(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b Identity
+		want bool
+	}{
+		{"same email", Identity{"Alice", "a@x.com"}, Identity{"Different", "a@x.com"}, true},
+		{"email case-insensitive", Identity{"A", "A@X.com"}, Identity{"B", "a@x.com"}, true},
+		{"different email", alice, bob, false},
+		{"name match when no email", Identity{Name: "Alice"}, Identity{Name: "alice"}, true},
+		{"two zero identities are not the same", Identity{}, Identity{}, false},
+		{"zero vs named is not the same", Identity{}, alice, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.a.SameAs(tt.b); got != tt.want {
+				t.Errorf("SameAs = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAuthorOf(t *testing.T) {
+	dir := t.TempDir()
+	path := writeLearning(t, dir, "l.md", "Alice", "alice@example.com")
+	got := AuthorOf(path)
+	if !got.SameAs(alice) {
+		t.Errorf("AuthorOf = %+v, want Alice", got)
+	}
+	if missing := AuthorOf(filepath.Join(dir, "nope.md")); !missing.IsZero() {
+		t.Errorf("AuthorOf(missing) = %+v, want zero", missing)
+	}
+}
+
+// TestEarnedPromotion is the load-bearing L2 test: it drives the full gate
+// across the realistic lifecycle and asserts the exact eligibility at each step.
+func TestEarnedPromotion(t *testing.T) {
+	dir := t.TempDir()
+	entry := writeLearning(t, dir, "til.md", "Alice", "alice@example.com")
+	cl := NewCitationLedger(filepath.Join(dir, "citations.jsonl"))
+	vl := NewVerificationLedger(filepath.Join(dir, "verifications.jsonl"))
+	gate := DefaultGate()
+
+	mustEval := func() Decision {
+		t.Helper()
+		d, err := gate.Evaluate("til", cl, vl)
+		if err != nil {
+			t.Fatalf("evaluate: %v", err)
+		}
+		return d
+	}
+
+	// Step 0: nothing recorded → not eligible, both signals missing.
+	if d := mustEval(); d.Eligible || len(d.Unmet) != 2 {
+		t.Fatalf("fresh entry: eligible=%v unmet=%v, want not-eligible with 2 unmet", d.Eligible, d.Unmet)
+	}
+
+	// Step 1: the AUTHOR cites and verifies her own entry. Self-attestations
+	// must not move the gate at all.
+	if _, err := cl.Record("til", entry, "q", "s1", alice, clock); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := vl.Record("til", entry, "manual", "ran it", VerdictConfirmed, alice, clock); err != nil {
+		t.Fatal(err)
+	}
+	if d := mustEval(); d.Eligible || d.Citations != 0 || d.Verifications != 0 {
+		t.Fatalf("self-attestation counted: %+v, want citations=0 verifications=0 not-eligible", d)
+	}
+
+	// Step 2: Bob cites it (useful) but no independent verification yet.
+	if _, err := cl.Record("til", entry, "q", "s2", bob, clock); err != nil {
+		t.Fatal(err)
+	}
+	if d := mustEval(); d.Eligible || d.Citations != 1 || d.Verifications != 0 {
+		t.Fatalf("citation-only: %+v, want citations=1 verifications=0 not-eligible", d)
+	}
+
+	// Step 3: Carol independently confirms it → both signals present → earned.
+	if _, err := vl.Record("til", entry, "ao-verify", "gate.log:L42", VerdictConfirmed, carol, clock); err != nil {
+		t.Fatal(err)
+	}
+	if d := mustEval(); !d.Eligible || d.Citations != 1 || d.Verifications != 1 {
+		t.Fatalf("earned: %+v, want citations=1 verifications=1 eligible", d)
+	}
+}
+
+func TestRefutationHardBlocks(t *testing.T) {
+	dir := t.TempDir()
+	entry := writeLearning(t, dir, "bad.md", "Alice", "alice@example.com")
+	cl := NewCitationLedger(filepath.Join(dir, "c.jsonl"))
+	vl := NewVerificationLedger(filepath.Join(dir, "v.jsonl"))
+
+	// Plenty of citations and a confirmation — would otherwise pass.
+	if _, err := cl.Record("bad", entry, "", "", bob, clock); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := vl.Record("bad", entry, "manual", "r", VerdictConfirmed, carol, clock); err != nil {
+		t.Fatal(err)
+	}
+	// But Bob independently refutes it.
+	if _, err := vl.Record("bad", entry, "manual", "found counterexample", VerdictRefuted, bob, clock); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := DefaultGate().Evaluate("bad", cl, vl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Eligible || !d.Refuted {
+		t.Errorf("refuted entry: eligible=%v refuted=%v, want not-eligible refuted", d.Eligible, d.Refuted)
+	}
+}
+
+func TestDistinctEngineersRequired(t *testing.T) {
+	dir := t.TempDir()
+	entry := writeLearning(t, dir, "l.md", "Alice", "alice@example.com")
+	cl := NewCitationLedger(filepath.Join(dir, "c.jsonl"))
+
+	// Bob cites three times from different sessions — still ONE engineer.
+	for _, s := range []string{"s1", "s2", "s3"} {
+		if _, err := cl.Record("e", entry, "q", s, bob, clock); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := cl.CrossEngineerCitations("e")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 1 {
+		t.Errorf("CrossEngineerCitations = %d, want 1 (same engineer cannot stack)", got)
+	}
+}
+
+func TestRequireReceipt(t *testing.T) {
+	dir := t.TempDir()
+	entry := writeLearning(t, dir, "l.md", "Alice", "alice@example.com")
+	vl := NewVerificationLedger(filepath.Join(dir, "v.jsonl"))
+
+	// Bob confirms WITHOUT a receipt; Carol confirms WITH one.
+	if _, err := vl.Record("e", entry, "manual", "", VerdictConfirmed, bob, clock); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := vl.Record("e", entry, "ao-verify", "gate.log:L9", VerdictConfirmed, carol, clock); err != nil {
+		t.Fatal(err)
+	}
+
+	lenient, err := vl.IndependentConfirmations("e", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lenient != 2 {
+		t.Errorf("lenient confirmations = %d, want 2", lenient)
+	}
+	strict, err := vl.IndependentConfirmations("e", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strict != 1 {
+		t.Errorf("receipt-required confirmations = %d, want 1 (Bob's unreceipted dropped)", strict)
+	}
+}
+
+func TestLedgerSurvivesMalformedLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "c.jsonl")
+	entry := writeLearning(t, dir, "l.md", "Alice", "alice@example.com")
+	cl := NewCitationLedger(path)
+	if _, err := cl.Record("e", entry, "q", "s", bob, clock); err != nil {
+		t.Fatal(err)
+	}
+	// Corrupt the ledger with a junk line, then append a good one.
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString("{ this is not json\n")
+	f.Close()
+	if _, err := cl.Record("e", entry, "q", "s", carol, clock); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := cl.CrossEngineerCitations("e")
+	if err != nil {
+		t.Fatalf("load after corruption: %v", err)
+	}
+	if got != 2 {
+		t.Errorf("CrossEngineerCitations = %d, want 2 (malformed line skipped, good ones kept)", got)
+	}
+}

--- a/cli/internal/canon/citation.go
+++ b/cli/internal/canon/citation.go
@@ -1,0 +1,107 @@
+// practices: [ddd-bounded-context, knowledge-flywheel]
+
+package canon
+
+import (
+	"time"
+)
+
+// Citation records that an engineer used a learning — surfaced it during work
+// and applied it. It is the "useful" signal: someone other than the author got
+// value from the knowledge.
+//
+// Adapted from the warmind prototype (Doug Dan, PR #671): the load-bearing
+// field is Self, which marks citations by the entry's own author so the
+// promotion gate can exclude them.
+type Citation struct {
+	EntryID   string    `json:"entry_id"`
+	Path      string    `json:"path"`
+	By        Identity  `json:"by"`
+	At        time.Time `json:"at"`
+	Query     string    `json:"query,omitempty"`
+	SessionID string    `json:"session_id,omitempty"`
+	// Self is true when the citing engineer authored the entry. Self-citations
+	// are recorded for provenance but never count toward promotion.
+	Self bool `json:"self"`
+}
+
+// CitationLedger is the append-only JSONL record of citation events.
+type CitationLedger struct{ *ledger[Citation] }
+
+// NewCitationLedger opens (without creating) the citation ledger at path.
+func NewCitationLedger(path string) *CitationLedger {
+	return &CitationLedger{newLedger[Citation](path)}
+}
+
+// Record appends a citation for entryID at path by the current engineer,
+// stamping Self by comparing the citer against the entry's author. The clock
+// is injected so callers (and tests) control timestamps.
+func (l *CitationLedger) Record(entryID, path, query, sessionID string, by Identity, now time.Time) (Citation, error) {
+	c := Citation{
+		EntryID:   entryID,
+		Path:      path,
+		By:        by,
+		At:        now,
+		Query:     query,
+		SessionID: sessionID,
+		Self:      by.SameAs(AuthorOf(path)),
+	}
+	return c, l.append(c)
+}
+
+// ForEntry returns every citation recorded against entryID.
+func (l *CitationLedger) ForEntry(entryID string) ([]Citation, error) {
+	all, err := l.load()
+	if err != nil {
+		return nil, err
+	}
+	var out []Citation
+	for _, c := range all {
+		if c.EntryID == entryID {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
+// CrossEngineerCitations counts distinct non-author engineers who cited
+// entryID. Distinctness uses Identity.SameAs so the same person citing twice
+// (or from two workspaces) cannot manufacture promotion eligibility.
+func (l *CitationLedger) CrossEngineerCitations(entryID string) (int, error) {
+	cites, err := l.ForEntry(entryID)
+	if err != nil {
+		return 0, err
+	}
+	var distinct []Identity
+	for _, c := range cites {
+		if c.Self {
+			continue
+		}
+		if !containsIdentity(distinct, c.By) {
+			distinct = append(distinct, c.By)
+		}
+	}
+	return len(distinct), nil
+}
+
+// AllEntryIDs returns the distinct entry IDs that appear in the citation ledger.
+func (l *CitationLedger) AllEntryIDs() ([]string, error) {
+	all, err := l.load()
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(all))
+	for _, c := range all {
+		ids = append(ids, c.EntryID)
+	}
+	return distinctStrings(ids), nil
+}
+
+func containsIdentity(ids []Identity, target Identity) bool {
+	for _, id := range ids {
+		if id.SameAs(target) {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/canon/identity.go
+++ b/cli/internal/canon/identity.go
@@ -1,0 +1,79 @@
+// practices: [hexagonal-architecture, ddd-bounded-context]
+
+package canon
+
+import (
+	"os"
+	"strings"
+)
+
+// Environment variables through which an orchestrator injects the acting
+// actor's identity. The orchestrator (gc/ntm) sets these at agent spawn time,
+// sourcing the value from the fleet's agent registry (e.g. Agent Mail
+// `whois`/`register_agent`). This keeps `ao` decoupled from any MCP/session
+// protocol: the registry is the source of truth, the env var is the transport.
+const (
+	envActor      = "AGENTOPS_ACTOR"       // "Name" or "Name <email>"
+	envActorEmail = "AGENTOPS_ACTOR_EMAIL" // optional explicit email
+)
+
+// IdentitySource records which tier of the resolution chain produced an
+// identity, so the CLI can show it (the guard is only as trustworthy as the
+// attribution behind it — surfacing the source makes a weak one visible).
+type IdentitySource string
+
+const (
+	SourceExplicit IdentitySource = "explicit" // --as flag / scripted override
+	SourceEnv      IdentitySource = "env"      // AGENTOPS_ACTOR, set by the orchestrator
+	SourceGit      IdentitySource = "git"      // git config (human fallback)
+)
+
+// ResolveIdentity resolves the acting actor (human OR agent) by precedence:
+//
+//  1. explicit  — an --as override passed by the caller
+//  2. env        — AGENTOPS_ACTOR, set by the orchestrator from the agent registry
+//  3. git        — git config user.name/email (the human fallback)
+//
+// The env tier is how a distinct AGENT identity reaches the CLI: a swarm
+// orchestrator that already knows each agent's identity exports it at spawn.
+// Without it, every agent on one box would attribute to the same git user and
+// the cross-actor promotion guard would collapse. The guard defends against
+// *accidental* self-certification, not malicious impersonation — a stronger
+// (signed) tier is a later concern, not this one.
+func ResolveIdentity(explicit string) (Identity, IdentitySource) {
+	if id, ok := parseActor(explicit); ok {
+		return id, SourceExplicit
+	}
+	if id, ok := parseActor(os.Getenv(envActor)); ok {
+		if id.Email == "" {
+			if email := strings.TrimSpace(os.Getenv(envActorEmail)); email != "" {
+				id.Email = email
+			}
+		}
+		return id, SourceEnv
+	}
+	return gitIdentity(), SourceGit
+}
+
+// CurrentIdentity resolves the acting actor with no explicit override (env then
+// git). Preserved as the zero-argument entry point for callers that do not
+// expose an --as flag.
+func CurrentIdentity() Identity {
+	id, _ := ResolveIdentity("")
+	return id
+}
+
+// parseActor parses an actor spec in either "Name <email>" or "Name" form,
+// returning ok=false for an empty/whitespace spec.
+func parseActor(spec string) (Identity, bool) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return Identity{}, false
+	}
+	if open := strings.LastIndex(spec, "<"); open >= 0 && strings.HasSuffix(spec, ">") {
+		name := strings.TrimSpace(spec[:open])
+		email := strings.TrimSpace(spec[open+1 : len(spec)-1])
+		return Identity{Name: name, Email: email}, true
+	}
+	return Identity{Name: spec}, true
+}

--- a/cli/internal/canon/identity_test.go
+++ b/cli/internal/canon/identity_test.go
@@ -1,0 +1,92 @@
+package canon
+
+import "testing"
+
+func TestParseActor(t *testing.T) {
+	tests := []struct {
+		name      string
+		spec      string
+		wantName  string
+		wantEmail string
+		wantOK    bool
+	}{
+		{"empty", "", "", "", false},
+		{"whitespace", "   ", "", "", false},
+		{"name only", "apollo", "apollo", "", true},
+		{"name and email", "apollo <apollo@fleet>", "apollo", "apollo@fleet", true},
+		{"name with spaces and email", "Apollo Agent <a@x.com>", "Apollo Agent", "a@x.com", true},
+		{"angle without close is name", "apollo <oops", "apollo <oops", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, ok := parseActor(tt.spec)
+			if ok != tt.wantOK || id.Name != tt.wantName || id.Email != tt.wantEmail {
+				t.Errorf("parseActor(%q) = (%+v, %v), want ({%q %q}, %v)", tt.spec, id, ok, tt.wantName, tt.wantEmail, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestResolveIdentityPrecedence(t *testing.T) {
+	// Explicit beats env beats git.
+	t.Setenv(envActor, "envagent <env@x>")
+	t.Setenv(envActorEmail, "")
+
+	id, src := ResolveIdentity("explicitagent <ex@x>")
+	if src != SourceExplicit || id.Name != "explicitagent" || id.Email != "ex@x" {
+		t.Errorf("explicit override = (%+v, %s), want explicitagent/ex@x/explicit", id, src)
+	}
+
+	id, src = ResolveIdentity("")
+	if src != SourceEnv || id.Name != "envagent" || id.Email != "env@x" {
+		t.Errorf("env tier = (%+v, %s), want envagent/env@x/env", id, src)
+	}
+}
+
+func TestResolveIdentityEnvEmailSupplements(t *testing.T) {
+	t.Setenv(envActor, "witness") // no inline email
+	t.Setenv(envActorEmail, "witness@fleet")
+	id, src := ResolveIdentity("")
+	if src != SourceEnv || id.Name != "witness" || id.Email != "witness@fleet" {
+		t.Errorf("env + email supplement = (%+v, %s), want witness/witness@fleet/env", id, src)
+	}
+}
+
+// TestCrossAgentGuard is the load-bearing test: distinct agent identities,
+// injected via AGENTOPS_ACTOR, satisfy the cross-actor guard, while an agent
+// attesting its own authored entry does not.
+func TestCrossAgentGuard(t *testing.T) {
+	dir := t.TempDir()
+	// Entry authored by agent "apollo".
+	entry := writeLearning(t, dir, "l.md", "apollo", "apollo@fleet")
+	cl := NewCitationLedger(joinTmp(dir, "c.jsonl"))
+	vl := NewVerificationLedger(joinTmp(dir, "v.jsonl"))
+
+	apollo := Identity{Name: "apollo", Email: "apollo@fleet"}
+	witness := Identity{Name: "witness", Email: "witness@fleet"}
+
+	// apollo (author) cites + verifies its own work → self, must not count.
+	if _, err := cl.Record("e", entry, "", "", apollo, clock); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := vl.Record("e", entry, "manual", "r", VerdictConfirmed, apollo, clock); err != nil {
+		t.Fatal(err)
+	}
+	// witness (a different agent) cites + verifies → counts.
+	if _, err := cl.Record("e", entry, "", "", witness, clock); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := vl.Record("e", entry, "council", "gate.log:L1", VerdictConfirmed, witness, clock); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := DefaultGate().Evaluate("e", cl, vl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.Eligible || d.Citations != 1 || d.Verifications != 1 {
+		t.Errorf("cross-agent attestation: %+v, want citations=1 verifications=1 eligible (apollo's self-attestations excluded)", d)
+	}
+}
+
+func joinTmp(dir, name string) string { return dir + "/" + name }

--- a/cli/internal/canon/ledger.go
+++ b/cli/internal/canon/ledger.go
@@ -1,0 +1,90 @@
+// practices: [ddd-bounded-context, evidence-ledger]
+
+package canon
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ledger is an append-only JSONL store of attestation records of type T
+// (citations, verifications). It mirrors the .agents/ao/citations.jsonl
+// convention: one JSON object per line, malformed lines skipped on read so a
+// single corrupt record can never strand the whole ledger.
+type ledger[T any] struct {
+	path string
+}
+
+func newLedger[T any](path string) *ledger[T] {
+	return &ledger[T]{path: path}
+}
+
+// append writes one record as a JSON line, creating the parent directory and
+// file on first write.
+func (l *ledger[T]) append(record T) error {
+	if err := os.MkdirAll(filepath.Dir(l.path), 0o755); err != nil {
+		return fmt.Errorf("create ledger dir: %w", err)
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("marshal record: %w", err)
+	}
+	f, err := os.OpenFile(l.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open ledger: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("write record: %w", err)
+	}
+	return nil
+}
+
+// distinctStrings returns the input with duplicates removed, preserving first-
+// seen order.
+func distinctStrings(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// load replays every record. A missing ledger is an empty ledger, not an error.
+func (l *ledger[T]) load() ([]T, error) {
+	f, err := os.Open(l.path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("open ledger: %w", err)
+	}
+	defer f.Close()
+
+	var out []T
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var record T
+		if err := json.Unmarshal(line, &record); err != nil {
+			continue // skip malformed line; do not strand the ledger
+		}
+		out = append(out, record)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan ledger: %w", err)
+	}
+	return out, nil
+}

--- a/cli/internal/canon/promote.go
+++ b/cli/internal/canon/promote.go
@@ -1,0 +1,76 @@
+// practices: [ddd-bounded-context, anti-self-certification]
+
+package canon
+
+import "fmt"
+
+// Gate is the earned-promotion policy. An entry joins the team canon only when
+// it clears every requirement. Defaults encode the thesis minimum: at least one
+// cross-engineer citation AND at least one independent confirmation.
+type Gate struct {
+	// MinCitations is the required count of distinct non-author engineers who
+	// cited the entry (proves useful).
+	MinCitations int
+	// MinVerifications is the required count of distinct non-author engineers
+	// who confirmed the entry (proves checked-true).
+	MinVerifications int
+	// RequireReceipt, when set, counts only verifications whose verifier
+	// recorded the evidence they independently gathered.
+	RequireReceipt bool
+}
+
+// DefaultGate is the thesis minimum: one of each independent signal.
+func DefaultGate() Gate {
+	return Gate{MinCitations: 1, MinVerifications: 1, RequireReceipt: false}
+}
+
+// Decision is the gate's verdict for one entry, with the reasons any
+// requirement was unmet so the CLI can tell an engineer exactly what is missing.
+type Decision struct {
+	EntryID       string   `json:"entry_id"`
+	Eligible      bool     `json:"eligible"`
+	Citations     int      `json:"citations"`
+	Verifications int      `json:"verifications"`
+	Refuted       bool     `json:"refuted"`
+	Unmet         []string `json:"unmet,omitempty"`
+}
+
+// Evaluate decides whether entryID may be promoted under this gate, reading the
+// two ledgers. An independent refutation is a hard block: a refuted entry is
+// never eligible, regardless of how many citations or confirmations it carries.
+func (g Gate) Evaluate(entryID string, cl *CitationLedger, vl *VerificationLedger) (Decision, error) {
+	cites, err := cl.CrossEngineerCitations(entryID)
+	if err != nil {
+		return Decision{}, fmt.Errorf("count citations: %w", err)
+	}
+	confs, err := vl.IndependentConfirmations(entryID, g.RequireReceipt)
+	if err != nil {
+		return Decision{}, fmt.Errorf("count verifications: %w", err)
+	}
+	refuted, err := vl.Refuted(entryID)
+	if err != nil {
+		return Decision{}, fmt.Errorf("check refutation: %w", err)
+	}
+
+	d := Decision{
+		EntryID:       entryID,
+		Citations:     cites,
+		Verifications: confs,
+		Refuted:       refuted,
+	}
+	if refuted {
+		d.Unmet = append(d.Unmet, "independently refuted — cannot be promoted")
+	}
+	if cites < g.MinCitations {
+		d.Unmet = append(d.Unmet, fmt.Sprintf("needs %d cross-engineer citation(s), has %d", g.MinCitations, cites))
+	}
+	if confs < g.MinVerifications {
+		receipt := ""
+		if g.RequireReceipt {
+			receipt = " with receipt"
+		}
+		d.Unmet = append(d.Unmet, fmt.Sprintf("needs %d independent confirmation(s)%s, has %d", g.MinVerifications, receipt, confs))
+	}
+	d.Eligible = len(d.Unmet) == 0
+	return d, nil
+}

--- a/cli/internal/canon/verification.go
+++ b/cli/internal/canon/verification.go
@@ -1,0 +1,137 @@
+// practices: [ddd-bounded-context, mechanical-verify-before-judgment]
+
+package canon
+
+import (
+	"time"
+)
+
+// Verdict is the outcome of an independent check of a learning.
+type Verdict string
+
+const (
+	// VerdictConfirmed means the verifier independently checked the learning
+	// and it holds.
+	VerdictConfirmed Verdict = "confirmed"
+	// VerdictRefuted means the verifier independently checked the learning and
+	// it does NOT hold. A refuted entry must never be promoted.
+	VerdictRefuted Verdict = "refuted"
+)
+
+// Verification records that an engineer independently checked a learning. It is
+// the "true" signal — the part the warmind prototype lacked. Where a citation
+// proves a learning was *useful*, a verification proves it was *checked*.
+//
+// The keystone lesson (acfs council refutation, 2026-05-31): a verification is
+// only independent if the verifier GATHERED ITS OWN EVIDENCE — ran/read the
+// thing and can cite what it actually saw — rather than grading a summary the
+// author wrote. Receipt records that evidence (a path, hash, or gate line the
+// verifier observed). A verification without a receipt is weak by construction;
+// the promotion gate can require one.
+type Verification struct {
+	EntryID string    `json:"entry_id"`
+	Path    string    `json:"path"`
+	By      Identity  `json:"by"`
+	At      time.Time `json:"at"`
+	Verdict Verdict   `json:"verdict"`
+	// Method names how the check was done: "manual", "ao-verify", "council",
+	// "cross-model". Free-form; informational.
+	Method string `json:"method,omitempty"`
+	// Receipt is the evidence the verifier independently gathered (e.g. a gate
+	// log path, an evidence hash, a file:line they read). Empty = unreceipted.
+	Receipt string `json:"receipt,omitempty"`
+	// Self is true when the verifying engineer authored the entry.
+	// Self-verifications are recorded for provenance but never count toward
+	// promotion — the anti-self-certification rule applied to verification.
+	Self bool `json:"self"`
+}
+
+// VerificationLedger is the append-only JSONL record of verification events.
+type VerificationLedger struct{ *ledger[Verification] }
+
+// NewVerificationLedger opens (without creating) the verification ledger at path.
+func NewVerificationLedger(path string) *VerificationLedger {
+	return &VerificationLedger{newLedger[Verification](path)}
+}
+
+// Record appends a verification for entryID at path by the current engineer,
+// stamping Self by comparing the verifier against the entry's author.
+func (l *VerificationLedger) Record(entryID, path, method, receipt string, verdict Verdict, by Identity, now time.Time) (Verification, error) {
+	v := Verification{
+		EntryID: entryID,
+		Path:    path,
+		By:      by,
+		At:      now,
+		Verdict: verdict,
+		Method:  method,
+		Receipt: receipt,
+		Self:    by.SameAs(AuthorOf(path)),
+	}
+	return v, l.append(v)
+}
+
+// ForEntry returns every verification recorded against entryID.
+func (l *VerificationLedger) ForEntry(entryID string) ([]Verification, error) {
+	all, err := l.load()
+	if err != nil {
+		return nil, err
+	}
+	var out []Verification
+	for _, v := range all {
+		if v.EntryID == entryID {
+			out = append(out, v)
+		}
+	}
+	return out, nil
+}
+
+// Refuted reports whether any independent (non-self) verifier refuted entryID.
+// A single independent refutation blocks promotion regardless of confirmations.
+func (l *VerificationLedger) Refuted(entryID string) (bool, error) {
+	vers, err := l.ForEntry(entryID)
+	if err != nil {
+		return false, err
+	}
+	for _, v := range vers {
+		if !v.Self && v.Verdict == VerdictRefuted {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// AllEntryIDs returns the distinct entry IDs that appear in the verification ledger.
+func (l *VerificationLedger) AllEntryIDs() ([]string, error) {
+	all, err := l.load()
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(all))
+	for _, v := range all {
+		ids = append(ids, v.EntryID)
+	}
+	return distinctStrings(ids), nil
+}
+
+// IndependentConfirmations counts distinct non-author engineers who confirmed
+// entryID. When requireReceipt is set, only verifications carrying a receipt
+// (evidence the verifier independently gathered) are counted.
+func (l *VerificationLedger) IndependentConfirmations(entryID string, requireReceipt bool) (int, error) {
+	vers, err := l.ForEntry(entryID)
+	if err != nil {
+		return 0, err
+	}
+	var distinct []Identity
+	for _, v := range vers {
+		if v.Self || v.Verdict != VerdictConfirmed {
+			continue
+		}
+		if requireReceipt && v.Receipt == "" {
+			continue
+		}
+		if !containsIdentity(distinct, v.By) {
+			distinct = append(distinct, v.By)
+		}
+	}
+	return len(distinct), nil
+}

--- a/cli/internal/search/types.go
+++ b/cli/internal/search/types.go
@@ -25,6 +25,7 @@ type Learning struct {
 	Stability       string  `json:"-"` // "experimental" | "stable", default "stable"
 	Superseded      bool    `json:"-"` // Internal flag - not serialized
 	Global          bool    `json:"-"` // Internal flag: from global dir
+	Canon           bool    `json:"-"` // Internal flag: from the verification-earned team canon
 }
 
 // Scorable interface implementation for Learning.

--- a/docs/cli-skills-map.md
+++ b/docs/cli-skills-map.md
@@ -2,7 +2,7 @@
 
 > Which `ao` commands are called by which skills and hooks — and vice versa.
 
-Auto-audited 2026-04-24; targeted runtime-proof update 2026-04-28. 75 generated CLI command headings, 69 source skills, 12 runtime hook event sections.
+Auto-audited 2026-04-24; targeted runtime-proof update 2026-04-28. 76 generated CLI command headings, 69 source skills, 12 runtime hook event sections.
 
 Source-of-truth note: `hooks/hooks.json` currently declares the full Claude runtime event surface. `hooks/codex-hooks.json` declares the Codex-native subset that runtime can support.
 

--- a/docs/contracts/agents-write-surfaces.md
+++ b/docs/contracts/agents-write-surfaces.md
@@ -32,6 +32,7 @@ lane must name the intended write path; it cannot be blank or placeholder text.
 | `archive` | persistent | cli | retention-archive | Archived/superseded artifacts with retention metadata |
 | `briefings` | regenerated | scripts | generated-output | Compiled session-start briefings |
 | `candidates` | rolling | cli | candidate-cache | Pre-promotion candidate observations |
+| `canon` | persistent | cli | earned-knowledge | Team-knowledge canon: earned learnings plus the citation/verification attestation ledgers gating promotion |
 | `compiled` | regenerated | cli | generated-output | Compiled wiki output (subset; see `wiki/`) |
 | `config` | persistent | cli, operators | operator-config | Rig identity (project/crew) - read by harvest path-prefix fallback |
 | `constraints` | persistent | cli | generated-policy | Compiled constraint manifests |
@@ -102,6 +103,7 @@ ao
 archive
 briefings
 candidates
+canon
 compiled
 config
 constraints

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=75 sub=188 all=263"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=76 sub=192 all=268"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,4} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "75" || "$sub_count" != "188" || "$all_count" != "263" ]]; then
+if [[ "$top_count" != "76" || "$sub_count" != "192" || "$all_count" != "268" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 263 ]]; then
+if [[ "${#commands[@]}" -ne 268 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/registry.json
+++ b/registry.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-05-31T20:11:38Z",
+  "generated_at": "2026-06-01T04:16:58Z",
   "summary": {
     "skills": 81,
     "hooks": 0,
     "knowledge_stores": 5,
     "job_types": 0,
     "eval_files": 56,
-    "cli_commands": 73,
-    "capabilities": 168
+    "cli_commands": 74,
+    "capabilities": 169
   },
   "surfaces": {
     "skills": [
@@ -822,6 +822,13 @@
         "driven_by_skills": []
       },
       {
+        "name": "ao canon",
+        "path": "cli/cmd/ao/",
+        "purpose": "Team-knowledge canon: learnings earned by independent attestation",
+        "bounded_context": "",
+        "driven_by_skills": []
+      },
+      {
         "name": "ao capabilities",
         "path": "cli/cmd/ao/",
         "purpose": "Print the machine-readable CLI contract (JSON)",
@@ -1435,9 +1442,9 @@
     ]
   },
   "capability_summary": {
-    "total": 168,
+    "total": 169,
     "skills": 81,
-    "cli_commands": 73,
+    "cli_commands": 74,
     "gates": 11,
     "reference_impls": 3
   },
@@ -1448,6 +1455,7 @@
     "autodev",
     "badge",
     "beads",
+    "canon",
     "capabilities",
     "ci",
     "citation",
@@ -3479,6 +3487,23 @@
       "type": "cli-command",
       "bounded_context": "BC3",
       "purpose": "Complementary tooling for the bd (beads) issue tracker",
+      "status": "active",
+      "driven_by_skills": [],
+      "flags": [
+        "--config",
+        "--dry-run",
+        "--json",
+        "--output",
+        "--verbose"
+      ],
+      "path": "cli/cmd/ao/"
+    },
+    {
+      "sku": "cmd:ao.canon",
+      "name": "ao canon",
+      "type": "cli-command",
+      "bounded_context": "",
+      "purpose": "Team-knowledge canon: learnings earned by independent attestation",
       "status": "active",
       "driven_by_skills": [],
       "flags": [


### PR DESCRIPTION
## What

A team-knowledge **canon**: learnings *earned* into a shared trusted set, not self-asserted. Adapts Doug Dan's warmind (#671) to the post-ACFS direction — moat = knowledge earned by verification, not self-certification.

Promotion requires **two independent, self-guarded signals**:
- **citation** — another engineer/agent USED it (proves useful)
- **verification** — another engineer/agent CHECKED it (proves true; receipt-bearing)

An independent refutation hard-blocks. The anti-self-certification guard is generalized to *all* promotion signals: the factory may not grade its own homework.

## Slices (3 commits, one coherent arc)
1. **Earned-promotion gate** — `internal/canon` (identity guard, citation + verification JSONL ledgers, gate); `ao canon cite/verify/status/promote`.
2. **Inject trusted tier** — `collectLearnings` surfaces `.agents/canon/learnings/` deduped + boosted 1.15× over equal-utility local; flagged `Canon`.
3. **IdentityResolver port** — `--as` > `AGENTOPS_ACTOR` env > git. Env tier is the seam to Agent Mail (`whois`) with **no MCP coupling** — `ao` stays portable. Makes the cross-actor guard hold for humans AND agents.

## Deliberately dropped from #671
Resurrected `hooks/` + session-end auto-sync (hookless regression), the "Gas City Dispatch (CRITICAL)" doctrine (contradicts prune-the-coordination-plane), the parallel scoring/maturity engine (duplicated inject primitives), and the "warmind" name.

## Verification
- `go build`/`vet` clean, gofmt clean
- 9,388 tests green (`cmd/ao` + `internal/canon` + `internal/search`)
- e2e: apollo self-attesting excluded; witness (distinct agent via `AGENTOPS_ACTOR`) earns promotion; `ao inject` ranks canon first at equal utility

## Deferred (next)
Wire `verify` → `ao verify`/council (currently operator-attested — the load-bearing gap); tier-aware gate (heuristics earn citation, not verification).

Closes-scenario: ag-bw5s#earned-promotion-gate
Closes-scenario: ag-bw5s#inject-trusted-tier
Closes-scenario: ag-bw5s#agent-identity-resolver
Bounded-context: BC1-Corpus
Evidence: cli/internal/canon/promote.go
