### PR TITLE
docs(agent-mail): clarify side-channel role

### DIFF
--- a/.agy-plugin/skills/agent-mail/SKILL.md
+++ b/.agy-plugin/skills/agent-mail/SKILL.md
@@ -9,11 +9,24 @@ description: "Use when coordinating agents with Agent Mail locks, inboxes, threa
 practices:
 - pragmatic-programmer
 ---
-<!-- TOC: Bootstrap | Core Ops | File Reservations | Beads | Troubleshooting | Identity | Human Overseer | Pre-Commit Guard | References -->
+<!-- TOC: Boundary | Bootstrap | Core Ops | File Reservations | Beads | Troubleshooting | Identity | Human Overseer | Pre-Commit Guard | References -->
 
 # Using MCP Agent Mail
 
-> **Core Insight:** Without coordination, multiple agents overwrite each other's work. Agent Mail provides identities, messaging, and file reservations to prevent conflicts.
+> **Core Insight:** Agent Mail is the side channel for leases, notifications, acknowledgements, and handoffs. BR/beads is the durable coordination bus and source of truth for work state, evidence, and decisions.
+
+## Coordination Boundary
+
+| Need | Source of truth |
+|------|-----------------|
+| Work queue, status, dependencies, priority, closure evidence | BR/beads (`br`/`bv`) |
+| File ownership, active edit leases, lane notifications, acks | Agent Mail |
+| Final proof that work is done | Bead notes/closure plus git/CI evidence |
+| "Who may write this hot path right now?" | Agent Mail file reservation |
+
+Use Agent Mail to prevent collisions and notify active agents. Do not use it as the durable task queue, audit log, or final evidence store. If a mail thread and BR disagree, reconcile the bead first and link the mail thread from the bead note if the conversation matters.
+
+One-writer-per-hot-dir rule: reserve the path before editing it. If the reservation conflicts, do not write into that path; coordinate with the holder, narrow scope, or wait for the lease to clear.
 
 ## When to Use What
 
@@ -23,6 +36,7 @@ practices:
 | About to edit files | `file_reservation_paths` → edit → `release_file_reservations` |
 | Need to tell another agent something | `send_message` with `thread_id` |
 | Picking up someone else's work | `macro_prepare_thread` |
+| Need durable work state or evidence | Update BR/beads, then link the mail thread if useful |
 | Can't message an agent | `request_contact` → wait for approval |
 | Server seems broken | Use `health_check()` first; CLI-only: `doctor check --verbose` → `doctor repair --yes` |
 
@@ -35,7 +49,7 @@ practices:
 ```
 macro_start_session(
   human_key="/abs/path/to/project",
-  program="claude-code",
+  program="codex-cli",
   model="YOUR_MODEL",
   task_description="Working on auth module"
 )
@@ -113,17 +127,20 @@ release_file_reservations(project_key="/abs/path/project", agent_name="GreenCast
 
 ## Beads Integration
 
-Use bead IDs as your threading anchor:
+Use bead IDs as your threading anchor. BR remains authoritative; mail carries the lease, notification, and discussion side channel.
 
 ```
 1. Pick work:        br ready --json → choose bd-123
 2. Reserve files:    file_reservation_paths(..., reason="bd-123")
 3. Announce:         send_message(..., thread_id="bd-123", subject="[bd-123] Starting...")
 4. Work:             Reply in thread with progress
-5. Complete:         br close bd-123, release_file_reservations(...), final message
+5. Record evidence:  br update bd-123 --notes "Validation: tests, commit, CI, or handoff proof"
+6. Complete:         br close bd-123, release_file_reservations(...), final message
 ```
 
 **Bead ID (often bd-###) goes in:** thread_id, subject prefix, reservation reason, commit message
+
+**Do not infer durable state from mail silence.** A missing reply is not proof that a bead is abandoned, blocked, or complete. Check `br show <id> --json`, `bv --robot-insights`, git state, and CI evidence before changing work state.
 
 ---
 
@@ -165,7 +182,7 @@ Agents get adjective+noun names: GreenCastle, BlueLake, RedBear.
 ```
 register_agent(
   project_key="/abs/path/project",
-  program="claude-code",
+  program="codex-cli",
   model="YOUR_MODEL",
   task_description="Auth refactor"
 )  # name auto-generated

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1750,8 +1750,8 @@
     {
       "name": "agent-mail",
       "source_skill": "skills/agent-mail",
-      "source_hash": "47ac0e2bbb0305c63ed45678eaa25a2171370c17457ada6137ca37f539ca4218",
-      "generated_hash": "446d988bddb4c4a0cb70fb35092e250a02434f2cce5b78b612effd46ba26ff53"
+      "source_hash": "5f99f9052efade45436c2ea60801eb0a38cf0cd00f1072462987feea7dcb3a22",
+      "generated_hash": "e66befdbae502fe31a8b1094e7ff90c6779abfdd6ec01723c65cfa641a346ae6"
     },
     {
       "name": "agy-native",

--- a/skills-codex/agent-mail/.agentops-generated.json
+++ b/skills-codex/agent-mail/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/agent-mail",
   "layout": "modular",
-  "source_hash": "47ac0e2bbb0305c63ed45678eaa25a2171370c17457ada6137ca37f539ca4218",
-  "generated_hash": "446d988bddb4c4a0cb70fb35092e250a02434f2cce5b78b612effd46ba26ff53"
+  "source_hash": "5f99f9052efade45436c2ea60801eb0a38cf0cd00f1072462987feea7dcb3a22",
+  "generated_hash": "e66befdbae502fe31a8b1094e7ff90c6779abfdd6ec01723c65cfa641a346ae6"
 }

--- a/skills-codex/agent-mail/SKILL.md
+++ b/skills-codex/agent-mail/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-mail
-description: "Run agent mail."
+description: "Use Agent Mail from Codex for file leases, notifications, inboxes, and conflict prevention."
 ---
 
 # agent-mail (Codex)
@@ -16,5 +16,6 @@ Read it first, then use `prompt.md` for the Codex runtime profile.
 - Use Codex plus the local shell. Do not invoke Claude Code as an executor.
 - Load only the relevant source references or scripts for the task.
 - Prefer robot/JSON/NDJSON command surfaces when the source skill exposes them.
+- Keep durable task state, evidence, and closure in BR/beads; use Agent Mail as the side channel for leases and pings.
 - Verify command syntax from local `--help` or checked-in references before acting.
 - Return concrete evidence: commands run, files touched, exit codes, and any remaining blocker.

--- a/skills-codex/agent-mail/prompt.md
+++ b/skills-codex/agent-mail/prompt.md
@@ -1,6 +1,6 @@
 # Codex Execution Profile -- agent-mail
 
-MCP Agent Mail for multi-agent coordination. Use when agents need file locks, messaging, inboxes, or conflict prevention. Handles macro_start_session, file_reservation_paths, send_message, threading, pre-commit guards.
+MCP Agent Mail for multi-agent coordination side-channel work. Use when agents need file leases, lane notifications, inboxes, acknowledgements, or conflict prevention. Keep durable work state, evidence, and closure in BR/beads; Agent Mail carries leases and pings.
 
 ## Steps
 
@@ -8,13 +8,14 @@ MCP Agent Mail for multi-agent coordination. Use when agents need file locks, me
 2. Load only the source `references/*` or `scripts/*` files needed for that path.
 3. Confirm live command syntax with local `--help`, repo docs, or the source skill's evidence before running state-changing commands.
 4. Execute with Codex-native tools: local shell, `rg`, `apply_patch`, repo scripts, and AgentOps/ACFS binaries as directed by the source skill.
-5. Capture machine-checkable evidence: command, exit code, affected paths, and validation output.
+5. Capture machine-checkable evidence: command, exit code, affected paths, validation output, and the BR/bead state updated for durable record.
 6. If the source skill is still being upgraded by the Claude lane, do not rewrite it. Report the missing source-side contract and keep this Codex wrapper intact.
 
 ## Guardrails
 
 - Do not use Claude Code, `claude -p`, or Claude-only tools as the executor from Codex.
 - Do not invent command flags. Verify with `--help` or checked-in references.
+- Do not treat mail threads as the source of truth for work status; reconcile conflicts in BR/beads first.
 - Do not broaden scope beyond the requested operator action.
 - Do not land source files into `~/dev/agentops`; staged generation belongs under `$HOME/acfs` until the orchestrator lands the batch.
 - Keep backstage/operator terminology out of client-facing artifacts.

--- a/skills/agent-mail/SKILL.md
+++ b/skills/agent-mail/SKILL.md
@@ -9,11 +9,24 @@ description: "Use when coordinating agents with Agent Mail locks, inboxes, threa
 practices:
 - pragmatic-programmer
 ---
-<!-- TOC: Bootstrap | Core Ops | File Reservations | Beads | Troubleshooting | Identity | Human Overseer | Pre-Commit Guard | References -->
+<!-- TOC: Boundary | Bootstrap | Core Ops | File Reservations | Beads | Troubleshooting | Identity | Human Overseer | Pre-Commit Guard | References -->
 
 # Using MCP Agent Mail
 
-> **Core Insight:** Without coordination, multiple agents overwrite each other's work. Agent Mail provides identities, messaging, and file reservations to prevent conflicts.
+> **Core Insight:** Agent Mail is the side channel for leases, notifications, acknowledgements, and handoffs. BR/beads is the durable coordination bus and source of truth for work state, evidence, and decisions.
+
+## Coordination Boundary
+
+| Need | Source of truth |
+|------|-----------------|
+| Work queue, status, dependencies, priority, closure evidence | BR/beads (`br`/`bv`) |
+| File ownership, active edit leases, lane notifications, acks | Agent Mail |
+| Final proof that work is done | Bead notes/closure plus git/CI evidence |
+| "Who may write this hot path right now?" | Agent Mail file reservation |
+
+Use Agent Mail to prevent collisions and notify active agents. Do not use it as the durable task queue, audit log, or final evidence store. If a mail thread and BR disagree, reconcile the bead first and link the mail thread from the bead note if the conversation matters.
+
+One-writer-per-hot-dir rule: reserve the path before editing it. If the reservation conflicts, do not write into that path; coordinate with the holder, narrow scope, or wait for the lease to clear.
 
 ## When to Use What
 
@@ -23,6 +36,7 @@ practices:
 | About to edit files | `file_reservation_paths` → edit → `release_file_reservations` |
 | Need to tell another agent something | `send_message` with `thread_id` |
 | Picking up someone else's work | `macro_prepare_thread` |
+| Need durable work state or evidence | Update BR/beads, then link the mail thread if useful |
 | Can't message an agent | `request_contact` → wait for approval |
 | Server seems broken | Use `health_check()` first; CLI-only: `doctor check --verbose` → `doctor repair --yes` |
 
@@ -35,7 +49,7 @@ practices:
 ```
 macro_start_session(
   human_key="/abs/path/to/project",
-  program="claude-code",
+  program="codex-cli",
   model="YOUR_MODEL",
   task_description="Working on auth module"
 )
@@ -113,17 +127,20 @@ release_file_reservations(project_key="/abs/path/project", agent_name="GreenCast
 
 ## Beads Integration
 
-Use bead IDs as your threading anchor:
+Use bead IDs as your threading anchor. BR remains authoritative; mail carries the lease, notification, and discussion side channel.
 
 ```
 1. Pick work:        br ready --json → choose bd-123
 2. Reserve files:    file_reservation_paths(..., reason="bd-123")
 3. Announce:         send_message(..., thread_id="bd-123", subject="[bd-123] Starting...")
 4. Work:             Reply in thread with progress
-5. Complete:         br close bd-123, release_file_reservations(...), final message
+5. Record evidence:  br update bd-123 --notes "Validation: tests, commit, CI, or handoff proof"
+6. Complete:         br close bd-123, release_file_reservations(...), final message
 ```
 
 **Bead ID (often bd-###) goes in:** thread_id, subject prefix, reservation reason, commit message
+
+**Do not infer durable state from mail silence.** A missing reply is not proof that a bead is abandoned, blocked, or complete. Check `br show <id> --json`, `bv --robot-insights`, git state, and CI evidence before changing work state.
 
 ---
 
@@ -165,7 +182,7 @@ Agents get adjective+noun names: GreenCastle, BlueLake, RedBear.
 ```
 register_agent(
   project_key="/abs/path/project",
-  program="claude-code",
+  program="codex-cli",
   model="YOUR_MODEL",
   task_description="Auth refactor"
 )  # name auto-generated

--- a/skills/agent-mail/references/CROSS-PROJECT.md
+++ b/skills/agent-mail/references/CROSS-PROJECT.md
@@ -12,8 +12,8 @@ Use the same `project_key` for related repos. Agents auto-coordinate.
 # Both agents use same project_key
 macro_start_session(
   human_key="/abs/path/monorepo",
-  program="claude-code",
-  model="opus-4.5"
+  program="codex-cli",
+  model="YOUR_MODEL"
 )
 ```
 

--- a/skills/agent-mail/references/TOOLS.md
+++ b/skills/agent-mail/references/TOOLS.md
@@ -30,7 +30,7 @@ Register identity in project.
 ```
 register_agent(
   project_key="/abs/path/project",
-  program="claude-code",
+  program="codex-cli",
   model="YOUR_MODEL",
   name="GreenCastle",        # Optional, auto-generates if omitted
   task_description="Auth work"
@@ -64,7 +64,7 @@ Always create new unique agent (never updates existing).
 ```
 create_agent_identity(
   project_key="/abs/path/project",
-  program="claude-code",
+  program="codex-cli",
   model="YOUR_MODEL",
   name_hint="GreenCastle"    # Optional
 )
@@ -301,7 +301,7 @@ One-call bootstrap.
 ```
 macro_start_session(
   human_key="/abs/path/project",
-  program="claude-code",
+  program="codex-cli",
   model="YOUR_MODEL",
   task_description="Auth refactor",
   file_reservation_paths=["src/auth/**"],
@@ -319,7 +319,7 @@ Join existing thread with context.
 macro_prepare_thread(
   project_key="/abs/path/project",
   thread_id="bd-123",
-  program="claude-code",
+  program="codex-cli",
   model="YOUR_MODEL",
   include_examples=true,
   inbox_limit=10

--- a/skills/agent-mail/references/WORKFLOWS.md
+++ b/skills/agent-mail/references/WORKFLOWS.md
@@ -11,13 +11,13 @@
 
 ## Standard Bead Workflow
 
-The canonical workflow for working on a bead with coordination.
+The canonical workflow for working on a bead with coordination. BR/beads is the durable bus for status, ownership, priority, dependencies, and completion evidence. Agent Mail is the side channel for file reservations, lane notifications, acknowledgements, and handoff messages.
 
 ### Steps
 
 ```
 1. Bootstrap session
-   macro_start_session(human_key="/abs/path", program="claude-code", model="YOUR_MODEL")
+   macro_start_session(human_key="/abs/path", program="codex-cli", model="YOUR_MODEL")
 
 2. Pick work
    br ready --json → select bd-123
@@ -45,8 +45,10 @@ The canonical workflow for working on a bead with coordination.
    - Make changes
    - Periodically check inbox
    - Reply in thread with progress updates
+   - Keep durable state/evidence on the bead, not only in mail
 
 6. Complete
+   br update bd-123 --notes "Validation: npm test, CI run 123, commit abc123"
    br close bd-123 --reason "Implemented OAuth flow"
    release_file_reservations(project_key="/abs/path", agent_name="GreenCastle")
    send_message(
@@ -55,6 +57,12 @@ The canonical workflow for working on a bead with coordination.
      body_md="OAuth flow implemented. Ready for review."
    )
 ```
+
+If the mail thread and BR disagree, fix BR first. Treat the mail thread as context that may be cited from the bead, not as the work record itself.
+
+### One-Writer Rule
+
+Before editing any hot path, acquire an exclusive Agent Mail reservation for the exact directory or file set. If the reservation conflicts, do not write there. Message the holder in the bead thread, split the scope, or wait for the lease to expire. This is the lane boundary that keeps parallel workers from corrupting each other's files.
 
 ---
 
@@ -170,7 +178,7 @@ release_file_reservations(project_key="/abs/path", agent_name="GreenCastle")
 macro_prepare_thread(
   project_key="/abs/path",
   thread_id="bd-123",
-  program="claude-code",
+  program="codex-cli",
   model="YOUR_MODEL"
 )
 


### PR DESCRIPTION
## Summary
- clarify that BR/beads is the durable coordination bus while Agent Mail is the side channel for leases, lane notifications, acknowledgements, and handoffs
- update Agent Mail bead workflow references to keep evidence and closure in BR
- refresh Codex agent-mail artifacts and sync the AGY bundled copy

## Validation
- bash scripts/refresh-codex-artifacts.sh --scope worktree
- bash scripts/validate-agy-plugin.sh
- bash scripts/validate-codex-generated-artifacts.sh --scope worktree
- bash scripts/regen-all.sh --check
- bash scripts/validate-manifests.sh
- git diff --check
- PRE_PUSH_SKIP_MKDOCS=1 bash scripts/pre-push-gate.sh --fast

Note: fast pre-push gate still reports existing warn-only executable-spec drift for scenarios --lint and trace --orphans.