### PR TITLE
chore(test): migrate redundant os.Setenv to t.Setenv; lower isolation ratchet 22->12 (ag-k38x #bulk-migration-setenv)

### DIFF
--- a/cli/cmd/ao/rpi_reliability_test.go
+++ b/cli/cmd/ao/rpi_reliability_test.go
@@ -112,9 +112,7 @@ func TestSelectExecutor_StreamDefault(t *testing.T) {
 // TestDirectExecutor_Execute_PropagatesError verifies that directExecutor.Execute
 // returns an error when the claude binary is not available.
 func TestDirectExecutor_Execute_PropagatesError(t *testing.T) {
-	// Temporarily redirect PATH so claude is not found.
-	origPath := os.Getenv("PATH")
-	defer func() { _ = os.Setenv("PATH", origPath) }()
+	// Redirect PATH so claude is not found; t.Setenv auto-restores.
 	t.Setenv("PATH", t.TempDir()) // empty dir = no binaries
 
 	d := &directExecutor{}
@@ -127,9 +125,7 @@ func TestDirectExecutor_Execute_PropagatesError(t *testing.T) {
 // TestStreamExecutor_Execute_PropagatesError verifies streamExecutor.Execute
 // returns an error when claude is not found.
 func TestStreamExecutor_Execute_PropagatesError(t *testing.T) {
-	origPath := os.Getenv("PATH")
-	defer func() { _ = os.Setenv("PATH", origPath) }()
-	t.Setenv("PATH", t.TempDir()) // no binaries
+	t.Setenv("PATH", t.TempDir()) // no binaries; t.Setenv auto-restores
 
 	s := &streamExecutor{statusPath: filepath.Join(t.TempDir(), "status.md"), allPhases: nil}
 	err := s.Execute(context.Background(), "prompt", t.TempDir(), "run-stream-err", 3)
@@ -431,9 +427,7 @@ func TestWritePhasedStateAtomic_LeavesNoTmpOnSuccess(t *testing.T) {
 // TestRecordRatchetCheckpoint_FailSilently verifies that recordRatchetCheckpoint
 // does not panic or return an error when ao ratchet is not on PATH.
 func TestRecordRatchetCheckpoint_FailSilently(t *testing.T) {
-	origPath := os.Getenv("PATH")
-	defer func() { _ = os.Setenv("PATH", origPath) }()
-	// Use an empty dir so no binaries are found.
+	// Use an empty dir so no binaries are found; t.Setenv auto-restores.
 	t.Setenv("PATH", t.TempDir())
 
 	// Should complete without panic when ao is not on PATH

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -96,19 +96,10 @@ func TestMerge_BooleanNotSet(t *testing.T) {
 }
 
 func TestApplyEnv(t *testing.T) {
-	// Save and restore env
-	origOutput := os.Getenv("AGENTOPS_OUTPUT")
-	origVerbose := os.Getenv("AGENTOPS_VERBOSE")
-	origNoSC := os.Getenv("AGENTOPS_NO_SC")
-	defer func() {
-		_ = os.Setenv("AGENTOPS_OUTPUT", origOutput)   //nolint:errcheck // test env restore
-		_ = os.Setenv("AGENTOPS_VERBOSE", origVerbose) //nolint:errcheck // test env restore
-		_ = os.Setenv("AGENTOPS_NO_SC", origNoSC)      //nolint:errcheck // test env restore
-	}()
-
-	_ = os.Setenv("AGENTOPS_OUTPUT", "yaml")  //nolint:errcheck // test env setup
-	_ = os.Setenv("AGENTOPS_VERBOSE", "true") //nolint:errcheck // test env setup
-	_ = os.Setenv("AGENTOPS_NO_SC", "1")      //nolint:errcheck // test env setup
+	// t.Setenv sets and auto-restores on cleanup (and blocks t.Parallel).
+	t.Setenv("AGENTOPS_OUTPUT", "yaml")
+	t.Setenv("AGENTOPS_VERBOSE", "true")
+	t.Setenv("AGENTOPS_NO_SC", "1")
 
 	cfg := Default()
 	cfg = applyEnv(cfg)

--- a/cli/internal/goals/measure_test.go
+++ b/cli/internal/goals/measure_test.go
@@ -357,10 +357,8 @@ func TestTruncateOutput_MultiByteRunes(t *testing.T) {
 // (lines 109-113). When bash itself cannot start, the function should return
 // a fail result with the error message in Output.
 func TestMeasureOne_StartError(t *testing.T) {
-	// Save current PATH and set it to empty to make "bash" unresolvable.
-	origPath := os.Getenv("PATH")
+	// Set PATH empty to make "bash" unresolvable; t.Setenv auto-restores.
 	t.Setenv("PATH", "")
-	defer os.Setenv("PATH", origPath)
 
 	goal := Goal{
 		ID:     "start-error",

--- a/scripts/check-test-isolation.sh
+++ b/scripts/check-test-isolation.sh
@@ -19,8 +19,11 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 # Baselines captured 2026-06-03 (excludes the testutil_test.go helper home).
+# os.Setenv lowered 22->12 on 2026-06-06 (ag-k38x #bulk-migration). The remaining 12
+# are intentional and cannot use t.Setenv: TestMain sites (no *testing.T), string-literal
+# fixtures in fix_cliconfig_test.go, and unset-semantics helpers (t.Setenv cannot unset).
 BASELINE_CHDIR=163
-BASELINE_SETENV=22
+BASELINE_SETENV=12
 
 chdir=$(grep -rho --include='*_test.go' --exclude='testutil_test.go' 'os\.Chdir(' cli 2>/dev/null | wc -l | tr -d ' ')
 setenv=$(grep -rho --include='*_test.go' --exclude='testutil_test.go' 'os\.Setenv(' cli 2>/dev/null | wc -l | tr -d ' ')


### PR DESCRIPTION
## What

Advances the test-isolation ratchet (`scripts/check-test-isolation.sh`, shipped in #699) by driving the `os.Setenv` baseline from **22 → 12**. Pure test-hygiene; no production-code change.

`t.Setenv` auto-restores on cleanup **and** fails fast under `t.Parallel` — the raw `os.Setenv` form is the latent-flake landmine the ratchet exists to retire (cf. ag-jfzs).

## Sites migrated (10 eliminated)

| File | Δ | How |
|---|---|---|
| `internal/config/config_test.go` | -6 | Collapse the `origX := os.Getenv(...)` + `defer os.Setenv(... restore)` block into 3× `t.Setenv` |
| `internal/goals/measure_test.go` | -1 | Delete the redundant `origPath`/`defer os.Setenv` — the existing `t.Setenv("PATH","")` already auto-restores |
| `cmd/ao/rpi_reliability_test.go` | -3 | Delete 3 redundant restore-defers wrapped around existing `t.Setenv` calls |

## The remaining 12 are intentional (not migratable)

Documented inline in the ratchet script. They cannot use `t.Setenv`:
- **TestMain** (`cmd/ao/main_test.go`, `internal/doctor/doctor_testmain_test.go`) — no `*testing.T` in scope (4)
- **String-literal fixtures** (`internal/doctor/fix_cliconfig_test.go`) — `os.Setenv` appears inside generated test-program source, not a real call (2)
- **Unset-semantics helpers** (`cmd/ao/handoff_test.go`, `internal/lifecycle/repo_readiness_test.go`, `internal/wiki/locator_test.go`) — these `os.Unsetenv`+restore vars; `t.Setenv` has no unset form (6)

## Verification

- `bash scripts/check-test-isolation.sh` → `PASS … os.Setenv=12/12`
- `go build ./...` ✓ · `go vet` (touched pkgs) ✓
- `go test ./internal/config/ ./internal/goals/` → 526 passed; touched cmd/ao tests → 3 passed

Closes-scenario: ag-k38x#bulk-migration-setenv
Bounded-context: BC5-Runtime
Evidence: scripts/check-test-isolation.sh PASS 12/12