### PR TITLE
ci: report Go gate workflow coverage

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -194,7 +194,7 @@ jobs:
       - name: Build ao
         run: |
           mkdir -p bin
-          go build -o bin/ao ./cli/cmd/ao
+          (cd cli && go build -o ../bin/ao ./cmd/ao)
 
       - name: Run Go gate shadow
         id: go_gate

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -202,10 +202,11 @@ jobs:
         run: |
           set +e
           WORKTREE_DISPOSITION_CI_SKIP=1 \
-            ./bin/ao gate check --full --json --github-annotations \
+            ./bin/ao gate check --full --json --github-annotations --workflow-coverage \
             > ao-gate-report.json
           rc=$?
           jq '.run.summary' ao-gate-report.json
+          jq '.coverage | {workflow_script_count, registry_script_count, missing_script_count, registry_only_script_count, missing_scripts}' ao-gate-report.json
           echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
           exit "$rc"
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -155,6 +155,69 @@ jobs:
               - '.agents/**/*.jsonl'
 
   # ─────────────────────────────────────────────────────────────────────────
+  # go-gate-shadow — PB3 migration shadow lane.
+  #
+  # Runs the single Go gate entrypoint in CI and emits per-check GitHub
+  # annotations + JSON evidence while the legacy purpose jobs remain the
+  # blocking authority. This makes validate.yml exercise `ao gate check --full`
+  # without silently dropping the checks that are not yet registered in Go.
+  # Remove continue-on-error only after the registry coverage guard proves
+  # validate.yml parity.
+  # ─────────────────────────────────────────────────────────────────────────
+  go-gate-shadow:
+    needs: [changes]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.3'
+          cache-dependency-path: cli/go.sum
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Install gate dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq shellcheck
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          pip install jsonschema pyyaml
+
+      - name: Build ao
+        run: |
+          mkdir -p bin
+          go build -o bin/ao ./cli/cmd/ao
+
+      - name: Run Go gate shadow
+        id: go_gate
+        shell: bash
+        run: |
+          set +e
+          WORKTREE_DISPOSITION_CI_SKIP=1 \
+            ./bin/ao gate check --full --json --github-annotations \
+            > ao-gate-report.json
+          rc=$?
+          jq '.run.summary' ao-gate-report.json
+          echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
+          exit "$rc"
+
+      - name: Upload Go gate report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: ao-gate-shadow-report
+          path: ao-gate-report.json
+          if-no-files-found: error
+
+  # ─────────────────────────────────────────────────────────────────────────
   # skill-gates — REQUIRED. The consolidated skill-authoring gate surface:
   # every check that guards a SKILL.md / .feature / derived-skill-surface edit,
   # grouped into one named job (ag-87sv). Pure regroup of already-live gates —
@@ -1710,7 +1773,10 @@ jobs:
           trap 'rm -f "$OVERLAP_TMP" "$CLEAN_TMP"' EXIT
           # Self-test: overlapping manifests should fail
           echo '[{"id":"1","subject":"A","files":["a.go"]},{"id":"2","subject":"B","files":["a.go"]}]' > "$OVERLAP_TMP"
-          ! scripts/check-file-manifest-overlap.sh "$OVERLAP_TMP"
+          if scripts/check-file-manifest-overlap.sh "$OVERLAP_TMP"; then
+            echo "expected overlapping manifests to fail" >&2
+            exit 1
+          fi
           # Self-test: non-overlapping should pass
           echo '[{"id":"1","subject":"A","files":["a.go"]},{"id":"2","subject":"B","files":["b.go"]}]' > "$CLEAN_TMP"
           scripts/check-file-manifest-overlap.sh "$CLEAN_TMP"

--- a/cli/cmd/ao/gate_check.go
+++ b/cli/cmd/ao/gate_check.go
@@ -26,6 +26,7 @@ var (
 	gateCheckFast     bool
 	gateCheckFull     bool
 	gateCheckJSON     bool
+	gateCheckGitHub   bool
 	gateCheckFailFast bool
 	gateCheckScope    string
 )
@@ -54,6 +55,7 @@ func init() {
 	f.BoolVar(&gateCheckFast, "fast", false, "fast cockpit subset routed to changed files (the default; explicit flag for clarity in hooks)")
 	f.BoolVar(&gateCheckFull, "full", false, "run every check (routing ignored); default is the fast changed-file subset")
 	f.BoolVar(&gateCheckJSON, "json", false, "emit the machine-readable JSON report")
+	f.BoolVar(&gateCheckGitHub, "github-annotations", false, "emit GitHub Actions annotations for WARN/FAIL checks")
 	f.BoolVar(&gateCheckFailFast, "fail-fast", false, "stop after the first blocking failure")
 	f.StringVar(&gateCheckScope, "scope", "head", "fast-mode changed-file scope: head|staged|worktree|upstream")
 	gateCmd.AddCommand(gateCheckCmd)
@@ -111,6 +113,9 @@ func runGateCheck(cmd *cobra.Command, _ []string) error {
 		fmt.Fprintln(out, string(raw))
 	} else {
 		report.Human(out)
+	}
+	if gateCheckGitHub {
+		report.GitHubAnnotations(cmd.ErrOrStderr())
 	}
 
 	if code := report.ExitCode(); code != 0 {

--- a/cli/cmd/ao/gate_check.go
+++ b/cli/cmd/ao/gate_check.go
@@ -23,12 +23,15 @@ import (
 // `--full`, refinery `--full --json` — so local and CI run the identical binary.
 
 var (
-	gateCheckFast     bool
-	gateCheckFull     bool
-	gateCheckJSON     bool
-	gateCheckGitHub   bool
-	gateCheckFailFast bool
-	gateCheckScope    string
+	gateCheckFast                  bool
+	gateCheckFull                  bool
+	gateCheckJSON                  bool
+	gateCheckGitHub                bool
+	gateCheckFailFast              bool
+	gateCheckScope                 string
+	gateCheckWorkflowCoverage      bool
+	gateCheckRequireWorkflowParity bool
+	gateCheckWorkflowPath          string
 )
 
 // gateCheckRegistry is the registry the command runs; a seam so tests can swap
@@ -58,6 +61,9 @@ func init() {
 	f.BoolVar(&gateCheckGitHub, "github-annotations", false, "emit GitHub Actions annotations for WARN/FAIL checks")
 	f.BoolVar(&gateCheckFailFast, "fail-fast", false, "stop after the first blocking failure")
 	f.StringVar(&gateCheckScope, "scope", "head", "fast-mode changed-file scope: head|staged|worktree|upstream")
+	f.BoolVar(&gateCheckWorkflowCoverage, "workflow-coverage", false, "include validate.yml-vs-registry script coverage in the report")
+	f.BoolVar(&gateCheckRequireWorkflowParity, "require-workflow-parity", false, "fail if validate.yml references scripts missing from the Go gate registry")
+	f.StringVar(&gateCheckWorkflowPath, "workflow-path", ".github/workflows/validate.yml", "workflow path used by --workflow-coverage and --require-workflow-parity")
 	gateCmd.AddCommand(gateCheckCmd)
 }
 
@@ -103,6 +109,13 @@ func runGateCheck(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return &gateExitError{code: gateExitInternal, msg: err.Error()}
 	}
+	if gateCheckWorkflowCoverage || gateCheckRequireWorkflowParity {
+		coverage, cerr := gates.RegistryWorkflowCoverage(gateCheckRegistry, root, gateCheckWorkflowPath)
+		if cerr != nil {
+			return &gateExitError{code: gateExitInternal, msg: cerr.Error()}
+		}
+		report.Coverage = coverage
+	}
 
 	out := cmd.OutOrStdout()
 	if gateCheckJSON {
@@ -120,6 +133,12 @@ func runGateCheck(cmd *cobra.Command, _ []string) error {
 
 	if code := report.ExitCode(); code != 0 {
 		return &gateExitError{code: code}
+	}
+	if gateCheckRequireWorkflowParity && report.Coverage != nil && report.Coverage.MissingScriptCount > 0 {
+		return &gateExitError{
+			code: gateExitFail,
+			msg:  fmt.Sprintf("workflow parity missing %d script(s)", report.Coverage.MissingScriptCount),
+		}
 	}
 	return nil
 }

--- a/cli/cmd/ao/gate_check_test.go
+++ b/cli/cmd/ao/gate_check_test.go
@@ -43,12 +43,15 @@ func runGateCheckWith(t *testing.T, reg *gates.Registry, full, jsonOut bool) (st
 	t.Helper()
 	save := func() func() {
 		r, fl, j, ff, sc := gateCheckRegistry, gateCheckFull, gateCheckJSON, gateCheckFailFast, gateCheckScope
+		wc, req, wp := gateCheckWorkflowCoverage, gateCheckRequireWorkflowParity, gateCheckWorkflowPath
 		return func() {
 			gateCheckRegistry, gateCheckFull, gateCheckJSON, gateCheckFailFast, gateCheckScope = r, fl, j, ff, sc
+			gateCheckWorkflowCoverage, gateCheckRequireWorkflowParity, gateCheckWorkflowPath = wc, req, wp
 		}
 	}()
 	defer save()
 	gateCheckRegistry, gateCheckFull, gateCheckJSON, gateCheckFailFast, gateCheckScope = reg, full, jsonOut, false, "head"
+	gateCheckWorkflowCoverage, gateCheckRequireWorkflowParity, gateCheckWorkflowPath = false, false, ".github/workflows/validate.yml"
 
 	var buf bytes.Buffer
 	c := &cobra.Command{}
@@ -80,7 +83,17 @@ func TestGateCheck_RegisteredUnderGate(t *testing.T) {
 }
 
 func TestGateCheck_HasModeFlags(t *testing.T) {
-	for _, name := range []string{"fast", "full", "json", "github-annotations", "fail-fast", "scope"} {
+	for _, name := range []string{
+		"fast",
+		"full",
+		"json",
+		"github-annotations",
+		"fail-fast",
+		"scope",
+		"workflow-coverage",
+		"require-workflow-parity",
+		"workflow-path",
+	} {
 		if gateCheckCmd.Flags().Lookup(name) == nil {
 			t.Errorf("ao gate check missing --%s flag", name)
 		}

--- a/cli/cmd/ao/gate_check_test.go
+++ b/cli/cmd/ao/gate_check_test.go
@@ -80,7 +80,7 @@ func TestGateCheck_RegisteredUnderGate(t *testing.T) {
 }
 
 func TestGateCheck_HasModeFlags(t *testing.T) {
-	for _, name := range []string{"fast", "full", "json", "fail-fast", "scope"} {
+	for _, name := range []string{"fast", "full", "json", "github-annotations", "fail-fast", "scope"} {
 		if gateCheckCmd.Flags().Lookup(name) == nil {
 			t.Errorf("ao gate check missing --%s flag", name)
 		}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -669,13 +669,16 @@ ao gate check [flags]
 **Flags:**
 
 ```
-      --fail-fast            stop after the first blocking failure
-      --fast                 fast cockpit subset routed to changed files (the default; explicit flag for clarity in hooks)
-      --full                 run every check (routing ignored); default is the fast changed-file subset
-      --github-annotations   emit GitHub Actions annotations for WARN/FAIL checks
-  -h, --help                 help for check
-      --json                 emit the machine-readable JSON report
-      --scope string         fast-mode changed-file scope: head|staged|worktree|upstream (default "head")
+      --fail-fast                 stop after the first blocking failure
+      --fast                      fast cockpit subset routed to changed files (the default; explicit flag for clarity in hooks)
+      --full                      run every check (routing ignored); default is the fast changed-file subset
+      --github-annotations        emit GitHub Actions annotations for WARN/FAIL checks
+  -h, --help                      help for check
+      --json                      emit the machine-readable JSON report
+      --require-workflow-parity   fail if validate.yml references scripts missing from the Go gate registry
+      --scope string              fast-mode changed-file scope: head|staged|worktree|upstream (default "head")
+      --workflow-coverage         include validate.yml-vs-registry script coverage in the report
+      --workflow-path string      workflow path used by --workflow-coverage and --require-workflow-parity (default ".github/workflows/validate.yml")
 ```
 
 #### `ao gate pending`

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -669,12 +669,13 @@ ao gate check [flags]
 **Flags:**
 
 ```
-      --fail-fast      stop after the first blocking failure
-      --fast           fast cockpit subset routed to changed files (the default; explicit flag for clarity in hooks)
-      --full           run every check (routing ignored); default is the fast changed-file subset
-  -h, --help           help for check
-      --json           emit the machine-readable JSON report
-      --scope string   fast-mode changed-file scope: head|staged|worktree|upstream (default "head")
+      --fail-fast            stop after the first blocking failure
+      --fast                 fast cockpit subset routed to changed files (the default; explicit flag for clarity in hooks)
+      --full                 run every check (routing ignored); default is the fast changed-file subset
+      --github-annotations   emit GitHub Actions annotations for WARN/FAIL checks
+  -h, --help                 help for check
+      --json                 emit the machine-readable JSON report
+      --scope string         fast-mode changed-file scope: head|staged|worktree|upstream (default "head")
 ```
 
 #### `ao gate pending`

--- a/cli/internal/gates/report.go
+++ b/cli/internal/gates/report.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/boshu2/agentops/cli/internal/ports"
@@ -132,6 +133,48 @@ func (r *Report) Human(w io.Writer) {
 	}
 	fmt.Fprintf(w, "\n%s/%s: %d checks — %d pass, %d warn, %d fail, %d skip (%dms)\n",
 		modeString(r.Mode), r.Scope, s.Total, s.Passed, s.Warned, s.Failed, s.Skipped, r.Elapsed.Milliseconds())
+}
+
+// GitHubAnnotations writes GitHub Actions log annotations for failing or
+// advisory checks. Human/JSON output remains the primary report; annotations
+// preserve per-check CI ergonomics when validate.yml delegates to ao gate check.
+func (r *Report) GitHubAnnotations(w io.Writer) {
+	for _, res := range r.Results {
+		level := ""
+		switch res.Verdict.Status {
+		case ports.GateStatusFail:
+			if res.Check.Blocking {
+				level = "error"
+			} else {
+				level = "warning"
+			}
+		case ports.GateStatusWarn:
+			level = "warning"
+		default:
+			continue
+		}
+		msg := res.Verdict.Reason
+		if res.Err != nil {
+			msg = "evaluation error: " + res.Err.Error()
+		}
+		if res.Verdict.LogTail != "" {
+			msg += "\n" + res.Verdict.LogTail
+		}
+		fmt.Fprintf(w, "::%s title=%s::%s\n",
+			level,
+			escapeGitHubAnnotation(res.Check.ID),
+			escapeGitHubAnnotation(msg),
+		)
+	}
+}
+
+func escapeGitHubAnnotation(s string) string {
+	replacer := strings.NewReplacer(
+		"%", "%25",
+		"\r", "%0D",
+		"\n", "%0A",
+	)
+	return replacer.Replace(s)
 }
 
 func modeString(t Tier) string {

--- a/cli/internal/gates/report.go
+++ b/cli/internal/gates/report.go
@@ -19,6 +19,7 @@ type Report struct {
 	StartedAt    time.Time
 	Elapsed      time.Duration
 	Results      []CheckResult
+	Coverage     *WorkflowCoverage
 }
 
 // ExitCode is 1 if any blocking check FAILed, else 0. WARN/SKIP and
@@ -66,8 +67,9 @@ type Summary struct {
 // ---- JSON wire format (the contract the refinery + CI consume) ----
 
 type jsonReport struct {
-	Run   jsonRun    `json:"run"`
-	Gates []jsonGate `json:"gates"`
+	Run      jsonRun           `json:"run"`
+	Gates    []jsonGate        `json:"gates"`
+	Coverage *WorkflowCoverage `json:"coverage,omitempty"`
 }
 
 type jsonRun struct {
@@ -102,6 +104,9 @@ func (r *Report) JSON() ([]byte, error) {
 		},
 		Gates: make([]jsonGate, 0, len(r.Results)),
 	}
+	if r.Coverage != nil {
+		jr.Coverage = r.Coverage
+	}
 	for _, res := range r.Results {
 		reason := res.Verdict.Reason
 		if res.Err != nil {
@@ -133,6 +138,14 @@ func (r *Report) Human(w io.Writer) {
 	}
 	fmt.Fprintf(w, "\n%s/%s: %d checks — %d pass, %d warn, %d fail, %d skip (%dms)\n",
 		modeString(r.Mode), r.Scope, s.Total, s.Passed, s.Warned, s.Failed, s.Skipped, r.Elapsed.Milliseconds())
+	if r.Coverage != nil {
+		fmt.Fprintf(w, "workflow coverage: %d workflow scripts, %d registry scripts, %d missing, %d registry-only\n",
+			r.Coverage.WorkflowScriptCount,
+			r.Coverage.RegistryScriptCount,
+			r.Coverage.MissingScriptCount,
+			r.Coverage.RegistryOnlyScriptCount,
+		)
+	}
 }
 
 // GitHubAnnotations writes GitHub Actions log annotations for failing or
@@ -165,6 +178,9 @@ func (r *Report) GitHubAnnotations(w io.Writer) {
 			escapeGitHubAnnotation(res.Check.ID),
 			escapeGitHubAnnotation(msg),
 		)
+	}
+	if r.Coverage != nil {
+		r.Coverage.GitHubAnnotations(w)
 	}
 }
 

--- a/cli/internal/gates/report_test.go
+++ b/cli/internal/gates/report_test.go
@@ -1,0 +1,49 @@
+package gates
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/boshu2/agentops/cli/internal/ports"
+)
+
+func TestReportGitHubAnnotations(t *testing.T) {
+	report := &Report{
+		Mode:      Full,
+		Scope:     ScopeHead,
+		StartedAt: time.Unix(0, 0),
+		Results: []CheckResult{
+			{
+				Check: Check{ID: "blocking.fail", Blocking: true},
+				Verdict: ports.GateVerdict{
+					Status:  ports.GateStatusFail,
+					Reason:  "failed 100%",
+					LogTail: "line one\nline two",
+				},
+			},
+			{
+				Check:   Check{ID: "advisory.warn", Blocking: false},
+				Verdict: ports.GateVerdict{Status: ports.GateStatusWarn, Reason: "warned"},
+			},
+			{
+				Check:   Check{ID: "passing", Blocking: true},
+				Verdict: ports.GateVerdict{Status: ports.GateStatusPass, Reason: "ok"},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	report.GitHubAnnotations(&out)
+	got := out.String()
+	if !strings.Contains(got, "::error title=blocking.fail::failed 100%25%0Aline one%0Aline two") {
+		t.Fatalf("missing escaped error annotation: %q", got)
+	}
+	if !strings.Contains(got, "::warning title=advisory.warn::warned") {
+		t.Fatalf("missing warning annotation: %q", got)
+	}
+	if strings.Contains(got, "passing") {
+		t.Fatalf("PASS checks should not emit annotations: %q", got)
+	}
+}

--- a/cli/internal/gates/workflow_coverage.go
+++ b/cli/internal/gates/workflow_coverage.go
@@ -1,0 +1,210 @@
+package gates
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// WorkflowCoverage compares the Go gate registry with one GitHub Actions
+// workflow. It is diagnostic by default; --require-workflow-parity can promote
+// MissingScripts to a blocking gate once CI is ready to flip authority.
+type WorkflowCoverage struct {
+	WorkflowPath            string              `json:"workflow_path"`
+	WorkflowScriptCount     int                 `json:"workflow_script_count"`
+	RegistryScriptCount     int                 `json:"registry_script_count"`
+	MissingScriptCount      int                 `json:"missing_script_count"`
+	RegistryOnlyScriptCount int                 `json:"registry_only_script_count"`
+	WorkflowScripts         []WorkflowScriptRef `json:"workflow_scripts"`
+	RegistryScripts         []string            `json:"registry_scripts"`
+	MissingScripts          []string            `json:"missing_scripts"`
+	RegistryOnlyScripts     []string            `json:"registry_only_scripts"`
+}
+
+// WorkflowScriptRef records a script reference found in a workflow run block.
+type WorkflowScriptRef struct {
+	Script   string `json:"script"`
+	Job      string `json:"job"`
+	Step     string `json:"step,omitempty"`
+	Advisory bool   `json:"advisory"`
+}
+
+type workflowFile struct {
+	Jobs map[string]workflowJob `yaml:"jobs"`
+}
+
+type workflowJob struct {
+	ContinueOnError any            `yaml:"continue-on-error"`
+	Steps           []workflowStep `yaml:"steps"`
+}
+
+type workflowStep struct {
+	Name            string `yaml:"name"`
+	Run             string `yaml:"run"`
+	ContinueOnError any    `yaml:"continue-on-error"`
+}
+
+var workflowScriptPattern = regexp.MustCompile("(?:^|[\\s\"'`])((?:scripts|skills/[A-Za-z0-9._/-]+/scripts)/[A-Za-z0-9._/-]+\\.(?:sh|py))")
+
+// RegistryWorkflowCoverage returns workflow-vs-registry script coverage.
+func RegistryWorkflowCoverage(reg *Registry, repoRoot, workflowRel string) (*WorkflowCoverage, error) {
+	if reg == nil {
+		return nil, fmt.Errorf("gates: registry required")
+	}
+	if repoRoot == "" {
+		return nil, fmt.Errorf("gates: repo root required")
+	}
+	if workflowRel == "" {
+		workflowRel = filepath.Join(".github", "workflows", "validate.yml")
+	}
+	workflowPath := workflowRel
+	if !filepath.IsAbs(workflowPath) {
+		workflowPath = filepath.Join(repoRoot, workflowRel)
+	}
+	refs, workflowScripts, err := workflowScriptRefs(workflowPath)
+	if err != nil {
+		return nil, err
+	}
+	registryScripts := registryBackingScripts(reg)
+
+	missing := sortedSetDiff(workflowScripts, registryScripts)
+	registryOnly := sortedSetDiff(registryScripts, workflowScripts)
+	return &WorkflowCoverage{
+		WorkflowPath:            workflowRel,
+		WorkflowScriptCount:     len(workflowScripts),
+		RegistryScriptCount:     len(registryScripts),
+		MissingScriptCount:      len(missing),
+		RegistryOnlyScriptCount: len(registryOnly),
+		WorkflowScripts:         refs,
+		RegistryScripts:         setToSortedSlice(registryScripts),
+		MissingScripts:          missing,
+		RegistryOnlyScripts:     registryOnly,
+	}, nil
+}
+
+// GitHubAnnotations emits one annotation summarizing the parity gap.
+func (c *WorkflowCoverage) GitHubAnnotations(w io.Writer) {
+	if c == nil || c.MissingScriptCount == 0 {
+		return
+	}
+	msg := fmt.Sprintf("%d validate.yml script(s) are not registered in ao gate check: %s",
+		c.MissingScriptCount,
+		strings.Join(c.MissingScripts, ", "),
+	)
+	fmt.Fprintf(w, "::warning title=%s::%s\n",
+		escapeGitHubAnnotation("ao-gate-workflow-coverage"),
+		escapeGitHubAnnotation(msg),
+	)
+}
+
+func workflowScriptRefs(path string) ([]WorkflowScriptRef, map[string]struct{}, error) {
+	raw, err := os.ReadFile(path) // #nosec G304 -- repo-local workflow path supplied by caller.
+	if err != nil {
+		return nil, nil, fmt.Errorf("gates: read workflow %s: %w", path, err)
+	}
+	var wf workflowFile
+	if err := yaml.Unmarshal(raw, &wf); err != nil {
+		return nil, nil, fmt.Errorf("gates: parse workflow %s: %w", path, err)
+	}
+
+	var refs []WorkflowScriptRef
+	seenRefs := map[string]struct{}{}
+	scripts := map[string]struct{}{}
+	for jobName, job := range wf.Jobs {
+		for _, step := range job.Steps {
+			if step.Run == "" {
+				continue
+			}
+			for _, script := range scriptsInRunBlock(step.Run) {
+				ref := WorkflowScriptRef{
+					Script:   script,
+					Job:      jobName,
+					Step:     step.Name,
+					Advisory: boolish(job.ContinueOnError) || boolish(step.ContinueOnError),
+				}
+				key := ref.Job + "\x00" + ref.Step + "\x00" + ref.Script
+				if _, ok := seenRefs[key]; ok {
+					continue
+				}
+				seenRefs[key] = struct{}{}
+				refs = append(refs, ref)
+				scripts[script] = struct{}{}
+			}
+		}
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].Script != refs[j].Script {
+			return refs[i].Script < refs[j].Script
+		}
+		if refs[i].Job != refs[j].Job {
+			return refs[i].Job < refs[j].Job
+		}
+		return refs[i].Step < refs[j].Step
+	})
+	return refs, scripts, nil
+}
+
+func scriptsInRunBlock(run string) []string {
+	matches := workflowScriptPattern.FindAllStringSubmatch(run, -1)
+	seen := map[string]struct{}{}
+	for _, m := range matches {
+		if len(m) < 2 {
+			continue
+		}
+		script := strings.TrimPrefix(m[1], "./")
+		seen[script] = struct{}{}
+	}
+	return setToSortedSlice(seen)
+}
+
+func registryBackingScripts(reg *Registry) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, check := range reg.All() {
+		if check.Backing == "" {
+			continue
+		}
+		script := check.Backing
+		if !strings.Contains(script, "/") {
+			script = filepath.Join("scripts", script)
+		}
+		out[filepath.ToSlash(script)] = struct{}{}
+	}
+	return out
+}
+
+func boolish(v any) bool {
+	switch t := v.(type) {
+	case bool:
+		return t
+	case string:
+		return strings.EqualFold(strings.TrimSpace(t), "true")
+	default:
+		return false
+	}
+}
+
+func setToSortedSlice(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for v := range set {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedSetDiff(a, b map[string]struct{}) []string {
+	var out []string
+	for v := range a {
+		if _, ok := b[v]; !ok {
+			out = append(out, v)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cli/internal/gates/workflow_coverage_test.go
+++ b/cli/internal/gates/workflow_coverage_test.go
@@ -1,0 +1,55 @@
+package gates
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRegistryWorkflowCoverageReportsMissingAndRegistryOnly(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".github", "workflows"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workflow := []byte(`name: Validate
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    steps:
+      - name: covered
+        run: bash scripts/check-covered.sh
+      - name: missing
+        continue-on-error: true
+        run: |
+          chmod +x scripts/check-missing.sh
+          ./scripts/check-missing.sh
+`)
+	if err := os.WriteFile(filepath.Join(root, ".github", "workflows", "validate.yml"), workflow, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := NewRegistry()
+	if err := reg.Add(Check{ID: "covered", Tiers: Full, Blocking: true, Backing: "check-covered.sh"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Add(Check{ID: "extra", Tiers: Full, Blocking: true, Backing: "check-extra.sh"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := RegistryWorkflowCoverage(reg, root, ".github/workflows/validate.yml")
+	if err != nil {
+		t.Fatalf("RegistryWorkflowCoverage: %v", err)
+	}
+	if got.WorkflowScriptCount != 2 {
+		t.Fatalf("WorkflowScriptCount = %d, want 2", got.WorkflowScriptCount)
+	}
+	if got.RegistryScriptCount != 2 {
+		t.Fatalf("RegistryScriptCount = %d, want 2", got.RegistryScriptCount)
+	}
+	if got.MissingScriptCount != 1 || got.MissingScripts[0] != "scripts/check-missing.sh" {
+		t.Fatalf("MissingScripts = %+v, want check-missing", got.MissingScripts)
+	}
+	if got.RegistryOnlyScriptCount != 1 || got.RegistryOnlyScripts[0] != "scripts/check-extra.sh" {
+		t.Fatalf("RegistryOnlyScripts = %+v, want check-extra", got.RegistryOnlyScripts)
+	}
+}

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,7 @@
 {
   "schema_version": 2,
   "generated_at": "2026-06-07T20:47:50Z",
+  "generated_at": "2026-06-07T21:38:12Z",
   "summary": {
     "skills": 158,
     "hooks": 0,
@@ -9,6 +10,7 @@
     "eval_files": 56,
     "cli_commands": 83,
     "capabilities": 254
+    "capabilities": 268
   },
   "surfaces": {
     "skills": [
@@ -2110,8 +2112,10 @@
   "capability_summary": {
     "total": 254,
     "skills": 158,
+    "total": 268,
+    "skills": 171,
     "cli_commands": 83,
-    "gates": 13,
+    "gates": 14,
     "reference_impls": 0
   },
   "cli_top_level_commands": [
@@ -7215,6 +7219,15 @@
     {
       "sku": "gate:changes",
       "name": "changes",
+      "type": "gate",
+      "bounded_context": "BC2",
+      "purpose": "CI validation gate (.github/workflows/validate.yml).",
+      "status": "active",
+      "path": ".github/workflows/validate.yml"
+    },
+    {
+      "sku": "gate:go-gate-shadow",
+      "name": "go-gate-shadow",
       "type": "gate",
       "bounded_context": "BC2",
       "purpose": "CI validation gate (.github/workflows/validate.yml).",

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-07T20:47:50Z",
-  "generated_at": "2026-06-07T21:38:12Z",
+  "generated_at": "2026-06-07T22:32:25Z",
   "summary": {
     "skills": 158,
     "hooks": 0,
@@ -9,8 +8,7 @@
     "job_types": 0,
     "eval_files": 56,
     "cli_commands": 83,
-    "capabilities": 254
-    "capabilities": 268
+    "capabilities": 255
   },
   "surfaces": {
     "skills": [
@@ -2110,10 +2108,8 @@
     ]
   },
   "capability_summary": {
-    "total": 254,
+    "total": 255,
     "skills": 158,
-    "total": 268,
-    "skills": 171,
     "cli_commands": 83,
     "gates": 14,
     "reference_impls": 0

--- a/scripts/check-worktree-disposition.sh
+++ b/scripts/check-worktree-disposition.sh
@@ -14,6 +14,11 @@ repo_root="$(git rev-parse --show-toplevel)"
 current_branch="$(git branch --show-current)"
 common_dir="$(git rev-parse --git-common-dir)"
 
+if [[ "${WORKTREE_DISPOSITION_CI_SKIP:-0}" == "1" ]]; then
+    echo "SKIP: worktree disposition is a local canonical-root gate; disabled for detached CI checkout"
+    exit 0
+fi
+
 run_git_external() {
     local target_root="$1"
     shift


### PR DESCRIPTION
## Summary
- rebases the cp-v8m.2 Go-gate shadow branch onto merged main
- adds Go-native validate.yml workflow coverage accounting to ao gate check
- emits coverage counts and missing registry scripts in the shadow CI artifact

This intentionally does not close cp-v8m.2. The current report proves ao gate check --full runs green, but also proves the remaining parity gap: 66 workflow scripts, 45 shell-backed registry scripts, 40 workflow scripts still missing from the Go registry, and 19 registry-only scripts.

## Validation
- go test ./internal/gates ./cmd/ao
- scripts/generate-cli-reference.sh --check
- bash scripts/validate-sku-catalog-drift.sh
- WORKTREE_DISPOSITION_CI_SKIP=1 go run ./cmd/ao gate check --full --json --workflow-coverage from cli/
- scripts/regen-all.sh --check
- local pre-push Go gate passed: 47 checks, 46 pass, 1 advisory warn, 0 fail
