### PR TITLE
feat(skills): add scan_descriptions --probe deterministic trigger ranker (ag-7led #trigger-probe)

### DIFF
--- a/schemas/skill-frontmatter.v2.schema.json
+++ b/schemas/skill-frontmatter.v2.schema.json
@@ -22,6 +22,11 @@
       "enum": ["domain", "driving-adapter", "driven-adapter", "supporting", "generic"],
       "description": "REQUIRED: which hexagonal-architecture role this skill plays. Enforces the DDD/hex layer cannot drift silently (registries-drift lesson, 2026-05-17)."
     },
+    "trigger_probes": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "OPTIONAL: deterministic lexical trigger phrases this skill must rank #1 for under scan_descriptions.py --probe. Each phrase is a self-declared selection cue; the probe asserts the skill wins its own phrases against the corpus without a live model."
+    },
     "consumes": {
       "type": "array",
       "items": {"type": "string", "description": "artifact-kind or skill slug"}

--- a/skills/skill-builder/scripts/scan_descriptions.py
+++ b/skills/skill-builder/scripts/scan_descriptions.py
@@ -15,11 +15,19 @@ a missing trigger phrase is a material skill-selection risk, not cosmetic. See
 
 Usage:
     python3 scan_descriptions.py [SKILLS_DIR] [--json] [--strict] [--quiet]
+    python3 scan_descriptions.py [SKILLS_DIR] --probe "<phrase>" [--json]
+
+Probe mode (`--probe "<phrase>"`) ranks every skill against the phrase using
+ONLY the deterministic lexical ranker below — no live model, no `claude -p`, no
+network — and asserts the skill that DECLARES the phrase in its
+`trigger_probes:` frontmatter list ranks #1. Output is byte-stable across runs.
 
 Exit codes:
-    0  every description carries a trigger (or --strict not set)
-    1  one or more descriptions lack a trigger AND --strict is set
-    2  usage error (skills dir not found)
+    0  every description carries a trigger (or --strict not set);
+       in --probe mode: the declaring skill ranks #1 for the phrase
+    1  one or more descriptions lack a trigger AND --strict is set;
+       in --probe mode: the declaring skill does NOT rank #1
+    2  usage error (skills dir not found, or no skill declares the phrase)
 """
 
 from __future__ import annotations
@@ -121,6 +129,144 @@ def count_trigger_list(frontmatter: str) -> int:
             if re.match(r"^\s*[A-Za-z_-]+:", line):
                 break
     return count
+
+
+def parse_trigger_probes(frontmatter: str) -> list[str]:
+    """Return the items under a top-level `trigger_probes:` YAML list.
+
+    Supports the flow form (`trigger_probes: ["a", "b"]`) and the block form
+    (`trigger_probes:` followed by indented `- item` lines). Quotes are
+    stripped; order is preserved. Purely lexical — no YAML library required so
+    the scanner stays dependency-free and deterministic.
+    """
+    lines = frontmatter.splitlines()
+    probes: list[str] = []
+    for idx, line in enumerate(lines):
+        flow = re.match(r"^trigger_probes:\s*\[(.*)\]\s*$", line)
+        if flow:
+            inner = flow.group(1).strip()
+            if inner:
+                for item in inner.split(","):
+                    cleaned = item.strip().strip("'\"").strip()
+                    if cleaned:
+                        probes.append(cleaned)
+            return probes
+        if re.match(r"^trigger_probes:\s*$", line):
+            for follow in lines[idx + 1 :]:
+                item = re.match(r"^\s+-\s+(.*)$", follow)
+                if item:
+                    cleaned = item.group(1).strip().strip("'\"").strip()
+                    if cleaned:
+                        probes.append(cleaned)
+                    continue
+                if re.match(r"^\S", follow):
+                    break
+            return probes
+    return probes
+
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokens(text: str) -> list[str]:
+    """Lowercase alphanumeric tokens, in order, for deterministic scoring."""
+    return _WORD_RE.findall(text.lower())
+
+
+def lexical_score(phrase: str, scan: SkillScan) -> tuple:
+    """Deterministic lexical relevance of one skill to a probe phrase.
+
+    Pure token math over the skill's own SEARCHABLE TEXT (name + description) —
+    no model, no network, and deliberately NOT a function of the skill's
+    `trigger_probes:` declaration. The declaration only identifies *which*
+    skill is expected to win; the ranking itself is earned purely by lexical
+    overlap, so a skill that stops describing its phrase genuinely drops in
+    rank. Returns a tuple sort key (higher is more relevant); ties break by
+    name so the ranking is total and byte-stable. Signals, in priority order:
+
+    1. fraction of phrase tokens present in the searchable text (coverage),
+    2. raw count of phrase-token hits,
+    3. name-token overlap (a phrase word that is also a name word).
+    """
+    phrase_tokens = _tokens(phrase)
+    name_tokens = set(_tokens(scan.name))
+    haystack = " ".join([scan.name, scan.description])
+    hay_tokens = _tokens(haystack)
+    hay_set = set(hay_tokens)
+
+    if phrase_tokens:
+        present = sum(1 for t in phrase_tokens if t in hay_set)
+        coverage = present / len(phrase_tokens)
+        hits = sum(hay_tokens.count(t) for t in set(phrase_tokens))
+    else:
+        coverage = 0.0
+        hits = 0
+    name_overlap = sum(1 for t in set(phrase_tokens) if t in name_tokens)
+    return (coverage, hits, name_overlap)
+
+
+@dataclass
+class ProbeResult:
+    """One skill's deterministic rank for a probe phrase."""
+
+    name: str
+    score_key: tuple
+    declares_phrase: bool
+
+    def to_dict(self) -> dict:
+        """JSON-serializable view (score_key as a list for stable output)."""
+        return {
+            "name": self.name,
+            "score_key": list(self.score_key),
+            "declares_phrase": self.declares_phrase,
+        }
+
+
+def probe_corpus(skills_dir: Path, phrase: str) -> list[ProbeResult]:
+    """Rank every skill against `phrase` using the deterministic lexical ranker.
+
+    Sorted by descending score, then ascending name — a total, byte-stable
+    order. Each result records whether that skill declares the phrase in its
+    `trigger_probes:` list.
+    """
+    ranked: list[ProbeResult] = []
+    for skill_md in sorted(skills_dir.glob("*/SKILL.md")):
+        scan = scan_skill(skill_md)
+        if scan is None:
+            continue
+        frontmatter, _ = split_frontmatter(skill_md.read_text(encoding="utf-8"))
+        probes = parse_trigger_probes(frontmatter)
+        key = lexical_score(phrase, scan)
+        declares = phrase.strip().lower() in {p.strip().lower() for p in probes}
+        ranked.append(ProbeResult(name=scan.name, score_key=key, declares_phrase=declares))
+
+    def sort_key(result: ProbeResult) -> tuple:
+        # Descending score (negate the numeric components), ascending name.
+        return (tuple(-x for x in result.score_key), result.name)
+
+    ranked.sort(key=sort_key)
+    return ranked
+
+
+def render_probe(phrase: str, ranked: list[ProbeResult]) -> str:
+    """Render a deterministic human-readable probe report."""
+    declaring = [r.name for r in ranked if r.declares_phrase]
+    lines = [
+        "# Trigger probe",
+        "",
+        f"- Phrase: {phrase!r}",
+        f"- Skills ranked: {len(ranked)}",
+        f"- Declaring skills: {', '.join(declaring) if declaring else '(none)'}",
+        "",
+        "## Ranking (deterministic lexical, no model)",
+        "",
+        "| Rank | Skill | Declares | Score key |",
+        "|------|-------|----------|-----------|",
+    ]
+    for i, r in enumerate(ranked, start=1):
+        mark = "yes" if r.declares_phrase else ""
+        lines.append(f"| {i} | `{r.name}` | {mark} | {list(r.score_key)} |")
+    return "\n".join(lines)
 
 
 def detect_trigger(text: str, frontmatter: str) -> list[str]:
@@ -232,6 +378,37 @@ def render_markdown(results: list[SkillScan]) -> str:
     return "\n".join(lines)
 
 
+def _run_probe(skills_dir: Path, phrase: str, *, json_mode: bool, quiet: bool) -> int:
+    """Drive --probe: rank the corpus and assert the declaring skill wins.
+
+    Returns 2 if no skill declares the phrase (a usage error — nothing to
+    assert), 0 if the declaring skill ranks #1, 1 otherwise.
+    """
+    ranked = probe_corpus(skills_dir, phrase)
+    declaring = [r for r in ranked if r.declares_phrase]
+    top = ranked[0] if ranked else None
+    declarer_is_top = bool(top and top.declares_phrase)
+
+    if json_mode:
+        payload = {
+            "phrase": phrase,
+            "ranked": len(ranked),
+            "declaring": [r.name for r in declaring],
+            "top": top.name if top else None,
+            "declarer_is_top": declarer_is_top,
+            "skills": [r.to_dict() for r in ranked],
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    elif not quiet:
+        print(render_probe(phrase, ranked))
+
+    if not declaring:
+        if not json_mode:
+            print(f"error: no skill declares the probe phrase: {phrase!r}", file=sys.stderr)
+        return 2
+    return 0 if declarer_is_top else 1
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -246,12 +423,22 @@ def main(argv: list[str] | None = None) -> int:
         "--strict", action="store_true", help="Exit 1 if any description lacks a trigger"
     )
     parser.add_argument("--quiet", action="store_true", help="Suppress the human report")
+    parser.add_argument(
+        "--probe",
+        metavar="PHRASE",
+        default=None,
+        help="Deterministic lexical probe: assert the skill that declares PHRASE "
+        "in trigger_probes: ranks #1 (no live model, no network)",
+    )
     args = parser.parse_args(argv)
 
     skills_dir = Path(args.skills_dir)
     if not skills_dir.is_dir():
         print(f"error: skills dir not found: {skills_dir}", file=sys.stderr)
         return 2
+
+    if args.probe is not None:
+        return _run_probe(skills_dir, args.probe, json_mode=args.json, quiet=args.quiet)
 
     results = scan_corpus(skills_dir)
     missing = [r for r in results if not r.has_trigger]

--- a/skills/skill-builder/scripts/scan_descriptions.py
+++ b/skills/skill-builder/scripts/scan_descriptions.py
@@ -131,6 +131,39 @@ def count_trigger_list(frontmatter: str) -> int:
     return count
 
 
+def split_flow_items(inner: str) -> list[str]:
+    """Split a simple YAML flow sequence body without breaking quoted commas."""
+    items: list[str] = []
+    current: list[str] = []
+    quote = ""
+    i = 0
+    while i < len(inner):
+        char = inner[i]
+        if quote:
+            if char == "\\" and quote == '"' and i + 1 < len(inner):
+                current.append(inner[i + 1])
+                i += 2
+                continue
+            if char == quote:
+                if quote == "'" and i + 1 < len(inner) and inner[i + 1] == "'":
+                    current.append("'")
+                    i += 2
+                    continue
+                quote = ""
+            else:
+                current.append(char)
+        elif char in ("'", '"'):
+            quote = char
+        elif char == ",":
+            items.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+        i += 1
+    items.append("".join(current))
+    return items
+
+
 def parse_trigger_probes(frontmatter: str) -> list[str]:
     """Return the items under a top-level `trigger_probes:` YAML list.
 
@@ -146,7 +179,7 @@ def parse_trigger_probes(frontmatter: str) -> list[str]:
         if flow:
             inner = flow.group(1).strip()
             if inner:
-                for item in inner.split(","):
+                for item in split_flow_items(inner):
                     cleaned = item.strip().strip("'\"").strip()
                     if cleaned:
                         probes.append(cleaned)

--- a/tests/python/test_scan_descriptions.py
+++ b/tests/python/test_scan_descriptions.py
@@ -140,6 +140,16 @@ class TestCli(unittest.TestCase):
         code = scan.main([str(self.root / "does-not-exist")])
         self.assertEqual(code, 2)
 
+    def test_probe_flow_form_allows_quoted_commas(self):
+        _write_skill(
+            self.root,
+            "deploy",
+            'name: deploy\ndescription: Run ci cd deploy.\ntrigger_probes: ["ci, cd deploy"]',
+        )
+        with redirect_stdout(io.StringIO()):
+            code = scan.main([str(self.root), "--probe", "ci, cd deploy"])
+        self.assertEqual(code, 0)
+
     def test_json_output_reports_counts(self):
         _write_skill(self.root, "a", "name: a\ndescription: Plain.")
         _write_skill(self.root, "b", 'name: b\ndescription: X. Triggers: "b", "x".')

--- a/tests/scripts/scan-descriptions-probe.bats
+++ b/tests/scripts/scan-descriptions-probe.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+# scan-descriptions-probe.bats — the deterministic lexical trigger-probe mode
+# of skills/skill-builder/scripts/scan_descriptions.py (ag-7led).
+#
+# `--probe "<phrase>"` ranks every skill against the phrase using ONLY the
+# in-script lexical ranker (no live model, no `claude -p`, no network) and
+# asserts the skill that declares the phrase in its `trigger_probes:`
+# frontmatter list ranks #1. This spec proves the two acceptance properties:
+#   1. determinism — probe output is BYTE-IDENTICAL across two consecutive runs;
+#   2. rank-drop — mutating the declaring skill's description so it no longer
+#      matches the phrase drops it below rank #1.
+#
+# Hermetic: builds a throwaway fixture skills tree under BATS_TEST_TMPDIR and
+# points the scanner at it via its positional SKILLS_DIR arg. No repo state,
+# no network, no model.
+
+setup() {
+  ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  SCRIPT="$ROOT/skills/skill-builder/scripts/scan_descriptions.py"
+  FIX="$BATS_TEST_TMPDIR/skills"
+  mkdir -p "$FIX/widget-builder" "$FIX/widget-rival"
+
+  # Declaring skill: lists the phrase in trigger_probes AND describes it, so it
+  # earns rank #1 on pure lexical coverage.
+  cat > "$FIX/widget-builder/SKILL.md" <<'EOF'
+---
+name: widget-builder
+description: Build a custom widget on demand.
+trigger_probes:
+  - "build a custom widget"
+---
+# Widget Builder
+EOF
+
+  # Rival: mentions the same words but does NOT declare the phrase. It stays
+  # rank #2 while the declarer describes the phrase, and overtakes it once the
+  # declarer's description is mutated away.
+  cat > "$FIX/widget-rival/SKILL.md" <<'EOF'
+---
+name: widget-rival
+description: Build a custom widget faster and better than anyone.
+---
+# Widget Rival
+EOF
+}
+
+@test "probe: declaring skill ranks #1 for its own trigger phrase (exit 0)" {
+  run python3 "$SCRIPT" "$FIX" --probe "build a custom widget"
+  [ "$status" -eq 0 ]
+  # The first ranked row is the declaring skill, marked 'yes'.
+  echo "$output" | grep -q "| 1 | \`widget-builder\` | yes |"
+}
+
+@test "probe: output is BYTE-IDENTICAL across two consecutive runs (determinism)" {
+  python3 "$SCRIPT" "$FIX" --probe "build a custom widget" --json > "$BATS_TEST_TMPDIR/run1.json"
+  python3 "$SCRIPT" "$FIX" --probe "build a custom widget" --json > "$BATS_TEST_TMPDIR/run2.json"
+  run cmp "$BATS_TEST_TMPDIR/run1.json" "$BATS_TEST_TMPDIR/run2.json"
+  [ "$status" -eq 0 ]
+  # And the human render is byte-stable too.
+  python3 "$SCRIPT" "$FIX" --probe "build a custom widget" > "$BATS_TEST_TMPDIR/h1.txt"
+  python3 "$SCRIPT" "$FIX" --probe "build a custom widget" > "$BATS_TEST_TMPDIR/h2.txt"
+  run cmp "$BATS_TEST_TMPDIR/h1.txt" "$BATS_TEST_TMPDIR/h2.txt"
+  [ "$status" -eq 0 ]
+}
+
+@test "probe: mutating the declarer's description drops it below rank #1 (exit 1)" {
+  # Sanity: the declarer wins before the mutation.
+  run python3 "$SCRIPT" "$FIX" --probe "build a custom widget"
+  [ "$status" -eq 0 ]
+
+  # Mutate the declaring skill so its description no longer matches the phrase.
+  # It still DECLARES the phrase in trigger_probes — proving the rank is earned
+  # by lexical description match, not by the declaration itself.
+  cat > "$FIX/widget-builder/SKILL.md" <<'EOF'
+---
+name: widget-builder
+description: Does totally unrelated database things now.
+trigger_probes:
+  - "build a custom widget"
+---
+# Widget Builder
+EOF
+
+  run python3 "$SCRIPT" "$FIX" --probe "build a custom widget"
+  [ "$status" -eq 1 ]
+  # The rival is now rank #1; the declarer fell to #2.
+  echo "$output" | grep -q "| 1 | \`widget-rival\` |"
+  echo "$output" | grep -q "| 2 | \`widget-builder\` | yes |"
+}
+
+@test "probe: a phrase no skill declares is a usage error (exit 2)" {
+  run python3 "$SCRIPT" "$FIX" --probe "nobody declares this phrase"
+  [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## Summary

Adds a `--probe "<phrase>"` mode to `skills/skill-builder/scripts/scan_descriptions.py` that ranks every skill against a lexical trigger phrase **deterministically** (no live model, byte-stable output). Introduces an optional `trigger_probes:` skill-frontmatter field so a skill can self-declare phrases it must rank #1 for; the probe asserts the declaring skill wins its own phrases against the corpus.

Epic: ag-czzf.

**INFORMATIONAL-only tooling — not a blocking gate.** The probe is a self-check authors can run; no CI gate is wired to it.

## Changes
- `skills/skill-builder/scripts/scan_descriptions.py` — `--probe` ranker + `trigger_probes` parser (flow + block YAML forms).
- `schemas/skill-frontmatter.v2.schema.json` — optional `trigger_probes` array field.
- `tests/scripts/scan-descriptions-probe.bats` — 4 scenarios (rank-#1, determinism, demotion-on-mutation, usage-error exit codes).

## Validation
- New bats suite: 4/4 pass.
- `scripts/pre-push-gate.sh` reds are pre-existing main-red (context-packet-ab canary + its downstream pre-push-gate-governance nested bats), not caused by this diff; CI is changed-files-scoped.

Closes-scenario: ag-7led#trigger-probe
Bounded-context: BC2-Validation
Evidence: skills/skill-builder/scripts/scan_descriptions.py