### PR TITLE
chore(skills): agent-swarm-cleanup Codex mirror greps match Antigravity (agy) (ag-2zf8 #codex-mirror-agy-grep)

### DIFF
--- a/skills-codex/system-tuning/references/agent-swarm-cleanup.md
+++ b/skills-codex/system-tuning/references/agent-swarm-cleanup.md
@@ -71,7 +71,8 @@ loop or repeatedly retrying the same failing step.
 
 ```bash
 # Agents older than 16h with no live children of substance
-ps -eo pid,etimes,args | grep -E 'claude|codex|gemini' | grep -v grep \
+# (agy = Antigravity, the agy/antigravity CLI that replaced gemini-cli — match both)
+ps -eo pid,etimes,args | grep -E 'claude|codex|gemini|agy|antigravity' | grep -v grep \
   | awk '$2 > 57600 { print }' \
   | while read pid age rest; do
       kids=$(pgrep -P "$pid" | wc -l)
@@ -127,7 +128,7 @@ Re-run the original three checks and the count of agents:
 ```bash
 uptime
 cat /proc/pressure/cpu /proc/pressure/memory 2>/dev/null
-pgrep -af 'claude|codex|gemini' | wc -l
+pgrep -af 'claude|codex|gemini|agy|antigravity' | wc -l
 ```
 
 If pressure is down and the agent count dropped to the expected steady


### PR DESCRIPTION
## What / why
The Codex mirror of `agent-swarm-cleanup` still greps process lists with `claude|codex|gemini`, so its reaper and post-cleanup count **miss every Antigravity (`agy`) pane** — the substrate already launches Antigravity as `agy --dangerously-skip-permissions` (ntm config migrated, ag-ni1b).

This is the **dual-runtime complement to PR #780**, which fixed only the Claude form (`skills/system-tuning/references/agent-swarm-cleanup.md`) and was explicitly single-file. On `main` both forms were identical and both buggy; this mirrors the exact PR780 change into `skills-codex/` to complete the `skills/` ∥ `skills-codex/` contract.

## Change
2-line alternation fix (+1 explanatory comment) in `skills-codex/system-tuning/references/agent-swarm-cleanup.md`: `claude|codex|gemini` → `claude|codex|gemini|agy|antigravity` in both the reap grep and the post-cleanup `pgrep` count. Diff = 3 ins / 2 del, single file.

## Verification
- markdownlint-cli2: 0 errors
- `scripts/generate-registry.sh --check`: up to date (registry walks `skills/` only — unaffected)
- `scripts/pre-push-gate.sh --fast`: passed

Closes-scenario: ag-2zf8#codex-mirror-agy-grep
Bounded-context: BC5-Runtime
Evidence: skills-codex/system-tuning/references/agent-swarm-cleanup.md