### PR TITLE
refactor(ao): route cron self-adjust to MTO

### DIFF
--- a/REDUCTION.md
+++ b/REDUCTION.md
@@ -38,8 +38,8 @@ Current inventory count:
 
 | Bucket | Files |
 |---|---:|
-| KEEP | 450 |
-| RELOCATE | 146 |
+| KEEP | 453 |
+| RELOCATE | 143 |
 | ARCHIVE | 0 |
 | RESEARCH | 39 |
 | Total | 635 |
@@ -90,6 +90,13 @@ helpers. Legacy knowledge captures remain supported through the lean local
 flywheel path: `ao pool ingest` already scans `.agents/knowledge/*.md` when no
 explicit files are provided, and the legacy-capture e2e now exercises that
 direct ingest route.
+
+## Relocated Cron-Fire Surface
+
+The cron-fire scheduling renderer moved behind the `mto-fleet` route. AO keeps
+`ao cron self-adjust` as a compatibility shim that emits a structured route
+notice, but it no longer renders CronCreate prompts, verifies cron templates,
+or writes `.agents/evolve/cron-history.jsonl` from the lean local image.
 
 ## Reversibility
 

--- a/cli/cmd/ao/cron.go
+++ b/cli/cmd/ao/cron.go
@@ -5,24 +5,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// cronCmd is the parent command for cron-loop helpers used by the /evolve
-// loop's cron-fire continuity primitive. Today it carries `self-adjust`
-// (soc-un0m); future subcommands belong on this same parent so the operator
-// surface stays consistent ("manage the cron contract").
+// cronCmd is the compatibility parent for cron-loop helpers that moved behind
+// the MTO/factory boundary during lean-image distillation.
 var cronCmd = &cobra.Command{
 	Use:   "cron",
-	Short: "Cron-fire loop helpers (used by /evolve --mode=loop)",
-	Long: `Helpers for the /evolve --mode=loop cron-fire continuity primitive.
-
-The /evolve loop runs as a recurring cron-fire that the agent re-arms each
-cycle. These subcommands are the mechanical surfaces the agent calls to
-participate in that contract:
-
-  ao cron self-adjust ...   Render the next cycle's cron prompt from the
-                            versioned template + last-cycle context, and emit
-                            a JSON spec the harness uses to re-arm the cron.
-
-See docs/plans/2026-05-21-evolve-loop-epic-design.md §A4 for the full design.`,
+	Short: "Compatibility shims for relocated cron-fire scheduling",
+	Long: `Compatibility shims for cron-fire scheduling surfaces that now belong
+behind the MTO/factory boundary. AO keeps command discovery and route notices;
+fleet cadence and prompt re-arming are owned by MTO.`,
 }
 
 func init() {

--- a/cli/cmd/ao/cron_self_adjust.go
+++ b/cli/cmd/ao/cron_self_adjust.go
@@ -2,31 +2,16 @@
 package main
 
 import (
-	"bufio"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
 
-	"github.com/boshu2/agentops/cli/internal/evolve"
 	"github.com/spf13/cobra"
 )
 
-// cronSelfAdjust (soc-un0m) renders the next /evolve loop-mode cron prompt
-// from the versioned template and emits a JSON spec the harness consumes to
-// orchestrate CronCreate. The CLI never calls CronCreate itself — that boundary
-// is intentional. See docs/plans/2026-05-21-evolve-loop-epic-design.md §A4.
-//
-// Audit trail: every render appends a row to .agents/evolve/cron-history.jsonl
-// so operators can reconstruct the loop's prompt evolution.
-
 const (
-	cronSelfAdjustDefaultTemplate = ".agents/evolve/cron-template.md"
-	cronSelfAdjustHistoryRel      = ".agents/evolve/cron-history.jsonl"
+	cronSelfAdjustRelocatedRoute       = "mto-fleet"
+	cronSelfAdjustRelocatedReplacement = "MTO cron-fire driver"
 )
 
 var (
@@ -36,261 +21,65 @@ var (
 	cronSelfAdjustNext       string
 	cronSelfAdjustSubBeads   string
 	cronSelfAdjustTestsDelta string
-	cronSelfAdjustClock      func() time.Time
 )
 
 var cronSelfAdjustCmd = &cobra.Command{
 	Use:   "self-adjust",
-	Short: "Render the next loop-mode cron prompt and emit a CronCreate spec",
-	Long: `Render the next /evolve loop-mode cron prompt and emit JSON for the harness.
+	Short: "Compatibility shim for relocated cron-fire scheduling",
+	Long: `Compatibility shim for the retired local cron self-adjust renderer.
 
-This subcommand is the mechanical primitive the /evolve loop calls at the end
-of every cycle. It:
-
-  1. Reads the versioned cron template (default .agents/evolve/cron-template.md)
-  2. Verifies VERBATIM-PRESERVE marker hashes (refuses on drift)
-  3. Renders the template with the supplied shipped/next/sub-beads/tests-delta
-  4. Appends one row to .agents/evolve/cron-history.jsonl
-  5. Emits a JSON spec on stdout: {"new_cron_prompt": "<rendered>", "schedule_hint": "..."}
-
-The CLI does NOT call CronCreate. The harness reads the JSON spec and
-orchestrates CronList/Delete/Create itself; the CLI's responsibility ends at
-emitting the spec.
-
---shipped accepts one or more "<commit-sha>:<bead-id>[#<scenario>]" entries,
-comma-separated.
-
-Example:
-  ao cron self-adjust --on cycle-close \
-    --template .agents/evolve/cron-template.md \
-    --shipped abc123:soc-x,def456:soc-y#scen \
-    --next soc-z --sub-beads soc-q,soc-r \
-    --tests-delta "+3 passing, 0 new failures"`,
+AgentOps no longer renders CronCreate prompts or writes cron-history from the
+lean local image. Fleet cadence, cron-fire scheduling, and prompt re-arming now
+belong behind the MTO/factory boundary. This command remains so older scripts
+can discover the relocation route without losing the public command surface.`,
 	Args: cobra.NoArgs,
 	RunE: runCronSelfAdjust,
 }
 
+type cronSelfAdjustRelocationNotice struct {
+	Status      string            `json:"status"`
+	Route       string            `json:"route"`
+	Replacement string            `json:"replacement"`
+	Message     string            `json:"message"`
+	Accepted    map[string]string `json:"accepted_flags,omitempty"`
+}
+
 func init() {
-	cronSelfAdjustClock = func() time.Time { return time.Now().UTC() }
-	cronSelfAdjustCmd.Flags().StringVar(&cronSelfAdjustOn, "on", "cycle-close", "Trigger marker: 'cycle-close' for default loop usage")
-	cronSelfAdjustCmd.Flags().StringVar(&cronSelfAdjustTemplate, "template", cronSelfAdjustDefaultTemplate, "Path to the cron-loop-mode template")
-	cronSelfAdjustCmd.Flags().StringVar(&cronSelfAdjustShipped, "shipped", "", "Comma-separated commit:bead entries shipped this cycle")
-	cronSelfAdjustCmd.Flags().StringVar(&cronSelfAdjustNext, "next", "", "Optional recommended next bead")
-	cronSelfAdjustCmd.Flags().StringVar(&cronSelfAdjustSubBeads, "sub-beads", "", "Comma-separated bead ids filed this cycle")
-	cronSelfAdjustCmd.Flags().StringVar(&cronSelfAdjustTestsDelta, "tests-delta", "", "Human-readable tests delta summary")
+	cronSelfAdjustCmd.Flags().StringVar(&cronSelfAdjustOn, "on", "cycle-close", "Accepted for compatibility; MTO owns cron scheduling")
+	cronSelfAdjustCmd.Flags().StringVar(&cronSelfAdjustTemplate, "template", "", "Accepted for compatibility; MTO owns prompt rendering")
+	cronSelfAdjustCmd.Flags().StringVar(&cronSelfAdjustShipped, "shipped", "", "Accepted for compatibility; MTO owns shipped-cycle context")
+	cronSelfAdjustCmd.Flags().StringVar(&cronSelfAdjustNext, "next", "", "Accepted for compatibility; MTO owns next-cycle selection")
+	cronSelfAdjustCmd.Flags().StringVar(&cronSelfAdjustSubBeads, "sub-beads", "", "Accepted for compatibility; MTO owns sub-bead fan-out context")
+	cronSelfAdjustCmd.Flags().StringVar(&cronSelfAdjustTestsDelta, "tests-delta", "", "Accepted for compatibility; MTO owns test-delta context")
 	cronCmd.AddCommand(cronSelfAdjustCmd)
 }
 
-// cronSelfAdjustSpec is the JSON spec written to stdout for the harness.
-type cronSelfAdjustSpec struct {
-	NewCronPrompt string `json:"new_cron_prompt"`
-	ScheduleHint  string `json:"schedule_hint"`
-}
-
-// cronSelfAdjustHistoryRow is one row of cron-history.jsonl.
-type cronSelfAdjustHistoryRow struct {
-	Timestamp        string   `json:"timestamp"`
-	CronIDBefore     string   `json:"cron_id_before"`
-	CronIDAfter      string   `json:"cron_id_after"`
-	Shipped          []string `json:"shipped"`
-	Next             string   `json:"next,omitempty"`
-	SubBeadsFiled    []string `json:"sub_beads_filed"`
-	TestsDelta       string   `json:"tests_delta,omitempty"`
-	RenderedTemplate string   `json:"rendered_template_path,omitempty"`
-}
-
 func runCronSelfAdjust(cmd *cobra.Command, _ []string) error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("get working directory: %w", err)
+	notice := cronSelfAdjustRelocationNotice{
+		Status:      "relocated",
+		Route:       cronSelfAdjustRelocatedRoute,
+		Replacement: cronSelfAdjustRelocatedReplacement,
+		Message:     "ao cron self-adjust has moved behind the MTO/factory boundary; AO keeps only this compatibility shim.",
+		Accepted: map[string]string{
+			"on":          cronSelfAdjustOn,
+			"template":    cronSelfAdjustTemplate,
+			"shipped":     cronSelfAdjustShipped,
+			"next":        cronSelfAdjustNext,
+			"sub_beads":   cronSelfAdjustSubBeads,
+			"tests_delta": cronSelfAdjustTestsDelta,
+		},
 	}
-	templatePath := cronSelfAdjustTemplate
-	if !filepath.IsAbs(templatePath) {
-		templatePath = filepath.Join(cwd, templatePath)
-	}
-
-	// Verify VERBATIM-PRESERVE markers before rendering. evolve.VerifyMarkers
-	// returns a typed error listing each drifted marker; surface unchanged.
-	if err := evolve.VerifyMarkers(templatePath); err != nil {
-		return err
-	}
-
-	shipped := parseShippedCommits(cronSelfAdjustShipped)
-	subBeads := splitCronCSV(cronSelfAdjustSubBeads)
-
-	counter := countCronHistoryRows(filepath.Join(cwd, cronSelfAdjustHistoryRel)) + 1
-	rendered, err := evolve.Render(templatePath, evolve.CronContext{
-		ShippedCommits:         shipped,
-		NextRecommendedBead:    cronSelfAdjustNext,
-		SubBeadsFiledThisCycle: subBeads,
-		TestsDelta:             cronSelfAdjustTestsDelta,
-		CronSelfAdjustCounter:  counter,
-	})
-	if err != nil {
-		return err
-	}
-
-	now := cronSelfAdjustClock()
-	row := cronSelfAdjustHistoryRow{
-		Timestamp:        now.Format(time.RFC3339),
-		CronIDBefore:     "",
-		CronIDAfter:      "",
-		Shipped:          shippedAsStrings(shipped),
-		Next:             cronSelfAdjustNext,
-		SubBeadsFiled:    subBeads,
-		TestsDelta:       cronSelfAdjustTestsDelta,
-		RenderedTemplate: templatePath,
-	}
-	if err := appendCronHistoryRow(filepath.Join(cwd, cronSelfAdjustHistoryRel), row); err != nil {
-		return err
-	}
-
-	spec := cronSelfAdjustSpec{
-		NewCronPrompt: rendered,
-		ScheduleHint:  cronSelfAdjustOn,
-	}
-	return writeCronSelfAdjustSpec(cmd.OutOrStdout(), spec)
+	return writeCronSelfAdjustNotice(cmd.OutOrStdout(), notice)
 }
 
-// parseShippedCommits parses the comma-separated --shipped value into a slice
-// of evolve.ShippedCommit. Each entry is "<sha>:<bead>[#<scenario>]".
-func parseShippedCommits(in string) []evolve.ShippedCommit {
-	if strings.TrimSpace(in) == "" {
-		return nil
+func writeCronSelfAdjustNotice(w io.Writer, notice cronSelfAdjustRelocationNotice) error {
+	if w == nil {
+		return fmt.Errorf("cron self-adjust notice requires a writer")
 	}
-	parts := strings.Split(in, ",")
-	out := make([]evolve.ShippedCommit, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-		sha, rest, ok := strings.Cut(p, ":")
-		if !ok {
-			// No colon — treat the whole token as the bead id.
-			out = append(out, evolve.ShippedCommit{Bead: p})
-			continue
-		}
-		bead, scenario, hasScen := strings.Cut(rest, "#")
-		commit := evolve.ShippedCommit{Sha: sha, Bead: bead}
-		if hasScen {
-			commit.Scenario = scenario
-		}
-		out = append(out, commit)
-	}
-	return out
-}
-
-// shippedAsStrings rebuilds the canonical "<sha>:<bead>[#<scenario>]" form for
-// logging.
-func shippedAsStrings(in []evolve.ShippedCommit) []string {
-	if len(in) == 0 {
-		return []string{}
-	}
-	out := make([]string, 0, len(in))
-	for _, c := range in {
-		s := c.Sha + ":" + c.Bead
-		if c.Scenario != "" {
-			s += "#" + c.Scenario
-		}
-		out = append(out, s)
-	}
-	return out
-}
-
-// splitCronCSV is the local trim-aware splitter (the standard library's
-// strings.Split keeps empty trailing tokens; we want a clean slice).
-func splitCronCSV(in string) []string {
-	if strings.TrimSpace(in) == "" {
-		return []string{}
-	}
-	parts := strings.Split(in, ",")
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-		out = append(out, p)
-	}
-	return out
-}
-
-// appendCronHistoryRow writes one JSONL row to path, creating the dir if
-// needed.
-func appendCronHistoryRow(path string, row cronSelfAdjustHistoryRow) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("create history dir: %w", err)
-	}
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return fmt.Errorf("open history %s: %w", path, err)
-	}
-	defer func() { _ = f.Close() }()
-	data, err := json.Marshal(row)
-	if err != nil {
-		return fmt.Errorf("marshal history row: %w", err)
-	}
-	if _, err := f.Write(append(data, '\n')); err != nil {
-		return fmt.Errorf("write history row: %w", err)
-	}
-	return nil
-}
-
-// writeCronSelfAdjustSpec emits the harness spec.
-func writeCronSelfAdjustSpec(w io.Writer, spec cronSelfAdjustSpec) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	if err := enc.Encode(spec); err != nil {
-		return fmt.Errorf("encode spec: %w", err)
+	if err := enc.Encode(notice); err != nil {
+		return fmt.Errorf("encode cron relocation notice: %w", err)
 	}
 	return nil
-}
-
-// cronHistoryReadRows decodes path into typed rows. Missing file returns an
-// empty slice. Exported for tests in this package only.
-func cronHistoryReadRows(path string) ([]cronSelfAdjustHistoryRow, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("open %s: %w", path, err)
-	}
-	defer func() { _ = f.Close() }()
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	var rows []cronSelfAdjustHistoryRow
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
-		var row cronSelfAdjustHistoryRow
-		if err := json.Unmarshal([]byte(line), &row); err != nil {
-			return nil, fmt.Errorf("decode history row: %w", err)
-		}
-		rows = append(rows, row)
-	}
-	return rows, scanner.Err()
-}
-
-// countCronHistoryRows counts non-empty lines in a JSONL file (0 if missing).
-// Relocated from the deleted ao-evolve CLI surface (ag-llni); its only consumer
-// is cronSelfAdjust above.
-func countCronHistoryRows(path string) int {
-	f, err := os.Open(path)
-	if err != nil {
-		return 0
-	}
-	defer func() { _ = f.Close() }()
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	n := 0
-	for scanner.Scan() {
-		if strings.TrimSpace(scanner.Text()) != "" {
-			n++
-		}
-	}
-	return n
 }

--- a/cli/cmd/ao/cron_self_adjust_test.go
+++ b/cli/cmd/ao/cron_self_adjust_test.go
@@ -3,264 +3,45 @@ package main
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
-	"time"
-
-	"github.com/boshu2/agentops/cli/internal/evolve"
 )
 
-// minimalCronTemplate returns a self-contained template with a single
-// VERBATIM-PRESERVE marker whose SHA is computed inline. Used by tests that
-// don't need the real production template.
-func minimalCronTemplate(t *testing.T) string {
-	t.Helper()
-	inner := "\nload-bearing\n"
-	sha := evolve.ComputeMarkerSHA(inner)
-	return strings.Join([]string{
-		"---",
-		"template_version: 1",
-		"verbatim_markers:",
-		"  test-marker: " + sha,
-		"---",
-		"",
-		"# Cycle {{.CronSelfAdjustCounter}}",
-		"",
-		"Shipped: {{range .ShippedCommits}}{{.Sha}}:{{.Bead}}{{if .Scenario}}#{{.Scenario}}{{end}} {{end}}",
-		"Next: {{.NextRecommendedBead}}",
-		"Sub-beads: {{range .SubBeadsFiledThisCycle}}- {{.}} {{end}}",
-		"Tests: {{.TestsDelta}}",
-		"",
-		"<!-- VERBATIM-PRESERVE:start name=\"test-marker\" -->" + inner + "<!-- VERBATIM-PRESERVE:end -->",
-	}, "\n")
-}
-
-// withFixedCronClock pins the clock for deterministic timestamps.
-func withFixedCronClock(t *testing.T, ts time.Time) {
-	t.Helper()
-	prev := cronSelfAdjustClock
-	cronSelfAdjustClock = func() time.Time { return ts }
-	t.Cleanup(func() { cronSelfAdjustClock = prev })
-}
-
-// TestCronSelfAdjust_RoundTrip exercises the happy path: render a template
-// with shipped/next/sub-beads, verify stdout JSON and history row.
-func TestCronSelfAdjust_RoundTrip(t *testing.T) {
-	dir := chdirTemp(t)
-	withFixedCronClock(t, time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC))
-
-	templatePath := filepath.Join(dir, ".agents/evolve/cron-template.md")
-	if err := os.MkdirAll(filepath.Dir(templatePath), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(templatePath, []byte(minimalCronTemplate(t)), 0o644); err != nil {
-		t.Fatalf("seed template: %v", err)
-	}
-
+func TestCronSelfAdjust_RoutesToMTO(t *testing.T) {
 	out, err := executeCommand(
 		"cron", "self-adjust",
 		"--on", "cycle-close",
 		"--template", ".agents/evolve/cron-template.md",
-		"--shipped", "abc123:soc-x,def456:soc-y#scen",
-		"--next", "soc-z",
-		"--sub-beads", "soc-q,soc-r",
+		"--shipped", "abc123:cp-x",
+		"--next", "cp-y",
+		"--sub-beads", "cp-a,cp-b",
 		"--tests-delta", "+3 passing",
 	)
 	if err != nil {
 		t.Fatalf("err: %v\nout=%s", err, out)
 	}
-	jsonStart := strings.Index(out, "{")
-	if jsonStart < 0 {
-		t.Fatalf("no JSON in output: %q", out)
-	}
-	var spec cronSelfAdjustSpec
-	if err := json.Unmarshal([]byte(out[jsonStart:]), &spec); err != nil {
-		t.Fatalf("decode spec: %v\nout=%s", err, out)
-	}
-	if !strings.Contains(spec.NewCronPrompt, "Cycle 1") {
-		t.Errorf("prompt missing cycle counter: %q", spec.NewCronPrompt)
-	}
-	if !strings.Contains(spec.NewCronPrompt, "abc123:soc-x") {
-		t.Errorf("prompt missing shipped commit: %q", spec.NewCronPrompt)
-	}
-	if !strings.Contains(spec.NewCronPrompt, "soc-y#scen") {
-		t.Errorf("prompt missing scenario: %q", spec.NewCronPrompt)
-	}
-	if !strings.Contains(spec.NewCronPrompt, "Next: soc-z") {
-		t.Errorf("prompt missing next: %q", spec.NewCronPrompt)
-	}
-	if !strings.Contains(spec.NewCronPrompt, "- soc-q") || !strings.Contains(spec.NewCronPrompt, "- soc-r") {
-		t.Errorf("prompt missing sub-beads: %q", spec.NewCronPrompt)
-	}
-	if !strings.Contains(spec.NewCronPrompt, "+3 passing") {
-		t.Errorf("prompt missing tests delta: %q", spec.NewCronPrompt)
-	}
-	if spec.ScheduleHint != "cycle-close" {
-		t.Errorf("schedule hint = %q, want cycle-close", spec.ScheduleHint)
-	}
 
-	rows, err := cronHistoryReadRows(filepath.Join(dir, cronSelfAdjustHistoryRel))
-	if err != nil {
-		t.Fatalf("read history: %v", err)
+	var notice cronSelfAdjustRelocationNotice
+	if err := json.Unmarshal([]byte(out), &notice); err != nil {
+		t.Fatalf("decode notice: %v\nout=%s", err, out)
 	}
-	if len(rows) != 1 {
-		t.Fatalf("history rows = %d, want 1", len(rows))
+	if notice.Status != "relocated" {
+		t.Fatalf("status = %q, want relocated", notice.Status)
 	}
-	got := rows[0]
-	want := cronSelfAdjustHistoryRow{
-		Timestamp:        "2026-05-21T12:00:00Z",
-		CronIDBefore:     "",
-		CronIDAfter:      "",
-		Shipped:          []string{"abc123:soc-x", "def456:soc-y#scen"},
-		Next:             "soc-z",
-		SubBeadsFiled:    []string{"soc-q", "soc-r"},
-		TestsDelta:       "+3 passing",
-		RenderedTemplate: templatePath,
+	if notice.Route != "mto-fleet" {
+		t.Fatalf("route = %q, want mto-fleet", notice.Route)
 	}
-	if got.Timestamp != want.Timestamp ||
-		got.Next != want.Next ||
-		got.TestsDelta != want.TestsDelta ||
-		got.RenderedTemplate != want.RenderedTemplate {
-		t.Errorf("history scalars mismatch:\n got=%+v\nwant=%+v", got, want)
+	if notice.Replacement == "" {
+		t.Fatal("replacement should be populated")
 	}
-	if strings.Join(got.Shipped, "|") != strings.Join(want.Shipped, "|") {
-		t.Errorf("shipped mismatch: got=%v want=%v", got.Shipped, want.Shipped)
+	if !strings.Contains(notice.Message, "MTO/factory boundary") {
+		t.Fatalf("message did not explain route: %q", notice.Message)
 	}
-	if strings.Join(got.SubBeadsFiled, "|") != strings.Join(want.SubBeadsFiled, "|") {
-		t.Errorf("sub-beads mismatch: got=%v want=%v", got.SubBeadsFiled, want.SubBeadsFiled)
+	if notice.Accepted["next"] != "cp-y" {
+		t.Fatalf("accepted next = %q, want cp-y", notice.Accepted["next"])
 	}
 }
 
-// TestCronSelfAdjust_RefusesOnMarkerDrift confirms VerifyMarkers gating wires
-// through; tampering with marker content trips an exit-1 error.
-func TestCronSelfAdjust_RefusesOnMarkerDrift(t *testing.T) {
-	dir := chdirTemp(t)
-
-	templatePath := filepath.Join(dir, ".agents/evolve/cron-template.md")
-	if err := os.MkdirAll(filepath.Dir(templatePath), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	// Use the minimal template, but tamper with the marker's inner content
-	// after generating its SHA — drift should be detected.
-	tpl := minimalCronTemplate(t)
-	tampered := strings.Replace(tpl, "load-bearing", "tampered-content", 1)
-	if err := os.WriteFile(templatePath, []byte(tampered), 0o644); err != nil {
-		t.Fatalf("write template: %v", err)
-	}
-
-	out, err := executeCommand(
-		"cron", "self-adjust",
-		"--template", ".agents/evolve/cron-template.md",
-		"--shipped", "abc:soc-x",
-	)
-	if err == nil {
-		t.Fatalf("expected drift error\nout=%s", out)
-	}
-	if !strings.Contains(err.Error(), "drift") {
-		t.Errorf("error message: %v", err)
-	}
-}
-
-// TestCronSelfAdjust_EmptyShippedTolerated covers the corner case where the
-// cycle shipped nothing — render should still succeed and emit a valid spec.
-func TestCronSelfAdjust_EmptyShippedTolerated(t *testing.T) {
-	dir := chdirTemp(t)
-	withFixedCronClock(t, time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC))
-
-	templatePath := filepath.Join(dir, ".agents/evolve/cron-template.md")
-	if err := os.MkdirAll(filepath.Dir(templatePath), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(templatePath, []byte(minimalCronTemplate(t)), 0o644); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
-
-	out, err := executeCommand(
-		"cron", "self-adjust",
-		"--template", ".agents/evolve/cron-template.md",
-	)
-	if err != nil {
-		t.Fatalf("err: %v\nout=%s", err, out)
-	}
-	jsonStart := strings.Index(out, "{")
-	if jsonStart < 0 {
-		t.Fatalf("no JSON: %q", out)
-	}
-	var spec cronSelfAdjustSpec
-	if err := json.Unmarshal([]byte(out[jsonStart:]), &spec); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if spec.NewCronPrompt == "" {
-		t.Errorf("expected non-empty prompt")
-	}
-}
-
-// TestCronSelfAdjust_CounterIncrementsAcrossInvocations verifies cycle counter
-// advances each call.
-func TestCronSelfAdjust_CounterIncrementsAcrossInvocations(t *testing.T) {
-	dir := chdirTemp(t)
-	withFixedCronClock(t, time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC))
-
-	templatePath := filepath.Join(dir, ".agents/evolve/cron-template.md")
-	if err := os.MkdirAll(filepath.Dir(templatePath), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(templatePath, []byte(minimalCronTemplate(t)), 0o644); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
-
-	// First call → counter 1.
-	out, err := executeCommand("cron", "self-adjust", "--template", ".agents/evolve/cron-template.md")
-	if err != nil {
-		t.Fatalf("call 1: %v\nout=%s", err, out)
-	}
-	if !strings.Contains(out, "Cycle 1") {
-		t.Errorf("call 1 counter: %q", out)
-	}
-
-	// Second call → counter 2.
-	out, err = executeCommand("cron", "self-adjust", "--template", ".agents/evolve/cron-template.md")
-	if err != nil {
-		t.Fatalf("call 2: %v\nout=%s", err, out)
-	}
-	if !strings.Contains(out, "Cycle 2") {
-		t.Errorf("call 2 counter: %q", out)
-	}
-}
-
-// TestParseShippedCommits covers the comma-separated --shipped parser.
-func TestParseShippedCommits(t *testing.T) {
-	cases := []struct {
-		in   string
-		want []evolve.ShippedCommit
-	}{
-		{"", nil},
-		{"abc:soc-x", []evolve.ShippedCommit{{Sha: "abc", Bead: "soc-x"}}},
-		{"abc:soc-x,def:soc-y", []evolve.ShippedCommit{
-			{Sha: "abc", Bead: "soc-x"},
-			{Sha: "def", Bead: "soc-y"},
-		}},
-		{"abc:soc-x#scen", []evolve.ShippedCommit{{Sha: "abc", Bead: "soc-x", Scenario: "scen"}}},
-		{"soc-only", []evolve.ShippedCommit{{Bead: "soc-only"}}},
-	}
-	for _, tc := range cases {
-		got := parseShippedCommits(tc.in)
-		if len(got) != len(tc.want) {
-			t.Errorf("parseShippedCommits(%q) len=%d, want %d", tc.in, len(got), len(tc.want))
-			continue
-		}
-		for i := range got {
-			if got[i] != tc.want[i] {
-				t.Errorf("parseShippedCommits(%q)[%d] = %+v, want %+v", tc.in, i, got[i], tc.want[i])
-			}
-		}
-	}
-}
-
-// TestCronSelfAdjust_RegisteredOnCron confirms the subcommand is reachable
-// via `ao cron self-adjust`.
 func TestCronSelfAdjust_RegisteredOnCron(t *testing.T) {
 	var found bool
 	for _, sub := range cronCmd.Commands() {
@@ -274,7 +55,6 @@ func TestCronSelfAdjust_RegisteredOnCron(t *testing.T) {
 	}
 }
 
-// TestCron_RegisteredOnRoot confirms `ao cron` is reachable.
 func TestCron_RegisteredOnRoot(t *testing.T) {
 	var found bool
 	for _, sub := range rootCmd.Commands() {

--- a/cli/cmd/ao/loop_blocked.go
+++ b/cli/cmd/ao/loop_blocked.go
@@ -354,3 +354,19 @@ func nextBlockedCycleID(cwd string, now time.Time) string {
 
 // countCronHistoryRows returns the number of non-blank lines in path; 0 on
 // missing or unreadable file (the cycle counter is a soft default).
+func countCronHistoryRows(path string) int {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = f.Close() }()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	n := 0
+	for scanner.Scan() {
+		if strings.TrimSpace(scanner.Text()) != "" {
+			n++
+		}
+	}
+	return n
+}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -1436,7 +1436,7 @@ ao codex stop [flags]
 
 ### `ao cron`
 
-Helpers for the /evolve --mode=loop cron-fire continuity primitive.
+Compatibility shims for cron-fire scheduling surfaces that now belong
 
 ```
 ao cron [command]
@@ -1446,7 +1446,7 @@ ao cron [command]
 
 #### `ao cron self-adjust`
 
-Render the next /evolve loop-mode cron prompt and emit JSON for the harness.
+Compatibility shim for the retired local cron self-adjust renderer.
 
 ```
 ao cron self-adjust [flags]
@@ -1456,12 +1456,12 @@ ao cron self-adjust [flags]
 
 ```
   -h, --help                 help for self-adjust
-      --next string          Optional recommended next bead
-      --on string            Trigger marker: 'cycle-close' for default loop usage (default "cycle-close")
-      --shipped string       Comma-separated commit:bead entries shipped this cycle
-      --sub-beads string     Comma-separated bead ids filed this cycle
-      --template string      Path to the cron-loop-mode template (default ".agents/evolve/cron-template.md")
-      --tests-delta string   Human-readable tests delta summary
+      --next string          Accepted for compatibility; MTO owns next-cycle selection
+      --on string            Accepted for compatibility; MTO owns cron scheduling (default "cycle-close")
+      --shipped string       Accepted for compatibility; MTO owns shipped-cycle context
+      --sub-beads string     Accepted for compatibility; MTO owns sub-bead fan-out context
+      --template string      Accepted for compatibility; MTO owns prompt rendering
+      --tests-delta string   Accepted for compatibility; MTO owns test-delta context
 ```
 
 ---

--- a/docs/reduction/ao-file-buckets.tsv
+++ b/docs/reduction/ao-file-buckets.tsv
@@ -105,9 +105,9 @@ cli/cmd/ao/corpus_inject.go	KEEP	self-contained AO image surface: loop, mind, lo
 cli/cmd/ao/corpus_inject_test.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	bytes,context,errors,internal/ports,os,path/...,strings,testing
 cli/cmd/ao/corpus_snapshot.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	archive/...,compress/...,crypto/...,encoding/...,fmt,github.com/...,io,os,path/...,sort,strings,time
 cli/cmd/ao/corpus_snapshot_test.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	archive/...,compress/...,encoding/...,io,os,path/...,strings,testing,time
-cli/cmd/ao/cron.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	github.com/...
-cli/cmd/ao/cron_self_adjust.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	bufio,encoding/...,errors,fmt,github.com/...,internal/evolve,io,os,path/...,strings,time
-cli/cmd/ao/cron_self_adjust_test.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	encoding/...,internal/evolve,os,path/...,strings,testing,time
+cli/cmd/ao/cron.go	KEEP	compatibility shim retained in the lean AO image after cron-fire scheduling moved to the mto-fleet route	github.com/...
+cli/cmd/ao/cron_self_adjust.go	KEEP	compatibility shim retained in the lean AO image after cron-fire scheduling moved to the mto-fleet route	encoding/...,fmt,github.com/...,io
+cli/cmd/ao/cron_self_adjust_test.go	KEEP	compatibility shim test for the mto-fleet route notice; no local CronCreate renderer remains	encoding/...,strings,testing
 cli/cmd/ao/curate.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	encoding/...,fmt,github.com/...,internal/goals,internal/lifecycle,io,os,os/...,path/...,strings,time
 cli/cmd/ao/curate_integration_test.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	bytes,encoding/...,path/...,strings,testing,time
 cli/cmd/ao/curate_test.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	encoding/...,os,path/...,strings,testing,time

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-07T06:25:22Z",
+  "generated_at": "2026-06-07T07:08:58Z",
   "summary": {
     "skills": 173,
     "hooks": 0,
@@ -1671,7 +1671,7 @@
       {
         "name": "ao cron",
         "path": "cli/cmd/ao/",
-        "purpose": "Cron-fire loop helpers (used by /evolve --mode=loop)",
+        "purpose": "Compatibility shims for relocated cron-fire scheduling",
         "bounded_context": "BC3",
         "driven_by_skills": []
       },
@@ -6329,14 +6329,13 @@
       "name": "ao cron",
       "type": "cli-command",
       "bounded_context": "BC3",
-      "purpose": "Cron-fire loop helpers (used by /evolve --mode=loop)",
+      "purpose": "Compatibility shims for relocated cron-fire scheduling",
       "status": "active",
       "driven_by_skills": [],
       "flags": [
         "--config",
         "--dry-run",
         "--json",
-        "--mode",
         "--output",
         "--verbose"
       ],


### PR DESCRIPTION
## Summary
- replaces the local `ao cron self-adjust` CronCreate renderer/history writer with a compatibility shim that emits a structured `mto-fleet` route notice
- keeps the public command discoverable while moving cron-fire scheduling ownership behind the MTO/factory boundary
- updates reduction inventory from KEEP 450 / RELOCATE 146 to KEEP 453 / RELOCATE 143 and records the relocated cron-fire surface
- regenerates `cli/docs/COMMANDS.md` and `registry.json`

## Validation
- cd cli && go test ./cmd/ao -run 'TestCron|TestLoopBlocked|TestCommandSurface|TestCobra'\n- bash scripts/regen-all.sh\n- bash scripts/regen-all.sh --check\n- git diff --check\n- TSV count check: docs/reduction rows == cli/cmd/ao/*.go\n- PRE_PUSH_SKIP_MKDOCS=1 bash scripts/pre-push-gate.sh --fast\n\n## cp-cd9 route\n- cites old rows: `cli/cmd/ao/cron.go`, `cli/cmd/ao/cron_self_adjust.go`, `cli/cmd/ao/cron_self_adjust_test.go`\n- route: `mto-fleet`\n- scope: narrow cron-fire scheduling slice; `rpi_*` remains defer-load-bearing