### PR TITLE
docs: remove hooks-as-live-runtime refs from footguns/context-packet/seed (ag-t1ca #small-files)

### DIFF
--- a/docs/agent-footguns.md
+++ b/docs/agent-footguns.md
@@ -24,7 +24,7 @@ See also: `skills/swarm/references/worker-pitfalls.md` for general platform pitf
 
 ## Embedded Assets
 
-- **Sync after editing hooks/skills**: After editing `hooks/`, `lib/hook-helpers.sh`, or `skills/standards/references/`, run `cd cli && make sync-hooks`. Tests and builds use the embedded copies, not the source files.
+- **Sync embedded copies after editing source**: After editing `lib/chain-parser.sh`, `skills/standards/references/`, `skills/using-agentops/SKILL.md`, or `skills/compile/scripts/`, run `cd cli && make sync-hooks` (it copies those into `cli/embedded/`). Tests and builds use the embedded copies, not the source files. (The target name is legacy — AgentOps 3.0 is hookless; it embeds skills/lib, not runtime hooks.)
 - **CLI docs drift**: After adding/changing CLI commands or flags, run `scripts/generate-cli-reference.sh`. CI checks for drift.
 
 ## Scope Overflow

--- a/docs/context-packet.md
+++ b/docs/context-packet.md
@@ -495,7 +495,7 @@ The context packet unifies and structures what multiple components already provi
 | `collectRecentSessions()` | Session history | Feeds HISTORY section (sessions) |
 | `ratchet.LoadChain()` | Provenance chain | Feeds HISTORY section (chain) |
 | `recordCitations()` | Citation tracking | Provenance tracking (injection-log.jsonl) |
-| `hooks/session-start.sh` | Session initialization | Points agent to `.agents/AGENTS.md` for on-demand lookup |
+| `ao session bootstrap` (hookless orientation) | Session initialization | Points agent to `.agents/AGENTS.md` for on-demand lookup |
 | Memory packets (`memory-packet.v1.schema.json`) | Boundary-memory for handoff | Orthogonal — handoff packets are emitted at session END; context packets are assembled at session START |
 
 ---

--- a/docs/seed-definition.md
+++ b/docs/seed-definition.md
@@ -13,7 +13,7 @@ AgentOps is the same. The same core seed, planted in a Go CLI repo or a Python w
 ```
 1. GOALS.md           -- what to optimize toward
 2. .agents/           -- where knowledge accumulates
-3. Hook readiness     -- optional rules that enforce the flywheel
+3. Lifecycle stages   -- explicit, hookless rules that run the flywheel
 4. CLAUDE.md section  -- instructions that start the flywheel
 5. Core skills        -- the capabilities the agent can invoke
 6. Bootstrap learning -- the first turn of the flywheel
@@ -28,8 +28,9 @@ ao quick-start
 
 Optional layers are deliberately separate: `/bootstrap` adds PRODUCT.md,
 README.md, and PROGRAM.md/AUTODEV.md; `bd init --prefix <prefix>` adds
-tracking; `ao init --hooks` explicitly activates optional hooks; `ao init --with-schedule` opts
-into continuous scheduling.
+tracking; the `hooks-authoring` skill lets you author your own optional runtime
+hooks (AgentOps 3.0 ships none); an out-of-session substrate (NTM + MCP +
+managed-agents) adds continuous scheduling.
 
 ### 1. GOALS.md -- Fitness Specification
 
@@ -100,7 +101,7 @@ Two lines added to the repo's CLAUDE.md:
 See `.agents/AGENTS.md` for orientation. Run `ao lookup --query "topic"` when you need prior knowledge. Run `ao forge` at session end.
 ```
 
-**Why it exists:** Hooks handle the automation, but CLAUDE.md provides the fallback for environments where hooks are not configured and the explanation for environments where they are. It bridges the gap between "hooks fire automatically" and "the agent understands why." This is belt-and-suspenders: structural enforcement (hooks) plus cognitive priming (instructions).
+**Why it exists:** The explicit lifecycle rules (`ao` commands) and CI gates handle enforcement, but CLAUDE.md provides the explanation so the agent understands *why* the flywheel matters and runs the stages even without any optional hook configured. This is belt-and-suspenders: mechanical enforcement (CI gates + explicit commands) plus cognitive priming (instructions).
 
 **Meadows mapping:** #6 (information flows -- ensures the agent is aware of the flywheel even if hooks are not installed).
 
@@ -115,7 +116,7 @@ Four skills installed globally, available in any repo:
 | `/implement` | Full lifecycle for one task: plan, build, validate, learn | #8 (balancing feedback) |
 | `/vibe` | Code quality review with multi-model council | #8 (balancing feedback) |
 
-**Why it exists:** The seed needs agency. GOALS.md defines intent, `.agents/` stores knowledge, hooks enforce rules -- but without skills, the agent has no structured way to act on goals, validate work, or extract learnings. Skills are the verbs that operate on the nouns.
+**Why it exists:** The seed needs agency. GOALS.md defines intent, `.agents/` stores knowledge, CI gates + explicit lifecycle rules enforce -- but without skills, the agent has no structured way to act on goals, validate work, or extract learnings. Skills are the verbs that operate on the nouns.
 
 **Meadows mapping:** #4 (self-organization -- `/evolve` changes the system's own rules based on measured fitness).
 


### PR DESCRIPTION
## What

First slice of the hooks-runtime decoupling (ag-t1ca) — the small/surgical files. Every claim verified against the repo (`hooks/` absent, `ao hooks` / `ao init --hooks` absent, `make sync-hooks` now embeds skills/lib not hooks).

- **agent-footguns.md:27** — `make sync-hooks` trigger list dropped dead `hooks/` + `lib/hook-helpers.sh`; now lists what the target actually copies into `cli/embedded/`.
- **context-packet.md:498** — `hooks/session-start.sh` → `ao session bootstrap` (hookless).
- **seed-definition.md** — seed element #3 "Hook readiness" → "Lifecycle stages (hookless)" (matched the doc's own §3); dropped non-existent `ao init --hooks` flag; reframed two "hooks enforce/fire automatically" lines to CI-gates + explicit lifecycle rules.

## Verify-first SAVES (left unchanged — consistent with executable truth)
- **agents-operator-guide.md** — `check-agents-write-surfaces.sh` still lists `hooks/` in its scan scope, so the doc matches the script (the vestigial scan is a code-cleanup item, not doc drift).
- **SCHEMAS.md** — `hooks-manifest.v1.schema.json` already correctly labeled "legacy / 3.0 hookless".

## Remaining in ag-t1ca (re-scoped, NOT in this PR)
The 6 large files need a dedicated careful pass: ARCHITECTURE.md, agentops-system-map.md, context-lifecycle.md, leverage-points.md, troubleshooting.md, INCIDENT-RUNBOOK.md.

Closes-scenario: ag-t1ca#small-files
Bounded-context: BC1-Corpus
Evidence: docs/context-packet.md