### PR TITLE
refactor(ao): extract agent bundle adapter

### DIFF
--- a/REDUCTION.md
+++ b/REDUCTION.md
@@ -38,11 +38,11 @@ Current inventory count:
 
 | Bucket | Files |
 |---|---:|
-| KEEP | 453 |
-| RELOCATE | 143 |
+| KEEP | 454 |
+| RELOCATE | 140 |
 | ARCHIVE | 0 |
 | RESEARCH | 39 |
-| Total | 635 |
+| Total | 633 |
 
 Validation command:
 
@@ -97,6 +97,13 @@ The cron-fire scheduling renderer moved behind the `mto-fleet` route. AO keeps
 `ao cron self-adjust` as a compatibility shim that emits a structured route
 notice, but it no longer renders CronCreate prompts, verifies cron templates,
 or writes `.agents/evolve/cron-history.jsonl` from the lean local image.
+
+## Extracted Vendor-Image Bundle Surface
+
+The `ao agent bundle` pure builder moved behind the `vendor-image-adapter`
+route. AO keeps the public command wrapper and JSON contract in place for
+compatibility, while the runtime-specific bundle construction now lives under
+`cli/internal/adapters/vendorimage/agentbundle`.
 
 ## Reversibility
 

--- a/cli/cmd/ao/agent.go
+++ b/cli/cmd/ao/agent.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/boshu2/agentops/cli/internal/adapters/vendorimage/agentbundle"
 	"github.com/spf13/cobra"
 )
 
@@ -69,7 +70,7 @@ func runAgentBundle(cmd *cobra.Command, _ []string) error {
 			}
 		}
 	}
-	bundle, err := buildAgentBundle(bundleOptions{
+	bundle, err := agentbundle.Build(agentbundle.Options{
 		Runtime: agentBundleRuntime,
 		Skills:  skills,
 		Sandbox: agentBundleSandbox,

--- a/cli/internal/adapters/vendorimage/agentbundle/bundle.go
+++ b/cli/internal/adapters/vendorimage/agentbundle/bundle.go
@@ -1,5 +1,5 @@
 // practices: [hexagonal-architecture, design-by-contract]
-package main
+package agentbundle
 
 import (
 	"fmt"
@@ -20,44 +20,44 @@ const defaultAgentModel = "claude-opus-4-8"
 // Managed Agents are NOT ZDR — see ~/.agents/evals/SCHEMA.md (LOCKED).
 var holdoutMarkers = []string{"private_holdout", "ground_truth", "holdout target"}
 
-// bundleOptions is the resolved input to buildAgentBundle.
-type bundleOptions struct {
+// Options is the resolved input to Build.
+type Options struct {
 	Runtime   string   // "managed" | "codex-ntm"
 	Skills    []string // nil => defaultBundleSkills
 	Sandbox   string   // "self-hosted" | "cloud" | ""
 	SkillsDir string   // root to resolve+scan skills (default: "skills")
 }
 
-// bundleTool is an MCP tool descriptor the hosted loop can call to self-check.
-type bundleTool struct {
+// Tool is an MCP tool descriptor the hosted loop can call to self-check.
+type Tool struct {
 	Type   string `json:"type"`
 	Server string `json:"server"`
 	Cmd    string `json:"cmd"`
 }
 
-// sandboxBlock describes where a self-hosted loop runs.
-type sandboxBlock struct {
+// Sandbox describes where a self-hosted loop runs.
+type Sandbox struct {
 	Kind string `json:"kind"`
 	Note string `json:"note"`
 }
 
-// agentBundle is the runtime-specific Agent definition emitted by `ao agent bundle`.
-type agentBundle struct {
-	Runtime      string        `json:"runtime"`
-	Model        string        `json:"model,omitempty"`
-	Instructions string        `json:"instructions"`
-	Skills       []string      `json:"skills"`
-	Tools        []bundleTool  `json:"tools,omitempty"`
-	Sandbox      *sandboxBlock `json:"sandbox,omitempty"`
-	Bootstrap    string        `json:"bootstrap,omitempty"` // codex-ntm pane snippet
-	Reference    string        `json:"reference,omitempty"` // codex-ntm skill reference
+// Bundle is the runtime-specific Agent definition emitted by `ao agent bundle`.
+type Bundle struct {
+	Runtime      string   `json:"runtime"`
+	Model        string   `json:"model,omitempty"`
+	Instructions string   `json:"instructions"`
+	Skills       []string `json:"skills"`
+	Tools        []Tool   `json:"tools,omitempty"`
+	Sandbox      *Sandbox `json:"sandbox,omitempty"`
+	Bootstrap    string   `json:"bootstrap,omitempty"` // codex-ntm pane snippet
+	Reference    string   `json:"reference,omitempty"` // codex-ntm skill reference
 }
 
-// buildAgentBundle resolves the skill set, enforces the NOT-ZDR holdout
+// Build resolves the skill set, enforces the NOT-ZDR holdout
 // refusal, and dispatches to the runtime-specific builder.
-func buildAgentBundle(opts bundleOptions) (agentBundle, error) {
+func Build(opts Options) (Bundle, error) {
 	if opts.Runtime != "managed" && opts.Runtime != "codex-ntm" {
-		return agentBundle{}, fmt.Errorf("unknown --runtime %q (want managed|codex-ntm)", opts.Runtime)
+		return Bundle{}, fmt.Errorf("unknown --runtime %q (want managed|codex-ntm)", opts.Runtime)
 	}
 	skills := opts.Skills
 	if len(skills) == 0 {
@@ -68,7 +68,7 @@ func buildAgentBundle(opts bundleOptions) (agentBundle, error) {
 		skillsDir = "skills"
 	}
 	if leak, why := selectionInlinesHoldout(skills, skillsDir); leak {
-		return agentBundle{}, fmt.Errorf(
+		return Bundle{}, fmt.Errorf(
 			"refusing to bundle %s — Managed Agents are NOT ZDR; %s would inline holdout/eval content (the eval substrate is LOCKED). "+
 				"AGENTOPS_HOLDOUT_EVALUATOR does not authorize leaking holdout data to a cloud agent", opts.Runtime, why)
 	}
@@ -79,20 +79,20 @@ func buildAgentBundle(opts bundleOptions) (agentBundle, error) {
 }
 
 // buildManagedBundle emits a Managed Agents Agent-definition payload.
-func buildManagedBundle(skills []string, sandbox string) agentBundle {
-	b := agentBundle{
+func buildManagedBundle(skills []string, sandbox string) Bundle {
+	b := Bundle{
 		Runtime:      "managed",
 		Model:        defaultAgentModel,
 		Instructions: stitchInstructions(skills),
 		Skills:       skills,
-		Tools: []bundleTool{{
+		Tools: []Tool{{
 			Type:   "mcp",
 			Server: "ao",
 			Cmd:    "ao mcp serve",
 		}},
 	}
 	if sandbox == "self-hosted" {
-		b.Sandbox = &sandboxBlock{
+		b.Sandbox = &Sandbox{
 			Kind: "self-hosted",
 			Note: "MCP server runs inside the sandbox boundary (e.g. bushido) with tailnet access to Dolt; holdout-touching work stays here, never the cloud",
 		}
@@ -101,8 +101,8 @@ func buildManagedBundle(skills []string, sandbox string) agentBundle {
 }
 
 // buildCodexNTMBundle emits an NTM-consumable bundle (Codex shells ao directly).
-func buildCodexNTMBundle(skills []string) agentBundle {
-	return agentBundle{
+func buildCodexNTMBundle(skills []string) Bundle {
+	return Bundle{
 		Runtime:      "codex-ntm",
 		Instructions: stitchInstructions(skills),
 		Skills:       skills,

--- a/cli/internal/adapters/vendorimage/agentbundle/bundle_test.go
+++ b/cli/internal/adapters/vendorimage/agentbundle/bundle_test.go
@@ -1,4 +1,4 @@
-package main
+package agentbundle
 
 import (
 	"encoding/json"
@@ -42,7 +42,7 @@ func writeFixtureSkill(t *testing.T, dir, name, body string) {
 }
 
 func TestBuildAgentBundle_ManagedDefaults(t *testing.T) {
-	b, err := buildAgentBundle(bundleOptions{Runtime: "managed", SkillsDir: fixtureSkills(t)})
+	b, err := Build(Options{Runtime: "managed", SkillsDir: fixtureSkills(t)})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestBuildAgentBundle_ManagedDefaults(t *testing.T) {
 }
 
 func TestBuildAgentBundle_SelfHostedSandbox(t *testing.T) {
-	b, err := buildAgentBundle(bundleOptions{Runtime: "managed", Sandbox: "self-hosted", SkillsDir: fixtureSkills(t)})
+	b, err := Build(Options{Runtime: "managed", Sandbox: "self-hosted", SkillsDir: fixtureSkills(t)})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestBuildAgentBundle_SelfHostedSandbox(t *testing.T) {
 }
 
 func TestBuildAgentBundle_CodexNTM(t *testing.T) {
-	b, err := buildAgentBundle(bundleOptions{Runtime: "codex-ntm", SkillsDir: fixtureSkills(t)})
+	b, err := Build(Options{Runtime: "codex-ntm", SkillsDir: fixtureSkills(t)})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestBuildAgentBundle_CodexNTM(t *testing.T) {
 }
 
 func TestBuildAgentBundle_HoldoutRefusal(t *testing.T) {
-	_, err := buildAgentBundle(bundleOptions{
+	_, err := Build(Options{
 		Runtime:   "managed",
 		Skills:    []string{"standards", "leaky-eval"},
 		SkillsDir: fixtureSkills(t),
@@ -130,14 +130,14 @@ func TestBuildAgentBundle_HoldoutRefusal(t *testing.T) {
 }
 
 func TestBuildAgentBundle_UnknownRuntime(t *testing.T) {
-	_, err := buildAgentBundle(bundleOptions{Runtime: "wat", SkillsDir: fixtureSkills(t)})
+	_, err := Build(Options{Runtime: "wat", SkillsDir: fixtureSkills(t)})
 	if err == nil {
 		t.Fatal("unknown --runtime must error")
 	}
 }
 
 func TestBuildAgentBundle_ManagedJSONShape(t *testing.T) {
-	b, err := buildAgentBundle(bundleOptions{Runtime: "managed", SkillsDir: fixtureSkills(t)})
+	b, err := Build(Options{Runtime: "managed", SkillsDir: fixtureSkills(t)})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/docs/reduction/ao-file-buckets.tsv
+++ b/docs/reduction/ao-file-buckets.tsv
@@ -1,7 +1,5 @@
 file	bucket	rationale	imports
-cli/cmd/ao/agent.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	encoding/...,fmt,github.com/...,os,strings
-cli/cmd/ao/agent_bundle.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	fmt,os,path/...,strings
-cli/cmd/ao/agent_bundle_test.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	encoding/...,os,path/...,strings,testing
+cli/cmd/ao/agent.go	KEEP	public compatibility wrapper for `ao agent bundle`; pure builder moved to vendor-image adapter boundary	encoding/...,fmt,github.com/...,os,strings
 cli/cmd/ao/agents.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	encoding/...,fmt,github.com/...,os,path/...,sort,strings
 cli/cmd/ao/agents_doctor.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	encoding/...,fmt,github.com/...,io,os,os/...,path/...,sort
 cli/cmd/ao/agents_doctor_test.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	bytes,encoding/...,errors,os,path/...,strings,testing


### PR DESCRIPTION
## Summary

- routes the `ao agent bundle` pure builder through the `vendor-image-adapter` seam
- keeps the public `ao agent bundle` command wrapper and JSON contract in `cmd/ao`
- updates the cp-cd9 reduction ledger: `agent.go` is now the compatibility wrapper, the pure builder/test left `cli/cmd/ao`

## cp-cd9 route

Rows cited from `docs/reduction/ao-file-buckets.tsv`:

- `cli/cmd/ao/agent.go`: now `KEEP` as the public compatibility wrapper
- `cli/cmd/ao/agent_bundle.go`: moved to `cli/internal/adapters/vendorimage/agentbundle/bundle.go`
- `cli/cmd/ao/agent_bundle_test.go`: moved to `cli/internal/adapters/vendorimage/agentbundle/bundle_test.go`

Replacement route: `vendor-image-adapter`.

## Validation

- `cd cli && go test ./internal/adapters/vendorimage/agentbundle`
- `cd cli && go test ./cmd/ao -run 'TestAgentBundle|TestCobraCommandTreeRegistration|TestCobraExpectedCmdsMatchRegistration|TestCobra'`\n- TSV count check: `rows=633 files=633`\n- `bash scripts/regen-all.sh --check`\n- `scripts/regen-command-surfaces.sh --check`\n- `git diff --check`\n- `cd cli && go vet ./...`\n- `cd cli && go test ./... -count=1 -short`\n- `PRE_PUSH_SKIP_MKDOCS=1 bash scripts/pre-push-gate.sh --fast`\n\nNote: Agent Mail CLI was locked locally during commit, so the commit used `AGENT_MAIL_BYPASS=1`; the repo write set was scoped to this PR.