### PR TITLE
chore(tests): test-isolation ratchet + migrate testutil chdir helpers to t.Chdir (ag-k38x #lint-ratchet)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1452,6 +1452,12 @@ jobs:
           chmod +x scripts/check-test-count-regression.sh
           ./scripts/check-test-count-regression.sh
 
+      - name: Test-isolation ratchet (scripts/check-test-isolation.sh)
+        if: needs.changes.outputs.go == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.ci == 'true'
+        run: |
+          chmod +x scripts/check-test-isolation.sh
+          ./scripts/check-test-isolation.sh
+
       - name: Check for stale tests (advisory)
         if: needs.changes.outputs.go == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.ci == 'true'
         continue-on-error: true

--- a/cli/cmd/ao/testutil_test.go
+++ b/cli/cmd/ao/testutil_test.go
@@ -501,14 +501,9 @@ func resetCommandState(t *testing.T) {
 func chdirTemp(t *testing.T) string {
 	t.Helper()
 	tmp := t.TempDir()
-	prev, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(tmp); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(prev) })
+	// ag-k38x: t.Chdir auto-restores on cleanup and fails fast if the test (or a
+	// parent) is parallel — the isolation-safe replacement for os.Chdir + t.Cleanup.
+	t.Chdir(tmp)
 	// Match os.Getwd() canonicalization (macOS /var → /private/var symlinks).
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -527,10 +522,8 @@ func chdirTo(t *testing.T, wd string) string {
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	if err := os.Chdir(wd); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(prev) })
+	// ag-k38x: t.Chdir auto-restores + blocks parallel; prev is returned for callers.
+	t.Chdir(wd)
 	return prev
 }
 

--- a/scripts/check-test-isolation.sh
+++ b/scripts/check-test-isolation.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# check-test-isolation.sh (ag-k38x) — ratchet: raw os.Chdir / os.Setenv in Go test
+# files must not GROW.
+#
+# Idiomatic test isolation is t.Chdir / t.Setenv: they auto-restore on cleanup AND
+# fail fast if the test (or a parent) called t.Parallel. Raw os.Chdir/os.Setenv mutate
+# process-global cwd/env and are a latent flake landmine the moment any test opts into
+# parallelism (cf. ag-jfzs — the memory-sync flake was exactly this class). This gate
+# pre-empts the class by preventing NEW raw forms.
+#
+# This is a BASELINE RATCHET, not a zero-tolerance ban: ~163 os.Chdir + 22 os.Setenv
+# inline sites predate it. The baseline only goes DOWN — new raw forms must use the
+# t.* idiom (or the sanctioned chdirTemp/chdirTo helpers in cli/cmd/ao/testutil_test.go,
+# which are excluded here and themselves use t.Chdir). Migrate inline sites to drive the
+# baselines toward zero, then lower the constants below to lock each gain (ag-k38x.1).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Baselines captured 2026-06-03 (excludes the testutil_test.go helper home).
+BASELINE_CHDIR=163
+BASELINE_SETENV=22
+
+chdir=$(grep -rho --include='*_test.go' --exclude='testutil_test.go' 'os\.Chdir(' cli 2>/dev/null | wc -l | tr -d ' ')
+setenv=$(grep -rho --include='*_test.go' --exclude='testutil_test.go' 'os\.Setenv(' cli 2>/dev/null | wc -l | tr -d ' ')
+
+rc=0
+if [ "$chdir" -gt "$BASELINE_CHDIR" ]; then
+  echo "FAIL: raw os.Chdir in *_test.go rose to $chdir (baseline $BASELINE_CHDIR)."
+  echo "      Use t.Chdir (auto-restores, blocks t.Parallel) or the testutil chdirTemp/chdirTo helpers."
+  rc=1
+fi
+if [ "$setenv" -gt "$BASELINE_SETENV" ]; then
+  echo "FAIL: raw os.Setenv in *_test.go rose to $setenv (baseline $BASELINE_SETENV)."
+  echo "      Use t.Setenv (auto-restores, blocks t.Parallel)."
+  rc=1
+fi
+
+if [ "$chdir" -lt "$BASELINE_CHDIR" ] || [ "$setenv" -lt "$BASELINE_SETENV" ]; then
+  echo "NOTE: isolation ratchet improved (os.Chdir=$chdir<=$BASELINE_CHDIR, os.Setenv=$setenv<=$BASELINE_SETENV)."
+  echo "      Lower BASELINE_CHDIR/BASELINE_SETENV in $(basename "$0") to lock the gain."
+fi
+
+if [ "$rc" -eq 0 ]; then
+  echo "PASS: test-isolation ratchet (os.Chdir=$chdir/$BASELINE_CHDIR, os.Setenv=$setenv/$BASELINE_SETENV)"
+fi
+exit "$rc"


### PR DESCRIPTION
## What
Lands the durable mechanism for ag-k38x (codebase-audit P2-1/P2-2): raw `os.Chdir`/`os.Setenv` in tests mutate process-global cwd/env — a latent flake landmine once any test opts into `t.Parallel` (cf. **ag-jfzs**, the memory-sync flake of exactly this class).

The repo has ~163 `os.Chdir` + 22 `os.Setenv` inline sites across 34 files in **non-uniform patterns** (`defer` / `t.Cleanup` / `defer func(){}()` with reversed order) — a blind sweep would break the suite. So this ships the **durable gate + the canonical lever**, not a risky 80-site mass-edit:

- **`scripts/check-test-isolation.sh`** — a baseline ratchet (163/22) wired into the **process-hygiene** job: raw `os.Chdir`/`os.Setenv` in `*_test.go` may not **grow**; new code must use `t.Chdir`/`t.Setenv` or the testutil helpers. This pre-empts the flake class from spreading.
- **`testutil_test.go`** — `chdirTemp`/`chdirTo` migrated from `os.Chdir`+`t.Cleanup` to `t.Chdir` (the shared helpers most tests delegate to; canonical example).

## Follow-up
The bulk inline-site migration drives the baseline toward zero incrementally — **ag-k38x stays open** for it (scenario `#bulk-migration`). Decomposing an ~80-site, non-uniform migration into *gate-the-growth now + reduce-incrementally* is the responsible path; a one-shot sed would be the reckless one.

## Verification
Ratchet PASSes at baseline AND catches a synthetic increase; shellcheck + `validate-ci-policy-parity` green; `go vet` clean; chdir-helper-caller tests pass under `-race`.

Closes-scenario: ag-k38x#lint-ratchet
Bounded-context: BC2-Validation
Evidence: scripts/check-test-isolation.sh