### PR TITLE
chore(cli): gofmt agent_bundle.go struct-literal indentation (ag-tcf0.2 #gofmt-agent-bundle)

### DIFF
--- a/cli/cmd/ao/agent_bundle.go
+++ b/cli/cmd/ao/agent_bundle.go
@@ -106,7 +106,7 @@ func buildCodexNTMBundle(skills []string) agentBundle {
 		Runtime:      "codex-ntm",
 		Instructions: stitchInstructions(skills),
 		Skills:       skills,
-			Bootstrap:    "ao session bootstrap && ao inject --bead \"$BEAD\"",
+		Bootstrap:    "ao session bootstrap && ao inject --bead \"$BEAD\"",
 		Reference:    "skills-codex/agent-native",
 	}
 }

--- a/cli/cmd/ao/agent_bundle_test.go
+++ b/cli/cmd/ao/agent_bundle_test.go
@@ -91,6 +91,11 @@ func TestBuildAgentBundle_CodexNTM(t *testing.T) {
 	if b.Runtime != "codex-ntm" {
 		t.Errorf("Runtime = %q, want codex-ntm", b.Runtime)
 	}
+	// Exact Bootstrap value — guards the codex-ntm struct literal against
+	// silent edits/drift (the field was the site of an unformatted-source fix).
+	if want := `ao session bootstrap && ao inject --bead "$BEAD"`; b.Bootstrap != want {
+		t.Errorf("codex-ntm Bootstrap = %q, want exactly %q", b.Bootstrap, want)
+	}
 	if !strings.Contains(b.Bootstrap, "ao session bootstrap") {
 		t.Errorf("codex-ntm Bootstrap must run `ao session bootstrap`, got %q", b.Bootstrap)
 	}


### PR DESCRIPTION
Fixes a gofmt drift that landed on `main`: `cmd/ao/agent_bundle.go` had an extra-tab indent on the `Bootstrap` field of the codex-ntm bundle struct literal (unformatted since df3cc98, ~24h ago). Whitespace-only — the `Bootstrap` string value is unchanged, behavior identical.

## Why it slipped through
CI runs `golangci-lint run` with **default linters**, which exclude the `gofmt` formatter, so source-formatting drift is not gated and lands on `main` undetected. This is the same class as the ag-tcf0 audit "14 files unformatted" finding; the earlier sweep (ag-ozac) fixed files but did not add an enforcement gate. **The missing gofmt CI gate is drafted to the operator queue** (it interacts with the gate-target/path-filter system and the active ag-tcf0.1 golangci worktree, so it warrants operator confirmation rather than a unilateral CI-gate change).

## Test
The paired `agent_bundle_test.go` change strengthens the existing `Bootstrap` substring assertion to **exact equality** (per `.claude/rules/go.md`: "assert exact expected values, not just substring"), guarding the struct literal against silent drift at the exact site of the fix.

- `gofmt -l cli/` clean
- `go build ./...`, `go vet ./cmd/ao/` ok
- `go test ./cmd/ao/ -run TestBuildAgentBundle_CodexNTM` pass (8 bundle tests green)
- `scripts/pre-push-gate.sh --fast` passed

Closes-scenario: ag-tcf0.2#gofmt-agent-bundle
Bounded-context: BC5-Runtime
Evidence: pre-push-gate --fast passed; gofmt -l clean; bundle tests green