### PR TITLE
feat(lookup): --pointers bounded retrieval (knowledge-field S1, gold pull)

### DIFF
--- a/cli/cmd/ao/lookup.go
+++ b/cli/cmd/ao/lookup.go
@@ -25,6 +25,7 @@ var (
 	lookupCiteType  string
 	lookupSessionID string
 	lookupGold      bool
+	lookupPointers  bool
 )
 
 var lookupCmd = &cobra.Command{
@@ -61,6 +62,7 @@ func init() {
 	lookupCmd.Flags().StringVar(&lookupCiteType, "cite", "retrieved", "Citation type to record for returned artifacts: retrieved, reference, applied")
 	lookupCmd.Flags().StringVar(&lookupSessionID, "session", "", "Session ID for citation tracking")
 	lookupCmd.Flags().BoolVar(&lookupGold, "gold", false, "Retrieve from the sanitized OKF gold wiki (.ao/wiki) instead of the raw .agents/ corpus")
+	lookupCmd.Flags().BoolVar(&lookupPointers, "pointers", false, "Compact pointers only (type · title · path · score) — no bodies; the token-cheap mode for decision-point pulls")
 }
 
 func runLookup(cmd *cobra.Command, args []string) error {
@@ -74,8 +76,13 @@ func runLookup(cmd *cobra.Command, args []string) error {
 		VerbosePrintf("Warning: config load: %v (using defaults)\n", cfgErr)
 	}
 
-	// Mode 1: Lookup by ID
+	// Mode 1: Lookup by ID — fetches ONE artifact's full content, so --pointers
+	// (body-free) is contradictory and would otherwise leak a body past the
+	// compact contract. Refuse rather than silently emit the full artifact.
 	if len(args) > 0 {
+		if lookupPointers {
+			return fmt.Errorf("--pointers applies to --query/--bead retrieval, not by-ID fetch")
+		}
 		return lookupByID(cwd, args[0], cfg)
 	}
 
@@ -402,7 +409,33 @@ func outputFinding(cwd string, f knowledgeFinding) error {
 }
 
 // outputResults renders multiple learnings, patterns, and findings.
+// outputPointers renders compact, body-free pointers — the token-cheap retrieval
+// mode for decision-point pulls. One line per item (type · title · path · score),
+// no Summary/evidence/bodies, so a mandatory pre-decision retrieval can't restack
+// the prompt (the spray failure that killed the bookends: delta=0 @ 10.35M tokens).
+func outputPointers(cwd string, learnings []learning, patterns []pattern, findings []knowledgeFinding) error {
+	if len(learnings) == 0 && len(patterns) == 0 && len(findings) == 0 {
+		fmt.Println("No matching artifacts found.")
+		return nil
+	}
+	for _, l := range learnings {
+		fmt.Printf("- [learning] %s — %s (score %.2f)\n", l.Title, relPath(cwd, l.Source), l.CompositeScore)
+	}
+	for _, p := range patterns {
+		fmt.Printf("- [pattern] %s — %s (score %.2f)\n", p.Name, relPath(cwd, p.FilePath), p.CompositeScore)
+	}
+	for _, f := range findings {
+		fmt.Printf("- [finding] %s — %s (score %.2f)\n", f.Title, relPath(cwd, f.Source), f.CompositeScore)
+	}
+	return nil
+}
+
 func outputResults(cwd string, learnings []learning, patterns []pattern, findings []knowledgeFinding) error {
+	// --pointers wins over --json: the token-cheap, body-free contract must hold
+	// on every output path (a --json --pointers combo must NOT emit bodies).
+	if lookupPointers {
+		return outputPointers(cwd, learnings, patterns, findings)
+	}
 	if lookupJSON {
 		result := struct {
 			Learnings []learning         `json:"learnings"`

--- a/cli/cmd/ao/lookup_test.go
+++ b/cli/cmd/ao/lookup_test.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1012,5 +1013,60 @@ func TestCollectGoldKnowledge_RespectsLimit(t *testing.T) {
 	learnings, _, _ := collectGoldKnowledge(gold, "flywheel", 2)
 	if len(learnings) != 2 {
 		t.Errorf("ε=0: expected exactly limit=2 from 5 matching learnings, got %d", len(learnings))
+	}
+}
+
+// TestOutputPointers_CompactNoBodies proves the --pointers mode is token-cheap:
+// one line per item (title/path/score), and the body/Summary is NOT emitted — so a
+// mandatory pre-decision gold pull can't restack the prompt (the spray failure).
+func TestOutputPointers_CompactNoBodies(t *testing.T) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	_ = outputPointers(".",
+		[]learning{{Title: "Ratchet lesson", Summary: "SECRET_BODY_TEXT", Source: "/x/r.md", CompositeScore: 0.9}},
+		nil, nil)
+	_ = w.Close()
+	os.Stdout = old
+	b, _ := io.ReadAll(r)
+	out := string(b)
+	if !strings.Contains(out, "Ratchet lesson") || !strings.Contains(out, "r.md") || !strings.Contains(out, "score") {
+		t.Errorf("pointers must include title/path/score: %q", out)
+	}
+	if strings.Contains(out, "SECRET_BODY_TEXT") {
+		t.Errorf("pointers must NOT include the body (token-cheap mode): %q", out)
+	}
+	if n := strings.Count(strings.TrimSpace(out), "\n"); n != 0 {
+		t.Errorf("expected exactly 1 pointer line for 1 item, got %q", out)
+	}
+}
+
+// TestOutputPointers_WinsOverJSON: --json --pointers must NOT leak bodies
+// (pointers takes precedence — the token-cheap contract holds on every path).
+func TestOutputPointers_WinsOverJSON(t *testing.T) {
+	oldP, oldJ := lookupPointers, lookupJSON
+	lookupPointers, lookupJSON = true, true
+	defer func() { lookupPointers, lookupJSON = oldP, oldJ }()
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	_ = outputResults(".", []learning{{Title: "T1", Summary: "SECRET_BODY", Source: "/x/a.md", CompositeScore: 0.5}}, nil, nil)
+	_ = w.Close()
+	os.Stdout = old
+	b, _ := io.ReadAll(r)
+	if out := string(b); strings.Contains(out, "SECRET_BODY") || !strings.Contains(out, "T1") {
+		t.Errorf("--json --pointers must be compact body-free, got %q", out)
+	}
+}
+
+// TestLookup_PointersByIDErrors: --pointers on a by-ID fetch is contradictory and
+// must error rather than emit the full artifact body.
+func TestLookup_PointersByIDErrors(t *testing.T) {
+	old := lookupPointers
+	lookupPointers = true
+	defer func() { lookupPointers = old }()
+	err := runLookup(nil, []string{"some-id"})
+	if err == nil || !strings.Contains(err.Error(), "--pointers applies") {
+		t.Errorf("by-ID + --pointers must error, got %v", err)
 	}
 }


### PR DESCRIPTION
Bounded token-cheap retrieval (outputPointers: type·title·path·score, no bodies) so a mandatory pre-decision gold pull can't restack the prompt (the delta=0 @ 10.35M bookend lesson). Composes with --gold + ε-floor. Codex PASS-WITH-CHANGES applied: --pointers wins over --json (no body leak); by-ID + --pointers errors. Tests: compact/no-body, wins-over-json, by-ID-errors, collectGoldKnowledge-limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)