### PR TITLE
feat(memory): inject canon memory during session bootstrap

### DIFF
--- a/cli/cmd/ao/session_bootstrap.go
+++ b/cli/cmd/ao/session_bootstrap.go
@@ -29,14 +29,19 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/boshu2/agentops/cli/internal/adapters/tracker_bd"
+	"github.com/boshu2/agentops/cli/internal/search"
+	"github.com/boshu2/agentops/cli/internal/types"
 
 	"github.com/spf13/cobra"
 )
@@ -86,14 +91,32 @@ func init() {
 // SessionBootstrapStatus is the canonical bootstrap report shape. Field
 // names and types must match schemas/session-bootstrap.v1.schema.json.
 type SessionBootstrapStatus struct {
-	AgentsMDRead       bool     `json:"agents_md_read"`
-	AgentsSiblingsRead []string `json:"agents_siblings_read"`
-	OnboardPhase       string   `json:"onboard_phase"`
-	ReadyBeadsCount    *int     `json:"ready_beads_count"`
-	MailUnreadCount    *int     `json:"mail_unread_count"`
-	Runtime            string   `json:"runtime"`
-	StartedAt          string   `json:"started_at"`
-	BootstrapVersion   string   `json:"bootstrap_version"`
+	AgentsMDRead                bool                         `json:"agents_md_read"`
+	AgentsSiblingsRead          []string                     `json:"agents_siblings_read"`
+	OnboardPhase                string                       `json:"onboard_phase"`
+	ReadyBeadsCount             *int                         `json:"ready_beads_count"`
+	MailUnreadCount             *int                         `json:"mail_unread_count"`
+	Runtime                     string                       `json:"runtime"`
+	StartedAt                   string                       `json:"started_at"`
+	BootstrapVersion            string                       `json:"bootstrap_version"`
+	BootstrapMemory             []SessionBootstrapMemoryItem `json:"bootstrap_memory"`
+	BootstrapMemoryBudgetTokens int                          `json:"bootstrap_memory_budget_tokens"`
+	BootstrapMemoryUsedTokens   int                          `json:"bootstrap_memory_used_tokens"`
+	BootstrapMemoryOmittedCount int                          `json:"bootstrap_memory_omitted_count"`
+	BootstrapMemoryOverBudget   bool                         `json:"bootstrap_memory_over_budget"`
+}
+
+// SessionBootstrapMemoryItem is a compact canon-gated T2 memory entry surfaced
+// at bootstrap.
+type SessionBootstrapMemoryItem struct {
+	ID       string  `json:"id"`
+	Title    string  `json:"title"`
+	Content  string  `json:"content"`
+	Source   string  `json:"source"`
+	Maturity string  `json:"maturity"`
+	Reach    string  `json:"reach"`
+	Score    float64 `json:"score"`
+	Tokens   int     `json:"tokens"`
 }
 
 // agentsMDSiblings are the post-vuu6.3 split files. Reported individually so
@@ -105,9 +128,14 @@ var agentsMDSiblings = []string{
 	"AGENTS-RUNTIME.md",
 }
 
+const sessionBootstrapMemoryTokenBudget = 1200
+
 func runSessionBootstrap(cmd *cobra.Command, _ []string) error {
 	robot := sessionBootstrapRobot || sessionBootstrapJSON
 	status := computeBootstrapStatus(cmd.Context(), os.Getenv("PWD"), sessionBootstrapNoMail)
+	if err := writeBootstrapMemoryWarning(cmd.ErrOrStderr(), status); err != nil {
+		return err
+	}
 
 	if robot {
 		enc := json.NewEncoder(cmd.OutOrStdout())
@@ -132,11 +160,13 @@ func computeBootstrapStatus(ctx context.Context, cwd string, noMail bool) Sessio
 	}
 
 	status := SessionBootstrapStatus{
-		AgentsSiblingsRead: []string{},
-		Runtime:            detectRuntime(),
-		StartedAt:          time.Now().UTC().Format(time.RFC3339),
-		BootstrapVersion:   "v1",
-		OnboardPhase:       sessionBootstrapOnboard(ctx, cwd),
+		AgentsSiblingsRead:          []string{},
+		Runtime:                     detectRuntime(),
+		StartedAt:                   time.Now().UTC().Format(time.RFC3339),
+		BootstrapVersion:            "v1",
+		OnboardPhase:                sessionBootstrapOnboard(ctx, cwd),
+		BootstrapMemory:             []SessionBootstrapMemoryItem{},
+		BootstrapMemoryBudgetTokens: sessionBootstrapMemoryTokenBudget,
 	}
 
 	status.AgentsMDRead = fileExists(filepath.Join(cwd, "AGENTS.md"))
@@ -156,7 +186,146 @@ func computeBootstrapStatus(ctx context.Context, cwd string, noMail bool) Sessio
 		}
 	}
 
+	memory, used, omitted := sessionBootstrapCanonMemory(cwd, sessionBootstrapMemoryTokenBudget, nowFunc())
+	status.BootstrapMemory = memory
+	status.BootstrapMemoryUsedTokens = used
+	status.BootstrapMemoryOmittedCount = omitted
+	status.BootstrapMemoryOverBudget = omitted > 0
+
 	return status
+}
+
+type sessionBootstrapMemoryCandidate struct {
+	item  SessionBootstrapMemoryItem
+	score float64
+}
+
+func sessionBootstrapCanonMemory(cwd string, tokenBudget int, now time.Time) ([]SessionBootstrapMemoryItem, int, int) {
+	if tokenBudget <= 0 || cwd == "" {
+		return []SessionBootstrapMemoryItem{}, 0, 0
+	}
+	canonPath := filepath.Join(cwd, canonLearningsDir)
+	if !dirExists(canonPath) {
+		return []SessionBootstrapMemoryItem{}, 0, 0
+	}
+
+	candidates := make([]sessionBootstrapMemoryCandidate, 0)
+	for _, file := range globLearningFiles(canonPath) {
+		l, err := parseLearningFile(file)
+		if err != nil || l.Superseded {
+			continue
+		}
+		meta := sessionBootstrapLearningMetadata(file)
+		if !sessionBootstrapMemoryEligible(l, meta) {
+			continue
+		}
+		applyFreshnessScore(&l, file, now)
+		if l.Utility <= 0 {
+			l.Utility = types.InitialUtility
+		}
+		content := sessionBootstrapMemoryContent(l)
+		tokens := max(1, estimateTokens(strings.Join([]string{l.Title, content}, "\n")))
+		score := l.Utility * meta.confidence * maxFloat(l.FreshnessScore, 0.1)
+		item := SessionBootstrapMemoryItem{
+			ID:       l.ID,
+			Title:    l.Title,
+			Content:  content,
+			Source:   l.Source,
+			Maturity: l.Maturity,
+			Reach:    search.ComputeReach(l.Reach, l.Maturity, true),
+			Score:    score,
+			Tokens:   tokens,
+		}
+		candidates = append(candidates, sessionBootstrapMemoryCandidate{item: item, score: score})
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].score == candidates[j].score {
+			return candidates[i].item.ID < candidates[j].item.ID
+		}
+		return candidates[i].score > candidates[j].score
+	})
+
+	selected := make([]SessionBootstrapMemoryItem, 0, len(candidates))
+	used := 0
+	omitted := 0
+	for _, candidate := range candidates {
+		if used+candidate.item.Tokens > tokenBudget {
+			omitted++
+			continue
+		}
+		selected = append(selected, candidate.item)
+		used += candidate.item.Tokens
+	}
+	return selected, used, omitted
+}
+
+type sessionBootstrapMemoryMetadata struct {
+	confidence float64
+	severity   string
+}
+
+func sessionBootstrapLearningMetadata(file string) sessionBootstrapMemoryMetadata {
+	meta := sessionBootstrapMemoryMetadata{confidence: 0.5}
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return meta
+	}
+	content := string(data)
+	if strings.HasSuffix(file, ".jsonl") {
+		first := strings.SplitN(content, "\n", 2)[0]
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(first), &payload); err == nil {
+			if confidence, ok := payload["confidence"].(float64); ok && confidence > 0 {
+				meta.confidence = confidence
+			}
+			if severity, ok := payload["severity"].(string); ok {
+				meta.severity = strings.ToLower(strings.TrimSpace(severity))
+			}
+		}
+		return meta
+	}
+	fields := parseFrontmatterFromContent(content, "confidence", "severity")
+	if confidence, err := strconv.ParseFloat(strings.TrimSpace(fields["confidence"]), 64); err == nil && confidence > 0 {
+		meta.confidence = confidence
+	}
+	meta.severity = strings.ToLower(strings.TrimSpace(fields["severity"]))
+	return meta
+}
+
+func sessionBootstrapMemoryEligible(l learning, meta sessionBootstrapMemoryMetadata) bool {
+	switch types.Maturity(strings.ToLower(strings.TrimSpace(l.Maturity))) {
+	case types.MaturityEstablished:
+		return true
+	case types.MaturityAntiPattern:
+		return meta.severity == "high" || meta.severity == "critical"
+	default:
+		return false
+	}
+}
+
+func sessionBootstrapMemoryContent(l learning) string {
+	content := strings.TrimSpace(l.BodyText)
+	if content == "" {
+		content = strings.TrimSpace(l.Summary)
+	}
+	return content
+}
+
+func writeBootstrapMemoryWarning(w io.Writer, s SessionBootstrapStatus) error {
+	if !s.BootstrapMemoryOverBudget {
+		return nil
+	}
+	_, err := fmt.Fprintf(w, "warn: bootstrap memory canon set exceeded %d tokens; injected %d tokens and omitted %d lower-ranked item(s)\n",
+		s.BootstrapMemoryBudgetTokens, s.BootstrapMemoryUsedTokens, s.BootstrapMemoryOmittedCount)
+	return err
+}
+
+func maxFloat(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func detectRuntime() string {
@@ -254,12 +423,41 @@ func printBootstrapSummary(cmd *cobra.Command, s SessionBootstrapStatus) error {
 	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "session bootstrap: %s\n", strings.Join(parts, " ")); err != nil {
 		return err
 	}
+	if len(s.BootstrapMemory) > 0 {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "bootstrap memory: %d item(s), %d/%d tokens\n",
+			len(s.BootstrapMemory), s.BootstrapMemoryUsedTokens, s.BootstrapMemoryBudgetTokens); err != nil {
+			return err
+		}
+		for _, item := range s.BootstrapMemory {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "- %s [%s/%s] score=%.3f source=%s\n",
+				item.Title, item.Maturity, item.Reach, item.Score, item.Source); err != nil {
+				return err
+			}
+			if content := formatBootstrapMemoryContent(item.Content); content != "" {
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", content); err != nil {
+					return err
+				}
+			}
+		}
+	}
 	if !s.AgentsMDRead {
 		_, err := fmt.Fprintln(cmd.ErrOrStderr(),
 			"warn: AGENTS.md missing — start with `cat AGENTS.md` if it exists, or `bd onboard` for repo orientation")
 		return err
 	}
 	return nil
+}
+
+func formatBootstrapMemoryContent(content string) string {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return ""
+	}
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimSpace(line)
+	}
+	return strings.Join(lines, "\n  ")
 }
 
 // sessionBootstrapMakeReady is a test seam for the ready-beads path. Kept here

--- a/cli/cmd/ao/session_bootstrap_test.go
+++ b/cli/cmd/ao/session_bootstrap_test.go
@@ -10,9 +10,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSessionBootstrap_FullStatusJSON(t *testing.T) {
@@ -106,6 +109,8 @@ func TestSessionBootstrap_PrintsHumanSummaryByDefault(t *testing.T) {
 	dir := t.TempDir()
 	mustWriteFile(t, filepath.Join(dir, "AGENTS.md"), "# A")
 	mustWriteFile(t, filepath.Join(dir, "AGENTS-WORKFLOW.md"), "# w")
+	writeBootstrapLearning(t, filepath.Join(dir, ".agents", "canon", "learnings", "human.md"),
+		"Canon Human", "established", "", "0.8", "1.0", "human bootstrap canon memory should be visible")
 
 	s := computeBootstrapStatus(context.Background(), dir, true)
 
@@ -117,7 +122,15 @@ func TestSessionBootstrap_PrintsHumanSummaryByDefault(t *testing.T) {
 		t.Fatalf("printBootstrapSummary: %v", err)
 	}
 	got := out.String()
-	for _, want := range []string{"session bootstrap:", "agents_md=ok", "siblings=1/4", "onboard=skipped"} {
+	for _, want := range []string{
+		"session bootstrap:",
+		"agents_md=ok",
+		"siblings=1/4",
+		"onboard=skipped",
+		"bootstrap memory: 1 item(s)",
+		"Canon Human",
+		"human bootstrap canon memory should be visible",
+	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("summary: want substring %q, got %q", want, got)
 		}
@@ -126,12 +139,14 @@ func TestSessionBootstrap_PrintsHumanSummaryByDefault(t *testing.T) {
 
 func TestSessionBootstrap_JSONRoundTripsStatus(t *testing.T) {
 	s := SessionBootstrapStatus{
-		AgentsMDRead:       true,
-		AgentsSiblingsRead: []string{"AGENTS-WORKFLOW.md"},
-		OnboardPhase:       "skipped:not-implemented",
-		Runtime:            "test",
-		StartedAt:          "2026-05-20T00:00:00Z",
-		BootstrapVersion:   "v1",
+		AgentsMDRead:                true,
+		AgentsSiblingsRead:          []string{"AGENTS-WORKFLOW.md"},
+		OnboardPhase:                "skipped:not-implemented",
+		Runtime:                     "test",
+		StartedAt:                   "2026-05-20T00:00:00Z",
+		BootstrapVersion:            "v1",
+		BootstrapMemory:             []SessionBootstrapMemoryItem{},
+		BootstrapMemoryBudgetTokens: sessionBootstrapMemoryTokenBudget,
 	}
 	blob, err := json.Marshal(s)
 	if err != nil {
@@ -143,6 +158,87 @@ func TestSessionBootstrap_JSONRoundTripsStatus(t *testing.T) {
 	}
 	if back.AgentsMDRead != s.AgentsMDRead || back.OnboardPhase != s.OnboardPhase {
 		t.Fatalf("round-trip mismatch: %+v vs %+v", back, s)
+	}
+}
+
+func TestSessionBootstrap_CanonGatedMemoryFiltersToEstablishedAndHighAntiPatterns(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "AGENTS.md"), "# AGENTS")
+	for i := range 200 {
+		writeBootstrapLearning(t, filepath.Join(dir, ".agents", "learnings", fmt.Sprintf("local-%03d.md", i)),
+			"Local Established", "established", "high", "0.99", "1.0", "local established must not be injected")
+		writeBootstrapLearning(t, filepath.Join(dir, ".agents", "canon", "learnings", fmt.Sprintf("candidate-%03d.md", i)),
+			"Canon Candidate", "candidate", "high", "0.99", "1.0", "canon candidate must not be injected")
+	}
+	writeBootstrapLearning(t, filepath.Join(dir, ".agents", "canon", "learnings", "established.md"),
+		"Canon Established", "established", "", "0.9", "1.0", "established canon memory should be injected")
+	writeBootstrapLearning(t, filepath.Join(dir, ".agents", "canon", "learnings", "anti-high.md"),
+		"High Anti Pattern", "anti-pattern", "high", "0.8", "1.0", "high severity anti-pattern guardrail should be injected")
+	writeBootstrapLearning(t, filepath.Join(dir, ".agents", "canon", "learnings", "anti-medium.md"),
+		"Medium Anti Pattern", "anti-pattern", "medium", "0.8", "1.0", "medium severity anti-pattern must not be injected")
+
+	got := computeBootstrapStatus(context.Background(), dir, true)
+	titles := map[string]bool{}
+	for _, item := range got.BootstrapMemory {
+		titles[item.Title] = true
+		if item.Maturity == "established" && item.Reach != "always" {
+			t.Fatalf("established canon reach = %q, want always", item.Reach)
+		}
+	}
+	if !titles["Canon Established"] || !titles["High Anti Pattern"] {
+		t.Fatalf("missing expected canon memory titles: %v", titles)
+	}
+	if titles["Local Established"] || titles["Canon Candidate"] || titles["Medium Anti Pattern"] {
+		t.Fatalf("ineligible memory injected: %v", titles)
+	}
+	if got.BootstrapMemoryUsedTokens > sessionBootstrapMemoryTokenBudget {
+		t.Fatalf("used tokens = %d, want <= %d", got.BootstrapMemoryUsedTokens, sessionBootstrapMemoryTokenBudget)
+	}
+}
+
+func TestSessionBootstrap_CanonMemoryOverBudgetWarnsAndKeepsTopUnderCap(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "AGENTS.md"), "# AGENTS")
+	body := strings.Repeat("budgeted canon sentence ", 100)
+	for i := range 8 {
+		writeBootstrapLearning(t, filepath.Join(dir, ".agents", "canon", "learnings", fmt.Sprintf("canon-%02d.md", i)),
+			fmt.Sprintf("Canon %02d", i), "established", "", fmt.Sprintf("0.%d", i+1), "1.0", body)
+	}
+
+	got := computeBootstrapStatus(context.Background(), dir, true)
+	if !got.BootstrapMemoryOverBudget {
+		t.Fatal("BootstrapMemoryOverBudget = false, want true")
+	}
+	if got.BootstrapMemoryUsedTokens > sessionBootstrapMemoryTokenBudget {
+		t.Fatalf("used tokens = %d, want <= %d", got.BootstrapMemoryUsedTokens, sessionBootstrapMemoryTokenBudget)
+	}
+	if got.BootstrapMemoryOmittedCount == 0 {
+		t.Fatal("BootstrapMemoryOmittedCount = 0, want omitted lower-ranked items")
+	}
+	if len(got.BootstrapMemory) == 0 || got.BootstrapMemory[0].Title != "Canon 07" {
+		t.Fatalf("first bootstrap memory = %+v, want highest utility Canon 07", got.BootstrapMemory)
+	}
+	var warn bytes.Buffer
+	if err := writeBootstrapMemoryWarning(&warn, got); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(warn.String(), "exceeded 1200 tokens") {
+		t.Fatalf("warning = %q, want token budget warning", warn.String())
+	}
+}
+
+func writeBootstrapLearning(t *testing.T, path, title, maturity, severity, utility, confidence, body string) {
+	t.Helper()
+	severityLine := ""
+	if severity != "" {
+		severityLine = "severity: " + severity + "\n"
+	}
+	content := fmt.Sprintf("---\nmaturity: %s\n%sutility: %s\nconfidence: %s\n---\n# %s\n\n%s\n",
+		maturity, severityLine, utility, confidence, title, body)
+	mustWriteFile(t, path, content)
+	when := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(path, when, when); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
 	}
 }
 

--- a/docs/cli-surface.json
+++ b/docs/cli-surface.json
@@ -912,11 +912,11 @@
       "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
     },
     {
-      "category": "manual-only",
+      "category": "public-tested",
       "command": "loop blocked",
-      "coverage_status": "missing",
+      "coverage_status": "covered",
       "kind": "leaf",
-      "reason": "No smoke, direct test, or allowlist coverage found."
+      "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
     },
     {
       "category": "public-tested",
@@ -947,11 +947,11 @@
       "reason": "No smoke, direct test, or allowlist coverage found."
     },
     {
-      "category": "manual-only",
+      "category": "public-tested",
       "command": "loop next-work",
-      "coverage_status": "missing",
+      "coverage_status": "covered",
       "kind": "leaf",
-      "reason": "No smoke, direct test, or allowlist coverage found."
+      "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
     },
     {
       "category": "public-tested",
@@ -961,11 +961,11 @@
       "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
     },
     {
-      "category": "manual-only",
+      "category": "public-tested",
       "command": "loop write-stop-marker",
-      "coverage_status": "missing",
+      "coverage_status": "covered",
       "kind": "leaf",
-      "reason": "No smoke, direct test, or allowlist coverage found."
+      "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
     },
     {
       "category": "public-tested",

--- a/docs/cli-surface.md
+++ b/docs/cli-surface.md
@@ -134,14 +134,14 @@
 | `ao knowledge playbooks` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao lookup` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao loop append` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
-| `ao loop blocked` | `manual-only` | `missing` | No smoke, direct test, or allowlist coverage found. |
+| `ao loop blocked` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao loop converged` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao loop history` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao loop hypothesis append` | `manual-only` | `missing` | No smoke, direct test, or allowlist coverage found. |
 | `ao loop hypothesis list` | `manual-only` | `missing` | No smoke, direct test, or allowlist coverage found. |
-| `ao loop next-work` | `manual-only` | `missing` | No smoke, direct test, or allowlist coverage found. |
+| `ao loop next-work` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao loop verify` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
-| `ao loop write-stop-marker` | `manual-only` | `missing` | No smoke, direct test, or allowlist coverage found. |
+| `ao loop write-stop-marker` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao maturity` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao mcp serve` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao memory sync` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-05T02:33:27Z",
+  "generated_at": "2026-06-05T03:05:00Z",
   "summary": {
     "skills": 82,
     "hooks": 0,

--- a/schemas/session-bootstrap.v1.schema.json
+++ b/schemas/session-bootstrap.v1.schema.json
@@ -12,7 +12,12 @@
     "mail_unread_count",
     "runtime",
     "started_at",
-    "bootstrap_version"
+    "bootstrap_version",
+    "bootstrap_memory",
+    "bootstrap_memory_budget_tokens",
+    "bootstrap_memory_used_tokens",
+    "bootstrap_memory_omitted_count",
+    "bootstrap_memory_over_budget"
   ],
   "properties": {
     "agents_md_read": {
@@ -67,6 +72,51 @@
       "type": "string",
       "const": "v1",
       "description": "Schema version. Increment in a new schema file when fields change shape."
+    },
+    "bootstrap_memory": {
+      "type": "array",
+      "description": "Canon-gated T2 memory injected at bootstrap: canon-promoted established learnings plus high-severity canon anti-patterns, ranked and capped below the normal ao inject budget.",
+      "items": {
+        "type": "object",
+        "required": ["id", "title", "content", "source", "maturity", "reach", "score", "tokens"],
+        "properties": {
+          "id": { "type": "string" },
+          "title": { "type": "string" },
+          "content": { "type": "string" },
+          "source": { "type": "string" },
+          "maturity": { "type": "string" },
+          "reach": {
+            "type": "string",
+            "enum": ["bead", "pull", "always"]
+          },
+          "score": { "type": "number" },
+          "tokens": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "bootstrap_memory_budget_tokens": {
+      "type": "integer",
+      "const": 1200,
+      "description": "Hard token budget for bootstrap_memory; intentionally below DefaultInjectMaxTokens (1500)."
+    },
+    "bootstrap_memory_used_tokens": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1200,
+      "description": "Approximate tokens used by selected bootstrap_memory items."
+    },
+    "bootstrap_memory_omitted_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of eligible canon memory items omitted because the 1200-token bootstrap budget was full."
+    },
+    "bootstrap_memory_over_budget": {
+      "type": "boolean",
+      "description": "True when eligible canon memory exceeded the hard budget and lower-ranked items were omitted with a stderr warning."
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## Summary

Implements ag-11bi W2.3 canon-gated T2 bootstrap memory for `ao session bootstrap`.

- Selects only canon-promoted established learnings plus high/critical severity canon anti-patterns from `.agents/canon/learnings`.
- Ranks by `utility * confidence * freshness`, caps selection at 1200 estimated tokens, and warns on stderr when eligible canon memory exceeds the cap.
- Computes reach through the existing search reach helper, so established canon memory surfaces as `reach=always` without author-set reach.
- Emits the memory payload in JSON/robot output and prints selected memory in the default human bootstrap output.
- Extends `schemas/session-bootstrap.v1.schema.json` and tests the filter, budget, warning, and human-output paths.

## Validation

Focused checks:

- `go test ./cmd/ao -run 'TestSessionBootstrap'`
- `go test ./internal/search ./internal/types`
- `git diff --check`
- `python3 -m json.tool schemas/session-bootstrap.v1.schema.json`

Required regen:

- `bash scripts/regen-all.sh` regenerated artifacts but exited on the known CMDAO `wiki query` parity red.

Required pre-push after rebase:

- `PRE_PUSH_FAIL_FAST=false bash scripts/pre-push-gate.sh` completed with 4 known non-diff failures:
  - test-fixture parity: `scripts/gc-stale-worktrees.sh`
  - worktree disposition: canonical root dirty/untracked operator state
  - corpus freshness: newest local snapshot older than threshold
  - contract canaries: known `agentops-core.pre-push-gate-governance` Bats failure

Diff-relevant gates passed in the pre-push run, including changed-scope Go race tests, command/test pairing, goals validate, registry drift, CLI docs parity, command-surface matrix canary, schema checks, CI policy parity, and shellcheck.

## Review Ask

Requesting cross-model ACK/AMEND/BLOCK before merge. Primary attacks to run:

- Does any non-canon or candidate/provisional learning enter bootstrap memory?
- Can the 1200-token cap be bypassed or hidden from callers?
- Does the default human path actually expose the selected memory, not just JSON?
- Is the generated CLI-surface drift acceptable as regen output on this branch?

No self-grade for merge.
