### PR TITLE
docs(skills): reframe /evolve + domain/rpi dispatch as skill-not-CLI (ag-wb6k #skills-dispatch-narration)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-03T12:02:11Z",
+  "generated_at": "2026-06-03T16:03:08Z",
   "summary": {
     "skills": 82,
     "hooks": 0,
@@ -1323,7 +1323,7 @@
         "bounded_context": "BC3",
         "driven_by_skills": [
           "autodev",
-          "domain",
+          "evolve",
           "shared",
           "standards",
           "swarm"
@@ -2007,7 +2007,6 @@
         "ao inject",
         "ao maturity",
         "ao mcp serve",
-        "ao rpi",
         "ao rpi phased"
       ],
       "path": "skills/domain/",
@@ -2097,6 +2096,7 @@
         "ao metrics cite",
         "ao mine",
         "ao ratchet",
+        "ao rpi",
         "ao rpi loop"
       ],
       "path": "skills/evolve/",
@@ -4708,7 +4708,7 @@
       "status": "active",
       "driven_by_skills": [
         "autodev",
-        "domain",
+        "evolve",
         "shared",
         "standards",
         "swarm"

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -793,7 +793,7 @@
     {
       "name": "domain",
       "source_skill": "skills/domain",
-      "source_hash": "7dc9ac3269b8ede42329a33bf371589d0ba19e83d0d2c61fda8d06512fe5e397",
+      "source_hash": "c9d5cce3ca895016630f361b99938afbfba3b77eaddeeb5042f4767370036a75",
       "generated_hash": "5de534737803c76fab3ad06e1a47dba85eb8f631a159cc6157ce4f932c2e99e4"
     },
     {
@@ -811,7 +811,7 @@
     {
       "name": "evolve",
       "source_skill": "skills/evolve",
-      "source_hash": "e2f99817140bfc465c56832e93c61202a09d365ebfa07464356f7b0022c95179",
+      "source_hash": "a74d21b0a712c5c5361abef76aeda637c3dbc50e3e1ce82f689fd4168efd0535",
       "generated_hash": "4c291f25cfc6e9ee2547e8140488a75097c6fa38615282742d375f603f5daae5"
     },
     {

--- a/skills-codex/domain/.agentops-generated.json
+++ b/skills-codex/domain/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/domain",
   "layout": "modular",
-  "source_hash": "7dc9ac3269b8ede42329a33bf371589d0ba19e83d0d2c61fda8d06512fe5e397",
+  "source_hash": "c9d5cce3ca895016630f361b99938afbfba3b77eaddeeb5042f4767370036a75",
   "generated_hash": "5de534737803c76fab3ad06e1a47dba85eb8f631a159cc6157ce4f932c2e99e4"
 }

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/evolve",
   "layout": "modular",
-  "source_hash": "e2f99817140bfc465c56832e93c61202a09d365ebfa07464356f7b0022c95179",
+  "source_hash": "a74d21b0a712c5c5361abef76aeda637c3dbc50e3e1ce82f689fd4168efd0535",
   "generated_hash": "4c291f25cfc6e9ee2547e8140488a75097c6fa38615282742d375f603f5daae5"
 }

--- a/skills/domain/references/rpi.md
+++ b/skills/domain/references/rpi.md
@@ -20,7 +20,7 @@ The **inner tick** of the [Loop](loop.md): one Research → Plan → Implement �
 
 ## RPI is one invocable unit
 
-A substrate dispatches `ao rpi` as one unit; it does not drive the five beats as separate substrate steps. Decomposing rpi across the substrate seam would duplicate the loop shape and pit substrate retry against the ratchet rules. Whoever owns the loop owns its invariants, and AgentOps owns rpi.
+A substrate dispatches the `/rpi` loop (an agent running the skill) as one unit; it does not drive the five beats as separate substrate steps. Decomposing rpi across the substrate seam would duplicate the loop shape and pit substrate retry against the ratchet rules. Whoever owns the loop owns its invariants, and AgentOps owns rpi.
 
 ## When to use
 

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -48,10 +48,13 @@ output_contract: code changes, GOALS.md fitness deltas
 
 > Measure what's wrong. Fix the worst thing. Measure again. Compound.
 
-**V2 command surface:** keep the name `evolve`. Use `ao evolve` for the
-terminal-native loop. It is the top-level operator entrypoint for
-`ao rpi loop --supervisor`, preserving the old `/evolve` concept while reusing
-the v2 RPI loop engine.
+**The loop runs as this skill (skills-are-the-runtime).** `/evolve` selects work
+and invokes complete `/rpi --auto` cycles — that *is* the loop. `ao evolve` (and
+`ao rpi loop --supervisor`) are terminal-native **wrapper commands** for humans or
+non-skill runtimes, not the default expression of the loop; they reuse the same v2
+RPI loop engine. (The substrate dispatches the whole `/evolve` skill loop as one
+unit; it never drives the loop's insides. The `ao evolve`/`ao rpi` CLI wrappers are
+being retired — ag-iowf.)
 
 **Operator cadence:** post-mortem finished work, analyze the current repo state,
 select or create the next highest-value work item, let `/rpi` handle research,


### PR DESCRIPTION
## What
**iowf Wave 1** (ag-wb6k): bring the CLAUDE skills in line with the codex stance the `validate-codex-rpi-contract.sh` gate already enforces — `ao evolve`/`ao rpi` are terminal **wrappers**, not the runtime default; the loop runs as the skill.

- **skills/evolve/SKILL.md** — the "V2 command surface" para framed `ao evolve` as *the* entry. Reframed: the loop runs as the `/evolve` skill (chaining `/rpi --auto` cycles); `ao evolve` / `ao rpi loop --supervisor` are terminal-native wrapper commands for humans/non-skill runtimes (being retired — ag-iowf).
- **skills/domain/references/rpi.md** — "a substrate dispatches `ao rpi` as one unit" → "dispatches the `/rpi` loop (an agent running the skill) as one unit" (matches the ag-88y5 doctrine reframe).

**Left as-is (legitimate, not misframings):** autodev's skill-first "use `/evolve` or `ao evolve`" listing; ralph-loop-contract's accurate `ao rpi phased` backend references.

## Verification
Six derived surfaces regenerated. Gates green: **codex-rpi-contract** (the coupled gate — the codex side already had the correct stance, so no twin edit needed), regen-all --check, embedded-sync, heal --strict, registry-drift, body-refs.

## Scope
This is Wave 1 (docs/skills narration) of ag-iowf. The actual `ao evolve`/`ao rpi` CLI removal is W2–W4 (ag-kbh0/ayst/zoa1, blocked on soc-1gbpz + live-automation migration).

Closes-scenario: ag-wb6k#skills-dispatch-narration
Bounded-context: BC3-Loop
Evidence: skills/evolve/SKILL.md