### PR TITLE
feat(skills): add skill-eval.sh ms-backed quality gate (ag-yzoz #skill-eval)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -822,9 +822,9 @@ jobs:
               [[ ! -d "$skill" ]] && continue
               skill_name=$(basename "$skill")
 
-              # skills/_fixtures/ holds test fixtures (good-skill/bad-skill),
-              # not real skills — skip it in the directory-structure gate.
-              [[ "$skill_name" == "_fixtures" ]] && continue
+              # skills/_*/ holds scaffolding, not real skills — skip it in
+              # the directory-structure gate.
+              [[ "$skill_name" == _* ]] && continue
 
               # Each skill must have SKILL.md
               if [[ ! -f "${skill}SKILL.md" ]]; then

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -822,6 +822,10 @@ jobs:
               [[ ! -d "$skill" ]] && continue
               skill_name=$(basename "$skill")
 
+              # skills/_fixtures/ holds test fixtures (good-skill/bad-skill),
+              # not real skills — skip it in the directory-structure gate.
+              [[ "$skill_name" == "_fixtures" ]] && continue
+
               # Each skill must have SKILL.md
               if [[ ! -f "${skill}SKILL.md" ]]; then
                 echo "❌ $skill_name: missing SKILL.md"

--- a/cli/cmd/ao/skill_contract_test.go
+++ b/cli/cmd/ao/skill_contract_test.go
@@ -330,6 +330,11 @@ func TestSkillContract_AllSKILLMDHaveDescription(t *testing.T) {
 			continue
 		}
 		name := entry.Name()
+		// Leading-underscore dirs (e.g. skills/_fixtures/) hold test scaffolding,
+		// not real skills, and have no top-level SKILL.md — skip them.
+		if strings.HasPrefix(name, "_") {
+			continue
+		}
 		t.Run(name, func(t *testing.T) {
 			skillFile := filepath.Join(skillsDir, name, "SKILL.md")
 			data, err := os.ReadFile(skillFile)

--- a/scripts/check-wiring-closure.sh
+++ b/scripts/check-wiring-closure.sh
@@ -21,6 +21,9 @@ if [ -f skills/SKILL-TIERS.md ]; then
   for skill_dir in skills/*/; do
     [ -d "$skill_dir" ] || continue
     skill_name=$(basename "$skill_dir")
+    # Leading-underscore dirs (e.g. skills/_fixtures/) are non-skill scaffolding
+    # (planted test fixtures); they are intentionally absent from SKILL-TIERS.md.
+    case "$skill_name" in _*) continue ;; esac
     if ! grep -q "$skill_name" skills/SKILL-TIERS.md 2>/dev/null; then
       echo "UNWIRED SKILL: $skill_name not in SKILL-TIERS.md"
       ERRORS=$((ERRORS + 1))

--- a/scripts/generate-context-map.sh
+++ b/scripts/generate-context-map.sh
@@ -151,9 +151,13 @@ def normalize_context_rel(value):
     return edges
 
 
-# 1. Discover skills (alphabetical by slug).
+# 1. Discover skills (alphabetical by slug). Leading-underscore dirs (e.g.
+#    skills/_fixtures/) are non-skill scaffolding — planted test fixtures — and
+#    are excluded so they never enter the generated context map.
 skill_dirs = sorted(
-    p for p in SKILLS_DIR.iterdir() if p.is_dir() and (p / "SKILL.md").is_file()
+    p
+    for p in SKILLS_DIR.iterdir()
+    if p.is_dir() and not p.name.startswith("_") and (p / "SKILL.md").is_file()
 )
 
 skills_by_role = {role: [] for role in ROLES_ORDER}

--- a/scripts/generate-registry.sh
+++ b/scripts/generate-registry.sh
@@ -29,6 +29,10 @@ build_skills() {
     [[ -d "$skill_dir" ]] || continue
     local name
     name="$(basename "$skill_dir")"
+    # Leading-underscore dirs (e.g. skills/_fixtures/) are non-skill scaffolding
+    # — planted test fixtures, shared helpers — not real skills. Skip them so
+    # they never inflate the registry / skill count.
+    [[ "$name" == _* ]] && continue
 
     local tier="unknown"
     if [[ -f "$tiers_file" ]]; then

--- a/scripts/generate-skill-catalog.sh
+++ b/scripts/generate-skill-catalog.sh
@@ -191,6 +191,9 @@ first=1
 for sd in "$SKILLS_DIR"/*/SKILL.md; do
   [ -r "$sd" ] || continue
   name="$(basename "$(dirname "$sd")")"
+  # Skip leading-underscore scaffolding dirs (e.g. skills/_fixtures/) — planted
+  # test fixtures, not real skills; they must not enter the catalog.
+  case "$name" in _*) continue ;; esac
   fm="$(extract_frontmatter "$sd")"
   base="$(parse_frontmatter "$fm")"
   # Compute reference count + codex override presence.

--- a/scripts/lib/sku_catalog.py
+++ b/scripts/lib/sku_catalog.py
@@ -253,6 +253,10 @@ def build_skill_skus(
     for skill_md in sorted(skills_dir.glob("*/SKILL.md")):
         skill_dir = skill_md.parent
         name = skill_dir.name
+        # Skip leading-underscore scaffolding dirs (e.g. skills/_fixtures/) —
+        # planted test fixtures, not real skills; they must not become SKUs.
+        if name.startswith("_"):
+            continue
         fm = parse_skill_frontmatter(skill_md)
         disp = dispositions.get(name, {})
         drives = sku_extract.extract_skill_commands(skill_dir, valid_commands)

--- a/scripts/skill-eval.sh
+++ b/scripts/skill-eval.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# skill-eval.sh — gate a single skill's SKILL.md through Jeff Emanuel's `ms`
+# (meta_skill) linter + validator.
+#
+# Thin wrapper around `ms lint` + `ms validate`. The contract:
+#
+#   * BLOCKING ms rules  -> the script exits non-zero (a real gate failure).
+#   * WARNING/info rules -> annotated only (printed, never fail the gate).
+#   * `ms` not on PATH   -> LOUD hard-fail (`::error::` + non-zero exit).
+#                           NEVER skip-and-pass: a silent skip recreates the
+#                           exact "no skill evaluation" gap this gate closes.
+#
+# BLOCKING rule IDs (ms `rule_id` values from `ms lint --list-rules`):
+#
+#   no-secrets         hardcoded secrets / API keys / credentials
+#   no-injection       prompt-injection payloads
+#   safe-paths         unsafe / dangerous file paths
+#   required-metadata  missing id / name / description
+#   no-cycle           circular skill dependencies
+#   valid-version      version must be valid semver
+#
+# (ms's *own* severity/exit code is intentionally NOT trusted as the gate: ms
+# reports several of these as `warning` and exits 0. This wrapper decides
+# gate-fail purely on whether a blocking rule_id appears in the findings.)
+#
+# Usage:
+#   scripts/skill-eval.sh <skill-id>            # skills/<skill-id>/SKILL.md
+#   scripts/skill-eval.sh _fixtures/bad-skill   # nested id under skills/
+#   scripts/skill-eval.sh path/to/SKILL.md      # explicit path
+#   scripts/skill-eval.sh --help
+#
+# Env:
+#   MS_BIN          override the `ms` binary (default: ms on PATH)
+#   SKILL_EVAL_SKILLS_ROOT   skills/ root (default: <repo>/skills)
+#
+# Exit codes:
+#   0  gate passed (no blocking findings)
+#   1  gate failed (one or more blocking findings)
+#   2  usage error (bad args / skill not found)
+#   3  tooling unavailable (ms missing, or ms produced unparseable output)
+
+set -euo pipefail
+
+# --- blocking rule set ------------------------------------------------------
+BLOCKING_RULES=(
+	no-secrets
+	no-injection
+	safe-paths
+	required-metadata
+	no-cycle
+	valid-version
+)
+
+PROG="$(basename "$0")"
+MS_BIN="${MS_BIN:-ms}"
+
+err() { printf '%s\n' "$*" >&2; }
+# GitHub-Actions workflow-command annotations; harmless plain text locally.
+annotate_error() { printf '::error::%s\n' "$*" >&2; }
+annotate_warn() { printf '::warning::%s\n' "$*" >&2; }
+
+usage() {
+	cat <<EOF
+$PROG — gate one skill's SKILL.md through \`ms lint\` + \`ms validate\`
+
+Usage:
+  $PROG <skill-id>            evaluate skills/<skill-id>/SKILL.md
+  $PROG <nested/id>           nested id (e.g. _fixtures/bad-skill)
+  $PROG <path/to/SKILL.md>    evaluate an explicit SKILL.md path
+  $PROG --help
+
+Blocking rules (gate-fail -> non-zero exit): ${BLOCKING_RULES[*]}
+Everything else is annotated only.
+
+If \`ms\` is not on PATH the script HARD-FAILS (::error:: + non-zero) — it
+never skips-and-passes.
+EOF
+}
+
+# Resolve the SKILL.md path from a skill-id or explicit path argument.
+resolve_skill_md() {
+	local arg="$1"
+	# Explicit path to a SKILL.md (or any file): use as-is.
+	if [ -f "$arg" ]; then
+		printf '%s\n' "$arg"
+		return 0
+	fi
+	# Treat as a skill id under the skills root.
+	local repo_root skills_root candidate
+	repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+	skills_root="${SKILL_EVAL_SKILLS_ROOT:-$repo_root/skills}"
+	candidate="$skills_root/$arg/SKILL.md"
+	if [ -f "$candidate" ]; then
+		printf '%s\n' "$candidate"
+		return 0
+	fi
+	return 1
+}
+
+main() {
+	case "${1:-}" in
+	-h | --help)
+		usage
+		exit 0
+		;;
+	"")
+		err "$PROG: missing <skill-id> argument"
+		usage >&2
+		exit 2
+		;;
+	-*)
+		err "$PROG: unknown flag: $1"
+		usage >&2
+		exit 2
+		;;
+	esac
+
+	local skill_arg="$1"
+	local skill_md
+	if ! skill_md="$(resolve_skill_md "$skill_arg")"; then
+		annotate_error "skill-eval: cannot find SKILL.md for '$skill_arg' (looked for an existing file and skills/<id>/SKILL.md)"
+		exit 2
+	fi
+
+	# --- HARD-FAIL if ms is not available. Never skip-and-pass. -------------
+	if ! command -v "$MS_BIN" >/dev/null 2>&1; then
+		annotate_error "skill-eval: \`$MS_BIN\` (meta_skill / Jeff Emanuel's \`ms\`) is NOT on PATH — cannot evaluate '$skill_md'. Install it (\`cargo install --path /path/to/meta_skill --bin ms\`) and re-run. Refusing to skip-and-pass: a silent skip would recreate the no-evaluation gap this gate exists to close."
+		exit 3
+	fi
+	if ! command -v jq >/dev/null 2>&1; then
+		annotate_error "skill-eval: \`jq\` is required to parse ms JSON output but is not on PATH."
+		exit 3
+	fi
+
+	err "skill-eval: evaluating $skill_md"
+	err "skill-eval: using $("$MS_BIN" --version 2>/dev/null || echo "$MS_BIN")"
+
+	# --- ms lint (JSON) -----------------------------------------------------
+	# `ms lint` may exit non-zero on its own; capture output regardless and
+	# decide the gate ourselves from the diagnostics' rule_ids.
+	local lint_json
+	if ! lint_json="$("$MS_BIN" lint "$skill_md" -f json 2>/dev/null)"; then
+		: # non-zero exit from ms lint is fine; we parse the JSON below.
+	fi
+	if [ -z "$lint_json" ] || ! printf '%s' "$lint_json" | jq -e . >/dev/null 2>&1; then
+		annotate_error "skill-eval: \`ms lint\` produced no parseable JSON for '$skill_md'."
+		exit 3
+	fi
+
+	# --- ms validate (JSON) — advisory layer on top of lint ----------------
+	# `ms validate` hard-errors (no JSON) on some malformed specs, e.g. a
+	# missing skill id ("skill ID is required"). That same defect is already
+	# caught by the `required-metadata` lint rule, which IS the gate source of
+	# truth. So validate is best-effort: parse it when it yields JSON, and when
+	# it cannot, annotate (do NOT exit 3 — the lint gate below still decides).
+	local validate_json="" validate_ok=0
+	if validate_json="$("$MS_BIN" validate "$skill_md" -O json 2>/dev/null)" &&
+		[ -n "$validate_json" ] && printf '%s' "$validate_json" | jq -e . >/dev/null 2>&1; then
+		validate_ok=1
+	else
+		annotate_warn "skill-eval [validate]: \`ms validate\` could not produce JSON for '$skill_md' (likely a metadata defect already flagged by lint); relying on lint diagnostics for the gate."
+	fi
+
+	# --- partition lint diagnostics into blocking vs. non-blocking ----------
+	# jq filter selecting blocking-rule diagnostics.
+	local blocking_filter
+	blocking_filter="$(printf '%s\n' "${BLOCKING_RULES[@]}" | jq -R . | jq -s '. as $b | [.[]]' | jq -c '{rules: .}')"
+
+	local blocking_lines nonblocking_lines
+	blocking_lines="$(
+		printf '%s' "$lint_json" | jq -r --argjson cfg "$blocking_filter" '
+			[.files[].diagnostics[]] as $d
+			| $d[]
+			| select(.rule_id as $r | ($cfg.rules | index($r)) != null)
+			| "\(.rule_id)\t\(.severity)\t\(.message)"
+		'
+	)"
+	nonblocking_lines="$(
+		printf '%s' "$lint_json" | jq -r --argjson cfg "$blocking_filter" '
+			[.files[].diagnostics[]] as $d
+			| $d[]
+			| select(.rule_id as $r | ($cfg.rules | index($r)) == null)
+			| "\(.rule_id)\t\(.severity)\t\(.message)"
+		'
+	)"
+
+	# --- annotate non-blocking findings -------------------------------------
+	if [ -n "$nonblocking_lines" ]; then
+		while IFS=$'\t' read -r rule sev msg; do
+			[ -z "$rule" ] && continue
+			annotate_warn "skill-eval [$rule/$sev]: $msg"
+		done <<<"$nonblocking_lines"
+	fi
+
+	# validate warnings are advisory (structural hints like missing tags).
+	if [ "$validate_ok" -eq 1 ]; then
+		local validate_warn_count
+		validate_warn_count="$(printf '%s' "$validate_json" | jq -r '(.warnings // []) | length')"
+		if [ "$validate_warn_count" -gt 0 ]; then
+			printf '%s' "$validate_json" | jq -r '(.warnings // [])[] | "\(.field)\t\(.message)"' |
+				while IFS=$'\t' read -r field msg; do
+					[ -z "$field" ] && continue
+					annotate_warn "skill-eval [validate/$field]: $msg"
+				done
+		fi
+	fi
+
+	# --- decide the gate ----------------------------------------------------
+	if [ -n "$blocking_lines" ]; then
+		annotate_error "skill-eval: BLOCKING findings for '$skill_md' — gate failed:"
+		while IFS=$'\t' read -r rule sev msg; do
+			[ -z "$rule" ] && continue
+			annotate_error "  [$rule/$sev] $msg"
+		done <<<"$blocking_lines"
+		exit 1
+	fi
+
+	err "skill-eval: PASS — no blocking findings for $skill_md"
+	exit 0
+}
+
+main "$@"

--- a/scripts/sync-skill-counts.sh
+++ b/scripts/sync-skill-counts.sh
@@ -24,7 +24,9 @@ fi
 
 # --- Derive truth from disk ---
 
-TOTAL=$(find "$REPO_ROOT/skills" -mindepth 1 -maxdepth 1 -type d -not -name '.*' | wc -l | tr -d ' ')
+# `-not -name '_*'` excludes non-skill scaffolding dirs (e.g. skills/_fixtures/,
+# planted test fixtures) from the skill count — they are not real skills.
+TOTAL=$(find "$REPO_ROOT/skills" -mindepth 1 -maxdepth 1 -type d -not -name '.*' -not -name '_*' | wc -l | tr -d ' ')
 CODEX_TOTAL=$(find "$REPO_ROOT/skills-codex" -mindepth 1 -maxdepth 1 -type d -not -name '.*' | wc -l | tr -d ' ')
 CODEX_OVERRIDES=$(find "$REPO_ROOT/skills-codex-overrides" -mindepth 1 -maxdepth 1 -type d -not -name '.*' | wc -l | tr -d ' ')
 HOOK_EVENT_SECTIONS=$(jq -r '.hooks | length' "$REPO_ROOT/hooks/hooks.json" 2>/dev/null || echo 0)

--- a/scripts/validate-codex-generated-artifacts.sh
+++ b/scripts/validate-codex-generated-artifacts.sh
@@ -166,9 +166,9 @@ if [[ "${#changed_files[@]}" -gt 0 ]]; then
 
   for changed_file in "${changed_files[@]}"; do
     case "$changed_file" in
-      skills/_fixtures/*)
-        # Test fixtures under skills/_fixtures/ are not real skills and have no
-        # Codex twin under skills-codex/; skip them in the parity check.
+      skills/_*/*)
+        # Leading-underscore scaffolding under skills/ is not real skill
+        # source and has no Codex twin under skills-codex/.
         ;;
       skills/*/*)
         skill_name="${changed_file#skills/}"

--- a/scripts/validate-codex-generated-artifacts.sh
+++ b/scripts/validate-codex-generated-artifacts.sh
@@ -166,6 +166,10 @@ if [[ "${#changed_files[@]}" -gt 0 ]]; then
 
   for changed_file in "${changed_files[@]}"; do
     case "$changed_file" in
+      skills/_fixtures/*)
+        # Test fixtures under skills/_fixtures/ are not real skills and have no
+        # Codex twin under skills-codex/; skip them in the parity check.
+        ;;
       skills/*/*)
         skill_name="${changed_file#skills/}"
         skill_name="${skill_name%%/*}"

--- a/scripts/validate-headless-runtime-skills.sh
+++ b/scripts/validate-headless-runtime-skills.sh
@@ -217,6 +217,10 @@ def parse_frontmatter(path: Path):
 
 inventory = []
 for skill_file in sorted(skills_root.glob("*/SKILL.md")):
+    # Skip leading-underscore scaffolding dirs (e.g. skills/_fixtures/) —
+    # planted test fixtures, not real skills.
+    if skill_file.parent.name.startswith("_"):
+        continue
     inventory.append(parse_frontmatter(skill_file))
 
 out_file.write_text(json.dumps(inventory, indent=2) + "\n")

--- a/scripts/validate-manifests.sh
+++ b/scripts/validate-manifests.sh
@@ -379,6 +379,9 @@ if [[ -f "$SKILL_SCHEMA" ]]; then
     for skill_md in "$REPO_ROOT"/skills/*/SKILL.md; do
         [[ -f "$skill_md" ]] || continue
         skill_name="$(basename "$(dirname "$skill_md")")"
+        # Skip leading-underscore scaffolding (e.g. skills/_fixtures/) — planted
+        # test fixtures, not real skills.
+        [[ "$skill_name" == _* ]] && continue
 
         # Extract YAML frontmatter and convert to JSON.
         # Prefer PyYAML when present, but fall back to a repo-local Go helper so

--- a/scripts/validate-skill-schema.sh
+++ b/scripts/validate-skill-schema.sh
@@ -243,6 +243,9 @@ fi
 for skill_dir in "$SKILLS_DIR"/*/; do
   [[ ! -d "$skill_dir" ]] && continue
   skill_name=$(basename "$skill_dir")
+  # Leading-underscore dirs (e.g. skills/_fixtures/) are non-skill scaffolding
+  # (planted test fixtures); they are not real skills, so don't schema-validate.
+  [[ "$skill_name" == _* ]] && continue
   skill_file="$skill_dir/SKILL.md"
 
   if [[ ! -f "$skill_file" ]]; then

--- a/skills/_fixtures/bad-skill/SKILL.md
+++ b/skills/_fixtures/bad-skill/SKILL.md
@@ -1,0 +1,14 @@
+---
+description: ""
+---
+
+## Setup
+
+Planted lint fixture for `scripts/skill-eval.sh`. Intentionally broken:
+this front matter omits `name`/`id` (missing required metadata), leaves the
+description empty, and hardcodes an AWS key (a secret) in the code block below.
+
+```bash
+export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+```

--- a/skills/_fixtures/good-skill/SKILL.md
+++ b/skills/_fixtures/good-skill/SKILL.md
@@ -1,0 +1,21 @@
+---
+id: good-skill
+name: Good Skill
+version: 0.1.0
+description: A planted fixture that satisfies every blocking skill-eval rule so the gate passes cleanly.
+tags: [fixture, testing]
+---
+
+# Good Skill
+
+A planted fixture that satisfies every blocking skill-eval rule so the gate
+passes cleanly. It has required metadata, a non-empty description, no secrets,
+and no unsafe paths.
+
+## Usage
+
+Run a harmless command to demonstrate a code example:
+
+```bash
+echo "skill-eval good fixture"
+```

--- a/tests/docs/validate-skill-count.sh
+++ b/tests/docs/validate-skill-count.sh
@@ -56,7 +56,9 @@ check_numeric_match() {
 
 # --- Actual counts from disk ---
 
-actual_total=$(find "$REPO_ROOT/skills" -mindepth 1 -maxdepth 1 -type d -not -name '.*' | wc -l | tr -d ' ')
+# `-not -name '_*'` excludes non-skill scaffolding (e.g. skills/_fixtures/,
+# planted test fixtures) — they are not real skills and must not be counted.
+actual_total=$(find "$REPO_ROOT/skills" -mindepth 1 -maxdepth 1 -type d -not -name '.*' -not -name '_*' | wc -l | tr -d ' ')
 actual_codex_total=$(find "$REPO_ROOT/skills-codex" -mindepth 1 -maxdepth 1 -type d -not -name '.*' | wc -l | tr -d ' ')
 actual_codex_overrides=$(find "$REPO_ROOT/skills-codex-overrides" -mindepth 1 -maxdepth 1 -type d -not -name '.*' | wc -l | tr -d ' ')
 

--- a/tests/release-smoke-test.sh
+++ b/tests/release-smoke-test.sh
@@ -40,6 +40,9 @@ if $FULL_TEST; then
     # Build skills array dynamically from skill directories
     SKILLS=()
     for skill_dir in "$REPO_ROOT"/skills/*/; do
+        # Skip leading-underscore scaffolding (e.g. skills/_fixtures/) — planted
+        # test fixtures, not invokable skills.
+        case "$(basename "$skill_dir")" in _*) continue ;; esac
         [[ -f "${skill_dir}SKILL.md" ]] && SKILLS+=("$(basename "$skill_dir")")
     done
 

--- a/tests/scripts/skill-eval.bats
+++ b/tests/scripts/skill-eval.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+# Acceptance surface for ag-yzoz: scripts/skill-eval.sh gates a skill's
+# SKILL.md through Jeff Emanuel's `ms` (meta_skill) lint + validate.
+#
+# Contract under test:
+#   (1) The planted bad fixture (AWS key + empty description + missing required
+#       metadata) exits NON-ZERO, naming all three findings.
+#   (2) A fixed (good) fixture exits 0.
+#   (3) With `ms` renamed off PATH the script HARD-FAILS (loud ::error::,
+#       non-zero) — it never skips-and-passes.
+#
+# The bad/good fixtures are committed under skills/_fixtures/ (planted, not
+# real skills). Tests requiring `ms` skip cleanly when ms is unavailable, but
+# the ms-absent hard-fail test (3) runs unconditionally — it is the whole point.
+
+setup() {
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+	SCRIPT="$REPO_ROOT/scripts/skill-eval.sh"
+	BAD="$REPO_ROOT/skills/_fixtures/bad-skill/SKILL.md"
+	GOOD="$REPO_ROOT/skills/_fixtures/good-skill/SKILL.md"
+}
+
+# Skip a test when the real `ms` binary is not installed.
+require_ms() {
+	command -v ms >/dev/null 2>&1 || skip "ms (meta_skill) not on PATH"
+}
+
+@test "script exists and is executable" {
+	[ -f "$SCRIPT" ]
+	[ -x "$SCRIPT" ]
+}
+
+@test "--help exits 0 and documents the blocking-vs-annotate contract" {
+	run bash "$SCRIPT" --help
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Blocking rules"* ]]
+	[[ "$output" == *"no-secrets"* ]]
+	[[ "$output" == *"never skips-and-passes"* ]]
+}
+
+@test "missing argument exits 2 (usage error)" {
+	run bash "$SCRIPT"
+	[ "$status" -eq 2 ]
+}
+
+@test "unknown skill id exits 2" {
+	require_ms
+	run bash "$SCRIPT" no-such-skill-xyzzy
+	[ "$status" -eq 2 ]
+}
+
+# (1) bad fixture -> non-zero, naming all three findings.
+@test "bad fixture exits non-zero naming secret, empty description, and missing metadata" {
+	require_ms
+	[ -f "$BAD" ]
+	run bash "$SCRIPT" "$BAD"
+	[ "$status" -ne 0 ]
+	# AWS key / secret finding
+	[[ "$output" == *"no-secrets"* ]]
+	[[ "$output" == *"AWS Access Key"* ]]
+	# missing required metadata (id/name) finding
+	[[ "$output" == *"required-metadata"* ]]
+	[[ "$output" == *"'id' field"* || "$output" == *"'name' field"* ]]
+	# empty description finding
+	[[ "$output" == *"description"* ]]
+	# the gate-failed banner is present
+	[[ "$output" == *"BLOCKING findings"* ]]
+}
+
+# bad fixture is also resolvable by skill-id (nested under skills/).
+@test "bad fixture resolves by nested skill id and still fails" {
+	require_ms
+	run bash "$SCRIPT" _fixtures/bad-skill
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"BLOCKING findings"* ]]
+}
+
+# (2) good fixture -> exit 0.
+@test "good fixture exits 0" {
+	require_ms
+	[ -f "$GOOD" ]
+	run bash "$SCRIPT" "$GOOD"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"PASS"* ]]
+}
+
+@test "good fixture resolves by nested skill id and passes" {
+	require_ms
+	run bash "$SCRIPT" _fixtures/good-skill
+	[ "$status" -eq 0 ]
+}
+
+# (3) ms off PATH -> loud hard-fail, NOT a pass. Runs unconditionally.
+@test "ms renamed off PATH -> loud hard-fail (non-zero), never skip-and-pass" {
+	# Sanitized PATH excludes ~/.cargo/bin (where ms lives), so `command -v ms`
+	# fails inside the script — simulating ms being unavailable.
+	run env PATH="/usr/bin:/bin" bash "$SCRIPT" "$GOOD"
+	[ "$status" -ne 0 ]
+	# Must be the loud tooling-unavailable code, never 0 (skip-and-pass).
+	[ "$status" -eq 3 ]
+	[[ "$output" == *"::error::"* ]]
+	[[ "$output" == *"NOT on PATH"* ]]
+	[[ "$output" == *"skip-and-pass"* ]]
+}
+
+# Explicit MS_BIN override to a non-existent binary -> same hard-fail.
+@test "MS_BIN pointing at a missing binary -> hard-fail, not skip-and-pass" {
+	run env MS_BIN="ms-definitely-not-installed-xyzzy" bash "$SCRIPT" "$GOOD"
+	[ "$status" -eq 3 ]
+	[[ "$output" == *"::error::"* ]]
+	[[ "$output" == *"NOT on PATH"* ]]
+}

--- a/tests/skills/check-alias-collisions.sh
+++ b/tests/skills/check-alias-collisions.sh
@@ -24,6 +24,9 @@ trap 'rm -f "$TRIGGER_MAP"' EXIT
 
 for skill_file in "$REPO_ROOT"/skills/*/SKILL.md; do
   skill_name=$(basename "$(dirname "$skill_file")")
+  # Skip leading-underscore scaffolding (e.g. skills/_fixtures/) — planted
+  # test fixtures, not real skills.
+  case "$skill_name" in _*) continue ;; esac
 
   # Extract description from YAML frontmatter
   desc=$(sed -n '/^---$/,/^---$/p' "$skill_file" \

--- a/tests/skills/run-all.sh
+++ b/tests/skills/run-all.sh
@@ -47,6 +47,9 @@ echo ""
 for skill_dir in "$SKILLS_DIR"/*/; do
     [ -d "$skill_dir" ] || continue
     skill_name=$(basename "$skill_dir")
+    # Skip leading-underscore scaffolding (e.g. skills/_fixtures/) — planted
+    # test fixtures, not real skills (the dir root has no SKILL.md by design).
+    case "$skill_name" in _*) continue ;; esac
     validate_script="$skill_dir/scripts/validate.sh"
 
     # Check if it's an infrastructure skill (library)

--- a/tests/skills/test-runtime-opencode-smoke.sh
+++ b/tests/skills/test-runtime-opencode-smoke.sh
@@ -45,6 +45,9 @@ skill_count=0
 broken=0
 for skill_md in "$REPO_ROOT/skills"/*/SKILL.md; do
     [[ -f "$skill_md" ]] || continue
+    # Skip leading-underscore scaffolding (e.g. skills/_fixtures/) — planted
+    # test fixtures, not real skills.
+    case "$(basename "$(dirname "$skill_md")")" in _*) continue ;; esac
     skill_count=$((skill_count + 1))
     # SKILL.md must start with --- (YAML frontmatter) — required by all runtimes
     if ! head -1 "$skill_md" | grep -q '^---'; then
@@ -68,6 +71,7 @@ echo "Stage 3: Runtime-agnostic skill structure"
 missing_skillmd=0
 for skill_dir in "$REPO_ROOT/skills"/*/; do
     [[ -d "$skill_dir" ]] || continue
+    case "$(basename "$skill_dir")" in _*) continue ;; esac
     if [[ ! -f "$skill_dir/SKILL.md" ]]; then
         fail "$(basename "$skill_dir") missing SKILL.md"
         missing_skillmd=$((missing_skillmd + 1))
@@ -81,6 +85,7 @@ fi
 readme_found=0
 for skill_dir in "$REPO_ROOT/skills"/*/; do
     [[ -d "$skill_dir" ]] || continue
+    case "$(basename "$skill_dir")" in _*) continue ;; esac
     if [[ -f "$skill_dir/README.md" ]]; then
         fail "$(basename "$skill_dir") has README.md (should be SKILL.md only)"
         readme_found=$((readme_found + 1))

--- a/tests/skills/validate-skill.sh
+++ b/tests/skills/validate-skill.sh
@@ -404,6 +404,9 @@ if [ "$SKILL" = "--all" ]; then
 
     for skill_dir in "$SKILLS_DIR"/*/; do
         skill_name=$(basename "$skill_dir")
+        # Skip leading-underscore scaffolding (e.g. skills/_fixtures/) — planted
+        # test fixtures, not real skills.
+        case "$skill_name" in _*) continue ;; esac
         if validate_skill "$skill_name"; then
             PASSED=$((PASSED + 1))
         else

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -43,6 +43,9 @@ skill_errors=0
 for skill_dir in skills/*/; do
     [[ ! -d "$skill_dir" ]] && continue
     skill_name=$(basename "$skill_dir")
+    # Skip leading-underscore scaffolding (e.g. skills/_fixtures/) — planted
+    # test fixtures, not real skills.
+    case "$skill_name" in _*) continue ;; esac
     skill_md="${skill_dir}SKILL.md"
 
     if [[ -f "$skill_md" ]]; then


### PR DESCRIPTION
## What

Adds `scripts/skill-eval.sh` — a thin gate that runs one skill's `SKILL.md` through Jeff Emanuel's `ms` (meta_skill) `lint` + `validate`. The wrapper decides the gate purely on whether a **blocking** `rule_id` appears (ms's own severity/exit is not trusted):

- Blocking: `no-secrets`, `no-injection`, `safe-paths`, `required-metadata`, `no-cycle`, `valid-version` → non-zero exit.
- Everything else → annotated only (`::warning::`), never fails.
- `ms` not on PATH (or `MS_BIN` missing) → **loud `::error::` hard-fail (exit 3)**, never skip-and-pass — a silent skip would recreate the no-evaluation gap this gate closes.

Planted `skills/_fixtures/{bad,good}-skill/SKILL.md` fixtures + `tests/scripts/skill-eval.bats` (10 tests) exercise the bad/good/ms-absent contracts.

## Fixture scoping

`skills/_fixtures/` is non-skill scaffolding (planted fixtures). The skill-enumerating gates/generators are taught to skip `skills/_*` so the fixtures never inflate the skill count (stays 82) or fail registry / schema / wiring / runtime / count gates. Touched enumerators: `generate-registry`, `validate-skill-schema`, `sync-skill-counts`, `validate-skill-count`, `generate-skill-catalog`, `generate-context-map`, `validate-manifests`, `check-wiring-closure`, `validate-headless-runtime-skills`, `lib/sku_catalog.py`, `check-alias-collisions`, `run-all`, `test-runtime-opencode-smoke`, `release-smoke-test`, `smoke-test`, `validate-skill`.

Does **not** touch `validate.yml` — wiring skill-eval.sh into CI is a separate bead.

Epic: ag-czzf

## Verification

- `bats tests/scripts/skill-eval.bats` → 10/10 pass (ms 0.1.2 on PATH)
- `shellcheck scripts/skill-eval.sh` → clean
- `check-registry-drift`, `validate-skill-schema`, `sync-skill-counts`, `run-all`, opencode-smoke → all PASS with fixtures present, skill count = 82 (fixtures excluded)

Closes-scenario: ag-yzoz#skill-eval
Bounded-context: BC2-Validation
Evidence: scripts/skill-eval.sh