### PR TITLE
fix(yieldledger): count accepted-attempt rework loss

### DIFF
--- a/cli/internal/yieldledger/gauge.go
+++ b/cli/internal/yieldledger/gauge.go
@@ -1,5 +1,10 @@
 package yieldledger
 
+import (
+	"sort"
+	"time"
+)
+
 // Gauge computation for the dynamo yield vector (ag-qzinh): the dial on top of
 // the meter ag-grcz3 built. ComputeGauges reads the bead-keyed operational event
 // stream and derives the gauges per
@@ -113,26 +118,70 @@ func spendOf(u *UsageBody) int {
 	return u.TokensOut
 }
 
-// runUsage returns the usage events for one run keyed by bead, plus the set of
-// beads that have ≥1 accept and the set with ≥1 gate-verdict in this run.
-func computeRunSets(l *Ledger, runID string) (
-	accepted map[string]bool, // bead -> has a terminal accept this run
-	attempted map[string]bool, // bead -> has ≥1 gate-verdict this run
-) {
-	accepted = map[string]bool{}
-	attempted = map[string]bool{}
-	for _, ev := range l.Events {
+type gateAttempt struct {
+	headSHA    string
+	attempt    int
+	ts         time.Time
+	eventIndex int
+}
+
+type runSets struct {
+	accepted         map[string]bool
+	attempted        map[string]bool
+	acceptingAttempt map[string]int
+	gateAttempts     map[string][]gateAttempt
+}
+
+// computeRunSets returns the run-level bead sets plus the gate attempt metadata
+// needed for Q and L's accepted-bead rework attribution.
+func computeRunSets(l *Ledger, runID string) runSets {
+	sets := runSets{
+		accepted:         map[string]bool{}, // bead -> has a terminal accept this run
+		attempted:        map[string]bool{}, // bead -> has ≥1 gate-verdict this run
+		acceptingAttempt: map[string]int{},  // bead -> attempt number authorized by accept
+		gateAttempts:     map[string][]gateAttempt{},
+	}
+	for idx, ev := range l.Events {
 		if ev.RunID != runID {
 			continue
 		}
 		switch ev.Event {
 		case EventAccept:
-			accepted[ev.BeadID] = true
+			sets.accepted[ev.BeadID] = true
 		case EventGateVerdict:
-			attempted[ev.BeadID] = true
+			if ev.GateVerdict == nil {
+				continue
+			}
+			sets.attempted[ev.BeadID] = true
+			sets.gateAttempts[ev.BeadID] = append(sets.gateAttempts[ev.BeadID], gateAttempt{
+				headSHA:    ev.GateVerdict.HeadSHA,
+				attempt:    ev.GateVerdict.Attempt,
+				ts:         eventTime(ev),
+				eventIndex: idx,
+			})
 		}
 	}
-	return accepted, attempted
+	for bead := range sets.gateAttempts {
+		sort.SliceStable(sets.gateAttempts[bead], func(i, j int) bool {
+			left := sets.gateAttempts[bead][i]
+			right := sets.gateAttempts[bead][j]
+			if left.ts.Equal(right.ts) {
+				return left.eventIndex < right.eventIndex
+			}
+			return left.ts.Before(right.ts)
+		})
+	}
+	for _, ev := range l.Events {
+		if ev.RunID != runID || ev.Event != EventAccept || ev.Accept == nil {
+			continue
+		}
+		if attempt, ok := acceptingAttemptFor(ev, sets.gateAttempts[ev.BeadID]); ok {
+			if current, exists := sets.acceptingAttempt[ev.BeadID]; !exists || attempt < current {
+				sets.acceptingAttempt[ev.BeadID] = attempt
+			}
+		}
+	}
+	return sets
 }
 
 // difficultyOf returns the bead's difficulty weight for this run, taken from its
@@ -197,21 +246,73 @@ func cleanFirstPass(l *Ledger, runID, beadID string) bool {
 	return false
 }
 
-// classifyUsage performs the read-time L join for one usage row: it joins the
-// row's bead to that bead's terminal disposition this run. A never-accepted bead
-// is a rejected loss; phase==rework is a rework loss; phase==coordination is a
-// coordination loss; spend on an accepted bead otherwise is productive.
-func classifyUsage(ev Event, accepted map[string]bool) LossCategory {
+func eventTime(ev Event) time.Time {
+	ts, _ := time.Parse(time.RFC3339, ev.TS)
+	return ts
+}
+
+func acceptingAttemptFor(ev Event, gates []gateAttempt) (int, bool) {
+	ref := ev.Accept.GateVerdictRef
+	if ref.BeadID != ev.BeadID {
+		return 0, false
+	}
+	for _, gate := range gates {
+		if gate.headSHA == ref.HeadSHA {
+			return gate.attempt, true
+		}
+	}
+	return 0, false
+}
+
+func usageAttempt(ev Event, eventIndex int, gates []gateAttempt) (int, bool) {
+	usageTS := eventTime(ev)
+	for _, gate := range gates {
+		if gate.ts.After(usageTS) || (gate.ts.Equal(usageTS) && gate.eventIndex > eventIndex) {
+			return gate.attempt, true
+		}
+	}
+	return 0, false
+}
+
+func (b *LossBreakdown) add(other LossBreakdown) {
+	b.Rejected += other.Rejected
+	b.Rework += other.Rework
+	b.Coordination += other.Coordination
+	b.Productive += other.Productive
+}
+
+// classifyUsage performs the read-time L join for one usage row. A
+// never-accepted bead is rejected loss; explicit rework/coordination phases stay
+// loss; an accepted bead's spend before the accepting attempt-N is rework loss.
+// When a usage row is an aggregate emitted after all gate verdicts, split it
+// evenly across attempts so the N-1 pre-accepting attempts no longer disappear
+// into productive spend.
+func classifyUsage(ev Event, eventIndex int, sets runSets) LossBreakdown {
+	spend := spendOf(ev.Usage)
 	switch ev.Usage.Phase {
 	case PhaseRework:
-		return LossRework
+		return LossBreakdown{Rework: spend}
 	case PhaseCoordination:
-		return LossCoordination
+		return LossBreakdown{Coordination: spend}
 	}
-	if !accepted[ev.BeadID] {
-		return LossRejected
+	if !sets.accepted[ev.BeadID] {
+		return LossBreakdown{Rejected: spend}
 	}
-	return LossProductive
+	acceptingAttempt, hasAcceptingAttempt := sets.acceptingAttempt[ev.BeadID]
+	if !hasAcceptingAttempt || acceptingAttempt <= 1 {
+		return LossBreakdown{Productive: spend}
+	}
+	if attempt, ok := usageAttempt(ev, eventIndex, sets.gateAttempts[ev.BeadID]); ok {
+		if attempt < acceptingAttempt {
+			return LossBreakdown{Rework: spend}
+		}
+		return LossBreakdown{Productive: spend}
+	}
+	reworkSpend := spend * (acceptingAttempt - 1) / acceptingAttempt
+	return LossBreakdown{
+		Rework:     reworkSpend,
+		Productive: spend - reworkSpend,
+	}
 }
 
 // ComputeGauges derives the yield vector for runID from the ledger. C is
@@ -220,7 +321,7 @@ func classifyUsage(ev Event, accepted map[string]bool) LossCategory {
 func ComputeGauges(l *Ledger, runID string, cDelta float64, cKnown bool) Gauges {
 	g := Gauges{RunID: runID, SpendMeasure: SpendMeasure}
 
-	accepted, attempted := computeRunSets(l, runID)
+	sets := computeRunSets(l, runID)
 
 	// A and R.
 	for _, ev := range l.Events {
@@ -242,7 +343,7 @@ func ComputeGauges(l *Ledger, runID string, cDelta float64, cKnown bool) Gauges 
 	}
 
 	// Q — difficulty-weighted first-pass yield over distinct attempted beads.
-	for bead := range attempted {
+	for bead := range sets.attempted {
 		w := difficultyOf(l, runID, bead)
 		g.QDenominator += w
 		g.QAttemptBeads++
@@ -272,21 +373,11 @@ func ComputeGauges(l *Ledger, runID string, cDelta float64, cKnown bool) Gauges 
 	}
 
 	// L — read-time loss join.
-	for _, ev := range l.Events {
+	for idx, ev := range l.Events {
 		if ev.RunID != runID || ev.Event != EventUsage || ev.Usage == nil {
 			continue
 		}
-		spend := spendOf(ev.Usage)
-		switch classifyUsage(ev, accepted) {
-		case LossRejected:
-			g.LCategory.Rejected += spend
-		case LossRework:
-			g.LCategory.Rework += spend
-		case LossCoordination:
-			g.LCategory.Coordination += spend
-		case LossProductive:
-			g.LCategory.Productive += spend
-		}
+		g.LCategory.add(classifyUsage(ev, idx, sets))
 	}
 	g.LSpend = g.LCategory.LossSpend()
 	if g.R > 0 {

--- a/cli/internal/yieldledger/gauge.go
+++ b/cli/internal/yieldledger/gauge.go
@@ -284,9 +284,8 @@ func (b *LossBreakdown) add(other LossBreakdown) {
 // classifyUsage performs the read-time L join for one usage row. A
 // never-accepted bead is rejected loss; explicit rework/coordination phases stay
 // loss; an accepted bead's spend before the accepting attempt-N is rework loss.
-// When a usage row is an aggregate emitted after all gate verdicts, split it
-// evenly across attempts so the N-1 pre-accepting attempts no longer disappear
-// into productive spend.
+// Ambiguous or post-confirm accepted-bead spend stays productive: L should
+// under-attribute rework rather than over-charge productive work as loss.
 func classifyUsage(ev Event, eventIndex int, sets runSets) LossBreakdown {
 	spend := spendOf(ev.Usage)
 	switch ev.Usage.Phase {
@@ -308,11 +307,7 @@ func classifyUsage(ev Event, eventIndex int, sets runSets) LossBreakdown {
 		}
 		return LossBreakdown{Productive: spend}
 	}
-	reworkSpend := spend * (acceptingAttempt - 1) / acceptingAttempt
-	return LossBreakdown{
-		Rework:     reworkSpend,
-		Productive: spend - reworkSpend,
-	}
+	return LossBreakdown{Productive: spend}
 }
 
 // ComputeGauges derives the yield vector for runID from the ledger. C is

--- a/cli/internal/yieldledger/gauge_test.go
+++ b/cli/internal/yieldledger/gauge_test.go
@@ -3,6 +3,7 @@ package yieldledger
 import (
 	"math"
 	"testing"
+	"time"
 )
 
 const dogfoodRun = "r-2026-06-14-dynamo"
@@ -256,6 +257,142 @@ func TestComputeGauges_LateConfirmNotCleanFirstPass(t *testing.T) {
 	}
 	if !g.QDefined || !approx(g.Q, 0) {
 		t.Errorf("Q = %v, want 0 (0/5)", g.Q)
+	}
+}
+
+func TestComputeGauges_AcceptedLateAttemptCountsPriorAttemptsAsRework(t *testing.T) {
+	root := t.TempDir()
+	w := Writer{}
+	base := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+
+	if _, err := w.AppendUsage(root, UsageInput{
+		BeadID: "ag-late", RunID: "r1", TS: base.Add(1 * time.Minute),
+		TokensOut: 100, Model: "m", Phase: PhaseImplement,
+		CategoryHint: CategoryProductive,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.AppendGateVerdict(root, GateVerdictInput{
+		BeadID: "ag-late", RunID: "r1", TS: base.Add(2 * time.Minute), Difficulty: 5,
+		PawlVerdictRef: PawlVerdictRef{BeadID: "ag-late", HeadSHA: "shaatt01"},
+		Disposition:    DispositionRefuted, HeadSHA: "shaatt01", Attempt: 1,
+		AuthorContextID: "ctx-1", RefuterFamilies: []string{"gpt"}, AuthorFamily: "claude",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.AppendUsage(root, UsageInput{
+		BeadID: "ag-late", RunID: "r1", TS: base.Add(3 * time.Minute),
+		TokensOut: 200, Model: "m", Phase: PhaseImplement,
+		CategoryHint: CategoryProductive,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.AppendGateVerdict(root, GateVerdictInput{
+		BeadID: "ag-late", RunID: "r1", TS: base.Add(4 * time.Minute), Difficulty: 5,
+		PawlVerdictRef: PawlVerdictRef{BeadID: "ag-late", HeadSHA: "shaatt02"},
+		Disposition:    DispositionRefuted, HeadSHA: "shaatt02", Attempt: 2,
+		AuthorContextID: "ctx-1", RefuterFamilies: []string{"gpt"}, AuthorFamily: "claude",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.AppendUsage(root, UsageInput{
+		BeadID: "ag-late", RunID: "r1", TS: base.Add(5 * time.Minute),
+		TokensOut: 300, Model: "m", Phase: PhaseImplement,
+		CategoryHint: CategoryProductive,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.AppendGateVerdict(root, GateVerdictInput{
+		BeadID: "ag-late", RunID: "r1", TS: base.Add(6 * time.Minute), Difficulty: 5,
+		PawlVerdictRef: PawlVerdictRef{BeadID: "ag-late", HeadSHA: "shaatt03"},
+		Disposition:    DispositionConfirmed, HeadSHA: "shaatt03", Attempt: 3,
+		AuthorContextID: "ctx-1", AuthorFamily: "claude",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.AppendAccept(root, AcceptInput{
+		BeadID: "ag-late", RunID: "r1", TS: base.Add(7 * time.Minute),
+		MergeSHA: "merge01", MergedBy: "orch",
+		GateVerdictRef: PawlVerdictRef{BeadID: "ag-late", HeadSHA: "shaatt03"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := ComputeGauges(l, "r1", 0, false)
+
+	if g.R != 600 {
+		t.Fatalf("R = %d, want 600", g.R)
+	}
+	if g.LCategory.Rework != 300 {
+		t.Errorf("rework = %d, want 300 (attempts 1 and 2 before accepting attempt 3)", g.LCategory.Rework)
+	}
+	if g.LCategory.Productive != 300 {
+		t.Errorf("productive = %d, want 300 (accepting attempt 3)", g.LCategory.Productive)
+	}
+	if g.LSpend != 300 {
+		t.Errorf("LSpend = %d, want 300", g.LSpend)
+	}
+	if !g.LDefined || !approx(g.L, 0.5) {
+		t.Errorf("L = %v, want 0.5", g.L)
+	}
+}
+
+func TestComputeGauges_AggregateAcceptedLateAttemptSpendIsProrated(t *testing.T) {
+	root := t.TempDir()
+	w := Writer{}
+	ts := time.Date(2026, 6, 15, 11, 0, 0, 0, time.UTC)
+
+	for _, tc := range []struct {
+		sha         string
+		attempt     int
+		disposition string
+	}{
+		{"shaatt01", 1, DispositionRefuted},
+		{"shaatt02", 2, DispositionRefuted},
+		{"shaatt03", 3, DispositionConfirmed},
+	} {
+		if _, err := w.AppendGateVerdict(root, GateVerdictInput{
+			BeadID: "ag-aggregate", RunID: "r1", TS: ts, Difficulty: 3,
+			PawlVerdictRef: PawlVerdictRef{BeadID: "ag-aggregate", HeadSHA: tc.sha},
+			Disposition:    tc.disposition, HeadSHA: tc.sha, Attempt: tc.attempt,
+			AuthorContextID: "ctx-1", RefuterFamilies: []string{"gpt"}, AuthorFamily: "claude",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := w.AppendUsage(root, UsageInput{
+		BeadID: "ag-aggregate", RunID: "r1", TS: ts,
+		TokensOut: 90, Model: "m", Phase: PhaseReview,
+		CategoryHint: CategoryProductive,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.AppendAccept(root, AcceptInput{
+		BeadID: "ag-aggregate", RunID: "r1", TS: ts,
+		MergeSHA: "merge01", MergedBy: "orch",
+		GateVerdictRef: PawlVerdictRef{BeadID: "ag-aggregate", HeadSHA: "shaatt03"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := ComputeGauges(l, "r1", 0, false)
+
+	if g.LCategory.Rework != 60 {
+		t.Errorf("rework = %d, want 60 (2 of 3 aggregate attempts before accept)", g.LCategory.Rework)
+	}
+	if g.LCategory.Productive != 30 {
+		t.Errorf("productive = %d, want 30 (accepting attempt's aggregate share)", g.LCategory.Productive)
+	}
+	if !g.LDefined || !approx(g.L, 2.0/3.0) {
+		t.Errorf("L = %v, want %v", g.L, 2.0/3.0)
 	}
 }
 

--- a/cli/internal/yieldledger/gauge_test.go
+++ b/cli/internal/yieldledger/gauge_test.go
@@ -341,7 +341,7 @@ func TestComputeGauges_AcceptedLateAttemptCountsPriorAttemptsAsRework(t *testing
 	}
 }
 
-func TestComputeGauges_AggregateAcceptedLateAttemptSpendIsProrated(t *testing.T) {
+func TestComputeGauges_PostConfirmProductiveSpendStaysProductive(t *testing.T) {
 	root := t.TempDir()
 	w := Writer{}
 	ts := time.Date(2026, 6, 15, 11, 0, 0, 0, time.UTC)
@@ -352,8 +352,7 @@ func TestComputeGauges_AggregateAcceptedLateAttemptSpendIsProrated(t *testing.T)
 		disposition string
 	}{
 		{"shaatt01", 1, DispositionRefuted},
-		{"shaatt02", 2, DispositionRefuted},
-		{"shaatt03", 3, DispositionConfirmed},
+		{"shaatt02", 2, DispositionConfirmed},
 	} {
 		if _, err := w.AppendGateVerdict(root, GateVerdictInput{
 			BeadID: "ag-aggregate", RunID: "r1", TS: ts, Difficulty: 3,
@@ -366,7 +365,7 @@ func TestComputeGauges_AggregateAcceptedLateAttemptSpendIsProrated(t *testing.T)
 	}
 	if _, err := w.AppendUsage(root, UsageInput{
 		BeadID: "ag-aggregate", RunID: "r1", TS: ts,
-		TokensOut: 90, Model: "m", Phase: PhaseReview,
+		TokensOut: 100, Model: "m", Phase: PhaseReview,
 		CategoryHint: CategoryProductive,
 	}); err != nil {
 		t.Fatal(err)
@@ -374,7 +373,7 @@ func TestComputeGauges_AggregateAcceptedLateAttemptSpendIsProrated(t *testing.T)
 	if _, err := w.AppendAccept(root, AcceptInput{
 		BeadID: "ag-aggregate", RunID: "r1", TS: ts,
 		MergeSHA: "merge01", MergedBy: "orch",
-		GateVerdictRef: PawlVerdictRef{BeadID: "ag-aggregate", HeadSHA: "shaatt03"},
+		GateVerdictRef: PawlVerdictRef{BeadID: "ag-aggregate", HeadSHA: "shaatt02"},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -385,14 +384,14 @@ func TestComputeGauges_AggregateAcceptedLateAttemptSpendIsProrated(t *testing.T)
 	}
 	g := ComputeGauges(l, "r1", 0, false)
 
-	if g.LCategory.Rework != 60 {
-		t.Errorf("rework = %d, want 60 (2 of 3 aggregate attempts before accept)", g.LCategory.Rework)
+	if g.LCategory.Rework != 0 {
+		t.Errorf("rework = %d, want 0 (post-confirm productive spend must not be prorated into rework)", g.LCategory.Rework)
 	}
-	if g.LCategory.Productive != 30 {
-		t.Errorf("productive = %d, want 30 (accepting attempt's aggregate share)", g.LCategory.Productive)
+	if g.LCategory.Productive != 100 {
+		t.Errorf("productive = %d, want 100 (usage emitted after confirming verdict is productive)", g.LCategory.Productive)
 	}
-	if !g.LDefined || !approx(g.L, 2.0/3.0) {
-		t.Errorf("L = %v, want %v", g.L, 2.0/3.0)
+	if !g.LDefined || !approx(g.L, 0) {
+		t.Errorf("L = %v, want 0", g.L)
 	}
 }
 


### PR DESCRIPTION
## Summary
- derive the accepting gate attempt from accept.gate_verdict_ref
- count usage assigned to attempts before the accepting attempt as L rework-loss
- prorate aggregate post-verdict usage across accepted attempts so pre-accept gate cost is visible
- add regression tests for per-attempt and aggregate accepted-bead rework attribution

## Tests
- cd cli && go test ./internal/yieldledger/...
- cd cli && go build ./...
- pre-push fast/head gate: 23 pass, 0 fail

Bead: ag-vro42