### PR TITLE
release: ship the Cathedral Cut as v3.3.0 (stay on the 3.x line)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Fresh-context validation for coding-agent work: one behavior, one bounded experiment, one independent verdict.",
-    "version": "4.0.0"
+    "version": "3.3.0"
   },
   "plugins": [
     {
       "name": "agentops",
       "description": "Fresh-context validation for coding-agent work: one behavior, one bounded experiment, one independent verdict.",
-      "version": "4.0.0",
+      "version": "3.3.0",
       "source": "./",
       "author": {
         "name": "Boden Fuller",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentops",
-  "version": "4.0.0",
+  "version": "3.3.0",
   "description": "Fresh-context validation for coding-agent work: shape one behavior, run one bounded experiment, and persist an independent verdict.",
   "author": {
     "name": "Boden Fuller",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentops",
-  "version": "4.0.0",
+  "version": "3.3.0",
   "description": "Fresh-context validation for coding-agent work: shape one behavior, run one bounded experiment, and persist an independent verdict.",
   "skills": "./skills-codex",
   "interface": {

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -1,6 +1,6 @@
 # Installing AgentOps for Codex
 
-AgentOps 4 uses one canonical checkout and source symlinks. Do not use the
+AgentOps 3.3 uses one canonical checkout and source symlinks. Do not use the
 old curl installer or a Codex plugin cache.
 
 ## Installation

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -1,5 +1,5 @@
 # End-to-end install against clean OS containers.
-# Canonical AgentOps 4 path: build/install ao + `ao skills link`.
+# Canonical AgentOps 3.3 path: build/install ao + `ao skills link`.
 #
 # Triggered:
 #   - Nightly (UTC 09:30)

--- a/.github/workflows/windows-installers.yml
+++ b/.github/workflows/windows-installers.yml
@@ -1,5 +1,5 @@
 # Windows onboarding leg: exercise scripts/install-ao.ps1 on windows-latest.
-# Skills install via `ao skills link` (canonical AgentOps 4 path). The old
+# Skills install via `ao skills link` (canonical AgentOps 3.3 path). The old
 # install-codex.ps1 plugin installer is retained only as a tombstone.
 
 name: windows-installers
@@ -31,8 +31,8 @@ jobs:
       - name: Confirm install-codex.ps1 is a removed-installer tombstone
         run: |
           $script = Get-Content -Raw (Join-Path $env:GITHUB_WORKSPACE 'scripts\install-codex.ps1')
-          if ($script -notmatch 'removed in 4') {
-            throw "install-codex.ps1 should be an AgentOps 4 tombstone"
+          if ($script -notmatch 'removed in 3\.3') {
+            throw "install-codex.ps1 should be an AgentOps 3.3 tombstone"
           }
           if ($script -notmatch 'ao skills link') {
             throw "install-codex.ps1 tombstone must point at ao skills link"

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -1,6 +1,6 @@
 # Installing AgentOps for OpenCode
 
-AgentOps 4 uses one canonical checkout and source symlinks.
+AgentOps 3.3 uses one canonical checkout and source symlinks.
 
 ## Recommended install
 
@@ -41,5 +41,5 @@ ao skills link
 
 ## Migration
 
-The old `scripts/install-opencode.sh` curl installer was removed in 4.x. See
+The old `scripts/install-opencode.sh` curl installer was removed in 3.3. See
 [docs/MIGRATION.md](../docs/MIGRATION.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,33 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+## [3.3.0] - 2026-07-17
 
-- A deterministic `toil-mining` extractor for recent human-origin Codex JSONL
-  messages, with provenance, wrapper normalization, deduplication, exclusion
-  accounting, and explicit checked/not-checked scope.
-- Read-only `ao status` inventory for durable intent and verdict evidence,
-  including newest-evidence recency without runtime-phase inference.
-- One-shot MCP-backed `ms` search for environments without an attached MCP
-  tool, plus multi-report synthesis guidance in Research.
-
-### Changed
-
-- Published `ao demo` now presents the packet-free one-pass loop; active docs,
-  templates, and smoke tests use caller-owned intent plus runtime-derived
-  subject evidence. The old Plan, Candidate, and revision schemas are labeled
-  deprecated compatibility formats.
-- `scripts/ms-reindex.sh` derives completeness from live
-  discovered/indexed/error accounting instead of a hard-coded corpus floor.
-- CASS guidance distinguishes authoritative rebuild fallback and timed-out
-  concurrent reads from empty results or source loss.
-
-## [4.0.0] - 2026-07-15
-
-AgentOps 4.0 is the Cathedral Cut: the product returns to one small trust
+AgentOps 3.3 is the Cathedral Cut: the product returns to one small trust
 boundary—shape one behavior, run one bounded experiment, validate the exact
 result from fresh context, persist the verdict, and stop. Git, CI, retries,
 queues, work ownership, closure, release, and delivery are caller-owned.
+This release removes public command surfaces despite the minor version
+number; read [docs/UPGRADING.md](https://github.com/boshu2/agentops/blob/main/docs/UPGRADING.md)
+before upgrading.
 
 ### Added
 
@@ -44,6 +26,13 @@ queues, work ownership, closure, release, and delivery are caller-owned.
   across portable, Claude, Codex, Gemini, Cursor, and Pi skill roots.
 - Structural conformance for the four-skill core, forbidden lifecycle authority,
   one-pass RPI sequencing, optional adapters, and inert command tombstones.
+- A deterministic `toil-mining` extractor for recent human-origin Codex JSONL
+  messages, with provenance, wrapper normalization, deduplication, exclusion
+  accounting, and explicit checked/not-checked scope.
+- Read-only `ao status` inventory for durable intent and verdict evidence,
+  including newest-evidence recency without runtime-phase inference.
+- One-shot MCP-backed `ms` search for environments without an attached MCP
+  tool, plus multi-report synthesis guidance in Research.
 
 ### Changed
 
@@ -58,6 +47,14 @@ queues, work ownership, closure, release, and delivery are caller-owned.
   work lifecycle, Git, or delivery.
 - New installations use one canonical checkout plus symlinks. Runtime plugin
   installers remain migration-only compatibility for this release.
+- Published `ao demo` now presents the packet-free one-pass loop; active docs,
+  templates, and smoke tests use caller-owned intent plus runtime-derived
+  subject evidence. The old Plan, Candidate, and revision schemas are labeled
+  deprecated compatibility formats.
+- `scripts/ms-reindex.sh` derives completeness from live
+  discovered/indexed/error accounting instead of a hard-coded corpus floor.
+- CASS guidance distinguishes authoritative rebuild fallback and timed-out
+  concurrent reads from empty results or source loss.
 
 ### Removed
 
@@ -84,7 +81,7 @@ queues, work ownership, closure, release, and delivery are caller-owned.
 - Scenario coverage is a caller-supplied static evidence check and no longer
   depends on beads, admission, tracker lookup, or lifecycle state.
 
-See [docs/4.0.md](https://github.com/boshu2/agentops/blob/main/docs/4.0.md) for
+See [docs/3.3.md](https://github.com/boshu2/agentops/blob/main/docs/3.3.md) for
 the release narrative and migration boundary.
 
 ## [3.2.0] - 2026-07-03

--- a/cli/cmd/ao/default_spine_test.go
+++ b/cli/cmd/ao/default_spine_test.go
@@ -17,6 +17,7 @@ var approvedDefaultSpine = map[string]bool{
 	"close": true, "governor": true, "yield": true, "claim": true,
 	"next-work": true, "state": true, "worktree": true, "validate": true,
 	"converge": true, "reconcile": true, "membrane": true, "crank": true,
+	"verify": true,
 }
 
 var approvedDefaultChildren = map[string]map[string]bool{

--- a/cli/cmd/ao/main.go
+++ b/cli/cmd/ao/main.go
@@ -3,9 +3,9 @@
 package main
 
 // version is set at build time via ldflags (goreleaser: -X main.version={{ .Version }}).
-// The fallback identifies untagged source builds for the next breaking release;
+// The fallback identifies untagged source builds for the next release;
 // published binaries override it from the release tag via GoReleaser.
-var version = "4.0.0-rc"
+var version = "3.3.0-rc"
 
 func main() {
 	Execute()

--- a/cli/cmd/ao/removed_command_hint.go
+++ b/cli/cmd/ao/removed_command_hint.go
@@ -41,6 +41,7 @@ var removedCommands = map[string]removedCommand{
 	"membrane":   {use: "admission was removed; record observations as verdict findings or generic provenance"},
 	"crank":      {use: "factory control was removed; call an executor directly or use optional `dispatch_once`"},
 	"constraint": {use: "AgentOps no longer promotes findings into blocking policy; encode accepted rules in repository-owned checks"},
+	"verify":     {use: "the 3.2 verification front door was removed; semantic judgment is the Validate skill. If `ao verify init` installed a pre-push hook, delete the AGENTOPS-VERIFY-RATCHET block from .git/hooks/pre-push (see docs/UPGRADING.md)"},
 }
 
 var removedChildCommands = map[string]map[string]removedCommand{
@@ -113,7 +114,7 @@ var cathedralCutCommands = map[string]struct{}{
 	"governor": {}, "yield": {}, "claim": {}, "next-work": {}, "state": {},
 	"worktree": {}, "validate": {}, "converge": {}, "reconcile": {},
 	"membrane": {}, "crank": {},
-	"constraint": {},
+	"constraint": {}, "verify": {},
 }
 
 // removedCommandHint returns the tombstone hint for an "unknown command"

--- a/cli/cmd/ao/zzz_default_spine.go
+++ b/cli/cmd/ao/zzz_default_spine.go
@@ -19,7 +19,7 @@ var defaultSpineCommands = map[string]struct{}{
 	"pawl": {}, "plan-pawl": {}, "land": {}, "done": {}, "close": {},
 	"governor": {}, "yield": {}, "claim": {}, "next-work": {}, "state": {},
 	"worktree": {}, "validate": {}, "converge": {}, "reconcile": {},
-	"membrane": {}, "crank": {},
+	"membrane": {}, "crank": {}, "verify": {},
 }
 
 // defaultChildSpineCommands removes legacy controller behavior nested under a

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -1044,6 +1044,16 @@ ao validate [flags]
 
 ---
 
+### `ao verify`
+
+Removed in the AgentOps Cathedral Cut
+
+```
+ao verify [flags]
+```
+
+---
+
 ### `ao worktree`
 
 Removed in the AgentOps Cathedral Cut

--- a/cli/internal/adapters/doctor/legacy.go
+++ b/cli/internal/adapters/doctor/legacy.go
@@ -72,7 +72,7 @@ func SystemLegacyChecks(toolVersion string, ledgerPath func() string) LegacyChec
 
 var runtimeSkillRoots = []string{".claude", ".codex", ".gemini", ".cursor", ".pi"}
 
-// CheckSkillLinks verifies the v4 distribution contract: canonical skills are
+// CheckSkillLinks verifies the source-linked distribution contract: canonical skills are
 // consumed directly from one checkout through exact symlinks. Portable
 // ~/.agents/skills is always checked; installed runtime roots are checked when
 // their config directory exists. Plugin caches are intentionally irrelevant.

--- a/cli/internal/adapters/doctor/legacy_test.go
+++ b/cli/internal/adapters/doctor/legacy_test.go
@@ -246,8 +246,8 @@ func TestBinaryFreshnessCheck(t *testing.T) {
 	if check := BinaryFreshnessCheck(t.TempDir(), "1.0.0"); check.Status != "pass" || !strings.Contains(check.Detail, "outside the agentops repo") {
 		t.Fatalf("outside-repo check = %+v", check)
 	}
-	rcRoot := makeFakeAgentopsRepo(t, "4.0.0-rc")
-	if check := BinaryFreshnessCheck(rcRoot, "4.0.0"); check.Status != "pass" || !strings.Contains(check.Detail, "release build") {
+	rcRoot := makeFakeAgentopsRepo(t, "3.3.0-rc")
+	if check := BinaryFreshnessCheck(rcRoot, "3.3.0"); check.Status != "pass" || !strings.Contains(check.Detail, "release build") {
 		t.Fatalf("release build against rc source = %+v", check)
 	}
 }

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/boshu2/agentops/cli/internal/storage"
 	"gopkg.in/yaml.v3"
@@ -418,7 +419,10 @@ func homeConfigPath() string {
 
 // legacyWarned tracks which legacy config paths already produced a
 // deprecation warning, so repeated loads in one process warn once per path.
-var legacyWarned = map[string]bool{}
+var (
+	legacyWarnedMu sync.Mutex
+	legacyWarned   = map[string]bool{}
+)
 
 // withLegacyFallback returns newPath when a file exists there. When it does
 // not and legacyPath holds a file, it returns legacyPath and warns once on
@@ -434,11 +438,20 @@ func withLegacyFallback(newPath, legacyPath string) string {
 	if _, err := os.Stat(legacyPath); err != nil {
 		return newPath
 	}
-	if !legacyWarned[legacyPath] {
-		legacyWarned[legacyPath] = true
-		fmt.Fprintf(os.Stderr, "Warning: reading deprecated config path %s; move it to %s\n", legacyPath, newPath)
-	}
+	warnLegacyConfigOnce(legacyPath, newPath)
 	return legacyPath
+}
+
+func warnLegacyConfigOnce(legacyPath, newPath string) {
+	legacyWarnedMu.Lock()
+	if legacyWarned[legacyPath] {
+		legacyWarnedMu.Unlock()
+		return
+	}
+	legacyWarned[legacyPath] = true
+	legacyWarnedMu.Unlock()
+
+	fmt.Fprintf(os.Stderr, "Warning: reading deprecated config path %s; move it to %s\n", legacyPath, newPath)
 }
 
 // homeConfigReadPath returns the home config path for reads, falling back to
@@ -458,17 +471,11 @@ func homeConfigReadPath() string {
 // back to the legacy ./.agentops/config.yaml location when the new path is
 // absent. An explicit AGENTOPS_CONFIG override is returned verbatim.
 func projectConfigReadPath() string {
-	if override := strings.TrimSpace(os.Getenv("AGENTOPS_CONFIG")); override != "" {
-		return override
+	newPath, legacyPath := projectConfigPaths()
+	if legacyPath == "" {
+		return newPath
 	}
-	cwd, err := getwdFunc()
-	if err != nil {
-		return ""
-	}
-	return withLegacyFallback(
-		filepath.Join(cwd, ".agents", "ao", "config.yaml"),
-		filepath.Join(cwd, ".agentops", "config.yaml"),
-	)
+	return withLegacyFallback(newPath, legacyPath)
 }
 
 // getwdFunc is the function used to get the current working directory.
@@ -477,14 +484,23 @@ var getwdFunc = os.Getwd
 
 // projectConfigPath returns the project config path.
 func projectConfigPath() string {
+	path, _ := projectConfigPaths()
+	return path
+}
+
+// projectConfigPaths returns the canonical write path and optional legacy read
+// fallback in one working-directory snapshot. An explicit AGENTOPS_CONFIG is
+// authoritative for both reads and writes and therefore has no fallback.
+func projectConfigPaths() (string, string) {
 	if override := strings.TrimSpace(os.Getenv("AGENTOPS_CONFIG")); override != "" {
-		return override
+		return override, ""
 	}
 	cwd, err := getwdFunc()
 	if err != nil {
-		return ""
+		return "", ""
 	}
-	return filepath.Join(cwd, ".agents", "ao", "config.yaml")
+	return filepath.Join(cwd, ".agents", "ao", "config.yaml"),
+		filepath.Join(cwd, ".agentops", "config.yaml")
 }
 
 // loadHomeConfig loads the home directory config, returning nil on error.
@@ -723,7 +739,7 @@ func mergePaths(dst, src *PathsConfig) {
 // Save writes the given config to the project config file.
 // It merges with existing config to preserve fields not being changed.
 func Save(cfg *Config) error {
-	path := projectConfigPath()
+	path, legacyPath := projectConfigPaths()
 	if path == "" {
 		return fmt.Errorf("determining project config path: could not resolve working directory")
 	}
@@ -734,7 +750,7 @@ func Save(cfg *Config) error {
 	}
 
 	return withConfigLock(path, func() error {
-		data, err := prepareSave(path, cfg)
+		data, err := prepareSave(path, legacyPath, cfg)
 		if err != nil {
 			return err
 		}
@@ -748,18 +764,22 @@ func Save(cfg *Config) error {
 // PreviewSave validates the exact read-merge-marshal path used by Save without
 // creating directories, locks, or files. A missing target is a valid new config.
 func PreviewSave(cfg *Config) error {
-	path := projectConfigPath()
+	path, legacyPath := projectConfigPaths()
 	if path == "" {
 		return fmt.Errorf("determining project config path: could not resolve working directory")
 	}
-	_, err := prepareSave(path, cfg)
+	_, err := prepareSave(path, legacyPath, cfg)
 	return err
 }
 
-func prepareSave(path string, cfg *Config) ([]byte, error) {
-	existing, err := loadFromPath(path)
+func prepareSave(path, legacyPath string, cfg *Config) ([]byte, error) {
+	readPath := path
+	if legacyPath != "" {
+		readPath = withLegacyFallback(path, legacyPath)
+	}
+	existing, err := loadFromPath(readPath)
 	if err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("loading existing config %s: %w", path, err)
+		return nil, fmt.Errorf("loading existing config %s: %w", readPath, err)
 	}
 	if existing != nil {
 		existing = merge(existing, cfg)

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -385,13 +385,13 @@ func Load(flagOverrides *Config) (*Config, error) {
 	}
 
 	// Load home config
-	homeConfig, _ := loadFromPath(homeConfigPath())
+	homeConfig, _ := loadFromPath(homeConfigReadPath())
 	if homeConfig != nil {
 		cfg = merge(cfg, homeConfig)
 	}
 
 	// Load project config
-	projectConfig, _ := loadFromPath(projectConfigPath())
+	projectConfig, _ := loadFromPath(projectConfigReadPath())
 	if projectConfig != nil {
 		cfg = merge(cfg, projectConfig)
 	}
@@ -416,6 +416,61 @@ func homeConfigPath() string {
 	return filepath.Join(home, ".agents", "ao", "config.yaml")
 }
 
+// legacyWarned tracks which legacy config paths already produced a
+// deprecation warning, so repeated loads in one process warn once per path.
+var legacyWarned = map[string]bool{}
+
+// withLegacyFallback returns newPath when a file exists there. When it does
+// not and legacyPath holds a file, it returns legacyPath and warns once on
+// stderr: the pre-3.3 `.agentops/` location is read-only compatibility for
+// this release. Writes (Save) always target the new path.
+func withLegacyFallback(newPath, legacyPath string) string {
+	if newPath == "" || legacyPath == "" {
+		return newPath
+	}
+	if _, err := os.Stat(newPath); err == nil {
+		return newPath
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		return newPath
+	}
+	if !legacyWarned[legacyPath] {
+		legacyWarned[legacyPath] = true
+		fmt.Fprintf(os.Stderr, "Warning: reading deprecated config path %s; move it to %s\n", legacyPath, newPath)
+	}
+	return legacyPath
+}
+
+// homeConfigReadPath returns the home config path for reads, falling back to
+// the legacy ~/.agentops/config.yaml location when the new path is absent.
+func homeConfigReadPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return withLegacyFallback(
+		filepath.Join(home, ".agents", "ao", "config.yaml"),
+		filepath.Join(home, ".agentops", "config.yaml"),
+	)
+}
+
+// projectConfigReadPath returns the project config path for reads, falling
+// back to the legacy ./.agentops/config.yaml location when the new path is
+// absent. An explicit AGENTOPS_CONFIG override is returned verbatim.
+func projectConfigReadPath() string {
+	if override := strings.TrimSpace(os.Getenv("AGENTOPS_CONFIG")); override != "" {
+		return override
+	}
+	cwd, err := getwdFunc()
+	if err != nil {
+		return ""
+	}
+	return withLegacyFallback(
+		filepath.Join(cwd, ".agents", "ao", "config.yaml"),
+		filepath.Join(cwd, ".agentops", "config.yaml"),
+	)
+}
+
 // getwdFunc is the function used to get the current working directory.
 // It can be overridden in tests to simulate os.Getwd failures.
 var getwdFunc = os.Getwd
@@ -434,13 +489,13 @@ func projectConfigPath() string {
 
 // loadHomeConfig loads the home directory config, returning nil on error.
 func loadHomeConfig() *Config {
-	cfg, _ := loadFromPath(homeConfigPath())
+	cfg, _ := loadFromPath(homeConfigReadPath())
 	return cfg
 }
 
 // loadProjectConfig loads the project config, returning nil on error.
 func loadProjectConfig() *Config {
-	cfg, _ := loadFromPath(projectConfigPath())
+	cfg, _ := loadFromPath(projectConfigReadPath())
 	return cfg
 }
 

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -2533,3 +2533,133 @@ func TestMerge_HarvestRoots(t *testing.T) {
 		t.Errorf("merge HarvestRoots[0] = %q, want %q", result.Paths.HarvestRoots[0], "/custom/root1")
 	}
 }
+
+// clearConfigEnv blanks the env vars that would otherwise leak into Load()
+// during legacy-fallback tests.
+func clearConfigEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("AGENTOPS_CONFIG", "")
+	t.Setenv("AGENTOPS_OUTPUT", "")
+	t.Setenv("AGENTOPS_BASE_DIR", "")
+	t.Setenv("AGENTOPS_VERBOSE", "")
+	t.Setenv("AGENTOPS_NO_SC", "")
+}
+
+// TestLoad_LegacyHomeConfigFallback pins the 3.3 migration contract: with no
+// config at ~/.agents/ao/config.yaml, a legacy ~/.agentops/config.yaml is
+// still read; once the new path exists it wins and the legacy file is ignored.
+func TestLoad_LegacyHomeConfigFallback(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir())
+
+	legacyDir := filepath.Join(home, ".agentops")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatalf("mkdir legacy cfg: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyDir, "config.yaml"), []byte("output: json\n"), 0o644); err != nil {
+		t.Fatalf("write legacy cfg: %v", err)
+	}
+
+	cfg, err := Load(nil)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Output != "json" {
+		t.Errorf("Output = %q, want %q (legacy ~/.agentops/config.yaml must be read when the new path is absent)", cfg.Output, "json")
+	}
+
+	// The new path, once present, wins and the legacy file is ignored.
+	newDir := filepath.Join(home, ".agents", "ao")
+	if err := os.MkdirAll(newDir, 0o755); err != nil {
+		t.Fatalf("mkdir new cfg: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(newDir, "config.yaml"), []byte("output: yaml\n"), 0o644); err != nil {
+		t.Fatalf("write new cfg: %v", err)
+	}
+	cfg, err = Load(nil)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Output != "yaml" {
+		t.Errorf("Output = %q, want %q (new path must win over legacy)", cfg.Output, "yaml")
+	}
+}
+
+// TestLoad_LegacyProjectConfigFallback pins the same contract for the
+// project layer: ./.agentops/config.yaml is read when ./.agents/ao/config.yaml
+// is absent, and the new path wins once present.
+func TestLoad_LegacyProjectConfigFallback(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	project := t.TempDir()
+	t.Chdir(project)
+
+	if err := os.MkdirAll(filepath.Join(project, ".agentops"), 0o755); err != nil {
+		t.Fatalf("mkdir legacy cfg: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".agentops", "config.yaml"), []byte("base_dir: /legacy/base\n"), 0o644); err != nil {
+		t.Fatalf("write legacy cfg: %v", err)
+	}
+
+	cfg, err := Load(nil)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.BaseDir != "/legacy/base" {
+		t.Errorf("BaseDir = %q, want %q (legacy ./.agentops/config.yaml must be read when the new path is absent)", cfg.BaseDir, "/legacy/base")
+	}
+
+	if err := os.MkdirAll(filepath.Join(project, ".agents", "ao"), 0o755); err != nil {
+		t.Fatalf("mkdir new cfg: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".agents", "ao", "config.yaml"), []byte("base_dir: /new/base\n"), 0o644); err != nil {
+		t.Fatalf("write new cfg: %v", err)
+	}
+	cfg, err = Load(nil)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.BaseDir != "/new/base" {
+		t.Errorf("BaseDir = %q, want %q (new path must win over legacy)", cfg.BaseDir, "/new/base")
+	}
+}
+
+// TestSave_WritesNewPathNotLegacy pins that writes never target the legacy
+// location: Save with only ./.agentops/config.yaml present creates
+// ./.agents/ao/config.yaml and leaves the legacy file untouched.
+func TestSave_WritesNewPathNotLegacy(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	project := t.TempDir()
+	t.Chdir(project)
+
+	legacy := filepath.Join(project, ".agentops", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
+		t.Fatalf("mkdir legacy cfg: %v", err)
+	}
+	if err := os.WriteFile(legacy, []byte("output: json\n"), 0o644); err != nil {
+		t.Fatalf("write legacy cfg: %v", err)
+	}
+
+	if err := Save(&Config{Output: "yaml"}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	newPath := filepath.Join(project, ".agents", "ao", "config.yaml")
+	data, err := os.ReadFile(newPath)
+	if err != nil {
+		t.Fatalf("Save must write the new path %s: %v", newPath, err)
+	}
+	if !strings.Contains(string(data), "output: yaml") {
+		t.Errorf("new config = %q, want it to contain %q", string(data), "output: yaml")
+	}
+	legacyData, err := os.ReadFile(legacy)
+	if err != nil {
+		t.Fatalf("legacy config must remain untouched: %v", err)
+	}
+	if string(legacyData) != "output: json\n" {
+		t.Errorf("legacy config mutated to %q; Save must not write the legacy path", string(legacyData))
+	}
+}

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -2545,11 +2545,95 @@ func clearConfigEnv(t *testing.T) {
 	t.Setenv("AGENTOPS_NO_SC", "")
 }
 
+func isolateLegacyWarnings(t *testing.T) {
+	t.Helper()
+	legacyWarnedMu.Lock()
+	previous := legacyWarned
+	legacyWarned = map[string]bool{}
+	legacyWarnedMu.Unlock()
+	t.Cleanup(func() {
+		legacyWarnedMu.Lock()
+		legacyWarned = previous
+		legacyWarnedMu.Unlock()
+	})
+}
+
+func TestWithLegacyFallback_WarnsOncePerPathConcurrently(t *testing.T) {
+	isolateLegacyWarnings(t)
+	root := t.TempDir()
+	firstNew := filepath.Join(root, "first", ".agents", "ao", "config.yaml")
+	firstLegacy := filepath.Join(root, "first", ".agentops", "config.yaml")
+	secondNew := filepath.Join(root, "second", ".agents", "ao", "config.yaml")
+	secondLegacy := filepath.Join(root, "second", ".agentops", "config.yaml")
+	for _, path := range []string{firstLegacy, secondLegacy} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir legacy config dir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte("output: json\n"), 0o644); err != nil {
+			t.Fatalf("write legacy config: %v", err)
+		}
+	}
+
+	originalStderr := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+	os.Stderr = writer
+	t.Cleanup(func() {
+		os.Stderr = originalStderr
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+
+	const readers = 32
+	results := make(chan string, readers)
+	start := make(chan struct{})
+	var group sync.WaitGroup
+	for range readers {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			<-start
+			results <- withLegacyFallback(firstNew, firstLegacy)
+		}()
+	}
+	close(start)
+	group.Wait()
+	close(results)
+	for got := range results {
+		if got != firstLegacy {
+			t.Errorf("withLegacyFallback() = %q, want %q", got, firstLegacy)
+		}
+	}
+	if got := withLegacyFallback(secondNew, secondLegacy); got != secondLegacy {
+		t.Errorf("second withLegacyFallback() = %q, want %q", got, secondLegacy)
+	}
+	if got := withLegacyFallback(secondNew, secondLegacy); got != secondLegacy {
+		t.Errorf("repeated second withLegacyFallback() = %q, want %q", got, secondLegacy)
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	os.Stderr = originalStderr
+	warnings, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read warnings: %v", err)
+	}
+	want := "Warning: reading deprecated config path " + firstLegacy + "; move it to " + firstNew + "\n" +
+		"Warning: reading deprecated config path " + secondLegacy + "; move it to " + secondNew + "\n"
+	if string(warnings) != want {
+		t.Errorf("legacy warnings = %q, want %q", string(warnings), want)
+	}
+}
+
 // TestLoad_LegacyHomeConfigFallback pins the 3.3 migration contract: with no
 // config at ~/.agents/ao/config.yaml, a legacy ~/.agentops/config.yaml is
 // still read; once the new path exists it wins and the legacy file is ignored.
 func TestLoad_LegacyHomeConfigFallback(t *testing.T) {
 	clearConfigEnv(t)
+	isolateLegacyWarnings(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Chdir(t.TempDir())
@@ -2592,6 +2676,7 @@ func TestLoad_LegacyHomeConfigFallback(t *testing.T) {
 // is absent, and the new path wins once present.
 func TestLoad_LegacyProjectConfigFallback(t *testing.T) {
 	clearConfigEnv(t)
+	isolateLegacyWarnings(t)
 	t.Setenv("HOME", t.TempDir())
 	project := t.TempDir()
 	t.Chdir(project)
@@ -2626,11 +2711,13 @@ func TestLoad_LegacyProjectConfigFallback(t *testing.T) {
 	}
 }
 
-// TestSave_WritesNewPathNotLegacy pins that writes never target the legacy
-// location: Save with only ./.agentops/config.yaml present creates
-// ./.agents/ao/config.yaml and leaves the legacy file untouched.
-func TestSave_WritesNewPathNotLegacy(t *testing.T) {
+// TestSave_MigratesLegacyProjectConfigToNewPath pins that the first write after
+// upgrading preserves fields from the legacy project config while writing only
+// the new path. The new file becomes authoritative immediately, so failing to
+// merge the legacy bytes would silently reset every field not in the update.
+func TestSave_MigratesLegacyProjectConfigToNewPath(t *testing.T) {
 	clearConfigEnv(t)
+	isolateLegacyWarnings(t)
 	t.Setenv("HOME", t.TempDir())
 	project := t.TempDir()
 	t.Chdir(project)
@@ -2639,27 +2726,44 @@ func TestSave_WritesNewPathNotLegacy(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
 		t.Fatalf("mkdir legacy cfg: %v", err)
 	}
-	if err := os.WriteFile(legacy, []byte("output: json\n"), 0o644); err != nil {
+	legacyBody := "output: json\nbase_dir: /legacy/base\n"
+	if err := os.WriteFile(legacy, []byte(legacyBody), 0o644); err != nil {
 		t.Fatalf("write legacy cfg: %v", err)
 	}
 
-	if err := Save(&Config{Output: "yaml"}); err != nil {
+	if err := Save(&Config{Models: ModelsConfig{DefaultTier: "quality"}}); err != nil {
 		t.Fatalf("Save() error = %v", err)
 	}
 
 	newPath := filepath.Join(project, ".agents", "ao", "config.yaml")
-	data, err := os.ReadFile(newPath)
+	newConfig, err := loadFromPath(newPath)
 	if err != nil {
-		t.Fatalf("Save must write the new path %s: %v", newPath, err)
+		t.Fatalf("load new config %s: %v", newPath, err)
 	}
-	if !strings.Contains(string(data), "output: yaml") {
-		t.Errorf("new config = %q, want it to contain %q", string(data), "output: yaml")
+	if newConfig.Output != "json" {
+		t.Errorf("new config Output = %q, want %q preserved from legacy", newConfig.Output, "json")
+	}
+	if newConfig.BaseDir != "/legacy/base" {
+		t.Errorf("new config BaseDir = %q, want %q preserved from legacy", newConfig.BaseDir, "/legacy/base")
+	}
+	if newConfig.Models.DefaultTier != "quality" {
+		t.Errorf("new config Models.DefaultTier = %q, want %q from update", newConfig.Models.DefaultTier, "quality")
 	}
 	legacyData, err := os.ReadFile(legacy)
 	if err != nil {
 		t.Fatalf("legacy config must remain untouched: %v", err)
 	}
-	if string(legacyData) != "output: json\n" {
+	if string(legacyData) != legacyBody {
 		t.Errorf("legacy config mutated to %q; Save must not write the legacy path", string(legacyData))
+	}
+
+	effective, err := Load(nil)
+	if err != nil {
+		t.Fatalf("Load() after Save error = %v", err)
+	}
+	if effective.Output != "json" || effective.BaseDir != "/legacy/base" || effective.Models.DefaultTier != "quality" {
+		t.Errorf("effective config after Save = Output %q, BaseDir %q, Models.DefaultTier %q; want %q, %q, %q",
+			effective.Output, effective.BaseDir, effective.Models.DefaultTier,
+			"json", "/legacy/base", "quality")
 	}
 }

--- a/docs/3.3.md
+++ b/docs/3.3.md
@@ -1,4 +1,4 @@
-# AgentOps 4.0: The Cathedral Cut
+# AgentOps 3.3: The Cathedral Cut
 
 AgentOps 3.2 tried to make validation inescapable by owning the path around it.
 That turned a useful trust boundary into a control plane: retries, queues, work
@@ -7,7 +7,7 @@ one fresh-context review. The result was correct-looking gridlock. Validation
 often took longer than implementation, and moving `main` repeatedly invalidated
 expensive proof.
 
-Version 4.0 removes that control plane.
+Version 3.3 removes that control plane.
 
 ```text
 RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,33 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+## [3.3.0] - 2026-07-17
 
-- A deterministic `toil-mining` extractor for recent human-origin Codex JSONL
-  messages, with provenance, wrapper normalization, deduplication, exclusion
-  accounting, and explicit checked/not-checked scope.
-- Read-only `ao status` inventory for durable intent and verdict evidence,
-  including newest-evidence recency without runtime-phase inference.
-- One-shot MCP-backed `ms` search for environments without an attached MCP
-  tool, plus multi-report synthesis guidance in Research.
-
-### Changed
-
-- Published `ao demo` now presents the packet-free one-pass loop; active docs,
-  templates, and smoke tests use caller-owned intent plus runtime-derived
-  subject evidence. The old Plan, Candidate, and revision schemas are labeled
-  deprecated compatibility formats.
-- `scripts/ms-reindex.sh` derives completeness from live
-  discovered/indexed/error accounting instead of a hard-coded corpus floor.
-- CASS guidance distinguishes authoritative rebuild fallback and timed-out
-  concurrent reads from empty results or source loss.
-
-## [4.0.0] - 2026-07-15
-
-AgentOps 4.0 is the Cathedral Cut: the product returns to one small trust
+AgentOps 3.3 is the Cathedral Cut: the product returns to one small trust
 boundary—shape one behavior, run one bounded experiment, validate the exact
 result from fresh context, persist the verdict, and stop. Git, CI, retries,
 queues, work ownership, closure, release, and delivery are caller-owned.
+This release removes public command surfaces despite the minor version
+number; read [docs/UPGRADING.md](https://github.com/boshu2/agentops/blob/main/docs/UPGRADING.md)
+before upgrading.
 
 ### Added
 
@@ -44,6 +26,13 @@ queues, work ownership, closure, release, and delivery are caller-owned.
   across portable, Claude, Codex, Gemini, Cursor, and Pi skill roots.
 - Structural conformance for the four-skill core, forbidden lifecycle authority,
   one-pass RPI sequencing, optional adapters, and inert command tombstones.
+- A deterministic `toil-mining` extractor for recent human-origin Codex JSONL
+  messages, with provenance, wrapper normalization, deduplication, exclusion
+  accounting, and explicit checked/not-checked scope.
+- Read-only `ao status` inventory for durable intent and verdict evidence,
+  including newest-evidence recency without runtime-phase inference.
+- One-shot MCP-backed `ms` search for environments without an attached MCP
+  tool, plus multi-report synthesis guidance in Research.
 
 ### Changed
 
@@ -58,6 +47,14 @@ queues, work ownership, closure, release, and delivery are caller-owned.
   work lifecycle, Git, or delivery.
 - New installations use one canonical checkout plus symlinks. Runtime plugin
   installers remain migration-only compatibility for this release.
+- Published `ao demo` now presents the packet-free one-pass loop; active docs,
+  templates, and smoke tests use caller-owned intent plus runtime-derived
+  subject evidence. The old Plan, Candidate, and revision schemas are labeled
+  deprecated compatibility formats.
+- `scripts/ms-reindex.sh` derives completeness from live
+  discovered/indexed/error accounting instead of a hard-coded corpus floor.
+- CASS guidance distinguishes authoritative rebuild fallback and timed-out
+  concurrent reads from empty results or source loss.
 
 ### Removed
 
@@ -84,7 +81,7 @@ queues, work ownership, closure, release, and delivery are caller-owned.
 - Scenario coverage is a caller-supplied static evidence check and no longer
   depends on beads, admission, tracker lookup, or lifecycle state.
 
-See [docs/4.0.md](https://github.com/boshu2/agentops/blob/main/docs/4.0.md) for
+See [docs/3.3.md](https://github.com/boshu2/agentops/blob/main/docs/3.3.md) for
 the release narrative and migration boundary.
 
 ## [3.2.0] - 2026-07-03

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -30,9 +30,30 @@ under `ao gate check`; semantic judgment is the Validate skill.
 | `ao skills edit` | Edit canonical `skills/<slug>/` sources directly; use normal repository Git policy outside `ao`. |
 | `ao goals trace` | Inspect current goal/scenario artifacts directly; the retired directive-to-bead lifecycle chain has no replacement. |
 | `ao session memory` | Use caller-authored `ao session handoff` evidence or maintain repository memory through the caller's own policy. |
+| `ao verify` | Use the Validate skill for semantic judgment and `ao gate check` for deterministic checks. Delete any `ao verify init` pre-push ratchet from `.git/hooks/pre-push` (restore `pre-push.agentops-orig` if one was set aside); `ao verify init --remove` no longer exists, and `git push --no-verify` bypasses a stale hook once. |
 
 These major public names have inert, nonzero-exit tombstones for this cut
 release only. They do not forward to old code or mutate old state.
+
+Other 3.2 bookkeeping and knowledge verbs (`ao beads`, `ao agents`, `ao canon`,
+`ao ci`, `ao citation`, `ao eval`, `ao findings`, `ao forge`, `ao knowledge`,
+`ao mcp`, `ao metrics`, `ao notebook`, `ao patterns`, `ao pool`, `ao ratchet`,
+`ao registry`, `ao scope`, `ao sessions`, `ao wiki`) were pruned from the
+default build without tombstones. They have no replacement inside AgentOps; use
+the caller's own tools, `ao gate check` for deterministic checks, or generic
+`ao provenance` records.
+
+## Config file location
+
+`~/.agentops/config.yaml` and `./.agentops/config.yaml` moved to
+`~/.agents/ao/config.yaml` and `./.agents/ao/config.yaml`. The legacy paths are
+still read as a fallback for this release (with a deprecation warning on
+stderr) when no file exists at the new path; move the file to silence the
+warning:
+
+```bash
+mkdir -p ~/.agents/ao && mv ~/.agentops/config.yaml ~/.agents/ao/config.yaml
+```
 
 ## Skills
 
@@ -60,7 +81,7 @@ outcomes.
 
 ## Install migration
 
-AgentOps 4 uses one canonical checkout plus source symlinks. A plugin cache is
+AgentOps 3.3 uses one canonical checkout plus source symlinks. A plugin cache is
 not part of the active skill path.
 
 ```bash

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,10 +1,25 @@
 # Upgrading
 
-This page contains the action required for the AgentOps 4.0 Cathedral Cut. The
+This page contains the action required for the AgentOps 3.3 Cathedral Cut. The
 full history remains in [the changelog](CHANGELOG.md); the exact removed-command
 map is in [the migration guide](MIGRATION.md).
 
-## Upgrade to 4.0
+## Upgrade to 3.3
+
+AgentOps 3.3 removes public command surfaces despite the minor version number.
+Three actions prevent broken workflows after upgrading:
+
+1. **Remove the 3.2 pre-push verify hook.** If you ever ran `ao verify init`
+   in a repository, delete the `AGENTOPS-VERIFY-RATCHET` block from that
+   repository's `.git/hooks/pre-push` (restore `pre-push.agentops-orig` if one
+   was set aside). The hook calls removed commands and blocks every push with a
+   misleading "ao too old" error; `ao verify init --remove` no longer exists.
+   `git push --no-verify` bypasses it once.
+2. **Move your config file.** `~/.agentops/config.yaml` and
+   `./.agentops/config.yaml` moved to `~/.agents/ao/config.yaml` and
+   `./.agents/ao/config.yaml`. Legacy paths are still read as a fallback for
+   this release, with a deprecation warning.
+3. **Replace plugin installs with source links** (next section).
 
 The semantic loop is now:
 
@@ -47,7 +62,7 @@ directories or foreign symlinks.
 
 Removed lifecycle commands return nonzero, non-mutating tombstones for this
 release. They never forward to old implementations. Update integrations now;
-the tombstones are removed in the next major release.
+the tombstones are removed in the next release.
 
 Use:
 
@@ -73,4 +88,4 @@ influence current phase sequencing or verdict validity.
 The 3.x and 2.x migration record is historical. Read
 [MIGRATION-3.0.md](MIGRATION-3.0.md) and the versioned entries in
 [CHANGELOG.md](CHANGELOG.md) when maintaining an old installation; do not apply
-those old controller, daemon, hook, tracker, or plugin instructions to 4.0.
+those old controller, daemon, hook, tracker, or plugin instructions to 3.3.

--- a/docs/cli-surface.json
+++ b/docs/cli-surface.json
@@ -485,11 +485,11 @@
       "reason": "One-release failure stub for removed semantic CLI validation."
     },
     {
-      "category": "public-tested",
+      "category": "deprecated",
       "command": "verify",
-      "coverage_status": "covered",
+      "coverage_status": "allowlisted",
       "kind": "leaf",
-      "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
+      "reason": "One-release failure stub for removed 3.2 verification front door."
     },
     {
       "category": "public-tested",

--- a/docs/cli-surface.json
+++ b/docs/cli-surface.json
@@ -486,6 +486,13 @@
     },
     {
       "category": "public-tested",
+      "command": "verify",
+      "coverage_status": "covered",
+      "kind": "leaf",
+      "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
+    },
+    {
+      "category": "public-tested",
       "command": "version",
       "coverage_status": "covered",
       "kind": "leaf",

--- a/docs/cli-surface.md
+++ b/docs/cli-surface.md
@@ -73,6 +73,7 @@
 | `ao state` | `deprecated` | `allowlisted` | One-release failure stub for removed lifecycle admission. |
 | `ao status` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao validate` | `deprecated` | `allowlisted` | One-release failure stub for removed semantic CLI validation. |
+| `ao verify` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao version` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao worktree` | `deprecated` | `allowlisted` | One-release failure stub for removed Git mutation. |
 | `ao yield` | `deprecated` | `allowlisted` | One-release failure stub for removed throughput control. |

--- a/docs/cli-surface.md
+++ b/docs/cli-surface.md
@@ -73,7 +73,7 @@
 | `ao state` | `deprecated` | `allowlisted` | One-release failure stub for removed lifecycle admission. |
 | `ao status` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao validate` | `deprecated` | `allowlisted` | One-release failure stub for removed semantic CLI validation. |
-| `ao verify` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
+| `ao verify` | `deprecated` | `allowlisted` | One-release failure stub for removed 3.2 verification front door. |
 | `ao version` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao worktree` | `deprecated` | `allowlisted` | One-release failure stub for removed Git mutation. |
 | `ao yield` | `deprecated` | `allowlisted` | One-release failure stub for removed throughput control. |

--- a/docs/install-day2-ops.md
+++ b/docs/install-day2-ops.md
@@ -1,6 +1,6 @@
 # Install And Day-2 Operations
 
-AgentOps 4 uses one canonical checkout and source symlinks. The checkout is the
+AgentOps 3.3 uses one canonical checkout and source symlinks. The checkout is the
 source of truth; runtime plugin caches and copied skill mirrors are not part of
 the active path.
 

--- a/docs/profiles/README.md
+++ b/docs/profiles/README.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Organize 12 domain skills into 3 discoverable profiles for different work contexts.
 
-**Version**: 4.0.0 (Updated for skills-based approach)
+**Version**: 3.3.0 (Updated for skills-based approach)
 
 ---
 

--- a/docs/profiles/roles/content-creation.yaml
+++ b/docs/profiles/roles/content-creation.yaml
@@ -2,7 +2,7 @@
 # Documentation, writing, research, pattern extraction, tutorials
 
 name: content-creation
-version: 4.0.0
+version: 3.3.0
 description: |
   Content creation, research, and knowledge synthesis. Write documentation (technical
   and non-technical), extract patterns from completed work, conduct research and

--- a/docs/profiles/roles/platform-ops.yaml
+++ b/docs/profiles/roles/platform-ops.yaml
@@ -2,7 +2,7 @@
 # SRE, DevOps, infrastructure, monitoring, incidents, reliability
 
 name: platform-ops
-version: 4.0.0
+version: 3.3.0
 description: |
   Platform operations and site reliability engineering. Respond to production incidents,
   monitor system health and performance, debug errors, analyze logs, manage security

--- a/docs/profiles/roles/software-dev.yaml
+++ b/docs/profiles/roles/software-dev.yaml
@@ -2,7 +2,7 @@
 # Full-stack development, backend, frontend, APIs, applications
 
 name: software-dev
-version: 4.0.0
+version: 3.3.0
 description: |
   Software development across the stack. Build applications (backend APIs, frontends,
   full-stack features), write code in Python, Go, Rust, TypeScript, Java, review code,

--- a/docs/releases/2026-07-17-v3.3.0-notes.md
+++ b/docs/releases/2026-07-17-v3.3.0-notes.md
@@ -1,16 +1,29 @@
 ## Highlights
 
-AgentOps 4.0 is the Cathedral Cut. It restores the original trust boundary:
+AgentOps 3.3 is the Cathedral Cut. It restores the original trust boundary:
 shape one behavior, run one bounded experiment, validate the exact candidate
 from fresh context, persist the verdict, and stop. The release removes the
 control plane that made Git delivery, retries, queues, and closure part of
 AgentOps correctness.
 
+This release removes public command surfaces despite the minor version number
+— a knowing semver deviation while the 3.x audience is small. Read the
+Breaking Changes section and [docs/UPGRADING.md](../UPGRADING.md) before
+upgrading.
+
 ## Upgrade Notes
 
+- If you ever ran `ao verify init`, delete the `AGENTOPS-VERIFY-RATCHET` block
+  from that repository's `.git/hooks/pre-push` (restore `pre-push.agentops-orig`
+  if one was set aside). The 3.2 hook calls removed commands and blocks every
+  push with a misleading "ao too old" error; `ao verify init --remove` no
+  longer exists.
+- Move `~/.agentops/config.yaml` (and any `./.agentops/config.yaml`) to
+  `~/.agents/ao/config.yaml` / `./.agents/ao/config.yaml`. Legacy paths are
+  still read as a fallback for this release, with a deprecation warning.
 - Remove old runtime plugin installs, keep one canonical checkout, and run
   `ao skills link`; see [the migration guide](../MIGRATION.md).
-- Replace folded skills and removed CLI lifecycle commands before the next major
+- Replace folded skills and removed CLI lifecycle commands before the next
   release removes their one-release tombstones.
 - Migrate verdict consumers to `verdict.v2` and `subject-manifest.v1`.
 
@@ -125,6 +138,6 @@ AgentOps correctness.
 
 - Removed command tombstones and legacy plugin installers intentionally remain
   for one migration release. They are compatibility notices, not live control
-  paths, and are scheduled for deletion in the next major release.
+  paths, and are scheduled for deletion in the next release.
 
 [Full changelog](../../CHANGELOG.md)

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=35 sub=44 all=79"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=36 sub=44 all=80"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/distribution-install-update.json
+++ b/evals/agentops-core/distribution-install-update.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "id": "agentops-core.distribution-install-update",
   "name": "AgentOps Distribution Install and Update Canary",
-  "description": "Offline public canary for the AgentOps 4 install surface (ao skills link), release bundle coherence, Windows ao installer smoke wiring, and public install docs.",
+  "description": "Offline public canary for the AgentOps 3.3 install surface (ao skills link), release bundle coherence, Windows ao installer smoke wiring, and public install docs.",
   "practices": ["llm-eval-harness", "ai-assisted-dev"],
   "domain": "mixed",
   "visibility": "public_canary",

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,4} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "35" || "$sub_count" != "44" || "$all_count" != "79" ]]; then
+if [[ "$top_count" != "36" || "$sub_count" != "44" || "$all_count" != "80" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 79 ]]; then
+if [[ "${#commands[@]}" -ne 80 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/images/claude/verify.sh
+++ b/images/claude/verify.sh
@@ -58,7 +58,7 @@ fi
 # Version guard: the Claude marketplace plugin manifest is the install entrypoint
 # for this image. Assert .claude-plugin/plugin.json declares the expected version
 # so a stale-version drift (plugin.json behind the release) fails the gate.
-EXPECTED_VERSION="${AGENTOPS_EXPECTED_VERSION:-4.0.0}"
+EXPECTED_VERSION="${AGENTOPS_EXPECTED_VERSION:-3.3.0}"
 plugin_manifest="$repo_root/.claude-plugin/plugin.json"
 if [ ! -f "$plugin_manifest" ]; then
   echo "FAIL: Claude plugin manifest not found: $plugin_manifest" >&2

--- a/images/gemini/plugin.json
+++ b/images/gemini/plugin.json
@@ -13,5 +13,5 @@
   "name": "agentops-core-gemini",
   "rules": "./rules",
   "skills": "./skills",
-  "version": "4.0.0"
+  "version": "3.3.0"
 }

--- a/scripts/cmdao-surface-allowlist.txt
+++ b/scripts/cmdao-surface-allowlist.txt
@@ -48,6 +48,7 @@ deprecated|next-work|One-release failure stub for removed work selection.
 deprecated|state|One-release failure stub for removed lifecycle admission.
 deprecated|worktree|One-release failure stub for removed Git mutation.
 deprecated|validate|One-release failure stub for removed semantic CLI validation.
+deprecated|verify|One-release failure stub for removed 3.2 verification front door.
 deprecated|converge|One-release failure stub for removed retry convergence.
 deprecated|reconcile|One-release failure stub for removed lifecycle reconciliation.
 deprecated|membrane|One-release failure stub for removed admission behavior.

--- a/scripts/install-agy.sh
+++ b/scripts/install-agy.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Tombstone: AgentOps 4 removed the 3.x runtime plugin installers.
+# Tombstone: AgentOps 3.3 removed the legacy runtime plugin installers.
 # Canonical install: one checkout + `ao skills link` (see docs/MIGRATION.md).
 set -euo pipefail
 cat >&2 <<'MSG'
-This AgentOps installer was removed in 4.x.
+This AgentOps installer was removed in 3.3.
 
 New installs:
   brew tap boshu2/agentops https://github.com/boshu2/homebrew-agentops

--- a/scripts/install-claude.sh
+++ b/scripts/install-claude.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Tombstone: AgentOps 4 removed the 3.x runtime plugin installers.
+# Tombstone: AgentOps 3.3 removed the legacy runtime plugin installers.
 # Canonical install: one checkout + `ao skills link` (see docs/MIGRATION.md).
 set -euo pipefail
 cat >&2 <<'MSG'
-This AgentOps installer was removed in 4.x.
+This AgentOps installer was removed in 3.3.
 
 New installs:
   brew tap boshu2/agentops https://github.com/boshu2/homebrew-agentops

--- a/scripts/install-codex.ps1
+++ b/scripts/install-codex.ps1
@@ -1,8 +1,8 @@
-# Tombstone: AgentOps 4 removed the 3.x Codex plugin installer.
+# Tombstone: AgentOps 3.3 removed the legacy Codex plugin installer.
 # Canonical install: one checkout + `ao skills link` (see docs/MIGRATION.md).
 $ErrorActionPreference = "Stop"
 Write-Error @"
-This AgentOps installer was removed in 4.x.
+This AgentOps installer was removed in 3.3.
 
 New installs:
   git clone https://github.com/boshu2/agentops.git `$HOME\.local\share\agentops

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Tombstone: AgentOps 4 removed the 3.x runtime plugin installers.
+# Tombstone: AgentOps 3.3 removed the legacy runtime plugin installers.
 # Canonical install: one checkout + `ao skills link` (see docs/MIGRATION.md).
 set -euo pipefail
 cat >&2 <<'MSG'
-This AgentOps installer was removed in 4.x.
+This AgentOps installer was removed in 3.3.
 
 New installs:
   brew tap boshu2/agentops https://github.com/boshu2/homebrew-agentops

--- a/scripts/install-opencode.sh
+++ b/scripts/install-opencode.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Tombstone: AgentOps 4 removed the 3.x runtime plugin installers.
+# Tombstone: AgentOps 3.3 removed the legacy runtime plugin installers.
 # Canonical install: one checkout + `ao skills link` (see docs/MIGRATION.md).
 set -euo pipefail
 cat >&2 <<'MSG'
-This AgentOps installer was removed in 4.x.
+This AgentOps installer was removed in 3.3.
 
 New installs:
   brew tap boshu2/agentops https://github.com/boshu2/homebrew-agentops

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Tombstone: AgentOps 4 removed the 3.x runtime plugin installers.
+# Tombstone: AgentOps 3.3 removed the legacy runtime plugin installers.
 # Canonical install: one checkout + `ao skills link` (see docs/MIGRATION.md).
 set -euo pipefail
 cat >&2 <<'MSG'
-This AgentOps installer was removed in 4.x.
+This AgentOps installer was removed in 3.3.
 
 New installs:
   brew tap boshu2/agentops https://github.com/boshu2/homebrew-agentops

--- a/scripts/refresh-codex-local.sh
+++ b/scripts/refresh-codex-local.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # refresh-codex-local.sh — thin compatibility wrapper.
-# AgentOps 4 uses source links, not a Codex plugin cache refresh.
+# AgentOps 3.3 uses source links, not a Codex plugin cache refresh.
 # Prefer: ao skills link
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/release-smoke-test.sh
+++ b/scripts/release-smoke-test.sh
@@ -92,8 +92,8 @@ run_json "provenance list JSON" bash -c "cd '$TMP_ROOT' && '$AO' provenance list
 run_json "source-link dry-run JSON" env HOME="$TMP_ROOT/home" "$AO" skills link --dest "$TMP_ROOT/skills" --dry-run --json
 
 for command in \
-  claim close constraint converge crank done governor land membrane next-work \
-  pawl plan-pawl reconcile state validate worktree yield; do
+  claim close constraint converge crank "done" governor land membrane next-work \
+  pawl plan-pawl reconcile state validate verify worktree yield; do
   run_tombstone "ao $command tombstone" "$AO" "$command"
 done
 run_tombstone "ao goals trace tombstone" "$AO" goals trace

--- a/scripts/release-smoke-test.sh
+++ b/scripts/release-smoke-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Release smoke for the retained AgentOps 4 CLI surface.
+# Release smoke for the retained AgentOps 3.3 CLI surface.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/validate-headless-runtime-skills.sh
+++ b/scripts/validate-headless-runtime-skills.sh
@@ -398,7 +398,7 @@ run_codex_validation() {
     fi
 
     mkdir -p "$CODEX_USER_HOME" "$CODEX_VALIDATION_HOME/skills"
-    # AgentOps 4: source-link skills into the isolated Codex skills root.
+    # AgentOps 3.3: source-link skills into the isolated Codex skills root.
     local ao_bin=""
     if [[ -x "$REPO_ROOT/cli/bin/ao" ]]; then
       ao_bin="$REPO_ROOT/cli/bin/ao"

--- a/tests/install/test-install-smoke.sh
+++ b/tests/install/test-install-smoke.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Smoke tests for install surfaces — validates syntax and the canonical
-# AgentOps 4 install path (ao skills link). Legacy 3.x plugin installers are
+# AgentOps 3.3 install path (ao skills link). Legacy 3.x plugin installers are
 # retained only as tombstones that exit nonzero with migration guidance.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -69,7 +69,7 @@ TOMBSTONES=(
 for script in "${TOMBSTONES[@]}"; do
     check "$script syntax valid" bash -n "$REPO_ROOT/$script"
     check "$script is a removed-installer tombstone" \
-        grep -q 'removed in 4' "$REPO_ROOT/$script"
+        grep -q 'removed in 3.3' "$REPO_ROOT/$script"
     check "$script points at ao skills link" \
         grep -q 'ao skills link' "$REPO_ROOT/$script"
     # Must exit nonzero (migration refusal).

--- a/tests/integration/test-cli-commands.sh
+++ b/tests/integration/test-cli-commands.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Functional subprocess smoke for the retained AgentOps 4 CLI.
+# Functional subprocess smoke for the retained AgentOps 3.3 CLI.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/tests/skills/test-runtime-codex-smoke.sh
+++ b/tests/skills/test-runtime-codex-smoke.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Test: Codex runtime smoke — validates AgentOps 4 source-link install under
+# Test: Codex runtime smoke — validates AgentOps 3.3 source-link install under
 # an isolated HOME (ao skills link → ~/.codex/skills). Standalone: no live
 # Codex session or network required.
 set -euo pipefail

--- a/tests/windows/test-windows-smoke.ps1
+++ b/tests/windows/test-windows-smoke.ps1
@@ -138,8 +138,8 @@ Test-PowerShellSyntax (Join-PathSegments -Base $RepoRoot -Segments 'scripts', 'i
 $codexTombstone = Join-PathSegments -Base $RepoRoot -Segments 'scripts', 'install-codex.ps1'
 Test-PowerShellSyntax $codexTombstone
 $tombstoneText = Get-Content -Raw -LiteralPath $codexTombstone
-if ($tombstoneText -notmatch 'removed in 4' -or $tombstoneText -notmatch 'ao skills link') {
-  throw "install-codex.ps1 must remain an AgentOps 4 tombstone pointing at ao skills link"
+if ($tombstoneText -notmatch 'removed in 3\.3' -or $tombstoneText -notmatch 'ao skills link') {
+  throw "install-codex.ps1 must remain an AgentOps 3.3 tombstone pointing at ao skills link"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Re-badges the unpublished 4.0 "Cathedral Cut" release as **v3.3.0** and fixes the two worst 3.2→3.3 upgrade traps so the release is humane to ship. Two commits: the version re-badge, and the upgrade-path fixes. No tag is pushed — tagging `v3.3.0` stays a manual decision after this merges.

**Re-badge (commit 1):**
- Changelog: `[Unreleased]` folded into a new `## [3.3.0] - 2026-07-17` section (root + `docs/` mirror, both required by the doc-release gate); narrative states plainly that this minor removes public surfaces
- `docs/4.0.md` → `docs/3.3.md`; curated notes → `docs/releases/2026-07-17-v3.3.0-notes.md` (the release workflow locates this file by tag) with a hand-added Breaking Changes callout
- Version stamps → 3.3.0: `.claude-plugin/plugin.json`, `marketplace.json` (×2), `.codex-plugin/plugin.json`, `images/gemini/plugin.json`, `images/claude/verify.sh`, and `main.go` fallback → `3.3.0-rc`
- Installer tombstones now say "removed in 3.3", updated in lockstep with the CI/test assertions that pin that text; remaining "AgentOps 4" branding swept from docs/scripts/evals ("Cathedral Cut" codename kept — no version digit, and it's wired into gate IDs)

**Upgrade path (commit 2):**
- `ao verify` — the 3.2 flagship — had **no tombstone** (bare cobra error). Added one (map + spine + allowlist + MIGRATION row); its text also explains how to defuse a stale `ao verify init` pre-push hook, which otherwise hard-blocks every push with a misleading "ao too old" error
- Legacy config at `~/.agentops/config.yaml` / `./.agentops/config.yaml` was silently ignored; reads now fall back with a one-time deprecation warning (writes stay on the new path)
- MIGRATION.md: verify row, config-relocation section, catch-all row for untombstoned bookkeeping verbs

## Why

The maintainer decided the cut ships on the 3.x line — only a few releases exist at this major and the audience is small, so spending a major version number on it buys nothing. Without the re-badge, tagging v3.3.0 would have published 4.0.0-labeled manifests (no gate compares manifest version to the tag). The upgrade fixes close gaps against the changelog's own claim that "major public names return one-release non-mutating tombstones."

## How I tested

- `cd cli && go build ./... && go vet ./... && go test ./...` — full suite green
- `scripts/validate-release-notes.sh v3.3.0 --since v3.2.0` — PASS (the hard gate in release.yml)
- `tests/docs/validate-doc-release.sh` — PASS; `tests/install/test-install-smoke.sh` — 42/42
- `scripts/check-cathedral-cut-conformance.py` — PASS; `make -C cli sync-hooks` leaves the tree clean; manifest versions consistent
- Ran the built binary: `ao verify` / `ao verify pre-push` print the tombstone and exit 1 non-mutating; `ao version` → 3.3.0-rc
- New tests: legacy home/project config fallback, new-path precedence, Save-writes-new-path-only

## Checklist

- [x] `make build && make test` passes (if Go changes)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — release notes, CHANGELOG, UPGRADING, MIGRATION all state the minor-version semver deviation explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zw9NuJdNmLbR8wdfcMk4k

---
_Generated by [Claude Code](https://claude.ai/code/session_019zw9NuJdNmLbR8wdfcMk4k)_