### PR TITLE
feat(search): cold-start ε-exploration floor for retrieval (knowledge-field S1)

### DIFF
--- a/cli/cmd/ao/lookup.go
+++ b/cli/cmd/ao/lookup.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/boshu2/agentops/cli/internal/config"
 	"github.com/boshu2/agentops/cli/internal/ratchet"
+	"github.com/boshu2/agentops/cli/internal/search"
 	"github.com/boshu2/agentops/cli/internal/types"
 )
 
@@ -167,20 +168,20 @@ func collectGoldKnowledge(goldRoot, query string, limit int) ([]learning, []patt
 	now := nowFunc()
 	tokens := queryTokens(strings.ToLower(query))
 	qLower := strings.ToLower(query)
+	// ε-exploration floor (cold-start): reserve a fraction of returned slots for
+	// tail trails so under-explored gold gets surfaced/cited/reinforced. ε=0
+	// (default) is identical to the prior top-K trim — zero behavior change.
+	eps := search.ResolveRetrievalEpsilon()
 
 	learnings := collectLocalLearnings(goldDocFiles(globLearningFiles(filepath.Join(goldRoot, SectionLearnings))), tokens, now)
 	rankLearnings(learnings)
-	learnings = limitCollectedLearnings(learnings, limit)
+	learnings = search.ExploreSelect(learnings, limit, eps, nil)
 
 	patterns, _ := collectPatternsFromDir(filepath.Join(goldRoot, SectionPatterns), qLower, now, false)
-	if len(patterns) > limit {
-		patterns = patterns[:limit]
-	}
+	patterns = search.ExploreSelect(patterns, limit, eps, nil)
 
 	findings, _ := collectFindingsFromDir(filepath.Join(goldRoot, SectionFindings), qLower, now, false, false)
-	if len(findings) > limit {
-		findings = findings[:limit]
-	}
+	findings = search.ExploreSelect(findings, limit, eps, nil)
 
 	return learnings, patterns, findings
 }

--- a/cli/cmd/ao/lookup_test.go
+++ b/cli/cmd/ao/lookup_test.go
@@ -991,3 +991,26 @@ func TestCollectGoldKnowledge_SkipsCatalogFiles(t *testing.T) {
 		t.Fatalf("collectGoldKnowledge returned %d learnings, want 1 (real doc only, index.md excluded)", len(learnings))
 	}
 }
+
+// TestCollectGoldKnowledge_RespectsLimit exercises the ε-floor wiring: with
+// AO_RETRIEVAL_EPSILON unset (ε=0), gold retrieval returns exactly `limit` from a
+// larger matching set — i.e. zero behavior change vs the prior top-K trim.
+func TestCollectGoldKnowledge_RespectsLimit(t *testing.T) {
+	gold := t.TempDir()
+	learn := filepath.Join(gold, SectionLearnings)
+	if err := os.MkdirAll(learn, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "Use flywheel compounding for durable knowledge retention and retrieval across sessions reliably."
+	for _, name := range []string{"a", "b", "c", "d", "e"} {
+		content := "---\nmaturity: provisional\n---\n# Flywheel lesson " + name + "\n\n" + body + "\n"
+		if err := os.WriteFile(filepath.Join(learn, name+".md"), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("AO_RETRIEVAL_EPSILON", "") // ε=0 → top-K, zero behavior change
+	learnings, _, _ := collectGoldKnowledge(gold, "flywheel", 2)
+	if len(learnings) != 2 {
+		t.Errorf("ε=0: expected exactly limit=2 from 5 matching learnings, got %d", len(learnings))
+	}
+}

--- a/cli/internal/search/exploration.go
+++ b/cli/internal/search/exploration.go
@@ -1,0 +1,95 @@
+package search
+
+import (
+	"math"
+	"math/rand"
+	"os"
+	"strconv"
+)
+
+// The ε-exploration floor (knowledge-field S1, cold-start).
+//
+// Retrieval ranks best-first and returns the top-K. With a flat default utility
+// (every un-rewarded trail sits at the same low prior), new/under-explored trails
+// live in the tail and are NEVER returned → never cited → never reinforced → the
+// cold-start lock: the strong trails win forever and the field can't learn what
+// the tail is worth. ExploreSelect reserves a fraction of the returned slots for
+// tail trails so they get surfaced, cited, and can earn their way up — the ACO
+// τ_min / exploration-noise analog. (Complement: optimistic-init, a later slice,
+// boosts under-observed trails UP the ranking; this floor samples the tail.)
+
+// retrievalEpsilonEnv tunes the exploration fraction at runtime.
+const retrievalEpsilonEnv = "AO_RETRIEVAL_EPSILON"
+
+// ResolveRetrievalEpsilon reads AO_RETRIEVAL_EPSILON (a float in [0,1]); defaults
+// to 0 (no exploration → zero behavior change). Out-of-range/garbage → 0.
+func ResolveRetrievalEpsilon() float64 {
+	s := os.Getenv(retrievalEpsilonEnv)
+	if s == "" {
+		return 0
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil || math.IsNaN(f) || math.IsInf(f, 0) || f < 0 || f > 1 {
+		return 0
+	}
+	return f
+}
+
+// ExploreSelect returns `limit` items from a slice already ranked best-first:
+// the top (limit - reserve) by rank (exploit) plus reserve = floor(epsilon*limit)
+// items sampled WITHOUT replacement from the tail (rank >= keep) (explore).
+//
+//   - epsilon <= 0 (default): returns ranked[:limit] verbatim — zero behavior change.
+//   - len(ranked) <= limit, or limit <= 0: returns ranked unchanged (nothing to trim).
+//   - limit == 1: no exploration is possible without dropping the only exploit slot,
+//     so the top item is always kept.
+//
+// rng nil uses the global source; callers pass a seeded *rand.Rand for determinism.
+func ExploreSelect[T any](ranked []T, limit int, epsilon float64, rng *rand.Rand) []T {
+	if limit <= 0 {
+		return ranked[:0] // match `ranked[:limit]` semantics (limit 0 -> empty)
+	}
+	if len(ranked) <= limit {
+		return ranked
+	}
+	if epsilon <= 0 {
+		return ranked[:limit]
+	}
+	reserve := int(epsilon * float64(limit))
+	if reserve < 1 {
+		reserve = 1 // epsilon > 0 guarantees at least one exploration slot
+	}
+	if reserve >= limit {
+		reserve = limit - 1 // always keep at least one exploit slot
+	}
+	keep := limit - reserve
+
+	out := make([]T, 0, limit)
+	out = append(out, ranked[:keep]...)
+
+	// Sample exploration slots from the TRUE tail (indices >= limit — items that
+	// were never in the top-K), so the floor actually surfaces previously-excluded
+	// cold-start trails. ranked[keep:limit) are the displaced top-K items; use them
+	// only as fallback fill to still return exactly `limit`.
+	trueTail := make([]int, 0, len(ranked)-limit)
+	for i := limit; i < len(ranked); i++ {
+		trueTail = append(trueTail, i)
+	}
+	intn := func(n int) int {
+		if rng != nil {
+			return rng.Intn(n)
+		}
+		return rand.Intn(n)
+	}
+	for r := 0; r < reserve && len(trueTail) > 0; r++ {
+		j := intn(len(trueTail))
+		out = append(out, ranked[trueTail[j]])
+		trueTail = append(trueTail[:j], trueTail[j+1:]...)
+	}
+	// Fallback: if the true tail was smaller than reserve, fill from the displaced
+	// top-K items in rank order so the result is exactly `limit`.
+	for i := keep; i < limit && len(out) < limit; i++ {
+		out = append(out, ranked[i])
+	}
+	return out
+}

--- a/cli/internal/search/exploration_test.go
+++ b/cli/internal/search/exploration_test.go
@@ -1,0 +1,112 @@
+package search
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+)
+
+func TestExploreSelect_EpsilonZeroIsTopK(t *testing.T) {
+	in := []int{9, 8, 7, 6, 5, 4} // ranked best-first
+	got := ExploreSelect(in, 3, 0, nil)
+	if !reflect.DeepEqual(got, []int{9, 8, 7}) {
+		t.Errorf("epsilon=0 must be top-K (zero behavior change), got %v", got)
+	}
+}
+
+func TestExploreSelect_ShortSliceUnchanged(t *testing.T) {
+	in := []int{3, 2}
+	if got := ExploreSelect(in, 5, 0.5, nil); !reflect.DeepEqual(got, in) {
+		t.Errorf("len<=limit must return unchanged, got %v", got)
+	}
+}
+
+func TestExploreSelect_ReservesTailSlots(t *testing.T) {
+	in := []int{9, 8, 7, 6, 5, 4, 3, 2, 1, 0} // 10 items, ranked
+	rng := rand.New(rand.NewSource(42))
+	got := ExploreSelect(in, 4, 0.5, rng) // reserve = floor(0.5*4)=2, keep=2
+	if len(got) != 4 {
+		t.Fatalf("must return exactly limit=4, got %d (%v)", len(got), got)
+	}
+	// top-2 (exploit) always present and first
+	if got[0] != 9 || got[1] != 8 {
+		t.Errorf("top-2 exploit slots must be the best ranked, got %v", got)
+	}
+	// the other 2 must come from the TRUE tail (rank >= limit=4 → values <= 5),
+	// NOT the displaced top-K items (values 7,6) — locks the tail-boundary fix.
+	for _, v := range got[2:] {
+		if v > 5 {
+			t.Errorf("explore slot %d came from the displaced top-K, not the true tail", v)
+		}
+	}
+	// no duplicates
+	seen := map[int]bool{}
+	for _, v := range got {
+		if seen[v] {
+			t.Errorf("duplicate %d in selection %v", v, got)
+		}
+		seen[v] = true
+	}
+}
+
+func TestExploreSelect_Limit1KeepsTop(t *testing.T) {
+	in := []int{9, 8, 7}
+	if got := ExploreSelect(in, 1, 0.9, rand.New(rand.NewSource(1))); !reflect.DeepEqual(got, []int{9}) {
+		t.Errorf("limit=1 must keep the top item (no room to explore), got %v", got)
+	}
+}
+
+func TestExploreSelect_Deterministic(t *testing.T) {
+	in := []int{9, 8, 7, 6, 5, 4, 3, 2}
+	a := ExploreSelect(in, 4, 0.5, rand.New(rand.NewSource(7)))
+	b := ExploreSelect(in, 4, 0.5, rand.New(rand.NewSource(7)))
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("same seed must be deterministic: %v vs %v", a, b)
+	}
+}
+
+func TestExploreSelect_LimitZeroIsEmpty(t *testing.T) {
+	// match ranked[:limit] semantics: limit 0 -> empty (not the whole slice)
+	if got := ExploreSelect([]int{9, 8, 7}, 0, 0.5, nil); len(got) != 0 {
+		t.Errorf("limit<=0 must return empty (matches [:0]), got %v", got)
+	}
+}
+
+func TestExploreSelect_FallbackFillsToLimit(t *testing.T) {
+	// true tail smaller than reserve → fill from displaced to still return limit
+	in := []int{9, 8, 7, 6, 5}                                    // len 5
+	got := ExploreSelect(in, 4, 0.5, rand.New(rand.NewSource(3))) // reserve=2, keep=2, trueTail=[idx4]=1 item
+	if len(got) != 4 {
+		t.Fatalf("must return exactly limit=4 even when true tail < reserve, got %d (%v)", len(got), got)
+	}
+	if got[0] != 9 || got[1] != 8 {
+		t.Errorf("exploit slots must be the top-2, got %v", got)
+	}
+	seen := map[int]bool{}
+	for _, v := range got {
+		if seen[v] {
+			t.Errorf("duplicate %d in %v", v, got)
+		}
+		seen[v] = true
+	}
+	if !seen[5] { // the lone true-tail item (idx4) must be included
+		t.Errorf("true-tail item not surfaced: %v", got)
+	}
+}
+
+func TestResolveRetrievalEpsilon(t *testing.T) {
+	t.Setenv(retrievalEpsilonEnv, "")
+	if ResolveRetrievalEpsilon() != 0 {
+		t.Error("default epsilon must be 0")
+	}
+	t.Setenv(retrievalEpsilonEnv, "0.2")
+	if ResolveRetrievalEpsilon() != 0.2 {
+		t.Error("0.2 should parse")
+	}
+	for _, bad := range []string{"-0.1", "1.5", "abc", "NaN", "nan", "Inf", "+Inf"} {
+		t.Setenv(retrievalEpsilonEnv, bad)
+		if ResolveRetrievalEpsilon() != 0 {
+			t.Errorf("out-of-range/garbage %q must clamp to 0", bad)
+		}
+	}
+}


### PR DESCRIPTION
Knowledge-field S1: breaks the cold-start lock so under-explored gold trails get surfaced → cited → reinforced. See docs/architecture/knowledge-field-discovery.md.

`ExploreSelect` reserves `floor(ε·limit)` of the K returned slots for **true-tail** trails (rank ≥ limit, never in top-K) sampled without replacement — the ACO τ_min / exploration-noise analog. Wired into the gold lookup behind `AO_RETRIEVAL_EPSILON`. **ε=0 (default) == the prior top-K trim — zero behavior change** until opted in.

**Cross-family reviewed** (codex PASS-WITH-CHANGES, all applied): `limit<=0` now returns empty (matches `[:limit]`); exploration samples the **true tail** first (was `ranked[keep:]`, which could re-pick already-top-K items); `ResolveRetrievalEpsilon` rejects NaN/Inf.

8 unit tests + a `collectGoldKnowledge` integration test (ε=0 caps at limit). Scope: tail-sampling floor only — *optimistic-init* (boost under-observed trails up the rank) is the deferred complement; the full **token-budget A/B** is the integration gate for when the decision-point pull lands on a populated corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)