### PR TITLE
Document ATM peer duel default

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1678,8 +1678,8 @@
     {
       "name": "using-atm",
       "source_skill": "skills/using-atm",
-      "source_hash": "61fd16d8ad46cfa7935ff3a5e52009fec3db793c708ab492d493f2b9edfd9b70",
-      "generated_hash": "99c0032be04b21d717fd071fc83db6db37c3235202547a5820c409bb3e10da87"
+      "source_hash": "7ed9c93047c0874ab63d6605aae202618cec6bdf1b5958a1743d7df05a306227",
+      "generated_hash": "370526e80efd36b2aae6b6a15f0897f570c90f656069b89f7828c3e367de6d57"
     },
     {
       "name": "validate",
@@ -1696,8 +1696,8 @@
     {
       "name": "vibing-with-ntm",
       "source_skill": "skills/vibing-with-ntm",
-      "source_hash": "af5f17f44cad354359a4abed8de05422b2bc6dc35f8f612793c603dfd834a7f2",
-      "generated_hash": "cda2515fc6773fb561d9c6432c7ecbcf5e5fdea9e4e4c8e03417069e25a60fdc"
+      "source_hash": "33b4d4d88af99774ba37d52b934f0c5c1a0bef23e53055628ef1681047de9212",
+      "generated_hash": "75e5fd0a64297dd770bd5870be3bf1adbdb0843382367e910174fe56a1ba0e12"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/using-atm/.agentops-generated.json
+++ b/skills-codex/using-atm/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/using-atm",
   "layout": "modular",
-  "source_hash": "61fd16d8ad46cfa7935ff3a5e52009fec3db793c708ab492d493f2b9edfd9b70",
-  "generated_hash": "99c0032be04b21d717fd071fc83db6db37c3235202547a5820c409bb3e10da87"
+  "source_hash": "7ed9c93047c0874ab63d6605aae202618cec6bdf1b5958a1743d7df05a306227",
+  "generated_hash": "370526e80efd36b2aae6b6a15f0897f570c90f656069b89f7828c3e367de6d57"
 }

--- a/skills-codex/using-atm/SKILL.md
+++ b/skills-codex/using-atm/SKILL.md
@@ -48,6 +48,39 @@ tend AgentOps loops on an ATM swarm.
 4. **Green CI is the merge gate.** Each worker drives its bead to a green PR from
    a per-bead worktree; the operator stays *on* the loop (intent + stop), not *in* it.
 
+### Fresh Claude/Codex Peer Duels
+
+When the operator asks for "a fresh Claude and Codex", "fresh peer models", a
+"duel", or a cross-family opinion, the default substrate is **ATM panes**, not
+headless one-shot CLIs. Spawn the requested model families, give both panes the
+same bounded prompt, verify engagement, collect pane output, and kill the
+temporary session.
+
+Do not use print-mode CLIs for the other-family pane; use an interactive pane.
+Use headless `codex exec` only when the operator explicitly asks for a headless
+run or when there is no pane/TUI requirement.
+
+Minimal bounded pattern:
+
+```bash
+atm spawn agentops --label navi-duel --no-user --cc=1:opus --cod=1:gpt-5.5 \
+  --no-cass-context --ready-timeout=2m --json
+
+atm send agentops--navi-duel --pane=1 --file prompt.md \
+  --no-cass-check --force-non-interactive --json
+
+atm codex preflight --session agentops--navi-duel --pane 2 --json
+atm send agentops--navi-duel --pane=2 --codex-goal --file prompt.md \
+  --no-cass-check --force-non-interactive --json
+atm codex wait-goal-engaged --session agentops--navi-duel --pane 2 --json
+
+atm kill agentops--navi-duel --json
+```
+
+If a requested alias resolves to a nearby installed model (for example `opus`
+resolving to the available Opus build), report the actual pane model in the
+verdict.
+
 ## Quick start
 
 ```bash

--- a/skills-codex/vibing-with-ntm/.agentops-generated.json
+++ b/skills-codex/vibing-with-ntm/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/vibing-with-ntm",
   "layout": "modular",
-  "source_hash": "af5f17f44cad354359a4abed8de05422b2bc6dc35f8f612793c603dfd834a7f2",
-  "generated_hash": "cda2515fc6773fb561d9c6432c7ecbcf5e5fdea9e4e4c8e03417069e25a60fdc"
+  "source_hash": "33b4d4d88af99774ba37d52b934f0c5c1a0bef23e53055628ef1681047de9212",
+  "generated_hash": "75e5fd0a64297dd770bd5870be3bf1adbdb0843382367e910174fe56a1ba0e12"
 }

--- a/skills-codex/vibing-with-ntm/SKILL.md
+++ b/skills-codex/vibing-with-ntm/SKILL.md
@@ -21,4 +21,8 @@ Read it first, then use `prompt.md` for the Codex runtime profile.
   unblock-condition, verdict/dry-run requests) as interrupts: answer the gate
   before broad watching, and surface the result where the peer can actually read
   it.
+- For fresh Claude/Codex duel requests, load `$using-atm` and use ATM panes
+  (`atm spawn ... --cc=1:opus --cod=1:gpt-5.5 --no-user`), Codex goal-flow
+  verification, and `atm kill` cleanup. Never use print-mode CLIs for the
+  other-family pane.
 - Return concrete evidence: commands run, files touched, exit codes, and any remaining blocker.

--- a/skills/using-atm/SKILL.md
+++ b/skills/using-atm/SKILL.md
@@ -81,6 +81,41 @@ dispatch and tend AgentOps loops on an ATM swarm.
    a per-bead worktree (orchestrator-merge model); the operator stays *on* the
    loop (intent + stop), not *in* it (per-PR approval).
 
+### Fresh Claude/Codex Peer Duels
+
+When the operator asks for "a fresh Claude and Codex", "fresh peer models", a
+"duel", or a cross-family opinion, the default substrate is **ATM panes**, not
+headless one-shot CLIs. Spawn exactly the requested model families, give both
+the same bounded prompt, verify engagement, collect pane output, and kill the
+temporary session when done. Do **not** use `claude -p` / `claude --print` for
+this shape; use an interactive Claude pane. Use headless `codex exec` only when
+the operator explicitly asks for headless execution or there is no pane/TUI
+requirement.
+
+Minimal bounded pattern:
+
+```bash
+atm spawn agentops --label navi-duel --no-user --cc=1:opus --cod=1:gpt-5.5 \
+  --no-cass-context --ready-timeout=2m --json
+
+# Claude pane: direct prompt is fine.
+atm send agentops--navi-duel --pane=1 --file prompt.md \
+  --no-cass-check --force-non-interactive --json
+
+# Codex pane: use the goal lifecycle and prove engagement.
+atm codex preflight --session agentops--navi-duel --pane 2 --json
+atm send agentops--navi-duel --pane=2 --codex-goal --file prompt.md \
+  --no-cass-check --force-non-interactive --json
+atm codex wait-goal-engaged --session agentops--navi-duel --pane 2 --json
+
+# After collecting outputs, do not leave idle duel panes around.
+atm kill agentops--navi-duel --json
+```
+
+If the requested model alias resolves to a nearby available runtime (for
+example `opus` resolving to the installed Opus build), report the actual pane
+model in the closeout instead of silently claiming the requested alias.
+
 ## Quick start
 
 ```bash

--- a/skills/vibing-with-ntm/SKILL.md
+++ b/skills/vibing-with-ntm/SKILL.md
@@ -147,6 +147,15 @@ Every card (OC-###) and anti-pattern (AP-###) is documented with recipe, prompt 
 ## Command Surfaces (do not re-learn from here)
 
 - **`atm` is `ntm`.** `atm` (Bo's fork/alias, `~/.local/bin/atm`) is byte-identical to `ntm` — same robot surface, same flags, same exit codes. Every `ntm …` / `ntm --robot-*` form in this skill and its references applies verbatim to `atm`; the out-of-session substrate-runner skill is named `using-atm` for that reason. Use whichever the operator typed; they resolve to one contract.
+- **Fresh Claude/Codex duel requests go through ATM panes.** If the operator asks for
+  fresh Claude and Codex peers, a cross-family duel, or fresh peer-model
+  judgment, spawn the requested panes with `atm spawn` and follow the
+  `using-atm` "Fresh Claude/Codex Peer Duels" pattern. Do not route this shape
+  through `claude -p` / `claude --print` or ad hoc headless one-shots; the value
+  is fresh interactive peer state plus observable pane engagement. Use
+  `atm codex preflight`, `atm send --codex-goal`, and
+  `atm codex wait-goal-engaged` for the Codex pane, then kill the temporary
+  duel session after collecting output.
 - **Agents use robot surfaces** (`--robot-snapshot`, `--robot-attention`, `--robot-send`, `--robot-smart-restart`, …); interactive TUIs (`ntm dashboard`, `palette`, `view`) are for humans. The authoritative catalog is `ntm robot-docs` / `ntm --help` — re-query it; see [ROBOT-MODE.md](references/ROBOT-MODE.md) for lanes, transports, and deprecations.
 - **Marching orders:** copy-paste dispatch prompts (first dispatch, steady-state, wide-swarm domain assignment, review dispatch) live in [PROMPTS.md](references/PROMPTS.md); the fill-in template is [assets/marching-orders-template.md](https://github.com/boshu2/agentops/blob/main/skills/vibing-with-ntm/assets/marching-orders-template.md). Keep one constraint live: first dispatch claims one scoped item and reserves files/worktree scope; steady-state asks for one commit or one explicit blocker per timebox.
 - **Isolation:** default is Agent Mail file reservations + clear bead ownership; `--worktrees` when repo policy allows. Repo-local `AGENTS.md` always wins.


### PR DESCRIPTION
## Summary
- encode the default for fresh Claude/Codex peer duels as ATM panes, not one-shot headless CLIs
- add the bounded spawn/send/verify/kill pattern to using-atm
- add the same routing rule to vibing-with-ntm and Codex skill mirrors

## Validation
- bash scripts/regen-codex-hashes.sh --check --only using-atm,vibing-with-ntm
- bash scripts/validate-codex-generated-artifacts.sh . --scope worktree
- bash scripts/audit-codex-parity.sh --skill using-atm --skill vibing-with-ntm
- bash scripts/validate-codex-runtime-sections.sh
- bash scripts/validate-skill-runtime-formats.sh
- git diff --check
- pre-push fast/head gate set: 34/34 pass

Bead: ag-00bez