### PR TITLE
chore(cli): gofmt sweep — 14 unformatted files (ag-ozac #gofmt-sweep)

### DIFF
--- a/cli/cmd/ao/evolve_blocked.go
+++ b/cli/cmd/ao/evolve_blocked.go
@@ -87,12 +87,12 @@ func init() {
 // fields except cycle/timestamp/reason are optional; the JSONL reader rejects
 // records missing those three.
 type BlockedEvent struct {
-	Cycle             string `json:"cycle"`
-	Timestamp         string `json:"timestamp"`
-	Bead              string `json:"bead,omitempty"`
-	Reason            string `json:"reason"`
-	NeededContext     string `json:"needed_context,omitempty"`
-	LadderStepFailed  int    `json:"ladder_step_failed,omitempty"`
+	Cycle            string `json:"cycle"`
+	Timestamp        string `json:"timestamp"`
+	Bead             string `json:"bead,omitempty"`
+	Reason           string `json:"reason"`
+	NeededContext    string `json:"needed_context,omitempty"`
+	LadderStepFailed int    `json:"ladder_step_failed,omitempty"`
 }
 
 func runEvolveBlocked(cmd *cobra.Command, _ []string) error {

--- a/cli/cmd/ao/evolve_next_work.go
+++ b/cli/cmd/ao/evolve_next_work.go
@@ -25,13 +25,13 @@ const (
 )
 
 var (
-	evolveNextWorkMode             string
-	evolveNextWorkIncludeOperator  bool
-	evolveNextWorkJSON             bool
-	evolveNextWorkBDBinary         string
-	evolveNextWorkRunnerOverride   ladder.BeadRunner
-	evolveNextWorkGrepOverride     ladder.GrepRunner
-	evolveNextWorkClock            func() time.Time
+	evolveNextWorkMode            string
+	evolveNextWorkIncludeOperator bool
+	evolveNextWorkJSON            bool
+	evolveNextWorkBDBinary        string
+	evolveNextWorkRunnerOverride  ladder.BeadRunner
+	evolveNextWorkGrepOverride    ladder.GrepRunner
+	evolveNextWorkClock           func() time.Time
 )
 
 var evolveNextWorkCmd = &cobra.Command{

--- a/cli/cmd/ao/evolve_write_stop_marker_test.go
+++ b/cli/cmd/ao/evolve_write_stop_marker_test.go
@@ -14,13 +14,13 @@ import (
 // every marker variant with a stderr message referencing 'operator-stop'.
 func TestEvolveWriteStopMarker_Table(t *testing.T) {
 	tests := []struct {
-		name        string
-		mode        string
-		marker      string
-		reason      string
-		wantErr     bool
-		wantErrSub  string
-		wantFile    string
+		name         string
+		mode         string
+		marker       string
+		reason       string
+		wantErr      bool
+		wantErrSub   string
+		wantFile     string
 		wantFileBody string
 	}{
 		{
@@ -33,28 +33,28 @@ func TestEvolveWriteStopMarker_Table(t *testing.T) {
 			wantFileBody: "queue stable",
 		},
 		{
-			name:        "loop dormant refused",
-			mode:        "loop",
-			marker:      "dormant",
-			reason:      "agent self-halt attempt",
-			wantErr:     true,
-			wantErrSub:  "refused under --mode=loop",
+			name:       "loop dormant refused",
+			mode:       "loop",
+			marker:     "dormant",
+			reason:     "agent self-halt attempt",
+			wantErr:    true,
+			wantErrSub: "refused under --mode=loop",
 		},
 		{
-			name:        "loop stop refused",
-			mode:        "loop",
-			marker:      "stop",
-			reason:      "operator override",
-			wantErr:     true,
-			wantErrSub:  "refused under --mode=loop",
+			name:       "loop stop refused",
+			mode:       "loop",
+			marker:     "stop",
+			reason:     "operator override",
+			wantErr:    true,
+			wantErrSub: "refused under --mode=loop",
 		},
 		{
-			name:        "loop kill refused",
-			mode:        "loop",
-			marker:      "kill",
-			reason:      "kill switch",
-			wantErr:     true,
-			wantErrSub:  "refused under --mode=loop",
+			name:       "loop kill refused",
+			mode:       "loop",
+			marker:     "kill",
+			reason:     "kill switch",
+			wantErr:    true,
+			wantErrSub: "refused under --mode=loop",
 		},
 	}
 

--- a/cli/cmd/ao/goals_measure_scenarios_gaps_test.go
+++ b/cli/cmd/ao/goals_measure_scenarios_gaps_test.go
@@ -165,4 +165,3 @@ func TestGoalsMeasure_ContributingIsEmptySliceNotNil(t *testing.T) {
 		t.Fatalf("JSON contains 'contributing': null; want empty array []\nraw: %s", raw)
 	}
 }
-

--- a/cli/cmd/ao/provenance_trace_test.go
+++ b/cli/cmd/ao/provenance_trace_test.go
@@ -48,8 +48,8 @@ func fixturePath(t *testing.T, name string) string {
 // expectedOrphanFixtures mirrors tests/fixtures/provenance/expected-orphans.json.
 type expectedOrphanFixtures struct {
 	Fixtures []struct {
-		File             string                       `json:"file"`
-		OrphanArtifactID string                       `json:"orphan_artifact_id"`
+		File             string                        `json:"file"`
+		OrphanArtifactID string                        `json:"orphan_artifact_id"`
 		ExpectedFinding  provenancegraph.OrphanFinding `json:"expected_finding"`
 	} `json:"fixtures"`
 }

--- a/cli/internal/bench/bench_test.go
+++ b/cli/internal/bench/bench_test.go
@@ -101,13 +101,13 @@ func TestScoreResults(t *testing.T) {
 	expected := map[string]bool{"a": true, "b": true, "c": true}
 
 	tests := []struct {
-		name      string
-		results   []string
-		expected  map[string]bool
-		bestID    string
-		k         int
-		wantPAtK  float64
-		wantMRR   float64
+		name     string
+		results  []string
+		expected map[string]bool
+		bestID   string
+		k        int
+		wantPAtK float64
+		wantMRR  float64
 	}{
 		{
 			name:     "perfect precision",

--- a/cli/internal/bridge/bridge_test.go
+++ b/cli/internal/bridge/bridge_test.go
@@ -52,12 +52,12 @@ func TestFirstNonEmptyTrimmed(t *testing.T) {
 
 func TestCodexStopAlreadyClosed(t *testing.T) {
 	tests := []struct {
-		name                  string
-		lastStopSessionID     string
-		lastStopTranscript    string
-		sessionID             string
-		transcriptPath        string
-		want                  bool
+		name               string
+		lastStopSessionID  string
+		lastStopTranscript string
+		sessionID          string
+		transcriptPath     string
+		want               bool
 	}{
 		{
 			name:               "matching transcripts same session",
@@ -188,4 +188,3 @@ func TestCompareSemver(t *testing.T) {
 		})
 	}
 }
-

--- a/cli/internal/eval/types.go
+++ b/cli/internal/eval/types.go
@@ -50,8 +50,8 @@ const (
 	DimensionRuntimeCompatibility Dimension = "runtime_compatibility"
 	DimensionEfficiency           Dimension = "efficiency"
 	DimensionSafety               Dimension = "safety"
-	DimensionLearningClosure        Dimension = "learning_closure"
-	DimensionContextComprehension   Dimension = "context_comprehension"
+	DimensionLearningClosure      Dimension = "learning_closure"
+	DimensionContextComprehension Dimension = "context_comprehension"
 )
 
 type Status string

--- a/cli/internal/evidencedturn/evidencedturn.go
+++ b/cli/internal/evidencedturn/evidencedturn.go
@@ -178,10 +178,10 @@ func Evaluate(in Input) (Verdict, error) {
 	}
 
 	results := map[string]PredicateResult{
-		PredicateChainIntact:      evalChainIntact(in),
-		PredicateTerminalState:    evalTerminalState(in),
-		PredicateScenariosCovered: evalScenariosCovered(in),
-		PredicateEvidenceResolves: evalEvidenceResolves(in),
+		PredicateChainIntact:        evalChainIntact(in),
+		PredicateTerminalState:      evalTerminalState(in),
+		PredicateScenariosCovered:   evalScenariosCovered(in),
+		PredicateEvidenceResolves:   evalEvidenceResolves(in),
 		PredicateProvenanceEvent:    evalProvenanceEvent(in),
 		PredicateNoOrphan:           evalNoOrphan(in),
 		PredicateAuthorNeqValidator: evalAuthorNeqValidator(in),

--- a/cli/internal/evidencedturn/evidencedturn_test.go
+++ b/cli/internal/evidencedturn/evidencedturn_test.go
@@ -37,14 +37,14 @@ func wellFormedTransitions(t *testing.T, beadID string) []turnstate.Transition {
 func provEdge(t *testing.T, from, to string) provenancegraph.Edge {
 	t.Helper()
 	e := provenancegraph.Edge{
-		FromID:   from,
-		FromType: "commit",
-		ToID:     to,
-		ToType:   "bead",
-		Relation: "wasRevisionOf",
+		FromID:      from,
+		FromType:    "commit",
+		ToID:        to,
+		ToType:      "bead",
+		Relation:    "wasRevisionOf",
 		EvidenceRef: "deadbeef",
-		TrustTier: "inferred",
-		TS:        "2026-05-31T03:00:00Z",
+		TrustTier:   "inferred",
+		TS:          "2026-05-31T03:00:00Z",
 	}
 	sealed, err := provenancegraph.Seal(e, "")
 	if err != nil {
@@ -269,7 +269,7 @@ func TestEvaluate_EmptyBeadIDErrors(t *testing.T) {
 
 func TestEvaluate_MultipleGapsAllReported(t *testing.T) {
 	in := wellFormedInput(t)
-	in.Scenarios = nil      // fails scenarios_covered + evidence_resolves
+	in.Scenarios = nil       // fails scenarios_covered + evidence_resolves
 	in.ProvenanceEdges = nil // fails provenance_event
 	v, err := Evaluate(in)
 	if err != nil {

--- a/cli/internal/evolve/ladder/ladder_test.go
+++ b/cli/internal/evolve/ladder/ladder_test.go
@@ -11,14 +11,14 @@ import (
 
 // fakeBeadRunner is a test double implementing BeadRunner.
 type fakeBeadRunner struct {
-	ReadyList         []Bead
-	ReadyErr          error
-	ReadyByTypeMap    map[string][]Bead
-	ReadyByTypeErr    error
-	ShowMap           map[string]Bead
-	ShowErr           error
-	InProgressList    []Bead
-	InProgressErr     error
+	ReadyList      []Bead
+	ReadyErr       error
+	ReadyByTypeMap map[string][]Bead
+	ReadyByTypeErr error
+	ShowMap        map[string]Bead
+	ShowErr        error
+	InProgressList []Bead
+	InProgressErr  error
 }
 
 func (f *fakeBeadRunner) Ready(ctx context.Context) ([]Bead, error) {
@@ -56,11 +56,11 @@ func (g fakeGrep) Grep(ctx context.Context, pattern string, roots []string) ([]s
 // TestStep1ShapeFilter exercises the operator-shape skip behavior.
 func TestStep1ShapeFilter(t *testing.T) {
 	tests := []struct {
-		name        string
-		beads       []Bead
-		includeOps  bool
-		wantID      string
-		wantAlts    []string
+		name       string
+		beads      []Bead
+		includeOps bool
+		wantID     string
+		wantAlts   []string
 	}{
 		{
 			name: "filters operator-shape by default",
@@ -83,9 +83,9 @@ func TestStep1ShapeFilter(t *testing.T) {
 			wantAlts:   []string{"soc-b"},
 		},
 		{
-			name:    "empty when nothing ready",
-			beads:   nil,
-			wantID:  "",
+			name:   "empty when nothing ready",
+			beads:  nil,
+			wantID: "",
 		},
 		{
 			name: "all filtered returns empty",

--- a/cli/internal/goals/measure_test.go
+++ b/cli/internal/goals/measure_test.go
@@ -567,9 +567,9 @@ func TestComputeSummary_CodeDrivenAndRuntimeArtifactSplit(t *testing.T) {
 	// Mixed corpus: two code-driven (one pass, one fail), two
 	// runtime-artifact (one pass, one fail), one skip in each lane.
 	summary := computeSummary([]Measurement{
-		{Result: resultPass, Weight: 6}, // code-driven pass
-		{Result: resultFail, Weight: 8}, // code-driven fail
-		{Result: resultSkip, Weight: 3}, // code-driven skip
+		{Result: resultPass, Weight: 6},                                     // code-driven pass
+		{Result: resultFail, Weight: 8},                                     // code-driven fail
+		{Result: resultSkip, Weight: 3},                                     // code-driven skip
 		{Result: resultPass, Weight: 4, Tags: []string{"runtime-artifact"}}, // RA pass
 		{Result: resultFail, Weight: 4, Tags: []string{"runtime-artifact"}}, // RA fail
 	})

--- a/cli/internal/knowledge/parse_test.go
+++ b/cli/internal/knowledge/parse_test.go
@@ -8,10 +8,10 @@ import (
 
 func TestParseBuilderMetadata(t *testing.T) {
 	tests := []struct {
-		name   string
-		input  string
-		want   map[string]string
-		isNil  bool
+		name  string
+		input string
+		want  map[string]string
+		isNil bool
 	}{
 		{
 			name:  "key=value pairs",

--- a/cli/internal/verdictledger/gap_test.go
+++ b/cli/internal/verdictledger/gap_test.go
@@ -24,10 +24,10 @@ func TestValidDirectiveID_Boundaries(t *testing.T) {
 		{"d-123", true},
 		// Invalid: missing prefix, uppercase, spaces, leading digit after d-
 		{"", false},
-		{"dx", false},       // no hyphen
-		{"D-x", false},      // uppercase
-		{"d-X", false},      // uppercase body
-		{"d- x", false},     // space
+		{"dx", false},           // no hyphen
+		{"D-x", false},          // uppercase
+		{"d-X", false},          // uppercase body
+		{"d- x", false},         // space
 		{"reduce-flaky", false}, // no d- prefix
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Mechanical `gofmt -w` across `cli/` — fixes the 14 unformatted files surfaced by the **ag-tcf0** Go-cohesion audit. No logic change (diff is whitespace/grouping only; `git diff -w` is ~empty).

## Verification
- `gofmt -l cli/` → empty
- `go build ./...` → passes
- Rebased onto current `origin/main`

Closes-scenario: ag-ozac#gofmt-sweep
Bounded-context: BC5-Runtime
Evidence: cli/internal/eval/types.go