### PR TITLE
test(corpus-delta): expand held task set

### DIFF
--- a/evals/workbench/tasks/cd-agents-1/golden-solution.sh
+++ b/evals/workbench/tasks/cd-agents-1/golden-solution.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+file="${1:?Usage: check-no-runtime-agents.sh <changed-files.txt>}"
+bad=0
+while IFS= read -r path; do
+  case "$path" in
+    .agents/rpi/*|.agents/yield/*|.agents/swarm/*|.agents/ao/*|.agents/handoff/*)
+      echo "runtime .agents artifact: $path"
+      bad=1
+      ;;
+  esac
+done < "$file"
+exit "$bad"

--- a/evals/workbench/tasks/cd-agents-1/prompt.md
+++ b/evals/workbench/tasks/cd-agents-1/prompt.md
@@ -1,0 +1,14 @@
+# Task: runtime `.agents` artifact guard
+
+The `.agents` tree contains runtime evidence as well as intentional planning and
+spec artifacts. Runtime evidence should not be committed as product source.
+
+Write an executable script `check-no-runtime-agents.sh` in the current directory.
+
+Contract: `check-no-runtime-agents.sh <changed-files.txt>`
+- exit **1** if a changed file is under `.agents/rpi/`, `.agents/yield/`,
+  `.agents/swarm/`, `.agents/ao/`, or `.agents/handoff/`;
+- allow `.agents/specs/`, `.agents/plans/`, and `.agents/research/`;
+- exit **0** otherwise.
+
+Just write the script. Do not explain.

--- a/evals/workbench/tasks/cd-agents-1/score.sh
+++ b/evals/workbench/tasks/cd-agents-1/score.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKDIR="${1:?Usage: score.sh <workdir>}"
+SCRIPT="$WORKDIR/check-no-runtime-agents.sh"
+total=3
+score=0
+
+bad="$(mktemp)"; good="$(mktemp)"
+printf '.agents/rpi/run-1/state.json\n.agents/yield/yield-ledger.jsonl\n' > "$bad"
+printf '.agents/specs/yield.md\n.agents/plans/next.md\ndocs/3.0.md\n' > "$good"
+
+if [[ -f "$SCRIPT" ]]; then
+  score=$((score + 1))
+  chmod +x "$SCRIPT" 2>/dev/null || true
+  rc=0; bash "$SCRIPT" "$bad" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 1 ]] && score=$((score + 1))
+  rc=0; bash "$SCRIPT" "$good" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 0 ]] && score=$((score + 1))
+fi
+rm -f "$bad" "$good"
+
+pass=false; [[ "$score" -eq "$total" ]] && pass=true
+echo "{\"score\": $score, \"total\": $total, \"pass\": $pass}"

--- a/evals/workbench/tasks/cd-agents-1/setup.sh
+++ b/evals/workbench/tasks/cd-agents-1/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKDIR="${1:?Usage: setup.sh <workdir>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$WORKDIR"
+cp "$SCRIPT_DIR/prompt.md" "$WORKDIR/prompt.md"
+cat > "$WORKDIR/changed-files.txt" <<'TXT'
+.agents/specs/2026-06-14-yield-vector.md
+docs/3.0.md
+TXT

--- a/evals/workbench/tasks/cd-am-1/golden-solution.sh
+++ b/evals/workbench/tasks/cd-am-1/golden-solution.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+json="${1:?Usage: check-am-reservation-conflicts.sh <reservation-response.json>}"
+python3 - "$json" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1]))
+conflicts = data.get("conflicts") or []
+if conflicts:
+    first = conflicts[0]
+    path = first.get("path") or first.get("path_pattern") or first.get("pattern") or "<unknown>"
+    print(f"reservation conflict: {path}")
+    sys.exit(1)
+sys.exit(0)
+PY

--- a/evals/workbench/tasks/cd-am-1/prompt.md
+++ b/evals/workbench/tasks/cd-am-1/prompt.md
@@ -1,0 +1,15 @@
+# Task: reservation conflict fail-closed guard
+
+AgentOps agents reserve files before editing. A reservation response can grant
+some paths while also reporting conflicts. In that case automation must stop,
+not proceed with the granted subset.
+
+Write an executable script `check-am-reservation-conflicts.sh` in the current
+directory.
+
+Contract: `check-am-reservation-conflicts.sh <reservation-response.json>`
+- exit **1** if the JSON has any entries in `.conflicts`;
+- print a short message naming the conflicted path if possible;
+- exit **0** when `.conflicts` is absent or empty.
+
+Just write the script. Do not explain.

--- a/evals/workbench/tasks/cd-am-1/score.sh
+++ b/evals/workbench/tasks/cd-am-1/score.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKDIR="${1:?Usage: score.sh <workdir>}"
+SCRIPT="$WORKDIR/check-am-reservation-conflicts.sh"
+total=3
+score=0
+
+bad="$(mktemp)"
+good="$(mktemp)"
+cat > "$bad" <<'JSON'
+{"granted":[{"path_pattern":"a.go"}],"conflicts":[{"path":"b.go","holder":"OtherAgent"}]}
+JSON
+cat > "$good" <<'JSON'
+{"granted":[{"path_pattern":"a.go"}],"conflicts":[]}
+JSON
+
+if [[ -f "$SCRIPT" ]]; then
+  score=$((score + 1))
+  chmod +x "$SCRIPT" 2>/dev/null || true
+  rc=0; bash "$SCRIPT" "$bad" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 1 ]] && score=$((score + 1))
+  rc=0; bash "$SCRIPT" "$good" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 0 ]] && score=$((score + 1))
+fi
+rm -f "$bad" "$good"
+
+pass=false; [[ "$score" -eq "$total" ]] && pass=true
+echo "{\"score\": $score, \"total\": $total, \"pass\": $pass}"

--- a/evals/workbench/tasks/cd-am-1/setup.sh
+++ b/evals/workbench/tasks/cd-am-1/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKDIR="${1:?Usage: setup.sh <workdir>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$WORKDIR"
+cp "$SCRIPT_DIR/prompt.md" "$WORKDIR/prompt.md"
+cat > "$WORKDIR/reservation-response.json" <<'JSON'
+{
+  "granted": [{"path_pattern": "cli/internal/foo.go"}],
+  "conflicts": []
+}
+JSON

--- a/evals/workbench/tasks/cd-beads-1/golden-solution.sh
+++ b/evals/workbench/tasks/cd-beads-1/golden-solution.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+file="${1:?Usage: check-br-beads-dir.sh <shell-script>}"
+bad=0
+while IFS= read -r line; do
+  line="${line%%#*}"
+  [[ "$line" =~ (^|[[:space:]\;\&\|])br[[:space:]]+ ]] || continue
+  if [[ ! "$line" =~ BEADS_DIR=[^[:space:]\;\&\|]*_beads[\"\']?[[:space:]]+br[[:space:]]+ ]]; then
+    echo "unscoped br command: $line"
+    bad=1
+  fi
+done < "$file"
+exit "$bad"

--- a/evals/workbench/tasks/cd-beads-1/prompt.md
+++ b/evals/workbench/tasks/cd-beads-1/prompt.md
@@ -1,0 +1,14 @@
+# Task: file-backed br invocation guard
+
+AgentOps uses the file-backed `_beads` tracker database. A bare `br` command can
+hit the wrong local store and make a claim or close vanish from the shared file
+database.
+
+Write an executable script `check-br-beads-dir.sh` in the current directory.
+
+Contract: `check-br-beads-dir.sh <shell-script>`
+- exit **1** if a non-comment line invokes `br` without a same-command
+  `BEADS_DIR=.../_beads` environment assignment;
+- exit **0** when every `br` invocation is scoped to `_beads`.
+
+Just write the script. Do not explain.

--- a/evals/workbench/tasks/cd-beads-1/score.sh
+++ b/evals/workbench/tasks/cd-beads-1/score.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKDIR="${1:?Usage: score.sh <workdir>}"
+SCRIPT="$WORKDIR/check-br-beads-dir.sh"
+total=3
+score=0
+
+bad="$(mktemp)"; good="$(mktemp)"
+cat > "$bad" <<'SH'
+br update ag-123 --claim
+BEADS_DIR="$PWD/_beads" br show ag-123
+SH
+cat > "$good" <<'SH'
+BEADS_DIR="$PWD/_beads" br update ag-123 --claim
+BEADS_DIR=/repo/_beads br close ag-123 --reason done
+SH
+
+if [[ -f "$SCRIPT" ]]; then
+  score=$((score + 1))
+  chmod +x "$SCRIPT" 2>/dev/null || true
+  rc=0; bash "$SCRIPT" "$bad" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 1 ]] && score=$((score + 1))
+  rc=0; bash "$SCRIPT" "$good" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 0 ]] && score=$((score + 1))
+fi
+rm -f "$bad" "$good"
+
+pass=false; [[ "$score" -eq "$total" ]] && pass=true
+echo "{\"score\": $score, \"total\": $total, \"pass\": $pass}"

--- a/evals/workbench/tasks/cd-beads-1/setup.sh
+++ b/evals/workbench/tasks/cd-beads-1/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKDIR="${1:?Usage: setup.sh <workdir>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$WORKDIR"
+cp "$SCRIPT_DIR/prompt.md" "$WORKDIR/prompt.md"
+cat > "$WORKDIR/sample.sh" <<'SH'
+#!/usr/bin/env bash
+BEADS_DIR="$PWD/_beads" br show ag-demo
+SH

--- a/evals/workbench/tasks/cd-bv-1/golden-solution.sh
+++ b/evals/workbench/tasks/cd-bv-1/golden-solution.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+file="${1:?Usage: check-bv-robot-mode.sh <shell-script>}"
+bad=0
+while IFS= read -r line; do
+  line="${line%%#*}"
+  [[ "$line" =~ (^|[[:space:]\;\&\|])bv([[:space:]]|$) ]] || continue
+  if [[ ! "$line" =~ (^|[[:space:]\;\&\|])bv[[:space:]]+--robot-[A-Za-z0-9_-]+ ]]; then
+    echo "bare bv command: $line"
+    bad=1
+  fi
+done < "$file"
+exit "$bad"

--- a/evals/workbench/tasks/cd-bv-1/prompt.md
+++ b/evals/workbench/tasks/cd-bv-1/prompt.md
@@ -1,0 +1,12 @@
+# Task: robot-safe graph triage guard
+
+The graph triage tool has an interactive mode that can block an unattended
+agent lane. Automation must use robot-safe flags instead.
+
+Write an executable script `check-bv-robot-mode.sh` in the current directory.
+
+Contract: `check-bv-robot-mode.sh <shell-script>`
+- exit **1** if a non-comment line runs `bv` without a `--robot-*` flag;
+- exit **0** if every `bv` command uses a robot mode.
+
+Just write the script. Do not explain.

--- a/evals/workbench/tasks/cd-bv-1/score.sh
+++ b/evals/workbench/tasks/cd-bv-1/score.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKDIR="${1:?Usage: score.sh <workdir>}"
+SCRIPT="$WORKDIR/check-bv-robot-mode.sh"
+total=3
+score=0
+
+bad="$(mktemp)"; good="$(mktemp)"
+cat > "$bad" <<'SH'
+bv
+bv --robot-next
+SH
+cat > "$good" <<'SH'
+bv --robot-insights
+bv --robot-next --limit 5
+SH
+
+if [[ -f "$SCRIPT" ]]; then
+  score=$((score + 1))
+  chmod +x "$SCRIPT" 2>/dev/null || true
+  rc=0; bash "$SCRIPT" "$bad" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 1 ]] && score=$((score + 1))
+  rc=0; bash "$SCRIPT" "$good" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 0 ]] && score=$((score + 1))
+fi
+rm -f "$bad" "$good"
+
+pass=false; [[ "$score" -eq "$total" ]] && pass=true
+echo "{\"score\": $score, \"total\": $total, \"pass\": $pass}"

--- a/evals/workbench/tasks/cd-bv-1/setup.sh
+++ b/evals/workbench/tasks/cd-bv-1/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKDIR="${1:?Usage: setup.sh <workdir>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$WORKDIR"
+cp "$SCRIPT_DIR/prompt.md" "$WORKDIR/prompt.md"
+cat > "$WORKDIR/sample.sh" <<'SH'
+#!/usr/bin/env bash
+bv --robot-insights
+SH

--- a/evals/workbench/tasks/cd-door9-1/golden-solution.sh
+++ b/evals/workbench/tasks/cd-door9-1/golden-solution.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root="${1:?Usage: check-no-claude-print.sh <search-root>}"
+matches="$(grep -RIlE 'claude[[:space:]]+(-p|--print)([[:space:]]|$)' "$root" 2>/dev/null || true)"
+if [[ -n "$matches" ]]; then
+  printf '%s\n' "$matches"
+  exit 1
+fi
+exit 0

--- a/evals/workbench/tasks/cd-door9-1/prompt.md
+++ b/evals/workbench/tasks/cd-door9-1/prompt.md
@@ -1,0 +1,14 @@
+# Task: forbidden Claude print invocation guard
+
+There is a local quota/safety rule that forbids non-interactive Claude print
+invocations in this repo.
+
+Write an executable script `check-no-claude-print.sh` in the current directory.
+
+Contract: `check-no-claude-print.sh <search-root>`
+- exit **1** if any file under `<search-root>` contains `claude -p` or
+  `claude --print`;
+- print the offending file path(s);
+- exit **0** otherwise.
+
+Just write the script. Do not explain.

--- a/evals/workbench/tasks/cd-door9-1/score.sh
+++ b/evals/workbench/tasks/cd-door9-1/score.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKDIR="${1:?Usage: score.sh <workdir>}"
+SCRIPT="$WORKDIR/check-no-claude-print.sh"
+total=3
+score=0
+
+bad="$(mktemp -d)"; good="$(mktemp -d)"
+echo 'claude -p "review this"' > "$bad/run.sh"
+echo 'claude --print "review this"' > "$bad/also.sh"
+echo 'codex exec "review this"' > "$good/run.sh"
+
+if [[ -f "$SCRIPT" ]]; then
+  score=$((score + 1))
+  chmod +x "$SCRIPT" 2>/dev/null || true
+  rc=0; bash "$SCRIPT" "$bad" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 1 ]] && score=$((score + 1))
+  rc=0; bash "$SCRIPT" "$good" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 0 ]] && score=$((score + 1))
+fi
+rm -rf "$bad" "$good"
+
+pass=false; [[ "$score" -eq "$total" ]] && pass=true
+echo "{\"score\": $score, \"total\": $total, \"pass\": $pass}"

--- a/evals/workbench/tasks/cd-door9-1/setup.sh
+++ b/evals/workbench/tasks/cd-door9-1/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKDIR="${1:?Usage: setup.sh <workdir>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$WORKDIR/sample"
+cp "$SCRIPT_DIR/prompt.md" "$WORKDIR/prompt.md"
+echo 'codex exec "fix it"' > "$WORKDIR/sample/runner.sh"

--- a/evals/workbench/tasks/cd-generated-1/golden-solution.sh
+++ b/evals/workbench/tasks/cd-generated-1/golden-solution.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+file="${1:?Usage: check-generated-edits.sh <changed-files.txt>}"
+generated=false
+source=false
+while IFS= read -r path; do
+  case "$path" in
+    registry.json|docs/SKILLS.md|cli/docs/COMMANDS.md|docs/cli-surface.json|docs/cli-surface.md) generated=true ;;
+    skills/*|skills-codex/*|cli/cmd/ao/*) source=true ;;
+  esac
+done < "$file"
+if [[ "$generated" == "true" && "$source" != "true" ]]; then
+  echo "generated inventory changed without source"
+  exit 1
+fi
+exit 0

--- a/evals/workbench/tasks/cd-generated-1/prompt.md
+++ b/evals/workbench/tasks/cd-generated-1/prompt.md
@@ -1,0 +1,17 @@
+# Task: generated inventory edit guard
+
+AgentOps has generated inventories. The sources are edited, then regeneration
+updates the generated files. A PR that touches only the generated inventory is a
+hand-edit smell.
+
+Write an executable script `check-generated-edits.sh` in the current directory.
+
+Contract: `check-generated-edits.sh <changed-files.txt>`
+- exit **1** if a generated inventory path is changed without any matching
+  source path;
+- generated paths include `registry.json`, `docs/SKILLS.md`,
+  `cli/docs/COMMANDS.md`, `docs/cli-surface.json`, and `docs/cli-surface.md`;
+- source paths include `skills/`, `skills-codex/`, and `cli/cmd/ao/`;
+- exit **0** otherwise.
+
+Just write the script. Do not explain.

--- a/evals/workbench/tasks/cd-generated-1/score.sh
+++ b/evals/workbench/tasks/cd-generated-1/score.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKDIR="${1:?Usage: score.sh <workdir>}"
+SCRIPT="$WORKDIR/check-generated-edits.sh"
+total=3
+score=0
+
+bad="$(mktemp)"; good="$(mktemp)"
+printf 'registry.json\ndocs/SKILLS.md\n' > "$bad"
+printf 'skills/example/SKILL.md\nregistry.json\n' > "$good"
+
+if [[ -f "$SCRIPT" ]]; then
+  score=$((score + 1))
+  chmod +x "$SCRIPT" 2>/dev/null || true
+  rc=0; bash "$SCRIPT" "$bad" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 1 ]] && score=$((score + 1))
+  rc=0; bash "$SCRIPT" "$good" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 0 ]] && score=$((score + 1))
+fi
+rm -f "$bad" "$good"
+
+pass=false; [[ "$score" -eq "$total" ]] && pass=true
+echo "{\"score\": $score, \"total\": $total, \"pass\": $pass}"

--- a/evals/workbench/tasks/cd-generated-1/setup.sh
+++ b/evals/workbench/tasks/cd-generated-1/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKDIR="${1:?Usage: setup.sh <workdir>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$WORKDIR"
+cp "$SCRIPT_DIR/prompt.md" "$WORKDIR/prompt.md"
+cat > "$WORKDIR/changed-files.txt" <<'TXT'
+skills/example/SKILL.md
+registry.json
+TXT

--- a/evals/workbench/tasks/cd-git-1/golden-solution.sh
+++ b/evals/workbench/tasks/cd-git-1/golden-solution.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+file="${1:?Usage: check-no-main-push.sh <shell-script>}"
+bad=0
+while IFS= read -r line; do
+  line="${line%%#*}"
+  if [[ "$line" =~ git[[:space:]]+push([^#]*[[:space:]])?origin[[:space:]]+main([[:space:]]|$) ]]; then
+    echo "direct main push: $line"
+    bad=1
+  fi
+done < "$file"
+exit "$bad"

--- a/evals/workbench/tasks/cd-git-1/prompt.md
+++ b/evals/workbench/tasks/cd-git-1/prompt.md
@@ -1,0 +1,13 @@
+# Task: PR-only lane main-push guard
+
+In PR-only work, the author branch may be pushed, but `main` must be merged by
+the orchestrator or release gate.
+
+Write an executable script `check-no-main-push.sh` in the current directory.
+
+Contract: `check-no-main-push.sh <shell-script>`
+- exit **1** if a non-comment line pushes directly to `main`;
+- allow pushing a task branch;
+- exit **0** otherwise.
+
+Just write the script. Do not explain.

--- a/evals/workbench/tasks/cd-git-1/score.sh
+++ b/evals/workbench/tasks/cd-git-1/score.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKDIR="${1:?Usage: score.sh <workdir>}"
+SCRIPT="$WORKDIR/check-no-main-push.sh"
+total=3
+score=0
+
+bad="$(mktemp)"; good="$(mktemp)"
+cat > "$bad" <<'SH'
+git push origin main
+git push -u origin task/ag-good
+SH
+cat > "$good" <<'SH'
+git push -u origin task/ag-good
+git push origin HEAD:refs/heads/task/ag-good
+SH
+
+if [[ -f "$SCRIPT" ]]; then
+  score=$((score + 1))
+  chmod +x "$SCRIPT" 2>/dev/null || true
+  rc=0; bash "$SCRIPT" "$bad" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 1 ]] && score=$((score + 1))
+  rc=0; bash "$SCRIPT" "$good" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 0 ]] && score=$((score + 1))
+fi
+rm -f "$bad" "$good"
+
+pass=false; [[ "$score" -eq "$total" ]] && pass=true
+echo "{\"score\": $score, \"total\": $total, \"pass\": $pass}"

--- a/evals/workbench/tasks/cd-git-1/setup.sh
+++ b/evals/workbench/tasks/cd-git-1/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKDIR="${1:?Usage: setup.sh <workdir>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$WORKDIR"
+cp "$SCRIPT_DIR/prompt.md" "$WORKDIR/prompt.md"
+cat > "$WORKDIR/sample.sh" <<'SH'
+git push -u origin task/ag-demo
+SH

--- a/evals/workbench/tasks/cd-worktree-1/golden-solution.sh
+++ b/evals/workbench/tasks/cd-worktree-1/golden-solution.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+bead="${1:?Usage: check-worktree-per-bead.sh <bead-id> <shell-script>}"
+file="${2:?}"
+if grep -Eq "git[[:space:]]+worktree[[:space:]]+add[^#\n]*${bead}" "$file" || grep -Eq "agentops-wt-${bead}" "$file"; then
+  exit 0
+fi
+echo "missing per-bead worktree for $bead"
+exit 1

--- a/evals/workbench/tasks/cd-worktree-1/prompt.md
+++ b/evals/workbench/tasks/cd-worktree-1/prompt.md
@@ -1,0 +1,13 @@
+# Task: per-bead worktree preflight
+
+AgentOps lanes should not edit from the shared root checkout. They start from a
+per-bead worktree whose path names the bead.
+
+Write an executable script `check-worktree-per-bead.sh` in the current directory.
+
+Contract: `check-worktree-per-bead.sh <bead-id> <shell-script>`
+- exit **1** if the script does not add or use a git worktree path containing
+  the bead id;
+- exit **0** when it does.
+
+Just write the script. Do not explain.

--- a/evals/workbench/tasks/cd-worktree-1/score.sh
+++ b/evals/workbench/tasks/cd-worktree-1/score.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKDIR="${1:?Usage: score.sh <workdir>}"
+SCRIPT="$WORKDIR/check-worktree-per-bead.sh"
+total=3
+score=0
+
+bad="$(mktemp)"; good="$(mktemp)"
+cat > "$bad" <<'SH'
+cd /Users/bo/dev/agentops
+git checkout -b task/ag-demo
+SH
+cat > "$good" <<'SH'
+git worktree add ../agentops-wt-ag-demo -b task/ag-demo origin/main
+cd ../agentops-wt-ag-demo
+SH
+
+if [[ -f "$SCRIPT" ]]; then
+  score=$((score + 1))
+  chmod +x "$SCRIPT" 2>/dev/null || true
+  rc=0; bash "$SCRIPT" ag-demo "$bad" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 1 ]] && score=$((score + 1))
+  rc=0; bash "$SCRIPT" ag-demo "$good" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -eq 0 ]] && score=$((score + 1))
+fi
+rm -f "$bad" "$good"
+
+pass=false; [[ "$score" -eq "$total" ]] && pass=true
+echo "{\"score\": $score, \"total\": $total, \"pass\": $pass}"

--- a/evals/workbench/tasks/cd-worktree-1/setup.sh
+++ b/evals/workbench/tasks/cd-worktree-1/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKDIR="${1:?Usage: setup.sh <workdir>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$WORKDIR"
+cp "$SCRIPT_DIR/prompt.md" "$WORKDIR/prompt.md"
+cat > "$WORKDIR/sample.sh" <<'SH'
+git worktree add ../agentops-wt-ag-demo -b task/ag-demo origin/main
+SH

--- a/evals/workbench/tasks/corpus-delta-held-set.md
+++ b/evals/workbench/tasks/corpus-delta-held-set.md
@@ -1,0 +1,46 @@
+# Corpus Delta Held Task Set
+
+Bead: ag-nfux, W1b of ag-8p8o.
+
+The original design document named in the bead,
+`.agents/research/2026-06-03-corpus-delta-experiment-design.md`, is absent from
+this workspace. The local replacement plan records it as lost in the 2026-05-07
+`.agents` wipe and restates the W1b constraint: expand the held set to at least
+10 realistic, under-specified tasks whose relevant prior decisions exist in the
+corpus, with deterministic graders and no LLM judge.
+
+## Selection Rule
+
+Tasks were selected from recurring AgentOps operational failures that the corpus
+documents as decisions, guardrails, or incident lessons. They are not selected
+because the exact requested script already exists in the corpus. The expected
+answer is a small new guard script, while the helpful context is the local
+doctrine: what counts as a violation, what is allowed, and why the rule matters.
+
+Every task ships:
+
+- `prompt.md`: the agent-facing task prompt.
+- `setup.sh`: an isolated workspace fixture.
+- `score.sh`: a deterministic pass/fail grader.
+- `golden-solution.sh`: a reference implementation used only by fixture tests.
+
+The grader-discrimination gate requires each golden solution to pass and an
+empty workspace to fail.
+
+## Held Tasks
+
+| Task | Corpus decision it exercises | Why it plausibly benefits from corpus |
+|---|---|---|
+| `cd-ci-1` | No advisory middle tier in CI: a continue-on-error job cannot also be a PR check. | The rule is local CI doctrine, not generic GitHub Actions trivia. |
+| `cd-ci-4` | Removing a named CI job requires a corpus grep for surviving assertions. | The failure mode is a local release/eval artifact pattern. |
+| `cd-am-1` | Agent Mail reservation responses must fail closed on any file conflict. | The AM conflict-prevention contract is local operating doctrine. |
+| `cd-beads-1` | `br` must be scoped with `BEADS_DIR=$PWD/_beads`; legacy/default stores are unsafe. | The root tracker migration and file-backed DB rule are repo-specific. |
+| `cd-bv-1` | `bv` is never run bare; only robot modes are safe in automation. | This prevents a real local TUI hang failure encoded in the beads skill. |
+| `cd-door9-1` | `claude -p` / `claude --print` are forbidden command surfaces. | The ban is a local quota/safety law, not a universal shell rule. |
+| `cd-git-1` | PR-only lanes must never push directly to `main`. | The release gate and orchestrator merge boundary are local workflow rules. |
+| `cd-worktree-1` | Work starts in a per-bead worktree whose path names the bead. | The durable-lane model depends on bead-scoped worktrees, not shared root edits. |
+| `cd-generated-1` | Generated inventories cannot be hand-edited without source changes. | The generated artifact list and source-of-truth order are local contracts. |
+| `cd-agents-1` | Runtime `.agents` evidence must not be committed as product surface. | The repo distinguishes corpus/runtime artifacts from tracked source. |
+
+The set deliberately mixes CI, tracker, coordination, runtime, and generated
+artifact surfaces so success is not reducible to one regex trick or one domain.

--- a/tests/scripts/corpus-delta-tasks.bats
+++ b/tests/scripts/corpus-delta-tasks.bats
@@ -1,10 +1,23 @@
 #!/usr/bin/env bats
-# ag-nfux (ag-8p8o W1b): the held corpus-delta task set (operator-approved: cd-ci-1, cd-ci-4).
+# ag-nfux (ag-8p8o W1b): the held corpus-delta task set.
 # These cases verify the TASK FIXTURES THEMSELVES are well-formed: each grader must
 # DISCRIMINATE — the golden reference solution scores pass, an empty workspace scores fail.
 # A grader that always passes (or always fails) would make the A/B meaningless.
 
 TASKS="$BATS_TEST_DIRNAME/../../evals/workbench/tasks"
+
+CORPUS_DELTA_TASKS=(
+  "cd-ci-1:check-no-advisory-tier.sh"
+  "cd-ci-4:check-removed-job-assertions.sh"
+  "cd-am-1:check-am-reservation-conflicts.sh"
+  "cd-beads-1:check-br-beads-dir.sh"
+  "cd-bv-1:check-bv-robot-mode.sh"
+  "cd-door9-1:check-no-claude-print.sh"
+  "cd-git-1:check-no-main-push.sh"
+  "cd-worktree-1:check-worktree-per-bead.sh"
+  "cd-generated-1:check-generated-edits.sh"
+  "cd-agents-1:check-no-runtime-agents.sh"
+)
 
 run_task_with_solution() {
   local task="$1" outfile="$2" solution="$3"   # solution: path to drop in, or "" for none
@@ -14,35 +27,36 @@ run_task_with_solution() {
   bash "$TASKS/$task/score.sh" "$wd"
 }
 
-@test "cd-ci-1: golden solution scores pass (grader rewards a correct gate)" {
-  run run_task_with_solution cd-ci-1 check-no-advisory-tier.sh golden-solution.sh
-  [ "$status" -eq 0 ]
-  echo "$output" | tail -1 | jq -e '.pass == true and .score == 3' >/dev/null
+@test "held task set has at least 10 corpus-delta tasks" {
+  [ "${#CORPUS_DELTA_TASKS[@]}" -ge 10 ]
 }
 
-@test "cd-ci-1: empty workspace scores fail (grader does not pass nothing)" {
-  run run_task_with_solution cd-ci-1 check-no-advisory-tier.sh ""
-  [ "$status" -eq 0 ]
-  echo "$output" | tail -1 | jq -e '.pass == false' >/dev/null
-}
-
-@test "cd-ci-4: golden solution scores pass" {
-  run run_task_with_solution cd-ci-4 check-removed-job-assertions.sh golden-solution.sh
-  [ "$status" -eq 0 ]
-  echo "$output" | tail -1 | jq -e '.pass == true and .score == 3' >/dev/null
-}
-
-@test "cd-ci-4: empty workspace scores fail" {
-  run run_task_with_solution cd-ci-4 check-removed-job-assertions.sh ""
-  [ "$status" -eq 0 ]
-  echo "$output" | tail -1 | jq -e '.pass == false' >/dev/null
-}
-
-@test "both tasks ship prompt.md + setup.sh + score.sh + golden-solution.sh" {
-  for t in cd-ci-1 cd-ci-4; do
+@test "all corpus-delta tasks ship prompt, setup, score, and golden solution" {
+  for entry in "${CORPUS_DELTA_TASKS[@]}"; do
+    t="${entry%%:*}"
     [ -f "$TASKS/$t/prompt.md" ]
     [ -f "$TASKS/$t/setup.sh" ]
     [ -f "$TASKS/$t/score.sh" ]
     [ -f "$TASKS/$t/golden-solution.sh" ]
+  done
+}
+
+@test "every golden solution passes its deterministic grader" {
+  for entry in "${CORPUS_DELTA_TASKS[@]}"; do
+    t="${entry%%:*}"
+    outfile="${entry#*:}"
+    run run_task_with_solution "$t" "$outfile" golden-solution.sh
+    [ "$status" -eq 0 ]
+    echo "$output" | tail -1 | jq -e '.pass == true and .score == .total' >/dev/null
+  done
+}
+
+@test "every empty workspace fails its deterministic grader" {
+  for entry in "${CORPUS_DELTA_TASKS[@]}"; do
+    t="${entry%%:*}"
+    outfile="${entry#*:}"
+    run run_task_with_solution "$t" "$outfile" ""
+    [ "$status" -eq 0 ]
+    echo "$output" | tail -1 | jq -e '.pass == false' >/dev/null
   done
 }


### PR DESCRIPTION
## Summary
- expand the ag-nfux corpus-delta held set from 2 to 10 deterministic workbench tasks
- add eight new corpus-plausible task fixtures with prompt/setup/score/golden-solution files
- add held-set selection rationale documenting the anti-engineering selection rule and the missing original design doc
- update the corpus-delta task verifier so every task must pass golden and fail empty workspace

## Added tasks
- cd-am-1: Agent Mail reservation conflicts fail closed
- cd-beads-1: br commands must be BEADS_DIR-scoped to _beads
- cd-bv-1: bv automation must use robot mode
- cd-door9-1: no claude -p / --print
- cd-git-1: PR-only lanes do not push main
- cd-worktree-1: per-bead worktree preflight
- cd-generated-1: generated inventories require source edits
- cd-agents-1: runtime .agents artifacts stay out of tracked changes

## Validation
- bash -n over evals/workbench/tasks/cd-*/*.sh
- shellcheck evals/workbench/tasks/cd-*/*.sh
- bats tests/scripts/corpus-delta-tasks.bats
- bash scripts/check-eval-workbench.sh
- git diff --check
- pre-push fast/head: 19 pass, 0 fail

Bead: ag-nfux