### PR TITLE
docs(runbooks): re-narrate Gas City orchestration to NTM+MCP+managed-agents (ag-r6g1 #runbooks-slice)

### DIFF
--- a/docs/runbooks/autonomy-runtime-cycle-1.md
+++ b/docs/runbooks/autonomy-runtime-cycle-1.md
@@ -10,8 +10,9 @@ phased runs and `ao evolve` supervisor loops.
 > daemon of its own (see
 > [ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)). The in-session
 > loop (`ao rpi`, `ao evolve`) runs end-to-end in a plain session; to run it
-> unattended out of session, dispatch it on the **Gas City reference City** (a
-> mayor agent slings ready beads to refinery workers that run `ao rpi`). This
+> unattended out of session, dispatch it on the **reference substrate**
+> (NTM + MCP + managed-agents) — an NTM swarm (or a lead agent) slings ready
+> beads to workers that run `ao rpi`. This
 > runbook now covers the in-session surfaces only.
 
 ## Activation
@@ -41,7 +42,7 @@ Cycle-1 runtime controls are in-session command flags:
 Activation rule:
 
 - Start with `--dry-run` and `--max-cycles 1`.
-- For unattended out-of-session runs, dispatch the loop on the Gas City reference City only after the local RPI and evolve dry runs are clean.
+- For unattended out-of-session runs, dispatch the loop on the reference substrate (NTM + MCP + managed-agents) only after the local RPI and evolve dry runs are clean.
 - Keep manual merge/review in the loop until the release-readiness contract says otherwise.
 
 ## Rollback Trigger
@@ -64,7 +65,7 @@ Verify lifecycle and orchestration evidence via:
 
 1. RPI / bead events include the relevant lifecycle markers and payload fields.
    - RPI phased state and artifacts live under `.agents/rpi/`.
-   - Out-of-session job events (when dispatched on Gas City) are inspectable through the substrate's own event surface, not an AgentOps daemon.
+   - Out-of-session job events (when dispatched on the substrate) are inspectable through the substrate's own event surface, not an AgentOps daemon.
 2. RPI run ledger / bead store contains attempt records for affected beads (`bd show <id>`, `ao rpi status`).
 3. RPI tests pass:
    - `cd cli && go test ./internal/rpi/...`
@@ -74,7 +75,7 @@ Verify lifecycle and orchestration evidence via:
 
 ## Operator Notes
 
-- This runbook covers the in-session loop only; out-of-session/fleet orchestration is delegated to the Gas City reference City, not an AgentOps daemon.
+- This runbook covers the in-session loop only; out-of-session/fleet orchestration is delegated to the reference substrate (NTM + MCP + managed-agents), not an AgentOps daemon.
 - This runbook does not relax validation boundaries (`/vibe`, `/council`, `ao goals validate`, gate scripts all still apply).
 - This runbook is cycle-1 only; fleet/autopilot runtime expansion is a follow-on cycle.
 

--- a/docs/runbooks/nightly-evolution.md
+++ b/docs/runbooks/nightly-evolution.md
@@ -6,11 +6,12 @@
 > scheduler, or overnight runner of its own (see
 > [ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)). The loop
 > (`ao rpi` / `ao evolve`, the `/dream` skill) runs in session; to run it
-> unattended out of session, dispatch it on the **Gas City reference City** (a
-> long-lived mayor agent slings ready beads to refinery workers that run
-> `ao rpi`; scheduled maintenance runs as Gas City cron Orders). This runbook is
-> retained for the repo-owned run-contract and digest mechanics; treat the
-> orchestration surface as Gas City, not an AgentOps daemon.
+> unattended out of session, dispatch it on the **reference substrate**
+> (NTM + MCP + managed-agents): an NTM swarm (or a lead agent) slings ready beads
+> to workers that run `ao rpi`; scheduled maintenance runs via a managed-agent
+> driver or cron. This runbook is retained for the repo-owned run-contract and
+> digest mechanics; treat the orchestration surface as the substrate, not an
+> AgentOps daemon.
 
 This runbook describes the private local nightly automation lane. It is separate
 from GitHub Actions.
@@ -21,16 +22,16 @@ from GitHub Actions.
 |---------|------|
 | GitHub Nightly | Public proof harness over repo-visible state |
 | Nightly RPI Brief | Evidence packet and prompt issue |
-| Gas City reference City | Out-of-session orchestration substrate (mayor + refinery agents) for unattended runs |
+| Reference substrate (NTM + MCP + managed-agents) | Out-of-session orchestration (swarm + worker agents) for unattended runs |
 | `scripts/nightly-evolution.sh` | Repo-owned run contract and digest writer |
-| `/dream` skill | Private Dream/wiki knowledge compounding (in session; dispatched out of session via a Gas City Order) |
+| `/dream` skill | Private Dream/wiki knowledge compounding (in session; dispatched out of session via the substrate) |
 | `ao rpi` / `ao evolve` | Code-mutating implementation cycles, dispatched as one invocable unit |
 | Claude Code | Headless worker/reviewer via local CLI or GitHub companion action |
 | Codex | Headless worker/reviewer via `codex exec` or local AgentOps runtime |
 | Mt. Olympus | Sovereign full-custom runtime (keeps its own Rust daemon) — alternate out-of-session driver |
 
 Bushido is a private dogfood target, not a public AgentOps namespace. Out-of-
-session runs are dispatched on the Gas City reference City; AgentOps ships no
+session runs are dispatched on the reference substrate (NTM + MCP + managed-agents); AgentOps ships no
 scheduler of its own. Mt. Olympus can run the same contract through its sovereign
 Rust core once provider readiness and replay are proven.
 
@@ -49,7 +50,7 @@ scripts/nightly-evolution.sh --execute --run-dream
 ```
 
 In 3.0 the Dream lane runs the `/dream` skill in session; to run it unattended,
-dispatch it as a Gas City Order. The daemon-backed `dream.run` job submission
+dispatch it on the substrate (an NTM swarm pane or managed-agent driver). The daemon-backed `dream.run` job submission
 this flag historically used was removed with the daemon
 ([ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)); the run
 contract and digest mechanics below are unaffected.
@@ -74,8 +75,8 @@ scripts/nightly-evolution.sh --execute --run-dream --run-evolve --max-cycles 1
 ## Host-OS timing (not an AgentOps scheduler)
 
 AgentOps ships no scheduler; recurring runs are driven by host-OS timing (a
-systemd user timer or cron) calling the repo script, or by a Gas City cron
-Order. The helper below installs a **host systemd user timer** — operator
+systemd user timer or cron) calling the repo script, or by a substrate-side
+dispatch (a managed-agent driver or cron). The helper below installs a **host systemd user timer** — operator
 infrastructure, not an AgentOps-managed surface.
 
 ### Automated Install
@@ -140,7 +141,7 @@ systemctl --user enable --now agentops-nightly-evolution.timer
 Use Claude and Codex differently until eval evidence says mixed mode is stable:
 
 - Dream handoff: run the `/dream` skill in session; dispatch it out of session
-  as a Gas City Order (no AgentOps daemon — see
+  on the substrate (no AgentOps daemon — see
   [ADR-0009](../adr/ADR-0009-daemon-deletion-in-session-only.md)). The run
   contract still honors the configured Claude/Codex runner list.
 - Planning/review: prefer Claude or mixed mode for synthesis-heavy work.
@@ -148,7 +149,7 @@ Use Claude and Codex differently until eval evidence says mixed mode is stable:
   burden.
 - CI/GitHub companion: use Claude Code GitHub Actions for repo-visible reviews
   or reports, not private `.agents` mutation.
-- Gas City: dispatch whole `ao rpi` / `ao evolve` loops as one invocable unit
+- Substrate: dispatch whole `ao rpi` / `ao evolve` loops as one invocable unit
   only after provider readiness and replay are proven.
 
 ## Safety Controls


### PR DESCRIPTION
## What

Round-3 Gas City doctrine sweep — **operator-runbooks slice** (**ag-r6g1**). Both runbooks framed out-of-session orchestration as the "Gas City reference City" with GC-specific mechanics (mayor + refinery agents, Gas City cron Orders). Re-narrated to the canonical substrate **NTM + MCP + managed-agents** per [`docs/3.0.md`](docs/3.0.md).

## Surfaces (2 files, +20 −18)

- `docs/runbooks/nightly-evolution.md` — 3.0-note header, Architecture table rows (reference-City + `/dream` dispatch), out-of-session prose, First-Safe-Run note, recurring-runs note, Vendor-Policy Dream-handoff + substrate bullet. Mayor/refinery → NTM swarm + workers; Gas City cron Order → managed-agent driver or cron.
- `docs/runbooks/autonomy-runtime-cycle-1.md` — 3.0-note header, dry-run guidance, observability bullet, operator-notes line.

Kept the correct "AgentOps ships no daemon/scheduler" framing and Mt. Olympus (separate sovereign runtime) untouched.

## Scope

This clears the **operator-facing** surfaces. ag-r6g1's remaining refs are descriptive comparison/example/explainer mentions (illustrative "dispatched on the Gas City reference City") — a final low-priority slice.

## Verification

- markdownlint 0 errors · `regen-all.sh --check` ALL GREEN (docs-only).

Closes-scenario: ag-r6g1#runbooks-slice
Bounded-context: BC1-Corpus
Evidence: docs/runbooks/nightly-evolution.md
