### PR TITLE
refactor(evidencedturn): converge author≠judge onto liveness.Disjoint (DRIFT fix, impl #2)

### DIFF
--- a/cli/internal/evidencedturn/evidencedturn.go
+++ b/cli/internal/evidencedturn/evidencedturn.go
@@ -35,6 +35,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/boshu2/agentops/cli/internal/liveness"
 	"github.com/boshu2/agentops/cli/internal/provenancegraph"
 	"github.com/boshu2/agentops/cli/internal/turnstate"
 )
@@ -339,16 +340,23 @@ func evalAuthorNeqValidator(in Input) PredicateResult {
 		r.Reason = "self-grading explicitly waived via --allow-self (inline fallback)"
 		return r
 	}
-	if author == "" {
-		r.Reason = "no author_id recorded (cannot prove the judge is independent of the author)"
-		return r
-	}
-	if judge == "" {
-		r.Reason = "no judge_id recorded (independent judge context required; use --allow-self to waive)"
-		return r
-	}
-	if judge == author {
-		r.Reason = fmt.Sprintf("verdict self-graded: judge_id == author_id (%q); an independent judge context is required (use --allow-self to waive)", author)
+	// Route the core author!=judge decision through the canonical
+	// liveness.Disjoint predicate (ag-xdrw/#737) so there is ONE no-self-grade
+	// invariant, not a divergent reimplementation. Disjoint denies on empty
+	// author, empty judge, OR author==judge — behaviour-identical to the prior
+	// inline checks here — but now a single source of truth. The divergence
+	// between these reimplementations is exactly what let the empty-ID
+	// self-grade bypass recur (#737 PG3/PG4, #741 citation reward). Reason
+	// strings stay specific for verdict legibility.
+	if liveness.Disjoint(author, judge) != liveness.Allowed {
+		switch {
+		case author == "":
+			r.Reason = "no author_id recorded (cannot prove the judge is independent of the author)"
+		case judge == "":
+			r.Reason = "no judge_id recorded (independent judge context required; use --allow-self to waive)"
+		default:
+			r.Reason = fmt.Sprintf("verdict self-graded: judge_id == author_id (%q); an independent judge context is required (use --allow-self to waive)", author)
+		}
 		return r
 	}
 	r.Passed = true

--- a/cli/internal/evidencedturn/evidencedturn_test.go
+++ b/cli/internal/evidencedturn/evidencedturn_test.go
@@ -3,9 +3,46 @@ package evidencedturn
 import (
 	"testing"
 
+	"github.com/boshu2/agentops/cli/internal/liveness"
 	"github.com/boshu2/agentops/cli/internal/provenancegraph"
 	"github.com/boshu2/agentops/cli/internal/turnstate"
 )
+
+// TestAuthorNeqValidator_AgreesWithDisjoint locks the no-self-grade consolidation:
+// the predicate's decision MUST match the canonical liveness.Disjoint predicate
+// (ag-xdrw) across every identity case. If a future change reintroduces a
+// divergent inline check, this fails — the divergence between reimplementations
+// is precisely what let the empty-ID self-grade bypass recur (#737 PG3/PG4, #741
+// citation reward). The --allow-self waiver is an explicit override on top.
+func TestAuthorNeqValidator_AgreesWithDisjoint(t *testing.T) {
+	cases := []struct {
+		name          string
+		author, judge string
+		wantPass      bool
+	}{
+		{"distinct", "session:a", "session:b", true},
+		{"self-graded", "session:a", "session:a", false},
+		{"empty-author", "", "session:b", false},
+		{"empty-judge", "session:a", "", false},
+		{"both-empty", "", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := evalAuthorNeqValidator(Input{AuthorID: c.author, JudgeID: c.judge})
+			wantDisjoint := liveness.Disjoint(c.author, c.judge) == liveness.Allowed
+			if got.Passed != wantDisjoint {
+				t.Fatalf("author=%q judge=%q: validator pass=%v but Disjoint=%v — DIVERGENCE", c.author, c.judge, got.Passed, wantDisjoint)
+			}
+			if got.Passed != c.wantPass {
+				t.Fatalf("author=%q judge=%q: want pass=%v, got %v", c.author, c.judge, c.wantPass, got.Passed)
+			}
+		})
+	}
+	// The documented --allow-self escape hatch still overrides a self-grade.
+	if w := evalAuthorNeqValidator(Input{AuthorID: "session:x", JudgeID: "session:x", AllowSelf: true}); !w.Passed {
+		t.Fatal("--allow-self must still waive a self-graded verdict (preserved behavior)")
+	}
+}
 
 // wellFormedTransitions builds a verifying, sealed log that folds the bead into
 // the "closed" state: ""->in_progress->validated->closed.


### PR DESCRIPTION
## What
WindyCastle's vibe-check (Agent Mail #149) found the **no-self-grade / author≠judge invariant fragmented across 3 divergent implementations** on main:
1. `liveness.Disjoint` (ag-xdrw/#737) — the canonical one.
2. `evidencedturn`'s `evalAuthorNeqValidator` (ag-lmdx.4) — **this PR**.
3. #741's inline `EqualFold` — SageHarbor converges in parallel.

That divergence (empty-handling / case / waiver) is **why the empty-ID self-grade bypass recurred** (#737 PG3/PG4 → #741 citation reward).

This PR converges **impl #2**: `evalAuthorNeqValidator` now routes its core author≠judge decision through `liveness.Disjoint`.

## Behavior-preserving
`Disjoint` denies on `empty-author OR empty-judge OR author==judge` — **identical** to the prior inline checks. Verified: all existing `evidencedturn` tests pass unchanged. Preserved: the `--allow-self` waiver (explicit pre-check) + the specific legible reason strings.

## Anti-recurrence lock
Adds `TestAuthorNeqValidator_AgreesWithDisjoint` — asserts the validator's decision matches `liveness.Disjoint` across every identity case (distinct / self-graded / empty-author / empty-judge / both-empty) + the waiver. **A future re-divergence fails CI** — the structural fix WindyCastle's finding asks for.

## Scope
2 files (`evidencedturn.go` +28/−10, `evidencedturn_test.go` +37). `evidencedturn`→`liveness` import, **no cycle** (liveness doesn't import evidencedturn). No overlap with #741 (different package — SageHarbor owns impl #3). `go build ./...` + vet + race + package tests green; 4 reds are the known non-diff set.

> Provenance: bead pending Dolt write recovery (down per #149); vibe-check #149 + Agent Mail #151 carry the claim. File the p1 DRIFT bead when Dolt's back.

Bounded-context: BC5-Runtime
Evidence: TestAuthorNeqValidator_AgreesWithDisjoint