### PR TITLE
refactor(cli): decouple mine.go + handoff.go from rpi symbols (ag-362v #decouple)

### DIFF
--- a/cli/cmd/ao/c2_event_reader.go
+++ b/cli/cmd/ao/c2_event_reader.go
@@ -1,0 +1,73 @@
+// practices: [agile-manifesto, dora-metrics]
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// RPIC2Event is one normalized C2/runtime event stored in a run's events.jsonl.
+//
+// The type and its reader (loadRPIC2Events) live outside the rpi command
+// surface so mine.go can read historical run-event logs after the rpi engine
+// is removed. The writer (appendRPIC2Event) stays with the rpi engine and is
+// deleted with it. (ag-362v / ag-llni)
+type RPIC2Event struct {
+	SchemaVersion int             `json:"schema_version"`
+	EventID       string          `json:"event_id"`
+	RunID         string          `json:"run_id"`
+	CommandID     string          `json:"command_id,omitempty"`
+	Phase         int             `json:"phase,omitempty"`
+	Backend       string          `json:"backend,omitempty"`
+	Source        string          `json:"source,omitempty"`
+	WorkerID      string          `json:"worker_id,omitempty"`
+	Type          string          `json:"type"`
+	Message       string          `json:"message,omitempty"`
+	Details       json.RawMessage `json:"details,omitempty"`
+	Timestamp     string          `json:"timestamp"`
+}
+
+// loadRPIC2Events reads the normalized C2 event log for a run from
+// <root>/.agents/rpi/runs/<runID>/events.jsonl. A missing file returns
+// (nil, nil). The path is computed inline so this reader carries no dependency
+// on the rpi command surface (mirrors internal/rpi.RPIRunRegistryDir).
+func loadRPIC2Events(root, runID string) ([]RPIC2Event, error) {
+	if root == "" || runID == "" {
+		return nil, nil
+	}
+	path := filepath.Join(root, ".agents", "rpi", "runs", runID, "events.jsonl")
+	file, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open events log: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 128*1024), 2*1024*1024)
+	out := make([]RPIC2Event, 0)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var ev RPIC2Event
+		if err := json.Unmarshal(line, &ev); err != nil {
+			return nil, fmt.Errorf("parse events.jsonl line %d: %w", lineNum, err)
+		}
+		out = append(out, ev)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan events.jsonl: %w", err)
+	}
+	return out, nil
+}

--- a/cli/cmd/ao/c2_event_reader.go
+++ b/cli/cmd/ao/c2_event_reader.go
@@ -37,7 +37,7 @@ type RPIC2Event struct {
 // (nil, nil). The path is computed inline so this reader carries no dependency
 // on the rpi command surface (mirrors internal/rpi.RPIRunRegistryDir).
 func loadRPIC2Events(root, runID string) ([]RPIC2Event, error) {
-	if root == "" || runID == "" {
+	if runID == "" {
 		return nil, nil
 	}
 	path := filepath.Join(root, ".agents", "rpi", "runs", runID, "events.jsonl")

--- a/cli/cmd/ao/c2_event_reader_test.go
+++ b/cli/cmd/ao/c2_event_reader_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadRPIC2Events_ReadsRunEventLog(t *testing.T) {
+	root := t.TempDir()
+	runID := "run-abc123"
+	runDir := filepath.Join(root, ".agents", "rpi", "runs", runID)
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatalf("mkdir run dir: %v", err)
+	}
+	// Two valid events + a blank line that must be skipped.
+	content := `{"schema_version":1,"event_id":"e1","run_id":"run-abc123","type":"phase_start","timestamp":"2026-06-04T00:00:00Z"}
+
+{"schema_version":1,"event_id":"e2","run_id":"run-abc123","type":"error","message":"boom","timestamp":"2026-06-04T00:01:00Z"}
+`
+	if err := os.WriteFile(filepath.Join(runDir, "events.jsonl"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write events.jsonl: %v", err)
+	}
+
+	events, err := loadRPIC2Events(root, runID)
+	if err != nil {
+		t.Fatalf("loadRPIC2Events: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].Type != "phase_start" || events[0].EventID != "e1" {
+		t.Errorf("event[0] mismatch: got type=%q id=%q", events[0].Type, events[0].EventID)
+	}
+	if events[1].Type != "error" || events[1].Message != "boom" {
+		t.Errorf("event[1] mismatch: got type=%q message=%q", events[1].Type, events[1].Message)
+	}
+}
+
+func TestLoadRPIC2Events_MissingFileIsEmpty(t *testing.T) {
+	events, err := loadRPIC2Events(t.TempDir(), "no-such-run")
+	if err != nil {
+		t.Fatalf("expected nil error for missing log, got %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events for missing log, got %d", len(events))
+	}
+}
+
+func TestLoadRPIC2Events_EmptyRunIDReturnsNil(t *testing.T) {
+	events, err := loadRPIC2Events(t.TempDir(), "")
+	if err != nil || events != nil {
+		t.Fatalf("expected (nil,nil) for empty runID, got (%v,%v)", events, err)
+	}
+}

--- a/cli/cmd/ao/c2_event_reader_test.go
+++ b/cli/cmd/ao/c2_event_reader_test.go
@@ -50,18 +50,9 @@ func TestLoadRPIC2Events_EmptyRootReadsRelativeRunEventLog(t *testing.T) {
 		t.Fatalf("write events.jsonl: %v", err)
 	}
 
-	previous, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("get cwd: %v", err)
-	}
-	if err := os.Chdir(root); err != nil {
-		t.Fatalf("chdir temp root: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(previous); err != nil {
-			t.Fatalf("restore cwd: %v", err)
-		}
-	})
+	// t.Chdir resolves the relative ("") root and auto-restores cwd at test
+	// end — the test-isolation ratchet's preferred helper over raw os.Chdir.
+	t.Chdir(root)
 
 	events, err := loadRPIC2Events("", runID)
 	if err != nil {

--- a/cli/cmd/ao/c2_event_reader_test.go
+++ b/cli/cmd/ao/c2_event_reader_test.go
@@ -37,6 +37,44 @@ func TestLoadRPIC2Events_ReadsRunEventLog(t *testing.T) {
 	}
 }
 
+func TestLoadRPIC2Events_EmptyRootReadsRelativeRunEventLog(t *testing.T) {
+	root := t.TempDir()
+	runID := "run-relative"
+	runDir := filepath.Join(root, ".agents", "rpi", "runs", runID)
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatalf("mkdir run dir: %v", err)
+	}
+	content := `{"schema_version":1,"event_id":"e1","run_id":"run-relative","type":"phase_start","timestamp":"2026-06-04T00:00:00Z"}
+`
+	if err := os.WriteFile(filepath.Join(runDir, "events.jsonl"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write events.jsonl: %v", err)
+	}
+
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir temp root: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(previous); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+
+	events, err := loadRPIC2Events("", runID)
+	if err != nil {
+		t.Fatalf("loadRPIC2Events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].RunID != runID || events[0].EventID != "e1" {
+		t.Errorf("event mismatch: got runID=%q id=%q", events[0].RunID, events[0].EventID)
+	}
+}
+
 func TestLoadRPIC2Events_MissingFileIsEmpty(t *testing.T) {
 	events, err := loadRPIC2Events(t.TempDir(), "no-such-run")
 	if err != nil {

--- a/cli/cmd/ao/rpi_c2_events.go
+++ b/cli/cmd/ao/rpi_c2_events.go
@@ -20,21 +20,9 @@ const (
 	rpiC2EventsFileName     = "events.jsonl"
 )
 
-// RPIC2Event is one normalized C2/runtime event stored in events.jsonl.
-type RPIC2Event struct {
-	SchemaVersion int             `json:"schema_version"`
-	EventID       string          `json:"event_id"`
-	RunID         string          `json:"run_id"`
-	CommandID     string          `json:"command_id,omitempty"`
-	Phase         int             `json:"phase,omitempty"`
-	Backend       string          `json:"backend,omitempty"`
-	Source        string          `json:"source,omitempty"`
-	WorkerID      string          `json:"worker_id,omitempty"`
-	Type          string          `json:"type"`
-	Message       string          `json:"message,omitempty"`
-	Details       json.RawMessage `json:"details,omitempty"`
-	Timestamp     string          `json:"timestamp"`
-}
+// RPIC2Event (type) and loadRPIC2Events (reader) moved to c2_event_reader.go
+// (ag-362v) so mine.go keeps reading run event logs after the rpi engine is
+// removed. The writer (appendRPIC2Event) below stays with the rpi engine.
 
 type rpiC2EventInput struct {
 	RunID     string
@@ -151,42 +139,6 @@ func mirrorRootsForEvent(root, runID string) []string {
 		out = append(out, clean)
 	}
 	return out
-}
-
-func loadRPIC2Events(root, runID string) ([]RPIC2Event, error) {
-	path := rpiC2EventsPath(root, runID)
-	if path == "" {
-		return nil, nil
-	}
-	file, err := os.Open(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("open events log: %w", err)
-	}
-	defer func() { _ = file.Close() }()
-
-	scanner := bufio.NewScanner(file)
-	scanner.Buffer(make([]byte, 0, 128*1024), 2*1024*1024)
-	out := make([]RPIC2Event, 0)
-	lineNum := 0
-	for scanner.Scan() {
-		lineNum++
-		line := bytes.TrimSpace(scanner.Bytes())
-		if len(line) == 0 {
-			continue
-		}
-		var ev RPIC2Event
-		if err := json.Unmarshal(line, &ev); err != nil {
-			return nil, fmt.Errorf("parse events.jsonl line %d: %w", lineNum, err)
-		}
-		out = append(out, ev)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan events.jsonl: %w", err)
-	}
-	return out, nil
 }
 
 func appendRPIC2WorkerLogEvents(root, runID string, phaseNum int, backend, workerID, logPath string) error {

--- a/cli/cmd/ao/rpi_parallel.go
+++ b/cli/cmd/ao/rpi_parallel.go
@@ -577,8 +577,7 @@ func resolveMergeOrder(epics []parallelEpic, results []parallelResult) []int {
 // goalSlug delegates to internal/rpi.GoalSlug.
 func goalSlug(goal string) string { return cliRPI.GoalSlug(goal) }
 
-// shellQuote delegates to internal/rpi.ShellQuote.
-func shellQuote(s string) string { return cliRPI.ShellQuote(s) }
+// shellQuote moved to shell_quote.go (ag-362v) so it outlives the rpi removal.
 
 // tmuxPaneIsDead checks whether a tmux pane has exited.
 // Returns (dead, exitCode). If the pane/window is gone, returns (true, 1).

--- a/cli/cmd/ao/shell_quote.go
+++ b/cli/cmd/ao/shell_quote.go
@@ -1,0 +1,13 @@
+// practices: [agile-manifesto]
+package main
+
+import "strings"
+
+// shellQuote wraps a string in POSIX single quotes, escaping any embedded
+// single quotes, so it is safe to embed in a /bin/sh command line.
+//
+// Relocated out of the rpi command surface (was rpi_parallel.go) so it survives
+// the ao-rpi removal: handoff.go depends on it. (ag-362v / ag-llni)
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}


### PR DESCRIPTION
**Prerequisite for removing `ao rpi` / `ao evolve`** (epic ag-llni / soc-1gbpz). Operator directive: out-of-session orchestration moves to the substrate (NTM + background agents + `/discovery`); the in-CLI loop engines are removed.

A full-repo map confirmed the **only 2 non-rpi/evolve production callers** of rpi symbols:
- `mine.go` → `RPIC2Event` + `loadRPIC2Events`
- `handoff.go` → `shellQuote`

This PR relocates both into files that survive the `rpi*.go` deletion glob, **zero behavior change**:
- **`shell_quote.go`** — POSIX single-quote helper moved out of `rpi_parallel.go` (body inlined, drops the `internal/rpi.ShellQuote` hop). Both `handoff.go` and `rpi_parallel.go` keep using it.
- **`c2_event_reader.go`** — `RPIC2Event` type + `loadRPIC2Events` reader moved out of `rpi_c2_events.go` (events.jsonl path inlined to mirror `internal/rpi.RPIRunRegistryDir`). `mine.go` unchanged; the rpi-internal **writer** `appendRPIC2Event` stays and is deleted with the engine.

After this, **nothing outside `rpi*.go`/`evolve*.go` references any rpi-internal symbol** — the engine deletion (next PR) is unblocked.

## Verification
- `go build ./...` + `go vet` clean
- 3 new reader tests + 21 existing handoff/mine/c2/shellQuote tests pass
- `rg` confirms `mine.go`/`handoff.go` carry no rpi-internal symbol refs

Closes-scenario: ag-362v#decouple
Bounded-context: BC5-Runtime
Evidence: cli/cmd/ao/c2_event_reader.go