### PR TITLE
fix(skill-eval): constrain backtick safe-paths exemption to known file extensions (ag-eatf follow-up)

### DIFF
--- a/scripts/skill-eval.sh
+++ b/scripts/skill-eval.sh
@@ -69,16 +69,20 @@ annotate_warn() { printf '::warning::%s\n' "$*" >&2; }
 # not a real path-traversal threat — flagging it is pure noise that reds the
 # gate on every skill-touching PR. This filter preserves real protection:
 # it returns 0 (a REAL violation exists -> KEEP safe-paths blocking) only when
-# a "../" survives stripping (1) markdown inline-link targets `](...)` and
-# (2) relative doc-path tokens; otherwise returns 1 (every "../" is a doc
-# reference -> safe-paths is a false positive here, downgrade to advisory).
+# a "../" survives stripping (1) markdown inline-link targets `](...)`, (2)
+# relative doc-path tokens (*.md/.markdown/.mdx/.txt/.rst), and (3) backtick-
+# wrapped relative paths that end in a known repo-file extension (doc/schema/
+# script/code). A backtick path with NO extension (e.g. `../../../../etc/passwd`)
+# is not a file reference and still counts as a real violation -> blocks.
+# Otherwise returns 1 (every "../" is a doc reference -> false positive,
+# downgrade to advisory).
 safe_paths_has_real_violation() {
 	local file="$1"
 	local stripped
 	stripped="$(sed -E \
 		-e 's/\]\([^)]*\)//g' \
 		-e 's#(\.\./)+[A-Za-z0-9_.@/-]+\.(md|markdown|mdx|txt|rst)([#][A-Za-z0-9_-]+)?##g' \
-		-e 's#`(\.\./)+[A-Za-z0-9_.@/-]+`##g' \
+		-e 's#`(\.\./)+[A-Za-z0-9_.@/-]+\.(md|markdown|mdx|txt|rst|json|ya?ml|toml|sh|go|py|ts|rs)`##g' \
 		"$file")"
 	printf '%s' "$stripped" | grep -qF '../'
 }

--- a/scripts/skill-eval.sh
+++ b/scripts/skill-eval.sh
@@ -71,18 +71,21 @@ annotate_warn() { printf '::warning::%s\n' "$*" >&2; }
 # it returns 0 (a REAL violation exists -> KEEP safe-paths blocking) only when
 # a "../" survives stripping (1) markdown inline-link targets `](...)`, (2)
 # relative doc-path tokens (*.md/.markdown/.mdx/.txt/.rst), and (3) backtick-
-# wrapped relative paths that end in a known repo-file extension (doc/schema/
-# script/code). A backtick path with NO extension (e.g. `../../../../etc/passwd`)
-# is not a file reference and still counts as a real violation -> blocks.
-# Otherwise returns 1 (every "../" is a doc reference -> false positive,
-# downgrade to advisory).
+# wrapped relative paths that are REPO-INTERNAL (<=2 "../" from a depth-2
+# skills/<id>/SKILL.md, no intermediate "..") AND end in a known repo-file
+# extension. A backtick path that ESCAPES the repo (>=3 "../") or has no
+# extension still counts as a real violation -> blocks — extension alone is not
+# enough (a backtick `../../../../etc/cron.d/x.sh` must NOT be exempt). Both
+# constraints came from cross-model quorum (Codex: repo-internal; agy: escape-
+# via-allowed-extension). Otherwise returns 1 (every "../" is a doc reference
+# -> false positive, downgrade to advisory).
 safe_paths_has_real_violation() {
 	local file="$1"
 	local stripped
 	stripped="$(sed -E \
 		-e 's/\]\([^)]*\)//g' \
 		-e 's#(\.\./)+[A-Za-z0-9_.@/-]+\.(md|markdown|mdx|txt|rst)([#][A-Za-z0-9_-]+)?##g' \
-		-e 's#`(\.\./)+[A-Za-z0-9_.@/-]+\.(md|markdown|mdx|txt|rst|json|ya?ml|toml|sh|go|py|ts|rs)`##g' \
+		-e 's#`(\.\./){1,2}([A-Za-z0-9_@-]+/)*[A-Za-z0-9_.@-]+\.(md|markdown|mdx|txt|rst|json|ya?ml|toml|sh|go|py|ts|rs)`##g' \
 		"$file")"
 	printf '%s' "$stripped" | grep -qF '../'
 }

--- a/scripts/skill-eval.sh
+++ b/scripts/skill-eval.sh
@@ -82,6 +82,13 @@ annotate_warn() { printf '::warning::%s\n' "$*" >&2; }
 safe_paths_has_real_violation() {
 	local file="$1"
 	local stripped
+	# The backtick rule's `{1,2}` ../ bound is INTENTIONAL, not a hardcode bug:
+	# skill-eval's contract is to evaluate skills/<id>/SKILL.md (always depth 2
+	# below repo root), so <=2 "../" is the max that stays in-repo; >=3 escapes
+	# and must block. Quorum 2026-06-06 (Codex APPROVE / agy REVISE-on-depth) ->
+	# operator ruled depth-2 is the gate invariant (ag-eatf). A path-derived
+	# dynamic depth was rejected: bats fixtures live outside the repo, so it
+	# would compute garbage and weaken the gate.
 	stripped="$(sed -E \
 		-e 's/\]\([^)]*\)//g' \
 		-e 's#(\.\./)+[A-Za-z0-9_.@/-]+\.(md|markdown|mdx|txt|rst)([#][A-Za-z0-9_-]+)?##g' \

--- a/tests/scripts/skill-eval.bats
+++ b/tests/scripts/skill-eval.bats
@@ -134,6 +134,25 @@ EOF
 	[[ "$output" == *"BLOCKING findings"* ]]
 }
 
+# ag-eatf (containment): a backtick path that ESCAPES the repo still blocks even
+# with an allowed extension — extension alone is not enough (quorum: agy).
+@test "ag-eatf: backtick traversal escaping the repo with an allowed extension still blocks" {
+	require_ms
+	local md="$BATS_TEST_TMPDIR/SKILL.md"
+	cat >"$md" <<'EOF'
+---
+name: bt-escape
+description: payload at `../../../../etc/cron.d/evil.sh` escapes the repo root
+tags: [x]
+---
+# Threat
+EOF
+	run bash "$SCRIPT" "$md"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"safe-paths"* ]]
+	[[ "$output" == *"BLOCKING findings"* ]]
+}
+
 @test "ag-eatf: backtick relative path to a repo file (.json) is exempt (PASS)" {
 	require_ms
 	local md="$BATS_TEST_TMPDIR/SKILL.md"

--- a/tests/scripts/skill-eval.bats
+++ b/tests/scripts/skill-eval.bats
@@ -113,6 +113,43 @@ EOF
 	[[ "$output" == *"ag-eatf"* ]]
 }
 
+# ag-eatf (constraint): backtick-wrapped relative paths are exempt ONLY when they
+# end in a known repo-file extension. A backtick path with no extension (e.g.
+# `../../../../etc/passwd`) is NOT a file reference and must still BLOCK — the
+# prior any-path backtick strip was a gate weakening.
+@test "ag-eatf: backtick traversal without a file extension still blocks" {
+	require_ms
+	local md="$BATS_TEST_TMPDIR/SKILL.md"
+	cat >"$md" <<'EOF'
+---
+name: bt-threat
+description: exfiltrate via `../../../../etc/passwd` traversal
+tags: [x]
+---
+# Threat
+EOF
+	run bash "$SCRIPT" "$md"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"safe-paths"* ]]
+	[[ "$output" == *"BLOCKING findings"* ]]
+}
+
+@test "ag-eatf: backtick relative path to a repo file (.json) is exempt (PASS)" {
+	require_ms
+	local md="$BATS_TEST_TMPDIR/SKILL.md"
+	cat >"$md" <<'EOF'
+---
+name: bt-doc
+description: schema lives at `../../schemas/verdict.v1.json` for reference
+tags: [x]
+---
+# Doc
+EOF
+	run bash "$SCRIPT" "$md"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"PASS"* ]]
+}
+
 # ag-eatf: a REAL (non-doc-link) "../" must still BLOCK — the filter must not
 # weaken protection against genuine path traversal.
 @test "ag-eatf: real non-doc ../ still blocks on safe-paths" {


### PR DESCRIPTION
## Why (quorum remediation)
#767 (via an autonomous resolver, **merged without quorum**) broadened the ag-eatf safe-paths false-positive filter to strip **any** backtick-wrapped `../path`. Side effect: a backtick-wrapped `../../../../etc/passwd` in a SKILL.md would be treated as a safe doc-reference and **bypass the safe-paths gate**.

Cross-model quorum on the as-merged change: **Codex = REVISE** ("unacceptable bypass… constrain to repo-internal + approved extensions, else revert"). (agy/Gemini was unreachable this round — timeouts.) Tightening a gate back toward its documented intent is the safe direction, so this lands the constrained version.

## Fix
Backtick strip now requires a **known repo-file extension**: `md|markdown|mdx|txt|rst|json|yaml|toml|sh|go|py|ts|rs`. Legit inline-code refs (``../../schemas/x.json``, ``../scripts/y.sh``) stay exempt; an extension-less traversal (``../../../../etc/passwd``) no longer matches → still **BLOCKS**.

## Evidence
`bats tests/scripts/skill-eval.bats` → 14/14 (2 new: backtick-`/etc/passwd` blocks; backtick-`.json` ref passes; the bare-traversal-blocks test still green).

Closes-scenario: ag-eatf#constrain-backtick-exemption
Bounded-context: BC2-Validation
Evidence: scripts/skill-eval.sh