### PR TITLE
fix(ci): make the validate.yml backstop green — fix all four pre-existing red check classes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -214,9 +214,10 @@ jobs:
       - name: Install gate dependencies
         run: |
           sudo apt-get update
-          # bats: the full gate's check-cli-contract.sh shells out to it and
-          # fails closed (exit 127) when absent.
-          sudo apt-get install -y jq shellcheck bats
+          # bats + ripgrep: the full gate's check-cli-contract.sh shells out to
+          # both (bats runs tests/cli_contract_gate.bats, whose tests `run rg`
+          # and assert exit 1 — an absent rg exits 127 and fails them).
+          sudo apt-get install -y jq shellcheck bats ripgrep
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
           pip install jsonschema pyyaml
@@ -304,7 +305,12 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          fetch-depth: 2
+          # fetch-depth: 0 so origin/main resolves (same rationale as the
+          # go-gate-shadow checkout, age-ipbr): bats suites that exercise the
+          # frontdoor-admission guard (reconcile-pr, disposition-schema) fail
+          # CLOSED with "cannot resolve admission base 'origin/main'" on a
+          # shallow single-ref checkout.
+          fetch-depth: 0
 
       # ── bats runs FIRST, on the pristine checkout, before the Go build/test
       # steps below. The Go test phase shares this working tree and a cli/ test

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -311,20 +311,42 @@ jobs:
       # self-tests in the bats suite read stale validate.yml. Running bats up
       # front — exactly the pristine-checkout + npm-bats setup the standalone
       # bats-tests job used pre-rebuild — keeps it pollution-free (ag-877).
+      #
       # bats needs only the runner's preinstalled python+PyYAML/jq/ripgrep; it
-      # does not need Go or a built ao.
+      # does not need Go or a built ao — but it DOES need PAWL_EDGE_FAIL_OPEN=1
+      # (set on the Run step below). Several suites (reconcile-pr, pawl-review*,
+      # check-pawl-pre-push, reviewer-adapters, …) seed verdicts via
+      # scripts/pawl-verdict.sh, whose F2 hardening (age-pawl-intent-zhndq.2)
+      # makes `write` fail-CLOSED exit 7 (EDGE-UNBOUND) when no trusted ao can
+      # emit the provenance verdict edge. There is deliberately NO ao here: an
+      # ao on PATH would instead trip pawl-review's preflight `ao gate check`
+      # against the hermetic temp repos. The verdict-edge emit is a best-effort
+      # sensor, so fail-OPEN it for the whole suite; the dedicated fail-closed
+      # regression files re-assert the strict default by unsetting the var
+      # themselves (pawl-verdict-edge-failclosed / pawl-verdict-autobind /
+      # pawl-review-edge-unbound).
       - name: Install bats
         if: runner.os == 'Linux' && (needs.changes.outputs.hooks == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.bats == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.docs == 'true')
         run: sudo npm install -g bats@1.12.0
 
       - name: Run bats tests
         if: runner.os == 'Linux' && (needs.changes.outputs.hooks == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.bats == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.skills == 'true' || needs.changes.outputs.docs == 'true')
+        env:
+          # See the note above "Install bats": with no trusted ao in this phase,
+          # scripts/pawl-verdict.sh's F2 verdict-edge emit would fail-CLOSED
+          # (exit 7) and abort every suite that seeds a verdict. The emit is a
+          # best-effort sensor, so fail-OPEN it here. The fail-closed regression
+          # files unset this per-invocation to keep asserting the strict default.
+          PAWL_EDGE_FAIL_OPEN: "1"
         run: |
           echo "=== Running bats tests (4-way parallel) ==="
           # bats --jobs needs GNU parallel; the serial run was ~237s (55% of the
           # correctness critical path). --no-parallelize-within-files preserves
           # ordering inside each file; only independent files run concurrently.
-          sudo apt-get install -y parallel >/dev/null 2>&1 || { sudo apt-get update -qq && sudo apt-get install -y parallel; }
+          # ripgrep is NOT preinstalled on the runner image: a few gate scripts
+          # (check-orchestration-skill-boundaries.sh, skill-standards-convergence,
+          # the cli_contract nested gate) shell out to `rg` and otherwise 127.
+          sudo apt-get install -y parallel ripgrep >/dev/null 2>&1 || { sudo apt-get update -qq && sudo apt-get install -y parallel ripgrep; }
           bats --jobs 4 --no-parallelize-within-files --print-output-on-failure tests/scripts/*.bats
           echo "✅ Bats tests passed"
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.5'
           cache-dependency-path: cli/go.sum
 
       - name: Set up Python
@@ -214,7 +214,9 @@ jobs:
       - name: Install gate dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y jq shellcheck
+          # bats: the full gate's check-cli-contract.sh shells out to it and
+          # fails closed (exit 127) when absent.
+          sudo apt-get install -y jq shellcheck bats
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
           pip install jsonschema pyyaml
@@ -353,7 +355,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.5'
           cache-dependency-path: cli/go.sum
 
       - name: Set up Python (smoke-test)
@@ -679,7 +681,7 @@ jobs:
         if: needs.changes.outputs.go == 'true' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.ci == 'true'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.5'
           cache-dependency-path: cli/go.sum
 
       - name: Set up Python (security toolchain)

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Supporting control plane behind the skills (bookkeeping, retrieval, release gate
 ao quick-start            # set up AgentOps in a repo
 ao doctor                 # check skills, reviewers, ledger health
 ao gate check --fast      # optional deterministic release check before you push
-ao verify                 # deterministic support check; skills own completion
+ao verify my-first-change # deterministic support check; skills own completion
 ao provenance show <sha>  # recorded verdict trail
 ao skills graph           # inspect the generated skill dependency graph
 

--- a/cli/cmd/ao/session_bootstrap_posix_test.go
+++ b/cli/cmd/ao/session_bootstrap_posix_test.go
@@ -1,0 +1,48 @@
+//go:build !windows
+
+// The FIFO DoS regression is POSIX-specific: syscall.Mkfifo does not exist on
+// Windows (the symbol does not compile there), and readRegularFileCapped's
+// non-regular-file skip is already exercised cross-platform via the directory
+// case in session_bootstrap_test.go.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Regression for the cross-family DoS refute: a FIFO (or any non-regular path)
+// must be skipped WITHOUT hanging, so a hostile repo cannot stall bootstrap.
+func TestReadRegularFileCapped_SkipsNonRegularNoHang(t *testing.T) {
+	dir := t.TempDir()
+	if _, ok := readRegularFileCapped(dir, 1<<10); ok {
+		t.Fatal("directory: want skip (false)")
+	}
+	reg := filepath.Join(dir, "f")
+	if err := os.WriteFile(reg, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if data, ok := readRegularFileCapped(reg, 1<<10); !ok || string(data) != "hello" {
+		t.Fatalf("regular file: ok=%v data=%q", ok, data)
+	}
+	fifo := filepath.Join(dir, "pipe")
+	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+		t.Skipf("mkfifo unavailable: %v", err)
+	}
+	done := make(chan bool, 1)
+	go func() {
+		_, ok := readRegularFileCapped(fifo, 1<<10)
+		done <- ok
+	}()
+	select {
+	case ok := <-done:
+		if ok {
+			t.Fatal("FIFO: want skip (false)")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("DoS: readRegularFileCapped hung on a FIFO")
+	}
+}

--- a/cli/cmd/ao/session_bootstrap_test.go
+++ b/cli/cmd/ao/session_bootstrap_test.go
@@ -15,7 +15,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -401,39 +400,6 @@ func TestSessionBootstrapGateHookStatus_NeverExecutesInstaller(t *testing.T) {
 	}
 	if quality.FileExists(sentinel) {
 		t.Fatal("SECURITY: gate-hook status executed a working-tree installer script")
-	}
-}
-
-// Regression for the cross-family DoS refute: a FIFO (or any non-regular path)
-// must be skipped WITHOUT hanging, so a hostile repo cannot stall bootstrap.
-func TestReadRegularFileCapped_SkipsNonRegularNoHang(t *testing.T) {
-	dir := t.TempDir()
-	if _, ok := readRegularFileCapped(dir, 1<<10); ok {
-		t.Fatal("directory: want skip (false)")
-	}
-	reg := filepath.Join(dir, "f")
-	if err := os.WriteFile(reg, []byte("hello"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if data, ok := readRegularFileCapped(reg, 1<<10); !ok || string(data) != "hello" {
-		t.Fatalf("regular file: ok=%v data=%q", ok, data)
-	}
-	fifo := filepath.Join(dir, "pipe")
-	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
-		t.Skipf("mkfifo unavailable: %v", err)
-	}
-	done := make(chan bool, 1)
-	go func() {
-		_, ok := readRegularFileCapped(fifo, 1<<10)
-		done <- ok
-	}()
-	select {
-	case ok := <-done:
-		if ok {
-			t.Fatal("FIFO: want skip (false)")
-		}
-	case <-time.After(3 * time.Second):
-		t.Fatal("DoS: readRegularFileCapped hung on a FIFO")
 	}
 }
 

--- a/cli/cmd/ao/skills_link.go
+++ b/cli/cmd/ao/skills_link.go
@@ -245,7 +245,7 @@ func linkAllDests(srcDir string, dests []string, dryRun bool) ([]skillLinkResult
 	results := make([]skillLinkResult, 0, len(dests))
 	anyErr := false
 	for _, dest := range dests {
-		res, err := linkMissingSkills(srcDir, dest, dryRun)
+		res, err := linkMissingSkills(srcDir, dest, dryRun) // nosemgrep -- res is a value struct (never nil); setting res.Err on error cannot nil-deref.
 		if err != nil {
 			res.Err = err.Error()
 			anyErr = true

--- a/cli/cmd/ao/skills_link_test.go
+++ b/cli/cmd/ao/skills_link_test.go
@@ -310,3 +310,32 @@ func TestLinkAllDests_ResilientAcrossDests(t *testing.T) {
 		t.Fatalf("good dest was skipped after the earlier failure: %v", err)
 	}
 }
+
+// renderLinkResult is the human-facing per-dest summary: the ERROR line must
+// promise the fan-out continued, and dry-run must never claim links were made.
+// (Paired with the resilient linkAllDests contract above; added alongside the
+// semgrep-suppression annotation on that call site.)
+func TestRenderLinkResult_ErrorDryRunAndConflictLines(t *testing.T) {
+	var errBuf strings.Builder
+	renderLinkResult(&errBuf, skillLinkResult{Dest: "/d1", Err: "boom"})
+	out := errBuf.String()
+	if !strings.Contains(out, "ERROR: boom") || !strings.Contains(out, "other runtimes still attempted") {
+		t.Errorf("error rendering must name the error and the continued fan-out, got:\n%s", out)
+	}
+	if strings.Contains(out, "linked:") {
+		t.Errorf("error rendering must not print link counts, got:\n%s", out)
+	}
+
+	var dryBuf strings.Builder
+	renderLinkResult(&dryBuf, skillLinkResult{Dest: "/d2", DryRun: true, Linked: []string{"alpha"}, Conflicts: []string{"gamma"}})
+	out = dryBuf.String()
+	if !strings.Contains(out, "missing (dry-run, not linked): 1") {
+		t.Errorf("dry-run rendering must label links as not created, got:\n%s", out)
+	}
+	if !strings.Contains(out, "? alpha") {
+		t.Errorf("dry-run link mark must be '?', got:\n%s", out)
+	}
+	if !strings.Contains(out, "! gamma (real dir — foreign corpus, not clobbered)") {
+		t.Errorf("conflict line must state the non-clobber guarantee, got:\n%s", out)
+	}
+}

--- a/cli/cmd/ao/skills_unlink.go
+++ b/cli/cmd/ao/skills_unlink.go
@@ -197,7 +197,7 @@ func unlinkAllDests(srcDir string, dests []string, dryRun bool) ([]skillUnlinkRe
 	results := make([]skillUnlinkResult, 0, len(dests))
 	anyErr := false
 	for _, dest := range dests {
-		res, err := unlinkOwnedSkills(srcDir, dest, dryRun)
+		res, err := unlinkOwnedSkills(srcDir, dest, dryRun) // nosemgrep -- res is a value struct (never nil); setting res.Err on error cannot nil-deref.
 		if err != nil {
 			res.Err = err.Error()
 			anyErr = true

--- a/cli/cmd/ao/skills_unlink_test.go
+++ b/cli/cmd/ao/skills_unlink_test.go
@@ -242,3 +242,32 @@ func TestUnlinkAllDests_ResilientAcrossDests(t *testing.T) {
 		t.Fatalf("good dest was skipped after the earlier failure (link still present): %v", err)
 	}
 }
+
+// renderUnlinkResult is the human-facing per-dest summary: the ERROR line must
+// promise the sweep continued, and dry-run must never claim removals happened.
+// (Paired with the resilient unlinkAllDests contract above; added alongside the
+// semgrep-suppression annotation on that call site.)
+func TestRenderUnlinkResult_ErrorDryRunAndForeignLines(t *testing.T) {
+	var errBuf strings.Builder
+	renderUnlinkResult(&errBuf, skillUnlinkResult{Dest: "/d1", Err: "boom"})
+	out := errBuf.String()
+	if !strings.Contains(out, "ERROR: boom") || !strings.Contains(out, "other runtimes still attempted") {
+		t.Errorf("error rendering must name the error and the continued sweep, got:\n%s", out)
+	}
+	if strings.Contains(out, "removed:") {
+		t.Errorf("error rendering must not print removal counts, got:\n%s", out)
+	}
+
+	var dryBuf strings.Builder
+	renderUnlinkResult(&dryBuf, skillUnlinkResult{Dest: "/d2", DryRun: true, Removed: []string{"alpha"}, Foreign: []string{"gamma"}})
+	out = dryBuf.String()
+	if !strings.Contains(out, "would remove (dry-run): 1") {
+		t.Errorf("dry-run rendering must label removals as not performed, got:\n%s", out)
+	}
+	if !strings.Contains(out, "? alpha") {
+		t.Errorf("dry-run removal mark must be '?', got:\n%s", out)
+	}
+	if !strings.Contains(out, ". gamma (not AgentOps-owned — kept)") {
+		t.Errorf("foreign line must state the keep guarantee, got:\n%s", out)
+	}
+}

--- a/cli/internal/adapters/beads/executor.go
+++ b/cli/internal/adapters/beads/executor.go
@@ -23,6 +23,12 @@ func (executor *Executor) Execute(ctx context.Context, args []string, streams be
 	if executor == nil || executor.tracker == nil {
 		return fmt.Errorf("beads tracker executor is not configured")
 	}
+	// A cobra command invoked outside Execute (direct RunE calls in tests or
+	// embedding) carries a nil context; exec.CommandContext panics on nil.
+	// Background preserves the no-cancellation semantics such callers had.
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	resolution, err := executor.tracker.Resolve()
 	if err != nil {
 		return err

--- a/cli/internal/archcheck/checker.go
+++ b/cli/internal/archcheck/checker.go
@@ -161,7 +161,7 @@ func Check(options Options) ([]Violation, error) {
 		return nil, err
 	}
 	violations = append(violations, semanticViolations...)
-	violations = filterAcceptedSemanticDebt(root, violations)
+
 	violations = dedupe(violations)
 	sortViolations(violations)
 	return violations, nil

--- a/cli/internal/archcheck/checker.go
+++ b/cli/internal/archcheck/checker.go
@@ -180,7 +180,7 @@ func checkTree(root, tree string) ([]Violation, error) {
 		if err != nil {
 			return err
 		}
-		data, err := os.ReadFile(path)
+		data, err := os.ReadFile(path) // #nosec G122 -- dev-time arch checker walks this repo's own trusted source tree; no symlink-TOCTOU threat model.
 		if err != nil {
 			return err
 		}

--- a/cli/internal/archcheck/checker_test.go
+++ b/cli/internal/archcheck/checker_test.go
@@ -21,13 +21,16 @@ func TestSemanticEscapeClassifierPositiveAndNegativeFixtures(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	positive := []string{
 		"cli/internal/adapters/claim/tracker.go",
-		"cli/internal/commands/beads/module.go",
 		"cli/cmd/ao/root.go",
 	}
 	negative := []string{
 		"cli/internal/adapters/worktreeconfig/worktree_config.go",
 		"cli/internal/context/run.go",
 		"cli/internal/adapters/tracker_br/tracker_br_test.go",
+		// The beads module's context debt was paid (bb35feb0e routed tracker
+		// launches through trackerexec with cancellation propagated); pin the
+		// clean state so the debt cannot silently return.
+		"cli/internal/commands/beads/module.go",
 	}
 	for _, path := range positive {
 		source, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(path)))

--- a/cli/internal/archcheck/inventory.go
+++ b/cli/internal/archcheck/inventory.go
@@ -45,7 +45,7 @@ func BuildInventory(root, family string) (Inventory, error) {
 	cmdRoot := filepath.Join(root, "cli", "cmd", "ao")
 	ownerSet := map[string]bool{}
 	symbolSet := map[string]bool{}
-	effectSet := map[Rule]bool{}
+	effectSet := map[Rule]bool{} // nosemgrep -- populated via the sets struct inside scanInventoryOwner (sets.effects[...]=true) before the range below; not empty.
 	candidateSet := map[string]bool{}
 	sets := inventorySets{
 		owners:     ownerSet,

--- a/cli/internal/archcheck/semantic.go
+++ b/cli/internal/archcheck/semantic.go
@@ -15,11 +15,6 @@ import (
 
 const semanticSealFilename = "semantic-seal.json"
 
-const (
-	beadsContextDebtPath   = "cli/internal/commands/beads/module.go"
-	beadsContextDebtSHA256 = "b12905e003a327ccff1b31ff6f077c0e69bffe4956c00435cf29dcefd1ac6dae"
-)
-
 type semanticSealManifest struct {
 	SchemaVersion int                 `json:"schema_version"`
 	Class         string              `json:"class"`
@@ -47,24 +42,6 @@ type semanticEvidenceDocument struct {
 	Class         string            `json:"class"`
 	CandidateSHA  string            `json:"candidate_sha"`
 	SourceDigests map[string]string `json:"source_digests"`
-}
-
-func filterAcceptedSemanticDebt(root string, violations []Violation) []Violation {
-	if _, err := os.Stat(filepath.Join(root, ".git")); err != nil {
-		return violations
-	}
-	source, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(beadsContextDebtPath)))
-	if err != nil || digestBytes(source) != beadsContextDebtSHA256 {
-		return violations
-	}
-	filtered := violations[:0]
-	for _, violation := range violations {
-		if violation.Rule == RuleContext && violation.Path == beadsContextDebtPath {
-			continue
-		}
-		filtered = append(filtered, violation)
-	}
-	return filtered
 }
 
 func checkSemanticSeal(root, expectedCandidate string) ([]Violation, error) {

--- a/cli/internal/archcheck/semantic.go
+++ b/cli/internal/archcheck/semantic.go
@@ -231,7 +231,7 @@ func SemanticProductionGate(expectedCandidate string) ([]Rule, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer os.RemoveAll(root)
+	defer func() { _ = os.RemoveAll(root) }()
 	changedSource := []byte("changed source\n")
 	generated := []byte("generated from source\n")
 	if err := os.WriteFile(filepath.Join(root, "source.txt"), changedSource, 0o600); err != nil {
@@ -328,6 +328,71 @@ func checkGeneratedEvidence(root string, manifest semanticSealManifest) []Violat
 	return violations
 }
 
+// recursiveCommandNode is a discovered cobra command literal plus whether it is runnable.
+type recursiveCommandNode struct {
+	node     ast.Node
+	runnable bool
+}
+
+// collectCommandDefinition records a cobra command literal assigned to an identifier.
+func collectCommandDefinition(node ast.Node, aliases map[string]string, commands map[string]recursiveCommandNode) {
+	assignment, ok := node.(*ast.AssignStmt)
+	if !ok || len(assignment.Lhs) != 1 || len(assignment.Rhs) != 1 {
+		return
+	}
+	name, nameOK := assignment.Lhs[0].(*ast.Ident)
+	literal, literalOK := cobraCommandLiteral(assignment.Rhs[0], aliases)
+	if nameOK && literalOK {
+		commands[name.Name] = recursiveCommandNode{node: literal, runnable: cobraCommandRunnable(literal)}
+	}
+}
+
+// collectCommandGraphEdges records AddCommand parent→child edges and clicontract attachment counts.
+func collectCommandGraphEdges(node ast.Node, aliases map[string]string, edges map[string][]string, attachments map[string]int) {
+	call, ok := node.(*ast.CallExpr)
+	if !ok {
+		return
+	}
+	selector, selectorOK := call.Fun.(*ast.SelectorExpr)
+	if !selectorOK {
+		return
+	}
+	if selector.Sel.Name == "AddCommand" {
+		if parent, parentOK := selector.X.(*ast.Ident); parentOK {
+			for _, argument := range call.Args {
+				if child, childOK := argument.(*ast.Ident); childOK {
+					edges[parent.Name] = append(edges[parent.Name], child.Name)
+				}
+			}
+		}
+	}
+	if selector.Sel.Name == "Attach" {
+		pkg, pkgOK := selector.X.(*ast.Ident)
+		if pkgOK && aliases[pkg.Name] == "github.com/boshu2/agentops/cli/internal/clicontract" && len(call.Args) > 0 {
+			if command, commandOK := call.Args[0].(*ast.Ident); commandOK {
+				attachments[command.Name]++
+			}
+		}
+	}
+}
+
+// collectCommandRoots records identifiers returned as command roots.
+func collectCommandRoots(node ast.Node, commands map[string]recursiveCommandNode, roots map[string]bool) {
+	statement, ok := node.(*ast.ReturnStmt)
+	if !ok {
+		return
+	}
+	for _, result := range statement.Results {
+		root, rootOK := result.(*ast.Ident)
+		if !rootOK {
+			continue
+		}
+		if _, commandOK := commands[root.Name]; commandOK {
+			roots[root.Name] = true
+		}
+	}
+}
+
 func checkRecursiveContractsSource(path string, source []byte) ([]Violation, error) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, path, source, 0)
@@ -335,53 +400,14 @@ func checkRecursiveContractsSource(path string, source []byte) ([]Violation, err
 		return nil, fmt.Errorf("parse semantic source %s: %w", path, err)
 	}
 	aliases := sourceImportAliases(file)
-	type commandNode struct {
-		node     ast.Node
-		runnable bool
-	}
-	commands := map[string]commandNode{}
+	commands := map[string]recursiveCommandNode{}
 	edges := map[string][]string{}
 	attachments := map[string]int{}
 	roots := map[string]bool{}
 	ast.Inspect(file, func(node ast.Node) bool {
-		if assignment, ok := node.(*ast.AssignStmt); ok && len(assignment.Lhs) == 1 && len(assignment.Rhs) == 1 {
-			name, nameOK := assignment.Lhs[0].(*ast.Ident)
-			literal, literalOK := cobraCommandLiteral(assignment.Rhs[0], aliases)
-			if nameOK && literalOK {
-				commands[name.Name] = commandNode{node: literal, runnable: cobraCommandRunnable(literal)}
-			}
-		}
-		call, ok := node.(*ast.CallExpr)
-		if ok {
-			selector, selectorOK := call.Fun.(*ast.SelectorExpr)
-			if selectorOK && selector.Sel.Name == "AddCommand" {
-				parent, parentOK := selector.X.(*ast.Ident)
-				if parentOK {
-					for _, argument := range call.Args {
-						if child, childOK := argument.(*ast.Ident); childOK {
-							edges[parent.Name] = append(edges[parent.Name], child.Name)
-						}
-					}
-				}
-			}
-			if selectorOK && selector.Sel.Name == "Attach" {
-				pkg, pkgOK := selector.X.(*ast.Ident)
-				if pkgOK && aliases[pkg.Name] == "github.com/boshu2/agentops/cli/internal/clicontract" && len(call.Args) > 0 {
-					if command, commandOK := call.Args[0].(*ast.Ident); commandOK {
-						attachments[command.Name]++
-					}
-				}
-			}
-		}
-		if statement, ok := node.(*ast.ReturnStmt); ok {
-			for _, result := range statement.Results {
-				if root, rootOK := result.(*ast.Ident); rootOK {
-					if _, commandOK := commands[root.Name]; commandOK {
-						roots[root.Name] = true
-					}
-				}
-			}
-		}
+		collectCommandDefinition(node, aliases, commands)
+		collectCommandGraphEdges(node, aliases, edges, attachments)
+		collectCommandRoots(node, commands, roots)
 		return true
 	})
 	reachable := map[string]bool{}
@@ -443,13 +469,9 @@ func cobraCommandRunnable(literal *ast.CompositeLit) bool {
 	return false
 }
 
-func checkOutputSource(path string, source []byte) ([]Violation, error) {
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, path, source, 0)
-	if err != nil {
-		return nil, fmt.Errorf("parse semantic source %s: %w", path, err)
-	}
-	aliases := sourceImportAliases(file)
+// collectStructuredFunctions reports the functions that call clicontract.OutputStructured
+// and whether any structured contract exists at all.
+func collectStructuredFunctions(file *ast.File, aliases map[string]string) (map[string]bool, bool) {
 	structuredFunctions := map[string]bool{}
 	structured := false
 	for _, declaration := range file.Decls {
@@ -474,53 +496,52 @@ func checkOutputSource(path string, source []byte) ([]Violation, error) {
 			structuredFunctions[function.Name.Name] = true
 		}
 	}
-	runnables := map[string]ast.Node{}
-	structuredAttachments := map[string]int{}
-	ast.Inspect(file, func(node ast.Node) bool {
-		if assignment, ok := node.(*ast.AssignStmt); ok && len(assignment.Lhs) == 1 && len(assignment.Rhs) == 1 {
-			name, nameOK := assignment.Lhs[0].(*ast.Ident)
-			literal, literalOK := cobraCommandLiteral(assignment.Rhs[0], aliases)
-			if nameOK && literalOK && cobraCommandRunnable(literal) {
-				runnables[name.Name] = literal
-			}
-		}
-		if statement, ok := node.(*ast.ReturnStmt); ok {
-			for _, result := range statement.Results {
-				literal, literalOK := cobraCommandLiteral(result, aliases)
-				if literalOK && cobraCommandRunnable(literal) {
-					runnables[fmt.Sprintf("@%d", fset.Position(literal.Pos()).Line)] = literal
-				}
-			}
-		}
-		call, ok := node.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		selector, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || selector.Sel.Name != "Attach" || len(call.Args) < 2 {
-			return true
-		}
-		pkg, pkgOK := selector.X.(*ast.Ident)
-		command, commandOK := call.Args[0].(*ast.Ident)
-		contractCall, callOK := call.Args[1].(*ast.CallExpr)
-		if !callOK {
-			return true
-		}
-		contractName, nameOK := contractCall.Fun.(*ast.Ident)
-		if pkgOK && commandOK && nameOK && aliases[pkg.Name] == "github.com/boshu2/agentops/cli/internal/clicontract" && structuredFunctions[contractName.Name] {
-			structuredAttachments[command.Name]++
-		}
-		return true
-	})
-	if !structured {
-		return nil, nil
-	}
-	var violations []Violation
-	for name, node := range runnables {
-		if structuredAttachments[name] != 1 {
-			violations = append(violations, Violation{Rule: RuleOutput, Path: path, Line: fset.Position(node.Pos()).Line, Message: fmt.Sprintf("structured output contract must be attached exactly once to runnable %s", name)})
+	return structuredFunctions, structured
+}
+
+// collectOutputRunnable records runnable cobra commands defined by assignment or returned inline.
+func collectOutputRunnable(node ast.Node, aliases map[string]string, fset *token.FileSet, runnables map[string]ast.Node) {
+	if assignment, ok := node.(*ast.AssignStmt); ok && len(assignment.Lhs) == 1 && len(assignment.Rhs) == 1 {
+		name, nameOK := assignment.Lhs[0].(*ast.Ident)
+		literal, literalOK := cobraCommandLiteral(assignment.Rhs[0], aliases)
+		if nameOK && literalOK && cobraCommandRunnable(literal) {
+			runnables[name.Name] = literal
 		}
 	}
+	if statement, ok := node.(*ast.ReturnStmt); ok {
+		for _, result := range statement.Results {
+			literal, literalOK := cobraCommandLiteral(result, aliases)
+			if literalOK && cobraCommandRunnable(literal) {
+				runnables[fmt.Sprintf("@%d", fset.Position(literal.Pos()).Line)] = literal
+			}
+		}
+	}
+}
+
+// collectStructuredAttachment counts clicontract.Attach calls that bind a structured contract.
+func collectStructuredAttachment(node ast.Node, aliases map[string]string, structuredFunctions map[string]bool, structuredAttachments map[string]int) {
+	call, ok := node.(*ast.CallExpr)
+	if !ok {
+		return
+	}
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != "Attach" || len(call.Args) < 2 {
+		return
+	}
+	pkg, pkgOK := selector.X.(*ast.Ident)
+	command, commandOK := call.Args[0].(*ast.Ident)
+	contractCall, callOK := call.Args[1].(*ast.CallExpr)
+	if !callOK {
+		return
+	}
+	contractName, nameOK := contractCall.Fun.(*ast.Ident)
+	if pkgOK && commandOK && nameOK && aliases[pkg.Name] == "github.com/boshu2/agentops/cli/internal/clicontract" && structuredFunctions[contractName.Name] {
+		structuredAttachments[command.Name]++
+	}
+}
+
+// appendHumanTextViolations flags fmt.Fprint* human-text formatting under a structured contract.
+func appendHumanTextViolations(file *ast.File, aliases map[string]string, fset *token.FileSet, path string, violations []Violation) []Violation {
 	ast.Inspect(file, func(node ast.Node) bool {
 		call, ok := node.(*ast.CallExpr)
 		if !ok {
@@ -536,6 +557,34 @@ func checkOutputSource(path string, source []byte) ([]Violation, error) {
 		}
 		return true
 	})
+	return violations
+}
+
+func checkOutputSource(path string, source []byte) ([]Violation, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, source, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parse semantic source %s: %w", path, err)
+	}
+	aliases := sourceImportAliases(file)
+	structuredFunctions, structured := collectStructuredFunctions(file, aliases)
+	runnables := map[string]ast.Node{}
+	structuredAttachments := map[string]int{}
+	ast.Inspect(file, func(node ast.Node) bool {
+		collectOutputRunnable(node, aliases, fset, runnables)
+		collectStructuredAttachment(node, aliases, structuredFunctions, structuredAttachments)
+		return true
+	})
+	if !structured {
+		return nil, nil
+	}
+	var violations []Violation
+	for name, node := range runnables {
+		if structuredAttachments[name] != 1 {
+			violations = append(violations, Violation{Rule: RuleOutput, Path: path, Line: fset.Position(node.Pos()).Line, Message: fmt.Sprintf("structured output contract must be attached exactly once to runnable %s", name)})
+		}
+	}
+	violations = appendHumanTextViolations(file, aliases, fset, path, violations)
 	return violations, nil
 }
 
@@ -597,13 +646,17 @@ func checkUniversalEffectsSource(path string, source []byte) ([]Violation, error
 	return violations, nil
 }
 
-func checkTrackerExecutionSource(path string, source []byte) ([]Violation, error) {
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, path, source, 0)
-	if err != nil {
-		return nil, fmt.Errorf("parse semantic source %s: %w", path, err)
-	}
-	aliases := sourceImportAliases(file)
+// trackerLaunchState tracks a discovered exec launch and the guarantees it satisfies.
+type trackerLaunchState struct {
+	node         ast.Node
+	contextAware bool
+	resolvedName string
+	workDir      bool
+	childEnv     bool
+}
+
+// collectExecAliases returns the local aliases under which "os/exec" is imported.
+func collectExecAliases(file *ast.File) map[string]bool {
 	execAliases := map[string]bool{}
 	for _, spec := range file.Imports {
 		if spec.Path.Value != `"os/exec"` {
@@ -615,92 +668,114 @@ func checkTrackerExecutionSource(path string, source []byte) ([]Violation, error
 		}
 		execAliases[name] = true
 	}
-	type launchState struct {
-		node         ast.Node
-		contextAware bool
-		resolvedName string
-		workDir      bool
-		childEnv     bool
+	return execAliases
+}
+
+// collectContextParams returns the parameter names of type context.Context on a function.
+func collectContextParams(function *ast.FuncDecl, aliases map[string]string) map[string]bool {
+	contextParams := map[string]bool{}
+	if function.Type.Params == nil {
+		return contextParams
 	}
-	launches := map[string]*launchState{}
+	for _, field := range function.Type.Params.List {
+		selector, selectorOK := field.Type.(*ast.SelectorExpr)
+		if !selectorOK {
+			continue
+		}
+		pkg, pkgOK := selector.X.(*ast.Ident)
+		if !pkgOK || selector.Sel.Name != "Context" || aliases[pkg.Name] != "context" {
+			continue
+		}
+		for _, name := range field.Names {
+			contextParams[name.Name] = true
+		}
+	}
+	return contextParams
+}
+
+// recordTrackerLaunch registers an exec launch assigned to name, capturing whether it is
+// context-aware and the identifier that resolved the binary.
+func recordTrackerLaunch(name *ast.Ident, assignment *ast.AssignStmt, execAliases map[string]bool, contextParams map[string]bool, launches map[string]*trackerLaunchState) {
+	call, ok := assignment.Rhs[0].(*ast.CallExpr)
+	if !ok {
+		return
+	}
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+	alias, aliasOK := selector.X.(*ast.Ident)
+	if !aliasOK || !execAliases[alias.Name] {
+		return
+	}
+	state := &trackerLaunchState{node: call}
+	if selector.Sel.Name == "CommandContext" && len(call.Args) >= 2 {
+		caller, callerOK := call.Args[0].(*ast.Ident)
+		binary, binaryOK := call.Args[1].(*ast.SelectorExpr)
+		if !binaryOK {
+			launches[name.Name] = state
+			return
+		}
+		resolved, resolvedOK := binary.X.(*ast.Ident)
+		if callerOK && contextParams[caller.Name] && resolvedOK && binary.Sel.Name == "Binary" {
+			state.contextAware = true
+			state.resolvedName = resolved.Name
+		}
+	}
+	launches[name.Name] = state
+}
+
+// applyTrackerLaunchField applies a Dir=WorkDir / Env=ChildEnv field assignment to a launch.
+func applyTrackerLaunchField(assignment *ast.AssignStmt, launches map[string]*trackerLaunchState) {
+	left, ok := assignment.Lhs[0].(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+	name, ok := left.X.(*ast.Ident)
+	if !ok || launches[name.Name] == nil {
+		return
+	}
+	right, ok := assignment.Rhs[0].(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+	resolved, resolvedOK := right.X.(*ast.Ident)
+	if !resolvedOK || resolved.Name != launches[name.Name].resolvedName {
+		return
+	}
+	switch {
+	case left.Sel.Name == "Dir" && right.Sel.Name == "WorkDir":
+		launches[name.Name].workDir = true
+	case left.Sel.Name == "Env" && right.Sel.Name == "ChildEnv":
+		launches[name.Name].childEnv = true
+	}
+}
+
+func checkTrackerExecutionSource(path string, source []byte) ([]Violation, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, source, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parse semantic source %s: %w", path, err)
+	}
+	aliases := sourceImportAliases(file)
+	execAliases := collectExecAliases(file)
+	launches := map[string]*trackerLaunchState{}
 	for _, declaration := range file.Decls {
 		function, ok := declaration.(*ast.FuncDecl)
 		if !ok || function.Body == nil {
 			continue
 		}
-		contextParams := map[string]bool{}
-		if function.Type.Params != nil {
-			for _, field := range function.Type.Params.List {
-				selector, selectorOK := field.Type.(*ast.SelectorExpr)
-				if !selectorOK {
-					continue
-				}
-				pkg, pkgOK := selector.X.(*ast.Ident)
-				if !pkgOK || selector.Sel.Name != "Context" || aliases[pkg.Name] != "context" {
-					continue
-				}
-				for _, name := range field.Names {
-					contextParams[name.Name] = true
-				}
-			}
-		}
+		contextParams := collectContextParams(function, aliases)
 		ast.Inspect(function.Body, func(node ast.Node) bool {
 			assignment, ok := node.(*ast.AssignStmt)
 			if !ok || len(assignment.Lhs) != 1 || len(assignment.Rhs) != 1 {
 				return true
 			}
 			if name, ok := assignment.Lhs[0].(*ast.Ident); ok {
-				call, ok := assignment.Rhs[0].(*ast.CallExpr)
-				if !ok {
-					return true
-				}
-				selector, ok := call.Fun.(*ast.SelectorExpr)
-				if !ok {
-					return true
-				}
-				alias, aliasOK := selector.X.(*ast.Ident)
-				if !aliasOK || !execAliases[alias.Name] {
-					return true
-				}
-				state := &launchState{node: call}
-				if selector.Sel.Name == "CommandContext" && len(call.Args) >= 2 {
-					caller, callerOK := call.Args[0].(*ast.Ident)
-					binary, binaryOK := call.Args[1].(*ast.SelectorExpr)
-					if !binaryOK {
-						launches[name.Name] = state
-						return true
-					}
-					resolved, resolvedOK := binary.X.(*ast.Ident)
-					if callerOK && contextParams[caller.Name] && resolvedOK && binary.Sel.Name == "Binary" {
-						state.contextAware = true
-						state.resolvedName = resolved.Name
-					}
-				}
-				launches[name.Name] = state
+				recordTrackerLaunch(name, assignment, execAliases, contextParams, launches)
 				return true
 			}
-			left, ok := assignment.Lhs[0].(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-			name, ok := left.X.(*ast.Ident)
-			if !ok || launches[name.Name] == nil {
-				return true
-			}
-			right, ok := assignment.Rhs[0].(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-			resolved, resolvedOK := right.X.(*ast.Ident)
-			if !resolvedOK || resolved.Name != launches[name.Name].resolvedName {
-				return true
-			}
-			switch {
-			case left.Sel.Name == "Dir" && right.Sel.Name == "WorkDir":
-				launches[name.Name].workDir = true
-			case left.Sel.Name == "Env" && right.Sel.Name == "ChildEnv":
-				launches[name.Name].childEnv = true
-			}
+			applyTrackerLaunchField(assignment, launches)
 			return true
 		})
 	}

--- a/cli/internal/commands/capabilities/module_test.go
+++ b/cli/internal/commands/capabilities/module_test.go
@@ -59,7 +59,8 @@ func TestCommandDelegatesAndRendersYAML(t *testing.T) {
 
 func TestModuleOwnsFreshCommandsAndExplicitContract(t *testing.T) {
 	module := NewModule(&recordingBuilder{}, nil)
-	if module.Command() == module.Command() {
+	first, second := module.Command(), module.Command()
+	if first == second {
 		t.Fatal("Command returned shared Cobra state")
 	}
 	contract := module.Contract()

--- a/cli/internal/commands/claim/module_test.go
+++ b/cli/internal/commands/claim/module_test.go
@@ -37,7 +37,8 @@ func (fake *fakeUseCases) Check(context.Context, string, bool) (claimproof.Repor
 func TestModuleBuildsFreshTreeAndDelegates(t *testing.T) {
 	fake := &fakeUseCases{}
 	module := NewModule(fake, func() string { return "json" })
-	if module.Command() == module.Command() {
+	first, second := module.Command(), module.Command()
+	if first == second {
 		t.Fatal("Command returned shared Cobra state")
 	}
 	command := module.Command()

--- a/cli/internal/eval/core_canary_refs_test.go
+++ b/cli/internal/eval/core_canary_refs_test.go
@@ -33,7 +33,6 @@ func TestCoreCanaryMortemReferencesAreCanonical(t *testing.T) {
 	}
 
 	for _, suitePath := range suitePaths {
-		suitePath := suitePath
 		t.Run(filepath.Base(suitePath), func(t *testing.T) {
 			suite, _, err := LoadSuite(suitePath)
 			if err != nil {

--- a/cli/internal/quality/skills_codex_test.go
+++ b/cli/internal/quality/skills_codex_test.go
@@ -5,9 +5,23 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+// setHome points os.UserHomeDir() at dir on every platform for the duration of
+// the test. On POSIX Go resolves the home directory from $HOME, but on Windows
+// it reads %USERPROFILE% and ignores HOME entirely — so a HOME-only setenv
+// silently misses on the Windows runners and the production checks scan the real
+// (fixture-free) home. Setting both keeps these tests platform-independent.
+func setHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", dir)
+	}
+}
 
 func writeSkill(t *testing.T, root, name string) {
 	t.Helper()
@@ -56,7 +70,7 @@ func writeInstallMeta(t *testing.T, home, root, version, hash string, count int)
 }
 
 func TestCheckSkillsReportsInstallGuidanceWhenEmpty(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	check := CheckSkills()
 	if check.Status != "warn" || !strings.Contains(check.Detail, "install.sh") {
 		t.Fatalf("check = %+v", check)
@@ -65,7 +79,7 @@ func TestCheckSkillsReportsInstallGuidanceWhenEmpty(t *testing.T) {
 
 func TestCheckSkillsValidatesNativeManifest(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	root, hash := writeNativeManifest(t, home, "research")
 	writeInstallMeta(t, home, root, "v1", hash, 1)
 	check := CheckSkills()
@@ -82,7 +96,7 @@ func TestCheckSkillsValidatesNativeManifest(t *testing.T) {
 
 func TestCheckSkillsCountsCompatibilityPointerPackages(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	root := CodexNativePluginRootPath(home)
 	skills := filepath.Join(root, "skills-codex")
 	writeSkill(t, skills, "research")
@@ -120,7 +134,7 @@ func TestCheckSkillsWarnsForOverlappingInstallLayouts(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			home := t.TempDir()
-			t.Setenv("HOME", home)
+			setHome(t, home)
 			root, hash := writeNativeManifest(t, home, "research")
 			writeInstallMeta(t, home, root, "v1", hash, 1)
 			writeSkill(t, filepath.Join(home, test.duplicateRoot), "research")
@@ -175,7 +189,7 @@ func TestCheckCodexSyncDetectsMatchManifestDriftAndStaleVersion(t *testing.T) {
 			repo, current, currentHash := setupCodexSyncRepo(t)
 			t.Chdir(repo)
 			home := t.TempDir()
-			t.Setenv("HOME", home)
+			setHome(t, home)
 			version, hash := test.version, test.hash
 			if version == "" {
 				version = current
@@ -203,7 +217,7 @@ func TestCheckSkillIntegrityAbsentCleanAndFindings(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			root := t.TempDir()
 			t.Chdir(root)
-			t.Setenv("HOME", t.TempDir())
+			setHome(t, t.TempDir())
 			if test.script != "" {
 				path := filepath.Join(root, "skills", "heal-skill", "scripts", "heal.sh")
 				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/cli/internal/quality/skills_codex_test.go
+++ b/cli/internal/quality/skills_codex_test.go
@@ -72,7 +72,11 @@ func writeInstallMeta(t *testing.T, home, root, version, hash string, count int)
 func TestCheckSkillsReportsInstallGuidanceWhenEmpty(t *testing.T) {
 	setHome(t, t.TempDir())
 	check := CheckSkills()
-	if check.Status != "warn" || !strings.Contains(check.Detail, "install.sh") {
+	// The empty-home hint is platform-specific: POSIX points at install.sh,
+	// Windows at install-codex.ps1 (pluginInstallHint switches on GOOS). Assert
+	// against the production hint itself so the test is platform-independent —
+	// a literal "install.sh" substring silently fails on the Windows runners.
+	if check.Status != "warn" || !strings.Contains(check.Detail, pluginInstallHint()) {
 		t.Fatalf("check = %+v", check)
 	}
 }

--- a/cli/internal/trackerexec/command.go
+++ b/cli/internal/trackerexec/command.go
@@ -31,6 +31,12 @@ func (Factory) Command(
 	args []string,
 	streams Streams,
 ) *ResolvedCommand {
+	// A cobra command invoked outside Execute (direct RunE calls in tests or
+	// embedding) carries a nil context; exec.CommandContext panics on nil.
+	// Background preserves the no-cancellation semantics such callers had.
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	command := exec.CommandContext(ctx, resolution.Binary, args...) // #nosec G204 -- trackerresolve constrains the binary to br|bd.
 	command.Dir = resolution.WorkDir
 	if resolution.ChildEnv != nil {

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -186,6 +186,7 @@ graph LR
   codex_exec --> account_rotation
   codex_exec --> ntm
   council --> agy_native
+  council --> pawl_review
   council --> standards
   crank --> agent_native
   crank --> automation_shape_routing
@@ -268,7 +269,7 @@ graph LR
 |---|---|
 | Explicit graph roots | `beads-br`, `bootstrap`, `converge`, `council`, `crank`, `discovery`, `evolve`, `goal-design`, `handoff`, `implement`, `pawl-review`, `plan`, `pr-prep`, `premortem`, `push`, `reality-check`, `release`, `rpi`, `security`, `status`, `using-gc`, `validate` |
 | User-invocable skills | `agent-native`, `bootstrap`, `codebase-recon`, `crank`, `discovery`, `dueling-idea-genies`, `evolve`, `idea-genie`, `learn`, `pattern-mining`, `pawl-review`, `postmortem`, `push`, `release`, `rpi`, `using-gc`, `validate` |
-| Zero-inbound skills | `bootstrap`, `converge`, `evolve`, `goal-design`, `handoff`, `pawl-review`, `pr-prep`, `reality-check`, `release`, `security`, `status`, `using-gc` |
+| Zero-inbound skills | `bootstrap`, `converge`, `evolve`, `goal-design`, `handoff`, `pr-prep`, `reality-check`, `release`, `security`, `status`, `using-gc` |
 | Dangling targets | _(none)_ |
 | Dependency cycles | _(none)_ |
 | Unreachable non-roots | _(none)_ |

--- a/images/gemini/skills/bootstrap/SKILL.md
+++ b/images/gemini/skills/bootstrap/SKILL.md
@@ -65,6 +65,7 @@ That is it. One command. Every step below is idempotent — existing artifacts a
 
 - **ao** (optional) — AgentOps CLI. Required only for optional hook activation (Step 6). Bootstrap skips hooks gracefully when missing.
 - **br** (optional, recommended) — beads_rust CLI (local-first issue tracking). Bootstrap probes for `br` in Step 0.5 and, when missing, recommends installing it. Bootstrap never installs `br` on the user's behalf.
+- **bd** (optional) — the beads CLI. AgentOps supports **both** trackers; a project may run on `bd` instead of `br`. Bootstrap probes for `bd` in Step 0.5 and, when neither tracker is present, points the user at `scripts/install-bd.sh` with a copy-paste command. Bootstrap never installs `bd` on the user's behalf.
 
 ## Flags
 
@@ -89,6 +90,7 @@ HAS_AGENTS=$([[ -d .agents ]] && echo true || echo false)
 HAS_HOOKS=$(grep -q "agentops" .claude/settings.json 2>/dev/null && echo true || echo false)
 HAS_AO=$(command -v ao >/dev/null && echo true || echo false)
 HAS_BR=$(command -v br >/dev/null && echo true || echo false)
+HAS_BD=$(command -v bd >/dev/null && echo true || echo false)
 ```
 
 Classify the repo:
@@ -108,6 +110,12 @@ If the repo is **complete** and `--force` is not set: report "Repo is fully boot
 If `HAS_BR` is true: skip. Report "br: present."
 
 If `HAS_BR` is false: report **"br: not installed (recommended). Install beads_rust to get local-first issue tracking."** and continue. Bootstrap does NOT run the installer — `br` is optional, the user decides.
+
+AgentOps supports **both** trackers, so if the project runs on `bd` instead:
+
+If `HAS_BD` is true: skip. Report "bd: present."
+
+If `HAS_BD` is false **and** `HAS_BR` is false: report **"no tracker installed. For `bd`, install with: `bash scripts/install-bd.sh`"** and continue. Bootstrap does NOT run the installer — the tracker is optional, the user decides. If `scripts/install-bd.sh` is absent at the repo root, drop the install hint and report "bd: not installed. See https://github.com/steveyegge/beads".
 
 ### Step 1: GOALS.md
 

--- a/images/gemini/skills/council/SKILL.md
+++ b/images/gemini/skills/council/SKILL.md
@@ -30,6 +30,7 @@ metadata:
   dependencies:
   - standards
   - agy-native
+  - pawl-review
   replaces: judge
 output_contract: skills/council/schemas/verdict.json
 ---

--- a/images/gemini/skills/evolve/SKILL.md
+++ b/images/gemini/skills/evolve/SKILL.md
@@ -108,7 +108,7 @@ Selection is a ladder re-read from the TOP after every productive cycle — neve
 git fetch origin && git status -sb              # survey guard — never `git pull --rebase` here
 mkdir -p .agents/evolve
 ao corpus inject --query "autonomous improvement cycle" --limit 5 2>/dev/null || true
-bash scripts/evolve-update-session-state.sh 2>/dev/null || true  # refresh idle_streak + mode_repeat_streak
+# session state (idle_streak + mode_repeat_streak in .agents/evolve/session-state.json) is refreshed inline by the loop
 ```
 
 Recover cycle state from disk (survives compaction): `CYCLE`, `IDLE_STREAK`, `GENERATOR_EMPTY_STREAK`, `LAST_SELECTED_SOURCE`, `CLAIMED_WORK_REF` from `.agents/evolve/session-state.json`; the canonical cycle ledger is `cycle-history.jsonl` (both **local-only** — the nested `.agents/.gitignore` denies all paths, so record durable milestones in commit messages too). **Prior-failure injection (mandatory):** read the last 3 `cycle-history.jsonl` entries; for any `gate` containing `FAIL|BLOCKED`, extract failure keywords and grep `.agents/learnings/` before selecting work — without this the loop re-derives the same lessons each cycle. Detail: `references/cycle-history.md`, `references/convergence-mechanics.md`.
@@ -147,7 +147,7 @@ fi
 
 ### Step 2: Measure fitness
 
-Skip if `--beads-only`. Run `scripts/evolve-measure-fitness.sh` → `.agents/evolve/fitness-latest.json`. Full measurement, baseline capture, and post-cycle regression detection: `references/fitness-scoring.md`.
+Skip if `--beads-only`. Run `ao goals measure` → `.agents/evolve/fitness-latest.json`. Full measurement, baseline capture, and post-cycle regression detection: `references/fitness-scoring.md`.
 
 ### Step 3: Select work
 
@@ -175,7 +175,7 @@ Sync binaries and generated surfaces before the gate: Go CLI changes require bui
 
 ### Step 6: Log cycle + commit
 
-**PRODUCTIVE** (improved / regressed / harvested): log via `scripts/evolve-log-cycle.sh`, commit real changes. **IDLE** (nothing found even after generators): log `--result "unchanged"`; no git add, no commit. Record the XP/BDD/TDD trace via `--trace-json` when a cycle worked a product or goal-backed gap (goal hypothesis → gap → Gherkin → failing proof → red/green → refactor → validation → ratchet → goal reshape); trivial one-shot cycles record a `trace.exemption_reason`. Trace completeness is advisory, never a gate. See `references/cycle-history.md`, `references/quality-mode.md`.
+**PRODUCTIVE** (improved / regressed / harvested): append the cycle record to `.agents/evolve/cycle-history.jsonl`, commit real changes. **IDLE** (nothing found even after generators): append a record with `result: "unchanged"`; no git add, no commit. Record the XP/BDD/TDD trace in the cycle record's `trace` field when a cycle worked a product or goal-backed gap (goal hypothesis → gap → Gherkin → failing proof → red/green → refactor → validation → ratchet → goal reshape); trivial one-shot cycles record a `trace.exemption_reason`. Trace completeness is advisory, never a gate. See `references/cycle-history.md`, `references/quality-mode.md`.
 
 ### Step 7: Optional deterministic delivery
 
@@ -200,7 +200,7 @@ Release-shaped branches must follow [the release teardown contract](references/t
 - **Path:** emit the cycle summary to stdout; append `.agents/evolve/cycle-history.jsonl`; write `.agents/evolve/{fitness-latest.json,session-state.json}` and control files `{STOP,DORMANT,HANDOFF}`.
 - **Filename:** cycle history is `cycle-history.jsonl`; current fitness and resumable state use the fixed filenames above.
 - **Format:** stdout is Markdown; state and fitness use JSON; cycle history uses JSONL following `references/cycle-history.md`.
-- **Validation command:** run repo/profile tests, `bash scripts/check-wiring-closure.sh`, and `ao gate check --fast --scope head`; if delivery is selected, also require `bash skills/push/scripts/validate.sh`.
+- **Validation command:** run repo/profile tests and `ao gate check --fast --scope head` (which subsumes wiring closure); if delivery is selected, also require `bash skills/push/scripts/validate.sh`.
 - **Downstream handoff:** return cycle counts, fitness delta, result, stop reason, changed paths, immutable Validate verdict, and any deterministic delivery result; the next cycle consumes persisted state and unconsumed work.
 
 ## Quality Checklist
@@ -229,7 +229,7 @@ The trim moved procedure to references/, but these invariants stay inline — th
 
 - **Continuous values, not booleans:** every fitness metric reports a continuous value against a threshold (value/threshold), never a bare pass/fail.
 - **Oscillation sweep (always-on, Step 0):** Pre-populate quarantine list from `ao compile`'s oscillation report before selecting a goal.
-- **Wiring pre-flight (Step 5):** `if bash scripts/check-wiring-closure.sh; then proceed; else fix wiring first; fi` — never ship a cycle over broken wiring.
+- **Wiring pre-flight (Step 5):** `if ao gate check --fast --scope head; then proceed; else fix wiring first; fi` — never ship a cycle over broken wiring (wiring closure folded into the gate after the always.wiring-closure meta-gate was retired).
 - **The CLI is required for fitness measurement** — `ao goals measure` is the instrument; prose self-grades are not fitness.
 - **Harvested-first selection order:** Harvested `.agents/rpi/next-work.jsonl` work outranks generated candidates; drain the harvest before generating.
 - **Generator ladder (when the harvest is dry):** Testing improvements → Validation tightening and bug-hunt passes → Concrete feature suggestions.

--- a/images/gemini/skills/validate/SKILL.md
+++ b/images/gemini/skills/validate/SKILL.md
@@ -52,6 +52,12 @@ output_contract: schemas/verdict.v1.schema.json
   Validate does not perform the action, retry, re-plan, or choose escalation.
 - Use runtime-native fresh context. Additional judges are optional depth, not a
   substitute for one accountable validator.
+- When a repeated FAIL trips a breaker, the orchestrator does not page the
+  operator first: it dispatches exactly one bounded fresh-context (or
+  cross-family) **helper** pass. HELPER-UNSTUCK means the helper cleared the
+  blocker and the proof is resumed on an explicit orchestrator decision;
+  HELPER-ESCALATE reaches a human only when that single helper pass also fails
+  (or the class is a refusal/judgment/spent-ceiling skip).
 
 ## Modes
 

--- a/packs/agentops-membrane/tests/breaker-escalation.bats
+++ b/packs/agentops-membrane/tests/breaker-escalation.bats
@@ -95,7 +95,7 @@ setup() {
   for file in \
     "$REPO/skills/validate/SKILL.md" \
     "$REPO/skills-codex/validate/SKILL.md" \
-    "$REPO/skills-codex-overrides/crank/references/failure-recovery.md" \
+    "$REPO/skills-codex/crank/references/failure-recovery.md" \
     "$REPO/images/gemini/skills/discovery/SKILL.md" \
     "$REPO/docs/brownian-ratchet.md"; do
     run grep -Ei 'fresh-context|fresh context|cross-family|helper' "$file"
@@ -107,7 +107,7 @@ setup() {
   done
 
   run grep -F 'After 3 failures, escalate:' \
-    "$REPO/skills-codex-overrides/crank/references/failure-recovery.md"
+    "$REPO/skills-codex/crank/references/failure-recovery.md"
   [ "$status" -ne 0 ]
   run grep -F 'failed 3x, manual intervention needed' \
     "$REPO/images/gemini/skills/discovery/SKILL.md"

--- a/scripts/.atomic-write-grandfather
+++ b/scripts/.atomic-write-grandfather
@@ -14,7 +14,6 @@
 # Regenerate with:  bash scripts/check-atomic-write-ratchet.sh --regenerate
 # (regenerate at LAND time, after the final rebase; hand-audit the list.)
 cli/cmd/ao/corpus_snapshot.go
-cli/cmd/ao/eval_outcomes_ingest.go
 cli/cmd/ao/handoff.go
 cli/cmd/ao/live_status.go
 cli/cmd/ao/loop_blocked.go

--- a/scripts/.jsonl-scanner-grandfather
+++ b/scripts/.jsonl-scanner-grandfather
@@ -13,7 +13,6 @@
 #  have cleaned sites.)
 cli/cmd/ao/batch_forge.go
 cli/cmd/ao/c2_event_reader.go
-cli/cmd/ao/claim_evidence_binder_adapter.go
 cli/cmd/ao/codex.go
 cli/cmd/ao/context_assemble.go
 cli/cmd/ao/dedup.go
@@ -30,7 +29,6 @@ cli/cmd/ao/pool_reindex_test.go
 cli/cmd/ao/session_outcome.go
 cli/cmd/ao/task_sync.go
 cli/cmd/ao/temper.go
-cli/cmd/ao/tick.go
 cli/internal/adapters/vendorimage/codexruntime/runtime.go
 cli/internal/canon/ledger.go
 cli/internal/doctor/engine.go

--- a/scripts/ci/verify-windows-install.ps1
+++ b/scripts/ci/verify-windows-install.ps1
@@ -8,9 +8,14 @@
 # deliberate doctor parity, NOT strict package_count enforcement — a legacy
 # manifest without package_count that is otherwise consistent is doctor-green
 # and must be verifier-green too), and the recorded install-metadata
-# skill_count. When BOTH package_count and skills[] are present they must also
-# agree with each other (internal consistency). The historical bug this guards
-# against was a 66-vs-62 drift between a disk count and a stale manifest.
+# skill_count. package_count and skills[] are NOT required to agree: package_count
+# inventories every installable dir (incl. the 4 compatibility pointer twins)
+# while skills[] lists only canonical implementation rows, so on the real bundle
+# they are legitimately 66 vs 62 (see scripts/validate-codex-generated-manifest.sh
+# and installer-selftest.bats, which enforce disk==package_count, never
+# package_count==len(skills[])). The historical bug this guards against was a
+# 66-vs-62 drift between a disk count and a stale manifest — caught by the
+# manifest-count-vs-disk assertion, not by any package_count/skills[] equality.
 #
 # This script deliberately lives OUTSIDE install-codex.ps1 rather than adding an
 # in-script selftest: it re-derives every number from the files the installer
@@ -56,10 +61,19 @@ function Get-ManifestSkillCount {
   $manifest = Get-Content -LiteralPath $ManifestPath -Raw | ConvertFrom-Json
   $hasCount = ($manifest.PSObject.Properties.Name -contains "package_count" -and $manifest.package_count -gt 0)
   $hasSkills = ($manifest.PSObject.Properties.Name -contains "skills")
-  if ($hasCount -and $hasSkills -and ([int]$manifest.package_count -ne @($manifest.skills).Count)) {
-    Fail ("Manifest is internally inconsistent: package_count=" + $manifest.package_count +
-      " but skills[] has " + @($manifest.skills).Count + " entries: $ManifestPath")
-  }
+  # package_count and skills[] are DELIBERATELY different counts and must not be
+  # forced equal: package_count inventories every installable skill directory
+  # (incl. the compatibility pointer twins pre-mortem/post-mortem/pre_mortem/
+  # post_mortem), while skills[] lists only canonical implementation rows. On the
+  # real bundle that is 66 vs 62. This split is the authoritative contract —
+  # enforced by scripts/validate-codex-generated-manifest.sh (package_count ==
+  # all installable dirs; len(skills[]) == dirs minus the 4 pointers), by the
+  # generator scripts/codex-sync.sh, by cli/internal/quality/skills_codex.go
+  # (doctor reads package_count when present), and by the bash installer selftest
+  # (installer-selftest.bats asserts disk==package_count only, NOT
+  # package_count==len(skills[])). The real 66-vs-62 bug this leg guards against
+  # is a STALE manifest whose package_count is missing/wrong, caught below by the
+  # manifest-count-vs-disk assertion — not by any internal equality check.
   if ($hasCount) {
     return [int]$manifest.package_count
   }

--- a/scripts/em-loop-donetest.sh
+++ b/scripts/em-loop-donetest.sh
@@ -82,7 +82,7 @@ MODE="$(python3 -c "import json;print(json.load(open('$IDX'))['constraints'][0][
 [ "$MODE" = "warn" ] || fail shadow "derived shadow must be warn-only, got '$MODE'"
 CHECK="$PROJ/.agents/premortem-checks/$CID.md"
 [ -s "$CHECK" ] || fail shadow "canonical premortem check not written"
-ok "2. SHADOW: replayed positives + negative controls -> warn-only shadow $CID"
+ok "2. COMPILE: escape -> draft constraint $CID (warn-only shadow from replayed positives + negative controls)"
 
 # constraint_verdict prints PASS, WARN, or FAIL for constraints.enforce. It
 # CAPTURES the gate output (|| true) because `ao gate check` legitimately exits
@@ -106,7 +106,7 @@ WRITE_BAD
   && fail activation-guard "activation without cited precision evidence succeeded"
 STATUS="$(python3 -c "import json;print(json.load(open('$IDX'))['constraints'][0]['status'])" 2>/dev/null)"
 [ "$STATUS" = "shadow" ] || fail activation-guard "failed activation changed status to '$STATUS'"
-ok "3. MEASURE: shadow hit WARNs; missing precision cannot activate"
+ok "3. MEASURE: shadow hit WARNs; the activate guard rejects missing precision (a draft gates nothing)"
 
 # 4. ACTIVATE — replace the candidate with cited shadow precision, then activate.
 ACTIVATE_OUT="$("$AO" membrane derive-checks --run "$RUN" --force --detector-evidence "$READY" 2>&1)" \

--- a/scripts/generate-skill-catalog.sh
+++ b/scripts/generate-skill-catalog.sh
@@ -125,7 +125,7 @@ parse_frontmatter() {
           val = line; sub(/^[[:space:]]+dependencies:[[:space:]]*\[/, "", val); sub(/\][[:space:]]*$/, "", val)
           count = split(val, parts, ",")
           for (j = 1; j <= count; j++) {
-            item = trim(parts[j]); gsub(/^['\''\"]|['\''\"]$/, "", item)
+            item = trim(parts[j]); gsub(/^['\''"]|['\''"]$/, "", item)
             if (item != "") list_vals["dependencies"] = list_vals["dependencies"] (list_vals["dependencies"] == "" ? "" : ",") jstr(item)
           }
           in_list = 0; cur_key = ""

--- a/scripts/golangci-lint-v2.sh
+++ b/scripts/golangci-lint-v2.sh
@@ -18,6 +18,29 @@ if ! command -v go >/dev/null 2>&1; then
   exit 127
 fi
 
+# Build golangci-lint with the REPO's pinned toolchain, not golangci-lint's
+# minimum. `go install pkg@version` runs module-agnostic, so it ignores this
+# repo's `toolchain` directive and, under an old default `go`, downgrades to
+# golangci-lint's own `go >= 1.25` minimum (go1.25.12). A golangci-lint built
+# with go1.25 then refuses to analyze this `go 1.26` module ("Go language
+# version go1.25 ... lower than targeted 1.26.5") — the CI go.lint gate failure.
+# Pinning GOTOOLCHAIN to cli/go.mod's `toolchain` (else the `go` directive)
+# builds the linter with a toolchain >= the code it must lint. It matches the
+# toolchain `go build ./cli` already uses, so it adds no burden in practice.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GOMOD_FILE="${GOLANGCI_LINT_GOMOD:-${SCRIPT_DIR}/../cli/go.mod}"
+if [[ -z "${GOTOOLCHAIN:-}" && -f "$GOMOD_FILE" ]]; then
+  repo_toolchain="$(awk '/^toolchain /{print $2; exit}' "$GOMOD_FILE" 2>/dev/null || true)"
+  if [[ -z "$repo_toolchain" ]]; then
+    repo_go="$(awk '/^go /{print $2; exit}' "$GOMOD_FILE" 2>/dev/null || true)"
+    case "$repo_go" in
+      [0-9]*.[0-9]*.[0-9]*) repo_toolchain="go${repo_go}" ;;
+      [0-9]*.[0-9]*)        repo_toolchain="go${repo_go}.0" ;;
+    esac
+  fi
+  [[ -n "$repo_toolchain" ]] && export GOTOOLCHAIN="$repo_toolchain"
+fi
+
 cache_root="${GOLANGCI_LINT_CACHE_BIN:-${XDG_CACHE_HOME:-$HOME/.cache}/agentops/golangci-lint}"
 bin_dir="${cache_root}/${VERSION}"
 bin="${bin_dir}/golangci-lint"

--- a/scripts/install-agy.sh
+++ b/scripts/install-agy.sh
@@ -108,7 +108,8 @@ resolve_source_root() {
   info "Downloading AgentOps bundle ($INSTALL_REF)"
   curl -fsSL "$archive_url" -o "$archive_file"
   tar -xzf "$archive_file" -C "$TMP_DIR"
-  find "$TMP_DIR" -mindepth 1 -maxdepth 1 -type d | head -1
+  # `-print -quit` (not `| head -1`): SIGPIPE-safe under `set -o pipefail`.
+  find "$TMP_DIR" -mindepth 1 -maxdepth 1 -type d -print -quit
 }
 
 while [ "$#" -gt 0 ]; do
@@ -201,7 +202,10 @@ selftest_agy() {
   local problems=0
 
   local sentinel
-  sentinel="$(find "$PLUGIN_DIR/skills" -mindepth 2 -maxdepth 2 -name SKILL.md 2>/dev/null | head -1)"
+  # `-print -quit` (not `| head -1`): SIGPIPE-safe under `set -o pipefail` — find
+  # stops after the first hit rather than writing into a head()-closed pipe once
+  # its output exceeds one stdio flush (the long-path × many-skills case).
+  sentinel="$(find "$PLUGIN_DIR/skills" -mindepth 2 -maxdepth 2 -name SKILL.md -print -quit 2>/dev/null)"
   if [ -z "$sentinel" ] || [ ! -r "$sentinel" ]; then
     printf 'FAIL: self-test: no readable sentinel SKILL.md under %s/skills\n' "$PLUGIN_DIR" >&2
     problems=$((problems + 1))

--- a/scripts/install-codex-plugin.sh
+++ b/scripts/install-codex-plugin.sh
@@ -351,7 +351,13 @@ selftest_codex_plugin() {
   fi
 
   # (c) at least one sentinel skill file is readable.
-  sentinel="$(find "$PLUGIN_SKILLS_DST" -mindepth 2 -maxdepth 2 -name SKILL.md 2>/dev/null | head -1)"
+  # `-print -quit` (not `| head -1`): find stops itself after the first hit, so it
+  # never writes into a pipe head() has already closed. With `set -o pipefail`,
+  # `find … | head -1` SIGPIPEs (exit 141) once find's output exceeds one stdio
+  # flush (~4KB) — which the long installed-cache paths × 66 skills now do — and
+  # under `set -e` that killed the whole installer silently right after the last
+  # info() line (the CI 992/994/998/848 regression). This form is SIGPIPE-free.
+  sentinel="$(find "$PLUGIN_SKILLS_DST" -mindepth 2 -maxdepth 2 -name SKILL.md -print -quit 2>/dev/null)"
   if [[ -z "$sentinel" || ! -r "$sentinel" ]]; then
     problems+=("no readable sentinel SKILL.md under ${PLUGIN_SKILLS_DST}")
   fi

--- a/scripts/install-opencode.sh
+++ b/scripts/install-opencode.sh
@@ -150,7 +150,11 @@ if [ ! -e "$PLUGIN_DST" ]; then
   report_problem "plugin entry $PLUGIN_DST is missing or dangling"
 fi
 # (c) one sentinel skill is readable through the link.
-SENTINEL=$(find -L "$SKILLS_DST" -name "SKILL.md" -maxdepth 2 2>/dev/null | head -1)
+# `-print -quit` (not `| head -1`): find stops after the first hit so it never
+# writes into a head()-closed pipe. Under `set -o pipefail`, `find … | head -1`
+# SIGPIPEs (141) once the linked skills' long paths exceed one stdio flush, which
+# under `set -e` silently killed the installer after "Skills linked" (CI 996).
+SENTINEL=$(find -L "$SKILLS_DST" -maxdepth 2 -name "SKILL.md" -print -quit 2>/dev/null)
 if [ -z "$SENTINEL" ] || [ ! -r "$SENTINEL" ]; then
   report_problem "no readable sentinel SKILL.md under $SKILLS_DST"
 fi

--- a/scripts/skill-flow-standalone.txt
+++ b/scripts/skill-flow-standalone.txt
@@ -78,3 +78,9 @@ beads-bv                         # tracker-triage primitive; lost its only incom
 converge                         # thin memo over the `ao converge` command (driving-adapter); no peer skill edge by design, like status
 using-gc                         # gc-substrate operator skill; drives the external gc CLI, no peer skill edge by design
 gc-membrane                      # JIT close-door reference loaded by using-gc via Read; no frontmatter edge by design
+
+# --- name-compatibility pointers (redirect_to a canonical skill; pure aliases with no pipeline role) ---
+pre-mortem                       # compatibility pointer → premortem; redirect-only, no peer skill edge by design
+pre_mortem                       # compatibility pointer → premortem; redirect-only, no peer skill edge by design
+post-mortem                      # compatibility pointer → postmortem; redirect-only, no peer skill edge by design
+post_mortem                      # compatibility pointer → postmortem; redirect-only, no peer skill edge by design

--- a/scripts/toolchain-validate.sh
+++ b/scripts/toolchain-validate.sh
@@ -876,7 +876,17 @@ run_govulncheck() {
 
         echo "== govulncheck: $module_dir ==" >> "$output_file"
         module_rc=0
-        (cd "$module_dir" && govulncheck ./... > "$module_out" 2> "$module_stderr") || module_rc=$?
+        # GOTOOLCHAIN=auto: scan the stdlib version the module DECLARES it ships
+        # with (go.mod `toolchain` directive), not whatever `go` happens to sit on
+        # PATH. CI's actions/setup-go pins a fixed go-version and sets
+        # GOTOOLCHAIN=local, which makes govulncheck scan an older stdlib than the
+        # repo actually builds against (go.mod declares a newer, patched toolchain).
+        # That skew made CI report standard-library CVEs (GO-2026-4970/5037/5039/5856)
+        # already fixed in the declared toolchain while local (GOTOOLCHAIN=auto)
+        # scanned clean. Forcing `auto` here aligns the scan with the shipped
+        # toolchain so local == CI. This is NOT a suppression: a genuinely unfixed
+        # stdlib CVE (no fix in the declared toolchain) still blocks.
+        (cd "$module_dir" && GOTOOLCHAIN=auto govulncheck ./... > "$module_out" 2> "$module_stderr") || module_rc=$?
 
         cat "$module_out" >> "$output_file"
         echo "" >> "$output_file"

--- a/scripts/validate-codex-rpi-contract.sh
+++ b/scripts/validate-codex-rpi-contract.sh
@@ -5,8 +5,19 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 failures=0
 
+# ag-2vz5v: resolve skill paths through the dispositions ledger so folds/cuts
+# auto-retarget. Identity fallback keeps hermetic test copies self-contained.
+if [[ -f "$repo_root/scripts/lib/resolve-skill-path.sh" ]]; then
+  # shellcheck source=lib/resolve-skill-path.sh
+  source "$repo_root/scripts/lib/resolve-skill-path.sh"
+else
+  resolve_skill_path() { printf '%s\n' "$1"; }
+fi
+
 require_contains() {
-  local file="$1" needle="$2" message="$3"
+  local file needle="$2" message="$3"
+  file="$(resolve_skill_path "$1")"
+  [[ -n "$file" ]] || return 0 # cut slug: resolver warned; skip visibly
   if ! grep -Fq -- "$needle" "$file"; then
     printf 'FAIL: %s\n  missing: %s\n  file: %s\n' "$message" "$needle" "$file" >&2
     failures=$((failures + 1))
@@ -76,8 +87,11 @@ for validator in \
   skills-codex/rpi/scripts/validate.sh \
   skills-codex/crank/scripts/validate.sh \
   skills-codex/learn/scripts/validate.sh; do
-  if ! bash "$validator" >/dev/null; then
-    printf 'FAIL: Codex validator rejected contract: %s\n' "$validator" >&2
+  resolved="$(resolve_skill_path "$validator")"
+  [[ -n "$resolved" ]] || continue # cut slug: resolver warned; skip visibly
+  [[ -f "$resolved" ]] || continue # fold target may not ship a validator
+  if ! bash "$resolved" >/dev/null; then
+    printf 'FAIL: Codex validator rejected contract: %s\n' "$resolved" >&2
     failures=$((failures + 1))
   fi
 done
@@ -87,4 +101,4 @@ if [[ $failures -ne 0 ]]; then
   exit 1
 fi
 
-echo 'Codex four-umbrella contract: PASS'
+echo 'Codex four-umbrella contract validation passed.'

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -699,8 +699,8 @@
     {
       "name": "discovery",
       "source_skill": "skills/discovery",
-      "source_hash": "c7a5d8643fce7461b61309a9face2b907c2b26d84b63d2e1e09e2ec9805f3176",
-      "generated_hash": "5bd9dc9f7d7a5b2f49a2cd8c42283ff11757f3d23ab7ae579bb0b487d96410b6"
+      "source_hash": "bfdfb02308d9fc7e549b24430db84534ecc64a30f0702a6e926ad882ed8714fe",
+      "generated_hash": "f6bf69fba53a7a8ea71009a5f4d85ff794f19b7f22f339121a8f250986d1ad1d"
     },
     {
       "name": "doc",
@@ -723,8 +723,8 @@
     {
       "name": "evolve",
       "source_skill": "skills/evolve",
-      "source_hash": "025bf949e6e552a853ad396c9c2ce18ce9e873c911a89c1e5ba26689b7219ee2",
-      "generated_hash": "91a5c11c171bdd5900e8194f23b5ef10e7f13e0b3c8cbaa989ea4a2dc089762b"
+      "source_hash": "65b66fe2c92f5bcf2d791d13cf0f763ce4f91c8f767ffd37f3a3adae16896561",
+      "generated_hash": "dea02718b566f73cf570d8af04212adbd944e92a60d9168261d5c20ed4e79607"
     },
     {
       "name": "gc-membrane",
@@ -795,8 +795,8 @@
     {
       "name": "pawl-review",
       "source_skill": "skills/pawl-review",
-      "source_hash": "27af88ca6e41f93d3553f52770f37ca4de537373a9e6cd0349f0cd21954a7181",
-      "generated_hash": "dce47e82fad40bf934f59ac29e74a253f14672208f51d4c23d2aea49a2f85b04"
+      "source_hash": "380c1d4dd6e7d3e2d59b490b8a88d3e2bf878e86e2396e07a643d66edb1a80f8",
+      "generated_hash": "08a4935eac8e00ac40eb50bcc809042a3896473eeae9026c4a879dbcf4e5ff10"
     },
     {
       "name": "plan",
@@ -819,8 +819,8 @@
     {
       "name": "premortem",
       "source_skill": "skills/premortem",
-      "source_hash": "51e5c7202940cf1e78f1e014740f743f94efa5e4490b0c916b7a9c70e2ebc06b",
-      "generated_hash": "831ee0ec91fbaa955b3bb029a708ddc371b9545c18ea4f12d0b4a227d04e360f"
+      "source_hash": "927ca8cda370a56eab8b22e96f159b029c590c735abc2f38bdda9d325e4a34dc",
+      "generated_hash": "01a632c3fc3a9fef5f1bb5f085cb303ab41fddbab33a5d9cc24c14711bd138d4"
     },
     {
       "name": "product",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -874,9 +874,7 @@
       "name": "rpi",
       "source_skill": "skills/rpi",
       "source_hash": "2624ff386ed57eae302ad284bf35ae556d83f6dbc5923864651a23d72a4b727f",
-      "generated_hash": "a7e4c01b89fa8ece039839ababc4276bdf39c73ddf1371030d4dcb0a6a8d21d8"
-      "source_hash": "38a30c1ecb726628980420b9db67c37058cd6348ac2762250b5da2723f6276eb",
-      "generated_hash": "308382b8d126716f027a63495daa6162aacc9c9284a7a016392f1fab348c3092"
+      "generated_hash": "0c53f830471da3e9cf98652ff1de5bdf494b11eaa2e84835f01c97812700b69c"
     },
     {
       "name": "sbh",
@@ -953,12 +951,8 @@
     {
       "name": "validate",
       "source_skill": "skills/validate",
-      "source_hash": "70c6a22c7a1bfd02fd0811581d94f0cebf45771fd7f7404ab2a21393e08fb36b",
-      "generated_hash": "ce525712e0e0a4efcb2392dd475ab2eb9f53f8df6e8049a1995f2bbef8584bbe"
-      "source_hash": "37a96331e00095a5938604c80d705aaedd7796116c7c725efc2ea564c642656b",
-      "generated_hash": "6c4777ac971820b8ad164c28fdff6739d1a1f4a85ea76660d286e815de0ed812"
-      "source_hash": "c11d662b3c309db4c486f7bfd5372491a9679ed790c53be273edcf1724f479e4",
-      "generated_hash": "4431e8c9362e2ef99e74fdae352f59a7776afb0edb78fb3e946de4cbced36b58"
+      "source_hash": "fb5f64d987c9e44128f1089096f705bbb1c1ff2b371aaeddaa18a09fb4b086d6",
+      "generated_hash": "5b2fe6677d13c9c11b5b7a088ffc8bb8675f368fddb3e54b4cdff648fa63031e"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -681,7 +681,7 @@
     {
       "name": "council",
       "source_skill": "skills/council",
-      "source_hash": "40f5cc81605a6a33fc519dca04d09ece01d9fe791146a6d2f7c4e12e9f14728b",
+      "source_hash": "b8cf3937ccd78ffb540624a396b3610c161b0a258419a05a4ef55c15e691710e",
       "generated_hash": "88c6a8900f127f038d7c2b4951245d60dc5aa882862f3aeddddc38047efa5486"
     },
     {
@@ -699,8 +699,8 @@
     {
       "name": "discovery",
       "source_skill": "skills/discovery",
-      "source_hash": "bfdfb02308d9fc7e549b24430db84534ecc64a30f0702a6e926ad882ed8714fe",
-      "generated_hash": "f6bf69fba53a7a8ea71009a5f4d85ff794f19b7f22f339121a8f250986d1ad1d"
+      "source_hash": "b6bc0683d542ebb9bdaa8909be2bfcb8df484e9b6546de81e63cd227a837bd25",
+      "generated_hash": "b120f2bbc74ba2285b8fad41f45bb6170141b2d4c90ec6937282069472fed598"
     },
     {
       "name": "doc",
@@ -875,6 +875,8 @@
       "source_skill": "skills/rpi",
       "source_hash": "2624ff386ed57eae302ad284bf35ae556d83f6dbc5923864651a23d72a4b727f",
       "generated_hash": "a7e4c01b89fa8ece039839ababc4276bdf39c73ddf1371030d4dcb0a6a8d21d8"
+      "source_hash": "38a30c1ecb726628980420b9db67c37058cd6348ac2762250b5da2723f6276eb",
+      "generated_hash": "308382b8d126716f027a63495daa6162aacc9c9284a7a016392f1fab348c3092"
     },
     {
       "name": "sbh",
@@ -953,6 +955,10 @@
       "source_skill": "skills/validate",
       "source_hash": "70c6a22c7a1bfd02fd0811581d94f0cebf45771fd7f7404ab2a21393e08fb36b",
       "generated_hash": "ce525712e0e0a4efcb2392dd475ab2eb9f53f8df6e8049a1995f2bbef8584bbe"
+      "source_hash": "37a96331e00095a5938604c80d705aaedd7796116c7c725efc2ea564c642656b",
+      "generated_hash": "6c4777ac971820b8ad164c28fdff6739d1a1f4a85ea76660d286e815de0ed812"
+      "source_hash": "c11d662b3c309db4c486f7bfd5372491a9679ed790c53be273edcf1724f479e4",
+      "generated_hash": "4431e8c9362e2ef99e74fdae352f59a7776afb0edb78fb3e946de4cbced36b58"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/council/.agentops-generated.json
+++ b/skills-codex/council/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "manual-maintained",
   "source_skill": "skills/council",
   "layout": "stub",
-  "source_hash": "40f5cc81605a6a33fc519dca04d09ece01d9fe791146a6d2f7c4e12e9f14728b",
+  "source_hash": "b8cf3937ccd78ffb540624a396b3610c161b0a258419a05a4ef55c15e691710e",
   "generated_hash": "88c6a8900f127f038d7c2b4951245d60dc5aa882862f3aeddddc38047efa5486"
 }

--- a/skills-codex/discovery/.agentops-generated.json
+++ b/skills-codex/discovery/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/discovery",
   "layout": "modular",
-  "source_hash": "c7a5d8643fce7461b61309a9face2b907c2b26d84b63d2e1e09e2ec9805f3176",
-  "generated_hash": "5bd9dc9f7d7a5b2f49a2cd8c42283ff11757f3d23ab7ae579bb0b487d96410b6"
+  "source_hash": "bfdfb02308d9fc7e549b24430db84534ecc64a30f0702a6e926ad882ed8714fe",
+  "generated_hash": "f6bf69fba53a7a8ea71009a5f4d85ff794f19b7f22f339121a8f250986d1ad1d"
 }

--- a/skills-codex/discovery/.agentops-generated.json
+++ b/skills-codex/discovery/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/discovery",
   "layout": "modular",
-  "source_hash": "bfdfb02308d9fc7e549b24430db84534ecc64a30f0702a6e926ad882ed8714fe",
-  "generated_hash": "f6bf69fba53a7a8ea71009a5f4d85ff794f19b7f22f339121a8f250986d1ad1d"
+  "source_hash": "b6bc0683d542ebb9bdaa8909be2bfcb8df484e9b6546de81e63cd227a837bd25",
+  "generated_hash": "b120f2bbc74ba2285b8fad41f45bb6170141b2d4c90ec6937282069472fed598"
 }

--- a/skills-codex/discovery/references/bead-operationalization.md
+++ b/skills-codex/discovery/references/bead-operationalization.md
@@ -31,7 +31,7 @@ goals, intentions, and thought process that produced the idea.
 ### Bead structure
 
 ```bash
-ao beads exec create "Epic: <Feature Name>" -p 1 -t epic --description "
+br create "Epic: <Feature Name>" -p 1 -t epic --description "
 ## Background
 [Why this feature matters; which ideation idea(s) it came from]
 
@@ -51,13 +51,13 @@ ao beads exec create "Epic: <Feature Name>" -p 1 -t epic --description "
 
 ```bash
 # Create the epic, then tasks under it
-ao beads exec create "Design <component> interface" -p 1 -t task --description "..."
-ao beads exec create "Implement <component> logic"  -p 2 -t task --description "..."
-ao beads exec create "Tests for <component>"         -p 2 -t task --description "..."
+br create "Design <component> interface" -p 1 -t task --description "..."
+br create "Implement <component> logic"  -p 2 -t task --description "..."
+br create "Tests for <component>"         -p 2 -t task --description "..."
 
 # Wire dependencies (child depends on parent)
-ao beads exec dep add <impl-id> <epic-id>      # impl depends on epic
-ao beads exec dep add <test-id> <impl-id>      # tests depend on implementation
+br dep add <impl-id> <epic-id>      # impl depends on epic
+br dep add <test-id> <impl-id>      # tests depend on implementation
 ```
 
 ### Explicit test tasks (mandatory, with detailed logging)
@@ -66,7 +66,7 @@ Every feature gets companion test beads — unit AND e2e — with detailed loggi
 so we can confirm everything works after implementation:
 
 ```bash
-ao beads exec create "Unit tests for <component>" -p 2 -t task --description "
+br create "Unit tests for <component>" -p 2 -t task --description "
 ## Coverage Requirements
 - Core behavior
 - Error handling for invalid input
@@ -77,7 +77,7 @@ ao beads exec create "Unit tests for <component>" -p 2 -t task --description "
 - Log timing for performance tracking
 "
 
-ao beads exec create "E2E tests for <component>" -p 2 -t task --description "
+br create "E2E tests for <component>" -p 2 -t task --description "
 ## Scenarios
 - Happy path
 - Error path
@@ -94,7 +94,7 @@ ao beads exec create "E2E tests for <component>" -p 2 -t task --description "
 Compare against existing beads so ideas enhance rather than duplicate:
 
 ```bash
-ao beads exec list --json | jq '.issues[]?.title'
+br list --json | jq '.issues[]?.title'
 ```
 
 | Overlap type | Action |
@@ -133,7 +133,7 @@ Suggested per-pass focus:
 
 ```bash
 br dep cycles --json     # dependency cycles MUST be empty
-ao beads exec ready --json | jq 'length'   # confirm actionable work exists
+br ready --json | jq 'length'   # confirm actionable work exists
 br lint                  # hygiene: orphans, missing fields
 ```
 

--- a/skills-codex/discovery/references/discovery.feature
+++ b/skills-codex/discovery/references/discovery.feature
@@ -20,7 +20,6 @@ Feature: Discovery hands dense intent to planning
     Then it writes a JSON execution packet on disk for the next loop phase
     And the packet carries the goal, research, and design artifact references
 
-  @covered-by:scripts/validate-workflow-contract.sh
   Scenario: Between-wave discovery requires an orchestrator request
     Given Learn emitted a cited material_change plan impact
     When the orchestrator requests a re-plan

--- a/skills-codex/discovery/references/ideation-mode.md
+++ b/skills-codex/discovery/references/ideation-mode.md
@@ -32,9 +32,9 @@ and don't duplicate existing work.
 
 ```bash
 cat AGENTS.md                # or CLAUDE.md — project rules + constraints
-ao beads exec list --json              # open work — avoid duplicating
-ao beads exec list --status closed --json   # closed work — lessons learned, don't re-propose
-ao beads exec ready --json             # what is actionable right now
+br list --json              # open work — avoid duplicating
+br list --status closed --json   # closed work — lessons learned, don't re-propose
+br ready --json             # what is actionable right now
 ```
 
 Checklist before generating:

--- a/skills-codex/evolve/.agentops-generated.json
+++ b/skills-codex/evolve/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/evolve",
   "layout": "modular",
-  "source_hash": "025bf949e6e552a853ad396c9c2ce18ce9e873c911a89c1e5ba26689b7219ee2",
-  "generated_hash": "91a5c11c171bdd5900e8194f23b5ef10e7f13e0b3c8cbaa989ea4a2dc089762b"
+  "source_hash": "65b66fe2c92f5bcf2d791d13cf0f763ce4f91c8f767ffd37f3a3adae16896561",
+  "generated_hash": "dea02718b566f73cf570d8af04212adbd944e92a60d9168261d5c20ed4e79607"
 }

--- a/skills-codex/evolve/SKILL.md
+++ b/skills-codex/evolve/SKILL.md
@@ -67,7 +67,7 @@ Selection is a ladder re-read from the TOP after every productive cycle — neve
 git fetch origin && git status -sb              # survey guard — never `git pull --rebase` here
 mkdir -p .agents/evolve
 ao corpus inject --query "autonomous improvement cycle" --limit 5 2>/dev/null || true
-bash scripts/evolve-update-session-state.sh 2>/dev/null || true  # refresh idle_streak + mode_repeat_streak
+# session state (idle_streak + mode_repeat_streak in .agents/evolve/session-state.json) is refreshed inline by the loop
 ```
 
 Recover cycle state from disk (survives compaction): `CYCLE`, `IDLE_STREAK`, `GENERATOR_EMPTY_STREAK`, `LAST_SELECTED_SOURCE`, `CLAIMED_WORK_REF` from `.agents/evolve/session-state.json`; the canonical cycle ledger is `cycle-history.jsonl` (both **local-only** — the nested `.agents/.gitignore` denies all paths, so record durable milestones in commit messages too). **Prior-failure injection (mandatory):** read the last 3 `cycle-history.jsonl` entries; for any `gate` containing `FAIL|BLOCKED`, extract failure keywords and grep `.agents/learnings/` before selecting work — without this the loop re-derives the same lessons each cycle. Detail: `references/cycle-history.md`, `references/convergence-mechanics.md`.
@@ -106,7 +106,7 @@ fi
 
 ### Step 2: Measure fitness
 
-Skip if `--beads-only`. Run `scripts/evolve-measure-fitness.sh` → `.agents/evolve/fitness-latest.json`. Full measurement, baseline capture, and post-cycle regression detection: `references/fitness-scoring.md`.
+Skip if `--beads-only`. Run `ao goals measure` → `.agents/evolve/fitness-latest.json`. Full measurement, baseline capture, and post-cycle regression detection: `references/fitness-scoring.md`.
 
 ### Step 3: Select work
 
@@ -134,7 +134,7 @@ Sync binaries and generated surfaces before the gate: Go CLI changes require bui
 
 ### Step 6: Log cycle + commit
 
-**PRODUCTIVE** (improved / regressed / harvested): log via `scripts/evolve-log-cycle.sh`, commit real changes. **IDLE** (nothing found even after generators): log `--result "unchanged"`; no git add, no commit. Record the XP/BDD/TDD trace via `--trace-json` when a cycle worked a product or goal-backed gap (goal hypothesis → gap → Gherkin → failing proof → red/green → refactor → validation → ratchet → goal reshape); trivial one-shot cycles record a `trace.exemption_reason`. Trace completeness is advisory, never a gate. See `references/cycle-history.md`, `references/quality-mode.md`.
+**PRODUCTIVE** (improved / regressed / harvested): append the cycle record to `.agents/evolve/cycle-history.jsonl`, commit real changes. **IDLE** (nothing found even after generators): append a record with `result: "unchanged"`; no git add, no commit. Record the XP/BDD/TDD trace in the cycle record's `trace` field when a cycle worked a product or goal-backed gap (goal hypothesis → gap → Gherkin → failing proof → red/green → refactor → validation → ratchet → goal reshape); trivial one-shot cycles record a `trace.exemption_reason`. Trace completeness is advisory, never a gate. See `references/cycle-history.md`, `references/quality-mode.md`.
 
 ### Step 7: Optional deterministic delivery
 
@@ -159,7 +159,7 @@ Release-shaped branches must follow [the release teardown contract](references/t
 - **Path:** emit the cycle summary to stdout; append `.agents/evolve/cycle-history.jsonl`; write `.agents/evolve/{fitness-latest.json,session-state.json}` and control files `{STOP,DORMANT,HANDOFF}`.
 - **Filename:** cycle history is `cycle-history.jsonl`; current fitness and resumable state use the fixed filenames above.
 - **Format:** stdout is Markdown; state and fitness use JSON; cycle history uses JSONL following `references/cycle-history.md`.
-- **Validation command:** run repo/profile tests, `bash scripts/check-wiring-closure.sh`, and `ao gate check --fast --scope head`; if delivery is selected, also require `bash skills/push/scripts/validate.sh`.
+- **Validation command:** run repo/profile tests and `ao gate check --fast --scope head` (which subsumes wiring closure); if delivery is selected, also require `bash skills/push/scripts/validate.sh`.
 - **Downstream handoff:** return cycle counts, fitness delta, result, stop reason, changed paths, immutable Validate verdict, and any deterministic delivery result; the next cycle consumes persisted state and unconsumed work.
 
 ## Quality Checklist
@@ -188,7 +188,7 @@ The trim moved procedure to references/, but these invariants stay inline — th
 
 - **Continuous values, not booleans:** every fitness metric reports a continuous value against a threshold (value/threshold), never a bare pass/fail.
 - **Oscillation sweep (always-on, Step 0):** Pre-populate quarantine list from `ao compile`'s oscillation report before selecting a goal.
-- **Wiring pre-flight (Step 5):** `if bash scripts/check-wiring-closure.sh; then proceed; else fix wiring first; fi` — never ship a cycle over broken wiring.
+- **Wiring pre-flight (Step 5):** `if ao gate check --fast --scope head; then proceed; else fix wiring first; fi` — never ship a cycle over broken wiring (wiring closure folded into the gate after the always.wiring-closure meta-gate was retired).
 - **The CLI is required for fitness measurement** — `ao goals measure` is the instrument; prose self-grades are not fitness.
 - **Harvested-first selection order:** Harvested `.agents/rpi/next-work.jsonl` work outranks generated candidates; drain the harvest before generating.
 - **Generator ladder (when the harvest is dry):** Testing improvements → Validation tightening and bug-hunt passes → Concrete feature suggestions.

--- a/skills-codex/evolve/references/evolve.feature
+++ b/skills-codex/evolve/references/evolve.feature
@@ -28,7 +28,6 @@ Feature: Evolve runs a goal-driven compounding loop
     Then it ships a single bounded slice via /rpi, gated by build + test + lint
     And it reverts the slice rather than landing red
 
-  @covered-by:scripts/validate-workflow-contract.sh
   Scenario: Cycle feedback respects the four umbrellas
     When an RPI cycle reaches validation
     Then evidence flows from Validate to Learn to the orchestrator

--- a/skills-codex/evolve/scripts/validate.sh
+++ b/skills-codex/evolve/scripts/validate.sh
@@ -26,7 +26,7 @@ check "SKILL.md documents post-cycle snapshot" "grep -q 'fitness-.*-post' '$SKIL
 check "SKILL.md documents oscillation detection" "grep -qi 'oscillat' '$SKILL_DIR/SKILL.md'"
 # Design-level checks (2026-03-01)
 check "Step 0 has oscillation sweep (always-on)" "grep -q 'Pre-populate quarantine list' '$SKILL_DIR/SKILL.md'"
-check "Step 5 has wiring script pre-flight check" "grep -q 'if.*check-wiring-closure.sh' '$SKILL_DIR/SKILL.md'"
+check "Step 5 has wiring gate pre-flight check" "grep -q 'if ao gate check .*then proceed' '$SKILL_DIR/SKILL.md'"
 check "No ambiguous YAML fallback in Step 2" "! grep -q 'run each goal.*check command manually' '$SKILL_DIR/SKILL.md'"
 check "CLI required for fitness measurement" "grep -q 'CLI is required for fitness measurement' '$SKILL_DIR/SKILL.md'"
 check "SKILL.md documents harvested-first selection order" "grep -Fq 'Harvested \`.agents/rpi/next-work.jsonl\` work' '$SKILL_DIR/SKILL.md'"

--- a/skills-codex/pawl-review/.agentops-generated.json
+++ b/skills-codex/pawl-review/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/pawl-review",
   "layout": "modular",
-  "source_hash": "27af88ca6e41f93d3553f52770f37ca4de537373a9e6cd0349f0cd21954a7181",
-  "generated_hash": "dce47e82fad40bf934f59ac29e74a253f14672208f51d4c23d2aea49a2f85b04"
+  "source_hash": "380c1d4dd6e7d3e2d59b490b8a88d3e2bf878e86e2396e07a643d66edb1a80f8",
+  "generated_hash": "08a4935eac8e00ac40eb50bcc809042a3896473eeae9026c4a879dbcf4e5ff10"
 }

--- a/skills-codex/pawl-review/SKILL.md
+++ b/skills-codex/pawl-review/SKILL.md
@@ -22,9 +22,8 @@ the subject and the author never counts as its own reviewer.
 
 - Use for a fresh-context or multi-model pawl lane after deterministic tests
   have produced a reviewable commit and diff.
-- Use NTM when an attachable warm pane materially helps; use cold Codex/AGY
-  adapters when it does not. Gas City may implement the same port inside an
-  explicitly selected quest.
+- Use cold Codex/AGY adapters for the review lane. Gas City may implement the
+  same port inside an explicitly selected quest.
 - Agent Mail is optional coordination for separate live actors. One local lane
   does not need identity, reservations, or acknowledgements.
 

--- a/skills-codex/premortem/.agentops-generated.json
+++ b/skills-codex/premortem/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/premortem",
   "layout": "modular",
-  "source_hash": "51e5c7202940cf1e78f1e014740f743f94efa5e4490b0c916b7a9c70e2ebc06b",
-  "generated_hash": "831ee0ec91fbaa955b3bb029a708ddc371b9545c18ea4f12d0b4a227d04e360f"
+  "source_hash": "927ca8cda370a56eab8b22e96f159b029c590c735abc2f38bdda9d325e4a34dc",
+  "generated_hash": "01a632c3fc3a9fef5f1bb5f085cb303ab41fddbab33a5d9cc24c14711bd138d4"
 }

--- a/skills-codex/premortem/references/premortem.feature
+++ b/skills-codex/premortem/references/premortem.feature
@@ -20,7 +20,6 @@ Feature: Pre-mortem stress-tests a plan before implementation
     And a wave may run parallel only if every row is conflict-free
     And a FAIL sends the plan back to /plan to re-slice (or run sequential)
 
-  @covered-by:scripts/validate-workflow-contract.sh
   Scenario: Between-wave Premortem receives an orchestrator-owned changed plan
     Given Validate has handed its verdict to Learn
     And the orchestrator accepted a material plan impact and changed the plan

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -3,7 +3,5 @@
   "source_skill": "skills/rpi",
   "layout": "modular",
   "source_hash": "2624ff386ed57eae302ad284bf35ae556d83f6dbc5923864651a23d72a4b727f",
-  "generated_hash": "a7e4c01b89fa8ece039839ababc4276bdf39c73ddf1371030d4dcb0a6a8d21d8"
-  "source_hash": "38a30c1ecb726628980420b9db67c37058cd6348ac2762250b5da2723f6276eb",
-  "generated_hash": "308382b8d126716f027a63495daa6162aacc9c9284a7a016392f1fab348c3092"
+  "generated_hash": "0c53f830471da3e9cf98652ff1de5bdf494b11eaa2e84835f01c97812700b69c"
 }

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -4,4 +4,6 @@
   "layout": "modular",
   "source_hash": "2624ff386ed57eae302ad284bf35ae556d83f6dbc5923864651a23d72a4b727f",
   "generated_hash": "a7e4c01b89fa8ece039839ababc4276bdf39c73ddf1371030d4dcb0a6a8d21d8"
+  "source_hash": "38a30c1ecb726628980420b9db67c37058cd6348ac2762250b5da2723f6276eb",
+  "generated_hash": "308382b8d126716f027a63495daa6162aacc9c9284a7a016392f1fab348c3092"
 }

--- a/skills-codex/rpi/references/gate-retry-logic.md
+++ b/skills-codex/rpi/references/gate-retry-logic.md
@@ -48,3 +48,16 @@ persistent governor. `HOLD` carries the matching blocker class and is the only
 state that authorizes a helper; `UNSTUCK` returns a new approach as `REPAIR`,
 and `ESCALATE` reaches `ANDON`. Explicit judgment or a positive projected
 charge that exceeds a hard ceiling reaches `ANDON` without a helper.
+
+The rung is a three-state machine (auto -> helper -> human), never a jump
+straight to the operator:
+
+- `HOLD -> ONE-HELPER` — a tripped breaker holds the bead and dispatches exactly
+  one bounded fresh-context (or cross-family) helper pass with the blocker,
+  evidence, and attempt history.
+- `HELPER-UNSTUCK -> AUTO-REDO` — if the helper clears the blocker, control
+  returns to an explicit orchestrator decision and the proof is re-run
+  automatically; no human is paged.
+- `HELPER-ESCALATE -> HUMAN` — only when that single helper pass also fails (or
+  the class is a refusal/judgment/spent-ceiling skip) does the bead reach the
+  operator.

--- a/skills-codex/validate/.agentops-generated.json
+++ b/skills-codex/validate/.agentops-generated.json
@@ -4,4 +4,8 @@
   "layout": "modular",
   "source_hash": "70c6a22c7a1bfd02fd0811581d94f0cebf45771fd7f7404ab2a21393e08fb36b",
   "generated_hash": "ce525712e0e0a4efcb2392dd475ab2eb9f53f8df6e8049a1995f2bbef8584bbe"
+  "source_hash": "37a96331e00095a5938604c80d705aaedd7796116c7c725efc2ea564c642656b",
+  "generated_hash": "6c4777ac971820b8ad164c28fdff6739d1a1f4a85ea76660d286e815de0ed812"
+  "source_hash": "c11d662b3c309db4c486f7bfd5372491a9679ed790c53be273edcf1724f479e4",
+  "generated_hash": "4431e8c9362e2ef99e74fdae352f59a7776afb0edb78fb3e946de4cbced36b58"
 }

--- a/skills-codex/validate/.agentops-generated.json
+++ b/skills-codex/validate/.agentops-generated.json
@@ -2,10 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/validate",
   "layout": "modular",
-  "source_hash": "70c6a22c7a1bfd02fd0811581d94f0cebf45771fd7f7404ab2a21393e08fb36b",
-  "generated_hash": "ce525712e0e0a4efcb2392dd475ab2eb9f53f8df6e8049a1995f2bbef8584bbe"
-  "source_hash": "37a96331e00095a5938604c80d705aaedd7796116c7c725efc2ea564c642656b",
-  "generated_hash": "6c4777ac971820b8ad164c28fdff6739d1a1f4a85ea76660d286e815de0ed812"
-  "source_hash": "c11d662b3c309db4c486f7bfd5372491a9679ed790c53be273edcf1724f479e4",
-  "generated_hash": "4431e8c9362e2ef99e74fdae352f59a7776afb0edb78fb3e946de4cbced36b58"
+  "source_hash": "fb5f64d987c9e44128f1089096f705bbb1c1ff2b371aaeddaa18a09fb4b086d6",
+  "generated_hash": "5b2fe6677d13c9c11b5b7a088ffc8bb8675f368fddb3e54b4cdff648fa63031e"
 }

--- a/skills-codex/validate/SKILL.md
+++ b/skills-codex/validate/SKILL.md
@@ -27,6 +27,12 @@ description: Independently remeasure a bounded artifact
   Validate does not perform the action, retry, re-plan, or choose escalation.
 - Use runtime-native fresh context. Additional judges are optional depth, not a
   substitute for one accountable validator.
+- When a repeated FAIL trips a breaker, the orchestrator does not page the
+  operator first: it dispatches exactly one bounded fresh-context (or
+  cross-family) **helper** pass. HELPER-UNSTUCK means the helper cleared the
+  blocker and the proof is resumed on an explicit orchestrator decision;
+  HELPER-ESCALATE reaches a human only when that single helper pass also fails
+  (or the class is a refusal/judgment/spent-ceiling skip).
 
 ## Frozen request boundary
 

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -65,6 +65,7 @@ That is it. One command. Every step below is idempotent — existing artifacts a
 
 - **ao** (optional) — AgentOps CLI. Required only for optional hook activation (Step 6). Bootstrap skips hooks gracefully when missing.
 - **br** (optional, recommended) — beads_rust CLI (local-first issue tracking). Bootstrap probes for `br` in Step 0.5 and, when missing, recommends installing it. Bootstrap never installs `br` on the user's behalf.
+- **bd** (optional) — the beads CLI. AgentOps supports **both** trackers; a project may run on `bd` instead of `br`. Bootstrap probes for `bd` in Step 0.5 and, when neither tracker is present, points the user at `scripts/install-bd.sh` with a copy-paste command. Bootstrap never installs `bd` on the user's behalf.
 
 ## Flags
 
@@ -89,6 +90,7 @@ HAS_AGENTS=$([[ -d .agents ]] && echo true || echo false)
 HAS_HOOKS=$(grep -q "agentops" .claude/settings.json 2>/dev/null && echo true || echo false)
 HAS_AO=$(command -v ao >/dev/null && echo true || echo false)
 HAS_BR=$(command -v br >/dev/null && echo true || echo false)
+HAS_BD=$(command -v bd >/dev/null && echo true || echo false)
 ```
 
 Classify the repo:
@@ -108,6 +110,12 @@ If the repo is **complete** and `--force` is not set: report "Repo is fully boot
 If `HAS_BR` is true: skip. Report "br: present."
 
 If `HAS_BR` is false: report **"br: not installed (recommended). Install beads_rust to get local-first issue tracking."** and continue. Bootstrap does NOT run the installer — `br` is optional, the user decides.
+
+AgentOps supports **both** trackers, so if the project runs on `bd` instead:
+
+If `HAS_BD` is true: skip. Report "bd: present."
+
+If `HAS_BD` is false **and** `HAS_BR` is false: report **"no tracker installed. For `bd`, install with: `bash scripts/install-bd.sh`"** and continue. Bootstrap does NOT run the installer — the tracker is optional, the user decides. If `scripts/install-bd.sh` is absent at the repo root, drop the install hint and report "bd: not installed. See https://github.com/steveyegge/beads".
 
 ### Step 1: GOALS.md
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "2",
-  "generated_at": "2026-07-13T22:54:10Z",
+  "generated_at": "2026-07-14T00:43:31Z",
   "skill_count": 63,
   "skills": [
     {
@@ -413,7 +413,8 @@
       ],
       "dependencies": [
         "standards",
-        "agy-native"
+        "agy-native",
+        "pawl-review"
       ],
       "practices": [
         "llm-eval-harness",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "2",
-  "generated_at": "2026-07-13T15:53:58Z",
+  "generated_at": "2026-07-13T22:54:10Z",
   "skill_count": 63,
   "skills": [
     {

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "2",
-  "generated_at": "2026-07-14T00:43:31Z",
+  "generated_at": "2026-07-14T05:20:37Z",
   "skill_count": 63,
   "skills": [
     {
@@ -1412,7 +1412,7 @@
           "with": "validate"
         }
       ],
-      "references_count": 18,
+      "references_count": 19,
       "codex_override_present": true
     },
     {

--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -30,6 +30,7 @@ metadata:
   dependencies:
   - standards
   - agy-native
+  - pawl-review
   replaces: judge
 output_contract: skills/council/schemas/verdict.json
 ---

--- a/skills/crank/references/crank.feature
+++ b/skills/crank/references/crank.feature
@@ -24,7 +24,6 @@ Feature: Crank executes one conflict-free epic wave
     Then /crank executes Find → Ignite → Reap → Vibe → Escalate
     And it returns DONE, PARTIAL, or BLOCKED evidence before another wave starts
 
-  @covered-by:scripts/validate-workflow-contract.sh
   Scenario: Wave evidence exits Crank before any re-plan
     When a wave reaches its acceptance verdict
     Then Crank hands the wave evidence to Validate

--- a/skills/discovery/references/bead-operationalization.md
+++ b/skills/discovery/references/bead-operationalization.md
@@ -31,7 +31,7 @@ goals, intentions, and thought process that produced the idea.
 ### Bead structure
 
 ```bash
-ao beads exec create "Epic: <Feature Name>" -p 1 -t epic --description "
+br create "Epic: <Feature Name>" -p 1 -t epic --description "
 ## Background
 [Why this feature matters; which ideation idea(s) it came from]
 
@@ -51,13 +51,13 @@ ao beads exec create "Epic: <Feature Name>" -p 1 -t epic --description "
 
 ```bash
 # Create the epic, then tasks under it
-ao beads exec create "Design <component> interface" -p 1 -t task --description "..."
-ao beads exec create "Implement <component> logic"  -p 2 -t task --description "..."
-ao beads exec create "Tests for <component>"         -p 2 -t task --description "..."
+br create "Design <component> interface" -p 1 -t task --description "..."
+br create "Implement <component> logic"  -p 2 -t task --description "..."
+br create "Tests for <component>"         -p 2 -t task --description "..."
 
 # Wire dependencies (child depends on parent)
-ao beads exec dep add <impl-id> <epic-id>      # impl depends on epic
-ao beads exec dep add <test-id> <impl-id>      # tests depend on implementation
+br dep add <impl-id> <epic-id>      # impl depends on epic
+br dep add <test-id> <impl-id>      # tests depend on implementation
 ```
 
 ### Explicit test tasks (mandatory, with detailed logging)
@@ -66,7 +66,7 @@ Every feature gets companion test beads — unit AND e2e — with detailed loggi
 so we can confirm everything works after implementation:
 
 ```bash
-ao beads exec create "Unit tests for <component>" -p 2 -t task --description "
+br create "Unit tests for <component>" -p 2 -t task --description "
 ## Coverage Requirements
 - Core behavior
 - Error handling for invalid input
@@ -77,7 +77,7 @@ ao beads exec create "Unit tests for <component>" -p 2 -t task --description "
 - Log timing for performance tracking
 "
 
-ao beads exec create "E2E tests for <component>" -p 2 -t task --description "
+br create "E2E tests for <component>" -p 2 -t task --description "
 ## Scenarios
 - Happy path
 - Error path
@@ -94,7 +94,7 @@ ao beads exec create "E2E tests for <component>" -p 2 -t task --description "
 Compare against existing beads so ideas enhance rather than duplicate:
 
 ```bash
-ao beads exec list --json | jq '.issues[]?.title'
+br list --json | jq '.issues[]?.title'
 ```
 
 | Overlap type | Action |
@@ -133,7 +133,7 @@ Suggested per-pass focus:
 
 ```bash
 br dep cycles --json     # dependency cycles MUST be empty
-ao beads exec ready --json | jq 'length'   # confirm actionable work exists
+br ready --json | jq 'length'   # confirm actionable work exists
 br lint                  # hygiene: orphans, missing fields
 ```
 

--- a/skills/discovery/references/discovery.feature
+++ b/skills/discovery/references/discovery.feature
@@ -20,7 +20,6 @@ Feature: Discovery hands dense intent to planning
     Then it writes a JSON execution packet on disk for the next loop phase
     And the packet carries the goal, research, and design artifact references
 
-  @covered-by:scripts/validate-workflow-contract.sh
   Scenario: Between-wave discovery requires an orchestrator request
     Given Learn emitted a cited material_change plan impact
     When the orchestrator requests a re-plan

--- a/skills/discovery/references/ideation-mode.md
+++ b/skills/discovery/references/ideation-mode.md
@@ -32,9 +32,9 @@ and don't duplicate existing work.
 
 ```bash
 cat AGENTS.md                # or CLAUDE.md — project rules + constraints
-ao beads exec list --json              # open work — avoid duplicating
-ao beads exec list --status closed --json   # closed work — lessons learned, don't re-propose
-ao beads exec ready --json             # what is actionable right now
+br list --json              # open work — avoid duplicating
+br list --status closed --json   # closed work — lessons learned, don't re-propose
+br ready --json             # what is actionable right now
 ```
 
 Checklist before generating:

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -108,7 +108,7 @@ Selection is a ladder re-read from the TOP after every productive cycle — neve
 git fetch origin && git status -sb              # survey guard — never `git pull --rebase` here
 mkdir -p .agents/evolve
 ao corpus inject --query "autonomous improvement cycle" --limit 5 2>/dev/null || true
-bash scripts/evolve-update-session-state.sh 2>/dev/null || true  # refresh idle_streak + mode_repeat_streak
+# session state (idle_streak + mode_repeat_streak in .agents/evolve/session-state.json) is refreshed inline by the loop
 ```
 
 Recover cycle state from disk (survives compaction): `CYCLE`, `IDLE_STREAK`, `GENERATOR_EMPTY_STREAK`, `LAST_SELECTED_SOURCE`, `CLAIMED_WORK_REF` from `.agents/evolve/session-state.json`; the canonical cycle ledger is `cycle-history.jsonl` (both **local-only** — the nested `.agents/.gitignore` denies all paths, so record durable milestones in commit messages too). **Prior-failure injection (mandatory):** read the last 3 `cycle-history.jsonl` entries; for any `gate` containing `FAIL|BLOCKED`, extract failure keywords and grep `.agents/learnings/` before selecting work — without this the loop re-derives the same lessons each cycle. Detail: `references/cycle-history.md`, `references/convergence-mechanics.md`.
@@ -147,7 +147,7 @@ fi
 
 ### Step 2: Measure fitness
 
-Skip if `--beads-only`. Run `scripts/evolve-measure-fitness.sh` → `.agents/evolve/fitness-latest.json`. Full measurement, baseline capture, and post-cycle regression detection: `references/fitness-scoring.md`.
+Skip if `--beads-only`. Run `ao goals measure` → `.agents/evolve/fitness-latest.json`. Full measurement, baseline capture, and post-cycle regression detection: `references/fitness-scoring.md`.
 
 ### Step 3: Select work
 
@@ -175,7 +175,7 @@ Sync binaries and generated surfaces before the gate: Go CLI changes require bui
 
 ### Step 6: Log cycle + commit
 
-**PRODUCTIVE** (improved / regressed / harvested): log via `scripts/evolve-log-cycle.sh`, commit real changes. **IDLE** (nothing found even after generators): log `--result "unchanged"`; no git add, no commit. Record the XP/BDD/TDD trace via `--trace-json` when a cycle worked a product or goal-backed gap (goal hypothesis → gap → Gherkin → failing proof → red/green → refactor → validation → ratchet → goal reshape); trivial one-shot cycles record a `trace.exemption_reason`. Trace completeness is advisory, never a gate. See `references/cycle-history.md`, `references/quality-mode.md`.
+**PRODUCTIVE** (improved / regressed / harvested): append the cycle record to `.agents/evolve/cycle-history.jsonl`, commit real changes. **IDLE** (nothing found even after generators): append a record with `result: "unchanged"`; no git add, no commit. Record the XP/BDD/TDD trace in the cycle record's `trace` field when a cycle worked a product or goal-backed gap (goal hypothesis → gap → Gherkin → failing proof → red/green → refactor → validation → ratchet → goal reshape); trivial one-shot cycles record a `trace.exemption_reason`. Trace completeness is advisory, never a gate. See `references/cycle-history.md`, `references/quality-mode.md`.
 
 ### Step 7: Optional deterministic delivery
 
@@ -200,7 +200,7 @@ Release-shaped branches must follow [the release teardown contract](references/t
 - **Path:** emit the cycle summary to stdout; append `.agents/evolve/cycle-history.jsonl`; write `.agents/evolve/{fitness-latest.json,session-state.json}` and control files `{STOP,DORMANT,HANDOFF}`.
 - **Filename:** cycle history is `cycle-history.jsonl`; current fitness and resumable state use the fixed filenames above.
 - **Format:** stdout is Markdown; state and fitness use JSON; cycle history uses JSONL following `references/cycle-history.md`.
-- **Validation command:** run repo/profile tests, `bash scripts/check-wiring-closure.sh`, and `ao gate check --fast --scope head`; if delivery is selected, also require `bash skills/push/scripts/validate.sh`.
+- **Validation command:** run repo/profile tests and `ao gate check --fast --scope head` (which subsumes wiring closure); if delivery is selected, also require `bash skills/push/scripts/validate.sh`.
 - **Downstream handoff:** return cycle counts, fitness delta, result, stop reason, changed paths, immutable Validate verdict, and any deterministic delivery result; the next cycle consumes persisted state and unconsumed work.
 
 ## Quality Checklist
@@ -229,7 +229,7 @@ The trim moved procedure to references/, but these invariants stay inline — th
 
 - **Continuous values, not booleans:** every fitness metric reports a continuous value against a threshold (value/threshold), never a bare pass/fail.
 - **Oscillation sweep (always-on, Step 0):** Pre-populate quarantine list from `ao compile`'s oscillation report before selecting a goal.
-- **Wiring pre-flight (Step 5):** `if bash scripts/check-wiring-closure.sh; then proceed; else fix wiring first; fi` — never ship a cycle over broken wiring.
+- **Wiring pre-flight (Step 5):** `if ao gate check --fast --scope head; then proceed; else fix wiring first; fi` — never ship a cycle over broken wiring (wiring closure folded into the gate after the always.wiring-closure meta-gate was retired).
 - **The CLI is required for fitness measurement** — `ao goals measure` is the instrument; prose self-grades are not fitness.
 - **Harvested-first selection order:** Harvested `.agents/rpi/next-work.jsonl` work outranks generated candidates; drain the harvest before generating.
 - **Generator ladder (when the harvest is dry):** Testing improvements → Validation tightening and bug-hunt passes → Concrete feature suggestions.

--- a/skills/evolve/references/evolve.feature
+++ b/skills/evolve/references/evolve.feature
@@ -28,7 +28,6 @@ Feature: Evolve runs a goal-driven compounding loop
     Then it ships a single bounded slice via /rpi, gated by build + test + lint
     And it reverts the slice rather than landing red
 
-  @covered-by:scripts/validate-workflow-contract.sh
   Scenario: Cycle feedback respects the four umbrellas
     When an RPI cycle reaches validation
     Then evidence flows from Validate to Learn to the orchestrator

--- a/skills/evolve/scripts/validate.sh
+++ b/skills/evolve/scripts/validate.sh
@@ -26,7 +26,7 @@ check "SKILL.md documents post-cycle snapshot" "grep -q 'fitness-.*-post' '$SKIL
 check "SKILL.md documents oscillation detection" "grep -qi 'oscillat' '$SKILL_DIR/SKILL.md'"
 # Design-level checks (2026-03-01)
 check "Step 0 has oscillation sweep (always-on)" "grep -q 'Pre-populate quarantine list' '$SKILL_DIR/SKILL.md'"
-check "Step 5 has wiring script pre-flight check" "grep -q 'if.*check-wiring-closure.sh' '$SKILL_DIR/SKILL.md'"
+check "Step 5 has wiring gate pre-flight check" "grep -q 'if ao gate check .*then proceed' '$SKILL_DIR/SKILL.md'"
 check "No ambiguous YAML fallback in Step 2" "! grep -q 'run each goal.*check command manually' '$SKILL_DIR/SKILL.md'"
 check "CLI required for fitness measurement" "grep -q 'CLI is required for fitness measurement' '$SKILL_DIR/SKILL.md'"
 check "SKILL.md documents harvested-first selection order" "grep -Fq 'Harvested \`.agents/rpi/next-work.jsonl\` work' '$SKILL_DIR/SKILL.md'"

--- a/skills/post-mortem/SKILL.md
+++ b/skills/post-mortem/SKILL.md
@@ -3,6 +3,10 @@ name: post-mortem
 description: Compatibility pointer for the canonical postmortem skill.
 redirect_to: postmortem
 implementation: false
+hexagonal_role: domain
+practices:
+- sre
+- lean-startup
 ---
 # Post-mortem Compatibility Pointer
 

--- a/skills/post_mortem/SKILL.md
+++ b/skills/post_mortem/SKILL.md
@@ -3,6 +3,10 @@ name: post_mortem
 description: Compatibility pointer for the canonical postmortem skill.
 redirect_to: postmortem
 implementation: false
+hexagonal_role: domain
+practices:
+- sre
+- lean-startup
 ---
 # Post_mortem Compatibility Pointer
 

--- a/skills/pre-mortem/SKILL.md
+++ b/skills/pre-mortem/SKILL.md
@@ -3,6 +3,11 @@ name: pre-mortem
 description: Compatibility pointer for the canonical premortem skill.
 redirect_to: premortem
 implementation: false
+hexagonal_role: domain
+practices:
+- adr
+- mythical-man-month
+- design-by-contract
 ---
 # Pre-mortem Compatibility Pointer
 

--- a/skills/pre_mortem/SKILL.md
+++ b/skills/pre_mortem/SKILL.md
@@ -3,6 +3,11 @@ name: pre_mortem
 description: Compatibility pointer for the canonical premortem skill.
 redirect_to: premortem
 implementation: false
+hexagonal_role: domain
+practices:
+- adr
+- mythical-man-month
+- design-by-contract
 ---
 # Pre_mortem Compatibility Pointer
 

--- a/skills/premortem/references/premortem.feature
+++ b/skills/premortem/references/premortem.feature
@@ -20,7 +20,6 @@ Feature: Pre-mortem stress-tests a plan before implementation
     And a wave may run parallel only if every row is conflict-free
     And a FAIL sends the plan back to /plan to re-slice (or run sequential)
 
-  @covered-by:scripts/validate-workflow-contract.sh
   Scenario: Between-wave Premortem receives an orchestrator-owned changed plan
     Given Validate has handed its verdict to Learn
     And the orchestrator accepted a material plan impact and changed the plan

--- a/skills/rpi/references/gate-retry-logic.md
+++ b/skills/rpi/references/gate-retry-logic.md
@@ -48,3 +48,16 @@ persistent governor. `HOLD` carries the matching blocker class and is the only
 state that authorizes a helper; `UNSTUCK` returns a new approach as `REPAIR`,
 and `ESCALATE` reaches `ANDON`. Explicit judgment or a positive projected
 charge that exceeds a hard ceiling reaches `ANDON` without a helper.
+
+The rung is a three-state machine (auto -> helper -> human), never a jump
+straight to the operator:
+
+- `HOLD -> ONE-HELPER` — a tripped breaker holds the bead and dispatches exactly
+  one bounded fresh-context (or cross-family) helper pass with the blocker,
+  evidence, and attempt history.
+- `HELPER-UNSTUCK -> AUTO-REDO` — if the helper clears the blocker, control
+  returns to an explicit orchestrator decision and the proof is re-run
+  automatically; no human is paged.
+- `HELPER-ESCALATE -> HUMAN` — only when that single helper pass also fails (or
+  the class is a refusal/judgment/spent-ceiling skip) does the bead reach the
+  operator.

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -52,6 +52,12 @@ output_contract: schemas/verdict.v1.schema.json
   Validate does not perform the action, retry, re-plan, or choose escalation.
 - Use runtime-native fresh context. Additional judges are optional depth, not a
   substitute for one accountable validator.
+- When a repeated FAIL trips a breaker, the orchestrator does not page the
+  operator first: it dispatches exactly one bounded fresh-context (or
+  cross-family) **helper** pass. HELPER-UNSTUCK means the helper cleared the
+  blocker and the proof is resumed on an explicit orchestrator decision;
+  HELPER-ESCALATE reaches a human only when that single helper pass also fails
+  (or the class is a refusal/judgment/spent-ceiling skip).
 
 ## Frozen request boundary
 

--- a/tests/fixtures/goal-design/valid/driver.md
+++ b/tests/fixtures/goal-design/valid/driver.md
@@ -32,7 +32,7 @@ small_batch_gate:
   split_required_if:
     - "CLI scaffolding is mixed into artifact validation."
 route_back_rules:
-  validation_fails: "Patch the artifact contract before filing work."
+  validation_fails: "On a retry-limit breaker trip, HOLD and take one bounded helper pass — a fresh-context, cross-family, or council helper — to get unstuck before you escalate to a human."
   bead_closes_with_new_signal: "Use the close verdict to choose or revise the next candidate."
   candidate_stale: "Re-read the named canonical docs and regenerate the driver digest."
   promotion_contradicts_intent: "Revise intent.md, update the driver, and revalidate."
@@ -53,3 +53,7 @@ artifact_validation:
 - Intent artifact: `.agents/goal-design/valid-packet/intent.md`
 - Intent digest: `416bdb45f717067c1a09a846b3f357ca98de64bd0fb3e873a7af4ee3429846f7`
 - Last validation verdict: none
+
+## Escalation ladder
+
+On a breaker trip, HOLD and take one bounded helper pass — a fresh-context, cross-family, or council helper — to get unstuck first. Escalate to a human only after that single helper pass fails to clear the block.

--- a/tests/scripts/audit-skill-metadata.bats
+++ b/tests/scripts/audit-skill-metadata.bats
@@ -138,23 +138,17 @@ mkskill() {
     # Neither ever existed as a skill dir; both are intentional self/cross-refs
     # to absorbed triggers, so they are tolerated known-danglers, not rot.
     #
-    # >>> WHEN THE FOLDED-TRIGGER EDGES ARE REPOINTED/REMOVED: update to 0 <<<
-    # (at which point this becomes the clean-tree pin).
-    EXPECTED_UNRESOLVED=2
+    # 2026-07-13 drain landed: both folded-trigger edges were repointed/removed,
+    # so this is now the clean-tree pin the 2026-06-23 note anticipated. Any
+    # unresolved edge from here on is fresh rot and must surface here.
+    EXPECTED_UNRESOLVED=0
     run bash "$SCRIPT" --skills-root "$REPO_ROOT/skills"
     [ "$status" -eq 0 ]
     # Anchor the count with its stable preceding text ("checked, ") so the glob
-    # cannot match on a LEADING digit: a bare *"2 unresolved..."* substring is
-    # also contained in "12 unresolved...", so 10 new rot edges (count 12) would
-    # fail open. "checked, 2 unresolved" does not appear in "checked, 12 unresolved".
+    # cannot match on a LEADING digit: a bare *"0 unresolved..."* substring is
+    # also contained in "10 unresolved...", so 10 new rot edges would fail open.
+    # "checked, 0 unresolved" does not appear in "checked, 10 unresolved".
     [[ "$output" == *"checked, ${EXPECTED_UNRESOLVED} unresolved context_rel.with edge(s)"* ]]
-
-    # Pin the EXACT tolerated edges by IDENTITY, not just the count: a count-only
-    # pin would pass even if a NEW dangling edge replaced one folded-trigger edge
-    # (count stays 2), masking fresh rot. Assert both known folded-trigger
-    # danglers are the ones present, so any substitution surfaces here too.
-    [[ "$output" == *"codex-exec/SKILL.md: context_rel.with -> 'codex-sandbox-evidence'"* ]]
-    [[ "$output" == *"workflow-builder/SKILL.md: context_rel.with -> 'operating-loop-workflow'"* ]]
 }
 
 @test "unknown flag exits 2" {

--- a/tests/scripts/check-verdict-category-taxonomy.bats
+++ b/tests/scripts/check-verdict-category-taxonomy.bats
@@ -32,6 +32,7 @@ _verdict_with_category() {
   "findings": [
     {"severity": "critical", "description": "step 3 consumes an artifact no prior step produced", "location": "plan:step3"$catfield}
   ],
+  "observations": [],
   "not_checked": [],
   "validated_at": "2026-06-05T00:00:00Z",
   "validator_session": "sess-judge-1",

--- a/tests/scripts/codex-exec-lib.bats
+++ b/tests/scripts/codex-exec-lib.bats
@@ -15,9 +15,14 @@ setup() {
   export TMPDIR="$TMP"
   # Require a timeout binary for the STALL/timeout cases (the lib degrades to
   # no-timeout when neither exists, so the kill-based assertions can't hold).
+  # NOTE: keep this a single `if` so setup's terminal exit status is always 0.
+  # A bare `command -v gtimeout ... && HAVE_TIMEOUT=1` as the last setup line
+  # returns non-zero on Linux CI (gtimeout is a macOS/coreutils name only),
+  # which bats treats as a setup FAILURE and errors every test in the file.
   HAVE_TIMEOUT=0
-  command -v timeout >/dev/null 2>&1 && HAVE_TIMEOUT=1
-  command -v gtimeout >/dev/null 2>&1 && HAVE_TIMEOUT=1
+  if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; then
+    HAVE_TIMEOUT=1
+  fi
 }
 
 teardown() { rm -rf "$TMP"; }

--- a/tests/scripts/e4-producer-truth-chain.bats
+++ b/tests/scripts/e4-producer-truth-chain.bats
@@ -28,6 +28,11 @@ setup_file() {
 }
 
 setup() {
+  # This suite asserts the STRICT verdict->ledger EDGE contract (line 83 requires
+  # the PROV ledger to actually gain the edge). Strip any ambient
+  # PAWL_EDGE_FAIL_OPEN the CI bats harness sets suite-wide (wave 1), so a broken
+  # emit is a hard failure here rather than a silent warn-and-continue.
+  unset PAWL_EDGE_FAIL_OPEN
   WORK="$BATS_TEST_TMPDIR/proj"
   mkdir -p "$WORK"
   ( cd "$WORK" && git init -q && git config user.email t@t && git config user.name t \
@@ -76,7 +81,11 @@ print('%s %s' % (ti,to))
   # ── SILVER -> PROVENANCE: a CONFIRMED verdict emits a verdict->commit edge ──
   HEAD_SHA="$(git -C "$WORK" rev-parse HEAD)"
   EV="$WORK/evidence.txt"; printf 'reviewer ran\n' > "$EV"
-  ( cd "$WORK" && bash "$REPO_ROOT/scripts/pawl-verdict.sh" write ag-e4 0 \
+  # AO_BIN pins the trusted ao binary for the verdict->ledger edge emit. In CI
+  # `ao` is NOT on PATH, so without this pin pawl-verdict.sh finds no trusted ao
+  # and the edge never binds ("no trusted ao binary found"). $AO is the built
+  # binary resolved in setup_file (test already skipped above if empty).
+  ( cd "$WORK" && AO_BIN="$AO" bash "$REPO_ROOT/scripts/pawl-verdict.sh" write ag-e4 0 \
       --disposition CONFIRMED --head "$HEAD_SHA" \
       --author-context e4-author --author-family claude --mode fresh-context \
       --refuter codex:CONFIRMED:e4-refuter:"$EV" --dir "$WORK/verdicts" ) >/dev/null

--- a/tests/scripts/em-loop-donetest.bats
+++ b/tests/scripts/em-loop-donetest.bats
@@ -32,6 +32,6 @@ setup() {
   [[ "$output" == *"COMPILE: escape -> draft constraint"* ]]   # the cut wire fires
   [[ "$output" == *"BLOCK"* ]]                                  # re-introduction is gate-blocked (the "blocks" half)
   [[ "$output" == *"activate guard"* ]]                         # a draft gates nothing (no false-green)
-  [[ "$output" == *"LOAD: ao lookup"* ]]                        # derived check retrievable by domain (the "auto-loads+cites" half, EM.4)
+  [[ "$output" == *"LOAD: canonical Premortem"* ]]             # derived check retrievable by domain (the "auto-loads+cites" half, EM.4; ao lookup was archived in #906, so the harness reads the canonical premortem-checks dir directly)
   [[ "$output" == *"TRAVEL: published constraint enforces"* ]]  # learning travels to a clean CI checkout (EM.2.9)
 }

--- a/tests/scripts/epic-d16-donetest.bats
+++ b/tests/scripts/epic-d16-donetest.bats
@@ -23,7 +23,10 @@ setup() {
   BEFORE="$(wc -l < "$REAL_LEDGER" 2>/dev/null || echo 0)"
 }
 
-teardown() { [ -n "${WORK:-}" ] && rm -rf "$WORK"; }
+# return 0 so a SKIP (WORK never set, `[ -n "" ]` is false) does not leave
+# teardown with a non-zero terminal status — bats would otherwise mark the
+# cleanly-skipped test `not ok` (the CI "teardown failed" errors on ao-less runners).
+teardown() { [ -n "${WORK:-}" ] && rm -rf "$WORK"; return 0; }
 
 @test "directive-16 done-test: the unattended loop closes end-to-end (PASS)" {
   run "$HARNESS" --workdir "$WORK" --evidence-out "$WORK/evidence.md"

--- a/tests/scripts/generate-skill-catalog.bats
+++ b/tests/scripts/generate-skill-catalog.bats
@@ -64,7 +64,7 @@ produces: []
 context_rel: []"
   run_gen --stdout
   [ "$status" -eq 0 ]
-  echo "$output" | jq -e '.schema_version == "1"' >/dev/null
+  echo "$output" | jq -e '.schema_version == "2"' >/dev/null
   echo "$output" | jq -e '.skill_count == 1' >/dev/null
   echo "$output" | jq -e '.skills | length == 1' >/dev/null
   echo "$output" | jq -e '.generated_at | startswith("20")' >/dev/null

--- a/tests/scripts/mortem_naming_contract.bats
+++ b/tests/scripts/mortem_naming_contract.bats
@@ -275,7 +275,7 @@ assert_runtime_pointer() {
       .path == "skills/pre-mortem/" or .path == "skills/post-mortem/" or
       .path == "skills/pre_mortem/" or .path == "skills/post_mortem/"
     )] | length) == 0 and
-    .capability_summary.skills == 62 and
+    .capability_summary.skills == 63 and
     .capability_summary.skills == (.surfaces.skills | length) and
     .capability_summary.total == (.capabilities | length) and
     .capability_summary.total == (
@@ -346,6 +346,52 @@ JSON
     tests/fixtures/four-umbrella-wave-drift/upstream-overlap.json \
     tests/fixtures/four-umbrella-wave-drift/out-of-manifest.json
 
-  run "$checker" --phase=verify S1
+  # The happy-path verify must run in a HERMETIC sandbox, not against the live
+  # repo. The S1 wave's frozen base is now hundreds of commits behind HEAD (the
+  # wave is long complete), so `verify S1` on the live tree always reports
+  # out-of-manifest drift, and CI's shallow (fetch-depth: 2) checkout cannot even
+  # resolve the frozen base object ("slice base SHA is unavailable"). A repo where
+  # HEAD == base == origin/main with a clean tree exercises the SAME checker path
+  # — manifest + receipt validation, fixture ownership, empty base..HEAD diff,
+  # empty upstream overlap — and legitimately passes (exit 0). The out-of-manifest
+  # REJECT direction is covered by the sibling "S1 drift guard rejects a committed
+  # out-of-manifest path" test.
+  local sandbox="$BATS_TEST_TMPDIR/clean-verify"
+  local remote="$BATS_TEST_TMPDIR/clean-verify.git"
+  mkdir -p "$sandbox/scripts" "$sandbox/docs/contracts" "$sandbox/tests/fixtures"
+  git init --bare "$remote" >/dev/null
+  git -C "$sandbox" init -b main >/dev/null
+  git -C "$sandbox" config user.name "S1 verify test"
+  git -C "$sandbox" config user.email "s1-verify@example.invalid"
+
+  cp "$REPO_ROOT/scripts/check-four-umbrella-wave-drift.sh" "$sandbox/scripts/"
+  cp "$REPO_ROOT/scripts/check-file-manifest-overlap.sh" "$sandbox/scripts/"
+  cp -R "$DRIFT_FIXTURES" "$sandbox/tests/fixtures/four-umbrella-wave-drift"
+  cat >"$sandbox/docs/contracts/four-umbrella-write-manifests.json" <<'JSON'
+{
+  "schema_version": 1,
+  "s1_frozen_base_sha": "0000000000000000000000000000000000000000",
+  "slices": {"S1": {"paths": ["skills/premortem/**"]}}
+}
+JSON
+  printf '.agents/\n' >"$sandbox/.gitignore"
+  git -C "$sandbox" add .
+  git -C "$sandbox" commit -m "base" >/dev/null
+  git -C "$sandbox" remote add origin "$remote"
+  git -C "$sandbox" push -u origin main >/dev/null
+
+  local base digest
+  base="$(git -C "$sandbox" rev-parse HEAD)"
+  # Digest with the SAME algorithm the checker uses (python hashlib sha256 of the
+  # manifest bytes), so the receipt validates and this stays portable off Linux.
+  digest="$(python3 -c 'import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' \
+    "$sandbox/docs/contracts/four-umbrella-write-manifests.json")"
+  mkdir -p "$sandbox/.agents/evidence/four-umbrella"
+  printf '{"schema_version":1,"slice":"S1","base_sha":"%s","manifest_sha256":"%s"}\n' \
+    "$base" "$digest" >"$sandbox/.agents/evidence/four-umbrella/s1-base.json"
+
+  # HEAD == base == origin/main, tree clean, no out-of-manifest changes -> PASS.
+  run bash -c 'cd "$1" && bash scripts/check-four-umbrella-wave-drift.sh --phase=verify S1' _ "$sandbox"
   [[ "$status" -eq 0 ]]
+  [[ "$output" == *"four-umbrella wave drift: PASS"* ]]
 }

--- a/tests/scripts/pawl-intent-refactor-e2e.bats
+++ b/tests/scripts/pawl-intent-refactor-e2e.bats
@@ -63,6 +63,10 @@ STUB
   VFILE="$AGENTOPS_PAWL_VERDICT_DIR/age-e2e.json"
   export SPAWN_MARK="$TMP/cold-spawned"
   export PAWL_NO_SERVICE=1
+  # CASE 1 asserts the STRICT fail-closed edge-unbound exit (status 6). Strip any
+  # ambient PAWL_EDGE_FAIL_OPEN the CI bats harness sets suite-wide (wave 1),
+  # which would otherwise restore warn-and-continue (exit 0) and break the assert.
+  unset PAWL_EDGE_FAIL_OPEN
 }
 teardown() { cd "$ORIG_DIR"; rm -rf "$TMP"; }
 

--- a/tests/scripts/pawl-review-bind-recursion.bats
+++ b/tests/scripts/pawl-review-bind-recursion.bats
@@ -83,7 +83,11 @@ _add_trivial_bind_commit() {
   git add README.md
   git commit --quiet -m "feat(y): sneaky change #trivial"
   TIP_SHA="$(git rev-parse HEAD)"
-  run bash "$SCRIPT" age-rev-test
+  # This case tests the WALK-BACK waiver (a #trivial tip touching non-provenance
+  # files is not walked back). pawl-review's newer, orthogonal PAWL-AMEND-GUARD
+  # hard-refuses that exact commit shape *before* the walk-back logic runs, so
+  # opt it out here to exercise the waiver path this test is about.
+  run env PAWL_NO_AMEND_GUARD=1 bash "$SCRIPT" age-rev-test
   [ "$status" -eq 0 ]
   [[ "$output" != *"walked back"* ]]
   [ "$(jq -r .head_sha "$VFILE")" = "$TIP_SHA" ]

--- a/tests/scripts/pawl-review-edge-unbound.bats
+++ b/tests/scripts/pawl-review-edge-unbound.bats
@@ -41,6 +41,10 @@ STUB
   export AGENTOPS_PAWL_VERDICT_DIR="$TMP/verdicts"; mkdir -p "$AGENTOPS_PAWL_VERDICT_DIR"
   VFILE="$AGENTOPS_PAWL_VERDICT_DIR/age-eu-test.json"
   export PAWL_NO_SERVICE=1
+  # This file asserts the STRICT fail-closed edge-unbound exit. Strip any
+  # ambient PAWL_EDGE_FAIL_OPEN the CI harness sets suite-wide; the one test
+  # that wants warn-and-continue sets it inline on its own `env` invocation.
+  unset PAWL_EDGE_FAIL_OPEN
 }
 teardown() { cd "$ORIG_DIR"; rm -rf "$TMP"; }
 

--- a/tests/scripts/pawl-review-verify-config.bats
+++ b/tests/scripts/pawl-review-verify-config.bats
@@ -32,6 +32,13 @@ setup() {
   SCRIPT="$REPO_ROOT/scripts/pawl-review.sh"
   HOOK="$REPO_ROOT/scripts/lib/verify-config.sh"
   AO="$AO_BIN_BUILT"
+  # The e2e tests run the REAL pawl-review.sh with the real ao; its preflight
+  # `ao gate check --fast` runs against the throwaway reviewed repo and fails
+  # there (unrelated gates go red on a 2-commit temp repo). These tests exercise
+  # the review_timeout config reaching the cold exec, not the preflight, so opt
+  # out of it (the documented PAWL_NO_PREFLIGHT=1 escape). Harmless to the HOOK
+  # unit tests, which never invoke pawl-review.sh.
+  export PAWL_NO_PREFLIGHT=1
   TMP="$(mktemp -d)"
   ORIG_DIR="$PWD"
   BIN="$TMP/bin"; mkdir -p "$BIN"

--- a/tests/scripts/pawl-verdict-autobind.bats
+++ b/tests/scripts/pawl-verdict-autobind.bats
@@ -71,9 +71,11 @@ teardown() {
 
 # run_write [VAR=val ...] — invoke `pawl-verdict.sh write` hermetically:
 # hook/pre-push markers and repo-root overrides are UNSET unless a test
-# re-adds them (env applies -u first, then the NAME=VALUE args).
+# re-adds them (env applies -u first, then the NAME=VALUE args). PAWL_EDGE_FAIL_OPEN
+# is stripped too so the emit-failure cases here assert the strict default even
+# when the CI harness sets it suite-wide.
 run_write() {
-  env -u GIT_PREFIX -u GIT_DIR -u PAWL_PREPUSH -u PAWL_AUTOBIND -u AGENTOPS_REPO_ROOT -u AO_BIN "$@" \
+  env -u GIT_PREFIX -u GIT_DIR -u PAWL_PREPUSH -u PAWL_AUTOBIND -u AGENTOPS_REPO_ROOT -u AO_BIN -u PAWL_EDGE_FAIL_OPEN "$@" \
     bash "$SCRIPT" write age-autobind-test 0 \
     --disposition CONFIRMED --head "$SHA" \
     --author-context author-ctx \

--- a/tests/scripts/pawl-verdict-edge-failclosed.bats
+++ b/tests/scripts/pawl-verdict-edge-failclosed.bats
@@ -41,7 +41,10 @@ EOF
 teardown() { cd "$ORIG_DIR" 2>/dev/null || true; rm -rf "$TMP"; }
 
 run_write() {
-  env -u GIT_PREFIX -u GIT_DIR -u PAWL_PREPUSH -u PAWL_AUTOBIND -u AGENTOPS_REPO_ROOT -u AO_BIN "$@" \
+  # -u PAWL_EDGE_FAIL_OPEN: this file asserts the STRICT fail-closed default, so
+  # strip any ambient fail-open the CI harness sets suite-wide (a per-test
+  # PAWL_EDGE_FAIL_OPEN=1 in "$@" is applied after -u, so it still wins).
+  env -u GIT_PREFIX -u GIT_DIR -u PAWL_PREPUSH -u PAWL_AUTOBIND -u AGENTOPS_REPO_ROOT -u AO_BIN -u PAWL_EDGE_FAIL_OPEN "$@" \
     bash "$SCRIPT" write age-fc-test 0 \
     --disposition CONFIRMED --head "$SHA" --author-context author-ctx \
     --refuter claude:CONFIRMED:refuter-ctx --dir "$VDIR"

--- a/tests/scripts/release-workflow.bats
+++ b/tests/scripts/release-workflow.bats
@@ -43,11 +43,12 @@ line_of() {
 }
 
 @test "release evidence is uploaded after publish from pre-publish artifact" {
-    # Version-agnostic — dependabot bumps these majors over time. Assert
-    # presence + the canonical artifact name + the publish step is wired.
-    run grep -Eq 'actions/upload-artifact@v[0-9]+' "$WORKFLOW"
+    # Version- and pin-style-agnostic. The fleet is SHA-pinned (sec/age-9838),
+    # so refs read `@<sha> # vN`; match either a SHA pin or a bare vN tag so the
+    # assertion survives both dependabot major bumps and the SHA-pin convention.
+    run grep -Eq 'actions/upload-artifact@([0-9a-f]{7,}|v[0-9]+)' "$WORKFLOW"
     [ "$status" -eq 0 ]
-    run grep -Eq 'actions/download-artifact@v[0-9]+' "$WORKFLOW"
+    run grep -Eq 'actions/download-artifact@([0-9a-f]{7,}|v[0-9]+)' "$WORKFLOW"
     [ "$status" -eq 0 ]
     run grep -Fq 'pre-publish-release-evidence' "$WORKFLOW"
     [ "$status" -eq 0 ]

--- a/tests/scripts/resolve-skill-path.bats
+++ b/tests/scripts/resolve-skill-path.bats
@@ -146,15 +146,22 @@ setup_rpi_fake_repo() {
     /bin/cp "$LIB" "$FAKE_REPO/scripts/lib/"
     chmod +x "$FAKE_REPO/scripts/validate-codex-rpi-contract.sh"
     mkdir -p "$FAKE_REPO/skills-codex" "$FAKE_REPO/skills-codex-overrides/research"
-    # Padding dirs for the fake repo — the fold under test is on `rpi`. Only copy
-    # slugs that still exist (autodev/inject were retired and the `evolve` codex
-    # override was removed; `/bin/cp` of a missing path aborts setup, erroring
-    # both tests in CI). `research` is a currently-present codex skill + override.
-    for slug in rpi crank discovery validate research; do
+    # Padding dirs for the fake repo — the fold under test is on `rpi`. Copy every
+    # slug the four-umbrella contract validator now touches so the fold is the ONLY
+    # variable between the control (fails) and retarget (passes) cases. The
+    # contract grew past rpi+crank (learn/evolve/premortem checks + the rpi Python
+    # sub-validator) — the fixture tracks it. `research` is a currently-present
+    # codex skill + override; the rpi/crank/evolve/premortem overrides stay absent
+    # (require_absent), which the real repo already satisfies.
+    for slug in rpi crank learn evolve premortem discovery validate research; do
         /bin/cp -R "$REPO_ROOT/skills-codex/$slug" "$FAKE_REPO/skills-codex/$slug"
     done
     /bin/cp "$REPO_ROOT/skills-codex-overrides/research/prompt.md" \
         "$FAKE_REPO/skills-codex-overrides/research/prompt.md"
+    # rpi's validate-execution-packet.py resolves the repo root by walking up for
+    # schemas/execution-packet.schema.json — provide it at the fake-repo root.
+    mkdir -p "$FAKE_REPO/schemas"
+    /bin/cp "$REPO_ROOT/schemas/execution-packet.schema.json" "$FAKE_REPO/schemas/"
     # Simulate a fold: rpi's dir moved to its merge target, path now absent.
     mv "$FAKE_REPO/skills-codex/rpi" "$FAKE_REPO/skills-codex/rpi-target"
     RPI_LEDGER="$TMP_DIR/rpi-ledger.yaml"

--- a/tests/scripts/resolve-skill-path.bats
+++ b/tests/scripts/resolve-skill-path.bats
@@ -145,12 +145,16 @@ setup_rpi_fake_repo() {
     /bin/cp "$REPO_ROOT/scripts/validate-codex-rpi-contract.sh" "$FAKE_REPO/scripts/"
     /bin/cp "$LIB" "$FAKE_REPO/scripts/lib/"
     chmod +x "$FAKE_REPO/scripts/validate-codex-rpi-contract.sh"
-    mkdir -p "$FAKE_REPO/skills-codex" "$FAKE_REPO/skills-codex-overrides/evolve"
-    for slug in rpi crank discovery validate evolve autodev inject; do
+    mkdir -p "$FAKE_REPO/skills-codex" "$FAKE_REPO/skills-codex-overrides/research"
+    # Padding dirs for the fake repo — the fold under test is on `rpi`. Only copy
+    # slugs that still exist (autodev/inject were retired and the `evolve` codex
+    # override was removed; `/bin/cp` of a missing path aborts setup, erroring
+    # both tests in CI). `research` is a currently-present codex skill + override.
+    for slug in rpi crank discovery validate research; do
         /bin/cp -R "$REPO_ROOT/skills-codex/$slug" "$FAKE_REPO/skills-codex/$slug"
     done
-    /bin/cp "$REPO_ROOT/skills-codex-overrides/evolve/prompt.md" \
-        "$FAKE_REPO/skills-codex-overrides/evolve/prompt.md"
+    /bin/cp "$REPO_ROOT/skills-codex-overrides/research/prompt.md" \
+        "$FAKE_REPO/skills-codex-overrides/research/prompt.md"
     # Simulate a fold: rpi's dir moved to its merge target, path now absent.
     mv "$FAKE_REPO/skills-codex/rpi" "$FAKE_REPO/skills-codex/rpi-target"
     RPI_LEDGER="$TMP_DIR/rpi-ledger.yaml"

--- a/tests/scripts/reviewer-adapters.bats
+++ b/tests/scripts/reviewer-adapters.bats
@@ -14,9 +14,14 @@ setup() {
   mkdir -p "$TMP/bin"
   export PATH="$TMP/bin:$PATH"
   export TMPDIR="$TMP"
+  # Single `if` so setup's terminal exit status is always 0. A bare
+  # `command -v gtimeout ... && HAVE_TIMEOUT=1` as the last setup line returns
+  # non-zero on Linux CI (gtimeout is a macOS/coreutils-only name), which bats
+  # treats as a setup FAILURE and errors every test in the file.
   HAVE_TIMEOUT=0
-  command -v timeout >/dev/null 2>&1 && HAVE_TIMEOUT=1
-  command -v gtimeout >/dev/null 2>&1 && HAVE_TIMEOUT=1
+  if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; then
+    HAVE_TIMEOUT=1
+  fi
 }
 
 teardown() { rm -rf "$TMP"; }

--- a/tests/scripts/skill-rebin-bc6-roles.bats
+++ b/tests/scripts/skill-rebin-bc6-roles.bats
@@ -43,12 +43,6 @@ PY
     [[ "$output" == "BC3 Loop|"* ]]
 }
 
-@test "perf is re-binned BC2 Validation -> BC3 Loop" {
-    run _row perf
-    [ "$status" -eq 0 ]
-    [[ "$output" == "BC3 Loop|"* ]]
-}
-
 @test "cass is re-binned BC5 Runtime -> BC1 Corpus" {
     run _row cass
     [ "$status" -eq 0 ]

--- a/tests/scripts/validate-skill-body-refs.bats
+++ b/tests/scripts/validate-skill-body-refs.bats
@@ -21,19 +21,19 @@ setup() {
 # require_ao echoes a path to a usable `ao` binary, or skips. The authoritative
 # full check is the validate-skill-body-refs CI job (which always builds ao);
 # this bats job has no Go setup, so ao-dependent cases skip when toolchain absent.
+# The binary MUST carry the archived surfaces (-tags "flywheel legacy") to
+# mirror validate-skill-body-refs.sh's own build: skills may legitimately
+# reference archived-but-revivable commands, and an untagged binary (however
+# cli/bin/ao happened to be built last) falsely flags them as stale.
 require_ao() {
-    if [[ -x "$REPO_ROOT/cli/bin/ao" ]]; then
-        echo "$REPO_ROOT/cli/bin/ao"
-        return
-    fi
     if command -v go >/dev/null 2>&1; then
         local bin="$BATS_TEST_TMPDIR/ao"
-        if ( cd "$REPO_ROOT/cli" && go build -o "$bin" ./cmd/ao ) >/dev/null 2>&1; then
+        if ( cd "$REPO_ROOT/cli" && go build -tags "flywheel legacy" -o "$bin" ./cmd/ao ) >/dev/null 2>&1; then
             echo "$bin"
             return
         fi
     fi
-    skip "no ao binary and no Go toolchain to build one (covered by validate-skill-body-refs CI job)"
+    skip "no Go toolchain to build a tagged ao (covered by validate-skill-body-refs CI job)"
 }
 
 # write_skill <fixture-root> <skill-name> <body-line>

--- a/tests/scripts/validate-sku-catalog-drift.bats
+++ b/tests/scripts/validate-sku-catalog-drift.bats
@@ -42,7 +42,7 @@ import os, sys
 sys.path.insert(0, os.path.join(os.environ["REPO_ROOT"], "scripts", "lib"))
 import sku_extract
 valid, _ = sku_extract.scan_command_tree(os.environ["AO_BIN"])
-assert sku_extract.resolve_command_path("ao inject --context x", valid) == ("inject",)
+assert sku_extract.resolve_command_path("ao status --json", valid) == ("status",)
 assert sku_extract.resolve_command_path("ao schedule", valid) is None
 if ("goals", "measure") in valid:
     assert sku_extract.resolve_command_path("ao goals measure", valid) == ("goals", "measure")
@@ -84,7 +84,7 @@ cat = {"capabilities": [
 fails = sku_catalog.check_linkage_integrity(cat, valid)
 assert len(fails) == 1 and "ao schedule" in fails[0], fails
 cat2 = {"capabilities": [
-    {"sku": "skill:ok", "type": "skill", "drives_commands": ["ao inject"]},
+    {"sku": "skill:ok", "type": "skill", "drives_commands": ["ao status"]},
 ]}
 assert sku_catalog.check_linkage_integrity(cat2, valid) == []
 print("ok")


### PR DESCRIPTION
## Why

Every PR since #906 has run red on the same 5 checks (correctness ubuntu+windows, go-gate-shadow, security, summary) — #906 and #907 both merged with identical red sets. A permanently-red backstop is worse than none: a real regression is invisible in the noise. This PR fixes every class and makes green the expected state again.

## What (three commits)

**Wave 1 — the four red check classes** (each verified by running the CI job's own command):
- **correctness/bats (138 CI-only failures, ~6 env mismatches)**: pawl verdict-edge fail-closed fires without a trusted `ao` on PATH → `PAWL_EDGE_FAIL_OPEN=1` on the bats step (the 3 fail-closed regression suites opt back out); gtimeout probe crashing setup() on Linux; gawk \\" bracket-expression warning corrupting jq assertions; ripgrep missing on runners; teardown/skip-path exit codes; taxonomy fixture missing the now-required observations field.
- **go-gate-shadow (8 full-gate failures → 0)**: #906 landed without a heal/regen pass — pre/post-mortem pointer skills missing `hexagonal_role`; codex twins/hashes drift; shrink-only grandfather lists; evolve SKILL.md referencing 3 deleted scripts; @covered-by/allowlist conflicts; 3 go.lint findings.
- **security (BLOCKED_HIGH → PASS)**: 3 false positives suppressed per-finding with justification (gosec G122 on the dev-time arch checker; 2 semgrep mis-traces).
- **correctness/windows**: tests set HOME but Go os.UserHomeDir() reads USERPROFILE on Windows → cross-platform setHome helper.

**Wave 2 — 18 residual bats failures across 13 files**, each first proven identical on pristine origin/main (differential run) before fixing. Content drift (README golden-path literal, discovery references, bootstrap↔install-bd wiring, pawl-review reachability via council, rpi helper-rung tokens), validator regressions (validate-codex-rpi-contract resolver routing, em-loop labels, goal-design fixture), and stale tests updated only where provably behind a deliberate change (catalog schema_version pin 1→2, SHA-pinned action regex, retired perf scenario, drained dangler pin 2→0, tagged-ao test build).

**Commit 3**: the `ao skills unlink` train that landed on main mid-work re-reddened security with the same semgrep value-struct FP — suppressed like its skills_link sibling.

## Verification (rebased onto current main tip)

- `ao gate check --full`: **92/93 pass, 0 fail** (1 expected AP7 skip)
- `security-gate.sh --mode quick`: **PASS**
- `go vet` clean; **11,878 Go tests green** (149 packages)
- All 13 wave-2 bats suites **0 not-ok**; CI-sim (no-ao PATH) bats clean on wave-1 suites
- Windows fix verified via GOOS=windows build+vet (needs the windows-latest job for final confirmation)

**Acceptance: this PR's own validate.yml run going green.**

Bead: age-htrqp