### PR TITLE
docs: re-narrate live Gas City operator instructions to NTM+MCP+managed-agents (ag-r6g1 #docs-slice)

### DIFF
--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -18,7 +18,7 @@ CI ensures code quality, security, and release integrity for the AgentOps reposi
 AgentOps has two different overnight surfaces:
 
 - **GitHub nightly** validates AgentOps the product. It runs in GitHub Actions against the checked-out repository and proves the CI, flywheel, and Dream report contracts still work.
-- **The Dream loop** is the private local compounding engine. AgentOps runs it **in session** via the `/dream` skill against the real repo-local `.agents` corpus, writing the morning report defined in [Dream Report Contract](contracts/dream-report.md). To run it *unattended*, hand it to an orchestration substrate (Gas City is the reference) as a scheduled `exec` Order — AgentOps ships no daemon or scheduler of its own.
+- **The Dream loop** is the private local compounding engine. AgentOps runs it **in session** via the `/dream` skill against the real repo-local `.agents` corpus, writing the morning report defined in [Dream Report Contract](contracts/dream-report.md). To run it *unattended*, hand it to an orchestration substrate (the reference is NTM + MCP + managed-agents) as a scheduled dispatch — AgentOps ships no daemon or scheduler of its own.
 
 They share primitive steps and report shapes, but they are not the same pipeline.
 
@@ -35,8 +35,8 @@ selection grounded in observed Nightly drift and current CI blockers while
 avoiding hidden source-code mutation from GitHub Actions.
 
 If you want scheduled private Dream runs, delegate them to an orchestration
-substrate. Point the AgentOps reference Gas City (`city.toml` + `packs/agentops`)
-at the repo and wire a cron `exec` Order that runs the Dream loop on a schedule;
+substrate (the reference is NTM + MCP + managed-agents) and wire a scheduled
+dispatch (a managed-agent driver or cron) that runs the Dream loop on a schedule;
 the substrate owns the wake, scheduling, and supervision semantics. For the
 cross-vendor private local chain that combines Dream, Claude/Codex runners,
 RPI/evolve, and PR digest output, see

--- a/docs/agentops-3-pmf-evidence-loop.md
+++ b/docs/agentops-3-pmf-evidence-loop.md
@@ -57,8 +57,8 @@ Minimum scenario:
 Second-stage scenario:
 
 1. Reuse the same packet or verdict in a later engineering decision.
-2. Run the loop out of session: point the reference Gas City at the repo and let
-   the mayor sling ready beads to refinery workers running `ao rpi`.
+2. Run the loop out of session: hand it to the reference substrate (NTM + MCP +
+   managed-agents) and let it dispatch ready beads to workers running `ao rpi`.
 3. Report whether always-on compounding felt useful or premature.
 
 ## Interview Script
@@ -125,8 +125,8 @@ Record:
 - No always-on interest.
 - Interested but blocked.
 - Ran the loop in session (`ao rpi` / `ao evolve`).
-- Pointed the reference Gas City at the repo.
-- Mayor-driven dispatch slung a ready bead to a refinery worker.
+- Handed the loop to the reference substrate (NTM + MCP + managed-agents).
+- Substrate dispatch sent a ready bead to a worker running `ao rpi`.
 - An out-of-session run completed and produced an inspected artifact.
 
 Do not count always-on substrate setup as first-value activation.

--- a/docs/agentops-3-youtube-starter-series.md
+++ b/docs/agentops-3-youtube-starter-series.md
@@ -159,11 +159,11 @@ with clearer context.
 
 1. Recap the packet and verdict artifact.
 2. Run the loop in session: `ao rpi <bead>` (one cycle), `ao evolve` (many).
-3. To run it out of session, point the AgentOps reference Gas City at the repo
-   (`city.toml` + `packs/agentops`); a long-lived mayor agent slings ready beads
-   to refinery workers that run `ao rpi`.
-4. Schedule corpus maintenance as Gas City cron `exec` Orders (`ao compile`,
-   `ao maturity --scan`).
+3. To run it out of session, hand the loop to the reference substrate
+   (NTM + MCP + managed-agents); e.g. an NTM tmux swarm (or a lead agent) runs
+   `bd ready` and dispatches ready beads to workers that run `ao rpi`.
+4. Schedule corpus maintenance via the substrate (a managed-agent driver or cron
+   running `ao compile`, `ao maturity --scan`).
 5. Explain Dream/wiki/forge as compounding jobs, not unattended source mutation.
 
 **CTA**
@@ -174,7 +174,7 @@ session.
 **Measurement fields**
 
 - In-session loop runs (`ao rpi` / `ao evolve`) before opting into always-on.
-- Gas City dispatch screenshots or reports.
+- Substrate dispatch screenshots or reports.
 - Questions about safety boundaries and source mutation.
 
 ### 5. AgentOps 3.0 Full Path: First Verdict To PMF Evidence

--- a/docs/wiki-for-agents.md
+++ b/docs/wiki-for-agents.md
@@ -62,7 +62,7 @@ AgentOps inverts this. Sessions write to the wiki by default — runs land citat
 
 **Automated capture.** Sessions write run packets, citations, and verdicts without anyone being asked. The discipline lives in the tooling.
 
-**Always-on compounding.** Run defrag, evolve, compile, and dream against the corpus out of session by handing the loop to an orchestration substrate — point the AgentOps reference Gas City at the repo and the corpus compounds while you sleep. A SaaS wiki cannot get smarter on its own.
+**Always-on compounding.** Run defrag, evolve, compile, and dream against the corpus out of session by handing the loop to an orchestration substrate — the reference is NTM + MCP + managed-agents — and the corpus compounds while you sleep. A SaaS wiki cannot get smarter on its own.
 
 **Self-writing.** Every consumer of the wiki is also a producer of it. That is the inversion that makes the whole thing tractable.
 


### PR DESCRIPTION
## What

Round-3 Gas City doctrine sweep — **docs/ slice** (user-facing operator instructions) (**ag-r6g1**). Four docs told the reader to *"point the reference Gas City at the repo"* to run the loop out of session; re-narrated to the canonical substrate **NTM + MCP + managed-agents** per [`docs/3.0.md`](docs/3.0.md).

## Surfaces (4 files, +14 −14)

- `docs/agentops-3-youtube-starter-series.md` — out-of-session demo beat + measurement field.
- `docs/wiki-for-agents.md` — the always-on compounding line.
- `docs/CI-CD.md` — the unattended-Dream line + scheduled-private-Dream-runs section (dropped the Gas-City-specific `city.toml`/`packs/`/`exec` Order mechanics).
- `docs/agentops-3-pmf-evidence-loop.md` — out-of-session step + engagement checklist.

## Scope (sprawl-controlled)

Triaged to **live present-tense operator instructions only**. Left already-correct architectural "ships no daemon / delegates to a substrate" framing intact. **ag-r6g1 stays OPEN** — the operator runbooks (`nightly-evolution`, `autonomy-runtime-cycle-1`, which carry deeper GC-specific mayor/refinery/Order mechanics) and descriptive comparison/example/explainer mentions are deferred to a later slice.

## Verification

- markdownlint 0 errors · `regen-all.sh --check` ALL GREEN (docs-only; no derived-surface drift).

Closes-scenario: ag-r6g1#docs-slice
Bounded-context: BC1-Corpus
Evidence: docs/CI-CD.md
