### PR TITLE
chore(skills): agy panes in swarm-cleanup greps — parity-complete, consolidates #788/#780/#785 (ag-ni1b #agy-swarm-cleanup-grep)

### DIFF
--- a/skills-codex/system-tuning/references/agent-swarm-cleanup.md
+++ b/skills-codex/system-tuning/references/agent-swarm-cleanup.md
@@ -69,9 +69,13 @@ Naming conventions help: prefix throwaway sessions (`ntm-test-*`,
 An agent older than the work it was meant to do is almost always idle in a
 loop or repeatedly retrying the same failing step.
 
+The matcher includes `agy` (Antigravity): ntm now maps its `gemini` agent
+slot to `agy --dangerously-skip-permissions`, so the gemini-family pane runs
+as an `agy` process. Match both — older sessions may still launch `gemini`.
+
 ```bash
 # Agents older than 16h with no live children of substance
-ps -eo pid,etimes,args | grep -E 'claude|codex|gemini' | grep -v grep \
+ps -eo pid,etimes,args | grep -E 'claude|codex|gemini|agy|antigravity' | grep -v grep \
   | awk '$2 > 57600 { print }' \
   | while read pid age rest; do
       kids=$(pgrep -P "$pid" | wc -l)
@@ -127,7 +131,7 @@ Re-run the original three checks and the count of agents:
 ```bash
 uptime
 cat /proc/pressure/cpu /proc/pressure/memory 2>/dev/null
-pgrep -af 'claude|codex|gemini' | wc -l
+pgrep -af 'claude|codex|gemini|agy|antigravity' | wc -l
 ```
 
 If pressure is down and the agent count dropped to the expected steady

--- a/skills/system-tuning/references/agent-swarm-cleanup.md
+++ b/skills/system-tuning/references/agent-swarm-cleanup.md
@@ -69,9 +69,13 @@ Naming conventions help: prefix throwaway sessions (`ntm-test-*`,
 An agent older than the work it was meant to do is almost always idle in a
 loop or repeatedly retrying the same failing step.
 
+The matcher includes `agy` (Antigravity): ntm now maps its `gemini` agent
+slot to `agy --dangerously-skip-permissions`, so the gemini-family pane runs
+as an `agy` process. Match both — older sessions may still launch `gemini`.
+
 ```bash
 # Agents older than 16h with no live children of substance
-ps -eo pid,etimes,args | grep -E 'claude|codex|gemini' | grep -v grep \
+ps -eo pid,etimes,args | grep -E 'claude|codex|gemini|agy|antigravity' | grep -v grep \
   | awk '$2 > 57600 { print }' \
   | while read pid age rest; do
       kids=$(pgrep -P "$pid" | wc -l)
@@ -127,7 +131,7 @@ Re-run the original three checks and the count of agents:
 ```bash
 uptime
 cat /proc/pressure/cpu /proc/pressure/memory 2>/dev/null
-pgrep -af 'claude|codex|gemini' | wc -l
+pgrep -af 'claude|codex|gemini|agy|antigravity' | wc -l
 ```
 
 If pressure is down and the agent count dropped to the expected steady


### PR DESCRIPTION
## What
One parity-complete PR for the agy/Antigravity swarm-cleanup grep change, **consolidating a 3-way overnight swarm collision**:
- **#788** (ag-ni1b) + **#780** (ag-mtfe) — both edited `skills/system-tuning/references/agent-swarm-cleanup.md` (true duplicates).
- **#785** (ag-2zf8) — edited the `skills-codex/` mirror alone → failed `codex-parity`/`contracts-sync` because its `skills/` half was in a *separate* PR.

This PR changes **both** files identically, so codex-parity passes in one shot.

## Change
Add `agy|antigravity` to the two cleanup greps (`ps …` + `pgrep -af …`) and a note that ntm now maps the `gemini` slot to `agy --dangerously-skip-permissions`.

## Recommendation
**Close #788, #780, #785** in favor of this (orchestrator/Bo's call — I did not close peers' PRs).

## Evidence
`generate-registry.sh --check` OK; both files carry identical diffs (parity).

Closes-scenario: ag-ni1b#agy-swarm-cleanup-grep
Bounded-context: BC5-Runtime
Evidence: registry-check-ok + parity-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)