### PR TITLE
docs(skills): re-narrate live Gas City substrate framing to NTM+MCP+managed-agents (ag-94vu #live-substrate-renarration)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-02T12:40:24Z",
+  "generated_at": "2026-06-02T18:29:10Z",
   "summary": {
     "skills": 80,
     "hooks": 0,
@@ -770,6 +770,7 @@
         "purpose": "Produce AgentOps-native Agent definitions for out-of-session loops",
         "bounded_context": "",
         "driven_by_skills": [
+          "domain",
           "shared",
           "using-agentops"
         ]
@@ -1966,10 +1967,12 @@
         "stdout"
       ],
       "drives_commands": [
+        "ao agent",
         "ao compile",
         "ao eval run",
         "ao inject",
         "ao maturity",
+        "ao mcp serve",
         "ao rpi",
         "ao rpi phased"
       ],
@@ -3363,6 +3366,7 @@
       "purpose": "Produce AgentOps-native Agent definitions for out-of-session loops",
       "status": "active",
       "driven_by_skills": [
+        "domain",
         "shared",
         "using-agentops"
       ],

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -781,7 +781,7 @@
     {
       "name": "domain",
       "source_skill": "skills/domain",
-      "source_hash": "594c5d173260e0c6d3b6ad29dbb82210103afe07181f0989f71f57ccb3081073",
+      "source_hash": "bfc7fa6664f6954c9ae891c889580ee4954944838a0e80da5c451797eab826f6",
       "generated_hash": "5de534737803c76fab3ad06e1a47dba85eb8f631a159cc6157ce4f932c2e99e4"
     },
     {
@@ -1033,7 +1033,7 @@
     {
       "name": "scope",
       "source_skill": "skills/scope",
-      "source_hash": "48bfe199c168e04a9ed67cfec0fbecb5daca02ef3f5558e37c82af630192b1e9",
+      "source_hash": "744978fa54136fdcd38dfe19069b3348828e7a62bc61f9b395d53e55c8cd486f",
       "generated_hash": "5e2f8802349594d45ceb081c3c3acdd02c1b92a82255db7a1d71e96915bfe62f"
     },
     {
@@ -1051,7 +1051,7 @@
     {
       "name": "session-bootstrap",
       "source_skill": "skills/session-bootstrap",
-      "source_hash": "96f95918d13f28d0fbf82836df3c3423d2fd0ff279797530ba23e5f8a5b0edad",
+      "source_hash": "5ff21fb43e1f1ab3bf36115ae0b0f22b61fa98b32df9f693b1f16322fc0105a5",
       "generated_hash": "f91092f706a0f196e8f787a75208e1b71a86d57eae112f156cd9b0b3fe0819cb"
     },
     {
@@ -1118,7 +1118,7 @@
       "name": "using-agentops",
       "source_skill": "skills/using-agentops",
       "source_hash": "bc0d61f7fa8ce5a9d53ab77948fa7dffd3fe3ba970cd4edfb32f0240662cd930",
-      "generated_hash": "80119493d38739d5ca4d9377c97c7e4f6e5766365525c965297c1cd78029e74b"
+      "generated_hash": "93c23a804e321d4dbdf86a31fe7d2165632d159b426395c5040f0a1fdb84fe0c"
     },
     {
       "name": "validate",

--- a/skills-codex/domain/.agentops-generated.json
+++ b/skills-codex/domain/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/domain",
   "layout": "modular",
-  "source_hash": "594c5d173260e0c6d3b6ad29dbb82210103afe07181f0989f71f57ccb3081073",
+  "source_hash": "bfc7fa6664f6954c9ae891c889580ee4954944838a0e80da5c451797eab826f6",
   "generated_hash": "5de534737803c76fab3ad06e1a47dba85eb8f631a159cc6157ce4f932c2e99e4"
 }

--- a/skills-codex/scope/.agentops-generated.json
+++ b/skills-codex/scope/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual",
   "source_skill": "skills/scope",
   "layout": "modular",
-  "source_hash": "48bfe199c168e04a9ed67cfec0fbecb5daca02ef3f5558e37c82af630192b1e9",
+  "source_hash": "744978fa54136fdcd38dfe19069b3348828e7a62bc61f9b395d53e55c8cd486f",
   "generated_hash": "5e2f8802349594d45ceb081c3c3acdd02c1b92a82255db7a1d71e96915bfe62f"
 }

--- a/skills-codex/session-bootstrap/.agentops-generated.json
+++ b/skills-codex/session-bootstrap/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/session-bootstrap",
   "layout": "modular",
-  "source_hash": "96f95918d13f28d0fbf82836df3c3423d2fd0ff279797530ba23e5f8a5b0edad",
+  "source_hash": "5ff21fb43e1f1ab3bf36115ae0b0f22b61fa98b32df9f693b1f16322fc0105a5",
   "generated_hash": "f91092f706a0f196e8f787a75208e1b71a86d57eae112f156cd9b0b3fe0819cb"
 }

--- a/skills-codex/using-agentops/.agentops-generated.json
+++ b/skills-codex/using-agentops/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/using-agentops",
   "layout": "modular",
   "source_hash": "bc0d61f7fa8ce5a9d53ab77948fa7dffd3fe3ba970cd4edfb32f0240662cd930",
-  "generated_hash": "80119493d38739d5ca4d9377c97c7e4f6e5766365525c965297c1cd78029e74b"
+  "generated_hash": "93c23a804e321d4dbdf86a31fe7d2165632d159b426395c5040f0a1fdb84fe0c"
 }

--- a/skills-codex/using-agentops/SKILL.md
+++ b/skills-codex/using-agentops/SKILL.md
@@ -162,12 +162,12 @@ Inspect, lint, and triage the `.agents/` write surface contract via `ao agents i
 
 ## Runtime Modes
 
-AgentOps has three runtime modes. Do not assume hook automation exists everywhere.
+AgentOps has several runtime modes. Do not assume hook automation exists everywhere.
 
 | Mode | When it applies | Start path | Closeout path | Guarantees |
 |------|-----------------|------------|---------------|------------|
-| `gc` | Gas City (`gc`) binary available and `city.toml` present | terminal wrapper sessions can use the gc controller | gc event bus captures phase/gate/failure/metric events | CLI/runtime substrate for terminal launches; Codex skills still chain `$skill` invocations for lead orchestration |
-| `codex-hookless-fallback` | Codex Desktop / Codex CLI without hook surfaces (no gc) | `ao codex start` or `ao codex ensure-start` | `ao codex stop` or `ao codex ensure-stop` | Explicit startup context, citation tracking, transcript fallback, and close-loop metrics without hooks |
+| `substrate` (out-of-session) | A swappable orchestration substrate available out-of-session: an NTM tmux swarm, MCP (`ao mcp serve`), or managed-agents (`ao agent`) | The operator or a lead agent runs `bd ready` and dispatches a whole loop per bead (`ao rpi <bead>`); cron / managed triggers run maintenance | The substrate owns the merge gate (CI-green is the signal) and triggers the knowledge-flywheel feedback | The substrate orchestrates *whole* `ao rpi`/`ao evolve` loops — it never sees the loop's insides; the seam is substrate → `ao` as a subprocess. There is no in-CLI `runtime=gc` executor. Codex skills still chain `$skill` invocations for lead orchestration. See [docs/3.0.md](https://github.com/boshu2/agentops/blob/main/docs/3.0.md). |
+| `codex-hookless-fallback` | Codex Desktop / Codex CLI without hook surfaces | `ao codex start` or `ao codex ensure-start` | `ao codex stop` or `ao codex ensure-stop` | Explicit startup context, citation tracking, transcript fallback, and close-loop metrics without hooks |
 | `manual` | Codex cannot resolve repo/runtime state automatically | `ao inject` / `ao lookup` | `ao forge transcript` + `ao flywheel close-loop` | Works everywhere, but lifecycle actions are operator-driven |
 
 Codex skill orchestration default is `$skill` chaining. Inside a Codex skill,

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -371,7 +371,7 @@ Not auto-loaded — loaded JIT by other skills via Read or auto-triggered by hoo
 | doc | standards | required |
 | flywheel | - | - |
 | forge | - | - |
-| **dream** | - | - (retired pointer; out-of-session compounding runs via Gas City) |
+| **dream** | - | - (retired pointer; out-of-session compounding runs on the substrate — NTM + MCP + managed-agents) |
 | handoff | - | - |
 | **implement** | beads, standards | optional, required |
 | inject | - | - |

--- a/skills/domain/references/factory.md
+++ b/skills/domain/references/factory.md
@@ -10,11 +10,11 @@ The **out-of-session driver** of the [Loop](loop.md): the loop run unattended ov
 
 ## The substrate owns it, not AgentOps
 
-AgentOps 3.0 ships **no** always-on daemon, scheduler, or overnight runner — those surfaces were **deleted** in the 3.0 rearchitecture (see [`docs/adr/ADR-0009-daemon-deletion-in-session-only.md`](../../../docs/adr/ADR-0009-daemon-deletion-in-session-only.md)). The Factory driver is the orchestration substrate's job. **Gas City** is the reference substrate: its Orders drive the loop, its queue holds the work, its agents inherit the AgentOps skills via overlay. AgentOps stays zero-dependency in a plain session through the Evolve driver.
+AgentOps 3.0 ships **no** always-on daemon, scheduler, or overnight runner — those surfaces were **deleted** in the 3.0 rearchitecture (see [`docs/adr/ADR-0009-daemon-deletion-in-session-only.md`](../../../docs/adr/ADR-0009-daemon-deletion-in-session-only.md)). The Factory driver is the orchestration substrate's job. The reference substrate is the trio AgentOps actually runs on — **NTM** (a tmux agent swarm), **MCP** (`ao mcp serve`), and **managed-agents** (`ao agent`) — none of it AgentOps-owned: it holds the queue, supervises the agents, and they inherit the AgentOps skills via overlay. AgentOps stays zero-dependency in a plain session through the Evolve driver.
 
-## Mayor-driven dispatch (honest current state)
+## Swarm-driven dispatch (honest current state)
 
-On the reference Gas City City, dispatch is **mayor-driven** today: a long-lived mayor agent runs `bd ready`, then `gc sling`s the next bead to a refinery worker that runs `ao rpi <bead>`; cron `exec` Orders handle scheduled maintenance. Order-level autonomous dispatch (a cooldown Order binding the next ready bead to a formula on its own) is a known **Gas City maturity gap** — GC Orders have no per-fire variable binding — tracked as an upstream contribution (`soc-5jwah`), not a turnkey AgentOps feature.
+On the reference substrate, dispatch is **swarm-driven**: an NTM tmux swarm (or a lead agent) runs `bd ready`, then dispatches the next bead to a worker that runs `ao rpi <bead>`; a managed-agent driver (`ao agent`) or cron handles scheduled maintenance, and `ao mcp serve` exposes the `ao` tool surface across the seam. The substrate dispatches a whole loop as one invocable unit — it never re-expresses the rpi tick as substrate-side steps.
 
 ## When to use
 

--- a/skills/scope/SKILL.md
+++ b/skills/scope/SKILL.md
@@ -121,7 +121,7 @@ Reserved for a follow-up skill that combines `freeze` + status + spawn-orchestra
 
 - Wave 1 hardcodes the `.agents/scope.lock` path. Wave 2 (issue I5) migrates the path through `lib/ao-paths.sh`.
 - The hook's defensive parse on malformed JSON is intentional. See [references/lock-file-format.md](references/lock-file-format.md) for the rationale.
-- This skill is purely session-boundary (path-scope freezing within a session). Cron-cadence orchestration lives outside AgentOps on the orchestration substrate (the reference Gas City City), not in an AgentOps-shipped daemon.
+- This skill is purely session-boundary (path-scope freezing within a session). Cron-cadence orchestration lives outside AgentOps on the orchestration substrate (the reference is NTM + MCP + managed-agents), not in an AgentOps-shipped daemon.
 - Path-scope freezing handles *where* edits land. For a complementary lane that gates *what* commands run (`rm -rf`, `git reset --hard`, `DROP DATABASE`, `kubectl delete`, `terraform destroy`) — including allowlist layering, one-shot override codes, and PreToolUse wiring — see [references/destructive-command-guard-patterns.md](references/destructive-command-guard-patterns.md). Wire it alongside the scope guard when a wave touches infrastructure or shared data.
 - When a workflow needs human approval, hook parity, or simultaneous command review rather than only path freezing, use [references/command-approval-and-hook-guardrails.md](references/command-approval-and-hook-guardrails.md).
 - When authoring new hook behavior rather than using scope's existing guard, use `/hooks-authoring`.

--- a/skills/session-bootstrap/SKILL.md
+++ b/skills/session-bootstrap/SKILL.md
@@ -40,7 +40,7 @@ Triggers:
 
 - **Manual spawn** — operator just spawned a fresh agent into the repo: `ao session bootstrap`.
 - **SessionStart hook (opt-in)** — AgentOps 3.0 ships no SessionStart hook. If you author one via the `hooks-authoring` skill, it can fail-open auto-fire `ao session bootstrap --robot` and discard the exit code.
-- **Pipeline submit** — the orchestration substrate (the reference Gas City City) and headless CI agents call `ao session bootstrap --json` before claiming work.
+- **Pipeline submit** — the orchestration substrate (the reference is NTM + MCP + managed-agents) and headless CI agents call `ao session bootstrap --json` before claiming work.
 
 If you spawned without running it: stop, run it, then resume.
 


### PR DESCRIPTION
## What

Round-2 Gas City doctrine sweep (**ag-94vu**). Re-narrates the **5 named skill surfaces** that still framed Gas City as THE live reference substrate (present-tense operator instructions) to the canonical substrate trio — **NTM (tmux swarm) + MCP (`ao mcp serve`) + managed-agents (`ao agent`)** — matching [`docs/3.0.md`](docs/3.0.md). Driver: post-mortem checkpoint #6 Judge-3 FAIL ("the repo does not yet speak one doctrine").

## Surfaces (9 insertions / 9 deletions, 5 files)

- `skills/domain/references/factory.md` — "Gas City is the reference substrate" → the NTM/MCP/managed-agents trio; "Mayor-driven / `gc sling`" → **swarm-driven** dispatch.
- `skills/scope/SKILL.md` — cron-cadence orchestration reference.
- `skills/session-bootstrap/SKILL.md` — substrate submit reference.
- `skills/SKILL-TIERS.md` — dream retired-pointer note.
- `skills-codex/using-agentops/SKILL.md` — **codex-twin parity**: dropped the stale `gc` runtime-mode row for the canonical `substrate` row (the Claude twin was already correct; this one slipped in #679).

## Bounded by design

This PR is the coherent **"live skill operator-instructions speak one doctrine"** slice. A repo-wide grep shows ~35 more refs across other skills + `docs/` narrative; bundling them would reproduce the #682 mega-PR that was rejected for sprawl. Deferred to tracked follow-ups:

- **ag-r6g1** — round-3 narrative sweep (remaining skills/ + docs/ ~35 refs; many docs already frame GC correctly as "the reference" — triage required).
- **ag-82pv** — remove orphaned `GasCityPhaseEvidence*`/`GasCityTranscript*` dead types in `cli/internal/rpi/artifacts.go`.

## Verification (local, green)

- codex-parity-drift: PASS · registry-drift: PASS (80) · skill-catalog-drift: up-to-date · skill-isolation: PASS · skill-size: 0/0 · markdownlint: 0 errors.
- Residual live-substrate grep over the 5 surfaces: clean.

Closes-scenario: ag-94vu#live-substrate-renarration
Bounded-context: BC1-Corpus
Evidence: skills/domain/references/factory.md
