### PR TITLE
fix(memory): reconcile W6 cutover commands

### DIFF
--- a/cli/cmd/ao/agent_bundle.go
+++ b/cli/cmd/ao/agent_bundle.go
@@ -106,7 +106,7 @@ func buildCodexNTMBundle(skills []string) agentBundle {
 		Runtime:      "codex-ntm",
 		Instructions: stitchInstructions(skills),
 		Skills:       skills,
-		Bootstrap:    "ao session bootstrap && ao inject --query \"$BEAD\"",
+			Bootstrap:    "ao session bootstrap && ao inject --bead \"$BEAD\"",
 		Reference:    "skills-codex/agent-native",
 	}
 }

--- a/cli/cmd/ao/agent_bundle_test.go
+++ b/cli/cmd/ao/agent_bundle_test.go
@@ -94,6 +94,12 @@ func TestBuildAgentBundle_CodexNTM(t *testing.T) {
 	if !strings.Contains(b.Bootstrap, "ao session bootstrap") {
 		t.Errorf("codex-ntm Bootstrap must run `ao session bootstrap`, got %q", b.Bootstrap)
 	}
+	if !strings.Contains(b.Bootstrap, `ao inject --bead "$BEAD"`) {
+		t.Errorf("codex-ntm Bootstrap must request bead-scoped injection, got %q", b.Bootstrap)
+	}
+	if strings.Contains(b.Bootstrap, "ao inject --query") {
+		t.Errorf("codex-ntm Bootstrap must not use invalid `ao inject --query`, got %q", b.Bootstrap)
+	}
 	if b.Reference != "skills-codex/agent-native" {
 		t.Errorf("Reference = %q, want skills-codex/agent-native", b.Reference)
 	}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,7 +17,7 @@ the authoritative gate** (see `.github/workflows/validate.yml`).
 
 ```bash
 ao session bootstrap                 # the universal init prompt / orientation report
-ao inject --query "<topic>"          # pull decay-ranked prior context on demand
+ao inject "<topic>"                  # pull decay-ranked prior context on demand
 ```
 
 **Diagnosis (check your install, not hooks):**
@@ -348,7 +348,7 @@ primitives rather than relying on an auto-snapshot hook (there is none in 3.0):
 
 ```bash
 ao session bootstrap                 # re-orient
-ao inject --query "<topic>"          # pull back the relevant prior context
+ao inject "<topic>"                  # pull back the relevant prior context
 ```
 
 You can also manually re-seed the session from `MEMORY.md`.

--- a/docs/wiki-for-agents.md
+++ b/docs/wiki-for-agents.md
@@ -58,7 +58,7 @@ AgentOps inverts this. Sessions write to the wiki by default — runs land citat
 
 **Version control.** Diffs, branches, and merges are how engineers already think about change. A wiki you can `git revert` is a wiki you can trust.
 
-**Decay-ranked retrieval.** `ao inject --query "..."` returns a token-budgeted packet weighted by recency, citations, and validation history — different from full-text search.
+**Decay-ranked retrieval.** `ao inject "..."` returns a token-budgeted packet weighted by recency, citations, and validation history — different from full-text search.
 
 **Automated capture.** Sessions write run packets, citations, and verdicts without anyone being asked. The discipline lives in the tooling.
 
@@ -84,7 +84,7 @@ Then, inside any repo:
 ao quick-start          # seed .agents/, GOALS.md, AgentOps instructions
 ```
 
-That is the entry point. After that, work with your agents normally — `/rpi`, `/council`, `/research`, `/vibe`. `.agents/` accumulates without explicit attention. `ao inject --query "..."` returns a decay-ranked, token-budgeted packet whenever you ask.
+That is the entry point. After that, work with your agents normally — `/rpi`, `/council`, `/research`, `/vibe`. `.agents/` accumulates without explicit attention. `ao inject "..."` returns a decay-ranked, token-budgeted packet whenever you ask.
 
 ## What you own at the end
 

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -811,7 +811,7 @@
     {
       "name": "evolve",
       "source_skill": "skills/evolve",
-      "source_hash": "1dff0ccbfb96a0012f88653232e0bfce3cf52e1322b085dbf76a41b538f3722c",
+      "source_hash": "e740549f1550a3f55dde63b4e3a3b09e14f2f87948874cf0087465bcf1930e34",
       "generated_hash": "30756e2ad2f3b5f924fda8442038e9dc8feb8f19ef0a530c0592d7a29577763d"
     },
     {

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/evolve",
   "layout": "modular",
-  "source_hash": "1dff0ccbfb96a0012f88653232e0bfce3cf52e1322b085dbf76a41b538f3722c",
+  "source_hash": "e740549f1550a3f55dde63b4e3a3b09e14f2f87948874cf0087465bcf1930e34",
   "generated_hash": "30756e2ad2f3b5f924fda8442038e9dc8feb8f19ef0a530c0592d7a29577763d"
 }

--- a/skills/evolve/references/metronome-gate.md
+++ b/skills/evolve/references/metronome-gate.md
@@ -14,7 +14,7 @@ The metronome gate adds a structural detector: when the same `mode` value repeat
 |---|---|
 | 0–2 | No gate. The selection ladder runs normally. |
 | 3–4 | **Soft block.** If the selected work would produce the same `mode` value, skip to the next rung of the selection ladder. Do not abort — try the rung below. |
-| 5+ | **Hard block.** File `bd remember "metronome-N: <mode>"` and require operator override (write `.agents/evolve/RESCOPE` with a new directive). The cycle is logged as `unchanged` with `selected_source: "metronome-gate-blocked"`. |
+| 5+ | **Hard block.** Record the gap as bead/provenance evidence and require operator override (write `.agents/evolve/RESCOPE` with a new directive). The cycle is logged as `unchanged` with `selected_source: "metronome-gate-blocked"`. |
 
 ## Why the threshold is 3, not 2
 

--- a/skills/evolve/references/work-selection-ladder.md
+++ b/skills/evolve/references/work-selection-ladder.md
@@ -25,7 +25,7 @@ Before claiming a candidate, gate scope vs session budget. If the work touches >
 
 Scout NEVER returns "no work done." If `bd ready` ≥1, the loop MUST claim one this cycle. See `references/scout-mode.md` and `references/mechanical-batches.md`.
 
-**Metronome gate:** read `mode_repeat_streak` from `session-state.json`. If `>= 3` AND the candidate would repeat the trailing run's `mode`, BLOCK this rung and jump to the next. If `>= 5`, `bd remember "metronome-N: <mode>"` and require operator override. See `references/metronome-gate.md`.
+**Metronome gate:** read `mode_repeat_streak` from `session-state.json`. If `>= 3` AND the candidate would repeat the trailing run's `mode`, BLOCK this rung and jump to the next. If `>= 5`, record the gap as bead/provenance evidence and require operator override. See `references/metronome-gate.md`.
 
 **Step 3.1: Harvested work first**
 


### PR DESCRIPTION
## Summary
- Replace invalid `ao inject --query` guidance with executable `ao inject "<topic>"` examples in W6 docs.
- Update codex-ntm agent bundle bootstrap to use bead-scoped `ao inject --bead "$BEAD"` and add a regression test blocking the invalid query form.
- Remove active flat `bd remember` metronome-gate guidance, preserving auditability through bead/provenance evidence, and refresh generated Codex evolve metadata hashes.

## Validation
- `go test ./cmd/ao -run TestBuildAgentBundle_CodexNTM -count=1` PASS.
- `bash scripts/regen-all.sh` ran; blocked only known CMDAO `wiki query` surface red. Timestamp-only `registry.json` drift restored.
- `PRE_PUSH_FAIL_FAST=false bash scripts/pre-push-gate.sh` on rebased head `1f2a2cb410147fdaf162ee8ef235e0ce2d35ab8f`: BLOCKED (4 known standing failures): test-fixture parity, canonical root/worktree disposition, corpus freshness, contract canary governance/pre-push-bats. Branch-local Go, skill, docs, registry, mkdocs, shellcheck, CI policy, context-map, and executable-spec checks passed.

## Cutover scan
Remaining `bd remember`/`bd memories` hits are lineage, migration-manifest, or explicit “do not use” guidance. Active `ao inject --query` is removed; the only remaining occurrence is the negative regression assertion in `agent_bundle_test.go`.