### PR TITLE
refactor(ao): extract worktree config adapter

### DIFF
--- a/REDUCTION.md
+++ b/REDUCTION.md
@@ -39,10 +39,10 @@ Current inventory count:
 | Bucket | Files |
 |---|---:|
 | KEEP | 460 |
-| RELOCATE | 130 |
+| RELOCATE | 128 |
 | ARCHIVE | 0 |
 | RESEARCH | 39 |
-| Total | 629 |
+| Total | 627 |
 
 Validation command:
 
@@ -125,6 +125,13 @@ The `ao orchestrate select` production selector moved behind the `mto-fleet`
 route. AO keeps the public command wrapper and backend-selection contract in
 place, while the exec-backed NTM probe adapter and trace renderer now live
 under `cli/internal/adapters/mto/orchestrationselect`.
+
+## Extracted Worktree Config Surface
+
+The root pre-run Git worktree repair moved behind the `mto-fleet` adapter
+boundary. AO still runs the startup repair for local safety, but the Git
+environment sanitizer and shared `core.worktree` migration now live under
+`cli/internal/adapters/worktreeconfig` instead of `cli/cmd/ao`.
 
 ## Reversibility
 

--- a/cli/cmd/ao/root.go
+++ b/cli/cmd/ao/root.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/boshu2/agentops/cli/internal/adapters/worktreeconfig"
 	"github.com/boshu2/agentops/cli/internal/doctor"
 )
 
@@ -53,14 +54,14 @@ Use "ao <command> --help" for more information about a command.`,
 			output = "json"
 		}
 		syncConfigFlagToEnv()
-		if err := sanitizeGitProcessEnv(); err != nil {
+		if err := worktreeconfig.SanitizeGitProcessEnv(); err != nil {
 			return err
 		}
 		cwd, err := os.Getwd()
 		if err != nil {
 			return err
 		}
-		if err := repairSharedCoreWorktreeConfig(cwd); err != nil {
+		if err := worktreeconfig.RepairSharedCoreWorktreeConfig(cwd); err != nil {
 			return err
 		}
 

--- a/cli/cmd/ao/testutil_test.go
+++ b/cli/cmd/ao/testutil_test.go
@@ -633,6 +633,21 @@ func initTestRepo(t *testing.T) string {
 	}})
 }
 
+// realPathForTest resolves symlinks when possible and falls back to an absolute
+// path. Useful for Git worktree tests on hosts where temp dirs may be symlinked.
+func realPathForTest(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolved
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatalf("filepath.Abs(%q): %v", path, err)
+	}
+	return abs
+}
+
 // initMinimalGitRepo creates a git repo with one empty commit. Use this when
 // you need a valid git repo but don't care about file history.
 // Origin: uat_smoke_test.go (was initGitRepo)

--- a/cli/internal/adapters/worktreeconfig/worktree_config.go
+++ b/cli/internal/adapters/worktreeconfig/worktree_config.go
@@ -1,5 +1,5 @@
 // practices: [microservices, team-topologies]
-package main
+package worktreeconfig
 
 import (
 	"fmt"
@@ -9,7 +9,9 @@ import (
 	"strings"
 )
 
-func sanitizeGitProcessEnv() error {
+// SanitizeGitProcessEnv removes repository-discovery variables that can pin
+// Git commands to the wrong worktree when ao starts inside nested sessions.
+func SanitizeGitProcessEnv() error {
 	for _, key := range []string{"GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"} {
 		if err := os.Unsetenv(key); err != nil {
 			return fmt.Errorf("unset %s: %w", key, err)
@@ -18,7 +20,9 @@ func sanitizeGitProcessEnv() error {
 	return nil
 }
 
-func repairSharedCoreWorktreeConfig(cwd string) error {
+// RepairSharedCoreWorktreeConfig migrates a shared core.worktree setting into
+// per-worktree config when a linked worktree has inherited a stale top-level.
+func RepairSharedCoreWorktreeConfig(cwd string) error {
 	if strings.TrimSpace(cwd) == "" {
 		return nil
 	}
@@ -129,4 +133,21 @@ func runGitWithConfigFile(configPath string, args ...string) error {
 		return fmt.Errorf("git config --file %s %s: %w (%s)", configPath, strings.Join(args, " "), err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+func gitDiscoveryEnv() []string {
+	env := make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		switch {
+		case strings.HasPrefix(entry, "GIT_DIR="):
+			continue
+		case strings.HasPrefix(entry, "GIT_WORK_TREE="):
+			continue
+		case strings.HasPrefix(entry, "GIT_COMMON_DIR="):
+			continue
+		default:
+			env = append(env, entry)
+		}
+	}
+	return env
 }

--- a/cli/internal/adapters/worktreeconfig/worktree_config_test.go
+++ b/cli/internal/adapters/worktreeconfig/worktree_config_test.go
@@ -1,5 +1,5 @@
 // practices: [microservices, team-topologies]
-package main
+package worktreeconfig
 
 import (
 	"os"
@@ -30,11 +30,11 @@ func TestRepairSharedCoreWorktreeConfig_MigratesLinkedWorktrees(t *testing.T) {
 		t.Fatalf("broken linked worktree reproduction failed: got toplevel %q, want %q", got, repoRealPath)
 	}
 
-	if err := repairSharedCoreWorktreeConfig(nestedDir); err != nil {
-		t.Fatalf("repairSharedCoreWorktreeConfig: %v", err)
+	if err := RepairSharedCoreWorktreeConfig(nestedDir); err != nil {
+		t.Fatalf("RepairSharedCoreWorktreeConfig: %v", err)
 	}
-	if err := sanitizeGitProcessEnv(); err != nil {
-		t.Fatalf("sanitizeGitProcessEnv: %v", err)
+	if err := SanitizeGitProcessEnv(); err != nil {
+		t.Fatalf("SanitizeGitProcessEnv: %v", err)
 	}
 
 	if got := realPathForTest(t, strings.TrimSpace(runGitOutputCommand(t, worktreePath, "rev-parse", "--show-toplevel"))); got != worktreeRealPath {
@@ -54,6 +54,45 @@ func TestRepairSharedCoreWorktreeConfig_MigratesLinkedWorktrees(t *testing.T) {
 	if perWorktree != worktreeRealPath {
 		t.Fatalf("linked worktree core.worktree = %q, want %q", perWorktree, worktreeRealPath)
 	}
+}
+
+func TestRepairSharedCoreWorktreeConfig_NoOpOutsideGitRepo(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "note.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RepairSharedCoreWorktreeConfig(dir); err != nil {
+		t.Fatalf("expected no-op outside repo, got %v", err)
+	}
+}
+
+// initTestRepo creates a real git repo with one commit in a temp dir and
+// returns its root. It skips the test when git is unavailable.
+func initTestRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s: %v", args, out, err)
+		}
+	}
+	runGit("init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", ".")
+	runGit("commit", "-m", "seed")
+	return root
 }
 
 func runGitCommand(t *testing.T, cwd string, args ...string) {
@@ -102,14 +141,4 @@ func realPathForTest(t *testing.T, path string) string {
 		t.Fatalf("filepath.Abs(%q): %v", path, err)
 	}
 	return abs
-}
-
-func TestRepairSharedCoreWorktreeConfig_NoOpOutsideGitRepo(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "note.txt"), []byte("hello\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := repairSharedCoreWorktreeConfig(dir); err != nil {
-		t.Fatalf("expected no-op outside repo, got %v", err)
-	}
 }

--- a/docs/reduction/ao-file-buckets.tsv
+++ b/docs/reduction/ao-file-buckets.tsv
@@ -437,7 +437,7 @@ cli/cmd/ao/retrieval_search_backends_test.go	KEEP	self-contained AO image surfac
 cli/cmd/ao/retrieval_search_eval.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	encoding/...,fmt,internal/storage,os,path/...,strings
 cli/cmd/ao/retrieval_search_eval_test.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	encoding/...,os,path/...,strings,testing
 cli/cmd/ao/robot_docs.go	RESEARCH	unclear ownership from filename/import shape; inspect before cut, relocate, or archive	fmt,github.com/...,strings
-cli/cmd/ao/root.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	context,errors,fmt,github.com/...,internal/doctor,os,os/...,strings
+cli/cmd/ao/root.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	context,errors,fmt,github.com/...,internal/adapters,internal/doctor,os,os/...,strings
 cli/cmd/ao/round4_misc_test.go	KEEP	test coverage follows the command surface under review; keep while the source file remains	internal/types,testing
 cli/cmd/ao/round5_test.go	KEEP	test coverage follows the command surface under review; keep while the source file remains	context,encoding/...,errors,fmt,internal/storage,internal/types,io,os,os/...,path/...,testing,time
 cli/cmd/ao/rpi.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	github.com/...
@@ -624,7 +624,5 @@ cli/cmd/ao/wiki.go	KEEP	self-contained AO image surface: loop, mind, local Themi
 cli/cmd/ao/wiki_test.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	internal/ports,os,path/...,strings,testing
 cli/cmd/ao/workflow_integration_test.go	KEEP	test coverage follows the command surface under review; keep while the source file remains	encoding/...,fmt,internal/ratchet,os,path/...,strings,testing,time
 cli/cmd/ao/worktree.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	cmp,context,fmt,github.com/...,os,os/...,path/...,regexp,slices,sort,strconv,strings,time
-cli/cmd/ao/worktree_config.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	fmt,os,os/...,path/...,strings
-cli/cmd/ao/worktree_config_test.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	os,os/...,path/...,strings,testing
 cli/cmd/ao/worktree_gc_test.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	path/...,strconv,testing,time
 cli/cmd/ao/worktree_test.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	encoding/...,fmt,os,os/...,path/...,strings,testing,time


### PR DESCRIPTION
## Summary
- move root pre-run Git worktree repair from `cli/cmd/ao` into `cli/internal/adapters/worktreeconfig`
- keep root startup behavior intact through exported adapter calls
- update `REDUCTION.md` and `docs/reduction/ao-file-buckets.tsv` for cp-cd9: KEEP 460 / RELOCATE 128 / ARCHIVE 0 / RESEARCH 39 / Total 627

## Validation
- `cd cli && go test ./internal/adapters/worktreeconfig`
- `cd cli && go test ./cmd/ao -run 'TestCobraCommandTreeRegistration|TestCobraExpectedCmdsMatchRegistration|TestCobra|TestWorktree'`\n- TSV count parity: rows=627 files=627\n- `bash scripts/regen-all.sh --check`\n- `scripts/regen-command-surfaces.sh --check`\n- `git diff --check`\n- `cd cli && go vet ./...`\n- `cd cli && go test ./... -count=1 -short`\n- `PRE_PUSH_SKIP_MKDOCS=1 bash scripts/pre-push-gate.sh --fast`\n\nNote: fast pre-push produced only warn-only executable-spec link integrity advisories for pre-existing `scenarios --lint` and `trace --orphans` command references.