### PR TITLE
chore(gates): gate ASCII-diagram skill counts + drop dead hooks/ scan (ag-c4wn #lk80-papercuts)

### DIFF
--- a/scripts/check-agents-write-surfaces.sh
+++ b/scripts/check-agents-write-surfaces.sh
@@ -161,7 +161,7 @@ fi
 
 # Extract referenced top-level subdirs from production code.
 # - cli/**/*.go excluding _test.go
-# - scripts/*.sh, hooks/*.sh, lib/*.sh
+# - scripts/*.sh, lib/*.sh
 referenced_tmp="$(mktemp)"
 references_tmp="$(mktemp)"
 trap 'rm -f "$allowlist_tmp" "$contract_tmp" "$classification_errors_tmp" "$referenced_tmp" "$references_tmp"' EXIT
@@ -185,7 +185,6 @@ scan_agent_references() {
 
 scan_dirs=()
 [[ -d "$REPO_ROOT/scripts" ]] && scan_dirs+=("$REPO_ROOT/scripts")
-[[ -d "$REPO_ROOT/hooks" ]]   && scan_dirs+=("$REPO_ROOT/hooks")
 [[ -d "$REPO_ROOT/lib" ]]     && scan_dirs+=("$REPO_ROOT/lib")
 
 {

--- a/scripts/sync-skill-counts.sh
+++ b/scripts/sync-skill-counts.sh
@@ -207,6 +207,29 @@ patch_file "$REPO_ROOT/docs/GLOSSARY.md" \
   "s|ships [0-9]+ shared skills|ships ${TOTAL} shared skills|" \
   "docs/GLOSSARY.md shared-skills count"
 
+# --- ASCII-diagram skill-count guard (ag-c4wn) ---
+# docs/agentops-system-map.md and docs/agentops-brief.md hardcode the skill
+# count inside box-drawing borders whose column widths are alignment-sensitive.
+# patch_file deliberately does NOT rewrite them — a digit-width change (e.g.
+# 99 -> 100) would silently break the box. This is the "tolerant check" half:
+# VERIFY each "<N> [shared ]skills" token equals TOTAL and fail on drift so a
+# human re-pads the diagram by hand. Closes the drift class auto-patch leaves open.
+DIAGRAM_FILES=(
+  "docs/agentops-system-map.md"
+  "docs/agentops-brief.md"
+)
+for rel in "${DIAGRAM_FILES[@]}"; do
+  f="$REPO_ROOT/$rel"
+  [[ -f "$f" ]] || continue
+  while IFS= read -r found; do
+    [[ -n "$found" ]] || continue
+    if [[ "$found" != "$TOTAL" ]]; then
+      echo "ERROR: $rel ASCII diagram hardcodes skill count $found, expected $TOTAL (re-pad the box-drawing diagram by hand)"
+      errors=$((errors + 1))
+    fi
+  done < <(grep -oiE '[0-9]+ +(shared )?skills\b' "$f" | grep -oE '^[0-9]+')
+done
+
 echo ""
 
 if [[ "$errors" -gt 0 ]]; then


### PR DESCRIPTION
Three low-severity **ag-lk80** post-mortem papercuts, one chore arc (single rollback semantic).

## 1. ASCII-diagram skill-count drift guard — `sync-skill-counts.sh`
`docs/agentops-system-map.md` and `docs/agentops-brief.md` hardcode the skill count inside box-drawing borders whose column widths are alignment-sensitive. `patch_file` deliberately won't auto-rewrite them (a digit-width change, e.g. `99→100`, silently breaks the box). Added the sanctioned **tolerant check**: every `<N> [shared] skills` token must equal the on-disk skill TOTAL, else FAIL so a human re-pads the box. Closes the drift class auto-patch left open. Works in both `--check` and apply modes (reuses the existing `errors` counter).

## 2. `bd hooks` commit noise — not repo-actionable
The help-text dumped on every commit comes from `.git/hooks/*` bd-installed shims (**local, untracked git state**) — fixable only by a bd-tool change or a local `bd hooks` reinstall, nothing committable in agentops. Documented as resolved-here-not-applicable (the dump even appears in this PR's own commit step).

## 3. Drop dead `hooks/` scan — `check-agents-write-surfaces.sh`
`hooks/` doesn't exist post-3.0-teardown, so the `[[ -d hooks ]]` scan was a guaranteed no-op. Removed it + its comment. **Kept** `writer["hooks"]` — `hooks` remains a valid *opt-in* writer-surface label per `docs/contracts/agents-write-surfaces.md` (only the dead directory scan was vestigial, not the classifier vocabulary).

## Verification
- `sync-skill-counts.sh --check` → PASS; guard FAILs on an injected `82→99` drift (confirmed it bites)
- `check-agents-write-surfaces.sh` → PASS (68 referenced subdirs, all documented); **24/24 bats green**
- `shellcheck` clean on both scripts

Closes-scenario: ag-c4wn#lk80-papercuts
Bounded-context: BC2-Validation
Evidence: scripts/sync-skill-counts.sh