### PR TITLE
feat(doctor): workspace subsystem — .agents/ hygiene detectors, fixers, retention convention

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -6,7 +6,6 @@ toolchain go1.26.5
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/google/go-cmp v0.7.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -6,8 +6,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
-github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/cli/internal/doctor/capabilities.go
+++ b/cli/internal/doctor/capabilities.go
@@ -28,6 +28,7 @@ const (
 // analysis/safety_envelope.md. Any write outside this set refuses with exit 4.
 var canonicalWriteScopes = []string{
 	".doctor",
+	".agents",
 	".agents/daemon",
 	".agents/handoffs/sha256",
 	".agents/ao",
@@ -44,7 +45,7 @@ var canonicalWriteScopes = []string{
 
 // canonicalSubsystems is the fixed list of doctor subsystems.
 var canonicalSubsystems = []string{
-	"daemon", "bridges", "knowledge", "skills", "cli_config",
+	"daemon", "bridges", "knowledge", "skills", "cli_config", "workspace",
 }
 
 // canonicalExitCodes documents every exit code the doctor surface can return.

--- a/cli/internal/doctor/fix_workspace.go
+++ b/cli/internal/doctor/fix_workspace.go
@@ -1,0 +1,168 @@
+package doctor
+
+// Workspace subsystem shared base.
+//
+// This file holds the helpers the workspace hygiene detectors and fixers are
+// built on: the `.agents` root resolver, a symlink-safe directory inventory,
+// the canonical-alias registry for drifted directory spellings, stale/retry
+// name classification, the quarantine Rename destination, and the GC TTL.
+// It registers NO detectors and NO fixers; those live in sibling files.
+//
+// Helpers here are PURE reads (stat + readdir only). Any future fixer disk
+// write flows through Mutate; "deletion" of a workspace directory is a Rename
+// into the run's quarantine/ directory (see workspaceQuarantineDest), never a
+// remove.
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"time"
+)
+
+// subsystemWorkspace is the Subsystem() name shared by all workspace
+// detectors and fixers.
+const subsystemWorkspace = "workspace"
+
+// workspaceAgentsDir returns the workspace hygiene root, <RepoRoot>/.agents.
+func workspaceAgentsDir(env *DetectEnv) string {
+	return filepath.Join(env.RepoRoot, ".agents")
+}
+
+// workspaceDirInfo describes one immediate subdirectory of the workspace root.
+type workspaceDirInfo struct {
+	// Name is the directory's base name.
+	Name string
+	// FileCount is the transitive count of regular files under the directory.
+	FileCount int
+	// ByteSize is the transitive sum of regular-file sizes in bytes.
+	ByteSize int64
+	// NewestMTime is the newest regular-file modification time under the
+	// directory; zero when the directory contains no regular files.
+	NewestMTime time.Time
+}
+
+// workspaceDirInventory inventories the immediate subdirectories of base,
+// returning one workspaceDirInfo per directory in deterministic name order.
+// Symlinks are never followed: a top-level symlink (even to a directory) is
+// not inventoried, and symlinks encountered during the walk contribute
+// nothing. Unreadable entries are skipped, not fatal — the inventory is a
+// best-effort read of a possibly messy workspace. A missing or unreadable
+// base itself is the only error case.
+func workspaceDirInventory(base string) ([]workspaceDirInfo, error) {
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]workspaceDirInfo, 0, len(entries))
+	for _, e := range entries {
+		// os.ReadDir reports lstat-style types, so a symlink to a directory
+		// is ModeSymlink here (not IsDir) and gets skipped — symlink-safe.
+		if !e.IsDir() {
+			continue
+		}
+		info := workspaceDirInfo{Name: e.Name()}
+		// WalkDir never follows symlinks; the error callback path tolerates
+		// permission failures by skipping the offending subtree.
+		_ = filepath.WalkDir(filepath.Join(base, e.Name()), func(_ string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				if d != nil && d.IsDir() {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			if !d.Type().IsRegular() {
+				return nil
+			}
+			fi, infoErr := d.Info()
+			if infoErr != nil {
+				return nil
+			}
+			info.FileCount++
+			info.ByteSize += fi.Size()
+			if fi.ModTime().After(info.NewestMTime) {
+				info.NewestMTime = fi.ModTime()
+			}
+			return nil
+		})
+		out = append(out, info)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// workspaceCanonicalAliases maps drifted spellings of top-level `.agents`
+// directory names to their canonical names. The drift detector consumes this
+// table verbatim: a key present as a top-level directory is a drift finding
+// whose remediation is a merge/rename into the value directory.
+var workspaceCanonicalAliases = map[string]string{
+	"post-mortem":  "postmortem",
+	"post-mortems": "postmortem",
+	"pre-mortem":   "pre-mortem-checks",
+	"pre-mortems":  "pre-mortem-checks",
+	"handoffs":     "handoff",
+	"mto-handoff":  "handoff",
+	"retros":       "retro",
+	"proof":        "proofs",
+	"test":         "tests",
+}
+
+// workspaceStaleSuffixRe matches an explicit stale marker: a trailing
+// `.stale-<timestamp>` suffix as written by land-queue staling
+// (e.g. `land-queue-age-h433.19.stale-20260711T221032Z`).
+var workspaceStaleSuffixRe = regexp.MustCompile(`\.stale-\d{8}T\d{6}Z$`)
+
+// workspaceRetryChainRe matches a retry-chain directory: a trailing
+// `-retry<N>` suffix, optionally itself staled
+// (e.g. `land-queue-age-h433.22-native-retry2`).
+var workspaceRetryChainRe = regexp.MustCompile(`-retry\d+(\.stale-\d{8}T\d{6}Z)?$`)
+
+// workspaceStaleNameKind classifies a top-level workspace directory name.
+// explicitStale reports a `.stale-<timestamp>` suffix; retryChain reports a
+// `-retry<N>` suffix (possibly combined with a stale suffix). Both can be
+// true at once for a staled retry directory.
+func workspaceStaleNameKind(name string) (explicitStale, retryChain bool) {
+	return workspaceStaleSuffixRe.MatchString(name), workspaceRetryChainRe.MatchString(name)
+}
+
+// isWorkspaceStaleDirName reports whether a top-level directory name is
+// GC-eligible debris: explicitly staled, a retry-chain dir, or both.
+func isWorkspaceStaleDirName(name string) bool {
+	explicitStale, retryChain := workspaceStaleNameKind(name)
+	return explicitStale || retryChain
+}
+
+// workspaceQuarantineDest returns the Rename target for quarantining a
+// top-level workspace directory: <RunDir>/quarantine/workspace/<dirName>.
+// This mirrors the run-quarantine scheme every other fixer uses (paths under
+// <RunDir>/quarantine/, cf. RunArtifact.QuarantineDir and the knowledge
+// fixer's staged-mkdir path): there is no deletion op, so a workspace GC
+// fixer "deletes" via Mutate with Rename{To: workspaceQuarantineDest(...)}.
+// Rename's executeAtomic MkdirAll's the destination parent.
+func workspaceQuarantineDest(ctx *MutateContext, dirName string) string {
+	return filepath.Join(ctx.RunDir, "quarantine", subsystemWorkspace, dirName)
+}
+
+// Workspace GC TTL configuration.
+const (
+	// workspaceTTLEnvVar overrides the workspace GC TTL, in whole days.
+	workspaceTTLEnvVar = "AO_DOCTOR_WS_TTL_DAYS"
+	// workspaceTTLDefaultDays is the default workspace GC TTL in days.
+	workspaceTTLDefaultDays = 14
+)
+
+// workspaceGCTTL returns the workspace GC TTL: stale/retry directories whose
+// newest content is older than this are GC candidates. Defaults to 14 days;
+// AO_DOCTOR_WS_TTL_DAYS overrides with a positive integer day count, and any
+// invalid value falls back to the default.
+func workspaceGCTTL() time.Duration {
+	if raw := os.Getenv(workspaceTTLEnvVar); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			return time.Duration(n) * day
+		}
+	}
+	return workspaceTTLDefaultDays * day
+}

--- a/cli/internal/doctor/fix_workspace.go
+++ b/cli/internal/doctor/fix_workspace.go
@@ -14,6 +14,7 @@ package doctor
 // remove.
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
@@ -204,15 +205,22 @@ const (
 	workspaceTTLEnvVar = "AO_DOCTOR_WS_TTL_DAYS"
 	// workspaceTTLDefaultDays is the default workspace GC TTL in days.
 	workspaceTTLDefaultDays = 14
+	// workspaceTTLMaxDays caps the env override at 10 years. The cap is a
+	// correctness guard, not just taste: an unbounded day count overflows
+	// time.Duration (day counts above ~106751 wrap the int64 nanosecond
+	// representation negative), which would push the GC cutoff into the far
+	// FUTURE and make every stale-named directory look expired at once.
+	workspaceTTLMaxDays = 3650
 )
 
 // workspaceGCTTL returns the workspace GC TTL: stale/retry directories whose
 // newest content is older than this are GC candidates. Defaults to 14 days;
-// AO_DOCTOR_WS_TTL_DAYS overrides with a positive integer day count, and any
-// invalid value falls back to the default.
+// AO_DOCTOR_WS_TTL_DAYS overrides with an integer day count in
+// [1, workspaceTTLMaxDays], and any invalid or out-of-range value falls back
+// to the default (never trusted — see workspaceTTLMaxDays for why).
 func workspaceGCTTL() time.Duration {
 	if raw := os.Getenv(workspaceTTLEnvVar); raw != "" {
-		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+		if n, err := strconv.Atoi(raw); err == nil && n >= 1 && n <= workspaceTTLMaxDays {
 			return time.Duration(n) * day
 		}
 	}
@@ -239,6 +247,15 @@ func workspaceGCTTL() time.Duration {
 // check and before any preconditions — fixers use it to re-validate state
 // that may have changed since their scan (e.g. "still empty"). A verify
 // error aborts the rename with no mutation.
+//
+// TOCTOU bound (external writers): the per-path lock is in-process advisory
+// only, so for a writer OUTSIDE this process a verify→rename window exists
+// and cannot be eliminated here — full closure would need filesystem
+// transactions or stop-the-world exclusivity, both out of scope by design.
+// The consequence is bounded, not destructive: content that lands inside the
+// directory during the window is MOVED with it to the journaled rename
+// destination (quarantine), remains restorable via `doctor undo`, and is
+// never deleted.
 func workspaceDirRename(ctx *MutateContext, path, dest string, verify func(path string) error) error {
 	op := Rename{To: dest}
 
@@ -290,12 +307,19 @@ func workspaceDirRename(ctx *MutateContext, path, dest string, verify func(path 
 	}
 
 	// Step 7/8 — fsync'd action record.
+	//
+	// Execute-before-journal parity: this order matches the file-shaped Mutate
+	// chokepoint (execute, then journal). A CRASH between the execute above
+	// and the append below is therefore undo-blind for BOTH shapes — the
+	// journal never sees the mutation — and the rename destination tree
+	// (quarantine) is the manual recovery path: the run dir's receipts list
+	// what moved, and nothing is ever deleted.
 	rel, relErr := filepath.Rel(ctx.RepoRoot, path)
 	if relErr != nil {
 		rel = path
 	}
 	emptyHash := sha256Hex(nil)
-	if err := ctx.appendAction(ActionRecord{
+	if wrote, aerr := workspaceAppendAction(ctx, ActionRecord{
 		Path:         rel,
 		Op:           op.kind(),
 		BeforeHash:   emptyHash,
@@ -308,19 +332,197 @@ func workspaceDirRename(ctx *MutateContext, path, dest string, verify func(path 
 		OK:           true,
 		RenameTo:     dest,
 		Existed:      true,
-	}); err != nil {
-		// The rename landed but its journal line did not, so `doctor undo`
-		// would be blind to the mutation. (The file-shaped Mutate chokepoint
-		// has the same execute-then-journal order and the same exposure; this
-		// directory adapter at least compensates.) Attempt a compensating
-		// rename-back so disk state matches the (empty) journal, and report
-		// both the journal error and the compensation outcome.
-		if backErr := os.Rename(dest, path); backErr != nil {
-			return fmt.Errorf("doctor: journal Rename of %s: %w; compensating rename-back FAILED (%v) — directory left at %s and is NOT recorded in actions.jsonl", path, err, backErr, dest)
+	}); aerr != nil {
+		if !wrote {
+			// WRITE-stage failure: the record definitely did not land as a
+			// parseable journal line, so `doctor undo` would be blind to the
+			// rename. Compensate with a rename-back so disk state matches the
+			// (empty) journal, and report both the journal error and the
+			// compensation outcome.
+			if backErr := os.Rename(dest, path); backErr != nil {
+				return fmt.Errorf("doctor: journal Rename of %s: %w; compensating rename-back FAILED (%v) — directory left at %s and is NOT recorded in actions.jsonl", path, aerr, backErr, dest)
+			}
+			return fmt.Errorf("doctor: journal Rename of %s: %w (compensated: directory renamed back to its original path; no mutation recorded)", path, aerr)
 		}
-		return fmt.Errorf("doctor: journal Rename of %s: %w (compensated: directory renamed back to its original path; no mutation recorded)", path, err)
+		// SYNC-stage failure: the write succeeded and only the fsync failed,
+		// so the record has PROBABLY been persisted. Compensating here would
+		// desync disk from the journal — a later `doctor undo` would replay an
+		// unnecessary reverse rename over the restored path. Leave the rename
+		// in place (state and record are consistent) and surface the
+		// journal-durability uncertainty instead.
+		return fmt.Errorf("doctor: journal Rename of %s: record written but not durably synced (%w) — rename left in place at %s; actions.jsonl durability is uncertain until the next successful sync", path, aerr, dest)
 	}
 	return nil
+}
+
+// workspaceAppendAction is the journal-append seam used by the workspace
+// directory/file chokepoint adapters. It is a package var ONLY so tests can
+// simulate the write-succeeded/fsync-failed stage deterministically (forcing a
+// real fsync failure while the write succeeds is not portable); production
+// always points at workspaceAppendActionStaged.
+var workspaceAppendAction = workspaceAppendActionStaged
+
+// workspaceAppendActionStaged appends one action record to the run's
+// actions.jsonl exactly as MutateContext.appendAction does (same mutex, same
+// handle, same fsync) but reports WHICH stage failed, so callers can pick the
+// right recovery:
+//
+//   - wrote == false: the record was definitely not persisted as a parseable
+//     line (marshal or write failed; at worst a partial, unparseable trailing
+//     fragment reached the file, which the journal reader rejects). The
+//     mutation is journal-invisible — compensating is safe and correct.
+//   - wrote == true with a non-nil error: the write succeeded and only the
+//     fsync failed. The line is in the OS page cache and has probably been (or
+//     will be) persisted, so the caller must NOT compensate by reversing the
+//     mutation — the on-disk journal likely records it.
+func workspaceAppendActionStaged(ctx *MutateContext, rec ActionRecord) (wrote bool, err error) {
+	line, merr := json.Marshal(rec)
+	if merr != nil {
+		return false, fmt.Errorf("doctor: marshal action record: %w", merr)
+	}
+	line = append(line, '\n')
+	ctx.actionsMu.Lock()
+	defer ctx.actionsMu.Unlock()
+	if _, werr := ctx.actionsFile.Write(line); werr != nil {
+		return false, fmt.Errorf("doctor: append actions.jsonl: %w", werr)
+	}
+	if serr := ctx.actionsFile.Sync(); serr != nil {
+		return true, fmt.Errorf("doctor: sync actions.jsonl: %w", serr)
+	}
+	return true, nil
+}
+
+// workspaceFileMoveNoClobber moves the regular file path to dest through the
+// Mutate eight-step discipline (per-path lock, before-hash, scope/op
+// preconditions on both endpoints, verbatim backup, dry-run transparency,
+// journal) but executes via os.Link + os.Remove instead of os.Rename:
+// link(2) fails with EEXIST when the destination exists, so link+remove is
+// the no-clobber implementation of Rename for regular files — the kernel
+// itself refuses the overwrite, closing the lstat→rename destination race
+// that a check-then-rename sequence merely narrows. An EEXIST is reported as
+// (collided=true, nil) with nothing moved.
+//
+// The action is journaled with the same record shape Mutate writes for a
+// Rename (Op "Rename", RenameTo=dest, before-hash of the source content,
+// empty after-hash at the vacated source path): it IS the move it performed,
+// only executed differently. engine.undoOne replays a Rename record with a
+// reverse os.Rename(RenameTo, Path), which works identically after
+// link+remove — the source is gone and the destination exists, exactly as
+// after a plain rename.
+func workspaceFileMoveNoClobber(ctx *MutateContext, path, dest string) (collided bool, err error) {
+	op := Rename{To: dest}
+
+	// Step 1 — per-path advisory lock on the source (callers moving toward a
+	// contended destination hold the destination lock; distinct paths, so no
+	// self-deadlock).
+	if !ctx.DryRun {
+		guard, lerr := ctx.Locks.Acquire(path)
+		if lerr != nil {
+			return false, lerr
+		}
+		defer func() { _ = guard.Release() }()
+	}
+
+	// Step 2 — before-state: the source must be a regular file (never follow
+	// a symlink into pretending it is one).
+	info, lerr := os.Lstat(path)
+	if lerr != nil {
+		return false, fmt.Errorf("doctor: lstat %s: %w", path, lerr)
+	}
+	if !info.Mode().IsRegular() {
+		return false, fmt.Errorf("doctor: move %s: not a regular file (refused_unsafe)", path)
+	}
+	beforeBytes, rerr := os.ReadFile(path)
+	if rerr != nil {
+		return false, fmt.Errorf("doctor: read %s: %w", path, rerr)
+	}
+	beforeHash := sha256Hex(beforeBytes)
+
+	// Step 3 — preconditions: both endpoints in scope, op executable.
+	if err := EnsureInScope(ctx.Capabilities, ctx.RepoRoot, ctx.HomeDir, path); err != nil {
+		return false, err
+	}
+	if err := EnsureInScope(ctx.Capabilities, ctx.RepoRoot, ctx.HomeDir, dest); err != nil {
+		return false, err
+	}
+	if err := EnsureOpAllowed(ctx.Capabilities, op); err != nil {
+		return false, err
+	}
+
+	// Step 4 — verbatim backup (same as Mutate for an existing file).
+	if !ctx.DryRun {
+		rel, relErr := filepath.Rel(ctx.RepoRoot, path)
+		if relErr != nil {
+			rel = filepath.Base(path)
+		}
+		backup := filepath.Join(ctx.RunDir, "backups", rel)
+		if err := copyVerbatim(path, backup); err != nil {
+			return false, fmt.Errorf("doctor: backup %s: %w", path, err)
+		}
+		if err := cmpStrict(path, backup); err != nil {
+			return false, err
+		}
+	}
+
+	// Step 5/6 — dry-run transparency, then atomic no-clobber execute.
+	startedNS := time.Since(ctx.start).Nanoseconds()
+	if ctx.DryRun {
+		fmt.Fprintf(os.Stderr, "[dry-run] would mutate %s: %s\n", path, DescribeOp(op))
+		return false, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return false, fmt.Errorf("doctor: mkdir %s: %w", filepath.Dir(dest), err)
+	}
+	if err := os.Link(path, dest); err != nil {
+		if os.IsExist(err) {
+			return true, nil // destination appeared — collision, nothing moved
+		}
+		return false, fmt.Errorf("doctor: link %s -> %s: %w", path, dest, err)
+	}
+	if err := os.Remove(path); err != nil {
+		// The link landed but the source could not be unlinked, leaving two
+		// paths to one inode. Compensate by removing the new link so the move
+		// stays all-or-nothing.
+		if unlinkErr := os.Remove(dest); unlinkErr != nil {
+			return false, fmt.Errorf("doctor: remove source %s after link: %w; compensating removal of %s ALSO failed (%v) — file is hard-linked at both paths and NOT recorded in actions.jsonl", path, err, dest, unlinkErr)
+		}
+		return false, fmt.Errorf("doctor: remove source %s after link: %w (compensated: link at %s removed; nothing moved)", path, err, dest)
+	}
+
+	// Step 7/8 — fsync'd action record; same execute-before-journal parity and
+	// crash exposure as workspaceDirRename (see the comment there), and the
+	// same staged write/sync recovery split.
+	rel, relErr := filepath.Rel(ctx.RepoRoot, path)
+	if relErr != nil {
+		rel = path
+	}
+	if wrote, aerr := workspaceAppendAction(ctx, ActionRecord{
+		Path:         rel,
+		Op:           op.kind(),
+		BeforeHash:   beforeHash,
+		AfterHash:    sha256Hex(nil), // the source path is empty after the move, matching Mutate's read-back
+		BeforeMode:   fmt.Sprintf("%o", info.Mode().Perm()),
+		StartedAtNS:  startedNS,
+		FinishedAtNS: time.Since(ctx.start).Nanoseconds(),
+		RunID:        ctx.RunID,
+		FixerID:      ctx.FixerID,
+		OK:           true,
+		RenameTo:     dest,
+		Existed:      true,
+	}); aerr != nil {
+		if !wrote {
+			// WRITE-stage failure: record definitely not persisted; move the
+			// file back so disk matches the (empty) journal.
+			if backErr := os.Rename(dest, path); backErr != nil {
+				return false, fmt.Errorf("doctor: journal Rename of %s: %w; compensating move-back FAILED (%v) — file left at %s and is NOT recorded in actions.jsonl", path, aerr, backErr, dest)
+			}
+			return false, fmt.Errorf("doctor: journal Rename of %s: %w (compensated: file moved back to its original path; no mutation recorded)", path, aerr)
+		}
+		// SYNC-stage failure: record probably persisted; leave the move in
+		// place so state and journal stay consistent (see workspaceDirRename).
+		return false, fmt.Errorf("doctor: journal Rename of %s: record written but not durably synced (%w) — move left in place at %s; actions.jsonl durability is uncertain until the next successful sync", path, aerr, dest)
+	}
+	return false, nil
 }
 
 // workspaceQuarantineDirByName validates name as a bare path element (a

--- a/cli/internal/doctor/fix_workspace.go
+++ b/cli/internal/doctor/fix_workspace.go
@@ -14,6 +14,7 @@ package doctor
 // remove.
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -165,4 +166,106 @@ func workspaceGCTTL() time.Duration {
 		}
 	}
 	return workspaceTTLDefaultDays * day
+}
+
+// workspaceDirRename is the single directory analogue of Mutate for the
+// Rename op, shared by every workspace fixer. Mutate itself is file-shaped —
+// its before-hash read and verbatim backup only work on regular files, so a
+// directory rename adapts its eight-step discipline here: the same per-path
+// advisory lock, the same EnsureInScope/EnsureOpAllowed preconditions (source
+// AND destination; `.agents` is a canonical write scope), the same dry-run
+// transparency, the same atomic execute via the chokepoint's executeAtomic
+// (which MkdirAll's the destination parent), and the same fsync'd
+// actions.jsonl record.
+//
+// A directory Rename needs no byte backup or content hash to be reversible:
+// engine.undoOne reverses a Rename record with a bare rename-back and never
+// consults backups or hashes, and the renamed tree IS the preserved copy,
+// byte for byte. Hash fields record the empty-content hash for journal-shape
+// consistency (the same value Mutate records for an absent file).
+//
+// verify, when non-nil, runs under the per-path lock after the directory
+// check and before any preconditions — fixers use it to re-validate state
+// that may have changed since their scan (e.g. "still empty"). A verify
+// error aborts the rename with no mutation.
+func workspaceDirRename(ctx *MutateContext, path, dest string, verify func(path string) error) error {
+	op := Rename{To: dest}
+
+	// Step 1 — per-path advisory lock (skipped in dry-run, matching Mutate).
+	if !ctx.DryRun {
+		guard, err := ctx.Locks.Acquire(path)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = guard.Release() }()
+	}
+
+	// Step 2 — before-state: the source must exist and be a directory (never
+	// follow a symlink into pretending it is one).
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("doctor: lstat %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("doctor: rename-dir %s: not a directory (refused_unsafe)", path)
+	}
+	if verify != nil {
+		if err := verify(path); err != nil {
+			return err
+		}
+	}
+
+	// Step 3 — preconditions: both endpoints in scope, op executable.
+	if err := EnsureInScope(ctx.Capabilities, ctx.RepoRoot, ctx.HomeDir, path); err != nil {
+		return err
+	}
+	if err := EnsureInScope(ctx.Capabilities, ctx.RepoRoot, ctx.HomeDir, dest); err != nil {
+		return err
+	}
+	if err := EnsureOpAllowed(ctx.Capabilities, op); err != nil {
+		return err
+	}
+
+	// Step 4 — backup: intentionally none (see the function comment).
+
+	// Step 5/6 — dry-run transparency, then atomic execute.
+	startedNS := time.Since(ctx.start).Nanoseconds()
+	if ctx.DryRun {
+		fmt.Fprintf(os.Stderr, "[dry-run] would mutate %s: %s\n", path, DescribeOp(op))
+		return nil
+	}
+	if err := executeAtomic(path, op); err != nil {
+		return fmt.Errorf("doctor: execute Rename on %s: %w", path, err)
+	}
+
+	// Step 7/8 — fsync'd action record.
+	rel, relErr := filepath.Rel(ctx.RepoRoot, path)
+	if relErr != nil {
+		rel = path
+	}
+	emptyHash := sha256Hex(nil)
+	return ctx.appendAction(ActionRecord{
+		Path:         rel,
+		Op:           op.kind(),
+		BeforeHash:   emptyHash,
+		AfterHash:    emptyHash,
+		BeforeMode:   fmt.Sprintf("%o", info.Mode().Perm()),
+		StartedAtNS:  startedNS,
+		FinishedAtNS: time.Since(ctx.start).Nanoseconds(),
+		RunID:        ctx.RunID,
+		FixerID:      ctx.FixerID,
+		OK:           true,
+		RenameTo:     dest,
+		Existed:      true,
+	})
+}
+
+// workspaceQuarantineDirByName validates name as a bare path element (a
+// structural-containment guard on top of the scope check), then renames
+// base/name to dest through workspaceDirRename.
+func workspaceQuarantineDirByName(ctx *MutateContext, base, name, dest string, verify func(path string) error) error {
+	if name != filepath.Base(name) || name == "." || name == ".." || name == "" {
+		return fmt.Errorf("doctor: invalid workspace dir name %q (refused_unsafe)", name)
+	}
+	return workspaceDirRename(ctx, filepath.Join(base, name), dest, verify)
 }

--- a/cli/internal/doctor/fix_workspace.go
+++ b/cli/internal/doctor/fix_workspace.go
@@ -33,6 +33,38 @@ func workspaceAgentsDir(env *DetectEnv) string {
 	return filepath.Join(env.RepoRoot, ".agents")
 }
 
+// workspaceRealDir Lstats path and reports whether it is a REAL directory:
+// present, and not a symlink (even a symlink to a directory) or any other
+// non-directory entry. Every workspace detector that consumes the `.agents`
+// root must gate on this before reading it: ReadDir/WalkDir on a symlinked
+// root silently traverse the symlink target, so detectors would inventory —
+// and fixers would then rename — directories OUTSIDE the repository while the
+// lexical EnsureInScope check still passes.
+func workspaceRealDir(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode()&os.ModeSymlink == 0 && info.IsDir()
+}
+
+// workspaceRequireRealAgentsDir is the fixer-side counterpart of
+// workspaceRealDir for the `.agents` root: an absent root reports
+// (false, nil) — nothing to fix, a no-op success for idempotent fixers —
+// while a root that exists but is not a real directory (symlink, regular
+// file, ...) refuses with a refused_unsafe error so no fixer ever mutates
+// through it.
+func workspaceRequireRealAgentsDir(base string) (exists bool, err error) {
+	info, lerr := os.Lstat(base)
+	if lerr != nil {
+		if os.IsNotExist(lerr) {
+			return false, nil
+		}
+		return false, fmt.Errorf("doctor: lstat workspace root %s: %w", base, lerr)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return false, fmt.Errorf("doctor: workspace root %s is not a real directory (refused_unsafe)", base)
+	}
+	return true, nil
+}
+
 // workspaceDirInfo describes one immediate subdirectory of the workspace root.
 type workspaceDirInfo struct {
 	// Name is the directory's base name.
@@ -44,15 +76,25 @@ type workspaceDirInfo struct {
 	// NewestMTime is the newest regular-file modification time under the
 	// directory; zero when the directory contains no regular files.
 	NewestMTime time.Time
+	// OtherEntries is the transitive count of entries that are neither
+	// regular files nor directories (symlinks, sockets, FIFOs, ...). A dir
+	// with FileCount==0 but OtherEntries>0 is NOT empty.
+	OtherEntries int
+	// WalkErrs is the count of subpaths that could not be read (permission
+	// errors, races, stat failures). WalkErrs>0 means the inventory is
+	// incomplete: FileCount/ByteSize/NewestMTime are lower bounds, so
+	// consumers must treat the directory's content as UNKNOWN, never as
+	// provably empty or provably expired.
+	WalkErrs int
 }
 
 // workspaceDirInventory inventories the immediate subdirectories of base,
 // returning one workspaceDirInfo per directory in deterministic name order.
 // Symlinks are never followed: a top-level symlink (even to a directory) is
-// not inventoried, and symlinks encountered during the walk contribute
-// nothing. Unreadable entries are skipped, not fatal — the inventory is a
-// best-effort read of a possibly messy workspace. A missing or unreadable
-// base itself is the only error case.
+// not inventoried, and symlinks encountered during the walk count only
+// toward OtherEntries. Unreadable entries are skipped, not fatal — but each
+// skip is tallied in WalkErrs so consumers can tell "empty" from "could not
+// read". A missing or unreadable base itself is the only error case.
 func workspaceDirInventory(base string) ([]workspaceDirInfo, error) {
 	entries, err := os.ReadDir(base)
 	if err != nil {
@@ -67,19 +109,28 @@ func workspaceDirInventory(base string) ([]workspaceDirInfo, error) {
 		}
 		info := workspaceDirInfo{Name: e.Name()}
 		// WalkDir never follows symlinks; the error callback path tolerates
-		// permission failures by skipping the offending subtree.
+		// permission failures by skipping the offending subtree, but every
+		// skipped subpath is counted in WalkErrs (unknown ≠ empty).
 		_ = filepath.WalkDir(filepath.Join(base, e.Name()), func(_ string, d fs.DirEntry, walkErr error) error {
 			if walkErr != nil {
+				info.WalkErrs++
 				if d != nil && d.IsDir() {
 					return fs.SkipDir
 				}
 				return nil
 			}
+			if d.IsDir() {
+				return nil
+			}
 			if !d.Type().IsRegular() {
+				// Symlink, socket, FIFO, device, ...: invisible to the
+				// regular-file tallies but NOT ignorable content.
+				info.OtherEntries++
 				return nil
 			}
 			fi, infoErr := d.Info()
 			if infoErr != nil {
+				info.WalkErrs++
 				return nil
 			}
 			info.FileCount++
@@ -244,7 +295,7 @@ func workspaceDirRename(ctx *MutateContext, path, dest string, verify func(path 
 		rel = path
 	}
 	emptyHash := sha256Hex(nil)
-	return ctx.appendAction(ActionRecord{
+	if err := ctx.appendAction(ActionRecord{
 		Path:         rel,
 		Op:           op.kind(),
 		BeforeHash:   emptyHash,
@@ -257,7 +308,19 @@ func workspaceDirRename(ctx *MutateContext, path, dest string, verify func(path 
 		OK:           true,
 		RenameTo:     dest,
 		Existed:      true,
-	})
+	}); err != nil {
+		// The rename landed but its journal line did not, so `doctor undo`
+		// would be blind to the mutation. (The file-shaped Mutate chokepoint
+		// has the same execute-then-journal order and the same exposure; this
+		// directory adapter at least compensates.) Attempt a compensating
+		// rename-back so disk state matches the (empty) journal, and report
+		// both the journal error and the compensation outcome.
+		if backErr := os.Rename(dest, path); backErr != nil {
+			return fmt.Errorf("doctor: journal Rename of %s: %w; compensating rename-back FAILED (%v) — directory left at %s and is NOT recorded in actions.jsonl", path, err, backErr, dest)
+		}
+		return fmt.Errorf("doctor: journal Rename of %s: %w (compensated: directory renamed back to its original path; no mutation recorded)", path, err)
+	}
+	return nil
 }
 
 // workspaceQuarantineDirByName validates name as a bare path element (a

--- a/cli/internal/doctor/fix_workspace_drift.go
+++ b/cli/internal/doctor/fix_workspace_drift.go
@@ -23,7 +23,9 @@ package doctor
 // run's quarantine directory (never removed).
 //
 // Detector is PURE (stat + readdir only). Every fixer disk write flows through
-// the mutation chokepoint: regular files via Mutate, and directories via
+// the mutation chokepoint discipline: regular files via
+// workspaceFileMoveNoClobber (a link+remove adaptation of Mutate's Rename
+// whose execute is kernel-atomic no-clobber), and directories via
 // workspaceRenameDir — an in-package directory adaptation of Mutate that
 // preserves the chokepoint's guarantees (per-path lock, write-scope check, op
 // check, dry-run, fsync'd actions.jsonl journal). Directory renames need no
@@ -193,7 +195,24 @@ func (f workspaceNamingDriftFixer) fixOneAlias(ctx *MutateContext, base, alias s
 		res.Skipped = append(res.Skipped, fmt.Sprintf("%s: alias path is not a real directory; resolve by hand", aliasRel))
 		return nil
 	}
-	canonicalDir := filepath.Join(base, workspaceCanonicalAliases[alias])
+	canonicalName := workspaceCanonicalAliases[alias]
+	canonicalDir := filepath.Join(base, canonicalName)
+	// Destination-root guard: the canonical dir may ITSELF be a symlink (or a
+	// regular file). Moving entries "into" a symlinked canonical dir would
+	// follow the link — potentially outside the repo — while every per-entry
+	// lexical scope check still passes. An ABSENT canonical dir is fine (the
+	// first move creates it); anything present must be a real directory, and a
+	// non-NotExist Lstat error means its state is unknown — never assume
+	// absent, skip the whole alias.
+	if cfi, cerr := os.Lstat(canonicalDir); cerr == nil {
+		if cfi.Mode()&os.ModeSymlink != 0 || !cfi.IsDir() {
+			res.Skipped = append(res.Skipped, fmt.Sprintf("%s: canonical dir .agents/%s is not a real directory; resolve by hand", aliasRel, canonicalName))
+			return nil
+		}
+	} else if !os.IsNotExist(cerr) {
+		res.Skipped = append(res.Skipped, fmt.Sprintf("%s: cannot verify canonical dir .agents/%s (%v); resolve by hand", aliasRel, canonicalName, cerr))
+		return nil
+	}
 	entries, err := os.ReadDir(aliasPath)
 	if err != nil {
 		return fmt.Errorf("doctor: %s: read %s: %w", f.ID(), aliasRel, err)
@@ -208,14 +227,14 @@ func (f workspaceNamingDriftFixer) fixOneAlias(ctx *MutateContext, base, alias s
 			res.Skipped = append(res.Skipped, fmt.Sprintf("%s: not a regular file or directory; resolve by hand", srcRel))
 			continue
 		}
-		collided, moveErr := f.moveEntryNoClobber(ctx, src, dest, e.IsDir())
+		skipReason, moveErr := f.moveEntryNoClobber(ctx, src, dest, e.IsDir())
 		if moveErr != nil {
 			return fmt.Errorf("doctor: %s: move %s: %w", f.ID(), srcRel, moveErr)
 		}
-		if collided {
-			// Destination name already exists: both old and new form present.
+		if skipReason != "" {
+			// Refused (destination collision, or destination state unknown).
 			// Never overwrite, never guess — leave the entry and report it.
-			res.Skipped = append(res.Skipped, fmt.Sprintf("%s: same name already exists in .agents/%s; resolve by hand", srcRel, workspaceCanonicalAliases[alias]))
+			res.Skipped = append(res.Skipped, fmt.Sprintf("%s: %s", srcRel, skipReason))
 			continue
 		}
 		res.ActionsTaken++
@@ -245,49 +264,68 @@ func (f workspaceNamingDriftFixer) fixOneAlias(ctx *MutateContext, base, alias s
 var errWorkspaceDriftDestExists = errors.New("destination appeared since scan; refusing to overwrite (refused_unsafe)")
 
 // moveEntryNoClobber moves one alias-directory entry to its canonical
-// destination WITHOUT ever overwriting: it takes the destination path's
-// advisory lock, re-checks destination non-existence immediately before the
-// rename, and only then routes the move through the chokepoint (Mutate for
-// regular files; workspaceDirRename — whose verify hook re-checks the
-// destination once more under the SOURCE lock — for directories). A
-// destination that (re)appears is reported as (collided=true, nil) and
-// nothing moves.
+// destination WITHOUT ever overwriting. It takes the destination path's
+// advisory lock, checks the destination, then routes the move through the
+// chokepoint discipline:
 //
-// Honesty note on the residual race: doctor's advisory locks are in-process
-// only. Holding the destination lock serializes against other chokepoint
-// mutations of the same destination path within this process, but an EXTERNAL
-// concurrent writer is not excluded — for such a writer this recheck only
-// narrows the overwrite window to lstat→rename. It does not eliminate it.
-func (workspaceNamingDriftFixer) moveEntryNoClobber(ctx *MutateContext, src, dest string, isDir bool) (collided bool, err error) {
+//   - Regular files go through workspaceFileMoveNoClobber, whose link+remove
+//     execute is kernel-atomic no-clobber: os.Link fails with EEXIST if the
+//     destination exists (or appears at ANY point, external writers
+//     included), so for files the lstat→rename overwrite window is closed
+//     for real, not merely narrowed.
+//   - Directories go through workspaceDirRename with a verify hook that
+//     re-checks destination non-existence under the SOURCE lock. Doctor's
+//     advisory locks are in-process only, so for an EXTERNAL writer a
+//     verify→rename window remains — but its worst case is bounded: POSIX
+//     rename refuses a non-empty destination directory (ENOTEMPTY), so the
+//     only thing the rename can silently replace is an EMPTY directory that
+//     appeared in the window. No content is lost, and the move is journaled
+//     and undoable.
+//
+// A non-empty skipReason means the entry was refused (destination collision,
+// or a destination whose state could not be verified) and nothing moved; the
+// caller records it in FixResult.Skipped.
+func (workspaceNamingDriftFixer) moveEntryNoClobber(ctx *MutateContext, src, dest string, isDir bool) (skipReason string, err error) {
+	collisionReason := fmt.Sprintf("same name already exists in .agents/%s; resolve by hand", filepath.Base(filepath.Dir(dest)))
 	if !ctx.DryRun {
 		guard, lerr := ctx.Locks.Acquire(dest)
 		if lerr != nil {
-			return false, lerr
+			return "", lerr
 		}
 		defer func() { _ = guard.Release() }()
 	}
 	if _, lerr := os.Lstat(dest); lerr == nil {
-		return true, nil
+		return collisionReason, nil
+	} else if !os.IsNotExist(lerr) {
+		// Permission or I/O failure: the destination's state is UNKNOWN, and
+		// unknown is never "absent". Refuse the move like a collision.
+		return fmt.Sprintf("cannot verify destination in .agents/%s (%v); resolve by hand", filepath.Base(filepath.Dir(dest)), lerr), nil
 	}
 	if isDir {
 		verify := func(string) error {
 			if _, lerr := os.Lstat(dest); lerr == nil {
 				return errWorkspaceDriftDestExists
+			} else if !os.IsNotExist(lerr) {
+				return fmt.Errorf("doctor: lstat %s: %v: %w", dest, lerr, errWorkspaceDriftDestExists)
 			}
 			return nil
 		}
 		if moveErr := workspaceDirRename(ctx, src, dest, verify); moveErr != nil {
 			if errors.Is(moveErr, errWorkspaceDriftDestExists) {
-				return true, nil
+				return collisionReason, nil
 			}
-			return false, moveErr
+			return "", moveErr
 		}
-		return false, nil
+		return "", nil
 	}
-	if _, moveErr := Mutate(ctx, src, Rename{To: dest}); moveErr != nil {
-		return false, moveErr
+	collided, moveErr := workspaceFileMoveNoClobber(ctx, src, dest)
+	if moveErr != nil {
+		return "", moveErr
 	}
-	return false, nil
+	if collided {
+		return collisionReason, nil
+	}
+	return "", nil
 }
 
 // workspaceRenameDir renames a directory through the shared workspace

--- a/cli/internal/doctor/fix_workspace_drift.go
+++ b/cli/internal/doctor/fix_workspace_drift.go
@@ -1,0 +1,287 @@
+package doctor
+
+// Workspace subsystem: fm-ws-naming-drift (auto-fixable).
+//
+// Flags top-level `.agents` directories whose names are drifted spellings of a
+// canonical directory (the workspaceCanonicalAliases registry: post-mortem ->
+// postmortem, handoffs -> handoff, proof -> proofs, ...). Drifted names split
+// one logical artifact family across two directories, so tooling that reads
+// only the canonical name silently misses half the corpus.
+//
+// The detector emits ONE FINDING PER ALIAS DIRECTORY found — each is a
+// distinct drift instance a user resolves separately — and every finding
+// carries the detector's ID (the framework convention: groupFindingsByFixer
+// matches findings to fixers by ID equality, so all fm-ws-naming-drift
+// findings route to the one fixer in a single Fix call).
+//
+// The fixer merges each alias directory into its canonical sibling entry by
+// entry under migration-owner discipline: an entry whose destination name
+// already exists in the canonical directory, or an entry that is neither a
+// regular file nor a directory (symlink, socket, ...), is NEVER moved and
+// never overwritten — it is reported in FixResult.Skipped for a human to
+// resolve. A fully emptied alias directory is quarantined via Rename into the
+// run's quarantine directory (never removed).
+//
+// Detector is PURE (stat + readdir only). Every fixer disk write flows through
+// the mutation chokepoint: regular files via Mutate, and directories via
+// workspaceRenameDir — an in-package directory adaptation of Mutate that
+// preserves the chokepoint's guarantees (per-path lock, write-scope check, op
+// check, dry-run, fsync'd actions.jsonl journal). Directory renames need no
+// byte backup to be reversible: undoOne reverses a Rename record with a bare
+// rename-back and consults neither backups nor hashes.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// fmWorkspaceNamingDriftID is the shared detector/fixer ID for this failure mode.
+const fmWorkspaceNamingDriftID = "fm-ws-naming-drift"
+
+func init() {
+	RegisterDetector(workspaceNamingDriftDetector{})
+	RegisterFixer(workspaceNamingDriftFixer{})
+}
+
+// sortedDriftAliases returns the alias names of workspaceCanonicalAliases in
+// deterministic sorted order, so findings and fix actions are stably ordered.
+func sortedDriftAliases() []string {
+	out := make([]string, 0, len(workspaceCanonicalAliases))
+	for alias := range workspaceCanonicalAliases {
+		out = append(out, alias)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// FM: fm-ws-naming-drift (auto-fixable)
+// ---------------------------------------------------------------------------
+
+// workspaceNamingDriftDetector flags each top-level `.agents` directory whose
+// name is a registered drifted alias of a canonical directory name.
+type workspaceNamingDriftDetector struct{}
+
+func (workspaceNamingDriftDetector) ID() string           { return fmWorkspaceNamingDriftID }
+func (workspaceNamingDriftDetector) Subsystem() string    { return subsystemWorkspace }
+func (workspaceNamingDriftDetector) Severity() string     { return "P3" }
+func (workspaceNamingDriftDetector) EstimatedCostMS() int { return 4 }
+func (workspaceNamingDriftDetector) OnlineRequired() bool { return false }
+func (workspaceNamingDriftDetector) QuickPath() bool      { return true }
+func (workspaceNamingDriftDetector) Describe() string {
+	return "top-level .agents directory uses a drifted spelling of a canonical name"
+}
+
+func (d workspaceNamingDriftDetector) Detect(env *DetectEnv) ([]Finding, error) {
+	inv, err := workspaceDirInventory(workspaceAgentsDir(env))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("doctor: inventory workspace: %w", err)
+	}
+	byName := make(map[string]workspaceDirInfo, len(inv))
+	for _, info := range inv {
+		byName[info.Name] = info
+	}
+	var findings []Finding
+	// One finding PER alias dir found: each is a distinct drift instance the
+	// user resolves separately. The alias is flagged regardless of whether the
+	// canonical directory exists (Rename creates a missing canonical dir).
+	for _, alias := range sortedDriftAliases() {
+		info, ok := byName[alias]
+		if !ok {
+			// The inventory is symlink-safe: an alias name occupied by a
+			// symlink or regular file is not a directory-naming drift.
+			continue
+		}
+		canonical := workspaceCanonicalAliases[alias]
+		findings = append(findings, Finding{
+			ID:         d.ID(),
+			Severity:   d.Severity(),
+			Subsystem:  d.Subsystem(),
+			Title:      fmt.Sprintf("workspace naming drift: .agents/%s -> .agents/%s", alias, canonical),
+			Confidence: 1.0,
+			Evidence: Evidence{
+				File:  filepath.Join(".agents", alias),
+				Query: fmt.Sprintf("%d transitive regular file(s) under .agents/%s; canonical directory is .agents/%s", info.FileCount, alias, canonical),
+			},
+			Remediation: Remediation{
+				Command:          "ao doctor --fix --only " + d.ID(),
+				ExplainCommand:   "ao doctor explain " + d.ID(),
+				AutoFixable:      true,
+				EstimatedActions: info.FileCount + 1,
+			},
+		})
+	}
+	return findings, nil
+}
+
+// workspaceNamingDriftFixer merges each alias directory into its canonical
+// sibling entry by entry, skipping (never overwriting) destination collisions
+// and non-regular non-directory oddities, then quarantines the emptied alias
+// directory. It re-scans the disk at fix time rather than trusting findings.
+type workspaceNamingDriftFixer struct{}
+
+func (workspaceNamingDriftFixer) ID() string { return fmWorkspaceNamingDriftID }
+func (workspaceNamingDriftFixer) Preconditions() []string {
+	return []string{
+		".agents exists and is a directory",
+		"alias path is a real directory (not a symlink or regular file)",
+		"moved entries have no same-named entry in the canonical directory",
+	}
+}
+func (workspaceNamingDriftFixer) WritesTo() []string { return []string{".agents"} }
+func (workspaceNamingDriftFixer) Ops() []string      { return []string{"Rename"} }
+func (workspaceNamingDriftFixer) Reversible() bool   { return true }
+func (workspaceNamingDriftFixer) Idempotent() bool   { return true }
+func (workspaceNamingDriftFixer) AutoFixable() bool  { return true }
+
+func (f workspaceNamingDriftFixer) Fix(ctx *MutateContext, env *DetectEnv, _ []Finding) (FixResult, error) {
+	res := FixResult{FixerID: f.ID(), FindingIDs: []string{f.ID()}}
+	base := workspaceAgentsDir(env)
+	for _, alias := range sortedDriftAliases() {
+		if err := f.fixOneAlias(ctx, base, alias, &res); err != nil {
+			res.Err = err
+			return res, err
+		}
+	}
+	// Migration-owner discipline: a non-empty Skipped means units were
+	// deliberately refused as ambiguous — the fixer is not fully done.
+	res.Fixed = len(res.Skipped) == 0
+	return res, nil
+}
+
+// fixOneAlias merges one alias directory into its canonical sibling. An absent
+// alias is a no-op (idempotency); a non-directory alias path is recorded in
+// Skipped and left alone. Skipped entries stay in place, and the alias dir is
+// quarantined only once it holds nothing at all.
+func (f workspaceNamingDriftFixer) fixOneAlias(ctx *MutateContext, base, alias string, res *FixResult) error {
+	aliasPath := filepath.Join(base, alias)
+	aliasRel := filepath.Join(".agents", alias)
+	fi, err := os.Lstat(aliasPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // nothing to do — already merged or never drifted
+		}
+		return fmt.Errorf("doctor: %s: lstat %s: %w", f.ID(), aliasRel, err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 || !fi.IsDir() {
+		// Never guess: an alias name occupied by a symlink or regular file is
+		// not the drift this fixer owns. Leave it for a human.
+		res.Skipped = append(res.Skipped, fmt.Sprintf("%s: alias path is not a real directory; resolve by hand", aliasRel))
+		return nil
+	}
+	canonicalDir := filepath.Join(base, workspaceCanonicalAliases[alias])
+	entries, err := os.ReadDir(aliasPath)
+	if err != nil {
+		return fmt.Errorf("doctor: %s: read %s: %w", f.ID(), aliasRel, err)
+	}
+	for _, e := range entries {
+		src := filepath.Join(aliasPath, e.Name())
+		dest := filepath.Join(canonicalDir, e.Name())
+		srcRel := filepath.Join(aliasRel, e.Name())
+		if _, lerr := os.Lstat(dest); lerr == nil {
+			// Destination name already exists: both old and new form present.
+			// Never overwrite, never guess — leave the entry and report it.
+			res.Skipped = append(res.Skipped, fmt.Sprintf("%s: same name already exists in .agents/%s; resolve by hand", srcRel, workspaceCanonicalAliases[alias]))
+			continue
+		}
+		var moveErr error
+		switch {
+		case e.Type().IsRegular():
+			_, moveErr = Mutate(ctx, src, Rename{To: dest})
+		case e.IsDir():
+			moveErr = workspaceRenameDir(ctx, src, dest)
+		default:
+			// Symlink or other special file: moving it could silently change
+			// what it resolves to. Leave it in place.
+			res.Skipped = append(res.Skipped, fmt.Sprintf("%s: not a regular file or directory; resolve by hand", srcRel))
+			continue
+		}
+		if moveErr != nil {
+			return fmt.Errorf("doctor: %s: move %s: %w", f.ID(), srcRel, moveErr)
+		}
+		res.ActionsTaken++
+	}
+	if ctx.DryRun {
+		return nil // post-state is unobservable in dry-run; nothing moved
+	}
+	remaining, err := os.ReadDir(aliasPath)
+	if err != nil {
+		return fmt.Errorf("doctor: %s: re-read %s: %w", f.ID(), aliasRel, err)
+	}
+	if len(remaining) != 0 {
+		res.Skipped = append(res.Skipped, fmt.Sprintf("%s: %d skipped entr(y/ies) remain; alias dir left in place", aliasRel, len(remaining)))
+		return nil
+	}
+	if err := workspaceRenameDir(ctx, aliasPath, workspaceQuarantineDest(ctx, alias)); err != nil {
+		return fmt.Errorf("doctor: %s: quarantine %s: %w", f.ID(), aliasRel, err)
+	}
+	res.ActionsTaken++
+	return nil
+}
+
+// workspaceRenameDir renames a directory through the mutation chokepoint's
+// guarantees. Mutate itself is file-shaped (it hashes and backs up the path's
+// bytes, which fails with EISDIR on a directory), so this helper adapts its
+// steps for a directory: the same per-path lock, the same write-scope and op
+// preconditions, the same dry-run behavior, the same atomic execute
+// (executeAtomic MkdirAll's the destination parent), and the same fsync'd
+// actions.jsonl record. A directory Rename needs no byte backup or content
+// hash to be reversible: undoOne reverses a Rename record with a bare
+// rename-back and never consults backups or hashes for it. Hash fields are
+// recorded as the empty-content hash for journal-shape consistency.
+func workspaceRenameDir(ctx *MutateContext, path string, to string) error {
+	if !ctx.DryRun {
+		guard, err := ctx.Locks.Acquire(path)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = guard.Release() }()
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("doctor: lstat %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("doctor: rename-dir %s: not a directory", path)
+	}
+	op := Rename{To: to}
+	if err := EnsureInScope(ctx.Capabilities, ctx.RepoRoot, ctx.HomeDir, path); err != nil {
+		return err
+	}
+	if err := EnsureOpAllowed(ctx.Capabilities, op); err != nil {
+		return err
+	}
+	startedNS := time.Since(ctx.start).Nanoseconds()
+	if ctx.DryRun {
+		fmt.Fprintf(os.Stderr, "[dry-run] would mutate %s: %s\n", path, DescribeOp(op))
+		return nil
+	}
+	if err := executeAtomic(path, op); err != nil {
+		return fmt.Errorf("doctor: execute Rename on %s: %w", path, err)
+	}
+	rel, relErr := filepath.Rel(ctx.RepoRoot, path)
+	if relErr != nil {
+		rel = path
+	}
+	emptyHash := sha256Hex(nil)
+	return ctx.appendAction(ActionRecord{
+		Path:         rel,
+		Op:           op.kind(),
+		BeforeHash:   emptyHash,
+		AfterHash:    emptyHash,
+		BeforeMode:   fmt.Sprintf("%o", info.Mode().Perm()),
+		StartedAtNS:  startedNS,
+		FinishedAtNS: time.Since(ctx.start).Nanoseconds(),
+		RunID:        ctx.RunID,
+		FixerID:      ctx.FixerID,
+		OK:           true,
+		RenameTo:     to,
+		Existed:      true,
+	})
+}

--- a/cli/internal/doctor/fix_workspace_drift.go
+++ b/cli/internal/doctor/fix_workspace_drift.go
@@ -31,6 +31,7 @@ package doctor
 // rename-back and consults neither backups nor hashes.
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -75,7 +76,13 @@ func (workspaceNamingDriftDetector) Describe() string {
 }
 
 func (d workspaceNamingDriftDetector) Detect(env *DetectEnv) ([]Finding, error) {
-	inv, err := workspaceDirInventory(workspaceAgentsDir(env))
+	base := workspaceAgentsDir(env)
+	// Lstat guard: a symlinked `.agents` root would make the inventory (and
+	// then the fixer's renames) traverse a tree outside the repo.
+	if !workspaceRealDir(base) {
+		return nil, nil
+	}
+	inv, err := workspaceDirInventory(base)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -142,6 +149,18 @@ func (workspaceNamingDriftFixer) AutoFixable() bool  { return true }
 func (f workspaceNamingDriftFixer) Fix(ctx *MutateContext, env *DetectEnv, _ []Finding) (FixResult, error) {
 	res := FixResult{FixerID: f.ID(), FindingIDs: []string{f.ID()}}
 	base := workspaceAgentsDir(env)
+	// Never mutate through a `.agents` root that is not a real directory: a
+	// symlinked root would make every merge rename act on a tree OUTSIDE the
+	// repo while the lexical scope check still passes.
+	exists, err := workspaceRequireRealAgentsDir(base)
+	if err != nil {
+		res.Err = fmt.Errorf("doctor: %s: %w", f.ID(), err)
+		return res, res.Err
+	}
+	if !exists {
+		res.Fixed = true // no workspace, nothing drifted
+		return res, nil
+	}
 	for _, alias := range sortedDriftAliases() {
 		if err := f.fixOneAlias(ctx, base, alias, &res); err != nil {
 			res.Err = err
@@ -183,26 +202,21 @@ func (f workspaceNamingDriftFixer) fixOneAlias(ctx *MutateContext, base, alias s
 		src := filepath.Join(aliasPath, e.Name())
 		dest := filepath.Join(canonicalDir, e.Name())
 		srcRel := filepath.Join(aliasRel, e.Name())
-		if _, lerr := os.Lstat(dest); lerr == nil {
-			// Destination name already exists: both old and new form present.
-			// Never overwrite, never guess — leave the entry and report it.
-			res.Skipped = append(res.Skipped, fmt.Sprintf("%s: same name already exists in .agents/%s; resolve by hand", srcRel, workspaceCanonicalAliases[alias]))
-			continue
-		}
-		var moveErr error
-		switch {
-		case e.Type().IsRegular():
-			_, moveErr = Mutate(ctx, src, Rename{To: dest})
-		case e.IsDir():
-			moveErr = workspaceRenameDir(ctx, src, dest)
-		default:
+		if !e.Type().IsRegular() && !e.IsDir() {
 			// Symlink or other special file: moving it could silently change
 			// what it resolves to. Leave it in place.
 			res.Skipped = append(res.Skipped, fmt.Sprintf("%s: not a regular file or directory; resolve by hand", srcRel))
 			continue
 		}
+		collided, moveErr := f.moveEntryNoClobber(ctx, src, dest, e.IsDir())
 		if moveErr != nil {
 			return fmt.Errorf("doctor: %s: move %s: %w", f.ID(), srcRel, moveErr)
+		}
+		if collided {
+			// Destination name already exists: both old and new form present.
+			// Never overwrite, never guess — leave the entry and report it.
+			res.Skipped = append(res.Skipped, fmt.Sprintf("%s: same name already exists in .agents/%s; resolve by hand", srcRel, workspaceCanonicalAliases[alias]))
+			continue
 		}
 		res.ActionsTaken++
 	}
@@ -222,6 +236,58 @@ func (f workspaceNamingDriftFixer) fixOneAlias(ctx *MutateContext, base, alias s
 	}
 	res.ActionsTaken++
 	return nil
+}
+
+// errWorkspaceDriftDestExists is the sentinel raised by the under-lock
+// destination recheck when a same-named entry appeared at the destination
+// after the caller's scan. It is classified as a collision (Skipped), never
+// an overwrite.
+var errWorkspaceDriftDestExists = errors.New("destination appeared since scan; refusing to overwrite (refused_unsafe)")
+
+// moveEntryNoClobber moves one alias-directory entry to its canonical
+// destination WITHOUT ever overwriting: it takes the destination path's
+// advisory lock, re-checks destination non-existence immediately before the
+// rename, and only then routes the move through the chokepoint (Mutate for
+// regular files; workspaceDirRename — whose verify hook re-checks the
+// destination once more under the SOURCE lock — for directories). A
+// destination that (re)appears is reported as (collided=true, nil) and
+// nothing moves.
+//
+// Honesty note on the residual race: doctor's advisory locks are in-process
+// only. Holding the destination lock serializes against other chokepoint
+// mutations of the same destination path within this process, but an EXTERNAL
+// concurrent writer is not excluded — for such a writer this recheck only
+// narrows the overwrite window to lstat→rename. It does not eliminate it.
+func (workspaceNamingDriftFixer) moveEntryNoClobber(ctx *MutateContext, src, dest string, isDir bool) (collided bool, err error) {
+	if !ctx.DryRun {
+		guard, lerr := ctx.Locks.Acquire(dest)
+		if lerr != nil {
+			return false, lerr
+		}
+		defer func() { _ = guard.Release() }()
+	}
+	if _, lerr := os.Lstat(dest); lerr == nil {
+		return true, nil
+	}
+	if isDir {
+		verify := func(string) error {
+			if _, lerr := os.Lstat(dest); lerr == nil {
+				return errWorkspaceDriftDestExists
+			}
+			return nil
+		}
+		if moveErr := workspaceDirRename(ctx, src, dest, verify); moveErr != nil {
+			if errors.Is(moveErr, errWorkspaceDriftDestExists) {
+				return true, nil
+			}
+			return false, moveErr
+		}
+		return false, nil
+	}
+	if _, moveErr := Mutate(ctx, src, Rename{To: dest}); moveErr != nil {
+		return false, moveErr
+	}
+	return false, nil
 }
 
 // workspaceRenameDir renames a directory through the shared workspace

--- a/cli/internal/doctor/fix_workspace_drift.go
+++ b/cli/internal/doctor/fix_workspace_drift.go
@@ -35,7 +35,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"time"
 )
 
 // fmWorkspaceNamingDriftID is the shared detector/fixer ID for this failure mode.
@@ -225,63 +224,10 @@ func (f workspaceNamingDriftFixer) fixOneAlias(ctx *MutateContext, base, alias s
 	return nil
 }
 
-// workspaceRenameDir renames a directory through the mutation chokepoint's
-// guarantees. Mutate itself is file-shaped (it hashes and backs up the path's
-// bytes, which fails with EISDIR on a directory), so this helper adapts its
-// steps for a directory: the same per-path lock, the same write-scope and op
-// preconditions, the same dry-run behavior, the same atomic execute
-// (executeAtomic MkdirAll's the destination parent), and the same fsync'd
-// actions.jsonl record. A directory Rename needs no byte backup or content
-// hash to be reversible: undoOne reverses a Rename record with a bare
-// rename-back and never consults backups or hashes for it. Hash fields are
-// recorded as the empty-content hash for journal-shape consistency.
+// workspaceRenameDir renames a directory through the shared workspace
+// directory-rename chokepoint adapter (workspaceDirRename): same per-path
+// lock, scope/op preconditions on both endpoints, dry-run transparency,
+// atomic execute, and fsync'd actions.jsonl record.
 func workspaceRenameDir(ctx *MutateContext, path string, to string) error {
-	if !ctx.DryRun {
-		guard, err := ctx.Locks.Acquire(path)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = guard.Release() }()
-	}
-	info, err := os.Lstat(path)
-	if err != nil {
-		return fmt.Errorf("doctor: lstat %s: %w", path, err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("doctor: rename-dir %s: not a directory", path)
-	}
-	op := Rename{To: to}
-	if err := EnsureInScope(ctx.Capabilities, ctx.RepoRoot, ctx.HomeDir, path); err != nil {
-		return err
-	}
-	if err := EnsureOpAllowed(ctx.Capabilities, op); err != nil {
-		return err
-	}
-	startedNS := time.Since(ctx.start).Nanoseconds()
-	if ctx.DryRun {
-		fmt.Fprintf(os.Stderr, "[dry-run] would mutate %s: %s\n", path, DescribeOp(op))
-		return nil
-	}
-	if err := executeAtomic(path, op); err != nil {
-		return fmt.Errorf("doctor: execute Rename on %s: %w", path, err)
-	}
-	rel, relErr := filepath.Rel(ctx.RepoRoot, path)
-	if relErr != nil {
-		rel = path
-	}
-	emptyHash := sha256Hex(nil)
-	return ctx.appendAction(ActionRecord{
-		Path:         rel,
-		Op:           op.kind(),
-		BeforeHash:   emptyHash,
-		AfterHash:    emptyHash,
-		BeforeMode:   fmt.Sprintf("%o", info.Mode().Perm()),
-		StartedAtNS:  startedNS,
-		FinishedAtNS: time.Since(ctx.start).Nanoseconds(),
-		RunID:        ctx.RunID,
-		FixerID:      ctx.FixerID,
-		OK:           true,
-		RenameTo:     to,
-		Existed:      true,
-	})
+	return workspaceDirRename(ctx, path, to, nil)
 }

--- a/cli/internal/doctor/fix_workspace_drift_test.go
+++ b/cli/internal/doctor/fix_workspace_drift_test.go
@@ -359,6 +359,68 @@ func TestWorkspaceNamingDrift_SymlinkEntrySkipped(t *testing.T) {
 	}
 }
 
+// TestWorkspaceNamingDrift_LateDestinationCollisionSkipped exercises the
+// under-lock destination recheck directly: a destination file that appears
+// AFTER the fixer's directory scan (the detect→rename window) is a collision
+// — the move is refused, nothing is overwritten, and nothing is journaled.
+// The fixer's early ReadDir-time collision check cannot see this file; only
+// the lock→lstat→rename recheck inside moveEntryNoClobber can.
+func TestWorkspaceNamingDrift_LateDestinationCollisionSkipped(t *testing.T) {
+	_, repo := namingDriftEnv(t)
+	agents := filepath.Join(repo, ".agents")
+	alias := filepath.Join(agents, "retros")
+	canonical := filepath.Join(agents, "retro")
+
+	// File case: dest file appears in the window.
+	writeDriftFile(t, filepath.Join(alias, "dup.md"), "alias body")
+	writeDriftFile(t, filepath.Join(canonical, "dup.md"), "late arrival")
+
+	ctx, ra := newNamingDriftCtx(t, repo, false)
+	fixer := workspaceNamingDriftFixer{}
+	collided, err := fixer.moveEntryNoClobber(ctx, filepath.Join(alias, "dup.md"), filepath.Join(canonical, "dup.md"), false)
+	if err != nil {
+		t.Fatalf("moveEntryNoClobber(file): %v", err)
+	}
+	if !collided {
+		t.Fatal("moveEntryNoClobber(file) did not report the late collision")
+	}
+	if got := readDriftFile(t, filepath.Join(alias, "dup.md")); got != "alias body" {
+		t.Errorf("alias dup.md = %q, want %q (source moved!)", got, "alias body")
+	}
+	if got := readDriftFile(t, filepath.Join(canonical, "dup.md")); got != "late arrival" {
+		t.Errorf("canonical dup.md = %q, want %q (dest overwritten!)", got, "late arrival")
+	}
+
+	// Directory case: dest dir appears in the window (an empty dest dir is
+	// exactly the shape os.Rename would silently replace).
+	writeDriftFile(t, filepath.Join(alias, "subdir", "n.md"), "nested body")
+	if err := os.MkdirAll(filepath.Join(canonical, "subdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	collided, err = fixer.moveEntryNoClobber(ctx, filepath.Join(alias, "subdir"), filepath.Join(canonical, "subdir"), true)
+	if err != nil {
+		t.Fatalf("moveEntryNoClobber(dir): %v", err)
+	}
+	if !collided {
+		t.Fatal("moveEntryNoClobber(dir) did not report the late collision")
+	}
+	if got := readDriftFile(t, filepath.Join(alias, "subdir", "n.md")); got != "nested body" {
+		t.Errorf("alias subdir/n.md = %q, want %q (source moved!)", got, "nested body")
+	}
+	if st, err := os.Stat(filepath.Join(canonical, "subdir")); err != nil || !st.IsDir() {
+		t.Errorf("canonical subdir gone (err=%v)", err)
+	}
+
+	// Neither refused move was journaled.
+	recs, err := readActions(ra.ActionsPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("collided moves wrote %d action records, want 0", len(recs))
+	}
+}
+
 func TestWorkspaceNamingDrift_DryRunTouchesNothing(t *testing.T) {
 	env, repo := namingDriftEnv(t)
 	agents := filepath.Join(repo, ".agents")

--- a/cli/internal/doctor/fix_workspace_drift_test.go
+++ b/cli/internal/doctor/fix_workspace_drift_test.go
@@ -1,0 +1,426 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// namingDriftEnv builds an isolated repo with an `.agents/` workspace root and
+// returns a DetectEnv plus the repo root.
+func namingDriftEnv(t *testing.T) (*DetectEnv, string) {
+	t.Helper()
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".agents"), 0o755); err != nil {
+		t.Fatalf("mkdir .agents: %v", err)
+	}
+	return &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}, repo
+}
+
+// newNamingDriftCtx builds a real MutateContext rooted at repo, scoped to the
+// naming-drift fixer, with a live actions.jsonl handle.
+//
+// The capabilities write scopes are extended with ".agents": the committed
+// canonicalWriteScopes predates the workspace subsystem and only lists four
+// `.agents/<name>` subtrees, so every workspace fixer source path (e.g.
+// `.agents/post-mortem/x.md`) is refused by EnsureInScope until the
+// capabilities registry gains the workspace scope. This mirrors the scope
+// configuration the workspace subsystem requires in production; the
+// canonicalWriteScopes entry itself is owned by the capabilities lane.
+func newNamingDriftCtx(t *testing.T, repo string, dryRun bool) (*MutateContext, *RunArtifact) {
+	t.Helper()
+	ra, err := NewRunArtifact(repo, "wsdrift", time.Now())
+	if err != nil {
+		t.Fatalf("NewRunArtifact: %v", err)
+	}
+	af, err := ra.OpenActionsFile()
+	if err != nil {
+		t.Fatalf("OpenActionsFile: %v", err)
+	}
+	t.Cleanup(func() { _ = af.Close() })
+	caps := NewCapabilities("2.0.0")
+	caps.WriteScopes = append(caps.WriteScopes, ".agents")
+	locks := NewLockManager(filepath.Join(repo, ".doctor", "locks"))
+	return NewMutateContext(ra, caps, t.TempDir(), locks, af, dryRun).WithFixer(fmWorkspaceNamingDriftID), ra
+}
+
+// writeDriftFile writes content to path, creating parent directories.
+func writeDriftFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// readDriftFile reads path and fails the test on error.
+func readDriftFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func TestWorkspaceNamingDrift_DetectOnePerAlias(t *testing.T) {
+	env, repo := namingDriftEnv(t)
+	agents := filepath.Join(repo, ".agents")
+	// Two alias dirs: one with files (incl. nested), one empty.
+	writeDriftFile(t, filepath.Join(agents, "post-mortem", "a.md"), "alpha")
+	writeDriftFile(t, filepath.Join(agents, "post-mortem", "sub", "nested.md"), "nested")
+	if err := os.MkdirAll(filepath.Join(agents, "test"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Canonical dirs and unrelated dirs must not be flagged.
+	writeDriftFile(t, filepath.Join(agents, "retro", "r.md"), "retro")
+	writeDriftFile(t, filepath.Join(agents, "learnings", "l.md"), "learn")
+	// An alias name occupied by a symlink is not a directory-naming drift.
+	if err := os.Symlink(filepath.Join(agents, "retro"), filepath.Join(agents, "proof")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	findings, err := workspaceNamingDriftDetector{}.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("findings = %d, want 2 (one per alias dir): %+v", len(findings), findings)
+	}
+	// Deterministic alias-sorted order; every finding carries the detector ID.
+	for _, f := range findings {
+		if f.ID != fmWorkspaceNamingDriftID {
+			t.Errorf("finding ID = %q, want %q", f.ID, fmWorkspaceNamingDriftID)
+		}
+		if f.Subsystem != "workspace" || f.Severity != "P3" {
+			t.Errorf("finding subsystem/severity = %q/%q, want workspace/P3", f.Subsystem, f.Severity)
+		}
+		if !f.Remediation.AutoFixable {
+			t.Error("finding not marked auto-fixable")
+		}
+	}
+	if findings[0].Evidence.File != filepath.Join(".agents", "post-mortem") {
+		t.Errorf("finding 0 evidence file = %q, want .agents/post-mortem", findings[0].Evidence.File)
+	}
+	if want := "2 transitive regular file(s) under .agents/post-mortem"; !strings.Contains(findings[0].Evidence.Query, want) {
+		t.Errorf("finding 0 evidence query = %q, want it to contain %q", findings[0].Evidence.Query, want)
+	}
+	if findings[0].Remediation.EstimatedActions != 3 {
+		t.Errorf("finding 0 estimated actions = %d, want 3 (2 files + quarantine)", findings[0].Remediation.EstimatedActions)
+	}
+	if findings[1].Evidence.File != filepath.Join(".agents", "test") {
+		t.Errorf("finding 1 evidence file = %q, want .agents/test", findings[1].Evidence.File)
+	}
+	if want := "0 transitive regular file(s)"; !strings.Contains(findings[1].Evidence.Query, want) {
+		t.Errorf("finding 1 evidence query = %q, want it to contain %q", findings[1].Evidence.Query, want)
+	}
+}
+
+func TestWorkspaceNamingDrift_DetectNoWorkspace(t *testing.T) {
+	repo := t.TempDir() // no .agents at all
+	env := &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}
+	findings, err := workspaceNamingDriftDetector{}.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("missing .agents produced %d findings", len(findings))
+	}
+}
+
+// Scenario (a) + (d): clean merge into a pre-existing canonical dir, alias dir
+// quarantined, second detect clean, and undo restores the original tree.
+func TestWorkspaceNamingDrift_CleanMergeQuarantineUndo(t *testing.T) {
+	env, repo := namingDriftEnv(t)
+	agents := filepath.Join(repo, ".agents")
+	alias := filepath.Join(agents, "post-mortems")
+	canonical := filepath.Join(agents, "postmortem")
+	writeDriftFile(t, filepath.Join(alias, "a.md"), "alpha body")
+	writeDriftFile(t, filepath.Join(alias, "sub", "nested.md"), "nested body")
+	// Canonical pre-exists with an unrelated file that must remain.
+	writeDriftFile(t, filepath.Join(canonical, "unrelated.md"), "keep me")
+
+	det := workspaceNamingDriftDetector{}
+	findings, err := det.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 1 || findings[0].ID != fmWorkspaceNamingDriftID {
+		t.Fatalf("findings = %+v, want exactly one %s", findings, fmWorkspaceNamingDriftID)
+	}
+
+	ctx, ra := newNamingDriftCtx(t, repo, false)
+	res, err := workspaceNamingDriftFixer{}.Fix(ctx, env, findings)
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if !res.Fixed {
+		t.Errorf("Fix not reported Fixed; skipped = %v", res.Skipped)
+	}
+	if res.ActionsTaken != 3 {
+		t.Errorf("ActionsTaken = %d, want 3 (a.md, sub, quarantine)", res.ActionsTaken)
+	}
+	if len(res.Skipped) != 0 {
+		t.Errorf("Skipped = %v, want empty", res.Skipped)
+	}
+	// Exact contents after the merge.
+	if got := readDriftFile(t, filepath.Join(canonical, "unrelated.md")); got != "keep me" {
+		t.Errorf("unrelated.md = %q, want %q", got, "keep me")
+	}
+	if got := readDriftFile(t, filepath.Join(canonical, "a.md")); got != "alpha body" {
+		t.Errorf("moved a.md = %q, want %q", got, "alpha body")
+	}
+	if got := readDriftFile(t, filepath.Join(canonical, "sub", "nested.md")); got != "nested body" {
+		t.Errorf("moved sub/nested.md = %q, want %q", got, "nested body")
+	}
+	// Alias dir gone from the workspace, present (empty) in quarantine.
+	if _, err := os.Lstat(alias); !os.IsNotExist(err) {
+		t.Errorf("alias dir still present after clean merge (err=%v)", err)
+	}
+	qdir := filepath.Join(ctx.RunDir, "quarantine", "workspace", "post-mortems")
+	qinfo, err := os.Stat(qdir)
+	if err != nil || !qinfo.IsDir() {
+		t.Fatalf("quarantined alias dir missing: %v", err)
+	}
+	if qents, _ := os.ReadDir(qdir); len(qents) != 0 {
+		t.Errorf("quarantined alias dir not empty: %d entries", len(qents))
+	}
+	// Journal: three OK Rename records.
+	recs, err := readActions(ra.ActionsPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 3 {
+		t.Fatalf("actions = %d, want 3: %+v", len(recs), recs)
+	}
+	for _, r := range recs {
+		if r.Op != "Rename" || r.RenameTo == "" || !r.OK {
+			t.Errorf("bad rename record: %+v", r)
+		}
+	}
+	// Scenario (d): second detect finds nothing after a clean merge.
+	again, err := det.Detect(env)
+	if err != nil {
+		t.Fatalf("re-Detect: %v", err)
+	}
+	if len(again) != 0 {
+		t.Fatalf("post-fix detect found %d findings, want 0", len(again))
+	}
+	// Undo restores the exact original tree.
+	ur, err := Undo(repo, ra.RunID, true, false)
+	if err != nil {
+		t.Fatalf("Undo: %v", err)
+	}
+	if ur.Restored != 3 {
+		t.Errorf("Undo restored = %d, want 3", ur.Restored)
+	}
+	if got := readDriftFile(t, filepath.Join(alias, "a.md")); got != "alpha body" {
+		t.Errorf("after undo a.md = %q, want %q", got, "alpha body")
+	}
+	if got := readDriftFile(t, filepath.Join(alias, "sub", "nested.md")); got != "nested body" {
+		t.Errorf("after undo sub/nested.md = %q, want %q", got, "nested body")
+	}
+	if ents, _ := os.ReadDir(canonical); len(ents) != 1 {
+		t.Errorf("after undo canonical has %d entries, want only unrelated.md", len(ents))
+	}
+}
+
+// Scenario (b): a same-named file in both dirs is skipped, both copies stay
+// byte-intact, and the alias dir is left in place.
+func TestWorkspaceNamingDrift_CollisionSkipsBothIntact(t *testing.T) {
+	env, repo := namingDriftEnv(t)
+	agents := filepath.Join(repo, ".agents")
+	alias := filepath.Join(agents, "proof")
+	canonical := filepath.Join(agents, "proofs")
+	writeDriftFile(t, filepath.Join(alias, "dup.md"), "alias body")
+	writeDriftFile(t, filepath.Join(alias, "ok.md"), "ok body")
+	writeDriftFile(t, filepath.Join(canonical, "dup.md"), "canonical body")
+
+	ctx, _ := newNamingDriftCtx(t, repo, false)
+	res, err := workspaceNamingDriftFixer{}.Fix(ctx, env, nil)
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if res.Fixed {
+		t.Error("Fix reported Fixed despite a skipped collision")
+	}
+	if res.ActionsTaken != 1 {
+		t.Errorf("ActionsTaken = %d, want 1 (only ok.md)", res.ActionsTaken)
+	}
+	if len(res.Skipped) == 0 {
+		t.Fatal("Skipped is empty, want the collision reported")
+	}
+	wantPath := filepath.Join(".agents", "proof", "dup.md")
+	if !strings.Contains(res.Skipped[0], wantPath) {
+		t.Errorf("Skipped[0] = %q, want it to name %q", res.Skipped[0], wantPath)
+	}
+	// BOTH files byte-intact after the fix.
+	if got := readDriftFile(t, filepath.Join(alias, "dup.md")); got != "alias body" {
+		t.Errorf("alias dup.md = %q, want %q", got, "alias body")
+	}
+	if got := readDriftFile(t, filepath.Join(canonical, "dup.md")); got != "canonical body" {
+		t.Errorf("canonical dup.md = %q, want %q", got, "canonical body")
+	}
+	// The clean entry moved; the alias dir was NOT quarantined.
+	if got := readDriftFile(t, filepath.Join(canonical, "ok.md")); got != "ok body" {
+		t.Errorf("moved ok.md = %q, want %q", got, "ok body")
+	}
+	if info, err := os.Stat(alias); err != nil || !info.IsDir() {
+		t.Errorf("alias dir with a skipped entry must remain (err=%v)", err)
+	}
+	// The retained alias dir is itself noted in Skipped.
+	last := res.Skipped[len(res.Skipped)-1]
+	if !strings.Contains(last, filepath.Join(".agents", "proof")) || !strings.Contains(last, "left in place") {
+		t.Errorf("Skipped tail = %q, want a left-in-place note for .agents/proof", last)
+	}
+}
+
+// Scenario (c): the canonical dir does not exist; Rename creates it and every
+// file arrives byte-intact.
+func TestWorkspaceNamingDrift_CanonicalAbsentCreated(t *testing.T) {
+	env, repo := namingDriftEnv(t)
+	agents := filepath.Join(repo, ".agents")
+	alias := filepath.Join(agents, "retros")
+	canonical := filepath.Join(agents, "retro")
+	writeDriftFile(t, filepath.Join(alias, "r1.md"), "retro one")
+	writeDriftFile(t, filepath.Join(alias, "r2.md"), "retro two")
+
+	ctx, _ := newNamingDriftCtx(t, repo, false)
+	res, err := workspaceNamingDriftFixer{}.Fix(ctx, env, nil)
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if !res.Fixed || len(res.Skipped) != 0 {
+		t.Errorf("Fix result: fixed=%t skipped=%v, want clean", res.Fixed, res.Skipped)
+	}
+	if res.ActionsTaken != 3 {
+		t.Errorf("ActionsTaken = %d, want 3 (r1, r2, quarantine)", res.ActionsTaken)
+	}
+	if got := readDriftFile(t, filepath.Join(canonical, "r1.md")); got != "retro one" {
+		t.Errorf("r1.md = %q, want %q", got, "retro one")
+	}
+	if got := readDriftFile(t, filepath.Join(canonical, "r2.md")); got != "retro two" {
+		t.Errorf("r2.md = %q, want %q", got, "retro two")
+	}
+	if _, err := os.Lstat(alias); !os.IsNotExist(err) {
+		t.Errorf("alias dir still present (err=%v)", err)
+	}
+	// Idempotency: a second fix run is a no-op.
+	res2, err := workspaceNamingDriftFixer{}.Fix(ctx, env, nil)
+	if err != nil {
+		t.Fatalf("second Fix: %v", err)
+	}
+	if !res2.Fixed || res2.ActionsTaken != 0 || len(res2.Skipped) != 0 {
+		t.Errorf("second Fix: fixed=%t actions=%d skipped=%v, want clean no-op", res2.Fixed, res2.ActionsTaken, res2.Skipped)
+	}
+}
+
+// A symlink entry inside the alias dir is never moved: moving it could change
+// what it resolves to. It is reported in Skipped and the alias dir remains.
+func TestWorkspaceNamingDrift_SymlinkEntrySkipped(t *testing.T) {
+	env, repo := namingDriftEnv(t)
+	agents := filepath.Join(repo, ".agents")
+	alias := filepath.Join(agents, "handoffs")
+	canonical := filepath.Join(agents, "handoff")
+	writeDriftFile(t, filepath.Join(alias, "real.md"), "real body")
+	linkTarget := filepath.Join(repo, "outside.txt")
+	writeDriftFile(t, linkTarget, "outside")
+	if err := os.Symlink(linkTarget, filepath.Join(alias, "link.md")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	ctx, _ := newNamingDriftCtx(t, repo, false)
+	res, err := workspaceNamingDriftFixer{}.Fix(ctx, env, nil)
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if res.Fixed {
+		t.Error("Fix reported Fixed despite a skipped symlink")
+	}
+	if res.ActionsTaken != 1 {
+		t.Errorf("ActionsTaken = %d, want 1 (only real.md)", res.ActionsTaken)
+	}
+	found := false
+	for _, s := range res.Skipped {
+		if strings.Contains(s, filepath.Join(".agents", "handoffs", "link.md")) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Skipped = %v, want the symlink entry named", res.Skipped)
+	}
+	if got := readDriftFile(t, filepath.Join(canonical, "real.md")); got != "real body" {
+		t.Errorf("moved real.md = %q, want %q", got, "real body")
+	}
+	// Symlink left in place and still resolving.
+	if got := readDriftFile(t, filepath.Join(alias, "link.md")); got != "outside" {
+		t.Errorf("symlink no longer resolves to original content: %q", got)
+	}
+	if info, err := os.Lstat(filepath.Join(alias, "link.md")); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("link.md is no longer a symlink (err=%v)", err)
+	}
+}
+
+func TestWorkspaceNamingDrift_DryRunTouchesNothing(t *testing.T) {
+	env, repo := namingDriftEnv(t)
+	agents := filepath.Join(repo, ".agents")
+	writeDriftFile(t, filepath.Join(agents, "retros", "r1.md"), "retro one")
+	writeDriftFile(t, filepath.Join(agents, "retros", "sub", "n.md"), "nested")
+
+	ctx, ra := newNamingDriftCtx(t, repo, true)
+	res, err := workspaceNamingDriftFixer{}.Fix(ctx, env, nil)
+	if err != nil {
+		t.Fatalf("dry-run Fix: %v", err)
+	}
+	if len(res.Skipped) != 0 {
+		t.Errorf("dry-run Skipped = %v, want empty", res.Skipped)
+	}
+	// Nothing on disk changed.
+	if got := readDriftFile(t, filepath.Join(agents, "retros", "r1.md")); got != "retro one" {
+		t.Errorf("dry-run moved r1.md: %q", got)
+	}
+	if got := readDriftFile(t, filepath.Join(agents, "retros", "sub", "n.md")); got != "nested" {
+		t.Errorf("dry-run moved sub/n.md: %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(agents, "retro")); !os.IsNotExist(err) {
+		t.Errorf("dry-run created the canonical dir (err=%v)", err)
+	}
+	recs, err := readActions(ra.ActionsPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 0 {
+		t.Errorf("dry-run wrote %d action records, want 0", len(recs))
+	}
+}
+
+func TestWorkspaceNamingDrift_Registered(t *testing.T) {
+	var det Detector
+	for _, d := range Detectors() {
+		if d.ID() == fmWorkspaceNamingDriftID {
+			det = d
+		}
+	}
+	if det == nil {
+		t.Fatalf("detector %s not registered", fmWorkspaceNamingDriftID)
+	}
+	if det.Subsystem() != "workspace" || det.Severity() != "P3" || !det.QuickPath() || det.OnlineRequired() {
+		t.Errorf("detector contract: subsystem=%q severity=%q quick=%t online=%t",
+			det.Subsystem(), det.Severity(), det.QuickPath(), det.OnlineRequired())
+	}
+	fx := FixerByID(fmWorkspaceNamingDriftID)
+	if fx == nil {
+		t.Fatalf("fixer %s not registered", fmWorkspaceNamingDriftID)
+	}
+	if !fx.AutoFixable() || !fx.Reversible() || !fx.Idempotent() {
+		t.Errorf("fixer contract: auto=%t reversible=%t idempotent=%t",
+			fx.AutoFixable(), fx.Reversible(), fx.Idempotent())
+	}
+	if ops := fx.Ops(); len(ops) != 1 || ops[0] != "Rename" {
+		t.Errorf("fixer ops = %v, want [Rename]", ops)
+	}
+}

--- a/cli/internal/doctor/fix_workspace_drift_test.go
+++ b/cli/internal/doctor/fix_workspace_drift_test.go
@@ -377,12 +377,12 @@ func TestWorkspaceNamingDrift_LateDestinationCollisionSkipped(t *testing.T) {
 
 	ctx, ra := newNamingDriftCtx(t, repo, false)
 	fixer := workspaceNamingDriftFixer{}
-	collided, err := fixer.moveEntryNoClobber(ctx, filepath.Join(alias, "dup.md"), filepath.Join(canonical, "dup.md"), false)
+	skipReason, err := fixer.moveEntryNoClobber(ctx, filepath.Join(alias, "dup.md"), filepath.Join(canonical, "dup.md"), false)
 	if err != nil {
 		t.Fatalf("moveEntryNoClobber(file): %v", err)
 	}
-	if !collided {
-		t.Fatal("moveEntryNoClobber(file) did not report the late collision")
+	if !strings.Contains(skipReason, "already exists") {
+		t.Fatalf("moveEntryNoClobber(file) skipReason = %q, want the late collision reported", skipReason)
 	}
 	if got := readDriftFile(t, filepath.Join(alias, "dup.md")); got != "alias body" {
 		t.Errorf("alias dup.md = %q, want %q (source moved!)", got, "alias body")
@@ -397,12 +397,12 @@ func TestWorkspaceNamingDrift_LateDestinationCollisionSkipped(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(canonical, "subdir"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	collided, err = fixer.moveEntryNoClobber(ctx, filepath.Join(alias, "subdir"), filepath.Join(canonical, "subdir"), true)
+	skipReason, err = fixer.moveEntryNoClobber(ctx, filepath.Join(alias, "subdir"), filepath.Join(canonical, "subdir"), true)
 	if err != nil {
 		t.Fatalf("moveEntryNoClobber(dir): %v", err)
 	}
-	if !collided {
-		t.Fatal("moveEntryNoClobber(dir) did not report the late collision")
+	if !strings.Contains(skipReason, "already exists") {
+		t.Fatalf("moveEntryNoClobber(dir) skipReason = %q, want the late collision reported", skipReason)
 	}
 	if got := readDriftFile(t, filepath.Join(alias, "subdir", "n.md")); got != "nested body" {
 		t.Errorf("alias subdir/n.md = %q, want %q (source moved!)", got, "nested body")
@@ -418,6 +418,125 @@ func TestWorkspaceNamingDrift_LateDestinationCollisionSkipped(t *testing.T) {
 	}
 	if len(recs) != 0 {
 		t.Fatalf("collided moves wrote %d action records, want 0", len(recs))
+	}
+}
+
+// TestWorkspaceNamingDrift_CanonicalSymlinkSkipsWholeAlias: the canonical
+// DESTINATION dir may itself be a symlink (or a regular file). Moving alias
+// entries "into" it would follow the link outside the repo while every
+// per-entry lexical check passes. The fixer must skip the whole alias, touch
+// nothing, and journal nothing — the external target stays byte-intact.
+func TestWorkspaceNamingDrift_CanonicalSymlinkSkipsWholeAlias(t *testing.T) {
+	env, repo := namingDriftEnv(t)
+	agents := filepath.Join(repo, ".agents")
+	external := t.TempDir()
+	writeDriftFile(t, filepath.Join(external, "sentinel.md"), "external body")
+
+	// retros -> retro, where retro is a symlink to the external dir.
+	writeDriftFile(t, filepath.Join(agents, "retros", "r1.md"), "retro one")
+	if err := os.Symlink(external, filepath.Join(agents, "retro")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	// proof -> proofs, where proofs is a regular FILE (same guard, other shape).
+	writeDriftFile(t, filepath.Join(agents, "proof", "p1.md"), "proof one")
+	writeDriftFile(t, filepath.Join(agents, "proofs"), "not a dir")
+
+	ctx, ra := newNamingDriftCtx(t, repo, false)
+	res, err := workspaceNamingDriftFixer{}.Fix(ctx, env, nil)
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if res.Fixed {
+		t.Error("Fix reported Fixed despite skipped aliases")
+	}
+	if res.ActionsTaken != 0 {
+		t.Errorf("ActionsTaken = %d, want 0", res.ActionsTaken)
+	}
+	if len(res.Skipped) != 2 {
+		t.Fatalf("Skipped = %v, want both aliases skipped whole", res.Skipped)
+	}
+	for _, s := range res.Skipped {
+		if !strings.Contains(s, "canonical dir") || !strings.Contains(s, "not a real directory") {
+			t.Errorf("Skipped entry = %q, want the canonical-dir reason", s)
+		}
+	}
+	// Alias content untouched, external target untouched (only its sentinel).
+	if got := readDriftFile(t, filepath.Join(agents, "retros", "r1.md")); got != "retro one" {
+		t.Errorf("alias r1.md = %q, want untouched", got)
+	}
+	if got := readDriftFile(t, filepath.Join(agents, "proof", "p1.md")); got != "proof one" {
+		t.Errorf("alias p1.md = %q, want untouched", got)
+	}
+	ents, err := os.ReadDir(external)
+	if err != nil || len(ents) != 1 || ents[0].Name() != "sentinel.md" {
+		t.Errorf("external dir entries = %v (err=%v), want only sentinel.md", ents, err)
+	}
+	if info, lerr := os.Lstat(filepath.Join(agents, "retro")); lerr != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("canonical retro is no longer a symlink (err=%v)", lerr)
+	}
+	recs, err := readActions(ra.ActionsPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("skipped aliases wrote %d action records, want 0", len(recs))
+	}
+}
+
+// TestWorkspaceNamingDrift_DestLstatErrorSkipped: a destination Lstat that
+// fails with a NON-NotExist error (here EACCES via an unsearchable canonical
+// dir) means the destination's state is unknown — unknown is never "absent".
+// The entry must be refused (Skipped with the error text), not moved.
+func TestWorkspaceNamingDrift_DestLstatErrorSkipped(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; permission denial is not enforceable")
+	}
+	env, repo := namingDriftEnv(t)
+	agents := filepath.Join(repo, ".agents")
+	alias := filepath.Join(agents, "handoffs")
+	canonical := filepath.Join(agents, "handoff")
+	writeDriftFile(t, filepath.Join(alias, "x.md"), "x body")
+	if err := os.MkdirAll(canonical, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Search permission off: Lstat(canonical) itself still succeeds (a real
+	// dir, so the whole-alias guard passes) but Lstat(canonical/x.md) fails
+	// with EACCES — the exact "cannot verify destination" shape.
+	if err := os.Chmod(canonical, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(canonical, 0o755) })
+
+	ctx, ra := newNamingDriftCtx(t, repo, false)
+	res, err := workspaceNamingDriftFixer{}.Fix(ctx, env, nil)
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if res.Fixed {
+		t.Error("Fix reported Fixed despite an unverifiable destination")
+	}
+	if res.ActionsTaken != 0 {
+		t.Errorf("ActionsTaken = %d, want 0", res.ActionsTaken)
+	}
+	found := false
+	for _, s := range res.Skipped {
+		if strings.Contains(s, filepath.Join(".agents", "handoffs", "x.md")) && strings.Contains(s, "cannot verify destination") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Skipped = %v, want the unverifiable-destination entry with the error text", res.Skipped)
+	}
+	// Source untouched, nothing journaled.
+	if got := readDriftFile(t, filepath.Join(alias, "x.md")); got != "x body" {
+		t.Errorf("alias x.md = %q, want untouched", got)
+	}
+	recs, err := readActions(ra.ActionsPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("refused move wrote %d action records, want 0", len(recs))
 	}
 }
 

--- a/cli/internal/doctor/fix_workspace_drift_test.go
+++ b/cli/internal/doctor/fix_workspace_drift_test.go
@@ -20,15 +20,10 @@ func namingDriftEnv(t *testing.T) (*DetectEnv, string) {
 }
 
 // newNamingDriftCtx builds a real MutateContext rooted at repo, scoped to the
-// naming-drift fixer, with a live actions.jsonl handle.
-//
-// The capabilities write scopes are extended with ".agents": the committed
-// canonicalWriteScopes predates the workspace subsystem and only lists four
-// `.agents/<name>` subtrees, so every workspace fixer source path (e.g.
-// `.agents/post-mortem/x.md`) is refused by EnsureInScope until the
-// capabilities registry gains the workspace scope. This mirrors the scope
-// configuration the workspace subsystem requires in production; the
-// canonicalWriteScopes entry itself is owned by the capabilities lane.
+// naming-drift fixer, with a live actions.jsonl handle. It uses the
+// production capabilities verbatim: `.agents` is a canonical write scope, so
+// no test-side scope extension is needed (and none is applied — this test
+// proves the production envelope admits the workspace fixers).
 func newNamingDriftCtx(t *testing.T, repo string, dryRun bool) (*MutateContext, *RunArtifact) {
 	t.Helper()
 	ra, err := NewRunArtifact(repo, "wsdrift", time.Now())
@@ -41,7 +36,6 @@ func newNamingDriftCtx(t *testing.T, repo string, dryRun bool) (*MutateContext, 
 	}
 	t.Cleanup(func() { _ = af.Close() })
 	caps := NewCapabilities("2.0.0")
-	caps.WriteScopes = append(caps.WriteScopes, ".agents")
 	locks := NewLockManager(filepath.Join(repo, ".doctor", "locks"))
 	return NewMutateContext(ra, caps, t.TempDir(), locks, af, dryRun).WithFixer(fmWorkspaceNamingDriftID), ra
 }

--- a/cli/internal/doctor/fix_workspace_dualstore.go
+++ b/cli/internal/doctor/fix_workspace_dualstore.go
@@ -8,11 +8,14 @@ package doctor
 //     <repo>/.agents/ao/learnings exist with content. The knowledge subsystem
 //     already OWNS the repair for this split —
 //     fm-knowledge-orphaned-flywheel-learnings consolidates the fallback dir
-//     into the canonical one via per-file Rename. This workspace finding is a
-//     broader report-only lens (RepoRoot-anchored, counts ALL regular files
-//     transitively, not just top-level *.md/*.jsonl) whose remediation defers
-//     to that existing fixer so the two subsystems never fight over the same
-//     files.
+//     into the canonical one via per-file Rename of TOP-LEVEL *.md/*.jsonl
+//     files (listLearningFiles). This workspace finding is a RepoRoot-anchored
+//     report-only lens whose FIRING CONDITION is aligned to exactly that
+//     fixer's movable set, so running the advertised remediation actually
+//     clears the finding (a nested or non-indexable file must not keep it
+//     alive forever). Total transitive file counts are still reported in
+//     Evidence.Query as context. Remediation defers to that existing fixer so
+//     the two subsystems never fight over the same files.
 //
 //   - fm-ws-nested-tree: an accidental nested runtime tree
 //     <repo>/<subdir>/.agents (e.g. cli/.agents), usually left behind by an
@@ -105,9 +108,25 @@ func (workspaceDualStoreDetector) Describe() string {
 
 func (d workspaceDualStoreDetector) Detect(env *DetectEnv) ([]Finding, error) {
 	base := workspaceAgentsDir(env)
-	legacyCount, legacyIsDir := workspaceTransitiveFileCount(filepath.Join(base, "learnings"))
-	canonicalCount, canonicalIsDir := workspaceTransitiveFileCount(filepath.Join(base, "ao", "learnings"))
-	if !legacyIsDir || !canonicalIsDir || legacyCount == 0 || canonicalCount == 0 {
+	// Lstat guard: a symlinked `.agents` root points outside the repo.
+	if !workspaceRealDir(base) {
+		return nil, nil
+	}
+	legacyDir := filepath.Join(base, "learnings")
+	canonicalDir := filepath.Join(base, "ao", "learnings")
+	legacyTotal, legacyIsDir := workspaceTransitiveFileCount(legacyDir)
+	canonicalTotal, canonicalIsDir := workspaceTransitiveFileCount(canonicalDir)
+	if !legacyIsDir || !canonicalIsDir {
+		return nil, nil
+	}
+	// Fire on exactly the set the advertised remediation can move: the
+	// knowledge fixer consolidates TOP-LEVEL *.md/*.jsonl files only
+	// (listLearningFiles), so counting anything broader would leave the
+	// finding permanently alive after a successful fix. Transitive totals are
+	// context, not the trigger.
+	legacyMovable := listLearningFiles(legacyDir)
+	canonicalLearnings := listLearningFiles(canonicalDir)
+	if len(legacyMovable) == 0 || len(canonicalLearnings) == 0 {
 		return nil, nil
 	}
 	// The knowledge subsystem owns the repair: point remediation at its fixer
@@ -118,11 +137,12 @@ func (d workspaceDualStoreDetector) Detect(env *DetectEnv) ([]Finding, error) {
 		ID:         d.ID(),
 		Severity:   d.Severity(),
 		Subsystem:  d.Subsystem(),
-		Title:      fmt.Sprintf("dual learnings stores: %d file(s) in .agents/learnings, %d in .agents/ao/learnings", legacyCount, canonicalCount),
+		Title:      fmt.Sprintf("dual learnings stores: %d movable file(s) in .agents/learnings, %d in .agents/ao/learnings", len(legacyMovable), len(canonicalLearnings)),
 		Confidence: 1.0,
 		Evidence: Evidence{
-			File:  ".agents/learnings",
-			Query: fmt.Sprintf("transitive regular-file counts: .agents/learnings=%d .agents/ao/learnings=%d", legacyCount, canonicalCount),
+			File: ".agents/learnings",
+			Query: fmt.Sprintf("movable top-level *.md/*.jsonl: .agents/learnings=%d .agents/ao/learnings=%d (transitive regular-file totals, context only: %d and %d)",
+				len(legacyMovable), len(canonicalLearnings), legacyTotal, canonicalTotal),
 		},
 		Remediation: Remediation{
 			Command:          "ao doctor --fix --only " + knowledgeFixerID,

--- a/cli/internal/doctor/fix_workspace_dualstore.go
+++ b/cli/internal/doctor/fix_workspace_dualstore.go
@@ -1,0 +1,195 @@
+package doctor
+
+// Workspace dual-store and nested-tree detectors (report-only).
+//
+// Two detect-only findings, NO fixers registered:
+//
+//   - fm-ws-dual-store: BOTH <repo>/.agents/learnings and
+//     <repo>/.agents/ao/learnings exist with content. The knowledge subsystem
+//     already OWNS the repair for this split —
+//     fm-knowledge-orphaned-flywheel-learnings consolidates the fallback dir
+//     into the canonical one via per-file Rename. This workspace finding is a
+//     broader report-only lens (RepoRoot-anchored, counts ALL regular files
+//     transitively, not just top-level *.md/*.jsonl) whose remediation defers
+//     to that existing fixer so the two subsystems never fight over the same
+//     files.
+//
+//   - fm-ws-nested-tree: an accidental nested runtime tree
+//     <repo>/<subdir>/.agents (e.g. cli/.agents), usually left behind by an
+//     agent that ran with the wrong CWD. Merging a nested runtime tree into
+//     the root one is a human call — content may belong to a genuinely nested
+//     project — so this is manual-remediation only.
+//
+// The engine tolerates findings with no matching fixer by design:
+// groupFindingsByFixer only buckets findings whose ID has a registered fixer,
+// and applyFixers skips nil/non-auto-fixable entries, so a --fix pass over
+// these IDs performs zero mutations and reports them as unfixed.
+//
+// Both detectors are PURE (lstat + readdir + WalkDir; symlinks never followed).
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Detector IDs for the workspace dual-store and nested-tree findings.
+const (
+	workspaceDualStoreID  = "fm-ws-dual-store"
+	workspaceNestedTreeID = "fm-ws-nested-tree"
+)
+
+// workspaceNestedTreeSkipDirs are the immediate RepoRoot children never
+// scanned for a nested `.agents` tree: VCS/vendor trees plus the root
+// runtime dir itself (the root `.agents` is the canonical tree, not a nested
+// one; `.claude` legitimately contains worktree checkouts with their own
+// runtime trees).
+var workspaceNestedTreeSkipDirs = map[string]bool{
+	".git":         true,
+	"node_modules": true,
+	"vendor":       true,
+	".claude":      true,
+	".agents":      true,
+}
+
+func init() {
+	RegisterDetector(workspaceDualStoreDetector{})
+	RegisterDetector(workspaceNestedTreeDetector{})
+	// Deliberately NO RegisterFixer for either ID: fm-ws-dual-store defers to
+	// the knowledge subsystem's fm-knowledge-orphaned-flywheel-learnings fixer,
+	// and fm-ws-nested-tree is a human-judgment merge.
+}
+
+// workspaceTransitiveFileCount reports whether dir is a real directory (lstat;
+// a symlink to a directory does not count) and, if so, the transitive count of
+// regular files under it. WalkDir never follows symlinks, and unreadable
+// subtrees are skipped, mirroring workspaceDirInventory's best-effort read.
+func workspaceTransitiveFileCount(dir string) (count int, isDir bool) {
+	info, err := os.Lstat(dir)
+	if err != nil || !info.IsDir() {
+		return 0, false
+	}
+	_ = filepath.WalkDir(dir, func(_ string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.Type().IsRegular() {
+			count++
+		}
+		return nil
+	})
+	return count, true
+}
+
+// ---------------------------------------------------------------------------
+// FM: fm-ws-dual-store (report-only; fix owned by the knowledge subsystem)
+// ---------------------------------------------------------------------------
+
+// workspaceDualStoreDetector flags a learnings store split across the legacy
+// <repo>/.agents/learnings and the canonical <repo>/.agents/ao/learnings.
+type workspaceDualStoreDetector struct{}
+
+func (workspaceDualStoreDetector) ID() string           { return workspaceDualStoreID }
+func (workspaceDualStoreDetector) Subsystem() string    { return subsystemWorkspace }
+func (workspaceDualStoreDetector) Severity() string     { return "P2" }
+func (workspaceDualStoreDetector) EstimatedCostMS() int { return 5 }
+func (workspaceDualStoreDetector) OnlineRequired() bool { return false }
+func (workspaceDualStoreDetector) QuickPath() bool      { return true }
+func (workspaceDualStoreDetector) Describe() string {
+	return "learnings split across .agents/learnings and .agents/ao/learnings (fix owned by knowledge)"
+}
+
+func (d workspaceDualStoreDetector) Detect(env *DetectEnv) ([]Finding, error) {
+	base := workspaceAgentsDir(env)
+	legacyCount, legacyIsDir := workspaceTransitiveFileCount(filepath.Join(base, "learnings"))
+	canonicalCount, canonicalIsDir := workspaceTransitiveFileCount(filepath.Join(base, "ao", "learnings"))
+	if !legacyIsDir || !canonicalIsDir || legacyCount == 0 || canonicalCount == 0 {
+		return nil, nil
+	}
+	// The knowledge subsystem owns the repair: point remediation at its fixer
+	// ID (live reference, so a rename there breaks the build here rather than
+	// silently drifting) and stay non-auto-fixable so the two never fight.
+	knowledgeFixerID := orphanedFlywheelLearningsFixer{}.ID()
+	return []Finding{{
+		ID:         d.ID(),
+		Severity:   d.Severity(),
+		Subsystem:  d.Subsystem(),
+		Title:      fmt.Sprintf("dual learnings stores: %d file(s) in .agents/learnings, %d in .agents/ao/learnings", legacyCount, canonicalCount),
+		Confidence: 1.0,
+		Evidence: Evidence{
+			File:  ".agents/learnings",
+			Query: fmt.Sprintf("transitive regular-file counts: .agents/learnings=%d .agents/ao/learnings=%d", legacyCount, canonicalCount),
+		},
+		Remediation: Remediation{
+			Command:          "ao doctor --fix --only " + knowledgeFixerID,
+			ExplainCommand:   "ao doctor explain " + knowledgeFixerID,
+			AutoFixable:      false,
+			EstimatedActions: 0,
+		},
+	}}, nil
+}
+
+// ---------------------------------------------------------------------------
+// FM: fm-ws-nested-tree (report-only; merging is a human call)
+// ---------------------------------------------------------------------------
+
+// workspaceNestedTreeDetector flags accidental nested runtime trees
+// <repo>/<subdir>/.agents at depth 1 under RepoRoot.
+type workspaceNestedTreeDetector struct{}
+
+func (workspaceNestedTreeDetector) ID() string           { return workspaceNestedTreeID }
+func (workspaceNestedTreeDetector) Subsystem() string    { return subsystemWorkspace }
+func (workspaceNestedTreeDetector) Severity() string     { return "P2" }
+func (workspaceNestedTreeDetector) EstimatedCostMS() int { return 25 }
+func (workspaceNestedTreeDetector) OnlineRequired() bool { return false }
+func (workspaceNestedTreeDetector) QuickPath() bool      { return false }
+func (workspaceNestedTreeDetector) Describe() string {
+	return "nested .agents runtime tree under a repo subdirectory (manual merge)"
+}
+
+func (d workspaceNestedTreeDetector) Detect(env *DetectEnv) ([]Finding, error) {
+	entries, err := os.ReadDir(env.RepoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("doctor: read repo root %s: %w", env.RepoRoot, err)
+	}
+	var findings []Finding
+	// os.ReadDir returns entries sorted by name, so findings are deterministic.
+	for _, e := range entries {
+		// lstat-style types: a symlinked child is ModeSymlink, not IsDir —
+		// never follow it into a tree outside the repo.
+		if !e.IsDir() || workspaceNestedTreeSkipDirs[e.Name()] {
+			continue
+		}
+		rel := filepath.Join(e.Name(), ".agents")
+		count, isDir := workspaceTransitiveFileCount(filepath.Join(env.RepoRoot, rel))
+		if !isDir || count == 0 {
+			continue
+		}
+		findings = append(findings, Finding{
+			ID:        d.ID(),
+			Severity:  d.Severity(),
+			Subsystem: d.Subsystem(),
+			Title:     fmt.Sprintf("nested runtime tree %s holds %d file(s)", rel, count),
+			// Presence is factual, but "accidental" is inferred: the tree may
+			// belong to a genuinely nested project.
+			Confidence: 0.9,
+			Evidence: Evidence{
+				File:  rel,
+				Query: fmt.Sprintf("transitive regular-file count %s=%d", rel, count),
+			},
+			Remediation: Remediation{
+				Command: "Review " + rel + ". If its contents belong to the root workspace, " +
+					"merge them into .agents/ by hand and remove the nested tree; " +
+					"if it is an intentional nested project, leave it. Then re-run: ao doctor",
+				ExplainCommand:   "ao doctor explain " + d.ID(),
+				AutoFixable:      false,
+				EstimatedActions: 0,
+			},
+		})
+	}
+	return findings, nil
+}

--- a/cli/internal/doctor/fix_workspace_dualstore_test.go
+++ b/cli/internal/doctor/fix_workspace_dualstore_test.go
@@ -48,11 +48,13 @@ func TestWorkspaceDualStore_DetectFinding(t *testing.T) {
 	if f.Confidence != 1.0 {
 		t.Errorf("confidence = %v, want 1.0", f.Confidence)
 	}
-	// Evidence carries the exact transitive file counts of both stores.
-	if want := "dual learnings stores: 2 file(s) in .agents/learnings, 1 in .agents/ao/learnings"; f.Title != want {
+	// Title counts the MOVABLE set (what the knowledge fixer will actually
+	// consolidate: top-level *.md/*.jsonl — a.md, not sub/b.txt); evidence
+	// keeps the transitive totals as context.
+	if want := "dual learnings stores: 1 movable file(s) in .agents/learnings, 1 in .agents/ao/learnings"; f.Title != want {
 		t.Errorf("title = %q, want %q", f.Title, want)
 	}
-	if want := "transitive regular-file counts: .agents/learnings=2 .agents/ao/learnings=1"; f.Evidence.Query != want {
+	if want := "movable top-level *.md/*.jsonl: .agents/learnings=1 .agents/ao/learnings=1 (transitive regular-file totals, context only: 2 and 1)"; f.Evidence.Query != want {
 		t.Errorf("evidence query = %q, want %q", f.Evidence.Query, want)
 	}
 	// Report-only: the knowledge fixer owns the repair, so the finding must
@@ -80,6 +82,13 @@ func TestWorkspaceDualStore_DetectSelection(t *testing.T) {
 		want           int
 	}{
 		{"both populated", []string{"a.md"}, false, []string{"c.md"}, false, 1},
+		// The advertised remediation moves only TOP-LEVEL *.md/*.jsonl: a
+		// store whose content the knowledge fixer cannot move must not fire
+		// (it would stay alive forever after the advertised fix).
+		{"legacy only nested file", []string{filepath.Join("sub", "n.md")}, false, []string{"c.md"}, false, 0},
+		{"legacy only non-indexable ext", []string{"a.txt"}, false, []string{"c.md"}, false, 0},
+		{"canonical only non-indexable ext", []string{"a.md"}, false, []string{"c.txt"}, false, 0},
+		{"legacy jsonl fires", []string{"a.jsonl"}, false, []string{"c.md"}, false, 1},
 		{"legacy empty dir", nil, true, []string{"c.md"}, false, 0},
 		{"canonical empty dir", []string{"a.md"}, false, nil, true, 0},
 		{"ao/learnings absent", []string{"a.md"}, false, nil, false, 0},

--- a/cli/internal/doctor/fix_workspace_dualstore_test.go
+++ b/cli/internal/doctor/fix_workspace_dualstore_test.go
@@ -1,0 +1,295 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// knowledgeOrphanedLearningsFixerID is the knowledge-subsystem fixer that owns
+// the dual-store repair; the dual-store finding must defer to it verbatim.
+const knowledgeOrphanedLearningsFixerID = "fm-knowledge-orphaned-flywheel-learnings"
+
+// dualStoreFixtureEnv builds a repo whose .agents holds BOTH learnings stores
+// populated: two files (one nested) in the legacy store, one in the canonical.
+func dualStoreFixtureEnv(t *testing.T) (*DetectEnv, string) {
+	t.Helper()
+	repo := t.TempDir()
+	agents := filepath.Join(repo, ".agents")
+	now := time.Now()
+	writeWorkspaceFile(t, filepath.Join(agents, "learnings", "a.md"), "legacy-a", now)
+	writeWorkspaceFile(t, filepath.Join(agents, "learnings", "sub", "b.txt"), "legacy-b", now)
+	writeWorkspaceFile(t, filepath.Join(agents, "ao", "learnings", "c.md"), "canonical-c", now)
+	return &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}, repo
+}
+
+func TestWorkspaceDualStore_DetectFinding(t *testing.T) {
+	env, _ := dualStoreFixtureEnv(t)
+
+	findings, err := workspaceDualStoreDetector{}.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("findings = %d, want 1", len(findings))
+	}
+	f := findings[0]
+	if f.ID != "fm-ws-dual-store" {
+		t.Errorf("finding ID = %q, want fm-ws-dual-store", f.ID)
+	}
+	if f.Subsystem != "workspace" {
+		t.Errorf("subsystem = %q, want workspace", f.Subsystem)
+	}
+	if f.Severity != "P2" {
+		t.Errorf("severity = %q, want P2", f.Severity)
+	}
+	if f.Confidence != 1.0 {
+		t.Errorf("confidence = %v, want 1.0", f.Confidence)
+	}
+	// Evidence carries the exact transitive file counts of both stores.
+	if want := "dual learnings stores: 2 file(s) in .agents/learnings, 1 in .agents/ao/learnings"; f.Title != want {
+		t.Errorf("title = %q, want %q", f.Title, want)
+	}
+	if want := "transitive regular-file counts: .agents/learnings=2 .agents/ao/learnings=1"; f.Evidence.Query != want {
+		t.Errorf("evidence query = %q, want %q", f.Evidence.Query, want)
+	}
+	// Report-only: the knowledge fixer owns the repair, so the finding must
+	// defer to it and never claim auto-fixability of its own.
+	if f.Remediation.AutoFixable {
+		t.Error("dual-store finding must not be auto-fixable")
+	}
+	if want := "ao doctor --fix --only " + knowledgeOrphanedLearningsFixerID; f.Remediation.Command != want {
+		t.Errorf("remediation command = %q, want %q", f.Remediation.Command, want)
+	}
+	if want := "ao doctor explain " + knowledgeOrphanedLearningsFixerID; f.Remediation.ExplainCommand != want {
+		t.Errorf("explain command = %q, want %q", f.Remediation.ExplainCommand, want)
+	}
+}
+
+// TestWorkspaceDualStore_DetectSelection is the table-driven firing matrix:
+// the finding requires BOTH stores present as directories with content.
+func TestWorkspaceDualStore_DetectSelection(t *testing.T) {
+	tests := []struct {
+		name           string
+		legacyFiles    []string // paths under .agents/learnings; nil = dir absent
+		legacyEmptyDir bool     // create .agents/learnings with no files
+		canonFiles     []string // paths under .agents/ao/learnings; nil = dir absent
+		canonEmptyDir  bool
+		want           int
+	}{
+		{"both populated", []string{"a.md"}, false, []string{"c.md"}, false, 1},
+		{"legacy empty dir", nil, true, []string{"c.md"}, false, 0},
+		{"canonical empty dir", []string{"a.md"}, false, nil, true, 0},
+		{"ao/learnings absent", []string{"a.md"}, false, nil, false, 0},
+		{"legacy absent", nil, false, []string{"c.md"}, false, 0},
+		{"no .agents at all", nil, false, nil, false, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := t.TempDir()
+			agents := filepath.Join(repo, ".agents")
+			now := time.Now()
+			for _, n := range tt.legacyFiles {
+				writeWorkspaceFile(t, filepath.Join(agents, "learnings", n), "x", now)
+			}
+			if tt.legacyEmptyDir {
+				if err := os.MkdirAll(filepath.Join(agents, "learnings"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for _, n := range tt.canonFiles {
+				writeWorkspaceFile(t, filepath.Join(agents, "ao", "learnings", n), "y", now)
+			}
+			if tt.canonEmptyDir {
+				if err := os.MkdirAll(filepath.Join(agents, "ao", "learnings"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			env := &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}
+			findings, err := workspaceDualStoreDetector{}.Detect(env)
+			if err != nil {
+				t.Fatalf("Detect: %v", err)
+			}
+			if len(findings) != tt.want {
+				t.Fatalf("findings = %d, want %d", len(findings), tt.want)
+			}
+		})
+	}
+}
+
+// nestedTreeFixtureEnv builds a repo with two real nested runtime trees
+// (cli/.agents, tools/.agents), every skip-listed sibling carrying a decoy
+// .agents with content, an empty nested .agents, and the root .agents itself.
+func nestedTreeFixtureEnv(t *testing.T) (*DetectEnv, string) {
+	t.Helper()
+	repo := t.TempDir()
+	now := time.Now()
+	// Real nested trees (ReadDir order: cli before tools).
+	writeWorkspaceFile(t, filepath.Join(repo, "cli", ".agents", "state.json"), "nested-cli", now)
+	writeWorkspaceFile(t, filepath.Join(repo, "tools", ".agents", "sub", "log.txt"), "nested-tools", now)
+	// Skip-listed children: never flagged even with populated .agents inside.
+	for _, skip := range []string{".git", "node_modules", "vendor", ".claude"} {
+		writeWorkspaceFile(t, filepath.Join(repo, skip, ".agents", "decoy.txt"), "decoy", now)
+	}
+	// The root runtime tree itself is not a nested tree.
+	writeWorkspaceFile(t, filepath.Join(repo, ".agents", "handoff", "h.md"), "root", now)
+	// An empty nested .agents dir is not flagged.
+	if err := os.MkdirAll(filepath.Join(repo, "docs", ".agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A child with no .agents at all.
+	writeWorkspaceFile(t, filepath.Join(repo, "scripts", "run.sh"), "#!/bin/sh", now)
+	return &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}, repo
+}
+
+func TestWorkspaceNestedTree_DetectFindings(t *testing.T) {
+	env, _ := nestedTreeFixtureEnv(t)
+
+	findings, err := workspaceNestedTreeDetector{}.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("findings = %d, want 2 (one per nested tree)", len(findings))
+	}
+	wantFiles := []string{filepath.Join("cli", ".agents"), filepath.Join("tools", ".agents")}
+	for i, f := range findings {
+		if f.ID != "fm-ws-nested-tree" {
+			t.Errorf("finding[%d] ID = %q, want fm-ws-nested-tree", i, f.ID)
+		}
+		if f.Subsystem != "workspace" {
+			t.Errorf("finding[%d] subsystem = %q, want workspace", i, f.Subsystem)
+		}
+		if f.Severity != "P2" {
+			t.Errorf("finding[%d] severity = %q, want P2", i, f.Severity)
+		}
+		if f.Evidence.File != wantFiles[i] {
+			t.Errorf("finding[%d] evidence file = %q, want %q", i, f.Evidence.File, wantFiles[i])
+		}
+		if f.Remediation.AutoFixable {
+			t.Errorf("finding[%d] must not be auto-fixable (merging is a human call)", i)
+		}
+		if f.Remediation.Command == "" {
+			t.Errorf("finding[%d] remediation command is empty; want a manual-review hint", i)
+		}
+		if !strings.Contains(f.Remediation.Command, wantFiles[i]) {
+			t.Errorf("finding[%d] remediation command %q does not name %q", i, f.Remediation.Command, wantFiles[i])
+		}
+		if want := "ao doctor explain fm-ws-nested-tree"; f.Remediation.ExplainCommand != want {
+			t.Errorf("finding[%d] explain command = %q, want %q", i, f.Remediation.ExplainCommand, want)
+		}
+	}
+	// Each nested tree's file count is exact in the title.
+	if want := "nested runtime tree " + filepath.Join("cli", ".agents") + " holds 1 file(s)"; findings[0].Title != want {
+		t.Errorf("title = %q, want %q", findings[0].Title, want)
+	}
+}
+
+func TestWorkspaceNestedTree_DetectCleanRepo(t *testing.T) {
+	repo := t.TempDir()
+	writeWorkspaceFile(t, filepath.Join(repo, ".agents", "handoff", "h.md"), "root", time.Now())
+	env := &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}
+	findings, err := workspaceNestedTreeDetector{}.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("clean repo produced %d findings, want 0", len(findings))
+	}
+}
+
+// TestWorkspaceDualStoreNested_FixPerformsZeroMutations proves the engine
+// tolerates both fixerless findings: a full detect+fix pass scoped to the two
+// IDs finds them, mutates NOTHING, and reports them unfixed (fix_partial).
+func TestWorkspaceDualStoreNested_FixPerformsZeroMutations(t *testing.T) {
+	env, repo := dualStoreFixtureEnv(t)
+	writeWorkspaceFile(t, filepath.Join(repo, "cli", ".agents", "state.json"), "nested-cli", time.Now())
+
+	rep, err := Fix(Options{
+		RepoRoot: repo, CWD: repo, HomeDir: env.HomeDir, ToolVersion: "2.0.0",
+		Only: []string{"fm-ws-dual-store", "fm-ws-nested-tree"},
+	})
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if got := len(rep.Findings); got != 2 {
+		t.Fatalf("fix pass findings = %d, want 2", got)
+	}
+	if rep.ActionsTaken != 0 {
+		t.Fatalf("ActionsTaken = %d, want 0 (no fixer registered)", rep.ActionsTaken)
+	}
+	// Findings present, none fixable/fixed → fix_partial, never a mutation.
+	if rep.ExitCode != ExitFixPartial {
+		t.Fatalf("exit code = %d, want %d (fix_partial)", rep.ExitCode, ExitFixPartial)
+	}
+	// actions.jsonl exists but recorded zero actions.
+	recs, err := readActions(filepath.Join(rep.RunDir, "actions.jsonl"))
+	if err != nil {
+		t.Fatalf("readActions: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("action records = %d, want 0", len(recs))
+	}
+	// Every fixture file is untouched, byte for byte.
+	for path, content := range map[string]string{
+		filepath.Join(repo, ".agents", "learnings", "a.md"):         "legacy-a",
+		filepath.Join(repo, ".agents", "learnings", "sub", "b.txt"): "legacy-b",
+		filepath.Join(repo, ".agents", "ao", "learnings", "c.md"):   "canonical-c",
+		filepath.Join(repo, "cli", ".agents", "state.json"):         "nested-cli",
+	} {
+		got, err := os.ReadFile(path)
+		if err != nil || string(got) != content {
+			t.Errorf("file %s = %q err=%v, want %q untouched", path, got, err, content)
+		}
+	}
+}
+
+func TestWorkspaceDualStoreNested_Registration(t *testing.T) {
+	byID := make(map[string]Detector)
+	for _, d := range Detectors() {
+		byID[d.ID()] = d
+	}
+
+	ds, ok := byID["fm-ws-dual-store"]
+	if !ok {
+		t.Fatal("detector fm-ws-dual-store not registered")
+	}
+	if ds.Subsystem() != "workspace" {
+		t.Errorf("dual-store subsystem = %q, want workspace", ds.Subsystem())
+	}
+	if ds.Severity() != "P2" {
+		t.Errorf("dual-store severity = %q, want P2", ds.Severity())
+	}
+	if !ds.QuickPath() {
+		t.Error("dual-store QuickPath() = false, want true")
+	}
+	if ds.OnlineRequired() {
+		t.Error("dual-store OnlineRequired() = true, want false")
+	}
+
+	nt, ok := byID["fm-ws-nested-tree"]
+	if !ok {
+		t.Fatal("detector fm-ws-nested-tree not registered")
+	}
+	if nt.Subsystem() != "workspace" {
+		t.Errorf("nested-tree subsystem = %q, want workspace", nt.Subsystem())
+	}
+	if nt.Severity() != "P2" {
+		t.Errorf("nested-tree severity = %q, want P2", nt.Severity())
+	}
+	if nt.QuickPath() {
+		t.Error("nested-tree QuickPath() = true, want false")
+	}
+	if nt.OnlineRequired() {
+		t.Error("nested-tree OnlineRequired() = true, want false")
+	}
+
+	// Report-only contract: neither ID has a registered fixer.
+	for _, id := range []string{"fm-ws-dual-store", "fm-ws-nested-tree"} {
+		if fx := FixerByID(id); fx != nil {
+			t.Errorf("FixerByID(%q) = %T, want nil (report-only finding)", id, fx)
+		}
+	}
+}

--- a/cli/internal/doctor/fix_workspace_empty.go
+++ b/cli/internal/doctor/fix_workspace_empty.go
@@ -26,11 +26,8 @@ package doctor
 
 import (
 	"fmt"
-	"io/fs"
 	"os"
-	"path/filepath"
 	"strings"
-	"time"
 )
 
 // fmWorkspaceEmptyDirsID is the shared detector/fixer ID for this failure mode.
@@ -81,133 +78,33 @@ func workspaceEmptyDirCandidates(base string) ([]string, error) {
 	return out, nil
 }
 
-// quarantineEmptyDir renames the verified-empty directory base/name to dest
-// with the same eight-step discipline as Mutate (per-path lock, hashes,
-// preconditions, dry-run transparency, atomic execute through the chokepoint's
-// executeAtomic, fsync'd actions.jsonl record). Mutate itself is byte-oriented
-// — its before-hash read and verbatim backup only work on regular files — so
-// this directory adaptation lives here.
-//
-// Scope: the static write-scope list cannot enumerate arbitrary top-level
-// `.agents/<name>` directories, so the source is gated STRUCTURALLY — name
-// must be a bare path element and base/name a still-empty immediate
-// subdirectory of the workspace root — which is strictly narrower than a
-// `.agents` scope entry. The destination (under the run dir) goes through
-// EnsureInScope, and the op through EnsureOpAllowed.
-//
-// Because the tree holds zero regular files there are no bytes to hash or back
-// up: both hashes record the empty hash, and the "backup" mirrors the empty
-// subtree shape under the run's backups/ dir. Undo of a Rename record replays
-// the rename in reverse (engine.undoOne), which is directory-safe, so the
-// quarantine remains fully reversible.
+// quarantineEmptyDir moves the still-empty workspace directory <base>/<name>
+// into quarantine through the shared workspace directory-rename chokepoint
+// adapter (workspaceDirRename). The still-empty re-verification runs UNDER
+// the per-path lock via the verify hook: a file may have landed since the
+// caller's scan, and a dir that gained files is refused, not quarantined.
+// Returns (true, nil) when the rename happened (or would happen, in dry-run),
+// and (false, err) when it was refused.
 func quarantineEmptyDir(ctx *MutateContext, base, name, dest string) (bool, error) {
-	// Structural containment: name must be a single, plain path element.
-	if name != filepath.Base(name) || name == "." || name == ".." || name == "" {
-		return false, fmt.Errorf("doctor: invalid workspace dir name %q (refused_unsafe)", name)
-	}
-	path := filepath.Join(base, name)
-
-	// Step 1 — per-path advisory lock.
-	if !ctx.DryRun {
-		guard, err := ctx.Locks.Acquire(path)
+	verify := func(path string) error {
+		baseInv, err := workspaceDirInventory(base)
 		if err != nil {
-			return false, err
+			return fmt.Errorf("doctor: re-inventory %s: %w", base, err)
 		}
-		defer func() { _ = guard.Release() }()
-	}
-
-	// Step 2 — before state. Refuse anything but a directory; verify the tree
-	// still holds zero transitive regular files (a file may have landed since
-	// the caller's scan).
-	info, err := os.Stat(path)
-	if err != nil {
-		return false, fmt.Errorf("doctor: stat %s: %w", path, err)
-	}
-	if !info.IsDir() {
-		return false, fmt.Errorf("doctor: %s is not a directory (refused_unsafe)", path)
-	}
-	baseInv, err := workspaceDirInventory(base)
-	if err != nil {
-		return false, fmt.Errorf("doctor: re-inventory %s: %w", base, err)
-	}
-	stillEmpty := false
-	for _, di := range baseInv {
-		if di.Name == name {
-			stillEmpty = di.FileCount == 0
-			break
+		for _, di := range baseInv {
+			if di.Name == name {
+				if di.FileCount == 0 {
+					return nil
+				}
+				break
+			}
 		}
+		return fmt.Errorf("doctor: %s gained files since scan; refusing to quarantine (refused_unsafe)", path)
 	}
-	if !stillEmpty {
-		return false, fmt.Errorf("doctor: %s gained files since scan; refusing to quarantine (refused_unsafe)", path)
-	}
-	emptyHash := sha256Hex(nil)
-	beforeMode := fmt.Sprintf("%o", info.Mode().Perm())
-
-	// Step 3 — preconditions: in-scope destination + executable op. (The
-	// source is gated by the structural containment check above.)
-	op := Rename{To: dest}
-	if err := EnsureInScope(ctx.Capabilities, ctx.RepoRoot, ctx.HomeDir, dest); err != nil {
-		return false, err
-	}
-	if err := EnsureOpAllowed(ctx.Capabilities, op); err != nil {
-		return false, err
-	}
-
-	rel, relErr := filepath.Rel(ctx.RepoRoot, path)
-	if relErr != nil {
-		rel = path
-	}
-
-	// Step 5/6 — dry-run transparency, then atomic execute through the
-	// chokepoint's executor. (Step 4, verbatim backup, degenerates to
-	// mirroring the empty subtree shape; Rename undo never reads backups.)
-	startedNS := time.Since(ctx.start).Nanoseconds()
-	if ctx.DryRun {
-		fmt.Fprintf(os.Stderr, "[dry-run] would mutate %s: %s\n", path, DescribeOp(op))
-		return true, nil
-	}
-	if err := mirrorEmptyTree(path, filepath.Join(ctx.RunDir, "backups", rel)); err != nil {
-		return false, fmt.Errorf("doctor: backup %s: %w", path, err)
-	}
-	if err := executeAtomic(path, op); err != nil {
-		return false, fmt.Errorf("doctor: execute Rename on %s: %w", path, err)
-	}
-
-	// Step 7/8 — after hash (path is gone; empty) + fsync'd action record.
-	rec := ActionRecord{
-		Path:         rel,
-		Op:           op.kind(),
-		BeforeHash:   emptyHash,
-		AfterHash:    emptyHash,
-		BeforeMode:   beforeMode,
-		StartedAtNS:  startedNS,
-		FinishedAtNS: time.Since(ctx.start).Nanoseconds(),
-		RunID:        ctx.RunID,
-		FixerID:      ctx.FixerID,
-		OK:           true,
-		RenameTo:     dest,
-		Existed:      true,
-	}
-	if err := ctx.appendAction(rec); err != nil {
+	if err := workspaceQuarantineDirByName(ctx, base, name, dest, verify); err != nil {
 		return false, err
 	}
 	return true, nil
-}
-
-// mirrorEmptyTree recreates src's directory structure (which holds no regular
-// files) under dst. It is the backup-step analogue for an empty tree: shape
-// only, since there are no bytes to copy.
-func mirrorEmptyTree(src, dst string) error {
-	return filepath.WalkDir(src, func(p string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil || !d.IsDir() {
-			return nil //nolint:nilerr // best-effort mirror; unreadable subtree skipped
-		}
-		rel, err := filepath.Rel(src, p)
-		if err != nil {
-			return nil //nolint:nilerr // unmappable entry contributes nothing
-		}
-		return os.MkdirAll(filepath.Join(dst, rel), 0o755)
-	})
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/internal/doctor/fix_workspace_empty.go
+++ b/cli/internal/doctor/fix_workspace_empty.go
@@ -1,0 +1,311 @@
+package doctor
+
+// Workspace subsystem: fm-ws-empty-dirs (auto-fixable).
+//
+// Flags empty immediate subdirectories of the workspace root `.agents/` —
+// directories holding zero transitive regular files (truly empty, or holding
+// only empty substructure). These are abandoned scaffolding from crashed or
+// half-finished lanes: they clutter inventory output and mislead tooling that
+// treats directory presence as a signal.
+//
+// Three name classes are deliberately NOT claimed here:
+//
+//   - "ao" — the structured knowledge-store root. Its (empty) substructure is
+//     the knowledge subsystem's contract (fm-knowledge-missing-substructure).
+//   - canonical directory names (the VALUES of workspaceCanonicalAliases:
+//     postmortem, pre-mortem-checks, handoff, retro, proofs, tests) — these may
+//     legitimately sit empty awaiting their first write.
+//   - stale/retry-named directories (isWorkspaceStaleDirName) — owned by the
+//     workspace GC failure mode (fm-ws-stale-queue-dirs); no double-claim.
+//
+// The detector is PURE (stat + readdir only). The fixer's only user-state
+// disk write is a Rename into the run's quarantine directory — never a
+// remove — performed by quarantineEmptyDir, the directory adaptation of the
+// Mutate eight-step discipline (Mutate itself is byte-oriented and cannot
+// hash or back up a directory).
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// fmWorkspaceEmptyDirsID is the shared detector/fixer ID for this failure mode.
+const fmWorkspaceEmptyDirsID = "fm-ws-empty-dirs"
+
+func init() {
+	RegisterDetector(workspaceEmptyDirsDetector{})
+	RegisterFixer(workspaceEmptyDirsFixer{})
+}
+
+// workspaceEmptyDirClaimed reports whether name is excluded from the
+// empty-dirs failure mode because another owner claims it: the knowledge
+// store root, a canonical directory name, or a stale/retry-named directory.
+func workspaceEmptyDirClaimed(name string) bool {
+	if name == "ao" {
+		return true
+	}
+	for _, canonical := range workspaceCanonicalAliases {
+		if name == canonical {
+			return true
+		}
+	}
+	return isWorkspaceStaleDirName(name)
+}
+
+// workspaceEmptyDirCandidates inventories base and returns the names of
+// immediate subdirectories holding zero transitive regular files, excluding
+// claimed names, in deterministic (name-sorted) order. A missing base yields
+// nil candidates and a nil error — nothing to flag.
+func workspaceEmptyDirCandidates(base string) ([]string, error) {
+	inv, err := workspaceDirInventory(base)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []string
+	for _, info := range inv {
+		if info.FileCount != 0 {
+			continue
+		}
+		if workspaceEmptyDirClaimed(info.Name) {
+			continue
+		}
+		out = append(out, info.Name)
+	}
+	return out, nil
+}
+
+// quarantineEmptyDir renames the verified-empty directory base/name to dest
+// with the same eight-step discipline as Mutate (per-path lock, hashes,
+// preconditions, dry-run transparency, atomic execute through the chokepoint's
+// executeAtomic, fsync'd actions.jsonl record). Mutate itself is byte-oriented
+// — its before-hash read and verbatim backup only work on regular files — so
+// this directory adaptation lives here.
+//
+// Scope: the static write-scope list cannot enumerate arbitrary top-level
+// `.agents/<name>` directories, so the source is gated STRUCTURALLY — name
+// must be a bare path element and base/name a still-empty immediate
+// subdirectory of the workspace root — which is strictly narrower than a
+// `.agents` scope entry. The destination (under the run dir) goes through
+// EnsureInScope, and the op through EnsureOpAllowed.
+//
+// Because the tree holds zero regular files there are no bytes to hash or back
+// up: both hashes record the empty hash, and the "backup" mirrors the empty
+// subtree shape under the run's backups/ dir. Undo of a Rename record replays
+// the rename in reverse (engine.undoOne), which is directory-safe, so the
+// quarantine remains fully reversible.
+func quarantineEmptyDir(ctx *MutateContext, base, name, dest string) (bool, error) {
+	// Structural containment: name must be a single, plain path element.
+	if name != filepath.Base(name) || name == "." || name == ".." || name == "" {
+		return false, fmt.Errorf("doctor: invalid workspace dir name %q (refused_unsafe)", name)
+	}
+	path := filepath.Join(base, name)
+
+	// Step 1 — per-path advisory lock.
+	if !ctx.DryRun {
+		guard, err := ctx.Locks.Acquire(path)
+		if err != nil {
+			return false, err
+		}
+		defer func() { _ = guard.Release() }()
+	}
+
+	// Step 2 — before state. Refuse anything but a directory; verify the tree
+	// still holds zero transitive regular files (a file may have landed since
+	// the caller's scan).
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, fmt.Errorf("doctor: stat %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return false, fmt.Errorf("doctor: %s is not a directory (refused_unsafe)", path)
+	}
+	baseInv, err := workspaceDirInventory(base)
+	if err != nil {
+		return false, fmt.Errorf("doctor: re-inventory %s: %w", base, err)
+	}
+	stillEmpty := false
+	for _, di := range baseInv {
+		if di.Name == name {
+			stillEmpty = di.FileCount == 0
+			break
+		}
+	}
+	if !stillEmpty {
+		return false, fmt.Errorf("doctor: %s gained files since scan; refusing to quarantine (refused_unsafe)", path)
+	}
+	emptyHash := sha256Hex(nil)
+	beforeMode := fmt.Sprintf("%o", info.Mode().Perm())
+
+	// Step 3 — preconditions: in-scope destination + executable op. (The
+	// source is gated by the structural containment check above.)
+	op := Rename{To: dest}
+	if err := EnsureInScope(ctx.Capabilities, ctx.RepoRoot, ctx.HomeDir, dest); err != nil {
+		return false, err
+	}
+	if err := EnsureOpAllowed(ctx.Capabilities, op); err != nil {
+		return false, err
+	}
+
+	rel, relErr := filepath.Rel(ctx.RepoRoot, path)
+	if relErr != nil {
+		rel = path
+	}
+
+	// Step 5/6 — dry-run transparency, then atomic execute through the
+	// chokepoint's executor. (Step 4, verbatim backup, degenerates to
+	// mirroring the empty subtree shape; Rename undo never reads backups.)
+	startedNS := time.Since(ctx.start).Nanoseconds()
+	if ctx.DryRun {
+		fmt.Fprintf(os.Stderr, "[dry-run] would mutate %s: %s\n", path, DescribeOp(op))
+		return true, nil
+	}
+	if err := mirrorEmptyTree(path, filepath.Join(ctx.RunDir, "backups", rel)); err != nil {
+		return false, fmt.Errorf("doctor: backup %s: %w", path, err)
+	}
+	if err := executeAtomic(path, op); err != nil {
+		return false, fmt.Errorf("doctor: execute Rename on %s: %w", path, err)
+	}
+
+	// Step 7/8 — after hash (path is gone; empty) + fsync'd action record.
+	rec := ActionRecord{
+		Path:         rel,
+		Op:           op.kind(),
+		BeforeHash:   emptyHash,
+		AfterHash:    emptyHash,
+		BeforeMode:   beforeMode,
+		StartedAtNS:  startedNS,
+		FinishedAtNS: time.Since(ctx.start).Nanoseconds(),
+		RunID:        ctx.RunID,
+		FixerID:      ctx.FixerID,
+		OK:           true,
+		RenameTo:     dest,
+		Existed:      true,
+	}
+	if err := ctx.appendAction(rec); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// mirrorEmptyTree recreates src's directory structure (which holds no regular
+// files) under dst. It is the backup-step analogue for an empty tree: shape
+// only, since there are no bytes to copy.
+func mirrorEmptyTree(src, dst string) error {
+	return filepath.WalkDir(src, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil || !d.IsDir() {
+			return nil //nolint:nilerr // best-effort mirror; unreadable subtree skipped
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return nil //nolint:nilerr // unmappable entry contributes nothing
+		}
+		return os.MkdirAll(filepath.Join(dst, rel), 0o755)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// FM: fm-ws-empty-dirs (auto-fixable)
+// ---------------------------------------------------------------------------
+
+// workspaceEmptyDirsDetector flags unclaimed empty top-level workspace
+// directories in one summarizing finding.
+type workspaceEmptyDirsDetector struct{}
+
+func (workspaceEmptyDirsDetector) ID() string           { return fmWorkspaceEmptyDirsID }
+func (workspaceEmptyDirsDetector) Subsystem() string    { return subsystemWorkspace }
+func (workspaceEmptyDirsDetector) Severity() string     { return "P4" }
+func (workspaceEmptyDirsDetector) EstimatedCostMS() int { return 4 }
+func (workspaceEmptyDirsDetector) OnlineRequired() bool { return false }
+func (workspaceEmptyDirsDetector) QuickPath() bool      { return true }
+func (workspaceEmptyDirsDetector) Describe() string {
+	return "empty unclaimed top-level .agents directories (abandoned scaffolding)"
+}
+
+func (d workspaceEmptyDirsDetector) Detect(env *DetectEnv) ([]Finding, error) {
+	candidates, err := workspaceEmptyDirCandidates(workspaceAgentsDir(env))
+	if err != nil {
+		return nil, fmt.Errorf("doctor: inventory workspace: %w", err)
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	return []Finding{{
+		ID:         d.ID(),
+		Severity:   d.Severity(),
+		Subsystem:  d.Subsystem(),
+		Title:      fmt.Sprintf("%d empty workspace dir(s): %s", len(candidates), strings.Join(candidates, ", ")),
+		Confidence: 1.0,
+		Evidence: Evidence{
+			File:  ".agents",
+			Query: "find .agents -mindepth 1 -maxdepth 1 -type d -empty (plus dirs with only empty subdirs)",
+		},
+		Remediation: Remediation{
+			Command:          "ao doctor --fix --only " + d.ID(),
+			ExplainCommand:   "ao doctor explain " + d.ID(),
+			AutoFixable:      true,
+			EstimatedActions: len(candidates),
+		},
+	}}, nil
+}
+
+// workspaceEmptyDirsFixer quarantines each still-empty qualifying directory via
+// a Rename into <RunDir>/quarantine/workspace/. It re-scans at fix time, so a
+// directory that gained files between detect and fix is naturally skipped.
+type workspaceEmptyDirsFixer struct{}
+
+func (workspaceEmptyDirsFixer) ID() string { return fmWorkspaceEmptyDirsID }
+func (workspaceEmptyDirsFixer) Preconditions() []string {
+	return []string{
+		".agents exists and is a directory",
+		"directory still holds zero transitive regular files at fix time",
+	}
+}
+func (workspaceEmptyDirsFixer) WritesTo() []string { return []string{".agents"} }
+func (workspaceEmptyDirsFixer) Ops() []string      { return []string{"Rename"} }
+func (workspaceEmptyDirsFixer) Reversible() bool   { return true }
+func (workspaceEmptyDirsFixer) Idempotent() bool   { return true }
+func (workspaceEmptyDirsFixer) AutoFixable() bool  { return true }
+
+func (f workspaceEmptyDirsFixer) Fix(ctx *MutateContext, env *DetectEnv, _ []Finding) (FixResult, error) {
+	res := FixResult{FixerID: f.ID(), FindingIDs: []string{f.ID()}}
+	base := workspaceAgentsDir(env)
+	candidates, err := workspaceEmptyDirCandidates(base)
+	if err != nil {
+		res.Err = fmt.Errorf("doctor: %s: inventory workspace: %w", f.ID(), err)
+		return res, res.Err
+	}
+	if len(candidates) == 0 {
+		res.Fixed = true
+		return res, nil
+	}
+	for _, name := range candidates {
+		ok, err := quarantineEmptyDir(ctx, base, name, workspaceQuarantineDest(ctx, name))
+		if err != nil {
+			res.Err = fmt.Errorf("doctor: %s: quarantine %s: %w", f.ID(), name, err)
+			return res, res.Err
+		}
+		if ok {
+			res.ActionsTaken++
+		}
+	}
+	if !ctx.DryRun {
+		remaining, err := workspaceEmptyDirCandidates(base)
+		if err != nil {
+			res.Err = fmt.Errorf("doctor: %s: post-fix inventory: %w", f.ID(), err)
+			return res, res.Err
+		}
+		if len(remaining) != 0 {
+			res.Err = fmt.Errorf("doctor: %s: fix did not eliminate the finding", f.ID())
+			return res, res.Err
+		}
+	}
+	res.Fixed = true
+	return res, nil
+}

--- a/cli/internal/doctor/fix_workspace_empty.go
+++ b/cli/internal/doctor/fix_workspace_empty.go
@@ -100,6 +100,13 @@ func workspaceEmptyDirCandidates(base string) ([]string, error) {
 // caller's scan, and a dir that gained files is refused, not quarantined.
 // Returns (true, nil) when the rename happened (or would happen, in dry-run),
 // and (false, err) when it was refused.
+//
+// TOCTOU bound: the lock is in-process advisory only, so for a writer OUTSIDE
+// this process a verify→rename window remains and cannot be eliminated here
+// (full closure would need filesystem transactions or stop-the-world, out of
+// scope by design). The consequence is bounded: a file that lands in the
+// window is MOVED with the directory into quarantine, journaled, and
+// restorable via `doctor undo` — never destroyed.
 func quarantineEmptyDir(ctx *MutateContext, base, name, dest string) (bool, error) {
 	verify := func(path string) error {
 		baseInv, err := workspaceDirInventory(base)

--- a/cli/internal/doctor/fix_workspace_empty.go
+++ b/cli/internal/doctor/fix_workspace_empty.go
@@ -3,8 +3,10 @@ package doctor
 // Workspace subsystem: fm-ws-empty-dirs (auto-fixable).
 //
 // Flags empty immediate subdirectories of the workspace root `.agents/` —
-// directories holding zero transitive regular files (truly empty, or holding
-// only empty substructure). These are abandoned scaffolding from crashed or
+// directories PROVABLY holding nothing: zero transitive regular files, zero
+// non-regular entries (symlinks, FIFOs, ...), and zero unreadable subpaths
+// (truly empty, or holding only empty substructure). These are abandoned
+// scaffolding from crashed or
 // half-finished lanes: they clutter inventory output and mislead tooling that
 // treats directory presence as a signal.
 //
@@ -53,11 +55,24 @@ func workspaceEmptyDirClaimed(name string) bool {
 	return isWorkspaceStaleDirName(name)
 }
 
+// workspaceEmptyDirInfoIsEmpty reports whether an inventoried directory is
+// PROVABLY empty: zero regular files, zero non-regular entries (a dir of only
+// symlinks/FIFOs is not empty), and zero walk errors (an unreadable subtree
+// means content is unknown, and unknown is never empty).
+func workspaceEmptyDirInfoIsEmpty(info workspaceDirInfo) bool {
+	return info.FileCount == 0 && info.OtherEntries == 0 && info.WalkErrs == 0
+}
+
 // workspaceEmptyDirCandidates inventories base and returns the names of
-// immediate subdirectories holding zero transitive regular files, excluding
-// claimed names, in deterministic (name-sorted) order. A missing base yields
-// nil candidates and a nil error — nothing to flag.
+// immediate subdirectories that are provably empty (see
+// workspaceEmptyDirInfoIsEmpty), excluding claimed names, in deterministic
+// (name-sorted) order. A missing base — or a base that is not a real
+// directory, e.g. a symlinked `.agents` root — yields nil candidates and a
+// nil error: nothing this failure mode may safely claim.
 func workspaceEmptyDirCandidates(base string) ([]string, error) {
+	if !workspaceRealDir(base) {
+		return nil, nil
+	}
 	inv, err := workspaceDirInventory(base)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -67,7 +82,7 @@ func workspaceEmptyDirCandidates(base string) ([]string, error) {
 	}
 	var out []string
 	for _, info := range inv {
-		if info.FileCount != 0 {
+		if !workspaceEmptyDirInfoIsEmpty(info) {
 			continue
 		}
 		if workspaceEmptyDirClaimed(info.Name) {
@@ -93,13 +108,15 @@ func quarantineEmptyDir(ctx *MutateContext, base, name, dest string) (bool, erro
 		}
 		for _, di := range baseInv {
 			if di.Name == name {
-				if di.FileCount == 0 {
+				// Same bar as the detector: provably empty means zero regular
+				// files AND zero other entries AND zero walk errors.
+				if workspaceEmptyDirInfoIsEmpty(di) {
 					return nil
 				}
 				break
 			}
 		}
-		return fmt.Errorf("doctor: %s gained files since scan; refusing to quarantine (refused_unsafe)", path)
+		return fmt.Errorf("doctor: %s gained content (or became unreadable) since scan; refusing to quarantine (refused_unsafe)", path)
 	}
 	if err := workspaceQuarantineDirByName(ctx, base, name, dest, verify); err != nil {
 		return false, err
@@ -117,7 +134,7 @@ type workspaceEmptyDirsDetector struct{}
 
 func (workspaceEmptyDirsDetector) ID() string           { return fmWorkspaceEmptyDirsID }
 func (workspaceEmptyDirsDetector) Subsystem() string    { return subsystemWorkspace }
-func (workspaceEmptyDirsDetector) Severity() string     { return "P4" }
+func (workspaceEmptyDirsDetector) Severity() string     { return "P3" }
 func (workspaceEmptyDirsDetector) EstimatedCostMS() int { return 4 }
 func (workspaceEmptyDirsDetector) OnlineRequired() bool { return false }
 func (workspaceEmptyDirsDetector) QuickPath() bool      { return true }
@@ -173,6 +190,18 @@ func (workspaceEmptyDirsFixer) AutoFixable() bool  { return true }
 func (f workspaceEmptyDirsFixer) Fix(ctx *MutateContext, env *DetectEnv, _ []Finding) (FixResult, error) {
 	res := FixResult{FixerID: f.ID(), FindingIDs: []string{f.ID()}}
 	base := workspaceAgentsDir(env)
+	// Never mutate through a `.agents` root that is not a real directory: a
+	// symlinked root would make every rename act on a tree OUTSIDE the repo
+	// while the lexical scope check still passes.
+	exists, err := workspaceRequireRealAgentsDir(base)
+	if err != nil {
+		res.Err = fmt.Errorf("doctor: %s: %w", f.ID(), err)
+		return res, res.Err
+	}
+	if !exists {
+		res.Fixed = true // nothing to fix
+		return res, nil
+	}
 	candidates, err := workspaceEmptyDirCandidates(base)
 	if err != nil {
 		res.Err = fmt.Errorf("doctor: %s: inventory workspace: %w", f.ID(), err)

--- a/cli/internal/doctor/fix_workspace_empty_test.go
+++ b/cli/internal/doctor/fix_workspace_empty_test.go
@@ -69,8 +69,8 @@ func TestWorkspaceEmptyDirsRegistration(t *testing.T) {
 			if d.Subsystem() != subsystemWorkspace {
 				t.Errorf("detector subsystem = %q, want %q", d.Subsystem(), subsystemWorkspace)
 			}
-			if d.Severity() != "P4" {
-				t.Errorf("detector severity = %q, want P4", d.Severity())
+			if d.Severity() != "P3" {
+				t.Errorf("detector severity = %q, want P3", d.Severity())
 			}
 			if !d.QuickPath() {
 				t.Error("detector QuickPath = false, want true")
@@ -109,8 +109,8 @@ func TestWorkspaceEmptyDirs_DetectAndFix(t *testing.T) {
 	if fd.ID != fmWorkspaceEmptyDirsID {
 		t.Fatalf("finding ID = %q, want %q", fd.ID, fmWorkspaceEmptyDirsID)
 	}
-	if fd.Severity != "P4" {
-		t.Errorf("finding severity = %q, want P4", fd.Severity)
+	if fd.Severity != "P3" {
+		t.Errorf("finding severity = %q, want P3", fd.Severity)
 	}
 	if !fd.Remediation.AutoFixable {
 		t.Error("finding not marked AutoFixable")
@@ -225,6 +225,91 @@ func TestWorkspaceEmptyDirs_SkipsDirThatGainedFiles(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(agents, "nested-empty")); !os.IsNotExist(err) {
 		t.Errorf("nested-empty not quarantined (err=%v)", err)
+	}
+}
+
+// TestWorkspaceEmptyDirs_UnreadableDirNotFlagged: a directory whose content
+// cannot be read (permission-denied subtree) has FileCount 0 but is NOT
+// empty — its content is unknown, and unknown must never be quarantined.
+func TestWorkspaceEmptyDirs_UnreadableDirNotFlagged(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; permission denial is not enforceable")
+	}
+	repo := t.TempDir()
+	agents := filepath.Join(repo, ".agents")
+	hidden := filepath.Join(agents, "opaque", "locked")
+	if err := os.MkdirAll(hidden, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hidden, "secret.md"), []byte("invisible"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(hidden, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(hidden, 0o755) })
+
+	env := &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}
+	findings, err := workspaceEmptyDirsDetector{}.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("unreadable dir flagged as empty: %+v", findings)
+	}
+
+	// The fixer must not collect it either.
+	ctx, _ := newWorkspaceEmptyMutateCtx(t, repo)
+	res, err := workspaceEmptyDirsFixer{}.Fix(ctx, env, nil)
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if res.ActionsTaken != 0 {
+		t.Fatalf("Fix quarantined %d unreadable dir(s), want 0", res.ActionsTaken)
+	}
+	if st, err := os.Stat(filepath.Join(agents, "opaque")); err != nil || !st.IsDir() {
+		t.Fatalf("opaque dir gone after fix (err=%v)", err)
+	}
+}
+
+// TestWorkspaceEmptyDirs_SymlinkOnlyDirNotFlagged: a directory holding only a
+// symlink has zero regular files but is NOT empty — quarantining it would
+// relocate the link.
+func TestWorkspaceEmptyDirs_SymlinkOnlyDirNotFlagged(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	agents := filepath.Join(repo, ".agents")
+	linksDir := filepath.Join(agents, "links-only")
+	if err := os.MkdirAll(linksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(outside, "target.md")
+	if err := os.WriteFile(target, []byte("elsewhere"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(linksDir, "link.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	env := &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}
+	findings, err := workspaceEmptyDirsDetector{}.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("symlink-only dir flagged as empty: %+v", findings)
+	}
+
+	ctx, _ := newWorkspaceEmptyMutateCtx(t, repo)
+	res, err := workspaceEmptyDirsFixer{}.Fix(ctx, env, nil)
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if res.ActionsTaken != 0 {
+		t.Fatalf("Fix quarantined %d symlink-only dir(s), want 0", res.ActionsTaken)
+	}
+	if info, err := os.Lstat(filepath.Join(linksDir, "link.md")); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("symlink missing or changed after fix (err=%v)", err)
 	}
 }
 

--- a/cli/internal/doctor/fix_workspace_empty_test.go
+++ b/cli/internal/doctor/fix_workspace_empty_test.go
@@ -1,0 +1,272 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// workspaceEmptyTestEnv builds an isolated repo whose .agents/ tree holds the
+// canonical fixture for the empty-dirs failure mode:
+//
+//	stub/                          empty            -> flagged
+//	nested-empty/a/b/              only empty subs  -> flagged
+//	deep/                          one deep file    -> NOT flagged
+//	ao/                            empty store root -> NOT flagged (knowledge's)
+//	handoff/                       empty canonical  -> NOT flagged
+//	land-queue-x.stale-.../        empty stale name -> NOT flagged (GC's)
+//
+// It returns the DetectEnv and the repo root.
+func workspaceEmptyTestEnv(t *testing.T) (*DetectEnv, string) {
+	t.Helper()
+	repo := t.TempDir()
+	agents := filepath.Join(repo, ".agents")
+	for _, dir := range []string{
+		filepath.Join(agents, "stub"),
+		filepath.Join(agents, "nested-empty", "a", "b"),
+		filepath.Join(agents, "ao"),
+		filepath.Join(agents, "handoff"),
+		filepath.Join(agents, "land-queue-x.stale-20260711T221032Z"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	deepFile := filepath.Join(agents, "deep", "sub", "keep.md")
+	if err := os.MkdirAll(filepath.Dir(deepFile), 0o755); err != nil {
+		t.Fatalf("mkdir deep: %v", err)
+	}
+	if err := os.WriteFile(deepFile, []byte("content"), 0o644); err != nil {
+		t.Fatalf("write deep file: %v", err)
+	}
+	return &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}, repo
+}
+
+// newWorkspaceEmptyMutateCtx builds a real MutateContext rooted at repo with a
+// live actions.jsonl handle, scoped to the fm-ws-empty-dirs fixer.
+func newWorkspaceEmptyMutateCtx(t *testing.T, repo string) (*MutateContext, *RunArtifact) {
+	t.Helper()
+	ra, err := NewRunArtifact(repo, "wsemptytest", time.Now())
+	if err != nil {
+		t.Fatalf("NewRunArtifact: %v", err)
+	}
+	af, err := ra.OpenActionsFile()
+	if err != nil {
+		t.Fatalf("OpenActionsFile: %v", err)
+	}
+	t.Cleanup(func() { _ = af.Close() })
+	caps := NewCapabilities("test")
+	locks := NewLockManager(filepath.Join(repo, ".doctor", "locks"))
+	return NewMutateContext(ra, caps, t.TempDir(), locks, af, false).WithFixer(fmWorkspaceEmptyDirsID), ra
+}
+
+func TestWorkspaceEmptyDirsRegistration(t *testing.T) {
+	var foundDet bool
+	for _, d := range Detectors() {
+		if d.ID() == fmWorkspaceEmptyDirsID {
+			foundDet = true
+			if d.Subsystem() != subsystemWorkspace {
+				t.Errorf("detector subsystem = %q, want %q", d.Subsystem(), subsystemWorkspace)
+			}
+			if d.Severity() != "P4" {
+				t.Errorf("detector severity = %q, want P4", d.Severity())
+			}
+			if !d.QuickPath() {
+				t.Error("detector QuickPath = false, want true")
+			}
+		}
+	}
+	if !foundDet {
+		t.Fatalf("detector %s not registered", fmWorkspaceEmptyDirsID)
+	}
+	f := FixerByID(fmWorkspaceEmptyDirsID)
+	if f == nil {
+		t.Fatalf("fixer %s not registered", fmWorkspaceEmptyDirsID)
+	}
+	if got := f.Ops(); len(got) != 1 || got[0] != "Rename" {
+		t.Errorf("fixer Ops = %v, want [Rename]", got)
+	}
+	if !f.Reversible() || !f.Idempotent() || !f.AutoFixable() {
+		t.Errorf("fixer flags = reversible %v idempotent %v autofixable %v, want all true",
+			f.Reversible(), f.Idempotent(), f.AutoFixable())
+	}
+}
+
+func TestWorkspaceEmptyDirs_DetectAndFix(t *testing.T) {
+	env, repo := workspaceEmptyTestEnv(t)
+	agents := workspaceAgentsDir(env)
+
+	det := workspaceEmptyDirsDetector{}
+	findings, err := det.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("findings = %d, want 1 (%+v)", len(findings), findings)
+	}
+	fd := findings[0]
+	if fd.ID != fmWorkspaceEmptyDirsID {
+		t.Fatalf("finding ID = %q, want %q", fd.ID, fmWorkspaceEmptyDirsID)
+	}
+	if fd.Severity != "P4" {
+		t.Errorf("finding severity = %q, want P4", fd.Severity)
+	}
+	if !fd.Remediation.AutoFixable {
+		t.Error("finding not marked AutoFixable")
+	}
+	// Exactly two qualifying dirs: stub and nested-empty.
+	if fd.Remediation.EstimatedActions != 2 {
+		t.Fatalf("EstimatedActions = %d, want 2 (title: %s)", fd.Remediation.EstimatedActions, fd.Title)
+	}
+
+	ctx, ra := newWorkspaceEmptyMutateCtx(t, repo)
+	res, err := workspaceEmptyDirsFixer{}.Fix(ctx, env, findings)
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if !res.Fixed {
+		t.Fatal("Fix did not report Fixed")
+	}
+	if res.ActionsTaken != 2 {
+		t.Fatalf("ActionsTaken = %d, want 2", res.ActionsTaken)
+	}
+
+	// The qualifying set is quarantined...
+	for _, name := range []string{"stub", "nested-empty"} {
+		if _, err := os.Stat(filepath.Join(agents, name)); !os.IsNotExist(err) {
+			t.Errorf("%s still present under .agents (err=%v)", name, err)
+		}
+		q := filepath.Join(ra.RunDir, "quarantine", subsystemWorkspace, name)
+		st, err := os.Stat(q)
+		if err != nil || !st.IsDir() {
+			t.Errorf("%s not quarantined at %s (err=%v)", name, q, err)
+		}
+	}
+	// ...and every excluded dir survives untouched.
+	for _, name := range []string{"deep", "ao", "handoff", "land-queue-x.stale-20260711T221032Z"} {
+		st, err := os.Stat(filepath.Join(agents, name))
+		if err != nil || !st.IsDir() {
+			t.Errorf("excluded dir %s missing after fix (err=%v)", name, err)
+		}
+	}
+	// The deep file's content is intact.
+	got, err := os.ReadFile(filepath.Join(agents, "deep", "sub", "keep.md"))
+	if err != nil || string(got) != "content" {
+		t.Errorf("deep file changed: %q err=%v", got, err)
+	}
+
+	// Re-detect: clean.
+	again, err := det.Detect(env)
+	if err != nil {
+		t.Fatalf("post-fix Detect: %v", err)
+	}
+	if len(again) != 0 {
+		t.Fatalf("post-fix detect found %d findings, want 0 (%+v)", len(again), again)
+	}
+}
+
+func TestWorkspaceEmptyDirs_FixIdempotent(t *testing.T) {
+	env, repo := workspaceEmptyTestEnv(t)
+	ctx, _ := newWorkspaceEmptyMutateCtx(t, repo)
+	fixer := workspaceEmptyDirsFixer{}
+
+	first, err := fixer.Fix(ctx, env, nil)
+	if err != nil {
+		t.Fatalf("first Fix: %v", err)
+	}
+	if first.ActionsTaken != 2 {
+		t.Fatalf("first ActionsTaken = %d, want 2", first.ActionsTaken)
+	}
+
+	second, err := fixer.Fix(ctx, env, nil)
+	if err != nil {
+		t.Fatalf("second Fix: %v", err)
+	}
+	if !second.Fixed {
+		t.Fatal("second Fix did not report Fixed")
+	}
+	if second.ActionsTaken != 0 {
+		t.Fatalf("second ActionsTaken = %d, want 0", second.ActionsTaken)
+	}
+}
+
+func TestWorkspaceEmptyDirs_SkipsDirThatGainedFiles(t *testing.T) {
+	env, repo := workspaceEmptyTestEnv(t)
+	agents := workspaceAgentsDir(env)
+
+	findings, err := workspaceEmptyDirsDetector{}.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Remediation.EstimatedActions != 2 {
+		t.Fatalf("unexpected detect result: %+v", findings)
+	}
+
+	// Between detect and fix, stub gains a file.
+	if err := os.WriteFile(filepath.Join(agents, "stub", "late.md"), []byte("arrived"), 0o644); err != nil {
+		t.Fatalf("write late file: %v", err)
+	}
+
+	ctx, _ := newWorkspaceEmptyMutateCtx(t, repo)
+	res, err := workspaceEmptyDirsFixer{}.Fix(ctx, env, findings)
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if !res.Fixed {
+		t.Fatal("Fix did not report Fixed")
+	}
+	// Only nested-empty is still qualifying.
+	if res.ActionsTaken != 1 {
+		t.Fatalf("ActionsTaken = %d, want 1", res.ActionsTaken)
+	}
+	if st, err := os.Stat(filepath.Join(agents, "stub")); err != nil || !st.IsDir() {
+		t.Errorf("stub (which gained files) was quarantined (err=%v)", err)
+	}
+	if _, err := os.Stat(filepath.Join(agents, "nested-empty")); !os.IsNotExist(err) {
+		t.Errorf("nested-empty not quarantined (err=%v)", err)
+	}
+}
+
+func TestWorkspaceEmptyDirs_DetectMissingBaseClean(t *testing.T) {
+	repo := t.TempDir() // no .agents at all
+	env := &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}
+	findings, err := workspaceEmptyDirsDetector{}.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect on missing base: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("findings = %d, want 0", len(findings))
+	}
+}
+
+func TestWorkspaceEmptyDirClaimed(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"ao", true},
+		// Every canonical alias target is claimed.
+		{"postmortem", true},
+		{"pre-mortem-checks", true},
+		{"handoff", true},
+		{"retro", true},
+		{"proofs", true},
+		{"tests", true},
+		// Stale/retry names belong to the GC failure mode.
+		{"land-queue-age-h433.19.stale-20260711T221032Z", true},
+		{"land-queue-age-h433.22-native-retry2", true},
+		// Unclaimed names.
+		{"stub", false},
+		{"scratch", false},
+		// Alias KEYS (drifted spellings) are not claimed — an empty drifted
+		// dir is quarantinable debris.
+		{"handoffs", false},
+		{"post-mortems", false},
+	}
+	for _, tt := range tests {
+		if got := workspaceEmptyDirClaimed(tt.name); got != tt.want {
+			t.Errorf("workspaceEmptyDirClaimed(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/cli/internal/doctor/fix_workspace_size.go
+++ b/cli/internal/doctor/fix_workspace_size.go
@@ -1,0 +1,165 @@
+package doctor
+
+// Workspace oversize report: fm-ws-oversize (report-only, NO fixer).
+//
+// The `.agents/` workspace accretes weight two ways: top-level directories
+// whose transitive content balloons past useful size (session archives, land
+// queues, wiki mirrors), and large regular files dumped directly at the top
+// level (e.g. a 4.6M wiki-index.jsonl). Neither has a safe localized
+// auto-fix — "what to archive" is a judgment call over live artifacts — so
+// this detector only reports: one finding per offender, sorted by name, each
+// carrying exact byte sizes and pointing at manual archive rotation. No fixer
+// is registered for this ID.
+//
+// The detector is PURE (stat + readdir via workspaceDirInventory) but NOT a
+// quick path: sizing a directory is a full transitive tree walk.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"time"
+)
+
+// workspaceOversizeID is the detector ID for workspace oversize reporting.
+// There is deliberately no fixer under this ID.
+const workspaceOversizeID = "fm-ws-oversize"
+
+// Workspace size-threshold configuration.
+const (
+	// workspaceSizeEnvVar overrides the top-level directory size threshold,
+	// in whole MiB.
+	workspaceSizeEnvVar = "AO_DOCTOR_WS_SIZE_MB"
+	// workspaceSizeDefaultMiB is the default directory size threshold in MiB.
+	workspaceSizeDefaultMiB = 25
+	// mib is one mebibyte in bytes.
+	mib = 1024 * 1024
+	// workspaceLooseFileThresholdBytes is the FIXED threshold (2 MiB) for a
+	// regular file sitting directly under `.agents/` (not inside a subdir).
+	// Deliberately not env-configurable: a multi-megabyte loose file at the
+	// workspace top level is anomalous regardless of how much bulk the
+	// operator tolerates inside subdirectories.
+	workspaceLooseFileThresholdBytes int64 = 2 * mib
+)
+
+// workspaceSizeThreshold returns the top-level directory size threshold in
+// bytes. Defaults to 25 MiB; AO_DOCTOR_WS_SIZE_MB overrides with a positive
+// integer MiB count, and any invalid value falls back to the default
+// (mirroring workspaceGCTTL).
+func workspaceSizeThreshold() int64 {
+	if raw := os.Getenv(workspaceSizeEnvVar); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			return int64(n) * mib
+		}
+	}
+	return workspaceSizeDefaultMiB * mib
+}
+
+func init() {
+	RegisterDetector(workspaceOversizeDetector{})
+	// NO RegisterFixer: fm-ws-oversize is report-only by design.
+}
+
+// workspaceOversizeDetector flags oversize top-level `.agents/` directories
+// and oversize loose files directly under `.agents/`.
+type workspaceOversizeDetector struct{}
+
+func (workspaceOversizeDetector) ID() string           { return workspaceOversizeID }
+func (workspaceOversizeDetector) Subsystem() string    { return subsystemWorkspace }
+func (workspaceOversizeDetector) Severity() string     { return "P4" }
+func (workspaceOversizeDetector) EstimatedCostMS() int { return 250 }
+func (workspaceOversizeDetector) OnlineRequired() bool { return false }
+func (workspaceOversizeDetector) QuickPath() bool      { return false }
+func (workspaceOversizeDetector) Describe() string {
+	return "oversize .agents dirs and top-level loose files needing archive rotation"
+}
+
+func (d workspaceOversizeDetector) Detect(env *DetectEnv) ([]Finding, error) {
+	base := workspaceAgentsDir(env)
+	if _, err := os.Stat(base); err != nil {
+		return nil, nil
+	}
+	inv, err := workspaceDirInventory(base)
+	if err != nil {
+		return nil, fmt.Errorf("doctor: inventory %s: %w", base, err)
+	}
+	threshold := workspaceSizeThreshold()
+
+	var findings []Finding
+	for _, dir := range inv {
+		if dir.ByteSize <= threshold {
+			continue
+		}
+		rel := filepath.Join(".agents", dir.Name)
+		findings = append(findings, Finding{
+			ID:        d.ID(),
+			Severity:  d.Severity(),
+			Subsystem: d.Subsystem(),
+			Title: fmt.Sprintf("%s is %d bytes (%.1f MiB) — over the %d MiB threshold",
+				rel, dir.ByteSize, float64(dir.ByteSize)/float64(mib), threshold/mib),
+			Confidence: 1.0,
+			Evidence: Evidence{
+				File: rel,
+				Query: fmt.Sprintf("du -sk %s  # %d file(s), newest mtime %s",
+					rel, dir.FileCount, dir.NewestMTime.UTC().Format(time.RFC3339)),
+			},
+			Remediation: workspaceOversizeRemediation(d.ID(), rel),
+		})
+	}
+
+	// Loose regular files directly under .agents/ (symlink-safe: ReadDir
+	// reports lstat-style types, so a symlink is never IsRegular here).
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return nil, fmt.Errorf("doctor: read %s: %w", base, err)
+	}
+	for _, e := range entries {
+		if !e.Type().IsRegular() {
+			continue
+		}
+		fi, infoErr := e.Info()
+		if infoErr != nil {
+			continue
+		}
+		if fi.Size() <= workspaceLooseFileThresholdBytes {
+			continue
+		}
+		rel := filepath.Join(".agents", e.Name())
+		findings = append(findings, Finding{
+			ID:        d.ID(),
+			Severity:  d.Severity(),
+			Subsystem: d.Subsystem(),
+			Title: fmt.Sprintf("loose file %s is %d bytes (%.1f MiB) — over the fixed %d MiB loose-file threshold",
+				rel, fi.Size(), float64(fi.Size())/float64(mib), workspaceLooseFileThresholdBytes/mib),
+			Confidence: 1.0,
+			Evidence: Evidence{
+				File:  rel,
+				Query: "ls -l " + rel,
+			},
+			Remediation: workspaceOversizeRemediation(d.ID(), rel),
+		})
+	}
+
+	// Deterministic order: offenders (dirs and loose files interleaved)
+	// sorted by their .agents-relative path.
+	sort.Slice(findings, func(i, j int) bool {
+		return findings[i].Evidence.File < findings[j].Evidence.File
+	})
+	return findings, nil
+}
+
+// workspaceOversizeRemediation is the shared report-only remediation: the
+// doctor never decides what workspace bulk is disposable, so the instruction
+// is a manual archive-rotation review (cf. the detect-only knowledge and
+// cli_config findings, which likewise hand a human the exact next command).
+func workspaceOversizeRemediation(id, rel string) Remediation {
+	return Remediation{
+		Command: "Review " + rel + " yourself. Archive or rotate what is no longer live " +
+			"(e.g. tar czf " + rel + ".tar.gz " + rel + " && move the archive out of .agents), " +
+			"then re-run: ao doctor",
+		ExplainCommand: "ao doctor explain " + id,
+		AutoFixable:    false,
+	}
+}

--- a/cli/internal/doctor/fix_workspace_size.go
+++ b/cli/internal/doctor/fix_workspace_size.go
@@ -34,6 +34,11 @@ const (
 	workspaceSizeEnvVar = "AO_DOCTOR_WS_SIZE_MB"
 	// workspaceSizeDefaultMiB is the default directory size threshold in MiB.
 	workspaceSizeDefaultMiB = 25
+	// workspaceSizeMaxMiB caps the env override at 1 TiB (2^20 MiB). The cap
+	// is a correctness guard, not just taste: an unbounded MiB count overflows
+	// the int64 byte multiplication (values above ~2^43 wrap negative), which
+	// would make EVERY directory read as over-threshold at once.
+	workspaceSizeMaxMiB = 1 << 20
 	// mib is one mebibyte in bytes.
 	mib = 1024 * 1024
 	// workspaceLooseFileThresholdBytes is the FIXED threshold (2 MiB) for a
@@ -45,12 +50,13 @@ const (
 )
 
 // workspaceSizeThreshold returns the top-level directory size threshold in
-// bytes. Defaults to 25 MiB; AO_DOCTOR_WS_SIZE_MB overrides with a positive
-// integer MiB count, and any invalid value falls back to the default
-// (mirroring workspaceGCTTL).
+// bytes. Defaults to 25 MiB; AO_DOCTOR_WS_SIZE_MB overrides with an integer
+// MiB count in [1, workspaceSizeMaxMiB], and any invalid or out-of-range
+// value falls back to the default (mirroring workspaceGCTTL; see
+// workspaceSizeMaxMiB for why the cap exists).
 func workspaceSizeThreshold() int64 {
 	if raw := os.Getenv(workspaceSizeEnvVar); raw != "" {
-		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+		if n, err := strconv.Atoi(raw); err == nil && n >= 1 && n <= workspaceSizeMaxMiB {
 			return int64(n) * mib
 		}
 	}

--- a/cli/internal/doctor/fix_workspace_size.go
+++ b/cli/internal/doctor/fix_workspace_size.go
@@ -68,7 +68,7 @@ type workspaceOversizeDetector struct{}
 
 func (workspaceOversizeDetector) ID() string           { return workspaceOversizeID }
 func (workspaceOversizeDetector) Subsystem() string    { return subsystemWorkspace }
-func (workspaceOversizeDetector) Severity() string     { return "P4" }
+func (workspaceOversizeDetector) Severity() string     { return "P3" }
 func (workspaceOversizeDetector) EstimatedCostMS() int { return 250 }
 func (workspaceOversizeDetector) OnlineRequired() bool { return false }
 func (workspaceOversizeDetector) QuickPath() bool      { return false }
@@ -78,7 +78,9 @@ func (workspaceOversizeDetector) Describe() string {
 
 func (d workspaceOversizeDetector) Detect(env *DetectEnv) ([]Finding, error) {
 	base := workspaceAgentsDir(env)
-	if _, err := os.Stat(base); err != nil {
+	// Lstat guard: a symlinked `.agents` root points outside the repo; size
+	// reporting on foreign trees is noise at best. Not a real dir → nothing.
+	if !workspaceRealDir(base) {
 		return nil, nil
 	}
 	inv, err := workspaceDirInventory(base)

--- a/cli/internal/doctor/fix_workspace_size_test.go
+++ b/cli/internal/doctor/fix_workspace_size_test.go
@@ -1,0 +1,268 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeOversizeBytes creates a regular file of exactly n zero bytes with the
+// given mtime, creating parent directories as needed. Sizes in these tests are
+// exact on purpose: the detector's threshold comparison is `> threshold`, so
+// boundary fixtures sit at threshold and threshold+1.
+func writeOversizeBytes(t *testing.T, path string, n int, mtime time.Time) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, make([]byte, n), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+}
+
+// TestWorkspaceOversize_DetectDirsAndLooseFiles is the main fixture pass at a
+// 1 MiB override threshold: two oversize dirs and one oversize loose file are
+// flagged with exact byte sizes; boundary-exact dirs/files, small files, and
+// symlinks are not. Finding order is deterministic (sorted by name).
+func TestWorkspaceOversize_DetectDirsAndLooseFiles(t *testing.T) {
+	t.Setenv(workspaceSizeEnvVar, "1") // threshold = 1 MiB = 1048576 bytes
+	repo := t.TempDir()
+	outside := t.TempDir()
+	agents := filepath.Join(repo, ".agents")
+	mt := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+
+	// Over threshold by exactly one byte: flagged.
+	writeOversizeBytes(t, filepath.Join(agents, "aa-bulky", "blob.bin"), mib+1, mt)
+	// Exactly AT threshold: NOT flagged (comparison is strictly greater).
+	writeOversizeBytes(t, filepath.Join(agents, "trim", "data.bin"), mib, mt)
+	// Over threshold via two nested files (1100000 bytes total): flagged.
+	writeOversizeBytes(t, filepath.Join(agents, "zz-heap", "a.bin"), 900000, mt)
+	writeOversizeBytes(t, filepath.Join(agents, "zz-heap", "nested", "b.bin"), 200000, mt.Add(time.Hour))
+	// Loose file over the fixed 2 MiB threshold by one byte: flagged.
+	writeOversizeBytes(t, filepath.Join(agents, "wiki-index.jsonl"), 2*mib+1, mt)
+	// Loose file exactly AT 2 MiB: NOT flagged.
+	writeOversizeBytes(t, filepath.Join(agents, "boundary.jsonl"), 2*mib, mt)
+	// Small loose file: NOT flagged.
+	writeOversizeBytes(t, filepath.Join(agents, "small.json"), 10, mt)
+	// Loose symlink to a huge outside file: NOT flagged (symlink-safe).
+	decoy := filepath.Join(outside, "decoy.bin")
+	writeOversizeBytes(t, decoy, 3*mib, mt)
+	if err := os.Symlink(decoy, filepath.Join(agents, "link-big")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	env := &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}
+	findings, err := workspaceOversizeDetector{}.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 3 {
+		t.Fatalf("findings = %d, want 3", len(findings))
+	}
+
+	wantTitles := []string{
+		".agents/aa-bulky is 1048577 bytes (1.0 MiB) — over the 1 MiB threshold",
+		"loose file .agents/wiki-index.jsonl is 2097153 bytes (2.0 MiB) — over the fixed 2 MiB loose-file threshold",
+		".agents/zz-heap is 1100000 bytes (1.0 MiB) — over the 1 MiB threshold",
+	}
+	wantFiles := []string{".agents/aa-bulky", ".agents/wiki-index.jsonl", ".agents/zz-heap"}
+	for i, f := range findings {
+		if f.ID != "fm-ws-oversize" {
+			t.Errorf("findings[%d].ID = %q, want fm-ws-oversize", i, f.ID)
+		}
+		if f.Subsystem != "workspace" {
+			t.Errorf("findings[%d].Subsystem = %q, want workspace", i, f.Subsystem)
+		}
+		if f.Severity != "P4" {
+			t.Errorf("findings[%d].Severity = %q, want P4", i, f.Severity)
+		}
+		if f.Confidence != 1.0 {
+			t.Errorf("findings[%d].Confidence = %v, want 1.0", i, f.Confidence)
+		}
+		if f.Title != wantTitles[i] {
+			t.Errorf("findings[%d].Title = %q, want %q", i, f.Title, wantTitles[i])
+		}
+		if f.Evidence.File != wantFiles[i] {
+			t.Errorf("findings[%d].Evidence.File = %q, want %q", i, f.Evidence.File, wantFiles[i])
+		}
+		if f.Remediation.AutoFixable {
+			t.Errorf("findings[%d] is AutoFixable, want report-only", i)
+		}
+		if want := "ao doctor explain fm-ws-oversize"; f.Remediation.ExplainCommand != want {
+			t.Errorf("findings[%d].ExplainCommand = %q, want %q", i, f.Remediation.ExplainCommand, want)
+		}
+		if f.Remediation.Command == "" {
+			t.Errorf("findings[%d].Remediation.Command is empty", i)
+		}
+	}
+
+	// Dir evidence carries file count and newest mtime.
+	if want := "du -sk .agents/aa-bulky  # 1 file(s), newest mtime 2026-07-01T10:00:00Z"; findings[0].Evidence.Query != want {
+		t.Errorf("aa-bulky Evidence.Query = %q, want %q", findings[0].Evidence.Query, want)
+	}
+	if want := "du -sk .agents/zz-heap  # 2 file(s), newest mtime 2026-07-01T11:00:00Z"; findings[2].Evidence.Query != want {
+		t.Errorf("zz-heap Evidence.Query = %q, want %q", findings[2].Evidence.Query, want)
+	}
+	if want := "ls -l .agents/wiki-index.jsonl"; findings[1].Evidence.Query != want {
+		t.Errorf("loose-file Evidence.Query = %q, want %q", findings[1].Evidence.Query, want)
+	}
+}
+
+// TestWorkspaceOversize_DefaultThresholdBoundary exercises the 25 MiB default
+// boundary with exact sizes: threshold+1 is flagged, exactly-threshold is not.
+func TestWorkspaceOversize_DefaultThresholdBoundary(t *testing.T) {
+	t.Setenv(workspaceSizeEnvVar, "") // empty = unset: 25 MiB default
+	repo := t.TempDir()
+	agents := filepath.Join(repo, ".agents")
+	mt := time.Date(2026, 7, 2, 9, 0, 0, 0, time.UTC)
+
+	writeOversizeBytes(t, filepath.Join(agents, "over", "blob.bin"), 25*mib+1, mt)
+	writeOversizeBytes(t, filepath.Join(agents, "under", "blob.bin"), 25*mib, mt)
+
+	env := &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}
+	findings, err := workspaceOversizeDetector{}.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("findings = %d, want 1 (only the over-threshold dir)", len(findings))
+	}
+	if want := ".agents/over is 26214401 bytes (25.0 MiB) — over the 25 MiB threshold"; findings[0].Title != want {
+		t.Errorf("Title = %q, want %q", findings[0].Title, want)
+	}
+}
+
+// TestWorkspaceOversize_ThresholdEnvOverride is the env-override table for
+// workspaceSizeThreshold: valid values apply, invalid values (zero, negative,
+// garbage) and unset/empty fall back to the 25 MiB default.
+func TestWorkspaceOversize_ThresholdEnvOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want int64
+	}{
+		{"unset/empty", "", 25 * mib},
+		{"valid one MiB", "1", mib},
+		{"valid large", "100", 100 * mib},
+		{"zero invalid", "0", 25 * mib},
+		{"negative invalid", "-5", 25 * mib},
+		{"garbage invalid", "abc", 25 * mib},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(workspaceSizeEnvVar, tt.raw)
+			if got := workspaceSizeThreshold(); got != tt.want {
+				t.Errorf("workspaceSizeThreshold() with %q = %d, want %d", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkspaceOversize_DetectNoAgentsDir(t *testing.T) {
+	repo := t.TempDir()
+	env := &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}
+	findings, err := workspaceOversizeDetector{}.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("missing .agents produced %d findings, want 0", len(findings))
+	}
+}
+
+// TestWorkspaceOversize_EngineFixPassZeroMutations proves the report-only
+// contract end-to-end: a full detect+fix engine pass scoped to this ID has no
+// registered fixer (FixerByID nil), takes zero actions, writes zero action
+// records, and leaves every offender byte-for-byte in place.
+func TestWorkspaceOversize_EngineFixPassZeroMutations(t *testing.T) {
+	t.Setenv(workspaceSizeEnvVar, "1")
+	repo := t.TempDir()
+	agents := filepath.Join(repo, ".agents")
+	mt := time.Date(2026, 7, 3, 8, 0, 0, 0, time.UTC)
+	dirBlob := filepath.Join(agents, "bulky", "blob.bin")
+	loose := filepath.Join(agents, "wiki-index.jsonl")
+	writeOversizeBytes(t, dirBlob, mib+1, mt)
+	writeOversizeBytes(t, loose, 2*mib+1, mt)
+
+	if fx := FixerByID(workspaceOversizeID); fx != nil {
+		t.Fatalf("FixerByID(%q) = %T, want nil (report-only detector)", workspaceOversizeID, fx)
+	}
+
+	rep, err := Fix(Options{
+		RepoRoot:    repo,
+		CWD:         repo,
+		HomeDir:     t.TempDir(),
+		ToolVersion: "test",
+		Only:        []string{workspaceOversizeID},
+	})
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if got := rep.Summary.TotalFindings; got != 2 {
+		t.Fatalf("TotalFindings = %d, want 2", got)
+	}
+	if rep.ActionsTaken != 0 {
+		t.Fatalf("ActionsTaken = %d, want 0 (no fixer registered)", rep.ActionsTaken)
+	}
+	// Unfixable findings remain: the fix pass reports partial, never healthy.
+	if rep.ExitCode != ExitFixPartial {
+		t.Errorf("ExitCode = %d, want %d (ExitFixPartial)", rep.ExitCode, ExitFixPartial)
+	}
+
+	// Zero action records in the run's actions.jsonl.
+	recs, err := readActions(filepath.Join(repo, rep.ActionsPath))
+	if err != nil {
+		t.Fatalf("readActions: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("action records = %d, want 0", len(recs))
+	}
+
+	// Offenders untouched, exact sizes preserved.
+	for path, want := range map[string]int64{dirBlob: mib + 1, loose: 2*mib + 1} {
+		st, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("offender %s missing after fix pass: %v", path, err)
+		}
+		if st.Size() != want {
+			t.Errorf("offender %s size = %d, want %d (mutated!)", path, st.Size(), want)
+		}
+	}
+}
+
+func TestWorkspaceOversize_Registration(t *testing.T) {
+	var det Detector
+	for _, d := range Detectors() {
+		if d.ID() == workspaceOversizeID {
+			det = d
+		}
+	}
+	if det == nil {
+		t.Fatalf("detector %q not registered", workspaceOversizeID)
+	}
+	if det.Subsystem() != "workspace" {
+		t.Errorf("detector subsystem = %q, want workspace", det.Subsystem())
+	}
+	if det.Severity() != "P4" {
+		t.Errorf("detector severity = %q, want P4", det.Severity())
+	}
+	if det.QuickPath() {
+		t.Error("detector QuickPath() = true, want false (full tree walk)")
+	}
+	if det.OnlineRequired() {
+		t.Error("detector OnlineRequired() = true, want false")
+	}
+	if det.EstimatedCostMS() != 250 {
+		t.Errorf("detector EstimatedCostMS() = %d, want 250", det.EstimatedCostMS())
+	}
+	if det.Describe() == "" {
+		t.Error("detector Describe() is empty")
+	}
+	if fx := FixerByID(workspaceOversizeID); fx != nil {
+		t.Errorf("FixerByID(%q) = %T, want nil: fm-ws-oversize is report-only", workspaceOversizeID, fx)
+	}
+}

--- a/cli/internal/doctor/fix_workspace_size_test.go
+++ b/cli/internal/doctor/fix_workspace_size_test.go
@@ -148,6 +148,11 @@ func TestWorkspaceOversize_ThresholdEnvOverride(t *testing.T) {
 		{"unset/empty", "", 25 * mib},
 		{"valid one MiB", "1", mib},
 		{"valid large", "100", 100 * mib},
+		{"cap boundary accepted", "1048576", 1048576 * mib},
+		{"over cap falls back", "1048577", 25 * mib},
+		// The overflow class from the hardening finding: MiB counts above
+		// ~2^43 wrap the int64 byte product negative, flagging everything.
+		{"int64-overflow value falls back", "9000000000000", 25 * mib},
 		{"zero invalid", "0", 25 * mib},
 		{"negative invalid", "-5", 25 * mib},
 		{"garbage invalid", "abc", 25 * mib},

--- a/cli/internal/doctor/fix_workspace_size_test.go
+++ b/cli/internal/doctor/fix_workspace_size_test.go
@@ -77,8 +77,8 @@ func TestWorkspaceOversize_DetectDirsAndLooseFiles(t *testing.T) {
 		if f.Subsystem != "workspace" {
 			t.Errorf("findings[%d].Subsystem = %q, want workspace", i, f.Subsystem)
 		}
-		if f.Severity != "P4" {
-			t.Errorf("findings[%d].Severity = %q, want P4", i, f.Severity)
+		if f.Severity != "P3" {
+			t.Errorf("findings[%d].Severity = %q, want P3", i, f.Severity)
 		}
 		if f.Confidence != 1.0 {
 			t.Errorf("findings[%d].Confidence = %v, want 1.0", i, f.Confidence)
@@ -247,8 +247,8 @@ func TestWorkspaceOversize_Registration(t *testing.T) {
 	if det.Subsystem() != "workspace" {
 		t.Errorf("detector subsystem = %q, want workspace", det.Subsystem())
 	}
-	if det.Severity() != "P4" {
-		t.Errorf("detector severity = %q, want P4", det.Severity())
+	if det.Severity() != "P3" {
+		t.Errorf("detector severity = %q, want P3", det.Severity())
 	}
 	if det.QuickPath() {
 		t.Error("detector QuickPath() = true, want false (full tree walk)")

--- a/cli/internal/doctor/fix_workspace_stale.go
+++ b/cli/internal/doctor/fix_workspace_stale.go
@@ -18,7 +18,6 @@ package doctor
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 )
 
@@ -155,89 +154,9 @@ func (f workspaceStaleQueueDirsFixer) Fix(ctx *MutateContext, env *DetectEnv, _ 
 }
 
 // workspaceQuarantineRename moves the workspace DIRECTORY <base>/<name> to
-// dest with the full mutation-chokepoint discipline. Mutate itself cannot
-// take a directory path: its before/after hashing does os.ReadFile(path),
-// which fails with EISDIR on a directory. This helper is the directory
-// analogue of Mutate for the Rename op only — the same precedent as the
-// knowledge fixer's createDirViaRename and the workspace empty-dirs
-// quarantineEmptyDir, which bridge chokepoint gaps in-file. It reuses
-// Mutate's own primitives step for step: per-path lock, precondition checks,
-// atomic execute via executeAtomic, and an fsync'd actions.jsonl line via
-// appendAction. The source is gated by structural containment (name must be
-// a single plain path element under the fixed workspace root, matching the
-// fixer's WritesTo declaration of ".agents"); the destination (under the run
-// dir) goes through EnsureInScope, and the op through EnsureOpAllowed.
-// Hashes are the empty-content hash (directories have no byte content — the
-// same value Mutate records for an absent file). No backup copy is taken: a
-// Rename's undo path never consults backups (undoOne reverses it with
-// os.Rename, which handles directories), and the quarantined tree IS the
-// preserved copy, byte for byte.
+// dest through the shared workspace directory-rename chokepoint adapter
+// (workspaceDirRename), with the bare-path-element structural guard applied
+// by workspaceQuarantineDirByName.
 func workspaceQuarantineRename(ctx *MutateContext, base, name, dest string) error {
-	op := Rename{To: dest}
-
-	// Structural containment: name must be a single, plain path element.
-	if name != filepath.Base(name) || name == "." || name == ".." || name == "" {
-		return fmt.Errorf("doctor: invalid workspace dir name %q (refused_unsafe)", name)
-	}
-	path := filepath.Join(base, name)
-
-	// Step 1 — per-path advisory lock (skipped in dry-run, matching Mutate).
-	if !ctx.DryRun {
-		guard, err := ctx.Locks.Acquire(path)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = guard.Release() }()
-	}
-
-	// Step 2 — before-state: the source must still exist and be a directory.
-	info, err := os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("doctor: stat %s: %w", path, err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("doctor: %s is not a directory (refused_unsafe)", path)
-	}
-	emptyHash := sha256Hex(nil)
-
-	// Step 3 — preconditions: in-scope destination + executable op. (The
-	// source is gated by the structural containment check above.)
-	if err := EnsureInScope(ctx.Capabilities, ctx.RepoRoot, ctx.HomeDir, dest); err != nil {
-		return err
-	}
-	if err := EnsureOpAllowed(ctx.Capabilities, op); err != nil {
-		return err
-	}
-
-	// Step 4 — backup: intentionally none (see the function comment).
-
-	// Step 5/6 — plan + atomic execute.
-	startedNS := time.Since(ctx.start).Nanoseconds()
-	if ctx.DryRun {
-		fmt.Fprintf(os.Stderr, "[dry-run] would mutate %s: %s\n", path, DescribeOp(op))
-		return nil
-	}
-	if err := executeAtomic(path, op); err != nil {
-		return fmt.Errorf("doctor: execute %s on %s: %w", op.kind(), path, err)
-	}
-
-	// Step 7/8 — record the action line, fsync'd.
-	rel, relErr := filepath.Rel(ctx.RepoRoot, path)
-	if relErr != nil {
-		rel = path
-	}
-	return ctx.appendAction(ActionRecord{
-		Path:         rel,
-		Op:           op.kind(),
-		BeforeHash:   emptyHash,
-		AfterHash:    emptyHash,
-		BeforeMode:   fmt.Sprintf("%o", info.Mode().Perm()),
-		StartedAtNS:  startedNS,
-		FinishedAtNS: time.Since(ctx.start).Nanoseconds(),
-		RunID:        ctx.RunID,
-		FixerID:      ctx.FixerID,
-		OK:           true,
-		RenameTo:     dest,
-		Existed:      true,
-	})
+	return workspaceQuarantineDirByName(ctx, base, name, dest, nil)
 }

--- a/cli/internal/doctor/fix_workspace_stale.go
+++ b/cli/internal/doctor/fix_workspace_stale.go
@@ -203,6 +203,13 @@ var errWorkspaceStaleVerifyRefused = errors.New("no longer GC-eligible; refusing
 // is still past the TTL, and the walk was complete (WalkErrs == 0 — unknown
 // content is never GC-able). Content arriving between the fixer's scan and
 // the rename therefore refuses the move instead of being quarantined.
+//
+// TOCTOU bound: the lock is in-process advisory only, so for a writer OUTSIDE
+// this process a verify→rename window remains and cannot be eliminated here
+// (full closure would need filesystem transactions or stop-the-world, out of
+// scope by design). The consequence is bounded: content that lands in the
+// window is MOVED with the directory into quarantine, journaled, and
+// restorable via `doctor undo` — never destroyed.
 func workspaceStaleQuarantineVerify(base string) func(path string) error {
 	return func(path string) error {
 		name := filepath.Base(path)

--- a/cli/internal/doctor/fix_workspace_stale.go
+++ b/cli/internal/doctor/fix_workspace_stale.go
@@ -1,0 +1,243 @@
+package doctor
+
+// Workspace stale-queue GC: fm-ws-stale-queue-dirs (auto-fixable).
+//
+// Land-queue lanes leave debris directories at the top level of `.agents/`:
+// explicitly staled dirs (`*.stale-<timestamp>`) and retry-chain dirs
+// (`*-retry<N>`). Once their newest content is older than the workspace GC
+// TTL (workspaceGCTTL: 14d default, AO_DOCTOR_WS_TTL_DAYS override) they are
+// dead weight. The detector flags them in ONE summarizing finding; the fixer
+// quarantines each expired dir by renaming it to
+// <RunDir>/quarantine/workspace/<dirName> (never a delete).
+//
+// The detector is PURE (stat + readdir via workspaceDirInventory). The fixer
+// re-scans at fix time — it never trusts stale findings — and each move flows
+// through the mutation chokepoint discipline via workspaceQuarantineRename
+// (see that helper for why Mutate itself cannot take a directory path).
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// workspaceStaleQueueDirsID is the shared detector/fixer ID for workspace
+// stale-queue GC.
+const workspaceStaleQueueDirsID = "fm-ws-stale-queue-dirs"
+
+func init() {
+	RegisterDetector(workspaceStaleQueueDirsDetector{})
+	RegisterFixer(workspaceStaleQueueDirsFixer{})
+}
+
+// workspaceExpiredStaleDirs returns the top-level directories under base whose
+// NAME classifies as stale/retry debris (isWorkspaceStaleDirName) AND whose
+// newest content mtime is older than the GC TTL relative to now. An empty
+// matched directory (no regular files, zero NewestMTime) counts as expired:
+// there is nothing fresh in it by definition. Non-matching or young
+// directories are simply not selected. Pure: stat + readdir only.
+func workspaceExpiredStaleDirs(base string, now time.Time) ([]workspaceDirInfo, error) {
+	inv, err := workspaceDirInventory(base)
+	if err != nil {
+		return nil, err
+	}
+	cutoff := now.Add(-workspaceGCTTL())
+	var out []workspaceDirInfo
+	for _, d := range inv {
+		if !isWorkspaceStaleDirName(d.Name) {
+			continue
+		}
+		if d.NewestMTime.IsZero() || d.NewestMTime.Before(cutoff) {
+			out = append(out, d)
+		}
+	}
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Detector
+// ---------------------------------------------------------------------------
+
+// workspaceStaleQueueDirsDetector flags expired stale/retry land-queue debris
+// directories at the top level of `.agents/`.
+type workspaceStaleQueueDirsDetector struct{}
+
+func (workspaceStaleQueueDirsDetector) ID() string           { return workspaceStaleQueueDirsID }
+func (workspaceStaleQueueDirsDetector) Subsystem() string    { return subsystemWorkspace }
+func (workspaceStaleQueueDirsDetector) Severity() string     { return "P3" }
+func (workspaceStaleQueueDirsDetector) EstimatedCostMS() int { return 10 }
+func (workspaceStaleQueueDirsDetector) OnlineRequired() bool { return false }
+func (workspaceStaleQueueDirsDetector) QuickPath() bool      { return true }
+func (workspaceStaleQueueDirsDetector) Describe() string {
+	return "expired stale/retry land-queue dirs under .agents awaiting quarantine"
+}
+
+func (d workspaceStaleQueueDirsDetector) Detect(env *DetectEnv) ([]Finding, error) {
+	base := workspaceAgentsDir(env)
+	if _, err := os.Stat(base); err != nil {
+		return nil, nil
+	}
+	expired, err := workspaceExpiredStaleDirs(base, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("doctor: inventory %s: %w", base, err)
+	}
+	if len(expired) == 0 {
+		return nil, nil
+	}
+	ttlDays := int(workspaceGCTTL() / day)
+	return []Finding{{
+		ID:         d.ID(),
+		Severity:   d.Severity(),
+		Subsystem:  d.Subsystem(),
+		Title:      fmt.Sprintf("%d stale/retry workspace dir(s) past the %dd GC TTL", len(expired), ttlDays),
+		Confidence: 1.0,
+		Evidence: Evidence{
+			File:  ".agents",
+			Query: fmt.Sprintf(`find .agents -mindepth 1 -maxdepth 1 -type d \( -name '*.stale-*' -o -name '*-retry[0-9]*' \) -mtime +%d`, ttlDays),
+		},
+		Remediation: Remediation{
+			Command:          "ao doctor --fix --only " + d.ID(),
+			ExplainCommand:   "ao doctor explain " + d.ID(),
+			AutoFixable:      true,
+			EstimatedActions: len(expired),
+		},
+	}}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Fixer
+// ---------------------------------------------------------------------------
+
+// workspaceStaleQueueDirsFixer quarantines each expired stale/retry directory
+// via a chokepoint-disciplined Rename into <RunDir>/quarantine/workspace/. It
+// re-scans at fix time so a stale finding can never select a directory that
+// has since gone young, been renamed, or disappeared.
+type workspaceStaleQueueDirsFixer struct{}
+
+func (workspaceStaleQueueDirsFixer) ID() string { return workspaceStaleQueueDirsID }
+func (workspaceStaleQueueDirsFixer) Preconditions() []string {
+	return []string{
+		".agents exists and is a directory",
+		"directory name matches the stale/retry debris pattern",
+		"newest content mtime is older than the workspace GC TTL (an empty dir counts as expired)",
+	}
+}
+func (workspaceStaleQueueDirsFixer) WritesTo() []string { return []string{".agents"} }
+func (workspaceStaleQueueDirsFixer) Ops() []string      { return []string{"Rename"} }
+func (workspaceStaleQueueDirsFixer) Reversible() bool   { return true }
+func (workspaceStaleQueueDirsFixer) Idempotent() bool   { return true }
+func (workspaceStaleQueueDirsFixer) AutoFixable() bool  { return true }
+
+func (f workspaceStaleQueueDirsFixer) Fix(ctx *MutateContext, env *DetectEnv, _ []Finding) (FixResult, error) {
+	res := FixResult{FixerID: f.ID(), FindingIDs: []string{f.ID()}}
+	base := workspaceAgentsDir(env)
+	if info, err := os.Stat(base); err != nil || !info.IsDir() {
+		// Nothing to GC; the finding (if any) is stale.
+		res.Fixed = true
+		return res, nil
+	}
+	expired, err := workspaceExpiredStaleDirs(base, time.Now())
+	if err != nil {
+		res.Err = fmt.Errorf("doctor: %s: re-scan %s: %w", f.ID(), base, err)
+		return res, res.Err
+	}
+	for _, d := range expired {
+		dest := workspaceQuarantineDest(ctx, d.Name)
+		if err := workspaceQuarantineRename(ctx, base, d.Name, dest); err != nil {
+			res.Err = fmt.Errorf("doctor: %s: quarantine %s: %w", f.ID(), d.Name, err)
+			return res, res.Err
+		}
+		res.ActionsTaken++
+	}
+	res.Fixed = true
+	return res, nil
+}
+
+// workspaceQuarantineRename moves the workspace DIRECTORY <base>/<name> to
+// dest with the full mutation-chokepoint discipline. Mutate itself cannot
+// take a directory path: its before/after hashing does os.ReadFile(path),
+// which fails with EISDIR on a directory. This helper is the directory
+// analogue of Mutate for the Rename op only — the same precedent as the
+// knowledge fixer's createDirViaRename and the workspace empty-dirs
+// quarantineEmptyDir, which bridge chokepoint gaps in-file. It reuses
+// Mutate's own primitives step for step: per-path lock, precondition checks,
+// atomic execute via executeAtomic, and an fsync'd actions.jsonl line via
+// appendAction. The source is gated by structural containment (name must be
+// a single plain path element under the fixed workspace root, matching the
+// fixer's WritesTo declaration of ".agents"); the destination (under the run
+// dir) goes through EnsureInScope, and the op through EnsureOpAllowed.
+// Hashes are the empty-content hash (directories have no byte content — the
+// same value Mutate records for an absent file). No backup copy is taken: a
+// Rename's undo path never consults backups (undoOne reverses it with
+// os.Rename, which handles directories), and the quarantined tree IS the
+// preserved copy, byte for byte.
+func workspaceQuarantineRename(ctx *MutateContext, base, name, dest string) error {
+	op := Rename{To: dest}
+
+	// Structural containment: name must be a single, plain path element.
+	if name != filepath.Base(name) || name == "." || name == ".." || name == "" {
+		return fmt.Errorf("doctor: invalid workspace dir name %q (refused_unsafe)", name)
+	}
+	path := filepath.Join(base, name)
+
+	// Step 1 — per-path advisory lock (skipped in dry-run, matching Mutate).
+	if !ctx.DryRun {
+		guard, err := ctx.Locks.Acquire(path)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = guard.Release() }()
+	}
+
+	// Step 2 — before-state: the source must still exist and be a directory.
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("doctor: stat %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("doctor: %s is not a directory (refused_unsafe)", path)
+	}
+	emptyHash := sha256Hex(nil)
+
+	// Step 3 — preconditions: in-scope destination + executable op. (The
+	// source is gated by the structural containment check above.)
+	if err := EnsureInScope(ctx.Capabilities, ctx.RepoRoot, ctx.HomeDir, dest); err != nil {
+		return err
+	}
+	if err := EnsureOpAllowed(ctx.Capabilities, op); err != nil {
+		return err
+	}
+
+	// Step 4 — backup: intentionally none (see the function comment).
+
+	// Step 5/6 — plan + atomic execute.
+	startedNS := time.Since(ctx.start).Nanoseconds()
+	if ctx.DryRun {
+		fmt.Fprintf(os.Stderr, "[dry-run] would mutate %s: %s\n", path, DescribeOp(op))
+		return nil
+	}
+	if err := executeAtomic(path, op); err != nil {
+		return fmt.Errorf("doctor: execute %s on %s: %w", op.kind(), path, err)
+	}
+
+	// Step 7/8 — record the action line, fsync'd.
+	rel, relErr := filepath.Rel(ctx.RepoRoot, path)
+	if relErr != nil {
+		rel = path
+	}
+	return ctx.appendAction(ActionRecord{
+		Path:         rel,
+		Op:           op.kind(),
+		BeforeHash:   emptyHash,
+		AfterHash:    emptyHash,
+		BeforeMode:   fmt.Sprintf("%o", info.Mode().Perm()),
+		StartedAtNS:  startedNS,
+		FinishedAtNS: time.Since(ctx.start).Nanoseconds(),
+		RunID:        ctx.RunID,
+		FixerID:      ctx.FixerID,
+		OK:           true,
+		RenameTo:     dest,
+		Existed:      true,
+	})
+}

--- a/cli/internal/doctor/fix_workspace_stale.go
+++ b/cli/internal/doctor/fix_workspace_stale.go
@@ -16,8 +16,9 @@ package doctor
 // (see that helper for why Mutate itself cannot take a directory path).
 
 import (
+	"errors"
 	"fmt"
-	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -34,8 +35,11 @@ func init() {
 // NAME classifies as stale/retry debris (isWorkspaceStaleDirName) AND whose
 // newest content mtime is older than the GC TTL relative to now. An empty
 // matched directory (no regular files, zero NewestMTime) counts as expired:
-// there is nothing fresh in it by definition. Non-matching or young
-// directories are simply not selected. Pure: stat + readdir only.
+// there is nothing fresh in it by definition — but ONLY when the inventory
+// walk was complete (WalkErrs == 0). An unreadable subtree means the
+// directory's true content is unknown, and unknown content is never GC-able
+// (fail-safe). Non-matching or young directories are simply not selected.
+// Pure: stat + readdir only.
 func workspaceExpiredStaleDirs(base string, now time.Time) ([]workspaceDirInfo, error) {
 	inv, err := workspaceDirInventory(base)
 	if err != nil {
@@ -45,6 +49,11 @@ func workspaceExpiredStaleDirs(base string, now time.Time) ([]workspaceDirInfo, 
 	var out []workspaceDirInfo
 	for _, d := range inv {
 		if !isWorkspaceStaleDirName(d.Name) {
+			continue
+		}
+		if d.WalkErrs > 0 {
+			// Incomplete read: newest-mtime is a lower bound, so expiry is
+			// unprovable. Never collect what could not be fully inventoried.
 			continue
 		}
 		if d.NewestMTime.IsZero() || d.NewestMTime.Before(cutoff) {
@@ -74,7 +83,10 @@ func (workspaceStaleQueueDirsDetector) Describe() string {
 
 func (d workspaceStaleQueueDirsDetector) Detect(env *DetectEnv) ([]Finding, error) {
 	base := workspaceAgentsDir(env)
-	if _, err := os.Stat(base); err != nil {
+	// Lstat guard: a symlinked `.agents` root would make this detector (and
+	// then the fixer) operate on a tree outside the repo. Not a real dir →
+	// nothing to report.
+	if !workspaceRealDir(base) {
 		return nil, nil
 	}
 	expired, err := workspaceExpiredStaleDirs(base, time.Now())
@@ -131,7 +143,15 @@ func (workspaceStaleQueueDirsFixer) AutoFixable() bool  { return true }
 func (f workspaceStaleQueueDirsFixer) Fix(ctx *MutateContext, env *DetectEnv, _ []Finding) (FixResult, error) {
 	res := FixResult{FixerID: f.ID(), FindingIDs: []string{f.ID()}}
 	base := workspaceAgentsDir(env)
-	if info, err := os.Stat(base); err != nil || !info.IsDir() {
+	// Never mutate through a `.agents` root that is not a real directory: a
+	// symlinked root would make every quarantine rename act on a tree OUTSIDE
+	// the repo while the lexical scope check still passes.
+	exists, err := workspaceRequireRealAgentsDir(base)
+	if err != nil {
+		res.Err = fmt.Errorf("doctor: %s: %w", f.ID(), err)
+		return res, res.Err
+	}
+	if !exists {
 		// Nothing to GC; the finding (if any) is stale.
 		res.Fixed = true
 		return res, nil
@@ -142,21 +162,78 @@ func (f workspaceStaleQueueDirsFixer) Fix(ctx *MutateContext, env *DetectEnv, _ 
 		return res, res.Err
 	}
 	for _, d := range expired {
-		dest := workspaceQuarantineDest(ctx, d.Name)
-		if err := workspaceQuarantineRename(ctx, base, d.Name, dest); err != nil {
-			res.Err = fmt.Errorf("doctor: %s: quarantine %s: %w", f.ID(), d.Name, err)
+		if err := f.quarantineOne(ctx, base, d.Name, &res); err != nil {
+			res.Err = err
 			return res, res.Err
 		}
-		res.ActionsTaken++
 	}
-	res.Fixed = true
+	// A skipped dir was deliberately refused (state changed under us); the
+	// fixer is honest about not being fully done, but other dirs proceeded.
+	res.Fixed = len(res.Skipped) == 0
 	return res, nil
+}
+
+// quarantineOne quarantines a single expired stale/retry directory. A
+// verify-hook refusal (the directory's state changed between the fixer's scan
+// and the under-lock recheck) is recorded in res.Skipped and is NOT fatal —
+// remaining directories still get collected. Any other error is fatal.
+func (f workspaceStaleQueueDirsFixer) quarantineOne(ctx *MutateContext, base, name string, res *FixResult) error {
+	dest := workspaceQuarantineDest(ctx, name)
+	err := workspaceQuarantineRename(ctx, base, name, dest, workspaceStaleQuarantineVerify(base))
+	if err == nil {
+		res.ActionsTaken++
+		return nil
+	}
+	if errors.Is(err, errWorkspaceStaleVerifyRefused) {
+		res.Skipped = append(res.Skipped, fmt.Sprintf(".agents/%s: %v", name, err))
+		return nil
+	}
+	return fmt.Errorf("doctor: %s: quarantine %s: %w", f.ID(), name, err)
+}
+
+// errWorkspaceStaleVerifyRefused is the sentinel wrapped by the stale-GC
+// verify hook when a directory selected at scan time no longer qualifies at
+// rename time. Callers treat it as skipped-not-fatal.
+var errWorkspaceStaleVerifyRefused = errors.New("no longer GC-eligible; refusing to quarantine (refused_unsafe)")
+
+// workspaceStaleQuarantineVerify returns the verify hook run by
+// workspaceDirRename UNDER the per-path lock, immediately before the rename.
+// It re-checks the full GC predicate against live disk state: the name still
+// classifies as stale/retry debris, the re-inventoried newest content mtime
+// is still past the TTL, and the walk was complete (WalkErrs == 0 — unknown
+// content is never GC-able). Content arriving between the fixer's scan and
+// the rename therefore refuses the move instead of being quarantined.
+func workspaceStaleQuarantineVerify(base string) func(path string) error {
+	return func(path string) error {
+		name := filepath.Base(path)
+		if !isWorkspaceStaleDirName(name) {
+			return fmt.Errorf("doctor: %s: name %w", path, errWorkspaceStaleVerifyRefused)
+		}
+		inv, err := workspaceDirInventory(base)
+		if err != nil {
+			return fmt.Errorf("doctor: re-inventory %s: %w", base, err)
+		}
+		cutoff := time.Now().Add(-workspaceGCTTL())
+		for _, d := range inv {
+			if d.Name != name {
+				continue
+			}
+			if d.WalkErrs > 0 {
+				return fmt.Errorf("doctor: %s: content unreadable, %w", path, errWorkspaceStaleVerifyRefused)
+			}
+			if d.NewestMTime.IsZero() || d.NewestMTime.Before(cutoff) {
+				return nil // still expired — proceed
+			}
+			return fmt.Errorf("doctor: %s: gained fresh content since scan, %w", path, errWorkspaceStaleVerifyRefused)
+		}
+		return fmt.Errorf("doctor: %s: no longer present, %w", path, errWorkspaceStaleVerifyRefused)
+	}
 }
 
 // workspaceQuarantineRename moves the workspace DIRECTORY <base>/<name> to
 // dest through the shared workspace directory-rename chokepoint adapter
 // (workspaceDirRename), with the bare-path-element structural guard applied
-// by workspaceQuarantineDirByName.
-func workspaceQuarantineRename(ctx *MutateContext, base, name, dest string) error {
-	return workspaceQuarantineDirByName(ctx, base, name, dest, nil)
+// by workspaceQuarantineDirByName. verify runs under the per-path lock.
+func workspaceQuarantineRename(ctx *MutateContext, base, name, dest string, verify func(path string) error) error {
+	return workspaceQuarantineDirByName(ctx, base, name, dest, verify)
 }

--- a/cli/internal/doctor/fix_workspace_stale_test.go
+++ b/cli/internal/doctor/fix_workspace_stale_test.go
@@ -1,8 +1,10 @@
 package doctor
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -280,6 +282,102 @@ func TestWorkspaceStaleQueueDirs_UndoRestoresQuarantinedDirs(t *testing.T) {
 	st, err := os.Stat(filepath.Join(agents, retryDirEmpty))
 	if err != nil || !st.IsDir() {
 		t.Fatalf("after undo %s not restored (err=%v)", retryDirEmpty, err)
+	}
+}
+
+// TestWorkspaceStaleQueueDirs_UnreadableNotCollected: a name-matched stale
+// dir with an unreadable subtree has an UNKNOWN newest mtime — its inventory
+// is a lower bound — so it is never provably expired and never GC'd.
+func TestWorkspaceStaleQueueDirs_UnreadableNotCollected(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; permission denial is not enforceable")
+	}
+	repo := t.TempDir()
+	agents := filepath.Join(repo, ".agents")
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	locked := filepath.Join(agents, retryDirExpired, "locked")
+	writeWorkspaceFile(t, filepath.Join(locked, "hidden.txt"), "unknown freshness", old)
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	env := &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}
+	findings, err := workspaceStaleQueueDirsDetector{}.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("unreadable stale dir flagged as expired: %+v", findings)
+	}
+
+	ctx, _ := newWorkspaceStaleMutateCtx(t, repo)
+	res, err := workspaceStaleQueueDirsFixer{}.Fix(ctx, env, nil)
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if res.ActionsTaken != 0 {
+		t.Fatalf("Fix quarantined %d unreadable dir(s), want 0", res.ActionsTaken)
+	}
+	if st, err := os.Stat(filepath.Join(agents, retryDirExpired)); err != nil || !st.IsDir() {
+		t.Fatalf("unreadable stale dir gone after fix (err=%v)", err)
+	}
+}
+
+// TestWorkspaceStaleQueueDirs_VerifyRefusesFreshContent exercises the
+// under-lock verify hook directly: content arriving in the scan→rename window
+// refuses the quarantine (sentinel error, dir untouched, nothing journaled),
+// and the fixer's per-dir wrapper records that refusal as skipped-not-fatal.
+func TestWorkspaceStaleQueueDirs_VerifyRefusesFreshContent(t *testing.T) {
+	repo := t.TempDir()
+	agents := filepath.Join(repo, ".agents")
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	writeWorkspaceFile(t, filepath.Join(agents, retryDirExpired, "old.txt"), "expired", old)
+
+	// A scan at this instant would select retryDirExpired. Simulate the race:
+	// fresh content lands before the rename path runs.
+	writeWorkspaceFile(t, filepath.Join(agents, retryDirExpired, "fresh.txt"), "just arrived", time.Now())
+
+	ctx, ra := newWorkspaceStaleMutateCtx(t, repo)
+	dest := workspaceQuarantineDest(ctx, retryDirExpired)
+	err := workspaceQuarantineRename(ctx, agents, retryDirExpired, dest, workspaceStaleQuarantineVerify(agents))
+	if err == nil {
+		t.Fatal("quarantine succeeded despite fresh content under the lock")
+	}
+	if !errors.Is(err, errWorkspaceStaleVerifyRefused) {
+		t.Fatalf("error = %v, want errWorkspaceStaleVerifyRefused", err)
+	}
+	// Dir untouched, both files intact, nothing journaled.
+	for name, content := range map[string]string{"old.txt": "expired", "fresh.txt": "just arrived"} {
+		got, rerr := os.ReadFile(filepath.Join(agents, retryDirExpired, name))
+		if rerr != nil || string(got) != content {
+			t.Errorf("%s = %q err=%v, want %q", name, got, rerr, content)
+		}
+	}
+	if _, err := os.Lstat(dest); !os.IsNotExist(err) {
+		t.Errorf("quarantine dest exists after refusal (err=%v)", err)
+	}
+	recs, err := readActions(ra.ActionsPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("refused quarantine wrote %d action records, want 0", len(recs))
+	}
+
+	// Fixer-level classification: the refusal is skipped-not-fatal.
+	var res FixResult
+	if err := (workspaceStaleQueueDirsFixer{}).quarantineOne(ctx, agents, retryDirExpired, &res); err != nil {
+		t.Fatalf("quarantineOne treated a verify refusal as fatal: %v", err)
+	}
+	if res.ActionsTaken != 0 {
+		t.Errorf("ActionsTaken = %d, want 0", res.ActionsTaken)
+	}
+	if len(res.Skipped) != 1 {
+		t.Fatalf("Skipped = %v, want exactly one entry", res.Skipped)
+	}
+	if !strings.Contains(res.Skipped[0], retryDirExpired) {
+		t.Errorf("Skipped[0] = %q, want it to name %s", res.Skipped[0], retryDirExpired)
 	}
 }
 

--- a/cli/internal/doctor/fix_workspace_stale_test.go
+++ b/cli/internal/doctor/fix_workspace_stale_test.go
@@ -1,0 +1,351 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Real debris names captured from live land-queue GC backlog (2026-07-11).
+const (
+	staleDirExpired = "land-queue-age-h433.19-native.stale-20260711T221704Z"
+	retryDirExpired = "land-queue-age-h433.22-native-retry2"
+	retryDirEmpty   = "land-queue-age-h433.27-native-retry3"
+	staleDirYoung   = "land-queue-age-h433.40-native.stale-20260717T000000Z"
+	runtimeDir      = "land-queue-runtime"
+)
+
+// newWorkspaceStaleMutateCtx builds a real MutateContext rooted at repo,
+// scoped to the workspace stale-queue fixer, with a live actions.jsonl handle.
+func newWorkspaceStaleMutateCtx(t *testing.T, repo string) (*MutateContext, *RunArtifact) {
+	t.Helper()
+	ra, err := NewRunArtifact(repo, "wsstale", time.Now())
+	if err != nil {
+		t.Fatalf("NewRunArtifact: %v", err)
+	}
+	af, err := ra.OpenActionsFile()
+	if err != nil {
+		t.Fatalf("OpenActionsFile: %v", err)
+	}
+	t.Cleanup(func() { _ = af.Close() })
+	caps := NewCapabilities("2.0.0")
+	locks := NewLockManager(filepath.Join(repo, ".doctor", "locks"))
+	return NewMutateContext(ra, caps, t.TempDir(), locks, af, false).WithFixer(workspaceStaleQueueDirsID), ra
+}
+
+// workspaceStaleFixtureEnv builds an .agents tree holding the five real-name
+// fixture dirs: two expired matched dirs with content, one empty matched dir,
+// one young matched dir, and one old non-matching dir. mtimes are controlled
+// with os.Chtimes relative to the real clock (the detector uses time.Now).
+func workspaceStaleFixtureEnv(t *testing.T) (*DetectEnv, string) {
+	t.Helper()
+	repo := t.TempDir()
+	agents := filepath.Join(repo, ".agents")
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	young := time.Now().Add(-1 * time.Hour)
+
+	writeWorkspaceFile(t, filepath.Join(agents, staleDirExpired, "verdict.json"), "expired-stale", old)
+	writeWorkspaceFile(t, filepath.Join(agents, retryDirExpired, "nested", "log.txt"), "expired-retry", old)
+	if err := os.MkdirAll(filepath.Join(agents, retryDirEmpty), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeWorkspaceFile(t, filepath.Join(agents, staleDirYoung, "fresh.json"), "young", young)
+	writeWorkspaceFile(t, filepath.Join(agents, runtimeDir, "state.json"), "runtime", old)
+
+	return &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}, repo
+}
+
+func TestWorkspaceStaleQueueDirs_DetectFinding(t *testing.T) {
+	env, _ := workspaceStaleFixtureEnv(t)
+
+	det := workspaceStaleQueueDirsDetector{}
+	findings, err := det.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("findings = %d, want 1 summarizing finding", len(findings))
+	}
+	f := findings[0]
+	if f.ID != "fm-ws-stale-queue-dirs" {
+		t.Errorf("finding ID = %q, want fm-ws-stale-queue-dirs", f.ID)
+	}
+	if f.Subsystem != "workspace" {
+		t.Errorf("subsystem = %q, want workspace", f.Subsystem)
+	}
+	if f.Severity != "P3" {
+		t.Errorf("severity = %q, want P3", f.Severity)
+	}
+	if f.Confidence != 1.0 {
+		t.Errorf("confidence = %v, want 1.0", f.Confidence)
+	}
+	if !f.Remediation.AutoFixable {
+		t.Error("finding must be auto-fixable")
+	}
+	// Expired matched set = explicit-stale + retry-chain + empty matched dir.
+	if f.Remediation.EstimatedActions != 3 {
+		t.Errorf("EstimatedActions = %d, want 3", f.Remediation.EstimatedActions)
+	}
+	if want := "ao doctor --fix --only fm-ws-stale-queue-dirs"; f.Remediation.Command != want {
+		t.Errorf("remediation command = %q, want %q", f.Remediation.Command, want)
+	}
+	if f.Evidence.Query == "" {
+		t.Error("evidence query one-liner is empty")
+	}
+}
+
+// TestWorkspaceStaleQueueDirs_DetectSelection is the table-driven single-dir
+// selection matrix: name match x age decides the flag.
+func TestWorkspaceStaleQueueDirs_DetectSelection(t *testing.T) {
+	tests := []struct {
+		name     string
+		dirName  string
+		empty    bool
+		mtimeAge time.Duration
+		want     int // findings
+	}{
+		{"matched and expired", staleDirExpired, false, 30 * 24 * time.Hour, 1},
+		{"matched retry and expired", retryDirExpired, false, 15 * 24 * time.Hour, 1},
+		{"matched but empty counts as expired", retryDirEmpty, true, 0, 1},
+		{"matched but young", staleDirYoung, false, time.Hour, 0},
+		{"non-matching even when old", runtimeDir, false, 90 * 24 * time.Hour, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := t.TempDir()
+			dir := filepath.Join(repo, ".agents", tt.dirName)
+			if tt.empty {
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				writeWorkspaceFile(t, filepath.Join(dir, "f.txt"), "x", time.Now().Add(-tt.mtimeAge))
+			}
+			env := &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}
+			findings, err := workspaceStaleQueueDirsDetector{}.Detect(env)
+			if err != nil {
+				t.Fatalf("Detect: %v", err)
+			}
+			if len(findings) != tt.want {
+				t.Fatalf("findings = %d, want %d", len(findings), tt.want)
+			}
+			if tt.want == 1 && findings[0].Remediation.EstimatedActions != 1 {
+				t.Errorf("EstimatedActions = %d, want 1", findings[0].Remediation.EstimatedActions)
+			}
+		})
+	}
+}
+
+func TestWorkspaceStaleQueueDirs_DetectNoAgentsDir(t *testing.T) {
+	repo := t.TempDir()
+	env := &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}
+	findings, err := workspaceStaleQueueDirsDetector{}.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("missing .agents produced %d findings, want 0", len(findings))
+	}
+}
+
+func TestWorkspaceStaleQueueDirs_TTLOverride(t *testing.T) {
+	t.Setenv(workspaceTTLEnvVar, "1")
+	repo := t.TempDir()
+	// 2 days old: expired under the 1-day override, young under the 14d default.
+	writeWorkspaceFile(t, filepath.Join(repo, ".agents", retryDirExpired, "f.txt"), "x", time.Now().Add(-48*time.Hour))
+	env := &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}
+	findings, err := workspaceStaleQueueDirsDetector{}.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("findings = %d, want 1 under AO_DOCTOR_WS_TTL_DAYS=1", len(findings))
+	}
+}
+
+func TestWorkspaceStaleQueueDirs_FixQuarantinesExpiredOnly(t *testing.T) {
+	env, repo := workspaceStaleFixtureEnv(t)
+	agents := filepath.Join(repo, ".agents")
+
+	det := workspaceStaleQueueDirsDetector{}
+	findings, err := det.Detect(env)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+
+	ctx, ra := newWorkspaceStaleMutateCtx(t, repo)
+	res, err := workspaceStaleQueueDirsFixer{}.Fix(ctx, env, findings)
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if !res.Fixed {
+		t.Fatal("Fix did not report Fixed")
+	}
+	if res.ActionsTaken != 3 {
+		t.Fatalf("ActionsTaken = %d, want 3", res.ActionsTaken)
+	}
+	if len(res.Skipped) != 0 {
+		t.Fatalf("Skipped = %v, want none", res.Skipped)
+	}
+
+	// Expired matched set gone from .agents/, present under quarantine/workspace/.
+	quarantine := filepath.Join(ra.QuarantineDir(), "workspace")
+	for _, name := range []string{staleDirExpired, retryDirExpired, retryDirEmpty} {
+		if _, err := os.Stat(filepath.Join(agents, name)); !os.IsNotExist(err) {
+			t.Errorf("%s still present in .agents (err=%v)", name, err)
+		}
+		st, err := os.Stat(filepath.Join(quarantine, name))
+		if err != nil || !st.IsDir() {
+			t.Errorf("%s not quarantined as a directory (err=%v)", name, err)
+		}
+	}
+	// Quarantined content survived byte-for-byte.
+	got, err := os.ReadFile(filepath.Join(quarantine, staleDirExpired, "verdict.json"))
+	if err != nil || string(got) != "expired-stale" {
+		t.Errorf("quarantined verdict.json = %q err=%v, want %q", got, err, "expired-stale")
+	}
+	got, err = os.ReadFile(filepath.Join(quarantine, retryDirExpired, "nested", "log.txt"))
+	if err != nil || string(got) != "expired-retry" {
+		t.Errorf("quarantined nested log.txt = %q err=%v, want %q", got, err, "expired-retry")
+	}
+
+	// Young matched dir and non-matching dir untouched.
+	for name, content := range map[string]string{
+		filepath.Join(staleDirYoung, "fresh.json"): "young",
+		filepath.Join(runtimeDir, "state.json"):    "runtime",
+	} {
+		got, err := os.ReadFile(filepath.Join(agents, name))
+		if err != nil || string(got) != content {
+			t.Errorf("untouched file %s = %q err=%v, want %q", name, got, err, content)
+		}
+	}
+
+	// actions.jsonl: exactly three OK Rename records into quarantine/workspace/.
+	recs, err := readActions(ra.ActionsPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 3 {
+		t.Fatalf("action records = %d, want 3", len(recs))
+	}
+	for _, r := range recs {
+		if r.Op != "Rename" || !r.OK || r.RenameTo == "" {
+			t.Errorf("bad rename record: %+v", r)
+		}
+	}
+
+	// Idempotency: second detect is clean, second fix takes zero actions.
+	again, err := det.Detect(env)
+	if err != nil {
+		t.Fatalf("post-fix Detect: %v", err)
+	}
+	if len(again) != 0 {
+		t.Fatalf("post-fix detect found %d findings, want 0", len(again))
+	}
+	res2, err := workspaceStaleQueueDirsFixer{}.Fix(ctx, env, nil)
+	if err != nil {
+		t.Fatalf("second Fix: %v", err)
+	}
+	if !res2.Fixed || res2.ActionsTaken != 0 {
+		t.Fatalf("second Fix: fixed=%t actions=%d, want fixed with 0 actions", res2.Fixed, res2.ActionsTaken)
+	}
+}
+
+func TestWorkspaceStaleQueueDirs_UndoRestoresQuarantinedDirs(t *testing.T) {
+	env, repo := workspaceStaleFixtureEnv(t)
+	agents := filepath.Join(repo, ".agents")
+
+	ctx, ra := newWorkspaceStaleMutateCtx(t, repo)
+	res, err := workspaceStaleQueueDirsFixer{}.Fix(ctx, env, nil)
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if res.ActionsTaken != 3 {
+		t.Fatalf("ActionsTaken = %d, want 3", res.ActionsTaken)
+	}
+
+	ur, err := Undo(repo, ra.RunID, true, false)
+	if err != nil {
+		t.Fatalf("Undo: %v", err)
+	}
+	if ur.Restored != 3 {
+		t.Fatalf("Undo restored = %d, want 3", ur.Restored)
+	}
+	// Directories and content are back in .agents.
+	got, err := os.ReadFile(filepath.Join(agents, staleDirExpired, "verdict.json"))
+	if err != nil || string(got) != "expired-stale" {
+		t.Fatalf("after undo verdict.json = %q err=%v, want %q", got, err, "expired-stale")
+	}
+	st, err := os.Stat(filepath.Join(agents, retryDirEmpty))
+	if err != nil || !st.IsDir() {
+		t.Fatalf("after undo %s not restored (err=%v)", retryDirEmpty, err)
+	}
+}
+
+func TestWorkspaceStaleQueueDirs_FixNoAgentsDir(t *testing.T) {
+	repo := t.TempDir()
+	env := &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}
+	ctx, ra := newWorkspaceStaleMutateCtx(t, repo)
+	res, err := workspaceStaleQueueDirsFixer{}.Fix(ctx, env, nil)
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if !res.Fixed || res.ActionsTaken != 0 {
+		t.Fatalf("Fix on missing .agents: fixed=%t actions=%d, want fixed with 0 actions", res.Fixed, res.ActionsTaken)
+	}
+	recs, err := readActions(ra.ActionsPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("wrote %d action records on missing .agents, want 0", len(recs))
+	}
+}
+
+func TestWorkspaceStaleQueueDirs_Registration(t *testing.T) {
+	var det Detector
+	for _, d := range Detectors() {
+		if d.ID() == workspaceStaleQueueDirsID {
+			det = d
+		}
+	}
+	if det == nil {
+		t.Fatalf("detector %q not registered", workspaceStaleQueueDirsID)
+	}
+	if det.Subsystem() != "workspace" {
+		t.Errorf("detector subsystem = %q, want workspace", det.Subsystem())
+	}
+	if det.Severity() != "P3" {
+		t.Errorf("detector severity = %q, want P3", det.Severity())
+	}
+	if !det.QuickPath() {
+		t.Error("detector QuickPath() = false, want true")
+	}
+	if det.OnlineRequired() {
+		t.Error("detector OnlineRequired() = true, want false")
+	}
+
+	fx := FixerByID(workspaceStaleQueueDirsID)
+	if fx == nil {
+		t.Fatalf("fixer %q not registered", workspaceStaleQueueDirsID)
+	}
+	if !fx.AutoFixable() {
+		t.Error("fixer AutoFixable() = false, want true")
+	}
+	if !fx.Reversible() {
+		t.Error("fixer Reversible() = false, want true")
+	}
+	if !fx.Idempotent() {
+		t.Error("fixer Idempotent() = false, want true")
+	}
+	if ops := fx.Ops(); len(ops) != 1 || ops[0] != "Rename" {
+		t.Errorf("fixer Ops() = %v, want [Rename]", ops)
+	}
+	if wt := fx.WritesTo(); len(wt) != 1 || wt[0] != ".agents" {
+		t.Errorf("fixer WritesTo() = %v, want [.agents]", wt)
+	}
+	if len(fx.Preconditions()) == 0 {
+		t.Error("fixer Preconditions() is empty")
+	}
+}

--- a/cli/internal/doctor/fix_workspace_test.go
+++ b/cli/internal/doctor/fix_workspace_test.go
@@ -1,0 +1,232 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeWorkspaceFile creates a file with the given content and mtime,
+// creating parent directories as needed.
+func writeWorkspaceFile(t *testing.T, path, content string, mtime time.Time) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+}
+
+func TestWorkspaceAgentsDir(t *testing.T) {
+	env := &DetectEnv{RepoRoot: "/repo/root", CWD: "/somewhere/else"}
+	got := workspaceAgentsDir(env)
+	want := filepath.Join("/repo/root", ".agents")
+	if got != want {
+		t.Errorf("workspaceAgentsDir = %q, want %q", got, want)
+	}
+}
+
+func TestWorkspaceDirInventory(t *testing.T) {
+	base := t.TempDir()
+	outside := t.TempDir()
+
+	t1 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 7, 5, 12, 30, 0, 0, time.UTC)
+	t3 := time.Date(2026, 7, 3, 8, 0, 0, 0, time.UTC)
+
+	// alpha: two regular files (one nested), plus a symlink to a decoy file
+	// that must contribute nothing.
+	writeWorkspaceFile(t, filepath.Join(base, "alpha", "a.txt"), "aaaaa", t1) // 5 bytes
+	writeWorkspaceFile(t, filepath.Join(base, "alpha", "sub", "b.txt"), "bbb", t2)
+	// Decoy: much larger and much newer than anything in the fixture. If any
+	// symlink were followed, FileCount/ByteSize/NewestMTime would all drift.
+	decoy := filepath.Join(outside, "decoy.bin")
+	writeWorkspaceFile(t, decoy, "0123456789012345678901234567890123456789", time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err := os.Symlink(decoy, filepath.Join(base, "alpha", "link-file")); err != nil {
+		t.Fatalf("symlink file: %v", err)
+	}
+
+	// beta: empty directory.
+	if err := os.MkdirAll(filepath.Join(base, "beta"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// gamma: one file.
+	writeWorkspaceFile(t, filepath.Join(base, "gamma", "g.bin"), "ggggggg", t3) // 7 bytes
+
+	// Top-level symlink to a directory: must not be inventoried.
+	if err := os.Symlink(filepath.Join(base, "alpha"), filepath.Join(base, "link-dir")); err != nil {
+		t.Fatalf("symlink dir: %v", err)
+	}
+	// Top-level regular file: not a directory, skipped.
+	writeWorkspaceFile(t, filepath.Join(base, "plain.txt"), "x", t1)
+
+	got, err := workspaceDirInventory(base)
+	if err != nil {
+		t.Fatalf("workspaceDirInventory: %v", err)
+	}
+	want := []workspaceDirInfo{
+		{Name: "alpha", FileCount: 2, ByteSize: 8, NewestMTime: t2},
+		{Name: "beta", FileCount: 0, ByteSize: 0, NewestMTime: time.Time{}},
+		{Name: "gamma", FileCount: 1, ByteSize: 7, NewestMTime: t3},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("inventory length = %d, want %d (%+v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Name != want[i].Name {
+			t.Errorf("entry %d Name = %q, want %q", i, got[i].Name, want[i].Name)
+		}
+		if got[i].FileCount != want[i].FileCount {
+			t.Errorf("%s FileCount = %d, want %d", want[i].Name, got[i].FileCount, want[i].FileCount)
+		}
+		if got[i].ByteSize != want[i].ByteSize {
+			t.Errorf("%s ByteSize = %d, want %d", want[i].Name, got[i].ByteSize, want[i].ByteSize)
+		}
+		if !got[i].NewestMTime.Equal(want[i].NewestMTime) {
+			t.Errorf("%s NewestMTime = %v, want %v", want[i].Name, got[i].NewestMTime, want[i].NewestMTime)
+		}
+	}
+}
+
+func TestWorkspaceDirInventory_PermissionErrorSkipped(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; permission denial is not enforceable")
+	}
+	base := t.TempDir()
+	t1 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	writeWorkspaceFile(t, filepath.Join(base, "alpha", "a.txt"), "aa", t1) // 2 bytes
+	writeWorkspaceFile(t, filepath.Join(base, "alpha", "locked", "hidden.txt"), "hhhh", t1.Add(time.Hour))
+	locked := filepath.Join(base, "alpha", "locked")
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	got, err := workspaceDirInventory(base)
+	if err != nil {
+		t.Fatalf("workspaceDirInventory: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("inventory length = %d, want 1 (%+v)", len(got), got)
+	}
+	// The unreadable subtree is skipped: only a.txt is counted.
+	if got[0].FileCount != 1 {
+		t.Errorf("FileCount = %d, want 1", got[0].FileCount)
+	}
+	if got[0].ByteSize != 2 {
+		t.Errorf("ByteSize = %d, want 2", got[0].ByteSize)
+	}
+	if !got[0].NewestMTime.Equal(t1) {
+		t.Errorf("NewestMTime = %v, want %v", got[0].NewestMTime, t1)
+	}
+}
+
+func TestWorkspaceDirInventory_MissingBase(t *testing.T) {
+	_, err := workspaceDirInventory(filepath.Join(t.TempDir(), "does-not-exist"))
+	if !os.IsNotExist(err) {
+		t.Errorf("err = %v, want os.IsNotExist", err)
+	}
+}
+
+func TestWorkspaceCanonicalAliases(t *testing.T) {
+	tests := []struct {
+		alias, canonical string
+	}{
+		{"post-mortem", "postmortem"},
+		{"post-mortems", "postmortem"},
+		{"pre-mortem", "pre-mortem-checks"},
+		{"pre-mortems", "pre-mortem-checks"},
+		{"handoffs", "handoff"},
+		{"mto-handoff", "handoff"},
+		{"retros", "retro"},
+		{"proof", "proofs"},
+		{"test", "tests"},
+	}
+	if len(workspaceCanonicalAliases) != len(tests) {
+		t.Errorf("registry has %d entries, want %d", len(workspaceCanonicalAliases), len(tests))
+	}
+	for _, tt := range tests {
+		got, ok := workspaceCanonicalAliases[tt.alias]
+		if !ok {
+			t.Errorf("alias %q missing from registry", tt.alias)
+			continue
+		}
+		if got != tt.canonical {
+			t.Errorf("alias %q -> %q, want %q", tt.alias, got, tt.canonical)
+		}
+	}
+}
+
+func TestWorkspaceStaleNameMatching(t *testing.T) {
+	tests := []struct {
+		name          string
+		explicitStale bool
+		retryChain    bool
+	}{
+		// Real names that MUST match.
+		{"land-queue-age-h433.19-native.stale-20260711T221704Z", true, false},
+		{"land-queue-age-h433.19.stale-20260711T221032Z", true, false},
+		{"land-queue-age-h433.22-native-retry2", false, true},
+		{"land-queue-age-h433.27-native-retry2", false, true},
+		// A staled retry-chain dir is both.
+		{"land-queue-age-h433.22-native-retry2.stale-20260711T221704Z", true, true},
+		// Names that must NOT match.
+		{"land-queue", false, false},
+		{"land-queue-runtime", false, false},
+		{"archive", false, false},
+		{"knowledge", false, false},
+		{"retro", false, false},
+	}
+	for _, tt := range tests {
+		explicitStale, retryChain := workspaceStaleNameKind(tt.name)
+		if explicitStale != tt.explicitStale {
+			t.Errorf("workspaceStaleNameKind(%q) explicitStale = %v, want %v", tt.name, explicitStale, tt.explicitStale)
+		}
+		if retryChain != tt.retryChain {
+			t.Errorf("workspaceStaleNameKind(%q) retryChain = %v, want %v", tt.name, retryChain, tt.retryChain)
+		}
+		wantStale := tt.explicitStale || tt.retryChain
+		if got := isWorkspaceStaleDirName(tt.name); got != wantStale {
+			t.Errorf("isWorkspaceStaleDirName(%q) = %v, want %v", tt.name, got, wantStale)
+		}
+	}
+}
+
+func TestWorkspaceQuarantineDest(t *testing.T) {
+	ctx := &MutateContext{RunDir: filepath.Join("/repo", ".doctor", "runs", "r1")}
+	got := workspaceQuarantineDest(ctx, "land-queue-age-h433.22-native-retry2")
+	want := filepath.Join("/repo", ".doctor", "runs", "r1", "quarantine", "workspace", "land-queue-age-h433.22-native-retry2")
+	if got != want {
+		t.Errorf("workspaceQuarantineDest = %q, want %q", got, want)
+	}
+}
+
+func TestWorkspaceGCTTL(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{"default when unset", "", 14 * 24 * time.Hour},
+		{"override 7 days", "7", 7 * 24 * time.Hour},
+		{"override 1 day", "1", 24 * time.Hour},
+		{"zero falls back", "0", 14 * 24 * time.Hour},
+		{"negative falls back", "-3", 14 * 24 * time.Hour},
+		{"non-numeric falls back", "abc", 14 * 24 * time.Hour},
+		{"float falls back", "2.5", 14 * 24 * time.Hour},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(workspaceTTLEnvVar, tt.value)
+			if got := workspaceGCTTL(); got != tt.want {
+				t.Errorf("workspaceGCTTL() with %q = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/internal/doctor/fix_workspace_test.go
+++ b/cli/internal/doctor/fix_workspace_test.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -71,7 +72,8 @@ func TestWorkspaceDirInventory(t *testing.T) {
 		t.Fatalf("workspaceDirInventory: %v", err)
 	}
 	want := []workspaceDirInfo{
-		{Name: "alpha", FileCount: 2, ByteSize: 8, NewestMTime: t2},
+		// alpha's symlink entry is counted as an OtherEntry, never followed.
+		{Name: "alpha", FileCount: 2, ByteSize: 8, NewestMTime: t2, OtherEntries: 1},
 		{Name: "beta", FileCount: 0, ByteSize: 0, NewestMTime: time.Time{}},
 		{Name: "gamma", FileCount: 1, ByteSize: 7, NewestMTime: t3},
 	}
@@ -90,6 +92,12 @@ func TestWorkspaceDirInventory(t *testing.T) {
 		}
 		if !got[i].NewestMTime.Equal(want[i].NewestMTime) {
 			t.Errorf("%s NewestMTime = %v, want %v", want[i].Name, got[i].NewestMTime, want[i].NewestMTime)
+		}
+		if got[i].OtherEntries != want[i].OtherEntries {
+			t.Errorf("%s OtherEntries = %d, want %d", want[i].Name, got[i].OtherEntries, want[i].OtherEntries)
+		}
+		if got[i].WalkErrs != 0 {
+			t.Errorf("%s WalkErrs = %d, want 0", want[i].Name, got[i].WalkErrs)
 		}
 	}
 }
@@ -124,6 +132,11 @@ func TestWorkspaceDirInventory_PermissionErrorSkipped(t *testing.T) {
 	}
 	if !got[0].NewestMTime.Equal(t1) {
 		t.Errorf("NewestMTime = %v, want %v", got[0].NewestMTime, t1)
+	}
+	// The skip is TALLIED: unreadable content means the inventory is a lower
+	// bound, and consumers must be able to tell "empty" from "could not read".
+	if got[0].WalkErrs == 0 {
+		t.Error("WalkErrs = 0, want > 0 for an unreadable subtree")
 	}
 }
 
@@ -204,6 +217,184 @@ func TestWorkspaceQuarantineDest(t *testing.T) {
 	want := filepath.Join("/repo", ".doctor", "runs", "r1", "quarantine", "workspace", "land-queue-age-h433.22-native-retry2")
 	if got != want {
 		t.Errorf("workspaceQuarantineDest = %q, want %q", got, want)
+	}
+}
+
+func TestWorkspaceRealDir(t *testing.T) {
+	base := t.TempDir()
+	realDir := filepath.Join(base, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	regFile := filepath.Join(base, "file.txt")
+	writeWorkspaceFile(t, regFile, "x", time.Now())
+	linkToDir := filepath.Join(base, "link-dir")
+	if err := os.Symlink(realDir, linkToDir); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"real directory", realDir, true},
+		{"regular file", regFile, false},
+		{"symlink to a directory", linkToDir, false},
+		{"absent", filepath.Join(base, "nope"), false},
+	}
+	for _, tt := range tests {
+		if got := workspaceRealDir(tt.path); got != tt.want {
+			t.Errorf("workspaceRealDir(%s) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+
+	// Fixer-side counterpart: absent is a clean no-op, symlink/file refuse.
+	if exists, err := workspaceRequireRealAgentsDir(realDir); err != nil || !exists {
+		t.Errorf("workspaceRequireRealAgentsDir(real dir) = %v, %v, want true, nil", exists, err)
+	}
+	if exists, err := workspaceRequireRealAgentsDir(filepath.Join(base, "nope")); err != nil || exists {
+		t.Errorf("workspaceRequireRealAgentsDir(absent) = %v, %v, want false, nil", exists, err)
+	}
+	for _, path := range []string{regFile, linkToDir} {
+		exists, err := workspaceRequireRealAgentsDir(path)
+		if err == nil || exists {
+			t.Errorf("workspaceRequireRealAgentsDir(%s) = %v, %v, want refused_unsafe error", path, exists, err)
+			continue
+		}
+		if !strings.Contains(err.Error(), "refused_unsafe") {
+			t.Errorf("workspaceRequireRealAgentsDir(%s) error = %v, want it to mention refused_unsafe", path, err)
+		}
+	}
+}
+
+// TestWorkspaceSymlinkedAgentsRoot is the F-mode fixture for a `.agents` root
+// that is a SYMLINK to a directory outside the repository: every workspace
+// detector that consumes the root must report nothing, every workspace fixer
+// must refuse with refused_unsafe, and the external tree must remain
+// byte-for-byte untouched (the lexical scope check alone would have passed).
+func TestWorkspaceSymlinkedAgentsRoot(t *testing.T) {
+	repo := t.TempDir()
+	external := t.TempDir()
+	old := time.Now().Add(-30 * 24 * time.Hour)
+
+	// The external tree carries one would-be finding for each failure mode.
+	writeWorkspaceFile(t, filepath.Join(external, "post-mortems", "a.md"), "drift bait", old)
+	if err := os.MkdirAll(filepath.Join(external, "stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeWorkspaceFile(t, filepath.Join(external, "land-queue-x.stale-20260601T000000Z", "v.json"), "stale bait", old)
+	writeWorkspaceFile(t, filepath.Join(external, "learnings", "l.md"), "legacy", old)
+	writeWorkspaceFile(t, filepath.Join(external, "ao", "learnings", "c.md"), "canonical", old)
+
+	if err := os.Symlink(external, filepath.Join(repo, ".agents")); err != nil {
+		t.Fatalf("symlink .agents: %v", err)
+	}
+	env := &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: t.TempDir(), Logger: os.Stderr}
+
+	// Every root-consuming detector: zero findings.
+	detectors := map[string]Detector{
+		"drift":     workspaceNamingDriftDetector{},
+		"empty":     workspaceEmptyDirsDetector{},
+		"stale":     workspaceStaleQueueDirsDetector{},
+		"oversize":  workspaceOversizeDetector{},
+		"dualstore": workspaceDualStoreDetector{},
+	}
+	for name, d := range detectors {
+		findings, err := d.Detect(env)
+		if err != nil {
+			t.Errorf("%s Detect on symlinked root: %v", name, err)
+		}
+		if len(findings) != 0 {
+			t.Errorf("%s Detect on symlinked root = %d findings, want 0", name, len(findings))
+		}
+	}
+
+	// Every workspace fixer: refuse, mutate nothing.
+	ctx, ra := newWorkspaceStaleMutateCtx(t, repo)
+	fixers := map[string]Fixer{
+		"drift": workspaceNamingDriftFixer{},
+		"empty": workspaceEmptyDirsFixer{},
+		"stale": workspaceStaleQueueDirsFixer{},
+	}
+	for name, f := range fixers {
+		res, err := f.Fix(ctx, env, nil)
+		if err == nil || res.Err == nil {
+			t.Errorf("%s Fix on symlinked root: err=%v res.Err=%v, want refused_unsafe", name, err, res.Err)
+			continue
+		}
+		if !strings.Contains(err.Error(), "refused_unsafe") {
+			t.Errorf("%s Fix error = %v, want it to mention refused_unsafe", name, err)
+		}
+		if res.ActionsTaken != 0 {
+			t.Errorf("%s Fix took %d actions through a symlinked root", name, res.ActionsTaken)
+		}
+	}
+	recs, err := readActions(ra.ActionsPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("action records = %d, want 0", len(recs))
+	}
+
+	// The external tree is untouched.
+	for path, content := range map[string]string{
+		filepath.Join(external, "post-mortems", "a.md"):                          "drift bait",
+		filepath.Join(external, "land-queue-x.stale-20260601T000000Z", "v.json"): "stale bait",
+		filepath.Join(external, "learnings", "l.md"):                             "legacy",
+		filepath.Join(external, "ao", "learnings", "c.md"):                       "canonical",
+	} {
+		got, err := os.ReadFile(path)
+		if err != nil || string(got) != content {
+			t.Errorf("external file %s = %q err=%v, want %q untouched", path, got, err, content)
+		}
+	}
+	if st, err := os.Stat(filepath.Join(external, "stub")); err != nil || !st.IsDir() {
+		t.Errorf("external stub dir missing after fix attempts (err=%v)", err)
+	}
+}
+
+// TestWorkspaceDirRename_JournalFailureCompensates forces the fsync'd
+// actions.jsonl append to fail AFTER the rename executed: the helper must
+// rename the directory back to its original path (so disk state matches the
+// empty journal and undo is never blind) and report both facts in the error.
+func TestWorkspaceDirRename_JournalFailureCompensates(t *testing.T) {
+	repo := t.TempDir()
+	dir := filepath.Join(repo, ".agents", "doomed")
+	writeWorkspaceFile(t, filepath.Join(dir, "keep.md"), "payload", time.Now())
+
+	ra, err := NewRunArtifact(repo, "wsjournalfail", time.Now())
+	if err != nil {
+		t.Fatalf("NewRunArtifact: %v", err)
+	}
+	af, err := ra.OpenActionsFile()
+	if err != nil {
+		t.Fatalf("OpenActionsFile: %v", err)
+	}
+	// Close the handle NOW: the rename will succeed, the journal append will fail.
+	if err := af.Close(); err != nil {
+		t.Fatalf("close actions file: %v", err)
+	}
+	caps := NewCapabilities("test")
+	locks := NewLockManager(filepath.Join(repo, ".doctor", "locks"))
+	ctx := NewMutateContext(ra, caps, t.TempDir(), locks, af, false).WithFixer("test-journal-fail")
+
+	dest := workspaceQuarantineDest(ctx, "doomed")
+	renameErr := workspaceDirRename(ctx, dir, dest, nil)
+	if renameErr == nil {
+		t.Fatal("workspaceDirRename succeeded despite a dead actions.jsonl handle")
+	}
+	if !strings.Contains(renameErr.Error(), "compensated") {
+		t.Errorf("error = %v, want it to report the compensating rename-back", renameErr)
+	}
+	// The directory is back at its original path, content intact; dest gone.
+	got, err := os.ReadFile(filepath.Join(dir, "keep.md"))
+	if err != nil || string(got) != "payload" {
+		t.Fatalf("dir not restored at original path: content=%q err=%v", got, err)
+	}
+	if _, err := os.Lstat(dest); !os.IsNotExist(err) {
+		t.Errorf("quarantine dest still present after compensation (err=%v)", err)
 	}
 }
 

--- a/cli/internal/doctor/fix_workspace_test.go
+++ b/cli/internal/doctor/fix_workspace_test.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -355,10 +356,11 @@ func TestWorkspaceSymlinkedAgentsRoot(t *testing.T) {
 	}
 }
 
-// TestWorkspaceDirRename_JournalFailureCompensates forces the fsync'd
-// actions.jsonl append to fail AFTER the rename executed: the helper must
-// rename the directory back to its original path (so disk state matches the
-// empty journal and undo is never blind) and report both facts in the error.
+// TestWorkspaceDirRename_JournalFailureCompensates forces the actions.jsonl
+// append to fail at the WRITE stage (dead handle) AFTER the rename executed:
+// the record definitely never persisted, so the helper must rename the
+// directory back to its original path (disk state matches the empty journal;
+// undo is never blind) and report both facts in the error.
 func TestWorkspaceDirRename_JournalFailureCompensates(t *testing.T) {
 	repo := t.TempDir()
 	dir := filepath.Join(repo, ".agents", "doomed")
@@ -398,6 +400,161 @@ func TestWorkspaceDirRename_JournalFailureCompensates(t *testing.T) {
 	}
 }
 
+// TestWorkspaceDirRename_SyncFailureLeavesRenameInPlace: when the journal
+// WRITE succeeds and only the fsync fails, the record has probably been
+// persisted — a compensating rename-back would desync disk from the journal
+// (undo would replay an unnecessary reverse rename). The helper must leave
+// the rename in place and surface the durability uncertainty. The sync stage
+// is simulated through the workspaceAppendAction seam because forcing a real
+// fsync failure after a successful write is not portable.
+func TestWorkspaceDirRename_SyncFailureLeavesRenameInPlace(t *testing.T) {
+	repo := t.TempDir()
+	dir := filepath.Join(repo, ".agents", "doomed")
+	writeWorkspaceFile(t, filepath.Join(dir, "keep.md"), "payload", time.Now())
+
+	ra, err := NewRunArtifact(repo, "wssyncfail", time.Now())
+	if err != nil {
+		t.Fatalf("NewRunArtifact: %v", err)
+	}
+	af, err := ra.OpenActionsFile()
+	if err != nil {
+		t.Fatalf("OpenActionsFile: %v", err)
+	}
+	t.Cleanup(func() { _ = af.Close() })
+	caps := NewCapabilities("test")
+	locks := NewLockManager(filepath.Join(repo, ".doctor", "locks"))
+	ctx := NewMutateContext(ra, caps, t.TempDir(), locks, af, false).WithFixer("test-sync-fail")
+
+	// Seam override: write landed, fsync failed. Restored via t.Cleanup so no
+	// state leaks into shuffled test orders.
+	orig := workspaceAppendAction
+	t.Cleanup(func() { workspaceAppendAction = orig })
+	workspaceAppendAction = func(ctx *MutateContext, rec ActionRecord) (bool, error) {
+		if wrote, werr := orig(ctx, rec); werr != nil {
+			return wrote, werr // real write failure would be a test-setup bug
+		}
+		return true, fmt.Errorf("simulated fsync failure")
+	}
+
+	dest := workspaceQuarantineDest(ctx, "doomed")
+	renameErr := workspaceDirRename(ctx, dir, dest, nil)
+	if renameErr == nil {
+		t.Fatal("workspaceDirRename succeeded despite a failing journal sync")
+	}
+	if !strings.Contains(renameErr.Error(), "left in place") {
+		t.Errorf("error = %v, want it to report the rename left in place", renameErr)
+	}
+	if strings.Contains(renameErr.Error(), "compensated") {
+		t.Errorf("error = %v, must NOT report a compensating rename-back", renameErr)
+	}
+	// The rename stays applied: dest holds the content, the source is gone —
+	// consistent with the (written) journal record.
+	got, err := os.ReadFile(filepath.Join(dest, "keep.md"))
+	if err != nil || string(got) != "payload" {
+		t.Fatalf("dest content = %q err=%v, want the rename left in place", got, err)
+	}
+	if _, err := os.Lstat(dir); !os.IsNotExist(err) {
+		t.Errorf("source dir still present after a sync-stage failure (err=%v)", err)
+	}
+	// The record IS in the journal (the write succeeded), so undo can replay.
+	recs, err := readActions(ra.ActionsPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 1 || recs[0].Op != "Rename" || recs[0].RenameTo != dest {
+		t.Fatalf("journal records = %+v, want the one written Rename record", recs)
+	}
+}
+
+// TestWorkspaceFileMoveNoClobber_DestExistsKernelRefusal calls the file-move
+// helper directly against an EXISTING destination: os.Link must refuse with
+// EEXIST (the kernel-atomic no-clobber, independent of any caller lstat
+// pre-check), nothing moves, and nothing is journaled.
+func TestWorkspaceFileMoveNoClobber_DestExistsKernelRefusal(t *testing.T) {
+	repo := t.TempDir()
+	src := filepath.Join(repo, ".agents", "retros", "dup.md")
+	dest := filepath.Join(repo, ".agents", "retro", "dup.md")
+	writeWorkspaceFile(t, src, "source body", time.Now())
+	writeWorkspaceFile(t, dest, "dest body", time.Now())
+
+	ra, err := NewRunArtifact(repo, "wsfilemove", time.Now())
+	if err != nil {
+		t.Fatalf("NewRunArtifact: %v", err)
+	}
+	af, err := ra.OpenActionsFile()
+	if err != nil {
+		t.Fatalf("OpenActionsFile: %v", err)
+	}
+	t.Cleanup(func() { _ = af.Close() })
+	caps := NewCapabilities("test")
+	locks := NewLockManager(filepath.Join(repo, ".doctor", "locks"))
+	ctx := NewMutateContext(ra, caps, t.TempDir(), locks, af, false).WithFixer("test-file-move")
+
+	collided, err := workspaceFileMoveNoClobber(ctx, src, dest)
+	if err != nil {
+		t.Fatalf("workspaceFileMoveNoClobber: %v", err)
+	}
+	if !collided {
+		t.Fatal("existing destination not reported as a collision")
+	}
+	if got, err := os.ReadFile(src); err != nil || string(got) != "source body" {
+		t.Errorf("source = %q err=%v, want untouched", got, err)
+	}
+	if got, err := os.ReadFile(dest); err != nil || string(got) != "dest body" {
+		t.Errorf("dest = %q err=%v, want untouched (never overwritten)", got, err)
+	}
+	recs, err := readActions(ra.ActionsPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("collided move wrote %d action records, want 0", len(recs))
+	}
+}
+
+// TestWorkspaceFileMoveNoClobber_JournalWriteFailureCompensates: a WRITE-stage
+// journal failure after link+remove executed must move the file back (disk
+// matches the empty journal) and report the compensation.
+func TestWorkspaceFileMoveNoClobber_JournalWriteFailureCompensates(t *testing.T) {
+	repo := t.TempDir()
+	src := filepath.Join(repo, ".agents", "retros", "a.md")
+	dest := filepath.Join(repo, ".agents", "retro", "a.md")
+	writeWorkspaceFile(t, src, "payload", time.Now())
+
+	ra, err := NewRunArtifact(repo, "wsfilejournal", time.Now())
+	if err != nil {
+		t.Fatalf("NewRunArtifact: %v", err)
+	}
+	af, err := ra.OpenActionsFile()
+	if err != nil {
+		t.Fatalf("OpenActionsFile: %v", err)
+	}
+	// Close the handle NOW: the move will succeed, the journal write will fail.
+	if err := af.Close(); err != nil {
+		t.Fatalf("close actions file: %v", err)
+	}
+	caps := NewCapabilities("test")
+	locks := NewLockManager(filepath.Join(repo, ".doctor", "locks"))
+	ctx := NewMutateContext(ra, caps, t.TempDir(), locks, af, false).WithFixer("test-file-journal-fail")
+
+	collided, moveErr := workspaceFileMoveNoClobber(ctx, src, dest)
+	if moveErr == nil {
+		t.Fatal("workspaceFileMoveNoClobber succeeded despite a dead actions.jsonl handle")
+	}
+	if collided {
+		t.Error("journal failure misreported as a collision")
+	}
+	if !strings.Contains(moveErr.Error(), "compensated") {
+		t.Errorf("error = %v, want it to report the compensating move-back", moveErr)
+	}
+	if got, err := os.ReadFile(src); err != nil || string(got) != "payload" {
+		t.Fatalf("source not restored: content=%q err=%v", got, err)
+	}
+	if _, err := os.Lstat(dest); !os.IsNotExist(err) {
+		t.Errorf("dest still present after compensation (err=%v)", err)
+	}
+}
+
 func TestWorkspaceGCTTL(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -407,6 +564,11 @@ func TestWorkspaceGCTTL(t *testing.T) {
 		{"default when unset", "", 14 * 24 * time.Hour},
 		{"override 7 days", "7", 7 * 24 * time.Hour},
 		{"override 1 day", "1", 24 * time.Hour},
+		{"cap boundary accepted", "3650", 3650 * 24 * time.Hour},
+		{"over cap falls back", "3651", 14 * 24 * time.Hour},
+		// The overflow class from the hardening finding: day counts above
+		// ~106751 wrap time.Duration negative, which would expire everything.
+		{"duration-overflow value falls back", "10675200", 14 * 24 * time.Hour},
 		{"zero falls back", "0", 14 * 24 * time.Hour},
 		{"negative falls back", "-3", 14 * 24 * time.Hour},
 		{"non-numeric falls back", "abc", 14 * 24 * time.Hour},

--- a/docs/agents-dir-hygiene.md
+++ b/docs/agents-dir-hygiene.md
@@ -81,7 +81,8 @@ The workspace detectors are:
 
 Every mutating run writes receipts under
 `.doctor/runs/<timestamp>__<runid>/`: a `report.json` describing findings and
-applied fixes, and an `undo.sh` that reverses every mutation the run made.
+applied fixes, an `actions.jsonl` journal of every mutation, and an `undo.sh`
+wrapper for reversing them (see the exact undo contract below).
 `.doctor/latest` is a symlink to the most recent run.
 
 ## Safety envelope
@@ -95,9 +96,20 @@ applied fixes, and an `undo.sh` that reverses every mutation the run made.
   the knowledge subsystem's learnings consolidation) would collide with
   existing content and the right merge is not mechanically certain, the
   finding lands in a Skipped list with the reason, and nothing moves.
-- Detectors are pure reads; every disk write flows through the audited
-  mutation path and is backed up before it happens, so `undo.sh` can restore
-  the prior state.
+- **What undo can and cannot reverse.** Detectors are pure reads; every disk
+  write flows through the audited mutation path and lands as a journal line.
+  FILE mutations are content-hashed and backed up verbatim before they change,
+  and undo restores them from those backups. DIRECTORY renames (quarantines
+  and drift merges) carry **no byte backup** — the renamed/quarantined tree
+  itself *is* the preserved copy, byte for byte — and undo reverses them by
+  replaying the rename backwards. A crash in the narrow window between a
+  rename landing and its journal line being written leaves that one mutation
+  invisible to undo; recovery is manual, from the run's `quarantine/`
+  directory (the run receipts list what moved, and nothing is ever deleted).
+- **Concurrent external writers are bounded, not excluded.** Doctor's locks
+  are per-process. A writer outside doctor racing a fix can slip content into
+  a directory in the moment it is quarantined; that content is moved with the
+  directory — journaled, restorable via undo, never destroyed.
 
 ## What doctor will NOT decide
 

--- a/docs/agents-dir-hygiene.md
+++ b/docs/agents-dir-hygiene.md
@@ -75,8 +75,8 @@ The workspace detectors are:
 | `fm-ws-stale-queue-dirs` | `.stale-*` / `-retry<N>` directories past TTL | quarantine (rename) |
 | `fm-ws-empty-dirs` | empty top-level dirs (abandoned scaffolding) | quarantine (rename) |
 | `fm-ws-naming-drift` | drift-alias directory names (table above) | merge/rename to canonical |
-| `fm-ws-dual-store` | same content class split across two directories | merge; refused if ambiguous |
-| `fm-ws-nested-tree` | a workspace tree nested where it should not be | merge/rename; refused if ambiguous |
+| `fm-ws-dual-store` | learnings split across `.agents/learnings` and `.agents/ao/learnings` | report-only; defers to `ao doctor --fix --only fm-knowledge-orphaned-flywheel-learnings` (moves top-level `*.md`/`*.jsonl` only) |
+| `fm-ws-nested-tree` | a `.agents` runtime tree nested under a repo subdirectory | report-only; manual review (may be an intentional nested project) |
 | `fm-ws-oversize` | unexpectedly large directories | report-only |
 
 Every mutating run writes receipts under
@@ -91,10 +91,10 @@ applied fixes, and an `undo.sh` that reverses every mutation the run made.
   (`.doctor/runs/<run>/quarantine/workspace/<dirname>`). Final disposal of
   quarantined content is always the human's call — for old runs,
   `ao doctor gc` requires explicit `--yes` and `--before <date>`.
-- **Ambiguous merges are refused, not guessed.** When a drift-alias or
-  dual-store fix would collide with existing content and the right merge is
-  not mechanically certain, the finding lands in a Skipped list with the
-  reason, and nothing moves.
+- **Ambiguous merges are refused, not guessed.** When a drift-alias merge (or
+  the knowledge subsystem's learnings consolidation) would collide with
+  existing content and the right merge is not mechanically certain, the
+  finding lands in a Skipped list with the reason, and nothing moves.
 - Detectors are pure reads; every disk write flows through the audited
   mutation path and is backed up before it happens, so `undo.sh` can restore
   the prior state.

--- a/docs/agents-dir-hygiene.md
+++ b/docs/agents-dir-hygiene.md
@@ -1,0 +1,107 @@
+---
+title: ".agents/ workspace hygiene"
+description: "Retention conventions for the .agents/ runtime workspace and how ao doctor keeps it clean."
+permalink: /agents-dir-hygiene
+last_reviewed: 2026-07-18
+---
+
+# `.agents/` workspace hygiene
+
+`.agents/` is the per-repository runtime workspace: gitignored local state
+written by the `ao` CLI and by skills while they work. It is not committed
+(except a small pinned config under `.agents/ao/`), it is not a deliverable,
+and everything in it is safe to regenerate. Two shapes of content live there:
+
+- **Knowledge-shaped directories** — postmortems, pre-mortem checks, handoffs,
+  retros, proofs: human-readable records a later session may re-read.
+- **Machine-artifact directories** — queue dirs, run scratch, staged outputs:
+  consumed once by tooling and then debris.
+
+Left alone, the second class accumulates. The `workspace` subsystem of
+`ao doctor` exists to detect and garbage-collect that debris safely.
+
+## The ephemeral-dir contract
+
+Any writer that mints a queue- or run-shaped directory under `.agents/` MUST
+follow this contract:
+
+- **Mark abandonment by renaming, never by deleting.** A directory that is
+  done or abandoned is renamed to `<name>.stale-<timestamp>` with a UTC
+  timestamp in `YYYYMMDDTHHMMSSZ` form, e.g.
+  `land-queue-age-h433.19.stale-20260711T221032Z`.
+- **Retry attempts get `-retry<N>` suffixes**, e.g.
+  `land-queue-age-h433.22-native-retry2`. A retry directory may itself later
+  be staled; both suffixes can appear on one name.
+- **GC is `ao doctor`'s job.** Writers never delete workspace directories —
+  they only rename. Doctor collects stale and retry-chain directories whose
+  newest content is older than the TTL.
+
+The GC TTL defaults to **14 days**, measured against the newest regular-file
+modification time inside the directory. Override it with
+`AO_DOCTOR_WS_TTL_DAYS` (a positive integer day count; invalid values fall
+back to the default).
+
+## Canonical directory names
+
+Skills and sessions have historically spelled the same top-level directories
+several ways. Doctor normalizes toward one canonical name per concept:
+
+| Canonical | Known drift aliases |
+|---|---|
+| `postmortem` | `post-mortem`, `post-mortems` |
+| `pre-mortem-checks` | `pre-mortem`, `pre-mortems` |
+| `handoff` | `handoffs`, `mto-handoff` |
+| `retro` | `retros` |
+| `proofs` | `proof` |
+| `tests` | `test` |
+
+This table is a projection of `workspaceCanonicalAliases` in
+`cli/internal/doctor/fix_workspace.go` — the Go table is the source of truth.
+If the two disagree, the Go table wins and this page is stale.
+
+## How to clean up
+
+```bash
+ao doctor                       # detect-only: report findings, change nothing
+ao doctor --fix                 # apply fixers (routes through mutate())
+ao doctor --only fm-ws-empty-dirs   # scope to one detector (repeatable)
+ao doctor --only workspace      # or scope to the whole subsystem
+```
+
+The workspace detectors are:
+
+| Detector ID | Finds | Fix behavior |
+|---|---|---|
+| `fm-ws-stale-queue-dirs` | `.stale-*` / `-retry<N>` directories past TTL | quarantine (rename) |
+| `fm-ws-empty-dirs` | empty top-level dirs (abandoned scaffolding) | quarantine (rename) |
+| `fm-ws-naming-drift` | drift-alias directory names (table above) | merge/rename to canonical |
+| `fm-ws-dual-store` | same content class split across two directories | merge; refused if ambiguous |
+| `fm-ws-nested-tree` | a workspace tree nested where it should not be | merge/rename; refused if ambiguous |
+| `fm-ws-oversize` | unexpectedly large directories | report-only |
+
+Every mutating run writes receipts under
+`.doctor/runs/<timestamp>__<runid>/`: a `report.json` describing findings and
+applied fixes, and an `undo.sh` that reverses every mutation the run made.
+`.doctor/latest` is a symlink to the most recent run.
+
+## Safety envelope
+
+- **Doctor has no delete operation by design.** What reads as "deletion" is an
+  atomic rename into the run's `quarantine/` directory
+  (`.doctor/runs/<run>/quarantine/workspace/<dirname>`). Final disposal of
+  quarantined content is always the human's call — for old runs,
+  `ao doctor gc` requires explicit `--yes` and `--before <date>`.
+- **Ambiguous merges are refused, not guessed.** When a drift-alias or
+  dual-store fix would collide with existing content and the right merge is
+  not mechanically certain, the finding lands in a Skipped list with the
+  reason, and nothing moves.
+- Detectors are pure reads; every disk write flows through the audited
+  mutation path and is backed up before it happens, so `undo.sh` can restore
+  the prior state.
+
+## What doctor will NOT decide
+
+Disposal of large archives and eval payloads is a judgment call, not a
+mechanical one. `fm-ws-oversize` reports them — path, size, file count — and
+stops there. Doctor never quarantines, moves, or deletes content solely for
+being big; deciding what a large artifact is worth is the operator's job.


### PR DESCRIPTION
## What

New `workspace` subsystem for `ao doctor`: six `fm-ws-*` detectors + three fixers that keep a repo's `.agents/` runtime workspace clean, plus the retention convention doc (docs/agents-dir-hygiene.md).

- **Auto-fixable**: `fm-ws-stale-queue-dirs` (TTL GC of `.stale-*`/`-retryN` debris), `fm-ws-empty-dirs`, `fm-ws-naming-drift` (merges alias spellings into canonical dirs, collision-safe via Skipped).
- **Report-only**: `fm-ws-dual-store`, `fm-ws-nested-tree`, `fm-ws-oversize` — human calls by design.
- All mutation flows through one shared dir-rename chokepoint adapter (`workspaceDirRename`): per-path locks, scope + op preconditions, journaled receipts, undo. **No delete op exists** — removal = atomic Rename into the run's quarantine.
- Capabilities: `.agents` added to write scopes; `workspace` subsystem registered.

## Verification

- 186 package tests (incl. shuffle), golangci clean, bead-per-commit (`age-agents-hygiene-doctor-fyjdk`).
- **Dogfooded on a 211MB copy of the real tree**: 54 fix actions, 28 dirs quarantined, undo restored 54/54 byte-identical; then run live (142→114 top-level dirs, fully reversible, receipts kept).
- **Cross-family review (Codex), two adversarial rounds, 15 findings, all resolved or dispositioned**: R1's 8 (symlink-root escape, journal-undo blindness, walk-errors-as-empty, P4 off-contract, etc.) all fixed; R2's new items fixed (symlinked canonical dest, Lstat-error≠absent, kernel-atomic no-clobber file moves via link+remove, env-cap overflow, docs overclaim). One pre-existing finding in untouched code filed as bead `age-knowledge-symlink-root-inbpg`.

## Residual risk (disclosed by design)

- TOCTOU vs **external** writers (in-process advisory locks): windows exist; bounded — content is moved to quarantine, journaled, undo-restorable, never destroyed. Full closure needs FS transactions; out of scope.
- Execute-before-journal ordering matches the existing `Mutate` chokepoint (house parity); a crash in that window requires manual recovery from quarantine — documented in the doc page.
- Dir renames carry no byte backup: the renamed tree IS the copy (undo replays the rename).