### PR TITLE
chore(skills): agent-swarm-cleanup greps match Antigravity (agy) panes (ag-mtfe #agy-cleanup-grep)

### DIFF
--- a/skills/system-tuning/references/agent-swarm-cleanup.md
+++ b/skills/system-tuning/references/agent-swarm-cleanup.md
@@ -71,7 +71,8 @@ loop or repeatedly retrying the same failing step.
 
 ```bash
 # Agents older than 16h with no live children of substance
-ps -eo pid,etimes,args | grep -E 'claude|codex|gemini' | grep -v grep \
+# (agy = Antigravity, the agy/antigravity CLI that replaced gemini-cli — match both)
+ps -eo pid,etimes,args | grep -E 'claude|codex|gemini|agy|antigravity' | grep -v grep \
   | awk '$2 > 57600 { print }' \
   | while read pid age rest; do
       kids=$(pgrep -P "$pid" | wc -l)
@@ -127,7 +128,7 @@ Re-run the original three checks and the count of agents:
 ```bash
 uptime
 cat /proc/pressure/cpu /proc/pressure/memory 2>/dev/null
-pgrep -af 'claude|codex|gemini' | wc -l
+pgrep -af 'claude|codex|gemini|agy|antigravity' | wc -l
 ```
 
 If pressure is down and the agent count dropped to the expected steady


### PR DESCRIPTION
## What

`skills/system-tuning/references/agent-swarm-cleanup.md` greps process lists with `claude|codex|gemini` in two places:
- **L74** — detect confused long-horizon agents (>16h) to reap
- **L130** — count remaining agents to verify cleanup landed

## Why

The substrate has already migrated gemini-cli → Antigravity: `ntm config` launches the gemini slot as `agy --dangerously-skip-permissions` (per **ag-ni1b**, deadline 2026-06-18). An `agy`/`antigravity` process does **not** match `gemini`, so **today** both greps miss every Antigravity pane — the reaper skips confused `agy` agents and the post-cleanup count undercounts, falsely reading as "cleanup landed."

## Change

Extend the alternation to `claude|codex|gemini|agy|antigravity` on both lines + a one-line comment noting agy = Antigravity. Two-line behavioral fix, no other surface touched.

## Verification

- `markdownlint` clean (exit 0)
- diff is 3 insertions / 2 deletions, single file

Closes-scenario: ag-mtfe#agy-cleanup-grep
Bounded-context: BC5-Runtime
Evidence: skills/system-tuning/references/agent-swarm-cleanup.md