### PR TITLE
ci: cancel-superseded + parallel bats + union-merge generated files (ag-bdg1)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,14 @@
 
 # Keep executable scripts runnable when cloned on Windows.
 *.sh text eol=lf
+
+# Generated/derived artifacts — union-merge to kill textual re-conflicts during
+# multi-PR drains (their canonical content is restored by scripts/regen-all.sh).
+# Council 2026-06-06 (ag-bdg1). NOTE: cli/embedded/** is //go:embed'd and
+# skills-codex/** ships in the tarball — they MUST stay committed; union-merge
+# only avoids spurious conflict markers, regen produces the authoritative bytes.
+registry.json                          merge=union
+**/.agentops-generated.json            merge=union
+skills-codex/.agentops-manifest.json   merge=union
+docs/contracts/context-map.md          merge=union
+cli/docs/COMMANDS.md                   merge=union

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,6 +28,14 @@ on:
   # path-filter — which has no PR base in-queue — can't skip validation.
   merge_group:
 
+# Cancel superseded PR runs so update-branch / force-push churn during a merge
+# train doesn't leave stale runs eating the (20-slot, free-plan) concurrency pool
+# — the self-DoS that produced a 19-deep queue on 2026-06-06. NEVER cancels main
+# or tag pushes (cancel-in-progress is false unless this is a pull_request).
+concurrency:
+  group: validate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -284,8 +292,12 @@ jobs:
       - name: Run bats tests
         if: runner.os == 'Linux' && (needs.changes.outputs.hooks == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.bats == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.docs == 'true')
         run: |
-          echo "=== Running bats tests ==="
-          bats --print-output-on-failure tests/scripts/*.bats
+          echo "=== Running bats tests (4-way parallel) ==="
+          # bats --jobs needs GNU parallel; the serial run was ~237s (55% of the
+          # correctness critical path). --no-parallelize-within-files preserves
+          # ordering inside each file; only independent files run concurrently.
+          sudo apt-get install -y parallel >/dev/null 2>&1 || { sudo apt-get update -qq && sudo apt-get install -y parallel; }
+          bats --jobs 4 --no-parallelize-within-files --print-output-on-failure tests/scripts/*.bats
           echo "✅ Bats tests passed"
 
       - name: Setup Go


### PR DESCRIPTION
## Why
The PR drain became a CI-wait treadmill. A 4-lens council (2026-06-06) found three non-quorum-sensitive, mutually-reinforcing fixes. (Merge queue — the obvious answer — is **impossible**: it's org-only and this is a user-owned repo; strict-up-to-date was relaxed permanently instead.)

## What
1. **`concurrency` cancel-in-progress (PRs only).** validate.yml had no concurrency group, so every update-branch/force-push left stale runs consuming the 20-slot free pool — a self-DoS that produced a 19-deep queue. Now superseded PR runs cancel; **main/tag pushes never cancel** (`cancel-in-progress` is false unless pull_request).
2. **4-way parallel bats.** Serial `bats tests/scripts/*.bats` was ~237s = **55% of the `correctness` critical path**. `--jobs 4 --no-parallelize-within-files` targets ~150s off every run (within-file order preserved; only independent files run concurrently). Installs GNU `parallel`.
3. **`.gitattributes merge=union`** on `registry.json`, `*.agentops-generated.json`, `context-map.md`, `COMMANDS.md` — kills the O(n²) textual re-conflicts these generated files cause during multi-PR drains (regen-all restores canonical bytes). `cli/embedded/**` + `skills-codex/**` stay committed (go:embed / tarball-shipped).

## Risk / trial
Only #2 carries risk (parallel test collisions) — **this PR's own `correctness` run is the live trial**: if a bats suite collides under `--jobs 4`, correctness fails here and I drop it. The required-check SET (`summary`) and its semantics are unchanged, so this is not quorum-sensitive.

Closes-scenario: ag-bdg1#ci-throughput
Bounded-context: BC5-Runtime
Evidence: .github/workflows/validate.yml