### PR TITLE
feat(contracts): workflows first-class — bidirectional drift gate + Registries surface (ag-jy8gj #workflows-drift)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -112,6 +112,12 @@ jobs:
             contracts:
               - 'schemas/**'
               - 'docs/contracts/**'
+              # Claude workflows (ag-jy8gj): the workflow-governance drift gate is a
+              # bidirectional identity match between .claude/workflows/*.js and the
+              # `workflows:` ledger section in docs/contracts/skill-dispositions.yaml.
+              # A .js add/remove/rename must re-run that gate, so the workflow dir is
+              # a contracts trigger (the ledger half is already covered by docs/contracts/**).
+              - '.claude/workflows/**'
               # redteam-pack target globs (ag-nl1u): every file the
               # security redteam pack
               # (skills/security/references/agentops-redteam-pack.json)
@@ -1008,6 +1014,16 @@ jobs:
         run: |
           chmod +x scripts/check-bounded-contexts-drift.sh
           ./scripts/check-bounded-contexts-drift.sh
+
+      - name: Check workflow governance drift (ag-jy8gj — js<->ledger bijection + kind/BC/role)
+        # Bidirectional: every .claude/workflows/*.js has a `workflows:` ledger row
+        # carrying kind: workflow + a Bounded Context (domain) + a hexagonal_role,
+        # and every kind: workflow ledger row has a matching .js (no stale rows).
+        # Workflows are Claude-only — no Codex twin required.
+        if: needs.changes.outputs.contracts == 'true' || needs.changes.outputs.ci == 'true'
+        run: |
+          chmod +x scripts/check-workflow-governance.sh
+          ./scripts/check-workflow-governance.sh
 
       - name: Check skill-domain-map golden (soc-zxia.3 Phase 3)
         if: needs.changes.outputs.skills == 'true' || needs.changes.outputs.ci == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,10 @@ When in doubt about HOW the work should flow, read [`docs/cdlc.md`](docs/cdlc.md
 
 ## Registries (generated — don't hand-edit)
 
-Two drift-gated inventories. Edit the sources (`skills/**/SKILL.md`, `cli/cmd/ao/`), then `make regen-all` (`scripts/regen-all.sh`); `--check` is the gate. Never hand-edit the artifacts:
+Three drift-gated inventories (kind-discriminated: `skill` · `workflow` · CLI command), across the 6 Bounded Contexts. Edit the sources (`skills/**/SKILL.md`, `.claude/workflows/*.js` + the `workflows:` ledger, `cli/cmd/ao/`), then `make regen-all` (`scripts/regen-all.sh`); `--check` is the gate. Never hand-edit the artifacts:
 
 - **Skills** — `registry.json` · `docs/SKILLS.md` · `skills/SKILL-TIERS.md` · `docs/reference/agentops-skill-domain-map.md` · `docs/contracts/skill-dispositions.yaml` (disposition ledger; `ao skills retire` retargets validators through it).
+- **Workflows** — `registry.json` `workflows[]` (Claude-only `.claude/workflows/*.js`, `kind: workflow`); sourced from the `workflows:` section of `docs/contracts/skill-dispositions.yaml` (kind + BC + hexagonal_role). Drift gate: `scripts/check-workflow-governance.sh` (bidirectional `.js`↔ledger + identity triple). No Codex twin.
 - **Tools** — `cli/docs/COMMANDS.md` · `docs/cli-surface.{json,md}` (generated from `cli/cmd/ao/`).
 
 ## Installing/Updating Skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,9 +64,10 @@ WRONG:    ~/.claude/skills/evolve/SKILL.md (installed copy — do not edit)
 
 ## Registries (generated — don't hand-edit)
 
-Two machine-generated, drift-gated inventories. Edit the **sources** (`skills/**/SKILL.md` for skills, `cli/cmd/ao/` for commands), then regenerate with `make regen-all` (`scripts/regen-all.sh`); `scripts/regen-all.sh --check` is the pre-push/CI drift gate. Never hand-edit the artifacts below.
+Three machine-generated, drift-gated inventories (kind-discriminated: `skill` · `workflow` · CLI command), spanning the 6 Bounded Contexts. Edit the **sources** (`skills/**/SKILL.md` for skills, `.claude/workflows/*.js` + the `workflows:` ledger for workflows, `cli/cmd/ao/` for commands), then regenerate with `make regen-all` (`scripts/regen-all.sh`); `scripts/regen-all.sh --check` is the pre-push/CI drift gate. Never hand-edit the artifacts below.
 
 - **Skills registry** — `registry.json` (canonical skill inventory) · `docs/SKILLS.md` (catalog + routes) · `skills/SKILL-TIERS.md` (tiers) · `docs/reference/agentops-skill-domain-map.md` (DDD/domain map) · `docs/contracts/skill-dispositions.yaml` (per-skill disposition ledger — keep/fold/cut; the source `ao skills retire` retargets validators through).
+- **Workflows registry** — `registry.json` `workflows[]` surface (the Claude-only `.claude/workflows/*.js` orchestration scripts, `kind: workflow`) · sourced from the top-level `workflows:` section of `docs/contracts/skill-dispositions.yaml` (kind + Bounded Context + hexagonal_role). Workflows are Claude-runtime only (no Codex twin). Drift gate: `scripts/check-workflow-governance.sh` enforces the bidirectional `.js`↔ledger bijection + the kind/BC/role identity triple.
 - **Tools registry** — `cli/docs/COMMANDS.md` (full `ao` command surface) · `docs/cli-surface.{json,md}` (surface snapshot for parity). Both generated from `cli/cmd/ao/`.
 
 ## Deep reference (on-demand, not auto-loaded)

--- a/scripts/check-workflow-governance.sh
+++ b/scripts/check-workflow-governance.sh
@@ -1,17 +1,31 @@
 #!/usr/bin/env bash
-# check-workflow-governance.sh — kind-aware workflow governance gate (ag-km74w).
+# check-workflow-governance.sh — kind-aware workflow drift/governance gate
+# (ag-km74w; bidirectional + DDD-identity extension ag-jy8gj).
 #
-# Asserts every repo-tracked .claude/workflows/*.js has a matching entry in the
-# top-level `workflows:` section of docs/contracts/skill-dispositions.yaml, and
-# that each such entry declares `kind: workflow`. This is the thin
-# workflow-only sliver of the S0 artifact-dispositions schema: it gives
-# Claude Workflow scripts a governed home in the ledger WITHOUT teaching the
-# `- skill:` line-parsers (sku_catalog.py / generate-skill-domain-map.sh) to
+# Asserts a BIDIRECTIONAL identity match between the repo-tracked Claude
+# workflows (.claude/workflows/*.js) and the top-level `workflows:` section of
+# docs/contracts/skill-dispositions.yaml, plus the DDD identity triple on each
+# ledger row.
+#
+#   FORWARD  — every workflow .js has a `workflows.<id>` ledger row that carries
+#              kind: workflow + a Bounded Context (domain) + a hexagonal_role.
+#   REVERSE  — every `workflows.<id>` ledger row (kind: workflow) has a matching
+#              repo-tracked .js (else the row is STALE and the gate FAILS).
+#
+# Workflows are Claude-only (ag-jy8gj): they live only in .claude/workflows/
+# with no skills-codex twin, so this gate checks Claude-runtime presence and
+# never requires a Codex twin or trips audit-codex-parity.
+#
+# This is the thin workflow-only sliver of the S0 artifact-dispositions schema:
+# it gives Claude Workflow scripts a governed home in the ledger WITHOUT teaching
+# the `- skill:` line-parsers (sku_catalog.py / generate-skill-domain-map.sh) to
 # miscount them as skills (the `workflows:` mapping is top-level, skipped like
 # `historical:`).
 #
-# Exit 0: every workflow .js is registered with kind: workflow.
-# Exit 1: a workflow .js has no ledger entry, or an entry lacks kind: workflow.
+# Exit 0: the .js set and the kind: workflow ledger rows are in bijection and
+#         every row carries kind: workflow + domain (BC) + hexagonal_role.
+# Exit 1: a workflow .js has no ledger row; a row lacks the identity triple; or a
+#         kind: workflow row has no matching .js (stale).
 #
 # Repo root from cwd git. No hardcoded user paths.
 set -euo pipefail
@@ -39,7 +53,8 @@ while IFS= read -r tracked; do
     status=1
     continue
   fi
-  # Verify the ledger has this workflow id with kind: workflow.
+  # Verify the ledger has this workflow id with the DDD identity triple:
+  # kind: workflow + a Bounded Context (domain) + a hexagonal_role.
   if ! python3 - "$disp_yaml" "$id" "$rel" <<'PY'
 import sys
 import yaml
@@ -53,16 +68,58 @@ if entry is None:
 if entry.get("kind") != "workflow":
     print(f"FAIL: workflow '{wf_id}' ledger entry kind={entry.get('kind')!r}, expected 'workflow'", file=sys.stderr)
     sys.exit(1)
+# DDD identity: a Bounded Context (domain) and a hexagonal_role are required.
+if not (entry.get("domain") or "").strip():
+    print(f"FAIL: workflow '{wf_id}' ({rel}) ledger row has no `domain:` (Bounded Context)", file=sys.stderr)
+    sys.exit(1)
+if not (entry.get("hexagonal_role") or "").strip():
+    print(f"FAIL: workflow '{wf_id}' ({rel}) ledger row has no `hexagonal_role:`", file=sys.stderr)
+    sys.exit(1)
 sys.exit(0)
 PY
   then
     status=1
     continue
   fi
-  echo "OK: $id ($rel) registered with kind: workflow"
+  echo "OK: $id ($rel) registered with kind: workflow + BC + role"
 done < <(git -C "$repo_root" ls-files '.claude/workflows/*.js')
 
+# REVERSE: every `workflows.<id>` ledger row with kind: workflow must have a
+# matching repo-tracked .js. A row without one is STALE — fail naming it.
+# (The id list is computed once from the .js set, parsing meta.name the same way
+# the forward pass does, so a renamed-but-not-removed row is caught.)
+present_ids="$(
+  while IFS= read -r tracked; do
+    abs="$repo_root/$tracked"
+    [ -f "$abs" ] || continue
+    grep -oE "name:[[:space:]]*['\"][^'\"]+['\"]" "$abs" | head -1 | sed -E "s/.*['\"]([^'\"]+)['\"].*/\1/"
+  done < <(git -C "$repo_root" ls-files '.claude/workflows/*.js')
+)"
+if ! python3 - "$disp_yaml" "$present_ids" <<'PY'
+import sys
+import yaml
+disp_yaml, present_blob = sys.argv[1], sys.argv[2]
+present = {ln.strip() for ln in present_blob.splitlines() if ln.strip()}
+data = yaml.safe_load(open(disp_yaml, encoding="utf-8")) or {}
+workflows = data.get("workflows") or {}
+stale = []
+for wf_id, entry in workflows.items():
+    entry = entry or {}
+    if entry.get("kind") != "workflow":
+        continue
+    if wf_id not in present:
+        stale.append(wf_id)
+if stale:
+    for wf_id in stale:
+        print(f"FAIL: ledger workflow '{wf_id}' is STALE — kind: workflow row with no matching .claude/workflows/*.js", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+then
+  status=1
+fi
+
 if [ "$status" -eq 0 ]; then
-  echo "OK: all repo-tracked .claude/workflows/*.js are governed (kind: workflow)"
+  echo "OK: all repo-tracked .claude/workflows/*.js are governed (kind: workflow + BC + role), and no ledger workflow rows are stale"
 fi
 exit "$status"

--- a/tests/scripts/check-workflow-governance.bats
+++ b/tests/scripts/check-workflow-governance.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+#
+# Tests for the workflow governance / drift gate (ag-jy8gj):
+# scripts/check-workflow-governance.sh asserts a BIDIRECTIONAL identity match
+# between .claude/workflows/*.js and the top-level `workflows:` section of
+# docs/contracts/skill-dispositions.yaml, and that each ledger row carries the
+# DDD identity triple: kind: workflow + a Bounded Context (domain) + a
+# hexagonal_role.
+#
+# The gate runs against a temp git fixture (it derives repo_root from
+# `git rev-parse --show-toplevel`), so each case stamps a minimal repo with a
+# workflow .js + a ledger and asserts the gate's verdict. Workflows are
+# Claude-only (ag-jy8gj comment): the gate checks Claude-runtime presence and
+# never requires a Codex twin.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export REPO_ROOT
+    GATE="$REPO_ROOT/scripts/check-workflow-governance.sh"
+    # Build a throwaway git repo with the gate script + workflow dir + ledger.
+    FIX="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$FIX/scripts" "$FIX/.claude/workflows" "$FIX/docs/contracts"
+    cp "$GATE" "$FIX/scripts/check-workflow-governance.sh"
+    chmod +x "$FIX/scripts/check-workflow-governance.sh"
+    git -C "$FIX" init -q
+    git -C "$FIX" config user.email t@t.t
+    git -C "$FIX" config user.name t
+}
+
+# write_workflow_js <name> <meta-name>
+write_workflow_js() {
+    local file="$FIX/.claude/workflows/$1"
+    cat > "$file" <<JS
+export const meta = { name: '$2' };
+JS
+    git -C "$FIX" add "$file"
+}
+
+run_gate() { ( cd "$FIX" && bash scripts/check-workflow-governance.sh ); }
+
+@test "a fully-governed workflow (kind+BC+role, js<->ledger match) passes" {
+    write_workflow_js "demo.js" "demo"
+    cat > "$FIX/docs/contracts/skill-dispositions.yaml" <<'YAML'
+workflows:
+  demo:
+    kind:           workflow
+    domain:         "BC3 Loop"
+    hexagonal_role: driving-adapter
+    path:           .claude/workflows/demo.js
+YAML
+    run run_gate
+    [ "$status" -eq 0 ]
+}
+
+@test "a .js with no ledger row FAILS naming it" {
+    write_workflow_js "orphan.js" "orphan"
+    cat > "$FIX/docs/contracts/skill-dispositions.yaml" <<'YAML'
+workflows: {}
+YAML
+    run run_gate
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"orphan"* ]]
+}
+
+@test "a ledger row kind: workflow with no matching .js FAILS as stale" {
+    # No .js authored, but the ledger declares one.
+    cat > "$FIX/docs/contracts/skill-dispositions.yaml" <<'YAML'
+workflows:
+  ghost:
+    kind:           workflow
+    domain:         "BC3 Loop"
+    hexagonal_role: driving-adapter
+    path:           .claude/workflows/ghost.js
+YAML
+    run run_gate
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"ghost"* ]]
+    [[ "$output" == *"stale"* || "$output" == *"no .claude/workflows"* || "$output" == *"no matching"* ]]
+}
+
+@test "a ledger row missing its Bounded Context (domain) FAILS" {
+    write_workflow_js "nobc.js" "nobc"
+    cat > "$FIX/docs/contracts/skill-dispositions.yaml" <<'YAML'
+workflows:
+  nobc:
+    kind:           workflow
+    hexagonal_role: driving-adapter
+    path:           .claude/workflows/nobc.js
+YAML
+    run run_gate
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"nobc"* ]]
+}
+
+@test "a ledger row missing its hexagonal_role FAILS" {
+    write_workflow_js "norole.js" "norole"
+    cat > "$FIX/docs/contracts/skill-dispositions.yaml" <<'YAML'
+workflows:
+  norole:
+    kind:   workflow
+    domain: "BC3 Loop"
+    path:   .claude/workflows/norole.js
+YAML
+    run run_gate
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"norole"* ]]
+}
+
+@test "the real repo passes the governance gate" {
+    run bash "$GATE"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

S2 of the factory-DDD epic (ag-3fp54): makes Claude **workflows** a first-class, drift-gated registry surface, kind-discriminated alongside skills and CLI commands.

Prior slices already landed the ledger rows (`workflows:` section in `docs/contracts/skill-dispositions.yaml`) and the `registry.json` `workflows[]` surface + summary count (ag-km74w). This slice adds the **missing identity drift gate** and the **docs Registries pointers**.

## Changes

- **`scripts/check-workflow-governance.sh`** — promoted from a forward-only `kind: workflow` check to a **bidirectional `.js`↔ledger bijection** with the DDD identity triple:
  - FORWARD: every `.claude/workflows/*.js` has a ledger row carrying `kind: workflow` + a Bounded Context (`domain`) + a `hexagonal_role`.
  - REVERSE: every `kind: workflow` ledger row has a matching repo-tracked `.js` (else **STALE → FAIL**).
  - Workflows are **Claude-only** (no `skills-codex` twin) — the gate never requires a Codex twin or trips audit-codex-parity.
- **`.github/workflows/validate.yml`** — wire the gate into the `contracts-sync` job and add `.claude/workflows/**` to the `contracts` path filter so a `.js` add/remove/rename re-runs the gate.
- **`CLAUDE.md` + `AGENTS.md`** — Registries blocks now name the **Workflows registry** (kind-discriminated) + the 6 BCs.

## Test (TDD: red → green)

`tests/scripts/check-workflow-governance.bats` — written first; tests 3/4/5 failed red against the forward-only gate (no stale/BC/role check), then green after the enhancement:

- governed workflow (kind+BC+role, js↔ledger match) passes
- `.js` with no ledger row FAILS naming it
- `kind: workflow` ledger row with no matching `.js` FAILS as stale
- ledger row missing its Bounded Context FAILS
- ledger row missing its hexagonal_role FAILS
- the real repo passes the governance gate

`scripts/regen-all.sh --check` clean (no generated-surface drift — the `workflows[]` registry surface pre-existed).

Closes-scenario: ag-jy8gj#workflows-drift
Bounded-context: BC3-Loop
Evidence: scripts/check-workflow-governance.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)