### PR TITLE
docs: fix docs asserting Gas City is the reference -> NTM+MCP+managed-agents (ag-r6g1 #docs-slice-2)

### DIFF
--- a/docs/architecture/ports-and-adapters.md
+++ b/docs/architecture/ports-and-adapters.md
@@ -22,7 +22,7 @@ Primary adapters drive the domain from the outside: a human, an agent, or a work
 - **CLI commands** in `cli/cmd/ao/` — every `ao <verb>` is a driving adapter.
 - **Slash commands** in `skills/` — invocations like `/plan`, `/discovery`, `/validation`, `/vibe`.
 - **MCP** — Model Context Protocol entry points exposed by `ao` and by skills.
-- **Autonomous loops** — `/dream`, `/evolve`. These are in-session driving adapters; running them out of session (always-on, scheduled) is delegated to an orchestration substrate (Gas City is the reference), not an AgentOps daemon.
+- **Autonomous loops** — `/dream`, `/evolve`. These are in-session driving adapters; running them out of session (always-on, scheduled) is delegated to an orchestration substrate (the reference is NTM + MCP + managed-agents), not an AgentOps daemon.
 - **CI gates** — `scripts/*.sh` and `.github/workflows/validate.yml` jobs that drive validation against the same domain types they would in interactive runs.
 
 ## Secondary (driven) adapters

--- a/docs/first-value-path.md
+++ b/docs/first-value-path.md
@@ -11,7 +11,7 @@ The first value is a council verdict over a visible engineering domain:
 3. Assemble bounded context for one decision.
 4. Run council across Claude and Codex, with a same-packet fallback.
 5. Inspect the verdict artifact and turn it into tracked work.
-6. Only then point at the optional out-of-session compounding lane, which runs the same loop on an orchestration substrate (Gas City is the reference) — AgentOps itself ships no daemon or scheduler.
+6. Only then point at the optional out-of-session compounding lane, which runs the same loop on an orchestration substrate (the reference is NTM + MCP + managed-agents) — AgentOps itself ships no daemon or scheduler.
 
 ## Target Viewer
 
@@ -32,7 +32,7 @@ need to see one agent decision become an inspectable engineering artifact.
 | Context assembly | 1 min | `.agents/rpi/briefing-current.md` exists. |
 | Council run | 5-10 min | `.agents/council/<run-id>/verdict.md` exists. |
 | Verdict to work | 2 min | `bd show <issue-id>` cites the verdict path. |
-| Optional out-of-session lane | 5 min | A substrate (Gas City) Order is registered to run the loop unattended. |
+| Optional out-of-session lane | 5 min | A substrate (NTM / managed-agents) dispatch is registered to run the loop unattended. |
 
 ## Commands And Expected Outputs
 
@@ -167,15 +167,16 @@ the zero-dependency sovereignty floor. Running the same loop **out of session**
 (always-on, scheduled, unattended) is a separate concern. AgentOps 3.0 ships no
 daemon, scheduler, or overnight runner of its own — those surfaces were deleted
 (see [AgentOps 3.0 north star](3.0.md)). Out-of-session orchestration is
-delegated to a substrate, and AgentOps ships a reference one: a **Gas City**
-City (`city.toml` + `packs/agentops/`).
+delegated to a substrate. The reference is the trio AgentOps actually runs on —
+**NTM** (a tmux agent swarm), **MCP** (`ao mcp serve`), and **managed-agents**
+(`ao agent`) — none of it AgentOps-owned.
 
-On the reference substrate, a long-lived **mayor** agent runs `bd ready` and
-dispatches the next bead to a **refinery** worker that runs `ao rpi <bead>`;
-scheduled maintenance (`ao compile`, `ao maturity --scan`) runs as cron `exec`
-Orders. The agents inherit the AgentOps skills via an overlay and run the same
+On the reference substrate, an NTM swarm (or a lead agent) runs `bd ready` and
+dispatches the next bead to a worker that runs `ao rpi <bead>`; scheduled
+maintenance (`ao compile`, `ao maturity --scan`) runs via a managed-agent driver
+or cron. The agents inherit the AgentOps skills via an overlay and run the same
 loop you just ran by hand. See the [AgentOps 3.0 north star](3.0.md) for the
-in-session / out-of-session split and the reference City.
+in-session / out-of-session split and the reference substrate.
 
 ## First Artifacts To Inspect
 
@@ -185,7 +186,7 @@ in-session / out-of-session split and the reference City.
 | `.agents/rpi/briefing-current.md` | The bounded task context assembled for the run. |
 | `.agents/council/<run-id>/verdict.md` | The engineering verdict from the council. |
 | `.beads/issues.jsonl` | The tracked work created from the verdict. |
-| `city.toml` + `packs/agentops/` | The reference Gas City substrate for the optional out-of-session lane, only after first trust exists. |
+| Substrate config (an NTM swarm · `ao mcp serve` · `ao agent`) | The reference out-of-session substrate (NTM + MCP + managed-agents) for the optional lane, only after first trust exists. |
 
 ## Friction List
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -19,7 +19,7 @@ The same split applies to Dream's in-session surface:
 - skills (`/dream`) are the interactive operator surface for a compounding session
 - the `ao` CLI primitives (`ao compile`, `ao maturity`, `ao flywheel close-loop`) are the headless work the loop performs
 
-Running that compounding *out of session* — always-on, scheduled, unattended — is delegated to an orchestration substrate (Gas City is the reference City), not an AgentOps daemon or scheduler; those surfaces were deleted in 3.0. GitHub nightly remains the public CI proof harness for the report contract; the private always-on compounding engine is the Gas City substrate driving the in-session loop.
+Running that compounding *out of session* — always-on, scheduled, unattended — is delegated to an orchestration substrate (the reference is NTM + MCP + managed-agents), not an AgentOps daemon or scheduler; those surfaces were deleted in 3.0. GitHub nightly remains the public CI proof harness for the report contract; the private always-on compounding engine is the substrate driving the in-session loop.
 
 ## The Proof Gaps
 
@@ -221,7 +221,7 @@ Dream is the compounding expression of the same loop model:
 
 A foreground `/dream` session keeps runtime behavior honest: no tracked source-code edits by default, optional bounded Dream Council synthesis through independent runner reports, and a shared report contract.
 
-Running Dream **unattended** — always-on, scheduled, queue-driven — is out-of-session orchestration, which AgentOps delegates to a substrate (Gas City is the reference City) rather than shipping its own daemon or scheduler. The Gas City pattern is a long-lived agent running `/dream`-equivalent maintenance Orders (`ao compile`, `ao maturity --scan`) on a cron `exec` schedule. There are no fake scheduler guarantees on a sleeping laptop; the substrate owns when and where.
+Running Dream **unattended** — always-on, scheduled, queue-driven — is out-of-session orchestration, which AgentOps delegates to a substrate (the reference is NTM + MCP + managed-agents) rather than shipping its own daemon or scheduler. The pattern is a long-lived agent — an NTM swarm pane or a managed-agent driver — running `/dream`-equivalent maintenance (`ao compile`, `ao maturity --scan`) on a cron schedule. There are no fake scheduler guarantees on a sleeping laptop; the substrate owns when and where.
 
 GitHub nightly remains useful for a different job: it proves that Dream's report contract and flywheel primitives still work in CI. It does not replace a substrate-driven unattended run.
 

--- a/docs/software-factory.md
+++ b/docs/software-factory.md
@@ -56,7 +56,7 @@ What used to be hook responsibilities are now explicit, pulled surfaces:
 Both lanes run **in session** because people use Codex or they use Claude
 Code — neither relies on hooks. Running the same loop **out of session**
 (always-on, scheduled, unattended) is a separate concern AgentOps delegates to
-an orchestration substrate; Gas City is the reference City. AgentOps 3.0 ships
+an orchestration substrate; the reference is NTM + MCP + managed-agents. AgentOps 3.0 ships
 no daemon, scheduler, or overnight runner of its own — those surfaces were
 deleted (see [AgentOps 3.0 north star](3.0.md)).
 
@@ -66,7 +66,7 @@ deleted (see [AgentOps 3.0 north star](3.0.md)).
 |------|---------|------------------|
 | Operator | What the human or lead agent should touch first | `ao factory start`, `/rpi`, `ao rpi phased`, `ao rpi status` |
 | Briefing + runtime | Bounded startup context and thread-time state | `ao knowledge brief`, `ao context assemble` |
-| Out-of-session | Running the loop unattended (always-on, scheduled) | Delegated to an orchestration substrate (Gas City is the reference) — not an AgentOps surface |
+| Out-of-session | Running the loop unattended (always-on, scheduled) | Delegated to an orchestration substrate (the reference is NTM + MCP + managed-agents) — not an AgentOps surface |
 | Delivery line | Research, planning, execution, validation | `/discovery`, `/plan`, `/crank`, `/validation`, `/rpi` |
 | Learning loop | Convert completed work into future advantage | `ao knowledge activate`, `ao flywheel close-loop`, `/retro`, `/forge` |
 | Enforcement | Automatic quality gates and execution discipline | CI (`.github/workflows/validate.yml`), skill-level checks, `cd cli && make test` |

--- a/docs/workflows/session-lifecycle.md
+++ b/docs/workflows/session-lifecycle.md
@@ -65,9 +65,9 @@ workflow:
 **Running Dream unattended is out-of-session orchestration**, which AgentOps
 3.0 delegates to a substrate rather than shipping its own daemon, scheduler, or
 overnight runner — those surfaces were deleted (see
-[AgentOps 3.0 north star](../3.0.md)). On the reference substrate (Gas City), a
-long-lived agent runs `/dream`-equivalent maintenance Orders on a cron `exec`
-schedule. The substrate owns when and where; AgentOps owns what the loop does.
+[AgentOps 3.0 north star](../3.0.md)). On the reference substrate (NTM + MCP +
+managed-agents), a long-lived agent runs `/dream`-equivalent maintenance on a
+cron schedule. The substrate owns when and where; AgentOps owns what the loop does.
 No tool pretends a sleeping laptop has guaranteed wake behavior.
 
 ### Option 4: Lower-Level Codex Lifecycle
@@ -113,7 +113,7 @@ SessionEnd would normally run.
 | Hook-capable | Natural language, `/session-start`, or startup hooks | Natural language, `/session-end`, or session-end hooks | Best fit for Claude/OpenCode when hooks are installed; `CLAUDE.md` is the startup surface and hooks stage state silently |
 | Codex optional native hooks | Quiet native `SessionStart` maintenance plus explicit `ao codex start` / `ao codex ensure-start` when context retrieval is needed | Native `Stop` hook for turn-scope close-loop; explicit `ao codex stop` / `ao codex ensure-stop` for transcript-driven closeout | Opt-in with `install-codex.sh --with-hooks`; startup hooks stay quiet and no native `SessionEnd` event exists today |
 | Codex hookless default | `ao factory start --goal "<goal>"`, `ao rpi phased`, `ao codex start`, or skill-driven `ao codex ensure-start` | `ao codex stop` or skill-driven `ao codex ensure-stop` | No startup/session-end hook surface required; lifecycle is explicit, and closeout owns the same curation hygiene as SessionEnd |
-| Dream compounding run | `/dream "<goal>"` (foreground, in session) | Reads `summary.json` / `summary.md` from the run dir | Private local compounding in a watchable session. Running it unattended is out-of-session orchestration, delegated to a substrate (Gas City is the reference) — AgentOps ships no daemon or scheduler |
+| Dream compounding run | `/dream "<goal>"` (foreground, in session) | Reads `summary.json` / `summary.md` from the run dir | Private local compounding in a watchable session. Running it unattended is out-of-session orchestration, delegated to a substrate (the reference is NTM + MCP + managed-agents) — AgentOps ships no daemon or scheduler |
 | Manual fallback | `ao inject`, `ao lookup` | `ao forge transcript`, `ao flywheel close-loop` | Lowest-level portable path |
 
 ---


### PR DESCRIPTION
## What

Fixes the **post-mortem WARN caveat** from the #684–#687 session: 5 docs still **asserted "Gas City is the reference"** — a now-FALSE claim contradicting the north star ([`docs/3.0.md`](docs/3.0.md): substrate = **NTM + MCP + managed-agents**). Re-narrates all 11 refs (**ag-r6g1**, docs slice #2).

## Surfaces (5 files, +21 −20)

- `docs/how-it-works.md` (2) — out-of-session delegation + Dream-unattended para (de-GC'd the mayor/refinery/cron-`exec`-Order mechanics → NTM swarm / managed-agent driver).
- `docs/software-factory.md` (2) — prose + Surface Map row.
- `docs/first-value-path.md` (4) — step 6, fast-path table row, the substrate block (mayor/refinery/Orders/`city.toml` → the NTM+MCP+managed-agents trio), artifacts row.
- `docs/architecture/ports-and-adapters.md` (1) — autonomous-loops delegation.
- `docs/workflows/session-lifecycle.md` (2) — substrate prose + table row.

Kept the correct "AgentOps ships no daemon/scheduler; delegates to a substrate" framing intact.

## Scope

**ag-r6g1 stays OPEN** — operator runbooks (`nightly-evolution`, `autonomy-runtime-cycle-1`, deeper GC-specific mechanics) + descriptive comparison/example/explainer mentions remain for a later slice.

## Verification

- markdownlint 0 errors · `regen-all.sh --check` ALL GREEN (docs-only; no derived-surface drift).

Closes-scenario: ag-r6g1#docs-slice-2
Bounded-context: BC1-Corpus
Evidence: docs/how-it-works.md
