### PR TITLE
feat(skills): add AgentOps-owned using-ntm substrate-orchestration skill (ag-zaoj #using-ntm-skill)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -67,7 +67,7 @@ The April 2026 Claude Code source analysis confirmed that Anthropic's internal t
 | Anthropic Concept | AgentOps Equivalent | Status |
 |---|---|---|
 | **Learning Loop** — memory extraction, dream cycle consolidation, future session context | Knowledge Flywheel — `/retro` → `/forge` → `/harvest` → `ao lookup` / `ao context assemble`, tiered promotion (learning → pattern → rule), plus bounded Dream via `/dream` | Live with bounds. On-demand capture/promotion works, and Dream provides an operator-started compounding lane. GitHub nightly is the public proof harness for the contracts, not the user's private runtime. |
-| **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 81 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
+| **Skillify** — AI watches patterns, packages them as reusable skills, compound growth | Skills system — 82 skills, `/heal-skill` audit, `/converter` cross-runtime export, SKILL-TIERS classification | Prototype built. `ao flywheel close-loop` now drafts review-only skills from repeated patterns; promotion polish is the remaining gap. |
 | **Verification Agent** — adversarial AI auditing AI, VERDICT system for human review | Council architecture — `/council`, `/pre-mortem`, `/vibe`, `/post-mortem` with multi-model consensus, prediction tracking. Stage 4 behavioral validation adds holdout scenarios + satisfaction scoring in STEP 1.8. | Live on demand. STEP 1.8 fires automatically inside `/validation` when that skill is invoked. |
 | **Managed Agents Dreaming** (May 2026) — scheduled session review, pattern extraction, memory curation between sessions | `/dream` + `.github/workflows/nightly.yml` proof jobs + substrate-driven scheduling when needed | Live with operator setup. The bounded private Dream lane runs harvest → forge → close-loop → defrag when the operator or substrate starts it. AgentOps itself no longer ships the daemon executor. |
 | **Managed Agents Outcomes** (May 2026) — rubric-driven separate-context grader with iterate-until-pass | Live at three scopes: project — `GOALS.md` (rubric) + `ao goals measure` (each gate runs as separate subprocess; `cli/internal/goals/measure.go:132-164`) + `/evolve` (can iterate a worst-failing gate under operator limits; `skills/evolve/SKILL.md:379-388`); plan — `/pre-mortem` council judges as separate-context graders; code — `/vibe` council judges. An internal council review (2026-05-06) found these capabilities present across rubric authoring, separate-context grading, iterate-until-pass, and pinpoint-what-changed; this is an internal finding, not an audited external-parity claim. | Live at the capability layer. Empirical workbench A/B (2026-05-06): Δ=+0.0000 across 12 cases at v1 difficulty (both legs 12/12) — task difficulty floor exhausted; v2 substrate (realistic agent tasks where the hook layer differentiates) is roadmap. Counter-stat artifact: `evals/workbench/results/2026-05-06-yjzp9-counterstat.json`. |
@@ -176,7 +176,7 @@ The same model used in the README: bookkeeping records the work, the context com
 - `ao lookup` — decay-ranked retrieval for on-demand knowledge
 - `ao context assemble` — phase-scoped context packets
 - `ao compile` — rebuild the knowledge wiki (mine, grow, defrag, lint)
-- 81 skills — reusable context packages across Claude Code, Codex, and OpenCode
+- 82 skills — reusable context packages across Claude Code, Codex, and OpenCode
 - `bash <(curl -fsSL .../install.sh)` — 30 seconds, zero config
 
 #### Layer 3: Validation Gates
@@ -261,7 +261,7 @@ As of 2026-05-10:
 
 - GitHub repo: 341 stars, 33 forks, 2 open issues, last pushed 2026-05-10T03:24:01Z
 - Public surface: GitHub Pages mkdocs site live at boshu2.github.io/agentops/; doctrine site live at 12factoragentops.com
-- Distribution/runtime reach: 81 shared skills, 81 checked-in Codex artifacts, and 32 Codex overrides. `/validate` and `/curate` are additive in this train; legacy validation and mining skills remain until their shim/retirement gates are resolved.
+- Distribution/runtime reach: 82 shared skills, 82 checked-in Codex artifacts, and 32 Codex overrides. `/validate` and `/curate` are additive in this train; legacy validation and mining skills remain until their shim/retirement gates are resolved.
 
 **Measured operational proof:**
 

--- a/cli/embedded/skills/using-agentops/SKILL.md
+++ b/cli/embedded/skills/using-agentops/SKILL.md
@@ -145,6 +145,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/release` | Pre-flight, changelog, version bumps, tag |
 | `/crank` | Autonomous epic loop (uses swarm for each wave) |
 | `/swarm` | Fresh-context parallel execution (Ralph pattern) |
+| `/using-ntm` | Run AgentOps loops out of session on an NTM tmux swarm (the NTM leg of the substrate) |
 | `/evolve` | Goal-driven fitness-scored improvement loop |
 | `/burndown` | Bounded epic-completion loop — drive a finite target to all-merged, then stop |
 | `/eval-outcomes` | Grade via Outcomes as a holdout-safe projection of the locked eval substrate — one bar, many runtimes |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -351,7 +351,7 @@ All hooks can be disabled: `AGENTOPS_HOOKS_DISABLED=1` (kill switch) or per-hook
 .
 ├── .claude-plugin/
 │   └── plugin.json      # Plugin manifest
-├── skills/              # 81 skills (72 user-facing, 9 internal)
+├── skills/              # 82 skills (73 user-facing, 9 internal)
 │   ├── rpi/             # orchestration — Full RPI lifecycle orchestrator
 │   ├── council/         # orchestration — Multi-model validation (core primitive)
 │   ├── crank/           # orchestration — Autonomous epic execution

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -1,6 +1,6 @@
 # Skills Reference
 
-Complete reference for all 81 AgentOps skills (72 user-facing + 9 internal).
+Complete reference for all 82 AgentOps skills (73 user-facing + 9 internal).
 
 Skills are the primitive layer of AgentOps. Higher-level entry points like
 `/implement`, `/validation`, `/rpi`, and `/evolve` compose those primitives

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -96,7 +96,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `system-tuning` — Restore system responsiveness via safe, ordered process cleanup and agent-swarm hygiene.
 - `test` — Generate tests and coverage plans.
 - `trace` — Trace decisions through artifacts.
-- `using-ntm` — Use NTM (Named Tmux Manager) as the out-of-session substrate: spawn Claude/Codex panes that run the /rpi and /evolve skills over a bead queue, coordinate via beads + MCP Agent Mail, and tend the swarm to convergence. Use when running AgentOps loops unattended, standing up an NTM agent swarm, dispatching the loop to a substrate, or tending/unsticking a running swarm.
+- `using-ntm` — Use NTM as the out-of-session substrate: spawn Claude/Codex panes running /rpi and /evolve over a bead queue, then tend the swarm to convergence.
 - `workflow-builder` — Scaffold a new Claude Workflow script — deterministic multi-agent orchestration. Triggers: "build a workflow", "create a workflow", "scaffold workflow", "author a workflow".
 
 ### generic

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -96,6 +96,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `system-tuning` — Restore system responsiveness via safe, ordered process cleanup and agent-swarm hygiene.
 - `test` — Generate tests and coverage plans.
 - `trace` — Trace decisions through artifacts.
+- `using-ntm` — Use NTM (Named Tmux Manager) as the out-of-session substrate: spawn Claude/Codex panes that run the /rpi and /evolve skills over a bead queue, coordinate via beads + MCP Agent Mail, and tend the swarm to convergence. Use when running AgentOps loops unattended, standing up an NTM agent swarm, dispatching the loop to a substrate, or tending/unsticking a running swarm.
 - `workflow-builder` — Scaffold a new Claude Workflow script — deterministic multi-agent orchestration. Triggers: "build a workflow", "create a workflow", "scaffold workflow", "author a workflow".
 
 ### generic
@@ -166,6 +167,7 @@ graph LR
   skill-builder -- "supplier-to" --> skill-auditor
   swarm -- "customer-of" --> crank
   trace -- "customer-of" --> provenance
+  using-ntm -- "customer-of" --> swarm
   validate -- "customer-of" --> validation
   validation -- "shared-kernel" --> standards
   vibe -- "shared-kernel" --> standards
@@ -344,6 +346,7 @@ graph LR
 | `test` | produces | result.json |
 | `trace` | produces | result.json |
 | `using-agentops` | produces | documentation |
+| `using-ntm` | produces | documentation |
 | `validate` | consumes | validation |
 | `validate` | produces | result.json |
 | `validation` | consumes | forge |

--- a/docs/contracts/skill-dispositions.yaml
+++ b/docs/contracts/skill-dispositions.yaml
@@ -422,3 +422,8 @@ dispositions:
     hexagonal_role: supporting
     disposition:    keep
     rationale:      "Hookless reframe: makes out-of-session agents (Managed/SDK/sandbox) AgentOps-native via skills + ao CLI + CI; extends standards+converter, never a hook revival"
+  - skill:          using-ntm
+    domain:         "BC4 Factory"
+    hexagonal_role: supporting
+    disposition:    keep
+    rationale:      "Shippable AgentOps-scoped guide for the NTM leg of the out-of-session substrate (NTM+MCP+managed-agents): spawn agent panes that run the /rpi and /evolve skills over a bead queue. Replaces the dangling external ntm/vibing-with-ntm pointers in automation-shape-routing with an owned, skills-as-runtime skill."

--- a/docs/reference/agentops-domain-evolution-bdd.md
+++ b/docs/reference/agentops-domain-evolution-bdd.md
@@ -19,7 +19,7 @@ Feature: Domain-governed AgentOps 3.0 evolution
     And external-corpus-derived observations are used only through the clean-room policy
 
   Scenario: Audit every skill before changing shipped behavior
-    Given the checked-in skill catalog contains 81 skills
+    Given the checked-in skill catalog contains 82 skills
     When the evolution bootstrap audits the catalog
     Then every skill is assigned exactly one primary bounded context
     And each skill has a preliminary keep, update, refactor, merge-review, or cut-review disposition

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -1,7 +1,7 @@
 # AgentOps Skill Domain Map
 
 This map is the control surface for the next evolution loop. It classifies all
-81 checked-in AgentOps skills before any broad rewrite, using current
+82 checked-in AgentOps skills before any broad rewrite, using current
 `origin/main` product direction, GOALS Directive 12, the DDD/hexagonal ADR, and
 the `soc-y5vh` Loop epic.
 
@@ -18,9 +18,9 @@ around small provable changes.
 <!-- BEGIN:audit-summary -->
 | Signal | Result |
 |---|---:|
-| Skills audited | 81 |
+| Skills audited | 82 |
 | Domains classified | 5 of 5 (BC1-BC5) |
-| Dispositions assigned | 81 / 81 |
+| Dispositions assigned | 82 / 82 |
 <!-- END:audit-summary -->
 
 Observed gap: the catalog has strong operational kernels but weak productized
@@ -136,6 +136,7 @@ Disposition meanings:
 | `test` | BC2 Validation | supporting | update | Test generator; central to first-failing-test loop. |
 | `trace` | BC1 Corpus | supporting | update | Decision trace builder; align to provenance and cycle trace. |
 | `using-agentops` | BC4 Factory | generic | update | Operator education; align to 3.0 first-value path. |
+| `using-ntm` | BC4 Factory | supporting | keep | Shippable AgentOps-scoped guide for the NTM leg of the out-of-session substrate (NTM+MCP+managed-agents): spawn agent panes that run the /rpi and /evolve skills over a bead queue. Replaces the dangling external ntm/vibing-with-ntm pointers in automation-shape-routing with an owned, skills-as-runtime skill.. |
 | `validate` | BC2 Validation | driving-adapter | keep | Designed-future canonical unified validator (m6v5.D Phase 1, epic soc-cp7pv); not redundant cruft — epic GO/REVERT is a separate decision (resolved KEEP 2026-05-24). |
 | `validation` | BC2 Validation | domain | update | Canonical post-implementation validation; strengthen self-test first. |
 | `vibe` | BC2 Validation | domain | update | Code-readiness validator; add self-test and tighten result contract. |

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-02T23:58:44Z",
+  "generated_at": "2026-06-03T00:03:21Z",
   "summary": {
     "skills": 82,
     "hooks": 0,
@@ -989,8 +989,7 @@
           "autodev",
           "evolve",
           "shared",
-          "using-agentops",
-          "using-ntm"
+          "using-agentops"
         ]
       },
       {
@@ -1330,8 +1329,7 @@
           "shared",
           "standards",
           "swarm",
-          "using-agentops",
-          "using-ntm"
+          "using-agentops"
         ]
       },
       {
@@ -3309,9 +3307,7 @@
       "drives_commands": [
         "ao agent",
         "ao agent bundle",
-        "ao evolve",
-        "ao mcp serve",
-        "ao rpi"
+        "ao mcp serve"
       ],
       "path": "skills/using-ntm/",
       "references": 0
@@ -3918,8 +3914,7 @@
         "autodev",
         "evolve",
         "shared",
-        "using-agentops",
-        "using-ntm"
+        "using-agentops"
       ],
       "flags": [
         "--auto-clean",
@@ -4725,8 +4720,7 @@
         "shared",
         "standards",
         "swarm",
-        "using-agentops",
-        "using-ntm"
+        "using-agentops"
       ],
       "flags": [
         "--config",

--- a/registry.json
+++ b/registry.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-02T21:25:32Z",
+  "generated_at": "2026-06-02T23:40:17Z",
   "summary": {
-    "skills": 81,
+    "skills": 82,
     "hooks": 0,
     "knowledge_stores": 5,
     "job_types": 0,
     "eval_files": 56,
     "cli_commands": 74,
-    "capabilities": 166
+    "capabilities": 167
   },
   "surfaces": {
     "skills": [
@@ -315,6 +315,14 @@
         "has_skill_md": true,
         "has_references": true,
         "reference_count": 6
+      },
+      {
+        "name": "using-ntm",
+        "tier": "execution",
+        "path": "skills/using-ntm/",
+        "has_skill_md": true,
+        "has_references": false,
+        "reference_count": 0
       },
       {
         "name": "council",
@@ -780,7 +788,8 @@
         "driven_by_skills": [
           "domain",
           "shared",
-          "using-agentops"
+          "using-agentops",
+          "using-ntm"
         ]
       },
       {
@@ -980,7 +989,8 @@
           "autodev",
           "evolve",
           "shared",
-          "using-agentops"
+          "using-agentops",
+          "using-ntm"
         ]
       },
       {
@@ -1320,7 +1330,8 @@
           "shared",
           "standards",
           "swarm",
-          "using-agentops"
+          "using-agentops",
+          "using-ntm"
         ]
       },
       {
@@ -1441,8 +1452,8 @@
     ]
   },
   "capability_summary": {
-    "total": 166,
-    "skills": 81,
+    "total": 167,
+    "skills": 82,
     "cli_commands": 74,
     "gates": 11,
     "reference_impls": 0
@@ -3282,6 +3293,30 @@
       "references": 0
     },
     {
+      "sku": "skill:using-ntm",
+      "name": "using-ntm",
+      "type": "skill",
+      "bounded_context": "BC4",
+      "hex_role": "supporting",
+      "tier": "execution",
+      "purpose": "Use NTM (Named Tmux Manager) as the out-of-session substrate: spawn Claude/Codex panes that run the /rpi and /evolve skills over a bead queue, coordinate via beads + MCP Agent Mail, and tend the swarm to convergence. Use when running AgentOps loops unattended, standing up an NTM agent swarm, dispatching the loop to a substrate, or tending/unsticking a running swarm.",
+      "status": "active",
+      "disposition": "keep",
+      "consumes": [],
+      "produces": [
+        "documentation"
+      ],
+      "drives_commands": [
+        "ao agent",
+        "ao agent bundle",
+        "ao evolve",
+        "ao mcp serve",
+        "ao rpi"
+      ],
+      "path": "skills/using-ntm/",
+      "references": 0
+    },
+    {
       "sku": "skill:validate",
       "name": "validate",
       "type": "skill",
@@ -3397,7 +3432,8 @@
       "driven_by_skills": [
         "domain",
         "shared",
-        "using-agentops"
+        "using-agentops",
+        "using-ntm"
       ],
       "flags": [
         "--config",
@@ -3882,7 +3918,8 @@
         "autodev",
         "evolve",
         "shared",
-        "using-agentops"
+        "using-agentops",
+        "using-ntm"
       ],
       "flags": [
         "--auto-clean",
@@ -4688,7 +4725,8 @@
         "shared",
         "standards",
         "swarm",
-        "using-agentops"
+        "using-agentops",
+        "using-ntm"
       ],
       "flags": [
         "--config",

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-02T23:40:17Z",
+  "generated_at": "2026-06-02T23:58:44Z",
   "summary": {
     "skills": 82,
     "hooks": 0,
@@ -3299,7 +3299,7 @@
       "bounded_context": "BC4",
       "hex_role": "supporting",
       "tier": "execution",
-      "purpose": "Use NTM (Named Tmux Manager) as the out-of-session substrate: spawn Claude/Codex panes that run the /rpi and /evolve skills over a bead queue, coordinate via beads + MCP Agent Mail, and tend the swarm to convergence. Use when running AgentOps loops unattended, standing up an NTM agent swarm, dispatching the loop to a substrate, or tending/unsticking a running swarm.",
+      "purpose": "Use NTM as the out-of-session substrate: spawn Claude/Codex panes running /rpi and /evolve over a bead queue, then tend the swarm to convergence.",
       "status": "active",
       "disposition": "keep",
       "consumes": [],

--- a/skills-codex-overrides/catalog.json
+++ b/skills-codex-overrides/catalog.json
@@ -688,6 +688,12 @@
       "treatment": "parity_only",
       "wave": "catalog-parity",
       "reason": "TODO: confirm parity_only or flip to bespoke (+scaffold override dir) for bd-first-memory-migration"
+    },
+    {
+      "name": "using-ntm",
+      "treatment": "parity_only",
+      "wave": "catalog-parity",
+      "reason": "NTM substrate guidance is documentation-led and portable across runtimes; Codex parity is sufficient"
     }
   ]
 }

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -679,13 +679,13 @@
     {
       "name": "automation-shape-routing",
       "source_skill": "skills/automation-shape-routing",
-      "source_hash": "48310b535e3a04b7ba8dd34b451029473ce21b86d10620b39d1796cd829ac4a4",
-      "generated_hash": "9ec15ab56100ce6cb590ee64047c229b19ca0587b91448cbdbd4dbce66294c5b"
+      "source_hash": "91f7ee3cd2f0cebf30c4da10d69596b2618e58e0dc1c7d8640c5bc628911f2c3",
+      "generated_hash": "74764a511dbf6970f2352ecc713eb6579098fcdd269d7d13fe59db02090d6d45"
     },
     {
       "name": "bd-first-memory-migration",
       "source_skill": "skills/bd-first-memory-migration",
-      "source_hash": "d197166e0417115a76b42832203817a9b36f3b1b388d2d353f3658a99ed89a85",
+      "source_hash": "4bd3360ea8ffd0978e1a9e7fc7506216198a8eeb87a374234952a7af9a7c36df",
       "generated_hash": "4a5b627ca9df88b99a74178c414e5a65f85c83b0576aa213bb500315958104fe"
     },
     {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -2,7 +2,7 @@
   "generator": "manual-maintained",
   "source_root": "skills",
   "layout": "modular",
-  "codex_override_catalog_hash": "391a3d1bc2aae59453208361f11612fad2ab840739ec7489612a0ee5ebec018d",
+  "codex_override_catalog_hash": "9adf69f9b456a65338e914bf511025a64c5c7cc6b3d56ddf6a05185762ee0503",
   "codex_override_catalog": {
     "version": 1,
     "description": "Machine-readable Codex treatment map for the full skill catalog.",
@@ -660,6 +660,12 @@
         "treatment": "parity_only",
         "wave": "catalog-parity",
         "reason": "Hookless Agent-native pattern; codex form is canonical-derived (no bespoke shell idioms)."
+      },
+      {
+        "name": "using-ntm",
+        "treatment": "parity_only",
+        "wave": "catalog-parity",
+        "reason": "NTM substrate guidance is documentation-led and portable across runtimes; Codex parity is sufficient"
       }
     ]
   },
@@ -1123,8 +1129,14 @@
     {
       "name": "using-agentops",
       "source_skill": "skills/using-agentops",
-      "source_hash": "f9ed647dd29a9a0d7b4fb3af1644f6619ebb833bb237dcca66437ad175b3285c",
+      "source_hash": "ec3f75bd54588f260393006552ca7ad8104bec8e11c27ca4db80134a33b1ef65",
       "generated_hash": "93c23a804e321d4dbdf86a31fe7d2165632d159b426395c5040f0a1fdb84fe0c"
+    },
+    {
+      "name": "using-ntm",
+      "source_skill": "skills/using-ntm",
+      "source_hash": "ac30d1684cde02b76bb081e4df4ce80c47324b6db49b7440c0742b47fc2475b7",
+      "generated_hash": "6fa63809ed9265bb70107df030fbedfa1bb363fc89a21637841f873a24ea61dc"
     },
     {
       "name": "validate",

--- a/skills-codex/automation-shape-routing/.agentops-generated.json
+++ b/skills-codex/automation-shape-routing/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/automation-shape-routing",
   "layout": "modular",
-  "source_hash": "48310b535e3a04b7ba8dd34b451029473ce21b86d10620b39d1796cd829ac4a4",
-  "generated_hash": "9ec15ab56100ce6cb590ee64047c229b19ca0587b91448cbdbd4dbce66294c5b"
+  "source_hash": "91f7ee3cd2f0cebf30c4da10d69596b2618e58e0dc1c7d8640c5bc628911f2c3",
+  "generated_hash": "74764a511dbf6970f2352ecc713eb6579098fcdd269d7d13fe59db02090d6d45"
 }

--- a/skills-codex/automation-shape-routing/SKILL.md
+++ b/skills-codex/automation-shape-routing/SKILL.md
@@ -14,7 +14,7 @@ description: 'Front door for agent automation: route to the right builder.'
 | Shape | What it is | Mechanism |
 |---|---|---|
 | **Orchestration** | Deterministic, reproducible fan-out / pipeline / loop over sub-agents, each returning structured output | Codex orchestration — `codex exec` driving `spawn_agents` (parallel fan-out), staged pipelines, and loop-until-budget, with an `output_schema` per sub-agent. Headless, reproducible, bounded concurrency. |
-| **NTM swarm** | Long-lived, human-in-the-loop multi-agent run | `ntm` / `*-with-ntm` — persistent tmux panes, robot API, mail/locks, attach + nudge + kill/relaunch. |
+| **NTM swarm** | Long-lived, human-in-the-loop multi-agent run | `ntm` (the CLI) driven by $using-ntm — persistent tmux panes running whole $rpi/$evolve loops over a bead queue, with attach + nudge + kill/relaunch and mail/locks coordination. |
 | **Plain skill** | One model reasoning through a procedure or knowledge | A single `SKILL.md`. No fan-out, or a strictly sequential edit-loop. |
 
 ## The decision rule (three axes)
@@ -109,7 +109,7 @@ decided, hand off:
 |---|---|---|
 | **plain skill** | `$skill-builder` | Scaffold a new `SKILL.md` against the unified template → then `$skill-auditor` → `$heal-skill`. |
 | **Orchestration** | `$workflow-builder` | Author a deterministic `codex exec` + `spawn_agents` orchestration with per-sub-agent `output_schema`. |
-| **NTM swarm** | `ntm` + `vibing-with-ntm` | Stand up + tend a persistent, human-attachable tmux swarm. |
+| **NTM swarm** | `ntm` + $using-ntm | Stand up + tend an NTM swarm running AgentOps loops ($rpi/$evolve) over a bead queue. |
 
 State the verdict and the deciding axis in one line, then invoke the chosen
 builder. Do not scaffold here.

--- a/skills-codex/bd-first-memory-migration/.agentops-generated.json
+++ b/skills-codex/bd-first-memory-migration/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/bd-first-memory-migration",
   "layout": "modular",
-  "source_hash": "d197166e0417115a76b42832203817a9b36f3b1b388d2d353f3658a99ed89a85",
+  "source_hash": "4bd3360ea8ffd0978e1a9e7fc7506216198a8eeb87a374234952a7af9a7c36df",
   "generated_hash": "4a5b627ca9df88b99a74178c414e5a65f85c83b0576aa213bb500315958104fe"
 }

--- a/skills-codex/using-agentops/.agentops-generated.json
+++ b/skills-codex/using-agentops/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/using-agentops",
   "layout": "modular",
-  "source_hash": "f9ed647dd29a9a0d7b4fb3af1644f6619ebb833bb237dcca66437ad175b3285c",
+  "source_hash": "ec3f75bd54588f260393006552ca7ad8104bec8e11c27ca4db80134a33b1ef65",
   "generated_hash": "93c23a804e321d4dbdf86a31fe7d2165632d159b426395c5040f0a1fdb84fe0c"
 }

--- a/skills-codex/using-ntm/.agentops-generated.json
+++ b/skills-codex/using-ntm/.agentops-generated.json
@@ -1,0 +1,7 @@
+{
+  "generator": "manual-maintained",
+  "source_skill": "skills/using-ntm",
+  "layout": "modular",
+  "source_hash": "ac30d1684cde02b76bb081e4df4ce80c47324b6db49b7440c0742b47fc2475b7",
+  "generated_hash": "6fa63809ed9265bb70107df030fbedfa1bb363fc89a21637841f873a24ea61dc"
+}

--- a/skills-codex/using-ntm/SKILL.md
+++ b/skills-codex/using-ntm/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: using-ntm
+description: Use NTM as the out-of-session substrate for unattended AgentOps loops.
+---
+
+# Using NTM as the Out-of-Session Substrate
+
+AgentOps 3.0 runs its loops **in session** and ships **no** daemon, scheduler, or
+overnight runner. To run the loop **unattended** — always-on, scheduled,
+queue-driven — you hand it to an orchestration **substrate**. The reference
+substrate is **NTM + MCP + managed-agents**; this skill covers the **NTM leg**: a
+local Named Tmux Manager swarm of Claude/Codex agent panes. NTM is an adopted
+external tool (`ntm` on `PATH`), **not** an AgentOps-owned surface.
+
+> **Skills are the runtime, not the CLI.** The substrate dispatches a *whole
+> loop* by spawning an agent that **runs the $rpi or $evolve skill** — it does
+> **not** shell out to an `ao rpi` / `ao evolve` subprocess. Those terminal
+> wrappers are retired; the loop lives as a skill an agent executes. The seam is
+> **NTM pane → agent → $rpi <bead>**, one bead dispatched as one invocable unit.
+
+## When to use / when to skip
+
+**Use it when:** you want a bead queue worked unattended out of session; you're
+standing up or tending an NTM swarm that runs AgentOps loops; a pane is stuck,
+rate-limited, or wedged; you need to know whether the swarm has converged.
+
+**Skip it when:** the work fits a single in-session run (run $rpi or $evolve
+yourself); you want in-session parallel fan-out across worktrees (use $swarm);
+you're choosing between automation shapes (start at $automation-shape-routing).
+
+This skill does **not** re-document the full `ntm` command surface — run
+`ntm help`. It covers the **AgentOps substrate contract**: how to dispatch and
+tend AgentOps loops on an NTM swarm.
+
+## The dispatch contract
+
+1. **One bead = one whole-loop skill invocation.** A pane's agent runs
+   `$rpi <bead>` (one cycle) or `$evolve` (the outer loop). The substrate never
+   decomposes the loop into per-phase steps — whoever owns the loop owns its
+   invariants, and AgentOps owns the loop. Dispatch the skill; don't reimplement it.
+2. **Agents inherit the skills via overlay.** Each pane is a Claude or Codex
+   agent with the AgentOps Codex skills installed, so `$rpi`, `$evolve`,
+   `$validation` resolve in-pane.
+3. **The bead queue is the work source.** A lead runs `bd ready`, picks the next
+   bead, and dispatches it to a free worker pane.
+4. **Green CI is the merge gate.** Each worker drives its bead to a green PR from
+   a per-bead worktree; the operator stays *on* the loop (intent + stop), not *in* it.
+
+## Quick start
+
+```bash
+# 1. Spawn a swarm of agent panes against the repo (2 Claude + 1 Codex worker).
+ntm spawn agentops --cc=2 --cod=1
+
+# 2. Dispatch a whole loop to a pane — the SKILL, not a CLI subprocess.
+ntm send agentops --pane=1 "$rpi ag-1234"
+ntm send agentops --pane=2 "$evolve --beads-only"
+
+# 3. Watch / attach.
+ntm activity agentops          # per-pane agent state
+ntm attach agentops            # drop into the swarm
+
+# 4. Health + dependencies (run before a long unattended session).
+ntm doctor                     # validate the NTM ecosystem
+ntm deps                       # required agent CLIs present
+```
+
+Scheduled cadence (e.g. a nightly $evolve pass) is driven by host-OS timing (a
+systemd user timer or cron) that runs `ntm send … "$evolve"`, or by a
+managed-agent driver — **not** an AgentOps daemon.
+
+## Tending the swarm (operator loop)
+
+Run one tick at a time; take the first action whose trigger fires:
+
+- **Rate-limited / auth-expired pane** → rotate the account / relaunch, re-send its bead.
+- **Wedged pane** (no output, not at a prompt) → nudge once; if still wedged, kill + relaunch + re-dispatch.
+- **Context-saturated pane** (forgetting, repeating) → have it write a handoff, relaunch fresh, re-dispatch.
+- **Worker finished** (PR merged, bead closed) → dispatch the next `bd ready` bead.
+- **Many review beads open, few closing** → flip to review-only, drain the backlog.
+- **Otherwise** → observe; do not nudge a healthy working pane.
+
+## Coordination (the MCP leg)
+
+- **Beads (`bd`)** — shared work queue + state source: `bd ready`, `bd update --claim`, `bd close`.
+- **MCP Agent Mail** (`ao mcp serve`) — cross-pane messages + **file reservations** (reserve before edit, release on commit).
+- **Worktree-per-bead** is mandatory: no pane edits the shared checkout.
+
+## Convergence + shutdown
+
+Done when `bd ready` is empty, no pane has an in-flight bead, and the last few CI
+runs are green. Confirm with `ntm activity` (all idle) + `bd ready` (empty) before
+`ntm kill <session>`. Don't shut down on a transient quiet patch — a rate-limited
+pane also looks idle.
+
+## Anti-patterns
+
+- ❌ Shelling out to `ao rpi` / `ao evolve` — retired CLI; dispatch the `$rpi` / `$evolve` skill instead.
+- ❌ Decomposing the loop into substrate steps — dispatch the whole loop as one invocable unit.
+- ❌ Editing the shared checkout from a pane — worktree-per-bead, always.
+- ❌ Treating NTM as AgentOps-owned — it is an adopted external substrate; a managed-agents driver (`ao agent`) or a plain in-session run are equally valid legs. Choose via $automation-shape-routing.
+
+## Related skills
+
+- $automation-shape-routing — decide Workflow vs NTM swarm vs plain skill before standing up a swarm.
+- $swarm — in-session parallel fan-out across worktrees (the in-session sibling).
+- $agent-native — `ao agent bundle` produces the loop definition a managed-agents substrate runs.
+- $rpi · $evolve — the loops the substrate dispatches.

--- a/skills-codex/using-ntm/prompt.md
+++ b/skills-codex/using-ntm/prompt.md
@@ -1,0 +1,7 @@
+# using-ntm
+
+Use NTM as the out-of-session substrate for unattended AgentOps loops.
+
+## Instructions
+
+Load and follow the skill instructions from the sibling `SKILL.md` file for this skill.

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -221,7 +221,7 @@ These are how skills chain in practice:
 
 ## Current Skill Tiers
 
-### User-Facing Skills (72)
+### User-Facing Skills (73)
 
 **Judgment:**
 
@@ -248,6 +248,7 @@ These are how skills chain in practice:
 | **discovery** | meta | Discovery phase orchestrator — brainstorm → search → research → plan → pre-mortem |
 | **validation** | meta | Validation phase orchestrator — vibe → post-mortem → retro → forge |
 | **swarm** | execution | Parallelize any skill — fresh context per agent |
+| **using-ntm** | execution | Run AgentOps loops out of session on an NTM tmux swarm — the NTM leg of the substrate |
 | **rpi** | meta | Thin wrapper: /discovery → /crank → /validation with complexity classification and loop |
 | **evolve** | execution | Autonomous fitness-scored improvement loop |
 | **burndown** | execution | Bounded epic-completion loop — drive a finite target to all-merged, then stop |

--- a/skills/automation-shape-routing/SKILL.md
+++ b/skills/automation-shape-routing/SKILL.md
@@ -37,7 +37,7 @@ output_contract: 'a routing verdict — Workflow | NTM swarm | plain skill — w
 | Shape | What it is | Mechanism |
 |---|---|---|
 | **Workflow** | Deterministic, reproducible orchestration of subagents | Claude `Workflow` tool — `agent({schema})`, `parallel()`, `pipeline()`, `phase()`, loop-until-budget. In-process, headless, ~16 concurrent. |
-| **NTM swarm** | Long-lived, human-in-the-loop multi-agent run | `ntm` / `*-with-ntm` — persistent tmux panes, robot API, mail/locks, attach + nudge + kill/relaunch. |
+| **NTM swarm** | Long-lived, human-in-the-loop multi-agent run | `ntm` (the CLI) driven by [`/using-ntm`](../using-ntm/SKILL.md) — persistent tmux panes running whole `/rpi`/`/evolve` loops over a bead queue, with attach + nudge + kill/relaunch and mail/locks coordination. |
 | **Plain skill** | One model reasoning through a procedure or knowledge | A single `SKILL.md`. No fan-out, or a strictly sequential edit-loop. |
 
 ## The decision rule (three axes)
@@ -129,7 +129,7 @@ decided, hand off:
 |---|---|---|
 | **plain skill** | `skill-builder` | Scaffold a new `SKILL.md` against the unified template → then `skill-auditor` → `heal-skill`. |
 | **Workflow** | `workflow-builder` | Scaffold a new `.claude/workflows/*.js` from the operating-loop.js template. |
-| **NTM swarm** | `ntm` + `vibing-with-ntm` | Stand up + tend a persistent, human-attachable tmux swarm. |
+| **NTM swarm** | `ntm` + [`/using-ntm`](../using-ntm/SKILL.md) | Stand up + tend an NTM swarm running AgentOps loops (`/rpi`/`/evolve`) over a bead queue. |
 
 State the verdict and the deciding axis in one line, then invoke the chosen
 builder. Do not scaffold here.

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-02T21:25:32Z",
-  "skill_count": 81,
+  "generated_at": "2026-06-02T23:56:18Z",
+  "skill_count": 82,
   "skills": [
     {
       "name": "agent-native",
@@ -1762,6 +1762,29 @@
         "agile-manifesto"
       ],
       "context_rel": [],
+      "references_count": 0,
+      "codex_override_present": true
+    },
+    {
+      "name": "using-ntm",
+      "description": "Use NTM as the out-of-session substrate: spawn Claude/Codex panes running /rpi and /evolve over a bead queue, then tend the swarm to convergence.",
+      "hexagonal_role": "supporting",
+      "user_invocable": true,
+      "consumes": [],
+      "produces": [
+        "documentation"
+      ],
+      "practices": [
+        "team-topologies",
+        "agile-manifesto",
+        "mythical-man-month"
+      ],
+      "context_rel": [
+        {
+          "kind": "customer-of",
+          "with": "swarm"
+        }
+      ],
       "references_count": 0,
       "codex_override_present": true
     },

--- a/skills/using-agentops/SKILL.md
+++ b/skills/using-agentops/SKILL.md
@@ -145,6 +145,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/release` | Pre-flight, changelog, version bumps, tag |
 | `/crank` | Autonomous epic loop (uses swarm for each wave) |
 | `/swarm` | Fresh-context parallel execution (Ralph pattern) |
+| `/using-ntm` | Run AgentOps loops out of session on an NTM tmux swarm (the NTM leg of the substrate) |
 | `/evolve` | Goal-driven fitness-scored improvement loop |
 | `/burndown` | Bounded epic-completion loop — drive a finite target to all-merged, then stop |
 | `/eval-outcomes` | Grade via Outcomes as a holdout-safe projection of the locked eval substrate — one bar, many runtimes |

--- a/skills/using-ntm/SKILL.md
+++ b/skills/using-ntm/SKILL.md
@@ -41,8 +41,8 @@ AgentOps-owned surface — AgentOps adopts it, it does not vendor it.
 
 > **Skills are the runtime, not the CLI.** The substrate dispatches a *whole
 > loop* by spawning an agent that **runs the `/rpi` or `/evolve` skill** — it
-> does **not** shell out to an `ao rpi` / `ao evolve` subprocess. Those terminal
-> wrappers are retired; the loop lives as a skill an agent executes. The seam is
+> does **not** shell out to retired RPI/evolve CLI subprocesses. The loop
+> lives as a skill an agent executes. The seam is
 > **NTM pane → agent → `/rpi <bead>` skill**, one bead dispatched as one
 > invocable unit.
 
@@ -140,7 +140,7 @@ on a transient quiet patch — a rate-limited pane also looks idle.
 
 ## Anti-patterns
 
-- ❌ **Shelling out to `ao rpi` / `ao evolve`.** Those CLI wrappers are retired.
+- ❌ **Shelling out to retired RPI/evolve CLI subprocesses.**
   Dispatch the `/rpi` / `/evolve` **skill** to an agent pane instead.
 - ❌ **Decomposing the loop into substrate steps.** Dispatch the whole loop as
   one invocable unit; never re-express `/rpi`'s phases as NTM-side orchestration.

--- a/skills/using-ntm/SKILL.md
+++ b/skills/using-ntm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-ntm
-description: 'Use NTM (Named Tmux Manager) as the out-of-session substrate: spawn Claude/Codex panes that run the /rpi and /evolve skills over a bead queue, coordinate via beads + MCP Agent Mail, and tend the swarm to convergence. Use when running AgentOps loops unattended, standing up an NTM agent swarm, dispatching the loop to a substrate, or tending/unsticking a running swarm.'
+description: 'Use NTM as the out-of-session substrate: spawn Claude/Codex panes running /rpi and /evolve over a bead queue, then tend the swarm to convergence.'
 practices:
 - team-topologies
 - agile-manifesto

--- a/skills/using-ntm/SKILL.md
+++ b/skills/using-ntm/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: using-ntm
+description: 'Use NTM (Named Tmux Manager) as the out-of-session substrate: spawn Claude/Codex panes that run the /rpi and /evolve skills over a bead queue, coordinate via beads + MCP Agent Mail, and tend the swarm to convergence. Use when running AgentOps loops unattended, standing up an NTM agent swarm, dispatching the loop to a substrate, or tending/unsticking a running swarm.'
+practices:
+- team-topologies
+- agile-manifesto
+- mythical-man-month
+hexagonal_role: supporting
+consumes: []
+produces:
+- documentation
+context_rel:
+- kind: customer-of
+  with: swarm
+skill_api_version: 1
+user-invocable: true
+context:
+  window: isolated
+  intent:
+    mode: task
+  sections:
+    exclude:
+    - HISTORY
+    - INTEL
+  intel_scope: none
+metadata:
+  tier: orchestration
+  dependencies: []
+output_contract: 'stdout: NTM-substrate operating guide'
+---
+
+# Using NTM as the Out-of-Session Substrate
+
+AgentOps 3.0 runs its loops **in session** and ships **no** daemon, scheduler, or
+overnight runner. To run the loop **unattended** — always-on, scheduled,
+queue-driven — you hand it to an orchestration **substrate**. The reference
+substrate is **NTM + MCP + managed-agents**; this skill covers the **NTM leg**:
+a local [Named Tmux Manager](https://github.com/) swarm of Claude/Codex agent
+panes. NTM is an adopted external tool (`ntm` on `PATH`), **not** an
+AgentOps-owned surface — AgentOps adopts it, it does not vendor it.
+
+> **Skills are the runtime, not the CLI.** The substrate dispatches a *whole
+> loop* by spawning an agent that **runs the `/rpi` or `/evolve` skill** — it
+> does **not** shell out to an `ao rpi` / `ao evolve` subprocess. Those terminal
+> wrappers are retired; the loop lives as a skill an agent executes. The seam is
+> **NTM pane → agent → `/rpi <bead>` skill**, one bead dispatched as one
+> invocable unit.
+
+## When to use this skill / when to skip
+
+**Use it when:** you want a bead queue worked unattended out of session; you're
+standing up or tending an NTM swarm that runs AgentOps loops; a pane is stuck,
+rate-limited, or wedged; you need to know whether the swarm has converged.
+
+**Skip it when:** the work fits a single in-session run (just run `/rpi` or
+`/evolve` yourself); you want in-session parallel fan-out across worktrees (use
+[`/swarm`](../swarm/SKILL.md)); you're choosing between automation shapes at all
+(start at [`/automation-shape-routing`](../automation-shape-routing/SKILL.md),
+which routes Workflow vs NTM swarm vs plain skill).
+
+This skill does **not** re-document the full `ntm` command surface — run
+`ntm help` for that. It covers the **AgentOps substrate contract**: how to
+dispatch and tend AgentOps loops on an NTM swarm.
+
+## The dispatch contract
+
+1. **One bead = one whole-loop skill invocation.** A pane's agent runs
+   `/rpi <bead> --auto` (one cycle) or `/evolve --auto` (the outer loop). The
+   substrate never decomposes the loop into per-phase steps — whoever owns the
+   loop owns its invariants, and AgentOps owns the loop. Re-expressing `/rpi` as
+   substrate-side steps duplicates the loop shape and pits the substrate's retry
+   machinery against the ratchet rules. Dispatch the skill; don't reimplement it.
+2. **Agents inherit the skills via overlay.** Each pane is a Claude or Codex
+   agent with the AgentOps skills installed, so `/rpi`, `/evolve`, `/validation`,
+   etc. resolve in-pane.
+3. **The bead queue is the work source.** A lead (operator or a lead pane) runs
+   `bd ready`, picks the next bead, and dispatches it to a free worker pane.
+4. **Green CI is the merge gate.** Each worker drives its bead to a green PR from
+   a per-bead worktree (orchestrator-merge model); the operator stays *on* the
+   loop (intent + stop), not *in* it (per-PR approval).
+
+## Quick start
+
+```bash
+# 1. Spawn a swarm of agent panes against the repo (2 Claude + 1 Codex worker).
+ntm spawn agentops --cc=2 --cod=1
+
+# 2. Dispatch a whole loop to a pane — the SKILL, not a CLI subprocess.
+ntm send agentops --pane=1 "/rpi ag-1234 --auto"
+ntm send agentops --pane=2 "/evolve --beads-only --auto"
+
+# 3. Watch / attach.
+ntm activity agentops          # per-pane agent state
+ntm attach agentops            # drop into the swarm
+
+# 4. Health + dependencies (run before a long unattended session).
+ntm doctor                     # validate the NTM ecosystem
+ntm deps                       # required agent CLIs present
+```
+
+Scheduled cadence (e.g. a nightly `/evolve` pass) is driven by host-OS timing (a
+systemd user timer or cron) that runs `ntm send … "/evolve --auto"`, or by a
+managed-agent driver — **not** an AgentOps daemon.
+
+## Tending the swarm (operator loop)
+
+Run one tick at a time; take the first action whose trigger fires:
+
+- **A pane is rate-limited or auth-expired** → rotate the account / relaunch the
+  pane, then re-send its in-flight bead. Do not let a dead pane look idle.
+- **A pane is wedged** (no output, not at a prompt) → nudge it once; if still
+  wedged, kill + relaunch and re-dispatch its bead.
+- **A pane is context-saturated** (forgetting earlier instructions, repeating
+  itself) → have it write a handoff, then relaunch fresh and re-dispatch.
+- **A worker finished its bead** (PR merged, bead closed) → dispatch the next
+  `bd ready` bead to it.
+- **Many review beads open, few closing** → flip the swarm to review-only and
+  drain the backlog before taking new feature work.
+- **Otherwise** → observe; do not nudge a healthy working pane.
+
+## Coordination (the MCP leg)
+
+NTM panes coordinate through the other substrate legs, not bespoke glue:
+
+- **Beads (`bd`)** is the shared work queue and the source of truth for state —
+  `bd ready` to pick, `bd update --claim` to claim, `bd close` when merged.
+- **MCP Agent Mail** (`ao mcp serve` exposes the AgentOps tool surface across the
+  seam) carries cross-pane messages and **file reservations** — the swarm's
+  defense against two panes editing the same path. Reserve before editing;
+  release on commit.
+- **Worktree-per-bead** is mandatory: no pane edits the shared checkout. See
+  [../swarm/references/shared-checkout-discipline.md](../swarm/references/shared-checkout-discipline.md).
+
+## Convergence + shutdown
+
+The swarm is done when: `bd ready` is empty, no pane has an in-flight bead, and
+the last few CI runs are green. Confirm with `ntm activity` (all panes idle) and
+`bd ready` (empty) before tearing down with `ntm kill <session>`. Don't shut down
+on a transient quiet patch — a rate-limited pane also looks idle.
+
+## Anti-patterns
+
+- ❌ **Shelling out to `ao rpi` / `ao evolve`.** Those CLI wrappers are retired.
+  Dispatch the `/rpi` / `/evolve` **skill** to an agent pane instead.
+- ❌ **Decomposing the loop into substrate steps.** Dispatch the whole loop as
+  one invocable unit; never re-express `/rpi`'s phases as NTM-side orchestration.
+- ❌ **Editing the shared checkout from a pane.** Worktree-per-bead, always.
+- ❌ **Treating NTM as AgentOps-owned.** It is an adopted external substrate; a
+  managed-agents driver (`ao agent`) or a plain in-session run are equally valid
+  legs. Choose via [`/automation-shape-routing`](../automation-shape-routing/SKILL.md).
+
+## Related skills
+
+- [`/automation-shape-routing`](../automation-shape-routing/SKILL.md) — decide Workflow vs NTM swarm vs plain skill *before* standing up a swarm.
+- [`/swarm`](../swarm/SKILL.md) — in-session parallel fan-out across worktrees (the in-session sibling of this out-of-session substrate).
+- [`/agent-native`](../agent-native/SKILL.md) — `ao agent bundle` produces the loop definition a managed-agents substrate runs (the managed-agents leg).
+- [`/rpi`](../rpi/SKILL.md) · [`/evolve`](../evolve/SKILL.md) — the loops the substrate dispatches.


### PR DESCRIPTION
## What

Adds an **AgentOps-owned, shippable `using-ntm` skill** — the missing NTM leg of the `NTM + MCP + managed-agents` substrate doctrine (**ag-zaoj**). Until now `automation-shape-routing` pointed **by name** at the *proprietary* `ntm`/`vibing-with-ntm` skills, which AgentOps can't ship — a dangling pointer for standalone users. This is original content modeled on (not copied from) those.

## The seam: skills are the runtime, not the CLI

The skill teaches driving the open `ntm` CLI as the out-of-session substrate: **NTM spawns Claude/Codex panes that run the `/rpi` and `/evolve` *skills*** over a bead queue. It explicitly does **not** use `ao rpi`/`ao evolve` CLI subprocesses — those terminal wrappers are retired; the substrate dispatches the whole loop as one invocable skill.

## What lands (15 files, +~440)

- `skills/using-ntm/SKILL.md` + `skills-codex/using-ntm/SKILL.md` (twin) — the new skill.
- `automation-shape-routing` (+ codex twin) — dangling `ntm`/`vibing-with-ntm` pointers now route to the owned `/using-ntm`; `ntm` stays as the CLI tool.
- Six derived surfaces regenerated: `registry.json`, skill-domain-map, SKU catalog, codex hashes/manifest, context-map; + skill-disposition row and skill-count bumps (80 → 81) in PRODUCT / ARCHITECTURE / SKILLS / domain-map / BDD-Gherkin.

## E2E verification (against the real `ntm` CLI)

Per the directive (no `ao rpi`/`ao evolve`): verified every `ntm` subcommand the skill cites exists (`spawn/send/activity/attach/doctor/deps/kill/health`) and **fixed the documented flag to the real `--pane=N` syntax** (it had `--pane N`). `ntm doctor` runs (bv ✓ / bd ✓ / am ⚠). `docs/cli-surface.*` drift excluded (pre-existing, unrelated).

## Follow-up (not in this PR)

`ao rpi`/`ao evolve` CLI are slated for retirement; `docs/3.0.md` + the recent Gas City-prune PRs still reference `ao rpi <bead>` as the dispatch unit and need a skills-not-CLI reconciliation pass.

## Verification

- `regen-all.sh --check` ALL GREEN · registry-drift PASS · codex parity PASS · skill-isolation/size PASS · markdownlint 0.

Closes-scenario: ag-zaoj#using-ntm-skill
Bounded-context: BC4-Factory
Evidence: skills/using-ntm/SKILL.md
