### PR TITLE
feat(lifecycle): complete the deposit chokepoint — single door for all reward paths

### DIFF
--- a/cli/cmd/ao/batch_feedback_test.go
+++ b/cli/cmd/ao/batch_feedback_test.go
@@ -756,7 +756,7 @@ func TestFeedback_updateLearningUtility_dispatch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, _, err := updateLearningUtility(path, 0.8, 0.1)
+		_, _, err := updateLearningUtility(path, 0.8, 0.1, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -769,7 +769,7 @@ func TestFeedback_updateLearningUtility_dispatch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, _, err := updateLearningUtility(path, 0.8, 0.1)
+		_, _, err := updateLearningUtility(path, 0.8, 0.1, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/cli/cmd/ao/feedback.go
+++ b/cli/cmd/ao/feedback.go
@@ -130,19 +130,11 @@ func runFeedback(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("find learning: %w", err)
 	}
 
-	// Deposit chokepoint (the pawl): a reward may only strengthen a trail on a
-	// gate-passed outcome. A failed verdict never deposits; a missing verdict is
-	// refused under AO_DEPOSIT_GATE=strict, tolerated-with-warning otherwise.
+	// Resolve the gate verdict for this deposit; the chokepoint itself is
+	// enforced inside updateLearningUtility (the single door all paths route through).
 	verdict, gateErr := gateVerdictFromFlag(feedbackGate)
 	if gateErr != nil {
 		return gateErr
-	}
-	allowed, reason := lifecycle.GuardDeposit(verdict, lifecycle.ResolveDepositMode())
-	if !allowed {
-		return fmt.Errorf("deposit refused by gate chokepoint: %s", reason)
-	}
-	if len(reason) >= 4 && reason[:4] == "warn" {
-		fmt.Fprintf(os.Stderr, "WARNING: %s\n", reason)
 	}
 
 	if GetDryRun() {
@@ -152,7 +144,7 @@ func runFeedback(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	oldUtility, newUtility, err := updateLearningUtility(learningPath, feedbackReward, feedbackAlpha)
+	oldUtility, newUtility, err := updateLearningUtility(learningPath, feedbackReward, feedbackAlpha, verdict)
 	if err != nil {
 		return fmt.Errorf("update utility: %w", err)
 	}
@@ -176,7 +168,20 @@ func findLearningFile(baseDir, learningID string) (string, error) {
 	return resolver.NewFileResolver(baseDir).Resolve(learningID)
 }
 
-func updateLearningUtility(path string, reward, alpha float64) (oldUtility, newUtility float64, err error) {
+// updateLearningUtility is the SINGLE deposit chokepoint: every reward/utility
+// mutation in the CLI routes through here (verified: no other caller of
+// lifecycle.UpdateLearningUtility exists), so the pawl is structural, not a
+// per-command guard. Automated callers pass nil (tolerated in warn mode, refused
+// under AO_DEPOSIT_GATE=strict until they supply a real gate verdict — the
+// warn→strict ratchet); `ao feedback` passes its --gate verdict.
+func updateLearningUtility(path string, reward, alpha float64, verdict *lifecycle.GateVerdict) (oldUtility, newUtility float64, err error) {
+	allowed, reason := lifecycle.GuardDeposit(verdict, lifecycle.ResolveDepositMode())
+	if !allowed {
+		return 0, 0, fmt.Errorf("deposit refused by gate chokepoint: %s", reason)
+	}
+	if strings.HasPrefix(reason, "warn") {
+		fmt.Fprintf(os.Stderr, "WARNING: %s (%s)\n", reason, path)
+	}
 	return lifecycle.UpdateLearningUtility(path, reward, alpha, feedbackHelpful, feedbackHarmful)
 }
 

--- a/cli/cmd/ao/feedback_helpers_test.go
+++ b/cli/cmd/ao/feedback_helpers_test.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -133,5 +134,19 @@ func TestGateVerdictFromFlag(t *testing.T) {
 		if v, err := gateVerdictFromFlag(s); err == nil {
 			t.Errorf("%q: unknown value should error, got verdict %v", s, v)
 		}
+	}
+}
+
+// TestUpdateLearningUtility_ChokepointGatesAllPaths proves the guard now lives
+// in the single chokepoint: an automated nil-verdict deposit is refused under
+// strict mode (before any file I/O), and tolerated in warn mode.
+func TestUpdateLearningUtility_ChokepointGatesAllPaths(t *testing.T) {
+	t.Setenv("AO_DEPOSIT_GATE", "strict")
+	if _, _, err := updateLearningUtility("/nonexistent-kf.md", 0.8, 0.1, nil); err == nil || !strings.Contains(err.Error(), "deposit refused") {
+		t.Errorf("strict: nil-verdict deposit must be refused at the chokepoint, got err=%v", err)
+	}
+	t.Setenv("AO_DEPOSIT_GATE", "warn")
+	if _, _, err := updateLearningUtility("/nonexistent-kf.md", 0.8, 0.1, nil); err != nil && strings.Contains(err.Error(), "deposit refused") {
+		t.Errorf("warn: nil-verdict deposit must NOT be refused by the gate, got %v", err)
 	}
 }

--- a/cli/cmd/ao/feedback_loop.go
+++ b/cli/cmd/ao/feedback_loop.go
@@ -221,7 +221,7 @@ func processUniqueCitations(cwd, sessionID, transcriptPath string, citations []t
 			continue
 		}
 
-		oldUtility, newUtility, err := updateLearningUtility(learningPath, reward, alpha)
+		oldUtility, newUtility, err := updateLearningUtility(learningPath, reward, alpha, nil)
 		if err != nil {
 			VerbosePrintf("Warning: failed to update %s: %v\n", learningPath, err)
 			failedCount++
@@ -696,7 +696,7 @@ func applyDrainUpdates(baseDir string, unique []types.CitationEvent, opts drainO
 			continue
 		}
 
-		if _, _, err := updateLearningUtility(learningPath, opts.Reward, opts.Alpha); err != nil {
+		if _, _, err := updateLearningUtility(learningPath, opts.Reward, opts.Alpha, nil); err != nil {
 			VerbosePrintf("drain: failed to update %s: %v\n", learningPath, err)
 			failed++
 			continue

--- a/cli/cmd/ao/flywheel_citation_feedback.go
+++ b/cli/cmd/ao/flywheel_citation_feedback.go
@@ -277,7 +277,7 @@ func learningArtifactCitationFeedback(
 		return citationFeedbackResult{event: &event, rewarded: 1}
 	}
 
-	oldUtility, newUtility, err := updateLearningUtility(path, effectiveReward, alpha)
+	oldUtility, newUtility, err := updateLearningUtility(path, effectiveReward, alpha, nil)
 	if err != nil {
 		currentUtility := parseUtilityFromFile(path)
 		event := FeedbackEvent{

--- a/cli/cmd/ao/flywheel_fix_test.go
+++ b/cli/cmd/ao/flywheel_fix_test.go
@@ -378,7 +378,7 @@ func TestRecalibrate_ResetsUtility(t *testing.T) {
 	path := filepath.Join(dir, "inflated.jsonl")
 	os.WriteFile(path, []byte(`{"utility":0.85,"reward_count":10,"maturity":"established","confidence":0.8}`+"\n"), 0644)
 
-	oldUtility, newUtility, err := updateLearningUtility(path, types.InitialUtility, 1.0)
+	oldUtility, newUtility, err := updateLearningUtility(path, types.InitialUtility, 1.0, nil)
 	if err != nil {
 		t.Fatalf("updateLearningUtility: %v", err)
 	}

--- a/cli/cmd/ao/maturity.go
+++ b/cli/cmd/ao/maturity.go
@@ -274,7 +274,7 @@ func runMaturityRecalibrate(learningsDir string) error {
 	for _, file := range files {
 		// updateLearningUtility with alpha=1.0 and reward=InitialUtility
 		// yields: new = (1-1.0)*old + 1.0*0.5 = 0.5
-		_, _, err := updateLearningUtility(file, types.InitialUtility, 1.0)
+		_, _, err := updateLearningUtility(file, types.InitialUtility, 1.0, nil)
 		if err != nil {
 			VerbosePrintf("Warning: could not recalibrate %s: %v\n", filepath.Base(file), err)
 			continue

--- a/cli/cmd/ao/task_sync.go
+++ b/cli/cmd/ao/task_sync.go
@@ -563,7 +563,7 @@ func processSingleTaskFeedback(cwd string, task TaskEvent) bool {
 		return false
 	}
 
-	oldUtility, newUtility, err := updateLearningUtility(learningPath, completionReward, types.DefaultAlpha)
+	oldUtility, newUtility, err := updateLearningUtility(learningPath, completionReward, types.DefaultAlpha, nil)
 	if err != nil {
 		VerbosePrintf("Warning: failed to update %s: %v\n", learningPath, err)
 		return false

--- a/cli/internal/lifecycle/deposit.go
+++ b/cli/internal/lifecycle/deposit.go
@@ -13,17 +13,21 @@ import (
 // death-spiral, made worse by LLM agents that hallucinate trails. Every reward
 // deposit MUST route through GuardDeposit, which requires a GateVerdict.
 //
-// SCOPE (S1, honest — cross-family review confirmed bypasses): this is the guard
-// + the `ao feedback` deposit path. It is NOT yet the single chokepoint —
-// other reward-mutating callers still bypass it and must be routed through
-// GuardDeposit before strict mode is meaningful: flywheel_citation_feedback,
-// feedback_loop (normal + drain), close_loop callback, maturity recalibrate,
-// metrics cite, task_sync. That routing is the named S1 follow-up.
+// ENFORCEMENT (S1): GuardDeposit runs at the single live chokepoint
+// updateLearningUtility (cli/cmd/ao/feedback.go) — EVERY live reward/utility
+// deposit routes through it: ao feedback, flywheel_citation_feedback,
+// feedback_loop (normal + drain), maturity recalibrate, task_sync. Verified no
+// other live caller of lifecycle.UpdateLearningUtility (the lower helpers
+// applyJSONLRewardFields/updateJSONLUtility are test-only). Automated paths pass
+// a nil verdict.
+//
+// Remaining work is PROVENANCE, not routing: the automated paths should supply a
+// real GateVerdict (from the hindsight critic, S3) so strict mode rewards only
+// gate-passed marginal contribution.
 //
 // Rollout follows the warn-first ratchet: default mode is warn (tolerate a
-// missing verdict, but log it) so existing feedback flows keep working; flip to
-// strict (AO_DEPOSIT_GATE=strict) only AFTER every deposit path routes through
-// here.
+// missing verdict, but log it) so existing flows keep working; flip to strict
+// (AO_DEPOSIT_GATE=strict) once the automated paths supply verdicts.
 
 // DepositMode controls how a missing gate verdict is treated.
 type DepositMode int


### PR DESCRIPTION
Follow-up to #870 closing the codex-flagged gap (knowledge-field S1).

Moves `GuardDeposit` INTO `updateLearningUtility` — the single live helper all 6 reward/utility deposit paths call (`ao feedback`, `flywheel_citation_feedback`, `feedback_loop` normal+drain, `maturity`, `task_sync`). Verified no other live caller of `lifecycle.UpdateLearningUtility` (lower helpers are test-only). `*GateVerdict` threaded through every caller: `ao feedback` passes its `--gate` verdict; automated paths pass `nil` (tolerated in warn, refused in strict).

**Cross-family reviewed** (codex PASS-WITH-CHANGES, applied): confirmed single chokepoint + no warn-default regression; fixed the now-stale scope comment. Remaining S1 work is *provenance* (automated paths supplying real verdicts via the S3 hindsight critic), not routing.

Test: `TestUpdateLearningUtility_ChokepointGatesAllPaths`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)