### PR TITLE
feat(eval): corpus-delta A/B side-harness (ag-u6jh #harness)

### DIFF
--- a/scripts/corpus-delta-harness.sh
+++ b/scripts/corpus-delta-harness.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# corpus-delta-harness.sh — ag-u6jh (ag-8p8o Wave-1a)
+#
+# Runs ONE task in two CONTEXT ARMS and emits a ContextDeltaScorecard:
+#   context_off : agent runs against an isolated EMPTY corpus (fresh AO_AGENTS_DIR)
+#   context_on  : agent runs against the ORGANIC corpus (--corpus DIR, e.g. the repo's .agents)
+# K seeds per arm; arm score = pass-rate over seeds; aggregate_delta = on - off.
+#
+# WHY a side harness (not the ao eval runner): the deterministic eval runner rejects
+# non-shell runtimes ("out of deterministic scope", cli/internal/eval/io.go) and is
+# CI-locked. This lane is deliberately OUTSIDE it and is never part of the deterministic
+# canary suite. It is also NOT an `ao` subcommand (no new CLI surface).
+#
+# INJECTABLE RUNNER (so the harness is testable WITHOUT burning LLM calls):
+#   Set CORPUS_DELTA_RUNNER to a command. It is invoked as:
+#       "$CORPUS_DELTA_RUNNER" <task-id> <agent> <seed>
+#   with AO_AGENTS_DIR exported to the arm's corpus root. It MUST print one JSON line:
+#       {"pass": true|false, "score": <num>, "total": <num>}
+#   Default runner = scripts/eval-agent-harness.sh (real agent: claude|codex).
+#
+# ⚠️ HONESTY: a run of this harness with a STUB runner (e.g. the bats test) proves the
+#    harness PLUMBING only — it is NOT evidence of the corpus delta. The real claim needs
+#    a real agent + held, non-engineered tasks + K seeds (ag-nfux W1b, ag-epgk W1c).
+#    Do not cite a stub/plumbing run as proof of the moat (cf. the wave0 confusion).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TASK_ID=""
+SEEDS=3
+CORPUS_DIR="$REPO_ROOT/.agents"
+AGENT="claude"
+OUT=""
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/corpus-delta-harness.sh --task <id> [options]
+
+  --task <id>        Workbench task id (required)
+  --seeds <K>        Seeds per arm (default: 3)
+  --corpus <dir>     Organic corpus root for context_on (default: repo .agents)
+  --agent <name>     Agent for the default runner: claude|codex (default: claude)
+  --out <file>       Write the ContextDeltaScorecard JSON here (default: stdout only)
+
+Override CORPUS_DELTA_RUNNER to inject a custom runner (used by tests).
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --task) TASK_ID="$2"; shift 2 ;;
+    --seeds) SEEDS="$2"; shift 2 ;;
+    --corpus) CORPUS_DIR="$2"; shift 2 ;;
+    --agent) AGENT="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$TASK_ID" ]] || { echo "error: --task required" >&2; exit 2; }
+[[ "$SEEDS" =~ ^[1-9][0-9]*$ ]] || { echo "error: --seeds must be a positive integer" >&2; exit 2; }
+
+DEFAULT_RUNNER="$REPO_ROOT/scripts/eval-agent-harness.sh"
+RUNNER="${CORPUS_DELTA_RUNNER:-$DEFAULT_RUNNER}"
+
+# run_arm <variant> <corpus_root> -> echoes "passes total" (passes = #seeds that passed)
+run_arm() {
+  local variant="$1" corpus_root="$2"
+  local passes=0 seed line is_pass
+  echo "[corpus-delta] arm=$variant corpus=$corpus_root seeds=$SEEDS" >&2
+  for ((seed = 1; seed <= SEEDS; seed++)); do
+    if [[ "$RUNNER" == "$DEFAULT_RUNNER" ]]; then
+      line="$(AO_AGENTS_DIR="$corpus_root" "$RUNNER" --task "$TASK_ID" --agent "$AGENT" --runs 1 2>/dev/null | tail -1)"
+    else
+      # Injected (test) runner contract: <task> <agent> <seed>, reads AO_AGENTS_DIR.
+      line="$(AO_AGENTS_DIR="$corpus_root" "$RUNNER" "$TASK_ID" "$AGENT" "$seed" 2>/dev/null | tail -1)"
+    fi
+    is_pass="$(printf '%s' "$line" | jq -r 'if .pass == true then 1 else 0 end' 2>/dev/null || echo 0)"
+    [[ "$is_pass" == "1" ]] && passes=$((passes + 1))
+  done
+  echo "$passes $SEEDS"
+}
+
+# context_off: fresh empty isolated corpus root
+OFF_ROOT="$(mktemp -d)"
+trap 'rm -rf "$OFF_ROOT"' EXIT
+
+read -r off_pass off_total < <(run_arm context_off "$OFF_ROOT")
+read -r on_pass on_total < <(run_arm context_on "$CORPUS_DIR")
+
+# pass-rate per arm; delta = on - off
+scorecard="$(jq -n \
+  --argjson off_pass "$off_pass" --argjson off_total "$off_total" \
+  --argjson on_pass "$on_pass" --argjson on_total "$on_total" \
+  --arg task "$TASK_ID" --argjson seeds "$SEEDS" \
+  '
+  ($off_pass / $off_total) as $off_score |
+  ($on_pass / $on_total) as $on_score |
+  {
+    schema_version: 1,
+    suite_id: ("corpus-delta-" + $task),
+    suite_path: "scripts/corpus-delta-harness.sh",
+    evidence_kind: "harness_plumbing",
+    seeds_per_arm: $seeds,
+    context_off: { variant: "context_off", passes: $off_pass, total: $off_total, aggregate_score: ($off_score | (.*10000|round)/10000), status: (if $off_score >= 0.75 then "pass" else "fail" end) },
+    context_on:  { variant: "context_on",  passes: $on_pass,  total: $on_total,  aggregate_score: ($on_score  | (.*10000|round)/10000), status: (if $on_score  >= 0.75 then "pass" else "fail" end) },
+    aggregate_delta: (($on_score - $off_score) | (.*10000|round)/10000)
+  }')"
+
+printf '%s\n' "$scorecard"
+if [[ -n "$OUT" ]]; then
+  printf '%s\n' "$scorecard" > "$OUT"
+fi

--- a/tests/scripts/corpus-delta-harness.bats
+++ b/tests/scripts/corpus-delta-harness.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+# ag-u6jh (ag-8p8o W1a): corpus-delta-harness.sh is the side A/B lane that runs a
+# task in two context arms (empty vs organic corpus) and emits a ContextDeltaScorecard.
+# These cases exercise the harness PLUMBING deterministically via an injected STUB
+# runner (no LLM). They prove the harness mechanics (isolation, K-seed aggregation,
+# delta math, scorecard shape) — NOT the corpus-delta product claim, which needs a
+# real agent + held tasks (ag-nfux/ag-epgk).
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  HARNESS="$REPO_ROOT/scripts/corpus-delta-harness.sh"
+  TMP="$BATS_TEST_TMPDIR"
+  # Stub runner: passes iff AO_AGENTS_DIR contains a learnings/ marker (simulates
+  # "the corpus has useful content"). Contract: <task> <agent> <seed>, prints JSON.
+  STUB="$TMP/stub-runner.sh"
+  cat > "$STUB" <<'STUB_EOF'
+#!/usr/bin/env bash
+if [[ -n "${AO_AGENTS_DIR:-}" && -f "${AO_AGENTS_DIR}/learnings/marker.md" ]]; then
+  echo '{"pass": true, "score": 1, "total": 1}'
+else
+  echo '{"pass": false, "score": 0, "total": 1}'
+fi
+STUB_EOF
+  chmod +x "$STUB"
+  # Organic-corpus fixture (content present)
+  CORPUS="$TMP/corpus"
+  mkdir -p "$CORPUS/learnings"
+  echo "# a prior decision" > "$CORPUS/learnings/marker.md"
+}
+
+# Assert on the --out file (clean JSON; stdout/stderr carry a human progress line).
+@test "context_on (corpus present) beats context_off (empty): delta = 1.0" {
+  run env CORPUS_DELTA_RUNNER="$STUB" "$HARNESS" --task demo --seeds 3 --corpus "$CORPUS" --out "$TMP/sc.json"
+  [ "$status" -eq 0 ]
+  jq -e '.aggregate_delta == 1' "$TMP/sc.json" >/dev/null
+  jq -e '.context_off.aggregate_score == 0' "$TMP/sc.json" >/dev/null
+  jq -e '.context_on.aggregate_score == 1' "$TMP/sc.json" >/dev/null
+  jq -e '.context_off.status == "fail"' "$TMP/sc.json" >/dev/null
+  jq -e '.context_on.status == "pass"' "$TMP/sc.json" >/dev/null
+}
+
+@test "scorecard has the ContextDeltaScorecard-compatible shape" {
+  run env CORPUS_DELTA_RUNNER="$STUB" "$HARNESS" --task demo --seeds 2 --corpus "$CORPUS" --out "$TMP/sc.json"
+  [ "$status" -eq 0 ]
+  jq -e 'has("schema_version") and has("suite_id") and has("context_off") and has("context_on") and has("aggregate_delta")' "$TMP/sc.json" >/dev/null
+  jq -e '.seeds_per_arm == 2' "$TMP/sc.json" >/dev/null
+  jq -e '.evidence_kind == "harness_plumbing"' "$TMP/sc.json" >/dev/null
+}
+
+@test "no delta when both arms see the same (empty) corpus" {
+  EMPTY="$TMP/empty"; mkdir -p "$EMPTY"
+  run env CORPUS_DELTA_RUNNER="$STUB" "$HARNESS" --task demo --seeds 3 --corpus "$EMPTY" --out "$TMP/sc.json"
+  [ "$status" -eq 0 ]
+  jq -e '.aggregate_delta == 0' "$TMP/sc.json" >/dev/null
+  jq -e '.context_on.aggregate_score == 0' "$TMP/sc.json" >/dev/null
+}
+
+@test "--out writes the scorecard to a file" {
+  run env CORPUS_DELTA_RUNNER="$STUB" "$HARNESS" --task demo --seeds 1 --corpus "$CORPUS" --out "$TMP/sc.json"
+  [ "$status" -eq 0 ]
+  [ -f "$TMP/sc.json" ]
+  jq -e '.aggregate_delta == 1' "$TMP/sc.json" >/dev/null
+}
+
+@test "requires --task" {
+  run env CORPUS_DELTA_RUNNER="$STUB" "$HARNESS" --seeds 1
+  [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## What
Wave-1a of the corpus-delta proof (ag-8p8o) — the runnable arm.

The deterministic eval runner rejects non-shell runtimes ("out of deterministic scope", `cli/internal/eval/io.go`) and is CI-locked, so this is a **side harness** — *not* an extension of that runner, and **not a new `ao` subcommand** (no CLI surface growth, per the minimalist/competitive lenses).

- **`scripts/corpus-delta-harness.sh`** — runs one task in two context arms: `context_off` (isolated **empty** `AO_AGENTS_DIR`) vs `context_on` (organic `--corpus` root), K seeds each → a `ContextDeltaScorecard`-shaped JSON (matches the Go struct fields). The agent runner is **injectable** (`CORPUS_DELTA_RUNNER`, default `eval-agent-harness.sh --agent claude|codex`) so it's testable **without LLM calls**.
- **`tests/scripts/corpus-delta-harness.bats`** — 5 cases via a stub runner: off(empty)→fail, on(corpus)→pass, delta=1.0; no-delta when arms match; scorecard shape; `--out`; arg validation.

## Honesty guard (baked in)
The script header, test comments, and `evidence_kind: "harness_plumbing"` all state: **a stub/plumbing run is NOT evidence of the corpus delta.** The real claim needs a real agent + held non-engineered tasks + K seeds (ag-nfux W1b, ag-epgk W1c). This explicitly avoids repeating the wave0 confusion of citing plumbing as proof.

## Verification
5/5 bats pass; shellcheck clean. No ao is the CLI for AgentOps, a software-factory control plane for repo-native agent work.

"Problem in. Value out. Intelligence compounds."

Software Factory Lane:
  ao factory start --goal "fix auth startup"
  /rpi "fix auth startup"   or   ao rpi phased "fix auth startup"
  ao codex stop

The Knowledge Flywheel underneath it:
  Sessions compound via .agents/ + Smart Connections.
  Others start fresh. You get smarter every session.

For AI agents:
  ao capabilities     Machine-readable CLI contract (JSON) — run this first.
  ao robot-docs       Paste-ready agent handbook.
  Append --json to any read-side command for structured output.

Use "ao <command> --help" for more information about a command.

Usage:
  ao [command]

Getting Started:
  demo            Show the council-first AgentOps 3.0 value path
  init            Initialize AgentOps in the current repository
  quick-start     Set up AgentOps in your project (5 minutes)
  seed            Plant the seed in any repository

Core Commands:
  anti-patterns   List learnings marked as anti-patterns
  badge           Display knowledge flywheel health badge
  canon           Team-knowledge canon: learnings earned by independent attestation
  capabilities    Print the machine-readable CLI contract (JSON)
  ci              BC2 CI status operations (latest run by SHA, recent runs)
  citation        BC1 CitationPort operations (verify file/function/symbol citations)
  claim           BC2 ClaimEvidenceBinderPort operations (bind/list claim-evidence)
  constraint      Manage compiled constraints
  contradict      Detect potentially contradictory learnings
  curate          Curation pipeline operations
  dedup           Detect near-duplicate learnings
  doctor          Check AgentOps health
  flywheel        Knowledge flywheel operations
  gate            Human review gates
  harness         BC5 HarnessPort operations (sync state across skill harnesses)
  loop            BC3 Loop operations (cycle history, etc.)
  maturity        Check and manage learning maturity levels
  metrics         Knowledge flywheel metrics
  operator        BC4 OperatorPort operations (record/list operator intents)
  pool            Manage quality pools
  reconcile       Join git, CI, release, beads, and .agents truth into one report
  robot-docs      Print the paste-ready agent handbook for the ao CLI (Markdown)
  status          Show AgentOps status
  version         Show version information
  vibe-check      Analyze codebase health and vibe

Workflow:
  autodev         Manage the PROGRAM.md operational contract for autonomous development
  codex           Codex lifecycle commands (fallback for pre-v0.115.0; native hooks preferred)
  cron            Cron-fire loop helpers (used by /evolve --mode=loop)
  eval            Run deterministic local evaluation suites
  evolve          Run the autonomous code-improvement loop
  feedback-loop   Close the MemRL feedback loop for a session
  goals           Fitness goal measurement and validation
  handoff         Write a structured handoff artifact for session boundary isolation
  orchestrate     Resolve and inspect the orchestration backend ladder
  ratchet         Brownian Ratchet workflow tracking
  rpi             RPI lifecycle automation
  session         Session lifecycle operations
  validate        Umbrella validation gate (exit-code-as-verdict with --gate)

Configuration:
  completion      Generate shell completion scripts
  config          Manage configuration
  memory          Manage repo-root MEMORY.md for cross-runtime access
  notebook        Manage the session notebook (MEMORY.md)

Communication:

Knowledge:
  beads           Complementary tooling for the bd (beads) issue tracker
  compile         Compile .agents knowledge into an interlinked wiki
  corpus          Corpus-quality probes for Dream and the knowledge flywheel
  defrag          Prune and deduplicate .agents/ learning artifacts
  findings        Manage promoted findings
  forge           Extract knowledge from sources
  harvest         Sweep all rigs, extract and deduplicate cross-rig knowledge
  inject          Output relevant knowledge for explicit or JIT injection
  knowledge       Operationalize a mature .agents corpus into reusable operator surfaces
  lookup          Retrieve specific knowledge artifacts by ID or query
  mind            Knowledge graph operations
  mine            Extract knowledge signal from git, .agents/, and code
  patterns        Inspect and repair .agents/patterns/ artifacts
  retrieval-bench Run retrieval quality benchmarks
  search          Search workspace session history and repo-local knowledge
  sessions        Manage indexed session pages
  trace           Track artifact provenance
  wiki            Unified wiki knowledge surface (experimental)

Additional Commands:
  agent           Produce AgentOps-native session profiles for background agents
  agents          Inspect and manage .agents/ contracts and surfaces
  extract         Process pending learning extractions
  help            Help about any command
  mcp             Expose the ao tool surface over MCP for hosted/SDK Claude loops
  next-work       Operate on the harvested next-work queue (.agents/rpi/next-work.jsonl)
  provenance      Write and read the SDLC provenance edge ledger
  registry        Query the unified registry
  scenario        Manage holdout scenarios for behavioral validation
  scope           Manage edit-scope guard (freeze, unfreeze, status)
  skills          Inspect and validate the skills/ tree
  turn            Evidenced-Turn operations (the enforced unit-of-work definition-of-done)

Flags:
      --config string   Config file (default: ~/.agentops/config.yaml)
      --dry-run         Show what would happen without executing
  -h, --help            help for ao
      --json            Output as JSON (shorthand for -o json)
  -o, --output string   Output format (json, table, yaml) (default "table")
  -v, --verbose         Enable verbose output
      --version         version for ao

Use "ao [command] --help" for more information about a command. command surface; doesn't touch the locked deterministic eval runner; no derived-surface regen needed.

Closes-scenario: ag-u6jh#harness
Bounded-context: BC2-Validation
Evidence: scripts/corpus-delta-harness.sh