### PR TITLE
docs: reconcile narrative docs with retired daemon/Gas-City + reframe Anthropic claim (ag-6v3j #convergent)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-05-15
+last_reviewed: 2026-06-03
 ---
 
 # PRODUCT.md
@@ -62,7 +62,7 @@ Bring your agent and bring your harness. If it can consume plugins or skills, Ag
 
 ## Market Convergence
 
-The April 2026 Claude Code source analysis confirmed that Anthropic's internal tooling follows the same architecture AgentOps implements:
+Anthropic's Managed Agents (and peers like Cursor and Factory) appear to converge on the same architecture AgentOps implements — convergent, not derived-from (see the convergence note below):
 
 | Anthropic Concept | AgentOps Equivalent | Status |
 |---|---|---|
@@ -202,7 +202,7 @@ The same model used in the README: bookkeeping records the work, the context com
 <!-- agentops:claim:AOP-CLAIM-PRODUCT-EVOLVE-RECONCILE -->
 - `/evolve` — bounded reconciliation: reads goals, targets the worst gap, validates, and can repeat under operator limits
 - `/dream` — bounded private compounding lane
-- Gas City reference City — operator-owned cadence for unattended rpi, compile, maturity, and related jobs
+- Out-of-session substrate (reference: NTM + MCP + managed-agents) — operator-owned cadence for unattended rpi, compile, maturity, and related jobs
 - `.github/workflows/nightly.yml` — public proof harness for the contracts (not your private runtime)
 - MemRL feedback — cited artifacts receive session reward, utility scores update
 - Corpus health snapshot — the flywheel reports whether current citation flow is compounding or decaying

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -68,7 +68,7 @@ The AO↔Olympus bridge has been archived. Removed surfaces:
 
 ### Daemon mode is available as an opt-in product runtime
 
-> **⚠ Superseded in AgentOps 3.0:** the standalone daemon (`agentopsd`) was **removed** in the 3.0 rearchitecture — AgentOps is in-session only, and out-of-session orchestration is delegated to the Gas City reference City. See [`MIGRATION-3.0.md`](MIGRATION-3.0.md) and [ADR-0009](adr/ADR-0009-daemon-deletion-in-session-only.md). The entry below is retained as historical record of the (now-removed) v2.x daemon.
+> **⚠ Superseded in AgentOps 3.0:** the standalone daemon (`agentopsd`) was **removed** in the 3.0 rearchitecture — AgentOps is in-session only, and out-of-session orchestration is delegated to a swappable substrate (reference: NTM + MCP + managed-agents). See [`MIGRATION-3.0.md`](MIGRATION-3.0.md) and [ADR-0009](adr/ADR-0009-daemon-deletion-in-session-only.md). The entry below is retained as historical record of the (now-removed) v2.x daemon.
 
 **Affects:** anyone migrating RPI, Dream, wiki/forge, or OpenClaw integrations
 from foreground command ownership to `agentopsd`.

--- a/docs/agentops-3-explainer-kit.md
+++ b/docs/agentops-3-explainer-kit.md
@@ -8,7 +8,7 @@ section, launch post, or video description.
 AgentOps is the engineering operating system for agent teams: a disciplined
 engineering layer that gives coding agents shared domain context, review
 verdicts, tracked follow-up work, and optional out-of-session compounding (the
-loop dispatched on the Gas City reference City).
+loop dispatched on a reference NTM + MCP + managed-agents substrate).
 
 ## Problem Statement
 
@@ -116,20 +116,22 @@ The important shape:
 
 Out-of-session orchestration is the deeper lane, not the first proof.
 AgentOps ships no daemon or scheduler of its own — the loop runs in session,
-and unattended runs are delegated to the Gas City reference City (see
-[ADR-0009](adr/ADR-0009-daemon-deletion-in-session-only.md)).
+and unattended runs are delegated to a swappable orchestration substrate. The
+reference substrate is the trio **NTM + MCP + managed-agents** (see
+[ADR-0009](adr/ADR-0009-daemon-deletion-in-session-only.md) and
+[docs/dependencies.md](dependencies.md)).
 
 After the user sees one packet and one verdict:
 
 ```bash
-# In the reference City, a long-lived mayor agent slings the next ready bead
-# to a refinery worker, which runs the loop as one invocable unit:
+# The substrate dispatches a whole loop as one unit: it spawns an agent that
+# runs the /rpi skill over the next ready bead — it never drives the loop's insides:
 ao rpi <bead-id>
-# Scheduled maintenance (Dream reports, wiki curation, release checks) runs as
-# Gas City cron Orders. See docs/dependencies.md and the using-gc skill.
+# Scheduled maintenance (Dream reports, wiki curation, release checks) is driven
+# by the substrate's triggers (NTM swarm, cron, or MCP). See docs/dependencies.md.
 ```
 
-Use the Gas City lane for approved recurring work such as Dream reports, wiki
+Use the substrate lane for approved recurring work such as Dream reports, wiki
 curation, release checks, or other compounding jobs where the operator has
 already accepted the artifact shape.
 

--- a/docs/daemon-migration.md
+++ b/docs/daemon-migration.md
@@ -1,5 +1,14 @@
 # Legacy To Daemon Migration
 
+> ⚠️ **ARCHIVED — describes removed infrastructure.** AgentOps 3.0 has **no
+> daemon**. `agentopsd` and the `internal/daemon` package were deleted (soc-2rtm0),
+> and the `ao daemon` / `ao overnight` commands no longer exist (`ao daemon` →
+> "unknown command"). 3.0 is in-session only; always-on / out-of-session work is
+> delegated to a swappable substrate — **NTM + MCP (`ao mcp serve`) +
+> managed-agents (`ao agent`)**. See [docs/3.0.md](3.0.md) ("not … a daemon") and
+> [docs/dependencies.md](dependencies.md). This page is retained only as a record
+> of the pre-3.0 design; nothing below is live.
+
 AgentOps is moving from foreground command flows to an always-on local daemon.
 The daemon path is currently opt-in: existing one-shot RPI, Dream, and
 wiki/forge commands continue to work unless you pass the daemon flags.

--- a/docs/strategic-direction.md
+++ b/docs/strategic-direction.md
@@ -19,7 +19,7 @@ The public product does not require users to know this vocabulary. This is the i
 
 **Knowledge OS** (the systems-theoretic substrate — Meadows leverage points, the dK/dt equation, stigmergy as the multi-agent coordination primitive)
 → **Olympus** (archived runtime; patterns absorbed as skills)
-→ **AgentOps** (this reference implementation: skills + hooks + `ao` CLI + scheduling daemon)
+→ **AgentOps** (this reference implementation: skills + `ao` CLI + the CDLC operating loop; hookless, no daemon — out-of-session work is delegated to an NTM/MCP/managed-agents substrate)
 → **Mt. Olympus** (forkable Gas City runtime proof — the empirical demonstration the substrate runs autonomously against a real codebase under operator control).
 
 Industry parallels (Anthropic Managed Agents, factory-style mission systems, Cursor agents) are convergent on the same planner/implementer/validator shape — not derived-from.


### PR DESCRIPTION
## What

Second-wave staleness fixes for **removed infrastructure presented as live**, plus the operator-approved PRODUCT.md reframe (ag-6v3j). Verified against `cli/**` (`ao daemon`/`ao overnight` → "unknown command"), `docs/3.0.md`, and `docs/dependencies.md` (canonical out-of-session substrate = **NTM + MCP + managed-agents**; Gas City is not a substrate option — only the gc-*bridge* existed, and it was removed).

| File | Fix |
|---|---|
| daemon-migration.md | ARCHIVED banner — `agentopsd`/`ao daemon`/`ao overnight` deleted (soc-2rtm0); body kept only as pre-3.0 record |
| strategic-direction.md:22 | "skills + hooks + ao CLI + scheduling daemon" → "skills + ao CLI + CDLC loop; hookless, no daemon; NTM/MCP/managed-agents" |
| agentops-3-explainer-kit.md | "Gas City reference City" out-of-session lane → NTM + MCP + managed-agents |
| UPGRADING.md:71 | superseded-daemon banner's "Gas City reference City" → swappable substrate |
| PRODUCT.md (ag-6v3j) | line 65 "April 2026 Claude Code source analysis confirmed..." → "appear to converge … convergent, not derived-from" (no in-repo source; matches the doc's own hedging at 73/270/331); `last_reviewed` 2026-05-15 → 2026-06-03; line 205 Gas City → substrate |

## Verification
- `ao daemon --help` / `ao overnight --help` → "unknown command" (confirmed removed)
- `scripts/sync-skill-counts.sh --check` → clean (PRODUCT.md is a count target; untouched)
- Residual `agentopsd` mentions remain only under ARCHIVED/Superseded banners (historical, correct)

## Bead status
- **ag-6v3j** — fully resolved (reframe + temporal).
- **ag-ph6h** — partial: daemon + Gas-City done here; the local-8B "Tier 1" framing (philosophy.md/PRODUCT.md) and `local-compute-routing.md` relocation remain open (aspirational/structural — left for follow-up).

Closes-scenario: ag-6v3j#convergent
Bounded-context: BC5-Runtime
Evidence: PRODUCT.md