### PR TITLE
fix(hooks): delete orphaned cli/hooks/claude.json (ag-h93p)

### DIFF
--- a/cli/hooks/claude.json
+++ b/cli/hooks/claude.json
@@ -1,5 +1,0 @@
-{
-  "skipDangerousModePermissionPrompt": true,
-  "editorMode": "normal",
-  "hooks": {}
-}


### PR DESCRIPTION
## Summary
- Delete `cli/hooks/claude.json` — the file was already emptied (gc hooks stripped) and is not referenced by any Go code or install scripts
- Aligns with docs/3.0.md's "AgentOps does not ship one" claim for hookless-first architecture

## Test plan
- [x] Verify no Go code references `cli/hooks/` path
- [x] Verify install.sh doesn't reference the file
- [x] CI passes

Closes-scenario: ag-h93p#strip-gc-hooks
Bounded-context: BC5-Runtime
Evidence: cli/hooks/claude.json