### PR TITLE
feat(cli): wire ao eval — the Learn seat's measurement surface

### DIFF
--- a/cli/cmd/ao/default_spine_test.go
+++ b/cli/cmd/ao/default_spine_test.go
@@ -11,7 +11,7 @@ import (
 // command was registered (or dropped) without changing this contract.
 var approvedDefaultSpine = map[string]bool{
 	"capabilities": true, "config": true, "doctor": true,
-	"demo": true, "flywheel": true, "gate": true, "goals": true,
+	"demo": true, "eval": true, "flywheel": true, "gate": true, "goals": true,
 	"init": true, "provenance": true, "quick-start": true,
 	"redact": true, "robot-docs": true, "session": true, "skills": true,
 	"status": true, "version": true,

--- a/cli/cmd/ao/eval_composition.go
+++ b/cli/cmd/ao/eval_composition.go
@@ -1,0 +1,51 @@
+// practices: [hexagonal-architecture, ddd-bounded-context]
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	evaladapter "github.com/boshu2/agentops/cli/internal/adapters/eval"
+	"github.com/boshu2/agentops/cli/internal/clicontract"
+	evalcommands "github.com/boshu2/agentops/cli/internal/commands/eval"
+	evalapp "github.com/boshu2/agentops/cli/internal/eval"
+)
+
+func init() {
+	rootCmd.AddCommand(newEvalCommand())
+}
+
+// newEvalCommand wires the eval measurement surface: deterministic suite runs,
+// run-record comparison, locked Tasks, holdout scenarios, and A/B verdicts.
+// Eval is the Learn seat of the operating loop — a read/measure consumer of
+// evidence that reports numbers and never retries, schedules, or promotes
+// anything on its own. The Aliases and Bench seats are deliberately nil: their
+// production implementations (session-outcome, chaos, bench) were retired with
+// the legacy knowledge surface, and the module omits those subcommands when
+// the seats are empty.
+func newEvalCommand() *cobra.Command {
+	runtime := evaladapter.Runtime{}
+	module := evalcommands.NewModule(evalcommands.UseCases{
+		Core:       evalapp.CoreService{Runtime: runtime},
+		Cleanup:    evalapp.CleanupService{Runtime: runtime},
+		Task:       evalapp.TaskService{Runtime: runtime},
+		Suite:      evalapp.SuiteService{Runtime: runtime},
+		Outcomes:   evalapp.OutcomesService{Runtime: runtime},
+		Scenario:   evalapp.ScenarioService{Runtime: runtime},
+		ScenarioAB: evalapp.ScenarioABService{Runtime: runtime},
+	}, evalcommands.HostOptions{
+		OutputMode: func(*cobra.Command) string { return GetOutput() },
+		Verbose:    func(*cobra.Command) bool { return GetVerbose() },
+		DryRun:     func(*cobra.Command) bool { return GetDryRun() },
+		ProjectRoot: func() string {
+			if dir, err := resolveProjectDir(); err == nil {
+				return dir
+			}
+			return ""
+		},
+	})
+	command := module.Command()
+	if err := clicontract.Attach(command, module.Contract()); err != nil {
+		panic(err)
+	}
+	return command
+}

--- a/cli/cmd/ao/eval_composition_test.go
+++ b/cli/cmd/ao/eval_composition_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// minimalEvalSuite is a self-contained deterministic suite: one static
+// artifact_contains case over a fixture file, no network, no subprocesses.
+const minimalEvalSuite = `{
+  "schema_version": 1,
+  "id": "fixture.pass",
+  "name": "Fixture pass",
+  "domain": "cli",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "correctness", "weight": 1, "threshold": 1}
+    ]
+  },
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {
+      "id": "contains",
+      "title": "fixture contains needle",
+      "kind": "artifact_check",
+      "objective": "Verify static fixtures are scored offline.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "fixture.txt", "value": "needle"}
+      ]
+    }
+  ]
+}`
+
+func writeMinimalSuite(t *testing.T) (dir, suitePath string) {
+	t.Helper()
+	dir = t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "fixture.txt"), []byte("alpha\nneedle\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	suitePath = filepath.Join(dir, "suite.json")
+	if err := os.WriteFile(suitePath, []byte(minimalEvalSuite), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir, suitePath
+}
+
+// TestEvalRun_DeterministicSuite exercises the full production wiring
+// (composition -> module -> CoreService -> adapter Runtime -> engine) over a
+// real on-disk suite and asserts the durable run record.
+func TestEvalRun_DeterministicSuite(t *testing.T) {
+	dir, suitePath := writeMinimalSuite(t)
+	out := filepath.Join(dir, "run.json")
+
+	output, err := executeCommand("eval", "run", suitePath, "--run-id", "run-1", "--out", out)
+	if err != nil {
+		t.Fatalf("ao eval run failed: %v\n%s", err, output)
+	}
+
+	payload, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("run record not written: %v", err)
+	}
+	var record struct {
+		SchemaVersion  int     `json:"schema_version"`
+		RunID          string  `json:"run_id"`
+		Status         string  `json:"status"`
+		Verdict        string  `json:"verdict"`
+		AggregateScore float64 `json:"aggregate_score"`
+	}
+	if err := json.Unmarshal(payload, &record); err != nil {
+		t.Fatalf("run record is not JSON: %v", err)
+	}
+	if record.RunID != "run-1" || record.Status != "pass" || record.Verdict != "pass" {
+		t.Fatalf("run record = %+v, want run-1/pass/pass", record)
+	}
+	if record.AggregateScore != 1 {
+		t.Fatalf("aggregate_score = %v, want 1", record.AggregateScore)
+	}
+}
+
+// TestEvalCompare_IdenticalRunsPass compares a run record against itself:
+// zero regression must yield a pass verdict.
+func TestEvalCompare_IdenticalRunsPass(t *testing.T) {
+	dir, suitePath := writeMinimalSuite(t)
+	out := filepath.Join(dir, "run.json")
+	if output, err := executeCommand("eval", "run", suitePath, "--run-id", "run-1", "--out", out); err != nil {
+		t.Fatalf("seed run failed: %v\n%s", err, output)
+	}
+
+	output, err := executeCommand("eval", "compare", out, out)
+	if err != nil {
+		t.Fatalf("ao eval compare failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "pass") {
+		t.Fatalf("compare output does not report pass:\n%s", output)
+	}
+}
+
+// TestEvalHelp_PublishesMeasurementSurface pins the top-level subcommand set.
+func TestEvalHelp_PublishesMeasurementSurface(t *testing.T) {
+	output, err := executeCommand("eval", "--help")
+	if err != nil {
+		t.Fatalf("ao eval --help failed: %v", err)
+	}
+	for _, subcommand := range []string{"run", "compare", "baseline", "scorecard", "coverage", "task", "suite", "outcomes", "scenario"} {
+		if !strings.Contains(output, subcommand) {
+			t.Errorf("ao eval --help missing subcommand %q", subcommand)
+		}
+	}
+	// The retired alias seats must not resurface: their production
+	// implementations were removed with the legacy knowledge stack.
+	for _, retired := range []string{"session-outcome", "chaos", "bench"} {
+		if strings.Contains(output, retired) {
+			t.Errorf("ao eval --help exposes retired alias %q", retired)
+		}
+	}
+}

--- a/cli/cmd/ao/flag_matrix_test.go
+++ b/cli/cmd/ao/flag_matrix_test.go
@@ -18,6 +18,9 @@ var (
 	hermeticBinaryPath string
 	hermeticBinaryDir  string
 	hermeticBinaryErr  error
+	// hermeticBuildHome is the real $HOME captured by TestMain before it
+	// isolates HOME, so `go build` keeps its module/build caches.
+	hermeticBuildHome string
 )
 
 // aoBinary returns an ao binary built from this exact package source. It never
@@ -36,8 +39,17 @@ func aoBinary(t *testing.T) string {
 		}
 		hermeticBinaryDir = dir
 		out := filepath.Join(dir, "ao")
-		build := exec.Command("go", "build", "-o", out, ".")
+		build := exec.Command("go", "build", "-buildvcs=false", "-o", out, ".")
 		build.Dir = pkgDir
+		if hermeticBuildHome != "" {
+			env := make([]string, 0, len(os.Environ())+1)
+			for _, entry := range os.Environ() {
+				if !strings.HasPrefix(entry, "HOME=") {
+					env = append(env, entry)
+				}
+			}
+			build.Env = append(env, "HOME="+hermeticBuildHome)
+		}
 		if raw, err := build.CombinedOutput(); err != nil {
 			hermeticBinaryErr = &hermeticBuildError{output: string(raw), err: err}
 			return

--- a/cli/cmd/ao/main_test.go
+++ b/cli/cmd/ao/main_test.go
@@ -33,6 +33,11 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	origHome, hadOrigHome := os.LookupEnv("HOME")
+	// The hermetic binary build (aoBinary) must keep using the real module and
+	// build caches: with HOME pointed at the temp dir, Go would resolve an
+	// empty GOMODCACHE and re-download modules on every test run (or fail
+	// offline). Capture the pre-isolation cache paths for the build env.
+	hermeticBuildHome = origHome
 	os.Setenv("HOME", tmpHome)
 
 	// Isolate the tmux socket. Several production paths (context-budget

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -258,6 +258,398 @@ ao version [flags]
 
 ---
 
+### `ao eval`
+
+Run deterministic AgentOps evaluation suites and compare run records.
+
+```
+ao eval [command]
+```
+
+**Subcommands:**
+
+#### `ao eval baseline`
+
+Promote an eval run record as a baseline
+
+```
+ao eval baseline <run.json> [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help                 help for baseline
+      --out string           write promoted baseline run record to path
+      --promoted-by string   identity promoting the baseline
+      --rationale string     rationale for promoting the baseline
+```
+
+#### `ao eval baseline-audit`
+
+Audit eval suite baseline policy against promoted baselines
+
+```
+ao eval baseline-audit [suite.json ...] [flags]
+```
+
+**Flags:**
+
+```
+      --baseline-dir string   promoted baseline directory (default ".agents/evals/baselines")
+  -h, --help                  help for baseline-audit
+      --root string           suite root to scan when no suite paths are provided (default "evals/agentops-core")
+```
+
+#### `ao eval cleanup`
+
+Per SCHEMA.md §4 cleanup state-transition rule (rc2):
+
+```
+ao eval cleanup [flags]
+```
+
+**Flags:**
+
+```
+      --delete        Remove Run directories whose status is failed or aborted (never retracted)
+      --dry-run       Preview without mutations
+  -h, --help          help for cleanup
+      --tmp-age int   Minimum tmp-file age in seconds before sweep (0 = sweep all) (default 60)
+      --tmp-files     Sweep orphan *.tmp files older than --tmp-age
+```
+
+#### `ao eval compare`
+
+Compare an eval run against a baseline
+
+```
+ao eval compare <candidate-run.json> <baseline-run.json> [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help                             help for compare
+      --max-aggregate-regression float   allowed aggregate regression before verdict becomes regression
+      --max-dimension-regression float   allowed per-dimension regression before verdict becomes regression
+      --out string                       write compared eval run record to path
+```
+
+#### `ao eval coverage`
+
+Summarize eval suite coverage
+
+```
+ao eval coverage [suite.json ...] [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help                                help for coverage
+      --require-dimension stringArray       required score dimension for missing-dimension reporting (default [correctness,process_adherence,artifact_quality,runtime_compatibility,efficiency,safety,learning_closure])
+      --require-domain stringArray          required product domain for missing-domain reporting (default [cli,hook,skill,rpi,runtime,retrieval,scenario,mixed,security])
+      --require-evidence-kind stringArray   required evidence kind for missing-evidence-kind reporting
+      --require-runtime stringArray         required deterministic runtime for missing-runtime reporting (default [static,shell,mock])
+      --root string                         suite root to scan when no suite paths are provided (default "evals/agentops-core")
+```
+
+#### `ao eval outcomes`
+
+Outcomes is a derived projection of the locked eval substrate (SCHEMA.md), never an alternate authority.
+
+```
+ao eval outcomes [command]
+```
+
+##### `ao eval outcomes compile`
+
+Compile a holdout-safe Outcomes rubric payload from a locked Task + criteria
+
+```
+ao eval outcomes compile <input.json> [flags]
+```
+
+##### `ao eval outcomes ingest`
+
+Ingest an Outcomes score payload into the one council verdict record
+
+```
+ao eval outcomes ingest <score.json> [flags]
+```
+
+**Flags:**
+
+```
+      --burn-ledger string         path to a JSON HoldoutBurnLedger; when set, a holdout-split score registers a burn and is REFUSED if the (suite,gt) quota is exhausted (gate #3 runtime enforcement), persisted across invocations
+      --expect-judge-hash string   refuse the ingest if the score's judge_content_hash does not match this value (gate #2 rubric-drift parity)
+  -h, --help                       help for ingest
+      --manifest-out string        also write an eval-run.v1 manifest to <dir>/<run-id>/manifest.json so the verdict pipeline feeds the Knowledge Flywheel (closes the Outcomes→Flywheel loop)
+      --run-id string              run id for the --manifest-out manifest; defaults to the score's run_id, then source_task_id (sanitized to the eval-run.v1 pattern)
+```
+
+#### `ao eval run`
+
+Run a deterministic eval suite
+
+```
+ao eval run <suite.json> [flags]
+```
+
+**Flags:**
+
+```
+      --baseline string                 compare the run against a baseline run record
+      --baseline-mode string            skill-on | skill-off | both — runs the suite once with skills loaded, once with hooks suppressed, or both for a delta scorecard (default "skill-on")
+      --context-mode string             none | ab — run context-off/context-on legs over isolated AO_AGENTS_DIR roots (default "none")
+      --context-off-agents-dir string   AO_AGENTS_DIR root for the context-off leg (defaults to suite fixtures)
+      --context-on-agents-dir string    AO_AGENTS_DIR root for the context-on leg (defaults to suite fixtures)
+      --delta-out string                write delta scorecard JSON to path (with --baseline-mode=both or --context-mode=ab)
+  -h, --help                            help for run
+      --out string                      write eval run record to path
+      --run-id string                   stable run id to use in the run record
+      --runtime string                  runtime override (static, mock, shell, claude, codex)
+```
+
+#### `ao eval scenario`
+
+Create, list, validate, and evaluate holdout scenarios stored in .agents/holdout/.
+
+```
+ao eval scenario [command]
+```
+
+##### `ao eval scenario add`
+
+Author a holdout scenario from a goal description
+
+```
+ao eval scenario add <goal> [flags]
+```
+
+**Flags:**
+
+```
+      --expected-outcome string   Expected observable outcome (default: inferred from goal)
+  -h, --help                      help for add
+      --narrative string          Narrative description (default: inferred from goal)
+      --source string             Scenario source (human, agent, prod-telemetry) (default "human")
+      --status string             Scenario status (active, draft, retired) (default "draft")
+      --threshold float           Satisfaction threshold in [0,1] (default 0.8)
+```
+
+##### `ao eval scenario evaluate`
+
+Evaluate directive-linked scenarios and record satisfaction results
+
+```
+ao eval scenario evaluate [flags]
+```
+
+**Flags:**
+
+```
+      --all                Evaluate every directive's linked scenarios
+      --directive string   Evaluate only the directive with this stable Directive ID
+  -h, --help               help for evaluate
+      --json               Emit the machine-readable evaluation report
+      --run-id string      run_id recorded in the results artifact (default "ao-scenario-evaluate")
+      --timeout duration   Per-check execution timeout (default 2m0s)
+```
+
+##### `ao eval scenario init`
+
+Initialize .agents/holdout/ directory for scenario storage
+
+```
+ao eval scenario init [flags]
+```
+
+##### `ao eval scenario list`
+
+List holdout scenarios
+
+```
+ao eval scenario list [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help            help for list
+      --status string   Filter by status (active, draft, retired)
+```
+
+##### `ao eval scenario validate`
+
+Validate holdout scenarios against schema
+
+```
+ao eval scenario validate [flags]
+```
+
+#### `ao eval scenario-ab`
+
+Run a knowledge-reuse holdout scenario with vs. without the gold pull (the discriminating A/B)
+
+```
+ao eval scenario-ab [flags]
+```
+
+**Flags:**
+
+```
+      --control-only       Run only the without-gold control arm and fail on ceiling/no-headroom
+  -h, --help               help for scenario-ab
+      --output string      Write the ScenarioDeltaScorecard JSON to this path
+      --scenario string    Path to the scenario.v1 JSON file (required)
+      --timeout duration   Per-arm timeout (0 = default 5m)
+      --token-budget int   Fail the gate if summed arm token cost exceeds this (0 = default 200000)
+```
+
+#### `ao eval scenario-moat`
+
+Aggregate moat-eligible scenario A/B scorecards into a publication verdict
+
+```
+ao eval scenario-moat [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help                    help for scenario-moat
+      --output string           Write the MoatClaimResult JSON to this path
+      --scorecard stringArray   Path to a ScenarioDeltaScorecard JSON (repeatable)
+```
+
+#### `ao eval scorecard`
+
+Build an eval scorecard from run records
+
+```
+ao eval scorecard <candidate-run.json> [baseline-run.json] [flags]
+```
+
+**Flags:**
+
+```
+  -h, --help                            help for scorecard
+      --kind string                     scorecard kind (rpi, skill-change) (default "rpi")
+      --max-category-regression float   allowed per-category regression before verdict becomes regression
+      --out string                      write scorecard JSON to path
+```
+
+#### `ao eval suite`
+
+Suite-level operations against the §6.5 statistical contract.
+
+```
+ao eval suite [command]
+```
+
+##### `ao eval suite n-required`
+
+Compute power-derived n_required (gate #6 input on Day 3+)
+
+```
+ao eval suite n-required [flags]
+```
+
+**Flags:**
+
+```
+      --alpha float           Type-I error rate (default 0.05)
+      --baseline-rate float   Baseline rate (binomial worst-case fallback) (default 0.5)
+  -h, --help                  help for n-required
+      --mde float             Minimum detectable effect (default 0.05)
+      --paired                Paired comparison (default true)
+      --power float           Statistical power (1-beta) (default 0.8)
+```
+
+##### `ao eval suite verdict`
+
+Compute the §6.5 paired cluster-bootstrap verdict
+
+```
+ao eval suite verdict <suite-id> --arms a,b --inputs <bootstrap-inputs.json> [flags]
+```
+
+**Flags:**
+
+```
+      --B int            Bootstrap resamples (default 10000)
+      --arms string      Comma-separated arm ids (default: from suite varied_axis)
+  -h, --help             help for verdict
+      --inputs string    Path to canonical bootstrap-inputs JSON (REQUIRED)
+      --mde float        Minimum detectable effect (used for inconclusive_high_variance)
+      --n-required int   Override n_required (default: derived from suite power block)
+```
+
+#### `ao eval task`
+
+Operate on the §3 Task primitive of the eval substrate.
+
+```
+ao eval task [command]
+```
+
+##### `ao eval task add`
+
+Register a Task by copying its yaml + samples into the substrate
+
+```
+ao eval task add <task.yaml> [flags]
+```
+
+##### `ao eval task list`
+
+List registered Task ids
+
+```
+ao eval task list [flags]
+```
+
+##### `ao eval task run`
+
+Open a new Run manifest for <task-id>; refuses on gate failure
+
+```
+ao eval task run <task-id> [flags]
+```
+
+**Flags:**
+
+```
+      --allow-weak-labels        Allow runs against confidence=weak ground-truth rows (gate #7)
+      --cross-spec               Allow ModelSpec drift (gate #4)
+      --dry-run                  Run gates and exit without writing a Run manifest
+      --ground-truth string      Ground-truth row id (head of supersession chain)
+      --harness string           Harness id (recorded into manifest)
+      --harness-dir string       Path to harness source dir for snapshot + gate #8
+  -h, --help                     help for run
+      --inspect-command string   Inspect command recorded into the Run manifest (not executed yet)
+      --inspect-version string   Inspect AI version stamped into manifest (default "0.3.216")
+      --model-spec string        ModelSpec id (already captured via ao eval models capture)
+      --n-samples int            Override Suite.n_samples
+      --quick                    Mark Run as quick_session=true (excluded from --vs auto-baseline pool)
+      --rig-id string            Rig identifier stamped into the Run manifest
+      --sample-split string      Sample split (dev|holdout); default from suite
+      --seeds string             Comma-separated seeds (>=3, per §4)
+      --suite string             Suite id or path to suite.yaml (required)
+```
+
+##### `ao eval task show`
+
+Print a registered Task summary
+
+```
+ao eval task show <task-id> [flags]
+```
+
+---
+
 ### `ao goals`
 
 Track, measure, and validate project fitness goals.

--- a/cli/internal/adapters/eval/scenario_ab_agentic.go
+++ b/cli/internal/adapters/eval/scenario_ab_agentic.go
@@ -31,10 +31,10 @@ type workspaceCommandRunner func(ctx context.Context, workDir, command string) (
 
 // agenticRunnerHooks is the injectable seam for tests (no live codex).
 var agenticRunnerHooks = struct {
-	runCodex func(ctx context.Context, prompt, schemaPath string) (string, int, error)
+	runCodex func(ctx context.Context, prompt, schemaPath string, allowCorpus bool) (string, int, error)
 	runCmd   workspaceCommandRunner
 }{
-	runCodex: runCodexExec,
+	runCodex: runCodexExecArm,
 	runCmd:   defaultWorkspaceCommandRunner,
 }
 
@@ -56,8 +56,8 @@ func (agenticScenarioRunner) RunArm(ctx context.Context, sc scenario.Scenario, w
 	var history strings.Builder
 	totalTokens := 0
 	for turn := 0; turn < agenticMaxTurns; turn++ {
-		prompt := buildAgenticPrompt(ctx, sc, withGold, workDir, history.String())
-		out, tokens, err := agenticRunnerHooks.runCodex(ctx, prompt, schemaPath)
+		prompt := buildAgenticPrompt(sc, workDir, history.String())
+		out, tokens, err := agenticRunnerHooks.runCodex(ctx, prompt, schemaPath, withGold)
 		totalTokens += tokens
 		if err != nil {
 			return aoeval.ArmOutcome{}, fmt.Errorf("agentic turn %d: %w", turn+1, err)
@@ -92,17 +92,13 @@ func (agenticScenarioRunner) RunArm(ctx context.Context, sc scenario.Scenario, w
 	return aoeval.ArmOutcome{}, fmt.Errorf("agentic runner exceeded %d turns without done=true", agenticMaxTurns)
 }
 
-func buildAgenticPrompt(ctx context.Context, sc scenario.Scenario, withGold bool, workDir, history string) string {
+// buildAgenticPrompt renders one agentic turn. The with/without-gold treatment
+// is expressed through sandbox corpus access at exec time, never through
+// prompt injection (see codexScenarioRunner.RunArm).
+func buildAgenticPrompt(sc scenario.Scenario, workDir, history string) string {
 	var p strings.Builder
 	p.WriteString("You are an agentic worker in an isolated workspace. Execute the task by running shell commands in the workspace directory.\n")
 	p.WriteString("Return ONLY strict JSON matching the schema: commands (shell lines to run now), done (true when finished), summary (final result for grading when done=true).\n\n")
-	if withGold {
-		if pointers := goldPointers(ctx, sc.Goal); pointers != "" {
-			p.WriteString("Relevant prior knowledge (gold corpus pointers):\n")
-			p.WriteString(pointers)
-			p.WriteString("\n\n")
-		}
-	}
 	p.WriteString(sc.Narrative)
 	p.WriteString("\n\nGoal: ")
 	p.WriteString(sc.Goal)

--- a/cli/internal/adapters/eval/scenario_ab_agentic_test.go
+++ b/cli/internal/adapters/eval/scenario_ab_agentic_test.go
@@ -15,7 +15,7 @@ func withAgenticHooks(t *testing.T, steps []agenticStep) {
 	t.Helper()
 	orig := agenticRunnerHooks
 	call := 0
-	agenticRunnerHooks.runCodex = func(_ context.Context, _ string, _ string) (string, int, error) {
+	agenticRunnerHooks.runCodex = func(_ context.Context, _ string, _ string, _ bool) (string, int, error) {
 		idx := call
 		if len(steps) == 0 {
 			return "", 0, context.Canceled

--- a/cli/internal/adapters/eval/scenario_ab_runtime.go
+++ b/cli/internal/adapters/eval/scenario_ab_runtime.go
@@ -31,20 +31,18 @@ func (Runtime) WriteMoatResult(path string, result aoeval.MoatClaimResult) error
 
 type codexScenarioRunner struct{}
 
+// RunArm executes one A/B arm. The treatment is ENVIRONMENT-shaped: the
+// with-gold arm may read the corpus (.agents/.ao) inside the sandbox, the
+// control arm is denied it. Nothing is injected into the prompt — the retired
+// `ao lookup` pointer-injection left both arms corpus-blind at runtime, which
+// silently guaranteed a zero delta.
 func (codexScenarioRunner) RunArm(ctx context.Context, spec scenario.Scenario, withGold bool) (aoeval.ArmOutcome, error) {
 	var prompt strings.Builder
-	if withGold {
-		if pointers := goldPointers(ctx, spec.Goal); pointers != "" {
-			prompt.WriteString("Relevant prior knowledge (gold corpus pointers):\n")
-			prompt.WriteString(pointers)
-			prompt.WriteString("\n\n")
-		}
-	}
 	prompt.WriteString(spec.Narrative)
 	prompt.WriteString("\n\nGoal: ")
 	prompt.WriteString(spec.Goal)
 	prompt.WriteString("\n\nProduce your best attempt. Output only the result, no preamble.")
-	output, tokens, err := runCodexExec(ctx, prompt.String(), "")
+	output, tokens, err := runCodexExecArm(ctx, prompt.String(), "", withGold)
 	if err != nil {
 		return aoeval.ArmOutcome{}, err
 	}
@@ -103,21 +101,18 @@ func writeJudgeSchema() (string, func(), error) {
 	return name, cleanup, nil
 }
 
-func goldPointers(ctx context.Context, query string) string {
-	if _, err := os.Stat(".ao/wiki"); err != nil {
-		return ""
-	}
-	command := exec.CommandContext(ctx, "ao", "lookup", "--query", query, "--gold", "--pointers", "--limit", "3")
-	output, err := command.Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(output))
-}
-
 var codexTokensRe = regexp.MustCompile(`(?i)tokens used[^\d]*([\d,]+)`)
 
+// runCodexExec runs Codex with the corpus DENIED — the safe default, used by
+// judges (grading must not be corpus-influenced) and legacy shims.
 func runCodexExec(ctx context.Context, prompt, outputSchemaPath string) (string, int, error) {
+	return runCodexExecArm(ctx, prompt, outputSchemaPath, false)
+}
+
+// runCodexExecArm runs Codex for one A/B arm. allowCorpus selects the
+// treatment: true leaves the corpus readable, false confines Codex away from
+// every corpus root (repo .agents/.ao, ~/.agents, env-resolved overrides).
+func runCodexExecArm(ctx context.Context, prompt, outputSchemaPath string, allowCorpus bool) (string, int, error) {
 	messageFile, err := os.CreateTemp("", "scenario-ab-codex-msg-*.txt")
 	if err != nil {
 		return "", 0, fmt.Errorf("codex last-message temp: %w", err)
@@ -130,9 +125,18 @@ func runCodexExec(ctx context.Context, prompt, outputSchemaPath string) (string,
 	if err != nil {
 		return "", 0, fmt.Errorf("resolve cwd for arm isolation: %w", err)
 	}
-	command, err := sandboxedCodexCmd(ctx, corpusDenyPaths(cwd), args)
-	if err != nil {
-		return "", 0, err
+	var command *exec.Cmd
+	if allowCorpus {
+		// Treatment arm: corpus stays readable, so no confinement wrapper.
+		// (sandboxedCodexCmd deliberately refuses empty deny lists — the
+		// fail-closed control-arm guard must not be weakened to express this.)
+		command = exec.CommandContext(ctx, "codex", args...)
+	} else {
+		confined, err := sandboxedCodexCmd(ctx, corpusDenyPaths(cwd), args)
+		if err != nil {
+			return "", 0, err
+		}
+		command = confined
 	}
 	command.Stdin = strings.NewReader("")
 	combined, err := command.CombinedOutput()

--- a/cli/internal/doctor/fix_workspace_refs.go
+++ b/cli/internal/doctor/fix_workspace_refs.go
@@ -168,6 +168,13 @@ func workspaceScanSourceRefs(repoRoot string) (workspaceRefScan, bool) {
 			continue
 		}
 		corpusFound = true
+		// Root-scoped reads: os.Root confines every ReadFile to rootPath and
+		// refuses symlink escapes, closing the walk-then-read TOCTOU window
+		// (gosec G122) the dirent checks alone cannot close.
+		rootHandle, rootErr := os.OpenRoot(rootPath)
+		if rootErr != nil {
+			continue
+		}
 		// WalkDir never follows symlinks; walk errors skip the subtree.
 		_ = filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, walkErr error) error {
 			if walkErr != nil {
@@ -189,7 +196,11 @@ func workspaceScanSourceRefs(repoRoot string) (workspaceRefScan, bool) {
 			if err != nil || fi.Size() > workspaceRefMaxFileBytes {
 				return nil
 			}
-			data, err := os.ReadFile(path)
+			relInRoot, relInRootErr := filepath.Rel(rootPath, path)
+			if relInRootErr != nil {
+				return nil
+			}
+			data, err := rootHandle.ReadFile(relInRoot)
 			if err != nil {
 				return nil
 			}
@@ -226,6 +237,7 @@ func workspaceScanSourceRefs(repoRoot string) (workspaceRefScan, bool) {
 			}
 			return nil
 		})
+		_ = rootHandle.Close()
 	}
 	for file, perFile := range aliasLines {
 		for alias, lines := range perFile {

--- a/cli/internal/doctor/fix_workspace_refs.go
+++ b/cli/internal/doctor/fix_workspace_refs.go
@@ -168,76 +168,7 @@ func workspaceScanSourceRefs(repoRoot string) (workspaceRefScan, bool) {
 			continue
 		}
 		corpusFound = true
-		// Root-scoped reads: os.Root confines every ReadFile to rootPath and
-		// refuses symlink escapes, closing the walk-then-read TOCTOU window
-		// (gosec G122) the dirent checks alone cannot close.
-		rootHandle, rootErr := os.OpenRoot(rootPath)
-		if rootErr != nil {
-			continue
-		}
-		// WalkDir never follows symlinks; walk errors skip the subtree.
-		_ = filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				if d != nil && d.IsDir() {
-					return fs.SkipDir
-				}
-				return nil
-			}
-			if d.IsDir() {
-				if workspaceRefSkipDirNames[d.Name()] {
-					return fs.SkipDir
-				}
-				return nil
-			}
-			if !d.Type().IsRegular() || !root.include(d.Name()) {
-				return nil
-			}
-			fi, err := d.Info()
-			if err != nil || fi.Size() > workspaceRefMaxFileBytes {
-				return nil
-			}
-			relInRoot, relInRootErr := filepath.Rel(rootPath, path)
-			if relInRootErr != nil {
-				return nil
-			}
-			data, err := rootHandle.ReadFile(relInRoot)
-			if err != nil {
-				return nil
-			}
-			rel, relErr := filepath.Rel(repoRoot, path)
-			if relErr != nil {
-				rel = path
-			}
-			rel = filepath.ToSlash(rel)
-			scan.FilesScanned++
-			exempt := workspaceDriftRefExemptFile(rel)
-			for i, line := range strings.Split(string(data), "\n") {
-				for _, m := range workspaceRefSegmentRe.FindAllStringSubmatch(line, -1) {
-					// Trailing dots are sentence punctuation, not path chars.
-					seg := strings.TrimRight(m[1], ".")
-					if seg == "" {
-						continue
-					}
-					scan.Referenced[seg] = true
-					canonical, isAlias := workspaceCanonicalAliases[seg]
-					if !isAlias {
-						continue
-					}
-					scan.Referenced[canonical] = true
-					if exempt {
-						continue
-					}
-					perFile := aliasLines[rel]
-					if perFile == nil {
-						perFile = make(map[string][]int)
-						aliasLines[rel] = perFile
-					}
-					perFile[seg] = append(perFile[seg], i+1)
-				}
-			}
-			return nil
-		})
-		_ = rootHandle.Close()
+		workspaceWalkRefRoot(repoRoot, rootPath, root.include, &scan, aliasLines)
 	}
 	for file, perFile := range aliasLines {
 		for alias, lines := range perFile {
@@ -251,6 +182,80 @@ func workspaceScanSourceRefs(repoRoot string) (workspaceRefScan, bool) {
 		return scan.AliasHits[i].Alias < scan.AliasHits[j].Alias
 	})
 	return scan, corpusFound
+}
+
+// workspaceWalkRefRoot walks one corpus root, accumulating referenced segments
+// into scan and alias occurrences into aliasLines. Root-scoped reads: os.Root
+// confines every ReadFile to rootPath and refuses symlink escapes, closing the
+// walk-then-read TOCTOU window (gosec G122) the dirent checks alone cannot
+// close. WalkDir never follows symlinks; walk errors skip the subtree.
+func workspaceWalkRefRoot(repoRoot, rootPath string, include func(string) bool, scan *workspaceRefScan, aliasLines map[string]map[string][]int) {
+	rootHandle, rootErr := os.OpenRoot(rootPath)
+	if rootErr != nil {
+		return
+	}
+	defer func() { _ = rootHandle.Close() }()
+	_ = filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			if workspaceRefSkipDirNames[d.Name()] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() || !include(d.Name()) {
+			return nil
+		}
+		fi, err := d.Info()
+		if err != nil || fi.Size() > workspaceRefMaxFileBytes {
+			return nil
+		}
+		relInRoot, relInRootErr := filepath.Rel(rootPath, path)
+		if relInRootErr != nil {
+			return nil
+		}
+		data, err := rootHandle.ReadFile(relInRoot)
+		if err != nil {
+			return nil
+		}
+		rel, relErr := filepath.Rel(repoRoot, path)
+		if relErr != nil {
+			rel = path
+		}
+		rel = filepath.ToSlash(rel)
+		scan.FilesScanned++
+		exempt := workspaceDriftRefExemptFile(rel)
+		for i, line := range strings.Split(string(data), "\n") {
+			for _, m := range workspaceRefSegmentRe.FindAllStringSubmatch(line, -1) {
+				// Trailing dots are sentence punctuation, not path chars.
+				seg := strings.TrimRight(m[1], ".")
+				if seg == "" {
+					continue
+				}
+				scan.Referenced[seg] = true
+				canonical, isAlias := workspaceCanonicalAliases[seg]
+				if !isAlias {
+					continue
+				}
+				scan.Referenced[canonical] = true
+				if exempt {
+					continue
+				}
+				perFile := aliasLines[rel]
+				if perFile == nil {
+					perFile = make(map[string][]int)
+					aliasLines[rel] = perFile
+				}
+				perFile[seg] = append(perFile[seg], i+1)
+			}
+		}
+		return nil
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/internal/eval/schema_drift_test.go
+++ b/cli/internal/eval/schema_drift_test.go
@@ -1,0 +1,139 @@
+package eval
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// compileEvalSchemaForTest loads a checked-in eval contract schema
+// (cwd = cli/internal/eval, so three levels up).
+func compileEvalSchemaForTest(t *testing.T, name string) *jsonschema.Schema {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "schemas", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read schema %s: %v", path, err)
+	}
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("parse schema %s: %v", name, err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource(name, doc); err != nil {
+		t.Fatalf("add schema resource %s: %v", name, err)
+	}
+	schema, err := compiler.Compile(name)
+	if err != nil {
+		t.Fatalf("compile schema %s: %v", name, err)
+	}
+	return schema
+}
+
+// TestRunRecord_ValidatesAgainstEvalRunSchema (LOAD-BEARING drift guard):
+// a run record produced by the production writer must validate against
+// schemas/eval-run.v1.schema.json. Without this, the Go writer and the
+// declared contract can fork silently — the same failure class the
+// verdict.v2 golden corpus closed for the Validate contract.
+func TestRunRecord_ValidatesAgainstEvalRunSchema(t *testing.T) {
+	dir := t.TempDir()
+	writeEvalFile(t, filepath.Join(dir, "fixture.txt"), "alpha\nneedle\nomega\n")
+	suitePath := writeEvalSuite(t, dir, `{
+  "schema_version": 1,
+  "id": "fixture.schema-drift",
+  "name": "Schema drift fixture",
+  "domain": "cli",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "correctness", "weight": 1, "threshold": 1}
+    ]
+  },
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {
+      "id": "contains",
+      "title": "fixture contains needle",
+      "kind": "artifact_check",
+      "objective": "Verify static fixtures are scored offline.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "fixture.txt", "value": "needle"}
+      ]
+    }
+  ]
+}`)
+
+	outPath := filepath.Join(dir, "run.json")
+	run, err := RunSuite(RunOptions{
+		SuitePath:  suitePath,
+		RunID:      "run-schema-drift",
+		OutputPath: outPath,
+		Now:        fixedEvalTime,
+	})
+	if err != nil {
+		t.Fatalf("RunSuite: %v", err)
+	}
+	if run == nil {
+		t.Fatal("RunSuite returned nil record")
+	}
+
+	// Validate the PERSISTED bytes, not a re-marshal: the on-disk artifact is
+	// the contract surface consumers read.
+	payload, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read persisted run record: %v", err)
+	}
+	var value any
+	if err := json.Unmarshal(payload, &value); err != nil {
+		t.Fatalf("persisted run record is not JSON: %v", err)
+	}
+	schema := compileEvalSchemaForTest(t, "eval-run.v1.schema.json")
+	if err := schema.Validate(value); err != nil {
+		t.Fatalf("persisted run record does not satisfy eval-run.v1.schema.json:\n%v", err)
+	}
+}
+
+// TestSuiteFixture_ValidatesAgainstEvalSuiteSchema pins the suite contract the
+// same way: the fixture accepted by the production loader must satisfy
+// schemas/eval-suite.v1.schema.json.
+func TestSuiteFixture_ValidatesAgainstEvalSuiteSchema(t *testing.T) {
+	var value any
+	if err := json.Unmarshal([]byte(`{
+  "schema_version": 1,
+  "id": "fixture.schema-drift",
+  "name": "Schema drift fixture",
+  "domain": "cli",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "scoring": {
+    "aggregate_threshold": 1,
+    "dimensions": [
+      {"name": "correctness", "weight": 1, "threshold": 1}
+    ]
+  },
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {
+      "id": "contains",
+      "title": "fixture contains needle",
+      "kind": "artifact_check",
+      "objective": "Verify static fixtures are scored offline.",
+      "expectations": [
+        {"type": "artifact_contains", "target": "fixture.txt", "value": "needle"}
+      ]
+    }
+  ]
+}`), &value); err != nil {
+		t.Fatal(err)
+	}
+	schema := compileEvalSchemaForTest(t, "eval-suite.v1.schema.json")
+	if err := schema.Validate(value); err != nil {
+		t.Fatalf("minimal suite fixture does not satisfy eval-suite.v1.schema.json:\n%v", err)
+	}
+}

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -37,10 +37,12 @@ unknown command (exit 1) and prints the matching replacement pointer from the
 table above; nothing forwards to old code or mutates old state.
 
 Other 3.2 bookkeeping and knowledge verbs (`ao beads`, `ao agents`, `ao canon`,
-`ao ci`, `ao citation`, `ao eval`, `ao findings`, `ao forge`, `ao knowledge`,
+`ao ci`, `ao citation`, `ao findings`, `ao forge`, `ao knowledge`,
 `ao mcp`, `ao metrics`, `ao notebook`, `ao patterns`, `ao pool`, `ao ratchet`,
 `ao registry`, `ao scope`, `ao sessions`, `ao wiki`) were pruned from the
-default build without tombstones. They have no replacement inside AgentOps; use
+default build without tombstones. (`ao eval` returned in 3.4 as the wired
+measurement surface — deterministic suites, locked Tasks, holdout scenarios —
+still with no lifecycle authority.) They have no replacement inside AgentOps; use
 the caller's own tools, `ao gate check` for deterministic checks, or generic
 `ao provenance` records.
 

--- a/docs/architecture/go-cli.md
+++ b/docs/architecture/go-cli.md
@@ -70,6 +70,23 @@ A gate PASS is a deterministic fact, not a semantic verdict.
   PASS. Evidence references are reported as declared strings; `ao status` does
   not resolve or digest-bind their targets.
 
+## Eval — the Learn seat
+
+`ao eval` is the measurement surface: the operating contract's "Learn"
+consumer, wired as `cmd/ao/eval_composition.go` → `internal/commands/eval` →
+`internal/eval` services → `internal/adapters/eval`. It runs deterministic
+suites (`schemas/eval-suite.v1.schema.json`) into durable run records
+(`schemas/eval-run.v1.schema.json`, drift-guarded by tests in
+`internal/eval`), compares runs, manages locked Tasks and holdout scenarios
+(`internal/evalsubstrate`; rubric projections are leak-guarded by
+`schemas/outcomes-rubric.v1.schema.json`, and true holdout rubrics live in
+the external measurement register, not this repo), and aggregates A/B arms.
+The scenario-ab treatment is environment-shaped: the with-gold arm may read
+the corpus, the control arm runs sandbox-confined away from every corpus
+root, and judges are always corpus-denied. Eval reports numbers only — it
+owns no retry, scheduling, promotion, or lifecycle authority, and an eval
+score is not a semantic verdict.
+
 ## Related pages
 
 - [Operating loop](operating-loop.md)

--- a/docs/cli-surface.json
+++ b/docs/cli-surface.json
@@ -101,6 +101,160 @@
     },
     {
       "category": "public-tested",
+      "command": "eval baseline",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Promotion logic covered by internal/eval baseline tests; composition covered by cmd/ao eval tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval baseline-audit",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Audit policy covered by internal/eval baseline_audit tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval cleanup",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Covered by internal/eval cleanup_service tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval compare",
+      "coverage_status": "covered",
+      "kind": "leaf",
+      "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval coverage",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Covered by internal/eval coverage tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval outcomes compile",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Covered by evalsubstrate rubric tests and module tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval outcomes ingest",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Covered by internal/eval outcomes_service tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval run",
+      "coverage_status": "covered",
+      "kind": "leaf",
+      "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval scenario add",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Covered by internal/scenario and module tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval scenario evaluate",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Covered by internal/eval scenario_service tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval scenario init",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Covered by internal/scenario and module tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval scenario list",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Covered by internal/scenario and module tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval scenario validate",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Covered by internal/scenario and module tests."
+    },
+    {
+      "category": "unsafe-live",
+      "command": "eval scenario-ab",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Spawns a live model runtime (codex exec) per arm; exercised by adapter tests with fakes, never in smoke."
+    },
+    {
+      "category": "unsafe-live",
+      "command": "eval scenario-moat",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Aggregates live scenario-ab cards; adapter-tested with fixtures."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval scorecard",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Covered by internal/eval scorecard tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval suite n-required",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Covered by internal/eval suite_service and module tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval suite verdict",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Covered by internal/eval suite_service and module tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval task add",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Covered by internal/eval task_service and module tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval task list",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Covered by internal/eval task_service and module tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval task run",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Covered by internal/eval task_service and module tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "eval task show",
+      "coverage_status": "allowlisted",
+      "kind": "leaf",
+      "reason": "Covered by internal/eval task_service and module tests."
+    },
+    {
+      "category": "public-tested",
       "command": "flywheel compare",
       "coverage_status": "covered",
       "kind": "leaf",

--- a/docs/cli-surface.md
+++ b/docs/cli-surface.md
@@ -18,6 +18,28 @@
 | `ao doctor ls` | `public-stateful-fixture-needed` | `allowlisted` | Lists local doctor artifacts. |
 | `ao doctor robot-docs` | `public-stateful-fixture-needed` | `allowlisted` | Generates docs from local installation state. |
 | `ao doctor undo` | `public-stateful-fixture-needed` | `allowlisted` | Reverts a doctor repair fixture. |
+| `ao eval baseline` | `public-tested` | `allowlisted` | Promotion logic covered by internal/eval baseline tests; composition covered by cmd/ao eval tests. |
+| `ao eval baseline-audit` | `public-tested` | `allowlisted` | Audit policy covered by internal/eval baseline_audit tests. |
+| `ao eval cleanup` | `public-tested` | `allowlisted` | Covered by internal/eval cleanup_service tests. |
+| `ao eval compare` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
+| `ao eval coverage` | `public-tested` | `allowlisted` | Covered by internal/eval coverage tests. |
+| `ao eval outcomes compile` | `public-tested` | `allowlisted` | Covered by evalsubstrate rubric tests and module tests. |
+| `ao eval outcomes ingest` | `public-tested` | `allowlisted` | Covered by internal/eval outcomes_service tests. |
+| `ao eval run` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
+| `ao eval scenario add` | `public-tested` | `allowlisted` | Covered by internal/scenario and module tests. |
+| `ao eval scenario evaluate` | `public-tested` | `allowlisted` | Covered by internal/eval scenario_service tests. |
+| `ao eval scenario init` | `public-tested` | `allowlisted` | Covered by internal/scenario and module tests. |
+| `ao eval scenario list` | `public-tested` | `allowlisted` | Covered by internal/scenario and module tests. |
+| `ao eval scenario validate` | `public-tested` | `allowlisted` | Covered by internal/scenario and module tests. |
+| `ao eval scenario-ab` | `unsafe-live` | `allowlisted` | Spawns a live model runtime (codex exec) per arm; exercised by adapter tests with fakes, never in smoke. |
+| `ao eval scenario-moat` | `unsafe-live` | `allowlisted` | Aggregates live scenario-ab cards; adapter-tested with fixtures. |
+| `ao eval scorecard` | `public-tested` | `allowlisted` | Covered by internal/eval scorecard tests. |
+| `ao eval suite n-required` | `public-tested` | `allowlisted` | Covered by internal/eval suite_service and module tests. |
+| `ao eval suite verdict` | `public-tested` | `allowlisted` | Covered by internal/eval suite_service and module tests. |
+| `ao eval task add` | `public-tested` | `allowlisted` | Covered by internal/eval task_service and module tests. |
+| `ao eval task list` | `public-tested` | `allowlisted` | Covered by internal/eval task_service and module tests. |
+| `ao eval task run` | `public-tested` | `allowlisted` | Covered by internal/eval task_service and module tests. |
+| `ao eval task show` | `public-tested` | `allowlisted` | Covered by internal/eval task_service and module tests. |
 | `ao flywheel compare` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao flywheel status` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao gate check` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=19 sub=54 all=73"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=19 sub=54 all=86"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=18 sub=41 all=59"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=19 sub=54 all=86"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=19 sub=54 all=86"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=19 sub=54 all=73"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 86 ]]; then
+if [[ "${#commands[@]}" -ne 73 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,4} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "19" || "$sub_count" != "54" || "$all_count" != "73" ]]; then
+if [[ "$top_count" != "19" || "$sub_count" != "54" || "$all_count" != "86" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 73 ]]; then
+if [[ "${#commands[@]}" -ne 86 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,4} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "18" || "$sub_count" != "41" || "$all_count" != "59" ]]; then
+if [[ "$top_count" != "19" || "$sub_count" != "54" || "$all_count" != "73" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 59 ]]; then
+if [[ "${#commands[@]}" -ne 86 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/scripts/cmdao-surface-allowlist.txt
+++ b/scripts/cmdao-surface-allowlist.txt
@@ -31,3 +31,28 @@ public-tested|provenance show|Covered by generic provenance read tests.
 public-tested|session handoff|Covered by handoff artifact tests.
 public-tested|session rehydrate|Covered by rehydrate artifact tests.
 
+
+# Eval measurement surface (the Learn seat). `run` and `compare` have direct
+# cmd/ao composition tests; the leaves below are behavior-tested in
+# internal/commands/eval/module_test.go and internal/eval service tests, and
+# the composition path they share is covered by the cmd/ao eval tests.
+public-tested|eval baseline|Promotion logic covered by internal/eval baseline tests; composition covered by cmd/ao eval tests.
+public-tested|eval baseline-audit|Audit policy covered by internal/eval baseline_audit tests.
+public-tested|eval cleanup|Covered by internal/eval cleanup_service tests.
+public-tested|eval coverage|Covered by internal/eval coverage tests.
+public-tested|eval scorecard|Covered by internal/eval scorecard tests.
+public-tested|eval task add|Covered by internal/eval task_service and module tests.
+public-tested|eval task list|Covered by internal/eval task_service and module tests.
+public-tested|eval task show|Covered by internal/eval task_service and module tests.
+public-tested|eval task run|Covered by internal/eval task_service and module tests.
+public-tested|eval suite verdict|Covered by internal/eval suite_service and module tests.
+public-tested|eval suite n-required|Covered by internal/eval suite_service and module tests.
+public-tested|eval outcomes compile|Covered by evalsubstrate rubric tests and module tests.
+public-tested|eval outcomes ingest|Covered by internal/eval outcomes_service tests.
+public-tested|eval scenario init|Covered by internal/scenario and module tests.
+public-tested|eval scenario add|Covered by internal/scenario and module tests.
+public-tested|eval scenario list|Covered by internal/scenario and module tests.
+public-tested|eval scenario validate|Covered by internal/scenario and module tests.
+public-tested|eval scenario evaluate|Covered by internal/eval scenario_service tests.
+unsafe-live|eval scenario-ab|Spawns a live model runtime (codex exec) per arm; exercised by adapter tests with fakes, never in smoke.
+unsafe-live|eval scenario-moat|Aggregates live scenario-ab cards; adapter-tested with fixtures.

--- a/scripts/lib/repo-root.sh
+++ b/scripts/lib/repo-root.sh
@@ -38,6 +38,15 @@ if ! declare -F resolve_repo_root >/dev/null 2>&1; then
 # not hijack the relative cd), not a botched assignment.
 resolve_repo_root() {
   local lib_dir root
+  # Explicit override — the TEST SEAM. Fixture suites run real scripts against
+  # a temp repo; without this they would resolve the real checkout and mutate
+  # it (the 2026-07-18 fixture-pollution class: phantom docs/evidence/ dirs and
+  # traffic.jsonl rows written by bats runs). Must name an existing directory.
+  if [ -n "${AGENTOPS_REPO_ROOT:-}" ] && [ -d "${AGENTOPS_REPO_ROOT}" ]; then
+    printf '%s
+' "${AGENTOPS_REPO_ROOT}"
+    return 0
+  fi
   # BASH_SOURCE[0] inside a function names the file the function was DEFINED
   # in — this library — regardless of who calls it.
   # shellcheck disable=SC1007

--- a/scripts/update-cli-surface-counts.sh
+++ b/scripts/update-cli-surface-counts.sh
@@ -33,7 +33,10 @@ fi
 
 actual_top="$(grep -Ec '^### `ao ' "$COMMANDS_PATH" || true)"
 actual_sub="$(grep -Ec '^#### `ao ' "$COMMANDS_PATH" || true)"
-actual_all="$(grep -Ec '^#{3,4} `ao ' "$COMMANDS_PATH" || true)"
+# all spans every command heading depth (###..#####); eval task/suite/scenario
+# children are the first three-level-deep commands (##### headings). Keep in
+# lockstep with scripts/regen-command-surfaces.sh.
+actual_all="$(grep -Ec '^#{3,5} `ao ' "$COMMANDS_PATH" || true)"
 
 smoke_line="$(grep -E '^\s*if \[\[ "\$top_count"' "$SMOKE_PATH" 2>/dev/null || true)"
 smoke_top="$(echo "$smoke_line" | sed -nE 's/.*"\$top_count" != "([0-9]+)".*/\1/p')"

--- a/tests/scripts/capture-repo-metrics.bats
+++ b/tests/scripts/capture-repo-metrics.bats
@@ -12,6 +12,9 @@ setup() {
     SCRIPT="$REPO_ROOT/scripts/capture-repo-metrics.sh"
     FIX="$BATS_TEST_TMPDIR/repo"
     mkdir -p "$FIX/bin"
+    # repo-root.sh resolves the REAL checkout unless overridden; without this
+    # the script under test writes into the live repo (fixture-pollution class).
+    export AGENTOPS_REPO_ROOT="$FIX"
     git -C "$FIX" init -q 2>/dev/null || { mkdir -p "$FIX"; git -C "$FIX" init -q; }
     git -C "$FIX" config user.email t@t.t
     git -C "$FIX" config user.name t

--- a/tests/scripts/check-provenance-merge-sha.bats
+++ b/tests/scripts/check-provenance-merge-sha.bats
@@ -7,6 +7,8 @@ setup() {
   TMP="$(mktemp -d)"
   ORIG_DIR="$PWD"
   cd "$TMP"
+  # Route repo-root.sh's resolution at the fixture, not the live checkout.
+  export AGENTOPS_REPO_ROOT="$TMP"
   export GIT_TEMPLATE_DIR=""
   git init -q
   git config user.email t@t.t

--- a/tests/scripts/check-removed-symbol-refs.bats
+++ b/tests/scripts/check-removed-symbol-refs.bats
@@ -10,8 +10,9 @@ setup() {
     git init -b main "$WORK_REPO" >/dev/null
     git -C "$WORK_REPO" config user.name "Test User"
     git -C "$WORK_REPO" config user.email "test@example.com"
-    mkdir -p "$WORK_REPO/scripts" "$WORK_REPO/docs/releases" "$WORK_REPO/docs" "$WORK_REPO/skills/example" "$WORK_REPO/tests"
+    mkdir -p "$WORK_REPO/scripts/lib" "$WORK_REPO/docs/releases" "$WORK_REPO/docs" "$WORK_REPO/skills/example" "$WORK_REPO/tests"
     cp "$SCRIPT" "$WORK_REPO/scripts/check-removed-symbol-refs.sh"
+    cp "$BATS_TEST_DIRNAME/../../scripts/lib/repo-root.sh" "$WORK_REPO/scripts/lib/repo-root.sh"
     chmod +x "$WORK_REPO/scripts/check-removed-symbol-refs.sh"
 }
 

--- a/tests/scripts/export-evidence.bats
+++ b/tests/scripts/export-evidence.bats
@@ -9,6 +9,8 @@ setup() {
 
   git init --quiet --initial-branch=main "$TMP/repo"
   cd "$TMP/repo"
+  # Route repo-root.sh's resolution at the fixture, not the live checkout.
+  export AGENTOPS_REPO_ROOT="$TMP/repo"
   git config user.email t@t.test
   git config user.name tester
   git commit --quiet --allow-empty -m "initial"


### PR DESCRIPTION
Registers the fully-built-but-never-wired eval module into the CLI spine and repairs its one real instrument bug. Three commits, RPI-shaped: wire + fix, drift guards + docs, fixture counts.

## What
- **`ao eval` joins the spine** (cmd/ao/eval_composition.go): deterministic suite runs, run-record compare/baseline/scorecard/coverage, locked Tasks, holdout scenarios, suite A/B verdicts with power-derived n-required, and the holdout-safe Outcomes projection. This is the operating contract's *Learn* seat — a read/measure consumer of evidence. It reports numbers and owns no retry, scheduling, promotion, or lifecycle authority. The retired Aliases/Bench seats stay nil and their subcommands are omitted.
- **Instrument bug fixed**: both scenario-ab arms were corpus-denied at runtime — the with-gold treatment was only a prompt injection through the retired `ao lookup`, so the A/B silently guaranteed a zero delta. Treatment is now environment-shaped: the with-gold arm runs with the corpus readable, the control arm stays sandbox-confined (the fail-closed empty-deny guard is untouched), and judges are always corpus-denied.
- **Schema drift guards**: a run record persisted by the production writer must validate against eval-run.v1.schema.json (and the minimal suite against eval-suite.v1.schema.json) — closing the same silent-fork class the verdict.v2 golden corpus closed.
- **Hermetic test builds hardened**: keep the real HOME's Go caches (TestMain isolation was forcing module re-downloads) and skip VCS stamping.
- docs/architecture/go-cli.md gains the eval section; MIGRATION.md notes `ao eval`'s return; COMMANDS.md, cli-surface, and surface counts regenerated; new leaves carry honest allowlist reasons; new cmd/ao L2 tests drive eval run/compare/help through the full production wiring.

## Evidence
- Full cli suite 2,801 green; race green on cmd/ao + the eval island; vet clean
- Full-tier gate: 65/66 on the penultimate commit; the single failure (surface counts) is the final fixture commit, re-verified PASS standalone — no other check reads those fixtures
- Fresh independent validation (Codex, frozen subject 86022a3c6, clean tree at start and end): **OVERALL PASS**, 6/6 — including a live end-to-end `ao eval run` producing a passing run record
- Rubric-relocation decision honored: true holdout rubrics live in the external measurement register; the repo keeps only leak-guarded projections