### PR TITLE
docs(skills): rename using-ntm to using-atm

### DIFF
--- a/cli/embedded/skills/using-agentops/SKILL.md
+++ b/cli/embedded/skills/using-agentops/SKILL.md
@@ -145,7 +145,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/release` | Pre-flight, changelog, version bumps, tag |
 | `/crank` | Autonomous epic loop (uses swarm for each wave) |
 | `/swarm` | Fresh-context parallel execution (Ralph pattern) |
-| `/using-ntm` | Run AgentOps loops out of session on an NTM tmux swarm (the NTM leg of the substrate) |
+| `/using-atm` | Run AgentOps loops out of session on an ATM tmux swarm (the ATM leg of the substrate) |
 | `evolve` | Goal-driven fitness-scored improvement loop |
 | `/burndown` | Bounded epic-completion loop — drive a finite target to all-merged, then stop |
 | `/eval-outcomes` | Grade via Outcomes as a holdout-safe projection of the locked eval substrate — one bar, many runtimes |
@@ -171,7 +171,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/scenario` | Author and manage holdout scenarios for behavioral validation |
 | `/skill-auditor` | Two-pass audit of an existing SKILL.md against the unified template (15 checks) |
 | `/skill-builder` | Scaffold or absorb new SKILL.md files against the unified template |
-| `/automation-shape-routing` | Front door for building agent automation — decide the SHAPE (Workflow vs NTM swarm vs plain skill), then hand off to the right builder |
+| `/automation-shape-routing` | Front door for building agent automation — decide the SHAPE (Workflow vs ATM swarm vs plain skill), then hand off to the right builder |
 | `/workflow-builder` | Scaffold a new Claude Workflow script (`.claude/workflows/*.js`) — deterministic multi-agent orchestration |
 | `/agent-native` | Make out-of-session agents AgentOps-native via skills + ao CLI + CI, not hooks |
 
@@ -212,7 +212,7 @@ AgentOps has several runtime modes. Do not assume hook automation exists everywh
 
 | Mode | When it applies | Start path | Closeout path | Guarantees |
 |------|-----------------|------------|---------------|------------|
-| `substrate` (out-of-session) | A swappable orchestration substrate available out-of-session: an NTM tmux swarm, MCP (`ao mcp serve`), or managed-agents (`ao agent`) | The operator or a lead agent runs `bd ready` and dispatches a whole loop per bead — an agent that runs the `rpi` skill; cron / managed triggers run maintenance | The substrate owns the merge gate (CI-green is the signal) and triggers the knowledge-flywheel feedback | The substrate orchestrates *whole* `rpi`/`evolve` loops (each an agent running the skill) — it never sees the loop's insides; the seam is substrate → agent-running-the-skill. There is no in-CLI `runtime=gc` executor. See [agent-native](../agent-native/SKILL.md) and [docs/3.0.md](https://github.com/boshu2/agentops/blob/main/docs/3.0.md). |
+| `substrate` (out-of-session) | A swappable orchestration substrate available out-of-session: an ATM tmux swarm, MCP (`ao mcp serve`), or managed-agents (`ao agent`) | The operator or a lead agent runs `bd ready` and dispatches a whole loop per bead — an agent that runs the `rpi` skill; cron / managed triggers run maintenance | The substrate owns the merge gate (CI-green is the signal) and triggers the knowledge-flywheel feedback | The substrate orchestrates *whole* `rpi`/`evolve` loops (each an agent running the skill) — it never sees the loop's insides; the seam is substrate → agent-running-the-skill. There is no in-CLI `runtime=gc` executor. See [agent-native](../agent-native/SKILL.md) and [docs/3.0.md](https://github.com/boshu2/agentops/blob/main/docs/3.0.md). |
 | `hook-capable` | Claude/OpenCode with lifecycle hooks installed (no gc) | Runtime hook or `ao inject` / `ao lookup` | Runtime hook or `ao forge transcript` + `ao flywheel close-loop` | Automatic startup/context injection and session-end maintenance when hooks are installed |
 | `codex-native-hooks` | Codex CLI v0.115.0+ with native hook support (March 2026) | Runtime hooks (same as hook-capable) | Runtime hooks (same as hook-capable) | Native lifecycle hooks — same guarantees as hook-capable mode |
 | `codex-hookless-fallback` | Codex Desktop / Codex CLI pre-v0.115.0 without hook surfaces | `ao codex start` | `ao codex stop` | Explicit startup context, citation tracking, transcript fallback, and close-loop metrics without hooks |

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -89,7 +89,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `agy-sidecar-scheduled-tick` — Run a recurring AgentOps loop tick on AGY via an Antigravity sidecar (schedule builtin + agentapi), capturing agentapi runtime evidence a validator can read back. Triggers: agy, sidecar, schedule, agentapi, AGY scheduled tick, Antigravity sidecar, recurring AGY loop.
 - `autodev` — Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer Evolve and Factory read each tick, not a loop itself.
 - `automation-loop-hardening` — Use when turning repeated manual operations into safer, observable, reusable automation loops. Triggers:
-- `automation-shape-routing` — Front door for agent automation — decide the SHAPE (Workflow vs NTM vs skill), then hand off. Triggers: "build automation", "convert skills to workflows", "which shape".
+- `automation-shape-routing` — Front door for agent automation — decide the SHAPE (Workflow vs ATM vs skill), then hand off. Triggers: "build automation", "convert skills to workflows", "which shape".
 - `bead-completion-audit` — Use when auditing closed beads for real shipped evidence, acceptance proof, and truthful closeout. Triggers:
 - `bead-tracker-migration` — Use when migrating an issue tracker workspace from bd to br with loss-free verification. Triggers:
 - `beads-br` — Local-first issue tracker (beads_rust) for AI agents. Use when tracking tasks, managing dependencies, finding ready work, or syncing issues to git via JSONL.
@@ -174,7 +174,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `test` — Generate tests and coverage plans.
 - `trace` — Trace decisions through artifacts.
 - `ubs` — Use when reviewing code with UBS for bugs, security issues, AI-generated quality, or pre-commit checks.
-- `using-ntm` — Use NTM as the out-of-session substrate: spawn Claude/Codex panes running /rpi and /evolve over a bead queue, then tend the swarm to convergence.
+- `using-atm` — Use ATM as the out-of-session substrate: spawn Claude/Codex panes running /rpi and /evolve over a bead queue, then tend the swarm to convergence.
 - `vibing-with-ntm` — Use when tending NTM agent swarms, unsticking panes, handling rate limits, or coordinating convergence.
 - `workflow-builder` — Scaffold a new Claude Workflow script — deterministic multi-agent orchestration. Triggers: "build a workflow", "create a workflow", "scaffold workflow", "author a workflow".
 
@@ -287,7 +287,7 @@ graph LR
   spec-reliability-implementation -- "customer-of" --> validate
   swarm -- "customer-of" --> crank
   trace -- "shared-kernel" --> curate
-  using-ntm -- "customer-of" --> swarm
+  using-atm -- "customer-of" --> swarm
   vibe -- "shared-kernel" --> standards
   workflow-builder -- "customer-of" --> automation-shape-routing
   workflow-builder -- "shared-kernel" --> operating-loop-workflow
@@ -635,7 +635,7 @@ graph LR
 | `test` | produces | result.json |
 | `trace` | produces | result.json |
 | `using-agentops` | produces | documentation |
-| `using-ntm` | produces | documentation |
+| `using-atm` | produces | documentation |
 | `validate` | produces | result.json |
 | `vibe` | consumes | standards |
 | `vibe` | produces | result.json |

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -285,6 +285,7 @@ graph LR
   skill-builder -- "customer-of" --> automation-shape-routing
   skill-builder -- "supplier-to" --> skill-auditor
   spec-reliability-implementation -- "customer-of" --> validate
+  storage-watchdog-ops -- "partnership" --> system-performance-remediation
   swarm -- "customer-of" --> crank
   trace -- "shared-kernel" --> curate
   using-atm -- "customer-of" --> swarm
@@ -621,9 +622,9 @@ graph LR
 | `standards` | produces | stdout |
 | `status` | consumes | bd |
 | `status` | produces | stdout |
-| `storage-watchdog-ops` | consumes | daemon-config |
-| `storage-watchdog-ops` | consumes | host-state |
-| `storage-watchdog-ops` | consumes | incident-symptom |
+| `storage-watchdog-ops` | consumes | error-reports |
+| `storage-watchdog-ops` | consumes | runtime-configuration |
+| `storage-watchdog-ops` | consumes | runtime-metrics |
 | `storage-watchdog-ops` | produces | escalation-note |
 | `storage-watchdog-ops` | produces | remediation-action |
 | `storage-watchdog-ops` | produces | triage-finding |

--- a/docs/contracts/skill-dispositions.yaml
+++ b/docs/contracts/skill-dispositions.yaml
@@ -357,11 +357,11 @@ dispositions:
     hexagonal_role: supporting
     disposition:    keep
     rationale:      "Hookless reframe: makes out-of-session agents (Managed/SDK/sandbox) AgentOps-native via skills + ao CLI + CI; extends standards+converter, never a hook revival"
-  - skill:          using-ntm
+  - skill:          using-atm
     domain:         "BC4 Factory"
     hexagonal_role: supporting
     disposition:    keep
-    rationale:      "Shippable AgentOps-scoped guide for the NTM leg of the out-of-session substrate (NTM+MCP+managed-agents): spawn agent panes that run the /rpi and /evolve skills over a bead queue. Replaces the dangling external ntm/vibing-with-ntm pointers in automation-shape-routing with an owned, skills-as-runtime skill."
+    rationale:      "Shippable AgentOps-scoped guide for the ATM leg of the out-of-session substrate (ATM+Agent Mail+managed-agents): spawn agent panes that run the /rpi and /evolve skills over a bead queue. Replaces the dangling external ntm/vibing-with-ntm pointers in automation-shape-routing with an owned, skills-as-runtime skill."
 
   - skill:          acfs
     domain:         "BC5 Runtime"

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -214,7 +214,7 @@ Disposition meanings:
 | `trace` | BC1 Corpus | supporting | update | Decision trace builder; align to provenance and cycle trace. |
 | `ubs` | BC5 Runtime | supporting | keep | New factory-built skill from the four-vendor corpus expansion; keep as clean-room AgentOps-owned capability.. |
 | `using-agentops` | BC4 Factory | generic | update | Operator education; align to 3.0 first-value path. |
-| `using-ntm` | BC4 Factory | supporting | keep | Shippable AgentOps-scoped guide for the NTM leg of the out-of-session substrate (NTM+MCP+managed-agents): spawn agent panes that run the /rpi and /evolve skills over a bead queue. Replaces the dangling external ntm/vibing-with-ntm pointers in automation-shape-routing with an owned, skills-as-runtime skill.. |
+| `using-atm` | BC4 Factory | supporting | keep | Shippable AgentOps-scoped guide for the ATM leg of the out-of-session substrate (ATM+Agent Mail+managed-agents): spawn agent panes that run the /rpi and /evolve skills over a bead queue. Replaces the dangling external ntm/vibing-with-ntm pointers in automation-shape-routing with an owned, skills-as-runtime skill.. |
 | `validate` | BC2 Validation | driving-adapter | keep | Designed-future canonical unified validator (m6v5.D Phase 1, epic soc-cp7pv); not redundant cruft — epic GO/REVERT is a separate decision (resolved KEEP 2026-05-24). |
 | `vibe` | BC2 Validation | domain | update | Code-readiness validator; add self-test and tighten result contract. |
 | `vibing-with-ntm` | BC4 Factory | supporting | keep | New factory-built skill from the four-vendor corpus expansion; keep as clean-room AgentOps-owned capability.. |

--- a/registry.json
+++ b/registry.json
@@ -1,11 +1,8 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-08T02:16:17Z",
-  "generated_at": "2026-06-08T01:35:05Z",
-  "generated_at": "2026-06-08T01:20:40Z",
+  "generated_at": "2026-06-08T02:50:25Z",
   "summary": {
     "skills": 162,
-    "skills": 159,
     "hooks": 0,
     "knowledge_stores": 5,
     "job_types": 0,
@@ -1300,14 +1297,6 @@
         "tier": "unknown",
         "path": "skills/operating-loop-skill/",
         "has_skill_md": true,
-        "has_references": false,
-        "reference_count": 0
-      },
-      {
-        "name": "security-suite",
-        "tier": "unknown",
-        "path": "skills/security-suite/",
-        "has_skill_md": false,
         "has_references": false,
         "reference_count": 0
       },
@@ -5331,9 +5320,9 @@
       "status": "active",
       "disposition": "keep",
       "consumes": [
-        "incident-symptom",
-        "host-state",
-        "daemon-config"
+        "error-reports",
+        "runtime-metrics",
+        "runtime-configuration"
       ],
       "produces": [
         "triage-finding",

--- a/registry.json
+++ b/registry.json
@@ -2,8 +2,10 @@
   "schema_version": 2,
   "generated_at": "2026-06-08T02:16:17Z",
   "generated_at": "2026-06-08T01:35:05Z",
+  "generated_at": "2026-06-08T01:20:40Z",
   "summary": {
     "skills": 162,
+    "skills": 159,
     "hooks": 0,
     "knowledge_stores": 5,
     "job_types": 0,
@@ -662,9 +664,9 @@
         "reference_count": 3
       },
       {
-        "name": "using-ntm",
+        "name": "using-atm",
         "tier": "execution",
-        "path": "skills/using-ntm/",
+        "path": "skills/using-atm/",
         "has_skill_md": true,
         "has_references": false,
         "reference_count": 0
@@ -1302,6 +1304,14 @@
         "reference_count": 0
       },
       {
+        "name": "security-suite",
+        "tier": "unknown",
+        "path": "skills/security-suite/",
+        "has_skill_md": false,
+        "has_references": false,
+        "reference_count": 0
+      },
+      {
         "name": "system-tuning",
         "tier": "utility",
         "path": "skills/system-tuning/",
@@ -1430,7 +1440,7 @@
           "domain",
           "shared",
           "using-agentops",
-          "using-ntm"
+          "using-atm"
         ]
       },
       {
@@ -2485,7 +2495,7 @@
       "bounded_context": "BC4",
       "hex_role": "supporting",
       "tier": "meta",
-      "purpose": "Front door for agent automation — decide the SHAPE (Workflow vs NTM vs skill), then hand off. Triggers: \"build automation\", \"convert skills to workflows\", \"which shape\".",
+      "purpose": "Front door for agent automation — decide the SHAPE (Workflow vs ATM vs skill), then hand off. Triggers: \"build automation\", \"convert skills to workflows\", \"which shape\".",
       "status": "active",
       "disposition": "keep",
       "consumes": [],
@@ -5477,13 +5487,13 @@
       "references": 0
     },
     {
-      "sku": "skill:using-ntm",
-      "name": "using-ntm",
+      "sku": "skill:using-atm",
+      "name": "using-atm",
       "type": "skill",
       "bounded_context": "BC4",
       "hex_role": "supporting",
       "tier": "execution",
-      "purpose": "Use NTM as the out-of-session substrate: spawn Claude/Codex panes running /rpi and /evolve over a bead queue, then tend the swarm to convergence.",
+      "purpose": "Use ATM as the out-of-session substrate: spawn Claude/Codex panes running /rpi and /evolve over a bead queue, then tend the swarm to convergence.",
       "status": "active",
       "disposition": "keep",
       "consumes": [],
@@ -5492,10 +5502,9 @@
       ],
       "drives_commands": [
         "ao agent",
-        "ao agent bundle",
-        "ao mcp serve"
+        "ao agent bundle"
       ],
-      "path": "skills/using-ntm/",
+      "path": "skills/using-atm/",
       "references": 0
     },
     {
@@ -5637,7 +5646,7 @@
         "domain",
         "shared",
         "using-agentops",
-        "using-ntm"
+        "using-atm"
       ],
       "flags": [
         "--config",

--- a/scripts/check-wiring-closure.sh
+++ b/scripts/check-wiring-closure.sh
@@ -20,6 +20,7 @@ done
 if [ -f skills/SKILL-TIERS.md ]; then
   for skill_dir in skills/*/; do
     [ -d "$skill_dir" ] || continue
+    [ -f "${skill_dir}/SKILL.md" ] || continue
     skill_name=$(basename "$skill_dir")
     # Leading-underscore dirs (e.g. skills/_fixtures/) are non-skill scaffolding
     # (planted test fixtures); they are intentionally absent from SKILL-TIERS.md.

--- a/scripts/skill-flow-standalone.txt
+++ b/scripts/skill-flow-standalone.txt
@@ -74,7 +74,6 @@ rust-unsafe-boundary-audit       # standalone external-boundary or library/analy
 sbh                              # standalone external-boundary or library/analyzer skill; no peer skill edge by design
 ssh                              # standalone external-boundary or library/analyzer skill; no peer skill edge by design
 stash-hygiene-sweep              # standalone external-boundary or library/analyzer skill; no peer skill edge by design
-system-performance-remediation   # standalone external-boundary or library/analyzer skill; no peer skill edge by design
 ubs                              # standalone external-boundary or library/analyzer skill; no peer skill edge by design
 vibing-with-ntm                  # standalone external-boundary or library/analyzer skill; no peer skill edge by design
 worktree-branch-rationalization  # standalone external-boundary or library/analyzer skill; no peer skill edge by design

--- a/skills-codex-overrides/catalog.json
+++ b/skills-codex-overrides/catalog.json
@@ -612,10 +612,10 @@
       "reason": "TODO: confirm parity_only or flip to bespoke (+scaffold override dir) for bd-first-memory-migration"
     },
     {
-      "name": "using-ntm",
+      "name": "using-atm",
       "treatment": "parity_only",
       "wave": "catalog-parity",
-      "reason": "NTM substrate guidance is documentation-led and portable across runtimes; Codex parity is sufficient"
+      "reason": "ATM substrate guidance is documentation-led and portable across runtimes; Codex parity is sufficient"
     },
     {
       "name": "acfs",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -2476,7 +2476,7 @@
     {
       "name": "storage-watchdog-ops",
       "source_skill": "skills/storage-watchdog-ops",
-      "source_hash": "5f9e845fc3b454aa2939ca78af3f1395bc22055170e1834b96ddbbe583a08a8d",
+      "source_hash": "66de43babcd83537a640db65c6228ed3c7ab333cfcbf3f808d5841b44a548732",
       "generated_hash": "55c3fdc7869c538124fd94e831178df9d1286ee606d8607d84afd520a01b195d"
     },
     {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -617,12 +617,6 @@
         "reason": "TODO: confirm parity_only or flip to bespoke (+scaffold override dir) for bd-first-memory-migration"
       },
       {
-        "name": "using-ntm",
-        "treatment": "parity_only",
-        "wave": "catalog-parity",
-        "reason": "NTM substrate guidance is documentation-led and portable across runtimes; Codex parity is sufficient"
-      },
-      {
         "name": "acfs",
         "treatment": "parity_only",
         "wave": "catalog-parity",
@@ -1184,6 +1178,420 @@
   },
   "skills": [
     {
+      "name": "agent-native",
+      "source_skill": "skills/agent-native",
+      "source_hash": "d54880f144d966d14cd77baef2ac2a61941c925af764fb3e403486cf51047bc5",
+      "generated_hash": "1bbe19f6087257e2d92b30d437a63a8b34e116379a2cf99184aad0d618824b9e"
+    },
+    {
+      "name": "autodev",
+      "source_skill": "skills/autodev",
+      "source_hash": "028e8ab0e5b7682cd53de50b8d8e9dd931aa7cb6484ef842938fe546808feb2d",
+      "generated_hash": "4868b97e436c7650ae194e5eeefe11ae867c62aeb603d55de5c846d8a9975200"
+    },
+    {
+      "name": "automation-shape-routing",
+      "source_skill": "skills/automation-shape-routing",
+      "source_hash": "d278d50fb27e1137b61251bb7c889edf5988be87231acdd354acced2688dab25",
+      "generated_hash": "2afa14e81397373ee5d7c76c7a88287fa853257f33040a0a9a47597d7f4c3f69"
+    },
+    {
+      "name": "bd-first-memory-migration",
+      "source_skill": "skills/bd-first-memory-migration",
+      "source_hash": "2506c37874b05c26af7e824ce9dd2ff340c5c48991e1e9849429380790aebb7d",
+      "generated_hash": "b583d1d895925bbea3021b9165d945824788e1d59cc6f66629aae95c8e978cf1"
+    },
+    {
+      "name": "beads",
+      "source_skill": "skills/beads",
+      "source_hash": "86bfef3ef7ff64509d6321681275bcb0c9c437f208d2fd4226d05ed6f60dacde",
+      "generated_hash": "0960ad70dd5868ac65b387f98caab73f7b001449391d9d24a99b4cb10a8cb39a"
+    },
+    {
+      "name": "bootstrap",
+      "source_skill": "skills/bootstrap",
+      "source_hash": "c490abfe896c2f3dc2eb61dbb00214d7b652605a80e31624f0d4d2b19b546f57",
+      "generated_hash": "072c8d6e5cd45713b470301463dbf8d6356e3bb7d11cdf85a63cd8dbef1a4d03"
+    },
+    {
+      "name": "brainstorm",
+      "source_skill": "skills/brainstorm",
+      "source_hash": "19af5b72dc69e8dfefb83e19983dbe863ba999166e917fa852addf1ca5a293d6",
+      "generated_hash": "20b38ec0f390e235d85b46878eca6316b62e506f6d7bd6839eb0278d81a61583"
+    },
+    {
+      "name": "bug-hunt",
+      "source_skill": "skills/bug-hunt",
+      "source_hash": "66842b1a5726a435c61576b3f97736b8ed3941c8359fa85387b23af218618921",
+      "generated_hash": "99ecb0e0f7380c8b97347b9456a41a0de9d1b945d31b54cd5e0bb49bd5bd5f07"
+    },
+    {
+      "name": "burndown",
+      "source_skill": "skills/burndown",
+      "source_hash": "917f7277558d79c72c428fa6692d86d34d808a120d061341f5a393da063d4068",
+      "generated_hash": "408431e51b7b1e89e25aff9ec5dc525fcad40a368bdbb6d150554ccfcaeac5ad"
+    },
+    {
+      "name": "compile",
+      "source_skill": "skills/compile",
+      "source_hash": "043ee00a9c938d3bb57ee6077fff9fbdd4407b21800ea2ad1f7e701e46ae02c6",
+      "generated_hash": "681d3c13b9738c200c9615bb84120bdaf8517a2567de9f00818ac180031e054a"
+    },
+    {
+      "name": "complexity",
+      "source_skill": "skills/complexity",
+      "source_hash": "f5840d49ae8da97b069da5eb03f6e5b7379a212ac202c1a138306bcb8dd5e30a",
+      "generated_hash": "b20cde774e427d53998df6d595295d04d9dab7885210c9849bc607239e90851e"
+    },
+    {
+      "name": "converter",
+      "source_skill": "skills/converter",
+      "source_hash": "188685d5bc22609bdd3aeb0828a0d289465afdba90a035ccacb9c124bc3b6e71",
+      "generated_hash": "5bdeba2f0362189706829ca6ea22b00d777bb15f0af13be5661de9f637d6bba5"
+    },
+    {
+      "name": "council",
+      "source_skill": "skills/council",
+      "source_hash": "325ef84388d48f1ddbb115a89f09f75d354541889af7dc297a728dfbcf0d150f",
+      "generated_hash": "811ab60278e0f8cfc6aee26fb8cfa6196212813a30d76f587f83c095fcbf4359"
+    },
+    {
+      "name": "crank",
+      "source_skill": "skills/crank",
+      "source_hash": "80cbc1a46b0ef5174dc8244cb7c0b1ffb723ebb34979727d6249cc1f7ef19b56",
+      "generated_hash": "20ab5f915ad0433494daf5fc9b79eba11d608646f40dfae8446cd04af251f111"
+    },
+    {
+      "name": "curate",
+      "source_skill": "skills/curate",
+      "source_hash": "b10e303bf29aa9735e0ba19922ed674b9a49cf7d9d2fca22befd0dc88fd19ce7",
+      "generated_hash": "73e2221cb93078e9037b79d3f77c855c2f96214489d9fda86d252a4874ba8396"
+    },
+    {
+      "name": "deps",
+      "source_skill": "skills/deps",
+      "source_hash": "27ae05545f79c1422bfed81f60f05e60499b6ea1d36ca7bce3f141594fe0f0d0",
+      "generated_hash": "23d77f9f71b98dd6335a01bb5ac210ac04196718926bd2ae85347074a705cfaf"
+    },
+    {
+      "name": "design",
+      "source_skill": "skills/design",
+      "source_hash": "5f860efc5252389196902d118931f7c02c29b1201960126068a3192d7db4c19c",
+      "generated_hash": "9e9012aafbf4389c00d960be273ccecf87d4cfde2e83deb985181c7d04c0d1c9"
+    },
+    {
+      "name": "discovery",
+      "source_skill": "skills/discovery",
+      "source_hash": "05abf39f05f897a8fcf0654b255a72c6032960232a8d5a334a1767f0d94ace38",
+      "generated_hash": "44198d1a1de18d7425872be43ba8add4a62009b2bd8351a134d97763361f216d"
+    },
+    {
+      "name": "doc",
+      "source_skill": "skills/doc",
+      "source_hash": "b1293c5a52a1b7e6487ca40fa0847e1fd1cacf65dc7fa7f3e658831333be88a0",
+      "generated_hash": "48cb7813be9336eb918943246af792b25766b2ea870c9163a7cde5dae187411f"
+    },
+    {
+      "name": "domain",
+      "source_skill": "skills/domain",
+      "source_hash": "6da0f5fbce16cebc05a5855b53f2f5bd5deebd70b986ac7afe9bc46822fba901",
+      "generated_hash": "0c54e9c18349b56f507d891d250b1c78d64c644a0b18d26afb5ff1dc3db57273"
+    },
+    {
+      "name": "eval-outcomes",
+      "source_skill": "skills/eval-outcomes",
+      "source_hash": "4e9f5e6bfefd0b196ce88ac439db26666da9c249335d140423f815d539b82dae",
+      "generated_hash": "6f6ed5eba59ea419db5214b7a5dee0641723eb7c2a6699386b7427e90d2442fc"
+    },
+    {
+      "name": "evolve",
+      "source_skill": "skills/evolve",
+      "source_hash": "1d5ece611ea9b5442019985724a3ad11727f6c6ade3bd5ba8ca42bc2dd7b3b02",
+      "generated_hash": "71c8be7a7ef131ae14cec23a3666007573d3f3288579220662f13042773ba49b"
+    },
+    {
+      "name": "flywheel",
+      "source_skill": "skills/flywheel",
+      "source_hash": "5545163e23d082ab256937ab4ab4bfe454afe54552f191795cf1eb81be171326",
+      "generated_hash": "86c678a2c67031c06568eadac60b79c62d9d2e8ce718202b812fad03611fdef5"
+    },
+    {
+      "name": "forge",
+      "source_skill": "skills/forge",
+      "source_hash": "9a92aa27fdeaef88073b5daa8fe0c78e9704b70a1a68e4d6b351ff11ca8531e6",
+      "generated_hash": "de5cd2598754272bf9d8d344354a3d45455f8a0b49db58b295ccf18648dc1031"
+    },
+    {
+      "name": "goals",
+      "source_skill": "skills/goals",
+      "source_hash": "d8c3c5421217f885f047295f18c88bdd06d8f98bd9db8f8eb54f05a61559f3b5",
+      "generated_hash": "b39903d4af526414f9a2f5703c21e4607bbfda7139cd90905954c3a9be935c56"
+    },
+    {
+      "name": "handoff",
+      "source_skill": "skills/handoff",
+      "source_hash": "11fbba1f4b78ccfd589fe3241f2528f2b13c0f3825b3ea88806a3f8721df2f05",
+      "generated_hash": "5548fd48fe9a8d39d17bfe81467cc96f38053af0362b2b4d756f458d481fe30c"
+    },
+    {
+      "name": "heal-skill",
+      "source_skill": "skills/heal-skill",
+      "source_hash": "901f981bf69ce82bfc7535b38241c672c0465978c6aaaa3f91cc5176c47a1b91",
+      "generated_hash": "b956ee140cb383851ffd7dd5767fd89131ad6beda7087f77b61cc87b574b6600"
+    },
+    {
+      "name": "implement",
+      "source_skill": "skills/implement",
+      "source_hash": "ea8d9ab540c06802db4be79128737704271cf958e5f709ca5a21074089bc0dd5",
+      "generated_hash": "5f6103a3485005c9af806d25e2b4f0e29639db6ef375f51cdb81f33b052dbbc1"
+    },
+    {
+      "name": "inject",
+      "source_skill": "skills/inject",
+      "source_hash": "821284352cbde1d60041217071f7d12898c32d93fe5d5ba4e46920992deaac31",
+      "generated_hash": "ccadf5de66f99533830c411353fc44c9f872e8bcacfd2163f4810253e6393f24"
+    },
+    {
+      "name": "operating-loop-workflow",
+      "source_skill": "skills/operating-loop-workflow",
+      "source_hash": "a5101f268118143a999e8b95601e71a9fa844bf53d0b65572730c9fd928966cb",
+      "generated_hash": "c69a6b78385374c2dc58fdd7fe4a743c32b34c07dfef89510f3d3a9951c5aa02"
+    },
+    {
+      "name": "perf",
+      "source_skill": "skills/perf",
+      "source_hash": "76369d06999ce6adb4b4f37e62fecf0663bf10c8a22337299a91132486b53dee",
+      "generated_hash": "b6324ccfe099938dc6c1967791295f610e032f0c8edaa4bb876a80bc53860a52"
+    },
+    {
+      "name": "plan",
+      "source_skill": "skills/plan",
+      "source_hash": "bb49636ccce8c18a5f073c3b8025d7c45f8f6c3cf508e2acdf617a8eaecad638",
+      "generated_hash": "f9507a89370b23faee0560c7e74b85f9d0cec6af6c0591df293feea846b88de2"
+    },
+    {
+      "name": "post-mortem",
+      "source_skill": "skills/post-mortem",
+      "source_hash": "d61113588b74c23579fd689f3c84e88a023223dfb12a4ad2b80470b9b701f10b",
+      "generated_hash": "22379e3c959eabbbf37415cd1f1553586a96d315f5dde5a5c7c26dca61f5ab4b"
+    },
+    {
+      "name": "pr-implement",
+      "source_skill": "skills/pr-implement",
+      "source_hash": "e3a8fbe13252c5b02f91a3bd702ba3626411fa369ee3ebd0b1f70dbd311d5737",
+      "generated_hash": "0aff598b31587c58491f0634b867726382f96fd53a839b138818fcd35402cab3"
+    },
+    {
+      "name": "pr-prep",
+      "source_skill": "skills/pr-prep",
+      "source_hash": "9ccb475fa34fad42db9c9d42bd378d708ba59a3aa5aadbed6e64e26c3a00fc72",
+      "generated_hash": "0aee4cb7e57ca90daba9ab5f9c84d01038d3ef034ae83ae26d0835002786d783"
+    },
+    {
+      "name": "pr-research",
+      "source_skill": "skills/pr-research",
+      "source_hash": "d156b43972139c21a352e225a4ff019c2f78060731da7d2f26e95a7fc0c5f0c9",
+      "generated_hash": "954067c9d5236ffd07a66d5a41127e1bbd20a754bff3423ed66266f6b894a07c"
+    },
+    {
+      "name": "pre-mortem",
+      "source_skill": "skills/pre-mortem",
+      "source_hash": "f96f41c7abf1413294d7887bc8f02de0781c329146a9d0a802b9611a7d070679",
+      "generated_hash": "1bdfab053565fb61f62938969057859533cbc3f2178bbbefc88d6ee180d68e21"
+    },
+    {
+      "name": "product",
+      "source_skill": "skills/product",
+      "source_hash": "a2f51a7e71f2ff23025dc6b6cf806096cd6c2fb4324d426bd180ab256061e9d5",
+      "generated_hash": "a0f39432a23891f858a56263090d9c605940d97105c712dccc5816ea257673f5"
+    },
+    {
+      "name": "push",
+      "source_skill": "skills/push",
+      "source_hash": "9af3ec35904c38e53d7385419945a27a9bd5f2adcdc96477bcb0a03c300f8cd8",
+      "generated_hash": "1ffd92338bef4c7ee75396a608d07859496bf17f4e12c24bd59e4e136871acb2"
+    },
+    {
+      "name": "quickstart",
+      "source_skill": "skills/quickstart",
+      "source_hash": "4b9f33b8c50e01dae2633a98d905703680c714ddf2e01f3133a6c310ade20a67",
+      "generated_hash": "34f5228bb6d0c96f8f659ee7e3ca0cc585d7ae6f3001ff8448cc63643a5e1d10"
+    },
+    {
+      "name": "ratchet",
+      "source_skill": "skills/ratchet",
+      "source_hash": "30bd3b25b32283072db79de49e7cfd3ea12eb188363aba3b38cdab8e8bd9b216",
+      "generated_hash": "9cb929f145ff8791efd451f9235c62df4e2121d9f33298894c94085f1b7b59fd"
+    },
+    {
+      "name": "recover",
+      "source_skill": "skills/recover",
+      "source_hash": "74175f0df88b4749cbb167b20efd0565811bb75d92d46af73c808ad2048f3b2b",
+      "generated_hash": "c636916c453d94fc715d2b63b35c9864d2c714040c43010a91c702e7404908dd"
+    },
+    {
+      "name": "red-team",
+      "source_skill": "skills/red-team",
+      "source_hash": "6a100fe5fc59fdd24d360730d4fb3f6944b04502e0d39cb405771da9b20270f4",
+      "generated_hash": "4ba26755ae541432c64e24f119e44499d72418f73e2d27427b1bf32229f03161"
+    },
+    {
+      "name": "refactor",
+      "source_skill": "skills/refactor",
+      "source_hash": "bc6dba8ed3658a2c1d3a7950289dfde9f86fac8f238018246f2c196073f9d506",
+      "generated_hash": "ef99b3fea67e2ae5d9da0ba16cdf540af2a94c5b04c336c04cece7dd85c106e8"
+    },
+    {
+      "name": "release",
+      "source_skill": "skills/release",
+      "source_hash": "6f169bdd77b8f4773f04895e120c3d7202ede6e2bb0b7aab4e1f866e052fc6a0",
+      "generated_hash": "5bf8600b3b75771b4d73e60a6b2cad23b48de9298cf251618aea51771a2e2acc"
+    },
+    {
+      "name": "research",
+      "source_skill": "skills/research",
+      "source_hash": "c93c54815257992b01149c347e2f920843c103bc222cd4af5c0a6a2e537779de",
+      "generated_hash": "532252a2a03507e5bbd5b49a972bf527907f9aab1c5d903f665b8e127161d097"
+    },
+    {
+      "name": "reverse-engineer-rpi",
+      "source_skill": "skills/reverse-engineer-rpi",
+      "source_hash": "a3ba1517c06f9a5eeb788375f09cabb393af85288b640e926a3a3f162cb20a6d",
+      "generated_hash": "09320cb29ca3ce9d8fea6c69e710c8969dedc7adb68d0725d55ab9ef5ef4052b"
+    },
+    {
+      "name": "review",
+      "source_skill": "skills/review",
+      "source_hash": "25bce137d83b43dab3a55b1812b361fad5f4c06cc9d5fdd664f42e72f3db1430",
+      "generated_hash": "7170cbba7147d3e657c2ba5c0aadabe823fb2ea86d356824d9524cb29cab37e6"
+    },
+    {
+      "name": "rpi",
+      "source_skill": "skills/rpi",
+      "source_hash": "03cc0bcc12ad8c8d34df56d1149a52d1898b03216c278c4a334f614ad7bf9e40",
+      "generated_hash": "cb5745f73a9b761ed556dabafa77819781d7a7902ec2faed65fc60dad27cbab1"
+    },
+    {
+      "name": "scaffold",
+      "source_skill": "skills/scaffold",
+      "source_hash": "09a8af64645d11dc5c1e49fa4b54558248d29630a5dac9d7d25c99da8b0a3590",
+      "generated_hash": "26ec68f6c72a047d4889d9b3f50f2eeef4ed27ead9a440a09c4a1d1f2bc0a9dc"
+    },
+    {
+      "name": "scenario",
+      "source_skill": "skills/scenario",
+      "source_hash": "16f5dafbd35bb7ceb5e1c377e134299d7318944819e0ba290a753732972fc152",
+      "generated_hash": "83d145be52981c0b0b6077a4dd43aa0340656038afebca27852ead43ae9eed74"
+    },
+    {
+      "name": "scope",
+      "source_skill": "skills/scope",
+      "source_hash": "c71a44e4f7576900ce26383984d3e68eae5d7b29b9d07bc334858d062aa85768",
+      "generated_hash": "47a0e3cbeff64e7fd40f4c76a756435443b1644859a00ab85e21318539f58734"
+    },
+    {
+      "name": "security",
+      "source_skill": "skills/security",
+      "source_hash": "5584c104eb15c2b4bf6322f16ef45407a02e53d594ada05fa9687bf9b48f75d4",
+      "generated_hash": "0ba3d08ef58f6dc6e72d1d5b2290b2ffe400b8fde8b1289e0b2a54f0eeb4bf67"
+    },
+    {
+      "name": "session-bootstrap",
+      "source_skill": "skills/session-bootstrap",
+      "source_hash": "4687b43c39e3434ae1a0bb772248d867fb86070be855ef561cc3cd9e538cf51f",
+      "generated_hash": "5eeb89272ce57b9e8adc01bb06ecc550fc0d6574bb0980a922508df3ed251224"
+    },
+    {
+      "name": "shared",
+      "source_skill": "skills/shared",
+      "source_hash": "b54e7674ea40faa8ec782e12af182092397d4ac751c51e6a5bc410a390195ad6",
+      "generated_hash": "03747761781e40cedde91319c903f3df3ca48c49a04e0180f7f0ae3e88668be1"
+    },
+    {
+      "name": "ship-loop",
+      "source_skill": "skills/ship-loop",
+      "source_hash": "98f33d46a03b2f8d52e8cdfc17a38844d6371efdcc264202f332f404803ddfff",
+      "generated_hash": "34755a5fc0f099b82e93f69b57436da6ff34d59b3e82d8984c78e461360cb8f3"
+    },
+    {
+      "name": "skill-auditor",
+      "source_skill": "skills/skill-auditor",
+      "source_hash": "314de8417241d574543518f96c0be458feaf32fdcbb05ef4daf8c87cab06a786",
+      "generated_hash": "586d228b2817c1e4dc0b1abdb7b8cbaf568754da747bd1fe669531ee2542b026"
+    },
+    {
+      "name": "skill-builder",
+      "source_skill": "skills/skill-builder",
+      "source_hash": "c397515b2a38637c34b265d13cff1cce0310d41712e8d498655304a186cfa1d6",
+      "generated_hash": "154f768f146bd91820c511f0e71bada1d81d42699a6f3a83a077ffd47a7fd68b"
+    },
+    {
+      "name": "standards",
+      "source_skill": "skills/standards",
+      "source_hash": "bead4cb6731f973114a1ba33ce85b32450d799e0ebc0a90c582ffa571f956f4c",
+      "generated_hash": "5634d15c077bdfe3021ae4e280906d363395343ee2d8ff0801aeefab73bb6252"
+    },
+    {
+      "name": "status",
+      "source_skill": "skills/status",
+      "source_hash": "801cc64e7ffdeb36beadc3fef73983602311a3048694dde376f2635d099d607f",
+      "generated_hash": "6ed21b1c9e81071ea07880ca223b3ffdfc84653d8151293c29f5d3f970e76794"
+    },
+    {
+      "name": "swarm",
+      "source_skill": "skills/swarm",
+      "source_hash": "5c483aea88223216ea00c22cd2f1bebb3ba1d3d995c7a4bf8f977800a6035e96",
+      "generated_hash": "6a66e8bb7dd85f3addce4632f443351925d888fff74fb0b161533f473e88d8ac"
+    },
+    {
+      "name": "system-tuning",
+      "source_skill": "skills/system-tuning",
+      "source_hash": "6d340c15f61d023e1d87faaf576d9317756448ab30aaeacbcf566da895cf4486",
+      "generated_hash": "91c58bb3f192f4aeb34d96047c53b1288bfa908e5886df8c9e5ba5bbb6e77a75"
+    },
+    {
+      "name": "test",
+      "source_skill": "skills/test",
+      "source_hash": "c269a74fee173b40849ab3908e11715b1398b4b0a6a74eb9b9c87934cfda5566",
+      "generated_hash": "5c4db4e46a23dc0d8ce9d78f25ac4ee32a927dfd1b250862dc1acc64846fa9ed"
+    },
+    {
+      "name": "trace",
+      "source_skill": "skills/trace",
+      "source_hash": "c3ca50e4f2abe2c0b671be0b92c046be32725e2f8edc12017095652cdab4fb20",
+      "generated_hash": "2f33d40788ae0f05035dbf910dbe117c0828ad2593de15e47d614ab54ee1a7ec"
+    },
+    {
+      "name": "using-agentops",
+      "source_skill": "skills/using-agentops",
+      "source_hash": "32c966e0cfa9ac896c448faad6436a6e46c40c041eaf6d6db6079944f4c552ae",
+      "generated_hash": "56246e0dc03ecac27a7bec56c73972f41fd9f8aa5ccc0660e55fa249c79ee0a0"
+    },
+    {
+      "name": "using-atm",
+      "source_skill": "skills/using-atm",
+      "source_hash": "8a84324e9e1a6546d96e4a07e69743a3f781d77e6f9500867085d199b56877c3",
+      "generated_hash": "bae77030f0dd2d6830ea06734fdd31665e1700152b77c8a03ef0331c91ba539b"
+    },
+    {
+      "name": "validate",
+      "source_skill": "skills/validate",
+      "source_hash": "08e996eef817b7b913dcabfc7c5f9441aafd2bb03ab5b6c52b3e7c7cc034ae7b",
+      "generated_hash": "7dbdcbb47198ac587b4cc5998b15c572a5e901452d62e7099905ddae968a3862"
+    },
+    {
+      "name": "vibe",
+      "source_skill": "skills/vibe",
+      "source_hash": "c230c22c1ba440bfbd6f9b1fb4444adc28a73f22b6f602d198ab581faaa13f95",
+      "generated_hash": "8418e2d6b322d0783704a2c0d5198a8892da0ec8b69a63e6d2ef1c236a1766ae"
+    },
+    {
+      "name": "workflow-builder",
+      "source_skill": "skills/workflow-builder",
+      "source_hash": "d7851c1a9bed2cb411e09605e85044751ebc241cdfcffe6df363b5f02aa5bd64",
+      "generated_hash": "2cd6553c4fe2e484c2e8ee62bf63887442fbf2be920706551b660c6c89b7ba5b"
+    },
+    {
       "name": "acfs",
       "source_skill": "skills/acfs",
       "source_hash": "84f8222e01c0de6af9750afc0dc2ff31dfed383e76f59ce97a7950c32cd609f2",
@@ -1198,8 +1606,8 @@
     {
       "name": "agent-native",
       "source_skill": "skills/agent-native",
-      "source_hash": "5793ffc8354f85cc1d27a447e0fcdfd8ba11395dafa620960c827fc12b9371b1",
-      "generated_hash": "4278d76d9c0b6093157ae0f52b306c9081a0f12d35a66c34f5e56e337e876e9c"
+      "source_hash": "72c4e6eb5472d79ad7c1d1bb4678a315f3181cbcfbb2fa252b26a535ca22633c",
+      "generated_hash": "1bbe19f6087257e2d92b30d437a63a8b34e116379a2cf99184aad0d618824b9e"
     },
     {
       "name": "agy-headless-evidence",
@@ -1258,8 +1666,8 @@
     {
       "name": "automation-shape-routing",
       "source_skill": "skills/automation-shape-routing",
-      "source_hash": "24b1d8290e69c86ed447fcb800d8e5f2e0dde3d7e585c9b50f777b7c9e9fa378",
-      "generated_hash": "760fa89b39fe7a5d770ace8593c228d34078b1aaf830ce3f2422196772cdb485"
+      "source_hash": "233a91c8a26ca9d3b908632dedcb7f8b6a8bec5e88d050103cb4eb36221d3283",
+      "generated_hash": "2afa14e81397373ee5d7c76c7a88287fa853257f33040a0a9a47597d7f4c3f69"
     },
     {
       "name": "bd-first-memory-migration",
@@ -1474,14 +1882,14 @@
     {
       "name": "council",
       "source_skill": "skills/council",
-      "source_hash": "44e4521bbcec5ac3a26421bf4459dfa21f6afc6c38bcd745a19ad9d1e2457dd8",
-      "generated_hash": "2bc6030290f7fc269ae08cbec2cf0db76a3ea80b0d8366399cfc3966eabe5e50"
+      "source_hash": "325ef84388d48f1ddbb115a89f09f75d354541889af7dc297a728dfbcf0d150f",
+      "generated_hash": "811ab60278e0f8cfc6aee26fb8cfa6196212813a30d76f587f83c095fcbf4359"
     },
     {
       "name": "crank",
       "source_skill": "skills/crank",
-      "source_hash": "e1332fd5c8c9593e12a904969535c773b40fc0dc05dbcbc027d8290a46b0fc3d",
-      "generated_hash": "0f94f0fac03005a26a83492760395800b2ec6e73d85668de263c562cb25e17d5"
+      "source_hash": "80cbc1a46b0ef5174dc8244cb7c0b1ffb723ebb34979727d6249cc1f7ef19b56",
+      "generated_hash": "20ab5f915ad0433494daf5fc9b79eba11d608646f40dfae8446cd04af251f111"
     },
     {
       "name": "cross-vendor-trust-gate",
@@ -1930,8 +2338,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "dd7b89d1304aee1640102ceb6d28db9f981b57d14417c2128f5b1a45742c6774",
-      "generated_hash": "c95922aff346c6dfafa6eb14e51eb575a4a62afd4250b22c64d0c9e1c1f19750"
+      "source_hash": "03cc0bcc12ad8c8d34df56d1149a52d1898b03216c278c4a334f614ad7bf9e40",
+      "generated_hash": "cb5745f73a9b761ed556dabafa77819781d7a7902ec2faed65fc60dad27cbab1"
     },
     {
       "name": "ru-multi-repo-workflow",
@@ -2074,8 +2482,8 @@
     {
       "name": "swarm",
       "source_skill": "skills/swarm",
-      "source_hash": "5e0cbc76f558797720450b27f30ebe2b3651b7b2fad9d5114fa09c2827b488c1",
-      "generated_hash": "1b86423840582ebb3679f236df99c7d23e4e8ef87dac202f478e119b29b6a7f4"
+      "source_hash": "5c483aea88223216ea00c22cd2f1bebb3ba1d3d995c7a4bf8f977800a6035e96",
+      "generated_hash": "6a66e8bb7dd85f3addce4632f443351925d888fff74fb0b161533f473e88d8ac"
     },
     {
       "name": "system-performance-remediation",
@@ -2110,14 +2518,8 @@
     {
       "name": "using-agentops",
       "source_skill": "skills/using-agentops",
-      "source_hash": "a0445731ef1a1c9aa01a4555ba8e2ac572c97413864fa48afa4ac09ebe85b942",
-      "generated_hash": "ddb640155f793f2731266cd2c6e786d9cee856b5b8745a02ecfc82c554b1069a"
-    },
-    {
-      "name": "using-ntm",
-      "source_skill": "skills/using-ntm",
-      "source_hash": "2ee2269d91031235b2bbad0297d7574014e54a7251a09abaf3b7b65ea5598e2c",
-      "generated_hash": "4060b89666075275c1c86b7365816957253d262ffb39b0543f025f78b78923db"
+      "source_hash": "32c966e0cfa9ac896c448faad6436a6e46c40c041eaf6d6db6079944f4c552ae",
+      "generated_hash": "56246e0dc03ecac27a7bec56c73972f41fd9f8aa5ccc0660e55fa249c79ee0a0"
     },
     {
       "name": "validate",

--- a/skills-codex/agent-native/.agentops-generated.json
+++ b/skills-codex/agent-native/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/agent-native",
   "layout": "modular",
-  "source_hash": "5793ffc8354f85cc1d27a447e0fcdfd8ba11395dafa620960c827fc12b9371b1",
-  "generated_hash": "4278d76d9c0b6093157ae0f52b306c9081a0f12d35a66c34f5e56e337e876e9c"
+  "source_hash": "72c4e6eb5472d79ad7c1d1bb4678a315f3181cbcfbb2fa252b26a535ca22633c",
+  "generated_hash": "1bbe19f6087257e2d92b30d437a63a8b34e116379a2cf99184aad0d618824b9e"
 }

--- a/skills-codex/agent-native/SKILL.md
+++ b/skills-codex/agent-native/SKILL.md
@@ -7,9 +7,9 @@ description: "Run agent native."
 
 > **Quick Ref:** Run a Claude/Codex loop *outside* an interactive session (Managed Agent, Agent SDK, or self-hosted sandbox) under the same AgentOps guardrails — hooklessly. Guardrails = skills + the `ao` CLI + CI, never ported hooks. Bundle skills into the agent definition, expose `ao` as a callable tool so the loop self-bootstraps + self-validates, and gate the output through the SAME CI as interactive work.
 
-## Codex/NTM path
+## Codex/ATM path
 
-Codex (gpt-5.3-codex) has NO Managed Agents API, NO Workflow tool, NO Task subagent. It orchestrates via NTM (tmux pane swarms + agent-mail) + skills + the `ao` CLI + ssh to bushido. So an out-of-session Codex loop becomes AgentOps-native the same way: load the AgentOps skills, call `ao session bootstrap` / `ao inject` / `ao validate` directly (no MCP needed — Codex shells out), and gate outputs through CI (`agent-output-validate.yml`). `ao` does not wrap `gc`; a whole loop needing a mayor/refinery still routes through `gc`.
+Codex (gpt-5.3-codex) has NO Managed Agents API, NO Workflow tool, NO Task subagent. It orchestrates via ATM (tmux pane swarms + agent-mail) + skills + the `ao` CLI + ssh to bushido. ATM is Bo's fork/alias of upstream NTM: `atm` points at `~/dev/ntm/dist/atm-darwin-arm64` and preserves the upstream `ntm` command surface. So an out-of-session Codex loop becomes AgentOps-native the same way: load the AgentOps skills, call `ao session bootstrap` / `ao inject` / `ao validate` directly (no MCP needed — Codex shells out), and gate outputs through CI (`agent-output-validate.yml`). `ao` does not wrap `gc`; a whole loop needing a mayor/refinery still routes through `gc`.
 
 ## Instructions
 

--- a/skills-codex/automation-shape-routing/.agentops-generated.json
+++ b/skills-codex/automation-shape-routing/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/automation-shape-routing",
   "layout": "modular",
-  "source_hash": "24b1d8290e69c86ed447fcb800d8e5f2e0dde3d7e585c9b50f777b7c9e9fa378",
-  "generated_hash": "760fa89b39fe7a5d770ace8593c228d34078b1aaf830ce3f2422196772cdb485"
+  "source_hash": "233a91c8a26ca9d3b908632dedcb7f8b6a8bec5e88d050103cb4eb36221d3283",
+  "generated_hash": "2afa14e81397373ee5d7c76c7a88287fa853257f33040a0a9a47597d7f4c3f69"
 }

--- a/skills-codex/automation-shape-routing/SKILL.md
+++ b/skills-codex/automation-shape-routing/SKILL.md
@@ -2,11 +2,11 @@
 name: automation-shape-routing
 description: "Run automation shape routing."
 ---
-# $automation-shape-routing — Orchestration vs NTM vs Skill
+# $automation-shape-routing — Orchestration vs ATM vs Skill
 
 > **The trap this kills:** "I built a lot of skills; they should become
 > orchestration scripts." Mostly false. Most orchestration-looking skills are
-> either long-lived/human-attachable (stay NTM) or hard-sequential (stay skills).
+> either long-lived/human-attachable (stay ATM) or hard-sequential (stay skills).
 > The win is the routing rule, not a migration project.
 
 ## The three shapes
@@ -14,7 +14,7 @@ description: "Run automation shape routing."
 | Shape | What it is | Mechanism |
 |---|---|---|
 | **Orchestration** | Deterministic, reproducible fan-out / pipeline / loop over sub-agents, each returning structured output | Codex orchestration — `codex exec` driving `spawn_agents` (parallel fan-out), staged pipelines, and loop-until-budget, with an `output_schema` per sub-agent. Headless, reproducible, bounded concurrency. |
-| **NTM swarm** | Long-lived, human-in-the-loop multi-agent run | `ntm` (the CLI) driven by $using-ntm — persistent tmux panes running whole $rpi/$evolve loops over a bead queue, with attach + nudge + kill/relaunch and mail/locks coordination. |
+| **ATM swarm** | Long-lived, human-in-the-loop multi-agent run | `atm` (the CLI) driven by $using-atm — persistent tmux panes running whole $rpi/$evolve loops over a bead queue, with attach + nudge + kill/relaunch and mail/locks coordination. |
 | **Plain skill** | One model reasoning through a procedure or knowledge | A single `SKILL.md`. No fan-out, or a strictly sequential edit-loop. |
 
 ## The decision rule (three axes)
@@ -26,14 +26,14 @@ Ask in order:
 2. **Must a human attach and steer mid-run?** Or does it run for *hours*, do
    open-ended *file edits*, juggle a *fluid population* (rate limits, kill/
    relaunch, prompt-cache rounds), or relay between *cross-model* panes? — if
-   **yes** → **NTM swarm**.
+   **yes** → **ATM swarm**.
 3. Otherwise — fixed DAG, sub-agents return **structured JSON** (not free-form
    edits needing review), no attach needed, you want it **reproducible + headless**
    → **Orchestration**.
 
 **One-line litmus:**
 > deterministic DAG + structured JSON + no human-attach + headless-wanted → **Orchestration**
-> long-lived + attachable + open-ended file edits / fluid population → **NTM**
+> long-lived + attachable + open-ended file edits / fluid population → **ATM**
 > no fan-out, or hard-sequential edit loop → **plain skill**
 
 ## Spike-validated nuances (2026-05-29)
@@ -42,8 +42,8 @@ A live three-legged spike (`~/dev/agentops-3cat-spike/`) measured the same task 
 all three backends. Two findings refine the rule:
 
 1. **The primary axis is control-plane vs in-session, not "parallel vs serial."**
-   **NTM is a control-plane** that *runs Claude/Codex/Gemini as panes* — it is not a
-   peer of the native runtimes, it is the supervisor tier above them. Choose NTM when
+   **ATM is a control-plane** that *runs Claude/Codex/Gemini as panes* — it is not a
+   peer of the native runtimes, it is the supervisor tier above them. Choose ATM when
    you need the control plane (attach/steer, persistence, multi-vendor); choose
    in-session native orchestration (`codex exec` + `spawn_agents`) when you don't.
 2. **Parallel buys quality/independence, NOT wall-clock — at small N.** Measured: a
@@ -55,7 +55,7 @@ all three backends. Two findings refine the rule:
    large N **and** no barrier — use a streaming pipeline (no barrier), not a
    collect-all barrier.
 
-Degradation (NTM → native → beads floor) is governed by the
+Degradation (ATM → native → beads floor) is governed by the
 `OrchestrationPort` selector; opt out entirely with `AGENTOPS_ORCHESTRATION=off` →
 beads floor, which always works.
 
@@ -67,8 +67,8 @@ beads floor, which always works.
   nothing. *Exception:* it graduates to a loop-until-budget orchestration only once
   each step returns **structured output** instead of free-form edits, and you want
   it headless/reproducible.
-- **Don't NTM-ify a clean fan-out, and don't orchestrate an attach-and-steer run.**
-  Headless orchestration runs in-process and cannot be tmux-attached; NTM is built
+- **Don't ATM-ify a clean fan-out, and don't orchestrate an attach-and-steer run.**
+  Headless orchestration runs in-process and cannot be tmux-attached; ATM is built
   for exactly the live-steering headless orchestration can't do. Picking wrong
   fights the tool the whole way.
 
@@ -78,8 +78,8 @@ beads floor, which always works.
 `council` (N judges → consensus — near-trivial port), the **planning half** of
 `rpi`, judge/refutation panels, any "fan out N analyses → triangulate" task.
 
-**→ Stay NTM** (long-lived, attachable, open-ended edits, fluid population):
-the `*-with-ntm` family (hypothesis research, cross-model review swarms, browser
+**→ Stay ATM** (long-lived, attachable, open-ended edits, fluid population):
+the `*-with-atm` family (hypothesis research, cross-model review swarms, browser
 testing), plus `swarm`/`crank` in full epic-execution mode — they touch the
 working tree and need wave-validity gating + human review.
 
@@ -109,7 +109,7 @@ decided, hand off:
 |---|---|---|
 | **plain skill** | `$skill-builder` | Scaffold a new `SKILL.md` against the unified template → then `$skill-auditor` → `$heal-skill`. |
 | **Orchestration** | `$workflow-builder` | Author a deterministic `codex exec` + `spawn_agents` orchestration with per-sub-agent `output_schema`. |
-| **NTM swarm** | `ntm` + $using-ntm | Stand up + tend an NTM swarm running AgentOps loops ($rpi/$evolve) over a bead queue. |
+| **ATM swarm** | `atm` + $using-atm | Stand up + tend an ATM swarm running AgentOps loops ($rpi/$evolve) over a bead queue. |
 
 State the verdict and the deciding axis in one line, then invoke the chosen
 builder. Do not scaffold here.

--- a/skills-codex/council/.agentops-generated.json
+++ b/skills-codex/council/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/council",
   "layout": "modular",
-  "source_hash": "44e4521bbcec5ac3a26421bf4459dfa21f6afc6c38bcd745a19ad9d1e2457dd8",
-  "generated_hash": "2bc6030290f7fc269ae08cbec2cf0db76a3ea80b0d8366399cfc3966eabe5e50"
+  "source_hash": "325ef84388d48f1ddbb115a89f09f75d354541889af7dc297a728dfbcf0d150f",
+  "generated_hash": "811ab60278e0f8cfc6aee26fb8cfa6196212813a30d76f587f83c095fcbf4359"
 }

--- a/skills-codex/council/SKILL.md
+++ b/skills-codex/council/SKILL.md
@@ -215,6 +215,10 @@ When validating plans/specs, judges must check:
 
 Missing gate item → minimum WARN. Critical unverifiable invariant → FAIL.
 
+## Related skills
+
+- $using-atm — out-of-session ATM substrate for long-running multi-agent review swarms.
+
 ## Reference Documents
 
 - [references/modes.md](references/modes.md)

--- a/skills-codex/crank/.agentops-generated.json
+++ b/skills-codex/crank/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/crank",
   "layout": "modular",
-  "source_hash": "e1332fd5c8c9593e12a904969535c773b40fc0dc05dbcbc027d8290a46b0fc3d",
-  "generated_hash": "0f94f0fac03005a26a83492760395800b2ec6e73d85668de263c562cb25e17d5"
+  "source_hash": "80cbc1a46b0ef5174dc8244cb7c0b1ffb723ebb34979727d6249cc1f7ef19b56",
+  "generated_hash": "20ab5f915ad0433494daf5fc9b79eba11d608646f40dfae8446cd04af251f111"
 }

--- a/skills-codex/crank/SKILL.md
+++ b/skills-codex/crank/SKILL.md
@@ -529,6 +529,10 @@ fi
 | All workers fail | `<promise>BLOCKED</promise>` with diagnostics |
 | File conflict detected | Split into sub-waves, re-run |
 
+## Related skills
+
+- $using-atm — out-of-session ATM substrate for long-running $crank waves over a bead queue.
+
 ## Reference Documents
 
 - [references/de-sloppify.md](references/de-sloppify.md) - cleanup pass after implementation waves

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "dd7b89d1304aee1640102ceb6d28db9f981b57d14417c2128f5b1a45742c6774",
-  "generated_hash": "c95922aff346c6dfafa6eb14e51eb575a4a62afd4250b22c64d0c9e1c1f19750"
+  "source_hash": "03cc0bcc12ad8c8d34df56d1149a52d1898b03216c278c4a334f614ad7bf9e40",
+  "generated_hash": "cb5745f73a9b761ed556dabafa77819781d7a7902ec2faed65fc60dad27cbab1"
 }

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -182,6 +182,10 @@ interactive, and loop examples.
 | Packet shape unclear | Read [references/phase-data-contracts.md](references/phase-data-contracts.md) |
 | External executor fails | Read [references/codex-executor.md](references/codex-executor.md), run direct Codex validation, and only create follow-up work for reproducible source failures |
 
+## Related skills
+
+- $using-atm — out-of-session ATM substrate for running whole $rpi loops over a bead queue.
+
 ## Reference Documents
 
 - [references/autonomous-execution.md](references/autonomous-execution.md)

--- a/skills-codex/storage-watchdog-ops/.agentops-generated.json
+++ b/skills-codex/storage-watchdog-ops/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/storage-watchdog-ops",
   "layout": "modular",
-  "source_hash": "5f9e845fc3b454aa2939ca78af3f1395bc22055170e1834b96ddbbe583a08a8d",
+  "source_hash": "66de43babcd83537a640db65c6228ed3c7ab333cfcbf3f808d5841b44a548732",
   "generated_hash": "55c3fdc7869c538124fd94e831178df9d1286ee606d8607d84afd520a01b195d"
 }

--- a/skills-codex/swarm/.agentops-generated.json
+++ b/skills-codex/swarm/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/swarm",
   "layout": "modular",
-  "source_hash": "5e0cbc76f558797720450b27f30ebe2b3651b7b2fad9d5114fa09c2827b488c1",
-  "generated_hash": "1b86423840582ebb3679f236df99c7d23e4e8ef87dac202f478e119b29b6a7f4"
+  "source_hash": "5c483aea88223216ea00c22cd2f1bebb3ba1d3d995c7a4bf8f977800a6035e96",
+  "generated_hash": "6a66e8bb7dd85f3addce4632f443351925d888fff74fb0b161533f473e88d8ac"
 }

--- a/skills-codex/swarm/SKILL.md
+++ b/skills-codex/swarm/SKILL.md
@@ -206,6 +206,10 @@ for task in wave_tasks:
 
 This is slower but functionally identical.
 
+## Related skills
+
+- $using-atm — out-of-session ATM substrate when a swarm needs persistent panes and human attach/steer.
+
 ## Reference Documents
 
 - [references/conflict-recovery.md](references/conflict-recovery.md)

--- a/skills-codex/using-agentops/.agentops-generated.json
+++ b/skills-codex/using-agentops/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/using-agentops",
   "layout": "modular",
-  "source_hash": "a0445731ef1a1c9aa01a4555ba8e2ac572c97413864fa48afa4ac09ebe85b942",
-  "generated_hash": "ddb640155f793f2731266cd2c6e786d9cee856b5b8745a02ecfc82c554b1069a"
+  "source_hash": "32c966e0cfa9ac896c448faad6436a6e46c40c041eaf6d6db6079944f4c552ae",
+  "generated_hash": "56246e0dc03ecac27a7bec56c73972f41fd9f8aa5ccc0660e55fa249c79ee0a0"
 }

--- a/skills-codex/using-agentops/SKILL.md
+++ b/skills-codex/using-agentops/SKILL.md
@@ -133,6 +133,7 @@ These are the skills every user needs first. Everything else is available when y
 |-------|---------|
 | `$grafana-platform-dashboard` | Build Grafana platform dashboards from templates/contracts |
 | `$swarm` | Parallel Codex agent execution (folded the retired `$codex-team`) |
+| `$using-atm` | Run AgentOps loops out of session on an ATM tmux swarm (the ATM leg of the substrate) |
 | `$openai-docs` | Official OpenAI docs lookup with citations |
 | `$reverse-engineer-rpi` | Reverse-engineer a product into feature catalog and specs |
 | `$pr-research` | Upstream repository research before contribution |
@@ -165,7 +166,7 @@ AgentOps has several runtime modes. Do not assume hook automation exists everywh
 
 | Mode | When it applies | Start path | Closeout path | Guarantees |
 |------|-----------------|------------|---------------|------------|
-| `substrate` (out-of-session) | A swappable orchestration substrate available out-of-session: an NTM tmux swarm, MCP (`ao mcp serve`), or managed-agents (`ao agent`) | The operator or a lead agent runs `bd ready` and dispatches a whole loop per bead (`ao rpi <bead>`); cron / managed triggers run maintenance | The substrate owns the merge gate (CI-green is the signal) and triggers the knowledge-flywheel feedback | The substrate orchestrates *whole* `ao rpi` loops — it never sees the loop's insides; the seam is substrate → `ao` as a subprocess. There is no in-CLI `runtime=gc` executor. Codex skills still chain `$skill` invocations for lead orchestration. See [docs/3.0.md](https://github.com/boshu2/agentops/blob/main/docs/3.0.md). |
+| `substrate` (out-of-session) | A swappable orchestration substrate available out-of-session: an ATM tmux swarm, MCP (`ao mcp serve`), or managed-agents (`ao agent`) | The operator or a lead agent runs `bd ready` and dispatches a whole loop per bead — an agent that runs the `$rpi` skill; cron / managed triggers run maintenance | The substrate owns the merge gate (CI-green is the signal) and triggers the knowledge-flywheel feedback | The substrate orchestrates *whole* `$rpi`/`$evolve` loops (each an agent running the skill) — it never sees the loop's insides; the seam is substrate → agent-running-the-skill. There is no in-CLI `runtime=gc` executor. See `$agent-native` and [docs/3.0.md](https://github.com/boshu2/agentops/blob/main/docs/3.0.md). |
 | `codex-hookless-fallback` | Codex Desktop / Codex CLI without hook surfaces | `ao codex start` or `ao codex ensure-start` | `ao codex stop` or `ao codex ensure-stop` | Explicit startup context, citation tracking, transcript fallback, and close-loop metrics without hooks |
 | `manual` | Codex cannot resolve repo/runtime state automatically | `ao inject` / `ao lookup` | `ao forge transcript` + `ao flywheel close-loop` | Works everywhere, but lifecycle actions are operator-driven |
 

--- a/skills-codex/using-atm/.agentops-generated.json
+++ b/skills-codex/using-atm/.agentops-generated.json
@@ -1,0 +1,7 @@
+{
+  "generator": "manual-maintained",
+  "source_skill": "skills/using-atm",
+  "layout": "modular",
+  "source_hash": "8a84324e9e1a6546d96e4a07e69743a3f781d77e6f9500867085d199b56877c3",
+  "generated_hash": "bae77030f0dd2d6830ea06734fdd31665e1700152b77c8a03ef0331c91ba539b"
+}

--- a/skills-codex/using-atm/SKILL.md
+++ b/skills-codex/using-atm/SKILL.md
@@ -1,36 +1,38 @@
 ---
-name: using-ntm
-description: "Run using NTM."
+name: using-atm
+description: "Run using ATM."
 ---
 
-# Using NTM as the Out-of-Session Substrate
+# Using ATM as the Out-of-Session Substrate
 
 AgentOps 3.0 runs its loops **in session** and ships **no** daemon, scheduler, or
 overnight runner. To run the loop **unattended** — always-on, scheduled,
 queue-driven — you hand it to an orchestration **substrate**. The reference
-substrate is **NTM + Agent Mail (`am`) + managed-agents**; this skill covers the **NTM leg**: a
-local Named Tmux Manager swarm of Claude/Codex agent panes. NTM is an adopted
-external tool (`ntm` on `PATH`), **not** an AgentOps-owned surface.
+substrate is **ATM + Agent Mail (`am`) + managed-agents**; this skill covers the **ATM leg**: a
+local Named Tmux Manager swarm of Claude/Codex agent panes. ATM is an adopted
+external tool (`atm` on `PATH`), **not** an AgentOps-owned surface.
+ATM is Bo's fork/alias of upstream NTM: `atm` points at
+`~/dev/ntm/dist/atm-darwin-arm64` and keeps the upstream `ntm` command surface.
 
 > **Skills are the runtime, not the CLI.** The substrate dispatches a *whole
 > loop* by spawning an agent that **runs the $rpi or $evolve skill** — it does
 > **not** shell out to a retired CLI subprocess. Those terminal
 > wrappers are retired; the loop lives as a skill an agent executes. The seam is
-> **NTM pane → agent → $rpi <bead>**, one bead dispatched as one invocable unit.
+> **ATM pane → agent → $rpi <bead>**, one bead dispatched as one invocable unit.
 
 ## When to use / when to skip
 
 **Use it when:** you want a bead queue worked unattended out of session; you're
-standing up or tending an NTM swarm that runs AgentOps loops; a pane is stuck,
+standing up or tending an ATM swarm that runs AgentOps loops; a pane is stuck,
 rate-limited, or wedged; you need to know whether the swarm has converged.
 
 **Skip it when:** the work fits a single in-session run (run $rpi or $evolve
 yourself); you want in-session parallel fan-out across worktrees (use $swarm);
 you're choosing between automation shapes (start at $automation-shape-routing).
 
-This skill does **not** re-document the full `ntm` command surface — run
-`ntm help`. It covers the **AgentOps substrate contract**: how to dispatch and
-tend AgentOps loops on an NTM swarm.
+This skill does **not** re-document the full `atm` command surface — run
+`atm help`. It covers the **AgentOps substrate contract**: how to dispatch and
+tend AgentOps loops on an ATM swarm.
 
 ## The dispatch contract
 
@@ -50,23 +52,23 @@ tend AgentOps loops on an NTM swarm.
 
 ```bash
 # 1. Spawn a swarm of agent panes against the repo (2 Claude + 1 Codex worker).
-ntm spawn agentops --cc=2 --cod=1
+atm spawn agentops --cc=2 --cod=1
 
 # 2. Dispatch a whole loop to a pane — the SKILL, not a CLI subprocess.
-ntm send agentops --pane=1 "$rpi ag-1234"
-ntm send agentops --pane=2 "$evolve --beads-only"
+atm send agentops --pane=1 "$rpi ag-1234"
+atm send agentops --pane=2 "$evolve --beads-only"
 
 # 3. Watch / attach.
-ntm activity agentops          # per-pane agent state
-ntm attach agentops            # drop into the swarm
+atm activity agentops          # per-pane agent state
+atm attach agentops            # drop into the swarm
 
 # 4. Health + dependencies (run before a long unattended session).
-ntm doctor                     # validate the NTM ecosystem
-ntm deps                       # required agent CLIs present
+atm doctor                     # validate the ATM ecosystem
+atm deps                       # required agent CLIs present
 ```
 
 Scheduled cadence (e.g. a nightly $evolve pass) is driven by host-OS timing (a
-systemd user timer or cron) that runs `ntm send … "$evolve"`, or by a
+systemd user timer or cron) that runs `atm send … "$evolve"`, or by a
 managed-agent driver — **not** an AgentOps daemon.
 
 ## Tending the swarm (operator loop)
@@ -89,8 +91,8 @@ Run one tick at a time; take the first action whose trigger fires:
 ## Convergence + shutdown
 
 Done when `bd ready` is empty, no pane has an in-flight bead, and the last few CI
-runs are green. Confirm with `ntm activity` (all idle) + `bd ready` (empty) before
-`ntm kill <session>`. Don't shut down on a transient quiet patch — a rate-limited
+runs are green. Confirm with `atm activity` (all idle) + `bd ready` (empty) before
+`atm kill <session>`. Don't shut down on a transient quiet patch — a rate-limited
 pane also looks idle.
 
 ## Anti-patterns
@@ -98,11 +100,11 @@ pane also looks idle.
 - ❌ Shelling out to a retired CLI; dispatch the `$rpi` / `$evolve` skill instead.
 - ❌ Decomposing the loop into substrate steps — dispatch the whole loop as one invocable unit.
 - ❌ Editing the shared checkout from a pane — worktree-per-bead, always.
-- ❌ Treating NTM as AgentOps-owned — it is an adopted external substrate; a managed-agents driver (`ao agent`) or a plain in-session run are equally valid legs. Choose via $automation-shape-routing.
+- ❌ Treating ATM as AgentOps-owned — it is an adopted external substrate; a managed-agents driver (`ao agent`) or a plain in-session run are equally valid legs. Choose via $automation-shape-routing.
 
 ## Related skills
 
-- $automation-shape-routing — decide Workflow vs NTM swarm vs plain skill before standing up a swarm.
+- $automation-shape-routing — decide Workflow vs ATM swarm vs plain skill before standing up a swarm.
 - $swarm — in-session parallel fan-out across worktrees (the in-session sibling).
 - $agent-native — `ao agent bundle` produces the loop definition a managed-agents substrate runs.
 - $rpi · $evolve — the loops the substrate dispatches.

--- a/skills-codex/using-atm/prompt.md
+++ b/skills-codex/using-atm/prompt.md
@@ -1,6 +1,6 @@
-# using-ntm
+# using-atm
 
-Use NTM as the out-of-session substrate for unattended AgentOps loops.
+Use ATM as the out-of-session substrate for unattended AgentOps loops.
 
 ## Instructions
 

--- a/skills-codex/using-ntm/.agentops-generated.json
+++ b/skills-codex/using-ntm/.agentops-generated.json
@@ -1,7 +1,0 @@
-{
-  "generator": "manual-maintained",
-  "source_skill": "skills/using-ntm",
-  "layout": "modular",
-  "source_hash": "2ee2269d91031235b2bbad0297d7574014e54a7251a09abaf3b7b65ea5598e2c",
-  "generated_hash": "4060b89666075275c1c86b7365816957253d262ffb39b0543f025f78b78923db"
-}

--- a/skills-codex/using-ntm/SKILL.md
+++ b/skills-codex/using-ntm/SKILL.md
@@ -8,7 +8,7 @@ description: "Run using NTM."
 AgentOps 3.0 runs its loops **in session** and ships **no** daemon, scheduler, or
 overnight runner. To run the loop **unattended** — always-on, scheduled,
 queue-driven — you hand it to an orchestration **substrate**. The reference
-substrate is **NTM + MCP + managed-agents**; this skill covers the **NTM leg**: a
+substrate is **NTM + Agent Mail (`am`) + managed-agents**; this skill covers the **NTM leg**: a
 local Named Tmux Manager swarm of Claude/Codex agent panes. NTM is an adopted
 external tool (`ntm` on `PATH`), **not** an AgentOps-owned surface.
 
@@ -80,10 +80,10 @@ Run one tick at a time; take the first action whose trigger fires:
 - **Many review beads open, few closing** → flip to review-only, drain the backlog.
 - **Otherwise** → observe; do not nudge a healthy working pane.
 
-## Coordination (the MCP leg)
+## Coordination (the Agent Mail leg)
 
 - **Beads (`bd`)** — shared work queue + state source: `bd ready`, `bd update --claim`, `bd close`.
-- **MCP Agent Mail** (`ao mcp serve`) — cross-pane messages + **file reservations** (reserve before edit, release on commit).
+- **Agent Mail (`am`)** (its own daemon at `127.0.0.1:8765` — the `am` CLI, **not** an `ao` subcommand; old "MCP Agent Mail" name retired) — register with `am macros start-session`, then cross-pane messages + **file reservations** (reserve before edit, release on commit).
 - **Worktree-per-bead** is mandatory: no pane edits the shared checkout.
 
 ## Convergence + shutdown

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -246,7 +246,7 @@ These are how skills chain in practice:
 | **crank** | execution | Autonomous epic execution — parallel waves |
 | **discovery** | meta | Discovery phase orchestrator — brainstorm → search → research → plan → pre-mortem |
 | **swarm** | execution | Parallelize any skill — fresh context per agent |
-| **using-ntm** | execution | Run AgentOps loops out of session on an NTM tmux swarm — the NTM leg of the substrate |
+| **using-atm** | execution | Run AgentOps loops out of session on an ATM tmux swarm — the ATM leg of the substrate |
 | **rpi** | meta | Thin wrapper: /discovery → /crank → /validate with complexity classification and loop |
 | **evolve** | execution | Autonomous fitness-scored improvement loop |
 | **burndown** | execution | Bounded epic-completion loop — drive a finite target to all-merged, then stop |

--- a/skills/agent-native/references/codex-ntm-runtime.md
+++ b/skills/agent-native/references/codex-ntm-runtime.md
@@ -1,9 +1,9 @@
-# Codex/NTM runtime path — tmux pane swarms + agent-mail + direct `ao`
+# Codex/ATM runtime path — tmux pane swarms + agent-mail + direct `ao`
 
 > The Codex-side recipe behind the three-phase workflow in
 > [`../SKILL.md`](../SKILL.md). Same doctrine, different runtime: Codex
 > (gpt-5.3-codex) has **no Managed Agents API, no Workflow tool, no Task
-> subagent**. It orchestrates through **NTM** (tmux pane swarms + agent-mail) +
+> subagent**. It orchestrates through **ATM** (tmux pane swarms + agent-mail) +
 > skills + the `ao` CLI + `ssh bushido`. So the path is the same — bundle skills
 > → expose `ao` → gate via CI — but every Claude-only primitive is replaced by
 > its Codex equivalent.
@@ -12,17 +12,21 @@
 
 A **Codex** loop (or any non-Claude headless runtime) running out-of-session:
 
-- a Codex CLI loop driven by NTM tmux panes on bushido,
+- a Codex CLI loop driven by ATM tmux panes on bushido,
 - an OpenClaw / cron-scheduled Codex job, or
 - any agent that shells out rather than calling MCP tools.
 
+ATM is Bo's fork/alias of upstream NTM: `atm` points at
+`~/dev/ntm/dist/atm-darwin-arm64` and preserves the upstream `ntm` command
+surface while giving AgentOps a local name.
+
 ## The substitutions (Claude → Codex)
 
-| Claude primitive | Codex/NTM equivalent |
+| Claude primitive | Codex/ATM equivalent |
 |---|---|
-| Managed Agents API (`ao agent bundle --runtime managed`) | NTM swarm definition; load skills into the pane's instructions |
+| Managed Agents API (`ao agent bundle --runtime managed`) | ATM swarm definition; load skills into the pane's instructions |
 | `ao mcp serve` (MCP tool surface) | **direct `ao` shell calls** — Codex shells out, no MCP needed |
-| Workflow / Task subagent fan-out | tmux **pane swarm** (NTM), coordinated via **agent-mail** |
+| Workflow / Task subagent fan-out | tmux **pane swarm** (ATM), coordinated via **agent-mail** |
 | `PreToolUse` / `Stop` SDK adapter | not applicable — CI is the only gate |
 | in-loop MCP descriptor | a documented shell-tool spec invoking `ao <verb>` |
 
@@ -57,10 +61,10 @@ ssh bushido 'cd ~/dev/agentops && ao validate --gate --changes <files>'
 ```
 
 For a **whole out-of-session loop** (a swarm of panes, not a single pane),
-orchestration routes through the NTM substrate — `ao` does not own or wrap a
+orchestration routes through the ATM substrate — `ao` does not own or wrap a
 substrate; each pane dispatches its own `ao rpi` loop. See
-[`../../using-ntm/SKILL.md`](../../using-ntm/SKILL.md). Multi-pane coordination
-(file locks, inboxes, handoffs) uses **agent-mail**; see the `using-ntm` and
+[`../../using-atm/SKILL.md`](../../using-atm/SKILL.md). Multi-pane coordination
+(file locks, inboxes, handoffs) uses **agent-mail**; see the `using-atm` and
 `agent-mail` skills.
 
 **Checkpoint:** the pane can call `ao session bootstrap` + `ao inject` itself
@@ -70,12 +74,12 @@ before doing any work.
 
 Identical to the Claude path: the swarm's output (a PR branch) is gated by the
 **same** `agent-output-validate.yml` CI workflow running `ao validate` + the
-standards/scenario gates. Green CI is the merge gate. NTM panes do not get a
+standards/scenario gates. Green CI is the merge gate. ATM panes do not get a
 private gate — CI is the shared boundary for both runtimes.
 
 **Checkpoint:** the swarm's PR passed the identical CI gate as interactive work.
 
-## Boundaries (Codex/NTM-specific)
+## Boundaries (Codex/ATM-specific)
 
 - **No skill fork.** Panes load the `skills-codex/` artifact, which the converter
   keeps in parity with `skills/`. Editing the Codex body by hand without the

--- a/skills/automation-shape-routing/SKILL.md
+++ b/skills/automation-shape-routing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: automation-shape-routing
-description: 'Front door for agent automation — decide the SHAPE (Workflow vs NTM vs skill), then hand off. Triggers: "build automation", "convert skills to workflows", "which shape".'
+description: 'Front door for agent automation — decide the SHAPE (Workflow vs ATM vs skill), then hand off. Triggers: "build automation", "convert skills to workflows", "which shape".'
 practices:
 - hexagonal-architecture
 - team-topologies
@@ -22,14 +22,14 @@ context:
 metadata:
   tier: meta
   dependencies: []
-output_contract: 'a routing verdict — Workflow | NTM swarm | plain skill — with the deciding axis named'
+output_contract: 'a routing verdict — Workflow | ATM swarm | plain skill — with the deciding axis named'
 ---
 
-# Automation Shape Routing — Workflow vs NTM vs Skill
+# Automation Shape Routing — Workflow vs ATM vs Skill
 
 > **The trap this kills:** "I built a lot of skills; they should become
 > workflows." Mostly false. Most orchestration-looking skills are either
-> long-lived/human-attachable (stay NTM) or hard-sequential (stay skills). The
+> long-lived/human-attachable (stay ATM) or hard-sequential (stay skills). The
 > win is the routing rule, not a migration project.
 
 ## The three shapes
@@ -37,7 +37,7 @@ output_contract: 'a routing verdict — Workflow | NTM swarm | plain skill — w
 | Shape | What it is | Mechanism |
 |---|---|---|
 | **Workflow** | Deterministic, reproducible orchestration of subagents | Claude `Workflow` tool — `agent({schema})`, `parallel()`, `pipeline()`, `phase()`, loop-until-budget. In-process, headless, ~16 concurrent. |
-| **NTM swarm** | Long-lived, human-in-the-loop multi-agent run | `ntm` (the CLI) driven by [`/using-ntm`](../using-ntm/SKILL.md) — persistent tmux panes running whole `/rpi`/`/evolve` loops over a bead queue, with attach + nudge + kill/relaunch and mail/locks coordination. |
+| **ATM swarm** | Long-lived, human-in-the-loop multi-agent run | `atm` (the CLI) driven by [`/using-atm`](../using-atm/SKILL.md) — persistent tmux panes running whole `/rpi`/`/evolve` loops over a bead queue, with attach + nudge + kill/relaunch and mail/locks coordination. |
 | **Plain skill** | One model reasoning through a procedure or knowledge | A single `SKILL.md`. No fan-out, or a strictly sequential edit-loop. |
 
 ## The decision rule (three axes)
@@ -49,14 +49,14 @@ Ask in order:
 2. **Must a human attach and steer mid-run?** Or does it run for *hours*, do
    open-ended *file edits*, juggle a *fluid population* (rate limits, kill/
    relaunch, prompt-cache rounds), or relay between *cross-model* panes? — if
-   **yes** → **NTM swarm**.
+   **yes** → **ATM swarm**.
 3. Otherwise — fixed DAG, agents return **structured JSON** (not free-form edits
    needing review), no attach needed, you want it **reproducible + headless** →
    **Workflow**.
 
 **One-line litmus:**
 > deterministic DAG + structured JSON + no human-attach + headless-wanted → **Workflow**
-> long-lived + attachable + open-ended file edits / fluid population → **NTM**
+> long-lived + attachable + open-ended file edits / fluid population → **ATM**
 > no fan-out, or hard-sequential edit loop → **plain skill**
 
 ## Spike-validated nuances (2026-05-29)
@@ -65,8 +65,8 @@ A live three-legged spike (`~/dev/agentops-3cat-spike/`) measured the same task 
 all three backends. Two findings refine the rule:
 
 1. **The primary axis is control-plane vs in-session, not "parallel vs serial."**
-   **NTM is a control-plane** that *runs Claude/Codex/Gemini as panes* — it is not a
-   peer of the native runtimes, it is the supervisor tier above them. Choose NTM when
+   **ATM is a control-plane** that *runs Claude/Codex/Gemini as panes* — it is not a
+   peer of the native runtimes, it is the supervisor tier above them. Choose ATM when
    you need the control plane (attach/steer, persistence, multi-vendor); choose
    in-session native (Workflow/Task) when you don't.
 2. **Parallel buys quality/independence, NOT wall-clock — at small N.** Measured: a
@@ -77,7 +77,7 @@ all three backends. Two findings refine the rule:
    want *independent verification / fresh eyes*, not for speed. For speed, you need
    large N **and** no barrier — use `pipeline()` (no barrier), not `parallel()`.
 
-Degradation (NTM → Claude-native → beads floor) is governed by the
+Degradation (ATM → Claude-native → beads floor) is governed by the
 `OrchestrationPort` selector; opt out entirely with `AGENTOPS_ORCHESTRATION=off` →
 beads floor, which always works.
 
@@ -89,8 +89,8 @@ beads floor, which always works.
   *Exception:* it graduates to a `loop-until-budget` Workflow only once each step
   returns **structured output** instead of free-form edits, and you want it
   headless/reproducible.
-- **Don't NTM-ify a clean fan-out, and don't Workflow-ify an attach-and-steer
-  run.** The Workflow tool is in-process and cannot be tmux-attached; NTM is
+- **Don't ATM-ify a clean fan-out, and don't Workflow-ify an attach-and-steer
+  run.** The Workflow tool is in-process and cannot be tmux-attached; ATM is
   built for exactly the live-steering Workflow can't do. Picking wrong fights the
   tool the whole way.
 
@@ -100,8 +100,8 @@ beads floor, which always works.
 `council` (N judges → consensus — near-trivial port), the **planning half** of
 `rpi`, judge/refutation panels, any "fan out N analyses → triangulate" task.
 
-**→ Stay NTM** (long-lived, attachable, open-ended edits, fluid population):
-the `*-with-ntm` family (hypothesis research, cross-model review swarms, browser
+**→ Stay ATM** (long-lived, attachable, open-ended edits, fluid population):
+the `*-with-atm` family (hypothesis research, cross-model review swarms, browser
 testing), plus `swarm`/`crank` in full epic-execution mode — they touch the
 working tree and need wave-validity gating + human review.
 
@@ -129,7 +129,7 @@ decided, hand off:
 |---|---|---|
 | **plain skill** | `skill-builder` | Scaffold a new `SKILL.md` against the unified template → then `skill-auditor` → `heal-skill`. |
 | **Workflow** | `workflow-builder` | Scaffold a new `.claude/workflows/*.js` from the operating-loop.js template. |
-| **NTM swarm** | `ntm` + [`/using-ntm`](../using-ntm/SKILL.md) | Stand up + tend an NTM swarm running AgentOps loops (`/rpi`/`/evolve`) over a bead queue. |
+| **ATM swarm** | `atm` + [`/using-atm`](../using-atm/SKILL.md) | Stand up + tend an ATM swarm running AgentOps loops (`/rpi`/`/evolve`) over a bead queue. |
 
 State the verdict and the deciding axis in one line, then invoke the chosen
 builder. Do not scaffold here.

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-07T20:37:01Z",
+  "generated_at": "2026-06-08T01:20:42Z",
   "skill_count": 158,
   "skills": [
     {
@@ -218,7 +218,7 @@
     },
     {
       "name": "automation-shape-routing",
-      "description": "Front door for agent automation — decide the SHAPE (Workflow vs NTM vs skill), then hand off. Triggers: \"build automation\", \"convert skills to workflows\", \"which shape\".",
+      "description": "Front door for agent automation — decide the SHAPE (Workflow vs ATM vs skill), then hand off. Triggers: \"build automation\", \"convert skills to workflows\", \"which shape\".",
       "hexagonal_role": "supporting",
       "user_invocable": false,
       "consumes": [],
@@ -3203,8 +3203,8 @@
       ],
       "context_rel": [
         {
-          "kind": "customer-of",
-          "with": "provenance"
+          "kind": "shared-kernel",
+          "with": "curate"
         }
       ],
       "references_count": 3,
@@ -3243,8 +3243,8 @@
       "codex_override_present": true
     },
     {
-      "name": "using-ntm",
-      "description": "Use NTM as the out-of-session substrate: spawn Claude/Codex panes running /rpi and /evolve over a bead queue, then tend the swarm to convergence.",
+      "name": "using-atm",
+      "description": "Use ATM as the out-of-session substrate: spawn Claude/Codex panes running /rpi and /evolve over a bead queue, then tend the swarm to convergence.",
       "hexagonal_role": "supporting",
       "user_invocable": true,
       "consumes": [],

--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -209,6 +209,7 @@ See [references/multi-agent-architecture.md](references/multi-agent-architecture
 - `skills/pre-mortem/SKILL.md` — Plan validation (uses `--preset=plan-review`, always 3 judges)
 - `skills/post-mortem/SKILL.md` — Work wrap-up (uses `--preset=retrospective`, always 3 judges + retro)
 - `skills/swarm/SKILL.md` — Multi-agent orchestration
+- `skills/using-atm/SKILL.md` — Out-of-session ATM substrate for long-running multi-agent review swarms
 - `skills/standards/SKILL.md` — Language-specific coding standards
 - `skills/research/SKILL.md` — Codebase exploration (complementary to `--mode=brainstorm --focus=research`)
 

--- a/skills/crank/SKILL.md
+++ b/skills/crank/SKILL.md
@@ -195,6 +195,10 @@ If unsure whether a step is orchestrator-owned or delegatable, the default is **
 
 Crank runs as an isolated phase-2 execution context — discovery and validation are sealed off from this skill. See [references/isolation-contract.md](references/isolation-contract.md) for the four-lever enforcement model and the compression patterns `scripts/check-skill-isolation.sh` flags. See [references/best-practices.md](references/best-practices.md) for the lifecycle principle + anti-pattern citation table (cite by number; do not duplicate body content).
 
+## Related skills
+
+- [`/using-atm`](../using-atm/SKILL.md) — out-of-session ATM substrate for long-running `/crank` waves over a bead queue.
+
 ## Reference Documents
 
 - [references/crank.feature](references/crank.feature) — Executable spec: wave-validity hard gate, FIRE loop, mandatory completion marker, 50-wave cap (soc-qk4b.2)

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -58,10 +58,6 @@ real blocked state exhausts retries. Read
 [references/autonomous-execution.md](references/autonomous-execution.md) when
 you need the full autonomy contract.
 
-When an external executor fails but the code surface may still be valid, read
-[references/codex-executor.md](references/codex-executor.md) and recover through
-Codex direct checks before declaring a source-level regression.
-
 ## Loop position
 
 `/rpi` is the orchestrator across **every move** of the [operating loop](../../docs/architecture/operating-loop.md): BDD intent → vertical slices → conflict-free wave → bead acceptance → evidence + learning capture. It delegates each move to the skill that owns it (`/discovery`, `/plan`, `/crank`, `/validate`, `/forge`/`/post-mortem`), and enforces three loop-level invariants:
@@ -229,6 +225,10 @@ interactive, loop, and artifact-mode examples.
 | Validation FAIL | Re-crank with findings, then re-validate, up to 3 total attempts |
 | Packet shape unclear | Read [references/phase-data-contracts.md](references/phase-data-contracts.md) |
 | External executor fails | Read [references/codex-executor.md](references/codex-executor.md), run direct Codex validation, and only create follow-up work for reproducible source failures |
+
+## Related skills
+
+- [`/using-atm`](../using-atm/SKILL.md) — out-of-session ATM substrate for running whole `/rpi` loops over a bead queue.
 
 ## Reference Documents
 

--- a/skills/storage-watchdog-ops/SKILL.md
+++ b/skills/storage-watchdog-ops/SKILL.md
@@ -9,14 +9,16 @@ practices:
 - testable-architecture
 hexagonal_role: supporting
 consumes:
-- incident-symptom
-- host-state
-- daemon-config
+- error-reports
+- runtime-metrics
+- runtime-configuration
 produces:
 - triage-finding
 - remediation-action
 - escalation-note
-context_rel: []
+context_rel:
+- kind: partnership
+  with: system-performance-remediation
 skill_api_version: 1
 user-invocable: false
 context:

--- a/skills/swarm/SKILL.md
+++ b/skills/swarm/SKILL.md
@@ -309,6 +309,10 @@ Read [references/troubleshooting.md](references/troubleshooting.md) for full dia
 | gc backend detected but workers unresponsive | [references/troubleshooting.md](references/troubleshooting.md) |
 | Tasks assigned but workers never spawn | [references/troubleshooting.md](references/troubleshooting.md) |
 
+## Related skills
+
+- [`/using-atm`](../using-atm/SKILL.md) — out-of-session ATM substrate when a swarm needs persistent panes and human attach/steer.
+
 ## Reference Documents
 
 - [references/shared-checkout-discipline.md](references/shared-checkout-discipline.md)

--- a/skills/using-agentops/SKILL.md
+++ b/skills/using-agentops/SKILL.md
@@ -145,7 +145,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/release` | Pre-flight, changelog, version bumps, tag |
 | `/crank` | Autonomous epic loop (uses swarm for each wave) |
 | `/swarm` | Fresh-context parallel execution (Ralph pattern) |
-| `/using-ntm` | Run AgentOps loops out of session on an NTM tmux swarm (the NTM leg of the substrate) |
+| `/using-atm` | Run AgentOps loops out of session on an ATM tmux swarm (the ATM leg of the substrate) |
 | `evolve` | Goal-driven fitness-scored improvement loop |
 | `/burndown` | Bounded epic-completion loop — drive a finite target to all-merged, then stop |
 | `/eval-outcomes` | Grade via Outcomes as a holdout-safe projection of the locked eval substrate — one bar, many runtimes |
@@ -171,7 +171,7 @@ These are the skills every user needs first. Everything else is available when y
 | `/scenario` | Author and manage holdout scenarios for behavioral validation |
 | `/skill-auditor` | Two-pass audit of an existing SKILL.md against the unified template (15 checks) |
 | `/skill-builder` | Scaffold or absorb new SKILL.md files against the unified template |
-| `/automation-shape-routing` | Front door for building agent automation — decide the SHAPE (Workflow vs NTM swarm vs plain skill), then hand off to the right builder |
+| `/automation-shape-routing` | Front door for building agent automation — decide the SHAPE (Workflow vs ATM swarm vs plain skill), then hand off to the right builder |
 | `/workflow-builder` | Scaffold a new Claude Workflow script (`.claude/workflows/*.js`) — deterministic multi-agent orchestration |
 | `/agent-native` | Make out-of-session agents AgentOps-native via skills + ao CLI + CI, not hooks |
 
@@ -212,7 +212,7 @@ AgentOps has several runtime modes. Do not assume hook automation exists everywh
 
 | Mode | When it applies | Start path | Closeout path | Guarantees |
 |------|-----------------|------------|---------------|------------|
-| `substrate` (out-of-session) | A swappable orchestration substrate available out-of-session: an NTM tmux swarm, MCP (`ao mcp serve`), or managed-agents (`ao agent`) | The operator or a lead agent runs `bd ready` and dispatches a whole loop per bead — an agent that runs the `rpi` skill; cron / managed triggers run maintenance | The substrate owns the merge gate (CI-green is the signal) and triggers the knowledge-flywheel feedback | The substrate orchestrates *whole* `rpi`/`evolve` loops (each an agent running the skill) — it never sees the loop's insides; the seam is substrate → agent-running-the-skill. There is no in-CLI `runtime=gc` executor. See [agent-native](../agent-native/SKILL.md) and [docs/3.0.md](https://github.com/boshu2/agentops/blob/main/docs/3.0.md). |
+| `substrate` (out-of-session) | A swappable orchestration substrate available out-of-session: an ATM tmux swarm, MCP (`ao mcp serve`), or managed-agents (`ao agent`) | The operator or a lead agent runs `bd ready` and dispatches a whole loop per bead — an agent that runs the `rpi` skill; cron / managed triggers run maintenance | The substrate owns the merge gate (CI-green is the signal) and triggers the knowledge-flywheel feedback | The substrate orchestrates *whole* `rpi`/`evolve` loops (each an agent running the skill) — it never sees the loop's insides; the seam is substrate → agent-running-the-skill. There is no in-CLI `runtime=gc` executor. See [agent-native](../agent-native/SKILL.md) and [docs/3.0.md](https://github.com/boshu2/agentops/blob/main/docs/3.0.md). |
 | `hook-capable` | Claude/OpenCode with lifecycle hooks installed (no gc) | Runtime hook or `ao inject` / `ao lookup` | Runtime hook or `ao forge transcript` + `ao flywheel close-loop` | Automatic startup/context injection and session-end maintenance when hooks are installed |
 | `codex-native-hooks` | Codex CLI v0.115.0+ with native hook support (March 2026) | Runtime hooks (same as hook-capable) | Runtime hooks (same as hook-capable) | Native lifecycle hooks — same guarantees as hook-capable mode |
 | `codex-hookless-fallback` | Codex Desktop / Codex CLI pre-v0.115.0 without hook surfaces | `ao codex start` | `ao codex stop` | Explicit startup context, citation tracking, transcript fallback, and close-loop metrics without hooks |

--- a/skills/using-atm/SKILL.md
+++ b/skills/using-atm/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: using-ntm
-description: 'Use NTM as the out-of-session substrate: spawn Claude/Codex panes running /rpi and /evolve over a bead queue, then tend the swarm to convergence.'
+name: using-atm
+description: 'Use ATM as the out-of-session substrate: spawn Claude/Codex panes running /rpi and /evolve over a bead queue, then tend the swarm to convergence.'
 practices:
 - team-topologies
 - agile-manifesto
@@ -26,41 +26,43 @@ context:
 metadata:
   tier: orchestration
   dependencies: []
-output_contract: 'stdout: NTM-substrate operating guide'
+output_contract: 'stdout: ATM-substrate operating guide'
 ---
 
-# Using NTM as the Out-of-Session Substrate
+# Using ATM as the Out-of-Session Substrate
 
 AgentOps 3.0 runs its loops **in session** and ships **no** daemon, scheduler, or
 overnight runner. To run the loop **unattended** — always-on, scheduled,
 queue-driven — you hand it to an orchestration **substrate**. The reference
-substrate is **NTM + Agent Mail (`am`) + managed-agents**; this skill covers the **NTM leg**:
+substrate is **ATM + Agent Mail (`am`) + managed-agents**; this skill covers the **ATM leg**:
 a local [Named Tmux Manager](https://github.com/) swarm of Claude/Codex agent
-panes. NTM is an adopted external tool (`ntm` on `PATH`), **not** an
+panes. ATM is an adopted external tool (`atm` on `PATH`), **not** an
 AgentOps-owned surface — AgentOps adopts it, it does not vendor it.
+ATM is Bo's fork/alias of upstream NTM: `atm` points at
+`~/dev/ntm/dist/atm-darwin-arm64` and keeps the upstream `ntm` command surface.
 
 > **Skills are the runtime, not the CLI.** The substrate dispatches a *whole
 > loop* by spawning an agent that **runs the `rpi` or `evolve` skill** — it
 > does **not** shell out to retired RPI/evolve CLI subprocesses. The loop
 > lives as a skill an agent executes. The seam is
-> **NTM pane → agent → `/rpi <bead>` skill**, one bead dispatched as one
+> **ATM pane → agent → `/rpi <bead>` skill**, one bead dispatched as one
 > invocable unit.
 
 ## When to use this skill / when to skip
 
 **Use it when:** you want a bead queue worked unattended out of session; you're
-standing up or tending an NTM swarm that runs AgentOps loops; a pane is stuck,
+standing up or tending an ATM swarm that runs AgentOps loops; a pane is stuck,
 rate-limited, or wedged; you need to know whether the swarm has converged.
 
 **Skip it when:** the work fits a single in-session run (just run `rpi` or
 `evolve` yourself); you want in-session parallel fan-out across worktrees (use
 [`/swarm`](../swarm/SKILL.md)); you're choosing between automation shapes at all
 (start at [`/automation-shape-routing`](../automation-shape-routing/SKILL.md),
-which routes Workflow vs NTM swarm vs plain skill).
+which routes Workflow vs ATM swarm vs plain skill).
 
-This skill does **not** re-document the full `ntm` command surface — run
-`ntm help` for that. It covers the **AgentOps substrate contract**: how to
-dispatch and tend AgentOps loops on an NTM swarm.
+This skill does **not** re-document the full `atm` command surface — run
+`atm help` for that. It covers the **AgentOps substrate contract**: how to
+dispatch and tend AgentOps loops on an ATM swarm.
 
 ## The dispatch contract
 
@@ -83,23 +85,23 @@ dispatch and tend AgentOps loops on an NTM swarm.
 
 ```bash
 # 1. Spawn a swarm of agent panes against the repo (2 Claude + 1 Codex worker).
-ntm spawn agentops --cc=2 --cod=1
+atm spawn agentops --cc=2 --cod=1
 
 # 2. Dispatch a whole loop to a pane — the SKILL, not a CLI subprocess.
-ntm send agentops --pane=1 "/rpi ag-1234 --auto"
-ntm send agentops --pane=2 "/evolve --beads-only --auto"
+atm send agentops --pane=1 "/rpi ag-1234 --auto"
+atm send agentops --pane=2 "/evolve --beads-only --auto"
 
 # 3. Watch / attach.
-ntm activity agentops          # per-pane agent state
-ntm attach agentops            # drop into the swarm
+atm activity agentops          # per-pane agent state
+atm attach agentops            # drop into the swarm
 
 # 4. Health + dependencies (run before a long unattended session).
-ntm doctor                     # validate the NTM ecosystem
-ntm deps                       # required agent CLIs present
+atm doctor                     # validate the ATM ecosystem
+atm deps                       # required agent CLIs present
 ```
 
 Scheduled cadence (e.g. a nightly `evolve` pass) is driven by host-OS timing (a
-systemd user timer or cron) that runs `ntm send … "/evolve --auto"`, or by a
+systemd user timer or cron) that runs `atm send … "/evolve --auto"`, or by a
 managed-agent driver — **not** an AgentOps daemon.
 
 ## Tending the swarm (operator loop)
@@ -120,7 +122,7 @@ Run one tick at a time; take the first action whose trigger fires:
 
 ## Coordination (the Agent Mail leg)
 
-NTM panes coordinate through the other substrate legs, not bespoke glue:
+ATM panes coordinate through the other substrate legs, not bespoke glue:
 
 - **Beads (`bd`)** is the shared work queue and the source of truth for state —
   `bd ready` to pick, `bd update --claim` to claim, `bd close` when merged.
@@ -135,8 +137,8 @@ NTM panes coordinate through the other substrate legs, not bespoke glue:
 ## Convergence + shutdown
 
 The swarm is done when: `bd ready` is empty, no pane has an in-flight bead, and
-the last few CI runs are green. Confirm with `ntm activity` (all panes idle) and
-`bd ready` (empty) before tearing down with `ntm kill <session>`. Don't shut down
+the last few CI runs are green. Confirm with `atm activity` (all panes idle) and
+`bd ready` (empty) before tearing down with `atm kill <session>`. Don't shut down
 on a transient quiet patch — a rate-limited pane also looks idle.
 
 ## Anti-patterns
@@ -144,15 +146,15 @@ on a transient quiet patch — a rate-limited pane also looks idle.
 - ❌ **Shelling out to retired RPI/evolve CLI subprocesses.**
   Dispatch the `rpi` / `evolve` **skill** to an agent pane instead.
 - ❌ **Decomposing the loop into substrate steps.** Dispatch the whole loop as
-  one invocable unit; never re-express `rpi`'s phases as NTM-side orchestration.
+  one invocable unit; never re-express `rpi`'s phases as ATM-side orchestration.
 - ❌ **Editing the shared checkout from a pane.** Worktree-per-bead, always.
-- ❌ **Treating NTM as AgentOps-owned.** It is an adopted external substrate; a
+- ❌ **Treating ATM as AgentOps-owned.** It is an adopted external substrate; a
   managed-agents driver (`ao agent`) or a plain in-session run are equally valid
   legs. Choose via [`/automation-shape-routing`](../automation-shape-routing/SKILL.md).
 
 ## Related skills
 
-- [`/automation-shape-routing`](../automation-shape-routing/SKILL.md) — decide Workflow vs NTM swarm vs plain skill *before* standing up a swarm.
+- [`/automation-shape-routing`](../automation-shape-routing/SKILL.md) — decide Workflow vs ATM swarm vs plain skill *before* standing up a swarm.
 - [`/swarm`](../swarm/SKILL.md) — in-session parallel fan-out across worktrees (the in-session sibling of this out-of-session substrate).
 - [`/agent-native`](../agent-native/SKILL.md) — `ao agent bundle` produces the loop definition a managed-agents substrate runs (the managed-agents leg).
 - [`rpi`](../rpi/SKILL.md) · [`evolve`](../evolve/SKILL.md) — the loops the substrate dispatches.

--- a/skills/using-ntm/SKILL.md
+++ b/skills/using-ntm/SKILL.md
@@ -34,7 +34,7 @@ output_contract: 'stdout: NTM-substrate operating guide'
 AgentOps 3.0 runs its loops **in session** and ships **no** daemon, scheduler, or
 overnight runner. To run the loop **unattended** — always-on, scheduled,
 queue-driven — you hand it to an orchestration **substrate**. The reference
-substrate is **NTM + MCP + managed-agents**; this skill covers the **NTM leg**:
+substrate is **NTM + Agent Mail (`am`) + managed-agents**; this skill covers the **NTM leg**:
 a local [Named Tmux Manager](https://github.com/) swarm of Claude/Codex agent
 panes. NTM is an adopted external tool (`ntm` on `PATH`), **not** an
 AgentOps-owned surface — AgentOps adopts it, it does not vendor it.
@@ -118,16 +118,17 @@ Run one tick at a time; take the first action whose trigger fires:
   drain the backlog before taking new feature work.
 - **Otherwise** → observe; do not nudge a healthy working pane.
 
-## Coordination (the MCP leg)
+## Coordination (the Agent Mail leg)
 
 NTM panes coordinate through the other substrate legs, not bespoke glue:
 
 - **Beads (`bd`)** is the shared work queue and the source of truth for state —
   `bd ready` to pick, `bd update --claim` to claim, `bd close` when merged.
-- **MCP Agent Mail** (`ao mcp serve` exposes the AgentOps tool surface across the
-  seam) carries cross-pane messages and **file reservations** — the swarm's
-  defense against two panes editing the same path. Reserve before editing;
-  release on commit.
+- **Agent Mail (`am`)** (its own daemon at `127.0.0.1:8765` — the `am` CLI,
+  **not** an `ao` subcommand; the old "MCP Agent Mail" name is retired) carries cross-pane messages and
+  **file reservations** — the swarm's defense against two panes editing the same
+  path. Each pane registers once with `am macros start-session`, reserves before
+  editing (`am file_reservations reserve`), and releases on commit.
 - **Worktree-per-bead** is mandatory: no pane edits the shared checkout. See
   [../swarm/references/shared-checkout-discipline.md](../swarm/references/shared-checkout-discipline.md).
 


### PR DESCRIPTION
## Summary
- Rename the canonical and Codex `using-ntm` skill to `using-atm`.
- Update inbound references, catalogs, context-map/disposition/domain docs, and rpi/crank/swarm/council related-skill links.
- Sync Codex generated metadata and preserve the upstream NTM note for the ATM fork/alias surface.
- Repair post-`cp-z1s5` gate drift exposed by this PR: regenerate `registry.json`, wire `storage-watchdog-ops` into skill-flow, refresh context-map/Codex metadata, and remove its stale standalone allowlist entry.

## Validation
- pre-push fast/head on `95a8e9d35`: 34 checks, 33 pass, 1 warn, 0 fail; warn: `always.retrieval-manifest-paths`
- full local Go gate: `WORKTREE_DISPOSITION_CI_SKIP=1 /tmp/ao-cp-v8m2 gate check --full --json --workflow-coverage` => 72 total, 71 pass, 1 advisory warn, 0 fail
- `scripts/regen-all.sh --check`
- `bash scripts/validate-skill-flow.sh`
- `bash scripts/validate-skill-schema.sh`
- `bash scripts/validate-codex-generated-artifacts.sh --scope worktree`
- `bash scripts/validate-codex-api-conformance.sh`
- `bash scripts/validate-codex-runtime-sections.sh`
- `bash scripts/validate-codex-override-coverage.sh`

## Notes
- Deployed local Codex/Claude cache proof for `using-atm` was performed before push.
- Unrelated local dirty files in the original checkout were intentionally excluded: `skills/cass/scripts/validate.sh`, `skills/ru-multi-repo-workflow/scripts/validate.sh`, `wt-ag-qidx/`.
- `cp-z1s5` is closed on main at `e0932310d`; this PR carries the small gate-drift repair required to make that main state validate under PR CI.