### PR TITLE
refactor(ao): extract orchestration select adapter

### DIFF
--- a/REDUCTION.md
+++ b/REDUCTION.md
@@ -38,8 +38,8 @@ Current inventory count:
 
 | Bucket | Files |
 |---|---:|
-| KEEP | 458 |
-| RELOCATE | 132 |
+| KEEP | 460 |
+| RELOCATE | 130 |
 | ARCHIVE | 0 |
 | RESEARCH | 39 |
 | Total | 629 |
@@ -118,6 +118,13 @@ The GitHub Actions-backed `CIStatusPort` adapter moved behind the `mto-fleet`
 route. AO keeps the `ao ci` public command wrapper and JSON-lines contract in
 place, while the production `gh run list` adapter now lives under
 `cli/internal/adapters/ci_status`.
+
+## Extracted Orchestration Select Surface
+
+The `ao orchestrate select` production selector moved behind the `mto-fleet`
+route. AO keeps the public command wrapper and backend-selection contract in
+place, while the exec-backed NTM probe adapter and trace renderer now live
+under `cli/internal/adapters/mto/orchestrationselect`.
 
 ## Reversibility
 

--- a/cli/cmd/ao/orchestrate.go
+++ b/cli/cmd/ao/orchestrate.go
@@ -2,16 +2,10 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"os/exec"
-	"strings"
 
+	"github.com/boshu2/agentops/cli/internal/adapters/mto/orchestrationselect"
 	"github.com/spf13/cobra"
-
-	"github.com/boshu2/agentops/cli/internal/orchestration"
-	"github.com/boshu2/agentops/cli/internal/ports"
 )
 
 // orchestrateCmd is the parent for orchestration-backend tooling. It wires
@@ -64,63 +58,13 @@ func init() {
 		staticCompletionFunc("ntm", "claude", "codex", "beads"))
 }
 
-// execCommandRunner is the production CommandRunner adapter: it shells out
-// via os/exec so ProbeNTM actually invokes `ntm --robot-capabilities`. It
-// is a thin consumer of the orchestration package and adds no behavior of
-// its own.
-type execCommandRunner struct{}
-
-// Run executes name with args and returns the combined output. A non-zero
-// exit (or a missing binary) surfaces as an error, which ProbeNTM reads as
-// the canonical "tool absent or unusable" degradation signal.
-func (execCommandRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, name, args...).CombinedOutput()
-}
-
-// compile-time assertion that the adapter satisfies the probe's contract.
-var _ orchestration.CommandRunner = execCommandRunner{}
-
-// workSpecFromFlags maps the command's flag values onto a port WorkSpec.
-// It is split out from the cobra plumbing so the flag->intent mapping can
-// be unit-tested without constructing a command.
-func workSpecFromFlags(pin string, optOut bool) ports.WorkSpec {
-	return ports.WorkSpec{
-		OptOut: optOut,
-		Pin:    ports.Backend(strings.TrimSpace(pin)),
-	}
-}
-
 // runOrchestrateSelect builds the production Selector over an exec-backed
 // runner and resolves the backend for the flag-derived WorkSpec.
 func runOrchestrateSelect(cmd *cobra.Command, _ []string) error {
-	selector := orchestration.NewSelector(execCommandRunner{})
-	work := workSpecFromFlags(orchestrateSelectPin, orchestrateSelectOptOut)
-
-	trace, err := selector.Select(cmd.Context(), work)
+	trace, err := orchestrationselect.Select(cmd.Context(), orchestrateSelectPin, orchestrateSelectOptOut)
 	if err != nil {
 		return fmt.Errorf("selecting orchestration backend: %w", err)
 	}
 
-	return emitSelectionTrace(cmd, trace, orchestrateSelectJSON)
-}
-
-// emitSelectionTrace renders a SelectionTrace as JSON (when jsonOut) or as
-// a human-readable summary. Kept separate so both branches are testable
-// against an injected writer.
-func emitSelectionTrace(cmd *cobra.Command, trace ports.SelectionTrace, jsonOut bool) error {
-	out := cmd.OutOrStdout()
-	if jsonOut {
-		enc := json.NewEncoder(out)
-		enc.SetIndent("", "  ")
-		return enc.Encode(trace)
-	}
-
-	fmt.Fprintf(out, "Backend: %s\n", trace.Chosen)
-	fmt.Fprintf(out, "Reason:  %s\n", trace.Reason)
-	considered := make([]string, 0, len(trace.Considered))
-	for _, b := range trace.Considered {
-		considered = append(considered, string(b))
-	}
-	fmt.Fprintf(out, "Ladder:  %s\n", strings.Join(considered, " -> "))
-	return nil
+	return orchestrationselect.RenderSelectionTrace(cmd.OutOrStdout(), trace, orchestrateSelectJSON)
 }

--- a/cli/cmd/ao/orchestrate_test.go
+++ b/cli/cmd/ao/orchestrate_test.go
@@ -1,162 +1,22 @@
 package main
 
-import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"errors"
-	"strings"
-	"testing"
+import "testing"
 
-	"github.com/spf13/cobra"
-
-	"github.com/boshu2/agentops/cli/internal/orchestration"
-	"github.com/boshu2/agentops/cli/internal/ports"
-)
-
-// fakeRunner is an in-memory CommandRunner so the Select path can be
-// exercised without shelling out to a real `ntm` binary.
-type fakeRunner struct {
-	out []byte
-	err error
-}
-
-func (f fakeRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
-	return f.out, f.err
-}
-
-func TestOrchestrate_WorkSpecFromFlags(t *testing.T) {
-	tests := []struct {
-		name    string
-		pin     string
-		optOut  bool
-		wantPin ports.Backend
-		wantOpt bool
-	}{
-		{name: "empty", pin: "", optOut: false, wantPin: "", wantOpt: false},
-		{name: "pin trimmed", pin: "  claude  ", optOut: false, wantPin: ports.BackendClaude, wantOpt: false},
-		{name: "opt-out", pin: "", optOut: true, wantPin: "", wantOpt: true},
-		{name: "pin wins over opt-out flags", pin: "codex", optOut: true, wantPin: ports.BackendCodex, wantOpt: true},
+func TestOrchestrateSelectCommandRegistered(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"orchestrate", "select"})
+	if err != nil {
+		t.Fatalf("orchestrate select command not registered: %v", err)
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := workSpecFromFlags(tc.pin, tc.optOut)
-			if got.Pin != tc.wantPin {
-				t.Fatalf("Pin: got %q, want %q", got.Pin, tc.wantPin)
-			}
-			if got.OptOut != tc.wantOpt {
-				t.Fatalf("OptOut: got %v, want %v", got.OptOut, tc.wantOpt)
-			}
-		})
+	if cmd == nil {
+		t.Fatal("orchestrate select command not found")
 	}
-}
-
-// TestOrchestrate_SelectResolvesBackends drives a real Selector with an
-// injected fake runner across the ladder branches, asserting the chosen
-// backend for each flag combination.
-func TestOrchestrate_SelectResolvesBackends(t *testing.T) {
-	t.Setenv("AGENTOPS_ORCHESTRATION", "") // neutralize any operator override
-
-	tests := []struct {
-		name   string
-		runner orchestration.CommandRunner
-		pin    string
-		optOut bool
-		want   ports.Backend
-	}{
-		{
-			name:   "ntm absent degrades to claude",
-			runner: fakeRunner{err: errors.New("ntm: not found")},
-			want:   ports.BackendClaude,
-		},
-		{
-			name:   "ntm available selects ntm",
-			runner: fakeRunner{out: []byte(`{"capabilities":["tmux","git"]}`)},
-			want:   ports.BackendNTM,
-		},
-		{
-			name:   "opt-out routes to beads floor",
-			runner: fakeRunner{err: errors.New("ntm: not found")},
-			optOut: true,
-			want:   ports.BackendBeads,
-		},
-		{
-			name:   "pin wins over availability",
-			runner: fakeRunner{out: []byte(`{"capabilities":["tmux","git"]}`)},
-			pin:    "claude",
-			want:   ports.BackendClaude,
-		},
-		{
-			name:   "pin codex (never auto-selected) honored",
-			runner: fakeRunner{err: errors.New("ntm: not found")},
-			pin:    "codex",
-			want:   ports.BackendCodex,
-		},
+	if cmd.Flags().Lookup("json") == nil {
+		t.Fatal("orchestrate select missing --json flag")
 	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			selector := orchestration.NewSelector(tc.runner)
-			work := workSpecFromFlags(tc.pin, tc.optOut)
-			trace, err := selector.Select(context.Background(), work)
-			if err != nil {
-				t.Fatalf("Select returned error: %v", err)
-			}
-			if trace.Chosen != tc.want {
-				t.Fatalf("Chosen: got %q, want %q", trace.Chosen, tc.want)
-			}
-			if len(trace.Considered) == 0 {
-				t.Fatal("Considered ladder must be recorded")
-			}
-		})
+	if cmd.Flags().Lookup("pin") == nil {
+		t.Fatal("orchestrate select missing --pin flag")
 	}
-}
-
-// TestOrchestrate_EmitSelectionTraceJSON asserts the JSON branch emits the
-// trace verbatim and parses back into the port shape.
-func TestOrchestrate_EmitSelectionTraceJSON(t *testing.T) {
-	trace := ports.SelectionTrace{
-		Chosen:     ports.BackendBeads,
-		Reason:     "WorkSpec.OptOut -> beads floor",
-		Considered: []ports.Backend{"pin", "env", "optout"},
-	}
-	cmd := &cobra.Command{}
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-
-	if err := emitSelectionTrace(cmd, trace, true); err != nil {
-		t.Fatalf("emitSelectionTrace: %v", err)
-	}
-
-	var got ports.SelectionTrace
-	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
-		t.Fatalf("output is not valid JSON: %v", err)
-	}
-	if got.Chosen != ports.BackendBeads {
-		t.Fatalf("Chosen: got %q, want %q", got.Chosen, ports.BackendBeads)
-	}
-}
-
-// TestOrchestrate_EmitSelectionTraceHuman asserts the human-readable branch
-// renders the backend, reason, and ladder.
-func TestOrchestrate_EmitSelectionTraceHuman(t *testing.T) {
-	trace := ports.SelectionTrace{
-		Chosen:     ports.BackendClaude,
-		Reason:     "NTM absent -> claude-native fallback",
-		Considered: []ports.Backend{"pin", "env", "optout", "ntm", "claude", "beads"},
-	}
-	cmd := &cobra.Command{}
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-
-	if err := emitSelectionTrace(cmd, trace, false); err != nil {
-		t.Fatalf("emitSelectionTrace: %v", err)
-	}
-
-	got := buf.String()
-	for _, want := range []string{"Backend: claude", "Reason:  NTM absent", "pin -> env -> optout -> ntm -> claude -> beads"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("output missing %q\nfull output:\n%s", want, got)
-		}
+	if cmd.Flags().Lookup("opt-out") == nil {
+		t.Fatal("orchestrate select missing --opt-out flag")
 	}
 }

--- a/cli/internal/adapters/mto/orchestrationselect/select.go
+++ b/cli/internal/adapters/mto/orchestrationselect/select.go
@@ -1,0 +1,59 @@
+// practices: [hexagonal-architecture, safe-degradation]
+package orchestrationselect
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/boshu2/agentops/cli/internal/orchestration"
+	"github.com/boshu2/agentops/cli/internal/ports"
+)
+
+// execCommandRunner is the production CommandRunner adapter: it shells out via
+// os/exec so ProbeNTM actually invokes `ntm --robot-capabilities`.
+type execCommandRunner struct{}
+
+// Run executes name with args and returns the combined output. A non-zero exit
+// or missing binary surfaces as the canonical degradation signal.
+func (execCommandRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+var _ orchestration.CommandRunner = execCommandRunner{}
+
+// WorkSpecFromFlags maps command flag values onto the orchestration port shape.
+func WorkSpecFromFlags(pin string, optOut bool) ports.WorkSpec {
+	return ports.WorkSpec{
+		OptOut: optOut,
+		Pin:    ports.Backend(strings.TrimSpace(pin)),
+	}
+}
+
+// Select resolves the orchestration backend through the production selector.
+func Select(ctx context.Context, pin string, optOut bool) (ports.SelectionTrace, error) {
+	selector := orchestration.NewSelector(execCommandRunner{})
+	return selector.Select(ctx, WorkSpecFromFlags(pin, optOut))
+}
+
+// RenderSelectionTrace writes a SelectionTrace as JSON or as the stable human
+// summary used by `ao orchestrate select`.
+func RenderSelectionTrace(out io.Writer, trace ports.SelectionTrace, jsonOut bool) error {
+	if jsonOut {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(trace)
+	}
+
+	fmt.Fprintf(out, "Backend: %s\n", trace.Chosen)
+	fmt.Fprintf(out, "Reason:  %s\n", trace.Reason)
+	considered := make([]string, 0, len(trace.Considered))
+	for _, b := range trace.Considered {
+		considered = append(considered, string(b))
+	}
+	fmt.Fprintf(out, "Ladder:  %s\n", strings.Join(considered, " -> "))
+	return nil
+}

--- a/cli/internal/adapters/mto/orchestrationselect/select_test.go
+++ b/cli/internal/adapters/mto/orchestrationselect/select_test.go
@@ -1,0 +1,156 @@
+package orchestrationselect
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/orchestration"
+	"github.com/boshu2/agentops/cli/internal/ports"
+)
+
+// fakeRunner is an in-memory CommandRunner so the Select path can be
+// exercised without shelling out to a real `ntm` binary.
+type fakeRunner struct {
+	out []byte
+	err error
+}
+
+func (f fakeRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return f.out, f.err
+}
+
+func TestWorkSpecFromFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		pin     string
+		optOut  bool
+		wantPin ports.Backend
+		wantOpt bool
+	}{
+		{name: "empty", pin: "", optOut: false, wantPin: "", wantOpt: false},
+		{name: "pin trimmed", pin: "  claude  ", optOut: false, wantPin: ports.BackendClaude, wantOpt: false},
+		{name: "opt-out", pin: "", optOut: true, wantPin: "", wantOpt: true},
+		{name: "pin wins over opt-out flags", pin: "codex", optOut: true, wantPin: ports.BackendCodex, wantOpt: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := WorkSpecFromFlags(tc.pin, tc.optOut)
+			if got.Pin != tc.wantPin {
+				t.Fatalf("Pin: got %q, want %q", got.Pin, tc.wantPin)
+			}
+			if got.OptOut != tc.wantOpt {
+				t.Fatalf("OptOut: got %v, want %v", got.OptOut, tc.wantOpt)
+			}
+		})
+	}
+}
+
+// TestSelectResolvesBackends drives a real Selector with an injected fake
+// runner across the ladder branches, asserting the chosen backend for each flag
+// combination.
+func TestSelectResolvesBackends(t *testing.T) {
+	t.Setenv("AGENTOPS_ORCHESTRATION", "") // neutralize any operator override
+
+	tests := []struct {
+		name   string
+		runner orchestration.CommandRunner
+		pin    string
+		optOut bool
+		want   ports.Backend
+	}{
+		{
+			name:   "ntm absent degrades to claude",
+			runner: fakeRunner{err: errors.New("ntm: not found")},
+			want:   ports.BackendClaude,
+		},
+		{
+			name:   "ntm available selects ntm",
+			runner: fakeRunner{out: []byte(`{"capabilities":["tmux","git"]}`)},
+			want:   ports.BackendNTM,
+		},
+		{
+			name:   "opt-out routes to beads floor",
+			runner: fakeRunner{err: errors.New("ntm: not found")},
+			optOut: true,
+			want:   ports.BackendBeads,
+		},
+		{
+			name:   "pin wins over availability",
+			runner: fakeRunner{out: []byte(`{"capabilities":["tmux","git"]}`)},
+			pin:    "claude",
+			want:   ports.BackendClaude,
+		},
+		{
+			name:   "pin codex (never auto-selected) honored",
+			runner: fakeRunner{err: errors.New("ntm: not found")},
+			pin:    "codex",
+			want:   ports.BackendCodex,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			selector := orchestration.NewSelector(tc.runner)
+			work := WorkSpecFromFlags(tc.pin, tc.optOut)
+			trace, err := selector.Select(context.Background(), work)
+			if err != nil {
+				t.Fatalf("Select returned error: %v", err)
+			}
+			if trace.Chosen != tc.want {
+				t.Fatalf("Chosen: got %q, want %q", trace.Chosen, tc.want)
+			}
+			if len(trace.Considered) == 0 {
+				t.Fatal("Considered ladder must be recorded")
+			}
+		})
+	}
+}
+
+// TestRenderSelectionTraceJSON asserts the JSON branch emits the trace verbatim
+// and parses back into the port shape.
+func TestRenderSelectionTraceJSON(t *testing.T) {
+	trace := ports.SelectionTrace{
+		Chosen:     ports.BackendBeads,
+		Reason:     "WorkSpec.OptOut -> beads floor",
+		Considered: []ports.Backend{"pin", "env", "optout"},
+	}
+	var buf bytes.Buffer
+
+	if err := RenderSelectionTrace(&buf, trace, true); err != nil {
+		t.Fatalf("RenderSelectionTrace: %v", err)
+	}
+
+	var got ports.SelectionTrace
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if got.Chosen != ports.BackendBeads {
+		t.Fatalf("Chosen: got %q, want %q", got.Chosen, ports.BackendBeads)
+	}
+}
+
+// TestRenderSelectionTraceHuman asserts the human-readable branch renders the
+// backend, reason, and ladder.
+func TestRenderSelectionTraceHuman(t *testing.T) {
+	trace := ports.SelectionTrace{
+		Chosen:     ports.BackendClaude,
+		Reason:     "NTM absent -> claude-native fallback",
+		Considered: []ports.Backend{"pin", "env", "optout", "ntm", "claude", "beads"},
+	}
+	var buf bytes.Buffer
+
+	if err := RenderSelectionTrace(&buf, trace, false); err != nil {
+		t.Fatalf("RenderSelectionTrace: %v", err)
+	}
+
+	got := buf.String()
+	for _, want := range []string{"Backend: claude", "Reason:  NTM absent", "pin -> env -> optout -> ntm -> claude -> beads"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}

--- a/docs/reduction/ao-file-buckets.tsv
+++ b/docs/reduction/ao-file-buckets.tsv
@@ -368,8 +368,8 @@ cli/cmd/ao/operator_adapter.go	KEEP	self-contained AO image surface: loop, mind,
 cli/cmd/ao/operator_adapter_test.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	context,errors,internal/ports,os,path/...,strings,testing
 cli/cmd/ao/operator_cmd.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	context,encoding/...,errors,fmt,github.com/...,internal/ports,io,os,path/...
 cli/cmd/ao/operator_cmd_test.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	bytes,context,errors,internal/ports,strings,testing
-cli/cmd/ao/orchestrate.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	context,encoding/...,fmt,github.com/...,internal/orchestration,internal/ports,os/...,strings
-cli/cmd/ao/orchestrate_test.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	bytes,context,encoding/...,errors,github.com/...,internal/orchestration,internal/ports,strings,testing
+cli/cmd/ao/orchestrate.go	KEEP	public compatibility wrapper for `ao orchestrate select`; production selector moved to the mto-fleet route	fmt,github.com/...,internal/adapters
+cli/cmd/ao/orchestrate_test.go	KEEP	wrapper registration test for the retained `ao orchestrate select` public command surface	testing
 cli/cmd/ao/parity_test.go	KEEP	test coverage follows the command surface under review; keep while the source file remains	encoding/...,fmt,internal/goals,internal/pool,internal/types,internal/vibecheck,os,path/...,strings,testing,time
 cli/cmd/ao/patterns_repair.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	bufio,fmt,github.com/...,io,os,path/...,regexp,sort,strings
 cli/cmd/ao/patterns_repair_test.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	bytes,os,path/...,sort,strings,testing


### PR DESCRIPTION
## Summary
- move the production `ao orchestrate select` backend selector adapter and trace renderer to `cli/internal/adapters/mto/orchestrationselect`
- keep `cli/cmd/ao/orchestrate.go` as the public Cobra wrapper and preserve the backend-selection output contract
- update `REDUCTION.md` and `docs/reduction/ao-file-buckets.tsv` for cp-cd9: KEEP 460 / RELOCATE 130 / ARCHIVE 0 / RESEARCH 39 / Total 629

## Validation
- `cd cli && go test ./internal/adapters/mto/orchestrationselect`
- `cd cli && go test ./cmd/ao -run 'TestOrchestrate|TestCobraCommandTreeRegistration|TestCobraExpectedCmdsMatchRegistration|TestCobra'`\n- TSV count parity: rows=629 files=629\n- `bash scripts/regen-all.sh --check`\n- `scripts/regen-command-surfaces.sh --check`\n- `git diff --check`\n- `cd cli && go vet ./...`\n- `cd cli && go test ./... -count=1 -short`\n- `PRE_PUSH_SKIP_MKDOCS=1 bash scripts/pre-push-gate.sh --fast`\n\nNote: fast pre-push produced only warn-only executable-spec link integrity advisories for pre-existing `scenarios --lint` and `trace --orphans` command references.