### PR TITLE
refactor(ao): extract mcp surface adapter (cp-cd9 #mcp-surface-adapter)

### DIFF
--- a/REDUCTION.md
+++ b/REDUCTION.md
@@ -38,11 +38,11 @@ Current inventory count:
 
 | Bucket | Files |
 |---|---:|
-| KEEP | 462 |
-| RELOCATE | 120 |
+| KEEP | 463 |
+| RELOCATE | 118 |
 | ARCHIVE | 0 |
 | RESEARCH | 39 |
-| Total | 621 |
+| Total | 620 |
 
 Validation command:
 
@@ -165,6 +165,14 @@ boundary. AO keeps the public command wrapper and flags in place, while TOML
 template loading, required-field validation, variable expansion, hostname
 sanitization, init-step execution, tmux session creation, dry-run rendering, and
 no-tmux behavior now live under `cli/internal/adapters/sessionspawn`.
+
+## Extracted MCP Surface Adapter
+
+The curated `ao mcp serve` tool catalog, holdout-denial policy, print-tools JSON
+renderer, shell-backed executor, and transport wiring moved behind the
+`mto-fleet` adapter boundary. AO keeps the public `ao mcp serve` wrapper and
+flags in place, while MCP surface behavior now lives under
+`cli/internal/adapters/mcpsurface`.
 
 ## Reversibility
 

--- a/cli/cmd/ao/mcp_serve.go
+++ b/cli/cmd/ao/mcp_serve.go
@@ -2,143 +2,9 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"os"
-	"os/exec"
-	"strings"
-
-	"github.com/boshu2/agentops/cli/internal/adapters/mcptransport"
+	"github.com/boshu2/agentops/cli/internal/adapters/mcpsurface"
 	"github.com/spf13/cobra"
 )
-
-// mcpToolDescriptor is one curated tool the MCP surface exposes to a hosted /
-// SDK Claude loop. Slice 1 (ag-h1mk) ships the descriptors + the holdout
-// refusal policy; the live JSON-RPC transport is the ag-3ucpd follow-up.
-type mcpToolDescriptor = mcptransport.ToolDescriptor
-
-// mcpToolExecutor runs a curated tool by name and returns its structured text
-// output. The production executor shells the wrapped `ao` subcommand; tests
-// inject a deterministic fake.
-type mcpToolExecutor = mcptransport.ToolExecutor
-
-// mcpHoldoutMarkers are substrings in a tool-call arg that would surface the
-// LOCKED eval/holdout substrate to a cloud agent (Managed Agents are NOT ZDR).
-var mcpHoldoutMarkers = []string{"holdout", "ground_truth", ".agents/evals", "evals/"}
-
-// mcpToolDescriptors returns the curated, read-mostly, deterministic tool
-// surface. Each wraps an existing `ao` subcommand and returns structured JSON.
-func mcpToolDescriptors() []mcpToolDescriptor {
-	strProp := func(name, desc string) map[string]any {
-		return map[string]any{
-			"type":       "object",
-			"properties": map[string]any{name: map[string]any{"type": "string", "description": desc}},
-		}
-	}
-	empty := map[string]any{"type": "object", "properties": map[string]any{}}
-	return []mcpToolDescriptor{
-		{Name: "session_bootstrap", Description: "Run `ao session bootstrap` — the universal orientation report.", InputSchema: empty},
-		{Name: "inject", Description: "Run `ao inject` — decay-ranked prior context for a query.", InputSchema: strProp("query", "Topic to retrieve context for"), HoldoutSensitive: true},
-		{Name: "corpus_inject", Description: "Run `ao corpus inject --query` — typed BC1 corpus retrieval.", InputSchema: strProp("query", "Corpus query"), HoldoutSensitive: true},
-		{Name: "standards", Description: "Load the standards checklist for the given filetypes.", InputSchema: strProp("filetypes", "Comma-separated filetypes")},
-		{Name: "validate", Description: "Run `ao validate --gate` over the target artifact.", InputSchema: strProp("target", "File or bead to gate"), HoldoutSensitive: true},
-		{Name: "goals_measure", Description: "Run `ao goals measure` — fitness gate snapshot.", InputSchema: empty},
-	}
-}
-
-// mcpToolDenied reports whether a proposed tool call would surface holdout/eval
-// content to the cloud MCP surface. Deterministic; fails closed. Managed Agents
-// are NOT ZDR, so AGENTOPS_HOLDOUT_EVALUATOR does NOT unlock this for the cloud
-// surface — the eval substrate stays LOCKED.
-func mcpToolDenied(name string, args map[string]string) (bool, string) {
-	for key, val := range args {
-		low := strings.ToLower(val)
-		for _, marker := range mcpHoldoutMarkers {
-			if strings.Contains(low, marker) {
-				return true, fmt.Sprintf(
-					"refusing tool %q: arg %q=%q would surface holdout/eval corpus — the MCP surface is cloud-facing and Managed Agents are NOT ZDR (eval substrate is LOCKED)",
-					name, key, val)
-			}
-		}
-	}
-	return false, ""
-}
-
-// runMCPServePrintTools writes the curated tool surface as JSON consumable by
-// `ao agent bundle --runtime managed`.
-func runMCPServePrintTools(w io.Writer) error {
-	doc := struct {
-		Tools []mcpToolDescriptor `json:"tools"`
-	}{Tools: mcpToolDescriptors()}
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	return enc.Encode(doc)
-}
-
-// mcpServeOptions is the resolved input to runMCPServe.
-type mcpServeOptions struct {
-	PrintTools bool
-	In         io.Reader       // live transport input (default os.Stdin)
-	Out        io.Writer       // print-tools / live transport output (default os.Stdout)
-	Exec       mcpToolExecutor // tool executor (default realMCPExecutor)
-}
-
-// runMCPServe handles `ao mcp serve`, including --print-tools and the live
-// JSON-RPC stdio transport.
-func runMCPServe(opts mcpServeOptions) error {
-	if opts.PrintTools {
-		out := opts.Out
-		if out == nil {
-			return fmt.Errorf("runMCPServe: print-tools requires a non-nil writer")
-		}
-		return runMCPServePrintTools(out)
-	}
-	// Live MCP JSON-RPC stdio transport (ag-3ucpd).
-	in := opts.In
-	if in == nil {
-		in = os.Stdin
-	}
-	out := opts.Out
-	if out == nil {
-		out = os.Stdout
-	}
-	exec := opts.Exec
-	if exec == nil {
-		exec = realMCPExecutor
-	}
-	return mcptransport.Serve(in, out, mcptransport.Options{
-		ToolDescriptors: mcpToolDescriptors,
-		Deny:            mcpToolDenied,
-		Exec:            exec,
-	})
-}
-
-// realMCPExecutor shells the curated tool's underlying `ao` subcommand. Each
-// tool is read-mostly and deterministic. `standards` has no standalone command
-// — the standards checklist is enforced through `ao validate`, so it routes
-// there. Only reachable for non-denied calls (mcpToolDenied runs first).
-func realMCPExecutor(name string, args map[string]string) (string, error) {
-	var argv []string
-	switch name {
-	case "session_bootstrap":
-		argv = []string{"session", "bootstrap"}
-	case "inject":
-		argv = []string{"inject", "--query", args["query"]}
-	case "corpus_inject":
-		argv = []string{"corpus", "inject", "--query", args["query"]}
-	case "validate":
-		argv = []string{"validate", "--gate", "--changes", args["target"]}
-	case "standards":
-		argv = []string{"validate", "--gate"} // standards checklist runs via validate
-	case "goals_measure":
-		argv = []string{"goals", "measure"}
-	default:
-		return "", fmt.Errorf("unknown tool %q", name)
-	}
-	out, err := exec.Command("ao", argv...).CombinedOutput()
-	return string(out), err
-}
 
 // --- cobra wiring ---
 
@@ -170,9 +36,9 @@ The server refuses any tool call whose args would surface holdout/eval corpus
 (Managed Agents are NOT ZDR; the eval substrate is LOCKED).`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		if mcpServePrintTools {
-			return runMCPServePrintTools(cmd.OutOrStdout())
+			return mcpsurface.PrintTools(cmd.OutOrStdout())
 		}
-		return runMCPServe(mcpServeOptions{PrintTools: false, Out: cmd.OutOrStdout()})
+		return mcpsurface.Run(mcpsurface.Options{PrintTools: false, Out: cmd.OutOrStdout()})
 	},
 }
 

--- a/cli/internal/adapters/mcpsurface/surface.go
+++ b/cli/internal/adapters/mcpsurface/surface.go
@@ -1,0 +1,138 @@
+// practices: [hexagonal-architecture, design-by-contract]
+package mcpsurface
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/boshu2/agentops/cli/internal/adapters/mcptransport"
+)
+
+// ToolDescriptor is one curated tool the MCP surface exposes to a hosted / SDK
+// Claude loop.
+type ToolDescriptor = mcptransport.ToolDescriptor
+
+// ToolExecutor runs a curated tool by name and returns its structured text
+// output. The production executor shells the wrapped `ao` subcommand; tests
+// inject a deterministic fake.
+type ToolExecutor = mcptransport.ToolExecutor
+
+// Options is the resolved input to Run.
+type Options struct {
+	PrintTools bool
+	In         io.Reader    // live transport input (default os.Stdin)
+	Out        io.Writer    // print-tools / live transport output (default os.Stdout)
+	Exec       ToolExecutor // tool executor (default RealExecutor)
+}
+
+// HoldoutMarkers are substrings in a tool-call arg that would surface the
+// LOCKED eval/holdout substrate to a cloud agent (Managed Agents are NOT ZDR).
+var HoldoutMarkers = []string{"holdout", "ground_truth", ".agents/evals", "evals/"}
+
+// ToolDescriptors returns the curated, read-mostly, deterministic tool surface.
+// Each wraps an existing `ao` subcommand and returns structured JSON.
+func ToolDescriptors() []ToolDescriptor {
+	strProp := func(name, desc string) map[string]any {
+		return map[string]any{
+			"type":       "object",
+			"properties": map[string]any{name: map[string]any{"type": "string", "description": desc}},
+		}
+	}
+	empty := map[string]any{"type": "object", "properties": map[string]any{}}
+	return []ToolDescriptor{
+		{Name: "session_bootstrap", Description: "Run `ao session bootstrap` — the universal orientation report.", InputSchema: empty},
+		{Name: "inject", Description: "Run `ao inject` — decay-ranked prior context for a query.", InputSchema: strProp("query", "Topic to retrieve context for"), HoldoutSensitive: true},
+		{Name: "corpus_inject", Description: "Run `ao corpus inject --query` — typed BC1 corpus retrieval.", InputSchema: strProp("query", "Corpus query"), HoldoutSensitive: true},
+		{Name: "standards", Description: "Load the standards checklist for the given filetypes.", InputSchema: strProp("filetypes", "Comma-separated filetypes")},
+		{Name: "validate", Description: "Run `ao validate --gate` over the target artifact.", InputSchema: strProp("target", "File or bead to gate"), HoldoutSensitive: true},
+		{Name: "goals_measure", Description: "Run `ao goals measure` — fitness gate snapshot.", InputSchema: empty},
+	}
+}
+
+// ToolDenied reports whether a proposed tool call would surface holdout/eval
+// content to the cloud MCP surface. Deterministic; fails closed. Managed Agents
+// are NOT ZDR, so AGENTOPS_HOLDOUT_EVALUATOR does NOT unlock this for the cloud
+// surface — the eval substrate stays LOCKED.
+func ToolDenied(name string, args map[string]string) (bool, string) {
+	for key, val := range args {
+		low := strings.ToLower(val)
+		for _, marker := range HoldoutMarkers {
+			if strings.Contains(low, marker) {
+				return true, fmt.Sprintf(
+					"refusing tool %q: arg %q=%q would surface holdout/eval corpus — the MCP surface is cloud-facing and Managed Agents are NOT ZDR (eval substrate is LOCKED)",
+					name, key, val)
+			}
+		}
+	}
+	return false, ""
+}
+
+// PrintTools writes the curated tool surface as JSON consumable by
+// `ao agent bundle --runtime managed`.
+func PrintTools(w io.Writer) error {
+	doc := struct {
+		Tools []ToolDescriptor `json:"tools"`
+	}{Tools: ToolDescriptors()}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(doc)
+}
+
+// Run serves the MCP surface, including --print-tools and the live JSON-RPC
+// stdio transport.
+func Run(opts Options) error {
+	if opts.PrintTools {
+		out := opts.Out
+		if out == nil {
+			return fmt.Errorf("mcpsurface: print-tools requires a non-nil writer")
+		}
+		return PrintTools(out)
+	}
+	in := opts.In
+	if in == nil {
+		in = os.Stdin
+	}
+	out := opts.Out
+	if out == nil {
+		out = os.Stdout
+	}
+	execFn := opts.Exec
+	if execFn == nil {
+		execFn = RealExecutor
+	}
+	return mcptransport.Serve(in, out, mcptransport.Options{
+		ToolDescriptors: ToolDescriptors,
+		Deny:            ToolDenied,
+		Exec:            execFn,
+	})
+}
+
+// RealExecutor shells the curated tool's underlying `ao` subcommand. Each tool
+// is read-mostly and deterministic. `standards` has no standalone command: the
+// standards checklist is enforced through `ao validate`, so it routes there.
+// Only reachable for non-denied calls (ToolDenied runs first).
+func RealExecutor(name string, args map[string]string) (string, error) {
+	var argv []string
+	switch name {
+	case "session_bootstrap":
+		argv = []string{"session", "bootstrap"}
+	case "inject":
+		argv = []string{"inject", "--query", args["query"]}
+	case "corpus_inject":
+		argv = []string{"corpus", "inject", "--query", args["query"]}
+	case "validate":
+		argv = []string{"validate", "--gate", "--changes", args["target"]}
+	case "standards":
+		argv = []string{"validate", "--gate"} // standards checklist runs via validate
+	case "goals_measure":
+		argv = []string{"goals", "measure"}
+	default:
+		return "", fmt.Errorf("unknown tool %q", name)
+	}
+	out, err := exec.Command("ao", argv...).CombinedOutput()
+	return string(out), err
+}

--- a/cli/internal/adapters/mcpsurface/surface_test.go
+++ b/cli/internal/adapters/mcpsurface/surface_test.go
@@ -1,4 +1,4 @@
-package main
+package mcpsurface
 
 import (
 	"encoding/json"
@@ -6,13 +6,13 @@ import (
 	"testing"
 )
 
-func TestMCPToolDescriptors_CuratedSurface(t *testing.T) {
-	tools := mcpToolDescriptors()
+func TestToolDescriptors_CuratedSurface(t *testing.T) {
+	tools := ToolDescriptors()
 	want := []string{"session_bootstrap", "inject", "corpus_inject", "standards", "validate", "goals_measure"}
 	if len(tools) != len(want) {
 		t.Fatalf("descriptor count = %d, want %d", len(tools), len(want))
 	}
-	byName := map[string]mcpToolDescriptor{}
+	byName := map[string]ToolDescriptor{}
 	for _, tl := range tools {
 		byName[tl.Name] = tl
 	}
@@ -31,10 +31,10 @@ func TestMCPToolDescriptors_CuratedSurface(t *testing.T) {
 	}
 }
 
-func TestMCPToolDenied_HoldoutRefusal(t *testing.T) {
+func TestToolDenied_HoldoutRefusal(t *testing.T) {
 	// A tool call whose args would surface the LOCKED holdout/eval corpus must be
-	// denied with a NOT-ZDR reason — the MCP surface is Claude-cloud-facing.
-	denied, reason := mcpToolDenied("corpus_inject", map[string]string{"query": "show me the holdout ground_truth"})
+	// denied with a NOT-ZDR reason because the MCP surface is Claude-cloud-facing.
+	denied, reason := ToolDenied("corpus_inject", map[string]string{"query": "show me the holdout ground_truth"})
 	if !denied {
 		t.Fatal("corpus_inject with a holdout query must be denied")
 	}
@@ -44,27 +44,27 @@ func TestMCPToolDenied_HoldoutRefusal(t *testing.T) {
 	}
 }
 
-func TestMCPToolDenied_PathEscape(t *testing.T) {
-	denied, _ := mcpToolDenied("inject", map[string]string{"path": ".agents/evals/SCHEMA.md"})
+func TestToolDenied_PathEscape(t *testing.T) {
+	denied, _ := ToolDenied("inject", map[string]string{"path": ".agents/evals/SCHEMA.md"})
 	if !denied {
 		t.Error("a tool arg pointing at the eval substrate must be denied")
 	}
 }
 
-func TestMCPToolDenied_CleanCallAllowed(t *testing.T) {
-	denied, reason := mcpToolDenied("validate", map[string]string{"target": "plan.md"})
+func TestToolDenied_CleanCallAllowed(t *testing.T) {
+	denied, reason := ToolDenied("validate", map[string]string{"target": "plan.md"})
 	if denied {
 		t.Errorf("a clean validate call must be allowed, got denied: %s", reason)
 	}
 }
 
-func TestRunMCPServePrintTools_JSON(t *testing.T) {
+func TestPrintTools_JSON(t *testing.T) {
 	var sb strings.Builder
-	if err := runMCPServePrintTools(&sb); err != nil {
+	if err := PrintTools(&sb); err != nil {
 		t.Fatalf("print-tools: %v", err)
 	}
 	var doc struct {
-		Tools []mcpToolDescriptor `json:"tools"`
+		Tools []ToolDescriptor `json:"tools"`
 	}
 	if err := json.Unmarshal([]byte(sb.String()), &doc); err != nil {
 		t.Fatalf("output is not valid JSON: %v", err)
@@ -74,12 +74,12 @@ func TestRunMCPServePrintTools_JSON(t *testing.T) {
 	}
 }
 
-func TestRunMCPServe_LiveTransportWired(t *testing.T) {
+func TestRun_LiveTransportWired(t *testing.T) {
 	// ag-3ucpd: bare `ao mcp serve` now runs the live JSON-RPC transport.
-	// runMCPServe must drive serveMCP over the injected reader/writer/executor.
+	// Run must drive the transport over the injected reader/writer/executor.
 	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}` + "\n")
 	var out strings.Builder
-	err := runMCPServe(mcpServeOptions{
+	err := Run(Options{
 		PrintTools: false,
 		In:         in,
 		Out:        &out,

--- a/docs/cli-surface.json
+++ b/docs/cli-surface.json
@@ -1012,9 +1012,9 @@
     {
       "category": "public-tested",
       "command": "mcp serve",
-      "coverage_status": "covered",
+      "coverage_status": "allowlisted",
       "kind": "leaf",
-      "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
+      "reason": "Covered by mcpsurface and mcptransport adapter tests and command registration tests."
     },
     {
       "category": "public-tested",

--- a/docs/cli-surface.md
+++ b/docs/cli-surface.md
@@ -148,7 +148,7 @@
 | `ao loop verify` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao loop write-stop-marker` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao maturity` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
-| `ao mcp serve` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
+| `ao mcp serve` | `public-tested` | `allowlisted` | Covered by mcpsurface and mcptransport adapter tests and command registration tests. |
 | `ao memory sync` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao metrics baseline` | `public-tested` | `allowlisted` | Covered by metrics command tests. |
 | `ao metrics cite` | `public-tested` | `allowlisted` | Covered by metrics command tests. |

--- a/docs/reduction/ao-file-buckets.tsv
+++ b/docs/reduction/ao-file-buckets.tsv
@@ -328,8 +328,7 @@ cli/cmd/ao/maturity_inject_test.go	KEEP	self-contained AO image surface: loop, m
 cli/cmd/ao/maturity_integration_test.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	os,path/...,strings,testing
 cli/cmd/ao/maturity_target_size_test.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	fmt,os,path/...,sort,testing
 cli/cmd/ao/maturity_test.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	encoding/...,github.com/...,internal/ratchet,internal/types,os,path/...,strings,testing,time
-cli/cmd/ao/mcp_serve.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	encoding/...,fmt,github.com/...,internal/adapters,io,os,os/...,strings
-cli/cmd/ao/mcp_serve_test.go	RELOCATE	outer orchestration, runtime supervision, or fleet/adapter control; move toward MTO or vendor-image adapter boundary	encoding/...,strings,testing
+cli/cmd/ao/mcp_serve.go	KEEP	public compatibility wrapper for `ao mcp serve`; MCP surface moved to the mto-fleet adapter boundary	github.com/...,internal/adapters
 cli/cmd/ao/memory.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	fmt,github.com/...,os,path/...,sort,strings
 cli/cmd/ao/memory_test.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	encoding/...,fmt,os,path/...,strings,testing,time
 cli/cmd/ao/metrics.go	KEEP	self-contained AO image surface: loop, mind, local Themis, local flywheel, corpus, or operator ergonomics	github.com/...,internal/quality,internal/ratchet,internal/storage,internal/types,path/...,strings,time

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-07T09:28:20Z",
+  "generated_at": "2026-06-07T09:59:15Z",
   "summary": {
     "skills": 173,
     "hooks": 0,

--- a/scripts/cmdao-surface-allowlist.txt
+++ b/scripts/cmdao-surface-allowlist.txt
@@ -77,6 +77,7 @@ public-tested|metrics baseline|Covered by metrics command tests.
 public-tested|metrics cite|Covered by metrics command tests.
 public-tested|session close|Covered by session close tests.
 public-tested|agent bundle|Covered by vendorimage agentbundle adapter tests and command registration tests.
+public-tested|mcp serve|Covered by mcpsurface and mcptransport adapter tests and command registration tests.
 public-tested|turn verify|Covered by turnverify adapter tests and command registration tests.
 
 public-tested|hooks init|Covered by hook helper tests.


### PR DESCRIPTION
## Summary

Extract the `ao mcp serve` curated tool catalog, holdout-denial policy, print-tools renderer, shell-backed executor, and transport wiring into `cli/internal/adapters/mcpsurface` while preserving the public command wrapper and flags in `cli/cmd/ao`.

Closes-scenario: cp-cd9#mcp-surface-adapter
Bounded-context: BC5-runtime
Evidence: REDUCTION.md; docs/reduction/ao-file-buckets.tsv; docs/cli-surface.md

## Scope

- Keep `ao mcp serve` command registration, flags, help, and examples in `cli/cmd/ao/mcp_serve.go`.
- Move curated tool descriptors, holdout/eval denial policy, print-tools JSON rendering, real `ao` subcommand executor, and live transport wiring into `cli/internal/adapters/mcpsurface`.
- Move substantive MCP surface tests into the adapter package.
- Update the command-surface allowlist for adapter-backed `mcp serve` coverage.
- Update reduction inventory to 463 KEEP / 118 RELOCATE / 0 ARCHIVE / 39 RESEARCH / 620 total.

## Local validation

- `cd cli && go test ./internal/adapters/mcpsurface`
- `cd cli && go test ./cmd/ao -run 'TestMCP|TestCobraCommandTreeRegistration|TestCobraExpectedCmdsMatchRegistration|TestCobra'`
- TSV count check: `rows=620 files=620`
- `bash scripts/regen-all.sh`
- `bash scripts/regen-all.sh --check`
- `scripts/regen-command-surfaces.sh --check`
- `git diff --check`
- `cd cli && go vet ./...`
- `cd cli && go test ./... -count=1 -short`
- `PRE_PUSH_SKIP_MKDOCS=1 bash scripts/pre-push-gate.sh --fast`

## Notes

Fast pre-push passed with the existing warn-only executable-spec advisories:

- `scenarios --lint`: unknown flag
- `trace --orphans`: unknown flag
