### PR TITLE
docs(readme): pull demo videos pending rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,6 @@ AgentOps sits on top of the coding harness you already use (Claude Code, Codex, 
 
 ## See It Work
 
-<div align="center">
-
-![A real Claude Code session running the delivery loop with a cross-model council gate: research, plan, council --mixed, implement, validate](docs/assets/loop-hero.gif)
-
-<sub>Real Claude Code, lightly edited for pace — the delivery loop end to end: research → plan → <code>/council --mixed</code> (3 Claude + 3 Codex judges) → implement → validate. <a href="docs/assets/loop-hero.mp4">Full-resolution MP4</a>.</sub>
-
-</div>
-
 Most teams run coding agents as isolated chat sessions. Prior attempts, warnings, decisions, and fixes scatter across chats, commits, and human memory, so the same mistakes recur and nothing leaves a reviewable trail.
 
 AgentOps breaks intent into bounded slices, gives each slice a first failing test and a write scope, and makes every phase boundary a gate that records evidence.
@@ -278,12 +270,6 @@ Full reference: [docs/SKILLS.md](docs/SKILLS.md).
 ## The `ao` CLI
 
 The `ao` CLI is the repo-native control plane behind the skills. It handles retrieval, health checks, compounding, goals, and terminal workflows.
-
-<div align="center">
-
-![ao CLI: ao --help, the knowledge flywheel badge, and the council-first value path](docs/assets/agentops-demo.gif)
-
-</div>
 
 <!-- agentops:claim:AOP-CLAIM-README-EVOLVE-AUTONOMOUS -->
 


### PR DESCRIPTION
Temporarily removes the loop-hero hero and the ao-demo CLI gif from the README while the demo video is reworked to be skills-forward (live in-session Claude + Codex) and faster. Assets stay in docs/assets/.