### PR TITLE
fix(embedded): restore emptied standards embeds — main hotfix (ag-arpk follow-up)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -947,7 +947,12 @@ jobs:
           bash scripts/validate-context-map-drift.sh
 
       - name: Verify embedded lib/skills are in sync
-        if: needs.changes.outputs.hooks == 'true' || needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true'
+        # MUST include `skills`: the embedded copies mirror skills/standards/references/*,
+        # skills/using-agentops/SKILL.md and skills/compile/scripts/compile.sh, so a
+        # skills-only change can drift the embeds. Omitting `skills` here let #776's
+        # standards edit reach main with empty embeds (main-red 2026-06-06). `contracts`
+        # added for defense-in-depth.
+        if: needs.changes.outputs.skills == 'true' || needs.changes.outputs.hooks == 'true' || needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.contracts == 'true'
         run: |
           chmod +x scripts/validate-embedded-sync.sh
           ./scripts/validate-embedded-sync.sh

--- a/cli/embedded/skills/standards/references/go.md
+++ b/cli/embedded/skills/standards/references/go.md
@@ -264,6 +264,7 @@ func TestClassifyServeArg(t *testing.T) {
 - **Assert exact expected values:** Use `== expected`, never `!= wrong`. (See Exact Assertion Rule above.)
 - **Table-driven tests** preferred for multi-case functions. (See example above.)
 - **Test low-level functions directly;** don't depend on external CLIs (`bd`, `ao`) in tests. (See CI-Safe Test Pattern above.)
+- **Guard-test fixtures must use the real persisted shape.** Skip/dedup/consumed/idempotency/regression guard tests must round-trip a real persisted sample (production writer → production reader) or assert against a checked-in real example — never a hand-built in-memory constructor that sets a marker at a granularity the on-disk format never emits (e.g. `consumed` at item-level when `next-work.jsonl` marks it at batch-level). A fixture of a shape production can't produce gives a false green (ag-mjlg / PR #652). Full rationale: `test-pyramid.md` → "Fixture Fidelity".
 
 ### Benchmark Tests (BF7)
 

--- a/cli/embedded/skills/standards/references/test-pyramid.md
+++ b/cli/embedded/skills/standards/references/test-pyramid.md
@@ -407,6 +407,21 @@ After L0–L3 coverage is complete, run bug-finding levels:
 | `/plan` (format changes) | Flag BF8 backward compat — add old format as fixture before changing |
 | `/pre-mortem` (security) | Verify BF9 tests planned for code handling secrets or user input |
 
+## Fixture Fidelity — guard tests must use the real persisted shape
+
+> **Proven 2026-05-31 (ag-mjlg / PR #652):** a next-work materialize over-creation bug (44 beads planned vs 16 expected) shipped green because `TestNextWorkMaterialize_SkipsConsumed` set `consumed` at the **per-item** level while the real `next-work.jsonl` marks `consumed` at the **batch** level. The guard test exercised a data shape production never emits, so CI passed on a fixture that could not catch the bug.
+
+**The standard:** regression, idempotency, skip, dedup, and consumed/already-done guard tests MUST build their fixtures from the **real persisted data shape** — round-trip an actual on-disk sample (write → read back through the production serializer/parser), or assert against a checked-in real example. Do NOT hand-construct the in-memory struct via a convenient constructor when production reads the value from disk: the constructor lets you set fields at a granularity (per-item vs batch-level, flat vs nested) that the persisted format never produces, giving a false green.
+
+**Why it bites agents specifically:** an agent writing a guard test reaches for the cheapest fixture — the in-memory constructor — because it compiles fastest and reads cleanest. That fixture silently diverges from the persisted shape, and the test then "passes" by asserting on a state the system can't reach. The skip/dedup logic under test reads the persisted shape, so the test proves nothing about the real path.
+
+**How to comply:**
+- Round-trip the fixture: serialize a sample with the production writer, read it back with the production reader, then assert. If that path doesn't exist yet, write the sample to a temp file in the real on-disk format and load it through the production loader.
+- Match the marker granularity exactly: if production records `consumed`/`skip`/`dedup` state at the batch (or parent, or envelope) level, set it there — never only at the item level.
+- Prefer a checked-in real sample (a trimmed copy of an actual artifact) over a synthetic one for the canonical happy/skip cases.
+
+**Pre-mortem / checklist flag:** when reviewing a plan or diff that adds a skip/dedup/consumed/idempotency guard test, FLAG any fixture built only from an in-memory constructor or that sets the guard marker at item-level when the persisted artifact marks it at batch-level. Require the fixture to round-trip the real persisted shape before the test counts as coverage. (See `.claude/rules/go.md` → "Guard-test fixtures must use the real persisted shape.")
+
 ## Coverage Assessment Template
 
 Used by `/post-mortem` and `/vibe` to assess test shape health:

--- a/scripts/validate-embedded-sync.sh
+++ b/scripts/validate-embedded-sync.sh
@@ -35,7 +35,7 @@ check_file "$REPO_ROOT/skills/compile/scripts/compile.sh" "$EMBEDDED/skills/comp
 if [[ $ERRORS -gt 0 ]]; then
     echo ""
     echo "ERROR: $ERRORS embedded file(s) are out of sync."
-    echo "Run 'cd cli && make sync-embedded' to fix."
+    echo "Run 'cd cli && make sync-hooks' to fix."
     exit 1
 fi
 


### PR DESCRIPTION
## Main is red — hotfix

`cli/embedded/skills/standards/references/{go,test-pyramid}.md` were **empty (0 bytes)** on main HEAD; #776's merge truncated them. `contracts-sync` / `correctness` run the full embedded-sync check on main-push (changed-files-scoped on PRs, so it slipped through during the batch drain) → main Validate failed (run on 3df599df, def8fc9b).

## Fix
- Re-synced both embedded files from their sources via the `cli/Makefile` recipe (`cp ../skills/standards/references/*`). `scripts/validate-embedded-sync.sh` now reports **All embedded files are in sync**.
- Corrected that script's stale fix hint: `make sync-embedded` (no such target) → `make sync-hooks` (the real recipe).

## Evidence
`bash scripts/validate-embedded-sync.sh` → "All embedded files are in sync."

Bounded-context: BC5-Runtime
Evidence: cli/embedded/skills/standards/references/go.md