### PR TITLE
feat(propulsion): no-daemonized-wake guardrail (ag-cjruu)

### DIFF
--- a/scripts/check-no-daemonized-wake.sh
+++ b/scripts/check-no-daemonized-wake.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# check-no-daemonized-wake.sh — guardrail (ag-cjruu).
+#
+# The wake bridge (scripts/ntm-attention-tend.sh) is a SINGLE-SHOT, on-demand
+# reconcile pass BY DESIGN (Direction D; council verdict
+# .agents/council/2026-06-15-propulsion-one-way-door-verdict.md). Wiring it into
+# an always-on launcher — cron, launchd, systemd, or a shell loop — turns it into
+# the standing daemon the council DEFERRED until ag-egpu (the workload-object /
+# watch schema, one-way door #2) is council-ratified. Both judges named this trap:
+# D must not sprawl into a sticky pseudo-daemon before ag-egpu lands.
+#
+# This guard FAILS the build if a daemonized invocation of the bridge appears, so
+# the one-way door is never walked through silently. Once ag-egpu ratifies a watch
+# surface, the always-on form is allowed and this guard is retired.
+#
+# Usage: check-no-daemonized-wake.sh [root]    (default: git repo root)
+# Exit:  0 = no daemonized wake found (PASS); 1 = a daemonized invocation found.
+#
+# Portability: bash 3.2+ (no mapfile).
+
+set -euo pipefail
+
+ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+BRIDGE="ntm-attention-tend"
+note() { printf '[check-no-daemonized-wake] %s\n' "$*" >&2; }
+
+# Files that may legitimately NAME the bridge without daemonizing it: the bridge
+# itself, its test, this guard, and this guard's test.
+is_self() {
+  case "$1" in
+    */ntm-attention-tend.sh|*/ntm-attention-tend.bats) return 0 ;;
+    */check-no-daemonized-wake.sh|*/check-no-daemonized-wake.bats) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Collect files that reference the bridge (tracked files when in a repo).
+refs=()
+if git -C "$ROOT" rev-parse >/dev/null 2>&1; then
+  while IFS= read -r f; do [ -n "$f" ] && refs+=("$ROOT/$f"); done \
+    < <(git -C "$ROOT" grep -lI "$BRIDGE" -- . 2>/dev/null || true)
+else
+  while IFS= read -r f; do [ -n "$f" ] && refs+=("$f"); done \
+    < <(grep -rlI "$BRIDGE" "$ROOT" 2>/dev/null || true)
+fi
+
+violations=0
+[ "${#refs[@]}" -eq 0 ] && { note "no references to $BRIDGE — OK"; exit 0; }
+
+for f in "${refs[@]}"; do
+  is_self "$f" && continue
+  reason=""
+  # 1) systemd/launchd units, incl. generated (.in/.tmpl) + drop-in dirs.
+  case "$f" in
+    *.service|*.service.*|*.timer|*.timer.*|*.plist|*.plist.*) reason="systemd/launchd unit references the bridge" ;;
+    */systemd/*) reason="systemd unit directory references the bridge" ;;
+  esac
+  # 2) cron — numeric schedule OR macro (@reboot/@hourly/...) on a bridge line.
+  if [ -z "$reason" ] && grep -Eq '^[[:space:]]*(@(reboot|hourly|daily|weekly|monthly|yearly|annually|midnight)|([0-9*/,-]+[[:space:]]+){4,5}).*'"$BRIDGE" "$f" 2>/dev/null; then
+    reason="cron schedule/macro invokes the bridge"
+  fi
+  # 3) one-line launchers on the SAME line as the bridge (low false-positive).
+  if [ -z "$reason" ] && grep -Eq '((watch|nohup)[[:space:]]+.*'"$BRIDGE"'|'"$BRIDGE"'[^&]*&[[:space:]]*$)' "$f" 2>/dev/null; then
+    reason="backgrounded/watch launcher invokes the bridge"
+  fi
+  # 4) INFINITE-loop / process-manager / service-enable wrapping the bridge. Match
+  #    only daemon signals (while true, until false, for ((;;)), watch, nohup, pm2,
+  #    supervisor, systemctl enable, launchctl load) — NOT a finite `for x in`,
+  #    which is a legit on-demand multi-session call. Skip pure docs (*.md).
+  if [ -z "$reason" ]; then
+    case "$f" in *.md) : ;; *)
+      if grep -Eq 'while[[:space:]]+(true|:)|until[[:space:]]+(false|:)|for[[:space:]]*\(\([[:space:]]*;;|watch[[:space:]]|nohup[[:space:]]|disown|pm2|supervisor(d|ctl)?|systemctl[[:space:]]+enable|launchctl[[:space:]]+load|crontab' "$f" 2>/dev/null \
+         && grep -q "$BRIDGE" "$f" 2>/dev/null; then
+        reason="infinite-loop/process-manager/service-enable wraps the bridge"
+      fi ;;
+    esac
+  fi
+  if [ -n "$reason" ]; then
+    note "VIOLATION: $f — $reason"
+    violations=$((violations + 1))
+  fi
+done
+
+if [ "$violations" -gt 0 ]; then
+  note "FAIL: $violations daemonized wake invocation(s). The wake bridge must stay"
+  note "single-shot/on-demand until ag-egpu (one-way door #2) ratifies a watch"
+  note "surface. See ag-cjruu / the propulsion council verdict."
+  exit 1
+fi
+note "OK: no daemonized wake invocation found"
+exit 0

--- a/tests/scripts/check-no-daemonized-wake.bats
+++ b/tests/scripts/check-no-daemonized-wake.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+# Acceptance for scripts/check-no-daemonized-wake.sh (ag-cjruu).
+# The guard must FAIL when the wake bridge is wired into any always-on launcher
+# (systemd/launchd/cron/loop) and PASS for clean / on-demand / self references.
+
+setup() {
+  GUARD="${BATS_TEST_DIRNAME}/../../scripts/check-no-daemonized-wake.sh"
+  ROOT="$(mktemp -d)"          # non-git fixture dir -> guard uses grep fallback
+}
+teardown() { rm -rf "$ROOT"; }
+
+@test "PASS: no reference to the bridge" {
+  echo "nothing here" > "$ROOT/readme.md"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 0 ]
+}
+
+@test "PASS: on-demand mention (doc / plain call, no daemon)" {
+  printf '%s\n' "Run scripts/ntm-attention-tend.sh mysession once when you need it." > "$ROOT/docs.md"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 0 ]
+}
+
+@test "FAIL: systemd .service references the bridge" {
+  printf '%s\n' "[Service]" "ExecStart=/repo/scripts/ntm-attention-tend.sh sess" > "$ROOT/wake.service"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"VIOLATION"* ]]
+}
+
+@test "FAIL: systemd .timer references the bridge" {
+  printf '%s\n' "[Timer]" "OnCalendar=*:0/5" "Unit=wake.service ntm-attention-tend" > "$ROOT/wake.timer"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "FAIL: launchd .plist references the bridge" {
+  printf '%s\n' "<string>/repo/scripts/ntm-attention-tend.sh</string>" > "$ROOT/com.wake.plist"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "FAIL: cron schedule invokes the bridge" {
+  printf '%s\n' "*/5 * * * * /repo/scripts/ntm-attention-tend.sh sess" > "$ROOT/crontab"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "FAIL: shell loop wraps the bridge" {
+  printf '%s\n' "#!/usr/bin/env bash" "while true; do" "  ntm-attention-tend.sh sess" "  sleep 30" "done" > "$ROOT/loop.sh"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "FAIL: cron @reboot macro invokes the bridge" {
+  printf '%s\n' "@reboot /repo/scripts/ntm-attention-tend.sh sess" > "$ROOT/crontab"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "FAIL: for ((;;)) infinite loop wraps the bridge" {
+  printf '%s\n' "#!/usr/bin/env bash" "for ((;;)); do ntm-attention-tend.sh sess; sleep 30; done" > "$ROOT/loop2.sh"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "FAIL: watch -n drives the bridge" {
+  printf '%s\n' "#!/usr/bin/env bash" "watch -n 30 ntm-attention-tend.sh sess" > "$ROOT/w.sh"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "FAIL: nohup backgrounds the bridge" {
+  printf '%s\n' "#!/usr/bin/env bash" "nohup ntm-attention-tend.sh sess &" > "$ROOT/n.sh"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "FAIL: pm2 process manager runs the bridge" {
+  printf '%s\n' "module.exports = { apps: [{ script: 'scripts/ntm-attention-tend.sh' }] }" "// pm2 ecosystem" > "$ROOT/ecosystem.config.js"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "FAIL: supervisor program runs the bridge" {
+  printf '%s\n' "[program:wake]" "command=scripts/ntm-attention-tend.sh sess" "; supervisord" > "$ROOT/supervisor.conf"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "FAIL: generated unit (.service.in) references the bridge" {
+  printf '%s\n' "[Service]" "ExecStart=@PREFIX@/scripts/ntm-attention-tend.sh sess" > "$ROOT/wake.service.in"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "FAIL: systemd drop-in (.service.d/override.conf) references the bridge" {
+  mkdir -p "$ROOT/wake.service.d"
+  printf '%s\n' "[Service]" "ExecStart=scripts/ntm-attention-tend.sh sess" > "$ROOT/wake.service.d/override.conf"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 1 ]
+}
+
+@test "PASS: finite for-loop over sessions is on-demand, not a daemon" {
+  printf '%s\n' "#!/usr/bin/env bash" "for s in a b c; do ntm-attention-tend.sh \"\$s\"; done" > "$ROOT/finite.sh"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 0 ]
+}
+
+# This is the WIRING: CI runs this bats file (validate.yml), so this case runs the
+# guard against the REAL repo root every build. If anyone later daemonizes the
+# bridge in-repo, THIS test fails in CI — the guard has teeth, not just fixtures.
+@test "guard runs against the repo root and passes (CI enforcement)" {
+  repo_root="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  run bash "$GUARD" "$repo_root"
+  [ "$status" -eq 0 ]
+}
+
+@test "PASS: the bridge file itself is not flagged" {
+  mkdir -p "$ROOT/scripts"
+  printf '%s\n' "#!/usr/bin/env bash" "# ntm-attention-tend.sh self" "while kill -0 x; do :; done" > "$ROOT/scripts/ntm-attention-tend.sh"
+  run bash "$GUARD" "$ROOT"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Guardrail (Direction-D council): the wake bridge must stay single-shot/on-demand until ag-egpu (one-way door #2) ratifies a watch surface. `scripts/check-no-daemonized-wake.sh` FAILs the build if the bridge is wired into systemd/launchd/cron(+macros)/drop-ins or an infinite-loop/watch/nohup/pm2/supervisor wrapper; finite on-demand loops pass (no false positive). Wired into CI via a repo-root bats case. Cross-family gate PASS (codex gpt-5.5, author≠reviewer, 3 rounds — caught matcher gaps + the unwired-guard dead-authority risk). 18 bats, shellcheck clean.

Closes: ag-cjruu