### PR TITLE
docs: fix broken intra-repo links in docs/ (ag-28dp #docs-link-rot)

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -21,7 +21,7 @@ A unit of work with no shared mutable state with concurrent workers. Pure functi
 ## B
 
 ### Beads
-Git-native issue tracking system accessed via the `bd` CLI. Issues live in `.beads/` inside your repo and sync through normal git operations — no external service required. [Full documentation](skills/beads.md)
+Git-native issue tracking system accessed via the `bd` CLI. Issues live in `.beads/` inside your repo and sync through normal git operations — no external service required. [Full documentation](../skills/beads/SKILL.md)
 
 ### Bookkeeping
 AgentOps' public term for repo-native capture, retrieval, promotion, decay, and resurfacing of what sessions learn. `.agents/`, `/retro`, `/forge`, `/compile`, `ao inject`, and `ao lookup` are all bookkeeping surfaces. [Full documentation](https://github.com/boshu2/agentops/blob/main/README.md#how-bookkeeping-compounds)
@@ -32,7 +32,7 @@ The core execution model: spawn parallel agents (chaos), validate their output w
 ## C
 
 ### Codex Team
-A skill (`/codex-team`) that spawns parallel Codex (OpenAI) execution agents orchestrated by Claude, enabling cross-vendor parallel task execution. [Full documentation](skills/codex-team.md)
+A skill (`/codex-team`) that spawns parallel Codex (OpenAI) execution agents orchestrated by Claude, enabling cross-vendor parallel task execution. [Full documentation](../skills/codex-team/SKILL.md)
 
 ### Compact / PreCompact
 Runtime event fired when an agent prunes its conversation history. AgentOps 3.0 is hookless — capture context before compaction with `ao handoff` / `ao inject` rather than a runtime hook.
@@ -47,10 +47,10 @@ The technical framing for AgentOps. Raw session signal becomes reusable knowledg
 The bounded token budget an agent has in a single session. AgentOps assumes this is always finite and sometimes shrinking under compaction. The Ralph Wiggum Pattern, fresh-context waves, and `PreCompact` snapshots all exist to work around context-window limits rather than fight them.
 
 ### Council
-The core validation primitive. Spawns independent judge agents (Claude and/or Codex) that review work from different perspectives, deliberate, and converge on a verdict: PASS, WARN, or FAIL. Foundation for `/vibe`, `/pre-mortem`, and `/post-mortem`. [Full documentation](skills/council.md)
+The core validation primitive. Spawns independent judge agents (Claude and/or Codex) that review work from different perspectives, deliberate, and converge on a verdict: PASS, WARN, or FAIL. Foundation for `/vibe`, `/pre-mortem`, and `/post-mortem`. [Full documentation](../skills/council/SKILL.md)
 
 ### Crank
-A skill (`/crank`) that executes an epic by spawning parallel worker agents in dependency-ordered waves. Each worker gets fresh context, writes files, and reports back; the lead validates and commits. Runs until every issue in the epic is closed. [Full documentation](skills/crank.md)
+A skill (`/crank`) that executes an epic by spawning parallel worker agents in dependency-ordered waves. Each worker gets fresh context, writes files, and reports back; the lead validates and commits. Runs until every issue in the epic is closed. [Full documentation](../skills/crank/SKILL.md)
 
 ## D
 
@@ -66,7 +66,7 @@ A long-haul autonomous run that executes while you are away, emitting morning wo
 A group of related issues that together accomplish a goal. Created by `/plan`, executed by `/crank`. Each epic has a dependency graph that determines which issues can run in parallel (same wave) and which must wait (later waves). [Full documentation](SKILLS.md#plan)
 
 ### Extract
-An internal process that pulls learnings, patterns, and decisions from session transcripts and artifacts into structured knowledge files. Now handled by `/forge --promote`. [Full documentation](skills/forge.md)
+An internal process that pulls learnings, patterns, and decisions from session transcripts and artifacts into structured knowledge files. Now handled by `/forge --promote`. [Full documentation](../skills/forge/SKILL.md)
 
 ## F
 
@@ -80,7 +80,7 @@ The automated loop that extracts learnings from completed work, scores them for 
 A composite measure of whether the knowledge flywheel is actually compounding: retrieval rate, promotion rate, decay rate, and injection hit rate. Surfaced by `ao flywheel` commands and used by `/evolve` to steer improvements.
 
 ### Forge
-An internal skill that mines session transcripts for knowledge artifacts — decisions, patterns, failures, and fixes — and stores them in `.agents/`. [Full documentation](skills/forge.md)
+An internal skill that mines session transcripts for knowledge artifacts — decisions, patterns, failures, and fixes — and stores them in `.agents/`. [Full documentation](../skills/forge/SKILL.md)
 
 ## G
 
@@ -93,7 +93,7 @@ A checkpoint enforced by a hook that blocks progress until a condition is met. F
 A curation step that pulls learning candidates from recent sessions, scores them, and filters low-confidence output before they enter the flywheel. Invoked via `ao harvest` or inside `/forge --promote`.
 
 ### Handoff
-A skill (`/handoff`) that creates structured session handoff documents so another agent or future session can continue work with full context. [Full documentation](skills/handoff.md)
+A skill (`/handoff`) that creates structured session handoff documents so another agent or future session can continue work with full context. [Full documentation](../skills/handoff/SKILL.md)
 
 ### Holdout
 An isolated scenario file under `.agents/holdout/` used for behavioral validation. Read/glob/grep access to holdout directories is gated by `holdout-isolation-gate.sh` so validator and evaluee paths do not cross-contaminate. Schema: [`scenario.v1.schema.json`](https://github.com/boshu2/agentops/blob/main/schemas/scenario.v1.schema.json).
@@ -104,7 +104,7 @@ A shell script that fires automatically on agent lifecycle events. **AgentOps 3.
 ## I
 
 ### Inject
-An internal skill triggered at session start that loads relevant prior knowledge from `.agents/` into the current session context. [Full documentation](skills/inject.md)
+An internal skill triggered at session start that loads relevant prior knowledge from `.agents/` into the current session context. [Full documentation](../skills/inject/SKILL.md)
 
 ### Issue
 A discrete unit of trackable work, stored as a bead. Created by `/plan`, executed by `/implement` or `/crank`. Has status, dependencies, and parent/child relationships. [Full documentation](SKILLS.md#beads)
@@ -112,7 +112,7 @@ A discrete unit of trackable work, stored as a bead. Created by `/plan`, execute
 ## J
 
 ### Judge
-An agent in a council that evaluates work from a specific perspective (security, architecture, correctness, etc.). Judges deliberate asynchronously, then the lead consolidates verdicts. [Full documentation](skills/council.md)
+An agent in a council that evaluates work from a specific perspective (security, architecture, correctness, etc.). Judges deliberate asynchronously, then the lead consolidates verdicts. [Full documentation](../skills/council/SKILL.md)
 
 ## L
 
@@ -130,16 +130,16 @@ A cross-cutting rule enforced by hooks that applies to all skills and agents. Ex
 A knowledge quality tier — pending, tempered, or promoted. Artifacts start in pending, get tempered through repeated validation and use, and can be promoted to the permanent knowledge base. [Full documentation](ARCHITECTURE.md#knowledge-artifacts)
 
 ### Post-mortem
-A skill (`/post-mortem`) that runs after work is complete. Convenes a council to validate the implementation, runs a retro to extract learnings, and suggests the next `/rpi` command to continue the improvement loop. [Full documentation](skills/post-mortem.md)
+A skill (`/post-mortem`) that runs after work is complete. Convenes a council to validate the implementation, runs a retro to extract learnings, and suggests the next `/rpi` command to continue the improvement loop. [Full documentation](../skills/post-mortem/SKILL.md)
 
 ### Pre-mortem
-A skill (`/pre-mortem`) that runs before implementation begins. Judges simulate failures against the plan — including spec-completeness checks — and surface problems while they are still cheap to fix. A FAIL verdict sends the plan back for revision. [Full documentation](skills/pre-mortem.md)
+A skill (`/pre-mortem`) that runs before implementation begins. Judges simulate failures against the plan — including spec-completeness checks — and surface problems while they are still cheap to fix. A FAIL verdict sends the plan back for revision. [Full documentation](../skills/pre-mortem/SKILL.md)
 
 ### Profile
-A documentation grouping for domain-specific workflows and standards. Profiles organize coding standards and validation rules by language or domain. [Full documentation](skills/standards.md)
+A documentation grouping for domain-specific workflows and standards. Profiles organize coding standards and validation rules by language or domain. [Full documentation](../skills/standards/SKILL.md)
 
 ### Provenance
-An internal skill that traces the lineage and sources of knowledge artifacts — where a learning came from, which sessions produced it, and how it was validated. [Full documentation](skills/provenance.md)
+An internal skill that traces the lineage and sources of knowledge artifacts — where a learning came from, which sessions produced it, and how it was validated. [Full documentation](../skills/provenance/SKILL.md)
 
 ## R
 
@@ -147,13 +147,13 @@ An internal skill that traces the lineage and sources of knowledge artifacts —
 The practice of giving every worker agent a fresh context window instead of letting context accumulate across tasks. Named after the [Ralph Wiggum pattern](https://ghuntley.com/ralph/). Each wave spawns new workers with clean context, preventing bleed-through and contamination from prior work. [Full documentation](how-it-works.md#ralph-wiggum-pattern-fresh-context-every-wave)
 
 ### Ratchet
-A mechanism that locks progress forward so it cannot regress. Once a gate is passed (e.g., vibe validation), the ratchet records that state and hooks enforce it going forward. Combined with the Brownian Ratchet execution model, this ensures quality only moves in one direction. [Full documentation](skills/ratchet.md)
+A mechanism that locks progress forward so it cannot regress. Once a gate is passed (e.g., vibe validation), the ratchet records that state and hooks enforce it going forward. Combined with the Brownian Ratchet execution model, this ensures quality only moves in one direction. [Full documentation](../skills/ratchet/SKILL.md)
 
 ### Research
-The first phase of the RPI lifecycle. Deep codebase exploration using Explore agents that produce structured findings in `.agents/research/`. [Full documentation](skills/research.md)
+The first phase of the RPI lifecycle. Deep codebase exploration using Explore agents that produce structured findings in `.agents/research/`. [Full documentation](../skills/research/SKILL.md)
 
 ### Retro
-A skill (`/retro`) that extracts learnings from completed work — decisions made, patterns discovered, and failures encountered — and feeds them into the knowledge flywheel. Learnings are scored for specificity, actionability, and novelty. [Full documentation](skills/retro.md)
+A skill (`/retro`) that extracts learnings from completed work — decisions made, patterns discovered, and failures encountered — and feeds them into the knowledge flywheel. Learnings are scored for specificity, actionability, and novelty. [Full documentation](../skills/retro/SKILL.md)
 
 ### RPI (Research-Plan-Implement)
 The historical name for AgentOps' full lifecycle workflow. In current runtime terms, `/rpi` orchestrates **Discovery -> Implementation -> Validation** while `ao rpi phased` enforces fresh context windows between those phases. The older acronym persists in product language and command names, but validation and loop closure are now first-class parts of the executable lifecycle. [Full documentation](ARCHITECTURE.md#the-phased-lifecycle)
@@ -170,7 +170,7 @@ The full arc of a coding-agent session: `SessionStart` → many `UserPromptSubmi
 A self-contained capability defined by a `SKILL.md` file with YAML frontmatter. Skills are the primary unit of functionality in AgentOps — each one has triggers, instructions, and optional reference docs loaded just-in-time. AgentOps currently ships 82 shared skills, with runtime-specific artifacts maintained alongside them. [Full documentation](SKILLS.md)
 
 ### Swarm
-A skill (`/swarm`) that spawns parallel worker agents with fresh context. Each wave gets a new team; the lead validates and commits. Workers never commit directly. [Full documentation](skills/swarm.md)
+A skill (`/swarm`) that spawns parallel worker agents with fresh context. Each wave gets a new team; the lead validates and commits. Workers never commit directly. [Full documentation](../skills/swarm/SKILL.md)
 
 ## T
 
@@ -183,12 +183,12 @@ A knowledge quality state indicating an artifact has been validated through mult
 The second product layer (Layer 2). Multi-model councils challenge plans before build and code before commit, returning auditable verdicts — PASS, WARN, or FAIL. Gates block progress, not advise. Encompasses `/council`, `/vibe`, `/pre-mortem`, `/post-mortem`, and runtime hook gates. Maps to the Validation gap (judgment validation) in the [Context Lifecycle Contract](context-lifecycle.md).
 
 ### Vibe
-A skill (`/vibe`) that validates code after implementation by running a council of judges against the changes. Produces a PASS, WARN, or FAIL verdict. A passing vibe is typically required by the push gate before code can be pushed to the remote. [Full documentation](skills/vibe.md)
+A skill (`/vibe`) that validates code after implementation by running a council of judges against the changes. Produces a PASS, WARN, or FAIL verdict. A passing vibe is typically required by the push gate before code can be pushed to the remote. [Full documentation](../skills/vibe/SKILL.md)
 
 ## W
 
 ### Wave
-A batch of issues within an epic that can be executed in parallel because they have no dependencies on each other. Waves are ordered by the dependency graph: Wave 1 contains leaf issues, Wave 2 contains issues that depend on Wave 1, and so on. Each wave spawns fresh worker agents. [Full documentation](skills/crank.md)
+A batch of issues within an epic that can be executed in parallel because they have no dependencies on each other. Waves are ordered by the dependency graph: Wave 1 contains leaf issues, Wave 2 contains issues that depend on Wave 1, and so on. Each wave spawns fresh worker agents. [Full documentation](../skills/crank/SKILL.md)
 
 ### Worker
-An agent executing a single task in a swarm. Each worker gets fresh context (no bleed-through from other workers), writes files but never commits — the team lead validates and commits. [Full documentation](skills/swarm.md)
+An agent executing a single task in a swarm. Each worker gets fresh context (no bleed-through from other workers), writes files but never commits — the team lead validates and commits. [Full documentation](../skills/swarm/SKILL.md)

--- a/docs/behavioral-discipline.md
+++ b/docs/behavioral-discipline.md
@@ -100,6 +100,6 @@ AgentOps enforces this through the behavioral discipline standard in [`skills/st
 ## Where This Lives in AgentOps
 
 - [`README.md`](https://github.com/boshu2/agentops/blob/main/README.md) gives the front-door version.
-- [`skills/implement/SKILL.md`](skills/implement.md) requires an execution frame before editing.
-- [`skills/review/SKILL.md`](skills/review.md) checks for hidden assumptions, speculative abstractions, and weak proof.
+- [`skills/implement/SKILL.md`](../skills/implement/SKILL.md) requires an execution frame before editing.
+- [`skills/review/SKILL.md`](../skills/review/SKILL.md) checks for hidden assumptions, speculative abstractions, and weak proof.
 - [`skills/standards/references/behavioral-discipline.md`](https://github.com/boshu2/agentops/blob/main/skills/standards/references/behavioral-discipline.md) is the reusable reference that the skills load.

--- a/docs/context-lifecycle.md
+++ b/docs/context-lifecycle.md
@@ -37,9 +37,9 @@ actually closes these gaps.
 
 | Mechanism | Source | Role |
 |-----------|--------|------|
-| `/pre-mortem` | [skills/pre-mortem/SKILL.md](skills/pre-mortem.md) | Loads plan-review validation before code exists |
-| `/vibe` | [skills/vibe/SKILL.md](skills/vibe.md) | Runs post-implementation validation instead of stopping at build/test |
-| `/council` | [skills/council/SKILL.md](skills/council.md) | Supplies multi-judge review for plans and code |
+| `/pre-mortem` | [skills/pre-mortem/SKILL.md](../skills/pre-mortem/SKILL.md) | Loads plan-review validation before code exists |
+| `/vibe` | [skills/vibe/SKILL.md](../skills/vibe/SKILL.md) | Runs post-implementation validation instead of stopping at build/test |
+| `/council` | [skills/council/SKILL.md](../skills/council/SKILL.md) | Supplies multi-judge review for plans and code |
 | Pre-mortem gate | CI gate ([.github/workflows/validate.yml](https://github.com/boshu2/agentops/blob/main/.github/workflows/validate.yml)) + the `/pre-mortem` skill | Prevents large implementation work from skipping plan validation |
 | Task-validation constraint check | `/validate` skill + `ao constraint` reading `.agents/constraints/index.json` | Task-validation executes active compiled constraints for mechanically detectable findings |
 | Product-aware review context | [PRODUCT.md](https://github.com/boshu2/agentops/blob/main/PRODUCT.md) | Injects product and DX perspectives into validation flows |
@@ -67,7 +67,7 @@ actually closes these gaps.
 | `.agents/` ledger | [Knowledge Ledger](#the-knowledge-ledger-session-to-session-flow) | Stores plans, learnings, patterns, council outputs, and next-work artifacts on disk |
 | Finding registry | [docs/contracts/finding-registry.md](contracts/finding-registry.md) | Stores reusable structured findings that planning and validation can load before rediscovering the same failure |
 | `ao lookup` / injection | [Knowledge Ledger](#the-knowledge-ledger-session-to-session-flow) and `ao` CLI | Retrieves repo-specific context at session start and task boundaries |
-| `/retro` and `/post-mortem` extraction | [skills/post-mortem/SKILL.md](skills/post-mortem.md) | Turns completed work into reusable learnings and patterns |
+| `/retro` and `/post-mortem` extraction | [skills/post-mortem/SKILL.md](../skills/post-mortem/SKILL.md) | Turns completed work into reusable learnings and patterns |
 | Freshness / maturity controls | `ao maturity`, `ao dedup`, `ao contradict` | Keeps retrieval focused on useful, current knowledge |
 | Compile cycle | [GOALS.md](https://github.com/boshu2/agentops/blob/main/GOALS.md) directive 5 | Mines missed signal, defrags stale knowledge, and flags oscillation |
 
@@ -91,7 +91,7 @@ actually closes these gaps.
 
 | Mechanism | Source | Role |
 |-----------|--------|------|
-| `/post-mortem` | [skills/post-mortem/SKILL.md](skills/post-mortem.md) | Validates shipped work, extracts learnings, and harvests next work |
+| `/post-mortem` | [skills/post-mortem/SKILL.md](../skills/post-mortem/SKILL.md) | Validates shipped work, extracts learnings, and harvests next work |
 | Finding registry + compiler path | [docs/contracts/finding-registry.md](contracts/finding-registry.md), [docs/contracts/finding-compiler.md](contracts/finding-compiler.md), `ao findings` / `ao constraint` | Promotes reusable findings into advisory artifacts and active constraint index entries |
 | Task-validation constraint execution | `/validate` skill + `ao constraint` reading `.agents/constraints/index.json` | Turns mechanically detectable findings into enforced validation checks before task completion |
 | Flywheel close | `/post-mortem` skill + [docs/how-it-works.md](how-it-works.md) | Closes the feedback loop at session end |

--- a/docs/context-packet.md
+++ b/docs/context-packet.md
@@ -506,4 +506,4 @@ The context packet unifies and structures what multiple components already provi
 - [Knowledge Flywheel](knowledge-flywheel.md) — How learnings compound across sessions
 - [How It Works](how-it-works.md) — Context windowing, Brownian Ratchet, Ralph Wiggum
 - [The Science](the-science.md) — Freshness decay model, MemRL two-phase retrieval
-- [CLI Reference](cli/commands.md) — `ao lookup` command documentation
+- [CLI Reference](../cli/docs/COMMANDS.md) — `ao lookup` command documentation

--- a/docs/create-your-first-skill.md
+++ b/docs/create-your-first-skill.md
@@ -153,10 +153,10 @@ Start from a simple, high-signal skill rather than the biggest orchestration lay
 
 Useful examples:
 
-- [skills/research/SKILL.md](skills/research.md)
-- [skills/retro/SKILL.md](skills/retro.md)
-- [skills/doc/SKILL.md](skills/doc.md)
-- [skills/implement/SKILL.md](skills/implement.md)
+- [skills/research/SKILL.md](../skills/research/SKILL.md)
+- [skills/retro/SKILL.md](../skills/retro/SKILL.md)
+- [skills/doc/SKILL.md](../skills/doc/SKILL.md)
+- [skills/implement/SKILL.md](../skills/implement/SKILL.md)
 
 ## Opening The PR
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -145,18 +145,18 @@ Every skill works alone. Compose flows for end-to-end cycles.
 
 | Skill | Use it when |
 |-------|-------------|
-| [`/quickstart`](skills/quickstart.md) | You want the fastest setup check and next action |
-| [`/council`](skills/council.md) | You want independent judges to review a plan, PR, or decision |
-| [`/research`](skills/research.md) | You need codebase context and prior learnings before changing code |
-| [`/pre-mortem`](skills/pre-mortem.md) | You want to pressure-test a plan before implementation |
-| [`/implement`](skills/implement.md) | You want one scoped task built and validated |
-| [`/rpi`](skills/rpi.md) | You want discovery, build, validation, and bookkeeping in one flow |
-| [`/vibe`](skills/vibe.md) | You want a code-quality and risk review before shipping |
-| [`/evolve`](skills/evolve.md) | You want a goal-driven improvement loop with regression gates |
-| [`/dream`](skills/dream.md) | You want overnight knowledge compounding that never mutates source code |
+| [`/quickstart`](../skills/quickstart/SKILL.md) | You want the fastest setup check and next action |
+| [`/council`](../skills/council/SKILL.md) | You want independent judges to review a plan, PR, or decision |
+| [`/research`](../skills/research/SKILL.md) | You need codebase context and prior learnings before changing code |
+| [`/pre-mortem`](../skills/pre-mortem/SKILL.md) | You want to pressure-test a plan before implementation |
+| [`/implement`](../skills/implement/SKILL.md) | You want one scoped task built and validated |
+| [`/rpi`](../skills/rpi/SKILL.md) | You want discovery, build, validation, and bookkeeping in one flow |
+| [`/vibe`](../skills/vibe/SKILL.md) | You want a code-quality and risk review before shipping |
+| [`/evolve`](../skills/evolve/SKILL.md) | You want a goal-driven improvement loop with regression gates |
+| [`/dream`](../skills/dream/SKILL.md) | You want overnight knowledge compounding that never mutates source code |
 
 !!! info "Full catalog"
-    [:octicons-book-24: **All 82 skills**](skills/catalog.md) — complete reference with source links and descriptions.
+    [:octicons-book-24: **All 82 skills**](SKILLS.md) — complete reference with source links and descriptions.
     [:octicons-routes-24: **Decision tree**](skills-decision-tree.md) — "which skill do I need next?"
 
 ---
@@ -219,7 +219,7 @@ Read the lineage at [12factoragentops.com](https://12factoragentops.com) — Dev
 
     Progressive learning curriculum from single-session work to full autonomous orchestration.
 
--   :material-console-line: **[CLI Reference](cli/commands.md)**
+-   :material-console-line: **[CLI Reference](../cli/docs/COMMANDS.md)**
 
     ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -156,7 +156,7 @@ Every skill works alone. Compose flows for end-to-end cycles.
 | [`/dream`](../skills/dream/SKILL.md) | You want overnight knowledge compounding that never mutates source code |
 
 !!! info "Full catalog"
-    [:octicons-book-24: **All 82 skills**](SKILLS.md) — complete reference with source links and descriptions.
+    [:octicons-book-24: **All 82 skills**](skills/catalog.md) — complete reference with source links and descriptions.
     [:octicons-routes-24: **Decision tree**](skills-decision-tree.md) — "which skill do I need next?"
 
 ---

--- a/docs/software-factory.md
+++ b/docs/software-factory.md
@@ -119,4 +119,4 @@ primitives. With it, they see one product surface.
 - [Context Packet](context-packet.md)
 - [Knowledge Flywheel](knowledge-flywheel.md)
 - [Session Lifecycle](workflows/session-lifecycle.md)
-- [CLI Reference](cli/commands.md)
+- [CLI Reference](../cli/docs/COMMANDS.md)


### PR DESCRIPTION
## What

Fix 44 broken intra-repo links across 7 files under `docs/`, surfaced by a `docs/` markdown link audit. `mkdocs.yml` has `strict: false`, so the broken links slipped past CI — but they break GitHub-raw viewing and agent file-reading (the repo treats pointer rot in base docs as a defect).

## Two pointer-rot classes

1. **41× `](skills/<name>.md)` → `](../skills/<name>/SKILL.md)`** — skills live at `skills/<name>/SKILL.md`, never `skills/<name>.md`, and `docs/` is one level deep so the target needs `../`. Several links already had the **correct link text** (e.g. `[skills/pre-mortem/SKILL.md](skills/pre-mortem.md)`) — only the href was wrong, confirming intent. Special case: `skills/catalog.md` → `SKILLS.md` (`docs/SKILLS.md` = the complete 82-skill reference).
2. **3× `](cli/commands.md)` → `](../cli/docs/COMMANDS.md)`** — the generated CLI command doc.

Files: `GLOSSARY.md`, `index.md`, `context-lifecycle.md`, `behavioral-discipline.md`, `create-your-first-skill.md`, `context-packet.md`, `software-factory.md`.

**Not touched:** the intentional placeholder links in `docs/standards/markdown-style-guide.md` (syntax demos: `url`, `image.png`, `./other-doc.md`, etc.).

## Verification

- `docs/` broken-link scan: **44 → 0** outside the style-guide placeholders.
- `markdownlint-cli2` on all 7 files: **0 errors**.
- Pure link-href changes (44 insertions / 44 deletions); no prose or behavior change.

Closes-scenario: ag-28dp#docs-link-rot
Bounded-context: BC1-Corpus
Evidence: ag-28dp