### PR TITLE
feat(canon): tier-aware promotion gate (ag-n2r4 #heuristic-earns-on-citations)

### DIFF
--- a/cli/cmd/ao/canon.go
+++ b/cli/cmd/ao/canon.go
@@ -233,7 +233,6 @@ func runCanonStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	cl, vl := canonLedgers(cwd)
-	gate := canon.DefaultGate()
 
 	var ids []string
 	if len(args) == 1 {
@@ -247,7 +246,7 @@ func runCanonStatus(cmd *cobra.Command, args []string) error {
 
 	decisions := make([]canon.Decision, 0, len(ids))
 	for _, id := range ids {
-		d, err := gate.Evaluate(id, cl, vl)
+		d, err := canon.EvaluateEntry(id, canon.EntryPath(id, cl, vl), cl, vl)
 		if err != nil {
 			return err
 		}
@@ -268,7 +267,7 @@ func runCanonStatus(cmd *cobra.Command, args []string) error {
 		if d.Eligible {
 			status = "EARNED "
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "%s %-24s cites=%d verifs=%d\n", status, d.EntryID, d.Citations, d.Verifications)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s %-24s [%s] cites=%d verifs=%d\n", status, d.EntryID, d.Tier, d.Citations, d.Verifications)
 		for _, u := range d.Unmet {
 			fmt.Fprintf(cmd.OutOrStdout(), "          - %s\n", u)
 		}
@@ -286,7 +285,7 @@ func runCanonPromote(cmd *cobra.Command, args []string) error {
 	force, _ := cmd.Flags().GetBool("force")
 
 	cl, vl := canonLedgers(cwd)
-	d, err := canon.DefaultGate().Evaluate(entryID, cl, vl)
+	d, err := canon.EvaluateEntry(entryID, path, cl, vl)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/ao/canon_test.go
+++ b/cli/cmd/ao/canon_test.go
@@ -1,0 +1,56 @@
+// practices: [ddd-bounded-context, knowledge-flywheel]
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/boshu2/agentops/cli/internal/canon"
+	"github.com/spf13/cobra"
+)
+
+// TestRunCanonStatus_TierAware drives the canon status command and asserts the
+// tier-aware gate is surfaced: a heuristic learning earns on 3 cross-engineer
+// citations alone, and the tier is shown.
+func TestRunCanonStatus_TierAware(t *testing.T) {
+	dir := t.TempDir()
+	learnDir := filepath.Join(dir, ".agents", "learnings")
+	if err := os.MkdirAll(learnDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hPath := filepath.Join(learnDir, "h.md")
+	if err := os.WriteFile(hPath, []byte("---\nauthor: Alice\nauthor_email: alice@example.com\ncanon_tier: heuristic\n---\n\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cl, _ := canonLedgers(dir)
+	ts := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	for _, who := range []canon.Identity{
+		{Name: "Bob", Email: "bob@x"},
+		{Name: "Carol", Email: "carol@x"},
+		{Name: "Dave", Email: "dave@x"},
+	} {
+		if _, err := cl.Record("h", hPath, "q", "s", who, ts); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Chdir(dir)
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	if err := runCanonStatus(cmd, []string{"h"}); err != nil {
+		t.Fatalf("runCanonStatus: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "EARNED") {
+		t.Errorf("heuristic with 3 cross-engineer citations should be EARNED; got %q", out)
+	}
+	if !strings.Contains(out, "[heuristic]") {
+		t.Errorf("status should surface the tier; got %q", out)
+	}
+}

--- a/cli/internal/canon/promote.go
+++ b/cli/internal/canon/promote.go
@@ -29,6 +29,7 @@ func DefaultGate() Gate {
 type Decision struct {
 	EntryID       string   `json:"entry_id"`
 	Eligible      bool     `json:"eligible"`
+	Tier          Tier     `json:"tier,omitempty"`
 	Citations     int      `json:"citations"`
 	Verifications int      `json:"verifications"`
 	Refuted       bool     `json:"refuted"`

--- a/cli/internal/canon/tier.go
+++ b/cli/internal/canon/tier.go
@@ -1,0 +1,110 @@
+// practices: [ddd-bounded-context, anti-self-certification]
+
+package canon
+
+import (
+	"os"
+	"strings"
+)
+
+// Tier classifies what KIND of knowledge a learning is, which determines how it
+// can be earned into canon. Not all knowledge is mechanically verifiable: a
+// claim about code or gate output is falsifiable; a judgment call ("prefer X
+// when Y") is not. The gate must not demand verification of the unverifiable —
+// nor let unverifiable claims in on a single citation.
+type Tier string
+
+const (
+	// TierFalsifiable: the learning asserts something checkable against the
+	// codebase, a gate, or a command. It must be independently verified.
+	TierFalsifiable Tier = "falsifiable"
+	// TierHeuristic: judgment/experience that cannot be mechanically checked.
+	// It earns canon on breadth of independent reuse instead of verification.
+	TierHeuristic Tier = "heuristic"
+)
+
+// TierOf reads `canon_tier:` from a learning's YAML frontmatter, defaulting to
+// falsifiable. The default is the STRICTER tier on purpose: heuristic is an
+// explicit opt-out for judgment-only knowledge, so an unmarked learning cannot
+// dodge the verification requirement by omission.
+func TierOf(path string) Tier {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return TierFalsifiable
+	}
+	inFrontmatter := false
+	for _, line := range strings.Split(string(content), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "---" {
+			if !inFrontmatter {
+				inFrontmatter = true
+				continue
+			}
+			break
+		}
+		if !inFrontmatter {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "canon_tier:") {
+			v := unquote(strings.TrimSpace(strings.TrimPrefix(trimmed, "canon_tier:")))
+			if Tier(v) == TierHeuristic {
+				return TierHeuristic
+			}
+			return TierFalsifiable
+		}
+	}
+	return TierFalsifiable
+}
+
+// GateFor returns the promotion policy for a tier:
+//
+//   - falsifiable: 1 cross-engineer citation AND 1 independent verification
+//     (the DefaultGate — useful AND checked-true).
+//   - heuristic:   3 cross-engineer citations, no verification. It cannot be
+//     mechanically checked, so the only honest trust signal is breadth of
+//     independent reuse by other engineers.
+//
+// Refutation hard-blocks both tiers (handled in Evaluate).
+func GateFor(t Tier) Gate {
+	if t == TierHeuristic {
+		return Gate{MinCitations: 3, MinVerifications: 0, RequireReceipt: false}
+	}
+	return DefaultGate()
+}
+
+// EvaluateEntry resolves the entry's tier from its file, picks the tier-aware
+// gate, and evaluates. When path is empty (tier unknown), it falls back to the
+// strict falsifiable gate.
+func EvaluateEntry(entryID, path string, cl *CitationLedger, vl *VerificationLedger) (Decision, error) {
+	tier := TierFalsifiable
+	if path != "" {
+		tier = TierOf(path)
+	}
+	d, err := GateFor(tier).Evaluate(entryID, cl, vl)
+	if err != nil {
+		return d, err
+	}
+	d.Tier = tier
+	return d, nil
+}
+
+// EntryPath returns the learning path recorded for entryID in either ledger
+// (citations first, then verifications), or "" if the entry is untracked. Used
+// by surfaces that have only an entry ID (e.g. `canon status`) to resolve tier.
+func EntryPath(entryID string, cl *CitationLedger, vl *VerificationLedger) string {
+	if cites, err := cl.ForEntry(entryID); err == nil {
+		for _, c := range cites {
+			if c.Path != "" {
+				return c.Path
+			}
+		}
+	}
+	if vers, err := vl.ForEntry(entryID); err == nil {
+		for _, v := range vers {
+			if v.Path != "" {
+				return v.Path
+			}
+		}
+	}
+	return ""
+}

--- a/cli/internal/canon/tier_test.go
+++ b/cli/internal/canon/tier_test.go
@@ -1,0 +1,137 @@
+package canon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTieredLearning(t *testing.T, dir, name, tier string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	fm := "---\nauthor: Alice\nauthor_email: alice@example.com\n"
+	if tier != "" {
+		fm += "canon_tier: " + tier + "\n"
+	}
+	fm += "---\n\nbody\n"
+	if err := os.WriteFile(path, []byte(fm), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestTierOf(t *testing.T) {
+	dir := t.TempDir()
+	tests := []struct {
+		name, tier string
+		want       Tier
+	}{
+		{"explicit heuristic", "heuristic", TierHeuristic},
+		{"explicit falsifiable", "falsifiable", TierFalsifiable},
+		{"unmarked defaults falsifiable", "", TierFalsifiable},
+		{"garbage defaults falsifiable", "banana", TierFalsifiable},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := writeTieredLearning(t, dir, tt.name+".md", tt.tier)
+			if got := TierOf(p); got != tt.want {
+				t.Errorf("TierOf = %q, want %q", got, tt.want)
+			}
+		})
+	}
+	if got := TierOf(filepath.Join(dir, "missing.md")); got != TierFalsifiable {
+		t.Errorf("TierOf(missing) = %q, want falsifiable", got)
+	}
+}
+
+func TestGateForThresholds(t *testing.T) {
+	if g := GateFor(TierFalsifiable); g.MinCitations != 1 || g.MinVerifications != 1 {
+		t.Errorf("falsifiable gate = %+v, want 1 cite / 1 verif", g)
+	}
+	if g := GateFor(TierHeuristic); g.MinCitations != 3 || g.MinVerifications != 0 {
+		t.Errorf("heuristic gate = %+v, want 3 cites / 0 verif", g)
+	}
+}
+
+// TestHeuristicEarnsOnCitationsAlone: a judgment learning can't be verified, so
+// 3 cross-engineer citations (no verification) promote it; 2 do not.
+func TestHeuristicEarnsOnCitationsAlone(t *testing.T) {
+	dir := t.TempDir()
+	entry := writeTieredLearning(t, dir, "h.md", "heuristic")
+	cl := NewCitationLedger(filepath.Join(dir, "c.jsonl"))
+	vl := NewVerificationLedger(filepath.Join(dir, "v.jsonl"))
+
+	citers := []Identity{bob, carol, {Name: "Dave", Email: "dave@x"}}
+	for i, who := range citers {
+		if _, err := cl.Record("h", entry, "q", "s", who, clock); err != nil {
+			t.Fatal(err)
+		}
+		d, err := EvaluateEntry("h", entry, cl, vl)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantEligible := i == 2 // eligible only at the 3rd distinct citation
+		if d.Eligible != wantEligible {
+			t.Errorf("after %d citations: eligible=%v want %v (%+v)", i+1, d.Eligible, wantEligible, d)
+		}
+		if d.Tier != TierHeuristic {
+			t.Errorf("tier = %q, want heuristic", d.Tier)
+		}
+	}
+}
+
+// TestFalsifiableStillNeedsVerification: even with 3 citations, a falsifiable
+// learning is NOT eligible without an independent verification.
+func TestFalsifiableStillNeedsVerification(t *testing.T) {
+	dir := t.TempDir()
+	entry := writeTieredLearning(t, dir, "f.md", "falsifiable")
+	cl := NewCitationLedger(filepath.Join(dir, "c.jsonl"))
+	vl := NewVerificationLedger(filepath.Join(dir, "v.jsonl"))
+
+	for _, who := range []Identity{bob, carol, {Name: "Dave", Email: "dave@x"}} {
+		if _, err := cl.Record("f", entry, "q", "s", who, clock); err != nil {
+			t.Fatal(err)
+		}
+	}
+	d, err := EvaluateEntry("f", entry, cl, vl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Eligible {
+		t.Errorf("falsifiable with 3 citations but 0 verification should NOT be eligible: %+v", d)
+	}
+
+	// One independent verification clears it.
+	if _, err := vl.Record("f", entry, "council", "gate.log:L1", VerdictConfirmed, bob, clock); err != nil {
+		t.Fatal(err)
+	}
+	d, err = EvaluateEntry("f", entry, cl, vl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.Eligible {
+		t.Errorf("falsifiable with citation + verification should be eligible: %+v", d)
+	}
+}
+
+// TestUnknownPathDefaultsStrict: with no path (tier unknown), the strict
+// falsifiable gate applies — unverifiable entries can't slip through.
+func TestUnknownPathDefaultsStrict(t *testing.T) {
+	dir := t.TempDir()
+	entry := writeTieredLearning(t, dir, "h.md", "heuristic")
+	cl := NewCitationLedger(filepath.Join(dir, "c.jsonl"))
+	vl := NewVerificationLedger(filepath.Join(dir, "v.jsonl"))
+	for _, who := range []Identity{bob, carol, {Name: "Dave", Email: "dave@x"}} {
+		if _, err := cl.Record("h", entry, "q", "s", who, clock); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Path empty → falls back to falsifiable → needs verification despite 3 cites.
+	d, err := EvaluateEntry("h", "", cl, vl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Tier != TierFalsifiable || d.Eligible {
+		t.Errorf("empty path must default to strict falsifiable, not eligible: %+v", d)
+	}
+}


### PR DESCRIPTION
## What

gap#2 — **not all knowledge is mechanically verifiable.** A learning declares `canon_tier:` in its frontmatter; the promotion gate branches on it:

| Tier | Requirement | Why |
|---|---|---|
| `falsifiable` (default) | 1 cross-engineer citation **AND** 1 independent verification | claims about code/gates are checkable — and must be checked |
| `heuristic` | 3 cross-engineer citations, no verification | judgment can't be mechanically verified; breadth of independent reuse is the only honest trust signal |

- **Default is the stricter tier** (`falsifiable`) — `heuristic` is an explicit opt-out, so an unmarked learning can't dodge verification by omission.
- Refutation **hard-blocks both** tiers; unknown tier (no path) falls back to strict falsifiable.
- `status`/`promote` surface the tier; `EvaluateEntry` resolves it from the learning file.

## Verification
- 8 new unit tests (TierOf default/garbage/missing, per-tier thresholds, heuristic-earns-on-3-citations, falsifiable-still-needs-verification, unknown-path-strict) + a `cmd/ao` CLI test; canon package green (43)
- e2e: heuristic EARNED on 3rd citation (0 verifs); falsifiable PENDING on 3 citations until verified
- pre-push gate clean except the pre-existing bd-closeout/AGENTS.md drift (untouched file, out of scope)

Closes-scenario: ag-n2r4#heuristic-earns-on-citations
Bounded-context: BC1-Corpus
Evidence: cli/internal/canon/tier.go
