### PR TITLE
docs(skills): re-narrate residual live Gas City framing in skills/ (ag-r6g1 #skills-slice)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-02T18:29:10Z",
+  "generated_at": "2026-06-02T19:06:19Z",
   "summary": {
     "skills": 80,
     "hooks": 0,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -721,8 +721,8 @@
     {
       "name": "compile",
       "source_skill": "skills/compile",
-      "source_hash": "a5fcf6bc133acbbfbb73732e3f4d47b5886419161565228c742598ba65fa0b71",
-      "generated_hash": "a9cdb251491064df3f97acdb4ad4f78d187c681d32f3ee8c3867f87799886861"
+      "source_hash": "693a128f8d82af33afa4dbdbf47a0d7e831eac0c823438ca89100762070c78d6",
+      "generated_hash": "3610ba8eb9b1690d7d0f0765ef9319e71ec3fd39924c0599a6a5da65ffc945a9"
     },
     {
       "name": "complexity",
@@ -769,7 +769,7 @@
     {
       "name": "discovery",
       "source_skill": "skills/discovery",
-      "source_hash": "b9db5932d003bfc3d015a5c9ccd01d62284c68f2e106850d5dc9a71c473386d9",
+      "source_hash": "021e1c1b0ac5f6f1f1ca8c4aa6b6a0bf4ebcc3fc4366d9df1ad0f3c29085dbc7",
       "generated_hash": "279fece7b28692dc9be477ea7adbaad390ad6c7e976959fc3c1a97de59882004"
     },
     {
@@ -1093,7 +1093,7 @@
     {
       "name": "swarm",
       "source_skill": "skills/swarm",
-      "source_hash": "ae39b48066361c02f1417f0205fbacf4b1442d9eaddec7a1253b3d19736feaf8",
+      "source_hash": "bc6f995ae230675daf7d1c987d1d58ad8b42d745c9222872393ac677ae1e252b",
       "generated_hash": "093b9bb120ff3b2804b753ff69c80430d8738095ced1ef0e7a03c1fc8ca112d6"
     },
     {
@@ -1129,7 +1129,7 @@
     {
       "name": "validation",
       "source_skill": "skills/validation",
-      "source_hash": "7a19016c7b41fb1d81c05d751a2bd84509961617d6bf538c108f755d34cc7ad5",
+      "source_hash": "b79277d96e8328560d028fdbb1d0e3fa9133e845179262badb8c812ddc0e33dd",
       "generated_hash": "205fc9ab951b8a75912fb2cb41740fad8a99505f22e33ba8cb0b820a81e92665"
     },
     {

--- a/skills-codex/compile/.agentops-generated.json
+++ b/skills-codex/compile/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/compile",
   "layout": "modular",
-  "source_hash": "a5fcf6bc133acbbfbb73732e3f4d47b5886419161565228c742598ba65fa0b71",
-  "generated_hash": "a9cdb251491064df3f97acdb4ad4f78d187c681d32f3ee8c3867f87799886861"
+  "source_hash": "693a128f8d82af33afa4dbdbf47a0d7e831eac0c823438ca89100762070c78d6",
+  "generated_hash": "3610ba8eb9b1690d7d0f0765ef9319e71ec3fd39924c0599a6a5da65ffc945a9"
 }

--- a/skills-codex/compile/SKILL.md
+++ b/skills-codex/compile/SKILL.md
@@ -310,9 +310,9 @@ AgentOps exposes this flow through `ao compile`. If you want unattended
 compilation, use your host scheduler (`launchd`, `cron`, `systemd`, CI, etc.)
 to invoke `ao compile --force --runtime ollama` or call the lower-level
 `bash skills-codex/compile/scripts/compile.sh` directly.
-If you want the broader out-of-session compounding loop, run it on Gas City (the
-reference out-of-session substrate) instead of inventing a parallel Dream
-wrapper inside `$compile`.
+If you want the broader out-of-session compounding loop, run it on the
+out-of-session substrate (NTM + MCP + managed-agents) instead of inventing a
+parallel Dream wrapper inside `$compile`.
 
 ## Interactive Modes
 

--- a/skills-codex/discovery/.agentops-generated.json
+++ b/skills-codex/discovery/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/discovery",
   "layout": "modular",
-  "source_hash": "b9db5932d003bfc3d015a5c9ccd01d62284c68f2e106850d5dc9a71c473386d9",
+  "source_hash": "021e1c1b0ac5f6f1f1ca8c4aa6b6a0bf4ebcc3fc4366d9df1ad0f3c29085dbc7",
   "generated_hash": "279fece7b28692dc9be477ea7adbaad390ad6c7e976959fc3c1a97de59882004"
 }

--- a/skills-codex/swarm/.agentops-generated.json
+++ b/skills-codex/swarm/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/swarm",
   "layout": "modular",
-  "source_hash": "ae39b48066361c02f1417f0205fbacf4b1442d9eaddec7a1253b3d19736feaf8",
+  "source_hash": "bc6f995ae230675daf7d1c987d1d58ad8b42d745c9222872393ac677ae1e252b",
   "generated_hash": "093b9bb120ff3b2804b753ff69c80430d8738095ced1ef0e7a03c1fc8ca112d6"
 }

--- a/skills-codex/validation/.agentops-generated.json
+++ b/skills-codex/validation/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/validation",
   "layout": "modular",
-  "source_hash": "7a19016c7b41fb1d81c05d751a2bd84509961617d6bf538c108f755d34cc7ad5",
+  "source_hash": "b79277d96e8328560d028fdbb1d0e3fa9133e845179262badb8c812ddc0e33dd",
   "generated_hash": "205fc9ab951b8a75912fb2cb41740fad8a99505f22e33ba8cb0b820a81e92665"
 }

--- a/skills/compile/SKILL.md
+++ b/skills/compile/SKILL.md
@@ -141,9 +141,9 @@ AgentOps exposes this flow through `ao compile`. If you want unattended
 compilation, use your host scheduler (`launchd`, `cron`, `systemd`, CI, etc.)
 to invoke `ao compile --force --runtime ollama` or call the lower-level
 `bash skills/compile/scripts/compile.sh` directly.
-If you want the broader out-of-session compounding loop, run it on Gas City (the
-reference out-of-session substrate) instead of inventing a parallel Dream
-wrapper inside `/compile`.
+If you want the broader out-of-session compounding loop, run it on the
+out-of-session substrate (NTM + MCP + managed-agents) instead of inventing a
+parallel Dream wrapper inside `/compile`.
 
 ## Interactive Modes
 

--- a/skills/discovery/references/best-practices.md
+++ b/skills/discovery/references/best-practices.md
@@ -29,7 +29,7 @@ Source research: `.agents/research/2026-05-07-rpi-lifecycle-sharpening.md` §Obj
 |---|---|---|---|
 | 1 | Compression of strict delegation (inline phase work) | `.agents/learnings/2026-04-19-orchestrator-compression-anti-pattern.md` | rpi, discovery, validation |
 | 2 | Massive uncoordinated swarms (60+ unbounded) | `docs/scale-without-swarms.md` | crank, swarm |
-| 3 | Magic-claimed compounding (without a real mechanism — the in-session loop, or Gas City for out-of-session) | `PRODUCT.md` mission section | dream, evolve |
+| 3 | Magic-claimed compounding (without a real mechanism — the in-session loop, or the out-of-session substrate: NTM + MCP + managed-agents) | `PRODUCT.md` mission section | dream, evolve |
 | 4 | Vibe-based gates without rubric / separate-context grader | `PRODUCT.md` Gap 1 | validation, vibe |
 | 5 | Vendor memory follows the chat (context must reload from disk) | `PRODUCT.md` mission | rpi (orchestrator persists; phase workers DO NOT carry chat memory) |
 | 6 | Coverage-padding tests | `.claude/rules/go.md`, `.claude/rules/python.md`, `skills/standards/` | crank, test |

--- a/skills/swarm/references/shared-checkout-discipline.md
+++ b/skills/swarm/references/shared-checkout-discipline.md
@@ -2,7 +2,7 @@
 
 When `~/dev/<repo>` is contended — peer Codex agent in the same directory,
 NTM swarm pane, out-of-session scheduled loop (cron-driven `ao rpi` / `ao
-evolve` via Gas City), or operator parallel session — **never edit in the
+evolve` on the substrate), or operator parallel session — **never edit in the
 shared tree and never leave work
 uncommitted between turns.** Use a `git worktree`. Commit-or-stash
 incrementally with explicit paths. Verify a clean baseline before spawning

--- a/skills/validation/references/best-practices.md
+++ b/skills/validation/references/best-practices.md
@@ -29,7 +29,7 @@ Source research: `.agents/research/2026-05-07-rpi-lifecycle-sharpening.md` §Obj
 |---|---|---|---|
 | 1 | Compression of strict delegation (inline phase work) | `.agents/learnings/2026-04-19-orchestrator-compression-anti-pattern.md` | rpi, discovery, validation |
 | 2 | Massive uncoordinated swarms (60+ unbounded) | `docs/scale-without-swarms.md` | crank, swarm |
-| 3 | Magic-claimed compounding (without a real mechanism — the in-session loop, or Gas City for out-of-session) | `PRODUCT.md` mission section | dream, evolve |
+| 3 | Magic-claimed compounding (without a real mechanism — the in-session loop, or the out-of-session substrate: NTM + MCP + managed-agents) | `PRODUCT.md` mission section | dream, evolve |
 | 4 | Vibe-based gates without rubric / separate-context grader | `PRODUCT.md` Gap 1 | validation, vibe |
 | 5 | Vendor memory follows the chat (context must reload from disk) | `PRODUCT.md` mission | rpi (orchestrator persists; phase workers DO NOT carry chat memory) |
 | 6 | Coverage-padding tests | `.claude/rules/go.md`, `.claude/rules/python.md`, `skills/standards/` | crank, test |


### PR DESCRIPTION
## What

Round-3 Gas City doctrine sweep — **skills/ slice** (**ag-r6g1**). Five skill surfaces still framed Gas City as THE live out-of-session substrate; re-narrated to **NTM + MCP + managed-agents** per [`docs/3.0.md`](docs/3.0.md).

## Surfaces (5 source + 6 regenerated derived, +20 −20)

- `skills/compile/SKILL.md` + `skills-codex/compile` twin — "run it on Gas City" → the out-of-session substrate (NTM + MCP + managed-agents).
- `skills/discovery/references/best-practices.md` + `skills/validation/references/best-practices.md` — magic-compounding anti-pattern row's "Gas City for out-of-session" → "the out-of-session substrate: NTM + MCP + managed-agents".
- `skills/swarm/references/shared-checkout-discipline.md` — "`ao evolve` via Gas City" → "`ao evolve` on the substrate".
- Regenerated: `registry.json` + codex `.agentops-generated.json` hashes/manifest for the 4 edited skills.

## Scope

Triaged each ref — only **present-tense live-substrate** framing was changed; already-correct historical/reference mentions were left alone. **ag-r6g1 stays OPEN**: the docs/ narrative slice (~30 refs) is deferred to a later tick. `docs/cli-surface.*` drift excluded (pre-existing, unrelated to this change).

## Verification (full gate, pre-push)

- `generate-registry.sh --check` OK · codex parity audit passed · `regen-all.sh --check` ALL GREEN · markdownlint 0 errors · skill-isolation/size clean.

Closes-scenario: ag-r6g1#skills-slice
Bounded-context: BC1-Corpus
Evidence: skills/compile/SKILL.md
