### PR TITLE
docs(skills): encode skill-builder scale lessons

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-07T17:00:53Z",
+  "generated_at": "2026-06-07T17:18:04Z",
   "summary": {
     "skills": 171,
     "hooks": 0,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1654,8 +1654,8 @@
     {
       "name": "skill-builder",
       "source_skill": "skills/skill-builder",
-      "source_hash": "e63b80f0be4a97818b3913a372ef228baf33bccb7c17d366ea0401176a1edbc7",
-      "generated_hash": "352033dea58d4fbd1facd8fa7113ec401b847f38beb9af8218b0af9ca51df1ac"
+      "source_hash": "c397515b2a38637c34b265d13cff1cce0310d41712e8d498655304a186cfa1d6",
+      "generated_hash": "154f768f146bd91820c511f0e71bada1d81d42699a6f3a83a077ffd47a7fd68b"
     },
     {
       "name": "standards",

--- a/skills-codex/skill-builder/.agentops-generated.json
+++ b/skills-codex/skill-builder/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/skill-builder",
   "layout": "modular",
-  "source_hash": "e63b80f0be4a97818b3913a372ef228baf33bccb7c17d366ea0401176a1edbc7",
-  "generated_hash": "352033dea58d4fbd1facd8fa7113ec401b847f38beb9af8218b0af9ca51df1ac"
+  "source_hash": "c397515b2a38637c34b265d13cff1cce0310d41712e8d498655304a186cfa1d6",
+  "generated_hash": "154f768f146bd91820c511f0e71bada1d81d42699a6f3a83a077ffd47a7fd68b"
 }

--- a/skills-codex/skill-builder/SKILL.md
+++ b/skills-codex/skill-builder/SKILL.md
@@ -13,6 +13,11 @@ Materializes a new skill against the unified template at `references/skill-templ
 - **Codex parity is day-1, not later.** `from-scratch`, `from-template`, and `absorb-external` modes must produce both `skills/<name>/SKILL.md` AND `skills-codex/<name>/SKILL.md` + `skills-codex/<name>/prompt.md`. **Why:** finding `2026-05-03-codex-skill-shape-is-dual-file` — codex SKILL.md uses slim frontmatter (no `skill_api_version`); prompt.md is mandatory; `audit-codex-parity.sh` is a content scanner that won't catch frontmatter drift.
 - **250-line ceiling on new SKILL.md.** Use `references/` for overflow. **Why:** finding `f-2026-05-01-025` — every skill invocation reloads 5-15KB; multi-lifecycle sessions compound to 150-200KB+ pure scaffolding.
 - **Clean-room factory inputs only.** When using lessons learned from external corpora, read [references/agentops-skill-factory.md](references/agentops-skill-factory.md) and use only AgentOps-owned summaries, scripts, and rubrics. **Why:** productization must improve structure without copying protected third-party skill content.
+- **Real gate means exit code.** Validate with `heal-skill --check --strict <skill-dir>` and `$skill-auditor`; never infer green from grep/regex output. **Why:** regex checks created false-greens during the scale build.
+- **One skill directory = one writer.** Bulk builds fan out only when each worker owns a distinct new `skills/<name>/` plus `skills-codex/<name>/`; existing-dir mutations run in a later serial wave. **Why:** overlapping writers deleted untracked work.
+- **Trust repository state, not subagent reports.** Check `git status`, generated hashes, final files, and gate exit codes before declaring success. **Why:** stale self-reports can describe work that never persisted.
+- **Clean-room includes names.** Mint AgentOps-owned names; do not reuse exact third-party skill names for source skills, Codex mirrors, or wrappers. **Why:** provenance safety applies to labels too.
+- **Do not use the Workflow tool as the skill factory.** For scale authoring, use deterministic wave scripts or NTM/Agent Mail lanes with one worker per skill. **Why:** skill creation needs file ownership and durable git evidence.
 
 ## Modes
 
@@ -44,7 +49,7 @@ build.sh from-pattern                            # → ao flywheel close-loop
 
 For `absorb-external`, the external SKILL.md's content (Constraints / Workflow / Output / Quality sections) is preserved verbatim where possible; AgentOps' structured frontmatter is added on top; the external description is reformatted to satisfy `description-has-triggers`.
 
-**Checkpoint:** `$heal-skill --check skills/<new-name>` returns clean.
+**Checkpoint:** `heal-skill --check --strict skills/<new-name>` exits 0.
 
 ### Phase 3: Codex parity
 
@@ -70,6 +75,13 @@ python3 skills-codex/skill-auditor/scripts/score_agentops_skill.py skills/<name>
 Choose the smallest patch that improves the score while preserving the
 canonical template and Codex parity constraints.
 
+### Phase 6: Scale factory discipline
+
+For more than one skill, run ownership waves: create-only one-worker-per-new-dir,
+then existing-dir mutations, then Codex mirror/package refresh. Each wave ends
+with `git status`, `scripts/regen-all.sh --check`, and target gates by exit code.
+If ownership overlaps, stop and rescope.
+
 ## Output Specification
 
 **Format:** JSON conforming to `schemas/build-report.json` written to stdout; markdown audit report written to `.agents/audits/<skill>-build.md`.
@@ -90,7 +102,10 @@ skills-codex/<name>/
 ## Quality Rubric
 
 - [ ] All four modes produce skills that pass `skill-auditor` PASS or WARN (not FAIL)
+- [ ] `heal-skill --check --strict` exits 0 for every generated source and Codex skill directory
 - [ ] Codex parity files exist and pass slim-frontmatter check
+- [ ] Batch authoring has one writer per skill directory and validates persisted git state
+- [ ] Clean-room review covers exact names as well as prose, scripts, and examples
 - [ ] No SKILL.md exceeds 250 lines (overflow goes to `references/`)
 - [ ] Build report JSON validates against `schemas/build-report.json`
 - [ ] `from-pattern` mode prominently marked alpha/passthrough in user output

--- a/skills-codex/skill-builder/references/agentops-skill-factory.md
+++ b/skills-codex/skill-builder/references/agentops-skill-factory.md
@@ -29,9 +29,22 @@ only.
 
 3. Pick the smallest score-improving patch: `SELF-TEST.md`, linked references,
    focused scripts, output contracts, quality rubric, or clearer triggers.
-4. Re-run `skill-auditor`, `heal-skill`, and target validation.
+4. Re-run `skill-auditor`, `heal-skill --check --strict`, and target validation
+   by exit code, not by grepping output text.
 5. Mirror runtime-specific behavior into `skills-codex/` or
    `skills-codex-overrides/`.
+
+## Scale Run Discipline
+
+- One skill equals one worker equals one source directory plus its Codex mirror.
+- Run create-only work first; mutate existing skills only after the source corpus
+  is settled.
+- Use deterministic scripts or NTM/Agent Mail lanes for batch work. Do not use
+  the Workflow tool as the skill factory.
+- Trust `git status`, generated hashes, final file contents, and gate exit codes
+  over worker self-reports.
+- Clean-room review includes exact names. Rename third-party-derived labels into
+  AgentOps-owned names before source skills, Codex mirrors, or wrappers are keyed.
 
 ## Productization Rule
 

--- a/skills-codex/skill-builder/references/skill-template.md
+++ b/skills-codex/skill-builder/references/skill-template.md
@@ -98,7 +98,7 @@ output_contract: <path-to-schema-or-description>
 
 ## 2. Auditor 15-check checklist
 
-Audits run in **two passes**. Pass 1 wraps `bash skills/heal-skill/scripts/heal.sh` for structural hygiene. Pass 2 adds 8 NEW checks not covered by heal.
+Audits run in **two passes**. Pass 1 runs `heal-skill --check --strict` for structural hygiene and gates on the exit code. Pass 2 adds 8 NEW checks not covered by heal.
 
 ### Pass 1 — delegated to heal-skill (7 checks)
 

--- a/skills-codex/skill-builder/schemas/build-report.json
+++ b/skills-codex/skill-builder/schemas/build-report.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Skill Build Report",
+  "description": "Output contract for skill-builder. Reports what mode ran, which files were created, and whether the post-build self-audit passed.",
+  "type": "object",
+  "required": ["mode", "skill_name", "files_created", "audit_pass"],
+  "properties": {
+    "mode": {
+      "type": "string",
+      "enum": ["from-scratch", "from-template", "absorb-external", "from-pattern"],
+      "description": "Which builder mode produced this skill. from-pattern is alpha (passthrough to ao flywheel close-loop)."
+    },
+    "skill_name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "description": "Lowercase-hyphen slug for the new skill (matches directory name)."
+    },
+    "files_created": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Absolute or repo-relative paths of files written during this build."
+    },
+    "audit_pass": {
+      "type": "boolean",
+      "description": "Did the immediate post-build self-audit (skill-auditor) emit VERDICT: PASS or VERDICT: WARN? (False if FAIL.)"
+    },
+    "audit_report_path": {
+      "type": "string",
+      "description": "Where the self-audit report was written (typically .agents/audits/<skill>-build.md)."
+    },
+    "warnings": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Non-fatal issues surfaced during build (e.g., template SHA pin mismatch, missing optional sections)."
+    },
+    "source": {
+      "type": "object",
+      "description": "Mode-specific provenance.",
+      "properties": {
+        "external_path": {"type": "string", "description": "For absorb-external: source SKILL.md path"},
+        "template_skill": {"type": "string", "description": "For from-template: skill copied from"},
+        "flywheel_run_id": {"type": "string", "description": "For from-pattern: ao flywheel close-loop run id"}
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/skills-codex/skill-builder/scripts/validate.sh
+++ b/skills-codex/skill-builder/scripts/validate.sh
@@ -5,12 +5,25 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$SKILL_DIR/../.." && pwd)"
 
-# Run heal-skill structural check on ourselves
-bash "$REPO_ROOT/skills/heal-skill/scripts/heal.sh" --check "$SKILL_DIR"
+# Run heal-skill structural check on ourselves by exit code.
+bash "$REPO_ROOT/skills/heal-skill/scripts/heal.sh" --check --strict "$SKILL_DIR"
 
 # Verify required artifacts exist
 for f in SKILL.md scripts/build.sh scripts/init.sh references/skill-template.md schemas/build-report.json; do
   [[ -f "$SKILL_DIR/$f" ]] || { echo "validate.sh: missing $SKILL_DIR/$f" >&2; exit 1; }
+done
+
+# Verify scale-factory lessons stay encoded.
+for phrase in \
+  "heal-skill --check --strict" \
+  "One skill directory = one writer" \
+  "git status" \
+  "Clean-room includes names" \
+  "Workflow tool"; do
+  grep -q "$phrase" "$SKILL_DIR/SKILL.md" "$SKILL_DIR/references/agentops-skill-factory.md" || {
+    echo "validate.sh: missing scale-factory lesson: $phrase" >&2
+    exit 1
+  }
 done
 
 # Verify SKILL.md is within churn budget

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -45,6 +45,11 @@ Materializes a new skill against the unified template at `references/skill-templ
 - **Codex parity is day-1, not later.** `from-scratch`, `from-template`, and `absorb-external` modes must produce both `skills/<name>/SKILL.md` AND `skills-codex/<name>/SKILL.md` + `skills-codex/<name>/prompt.md`. **Why:** finding `2026-05-03-codex-skill-shape-is-dual-file` — codex SKILL.md uses slim frontmatter (no `skill_api_version`); prompt.md is mandatory; `audit-codex-parity.sh` is a content scanner that won't catch frontmatter drift.
 - **250-line ceiling on new SKILL.md.** Use `references/` for overflow. **Why:** finding `f-2026-05-01-025` — every Skill() invocation reloads 5-15KB; multi-lifecycle sessions compound to 150-200KB+ pure scaffolding.
 - **Clean-room factory inputs only.** When using lessons learned from external corpora, read [references/agentops-skill-factory.md](references/agentops-skill-factory.md) and use only AgentOps-owned summaries, scripts, and rubrics. **Why:** productization must improve structure without copying protected third-party skill content.
+- **Real gate means exit code.** Validate with `heal-skill --check --strict <skill-dir>` and `skill-auditor`; never infer green from grep/regex output. **Why:** regex presence checks created false-greens during the 2026-06 scale build.
+- **One skill directory = one writer.** Bulk builds fan out only when each worker owns a distinct new `skills/<name>/` plus `skills-codex/<name>/`; edits to existing skill dirs run in a later serial wave. **Why:** concurrent writers deleted untracked work and flipped HEAD mid-task.
+- **Trust repository state, not subagent reports.** Before declaring success, inspect `git status`, generated hashes, final files, and gate exit codes. **Why:** sandbox-overlay and stale self-reports can claim work that never persisted.
+- **Clean-room includes names.** Do not reuse exact third-party skill names; mint AgentOps-owned names before source skills, Codex mirrors, or wrappers are keyed. **Why:** provenance/IP safety applies to labels as well as prose and scripts.
+- **Do not use the Workflow tool as the skill factory.** For scale authoring, use deterministic wave scripts or NTM/Agent Mail lanes with one worker per skill. **Why:** skill creation needs file ownership and durable git evidence, not opaque background self-reporting.
 
 ## Modes
 
@@ -76,7 +81,7 @@ build.sh from-pattern                            # → ao flywheel close-loop
 
 For `absorb-external`, the external SKILL.md's content (Constraints / Workflow / Output / Quality sections) is preserved verbatim where possible; AgentOps' structured frontmatter is added on top; the external description is reformatted to satisfy `description-has-triggers`.
 
-**Checkpoint:** `/heal-skill --check skills/<new-name>` returns clean.
+**Checkpoint:** `heal-skill --check --strict skills/<new-name>` exits 0.
 
 ### Phase 3: Codex parity
 
@@ -102,6 +107,18 @@ python3 skills/skill-auditor/scripts/score_agentops_skill.py skills/<name> --mar
 Choose the smallest patch that improves the score while preserving the
 canonical template and Codex parity constraints.
 
+### Phase 6: Scale factory discipline
+
+For more than one skill, run in ownership waves:
+
+1. Create-only wave: one worker per new skill directory.
+2. Mutate wave: existing skill directories only after source creation settles.
+3. Mirror/package wave: Codex mirrors and generated hashes after the canonical
+   source corpus is complete.
+
+Every wave ends with `git status`, `scripts/regen-all.sh --check`, and the
+relevant target gates by exit code. If ownership overlaps, stop and rescope.
+
 ## Output Specification
 
 **Format:** JSON conforming to `schemas/build-report.json` written to stdout; markdown audit report written to `.agents/audits/<skill>-build.md`.
@@ -122,7 +139,10 @@ skills-codex/<name>/
 ## Quality Rubric
 
 - [ ] All four modes produce skills that pass `skill-auditor` PASS or WARN (not FAIL)
+- [ ] `heal-skill --check --strict` exits 0 for every generated source and Codex skill directory
 - [ ] Codex parity files exist and pass slim-frontmatter check
+- [ ] Batch authoring has one writer per skill directory and validates persisted git state
+- [ ] Clean-room review covers exact names as well as prose, scripts, and examples
 - [ ] No SKILL.md exceeds 250 lines (overflow goes to `references/`)
 - [ ] Build report JSON validates against `schemas/build-report.json`
 - [ ] `from-pattern` mode prominently marked alpha/passthrough in user output

--- a/skills/skill-builder/references/agentops-skill-factory.md
+++ b/skills/skill-builder/references/agentops-skill-factory.md
@@ -34,10 +34,25 @@ only.
    - add a focused validation script;
    - add an output contract or explicit quality rubric;
    - tighten trigger language in frontmatter and body.
-4. Re-run `skill-auditor`, `heal-skill`, and any target-specific validation.
+4. Re-run `skill-auditor`, `heal-skill --check --strict`, and any target-specific
+   validation by exit code, not by grepping output text.
 5. Mirror behavior into `skills-codex/<name>/` or
    `skills-codex-overrides/<name>/` when the Codex runtime needs different
    phrasing or execution instructions.
+
+## Scale Run Discipline
+
+When authoring multiple skills, protect file ownership before parallelism:
+
+- One skill equals one worker equals one source directory plus its Codex mirror.
+- Run create-only work first; mutate existing skills only after the source corpus
+  is settled.
+- Use deterministic scripts or NTM/Agent Mail lanes for batch work. Do not use
+  the Workflow tool as the skill factory.
+- Trust `git status`, generated hashes, final file contents, and gate exit codes
+  over worker self-reports.
+- Clean-room review includes exact names. Rename third-party-derived labels into
+  AgentOps-owned names before source skills, Codex mirrors, or wrappers are keyed.
 
 ## Productization Rule
 

--- a/skills/skill-builder/references/skill-template.md
+++ b/skills/skill-builder/references/skill-template.md
@@ -98,7 +98,7 @@ output_contract: <path-to-schema-or-description>
 
 ## 2. Auditor 15-check checklist
 
-Audits run in **two passes**. Pass 1 wraps `bash skills/heal-skill/scripts/heal.sh` for structural hygiene. Pass 2 adds 8 NEW checks not covered by heal.
+Audits run in **two passes**. Pass 1 runs `heal-skill --check --strict` for structural hygiene and gates on the exit code. Pass 2 adds 8 NEW checks not covered by heal.
 
 ### Pass 1 — delegated to heal-skill (7 checks)
 

--- a/skills/skill-builder/scripts/validate.sh
+++ b/skills/skill-builder/scripts/validate.sh
@@ -5,12 +5,25 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$SKILL_DIR/../.." && pwd)"
 
-# Run heal-skill structural check on ourselves
-bash "$REPO_ROOT/skills/heal-skill/scripts/heal.sh" --check "$SKILL_DIR"
+# Run heal-skill structural check on ourselves by exit code.
+bash "$REPO_ROOT/skills/heal-skill/scripts/heal.sh" --check --strict "$SKILL_DIR"
 
 # Verify required artifacts exist
 for f in SKILL.md scripts/build.sh scripts/init.sh references/skill-template.md schemas/build-report.json; do
   [[ -f "$SKILL_DIR/$f" ]] || { echo "validate.sh: missing $SKILL_DIR/$f" >&2; exit 1; }
+done
+
+# Verify scale-factory lessons stay encoded.
+for phrase in \
+  "heal-skill --check --strict" \
+  "One skill directory = one writer" \
+  "git status" \
+  "Clean-room includes names" \
+  "Workflow tool"; do
+  grep -q "$phrase" "$SKILL_DIR/SKILL.md" "$SKILL_DIR/references/agentops-skill-factory.md" || {
+    echo "validate.sh: missing scale-factory lesson: $phrase" >&2
+    exit 1
+  }
 done
 
 # Verify SKILL.md is within churn budget


### PR DESCRIPTION
## Summary
- Encode the skill-factory scale lessons into skill-builder source and Codex mirror: strict heal exit-code validation, one writer per skill directory, repository-state evidence, clean-room names, and no Workflow-tool bulk authoring.
- Add scale-run discipline to the skill-builder factory reference and enforce the lessons in source/Codex validate.sh.
- Mirror the Codex build-report schema and refresh generated hashes.

## Validation
- bash -n + shellcheck for skill-builder validators
- skills/skill-builder/scripts/validate.sh
- skills-codex/skill-builder/scripts/validate.sh
- HEAL_REPO_ROOT=/Users/bo/dev/agentops-worktrees/cp-lxo-skill-auditor-real-gate bash skills/heal-skill/scripts/heal.sh --check --strict skills/skill-builder skills-codex/skill-builder
- scripts/regen-all.sh --check
- HEAL_REPO_ROOT=/Users/bo/dev/agentops-worktrees/cp-lxo-skill-auditor-real-gate bash skills/heal-skill/scripts/heal.sh --check --strict
- scripts/audit-codex-parity.sh
- scripts/validate-codex-generated-artifacts.sh
- scripts/validate-codex-override-coverage.sh
- scripts/validate-codex-api-conformance.sh
- go run ./cmd/ao gate check --fast from cli/ (30 pass, 1 warn, 0 fail)
- pre-push Go gate (30 pass, 1 warn, 0 fail)