### PR TITLE
feat(eval): ao eval outcomes ingest --manifest-out emits eval-run.v1 manifest (ag-fy6e #manifest-out-eval-run)

### DIFF
--- a/cli/cmd/ao/eval_outcomes_ingest.go
+++ b/cli/cmd/ao/eval_outcomes_ingest.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/boshu2/agentops/cli/internal/evalsubstrate"
 	"github.com/spf13/cobra"
@@ -202,8 +203,10 @@ func applyOutcomesBurn(path string, s outcomesScore) error {
 }
 
 var (
-	evalOutcomesIngestExpectHash string
-	evalOutcomesIngestBurnLedger string
+	evalOutcomesIngestExpectHash  string
+	evalOutcomesIngestBurnLedger  string
+	evalOutcomesIngestManifestOut string
+	evalOutcomesIngestRunID       string
 )
 
 var evalOutcomesIngestCmd = &cobra.Command{
@@ -231,11 +234,21 @@ func runEvalOutcomesIngest(cmd *cobra.Command, args []string) error {
 	if err := applyOutcomesBurn(evalOutcomesIngestBurnLedger, s); err != nil {
 		return err
 	}
-	out, err := json.MarshalIndent(ingestOutcomesScore(s), "", "  ")
+	v := ingestOutcomesScore(s)
+	out, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode verdict: %w", err)
 	}
 	fmt.Fprintln(cmd.OutOrStdout(), string(out))
+	if evalOutcomesIngestManifestOut != "" {
+		runID := resolveOutcomesRunID(evalOutcomesIngestRunID, s)
+		rec := buildOutcomesRunManifest(s, v.Verdict, runID, time.Now().UTC())
+		path, err := writeOutcomesRunManifest(evalOutcomesIngestManifestOut, runID, rec)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.ErrOrStderr(), "wrote eval-run manifest: %s\n", path)
+	}
 	return nil
 }
 
@@ -244,5 +257,9 @@ func init() {
 		"refuse the ingest if the score's judge_content_hash does not match this value (gate #2 rubric-drift parity)")
 	evalOutcomesIngestCmd.Flags().StringVar(&evalOutcomesIngestBurnLedger, "burn-ledger", "",
 		"path to a JSON HoldoutBurnLedger; when set, a holdout-split score registers a burn and is REFUSED if the (suite,gt) quota is exhausted (gate #3 runtime enforcement), persisted across invocations")
+	evalOutcomesIngestCmd.Flags().StringVar(&evalOutcomesIngestManifestOut, "manifest-out", "",
+		"also write an eval-run.v1 manifest to <dir>/<run-id>/manifest.json so the verdict pipeline feeds the Knowledge Flywheel (closes the Outcomes→Flywheel loop)")
+	evalOutcomesIngestCmd.Flags().StringVar(&evalOutcomesIngestRunID, "run-id", "",
+		"run id for the --manifest-out manifest; defaults to the score's run_id, then source_task_id (sanitized to the eval-run.v1 pattern)")
 	evalOutcomesCmd.AddCommand(evalOutcomesIngestCmd)
 }

--- a/cli/cmd/ao/eval_outcomes_manifest.go
+++ b/cli/cmd/ao/eval_outcomes_manifest.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/boshu2/agentops/cli/internal/eval"
+)
+
+// This file (ag-fy6e) gives `ao eval outcomes ingest` a second, optional output:
+// an eval-run.v1 RUN MANIFEST alongside the council verdict record. With
+// --manifest-out <dir> set, ingest ALSO writes <dir>/<run-id>/manifest.json
+// conforming to schemas/eval-run.v1.schema.json, so the existing verdict
+// pipeline (docs/contracts/eval-verdict-pipeline.md) picks it up and feeds the
+// Knowledge Flywheel — closing the Outcomes→Flywheel loop end-to-end. The writer
+// lives in this NEW file (diversifies off eval_outcomes_ingest.go); ingest.go
+// only wires the thin flag.
+//
+// SCHEMA-vs-bead reconciliation (source-of-truth precedence, CLAUDE.md): the
+// bead text said "status=complete", but that value belongs to the *other*
+// SCHEMA.md run-manifest (the rc3 struct-verdict form). eval-run.v1's `status`
+// enum is pass/fail/error/skipped/inconclusive — it has NO "complete" member, so
+// this writer follows the schema and maps the PASS/WARN/FAIL band onto the
+// allowed enum (see outcomesBandToStatus). An out-of-process Outcomes grade has
+// no candidate git sha / live runtime / sandboxed environment, so git/runtime/
+// environment carry honest, schema-valid stubs and a `notes` entry records the
+// provenance.
+
+// outcomesManifestDimensions is the set of dimension keys eval-run.v1's
+// dimension_scores object permits (additionalProperties:false). A criterion
+// score whose key is outside this set cannot be placed in the manifest, so
+// outcomesDimensionScores filters to exactly these. Note context_comprehension
+// is a valid eval.Dimension but is NOT a dimension_scores property in
+// eval-run.v1, so it is intentionally excluded here.
+var outcomesManifestDimensions = map[eval.Dimension]bool{
+	eval.DimensionCorrectness:          true,
+	eval.DimensionProcessAdherence:     true,
+	eval.DimensionArtifactQuality:      true,
+	eval.DimensionRuntimeCompatibility: true,
+	eval.DimensionEfficiency:           true,
+	eval.DimensionSafety:               true,
+	eval.DimensionLearningClosure:      true,
+}
+
+var outcomesRunIDInvalid = regexp.MustCompile(`[^a-zA-Z0-9._:-]`)
+
+// clampOutcomesScore bounds a score into the schema's [0,1] range so a payload
+// carrying an out-of-band aggregate (or a malformed criterion score) still
+// produces a schema-valid manifest rather than a validation failure downstream.
+func clampOutcomesScore(v float64) float64 {
+	switch {
+	case v < 0:
+		return 0
+	case v > 1:
+		return 1
+	default:
+		return v
+	}
+}
+
+// outcomesBandToVerdict maps the council PASS/WARN/FAIL band onto the
+// eval-run.v1 verdict enum: PASS→pass, FAIL→fail, anything else (WARN)→advisory.
+// improvement/regression are baseline-delta verdicts; an Outcomes grade carries
+// no baseline, so this writer never emits them.
+func outcomesBandToVerdict(band string) eval.Verdict {
+	switch band {
+	case "PASS":
+		return eval.VerdictPass
+	case "FAIL":
+		return eval.VerdictFail
+	default:
+		return eval.VerdictAdvisory
+	}
+}
+
+// outcomesBandToStatus maps the band onto the eval-run.v1 status enum. The
+// schema's status enum lacks "complete", so the run lifecycle status mirrors the
+// band: PASS→pass, FAIL→fail, WARN→inconclusive.
+func outcomesBandToStatus(band string) eval.Status {
+	switch band {
+	case "PASS":
+		return eval.StatusPass
+	case "FAIL":
+		return eval.StatusFail
+	default:
+		return eval.StatusInconclusive
+	}
+}
+
+// outcomesVisibility maps the score's eval split onto the suite visibility:
+// a holdout grade is a private_holdout suite, everything else a public_canary.
+func outcomesVisibility(split string) eval.Visibility {
+	if split == "holdout" {
+		return eval.VisibilityPrivateHoldout
+	}
+	return eval.VisibilityPublicCanary
+}
+
+// outcomesDimensionScores projects an Outcomes score's per-criterion scores onto
+// the eval-run.v1 dimension_scores object, keeping only the schema-permitted
+// dimension keys (additionalProperties:false). If no criterion maps to a known
+// dimension, it synthesizes correctness=aggregate so the object satisfies the
+// schema's minProperties:1 — an Outcomes grade always carries an aggregate.
+func outcomesDimensionScores(crit map[string]float64, aggregate float64) map[eval.Dimension]float64 {
+	out := map[eval.Dimension]float64{}
+	for k, v := range crit {
+		d := eval.Dimension(k)
+		if outcomesManifestDimensions[d] {
+			out[d] = clampOutcomesScore(v)
+		}
+	}
+	if len(out) == 0 {
+		out[eval.DimensionCorrectness] = clampOutcomesScore(aggregate)
+	}
+	return out
+}
+
+// resolveOutcomesRunID picks the run id in precedence order — explicit
+// --run-id, then the score's own run_id, then its source_task_id — sanitizes it
+// to the schema pattern (^[a-zA-Z0-9][a-zA-Z0-9._:-]*$), and falls back to a
+// constant when nothing usable remains.
+func resolveOutcomesRunID(explicit string, s outcomesScore) string {
+	for _, cand := range []string{explicit, s.RunID, s.SourceTaskID} {
+		if id := sanitizeOutcomesRunID(cand); id != "" {
+			return id
+		}
+	}
+	return "outcomes-run"
+}
+
+// sanitizeOutcomesRunID coerces an arbitrary string into the eval-run.v1 run_id
+// pattern: invalid characters become '-', then leading non-alphanumerics are
+// trimmed (the first char must be [a-zA-Z0-9]). Returns "" when nothing valid
+// remains, so the caller can fall through to the next candidate.
+func sanitizeOutcomesRunID(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	cleaned := outcomesRunIDInvalid.ReplaceAllString(raw, "-")
+	cleaned = strings.TrimLeft(cleaned, "-._:")
+	return cleaned
+}
+
+// buildOutcomesRunManifest assembles an eval-run.v1 RunRecord from an Outcomes
+// score and its council band. startedAt is injected (clock seam) so callers and
+// tests are deterministic. git/runtime/environment are honest stubs because the
+// grade was produced out-of-process; a notes entry records that provenance.
+func buildOutcomesRunManifest(s outcomesScore, band, runID string, startedAt time.Time) eval.RunRecord {
+	completed := startedAt
+	dims := outcomesDimensionScores(s.CriterionScores, s.Aggregate)
+	caseID := s.SourceTaskID
+	if caseID == "" {
+		caseID = "aggregate"
+	}
+	suiteID := s.SuiteRef
+	if suiteID == "" {
+		suiteID = "outcomes"
+	}
+	return eval.RunRecord{
+		SchemaVersion: 1,
+		RunID:         runID,
+		Suite: eval.SuiteRef{
+			ID:         suiteID,
+			Path:       "out-of-process",
+			Visibility: outcomesVisibility(s.Split),
+			Tier:       eval.TierLive,
+		},
+		StartedAt:   startedAt,
+		CompletedAt: &completed,
+		Status:      outcomesBandToStatus(band),
+		Verdict:     outcomesBandToVerdict(band),
+		Git: eval.GitRecord{
+			// No candidate sha is known for an out-of-process grade; a zeroed
+			// hex sha satisfies the schema pattern while signalling "unknown".
+			CandidateRef: "out-of-process-outcomes-grade",
+			CandidateSHA: "0000000",
+			Dirty:        false,
+		},
+		Runtime: eval.RuntimeRecord{
+			Name: eval.RuntimeManual,
+			Live: false,
+		},
+		Environment: eval.EnvironmentRecord{
+			ScrubbedEnvPrefixes: []string{},
+			IsolatedHome:        false,
+			IsolatedCodexHome:   false,
+			NetworkAccess:       eval.NetworkUnknown,
+		},
+		CaseResults: []eval.CaseResult{
+			{
+				ID:              caseID,
+				Status:          outcomesBandToStatus(band),
+				Score:           clampOutcomesScore(s.Aggregate),
+				DimensionScores: dims,
+			},
+		},
+		AggregateScore:  clampOutcomesScore(s.Aggregate),
+		DimensionScores: dims,
+		Notes: []string{
+			fmt.Sprintf("Out-of-process Outcomes grade ingested by `ao eval outcomes ingest` (band=%s); git/runtime/environment are stubs — the grade was produced outside this harness.", band),
+		},
+	}
+}
+
+// writeOutcomesRunManifest writes rec to <dir>/<runID>/manifest.json (creating
+// the directory) and returns the manifest path. It is the file-system adapter
+// for buildOutcomesRunManifest.
+func writeOutcomesRunManifest(dir, runID string, rec eval.RunRecord) (string, error) {
+	runDir := filepath.Join(dir, runID)
+	if err := os.MkdirAll(runDir, 0o750); err != nil {
+		return "", fmt.Errorf("create manifest dir %s: %w", runDir, err)
+	}
+	blob, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("encode eval-run manifest: %w", err)
+	}
+	path := filepath.Join(runDir, "manifest.json")
+	if err := os.WriteFile(path, append(blob, '\n'), 0o600); err != nil {
+		return "", fmt.Errorf("write eval-run manifest %s: %w", path, err)
+	}
+	return path, nil
+}

--- a/cli/cmd/ao/eval_outcomes_manifest_test.go
+++ b/cli/cmd/ao/eval_outcomes_manifest_test.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/boshu2/agentops/cli/internal/eval"
+)
+
+func fixedManifestTime() time.Time {
+	return time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+}
+
+// findEvalRunSchema walks up from the working directory to locate
+// schemas/eval-run.v1.schema.json so the schema-linked assertions work whether
+// the test runs from cli/cmd/ao or the repo root. Returns "" when not found.
+func findEvalRunSchema(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for i := 0; i < 8; i++ {
+		cand := filepath.Join(dir, "schemas", "eval-run.v1.schema.json")
+		if _, err := os.Stat(cand); err == nil {
+			return cand
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return ""
+}
+
+func TestBuildOutcomesRunManifest_BandMapping(t *testing.T) {
+	cases := []struct {
+		name       string
+		band       string
+		wantStatus eval.Status
+		wantVerd   eval.Verdict
+	}{
+		{"pass", "PASS", eval.StatusPass, eval.VerdictPass},
+		{"fail", "FAIL", eval.StatusFail, eval.VerdictFail},
+		{"warn", "WARN", eval.StatusInconclusive, eval.VerdictAdvisory},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := outcomesScore{SourceTaskID: "task-1", Aggregate: 0.82}
+			rec := buildOutcomesRunManifest(s, tc.band, "run-1", fixedManifestTime())
+			if rec.Status != tc.wantStatus {
+				t.Errorf("status = %q, want %q", rec.Status, tc.wantStatus)
+			}
+			if rec.Verdict != tc.wantVerd {
+				t.Errorf("verdict = %q, want %q", rec.Verdict, tc.wantVerd)
+			}
+		})
+	}
+}
+
+func TestBuildOutcomesRunManifest_RequiredFieldsAndStubs(t *testing.T) {
+	s := outcomesScore{
+		SourceTaskID:    "task-xyz",
+		Aggregate:       0.9,
+		Threshold:       0.8,
+		Split:           "holdout",
+		SuiteRef:        "suite-a",
+		CriterionScores: map[string]float64{"correctness": 0.95, "safety": 0.88},
+	}
+	rec := buildOutcomesRunManifest(s, "PASS", "run-xyz", fixedManifestTime())
+
+	if rec.SchemaVersion != 1 {
+		t.Errorf("schema_version = %d, want 1", rec.SchemaVersion)
+	}
+	if rec.RunID != "run-xyz" {
+		t.Errorf("run_id = %q, want run-xyz", rec.RunID)
+	}
+	if rec.Suite.ID != "suite-a" {
+		t.Errorf("suite.id = %q, want suite-a", rec.Suite.ID)
+	}
+	if rec.Suite.Visibility != eval.VisibilityPrivateHoldout {
+		t.Errorf("holdout split must map to private_holdout, got %q", rec.Suite.Visibility)
+	}
+	if rec.Suite.Path == "" || rec.Suite.Tier != eval.TierLive {
+		t.Errorf("suite path/tier stubs wrong: path=%q tier=%q", rec.Suite.Path, rec.Suite.Tier)
+	}
+	if rec.AggregateScore != 0.9 {
+		t.Errorf("aggregate_score = %v, want 0.9", rec.AggregateScore)
+	}
+	if len(rec.CaseResults) != 1 {
+		t.Fatalf("case_results len = %d, want 1", len(rec.CaseResults))
+	}
+	if rec.CaseResults[0].ID != "task-xyz" {
+		t.Errorf("case id = %q, want task-xyz", rec.CaseResults[0].ID)
+	}
+	if len(rec.DimensionScores) != 2 {
+		t.Errorf("dimension_scores = %v, want 2 known dims", rec.DimensionScores)
+	}
+	// Honest stubs that must still be schema-valid.
+	if rec.Git.CandidateSHA != "0000000" {
+		t.Errorf("candidate_sha stub = %q, want 0000000", rec.Git.CandidateSHA)
+	}
+	if rec.Runtime.Name != eval.RuntimeManual {
+		t.Errorf("runtime.name = %q, want manual", rec.Runtime.Name)
+	}
+	if rec.Environment.NetworkAccess != eval.NetworkUnknown {
+		t.Errorf("network_access = %q, want unknown", rec.Environment.NetworkAccess)
+	}
+	if rec.Environment.ScrubbedEnvPrefixes == nil {
+		t.Error("scrubbed_env_prefixes must be a non-nil slice (marshals to [] not null)")
+	}
+	if len(rec.Notes) == 0 {
+		t.Error("expected a provenance note recording the out-of-process grade")
+	}
+}
+
+func TestOutcomesDimensionScores_FiltersAndFallback(t *testing.T) {
+	// Unknown keys are dropped; known keys (incl. clamping) are kept.
+	got := outcomesDimensionScores(map[string]float64{
+		"correctness":           1.4, // clamps to 1
+		"made_up_axis":          0.5, // not a schema dimension → dropped
+		"context_comprehension": 0.7, // valid Dimension but NOT an eval-run.v1 prop → dropped
+	}, 0.6)
+	if len(got) != 1 {
+		t.Fatalf("expected only correctness kept, got %v", got)
+	}
+	if got[eval.DimensionCorrectness] != 1.0 {
+		t.Errorf("correctness clamp = %v, want 1.0", got[eval.DimensionCorrectness])
+	}
+
+	// No known criterion → fallback synthesizes correctness from aggregate.
+	fb := outcomesDimensionScores(map[string]float64{"nope": 0.3}, 0.42)
+	if len(fb) != 1 || fb[eval.DimensionCorrectness] != 0.42 {
+		t.Errorf("fallback = %v, want {correctness:0.42}", fb)
+	}
+}
+
+func TestResolveOutcomesRunID(t *testing.T) {
+	cases := []struct {
+		name     string
+		explicit string
+		score    outcomesScore
+		want     string
+	}{
+		{"explicit wins", "my-run", outcomesScore{RunID: "other", SourceTaskID: "task"}, "my-run"},
+		{"falls back to run_id", "", outcomesScore{RunID: "from-payload", SourceTaskID: "task"}, "from-payload"},
+		{"falls back to source_task_id", "", outcomesScore{SourceTaskID: "task-7"}, "task-7"},
+		{"sanitizes invalid chars", "weird id/with spaces", outcomesScore{}, "weird-id-with-spaces"},
+		{"trims leading invalid", "  -lead", outcomesScore{}, "lead"},
+		{"all-empty fallback", "", outcomesScore{}, "outcomes-run"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveOutcomesRunID(tc.explicit, tc.score); got != tc.want {
+				t.Errorf("resolveOutcomesRunID(%q, %+v) = %q, want %q", tc.explicit, tc.score, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWriteOutcomesRunManifest_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := outcomesScore{SourceTaskID: "task-rt", Aggregate: 0.77, Threshold: 0.7,
+		CriterionScores: map[string]float64{"efficiency": 0.8}}
+	rec := buildOutcomesRunManifest(s, "PASS", "run-rt", fixedManifestTime())
+
+	path, err := writeOutcomesRunManifest(dir, "run-rt", rec)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	want := filepath.Join(dir, "run-rt", "manifest.json")
+	if path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var back eval.RunRecord
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal round-trip: %v", err)
+	}
+	if back.RunID != "run-rt" || back.AggregateScore != 0.77 || back.Verdict != eval.VerdictPass {
+		t.Errorf("round-trip mismatch: %+v", back)
+	}
+}
+
+// TestOutcomesManifest_MatchesSchemaContract ties the manifest to the actual
+// schema file: every top-level required key must be present and non-null in the
+// marshaled manifest, and status/verdict must be members of the schema's enums.
+// This is the Go-struct-roundtrip validation the bead permits in lieu of a
+// vendored jsonschema validator.
+func TestOutcomesManifest_MatchesSchemaContract(t *testing.T) {
+	schemaPath := findEvalRunSchema(t)
+	if schemaPath == "" {
+		t.Skip("eval-run.v1 schema not found from cwd; skipping schema-contract check")
+	}
+	raw, err := os.ReadFile(schemaPath)
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	var schema struct {
+		Required []string `json:"required"`
+		Defs     map[string]struct {
+			Enum []string `json:"enum"`
+		} `json:"$defs"`
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+
+	s := outcomesScore{SourceTaskID: "task-c", Aggregate: 0.5, Threshold: 0.8,
+		CriterionScores: map[string]float64{"correctness": 0.5}}
+	rec := buildOutcomesRunManifest(s, "WARN", "run-c", fixedManifestTime())
+	blob, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	var asMap map[string]json.RawMessage
+	if err := json.Unmarshal(blob, &asMap); err != nil {
+		t.Fatalf("unmarshal manifest to map: %v", err)
+	}
+
+	for _, key := range schema.Required {
+		v, ok := asMap[key]
+		if !ok {
+			t.Errorf("required key %q missing from manifest", key)
+			continue
+		}
+		if string(v) == "null" {
+			t.Errorf("required key %q is null", key)
+		}
+	}
+
+	assertEnumMember(t, schema.Defs["status"].Enum, string(rec.Status), "status")
+	assertEnumMember(t, schema.Defs["verdict"].Enum, string(rec.Verdict), "verdict")
+}
+
+func assertEnumMember(t *testing.T, enum []string, got, label string) {
+	t.Helper()
+	if len(enum) == 0 {
+		t.Fatalf("%s enum not found in schema", label)
+	}
+	for _, e := range enum {
+		if e == got {
+			return
+		}
+	}
+	t.Errorf("%s = %q is not a member of schema enum %v", label, got, enum)
+}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -1609,6 +1609,8 @@ ao eval outcomes ingest <score.json> [flags]
       --burn-ledger string         path to a JSON HoldoutBurnLedger; when set, a holdout-split score registers a burn and is REFUSED if the (suite,gt) quota is exhausted (gate #3 runtime enforcement), persisted across invocations
       --expect-judge-hash string   refuse the ingest if the score's judge_content_hash does not match this value (gate #2 rubric-drift parity)
   -h, --help                       help for ingest
+      --manifest-out string        also write an eval-run.v1 manifest to <dir>/<run-id>/manifest.json so the verdict pipeline feeds the Knowledge Flywheel (closes the Outcomes→Flywheel loop)
+      --run-id string              run id for the --manifest-out manifest; defaults to the score's run_id, then source_task_id (sanitized to the eval-run.v1 pattern)
 ```
 
 #### `ao eval run`


### PR DESCRIPTION
## What

Adds `--manifest-out <dir>` (+ `--run-id`) to `ao eval outcomes ingest`. When set, ingest **also** writes `<dir>/<run-id>/manifest.json` conforming to `schemas/eval-run.v1.schema.json`, so the existing verdict pipeline (`docs/contracts/eval-verdict-pipeline.md`) can pick it up and feed the Knowledge Flywheel — closing the **Outcomes→Flywheel loop** for the eval-run.v1 surface. Bead: **ag-fy6e**.

## How

- New file `cli/cmd/ao/eval_outcomes_manifest.go` (diversifies off `eval_outcomes_ingest.go`); ingest.go only wires the thin flag.
- Reuses the existing `eval.RunRecord` struct rather than hand-rolling the schema shape.
- Band mapping: `PASS→{status:pass, verdict:pass}`, `FAIL→{fail, fail}`, `WARN→{inconclusive, advisory}`.
- `dimension_scores` filtered to the 7 schema-permitted keys (foreign criterion dropped; `minProperties:1` guarded by synthesizing `correctness=aggregate`).
- Out-of-process grade → honest schema-valid stubs for `git`/`runtime`/`environment` + a `notes` provenance entry.

## Deviation from bead text (source-of-truth precedence)

The bead said `status=complete`, but that value belongs to the **other** SCHEMA.md run-manifest. eval-run.v1's `status` enum is `pass/fail/error/skipped/inconclusive` — no `complete` member — so this follows the schema (per CLAUDE.md precedence: executable contracts > narrative).

## Scope boundary (honest)

This delivers **only** the eval-run.v1 emission named in the bead's ACCEPTANCE CRITERIA. The downstream `eval-verdict-compiler.sh` / SCHEMA.md run-manifest path (rc3 struct verdict + holdout-sensitive `ground_truth_ref/hash`) remains **BLOCKED** on the external compiler contract + a holdout-safety decision, per the bead's own 2026-05-30 SCOUT CORRECTION. eval-run.v1 carries no holdout-sensitive fields, so that blocker does not apply to this slice. Bead left open for the compiler-path follow-up.

## Verification

- `go build ./... && go vet ./cmd/ao/` clean
- 77 eval/outcomes tests pass (`go test ./cmd/ao/ -run 'Eval|Outcomes'`)
- Real CLI run writes a manifest that validates against `eval-run.v1.schema.json` via python `jsonschema`
- `cli/docs/COMMANDS.md` regenerated for the two new flags

Closes-scenario: ag-fy6e#manifest-out-eval-run
Bounded-context: BC2-Validation
Evidence: cli/cmd/ao/eval_outcomes_manifest_test.go