### PR TITLE
fix(agentops): remove api-print worker paths

### DIFF
--- a/cli/cmd/ao/compile.go
+++ b/cli/cmd/ao/compile.go
@@ -90,7 +90,7 @@ By default it runs the repo-local compiled knowledge cycle:
 
 Headless compilation uses skills/compile/scripts/compile.sh. Set
 AGENTOPS_COMPILE_RUNTIME or pass --runtime to choose an LLM backend
-(ollama, claude, or openai).`,
+(codex-cli, ollama, claude, or openai).`,
 	Args: cobra.NoArgs,
 	RunE: runCompile,
 }
@@ -102,7 +102,7 @@ func init() {
 	compileCmd.Flags().StringVar(&compileSourcesDir, "sources", ".agents", "Source .agents root to compile")
 	compileCmd.Flags().StringVar(&compileOutputDir, "output-dir", ".agents/compiled", "Compiled wiki output directory")
 	compileCmd.Flags().StringVar(&compileSince, "since", "26h", "Mine lookback window for full and mine-only modes")
-	compileCmd.Flags().StringVar(&compileRuntime, "runtime", "", "LLM runtime override for headless compilation (ollama, claude, openai)")
+	compileCmd.Flags().StringVar(&compileRuntime, "runtime", "", "LLM runtime override for headless compilation (codex-cli, ollama, claude, openai)")
 	compileCmd.Flags().BoolVar(&compileIncremental, "incremental", true, "Compile only changed source artifacts")
 	compileCmd.Flags().BoolVar(&compileForce, "force", false, "Recompile all source artifacts regardless of hashes")
 	compileCmd.Flags().BoolVar(&compileOnly, "compile-only", false, "Skip mine and defrag; run compile plus lint")
@@ -613,7 +613,7 @@ var loadCompileConfigFn = func() (string, error) {
 //  3. compile.preferred_runtime in ~/.agentops/config.yaml or
 //     .agents/config.yaml (so privacy-preferring users can force Ollama
 //     even when `claude` is installed)
-//  4. auto-detect: if 'claude' binary is on PATH, use claude-cli
+//  4. auto-detect: if 'codex' binary is on PATH, use codex-cli
 //  5. empty (preflight will fail with an actionable error)
 func resolveCompileRuntime(flagValue string) string {
 	if v := strings.TrimSpace(flagValue); v != "" {
@@ -625,9 +625,9 @@ func resolveCompileRuntime(flagValue string) string {
 	if v, _ := loadCompileConfigFn(); strings.TrimSpace(v) != "" {
 		return strings.TrimSpace(v)
 	}
-	// Auto-detect local Claude Code CLI as a zero-config backend.
-	if _, err := lookPathFn("claude"); err == nil {
-		return "claude-cli"
+	// Auto-detect local Codex CLI as a zero-config backend.
+	if _, err := lookPathFn("codex"); err == nil {
+		return "codex-cli"
 	}
 	return ""
 }
@@ -642,20 +642,20 @@ func preflightCompileRuntime(runtime string) error {
 		return fmt.Errorf(`no LLM runtime configured for headless compile
 
 Pick one:
-  export AGENTOPS_COMPILE_RUNTIME=claude-cli   # uses local 'claude' binary, no API key needed
+  export AGENTOPS_COMPILE_RUNTIME=codex-cli   # uses local 'codex' binary, no API key needed
   export AGENTOPS_COMPILE_RUNTIME=ollama       # needs OLLAMA_HOST (fallback http://localhost:11434)
   export AGENTOPS_COMPILE_RUNTIME=claude       # needs ANTHROPIC_API_KEY
   export AGENTOPS_COMPILE_RUNTIME=openai       # needs OPENAI_API_KEY
 
 Or pass --runtime=<name> on this command.
 Or invoke /compile interactively inside a Claude Code session`)
-	case "claude-cli":
-		if _, err := lookPathFn("claude"); err != nil {
-			return fmt.Errorf("runtime=claude-cli but 'claude' binary is not on PATH; install Claude Code or switch: --runtime=ollama")
+	case "codex", "codex-cli":
+		if _, err := lookPathFn("codex"); err != nil {
+			return fmt.Errorf("runtime=codex-cli but 'codex' binary is not on PATH; install Codex CLI or switch: --runtime=ollama")
 		}
 	case "claude":
 		if strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")) == "" {
-			return fmt.Errorf("runtime=claude but ANTHROPIC_API_KEY is not set; export it or switch: --runtime=claude-cli (uses local claude binary, no key needed)")
+			return fmt.Errorf("runtime=claude but ANTHROPIC_API_KEY is not set; export it or switch: --runtime=codex-cli (uses local codex binary, no key needed)")
 		}
 	case "openai":
 		if strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) == "" {
@@ -664,7 +664,7 @@ Or invoke /compile interactively inside a Claude Code session`)
 	case "ollama":
 		// curl/ollama connectivity is best-effort; compile.sh will warn.
 	default:
-		return fmt.Errorf("unknown runtime %q; expected one of: ollama, claude, claude-cli, openai", runtime)
+		return fmt.Errorf("unknown runtime %q; expected one of: codex-cli, ollama, claude, openai", runtime)
 	}
 	return nil
 }

--- a/cli/cmd/ao/compile_integration_test.go
+++ b/cli/cmd/ao/compile_integration_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // TestRunCompile_EndToEnd_FixtureCorpus exercises `ao compile --full`
-// against a tiny .agents/ fixture with a PATH-shimmed `claude` binary
+// against a tiny .agents/ fixture with a PATH-shimmed `codex` binary
 // that echoes a canned wiki response. This catches the 2026-04-15
 // regression class (embed miss, runtime preflight silently skipped,
 // single-giant-prompt on large corpora) at integration level. It would
@@ -24,13 +24,13 @@ import (
 // The test creates a self-contained environment:
 //   - fresh tmp dir with .agents/{learnings,patterns,research}
 //   - 8 source .md files spread across the three dirs
-//   - a shell "claude" shim on PATH that returns a canned article response
-//   - runtime=claude-cli so the shim is invoked
+//   - a shell "codex" shim on PATH that returns a canned article response
+//   - runtime=codex-cli so the shim is invoked
 //   - batch-size=3 so the 8 files split across multiple batches
 //
 // Assertions:
 //   - ao compile --full succeeds
-//   - claude shim was invoked (batches > 0)
+//   - codex shim was invoked (batches > 0)
 //   - .agents/compiled/ contains >=1 compiled article
 //   - lint-report.md is generated
 //   - no "file does not exist" errors
@@ -65,7 +65,7 @@ func TestRunCompile_EndToEnd_FixtureCorpus(t *testing.T) {
 		}
 	}
 
-	// Create a PATH-shim claude binary in a bin/ dir under tmp. The shim
+	// Create a PATH-shim codex binary in a bin/ dir under tmp. The shim
 	// reads stdin and prints a canned response in the = ARTICLE = format
 	// compile.sh expects, regardless of input. This proves the runtime
 	// preflight passes, the script resolves, the batching logic fires,
@@ -74,7 +74,7 @@ func TestRunCompile_EndToEnd_FixtureCorpus(t *testing.T) {
 	if err := os.MkdirAll(shimDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	shimPath := filepath.Join(shimDir, "claude")
+	shimPath := filepath.Join(shimDir, "codex")
 	shimScript := `#!/usr/bin/env bash
 # Consume stdin so the pipe closes cleanly.
 cat >/dev/null
@@ -116,14 +116,14 @@ title: Index
 CANNED
 `
 	if err := os.WriteFile(shimPath, []byte(shimScript), 0o755); err != nil {
-		t.Fatalf("write claude shim: %v", err)
+		t.Fatalf("write codex shim: %v", err)
 	}
 
 	// Put the shim first on PATH and restore after test.
 	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	// Make sure we don't accidentally pick up an API key that would
 	// route the bash script down the HTTP path.
-	t.Setenv("AGENTOPS_COMPILE_RUNTIME", "claude-cli")
+	t.Setenv("AGENTOPS_COMPILE_RUNTIME", "codex-cli")
 	t.Setenv("ANTHROPIC_API_KEY", "")
 	t.Setenv("OPENAI_API_KEY", "")
 
@@ -132,7 +132,7 @@ CANNED
 	t.Cleanup(func() { testProjectDir = "" })
 
 	// Use the real runCompileScript (no stub) so we exercise the full
-	// materialize → exec bash → compile.sh → claude shim path. Keep mine
+	// materialize -> exec bash -> compile.sh -> codex shim path. Keep mine
 	// and defrag stubbed so they don't touch real git or lifecycle code.
 	origMine := runCompileMineFn
 	origDefrag := runCompileDefragFn

--- a/cli/cmd/ao/compile_test.go
+++ b/cli/cmd/ao/compile_test.go
@@ -218,10 +218,10 @@ func TestResolveCompileRuntime(t *testing.T) {
 
 	// env wins over config file + auto-detect
 	t.Setenv("AGENTOPS_COMPILE_RUNTIME", "openai")
-	loadCompileConfigFn = func() (string, error) { return "claude-cli", nil }
+	loadCompileConfigFn = func() (string, error) { return "codex-cli", nil }
 	lookPathFn = func(name string) (string, error) {
-		if name == "claude" {
-			return "/usr/local/bin/claude", nil
+		if name == "codex" {
+			return "/usr/local/bin/codex", nil
 		}
 		return "", os.ErrNotExist
 	}
@@ -229,13 +229,13 @@ func TestResolveCompileRuntime(t *testing.T) {
 		t.Fatalf("env var precedence: got %q want openai", got)
 	}
 
-	// config file wins over auto-detect (na-pmx1.9 core case: user has claude
+	// config file wins over auto-detect (na-pmx1.9 core case: user has codex
 	// installed but prefers ollama for privacy)
 	t.Setenv("AGENTOPS_COMPILE_RUNTIME", "")
 	loadCompileConfigFn = func() (string, error) { return "ollama", nil }
 	lookPathFn = func(name string) (string, error) {
-		if name == "claude" {
-			return "/usr/local/bin/claude", nil
+		if name == "codex" {
+			return "/usr/local/bin/codex", nil
 		}
 		return "", os.ErrNotExist
 	}
@@ -243,13 +243,13 @@ func TestResolveCompileRuntime(t *testing.T) {
 		t.Fatalf("config file precedence: got %q want ollama", got)
 	}
 
-	// auto-detect claude-cli when claude binary is present and nothing else set
+	// auto-detect codex-cli when codex binary is present and nothing else set
 	loadCompileConfigFn = func() (string, error) { return "", nil }
-	if got := resolveCompileRuntime(""); got != "claude-cli" {
-		t.Fatalf("auto-detect: got %q want claude-cli", got)
+	if got := resolveCompileRuntime(""); got != "codex-cli" {
+		t.Fatalf("auto-detect: got %q want codex-cli", got)
 	}
 
-	// no config and no claude → empty (preflight will fail with actionable error)
+	// no config and no codex -> empty (preflight will fail with actionable error)
 	lookPathFn = func(string) (string, error) { return "", os.ErrNotExist }
 	if got := resolveCompileRuntime(""); got != "" {
 		t.Fatalf("no config: got %q want empty", got)
@@ -258,13 +258,13 @@ func TestResolveCompileRuntime(t *testing.T) {
 	// config load error falls through to auto-detect gracefully
 	loadCompileConfigFn = func() (string, error) { return "", os.ErrNotExist }
 	lookPathFn = func(name string) (string, error) {
-		if name == "claude" {
-			return "/usr/local/bin/claude", nil
+		if name == "codex" {
+			return "/usr/local/bin/codex", nil
 		}
 		return "", os.ErrNotExist
 	}
-	if got := resolveCompileRuntime(""); got != "claude-cli" {
-		t.Fatalf("config error fallback: got %q want claude-cli", got)
+	if got := resolveCompileRuntime(""); got != "codex-cli" {
+		t.Fatalf("config error fallback: got %q want codex-cli", got)
 	}
 }
 
@@ -282,13 +282,13 @@ func TestPreflightCompileRuntimeErrors(t *testing.T) {
 		{
 			name:    "empty runtime names actionable env vars",
 			runtime: "",
-			wantErr: "AGENTOPS_COMPILE_RUNTIME=claude-cli",
+			wantErr: "AGENTOPS_COMPILE_RUNTIME=codex-cli",
 		},
 		{
-			name:    "claude-cli missing binary",
-			runtime: "claude-cli",
+			name:    "codex-cli missing binary",
+			runtime: "codex-cli",
 			lookup:  func(string) (string, error) { return "", os.ErrNotExist },
-			wantErr: "'claude' binary is not on PATH",
+			wantErr: "'codex' binary is not on PATH",
 		},
 		{
 			name:    "claude runtime missing API key",
@@ -334,15 +334,15 @@ func TestPreflightCompileRuntimeSuccess(t *testing.T) {
 	t.Cleanup(func() { lookPathFn = origLookPath })
 
 	lookPathFn = func(name string) (string, error) {
-		if name == "claude" {
-			return "/usr/local/bin/claude", nil
+		if name == "codex" {
+			return "/usr/local/bin/codex", nil
 		}
 		return "", os.ErrNotExist
 	}
 	t.Setenv("ANTHROPIC_API_KEY", "sk-fake")
 	t.Setenv("OPENAI_API_KEY", "sk-fake")
 
-	for _, rt := range []string{"claude-cli", "claude", "openai", "ollama"} {
+	for _, rt := range []string{"codex-cli", "claude", "openai", "ollama"} {
 		if err := preflightCompileRuntime(rt); err != nil {
 			t.Fatalf("%s: unexpected error %v", rt, err)
 		}
@@ -370,11 +370,11 @@ func TestCompileScriptOptionsPassesBatchFlags(t *testing.T) {
 	compileFull = true
 	compileBatchSize = 50
 	compileMaxBatches = 3
-	compileRuntime = "claude-cli"
+	compileRuntime = "codex-cli"
 	origLookPath := lookPathFn
 	lookPathFn = func(name string) (string, error) {
-		if name == "claude" {
-			return "/usr/local/bin/claude", nil
+		if name == "codex" {
+			return "/usr/local/bin/codex", nil
 		}
 		return "", os.ErrNotExist
 	}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -2966,7 +2966,7 @@ ao compile [flags]
       --quiet               Suppress human progress output
       --repair              Remove orphaned fallback stubs from .agents/compiled/ (files with no inbound wikilink traffic)
       --reset               Delete .agents/compiled/ and .hashes.json before compiling (force full rebuild)
-      --runtime string      LLM runtime override for headless compilation (ollama, claude, openai)
+      --runtime string      LLM runtime override for headless compilation (codex-cli, ollama, claude, openai)
       --since string        Mine lookback window for full and mine-only modes (default "26h")
       --sources string      Source .agents root to compile (default ".agents")
 ```

--- a/cli/embedded/skills/compile/scripts/compile.sh
+++ b/cli/embedded/skills/compile/scripts/compile.sh
@@ -12,7 +12,7 @@ HASH_FILE=""
 RUNTIME="${AGENTOPS_COMPILE_RUNTIME:-}"
 OLLAMA_MODEL="${AGENTOPS_COMPILE_MODEL:-gemma3:27b}"
 CLAUDE_MODEL="${AGENTOPS_COMPILE_CLAUDE_MODEL:-claude-sonnet-4-20250514}"
-CLAUDE_CLI_MODEL="${AGENTOPS_COMPILE_CLAUDE_CLI_MODEL:-}"
+CODEX_CLI_MODEL="${AGENTOPS_COMPILE_CODEX_CLI_MODEL:-}"
 OLLAMA_API="${OLLAMA_HOST:-http://localhost:11434}"
 BATCH_SIZE="${AGENTOPS_COMPILE_BATCH_SIZE:-25}"
 MAX_BATCHES="${AGENTOPS_COMPILE_MAX_BATCHES:-0}"  # 0 = unlimited
@@ -119,21 +119,20 @@ print(json.dumps({
         -H "anthropic-version: 2023-06-01" \
         -d "$payload" | python3 -c "import sys,json; print(json.load(sys.stdin)['content'][0]['text'])"
       ;;
-    claude-cli)
-      # Use the locally installed `claude` binary in headless (-p) mode.
-      # No API key required; inherits the user's Claude Code auth.
-      if ! command -v claude &>/dev/null; then
-        echo "ERROR: claude-cli runtime requested but 'claude' binary not on PATH." >&2
+    codex|codex-cli)
+      # Use the local Codex CLI subscription runtime for headless compilation.
+      if ! command -v codex &>/dev/null; then
+        echo "ERROR: codex-cli runtime requested but 'codex' binary not on PATH." >&2
         exit 1
       fi
       local combined="${system_prompt}
 
 ${user_prompt}"
-      if [[ -n "$CLAUDE_CLI_MODEL" ]]; then
-        printf '%s' "$combined" | claude -p --model "$CLAUDE_CLI_MODEL" 2>/dev/null
-      else
-        printf '%s' "$combined" | claude -p 2>/dev/null
+      local -a codex_cmd=(codex exec -C "$(pwd)" -s read-only)
+      if [[ -n "$CODEX_CLI_MODEL" ]]; then
+        codex_cmd+=(-m "$CODEX_CLI_MODEL")
       fi
+      printf '%s' "$combined" | "${codex_cmd[@]}" -
       ;;
     openai)
       local payload
@@ -153,10 +152,10 @@ print(json.dumps({
         -d "$payload" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'])"
       ;;
     *)
-      echo "ERROR: AGENTOPS_COMPILE_RUNTIME must be set to one of: ollama, claude, claude-cli, openai." >&2
+      echo "ERROR: AGENTOPS_COMPILE_RUNTIME must be set to one of: codex-cli, ollama, claude, openai." >&2
       echo "" >&2
       echo "Pick one of these that matches what you have installed:" >&2
-      echo "  export AGENTOPS_COMPILE_RUNTIME=claude-cli   # uses local 'claude' binary, no API key needed" >&2
+      echo "  export AGENTOPS_COMPILE_RUNTIME=codex-cli   # uses local 'codex' binary, no API key needed" >&2
       echo "  export AGENTOPS_COMPILE_RUNTIME=ollama       # needs OLLAMA_HOST (default http://localhost:11434)" >&2
       echo "  export AGENTOPS_COMPILE_RUNTIME=claude       # needs ANTHROPIC_API_KEY" >&2
       echo "  export AGENTOPS_COMPILE_RUNTIME=openai       # needs OPENAI_API_KEY" >&2
@@ -171,17 +170,17 @@ print(json.dumps({
 
 preflight_runtime() {
   case "$RUNTIME" in
-    claude-cli)
-      if ! command -v claude &>/dev/null; then
-        echo "ERROR: runtime=claude-cli but 'claude' binary is not on PATH." >&2
-        echo "Install Claude Code or switch runtime: export AGENTOPS_COMPILE_RUNTIME=ollama" >&2
+    codex|codex-cli)
+      if ! command -v codex &>/dev/null; then
+        echo "ERROR: runtime=codex-cli but 'codex' binary is not on PATH." >&2
+        echo "Install Codex CLI or switch runtime: export AGENTOPS_COMPILE_RUNTIME=ollama" >&2
         return 1
       fi
       ;;
     claude)
       if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
         echo "ERROR: runtime=claude but ANTHROPIC_API_KEY is not set." >&2
-        echo "Either export ANTHROPIC_API_KEY=... or switch: export AGENTOPS_COMPILE_RUNTIME=claude-cli" >&2
+        echo "Either export ANTHROPIC_API_KEY=... or switch: export AGENTOPS_COMPILE_RUNTIME=codex-cli" >&2
         return 1
       fi
       ;;
@@ -205,7 +204,7 @@ preflight_runtime() {
       return 1
       ;;
     *)
-      echo "ERROR: unknown runtime '$RUNTIME'. Expected one of: ollama, claude, claude-cli, openai." >&2
+      echo "ERROR: unknown runtime '$RUNTIME'. Expected one of: codex-cli, ollama, claude, openai." >&2
       return 1
       ;;
   esac

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -56,15 +56,15 @@ type Config struct {
 type CompileConfig struct {
 	// PreferredRuntime overrides the auto-detect runtime selection.
 	// When set, ao compile uses this value instead of auto-detecting a
-	// local `claude` binary. Useful for users who want to run Ollama
-	// even when Claude Code is installed. Accepted values: "claude-cli",
+	// local `codex` binary. Useful for users who want to run Ollama
+	// even when Codex CLI is installed. Accepted values: "codex-cli",
 	// "ollama", "claude", "openai", or empty (use auto-detect).
 	//
 	// Precedence (high → low):
 	//   1. --runtime flag
 	//   2. AGENTOPS_COMPILE_RUNTIME env var
 	//   3. compile.preferred_runtime in ~/.agentops/config.yaml
-	//   4. auto-detect (claude binary on PATH → claude-cli)
+	//   4. auto-detect (codex binary on PATH -> codex-cli)
 	//   5. empty (preflight will fail with an actionable error)
 	PreferredRuntime string `yaml:"preferred_runtime" json:"preferred_runtime"`
 }

--- a/scripts/eval-agent-harness.sh
+++ b/scripts/eval-agent-harness.sh
@@ -7,13 +7,13 @@ WORKBENCH="$REPO_ROOT/evals/workbench"
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/eval-agent-harness.sh --task <task-id> --agent <claude|codex> [options]
+Usage: scripts/eval-agent-harness.sh --task <task-id> --agent <codex> [options]
 
 Run an agent against a workbench task and score the result.
 
 Options:
   --task <id>          Task ID (e.g., go-01, py-04, ops-01)
-  --agent <name>       Agent CLI to use: claude or codex
+  --agent <name>       Agent CLI to use: codex
   --prompt <text>      Override the default prompt (ignores prompt.md)
   --generic-prompt     Force generic prompt even when prompt.md exists
   --timeout <secs>     Agent invocation timeout (default: 120)
@@ -102,22 +102,15 @@ run_agent() {
   fi
 
   case "$AGENT" in
-    claude)
-      if [[ ${#agent_env[@]} -gt 0 ]]; then
-        env "${agent_env[@]}" timeout "$TIMEOUT" claude -p "$prompt" --allowedTools "Edit,Write,Read,Bash" >/dev/null 2>&1 || true
-      else
-        timeout "$TIMEOUT" claude -p "$prompt" --allowedTools "Edit,Write,Read,Bash" >/dev/null 2>&1 || true
-      fi
-      ;;
     codex)
       if [[ ${#agent_env[@]} -gt 0 ]]; then
-        env "${agent_env[@]}" timeout "$TIMEOUT" codex exec "$prompt" >/dev/null 2>&1 || true
+        env "${agent_env[@]}" timeout "$TIMEOUT" codex exec -C "$workspace" -s workspace-write "$prompt" >/dev/null 2>&1 || true
       else
-        timeout "$TIMEOUT" codex exec "$prompt" >/dev/null 2>&1 || true
+        timeout "$TIMEOUT" codex exec -C "$workspace" -s workspace-write "$prompt" >/dev/null 2>&1 || true
       fi
       ;;
     *)
-      echo "error: unsupported agent: $AGENT (use claude or codex)" >&2
+      echo "error: unsupported agent: $AGENT (use codex)" >&2
       exit 1
       ;;
   esac

--- a/scripts/run-rpi-phases.sh
+++ b/scripts/run-rpi-phases.sh
@@ -9,15 +9,15 @@ SCRATCH_DIR="./scratch"
 mkdir -p "$SCRATCH_DIR"
 
 echo "=== RPI Phase 1: Research (10 min timeout) ==="
-claude -p "Execute RPI Phase 1: research and write findings to disk for: ${TASK}. Do NOT plan or ask questions — just execute. Write output to ${SCRATCH_DIR}/research.md" \
-  --allowedTools "Bash,Read,Write,Grep,Glob,WebSearch,WebFetch" \
-  --timeout 600 || echo "Phase 1 timed out or failed"
+timeout 600 codex exec -C "$(pwd)" -s workspace-write \
+  "Execute RPI Phase 1: research and write findings to disk for: ${TASK}. Do NOT plan or ask questions — just execute. Write output to ${SCRATCH_DIR}/research.md" \
+  || echo "Phase 1 timed out or failed"
 
 echo ""
 echo "=== RPI Phase 2: Implement (15 min timeout) ==="
-claude -p "Execute RPI Phase 2: implement changes for: ${TASK}. Use research from ${SCRATCH_DIR}/research.md if available. Run tests after each change. Do NOT stop to plan — implement and verify." \
-  --allowedTools "Bash,Read,Write,Edit,Grep,Glob" \
-  --timeout 900 || echo "Phase 2 timed out or failed"
+timeout 900 codex exec -C "$(pwd)" -s workspace-write \
+  "Execute RPI Phase 2: implement changes for: ${TASK}. Use research from ${SCRATCH_DIR}/research.md if available. Run tests after each change. Do NOT stop to plan — implement and verify." \
+  || echo "Phase 2 timed out or failed"
 
 echo ""
 echo "=== RPI Complete ==="

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1312,7 +1312,7 @@
     {
       "name": "compile",
       "source_skill": "skills/compile",
-      "source_hash": "6c51079d716df94195bb33cd2aa656ad7e66c5af768a636414750d845ceedaad",
+      "source_hash": "882bfc8e3924c5f8ab2032a408e44e081efca29f6d644451f8e56afbc86bf212",
       "generated_hash": "28e8eeee06ffa380ed19f4129e8502c7397542b4ab4945f6c397d3a71b469233"
     },
     {
@@ -1762,7 +1762,7 @@
     {
       "name": "agy-rules-workflows",
       "source_skill": "skills/agy-rules-workflows",
-      "source_hash": "51b71233099354015a41028cb3de820cc5faa9cf6327db7aaeaaecb46bae12d5",
+      "source_hash": "480777fe167ec38c824016fbb51de26cafdfc800005d3f5cc3eaf56eba1e1732",
       "generated_hash": "932e320aaa5e56888fd1a8e63d22a3f5bbe16b7208823129ce99784b135f6000"
     },
     {
@@ -2158,7 +2158,7 @@
     {
       "name": "rch",
       "source_skill": "skills/rch",
-      "source_hash": "29000cc23607742918b3d9a69c92cbba0617954def3f53c8e7b75bbf65ba69e3",
+      "source_hash": "5766df695f6273f0f875aa21d8f4468d1bed773203cfcef7a0fb7af5e912b5e1",
       "generated_hash": "931a67d6b832fe9c2d8a957329ef23a7db99cc1720983a03574c1bd14f8134c4"
     },
     {

--- a/skills-codex/agy-rules-workflows/.agentops-generated.json
+++ b/skills-codex/agy-rules-workflows/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/agy-rules-workflows",
   "layout": "modular",
-  "source_hash": "51b71233099354015a41028cb3de820cc5faa9cf6327db7aaeaaecb46bae12d5",
+  "source_hash": "480777fe167ec38c824016fbb51de26cafdfc800005d3f5cc3eaf56eba1e1732",
   "generated_hash": "932e320aaa5e56888fd1a8e63d22a3f5bbe16b7208823129ce99784b135f6000"
 }

--- a/skills-codex/compile/.agentops-generated.json
+++ b/skills-codex/compile/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/compile",
   "layout": "modular",
-  "source_hash": "6c51079d716df94195bb33cd2aa656ad7e66c5af768a636414750d845ceedaad",
+  "source_hash": "882bfc8e3924c5f8ab2032a408e44e081efca29f6d644451f8e56afbc86bf212",
   "generated_hash": "28e8eeee06ffa380ed19f4129e8502c7397542b4ab4945f6c397d3a71b469233"
 }

--- a/skills-codex/rch/.agentops-generated.json
+++ b/skills-codex/rch/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/rch",
   "layout": "modular",
-  "source_hash": "29000cc23607742918b3d9a69c92cbba0617954def3f53c8e7b75bbf65ba69e3",
+  "source_hash": "5766df695f6273f0f875aa21d8f4468d1bed773203cfcef7a0fb7af5e912b5e1",
   "generated_hash": "931a67d6b832fe9c2d8a957329ef23a7db99cc1720983a03574c1bd14f8134c4"
 }

--- a/skills/agy-rules-workflows/scripts/close-guard.sh
+++ b/skills/agy-rules-workflows/scripts/close-guard.sh
@@ -22,10 +22,10 @@ esac
 
 # Extract the bead id (best-effort: first token after 'close').
 bead="$(printf '%s\n' "$cmd" | sed -nE 's/.*(br|bd) close[[:space:]]+([A-Za-z0-9_-]+).*/\2/p' | head -1)"
+[ -n "$bead" ] || exit 0
 
 # --- IMPLEMENT: confirm the bead carries captured evidence before allowing close
 # Example shape (uncomment + adapt to your tracker):
-#   [ -n "$bead" ] || exit 0
 #   ev="$(br show "$bead" --json 2>/dev/null | jq -r '.evidence // empty' || true)"
 #   [ -n "$ev" ] || { echo "close-guard: bead $bead has no captured evidence (Rule 2)" >&2; exit 1; }
 #   [ -f ".agents/ratchet/$bead.md" ] || { echo "close-guard: bead $bead not persisted (Rule 5)" >&2; exit 1; }

--- a/skills/compile/SKILL.md
+++ b/skills/compile/SKILL.md
@@ -54,14 +54,14 @@ Set `AGENTOPS_COMPILE_RUNTIME` to choose the LLM backend:
 
 | Value | Backend | Notes |
 |-------|---------|-------|
-| `claude-cli` | Local `claude` binary | Zero-config. Inherits your Claude Code auth — no API key needed. Auto-selected if `claude` is on PATH and nothing else is set. |
+| `codex-cli` | Local `codex` binary | Zero-config. Inherits your Codex CLI auth — no API key needed. Auto-selected if `codex` is on PATH and nothing else is set. |
 | `ollama` | Ollama API | Default model: `gemma3:27b`. Set `OLLAMA_HOST` for remote (e.g., `ssh -L 11435:localhost:11435 bushido-windows`). |
 | `claude` | Claude API (HTTP) | Uses `ANTHROPIC_API_KEY`. Model: `claude-sonnet-4-20250514`. |
 | `openai` | OpenAI-compatible | Uses `OPENAI_API_KEY` + `OPENAI_BASE_URL`. |
 | (unset) | Claude Code session | Compilation happens inline via the current session's LLM. |
 
 When `AGENTOPS_COMPILE_RUNTIME` is unset, `ao compile` first tries to
-auto-detect a local `claude` binary (claude-cli runtime). If that is also
+auto-detect a local `codex` binary (codex-cli runtime). If that is also
 absent, headless compile fails fast with an explicit error naming the env var
 to set. Interactive `/compile` invocations still run compilation prompts
 inline — the agent reading this SKILL.md IS the compiler.
@@ -78,7 +78,7 @@ compile:
 ```
 
 Precedence (high → low): `--runtime` flag, `AGENTOPS_COMPILE_RUNTIME`
-env, `compile.preferred_runtime` config, `claude`-binary auto-detect,
+env, `compile.preferred_runtime` config, `codex`-binary auto-detect,
 empty (error).
 
 ### Large-corpus batching

--- a/skills/compile/scripts/compile.sh
+++ b/skills/compile/scripts/compile.sh
@@ -12,7 +12,7 @@ HASH_FILE=""
 RUNTIME="${AGENTOPS_COMPILE_RUNTIME:-}"
 OLLAMA_MODEL="${AGENTOPS_COMPILE_MODEL:-gemma3:27b}"
 CLAUDE_MODEL="${AGENTOPS_COMPILE_CLAUDE_MODEL:-claude-sonnet-4-20250514}"
-CLAUDE_CLI_MODEL="${AGENTOPS_COMPILE_CLAUDE_CLI_MODEL:-}"
+CODEX_CLI_MODEL="${AGENTOPS_COMPILE_CODEX_CLI_MODEL:-}"
 OLLAMA_API="${OLLAMA_HOST:-http://localhost:11434}"
 BATCH_SIZE="${AGENTOPS_COMPILE_BATCH_SIZE:-25}"
 MAX_BATCHES="${AGENTOPS_COMPILE_MAX_BATCHES:-0}"  # 0 = unlimited
@@ -119,21 +119,20 @@ print(json.dumps({
         -H "anthropic-version: 2023-06-01" \
         -d "$payload" | python3 -c "import sys,json; print(json.load(sys.stdin)['content'][0]['text'])"
       ;;
-    claude-cli)
-      # Use the locally installed `claude` binary in headless (-p) mode.
-      # No API key required; inherits the user's Claude Code auth.
-      if ! command -v claude &>/dev/null; then
-        echo "ERROR: claude-cli runtime requested but 'claude' binary not on PATH." >&2
+    codex|codex-cli)
+      # Use the local Codex CLI subscription runtime for headless compilation.
+      if ! command -v codex &>/dev/null; then
+        echo "ERROR: codex-cli runtime requested but 'codex' binary not on PATH." >&2
         exit 1
       fi
       local combined="${system_prompt}
 
 ${user_prompt}"
-      if [[ -n "$CLAUDE_CLI_MODEL" ]]; then
-        printf '%s' "$combined" | claude -p --model "$CLAUDE_CLI_MODEL" 2>/dev/null
-      else
-        printf '%s' "$combined" | claude -p 2>/dev/null
+      local -a codex_cmd=(codex exec -C "$(pwd)" -s read-only)
+      if [[ -n "$CODEX_CLI_MODEL" ]]; then
+        codex_cmd+=(-m "$CODEX_CLI_MODEL")
       fi
+      printf '%s' "$combined" | "${codex_cmd[@]}" -
       ;;
     openai)
       local payload
@@ -153,10 +152,10 @@ print(json.dumps({
         -d "$payload" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'])"
       ;;
     *)
-      echo "ERROR: AGENTOPS_COMPILE_RUNTIME must be set to one of: ollama, claude, claude-cli, openai." >&2
+      echo "ERROR: AGENTOPS_COMPILE_RUNTIME must be set to one of: codex-cli, ollama, claude, openai." >&2
       echo "" >&2
       echo "Pick one of these that matches what you have installed:" >&2
-      echo "  export AGENTOPS_COMPILE_RUNTIME=claude-cli   # uses local 'claude' binary, no API key needed" >&2
+      echo "  export AGENTOPS_COMPILE_RUNTIME=codex-cli   # uses local 'codex' binary, no API key needed" >&2
       echo "  export AGENTOPS_COMPILE_RUNTIME=ollama       # needs OLLAMA_HOST (default http://localhost:11434)" >&2
       echo "  export AGENTOPS_COMPILE_RUNTIME=claude       # needs ANTHROPIC_API_KEY" >&2
       echo "  export AGENTOPS_COMPILE_RUNTIME=openai       # needs OPENAI_API_KEY" >&2
@@ -171,17 +170,17 @@ print(json.dumps({
 
 preflight_runtime() {
   case "$RUNTIME" in
-    claude-cli)
-      if ! command -v claude &>/dev/null; then
-        echo "ERROR: runtime=claude-cli but 'claude' binary is not on PATH." >&2
-        echo "Install Claude Code or switch runtime: export AGENTOPS_COMPILE_RUNTIME=ollama" >&2
+    codex|codex-cli)
+      if ! command -v codex &>/dev/null; then
+        echo "ERROR: runtime=codex-cli but 'codex' binary is not on PATH." >&2
+        echo "Install Codex CLI or switch runtime: export AGENTOPS_COMPILE_RUNTIME=ollama" >&2
         return 1
       fi
       ;;
     claude)
       if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
         echo "ERROR: runtime=claude but ANTHROPIC_API_KEY is not set." >&2
-        echo "Either export ANTHROPIC_API_KEY=... or switch: export AGENTOPS_COMPILE_RUNTIME=claude-cli" >&2
+        echo "Either export ANTHROPIC_API_KEY=... or switch: export AGENTOPS_COMPILE_RUNTIME=codex-cli" >&2
         return 1
       fi
       ;;
@@ -205,7 +204,7 @@ preflight_runtime() {
       return 1
       ;;
     *)
-      echo "ERROR: unknown runtime '$RUNTIME'. Expected one of: ollama, claude, claude-cli, openai." >&2
+      echo "ERROR: unknown runtime '$RUNTIME'. Expected one of: codex-cli, ollama, claude, openai." >&2
       return 1
       ;;
   esac

--- a/skills/rch/scripts/mine_rch_history.sh
+++ b/skills/rch/scripts/mine_rch_history.sh
@@ -28,15 +28,15 @@ require() { command -v "$1" >/dev/null 2>&1 || { echo "missing: $1" >&2; exit 12
 require rg
 
 ROOTS=(
-  "\$HOME/.claude/projects"
-  "\$HOME/.codex/sessions"
-  "\$HOME/.gemini/tmp"
-  "\$HOME/.cursor/logs"
+  "$HOME/.claude/projects"
+  "$HOME/.codex/sessions"
+  "$HOME/.gemini/tmp"
+  "$HOME/.cursor/logs"
 )
 
 run_search_local() {
   for r in "${ROOTS[@]}"; do
-    eval "real=$r"
+    local real="$r"
     [[ -d "$real" ]] || continue
     printf '\n## %s\n' "$real"
     rg --type-add 'jsonl:*.jsonl' --type jsonl --type json -l --no-messages "$PATTERN" "$real" 2>/dev/null \


### PR DESCRIPTION
## Summary
- replace AgentOps headless Claude print worker paths with Codex exec or non-CLI providers
- switch compile auto-detect/default headless CLI runtime from claude-cli to codex-cli
- fix two shellcheck blockers from the merged skill corpus and refresh generated docs/hash metadata

## Validation
- bash /Users/bo/acfs/skill-pipeline/scripts/no-api-print-scan.sh /Users/bo/dev/agentops/skills /Users/bo/dev/agentops/scripts /Users/bo/dev/agentops/hooks
- shellcheck --severity=error skills/compile/scripts/compile.sh scripts/eval-agent-harness.sh scripts/run-rpi-phases.sh skills/agy-rules-workflows/scripts/close-guard.sh skills/rch/scripts/mine_rch_history.sh
- cd cli && go test ./cmd/ao -run 'TestResolveCompileRuntime|TestPreflightCompileRuntime|TestCompileScriptOptionsPassesBatchFlags|TestRunCompile_EndToEnd_FixtureCorpus' -count=1
- bash scripts/regen-all.sh --check
- PRE_PUSH_SKIP_MKDOCS=1 bash scripts/pre-push-gate.sh --fast

Note: unscoped /Users/bo/acfs/skill-pipeline/scripts/no-api-print-scan.sh still flags ACFS conformance-selftest fixture strings outside this repo; AgentOps scoped roots are clean.