### PR TITLE
feat(liveness): typed work-lease tracking (ag-c3c7.2 #work-lease)

### DIFF
--- a/cli/internal/liveness/work_lease.go
+++ b/cli/internal/liveness/work_lease.go
@@ -55,6 +55,11 @@ var (
 	// ErrEvidenceRequired is returned when a renewal omits fresh evidence —
 	// alive means externally-visible evidence, not self-report.
 	ErrEvidenceRequired = errors.New("liveness: lease renewal requires a non-empty evidence_ref")
+	// ErrLeaseExpired is returned when renewing an already-expired lease.
+	// Expiry is a HARD state: an expired lease cannot be resurrected by its old
+	// owner; it must go through Create (quorum takeover). This keeps deadman /
+	// fallback mechanical instead of scheduler-luck dependent.
+	ErrLeaseExpired = errors.New("liveness: cannot renew an expired lease; use Create for takeover")
 )
 
 // LeaseTracker is a deterministic in-memory store of work leases keyed by
@@ -103,9 +108,11 @@ func (t *LeaseTracker) Create(beadID, branch, ownerAgentID, modelFamily, reason,
 	return lease, nil
 }
 
-// Renew extends an existing lease by ttl from now and records fresh evidence.
+// Renew extends an active lease by ttl from now and records fresh evidence.
 // The evidenceRef MUST be non-empty: a lease is kept alive by externally-visible
-// progress, not by self-report. Fails if the lease is absent.
+// progress, not by self-report. Renewal is for ACTIVE leases only — an already
+// expired lease returns ErrLeaseExpired and is left expired (expiry is a hard
+// state; takeover goes through Create). Fails if the lease is absent.
 func (t *LeaseTracker) Renew(beadID, evidenceRef string, ttl time.Duration) (WorkLease, error) {
 	if ttl <= 0 {
 		return WorkLease{}, errors.New("liveness: Renew requires a positive ttl")
@@ -118,6 +125,9 @@ func (t *LeaseTracker) Renew(beadID, evidenceRef string, ttl time.Duration) (Wor
 		return WorkLease{}, fmt.Errorf("%w: %s", ErrLeaseNotFound, beadID)
 	}
 	now := t.now()
+	if lease.Status(now) == LeaseExpired {
+		return WorkLease{}, fmt.Errorf("%w: %s (expired %s)", ErrLeaseExpired, beadID, lease.ExpiresAt.Format(time.RFC3339))
+	}
 	lease.RenewedAt = now
 	lease.ExpiresAt = now.Add(ttl)
 	lease.EvidenceRef = evidenceRef

--- a/cli/internal/liveness/work_lease.go
+++ b/cli/internal/liveness/work_lease.go
@@ -1,0 +1,170 @@
+package liveness
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// Clock returns the current time. Inject a fixed Clock in tests for
+// deterministic lease behaviour; production passes time.Now.
+type Clock func() time.Time
+
+// LeaseStatus is the computed state of a WorkLease relative to a clock.
+type LeaseStatus string
+
+const (
+	// LeaseActive means the lease has not yet reached its ExpiresAt.
+	LeaseActive LeaseStatus = "active"
+	// LeaseExpired means the lease's ExpiresAt is at or before now.
+	LeaseExpired LeaseStatus = "expired"
+)
+
+// WorkLease is the substrate record of who owns an active work arc and when the
+// claim lapses. It makes no admission decision itself; deadman/fallback consume
+// expired leases to know which work is abandoned and eligible for quorum
+// takeover. A lease stays alive only on externally-visible evidence (renewal
+// requires a fresh evidence_ref), never on self-report.
+type WorkLease struct {
+	BeadID       string    // the work item under lease
+	Branch       string    // the worktree branch carrying the work
+	OwnerAgentID string    // the agent holding the lease
+	ModelFamily  string    // owner's model family (for cross-model accounting)
+	LeaseReason  string    // why the lease was taken
+	IssuedAt     time.Time // when the lease was first created
+	ExpiresAt    time.Time // when the lease lapses absent renewal
+	RenewedAt    time.Time // last renewal; zero until first renewal
+	EvidenceRef  string    // external evidence justifying the latest lease
+}
+
+// Status reports whether the lease is active or expired as of now.
+func (l WorkLease) Status(now time.Time) LeaseStatus {
+	if !now.Before(l.ExpiresAt) {
+		return LeaseExpired
+	}
+	return LeaseActive
+}
+
+// Sentinel errors for lease operations. Callers compare with errors.Is.
+var (
+	// ErrLeaseNotFound is returned when no lease exists for a BeadID.
+	ErrLeaseNotFound = errors.New("liveness: work lease not found")
+	// ErrLeaseActive is returned when creating over a still-active lease.
+	ErrLeaseActive = errors.New("liveness: an active work lease already exists for bead")
+	// ErrEvidenceRequired is returned when a renewal omits fresh evidence —
+	// alive means externally-visible evidence, not self-report.
+	ErrEvidenceRequired = errors.New("liveness: lease renewal requires a non-empty evidence_ref")
+)
+
+// LeaseTracker is a deterministic in-memory store of work leases keyed by
+// BeadID. Every time decision routes through the injected Clock, so the
+// behaviour is reproducible and testable.
+type LeaseTracker struct {
+	now    Clock
+	leases map[string]WorkLease
+}
+
+// NewLeaseTracker returns a tracker driven by the given Clock. A nil Clock
+// defaults to time.Now.
+func NewLeaseTracker(now Clock) *LeaseTracker {
+	if now == nil {
+		now = time.Now
+	}
+	return &LeaseTracker{now: now, leases: map[string]WorkLease{}}
+}
+
+// Create issues a new lease for beadID, expiring ttl from now. It succeeds when
+// no lease exists or the existing lease has already expired (quorum takeover
+// re-leases abandoned work); it fails on a still-active lease, empty identity
+// fields, or a non-positive ttl.
+func (t *LeaseTracker) Create(beadID, branch, ownerAgentID, modelFamily, reason, evidenceRef string, ttl time.Duration) (WorkLease, error) {
+	if beadID == "" || ownerAgentID == "" {
+		return WorkLease{}, errors.New("liveness: Create requires non-empty beadID and ownerAgentID")
+	}
+	if ttl <= 0 {
+		return WorkLease{}, errors.New("liveness: Create requires a positive ttl")
+	}
+	now := t.now()
+	if existing, ok := t.leases[beadID]; ok && existing.Status(now) == LeaseActive {
+		return WorkLease{}, fmt.Errorf("%w: %s (owner %s, expires %s)", ErrLeaseActive, beadID, existing.OwnerAgentID, existing.ExpiresAt.Format(time.RFC3339))
+	}
+	lease := WorkLease{
+		BeadID:       beadID,
+		Branch:       branch,
+		OwnerAgentID: ownerAgentID,
+		ModelFamily:  modelFamily,
+		LeaseReason:  reason,
+		IssuedAt:     now,
+		ExpiresAt:    now.Add(ttl),
+		EvidenceRef:  evidenceRef,
+	}
+	t.leases[beadID] = lease
+	return lease, nil
+}
+
+// Renew extends an existing lease by ttl from now and records fresh evidence.
+// The evidenceRef MUST be non-empty: a lease is kept alive by externally-visible
+// progress, not by self-report. Fails if the lease is absent.
+func (t *LeaseTracker) Renew(beadID, evidenceRef string, ttl time.Duration) (WorkLease, error) {
+	if ttl <= 0 {
+		return WorkLease{}, errors.New("liveness: Renew requires a positive ttl")
+	}
+	if evidenceRef == "" {
+		return WorkLease{}, ErrEvidenceRequired
+	}
+	lease, ok := t.leases[beadID]
+	if !ok {
+		return WorkLease{}, fmt.Errorf("%w: %s", ErrLeaseNotFound, beadID)
+	}
+	now := t.now()
+	lease.RenewedAt = now
+	lease.ExpiresAt = now.Add(ttl)
+	lease.EvidenceRef = evidenceRef
+	t.leases[beadID] = lease
+	return lease, nil
+}
+
+// Expire force-expires a lease (explicit release or quorum takeover) by setting
+// ExpiresAt to now. The record is retained for audit.
+func (t *LeaseTracker) Expire(beadID string) (WorkLease, error) {
+	lease, ok := t.leases[beadID]
+	if !ok {
+		return WorkLease{}, fmt.Errorf("%w: %s", ErrLeaseNotFound, beadID)
+	}
+	lease.ExpiresAt = t.now()
+	t.leases[beadID] = lease
+	return lease, nil
+}
+
+// Get returns the lease for beadID.
+func (t *LeaseTracker) Get(beadID string) (WorkLease, error) {
+	lease, ok := t.leases[beadID]
+	if !ok {
+		return WorkLease{}, fmt.Errorf("%w: %s", ErrLeaseNotFound, beadID)
+	}
+	return lease, nil
+}
+
+// List returns all leases sorted by BeadID for deterministic output.
+func (t *LeaseTracker) List() []WorkLease {
+	out := make([]WorkLease, 0, len(t.leases))
+	for _, l := range t.leases {
+		out = append(out, l)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].BeadID < out[j].BeadID })
+	return out
+}
+
+// Expired returns the leases whose ExpiresAt is at or before now, sorted by
+// BeadID. deadman/fallback consumes this to mark work for quorum takeover.
+func (t *LeaseTracker) Expired() []WorkLease {
+	now := t.now()
+	var out []WorkLease
+	for _, l := range t.List() {
+		if l.Status(now) == LeaseExpired {
+			out = append(out, l)
+		}
+	}
+	return out
+}

--- a/cli/internal/liveness/work_lease_test.go
+++ b/cli/internal/liveness/work_lease_test.go
@@ -108,6 +108,35 @@ func TestLeaseTracker_RenewRequiresFreshEvidence(t *testing.T) {
 	}
 }
 
+func TestLeaseTracker_RenewRejectsExpiredLease(t *testing.T) {
+	base := time.Date(2026, 6, 5, 3, 0, 0, 0, time.UTC)
+	clk := base
+	tr := NewLeaseTracker(func() time.Time { return clk })
+	if _, err := tr.Create("ag-1", "b", "ruby", "claude", "r", "ev-1", time.Hour); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Advance past expiry; renewal — even with fresh evidence — must NOT
+	// resurrect an expired lease. Expiry is a hard state; takeover goes through
+	// Create, not Renew.
+	clk = base.Add(2 * time.Hour)
+	if _, err := tr.Renew("ag-1", "ev-2", time.Hour); !errors.Is(err, ErrLeaseExpired) {
+		t.Fatalf("renew expired lease: want ErrLeaseExpired, got %v", err)
+	}
+	// The lease stays expired and its ExpiresAt is unchanged (not extended).
+	got, _ := tr.Get("ag-1")
+	if got.Status(clk) != LeaseExpired {
+		t.Fatalf("expired lease should stay expired after rejected renew, got %s", got.Status(clk))
+	}
+	if got.ExpiresAt != base.Add(time.Hour) {
+		t.Fatalf("rejected renew must not extend ExpiresAt: want %v, got %v", base.Add(time.Hour), got.ExpiresAt)
+	}
+	// Create over the expired lease IS the takeover path (still allowed).
+	if _, err := tr.Create("ag-1", "b2", "windy", "claude", "takeover", "ev-3", time.Hour); err != nil {
+		t.Fatalf("Create takeover over expired lease should succeed: %v", err)
+	}
+}
+
 func TestLeaseTracker_StatusListAndExpired(t *testing.T) {
 	base := time.Date(2026, 6, 5, 3, 0, 0, 0, time.UTC)
 	clk := base

--- a/cli/internal/liveness/work_lease_test.go
+++ b/cli/internal/liveness/work_lease_test.go
@@ -1,0 +1,166 @@
+package liveness
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func fixedClock(at time.Time) Clock { return func() time.Time { return at } }
+
+func TestLeaseTracker_CreateSetsFieldsAndTimes(t *testing.T) {
+	base := time.Date(2026, 6, 5, 3, 0, 0, 0, time.UTC)
+	tr := NewLeaseTracker(fixedClock(base))
+
+	got, err := tr.Create("ag-1", "feat/ag-1", "ruby", "claude", "build slice", "ev-1", time.Hour)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got.IssuedAt != base {
+		t.Fatalf("IssuedAt = %v, want %v", got.IssuedAt, base)
+	}
+	if got.ExpiresAt != base.Add(time.Hour) {
+		t.Fatalf("ExpiresAt = %v, want %v", got.ExpiresAt, base.Add(time.Hour))
+	}
+	if !got.RenewedAt.IsZero() {
+		t.Fatalf("RenewedAt should be zero before renewal, got %v", got.RenewedAt)
+	}
+	if got.OwnerAgentID != "ruby" || got.ModelFamily != "claude" || got.Branch != "feat/ag-1" || got.EvidenceRef != "ev-1" {
+		t.Fatalf("fields not recorded: %+v", got)
+	}
+	stored, err := tr.Get("ag-1")
+	if err != nil || stored.BeadID != "ag-1" {
+		t.Fatalf("Get after Create: %+v err=%v", stored, err)
+	}
+}
+
+func TestLeaseTracker_CreateRejectsInvalidAndActiveDuplicate(t *testing.T) {
+	base := time.Date(2026, 6, 5, 3, 0, 0, 0, time.UTC)
+	tr := NewLeaseTracker(fixedClock(base))
+
+	if _, err := tr.Create("", "b", "owner", "f", "r", "e", time.Hour); err == nil {
+		t.Fatal("empty beadID accepted")
+	}
+	if _, err := tr.Create("ag-1", "b", "", "f", "r", "e", time.Hour); err == nil {
+		t.Fatal("empty ownerAgentID accepted")
+	}
+	if _, err := tr.Create("ag-1", "b", "owner", "f", "r", "e", 0); err == nil {
+		t.Fatal("non-positive ttl accepted")
+	}
+	if _, err := tr.Create("ag-1", "b", "owner", "f", "r", "e", time.Hour); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	// Duplicate over an ACTIVE lease is rejected.
+	if _, err := tr.Create("ag-1", "b", "owner2", "f", "r", "e", time.Hour); !errors.Is(err, ErrLeaseActive) {
+		t.Fatalf("duplicate active create: want ErrLeaseActive, got %v", err)
+	}
+}
+
+func TestLeaseTracker_CreateReleasesExpiredForTakeover(t *testing.T) {
+	base := time.Date(2026, 6, 5, 3, 0, 0, 0, time.UTC)
+	clk := base
+	tr := NewLeaseTracker(func() time.Time { return clk })
+
+	if _, err := tr.Create("ag-1", "b", "ruby", "claude", "r", "e", time.Hour); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	// Advance past expiry; a new owner may take over the abandoned bead.
+	clk = base.Add(2 * time.Hour)
+	got, err := tr.Create("ag-1", "b2", "windy", "claude", "takeover", "ev-2", time.Hour)
+	if err != nil {
+		t.Fatalf("takeover Create over expired lease: %v", err)
+	}
+	if got.OwnerAgentID != "windy" || got.Branch != "b2" || got.IssuedAt != clk {
+		t.Fatalf("takeover did not replace owner: %+v", got)
+	}
+}
+
+func TestLeaseTracker_RenewRequiresFreshEvidence(t *testing.T) {
+	base := time.Date(2026, 6, 5, 3, 0, 0, 0, time.UTC)
+	clk := base
+	tr := NewLeaseTracker(func() time.Time { return clk })
+	if _, err := tr.Create("ag-1", "b", "ruby", "claude", "r", "ev-1", time.Hour); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Renewal without evidence is rejected — alive = external evidence.
+	if _, err := tr.Renew("ag-1", "", time.Hour); !errors.Is(err, ErrEvidenceRequired) {
+		t.Fatalf("renew without evidence: want ErrEvidenceRequired, got %v", err)
+	}
+	// Renewal with fresh evidence extends expiry and stamps RenewedAt.
+	clk = base.Add(30 * time.Minute)
+	got, err := tr.Renew("ag-1", "ev-2", time.Hour)
+	if err != nil {
+		t.Fatalf("Renew: %v", err)
+	}
+	if got.RenewedAt != clk {
+		t.Fatalf("RenewedAt = %v, want %v", got.RenewedAt, clk)
+	}
+	if got.ExpiresAt != clk.Add(time.Hour) {
+		t.Fatalf("ExpiresAt = %v, want %v", got.ExpiresAt, clk.Add(time.Hour))
+	}
+	if got.EvidenceRef != "ev-2" {
+		t.Fatalf("EvidenceRef = %q, want ev-2", got.EvidenceRef)
+	}
+	// Renewing a missing lease is an error.
+	if _, err := tr.Renew("nope", "ev", time.Hour); !errors.Is(err, ErrLeaseNotFound) {
+		t.Fatalf("renew missing: want ErrLeaseNotFound, got %v", err)
+	}
+}
+
+func TestLeaseTracker_StatusListAndExpired(t *testing.T) {
+	base := time.Date(2026, 6, 5, 3, 0, 0, 0, time.UTC)
+	clk := base
+	tr := NewLeaseTracker(func() time.Time { return clk })
+	mustCreate(t, tr, "ag-2", 2*time.Hour)
+	mustCreate(t, tr, "ag-1", time.Hour)
+
+	// Before any expiry: none expired, list sorted by BeadID.
+	if exp := tr.Expired(); len(exp) != 0 {
+		t.Fatalf("want 0 expired, got %d", len(exp))
+	}
+	all := tr.List()
+	if len(all) != 2 || all[0].BeadID != "ag-1" || all[1].BeadID != "ag-2" {
+		t.Fatalf("List not sorted/complete: %+v", all)
+	}
+
+	// Advance past ag-1's expiry only.
+	clk = base.Add(90 * time.Minute)
+	exp := tr.Expired()
+	if len(exp) != 1 || exp[0].BeadID != "ag-1" {
+		t.Fatalf("want [ag-1] expired, got %+v", exp)
+	}
+	if exp[0].Status(clk) != LeaseExpired {
+		t.Fatalf("ag-1 status = %s, want expired", exp[0].Status(clk))
+	}
+	if ag2, _ := tr.Get("ag-2"); ag2.Status(clk) != LeaseActive {
+		t.Fatalf("ag-2 status = %s, want active", ag2.Status(clk))
+	}
+}
+
+func TestLeaseTracker_ExpireForceExpires(t *testing.T) {
+	base := time.Date(2026, 6, 5, 3, 0, 0, 0, time.UTC)
+	tr := NewLeaseTracker(fixedClock(base))
+	mustCreate(t, tr, "ag-1", time.Hour)
+
+	got, err := tr.Expire("ag-1")
+	if err != nil {
+		t.Fatalf("Expire: %v", err)
+	}
+	if got.ExpiresAt != base {
+		t.Fatalf("force-expire should set ExpiresAt=now (%v), got %v", base, got.ExpiresAt)
+	}
+	if got.Status(base) != LeaseExpired {
+		t.Fatal("force-expired lease should report expired at now")
+	}
+	if _, err := tr.Expire("nope"); !errors.Is(err, ErrLeaseNotFound) {
+		t.Fatalf("expire missing: want ErrLeaseNotFound, got %v", err)
+	}
+}
+
+func mustCreate(t *testing.T, tr *LeaseTracker, beadID string, ttl time.Duration) {
+	t.Helper()
+	if _, err := tr.Create(beadID, "branch", "owner", "claude", "reason", "ev", ttl); err != nil {
+		t.Fatalf("Create(%s): %v", beadID, err)
+	}
+}


### PR DESCRIPTION
## What
A deterministic liveness-domain **work-lease tracker** — the substrate record of who owns an active work arc and when the claim lapses. deadman/fallback (later slice) consumes expired leases to know which work is abandoned and eligible for quorum takeover. Makes no admission decision itself.

`cli/internal/liveness/work_lease.go` (+ test):
- `WorkLease{BeadID, Branch, OwnerAgentID, ModelFamily, LeaseReason, IssuedAt, ExpiresAt, RenewedAt, EvidenceRef}` + `Status(now)`.
- `LeaseTracker` (injected `Clock`): `Create / Renew / Expire / Get / List / Expired`.

## Invariants (the kernel's principles, mechanical)
- **No-self-grade on liveness:** `Renew` requires a **non-empty `evidence_ref`** → `ErrEvidenceRequired`. Alive = externally-visible evidence, not self-report.
- **Quorum takeover:** `Create` rejects an *active* duplicate (`ErrLeaseActive`) but **re-leases an expired bead** (new owner takes over abandoned work).
- **Deterministic:** every time decision routes through the injected `Clock` — reproducible, testable; tests use a fixed clock.

## Scope (per SageHarbor's carve, Agent Mail #115)
New `work_lease{,_test}.go` ONLY. **Not** admission classification, pulse/quorum schema, deadman escalation, or the #737 author/judge gate. Untouched: `ports/claim_evidence_binder.go`, `session_bootstrap.go`, `search/*`, `registry.json`, generated CLI docs.

## Validation
- 6 tests pass (create/takeover, evidence-gated renewal, status/expired, force-expire) with exact-value assertions + fake clock.
- Local gate: `go build` / `go vet` / `go test -race (changed scope)` / command-test pairing / HOME-isolation all **green**. The 4 remaining local reds (gc-stale-worktrees fixture, canonical-root-dirty [shared checkout], goals-validate, corpus-freshness) are the **pre-existing non-diff** set (same as #730/#736/#737).

Requesting **≥2-of-3 cross-model review** — this is liveness-kernel code, review hard.

Closes-scenario: ag-c3c7.2#work-lease
Bounded-context: BC5-Runtime
Evidence: cli/internal/liveness/work_lease.go