### PR TITLE
refactor(ao): extract turn verify adapter (cp-cd9 #turnverify-adapter)

### DIFF
--- a/REDUCTION.md
+++ b/REDUCTION.md
@@ -38,11 +38,11 @@ Current inventory count:
 
 | Bucket | Files |
 |---|---:|
-| KEEP | 460 |
-| RELOCATE | 126 |
+| KEEP | 461 |
+| RELOCATE | 124 |
 | ARCHIVE | 0 |
 | RESEARCH | 39 |
-| Total | 625 |
+| Total | 624 |
 
 Validation command:
 
@@ -140,6 +140,14 @@ adapter boundary. AO keeps the `ao agents lint` public command wrapper and
 exit-code contract in place, while script invocation, stdout/stderr forwarding,
 JSON flag forwarding, and non-zero exit mapping now live under
 `cli/internal/adapters/agentslint`.
+
+## Extracted Turn Verify Adapter Surface
+
+The Evidenced-Turn verification evaluator moved behind a local assurance
+adapter boundary. AO keeps the `ao turn verify` public command wrapper and
+verdict contract in place, while input decoding, provenance ledger loading,
+trace-graph orphan checks, predicate evaluation, and verdict rendering now live
+under `cli/internal/adapters/turnverify`.
 
 ## Reversibility
 

--- a/cli/cmd/ao/turn_verify.go
+++ b/cli/cmd/ao/turn_verify.go
@@ -2,16 +2,9 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"strings"
-
 	"github.com/spf13/cobra"
 
-	"github.com/boshu2/agentops/cli/internal/evidencedturn"
-	"github.com/boshu2/agentops/cli/internal/provenancegraph"
-	"github.com/boshu2/agentops/cli/internal/turnstate"
+	"github.com/boshu2/agentops/cli/internal/adapters/turnverify"
 )
 
 var (
@@ -31,25 +24,6 @@ var turnCmd = &cobra.Command{
 unit of work. An Evidenced Turn is the assurance contract that lets a bead
 legally transition validated->closed: a hash-chained state log, covered
 scenarios, resolving Evidence, a provenance event, and no orphan.`,
-}
-
-// turnInputFile is the on-disk shape consumed by `ao turn verify --input`. It
-// carries the facts that are NOT in the committed provenance ledger: the bead's
-// state_transition log and its Closes-scenario coverage. Provenance edges and
-// orphans are read from the ledger (or --ledger) so they stay the audit
-// authority, not a hand-supplied claim.
-type turnInputFile struct {
-	BeadID      string                   `json:"bead_id"`
-	Transitions []turnstate.Transition   `json:"transitions"`
-	Scenarios   []evidencedturn.Scenario `json:"scenarios"`
-	// AuthorID and JudgeID carry the no-self-grading invariant (ag-lmdx.4):
-	// the identity of the context that AUTHORED the artifact vs. the context
-	// that PRODUCED the acceptance verdict. The author_neq_validator predicate
-	// fails when they are equal (a self-graded, autocorrelated verdict) unless
-	// --allow-self waives it. Empty judge_id also fails: independence that was
-	// never recorded cannot be asserted.
-	AuthorID string `json:"author_id,omitempty"`
-	JudgeID  string `json:"judge_id,omitempty"`
 }
 
 var turnVerifyCmd = &cobra.Command{
@@ -121,133 +95,17 @@ func init() {
 func runTurnVerify(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
 
-	beadID := strings.TrimSpace(args[0])
-	if beadID == "" {
-		return fmt.Errorf("a non-empty <bead> is required")
-	}
-	if turnVerifyInput == "" {
-		return fmt.Errorf("ao turn verify requires --input <turn-input.json>")
-	}
-
-	tf, err := readTurnInputFile(turnVerifyInput)
-	if err != nil {
-		return err
-	}
-	// The positional bead is authoritative; an input file declaring a different
-	// bead is a mistake worth surfacing rather than silently overriding.
-	if tf.BeadID != "" && tf.BeadID != beadID {
-		return fmt.Errorf("input file bead_id %q does not match <bead> %q", tf.BeadID, beadID)
-	}
-
 	ledgerPath := turnVerifyLedger
 	if ledgerPath == "" {
 		ledgerPath = resolveLedgerPath()
 	}
-	edges, err := readLedgerEdges(ledgerPath)
-	if err != nil {
-		return err
-	}
-
-	var orphans []provenancegraph.OrphanFinding
-	orphanChecked := false
-	if turnVerifyGraph != "" {
-		graph, gerr := provenancegraph.ReadGraphRecords(turnVerifyGraph)
-		if gerr != nil {
-			return fmt.Errorf("read provenance trace-graph: %w", gerr)
-		}
-		// Any orphan in the turn's trace-graph means its provenance is
-		// incomplete — mirrors the repo-wide `ao provenance trace --orphans`
-		// no-orphan gate. A turn with a dangling artifact is not provably done.
-		orphans = provenancegraph.FindOrphans(graph)
-		orphanChecked = true
-	}
-
-	v, err := evidencedturn.Evaluate(evidencedturn.Input{
-		BeadID:          beadID,
-		Transitions:     tf.Transitions,
-		Scenarios:       tf.Scenarios,
-		ProvenanceEdges: edges,
-		OrphanFindings:  orphans,
-		OrphanChecked:   orphanChecked,
-		AuthorID:        tf.AuthorID,
-		JudgeID:         tf.JudgeID,
-		AllowSelf:       turnVerifyAllowSelf,
+	return turnverify.Run(turnverify.Options{
+		BeadID:     args[0],
+		InputPath:  turnVerifyInput,
+		LedgerPath: ledgerPath,
+		GraphPath:  turnVerifyGraph,
+		JSON:       turnVerifyJSON,
+		AllowSelf:  turnVerifyAllowSelf,
+		Stdout:     cmd.OutOrStdout(),
 	})
-	if err != nil {
-		return err
-	}
-
-	if err := renderVerdict(cmd, v); err != nil {
-		return err
-	}
-	if !v.Done {
-		// Non-zero exit makes this usable as a validated->closed transition
-		// guard. SilenceUsage is set, so cobra won't print usage on this.
-		return fmt.Errorf("turn %s is NOT done: %d gap(s)", v.BeadID, len(v.Gaps))
-	}
-	return nil
-}
-
-// readTurnInputFile loads and decodes the turn-input JSON file, rejecting
-// unknown fields so a malformed contract fails loudly.
-func readTurnInputFile(path string) (turnInputFile, error) {
-	b, err := os.ReadFile(path) // #nosec G304 -- operator-supplied input path, same trust model as --graph
-	if err != nil {
-		return turnInputFile{}, fmt.Errorf("read turn-input file %q: %w", path, err)
-	}
-	dec := json.NewDecoder(strings.NewReader(string(b)))
-	dec.DisallowUnknownFields()
-	var tf turnInputFile
-	if err := dec.Decode(&tf); err != nil {
-		return turnInputFile{}, fmt.Errorf("parse turn-input file %q: %w", path, err)
-	}
-	return tf, nil
-}
-
-// readLedgerEdges reads the provenance ledger edges. A missing ledger is not a
-// hard error here: the evidencedturn evaluator will simply fail the
-// provenance_event predicate with a legible reason rather than crash.
-func readLedgerEdges(path string) ([]provenancegraph.Edge, error) {
-	if _, err := os.Stat(path); err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("stat provenance ledger %q: %w", path, err)
-	}
-	store := provenancegraph.NewStore(path)
-	edges, err := store.Read()
-	if err != nil {
-		return nil, fmt.Errorf("read provenance ledger: %w", err)
-	}
-	return edges, nil
-}
-
-// renderVerdict prints the legible checklist (or JSON). The text form is the
-// agent-facing default: a status glyph, the predicate, and its reason.
-func renderVerdict(cmd *cobra.Command, v evidencedturn.Verdict) error {
-	out := cmd.OutOrStdout()
-	if turnVerifyJSON {
-		enc := json.NewEncoder(out)
-		enc.SetIndent("", "  ")
-		return enc.Encode(v)
-	}
-
-	fmt.Fprintf(out, "Evidenced-Turn DoD for %s\n", v.BeadID)
-	for _, p := range v.Predicates {
-		glyph := "FAIL"
-		if p.Passed {
-			glyph = "PASS"
-		}
-		fmt.Fprintf(out, "  [%s] %-18s %s\n", glyph, p.Name, p.Reason)
-	}
-	fmt.Fprintln(out)
-	if v.Done {
-		fmt.Fprintf(out, "VERDICT: DONE — validated->closed is legal for %s\n", v.BeadID)
-	} else {
-		fmt.Fprintf(out, "VERDICT: NOT DONE — %d gap(s):\n", len(v.Gaps))
-		for _, g := range v.Gaps {
-			fmt.Fprintf(out, "  - %s\n", g)
-		}
-	}
-	return nil
 }

--- a/cli/internal/adapters/turnverify/verify.go
+++ b/cli/internal/adapters/turnverify/verify.go
@@ -1,0 +1,178 @@
+// practices: [design-by-contract, in-toto-provenance]
+package turnverify
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/boshu2/agentops/cli/internal/evidencedturn"
+	"github.com/boshu2/agentops/cli/internal/provenancegraph"
+	"github.com/boshu2/agentops/cli/internal/turnstate"
+)
+
+// Options configures the Evidenced-Turn verification adapter.
+type Options struct {
+	BeadID     string
+	InputPath  string
+	LedgerPath string
+	GraphPath  string
+	JSON       bool
+	AllowSelf  bool
+	Stdout     io.Writer
+}
+
+// InputFile is the on-disk shape consumed by `ao turn verify --input`. It
+// carries the facts that are NOT in the committed provenance ledger: the bead's
+// state_transition log and its Closes-scenario coverage. Provenance edges and
+// orphans are read from the ledger (or --ledger) so they stay the audit
+// authority, not a hand-supplied claim.
+type InputFile struct {
+	BeadID      string                   `json:"bead_id"`
+	Transitions []turnstate.Transition   `json:"transitions"`
+	Scenarios   []evidencedturn.Scenario `json:"scenarios"`
+	// AuthorID and JudgeID carry the no-self-grading invariant (ag-lmdx.4):
+	// the identity of the context that AUTHORED the artifact vs. the context
+	// that PRODUCED the acceptance verdict. The author_neq_validator predicate
+	// fails when they are equal (a self-graded, autocorrelated verdict) unless
+	// AllowSelf waives it. Empty judge_id also fails: independence that was
+	// never recorded cannot be asserted.
+	AuthorID string `json:"author_id,omitempty"`
+	JudgeID  string `json:"judge_id,omitempty"`
+}
+
+// Run evaluates one bead's Evidenced-Turn Definition-of-Done and writes either
+// a legible checklist or the JSON verdict to Stdout.
+func Run(opts Options) error {
+	beadID := strings.TrimSpace(opts.BeadID)
+	if beadID == "" {
+		return fmt.Errorf("a non-empty <bead> is required")
+	}
+	if opts.InputPath == "" {
+		return fmt.Errorf("ao turn verify requires --input <turn-input.json>")
+	}
+
+	tf, err := ReadInputFile(opts.InputPath)
+	if err != nil {
+		return err
+	}
+	// The positional bead is authoritative; an input file declaring a different
+	// bead is a mistake worth surfacing rather than silently overriding.
+	if tf.BeadID != "" && tf.BeadID != beadID {
+		return fmt.Errorf("input file bead_id %q does not match <bead> %q", tf.BeadID, beadID)
+	}
+
+	edges, err := ReadLedgerEdges(opts.LedgerPath)
+	if err != nil {
+		return err
+	}
+
+	var orphans []provenancegraph.OrphanFinding
+	orphanChecked := false
+	if opts.GraphPath != "" {
+		graph, gerr := provenancegraph.ReadGraphRecords(opts.GraphPath)
+		if gerr != nil {
+			return fmt.Errorf("read provenance trace-graph: %w", gerr)
+		}
+		// Any orphan in the turn's trace-graph means its provenance is
+		// incomplete: a turn with a dangling artifact is not provably done.
+		orphans = provenancegraph.FindOrphans(graph)
+		orphanChecked = true
+	}
+
+	v, err := evidencedturn.Evaluate(evidencedturn.Input{
+		BeadID:          beadID,
+		Transitions:     tf.Transitions,
+		Scenarios:       tf.Scenarios,
+		ProvenanceEdges: edges,
+		OrphanFindings:  orphans,
+		OrphanChecked:   orphanChecked,
+		AuthorID:        tf.AuthorID,
+		JudgeID:         tf.JudgeID,
+		AllowSelf:       opts.AllowSelf,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := RenderVerdict(opts.Stdout, v, opts.JSON); err != nil {
+		return err
+	}
+	if !v.Done {
+		// Non-zero exit makes this usable as a validated->closed transition
+		// guard.
+		return fmt.Errorf("turn %s is NOT done: %d gap(s)", v.BeadID, len(v.Gaps))
+	}
+	return nil
+}
+
+// ReadInputFile loads and decodes the turn-input JSON file, rejecting unknown
+// fields so a malformed contract fails loudly.
+func ReadInputFile(path string) (InputFile, error) {
+	b, err := os.ReadFile(path) // #nosec G304 -- operator-supplied input path, same trust model as --graph
+	if err != nil {
+		return InputFile{}, fmt.Errorf("read turn-input file %q: %w", path, err)
+	}
+	dec := json.NewDecoder(strings.NewReader(string(b)))
+	dec.DisallowUnknownFields()
+	var tf InputFile
+	if err := dec.Decode(&tf); err != nil {
+		return InputFile{}, fmt.Errorf("parse turn-input file %q: %w", path, err)
+	}
+	return tf, nil
+}
+
+// ReadLedgerEdges reads the provenance ledger edges. A missing ledger is not a
+// hard error here: the evidencedturn evaluator will simply fail the
+// provenance_event predicate with a legible reason rather than crash.
+func ReadLedgerEdges(path string) ([]provenancegraph.Edge, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat provenance ledger %q: %w", path, err)
+	}
+	store := provenancegraph.NewStore(path)
+	edges, err := store.Read()
+	if err != nil {
+		return nil, fmt.Errorf("read provenance ledger: %w", err)
+	}
+	return edges, nil
+}
+
+// RenderVerdict prints the legible checklist or JSON. The text form is the
+// agent-facing default: a status glyph, the predicate, and its reason.
+func RenderVerdict(out io.Writer, v evidencedturn.Verdict, asJSON bool) error {
+	if out == nil {
+		out = io.Discard
+	}
+	if asJSON {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(v)
+	}
+
+	fmt.Fprintf(out, "Evidenced-Turn DoD for %s\n", v.BeadID)
+	for _, p := range v.Predicates {
+		glyph := "FAIL"
+		if p.Passed {
+			glyph = "PASS"
+		}
+		fmt.Fprintf(out, "  [%s] %-18s %s\n", glyph, p.Name, p.Reason)
+	}
+	fmt.Fprintln(out)
+	if v.Done {
+		fmt.Fprintf(out, "VERDICT: DONE — validated->closed is legal for %s\n", v.BeadID)
+	} else {
+		fmt.Fprintf(out, "VERDICT: NOT DONE — %d gap(s):\n", len(v.Gaps))
+		for _, g := range v.Gaps {
+			fmt.Fprintf(out, "  - %s\n", g)
+		}
+	}
+	return nil
+}

--- a/cli/internal/adapters/turnverify/verify_test.go
+++ b/cli/internal/adapters/turnverify/verify_test.go
@@ -1,7 +1,8 @@
 // practices: [design-by-contract, in-toto-provenance]
-package main
+package turnverify
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -12,16 +13,7 @@ import (
 	"github.com/boshu2/agentops/cli/internal/turnstate"
 )
 
-// resetTurnVerifyFlags restores the turn-verify flags to a known baseline so
-// flag state does not leak across tests.
-func resetTurnVerifyFlags() {
-	turnVerifyInput = ""
-	turnVerifyLedger = ""
-	turnVerifyJSON = false
-	turnVerifyAllowSelf = false
-}
-
-// closedTransitionsJSON builds a sealed ""->in_progress->validated->closed log
+// closedTransitions builds a sealed ""->in_progress->validated->closed log
 // for the bead and returns it as the transitions field for the input file.
 func closedTransitions(t *testing.T, bead string) []turnstate.Transition {
 	t.Helper()
@@ -45,9 +37,7 @@ func closedTransitions(t *testing.T, bead string) []turnstate.Transition {
 
 // writeTurnInput marshals a turn-input file to a temp path and returns it. It
 // records a distinct author/judge by default so the no-self-grading invariant
-// (author_neq_validator, ag-lmdx.4) passes for the otherwise-complete fixtures;
-// tests exercising the guard set author_id/judge_id explicitly via
-// writeTurnInputGraded.
+// passes for otherwise-complete fixtures.
 func writeTurnInput(t *testing.T, bead string, transitions []turnstate.Transition, scenarios []evidencedturn.Scenario) string {
 	t.Helper()
 	return writeTurnInputGraded(t, bead, transitions, scenarios, "session:author", "session:judge")
@@ -57,7 +47,7 @@ func writeTurnInput(t *testing.T, bead string, transitions []turnstate.Transitio
 // for tests of the author_neq_validator predicate.
 func writeTurnInputGraded(t *testing.T, bead string, transitions []turnstate.Transition, scenarios []evidencedturn.Scenario, authorID, judgeID string) string {
 	t.Helper()
-	tf := turnInputFile{BeadID: bead, Transitions: transitions, Scenarios: scenarios, AuthorID: authorID, JudgeID: judgeID}
+	tf := InputFile{BeadID: bead, Transitions: transitions, Scenarios: scenarios, AuthorID: authorID, JudgeID: judgeID}
 	b, err := json.Marshal(tf)
 	if err != nil {
 		t.Fatalf("marshal turn input: %v", err)
@@ -85,15 +75,9 @@ func writeLedger(t *testing.T, lines []string) string {
 }
 
 // beadEdgeLine builds a sealed provenance-edge ledger line referencing the bead
-// as to_id (a "commit implements" edge). It is a node/edge graph line too:
-// FindOrphans reads "record"-tagged lines, while the Edge store reads the
-// schema_version-tagged form. We emit the schema_version Edge form for the
-// provenance_event predicate; orphan tests use the record/graph form separately.
+// as to_id (a "commit implements" edge).
 func beadEdgeLine(t *testing.T, bead string) string {
 	t.Helper()
-	// A minimal valid Edge JSON (the store only needs to parse + the evaluator
-	// only matches from_id/to_id). We bypass Seal here and hand-write a line
-	// the store reads; the evaluator does not re-verify the ledger chain.
 	obj := map[string]any{
 		"schema_version": "agentops-sdlc-provenance.v1",
 		"from_id":        "commit:abc123",
@@ -115,8 +99,6 @@ func beadEdgeLine(t *testing.T, bead string) string {
 	return string(b)
 }
 
-// writeCleanGraph writes a node/edge trace-graph where the bead's produced
-// artifact HAS an inbound edge (so it is not an orphan).
 func writeCleanGraph(t *testing.T, bead string) string {
 	t.Helper()
 	artifact := "cli/internal/evidencedturn/evidencedturn.go"
@@ -125,11 +107,9 @@ func writeCleanGraph(t *testing.T, bead string) string {
 		`{"record":"node","id":"` + artifact + `","type":"artifact","path":"` + artifact + `"}`,
 		`{"record":"edge","edge_type":"bead_produces_artifact","from_id":"` + bead + `","to_id":"` + artifact + `"}`,
 	}
-	return writeLedger(t, lines) // same JSONL writer; distinct temp dir per call
+	return writeLedger(t, lines)
 }
 
-// writeOrphanGraph writes a node/edge trace-graph containing an artifact node
-// with NO inbound edge (an orphan).
 func writeOrphanGraph(t *testing.T, bead string) string {
 	t.Helper()
 	artifact := "cli/orphan.go"
@@ -140,15 +120,28 @@ func writeOrphanGraph(t *testing.T, bead string) string {
 	return writeLedger(t, lines)
 }
 
-func TestTurnVerify_CompleteTurnVerifies(t *testing.T) {
-	resetTurnVerifyFlags()
+func runForTest(bead, input, ledger, graph string, jsonOut, allowSelf bool) (string, error) {
+	var out bytes.Buffer
+	err := Run(Options{
+		BeadID:     bead,
+		InputPath:  input,
+		LedgerPath: ledger,
+		GraphPath:  graph,
+		JSON:       jsonOut,
+		AllowSelf:  allowSelf,
+		Stdout:     &out,
+	})
+	return out.String(), err
+}
+
+func TestRun_CompleteTurnVerifies(t *testing.T) {
 	bead := "ag-lmdx.5"
 	input := writeTurnInput(t, bead, closedTransitions(t, bead),
 		[]evidencedturn.Scenario{{Slug: "ao-turn-verify", HasPassingTest: true, EvidenceResolved: true}})
 	ledger := writeLedger(t, []string{beadEdgeLine(t, bead)})
 	graph := writeCleanGraph(t, bead)
 
-	out, err := executeCommand("turn", "verify", bead, "--input", input, "--ledger", ledger, "--graph", graph)
+	out, err := runForTest(bead, input, ledger, graph, false, false)
 	if err != nil {
 		t.Fatalf("turn verify of a complete turn should succeed, got err=%v\noutput=%s", err, out)
 	}
@@ -160,15 +153,13 @@ func TestTurnVerify_CompleteTurnVerifies(t *testing.T) {
 	}
 }
 
-func TestTurnVerify_IncompleteTurnIsNotDone(t *testing.T) {
-	resetTurnVerifyFlags()
+func TestRun_IncompleteTurnIsNotDone(t *testing.T) {
 	bead := "ag-lmdx.5"
-	// Scenario has no passing test -> not done; the uncovered scenario is named.
 	input := writeTurnInput(t, bead, closedTransitions(t, bead),
 		[]evidencedturn.Scenario{{Slug: "ao-turn-verify", HasPassingTest: false, EvidenceResolved: true}})
 	ledger := writeLedger(t, []string{beadEdgeLine(t, bead)})
 
-	out, err := executeCommand("turn", "verify", bead, "--input", input, "--ledger", ledger)
+	out, err := runForTest(bead, input, ledger, "", false, false)
 	if err == nil {
 		t.Fatalf("turn verify of an incomplete turn must exit non-zero\noutput=%s", out)
 	}
@@ -183,19 +174,17 @@ func TestTurnVerify_IncompleteTurnIsNotDone(t *testing.T) {
 	}
 }
 
-func TestTurnVerify_JSONShape(t *testing.T) {
-	resetTurnVerifyFlags()
+func TestRun_JSONShape(t *testing.T) {
 	bead := "ag-lmdx.5"
 	input := writeTurnInput(t, bead, closedTransitions(t, bead),
 		[]evidencedturn.Scenario{{Slug: "ao-turn-verify", HasPassingTest: true, EvidenceResolved: true}})
 	ledger := writeLedger(t, []string{beadEdgeLine(t, bead)})
 	graph := writeCleanGraph(t, bead)
 
-	out, err := executeCommand("turn", "verify", bead, "--input", input, "--ledger", ledger, "--graph", graph, "--json")
+	out, err := runForTest(bead, input, ledger, graph, true, false)
 	if err != nil {
 		t.Fatalf("turn verify --json should succeed, got err=%v\noutput=%s", err, out)
 	}
-	// The JSON object may be preceded by nothing; find the first '{'.
 	idx := strings.Index(out, "{")
 	if idx < 0 {
 		t.Fatalf("no JSON object in output:\n%s", out)
@@ -218,10 +207,7 @@ func TestTurnVerify_JSONShape(t *testing.T) {
 	}
 }
 
-// TestTurnVerify_SelfGradedRefused: a verdict whose judge_id equals author_id
-// is refused (the no-self-grading invariant, ag-lmdx.4) and exits non-zero.
-func TestTurnVerify_SelfGradedRefused(t *testing.T) {
-	resetTurnVerifyFlags()
+func TestRun_SelfGradedRefused(t *testing.T) {
 	bead := "ag-lmdx.5"
 	input := writeTurnInputGraded(t, bead, closedTransitions(t, bead),
 		[]evidencedturn.Scenario{{Slug: "ao-turn-verify", HasPassingTest: true, EvidenceResolved: true}},
@@ -229,7 +215,7 @@ func TestTurnVerify_SelfGradedRefused(t *testing.T) {
 	ledger := writeLedger(t, []string{beadEdgeLine(t, bead)})
 	graph := writeCleanGraph(t, bead)
 
-	out, err := executeCommand("turn", "verify", bead, "--input", input, "--ledger", ledger, "--graph", graph)
+	out, err := runForTest(bead, input, ledger, graph, false, false)
 	if err == nil {
 		t.Fatalf("self-graded verdict must exit non-zero\noutput=%s", out)
 	}
@@ -238,10 +224,7 @@ func TestTurnVerify_SelfGradedRefused(t *testing.T) {
 	}
 }
 
-// TestTurnVerify_AllowSelfPasses: --allow-self waives the no-self-grading guard
-// for the inline fallback path; an otherwise-complete self-graded turn is DONE.
-func TestTurnVerify_AllowSelfPasses(t *testing.T) {
-	resetTurnVerifyFlags()
+func TestRun_AllowSelfPasses(t *testing.T) {
 	bead := "ag-lmdx.5"
 	input := writeTurnInputGraded(t, bead, closedTransitions(t, bead),
 		[]evidencedturn.Scenario{{Slug: "ao-turn-verify", HasPassingTest: true, EvidenceResolved: true}},
@@ -249,7 +232,7 @@ func TestTurnVerify_AllowSelfPasses(t *testing.T) {
 	ledger := writeLedger(t, []string{beadEdgeLine(t, bead)})
 	graph := writeCleanGraph(t, bead)
 
-	out, err := executeCommand("turn", "verify", bead, "--input", input, "--ledger", ledger, "--graph", graph, "--allow-self")
+	out, err := runForTest(bead, input, ledger, graph, false, true)
 	if err != nil {
 		t.Fatalf("turn verify --allow-self should succeed, got err=%v\noutput=%s", err, out)
 	}
@@ -258,15 +241,13 @@ func TestTurnVerify_AllowSelfPasses(t *testing.T) {
 	}
 }
 
-func TestTurnVerify_NoProvenanceEventFails(t *testing.T) {
-	resetTurnVerifyFlags()
+func TestRun_NoProvenanceEventFails(t *testing.T) {
 	bead := "ag-lmdx.5"
 	input := writeTurnInput(t, bead, closedTransitions(t, bead),
 		[]evidencedturn.Scenario{{Slug: "ao-turn-verify", HasPassingTest: true, EvidenceResolved: true}})
-	// Empty ledger -> no provenance edge references the bead.
 	ledger := writeLedger(t, nil)
 
-	out, err := executeCommand("turn", "verify", bead, "--input", input, "--ledger", ledger)
+	out, err := runForTest(bead, input, ledger, "", false, false)
 	if err == nil {
 		t.Fatalf("missing provenance event must exit non-zero\noutput=%s", out)
 	}
@@ -275,15 +256,14 @@ func TestTurnVerify_NoProvenanceEventFails(t *testing.T) {
 	}
 }
 
-func TestTurnVerify_OrphanArtifactFails(t *testing.T) {
-	resetTurnVerifyFlags()
+func TestRun_OrphanArtifactFails(t *testing.T) {
 	bead := "ag-lmdx.5"
 	input := writeTurnInput(t, bead, closedTransitions(t, bead),
 		[]evidencedturn.Scenario{{Slug: "ao-turn-verify", HasPassingTest: true, EvidenceResolved: true}})
 	ledger := writeLedger(t, []string{beadEdgeLine(t, bead)})
 	graph := writeOrphanGraph(t, bead)
 
-	out, err := executeCommand("turn", "verify", bead, "--input", input, "--ledger", ledger, "--graph", graph)
+	out, err := runForTest(bead, input, ledger, graph, false, false)
 	if err == nil {
 		t.Fatalf("orphan artifact must exit non-zero\noutput=%s", out)
 	}
@@ -295,14 +275,13 @@ func TestTurnVerify_OrphanArtifactFails(t *testing.T) {
 	}
 }
 
-func TestTurnVerify_NoGraphLeavesOrphanUnchecked(t *testing.T) {
-	resetTurnVerifyFlags()
+func TestRun_NoGraphLeavesOrphanUnchecked(t *testing.T) {
 	bead := "ag-lmdx.5"
 	input := writeTurnInput(t, bead, closedTransitions(t, bead),
 		[]evidencedturn.Scenario{{Slug: "ao-turn-verify", HasPassingTest: true, EvidenceResolved: true}})
 	ledger := writeLedger(t, []string{beadEdgeLine(t, bead)})
 
-	out, err := executeCommand("turn", "verify", bead, "--input", input, "--ledger", ledger)
+	out, err := runForTest(bead, input, ledger, "", false, false)
 	if err == nil {
 		t.Fatalf("missing --graph leaves no_orphan unchecked -> not done\noutput=%s", out)
 	}
@@ -314,9 +293,8 @@ func TestTurnVerify_NoGraphLeavesOrphanUnchecked(t *testing.T) {
 	}
 }
 
-func TestTurnVerify_RequiresInputFlag(t *testing.T) {
-	resetTurnVerifyFlags()
-	out, err := executeCommand("turn", "verify", "ag-lmdx.5")
+func TestRun_RequiresInputFlag(t *testing.T) {
+	out, err := runForTest("ag-lmdx.5", "", "", "", false, false)
 	if err == nil {
 		t.Fatalf("turn verify without --input must error\noutput=%s", out)
 	}
@@ -325,13 +303,11 @@ func TestTurnVerify_RequiresInputFlag(t *testing.T) {
 	}
 }
 
-func TestTurnVerify_InputBeadMismatchErrors(t *testing.T) {
-	resetTurnVerifyFlags()
+func TestRun_InputBeadMismatchErrors(t *testing.T) {
 	input := writeTurnInput(t, "ag-other", closedTransitions(t, "ag-other"),
 		[]evidencedturn.Scenario{{Slug: "s", HasPassingTest: true, EvidenceResolved: true}})
-	ledger := writeLedger(t, nil)
 
-	out, err := executeCommand("turn", "verify", "ag-lmdx.5", "--input", input, "--ledger", ledger)
+	out, err := runForTest("ag-lmdx.5", input, "", "", false, false)
 	if err == nil {
 		t.Fatalf("mismatched bead must error\noutput=%s", out)
 	}

--- a/docs/reduction/ao-file-buckets.tsv
+++ b/docs/reduction/ao-file-buckets.tsv
@@ -609,8 +609,7 @@ cli/cmd/ao/trace.go	RESEARCH	unclear ownership from filename/import shape; inspe
 cli/cmd/ao/trace_test.go	KEEP	test coverage follows the command surface under review; keep while the source file remains	encoding/...,internal/provenance,internal/storage,os,path/...,strings,testing,time
 cli/cmd/ao/tracker_health.go	RESEARCH	unclear ownership from filename/import shape; inspect before cut, relocate, or archive	context,encoding/...,fmt,os/...,strings,time
 cli/cmd/ao/tracker_health_test.go	KEEP	test coverage follows the command surface under review; keep while the source file remains	encoding/...,os,path/...,strings,testing
-cli/cmd/ao/turn_verify.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	encoding/...,fmt,github.com/...,internal/evidencedturn,internal/provenancegraph,internal/turnstate,os,strings
-cli/cmd/ao/turn_verify_test.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	encoding/...,internal/evidencedturn,internal/turnstate,os,path/...,strings,testing
+cli/cmd/ao/turn_verify.go	KEEP	public compatibility wrapper for `ao turn verify`; evaluator moved to the local assurance adapter boundary	github.com/...,internal/adapters
 cli/cmd/ao/uat_smoke_test.go	KEEP	test coverage follows the command surface under review; keep while the source file remains	encoding/...,os,path/...,slices,strings,testing
 cli/cmd/ao/validate.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	encoding/...,fmt,github.com/...,internal/ratchet,io,os,strings,time
 cli/cmd/ao/validate_test.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	bytes,encoding/...,errors,github.com/...,os,path/...,testing


### PR DESCRIPTION
## Summary

Extract the `ao turn verify` evaluator/renderer into `cli/internal/adapters/turnverify` while keeping the public Cobra wrapper and verdict contract in `cli/cmd/ao`.

Closes-scenario: cp-cd9#turnverify-adapter
Bounded-context: BC5-runtime
Evidence: REDUCTION.md; docs/reduction/ao-file-buckets.tsv

## Scope

- Keep `ao turn verify` command registration, flags, long help, and default ledger resolution in `cli/cmd/ao/turn_verify.go`.
- Move input JSON decoding, provenance ledger loading, trace-graph orphan checks, predicate evaluation, and text/JSON rendering into `cli/internal/adapters/turnverify`.
- Move substantive tests from the command package into the adapter package.
- Update reduction inventory to 461 KEEP / 124 RELOCATE / 0 ARCHIVE / 39 RESEARCH / 624 total.

## Local validation

- `cd cli && go test ./internal/adapters/turnverify`
- `cd cli && go test ./cmd/ao -run 'TestCobraCommandTreeRegistration|TestCobraExpectedCmdsMatchRegistration|TestCobra|TestTurn'`
- TSV count check: `rows=624 files=624`
- `bash scripts/regen-all.sh --check`
- `scripts/regen-command-surfaces.sh --check`
- `git diff --check`
- `cd cli && go vet ./...`
- `cd cli && go test ./... -count=1 -short`
- `PRE_PUSH_SKIP_MKDOCS=1 bash scripts/pre-push-gate.sh --fast`

## Notes

Fast pre-push passed with the existing warn-only executable-spec advisories:

- `scenarios --lint`: unknown flag
- `trace --orphans`: unknown flag
