### PR TITLE
fix(memory): missing sessions dir no-op + isolate flag-matrix memory-sync test (ag-jfzs #memsync-test-isolation)

### DIFF
--- a/cli/cmd/ao/flag_matrix_test.go
+++ b/cli/cmd/ao/flag_matrix_test.go
@@ -100,11 +100,19 @@ func TestFlagMatrix_QuietMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := exec.Command(bin, tt.args...)
+			args := tt.args
+			// ag-jfzs: `ao memory sync` defaults to writing the repo-root MEMORY.md. Running it
+			// against the real repo root under -race mutates a shared file and flakes. Redirect the
+			// write to a per-test temp file so the subprocess stays isolated while still exercising
+			// the real session-read path from the repo root.
+			if tt.name == "memory-sync" {
+				args = append(append([]string{}, tt.args...), "--output-file", filepath.Join(t.TempDir(), "MEMORY.md"))
+			}
+			cmd := exec.Command(bin, args...)
 			cmd.Dir = findRepoRoot(t)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
-				t.Fatalf("command %v failed (exit error: %v):\n%s", tt.args, err, string(out))
+				t.Fatalf("command %v failed (exit error: %v):\n%s", args, err, string(out))
 			}
 			// Quiet mode should succeed — output may be empty or minimal, both are fine.
 			// We only assert exit code 0 (already checked via err == nil).

--- a/cli/cmd/ao/memory.go
+++ b/cli/cmd/ao/memory.go
@@ -141,6 +141,10 @@ func readNLatestSessionEntries(cwd string, maxCount int) ([]*pendingEntry, error
 	sessionsDir := filepath.Join(cwd, ".agents", "ao", "sessions")
 	dirEntries, err := os.ReadDir(sessionsDir)
 	if err != nil {
+		if os.IsNotExist(err) {
+			// No sessions dir yet (fresh checkout / CI / isolated run) → no data to sync, not an error.
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/cli/cmd/ao/memory_test.go
+++ b/cli/cmd/ao/memory_test.go
@@ -437,10 +437,15 @@ func TestReadNLatestSessionEntries_Empty(t *testing.T) {
 }
 
 func TestReadNLatestSessionEntries_NoDir(t *testing.T) {
+	// ag-jfzs: a missing sessions dir is "no data", not an error — so `ao memory sync`
+	// is a clean no-op in a fresh checkout / CI / isolated run instead of failing.
 	tmp := t.TempDir()
-	_, err := readNLatestSessionEntries(tmp, 10)
-	if err == nil {
-		t.Error("expected error for missing sessions dir")
+	entries, err := readNLatestSessionEntries(tmp, 10)
+	if err != nil {
+		t.Fatalf("expected no error for missing sessions dir, got %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries for missing sessions dir, got %d", len(entries))
 	}
 }
 


### PR DESCRIPTION
## What
Fixes the ag-jfzs flake: `TestFlagMatrix_QuietMode/memory-sync` ran `ao memory sync` against the real repo root, mutating the shared repo-root MEMORY.md under `-race` (flaky), and `ao memory sync` hard-errored when `.agents/ao/sessions` was absent (clean checkout / CI).

## Changes
- `memory.go`: `readNLatestSessionEntries` treats a missing sessions dir as no data (`os.IsNotExist` -> `nil, nil`) — sync is a clean no-op instead of erroring.
- `flag_matrix_test.go`: redirect the memory-sync subprocess write to a per-test `t.TempDir()` via `--output-file` — never touches the real repo MEMORY.md.
- `memory_test.go`: `TestReadNLatestSessionEntries_NoDir` asserts the no-op contract.

## Verification
- `go vet` clean
- `TestFlagMatrix_QuietMode` 15/15 under `-race -count=5`
- 80 memory/flag-matrix tests pass under `-race`

This is the recurring red on main's `correctness(ubuntu)` — should make it reliably green.

Closes-scenario: ag-jfzs#memsync-test-isolation
Bounded-context: BC5-Runtime
Evidence: cli/cmd/ao/memory.go