### PR TITLE
docs(ntm): document Codex spawn fallback

### DIFF
--- a/.agy-plugin/skills/ntm/SKILL.md
+++ b/.agy-plugin/skills/ntm/SKILL.md
@@ -193,6 +193,10 @@ ntm quick myproject --template=go
 # Launch a mixed swarm
 ntm spawn myproject --cc=2 --cod=1 --gmi=1
 
+# Codex fallback when --cod opens a bare shell instead of Codex
+codex exec -s danger-full-access --skip-git-repo-check -C "$PWD" \
+  "Read AGENTS.md, claim the assigned bead, implement only that scope, and report evidence."
+
 # Dispatch work
 ntm send myproject --cc "Map the auth layer and propose a refactor plan."
 
@@ -281,6 +285,33 @@ ntm swarm stop <pattern>                  # stop sessions by name pattern
 ntm respawn myproject                     # recover dead agents in place
 ntm adopt <tmux-session>                  # bring an existing tmux session under ntm
 ```
+
+### Codex spawn fallback
+
+Treat `ntm spawn <project> --cod=N` as **provisional until observed**. Some local
+NTM builds have created and registered the `cod` pane but left it at a bare `zsh`
+prompt; the next sent "contract" then executes as shell text and fails with parse or
+`command not found` noise.
+
+Verification:
+
+```bash
+ntm spawn myproject --cod=1
+ntm --robot-tail=myproject --panes=2 --lines=20
+ntm --robot-snapshot
+```
+
+If the Codex pane is a shell instead of an active `codex` session, **do not** keep
+sending prompts to that pane. Use a Codex-native one-shot worker from the repo root
+or the intended worktree:
+
+```bash
+codex exec -s danger-full-access --skip-git-repo-check -C /path/to/gitdir \
+  "Read AGENTS.md, claim bead <id>, implement only that scope, run the gate, and report evidence."
+```
+
+For parallel lanes, prefer one `codex exec -C <isolated-worktree>` per worker until
+the live NTM `--cod` launcher is verified fixed by `--robot-tail` evidence.
 
 ## Dispatch and Reusable Assets
 
@@ -564,6 +595,8 @@ These are the NTM-specific trip-wires most commonly hit in practice. Each has a 
 15. **Agent Mail can be degraded without blocking work** — if the mail/reservation source in `sources` is stale/unavailable or reservations time out, stop retry loops and use bead assignee/status notes as the temporary soft lock.
 16. **`locks check` is for wrappers and commit guards** — it returns `free|held|blocked` for one path and caller context; use it instead of inventing per-wrapper reservation ledgers.
 17. **`--oc` is opencode** — if a prompt or profile says "opencode" but no agent appears, check `[agents] oc` config or that `opencode` is on PATH.
+18. **`--cod` must be observed before use** — if a Codex pane is just a bare shell,
+    stop sending prompts to it and run `codex exec -s danger-full-access --skip-git-repo-check -C <gitdir> "<contract>"` from an isolated repo/worktree instead.
 
 ## Reference Index
 

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -2092,8 +2092,8 @@
     {
       "name": "ntm",
       "source_skill": "skills/ntm",
-      "source_hash": "18426bb2e7d719d2483f160e0b4939efb33148d6bd738436b93fe4ade4d83be0",
-      "generated_hash": "88878059f23dc99cc06b02efe511ad7e3a027085791ff111b54e32c61272f46a"
+      "source_hash": "872ce7c62890e6f8e3cb26a238121acb16bdcc36b2459c1b98af90657cf9c364",
+      "generated_hash": "892e76dd5a98a33d79929db7af13610d836ba4377b4807b436a9b3171c3f051f"
     },
     {
       "name": "ntm-browser-test-coordination",

--- a/skills-codex/ntm/.agentops-generated.json
+++ b/skills-codex/ntm/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/ntm",
   "layout": "modular",
-  "source_hash": "18426bb2e7d719d2483f160e0b4939efb33148d6bd738436b93fe4ade4d83be0",
-  "generated_hash": "88878059f23dc99cc06b02efe511ad7e3a027085791ff111b54e32c61272f46a"
+  "source_hash": "872ce7c62890e6f8e3cb26a238121acb16bdcc36b2459c1b98af90657cf9c364",
+  "generated_hash": "892e76dd5a98a33d79929db7af13610d836ba4377b4807b436a9b3171c3f051f"
 }

--- a/skills-codex/ntm/prompt.md
+++ b/skills-codex/ntm/prompt.md
@@ -15,6 +15,9 @@ Orchestrates NTM tmux agent swarms and robot APIs. Use when spawning/sending pan
 
 - Do not use Claude Code, `claude -p`, or Claude-only tools as the executor from Codex.
 - Do not invent command flags. Verify with `--help` or checked-in references.
+- If `ntm spawn ... --cod` opens a bare shell instead of an active Codex runtime,
+  treat it as launcher failure. Use `codex exec -s danger-full-access --skip-git-repo-check -C <gitdir> "<contract>"`
+  from the repo or isolated worktree; do not send the contract into zsh.
 - Do not broaden scope beyond the requested operator action.
 - Do not land source files into `~/dev/agentops`; staged generation belongs under `$HOME/acfs` until the orchestrator lands the batch.
 - Keep backstage/operator terminology out of client-facing artifacts.

--- a/skills/ntm/SKILL.md
+++ b/skills/ntm/SKILL.md
@@ -193,6 +193,10 @@ ntm quick myproject --template=go
 # Launch a mixed swarm
 ntm spawn myproject --cc=2 --cod=1 --gmi=1
 
+# Codex fallback when --cod opens a bare shell instead of Codex
+codex exec -s danger-full-access --skip-git-repo-check -C "$PWD" \
+  "Read AGENTS.md, claim the assigned bead, implement only that scope, and report evidence."
+
 # Dispatch work
 ntm send myproject --cc "Map the auth layer and propose a refactor plan."
 
@@ -281,6 +285,33 @@ ntm swarm stop <pattern>                  # stop sessions by name pattern
 ntm respawn myproject                     # recover dead agents in place
 ntm adopt <tmux-session>                  # bring an existing tmux session under ntm
 ```
+
+### Codex spawn fallback
+
+Treat `ntm spawn <project> --cod=N` as **provisional until observed**. Some local
+NTM builds have created and registered the `cod` pane but left it at a bare `zsh`
+prompt; the next sent "contract" then executes as shell text and fails with parse or
+`command not found` noise.
+
+Verification:
+
+```bash
+ntm spawn myproject --cod=1
+ntm --robot-tail=myproject --panes=2 --lines=20
+ntm --robot-snapshot
+```
+
+If the Codex pane is a shell instead of an active `codex` session, **do not** keep
+sending prompts to that pane. Use a Codex-native one-shot worker from the repo root
+or the intended worktree:
+
+```bash
+codex exec -s danger-full-access --skip-git-repo-check -C /path/to/gitdir \
+  "Read AGENTS.md, claim bead <id>, implement only that scope, run the gate, and report evidence."
+```
+
+For parallel lanes, prefer one `codex exec -C <isolated-worktree>` per worker until
+the live NTM `--cod` launcher is verified fixed by `--robot-tail` evidence.
 
 ## Dispatch and Reusable Assets
 
@@ -564,6 +595,8 @@ These are the NTM-specific trip-wires most commonly hit in practice. Each has a 
 15. **Agent Mail can be degraded without blocking work** — if the mail/reservation source in `sources` is stale/unavailable or reservations time out, stop retry loops and use bead assignee/status notes as the temporary soft lock.
 16. **`locks check` is for wrappers and commit guards** — it returns `free|held|blocked` for one path and caller context; use it instead of inventing per-wrapper reservation ledgers.
 17. **`--oc` is opencode** — if a prompt or profile says "opencode" but no agent appears, check `[agents] oc` config or that `opencode` is on PATH.
+18. **`--cod` must be observed before use** — if a Codex pane is just a bare shell,
+    stop sending prompts to it and run `codex exec -s danger-full-access --skip-git-repo-check -C <gitdir> "<contract>"` from an isolated repo/worktree instead.
 
 ## Reference Index
 

--- a/skills/ntm/references/SPAWN.md
+++ b/skills/ntm/references/SPAWN.md
@@ -61,6 +61,30 @@ Ollama specifics:
 - `--local-fallback` converts local agents to cloud if preflight fails (`spawn.go:1218`).
 - `--local-fallback-provider` `cc|cod|gmi`, default `cod` (`spawn.go:1219`).
 
+### Codex launcher verification and fallback
+
+`--cod` creates Codex-typed panes, but treat the launcher as verified only after
+robot observation. If `ntm spawn <project> --cod=1` leaves the pane at a bare `zsh`
+prompt, the next prompt will be parsed by the shell rather than Codex.
+
+Verify before dispatch:
+
+```bash
+ntm spawn myproject --cod=1
+ntm --robot-tail=myproject --panes=2 --lines=20
+ntm --robot-snapshot
+```
+
+If the pane is not an active Codex session, use Codex directly from the target repo
+or isolated worktree:
+
+```bash
+codex exec -s danger-full-access --skip-git-repo-check -C /path/to/gitdir \
+  "Read AGENTS.md, claim bead <id>, implement only that scope, run the gate, and report evidence."
+```
+
+Do not paste or send the worker contract into a bare shell pane.
+
 ## Pane layout
 
 | Flag | Effect | Source |

--- a/skills/ntm/references/TROUBLESHOOTING.md
+++ b/skills/ntm/references/TROUBLESHOOTING.md
@@ -7,6 +7,7 @@ Grouped by family, most common first.
 
 - [Project resolution](#project-resolution) — `project not found`, agent-mail key drift
 - [`ntm send` surprises](#ntm-send-surprises) — broadcast to user pane, CASS dedup, missing `--pane`
+- [Codex spawn fallback](#codex-spawn-fallback) — `--cod` pane opened as bare shell
 - [Rate limits and pane state](#rate-limits-and-pane-state) — `resets 3pm`, `RATE_LIMITED`
 - [Approvals and tokens](#approvals-and-tokens) — `ntm approve` takes token, not bead id
 - [Commands that don't exist / migrated](#commands-that-dont-exist--migrated) — `timeline`, `changes conflicts`, `--mail-project` scope
@@ -98,6 +99,34 @@ ntm send myproject --pane=2 "..."
 # or
 ntm send myproject --cc "..."   # all Claude panes, excludes user pane by default
 ```
+
+## Codex spawn fallback
+
+### `ntm spawn --cod=1` opened a bare `zsh` shell
+
+**Symptom** — The pane is titled/registered as a Codex agent, but the visible prompt
+is a normal shell. A sent worker contract then hits `zsh` and fails with parse errors
+or `command not found`.
+
+**Root cause** — The Codex pane was created and registered, but the local launcher did
+not start the `codex` runtime inside it. The NTM control-plane state alone is not proof
+that the pane is executing Codex.
+
+**Fix** — Verify `--cod` panes before dispatch and fall back to a Codex-native worker
+when the pane is a shell:
+
+```bash
+ntm spawn myproject --cod=1
+ntm --robot-tail=myproject --panes=2 --lines=20
+ntm --robot-snapshot
+
+codex exec -s danger-full-access --skip-git-repo-check -C /path/to/gitdir \
+  "Read AGENTS.md, claim bead <id>, implement only that scope, run the gate, and report evidence."
+```
+
+Do not keep using `ntm send` against the bare shell pane. For concurrent Codex lanes,
+use one isolated worktree per `codex exec -C <worktree>` worker until `--cod` is
+verified fixed by robot-tail evidence.
 
 ## Rate limits and pane state
 


### PR DESCRIPTION
## Summary
- Document that NTM `--cod` panes must be observed before use because a local launcher can create a bare shell instead of an active Codex runtime.
- Add the reliable `codex exec -s danger-full-access --skip-git-repo-check -C <gitdir>` fallback to the NTM source skill, spawn reference, troubleshooting guide, Codex wrapper, and AGY bundled copy.
- Refresh Codex generated metadata for `ntm`.

## Validation
- bash scripts/refresh-codex-artifacts.sh --scope worktree
- bash scripts/validate-agy-plugin.sh
- bash scripts/validate-codex-generated-artifacts.sh --scope worktree
- bash scripts/regen-all.sh --check
- git diff --check
- PRE_PUSH_SKIP_MKDOCS=1 bash scripts/pre-push-gate.sh --fast (passes; existing warn-only executable-spec drift remains: scenarios --lint, trace --orphans)

BR: cp-ou6