### PR TITLE
fix(readme): restore PowerShell install one-liners (ag-5uau #readme-install-oneliners)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,10 @@ Pick your runtime, then type `/quickstart` in the agent.
 # Claude Code
 claude plugin marketplace add boshu2/agentops && claude plugin install agentops@agentops-marketplace
 
-# Codex CLI (macOS/Linux/WSL).  Windows: install-codex.ps1.  OpenCode: install-opencode.sh
+# Codex CLI (macOS/Linux/WSL).  OpenCode: install-opencode.sh
 curl -fsSL https://raw.githubusercontent.com/boshu2/agentops/main/scripts/install-codex.sh | bash
+# Codex CLI (Windows):
+irm https://raw.githubusercontent.com/boshu2/agentops/main/scripts/install-codex.ps1 | iex
 
 # Other skills-compatible agents
 npx skills@latest add boshu2/agentops --cursor -g
@@ -77,7 +79,8 @@ The `ao` CLI is optional but recommended (bookkeeping, retrieval, health, the lo
 
 ```bash
 brew tap boshu2/agentops https://github.com/boshu2/homebrew-agentops && brew install agentops   # macOS
-# Windows: irm .../install-ao.ps1 | iex.  Or release binaries / build from source (cli/README.md).
+# Windows: irm https://raw.githubusercontent.com/boshu2/agentops/main/scripts/install-ao.ps1 | iex
+# Or release binaries / build from source (cli/README.md).
 ```
 
 Installs hookless: skills and the `ao` CLI guide the workflow, and CI is the authoritative gate. The only hard requirement is an agent runtime and `git`; everything else degrades gracefully. Full dependency matrix: [docs/dependencies.md](docs/dependencies.md).


### PR DESCRIPTION
## What

Restore the two Windows PowerShell install one-liners to README.md that #754 ("tighten the README") abbreviated to comment fragments:

- `irm https://raw.githubusercontent.com/boshu2/agentops/main/scripts/install-codex.ps1 | iex`
- `irm https://raw.githubusercontent.com/boshu2/agentops/main/scripts/install-ao.ps1 | iex`

Restored in #754's tightened comment style (no prose re-expansion; +5/-2).

## Why (queue-wide trunk red)

The executable distribution canary `evals/agentops-core/distribution-install-update.json` (`public-install-docs-current`, lines 117/119) asserts README.md contains those **exact** strings via `artifact_contains`. #754 removed them, so the canary now **fails on main** → **`contracts-sync` (full 9-suite) is red on every open PR** (confirmed on #755, whose own change is clean). Source-of-truth precedence (per CLAUDE.md): the narrative README must satisfy the executable contract.

ag-5uau. Unblocks #755 and any other PR red on contracts-sync.

## Validation

- Both exact canary strings now present (`grep -F` = 1 each); diff is README-only (+5/-2); markdownlint clean.
- CI `contracts-sync` here is the authoritative check — it runs the actual `distribution-install-update` canary.

## Note

Restoring required install commands to satisfy the declared contract; #754's prose cuts elsewhere are untouched. If Windows install was meant to be de-documented, the alternative is updating the canary instead — flagged in ag-5uau. Not self-merged (cross-model quorum bus down).

Closes-scenario: ag-5uau#readme-install-oneliners
Bounded-context: BC2-Validation
Evidence: README.md