### PR TITLE
docs(canon): credit warmind lineage (ag-bw5s #trivial)

### DIFF
--- a/cli/internal/canon/canon.go
+++ b/cli/internal/canon/canon.go
@@ -20,6 +20,11 @@
 // An attestation made by the entry's own author never counts toward promotion.
 // This generalizes the self-citation guard to every promotion signal: the
 // factory may not grade its own homework.
+//
+// Lineage: adapted from the warmind prototype by Douglas J. Dan (PR #671). The
+// team-knowledge-sharing pipeline, citation-gated promotion, and the
+// self-citation guard originate there; canon re-aims promotion to be earned by
+// independent verification and folds retrieval into the existing inject path.
 package canon
 
 import (


### PR DESCRIPTION
## What

Records canon's lineage: the team-knowledge-sharing pipeline, citation-gated promotion, and the self-citation guard originate in **Douglas J. Dan's warmind prototype (#671)**. Canon adapted them — re-aiming promotion to be earned by independent verification and folding retrieval into the existing `ao inject` path.

Co-authored to Doug so his contribution lands on `main`'s history and contributor graph. #671 stays open for reference.

Closes-scenario: ag-bw5s#earned-promotion-gate
Bounded-context: BC1-Corpus
Evidence: cli/internal/canon/canon.go
