### PR TITLE
feat(liveness): enforce author-judge quorum gate (ag-xdrw)

### DIFF
--- a/cli/cmd/ao/claim_cmd.go
+++ b/cli/cmd/ao/claim_cmd.go
@@ -25,7 +25,7 @@ var claimCmd = &cobra.Command{
 }
 
 var claimBindCmd = &cobra.Command{
-	Use:   "bind --claim <AOP-CLAIM-X> --path <evidence-path> [--level PG1|PG2|PG3|PG4] [--anchor ...]",
+	Use:   "bind --claim <AOP-CLAIM-X> --path <evidence-path> [--level PG1|PG2|PG3|PG4] [--anchor ...] [--author-id <id> --judge-id <id>]",
 	Short: "Bind a claim to an evidence file at a promotion level",
 	Long: `Append (or upgrade) a claim→evidence binding via the typed BC2
 ClaimEvidenceBinderPort (productionClaimEvidenceBinder, cycle 116).
@@ -36,7 +36,8 @@ to downgrade (e.g., PG3 → PG1) returns an error.
 
 Examples:
   ao claim bind --claim AOP-CLAIM-X --path .agents/findings/x.md --level PG2
-  ao claim bind --claim AOP-CLAIM-Y --path p.md --level PG4 --anchor L10 --anchor L20`,
+  ao claim bind --claim AOP-CLAIM-Y --path p.md --level PG4 --anchor L10 --anchor L20
+  ao claim bind --claim AOP-CLAIM-Z --path verdict.md --level PG4 --author-id worker-1 --judge-id verifier-2`,
 	RunE: runClaimBind,
 }
 
@@ -48,13 +49,15 @@ var claimListCmd = &cobra.Command{
 }
 
 type claimOptions struct {
-	claim   string
-	path    string
-	level   string
-	anchors []string
-	writer  io.Writer
-	bindFn  func(ctx context.Context, opts claimOptions) error
-	listFn  func(ctx context.Context, opts claimOptions) ([]ports.EvidenceBinding, error)
+	claim    string
+	path     string
+	level    string
+	anchors  []string
+	authorID string
+	judgeID  string
+	writer   io.Writer
+	bindFn   func(ctx context.Context, opts claimOptions) error
+	listFn   func(ctx context.Context, opts claimOptions) ([]ports.EvidenceBinding, error)
 }
 
 func init() {
@@ -65,6 +68,8 @@ func init() {
 	claimBindCmd.Flags().String("path", "", "evidence file path (required, relative to repo root)")
 	claimBindCmd.Flags().String("level", "PG1", "promotion level: PG1|PG2|PG3|PG4")
 	claimBindCmd.Flags().StringArray("anchor", nil, "optional in-file anchors (repeatable)")
+	claimBindCmd.Flags().String("author-id", "", "artifact author identity for reviewer separation checks")
+	claimBindCmd.Flags().String("judge-id", "", "judge/verifier identity for reviewer separation checks")
 	_ = claimBindCmd.MarkFlagRequired("claim")
 	_ = claimBindCmd.MarkFlagRequired("path")
 	claimCmd.AddCommand(claimBindCmd)
@@ -77,12 +82,16 @@ func runClaimBind(cmd *cobra.Command, _ []string) error {
 	path, _ := cmd.Flags().GetString("path")
 	level, _ := cmd.Flags().GetString("level")
 	anchors, _ := cmd.Flags().GetStringArray("anchor")
+	authorID, _ := cmd.Flags().GetString("author-id")
+	judgeID, _ := cmd.Flags().GetString("judge-id")
 	return claimBindRun(cmd.Context(), claimOptions{
-		claim:   claim,
-		path:    path,
-		level:   level,
-		anchors: anchors,
-		writer:  cmd.OutOrStdout(),
+		claim:    claim,
+		path:     path,
+		level:    level,
+		anchors:  anchors,
+		authorID: authorID,
+		judgeID:  judgeID,
+		writer:   cmd.OutOrStdout(),
 	})
 }
 
@@ -165,10 +174,12 @@ func claimBindViaPort(ctx context.Context, opts claimOptions) error {
 	}
 	b := newProductionClaimEvidenceBinder(path)
 	return b.Bind(ctx, ports.EvidenceBinding{
-		Claim:   ports.ClaimID(opts.claim),
-		Path:    opts.path,
-		Level:   ports.EvidenceLevel(strings.ToUpper(opts.level)),
-		Anchors: opts.anchors,
+		Claim:    ports.ClaimID(opts.claim),
+		Path:     opts.path,
+		Level:    ports.EvidenceLevel(strings.ToUpper(opts.level)),
+		Anchors:  opts.anchors,
+		AuthorID: opts.authorID,
+		JudgeID:  opts.judgeID,
 	})
 }
 

--- a/cli/cmd/ao/claim_cmd_test.go
+++ b/cli/cmd/ao/claim_cmd_test.go
@@ -45,12 +45,14 @@ func TestClaimBind_StubCalledWithBinding(t *testing.T) {
 	}
 	var buf bytes.Buffer
 	err := claimBindRun(context.Background(), claimOptions{
-		claim:   "AOP-CLAIM-X",
-		path:    ".agents/findings/x.md",
-		level:   "PG3",
-		anchors: []string{"L10", "L20"},
-		writer:  &buf,
-		bindFn:  stub,
+		claim:    "AOP-CLAIM-X",
+		path:     ".agents/findings/x.md",
+		level:    "PG3",
+		anchors:  []string{"L10", "L20"},
+		authorID: "agent-1",
+		judgeID:  "agent-2",
+		writer:   &buf,
+		bindFn:   stub,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -60,6 +62,9 @@ func TestClaimBind_StubCalledWithBinding(t *testing.T) {
 	}
 	if gotOpts.claim != "AOP-CLAIM-X" || gotOpts.level != "PG3" {
 		t.Fatalf("opts mismatch: %+v", gotOpts)
+	}
+	if gotOpts.authorID != "agent-1" || gotOpts.judgeID != "agent-2" {
+		t.Fatalf("reviewer metadata mismatch: %+v", gotOpts)
 	}
 	if !strings.Contains(buf.String(), `level=PG3`) {
 		t.Fatalf("confirmation missing level: %q", buf.String())

--- a/cli/cmd/ao/claim_evidence_adapter.go
+++ b/cli/cmd/ao/claim_evidence_adapter.go
@@ -53,9 +53,11 @@ func (a *productionClaimEvidence) Derive(ctx context.Context, req ports.ClaimEvi
 	newLevel := productionPromoteEvidenceLevel(verdict.Status, existingLevel, targetLevel)
 	return ports.ClaimEvidenceResult{
 		Binding: ports.EvidenceBinding{
-			Claim: req.Claim,
-			Path:  req.EvidenceFile,
-			Level: newLevel,
+			Claim:    req.Claim,
+			Path:     req.EvidenceFile,
+			Level:    newLevel,
+			AuthorID: req.AuthorID,
+			JudgeID:  req.JudgeID,
 		},
 		Verdict: verdict,
 	}, nil

--- a/cli/cmd/ao/claim_evidence_adapter_test.go
+++ b/cli/cmd/ao/claim_evidence_adapter_test.go
@@ -40,6 +40,22 @@ func TestProductionClaimEvidence_TargetLevelHonored(t *testing.T) {
 	}
 }
 
+func TestProductionClaimEvidence_BindingCarriesReviewerMetadata(t *testing.T) {
+	c := newPCEFixture(map[ports.GateName]ports.GateVerdict{
+		"g": {Status: ports.GateStatusPass, Reason: "ok"},
+	})
+	res, _ := c.Derive(context.Background(), ports.ClaimEvidenceRequest{
+		Claim:        "X",
+		EvidenceFile: "p",
+		Gate:         "g",
+		AuthorID:     "agent-1",
+		JudgeID:      "agent-2",
+	}, ports.EvidenceLevelNone, ports.EvidenceLevelPG4)
+	if res.Binding.AuthorID != "agent-1" || res.Binding.JudgeID != "agent-2" {
+		t.Fatalf("reviewer metadata not carried: %+v", res.Binding)
+	}
+}
+
 func TestProductionClaimEvidence_WarnToPG1(t *testing.T) {
 	c := newPCEFixture(map[ports.GateName]ports.GateVerdict{
 		"g": {Status: ports.GateStatusWarn, Reason: "advisory"},

--- a/cli/cmd/ao/claim_evidence_binder_adapter.go
+++ b/cli/cmd/ao/claim_evidence_binder_adapter.go
@@ -51,6 +51,9 @@ func (b *productionClaimEvidenceBinder) Bind(ctx context.Context, binding ports.
 	if binding.Path == "" {
 		return errors.New("productionClaimEvidenceBinder: Path required")
 	}
+	if err := ports.ValidateEvidenceBindingReviewers(binding); err != nil {
+		return fmt.Errorf("productionClaimEvidenceBinder: %w", err)
+	}
 	if b.path == "" {
 		return errors.New("productionClaimEvidenceBinder: file path required")
 	}
@@ -73,10 +76,12 @@ func (b *productionClaimEvidenceBinder) Bind(ctx context.Context, binding ports.
 	}
 
 	payload, err := json.Marshal(evidenceBindingRecord{
-		Claim:   string(binding.Claim),
-		Path:    binding.Path,
-		Level:   string(binding.Level),
-		Anchors: binding.Anchors,
+		Claim:    string(binding.Claim),
+		Path:     binding.Path,
+		Level:    string(binding.Level),
+		Anchors:  binding.Anchors,
+		AuthorID: binding.AuthorID,
+		JudgeID:  binding.JudgeID,
 	})
 	if err != nil {
 		return fmt.Errorf("productionClaimEvidenceBinder marshal: %w", err)
@@ -147,10 +152,12 @@ func (b *productionClaimEvidenceBinder) scanAllLocked() ([]ports.EvidenceBinding
 			continue
 		}
 		out = append(out, ports.EvidenceBinding{
-			Claim:   ports.ClaimID(rec.Claim),
-			Path:    rec.Path,
-			Level:   ports.EvidenceLevel(rec.Level),
-			Anchors: rec.Anchors,
+			Claim:    ports.ClaimID(rec.Claim),
+			Path:     rec.Path,
+			Level:    ports.EvidenceLevel(rec.Level),
+			Anchors:  rec.Anchors,
+			AuthorID: rec.AuthorID,
+			JudgeID:  rec.JudgeID,
 		})
 	}
 	if err := scanner.Err(); err != nil {
@@ -161,10 +168,12 @@ func (b *productionClaimEvidenceBinder) scanAllLocked() ([]ports.EvidenceBinding
 
 // evidenceBindingRecord is the on-disk shape.
 type evidenceBindingRecord struct {
-	Claim   string   `json:"claim"`
-	Path    string   `json:"path"`
-	Level   string   `json:"level,omitempty"`
-	Anchors []string `json:"anchors,omitempty"`
+	Claim    string   `json:"claim"`
+	Path     string   `json:"path"`
+	Level    string   `json:"level,omitempty"`
+	Anchors  []string `json:"anchors,omitempty"`
+	AuthorID string   `json:"author_id,omitempty"`
+	JudgeID  string   `json:"judge_id,omitempty"`
 }
 
 // evidenceLevelRank gives EvidenceLevel an integer ordering for the

--- a/cli/cmd/ao/claim_evidence_binder_adapter_test.go
+++ b/cli/cmd/ao/claim_evidence_binder_adapter_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/boshu2/agentops/cli/internal/ports"
@@ -124,6 +125,43 @@ func TestProductionClaimEvidenceBinder_EmptyPathRejected(t *testing.T) {
 	err := b.Bind(context.Background(), ports.EvidenceBinding{Claim: "X", Level: ports.EvidenceLevelPG1})
 	if err == nil {
 		t.Fatal("expected empty-path rejection, got nil")
+	}
+}
+
+func TestProductionClaimEvidenceBinder_SelfGradeRejected(t *testing.T) {
+	b := newTempBinder(t)
+	err := b.Bind(context.Background(), ports.EvidenceBinding{
+		Claim:    "X",
+		Path:     "p",
+		Level:    ports.EvidenceLevelPG4,
+		AuthorID: "agent-1",
+		JudgeID:  "agent-1",
+	})
+	if err == nil {
+		t.Fatal("expected self-grade rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "author_id and judge_id") {
+		t.Fatalf("error = %v, want author/judge guidance", err)
+	}
+}
+
+func TestProductionClaimEvidenceBinder_PreservesReviewerMetadata(t *testing.T) {
+	b := newTempBinder(t)
+	if err := b.Bind(context.Background(), ports.EvidenceBinding{
+		Claim:    "X",
+		Path:     "p",
+		Level:    ports.EvidenceLevelPG4,
+		AuthorID: "agent-1",
+		JudgeID:  "agent-2",
+	}); err != nil {
+		t.Fatalf("distinct author/judge rejected: %v", err)
+	}
+	list, err := b.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list[0].AuthorID != "agent-1" || list[0].JudgeID != "agent-2" {
+		t.Fatalf("reviewer metadata not preserved: %+v", list[0])
 	}
 }
 

--- a/cli/cmd/ao/claim_evidence_binder_adapter_test.go
+++ b/cli/cmd/ao/claim_evidence_binder_adapter_test.go
@@ -46,9 +46,11 @@ func TestProductionClaimEvidenceBinder_UpgradeAllowed(t *testing.T) {
 		Level: ports.EvidenceLevelPG1,
 	})
 	err := b.Bind(context.Background(), ports.EvidenceBinding{
-		Claim: "AOP-CLAIM-X",
-		Path:  "p",
-		Level: ports.EvidenceLevelPG3,
+		Claim:    "AOP-CLAIM-X",
+		Path:     "p",
+		Level:    ports.EvidenceLevelPG3,
+		AuthorID: "agent-1",
+		JudgeID:  "agent-2",
 	})
 	if err != nil {
 		t.Fatalf("PG1 → PG3 upgrade rejected: %v", err)
@@ -62,7 +64,11 @@ func TestProductionClaimEvidenceBinder_UpgradeAllowed(t *testing.T) {
 func TestProductionClaimEvidenceBinder_DowngradeRejected(t *testing.T) {
 	b := newTempBinder(t)
 	_ = b.Bind(context.Background(), ports.EvidenceBinding{
-		Claim: "AOP-CLAIM-X", Path: "p", Level: ports.EvidenceLevelPG3,
+		Claim:    "AOP-CLAIM-X",
+		Path:     "p",
+		Level:    ports.EvidenceLevelPG3,
+		AuthorID: "agent-1",
+		JudgeID:  "agent-2",
 	})
 	err := b.Bind(context.Background(), ports.EvidenceBinding{
 		Claim: "AOP-CLAIM-X", Path: "p", Level: ports.EvidenceLevelPG1,
@@ -125,6 +131,21 @@ func TestProductionClaimEvidenceBinder_EmptyPathRejected(t *testing.T) {
 	err := b.Bind(context.Background(), ports.EvidenceBinding{Claim: "X", Level: ports.EvidenceLevelPG1})
 	if err == nil {
 		t.Fatal("expected empty-path rejection, got nil")
+	}
+}
+
+func TestProductionClaimEvidenceBinder_HighAssuranceWithoutReviewersRejected(t *testing.T) {
+	b := newTempBinder(t)
+	err := b.Bind(context.Background(), ports.EvidenceBinding{
+		Claim: "X",
+		Path:  "p",
+		Level: ports.EvidenceLevelPG3,
+	})
+	if err == nil {
+		t.Fatal("expected PG3 reviewer metadata rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "author_id and judge_id") {
+		t.Fatalf("error = %v, want author/judge guidance", err)
 	}
 }
 

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -276,15 +276,17 @@ ao claim [command]
 Append (or upgrade) a claim→evidence binding via the typed BC2
 
 ```
-ao claim bind --claim <AOP-CLAIM-X> --path <evidence-path> [--level PG1|PG2|PG3|PG4] [--anchor ...] [flags]
+ao claim bind --claim <AOP-CLAIM-X> --path <evidence-path> [--level PG1|PG2|PG3|PG4] [--anchor ...] [--author-id <id> --judge-id <id>] [flags]
 ```
 
 **Flags:**
 
 ```
       --anchor stringArray   optional in-file anchors (repeatable)
+      --author-id string     artifact author identity for reviewer separation checks
       --claim string         claim ID (required, e.g. AOP-CLAIM-X)
   -h, --help                 help for bind
+      --judge-id string      judge/verifier identity for reviewer separation checks
       --level string         promotion level: PG1|PG2|PG3|PG4 (default "PG1")
       --path string          evidence file path (required, relative to repo root)
 ```

--- a/cli/internal/liveness/quorum.go
+++ b/cli/internal/liveness/quorum.go
@@ -1,0 +1,82 @@
+package liveness
+
+// SignificantAction is a control-plane action that must not be performed by one
+// orchestrator acting alone.
+type SignificantAction string
+
+const (
+	SignificantActionMergeMain          SignificantAction = "merge-main"
+	SignificantActionDelete             SignificantAction = "delete"
+	SignificantActionArchitectureChange SignificantAction = "architecture-change"
+	SignificantActionProductNorthStar   SignificantAction = "product-north-star"
+	SignificantActionP0Bead             SignificantAction = "p0-bead"
+	SignificantActionDocCanonization    SignificantAction = "doc-canonization"
+)
+
+// ACKVerdict records whether a quorum participant approved a significant action.
+type ACKVerdict string
+
+const (
+	ACKVerdictApprove ACKVerdict = "ACK"
+	ACKVerdictBlock   ACKVerdict = "BLOCK"
+)
+
+// QuorumACK is one recorded cross-model ACK from the consensus log.
+type QuorumACK struct {
+	AgentID     string
+	ModelFamily string
+	Verdict     ACKVerdict
+}
+
+// SignificantActionRequest is the orchestration-tier gate input. ActorID is the
+// orchestrator attempting the action; ACKs are the already-recorded quorum
+// approvals, for example from Agent Mail or bd.
+type SignificantActionRequest struct {
+	ActorID string
+	Action  SignificantAction
+	ACKs    []QuorumACK
+}
+
+// IsSignificantAction reports whether action needs cross-model quorum.
+func IsSignificantAction(action SignificantAction) bool {
+	switch action {
+	case SignificantActionMergeMain,
+		SignificantActionDelete,
+		SignificantActionArchitectureChange,
+		SignificantActionProductNorthStar,
+		SignificantActionP0Bead,
+		SignificantActionDocCanonization:
+		return true
+	default:
+		return false
+	}
+}
+
+// CheckSignificantAction enforces the orchestration-tier no-self-grade rule. A
+// non-significant action is allowed. A significant action needs at least two
+// distinct non-actor ACKs spanning at least two model families; otherwise it must
+// be routed to admission instead of executed.
+func CheckSignificantAction(req SignificantActionRequest) Decision {
+	if !IsSignificantAction(req.Action) {
+		return Allowed
+	}
+	if req.ActorID == "" {
+		return Denied
+	}
+	agents := map[string]struct{}{}
+	families := map[string]struct{}{}
+	for _, ack := range req.ACKs {
+		if ack.Verdict != ACKVerdictApprove {
+			continue
+		}
+		if ack.AgentID == "" || ack.ModelFamily == "" || ack.AgentID == req.ActorID {
+			continue
+		}
+		agents[ack.AgentID] = struct{}{}
+		families[ack.ModelFamily] = struct{}{}
+	}
+	if len(agents) >= 2 && len(families) >= 2 {
+		return Allowed
+	}
+	return NeedsAdmission
+}

--- a/cli/internal/liveness/quorum_test.go
+++ b/cli/internal/liveness/quorum_test.go
@@ -1,0 +1,79 @@
+package liveness
+
+import "testing"
+
+func TestCheckSignificantActionSoloCommitNeedsAdmission(t *testing.T) {
+	got := CheckSignificantAction(SignificantActionRequest{
+		ActorID: "sageharbor",
+		Action:  SignificantActionMergeMain,
+		ACKs:    nil,
+	})
+	if got != NeedsAdmission {
+		t.Fatalf("solo significant action = %q, want %q", got, NeedsAdmission)
+	}
+}
+
+func TestCheckSignificantActionTwoCrossModelACKsAllowed(t *testing.T) {
+	got := CheckSignificantAction(SignificantActionRequest{
+		ActorID: "sageharbor",
+		Action:  SignificantActionMergeMain,
+		ACKs: []QuorumACK{
+			{AgentID: "windycastle", ModelFamily: "claude", Verdict: ACKVerdictApprove},
+			{AgentID: "rubymoose", ModelFamily: "openai", Verdict: ACKVerdictApprove},
+		},
+	})
+	if got != Allowed {
+		t.Fatalf("two cross-model ACKs = %q, want %q", got, Allowed)
+	}
+}
+
+func TestCheckSignificantActionSameFamilyNeedsAdmission(t *testing.T) {
+	got := CheckSignificantAction(SignificantActionRequest{
+		ActorID: "sageharbor",
+		Action:  SignificantActionDelete,
+		ACKs: []QuorumACK{
+			{AgentID: "windycastle", ModelFamily: "claude", Verdict: ACKVerdictApprove},
+			{AgentID: "rubymoose", ModelFamily: "claude", Verdict: ACKVerdictApprove},
+		},
+	})
+	if got != NeedsAdmission {
+		t.Fatalf("same-family ACKs = %q, want %q", got, NeedsAdmission)
+	}
+}
+
+func TestCheckSignificantActionActorACKDoesNotCount(t *testing.T) {
+	got := CheckSignificantAction(SignificantActionRequest{
+		ActorID: "sageharbor",
+		Action:  SignificantActionP0Bead,
+		ACKs: []QuorumACK{
+			{AgentID: "sageharbor", ModelFamily: "openai", Verdict: ACKVerdictApprove},
+			{AgentID: "windycastle", ModelFamily: "claude", Verdict: ACKVerdictApprove},
+		},
+	})
+	if got != NeedsAdmission {
+		t.Fatalf("actor self-ACK counted: got %q, want %q", got, NeedsAdmission)
+	}
+}
+
+func TestCheckSignificantActionNonSignificantAllowed(t *testing.T) {
+	got := CheckSignificantAction(SignificantActionRequest{
+		ActorID: "sageharbor",
+		Action:  SignificantAction("nudge"),
+	})
+	if got != Allowed {
+		t.Fatalf("non-significant action = %q, want %q", got, Allowed)
+	}
+}
+
+func TestCheckSignificantActionMissingActorDenied(t *testing.T) {
+	got := CheckSignificantAction(SignificantActionRequest{
+		Action: SignificantActionArchitectureChange,
+		ACKs: []QuorumACK{
+			{AgentID: "windycastle", ModelFamily: "claude", Verdict: ACKVerdictApprove},
+			{AgentID: "rubymoose", ModelFamily: "openai", Verdict: ACKVerdictApprove},
+		},
+	})
+	if got != Denied {
+		t.Fatalf("missing actor = %q, want %q", got, Denied)
+	}
+}

--- a/cli/internal/ports/claim_evidence.go
+++ b/cli/internal/ports/claim_evidence.go
@@ -10,6 +10,8 @@ type ClaimEvidenceRequest struct {
 	Claim        ClaimID
 	EvidenceFile string
 	Gate         GateName
+	AuthorID     string
+	JudgeID      string
 }
 
 // ClaimEvidenceResult is the materialized binding plus its derived

--- a/cli/internal/ports/claim_evidence_binder.go
+++ b/cli/internal/ports/claim_evidence_binder.go
@@ -51,17 +51,21 @@ type EvidenceBinding struct {
 }
 
 // ValidateEvidenceBindingReviewers enforces the artifact-tier no-self-grade
-// invariant when reviewer metadata is present. Legacy bindings may omit both
-// IDs; a judgment that names only one side, or names the same author and judge,
-// is rejected at the port boundary.
+// invariant. PG3/PG4 bindings are high-assurance evidence and must carry
+// reviewer metadata. PG1/PG2 legacy bindings may omit both IDs, but any binding
+// that names reviewers must name both sides distinctly.
 func ValidateEvidenceBindingReviewers(binding EvidenceBinding) error {
-	if binding.AuthorID == "" && binding.JudgeID == "" {
+	if binding.AuthorID == "" && binding.JudgeID == "" && !requiresReviewerMetadata(binding.Level) {
 		return nil
 	}
 	if liveness.Disjoint(binding.AuthorID, binding.JudgeID) != liveness.Allowed {
 		return errors.New("ports: EvidenceBinding author_id and judge_id must be non-empty and distinct")
 	}
 	return nil
+}
+
+func requiresReviewerMetadata(level EvidenceLevel) bool {
+	return level == EvidenceLevelPG3 || level == EvidenceLevelPG4
 }
 
 // ClaimEvidenceBinderPort wraps the bind operation that creates or
@@ -82,7 +86,9 @@ func ValidateEvidenceBindingReviewers(binding EvidenceBinding) error {
 //     error in that case.
 //   - List returns all known bindings, most-recently-bound first.
 //   - Empty Claim or empty Path is a structural-rejection error on Bind.
-//   - If AuthorID or JudgeID is present, both MUST be present and distinct.
+//   - PG3/PG4 bindings MUST include distinct AuthorID and JudgeID; PG1/PG2
+//     bindings MAY omit both for legacy compatibility, but if either is present
+//     both MUST be present and distinct.
 //   - Context cancellation MUST be honored on a best-effort basis.
 //
 // See docs/contracts/ubiquitous-language.md (BC2 row) for the

--- a/cli/internal/ports/claim_evidence_binder.go
+++ b/cli/internal/ports/claim_evidence_binder.go
@@ -1,7 +1,12 @@
 // practices: [hexagonal-architecture, ddd-bounded-context]
 package ports
 
-import "context"
+import (
+	"context"
+	"errors"
+
+	"github.com/boshu2/agentops/cli/internal/liveness"
+)
 
 // ClaimID identifies a single AOP-CLAIM in the project's
 // .agents/findings/all-claims-evidence-map.md ledger (e.g.
@@ -37,10 +42,26 @@ const (
 // anchors (line numbers, named anchors) that adapters MAY populate to
 // help readers find the exact evidence span.
 type EvidenceBinding struct {
-	Claim   ClaimID
-	Path    string
-	Level   EvidenceLevel
-	Anchors []string
+	Claim    ClaimID
+	Path     string
+	Level    EvidenceLevel
+	Anchors  []string
+	AuthorID string
+	JudgeID  string
+}
+
+// ValidateEvidenceBindingReviewers enforces the artifact-tier no-self-grade
+// invariant when reviewer metadata is present. Legacy bindings may omit both
+// IDs; a judgment that names only one side, or names the same author and judge,
+// is rejected at the port boundary.
+func ValidateEvidenceBindingReviewers(binding EvidenceBinding) error {
+	if binding.AuthorID == "" && binding.JudgeID == "" {
+		return nil
+	}
+	if liveness.Disjoint(binding.AuthorID, binding.JudgeID) != liveness.Allowed {
+		return errors.New("ports: EvidenceBinding author_id and judge_id must be non-empty and distinct")
+	}
+	return nil
 }
 
 // ClaimEvidenceBinderPort wraps the bind operation that creates or
@@ -61,6 +82,7 @@ type EvidenceBinding struct {
 //     error in that case.
 //   - List returns all known bindings, most-recently-bound first.
 //   - Empty Claim or empty Path is a structural-rejection error on Bind.
+//   - If AuthorID or JudgeID is present, both MUST be present and distinct.
 //   - Context cancellation MUST be honored on a best-effort basis.
 //
 // See docs/contracts/ubiquitous-language.md (BC2 row) for the

--- a/cli/internal/ports/inmemory_claim_evidence.go
+++ b/cli/internal/ports/inmemory_claim_evidence.go
@@ -53,9 +53,11 @@ func (a *InMemoryClaimEvidence) Derive(ctx context.Context, req ClaimEvidenceReq
 	newLevel := promoteEvidenceLevel(verdict.Status, existingLevel, targetLevel)
 	return ClaimEvidenceResult{
 		Binding: EvidenceBinding{
-			Claim: req.Claim,
-			Path:  req.EvidenceFile,
-			Level: newLevel,
+			Claim:    req.Claim,
+			Path:     req.EvidenceFile,
+			Level:    newLevel,
+			AuthorID: req.AuthorID,
+			JudgeID:  req.JudgeID,
 		},
 		Verdict: verdict,
 	}, nil

--- a/cli/internal/ports/inmemory_claim_evidence_binder.go
+++ b/cli/internal/ports/inmemory_claim_evidence_binder.go
@@ -36,6 +36,9 @@ func (a *InMemoryClaimEvidenceBinder) Bind(ctx context.Context, binding Evidence
 	if binding.Path == "" {
 		return errors.New("ports: EvidenceBinding.Path required")
 	}
+	if err := ValidateEvidenceBindingReviewers(binding); err != nil {
+		return err
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	prev, existed := a.bindings[binding.Claim]

--- a/cli/internal/ports/inmemory_claim_evidence_binder_test.go
+++ b/cli/internal/ports/inmemory_claim_evidence_binder_test.go
@@ -88,6 +88,53 @@ func TestInMemoryClaimEvidenceBinder_BindRejectsEmptyClaimOrPath(t *testing.T) {
 	}
 }
 
+func TestInMemoryClaimEvidenceBinder_BindRejectsSelfGrade(t *testing.T) {
+	a := NewInMemoryClaimEvidenceBinder()
+	err := a.Bind(context.Background(), EvidenceBinding{
+		Claim:    "C",
+		Path:     "p",
+		Level:    EvidenceLevelPG4,
+		AuthorID: "agent-1",
+		JudgeID:  "agent-1",
+	})
+	if err == nil {
+		t.Fatal("expected self-grade rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "author_id and judge_id") {
+		t.Fatalf("error = %v, want author/judge guidance", err)
+	}
+}
+
+func TestInMemoryClaimEvidenceBinder_BindRejectsPartialReviewerMetadata(t *testing.T) {
+	a := NewInMemoryClaimEvidenceBinder()
+	err := a.Bind(context.Background(), EvidenceBinding{
+		Claim:    "C",
+		Path:     "p",
+		Level:    EvidenceLevelPG4,
+		AuthorID: "agent-1",
+	})
+	if err == nil {
+		t.Fatal("expected partial reviewer metadata rejection, got nil")
+	}
+}
+
+func TestInMemoryClaimEvidenceBinder_BindAcceptsDistinctAuthorJudge(t *testing.T) {
+	a := NewInMemoryClaimEvidenceBinder()
+	if err := a.Bind(context.Background(), EvidenceBinding{
+		Claim:    "C",
+		Path:     "p",
+		Level:    EvidenceLevelPG4,
+		AuthorID: "agent-1",
+		JudgeID:  "agent-2",
+	}); err != nil {
+		t.Fatalf("distinct author/judge rejected: %v", err)
+	}
+	list, _ := a.List(context.Background())
+	if list[0].AuthorID != "agent-1" || list[0].JudgeID != "agent-2" {
+		t.Fatalf("reviewer metadata not preserved: %+v", list[0])
+	}
+}
+
 func TestInMemoryClaimEvidenceBinder_ListReturnsMostRecentFirst(t *testing.T) {
 	a := NewInMemoryClaimEvidenceBinder()
 	_ = a.Bind(context.Background(), EvidenceBinding{Claim: "A", Path: "p", Level: EvidenceLevelPG1})

--- a/cli/internal/ports/inmemory_claim_evidence_binder_test.go
+++ b/cli/internal/ports/inmemory_claim_evidence_binder_test.go
@@ -55,7 +55,13 @@ func TestInMemoryClaimEvidenceBinder_BindAllowsLevelUpgrade(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Upgrade to PG3
-	if err := a.Bind(context.Background(), EvidenceBinding{Claim: "C", Path: "p", Level: EvidenceLevelPG3}); err != nil {
+	if err := a.Bind(context.Background(), EvidenceBinding{
+		Claim:    "C",
+		Path:     "p",
+		Level:    EvidenceLevelPG3,
+		AuthorID: "agent-1",
+		JudgeID:  "agent-2",
+	}); err != nil {
 		t.Fatalf("upgrade PG1 → PG3 should succeed, got %v", err)
 	}
 	list, _ := a.List(context.Background())
@@ -66,7 +72,13 @@ func TestInMemoryClaimEvidenceBinder_BindAllowsLevelUpgrade(t *testing.T) {
 
 func TestInMemoryClaimEvidenceBinder_BindRejectsLevelDowngrade(t *testing.T) {
 	a := NewInMemoryClaimEvidenceBinder()
-	if err := a.Bind(context.Background(), EvidenceBinding{Claim: "C", Path: "p", Level: EvidenceLevelPG3}); err != nil {
+	if err := a.Bind(context.Background(), EvidenceBinding{
+		Claim:    "C",
+		Path:     "p",
+		Level:    EvidenceLevelPG3,
+		AuthorID: "agent-1",
+		JudgeID:  "agent-2",
+	}); err != nil {
 		t.Fatal(err)
 	}
 	err := a.Bind(context.Background(), EvidenceBinding{Claim: "C", Path: "p", Level: EvidenceLevelPG1})
@@ -85,6 +97,21 @@ func TestInMemoryClaimEvidenceBinder_BindRejectsEmptyClaimOrPath(t *testing.T) {
 	}
 	if err := a.Bind(context.Background(), EvidenceBinding{Claim: "C", Level: EvidenceLevelPG1}); err == nil {
 		t.Fatal("expected error on empty Path, got nil")
+	}
+}
+
+func TestInMemoryClaimEvidenceBinder_BindRejectsHighAssuranceWithoutReviewers(t *testing.T) {
+	a := NewInMemoryClaimEvidenceBinder()
+	err := a.Bind(context.Background(), EvidenceBinding{
+		Claim: "C",
+		Path:  "p",
+		Level: EvidenceLevelPG3,
+	})
+	if err == nil {
+		t.Fatal("expected PG3 reviewer metadata rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "author_id and judge_id") {
+		t.Fatalf("error = %v, want author/judge guidance", err)
 	}
 }
 
@@ -115,6 +142,17 @@ func TestInMemoryClaimEvidenceBinder_BindRejectsPartialReviewerMetadata(t *testi
 	})
 	if err == nil {
 		t.Fatal("expected partial reviewer metadata rejection, got nil")
+	}
+}
+
+func TestInMemoryClaimEvidenceBinder_BindAcceptsLowAssuranceWithoutReviewers(t *testing.T) {
+	a := NewInMemoryClaimEvidenceBinder()
+	if err := a.Bind(context.Background(), EvidenceBinding{
+		Claim: "C",
+		Path:  "p",
+		Level: EvidenceLevelPG2,
+	}); err != nil {
+		t.Fatalf("PG2 anonymous legacy binding rejected: %v", err)
 	}
 }
 

--- a/cli/internal/ports/inmemory_claim_evidence_test.go
+++ b/cli/internal/ports/inmemory_claim_evidence_test.go
@@ -137,6 +137,22 @@ func TestInMemoryClaimEvidence_BindingCarriesClaimAndPath(t *testing.T) {
 	}
 }
 
+func TestInMemoryClaimEvidence_BindingCarriesReviewerMetadata(t *testing.T) {
+	c := newCEFixture(map[GateName]GateVerdict{
+		"g": {Status: GateStatusPass, Reason: "ok"},
+	})
+	res, _ := c.Derive(context.Background(), ClaimEvidenceRequest{
+		Claim:        "AOP-CLAIM-Y",
+		EvidenceFile: "p/q.md",
+		Gate:         "g",
+		AuthorID:     "agent-1",
+		JudgeID:      "agent-2",
+	}, EvidenceLevelNone, EvidenceLevelNone)
+	if res.Binding.AuthorID != "agent-1" || res.Binding.JudgeID != "agent-2" {
+		t.Fatalf("reviewer metadata not carried: %+v", res.Binding)
+	}
+}
+
 func TestInMemoryClaimEvidence_HonorsContextCancellation(t *testing.T) {
 	c := newCEFixture(map[GateName]GateVerdict{})
 	ctx, cancel := context.WithCancel(context.Background())

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-05T03:05:00Z",
+  "generated_at": "2026-06-05T03:47:28Z",
   "summary": {
     "skills": 82,
     "hooks": 0,


### PR DESCRIPTION
## Summary

Implements `ag-xdrw` independent-verification gates for claim-evidence and significant orchestration actions.

- Adds `author_id` / `judge_id` metadata to claim-evidence bindings.
- Rejects self-graded bindings at the ClaimEvidenceBinder port.
- Requires non-empty, distinct author/judge metadata for high-assurance PG3/PG4 evidence while preserving legacy anonymous PG1/PG2 behavior.
- Carries reviewer metadata through in-memory + production claim-evidence derive paths and durable JSONL binding records.
- Adds `liveness.CheckSignificantAction` for orchestration-tier significant actions requiring two distinct non-actor ACKs across at least two model families.
- Regenerates CLI docs/surface/registry after adding `ao claim bind --author-id/--judge-id` flags.

## Validation

Current head: `e4456538d89660c954ca12d347a186bd1cf68edf` rebased over #740 (`853d781e`).

Focused checks after rebase:

- `go test ./internal/liveness ./internal/ports`
- `go test ./cmd/ao -run 'TestProductionClaimEvidenceBinder|TestClaimBind|TestClaimList|TestProductionClaimEvidence|TestClaim'`

Required regen after rebase:

- `bash scripts/regen-all.sh` regenerated artifacts, then exited nonzero on the known CMDAO surface parity red: `wiki query` / 30 uncovered commands.

Required pre-push after rebase:

- `PRE_PUSH_FAIL_FAST=false bash scripts/pre-push-gate.sh` completed with 4 known non-diff failures:
  - test-fixture parity: `scripts/gc-stale-worktrees.sh`
  - worktree disposition: canonical root dirty/untracked operator state
  - corpus freshness: newest local snapshot older than threshold
  - contract canaries: known `agentops-core.pre-push-gate-governance` Bats failure

Diff-relevant gates passed in the pre-push run, including changed-scope build/vet/race, command/test pairing, `goals validate`, registry drift, CLI docs parity, command-surface matrix canary, shellcheck, mkdocs, contract compatibility, CI policy parity, and context-map drift.

## Review Gate

No self-grade: cross-model ACKs are recorded in Agent Mail.

- WindyCastle re-confirmed ACK on `547eb36f` and then explicitly called to rebase once more over #740 and merge this keystone next (#134).
- RubyMoose re-confirmed ACK on `547eb36f`; current `e4456538` is the same reviewed semantic diff rebased over #740 plus regenerated registry timestamp.

Review attacks covered:

- PG3/PG4 anonymous reviewer metadata rejects; PG1/PG2 anonymous legacy remains allowed.
- `AuthorID == JudgeID` rejects.
- Significant-action actor ACK does not count toward quorum.
- Two same-family ACKs do not satisfy quorum.
- Non-quorum path returns `NeedsAdmission`, never `Allowed`.

Bead: `ag-xdrw`
Evidence: TestProductionClaimEvidenceBinder_SelfGradeRejected
Evidence: TestProductionClaimEvidenceBinder_HighAssuranceWithoutReviewersRejected
Evidence: TestCheckSignificantActionTwoCrossModelACKsAllowed
Evidence: TestCheckSignificantActionActorACKDoesNotCount
