### PR TITLE
feat(skills): explicit Use-when triggers for 8 weak-trigger skills (cp-xvt3)

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -18,7 +18,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `crank` — Execute epics through waves.
 - `design` — Validate product fit before discovery. Use when: framing a problem, checking product/market fit, or pressure-testing user value before writing a discovery packet or any code.
 - `discovery` — Create dense execution packets.
-- `domain` — Canonical vocabulary for human-AI software work.
+- `domain` — Canonical vocabulary for human-AI software work. Use when naming concepts, resolving terminology disputes, or establishing shared domain language across agents and docs.
 - `filesystem-path-rationalization` — Use when rationalizing file or directory layout and updating references without breaking builds. Triggers:
 - `flywheel` — Check knowledge flywheel health.
 - `forge` — Mine transcripts into learnings.
@@ -62,7 +62,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `recover` — Recover session context.
 - `research` — Explore and write findings.
 - `review` — Review diffs for risk, find mocks, scan for bugs, audit codebases. Use when: reviewing a diff/PR for bugs and risk, hunting mocks/stubs/placeholders, or auditing for quality.
-- `session-bootstrap` — Universal init prompt — every agent spawned into an AgentOps repo runs `ao session bootstrap` first.
+- `session-bootstrap` — Universal init prompt; every agent spawned into an AgentOps repo runs ao session bootstrap first. Use when starting or onboarding a fresh agent session in an AgentOps repo, or defining the first-turn init prompt.
 - `ship-loop` — Bot-paired fast-lane cycle for coherent-arc internal PRs (one closable bead or small-epic slice): claim → test → impl → pre-push → push → squash auto-merge → close.
 - `spec-reliability-implementation` — Use when implementing a written spec into a reliable service with acceptance examples and observability. Triggers:
 - `status` — Show AgentOps work status.
@@ -76,13 +76,13 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `dependency-update-safety` — Use when updating dependencies safely with changelog review, small batches, tests, and rollback. Triggers:
 - `deps` — Audit dependency risks and updates.
 - `pr-research` — Research an upstream repo.
-- `scope` — Hard-block edits outside declared frozen directories via PreToolUse hook.
-- `security` — Run repository security scans and composable security analysis.
+- `scope` — Hard-block edits outside declared frozen directories via PreToolUse hook. Use when freezing files or dirs from agent edits, enforcing edit boundaries, or protecting paths during a risky change.
+- `security` — Run repository security scans and composable security analysis. Use when auditing a repo for vulnerabilities, scanning dependencies or secrets, or gating a release on security checks.
 
 ### supporting
 
 - `agent-mail` — Use when coordinating agents with Agent Mail locks, inboxes, threads, and conflict-prevention handoffs.
-- `agent-native` — Make an out-of-session Claude (Managed Agent or Agent SDK loop) AgentOps-native — via skills + the ao CLI + CI, not hooks.
+- `agent-native` — Make an out-of-session Claude (Managed Agent or Agent SDK loop) AgentOps-native via skills plus the ao CLI and CI, not hooks. Use when wiring a Managed Agent or Agent SDK loop to AgentOps, or making an out-of-session agent AgentOps-native.
 - `agy-headless-evidence` — Run AGY headlessly via scheduled ticks or `agy -p`, capturing agentapi JSONL evidence for validation.
 - `autodev` — Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer Evolve and Factory read each tick, not a loop itself.
 - `automation-loop-hardening` — Use when turning repeated manual operations into safer, observable, reusable automation loops. Triggers:
@@ -111,8 +111,8 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `contract-conformance-testing` — Use when building conformance tests from specs, contracts, examples, or compatibility matrices. Triggers:
 - `curate` — Mine transcripts, .agents, bd, and git for skill diffs, bd updates, or rare wiki entries.
 - `dcg` — Handle blocked destructive commands. Use when dcg blocks rm -rf, git reset --hard, DROP DATABASE, kubectl delete, or when configuring agent safety guardrails.
-- `doc` — Generate and validate repo docs (default), READMEs (--mode=readme), and OSS doc packs (--mode=oss).
-- `eval-outcomes` — Grade against Outcomes as a holdout-safe projection of the locked eval substrate — one bar, many runtimes.
+- `doc` — Generate and validate repo docs (default), READMEs (--mode=readme), and OSS doc packs (--mode=oss). Use when writing or refreshing repo documentation, a README, or an open-source doc set.
+- `eval-outcomes` — Grade agent or model output against Outcomes as a holdout-safe projection of the locked eval substrate. Use when scoring output against outcomes, running a holdout-safe eval, or comparing runtimes on one bar.
 - `evolve` — Run autonomous improvement loops.
 - `expertise-to-procedure` — Use when turning tacit expert know-how into a durable skill, playbook, or checklist. Triggers:
 - `external-search-triage` — Use when deciding whether external research is needed and turning cited findings into repo actions. Triggers:
@@ -158,7 +158,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `rust-ub-risk-audit` — Use when auditing Rust UB risks in unsafe, FFI, raw pointers, layout, or concurrency. Triggers:
 - `rust-unsafe-boundary-audit` — Use when auditing Rust unsafe blocks and FFI boundaries, invariants, tests, and tooling. Triggers:
 - `sbh` — Disk-pressure defense for AI coding workloads. Use when: disk full, low space, ballast, cleanup, scan artifacts, emergency, sbh daemon, sbh status.
-- `scaffold` — Create project, component, or boilerplate scaffolds.
+- `scaffold` — Create project, component, or boilerplate scaffolds. Use when starting a new project, module, or component, generating boilerplate, or stamping a repeatable file structure.
 - `scenario` — Manage holdout scenarios.
 - `skill-auditor` — Audit an existing SKILL.md against the unified AgentOps template (15 checks). Triggers: "audit skill", "skill quality review", "is this skill ready".
 - `skill-builder` — Scaffold or absorb new SKILL.md files against the unified AgentOps template. Triggers: "create a skill", "scaffold skill", "absorb external skill", "new skill".

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-08T00:43:36Z",
+  "generated_at": "2026-06-08T02:16:17Z",
   "summary": {
     "skills": 158,
     "hooks": 0,
@@ -2241,7 +2241,7 @@
       "bounded_context": "BC5",
       "hex_role": "supporting",
       "tier": "meta",
-      "purpose": "Make an out-of-session Claude (Managed Agent or Agent SDK loop) AgentOps-native — via skills + the ao CLI + CI, not hooks.",
+      "purpose": "Make an out-of-session Claude (Managed Agent or Agent SDK loop) AgentOps-native via skills plus the ao CLI and CI, not hooks. Use when wiring a Managed Agent or Agent SDK loop to AgentOps, or making an out-of-session agent AgentOps-native.",
       "status": "active",
       "disposition": "keep",
       "consumes": [
@@ -3298,7 +3298,7 @@
       "bounded_context": "BC4",
       "hex_role": "supporting",
       "tier": "product",
-      "purpose": "Generate and validate repo docs (default), READMEs (--mode=readme), and OSS doc packs (--mode=oss).",
+      "purpose": "Generate and validate repo docs (default), READMEs (--mode=readme), and OSS doc packs (--mode=oss). Use when writing or refreshing repo documentation, a README, or an open-source doc set.",
       "status": "active",
       "disposition": "update",
       "consumes": [
@@ -3318,7 +3318,7 @@
       "bounded_context": "BC4",
       "hex_role": "domain",
       "tier": "knowledge",
-      "purpose": "Canonical vocabulary for human-AI software work.",
+      "purpose": "Canonical vocabulary for human-AI software work. Use when naming concepts, resolving terminology disputes, or establishing shared domain language across agents and docs.",
       "status": "active",
       "disposition": "keep",
       "consumes": [],
@@ -3346,7 +3346,7 @@
       "bounded_context": "BC2",
       "hex_role": "supporting",
       "tier": "execution",
-      "purpose": "Grade against Outcomes as a holdout-safe projection of the locked eval substrate — one bar, many runtimes.",
+      "purpose": "Grade agent or model output against Outcomes as a holdout-safe projection of the locked eval substrate. Use when scoring output against outcomes, running a holdout-safe eval, or comparing runtimes on one bar.",
       "status": "active",
       "disposition": "keep",
       "consumes": [
@@ -4920,7 +4920,7 @@
       "bounded_context": "BC4",
       "hex_role": "supporting",
       "tier": "execution",
-      "purpose": "Create project, component, or boilerplate scaffolds.",
+      "purpose": "Create project, component, or boilerplate scaffolds. Use when starting a new project, module, or component, generating boilerplate, or stamping a repeatable file structure.",
       "status": "active",
       "disposition": "update",
       "consumes": [],
@@ -4965,7 +4965,7 @@
       "bounded_context": "BC5",
       "hex_role": "driven-adapter",
       "tier": "execution",
-      "purpose": "Hard-block edits outside declared frozen directories via PreToolUse hook.",
+      "purpose": "Hard-block edits outside declared frozen directories via PreToolUse hook. Use when freezing files or dirs from agent edits, enforcing edit boundaries, or protecting paths during a risky change.",
       "status": "active",
       "disposition": "keep",
       "consumes": [],
@@ -4986,7 +4986,7 @@
       "bounded_context": "BC2",
       "hex_role": "driven-adapter",
       "tier": "product",
-      "purpose": "Run repository security scans and composable security analysis.",
+      "purpose": "Run repository security scans and composable security analysis. Use when auditing a repo for vulnerabilities, scanning dependencies or secrets, or gating a release on security checks.",
       "status": "active",
       "disposition": "keep",
       "consumes": [
@@ -5006,7 +5006,7 @@
       "bounded_context": "BC5",
       "hex_role": "driving-adapter",
       "tier": "session",
-      "purpose": "Universal init prompt — every agent spawned into an AgentOps repo runs `ao session bootstrap` first.",
+      "purpose": "Universal init prompt; every agent spawned into an AgentOps repo runs ao session bootstrap first. Use when starting or onboarding a fresh agent session in an AgentOps repo, or defining the first-turn init prompt.",
       "status": "active",
       "disposition": "keep",
       "consumes": [

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1162,7 +1162,7 @@
     {
       "name": "agent-native",
       "source_skill": "skills/agent-native",
-      "source_hash": "d02f74b1520efe96f2e28aea31c3a73596dd0738aee0f65845f8d53ad4b172e4",
+      "source_hash": "192f4971885e1b01f44cfd29fbbb3f9f6a6e75866407225fb732003c90731f8d",
       "generated_hash": "4278d76d9c0b6093157ae0f52b306c9081a0f12d35a66c34f5e56e337e876e9c"
     },
     {
@@ -1270,19 +1270,19 @@
     {
       "name": "doc",
       "source_skill": "skills/doc",
-      "source_hash": "c202b43aed74b998825974f77afcff4abd9ff99d82ec38f3b198dd59c1fb2a9c",
+      "source_hash": "b1293c5a52a1b7e6487ca40fa0847e1fd1cacf65dc7fa7f3e658831333be88a0",
       "generated_hash": "48cb7813be9336eb918943246af792b25766b2ea870c9163a7cde5dae187411f"
     },
     {
       "name": "domain",
       "source_skill": "skills/domain",
-      "source_hash": "3c1f6579e7af129d058d5c543b9bc07baa9e6ff7fb5a8b6cdb06aa3f52d9851b",
+      "source_hash": "6da0f5fbce16cebc05a5855b53f2f5bd5deebd70b986ac7afe9bc46822fba901",
       "generated_hash": "0c54e9c18349b56f507d891d250b1c78d64c644a0b18d26afb5ff1dc3db57273"
     },
     {
       "name": "eval-outcomes",
       "source_skill": "skills/eval-outcomes",
-      "source_hash": "950b886d88badfedc3b044f4fb3ec947a659bce698b27ea13d0fbc442f524645",
+      "source_hash": "4e9f5e6bfefd0b196ce88ac439db26666da9c249335d140423f815d539b82dae",
       "generated_hash": "6f6ed5eba59ea419db5214b7a5dee0641723eb7c2a6699386b7427e90d2442fc"
     },
     {
@@ -1456,7 +1456,7 @@
     {
       "name": "scaffold",
       "source_skill": "skills/scaffold",
-      "source_hash": "21b09c7743d763ff688ff80620e04f525775f986f03af7a5170bf44743ca919f",
+      "source_hash": "09a8af64645d11dc5c1e49fa4b54558248d29630a5dac9d7d25c99da8b0a3590",
       "generated_hash": "26ec68f6c72a047d4889d9b3f50f2eeef4ed27ead9a440a09c4a1d1f2bc0a9dc"
     },
     {
@@ -1468,19 +1468,19 @@
     {
       "name": "scope",
       "source_skill": "skills/scope",
-      "source_hash": "9e932a2a1096ae733eec15d802ef72152e265328c8ee6cab0310bbe4ad94a43a",
+      "source_hash": "c71a44e4f7576900ce26383984d3e68eae5d7b29b9d07bc334858d062aa85768",
       "generated_hash": "47a0e3cbeff64e7fd40f4c76a756435443b1644859a00ab85e21318539f58734"
     },
     {
       "name": "security",
       "source_skill": "skills/security",
-      "source_hash": "c0e4e5ab8af655ec0ef5257414ab2edcfb54a3f9b00cfe857cc070aceddda9d9",
+      "source_hash": "5584c104eb15c2b4bf6322f16ef45407a02e53d594ada05fa9687bf9b48f75d4",
       "generated_hash": "0ba3d08ef58f6dc6e72d1d5b2290b2ffe400b8fde8b1289e0b2a54f0eeb4bf67"
     },
     {
       "name": "session-bootstrap",
       "source_skill": "skills/session-bootstrap",
-      "source_hash": "26f06a4a9b29f62f0e92abd5aaaf32fdec2d68b256dc75ce42d3653a4c7bafb3",
+      "source_hash": "4687b43c39e3434ae1a0bb772248d867fb86070be855ef561cc3cd9e538cf51f",
       "generated_hash": "5eeb89272ce57b9e8adc01bb06ecc550fc0d6574bb0980a922508df3ed251224"
     },
     {

--- a/skills-codex/agent-native/.agentops-generated.json
+++ b/skills-codex/agent-native/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/agent-native",
   "layout": "modular",
-  "source_hash": "d02f74b1520efe96f2e28aea31c3a73596dd0738aee0f65845f8d53ad4b172e4",
+  "source_hash": "192f4971885e1b01f44cfd29fbbb3f9f6a6e75866407225fb732003c90731f8d",
   "generated_hash": "4278d76d9c0b6093157ae0f52b306c9081a0f12d35a66c34f5e56e337e876e9c"
 }

--- a/skills-codex/doc/.agentops-generated.json
+++ b/skills-codex/doc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/doc",
   "layout": "modular",
-  "source_hash": "c202b43aed74b998825974f77afcff4abd9ff99d82ec38f3b198dd59c1fb2a9c",
+  "source_hash": "b1293c5a52a1b7e6487ca40fa0847e1fd1cacf65dc7fa7f3e658831333be88a0",
   "generated_hash": "48cb7813be9336eb918943246af792b25766b2ea870c9163a7cde5dae187411f"
 }

--- a/skills-codex/domain/.agentops-generated.json
+++ b/skills-codex/domain/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/domain",
   "layout": "modular",
-  "source_hash": "3c1f6579e7af129d058d5c543b9bc07baa9e6ff7fb5a8b6cdb06aa3f52d9851b",
+  "source_hash": "6da0f5fbce16cebc05a5855b53f2f5bd5deebd70b986ac7afe9bc46822fba901",
   "generated_hash": "0c54e9c18349b56f507d891d250b1c78d64c644a0b18d26afb5ff1dc3db57273"
 }

--- a/skills-codex/eval-outcomes/.agentops-generated.json
+++ b/skills-codex/eval-outcomes/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/eval-outcomes",
   "layout": "modular",
-  "source_hash": "950b886d88badfedc3b044f4fb3ec947a659bce698b27ea13d0fbc442f524645",
+  "source_hash": "4e9f5e6bfefd0b196ce88ac439db26666da9c249335d140423f815d539b82dae",
   "generated_hash": "6f6ed5eba59ea419db5214b7a5dee0641723eb7c2a6699386b7427e90d2442fc"
 }

--- a/skills-codex/scaffold/.agentops-generated.json
+++ b/skills-codex/scaffold/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/scaffold",
   "layout": "modular",
-  "source_hash": "21b09c7743d763ff688ff80620e04f525775f986f03af7a5170bf44743ca919f",
+  "source_hash": "09a8af64645d11dc5c1e49fa4b54558248d29630a5dac9d7d25c99da8b0a3590",
   "generated_hash": "26ec68f6c72a047d4889d9b3f50f2eeef4ed27ead9a440a09c4a1d1f2bc0a9dc"
 }

--- a/skills-codex/scope/.agentops-generated.json
+++ b/skills-codex/scope/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual",
   "source_skill": "skills/scope",
   "layout": "modular",
-  "source_hash": "9e932a2a1096ae733eec15d802ef72152e265328c8ee6cab0310bbe4ad94a43a",
+  "source_hash": "c71a44e4f7576900ce26383984d3e68eae5d7b29b9d07bc334858d062aa85768",
   "generated_hash": "47a0e3cbeff64e7fd40f4c76a756435443b1644859a00ab85e21318539f58734"
 }

--- a/skills-codex/security/.agentops-generated.json
+++ b/skills-codex/security/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/security",
   "layout": "modular",
-  "source_hash": "c0e4e5ab8af655ec0ef5257414ab2edcfb54a3f9b00cfe857cc070aceddda9d9",
+  "source_hash": "5584c104eb15c2b4bf6322f16ef45407a02e53d594ada05fa9687bf9b48f75d4",
   "generated_hash": "0ba3d08ef58f6dc6e72d1d5b2290b2ffe400b8fde8b1289e0b2a54f0eeb4bf67"
 }

--- a/skills-codex/session-bootstrap/.agentops-generated.json
+++ b/skills-codex/session-bootstrap/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/session-bootstrap",
   "layout": "modular",
-  "source_hash": "26f06a4a9b29f62f0e92abd5aaaf32fdec2d68b256dc75ce42d3653a4c7bafb3",
+  "source_hash": "4687b43c39e3434ae1a0bb772248d867fb86070be855ef561cc3cd9e538cf51f",
   "generated_hash": "5eeb89272ce57b9e8adc01bb06ecc550fc0d6574bb0980a922508df3ed251224"
 }

--- a/skills/agent-native/SKILL.md
+++ b/skills/agent-native/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-native
-description: Make an out-of-session Claude (Managed Agent or Agent SDK loop) AgentOps-native — via skills + the ao CLI + CI, not hooks.
+description: Make an out-of-session Claude (Managed Agent or Agent SDK loop) AgentOps-native via skills plus the ao CLI and CI, not hooks. Use when wiring a Managed Agent or Agent SDK loop to AgentOps, or making an out-of-session agent AgentOps-native.
 skill_api_version: 1
 practices:
 - continuous-delivery

--- a/skills/doc/SKILL.md
+++ b/skills/doc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doc
-description: Generate and validate repo docs (default), READMEs (--mode=readme), and OSS doc packs (--mode=oss).
+description: Generate and validate repo docs (default), READMEs (--mode=readme), and OSS doc packs (--mode=oss). Use when writing or refreshing repo documentation, a README, or an open-source doc set.
 practices:
 - wiki-knowledge-surface
 - code-complete

--- a/skills/domain/SKILL.md
+++ b/skills/domain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: domain
-description: Canonical vocabulary for human-AI software work.
+description: Canonical vocabulary for human-AI software work. Use when naming concepts, resolving terminology disputes, or establishing shared domain language across agents and docs.
 practices:
 - ddd-bounded-context
 - wiki-knowledge-surface

--- a/skills/eval-outcomes/SKILL.md
+++ b/skills/eval-outcomes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eval-outcomes
-description: Grade against Outcomes as a holdout-safe projection of the locked eval substrate — one bar, many runtimes.
+description: Grade agent or model output against Outcomes as a holdout-safe projection of the locked eval substrate. Use when scoring output against outcomes, running a holdout-safe eval, or comparing runtimes on one bar.
 skill_api_version: 1
 practices:
 - continuous-delivery

--- a/skills/scaffold/SKILL.md
+++ b/skills/scaffold/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scaffold
-description: Create project, component, or boilerplate scaffolds.
+description: Create project, component, or boilerplate scaffolds. Use when starting a new project, module, or component, generating boilerplate, or stamping a repeatable file structure.
 practices:
 - pragmatic-programmer
 - design-patterns

--- a/skills/scope/SKILL.md
+++ b/skills/scope/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scope
-description: Hard-block edits outside declared frozen directories via PreToolUse hook.
+description: Hard-block edits outside declared frozen directories via PreToolUse hook. Use when freezing files or dirs from agent edits, enforcing edit boundaries, or protecting paths during a risky change.
 practices:
 - ddd-bounded-context
 - design-by-contract

--- a/skills/security/SKILL.md
+++ b/skills/security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security
-description: Run repository security scans and composable security analysis.
+description: Run repository security scans and composable security analysis. Use when auditing a repo for vulnerabilities, scanning dependencies or secrets, or gating a release on security checks.
 practices:
 - supply-chain-integrity
 - design-by-contract

--- a/skills/session-bootstrap/SKILL.md
+++ b/skills/session-bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-bootstrap
-description: Universal init prompt — every agent spawned into an AgentOps repo runs `ao session bootstrap` first.
+description: Universal init prompt; every agent spawned into an AgentOps repo runs ao session bootstrap first. Use when starting or onboarding a fresh agent session in an AgentOps repo, or defining the first-turn init prompt.
 skill_api_version: 1
 metadata:
   tier: session


### PR DESCRIPTION
cp-xvt3 batch 1 (from the cp-yxt trigger-quality audit). Adds an explicit `Use when …` clause to 8 auto-selected skills whose terse descriptions risked silent misfire: domain, scope, scaffold, security, doc, eval-outcomes, agent-native, session-bootstrap. Derived surfaces regenerated (codex hashes, registry/SKU catalog, context-map). `scripts/regen-all.sh --check` = ALL GATES GREEN; trigger-audit no-trigger count 20→12. Isolated worktree off origin/main; no codex (rename/v8m) or athena (Gap/kernel) lane files touched.