### PR TITLE
feat(lifecycle): knowledge-field S1 — deposit chokepoint (pawl) + field design docs

### DIFF
--- a/cli/cmd/ao/feedback.go
+++ b/cli/cmd/ao/feedback.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -21,6 +22,7 @@ var (
 	feedbackAlpha   float64
 	feedbackHelpful bool
 	feedbackHarmful bool
+	feedbackGate    string // gate verdict licensing this deposit: pass|fail (empty=none)
 )
 
 var feedbackCmd = &cobra.Command{
@@ -63,7 +65,25 @@ func init() {
 	feedbackCmd.Flags().Float64Var(&feedbackAlpha, "alpha", types.DefaultAlpha, "EMA learning rate")
 	feedbackCmd.Flags().BoolVar(&feedbackHelpful, "helpful", false, "Mark as helpful (shortcut for --reward 1.0)")
 	feedbackCmd.Flags().BoolVar(&feedbackHarmful, "harmful", false, "Mark as harmful (shortcut for --reward 0.0)")
+	feedbackCmd.Flags().StringVar(&feedbackGate, "gate", "", "Gate verdict licensing this deposit: pass|fail (empty=none; refused under AO_DEPOSIT_GATE=strict)")
 	// Note: reward is no longer required since --helpful/--harmful can be used instead
+}
+
+// gateVerdictFromFlag maps the --gate flag to a GateVerdict: "" -> nil (no
+// verdict), "pass" -> passed, "fail" -> failed. An unknown NON-EMPTY value is an
+// error, never silently downgraded to "missing" — otherwise a typo'd `--gate=FAIL`
+// would deposit-with-warning in warn mode (cross-family review caught this).
+func gateVerdictFromFlag(s string) (*lifecycle.GateVerdict, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return nil, nil
+	case "pass":
+		return &lifecycle.GateVerdict{Passed: true, Source: "ao feedback --gate=pass"}, nil
+	case "fail":
+		return &lifecycle.GateVerdict{Passed: false, Source: "ao feedback --gate=fail"}, nil
+	default:
+		return nil, fmt.Errorf("invalid --gate value %q (want: pass|fail)", s)
+	}
 }
 
 func resolveReward(helpful, harmful bool, reward, alpha float64) (float64, error) {
@@ -108,6 +128,21 @@ func runFeedback(cmd *cobra.Command, args []string) error {
 	learningPath, err := findLearningFile(cwd, learningID)
 	if err != nil {
 		return fmt.Errorf("find learning: %w", err)
+	}
+
+	// Deposit chokepoint (the pawl): a reward may only strengthen a trail on a
+	// gate-passed outcome. A failed verdict never deposits; a missing verdict is
+	// refused under AO_DEPOSIT_GATE=strict, tolerated-with-warning otherwise.
+	verdict, gateErr := gateVerdictFromFlag(feedbackGate)
+	if gateErr != nil {
+		return gateErr
+	}
+	allowed, reason := lifecycle.GuardDeposit(verdict, lifecycle.ResolveDepositMode())
+	if !allowed {
+		return fmt.Errorf("deposit refused by gate chokepoint: %s", reason)
+	}
+	if len(reason) >= 4 && reason[:4] == "warn" {
+		fmt.Fprintf(os.Stderr, "WARNING: %s\n", reason)
 	}
 
 	if GetDryRun() {

--- a/cli/cmd/ao/feedback_helpers_test.go
+++ b/cli/cmd/ao/feedback_helpers_test.go
@@ -109,3 +109,29 @@ func TestUpdateFrontMatterFields(t *testing.T) {
 		}
 	})
 }
+
+func TestGateVerdictFromFlag(t *testing.T) {
+	// empty -> no verdict, no error
+	if v, err := gateVerdictFromFlag(""); v != nil || err != nil {
+		t.Errorf("empty: got (%v,%v), want (nil,nil)", v, err)
+	}
+	// pass/fail, case-insensitive + trimmed
+	for _, s := range []string{"pass", "PASS", " Pass "} {
+		v, err := gateVerdictFromFlag(s)
+		if err != nil || v == nil || !v.Passed {
+			t.Errorf("%q: want passed verdict, got (%v,%v)", s, v, err)
+		}
+	}
+	for _, s := range []string{"fail", "FAIL"} {
+		v, err := gateVerdictFromFlag(s)
+		if err != nil || v == nil || v.Passed {
+			t.Errorf("%q: want failed verdict, got (%v,%v)", s, v, err)
+		}
+	}
+	// unknown non-empty -> ERROR (not silently "missing") — the codex-caught bug
+	for _, s := range []string{"failed", "yes", "true", "xyz"} {
+		if v, err := gateVerdictFromFlag(s); err == nil {
+			t.Errorf("%q: unknown value should error, got verdict %v", s, v)
+		}
+	}
+}

--- a/cli/internal/lifecycle/deposit.go
+++ b/cli/internal/lifecycle/deposit.go
@@ -1,0 +1,83 @@
+package lifecycle
+
+import (
+	"os"
+	"strings"
+)
+
+// The deposit chokepoint — the pawl made structural (knowledge-field S1).
+//
+// A knowledge trail's strength may only increase on a *gate-passed outcome*.
+// Mere retrieval / co-presence / popularity must NEVER license a deposit — that
+// is the positive-feedback loop that drives the ant-mill / confident-slop
+// death-spiral, made worse by LLM agents that hallucinate trails. Every reward
+// deposit MUST route through GuardDeposit, which requires a GateVerdict.
+//
+// SCOPE (S1, honest — cross-family review confirmed bypasses): this is the guard
+// + the `ao feedback` deposit path. It is NOT yet the single chokepoint —
+// other reward-mutating callers still bypass it and must be routed through
+// GuardDeposit before strict mode is meaningful: flywheel_citation_feedback,
+// feedback_loop (normal + drain), close_loop callback, maturity recalibrate,
+// metrics cite, task_sync. That routing is the named S1 follow-up.
+//
+// Rollout follows the warn-first ratchet: default mode is warn (tolerate a
+// missing verdict, but log it) so existing feedback flows keep working; flip to
+// strict (AO_DEPOSIT_GATE=strict) only AFTER every deposit path routes through
+// here.
+
+// DepositMode controls how a missing gate verdict is treated.
+type DepositMode int
+
+const (
+	// DepositModeWarn tolerates a missing verdict (logs a warning). The S1
+	// rollout default.
+	DepositModeWarn DepositMode = iota
+	// DepositModeStrict refuses any deposit without a passed verdict. The
+	// blocking end-state.
+	DepositModeStrict
+)
+
+// depositGateEnv selects the deposit mode at runtime.
+const depositGateEnv = "AO_DEPOSIT_GATE"
+
+// GateVerdict is the proof that a reward deposit is licensed: the outcome the
+// trail contributed to passed a gate. Source names the producer (e.g.
+// "pre-land-refuters", "holdout", "hindsight-critic") for provenance.
+type GateVerdict struct {
+	Passed bool
+	Source string
+}
+
+// ResolveDepositMode reads AO_DEPOSIT_GATE (warn|strict); defaults to warn.
+func ResolveDepositMode() DepositMode {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv(depositGateEnv)), "strict") {
+		return DepositModeStrict
+	}
+	return DepositModeWarn
+}
+
+// GuardDeposit is the single chokepoint every reward deposit must pass through.
+//
+//   - a FAILED verdict NEVER deposits, in ANY mode (a gate that rejected the
+//     outcome must not strengthen the trail — the anti-death-spiral invariant);
+//   - a MISSING (nil) verdict is refused in strict mode, tolerated-with-warning
+//     in warn mode (the rollout default);
+//   - a PASSED verdict deposits.
+//
+// Returns (allowed, reason); reason is always set for logging/telemetry.
+func GuardDeposit(verdict *GateVerdict, mode DepositMode) (allowed bool, reason string) {
+	if verdict == nil {
+		if mode == DepositModeStrict {
+			return false, "refused: no gate verdict (strict mode)"
+		}
+		return true, "warn: deposit without gate verdict (warn mode; strict will refuse)"
+	}
+	if !verdict.Passed {
+		return false, "refused: gate verdict did not pass"
+	}
+	src := verdict.Source
+	if src == "" {
+		src = "unspecified"
+	}
+	return true, "allowed: gate verdict passed (" + src + ")"
+}

--- a/cli/internal/lifecycle/deposit_test.go
+++ b/cli/internal/lifecycle/deposit_test.go
@@ -1,0 +1,49 @@
+package lifecycle
+
+import "testing"
+
+func TestGuardDeposit_FailedNeverDeposits(t *testing.T) {
+	// A failed verdict must be refused in BOTH modes — the anti-death-spiral
+	// invariant: a gate that rejected the outcome cannot strengthen the trail.
+	for _, mode := range []DepositMode{DepositModeWarn, DepositModeStrict} {
+		allowed, reason := GuardDeposit(&GateVerdict{Passed: false, Source: "x"}, mode)
+		if allowed {
+			t.Errorf("mode %v: failed verdict was allowed to deposit (%q)", mode, reason)
+		}
+	}
+}
+
+func TestGuardDeposit_PassedDeposits(t *testing.T) {
+	for _, mode := range []DepositMode{DepositModeWarn, DepositModeStrict} {
+		allowed, reason := GuardDeposit(&GateVerdict{Passed: true, Source: "holdout"}, mode)
+		if !allowed {
+			t.Errorf("mode %v: passed verdict was refused (%q)", mode, reason)
+		}
+	}
+}
+
+func TestGuardDeposit_MissingVerdict_WarnAllowsStrictRefuses(t *testing.T) {
+	allowedWarn, rWarn := GuardDeposit(nil, DepositModeWarn)
+	if !allowedWarn {
+		t.Errorf("warn mode: missing verdict should be allowed-with-warning, got refused (%q)", rWarn)
+	}
+	allowedStrict, rStrict := GuardDeposit(nil, DepositModeStrict)
+	if allowedStrict {
+		t.Errorf("strict mode: missing verdict should be refused, got allowed (%q)", rStrict)
+	}
+}
+
+func TestResolveDepositMode(t *testing.T) {
+	t.Setenv(depositGateEnv, "")
+	if ResolveDepositMode() != DepositModeWarn {
+		t.Error("default mode should be warn")
+	}
+	t.Setenv(depositGateEnv, "strict")
+	if ResolveDepositMode() != DepositModeStrict {
+		t.Error("AO_DEPOSIT_GATE=strict should select strict mode")
+	}
+	t.Setenv(depositGateEnv, "STRICT")
+	if ResolveDepositMode() != DepositModeStrict {
+		t.Error("mode resolution should be case-insensitive")
+	}
+}

--- a/docs/architecture/knowledge-field-discovery.md
+++ b/docs/architecture/knowledge-field-discovery.md
@@ -1,0 +1,174 @@
+# Discovery — the tiered stigmergic knowledge field (the reinforcement layer)
+
+> Discovery packet. Research basis: `KNOWLEDGE-FIELD-RESEARCH.md` (5-scout sweep) +
+> `LOOP-INVENTORY.md`. This shapes intent as BDD and slices it into a crank-ready
+> DAG with acceptance examples. Guarded by a fresh-context pre-mortem (below).
+> Complexity: full (foundational). Lane: knowledge/corpus (carved to this lane by
+> the active single-agent doctrine lane — no collision).
+
+## intent
+Make the agent system an **organism whose memory lives in the environment**: capture
+the exhaust of agent work, **reinforce the trails that demonstrably caused verified
+good outcomes** (strength↑), **evaporate** unused trails, and **pull the strongest
+trails into the next agent's context at decision points** — so context *compounds*
+across sessions instead of evaporating at session end. Built on what we already have
+(`citations.jsonl` ledger, `ao wiki gold`, `ao lookup --gold`, the cross-family gate,
+the holdout battery), not a greenfield store.
+
+**BDD — the load-bearing acceptance examples (the contract):**
+- **Closing the loop:** *Given* a learning that was retrieved and cited in a
+  gate-passed session, *When* `ao wiki gold` next runs, *Then* that learning's
+  strength/tier increases and it ranks higher in the next retrieval.
+- **Cold-start broken:** *Given* a corpus where retrieval rate is 0%, *When* a
+  session runs discovery/plan/pre-mortem, *Then* relevant gold is retrieved
+  (retrieval rate > 0) and a citation is recorded.
+- **Credit, not co-presence:** *Given* two trails both present in a winning session —
+  one load-bearing, one merely co-retrieved — *When* credit is assigned, *Then* only
+  the load-bearing trail gains strength.
+- **Compounding, measured:** *Given* a held-out scenario, *When* it is run with vs.
+  without the promoted knowledge, *Then* with-knowledge outperforms — and *only then*
+  does the knowledge earn its next tier.
+- **No death-spiral:** *Given* a popular-but-unverified (or hallucinated) trail, *When*
+  it is retrieved repeatedly without a gate-passed outcome, *Then* its strength does
+  NOT increase (deposit requires the pawl).
+
+## boundary
+- **In scope (the build):** the produce→consume→reward cycle made real on the existing
+  ledger; tiered strength (not binary); cold-start fix; hindsight credit assignment;
+  holdout-as-promotion-gate; Kappa projection substrate.
+- **Non-goals (explicit):** (1) NOT the full *shared multi-agent* field + real eviction
+  in this epic — that's the moat endgame (S6), a separate epic once the single-agent
+  loop is proven. (2) NOT replacing the reward/maturity machinery — it exists; we feed
+  it. (3) NOT a new datastore — `citations.jsonl` + projections (Kappa). (4) NOT
+  bookend hooks — produce is async/decoupled, consume is decision-point pull.
+- **Write scope:** agentops `cli/internal/{wiki,search,lifecycle}`, the decision-point
+  skills (discovery/plan/pre-mortem), `.ao/wiki` projection. **Lane:** knowledge/corpus
+  (mine). **Door 9:** no `claude -p`; cross-family critic uses `codex exec`/AGY.
+- **Coordination:** the field lives in agentops; the active lane owns orchestration/
+  single-agent + the bead DB. Operationalize into beads *in agentops*, coordinated, not
+  in the contended mt-olympus tracker.
+
+## the slice DAG (vertical slices, each with acceptance)
+Ordered by the research build-order. **S1 is the MVP that proves the loop closes;**
+the rest deepen it. Each slice ships behind a flag, additive, gates-green.
+
+**S0 — Author knowledge-field holdout scenarios (NEW — pre-mortem caught this).**
+- The promotion gate S4 names **does not exist**: the current holdout battery is 4
+  scenarios about BDD-foundry/planning quality, in mt-olympus, not agentops. Author
+  *knowledge-reuse* holdout scenarios in agentops: with-vs-without-knowledge tasks the
+  author never sees. Without this, S3 has nothing to validate "load-bearing vs present"
+  against and S4 is unbuildable.
+- *Acceptance:* ≥N agentops holdout scenarios that each run with-knowledge and
+  without-knowledge and score the outcome delta; isolated so implementers never see them.
+
+**S1 — Break cold-start + wire the pull (the unlock) — BOUNDED against ADR-0002.**
+- Make decision-point retrieval real: discovery + plan + pre-mortem call `ao lookup
+  --gold`. (Correction: today's retrieve is **fail-open best-effort** (`2>/dev/null ||
+  true`) **and hits the raw `.agents/` corpus, not `--gold`** — so this is net-new, not
+  "extend the pattern.") Retriever gets **optimistic init** + **ε-floor**, written as
+  **projection parameters (S5 Kappa), not hard-coded** (so S6 retunes by replay).
+- **The bound is the point** (S1 risks re-triggering the bookend spray — delta=0 @
+  10.35M tokens): hard cap **top-K ≤ 3, byte-bounded**; inject **pointers/citations, not
+  full bodies** (make dag.md's "pointers not full context" binding); **rebuild `ao`
+  preflight** (the resident `cli/ao` predates `--gold`).
+- **Lock the deposit chokepoint now:** a single `deposit(trail, gate_verdict)` function
+  that **refuses without a gate-verdict** (no-op body in S1) — so the pawl is structural,
+  not a later retrofit around an LLM judge.
+- *Acceptance (the discriminating A/B):* retrieval rate 0→>0 **AND** a retrieval-on
+  vs retrieval-off A/B shows **non-zero outcome delta at bounded token cost** — the same
+  A/B that caught delta=0 in ADR-0002. **If S1 can't beat delta=0 under the token cap, it
+  IS the spray returning — fail loudly here, not at S5.**
+
+**S2 — Emit tiers, not binary (graded strength + decay).**
+- `ao wiki gold` emits a **heat scalar** (`α·N_visit + β·magnitude + γ·exp(−Δt/μ)`,
+  MemoryOS form) + a tier band; retrieval ranks by strength×relevance; decay computed
+  **lazily on read** (`2^(−Δt/h)`); **verified reuse multiplies `h`** (→ power-law durability).
+- *Reality (pre-mortem):* gold today is **thin + flat** — ~20 learnings/3 patterns/59
+  findings, **every doc Utility 0.35 (the default prior)**; reward has never propagated
+  into gold. So S2's "verified citation raises half-life" needs **S1 to have driven ≥1
+  non-default utility into gold first** (explicit DAG edge S1→S2).
+- *Acceptance:* a gold doc carries heat+tier+half-life; after a verified citation its
+  half-life rises above the flat prior; a stale uncited doc's effective score decays on read.
+
+**S3 — Hindsight credit assignment (the moat mechanism) — DE-RISKED, gated behind S2.**
+- On a gate-passed outcome, a **CriticSearch-style cross-family retrospective critic**
+  (`codex exec`/AGY) scores which cited trail was *load-bearing* vs. *merely present*;
+  the marginal score feeds the **S1 deposit chokepoint** (already gate-locked).
+- *Cost de-risk (pre-mortem):* the critic per gate-pass is a real quota/latency sink and
+  its ~80% agreement is benchmark-not-our-trajectories. So: **run it on a sampled
+  subset**, and **prove on the S0 holdout that hindsight-credit beats the cheap
+  co-presence prior (equal credit to all cited trails) BEFORE paying for it fleet-wide.**
+  If it doesn't beat the prior, S3 isn't worth its token bill.
+- *Deliverable:* the "credit, not co-presence" BDD example needs a **fixture** — a
+  constructed trajectory with one load-bearing + one co-present trail and a known answer
+  (name it in S3).
+- *Acceptance:* the "credit, not co-presence" + "no death-spiral" BDD examples pass on
+  the fixture; hindsight beats the co-presence prior on S0 holdout.
+
+**S4 — Holdout becomes the promotion gate. (Depends on S0 — the gate doesn't exist yet.)**
+- A learning earns its next tier **only** when an **S0 knowledge-reuse holdout** run
+  *with* it beats the run *without* it. Holdout moves from downstream-of-promotion to
+  *being* the gate. Guard: don't let gate-use contaminate the holdout (rotate/burn-track
+  scenarios, as the existing holdout battery already does).
+- *Acceptance:* the "compounding, measured" BDD example passes; a learning that doesn't
+  improve the S0 holdout does not promote.
+
+**S5 — Substrate as controller (Kappa + dials).**
+- Treat `citations.jsonl` as the append-only event log; tiers/weights/scores are
+  **projections** (drop + replay to retune); decouple harvest (producer) from retrieve
+  (consumer) via a bounded queue; per-tier dials; golden signals observable.
+- *Acceptance:* change a decay rate → drop projection → replay → new field, no
+  migration; queue depth/retrieval-hit-rate/staleness are reported as signals.
+
+**S6 — (separate epic, the endgame/moat):** shared multi-agent field + real eviction +
+governance against poisoning. Unbuilt territory per the 2026 surveys; gated on S1–S5.
+
+## evidence
+The 5 BDD acceptance examples above are the executable contract. Research + proven-vs-
+open + formulas + citations: `KNOWLEDGE-FIELD-RESEARCH.md`. Existing instruments to
+reuse: `ao lookup --gold` (shipped), `citations.jsonl`/`feedback.jsonl`,
+`ratchet/maturity.go`, the cross-family gate, the holdout battery (`s-2026-06-12-*`).
+
+## decision
+Slice S1-first because the failure is **cold-start, not the reward rule** — and the
+pre-mortem sharpened *what* the cold-start is: retrieval IS happening (3,739 citations /
+209 sessions, ongoing) but **against the raw `.agents/` corpus, not gold, and reward
+never flows back into gold** (every gold doc sits at the 0.35 default prior). So S1's
+real job is narrower and clearer: route the pull at *gold* and let reward reach gold.
+It's the cheapest unlock and makes every later slice measurable (no credit to trails
+never pulled). Single-agent loop first, multi-agent moat (S6) after — de-risks the
+unbuilt frontier behind a working baseline; S1's exploration params are written as
+projection params so S6 retunes by replay, not rewrite.
+
+## constraint
+Door 9 (no `claude -p`; critic via `codex exec`/AGY). Additive + flag-gated; full
+package suite + pre-push gate green before each merge (per the push-skill guard). The
+**pawl is load-bearing**: nothing deposits except a gate-passed outcome — without it
+this becomes a confident-slop amplifier (the ant-mill / LLM-phantom-trail risk). No
+bookend hooks (the delta=0 / 10.35M-token lesson).
+
+## next_action
+On PASS-WITH-CHANGES (applied) → operationalize **S0 + S1** into agentops `br` beads
+(coordinated with the active lane; NOT the contended mt-olympus tracker) and
+`/rpi --from=implementation`. S2–S5 follow; S6 is a separate epic.
+
+## pre-mortem verdict (fresh-context, 2026-06-16): PASS-WITH-CHANGES — all applied
+Re-baseline (verified against agentops, not assumed):
+- `ao lookup --gold`: **CONFIRMED** (commit a04b6d51f) — but the resident `cli/ao`
+  binary predates the flag → **rebuild preflight required** (folded into S1).
+- reward→maturity machinery (`feedback.go`, `ratchet/maturity.go`): **CONFIRMED, complete.**
+- gold corpus: **CONFIRMED but thin + flat** (~20/3/59 docs, all Utility 0.35 default —
+  reward never propagated to gold) → S1→S2 DAG edge added.
+- "pre-mortem already does mandatory retrieval": **OVERSTATED** — it's fail-open
+  best-effort and hits raw `.agents/`, not `--gold` → S1 corrected to net-new.
+- holdout battery as the promotion gate: **WRONG for this purpose** (4 scenarios, about
+  planning not knowledge-reuse, in mt-olympus not agentops) → **S0 added** to author
+  knowledge-reuse holdout scenarios in agentops; S4 now depends on it.
+- ADR-0002 (delta=0 @ 10.35M) + flywheel-audit (0% cross-session): **CONFIRMED.**
+
+Changes applied: (1) S0 holdout scenarios added (the missing gate); (2) S1 bounded
+against ADR-0002 (top-K≤3, pointers-not-bodies, token-budget A/B as acceptance, rebuild
+preflight); (3) deposit chokepoint locked in S1, S3 de-risked (sampled critic, prove-vs-
+co-presence-prior on S0 holdout first, fixture named); (4) S1 exploration params written
+as projection params so S6 retunes by replay. Open residual: S3 critic cost is the one
+unproven risk — its acceptance is explicitly "beat the cheap prior or don't ship it."

--- a/docs/architecture/knowledge-field-research.md
+++ b/docs/architecture/knowledge-field-research.md
@@ -1,0 +1,168 @@
+# The Tiered Stigmergic Knowledge Field — research synthesis
+
+> Built 2026-06-16 from a 5-scout literature sweep (agentic memory architectures;
+> RL/credit-assignment for memory; self-improving/experiential agents; stigmergy +
+> decay math; async producer-consumer + control theory). Companion to
+> `LOOP-INVENTORY.md`. Purpose: ground the knowledge loop's reinforcement layer —
+> the moat — in evidence, not vibes.
+
+## The question (the moat)
+Validation proves a trail is *walkable* (the work is correct). It does **not** tell
+you which retrieved context *led to food* (caused the good outcome). That second
+signal — **credit assignment for knowledge** — is the RL reward problem applied to
+memory, and it's the unbuilt core. Capture it and compounding actually compounds.
+
+## The convergence (5 literatures, one equation)
+Independently, swarm intelligence, memory science, memory-RL, experiential agents,
+and control theory describe the **same machine**: a field of trails, each with a
+*strength* that is **reinforced by verified use and evaporates over time**, read by
+ephemeral agents, gated so only quality deposits.
+
+**Trail strength — the same formula three times:**
+- ACO pheromone: `τ ← (1−ρ)·τ + Δτ`, deposit `Δτ ∝ 1/L_k` (solution quality), winner-only.
+- MemoryOS heat (SOTA tiered memory): `Heat = α·N_visit + β·L_interaction + γ·exp(−Δt/μ)`.
+- Ebbinghaus/MemoryBank: `R = e^(−t/S)`, and `S += 1` on each recall (use → slower decay).
+- Generative Agents retrieval: `recency(exp-decay) · importance · relevance`.
+
+These are one model: **strength = f(verified-use frequency, magnitude, recency-decay).**
+
+## The credit-assignment answer (the central finding)
+The memory-RL cluster (**MemRL** 2601.03192; **Memory-R1** 2508.19828; **Memory-R2 /
+LoGo-GRPO** 2605.21768; **CriticSearch** 2511.12159; **ProRAG**, **TreeMem**, **PiCA**)
+converges hard:
+
+> **Presence ≠ contribution.** Never reinforce a trail because it was retrieved
+> *alongside* a win. Reinforce on **marginal/counterfactual contribution** — did the
+> outcome differ *with vs. without* this memory, from the *same starting state*.
+
+- **Strongest (rigorous):** Memory-R2's counterfactual re-rollout from an identical
+  anchor state isolates each memory's *marginal* effect; explicitly names and solves
+  the "useful vs. merely-redundant/popular" trap.
+- **Cheapest (runnable now):** CriticSearch's **retrospective hindsight critic** — a
+  frozen cross-family judge sees the trajectory **+ the known-good outcome** and scores
+  which cited trail was *load-bearing* vs. merely present (~80% human agreement, beats
+  outcome-only). This is implementable with our existing cross-family gate.
+- **MemRL:** two-phase retrieval (semantic recall → value re-rank); failures decrement
+  value, so retrieved-but-unhelpful actively decays.
+
+## Our actual bug: cold-start, not the reward rule
+We already have the right *shape* (citations: retrieved/applied/helpful/harmful → EMA
+utility → maturity ladder). The audit's 0% cross-session citation is **not an
+attribution failure — it's an exploration failure**:
+- EMA-on-citations is a **bandit that only learns about arms it pulls.** With 0%
+  retrieval, every trail keeps its prior forever. The update rule is fine; **it's
+  never invoked.**
+- Fixes (RL literature, in order): **(1) break cold-start** — optimistic
+  initialization (seed new trails high so the retriever must try them) + an
+  **ε-exploration floor** (always sample some weak/untried trails); **(2) wire the
+  pull** into decision-point skills so retrieval is non-zero at all; **(3) upgrade
+  reward** from co-presence to hindsight/marginal contribution; **(4) add a
+  decay/compression penalty** so unhelpful-but-retrieved trails lose strength.
+
+**A silent signal is an exploration failure. Fix the policy (make consume happen)
+before tuning the reward.**
+
+## The decay model (settled)
+Per-item **exponential** decay (`2^(−Δt/h)`, memoryless, O(1) lazily on read), with a
+**half-life `h` that *multiplies* on each verified reinforcement** (SM-2 expanding
+intervals / Ebbinghaus S-on-recall). The aggregate field then *automatically* shows
+the desirable **power-law** durability (Wixted-Ebbesen; power-law = averaged
+exponentials) — proven-durable knowledge becomes near-permanent, transient evaporates
+fast — **without hard-coding a tail.** Tier = a half-life band (hot/fast-ρ →
+canon/slow-ρ).
+
+## Anti-death-spiral (the pawl is load-bearing)
+Stigmergy amplifies whatever is reinforced — including a wrong trail (the **ant mill**:
+positive feedback with no correction). LLM agents make it worse: they **hallucinate
+trails that don't exist** and would deposit on phantom edges. Four guards (adopt all):
+1. **Evaporation** — a wrong trail that stops paying off decays (primary self-correction).
+2. **MAX-MIN bounds** `[τ_min, τ_max]` — ceiling caps any trail's dominance (retrieval
+   never collapses onto one source); floor keeps every once-verified trail discoverable
+   (can always escape a local optimum); reset-to-`τ_max` on detected monoculture.
+3. **Quality-gated, winner-only deposit** — **only a gate-passed outcome reinforces a
+   trail.** Raw access/citation count is at most a weak prior (`η`), never the deposit
+   (`Δτ`). This severs popularity→strength→popularity.
+4. **Exploration noise** — occasionally surface a non-top trail; transiently down-weight
+   a just-retrieved item so the swarm doesn't pile on.
+
+**This is the Brownian Ratchet, formalized:** the pawl (verification) is the deposit
+function; it makes the stock monotone — gold ratchets in, slop can't. The gate is
+load-bearing *exactly where the agent is least trustworthy.*
+
+## The substrate (async, append-only, replayable)
+- **Decouple produce (harvest) from consume (retrieve)** via a **bounded queue** —
+  never couple them at the session boundary (that was the bookend bug). Backpressure
+  for free: if validation can't keep up, harvest slows; queue depth is a golden signal.
+- **`citations.jsonl` is already CQRS/event-sourcing.** Append-only log = source of
+  truth; tiers/weights/decayed-scores are **projections**. Go **Kappa** (one replayable
+  stream), so **tuning = drop projection + replay**, not migration. Delivery =
+  at-least-once + content-hash idempotency (re-feeding exhaust is a no-op).
+  (2026: ESAA puts event-sourcing under agents explicitly — 2602.23193.)
+- **Control it like a controller, not a threshold.** PID with **integral** action
+  (hold set-points without offset), conservative gain + short delays (projection lag is
+  loop delay → oscillation if ignored). **Ashby's requisite variety:** need ≥ as many
+  dials as failure modes (stale/poisoned/drifted/mis-tiered) → one global decay can't
+  stabilize it; per-tier controls. **Meadows:** the numeric dials (decay, thresholds)
+  are *lowest* leverage; invest in pruning-loop strength and the set-point definition.
+  **Allostasis** (2508.12791): let set-points *drift with workload*, treat noise as
+  signal — heavy-harvest week → tighten proactively.
+
+## Measurement (holdout as the promotion gate, not downstream of it)
+Every experiential result (ExpeL's monotonic curve, Voyager's held-out transfer) proves
+reuse **only** with-vs-without on tasks the artifact's author never saw — **never
+self-report** (matches our own `re-measure-done` / cross-family-gate memories). Our
+holdout battery (`s-2026-06-12-*`) is the right instrument but currently runs
+*downstream* of promotion; it should **be** the promotion gate: a learning earns its
+next tier only when a holdout run *with it beats the run without it.*
+
+## The moat: nobody has built the SHARED, VERIFIED field
+Every published memory system (MemGPT, A-MEM, Mem0, MemoryOS, HippoRAG, MemoryBank,
+Generative Agents) is **single-agent** — one user, one history. Stigmergy is inherently
+**multi-agent** (many depositors, many readers). The open territory, stated by the 2026
+surveys as unsolved:
+- **a shared multi-agent graded field** (A-MEM's deposit-reshapes-neighbors is the only
+  published analog, still single-agent),
+- **real eviction/selective-forgetting** (MemoryAgentBench: *no system masters it* — the
+  evaporation half is least solved),
+- **governance against reinforcement amplifying errors/poisoning** (SSGM, 2603.11768).
+
+Fuse them — **CoALA typed nodes + MemoryOS heat/decay + HippoRAG associative read +
+multi-agent verified deposit (the pawl) + real eviction** — and that is *exactly* the
+tiered stigmergic knowledge field. Bo's instinct is at the research frontier; the
+**verified-deposit + multi-agent + real-evaporation** combination is unbuilt, and the
+verification gate (which we already have and others lack) is the differentiator.
+
+## Proven vs. open
+- **Proven:** hot/warm/cold paging; recency·importance·relevance ranking; Ebbinghaus
+  decay + recall-reinforcement; MemoryOS heat-tiering at SOTA; PageRank associative
+  retrieval; LLM reflection raw→structured; counterfactual/hindsight credit assignment.
+- **Open (our claim space):** shared multi-agent field; real eviction; verified-deposit
+  gating at scale; holdout-as-promotion-gate; the controller/allostatic tuning layer.
+
+## The decision (build order)
+1. **Break cold-start + wire the pull** — optimistic init + ε-floor + mandatory
+   decision-point retrieval (`ao lookup --gold` in discovery/plan/pre-mortem). *Without
+   this nothing else matters; it's the silent-signal fix.*
+2. **Emit tiers, don't gate to binary** — gold carries a strength scalar (MemoryOS heat
+   form) + tier band; retrieval ranks by strength×relevance; lazy exponential decay with
+   multiply-on-verified-use.
+3. **Upgrade the reward to hindsight contribution** — CriticSearch-style cross-family
+   retrospective judge converts a citation into a marginal-contribution score; only
+   gate-passed outcomes deposit.
+4. **Holdout becomes the promotion gate** — with-vs-without on unseen scenarios.
+5. **Make the substrate a controller** — Kappa replay over the append-only ledger;
+   per-tier dials; measure golden signals; tune (later, allostatic).
+The reward/maturity machinery already exists — step 1 lights it up; steps 2–4 make the
+light mean *useful*; step 5 makes it self-tuning.
+
+## Citations
+Memory-RL: MemRL [2601.03192], Memory-R1 [2508.19828], Memory-R2 [2605.21768],
+CriticSearch [2511.12159], ProRAG [2601.21912], TreeMem [2605.04811], PiCA [2605.09287].
+Architectures: MemGPT [2310.08560], Generative Agents [2304.03442], CoALA [2309.02427],
+MemoryBank [2305.10250], A-MEM [2502.12110], Mem0 [2504.19413], HippoRAG [2405.14831],
+MemoryOS [2506.06326], MemOS [2507.03724]. Experiential: Reflexion [2303.11366],
+Voyager [2305.16291], ExpeL [2308.10144], CBR-for-agents [2504.06943], Compound
+Engineering (Every). Stigmergy/decay: ACO + MAX-MIN (Stützle), Ant mill [1703.06859],
+Duolingo HLR (Settles ACL'16), Wixted-Ebbesen power law (1997). Substrate/control:
+ESAA [2602.23193], allostasis [2508.12791], Ashby requisite variety, Meadows leverage
+points, PID (Åström). Governance: SSGM [2603.11768].

--- a/docs/architecture/loop-inventory.md
+++ b/docs/architecture/loop-inventory.md
@@ -1,0 +1,90 @@
+# Loop Inventory — every feedback loop in the system
+
+> Built 2026-06-16 from a 4-scout sweep across agentops, mt-olympus, ntm,
+> control-plane, dotfiles, ~/.claude. Purpose: enumerate ALL our loops *before*
+> designing the knowledge loop, so the decision is informed. This is the
+> "we've done this before" record — what exists, its state, and the lessons.
+>
+> **Frame:** we are doing **loop engineering** — DevOps' infinite loop, encoded.
+> A *system* (stocks + feedback) not a *DAG* (flows, no loops). The unit is the
+> loop; loops drive loops. Outer = **GOAL** (not gold — gold is knowledge
+> substrate).
+
+## The five loops (+ one ladder)
+
+| # | Loop | Role | Driver / forcing function | State |
+|---|------|------|---------------------------|-------|
+| 1 | **GOAL (outer)** | decides *what* + persists until met | `GOALS.md` → `/evolve` → `/goal` (Stop-hook); ADR-0008 | ✅ working |
+| 2 | **WORKFLOW (inner)** | *executes* the objective | RPI 7 moves; `/crank` for epics | ✅ working |
+| 3 | **VERIFICATION (pawl)** | balancing loop — don't regress | Brownian ratchet; pawl gates at merge/accept | ✅ working |
+| 4 | **KNOWLEDGE** | the stock + its feedback (mine→compile→retrieve→reward) | *(no forcing function on consume)* | ⚠️ **starved at consume** |
+| 5 | **NUDGE / TIME** | keep loops turning, unstick | cron / ScheduleWakeup / NTM ticks | ✅ working |
+| L | **PROMOTION ladder** | routes a lesson to its enforcement surface | post-mortem ratchet + finding-compiler | ✅ working |
+
+**The headline: 4 of 5 loops work. The knowledge loop is the lone broken one — and it's broken at *consume*, not anywhere else.**
+
+---
+
+## 1. GOAL loop (outer driver)
+- **What:** sets the objective and persists until met; decides what the inner loop runs.
+- **Lineage:** `GOALS.md` (steering) → `/evolve` (the original autonomous outer loop, goal-driven) → `/goal` (Stop-hook condition, its current successor — what we used all session).
+- **Where:** `GOALS.md`/`PROGRAM.md`/`AUTODEV.md`; `skills/evolve/SKILL.md`; ADR-0007 (deterministic), ADR-0008 (intelligent-agile: re-reads intent each cycle, **cannot redirect outside operator-set goals**).
+- **State:** working. `/evolve` perpetuates via ScheduleWakeup (270s productive / 600s scout / 1800s idle) or cron; hard stops never reschedule.
+- **Lesson:** the loop is *deterministic* — only the operator's goal moves it; circuit breakers escalate, never auto-redirect.
+
+## 2. WORKFLOW loop (inner — RPI)
+- **What:** the 7 moves — BDD intent → bead → vertical slice → TDD per slice → conflict-free wave → close-by-acceptance → capture evidence.
+- **Where:** `docs/architecture/operating-loop.md` (spine); `skills/rpi` (orchestrator), `skills/{discovery,plan,crank,validate}`; intent-to-loop-hexagon.
+- **State:** working/stable. RPI delegates each move, enforces 5 invariants (no move-skip, test-first, acceptance>activity, ports visible, context density across handoffs). Jump in/out via `--from`.
+- **Lesson:** chaos between pawls; validation cadence is pawl-gated, not per-tread.
+
+## 3. VERIFICATION loop (pawl / Brownian ratchet — the balancing loop)
+- **What:** chaos + filter + ratchet = progress. Pawls are the one-way doors where the gate fires; the ratchet locks gains so they can't slip back.
+- **Where:** `docs/contracts/pawls.md`, `docs/brownian-ratchet.md`; `/pre-land-refuters`; `scripts/reconcile-pr.sh`; `schemas/pawl-verdict.v1.schema.json`.
+- **Pawls:** mutate-shared-trunk, delete, external-send, schema/contract change, credential change, spend. **Blast-radius rule** is the authority (mutates shared state / changes gate logic / external effect / hard to roll back).
+- **Diversity:** fresh-context default (≥1 fresh red-team, model-agnostic); multi-model opt-in (≥2 families) for highest-irreversibility doors.
+- **Escalation:** circuit-breaker model — REFUTED auto-redoes; escalate to human only on max-attempts / time / cost / oscillation / explicit-judgment.
+- **State:** working. **Frontier: the meta-pawl** (validate the validator; terminate the regress) — `mt-olympus/docs/plans/meta-pawl-brief.md`.
+- **Why it matters for pay-it-forward:** this is the loop that stops the reinforcing loops from compounding *slop*. A pay-it-forward system without this pawl drifts; with it, the stock is monotone (gold ratchets in, slop can't).
+
+## 4. KNOWLEDGE loop ⚠️ — the starved one
+- **What:** produce → refine → compile → retrieve → reward. The stock that should make every next pass start richer.
+- **Parts (ALL built):**
+  - **Produce:** `forge` (transcript→`.agents/knowledge/pending`), `curate`.
+  - **Refine/promote:** `flywheel` close-loop scoring (Gold>0.85/Silver/Bronze), age+citation gates → `.agents/learnings`.
+  - **Compile→gold:** `ao wiki gold` (`.agents`→`.ao/wiki`, sanitize+durability-gate+OKF), auto-run by `ao compile`; `ao lookup --gold` (shipped THIS session).
+  - **Retrieve:** decay-ranked scoring (`scoring.go`: freshness `exp(-0.17·weeks)`, maturity weights, multi-feature relevance). Scores **0.93 synthetic.**
+  - **Reward:** citation → EMA utility (`feedback.go`) → `reward_count`/maturity (`ratchet/maturity.go`: provisional→candidate@≥3→established@≥5).
+  - **Eval:** `eval-outcomes` + holdout — but it never measures "does retrieval help."
+- **State: BUILT BUT STARVED.** The Apr-2026 `flywheel-audit.md` measured **0% cross-session citation** — 2,275 learning files across 14 workspaces, *zero* cited by any later plan/pre-mortem. Live retrieval scores **0.13** (vs 0.93 synthetic).
+- **Root cause — the over-correction:** the v2.x **bookend push** failed (ADR-0002: a trivial RPI cycle hit **10.35M tokens @ 97.6% cache-read / $7.48**, and the **A/B eval showed injected context delta = 0** — "the problem was never hooks; it was noise stacking in the prompt"). 3.0 moved to **JIT pull**… but then **nothing pulls.** Injection was disabled (post-`ag-8km`) with no replacement, and **no decision-point skill calls `ao lookup`** (pre-mortem is the lone exception). The pendulum swung **spray → silence.**
+- **The diagnosis:** this is the **only loop with no forcing function on its consume step.** Goal is forced by the Stop-hook; workflow by RPI's mandatory phases; verification by the merge gate; nudge by the timer. Knowledge-consume relies on an agent *choosing* to retrieve — and it doesn't. **Enforce the knowledge loop = give consume a forcing function**, the way every other loop has one.
+
+## 5. NUDGE / TIME loops (keep loops turning)
+- **What:** the time/event drivers that fire the other loops.
+- **Surfaces:** `/loop` (in-session, fixed-interval or self-paced); **ScheduleWakeup** (in-session perpetuation, cache-aware delays); **CronCreate / shell cron** (off-session, survives session death); **NTM/ATM tending** (8-step tick: baseline→attend→classify→score→act→verify→stop→log; the Liveness Truth Stack); **continuity-loop** (renewal ticks, 2-tick stall rule, `.agents/continuity/state.json`).
+- **State:** working (continuity-loop experimental). Temporal tiers: scheduling (hours/days) → autonomous (5–30 min, evolve) → operational (15–30 min, NTM tending) → workflow (3–5 min/phase, RPI).
+- **Lesson:** one continuous machine with multiple control surfaces, not a cascade of systems. All honor the same kill markers.
+
+## L. PROMOTION ladder (routes a lesson to its surface)
+- once→handoff / twice→`.agents/learnings` / changes-behavior→`SKILL.md` / must-never-regress→gate / doctrine→`PRODUCT.md`. Plus **R3: no durable learning without a constraint** (`check-ratchet-r3-constraint.sh`). Enforcement-strength routing (AGENTS.md / skill / hook — weakest that changes behavior) added to the post-mortem skill this session.
+- **Where:** `docs/architecture/operating-loop.md#the-promotion-ratchet`, `docs/contracts/finding-compiler.md`, `.agents/findings/`.
+
+---
+
+## The decision this inventory points to
+
+**Don't reopen the bookend.** The history is unambiguous: bookend *push* → delta=0 + 10.35M tokens. The fix is not "force mining at close-out."
+
+**The knowledge loop's three cadences are different and must be decoupled:**
+1. **PRODUCE (harvest the session-end gold):** async + gated, decoupled from the session boundary — a separate loop on its own timer (nudge tier), not a synchronous SessionEnd. The end-of-session agent is the highest-knowledge *and* most-biased context → the harvest must pass the **pawl** (independent verification), or it pays forward confident slop.
+2. **CONSUME (feed the next agent):** **JIT pull at the point of need, wired as a mandatory step in the decision-point skills** (discovery/plan/pre-mortem call `ao lookup --gold`) — a *forcing function*, the thing the knowledge loop uniquely lacks. Never bookend-push.
+3. **MEASURE (does it help):** the eval/holdout closes the loop empirically — did the next agent avoid the mistake? Without this, you can't tell gold from slop accumulating.
+
+**One line:** every other loop is enforced by a forcing function; the knowledge loop isn't. Give *consume* a forcing function (mandatory decision-point retrieval), keep *produce* async+gated, and let the eval prove it — and the dormant reward/maturity machinery lights up the moment retrieval happens.
+
+## Open frontiers (named, not yet built)
+- **Knowledge-consume forcing function** — the core gap above.
+- **Meta-pawl** — validate the validator (recursion termination).
+- **Eval measures retrieval value** — the missing empirical link.
+- **Auto-ingestion of session lessons** — so feed-forward isn't manual/lossy (this session proved manual is lossy).


### PR DESCRIPTION
First slice of the knowledge-field epic (the reinforcement/credit-assignment moat). See docs/architecture/knowledge-field-discovery.md.

**The pawl, made structural.** A reward deposit may only strengthen a knowledge trail on a **gate-passed outcome** — the anti-death-spiral invariant (mere retrieval/co-presence/popularity must never deposit; LLMs hallucinate trails). `GuardDeposit`: failed verdict never deposits (any mode); missing verdict refused under `AO_DEPOSIT_GATE=strict`, warned in warn (rollout default); passed deposits. Wired into `ao feedback --gate=pass|fail`.

**Cross-family reviewed** (codex, PASS-WITH-CHANGES — all applied): flag mapper now rejects unknown `--gate` values (typo'd `--gate=FAIL` no longer silently deposits); comments scoped honestly.

**Honest scope:** this is the guard + the `ao feedback` path — NOT yet the single chokepoint. `flywheel_citation_feedback`/`feedback_loop`/`close_loop`/`maturity`/`metrics-cite`/`task_sync` still bypass it; routing them is the named S1 follow-up before `strict` is meaningful.

Tests: GuardDeposit semantics (failed/passed/missing × warn/strict), mode resolution, flag rejection. Also relocates the knowledge-field design docs into agentops/docs/architecture/ (route-by-object).

🤖 Generated with [Claude Code](https://claude.com/claude-code)