### PR TITLE
refactor(rpi): remove orphaned GasCity phase-evidence dead types (ag-82pv #strip-deadtypes)

### DIFF
--- a/cli/internal/rpi/artifacts.go
+++ b/cli/internal/rpi/artifacts.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/boshu2/agentops/cli/internal/domain/packet"
 )
@@ -21,10 +20,6 @@ type ExecutionPacket = packet.ExecutionPacket
 
 // PhaseArtifactNumberPattern matches phase-N in artifact filenames.
 var PhaseArtifactNumberPattern = regexp.MustCompile(`phase-(\d+)`)
-
-// GasCityPhaseEvidenceFileFmt is the filename pattern for per-phase GasCity
-// session evidence captured after a terminal provider event.
-const GasCityPhaseEvidenceFileFmt = "phase-%d-gascity-evidence.json"
 
 // ArtifactRef is a reference to an RPI artifact on disk.
 type ArtifactRef struct {
@@ -48,36 +43,6 @@ type ArtifactContent struct {
 	Truncated   bool   `json:"truncated,omitempty"`
 }
 
-// GasCityPhaseEvidence records provider correlation and transcript metadata
-// for a GasCity-backed RPI phase. The transcript body may remain in GasCity;
-// this file is the durable AgentOps registry projection.
-type GasCityPhaseEvidence struct {
-	SchemaVersion        int                         `json:"schema_version"`
-	RunID                string                      `json:"run_id"`
-	Phase                int                         `json:"phase"`
-	PhaseName            string                      `json:"phase_name,omitempty"`
-	CityName             string                      `json:"city_name"`
-	SessionID            string                      `json:"session_id"`
-	SessionAlias         string                      `json:"session_alias,omitempty"`
-	Status               string                      `json:"status"`
-	EventCursor          string                      `json:"event_cursor,omitempty"`
-	RequestIDs           map[string]string           `json:"request_ids,omitempty"`
-	TranscriptID         string                      `json:"transcript_id,omitempty"`
-	TranscriptFormat     string                      `json:"transcript_format,omitempty"`
-	TranscriptTurnCount  int                         `json:"transcript_turn_count,omitempty"`
-	TranscriptMsgCount   int                         `json:"transcript_message_count,omitempty"`
-	TranscriptArtifacts  []GasCityTranscriptArtifact `json:"transcript_artifacts,omitempty"`
-	TranscriptCapturedAt string                      `json:"transcript_captured_at,omitempty"`
-	RecordedAt           string                      `json:"recorded_at"`
-}
-
-// GasCityTranscriptArtifact is one artifact reference returned by GasCity's
-// transcript/result evidence endpoint.
-type GasCityTranscriptArtifact struct {
-	Path string `json:"path"`
-	Kind string `json:"kind,omitempty"`
-}
-
 // PathClean normalises a relative path to forward-slash form.
 func PathClean(rel string) string {
 	return filepath.ToSlash(filepath.Clean(filepath.FromSlash(strings.TrimSpace(rel))))
@@ -93,47 +58,6 @@ func IsSafeArtifactRelPath(rel string) bool {
 		return false
 	}
 	return true
-}
-
-// GasCityPhaseEvidencePath returns the registry path for one phase's GasCity
-// evidence. When a run ID is available, evidence is stored under the per-run
-// registry; otherwise it falls back to the legacy .agents/rpi directory.
-func GasCityPhaseEvidencePath(cwd, runID string, phase int) string {
-	file := fmt.Sprintf(GasCityPhaseEvidenceFileFmt, phase)
-	if runDir := RPIRunRegistryDir(cwd, runID); runDir != "" {
-		return filepath.Join(runDir, file)
-	}
-	return filepath.Join(cwd, ".agents", "rpi", file)
-}
-
-// WriteGasCityPhaseEvidence writes GasCity phase evidence atomically and returns
-// the absolute path that was written.
-func WriteGasCityPhaseEvidence(cwd string, evidence GasCityPhaseEvidence) (string, error) {
-	if strings.TrimSpace(cwd) == "" {
-		return "", fmt.Errorf("cwd is required")
-	}
-	if evidence.Phase <= 0 {
-		return "", fmt.Errorf("phase must be positive")
-	}
-	if evidence.SchemaVersion == 0 {
-		evidence.SchemaVersion = 1
-	}
-	if evidence.RecordedAt == "" {
-		evidence.RecordedAt = time.Now().UTC().Format(time.RFC3339)
-	}
-	path := GasCityPhaseEvidencePath(cwd, evidence.RunID, evidence.Phase)
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return "", fmt.Errorf("create evidence dir: %w", err)
-	}
-	data, err := json.MarshalIndent(evidence, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("marshal gascity phase evidence: %w", err)
-	}
-	data = append(data, '\n')
-	if err := WritePhasedStateAtomic(path, data); err != nil {
-		return "", fmt.Errorf("write gascity phase evidence: %w", err)
-	}
-	return path, nil
 }
 
 // ClassifyRPIArtifact returns (kind, label, phase) for a relative artifact path.

--- a/cli/internal/rpi/artifacts_test.go
+++ b/cli/internal/rpi/artifacts_test.go
@@ -1,9 +1,6 @@
 package rpi
 
 import (
-	"encoding/json"
-	"os"
-	"path/filepath"
 	"testing"
 )
 
@@ -76,49 +73,6 @@ func TestClassifyRPIArtifact(t *testing.T) {
 				t.Errorf("got (%q, %d), want (%q, %d)", kind, phase, tc.wantKind, tc.wantPhase)
 			}
 		})
-	}
-}
-
-func TestWriteGasCityPhaseEvidence(t *testing.T) {
-	cwd := t.TempDir()
-	path, err := WriteGasCityPhaseEvidence(cwd, GasCityPhaseEvidence{
-		RunID:        "run-123",
-		Phase:        2,
-		PhaseName:    "implementation",
-		CityName:     "agentops",
-		SessionID:    "sess-123",
-		SessionAlias: "rpi-run-123-p2",
-		Status:       "completed",
-		EventCursor:  "evt-9",
-		RequestIDs: map[string]string{
-			"create": "req-create",
-			"stream": "req-stream",
-		},
-		TranscriptID:        "sess-123",
-		TranscriptFormat:    "conversation",
-		TranscriptTurnCount: 2,
-		TranscriptArtifacts: []GasCityTranscriptArtifact{{Path: ".agents/rpi/phase-2-summary.md", Kind: "summary"}},
-	})
-	if err != nil {
-		t.Fatalf("WriteGasCityPhaseEvidence: %v", err)
-	}
-	wantPath := filepath.Join(cwd, ".agents", "rpi", "runs", "run-123", "phase-2-gascity-evidence.json")
-	if path != wantPath {
-		t.Fatalf("path = %q, want %q", path, wantPath)
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read evidence: %v", err)
-	}
-	var got GasCityPhaseEvidence
-	if err := json.Unmarshal(data, &got); err != nil {
-		t.Fatalf("unmarshal evidence: %v", err)
-	}
-	if got.SchemaVersion != 1 || got.SessionID != "sess-123" || got.RequestIDs["stream"] != "req-stream" {
-		t.Fatalf("unexpected evidence: %#v", got)
-	}
-	if got.RecordedAt == "" {
-		t.Fatal("RecordedAt should be populated")
 	}
 }
 


### PR DESCRIPTION
## What

Removes the orphaned **GasCity phase-evidence** dead types from `cli/internal/rpi/artifacts.go` (**ag-82pv**). After the #679/#683 Gas City strip, these had **no production caller** — only their own unit test referenced them. Flagged by post-mortem #6 (Judge 2) and Bo's #682-close note ("pending rpi/artifacts.go cleanup").

## Removed (−122 lines, 2 files)

- `GasCityPhaseEvidenceFileFmt` (const), `GasCityPhaseEvidence` + `GasCityTranscriptArtifact` (structs), `GasCityPhaseEvidencePath` + `WriteGasCityPhaseEvidence` (funcs).
- The now-unused `time` import.
- `TestWriteGasCityPhaseEvidence` (the only caller) + its now-unused test imports.

## Kept (intentional)

`ClassifyRPIArtifact`'s `-gascity-evidence.json` case and its test — a **live, defensive classifier** for any legacy on-disk evidence files. It keys off a string literal, not the removed types, so it's safe and out of scope for this dead-type strip.

## Deletion safety

Repo-wide grep confirmed the removed symbols were referenced **only** in `artifacts.go` + `artifacts_test.go` — no other Go callers, no schema/doc/string-literal anchors, no indirect wiring.

## Verification (local, full gate)

- `go build ./...` ✓ · `go vet ./...` ✓ · `go test ./...` ✓ (**11,947 tests / 73 pkgs**) · `golangci-lint` clean on rpi.
- `regen-all.sh --check`: ALL GATES GREEN (no derived-surface drift).

Closes-scenario: ag-82pv#strip-deadtypes
Bounded-context: BC3-Loop
Evidence: cli/internal/rpi/artifacts.go
