### PR TITLE
fix(memory): relabel negative citation feedback

### DIFF
--- a/cli/cmd/ao/flywheel_citation_feedback.go
+++ b/cli/cmd/ao/flywheel_citation_feedback.go
@@ -448,9 +448,9 @@ func classifyCitationFeedback(citationType string) (decision, reason string, rew
 	case types.CitationTypeRetrieved:
 		return "skipped", "retrieved-no-artifact-evidence", false
 	case types.CitationTypeHarmful:
-		return "rewarded", "explicit-harmful", true
+		return "penalized", "explicit-harmful", true
 	case types.CitationTypeRefuted:
-		return "rewarded", "explicit-refuted", true
+		return "penalized", "explicit-refuted", true
 	default:
 		return "skipped", "unsupported-citation-type", false
 	}

--- a/cli/cmd/ao/flywheel_citation_feedback_test.go
+++ b/cli/cmd/ao/flywheel_citation_feedback_test.go
@@ -717,8 +717,27 @@ func TestProcessCitationFeedback_RefutedOverridesAppliedEvidence(t *testing.T) {
 	if len(feedback) != 1 {
 		t.Fatalf("feedback event count = %d, want 1", len(feedback))
 	}
-	if feedback[0].Decision != "rewarded" || feedback[0].Reason != "explicit-refuted" || feedback[0].Reward != 0 {
-		t.Fatalf("feedback decision/reason/reward = %q/%q/%v, want rewarded/explicit-refuted/0", feedback[0].Decision, feedback[0].Reason, feedback[0].Reward)
+	if feedback[0].Decision != "penalized" || feedback[0].Reason != "explicit-refuted" || feedback[0].Reward != 0 {
+		t.Fatalf("feedback decision/reason/reward = %q/%q/%v, want penalized/explicit-refuted/0", feedback[0].Decision, feedback[0].Reason, feedback[0].Reward)
+	}
+}
+
+func TestClassifyCitationFeedback_NegativeOutcomesArePenalized(t *testing.T) {
+	tests := []struct {
+		citationType string
+		wantReason   string
+	}{
+		{types.CitationTypeHarmful, "explicit-harmful"},
+		{types.CitationTypeRefuted, "explicit-refuted"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.citationType, func(t *testing.T) {
+			decision, reason, rewardable := classifyCitationFeedback(tt.citationType)
+			if decision != "penalized" || reason != tt.wantReason || !rewardable {
+				t.Fatalf("classifyCitationFeedback(%q) = %q/%q/%v, want penalized/%s/true", tt.citationType, decision, reason, rewardable, tt.wantReason)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- change harmful/refuted citation feedback events from `Decision: "rewarded"` to `Decision: "penalized"`
- keep the existing reward semantics unchanged: harmful/refuted still apply `Reward: 0` and pull utility toward zero
- add focused classifier coverage for both negative outcome labels and update the refuted integration assertion

## Source
Follow-up from #748 reviews:
- RubyMoose Agent Mail #209: `rewarded` + `Reward: 0` is ledger-confusing for refuted/harmful outcomes
- WindyCastle Agent Mail #213: semantic call is `penalized`

`bd create` failed with `begin write tx: context canceled`, so Agent Mail #215 records the claim/provenance.

## Validation
- `go test ./cmd/ao -run 'Test(ClassifyCitationFeedback_NegativeOutcomesArePenalized|ProcessCitationFeedback_DeduplicatesTowardStrongestOutcome|ProcessCitationFeedback_RejectsAuthorSelfOutcome)' -count=1`\n- `go test ./cmd/ao -count=1`\n- `bash scripts/regen-all.sh` (known CMDAO wiki-query standing red)\n- `PRE_PUSH_FAIL_FAST=false bash scripts/pre-push-gate.sh` (blocked only by known standing reds: fixture parity, canonical-root disposition, goals validate, corpus freshness, contract canaries)\n\nRequesting cross-model review; no self-grade merge.