### PR TITLE
feat(cc-hooks): hooks ship by default across every install path (age-4qw1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ Two install paths:
 - **npx / [skills.sh](https://skills.sh)** copies skills you can edit.
 - **Plugins** keep a read-only bundle current with the repo.
 
+## Admission-control hooks (on by default)
+
+AgentOps ships a PreToolUse **policy dispatcher** — deterministic guards that
+block a small set of known-destructive commands (staging the private bead
+ledger, hand-editing the hash-chained provenance ledger, overwriting installed
+skill copies) and route you to the correct tool instead. Silent on every clean
+call; every block is one line.
+
+- **Claude Code plugin installs:** active automatically — nothing to run.
+- **npx / skills.sh copies:** run `~/.claude/skills/cc-hooks/scripts/install-hooks.sh` once.
+- **git clone / brew:** run `scripts/install-policy-dispatch.sh` once.
+
+Disable anytime (`/plugin disable agentops`, or remove the two PreToolUse
+matchers from settings). Policy list and design:
+`skills/cc-hooks/SKILL.md`.
+
 Remove with your runtime's plugin uninstall, or delete the linked skill
 directories.
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/skills/cc-hooks/hooks/policy-dispatch.sh",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/skills/cc-hooks/hooks/policy-dispatch.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/images/gemini/skills/cc-hooks/SKILL.md
+++ b/images/gemini/skills/cc-hooks/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
-description: 'Configure Claude Code hooks (PreToolUse, PostToolUse, Stop, Notification) as an opt-in host adapter; AgentOps installs none by default. Triggers: "cc-hooks", "configure Claude Code hooks".'
+description: 'Claude Code hooks and the AgentOps admission-control layer. Enforcement hooks ship by DEFAULT: the plugin auto-wires the policy dispatcher; skill copies carry scripts/install-hooks.sh. Injection hooks stay dead (#511). Triggers: "cc-hooks", "configure Claude Code hooks", "install hooks".'
 practices:
 - pragmatic-programmer
 ---
@@ -31,7 +31,8 @@ contract, not a style preference.
 
 ## Constraints
 
-- Keep every hook opt-in because AgentOps installs no runtime hooks by default and host policy belongs to the operator.
+- Enforcement hooks (the PreToolUse policy dispatcher) ship by DEFAULT: plugin installs auto-wire `hooks/hooks.json`; skill copies and checkouts wire with one command (`scripts/install-hooks.sh`). Operators can disable per host (`/plugin disable`, or remove the settings matchers).
+- Injection hooks (SessionStart/UserPromptSubmit context stuffing) stay dead — the #511 teardown proved delta=0 at 10.35M resident tokens. Never ship one; the hookless-cold-start gate still enforces this.
 - Keep the happy path silent and block only with the event's documented exit/JSON contract because stray stdout can corrupt a tool call.
 - Bound Stop hooks with `stop_hook_active` and scope matchers narrowly to prevent recursion and unrelated-command interception.
 
@@ -116,8 +117,9 @@ Details: [DCG-RCH.md](references/DCG-RCH.md)
 ## Skill-First Coordination Guard (opt-in)
 
 A copy-paste PreToolUse recipe that nudges agents to **load the coordination
-skill before hand-rolling the `am`/`atm`/`ntm`/`tmux send-keys` CLI**. AgentOps
-3.0 is hookless — this auto-installs nothing; you opt in per host.
+skill before hand-rolling the `am`/`atm`/`ntm`/`tmux send-keys` CLI**. This
+recipe auto-installs nothing; you opt in per host (unlike the policy
+dispatcher, which ships by default).
 
 **Context-budget doctrine for hooks:** hooks are the most powerful enforcement
 (mechanical, can't be reasoned past) but they pollute context — use sparingly. A
@@ -165,7 +167,7 @@ positive value"), the criterion whose absence killed 2.x hooks (#511).
 
 Methodology: [GUARDRAIL-VALUE-PROOF.md](references/GUARDRAIL-VALUE-PROOF.md)
 
-## Policy Dispatch Engine (opt-in)
+## Policy Dispatch Engine (ships by default)
 
 The admission-control layer (epic age-4qw1): **one** PreToolUse dispatcher —
 [hooks/policy-dispatch.sh](hooks/policy-dispatch.sh) — evaluating a
@@ -202,12 +204,19 @@ Day-1 enforce cohort (age-wnyt, all pure-regex, high-pain):
 | `core.git:add-beads-ledger` | `git add` naming `_beads/` (private ledger leak is one-way) | push the ledger repo itself — never `git add _beads` in the public tree |
 | `core.provenance:ledger-hand-append` | redirect/`tee`/Edit/Write onto `docs/provenance/ledger.jsonl` (hash-chained, sealed) | `ao provenance add` |
 | `core.skills:copy-into-installed` | `cp`/`rsync`/`mv` INTO `~/.claude|.codex|.gemini/skills` (dest-position enforced) | `ao skills link` |
+| `core.skills:edit-installed-copy` | Edit/Write of an installed skill copy (`file_path` only — prose can never fire it) | edit repo `skills/<name>/` |
 
-Ships INERT — opt-in installer (lints the registry before wiring):
+**How it reaches users — every install path delivers hooks:**
 
-```bash
-scripts/install-policy-dispatch.sh   # user scope; --project for project scope
-```
+| Install path | Delivery |
+|---|---|
+| Claude Code plugin (`claude plugin install agentops@agentops-marketplace`) | **Automatic** — the plugin bundles `hooks/hooks.json` (`${CLAUDE_PLUGIN_ROOT}` paths); hooks are active on install, no wiring step |
+| `npx skills@latest add boshu2/agentops` / skills.sh copy | The skill package carries its own installer: `~/.claude/skills/cc-hooks/scripts/install-hooks.sh` (one command; file copies cannot self-wire) |
+| git clone / brew checkout | `scripts/install-policy-dispatch.sh` (delegates to the same skill-embedded installer) |
+
+The installer lints the registry before wiring, backs up settings, and is
+idempotent. Disable per host with `/plugin disable agentops` or by removing the
+two PreToolUse matchers from settings.
 
 Contract tests: `tests/scripts/policy-dispatch.bats` (block+message+telemetry
 per policy, stray-stdout hazard, waivers, audit/route modes, fail-open).

--- a/scripts/install-policy-dispatch.sh
+++ b/scripts/install-policy-dispatch.sh
@@ -1,84 +1,15 @@
 #!/usr/bin/env bash
-# install-policy-dispatch.sh — opt-in installer for the PreToolUse policy
-# dispatcher + policies-as-data registry (age-bhsz, epic age-4qw1).
+# install-policy-dispatch.sh — repo-root entry point for wiring the AgentOps
+# policy dispatcher (age-bhsz, epic age-4qw1). The implementation lives INSIDE
+# the cc-hooks skill package (skills/cc-hooks/scripts/install-hooks.sh) so that
+# skills-copy installs (npx skills / skills.sh) carry their own wiring; this
+# script just delegates for clone/brew users who expect scripts/install-*.
 #
-# AgentOps is hookless by default — the engine ships INERT. Run this script
-# explicitly to activate it on a host. It copies the dispatcher and the policy
-# registry into ~/.claude/hooks/aop/ and wires PreToolUse matchers for Bash and
-# Edit|Write into a Claude settings.json. Idempotent: re-running refreshes the
-# installed copies and is a settings no-op once wired.
-#
-# Usage:
-#   scripts/install-policy-dispatch.sh            # user settings (~/.claude/settings.json)
-#   scripts/install-policy-dispatch.sh --project  # project settings (.claude/settings.json)
-#   SETTINGS=/path/to/settings.json scripts/install-policy-dispatch.sh
+# Claude Code PLUGIN installs need neither: the plugin bundles hooks/hooks.json
+# and Claude wires it automatically.
 set -euo pipefail
-umask 022
 
 # shellcheck disable=SC1007,SC1091
 . "$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/repo-root.sh"
 repo_root="$(resolve_repo_root)"
-src_dispatch="${repo_root}/skills/cc-hooks/hooks/policy-dispatch.sh"
-src_policies="${repo_root}/skills/cc-hooks/policies/policies.json"
-lint="${repo_root}/skills/cc-hooks/scripts/lint-policies.sh"
-[[ -f "$src_dispatch" ]] || { echo "ERROR: dispatcher missing: ${src_dispatch}" >&2; exit 1; }
-[[ -f "$src_policies" ]] || { echo "ERROR: registry missing: ${src_policies}" >&2; exit 1; }
-command -v jq >/dev/null || { echo "ERROR: jq required" >&2; exit 1; }
-
-# Never install a registry that fails its own contract.
-bash "$lint" "$src_policies"
-
-settings="${SETTINGS:-}"
-if [[ -z "$settings" ]]; then
-  case "${1:-}" in
-    --project) settings=".claude/settings.json" ;;
-    *)         settings="${HOME}/.claude/settings.json" ;;
-  esac
-fi
-
-hooks_dir="${HOME}/.claude/hooks/aop"
-mkdir -p "$hooks_dir"
-install -m 0755 "$src_dispatch" "${hooks_dir}/policy-dispatch.sh"
-install -m 0644 "$src_policies" "${hooks_dir}/policies.json"
-dst="${hooks_dir}/policy-dispatch.sh"
-echo "✓ installed ${dst} (+ policies.json beside it)"
-
-mkdir -p "$(dirname "$settings")"
-[[ -f "$settings" ]] || echo '{}' > "$settings"
-
-if [[ -s "$settings" ]]; then
-  backup="${settings}.bak.$(date +%Y%m%d%H%M%S)"
-  cp -p "$settings" "$backup"
-  echo "✓ backed up settings → ${backup}"
-fi
-
-tmp="$(mktemp)"
-trap 'rm -f "$tmp"' EXIT
-jq --arg cmd "$dst" '
-  .hooks //= {} |
-  .hooks.PreToolUse //= [] |
-  reduce ("Bash", "Edit|Write") as $m (.;
-    if any(.hooks.PreToolUse[]?; .matcher == $m and any((.hooks // [])[]?; .command == $cmd))
-    then .
-    else .hooks.PreToolUse += [{
-      "matcher": $m,
-      "hooks": [ { "type": "command", "command": $cmd } ]
-    }]
-    end
-  )
-' "$settings" > "$tmp" && mv "$tmp" "$settings"
-trap - EXIT
-
-if grep -qF "$dst" "$settings"; then
-  echo "✓ wired PreToolUse (Bash, Edit|Write) policy dispatcher into ${settings}"
-else
-  echo "ERROR: failed to wire dispatcher into ${settings}" >&2
-  exit 1
-fi
-
-echo ""
-echo "Policy dispatcher active for this Claude scope. SILENT on every clean call;"
-echo "deny policies block with a one-line route to the correct tool; every fire"
-echo "lands one hashed telemetry line in \${AGENTOPS_HOME:-~/.agents/ao}/guardrail-telemetry.jsonl."
-echo "Waive once:  AOP_WAIVE=<policy-id> <your command>"
-echo "Uninstall:   remove the two PreToolUse matchers for ${dst} from ${settings}, then rm -rf ${hooks_dir}"
+exec bash "${repo_root}/skills/cc-hooks/scripts/install-hooks.sh" "$@"

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -369,8 +369,8 @@
     {
       "name": "cc-hooks",
       "source_skill": "skills/cc-hooks",
-      "source_hash": "db4cdf0960a2fb7f184f4ff8a05e3dcc5c948abc56380a74d0ff04cb54d48a2b",
-      "generated_hash": "4d7866732fefa0a7d98fa7d3d4c3cbad82baaaf5786021a2878b72485e149ac4"
+      "source_hash": "1e17e091dea81183aef666cf27321f8f03992ef1cdcdfbc7b3890d842a474b51",
+      "generated_hash": "06a47649e0d36e8ec423031df8f769a181ea10f1d2bcc369063f9bf11017d227"
     },
     {
       "name": "codebase-recon",

--- a/skills-codex/cc-hooks/.agentops-generated.json
+++ b/skills-codex/cc-hooks/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/cc-hooks",
   "layout": "modular",
-  "source_hash": "db4cdf0960a2fb7f184f4ff8a05e3dcc5c948abc56380a74d0ff04cb54d48a2b",
-  "generated_hash": "4d7866732fefa0a7d98fa7d3d4c3cbad82baaaf5786021a2878b72485e149ac4"
+  "source_hash": "1e17e091dea81183aef666cf27321f8f03992ef1cdcdfbc7b3890d842a474b51",
+  "generated_hash": "06a47649e0d36e8ec423031df8f769a181ea10f1d2bcc369063f9bf11017d227"
 }

--- a/skills-codex/cc-hooks/SKILL.md
+++ b/skills-codex/cc-hooks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-hooks
-description: Configure Claude Code hooks (PreToolUse
+description: Claude Code hooks and the AgentOps
 ---
 # Claude Code Hooks
 
@@ -16,7 +16,8 @@ contract, not a style preference.
 
 ## Constraints
 
-- Keep every hook opt-in because AgentOps installs no runtime hooks by default and host policy belongs to the operator.
+- Enforcement hooks (the PreToolUse policy dispatcher) ship by DEFAULT: plugin installs auto-wire `hooks/hooks.json`; skill copies and checkouts wire with one command (`scripts/install-hooks.sh`). Operators can disable per host (`/plugin disable`, or remove the settings matchers).
+- Injection hooks (SessionStart/UserPromptSubmit context stuffing) stay dead — the #511 teardown proved delta=0 at 10.35M resident tokens. Never ship one; the hookless-cold-start gate still enforces this.
 - Keep the happy path silent and block only with the event's documented exit/JSON contract because stray stdout can corrupt a tool call.
 - Bound Stop hooks with `stop_hook_active` and scope matchers narrowly to prevent recursion and unrelated-command interception.
 
@@ -101,8 +102,9 @@ Details: [DCG-RCH.md](references/DCG-RCH.md)
 ## Skill-First Coordination Guard (opt-in)
 
 A copy-paste PreToolUse recipe that nudges agents to **load the coordination
-skill before hand-rolling the `am`/`atm`/`ntm`/`tmux send-keys` CLI**. AgentOps
-3.0 is hookless — this auto-installs nothing; you opt in per host.
+skill before hand-rolling the `am`/`atm`/`ntm`/`tmux send-keys` CLI**. This
+recipe auto-installs nothing; you opt in per host (unlike the policy
+dispatcher, which ships by default).
 
 **Context-budget doctrine for hooks:** hooks are the most powerful enforcement
 (mechanical, can't be reasoned past) but they pollute context — use sparingly. A
@@ -150,7 +152,7 @@ positive value"), the criterion whose absence killed 2.x hooks (#511).
 
 Methodology: [GUARDRAIL-VALUE-PROOF.md](references/GUARDRAIL-VALUE-PROOF.md)
 
-## Policy Dispatch Engine (opt-in)
+## Policy Dispatch Engine (ships by default)
 
 The admission-control layer (epic age-4qw1): **one** PreToolUse dispatcher —
 [hooks/policy-dispatch.sh](hooks/policy-dispatch.sh) — evaluating a
@@ -187,12 +189,19 @@ Day-1 enforce cohort (age-wnyt, all pure-regex, high-pain):
 | `core.git:add-beads-ledger` | `git add` naming `_beads/` (private ledger leak is one-way) | push the ledger repo itself — never `git add _beads` in the public tree |
 | `core.provenance:ledger-hand-append` | redirect/`tee`/Edit/Write onto `docs/provenance/ledger.jsonl` (hash-chained, sealed) | `ao provenance add` |
 | `core.skills:copy-into-installed` | `cp`/`rsync`/`mv` INTO `~/.claude|.codex|.gemini/skills` (dest-position enforced) | `ao skills link` |
+| `core.skills:edit-installed-copy` | Edit/Write of an installed skill copy (`file_path` only — prose can never fire it) | edit repo `skills/<name>/` |
 
-Ships INERT — opt-in installer (lints the registry before wiring):
+**How it reaches users — every install path delivers hooks:**
 
-```bash
-scripts/install-policy-dispatch.sh   # user scope; --project for project scope
-```
+| Install path | Delivery |
+|---|---|
+| Claude Code plugin (`claude plugin install agentops@agentops-marketplace`) | **Automatic** — the plugin bundles `hooks/hooks.json` (`${CLAUDE_PLUGIN_ROOT}` paths); hooks are active on install, no wiring step |
+| `npx skills@latest add boshu2/agentops` / skills.sh copy | The skill package carries its own installer: `~/.claude/skills/cc-hooks/scripts/install-hooks.sh` (one command; file copies cannot self-wire) |
+| git clone / brew checkout | `scripts/install-policy-dispatch.sh` (delegates to the same skill-embedded installer) |
+
+The installer lints the registry before wiring, backs up settings, and is
+idempotent. Disable per host with `/plugin disable agentops` or by removing the
+two PreToolUse matchers from settings.
 
 Contract tests: `tests/scripts/policy-dispatch.bats` (block+message+telemetry
 per policy, stray-stdout hazard, waivers, audit/route modes, fail-open).

--- a/skills-codex/cc-hooks/hooks/policy-dispatch.sh
+++ b/skills-codex/cc-hooks/hooks/policy-dispatch.sh
@@ -49,10 +49,12 @@ command -v jq >/dev/null 2>&1 || exit 0
 [ -f "$registry" ] || exit 0
 
 input="$(cat)"
-tool="$(printf '%s' "$input" | jq -r '.tool_name // ""')"
-cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // ""')"
-fpath="$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""')"
-sid="$(printf '%s' "$input" | jq -r '.session_id // "nosession"')"
+# 2>/dev/null: malformed stdin must be FULLY silent (fail open), not leak jq
+# parse errors to stderr (validator finding F3, 2026-07-20).
+tool="$(printf '%s' "$input" | jq -r '.tool_name // ""' 2>/dev/null)"
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)"
+fpath="$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""' 2>/dev/null)"
+sid="$(printf '%s' "$input" | jq -r '.session_id // "nosession"' 2>/dev/null)"
 [ -n "$tool" ] || exit 0
 
 hash_value() {

--- a/skills-codex/cc-hooks/policies/policies.json
+++ b/skills-codex/cc-hooks/policies/policies.json
@@ -60,6 +60,24 @@
       "route_message": "~/.claude/skills (and .codex/.gemini) are INSTALLED/symlinked copies — a cp/rsync/mv into them writes through the symlink into whatever branch the factory checkout is on, or is overwritten on install. Link instead: ao skills link (repo) or link-skill --all (dotfiles). Closes the Bash gap of the Edit|Write-only installed-skill-edit-guard.",
       "rationale": "Global CLAUDE.md 'Never cp into ~/.claude/skills'. Destination position is enforced: the installed-skills path must be the LAST token of the command segment, so copying FROM an installed dir out to the repo never fires.",
       "value_proof": "declining fire-attempt rate (token_class core.skills:copy-into-installed); retire on false-positive evidence"
+    },
+    {
+      "id": "core.skills:edit-installed-copy",
+      "predicate_class": "pure",
+      "mode": "deny",
+      "matchers": [
+        {
+          "tools": [
+            "Edit",
+            "Write"
+          ],
+          "field": "file_path",
+          "pattern": "/\\.(claude|codex|gemini)/skills/"
+        }
+      ],
+      "route_message": "This is an INSTALLED skill copy (overwritten on install, or symlinked through to the factory checkout) — editing it is lost work. Edit skills/<name>/ in the source repo instead.",
+      "rationale": "Registry twin of the standalone installed-skill-edit-guard: matches tool_input.file_path ONLY (prose that merely mentions claude/skills lands in tool_input.content and can never fire). Subsumes the standalone guard for dispatcher users; the standalone script remains for hosts wanting only that one guard.",
+      "value_proof": "declining fire-attempt rate (token_class core.skills:edit-installed-copy); 2 real fires already recorded by the standalone guard's telemetry; retire on false-positive evidence"
     }
   ]
 }

--- a/skills-codex/cc-hooks/prompt.md
+++ b/skills-codex/cc-hooks/prompt.md
@@ -1,6 +1,6 @@
 # cc-hooks
 
-Configure Claude Code hooks (PreToolUse, PostToolUse, Stop, Notification) as an opt-in host adapter; AgentOps installs none by default. Triggers: "cc-hooks", "configure Claude Code hooks".
+Claude Code hooks and the AgentOps admission-control layer. Enforcement hooks ship by DEFAULT: the plugin auto-wires the policy dispatcher; skill copies carry scripts/install-hooks.sh. Injection hooks stay dead (#511). Triggers: "cc-hooks", "configure Claude Code hooks", "install hooks".
 
 ## Instructions
 

--- a/skills-codex/cc-hooks/scripts/install-hooks.sh
+++ b/skills-codex/cc-hooks/scripts/install-hooks.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# install-hooks.sh — wire the AgentOps policy dispatcher into Claude settings,
+# from ANY install shape (epic age-4qw1: hooks ship by default).
+#
+# This copy lives INSIDE the cc-hooks skill package so every distribution path
+# carries its own wiring:
+#   - npx skills / skills.sh copy  -> ~/.claude/skills/cc-hooks/scripts/install-hooks.sh
+#   - git clone / brew checkout    -> skills/cc-hooks/scripts/install-hooks.sh
+#     (scripts/install-policy-dispatch.sh at the repo root delegates here)
+#   - Claude Code PLUGIN installs need NO installer at all: the plugin bundles
+#     hooks/hooks.json and Claude wires it automatically.
+#
+# Everything resolves relative to THIS script's skill dir, so it works from a
+# copied skill directory with no repo present. Idempotent; backs up settings.
+#
+# Usage:
+#   install-hooks.sh            # user settings (~/.claude/settings.json)
+#   install-hooks.sh --project  # project settings (.claude/settings.json)
+#   SETTINGS=/path/settings.json install-hooks.sh
+set -euo pipefail
+umask 022
+
+# shellcheck disable=SC1007  # CDPATH= scopes an empty CDPATH to the cd, intentionally
+script_dir="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+skill_dir="$(dirname "$script_dir")"
+src_dispatch="${skill_dir}/hooks/policy-dispatch.sh"
+src_policies="${skill_dir}/policies/policies.json"
+lint="${script_dir}/lint-policies.sh"
+[[ -f "$src_dispatch" ]] || { echo "ERROR: dispatcher missing: ${src_dispatch}" >&2; exit 1; }
+[[ -f "$src_policies" ]] || { echo "ERROR: registry missing: ${src_policies}" >&2; exit 1; }
+command -v jq >/dev/null || { echo "ERROR: jq required" >&2; exit 1; }
+
+# Never install a registry that fails its own contract.
+bash "$lint" "$src_policies"
+
+settings="${SETTINGS:-}"
+if [[ -z "$settings" ]]; then
+  case "${1:-}" in
+    --project) settings=".claude/settings.json" ;;
+    *)         settings="${HOME}/.claude/settings.json" ;;
+  esac
+fi
+
+hooks_dir="${HOME}/.claude/hooks/aop"
+mkdir -p "$hooks_dir"
+install -m 0755 "$src_dispatch" "${hooks_dir}/policy-dispatch.sh"
+install -m 0644 "$src_policies" "${hooks_dir}/policies.json"
+dst="${hooks_dir}/policy-dispatch.sh"
+echo "✓ installed ${dst} (+ policies.json beside it)"
+
+mkdir -p "$(dirname "$settings")"
+[[ -f "$settings" ]] || echo '{}' > "$settings"
+
+if [[ -s "$settings" ]]; then
+  backup="${settings}.bak.$(date +%Y%m%d%H%M%S)"
+  cp -p "$settings" "$backup"
+  echo "✓ backed up settings → ${backup}"
+fi
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+jq --arg cmd "$dst" '
+  .hooks //= {} |
+  .hooks.PreToolUse //= [] |
+  reduce ("Bash", "Edit|Write") as $m (.;
+    if any(.hooks.PreToolUse[]?; .matcher == $m and any((.hooks // [])[]?; .command == $cmd))
+    then .
+    else .hooks.PreToolUse += [{
+      "matcher": $m,
+      "hooks": [ { "type": "command", "command": $cmd } ]
+    }]
+    end
+  )
+' "$settings" > "$tmp" && mv "$tmp" "$settings"
+trap - EXIT
+
+if grep -qF "$dst" "$settings"; then
+  echo "✓ wired PreToolUse (Bash, Edit|Write) policy dispatcher into ${settings}"
+else
+  echo "ERROR: failed to wire dispatcher into ${settings}" >&2
+  exit 1
+fi
+
+echo ""
+echo "Policy dispatcher active for this Claude scope. SILENT on every clean call;"
+echo "deny policies block with a one-line route to the correct tool; fires land one"
+echo "hashed telemetry line in \${AGENTOPS_HOME:-~/.agents/ao}/guardrail-telemetry.jsonl."
+echo "Waive once:  AOP_WAIVE=<policy-id> <your command>"
+echo "Uninstall:   remove the two PreToolUse matchers for ${dst} from ${settings}, then rm -rf ${hooks_dir}"

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -252,7 +252,7 @@
       "consumes": [],
       "context_rel": [],
       "dependencies": [],
-      "description": "Configure Claude Code hooks (PreToolUse, PostToolUse, Stop, Notification) as an opt-in host adapter; AgentOps installs none by default. Triggers: \"cc-hooks\", \"configure Claude Code hooks\".",
+      "description": "Claude Code hooks and the AgentOps admission-control layer. Enforcement hooks ship by DEFAULT: the plugin auto-wires the policy dispatcher; skill copies carry scripts/install-hooks.sh. Injection hooks stay dead (#511). Triggers: \"cc-hooks\", \"configure Claude Code hooks\", \"install hooks\".",
       "disposition": "keep_specialist",
       "effects": [],
       "graph_root": false,

--- a/skills/cc-hooks/SKILL.md
+++ b/skills/cc-hooks/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
-description: 'Configure Claude Code hooks (PreToolUse, PostToolUse, Stop, Notification) as an opt-in host adapter; AgentOps installs none by default. Triggers: "cc-hooks", "configure Claude Code hooks".'
+description: 'Claude Code hooks and the AgentOps admission-control layer. Enforcement hooks ship by DEFAULT: the plugin auto-wires the policy dispatcher; skill copies carry scripts/install-hooks.sh. Injection hooks stay dead (#511). Triggers: "cc-hooks", "configure Claude Code hooks", "install hooks".'
 practices:
 - pragmatic-programmer
 ---
@@ -31,7 +31,8 @@ contract, not a style preference.
 
 ## Constraints
 
-- Keep every hook opt-in because AgentOps installs no runtime hooks by default and host policy belongs to the operator.
+- Enforcement hooks (the PreToolUse policy dispatcher) ship by DEFAULT: plugin installs auto-wire `hooks/hooks.json`; skill copies and checkouts wire with one command (`scripts/install-hooks.sh`). Operators can disable per host (`/plugin disable`, or remove the settings matchers).
+- Injection hooks (SessionStart/UserPromptSubmit context stuffing) stay dead — the #511 teardown proved delta=0 at 10.35M resident tokens. Never ship one; the hookless-cold-start gate still enforces this.
 - Keep the happy path silent and block only with the event's documented exit/JSON contract because stray stdout can corrupt a tool call.
 - Bound Stop hooks with `stop_hook_active` and scope matchers narrowly to prevent recursion and unrelated-command interception.
 
@@ -116,8 +117,9 @@ Details: [DCG-RCH.md](references/DCG-RCH.md)
 ## Skill-First Coordination Guard (opt-in)
 
 A copy-paste PreToolUse recipe that nudges agents to **load the coordination
-skill before hand-rolling the `am`/`atm`/`ntm`/`tmux send-keys` CLI**. AgentOps
-3.0 is hookless — this auto-installs nothing; you opt in per host.
+skill before hand-rolling the `am`/`atm`/`ntm`/`tmux send-keys` CLI**. This
+recipe auto-installs nothing; you opt in per host (unlike the policy
+dispatcher, which ships by default).
 
 **Context-budget doctrine for hooks:** hooks are the most powerful enforcement
 (mechanical, can't be reasoned past) but they pollute context — use sparingly. A
@@ -165,7 +167,7 @@ positive value"), the criterion whose absence killed 2.x hooks (#511).
 
 Methodology: [GUARDRAIL-VALUE-PROOF.md](references/GUARDRAIL-VALUE-PROOF.md)
 
-## Policy Dispatch Engine (opt-in)
+## Policy Dispatch Engine (ships by default)
 
 The admission-control layer (epic age-4qw1): **one** PreToolUse dispatcher —
 [hooks/policy-dispatch.sh](hooks/policy-dispatch.sh) — evaluating a
@@ -202,12 +204,19 @@ Day-1 enforce cohort (age-wnyt, all pure-regex, high-pain):
 | `core.git:add-beads-ledger` | `git add` naming `_beads/` (private ledger leak is one-way) | push the ledger repo itself — never `git add _beads` in the public tree |
 | `core.provenance:ledger-hand-append` | redirect/`tee`/Edit/Write onto `docs/provenance/ledger.jsonl` (hash-chained, sealed) | `ao provenance add` |
 | `core.skills:copy-into-installed` | `cp`/`rsync`/`mv` INTO `~/.claude|.codex|.gemini/skills` (dest-position enforced) | `ao skills link` |
+| `core.skills:edit-installed-copy` | Edit/Write of an installed skill copy (`file_path` only — prose can never fire it) | edit repo `skills/<name>/` |
 
-Ships INERT — opt-in installer (lints the registry before wiring):
+**How it reaches users — every install path delivers hooks:**
 
-```bash
-scripts/install-policy-dispatch.sh   # user scope; --project for project scope
-```
+| Install path | Delivery |
+|---|---|
+| Claude Code plugin (`claude plugin install agentops@agentops-marketplace`) | **Automatic** — the plugin bundles `hooks/hooks.json` (`${CLAUDE_PLUGIN_ROOT}` paths); hooks are active on install, no wiring step |
+| `npx skills@latest add boshu2/agentops` / skills.sh copy | The skill package carries its own installer: `~/.claude/skills/cc-hooks/scripts/install-hooks.sh` (one command; file copies cannot self-wire) |
+| git clone / brew checkout | `scripts/install-policy-dispatch.sh` (delegates to the same skill-embedded installer) |
+
+The installer lints the registry before wiring, backs up settings, and is
+idempotent. Disable per host with `/plugin disable agentops` or by removing the
+two PreToolUse matchers from settings.
 
 Contract tests: `tests/scripts/policy-dispatch.bats` (block+message+telemetry
 per policy, stray-stdout hazard, waivers, audit/route modes, fail-open).

--- a/skills/cc-hooks/hooks/policy-dispatch.sh
+++ b/skills/cc-hooks/hooks/policy-dispatch.sh
@@ -49,10 +49,12 @@ command -v jq >/dev/null 2>&1 || exit 0
 [ -f "$registry" ] || exit 0
 
 input="$(cat)"
-tool="$(printf '%s' "$input" | jq -r '.tool_name // ""')"
-cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // ""')"
-fpath="$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""')"
-sid="$(printf '%s' "$input" | jq -r '.session_id // "nosession"')"
+# 2>/dev/null: malformed stdin must be FULLY silent (fail open), not leak jq
+# parse errors to stderr (validator finding F3, 2026-07-20).
+tool="$(printf '%s' "$input" | jq -r '.tool_name // ""' 2>/dev/null)"
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)"
+fpath="$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""' 2>/dev/null)"
+sid="$(printf '%s' "$input" | jq -r '.session_id // "nosession"' 2>/dev/null)"
 [ -n "$tool" ] || exit 0
 
 hash_value() {

--- a/skills/cc-hooks/policies/policies.json
+++ b/skills/cc-hooks/policies/policies.json
@@ -60,6 +60,24 @@
       "route_message": "~/.claude/skills (and .codex/.gemini) are INSTALLED/symlinked copies — a cp/rsync/mv into them writes through the symlink into whatever branch the factory checkout is on, or is overwritten on install. Link instead: ao skills link (repo) or link-skill --all (dotfiles). Closes the Bash gap of the Edit|Write-only installed-skill-edit-guard.",
       "rationale": "Global CLAUDE.md 'Never cp into ~/.claude/skills'. Destination position is enforced: the installed-skills path must be the LAST token of the command segment, so copying FROM an installed dir out to the repo never fires.",
       "value_proof": "declining fire-attempt rate (token_class core.skills:copy-into-installed); retire on false-positive evidence"
+    },
+    {
+      "id": "core.skills:edit-installed-copy",
+      "predicate_class": "pure",
+      "mode": "deny",
+      "matchers": [
+        {
+          "tools": [
+            "Edit",
+            "Write"
+          ],
+          "field": "file_path",
+          "pattern": "/\\.(claude|codex|gemini)/skills/"
+        }
+      ],
+      "route_message": "This is an INSTALLED skill copy (overwritten on install, or symlinked through to the factory checkout) — editing it is lost work. Edit skills/<name>/ in the source repo instead.",
+      "rationale": "Registry twin of the standalone installed-skill-edit-guard: matches tool_input.file_path ONLY (prose that merely mentions claude/skills lands in tool_input.content and can never fire). Subsumes the standalone guard for dispatcher users; the standalone script remains for hosts wanting only that one guard.",
+      "value_proof": "declining fire-attempt rate (token_class core.skills:edit-installed-copy); 2 real fires already recorded by the standalone guard's telemetry; retire on false-positive evidence"
     }
   ]
 }

--- a/skills/cc-hooks/scripts/install-hooks.sh
+++ b/skills/cc-hooks/scripts/install-hooks.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# install-hooks.sh — wire the AgentOps policy dispatcher into Claude settings,
+# from ANY install shape (epic age-4qw1: hooks ship by default).
+#
+# This copy lives INSIDE the cc-hooks skill package so every distribution path
+# carries its own wiring:
+#   - npx skills / skills.sh copy  -> ~/.claude/skills/cc-hooks/scripts/install-hooks.sh
+#   - git clone / brew checkout    -> skills/cc-hooks/scripts/install-hooks.sh
+#     (scripts/install-policy-dispatch.sh at the repo root delegates here)
+#   - Claude Code PLUGIN installs need NO installer at all: the plugin bundles
+#     hooks/hooks.json and Claude wires it automatically.
+#
+# Everything resolves relative to THIS script's skill dir, so it works from a
+# copied skill directory with no repo present. Idempotent; backs up settings.
+#
+# Usage:
+#   install-hooks.sh            # user settings (~/.claude/settings.json)
+#   install-hooks.sh --project  # project settings (.claude/settings.json)
+#   SETTINGS=/path/settings.json install-hooks.sh
+set -euo pipefail
+umask 022
+
+# shellcheck disable=SC1007  # CDPATH= scopes an empty CDPATH to the cd, intentionally
+script_dir="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+skill_dir="$(dirname "$script_dir")"
+src_dispatch="${skill_dir}/hooks/policy-dispatch.sh"
+src_policies="${skill_dir}/policies/policies.json"
+lint="${script_dir}/lint-policies.sh"
+[[ -f "$src_dispatch" ]] || { echo "ERROR: dispatcher missing: ${src_dispatch}" >&2; exit 1; }
+[[ -f "$src_policies" ]] || { echo "ERROR: registry missing: ${src_policies}" >&2; exit 1; }
+command -v jq >/dev/null || { echo "ERROR: jq required" >&2; exit 1; }
+
+# Never install a registry that fails its own contract.
+bash "$lint" "$src_policies"
+
+settings="${SETTINGS:-}"
+if [[ -z "$settings" ]]; then
+  case "${1:-}" in
+    --project) settings=".claude/settings.json" ;;
+    *)         settings="${HOME}/.claude/settings.json" ;;
+  esac
+fi
+
+hooks_dir="${HOME}/.claude/hooks/aop"
+mkdir -p "$hooks_dir"
+install -m 0755 "$src_dispatch" "${hooks_dir}/policy-dispatch.sh"
+install -m 0644 "$src_policies" "${hooks_dir}/policies.json"
+dst="${hooks_dir}/policy-dispatch.sh"
+echo "✓ installed ${dst} (+ policies.json beside it)"
+
+mkdir -p "$(dirname "$settings")"
+[[ -f "$settings" ]] || echo '{}' > "$settings"
+
+if [[ -s "$settings" ]]; then
+  backup="${settings}.bak.$(date +%Y%m%d%H%M%S)"
+  cp -p "$settings" "$backup"
+  echo "✓ backed up settings → ${backup}"
+fi
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+jq --arg cmd "$dst" '
+  .hooks //= {} |
+  .hooks.PreToolUse //= [] |
+  reduce ("Bash", "Edit|Write") as $m (.;
+    if any(.hooks.PreToolUse[]?; .matcher == $m and any((.hooks // [])[]?; .command == $cmd))
+    then .
+    else .hooks.PreToolUse += [{
+      "matcher": $m,
+      "hooks": [ { "type": "command", "command": $cmd } ]
+    }]
+    end
+  )
+' "$settings" > "$tmp" && mv "$tmp" "$settings"
+trap - EXIT
+
+if grep -qF "$dst" "$settings"; then
+  echo "✓ wired PreToolUse (Bash, Edit|Write) policy dispatcher into ${settings}"
+else
+  echo "ERROR: failed to wire dispatcher into ${settings}" >&2
+  exit 1
+fi
+
+echo ""
+echo "Policy dispatcher active for this Claude scope. SILENT on every clean call;"
+echo "deny policies block with a one-line route to the correct tool; fires land one"
+echo "hashed telemetry line in \${AGENTOPS_HOME:-~/.agents/ao}/guardrail-telemetry.jsonl."
+echo "Waive once:  AOP_WAIVE=<policy-id> <your command>"
+echo "Uninstall:   remove the two PreToolUse matchers for ${dst} from ${settings}, then rm -rf ${hooks_dir}"

--- a/tests/scripts/policy-dispatch.bats
+++ b/tests/scripts/policy-dispatch.bats
@@ -134,6 +134,33 @@ telemetry_lines() {
   [ "$status" -eq 2 ]
 }
 
+# ---------- policy (d): core.skills:edit-installed-copy ---------------------
+
+@test "FIRE deny: Edit of an installed skill copy blocks, routes to repo skills/" {
+  run run_dispatch Edit file_path "$HOME/.claude/skills/evolve/SKILL.md"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"core.skills:edit-installed-copy"* ]]
+  [[ "$output" == *"INSTALLED skill copy"* ]]
+}
+
+@test "SILENT: Edit of a repo skills/ source path does not fire" {
+  run run_dispatch Edit file_path "/Users/dev/agentops/skills/cc-hooks/SKILL.md"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ---------- plugin layout -----------------------------------------------------
+
+@test "plugin layout: dispatcher resolves ../policies/policies.json without AOP_POLICIES" {
+  plugin="$TMPDIR/plugin/skills/cc-hooks"
+  mkdir -p "$plugin"
+  cp -R "$BATS_TEST_DIRNAME/../../skills/cc-hooks/hooks" "$plugin/hooks"
+  cp -R "$BATS_TEST_DIRNAME/../../skills/cc-hooks/policies" "$plugin/policies"
+  run bash -c 'unset AOP_POLICIES; jq -nc "{tool_name:\"Bash\", tool_input:{command:\"git add _beads/x\"}, session_id:\"plugin-sess\"}" | bash "$1/hooks/policy-dispatch.sh"' _ "$plugin"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"core.git:add-beads-ledger"* ]]
+}
+
 @test "SILENT: copying FROM an installed skills dir OUT to the repo does not fire" {
   run run_dispatch Bash command "cp $HOME/.claude/skills/foo/SKILL.md /tmp/inspect.md"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Doctrine flip: enforcement hooks on by default

Operator directive: hooks reach **every** user regardless of install path. Injection hooks stay dead (#511, delta=0) — the hookless-cold-start gate is untouched and passing.

### Delivery per install path

| Path | Delivery |
|---|---|
| Claude Code plugin (marketplace) | **Automatic** — new `hooks/hooks.json` at plugin root; Claude wires the policy dispatcher on install (`${CLAUDE_PLUGIN_ROOT}` paths, 10s timeout, Bash + Edit\|Write) |
| npx skills / skills.sh copies | Skill package now carries its own installer: `skills/cc-hooks/scripts/install-hooks.sh` (resolves everything relative to the skill dir; works with no repo present) |
| git clone / brew | `scripts/install-policy-dispatch.sh` → thin delegator to the skill-embedded installer |

### Also in this PR

- 4th registry policy `core.skills:edit-installed-copy` (Edit|Write, `file_path`-only) — registry twin of the standalone guard, so dispatcher users get the full protection set.
- Dispatcher hardening: malformed stdin now fully silent (fail-open, zero stderr) — validator security-pass finding.
- README admission-control section; cc-hooks SKILL.md posture flip (description, constraints, delivery table).
- Codex twin force-synced (incl. the new installer file), skill mesh + catalog regenerated.

### Evidence

- 28/28 policy-dispatch bats (incl. plugin-layout registry-fallback test); 16/16 on the injection-doctrine + standalone-guard suites.
- `ao gate check`: 28 pass / 0 fail on the exact subject.
- Fresh-context validation: first round returned FAIL (uncommitted regen outputs + a stderr leak on malformed stdin) — repaired, amended, re-validation in flight; merge follows a PASS verdict.
- Adversarial security pass on the dispatcher (it auto-activates for plugin users): empty/malformed/1MB stdin, invalid registry, concurrent fires — all fail-open, silent, correct.

Epic: age-4qw1 (H1/H2 landed previously as 0eaf21f0c). Out of scope: Codex-plugin hook parity (follow-up on the epic).