### PR TITLE
B4: prohibit headless claude invocation — LAW 0 fail-closed (age-6j9ee.4)

### DIFF
--- a/cli/internal/eval/runtime.go
+++ b/cli/internal/eval/runtime.go
@@ -16,13 +16,15 @@ import (
 	"github.com/boshu2/agentops/cli/internal/runtimecmd"
 )
 
-const (
-	claudeExecutable = "claude"
-	codexExecutable  = "codex"
-)
+// codexExecutable is the default binary for the codex live adapter. There is no
+// claude equivalent: a live claude adapter is refused at construction (LAW 0),
+// so no default claude command is ever built. See liveRuntimeAdapterFor.
+const codexExecutable = "codex"
 
 // LiveRuntimeOptions configures an optional live runtime adapter execution.
-// Callers must set Enabled=true before any external Claude/Codex process is run.
+// Callers must set Enabled=true before any external runtime process is run.
+// Codex is the only runtime that can be live-invoked; a claude live invocation is
+// refused (LAW 0), regardless of Enabled.
 type LiveRuntimeOptions struct {
 	Suite          *Suite
 	SuitePath      string
@@ -47,7 +49,7 @@ type LiveRuntimeOptions struct {
 	OverrideDisableHooks bool
 }
 
-// RuntimeCommand describes one Claude or Codex process invocation.
+// RuntimeCommand describes one live runtime (Codex) process invocation.
 type RuntimeCommand struct {
 	Executable     string
 	Args           []string
@@ -83,7 +85,7 @@ type RuntimeVersionRunner func(context.Context, RuntimeCommand) (string, error)
 type liveRuntimeAdapter interface {
 	DefaultCommand() string
 	VersionArgs() []string
-	DirectArgs(command, prompt string) []string
+	DirectArgs(command, prompt string) ([]string, error)
 }
 
 type staticLiveRuntimeAdapter struct {
@@ -99,13 +101,16 @@ func (a staticLiveRuntimeAdapter) VersionArgs() []string {
 	return append([]string{}, a.versionArgs...)
 }
 
-func (a staticLiveRuntimeAdapter) DirectArgs(command, prompt string) []string {
+func (a staticLiveRuntimeAdapter) DirectArgs(command, prompt string) ([]string, error) {
 	return runtimecmd.DirectArgs(command, prompt)
 }
 
-// RunLiveRuntime executes an optional Claude or Codex adapter run and returns a
-// normal eval run record. It skips instead of invoking external processes unless
-// opts.Enabled is true.
+// RunLiveRuntime executes an optional live Codex adapter run and returns a normal
+// eval run record. It skips instead of invoking external processes unless
+// opts.Enabled is true. The claude runtime is fail-closed (LAW 0): a suite may
+// declare and be scored against runtime=claude, but any attempt to *live-invoke*
+// claude is refused before a process spawns — a headless `claude -p` would bill
+// the Anthropic API / burn the Claude Max quota.
 func RunLiveRuntime(ctx context.Context, opts LiveRuntimeOptions) (*RunRecord, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -181,9 +186,17 @@ func RunLiveRuntime(ctx context.Context, opts LiveRuntimeOptions) (*RunRecord, e
 	if runner == nil {
 		runner = defaultRuntimeRunner
 	}
+	// LAW 0 defense-in-depth: even though liveRuntimeAdapterFor already refuses
+	// the claude runtime, re-check the concrete argv here — DirectArgs fail-closes
+	// on any command resolving to the claude binary and never emits `-p`/`--print`.
+	directArgs, argErr := adapter.DirectArgs(command, liveRuntimePrompt(opts, suite))
+	if argErr != nil {
+		markRuntimeError(record, suite, argErr.Error())
+		return finishLiveRuntimeRun(opts, record, now)
+	}
 	result, attempts, runErr := runLiveRuntimeWithAttempts(ctx, runner, RuntimeCommand{
 		Executable:     executablePath,
-		Args:           adapter.DirectArgs(command, liveRuntimePrompt(opts, suite)),
+		Args:           directArgs,
 		Env:            env,
 		Dir:            workDir,
 		TimeoutSeconds: record.Runtime.TimeoutSeconds,
@@ -228,10 +241,12 @@ func probeRuntimeVersion(ctx context.Context, opts LiveRuntimeOptions, adapter l
 func liveRuntimeAdapterFor(runtimeName Runtime) (liveRuntimeAdapter, error) {
 	switch runtimeName {
 	case RuntimeClaude:
-		return staticLiveRuntimeAdapter{
-			defaultCommand: claudeExecutable,
-			versionArgs:    []string{"--version"},
-		}, nil
+		// LAW 0 (age-6j9ee.4): a live `claude` adapter would spawn a headless
+		// `claude -p` process, which bills the Anthropic API / burns the Claude
+		// Max quota. The runtime enum stays valid for suite parsing and scoring
+		// attribution, but live invocation is fail-closed here — no process is
+		// ever spawned for it (not even a version probe).
+		return nil, fmt.Errorf("%w", runtimecmd.ErrClaudeHeadlessProhibited)
 	case RuntimeCodex:
 		return staticLiveRuntimeAdapter{
 			defaultCommand: codexExecutable,

--- a/cli/internal/eval/runtime.go
+++ b/cli/internal/eval/runtime.go
@@ -127,13 +127,9 @@ func RunLiveRuntime(ctx context.Context, opts LiveRuntimeOptions) (*RunRecord, e
 			return nil, err
 		}
 	}
-	adapter, err := liveRuntimeAdapterFor(runtimeName)
-	if err != nil {
-		return nil, err
-	}
-
 	workDir := opts.WorkDir
 	if workDir == "" {
+		var err error
 		workDir, err = os.Getwd()
 		if err != nil {
 			return nil, fmt.Errorf("get working directory: %w", err)
@@ -149,15 +145,41 @@ func RunLiveRuntime(ctx context.Context, opts LiveRuntimeOptions) (*RunRecord, e
 	record.Runtime.Model = firstNonEmpty(opts.Model, model)
 	record.Runtime.Profile = firstNonEmpty(opts.Profile, profile)
 
+	// Live disabled: no external process is ever spawned, so this is the
+	// deterministic parse/skip path. It must NOT apply the LAW 0 spawn guard and
+	// must NOT construct a live adapter — a suite may declare runtime=claude and
+	// still be parsed and skipped here exactly as before (finding 3, age-6j9ee.4).
+	// The claude refusal fires only on the process-spawning path below.
 	if !opts.Enabled {
 		markRuntimeSkipped(record, suite, "live runtime disabled; set LiveRuntimeOptions.Enabled to true")
 		return finishLiveRuntimeRun(opts, record, now)
+	}
+
+	// From here on we are on the live (process-spawning) path.
+	//
+	// Enum-level LAW 0 gate: a claude runtime *enum* never has a live adapter, so
+	// no default claude command is ever built.
+	adapter, err := liveRuntimeAdapterFor(runtimeName)
+	if err != nil {
+		return nil, err
 	}
 
 	command := strings.TrimSpace(opts.RuntimeCommand)
 	if command == "" {
 		command = adapter.DefaultCommand()
 	}
+
+	// Command-level LAW 0 gate, BEFORE any process spawn (finding 1, age-6j9ee.4):
+	// even when the runtime enum is a live-invocable adapter (e.g. codex), the
+	// RESOLVED command may still name the claude binary — a bare `claude`, an
+	// env-wrapped form (`env -i claude`), or an absolute path (`/fake/bin/claude`).
+	// Refuse on the resolved tokens here, before LookPath and before the version
+	// probe, so no `claude --version` (or any other) process is ever launched.
+	// DirectArgs re-checks this at argv construction as defense-in-depth.
+	if runtimecmd.ContainsClaudeToken(command) {
+		return nil, fmt.Errorf("%w", runtimecmd.ErrClaudeHeadlessProhibited)
+	}
+
 	executable, _ := runtimecmd.Split(command)
 	if executable == "" {
 		markRuntimeSkipped(record, suite, "runtime command is empty")
@@ -186,9 +208,10 @@ func RunLiveRuntime(ctx context.Context, opts LiveRuntimeOptions) (*RunRecord, e
 	if runner == nil {
 		runner = defaultRuntimeRunner
 	}
-	// LAW 0 defense-in-depth: even though liveRuntimeAdapterFor already refuses
-	// the claude runtime, re-check the concrete argv here — DirectArgs fail-closes
-	// on any command resolving to the claude binary and never emits `-p`/`--print`.
+	// LAW 0 defense-in-depth: the enum gate (liveRuntimeAdapterFor) and the
+	// resolved-command gate (ContainsClaudeToken above) already refuse claude
+	// before any spawn; re-check at argv construction so DirectArgs remains the
+	// final chokepoint that never emits `-p`/`--print` for the claude binary.
 	directArgs, argErr := adapter.DirectArgs(command, liveRuntimePrompt(opts, suite))
 	if argErr != nil {
 		markRuntimeError(record, suite, argErr.Error())

--- a/cli/internal/eval/runtime_test.go
+++ b/cli/internal/eval/runtime_test.go
@@ -8,6 +8,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/runtimecmd"
 )
 
 func TestRunLiveRuntimeSkipsWhenExecutableUnavailable(t *testing.T) {
@@ -16,7 +18,8 @@ func TestRunLiveRuntimeSkipsWhenExecutableUnavailable(t *testing.T) {
 		runtime    Runtime
 		executable string
 	}{
-		{name: "claude", runtime: RuntimeClaude, executable: "claude"},
+		// claude is refused at adapter construction (LAW 0) before the
+		// executable-availability skip path; see TestRunLiveRuntimeRefusesClaude.
 		{name: "codex", runtime: RuntimeCodex, executable: "codex"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -185,24 +188,26 @@ func TestRunLiveRuntimeIsolatesAndScrubsCodexEnvironment(t *testing.T) {
 }
 
 func TestRunLiveRuntimeCapturesTranscriptAndScorecardArtifacts(t *testing.T) {
-	suite := liveRuntimeSuite(RuntimeClaude)
-	transcriptPath := filepath.Join(t.TempDir(), "claude-transcript.jsonl")
+	// Uses codex: claude is refused at construction (LAW 0), so the transcript /
+	// scorecard artifact plumbing is exercised over the only live-invocable runtime.
+	suite := liveRuntimeSuite(RuntimeCodex)
+	transcriptPath := filepath.Join(t.TempDir(), "codex-transcript.jsonl")
 	scorecardPath := filepath.Join(t.TempDir(), "scorecard.json")
 
 	run, err := RunLiveRuntime(context.Background(), LiveRuntimeOptions{
 		Suite:          suite,
 		RunID:          "live-artifacts",
-		Runtime:        RuntimeClaude,
-		RuntimeCommand: "claude --model sonnet",
+		Runtime:        RuntimeCodex,
+		RuntimeCommand: "codex --model sonnet",
 		Enabled:        true,
 		LookPath: func(name string) (string, error) {
-			if name != "claude" {
-				t.Fatalf("lookPath name = %q, want claude", name)
+			if name != "codex" {
+				t.Fatalf("lookPath name = %q, want codex", name)
 			}
-			return "/fake/bin/claude", nil
+			return "/fake/bin/codex", nil
 		},
 		VersionRunner: func(ctx context.Context, cmd RuntimeCommand) (string, error) {
-			return "claude 2.0.0", nil
+			return "codex 2.0.0", nil
 		},
 		Runner: func(ctx context.Context, cmd RuntimeCommand) (RuntimeExecutionResult, error) {
 			return RuntimeExecutionResult{
@@ -221,8 +226,8 @@ func TestRunLiveRuntimeCapturesTranscriptAndScorecardArtifacts(t *testing.T) {
 		t.Fatalf("RunLiveRuntime returned error: %v", err)
 	}
 
-	if run.Runtime.Version != "claude 2.0.0" {
-		t.Fatalf("version = %q, want claude 2.0.0", run.Runtime.Version)
+	if run.Runtime.Version != "codex 2.0.0" {
+		t.Fatalf("version = %q, want codex 2.0.0", run.Runtime.Version)
 	}
 	if run.Runtime.Model != "sonnet" {
 		t.Fatalf("model = %q, want sonnet", run.Runtime.Model)
@@ -307,14 +312,14 @@ func assertArtifact(t *testing.T, artifacts []Artifact, want Artifact) {
 }
 
 func TestRunLiveRuntimePropagatesRunnerErrors(t *testing.T) {
-	suite := liveRuntimeSuite(RuntimeClaude)
+	suite := liveRuntimeSuite(RuntimeCodex)
 	run, err := RunLiveRuntime(context.Background(), LiveRuntimeOptions{
 		Suite:   suite,
 		RunID:   "live-error",
-		Runtime: RuntimeClaude,
+		Runtime: RuntimeCodex,
 		Enabled: true,
 		LookPath: func(name string) (string, error) {
-			return "/fake/bin/claude", nil
+			return "/fake/bin/codex", nil
 		},
 		VersionRunner: func(ctx context.Context, cmd RuntimeCommand) (string, error) {
 			return "", nil
@@ -332,6 +337,38 @@ func TestRunLiveRuntimePropagatesRunnerErrors(t *testing.T) {
 	}
 	if run.CaseResults[0].FailureMessage != "runtime failed" {
 		t.Fatalf("failure = %q, want runtime failed", run.CaseResults[0].FailureMessage)
+	}
+}
+
+// TestRunLiveRuntimeRefusesClaude is the LAW 0 fail-closed contract at the eval
+// layer (age-6j9ee.4): a suite may declare runtime=claude and parse fine, but
+// enabling a live claude run must be refused BEFORE any process spawns — no
+// version probe, no runner call, no `claude -p`. LookPath / VersionRunner / Runner
+// all fail the test if invoked, proving nothing external is touched.
+func TestRunLiveRuntimeRefusesClaude(t *testing.T) {
+	suite := liveRuntimeSuite(RuntimeClaude)
+	_, err := RunLiveRuntime(context.Background(), LiveRuntimeOptions{
+		Suite:          suite,
+		RunID:          "live-claude-refused",
+		Runtime:        RuntimeClaude,
+		RuntimeCommand: "claude --model sonnet",
+		Enabled:        true,
+		LookPath: func(name string) (string, error) {
+			t.Fatalf("LookPath must not be called for a refused claude runtime (got %q)", name)
+			return "", nil
+		},
+		VersionRunner: func(ctx context.Context, cmd RuntimeCommand) (string, error) {
+			t.Fatalf("VersionRunner must not be called for a refused claude runtime")
+			return "", nil
+		},
+		Runner: func(ctx context.Context, cmd RuntimeCommand) (RuntimeExecutionResult, error) {
+			t.Fatalf("Runner must not be called for a refused claude runtime")
+			return RuntimeExecutionResult{}, nil
+		},
+		Now: fixedEvalTime,
+	})
+	if !errors.Is(err, runtimecmd.ErrClaudeHeadlessProhibited) {
+		t.Fatalf("RunLiveRuntime(claude) err = %v, want ErrClaudeHeadlessProhibited", err)
 	}
 }
 

--- a/cli/internal/eval/runtime_test.go
+++ b/cli/internal/eval/runtime_test.go
@@ -372,6 +372,91 @@ func TestRunLiveRuntimeRefusesClaude(t *testing.T) {
 	}
 }
 
+// TestRunLiveRuntimeRefusesClaudeCommandBeforeSpawn is the finding-1 contract
+// (age-6j9ee.4): even when the runtime ENUM is a live-invocable adapter (codex),
+// a RESOLVED command that names the claude binary — as a bare token, an
+// env-wrapped form, or an absolute path — must be refused BEFORE any process is
+// spawned, including before the `claude --version` probe. LookPath / VersionRunner
+// / Runner are fatal-if-called, proving nothing external (not even --version) runs.
+func TestRunLiveRuntimeRefusesClaudeCommandBeforeSpawn(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		command string
+	}{
+		{name: "flagged command", command: "claude --model sonnet"},
+		{name: "absolute path", command: "/fake/bin/claude"},
+		{name: "env wrapped", command: "env -i claude"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := RunLiveRuntime(context.Background(), LiveRuntimeOptions{
+				Suite:          liveRuntimeSuite(RuntimeCodex),
+				RunID:          "live-codex-claude-cmd",
+				Runtime:        RuntimeCodex, // enum is codex; the COMMAND smuggles claude
+				RuntimeCommand: tc.command,
+				Enabled:        true,
+				LookPath: func(name string) (string, error) {
+					t.Fatalf("LookPath must not run for a claude-resolving command (got %q)", name)
+					return "", nil
+				},
+				VersionRunner: func(ctx context.Context, cmd RuntimeCommand) (string, error) {
+					t.Fatalf("VersionRunner must not run — no `claude --version` may spawn")
+					return "", nil
+				},
+				Runner: func(ctx context.Context, cmd RuntimeCommand) (RuntimeExecutionResult, error) {
+					t.Fatalf("Runner must not run for a claude-resolving command")
+					return RuntimeExecutionResult{}, nil
+				},
+				Now: fixedEvalTime,
+			})
+			if !errors.Is(err, runtimecmd.ErrClaudeHeadlessProhibited) {
+				t.Fatalf("RunLiveRuntime(codex, %q) err = %v, want ErrClaudeHeadlessProhibited", tc.command, err)
+			}
+		})
+	}
+}
+
+// TestRunLiveRuntimeDisabledSkipsClaudeWithoutRefusal is the finding-3 contract
+// (age-6j9ee.4): a disabled live run spawns nothing, so it is the deterministic
+// parse/skip path. A suite declaring runtime=claude must parse and SKIP here
+// exactly as before — no LAW 0 refusal, no error — because the refusal fires only
+// on paths that would spawn a process. LookPath / VersionRunner / Runner are
+// fatal-if-called.
+func TestRunLiveRuntimeDisabledSkipsClaudeWithoutRefusal(t *testing.T) {
+	run, err := RunLiveRuntime(context.Background(), LiveRuntimeOptions{
+		Suite:          liveRuntimeSuite(RuntimeClaude),
+		RunID:          "live-claude-disabled",
+		Runtime:        RuntimeClaude,
+		RuntimeCommand: "claude --model sonnet",
+		Enabled:        false,
+		LookPath: func(name string) (string, error) {
+			t.Fatalf("LookPath must not run when live runtime is disabled (got %q)", name)
+			return "", nil
+		},
+		VersionRunner: func(ctx context.Context, cmd RuntimeCommand) (string, error) {
+			t.Fatalf("VersionRunner must not run when live runtime is disabled")
+			return "", nil
+		},
+		Runner: func(ctx context.Context, cmd RuntimeCommand) (RuntimeExecutionResult, error) {
+			t.Fatalf("Runner must not run when live runtime is disabled")
+			return RuntimeExecutionResult{}, nil
+		},
+		Now: fixedEvalTime,
+	})
+	if err != nil {
+		t.Fatalf("RunLiveRuntime(claude, disabled) returned error: %v", err)
+	}
+	if run.Status != StatusSkipped {
+		t.Fatalf("status = %s, want skipped", run.Status)
+	}
+	wantReason := "live runtime disabled; set LiveRuntimeOptions.Enabled to true"
+	if run.Runtime.SkippedReason != wantReason {
+		t.Fatalf("skipped_reason = %q, want %q", run.Runtime.SkippedReason, wantReason)
+	}
+	if run.Runtime.Name != RuntimeClaude || !run.Runtime.Live {
+		t.Fatalf("runtime = %+v, want live claude", run.Runtime)
+	}
+}
+
 // W1.1 — DisableHooks plumbing. Verifies the hook-suppression toggle propagates
 // through liveEnvironmentRecord, liveRuntimeEnv, and liveRuntimePrompt whether
 // it comes from the suite or the LiveRuntimeOptions override.

--- a/cli/internal/runtimecmd/runtimecmd.go
+++ b/cli/internal/runtimecmd/runtimecmd.go
@@ -1,13 +1,28 @@
 // Package runtimecmd parses and builds the CLI command lines used to invoke a
-// coding-agent runtime (e.g. `codex exec <prompt>`, `claude -p <prompt>`). It was
-// extracted from the former rpi engine (age-tlj6 teardown): the helpers are a
-// reusable utility with no orchestration-engine coupling, consumed by the eval
-// runtime. Pure string functions — no I/O, no side effects.
+// coding-agent runtime (e.g. `codex exec <prompt>`). It was extracted from the
+// former rpi engine (age-tlj6 teardown): the helpers are a reusable utility with
+// no orchestration-engine coupling, consumed by the eval runtime. Pure string
+// functions — no I/O, no side effects.
+//
+// LAW 0 (age-6j9ee.4): a headless `claude -p` / `claude --print` invocation bills
+// the Anthropic API / burns the Claude Max quota and is prohibited environment-wide.
+// DirectArgs therefore fail-closes: it never emits `-p`/`--print`, and it refuses
+// outright to build an argv for the `claude` binary. Route headless work to codex
+// or an interactive pane instead.
 package runtimecmd
 
 import (
+	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
+)
+
+// ErrClaudeHeadlessProhibited is returned by DirectArgs when asked to build a
+// direct (headless) invocation of the `claude` binary. It is the LAW 0 fail-closed
+// error: a headless claude call is never permitted, directly or indirectly.
+var ErrClaudeHeadlessProhibited = errors.New(
+	"claude headless invocation is prohibited (LAW 0): route this work to codex or an interactive pane",
 )
 
 // BinaryName extracts the lowercase base binary name from a runtime command string.
@@ -29,12 +44,38 @@ func Split(command string) (string, []string) {
 	return fields[0], fields[1:]
 }
 
-// DirectArgs builds the argument list for direct (non-stream) runtime execution.
-func DirectArgs(command, prompt string) []string {
-	_, prefixArgs := Split(command)
-	args := append([]string{}, prefixArgs...)
-	if BinaryName(command) == "codex" {
-		return append(args, "exec", prompt)
+// containsClaudeToken reports whether any whitespace-separated token of command
+// resolves (by base name, case-insensitively, with an optional .exe suffix) to
+// the `claude` binary. This catches env-wrapped forms like `env -i claude` in
+// addition to a bare `claude`, so no framing can smuggle the prohibited binary
+// past the LAW 0 gate.
+func containsClaudeToken(command string) bool {
+	for _, field := range strings.Fields(strings.TrimSpace(command)) {
+		base := strings.ToLower(filepath.Base(field))
+		base = strings.TrimSuffix(base, ".exe")
+		if base == "claude" {
+			return true
+		}
 	}
-	return append(args, "-p", prompt)
+	return false
+}
+
+// DirectArgs builds the argument list for direct (non-stream) runtime execution.
+//
+// Codex is the only supported direct runtime: it returns `<prefix args...> exec
+// <prompt>`. Any command that resolves to the `claude` binary is refused with
+// ErrClaudeHeadlessProhibited (LAW 0 — a headless `claude -p` bills the API /
+// burns quota). Any other, unrecognized runtime is likewise refused rather than
+// falling back to a `-p <prompt>` form, so this function can never emit the
+// prohibited flags.
+func DirectArgs(command, prompt string) ([]string, error) {
+	if containsClaudeToken(command) {
+		return nil, ErrClaudeHeadlessProhibited
+	}
+	_, prefixArgs := Split(command)
+	if BinaryName(command) == "codex" {
+		args := append([]string{}, prefixArgs...)
+		return append(args, "exec", prompt), nil
+	}
+	return nil, fmt.Errorf("runtimecmd: no direct-invocation form for command %q (only codex is supported for headless execution)", command)
 }

--- a/cli/internal/runtimecmd/runtimecmd.go
+++ b/cli/internal/runtimecmd/runtimecmd.go
@@ -44,12 +44,16 @@ func Split(command string) (string, []string) {
 	return fields[0], fields[1:]
 }
 
-// containsClaudeToken reports whether any whitespace-separated token of command
+// ContainsClaudeToken reports whether any whitespace-separated token of command
 // resolves (by base name, case-insensitively, with an optional .exe suffix) to
-// the `claude` binary. This catches env-wrapped forms like `env -i claude` in
-// addition to a bare `claude`, so no framing can smuggle the prohibited binary
-// past the LAW 0 gate.
-func containsClaudeToken(command string) bool {
+// the `claude` binary. This catches env-wrapped forms like `env -i claude` and
+// absolute paths like `/fake/bin/claude` in addition to a bare `claude`, so no
+// framing can smuggle the prohibited binary past the LAW 0 gate.
+//
+// It is exported so spawn-side callers (e.g. the eval live runtime) can fail
+// closed on the RESOLVED command tokens BEFORE any process — including a version
+// probe — is launched, not only at argv construction time.
+func ContainsClaudeToken(command string) bool {
 	for _, field := range strings.Fields(strings.TrimSpace(command)) {
 		base := strings.ToLower(filepath.Base(field))
 		base = strings.TrimSuffix(base, ".exe")
@@ -69,7 +73,7 @@ func containsClaudeToken(command string) bool {
 // falling back to a `-p <prompt>` form, so this function can never emit the
 // prohibited flags.
 func DirectArgs(command, prompt string) ([]string, error) {
-	if containsClaudeToken(command) {
+	if ContainsClaudeToken(command) {
 		return nil, ErrClaudeHeadlessProhibited
 	}
 	_, prefixArgs := Split(command)

--- a/cli/internal/runtimecmd/runtimecmd_test.go
+++ b/cli/internal/runtimecmd/runtimecmd_test.go
@@ -3,9 +3,13 @@ package runtimecmd
 
 import (
 	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -121,12 +125,50 @@ func TestDirectArgs_NeverEmitsDashP(t *testing.T) {
 	}
 }
 
-// TestNoUnreviewedDashPArgvInCLI is a repo-wide tripwire (age-6j9ee.4): it walks
+// headlessPrintLiteral reports whether the CONTENT of a single Go string literal
+// is a headless-print argv smell. It flags two shapes (age-6j9ee.4):
+//
+//  1. the argv-element form — the literal is exactly `-p` or `--print`, i.e. a
+//     single argv token passed straight to a runtime; and
+//  2. the smuggled-command form — one whitespace-separated literal that carries a
+//     `claude` token AND a standalone `-p` / `--print` flag token, e.g.
+//     `var x = "claude -p"`, `"env -i claude --print"`. The old byte-substring
+//     tripwire matched only the exact `"-p"` / `"--print"` source token and missed
+//     this entirely (validator finding: `var TripwireScratch = "claude -p"`
+//     slipped through).
+//
+// Matching is token-based (not raw substring) so it does NOT trip on identifiers
+// that merely embed the characters — e.g. the gate id `"always.door9-no-claude-p"`
+// or help text `"...default: claude..."` — which are legitimate and would only
+// bloat the allowlist.
+func headlessPrintLiteral(value string) bool {
+	if value == "-p" || value == "--print" {
+		return true
+	}
+	var hasClaude, hasPrintFlag bool
+	for _, field := range strings.Fields(value) {
+		if field == "-p" || field == "--print" {
+			hasPrintFlag = true
+			continue
+		}
+		base := strings.ToLower(filepath.Base(field))
+		base = strings.TrimSuffix(base, ".exe")
+		if base == "claude" {
+			hasClaude = true
+		}
+	}
+	return hasClaude && hasPrintFlag
+}
+
+// TestNoUnreviewedDashPArgvInCLI is a repo-wide tripwire (age-6j9ee.4): it parses
 // every non-test .go file in the cli module and asserts that the set of files
-// constructing a `-p` / `--print` argv string literal matches a known, reviewed
-// allowlist. This would have caught the original runtimecmd `claude -p` path, and
-// fails loudly if any new file reintroduces such a literal — forcing a human to
-// confirm it is not a headless-claude invocation before it can be allowlisted.
+// containing a headless-print string LITERAL (see headlessPrintLiteral) matches a
+// known, reviewed allowlist. Unlike the original byte-substring scan, it inspects
+// the parsed contents of each string literal, so it also catches a `-p`/`--print`
+// flag hidden inside a larger claude command literal (e.g. `"claude -p"`), not
+// only a bare `"-p"` argv token. It fails loudly if any new file reintroduces such
+// a literal — forcing a human to confirm it is not a headless-claude invocation
+// before it can be allowlisted.
 //
 // Known-safe today:
 //   - internal/adapters/eval/scenario_ab_sandbox.go — `sandbox-exec -p <profile>`
@@ -145,6 +187,7 @@ func TestNoUnreviewedDashPArgvInCLI(t *testing.T) {
 		t.Fatalf("cli root %q has no go.mod (test cwd assumption broke): %v", cliRoot, statErr)
 	}
 
+	fset := token.NewFileSet()
 	found := map[string]bool{}
 	walkErr := filepath.WalkDir(cliRoot, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -159,18 +202,28 @@ func TestNoUnreviewedDashPArgvInCLI(t *testing.T) {
 		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
-		data, readErr := os.ReadFile(path)
-		if readErr != nil {
-			return readErr
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
 		}
-		content := string(data)
-		if strings.Contains(content, `"-p"`) || strings.Contains(content, `"--print"`) {
-			rel, relErr := filepath.Rel(cliRoot, path)
-			if relErr != nil {
-				return relErr
+		rel, relErr := filepath.Rel(cliRoot, path)
+		if relErr != nil {
+			return relErr
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
 			}
-			found[rel] = true
-		}
+			value, unquoteErr := strconv.Unquote(lit.Value)
+			if unquoteErr != nil {
+				return true
+			}
+			if headlessPrintLiteral(value) {
+				found[rel] = true
+			}
+			return true
+		})
 		return nil
 	})
 	if walkErr != nil {
@@ -179,7 +232,7 @@ func TestNoUnreviewedDashPArgvInCLI(t *testing.T) {
 
 	for rel := range found {
 		if !allowed[rel] {
-			t.Errorf("unreviewed `-p`/`--print` argv literal in %s — if this is NOT a headless "+
+			t.Errorf("unreviewed `-p`/`--print` string literal in %s — if this is NOT a headless "+
 				"claude invocation (LAW 0), review it and add it to the allowlist in this test", rel)
 		}
 	}

--- a/cli/internal/runtimecmd/runtimecmd_test.go
+++ b/cli/internal/runtimecmd/runtimecmd_test.go
@@ -2,7 +2,11 @@
 package runtimecmd
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -53,16 +57,137 @@ func TestBinaryName(t *testing.T) {
 }
 
 func TestDirectArgs(t *testing.T) {
-	// codex uses `exec <prompt>`; everything else uses `-p <prompt>`.
-	if got := DirectArgs("codex", "hello"); !reflect.DeepEqual(got, []string{"exec", "hello"}) {
+	// codex uses `exec <prompt>`; prefix args are preserved.
+	got, err := DirectArgs("codex", "hello")
+	if err != nil {
+		t.Fatalf("DirectArgs codex returned error: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"exec", "hello"}) {
 		t.Errorf("DirectArgs codex = %v, want [exec hello]", got)
 	}
-	if got := DirectArgs("claude", "hello"); !reflect.DeepEqual(got, []string{"-p", "hello"}) {
-		t.Errorf("DirectArgs claude = %v, want [-p hello]", got)
+
+	gotPrefix, err := DirectArgs("/usr/local/bin/codex", "hi")
+	if err != nil {
+		t.Fatalf("DirectArgs codex path returned error: %v", err)
 	}
-	// prefix args are preserved; binary name is the FIRST token ("env" here, not
-	// "codex"), so this takes the non-codex -p path.
-	if got := DirectArgs("env -i codex", "hi"); !reflect.DeepEqual(got, []string{"-i", "codex", "-p", "hi"}) {
-		t.Errorf("DirectArgs with prefix = %v, want [-i codex -p hi]", got)
+	if !reflect.DeepEqual(gotPrefix, []string{"exec", "hi"}) {
+		t.Errorf("DirectArgs codex path = %v, want [exec hi]", gotPrefix)
+	}
+}
+
+// TestDirectArgs_ClaudeRefused is the LAW 0 fail-closed contract (age-6j9ee.4):
+// a headless `claude -p` bills the Anthropic API / burns quota, so DirectArgs
+// MUST refuse any command that resolves to the claude binary — replacing the old
+// behavior that emitted [-p <prompt>].
+func TestDirectArgs_ClaudeRefused(t *testing.T) {
+	claudeForms := []string{
+		"claude",
+		"Claude",
+		"claude.exe",
+		"/usr/local/bin/claude",
+		"env -i claude",             // env-wrapped: binary is `env`, but claude is a token
+		"env CLAUDE_CODE=1 claude",  // still refused
+		"  claude   ",               // whitespace padding
+	}
+	for _, form := range claudeForms {
+		got, err := DirectArgs(form, "hello")
+		if !errors.Is(err, ErrClaudeHeadlessProhibited) {
+			t.Errorf("DirectArgs(%q): err = %v, want ErrClaudeHeadlessProhibited", form, err)
+		}
+		if got != nil {
+			t.Errorf("DirectArgs(%q): args = %v, want nil (refused)", form, got)
+		}
+	}
+}
+
+// TestDirectArgs_NeverEmitsDashP is a behavioral guard: over a battery of inputs
+// — the supported codex forms, refused claude forms, and unrecognized runtimes —
+// DirectArgs must NEVER return an argv containing `-p` or `--print`. This is the
+// argv-construction chokepoint the original latent `claude -p` path ran through.
+func TestDirectArgs_NeverEmitsDashP(t *testing.T) {
+	inputs := []string{
+		"codex", "/usr/local/bin/codex", "codex exec",
+		"claude", "claude.exe", "/opt/claude", "env -i claude",
+		"gemini", "ollama", "some-future-runtime", "", "   ",
+		"env -i codex", // binary is `env` (unrecognized) — must refuse, not `-p`
+	}
+	for _, in := range inputs {
+		args, _ := DirectArgs(in, "prompt text -p not-a-flag")
+		for _, a := range args {
+			if a == "-p" || a == "--print" {
+				t.Errorf("DirectArgs(%q) emitted prohibited flag %q in argv %v", in, a, args)
+			}
+		}
+	}
+}
+
+// TestNoUnreviewedDashPArgvInCLI is a repo-wide tripwire (age-6j9ee.4): it walks
+// every non-test .go file in the cli module and asserts that the set of files
+// constructing a `-p` / `--print` argv string literal matches a known, reviewed
+// allowlist. This would have caught the original runtimecmd `claude -p` path, and
+// fails loudly if any new file reintroduces such a literal — forcing a human to
+// confirm it is not a headless-claude invocation before it can be allowlisted.
+//
+// Known-safe today:
+//   - internal/adapters/eval/scenario_ab_sandbox.go — `sandbox-exec -p <profile>`
+//     (the macOS sandbox profile flag), wrapping *codex*, never claude.
+func TestNoUnreviewedDashPArgvInCLI(t *testing.T) {
+	allowed := map[string]bool{
+		filepath.FromSlash("internal/adapters/eval/scenario_ab_sandbox.go"): true,
+	}
+
+	cliRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve cli root: %v", err)
+	}
+	// Sanity: confirm we are actually rooted at the cli module.
+	if _, statErr := os.Stat(filepath.Join(cliRoot, "go.mod")); statErr != nil {
+		t.Fatalf("cli root %q has no go.mod (test cwd assumption broke): %v", cliRoot, statErr)
+	}
+
+	found := map[string]bool{}
+	walkErr := filepath.WalkDir(cliRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == "testdata" || d.Name() == "vendor" || d.Name() == "bin" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		content := string(data)
+		if strings.Contains(content, `"-p"`) || strings.Contains(content, `"--print"`) {
+			rel, relErr := filepath.Rel(cliRoot, path)
+			if relErr != nil {
+				return relErr
+			}
+			found[rel] = true
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk cli tree: %v", walkErr)
+	}
+
+	for rel := range found {
+		if !allowed[rel] {
+			t.Errorf("unreviewed `-p`/`--print` argv literal in %s — if this is NOT a headless "+
+				"claude invocation (LAW 0), review it and add it to the allowlist in this test", rel)
+		}
+	}
+	// The allowlist must not rot: every allowlisted file must still contain such a
+	// literal, else the entry is stale and should be removed.
+	for rel := range allowed {
+		if !found[rel] {
+			t.Errorf("allowlisted file %s no longer contains a `-p`/`--print` literal; remove the stale allowlist entry", rel)
+		}
 	}
 }


### PR DESCRIPTION
Eval-remediation epic age-6j9ee. runtimecmd.DirectArgs + RunLiveRuntime refuse any claude-token command BEFORE any process spawn (fatal-if-called fakes prove zero contact); content-scanning go/parser tripwire (TestNoUnreviewedDashPArgvInCLI) catches claude+-p literals the old byte-scan missed; deterministic runtime:claude suites still parse+score (live-disabled skip moved before adapter construction). Codex path byte-identical. Enum retained for parsing compat. Sol fresh-context ACCEPT after 3-finding remediation (guard order, weak tripwire, deterministic leak). Full gate 67/67; uncapped lint 0. FF-push. Known pre-existing PR-CI red: age-sqjyl.