### PR TITLE
fix(ci): install PyYAML whenever the skill-gates drift sweep runs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -186,7 +186,9 @@ jobs:
         run: sudo apt-get install -y jq
 
       - name: Install python schema deps
-        if: needs.changes.outputs.skills == 'true' || needs.changes.outputs.contracts == 'true' || needs.changes.outputs.ci == 'true'
+        # Must cover every trigger that runs the drift sweep below (incl. docs/go/shell),
+        # otherwise a docs-only change runs regen-all.sh --check without PyYAML installed.
+        if: needs.changes.outputs.skills == 'true' || needs.changes.outputs.go == 'true' || needs.changes.outputs.contracts == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.ci == 'true'
         run: pip install jsonschema pyyaml
 
       - name: Run skill structural integrity checks (heal --strict)


### PR DESCRIPTION
## Problem
The `skill-gates` job's **drift sweep** (`regen-all.sh --check`) runs on `skills | go | contracts | docs | shell | ci`, but the **Install python schema deps** step (which installs PyYAML) only ran on `skills | contracts | ci`.

A **docs-only PR** (e.g. a README/asset change) therefore triggers the drift sweep but skips the PyYAML install, so the registry / skill-domain-map / context-map checks fail with `No module named 'yaml'` — blocking unrelated PRs.

## Fix
Broaden the install step's `if` to cover every trigger the drift sweep runs on (adds `go`, `docs`, `shell`). One-line condition change.

Found while shipping a docs-only README video PR (#727) that got blocked by this.