### PR TITLE
docs: de-hook the 6 big operator/architecture docs (ag-t1ca #big-files)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,7 +5,7 @@
 ## Overview
 
 AgentOps is a repo-native operating layer that combines interactive skills, the
-`ao` control plane, hooks, and `.agents/` artifacts. Three product layers do the
+`ao` control plane, CI gates, and `.agents/` artifacts. Three product layers do the
 work: the **Context Compiler** assembles the right context at session start, the
 **Validation Gates** challenge plans and code before they ship, and the
 **Knowledge Flywheel** extracts learnings, scores them, and resurfaces them so
@@ -52,11 +52,11 @@ The meta-framework. [DevOps' Three Ways](https://itrevolution.com/articles/the-t
 
 **Flow.** Orchestration skills move WIP through the system. Research → plan → validate → build → review → learn — single-piece flow, minimizing context switches. `/rpi` runs all phases end to end. `/crank` executes waves of parallel workers. `/swarm` spawns teams.
 
-**Feedback.** Shorten the feedback loop until defects can't survive it. Multi-model councils (`/council`) catch issues before code ships. Hooks make the rules unavoidable — validation gates, push blocking, regression auto-revert. Problems found Friday don't wait until Monday.
+**Feedback.** Shorten the feedback loop until defects can't survive it. Multi-model councils (`/council`) catch issues before code ships. CI gates (`.github/workflows/validate.yml`) make the rules unavoidable — validation gates, push blocking, regression auto-revert. Problems found Friday don't wait until Monday.
 
 **Continual Learning.** Stop rediscovering what you already know. Every session extracts learnings, scores them, and makes them retrievable via `ao lookup` for the next session. Knowledge compounds when retrieval quality and usage stay ahead of decay and scale friction. Session 50 knows what session 1 learned the hard way.
 
-These three ways aren't aspirational — they're mechanically enforced through skills, hooks, and operational invariants.
+These three ways aren't aspirational — they're mechanically enforced through skills, CI gates, and operational invariants.
 
 Deep dive: [the-science.md](the-science.md) — formal model, decay rates, escape velocity.
 
@@ -89,11 +89,11 @@ The reconciliation engine that implements the ratchet:
 
 ### Validation Gates
 
-Gates are checkpoints enforced by hooks. They block progress until a condition is met:
+Gates are checkpoints enforced by CI (`.github/workflows/validate.yml`) and explicit `/vibe` / `/pre-mortem` runs. They block progress until a condition is met:
 
 | Gate | Blocks | Condition |
 |------|--------|-----------|
-| Push gate | `git push` | `/vibe` must pass |
+| Push gate | merge to `main` | `/vibe` must pass |
 | Pre-mortem gate | `/crank` on 3+ issue epics | `/pre-mortem` must pass |
 | Task validation | Task completion | Acceptance criteria verified |
 | Worker guard | Workers committing | Only lead commits |
@@ -186,7 +186,7 @@ The system enforces context isolation at three levels:
 
 **Session boundaries.** Each session starts with injected knowledge (freshness-weighted, quality-gated) and ends with extracted learnings. The flywheel bridges sessions without carrying raw context forward.
 
-Deep dive: [how-it-works.md](how-it-works.md) — Ralph Wiggum Pattern, agent backends, hooks, context windowing.
+Deep dive: [how-it-works.md](how-it-works.md) — Ralph Wiggum Pattern, agent backends, context windowing.
 
 ---
 
@@ -324,16 +324,16 @@ Gate sizing adapts to epic complexity:
 
 ## Operational Invariants
 
-Cross-cutting rules enforced by hooks — not guidelines, not suggestions. Mechanically enforced.
+Cross-cutting rules enforced by CI gates (`.github/workflows/validate.yml`) and the skills that own each loop — not guidelines, not suggestions. Mechanically enforced.
 
 | Invariant | Enforced By | What It Prevents |
 |-----------|-------------|------------------|
-| Workers MUST NOT commit | Worker guard hook | Concurrent commits, unvalidated changes |
+| Workers MUST NOT commit | Worker-guard CI gate | Concurrent commits, unvalidated changes |
 | Workers MUST NOT race-claim tasks | Pre-assignment before spawn | Race conditions in multi-worker waves |
 | Verify THEN trust | Validation contract | False completion claims from agents |
-| Push blocked until `/vibe` passes | Push gate hook | Unvalidated code reaching remote |
-| `/crank` blocked until `/pre-mortem` passes (3+ issues) | Pre-mortem gate hook | Expensive implementation of flawed plans |
-| No destructive git without explicit request | Dangerous git guard | Accidental data loss |
+| Push blocked until `/vibe` passes | Push CI gate | Unvalidated code reaching remote |
+| `/crank` blocked until `/pre-mortem` passes (3+ issues) | Pre-mortem gate (`/crank` skill) | Expensive implementation of flawed plans |
+| No destructive git without explicit request | Dangerous-git CI gate | Accidental data loss |
 | Mechanical checks override council PASS | Constraint tests | LLMs estimating instead of measuring |
 | Max 50 waves per epic | Global wave limit | Infinite execution loops |
 | Max 3 retries per gate | Gate retry logic | Infinite retry loops |
@@ -341,7 +341,7 @@ Cross-cutting rules enforced by hooks — not guidelines, not suggestions. Mecha
 | Kill switch checked every cycle | Deploy kill switch | Runaway `/evolve` loops |
 | Skip goal after 3 consecutive failures | Strike check | Infinite retry on fundamentally broken goals |
 
-All hooks can be disabled: `AGENTOPS_HOOKS_DISABLED=1` (kill switch) or per-hook variables in [ENV-VARS.md](ENV-VARS.md).
+AgentOps 3.0 is hookless — these invariants live in CI and the skills themselves, not in always-on runtime hooks. If you want an always-on pre-creation signal, author one with the opt-in `hooks-authoring` skill; AgentOps ships zero hooks by default.
 
 ---
 
@@ -366,7 +366,7 @@ All hooks can be disabled: `AGENTOPS_HOOKS_DISABLED=1` (kill switch) or per-hook
 │   ├── post-mortem/     # solo — Council + knowledge lifecycle (wrap up work)
 │   ├── shared/          # library — Shared reference docs
 │   └── ...              # 39 more skills
-├── hooks/               # 12 hook scripts (lifecycle enforcement)
+├── cli/                 # Go CLI (ao binary) — the control plane
 ├── lib/                 # Shared code
 └── docs/                # Documentation
 ```
@@ -381,8 +381,8 @@ Skills span six tiers. Each level composes the ones below it.
 | **Team** | `/implement` | Single issue, full lifecycle |
 | **Solo** | `/research`, `/plan`, `/vibe`, `/pre-mortem`, `/post-mortem`, `/retro`, etc. | Standalone use |
 | **Library** | `beads`, `standards`, `shared` | Reference docs loaded by other skills |
-| **Background** | `inject`, `extract`, `forge`, `provenance`, `ratchet`, `flywheel` | Hook-triggered, invisible |
-| **Meta** | `using-agentops` | Flow guide, auto-injected |
+| **Background** | `inject`, `extract`, `forge`, `provenance`, `ratchet`, `flywheel` | Invoked by `ao` commands / CI, mostly invisible |
+| **Meta** | `using-agentops` | Flow guide, surfaced via `ao session bootstrap` |
 
 ### Subagents
 
@@ -442,35 +442,39 @@ managed-agents via `ao agent` — AgentOps adopts, does not own; see
 
 ---
 
-## Session Hooks
+## Session Lifecycle
 
-The runtime manifest currently declares seven hook event sections. Three lifecycle anchors form the compounding backbone, while the others enforce guardrails at prompt, tool, and task boundaries.
+AgentOps 3.0 is hookless — nothing auto-fires on session start or stop. The
+compounding backbone runs as explicit `ao` commands the agent invokes at the
+start, end, and close of work. (If you want these to fire automatically, the
+opt-in `hooks-authoring` skill can wire them into your harness; AgentOps ships
+zero hooks by default.)
 
-### SessionStart — sessions compound without eager context
+### Start — sessions compound without eager context
 
-On session start, `hooks/session-start.sh`:
+`ao session bootstrap` is the universal init prompt. It:
 1. Creates `.agents/` directories if missing (local + global `~/.agents/`)
 2. Runs lightweight stale-run cleanup and closes any pending flywheel loop
 3. Consumes structured handoff packets when present
 4. Stages factory-goal state so the first substantive prompt can build a
    task-scoped briefing
-5. Keeps operator-facing output silent
+5. Returns the standard orientation report
 
 Startup no longer injects broad prior knowledge by default. The agent uses
-goal-scoped factory briefings and `ao lookup --query "topic"` when task context
-is actually needed.
+goal-scoped factory briefings and `ao inject` / `ao lookup --query "topic"` when
+task context is actually needed.
 
-### SessionEnd — Extract and prune
+### End — Extract and prune
 
-On session end, `hooks/session-end-maintenance.sh` (35s timeout):
+At session end, the agent runs the maintenance pass:
 1. `ao forge transcript --last-session --queue` — mine transcript for learnings
 2. `ao maturity --scan` — identify artifacts ready for promotion
 3. `ao maturity --expire --archive` — mark stale artifacts (freshness decay ~17%/week)
 4. `ao maturity --evict --archive` — archive what's decayed past threshold
 
-### Stop — Close the loop
+### Close — Close the loop
 
-On stop, `hooks/ao-flywheel-close.sh` (15s timeout):
+To close out, the agent runs:
 1. `ao flywheel close-loop` — record session completion, trigger deferred promotion
 
 ---

--- a/docs/INCIDENT-RUNBOOK.md
+++ b/docs/INCIDENT-RUNBOOK.md
@@ -10,7 +10,7 @@
 1. [Emergency Kill Switches](#1-emergency-kill-switches)
 2. [Scenario A: Broken Skills After Update](#2-scenario-a-broken-skills-after-update)
 3. [Scenario B: Evolve Pushed Bad Code to Main](#3-scenario-b-evolve-pushed-bad-code-to-main)
-4. [Scenario C: Hook Scripts Fail at Session Start](#4-scenario-c-hook-scripts-fail-at-session-start)
+4. [Scenario C: Skills Not Loading / CI Gate Failing](#4-scenario-c-skills-not-loading--ci-gate-failing)
 5. [Rollback Options](#5-rollback-options)
 6. [Root Cause Analysis](#6-root-cause-analysis)
 7. [Prevention Checklist](#7-prevention-checklist)
@@ -22,56 +22,36 @@
 **Do these FIRST if sessions are broken. Restore functionality, then investigate.**
 
 ```bash
-# Disable ALL AgentOps hooks globally (instant, affects all sessions)
-export AGENTOPS_HOOKS_DISABLED=1
-
 # Stop evolve from running (persistent across sessions)
 mkdir -p ~/.config/evolve
 echo "incident $(date -Iseconds)" > ~/.config/evolve/KILL
 ```
 
-To make the hook disable persistent, add to your shell profile:
-```bash
-echo 'export AGENTOPS_HOOKS_DISABLED=1' >> ~/.zshrc
-```
-
-### Per-Hook Kill Switches
-
-If you know which hook is broken, disable just that one:
-
-| Hook | Kill Switch Env Var |
-|------|-------------------|
-| session-start.sh | `AGENTOPS_SESSION_START_DISABLED=1` |
-| pre-mortem-gate.sh | `AGENTOPS_SKIP_PRE_MORTEM_GATE=1` |
-| task-validation-gate.sh | `AGENTOPS_TASK_VALIDATION_DISABLED=1` |
-| pending-cleaner.sh | `AGENTOPS_PENDING_CLEANER_DISABLED=1` |
-| precompact-snapshot.sh | `AGENTOPS_PRECOMPACT_DISABLED=1` |
-| All hooks (global) | `AGENTOPS_HOOKS_DISABLED=1` |
-
-Every hook script checks `AGENTOPS_HOOKS_DISABLED=1` at the top and exits immediately if set.
+> **AgentOps 3.0 is hookless.** A default install ships **zero** hooks — nothing auto-runs at
+> session start, so there is no global "disable hooks" recovery step to take. Orientation is
+> explicit (`ao session bootstrap`, `ao inject`) and CI (`.github/workflows/validate.yml`) is the
+> authoritative gate. If you authored your own hooks via the `hooks-authoring` skill, see the
+> note under [Scenario C](#4-scenario-c-skills-not-loading--ci-gate-failing) for how to disable them.
 
 ---
 
 ## 2. Scenario A: Broken Skills After Update
 
-**Symptom:** Consumer ran the install script and now Claude sessions are broken — hooks error, skills don't load, or sessions hang at start.
+**Symptom:** Consumer ran the install script and now Claude sessions are broken — skills don't load, `ao` subcommands error, or skill invocations fail.
 
 ### Triage (< 5 min)
 
 ```bash
-# 1. Kill hooks immediately
-export AGENTOPS_HOOKS_DISABLED=1
-
-# 2. Check what version was installed
+# 1. Check what version was installed
 cat ~/.claude/skills/agentops/plugin.json 2>/dev/null | jq -r '.version'
 # Or check the marketplace cache
 cat ~/.claude/plugins/marketplaces/agentops-marketplace/plugin.json 2>/dev/null | jq -r '.version'
 
-# 3. Check if skills are symlinks (known failure mode)
+# 2. Check if skills are symlinks (known failure mode)
 ls -la ~/.claude/skills/ | head -20
 
-# 4. Test a hook manually
-bash ~/.claude/skills/agentops/hooks/session-start.sh
+# 3. Confirm the ao CLI is on PATH and runs
+which ao && ao status
 ```
 
 ### Fix: Reinstall from a known-good version
@@ -104,11 +84,12 @@ claude plugin marketplace add boshu2/agentops
 claude plugin install agentops@agentops-marketplace
 ```
 
-### Re-enable hooks after fix
+### Verify the fix
 
 ```bash
-unset AGENTOPS_HOOKS_DISABLED
-# Remove from shell profile if you added it there
+# Confirm skills resolve and the CLI runs
+ls ~/.claude/skills/agentops/ | head
+ao status
 ```
 
 ---
@@ -179,76 +160,61 @@ rm .agents/evolve/STOP 2>/dev/null
 
 ---
 
-## 4. Scenario C: Hook Scripts Fail at Session Start
+## 4. Scenario C: Skills Not Loading / CI Gate Failing
 
-**Symptom:** Claude session hangs, errors on start, or prints garbage JSON. The session-start hook or one of the other 11 hook scripts has a bug.
+**Symptom:** A skill won't invoke (Claude reports the skill is missing or malformed), or a PR is blocked because a CI gate in `.github/workflows/validate.yml` fails. AgentOps 3.0 is hookless — there is no session-start hook to misfire, so a broken skill or a failing gate is the usual culprit.
 
 ### Triage (< 5 min)
 
 ```bash
-# 1. Disable hooks to get a working session
+# 1. Confirm the skill exists and has a valid manifest
+ls ~/.claude/skills/agentops/skills/<skill-name>/SKILL.md
+# Frontmatter must parse — a malformed SKILL.md silently fails to load
+head -20 ~/.claude/skills/agentops/skills/<skill-name>/SKILL.md
+
+# 2. If a PR is red, see which gate failed (CI is the authoritative gate)
+gh pr checks <pr-number>
+
+# 3. Reproduce the failing gate locally (run the FULL job, not a subset)
+cat .github/workflows/validate.yml | grep -n "run:" | head -40   # find the step
+bash scripts/<failing-gate>.sh                                    # run it
+```
+
+### Common failures
+
+**Malformed or unregistered skill:**
+```bash
+# Skills source of truth is skills/ in the repo; the installed copy lives under
+# ~/.claude/skills/agentops/. A skill that isn't in the registry won't be offered.
+ls skills/<skill-name>/SKILL.md          # source of truth
+bash scripts/check-registry-drift.sh     # catches missing-from-registry skills
+```
+
+**CI gate disagreement (docs drifted from executable behavior):**
+```bash
+# Contracts/counts/context-map gates fail when a generated surface is stale.
+# Regenerate the derived surfaces, then re-run the gate.
+bash scripts/regen-all.sh 2>/dev/null || true
+bash scripts/validate-context-map-drift.sh
+```
+
+**Missing binary (ao, jq):**
+```bash
+which ao    # CLI must be installed and on PATH
+which jq    # required by several validation scripts
+```
+
+### Optional: user-authored hooks
+
+AgentOps ships **no** hooks by default. If you opted in and authored your own hooks via the
+`hooks-authoring` skill, hook troubleshooting applies to **those** files only — not to any shipped
+default. For backward-compat, AgentOps-authored hooks still honor the `AGENTOPS_HOOKS_DISABLED=1`
+environment variable as an opt-out:
+
+```bash
+# Only relevant if you authored your own hooks. Disables AgentOps-aware hooks for the session.
 export AGENTOPS_HOOKS_DISABLED=1
-
-# 2. Check hook error log
-cat .agents/ao/hook-errors.log 2>/dev/null | tail -20
-
-# 3. Test each hook manually to find the broken one
-for hook in ~/.claude/skills/agentops/hooks/*.sh; do
-  echo "--- Testing: $(basename $hook) ---"
-  timeout 5 bash "$hook" 2>&1 | tail -3
-  echo "Exit: $?"
-done
-
-# 4. Check for syntax errors
-for hook in ~/.claude/skills/agentops/hooks/*.sh; do
-  bash -n "$hook" 2>&1 && echo "OK: $(basename $hook)" || echo "BROKEN: $(basename $hook)"
-done
-```
-
-### Common hook failures
-
-**Missing binary (ao, jq, shellcheck):**
-```bash
-# Check if ao CLI is installed
-which ao    # should be /opt/homebrew/bin/ao
-which jq    # required by several hooks
-
-# If ao is missing, hooks degrade gracefully (|| true pattern)
-# But session-start.sh may still produce broken JSON
-```
-
-**Infinite loop or timeout:**
-```bash
-# hooks.json defines timeouts per hook (2-120s)
-# If a hook exceeds its timeout, Claude kills it
-# Check hooks.json for timeout values
-jq '.hooks | to_entries[] | .value[].hooks[] | {command: .command[:60], timeout: .timeout}' \
-  ~/.claude/skills/agentops/hooks/hooks.json
-```
-
-**Bad JSON output from session-start.sh:**
-```bash
-# session-start.sh must output valid JSON with hookSpecificOutput
-# Test it and validate output
-bash ~/.claude/skills/agentops/hooks/session-start.sh 2>/dev/null | jq .
-# If jq fails, the output is malformed
-```
-
-### Fix: Disable just the broken hook
-
-Once you identify the broken hook, disable only that one instead of all hooks. Use the per-hook kill switches from Section 1.
-
-If the broken hook doesn't have its own kill switch, you can patch it:
-```bash
-# Add a kill switch to the top of the hook (after the shebang)
-# This is a temporary fix in the installed copy
-HOOK_FILE=~/.claude/skills/agentops/hooks/<broken-hook>.sh
-# Back it up first
-cp "$HOOK_FILE" "${HOOK_FILE}.bak"
-# Make it exit immediately
-sed -i '' '2i\
-exit 0  # TEMPORARY: disabled during incident\
-' "$HOOK_FILE"
+# Then debug your own hook scripts wherever you installed them.
 ```
 
 ---
@@ -306,7 +272,7 @@ claude plugin install agentops@agentops-marketplace
 
 # Verify
 cat ~/.claude/skills/agentops/.claude-plugin/plugin.json | jq -r '.version'
-bash ~/.claude/skills/agentops/hooks/session-start.sh 2>/dev/null | jq .
+ao status
 ```
 
 ---
@@ -346,17 +312,18 @@ git bisect good <last-known-good-sha>
 git bisect reset
 ```
 
-### Was it a hook script bug?
+### Was it a skill or CI-gate failure?
 
 ```bash
-# Shellcheck all hooks
-shellcheck -x -P SCRIPTDIR hooks/*.sh
+# AgentOps 3.0 is hookless — CI is the authoritative gate. Reproduce it locally.
+# Check which gate failed on the PR
+gh pr checks <pr-number>
 
-# Check for recent hook changes
-git log --oneline -20 -- hooks/
+# Run the omnibus validation locally (the same job CI runs)
+bash scripts/pre-push-gate.sh
 
-# Run the hook preflight validation
-./scripts/validate-hook-preflight.sh
+# Check for recent skill / generated-surface changes
+git log --oneline -20 -- skills/ docs/
 
 # Run full test suite
 ./tests/run-all.sh
@@ -387,11 +354,9 @@ done
 - [ ] `./tests/run-all.sh` passes (all tiers)
 - [ ] `./tests/smoke-test.sh` passes
 - [ ] `cd cli && go build ./cmd/ao && go test -race ./...` clean
-- [ ] `shellcheck -x -P SCRIPTDIR hooks/*.sh` clean
-- [ ] `./scripts/validate-hook-preflight.sh` passes
-- [ ] All hook scripts test manually: `bash hooks/<name>.sh`
+- [ ] CI validation passes locally: `bash scripts/pre-push-gate.sh`
+- [ ] Generated/derived surfaces are in sync: `bash scripts/check-registry-drift.sh` and `bash scripts/validate-context-map-drift.sh` clean
 - [ ] Plugin and marketplace versions match: `jq -r '.version' .claude-plugin/plugin.json` equals `jq -r '.metadata.version' .claude-plugin/marketplace.json`
-- [ ] `session-start.sh` output is valid JSON: `bash hooks/session-start.sh 2>/dev/null | jq .`
 
 ### Before running evolve
 
@@ -408,24 +373,23 @@ done
 - [ ] Check `git log --oneline -20` for reasonable commit messages
 - [ ] Run `git diff <pre-evolve-sha>..HEAD --stat` to see total scope of changes
 
-### Hook script authoring rules
+### Optional hook authoring rules (only if you opt in)
 
-- Every hook MUST check `AGENTOPS_HOOKS_DISABLED=1` at the top
-- Every hook MUST fail open (`exit 0` on error, never `set -e`)
-- Every hook MUST respect its timeout in `hooks.json`
+AgentOps ships no hooks. If you author your own via the `hooks-authoring` skill, the safe pattern is:
+
+- Honor `AGENTOPS_HOOKS_DISABLED=1` at the top so operators can opt out
+- Fail open (`exit 0` on error, never `set -e`) — a broken hook must never wedge a session
 - Guard all external commands: `command -v <tool> >/dev/null 2>&1 && ...`
-- JSON output must be valid — test with `jq .` before committing
-- Log failures to `.agents/ao/hook-errors.log`, never to stderr
+- If a hook emits JSON, validate it with `jq .` before committing
 
 ---
 
 ## Quick Reference Card
 
 ```
-STOP EVERYTHING:     export AGENTOPS_HOOKS_DISABLED=1
 STOP EVOLVE:         echo "stop" > ~/.config/evolve/KILL
-CHECK HOOK ERRORS:   cat .agents/ao/hook-errors.log | tail -20
-TEST HOOKS:          for h in hooks/*.sh; do bash -n "$h"; done
+CHECK CI GATE:       gh pr checks <pr-number>
+RUN GATE LOCALLY:    bash scripts/pre-push-gate.sh
 REINSTALL:           claude plugin marketplace update agentops-marketplace && claude plugin install agentops@agentops-marketplace
 NUCLEAR REINSTALL:   rm -rf ~/.claude/skills/agentops ~/.claude/plugins/marketplaces/agentops-marketplace && claude plugin marketplace add boshu2/agentops && claude plugin install agentops@agentops-marketplace
 REVERT EVOLVE:       git revert --no-commit <good-sha>..HEAD && git commit -m "revert: evolve incident"

--- a/docs/agentops-brief.md
+++ b/docs/agentops-brief.md
@@ -43,10 +43,10 @@ the next session loads better context before repeating the mistake.
 Records the operational memory agents do not keep for themselves: attempts, decisions, citations, verdicts, handoffs, findings, retros, and post-mortems. The work leaves a trace in `.agents/`.
 
 ### Layer 1: Context Compiler
-Assembles the right context for the right phase. Research gets prior knowledge; plan gets a compressed summary; workers get fresh context per wave. Skills, hooks, and the `ao` CLI collaborate to load, scope, and trim context to the token budget before the agent sees it.
+Assembles the right context for the right phase. Research gets prior knowledge; plan gets a compressed summary; workers get fresh context per wave. Skills and the `ao` CLI (`ao session bootstrap`, `ao inject`, `ao corpus inject`) collaborate to load, scope, and trim context to the token budget before the agent sees it.
 
 ### Layer 2: Validation Gates
-Challenges plans before build and code before commit. Multi-model councils (`/council`, `/vibe`, `/pre-mortem`) return auditable verdicts — PASS, WARN, or FAIL. Gates block, not advise. Runtime hooks enforce them even when the operator forgets.
+Challenges plans before build and code before commit. Multi-model councils (`/council`, `/vibe`, `/pre-mortem`) return auditable verdicts — PASS, WARN, or FAIL. Gates block, not advise. CI is the authoritative gate (`.github/workflows/validate.yml`), enforcing them on every PR regardless of what the operator remembers to run locally.
 
 ### Layer 3: Knowledge Flywheel
 Extracts learnings from completed work, scores them for quality, promotes durable patterns, and re-injects them at the next session start. `.agents/` carries state on disk; `ao forge`, `ao lookup`, and maturity controls keep the loop closing.
@@ -57,7 +57,7 @@ Extracts learnings from completed work, scores them for quality, promotes durabl
 
 ```
 Session starts
-  -> Startup hooks retrieve lightweight context and continuity hints
+  -> ao session bootstrap + ao inject retrieve lightweight context and continuity hints (hookless)
   -> Discovery scopes the work and pressure-tests the plan
 
 Implementation runs
@@ -143,9 +143,9 @@ They will. Anthropic's Managed Agents is the first move; others will follow. Tha
 ┌──────────────────────────────────────────────────────────────────┐
 │                    AgentOps at a Glance                          │
 ├───────────────────┬──────────────────────┬───────────────────────┤
-│ 73 shared skills  │   `ao` Control Plane │   12 Hook Events      │
-│ plus runtime      │ repo-native retrieval│  runtime manifest     │
-│    artifacts      │ goals, and automation│                       │
+│ 82 shared skills  │   `ao` Control Plane │   CI-gated (hookless) │
+│ plus runtime      │ repo-native retrieval│  validate.yml is the  │
+│    artifacts      │ goals, and automation│  authoritative gate   │
 └───────────────────┴──────────────────────┴───────────────────────┘
 ```
 
@@ -191,18 +191,23 @@ GOALS.md
 /recover           ->    handoff artifacts          Interrupted work resumed from disk
 ```
 
-### Hooks — Automatic Enforcement
+### Lifecycle — Hookless Enforcement
+
+AgentOps 3.0 is hookless: nothing auto-fires at session boundaries. The lifecycle
+runs through explicit skills and `ao` commands, with CI as the authoritative gate.
+(An opt-in `hooks-authoring` skill exists if you want to add your own hooks;
+AgentOps ships none by default.)
 
 ```
-TRIGGER                   HOOK                        WHAT IT DOES
-───────                   ────                        ────────────
-Session starts         session-start.sh            Stage runtime state
-Session ends           session-end-maintenance.sh  Harvest learnings
-Agent stops            ao-flywheel-close.sh        Close learning loop
-Prompt submit         factory-router.sh           Route explicit factory intake
-Pre tool use          pre-mortem-gate.sh          Require review before risky work
-Post tool use         go-complexity-precommit.sh  Block over-complex edits
-Task complete         task-validation-gate.sh     Execute compiled validation constraints
+LIFECYCLE POINT           SKILL / COMMAND             WHAT IT DOES
+───────────────           ───────────────             ────────────
+Session starts         ao session bootstrap        Stage orientation + runtime state
+                       + ao inject                 Pull decay-ranked context
+Session ends           /post-mortem + ao forge     Harvest learnings
+Loop closure           ao flywheel + /retro        Close the learning loop
+Plan review            /pre-mortem                 Require review before risky work
+Code review            /vibe + ao ratchet          Block over-complex / unready edits
+PR validation          validate.yml (CI)           Execute compiled validation gates
 ```
 
 ### CLI Command Groups
@@ -215,7 +220,7 @@ ao search                   ao ratchet record        ao rpi status
 ao forge                    ao ratchet check         ao goals measure
 ao curate                   ao constraint activate   ao goals steer
 ao maturity                 ao constraint review     ao flywheel status
-ao dedup                    ao session close         ao hooks list
+ao dedup                    ao session close         ao session bootstrap
 ao contradict               ao temper validate       ao status
 ao notebook                                          ao doctor
 ao extract

--- a/docs/agentops-system-map.md
+++ b/docs/agentops-system-map.md
@@ -4,8 +4,8 @@
 ┌──────────────────────────────────────────────────────────────────┐
 │                    AgentOps at a Glance                          │
 ├───────────────────┬──────────────────────┬───────────────────────┤
-│    52  Skills     │  121 CLI Commands    │   13 Hook Entries     │
-│  (workflows)      │  (ao binary)         │  (auto-enforcement)   │
+│    82  Skills     │   76 CLI Commands    │   Hookless (CI-gated) │
+│  (workflows)      │  (ao binary)         │  (validate.yml)       │
 └───────────────────┴──────────────────────┴───────────────────────┘
 ```
 
@@ -85,7 +85,7 @@ Skills hand off to `ao` to persist knowledge across sessions:
 /evolve            →    ao goals measure           Fitness checked before next cycle
 /rpi               →    ao ratchet record          Progress gate checkpointed
 /implement         →    ao ratchet check           Gate verified before work starts
-/post-mortem       →    finding-compiler.sh        Findings become artifacts, checks, and constraints
+/post-mortem       →    ao compile                 Findings become artifacts, checks, and constraints
 /post-mortem       →    ao flywheel close-loop     Citation feedback and lifecycle updates applied
 ```
 
@@ -102,7 +102,7 @@ The closed-loop prevention path is file-native:
 .agents/findings/registry.jsonl
         │
         ▼
-hooks/finding-compiler.sh
+ao flywheel / compile  (explicit command — no auto-hook)
         │
         ├──> .agents/findings/<id>.md
         ├──> .agents/planning-rules/<id>.md
@@ -110,14 +110,14 @@ hooks/finding-compiler.sh
         └──> .agents/constraints/index.json   (mechanical + active only)
                                               │
                                               ▼
-                                   hooks/task-validation-gate.sh
+                              .github/workflows/validate.yml  (CI gate)
 ```
 
-`/plan`, `/pre-mortem`, `/vibe`, and `/post-mortem` load compiled planning and review artifacts first, then fall back to the registry when compiled outputs are missing. `task-validation-gate.sh` is the shift-left enforcement surface for active mechanical findings.
+`/plan`, `/pre-mortem`, `/vibe`, and `/post-mortem` load compiled planning and review artifacts first, then fall back to the registry when compiled outputs are missing. AgentOps 3.0 is hookless: enforcement of active mechanical findings is shift-left via the CI gates in `.github/workflows/validate.yml`, not an auto-firing hook.
 
 ---
 
-## CLI Command Groups (38 commands, 121 including subcommands)
+## CLI Command Groups (76 commands including subcommands)
 
 ```
 KNOWLEDGE FLYWHEEL          VALIDATION GATES         SESSION / LIFECYCLE
@@ -125,7 +125,7 @@ KNOWLEDGE FLYWHEEL          VALIDATION GATES         SESSION / LIFECYCLE
 ao forge                    ao gate pending          ao session close
 ao pool ingest              ao gate approve          ao rpi status
 ao pool promote             ao gate reject           ao rpi cancel
-ao lookup                   ao ratchet status        ao hooks list
+ao lookup                   ao ratchet status        ao session bootstrap
 ao lookup                   ao ratchet record        ao config
 ao search                   ao ratchet check
 ao dedup                    ao ratchet promote       METRICS / HEALTH
@@ -147,24 +147,19 @@ ao extract                  ao goals drift           UTILITIES
 
 ---
 
-## Hooks — Automatic Enforcement (13 hook entries across 7 trigger points)
+## Enforcement — Hookless, CI-Gated
 
-Hooks fire without human involvement. The AI cannot bypass them.
+AgentOps 3.0 is hookless: it ships zero hooks by default and nothing auto-injects or auto-enforces at session boundaries. Validation that used to live in shell hooks is now the authoritative CI gate in `.github/workflows/validate.yml` (T0/T1/T2 tiers, all required), with explicit `ao` commands and skills doing the in-session work. An opt-in `hooks-authoring` skill lets you add your own hooks if you want always-on local signals, but the corpus carries none.
 
 ```
-TRIGGER                   HOOK                        WHAT IT DOES
-───────                   ────                        ────────────
-Session starts         session-start.sh            Stage runtime state and briefing pointers
-Session ends           session-end-maintenance.sh  Harvest learnings, run maintenance
-Agent stops            ao-flywheel-close.sh        Close the learning loop
-Task completes         task-validation-gate.sh     Execute active compiled constraints and metadata checks
-Every tool call        go-complexity-precommit.sh  Block functions over complexity budget
-Pre-commit             skill-lint-gate.sh          Reject malformed skills
-Pre-commit             dangerous-git-guard.sh      Block force-pushes to main
-Pre-commit             pre-mortem-gate.sh          Require pre-mortem for large changes
-Worker stop            subagent-stop.sh            Clean up parallel agent state
-Worktree created       worktree-setup.sh           Initialize isolated workspace
-Worktree merged        worktree-cleanup.sh         Remove stale branches
+WAS A HOOK                  NOW
+──────────                  ───
+Session-boundary staging    ao session bootstrap / ao inject (explicit, run on demand)
+Learning-loop close         ao flywheel close-loop (called by /post-mortem)
+Task/constraint validation   .github/workflows/validate.yml CI gates
+Complexity budget            golangci-lint + validate.yml
+Skill / git / pre-mortem     validate.yml gates + /pre-mortem skill
+checks                       (re-author as opt-in via hooks-authoring skill)
 ```
 
 ---
@@ -194,4 +189,4 @@ post-mortem          crank                  goals               standards
 
 ---
 
-*52 skills · 121 CLI commands · 13 hook entries · 0 telemetry · everything in plain files*
+*82 skills · 76 CLI commands · hookless (CI-gated) · 0 telemetry · everything in plain files*

--- a/docs/context-lifecycle.md
+++ b/docs/context-lifecycle.md
@@ -40,8 +40,8 @@ actually closes these gaps.
 | `/pre-mortem` | [skills/pre-mortem/SKILL.md](skills/pre-mortem.md) | Loads plan-review validation before code exists |
 | `/vibe` | [skills/vibe/SKILL.md](skills/vibe.md) | Runs post-implementation validation instead of stopping at build/test |
 | `/council` | [skills/council/SKILL.md](skills/council.md) | Supplies multi-judge review for plans and code |
-| Pre-mortem gate hook | `hooks/pre-mortem-gate.sh` + [hooks/hooks.json](https://github.com/boshu2/agentops/blob/main/hooks/hooks.json) | Prevents large implementation work from skipping plan validation |
-| Task-validation constraint hook | `hooks/task-validation-gate.sh` + `.agents/constraints/index.json` | Task-validation executes active compiled constraints for mechanically detectable findings |
+| Pre-mortem gate | CI gate ([.github/workflows/validate.yml](https://github.com/boshu2/agentops/blob/main/.github/workflows/validate.yml)) + the `/pre-mortem` skill | Prevents large implementation work from skipping plan validation |
+| Task-validation constraint check | `/validate` skill + `ao constraint` reading `.agents/constraints/index.json` | Task-validation executes active compiled constraints for mechanically detectable findings |
 | Product-aware review context | [PRODUCT.md](https://github.com/boshu2/agentops/blob/main/PRODUCT.md) | Injects product and DX perspectives into validation flows |
 
 **Supporting failure modes addressed inside this gap:**
@@ -92,9 +92,9 @@ actually closes these gaps.
 | Mechanism | Source | Role |
 |-----------|--------|------|
 | `/post-mortem` | [skills/post-mortem/SKILL.md](skills/post-mortem.md) | Validates shipped work, extracts learnings, and harvests next work |
-| Finding registry + compiler path | [docs/contracts/finding-registry.md](contracts/finding-registry.md), [docs/contracts/finding-compiler.md](contracts/finding-compiler.md), `hooks/finding-compiler.sh` | Promotes reusable findings into advisory artifacts and active constraint index entries |
-| Task-validation constraint execution | `hooks/task-validation-gate.sh` + `.agents/constraints/index.json` | Turns mechanically detectable findings into enforced validation checks before task completion |
-| Flywheel close hook | `hooks/ao-flywheel-close.sh` + [docs/how-it-works.md](how-it-works.md) | Closes the feedback loop at stop time |
+| Finding registry + compiler path | [docs/contracts/finding-registry.md](contracts/finding-registry.md), [docs/contracts/finding-compiler.md](contracts/finding-compiler.md), `ao findings` / `ao constraint` | Promotes reusable findings into advisory artifacts and active constraint index entries |
+| Task-validation constraint execution | `/validate` skill + `ao constraint` reading `.agents/constraints/index.json` | Turns mechanically detectable findings into enforced validation checks before task completion |
+| Flywheel close | `/post-mortem` skill + [docs/how-it-works.md](how-it-works.md) | Closes the feedback loop at session end |
 | GOALS + `/evolve` | [GOALS.md](https://github.com/boshu2/agentops/blob/main/GOALS.md) and `/evolve` flows | Turns findings into measurable next work instead of leaving them as loose notes |
 | Ratchet + run registry | `ao ratchet`, `.agents/rpi/next-work.jsonl` | Records what passed, what remains, and what should be worked next |
 | Phase chaining | [README.md](https://github.com/boshu2/agentops/blob/main/README.md) full pipeline | Makes `research -> plan -> pre-mortem -> crank -> post-mortem` the normal operating shape |
@@ -111,13 +111,13 @@ actually closes these gaps.
 |-----|-----------|-----------------------------|---------------|
 | Validation | `/pre-mortem` | `skills/pre-mortem/SKILL.md` | Plan review before implementation |
 | Validation | `/vibe` | `skills/vibe/SKILL.md` | Code review before commit/merge |
-| Validation | pre-mortem gate | `hooks/pre-mortem-gate.sh`, `hooks/hooks.json` | Runtime hook enforcement |
+| Validation | pre-mortem gate | `.github/workflows/validate.yml`, `/pre-mortem` skill | CI gate enforcement |
 | Bookkeeping | extraction + retrieval | `.agents/`, `ao lookup`, `ao forge`, finding registry, finding artifacts | Repo-specific context and reusable structured findings loaded into later sessions |
 | Bookkeeping | curation | `ao maturity`, `ao dedup`, `ao contradict` | Freshness, contradiction, and duplication control |
 | Bookkeeping | Compile | `GOALS.md`, Compile checks | Daily maintenance of learning quality |
 | Closure | `/post-mortem` + finding compiler | `skills/post-mortem/SKILL.md`, `docs/contracts/finding-registry.md`, `docs/contracts/finding-compiler.md` | Learnings + next work harvested from completed work; reusable findings re-enter planning/review and compile into preventive artifacts |
-| Closure | task-validation compiled enforcement | `hooks/task-validation-gate.sh`, `.agents/constraints/index.json` | Task-validation executes active compiled constraints before completion is accepted |
-| Closure | flywheel close hook | `hooks/ao-flywheel-close.sh` | Stop-time closure of the feedback loop |
+| Closure | task-validation compiled enforcement | `/validate` skill, `ao constraint`, `.agents/constraints/index.json` | Task-validation executes active compiled constraints before completion is accepted |
+| Closure | flywheel close | `/post-mortem` skill | Session-end closure of the feedback loop |
 | Closure | goals / evolve | `GOALS.md`, flywheel-proof gate | Proof that the system compounds across sessions |
 
 ## What AgentOps Does Not Claim
@@ -125,7 +125,7 @@ actually closes these gaps.
 - It does not claim that prompt engineering or routing are unimportant.
 - It does not claim that every loop-closing behavior must be fully autonomous.
 - It does not claim that raw recall alone is enough; the contract depends on validation, curation, and re-use.
-- It does not claim that new runtime machinery should be invented when an existing command, hook, or gate already covers the gap.
+- It does not claim that new runtime machinery should be invented when an existing command, skill, or CI gate already covers the gap.
 
 ## The Knowledge Ledger — Session-to-Session Flow
 
@@ -153,6 +153,6 @@ Three tiers, descending priority: local `.agents/` → global `~/.agents/` → l
 ## See Also
 
 - [README.md](https://github.com/boshu2/agentops/blob/main/README.md) for the repo-level overview
-- [How It Works](how-it-works.md) for runtime mechanics and hook behavior
+- [How It Works](how-it-works.md) for runtime mechanics and gate behavior
 - [Knowledge Flywheel](knowledge-flywheel.md) for extraction, retrieval, and compounding details
 - [The Science](the-science.md) for the formal decay/escape-velocity model

--- a/docs/leverage-points.md
+++ b/docs/leverage-points.md
@@ -20,10 +20,10 @@
 | Operational delta | avg_age_days / 100 | `ao metrics health` (`cli/cmd/ao/metrics_health.go`) |
 | Retrieval target (sigma) | 0.7 | `ao metrics health` escape velocity threshold |
 | Citation target (rho) | 0.3 | `ao metrics health` escape velocity threshold |
-| Context load ceiling | 40% of window | Hook enforcement (35% warn, 40% hard stop) |
+| Context load ceiling | 40% of window | `ao context assemble` budgeting (35% warn, 40% hard stop) |
 | Summary budget | 500 tokens | Briefing packet assembly (`ao context assemble`) |
 | Max waves per epic | 50 | `/crank` FIRE loop global limit |
-| Max retries per gate | 3 | Gate retry logic in validation hooks |
+| Max retries per gate | 3 | Gate retry logic in the `/crank` FIRE loop |
 | Confidence decay | 10%/week | Learning freshness scoring in `ao lookup` |
 | Circuit breaker | 60 minutes | `/evolve` stops if no productive cycle in 60 min |
 
@@ -39,7 +39,7 @@
 
 **AgentOps implementation:**
 
-- **Context guard** — 35% warn threshold, 40% hard stop. Prevents the "lost in the middle" retrieval collapse (Liu et al. 2023). Implemented in session-start hook and context assembly.
+- **Context guard** — 35% warn threshold, 40% hard stop. Prevents the "lost in the middle" retrieval collapse (Liu et al. 2023). Enforced in `ao context assemble` / `ao inject` budgeting (AgentOps 3.0 is hookless — `ao session bootstrap` is the explicit session-start step that pulls decay-ranked context).
 - **Knowledge tiering** — Gold/silver/bronze tiers in `.agents/learnings/`. Gold learnings are always injected; bronze are available but not proactively loaded. Controls the hot-set size.
 - **Idle streak detection** — `/evolve` tracks consecutive idle cycles from `cycle-history.jsonl`. At threshold, the system stops rather than wasting cycles. This is a buffer against runaway autonomous loops.
 - **`.agents/` corpus size** — The physical K stock. Tiering and pruning (`ao maturity --expire`) prevent the buffer from growing past the point where retrieval degrades.
@@ -91,7 +91,7 @@ The knowledge stock `K` lives in `.agents/`. Its structure:
 - **Phase boundaries (R to P to I to V)** — The RPI lifecycle enforces sequential phases: Research, Plan, Implement, Validate. Each phase must complete before the next begins. This is a deliberate delay that prevents premature implementation. The cost of finding a bug increases 10x at each stage it survives.
 - **Circuit breaker (60 min)** — `/evolve` stops if no productive cycle occurred in the last 60 minutes. This prevents the system from oscillating between idle cycles indefinitely. Implemented as a timestamp check against `cycle-history.jsonl`.
 - **Confidence decay (10%/week)** — Learning freshness scores decay over time, creating a delay between when knowledge was created and when it becomes effectively invisible to retrieval. This matches Ebbinghaus's forgetting curve.
-- **Stale run TTL** — Sessions that do not close cleanly have their state cleaned up by the pending-cleaner hook after a timeout. Prevents stale state from contaminating future sessions.
+- **Stale run TTL** — RPI runs that do not close cleanly have their state cleaned up by `ao rpi cleanup` (and the `--auto-clean-stale-after` pre-run sweep) once older than the TTL. Prevents stale state from contaminating future sessions.
 - **Maturity lifecycle** — `ao maturity --expire` implements time-delayed eviction. Knowledge that is not retrieved within its TTL decays out of the active set.
 
 **dK/dt mapping:** Controls the lag between `I(t)` and usable `K`. Phase boundaries create healthy delays (validation before deployment). Confidence decay and maturity lifecycle create the `delta * K` drain term.
@@ -112,8 +112,8 @@ The knowledge stock `K` lives in `.agents/`. Its structure:
 | **B2: Scale friction** | As K grows, retrieval quality degrades and governance cost rises | Prevents corpus bloat from collapsing sigma | Tiering, pruning, MemRL utility scoring (`ao feedback`) |
 | **Regression gates** | `/evolve` snapshots fitness before each cycle; regression = automatic revert | Prevents improvement cycles from making things worse | `ao goals measure`, fitness snapshot comparison |
 | **Council FAIL** | Multi-model council returns FAIL verdict; blocks merge | Prevents bad code from locking into ratchet | `/vibe`, `/council` verdicts in `.agents/council/` |
-| **Push gate** | Hook blocks `git push` if `/vibe` has not passed | Prevents unvalidated code from reaching main | `hooks/push-gate.sh` |
-| **Pre-mortem gate** | Hook blocks `/crank` if `/pre-mortem` has not passed | Prevents implementation of unvetted plans | `hooks/pre-mortem-gate.sh` |
+| **Push gate** | CI (`.github/workflows/validate.yml`) blocks merge to main unless validation passes; `/vibe` is the explicit pre-push readiness step | Prevents unvalidated code from reaching main | `scripts/pre-push-gate.sh`, `/vibe`, branch protection + CI |
+| **Pre-mortem gate** | `/pre-mortem` is the explicit pre-implementation step; `/crank` / `/evolve` surface the post-mortem checkpoint | Prevents implementation of unvetted plans | `/pre-mortem`, `/crank`, `scripts/session-pr-scope.sh` |
 
 **dK/dt mapping:**
 - B1 creates the `delta * K` term — the constant drain that R1 must overcome.
@@ -183,18 +183,18 @@ When `dominant: "R1"`, the flywheel is spinning faster than decay can drain it. 
 | Flow | From | To | Mechanism | Why it matters |
 |------|------|----|-----------|----------------|
 | Knowledge injection | `.agents/learnings/` | Session context | `ao lookup` (freshness-weighted, utility-scored, on demand) | Session N knows what session 1 learned |
-| Knowledge extraction | Session output | `.agents/learnings/` | `ao forge` (hook-enforced at session end) | Experience survives session death |
+| Knowledge extraction | Session output | `.agents/learnings/` | `ao forge` (explicit session-end step, e.g. via `/post-mortem` / `/handoff`) | Experience survives session death |
 | Briefing packets | Prior research/plans | Agent context | `ao context assemble` (500-token summaries) | Right information, right phase, right agent |
 | Least-privilege loading | Full knowledge stock | Filtered subset | Phase-based and role-based filtering | Prevents lost-in-the-middle; context as security boundary |
 | Ralph Wiggum | Previous wave state | New wave workers | Fresh context per wave (zero bleed-through) | Workers reason from clean state, not accumulated garbage |
-| Hook nudges | System state | Agent prompt | PostToolUse/UserPromptSubmit hooks | "Run /vibe before pushing" — invisible except when needed |
-| Finding registry + compiled prevention | `.agents/findings/registry.jsonl`, `.agents/planning-rules/*.md`, `.agents/pre-mortem-checks/*.md`, `.agents/constraints/index.json` | `/plan`, `/pre-mortem`, `/vibe`, `/post-mortem`, `task-validation-gate.sh` | skill contracts + `hooks/finding-compiler.sh` + `docs/contracts/finding-registry.md` | Reusable failures become earlier planning/review checks, and mechanically detectable ones can become active validation blockers |
+| Workflow nudges | System state | Agent prompt | Explicit skill steps (`/vibe`, `/pre-mortem`) + opt-in hooks via the `hooks-authoring` skill (AgentOps ships none by default) | "Run /vibe before pushing" — surfaced at the relevant step |
+| Finding registry + compiled prevention | `.agents/findings/registry.jsonl`, `.agents/planning-rules/*.md`, `.agents/pre-mortem-checks/*.md`, `.agents/constraints/index.json` | `/plan`, `/pre-mortem`, `/vibe`, `/post-mortem` | skill contracts + `docs/contracts/finding-registry.md` + CI gate `scripts/check-finding-registry.sh` | Reusable failures become earlier planning/review checks, and the registry contract is CI-enforced |
 
 **The 40% Rule as an information flow control:** The context guard is not just a buffer control (#11). It is fundamentally an information flow decision: what gets loaded and what does not. At 40% capacity, the system must choose. That choice — freshness-weighted, utility-scored, phase-scoped — determines sigma.
 
 **dK/dt mapping:** Directly increases `sigma` by getting the right knowledge to the right window at the right time. Also increases `rho` by making retrieved knowledge more relevant to the current task (phase scoping reduces noise).
 
-**Status:** Implemented. All seven information flows are active. The prevention-oriented seventh flow now spans registry intake and compiled prevention outputs: planning and judgment load compiled artifacts first, and task validation consumes active constraint index entries for mechanically detectable findings. `ao context assemble` and `ao lookup` remain the primary CLI delivery mechanisms for broader knowledge retrieval.
+**Status:** Implemented. All seven information flows are active. The prevention-oriented seventh flow now spans registry intake and compiled prevention outputs: planning and judgment load compiled artifacts first (`/plan`, `/pre-mortem`, `/vibe`), and the registry contract is CI-enforced (`scripts/check-finding-registry.sh`). `ao context assemble` and `ao lookup` remain the primary CLI delivery mechanisms for broader knowledge retrieval.
 
 ---
 
@@ -204,26 +204,26 @@ When `dominant: "R1"`, the flywheel is spinning faster than decay can drain it. 
 
 **AgentOps implementation:**
 
-AgentOps has 3 active runtime hooks in `hooks/hooks.json` that enforce the core knowledge lifecycle mechanically. The agent does not decide whether to follow them. The system enforces them.
+AgentOps 3.0 is **hookless**: it ships zero runtime hooks. The core knowledge lifecycle is enforced by CI gates plus explicit skill steps, not by auto-firing hooks. CI (`.github/workflows/validate.yml`) is the authoritative gate — the agent cannot merge to main unless it passes — and the skills provide the in-session steps that keep the lifecycle whole.
 
 | Rule | Enforcement | What it prevents |
 |------|-------------|------------------|
-| Session start hook | Runs `hooks/session-start.sh` on `SessionStart` | Cold starts without prior knowledge |
-| Session end maintenance hook | Runs `hooks/session-end-maintenance.sh` on `SessionEnd` | Lost session learnings and stale pools |
-| Stop close-loop hook | Runs `hooks/ao-flywheel-close.sh` on `Stop` | Unclosed flywheel feedback cycles |
-| Task validation constraint hook | Runs `hooks/task-validation-gate.sh` on `TaskCompleted` | Mechanically detectable failures escaping validation despite prior findings |
+| Session orientation | Explicit `ao session bootstrap` + `ao inject` at session start | Cold starts without prior knowledge |
+| Session-end extraction | Explicit `ao forge` step via `/post-mortem` / `/handoff` | Lost session learnings and stale pools |
+| Flywheel close-loop | Explicit `/post-mortem` / citation-tracking step | Unclosed flywheel feedback cycles |
+| Validation gate | CI omnibus validation + `/vibe` pre-push step + `scripts/pre-push-gate.sh` | Mechanically detectable failures escaping validation |
 
-Guardrail hook scripts (push gate, worker guard, pre-mortem gate, etc.) remain in the repo and can be re-enabled by manifest policy, but they are not part of the active runtime contract by default.
+The guardrail behaviors above (session start, push gate, pre-mortem gate, etc.) are realized as CI gates and explicit skill steps. AgentOps does not ship them as hooks; a consumer who wants always-on, pre-action enforcement can author opt-in hooks via the `hooks-authoring` skill.
 
 **Additional rules:**
 - **Sisyphus rule** — Completion requires an explicit marker. The agent cannot claim "done" without the system agreeing. Prevents premature completion claims.
 - **Max 50 waves** — Global wave limit prevents infinite execution loops in `/crank`.
 - **Strike check** — Skip goal after 3 consecutive failures. Prevents infinite retry on fundamentally broken goals.
-- **Kill switches** — `AGENTOPS_HOOKS_DISABLED=1` (all hooks), deploy kill file (stops `/evolve`). Every autonomous loop has a manual override.
+- **Kill switches** — deploy kill file (stops `/evolve`), circuit breaker (60-min idle stop). Every autonomous loop has a manual override.
 
 **dK/dt mapping:** Rules do not appear directly in the equation, but they prevent catastrophic dK/dt events — regressions that would send K to zero. They also enforce the information flows (#6) that keep sigma high. Without rules, the flywheel depends on agent memory. Agents forget. Rules do not.
 
-**Status:** Implemented. The session-boundary hooks and task-validation constraint hook are enforced. All kill switches tested.
+**Status:** Implemented. The lifecycle steps are enforced by CI gates and explicit skill steps (AgentOps 3.0 ships zero hooks). All kill switches tested.
 
 ---
 
@@ -234,14 +234,14 @@ This is the product insight.
 Simple rules produce complex behavior that evolves. The seed encodes rules (#5). Emergence produces self-organization (#4). This transition — from mechanical enforcement to adaptive behavior — is what separates AgentOps from a checklist.
 
 Consider what happens:
-1. **Rules** (#5): Hooks enforce the extract-inject cycle. Every session deposits learnings. Every session retrieves them. The agent has no choice.
+1. **Rules** (#5): CI gates and explicit skill steps enforce the extract-inject cycle. Every session deposits learnings (`ao forge`). Every session retrieves them (`ao inject` / `ao session bootstrap`). The merge gate makes it non-optional.
 2. **Information flows** (#6): The flywheel delivers the right knowledge to the right context. Sigma increases.
 3. **Reinforcing feedback** (#7): Retrieved knowledge that is used gets reinforced. Utility scores rise. Future retrieval improves. The flywheel accelerates.
 4. **Self-organization** (#4): `/evolve` measures fitness, picks the worst gap, fixes it, validates nothing regressed, extracts what it learned. The system's rules change based on its own experience.
 
 The rules do not specify what the system should build. They specify how it should learn. The fitness landscape (GOALS.md) determines what gets built. The rules determine that whatever gets built also produces knowledge that compounds.
 
-This is why the product is the seed, not the tree. The same 6 seed elements — GOALS.md, `.agents/`, hooks, CLAUDE.md section, core skills, bootstrap learning — planted in different repos produce different systems. The rules are identical. The emergent behavior differs because the goals differ.
+This is why the product is the seed, not the tree. The same 6 seed elements — GOALS.md, `.agents/`, CI gates, CLAUDE.md section, core skills, bootstrap learning — planted in different repos produce different systems. The rules are identical. The emergent behavior differs because the goals differ.
 
 Fractal composition is the structural manifestation of this insight:
 
@@ -262,17 +262,17 @@ The same shape at every scale (function, issue, epic, repository) means rules at
 | Mechanism | What self-organizes | How |
 |-----------|--------------------|----|
 | `/evolve` fitness loop | Goal pursuit strategy | Measures all goals, selects worst by severity weight, fixes it, validates no regression, learns. Next cycle's choice depends on this cycle's result. |
-| Finding registry ratchet | Planning, review, and validation context | Structured findings enter through `.agents/findings/registry.jsonl`, compile into promoted artifacts plus planning/pre-mortem outputs, and mechanical active findings feed `.agents/constraints/index.json` for `task-validation-gate.sh`. |
+| Finding registry ratchet | Planning, review, and validation context | Structured findings enter through `.agents/findings/registry.jsonl`, compile into promoted artifacts plus planning/pre-mortem outputs, and feed `.agents/constraints/index.json`; the registry contract is CI-enforced (`scripts/check-finding-registry.sh`). |
 | `/forge` pattern extraction | Knowledge taxonomy | Extracts reusable patterns from sessions. The pattern library grows and changes shape based on what the system encounters. |
 | Skill composition | Capability surface | Skills chain: `/research` -> `/plan` -> `/pre-mortem` -> `/crank` -> `/vibe` -> `/post-mortem`. The chain is fixed but each skill adapts its behavior to its inputs. |
 | Progressive skill revelation | User-visible surface | New users see 8 starter skills. The remaining skills reveal as the user grows. The system's visible complexity adapts to the user's readiness. |
 | Severity-weighted goal selection | Priority ordering | `ao goals measure` scores all goals by weight. `/evolve` works the highest-weight failure first. The priority order changes every cycle based on measurement. |
 
-**The finding registry deserves emphasis.** It is the mechanism that converts #7 (reinforcing feedback - learnings) into earlier-stage prevention. When a failure is normalized into a structured finding, it no longer stays as prose: the compiler promotes it into reusable planning/review artifacts, and mechanically detectable active findings can also become task-validation constraints. The important limit is not "registry versus enforcement" anymore; it is "advisory for ambiguous findings, enforced for the mechanical subset."
+**The finding registry deserves emphasis.** It is the mechanism that converts #7 (reinforcing feedback - learnings) into earlier-stage prevention. When a failure is normalized into a structured finding, it no longer stays as prose: it is promoted into reusable planning/review artifacts that `/plan`, `/pre-mortem`, and `/vibe` load, and the registry contract itself is CI-enforced (`scripts/check-finding-registry.sh`). The important limit is selectivity: which findings are concrete enough to compile into a reusable check versus which stay advisory.
 
-**dK/dt mapping:** Self-organization does not appear in the equation because it changes the equation itself. When the finding registry promotes a failure into reusable planning/review artifacts, it changes the system's `sigma` by improving retrieval focus and its `rho` by making reuse happen earlier in the lifecycle. When the same finding becomes an active mechanical constraint, it also reduces `phi` by preventing repeated validation misses from compounding into governance friction.
+**dK/dt mapping:** Self-organization does not appear in the equation because it changes the equation itself. When the finding registry promotes a failure into reusable planning/review artifacts, it changes the system's `sigma` by improving retrieval focus and its `rho` by making reuse happen earlier in the lifecycle. By surfacing the same failure as a reusable check before implementation, it also reduces `phi` by preventing repeated validation misses from compounding into governance friction.
 
-**Status:** Implemented in part. `/evolve` is production-tested (116 cycles, ~7 hours continuous). Registry intake, compiled planning/review reuse, and active task-validation enforcement for mechanically detectable findings are all live. The remaining limit is selectivity, not absence: many findings will always stay advisory because they cannot be compiled safely.
+**Status:** Implemented in part. `/evolve` is production-tested (116 cycles, ~7 hours continuous). Registry intake, compiled planning/review reuse, and the CI-enforced registry contract are all live. The remaining limit is selectivity, not absence: many findings will always stay advisory because they cannot be compiled into a reusable check safely.
 
 ---
 
@@ -321,8 +321,8 @@ The same shape at every scale (function, issue, epic, repository) means rules at
 |---|------|----|-------|
 | 1 | Reduce variance | Harness variance (Brownian Ratchet) | Spawn parallel attempts, filter aggressively, ratchet successes |
 | 2 | Context is infinite | Context is scarce (40% Rule) | Treat context as a security boundary, least-privilege loading |
-| 3 | Validation is post-hoc | Validation is preventive (Shift-Left) | `/pre-mortem` before implementation, hooks at every gate |
-| 4 | Rules are guidelines | Rules are structural (Hooks) | 3 active runtime hooks that cannot be forgotten, skipped, or rationalized away |
+| 3 | Validation is post-hoc | Validation is preventive (Shift-Left) | `/pre-mortem` before implementation, CI gates + `/vibe` at every gate |
+| 4 | Rules are guidelines | Rules are structural (CI gates) | CI merge gates that cannot be forgotten, skipped, or rationalized away |
 | 5 | Knowledge is hoarded | Knowledge is flowing (Flywheel) | Extract, score, tier, decay, re-inject across sessions |
 | 6 | Designed systems | Evolved systems (The Seed) | Define starting conditions, let the system evolve toward goals |
 
@@ -337,7 +337,7 @@ A designed system is specified upfront and built to spec. An evolved system is g
 
 The seed does not design outcomes. It creates conditions for emergence:
 - GOALS.md defines the fitness landscape
-- Hooks enforce the rules of engagement
+- CI gates enforce the rules of engagement
 - The flywheel provides the memory mechanism
 - `/evolve` provides the selection pressure
 
@@ -361,7 +361,7 @@ Two mechanisms approach this level:
 
 **Stigmergy coordination** — Workers leave traces in shared state (`.agents/`) that influence other workers' behavior without direct communication. No worker knows the full system state. No coordinator directs the full system. The system's behavior emerges from local interactions with shared artifacts — the same principle that governs ant colonies.
 
-**The honest assessment:** Level #1 is aspirational. True paradigm transcendence would mean the system can recognize when its own organizing metaphors (the seed, the flywheel, the ratchet) are limiting and replace them. AgentOps does not do this yet. The finding registry (#4) can now promote learnings into reusable advisory checks and active task-validation constraints, and `/evolve` can change what it works on, but neither can change the fundamental assumptions of the system itself.
+**The honest assessment:** Level #1 is aspirational. True paradigm transcendence would mean the system can recognize when its own organizing metaphors (the seed, the flywheel, the ratchet) are limiting and replace them. AgentOps does not do this yet. The finding registry (#4) can now promote learnings into reusable planning/review checks, and `/evolve` can change what it works on, but neither can change the fundamental assumptions of the system itself.
 
 What exists is the infrastructure for it: append-only logs that let a future meta-observer analyze whether the system's paradigms are serving it.
 
@@ -400,7 +400,7 @@ Each term maps to specific leverage points:
 | #6 (Info flows) | Least-privilege loading, phase scoping, and context assembly determine what gets retrieved (sigma) |
 | #8 (B2 via MemRL) | Utility scoring (`ao feedback`) adjusts retrieval priority, preventing sigma collapse at scale |
 | #7 (R1 loop) | This IS the R1 loop. Retrieval × usage × existing stock = compound growth |
-| #5 (Rules) | Hooks enforce the extract-inject cycle that keeps sigma and rho nonzero |
+| #5 (Rules) | CI gates + explicit skill steps enforce the extract-inject cycle that keeps sigma and rho nonzero |
 
 ### phi * K^2 — Scale Friction
 
@@ -484,5 +484,5 @@ What is missing from the Meadows mapping and what would close each gap.
 - [strategic-direction.md](strategic-direction.md) — Consolidation decision, summary Meadows table, 6 paradigm shifts
 - [seed-definition.md](seed-definition.md) — The 6 seed elements with Meadows mapping per element
 - [the-science.md](the-science.md) — The dK/dt equation, escape velocity, limits to growth
-- [how-it-works.md](how-it-works.md) — Hooks, ratchet, Ralph Wiggum, compaction resilience
+- [how-it-works.md](how-it-works.md) — Hookless enforcement, ratchet, Ralph Wiggum, compaction resilience
 - [workflows/meta-observer-pattern.md](workflows/meta-observer-pattern.md) — Stigmergy coordination pattern

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,55 +4,36 @@ Common issues and quick fixes for AgentOps.
 
 ---
 
-## Hooks aren't running
+## "Where are the hooks?"
 
-Hooks are runtime-specific: Claude uses `~/.claude/settings.json`, while Codex
-v0.115.0+ uses `~/.codex/hooks.json` installed by the native plugin path.
+**AgentOps 3.0 ships zero hooks.** There is no `hooks/` directory, no
+`hooks.json`, and no `ao hooks` command — nothing auto-injects orientation or
+gates your tool calls at session start. If you came from an older version
+expecting hooks to "run", that behavior is gone by design (the hookless-first
+teardown). The workflow is now guided by **skills + the `ao` CLI**, and **CI is
+the authoritative gate** (see `.github/workflows/validate.yml`).
 
-**Diagnosis:**
+**What replaces the old auto-injected context:**
+
+```bash
+ao session bootstrap                 # the universal init prompt / orientation report
+ao inject --query "<topic>"          # pull decay-ranked prior context on demand
+```
+
+**Diagnosis (check your install, not hooks):**
 
 ```bash
 ao doctor
 ```
 
-Look for the "Hooks installed" check. If it shows `✗`, hooks are not configured.
+This reports CLI, knowledge-base, plugin, and freshness health. None of these
+are hooks — there are none to install.
 
-**Fixes:**
-
-1. Verify hooks are configured in `~/.claude/settings.json`:
-   ```json
-   {
-     "hooks": {
-       "PostToolUse": [...],
-       "UserPromptSubmit": [...]
-     }
-   }
-   ```
-   The `ao doctor` check counts all hooks across event types. If it reports "no hooks configured", hooks are missing from settings.json entirely.
-
-2. Check that hooks are not disabled via environment variable:
-   ```bash
-   echo $AGENTOPS_HOOKS_DISABLED
-   ```
-   If set to `1`, all hooks are bypassed. Unset it:
-   ```bash
-   unset AGENTOPS_HOOKS_DISABLED
-   ```
-
-3. Verify hook scripts exist and are executable:
-   ```bash
-   ls -la hooks/
-   ```
-   All `.sh` files in the hooks directory should have execute permissions.
-
-4. For Codex native-plugin installs, verify the native hooks file exists:
-   ```bash
-   cat ~/.codex/hooks.json | jq '.hooks'
-   ```
-   If it is missing, reinstall with:
-   ```bash
-   curl -fsSL https://raw.githubusercontent.com/boshu2/agentops/main/scripts/install-codex.sh | bash
-   ```
+**If you want your own gates:** AgentOps deliberately ships none, but you can
+author opt-in hooks yourself. Use the `hooks-authoring` skill to add a bounded
+gate (block a dangerous op, bootstrap a session, run a parity check) for your
+runtime — Claude reads `~/.claude/settings.json`; other harnesses use their own
+config. These are yours to own; AgentOps neither installs nor requires them.
 
 ---
 
@@ -226,30 +207,30 @@ raw-skill mode for a specific Codex build.
 
 ---
 
-## Push blocked by vibe gate
+## CI rejects a push that skipped quality validation
 
-The push gate hook blocks `git push` unless a recent `/vibe` check has passed. This enforces quality validation before code reaches the remote.
+AgentOps 3.0 has **no push gate hook** — `git push` itself is never blocked
+locally. Quality enforcement happens in **CI** (`.github/workflows/validate.yml`),
+which is the authoritative gate: a push that hasn't been validated will fail
+its checks on the PR, not before it leaves your machine.
 
-**Why it exists:** The vibe gate prevents untested or unreviewed code from being pushed. It is part of the AgentOps quality enforcement workflow.
-
-**Quick bypass (use sparingly):**
-
-```bash
-AGENTOPS_HOOKS_DISABLED=1 git push
-```
+**Why it works this way:** there is no local hook to bypass, so the gate cannot
+be silently skipped. The contract is "CI must be green to merge", and the cheap
+way to predict that locally is to run `/vibe` before you push.
 
 **Proper resolution:**
 
-1. Run `/vibe` on your changes:
+1. Run `/vibe` on your changes before pushing:
    ```
    /vibe
    ```
 
 2. Address any findings until you get a PASS verdict.
 
-3. Push normally:
+3. Push, then let CI confirm:
    ```bash
    git push
+   gh pr checks   # confirm the validation job is green
    ```
 
 ---
@@ -343,24 +324,34 @@ The pre-mortem gate denies ambiguous state by default (as of 2.37.2). If `/crank
    ```
    This downgrades the gate to a warning.
 
-## `go-test-precommit` blocks commits
+## Go tests fail in CI after a change
 
-The `go-test-precommit.sh` hook runs relevant Go tests before tool calls that would mutate Go code. If it fails, look for the test output above the block message. Common causes:
+AgentOps 3.0 ships no pre-commit hook that runs Go tests for you — verify
+locally before pushing. Run the per-tool checks for the surfaces you touched:
+
+```bash
+cd cli && make test          # or: go build ./... && go vet ./... && go test ./...
+```
+
+If tests fail, common causes:
 
 - Tests that depend on network (`go test -short` typically skips these).
 - A package import that fails to compile — fix compilation first, tests second.
 
-**Bypass (not recommended):** set `AGENTOPS_SKIP_GO_TEST_PRECOMMIT=1` for a single session. Prefer fixing the underlying test.
+CI runs the omnibus validation on push; if you skip the local check, the
+failure surfaces on the PR instead.
 
 ## Context window compacted and lost work
 
-If a session compacts and drops critical context, check whether `precompact-snapshot.sh` ran. Artifacts land in `.agents/compact/<timestamp>/`:
+If a session compacts and drops critical context, re-seed it with the corpus
+primitives rather than relying on an auto-snapshot hook (there is none in 3.0):
 
 ```bash
-ls -lt .agents/compact/ | head
+ao session bootstrap                 # re-orient
+ao inject --query "<topic>"          # pull back the relevant prior context
 ```
 
-Restore needed state with `ao inject --from .agents/compact/<timestamp>/` or manually re-seed the session with `MEMORY.md`.
+You can also manually re-seed the session from `MEMORY.md`.
 
 ## Getting help
 


### PR DESCRIPTION
## What

Completes the hooks-runtime decoupling (ag-t1ca) — the 6 large files, each de-hooked by a dedicated verify-first pass (no `hooks/` dir, no `hooks.json`, `ao hooks` absent, hook `.sh` files absent; CI = the authoritative gate).

| File | Reframe |
|---|---|
| ARCHITECTURE.md | hooks-as-enforcement / `hooks/ # 12 hook scripts` dir / "Session Hooks" → CI gates + `ao` commands + "Session Lifecycle"; 82-skill breakdown intact |
| agentops-system-map.md | "52 Skills/121 CLI/13 hook entries" → "82/76/hookless (CI-gated)"; hook-enforcement section → hookless mapping |
| context-lifecycle.md | hook-file citations → real mechanisms (CI gate + `/pre-mortem`,`/validate`,`/post-mortem` + `ao constraint`/`ao findings`) |
| leverage-points.md | "3 active hooks"/push-gate/pre-mortem-gate → CI gates + skill steps; resolved the doc's own active-vs-guardrail contradiction |
| troubleshooting.md | "Hooks aren't running" / "push gate hook" / `ao hooks test` → hookless guidance; **ROADMAP.md link kept** (audit's "broken link" was a false positive) |
| INCIDENT-RUNBOOK.md | Scenario C "Hook Scripts Fail" + Per-Hook Kill Switches → 3.0 "Skills Not Loading / CI Gate Failing"; `AGENTOPS_HOOKS_DISABLED` kept only as user-authored-hooks opt-out |
| agentops-brief.md | "73 shared skills/12 Hook Events"/"Startup hooks" → 82 skills, hookless lifecycle |

## Verification (aggregate, by me — not just subagent self-reports)
- `markdownlint -c .markdownlint.json` (all docs) → **0 errors**
- `tests/docs/validate-links.sh` → **0 broken** (2902 checked)
- `scripts/sync-skill-counts.sh --check` → clean (ARCHITECTURE.md gate target intact)
- residual hooks-as-live-runtime grep across all 7 → only correct negation/opt-in framing remains
- net −41 lines (reframe, not gutting)

Closes-scenario: ag-t1ca#big-files
Bounded-context: BC1-Corpus
Evidence: docs/ARCHITECTURE.md