### PR TITLE
docs(governance): fix broken bd-command references in governance docs (ag-55m0 #bd-command-doc-fixes)

### DIFF
--- a/AGENTS-WORKFLOW.md
+++ b/AGENTS-WORKFLOW.md
@@ -12,7 +12,7 @@
 
 1. **Claim.** `bd ready` → pick a bead → `bd update <id> --claim`. **No bead, no PR.** If the work is genuinely new, `bd create` first.
 2. **Scope.** Read the bead's acceptance: a `.feature` file (canonical when present) or an embedded `## Scenarios` block in the bead description. Free-text acceptance is invalid — promote it to scenarios before work begins. Default: **one PR per coherent arc** — bundle scenarios that ship-or-revert together; split scenarios with independent rollback. The PR is the *atomic-revert unit*. Carve-out: `type=chore` with `#trivial` label for tiny work.
-3. **Ship.** `bd worktree create --branch <type>/<bead-id>-<scenario-token>-<short-slug>` — worktree-mandatory; do not edit in the shared checkout. Implement. Run `scripts/pre-push-gate.sh --fast` before push.
+3. **Ship.** `bd worktree create wt-<bead-id> --branch <type>/<bead-id>-<scenario-token>-<short-slug>` (the worktree dir name is the required positional arg) — worktree-mandatory; do not edit in the shared checkout. Implement. Run `scripts/pre-push-gate.sh --fast` before push.
 4. **Close.** Open PR. CI validates the merge state. Squash-merge when green. The bead closes only when every scenario is merged (or explicitly cancelled in bead metadata).
 
 ### Branch + PR shape
@@ -27,7 +27,7 @@
 
 ### Multi-agent discipline (shared checkout)
 
-The host `~/dev/agentops` is contended. **Agents do not edit it directly.** Use `bd worktree create --branch <name>` for every change. Cross-bead merge serialization: `bd merge-slot`. Foreign uncommitted files = quarantined; identify owner, attach to a bead, move into a worktree.
+The host `~/dev/agentops` is contended. **Agents do not edit it directly.** Use `bd worktree create <name> --branch <branch>` for every change. Cross-bead merge serialization: `bd merge-slot`. Foreign uncommitted files = quarantined; identify owner, attach to a bead, move into a worktree.
 
 ### Provenance
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Building the CLI, the Key Scripts table, CI-validation detail + the "rules that 
 
 1. **Claim.** `bd ready` → pick a bead → `bd update <id> --claim`. **No bead, no PR.** If the work is genuinely new, `bd create` first.
 2. **Scope.** Read the bead's acceptance: a `.feature` file (canonical when present) or an embedded `## Scenarios` block in the bead description. Free-text acceptance is invalid — promote it to scenarios before work begins. Default: **one PR per coherent arc** — bundle scenarios that ship-or-revert together; split scenarios with independent rollback. The PR is the *atomic-revert unit*. Carve-out: `type=chore` with `#trivial` label for tiny work.
-3. **Ship.** `bd worktree create --branch <type>/<bead-id>-<scenario-token>-<short-slug>` — worktree-mandatory; do not edit in the shared checkout. Implement. Run `scripts/pre-push-gate.sh --fast` before push (smart conditional gate that runs the per-tool checks — `cd cli && make test`, `bats tests/scripts/<file>.bats`, etc. — only for the surfaces you changed); CI runs the omnibus validation on push.
+3. **Ship.** `bd worktree create wt-<bead-id> --branch <type>/<bead-id>-<scenario-token>-<short-slug>` (the worktree dir name is the required positional arg) — worktree-mandatory; do not edit in the shared checkout. Implement. Run `scripts/pre-push-gate.sh --fast` before push (smart conditional gate that runs the per-tool checks — `cd cli && make test`, `bats tests/scripts/<file>.bats`, etc. — only for the surfaces you changed); CI runs the omnibus validation on push.
 4. **Close.** Open PR. CI validates the merge state. Squash-merge when green. The bead closes only when every scenario is merged (or explicitly cancelled in bead metadata).
 
 ### Branch + PR shape
@@ -81,7 +81,7 @@ Building the CLI, the Key Scripts table, CI-validation detail + the "rules that 
 
 ### Multi-agent discipline (shared checkout)
 
-The host `~/dev/agentops` is contended. **Agents do not edit it directly.** Use `bd worktree create --branch <name>` for every change. Cross-bead merge serialization: `bd merge-slot`. Foreign uncommitted files = quarantined; identify owner, attach to a bead, move into a worktree.
+The host `~/dev/agentops` is contended. **Agents do not edit it directly.** Use `bd worktree create <name> --branch <branch>` for every change. Cross-bead merge serialization: `bd merge-slot`. Foreign uncommitted files = quarantined; identify owner, attach to a bead, move into a worktree.
 
 ### Provenance
 

--- a/scripts/validate-bd-closeout-contract.sh
+++ b/scripts/validate-bd-closeout-contract.sh
@@ -38,7 +38,9 @@ require_conditional_push_wording() {
     fi
 }
 
-require_conditional_push_wording "AGENTS.md"
+# The bd-closeout conditional-push wording lives in AGENTS-WORKFLOW.md after the
+# AGENTS.md tiered split (soc-vuu6.3); the thin root AGENTS.md only points to it.
+require_conditional_push_wording "AGENTS-WORKFLOW.md"
 require_conditional_push_wording "cli/AGENTS.md"
 
 if require_file "docs/runbooks/bd-server-mode-closeout.md"; then


### PR DESCRIPTION
## What

Two verified bd-command doc/contract bugs discovered while executing the ag-lk80 doc-staleness epic.

| Bead | Fix |
|---|---|
| ag-55m0 | `bd worktree create --branch <branch>` (4 sites: CLAUDE.md ×2, AGENTS-WORKFLOW.md ×2) omits bd 1.0.5's **required positional `<name>`** — the documented form prints help and creates nothing. Now `bd worktree create wt-<bead-id> --branch <branch>`. |
| ag-6jzv | `validate-bd-closeout-contract.sh` required the `bd dolt push` conditional wording in **AGENTS.md**, but the tiered split (soc-vuu6.3) moved that content to **AGENTS-WORKFLOW.md** (lines 150/277). Repointed the validator where the wording actually lives. |

## Verification
- `bd worktree create --help` → confirms the positional `<name>` requirement (hit live this session)
- `scripts/validate-bd-closeout-contract.sh` → **PASS** (was failing on AGENTS.md on pristine main)
- No `bd worktree create --branch` without a positional name remains in CLAUDE.md / AGENTS-WORKFLOW.md

Closes-scenario: ag-55m0#bd-command-doc-fixes
Closes-scenario: ag-6jzv#validator-repoint
Bounded-context: BC2-Validation
Evidence: scripts/validate-bd-closeout-contract.sh