### PR TITLE
docs(memory): remove legacy bd-memory guidance (ag-i788)

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -57,10 +57,9 @@ bd close <id>         # Complete work
 - Run `bd prime` for detailed command reference and session close protocol
 - Treat `bd prime` as tracker workflow context. Durable knowledge recall comes
   from the AgentOps markdown corpus via `ao session bootstrap` and
-  `ao inject --query`.
-- During the W4 migration, `bd prime` may still surface a legacy memories block;
-  treat it as lineage only. New recall is markdown-sourced, and W4.3 removes
-  that block.
+  `ao inject "<topic>"` or `ao corpus inject --query "<topic>"`.
+- If `bd prime` surfaces a legacy memories block from the external tracker,
+  treat it as lineage only. New recall is markdown-sourced.
 - Do not use `bd remember` for new persistent knowledge. Preserve existing
   entries only as migration lineage; do NOT use MEMORY.md files.
 

--- a/docs/contracts/ci-pathfilter-coverage-audit.md
+++ b/docs/contracts/ci-pathfilter-coverage-audit.md
@@ -81,7 +81,7 @@ A clean CI gate for this is **out of scope** here: GitHub Actions cannot reliabl
 **Policy (documented here; mechanical enforcement deferred to a follow-up bead):**
 
 1. An `--admin` squash-merge of a **self-authored** PR (PR author == the merging operator/agent) SHOULD carry a second automation signal before merge: either (a) a green `claude-code-review` verdict that did NOT soft-fail on usage-limit, or (b) an explicit human spot-check recorded as a provenance ledger event (`claude-code-review` verdicts are first-class ledger events per AGENTS.md → Provenance).
-2. When neither is available (e.g. weekly Claude limit exhausted during an autonomous run), the merge is permitted but the orchestrator MUST emit a `bd remember` note and flag the bead for a post-hoc human review pass, so the gap is auditable rather than silent.
+2. When neither is available (e.g. weekly Claude limit exhausted during an autonomous run), the merge is permitted but the orchestrator MUST record the gap as bead/provenance evidence and flag the bead for a post-hoc human review pass, so the gap is auditable rather than silent.
 3. The autonomous loop's post-mortem checkpoint (the sibling crank/evolve skill gate, ag-7gmv) is the human-in-the-loop counterweight: ≥5 self-merged PRs in one session forces the checkpoint.
 
 **Follow-up:** a mechanical signal (e.g. a `merge`-event workflow that records merge-method + author parity into the provenance ledger, or a branch-protection rule requiring `claude-code-review` to be a non-soft-fail success) is filed as a follow-up bead rather than shipped half-built here.

--- a/docs/contracts/claude-bot-delegation.md
+++ b/docs/contracts/claude-bot-delegation.md
@@ -141,4 +141,4 @@ Validated 2026-05-18 across PRs #321–#326: every PR received `claude-review: S
 - [Lesson Format](lesson-format.md) — schema for `.agents/learnings/` entries
 - [AGENTS.md `## Workflow`](https://github.com/boshu2/agentops/blob/main/AGENTS.md) — PR-only discipline this bot operates inside
 
-> `.agents/learnings/` is repo-local (gitignored). Search local lessons with `bd memories <keyword>` or via the [Lesson Format](lesson-format.md) contract.
+> `.agents/learnings/` is repo-local (gitignored). Search local lessons with `ao inject "<keyword>"`, or inspect files that follow the [Lesson Format](lesson-format.md) contract.

--- a/docs/contracts/lesson-format.md
+++ b/docs/contracts/lesson-format.md
@@ -128,7 +128,8 @@ The learning file is the source of truth. AgentOps recall reads this markdown co
 
 ```bash
 ao session bootstrap
-ao inject --query "<topic>"
+ao inject "<topic>"
+ao corpus inject --query "<topic>"
 ```
 
 Projection constraints:
@@ -140,8 +141,8 @@ Projection constraints:
 
 `bd prime` remains tracker workflow context. It should point agents to the markdown-backed AgentOps recall path
 instead of treating `bd memories` as the knowledge source.
-During the W4 migration, `bd prime` may still surface a legacy memories block; treat that block as lineage
-only. New recall is markdown-sourced, and W4.3 removes the legacy block.
+If `bd prime` still surfaces a legacy memories block from the external tracker, treat that block as lineage
+only. New recall is markdown-sourced.
 
 ---
 

--- a/registry.json
+++ b/registry.json
@@ -1086,6 +1086,7 @@
         "bounded_context": "BC1",
         "driven_by_skills": [
           "agent-native",
+          "beads",
           "domain",
           "harvest",
           "inject",
@@ -1635,6 +1636,8 @@
         "bd-issue"
       ],
       "drives_commands": [
+        "ao corpus inject",
+        "ao inject",
         "ao reconcile"
       ],
       "path": "skills/beads/",
@@ -4142,6 +4145,7 @@
       "status": "active",
       "driven_by_skills": [
         "agent-native",
+        "beads",
         "domain",
         "harvest",
         "inject",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -697,7 +697,7 @@
     {
       "name": "beads",
       "source_skill": "skills/beads",
-      "source_hash": "ed5f5d242b6bb903c7ba3120e7ffe82a8c2a7bd7f21b21d9c6274de205d710e1",
+      "source_hash": "86bfef3ef7ff64509d6321681275bcb0c9c437f208d2fd4226d05ed6f60dacde",
       "generated_hash": "51db26466d4646eddfc2132ea521508fe2ced556ef0ab69db41acd363afba770"
     },
     {
@@ -763,8 +763,8 @@
     {
       "name": "curate",
       "source_skill": "skills/curate",
-      "source_hash": "8dc6adda58141217c1b58a77c15f65927b2275f0d2e6d9a7b709ed1489fdc717",
-      "generated_hash": "e591a74578afc525c4eb284f36ee3e6f9efa103070505cf32e5c3b494fb7c490"
+      "source_hash": "3b20b9234d306929d649a651c5255a0c72e5ac435b6aa86e283b7f5571621efd",
+      "generated_hash": "d29c42ee80576ff28ea150b690dba46c6339b79c102af3de84a75a18fb9296c3"
     },
     {
       "name": "deps",

--- a/skills-codex/beads/.agentops-generated.json
+++ b/skills-codex/beads/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/beads",
   "layout": "modular",
-  "source_hash": "ed5f5d242b6bb903c7ba3120e7ffe82a8c2a7bd7f21b21d9c6274de205d710e1",
+  "source_hash": "86bfef3ef7ff64509d6321681275bcb0c9c437f208d2fd4226d05ed6f60dacde",
   "generated_hash": "51db26466d4646eddfc2132ea521508fe2ced556ef0ab69db41acd363afba770"
 }

--- a/skills-codex/curate/.agentops-generated.json
+++ b/skills-codex/curate/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/curate",
   "layout": "modular",
-  "source_hash": "8dc6adda58141217c1b58a77c15f65927b2275f0d2e6d9a7b709ed1489fdc717",
-  "generated_hash": "e591a74578afc525c4eb284f36ee3e6f9efa103070505cf32e5c3b494fb7c490"
+  "source_hash": "3b20b9234d306929d649a651c5255a0c72e5ac435b6aa86e283b7f5571621efd",
+  "generated_hash": "d29c42ee80576ff28ea150b690dba46c6339b79c102af3de84a75a18fb9296c3"
 }

--- a/skills-codex/curate/SKILL.md
+++ b/skills-codex/curate/SKILL.md
@@ -80,8 +80,8 @@ Each mode delegates to a body section in this skill (see § per-mode bodies belo
 Output is one of (priority order, per architecture knowledge-flywheel rule):
 
 1. **Skill diffs** — proposed changes to existing skill bodies, written to `.agents/skill-diffs/<date>-<skill>.diff`. Operator approves before applying. NEVER writes to `skills/` directly.
-2. **bd updates** — `bd note`, `bd remember`, or new `bd create` for surfaced issues. Direct, no approval queue.
-3. **Wiki entries** — `.agents/research/`, `.agents/learnings/`, `~/.agents/learnings/` (rare; only when knowledge is generally reusable).
+2. **bd updates** — `bd note` or new `bd create` for surfaced issues. Direct, no approval queue.
+3. **Knowledge entries** — `.agents/research/`, `.agents/learnings/`, `~/.agents/learnings/` (rare; only when knowledge is generally reusable).
 
 ### Step 5: Append to LOG.md
 

--- a/skills/beads/references/composition-over-invention.md
+++ b/skills/beads/references/composition-over-invention.md
@@ -34,8 +34,8 @@ The composition primitives that produce those semantics:
 | Create an isolated workspace for the work | `bd worktree create --branch <type>/<bead-id>-<slug>` |
 | Serialize merges across concurrent agents | `bd merge-slot` |
 | Mark an issue blocked / waiting | `bd update <id> --status=blocked` |
-| Record an insight for future cycles | `bd remember "<insight>"` |
-| Look up prior insights | `bd memories <keyword>` |
+| Record an insight for future cycles | Write a Lesson Format entry under `.agents/learnings/` and cite the current bead in `related:` |
+| Look up prior insights | `ao inject "<keyword>"`, `ao corpus inject --query "<keyword>"`, or grep `.agents/learnings/` |
 | Pull/push the dolt-backed history | `bd dolt pull` / `bd dolt push` |
 
 ## Evidence (anchored)

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -104,8 +104,8 @@ Each mode delegates to a body section in this skill (see § per-mode bodies belo
 Output is one of (priority order, per architecture knowledge-flywheel rule):
 
 1. **Skill diffs** — proposed changes to existing skill bodies, written to `.agents/skill-diffs/<date>-<skill>.diff`. Operator approves before applying. NEVER writes to `skills/` directly.
-2. **bd updates** — `bd note`, `bd remember`, or new `bd create` for surfaced issues. Direct, no approval queue.
-3. **Wiki entries** — `.agents/research/`, `.agents/learnings/`, `~/.agents/learnings/` (rare; only when knowledge is generally reusable).
+2. **bd updates** — `bd note` or new `bd create` for surfaced issues. Direct, no approval queue.
+3. **Knowledge entries** — `.agents/research/`, `.agents/learnings/`, `~/.agents/learnings/` (rare; only when knowledge is generally reusable).
 
 ### Step 5: Append to LOG.md
 


### PR DESCRIPTION
## Summary
- remove active guidance that routes durable knowledge through `bd remember` / `bd memories`
- point recall to markdown-backed AgentOps paths: `ao inject "<topic>"` and `ao corpus inject --query "<topic>"`
- keep legacy `bd prime`/`bd remember` mentions only as migration lineage or negative examples
- refresh generated Codex skill metadata and registry command projections

## Boundary
This repo can update AgentOps docs/skills and generated registry metadata. It cannot patch an external `bd prime` template emitted by the tracker binary, so the PR explicitly treats any remaining external legacy memories block as lineage only.

## Validation
- `bash scripts/validate-agents-split.sh`
- `bash scripts/check-contracts-structural-floor.sh`
- `bash scripts/validate-skill-schema.sh`
- `bash scripts/validate-skill-frontmatter.sh`
- `bash scripts/validate-skill-body-refs.sh`
- `bash scripts/validate-codex-skill-parity.sh`
- `git diff --check`
- `bash scripts/regen-all.sh` (known CMDAO wiki-query standing red)
- `PRE_PUSH_FAIL_FAST=false bash scripts/pre-push-gate.sh` after rebase onto #748/main (blocked only by known standing reds: fixture parity, canonical-root disposition, corpus freshness, contract canaries)

Quorum requested via Agent Mail topic `ag-i788`.