### PR TITLE
fix(ao): case-insensitive dedup in pool_ingest candidate IDs (soc-xn5s #dedup-case-insensitive)

### DIFF
--- a/cli/cmd/ao/pool_ingest.go
+++ b/cli/cmd/ao/pool_ingest.go
@@ -339,12 +339,18 @@ func buildCandidateFromLearningBlock(b learningBlock, srcPath string, fileDate t
 	// triple-ID filenames whenever a learning's source file, session hint, and
 	// frontmatter id all degenerated to the same string — and the resulting id
 	// re-amplified on each close-loop pass.
+	// Compare case-insensitively: the final id is lowercased by Slugify, and
+	// learningID is already lowercased (above), but base and sessionHint keep
+	// their source-filename case. Without normalizing, a source filename with
+	// any uppercase character (e.g. "...fix20260430T090800-1") skips the dedup
+	// branch and produces a DOUBLED id (soc-xn5s).
+	lowerBase := strings.ToLower(base)
 	parts := []string{base}
-	if sessionHint != "" && sessionHint != base && !strings.Contains(base, sessionHint) {
+	if sessionHint != "" && lowerBase != strings.ToLower(sessionHint) && !strings.Contains(lowerBase, strings.ToLower(sessionHint)) {
 		parts = append(parts, sessionHint)
 	}
 	if learningID != "" && learningID != "noid" {
-		joined := strings.Join(parts, "-")
+		joined := strings.ToLower(strings.Join(parts, "-"))
 		if !strings.Contains(joined, learningID) {
 			parts = append(parts, learningID)
 		}

--- a/cli/cmd/ao/pool_metrics_test.go
+++ b/cli/cmd/ao/pool_metrics_test.go
@@ -908,6 +908,45 @@ func TestPoolIngest_buildCandidateFromLearningBlock(t *testing.T) {
 			t.Errorf("high confidence score (%f) should be > low confidence score (%f)", candH.RawScore, candL.RawScore)
 		}
 	})
+
+	// soc-xn5s: learningID is lowercased before the dedup check, but base keeps
+	// its source-filename case. A filename with any uppercase character must
+	// still dedup against the (already-contained) learningID — otherwise the id
+	// doubles. Filename base "2026-04-30-fix20260430T090800-1" already contains
+	// the lowercased id "fix20260430t090800-1", so the id must appear once.
+	t.Run("mixed-case filename does not double the learning id", func(t *testing.T) {
+		b := learningBlock{
+			Title: "Mixed Case Dedup",
+			ID:    "fix20260430T090800-1",
+			Body:  "Body content for the mixed-case dedup regression.",
+		}
+		cand, _, ok := buildCandidateFromLearningBlock(b, "/p/2026-04-30-fix20260430T090800-1.md", time.Now(), "ag-test")
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		const idToken = "fix20260430t090800-1"
+		if n := strings.Count(cand.ID, idToken); n != 1 {
+			t.Errorf("learning id token %q appears %d times in %q, want exactly 1 (doubled-id bug)", idToken, n, cand.ID)
+		}
+	})
+
+	// soc-xn5s: the sessionHint == base equality/contains checks must also be
+	// case-insensitive so a mixed-case session hint that matches the base is not
+	// re-appended.
+	t.Run("mixed-case session hint matching base is not appended", func(t *testing.T) {
+		b := learningBlock{
+			Title: "Session Hint Dedup",
+			ID:    "L-1",
+			Body:  "Body content for the session-hint dedup regression.",
+		}
+		cand, _, ok := buildCandidateFromLearningBlock(b, "/p/ag-Session.md", time.Now(), "ag-session")
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if n := strings.Count(cand.ID, "ag-session"); n != 1 {
+			t.Errorf("session hint token appears %d times in %q, want exactly 1", n, cand.ID)
+		}
+	})
 }
 
 // ===========================================================================


### PR DESCRIPTION
## What

`buildCandidateFromLearningBlock` (cli/cmd/ao/pool_ingest.go) dedups the three ID
components (`base`, `sessionHint`, `learningID`). `learningID` is lowercased before
the check, but `base`/`sessionHint` keep their source-filename case. So any source
filename with an uppercase character (e.g. `2026-04-30-fix20260430T090800-1.md`)
**skipped** the `strings.Contains` dedup branch and produced a **doubled** candidate ID:

```
pend-2026-04-30-fix20260430t090800-1-ag-test-fix20260430t090800-1   (id appears twice)
```

The final ID is lowercased by `Slugify` anyway, so the comparisons should be
case-insensitive. Fix normalizes both sides of the equality/`Contains` checks for
`base`↔`sessionHint` and `joined`↔`learningID`.

## Why it mattered

Verified live 2026-04-30 (soc-xn5s): a mixed-case source filename re-amplified its
ID on each close-loop pass. Production residue was all-lowercase so unaffected, but
the edge case remained uncovered.

## Test

Two regression subtests in `TestPoolIngest_buildCandidateFromLearningBlock` reproduce
the exact doubled ID and the mixed-case session-hint duplication. Both fail against the
old code, pass with the fix:

```
--- FAIL .../mixed-case_filename_does_not_double_the_learning_id
    learning id token "fix20260430t090800-1" appears 2 times ... want exactly 1
--- FAIL .../mixed-case_session_hint_matching_base_is_not_appended
    session hint token appears 2 times ... want exactly 1
```

`go build ./...`, `go vet ./cmd/ao/`, `gofmt -l` all clean.

Closes-scenario: soc-xn5s#dedup-case-insensitive
Bounded-context: BC1-Corpus
Evidence: cli/cmd/ao/pool_metrics_test.go::TestPoolIngest_buildCandidateFromLearningBlock

🤖 Autonomous factory tick.