### PR TITLE
chore(ci): guard author≠judge convergence on liveness.Disjoint (DRIFT #149 gate)

### DIFF
--- a/scripts/check-author-judge-convergence.sh
+++ b/scripts/check-author-judge-convergence.sh
@@ -18,8 +18,15 @@ set -euo pipefail
 
 ROOT="${1:-cli}"
 
-# author<->judge identity equality in CODE, in any of the three historical shapes.
-PATTERN='(EqualFold\([^)]*([Aa]uthor|[Jj]udge)|([Aa]uthor[A-Za-z]*)[[:space:]]*==[[:space:]]*([Jj]udge|[Cc]ited)|([Jj]udge[A-Za-z]*)[[:space:]]*==[[:space:]]*([Aa]uthor))'
+# author<->grader identity equality in CODE, in EITHER operand order. The grader
+# side is "judge" (verdict) or "cited" (citation reward); the author!=judge
+# invariant covers both author/judge and author/cited pairs. Identifiers are matched
+# by *containing* the keyword (e.g. artifactAuthor, citedByAgent), and the equality
+# may be written in either direction (artifactAuthor == citedByAgent OR
+# citedByAgent == artifactAuthor) — both are the same self-grade predicate.
+AUTH='[A-Za-z]*[Aa]uthor[A-Za-z]*'
+GRADER='[A-Za-z]*([Jj]udge|[Cc]ited)[A-Za-z]*'
+PATTERN="(EqualFold\\([^)]*([Aa]uthor|[Jj]udge|[Cc]ited)|${AUTH}[[:space:]]*==[[:space:]]*${GRADER}|${GRADER}[[:space:]]*==[[:space:]]*${AUTH})"
 
 hits="$(grep -rnE "$PATTERN" "$ROOT" --include='*.go' 2>/dev/null \
   | grep -viE '_test\.go' \

--- a/scripts/check-author-judge-convergence.sh
+++ b/scripts/check-author-judge-convergence.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# check-author-judge-convergence.sh — guard the no-self-grade convergence.
+#
+# DRIFT #149 / the 2nd-occurrence gate: the empty-ID self-grade bypass recurred
+# (#737 PG3/PG4 -> #741 citation reward) because the author!=judge invariant was
+# reimplemented in divergent places instead of reusing one predicate. #744 + #741
+# converged the three sites onto cli/internal/liveness Disjoint. This guard keeps
+# it converged: the ONLY author!=judge equality logic may live in liveness.Disjoint
+# (cli/internal/liveness/guards.go). Any other Go site doing its own
+# `author == judge` / `EqualFold(author, judge)` / `judge_id == author_id`
+# equality is a divergent reimplementation and must call liveness.Disjoint instead.
+#
+# Comments and *_test.go files are not flagged (a comment may describe the
+# invariant; tests assert it). Exit non-zero on any divergent site.
+#
+# Usage: check-author-judge-convergence.sh [ROOT]   (ROOT defaults to "cli")
+set -euo pipefail
+
+ROOT="${1:-cli}"
+
+# author<->judge identity equality in CODE, in any of the three historical shapes.
+PATTERN='(EqualFold\([^)]*([Aa]uthor|[Jj]udge)|([Aa]uthor[A-Za-z]*)[[:space:]]*==[[:space:]]*([Jj]udge|[Cc]ited)|([Jj]udge[A-Za-z]*)[[:space:]]*==[[:space:]]*([Aa]uthor))'
+
+hits="$(grep -rnE "$PATTERN" "$ROOT" --include='*.go' 2>/dev/null \
+  | grep -viE '_test\.go' \
+  | grep -vE ':[0-9]+:[[:space:]]*//' \
+  | grep -vE '(^|/)internal/liveness/guards\.go:' \
+  || true)"
+
+if [ -n "$hits" ]; then
+  echo "FAIL: divergent author!=judge equality found outside liveness.Disjoint:" >&2
+  echo "$hits" >&2
+  echo >&2
+  echo "Route the no-self-grade decision through liveness.Disjoint (cli/internal/liveness/guards.go)." >&2
+  echo "Reimplementing author!=judge is the DRIFT #149 pattern that let the empty-ID bypass recur (#737->#741)." >&2
+  exit 1
+fi
+
+echo "ok: author!=judge convergence — all sites route through liveness.Disjoint"

--- a/scripts/check-author-judge-convergence.sh
+++ b/scripts/check-author-judge-convergence.sh
@@ -26,7 +26,12 @@ ROOT="${1:-cli}"
 # citedByAgent == artifactAuthor) — both are the same self-grade predicate.
 AUTH='[A-Za-z]*[Aa]uthor[A-Za-z]*'
 GRADER='[A-Za-z]*([Jj]udge|[Cc]ited)[A-Za-z]*'
-PATTERN="(EqualFold\\([^)]*([Aa]uthor|[Jj]udge|[Cc]ited)|${AUTH}[[:space:]]*==[[:space:]]*${GRADER}|${GRADER}[[:space:]]*==[[:space:]]*${AUTH})"
+# Both the case-insensitive (EqualFold) and direct (==) arms require exactly ONE
+# author operand AND ONE grader operand (judge/cited), in either order. This is
+# the author-vs-grader self-grade pair; author-vs-author or grader-vs-grader is
+# NOT flagged (e.g. EqualFold(authorName, authorEmail) is fine — no grader side).
+EQF="EqualFold\\([[:space:]]*(${AUTH}[[:space:]]*,[[:space:]]*${GRADER}|${GRADER}[[:space:]]*,[[:space:]]*${AUTH})"
+PATTERN="(${EQF}|${AUTH}[[:space:]]*==[[:space:]]*${GRADER}|${GRADER}[[:space:]]*==[[:space:]]*${AUTH})"
 
 hits="$(grep -rnE "$PATTERN" "$ROOT" --include='*.go' 2>/dev/null \
   | grep -viE '_test\.go' \

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -677,6 +677,22 @@ else
     fail "missing executable: scripts/check-mutation-route-coverage.sh"
 fi
 
+# --- 3a2. Author!=judge convergence guard (DRIFT #149) ---
+# The no-self-grade invariant must live in ONE predicate (liveness.Disjoint).
+# A divergent reimplementation is the pattern that let the empty-ID self-grade
+# bypass recur (#737->#741). Always-on (fast grep): a divergent author==judge
+# check landing on main reintroduces the bypass class.
+if [[ -x scripts/check-author-judge-convergence.sh ]]; then
+    if aj_conv_output="$(scripts/check-author-judge-convergence.sh 2>&1)"; then
+        pass "author!=judge convergence"
+    else
+        fail "author!=judge convergence"
+        indent_output "$aj_conv_output"
+    fi
+else
+    fail "missing executable: scripts/check-author-judge-convergence.sh"
+fi
+
 # --- 3b. HOME isolation in harvest.*/RunIngest tests ---
 if needs_check go; then
     if [[ -x scripts/check-home-isolation.sh ]]; then

--- a/tests/scripts/check-author-judge-convergence.bats
+++ b/tests/scripts/check-author-judge-convergence.bats
@@ -28,6 +28,19 @@ setup() {
   [ "$status" -eq 1 ]
 }
 
+@test "flags the REVERSED grader-left equality (citedByAgent == artifactAuthor)" {
+  # The same self-grade predicate with operands swapped (the #746 AMEND catch).
+  printf 'package foo\nfunc bad(citedByAgent, artifactAuthor string) bool { return citedByAgent == artifactAuthor }\n' > "$FIX/rev.go"
+  run bash "$GUARD" "$BATS_TEST_TMPDIR/fix"
+  [ "$status" -eq 1 ]
+}
+
+@test "does not flag author == author (not a self-grade pair)" {
+  printf 'package foo\nfunc ok(authorName, authorEmail string) bool { return authorName == authorEmail }\n' > "$FIX/aa.go"
+  run bash "$GUARD" "$BATS_TEST_TMPDIR/fix"
+  [ "$status" -eq 0 ]
+}
+
 @test "does not flag a comment describing author == judge" {
   printf 'package foo\n\t// a self-grade is author == judge\nfunc ok() bool { return false }\n' > "$FIX/c.go"
   run bash "$GUARD" "$BATS_TEST_TMPDIR/fix"

--- a/tests/scripts/check-author-judge-convergence.bats
+++ b/tests/scripts/check-author-judge-convergence.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-author-judge-convergence.sh — the DRIFT #149 guard that
+# keeps the no-self-grade (author!=judge) invariant converged on liveness.Disjoint.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  GUARD="$REPO_ROOT/scripts/check-author-judge-convergence.sh"
+  FIX="$BATS_TEST_TMPDIR/fix/internal/foo"
+  mkdir -p "$FIX"
+}
+
+@test "passes on the converged repo (cli routes through liveness.Disjoint)" {
+  run bash "$GUARD" "$REPO_ROOT/cli"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"author!=judge convergence"* ]]
+}
+
+@test "flags a divergent authorID == judgeID equality outside Disjoint" {
+  printf 'package foo\nfunc bad(authorID, judgeID string) bool { return authorID == judgeID }\n' > "$FIX/bad.go"
+  run bash "$GUARD" "$BATS_TEST_TMPDIR/fix"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"divergent author!=judge"* ]]
+}
+
+@test "flags a divergent EqualFold(author, judge)" {
+  printf 'package foo\nimport "strings"\nfunc bad(author, judge string) bool { return strings.EqualFold(author, judge) }\n' > "$FIX/ef.go"
+  run bash "$GUARD" "$BATS_TEST_TMPDIR/fix"
+  [ "$status" -eq 1 ]
+}
+
+@test "does not flag a comment describing author == judge" {
+  printf 'package foo\n\t// a self-grade is author == judge\nfunc ok() bool { return false }\n' > "$FIX/c.go"
+  run bash "$GUARD" "$BATS_TEST_TMPDIR/fix"
+  [ "$status" -eq 0 ]
+}
+
+@test "does not flag *_test.go files" {
+  printf 'package foo\nfunc helper(authorID, judgeID string) bool { return authorID == judgeID }\n' > "$FIX/x_test.go"
+  run bash "$GUARD" "$BATS_TEST_TMPDIR/fix"
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/check-author-judge-convergence.bats
+++ b/tests/scripts/check-author-judge-convergence.bats
@@ -41,6 +41,14 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
+@test "does not flag EqualFold(authorName, authorEmail) (author-vs-author, no grader operand)" {
+  # The #746 AMEND2 catch: the EqualFold arm must require one author AND one
+  # grader operand, not merely any author/judge/cited token.
+  printf 'package foo\nimport "strings"\nfunc ok(authorName, authorEmail string) bool { return strings.EqualFold(authorName, authorEmail) }\n' > "$FIX/ef_aa.go"
+  run bash "$GUARD" "$BATS_TEST_TMPDIR/fix"
+  [ "$status" -eq 0 ]
+}
+
 @test "does not flag a comment describing author == judge" {
   printf 'package foo\n\t// a self-grade is author == judge\nfunc ok() bool { return false }\n' > "$FIX/c.go"
   run bash "$GUARD" "$BATS_TEST_TMPDIR/fix"


### PR DESCRIPTION
## What
The empty-ID self-grade bypass **recurred** — #737 (PG3/PG4) → #741 (citation reward) — because the author≠judge invariant had been reimplemented in divergent places. #744 + #741 converged the 3 sites onto `liveness.Disjoint`. This is the **2nd-occurrence gate** that keeps them converged.

`scripts/check-author-judge-convergence.sh` flags any Go site doing its own `author == judge` / `EqualFold(author, judge)` / `judge_id == author_id` equality **outside** `liveness.Disjoint` (`cli/internal/liveness/guards.go`). Comments and `*_test.go` are excluded.

## Why
This completes the no-self-grade invariant to its full form — **converged + locked + gated**:
- **Converged** — #744 (`evidencedturn`) + #741 (`citation`) collapse the 3 impls onto one `Disjoint`.
- **Locked** — #744's `TestAuthorNeqValidator_AgreesWithDisjoint` fails CI if impl-#2 re-diverges.
- **Gated (this PR)** — catches a *new* 4th divergent impl **anywhere**, in the gate every cluster agent runs pre-push.

Catch → encode → never-again. A failure that recurred twice mandates a durable gate, not a third per-site patch.

## Validation
- Passes clean on current `main` (post-convergence: **zero** divergent sites).
- 5 bats specs: pass-on-converged, flag-equality, flag-`EqualFold`, skip-comment, skip-`_test.go`.
- Wired into `pre-push-gate.sh` always-on (fast grep, ~ms) — verified `ok  author!=judge convergence` in a full gate run. shellcheck clean (the 2 SC2317 infos are pre-existing in pre-push-gate.sh, not this change).
- Scope: 3 files, +96/−0 (guard script + bats + gate wiring). No production code.

> Follow-up: mirror as a `validate.yml` CI step once the validate.yml merge-churn settles (low-collision now via the pre-push gate). DRIFT bead pending Dolt-write recovery (#149); Agent Mail #151/#166 carry provenance.

Bounded-context: BC5-Runtime
Evidence: author!=judge convergence