### PR TITLE
docs: finish doc-staleness epic tails — local-model framing + dead test paths (ag-ph6h, ag-j4tw)

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing Guide
 
-Testing ensures AgentOps skills, hooks, and the `ao` CLI work correctly across changes. This guide covers what tests exist, how to run them, and how to write new ones.
+Testing ensures AgentOps skills and the `ao` CLI work correctly across changes. This guide covers what tests exist, how to run them, and how to write new ones.
 
 ## Test Types
 
@@ -10,8 +10,8 @@ Testing ensures AgentOps skills, hooks, and the `ao` CLI work correctly across c
 | Integration | `tests/integration/` | Shell scripts testing CLI commands, skill invocation, hook chains |
 | Smoke | `tests/smoke-test.sh` | Quick sanity checks that the plugin loads correctly |
 | Windows smoke | `tests/windows/test-windows-smoke.ps1` | Native Windows smoke for PowerShell installers, Codex plugin staging, `ao doctor` hints, and focused Windows-sensitive Go tests |
-| Contract | `tests/hooks/*.bats`, `scripts/check-contract-compatibility.sh` | Schema and contract validation |
-| BATS | `tests/hooks/*.bats`, `tests/scripts/*.bats` | Unit tests for shell hooks and scripts using the BATS framework |
+| Contract | `tests/scripts/*.bats`, `scripts/check-contract-compatibility.sh` | Schema and contract validation |
+| BATS | `tests/scripts/*.bats` | Unit tests for repo shell scripts using the BATS framework |
 | E2E | `tests/e2e/` | Full pipeline proof runs |
 | Skill | `tests/skills/`, `skills/*/scripts/validate.sh` | Skill structure, frontmatter, and behavior validation |
 | Doc | `tests/docs/` | Documentation link and count validation |
@@ -47,7 +47,6 @@ Run a specific tier:
 | Go build + vet + changed-scope race | `scripts/validate-go-fast.sh` | ~20s |
 | AgentOps contract canaries | `scripts/test-agentops-contract-canaries.sh` | ~2-5m |
 | AgentOps eval advisory corpus | `scripts/eval-agentops.sh --fast` | ~5-10m |
-| BATS hook tests | `bats tests/hooks/*.bats` | ~10s |
 | BATS script tests | `bats tests/scripts/*.bats` | ~10s |
 | Skill validation | `tests/skills/run-all.sh` | ~30s |
 | Skill integrity (heal) | `bash skills/heal-skill/scripts/heal.sh --strict` | ~15s |
@@ -127,7 +126,6 @@ That activates `.githooks/pre-commit` and `.githooks/pre-push` for the current c
 | Test type | Directory |
 |-----------|-----------|
 | Go unit tests | Next to the source file in `cli/` (e.g., `cli/internal/goals/measure_test.go`) |
-| Hook tests (BATS) | `tests/hooks/` |
 | Script tests (BATS) | `tests/scripts/` |
 | Skill validation | `skills/<name>/scripts/validate.sh` |
 | Integration tests | `tests/integration/test-<name>.sh` |
@@ -173,19 +171,11 @@ Each CLI command file in `cli/cmd/ao/` should have a corresponding `*_test.go` f
 
 Tests must make meaningful assertions about output content, exit codes, and side effects. A test that only checks `err == nil` without validating the result is insufficient.
 
-## Hook Testing (BATS)
+## Script Testing (BATS)
 
-Hooks are tested using the [BATS](https://github.com/bats-core/bats-core) framework. Test files live in `tests/hooks/`.
+Repo shell scripts (`scripts/*.sh`) are tested using the [BATS](https://github.com/bats-core/bats-core) framework. Test files live in `tests/scripts/`.
 
-### Existing BATS test files
-
-| File | Covers |
-|------|--------|
-| `test-hooks.bats` | Active hook categories (session-start, factory-router, kill switch, etc.) |
-| `hook-output-schema.bats` | Hook output JSON schema contracts |
-| `hook-stdin-contracts.bats` | Hook stdin JSON input contracts |
-| `constraint-compiler.bats` | Constraint compiler logic |
-| `lib-hook-helpers.bats` | Unit tests for `lib/hook-helpers.sh` functions |
+> AgentOps 3.0 is hookless — it ships no hook scripts, so there are no hook BATS tests. The BATS suite covers the repo's shell scripts.
 
 ### Writing a BATS test
 
@@ -193,37 +183,33 @@ Hooks are tested using the [BATS](https://github.com/bats-core/bats-core) framew
 #!/usr/bin/env bats
 
 setup() {
-    load helpers/test_helper
-    _helper_setup
-    export CLAUDE_SESSION_ID="bats-test-$$"
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    export REPO_ROOT
 }
 
-teardown() {
-    _helper_teardown
+@test "my-script: does the expected thing" {
+    run bash "$REPO_ROOT/scripts/my-script.sh" --json
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.someField == "expected"'
 }
 
-@test "my-hook: does the expected thing" {
-    RESULT=$(bash "$HOOKS_DIR/my-hook.sh" 2>/dev/null)
-    echo "$RESULT" | jq -e '.hookSpecificOutput.someField == "expected"'
-}
-
-@test "my-hook: kill switch suppresses output" {
-    OUTPUT=$(AGENTOPS_HOOKS_DISABLED=1 bash "$HOOKS_DIR/my-hook.sh" 2>&1 || true)
-    [ -z "$OUTPUT" ]
+@test "my-script: exits non-zero on bad input" {
+    run bash "$REPO_ROOT/scripts/my-script.sh" --bogus
+    [ "$status" -ne 0 ]
 }
 ```
 
 ### Running BATS tests
 
 ```bash
-# All hook tests
-bats tests/hooks/*.bats
+# All script tests
+bats tests/scripts/*.bats
 
 # Single file
-bats tests/hooks/test-hooks.bats
+bats tests/scripts/agent-output-validate.bats
 
 # Verbose output
-bats --verbose-run tests/hooks/*.bats
+bats --verbose-run tests/scripts/*.bats
 ```
 
 ## Skill Testing
@@ -267,7 +253,6 @@ Quarantined tests are excluded from the default `run-all.sh` tiers and CI. Stand
 
 | Directory | Purpose |
 |-----------|---------|
-| `tests/hooks/` | BATS unit tests for hook scripts (`hooks/*.sh`) |
 | `tests/skills/` | Skill validation scripts plus standalone runtime smoke tests (Claude Code, Codex, OpenCode) |
 | `tests/spec-consistency/` | Spec consistency gates across manifests and docs |
 | `tests/goals/` | Goal validation and measurement (`GOALS.yaml` / `GOALS.md`) |

--- a/docs/local-compute-routing.md
+++ b/docs/local-compute-routing.md
@@ -1,8 +1,14 @@
 # Local Compute Routing
 
-Status: policy draft
+> ⚠️ **Design draft — NOT implemented.** The `local-scout` and `local-review`
+> lanes described below are a proposed design, not shipped behavior. There are no
+> `local-scout` / `local-review` skills in `skills/`, and AgentOps 3.0 ships no
+> local model host (local Ollama/llama hosting is retired). Treat this as a
+> forward-looking policy sketch; nothing here is wired into the runtime today.
+
+Status: policy draft (design only — see banner above)
 Owner: AgentOps policy, with Mt. Olympus runtime evidence
-Last reviewed: 2026-05-03
+Last reviewed: 2026-06-03
 
 ## Purpose
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -60,11 +60,11 @@ Not every knowledge operation needs a frontier model. AgentOps uses three tiers:
 
 | Tier | When | Why |
 |------|------|-----|
-| Local 8B (ollama, etc.) | Volume work — dedup, defrag, freshness scoring, overnight compounding | Fast, private, cheap. Runs while you sleep. |
+| Local 8B (ollama, etc.) — **optional, user-supplied** | Volume work — dedup, defrag, freshness scoring, overnight compounding | Fast, private, cheap. Runs while you sleep. AgentOps ships no model host; bring your own, or run these on your frontier model. |
 | Frontier (Claude, GPT-4o, etc.) | Quality work — council validation, pre-mortem review, pattern extraction | Accuracy matters more than throughput. |
 | Human | Curation and promotion decisions | Judgment calls that agents get wrong systematically. |
 
-`/dream` uses the local tier for continuous compounding; when that compounding runs out of session — always-on, scheduled, unattended — it runs on the Gas City substrate (the reference out-of-session orchestrator), not an AgentOps daemon. `/council` and `/pre-mortem` use the frontier tier for high-stakes validation. The human reviews promotions from learning → finding → rule.
+`/dream` uses the local tier when one is configured (otherwise your frontier model) for continuous compounding; when that compounding runs out of session — always-on, scheduled, unattended — it runs on an out-of-session substrate (reference: NTM + MCP + managed-agents), not an AgentOps daemon. `/council` and `/pre-mortem` use the frontier tier for high-stakes validation. The human reviews promotions from learning → finding → rule.
 
 The ratio is intentional. Validation and curation cost 3-5x implementation time. This is not overhead — it is the ratchet. Without it, the flywheel runs backward.
 

--- a/docs/testing-skills.md
+++ b/docs/testing-skills.md
@@ -20,7 +20,7 @@ The AgentOps skill test framework provides utilities for validating Claude Code 
 ## Test Framework Location
 
 ```
-tests/_quarantine/claude-code/
+tests/claude-code/
 ├── test-helpers.sh          # Core test utilities (source this)
 ├── logs/                    # JSON logs from test runs
 ├── test-<skill>-skill.sh    # Individual skill tests
@@ -452,13 +452,13 @@ Tests in `tests/_quarantine/` are legacy integration tests that require a runnin
 
 ```bash
 cd <repo-root>
-./tests/_quarantine/claude-code/test-swarm-skill.sh
+./tests/claude-code/test-swarm-skill.sh
 ```
 
 ### All Tests
 
 ```bash
-for test in tests/_quarantine/claude-code/test-*-skill.sh; do
+for test in tests/claude-code/test-*-skill.sh; do
     echo "Running $test..."
     bash "$test" || echo "FAILED: $test"
 done
@@ -467,7 +467,7 @@ done
 ### With Custom Settings
 
 ```bash
-MAX_TURNS=10 DEFAULT_TIMEOUT=180 ./tests/_quarantine/claude-code/test-swarm-skill.sh
+MAX_TURNS=10 DEFAULT_TIMEOUT=180 ./tests/claude-code/test-swarm-skill.sh
 ```
 
 ---
@@ -486,7 +486,7 @@ MAX_TURNS=10 DEFAULT_TIMEOUT=180 ./tests/_quarantine/claude-code/test-swarm-skil
 **Solutions:**
 - Increase timeout: `run_claude "prompt" 180`
 - Increase `MAX_TURNS` for complex prompts
-- Check log files in `tests/_quarantine/claude-code/logs/`
+- Check log files in `tests/claude-code/logs/`
 
 ---
 
@@ -520,7 +520,7 @@ MAX_TURNS=10 DEFAULT_TIMEOUT=180 ./tests/_quarantine/claude-code/test-swarm-skil
 - Check skill namespace in log file
 - Review tool calls in JSON log:
   ```bash
-  grep '"name":' tests/_quarantine/claude-code/logs/claude-*.jsonl | head -10
+  grep '"name":' tests/claude-code/logs/claude-*.jsonl | head -10
   ```
 
 ---
@@ -562,18 +562,18 @@ MAX_TURNS=10 DEFAULT_TIMEOUT=180 ./tests/_quarantine/claude-code/test-swarm-skil
 
 1. **Check the log file:**
    ```bash
-   ls -la tests/_quarantine/claude-code/logs/
-   cat tests/_quarantine/claude-code/logs/claude-<timestamp>.jsonl | head -50
+   ls -la tests/claude-code/logs/
+   cat tests/claude-code/logs/claude-<timestamp>.jsonl | head -50
    ```
 
 2. **Extract tool calls:**
    ```bash
-   grep '"name":' tests/_quarantine/claude-code/logs/claude-*.jsonl | tail -20
+   grep '"name":' tests/claude-code/logs/claude-*.jsonl | tail -20
    ```
 
 3. **Check skill invocations:**
    ```bash
-   grep -E '"skill":"' tests/_quarantine/claude-code/logs/claude-*.jsonl
+   grep -E '"skill":"' tests/claude-code/logs/claude-*.jsonl
    ```
 
 4. **Run interactively:**
@@ -609,7 +609,7 @@ MAX_TURNS=10 DEFAULT_TIMEOUT=180 ./tests/_quarantine/claude-code/test-swarm-skil
 
 ## Example: Complete Test File
 
-See `<repo-root>/tests/_quarantine/claude-code/test-swarm-skill.sh` for a comprehensive example with:
+See `<repo-root>/tests/claude-code/test-swarm-skill.sh` for a comprehensive example with:
 - 8 tests covering full skill behavior
 - Retry logic for transient failures
 - Structured test runner with pass/fail tracking


### PR DESCRIPTION
## What

Final slice of the **ag-lk80 doc-staleness epic**. Verified against the repo.

**ag-ph6h remainder** (local-model / retired-infra framing):
- philosophy.md — "Local 8B (ollama)" Tier-1 caveated as **optional/user-supplied** (AgentOps ships no model host); "/dream … Gas City substrate" → out-of-session substrate (NTM + MCP + managed-agents).
- local-compute-routing.md — added a "**Design draft — NOT implemented**" banner (the local-scout/local-review lanes don't exist as skills; no local model host); bumped last-reviewed.

**ag-j4tw remainder** (dead test paths):
- testing-skills.md — `tests/_quarantine/claude-code` → `tests/claude-code` (11 refs; verified that's the real dir with the skill-test scripts).
- TESTING.md — removed/redirected 9 `tests/hooks/*.bats` refs (dir gone; 3.0 ships no hook scripts) → `tests/scripts/*.bats`; kept the real git-hooks "Local Hooking" section.

## Verification
- `tests/hooks`=0, `tests/_quarantine/claude-code`=0 in the docs
- markdownlint → 0 errors; `validate-links.sh` → 0 broken (2903 checked)

Closes the last two open children of ag-lk80.

Closes-scenario: ag-ph6h#local-model
Closes-scenario: ag-j4tw#dead-test-paths
Bounded-context: BC1-Corpus
Evidence: docs/philosophy.md