### PR TITLE
feat(canon): verify --council for independent cross-vendor verdicts (ag-mluj #council-verdict-independent)

### DIFF
--- a/cli/cmd/ao/canon.go
+++ b/cli/cmd/ao/canon.go
@@ -102,6 +102,7 @@ func init() {
 	canonVerifyCmd.Flags().String("method", "manual", "how it was checked: manual|ao-verify|council|cross-model")
 	canonVerifyCmd.Flags().String("receipt", "", "evidence you independently gathered (gate log, file:line, hash)")
 	canonVerifyCmd.Flags().String("as", "", "acting actor override (\"Name\" or \"Name <email>\"); else AGENTOPS_ACTOR / git")
+	canonVerifyCmd.Flags().Bool("council", false, "obtain the verdict from an independent cross-vendor judge (cmd: AGENTOPS_CANON_VERIFIER_CMD) instead of asserting it")
 	_ = canonVerifyCmd.MarkFlagRequired("path")
 	canonCmd.AddCommand(canonVerifyCmd)
 
@@ -142,11 +143,17 @@ func runCanonVerify(cmd *cobra.Command, args []string) error {
 	receipt, _ := cmd.Flags().GetString("receipt")
 	verdictStr, _ := cmd.Flags().GetString("verdict")
 	as, _ := cmd.Flags().GetString("as")
+	council, _ := cmd.Flags().GetBool("council")
+	_, vl := canonLedgers(cwd)
+
+	if council {
+		return runCanonCouncilVerify(cmd, args[0], path, vl)
+	}
+
 	verdict := canon.Verdict(verdictStr)
 	if verdict != canon.VerdictConfirmed && verdict != canon.VerdictRefuted {
 		return fmt.Errorf("invalid --verdict %q: want confirmed|refuted", verdictStr)
 	}
-	_, vl := canonLedgers(cwd)
 
 	by, src := canon.ResolveIdentity(as)
 	v, err := vl.Record(args[0], path, method, receipt, verdict, by, time.Now())
@@ -160,6 +167,50 @@ func runCanonVerify(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(cmd.OutOrStdout(), "  note: no --receipt recorded; this is a weak (unreceipted) verification")
 	}
 	return nil
+}
+
+// runCanonCouncilVerify obtains the verdict from an independent cross-vendor
+// judge instead of an operator assertion. The verdict is attributed to the
+// judge (not whoever ran the command), so it counts toward promotion even when
+// the operator authored the learning — independence by construction.
+func runCanonCouncilVerify(cmd *cobra.Command, entryID, path string, vl *canon.VerificationLedger) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read learning %s: %w", path, err)
+	}
+	judgeName := os.Getenv("AGENTOPS_CANON_JUDGE")
+	if judgeName == "" {
+		judgeName = "codex" // the cross-vendor lane in this fleet
+	}
+	verifier := canon.CommandVerifier{
+		Command: os.Getenv("AGENTOPS_CANON_VERIFIER_CMD"),
+		JudgeID: canon.Identity{Name: judgeName},
+	}
+	verdict, judge, evidence, err := verifier.Judge(canon.Claim{EntryID: entryID, Path: path, Content: string(content)})
+	if err != nil {
+		return fmt.Errorf("council verify: %w", err)
+	}
+
+	v, err := vl.Record(entryID, path, "council", truncateReceipt(evidence, 4000), verdict, judge, time.Now())
+	if err != nil {
+		return fmt.Errorf("record verification: %w", err)
+	}
+
+	if GetOutput() == "json" {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+			"kind": "verify", "method": "council", "entry_id": entryID,
+			"verdict": verdict, "judge": judge, "self": v.Self,
+		})
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "recorded council verify(%s) for %s by judge %s [independent cross-vendor]\n", verdict, entryID, judge.Name)
+	return nil
+}
+
+func truncateReceipt(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "\n…[truncated]"
 }
 
 func emitCanonAttestation(w io.Writer, kind, entryID string, by canon.Identity, src canon.IdentitySource, self bool) error {

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -178,6 +178,7 @@ ao canon verify <entry-id> [flags]
 
 ```
       --as string        acting actor override ("Name" or "Name <email>"); else AGENTOPS_ACTOR / git
+      --council          obtain the verdict from an independent cross-vendor judge (cmd: AGENTOPS_CANON_VERIFIER_CMD) instead of asserting it
   -h, --help             help for verify
       --method string    how it was checked: manual|ao-verify|council|cross-model (default "manual")
       --path string      path to the learning file (required)

--- a/cli/internal/canon/verifier.go
+++ b/cli/internal/canon/verifier.go
@@ -1,0 +1,107 @@
+// practices: [mechanical-verify-before-judgment, hexagonal-architecture]
+
+package canon
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// Claim is a learning submitted for independent verification.
+type Claim struct {
+	EntryID string
+	Path    string
+	Content string
+}
+
+// CouncilVerifier produces an independent verdict on a claim. Implementations
+// MUST judge from a different vantage than the author — a cross-vendor model is
+// the canonical case (council's cross-vendor DISAGREE rule). That independence
+// is the whole point: a verdict the author could have produced proves nothing.
+type CouncilVerifier interface {
+	// Judge returns the verdict, the judge's identity (the vendor/model that
+	// ruled), and the evidence it produced — recorded as the verification
+	// receipt so the ruling is auditable, not just asserted.
+	Judge(Claim) (verdict Verdict, judge Identity, evidence string, err error)
+}
+
+// CommandVerifier runs an external judge command — the cross-vendor lane. The
+// command receives the judge prompt on stdin and must print a line matching
+// `VERDICT: confirmed` or `VERDICT: refuted`; its full combined output becomes
+// the receipt. Configurable (codex in production, a fixture in tests) so the
+// vendor is swappable without touching canon and the path is testable offline.
+//
+// Honest scope: this wires the cross-vendor *judgment* lane (council P9). How
+// deeply the judge gathers its own evidence is bounded by what Command does —
+// a codex judge has shell access and can read the cited files; a thin judge
+// only sees the claim text. The receipt records which it was.
+type CommandVerifier struct {
+	// Command is a shell command (run via `sh -c`) that receives the claim
+	// prompt on stdin. Empty Command makes Judge fail loudly rather than
+	// silently fabricating a verdict.
+	Command string
+	// JudgeID attributes the verdict to the cross-vendor judge (e.g. the model
+	// name). It must denote a vantage distinct from any learning author.
+	JudgeID Identity
+}
+
+var verdictPattern = regexp.MustCompile(`(?i)VERDICT:\s*(confirmed|refuted)`)
+
+// Judge runs the configured command over the claim and parses its verdict.
+func (cv CommandVerifier) Judge(c Claim) (Verdict, Identity, string, error) {
+	if strings.TrimSpace(cv.Command) == "" {
+		return "", cv.JudgeID, "", fmt.Errorf("no council verifier command configured (set AGENTOPS_CANON_VERIFIER_CMD, e.g. \"codex exec\")")
+	}
+	cmd := exec.Command("sh", "-c", cv.Command)
+	cmd.Stdin = strings.NewReader(BuildJudgePrompt(c))
+	out, runErr := cmd.CombinedOutput()
+	evidence := strings.TrimSpace(string(out))
+	if runErr != nil {
+		return "", cv.JudgeID, evidence, fmt.Errorf("council verifier command failed: %w", runErr)
+	}
+	verdict, parseErr := ParseVerdict(evidence)
+	if parseErr != nil {
+		return "", cv.JudgeID, evidence, parseErr
+	}
+	return verdict, cv.JudgeID, evidence, nil
+}
+
+// BuildJudgePrompt instructs an independent judge to rule on a learning. It
+// tells the judge to gather its own evidence rather than trust the claim's
+// self-assertion — the anti-self-certification rule applied to the judge.
+func BuildJudgePrompt(c Claim) string {
+	var b strings.Builder
+	b.WriteString("You are an INDEPENDENT verifier judging whether a team learning holds.\n")
+	b.WriteString("Do NOT trust the learning's own assertion. Gather your own evidence — read the\n")
+	b.WriteString("cited files, run the cited commands where you can — then rule.\n\n")
+	if c.Path != "" {
+		b.WriteString("Learning file: " + c.Path + "\n")
+	}
+	b.WriteString("Learning id: " + c.EntryID + "\n\n")
+	b.WriteString("--- learning content ---\n")
+	b.WriteString(c.Content)
+	b.WriteString("\n--- end ---\n\n")
+	b.WriteString("Cite the file:line or command output you actually examined, then end with EXACTLY one line:\n")
+	b.WriteString("VERDICT: confirmed   (if your own evidence supports the learning)\n")
+	b.WriteString("VERDICT: refuted     (if it does not, or you could not corroborate it)\n")
+	return b.String()
+}
+
+// ParseVerdict extracts the VERDICT line from judge output. Absence of a clear
+// verdict is an error — never default to confirmed.
+func ParseVerdict(output string) (Verdict, error) {
+	m := verdictPattern.FindStringSubmatch(output)
+	if m == nil {
+		return "", fmt.Errorf("no VERDICT line in judge output")
+	}
+	switch strings.ToLower(m[1]) {
+	case "confirmed":
+		return VerdictConfirmed, nil
+	case "refuted":
+		return VerdictRefuted, nil
+	default:
+		return "", fmt.Errorf("unrecognized verdict %q", m[1])
+	}
+}

--- a/cli/internal/canon/verifier_test.go
+++ b/cli/internal/canon/verifier_test.go
@@ -1,0 +1,108 @@
+package canon
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseVerdict(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		want    Verdict
+		wantErr bool
+	}{
+		{"confirmed", "checked cli/x.go:42, holds.\nVERDICT: confirmed", VerdictConfirmed, false},
+		{"refuted", "could not reproduce.\nVERDICT: refuted", VerdictRefuted, false},
+		{"case insensitive", "verdict: CONFIRMED", VerdictConfirmed, false},
+		{"no verdict line", "the learning looks fine to me", "", true},
+		{"never defaults to confirmed on absence", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseVerdict(tt.output)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("ParseVerdict = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandVerifier_EmptyCommandFailsLoud(t *testing.T) {
+	cv := CommandVerifier{Command: "", JudgeID: Identity{Name: "codex"}}
+	_, _, _, err := cv.Judge(Claim{EntryID: "e"})
+	if err == nil {
+		t.Fatal("empty command must error, not fabricate a verdict")
+	}
+}
+
+// TestCommandVerifier_Confirmed exercises the real exec+parse path with a
+// fixture judge command standing in for the cross-vendor model.
+func TestCommandVerifier_Confirmed(t *testing.T) {
+	cv := CommandVerifier{
+		Command: `printf 'read cli/internal/canon/promote.go:1; holds.\nVERDICT: confirmed\n'`,
+		JudgeID: Identity{Name: "codex:gpt-5.3", Email: "codex@vendor"},
+	}
+	verdict, judge, evidence, err := cv.Judge(Claim{EntryID: "e", Path: "l.md", Content: "TIL x"})
+	if err != nil {
+		t.Fatalf("Judge: %v", err)
+	}
+	if verdict != VerdictConfirmed {
+		t.Errorf("verdict = %q, want confirmed", verdict)
+	}
+	if !judge.SameAs(Identity{Email: "codex@vendor"}) {
+		t.Errorf("judge = %+v, want the codex vendor identity", judge)
+	}
+	if !strings.Contains(evidence, "promote.go") {
+		t.Errorf("evidence should capture the judge transcript, got %q", evidence)
+	}
+}
+
+func TestCommandVerifier_Refuted(t *testing.T) {
+	cv := CommandVerifier{Command: `echo "no such file; VERDICT: refuted"`, JudgeID: Identity{Name: "codex"}}
+	verdict, _, _, err := cv.Judge(Claim{EntryID: "e"})
+	if err != nil {
+		t.Fatalf("Judge: %v", err)
+	}
+	if verdict != VerdictRefuted {
+		t.Errorf("verdict = %q, want refuted", verdict)
+	}
+}
+
+func TestCommandVerifier_NoVerdictIsError(t *testing.T) {
+	cv := CommandVerifier{Command: `echo "I am not sure, looks plausible"`, JudgeID: Identity{Name: "codex"}}
+	_, _, _, err := cv.Judge(Claim{EntryID: "e"})
+	if err == nil {
+		t.Fatal("judge output without a VERDICT line must error, not pass")
+	}
+}
+
+// TestCouncilVerificationIsIndependent proves a council verdict counts toward
+// promotion even when the operator running it authored the learning — because
+// the verdict is attributed to the cross-vendor judge, not the operator.
+func TestCouncilVerificationIsIndependent(t *testing.T) {
+	dir := t.TempDir()
+	entry := writeLearning(t, dir, "l.md", "Alice", "alice@example.com")
+	vl := NewVerificationLedger(joinTmp(dir, "v.jsonl"))
+
+	judge := Identity{Name: "codex:gpt-5.3", Email: "codex@vendor"}
+	// Alice authored it, but the verdict is the judge's, recorded under the
+	// judge identity → not a self-verification.
+	v, err := vl.Record("e", entry, "council", "judge transcript", VerdictConfirmed, judge, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Self {
+		t.Error("council verdict attributed to the cross-vendor judge must not be self")
+	}
+	confs, err := vl.IndependentConfirmations("e", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if confs != 1 {
+		t.Errorf("IndependentConfirmations = %d, want 1", confs)
+	}
+}


### PR DESCRIPTION
## What

gap#1 — the load-bearing **"earned by verification, not assertion"** gap.

`ao canon verify --council` delegates the verdict to an **independent cross-vendor judge** instead of taking an operator-asserted one:
- `CouncilVerifier` port + `CommandVerifier` adapter, configurable via `AGENTOPS_CANON_VERIFIER_CMD` (codex = the cross-vendor lane in this fleet)
- Verdict is attributed to the **judge**, not whoever ran the command → counts toward promotion even when the author invokes it (independence by construction)
- No judge configured → **loud error**, never fabricates a verdict
- Judge output must carry `VERDICT: confirmed|refuted`; absence is an error (never defaults to confirmed)
- The judge transcript is recorded as the verification **receipt**

## Honest scope

This wires the cross-vendor **judgment** lane (council's P9 cross-vendor rule). How deeply the judge gathers its own evidence is bounded by what the judge command does — a codex judge has shell access and can read cited files; the receipt records what it examined. The full "gather-your-own-evidence" keystone (mo-qz3srw) remains a further step.

## Verification
- 8 new unit tests (verdict parse, empty-cmd-fails-loud, confirmed/refuted exec, no-verdict-errors, council-is-independent); canon package green
- e2e: no judge → loud error; fixture cross-vendor judge → independent `confirmed` attributed to `codex:gpt-5.3`; learning EARNED even when author-invoked
- command-surface canary unchanged (flag, not a new heading)

Closes-scenario: ag-mluj#council-verdict-independent
Bounded-context: BC1-Corpus
Evidence: cli/internal/canon/verifier.go
