### PR TITLE
gate: register workflow parity batch

### DIFF
--- a/cli/internal/gates/checks/seed.go
+++ b/cli/internal/gates/checks/seed.go
@@ -12,14 +12,18 @@ import "github.com/boshu2/agentops/cli/internal/gates"
 
 // Change-class path globs (ported from the bash gate's HAS_<CLASS> regexes).
 var (
-	goPaths       = []string{"cli/**", "go.mod", "go.sum"}
-	skillPaths    = []string{"skills/**", "skills-codex/**", "tests/skills/**"}
+	goPaths         = []string{"cli/**", "go.mod", "go.sum"}
+	skillPaths      = []string{"skills/**", "skills-codex/**", "tests/skills/**"}
 	contractPaths   = []string{"docs/contracts/**", "schemas/**"}
 	ciPolicyPaths   = []string{".github/workflows/validate.yml", "docs/CI-CD.md", "AGENTS.md"}
 	evalPaths       = []string{"evals/**", "schemas/eval-*", "cli/internal/eval/**"}
 	contextMapPaths = []string{"skills/**", "docs/contracts/context-map.md"}
 	swarmPaths      = []string{".agents/swarm/**", "schemas/swarm-*"}
 	docsPaths       = []string{"docs/**", "README.md", "CHANGELOG.md", "PRODUCT.md", "SKILL-TIERS.md"}
+	agentsDocPaths  = []string{"AGENTS.md", "AGENTS-WORKFLOW.md", "AGENTS-CI.md", "AGENTS-CODEX.md", "AGENTS-RUNTIME.md", ".github/workflows/validate.yml"}
+	corpusPaths     = []string{".agents/**", "docs/canon/**", "canon/**"}
+	goalsPaths      = []string{"GOALS.md", "spec/scenarios/**", "docs/adr/ADR-0003*"}
+	registryPaths   = []string{"skills/**", "hooks/**", "evals/**", "cli/cmd/ao/**", "cli/internal/**", "registry.json"}
 )
 
 func init() {
@@ -54,25 +58,47 @@ func init() {
 		{ID: "skill.codex-rpi-contract", Tiers: gates.Fast | gates.Full, Match: skillPaths, Blocking: true, Backing: "validate-codex-rpi-contract.sh"},
 		{ID: "skill.codex-lifecycle-guards", Tiers: gates.Fast | gates.Full, Match: skillPaths, Blocking: true, Backing: "validate-codex-lifecycle-guards.sh"},
 		{ID: "skill.codex-generated-artifacts", Tiers: gates.Fast | gates.Full, Match: skillPaths, Blocking: true, Backing: "validate-codex-generated-artifacts.sh"},
+		{ID: "skill.heal-strict", Tiers: gates.Full, Match: skillPaths, Blocking: true, Backing: "skills/heal-skill/scripts/heal.sh", Args: []string{"--strict"}},
+		{ID: "skill.frontmatter-v2", Tiers: gates.Full, Match: skillPaths, Blocking: true, Backing: "validate-skill-frontmatter.sh"},
+		{ID: "skill.body-refs", Tiers: gates.Full, Match: skillPaths, Blocking: true, Backing: "validate-skill-body-refs.sh"},
+		{ID: "skill.flow", Tiers: gates.Full, Match: skillPaths, Blocking: true, Backing: "validate-skill-flow.sh"},
+		{ID: "skill.domain-map-golden", Tiers: gates.Full, Match: skillPaths, Blocking: true, Backing: "generate-skill-domain-map.sh", Args: []string{"--check"}},
+		{ID: "skill.scenario-test-linkage", Tiers: gates.Full, Match: skillPaths, Blocking: true, Backing: "check-scenario-test-linkage.sh"},
 
 		// go class
 		{ID: "go.home-isolation", Tiers: gates.Fast | gates.Full, Match: goPaths, Blocking: true, Backing: "check-home-isolation.sh"},
 		{ID: "go.test-home-isolation", Tiers: gates.Fast | gates.Full, Match: goPaths, Blocking: true, Backing: "check-test-home-isolation.sh"},
+		{ID: "go.complexity", Tiers: gates.Full, Match: goPaths, Blocking: true, Backing: "check-go-complexity.sh"},
+		{ID: "go.cli-reference", Tiers: gates.Full, Match: goPaths, Blocking: true, Backing: "generate-cli-reference.sh", Args: []string{"--check"}},
+		{ID: "go.cli-surface-counts", Tiers: gates.Full, Match: goPaths, Blocking: true, Backing: "update-cli-surface-counts.sh"},
+		{ID: "go.test-count-regression", Tiers: gates.Full, Match: goPaths, Blocking: true, Backing: "check-test-count-regression.sh"},
+		{ID: "go.test-isolation", Tiers: gates.Full, Match: goPaths, Blocking: true, Backing: "check-test-isolation.sh"},
+		{ID: "go.test-staleness", Tiers: gates.Full, Match: goPaths, Blocking: false, Backing: "check-test-staleness.sh"},
 
 		// contract / context-map / swarm classes
 		{ID: "contract.compatibility", Tiers: gates.Fast | gates.Full, Match: contractPaths, Blocking: true, Backing: "check-contract-compatibility.sh"},
 		{ID: "contract.context-map-drift", Tiers: gates.Fast | gates.Full, Match: contextMapPaths, Blocking: true, Backing: "validate-context-map-drift.sh"},
+		{ID: "contract.registry-json", Tiers: gates.Full, Match: registryPaths, Blocking: true, Backing: "generate-registry.sh", Args: []string{"--check"}},
+		{ID: "contract.sku-catalog-drift", Tiers: gates.Full, Match: registryPaths, Blocking: true, Backing: "validate-sku-catalog-drift.sh"},
+		{ID: "docs.agents-split", Tiers: gates.Full, Match: agentsDocPaths, Blocking: true, Backing: "validate-agents-split.sh"},
 		{ID: "swarm.evidence", Tiers: gates.Fast | gates.Full, Match: swarmPaths, Blocking: true, Backing: "validate-swarm-evidence.sh"},
 
 		// always-run structural invariants (no Match)
 		{ID: "always.author-judge-convergence", Tiers: gates.Fast | gates.Full, Blocking: true, Backing: "check-author-judge-convergence.sh"},
 		{ID: "always.contracts-structural-floor", Tiers: gates.Fast | gates.Full, Blocking: true, Backing: "check-contracts-structural-floor.sh"},
 		{ID: "always.docs-learning-references", Tiers: gates.Fast | gates.Full, Blocking: true, Backing: "check-docs-learning-references.sh"},
+		{ID: "always.docs-hookless", Tiers: gates.Full, Blocking: true, Backing: "check-doc-hooks-drift.sh"},
 		{ID: "always.flywheel-compounding-snapshot", Tiers: gates.Fast | gates.Full, Blocking: true, Backing: "check-flywheel-compounding-snapshot.sh"},
 		{ID: "always.retrieval-manifest-paths", Tiers: gates.Fast | gates.Full, Blocking: true, Backing: "check-retrieval-manifest-paths.sh"},
 		{ID: "always.wiring-closure", Tiers: gates.Fast | gates.Full, Blocking: true, Backing: "check-wiring-closure.sh"},
 		{ID: "always.bd-closeout-contract", Tiers: gates.Fast | gates.Full, Blocking: true, Backing: "validate-bd-closeout-contract.sh"},
 		{ID: "always.domain-evolution-plan", Tiers: gates.Fast | gates.Full, Blocking: true, Backing: "check-agentops-domain-evolution-plan.sh"},
+		{ID: "always.file-manifest-overlap", Tiers: gates.Full, Blocking: true, Backing: "check-file-manifest-overlap.sh"},
+		{ID: "always.regen-all", Tiers: gates.Full, Blocking: true, Backing: "regen-all.sh", Args: []string{"--check"}},
+		{ID: "always.three-gap-supergate", Tiers: gates.Full, Match: goalsPaths, Blocking: true, Backing: "check-three-gap-supergate.sh"},
+		{ID: "always.sovereignty-proof-citations", Tiers: gates.Full, Match: docsPaths, Blocking: true, Backing: "validate-sovereignty-proof-citations.sh"},
+		{ID: "corpus.secret-scan", Tiers: gates.Full, Match: corpusPaths, Blocking: true, Backing: "check-corpus-secret-scan.sh"},
+		{ID: "corpus.witness-dolt-jsonl-crosscheck", Tiers: gates.Full, Match: corpusPaths, Blocking: true, Backing: "witness-dolt-jsonl-crosscheck.sh"},
 
 		// full-mode-only / advisory (mirror the bash gate: these skip in fast or warn)
 		{ID: "full.worktree-disposition", Tiers: gates.Full, Blocking: true, Backing: "check-worktree-disposition.sh"},

--- a/cli/internal/gates/scriptrunner.go
+++ b/cli/internal/gates/scriptrunner.go
@@ -12,9 +12,10 @@ import (
 	"github.com/boshu2/agentops/cli/internal/ports"
 )
 
-// ScriptRunner runs scripts/<name> (name is the full basename including the
-// prefix and .sh suffix, e.g. "check-registry-drift.sh" or
-// "validate-skill-schema.sh") and maps its exit code to a GateVerdict.
+// ScriptRunner runs a shell-backed check and maps its exit code to a
+// GateVerdict. Basename backings resolve under scripts/ (for example
+// "check-registry-drift.sh"). Path backings resolve from the repo root (for
+// example "skills/heal-skill/scripts/heal.sh").
 //
 // It satisfies ports.GateRunnerPort, so the orchestrator can shell to ANY
 // scripts/* gate — both check-*.sh and validate-*.sh — not only the check-*
@@ -27,7 +28,7 @@ type ScriptRunner struct {
 // NewScriptRunner returns a ScriptRunner rooted at repoRoot.
 func NewScriptRunner(repoRoot string) *ScriptRunner { return &ScriptRunner{repoRoot: repoRoot} }
 
-// Run executes scripts/<req.Name> and returns its verdict.
+// Run executes the requested backing and returns its verdict.
 func (s *ScriptRunner) Run(ctx context.Context, req ports.GateRunRequest) (ports.GateVerdict, error) {
 	if err := ctx.Err(); err != nil {
 		return ports.GateVerdict{}, err
@@ -37,6 +38,9 @@ func (s *ScriptRunner) Run(ctx context.Context, req ports.GateRunRequest) (ports
 		return ports.GateVerdict{Status: ports.GateStatusUnknown, Reason: "empty gate name"}, nil
 	}
 	script := filepath.Join(s.repoRoot, "scripts", name)
+	if strings.Contains(name, "/") {
+		script = filepath.Join(s.repoRoot, name)
+	}
 	if fi, err := os.Stat(script); err != nil || fi.IsDir() {
 		return ports.GateVerdict{Status: ports.GateStatusUnknown, Reason: fmt.Sprintf("no script %s", script)}, nil
 	}

--- a/cli/internal/gates/workflow_coverage.go
+++ b/cli/internal/gates/workflow_coverage.go
@@ -50,7 +50,7 @@ type workflowStep struct {
 	ContinueOnError any    `yaml:"continue-on-error"`
 }
 
-var workflowScriptPattern = regexp.MustCompile("(?:^|[\\s\"'`])((?:scripts|skills/[A-Za-z0-9._/-]+/scripts)/[A-Za-z0-9._/-]+\\.(?:sh|py))")
+var workflowScriptPattern = regexp.MustCompile("(?:^|[\\s\"'`])(?:\\./)?((?:scripts|skills/[A-Za-z0-9._/-]+/scripts)/[A-Za-z0-9._/-]+\\.(?:sh|py))")
 
 // RegistryWorkflowCoverage returns workflow-vs-registry script coverage.
 func RegistryWorkflowCoverage(reg *Registry, repoRoot, workflowRel string) (*WorkflowCoverage, error) {
@@ -151,16 +151,34 @@ func workflowScriptRefs(path string) ([]WorkflowScriptRef, map[string]struct{}, 
 }
 
 func scriptsInRunBlock(run string) []string {
-	matches := workflowScriptPattern.FindAllStringSubmatch(run, -1)
 	seen := map[string]struct{}{}
-	for _, m := range matches {
-		if len(m) < 2 {
+	for _, line := range strings.Split(run, "\n") {
+		if !workflowLineMayInvokeScript(line) {
 			continue
 		}
-		script := strings.TrimPrefix(m[1], "./")
-		seen[script] = struct{}{}
+		matches := workflowScriptPattern.FindAllStringSubmatch(line, -1)
+		for _, m := range matches {
+			if len(m) < 2 {
+				continue
+			}
+			script := strings.TrimPrefix(m[1], "./")
+			seen[script] = struct{}{}
+		}
 	}
 	return setToSortedSlice(seen)
+}
+
+func workflowLineMayInvokeScript(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+		return false
+	}
+	if strings.HasPrefix(trimmed, "chmod ") ||
+		strings.HasPrefix(trimmed, "echo ") ||
+		strings.HasPrefix(trimmed, "printf ") {
+		return false
+	}
+	return workflowScriptPattern.MatchString(trimmed)
 }
 
 func registryBackingScripts(reg *Registry) map[string]struct{} {

--- a/cli/internal/gates/workflow_coverage_test.go
+++ b/cli/internal/gates/workflow_coverage_test.go
@@ -22,6 +22,7 @@ jobs:
         continue-on-error: true
         run: |
           chmod +x scripts/check-missing.sh
+          echo "run scripts/check-echo-only.sh if this fails"
           ./scripts/check-missing.sh
 `)
 	if err := os.WriteFile(filepath.Join(root, ".github", "workflows", "validate.yml"), workflow, 0o644); err != nil {


### PR DESCRIPTION
## Summary
- registers a batch of validate.yml workflow gates in the Go gate registry as full-mode checks
- lets ScriptRunner execute repo-relative path backings such as skills/heal-skill/scripts/heal.sh
- tightens workflow coverage parsing so chmod/echo mentions do not count as script invocations

## Evidence
- go test ./internal/gates ./internal/gates/checks
- go test ./cmd/ao
- scripts/regen-all.sh --check
- WORKTREE_DISPOSITION_CI_SKIP=1 go run ./cmd/ao gate check --fast --json => 47 total, 46 pass, 1 warn, 0 fail
- WORKTREE_DISPOSITION_CI_SKIP=1 go run ./cmd/ao gate check --full --json --workflow-coverage => 72 total, 71 pass, 1 warn, 0 fail; coverage 65 workflow scripts / 67 registry scripts / 17 missing / 19 registry-only

This reduces the validate.yml parity gap from 40 missing before PR #839 to 17 missing now. cp-v8m.2 remains open until the remaining artifact/runtime-dependent gates are modeled and validate.yml can delegate blocking authority to ao gate check.