### PR TITLE
fix(scripts): port skill-catalog generator off gawk-only awk -v (ag-mm6q #bsd-awk-portability)

### DIFF
--- a/scripts/generate-skill-catalog.sh
+++ b/scripts/generate-skill-catalog.sh
@@ -73,7 +73,12 @@ extract_frontmatter() {
 # Returns JSON object with only the fields we project into the catalog.
 parse_frontmatter() {
   local fm="$1"
-  awk -v fm="$fm" '
+  # Feed the frontmatter on stdin rather than via `-v fm=...`: BSD/POSIX awk
+  # rejects a literal newline inside a `-v var=value` assignment (only GNU awk
+  # tolerates it), so the multi-line value tripped "awk: newline in string" on
+  # macOS hosts without gawk. Lines are accumulated into lines[] and processed
+  # in END, identical to the prior split(fm,...) flow. (ag-mm6q)
+  printf '%s\n' "$fm" | awk '
     function trim(s){ sub(/^[[:space:]]+/,"",s); sub(/[[:space:]]+$/,"",s); return s }
     function jstr(s) {
       gsub(/\\/, "\\\\", s)
@@ -83,7 +88,6 @@ parse_frontmatter() {
       return "\"" s "\""
     }
     BEGIN {
-      n = split(fm, lines, "\n")
       cur_key = ""
       in_list = 0
       list_buf = ""
@@ -98,9 +102,11 @@ parse_frontmatter() {
       ctx_list = ""
     }
     {
-      # Re-iterate over the lines stored in `lines[]`.
+      # Accumulate each input line; the parse runs over lines[] in END.
+      lines[NR] = $0
     }
     END {
+      n = NR
       for (i = 1; i <= n; i++) {
         line = lines[i]
         if (line ~ /^[[:space:]]*$/) { continue }

--- a/tests/scripts/generate-skill-catalog.bats
+++ b/tests/scripts/generate-skill-catalog.bats
@@ -125,6 +125,32 @@ skill_api_version: 1"
   echo "$output" | jq -e '.skills[0].context_rel[2].with == "delta"' >/dev/null
 }
 
+@test "multi-line frontmatter parses on BSD/POSIX awk without 'newline in string' (ag-mm6q)" {
+  # Regression for the BSD-awk incompatibility: the parser used to pass the
+  # whole frontmatter via `awk -v fm="$fm"`, which only GNU awk accepts with
+  # embedded newlines. On macOS/BSD awk it errored "awk: newline in string"
+  # and produced no catalog. Assert a multi-line frontmatter parses cleanly
+  # and the error string never appears on stderr.
+  write_skill delta "name: delta
+description: multi-line frontmatter regression
+hexagonal_role: domain
+consumes:
+- standards
+- domain
+produces:
+- result.json
+context_rel:
+- kind: customer-of
+  with: alpha
+skill_api_version: 1"
+  run_gen --stdout
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"newline in string"* ]]
+  echo "$output" | jq -e '.skills[0].name == "delta"' >/dev/null
+  echo "$output" | jq -e '.skills[0].consumes == ["standards","domain"]' >/dev/null
+  echo "$output" | jq -e '.skills[0].context_rel[0].with == "alpha"' >/dev/null
+}
+
 @test "user_invocable is true only when explicitly set" {
   write_skill u1 "name: u1
 description: invocable


### PR DESCRIPTION
## What

`scripts/generate-skill-catalog.sh` passed the YAML frontmatter into awk via `awk -v fm="$fm"`. A literal newline inside a `-v var=value` assignment is accepted **only by GNU awk**; BSD/POSIX awk (macOS without gawk) errors with `awk: newline in string ...` and emits no catalog — so the catalog (and its drift gate `check-skill-catalog-drift.sh`) could only run inside Linux CI.

## Fix

Feed the frontmatter on **stdin** and accumulate input lines into `lines[]` (processed in `END` exactly as before) instead of `-v` + `split()`. Pure input-mechanism change — the parse logic is untouched.

## Evidence (macOS BSD awk, version 20200816)

- **Before:** `bash scripts/generate-skill-catalog.sh --stdout` → `awk: newline in string name: agent-native` (no output).
- **After:** valid JSON for all 81 skills; lists, `context_rel`, and quoted descriptions parse correctly (e.g. `deps` → `context_rel: [{kind: supplier-to, with: vibe}]`, matching the source SKILL.md).
- Added an explicit BSD/POSIX-awk regression test (`multi-line frontmatter parses ... without 'newline in string'`). Full bats suite **15/15 green** on macOS.
- `shellcheck` clean.

## Scope note

The committed `skills/catalog.json` is **independently stale** (75 vs 81 skills — drift predates this change, since the generator never ran off-Linux). Regenerating it is deliberately left to the Linux-CI drift path (the `check skill catalog drift` job is **I0 advisory / non-blocking**) to avoid committing a glob-order-sensitive artifact generated off-CI.

Closes-scenario: ag-mm6q#bsd-awk-portability
Bounded-context: BC2-Validation
Evidence: tests/scripts/generate-skill-catalog.bats