### PR TITLE
feat(skills): add Use-when triggers to cp-xvt3 batch 2 skills

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -12,7 +12,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `artifact-clarity-pass` — Use when removing generic filler from code, docs, or handoffs while preserving every load-bearing fact. Triggers:
 - `brainstorm` — Separate goals from implementation.
 - `bug-hunt` — Investigate bugs and root causes.
-- `burndown` — Drive a finite epic set to all-merged, then stop.
+- `burndown` — Drive a finite epic set to all-merged, then stop. Use when finishing a specific list of tasks, burning down a backlog epic, or executing a bounded set of beads until done.
 - `complexity` — Find focused refactor hotspots.
 - `council` — Run multi-judge consensus. Use when: an irreversible or high-stakes decision needs independent judges before committing — architecture forks, one-way doors, scoring options.
 - `crank` — Execute epics through waves.
@@ -54,7 +54,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `codex-goals` — Use when using Codex Goals to define an objective once and let Codex iterate until done. Triggers:
 - `implement` — Implement one tracked issue.
 - `inject` — Load relevant .agents context.
-- `operating-loop-workflow` — Install and run the operating-loop multi-agent Workflow (the seven-move loop) for AgentOps plugin users.
+- `operating-loop-workflow` — Install and run the operating-loop multi-agent Workflow (the seven-move loop) for AgentOps plugin users. Use when installing the seven-move workflow, running the operating-loop script, or orchestrating multi-agent tasks via Workflow tool.
 - `performance-profile-triage` — Use when investigating slowness with baselines, profiler evidence, and ranked bottlenecks. Triggers:
 - `pr-implement` — Implement a scoped OSS PR.
 - `pr-prep` — Prepare PR commits and body.
@@ -64,14 +64,14 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `research` — Explore and write findings.
 - `review` — Review diffs for risk, find mocks, scan for bugs, audit codebases. Use when: reviewing a diff/PR for bugs and risk, hunting mocks/stubs/placeholders, or auditing for quality.
 - `session-bootstrap` — Universal init prompt; every agent spawned into an AgentOps repo runs ao session bootstrap first. Use when starting or onboarding a fresh agent session in an AgentOps repo, or defining the first-turn init prompt.
-- `ship-loop` — Bot-paired fast-lane cycle for coherent-arc internal PRs (one closable bead or small-epic slice): claim → test → impl → pre-push → push → squash auto-merge → close.
+- `ship-loop` — Bot-paired fast-lane cycle for coherent-arc internal PRs (one closable bead or small-epic slice): claim → test → impl → pre-push → push → squash auto-merge → close. Use when shipping a fast-lane internal PR, landing a small fix, or closing a single harvested bead.
 - `spec-reliability-implementation` — Use when implementing a written spec into a reliable service with acceptance examples and observability. Triggers:
 - `status` — Show AgentOps work status.
 - `validate` — Produce PASS/WARN/FAIL verdicts for artifacts, plans, code, PRs, or gates. Use when: you need a structured verdict on an artifact, plan, code, PR, or CI gate before proceeding.
 
 ### driven-adapter
 
-- `agy-mcp-plugins` — Wire MCP servers and AgentOps plugin bundles into the AGY image with least-privilege tool access and rollback evidence.
+- `agy-mcp-plugins` — Wire MCP servers and AgentOps plugin bundles into the AGY image with least-privilege tool access and rollback evidence. Use when setting up AGY tool surfaces, wiring new MCP servers, or distributing AgentOps plugins.
 - `beads` — Track issues with bd/br, triage with bv, and convert plans to beads.
 - `codex-mcp-plugins` — Use when wiring MCP servers or plugins into Codex CLI and the AgentOps Codex skill bundle. Triggers:
 - `dependency-update-safety` — Use when updating dependencies safely with changelog review, small batches, tests, and rollback. Triggers:
@@ -84,10 +84,10 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 
 - `agent-mail` — Use when coordinating agents with Agent Mail locks, inboxes, threads, and conflict-prevention handoffs.
 - `agent-native` — Make an out-of-session Claude (Managed Agent or Agent SDK loop) AgentOps-native via skills plus the ao CLI and CI, not hooks. Use when wiring a Managed Agent or Agent SDK loop to AgentOps, or making an out-of-session agent AgentOps-native.
-- `agy-headless-evidence` — Run AGY headlessly via scheduled ticks or `agy -p`, capturing agentapi JSONL evidence for validation.
+- `agy-headless-evidence` — Run AGY headlessly via scheduled ticks or `agy -p`, capturing agentapi JSONL evidence for validation. Use when running AGY in an automated loop, testing headless execution, or capturing agent event streams for validation.
 - `agy-project-worktree-permissions` — Prove scoped project/worktree isolation on the AGY (Antigravity) image before a bead can join the quorum: pin each role to a non-overlapping --add-dir scope, a permission tier matched to author vs judge, and the dcg guard, then capture the isolation evidence. Triggers: agy, worktree, permissions, project.
 - `agy-sidecar-scheduled-tick` — Run a recurring AgentOps loop tick on AGY via an Antigravity sidecar (schedule builtin + agentapi), capturing agentapi runtime evidence a validator can read back. Triggers: agy, sidecar, schedule, agentapi, AGY scheduled tick, Antigravity sidecar, recurring AGY loop.
-- `autodev` — Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer Evolve and Factory read each tick, not a loop itself.
+- `autodev` — Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer Evolve and Factory read each tick, not a loop itself. Use when defining the autonomous improvement loop rules, repairing PROGRAM.md, or setting boundaries for evolve.
 - `automation-loop-hardening` — Use when turning repeated manual operations into safer, observable, reusable automation loops. Triggers:
 - `automation-shape-routing` — Front door for agent automation — decide the SHAPE (Workflow vs ATM vs skill), then hand off. Triggers: "build automation", "convert skills to workflows", "which shape".
 - `bead-completion-audit` — Use when auditing closed beads for real shipped evidence, acceptance proof, and truthful closeout. Triggers:
@@ -97,7 +97,7 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `beads-workflow` — Use when converting markdown plans into br beads with dependencies for implementation or swarm execution.
 - `behavior-preserving-simplification` — Use when simplifying code, reducing duplication, or clarifying flow while preserving behavior with tests. Triggers:
 - `caam` — Use when switching AI coding CLI accounts quickly to recover from subscription rate limits or OAuth friction.
-- `casr` — Cross Agent Session Resumer. Convert and resume sessions across Claude Code, Codex, Gemini, and other providers.
+- `casr` — Cross Agent Session Resumer. Convert and resume sessions across Claude Code, Codex, Gemini, and other providers. Use when switching AI agent providers mid-session or migrating an active chat history to a new tool.
 - `cass` — Mine past agent sessions for working prompts, decisions, and patterns. Use when "what did I ask?", "find that prompt", session archaeology, or agent history.
 - `cass-memory` — Use when starting non-trivial work, mining lessons, or preventing repeated mistakes with cm procedural memory.
 - `cc-hooks` — Configure Claude Code hooks for PreToolUse, PostToolUse, Stop, Notification. Use when blocking commands, auto-formatting, custom permissions, or writing hooks.
@@ -163,14 +163,14 @@ and [CDLC](https://github.com/boshu2/agentops/blob/main/docs/cdlc.md) for the ar
 - `sbh` — Disk-pressure defense for AI coding workloads. Use when: disk full, low space, ballast, cleanup, scan artifacts, emergency, sbh daemon, sbh status.
 - `scaffold` — Create project, component, or boilerplate scaffolds. Use when starting a new project, module, or component, generating boilerplate, or stamping a repeatable file structure.
 - `scenario` — Manage holdout scenarios.
-- `skill-auditor` — Audit an existing SKILL.md against the unified AgentOps template (15 checks). Triggers: "audit skill", "skill quality review", "is this skill ready".
+- `skill-auditor` — Audit an existing SKILL.md against the unified AgentOps template (15 checks). Use when running a skill quality review, checking if a skill is ready, or auditing skill template compliance.
 - `skill-builder` — Scaffold or absorb new SKILL.md files against the unified AgentOps template. Triggers: "create a skill", "scaffold skill", "absorb external skill", "new skill".
 - `ssh` — Use when configuring SSH access, keys, tunnels, host diagnostics, or safe remote command workflows.
 - `stash-hygiene-sweep` — Use when auditing git stashes, deciding keep/drop/apply/archive, and clearing confirmed stale entries. Triggers:
 - `storage-watchdog-ops` — Use when operating or remediating the ACFS storage watchdog daemon — checking disk pressure, reading its log, deciding whether automatic Rust target/ cleanup ran, and intervening safely when the disk is still under pressure. Triggers: storage, watchdog, disk, target, disk pressure, free space, target cleanup, acfs-storage-watchdog, disk full
 - `swarm` — Dispatch parallel agents.
 - `system-performance-remediation` — Use when restoring machine responsiveness from high CPU, memory, IO, cache, or runaway process pressure.
-- `system-tuning` — Restore system responsiveness via safe, ordered process cleanup and agent-swarm hygiene.
+- `system-tuning` — Restore system responsiveness via safe, ordered process cleanup and agent-swarm hygiene. Use when the system is slow, load average is high, or cleaning up stuck agents and background processes.
 - `test` — Generate tests and coverage plans.
 - `trace` — Trace decisions through artifacts.
 - `ubs` — Use when reviewing code with UBS for bugs, security issues, AI-generated quality, or pre-commit checks.

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-06-08T02:50:25Z",
+  "generated_at": "2026-06-08T03:16:50Z",
   "summary": {
     "skills": 162,
     "hooks": 0,
@@ -2444,7 +2444,7 @@
       "bounded_context": "BC3",
       "hex_role": "supporting",
       "tier": "execution",
-      "purpose": "Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer Evolve and Factory read each tick, not a loop itself.",
+      "purpose": "Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer Evolve and Factory read each tick, not a loop itself. Use when defining the autonomous improvement loop rules, repairing PROGRAM.md, or setting boundaries for evolve.",
       "status": "active",
       "disposition": "refactor",
       "consumes": [
@@ -2712,7 +2712,7 @@
       "bounded_context": "BC3",
       "hex_role": "domain",
       "tier": "execution",
-      "purpose": "Drive a finite epic set to all-merged, then stop.",
+      "purpose": "Drive a finite epic set to all-merged, then stop. Use when finishing a specific list of tasks, burning down a backlog epic, or executing a bounded set of beads until done.",
       "status": "active",
       "disposition": "keep",
       "consumes": [
@@ -4142,7 +4142,7 @@
       "bounded_context": "BC3",
       "hex_role": "driving-adapter",
       "tier": "execution",
-      "purpose": "Install and run the operating-loop multi-agent Workflow (the seven-move loop) for AgentOps plugin users.",
+      "purpose": "Install and run the operating-loop multi-agent Workflow (the seven-move loop) for AgentOps plugin users. Use when installing the seven-move workflow, running the operating-loop script, or orchestrating multi-agent tasks via Workflow tool.",
       "status": "active",
       "disposition": "keep",
       "consumes": [],
@@ -5148,7 +5148,7 @@
       "bounded_context": "BC5",
       "hex_role": "driving-adapter",
       "tier": "execution",
-      "purpose": "Bot-paired fast-lane cycle for coherent-arc internal PRs (one closable bead or small-epic slice): claim → test → impl → pre-push → push → squash auto-merge → close.",
+      "purpose": "Bot-paired fast-lane cycle for coherent-arc internal PRs (one closable bead or small-epic slice): claim → test → impl → pre-push → push → squash auto-merge → close. Use when shipping a fast-lane internal PR, landing a small fix, or closing a single harvested bead.",
       "status": "active",
       "disposition": "keep",
       "consumes": [
@@ -5171,7 +5171,7 @@
       "bounded_context": "BC4",
       "hex_role": "supporting",
       "tier": "meta",
-      "purpose": "Audit an existing SKILL.md against the unified AgentOps template (15",
+      "purpose": "Audit an existing SKILL.md against the unified AgentOps template (15 checks). Use when running a skill quality review, checking if a skill is ready, or auditing skill template compliance.",
       "status": "active",
       "disposition": "update",
       "consumes": [],
@@ -5381,7 +5381,7 @@
       "bounded_context": "BC5",
       "hex_role": "supporting",
       "tier": "utility",
-      "purpose": "Restore system responsiveness via safe, ordered process cleanup and agent-swarm",
+      "purpose": "Restore system responsiveness via safe, ordered process cleanup and agent-swarm hygiene. Use when the system is slow, load average is high, or cleaning up stuck agents and background processes.",
       "status": "active",
       "disposition": "keep",
       "consumes": [],

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1612,13 +1612,13 @@
     {
       "name": "agy-headless-evidence",
       "source_skill": "skills/agy-headless-evidence",
-      "source_hash": "585ff68ce9094f74f137b7a6c24cbde4b2b94723f1f80351b7ee599e2319ab6d",
+      "source_hash": "07ac48ce3de0947e16646531ce63cf478f68d91743f7963e1e4aef37240c545c",
       "generated_hash": "370fa02209ccdef1e3a2383e2671275dcf4c9e5c93ae2b22a958f3e5bc2b4aa4"
     },
     {
       "name": "agy-mcp-plugins",
       "source_skill": "skills/agy-mcp-plugins",
-      "source_hash": "5855344f70c2e5ba01b7a8e9400fb0720d6a7cca947960293e5e9b511a9ae76e",
+      "source_hash": "7ed681a1ebaf3eaec45926952c8deda028201eb0991bd8a7eaba1b076284250d",
       "generated_hash": "169e9f7e8acde4ee71ed7f959a52cfb241a3dd3780a649ba69ee6d984e722825"
     },
     {
@@ -1654,7 +1654,7 @@
     {
       "name": "autodev",
       "source_skill": "skills/autodev",
-      "source_hash": "350a9f3c5d80fee1be48f8f52aee30d8146fd217289848e57a360fb57dda9311",
+      "source_hash": "784fccb394271679e7667e6be128521a34b46be25e0ce55de0258031ca6f7f8a",
       "generated_hash": "4868b97e436c7650ae194e5eeefe11ae867c62aeb603d55de5c846d8a9975200"
     },
     {
@@ -1738,7 +1738,7 @@
     {
       "name": "burndown",
       "source_skill": "skills/burndown",
-      "source_hash": "fadfa15eba36f207bc5bfe5a417549a49702c9b793e319a336f93e79358a9018",
+      "source_hash": "ac4b903a16a0d8bb793d8fae5cb63a2e6eb8b008232ee9f3148b50e108da9f03",
       "generated_hash": "408431e51b7b1e89e25aff9ec5dc525fcad40a368bdbb6d150554ccfcaeac5ad"
     },
     {
@@ -1750,7 +1750,7 @@
     {
       "name": "casr",
       "source_skill": "skills/casr",
-      "source_hash": "d886eef784ff36559ce073e328b8a8df936d96939a9f9eb400d352022939a623",
+      "source_hash": "f289d623414a70692572e67ddf7bd82c45557a8242413b5ad41f833f1bc72e79",
       "generated_hash": "da2f7f21120f6208e0a8494814dbc3ccadbb855efa7693c70fa492428b5afa2a"
     },
     {
@@ -2146,7 +2146,7 @@
     {
       "name": "operating-loop-workflow",
       "source_skill": "skills/operating-loop-workflow",
-      "source_hash": "a5101f268118143a999e8b95601e71a9fa844bf53d0b65572730c9fd928966cb",
+      "source_hash": "426a05259f602d2a2dc0ad025e441946c319d6d904a0780e348ce4cd4d753cbe",
       "generated_hash": "c69a6b78385374c2dc58fdd7fe4a743c32b34c07dfef89510f3d3a9951c5aa02"
     },
     {
@@ -2428,13 +2428,13 @@
     {
       "name": "ship-loop",
       "source_skill": "skills/ship-loop",
-      "source_hash": "98f33d46a03b2f8d52e8cdfc17a38844d6371efdcc264202f332f404803ddfff",
+      "source_hash": "88ddb1cd294ba2ffa5e0d825744844be4b341f64ced44c96cbff214ee5524100",
       "generated_hash": "34755a5fc0f099b82e93f69b57436da6ff34d59b3e82d8984c78e461360cb8f3"
     },
     {
       "name": "skill-auditor",
       "source_skill": "skills/skill-auditor",
-      "source_hash": "314de8417241d574543518f96c0be458feaf32fdcbb05ef4daf8c87cab06a786",
+      "source_hash": "f9108c24d15708b576ae927c9c3221850168b66657541f0fbc94a8565c8f01f2",
       "generated_hash": "586d228b2817c1e4dc0b1abdb7b8cbaf568754da747bd1fe669531ee2542b026"
     },
     {
@@ -2494,7 +2494,7 @@
     {
       "name": "system-tuning",
       "source_skill": "skills/system-tuning",
-      "source_hash": "6d340c15f61d023e1d87faaf576d9317756448ab30aaeacbcf566da895cf4486",
+      "source_hash": "d56fb9e52ae2524543c7e485e824795422b2fa2dc8220870c287e18cc4af9ddc",
       "generated_hash": "91c58bb3f192f4aeb34d96047c53b1288bfa908e5886df8c9e5ba5bbb6e77a75"
     },
     {

--- a/skills-codex/agy-headless-evidence/.agentops-generated.json
+++ b/skills-codex/agy-headless-evidence/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/agy-headless-evidence",
   "layout": "modular",
-  "source_hash": "585ff68ce9094f74f137b7a6c24cbde4b2b94723f1f80351b7ee599e2319ab6d",
+  "source_hash": "07ac48ce3de0947e16646531ce63cf478f68d91743f7963e1e4aef37240c545c",
   "generated_hash": "370fa02209ccdef1e3a2383e2671275dcf4c9e5c93ae2b22a958f3e5bc2b4aa4"
 }

--- a/skills-codex/agy-mcp-plugins/.agentops-generated.json
+++ b/skills-codex/agy-mcp-plugins/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/agy-mcp-plugins",
   "layout": "modular",
-  "source_hash": "5855344f70c2e5ba01b7a8e9400fb0720d6a7cca947960293e5e9b511a9ae76e",
+  "source_hash": "7ed681a1ebaf3eaec45926952c8deda028201eb0991bd8a7eaba1b076284250d",
   "generated_hash": "169e9f7e8acde4ee71ed7f959a52cfb241a3dd3780a649ba69ee6d984e722825"
 }

--- a/skills-codex/autodev/.agentops-generated.json
+++ b/skills-codex/autodev/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/autodev",
   "layout": "modular",
-  "source_hash": "350a9f3c5d80fee1be48f8f52aee30d8146fd217289848e57a360fb57dda9311",
+  "source_hash": "784fccb394271679e7667e6be128521a34b46be25e0ce55de0258031ca6f7f8a",
   "generated_hash": "4868b97e436c7650ae194e5eeefe11ae867c62aeb603d55de5c846d8a9975200"
 }

--- a/skills-codex/burndown/.agentops-generated.json
+++ b/skills-codex/burndown/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/burndown",
   "layout": "modular",
-  "source_hash": "fadfa15eba36f207bc5bfe5a417549a49702c9b793e319a336f93e79358a9018",
+  "source_hash": "ac4b903a16a0d8bb793d8fae5cb63a2e6eb8b008232ee9f3148b50e108da9f03",
   "generated_hash": "408431e51b7b1e89e25aff9ec5dc525fcad40a368bdbb6d150554ccfcaeac5ad"
 }

--- a/skills-codex/casr/.agentops-generated.json
+++ b/skills-codex/casr/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/casr",
   "layout": "modular",
-  "source_hash": "d886eef784ff36559ce073e328b8a8df936d96939a9f9eb400d352022939a623",
+  "source_hash": "f289d623414a70692572e67ddf7bd82c45557a8242413b5ad41f833f1bc72e79",
   "generated_hash": "da2f7f21120f6208e0a8494814dbc3ccadbb855efa7693c70fa492428b5afa2a"
 }

--- a/skills-codex/operating-loop-workflow/.agentops-generated.json
+++ b/skills-codex/operating-loop-workflow/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/operating-loop-workflow",
   "layout": "modular",
-  "source_hash": "a5101f268118143a999e8b95601e71a9fa844bf53d0b65572730c9fd928966cb",
+  "source_hash": "426a05259f602d2a2dc0ad025e441946c319d6d904a0780e348ce4cd4d753cbe",
   "generated_hash": "c69a6b78385374c2dc58fdd7fe4a743c32b34c07dfef89510f3d3a9951c5aa02"
 }

--- a/skills-codex/ship-loop/.agentops-generated.json
+++ b/skills-codex/ship-loop/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/ship-loop",
   "layout": "modular",
-  "source_hash": "98f33d46a03b2f8d52e8cdfc17a38844d6371efdcc264202f332f404803ddfff",
+  "source_hash": "88ddb1cd294ba2ffa5e0d825744844be4b341f64ced44c96cbff214ee5524100",
   "generated_hash": "34755a5fc0f099b82e93f69b57436da6ff34d59b3e82d8984c78e461360cb8f3"
 }

--- a/skills-codex/skill-auditor/.agentops-generated.json
+++ b/skills-codex/skill-auditor/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/skill-auditor",
   "layout": "modular",
-  "source_hash": "314de8417241d574543518f96c0be458feaf32fdcbb05ef4daf8c87cab06a786",
+  "source_hash": "f9108c24d15708b576ae927c9c3221850168b66657541f0fbc94a8565c8f01f2",
   "generated_hash": "586d228b2817c1e4dc0b1abdb7b8cbaf568754da747bd1fe669531ee2542b026"
 }

--- a/skills-codex/system-tuning/.agentops-generated.json
+++ b/skills-codex/system-tuning/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/system-tuning",
   "layout": "modular",
-  "source_hash": "6d340c15f61d023e1d87faaf576d9317756448ab30aaeacbcf566da895cf4486",
+  "source_hash": "d56fb9e52ae2524543c7e485e824795422b2fa2dc8220870c287e18cc4af9ddc",
   "generated_hash": "91c58bb3f192f4aeb34d96047c53b1288bfa908e5886df8c9e5ba5bbb6e77a75"
 }

--- a/skills/agy-headless-evidence/SKILL.md
+++ b/skills/agy-headless-evidence/SKILL.md
@@ -2,7 +2,7 @@
 name: agy-headless-evidence
 user-invocable: false
 description: |-
-  Run AGY headlessly via scheduled ticks or `agy -p`, capturing agentapi JSONL evidence for validation.
+  Run AGY headlessly via scheduled ticks or `agy -p`, capturing agentapi JSONL evidence for validation. Use when running AGY in an automated loop, testing headless execution, or capturing agent event streams for validation.
 practices:
 - design-by-contract
 - evidence-over-assertion

--- a/skills/agy-mcp-plugins/SKILL.md
+++ b/skills/agy-mcp-plugins/SKILL.md
@@ -2,7 +2,7 @@
 name: agy-mcp-plugins
 user-invocable: false
 description: |-
-  Wire MCP servers and AgentOps plugin bundles into the AGY image with least-privilege tool access and rollback evidence.
+  Wire MCP servers and AgentOps plugin bundles into the AGY image with least-privilege tool access and rollback evidence. Use when setting up AGY tool surfaces, wiring new MCP servers, or distributing AgentOps plugins.
 practices:
 - data-contracts
 - least-privilege

--- a/skills/autodev/SKILL.md
+++ b/skills/autodev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autodev
-description: Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer Evolve and Factory read each tick, not a loop itself.
+description: Manage the PROGRAM.md/AUTODEV.md contract that drives the loop — the config layer Evolve and Factory read each tick, not a loop itself. Use when defining the autonomous improvement loop rules, repairing PROGRAM.md, or setting boundaries for evolve.
 practices:
 - cmm-process-maturity
 - ai-assisted-dev

--- a/skills/burndown/SKILL.md
+++ b/skills/burndown/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: burndown
-description: Drive a finite epic set to all-merged, then stop.
+description: Drive a finite epic set to all-merged, then stop. Use when finishing a specific list of tasks, burning down a backlog epic, or executing a bounded set of beads until done.
 practices:
 - continuous-delivery
 - xp

--- a/skills/casr/SKILL.md
+++ b/skills/casr/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   tier: execution
 description: >-
   Cross Agent Session Resumer. Convert and resume sessions across Claude Code,
-  Codex, Gemini, and other providers.
+  Codex, Gemini, and other providers. Use when switching AI agent providers mid-session or migrating an active chat history to a new tool.
 practices:
 - pragmatic-programmer
 ---

--- a/skills/operating-loop-workflow/SKILL.md
+++ b/skills/operating-loop-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: operating-loop-workflow
-description: Install and run the operating-loop multi-agent Workflow (the seven-move loop) for AgentOps plugin users.
+description: Install and run the operating-loop multi-agent Workflow (the seven-move loop) for AgentOps plugin users. Use when installing the seven-move workflow, running the operating-loop script, or orchestrating multi-agent tasks via Workflow tool.
 practices:
 - pragmatic-programmer
 - agile-manifesto

--- a/skills/ship-loop/SKILL.md
+++ b/skills/ship-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-loop
-description: 'Bot-paired fast-lane cycle for coherent-arc internal PRs (one closable bead or small-epic slice): claim → test → impl → pre-push → push → squash auto-merge → close.'
+description: 'Bot-paired fast-lane cycle for coherent-arc internal PRs (one closable bead or small-epic slice): claim → test → impl → pre-push → push → squash auto-merge → close. Use when shipping a fast-lane internal PR, landing a small fix, or closing a single harvested bead.'
 practices:
 - continuous-delivery
 - xp

--- a/skills/skill-auditor/SKILL.md
+++ b/skills/skill-auditor/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: skill-auditor
-description: 'Audit an existing SKILL.md against the unified AgentOps template (15
-  checks). Triggers: "audit skill", "skill quality review", "is this skill ready".'
+description: 'Audit an existing SKILL.md against the unified AgentOps template (15 checks). Use when running a skill quality review, checking if a skill is ready, or auditing skill template compliance.'
 practices:
 - code-complete
 - cmm-process-maturity

--- a/skills/system-tuning/SKILL.md
+++ b/skills/system-tuning/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: system-tuning
-description: Restore system responsiveness via safe, ordered process cleanup and agent-swarm
-  hygiene.
+description: Restore system responsiveness via safe, ordered process cleanup and agent-swarm hygiene. Use when the system is slow, load average is high, or cleaning up stuck agents and background processes.
 practices:
 - sre
 - resilience-patterns


### PR DESCRIPTION
Add explicit 'Use when' or 'Triggers:' clauses to the remaining 9 ambiguous
auto-selected weak-trigger skills: agy-headless-evidence, agy-mcp-plugins,
autodev, burndown, casr, operating-loop-workflow, ship-loop, skill-auditor,
and system-tuning.

This improves selection reliability for the harness. Regenerated context-map,
registry.json, and codex hashes.

Closes-scenario: cp-xvt3
