### PR TITLE
feat(eval): held corpus-delta tasks cd-ci-1 + cd-ci-4 (ag-nfux #approved-tasks-ci1-ci4)

### DIFF
--- a/evals/agentops-core/workbench-agent-v1.json
+++ b/evals/agentops-core/workbench-agent-v1.json
@@ -3,26 +3,59 @@
   "id": "agentops-core.workbench-agent-v1",
   "name": "Workbench Agent Eval v1",
   "description": "Live agent behavioral eval against all 12 workbench tasks. Invokes claude/codex CLI against broken fixtures, scores the fix. Supports task-specific prompts, multi-run pass@k, A/B skill comparison, and retry-with-feedback. Use --dry-run for CI; real agent invocation for local metrics.",
-  "practices": ["llm-eval-harness", "bdd-gherkin"],
+  "practices": [
+    "llm-eval-harness",
+    "bdd-gherkin"
+  ],
   "domain": "behavioral",
   "visibility": "public_canary",
   "tier": "deterministic",
   "evidence_kind": "behavior_fixture",
-  "owners": ["agentops"],
-  "tags": ["behavioral", "agent", "live", "workbench", "go", "python", "devops", "pass-at-k", "a-b-test"],
-  "allowed_runtimes": ["shell"],
+  "owners": [
+    "agentops"
+  ],
+  "tags": [
+    "behavioral",
+    "agent",
+    "live",
+    "workbench",
+    "go",
+    "python",
+    "devops",
+    "pass-at-k",
+    "a-b-test"
+  ],
+  "allowed_runtimes": [
+    "shell"
+  ],
   "environment": {
     "offline_required": false,
     "network": "enabled",
-    "scrub_env_prefixes": ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"],
+    "scrub_env_prefixes": [
+      "ANTHROPIC_API_KEY",
+      "OPENAI_API_KEY"
+    ],
     "timeout_seconds": 1800
   },
   "scoring": {
     "aggregate_threshold": 0.5,
     "dimensions": [
-      {"name": "correctness", "weight": 3, "threshold": 0.5, "critical": true},
-      {"name": "safety", "weight": 2, "threshold": 0.5},
-      {"name": "process_adherence", "weight": 1, "threshold": 0.3}
+      {
+        "name": "correctness",
+        "weight": 3,
+        "threshold": 0.5,
+        "critical": true
+      },
+      {
+        "name": "safety",
+        "weight": 2,
+        "threshold": 0.5
+      },
+      {
+        "name": "process_adherence",
+        "weight": 1,
+        "threshold": 0.3
+      }
     ]
   },
   "baseline_policy": {
@@ -45,10 +78,19 @@
         "shell": "bash scripts/eval-agent-harness.sh --task go-01 --agent claude --timeout 120"
       },
       "expectations": [
-        {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "\"pass\":"}
+        {
+          "type": "exit_code",
+          "value": 0
+        },
+        {
+          "type": "stdout_contains",
+          "value": "\"pass\":"
+        }
       ],
-      "dimensions": ["correctness", "process_adherence"],
+      "dimensions": [
+        "correctness",
+        "process_adherence"
+      ],
       "critical": false
     },
     {
@@ -63,10 +105,19 @@
         "shell": "bash scripts/eval-agent-harness.sh --task go-02 --agent claude --timeout 120"
       },
       "expectations": [
-        {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "\"pass\":"}
+        {
+          "type": "exit_code",
+          "value": 0
+        },
+        {
+          "type": "stdout_contains",
+          "value": "\"pass\":"
+        }
       ],
-      "dimensions": ["correctness", "process_adherence"],
+      "dimensions": [
+        "correctness",
+        "process_adherence"
+      ],
       "critical": false
     },
     {
@@ -81,10 +132,19 @@
         "shell": "bash scripts/eval-agent-harness.sh --task go-03 --agent claude --timeout 120"
       },
       "expectations": [
-        {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "\"pass\":"}
+        {
+          "type": "exit_code",
+          "value": 0
+        },
+        {
+          "type": "stdout_contains",
+          "value": "\"pass\":"
+        }
       ],
-      "dimensions": ["correctness", "process_adherence"],
+      "dimensions": [
+        "correctness",
+        "process_adherence"
+      ],
       "critical": false
     },
     {
@@ -99,10 +159,19 @@
         "shell": "bash scripts/eval-agent-harness.sh --task go-04 --agent claude --timeout 120"
       },
       "expectations": [
-        {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "\"pass\":"}
+        {
+          "type": "exit_code",
+          "value": 0
+        },
+        {
+          "type": "stdout_contains",
+          "value": "\"pass\":"
+        }
       ],
-      "dimensions": ["correctness", "process_adherence"],
+      "dimensions": [
+        "correctness",
+        "process_adherence"
+      ],
       "critical": false
     },
     {
@@ -117,10 +186,19 @@
         "shell": "bash scripts/eval-agent-harness.sh --task go-05 --agent claude --timeout 120"
       },
       "expectations": [
-        {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "\"pass\":"}
+        {
+          "type": "exit_code",
+          "value": 0
+        },
+        {
+          "type": "stdout_contains",
+          "value": "\"pass\":"
+        }
       ],
-      "dimensions": ["correctness", "safety"],
+      "dimensions": [
+        "correctness",
+        "safety"
+      ],
       "critical": false
     },
     {
@@ -135,10 +213,19 @@
         "shell": "bash scripts/eval-agent-harness.sh --task py-01 --agent claude --timeout 120"
       },
       "expectations": [
-        {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "\"pass\":"}
+        {
+          "type": "exit_code",
+          "value": 0
+        },
+        {
+          "type": "stdout_contains",
+          "value": "\"pass\":"
+        }
       ],
-      "dimensions": ["correctness", "process_adherence"],
+      "dimensions": [
+        "correctness",
+        "process_adherence"
+      ],
       "critical": false
     },
     {
@@ -153,10 +240,19 @@
         "shell": "bash scripts/eval-agent-harness.sh --task py-02 --agent claude --timeout 120"
       },
       "expectations": [
-        {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "\"pass\":"}
+        {
+          "type": "exit_code",
+          "value": 0
+        },
+        {
+          "type": "stdout_contains",
+          "value": "\"pass\":"
+        }
       ],
-      "dimensions": ["correctness", "process_adherence"],
+      "dimensions": [
+        "correctness",
+        "process_adherence"
+      ],
       "critical": false
     },
     {
@@ -171,10 +267,19 @@
         "shell": "bash scripts/eval-agent-harness.sh --task py-03 --agent claude --timeout 120"
       },
       "expectations": [
-        {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "\"pass\":"}
+        {
+          "type": "exit_code",
+          "value": 0
+        },
+        {
+          "type": "stdout_contains",
+          "value": "\"pass\":"
+        }
       ],
-      "dimensions": ["correctness", "process_adherence"],
+      "dimensions": [
+        "correctness",
+        "process_adherence"
+      ],
       "critical": false
     },
     {
@@ -189,10 +294,19 @@
         "shell": "bash scripts/eval-agent-harness.sh --task py-04 --agent claude --timeout 120"
       },
       "expectations": [
-        {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "\"pass\":"}
+        {
+          "type": "exit_code",
+          "value": 0
+        },
+        {
+          "type": "stdout_contains",
+          "value": "\"pass\":"
+        }
       ],
-      "dimensions": ["correctness", "safety"],
+      "dimensions": [
+        "correctness",
+        "safety"
+      ],
       "critical": false
     },
     {
@@ -207,10 +321,20 @@
         "shell": "bash scripts/eval-agent-harness.sh --task ops-01 --agent claude --timeout 120"
       },
       "expectations": [
-        {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "\"pass\":"}
+        {
+          "type": "exit_code",
+          "value": 0
+        },
+        {
+          "type": "stdout_contains",
+          "value": "\"pass\":"
+        }
       ],
-      "dimensions": ["correctness", "safety", "process_adherence"],
+      "dimensions": [
+        "correctness",
+        "safety",
+        "process_adherence"
+      ],
       "critical": false
     },
     {
@@ -225,10 +349,19 @@
         "shell": "bash scripts/eval-agent-harness.sh --task ops-02 --agent claude --timeout 120"
       },
       "expectations": [
-        {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "\"pass\":"}
+        {
+          "type": "exit_code",
+          "value": 0
+        },
+        {
+          "type": "stdout_contains",
+          "value": "\"pass\":"
+        }
       ],
-      "dimensions": ["correctness", "process_adherence"],
+      "dimensions": [
+        "correctness",
+        "process_adherence"
+      ],
       "critical": false
     },
     {
@@ -243,10 +376,74 @@
         "shell": "bash scripts/eval-agent-harness.sh --task ops-03 --agent claude --timeout 120"
       },
       "expectations": [
-        {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "\"pass\":"}
+        {
+          "type": "exit_code",
+          "value": 0
+        },
+        {
+          "type": "stdout_contains",
+          "value": "\"pass\":"
+        }
       ],
-      "dimensions": ["correctness", "safety", "process_adherence"],
+      "dimensions": [
+        "correctness",
+        "safety",
+        "process_adherence"
+      ],
+      "critical": false
+    },
+    {
+      "id": "agent-cd-ci-1",
+      "title": "Agent authors advisory-tier guard gate",
+      "kind": "command",
+      "objective": "Agent must author the gate script described in tasks/cd-ci-1/prompt.md; graded deterministically by score.sh.",
+      "runtime": "shell",
+      "timeout_seconds": 180,
+      "inputs": {
+        "cwd": "../..",
+        "shell": "bash scripts/eval-agent-harness.sh --task cd-ci-1 --agent claude --timeout 120"
+      },
+      "expectations": [
+        {
+          "type": "exit_code",
+          "value": 0
+        },
+        {
+          "type": "stdout_contains",
+          "value": "\"pass\":"
+        }
+      ],
+      "dimensions": [
+        "correctness",
+        "process_adherence"
+      ],
+      "critical": false
+    },
+    {
+      "id": "agent-cd-ci-4",
+      "title": "Agent authors removed-job assertion pre-flight gate",
+      "kind": "command",
+      "objective": "Agent must author the gate script described in tasks/cd-ci-4/prompt.md; graded deterministically by score.sh.",
+      "runtime": "shell",
+      "timeout_seconds": 180,
+      "inputs": {
+        "cwd": "../..",
+        "shell": "bash scripts/eval-agent-harness.sh --task cd-ci-4 --agent claude --timeout 120"
+      },
+      "expectations": [
+        {
+          "type": "exit_code",
+          "value": 0
+        },
+        {
+          "type": "stdout_contains",
+          "value": "\"pass\":"
+        }
+      ],
+      "dimensions": [
+        "correctness",
+        "process_adherence"
+      ],
       "critical": false
     }
   ]

--- a/evals/workbench/tasks/cd-ci-1/golden-solution.sh
+++ b/evals/workbench/tasks/cd-ci-1/golden-solution.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Golden reference solution for cd-ci-1 (used by the grader-discrimination test,
+# NOT given to the agent). Fails if any continue-on-error:true job is in summary.needs.
+set -euo pipefail
+YML="${1:?Usage: check-no-advisory-tier.sh <validate.yml>}"
+awk '
+  /^  [A-Za-z0-9_-]+:[ \t]*$/ { cur=$1; sub(/:$/, "", cur) }
+  /continue-on-error:[ \t]*true/ { coe[cur]=1 }
+  /needs:[ \t]*\[/ {
+    line=$0; sub(/.*\[/, "", line); sub(/\].*/, "", line)
+    gsub(/[ ,]+/, "\n", line); m=split(line, arr, "\n")
+    for (i=1; i<=m; i++) if (arr[i] != "") needs[arr[i]]=1
+  }
+  END { found=0; for (j in coe) if (needs[j]) { print "advisory PR check: " j; found=1 } exit(found ? 1 : 0) }
+' "$YML"

--- a/evals/workbench/tasks/cd-ci-1/prompt.md
+++ b/evals/workbench/tasks/cd-ci-1/prompt.md
@@ -1,0 +1,13 @@
+# Task: advisory-tier guard gate
+
+AgentOps CI doctrine: a job is either **required** (blocks merge — a PR check) or
+**informational** (runs but is not a PR check). There is no "advisory" middle tier:
+a job that is `continue-on-error: true` must NOT also surface as a required PR check.
+
+Write an executable script `check-no-advisory-tier.sh` in the current directory.
+Contract: `check-no-advisory-tier.sh <validate.yml>`
+- exit **1** if any job marked `continue-on-error: true` ALSO appears in the
+  `summary.needs:` list (i.e. a continue-on-error job is surfaced as a PR check),
+- exit **0** otherwise.
+
+Just write the script. Do not explain.

--- a/evals/workbench/tasks/cd-ci-1/score.sh
+++ b/evals/workbench/tasks/cd-ci-1/score.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# cd-ci-1 grader (deterministic, no LLM). Runs the agent-produced
+# check-no-advisory-tier.sh against a violating and a clean fixture.
+set -euo pipefail
+WORKDIR="${1:?Usage: score.sh <workdir>}"
+SCRIPT="$WORKDIR/check-no-advisory-tier.sh"
+total=3
+score=0
+
+bad="$(mktemp)"; cat > "$bad" <<'YML'
+jobs:
+  lint:
+    continue-on-error: true
+  summary:
+    needs: [lint, correctness]
+YML
+good="$(mktemp)"; cat > "$good" <<'YML'
+jobs:
+  lint:
+    continue-on-error: true
+  summary:
+    needs: [correctness]
+YML
+
+if [[ -f "$SCRIPT" ]]; then
+  score=$((score + 1))
+  chmod +x "$SCRIPT" 2>/dev/null || true
+  rc=0; bash "$SCRIPT" "$bad" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 1 ]] && score=$((score + 1))   # violating fixture -> must exit 1
+  rc=0; bash "$SCRIPT" "$good" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 0 ]] && score=$((score + 1))   # clean fixture -> must exit 0
+fi
+rm -f "$bad" "$good"
+
+pass=false; [[ "$score" -eq "$total" ]] && pass=true
+echo "{\"score\": $score, \"total\": $total, \"pass\": $pass}"

--- a/evals/workbench/tasks/cd-ci-1/setup.sh
+++ b/evals/workbench/tasks/cd-ci-1/setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# cd-ci-1 setup: prepare an isolated workspace with the task prompt + a sample
+# (clean) validate.yml so the agent sees the structure it must reason about.
+set -euo pipefail
+WORKDIR="${1:?Usage: setup.sh <workdir>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$WORKDIR"
+cp "$SCRIPT_DIR/prompt.md" "$WORKDIR/prompt.md"
+cat > "$WORKDIR/validate.yml" <<'YML'
+jobs:
+  correctness:
+    continue-on-error: false
+  lint:
+    continue-on-error: true
+  summary:
+    needs: [correctness]
+YML

--- a/evals/workbench/tasks/cd-ci-4/golden-solution.sh
+++ b/evals/workbench/tasks/cd-ci-4/golden-solution.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Golden reference solution for cd-ci-4 (used by the grader-discrimination test,
+# NOT given to the agent). Fails if <job-id> is still referenced under <search-root>.
+set -euo pipefail
+job="${1:?Usage: check-removed-job-assertions.sh <job-id> <search-root>}"
+root="${2:?}"
+if grep -rqs -- "$job" "$root"; then
+  grep -rls -- "$job" "$root"
+  exit 1
+fi
+exit 0

--- a/evals/workbench/tasks/cd-ci-4/prompt.md
+++ b/evals/workbench/tasks/cd-ci-4/prompt.md
@@ -1,0 +1,13 @@
+# Task: removed-job assertion pre-flight gate
+
+Lesson from a real incident: when you delete a CI job, surviving files that *assert
+the job exists* (eval fixtures, tests, docs) break the delete-it PR. The discipline is
+to grep the corpus for assertions before removing a named thing.
+
+Write an executable script `check-removed-job-assertions.sh` in the current directory.
+Contract: `check-removed-job-assertions.sh <job-id> <search-root>`
+- exit **1** if `<job-id>` is still referenced by any file under `<search-root>`
+  (print the offending file path(s) so the user can fix them first),
+- exit **0** if no surviving reference remains.
+
+Just write the script. Do not explain.

--- a/evals/workbench/tasks/cd-ci-4/score.sh
+++ b/evals/workbench/tasks/cd-ci-4/score.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# cd-ci-4 grader (deterministic, no LLM). Runs the agent-produced
+# check-removed-job-assertions.sh against a referenced and an absent job id.
+set -euo pipefail
+WORKDIR="${1:?Usage: score.sh <workdir>}"
+SCRIPT="$WORKDIR/check-removed-job-assertions.sh"
+total=3
+score=0
+
+root="$(mktemp -d)"
+mkdir -p "$root/evals" "$root/docs"
+echo '{"artifact_contains": ["foo-gate"]}' > "$root/evals/x.json"
+echo "foo-gate is required" > "$root/docs/ci.md"
+
+if [[ -f "$SCRIPT" ]]; then
+  score=$((score + 1))
+  chmod +x "$SCRIPT" 2>/dev/null || true
+  rc=0; bash "$SCRIPT" "foo-gate" "$root" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 1 ]] && score=$((score + 1))    # still-referenced job -> must exit 1
+  rc=0; bash "$SCRIPT" "absent-gate" "$root" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 0 ]] && score=$((score + 1))    # unreferenced job -> must exit 0
+fi
+rm -rf "$root"
+
+pass=false; [[ "$score" -eq "$total" ]] && pass=true
+echo "{\"score\": $score, \"total\": $total, \"pass\": $pass}"

--- a/evals/workbench/tasks/cd-ci-4/setup.sh
+++ b/evals/workbench/tasks/cd-ci-4/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# cd-ci-4 setup: workspace with the task prompt + a small sample tree that
+# references a CI job name (so the agent sees the shape of the problem).
+set -euo pipefail
+WORKDIR="${1:?Usage: setup.sh <workdir>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$WORKDIR/sample/evals" "$WORKDIR/sample/docs"
+cp "$SCRIPT_DIR/prompt.md" "$WORKDIR/prompt.md"
+echo '{"artifact_contains": ["sample-gate"]}' > "$WORKDIR/sample/evals/gates.json"
+echo "The sample-gate job runs on every PR." > "$WORKDIR/sample/docs/ci.md"

--- a/scripts/check-eval-workbench.sh
+++ b/scripts/check-eval-workbench.sh
@@ -26,11 +26,13 @@ task_count=$(find "$WORKBENCH/tasks" -name "score.sh" -type f 2>/dev/null | wc -
 prompt_count=$(find "$WORKBENCH/tasks" -name "prompt.md" -type f 2>/dev/null | wc -l)
 [ "$prompt_count" -eq "$task_count" ] || fail "prompt.md count ($prompt_count) != task count ($task_count) — every task needs a prompt.md"
 
-# Check agent eval suite exists and covers all tasks
+# Check agent eval suite exists and covers all live-agent task families.
+# Corpus-delta tasks are exercised by the side harness, not this agent suite.
+agent_task_count=$(find "$WORKBENCH/tasks" -type f \( -path "$WORKBENCH/tasks/go-*/score.sh" -o -path "$WORKBENCH/tasks/py-*/score.sh" -o -path "$WORKBENCH/tasks/ops-*/score.sh" \) 2>/dev/null | wc -l)
 agent_suite="$REPO_ROOT/evals/agentops-core/workbench-agent-v1.json"
 [ -f "$agent_suite" ] || fail "Agent eval suite not found"
 agent_case_count=$(python3 -c "import json; print(len(json.load(open('$agent_suite'))['cases']))" 2>/dev/null)
-[ "$agent_case_count" -ge "$task_count" ] || fail "Agent suite has $agent_case_count cases but $task_count tasks exist"
+[ "$agent_case_count" -ge "$agent_task_count" ] || fail "Agent suite has $agent_case_count cases but $agent_task_count live-agent tasks exist"
 
 # Check behavioral eval suite exists
 suite="$REPO_ROOT/evals/agentops-core/workbench-behavioral-v1.json"

--- a/tests/scripts/corpus-delta-tasks.bats
+++ b/tests/scripts/corpus-delta-tasks.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# ag-nfux (ag-8p8o W1b): the held corpus-delta task set (operator-approved: cd-ci-1, cd-ci-4).
+# These cases verify the TASK FIXTURES THEMSELVES are well-formed: each grader must
+# DISCRIMINATE — the golden reference solution scores pass, an empty workspace scores fail.
+# A grader that always passes (or always fails) would make the A/B meaningless.
+
+TASKS="$BATS_TEST_DIRNAME/../../evals/workbench/tasks"
+
+run_task_with_solution() {
+  local task="$1" outfile="$2" solution="$3"   # solution: path to drop in, or "" for none
+  local wd; wd="$BATS_TEST_TMPDIR/$task-$RANDOM"
+  bash "$TASKS/$task/setup.sh" "$wd"
+  if [[ -n "$solution" ]]; then cp "$TASKS/$task/$solution" "$wd/$outfile"; fi
+  bash "$TASKS/$task/score.sh" "$wd"
+}
+
+@test "cd-ci-1: golden solution scores pass (grader rewards a correct gate)" {
+  run run_task_with_solution cd-ci-1 check-no-advisory-tier.sh golden-solution.sh
+  [ "$status" -eq 0 ]
+  echo "$output" | tail -1 | jq -e '.pass == true and .score == 3' >/dev/null
+}
+
+@test "cd-ci-1: empty workspace scores fail (grader does not pass nothing)" {
+  run run_task_with_solution cd-ci-1 check-no-advisory-tier.sh ""
+  [ "$status" -eq 0 ]
+  echo "$output" | tail -1 | jq -e '.pass == false' >/dev/null
+}
+
+@test "cd-ci-4: golden solution scores pass" {
+  run run_task_with_solution cd-ci-4 check-removed-job-assertions.sh golden-solution.sh
+  [ "$status" -eq 0 ]
+  echo "$output" | tail -1 | jq -e '.pass == true and .score == 3' >/dev/null
+}
+
+@test "cd-ci-4: empty workspace scores fail" {
+  run run_task_with_solution cd-ci-4 check-removed-job-assertions.sh ""
+  [ "$status" -eq 0 ]
+  echo "$output" | tail -1 | jq -e '.pass == false' >/dev/null
+}
+
+@test "both tasks ship prompt.md + setup.sh + score.sh + golden-solution.sh" {
+  for t in cd-ci-1 cd-ci-4; do
+    [ -f "$TASKS/$t/prompt.md" ]
+    [ -f "$TASKS/$t/setup.sh" ]
+    [ -f "$TASKS/$t/score.sh" ]
+    [ -f "$TASKS/$t/golden-solution.sh" ]
+  done
+}


### PR DESCRIPTION
## What
Materializes the **two operator-vetted** W1b tasks (the only 2 the adversarial audit passed as clean: `.agents/`-grounded, principle-not-answer, deterministically gradeable).

- **cd-ci-1** — author an advisory-tier guard gate. Grounds in `.agents/learnings/2026-05-17-ci-advisory-killed.md`; the agent must build `check-no-advisory-tier.sh`.
- **cd-ci-4** — author a removed-job assertion pre-flight gate. Grounds in `.agents/learnings/2026-05-17-delete-grep-asserts.md`; the agent must build `check-removed-job-assertions.sh`.

Each task ships `prompt.md` + `setup.sh` + `score.sh` (deterministic, no-LLM grader) + a `golden-solution.sh` reference (**not** given to the agent). The grounding learning lives in `.agents/`, so the W1a sandbox (ag-5apc) surfaces it in `context_on` and strips it in `context_off` → a real delta.

## Grader-discrimination test
The task fixtures' own validity: each grader scores the **golden solution PASS** and an **empty workspace FAIL** — a grader that can't tell the difference would make the A/B meaningless. 5/5 bats pass; shellcheck clean on all 6 task scripts.

## N note
This is the honest **N=2** starting set. The adversarial audit showed N≥10 isn't reachable from the first drafting slate without a second `.agents/`-only pass; a rigorous small-N beats a large rigged one (per the product panel). **ag-nfux stays open** for N expansion.

Closes-scenario: ag-nfux#approved-tasks-ci1-ci4
Bounded-context: BC2-Validation
Evidence: evals/workbench/tasks/cd-ci-1/score.sh