### PR TITLE
docs: fix GLOSSARY skill count (66→82, gated) + portable test-debt path (ag-j4tw #counts)

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -167,7 +167,7 @@ One of the three named stages inside an RPI run: **Discovery**, **Implementation
 The full arc of a coding-agent session: `SessionStart` → many `UserPromptSubmit` / `PreToolUse` / `PostToolUse` cycles → `Stop` → `SessionEnd`. AgentOps 3.0 is hookless — it works the lifecycle through skills + the `ao` CLI rather than attaching runtime hooks. See [`workflows/session-lifecycle.md`](workflows/session-lifecycle.md).
 
 ### Skill
-A self-contained capability defined by a `SKILL.md` file with YAML frontmatter. Skills are the primary unit of functionality in AgentOps — each one has triggers, instructions, and optional reference docs loaded just-in-time. AgentOps currently ships 66 shared skills, with runtime-specific artifacts maintained alongside them. [Full documentation](SKILLS.md)
+A self-contained capability defined by a `SKILL.md` file with YAML frontmatter. Skills are the primary unit of functionality in AgentOps — each one has triggers, instructions, and optional reference docs loaded just-in-time. AgentOps currently ships 82 shared skills, with runtime-specific artifacts maintained alongside them. [Full documentation](SKILLS.md)
 
 ### Swarm
 A skill (`/swarm`) that spawns parallel worker agents with fresh context. Each wave gets a new team; the lead validates and commits. Workers never commit directly. [Full documentation](skills/swarm.md)

--- a/docs/test-architecture-debt-analysis.md
+++ b/docs/test-architecture-debt-analysis.md
@@ -1,6 +1,6 @@
 # Test Architecture Debt Analysis: cli/cmd/ao/
 
-**Package:** `/Users/fullerbt/gt/agentops/crew/nami/cli/cmd/ao/`  
+**Package:** `cli/cmd/ao/` (repo-relative)  
 **Analysis Date:** 2026-04-05  
 **Scope:** Single Go package with 4,163 test functions across 258 test files  
 

--- a/scripts/sync-skill-counts.sh
+++ b/scripts/sync-skill-counts.sh
@@ -201,6 +201,12 @@ patch_file "$REPO_ROOT/docs/documentation-index.md" \
   "s|All [0-9]+ checked-in skills mapped|All ${TOTAL} checked-in skills mapped|" \
   "docs/documentation-index.md domain-map skill count"
 
+# docs/GLOSSARY.md: "ships N shared skills" (TOTAL — every checked-in skill).
+patch_file "$REPO_ROOT/docs/GLOSSARY.md" \
+  'ships [0-9]+ shared skills' \
+  "s|ships [0-9]+ shared skills|ships ${TOTAL} shared skills|" \
+  "docs/GLOSSARY.md shared-skills count"
+
 echo ""
 
 if [[ "$errors" -gt 0 ]]; then


### PR DESCRIPTION
## What

Verified-clean subset of the second-wave counts/misc bead (ag-j4tw).

- **GLOSSARY.md:170** "ships 66 shared skills" → 82, and **extended `sync-skill-counts.sh`** to cover the call-site so it self-heals and CI catches future drift (same gate pattern as ag-bcl4).
- **test-architecture-debt-analysis.md:3** hardcoded Mac path `/Users/fullerbt/…/cli/cmd/ao/` → repo-relative `cli/cmd/ao/`.

## Verify-first dropped FALSE POSITIVES
Applying the session's recurring lesson (audit agents over-flag):
- ENV-VARS `COUNCIL_EXPLORER_MODEL/TIMEOUT`, `COUNCIL_R2_TIMEOUT` are **live** (consumed by `skills/council/`, not `cli/` — the audit only grepped cli/).
- `MEMRL_MODE` exists (3 files); `rg-optimized.md:70` is blank; ROADMAP "hookless S2–S5" is a real follow-on; `ao inject` is live.

## Still open (ag-j4tw stays open)
- agentops-brief.md / agentops-system-map.md counts are entangled in **hook-diagram lines** → handle with ag-t1ca.
- TESTING.md `tests/hooks/` (hooks) + testing-skills.md `tests/_quarantine/claude-code` → `tests/claude-code` (larger path rework).

## Verification
- `scripts/sync-skill-counts.sh --check` → clean (GLOSSARY now covered)

Closes-scenario: ag-j4tw#counts-glossary
Bounded-context: BC2-Validation
Evidence: docs/GLOSSARY.md