### PR TITLE
docs(evolve): backport pre-push fail-fast lever + ao-command surfaces (ag-ro1i #evolve-backport)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-05T01:01:16Z",
+  "generated_at": "2026-06-05T02:33:27Z",
   "summary": {
     "skills": 82,
     "hooks": 0,
@@ -178,7 +178,7 @@
         "path": "skills/evolve/",
         "has_skill_md": true,
         "has_references": true,
-        "reference_count": 26
+        "reference_count": 27
       },
       {
         "name": "grafana-platform-dashboard",
@@ -2098,7 +2098,7 @@
         "ao rpi loop"
       ],
       "path": "skills/evolve/",
-      "references": 26
+      "references": 27
     },
     {
       "sku": "skill:flywheel",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -811,7 +811,7 @@
     {
       "name": "evolve",
       "source_skill": "skills/evolve",
-      "source_hash": "659314217a89788bb2895f6e65265a550c1e1d3fcd2fa41495ab6e1555832eae",
+      "source_hash": "1dff0ccbfb96a0012f88653232e0bfce3cf52e1322b085dbf76a41b538f3722c",
       "generated_hash": "30756e2ad2f3b5f924fda8442038e9dc8feb8f19ef0a530c0592d7a29577763d"
     },
     {

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/evolve",
   "layout": "modular",
-  "source_hash": "659314217a89788bb2895f6e65265a550c1e1d3fcd2fa41495ab6e1555832eae",
+  "source_hash": "1dff0ccbfb96a0012f88653232e0bfce3cf52e1322b085dbf76a41b538f3722c",
   "generated_hash": "30756e2ad2f3b5f924fda8442038e9dc8feb8f19ef0a530c0592d7a29577763d"
 }

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -390,12 +390,22 @@ before invoking /release. Do NOT skip any of these on the basis of "cycles
 were green" — fast pre-push gate ≠ full pre-push gate; goals-measure ≠
 release readiness.
 
-  [ ] 1. Regenerate CLI reference docs if any cobra command/flag changed:
-         bash scripts/generate-cli-reference.sh
-         git diff cli/docs/COMMANDS.md   # commit if non-empty
+  [ ] 1. Regenerate ALL derived surfaces if any cobra command/flag changed:
+         bash scripts/regen-all.sh          # COMMANDS.md, registry.json, maps
+         # ADDING an `ao` command also needs the 2 surfaces regen-all only WARNS
+         # about: cli/cmd/ao/cobra_commands_test.go expectedCmds (x2 lists) +
+         # the cli-command-surface heading counts in
+         # evals/agentops-core/fixtures/cli-command-surface-smoke.sh AND
+         # evals/agentops-core/cli-command-surface-matrix.json (top/sub/all).
+         # Run the smoke fixture to read the exact new counts. (ag-jy12 will
+         # automate this.) Full procedure in
+         # [references/ao-command-landing.md](references/ao-command-landing.md)
+         git diff cli/docs/COMMANDS.md registry.json   # commit if non-empty
 
-  [ ] 2. Run the FULL pre-push gate (NOT --fast):
-         bash scripts/pre-push-gate.sh
+  [ ] 2. Run the FULL pre-push gate (NOT --fast) with fail-fast OFF, so a
+         PRE-EXISTING failure (e.g. corpus-freshness) cannot mask your own
+         regressions by stopping the run early:
+         PRE_PUSH_FAIL_FAST=false bash scripts/pre-push-gate.sh
 
   [ ] 3. Run the release-readiness gate:
          bash scripts/ci-local-release.sh
@@ -459,6 +469,7 @@ See `references/cycle-history.md` for advanced troubleshooting.
 - [references/fitness-scoring.md](references/fitness-scoring.md) — Baseline capture, regression detection, revert procedure
 - [references/gate-hygiene.md](references/gate-hygiene.md) — Pre-gate source-surface detection, structural gate-output parsing, pre-push diff-scope check, pre-existing-vs-mine red triage
 - [references/new-skill-landing.md](references/new-skill-landing.md) — The six derived surfaces a new/modified skill must regenerate in one shot to stay one-shot-green
+- [references/ao-command-landing.md](references/ao-command-landing.md) — The surfaces a new/renamed `ao` command must regenerate (cobra expectedCmds x2 + cli-command-surface counts that regen-all only WARNS about)
 - [references/goals-schema.md](references/goals-schema.md) — GOALS.yaml format and continuous metrics
 - [references/knowledge-loop-integration.md](references/knowledge-loop-integration.md) — Claim/release semantics and harvest re-read
 - [references/mechanical-batches.md](references/mechanical-batches.md) — Script-first vs per-file Edit for > 20-file uniform batches

--- a/skills/evolve/references/ao-command-landing.md
+++ b/skills/evolve/references/ao-command-landing.md
@@ -1,0 +1,52 @@
+# AO-Command Landing — the surfaces a new `ao` command must regenerate
+
+Adding (or renaming/removing) an `ao` command or subcommand touches more than the
+generated CLI reference. `scripts/regen-all.sh` regenerates the bulk of the derived
+surfaces, but it only **WARNS** about two that it cannot regenerate for you — those
+are the dominant fix-and-repush cause when landing a command. Regenerate them in the
+**same pass** before opening the PR, not piecemeal.
+
+This is the command-surface parallel of [new-skill-landing.md](new-skill-landing.md)
+(the six derived surfaces a *skill* edit must regenerate).
+
+## The shortcut
+
+`scripts/regen-all.sh` regenerates `cli/docs/COMMANDS.md`, `registry.json`, the
+skill/context maps, the embedded skills, and the cli-surface inventory in one pass —
+prefer it over running the individual generators. Then hand-fix the two surfaces it
+only warns about (below), and finally run `scripts/regen-all.sh --check`.
+
+## The two surfaces regen-all only WARNS about
+
+1. **Cobra `expectedCmds` (x2 lists)** — `cli/cmd/ao/cobra_commands_test.go` hardcodes
+   the registered-command list **twice**: once in `TestCobraCommandTreeRegistration`
+   and once in `TestCobraExpectedCmdsMatchRegistration` (the second comment even says
+   "Same list as TestCobraCommandTreeRegistration"). Both `expectedCmds` slices must
+   gain the new top-level command name, or the second test fails with
+   "registered command %q is not in expectedCmds — add it to keep the list in sync".
+
+2. **`cli-command-surface` heading counts** — the generated reference's `ao` heading
+   counts (`top`/`sub`/`all`) are asserted in **two** offline canaries that must move
+   together:
+   - `evals/agentops-core/fixtures/cli-command-surface-smoke.sh` — the
+     `top_count`/`sub_count`/`all_count` literals (currently `76`/`192`/`268`).
+   - `evals/agentops-core/cli-command-surface-matrix.json` — the public canary that
+     enumerates every documented command/subcommand help page.
+
+   **Run the smoke fixture to read the exact new counts** rather than computing them by
+   hand:
+
+   ```bash
+   bash evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+   # On a count mismatch it prints: unexpected command heading counts: top=.. sub=.. all=..
+   # Update the literals in the fixture (and the matrix.json cases) to the printed values.
+   ```
+
+   (Automating this regen is tracked as `ag-jy12`.)
+
+## See also
+
+- [new-skill-landing.md](new-skill-landing.md) — the six derived surfaces a *skill*
+  edit regenerates (the sibling discipline for the skills axis).
+- [gate-hygiene.md](gate-hygiene.md) — pre-push diff-scope check + pre-existing-vs-mine
+  red triage that keeps a command-landing PR one-shot-green.


### PR DESCRIPTION
## Summary

Backports two deltas validated on the LIVE plugin-cache evolve skill (`~/.claude/plugins/cache/agentops-marketplace/agentops/3.0.1/skills/evolve/SKILL.md`) into the repo source `skills/evolve/`, so they survive a plugin reinstall. Based on current `origin/main` (post-#724), preserving the `ao loop` refs — this PR only ADDs the missing lever/surface guidance.

**1. Pre-push fail-fast lever.** Pre-release checklist step 2 → `PRE_PUSH_FAIL_FAST=false bash scripts/pre-push-gate.sh`, with rationale: default fail-fast stops at a PRE-EXISTING failure (e.g. corpus-freshness) and masks the loop's own regressions by ending the run early. The full no-fail-fast gate surfaces every red.

**2. AO-command surfaces.** Pre-release checklist step 1 → `scripts/regen-all.sh` and names the two surfaces `regen-all` only WARNS about when ADDING an `ao` command: cobra `expectedCmds` (x2 lists in `cobra_commands_test.go`) + the `cli-command-surface` heading counts (smoke fixture + `matrix.json`). New reference `references/ao-command-landing.md` documents the full command-landing procedure, parallel to `new-skill-landing.md` (the skills axis).

## Regen / scope

- `registry.json` reference_count 26→27 (new reference file) + `skills-codex/*` source_hash for the SKILL.md prose edit — genuine consequences of the skill touch.
- Pre-existing `docs/cli-surface.*` drift (unrelated `ao loop` coverage recategorization) was REVERTED — out of scope.
- `regen-all.sh --check` clean across all skill/codex/registry drift validators.

## Note (install-lag)

The live v3.0.1 plugin-cache evolve skill was ALSO stale vs repo (pre-#724 `ao evolve` refs, missing the "six derived surfaces" note) — flagging the install-lag per the bead.

Closes-scenario: ag-ro1i#evolve-backport
Bounded-context: BC4-Factory
Evidence: skills/evolve/SKILL.md