### PR TITLE
feat(memory): reconcile citation outcomes before maturity (ag-sx9c)

### DIFF
--- a/cli/cmd/ao/flywheel_citation_feedback.go
+++ b/cli/cmd/ao/flywheel_citation_feedback.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/boshu2/agentops/cli/internal/liveness"
 	"github.com/boshu2/agentops/cli/internal/ratchet"
 	"github.com/boshu2/agentops/cli/internal/resolver"
 	"github.com/boshu2/agentops/cli/internal/types"
@@ -90,6 +91,9 @@ func evaluateCitationFeedback(
 	decision, reason, rewardable := classifyCitationFeedback(citationType)
 	metricNamespace := canonicalMetricNamespace(c.MetricNamespace)
 
+	if !citationFeedbackOutcomeIdentityAllowed(c, citationType) {
+		return rejectedOutcomeIdentityCitationFeedback(cwd, c, citationType, metricNamespace, sessionID, res)
+	}
 	if !isPrimaryMetricNamespace(metricNamespace) {
 		return nonPrimaryNamespaceCitationFeedback(cwd, c, citationType, metricNamespace, sessionID, res)
 	}
@@ -97,6 +101,47 @@ func evaluateCitationFeedback(
 		return findingArtifactCitationFeedback(cwd, c, citationType, metricNamespace, decision, reason, rewardable, sessionID, mutateArtifacts)
 	}
 	return learningArtifactCitationFeedback(cwd, c, citationType, metricNamespace, decision, reason, rewardable, sessionID, reward, mutateArtifacts, res)
+}
+
+func citationFeedbackOutcomeIdentityAllowed(c types.CitationEvent, citationType string) bool {
+	if !isOutcomeCitationType(citationType) {
+		return true
+	}
+	if c.ArtifactAuthorID == "" || c.CitedByAgentID == "" {
+		return false
+	}
+	return liveness.Disjoint(c.ArtifactAuthorID, c.CitedByAgentID) == liveness.Allowed
+}
+
+func rejectedOutcomeIdentityCitationFeedback(
+	cwd string,
+	c types.CitationEvent,
+	citationType, metricNamespace, sessionID string,
+	res *resolver.FileResolver,
+) citationFeedbackResult {
+	artifactPath := canonicalArtifactPath(cwd, c.ArtifactPath)
+	currentUtility := 0.0
+	if !isFindingArtifactPath(cwd, c.ArtifactPath) {
+		learningID := extractLearningID(c.ArtifactPath)
+		if path, err := res.Resolve(learningID); err == nil {
+			artifactPath = path
+			currentUtility = parseUtilityFromFile(path)
+		}
+	}
+	event := FeedbackEvent{
+		SessionID:       sessionID,
+		ArtifactPath:    artifactPath,
+		CitationType:    citationType,
+		MetricNamespace: metricNamespace,
+		Decision:        "skipped",
+		Reason:          "outcome-identity-not-disjoint",
+		Reward:          0,
+		UtilityBefore:   currentUtility,
+		UtilityAfter:    currentUtility,
+		Alpha:           0,
+		RecordedAt:      time.Now(),
+	}
+	return citationFeedbackResult{event: &event, skipped: 1}
 }
 
 func nonPrimaryNamespaceCitationFeedback(
@@ -211,6 +256,7 @@ func learningArtifactCitationFeedback(
 		return citationFeedbackResult{event: &event, skipped: 1}
 	}
 
+	effectiveReward := citationFeedbackReward(c, reward)
 	rewardCount := getLearningRewardCount(path)
 	alpha := annealedAlpha(types.DefaultAlpha, rewardCount)
 	if !mutateArtifacts {
@@ -222,7 +268,7 @@ func learningArtifactCitationFeedback(
 			MetricNamespace: metricNamespace,
 			Decision:        decision,
 			Reason:          reason,
-			Reward:          reward,
+			Reward:          effectiveReward,
 			UtilityBefore:   currentUtility,
 			UtilityAfter:    currentUtility,
 			Alpha:           0,
@@ -231,7 +277,7 @@ func learningArtifactCitationFeedback(
 		return citationFeedbackResult{event: &event, rewarded: 1}
 	}
 
-	oldUtility, newUtility, err := updateLearningUtility(path, reward, alpha)
+	oldUtility, newUtility, err := updateLearningUtility(path, effectiveReward, alpha)
 	if err != nil {
 		currentUtility := parseUtilityFromFile(path)
 		event := FeedbackEvent{
@@ -257,7 +303,7 @@ func learningArtifactCitationFeedback(
 		MetricNamespace: metricNamespace,
 		Decision:        decision,
 		Reason:          reason,
-		Reward:          reward,
+		Reward:          effectiveReward,
 		UtilityBefore:   oldUtility,
 		UtilityAfter:    newUtility,
 		Alpha:           alpha,
@@ -376,6 +422,19 @@ func citationEventIsHighConfidence(citation types.CitationEvent) bool {
 	return citationEventConfidence(citation) >= highConfidenceCitationThreshold
 }
 
+func citationFeedbackReward(citation types.CitationEvent, fallbackReward float64) float64 {
+	switch effectiveCitationFeedbackType(citation.CitationType) {
+	case types.CitationTypeHelpful:
+		return 1.0
+	case types.CitationTypeUsedInFinalArtifact:
+		return citationEventConfidence(citation)
+	case types.CitationTypeHarmful, types.CitationTypeRefuted:
+		return 0
+	default:
+		return fallbackReward
+	}
+}
+
 func classifyCitationFeedback(citationType string) (decision, reason string, rewardable bool) {
 	switch citationType {
 	case types.CitationTypeHelpful:
@@ -389,9 +448,9 @@ func classifyCitationFeedback(citationType string) (decision, reason string, rew
 	case types.CitationTypeRetrieved:
 		return "skipped", "retrieved-no-artifact-evidence", false
 	case types.CitationTypeHarmful:
-		return "skipped", "explicit-harmful", false
+		return "rewarded", "explicit-harmful", true
 	case types.CitationTypeRefuted:
-		return "skipped", "explicit-refuted", false
+		return "rewarded", "explicit-refuted", true
 	default:
 		return "skipped", "unsupported-citation-type", false
 	}

--- a/cli/cmd/ao/flywheel_citation_feedback_test.go
+++ b/cli/cmd/ao/flywheel_citation_feedback_test.go
@@ -688,7 +688,14 @@ func TestProcessCitationFeedback_RefutedOverridesAppliedEvidence(t *testing.T) {
 	}
 	citations := []types.CitationEvent{
 		{ArtifactPath: ".agents/learnings/refuted-evidence.jsonl", CitationType: types.CitationTypeApplied, FeedbackGiven: false, CitedAt: time.Now().Add(-time.Minute)},
-		{ArtifactPath: ".agents/learnings/refuted-evidence.jsonl", CitationType: types.CitationTypeRefuted, FeedbackGiven: false, CitedAt: time.Now()},
+		{
+			ArtifactPath:     ".agents/learnings/refuted-evidence.jsonl",
+			CitationType:     types.CitationTypeRefuted,
+			ArtifactAuthorID: "author-agent",
+			CitedByAgentID:   "judge-agent",
+			FeedbackGiven:    false,
+			CitedAt:          time.Now(),
+		},
 	}
 	var lines []string
 	for _, citation := range citations {
@@ -703,15 +710,64 @@ func TestProcessCitationFeedback_RefutedOverridesAppliedEvidence(t *testing.T) {
 	}
 
 	total, rewarded, skipped := processCitationFeedbackWithOptions(tmp, citationFeedbackOptions{MutateArtifacts: false})
-	if total != 1 || rewarded != 0 || skipped != 1 {
-		t.Fatalf("expected refuted evidence to skip reward, got (%d,%d,%d)", total, rewarded, skipped)
+	if total != 1 || rewarded != 1 || skipped != 0 {
+		t.Fatalf("expected refuted evidence to apply negative feedback, got (%d,%d,%d)", total, rewarded, skipped)
 	}
 	feedback := readCitationFeedbackEvents(t, filepath.Join(aoDir, "feedback.jsonl"))
 	if len(feedback) != 1 {
 		t.Fatalf("feedback event count = %d, want 1", len(feedback))
 	}
-	if feedback[0].Decision != "skipped" || feedback[0].Reason != "explicit-refuted" {
-		t.Fatalf("feedback decision/reason = %q/%q, want skipped/explicit-refuted", feedback[0].Decision, feedback[0].Reason)
+	if feedback[0].Decision != "rewarded" || feedback[0].Reason != "explicit-refuted" || feedback[0].Reward != 0 {
+		t.Fatalf("feedback decision/reason/reward = %q/%q/%v, want rewarded/explicit-refuted/0", feedback[0].Decision, feedback[0].Reason, feedback[0].Reward)
+	}
+}
+
+func TestProcessCitationFeedback_RejectsAuthorSelfOutcome(t *testing.T) {
+	tmp := t.TempDir()
+	aoDir := filepath.Join(tmp, ".agents", "ao")
+	learningsDir := filepath.Join(tmp, ".agents", "learnings")
+	if err := os.MkdirAll(aoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(learningsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	learningPath := filepath.Join(learningsDir, "self-judged.jsonl")
+	learningContent := `{"id":"self-judged","title":"Self Judged","utility":0.5}`
+	if err := os.WriteFile(learningPath, []byte(learningContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	citation := types.CitationEvent{
+		ArtifactPath:     ".agents/learnings/self-judged.jsonl",
+		CitationType:     types.CitationTypeHelpful,
+		ArtifactAuthorID: "same-agent",
+		CitedByAgentID:   "same-agent",
+		FeedbackGiven:    false,
+		CitedAt:          time.Now(),
+	}
+	data, err := json.Marshal(citation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(aoDir, "citations.jsonl"), append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	total, rewarded, skipped := processCitationFeedback(tmp)
+	if total != 1 || rewarded != 0 || skipped != 1 {
+		t.Fatalf("expected self-judged outcome to skip, got (%d,%d,%d)", total, rewarded, skipped)
+	}
+	gotLearning, err := os.ReadFile(learningPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotLearning) != learningContent {
+		t.Fatalf("self-judged outcome mutated learning:\n%s", string(gotLearning))
+	}
+	feedback := readCitationFeedbackEvents(t, filepath.Join(aoDir, "feedback.jsonl"))
+	if len(feedback) != 1 || feedback[0].Decision != "skipped" || feedback[0].Reason != "outcome-identity-not-disjoint" {
+		t.Fatalf("unexpected feedback event for self-judged outcome: %#v", feedback)
 	}
 }
 

--- a/cli/cmd/ao/maturity.go
+++ b/cli/cmd/ao/maturity.go
@@ -352,6 +352,8 @@ func runMaturityScanAll(learningsDir, patternsDir string) error {
 		return nil
 	}
 
+	reconcileMaturityCitationFeedback(dirs[0])
+
 	totalDist := &ratchet.MaturityDistribution{}
 	var allResults []*ratchet.MaturityTransitionResult
 
@@ -392,11 +394,42 @@ func runMaturityScanAll(learningsDir, patternsDir string) error {
 	return nil
 }
 
+func reconcileMaturityCitationFeedback(artifactDir string) {
+	if !maturityApply {
+		return
+	}
+	baseDir := maturityCitationBaseDir(artifactDir)
+	total, rewarded, skipped := processCitationFeedback(baseDir)
+	if total > 0 {
+		VerbosePrintf("Reconciled citation feedback before maturity scan: total=%d rewarded=%d skipped=%d\n", total, rewarded, skipped)
+	}
+}
+
+func maturityCitationBaseDir(artifactDir string) string {
+	dir := filepath.Clean(artifactDir)
+	if cwd, err := os.Getwd(); err == nil {
+		agentsDir := filepath.Clean(agentsDirIn(cwd))
+		if rel, relErr := filepath.Rel(agentsDir, dir); relErr == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return cwd
+		}
+	}
+	switch filepath.Base(dir) {
+	case "learnings", "patterns":
+		agentsDir := filepath.Dir(dir)
+		if filepath.Base(agentsDir) == ".agents" {
+			return filepath.Dir(agentsDir)
+		}
+	}
+	return filepath.Dir(filepath.Dir(dir))
+}
+
 func runMaturityScan(learningsDir string) error {
 	if GetDryRun() {
 		fmt.Printf("[dry-run] Would scan learnings in: %s\n", learningsDir)
 		return nil
 	}
+
+	reconcileMaturityCitationFeedback(learningsDir)
 
 	dist, err := ratchet.GetMaturityDistribution(learningsDir)
 	if err != nil {

--- a/cli/cmd/ao/maturity_test.go
+++ b/cli/cmd/ao/maturity_test.go
@@ -1975,6 +1975,125 @@ func TestMaturity_runMaturityScanAll_noTransitions2(t *testing.T) {
 	}
 }
 
+func TestMaturity_runMaturityScanAll_reconcilesHelpfulCitationBeforeApply(t *testing.T) {
+	tmp, learningsDir := setupMaturityDir(t)
+	patternsDir := filepath.Join(tmp, ".agents", "patterns")
+	chdirTo(t, tmp)
+
+	learningPath := writeTestMDLearning(t, learningsDir, "helpful-promote.md", map[string]string{
+		"id":            "helpful-promote",
+		"maturity":      "provisional",
+		"utility":       "0.5000",
+		"reward_count":  "2",
+		"helpful_count": "2",
+		"harmful_count": "0",
+		"confidence":    "0.4",
+	}, "# Helpful Promote\nCitation outcome should move this learning into candidate.\n")
+
+	if err := ratchet.RecordCitation(tmp, types.CitationEvent{
+		ArtifactPath:     ".agents/learnings/helpful-promote.md",
+		CitationType:     types.CitationTypeHelpful,
+		ArtifactAuthorID: "author-agent",
+		CitedByAgentID:   "judge-agent",
+		CitedAt:          time.Date(2026, 6, 5, 7, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("record helpful citation: %v", err)
+	}
+
+	oldApply := maturityApply
+	oldDryRun := dryRun
+	oldHelpful := feedbackHelpful
+	oldHarmful := feedbackHarmful
+	maturityApply = true
+	dryRun = false
+	feedbackHelpful = false
+	feedbackHarmful = false
+	defer func() {
+		maturityApply = oldApply
+		dryRun = oldDryRun
+		feedbackHelpful = oldHelpful
+		feedbackHarmful = oldHarmful
+	}()
+
+	captureJSONStdout(t, func() {
+		if err := runMaturityScanAll(learningsDir, patternsDir); err != nil {
+			t.Fatalf("scan all: %v", err)
+		}
+	})
+
+	data, err := os.ReadFile(learningPath)
+	if err != nil {
+		t.Fatalf("read learning: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{"maturity: candidate", "reward_count: 3", "helpful_count: 3"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected %q after helpful citation reconciliation, got:\n%s", want, text)
+		}
+	}
+
+	citations, err := ratchet.LoadCitations(tmp)
+	if err != nil {
+		t.Fatalf("load citations: %v", err)
+	}
+	if len(citations) != 1 || !citations[0].FeedbackGiven || citations[0].FeedbackReward != 1 {
+		t.Fatalf("citation feedback not marked with helpful reward: %#v", citations)
+	}
+}
+
+func TestMaturity_runMaturityScanAll_retrievedCitationDoesNotChangeUtility(t *testing.T) {
+	tmp, learningsDir := setupMaturityDir(t)
+	patternsDir := filepath.Join(tmp, ".agents", "patterns")
+	chdirTo(t, tmp)
+
+	learningPath := writeTestMDLearning(t, learningsDir, "retrieved-only.md", map[string]string{
+		"id":            "retrieved-only",
+		"maturity":      "provisional",
+		"utility":       "0.6000",
+		"reward_count":  "2",
+		"helpful_count": "2",
+		"harmful_count": "0",
+		"confidence":    "0.4",
+	}, "# Retrieved Only\nExposure without outcome evidence must not change maturity counters.\n")
+
+	if err := ratchet.RecordCitation(tmp, types.CitationEvent{
+		ArtifactPath: ".agents/learnings/retrieved-only.md",
+		CitationType: types.CitationTypeRetrieved,
+		CitedAt:      time.Date(2026, 6, 5, 7, 15, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("record retrieved citation: %v", err)
+	}
+
+	oldApply := maturityApply
+	oldDryRun := dryRun
+	maturityApply = true
+	dryRun = false
+	defer func() {
+		maturityApply = oldApply
+		dryRun = oldDryRun
+	}()
+
+	captureJSONStdout(t, func() {
+		if err := runMaturityScanAll(learningsDir, patternsDir); err != nil {
+			t.Fatalf("scan all: %v", err)
+		}
+	})
+
+	data, err := os.ReadFile(learningPath)
+	if err != nil {
+		t.Fatalf("read learning: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{"maturity: provisional", "utility: 0.6000", "reward_count: 2", "helpful_count: 2"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected %q to remain after retrieved-only citation, got:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "maturity: candidate") {
+		t.Fatalf("retrieved-only citation promoted learning unexpectedly:\n%s", text)
+	}
+}
+
 func TestMaturity_displayPendingTransitions_jsonOut(t *testing.T) {
 	oldOutput := output
 	output = "json"


### PR DESCRIPTION
## Summary
- reconcile `.agents/ao/citations.jsonl` outcome feedback immediately before `ao maturity --apply` scans transitions
- map helpful/final-artifact/refuted/harmful citations into the existing learning utility and frontmatter counter path consumed by `CheckMaturityTransition`
- reject outcome feedback unless artifact author and citing/judging agent are disjoint via the shared liveness identity guard
- keep retrieved-only exposure non-mutating so retrieval does not promote maturity

## Bead
- ag-sx9c (W3.2): Citation outcomes feed maturity transitions

## Validation
- `git diff --check` PASS
- `go test ./cmd/ao -run 'TestMaturity|TestProcessCitationFeedback|TestCloseLoop_CitationFeedbackBeforeMaturity' -count=1` PASS\n- `go test ./cmd/ao -count=1` PASS (`267.164s`)\n- `bash scripts/regen-all.sh` ran; known CMDAO surface parity red (`wiki query`)\n- `PRE_PUSH_FAIL_FAST=false bash scripts/pre-push-gate.sh` ran before and after rebase; changed-scope Go build/vet/race passed; final gate blocked only known standing reds: fixture parity, canonical-root dirty disposition, corpus freshness, contract canaries\n\n## Review Ask\nNeed cross-model review. Please focus on the maturity ordering and whether outcome identity enforcement is strict enough without blocking legacy non-outcome citations.