### PR TITLE
feat(skills): close skill-improvement feedback loop + push/discovery/pre-mortem guards

### DIFF
--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1390,7 +1390,7 @@
     {
       "name": "post-mortem",
       "source_skill": "skills/post-mortem",
-      "source_hash": "122bc4b8d31c8418174fedcd6ea30a4065fe17af40b8c1ab2deed5ccc1115905",
+      "source_hash": "d31d2c8c2e1c8f08d86132f3a47898f1feec31187bf186988e41b68138d1d097",
       "generated_hash": "a2291ceda1dd75efd5313046d7265964671c17290fbdc5bf57a1c4432e4aa661"
     },
     {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1210,7 +1210,7 @@
     {
       "name": "discovery",
       "source_skill": "skills/discovery",
-      "source_hash": "ede9c07210b494f53f026a5e998c949a74ec8c84842b505cdf2ed8aafe592d31",
+      "source_hash": "006ceb710747e660ca67edd1b5335030fb15eea575d90c53babfeb62c209655c",
       "generated_hash": "38ab1cbc2a714653d6d0a3c675d8336bc3f6e4dfe6f388016573a5d4f26f9491"
     },
     {
@@ -1420,7 +1420,7 @@
     {
       "name": "pre-mortem",
       "source_skill": "skills/pre-mortem",
-      "source_hash": "32090ab5d0df43b2974f18feb5c457640db4ce28fe7daa9a8df81421e0441751",
+      "source_hash": "d9768c3613a1c591de8c2b07a7e3fdfd2a97718a5d3592ab64154c9445d23d5c",
       "generated_hash": "043b465f78bf730d40c955b1ec4103f80ca5d179f918513adb03e21b857dfc8d"
     },
     {
@@ -1444,7 +1444,7 @@
     {
       "name": "push",
       "source_skill": "skills/push",
-      "source_hash": "9af3ec35904c38e53d7385419945a27a9bd5f2adcdc96477bcb0a03c300f8cd8",
+      "source_hash": "f28fcd367aac3f9806cf4504a94ef7f4eef497bd79ad1fbe762811a48fffc977",
       "generated_hash": "1ffd92338bef4c7ee75396a608d07859496bf17f4e12c24bd59e4e136871acb2"
     },
     {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -1210,7 +1210,7 @@
     {
       "name": "discovery",
       "source_skill": "skills/discovery",
-      "source_hash": "006ceb710747e660ca67edd1b5335030fb15eea575d90c53babfeb62c209655c",
+      "source_hash": "76b0c6fc1d9b2aed21daa4e52a022665d6b0c6865c080de7807d50859d56cab8",
       "generated_hash": "38ab1cbc2a714653d6d0a3c675d8336bc3f6e4dfe6f388016573a5d4f26f9491"
     },
     {

--- a/skills-codex/discovery/.agentops-generated.json
+++ b/skills-codex/discovery/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/discovery",
   "layout": "modular",
-  "source_hash": "006ceb710747e660ca67edd1b5335030fb15eea575d90c53babfeb62c209655c",
+  "source_hash": "76b0c6fc1d9b2aed21daa4e52a022665d6b0c6865c080de7807d50859d56cab8",
   "generated_hash": "38ab1cbc2a714653d6d0a3c675d8336bc3f6e4dfe6f388016573a5d4f26f9491"
 }

--- a/skills-codex/discovery/.agentops-generated.json
+++ b/skills-codex/discovery/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/discovery",
   "layout": "modular",
-  "source_hash": "ede9c07210b494f53f026a5e998c949a74ec8c84842b505cdf2ed8aafe592d31",
+  "source_hash": "006ceb710747e660ca67edd1b5335030fb15eea575d90c53babfeb62c209655c",
   "generated_hash": "38ab1cbc2a714653d6d0a3c675d8336bc3f6e4dfe6f388016573a5d4f26f9491"
 }

--- a/skills-codex/post-mortem/.agentops-generated.json
+++ b/skills-codex/post-mortem/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/post-mortem",
   "layout": "modular",
-  "source_hash": "122bc4b8d31c8418174fedcd6ea30a4065fe17af40b8c1ab2deed5ccc1115905",
+  "source_hash": "d31d2c8c2e1c8f08d86132f3a47898f1feec31187bf186988e41b68138d1d097",
   "generated_hash": "a2291ceda1dd75efd5313046d7265964671c17290fbdc5bf57a1c4432e4aa661"
 }

--- a/skills-codex/pre-mortem/.agentops-generated.json
+++ b/skills-codex/pre-mortem/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/pre-mortem",
   "layout": "modular",
-  "source_hash": "32090ab5d0df43b2974f18feb5c457640db4ce28fe7daa9a8df81421e0441751",
+  "source_hash": "d9768c3613a1c591de8c2b07a7e3fdfd2a97718a5d3592ab64154c9445d23d5c",
   "generated_hash": "043b465f78bf730d40c955b1ec4103f80ca5d179f918513adb03e21b857dfc8d"
 }

--- a/skills-codex/push/.agentops-generated.json
+++ b/skills-codex/push/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/push",
   "layout": "modular",
-  "source_hash": "9af3ec35904c38e53d7385419945a27a9bd5f2adcdc96477bcb0a03c300f8cd8",
+  "source_hash": "f28fcd367aac3f9806cf4504a94ef7f4eef497bd79ad1fbe762811a48fffc977",
   "generated_hash": "1ffd92338bef4c7ee75396a608d07859496bf17f4e12c24bd59e4e136871acb2"
 }

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-14T18:40:06Z",
+  "generated_at": "2026-06-16T12:22:18Z",
   "skill_count": 72,
   "skills": [
     {
@@ -278,7 +278,7 @@
         "pragmatic-programmer"
       ],
       "context_rel": [],
-      "references_count": 4,
+      "references_count": 5,
       "codex_override_present": true
     },
     {

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-16T12:22:18Z",
+  "generated_at": "2026-06-16T12:25:06Z",
   "skill_count": 72,
   "skills": [
     {

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -74,6 +74,16 @@ Strict delegation is the **default**.
 
 **Anti-pattern to reject:** inlining `/research` work (grep + read + synthesize), collapsing `/plan` into an inline decomposition, skipping `/pre-mortem`. See [`../shared/references/strict-delegation-contract.md`](../shared/references/strict-delegation-contract.md) for the full contract, supported compression escapes (`--quick`, `--skip-brainstorm`, `--interactive`/`--auto`, `--no-scaffold`), and the **Pre-Mortem Anti-Rationalization Clause** (what does NOT count as a pre-mortem: an inline risk section you wrote, a prior adversarial pass on an input/premise rather than this plan, or "a related council already ran").
 
+**Re-baseline before you scope (mandatory for "improve X" / "build the missing
+Y" goals).** Before scoping any *new construction*, `/research` (or a grep+read
+pass) MUST confirm the capability does not already exist. Author-as-researcher
+in `--auto` is the trap: the author "knows" what's unbuilt and scopes from memory
+without searching — and is wrong (machinery that exists gets re-estimated as
+net-new, inflating effort and risking a duplicate path). Every slice that claims
+"X is missing/unbuilt" carries the search that proved it (the command, file, or
+symbol you grepped). No search → the claim is an assumption, and `/pre-mortem`'s
+re-baseline check (Steps 2.4–2.8) will WARN/FAIL it.
+
 See [`docs/learnings/orchestrator-compression-anti-pattern.md`](../../docs/learnings/orchestrator-compression-anti-pattern.md) for the live compression signature.
 See [`references/isolation-contract.md`](references/isolation-contract.md) for the mechanical four-lever model and the compression patterns flagged by `scripts/check-skill-isolation.sh`. See [`references/best-practices.md`](references/best-practices.md) for the lifecycle principle + anti-pattern citation table.
 

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -74,15 +74,7 @@ Strict delegation is the **default**.
 
 **Anti-pattern to reject:** inlining `/research` work (grep + read + synthesize), collapsing `/plan` into an inline decomposition, skipping `/pre-mortem`. See [`../shared/references/strict-delegation-contract.md`](../shared/references/strict-delegation-contract.md) for the full contract, supported compression escapes (`--quick`, `--skip-brainstorm`, `--interactive`/`--auto`, `--no-scaffold`), and the **Pre-Mortem Anti-Rationalization Clause** (what does NOT count as a pre-mortem: an inline risk section you wrote, a prior adversarial pass on an input/premise rather than this plan, or "a related council already ran").
 
-**Re-baseline before you scope (mandatory for "improve X" / "build the missing
-Y" goals).** Before scoping any *new construction*, `/research` (or a grep+read
-pass) MUST confirm the capability does not already exist. Author-as-researcher
-in `--auto` is the trap: the author "knows" what's unbuilt and scopes from memory
-without searching — and is wrong (machinery that exists gets re-estimated as
-net-new, inflating effort and risking a duplicate path). Every slice that claims
-"X is missing/unbuilt" carries the search that proved it (the command, file, or
-symbol you grepped). No search → the claim is an assumption, and `/pre-mortem`'s
-re-baseline check (Steps 2.4–2.8) will WARN/FAIL it.
+**Re-baseline before you scope** (mandatory for "improve X" / "build the missing Y"): `/research` MUST confirm a capability doesn't already exist before scoping *new construction*. The `--auto` trap is author-as-researcher scoping "what's unbuilt" from memory without grepping — existing machinery gets re-estimated as net-new. Every "X is missing" claim carries the search that proved it; no search → `/pre-mortem`'s re-baseline check (2.4–2.8) WARN/FAILs it.
 
 See [`docs/learnings/orchestrator-compression-anti-pattern.md`](../../docs/learnings/orchestrator-compression-anti-pattern.md) for the live compression signature.
 See [`references/isolation-contract.md`](references/isolation-contract.md) for the mechanical four-lever model and the compression patterns flagged by `scripts/check-skill-isolation.sh`. See [`references/best-practices.md`](references/best-practices.md) for the lifecycle principle + anti-pattern citation table.

--- a/skills/post-mortem/SKILL.md
+++ b/skills/post-mortem/SKILL.md
@@ -41,6 +41,30 @@ output_contract: skills/council/schemas/verdict.json
 
 Move **7 (capture evidence + learning, then ratchet)** of the [operating loop](../../docs/architecture/operating-loop.md). Two outputs per loop turn: evidence (test names, snapshot keys, council verdicts, citation events) recorded against the bead and `.agents/flywheel/`; learnings promoted only under the [ratchet rules](../../docs/architecture/operating-loop.md#the-promotion-ratchet) — noticed once stays in the handoff, repeats twice goes to `.agents/learnings/`, changes future behavior updates a SKILL.md or template, must-never-regress becomes a gate, core doctrine promotes into PRODUCT.md/GOALS.md/docs/cdlc.md. Most observations die at handoff. That is correct.
 
+**Route a promoted learning to the WEAKEST enforcement surface that actually
+changes behavior** — this is the ladder, by strength, not three copies of the
+same note:
+
+| Surface | Strength | Promote here when |
+|---|---|---|
+| `AGENTS.md`/`CLAUDE.md` | always-on context | doctrine relevant to *most* turns in this repo |
+| a **SKILL.md** | JIT, model-invoked | contextual judgment that fires on a trigger |
+| a **gate/hook** | mechanical, un-skippable | must-never-regress; cannot be left to judgment |
+
+Put it as high as needed and no higher: a hook for what an agent must not be
+*able* to skip; a skill for what it should *choose* well; AGENTS.md for what it
+should always *know*. A lesson that only needs to be known doesn't need a hook;
+a lesson that must never regress is wasted as prose. **If the existing
+hook/gate layer already catches the failure** (it fired, just late), the fix is
+usually one rung weaker — teach a skill/AGENTS.md to run that gate *earlier*, not
+add a redundant hook.
+
+**Measure the shipped change on real data, not just unit-green.** A learning or
+feature that is unit-correct but has **zero observable effect on the real
+corpus/workload** is a STOP signal (stop investing in it), not a "do more"
+signal. Cite the real-data measurement (counts before/after on the actual
+corpus), not just "tests pass."
+
 Six phases:
 1. **Council** — Did we implement it correctly?
 2. **Extract** — What did we learn?

--- a/skills/pre-mortem/SKILL.md
+++ b/skills/pre-mortem/SKILL.md
@@ -157,6 +157,17 @@ Five mandatory checks run during council validation — temporal interrogation, 
 
 When a plan introduces a regex, grep, glob, or similar scope predicate, also apply [references/scope-predicate-positive-negative-cases.md](references/scope-predicate-positive-negative-cases.md): require positive and negative examples before approval.
 
+**Re-baseline against what exists (mandatory when the plan proposes NEW
+construction).** A plan that says "build X" / "X is missing" / "the unbuilt
+arm" must prove X does not already exist — `grep`/read the codebase for the
+capability, the command, the function, the table — *before* the effort estimate
+is accepted. The dominant scoping failure is estimating new construction for
+machinery that is already built (and only needs integration), which inflates
+effort 2× and risks a duplicate/competing implementation. Judge prompt: "For
+each 'build/add/missing' claim, was the absence verified by a search, or
+assumed? Name the search." Treat an unverified "it's missing" as a WARN at
+minimum; FAIL if the plan's effort/sequencing depends on it.
+
 ### Step 2.9: No-self-grading invariant (author ≠ validator)
 
 The pre-mortem verdict must NOT be graded by the plan's own author. A verdict produced by the authoring context is autocorrelated — the same assumptions that shaped the plan pass it. This is the no-self-grading invariant (`ag-lmdx.4`): the independent-trust-domain check on the plan-acceptance verdict.

--- a/skills/push/SKILL.md
+++ b/skills/push/SKILL.md
@@ -57,6 +57,10 @@ cd cli && go vet ./...
 cd cli && go test ./... -count=1 -short
 ```
 
+Run the **whole** suite (`./...`), never a `-run <feature>` subset. A filtered
+run stays green while cross-cutting tests (conformance, surface-parity) are red —
+they only surface at push, after you have already reported "green."
+
 **Python projects:**
 ```bash
 python -m pytest --tb=short -q
@@ -68,6 +72,28 @@ shellcheck <modified .sh files>
 ```
 
 If ANY test fails: **STOP.** Fix the failures before continuing. Do not commit broken code.
+
+### Step 2.5: Run the repo's own pre-push gate + regenerate derived artifacts
+
+`go test` green does **not** mean the push will pass. Repos with a pre-push gate
+also enforce **derived/generated artifacts** — generated CLI docs, registries,
+command-surface matrices, conformance trees, codex twins — that unit tests never
+touch. Discovering these at `git push` (after you reported "done") is the most
+common late failure.
+
+Before staging, if the repo has any of these, run its **regen + check locally**:
+
+- A gate runner / pre-push hook (run it directly, don't wait for the push).
+- A derived-scope or codegen finalizer after you touched a generating source
+  (e.g. you added a CLI command/flag, a skill, or a schema). In AgentOps:
+  `bash scripts/regen-changed-scope.sh --scope head` and
+  `bash scripts/generate-cli-reference.sh`; for skills, scope the codex-twin
+  regen to your skills (`scripts/regen-codex-hashes.sh --only <names>`).
+- Commit the regenerated artifacts **with** the change, not as a follow-up.
+
+Rule of thumb: **if you changed a file that generates another file, regenerate
+the other file now.** The gate that fails is the one whose globs you didn't
+think your change touched.
 
 ### Step 3: Stage Changes
 


### PR DESCRIPTION
Session-derived skill improvements (from the gold-wiki session's post-mortem + pre-mortem).

**(b) Top-2 ROI guards** — the failures these prevent happened this session:
- **push**: Step 2.5 run the repo's own pre-push gate + regen derived artifacts locally (`go test` green ≠ push passes); run the whole suite, never a `-run` subset.
- **pre-mortem** + **discovery**: re-baseline / grep-before-scope — a "build X / X is missing" claim must prove absence by search before the estimate stands (caught D+B as already-built this session).

**(a) Close the feedback loop** — post-mortem ratchet now routes a promoted learning to the **weakest enforcement surface that changes behavior**: AGENTS.md (always-on) / SKILL.md (JIT judgment) / hook (mechanical never-regress); "if the gate already catches it late, teach a skill to run it earlier, not add a redundant hook." Plus a measure-on-real-data STOP check (unit-correct + zero-corpus-effect = stop).

Codex twins/hashes/catalog regenerated (scoped). All skill.* pre-push gates green (34/34). No overlap with the active orchestration/single-agent lane (skills/ only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)