### PR TITLE
fix(corpus): relevance-rank ao inject — strip stopwords from query tokens (ag-32gx #stopword-relevance)

### DIFF
--- a/cli/internal/search/learnings.go
+++ b/cli/internal/search/learnings.go
@@ -10,10 +10,32 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/boshu2/agentops/cli/internal/types"
 	"github.com/boshu2/agentops/cli/internal/wiki"
 )
+
+// searchStopwords are common English function words dropped from query tokens so a
+// verbose query (e.g. a whole task prompt) reduces to its salient terms. Without this,
+// MatchRatio (matched/total) collapses for long queries and ranking falls back to generic
+// freshness — the retrieval-relevance gap found by the corpus-delta W1c first signal
+// (ag-32gx): the task-relevant learning was buried under recency-ranked noise. Only true
+// function words are listed — domain words (gate, job, exit, ci, run, check) are kept.
+var searchStopwords = map[string]bool{
+	"the": true, "a": true, "an": true, "and": true, "or": true, "of": true, "to": true,
+	"in": true, "on": true, "for": true, "is": true, "it": true, "with": true, "by": true,
+	"at": true, "as": true, "be": true, "this": true, "that": true, "these": true, "those": true,
+	"if": true, "any": true, "all": true, "do": true, "does": true, "not": true, "no": true,
+	"so": true, "than": true, "then": true, "into": true, "its": true, "are": true, "was": true,
+	"were": true, "will": true, "would": true, "can": true, "could": true, "should": true,
+	"must": true, "may": true, "you": true, "your": true, "we": true, "they": true, "i": true,
+	"but": true, "also": true, "such": true, "when": true, "which": true, "what": true,
+	"who": true, "whom": true, "via": true, "per": true, "from": true, "up": true, "out": true,
+	"about": true, "over": true, "only": true, "each": true, "both": true, "just": true,
+	"here": true, "there": true, "has": true, "have": true, "had": true, "been": true,
+	"some": true, "more": true, "most": true, "other": true, "them": true, "their": true,
+}
 
 // ValidPhases is the set of canonical RPI phase values for source_phase.
 var ValidPhases = map[string]bool{
@@ -29,15 +51,23 @@ func SanitizeSourcePhase(phase string) string {
 	return ""
 }
 
-// QueryTokens splits a lowercased query into individual search tokens.
-// Tokens shorter than 2 characters are dropped to avoid noise.
+// QueryTokens splits a lowercased query into salient search tokens: it splits on any
+// non-alphanumeric rune (so "continue-on-error:true" -> continue/error/true), drops
+// stopwords and sub-2-char tokens, and deduplicates (order-preserving). Stopword removal
+// is what lets a verbose query (a whole task prompt) still rank the relevant learning
+// instead of collapsing to generic freshness (ag-32gx).
 func QueryTokens(queryLower string) []string {
-	words := strings.Fields(queryLower)
-	tokens := make([]string, 0, len(words))
-	for _, w := range words {
-		if len(w) >= 2 {
-			tokens = append(tokens, w)
+	fields := strings.FieldsFunc(queryLower, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+	seen := make(map[string]bool, len(fields))
+	tokens := make([]string, 0, len(fields))
+	for _, w := range fields {
+		if len(w) < 2 || searchStopwords[w] || seen[w] {
+			continue
 		}
+		seen[w] = true
+		tokens = append(tokens, w)
 	}
 	return tokens
 }

--- a/cli/internal/search/relevance_test.go
+++ b/cli/internal/search/relevance_test.go
@@ -1,0 +1,61 @@
+package search
+
+import "testing"
+
+// ag-32gx: QueryTokens must strip stopwords + punctuation so a verbose query (a whole
+// task prompt) reduces to its salient terms. Without this, MatchRatio (matched/total)
+// collapses for long queries and ranking falls back to generic freshness (the corpus-delta
+// W1c retrieval-relevance gap).
+
+func TestQueryTokens_StripsStopwordsAndPunctuation(t *testing.T) {
+	got := QueryTokens("if any job is continue-on-error:true and it is in the summary.needs list")
+	gotSet := map[string]bool{}
+	for _, tk := range got {
+		gotSet[tk] = true
+	}
+	// stopwords must be gone
+	for _, sw := range []string{"if", "any", "is", "and", "it", "in", "the"} {
+		if gotSet[sw] {
+			t.Errorf("stopword %q should be stripped, got tokens %v", sw, got)
+		}
+	}
+	// salient terms must survive (punctuation split: continue-on-error -> continue/error)
+	for _, want := range []string{"job", "continue", "error", "true", "summary", "needs", "list"} {
+		if !gotSet[want] {
+			t.Errorf("salient token %q missing from %v", want, got)
+		}
+	}
+	// dedup: "is"/"the" appear twice in input but are stopwords anyway; ensure no dupes
+	seen := map[string]bool{}
+	for _, tk := range got {
+		if seen[tk] {
+			t.Errorf("duplicate token %q in %v", tk, got)
+		}
+		seen[tk] = true
+	}
+}
+
+// A verbose query (with stopwords) must still rank a learning matching its SALIENT terms
+// above one that matches none — the directional fix for the retrieval-relevance gap.
+func TestMatchRatio_VerboseQueryRanksRelevantAboveGeneric(t *testing.T) {
+	q := QueryTokens("write a gate that fails when a continue-on-error job is an advisory PR check")
+	relevant := MatchRatio(q, "CI advisory tier killed",
+		"required or informational; nothing between",
+		"a continue-on-error job must not be an advisory PR check")
+	generic := MatchRatio(q, "auto til flight is boring",
+		"journal note", "unrelated musing about essays and framing")
+	if !(relevant > generic) {
+		t.Errorf("relevant learning ratio (%.3f) must exceed generic (%.3f) for a verbose query", relevant, generic)
+	}
+	if generic != 0 {
+		t.Errorf("generic learning should match no salient tokens, got ratio %.3f", generic)
+	}
+}
+
+// Backstop: an all-stopword query yields no tokens -> MatchRatio returns 1.0 (no relevance
+// signal -> fall back to freshness), preserving prior behavior for degenerate queries.
+func TestQueryTokens_AllStopwordsYieldsEmpty(t *testing.T) {
+	if got := QueryTokens("the and or of to in on for"); len(got) != 0 {
+		t.Errorf("all-stopword query should yield no tokens, got %v", got)
+	}
+}


### PR DESCRIPTION
## What
Fixes the retrieval-relevance gap the corpus-delta **W1c first signal** located: `ao inject --context "<verbose query>"` returned generic recency-ranked learnings, not the task-relevant one. **Root cause:** `QueryTokens` did no stopword filtering — a long query became ~80 tokens (incl. the/if/any/that), so `MatchRatio` (matched ÷ total) collapsed for every learning and ranking fell back to freshness.

**Fix** (mirrors the proven `skills/find.go` tokenizer): `QueryTokens` now splits on any non-alphanumeric rune (`continue-on-error:true` → continue/error/true), drops a ~80-word English stopword set + sub-2-char tokens, and dedups. Domain words (gate/job/exit/ci/run/check) are deliberately kept.

## Validation
- **Empirical, against the real corpus:** a focused query's hits on the target learning rose (2 → 4); the learning is NOT quality-gate-filtered (it surfaces with a salient query).
- **Tests:** QueryTokens strips stopwords/punctuation + dedups; a verbose query ranks a salient-matching learning above a generic one; all-stopword query degrades safely (→ no relevance signal → freshness, preserving prior behavior). 86 search + 580 cmd/ao pass; build + vet clean.

## Honest residual (separate, NOT an inject defect)
A raw whole-prompt query still dilutes via `MatchRatio` length-normalization. inject's job is to rank *given* a query; it now does. The **caller** should pass a focused query — noted on **ag-epgk**: the W1c runner should derive a focused retrieval query (task title/salient line), not pass `prompt.md` verbatim. That, plus this fix, unblocks a clean W1c re-run.

Closes-scenario: ag-32gx#stopword-relevance
Bounded-context: BC1-Corpus
Evidence: cli/internal/search/learnings.go