### PR TITLE
refactor(ao): extract ci status adapter

### DIFF
--- a/REDUCTION.md
+++ b/REDUCTION.md
@@ -38,11 +38,11 @@ Current inventory count:
 
 | Bucket | Files |
 |---|---:|
-| KEEP | 456 |
-| RELOCATE | 136 |
+| KEEP | 458 |
+| RELOCATE | 132 |
 | ARCHIVE | 0 |
 | RESEARCH | 39 |
-| Total | 631 |
+| Total | 629 |
 
 Validation command:
 
@@ -111,6 +111,13 @@ The `ao harness status` filesystem sync adapter moved behind the
 `vendor-image-adapter` route. AO keeps the public command wrapper and JSONL
 contract in place, while the skill/skills-codex hash scanner now lives under
 `cli/internal/adapters/vendorimage/harnesssync`.
+
+## Extracted CI Status Adapter Surface
+
+The GitHub Actions-backed `CIStatusPort` adapter moved behind the `mto-fleet`
+route. AO keeps the `ao ci` public command wrapper and JSON-lines contract in
+place, while the production `gh run list` adapter now lives under
+`cli/internal/adapters/ci_status`.
 
 ## Reversibility
 

--- a/cli/cmd/ao/ci.go
+++ b/cli/cmd/ao/ci.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	cistatus "github.com/boshu2/agentops/cli/internal/adapters/ci_status"
 	"github.com/boshu2/agentops/cli/internal/ports"
 )
 
@@ -112,7 +113,7 @@ func ciStatusRun(ctx context.Context, opts ciStatusOptions) error {
 // ciStatusViaPort wires productionCIStatus (cycle 117) to gh. If
 // opts.sha is non-empty, calls Latest; otherwise Recent.
 func ciStatusViaPort(ctx context.Context, opts ciStatusOptions) ([]ports.CIRun, error) {
-	c := newProductionCIStatus()
+	c := cistatus.NewProduction()
 	if opts.sha != "" {
 		run, err := c.Latest(ctx, opts.sha)
 		if err != nil {

--- a/cli/internal/adapters/ci_status/ci_status.go
+++ b/cli/internal/adapters/ci_status/ci_status.go
@@ -1,5 +1,6 @@
 // practices: [hexagonal-architecture, ddd-bounded-context]
-package main
+// Package cistatus adapts GitHub Actions run history to ports.CIStatusPort.
+package cistatus
 
 import (
 	"bytes"
@@ -31,6 +32,11 @@ type productionCIStatus struct {
 
 func newProductionCIStatus() *productionCIStatus {
 	return &productionCIStatus{runGH: defaultRunGH}
+}
+
+// NewProduction returns a GitHub CLI-backed CIStatusPort adapter.
+func NewProduction() ports.CIStatusPort {
+	return newProductionCIStatus()
 }
 
 // defaultRunGH is the real gh-invocation. exposed for testing as a

--- a/cli/internal/adapters/ci_status/ci_status_test.go
+++ b/cli/internal/adapters/ci_status/ci_status_test.go
@@ -1,5 +1,5 @@
 // practices: [hexagonal-architecture, tdd]
-package main
+package cistatus
 
 import (
 	"context"

--- a/docs/reduction/ao-file-buckets.tsv
+++ b/docs/reduction/ao-file-buckets.tsv
@@ -40,10 +40,8 @@ cli/cmd/ao/canonical_identity.go	RESEARCH	unclear ownership from filename/import
 cli/cmd/ao/canonical_identity_test.go	KEEP	test coverage follows the command surface under review; keep while the source file remains	path/...,testing
 cli/cmd/ao/capabilities.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	encoding/...,github.com/...,runtime,sort
 cli/cmd/ao/capabilities_test.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	encoding/...,strings,testing
-cli/cmd/ao/ci.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	context,encoding/...,fmt,github.com/...,internal/ports,io,os
-cli/cmd/ao/ci_status_adapter.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	bytes,context,encoding/...,errors,fmt,internal/ports,os/...
-cli/cmd/ao/ci_status_adapter_test.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	context,errors,internal/ports,strings,testing
-cli/cmd/ao/ci_test.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	bytes,context,errors,internal/ports,strings,testing
+cli/cmd/ao/ci.go	KEEP	public compatibility wrapper for `ao ci`; GitHub Actions adapter moved to the mto-fleet route	context,encoding/...,fmt,github.com/...,internal/adapters,internal/ports,io,os
+cli/cmd/ao/ci_test.go	KEEP	wrapper test for the retained `ao ci` public JSON-lines command surface	bytes,context,errors,internal/ports,strings,testing
 cli/cmd/ao/citation_cmd.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	context,encoding/...,errors,fmt,github.com/...,internal/ports,io,os
 cli/cmd/ao/citation_cmd_test.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	bytes,context,errors,internal/ports,strings,testing
 cli/cmd/ao/citation_namespace.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	internal/types,os,strings


### PR DESCRIPTION
## Summary

- Move the GitHub Actions-backed `CIStatusPort` adapter from `cli/cmd/ao` to `cli/internal/adapters/ci_status`.
- Keep `ao ci` as the public JSON-lines command wrapper, importing the adapter through the port.
- Update `REDUCTION.md` and `docs/reduction/ao-file-buckets.tsv` for the `mto-fleet` route.

## Evidence

Local validation passed:

- `cd cli && go test ./internal/adapters/ci_status`
- `cd cli && go test ./cmd/ao -run 'TestCIStatus|TestCobraCommandTreeRegistration|TestCobraExpectedCmdsMatchRegistration|TestCobra'`
- TSV count check: `rows=629 files=629`
- `bash scripts/regen-all.sh --check`
- `scripts/regen-command-surfaces.sh --check`
- `git diff --check`
- `cd cli && go vet ./...`
- `cd cli && go test ./... -count=1 -short`
- `PRE_PUSH_SKIP_MKDOCS=1 bash scripts/pre-push-gate.sh --fast`

Reduction inventory after this slice:

- KEEP: 458
- RELOCATE: 132
- ARCHIVE: 0
- RESEARCH: 39
- Total `cli/cmd/ao/*.go`: 629
