### PR TITLE
feat(memory): compute always reach from canon maturity

### DIFF
--- a/cli/cmd/ao/inject_canon_test.go
+++ b/cli/cmd/ao/inject_canon_test.go
@@ -111,3 +111,50 @@ func TestCollectLearnings_CanonAbsentDirNoop(t *testing.T) {
 		t.Fatalf("expected 1 non-canon learning, got %d (canon=%v)", len(learnings), len(learnings) > 0 && learnings[0].Canon)
 	}
 }
+
+func TestCollectLearnings_ComputesAlwaysOnlyForEstablishedCanon(t *testing.T) {
+	root := t.TempDir()
+	localDir := filepath.Join(root, ".agents", "learnings")
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	local := "---\nutility: 0.8\nmaturity: established\nreach: always\n---\n# Local Established\n\nLocal established content tries to self-author always reach without canon.\n"
+	if err := os.WriteFile(filepath.Join(localDir, "local.md"), []byte(local), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	canonDir := filepath.Join(root, ".agents", "canon", "learnings")
+	if err := os.MkdirAll(canonDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	canonEstablished := "---\nutility: 0.8\nmaturity: established\n---\n# Canon Established\n\nCanon established content earned the computed always reach projection.\n"
+	if err := os.WriteFile(filepath.Join(canonDir, "canon-established.md"), []byte(canonEstablished), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	canonCandidate := "---\nutility: 0.8\nmaturity: candidate\nreach: always\n---\n# Canon Candidate\n\nCanon candidate content cannot self-author always reach before establishment.\n"
+	if err := os.WriteFile(filepath.Join(canonDir, "canon-candidate.md"), []byte(canonCandidate), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	learnings, err := collectLearnings(root, "", 10, "", 0.8)
+	if err != nil {
+		t.Fatalf("collectLearnings() error = %v", err)
+	}
+	if len(learnings) != 3 {
+		t.Fatalf("expected 3 learnings, got %d", len(learnings))
+	}
+
+	byTitle := map[string]learning{}
+	for _, l := range learnings {
+		byTitle[l.Title] = l
+	}
+	if got := byTitle["Local Established"].Reach; got != "pull" {
+		t.Fatalf("local authored reach=always computed to %q, want pull", got)
+	}
+	if got := byTitle["Canon Established"].Reach; got != "always" {
+		t.Fatalf("canon established reach = %q, want always", got)
+	}
+	if got := byTitle["Canon Candidate"].Reach; got != "pull" {
+		t.Fatalf("canon candidate authored reach=always computed to %q, want pull", got)
+	}
+}

--- a/cli/cmd/ao/inject_learnings.go
+++ b/cli/cmd/ao/inject_learnings.go
@@ -138,6 +138,7 @@ func appendCanonLearnings(learnings []learning, canonDir string, localPaths, loc
 			localContentHashes[contentHash] = true
 		}
 		l.Canon = true
+		l.Reach = search.ComputeReach(l.Reach, l.Maturity, true)
 		learnings = append(learnings, l)
 	}
 	return learnings

--- a/cli/internal/search/learnings.go
+++ b/cli/internal/search/learnings.go
@@ -68,6 +68,27 @@ func SanitizeReach(reach string) string {
 	return "pull"
 }
 
+// SanitizeAuthoredReach normalizes persisted/frontmatter reach values while
+// rejecting author-set "always". always is derived by ComputeReach once canon
+// membership is known.
+func SanitizeAuthoredReach(reach string) string {
+	r := SanitizeReach(reach)
+	if r == "always" {
+		return "pull"
+	}
+	return r
+}
+
+// ComputeReach derives the effective blast radius for a learning. The only path
+// to "always" is established maturity plus verification-earned canon; authored
+// "always" is treated like absent/invalid reach.
+func ComputeReach(authoredReach, maturity string, canon bool) string {
+	if canon && types.Maturity(strings.ToLower(strings.TrimSpace(maturity))) == types.MaturityEstablished {
+		return "always"
+	}
+	return SanitizeAuthoredReach(authoredReach)
+}
+
 // QueryTokens splits a lowercased query into salient search tokens: it splits on any
 // non-alphanumeric rune (so "continue-on-error:true" -> continue/error/true), drops
 // stopwords and sub-2-char tokens, and deduplicates (order-preserving). Stopword removal
@@ -262,7 +283,7 @@ func ParseLearningFile(path string) (Learning, error) {
 	l.SourcePhase = SanitizeSourcePhase(fm.SourcePhase)
 	l.Maturity = fm.Maturity
 	l.Stability = fm.Stability
-	l.Reach = SanitizeReach(fm.Reach)
+	l.Reach = SanitizeAuthoredReach(fm.Reach)
 
 	ParseLearningBody(lines, contentStart, &l)
 	l.Summary = ExtractSummary(lines, contentStart)
@@ -305,7 +326,7 @@ func PopulateLearningFromJSON(data map[string]any, l *Learning) {
 		l.Stability = s
 	}
 	if r, ok := data["reach"].(string); ok {
-		l.Reach = SanitizeReach(r)
+		l.Reach = SanitizeAuthoredReach(r)
 	}
 }
 

--- a/cli/internal/search/reach_test.go
+++ b/cli/internal/search/reach_test.go
@@ -41,3 +41,60 @@ func TestParseFrontMatter_Reach(t *testing.T) {
 		t.Fatalf("absent reach should default to pull, got %q", got)
 	}
 }
+
+func TestSanitizeAuthoredReach_DowngradesAlways(t *testing.T) {
+	for _, in := range []string{"always", "ALWAYS", "  always  "} {
+		if got := SanitizeAuthoredReach(in); got != "pull" {
+			t.Fatalf("SanitizeAuthoredReach(%q) = %q, want pull", in, got)
+		}
+	}
+	if got := SanitizeAuthoredReach("bead"); got != "bead" {
+		t.Fatalf("SanitizeAuthoredReach(bead) = %q, want bead", got)
+	}
+}
+
+func TestComputeReach_AlwaysRequiresEstablishedCanon(t *testing.T) {
+	cases := []struct {
+		name         string
+		authored     string
+		maturity     string
+		canon        bool
+		wantComputed string
+	}{
+		{
+			name:         "established canon computes always",
+			maturity:     "established",
+			canon:        true,
+			wantComputed: "always",
+		},
+		{
+			name:         "established non-canon remains pull",
+			authored:     "always",
+			maturity:     "established",
+			canon:        false,
+			wantComputed: "pull",
+		},
+		{
+			name:         "canon candidate remains pull",
+			authored:     "always",
+			maturity:     "candidate",
+			canon:        true,
+			wantComputed: "pull",
+		},
+		{
+			name:         "authored bead survives when not always",
+			authored:     "bead",
+			maturity:     "candidate",
+			canon:        false,
+			wantComputed: "bead",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ComputeReach(tt.authored, tt.maturity, tt.canon)
+			if got != tt.wantComputed {
+				t.Fatalf("ComputeReach(%q, %q, %v) = %q, want %q", tt.authored, tt.maturity, tt.canon, got, tt.wantComputed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Implements ag-oqha / W2.2: authored `reach: always` is sanitized back to `pull`.
- Computes effective `reach=always` only for learnings that are both canon-collected and `maturity: established`.
- Adds focused search/frontmatter tests plus canon collector integration coverage.

## Verification
- `cd cli && go test ./internal/search -run 'Test(SanitizeReach|SanitizeAuthoredReach|ComputeReach|ParseFrontMatter_Reach)' -count=1 -timeout=60s`\n- `cd cli && go test ./cmd/ao -run 'TestCollectLearnings_(CanonTierSurfaces|CanonBoost|CanonAbsentDirNoop|ComputesAlwaysOnlyForEstablishedCanon)' -count=1 -timeout=60s`\n- `git diff --check`\n- `bash scripts/regen-all.sh` was run before push and hit the pre-existing CMDAO surface parity red; generated drift was reverted to keep this PR scoped.\n- `PRE_PUSH_FAIL_FAST=false bash scripts/pre-push-gate.sh` was run before push and is blocked by known/pre-existing reds outside this diff: test-fixture parity for `scripts/gc-stale-worktrees.sh`, canonical root dirty state, goals validate, corpus freshness, and pre-push governance/Bats canary.\n\n## Coordination\n- #724 merged; branch is rebased on current `origin/main`.\n- Agent Mail file reservations were held for the four touched memory files.\n- Antigravity/Gemini review is unavailable because that pane is not authenticated; requesting normal cross-model PR review instead.