### PR TITLE
fix: kill the shared-config gremlin class (hook-safe repo-root, git-env scrubbing, config-hygiene gate)

### DIFF
--- a/cli/cmd/ao/git_read.go
+++ b/cli/cmd/ao/git_read.go
@@ -9,9 +9,11 @@ import (
 	"time"
 )
 
-// gitDiscoveryEnv strips GIT_DIR/GIT_WORK_TREE/GIT_COMMON_DIR from the
-// environment so read-only git discovery resolves the repository from the
-// working directory, never from a leaked parent-process override.
+// gitDiscoveryEnv strips GIT_DIR/GIT_WORK_TREE/GIT_COMMON_DIR/GIT_INDEX_FILE
+// from the environment so git discovery resolves the repository from the
+// working directory, never from a leaked parent-process override. A hook-leaked
+// GIT_DIR is not just a read hazard: a "scoped" `git -C <dir> config ...` under
+// it writes the LEAKED repo's shared config (age-gate-scripts-worktree-gitdir-p62wo).
 func gitDiscoveryEnv() []string {
 	env := make([]string, 0, len(os.Environ()))
 	for _, entry := range os.Environ() {
@@ -21,6 +23,8 @@ func gitDiscoveryEnv() []string {
 		case strings.HasPrefix(entry, "GIT_WORK_TREE="):
 			continue
 		case strings.HasPrefix(entry, "GIT_COMMON_DIR="):
+			continue
+		case strings.HasPrefix(entry, "GIT_INDEX_FILE="):
 			continue
 		default:
 			env = append(env, entry)

--- a/cli/cmd/ao/testutil_test.go
+++ b/cli/cmd/ao/testutil_test.go
@@ -494,14 +494,15 @@ func initHistoryFixtureGitRepo(t *testing.T, dir string) {
 }
 
 // runFixtureGit executes a git command in dir with optional extra environment
-// variables. Fatals the test on any non-zero exit.
+// variables. Fatals the test on any non-zero exit. Always scrubs git's
+// repo-discovery env (gitDiscoveryEnv): under a hook-leaked GIT_DIR, cmd.Dir
+// alone does NOT scope the command — `git config user.name Test` would write
+// the LEAKED repo's shared config (age-gate-scripts-worktree-gitdir-p62wo).
 func runFixtureGit(t *testing.T, dir string, extraEnv []string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
-	if len(extraEnv) > 0 {
-		cmd.Env = append(os.Environ(), extraEnv...)
-	}
+	cmd.Env = append(gitDiscoveryEnv(), extraEnv...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)

--- a/cli/internal/archcheck/checker_test.go
+++ b/cli/internal/archcheck/checker_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -523,9 +524,29 @@ func writeFixture(t *testing.T, path string, data []byte) {
 	}
 }
 
+// scrubbedGitEnv returns os.Environ() minus git's repo-discovery overrides
+// (GIT_DIR et al.): under a hook-leaked GIT_DIR, `git -C <tmpdir>` alone does
+// NOT scope a mutation — `git config user.name Test` would write the LEAKED
+// repo's shared config (age-gate-scripts-worktree-gitdir-p62wo;
+// .claude/rules/go.md test isolation).
+func scrubbedGitEnv() []string {
+	env := make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "GIT_DIR=") ||
+			strings.HasPrefix(entry, "GIT_WORK_TREE=") ||
+			strings.HasPrefix(entry, "GIT_COMMON_DIR=") ||
+			strings.HasPrefix(entry, "GIT_INDEX_FILE=") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return env
+}
+
 func runFixtureGit(t *testing.T, root string, args ...string) {
 	t.Helper()
 	command := exec.Command("git", append([]string{"-C", root}, args...)...)
+	command.Env = scrubbedGitEnv()
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, output)
 	}
@@ -534,6 +555,7 @@ func runFixtureGit(t *testing.T, root string, args ...string) {
 func fixtureGitOutput(t *testing.T, root string, args ...string) string {
 	t.Helper()
 	command := exec.Command("git", append([]string{"-C", root}, args...)...)
+	command.Env = scrubbedGitEnv()
 	output, err := command.Output()
 	if err != nil {
 		t.Fatal(err)

--- a/cli/internal/eval/engine_test.go
+++ b/cli/internal/eval/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -390,10 +391,30 @@ func writeEvalFile(t *testing.T, path, body string) {
 	}
 }
 
+// scrubbedGitEnv returns os.Environ() minus git's repo-discovery overrides
+// (GIT_DIR et al.): under a hook-leaked GIT_DIR, cmd.Dir alone does NOT scope
+// a mutation — `git config user.name Tester` would write the LEAKED repo's
+// shared config (age-gate-scripts-worktree-gitdir-p62wo; .claude/rules/go.md
+// test isolation).
+func scrubbedGitEnv() []string {
+	env := make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "GIT_DIR=") ||
+			strings.HasPrefix(entry, "GIT_WORK_TREE=") ||
+			strings.HasPrefix(entry, "GIT_COMMON_DIR=") ||
+			strings.HasPrefix(entry, "GIT_INDEX_FILE=") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return env
+}
+
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
+	cmd.Env = scrubbedGitEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v failed: %v\n%s", args, err, out)
 	}

--- a/cli/internal/gates/checks/git_config_hygiene.go
+++ b/cli/internal/gates/checks/git_config_hygiene.go
@@ -1,0 +1,21 @@
+package checks
+
+import "github.com/boshu2/agentops/cli/internal/gates"
+
+// init registers the git-config hygiene gate
+// (age-gate-scripts-worktree-gitdir-p62wo): the shared repo config must not
+// carry core.bare=true (breaks every linked-worktree git op) or a known
+// test/fixture identity (Test/test@test.com, factory@example.invalid,
+// pokki-deploy/v@v.com — mis-authors rebased commits). Both poisonings are
+// written by hook-leaked GIT_DIR redirecting "scoped" git writes into the
+// shared config, so the mutation lives in .git/ where changed-file routing can
+// never see it — always-run, no path globs, like workflow.install-drift. The
+// backing script is a <150ms config read, so it stays in the fast tier.
+func init() {
+	gates.Register(gates.Check{
+		ID:       "always.git-config-hygiene",
+		Tiers:    gates.Fast | gates.Full,
+		Blocking: true,
+		Backing:  "check-git-config-hygiene.sh",
+	})
+}

--- a/cli/internal/gates/checks/git_config_hygiene_test.go
+++ b/cli/internal/gates/checks/git_config_hygiene_test.go
@@ -1,0 +1,34 @@
+package checks
+
+import (
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/gates"
+)
+
+// TestGitConfigHygieneRegistration asserts the exact registration shape of the
+// always.git-config-hygiene gate (age-gate-scripts-worktree-gitdir-p62wo):
+// always-run (no path globs — the poisoning lives in .git/, invisible to
+// changed-file routing), blocking, Fast|Full, backed by
+// check-git-config-hygiene.sh.
+func TestGitConfigHygieneRegistration(t *testing.T) {
+	c, ok := gates.Default.Get("always.git-config-hygiene")
+	if !ok {
+		t.Fatal("always.git-config-hygiene is not registered in gates.Default")
+	}
+	if !c.Blocking {
+		t.Error("always.git-config-hygiene must be Blocking")
+	}
+	if c.Backing != "check-git-config-hygiene.sh" {
+		t.Errorf("always.git-config-hygiene Backing = %q, want check-git-config-hygiene.sh", c.Backing)
+	}
+	if !c.Tiers.Has(gates.Fast) {
+		t.Errorf("always.git-config-hygiene Tiers = %v, want Fast included", c.Tiers)
+	}
+	if !c.Tiers.Has(gates.Full) {
+		t.Errorf("always.git-config-hygiene Tiers = %v, want Full included", c.Tiers)
+	}
+	if len(c.Match) != 0 {
+		t.Errorf("always.git-config-hygiene must be always-run (empty path globs — the mutation lives in .git/config); got %v", c.Match)
+	}
+}

--- a/cli/internal/quality/skills_codex_test.go
+++ b/cli/internal/quality/skills_codex_test.go
@@ -149,11 +149,32 @@ func TestCheckSkillsWarnsForOverlappingInstallLayouts(t *testing.T) {
 	}
 }
 
+// scrubbedGitEnv returns os.Environ() minus git's repo-discovery overrides
+// (GIT_DIR et al.): under a hook-leaked GIT_DIR, `git -C <tmpdir>` alone does
+// NOT scope a mutation — `git config user.name Test` would write the LEAKED
+// repo's shared config (age-gate-scripts-worktree-gitdir-p62wo;
+// .claude/rules/go.md test isolation).
+func scrubbedGitEnv() []string {
+	env := make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "GIT_DIR=") ||
+			strings.HasPrefix(entry, "GIT_WORK_TREE=") ||
+			strings.HasPrefix(entry, "GIT_COMMON_DIR=") ||
+			strings.HasPrefix(entry, "GIT_INDEX_FILE=") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return env
+}
+
 func setupCodexSyncRepo(t *testing.T) (string, string, string) {
 	t.Helper()
 	repo := t.TempDir()
 	for _, args := range [][]string{{"init"}, {"config", "user.email", "test@example.com"}, {"config", "user.name", "Test"}} {
-		if output, err := exec.Command("git", append([]string{"-C", repo}, args...)...).CombinedOutput(); err != nil {
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		cmd.Env = scrubbedGitEnv()
+		if output, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("git %v: %v\n%s", args, err, output)
 		}
 	}

--- a/scripts/capture-repo-metrics.sh
+++ b/scripts/capture-repo-metrics.sh
@@ -22,7 +22,9 @@
 # is missing/unauthenticated or any endpoint cannot be fetched.
 set -euo pipefail
 
-repo_root="$(git rev-parse --show-toplevel)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+repo_root="$(resolve_repo_root)"
 slug="boshu2/agentops"
 dry_run=0
 for arg in "$@"; do

--- a/scripts/check-bdd-foundry-markers.sh
+++ b/scripts/check-bdd-foundry-markers.sh
@@ -13,7 +13,9 @@
 # floor SET is unchanged.
 set -euo pipefail
 
-repo_root="$(git rev-parse --show-toplevel)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+repo_root="$(resolve_repo_root)"
 candidate="${1:-$repo_root/.claude/workflows/bdd-foundry.js}"
 if [ ! -f "$candidate" ]; then
   echo "FAIL: candidate file not found: $candidate"

--- a/scripts/check-codex-parity-drift.sh
+++ b/scripts/check-codex-parity-drift.sh
@@ -4,7 +4,9 @@
 # Exit 0 = pass (no drift), exit 1 = fail (drift detected)
 set -euo pipefail
 
-ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Not in a git repo"; exit 1; }
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+ROOT=$(resolve_repo_root)
 
 AUDIT_PY="$ROOT/scripts/audit-codex-parity.py"
 if [[ ! -f "$AUDIT_PY" ]]; then

--- a/scripts/check-flywheel-compounding.sh
+++ b/scripts/check-flywheel-compounding.sh
@@ -7,7 +7,9 @@
 # Exit 0 = PASS, Exit 1 = FAIL.
 set -euo pipefail
 
-REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+REPO_ROOT="${REPO_ROOT:-$(resolve_repo_root)}"
 
 # Prefer the local ao build if one already exists; fall back to a scratch
 # build in /tmp so this gate works on fresh checkouts.

--- a/scripts/check-git-config-hygiene.sh
+++ b/scripts/check-git-config-hygiene.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# check-git-config-hygiene.sh — fail-closed guard against shared-repo git
+# config poisoning (bead age-gate-scripts-worktree-gitdir-p62wo, gremlins 2+3).
+#
+# WHY: git hooks export GIT_DIR. Any child process that inherits that env and
+# runs repo-mutating git commands "scoped" only by cwd/-C/cmd.Dir actually
+# writes THE SHARED CONFIG of the leaked repo (empirically verified):
+#   * `git init --bare` (no directory argument) re-initializes $GIT_DIR and
+#     sets core.bare=true in the shared config — which breaks every git
+#     operation in every linked worktree (observed 3x on 2026-07-18);
+#   * `git -C <tmpdir> config user.name Test` writes user.name=Test into the
+#     shared config, mis-authoring every subsequent commit/rebase (the
+#     Test/test@test.com and pokki-deploy/v@v.com identity traps).
+# This gate makes the poisoning loud at the next push instead of latent.
+#
+# WHAT (fail = exit 1, crisp message + repair command):
+#   1. effective core.bare=true on a non-bare checkout;
+#   2. effective user.name/user.email matching a known test/fixture identity:
+#      Test / test@test.com / test@example.com / factory@example.invalid /
+#      pokki-deploy / v@v.com.
+#   INFO only (never fails): effective user.email differing from the repo's
+#   dominant recent author.
+#
+# Usage:
+#   bash scripts/check-git-config-hygiene.sh              # check this repo
+#   bash scripts/check-git-config-hygiene.sh <repo-dir>   # check another repo
+#   bash scripts/check-git-config-hygiene.sh --self-test  # prove FAIL on a
+#                                                         # poisoned fixture
+#
+# Exit codes: 0 clean / self-test passed; 1 hygiene violation or self-test
+# failure; 127 missing git.
+
+# shellcheck disable=SC1007
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/preamble.sh"
+
+require_cmd git
+
+PROG="check-git-config-hygiene"
+
+note() { printf '[%s] %s\n' "$PROG" "$*"; }
+
+# effective_cfg REPO KEY → the value git resolves for KEY from inside REPO,
+# with hook-injected discovery env scrubbed so we inspect REPO itself, not a
+# leaked GIT_DIR target. Empty when unset.
+effective_cfg() {
+  local repo="$1" key="$2"
+  (
+    unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_OBJECT_DIRECTORY GIT_COMMON_DIR GIT_NAMESPACE
+    git -C "$repo" config --get "$key" 2>/dev/null
+  ) || true
+}
+
+# common_config_path REPO → the shared config file the poisoning lands in
+# (worktree-aware). Falls back to <repo>/.git/config when git itself is too
+# broken to answer (e.g. core.bare=true already poisoned).
+common_config_path() {
+  local repo="$1" common
+  common="$(
+    unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_OBJECT_DIRECTORY GIT_COMMON_DIR GIT_NAMESPACE
+    git -C "$repo" rev-parse --path-format=absolute --git-common-dir 2>/dev/null
+  )" || common=""
+  if [ -n "$common" ]; then
+    printf '%s/config\n' "$common"
+  else
+    printf '%s/.git/config\n' "$repo"
+  fi
+}
+
+# check_repo REPO → run all hygiene checks against REPO. Returns 1 on any
+# blocking violation.
+check_repo() {
+  local repo="$1" rc=0 cfg bare name email
+  cfg="$(common_config_path "$repo")"
+
+  # 1. core.bare poisoning. Direct file read first (a poisoned repo can make
+  #    `git -C` itself fail), effective-config read as backup.
+  bare="$(git config --file "$cfg" --get core.bare 2>/dev/null || true)"
+  [ -n "$bare" ] || bare="$(effective_cfg "$repo" core.bare)"
+  if [ "$bare" = "true" ]; then
+    note "FAIL: core.bare=true in $cfg — this is a checkout, not a bare repo; every linked-worktree git op will fail."
+    note "  Likely writer: a no-dir-arg 'git init --bare' run with a hook-leaked GIT_DIR."
+    note "  repair: git config --file '$cfg' core.bare false"
+    rc=1
+  fi
+
+  # 2. Known test/fixture identities in the effective config.
+  name="$(effective_cfg "$repo" user.name)"
+  email="$(effective_cfg "$repo" user.email)"
+  case "$name" in
+    Test|pokki-deploy)
+      note "FAIL: user.name='$name' is a known test/fixture identity leaked into the effective git config."
+      note "  repair: git config --file '$cfg' --unset user.name   (then verify: git -C '$repo' config user.name)"
+      rc=1
+      ;;
+  esac
+  case "$email" in
+    test@test.com|test@example.com|factory@example.invalid|v@v.com)
+      note "FAIL: user.email='$email' is a known test/fixture identity leaked into the effective git config."
+      note "  repair: git config --file '$cfg' --unset user.email   (then verify: git -C '$repo' config user.email)"
+      rc=1
+      ;;
+  esac
+
+  # 3. INFO only: effective identity vs the repo's dominant recent author.
+  #    Never fails — multiple legit identities exist (bushido, worktrees).
+  if [ -n "$email" ] && [ "$rc" -eq 0 ]; then
+    local dominant
+    dominant="$(
+      unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_OBJECT_DIRECTORY GIT_COMMON_DIR GIT_NAMESPACE
+      git -C "$repo" log -n 200 --no-merges --format='%ae' 2>/dev/null |
+        sort | uniq -c | sort -rn | head -n1 | awk '{print $2}'
+    )" || dominant=""
+    if [ -n "$dominant" ] && [ "$email" != "$dominant" ]; then
+      note "INFO: effective user.email='$email' differs from dominant recent author '$dominant' (informational only)."
+    fi
+  fi
+
+  return "$rc"
+}
+
+self_test() {
+  local fixdir rc=0
+  with_tmpdir fixdir git-config-hygiene-selftest
+
+  # Poisoned fixture: core.bare=true + Test identity in the repo config.
+  git -C "$fixdir" init -q
+  git -C "$fixdir" config core.bare true
+  git -C "$fixdir" config user.name Test
+  git -C "$fixdir" config user.email test@test.com
+  if check_repo "$fixdir" >/dev/null 2>&1; then
+    note "SELF-TEST FAIL: poisoned fixture (core.bare=true + Test identity) was NOT flagged"
+    rc=1
+  else
+    note "self-test: poisoned fixture correctly flagged"
+  fi
+  # Repair the fixture the way the FAIL message instructs, then it must pass.
+  git config --file "$fixdir/.git/config" core.bare false
+  git config --file "$fixdir/.git/config" --unset user.name
+  git config --file "$fixdir/.git/config" --unset user.email
+  if check_repo "$fixdir" >/dev/null 2>&1; then
+    note "self-test: repaired fixture correctly passes"
+  else
+    note "SELF-TEST FAIL: repaired fixture still flagged"
+    rc=1
+  fi
+
+  if [ "$rc" -eq 0 ]; then
+    note "PASS: self-test"
+  fi
+  return "$rc"
+}
+
+case "${1:-}" in
+  --self-test)
+    self_test
+    exit "$?"
+    ;;
+  -h|--help)
+    sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *)
+    target="${1:-$REPO_ROOT}"
+    if check_repo "$target"; then
+      note "OK: git config hygiene clean for $target"
+      exit 0
+    fi
+    exit 1
+    ;;
+esac

--- a/scripts/check-memrl-health.sh
+++ b/scripts/check-memrl-health.sh
@@ -12,7 +12,9 @@ set -euo pipefail
 # Exit 0: all links healthy
 # Exit 1: one or more links broken
 
-ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+ROOT="${1:-$(resolve_repo_root)}"
 
 failures=0
 

--- a/scripts/check-mutation-route-coverage.sh
+++ b/scripts/check-mutation-route-coverage.sh
@@ -20,12 +20,9 @@
 
 set -euo pipefail
 
-if REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" && [[ -n "$REPO_ROOT" ]]; then
-    :
-else
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-fi
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+REPO_ROOT="$(resolve_repo_root)"
 SERVER_DIR="$REPO_ROOT/cli/internal/daemon"
 
 if [[ ! -d "$SERVER_DIR" ]]; then

--- a/scripts/check-no-daemonized-wake.sh
+++ b/scripts/check-no-daemonized-wake.sh
@@ -20,7 +20,9 @@
 
 set -euo pipefail
 
-ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+ROOT="${1:-$(resolve_repo_root)}"
 BRIDGE="ntm-attention-tend"
 note() { printf '[check-no-daemonized-wake] %s\n' "$*" >&2; }
 

--- a/scripts/check-no-operator-skills.sh
+++ b/scripts/check-no-operator-skills.sh
@@ -59,13 +59,13 @@ done
 
 log() { [ "$QUIET" -eq 1 ] || printf '%s\n' "$*"; }
 
-# Resolve repo root: explicit arg, else git toplevel, else script's parent dir.
+# Resolve repo root: explicit arg, else hook-safe lib resolution (git
+# toplevel with scrubbed env, falling back to the lib's parent checkout).
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
 resolve_root() {
   if [ -n "$ROOT" ]; then printf '%s' "$ROOT"; return; fi
-  if git rev-parse --show-toplevel >/dev/null 2>&1; then
-    git rev-parse --show-toplevel; return
-  fi
-  cd "$(dirname "$0")/.." && pwd
+  resolve_repo_root
 }
 
 run_audit() {

--- a/scripts/check-no-tracked-agents.sh
+++ b/scripts/check-no-tracked-agents.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
 if [[ -n "${NO_TRACKED_AGENTS_REPO_ROOT:-}" ]]; then
   REPO_ROOT="$(cd "$NO_TRACKED_AGENTS_REPO_ROOT" && pwd)"
 else
-  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  REPO_ROOT="$(resolve_repo_root)"
 fi
 
 # The one declarative exception: the AgentOps project config is repo

--- a/scripts/check-paths-resolver-coverage.sh
+++ b/scripts/check-paths-resolver-coverage.sh
@@ -28,7 +28,9 @@
 
 set -uo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+REPO_ROOT="$(resolve_repo_root)"
 cd "$REPO_ROOT" 2>/dev/null || exit 0
 
 SURFACES=("cli/cmd/ao" "cli/internal" "hooks" "lib" "scripts")

--- a/scripts/check-proof-coherence.sh
+++ b/scripts/check-proof-coherence.sh
@@ -57,7 +57,9 @@ set -euo pipefail
 
 PROG="check-proof-coherence"
 
-repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+repo_root="$(resolve_repo_root)"
 
 ledger=""
 events=""

--- a/scripts/check-provenance-merge-sha.sh
+++ b/scripts/check-provenance-merge-sha.sh
@@ -7,7 +7,9 @@
 #   2 = script error
 set -uo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+REPO_ROOT="$(resolve_repo_root)"
 LEDGER="${PROVENANCE_LEDGER:-$REPO_ROOT/docs/provenance/ledger.jsonl}"
 TRUNK="${AGENTOPS_PROVENANCE_TRUNK_REF:-origin/main}"
 STRICT="${AGENTOPS_PROVENANCE_MERGE_SHA_STRICT:-0}"

--- a/scripts/check-quarantine-empty.sh
+++ b/scripts/check-quarantine-empty.sh
@@ -10,7 +10,9 @@
 # Exit 0 = pass (empty or override), exit 1 = fail (populated without override).
 set -euo pipefail
 
-ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Not in a git repo"; exit 1; }
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+ROOT=$(resolve_repo_root)
 QDIR="$ROOT/tests/_quarantine"
 
 if [[ "${ALLOW_QUARANTINE:-0}" == "1" ]]; then

--- a/scripts/check-release-parity.sh
+++ b/scripts/check-release-parity.sh
@@ -91,12 +91,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Resolve the repo root.
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
 if [[ -z "$REPO_ROOT" ]]; then
-    if REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
-        :
-    else
-        REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-    fi
+    REPO_ROOT="$(resolve_repo_root)"
 fi
 if [[ ! -d "$REPO_ROOT" ]]; then
     fail "repo root does not exist: $REPO_ROOT"

--- a/scripts/check-removed-symbol-refs.sh
+++ b/scripts/check-removed-symbol-refs.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck disable=SC1007,SC1091
+. "$SCRIPT_DIR/lib/repo-root.sh"
 MODE="fixed"
 SYMBOLS=()
 EXCLUDES=()
@@ -71,6 +73,9 @@ done
 
 cd "$REPO_ROOT"
 
+# Scrub hook-injected git env so the check (and every git call below) binds
+# to THIS checkout, not a leaked GIT_DIR (age-gate-scripts-worktree-gitdir-p62wo).
+scrub_git_env
 if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
     die "not inside a git repository: $REPO_ROOT"
 fi

--- a/scripts/check-retrieval-manifest-paths.sh
+++ b/scripts/check-retrieval-manifest-paths.sh
@@ -32,7 +32,9 @@ if ! command -v git >/dev/null 2>&1; then
     exit 2
 fi
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+REPO_ROOT="$(resolve_repo_root)"
 
 fail=0
 total=0

--- a/scripts/check-skill-size.sh
+++ b/scripts/check-skill-size.sh
@@ -12,7 +12,9 @@
 #   WARN_LINES=400 scripts/check-skill-size.sh
 set -euo pipefail
 
-ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Not in a git repo"; exit 1; }
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+ROOT=$(resolve_repo_root)
 cd "$ROOT"
 
 WARN_LINES=${WARN_LINES:-500}

--- a/scripts/check-test-fixture-parity.sh
+++ b/scripts/check-test-fixture-parity.sh
@@ -24,9 +24,11 @@ if [[ "${AGENTOPS_PARITY_GATE_DISABLED:-}" == "1" ]]; then
     exit 0
 fi
 
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
 ROOT="${1:-}"
 if [[ -z "$ROOT" ]]; then
-    ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+    ROOT="$(resolve_repo_root)"
 fi
 
 HOOKS_DIR="$ROOT/hooks"

--- a/scripts/check-test-isolation.sh
+++ b/scripts/check-test-isolation.sh
@@ -52,7 +52,44 @@ if [ "$chdir" -lt "$BASELINE_CHDIR" ] || [ "$setenv" -lt "$BASELINE_SETENV" ]; t
   echo "      Lower BASELINE_CHDIR/BASELINE_SETENV in $(basename "$0") to lock the gain."
 fi
 
+# --- git-exec env-scrub rule (age-gate-scripts-worktree-gitdir-p62wo) ---
+# A *_test.go that shells out to git with cmd.Dir/-C but an INHERITED env is not
+# isolated: git hooks export GIT_DIR, and under that leak a "scoped"
+# `git config user.name Test` writes the LEAKED repo's shared config, and a
+# no-dir-arg `git init --bare` sets core.bare=true there (both observed
+# 2026-07-18; both empirically verified). House pattern: build the child env
+# from os.Environ() minus GIT_DIR/GIT_WORK_TREE/GIT_COMMON_DIR/GIT_INDEX_FILE
+# (see gitDiscoveryEnv in cli/cmd/ao/git_read.go and the scrubbedGitEnv test
+# helpers).
+#
+# WARN-only ratchet for now: 3 legacy files predate the rule (projectdir_test,
+# check_runtime_test, measure_cwd_test — read-mostly, but the init calls are
+# still exposed). Flip to FAIL (rc=1) once GIT_WARN_BASELINE reaches 0 and
+# stays there — like BASELINE_CHDIR above, the count only goes DOWN.
+GIT_WARN_BASELINE=3
+git_offenders=""
+while IFS= read -r f; do
+  # A file that execs git must carry an env-scrub marker: its own scrubbed-env
+  # helper, the cmd/ao production helper, or an explicit Env assignment.
+  if ! grep -qE 'scrubbedGitEnv|gitDiscoveryEnv|\.Env = ' "$f"; then
+    git_offenders="$git_offenders$f"$'\n'
+  fi
+done < <(grep -rl --include='*_test.go' 'exec\.Command(\(ctx, \)\?"git"' cli 2>/dev/null || true)
+git_count=$(printf '%s' "$git_offenders" | grep -c . || true)
+if [ "$git_count" -gt "$GIT_WARN_BASELINE" ]; then
+  echo "FAIL: *_test.go files exec-ing git WITHOUT env scrubbing rose to $git_count (baseline $GIT_WARN_BASELINE):"
+  printf '%s' "$git_offenders" | sed 's/^/      /'
+  echo "      Build cmd.Env from os.Environ() minus GIT_DIR/GIT_WORK_TREE/GIT_COMMON_DIR/GIT_INDEX_FILE"
+  echo "      (copy the scrubbedGitEnv helper; see cli/cmd/ao/git_read.go gitDiscoveryEnv)."
+  rc=1
+elif [ "$git_count" -gt 0 ]; then
+  echo "WARN: $git_count *_test.go file(s) exec git without env scrubbing (baseline $GIT_WARN_BASELINE, ratchet-only):"
+  printf '%s' "$git_offenders" | sed 's/^/      /'
+elif [ "$git_count" -lt "$GIT_WARN_BASELINE" ]; then
+  echo "NOTE: git env-scrub ratchet improved ($git_count<=$GIT_WARN_BASELINE). Lower GIT_WARN_BASELINE to lock the gain."
+fi
+
 if [ "$rc" -eq 0 ]; then
-  echo "PASS: test-isolation ratchet (os.Chdir=$chdir/$BASELINE_CHDIR, os.Setenv=$setenv/$BASELINE_SETENV)"
+  echo "PASS: test-isolation ratchet (os.Chdir=$chdir/$BASELINE_CHDIR, os.Setenv=$setenv/$BASELINE_SETENV, git-unscrubbed=$git_count/$GIT_WARN_BASELINE)"
 fi
 exit "$rc"

--- a/scripts/check-workflow-drift.sh
+++ b/scripts/check-workflow-drift.sh
@@ -15,7 +15,9 @@
 # Repo root from cwd git; installed dir from $HOME. No hardcoded user paths.
 set -euo pipefail
 
-repo_root="$(git rev-parse --show-toplevel)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+repo_root="$(resolve_repo_root)"
 canon_dir="$repo_root/.claude/workflows"
 inst_dir="$HOME/.claude/workflows"
 blocking_name="bdd-foundry.js"

--- a/scripts/export-evidence.sh
+++ b/scripts/export-evidence.sh
@@ -46,7 +46,9 @@ if [ ! -r "$SRC" ]; then
   exit 3
 fi
 
-ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+ROOT="$(resolve_repo_root)"
 DEST_DIR="$ROOT/docs/evidence/$BEAD_ID"
 DEST_PATH="$DEST_DIR/$DEST_NAME"
 mkdir -p "$DEST_DIR"

--- a/scripts/install-installed-skill-edit-guard.sh
+++ b/scripts/install-installed-skill-edit-guard.sh
@@ -15,7 +15,9 @@ set -euo pipefail
 shopt -s lastpipe 2>/dev/null || true
 umask 022
 
-repo_root="$(git rev-parse --show-toplevel 2>/dev/null || cd "$(dirname "$0")/.." && pwd)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+repo_root="$(resolve_repo_root)"
 src="${repo_root}/skills/cc-hooks/hooks/installed-skill-edit-guard.sh"
 [[ -f "$src" ]] || { echo "ERROR: guard script missing: ${src}" >&2; exit 1; }
 command -v jq >/dev/null || { echo "ERROR: jq required" >&2; exit 1; }

--- a/scripts/install-workflows.sh
+++ b/scripts/install-workflows.sh
@@ -18,7 +18,9 @@ set -euo pipefail
 shopt -s lastpipe 2>/dev/null || true
 umask 022
 
-repo_root="$(git rev-parse --show-toplevel)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+repo_root="$(resolve_repo_root)"
 src_dir="$repo_root/.claude/workflows"
 dest_dir="$HOME/.claude/workflows"
 mkdir -p "$dest_dir"

--- a/scripts/lib/repo-root.sh
+++ b/scripts/lib/repo-root.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/lib/repo-root.sh — sourced library: hook-safe, worktree-correct repo
+# root resolution (bead age-gate-scripts-worktree-gitdir-p62wo).
+#
+# Source it at the top of a script (do NOT execute it):
+#     . "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+#
+# WHY: git hooks (pre-push et al.) export GIT_DIR — usually WITHOUT
+# GIT_WORK_TREE. Under that env a bare `git rev-parse --show-toplevel`:
+#   * from a subdirectory returns the SUBDIRECTORY (git treats cwd as the
+#     worktree top), so every REPO_ROOT-relative path breaks; and
+#   * fails outright ("fatal: this operation must be run in a work tree",
+#     empty root) when the shared config is poisoned with core.bare=true —
+#     the exact 2026-07-18 gate outage from linked worktrees.
+#
+# Unlike preamble.sh this library sets NO strict mode and defines only
+# functions, so scripts with their own option handling can source it safely.
+# preamble.sh already computes an equivalently hardened REPO_ROOT for its own
+# consumers; new scripts that want the full preamble should keep using it.
+
+# Idempotent: sourcing twice is a no-op.
+if ! declare -F resolve_repo_root >/dev/null 2>&1; then
+
+# resolve_repo_root → print the absolute root of the checkout this LIBRARY
+# lives in. Worktree-correct: a linked worktree carries its own copy of
+# scripts/lib, so resolution anchors at that copy and returns the WORKTREE
+# root, never the main checkout. Deliberately independent of the caller's cwd
+# (a script run from inside a different git checkout cannot hijack the root).
+#
+#   1. git resolution in a subshell with git's hook-injected discovery env
+#      (GIT_DIR, GIT_WORK_TREE, ...) unset, anchored at the lib's own dir;
+#   2. fallback: the lib's fixed position — <root>/scripts/lib/repo-root.sh,
+#      two dirs up — when git resolution fails (poisoned config, extracted
+#      tarball, git missing).
+#
+# `CDPATH=` is an intentional one-command env clear (a caller's CDPATH must
+# not hijack the relative cd), not a botched assignment.
+resolve_repo_root() {
+  local lib_dir root
+  # BASH_SOURCE[0] inside a function names the file the function was DEFINED
+  # in — this library — regardless of who calls it.
+  # shellcheck disable=SC1007
+  lib_dir="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if ! root="$(
+    unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_OBJECT_DIRECTORY GIT_COMMON_DIR GIT_NAMESPACE
+    git -C "$lib_dir" rev-parse --show-toplevel 2>/dev/null
+  )" || [ -z "$root" ]; then
+    # shellcheck disable=SC1007
+    root="$(CDPATH= cd "$lib_dir/../.." && pwd)"
+  fi
+  printf '%s\n' "$root"
+}
+
+# scrub_git_env → unset git's hook-injected discovery env in the CURRENT
+# shell. For scripts that go on to run many git commands (or spawn processes
+# — e.g. `go test` — that themselves run git): after cd-ing to the resolved
+# repo root, discovery from cwd is correct and the leaked hook env is only a
+# liability (it can point child git calls at the wrong repo or, combined with
+# a poisoned core.bare, break them outright).
+scrub_git_env() {
+  unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_OBJECT_DIRECTORY GIT_COMMON_DIR GIT_NAMESPACE
+}
+
+fi

--- a/scripts/prune-agents.sh
+++ b/scripts/prune-agents.sh
@@ -13,7 +13,9 @@
 set -euo pipefail
 
 # Anchor to repo root to avoid pruning wrong .agents/ when cwd differs
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+REPO_ROOT="$(resolve_repo_root)"
 AGENTS_DIR="${REPO_ROOT}/.agents"
 DRY_RUN=true
 TOTAL_FILES=0

--- a/scripts/restore-branch-protection.sh
+++ b/scripts/restore-branch-protection.sh
@@ -8,7 +8,9 @@
 #   scripts/restore-branch-protection.sh --dry-run  # print PUT body, do not apply
 set -euo pipefail
 
-repo_root="$(git rev-parse --show-toplevel)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+repo_root="$(resolve_repo_root)"
 backup="${repo_root}/scripts/branch-protection-backup.json"
 dry_run=false
 [[ "${1:-}" == "--dry-run" ]] && dry_run=true

--- a/scripts/skill-usage-report.sh
+++ b/scripts/skill-usage-report.sh
@@ -36,7 +36,9 @@ done
 [ -d "$TDIR" ] || { echo "skill-usage: FAIL — no transcripts dir at $TDIR (remedy: pass --dir)" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "skill-usage: FAIL — jq required" >&2; exit 1; }
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+REPO_ROOT="$(resolve_repo_root)"
 
 # Library / read-not-invoked set: metadata.internal skills plus the known JIT
 # libraries — invocation counts do not apply to them.

--- a/scripts/snapshot-flywheel-compounding.sh
+++ b/scripts/snapshot-flywheel-compounding.sh
@@ -10,7 +10,9 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+REPO_ROOT="$(resolve_repo_root)"
 SNAPSHOT_PATH="${SNAPSHOT_PATH:-$REPO_ROOT/docs/releases/flywheel-compounding-snapshot.json}"
 AO_BIN="${AO_BIN:-}"
 

--- a/scripts/validate-codex-generated-artifacts.sh
+++ b/scripts/validate-codex-generated-artifacts.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+ROOT="$(resolve_repo_root)"
 SCOPE="auto"
 SKILLS_ROOT="$ROOT/skills-codex"
 MANIFEST_FILE="$SKILLS_ROOT/.agentops-manifest.json"

--- a/scripts/validate-codex-install-bundle.sh
+++ b/scripts/validate-codex-install-bundle.sh
@@ -55,7 +55,7 @@ for cmd in git tar mktemp bash; do
     fi
 done
 
-git -C "$REPO_ROOT" rev-parse --show-toplevel >/dev/null 2>&1 || {
+( unset GIT_DIR GIT_WORK_TREE; git -C "$REPO_ROOT" rev-parse --show-toplevel >/dev/null 2>&1; ) || {
     echo "Not a git repository: $REPO_ROOT" >&2
     exit 1
 }

--- a/scripts/validate-codex-override-coverage.sh
+++ b/scripts/validate-codex-override-coverage.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+ROOT="$(resolve_repo_root)"
 WAVE_FILTER=""
 
 usage() {

--- a/scripts/validate-go-fast.sh
+++ b/scripts/validate-go-fast.sh
@@ -52,9 +52,13 @@ case "$SCOPE" in
         ;;
 esac
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+REPO_ROOT="$(resolve_repo_root)"
 cd "$REPO_ROOT"
+# Hook-injected git env (GIT_DIR et al.) must not leak into the git calls
+# below or into `go test` children (age-gate-scripts-worktree-gitdir-p62wo).
+scrub_git_env
 
 if ! command -v go >/dev/null 2>&1; then
     echo "SKIP: go not installed"

--- a/scripts/validate-skill-runtime-parity.sh
+++ b/scripts/validate-skill-runtime-parity.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+ROOT="${1:-$(resolve_repo_root)}"
 DEPRECATED_COMMANDS_GO="$ROOT/cli/internal/quality/stale_refs.go"
 SKILL_ROOTS=("$ROOT/skills" "$ROOT/skills-codex")
 

--- a/scripts/validate-workflow-install.sh
+++ b/scripts/validate-workflow-install.sh
@@ -7,7 +7,9 @@
 # their output. Clean machines stay green via the drift check's absent=>SKIP.
 set -uo pipefail
 
-repo_root="$(git rev-parse --show-toplevel)"
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+repo_root="$(resolve_repo_root)"
 
 status=0
 bash "$repo_root/scripts/check-workflow-drift.sh" || status=1

--- a/scripts/verify-pushed-commit-builds.sh
+++ b/scripts/verify-pushed-commit-builds.sh
@@ -32,7 +32,9 @@ if [ "${AGENTOPS_PREPUSH_SKIP_COMMIT_BUILD:-0}" = "1" ]; then
     exit 0
 fi
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+# shellcheck disable=SC1007,SC1091
+. "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
+REPO_ROOT="$(resolve_repo_root)"
 BUILD_CMD="${AGENTOPS_COMMIT_BUILD_CMD:-cd cli && go build ./...}"
 # Intentional word-split of the space-separated pathspec list into array elements.
 # shellcheck disable=SC2206


### PR DESCRIPTION
Fixes the three gremlins observed 2026-07-18 (bead age-gate-scripts-worktree-gitdir-p62wo):

1. **Gate scripts broke under hook env from linked worktrees** (#919 regression): new scripts/lib/repo-root.sh (GIT_*-scrubbed resolution, BASH_SOURCE anchor, worktree-correct) swept across 32 scripts. Proof: this PR's own push ran the pre-push gates from a linked worktree and passed.
2. **core.bare=true recurrence**: mechanism proven (leaked GIT_DIR + no-arg git init --bare rewrites the SHARED config); writer traced with high confidence to a live Gas City city process (concrete suspect: gascity cmd_rig_test.go runGitInTest, unscrubbed env + no-arg init --bare — fork-side fix filed separately). Defense: new always.git-config-hygiene gate fails fast on core.bare/test identities with the repair command inline (--self-test proves fail-closed).
3. **Test/test@test.com identity leak**: writer convicted — our own pre-push chain leaked GIT_DIR into go test, whose helpers wrote the shared config via git -C (mechanism proven). Cut at both ends: validate-go-fast scrubs env for children; every test git-helper set-site scrubs; check-test-isolation gains a WARN-ratchet rule (baseline 3 → FAIL at 0).

Gates: shellcheck rc=0 across 36 scripts; go build/vet clean; 655+379+149 tests; hygiene self-test; both originally-failing validators pass under the repro env.