### PR TITLE
fix(eval): strip always-loaded roots in context_off (ag-5apc #strip-always-loaded)

### DIFF
--- a/scripts/corpus-delta-harness.sh
+++ b/scripts/corpus-delta-harness.sh
@@ -109,7 +109,7 @@ build_arm_sandbox() {
   else
     # context_off: strip context the base may have carried, so off is provably clean.
     rm -f "$home/.claude/CLAUDE.md"
-    rm -rf "$home/.claude/projects"
+    rm -rf "$home/.claude/projects" "$home/.claude/rules"
   fi
   echo "$home $ws $agents"
 }
@@ -125,10 +125,10 @@ run_arm() {
   for ((seed = 1; seed <= SEEDS; seed++)); do
     read -r home ws agents < <(build_arm_sandbox "$variant" "$corpus_root")
     if [[ "$RUNNER" == "$DEFAULT_RUNNER" ]]; then
-      line="$(HOME="$home" AO_AGENTS_DIR="$agents" CORPUS_DELTA_WORKSPACE="$ws" "$RUNNER" --task "$TASK_ID" --agent "$AGENT" --runs 1 2>/dev/null | tail -1)"
+      line="$(cd "$ws" && HOME="$home" AO_AGENTS_DIR="$agents" CORPUS_DELTA_WORKSPACE="$ws" "$RUNNER" --task "$TASK_ID" --agent "$AGENT" --runs 1 2>/dev/null | tail -1)"
     else
       # Injected (test) runner contract: <task> <agent> <seed>; reads HOME, AO_AGENTS_DIR, CORPUS_DELTA_WORKSPACE.
-      line="$(HOME="$home" AO_AGENTS_DIR="$agents" CORPUS_DELTA_WORKSPACE="$ws" "$RUNNER" "$TASK_ID" "$AGENT" "$seed" 2>/dev/null | tail -1)"
+      line="$(cd "$ws" && HOME="$home" AO_AGENTS_DIR="$agents" CORPUS_DELTA_WORKSPACE="$ws" "$RUNNER" "$TASK_ID" "$AGENT" "$seed" 2>/dev/null | tail -1)"
     fi
     is_pass="$(printf '%s' "$line" | jq -r 'if .pass == true then 1 else 0 end' 2>/dev/null || echo 0)"
     [[ "$is_pass" == "1" ]] && passes=$((passes + 1))

--- a/scripts/corpus-delta-harness.sh
+++ b/scripts/corpus-delta-harness.sh
@@ -64,17 +64,71 @@ done
 DEFAULT_RUNNER="$REPO_ROOT/scripts/eval-agent-harness.sh"
 RUNNER="${CORPUS_DELTA_RUNNER:-$DEFAULT_RUNNER}"
 
-# run_arm <variant> <corpus_root> -> echoes "passes total" (passes = #seeds that passed)
+# --- ag-5apc: always-loaded-root contamination fix --------------------------------
+# Isolating AO_AGENTS_DIR alone is INSUFFICIENT: the agent also auto-loads knowledge
+# from always-loaded roots — the repo-root CLAUDE.md, .claude/rules/*, the user-global
+# ~/.claude/CLAUDE.md, and the auto-memory MEMORY.md. Read in BOTH arms, those leave no
+# delta to measure. So each arm runs in an isolated SANDBOX (HOME + workspace) and these
+# surfaces are treated as CORPUS — present in context_on, absent from context_off.
+# Sources are env-overridable so the self-test can point them at marker fixtures.
+SRC_REPO_ROOT="${CORPUS_DELTA_REPO_ROOT:-$REPO_ROOT}"
+SRC_USER_CLAUDE="${CORPUS_DELTA_USER_CLAUDE:-$HOME/.claude/CLAUDE.md}"
+SRC_MEM_DIR="${CORPUS_DELTA_MEM_DIR:-$HOME/.claude/projects/-home-boful-dev-agentops/memory}"
+# Optional auth base: a dir copied into every sandbox HOME's .claude BEFORE context is
+# applied, so real agents keep their credentials/settings while context is still stripped
+# from the off arm (off = base − context, on = base + context). Empty in tests.
+HOME_BASE="${CORPUS_DELTA_HOME_BASE:-}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# build_arm_sandbox <variant> <corpus_root> -> echoes "<home> <workspace> <agents_dir>"
+build_arm_sandbox() {
+  local variant="$1" corpus_root="$2" sb home ws agents
+  sb="$(mktemp -d -p "$WORK")"
+  home="$sb/home"; ws="$sb/ws"; agents="$ws/.agents"
+  mkdir -p "$home/.claude" "$ws" "$agents"
+  # auth/settings base (preserved in BOTH arms; never carries context)
+  if [[ -n "$HOME_BASE" && -d "$HOME_BASE" ]]; then
+    cp -r "$HOME_BASE/." "$home/.claude/" 2>/dev/null || true
+  fi
+  if [[ "$variant" == "context_on" ]]; then
+    # project always-loaded surface
+    if [[ -f "$SRC_REPO_ROOT/CLAUDE.md" ]]; then cp "$SRC_REPO_ROOT/CLAUDE.md" "$ws/CLAUDE.md"; fi
+    if [[ -d "$SRC_REPO_ROOT/.claude/rules" ]]; then
+      mkdir -p "$ws/.claude"; cp -r "$SRC_REPO_ROOT/.claude/rules" "$ws/.claude/rules"
+    fi
+    # user-global surface + auto-memory
+    if [[ -f "$SRC_USER_CLAUDE" ]]; then cp "$SRC_USER_CLAUDE" "$home/.claude/CLAUDE.md"; fi
+    if [[ -d "$SRC_MEM_DIR" ]]; then
+      mkdir -p "$home/.claude/projects/_mem/memory"
+      cp -r "$SRC_MEM_DIR/." "$home/.claude/projects/_mem/memory/" 2>/dev/null || true
+    fi
+    # organic .agents corpus
+    if [[ -d "$corpus_root" ]]; then cp -r "$corpus_root/." "$agents/" 2>/dev/null || true; fi
+  else
+    # context_off: strip context the base may have carried, so off is provably clean.
+    rm -f "$home/.claude/CLAUDE.md"
+    rm -rf "$home/.claude/projects"
+  fi
+  echo "$home $ws $agents"
+}
+
+# run_arm <variant> <corpus_root> -> echoes "passes total"
+# The runner is invoked with HOME=<sandbox home>, AO_AGENTS_DIR=<sandbox agents>, and
+# CORPUS_DELTA_WORKSPACE=<sandbox ws>; a real agent MUST run with that HOME and cwd=ws so
+# neither arm can reach always-loaded knowledge outside its sandbox.
 run_arm() {
   local variant="$1" corpus_root="$2"
-  local passes=0 seed line is_pass
+  local passes=0 seed line is_pass home ws agents
   echo "[corpus-delta] arm=$variant corpus=$corpus_root seeds=$SEEDS" >&2
   for ((seed = 1; seed <= SEEDS; seed++)); do
+    read -r home ws agents < <(build_arm_sandbox "$variant" "$corpus_root")
     if [[ "$RUNNER" == "$DEFAULT_RUNNER" ]]; then
-      line="$(AO_AGENTS_DIR="$corpus_root" "$RUNNER" --task "$TASK_ID" --agent "$AGENT" --runs 1 2>/dev/null | tail -1)"
+      line="$(HOME="$home" AO_AGENTS_DIR="$agents" CORPUS_DELTA_WORKSPACE="$ws" "$RUNNER" --task "$TASK_ID" --agent "$AGENT" --runs 1 2>/dev/null | tail -1)"
     else
-      # Injected (test) runner contract: <task> <agent> <seed>, reads AO_AGENTS_DIR.
-      line="$(AO_AGENTS_DIR="$corpus_root" "$RUNNER" "$TASK_ID" "$AGENT" "$seed" 2>/dev/null | tail -1)"
+      # Injected (test) runner contract: <task> <agent> <seed>; reads HOME, AO_AGENTS_DIR, CORPUS_DELTA_WORKSPACE.
+      line="$(HOME="$home" AO_AGENTS_DIR="$agents" CORPUS_DELTA_WORKSPACE="$ws" "$RUNNER" "$TASK_ID" "$AGENT" "$seed" 2>/dev/null | tail -1)"
     fi
     is_pass="$(printf '%s' "$line" | jq -r 'if .pass == true then 1 else 0 end' 2>/dev/null || echo 0)"
     [[ "$is_pass" == "1" ]] && passes=$((passes + 1))
@@ -82,11 +136,7 @@ run_arm() {
   echo "$passes $SEEDS"
 }
 
-# context_off: fresh empty isolated corpus root
-OFF_ROOT="$(mktemp -d)"
-trap 'rm -rf "$OFF_ROOT"' EXIT
-
-read -r off_pass off_total < <(run_arm context_off "$OFF_ROOT")
+read -r off_pass off_total < <(run_arm context_off "")
 read -r on_pass on_total < <(run_arm context_on "$CORPUS_DIR")
 
 # pass-rate per arm; delta = on - off

--- a/tests/scripts/corpus-delta-harness.bats
+++ b/tests/scripts/corpus-delta-harness.bats
@@ -66,3 +66,64 @@ STUB_EOF
   run env CORPUS_DELTA_RUNNER="$STUB" "$HARNESS" --seeds 1
   [ "$status" -eq 2 ]
 }
+
+# --- ag-5apc: always-loaded-root contamination self-test ---------------------------
+# Proves the off arm cannot reach knowledge from the always-loaded roots (repo CLAUDE.md,
+# .claude/rules/*, user-global ~/.claude/CLAUDE.md, auto-memory). A CONTAM stub passes iff
+# it finds a MARKER anywhere in its sandbox (HOME + workspace); the harness seeds the
+# marker into FIXTURE sources for the always-loaded roots. on -> sees marker; off -> must not.
+setup_contam() {
+  MK="CORPUS_DELTA_MARKER_a5pc"
+  SRCREPO="$TMP/srcrepo"; mkdir -p "$SRCREPO/.claude/rules"
+  echo "$MK project-claude" > "$SRCREPO/CLAUDE.md"
+  echo "$MK rules" > "$SRCREPO/.claude/rules/go.md"
+  USERCLAUDE="$TMP/user-CLAUDE.md"; echo "$MK user-global" > "$USERCLAUDE"
+  MEMDIR="$TMP/mem"; mkdir -p "$MEMDIR"; echo "$MK memory" > "$MEMDIR/MEMORY.md"
+  # CONTAM stub: greps its whole sandbox (HOME + workspace) for the marker.
+  CSTUB="$TMP/contam-stub.sh"
+  cat > "$CSTUB" <<CSTUB_EOF
+#!/usr/bin/env bash
+if grep -rqsl "$MK" "\${HOME}" "\${CORPUS_DELTA_WORKSPACE:-/nonexistent}" 2>/dev/null; then
+  echo '{"pass": true, "score": 1, "total": 1}'
+else
+  echo '{"pass": false, "score": 0, "total": 1}'
+fi
+CSTUB_EOF
+  chmod +x "$CSTUB"
+}
+
+@test "always-loaded marker reaches context_on but NOT context_off (delta=1)" {
+  setup_contam
+  run env CORPUS_DELTA_RUNNER="$CSTUB" \
+    CORPUS_DELTA_REPO_ROOT="$SRCREPO" \
+    CORPUS_DELTA_USER_CLAUDE="$USERCLAUDE" \
+    CORPUS_DELTA_MEM_DIR="$MEMDIR" \
+    "$HARNESS" --task demo --seeds 2 --corpus "$CORPUS" --out "$TMP/sc.json"
+  [ "$status" -eq 0 ]
+  # off arm provably blind to all always-loaded roots; on arm sees them.
+  jq -e '.context_off.aggregate_score == 0' "$TMP/sc.json" >/dev/null
+  jq -e '.context_on.aggregate_score == 1' "$TMP/sc.json" >/dev/null
+  jq -e '.aggregate_delta == 1' "$TMP/sc.json" >/dev/null
+}
+
+@test "HOME_BASE auth survives both arms while context is stripped from off" {
+  setup_contam
+  BASE="$TMP/homebase"; mkdir -p "$BASE"
+  echo '{"token":"x"}' > "$BASE/.credentials.json"   # auth-like file, no marker
+  echo "$MK leaked-via-base" > "$BASE/CLAUDE.md"      # context the base must NOT carry into off
+  # Stub: pass iff it sees the AUTH file (proves base copied into both arms).
+  ASTUB="$TMP/auth-stub.sh"
+  printf '#!/usr/bin/env bash\n[ -f "${HOME}/.claude/.credentials.json" ] && echo '"'"'{"pass":true}'"'"' || echo '"'"'{"pass":false}'"'"'\n' > "$ASTUB"
+  chmod +x "$ASTUB"
+  run env CORPUS_DELTA_RUNNER="$ASTUB" CORPUS_DELTA_HOME_BASE="$BASE" \
+    "$HARNESS" --task demo --seeds 1 --corpus "$CORPUS" --out "$TMP/sc.json"
+  [ "$status" -eq 0 ]
+  # auth present in BOTH arms -> both pass -> delta 0 (auth is runtime, not context)
+  jq -e '.context_off.aggregate_score == 1' "$TMP/sc.json" >/dev/null
+  jq -e '.context_on.aggregate_score == 1' "$TMP/sc.json" >/dev/null
+  # and the base-carried CLAUDE.md marker must NOT survive into the off arm
+  run env CORPUS_DELTA_RUNNER="$CSTUB" CORPUS_DELTA_HOME_BASE="$BASE" \
+    CORPUS_DELTA_REPO_ROOT="$TMP/none" CORPUS_DELTA_USER_CLAUDE="$TMP/none" CORPUS_DELTA_MEM_DIR="$TMP/none" \
+    "$HARNESS" --task demo --seeds 1 --corpus "$CORPUS" --out "$TMP/sc2.json"
+  jq -e '.context_off.aggregate_score == 0' "$TMP/sc2.json" >/dev/null
+}

--- a/tests/scripts/corpus-delta-harness.bats
+++ b/tests/scripts/corpus-delta-harness.bats
@@ -62,6 +62,16 @@ STUB_EOF
   jq -e '.aggregate_delta == 1' "$TMP/sc.json" >/dev/null
 }
 
+@test "runner is invoked from the sandbox workspace" {
+  WSTUB="$TMP/workspace-stub.sh"
+  printf '#!/usr/bin/env bash\n[ "$PWD" = "${CORPUS_DELTA_WORKSPACE}" ] && echo '"'"'{"pass":true}'"'"' || echo '"'"'{"pass":false}'"'"'\n' > "$WSTUB"
+  chmod +x "$WSTUB"
+  run env CORPUS_DELTA_RUNNER="$WSTUB" "$HARNESS" --task demo --seeds 1 --corpus "$CORPUS" --out "$TMP/sc.json"
+  [ "$status" -eq 0 ]
+  jq -e '.context_off.aggregate_score == 1' "$TMP/sc.json" >/dev/null
+  jq -e '.context_on.aggregate_score == 1' "$TMP/sc.json" >/dev/null
+}
+
 @test "requires --task" {
   run env CORPUS_DELTA_RUNNER="$STUB" "$HARNESS" --seeds 1
   [ "$status" -eq 2 ]
@@ -109,8 +119,10 @@ CSTUB_EOF
 @test "HOME_BASE auth survives both arms while context is stripped from off" {
   setup_contam
   BASE="$TMP/homebase"; mkdir -p "$BASE"
+  mkdir -p "$BASE/rules"
   echo '{"token":"x"}' > "$BASE/.credentials.json"   # auth-like file, no marker
   echo "$MK leaked-via-base" > "$BASE/CLAUDE.md"      # context the base must NOT carry into off
+  echo "$MK leaked-via-base-rules" > "$BASE/rules/base.md"
   # Stub: pass iff it sees the AUTH file (proves base copied into both arms).
   ASTUB="$TMP/auth-stub.sh"
   printf '#!/usr/bin/env bash\n[ -f "${HOME}/.claude/.credentials.json" ] && echo '"'"'{"pass":true}'"'"' || echo '"'"'{"pass":false}'"'"'\n' > "$ASTUB"
@@ -121,7 +133,7 @@ CSTUB_EOF
   # auth present in BOTH arms -> both pass -> delta 0 (auth is runtime, not context)
   jq -e '.context_off.aggregate_score == 1' "$TMP/sc.json" >/dev/null
   jq -e '.context_on.aggregate_score == 1' "$TMP/sc.json" >/dev/null
-  # and the base-carried CLAUDE.md marker must NOT survive into the off arm
+  # and base-carried context markers must NOT survive into the off arm
   run env CORPUS_DELTA_RUNNER="$CSTUB" CORPUS_DELTA_HOME_BASE="$BASE" \
     CORPUS_DELTA_REPO_ROOT="$TMP/none" CORPUS_DELTA_USER_CLAUDE="$TMP/none" CORPUS_DELTA_MEM_DIR="$TMP/none" \
     "$HARNESS" --task demo --seeds 1 --corpus "$CORPUS" --out "$TMP/sc2.json"


### PR DESCRIPTION
## What
Fixes the contamination flaw the W1b adversarial audit surfaced: isolating `AO_AGENTS_DIR` alone is **insufficient** — the agent also auto-loads knowledge from **always-loaded roots** (repo-root `CLAUDE.md`, `.claude/rules/*`, user-global `~/.claude/CLAUDE.md`, auto-memory `MEMORY.md`), read in **both** arms → no delta to measure (6 of 12 W1b candidates were invalidated by this).

Each arm now runs in an isolated **sandbox** (HOME + workspace). Those surfaces are treated as **corpus** — populated in `context_on`, absent from `context_off`:
- `build_arm_sandbox()` — ON copies project CLAUDE.md + .claude/rules + user CLAUDE.md + auto-memory + the .agents corpus; OFF leaves them out (and strips any base-carried context).
- `CORPUS_DELTA_HOME_BASE` seeds auth/settings into both arms **before** context, so a real agent keeps credentials while OFF stays context-clean (off = base − context, on = base + context).
- Runner now gets `HOME` + `AO_AGENTS_DIR` + `CORPUS_DELTA_WORKSPACE`; a real agent MUST run with that HOME + cwd=workspace.

## Contamination self-test (the bead's success criterion)
A marker seeded into **every** always-loaded root reaches `context_on` but **NOT** `context_off` (delta=1); a separate test proves auth (`HOME_BASE`) survives both arms while base-carried context is stripped from off.

## Verification
7/7 bats pass; shellcheck clean. No `ao` surface; no derived-surface regen. Unblocks honest W1b/W1c.

Closes-scenario: ag-5apc#strip-always-loaded
Bounded-context: BC2-Validation
Evidence: scripts/corpus-delta-harness.sh