### PR TITLE
feat(domain): name silent-contract-violation + verdict.v1 finding taxonomy (ag-twl8 #verdict-category-taxonomy)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-05T23:51:12Z",
+  "generated_at": "2026-06-05T23:59:12Z",
   "summary": {
     "skills": 82,
     "hooks": 0,

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-06T00:02:44Z",
+  "generated_at": "2026-06-06T12:24:09Z",
   "summary": {
     "skills": 82,
     "hooks": 0,

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-05T04:08:51Z",
+  "generated_at": "2026-06-05T23:51:12Z",
   "summary": {
     "skills": 82,
     "hooks": 0,
@@ -418,7 +418,7 @@
         "path": "skills/domain/",
         "has_skill_md": true,
         "has_references": true,
-        "reference_count": 18
+        "reference_count": 19
       },
       {
         "name": "harvest",
@@ -2011,7 +2011,7 @@
         "ao session bootstrap"
       ],
       "path": "skills/domain/",
-      "references": 18
+      "references": 19
     },
     {
       "sku": "skill:dream",

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-05T23:59:12Z",
+  "generated_at": "2026-06-06T00:02:44Z",
   "summary": {
     "skills": 82,
     "hooks": 0,

--- a/schemas/verdict.v1.schema.json
+++ b/schemas/verdict.v1.schema.json
@@ -36,7 +36,12 @@
         "properties": {
           "severity": {"type": "string", "enum": ["critical", "significant", "minor"]},
           "description": {"type": "string"},
-          "location": {"type": "string"}
+          "location": {"type": "string"},
+          "category": {
+            "type": "string",
+            "enum": ["tool-choice", "output-contract", "call-signature", "data-provenance"],
+            "description": "Optional RubricRefine contract-check category for a silent-contract-violation finding (runs clean, no exception, still wrong). Omitted for general findings. See skills/domain/references/silent-contract-violation.md."
+          }
         },
         "additionalProperties": false
       }

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -793,7 +793,7 @@
     {
       "name": "domain",
       "source_skill": "skills/domain",
-      "source_hash": "e9e0eb28202076cfd28ced3504a81c9dd2e6547dd5dcaec4c8c5457688c77d48",
+      "source_hash": "3c1f6579e7af129d058d5c543b9bc07baa9e6ff7fb5a8b6cdb06aa3f52d9851b",
       "generated_hash": "5de534737803c76fab3ad06e1a47dba85eb8f631a159cc6157ce4f932c2e99e4"
     },
     {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -793,7 +793,7 @@
     {
       "name": "domain",
       "source_skill": "skills/domain",
-      "source_hash": "9ac2cf9eb9c5f8b6495a2c6bbec05f73d7ff9ec1b835c351f433bcb1d108d331",
+      "source_hash": "e9e0eb28202076cfd28ced3504a81c9dd2e6547dd5dcaec4c8c5457688c77d48",
       "generated_hash": "5de534737803c76fab3ad06e1a47dba85eb8f631a159cc6157ce4f932c2e99e4"
     },
     {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -793,7 +793,7 @@
     {
       "name": "domain",
       "source_skill": "skills/domain",
-      "source_hash": "8f488910bbc573bf02e6af3fd06a11e320d73eef3ea44a123439451e10b9da4e",
+      "source_hash": "9ac2cf9eb9c5f8b6495a2c6bbec05f73d7ff9ec1b835c351f433bcb1d108d331",
       "generated_hash": "5de534737803c76fab3ad06e1a47dba85eb8f631a159cc6157ce4f932c2e99e4"
     },
     {

--- a/skills-codex/domain/.agentops-generated.json
+++ b/skills-codex/domain/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/domain",
   "layout": "modular",
-  "source_hash": "e9e0eb28202076cfd28ced3504a81c9dd2e6547dd5dcaec4c8c5457688c77d48",
+  "source_hash": "3c1f6579e7af129d058d5c543b9bc07baa9e6ff7fb5a8b6cdb06aa3f52d9851b",
   "generated_hash": "5de534737803c76fab3ad06e1a47dba85eb8f631a159cc6157ce4f932c2e99e4"
 }

--- a/skills-codex/domain/.agentops-generated.json
+++ b/skills-codex/domain/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/domain",
   "layout": "modular",
-  "source_hash": "9ac2cf9eb9c5f8b6495a2c6bbec05f73d7ff9ec1b835c351f433bcb1d108d331",
+  "source_hash": "e9e0eb28202076cfd28ced3504a81c9dd2e6547dd5dcaec4c8c5457688c77d48",
   "generated_hash": "5de534737803c76fab3ad06e1a47dba85eb8f631a159cc6157ce4f932c2e99e4"
 }

--- a/skills-codex/domain/.agentops-generated.json
+++ b/skills-codex/domain/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/domain",
   "layout": "modular",
-  "source_hash": "8f488910bbc573bf02e6af3fd06a11e320d73eef3ea44a123439451e10b9da4e",
+  "source_hash": "9ac2cf9eb9c5f8b6495a2c6bbec05f73d7ff9ec1b835c351f433bcb1d108d331",
   "generated_hash": "5de534737803c76fab3ad06e1a47dba85eb8f631a159cc6157ce4f932c2e99e4"
 }

--- a/skills/domain/SKILL.md
+++ b/skills/domain/SKILL.md
@@ -90,7 +90,7 @@ Operating discipline:
 - [`references/primitive-selection.md`](references/primitive-selection.md) — Primitive Selection: when to use a Skill vs CLI subcommand vs Hook vs CI gate (CLI is the deterministic core; hook + CI-gate are trigger surfaces that call it)
 - [`references/reach.md`](references/reach.md) — Reach: the blast-radius tier of a knowledge entry (`bead`/`pull`/`always`), orthogonal to maturity; `always` is computed from verification-earned canon, never authored
 
-Loop family (the operating loop — "one loop body, two drivers, one inner tick, one config"; doctrine in [`docs/architecture/canonical-loop-model.md`](../../docs/architecture/canonical-loop-model.md)):
+Loop family (the operating loop — "one loop body, two drivers, one inner tick, one config"; doctrine in `docs/architecture/canonical-loop-model.md`):
 
 - [`references/loop.md`](references/loop.md) — Loop: the umbrella; the same five-beat tick at every scale
 - [`references/evolve.md`](references/evolve.md) — Evolve: the in-session driver (AgentOps-shipped, zero-dependency)

--- a/skills/domain/SKILL.md
+++ b/skills/domain/SKILL.md
@@ -99,6 +99,10 @@ Loop family (the operating loop — "one loop body, two drivers, one inner tick,
 - [`references/autodev.md`](references/autodev.md) — Autodev: the config/intent layer the loop reads each tick (NOT a loop)
 - [`references/context-compiler.md`](references/context-compiler.md) — Context-Compiler: turns the corpus into the working set and absorbs the tick's exhaust
 
+Verification membrane:
+
+- [`references/silent-contract-violation.md`](references/silent-contract-violation.md) — Silent Contract Violation: tool-use code that runs clean, raises no exception, and is still wrong (wrong routing / output shape / argument provenance); the four contract-check categories that name where it lands (RubricRefine)
+
 Catalog:
 
 - [`references/INDEX.md`](references/INDEX.md) — full corpus index

--- a/skills/domain/references/INDEX.md
+++ b/skills/domain/references/INDEX.md
@@ -45,6 +45,12 @@ case-insensitive filesystems (macOS APFS default) do not collapse the two.
 |---------------------|---------------|------------|----------|
 | `tracer-bullet.md`  | Tracer Bullet | tracer     | concept  |
 
+### Verification membrane concepts
+
+| Slug                           | Concept                   | Status | Kind         |
+|--------------------------------|---------------------------|--------|--------------|
+| `silent-contract-violation.md` | Silent Contract Violation | draft  | anti-pattern |
+
 ### Operating discipline concepts
 
 | Slug                      | Concept              | Status     | Kind    |

--- a/skills/domain/references/silent-contract-violation.md
+++ b/skills/domain/references/silent-contract-violation.md
@@ -1,0 +1,85 @@
+---
+name: Silent Contract Violation
+kind: anti-pattern
+status: draft
+see-also: [anti-pattern, slice, citation]
+---
+# Silent Contract Violation
+
+A failure mode of tool-use agents where generated code **runs to completion,
+raises no exception, and is still wrong** — so execution-based feedback (tests,
+exit codes, CI green) cannot see it. The failure the verification membrane
+exists to catch.
+
+## Definition
+
+An agent composes calls to tools/skills and the program executes "successfully,"
+but a *contract* between calls was violated invisibly. Four contract categories
+(adopted from RubricRefine, Anduril, arxiv 2605.09730v3) name where the violation
+lands — and are the `category` enum on a `verdict.v1` finding:
+
+- **tool-choice** — the wrong tool/skill was routed for the task.
+- **output-contract** — the produced artifact's shape does not match the declared
+  `output_contract` / `produces`.
+- **call-signature** — a call's inputs do not satisfy the callee's declared
+  `consumes`.
+- **data-provenance** — a call consumes an argument no upstream step produced
+  (hallucinated or orphaned input).
+
+## Signature
+
+Green tests, zero raised exceptions, a clean exit — yet wrong routing, a
+mismatched output shape, or an argument with no real source. The tell is that
+*nothing failed loudly*; the defect is in the seams between calls, not inside any
+one call.
+
+## Cost
+
+The most expensive class of failure to catch late: it survives every
+execution-based gate and only surfaces downstream as corrupt data, a wrong action
+already taken (especially in stateful/expensive environments where retry is
+unsafe), or a confidently-wrong result a human trusts because "it ran."
+
+## Cause
+
+Verification that fires only *after* execution, plus reliance on exceptions as
+the failure signal. The contracts exist (every `SKILL.md` declares
+`consumes`/`produces`/`output_contract`) but nothing scores a plan against them
+*before* dispatch. Unstructured self-critique misses it; structured,
+registry-conditioned contract checks catch it.
+
+## Refusal
+
+When composing or reviewing a multi-step tool/skill plan, do **not** treat
+"it ran without error" as evidence of correctness. Score the plan against the
+four contract categories *before* the expensive/stateful action — a
+pre-execution contract gate — and record violations as `verdict.v1` findings
+with the matching `category`. Single-step calls are exempt (the failure mode is
+inter-tool; see RubricRefine's flat single-step result).
+
+## When to use
+
+- Reviewing a Workflow script, `rpi`/`crank` wave, or any composed tool plan
+  before it spends tokens or takes a live action.
+- Triaging "it passed but produced the wrong thing" reports — name the category
+  rather than re-describing the symptom.
+
+## What it is not
+
+- Not a runtime crash or a raised exception (those are caught by execution).
+- Not a style/quality nit — it is a *contract* violation between calls.
+- Not a substitute for the author≠judge independence invariant; the
+  pre-execution check is structured self-grade, a cheaper inner rung beneath
+  cross-model verification, never a replacement for it.
+
+## Incident citation
+
+- `bd` epic **ag-5elx** (RubricRefine integration) / bead **ag-twl8** — this
+  entry and the `verdict.v1` `category` enum were added together so the
+  membrane has a name for the run-clean-but-wrong class it is built to catch.
+
+## See also
+
+- `anti-pattern.md` — the shape this Entry follows
+- `slice.md` — what a Silent Contract Violation corrupts when it triggers
+- `citation.md` — how this anti-pattern is applied during a Slice

--- a/tests/scripts/check-verdict-category-taxonomy.bats
+++ b/tests/scripts/check-verdict-category-taxonomy.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+# ag-twl8: verdict.v1 carries the RubricRefine silent-contract-violation finding
+# taxonomy. A finding MAY declare a `category` drawn from the four
+# registry-conditioned contract-check buckets (tool-choice, output-contract,
+# call-signature, data-provenance). The field is OPTIONAL so existing validators
+# that emit uncategorized findings stay valid; an UNKNOWN category is rejected so
+# the taxonomy cannot silently drift. Behavioral validation uses python
+# jsonschema against the real schema (no Go binds verdict.v1 — it is a contract).
+# Source: RubricRefine (Anduril, arxiv 2605.09730v3); epic ag-5elx.
+
+setup() {
+  SCHEMA="$BATS_TEST_DIRNAME/../../schemas/verdict.v1.schema.json"
+  [ -f "$SCHEMA" ] || skip "schema not found: $SCHEMA"
+  command -v python3 >/dev/null || skip "python3 required"
+  python3 -c 'import jsonschema' 2>/dev/null || skip "python jsonschema required"
+}
+
+# Emit a minimal schema-valid verdict whose single finding has the given
+# category injected verbatim ($1). Pass the literal "OMIT" to emit no category.
+_verdict_with_category() {
+  local cat="$1" catfield=""
+  if [ "$cat" != "OMIT" ]; then
+    catfield=", \"category\": \"$cat\""
+  fi
+  cat <<JSON
+{
+  "verdict_id": "01ABCDEFGHJKMNPQRSTVWXYZ00",
+  "bead_id": "01ABCDEFGHJKMNPQRSTVWXYZ01",
+  "verdict": "FAIL",
+  "confidence": "HIGH",
+  "briefing_learnings": [],
+  "findings": [
+    {"severity": "critical", "description": "step 3 consumes an artifact no prior step produced", "location": "plan:step3"$catfield}
+  ],
+  "not_checked": [],
+  "validated_at": "2026-06-05T00:00:00Z",
+  "validator_session": "sess-judge-1",
+  "schema_version": 1
+}
+JSON
+}
+
+# Validate stdin instance against the schema; exit non-zero iff invalid.
+# Program is passed via -c so stdin stays free for the piped instance.
+_validate() {
+  python3 -c 'import json,sys,jsonschema; jsonschema.validate(json.load(sys.stdin), json.load(open(sys.argv[1])))' "$SCHEMA"
+}
+
+@test "finding with a valid contract-check category validates" {
+  _verdict_with_category output-contract | _validate
+}
+
+@test "all four RubricRefine categories are accepted" {
+  for c in tool-choice output-contract call-signature data-provenance; do
+    _verdict_with_category "$c" | _validate || { echo "category rejected: $c"; return 1; }
+  done
+}
+
+@test "finding without a category still validates (backward compatible)" {
+  _verdict_with_category OMIT | _validate
+}
+
+@test "an unknown category is rejected" {
+  local v; v="$(_verdict_with_category bogus-category)"
+  run _validate <<<"$v"
+  [ "$status" -ne 0 ]
+}
+
+@test "schema declares exactly the four taxonomy values" {
+  run jq -e '.properties.findings.items.properties.category.enum
+             | sort == ["call-signature","data-provenance","output-contract","tool-choice"]' "$SCHEMA"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## What

First slice of the RubricRefine integration epic (**ag-5elx**). Moves the paper's sharpest idea into the verification membrane — and it's the dependency that **blocks the flagship** pre-execution gate (ag-rjvf).

- **`skills/domain/references/silent-contract-violation.md`** — new draft anti-pattern entry. Names the failure class the whole membrane exists to catch: tool-use code that **runs clean, raises no exception, and is still wrong** (wrong routing, mismatched output shape, broken argument provenance). Full Signature / Cost / Cause / Refusal + `bd` incident citation, indexed in `INDEX.md` under a new "Verification membrane concepts" section.
- **`schemas/verdict.v1.schema.json`** — adds RubricRefine's 4-category contract-check taxonomy as an **optional** `category` enum on findings: `tool-choice | output-contract | call-signature | data-provenance`. Backward compatible — existing uncategorized findings stay valid (`additionalProperties:false` preserved), an unknown category is rejected so the taxonomy can't drift.
- **`tests/scripts/check-verdict-category-taxonomy.bats`** — behavioral schema tests via python `jsonschema` (valid accepted · all four accepted · omit valid · unknown rejected · enum exact). Written test-first: confirmed failing against the unmodified schema, then green.
- **`registry.json`** — regenerated (domain `reference_count` 18→19; scope-only diff).

## Why

RubricRefine (Anduril, arxiv 2605.09730v3) formalizes the failure AgentOps' no-self-grade membrane targets, but AgentOps had no name for it and no shared bucket vocabulary for findings. This slice supplies both, so every downstream gate (and the pre-execution gate ag-rjvf) can categorize and ablate contract violations.

## Verification

- `bats tests/scripts/check-verdict-category-taxonomy.bats` → 5/5 (CI runs it via the bats job; surfaces changed: schemas/skills/docs/bats).
- `scripts/generate-registry.sh --check` → up to date.
- `scripts/check-bead-scenario-coverage.sh --run` → PASS (1/1 scenario covered & passing).
- Full `pre-push-gate.sh --fast`: green except `corpus-freshness` (env-local snapshot 8d old; CI sets `AGENTOPS_CORPUS_FRESHNESS_SKIP=1` — not a PR blocker).

Closes-scenario: ag-twl8#verdict-category-taxonomy
Bounded-context: BC1-Corpus
Evidence: schemas/verdict.v1.schema.json