### PR TITLE
fix: close v3.3.0 release-audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,11 @@ before upgrading.
 ### Removed
 
 - Pawl admission, land/done/close, governor/converge/reconcile, claim/next-work,
-  state/worktree, membrane, semantic `ao validate`, and the Crank control plane.
-  Major public names return one-release non-mutating tombstones.
+  state/worktree, membrane, yield, constraint promotion, the 3.2 `ao verify`
+  front door, semantic `ao validate`, and the Crank control plane. Major public
+  names return one-release non-mutating tombstones; the full removed-surface
+  map with replacements is in
+  [docs/MIGRATION.md](https://github.com/boshu2/agentops/blob/main/docs/MIGRATION.md).
 - Discovery, behavior-first-planning, goal-design, Crank, delivery/controller,
   tracker-wrapper, and noncanonical mortem skill roots after their useful
   behavior was folded or retired.

--- a/cli/cmd/ao/default_spine_test.go
+++ b/cli/cmd/ao/default_spine_test.go
@@ -69,6 +69,27 @@ func TestDefaultSpineMatchesCathedralCutAllowlist(t *testing.T) {
 	}
 }
 
+// TestCathedralCutTombstonesSurvivePruning pins the tombstone contract: every
+// Cathedral Cut verb must keep a removedCommands stub AND stay a member of
+// defaultSpineCommands. Dropping a verb from the spine map would let
+// pruneToDefaultSpine delete its tombstone, silently degrading the failure
+// from an actionable "no longer exists" stub to a bare unknown-command error.
+func TestCathedralCutTombstonesSurvivePruning(t *testing.T) {
+	for name := range cathedralCutCommands {
+		tomb, ok := removedCommands[name]
+		if !ok {
+			t.Errorf("cathedral cut verb %q has no removedCommands tombstone", name)
+			continue
+		}
+		if tomb.use == "" {
+			t.Errorf("tombstone for %q has an empty replacement hint", name)
+		}
+		if _, retained := defaultSpineCommands[name]; !retained {
+			t.Errorf("cathedral cut verb %q is not in defaultSpineCommands; its tombstone would be pruned from the shipped binary", name)
+		}
+	}
+}
+
 func TestDefaultChildSpineMatchesCathedralCutAllowlist(t *testing.T) {
 	removed := pruneToDefaultSpine(rootCmd)
 	t.Cleanup(func() { restorePrunedCommands(rootCmd, removed) })

--- a/cli/cmd/ao/zzz_default_spine.go
+++ b/cli/cmd/ao/zzz_default_spine.go
@@ -10,16 +10,18 @@ import (
 // defaultSpineCommands is the published CLI membership boundary. Optional
 // source packages do not become public commands merely by registering in tests.
 var defaultSpineCommands = map[string]struct{}{
-	"capabilities": {}, "config": {}, "constraint": {}, "doctor": {},
+	"capabilities": {}, "config": {}, "doctor": {},
 	"demo": {}, "flywheel": {}, "gate": {}, "goals": {},
 	"init": {}, "provenance": {}, "quick-start": {},
 	"redact": {}, "robot-docs": {}, "session": {}, "skills": {}, "status": {},
 	"version": {},
 	// One-release inert tombstones. These names do not restore lifecycle code.
+	// constraint is tombstoned in production like the rest; the test binary
+	// alone keeps its legacy registration (see init below).
 	"pawl": {}, "plan-pawl": {}, "land": {}, "done": {}, "close": {},
 	"governor": {}, "yield": {}, "claim": {}, "next-work": {}, "state": {},
 	"worktree": {}, "validate": {}, "converge": {}, "reconcile": {},
-	"membrane": {}, "crank": {}, "verify": {},
+	"membrane": {}, "crank": {}, "constraint": {}, "verify": {},
 }
 
 // defaultChildSpineCommands removes legacy controller behavior nested under a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -59,8 +59,11 @@ before upgrading.
 ### Removed
 
 - Pawl admission, land/done/close, governor/converge/reconcile, claim/next-work,
-  state/worktree, membrane, semantic `ao validate`, and the Crank control plane.
-  Major public names return one-release non-mutating tombstones.
+  state/worktree, membrane, yield, constraint promotion, the 3.2 `ao verify`
+  front door, semantic `ao validate`, and the Crank control plane. Major public
+  names return one-release non-mutating tombstones; the full removed-surface
+  map with replacements is in
+  [docs/MIGRATION.md](https://github.com/boshu2/agentops/blob/main/docs/MIGRATION.md).
 - Discovery, behavior-first-planning, goal-design, Crank, delivery/controller,
   tracker-wrapper, and noncanonical mortem skill roots after their useful
   behavior was folded or retired.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -85,7 +85,7 @@ influence current phase sequencing or verdict validity.
 
 ## Older releases
 
-The 3.x and 2.x migration record is historical. Read
-[MIGRATION-3.0.md](MIGRATION-3.0.md) and the versioned entries in
-[CHANGELOG.md](CHANGELOG.md) when maintaining an old installation; do not apply
-those old controller, daemon, hook, tracker, or plugin instructions to 3.3.
+The 3.x and 2.x migration record is historical. Read the versioned entries in
+[CHANGELOG.md](CHANGELOG.md) (the standalone 3.0 migration map was retired in
+the Cathedral Cut) when maintaining an old installation; do not apply those old
+controller, daemon, hook, tracker, or plugin instructions to 3.3.

--- a/docs/cli-surface.json
+++ b/docs/cli-surface.json
@@ -44,11 +44,11 @@
       "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
     },
     {
-      "category": "public-tested",
+      "category": "deprecated",
       "command": "constraint",
-      "coverage_status": "covered",
+      "coverage_status": "allowlisted",
       "kind": "leaf",
-      "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
+      "reason": "One-release failure stub for removed constraint promotion."
     },
     {
       "category": "deprecated",
@@ -212,11 +212,11 @@
       "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
     },
     {
-      "category": "public-tested",
+      "category": "deprecated",
       "command": "goals trace",
-      "coverage_status": "covered",
+      "coverage_status": "allowlisted",
       "kind": "leaf",
-      "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
+      "reason": "One-release failure stub for removed lifecycle tracing."
     },
     {
       "category": "public-tested",
@@ -380,11 +380,11 @@
       "reason": "Covered by handoff artifact tests."
     },
     {
-      "category": "public-tested",
+      "category": "deprecated",
       "command": "session memory",
-      "coverage_status": "covered",
+      "coverage_status": "allowlisted",
       "kind": "leaf",
-      "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
+      "reason": "One-release failure stub for removed repository-memory synchronization."
     },
     {
       "category": "public-tested",
@@ -408,11 +408,11 @@
       "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
     },
     {
-      "category": "public-tested",
+      "category": "deprecated",
       "command": "skills edit",
-      "coverage_status": "covered",
+      "coverage_status": "allowlisted",
       "kind": "leaf",
-      "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
+      "reason": "One-release failure stub for removed skill-edit commit flow."
     },
     {
       "category": "public-tested",

--- a/docs/cli-surface.md
+++ b/docs/cli-surface.md
@@ -10,7 +10,7 @@
 | `ao close` | `deprecated` | `allowlisted` | One-release failure stub for removed closure control. |
 | `ao completion` | `public-tested` | `allowlisted` | Framework completion root has focused generation tests. |
 | `ao config models` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
-| `ao constraint` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
+| `ao constraint` | `deprecated` | `allowlisted` | One-release failure stub for removed constraint promotion. |
 | `ao converge` | `deprecated` | `allowlisted` | One-release failure stub for removed retry convergence. |
 | `ao crank` | `deprecated` | `allowlisted` | One-release failure stub for removed factory controller. |
 | `ao demo` | `manual-only` | `allowlisted` | Interactive demonstration requires a TTY. |
@@ -34,7 +34,7 @@
 | `ao goals meta` | `public-tested` | `allowlisted` | Covered through goals measurement behavior. |
 | `ao goals render` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao goals scenarios` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
-| `ao goals trace` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
+| `ao goals trace` | `deprecated` | `allowlisted` | One-release failure stub for removed lifecycle tracing. |
 | `ao goals validate` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao governor` | `deprecated` | `allowlisted` | One-release failure stub for removed retry control. |
 | `ao help` | `internal-hidden` | `allowlisted` | Built-in Cobra help dispatcher with no application handler. |
@@ -58,11 +58,11 @@
 | `ao robot-docs` | `public-tested` | `allowlisted` | Covered by generated documentation tests. |
 | `ao session bootstrap` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao session handoff` | `public-tested` | `allowlisted` | Covered by handoff artifact tests. |
-| `ao session memory` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
+| `ao session memory` | `deprecated` | `allowlisted` | One-release failure stub for removed repository-memory synchronization. |
 | `ao session rehydrate` | `public-tested` | `allowlisted` | Covered by rehydrate artifact tests. |
 | `ao skills check` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao skills consumers` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
-| `ao skills edit` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
+| `ao skills edit` | `deprecated` | `allowlisted` | One-release failure stub for removed skill-edit commit flow. |
 | `ao skills find` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao skills graph` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao skills link` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |

--- a/scripts/check-flywheel-compounding.sh
+++ b/scripts/check-flywheel-compounding.sh
@@ -16,7 +16,9 @@ if [[ -z "$AO_BIN" ]]; then
     if [[ -x "$REPO_ROOT/cli/bin/ao" ]]; then
         AO_BIN="$REPO_ROOT/cli/bin/ao"
     else
-        AO_BIN="/tmp/ao-fw-check"
+        scratch="$(mktemp -d "${TMPDIR:-/tmp}/ao-fw-check.XXXXXX")"
+        trap 'rm -rf "$scratch"' EXIT
+        AO_BIN="$scratch/ao"
         (cd "$REPO_ROOT/cli" && go build -o "$AO_BIN" ./cmd/ao) >/dev/null 2>&1 \
             || { echo "FAIL: could not build ao for flywheel-compounding gate"; exit 1; }
     fi

--- a/scripts/check-provenance-chain.sh
+++ b/scripts/check-provenance-chain.sh
@@ -62,7 +62,9 @@ if [[ -z "$AO" ]]; then
     elif command -v ao >/dev/null 2>&1; then
         AO="ao"
     else
-        AO="/tmp/ao-provenance-chain-check"
+        scratch="$(mktemp -d "${TMPDIR:-/tmp}/ao-provenance-chain-check.XXXXXX")"
+        trap 'rm -rf "$scratch"' EXIT
+        AO="$scratch/ao"
         (cd "$ROOT/cli" && go build -o "$AO" ./cmd/ao) >/dev/null 2>&1 \
             || { echo "PROVENANCE_CHAIN_GATE: FAIL — could not build ao for the chain gate" >&2; exit 1; }
     fi

--- a/scripts/cmdao-surface-allowlist.txt
+++ b/scripts/cmdao-surface-allowlist.txt
@@ -15,10 +15,6 @@ public-stateful-fixture-needed|goals drift|Requires two goal snapshots.
 public-tested|goals history|Historical view shares goals validation behavior.
 public-stateful-fixture-needed|goals init|Initializes GOALS.md and may prompt.
 
-public-tested|constraint activate|Covered through constraint list behavior.
-public-tested|constraint retire|Covered through constraint list behavior.
-public-tested|constraint review|Covered through constraint list behavior.
-
 public-stateful-fixture-needed|doctor capabilities|Inspects local installation state.
 public-stateful-fixture-needed|doctor diff|Compares local installation state.
 public-stateful-fixture-needed|doctor explain|Requires controlled findings.
@@ -53,3 +49,7 @@ deprecated|converge|One-release failure stub for removed retry convergence.
 deprecated|reconcile|One-release failure stub for removed lifecycle reconciliation.
 deprecated|membrane|One-release failure stub for removed admission behavior.
 deprecated|crank|One-release failure stub for removed factory controller.
+deprecated|constraint|One-release failure stub for removed constraint promotion.
+deprecated|goals trace|One-release failure stub for removed lifecycle tracing.
+deprecated|session memory|One-release failure stub for removed repository-memory synchronization.
+deprecated|skills edit|One-release failure stub for removed skill-edit commit flow.

--- a/scripts/install-bd.sh
+++ b/scripts/install-bd.sh
@@ -34,19 +34,39 @@ BD_REPO="steveyegge/beads"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 VERSION=""
 FORCE_INSTALL=0
+# shellcheck disable=SC2034  # consumed by the sourced installer-common.sh
 QUIET=0
+# shellcheck disable=SC2034  # consumed by the sourced installer-common.sh
 NO_GUM=0
 NO_VERIFY=0
 OFFLINE=0
 OFFLINE_TARBALL=""
+# shellcheck disable=SC2034  # consumed by the sourced installer-common.sh
 EASY_MODE=0
 FROM_SOURCE=0
+# shellcheck disable=SC2034  # consumed by the sourced installer-common.sh
 INSTALLER_NAME="bd"
+# shellcheck disable=SC2034  # consumed by the sourced installer-common.sh
 INSTALLER_TAGLINE="Install the beads (bd) CLI"
 
 # ── Load installer-workmanship common scaffold ────────────────────────────
+# Pin of scripts/lib/installer-common.sh for the curl|bash path. The drift
+# test in tests/scripts/install-bd.bats recomputes this on every change, so
+# an edit to installer-common.sh without a matching bump here fails CI.
+INSTALLER_COMMON_SHA256="6de10b1997a17e546cf4a9a75943b257de66df20708e881431917239b4bb2e28"
+
+_sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    echo ""
+  fi
+}
+
 _load_installer_common() {
-  local here bootstrap
+  local here
   # shellcheck disable=SC1007
   here="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd || true)"
   if [[ -n "$here" && -f "$here/lib/installer-bootstrap.sh" ]]; then
@@ -56,10 +76,27 @@ _load_installer_common() {
     return 0
   fi
   # curl|bash: fetch common lib (curl honors HTTPS_PROXY/HTTP_PROXY)
-  local url tmp
+  local url tmp actual
   url="${AGENTOPS_INSTALLER_COMMON_URL:-https://raw.githubusercontent.com/boshu2/agentops/main/scripts/lib/installer-common.sh}"
   tmp="$(mktemp "${TMPDIR:-/tmp}/agentops-installer-common.XXXXXX")"
   if command -v curl >/dev/null 2>&1 && curl -fsSL --connect-timeout 10 "${url}?$(date +%s)" -o "$tmp"; then
+    if [[ -z "${AGENTOPS_INSTALLER_COMMON_URL:-}" ]]; then
+      # Default URL: verify the fetched lib against the pin before sourcing.
+      # A custom AGENTOPS_INSTALLER_COMMON_URL is an explicit operator
+      # override and is sourced as supplied.
+      actual="$(_sha256_of "$tmp")"
+      if [[ -z "$actual" ]]; then
+        rm -f "$tmp"
+        echo "FATAL: no sha256sum/shasum available to verify installer-common.sh" >&2
+        exit 1
+      fi
+      if [[ "$actual" != "$INSTALLER_COMMON_SHA256" ]]; then
+        rm -f "$tmp"
+        echo "FATAL: installer-common.sh checksum mismatch (got $actual)" >&2
+        echo "Re-fetch this installer from the repo — the two files ship and update together." >&2
+        exit 1
+      fi
+    fi
     # shellcheck disable=SC1090
     . "$tmp"
     rm -f "$tmp"
@@ -72,9 +109,13 @@ _load_installer_common() {
 _load_installer_common
 
 # Cosign identity targets the beads upstream repo (not AgentOps).
+# shellcheck disable=SC2034  # all four consumed by the sourced installer-common.sh
 OWNER="steveyegge"
+# shellcheck disable=SC2034  # consumed by the sourced installer-common.sh
 REPO="beads"
+# shellcheck disable=SC2034  # consumed by the sourced installer-common.sh
 INSTALLER_NAME="bd"
+# shellcheck disable=SC2034  # consumed by the sourced installer-common.sh
 INSTALLER_TAGLINE="Install the beads (bd) CLI"
 
 usage() {
@@ -276,7 +317,9 @@ download_and_install() {
     if [[ "$NO_VERIFY" -eq 1 ]]; then
       warn "No published checksum found; continuing because --no-verify was set"
     else
-      warn "No published checksum found for $asset; proceeding without SHA256 (pass --no-verify to silence)"
+      err "No published checksum found for $asset; refusing to install an unverified binary"
+      err "Re-run with --no-verify to accept the download without SHA256 verification"
+      exit 1
     fi
   fi
 

--- a/scripts/lib/preamble.sh
+++ b/scripts/lib/preamble.sh
@@ -23,11 +23,16 @@ set -euo pipefail
 # to that other tree. Fall back to the lib's fixed position
 # (<root>/scripts/lib/preamble.sh → two dirs up) when not in a git checkout at
 # all (e.g. an extracted release tarball).
+# The git call scrubs git's hook-injected discovery env (age-ngtc): inside a
+# hook git exports GIT_DIR without GIT_WORK_TREE, which makes git treat the
+# CURRENT directory as the worktree top — `--show-toplevel` then returns
+# scripts/lib and every REPO_ROOT-relative path breaks (this refused every
+# worktree-origin push that touched cli/cmd/ao/**).
 # `CDPATH=` below is an intentional env-prefix (clears CDPATH for that one cd so
 # a caller's CDPATH can't hijack a relative path), not a botched assignment.
 # shellcheck disable=SC1007
 _preamble_dir="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if ! REPO_ROOT="$(git -C "$_preamble_dir" rev-parse --show-toplevel 2>/dev/null)"; then
+if ! REPO_ROOT="$(unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_OBJECT_DIRECTORY GIT_COMMON_DIR GIT_NAMESPACE; git -C "$_preamble_dir" rev-parse --show-toplevel 2>/dev/null)"; then
   # shellcheck disable=SC1007
   REPO_ROOT="$(CDPATH= cd "$_preamble_dir/../.." && pwd)"
 fi

--- a/scripts/snapshot-flywheel-compounding.sh
+++ b/scripts/snapshot-flywheel-compounding.sh
@@ -18,7 +18,9 @@ if [[ -z "$AO_BIN" ]]; then
     if [[ -x "$REPO_ROOT/cli/bin/ao" ]]; then
         AO_BIN="$REPO_ROOT/cli/bin/ao"
     else
-        AO_BIN="/tmp/ao-fw-snapshot"
+        scratch="$(mktemp -d "${TMPDIR:-/tmp}/ao-fw-snapshot.XXXXXX")"
+        trap 'rm -rf "$scratch"' EXIT
+        AO_BIN="$scratch/ao"
         (cd "$REPO_ROOT/cli" && go build -o "$AO_BIN" ./cmd/ao) >/dev/null 2>&1 || {
             echo "FAIL: could not build ao for snapshot" >&2
             exit 1

--- a/tests/scripts/install-bd.bats
+++ b/tests/scripts/install-bd.bats
@@ -51,3 +51,17 @@ setup() {
     [ "$status" -eq 0 ]
     [ -x "$SCRIPT" ]
 }
+
+@test "installer-common.sh pin in install-bd.sh matches the file on disk" {
+    # The curl|bash path of install-bd.sh sources installer-common.sh only
+    # after verifying it against INSTALLER_COMMON_SHA256. Any edit to
+    # installer-common.sh must bump that pin or remote installs fail closed.
+    pin="$(sed -n 's/^INSTALLER_COMMON_SHA256="\([0-9a-f]\{64\}\)"$/\1/p' "$SCRIPT")"
+    [ -n "$pin" ]
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual="$(sha256sum "$REPO_ROOT/scripts/lib/installer-common.sh" | awk '{print $1}')"
+    else
+        actual="$(shasum -a 256 "$REPO_ROOT/scripts/lib/installer-common.sh" | awk '{print $1}')"
+    fi
+    [ "$pin" = "$actual" ]
+}


### PR DESCRIPTION
## Summary

Closes the findings from the v3.3.0 release-viability audit of main.

**Surface truth (High):** `ao constraint`, `ao goals trace`, `ao session memory`, and `ao skills edit` are production tombstones but docs/cli-surface.md documented them as `public-tested`/`covered` (the test binary keeps constraint live, and the generated doc reflected the test build). Added `deprecated` allowlist rows, dropped the stale constraint-subcommand rows, regrouped constraint with its tombstone peers in the default spine, regenerated both surface projections, and added `TestCathedralCutTombstonesSurvivePruning` pinning the invariant that every Cathedral Cut verb keeps an executable tombstone.

**Installer hardening (Medium):** `install-bd.sh` now fails closed when no published checksum exists for a release asset (explicit `--no-verify` overrides), and the curl|bash path verifies the fetched `installer-common.sh` against a pinned SHA-256 before sourcing it (drift-guarded by a new install-bd.bats test).

**Docs (Medium/Low):** UPGRADING.md no longer links the MIGRATION-3.0.md file the Cathedral Cut deleted; CHANGELOG 3.3.0 `### Removed` now names `yield`, `constraint`, and the 3.2 `verify` front door and links the MIGRATION.md map.

**Gate scripts (Low):** flywheel/provenance gate scripts build `ao` into `mktemp -d` scratch dirs instead of fixed world-known /tmp paths (symlink/TOCTOU on shared hosts).

**Bonus (surfaced by the push gate):** `scripts/lib/preamble.sh` mis-resolved REPO_ROOT under git hook env (GIT_DIR without GIT_WORK_TREE), which made `go.cli-architecture` refuse every worktree-origin push touching `cli/cmd/ao/**`. Fixed by scrubbing the hook-injected discovery env around the rev-parse.

## Validation
- `go build && go vet && go test ./...`: 5,085 tests green, golangci-lint clean
- `ao gate check --fast`: 27/27 pass, including under simulated hook env
- bats install-bd suite 6/6 incl. new pin drift test; shellcheck clean on all touched scripts
- markdownlint clean; doc-release gate passes; tombstone exit codes verified on the built binary