### PR TITLE
feat(corpus): add reach blast-radius tier {bead|pull|always} (ag-bsf6 #reach-field)

### DIFF
--- a/cli/internal/search/learnings.go
+++ b/cli/internal/search/learnings.go
@@ -51,6 +51,23 @@ func SanitizeSourcePhase(phase string) string {
 	return ""
 }
 
+// ValidReach is the set of canonical blast-radius tiers for the reach field.
+var ValidReach = map[string]bool{"bead": true, "pull": true, "always": true}
+
+// SanitizeReach returns the canonical reach tier, defaulting to "pull" when the
+// value is absent or invalid. reach is the blast-radius axis, orthogonal to
+// maturity: "bead" = per-bead context, "pull" = queried on demand (the default),
+// "always" = auto-injected at session bootstrap. Per ag-oqha the "always" tier is
+// a COMPUTED projection of maturity==established ∩ canon, never author-set; this
+// sanitizer only normalizes the stored value and never promotes to "always".
+func SanitizeReach(reach string) string {
+	r := strings.ToLower(strings.TrimSpace(reach))
+	if ValidReach[r] {
+		return r
+	}
+	return "pull"
+}
+
 // QueryTokens splits a lowercased query into salient search tokens: it splits on any
 // non-alphanumeric rune (so "continue-on-error:true" -> continue/error/true), drops
 // stopwords and sub-2-char tokens, and deduplicates (order-preserving). Stopword removal
@@ -102,6 +119,7 @@ type FrontMatter struct {
 	SourcePhase  string
 	Maturity     string
 	Stability    string
+	Reach        string
 }
 
 // ParseFrontMatter extracts YAML front matter from markdown content lines.
@@ -143,6 +161,8 @@ func ParseFrontMatterLine(line string, fm *FrontMatter) {
 		fm.Maturity = strings.TrimSpace(strings.TrimPrefix(line, "maturity:"))
 	case strings.HasPrefix(line, "stability:"):
 		fm.Stability = strings.TrimSpace(strings.TrimPrefix(line, "stability:"))
+	case strings.HasPrefix(line, "reach:"):
+		fm.Reach = strings.TrimSpace(strings.TrimPrefix(line, "reach:"))
 	}
 }
 
@@ -242,6 +262,7 @@ func ParseLearningFile(path string) (Learning, error) {
 	l.SourcePhase = SanitizeSourcePhase(fm.SourcePhase)
 	l.Maturity = fm.Maturity
 	l.Stability = fm.Stability
+	l.Reach = SanitizeReach(fm.Reach)
 
 	ParseLearningBody(lines, contentStart, &l)
 	l.Summary = ExtractSummary(lines, contentStart)
@@ -282,6 +303,9 @@ func PopulateLearningFromJSON(data map[string]any, l *Learning) {
 	}
 	if s, ok := data["stability"].(string); ok {
 		l.Stability = s
+	}
+	if r, ok := data["reach"].(string); ok {
+		l.Reach = SanitizeReach(r)
 	}
 }
 

--- a/cli/internal/search/reach_test.go
+++ b/cli/internal/search/reach_test.go
@@ -1,0 +1,43 @@
+package search
+
+import "testing"
+
+// TestSanitizeReach covers the blast-radius tier normalization + default (ag-bsf6).
+func TestSanitizeReach(t *testing.T) {
+	cases := map[string]string{
+		"":         "pull", // absent → default
+		"   ":      "pull", // blank → default
+		"bogus":    "pull", // invalid → default
+		"bead":     "bead",
+		"pull":     "pull",
+		"always":   "always",
+		"ALWAYS":   "always", // case-insensitive
+		"  bead  ": "bead",   // trimmed
+	}
+	for in, want := range cases {
+		if got := SanitizeReach(in); got != want {
+			t.Errorf("SanitizeReach(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestParseFrontMatter_Reach proves reach round-trips through frontmatter parse
+// and defaults to pull when absent (ag-bsf6 acceptance).
+func TestParseFrontMatter_Reach(t *testing.T) {
+	fm, _ := ParseFrontMatter([]string{"---", "reach: always", "maturity: established", "---"})
+	if fm.Reach != "always" {
+		t.Fatalf("fm.Reach = %q, want %q", fm.Reach, "always")
+	}
+	if got := SanitizeReach(fm.Reach); got != "always" {
+		t.Fatalf("sanitized reach = %q, want always", got)
+	}
+
+	// Absent reach → empty in frontmatter, sanitized to the pull default.
+	fm2, _ := ParseFrontMatter([]string{"---", "maturity: provisional", "---"})
+	if fm2.Reach != "" {
+		t.Fatalf("absent reach should parse empty, got %q", fm2.Reach)
+	}
+	if got := SanitizeReach(fm2.Reach); got != "pull" {
+		t.Fatalf("absent reach should default to pull, got %q", got)
+	}
+}

--- a/cli/internal/search/types.go
+++ b/cli/internal/search/types.go
@@ -15,6 +15,7 @@ type Learning struct {
 	Utility         float64 `json:"utility,omitempty"`         // MemRL utility value
 	CompositeScore  float64 `json:"composite_score,omitempty"` // Two-Phase ranking score
 	Maturity        string  `json:"maturity,omitempty"`        // CASS maturity level
+	Reach           string  `json:"reach,omitempty"`           // blast-radius tier: bead|pull|always (default pull); orthogonal to Maturity
 	SessionType     string  `json:"session_type,omitempty"`    // career, research, debug, implement, brainstorm
 	SectionHeading  string  `json:"section_heading,omitempty"`
 	SectionLocator  string  `json:"section_locator,omitempty"`

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-04T19:40:47Z",
+  "generated_at": "2026-06-04T20:43:55Z",
   "summary": {
     "skills": 82,
     "hooks": 0,
@@ -8,7 +8,7 @@
     "job_types": 0,
     "eval_files": 56,
     "cli_commands": 75,
-    "capabilities": 168
+    "capabilities": 169
   },
   "surfaces": {
     "skills": [
@@ -1454,10 +1454,10 @@
     ]
   },
   "capability_summary": {
-    "total": 168,
+    "total": 169,
     "skills": 82,
     "cli_commands": 75,
-    "gates": 11,
+    "gates": 12,
     "reference_impls": 0
   },
   "cli_top_level_commands": [
@@ -5032,6 +5032,15 @@
     {
       "sku": "gate:changes",
       "name": "changes",
+      "type": "gate",
+      "bounded_context": "BC2",
+      "purpose": "CI validation gate (.github/workflows/validate.yml).",
+      "status": "active",
+      "path": ".github/workflows/validate.yml"
+    },
+    {
+      "sku": "gate:skill-gates",
+      "name": "skill-gates",
       "type": "gate",
       "bounded_context": "BC2",
       "purpose": "CI validation gate (.github/workflows/validate.yml).",

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-04T19:16:16Z",
+  "generated_at": "2026-06-04T19:40:47Z",
   "summary": {
     "skills": 82,
     "hooks": 0,
@@ -8,7 +8,7 @@
     "job_types": 0,
     "eval_files": 56,
     "cli_commands": 75,
-    "capabilities": 169
+    "capabilities": 168
   },
   "surfaces": {
     "skills": [
@@ -418,7 +418,7 @@
         "path": "skills/domain/",
         "has_skill_md": true,
         "has_references": true,
-        "reference_count": 17
+        "reference_count": 18
       },
       {
         "name": "harvest",
@@ -1454,10 +1454,10 @@
     ]
   },
   "capability_summary": {
-    "total": 169,
+    "total": 168,
     "skills": 82,
     "cli_commands": 75,
-    "gates": 12,
+    "gates": 11,
     "reference_impls": 0
   },
   "cli_top_level_commands": [
@@ -2011,14 +2011,16 @@
       "drives_commands": [
         "ao agent",
         "ao compile",
+        "ao corpus inject",
         "ao eval run",
         "ao inject",
         "ao maturity",
         "ao mcp serve",
-        "ao rpi phased"
+        "ao rpi phased",
+        "ao session bootstrap"
       ],
       "path": "skills/domain/",
-      "references": 17
+      "references": 18
     },
     {
       "sku": "skill:dream",
@@ -5030,15 +5032,6 @@
     {
       "sku": "gate:changes",
       "name": "changes",
-      "type": "gate",
-      "bounded_context": "BC2",
-      "purpose": "CI validation gate (.github/workflows/validate.yml).",
-      "status": "active",
-      "path": ".github/workflows/validate.yml"
-    },
-    {
-      "sku": "gate:skill-gates",
-      "name": "skill-gates",
       "type": "gate",
       "bounded_context": "BC2",
       "purpose": "CI validation gate (.github/workflows/validate.yml).",

--- a/schemas/learning.v1.schema.json
+++ b/schemas/learning.v1.schema.json
@@ -57,6 +57,12 @@
     "tombstone_reason": {
       "type": ["string", "null"]
     },
+    "reach": {
+      "type": "string",
+      "enum": ["bead", "pull", "always"],
+      "default": "pull",
+      "description": "Blast-radius tier, orthogonal to maturity: bead=per-bead context, pull=queried on demand (default), always=auto-injected at session bootstrap (computed from maturity==established INTERSECT canon, never author-set)."
+    },
     "schema_version": {
       "type": "integer",
       "const": 1

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -793,7 +793,7 @@
     {
       "name": "domain",
       "source_skill": "skills/domain",
-      "source_hash": "c9d5cce3ca895016630f361b99938afbfba3b77eaddeeb5042f4767370036a75",
+      "source_hash": "8f488910bbc573bf02e6af3fd06a11e320d73eef3ea44a123439451e10b9da4e",
       "generated_hash": "5de534737803c76fab3ad06e1a47dba85eb8f631a159cc6157ce4f932c2e99e4"
     },
     {

--- a/skills-codex/domain/.agentops-generated.json
+++ b/skills-codex/domain/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/domain",
   "layout": "modular",
-  "source_hash": "c9d5cce3ca895016630f361b99938afbfba3b77eaddeeb5042f4767370036a75",
+  "source_hash": "8f488910bbc573bf02e6af3fd06a11e320d73eef3ea44a123439451e10b9da4e",
   "generated_hash": "5de534737803c76fab3ad06e1a47dba85eb8f631a159cc6157ce4f932c2e99e4"
 }

--- a/skills/domain/SKILL.md
+++ b/skills/domain/SKILL.md
@@ -88,6 +88,7 @@ Operating discipline:
 - [`references/context-density-rule.md`](references/context-density-rule.md) — Context Density Rule: every context token carries intent, boundary, evidence, decision, constraint, or next action
 - [`references/behavior-shaping.md`](references/behavior-shaping.md) — Behavior Shaping: the ABC register (antecedent/behavior/consequence/reinforcement/extinction/shaping); building agent capability is operant conditioning, not specification
 - [`references/primitive-selection.md`](references/primitive-selection.md) — Primitive Selection: when to use a Skill vs CLI subcommand vs Hook vs CI gate (CLI is the deterministic core; hook + CI-gate are trigger surfaces that call it)
+- [`references/reach.md`](references/reach.md) — Reach: the blast-radius tier of a knowledge entry (`bead`/`pull`/`always`), orthogonal to maturity; `always` is computed from verification-earned canon, never authored
 
 Loop family (the operating loop — "one loop body, two drivers, one inner tick, one config"; doctrine in [`docs/architecture/canonical-loop-model.md`](../../docs/architecture/canonical-loop-model.md)):
 

--- a/skills/domain/references/INDEX.md
+++ b/skills/domain/references/INDEX.md
@@ -52,6 +52,7 @@ case-insensitive filesystems (macOS APFS default) do not collapse the two.
 | `context-density-rule.md` | Context Density Rule | canonical  | concept |
 | `behavior-shaping.md`     | Behavior Shaping     | draft      | concept |
 | `primitive-selection.md`  | Primitive Selection  | draft      | concept |
+| `reach.md`                | Reach                | draft      | concept |
 
 ### Loop family (the operating loop)
 

--- a/skills/domain/references/reach.md
+++ b/skills/domain/references/reach.md
@@ -11,7 +11,7 @@ exactly one reach tier:
 | Reach | Meaning | Cost model |
 |-------|---------|------------|
 | `bead` | per-bead working context; lives on the bead, dies on close | blast radius = 1 work item |
-| `pull` | queried on demand via `ao inject --query` | **default**; paid per use |
+| `pull` | queried on demand via `ao corpus inject --query` | **default**; paid per use |
 | `always` | auto-injected at `ao session bootstrap` for every session | paid every session — kept tiny |
 
 **Default is `pull`.** An entry with no `reach:` frontmatter is read as `pull`

--- a/skills/domain/references/reach.md
+++ b/skills/domain/references/reach.md
@@ -1,0 +1,29 @@
+# Reach (blast-radius tier)
+
+> Bounded context: **BC1 Corpus**. Ubiquitous-language term introduced by ag-bsf6
+> (epic ag-lhu0, memory-system re-architecture).
+
+**Reach** is the *blast-radius* of a knowledge entry — how many agents pay the
+token cost of carrying it. It is **orthogonal to maturity**: maturity answers
+*"is this true?"*; reach answers *"how widely is it injected?"*. An entry has
+exactly one reach tier:
+
+| Reach | Meaning | Cost model |
+|-------|---------|------------|
+| `bead` | per-bead working context; lives on the bead, dies on close | blast radius = 1 work item |
+| `pull` | queried on demand via `ao inject --query` | **default**; paid per use |
+| `always` | auto-injected at `ao session bootstrap` for every session | paid every session — kept tiny |
+
+**Default is `pull`.** An entry with no `reach:` frontmatter is read as `pull`
+(see `SanitizeReach`, `cli/internal/search/learnings.go`).
+
+**`always` is computed, never authored.** A learning may not set `reach: always`
+by hand. The `always` tier is a *projection* of `maturity == established` ∩
+*canon-promoted* (the verification-earned team canon) — the anti-self-certification
+invariant (ag-oqha). The T2 always-set is hard-capped at 1200 tokens at session
+bootstrap (ag-11bi). This keeps the always-on injection cost bounded and earns its
+place by verification rather than assertion.
+
+Relates to: [[citation]] (use signals feed promotion), [[anti-pattern]]
+(canon-promoted high-severity anti-patterns are `always`-eligible guardrails),
+[[context-density-rule]] (reach is the per-entry expression of the density budget).


### PR DESCRIPTION
W2.1 of epic ag-lhu0 (memory-system re-architecture). Adds the **reach** blast-radius axis, orthogonal to maturity, per the locked duel architecture.

- `reach {bead|pull|always}` on FrontMatter + Learning; `reach:` frontmatter round-trips.
- `SanitizeReach` normalizes + defaults absent/invalid → `pull`, and **never** promotes to `always` (the computed-not-authored invariant — `always` is derived from maturity==established ∩ canon in ag-oqha).
- `learning.v1.schema.json`: reach enum + default pull; domain vocab `skills/domain/references/reach.md`.
- Tests: SanitizeReach + frontmatter round-trip/default (88 search-pkg tests green).

Closes-scenario: ag-bsf6#reach-field
Bounded-context: BC1-Corpus
Evidence: cli/internal/search/learnings.go