### PR TITLE
fix(runtime): remove Claude print probes from headless checks (ag-eli0.2 #law0)

### DIFF
--- a/scripts/validate-headless-runtime-skills.sh
+++ b/scripts/validate-headless-runtime-skills.sh
@@ -11,18 +11,15 @@ CODEX_BIN="${CODEX_BIN:-codex}"
 CODEX_PROFILE="${CODEX_VALIDATE_PROFILE:-}"
 SOURCE_CODEX_HOME="${HEADLESS_RUNTIME_SOURCE_CODEX_HOME:-$HOME/.codex}"
 TIMEOUT_SECONDS="${HEADLESS_RUNTIME_SKILL_TIMEOUT_SECONDS:-120}"
-MAX_BUDGET_USD="${HEADLESS_RUNTIME_SKILL_MAX_BUDGET_USD:-2.00}"
 INVENTORY_RETRIES="${HEADLESS_RUNTIME_SKILL_INVENTORY_RETRIES:-2}"
 SKIP_ENV="${AGENTOPS_SKIP_HEADLESS_RUNTIME_SKILLS:-0}"
-CLAUDE_STRICT="${HEADLESS_RUNTIME_SKILL_CLAUDE_STRICT:-0}"
 CODEX_STRICT="${HEADLESS_RUNTIME_SKILL_CODEX_STRICT:-0}"
-CLAUDE_USED_FALLBACK=0
 CODEX_USED_FALLBACK=0
 
 print_runtime_proof_matrix() {
     cat <<'EOF'
 Runtime proof tiers:
-  Claude Code: Tier S via tests/skills/test-runtime-claude-code-smoke.sh; Tier I here when claude/auth are available; Tier E opt-in only.
+  Claude Code: Tier S via tests/skills/test-runtime-claude-code-smoke.sh; Tier I here is non-print load-check only.
   Codex: Tier S via tests/skills/test-runtime-codex-smoke.sh; Tier I here when codex/auth are available; Tier E opt-in only.
   Cursor: Tier S via tests/skills/test-runtime-cursor-smoke.sh; Tier I not implemented; Tier E not implemented.
   OpenCode: Tier S via tests/skills/test-runtime-opencode-smoke.sh; Tier I not implemented; Tier E not implemented.
@@ -33,9 +30,9 @@ usage() {
     cat <<'EOF'
 validate-headless-runtime-skills.sh
 
-Open fresh headless Claude and/or Codex sessions, ask each runtime to return the
-visible AgentOps skill inventory as JSON, then compare that inventory against
-the repo skill definitions.
+Validate Claude Code and/or Codex runtime skill loading. Claude Code is checked
+with non-print plugin-load smoke only; Codex performs the headless inventory
+comparison against the repo skill definitions.
 
 Options:
   --runtime <all|claude|codex>  Which runtime(s) to validate (default: all)
@@ -45,12 +42,11 @@ Options:
   --codex-bin <path>            Codex CLI binary (default: codex)
   --codex-profile <name>        Codex profile for headless exec (default: none)
   --timeout <seconds>           Per-runtime timeout (default: 120)
-  --max-budget-usd <amount>     Claude budget cap (default: 2.00)
+  --max-budget-usd <amount>     Accepted for old callers; ignored (Claude print is forbidden)
   --help                        Show this help
 
 Environment:
   AGENTOPS_SKIP_HEADLESS_RUNTIME_SKILLS=1  Skip the validation entirely
-  HEADLESS_RUNTIME_SKILL_CLAUDE_STRICT=1   Fail when Claude inventory cannot be collected
   HEADLESS_RUNTIME_SKILL_CODEX_STRICT=1    Fail when Codex inventory cannot be collected
   HEADLESS_RUNTIME_SKILL_INVENTORY_RETRIES Number of inventory compare attempts (default: 2)
   HEADLESS_RUNTIME_SOURCE_CODEX_HOME=/path Reuse auth.json from a real Codex home
@@ -88,7 +84,6 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --max-budget-usd)
-            MAX_BUDGET_USD="${2:-}"
             shift 2
             ;;
         -h|--help)
@@ -137,9 +132,7 @@ if [[ -z "$WORKDIR" ]]; then
 fi
 mkdir -p "$WORKDIR"
 
-EXPECTED_CLAUDE_JSON="$TMP_DIR/expected-claude.json"
 EXPECTED_CODEX_JSON="$TMP_DIR/expected-codex.json"
-ACTUAL_CLAUDE_JSON="$TMP_DIR/actual-claude.json"
 ACTUAL_CODEX_JSON="$TMP_DIR/actual-codex.json"
 CODEX_STREAM_JSON="$TMP_DIR/codex-stream.jsonl"
 CODEX_HOME_ROOT="$TMP_DIR/codex-home"
@@ -225,33 +218,6 @@ for skill_file in sorted(skills_root.glob("*/SKILL.md")):
 
 out_file.write_text(json.dumps(inventory, indent=2) + "\n")
 PY
-}
-
-claude_has_openai_docs_mcp() {
-    local settings_path="${CLAUDE_SETTINGS_PATH:-$HOME/.claude/settings.json}"
-    [[ -f "$settings_path" ]] || return 1
-    grep -q '"openaiDeveloperDocs"' "$settings_path"
-}
-
-prune_optional_claude_skills() {
-    local inventory_file="$1"
-
-    if claude_has_openai_docs_mcp; then
-        return 0
-    fi
-
-    python3 - "$inventory_file" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-path = Path(sys.argv[1])
-inventory = json.loads(path.read_text())
-filtered = [item for item in inventory if item.get("name") != "openai-docs"]
-path.write_text(json.dumps(filtered, indent=2) + "\n")
-PY
-
-    echo "WARN: Claude MCP server openaiDeveloperDocs not configured; excluding openai-docs from expected headless inventory." >&2
 }
 
 extract_json_array() {
@@ -363,12 +329,9 @@ print(f"{runtime}: validated {len(expected_map)} skills")
 PY
 }
 
-CLAUDE_PROMPT="List the available AgentOps skills in this session. Return ONLY a compact JSON array of skill names. Use the exact visible AgentOps skill names and exclude any built-in or non-AgentOps system skills."
 CODEX_PROMPT="List the available AgentOps skills in this session. Return ONLY a compact JSON array of skill names. Use the exact visible AgentOps skill names and exclude built-in OpenAI system skills such as skill-creator, skill-installer, slides, and spreadsheets."
 
-build_expected_inventory "$REPO_ROOT/skills" "$EXPECTED_CLAUDE_JSON"
 build_expected_inventory "$REPO_ROOT/skills-codex" "$EXPECTED_CODEX_JSON"
-prune_optional_claude_skills "$EXPECTED_CLAUDE_JSON"
 
 run_claude_load_check() {
     if timeout 20 "$CLAUDE_BIN" --plugin-dir "$REPO_ROOT" --help >/dev/null 2>&1; then
@@ -380,30 +343,6 @@ run_claude_load_check() {
         return $?
     fi
 
-    return 1
-}
-
-claude_inventory_failed() {
-    local reason="$1"
-    local raw_output="${2:-}"
-
-    echo "WARN: Claude inventory verification failed ($reason)." >&2
-    if [[ -n "$raw_output" && -f "$raw_output" ]]; then
-        sed -n '1,20p' "$raw_output" >&2 || true
-    fi
-
-    if run_claude_load_check; then
-        echo "WARN: Claude load check passed; using load-check fallback instead of verified inventory." >&2
-        if [[ "$CLAUDE_STRICT" == "1" ]]; then
-            echo "FAIL: HEADLESS_RUNTIME_SKILL_CLAUDE_STRICT=1 requires verified Claude inventory." >&2
-            return 1
-        fi
-        CLAUDE_USED_FALLBACK=1
-        echo "claude: load-check fallback passed"
-        return 0
-    fi
-
-    echo "Claude load check failed" >&2
     return 1
 }
 
@@ -437,103 +376,19 @@ codex_inventory_failed() {
     return 1
 }
 
-collect_claude_inventory_once() {
-    local raw_output="$TMP_DIR/claude-stream.jsonl"
-    CLAUDE_USED_FALLBACK=0
-
-    if (
-        cd "$REPO_ROOT"
-        AGENTOPS_HOOKS_DISABLED=1 timeout "$TIMEOUT_SECONDS" \
-            "$CLAUDE_BIN" -p "$CLAUDE_PROMPT" \
-            --plugin-dir "$REPO_ROOT" \
-            --dangerously-skip-permissions \
-            --max-turns 1 \
-            --no-session-persistence \
-            --max-budget-usd "$MAX_BUDGET_USD" \
-            --output-format stream-json \
-            --verbose
-    ) >"$raw_output" 2>&1; then
-        :
-    else
-        local rc=$?
-        claude_inventory_failed "headless command exit $rc" "$raw_output"
-        return $?
-    fi
-
-    if ! python3 - "$raw_output" "$TMP_DIR/claude-output.txt" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-messages = []
-for line in Path(sys.argv[1]).read_text().splitlines():
-    line = line.strip()
-    if not line:
-        continue
-    try:
-        payload = json.loads(line)
-    except json.JSONDecodeError:
-        continue
-    if payload.get("type") != "assistant":
-        continue
-    message = payload.get("message", {})
-    for item in message.get("content", []):
-        if item.get("type") == "text":
-            text = item.get("text", "").strip()
-            if text:
-                messages.append(text)
-
-if not messages:
-    print("No assistant text found in Claude stream-json output", file=sys.stderr)
-    sys.exit(1)
-
-Path(sys.argv[2]).write_text(messages[-1] + "\n")
-PY
-    then
-        claude_inventory_failed "stream-json parse error" "$raw_output"
-        return $?
-    fi
-
-    if ! extract_json_array "$TMP_DIR/claude-output.txt" "$ACTUAL_CLAUDE_JSON"; then
-        claude_inventory_failed "assistant output was not a JSON array" "$TMP_DIR/claude-output.txt"
-        return $?
-    fi
-}
-
 run_claude_validation() {
     if ! command -v "$CLAUDE_BIN" >/dev/null 2>&1; then
         echo "SKIP: Claude CLI not found in PATH"
         return 0
     fi
 
-    local compare_output
-    local attempt=1
-    while (( attempt <= INVENTORY_RETRIES )); do
-        if collect_claude_inventory_once; then
-            :
-        else
-            local rc=$?
-            return "$rc"
-        fi
-        if [[ "$CLAUDE_USED_FALLBACK" == "1" ]]; then
-            return 0
-        fi
+    if run_claude_load_check; then
+        echo "claude: non-print load check passed"
+        return 0
+    fi
 
-        if compare_output="$(compare_inventory "$EXPECTED_CLAUDE_JSON" "$ACTUAL_CLAUDE_JSON" "claude" "names-only-invocable" 2>&1)"; then
-            echo "claude: inventory verified"
-            printf '%s\n' "$compare_output"
-            return 0
-        fi
-
-        if (( attempt == INVENTORY_RETRIES )); then
-            printf '%s\n' "$compare_output" >&2
-            return 1
-        fi
-
-        echo "WARN: Claude inventory mismatch on attempt $attempt/$INVENTORY_RETRIES; retrying." >&2
-        printf '%s\n' "$compare_output" >&2
-        attempt=$((attempt + 1))
-    done
+    echo "Claude non-print load check failed" >&2
+    return 1
 }
 
 run_codex_validation() {

--- a/tests/claude-code/run-all.sh
+++ b/tests/claude-code/run-all.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Functional test runner for AgentOps skills
-# Tests skills by invoking Claude Code CLI and verifying behavior
+# Archived functional test runner for AgentOps skills.
+# The maintained Claude Code proof is tests/skills/test-runtime-claude-code-smoke.sh.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -13,6 +13,12 @@ echo ""
 echo "Repository: $(cd ../.. && pwd)"
 echo "Test time: $(date)"
 echo ""
+
+if [[ "${AGENTOPS_ENABLE_CLAUDE_CODE_FUNCTIONAL_TESTS:-0}" != "1" ]]; then
+    echo "SKIPPED: live Claude Code functional tests are archived."
+    echo "Run tests/skills/test-runtime-claude-code-smoke.sh for the maintained non-print proof."
+    exit 0
+fi
 
 # Check if Claude Code is available
 if ! command -v claude &> /dev/null; then

--- a/tests/claude-code/test-helpers.sh
+++ b/tests/claude-code/test-helpers.sh
@@ -29,84 +29,21 @@ NC='\033[0m'
 # Create log directory
 mkdir -p "$LOG_DIR"
 
-# Run Claude Code with a prompt and capture output as plain text
-# Usage: run_claude "prompt text" [timeout_seconds]
-# Environment:
-#   ALLOWED_TOOLS — comma-separated tool list (default: empty = --dangerously-skip-permissions)
-#   MAX_BUDGET_USD — cost guardrail in dollars (default: 1.00)
-#   MAX_TURNS — max agentic turns (default: 3)
+# Archived live Claude Code functional helpers. LAW 0 forbids AgentOps tests
+# from spawning Claude print workers; use tests/skills/test-runtime-claude-code-smoke.sh
+# for maintained Claude Code proof.
 run_claude() {
-    local prompt="$1"
-    local timeout="${2:-$DEFAULT_TIMEOUT}"
-    local output_file
-    output_file="$(mktemp)"
-
-    # Build permission flags: prefer --allowedTools over --dangerously-skip-permissions
-    local -a perm_flags
-    if [[ -n "${ALLOWED_TOOLS:-}" ]]; then
-        perm_flags=(--allowedTools "$ALLOWED_TOOLS")
-    else
-        perm_flags=(--dangerously-skip-permissions)
-    fi
-
-    if AGENTOPS_HOOKS_DISABLED="${AGENTOPS_HOOKS_DISABLED:-1}" \
-        timeout "$timeout" claude -p "$prompt" \
-        --plugin-dir "$REPO_ROOT" \
-        "${perm_flags[@]}" \
-        --max-turns "$MAX_TURNS" \
-        --no-session-persistence \
-        --max-budget-usd "$MAX_BUDGET_USD" \
-        > "$output_file" 2>&1; then
-        cat "$output_file"
-        rm -f "$output_file"
-        return 0
-    else
-        local exit_code=$?
-        cat "$output_file" >&2
-        rm -f "$output_file"
-        return $exit_code
-    fi
+    : "${1:-}" "${2:-$DEFAULT_TIMEOUT}"
+    echo "SKIP: live Claude Code print functional tests are archived; run tests/skills/test-runtime-claude-code-smoke.sh" >&2
+    return 2
 }
 
-# Run Claude Code with stream-json output for skill detection
-# Usage: run_claude_json "prompt text" [timeout_seconds]
-# Returns: path to JSON log file
-# Environment:
-#   ALLOWED_TOOLS — comma-separated tool list (default: empty = --dangerously-skip-permissions)
-#   MAX_BUDGET_USD — cost guardrail in dollars (default: 1.00)
-#   MAX_TURNS — max agentic turns (default: 3)
+# Archived stream-json helper; kept only so old test files fail closed if run
+# directly.
 run_claude_json() {
-    local prompt="$1"
-    local timeout="${2:-$DEFAULT_TIMEOUT}"
-    local ts
-    ts="$(date +%s)"
-    local log_file="$LOG_DIR/claude-${ts}-$$.jsonl"
-
-    # Build permission flags: prefer --allowedTools over --dangerously-skip-permissions
-    local -a perm_flags
-    if [[ -n "${ALLOWED_TOOLS:-}" ]]; then
-        perm_flags=(--allowedTools "$ALLOWED_TOOLS")
-    else
-        perm_flags=(--dangerously-skip-permissions)
-    fi
-
-    if AGENTOPS_HOOKS_DISABLED="${AGENTOPS_HOOKS_DISABLED:-1}" \
-        timeout "$timeout" claude -p "$prompt" \
-        --plugin-dir "$REPO_ROOT" \
-        "${perm_flags[@]}" \
-        --max-turns "$MAX_TURNS" \
-        --no-session-persistence \
-        --max-budget-usd "$MAX_BUDGET_USD" \
-        --output-format stream-json \
-        --verbose \
-        > "$log_file" 2>&1; then
-        echo "$log_file"
-        return 0
-    else
-        local exit_code=$?
-        echo "$log_file"
-        return $exit_code
-    fi
+    : "${1:-}" "${2:-$DEFAULT_TIMEOUT}"
+    echo "SKIP: live Claude Code print functional tests are archived; run tests/skills/test-runtime-claude-code-smoke.sh" >&2
+    return 2
 }
 
 # Check if a skill was triggered (looks in stream-json output)

--- a/tests/release-smoke-test.sh
+++ b/tests/release-smoke-test.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
-# Release smoke test - verify all skills are loadable
+# Release smoke test - verify all skills are packaged and structurally loadable
 # Usage: ./tests/release-smoke-test.sh [--full]
 #
 # Default: Fast verification (~30s) - checks components are registered
-# --full:  Slow verification (~10min) - invokes each skill individually
+# --full:  Runs structural runtime smoke checks; does not spawn headless workers
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# shellcheck source=tests/claude-code/test-helpers.sh
 source "$SCRIPT_DIR/claude-code/test-helpers.sh"
 
 # Logging (redefine to avoid conflict with macOS log command)
@@ -33,40 +34,27 @@ echo ""
 
 if $FULL_TEST; then
     # =========================================================================
-    # FULL TEST: Individual invocation of each skill
+    # FULL TEST: Structural runtime checks
     # =========================================================================
-    log "Running FULL test (individual invocations)..."
-
-    # Build skills array dynamically from skill directories
-    SKILLS=()
-    for skill_dir in "$REPO_ROOT"/skills/*/; do
-        # Skip leading-underscore scaffolding (e.g. skills/_fixtures/) — planted
-        # test fixtures, not invokable skills.
-        case "$(basename "$skill_dir")" in _*) continue ;; esac
-        [[ -f "${skill_dir}SKILL.md" ]] && SKILLS+=("$(basename "$skill_dir")")
-    done
-
+    log "Running FULL test (structural runtime smoke)..."
     passed=0
     failed=0
 
-    for skill in "${SKILLS[@]}"; do
-        # Skills need unrestricted tool access — they may use Write, Edit,
-        # WebFetch, etc. internally. --dangerously-skip-permissions is correct
-        # here; scoped --allowedTools would cause false failures.
-        if timeout 45 claude -p "Invoke agentops:$skill skill" \
-            --plugin-dir "$REPO_ROOT" \
-            --dangerously-skip-permissions \
-            --max-turns 3 \
-            --no-session-persistence \
-            --max-budget-usd 0.50 \
-            >/dev/null 2>&1; then
-            pass "$skill"
-            ((passed++))
-        else
-            fail "$skill"
-            ((failed++))
-        fi
-    done
+    if bash "$REPO_ROOT/tests/skills/test-runtime-claude-code-smoke.sh"; then
+        pass "Claude Code structural runtime smoke"
+        ((passed++)) || true
+    else
+        fail "Claude Code structural runtime smoke"
+        ((failed++)) || true
+    fi
+
+    if bash "$REPO_ROOT/tests/skills/test-runtime-codex-smoke.sh"; then
+        pass "Codex structural runtime smoke"
+        ((passed++)) || true
+    else
+        fail "Codex structural runtime smoke"
+        ((failed++)) || true
+    fi
 
     print_summary "$passed" "$failed" 0
     exit $((failed > 0))
@@ -77,20 +65,6 @@ fi
 # =============================================================================
 log "Running FAST test (registration check)..."
 echo ""
-
-log "Checking Claude can load the plugin..."
-
-load_output=$(timeout 30 claude --plugin-dir "$REPO_ROOT" --help 2>&1) || {
-    fail "Claude plugin load failed"
-    printf '%s\n' "$load_output" | sed -n '1,40p'
-    exit 1
-}
-
-if printf '%s\n' "$load_output" | grep -qiE "invalid manifest|validation error|failed to load"; then
-    fail "Claude reported plugin load errors"
-    printf '%s\n' "$load_output" | grep -iE "invalid|failed|error" | head -5
-    exit 1
-fi
 
 skill_count="$EXPECTED_SKILLS"
 

--- a/tests/scripts/test-headless-runtime-skills.sh
+++ b/tests/scripts/test-headless-runtime-skills.sh
@@ -94,18 +94,16 @@ EOF
 
 make_mock_claude() {
     local bin_dir="$1"
-    local mode="${2:-pass}"
     cat > "$bin_dir/claude" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
-prompt=""
 saw_help=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -p)
-      prompt="${2:-}"
-      shift 2
+    -p|--print)
+      echo "mock claude refuses print invocation" >&2
+      exit 99
       ;;
     *)
       if [[ "$1" == "--help" ]]; then
@@ -116,83 +114,14 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-mode="__MODE__"
-state_file="__STATE_FILE__"
 if [[ "$saw_help" == "1" ]]; then
   echo "Claude help"
   exit 0
 fi
-if [[ "$mode" == "fallback" ]]; then
-  exit 124
-fi
-if [[ "$mode" == "malformed" ]]; then
-  python3 - <<'PY'
-import json
 
-for payload in (
-    {"type": "assistant", "message": {"content": [{"type": "text", "text": 'not-json'}]}},
-    {"type": "result"},
-):
-    print(json.dumps(payload))
-PY
-  exit 0
-fi
-
-if [[ "$prompt" == *"compact JSON array of skill names"* ]]; then
-  text='["compile","research"]'
-  if [[ "$mode" == "retry-missing" ]]; then
-    count=0
-    if [[ -f "$state_file" ]]; then
-      count="$(cat "$state_file")"
-    fi
-    count=$((count + 1))
-    printf '%s' "$count" > "$state_file"
-    if [[ "$count" -eq 1 ]]; then
-      text='["compile"]'
-    fi
-  fi
-  if [[ "$mode" == "malformed" ]]; then
-    python3 - <<'PY'
-import json
-
-for payload in (
-    {"type": "assistant", "message": {"content": [{"type": "text", "text": 'not-json'}]}},
-    {"type": "result"},
-):
-    print(json.dumps(payload))
-PY
-    exit 0
-  fi
-  MOCK_CLAUDE_TEXT="$text" python3 - <<'PY'
-import json
-import os
-
-text = os.environ["MOCK_CLAUDE_TEXT"]
-for payload in (
-    {"type": "assistant", "message": {"content": [{"type": "text", "text": text}]}},
-    {"type": "result"},
-):
-    print(json.dumps(payload))
-PY
-  exit 0
-fi
-
-echo "unexpected Claude prompt: $prompt" >&2
+echo "unexpected Claude args: $*" >&2
 exit 1
 EOF
-    python3 - <<'PY' "$bin_dir/claude" "$mode" "$bin_dir/.claude-state"
-from pathlib import Path
-import sys
-
-path = Path(sys.argv[1])
-mode = sys.argv[2]
-state_file = sys.argv[3]
-path.write_text(
-    path.read_text()
-    .replace("__MODE__", mode)
-    .replace("__STATE_FILE__", state_file)
-)
-PY
     chmod +x "$bin_dir/claude"
 }
 
@@ -249,9 +178,9 @@ test_passes_with_mocked_runtimes() {
     make_mock_codex "$bin_dir" pass
 
     if PATH="$bin_dir:$PATH" bash "$SCRIPT" --repo-root "$repo" --workdir "$TMP_DIR/workdir-pass" >"$TMP_DIR/pass.log" 2>&1; then
-        pass "passes with mocked Claude and Codex inventories"
+        pass "passes with mocked Claude load check and Codex inventory"
     else
-        fail "passes with mocked Claude and Codex inventories"
+        fail "passes with mocked Claude load check and Codex inventory"
         sed -n '1,80p' "$TMP_DIR/pass.log" >&2
     fi
 }
@@ -261,7 +190,6 @@ test_fails_when_codex_inventory_is_missing_skill() {
     local bin_dir="$TMP_DIR/fail-bin"
     mkdir -p "$bin_dir"
     make_fixture "$repo"
-    make_mock_claude "$bin_dir"
     make_mock_codex "$bin_dir" missing
 
     if PATH="$bin_dir:$PATH" bash "$SCRIPT" --repo-root "$repo" --runtime codex --workdir "$TMP_DIR/workdir-fail" >"$TMP_DIR/fail.log" 2>&1; then
@@ -279,7 +207,6 @@ test_retries_when_codex_inventory_omits_skill_once() {
     local bin_dir="$TMP_DIR/codex-retry-bin"
     mkdir -p "$bin_dir"
     make_fixture "$repo"
-    make_mock_claude "$bin_dir"
     make_mock_codex "$bin_dir" retry-missing
 
     if PATH="$bin_dir:$PATH" bash "$SCRIPT" --repo-root "$repo" --runtime codex --workdir "$TMP_DIR/workdir-codex-retry" \
@@ -297,85 +224,23 @@ test_retries_when_codex_inventory_omits_skill_once() {
     fi
 }
 
-test_warns_and_passes_when_claude_inventory_falls_back_to_help() {
-    local repo="$TMP_DIR/fallback-repo"
-    local bin_dir="$TMP_DIR/fallback-bin"
+test_claude_runtime_uses_non_print_load_check_only() {
+    local repo="$TMP_DIR/claude-load-repo"
+    local bin_dir="$TMP_DIR/claude-load-bin"
     mkdir -p "$bin_dir"
     make_fixture "$repo"
-    make_mock_claude "$bin_dir" fallback
+    make_mock_claude "$bin_dir"
 
-    if PATH="$bin_dir:$PATH" bash "$SCRIPT" --repo-root "$repo" --runtime claude --workdir "$TMP_DIR/workdir-fallback" >"$TMP_DIR/fallback.log" 2>&1; then
-        if contains_text 'load-check fallback passed' "$TMP_DIR/fallback.log"; then
-            pass "warns and passes when Claude inventory falls back to explicit load-check fallback"
+    if PATH="$bin_dir:$PATH" bash "$SCRIPT" --repo-root "$repo" --runtime claude --workdir "$TMP_DIR/workdir-claude-load" >"$TMP_DIR/claude-load.log" 2>&1; then
+        if contains_text 'claude: non-print load check passed' "$TMP_DIR/claude-load.log"; then
+            pass "Claude runtime uses non-print load check only"
         else
-            fail "warns and passes when Claude inventory falls back to explicit load-check fallback"
-            sed -n '1,80p' "$TMP_DIR/fallback.log" >&2
+            fail "Claude runtime uses non-print load check only"
+            sed -n '1,80p' "$TMP_DIR/claude-load.log" >&2
         fi
     else
-        fail "warns and passes when Claude inventory falls back to explicit load-check fallback"
-        sed -n '1,80p' "$TMP_DIR/fallback.log" >&2
-    fi
-}
-
-test_warns_and_passes_when_claude_output_is_malformed() {
-    local repo="$TMP_DIR/malformed-repo"
-    local bin_dir="$TMP_DIR/malformed-bin"
-    mkdir -p "$bin_dir"
-    make_fixture "$repo"
-    make_mock_claude "$bin_dir" malformed
-
-    if PATH="$bin_dir:$PATH" bash "$SCRIPT" --repo-root "$repo" --runtime claude --workdir "$TMP_DIR/workdir-malformed" >"$TMP_DIR/malformed.log" 2>&1; then
-        if contains_text 'assistant output was not a JSON array' "$TMP_DIR/malformed.log" && \
-            contains_text 'load-check fallback passed' "$TMP_DIR/malformed.log"; then
-            pass "warns and passes when Claude output is malformed but load check succeeds"
-        else
-            fail "warns and passes when Claude output is malformed but load check succeeds"
-            sed -n '1,80p' "$TMP_DIR/malformed.log" >&2
-        fi
-    else
-        fail "warns and passes when Claude output is malformed but load check succeeds"
-        sed -n '1,80p' "$TMP_DIR/malformed.log" >&2
-    fi
-}
-
-test_retries_when_claude_inventory_omits_skill_once() {
-    local repo="$TMP_DIR/retry-repo"
-    local bin_dir="$TMP_DIR/retry-bin"
-    mkdir -p "$bin_dir"
-    make_fixture "$repo"
-    make_mock_claude "$bin_dir" retry-missing
-
-    if PATH="$bin_dir:$PATH" bash "$SCRIPT" --repo-root "$repo" --runtime claude --workdir "$TMP_DIR/workdir-retry" \
-        >"$TMP_DIR/retry.log" 2>&1; then
-        if contains_text 'inventory mismatch on attempt 1/2; retrying' "$TMP_DIR/retry.log" && \
-            contains_text 'claude: inventory verified' "$TMP_DIR/retry.log"; then
-            pass "retries when Claude inventory omits a skill once"
-        else
-            fail "retries when Claude inventory omits a skill once"
-            sed -n '1,80p' "$TMP_DIR/retry.log" >&2
-        fi
-    else
-        fail "retries when Claude inventory omits a skill once"
-        sed -n '1,80p' "$TMP_DIR/retry.log" >&2
-    fi
-}
-
-test_fails_in_strict_mode_when_claude_uses_load_check_fallback() {
-    local repo="$TMP_DIR/strict-repo"
-    local bin_dir="$TMP_DIR/strict-bin"
-    mkdir -p "$bin_dir"
-    make_fixture "$repo"
-    make_mock_claude "$bin_dir" fallback
-
-    if HEADLESS_RUNTIME_SKILL_CLAUDE_STRICT=1 PATH="$bin_dir:$PATH" \
-        bash "$SCRIPT" --repo-root "$repo" --runtime claude --workdir "$TMP_DIR/workdir-strict" \
-        >"$TMP_DIR/strict.log" 2>&1; then
-        fail "fails in strict mode when Claude falls back to load-check"
-    elif contains_text 'requires verified Claude inventory' "$TMP_DIR/strict.log"; then
-        pass "fails in strict mode when Claude falls back to load-check"
-    else
-        fail "fails in strict mode when Claude falls back to load-check"
-        sed -n '1,80p' "$TMP_DIR/strict.log" >&2
+        fail "Claude runtime uses non-print load check only"
+        sed -n '1,80p' "$TMP_DIR/claude-load.log" >&2
     fi
 }
 
@@ -383,10 +248,7 @@ echo "== test-headless-runtime-skills =="
 test_passes_with_mocked_runtimes
 test_fails_when_codex_inventory_is_missing_skill
 test_retries_when_codex_inventory_omits_skill_once
-test_warns_and_passes_when_claude_inventory_falls_back_to_help
-test_warns_and_passes_when_claude_output_is_malformed
-test_retries_when_claude_inventory_omits_skill_once
-test_fails_in_strict_mode_when_claude_uses_load_check_fallback
+test_claude_runtime_uses_non_print_load_check_only
 
 echo ""
 echo "Results: $PASS PASS, $FAIL FAIL"


### PR DESCRIPTION
## Summary
- remove executable Claude print inventory probes from headless runtime validation
- keep Claude Code coverage to non-print plugin/load structural checks
- keep Codex as the runtime that performs headless skill inventory comparison
- update release smoke and tests so mocks reject Claude `-p` paths

## Local validation
- `bash scripts/regen-all.sh --check`
- `bash -n scripts/validate-headless-runtime-skills.sh tests/claude-code/run-all.sh tests/claude-code/test-helpers.sh tests/release-smoke-test.sh tests/scripts/test-headless-runtime-skills.sh`
- `shellcheck scripts/validate-headless-runtime-skills.sh tests/claude-code/run-all.sh tests/claude-code/test-helpers.sh tests/release-smoke-test.sh tests/scripts/test-headless-runtime-skills.sh`
- `bash /Users/bo/acfs/skill-pipeline/scripts/no-api-print-scan.sh "$PWD/skills" "$PWD/scripts" "$PWD/hooks" "$PWD/lib" "$PWD/tests"`
- `bash tests/scripts/test-headless-runtime-skills.sh`
- `bash tests/release-smoke-test.sh && bash tests/release-smoke-test.sh --full`
- `git diff --check`
