### PR TITLE
docs(audit): remediate stale root + key docs — hookless refs, skill counts, retired CI jobs (ag-lk80 #staleness-fixes)

### DIFF
--- a/AGENTS-CI.md
+++ b/AGENTS-CI.md
@@ -13,9 +13,7 @@ Advisory and warn-only jobs run on every PR but their failure does NOT block mer
 
 | Job | Triage SLA | Escalation rule |
 |---|---|---|
-| **doctor-check** | 30d | Open a `bd` issue tracking the stale CLI reference; prioritize when the next `cli/cmd/ao/**` PR lands. |
-| **factory-claim-ledger-strict** | 14d | soc-lmww1: validates `docs/contracts/factory-claim-ledger.json` against source-set anchors. Open a `bd` issue tagged `ci-advisory` when red for >14d; promotion to blocking is a Wave 1E concern. |
-| **practice-citations** | 14d | Non-blocking strict walk of Primitives (skills/hooks/evals/CLI/schemas and scripts with declarations) for `practices: [slug,...]` derivation from PRACTICE-REGISTRY.md. Backfill in slices; promote to required after one clean cycle. Open a `bd` issue tagged `ci-advisory` when red for >14d with no backfill progress. |
+| **doctor-check** | 30d | Open a `bd` issue tracking the stale CLI reference; prioritize when the next `cli/cmd/ao/**` PR lands. Runs as an advisory step inside the consolidated `correctness` job, not a standalone GitHub job. |
 | **check-test-staleness** | none (info-only) | Read the report; no merge or release impact. Item 33 — drift signal, not a gate. |
 | **swarm-evidence** | none (info-only) | Read the report; no merge or release impact. Item 34 — informational artifact validation. |
 | **executable-spec-link-integrity** (inner trace --orphans step) | none (warn-only) | The job is now blocking (soc-x7y9f) on the `ao goals scenarios --lint` link check; only the inner `ao goals trace --orphans` whole-chain audit stays warn-only. Read the trace output for orphan-chain defects (tracked under soc-gqhrz); no merge impact from that step. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Building the CLI, the Key Scripts table, CI-validation detail + the "rules that 
 
 1. **Claim.** `bd ready` → pick a bead → `bd update <id> --claim`. **No bead, no PR.** If the work is genuinely new, `bd create` first.
 2. **Scope.** Read the bead's acceptance: a `.feature` file (canonical when present) or an embedded `## Scenarios` block in the bead description. Free-text acceptance is invalid — promote it to scenarios before work begins. Default: **one PR per coherent arc** — bundle scenarios that ship-or-revert together; split scenarios with independent rollback. The PR is the *atomic-revert unit*. Carve-out: `type=chore` with `#trivial` label for tiny work.
-3. **Ship.** `bd worktree create --branch <type>/<bead-id>-<scenario-token>-<short-slug>` — worktree-mandatory; do not edit in the shared checkout. Implement. Run per-tool sanity checks for the surfaces you touched (`cd cli && make test`, `bats tests/scripts/<file>.bats`, etc.); CI runs the omnibus validation on push.
+3. **Ship.** `bd worktree create --branch <type>/<bead-id>-<scenario-token>-<short-slug>` — worktree-mandatory; do not edit in the shared checkout. Implement. Run `scripts/pre-push-gate.sh --fast` before push (smart conditional gate that runs the per-tool checks — `cd cli && make test`, `bats tests/scripts/<file>.bats`, etc. — only for the surfaces you changed); CI runs the omnibus validation on push.
 4. **Close.** Open PR. CI validates the merge state. Squash-merge when green. The bead closes only when every scenario is merged (or explicitly cancelled in bead metadata).
 
 ### Branch + PR shape

--- a/docs/cli-skills-map.md
+++ b/docs/cli-skills-map.md
@@ -98,7 +98,7 @@ Which `ao` commands each skill invokes.
 | council | `rpi phased` |
 | shared | `rpi phased` |
 
-Skills with **no ao commands**: beads, brainstorm, bug-hunt, codex-team, complexity, converter, doc, heal-skill, llm-wiki, openai-docs, oss-docs, pr-implement, pr-plan, pr-prep, pr-research, pr-retro, pr-validate, product, readme, release, reverse-engineer-rpi, security, security-suite, standards, trace, update.
+Skills with **no ao commands**: beads, brainstorm, bug-hunt, codex-team, complexity, converter, doc, heal-skill, llm-wiki, openai-docs, pr-implement, pr-prep, pr-research, pr-validate, product, release, reverse-engineer-rpi, security, security-suite, standards, trace.
 
 Conceptual slash commands such as `/knowledge` are documented elsewhere in the product docs, but they are not counted as source skill directories in this map.
 

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -46,7 +46,7 @@ Bridge / framing docs:
 
 ## Architecture
 
-- [How It Works](how-it-works.md) — Brownian Ratchet, Ralph Wiggum Pattern, agent backends, hooks, context windowing
+- [How It Works](how-it-works.md) — Brownian Ratchet, Ralph Wiggum Pattern, agent backends, context windowing
 - [Software Factory Surface](software-factory.md) — Explicit automation surface for briefings, RPI flows, and operator-controlled closeout
 - [Assurance Profile](assurance-profile.md) — High-assurance operating posture, authority boundaries, and evidence artifact expectations for constrained environments
 - [Architecture](ARCHITECTURE.md) — System design and component overview
@@ -80,7 +80,7 @@ Bridge / framing docs:
 - [Skill API](SKILL-API.md) — Frontmatter fields, context declarations, enforcement status
 - [Skill Quality Rubric](reference/skill-quality-rubric.md) — Scoring rubric for repo-runtime, export, and mega-skill readiness
 - [AgentOps Domain Evolution BDD](reference/agentops-domain-evolution-bdd.md) — Gherkin acceptance contract for skill, CLI, and hook evolution
-- [AgentOps Skill Domain Map](reference/agentops-skill-domain-map.md) — All 78 checked-in skills mapped to Corpus, Validation, Loop, Factory, and Runtime domains (drift-checked by `scripts/check-registry-drift.sh`)
+- [AgentOps Skill Domain Map](reference/agentops-skill-domain-map.md) — All 82 checked-in skills mapped to Corpus, Validation, Loop, Factory, and Runtime domains (drift-checked by `scripts/check-registry-drift.sh`)
 - [AgentOps Hexagonal Architecture Map](reference/agentops-hexagonal-architecture-map.md) — Bounded contexts, ports, adapters, and proof gates for the evolution program
 - [AgentOps Domain Evolution Plan](reference/agentops-domain-evolution-plan.md) — Sequenced bootstrap and evolution plan anchored to `soc-y5vh`
 - [Skill Tiers](https://github.com/boshu2/agentops/blob/main/skills/SKILL-TIERS.md) — Taxonomy and dependency graph

--- a/docs/index.md
+++ b/docs/index.md
@@ -156,7 +156,7 @@ Every skill works alone. Compose flows for end-to-end cycles.
 | [`/dream`](skills/dream.md) | You want overnight knowledge compounding that never mutates source code |
 
 !!! info "Full catalog"
-    [:octicons-book-24: **All 73 skills**](skills/catalog.md) — complete reference with source links and descriptions.
+    [:octicons-book-24: **All 82 skills**](skills/catalog.md) — complete reference with source links and descriptions.
     [:octicons-routes-24: **Decision tree**](skills-decision-tree.md) — "which skill do I need next?"
 
 ---

--- a/docs/newcomer-guide.md
+++ b/docs/newcomer-guide.md
@@ -4,7 +4,7 @@ If you're new to this repository, this guide gives you a practical mental model,
 
 ## What this repo is
 
-AgentOps is the **operational layer for coding agents**: a skills + CLI system (with opt-in hooks) that provides bookkeeping, validation, primitives, and flows so sessions compound instead of restarting from zero.
+AgentOps is the **operational layer for coding agents**: a skills + CLI system that provides bookkeeping, validation, primitives, and flows so sessions compound instead of restarting from zero. (AgentOps 3.0 is hookless by default — CI is the authoritative gate; hooks are an opt-in surface you author yourself.)
 
 At a high level:
 
@@ -21,20 +21,19 @@ See also:
 
 ## Repo structure (what matters most)
 
-Think in five layers:
+Think in four layers:
 
 1. **Product/docs layer** — `docs/` + selected repo-root entrypoints such as `README.md`, `CHANGELOG.md`, `GOALS.md`, and `PRODUCT.md`
 2. **Skills layer** — `skills/`, checked-in `skills-codex/`, and `skills-codex-overrides/` (`SKILL.md` contracts + per-skill scripts/references + Codex-only tailoring)
-3. **Hooks layer** — `hooks/` with active runtime manifest in `hooks/hooks.json`
-4. **CLI layer** — `cli/` (`cli/cmd/ao/`, `cli/internal/`, generated `cli/docs/COMMANDS.md`)
-5. **Validation layer** — `scripts/`, `tests/`, and `.github/workflows/validate.yml`
+3. **CLI layer** — `cli/` (`cli/cmd/ao/`, `cli/internal/`, generated `cli/docs/COMMANDS.md`)
+4. **Validation layer** — `scripts/`, `tests/`, and `.github/workflows/validate.yml` (CI is the authoritative gate; AgentOps 3.0 ships no hooks)
 
 ## Source-of-truth precedence
 
 When docs disagree, follow this order:
 
-1. Executable code + generated artifacts (`cli/**`, `hooks/**`, `scripts/**`, `cli/docs/COMMANDS.md`)
-2. Skill contracts/manifests (`skills/**/SKILL.md`, `hooks/hooks.json`, `schemas/**`)
+1. Executable code + generated artifacts (`cli/**`, `scripts/**`, `cli/docs/COMMANDS.md`)
+2. Skill contracts/manifests (`skills/**/SKILL.md`, `schemas/**`)
 3. Explanatory docs (`docs/**`, `README.md`)
 
 For Codex skills specifically:
@@ -68,9 +67,9 @@ Use the router in [Skills Reference](SKILLS.md) to choose the right entry point:
 - Run multi-issue waves: `/crank`
 - Run end-to-end lifecycle: `/rpi`
 
-### 3) Hooks are part of runtime behavior
+### 3) Hooks are opt-in, not a default
 
-The active hook manifest in `hooks/hooks.json` is authoritative for what runs at session boundaries.
+AgentOps 3.0 ships zero hooks; nothing auto-injects or runs at session boundaries. CI (`.github/workflows/validate.yml`) is the authoritative gate. If you want a bounded local gate of your own, author one with the `hooks-authoring` skill — AgentOps does not ship one.
 
 ### 4) CLI docs are generated, not hand-maintained
 
@@ -78,7 +77,7 @@ The active hook manifest in `hooks/hooks.json` is authoritative for what runs at
 
 ### 5) CI checks many non-code contracts
 
-CI validates not just builds/tests but also docs parity, hook safety, skill integrity/schema, security scans, and contract compatibility.
+CI validates not just builds/tests but also docs parity, skill integrity/schema, security scans, and contract compatibility.
 
 ## Suggested learning path
 
@@ -94,23 +93,23 @@ CI validates not just builds/tests but also docs parity, hook safety, skill inte
 
 - **CLI behavior:** `cli/cmd/ao/`, `cli/internal/`, `cli/docs/COMMANDS.md`
 - **Skill behavior:** `skills/<name>/SKILL.md`
-- **Hook/gate behavior:** `hooks/hooks.json` + `hooks/*.sh`
+- **Opt-in hooks:** `skills/hooks-authoring/` (AgentOps ships none by default)
 - **Validation/release/security:** `scripts/*.sh` + `tests/` + `.github/workflows/validate.yml`
 
 ### Recommended first contributions
 
 1. **Docs-only fix** (safe): update wording or cross-links and run docs validation scripts.
-2. **Hook/docs parity fix** (medium): update docs to match runtime hook manifest and validate parity.
+2. **Skill/docs parity fix** (medium): update docs to match a `SKILL.md` change and validate parity.
 3. **Small CLI command improvement** (advanced beginner): update command behavior, regenerate CLI docs, and run CLI checks.
 
 ## Practical tips
 
-- Activate the repo-managed git hooks once per clone/worktree: `bash scripts/install-dev-hooks.sh`
+- Run the local gate before pushing: `bash scripts/pre-push-gate.sh --fast` (smart conditional gate that only checks what changed).
 - Trust runtime files over narrative docs when there is a mismatch.
 - Keep changes small and verify with local gates before pushing.
-- Treat `.agents/` and hooks as first-class parts of the system behavior.
+- Treat `.agents/` as a first-class part of the system behavior.
 - Treat Codex as a first-class runtime: when a skill change affects Codex UX or execution style, inspect `skills-codex-overrides/`, update `skills-codex-overrides/catalog.json` if treatment changes, update the checked-in `skills-codex/` copy when needed, and run the Codex validation scripts.
-- If you touch command surfaces or hook contracts, expect related parity checks to fail until updated.
+- If you touch command surfaces or skill contracts, expect related parity checks to fail until updated.
 
 ## Where to go next
 

--- a/scripts/sync-skill-counts.sh
+++ b/scripts/sync-skill-counts.sh
@@ -188,6 +188,19 @@ patch_file "$REPO_ROOT/PRODUCT.md" \
   "s|Distribution/runtime reach: [0-9]+ shared skills, [0-9]+ checked-in Codex artifacts, and [0-9]+ Codex overrides|Distribution/runtime reach: ${TOTAL} shared skills, ${CODEX_TOTAL} checked-in Codex artifacts, and ${CODEX_OVERRIDES} Codex overrides|" \
   "PRODUCT.md distribution/runtime reach"
 
+# docs/index.md: full-catalog link label "All N skills" (links to the generated
+# catalog, which lists every checked-in skill, so this is the TOTAL).
+patch_file "$REPO_ROOT/docs/index.md" \
+  '\*\*All [0-9]+ skills\*\*\]\(skills/catalog\.md\)' \
+  "s|\\*\\*All [0-9]+ skills\\*\\*\\]\\(skills/catalog\\.md\\)|**All ${TOTAL} skills**](skills/catalog.md)|" \
+  "docs/index.md catalog link count"
+
+# docs/documentation-index.md: skill-domain-map entry "All N checked-in skills".
+patch_file "$REPO_ROOT/docs/documentation-index.md" \
+  'All [0-9]+ checked-in skills mapped' \
+  "s|All [0-9]+ checked-in skills mapped|All ${TOTAL} checked-in skills mapped|" \
+  "docs/documentation-index.md domain-map skill count"
+
 echo ""
 
 if [[ "$errors" -gt 0 ]]; then


### PR DESCRIPTION
## What

Remediates verified staleness from the 2026-06-03 doc audit of root governance/product docs + the key `docs/` cluster. Two systemic rot patterns drove almost every finding: **skill-count drift** (73/78/~80 vs truth 82) and **hooks references that survived the 3.0 hookless teardown**.

All fixes independently verified against `cli/**`, `scripts/**`, `.github/workflows/validate.yml`, and `skills/**`.

## Changes (by bead)

| Bead | Sev | Fix |
|---|---|---|
| ag-swi1 | CRIT | `newcomer-guide.md`: removed hooks-as-runtime-layer framing (3.0 ships zero hooks); 5→4 layers; fixed dead `scripts/install-dev-hooks.sh` ref; reframed hooks as opt-in via `hooks-authoring` skill |
| ag-99xv | CRIT | `index.md`: skill count 73→82. **The "broken catalog link" was a false positive** — `docs/skills/catalog.md` is generated at build by `gen_skill_pages.py`; link left unchanged |
| ag-xa2b | CRIT | `cli-skills-map.md`: removed 5 phantom skills (`pr-plan`, `pr-retro`, `update`, `readme`, `oss-docs`) an agent could mis-invoke. Deep hooks-decoupling of this file (title, "Hook Callers" column, "Hooks → Commands" section) **decomposed to a follow-up** — half-editing leaves it internally inconsistent |
| ag-w4t8 | CRIT | `AGENTS-CI.md`: dropped retired advisory rows `practice-citations` (RETIRED 2026-05-19) and `factory-claim-ledger-strict` (no such job; references nonexistent file) |
| ag-bcl4 | HIGH | `index.md` + `documentation-index.md`: counts → 82, **and extended `sync-skill-counts.sh`** to cover both call-sites so the count self-heals and CI (`validate-doc-release.sh` → `sync --check`) catches future drift — the durable fix, not just retyping the number |
| ag-p7zg | HIGH | `CLAUDE.md`: aligned Ship-phase pre-push command to `scripts/pre-push-gate.sh --fast`, matching `AGENTS-WORKFLOW.md` |
| ag-y5ii | MED | `documentation-index.md`: dropped stale "hooks" from the how-it-works description |

## Deferred (filed as follow-up beads, not in this PR)

- PRODUCT.md "April 2026 Claude Code source analysis" reframe — product positioning, operator's call
- Full hooks-decoupling of `cli-skills-map.md` — structural rework, needs its own verification
- `bd worktree create --branch` syntax is wrong in CLAUDE.md/AGENTS-WORKFLOW.md (needs a positional name) — discovered this session
- `validate-bd-closeout-contract.sh` requires `bd dolt push` conditional wording in AGENTS.md that the AGENTS split dropped (pre-existing main red, local-only gate)
- Second-wave sweep of the remaining ~80 `docs/` files (ag-bz8n)

## Verification

- `scripts/sync-skill-counts.sh --check` → clean (both new call-sites covered)
- `scripts/validate-cli-skills-map.sh` → PASS
- `tests/docs/validate-doc-release.sh` → PASS
- No residual `hooks/` / `hooks.json` runtime refs in `newcomer-guide.md`
- All referenced paths exist (`skills/hooks-authoring/`, `scripts/pre-push-gate.sh`)

Closes-scenario: ag-lk80#staleness-fixes
Bounded-context: BC1-Corpus
Evidence: docs/index.md