### PR TITLE
W3 wave 5 (finish line): package-var allowlist invariant + root-only harness (age-a-plus-report-card-ieyp2.14)

### DIFF
--- a/cli/cmd/ao/carveout_regression_test.go
+++ b/cli/cmd/ao/carveout_regression_test.go
@@ -149,6 +149,81 @@ func TestNoCarvedLegacySymbolsRemain(t *testing.T) {
 	}
 }
 
+// TestPackageVarsAreAllowlisted is the durable finish-line invariant for the
+// cmd/ao carve-out: every package-level `var` declared in a non-test source file
+// must appear on the committed allowlist (testdata/package-var-allowlist.json),
+// each carrying a one-line reason (root flag target / ldflags injection /
+// immutable wiring / documented test seam). The test fails two ways so the
+// allowlist cannot rot: (1) an unlisted package-level var (a new mutable global
+// snuck in — it almost always belongs constructor-scoped inside
+// internal/commands/<family>), and (2) a stale allowlist entry whose var no
+// longer exists. Keyed by name+file so a var moving files is caught too.
+func TestPackageVarsAreAllowlisted(t *testing.T) {
+	type allowEntry struct {
+		Name   string `json:"name"`
+		File   string `json:"file"`
+		Reason string `json:"reason"`
+	}
+	allowPath := filepath.Join(packageDir, "testdata", "package-var-allowlist.json")
+	data, err := os.ReadFile(allowPath)
+	if err != nil {
+		t.Fatalf("read package-var allowlist %s: %v", allowPath, err)
+	}
+	var doc struct {
+		Allowed []allowEntry `json:"allowed"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("decode package-var allowlist: %v", err)
+	}
+
+	key := func(name, file string) string { return file + "::" + name }
+	allowed := make(map[string]allowEntry, len(doc.Allowed))
+	for _, entry := range doc.Allowed {
+		if entry.Name == "" || entry.File == "" || strings.TrimSpace(entry.Reason) == "" {
+			t.Errorf("allowlist entry %+v is incomplete: name, file, and reason are all required", entry)
+			continue
+		}
+		allowed[key(entry.Name, entry.File)] = entry
+	}
+
+	// Collect the actual package-level vars from every non-test source file.
+	actual := map[string]bool{}
+	fset := token.NewFileSet()
+	for name, path := range packageGoFiles(t) {
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.VAR {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				value, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for _, ident := range value.Names {
+					actual[key(ident.Name, name)] = true
+					if _, ok := allowed[key(ident.Name, name)]; !ok {
+						t.Errorf("cmd/ao/%s declares un-allowlisted package-level var %q; add it to testdata/package-var-allowlist.json with a reason, or (better) move the state constructor-scoped into internal/commands/<family>",
+							name, ident.Name)
+					}
+				}
+			}
+		}
+	}
+
+	// Fail on stale allowlist entries so the list cannot drift from reality.
+	for k, entry := range allowed {
+		if !actual[k] {
+			t.Errorf("stale allowlist entry: %s (%s) no longer exists as a package-level var; remove it from testdata/package-var-allowlist.json",
+				entry.Name, entry.File)
+		}
+	}
+}
+
 // packageLevelNames returns every top-level declared identifier (var, const,
 // type, func) in the parsed file.
 func packageLevelNames(file *ast.File) []string {

--- a/cli/cmd/ao/command_test_helpers_test.go
+++ b/cli/cmd/ao/command_test_helpers_test.go
@@ -9,6 +9,19 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// executeCommand runs the root command tree with args and returns everything it
+// wrote to both cobra's out/err buffer and os.Stdout.
+//
+// BOUNDED PURPOSE (carve-out finish line, age-a-plus-report-card-ieyp2.14): this
+// harness saves/restores ONLY still-existing root spine state — the five root
+// persistent-flag globals (dryRun/verbose/output/jsonFlag/cfgFile) plus cobra's
+// per-command Changed state. After the 12-family carve-out no module-scoped
+// global remains to save here; each carved family owns its flag state
+// constructor-scoped inside internal/commands/<family>, tested there. If you find
+// yourself adding another save/restore line, the state you are reaching for is
+// almost certainly a module global that should not exist — fix the module, not
+// this helper. TestPackageVarsAreAllowlisted enforces that no new such global
+// appears in cmd/ao.
 func executeCommand(args ...string) (string, error) {
 	originalDryRun, originalVerbose := dryRun, verbose
 	originalOutput, originalJSON, originalConfig := output, jsonFlag, cfgFile

--- a/cli/cmd/ao/testdata/package-var-allowlist.json
+++ b/cli/cmd/ao/testdata/package-var-allowlist.json
@@ -1,0 +1,29 @@
+{
+  "_comment": "Durable carve-out invariant (bead age-a-plus-report-card-ieyp2.14). Every package-level var declared in a cmd/ao non-test .go file MUST appear here with a one-line reason. TestPackageVarsAreAllowlisted (carveout_regression_test.go) fails on any unlisted var AND on any stale entry. After the 12-family carve-out the only legitimate package-level state is: the root cobra spine + its persistent-flag targets, host-resident module/command wiring, const-like data maps, the ldflags version string, and one documented test seam. Do NOT add a new entry to make a test pass without justifying it; a new mutable global almost always belongs constructor-scoped inside internal/commands/<family>.",
+  "allowed": [
+    { "name": "appKey", "file": "app.go", "reason": "immutable wiring: context-key sentinel (appKeyType{}) for App injection" },
+    { "name": "completionCmd", "file": "completion.go", "reason": "immutable wiring: shell-completion cobra.Command tree node" },
+    { "name": "configCommand", "file": "config_module.go", "reason": "immutable wiring: config module command tree ref" },
+    { "name": "configModule", "file": "config_module.go", "reason": "immutable wiring: config module singleton" },
+    { "name": "doctorCommand", "file": "doctor_module.go", "reason": "immutable wiring: doctor module command tree ref" },
+    { "name": "doctorMaintenanceService", "file": "doctor_module.go", "reason": "immutable wiring: doctor maintenance service singleton" },
+    { "name": "doctorModule", "file": "doctor_module.go", "reason": "immutable wiring: doctor module singleton" },
+    { "name": "doctorMutationService", "file": "doctor_module.go", "reason": "immutable wiring: doctor mutation service singleton" },
+    { "name": "doctorReadService", "file": "doctor_module.go", "reason": "immutable wiring: doctor read service singleton" },
+    { "name": "handoffCmd", "file": "handoff.go", "reason": "immutable wiring: handoff cobra.Command tree node (host-resident leaf)" },
+    { "name": "handoffGoal", "file": "handoff.go", "reason": "flag target: --goal for host-resident handoff command" },
+    { "name": "handoffContinuation", "file": "handoff.go", "reason": "flag target: --continuation for host-resident handoff command" },
+    { "name": "handoffCollect", "file": "handoff.go", "reason": "flag target: --collect for host-resident handoff command" },
+    { "name": "handoffDryRun", "file": "handoff.go", "reason": "flag target: --dry-run for host-resident handoff command" },
+    { "name": "version", "file": "main.go", "reason": "ldflags injection: build-time version string (-X main.version)" },
+    { "name": "testProjectDir", "file": "projectdir.go", "reason": "test seam: cross-file mutable override of resolveProjectDir; production never sets it. FOLLOW-UP: could migrate onto App to remove the last non-flag mutable global." },
+    { "name": "removedChildCommands", "file": "removed_command_hint.go", "reason": "immutable wiring: const-like data map of removed subcommand hints" },
+    { "name": "removedCommands", "file": "removed_command_hint.go", "reason": "immutable wiring: const-like data map of removed command hints" },
+    { "name": "cfgFile", "file": "root.go", "reason": "root flag target: --config persistent flag" },
+    { "name": "dryRun", "file": "root.go", "reason": "root flag target: --dry-run persistent flag" },
+    { "name": "jsonFlag", "file": "root.go", "reason": "root flag target: --json persistent flag" },
+    { "name": "output", "file": "root.go", "reason": "root flag target: -o/--output persistent flag (negotiated in negotiateOutput)" },
+    { "name": "rootCmd", "file": "root.go", "reason": "immutable wiring: the root cobra.Command spine" },
+    { "name": "verbose", "file": "root.go", "reason": "root flag target: -v/--verbose persistent flag" }
+  ]
+}

--- a/cli/cmd/ao/testutil_test.go
+++ b/cli/cmd/ao/testutil_test.go
@@ -209,6 +209,14 @@ func captureJSONStdout(t *testing.T, fn func()) string {
 // to defaults, clears cobra flag Changed state, and registers t.Cleanup to
 // restore originals. Call this at the start of any test that uses rootCmd
 // directly instead of executeCommand.
+//
+// BOUNDED PURPOSE (carve-out finish line, age-a-plus-report-card-ieyp2.14):
+// after the 12-family carve-out the only saved state is the root spine — the
+// five root persistent-flag globals plus the configShow test shim. There is no
+// remaining module-scoped global to reset here; carved families own their flag
+// state constructor-scoped inside internal/commands/<family>. Do not grow this
+// list to reach into a module — fix the module. TestPackageVarsAreAllowlisted
+// keeps cmd/ao free of new mutable globals.
 func resetCommandState(t *testing.T) {
 	t.Helper()
 


### PR DESCRIPTION
Final wave of the cmd/ao carve-out arc. Test-only diff (+125): TestPackageVarsAreAllowlisted (go/ast, bidirectional — unlisted vars AND stale entries fail) over a committed 24-entry reasoned allowlist; scratch-violation RED proven; executeCommand harness verified already root-only (saves exactly the 5 root flag globals) and documented. Zero production changes; capabilities byte-identical. Full gate 67/67; uncapped lint 0; shuffle green. Sol fresh-context ACCEPT. Lands via FF-push. Known pre-existing PR-CI red: age-sqjyl. Bead: age-a-plus-report-card-ieyp2.14.