### PR TITLE
feat(corpus): per-session corpus-reuse receipt at session close (ag-469h #corpus-reuse-receipt)

### DIFF
--- a/cli/cmd/ao/session_close.go
+++ b/cli/cmd/ao/session_close.go
@@ -111,6 +111,14 @@ type SessionCloseResult struct {
 	LearningsExtracted int     `json:"learnings_extracted"`
 	LearningsRejected  int     `json:"learnings_rejected,omitempty"`
 	HandoffWritten     string  `json:"handoff_written,omitempty"`
+
+	// Reused is the count of distinct prior corpus artifacts this session cited
+	// (the READ-side flywheel payoff). ReusedTitles is a short sample (≤3) and
+	// CorpusEntries is the current durable-corpus size — together the
+	// per-session corpus-reuse receipt that makes compounding felt (ag-469h).
+	Reused        int      `json:"reused,omitempty"`
+	ReusedTitles  []string `json:"reused_titles,omitempty"`
+	CorpusEntries int      `json:"corpus_entries,omitempty"`
 }
 
 func runSessionClose(cmd *cobra.Command, args []string) error {
@@ -209,6 +217,8 @@ func forgeExtractReportWithOptions(transcriptPath, cwd string, autoExtract, proc
 		}
 	}
 
+	receipt := computeReuseReceipt(cwd, session.ID)
+
 	return SessionCloseResult{
 		SessionID:          session.ID,
 		Transcript:         transcriptPath,
@@ -222,6 +232,9 @@ func forgeExtractReportWithOptions(transcriptPath, cwd string, autoExtract, proc
 		LearningsExtracted: extractResult.written,
 		LearningsRejected:  extractResult.rejected,
 		HandoffWritten:     handoffPath,
+		Reused:             receipt.Reused,
+		ReusedTitles:       receipt.Titles,
+		CorpusEntries:      receipt.CorpusEntries,
 	}, nil
 }
 
@@ -389,6 +402,7 @@ func printCloseTable(r SessionCloseResult) {
 	if r.LearningsRejected > 0 {
 		fmt.Printf("  Rejected:      %d (run with --verbose to see why)\n", r.LearningsRejected)
 	}
+	fmt.Printf("  Reused:        %d\n", r.Reused)
 	fmt.Println()
 
 	// Flywheel impact
@@ -398,7 +412,24 @@ func printCloseTable(r SessionCloseResult) {
 	}
 	fmt.Printf("  Flywheel:      %s (velocity %s%.3f)\n", r.Status, sign, r.VelocityDelta)
 	fmt.Println()
+	printReuseReceiptLine(r)
 	fmt.Printf("  %s\n", r.Message)
+	fmt.Println()
+}
+
+// printReuseReceiptLine renders the LOUD compounding payoff — the one line that
+// makes the corpus moat visible at the moment it pays off. Only printed when the
+// session actually reused prior corpus, so a cold run stays quiet (ag-469h).
+func printReuseReceiptLine(r SessionCloseResult) {
+	if r.Reused <= 0 {
+		return
+	}
+	noun := "learnings"
+	if r.Reused == 1 {
+		noun = "learning"
+	}
+	fmt.Printf("  ♻ Compounding: this run reused %d prior %s%s; corpus now %d entries.\n",
+		r.Reused, noun, formatReuseTitles(r.ReusedTitles), r.CorpusEntries)
 	fmt.Println()
 }
 

--- a/cli/cmd/ao/session_close_receipt.go
+++ b/cli/cmd/ao/session_close_receipt.go
@@ -1,0 +1,118 @@
+// practices: [knowledge-flywheel-surface, compounding-receipt]
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/boshu2/agentops/cli/internal/ratchet"
+)
+
+// corpusReuseReceipt is the READ-side payoff of the knowledge flywheel: how much
+// prior corpus a session actually reused, paired with the WRITE-side counts the
+// session-close table already reports. It makes compounding FELT — the moat is
+// otherwise invisible at the one moment it matters (cf. bead ag-469h).
+type corpusReuseReceipt struct {
+	// Reused is the number of distinct prior corpus artifacts this session cited
+	// (retrieved or applied) — the prior decisions this run stood on.
+	Reused int
+	// Titles is a short, human-readable sample of the reused artifacts (≤3).
+	Titles []string
+	// CorpusEntries is the current total size of the durable corpus
+	// (.agents/learnings + .agents/patterns).
+	CorpusEntries int
+}
+
+// reuseCorpusDirs are the durable-corpus sections counted as "entries" in the receipt.
+var reuseCorpusDirs = []string{"learnings", "patterns"}
+
+// datePrefixRe matches a leading ISO date prefix in artifact filenames
+// (e.g. "2026-06-06-foo" → "foo") so reused titles read cleanly.
+var datePrefixRe = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}[-_]?`)
+
+// computeReuseReceipt builds the per-session corpus-reuse receipt from the
+// citation ledger (.agents/ao/citations.jsonl) and the on-disk corpus. It is
+// best-effort and never fails the close: a missing ledger yields a zero receipt.
+func computeReuseReceipt(cwd, sessionID string) corpusReuseReceipt {
+	receipt := corpusReuseReceipt{CorpusEntries: countCorpusEntries(cwd)}
+	if sessionID == "" {
+		return receipt
+	}
+
+	citations, err := ratchet.LoadCitations(cwd)
+	if err != nil {
+		return receipt
+	}
+
+	seen := make(map[string]bool)
+	var titles []string
+	for _, c := range citations {
+		if c.SessionID != sessionID {
+			continue
+		}
+		// "reference" is a manual pointer, not a flywheel read-payoff; count
+		// retrievals and applications — the events where prior corpus shaped the run.
+		if c.CitationType == "reference" {
+			continue
+		}
+		key := ratchet.CanonicalArtifactPath(cwd, c.ArtifactPath)
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		if len(titles) < 3 {
+			titles = append(titles, reuseTitleFromPath(c.ArtifactPath))
+		}
+	}
+
+	receipt.Reused = len(seen)
+	receipt.Titles = titles
+	return receipt
+}
+
+// countCorpusEntries counts durable markdown artifacts under .agents/learnings
+// and .agents/patterns — the corpus whose growth the receipt reports.
+func countCorpusEntries(cwd string) int {
+	total := 0
+	for _, sub := range reuseCorpusDirs {
+		entries, err := os.ReadDir(filepath.Join(cwd, ".agents", sub))
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			if strings.HasSuffix(e.Name(), ".md") {
+				total++
+			}
+		}
+	}
+	return total
+}
+
+// reuseTitleFromPath derives a compact, human-readable title from an artifact
+// path: basename, drop the .md extension and any leading ISO date prefix.
+func reuseTitleFromPath(p string) string {
+	base := filepath.Base(p)
+	base = strings.TrimSuffix(base, ".md")
+	base = datePrefixRe.ReplaceAllString(base, "")
+	if base == "" {
+		return filepath.Base(p)
+	}
+	return base
+}
+
+// formatReuseTitles renders the reused-title sample as a parenthical suffix,
+// stable-ordered for deterministic output.
+func formatReuseTitles(titles []string) string {
+	if len(titles) == 0 {
+		return ""
+	}
+	sorted := append([]string(nil), titles...)
+	sort.Strings(sorted)
+	return " (" + strings.Join(sorted, ", ") + ")"
+}

--- a/cli/cmd/ao/session_close_receipt_test.go
+++ b/cli/cmd/ao/session_close_receipt_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/boshu2/agentops/cli/internal/ratchet"
+	"github.com/boshu2/agentops/cli/internal/types"
+)
+
+// writeCorpusFile creates an .agents/<section>/<name> markdown file under base.
+func writeCorpusFile(t *testing.T, base, section, name string) string {
+	t.Helper()
+	dir := filepath.Join(base, ".agents", section)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte("# learning\nbody\n"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+func TestComputeReuseReceipt(t *testing.T) {
+	base := t.TempDir()
+
+	// Corpus: 2 learnings + 1 pattern = 3 durable entries; a stray .txt is ignored.
+	pA := writeCorpusFile(t, base, "learnings", "2026-06-06-alpha-decision.md")
+	pB := writeCorpusFile(t, base, "learnings", "2026-06-05-beta-pattern.md")
+	writeCorpusFile(t, base, "patterns", "gamma.md")
+	writeCorpusFile(t, base, "learnings", "notes.txt")
+
+	now := time.Now().UTC()
+	events := []types.CitationEvent{
+		// Session under test reuses alpha twice (dedup → 1) and beta once.
+		{ArtifactPath: pA, SessionID: "sess-1", CitationType: "retrieved", CitedAt: now},
+		{ArtifactPath: pA, SessionID: "sess-1", CitationType: "applied", CitedAt: now},
+		{ArtifactPath: pB, SessionID: "sess-1", CitationType: "retrieved", CitedAt: now},
+		// A "reference" citation is a manual pointer, not a flywheel read-payoff.
+		{ArtifactPath: filepath.Join(base, ".agents", "patterns", "gamma.md"), SessionID: "sess-1", CitationType: "reference", CitedAt: now},
+		// Another session's reuse must not leak into this receipt.
+		{ArtifactPath: pB, SessionID: "sess-2", CitationType: "retrieved", CitedAt: now},
+	}
+	for _, e := range events {
+		if err := ratchet.RecordCitation(base, e); err != nil {
+			t.Fatalf("record citation: %v", err)
+		}
+	}
+
+	got := computeReuseReceipt(base, "sess-1")
+
+	if got.Reused != 2 {
+		t.Errorf("Reused = %d, want 2 (alpha deduped, beta; reference excluded)", got.Reused)
+	}
+	if got.CorpusEntries != 3 {
+		t.Errorf("CorpusEntries = %d, want 3 (2 learnings + 1 pattern, .txt ignored)", got.CorpusEntries)
+	}
+	titles := strings.Join(got.Titles, ",")
+	if !strings.Contains(titles, "alpha-decision") || !strings.Contains(titles, "beta-pattern") {
+		t.Errorf("Titles = %v, want date-stripped alpha-decision and beta-pattern", got.Titles)
+	}
+	for _, ti := range got.Titles {
+		if strings.HasPrefix(ti, "2026-") {
+			t.Errorf("title %q retained ISO date prefix", ti)
+		}
+	}
+}
+
+func TestComputeReuseReceipt_EmptySession(t *testing.T) {
+	base := t.TempDir()
+	writeCorpusFile(t, base, "learnings", "solo.md")
+
+	got := computeReuseReceipt(base, "")
+	if got.Reused != 0 {
+		t.Errorf("Reused = %d, want 0 for empty session ID", got.Reused)
+	}
+	if got.CorpusEntries != 1 {
+		t.Errorf("CorpusEntries = %d, want 1 (corpus still counted)", got.CorpusEntries)
+	}
+}
+
+func TestComputeReuseReceipt_NoLedger(t *testing.T) {
+	base := t.TempDir() // no .agents at all
+	got := computeReuseReceipt(base, "sess-x")
+	if got.Reused != 0 || got.CorpusEntries != 0 {
+		t.Errorf("got %+v, want zero receipt when no ledger/corpus exists", got)
+	}
+}
+
+func TestReuseTitleFromPath(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"/x/.agents/learnings/2026-06-06-foo-bar.md", "foo-bar"},
+		{"/x/.agents/patterns/gamma.md", "gamma"},
+		{"2026-01-02_underscore.md", "underscore"},
+		{"/x/2026-06-06.md", "2026-06-06.md"}, // date-only basename falls back to full name
+	}
+	for _, c := range cases {
+		if got := reuseTitleFromPath(c.in); got != c.want {
+			t.Errorf("reuseTitleFromPath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestPrintReuseReceiptLine(t *testing.T) {
+	t.Run("loud when reused", func(t *testing.T) {
+		out, _ := captureStdout(t, func() error {
+			printReuseReceiptLine(SessionCloseResult{
+				Reused:        2,
+				ReusedTitles:  []string{"alpha-decision", "beta-pattern"},
+				CorpusEntries: 42,
+			})
+			return nil
+		})
+		if !strings.Contains(out, "♻ Compounding") {
+			t.Errorf("missing compounding marker in %q", out)
+		}
+		if !strings.Contains(out, "reused 2 prior learnings") {
+			t.Errorf("missing reuse count phrase in %q", out)
+		}
+		if !strings.Contains(out, "alpha-decision") || !strings.Contains(out, "beta-pattern") {
+			t.Errorf("missing reused titles in %q", out)
+		}
+		if !strings.Contains(out, "corpus now 42 entries") {
+			t.Errorf("missing corpus size in %q", out)
+		}
+	})
+
+	t.Run("singular noun for one reuse", func(t *testing.T) {
+		out, _ := captureStdout(t, func() error {
+			printReuseReceiptLine(SessionCloseResult{Reused: 1, CorpusEntries: 5})
+			return nil
+		})
+		if !strings.Contains(out, "reused 1 prior learning;") {
+			t.Errorf("expected singular 'learning' in %q", out)
+		}
+	})
+
+	t.Run("quiet on cold run", func(t *testing.T) {
+		out, _ := captureStdout(t, func() error {
+			printReuseReceiptLine(SessionCloseResult{Reused: 0, CorpusEntries: 5})
+			return nil
+		})
+		if strings.TrimSpace(out) != "" {
+			t.Errorf("expected no output when Reused=0, got %q", out)
+		}
+	})
+}
+
+func TestPrintCloseTable_ShowsReusedLine(t *testing.T) {
+	out, _ := captureStdout(t, func() error {
+		printCloseTable(SessionCloseResult{
+			SessionID:     "sess-abc",
+			Transcript:    "/tmp/t.jsonl",
+			Knowledge:     1,
+			Reused:        3,
+			ReusedTitles:  []string{"alpha"},
+			CorpusEntries: 10,
+			Status:        "compounding",
+			Message:       "done",
+		})
+		return nil
+	})
+	if !strings.Contains(out, "Reused:        3") {
+		t.Errorf("missing Reused table line in %q", out)
+	}
+	if !strings.Contains(out, "♻ Compounding") {
+		t.Errorf("missing compounding receipt in %q", out)
+	}
+}


### PR DESCRIPTION
## What

Makes the knowledge-flywheel moat **felt**. `ao session close` now renders a per-session **corpus-reuse receipt**: a `Reused: N` table line plus a loud `♻ Compounding: reused N prior learnings (titles…); corpus now X entries` line. Closes the perception gap behind bead **ag-469h** — users perceive the WRITE tax every session but never the READ payoff, so they churn before the aha.

## How

- `computeReuseReceipt(cwd, sessionID)` reads `.agents/ao/citations.jsonl` (via `ratchet.LoadCitations`), filters to the closing session, dedupes by canonical artifact path, and excludes `reference` (manual-pointer) citations — counting only `retrieved`/`applied` read-payoffs.
- Corpus size counts durable `.md` under `.agents/{learnings,patterns}`.
- New `SessionCloseResult` fields `Reused`/`ReusedTitles`/`CorpusEntries` (all `omitempty`, so JSON output is backward-compatible).
- Best-effort: a missing ledger or corpus yields a zero receipt and never fails the close. Cold runs print nothing.
- No new CLI command (avoids the surface-matrix canary churn documented in ag-lkxx) — purely additive output on an existing command.

## Test

`cli/cmd/ao/session_close_receipt_test.go` — dedup, cross-session isolation, reference-exclusion, empty/no-ledger zero-receipt, singular-noun, cold-run silence, date-prefix title stripping, and `printCloseTable` integration. Full `cmd/ao` suite green (`go test`/`go vet`/`gofmt` clean).

Closes-scenario: ag-469h#corpus-reuse-receipt
Bounded-context: BC1-Corpus
Evidence: cli/cmd/ao/session_close_receipt_test.go