### PR TITLE
fix(goals): drop unresolved heuristic scenario claims to kill prose false positives (soc-artx7 #orphans-prose-false-positive)

### DIFF
--- a/cli/internal/goalstrace/beads_test.go
+++ b/cli/internal/goalstrace/beads_test.go
@@ -271,3 +271,39 @@ func TestWalk_EnglishAutoWordInBeadDescriptionProducesNoError(t *testing.T) {
 		}
 	}
 }
+
+// TestWalk_MultiSegmentProseAutoSlugProducesNoClaim is the soc-artx7 regression:
+// multi-segment "auto-" prose slugs that match the heuristic token grammar but
+// resolve to no scenario file (e.g. "auto-merge-update-branch", "auto-safe-pull")
+// must produce zero broken_bead_scenario_claim findings of ANY severity — not a
+// warning, not an error. Before the fix these surfaced as warnings that polluted
+// `ao goals trace --orphans` and blocked promoting it to a required gate.
+func TestWalk_MultiSegmentProseAutoSlugProducesNoClaim(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", "..", "..", "tests", "fixtures", "goals-trace"))
+	if err != nil {
+		t.Fatalf("resolving fixture root: %v", err)
+	}
+	beads := []beadRecord{
+		{
+			ID:    "soc-test.5",
+			Title: "prose auto-slug bead",
+			Description: "The orchestrator does auto-merge-update-branch when main moves, " +
+				"plus auto-safe-pull and auto-picks-up handling.",
+			Status: "open",
+		},
+	}
+	g, err := Walk(Options{
+		ProjectRoot: root,
+		Beads:       NewStaticBeadQuerier(true, beads),
+	})
+	if err != nil {
+		t.Fatalf("Walk error: %v", err)
+	}
+	for _, e := range g.Edges {
+		for _, d := range e.Defects {
+			if d.Code == DefectBrokenBeadScenarioClaim {
+				t.Errorf("unresolved prose auto- slug surfaced as %s broken_bead_scenario_claim: edge %+v defect %+v", d.Severity, e, d)
+			}
+		}
+	}
+}

--- a/cli/internal/goalstrace/walker.go
+++ b/cli/internal/goalstrace/walker.go
@@ -324,16 +324,30 @@ func emitArtifactCitationEdge(b *builder, a rpiArtifact, lf learningFile, learni
 
 // emitBeadClaimEdges emits one scenario_claimed_by_bead edge per scenario a
 // bead claims, classifying explicit vs heuristic claims per ADR-0005 §2.3.
+//
+// Heuristic (free-text) claims that resolve to no scenario file are dropped
+// before emission: a token that matches the slug grammar but names no real
+// scenario is indistinguishable from ordinary prose (e.g. "auto-merge-update-
+// branch", "auto-safe-pull", "auto-picks-up"), so surfacing it as a
+// broken_bead_scenario_claim is a false positive (soc-artx7). Only explicit
+// "Scenarios:"-line claims are kept when unresolved — a broken explicit link is
+// a genuine defect (ADR-0005 §4.1) and stays an error.
 func emitBeadClaimEdges(b *builder, root string, bead beadRecord) {
 	explicit, heuristic := claimedScenarios(bead)
-	if len(explicit) == 0 && len(heuristic) == 0 {
+	var resolvedHeuristic []string
+	for _, sid := range heuristic {
+		if resolveScenario(root, sid).Found {
+			resolvedHeuristic = append(resolvedHeuristic, sid)
+		}
+	}
+	if len(explicit) == 0 && len(resolvedHeuristic) == 0 {
 		return
 	}
 	b.addNode(Node{ID: bead.ID, Type: NodeBead, Label: bead.Title})
 	for _, sid := range explicit {
 		b.addEdge(beadClaimEdge(root, bead.ID, sid, ConfidenceHigh))
 	}
-	for _, sid := range heuristic {
+	for _, sid := range resolvedHeuristic {
 		b.addEdge(beadClaimEdge(root, bead.ID, sid, ConfidenceLow))
 	}
 }
@@ -345,7 +359,9 @@ func emitBeadClaimEdges(b *builder, root string, bead beadRecord) {
 // broken — i.e. the claim came from an explicit "Scenarios:" line
 // (conf == ConfidenceHigh). A heuristic free-text match (conf == ConfidenceLow)
 // can never constitute an explicit declaration, so an unresolvable heuristic
-// token is downgraded to a warning rather than an error.
+// token is downgraded to a warning rather than an error. In practice
+// emitBeadClaimEdges already drops unresolvable heuristic claims (soc-artx7), so
+// this downgrade is now a defensive fallback for direct callers.
 func beadClaimEdge(root, beadID, scenarioID string, conf Confidence) Edge {
 	e := Edge{
 		Type:       EdgeScenarioClaimedByBead,


### PR DESCRIPTION
## What

`ao goals trace --orphans` reported **7 `broken_bead_scenario_claim` warnings that were false positives** — bead-description prose mis-read as scenario references. All 7 were multi-segment `auto-` slugs (`auto-merge-update-branch`, `auto-safe-pull`, `auto-picks-up`, `auto-regen-on-skill-change`, …) that match the heuristic free-text token grammar but are lexically **indistinguishable** from genuine auto-generated scenario IDs like `auto-nightly-evolution-dry-run`. No regex can separate them — the only real discriminator is **resolution** (does the token name an actual `spec/scenarios/<id>.json` or `.agents/holdout/<id>.json` file?).

## Fix

`emitBeadClaimEdges` now drops heuristic (free-text) claims that resolve to no scenario file *before* emitting an edge: a token matching the slug grammar but naming no real scenario is prose, not a claim. This aligns with ADR-0005 §4.1 — **only explicit `Scenarios:`-line claims are defects.** Explicit claims are untouched: a broken explicit link stays an **error**.

## Evidence (live repo, before → after)

| class | old | fixed |
|---|---|---|
| `broken_bead_scenario_claim` | **7** | **0** |
| `no_learning_yield` | 15 | 15 |
| `scenario_no_bead_claim` | 14 | 14 |

Surgical: only the 7 prose false positives drop; every other warning class is unchanged. Acceptance ("`ao goals trace --orphans` returns 0 `broken_bead_scenario_claim` on current main, no false positives from bead prose") met. This unblocks promoting `trace --orphans` to a required gate.

## Tests

- `go test ./internal/goalstrace/...` — 78 pass (incl. new `TestWalk_MultiSegmentProseAutoSlugProducesNoClaim` regression).
- Existing heuristic/explicit contract tests stay green; `gofmt`/`go vet` clean.

Closes-scenario: soc-artx7#orphans-prose-false-positive
Bounded-context: BC5-Runtime
Evidence: cli/internal/goalstrace/beads_test.go