### PR TITLE
chore(doctor): drop dead `ao agentopsd`/GasCity strings (ag-9hhm #dead-text-removed-surfaces)

### DIFF
--- a/cli/cmd/ao/forge.go
+++ b/cli/cmd/ao/forge.go
@@ -40,7 +40,7 @@ var (
 )
 
 const forgeLegacyLocalLLMEnv = "AGENTOPS_FORGE_LEGACY_LOCAL_LLM"
-const forgeLegacyLocalLLMDeprecationWarning = "WARNING: --legacy-local-llm uses the deprecated local Ollama/Gemma bridge (removal target: v3.0.0); use AgentWorker/GasCity-backed Codex or Claude workers for daemon wiki/forge."
+const forgeLegacyLocalLLMDeprecationWarning = "WARNING: --legacy-local-llm uses the deprecated local Ollama/Gemma bridge (removal target: v3.0.0); configure a Dream worker queue for tier-1 forge instead."
 
 const (
 	// SnippetMaxLength is the maximum length for extracted text snippets.

--- a/cli/internal/doctor/fix_bridges.go
+++ b/cli/internal/doctor/fix_bridges.go
@@ -208,8 +208,8 @@ func probeOpenClawHealth(baseURL string) (kind, detail string) {
 	}
 }
 
-// openclawHealthUnreachableFixer is detect-only: it never starts/restarts
-// agentopsd and never rewrites the activation file.
+// openclawHealthUnreachableFixer is detect-only: it never starts/restarts the
+// OpenClaw daemon and never rewrites the activation file.
 type openclawHealthUnreachableFixer struct{}
 
 func (openclawHealthUnreachableFixer) ID() string { return fmOpenClawHealthUnreachable }
@@ -224,8 +224,8 @@ func (openclawHealthUnreachableFixer) Reversible() bool  { return true }
 func (openclawHealthUnreachableFixer) Idempotent() bool  { return true }
 func (openclawHealthUnreachableFixer) AutoFixable() bool { return false }
 
-// Fix re-runs the detector and reports the exact `ao agentopsd` action. It
-// starts nothing and rewrites no activation file. The finding persists.
+// Fix re-runs the detector and reports the remediation guidance. It starts
+// nothing and rewrites no activation file. The finding persists.
 func (openclawHealthUnreachableFixer) Fix(ctx *MutateContext, env *DetectEnv, _ []Finding) (FixResult, error) {
 	fs, err := openclawHealthUnreachableDetector{}.Detect(env)
 	if err != nil {
@@ -257,33 +257,32 @@ func (openclawHealthUnreachableFixer) Fix(ctx *MutateContext, env *DetectEnv, _ 
 func openclawHealthReport(kind, detail string) string {
 	switch kind {
 	case "activation_missing":
-		return "agentopsd was never started for this project: " +
-			"`.agents/daemon/activation.json` is absent. Start the daemon with " +
-			"`ao agentopsd start`, then re-run `ao doctor`. The doctor will not " +
+		return "The OpenClaw activation file `.agents/daemon/activation.json` is " +
+			"absent. The in-repo daemon that wrote it was removed (ADR-0009), so " +
+			"`ao` no longer starts a daemon in-session. Bring up the OpenClaw " +
+			"daemon out-of-band, then re-run `ao doctor`. The doctor will not " +
 			"start the daemon."
 	case "unreachable":
 		return fmt.Sprintf("OpenClaw health endpoint %s is unreachable. The daemon "+
-			"is down or the activation file points at a dead port. Run "+
-			"`ao agentopsd status`; if dead, `ao agentopsd restart`; if the "+
-			"activation file is stale, `ao agentopsd start` rewrites it. The "+
-			"doctor will not restart the daemon or rewrite the activation file.",
-			detail)
+			"is down or the activation file points at a dead port. Bring the "+
+			"OpenClaw daemon back up out-of-band (the in-repo daemon was removed — "+
+			"ADR-0009). The doctor will not restart the daemon or rewrite the "+
+			"activation file.", detail)
 	case "slow_or_hung":
 		return fmt.Sprintf("OpenClaw health endpoint %s did not respond within 3s. "+
-			"The daemon is slow or wedged. Inspect with `ao agentopsd status` and "+
-			"the daemon log; restart with `ao agentopsd restart` if wedged.", detail)
+			"The daemon is slow or wedged. Inspect and restart the OpenClaw daemon "+
+			"out-of-band; the doctor will not manage the daemon.", detail)
 	case "route_missing":
 		return fmt.Sprintf("The daemon at %s answers but `/openclaw/v1/health` "+
-			"returns 404 — this agentopsd build predates the OpenClaw consumer "+
-			"routes. Upgrade `ao`/agentopsd and restart the daemon "+
-			"(`ao agentopsd restart`).", detail)
+			"returns 404 — this OpenClaw build predates the consumer routes. "+
+			"Upgrade and restart the OpenClaw daemon out-of-band.", detail)
 	case "http_error":
 		return fmt.Sprintf("OpenClaw health endpoint %s returned an HTTP error. "+
-			"Inspect the daemon log; restart with `ao agentopsd restart` if it "+
-			"crashed.", detail)
+			"Inspect the daemon log and restart the OpenClaw daemon out-of-band if "+
+			"it crashed.", detail)
 	default: // not_ok
 		return fmt.Sprintf("OpenClaw health endpoint %s responded but status != ok. "+
-			"Inspect the daemon log and restart with `ao agentopsd restart` if "+
+			"Inspect the daemon log and restart the OpenClaw daemon out-of-band if "+
 			"needed.", detail)
 	}
 }
@@ -501,21 +500,25 @@ func snapshotStaleReport(obs snapshotObservation) string {
 	case "schema_mismatch":
 		return fmt.Sprintf("`latest.json` schema_version=%d, but the bridge "+
 			"requires version %d. A daemon upgrade bumped the snapshot schema. "+
-			"Rebuild the projection from the current daemon: `ao agentopsd "+
-			"projection rebuild --consumer openclaw` (or restart agentopsd so it "+
-			"re-emits a v%d snapshot). The doctor will not fabricate a schema "+
-			"downgrade.", obs.schemaVersion, openclaw.ConsumerSnapshotSchemaVersion,
+			"The in-repo daemon that emitted this projection was removed "+
+			"(ADR-0009); regenerate the OpenClaw projection from your out-of-session "+
+			"substrate so it re-emits a v%d snapshot. The doctor will not fabricate "+
+			"a schema downgrade.", obs.schemaVersion,
+			openclaw.ConsumerSnapshotSchemaVersion,
 			openclaw.ConsumerSnapshotSchemaVersion)
 	case "latest_missing":
 		return "`latest.json` is absent and no versioned snapshot exists to " +
-			"recover from. Rebuild via `ao agentopsd projection rebuild " +
-			"--consumer openclaw`."
+			"recover from. The in-repo daemon that emitted this projection was " +
+			"removed (ADR-0009); regenerate the OpenClaw projection from your " +
+			"out-of-session substrate."
 	case "torn_no_recovery":
 		return "`latest.json` is torn/truncated and no byte-valid versioned " +
-			"`snap_*.json` exists to recover from. Rebuild via `ao agentopsd " +
-			"projection rebuild --consumer openclaw`."
+			"`snap_*.json` exists to recover from. The in-repo daemon that emitted " +
+			"this projection was removed (ADR-0009); regenerate the OpenClaw " +
+			"projection from your out-of-session substrate."
 	default:
-		return "OpenClaw snapshot is not current. Rebuild via `ao agentopsd " +
-			"projection rebuild --consumer openclaw`."
+		return "OpenClaw snapshot is not current. The in-repo daemon that emitted " +
+			"this projection was removed (ADR-0009); regenerate the OpenClaw " +
+			"projection from your out-of-session substrate."
 	}
 }

--- a/cli/internal/doctor/fix_bridges_test.go
+++ b/cli/internal/doctor/fix_bridges_test.go
@@ -166,8 +166,11 @@ func TestBridgesOpenClawHealthUnreachableFixerRefuses(t *testing.T) {
 	if err != nil {
 		t.Fatalf("report not written: %v", err)
 	}
-	if !strings.Contains(string(body), "ao agentopsd") {
-		t.Errorf("report does not name ao agentopsd: %q", body)
+	if strings.Contains(string(body), "ao agentopsd") {
+		t.Errorf("report still instructs the removed `ao agentopsd` command: %q", body)
+	}
+	if !strings.Contains(string(body), "OpenClaw") {
+		t.Errorf("report missing OpenClaw remediation guidance: %q", body)
 	}
 }
 
@@ -338,8 +341,11 @@ func TestBridgesSnapshotSchemaMismatchRefuses(t *testing.T) {
 	if err != nil {
 		t.Fatalf("report not written: %v", err)
 	}
-	if !strings.Contains(string(body), "projection rebuild") {
-		t.Errorf("report does not name the rebuild command: %q", body)
+	if strings.Contains(string(body), "ao agentopsd") {
+		t.Errorf("report still instructs the removed `ao agentopsd` command: %q", body)
+	}
+	if !strings.Contains(string(body), "regenerate the OpenClaw projection") {
+		t.Errorf("report does not give projection-regeneration guidance: %q", body)
 	}
 }
 


### PR DESCRIPTION
## What

Two dead-text remnants pointed operators at **retired surfaces** (discovered in the 2026-06-03 feature-map analysis). Pure string hygiene — no behavior change.

1. **`cli/internal/doctor/fix_bridges.go`** — `openclawHealthReport` and `snapshotStaleReport` instructed `ao agentopsd start/status/restart` and `ao agentopsd projection rebuild --consumer openclaw`. The in-repo daemon was **removed (ADR-0009)** and no such command exists. Reworded to: bring the OpenClaw daemon up out-of-band / regenerate the projection from the out-of-session substrate, naming the daemon removal instead of a dead command. (Also fixed two stale code comments naming `agentopsd`.)
2. **`cli/cmd/ao/forge.go:43`** — the `--legacy-local-llm` deprecation warning named *"AgentWorker/GasCity-backed Codex or Claude workers"*. Gas City was pruned (ag-124p) and the GasCity worker adapter removed. Reworded to point at a **Dream worker queue** (consistent with the existing language elsewhere in `forge.go`).

## Why

These strings mislead operators toward commands/substrates that no longer exist; the `gc`/`agentopsd` prune was code-clean but the user-facing strings survived.

## Verification

- `gofmt` clean; `go build ./...`; `go vet ./internal/doctor/ ./cmd/ao/`
- `go test ./internal/doctor/` → 76 passed; `go test ./cmd/ao/ -run Forge` → 379 passed
- `git grep "ao agentopsd"` / `GasCity` over live (non-test) code in touched files → empty
- Updated the two doctor tests that asserted the old substrings.

Closes-scenario: ag-9hhm#dead-text-removed-surfaces
Bounded-context: BC5-Runtime
Evidence: cli/internal/doctor/fix_bridges_test.go