### PR TITLE
B1+B2: seam uniformity + drift guards + -o yaml truthfulness (age-6j9ee.1, .2)

### DIFF
--- a/cli/cmd/ao/capabilities.go
+++ b/cli/cmd/ao/capabilities.go
@@ -14,7 +14,7 @@ func init() {
 		capabilitiesadapter.NewCobraSurface(rootCmd),
 		capabilitiesadapter.RuntimePlatform{},
 	)
-	module := capabilitiescommands.NewModule(service, GetOutput)
+	module := capabilitiescommands.NewModule(service, clicontract.HostOptions{OutputMode: GetOutput})
 	command := module.Command()
 	command.GroupID = "core"
 	if err := clicontract.Attach(command, module.Contract()); err != nil {

--- a/cli/cmd/ao/carveout_regression_test.go
+++ b/cli/cmd/ao/carveout_regression_test.go
@@ -267,3 +267,205 @@ func loadFrozenLegacySymbols(t *testing.T, family string) []string {
 	}
 	return record.LegacySymbols
 }
+
+// ---------------------------------------------------------------------------
+// Seam-uniformity + drift guards (bead age-6j9ee.1 / B1)
+//
+// The cmd/ao carve-out finished with four incompatible host-seam shapes,
+// three re-rolled writeJSON bodies, and two duplicated ExitError types. The
+// checks below are the drift lock: they pin the single canonical host seam
+// (clicontract.HostOptions), keep command modules free of direct host effects,
+// and keep module/service singletons out of package main. All are AST-based and
+// cheap, mirroring the existing carve-out invariants above.
+// ---------------------------------------------------------------------------
+
+// commandModuleFiles returns every internal/commands/<family>/module.go, keyed
+// by family name, resolved against packageDir so concurrent os.Chdir in other
+// tests cannot break discovery.
+func commandModuleFiles(t *testing.T) map[string]string {
+	t.Helper()
+	base := filepath.Join(packageDir, "..", "..", "internal", "commands")
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		t.Fatalf("read commands dir %s: %v", base, err)
+	}
+	modules := map[string]string{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(base, entry.Name(), "module.go")
+		if _, statErr := os.Stat(path); statErr == nil {
+			modules[entry.Name()] = path
+		}
+	}
+	if len(modules) == 0 {
+		t.Fatalf("no command module.go files found under %s", base)
+	}
+	return modules
+}
+
+// importAliasMap maps each import's local alias to its full import path for one
+// parsed file. A dot or blank import is keyed by "." / "_".
+func importAliasMap(file *ast.File) map[string]string {
+	aliases := map[string]string{}
+	for _, spec := range file.Imports {
+		path := strings.Trim(spec.Path.Value, `"`)
+		alias := ""
+		if spec.Name != nil {
+			alias = spec.Name.Name
+		} else {
+			segments := strings.Split(path, "/")
+			alias = segments[len(segments)-1]
+		}
+		aliases[alias] = path
+	}
+	return aliases
+}
+
+// findNewModule returns the NewModule func declaration in a parsed file, if any.
+func findNewModule(file *ast.File) *ast.FuncDecl {
+	for _, decl := range file.Decls {
+		if function, ok := decl.(*ast.FuncDecl); ok && function.Recv == nil && function.Name.Name == "NewModule" {
+			return function
+		}
+	}
+	return nil
+}
+
+// TestModuleHostSeamIsSharedContract proves every command module receives its
+// host seam through the single shared clicontract.HostOptions type: no module
+// declares its own HostOptions struct, and no NewModule passes host wiring as a
+// bare positional func. Together these kill the four drifted seam shapes
+// (positional funcs, bespoke HostOptions structs, and the GlobalOptions bundle).
+func TestModuleHostSeamIsSharedContract(t *testing.T) {
+	for family, path := range commandModuleFiles(t) {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		// (a) No bespoke seam struct type declared in the module package.
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				typeSpec, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				if typeSpec.Name.Name == "HostOptions" || typeSpec.Name.Name == "GlobalOptions" {
+					t.Errorf("module %s declares bespoke seam type %q; the host seam must be the shared clicontract.HostOptions",
+						family, typeSpec.Name.Name)
+				}
+			}
+		}
+		// (b) NewModule passes no host wiring as a bare positional func.
+		newModule := findNewModule(file)
+		if newModule == nil || newModule.Type.Params == nil {
+			continue
+		}
+		for _, param := range newModule.Type.Params.List {
+			if _, isFunc := param.Type.(*ast.FuncType); isFunc {
+				names := make([]string, 0, len(param.Names))
+				for _, ident := range param.Names {
+					names = append(names, ident.Name)
+				}
+				t.Errorf("module %s NewModule takes bare positional func param %s; host seams must arrive via clicontract.HostOptions",
+					family, strings.Join(names, ", "))
+			}
+		}
+	}
+}
+
+// TestModuleImportsNoDirectHostEffects proves each module.go reaches for no
+// direct host effect: it imports neither os nor os/exec (filesystem/process
+// effects belong to injected adapters), and it never calls time.Now (the clock
+// arrives through clicontract.HostOptions.Now). Types and constants from time
+// (time.Duration, time.RFC3339) stay allowed, matching current legitimate use.
+func TestModuleImportsNoDirectHostEffects(t *testing.T) {
+	deniedImports := map[string]bool{"os": true, "os/exec": true}
+	for family, path := range commandModuleFiles(t) {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		for _, spec := range file.Imports {
+			imported := strings.Trim(spec.Path.Value, `"`)
+			if deniedImports[imported] {
+				t.Errorf("module %s imports direct-effect package %q; delegate the effect to an adapter or a host seam",
+					family, imported)
+			}
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, ok := selector.X.(*ast.Ident)
+			if ok && pkg.Name == "time" && selector.Sel.Name == "Now" {
+				t.Errorf("module %s calls time.Now; inject the clock through clicontract.HostOptions.Now", family)
+			}
+			return true
+		})
+	}
+}
+
+// TestNoModuleOrServiceSingletonPackageVars proves package main declares no
+// package-level var whose value is a command module or an app service singleton
+// — the pattern that let config and doctor drift into package globals while gate
+// and eval used constructor funcs. A var initialized by a call into an
+// internal/commands/* package, or by any New*Service constructor, must instead
+// live inside a newXxxCommand() constructor.
+func TestNoModuleOrServiceSingletonPackageVars(t *testing.T) {
+	for name, path := range packageGoFiles(t) {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		aliases := importAliasMap(file)
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.VAR {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				value, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for _, expr := range value.Values {
+					call, ok := expr.(*ast.CallExpr)
+					if !ok {
+						continue
+					}
+					selector, ok := call.Fun.(*ast.SelectorExpr)
+					if !ok {
+						continue
+					}
+					pkg, ok := selector.X.(*ast.Ident)
+					if !ok {
+						continue
+					}
+					importPath := aliases[pkg.Name]
+					if strings.Contains(importPath, "/internal/commands/") {
+						t.Errorf("cmd/ao/%s declares package-level var initialized by module constructor %s.%s; move it into a newXxxCommand() constructor",
+							name, pkg.Name, selector.Sel.Name)
+					}
+					if strings.HasPrefix(selector.Sel.Name, "New") && strings.HasSuffix(selector.Sel.Name, "Service") {
+						t.Errorf("cmd/ao/%s declares package-level service singleton var via %s.%s; construct it inside a newXxxCommand() constructor",
+							name, pkg.Name, selector.Sel.Name)
+					}
+				}
+			}
+		}
+	}
+}

--- a/cli/cmd/ao/carveout_regression_test.go
+++ b/cli/cmd/ao/carveout_regression_test.go
@@ -380,6 +380,102 @@ func TestModuleHostSeamIsSharedContract(t *testing.T) {
 	}
 }
 
+// newModuleTakesHostOptions reports whether a module's NewModule signature
+// includes a parameter of the shared clicontract.HostOptions type. It resolves
+// the clicontract import alias so a renamed import is still detected.
+func newModuleTakesHostOptions(file *ast.File, newModule *ast.FuncDecl) bool {
+	if newModule == nil || newModule.Type.Params == nil {
+		return false
+	}
+	aliases := importAliasMap(file)
+	for _, param := range newModule.Type.Params.List {
+		// A HostOptions param may arrive by value (clicontract.HostOptions) or by
+		// pointer (*clicontract.HostOptions); unwrap the star.
+		typ := param.Type
+		if star, ok := typ.(*ast.StarExpr); ok {
+			typ = star.X
+		}
+		selector, ok := typ.(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+		pkg, ok := selector.X.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		if aliases[pkg.Name] == "github.com/boshu2/agentops/cli/internal/clicontract" && selector.Sel.Name == "HostOptions" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestEveryModuleTakesHostSeamOrIsExempt closes the coverage hole that let five
+// modules bypass the shared host seam undetected: the shape guard
+// (TestModuleHostSeamIsSharedContract) only checks that IF a module takes a host
+// seam it is the shared type — it never required a seam to exist. This test
+// requires coverage: every internal/commands/<family>/module.go NewModule must
+// EITHER take clicontract.HostOptions OR appear in the committed
+// testdata/seamless-module-exemptions.json with a reason. It fails three ways so
+// the exemption list cannot drift from reality: (1) a zero-seam module that is
+// not exempted (a new bypasser), (2) a module that gained a HostOptions seam but
+// is still exempted (a stale exemption), and (3) an exemption for a module that
+// no longer exists.
+func TestEveryModuleTakesHostSeamOrIsExempt(t *testing.T) {
+	type exemption struct {
+		Module string `json:"module"`
+		Reason string `json:"reason"`
+	}
+	exemptPath := filepath.Join(packageDir, "testdata", "seamless-module-exemptions.json")
+	data, err := os.ReadFile(exemptPath)
+	if err != nil {
+		t.Fatalf("read seamless-module exemptions %s: %v", exemptPath, err)
+	}
+	var doc struct {
+		Exempt []exemption `json:"exempt"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("decode seamless-module exemptions: %v", err)
+	}
+	exempt := make(map[string]string, len(doc.Exempt))
+	for _, entry := range doc.Exempt {
+		if entry.Module == "" || strings.TrimSpace(entry.Reason) == "" {
+			t.Errorf("exemption entry %+v is incomplete: module and reason are both required", entry)
+			continue
+		}
+		exempt[entry.Module] = entry.Reason
+	}
+
+	seen := map[string]bool{}
+	for family, path := range commandModuleFiles(t) {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		seen[family] = true
+		takesSeam := newModuleTakesHostOptions(file, findNewModule(file))
+		_, isExempt := exempt[family]
+		switch {
+		case takesSeam && isExempt:
+			t.Errorf("module %q NewModule takes clicontract.HostOptions but is still listed in testdata/seamless-module-exemptions.json; remove the stale exemption",
+				family)
+		case !takesSeam && !isExempt:
+			t.Errorf("module %q NewModule takes no clicontract.HostOptions and is not in testdata/seamless-module-exemptions.json; wire the shared host seam or add a reasoned seam-less exemption",
+				family)
+		}
+	}
+
+	// Fail on an exemption for a module that no longer exists so the list cannot
+	// carry dead entries.
+	for family := range exempt {
+		if !seen[family] {
+			t.Errorf("stale exemption %q: no such command module under internal/commands/; remove it from testdata/seamless-module-exemptions.json",
+				family)
+		}
+	}
+}
+
 // TestModuleImportsNoDirectHostEffects proves each module.go reaches for no
 // direct host effect: it imports neither os nor os/exec (filesystem/process
 // effects belong to injected adapters), and it never calls time.Now (the clock

--- a/cli/cmd/ao/config_module.go
+++ b/cli/cmd/ao/config_module.go
@@ -2,19 +2,31 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	configadapter "github.com/boshu2/agentops/cli/internal/adapters/config"
 	"github.com/boshu2/agentops/cli/internal/clicontract"
 	configcommands "github.com/boshu2/agentops/cli/internal/commands/config"
 	configapp "github.com/boshu2/agentops/cli/internal/config"
 )
 
-var configModule = configcommands.NewModule(configapp.NewCommandService(configadapter.Gateway{}), GetOutput, GetVerbose, GetDryRun)
-var configCommand = configModule.Command()
-
 func init() {
-	configCommand.GroupID = "config"
-	if err := clicontract.Attach(configCommand, configModule.Contract()); err != nil {
+	rootCmd.AddCommand(newConfigCommand())
+}
+
+// newConfigCommand wires the config command module to its host seams (output
+// mode, verbose, dry-run) and attaches its CommandContract. Constructor-scoped
+// like the gate composition: no package-level module or command singleton, so
+// flag state lives inside internal/commands/config.
+func newConfigCommand() *cobra.Command {
+	module := configcommands.NewModule(
+		configapp.NewCommandService(configadapter.Gateway{}),
+		clicontract.HostOptions{OutputMode: GetOutput, Verbose: GetVerbose, DryRun: GetDryRun},
+	)
+	command := module.Command()
+	command.GroupID = "config"
+	if err := clicontract.Attach(command, module.Contract()); err != nil {
 		panic(err)
 	}
-	rootCmd.AddCommand(configCommand)
+	return command
 }

--- a/cli/cmd/ao/config_test.go
+++ b/cli/cmd/ao/config_test.go
@@ -108,7 +108,7 @@ func TestConfigModuleHonorsGlobalDryRun(t *testing.T) {
 	dryRun, output = true, "table"
 	t.Cleanup(func() { dryRun, output = originalDryRun, originalOutput })
 
-	command := configModule.Command()
+	command := newConfigCommand()
 	var stdout strings.Builder
 	command.SetOut(&stdout)
 	command.SetArgs([]string{"models", "--set-tier", "quality"})

--- a/cli/cmd/ao/config_test_shims_test.go
+++ b/cli/cmd/ao/config_test_shims_test.go
@@ -11,9 +11,9 @@ var (
 	configShow      bool
 	modelsSetTier   string
 	modelsSetSkill  string
-	configCmd       = configCommand
+	configCmd       = newConfigCommand()
 	configModelsCmd = func() *cobra.Command {
-		command, _, err := configCommand.Find([]string{"models"})
+		command, _, err := configCmd.Find([]string{"models"})
 		if err != nil {
 			panic(err)
 		}
@@ -24,7 +24,7 @@ var (
 type configModelsWriteResult = configapp.ModelsWriteResult
 
 func runConfig(command *cobra.Command, args []string) error {
-	fresh := configModule.Command()
+	fresh := newConfigCommand()
 	if configShow {
 		_ = fresh.Flags().Set("show", "true")
 	}
@@ -33,7 +33,7 @@ func runConfig(command *cobra.Command, args []string) error {
 }
 
 func runConfigModels(command *cobra.Command, args []string) error {
-	fresh := configModule.Command()
+	fresh := newConfigCommand()
 	models, _, err := fresh.Find([]string{"models"})
 	if err != nil {
 		return err

--- a/cli/cmd/ao/doctor_module.go
+++ b/cli/cmd/ao/doctor_module.go
@@ -10,35 +10,43 @@ import (
 	doctorapp "github.com/boshu2/agentops/cli/internal/doctor"
 )
 
+func init() {
+	rootCmd.AddCommand(newDoctorCommand())
+}
+
 func newLegacyDoctorService() doctorapp.LegacyService {
 	checks := doctoradapter.SystemLegacyChecks(version, resolveLedgerPath)
 	return doctorapp.NewLegacyService(version, checks)
 }
 
-var doctorReadService = doctorapp.NewReadService(version, doctoradapter.ReadRuntime{ToolVersion: version}, doctoradapter.ReadGateway{})
-var doctorMutationService = doctorapp.NewMutationService(doctoradapter.MutationRuntime{ToolVersion: version}, doctoradapter.MutationGateway{})
-var doctorMaintenanceService = doctorapp.NewMaintenanceService(doctoradapter.MaintenanceRuntime{}, doctoradapter.MaintenanceGateway{})
+// newDoctorCommand wires the doctor command module: its read/mutation/
+// maintenance services, the legacy check set, and the host seams (output mode,
+// dry-run, and flag-error enrichment). Constructor-scoped like the gate
+// composition — no package-level module, command, or service singleton.
+//
+// Doctor derives its JSON intent from OutputMode == "json"; the previous
+// GlobalOptions.JSON seam was redundant because negotiateOutput forces
+// output="json" whenever --json is set, so the two were always equal.
+func newDoctorCommand() *cobra.Command {
+	readService := doctorapp.NewReadService(version, doctoradapter.ReadRuntime{ToolVersion: version}, doctoradapter.ReadGateway{})
+	mutationService := doctorapp.NewMutationService(doctoradapter.MutationRuntime{ToolVersion: version}, doctoradapter.MutationGateway{})
+	maintenanceService := doctorapp.NewMaintenanceService(doctoradapter.MaintenanceRuntime{}, doctoradapter.MaintenanceGateway{})
 
-var doctorModule = doctorcommands.NewModule(doctorcommands.UseCases{
-	LegacyChecks:  newLegacyDoctorService().Checks,
-	Read:          doctorReadService,
-	Mutation:      doctorMutationService,
-	Maintenance:   doctorMaintenanceService,
-	DetectorCount: func() int { return len(doctorapp.Detectors()) },
-}, doctorcommands.HostOptions{
-	Globals: func(command *cobra.Command) doctorcommands.GlobalOptions {
-		app := AppFromContext(command.Context())
-		return doctorcommands.GlobalOptions{DryRun: app.DryRun, JSON: app.JSON, Output: app.Output}
-	},
-	EnrichFlagErr: flagErrorWithSuggestion,
-})
-
-var doctorCommand = doctorModule.Command()
-
-func init() {
-	doctorCommand.GroupID = "core"
-	if err := clicontract.Attach(doctorCommand, doctorModule.Contract()); err != nil {
+	module := doctorcommands.NewModule(doctorcommands.UseCases{
+		LegacyChecks:  newLegacyDoctorService().Checks,
+		Read:          readService,
+		Mutation:      mutationService,
+		Maintenance:   maintenanceService,
+		DetectorCount: func() int { return len(doctorapp.Detectors()) },
+	}, clicontract.HostOptions{
+		OutputMode:    GetOutput,
+		DryRun:        GetDryRun,
+		EnrichFlagErr: flagErrorWithSuggestion,
+	})
+	command := module.Command()
+	command.GroupID = "core"
+	if err := clicontract.Attach(command, module.Contract()); err != nil {
 		panic(err)
 	}
-	rootCmd.AddCommand(doctorCommand)
+	return command
 }

--- a/cli/cmd/ao/doctor_module_integration_test.go
+++ b/cli/cmd/ao/doctor_module_integration_test.go
@@ -11,20 +11,30 @@ import (
 	"github.com/boshu2/agentops/cli/internal/quality"
 )
 
+// withOutputMode pins the package-global output flag the doctor host seam reads
+// (GetOutput) for the duration of a test, isolating it from -shuffle leakage.
+func withOutputMode(t *testing.T, mode string) {
+	t.Helper()
+	original := output
+	output = mode
+	t.Cleanup(func() { output = original })
+}
+
 func TestDoctorModuleTableOutput(t *testing.T) {
 	root := t.TempDir()
 	t.Chdir(root)
 	t.Setenv("HOME", t.TempDir())
+	withOutputMode(t, "table")
 	if err := os.MkdirAll(filepath.Join(root, ".agents", "ao"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	command := doctorModule.Command()
-	var output bytes.Buffer
-	command.SetOut(&output)
-	command.SetErr(&output)
+	command := newDoctorCommand()
+	var out bytes.Buffer
+	command.SetOut(&out)
+	command.SetErr(&out)
 	_ = command.Execute()
-	if !strings.Contains(output.String(), "ao doctor") {
-		t.Fatalf("output=%q", output.String())
+	if !strings.Contains(out.String(), "ao doctor") {
+		t.Fatalf("output=%q", out.String())
 	}
 }
 
@@ -32,15 +42,16 @@ func TestDoctorModuleJSONOutputIsSingleHealthReport(t *testing.T) {
 	root := t.TempDir()
 	t.Chdir(root)
 	t.Setenv("HOME", t.TempDir())
-	command := doctorModule.Command()
-	var output bytes.Buffer
-	command.SetOut(&output)
-	command.SetErr(&output)
+	withOutputMode(t, "table")
+	command := newDoctorCommand()
+	var out bytes.Buffer
+	command.SetOut(&out)
+	command.SetErr(&out)
 	command.SetArgs([]string{"--json"})
 	_ = command.Execute()
 	var report quality.DoctorOutput
-	if err := json.Unmarshal(output.Bytes(), &report); err != nil {
-		t.Fatalf("json=%q err=%v", output.String(), err)
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("json=%q err=%v", out.String(), err)
 	}
 	if len(report.Checks) == 0 || report.Result == "" {
 		t.Fatalf("report=%+v", report)

--- a/cli/cmd/ao/doctor_read_contract_test.go
+++ b/cli/cmd/ao/doctor_read_contract_test.go
@@ -3,6 +3,7 @@ package main
 import "testing"
 
 func TestDoctorReadCommandsRejectJunkArguments(t *testing.T) {
+	doctorCommand := newDoctorCommand()
 	if err := doctorCommand.ValidateArgs([]string{"junk"}); err == nil {
 		t.Fatal("doctor accepted junk positional argument")
 	}

--- a/cli/cmd/ao/eval_composition.go
+++ b/cli/cmd/ao/eval_composition.go
@@ -32,10 +32,10 @@ func newEvalCommand() *cobra.Command {
 		Outcomes:   evalapp.OutcomesService{Runtime: runtime},
 		Scenario:   evalapp.ScenarioService{Runtime: runtime},
 		ScenarioAB: evalapp.ScenarioABService{Runtime: runtime},
-	}, evalcommands.HostOptions{
-		OutputMode: func(*cobra.Command) string { return GetOutput() },
-		Verbose:    func(*cobra.Command) bool { return GetVerbose() },
-		DryRun:     func(*cobra.Command) bool { return GetDryRun() },
+	}, clicontract.HostOptions{
+		OutputMode: GetOutput,
+		Verbose:    GetVerbose,
+		DryRun:     GetDryRun,
 		ProjectRoot: func() string {
 			if dir, err := resolveProjectDir(); err == nil {
 				return dir

--- a/cli/cmd/ao/flywheel_composition.go
+++ b/cli/cmd/ao/flywheel_composition.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 
 	flywheelcommands "github.com/boshu2/agentops/cli/internal/commands/flywheel"
 )
@@ -16,7 +17,7 @@ func init() {
 // version, flywheel carries no attached CommandContract; this composition does
 // not attach one, preserving flywheel's synthesized capabilities surface.
 func newFlywheelCommand() *cobra.Command {
-	module := flywheelcommands.NewModule(flywheelcommands.HostOptions{
+	module := flywheelcommands.NewModule(clicontract.HostOptions{
 		OutputMode: GetOutput,
 		Verbosef:   VerbosePrintf,
 	})

--- a/cli/cmd/ao/gate_composition.go
+++ b/cli/cmd/ao/gate_composition.go
@@ -22,9 +22,9 @@ func init() {
 func newGateCommand() *cobra.Command {
 	module := gatecommands.NewModule(gatecommands.UseCases{
 		Check: gateCheckUseCases{},
-	}, gatecommands.HostOptions{
-		DryRun:       GetDryRun,
-		OutputFormat: GetOutput,
+	}, clicontract.HostOptions{
+		DryRun:     GetDryRun,
+		OutputMode: GetOutput,
 	})
 	command := module.Command()
 	if err := clicontract.Attach(command, module.Contract()); err != nil {

--- a/cli/cmd/ao/goals_composition.go
+++ b/cli/cmd/ao/goals_composition.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 
 	goalscommands "github.com/boshu2/agentops/cli/internal/commands/goals"
 )
@@ -19,7 +20,7 @@ func init() {
 // clock effects to internal/goals. The goals family attaches no CommandContract
 // to the command tree, preserving its pre-migration capabilities surface.
 func newGoalsCommand() *cobra.Command {
-	module := goalscommands.NewModule(goalscommands.HostOptions{
+	module := goalscommands.NewModule(clicontract.HostOptions{
 		OutputMode:  GetOutput,
 		Verbose:     GetVerbose,
 		ProjectRoot: goalsProjectRoot,

--- a/cli/cmd/ao/init_composition.go
+++ b/cli/cmd/ao/init_composition.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 
 	initcommands "github.com/boshu2/agentops/cli/internal/commands/init"
 )
@@ -16,7 +17,7 @@ func init() {
 // delegated to internal/initapp. The init family attaches no CommandContract to
 // the command tree, preserving its pre-migration capabilities surface.
 func newInitCommand() *cobra.Command {
-	module := initcommands.NewModule(initcommands.HostOptions{
+	module := initcommands.NewModule(clicontract.HostOptions{
 		DryRun: GetDryRun,
 	})
 	return module.Command()

--- a/cli/cmd/ao/output_yaml_truthfulness_test.go
+++ b/cli/cmd/ao/output_yaml_truthfulness_test.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestOutputYAMLTruthfulness is the acceptance probe for age-6j9ee.2: `-o yaml`
+// is advertised uniformly (capabilities output_formats [table, json, yaml], the
+// --output flag help, robot-docs), so it must be REAL everywhere `-o json` is
+// real. This probe enumerates every read-side command that emits structured
+// output and asserts, for each, that `-o yaml`:
+//
+//   - parses as YAML (a human table does not), AND
+//   - is semantically equal to the `-o json` output (same decoded tree), AND
+//   - is not byte-identical to the `-o table` human view (the silent-fallback
+//     signature this bead exists to kill).
+//
+// RED (pre-fix, HEAD 11e25f93f): status, version, doctor, goals, provenance,
+// session, and skills had no yaml branch, so `-o yaml <cmd>` silently returned
+// the human table — yaml.Unmarshal of that table does not reproduce the json
+// tree, so every such row FAILS. GREEN (this commit): each command routes
+// `-o yaml` through clicontract.WriteYAML (or JSONToYAML), so every row passes.
+//
+// Determinism guard: a few commands embed now-derived leaf values (e.g. an
+// average-age metric). For those the probe compares tree SHAPE (keys + value
+// types, recursively) instead of exact leaf values, which still catches a table
+// fallback and a missing-key divergence (the flywheel-status yaml that used to
+// omit "metrics") while staying immune to sub-second float drift. For every
+// deterministic command it compares full values.
+func TestOutputYAMLTruthfulness(t *testing.T) {
+	// Structured read-side commands. Each is invocable with no required file
+	// argument and resolves its repository content by walking up from the test
+	// working directory, so it emits a single structured document in this repo.
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"capabilities", []string{"capabilities"}},
+		{"version", []string{"version"}},
+		{"status", []string{"status"}},
+		{"doctor", []string{"doctor"}},
+		{"goals history", []string{"goals", "history"}},
+		{"provenance list", []string{"provenance", "list"}},
+		{"provenance position", []string{"provenance", "position"}},
+		{"provenance verify", []string{"provenance", "verify"}},
+		{"provenance export", []string{"provenance", "export"}},
+		{"session bootstrap", []string{"session", "bootstrap"}},
+		{"session rehydrate", []string{"session", "rehydrate"}},
+		{"flywheel status", []string{"flywheel", "status"}},
+		{"flywheel compare", []string{"flywheel", "compare"}},
+		{"skills check", []string{"skills", "check"}},
+		{"skills list", []string{"skills", "list"}},
+		{"skills resolve", []string{"skills", "resolve"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			jsonOut, _ := executeCommand(withOutput("json", tc.args)...)
+			var jsonTree any
+			if err := json.Unmarshal([]byte(jsonOut), &jsonTree); err != nil {
+				// -o json did not emit a single JSON document in this environment
+				// (e.g. the command is not applicable to this repository state).
+				// There is nothing to hold -o yaml against, so skip — but never
+				// treat this as a pass for the yaml contract.
+				t.Skipf("%s: -o json did not emit a single JSON document here (%v); nothing to compare", tc.name, err)
+				return
+			}
+
+			yamlOut, _ := executeCommand(withOutput("yaml", tc.args)...)
+			var yamlTree any
+			if err := yaml.Unmarshal([]byte(yamlOut), &yamlTree); err != nil {
+				t.Fatalf("%s: -o yaml did not parse as YAML — silent table fallback?\nerr=%v\noutput:\n%s", tc.name, err, yamlOut)
+			}
+
+			// A YAML document that decodes to a bare string is the table text
+			// masquerading as YAML; the structured commands here decode to a map
+			// or a sequence.
+			switch yamlTree.(type) {
+			case map[string]any, []any:
+				// structured — good
+			default:
+				t.Fatalf("%s: -o yaml decoded to %T, not a mapping/sequence — silent table fallback?\noutput:\n%s", tc.name, yamlTree, yamlOut)
+			}
+
+			// Second json run to detect now-derived (non-deterministic) leaves.
+			jsonOut2, _ := executeCommand(withOutput("json", tc.args)...)
+			var jsonTree2 any
+			_ = json.Unmarshal([]byte(jsonOut2), &jsonTree2)
+
+			if canonical(t, jsonTree) == canonical(t, jsonTree2) {
+				// Deterministic: yaml must equal json exactly (same tree).
+				if got, want := canonical(t, yamlTree), canonical(t, jsonTree); got != want {
+					t.Fatalf("%s: -o yaml tree != -o json tree\nyaml: %s\njson: %s", tc.name, got, want)
+				}
+			} else {
+				// Non-deterministic leaves: compare tree SHAPE (keys + types).
+				if got, want := canonical(t, shapeOf(yamlTree)), canonical(t, shapeOf(jsonTree)); got != want {
+					t.Fatalf("%s: -o yaml shape != -o json shape (missing key or table fallback)\nyaml: %s\njson: %s", tc.name, got, want)
+				}
+			}
+
+			// Belt-and-suspenders: -o yaml must not be the human table verbatim.
+			tableOut, _ := executeCommand(withOutput("table", tc.args)...)
+			if strings.TrimSpace(tableOut) != "" && strings.TrimSpace(yamlOut) == strings.TrimSpace(tableOut) {
+				t.Fatalf("%s: -o yaml is byte-identical to -o table (silent fallback)", tc.name)
+			}
+		})
+	}
+}
+
+// withOutput prepends the global -o <mode> flag to a command's args.
+func withOutput(mode string, args []string) []string {
+	return append([]string{"-o", mode}, args...)
+}
+
+// canonical marshals a decoded tree to canonical JSON (sorted map keys, number
+// types normalized), so a YAML-decoded tree and a JSON-decoded tree of the same
+// data compare equal regardless of decoder-specific int/float representation.
+func canonical(t *testing.T, v any) string {
+	t.Helper()
+	data, err := json.Marshal(normalizeForJSON(v))
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	return string(data)
+}
+
+// normalizeForJSON rewrites yaml.v3's map[any]any (possible for non-string keys)
+// into map[string]any so encoding/json can marshal it. The structured surfaces
+// here use string keys, but this keeps the probe robust.
+func normalizeForJSON(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, item := range val {
+			out[k] = normalizeForJSON(item)
+		}
+		return out
+	case map[any]any:
+		out := make(map[string]any, len(val))
+		for k, item := range val {
+			out[fmt.Sprint(k)] = normalizeForJSON(item)
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, item := range val {
+			out[i] = normalizeForJSON(item)
+		}
+		return out
+	default:
+		return val
+	}
+}
+
+// shapeOf replaces every scalar leaf with its type name, preserving map keys and
+// sequence structure. Two trees with the same keys and value types but different
+// leaf values (e.g. a now-derived metric) share a shape.
+func shapeOf(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, item := range val {
+			out[k] = shapeOf(item)
+		}
+		return out
+	case map[any]any:
+		out := make(map[string]any, len(val))
+		for k, item := range val {
+			out[fmt.Sprint(k)] = shapeOf(item)
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, item := range val {
+			out[i] = shapeOf(item)
+		}
+		return out
+	case nil:
+		return "null"
+	case bool:
+		return "bool"
+	case string:
+		return "string"
+	default:
+		// json.Number, float64, int, int64, uint64 — all numeric leaves.
+		return "number"
+	}
+}
+
+// TestOutputYAMLProbeStalenessGuard fails when a new top-level command appears
+// that the yaml-truthfulness probe has neither exercised nor explicitly excused.
+// It is a coarse staleness net: it forces whoever adds a command to decide
+// whether it emits structured output (add it to TestOutputYAMLTruthfulness) or
+// not (add it to the excused set below with a reason). Subcommand-level coverage
+// (e.g. provenance list vs position) is the probe's own concern.
+func TestOutputYAMLProbeStalenessGuard(t *testing.T) {
+	// Top-level commands the yaml probe exercises (via at least one subcommand
+	// for the families).
+	probed := map[string]bool{
+		"capabilities": true,
+		"version":      true,
+		"status":       true,
+		"doctor":       true,
+		"goals":        true,
+		"provenance":   true,
+		"session":      true,
+		"flywheel":     true,
+		"skills":       true,
+		"eval":         true, // yaml wired at every eval json site; probed by eval package tests (needs suite fixtures)
+	}
+	// Commands with no structured output, so -o yaml/-o json are not applicable
+	// (they emit human text or are pure side-effect verbs). Each ignores -o
+	// consistently — no silent yaml→table divergence to assert.
+	excused := map[string]string{
+		"config":      "structured show/models covered by config package tests; top-level config prints help",
+		"demo":        "human-only demonstrative output",
+		"gate":        "human/exit-code gate; no structured document contract",
+		"init":        "side-effect scaffolder, human output",
+		"quick-start": "human onboarding text",
+		"redact":      "stream transform, not a structured document",
+		"robot-docs":  "markdown handbook, not json/yaml",
+		"completion":  "shell completion script (cobra builtin)",
+		"help":        "cobra builtin help",
+	}
+
+	var unclassified []string
+	for _, cmd := range rootCmd.Commands() {
+		name := cmd.Name()
+		if probed[name] || excused[name] != "" {
+			continue
+		}
+		unclassified = append(unclassified, name)
+	}
+	sort.Strings(unclassified)
+	if len(unclassified) > 0 {
+		t.Fatalf("top-level command(s) %v are neither probed by TestOutputYAMLTruthfulness "+
+			"nor excused in TestOutputYAMLProbeStalenessGuard — classify each: if it emits "+
+			"structured output, add it to the probe; if not, excuse it with a reason.", unclassified)
+	}
+}

--- a/cli/cmd/ao/provenance_composition.go
+++ b/cli/cmd/ao/provenance_composition.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 
 	provenancecommands "github.com/boshu2/agentops/cli/internal/commands/provenance"
 )
@@ -19,7 +20,7 @@ func init() {
 // capabilities contract before the carve-out, so this composition does not
 // attach the module's contract either — the capabilities surface is unchanged.
 func newProvenanceCommand() *cobra.Command {
-	module := provenancecommands.NewModule(provenancecommands.HostOptions{
+	module := provenancecommands.NewModule(clicontract.HostOptions{
 		LedgerPath: resolveLedgerPath,
 		Now:        time.Now,
 	})

--- a/cli/cmd/ao/provenance_composition.go
+++ b/cli/cmd/ao/provenance_composition.go
@@ -23,6 +23,7 @@ func newProvenanceCommand() *cobra.Command {
 	module := provenancecommands.NewModule(clicontract.HostOptions{
 		LedgerPath: resolveLedgerPath,
 		Now:        time.Now,
+		OutputMode: GetOutput,
 	})
 	return module.Command()
 }

--- a/cli/cmd/ao/root.go
+++ b/cli/cmd/ao/root.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	doctorcommands "github.com/boshu2/agentops/cli/internal/commands/doctor"
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 	"github.com/boshu2/agentops/cli/internal/doctor"
 )
 
@@ -90,16 +90,18 @@ func negotiateOutput(cmd *cobra.Command) error {
 func Execute() {
 	executedCmd, err := rootCmd.ExecuteC()
 	if err != nil {
-		var docErr *doctorcommands.ExitError
-		if errors.As(err, &docErr) {
-			// Exit 1 means findings are present — a normal diagnostic result,
-			// not a failure, so it carries no stderr noise. Higher codes are
-			// genuine failures; surface the reason on stderr (doctor commands
-			// set SilenceErrors, so cobra prints nothing itself).
-			if docErr.ExitCode() != doctor.ExitFindings && docErr.Error() != "" {
-				fmt.Fprintln(os.Stderr, "ao doctor: "+docErr.Error())
+		var exitErr *clicontract.ExitError
+		if errors.As(err, &exitErr) {
+			// A labeled ExitError (doctor) surfaces its reason on stderr: exit 1
+			// means findings are present — a normal diagnostic result carrying no
+			// stderr noise — while higher codes are genuine failures the module
+			// silenced (SilenceErrors), so the root prints them. An empty Label
+			// (gate) means the module already surfaced its own output; the root
+			// stays silent and only maps the process code.
+			if exitErr.Label != "" && exitErr.ExitCode() != doctor.ExitFindings && exitErr.Error() != "" {
+				fmt.Fprintln(os.Stderr, exitErr.Label+": "+exitErr.Error())
 			}
-			os.Exit(docErr.ExitCode())
+			os.Exit(exitErr.ExitCode())
 		}
 		var commandExit commandExitError
 		if errors.As(err, &commandExit) {

--- a/cli/cmd/ao/session_composition.go
+++ b/cli/cmd/ao/session_composition.go
@@ -4,6 +4,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 	sessioncommands "github.com/boshu2/agentops/cli/internal/commands/session"
 )
 
@@ -18,7 +19,7 @@ func init() {
 // to internal/sessionapp. The session family attaches no CommandContract to the
 // command tree, preserving its pre-migration capabilities surface.
 func newSessionCommand() *cobra.Command {
-	command := sessioncommands.NewModule().Command()
+	command := sessioncommands.NewModule(clicontract.HostOptions{OutputMode: GetOutput}).Command()
 	command.AddCommand(handoffCmd)
 	return command
 }

--- a/cli/cmd/ao/skills_composition.go
+++ b/cli/cmd/ao/skills_composition.go
@@ -20,7 +20,8 @@ func init() {
 // unchanged.
 func newSkillsCommand() *cobra.Command {
 	module := skillscommands.NewModule(clicontract.HostOptions{
-		DryRun: GetDryRun,
+		DryRun:     GetDryRun,
+		OutputMode: GetOutput,
 	})
 	return module.Command()
 }

--- a/cli/cmd/ao/skills_composition.go
+++ b/cli/cmd/ao/skills_composition.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 
 	skillscommands "github.com/boshu2/agentops/cli/internal/commands/skills"
 )
@@ -18,7 +19,7 @@ func init() {
 // does not attach the module's contract either — the capabilities surface is
 // unchanged.
 func newSkillsCommand() *cobra.Command {
-	module := skillscommands.NewModule(skillscommands.HostOptions{
+	module := skillscommands.NewModule(clicontract.HostOptions{
 		DryRun: GetDryRun,
 	})
 	return module.Command()

--- a/cli/cmd/ao/status_composition.go
+++ b/cli/cmd/ao/status_composition.go
@@ -16,7 +16,7 @@ func init() {
 // reads the global -o/--output flag for its output mode and delegates all
 // filesystem and clock effects to internal/statusapp.
 func newStatusCommand() *cobra.Command {
-	module := statuscommands.NewModule(statuscommands.HostOptions{
+	module := statuscommands.NewModule(clicontract.HostOptions{
 		OutputMode: GetOutput,
 	})
 	command := module.Command()

--- a/cli/cmd/ao/testdata/package-var-allowlist.json
+++ b/cli/cmd/ao/testdata/package-var-allowlist.json
@@ -3,13 +3,6 @@
   "allowed": [
     { "name": "appKey", "file": "app.go", "reason": "immutable wiring: context-key sentinel (appKeyType{}) for App injection" },
     { "name": "completionCmd", "file": "completion.go", "reason": "immutable wiring: shell-completion cobra.Command tree node" },
-    { "name": "configCommand", "file": "config_module.go", "reason": "immutable wiring: config module command tree ref" },
-    { "name": "configModule", "file": "config_module.go", "reason": "immutable wiring: config module singleton" },
-    { "name": "doctorCommand", "file": "doctor_module.go", "reason": "immutable wiring: doctor module command tree ref" },
-    { "name": "doctorMaintenanceService", "file": "doctor_module.go", "reason": "immutable wiring: doctor maintenance service singleton" },
-    { "name": "doctorModule", "file": "doctor_module.go", "reason": "immutable wiring: doctor module singleton" },
-    { "name": "doctorMutationService", "file": "doctor_module.go", "reason": "immutable wiring: doctor mutation service singleton" },
-    { "name": "doctorReadService", "file": "doctor_module.go", "reason": "immutable wiring: doctor read service singleton" },
     { "name": "handoffCmd", "file": "handoff.go", "reason": "immutable wiring: handoff cobra.Command tree node (host-resident leaf)" },
     { "name": "handoffGoal", "file": "handoff.go", "reason": "flag target: --goal for host-resident handoff command" },
     { "name": "handoffContinuation", "file": "handoff.go", "reason": "flag target: --continuation for host-resident handoff command" },

--- a/cli/cmd/ao/testdata/seamless-module-exemptions.json
+++ b/cli/cmd/ao/testdata/seamless-module-exemptions.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Seam-coverage exemptions (bead age-6j9ee.1 / B1). Every internal/commands/<family>/module.go NewModule MUST either take a clicontract.HostOptions parameter (the shared host seam) OR appear here with a one-line reason justifying why it is genuinely seam-less (pure static text or a pure deterministic transform with no output-mode / dry-run / verbose / project-root / clock dependency). TestEveryModuleTakesHostSeamOrIsExempt (carveout_regression_test.go) fails three ways so this list cannot rot: (1) a zero-seam module missing from this list, (2) a module that gained a HostOptions seam but is still listed here (stale), and (3) an exemption for a module that no longer exists. Do NOT add an entry to dodge wiring a real seam: if a module reads output mode, dry-run, verbose, the project root, or the clock, it takes clicontract.HostOptions instead.",
+  "exempt": [
+    { "module": "demo", "reason": "pure static text: renders fixed explanatory strings to stdout; no output-mode, dry-run, verbose, project-root, or clock dependency" },
+    { "module": "quickstart", "reason": "pure static text: prints a fixed single-pass workflow summary to stdout; no host seam of any kind" },
+    { "module": "redact", "reason": "pure deterministic transform: reads stdin, applies the canonical secret redactor, writes raw scrubbed bytes to stdout; a byte passthrough with no structured output mode or other host seam" },
+    { "module": "robotdocs", "reason": "pure read of the live cobra command tree: renders a Markdown-only handbook; no JSON/YAML variant and no other host seam" }
+  ]
+}

--- a/cli/cmd/ao/version_composition.go
+++ b/cli/cmd/ao/version_composition.go
@@ -18,7 +18,7 @@ func init() {
 // CommandContract; this composition attaches it to the command tree so the
 // capabilities surface is unchanged by the carve-out.
 func newVersionCommand() *cobra.Command {
-	module := versioncommands.NewModule(versioncommands.HostOptions{
+	module := versioncommands.NewModule(clicontract.HostOptions{
 		Version:    func() string { return version },
 		OutputMode: GetOutput,
 	})

--- a/cli/internal/clicontract/host.go
+++ b/cli/internal/clicontract/host.go
@@ -1,0 +1,92 @@
+package clicontract
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// HostOptions is the single canonical host-seam contract every command module
+// in internal/commands/<family> receives from the root executable. It replaced
+// the four incompatible per-module seam shapes (positional funcs, bespoke
+// HostOptions structs, and a GlobalOptions bundle) that drifted apart across
+// the cmd/ao carve-out waves.
+//
+// A module reads only the seams it needs; an unset (nil) field means the seam
+// is absent for that module (zero-value = absent). Modules keep their own
+// per-domain UseCases types — only the host seams are unified here.
+//
+// The flag-derived seams (OutputMode, Verbose, DryRun) resolve the negotiated
+// global flag values the root wires from its persistent flags. The remaining
+// seams inject host-owned environment, filesystem, and clock facts that a
+// module must never read directly (the carveout drift guards enforce that a
+// module.go imports no os/os-exec package and calls no time.Now).
+type HostOptions struct {
+	// OutputMode resolves the active output format ("table" | "json" | "yaml").
+	OutputMode func() string
+	// Verbose reports whether -v/--verbose is enabled.
+	Verbose func() bool
+	// Verbosef is the host verbose diagnostic printer. It is safe to leave nil
+	// only when a module never calls it; modules that use it must nil-check.
+	Verbosef func(format string, args ...any)
+	// DryRun reports whether --dry-run is enabled.
+	DryRun func() bool
+	// ProjectRoot resolves the working project root directory.
+	ProjectRoot func() string
+	// GoalsPath resolves the declared goals file path, for modules that read it.
+	GoalsPath func() string
+	// LedgerPath resolves the provenance ledger path for the current tree.
+	LedgerPath func() string
+	// Version supplies the build-time tool version string (ldflags-injected).
+	Version func() string
+	// Now supplies the wall clock (injected so modules never call time.Now).
+	Now func() time.Time
+	// EnrichFlagErr decorates a flag-parse error with a suggestion before the
+	// root surfaces it.
+	EnrichFlagErr func(*cobra.Command, error) error
+}
+
+// ExitError carries a process exit status and message from a command module up
+// to the root executable, which owns process-code mapping. Modules return it
+// instead of calling os.Exit so a fresh context can observe the outcome. It is
+// the single shared exit-error type; the doctor and gate families previously
+// each declared a byte-identical copy.
+type ExitError struct {
+	// Code is the process exit status.
+	Code int
+	// Message is the human-readable failure reason.
+	Message string
+	// Label, when non-empty, is the stderr prefix the root prints for a
+	// non-zero failure (e.g. "ao doctor"). An empty Label means the module
+	// already surfaced its own output and the root stays silent — the behavior
+	// the gate family relies on.
+	Label string
+}
+
+// Error implements the error interface.
+func (failure *ExitError) Error() string { return failure.Message }
+
+// ExitCode returns the process exit status the root should use.
+func (failure *ExitError) ExitCode() int { return failure.Code }
+
+// WriteJSON marshals value as two-space-indented JSON with a single trailing
+// newline to w. The emitted bytes are identical to both
+// json.MarshalIndent(value, "", "  ") followed by a newline and a
+// json.Encoder configured with SetIndent("", "  ") — encoding/json HTML
+// escaping stays on — so it is a byte-for-byte drop-in for every command
+// module's prior hand-rolled JSON writer.
+//
+// A YAML sibling (WriteYAML) belongs beside this helper when the eval/config
+// yaml-output bead lands; keeping the structured writers in one home lets a
+// caller switch on HostOptions.OutputMode without re-rolling the encoder.
+func WriteJSON(w io.Writer, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, string(data))
+	return err
+}

--- a/cli/internal/clicontract/host.go
+++ b/cli/internal/clicontract/host.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 // HostOptions is the single canonical host-seam contract every command module
@@ -79,9 +80,8 @@ func (failure *ExitError) ExitCode() int { return failure.Code }
 // escaping stays on — so it is a byte-for-byte drop-in for every command
 // module's prior hand-rolled JSON writer.
 //
-// A YAML sibling (WriteYAML) belongs beside this helper when the eval/config
-// yaml-output bead lands; keeping the structured writers in one home lets a
-// caller switch on HostOptions.OutputMode without re-rolling the encoder.
+// WriteJSON has a YAML sibling (WriteYAML) beside it so a caller can switch on
+// HostOptions.OutputMode without re-rolling an encoder.
 func WriteJSON(w io.Writer, value any) error {
 	data, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
@@ -89,4 +89,57 @@ func WriteJSON(w io.Writer, value any) error {
 	}
 	_, err = fmt.Fprintln(w, string(data))
 	return err
+}
+
+// WriteYAML marshals value as YAML to w. It marshals through a JSON round-trip
+// so the emitted YAML keys mirror the value's json struct tags exactly
+// (schema_version, not the field-name-lowercased schemaversion that a direct
+// yaml.Marshal of a json-tagged struct would produce) and the emitted tree is
+// semantically identical to WriteJSON's for the same value. This is what makes
+// `-o yaml` a truthful sibling of `-o json` everywhere json is implemented:
+// the same payload, the same keys, the same values — only the serialization
+// differs. yaml.v3 renders the generic tree in map-key order (alphabetical)
+// with a single trailing newline; integral numbers stay integral (5, not 5.0).
+func WriteYAML(w io.Writer, value any) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return JSONToYAML(w, data)
+}
+
+// JSONToYAML converts a single JSON document to YAML and writes it to w. It is
+// the seam a command uses to add `-o yaml` without re-plumbing an app package
+// that already emits JSON: capture the existing JSON bytes into a buffer, hand
+// them here, and emit the YAML equivalent. The bytes must be one JSON document
+// (not JSONL); a decode failure is returned so a caller never silently emits
+// malformed YAML.
+func JSONToYAML(w io.Writer, jsonData []byte) error {
+	var generic any
+	if err := json.Unmarshal(jsonData, &generic); err != nil {
+		return fmt.Errorf("decode json for yaml conversion: %w", err)
+	}
+	out, err := yaml.Marshal(generic)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(out)
+	return err
+}
+
+// EmitStructured writes value as JSON or YAML per the negotiated output mode and
+// reports whether it handled the mode. A "table" (or any non-structured) mode
+// returns handled=false so the caller renders its own human view; "json" and
+// "yaml" return handled=true. This is the single dispatch every command with
+// structured output routes through, so `-o json` and `-o yaml` stay paired —
+// there is no code path where one exists without the other.
+func EmitStructured(w io.Writer, mode string, value any) (handled bool, err error) {
+	switch mode {
+	case "json":
+		return true, WriteJSON(w, value)
+	case "yaml":
+		return true, WriteYAML(w, value)
+	default:
+		return false, nil
+	}
 }

--- a/cli/internal/commands/capabilities/module.go
+++ b/cli/internal/commands/capabilities/module.go
@@ -14,11 +14,11 @@ import (
 
 type Module struct {
 	builder capabilitiesapp.Builder
-	output  func() string
+	host    clicontract.HostOptions
 }
 
-func NewModule(builder capabilitiesapp.Builder, output func() string) Module {
-	return Module{builder: builder, output: output}
+func NewModule(builder capabilitiesapp.Builder, host clicontract.HostOptions) Module {
+	return Module{builder: builder, host: host}
 }
 
 func (Module) Contract() clicontract.CommandContract {
@@ -56,7 +56,7 @@ contract_version).`,
 
 func (module Module) render(command *cobra.Command) error {
 	document := module.builder.Build()
-	if module.output != nil && module.output() == "yaml" {
+	if module.host.OutputMode != nil && module.host.OutputMode() == "yaml" {
 		data, err := yaml.Marshal(document)
 		if err != nil {
 			return err

--- a/cli/internal/commands/capabilities/module.go
+++ b/cli/internal/commands/capabilities/module.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 
 	capabilitiesapp "github.com/boshu2/agentops/cli/internal/capabilities"
 	"github.com/boshu2/agentops/cli/internal/clicontract"
@@ -57,12 +56,11 @@ contract_version).`,
 func (module Module) render(command *cobra.Command) error {
 	document := module.builder.Build()
 	if module.host.OutputMode != nil && module.host.OutputMode() == "yaml" {
-		data, err := yaml.Marshal(document)
-		if err != nil {
-			return err
-		}
-		_, err = command.OutOrStdout().Write(data)
-		return err
+		// Route through the shared WriteYAML so the YAML keys mirror the json
+		// struct tags (schema_version, not schemaversion) and are semantically
+		// identical to the JSON output — the truthfulness the -o yaml contract
+		// advertises.
+		return clicontract.WriteYAML(command.OutOrStdout(), document)
 	}
 	encoder := json.NewEncoder(command.OutOrStdout())
 	encoder.SetIndent("", "  ")

--- a/cli/internal/commands/capabilities/module_test.go
+++ b/cli/internal/commands/capabilities/module_test.go
@@ -52,7 +52,10 @@ func TestCommandDelegatesAndRendersYAML(t *testing.T) {
 	if err := command.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if builder.calls != 1 || !strings.Contains(output.String(), "schemaversion: \"2.0\"") {
+	// The YAML keys mirror the json struct tags (schema_version), not the
+	// field-name-lowercased form a direct yaml.Marshal would emit, so -o yaml is
+	// a truthful sibling of -o json.
+	if builder.calls != 1 || !strings.Contains(output.String(), "schema_version: \"2.0\"") {
 		t.Fatalf("YAML output = %q, calls=%d", output.String(), builder.calls)
 	}
 }

--- a/cli/internal/commands/capabilities/module_test.go
+++ b/cli/internal/commands/capabilities/module_test.go
@@ -25,7 +25,7 @@ func (builder *recordingBuilder) Build() capabilitiesapp.Document {
 
 func TestCommandDelegatesAndRendersJSON(t *testing.T) {
 	builder := &recordingBuilder{}
-	module := NewModule(builder, func() string { return "json" })
+	module := NewModule(builder, clicontract.HostOptions{OutputMode: func() string { return "json" }})
 	command := module.Command()
 	var output bytes.Buffer
 	command.SetOut(&output)
@@ -46,7 +46,7 @@ func TestCommandDelegatesAndRendersJSON(t *testing.T) {
 
 func TestCommandDelegatesAndRendersYAML(t *testing.T) {
 	builder := &recordingBuilder{}
-	command := NewModule(builder, func() string { return "yaml" }).Command()
+	command := NewModule(builder, clicontract.HostOptions{OutputMode: func() string { return "yaml" }}).Command()
 	var output bytes.Buffer
 	command.SetOut(&output)
 	if err := command.Execute(); err != nil {
@@ -58,7 +58,7 @@ func TestCommandDelegatesAndRendersYAML(t *testing.T) {
 }
 
 func TestModuleOwnsFreshCommandsAndExplicitContract(t *testing.T) {
-	module := NewModule(&recordingBuilder{}, nil)
+	module := NewModule(&recordingBuilder{}, clicontract.HostOptions{})
 	first, second := module.Command(), module.Command()
 	if first == second {
 		t.Fatal("Command returned shared Cobra state")

--- a/cli/internal/commands/config/module.go
+++ b/cli/internal/commands/config/module.go
@@ -3,7 +3,6 @@ package config
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sort"
 
@@ -31,9 +30,7 @@ type UseCases interface {
 
 type Module struct {
 	useCases UseCases
-	output   func() string
-	verbose  func() bool
-	dryRun   func() bool
+	host     clicontract.HostOptions
 }
 
 type options struct {
@@ -42,8 +39,8 @@ type options struct {
 	setSkill string
 }
 
-func NewModule(useCases UseCases, output func() string, verbose func() bool, dryRun func() bool) Module {
-	return Module{useCases: useCases, output: output, verbose: verbose, dryRun: dryRun}
+func NewModule(useCases UseCases, host clicontract.HostOptions) Module {
+	return Module{useCases: useCases, host: host}
 }
 
 func (Module) Contract() clicontract.CommandContract {
@@ -67,11 +64,11 @@ func (module Module) Command() *cobra.Command {
 		if !commandOptions.show {
 			return command.Help()
 		}
-		result, err := module.useCases.Show(command.Context(), module.output(), module.verbose())
+		result, err := module.useCases.Show(command.Context(), module.host.OutputMode(), module.host.Verbose())
 		if err != nil {
 			return err
 		}
-		return renderShow(command, module.output(), result)
+		return renderShow(command, module.host.OutputMode(), result)
 	}
 	models := module.modelsCommand(&commandOptions)
 	root.AddCommand(models)
@@ -86,18 +83,18 @@ func (module Module) modelsCommand(commandOptions *options) *cobra.Command {
 	command.RunE = func(command *cobra.Command, _ []string) error {
 		if commandOptions.setTier != "" || commandOptions.setSkill != "" {
 			result, err := module.useCases.WriteModels(command.Context(), configapp.ModelsWriteRequest{
-				DefaultTier: commandOptions.setTier, Skill: commandOptions.setSkill, DryRun: module.dryRun != nil && module.dryRun(),
+				DefaultTier: commandOptions.setTier, Skill: commandOptions.setSkill, DryRun: module.host.DryRun != nil && module.host.DryRun(),
 			})
 			if err != nil {
 				return err
 			}
-			return renderModelsWrite(command, module.output(), commandOptions.setTier, commandOptions.setSkill, result)
+			return renderModelsWrite(command, module.host.OutputMode(), commandOptions.setTier, commandOptions.setSkill, result)
 		}
 		result, err := module.useCases.Models(command.Context())
 		if err != nil {
 			return err
 		}
-		return renderModels(command, module.output(), result)
+		return renderModels(command, module.host.OutputMode(), result)
 	}
 	return command
 }
@@ -219,12 +216,10 @@ func splitSkill(value string) []string {
 }
 
 func writeJSON(command *cobra.Command, value any, label string) error {
-	data, err := json.MarshalIndent(value, "", "  ")
-	if err != nil {
+	if err := clicontract.WriteJSON(command.OutOrStdout(), value); err != nil {
 		return fmt.Errorf("%s: %w", label, err)
 	}
-	_, err = fmt.Fprintln(command.OutOrStdout(), string(data))
-	return err
+	return nil
 }
 
 func printConfigFile(w interface{ Write([]byte) (int, error) }, label, path string, exists bool) {

--- a/cli/internal/commands/config/module.go
+++ b/cli/internal/commands/config/module.go
@@ -100,6 +100,9 @@ func (module Module) modelsCommand(commandOptions *options) *cobra.Command {
 }
 
 func renderShow(command *cobra.Command, output string, result configapp.ShowResult) error {
+	if output == "yaml" {
+		return writeYAML(command, result.Resolved, "marshal config")
+	}
 	if output == "json" {
 		return writeJSON(command, result.Resolved, "marshal config")
 	}
@@ -137,6 +140,9 @@ func renderShow(command *cobra.Command, output string, result configapp.ShowResu
 }
 
 func renderModels(command *cobra.Command, output string, result configapp.ModelsResult) error {
+	if output == "yaml" {
+		return writeYAML(command, result.Config.Models, "marshal models config")
+	}
 	if output == "json" {
 		return writeJSON(command, result.Config.Models, "marshal models config")
 	}
@@ -188,6 +194,9 @@ func renderModels(command *cobra.Command, output string, result configapp.Models
 }
 
 func renderModelsWrite(command *cobra.Command, output, tier, skill string, result configapp.ModelsWriteResult) error {
+	if output == "yaml" {
+		return writeYAML(command, result, "marshal models write result")
+	}
 	if output == "json" {
 		return writeJSON(command, result, "marshal models write result")
 	}
@@ -217,6 +226,13 @@ func splitSkill(value string) []string {
 
 func writeJSON(command *cobra.Command, value any, label string) error {
 	if err := clicontract.WriteJSON(command.OutOrStdout(), value); err != nil {
+		return fmt.Errorf("%s: %w", label, err)
+	}
+	return nil
+}
+
+func writeYAML(command *cobra.Command, value any, label string) error {
+	if err := clicontract.WriteYAML(command.OutOrStdout(), value); err != nil {
 		return fmt.Errorf("%s: %w", label, err)
 	}
 	return nil

--- a/cli/internal/commands/config/module_test.go
+++ b/cli/internal/commands/config/module_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 	configapp "github.com/boshu2/agentops/cli/internal/config"
 )
 
@@ -31,7 +32,7 @@ func (useCases *fakeUseCases) WriteModels(_ context.Context, request configapp.M
 
 func TestModuleShowJSONUsesCommandWriter(t *testing.T) {
 	useCases := &fakeUseCases{showResult: configapp.ShowResult{Resolved: &configapp.ResolvedConfig{}}}
-	command := NewModule(useCases, func() string { return "json" }, func() bool { return false }, func() bool { return false }).Command()
+	command := NewModule(useCases, clicontract.HostOptions{OutputMode: func() string { return "json" }, Verbose: func() bool { return false }, DryRun: func() bool { return false }}).Command()
 	var stdout bytes.Buffer
 	command.SetOut(&stdout)
 	command.SetArgs([]string{"--show"})
@@ -45,7 +46,7 @@ func TestModuleShowJSONUsesCommandWriter(t *testing.T) {
 
 func TestModuleModelsWriteParsesDelegatesAndRenders(t *testing.T) {
 	useCases := &fakeUseCases{writeResult: configapp.ModelsWriteResult{Updated: true, DefaultTier: "quality"}}
-	command := NewModule(useCases, func() string { return "table" }, func() bool { return false }, func() bool { return false }).Command()
+	command := NewModule(useCases, clicontract.HostOptions{OutputMode: func() string { return "table" }, Verbose: func() bool { return false }, DryRun: func() bool { return false }}).Command()
 	var stdout bytes.Buffer
 	command.SetOut(&stdout)
 	command.SetArgs([]string{"models", "--set-tier", "quality", "--set-skill", "council=budget"})
@@ -62,7 +63,7 @@ func TestModuleModelsWriteParsesDelegatesAndRenders(t *testing.T) {
 
 func TestModuleModelsDryRunDelegatesAndRendersPreview(t *testing.T) {
 	useCases := &fakeUseCases{writeResult: configapp.ModelsWriteResult{DryRun: true, DefaultTier: "quality"}}
-	command := NewModule(useCases, func() string { return "table" }, func() bool { return false }, func() bool { return true }).Command()
+	command := NewModule(useCases, clicontract.HostOptions{OutputMode: func() string { return "table" }, Verbose: func() bool { return false }, DryRun: func() bool { return true }}).Command()
 	var stdout bytes.Buffer
 	command.SetOut(&stdout)
 	command.SetArgs([]string{"models", "--set-tier", "quality"})

--- a/cli/internal/commands/doctor/module.go
+++ b/cli/internal/commands/doctor/module.go
@@ -3,7 +3,6 @@ package doctor
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -34,12 +33,6 @@ type MaintenanceUseCases interface {
 	GC(context.Context, doctorapp.GCRequest) (doctorapp.GCResult, error)
 }
 
-type GlobalOptions struct {
-	DryRun bool
-	JSON   bool
-	Output string
-}
-
 type UseCases struct {
 	LegacyChecks  func(context.Context) []quality.Check
 	Read          ReadUseCases
@@ -48,17 +41,12 @@ type UseCases struct {
 	DetectorCount func() int
 }
 
-type HostOptions struct {
-	Globals       func(*cobra.Command) GlobalOptions
-	EnrichFlagErr func(*cobra.Command, error) error
-}
-
 type Module struct {
 	useCases UseCases
-	host     HostOptions
+	host     clicontract.HostOptions
 }
 
-func NewModule(useCases UseCases, host HostOptions) Module {
+func NewModule(useCases UseCases, host clicontract.HostOptions) Module {
 	return Module{useCases: useCases, host: host}
 }
 
@@ -87,22 +75,6 @@ type undoOptions struct{ strict, dryRun bool }
 type gcOptions struct {
 	before string
 	yes    bool
-}
-
-// ExitError carries a doctor process status through Cobra.
-type ExitError struct {
-	Code    int
-	Message string
-}
-
-func (failure *ExitError) Error() string { return failure.Message }
-func (failure *ExitError) ExitCode() int { return failure.Code }
-
-func (module Module) globals(command *cobra.Command) GlobalOptions {
-	if module.host.Globals == nil {
-		return GlobalOptions{}
-	}
-	return module.host.Globals(command)
 }
 
 func (module Module) Command() *cobra.Command {
@@ -154,13 +126,23 @@ Examples:
 	return command
 }
 
-func (module Module) wantsJSON(command *cobra.Command, options *rootOptions) bool {
-	global := module.globals(command)
-	return options.json || options.robot || global.JSON || global.Output == "json"
+func (module Module) wantsJSON(_ *cobra.Command, options *rootOptions) bool {
+	return options.json || options.robot || module.outputMode() == "json"
 }
 
-func (module Module) effectiveDryRun(command *cobra.Command, options *rootOptions, local bool) bool {
-	return local || options.dryRun || module.globals(command).DryRun
+func (module Module) outputMode() string {
+	if module.host.OutputMode == nil {
+		return ""
+	}
+	return module.host.OutputMode()
+}
+
+func (module Module) dryRun() bool {
+	return module.host.DryRun != nil && module.host.DryRun()
+}
+
+func (module Module) effectiveDryRun(_ *cobra.Command, options *rootOptions, local bool) bool {
+	return local || options.dryRun || module.dryRun()
 }
 
 func readRequest(options rootOptions, dryRun, jsonOutput bool) doctorapp.ReadRequest {
@@ -221,7 +203,9 @@ func advancedDiagnosticsRequested(command *cobra.Command) bool {
 	return false
 }
 
-func exit(code int, message string) error { return &ExitError{Code: code, Message: message} }
+func exit(code int, message string) error {
+	return &clicontract.ExitError{Code: code, Message: message, Label: "ao doctor"}
+}
 func resultExit(code int, message string) error {
 	if code == doctorapp.ExitHealthy {
 		return nil
@@ -230,12 +214,10 @@ func resultExit(code int, message string) error {
 }
 
 func writeJSON(command *cobra.Command, value any) error {
-	data, err := json.MarshalIndent(value, "", "  ")
-	if err != nil {
+	if err := clicontract.WriteJSON(command.OutOrStdout(), value); err != nil {
 		return exit(doctorapp.ExitIOError, err.Error())
 	}
-	_, err = fmt.Fprintln(command.OutOrStdout(), string(data))
-	return err
+	return nil
 }
 
 func renderFindings(command *cobra.Command, report *doctorapp.Report) {

--- a/cli/internal/commands/doctor/module.go
+++ b/cli/internal/commands/doctor/module.go
@@ -2,6 +2,7 @@
 package doctor
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -127,7 +128,22 @@ Examples:
 }
 
 func (module Module) wantsJSON(_ *cobra.Command, options *rootOptions) bool {
-	return options.json || options.robot || module.outputMode() == "json"
+	return options.json || options.robot || module.outputMode() == "json" || module.outputMode() == "yaml"
+}
+
+// emitStructured writes a module-built report as JSON, or as YAML when the
+// negotiated global output mode is yaml. The doctor render paths reach here only
+// after wantsJSON already selected structured output; the local --json and
+// --robot flags leave outputMode() at "table"/"json", so YAML is chosen only for
+// an explicit global `-o yaml` — never for a robot/local-json json contract.
+func (module Module) emitStructured(command *cobra.Command, value any) error {
+	if module.outputMode() == "yaml" {
+		if err := clicontract.WriteYAML(command.OutOrStdout(), value); err != nil {
+			return exit(doctorapp.ExitIOError, err.Error())
+		}
+		return nil
+	}
+	return writeJSON(command, value)
 }
 
 func (module Module) outputMode() string {
@@ -182,7 +198,7 @@ func (module Module) runRoot(command *cobra.Command, options rootOptions) error 
 			return exit(doctorapp.ExitIOError, err.Error())
 		}
 		if jsonOutput {
-			if err := writeJSON(command, report); err != nil {
+			if err := module.emitStructured(command, report); err != nil {
 				return err
 			}
 		} else {
@@ -191,6 +207,16 @@ func (module Module) runRoot(command *cobra.Command, options rootOptions) error 
 		return resultExit(report.ExitCode, "doctor findings present")
 	}
 	checks := module.useCases.LegacyChecks(command.Context())
+	if module.outputMode() == "yaml" {
+		// quality.RunDoctor emits exactly one JSON document in JSON mode; capture
+		// and re-emit as YAML so `ao doctor -o yaml` is the same data
+		// yaml-marshaled, not a silent human-summary fallback.
+		var buf bytes.Buffer
+		if err := quality.RunDoctor(quality.DoctorOptions{JSON: true, Checks: checks, Stdout: &buf}); err != nil {
+			return err
+		}
+		return clicontract.JSONToYAML(command.OutOrStdout(), buf.Bytes())
+	}
 	return quality.RunDoctor(quality.DoctorOptions{JSON: jsonOutput, Checks: checks, Stdout: command.OutOrStdout()})
 }
 
@@ -238,7 +264,7 @@ func (module Module) runFix(command *cobra.Command, request doctorapp.MutationRe
 		return exit(doctorapp.ExitIOError, err.Error())
 	}
 	if jsonOutput {
-		if err := writeJSON(command, report); err != nil {
+		if err := module.emitStructured(command, report); err != nil {
 			return err
 		}
 	} else {
@@ -261,7 +287,7 @@ func (module Module) runExplain(command *cobra.Command, id string, jsonOutput bo
 		return exit(doctorapp.ExitNoInput, err.Error())
 	}
 	if jsonOutput {
-		return writeJSON(command, finding)
+		return module.emitStructured(command, finding)
 	}
 	fmt.Fprintf(command.OutOrStdout(), "%s [%s] (%s)\n%s\n", finding.ID, finding.Severity, finding.Subsystem, finding.Title)
 	fmt.Fprintf(command.OutOrStdout(), "Remediation: %s\n", finding.Remediation.Command)
@@ -287,14 +313,14 @@ func (module Module) undoCommand(options *rootOptions) *cobra.Command {
 		result, err := module.useCases.Maintenance.Undo(command.Context(), request)
 		if err != nil {
 			if jsonOutput {
-				_ = writeJSON(command, map[string]any{"run_id": args[0], "exit_code": doctorapp.ExitIOError, "error": err.Error()})
+				_ = module.emitStructured(command, map[string]any{"run_id": args[0], "exit_code": doctorapp.ExitIOError, "error": err.Error()})
 			} else {
 				fmt.Fprintf(command.ErrOrStderr(), "undo failed: %v\n", err)
 			}
 			return exit(doctorapp.ExitIOError, err.Error())
 		}
 		if jsonOutput {
-			return writeJSON(command, result)
+			return module.emitStructured(command, result)
 		}
 		fmt.Fprintf(command.OutOrStdout(), "undo %s: restored=%d skipped=%d\n", result.RunID, result.Restored, result.Skipped)
 		return nil
@@ -310,7 +336,7 @@ func (module Module) explainCommand(options *rootOptions) *cobra.Command {
 
 func (module Module) capabilitiesCommand() *cobra.Command {
 	return &cobra.Command{Use: "capabilities", Short: "Print the machine-readable doctor contract (JSON)", Args: cobra.NoArgs, RunE: func(command *cobra.Command, _ []string) error {
-		return writeJSON(command, module.useCases.Read.Capabilities(command.Context()))
+		return module.emitStructured(command, module.useCases.Read.Capabilities(command.Context()))
 	}}
 }
 
@@ -321,7 +347,7 @@ func (module Module) healthCommand(options *rootOptions) *cobra.Command {
 			return exit(doctorapp.ExitIOError, err.Error())
 		}
 		if module.wantsJSON(command, options) {
-			if err := writeJSON(command, result); err != nil {
+			if err := module.emitStructured(command, result); err != nil {
 				return err
 			}
 		} else {
@@ -353,7 +379,7 @@ func (module Module) gcCommand(options *rootOptions) *cobra.Command {
 			return exit(doctorapp.ExitIOError, err.Error())
 		}
 		if module.wantsJSON(command, options) {
-			return writeJSON(command, result)
+			return module.emitStructured(command, result)
 		}
 		if result.DryRun {
 			fmt.Fprintf(command.OutOrStdout(), "would prune %d run(s)\n", result.Matched)
@@ -372,7 +398,7 @@ func (module Module) listCommand(options *rootOptions) *cobra.Command {
 			return exit(doctorapp.ExitIOError, err.Error())
 		}
 		if module.wantsJSON(command, options) {
-			return writeJSON(command, map[string]any{"runs": runs})
+			return module.emitStructured(command, map[string]any{"runs": runs})
 		}
 		if len(runs) == 0 {
 			fmt.Fprintln(command.OutOrStdout(), "no doctor runs")
@@ -393,7 +419,7 @@ func (module Module) diffCommand(options *rootOptions) *cobra.Command {
 			return exit(doctorapp.ExitIOError, err.Error())
 		}
 		if jsonOutput {
-			return writeJSON(command, report)
+			return module.emitStructured(command, report)
 		}
 		renderFindings(command, report)
 		if len(report.Findings) == 0 {

--- a/cli/internal/commands/doctor/module_test.go
+++ b/cli/internal/commands/doctor/module_test.go
@@ -6,11 +6,20 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/spf13/cobra"
-
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 	doctorapp "github.com/boshu2/agentops/cli/internal/doctor"
 	"github.com/boshu2/agentops/cli/internal/quality"
 )
+
+// GlobalOptions is the doctor test's stand-in for the root's resolved global
+// flags. testModule translates it into the shared clicontract.HostOptions seams
+// the module actually reads (DryRun and OutputMode); the module derives its
+// JSON intent from OutputMode == "json", so a JSON-true row maps to "json".
+type GlobalOptions struct {
+	DryRun bool
+	JSON   bool
+	Output string
+}
 
 type fakeRead struct{}
 
@@ -61,7 +70,15 @@ func testModule(mutation *fakeMutation, maintenance *fakeMaintenance, globals Gl
 		LegacyChecks: func(context.Context) []quality.Check { return nil },
 		Read:         fakeRead{}, Mutation: mutation, Maintenance: maintenance,
 		DetectorCount: func() int { return 0 },
-	}, HostOptions{Globals: func(*cobra.Command) GlobalOptions { return globals }})
+	}, clicontract.HostOptions{
+		DryRun: func() bool { return globals.DryRun },
+		OutputMode: func() string {
+			if globals.JSON {
+				return "json"
+			}
+			return globals.Output
+		},
+	})
 }
 
 func TestInheritedDryRunProtectsFixGCAndUndo(t *testing.T) {

--- a/cli/internal/commands/eval/module.go
+++ b/cli/internal/commands/eval/module.go
@@ -214,6 +214,9 @@ func (module Module) compareCommand() *cobra.Command {
 		if err != nil {
 			return err
 		}
+		if module.outputMode() == "yaml" {
+			return clicontract.WriteYAML(command.OutOrStdout(), result.Candidate)
+		}
 		if module.outputMode() == "json" {
 			return clicontract.WriteJSON(command.OutOrStdout(), result.Candidate)
 		}
@@ -241,6 +244,9 @@ func (module Module) baselineCommand() *cobra.Command {
 		if err != nil {
 			return err
 		}
+		if module.outputMode() == "yaml" {
+			return clicontract.WriteYAML(command.OutOrStdout(), result)
+		}
 		if module.outputMode() == "json" {
 			return clicontract.WriteJSON(command.OutOrStdout(), result)
 		}
@@ -263,6 +269,9 @@ func (module Module) baselineAuditCommand() *cobra.Command {
 		report, err := module.useCases.Core.AuditBaseline(command.Context(), aoeval.CoreBaselineAuditRequest{SuitePaths: args, Root: options.root, BaselineDir: options.baselineDir})
 		if err != nil {
 			return err
+		}
+		if module.outputMode() == "yaml" {
+			return clicontract.WriteYAML(command.OutOrStdout(), report)
 		}
 		if module.outputMode() == "json" {
 			return clicontract.WriteJSON(command.OutOrStdout(), report)
@@ -301,6 +310,9 @@ func (module Module) scorecardCommand() *cobra.Command {
 		if err != nil {
 			return err
 		}
+		if module.outputMode() == "yaml" {
+			return clicontract.WriteYAML(command.OutOrStdout(), card)
+		}
 		if module.outputMode() == "json" {
 			return clicontract.WriteJSON(command.OutOrStdout(), card)
 		}
@@ -325,6 +337,9 @@ func (module Module) coverageCommand() *cobra.Command {
 		report, err := module.useCases.Core.Coverage(command.Context(), aoeval.CoreCoverageRequest{SuitePaths: args, Root: options.root, RequiredDomains: options.domains, RequiredEvidenceKinds: options.evidenceKinds, RequiredDimensions: options.dimensions, RequiredRuntimes: options.runtimes})
 		if err != nil {
 			return err
+		}
+		if module.outputMode() == "yaml" {
+			return clicontract.WriteYAML(command.OutOrStdout(), report)
 		}
 		if module.outputMode() == "json" {
 			return clicontract.WriteJSON(command.OutOrStdout(), report)
@@ -367,6 +382,9 @@ never auto-removed — retraction is an audit trail.`,
 		report, err := module.useCases.Cleanup.Execute(command.Context(), options)
 		if err != nil {
 			return err
+		}
+		if module.outputMode() == "yaml" {
+			return clicontract.WriteYAML(command.OutOrStdout(), report)
 		}
 		if module.outputMode() == "json" {
 			return clicontract.WriteJSON(command.OutOrStdout(), report)
@@ -417,6 +435,9 @@ func (module Module) taskListCommand() *cobra.Command {
 		for _, summary := range result.Tasks {
 			ids = append(ids, summary.ID)
 		}
+		if module.outputMode() == "yaml" {
+			return clicontract.WriteYAML(command.OutOrStdout(), map[string]any{"tasks": ids, "root": result.Root})
+		}
 		if module.outputMode() == "json" {
 			return clicontract.WriteJSON(command.OutOrStdout(), map[string]any{"tasks": ids, "root": result.Root})
 		}
@@ -444,6 +465,9 @@ func (module Module) taskShowCommand() *cobra.Command {
 		task, err := module.useCases.Task.Show(command.Context(), args[0])
 		if err != nil {
 			return err
+		}
+		if module.outputMode() == "yaml" {
+			return clicontract.WriteYAML(command.OutOrStdout(), task)
 		}
 		if module.outputMode() == "json" {
 			return clicontract.WriteJSON(command.OutOrStdout(), task)
@@ -489,6 +513,9 @@ func (module Module) taskRunCommand() *cobra.Command {
 			fmt.Fprintln(command.OutOrStdout(), "Dry run: gates passed; no Run manifest written.")
 			return nil
 		}
+		if module.outputMode() == "yaml" {
+			return clicontract.WriteYAML(command.OutOrStdout(), result.Manifest)
+		}
 		if module.outputMode() == "json" {
 			return clicontract.WriteJSON(command.OutOrStdout(), result.Manifest)
 		}
@@ -519,6 +546,9 @@ func (module Module) suiteVerdictCommand() *cobra.Command {
 		if err != nil {
 			return err
 		}
+		if module.outputMode() == "yaml" {
+			return clicontract.JSONToYAML(command.OutOrStdout(), result.Raw)
+		}
 		if module.outputMode() == "json" {
 			_, err = command.OutOrStdout().Write(append(append([]byte(nil), result.Raw...), '\n'))
 			return err
@@ -542,6 +572,9 @@ func (module Module) suiteNRequiredCommand() *cobra.Command {
 		result, err := module.useCases.Suite.NRequired(command.Context(), options)
 		if err != nil {
 			return err
+		}
+		if module.outputMode() == "yaml" {
+			return clicontract.JSONToYAML(command.OutOrStdout(), result.Raw)
 		}
 		if module.outputMode() == "json" {
 			_, err = command.OutOrStdout().Write(append(append([]byte(nil), result.Raw...), '\n'))
@@ -587,7 +620,13 @@ func (module Module) outcomesIngestCommand() *cobra.Command {
 		if result.Warning != "" {
 			fmt.Fprintln(command.ErrOrStderr(), result.Warning)
 		}
-		if err := clicontract.WriteJSON(command.OutOrStdout(), result.Verdict); err != nil {
+		// ingest emits the verdict as structured output unconditionally (its
+		// default is JSON, not a human table); honor -o yaml when asked.
+		emit := clicontract.WriteJSON
+		if module.outputMode() == "yaml" {
+			emit = clicontract.WriteYAML
+		}
+		if err := emit(command.OutOrStdout(), result.Verdict); err != nil {
 			return err
 		}
 		if result.ManifestPath != "" {
@@ -631,6 +670,9 @@ func (module Module) scenarioAddCommand() *cobra.Command {
 		result, err := module.useCases.Scenario.Add(command.Context(), options)
 		if err != nil {
 			return err
+		}
+		if module.outputMode() == "yaml" {
+			return clicontract.WriteYAML(command.OutOrStdout(), result.Scenario)
 		}
 		if module.outputMode() == "json" {
 			return clicontract.WriteJSON(command.OutOrStdout(), result.Scenario)
@@ -710,6 +752,9 @@ func (module Module) scenarioEvaluateCommand() *cobra.Command {
 		report, err := module.useCases.Scenario.Evaluate(command.Context(), options)
 		if err != nil {
 			return err
+		}
+		if module.outputMode() == "yaml" {
+			return clicontract.WriteYAML(command.OutOrStdout(), report)
 		}
 		if jsonOutput || module.outputMode() == "json" {
 			return clicontract.WriteJSON(command.OutOrStdout(), report)
@@ -796,6 +841,9 @@ func (module Module) scenarioMoatCommand() *cobra.Command {
 			}
 			return err
 		}
+		if module.outputMode() == "yaml" {
+			return clicontract.WriteYAML(command.OutOrStdout(), result)
+		}
 		if module.outputMode() == "json" {
 			return clicontract.WriteJSON(command.OutOrStdout(), result)
 		}
@@ -826,6 +874,9 @@ func (module Module) sessionOutcomeCommand() *cobra.Command {
 		if result.DryRun {
 			fmt.Fprintf(command.OutOrStdout(), "[dry-run] Would analyze transcript: %s\n", result.Transcript)
 			return nil
+		}
+		if module.outputMode() == "yaml" {
+			return clicontract.WriteYAML(command.OutOrStdout(), result)
 		}
 		if format == "json" || module.outputMode() == "json" {
 			return clicontract.WriteJSON(command.OutOrStdout(), result)
@@ -892,6 +943,9 @@ func (module Module) renderRun(command *cobra.Command, result aoeval.CoreRunResu
 	}
 	if result.Mode == aoeval.CoreRunContextAB {
 		value = result.ContextDelta
+	}
+	if module.outputMode() == "yaml" {
+		return clicontract.WriteYAML(command.OutOrStdout(), value)
 	}
 	if module.outputMode() == "json" {
 		return clicontract.WriteJSON(command.OutOrStdout(), value)

--- a/cli/internal/commands/eval/module.go
+++ b/cli/internal/commands/eval/module.go
@@ -3,7 +3,6 @@ package eval
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -69,20 +68,12 @@ type UseCases struct {
 	Bench      aoeval.BenchUseCases
 }
 
-type HostOptions struct {
-	OutputMode  func(*cobra.Command) string
-	Verbose     func(*cobra.Command) bool
-	ProjectRoot func() string
-	GoalsPath   func() string
-	DryRun      func(*cobra.Command) bool
-}
-
 type Module struct {
 	useCases UseCases
-	host     HostOptions
+	host     clicontract.HostOptions
 }
 
-func NewModule(useCases UseCases, host HostOptions) Module {
+func NewModule(useCases UseCases, host clicontract.HostOptions) Module {
 	return Module{useCases: useCases, host: host}
 }
 
@@ -171,11 +162,11 @@ release. Live Claude and Codex adapters are evaluated by a later runtime tier.`,
 	return command
 }
 
-func (module Module) outputMode(command *cobra.Command) string {
+func (module Module) outputMode() string {
 	if module.host.OutputMode == nil {
 		return ""
 	}
-	return module.host.OutputMode(command)
+	return module.host.OutputMode()
 }
 
 func (module Module) runCommand() *cobra.Command {
@@ -223,8 +214,8 @@ func (module Module) compareCommand() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		if module.outputMode(command) == "json" {
-			return writeJSON(command, result.Candidate)
+		if module.outputMode() == "json" {
+			return clicontract.WriteJSON(command.OutOrStdout(), result.Candidate)
 		}
 		delta := 0.0
 		if result.Candidate.BaselineComparison != nil {
@@ -250,8 +241,8 @@ func (module Module) baselineCommand() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		if module.outputMode(command) == "json" {
-			return writeJSON(command, result)
+		if module.outputMode() == "json" {
+			return clicontract.WriteJSON(command.OutOrStdout(), result)
 		}
 		path := ""
 		if result.Baseline != nil {
@@ -273,8 +264,8 @@ func (module Module) baselineAuditCommand() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		if module.outputMode(command) == "json" {
-			return writeJSON(command, report)
+		if module.outputMode() == "json" {
+			return clicontract.WriteJSON(command.OutOrStdout(), report)
 		}
 		fmt.Fprintf(command.OutOrStdout(), "Eval baseline audit: %d suites, %d baselines, %d policy mismatches\n", report.SuiteCount, report.BaselineCount, report.PolicyMismatchCount)
 		if len(report.MissingCompareBaselines) > 0 {
@@ -310,8 +301,8 @@ func (module Module) scorecardCommand() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		if module.outputMode(command) == "json" {
-			return writeJSON(command, card)
+		if module.outputMode() == "json" {
+			return clicontract.WriteJSON(command.OutOrStdout(), card)
 		}
 		fmt.Fprintf(command.OutOrStdout(), "Eval scorecard %s: %s (%s, categories %d)\n", card.CandidateRunID, card.Verdict, card.Kind, len(card.Categories))
 		if options.output != "" {
@@ -335,8 +326,8 @@ func (module Module) coverageCommand() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		if module.outputMode(command) == "json" {
-			return writeJSON(command, report)
+		if module.outputMode() == "json" {
+			return clicontract.WriteJSON(command.OutOrStdout(), report)
 		}
 		fmt.Fprintf(command.OutOrStdout(), "Eval coverage: %d suites, %d cases, %d critical cases\n", report.SuiteCount, report.CaseCount, report.CriticalCaseCount)
 		renderCoverage(command, "domains", report.MissingRequiredDomains, report.RequiredDomains)
@@ -377,11 +368,11 @@ never auto-removed — retraction is an audit trail.`,
 		if err != nil {
 			return err
 		}
-		if module.outputMode(command) == "json" {
-			return writeJSON(command, report)
+		if module.outputMode() == "json" {
+			return clicontract.WriteJSON(command.OutOrStdout(), report)
 		}
 		fmt.Fprintf(command.OutOrStdout(), "Eval cleanup:\n  transitions->aborted: %d\n  transitions->failed:  %d\n  runs deleted:         %d\n  tmp files swept:      %d\n", report.TransitionsAborted, report.TransitionsFailed, report.RunsDeleted, report.TmpFilesSwept)
-		verbose := module.host.Verbose != nil && module.host.Verbose(command)
+		verbose := module.host.Verbose != nil && module.host.Verbose()
 		if len(report.Touched) > 0 && verbose {
 			fmt.Fprintln(command.OutOrStdout(), "Touched:")
 			for _, touched := range report.Touched {
@@ -426,8 +417,8 @@ func (module Module) taskListCommand() *cobra.Command {
 		for _, summary := range result.Tasks {
 			ids = append(ids, summary.ID)
 		}
-		if module.outputMode(command) == "json" {
-			return writeJSON(command, map[string]any{"tasks": ids, "root": result.Root})
+		if module.outputMode() == "json" {
+			return clicontract.WriteJSON(command.OutOrStdout(), map[string]any{"tasks": ids, "root": result.Root})
 		}
 		if len(result.Tasks) == 0 {
 			fmt.Fprintln(command.OutOrStdout(), "No tasks registered")
@@ -454,8 +445,8 @@ func (module Module) taskShowCommand() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		if module.outputMode(command) == "json" {
-			return writeJSON(command, task)
+		if module.outputMode() == "json" {
+			return clicontract.WriteJSON(command.OutOrStdout(), task)
 		}
 		fmt.Fprintf(command.OutOrStdout(), "Task: %s\n", task.ID)
 		fmt.Fprintf(command.OutOrStdout(), "  schema_version: %d\n  domain:         %s\n  description:    %s\n  harness_ref:    %s\n", task.SchemaVersion, task.Domain, task.Description, task.HarnessRef)
@@ -498,8 +489,8 @@ func (module Module) taskRunCommand() *cobra.Command {
 			fmt.Fprintln(command.OutOrStdout(), "Dry run: gates passed; no Run manifest written.")
 			return nil
 		}
-		if module.outputMode(command) == "json" {
-			return writeJSON(command, result.Manifest)
+		if module.outputMode() == "json" {
+			return clicontract.WriteJSON(command.OutOrStdout(), result.Manifest)
 		}
 		manifest := result.Manifest
 		fmt.Fprintf(command.OutOrStdout(), "Run opened: %s\n  status:    %s\n  manifest:  %s\n  rig_id:    %s\n  task_ref:  %s\n  suite_ref: %s\n", manifest.ID, manifest.Status, result.Path, manifest.RigID, manifest.TaskRef, manifest.SuiteRef)
@@ -528,7 +519,7 @@ func (module Module) suiteVerdictCommand() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		if module.outputMode(command) == "json" {
+		if module.outputMode() == "json" {
 			_, err = command.OutOrStdout().Write(append(append([]byte(nil), result.Raw...), '\n'))
 			return err
 		}
@@ -552,7 +543,7 @@ func (module Module) suiteNRequiredCommand() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		if module.outputMode(command) == "json" {
+		if module.outputMode() == "json" {
 			_, err = command.OutOrStdout().Write(append(append([]byte(nil), result.Raw...), '\n'))
 			return err
 		}
@@ -575,7 +566,7 @@ func (module Module) outcomesCompileCommand() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		return writeJSON(command, rubric)
+		return clicontract.WriteJSON(command.OutOrStdout(), rubric)
 	}
 	return command
 }
@@ -596,7 +587,7 @@ func (module Module) outcomesIngestCommand() *cobra.Command {
 		if result.Warning != "" {
 			fmt.Fprintln(command.ErrOrStderr(), result.Warning)
 		}
-		if err := writeJSON(command, result.Verdict); err != nil {
+		if err := clicontract.WriteJSON(command.OutOrStdout(), result.Verdict); err != nil {
 			return err
 		}
 		if result.ManifestPath != "" {
@@ -641,8 +632,8 @@ func (module Module) scenarioAddCommand() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		if module.outputMode(command) == "json" {
-			return writeJSON(command, result.Scenario)
+		if module.outputMode() == "json" {
+			return clicontract.WriteJSON(command.OutOrStdout(), result.Scenario)
 		}
 		fmt.Fprintf(command.OutOrStdout(), "Created scenario %s at %s\n", result.Scenario.ID, result.Path)
 		return nil
@@ -664,13 +655,13 @@ func (module Module) scenarioListCommand() *cobra.Command {
 		// goes to stderr. Exit 0.
 		if result.MissingDirectory {
 			fmt.Fprintln(command.ErrOrStderr(), "No holdout directory found. Run 'ao eval scenario init' first.")
-			return writeJSON(command, []aoeval.ScenarioSummary{})
+			return clicontract.WriteJSON(command.OutOrStdout(), []aoeval.ScenarioSummary{})
 		}
 		if len(result.Scenarios) == 0 {
 			fmt.Fprintln(command.ErrOrStderr(), "No scenarios found.")
-			return writeJSON(command, []aoeval.ScenarioSummary{})
+			return clicontract.WriteJSON(command.OutOrStdout(), []aoeval.ScenarioSummary{})
 		}
-		return writeJSON(command, result.Scenarios)
+		return clicontract.WriteJSON(command.OutOrStdout(), result.Scenarios)
 	}
 	return command
 }
@@ -720,8 +711,8 @@ func (module Module) scenarioEvaluateCommand() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		if jsonOutput || module.outputMode(command) == "json" {
-			return writeJSON(command, report)
+		if jsonOutput || module.outputMode() == "json" {
+			return clicontract.WriteJSON(command.OutOrStdout(), report)
 		}
 		return renderScenarioEvaluate(command, report)
 	}
@@ -805,8 +796,8 @@ func (module Module) scenarioMoatCommand() *cobra.Command {
 			}
 			return err
 		}
-		if module.outputMode(command) == "json" {
-			return writeJSON(command, result)
+		if module.outputMode() == "json" {
+			return clicontract.WriteJSON(command.OutOrStdout(), result)
 		}
 		fmt.Fprintf(command.OutOrStdout(), "scenario-moat: verdict=%s scenarios=%d mean_delta=%.4f\n  %s\n", result.Verdict, result.ScenarioCount, result.MeanAggregateDelta, result.Reason)
 		if options.OutputPath != "" {
@@ -827,7 +818,7 @@ func (module Module) sessionOutcomeCommand() *cobra.Command {
 		if len(args) > 0 {
 			path = args[0]
 		}
-		dryRun := module.host.DryRun != nil && module.host.DryRun(command)
+		dryRun := module.host.DryRun != nil && module.host.DryRun()
 		result, err := module.useCases.Aliases.SessionOutcome(command.Context(), aoeval.SessionOutcomeRequest{TranscriptPath: path, SessionID: sessionID, DryRun: dryRun})
 		if err != nil {
 			return err
@@ -836,8 +827,8 @@ func (module Module) sessionOutcomeCommand() *cobra.Command {
 			fmt.Fprintf(command.OutOrStdout(), "[dry-run] Would analyze transcript: %s\n", result.Transcript)
 			return nil
 		}
-		if format == "json" || module.outputMode(command) == "json" {
-			return writeJSON(command, result)
+		if format == "json" || module.outputMode() == "json" {
+			return clicontract.WriteJSON(command.OutOrStdout(), result)
 		}
 		fmt.Fprintln(command.OutOrStdout(), "Session Outcome Analysis\n========================")
 		fmt.Fprintf(command.OutOrStdout(), "Session ID:  %s\nReward:      %.2f\nLines:       %d\n\nSignals detected:\n", result.SessionID, result.Reward, result.TotalLines)
@@ -902,8 +893,8 @@ func (module Module) renderRun(command *cobra.Command, result aoeval.CoreRunResu
 	if result.Mode == aoeval.CoreRunContextAB {
 		value = result.ContextDelta
 	}
-	if module.outputMode(command) == "json" {
-		return writeJSON(command, value)
+	if module.outputMode() == "json" {
+		return clicontract.WriteJSON(command.OutOrStdout(), value)
 	}
 	switch result.Mode {
 	case aoeval.CoreRunContextAB:
@@ -958,12 +949,6 @@ func annotateSuiteParseError(err error) error {
 		}
 	}
 	return err
-}
-
-func writeJSON(command *cobra.Command, value any) error {
-	encoder := json.NewEncoder(command.OutOrStdout())
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(value)
 }
 
 func staticCompletion(values ...string) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {

--- a/cli/internal/commands/eval/module_test.go
+++ b/cli/internal/commands/eval/module_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spf13/cobra"
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 
 	aoeval "github.com/boshu2/agentops/cli/internal/eval"
 	"github.com/boshu2/agentops/cli/internal/evalsubstrate"
@@ -80,7 +80,7 @@ func TestModuleScenarioListJSONEmptyStates(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			spy := &scenarioListSpy{listResult: tc.result}
-			command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Scenario: spy}, HostOptions{}).Command()
+			command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Scenario: spy}, clicontract.HostOptions{}).Command()
 			command.SetArgs([]string{"scenario", "list"})
 			var stdout, stderr bytes.Buffer
 			command.SetOut(&stdout)
@@ -219,7 +219,7 @@ func (*coreUseCasesSpy) Coverage(context.Context, aoeval.CoreCoverageRequest) (*
 
 func TestModuleRunParsesClosureLocalFlagsAndDelegates(t *testing.T) {
 	useCases := &coreUseCasesSpy{}
-	command := NewModule(UseCases{Core: useCases}, HostOptions{}).Command()
+	command := NewModule(UseCases{Core: useCases}, clicontract.HostOptions{}).Command()
 	command.SetArgs([]string{"run", "suite.json", "--run-id", "run-1", "--runtime", "static", "--baseline-mode", "skill-on"})
 	var output strings.Builder
 	command.SetOut(&output)
@@ -236,8 +236,8 @@ func TestModuleRunParsesClosureLocalFlagsAndDelegates(t *testing.T) {
 }
 
 func TestModuleCommandsDoNotShareFlagState(t *testing.T) {
-	first := NewModule(UseCases{Core: &coreUseCasesSpy{}}, HostOptions{}).Command()
-	second := NewModule(UseCases{Core: &coreUseCasesSpy{}}, HostOptions{}).Command()
+	first := NewModule(UseCases{Core: &coreUseCasesSpy{}}, clicontract.HostOptions{}).Command()
+	second := NewModule(UseCases{Core: &coreUseCasesSpy{}}, clicontract.HostOptions{}).Command()
 	firstRun, _, err := first.Find([]string{"run"})
 	if err != nil {
 		t.Fatal(err)
@@ -256,7 +256,7 @@ func TestModuleCommandsDoNotShareFlagState(t *testing.T) {
 
 func TestModuleCleanupDelegatesClosureLocalOptions(t *testing.T) {
 	cleanup := &cleanupUseCasesSpy{}
-	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Cleanup: cleanup}, HostOptions{Verbose: func(*cobra.Command) bool { return true }}).Command()
+	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Cleanup: cleanup}, clicontract.HostOptions{Verbose: func() bool { return true }}).Command()
 	command.SetArgs([]string{"cleanup", "--delete", "--tmp-files", "--tmp-age", "7", "--dry-run"})
 	var output strings.Builder
 	command.SetOut(&output)
@@ -273,7 +273,7 @@ func TestModuleCleanupDelegatesClosureLocalOptions(t *testing.T) {
 
 func TestModuleTaskRunDelegatesClosureLocalFlags(t *testing.T) {
 	task := &taskUseCasesSpy{}
-	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Task: task}, HostOptions{}).Command()
+	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Task: task}, clicontract.HostOptions{}).Command()
 	command.SetArgs([]string{"task", "run", "task-1", "--suite", "suite-1", "--seeds", "1,2,3", "--rig-id", "rig-1", "--dry-run"})
 	var output strings.Builder
 	command.SetOut(&output)
@@ -290,7 +290,7 @@ func TestModuleTaskRunDelegatesClosureLocalFlags(t *testing.T) {
 
 func TestModuleSuiteVerdictDelegatesFlags(t *testing.T) {
 	suite := &suiteUseCasesSpy{}
-	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Suite: suite}, HostOptions{}).Command()
+	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Suite: suite}, clicontract.HostOptions{}).Command()
 	command.SetArgs([]string{"suite", "verdict", "suite-1", "--arms", "a,b", "--inputs", "in.json", "--B", "99"})
 	if err := command.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -302,7 +302,7 @@ func TestModuleSuiteVerdictDelegatesFlags(t *testing.T) {
 
 func TestModuleOutcomesIngestDelegatesSafetyFlags(t *testing.T) {
 	outcomes := &outcomesUseCasesSpy{}
-	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Outcomes: outcomes}, HostOptions{}).Command()
+	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Outcomes: outcomes}, clicontract.HostOptions{}).Command()
 	command.SetArgs([]string{"outcomes", "ingest", "score.json", "--expect-judge-hash", "hash", "--burn-ledger", "burn.json", "--manifest-out", "runs"})
 	if err := command.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -314,7 +314,7 @@ func TestModuleOutcomesIngestDelegatesSafetyFlags(t *testing.T) {
 
 func TestModuleScenarioAddDelegatesClosureLocalFlags(t *testing.T) {
 	useCases := &scenarioUseCasesSpy{}
-	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Scenario: useCases}, HostOptions{}).Command()
+	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Scenario: useCases}, clicontract.HostOptions{}).Command()
 	command.SetArgs([]string{"scenario", "add", "goal", "--threshold", "0.7", "--status", "active"})
 	if err := command.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -326,7 +326,7 @@ func TestModuleScenarioAddDelegatesClosureLocalFlags(t *testing.T) {
 
 func TestModuleScenarioABDelegatesFlags(t *testing.T) {
 	useCases := &scenarioABUseCasesSpy{}
-	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, ScenarioAB: useCases}, HostOptions{}).Command()
+	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, ScenarioAB: useCases}, clicontract.HostOptions{}).Command()
 	command.SetArgs([]string{"scenario-ab", "--scenario", "s.json", "--token-budget", "9", "--control-only"})
 	if err := command.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -338,7 +338,7 @@ func TestModuleScenarioABDelegatesFlags(t *testing.T) {
 
 func TestModuleSessionOutcomeDelegatesFlags(t *testing.T) {
 	useCases := &aliasUseCasesSpy{}
-	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Aliases: useCases}, HostOptions{}).Command()
+	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Aliases: useCases}, clicontract.HostOptions{}).Command()
 	command.SetArgs([]string{"session-outcome", "transcript.jsonl", "--session", "s-1"})
 	if err := command.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -349,7 +349,7 @@ func TestModuleSessionOutcomeDelegatesFlags(t *testing.T) {
 }
 
 func TestModuleChaosRendersAdapterStreams(t *testing.T) {
-	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Aliases: &aliasUseCasesSpy{}}, HostOptions{}).Command()
+	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Aliases: &aliasUseCasesSpy{}}, clicontract.HostOptions{}).Command()
 	command.SetArgs([]string{"chaos"})
 	var stdout strings.Builder
 	command.SetOut(&stdout)
@@ -363,7 +363,7 @@ func TestModuleChaosRendersAdapterStreams(t *testing.T) {
 
 func TestModuleBenchDelegatesClosureLocalFlags(t *testing.T) {
 	useCases := &benchUseCasesSpy{}
-	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Bench: useCases}, HostOptions{}).Command()
+	command := NewModule(UseCases{Core: &coreUseCasesSpy{}, Bench: useCases}, clicontract.HostOptions{}).Command()
 	command.SetArgs([]string{"bench", "--corpus", "fixture", "--k", "7", "--json"})
 	if err := command.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)

--- a/cli/internal/commands/flywheel/module.go
+++ b/cli/internal/commands/flywheel/module.go
@@ -15,22 +15,13 @@ import (
 	"github.com/boshu2/agentops/cli/internal/flywheelapp"
 )
 
-// HostOptions carries the ambient CLI seams the flywheel commands read: the
-// global -o/--output mode and the verbose diagnostic printer. Output selection
-// and diagnostics flow through these seams so the module reads no package
-// global.
-type HostOptions struct {
-	OutputMode func() string
-	Verbosef   func(format string, args ...any)
-}
-
 // Module owns Cobra presentation for the flywheel command family.
 type Module struct {
-	host HostOptions
+	host clicontract.HostOptions
 }
 
 // NewModule constructs the flywheel command module from its host seams.
-func NewModule(host HostOptions) Module {
+func NewModule(host clicontract.HostOptions) Module {
 	return Module{host: host}
 }
 

--- a/cli/internal/commands/flywheel/module_test.go
+++ b/cli/internal/commands/flywheel/module_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func newTestModule(outputMode string) Module {
-	return NewModule(HostOptions{
+	return NewModule(clicontract.HostOptions{
 		OutputMode: func() string { return outputMode },
 		Verbosef:   func(string, ...any) {},
 	})

--- a/cli/internal/commands/gate/module.go
+++ b/cli/internal/commands/gate/module.go
@@ -16,19 +16,12 @@ type CheckUseCases interface {
 
 type UseCases struct{ Check CheckUseCases }
 
-// HostOptions is retained as the command-module host seam. Gate check does not
-// use lifecycle or review state from the host.
-type HostOptions struct {
-	DryRun       func() bool
-	OutputFormat func() string
-}
-
 type Module struct {
 	useCases UseCases
-	host     HostOptions
+	host     clicontract.HostOptions
 }
 
-func NewModule(useCases UseCases, host HostOptions) Module {
+func NewModule(useCases UseCases, host clicontract.HostOptions) Module {
 	return Module{useCases: useCases, host: host}
 }
 
@@ -70,14 +63,6 @@ func (Module) CheckContract() clicontract.CommandContract {
 	}
 }
 
-type ExitError struct {
-	Code    int
-	Message string
-}
-
-func (failure *ExitError) Error() string { return failure.Message }
-func (failure *ExitError) ExitCode() int { return failure.Code }
-
 func (module Module) Command() *cobra.Command {
 	command := &cobra.Command{
 		Use:     "gate",
@@ -108,19 +93,19 @@ func (module Module) newCheckCommand() *cobra.Command {
 		RunE: func(command *cobra.Command, _ []string) error {
 			_ = fast
 			if module.useCases.Check == nil {
-				return &ExitError{Code: 2, Message: "gate check: use case not configured"}
+				return &clicontract.ExitError{Code: 2, Message: "gate check: use case not configured"}
 			}
 			result, err := module.useCases.Check.Execute(command.Context(), gateapp.CheckRequest{
 				Full: full, Scope: scope, FailFast: failFast,
 				WorkflowCoverage: workflowCoverage, RequireWorkflowParity: requireWorkflowParity, WorkflowPath: workflowPath,
 			})
 			if err != nil {
-				return &ExitError{Code: 2, Message: err.Error()}
+				return &clicontract.ExitError{Code: 2, Message: err.Error()}
 			}
 			if jsonOutput {
 				raw, jsonErr := result.Report.JSON()
 				if jsonErr != nil {
-					return &ExitError{Code: 2, Message: jsonErr.Error()}
+					return &clicontract.ExitError{Code: 2, Message: jsonErr.Error()}
 				}
 				fmt.Fprintln(command.OutOrStdout(), string(raw))
 			} else {
@@ -134,7 +119,7 @@ func (module Module) newCheckCommand() *cobra.Command {
 				if result.WorkflowParityMissing > 0 {
 					message = fmt.Sprintf("workflow parity missing %d blocking script(s)", result.WorkflowParityMissing)
 				}
-				return &ExitError{Code: result.ExitCode, Message: message}
+				return &clicontract.ExitError{Code: result.ExitCode, Message: message}
 			}
 			return nil
 		},

--- a/cli/internal/commands/gate/module.go
+++ b/cli/internal/commands/gate/module.go
@@ -74,6 +74,18 @@ The result means only that the selected checks passed or failed. It is not a
 semantic verdict and does not authorize Git, release, or delivery.`,
 	}
 	command.AddCommand(module.newCheckCommand())
+	// Silence cobra's own error/usage printing so the ExitError path is the sole
+	// error surface: a gate check failure returns an empty-Label ExitError whose
+	// report already sits on stdout, and the root stays silent (see cmd/ao
+	// Execute). Without this, cobra prints its own "Error: <msg>" to stderr,
+	// double-surfacing the failure and breaking the "quiet stderr on gate
+	// failure" contract. Mirrors doctor/module.go.
+	command.SilenceErrors = true
+	command.SilenceUsage = true
+	for _, child := range command.Commands() {
+		child.SilenceErrors = true
+		child.SilenceUsage = true
+	}
 	return command
 }
 
@@ -93,19 +105,19 @@ func (module Module) newCheckCommand() *cobra.Command {
 		RunE: func(command *cobra.Command, _ []string) error {
 			_ = fast
 			if module.useCases.Check == nil {
-				return &clicontract.ExitError{Code: 2, Message: "gate check: use case not configured"}
+				return &clicontract.ExitError{Code: 2, Message: "gate check: use case not configured", Label: "ao gate"}
 			}
 			result, err := module.useCases.Check.Execute(command.Context(), gateapp.CheckRequest{
 				Full: full, Scope: scope, FailFast: failFast,
 				WorkflowCoverage: workflowCoverage, RequireWorkflowParity: requireWorkflowParity, WorkflowPath: workflowPath,
 			})
 			if err != nil {
-				return &clicontract.ExitError{Code: 2, Message: err.Error()}
+				return &clicontract.ExitError{Code: 2, Message: err.Error(), Label: "ao gate"}
 			}
 			if jsonOutput {
 				raw, jsonErr := result.Report.JSON()
 				if jsonErr != nil {
-					return &clicontract.ExitError{Code: 2, Message: jsonErr.Error()}
+					return &clicontract.ExitError{Code: 2, Message: jsonErr.Error(), Label: "ao gate"}
 				}
 				fmt.Fprintln(command.OutOrStdout(), string(raw))
 			} else {
@@ -115,11 +127,16 @@ func (module Module) newCheckCommand() *cobra.Command {
 				result.Report.GitHubAnnotations(command.ErrOrStderr())
 			}
 			if result.ExitCode != 0 {
-				message := ""
+				// A check failure is not an error condition of the command: the
+				// report already sits on stdout and the process code carries the
+				// verdict. Surface only the workflow-parity note (a distinct,
+				// opt-in diagnostic that is not part of the report) on stderr, then
+				// return an empty-Label ExitError so the root maps the code and
+				// stays otherwise silent (quiet-stderr-on-gate-failure contract).
 				if result.WorkflowParityMissing > 0 {
-					message = fmt.Sprintf("workflow parity missing %d blocking script(s)", result.WorkflowParityMissing)
+					fmt.Fprintf(command.ErrOrStderr(), "workflow parity missing %d blocking script(s)\n", result.WorkflowParityMissing)
 				}
-				return &clicontract.ExitError{Code: result.ExitCode, Message: message}
+				return &clicontract.ExitError{Code: result.ExitCode}
 			}
 			return nil
 		},

--- a/cli/internal/commands/gate/module_test.go
+++ b/cli/internal/commands/gate/module_test.go
@@ -1,6 +1,7 @@
 package gate
 
 import (
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 	"context"
 	"testing"
 
@@ -17,7 +18,7 @@ func (fake *fakeChecks) Execute(context.Context, gateapp.CheckRequest) (gateapp.
 
 func TestGateExposesOnlyDeterministicCheck(t *testing.T) {
 	fake := &fakeChecks{}
-	command := NewModule(UseCases{Check: fake}, HostOptions{}).Command()
+	command := NewModule(UseCases{Check: fake}, clicontract.HostOptions{}).Command()
 	children := command.Commands()
 	if len(children) != 1 || children[0].Name() != "check" {
 		t.Fatalf("gate children = %v, want only check", children)

--- a/cli/internal/commands/goals/module.go
+++ b/cli/internal/commands/goals/module.go
@@ -17,22 +17,13 @@ import (
 // to cover the repository's own long-running race gate.
 const defaultGoalsTimeoutSeconds = 240
 
-// HostOptions carries the ambient CLI seams the goals commands read: the global
-// output mode, verbosity, and the project root (working directory) used to
-// resolve scenario evidence.
-type HostOptions struct {
-	OutputMode  func() string
-	Verbose     func() bool
-	ProjectRoot func() string
-}
-
 // Module owns Cobra presentation for the goals command family.
 type Module struct {
-	host HostOptions
+	host clicontract.HostOptions
 }
 
 // NewModule constructs the goals command module from its host seams.
-func NewModule(host HostOptions) Module {
+func NewModule(host clicontract.HostOptions) Module {
 	return Module{host: host}
 }
 

--- a/cli/internal/commands/goals/module.go
+++ b/cli/internal/commands/goals/module.go
@@ -5,6 +5,8 @@
 package goals
 
 import (
+	"bytes"
+	"io"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -45,6 +47,29 @@ func (Module) Contract() clicontract.CommandContract {
 }
 
 func (module Module) jsonOutput() bool { return module.host.OutputMode() == "json" }
+
+// renderStructured runs a goalsapp entry point and honors the negotiated output
+// mode. Under -o yaml it captures the app's JSON document (goalsapp emits one
+// JSON document to Stdout in JSON mode) and re-emits it as YAML, so `-o yaml` is
+// the same data yaml-marshaled instead of a silent human-table fallback. The
+// run error (which may carry a non-zero exit, e.g. a drift regression) is still
+// surfaced after the YAML is written, preserving json/yaml parity.
+func (module Module) renderStructured(cmd *cobra.Command, run func(w io.Writer, asJSON bool) error) error {
+	if module.host.OutputMode() == "yaml" {
+		var buf bytes.Buffer
+		runErr := run(&buf, true)
+		if buf.Len() > 0 {
+			if convErr := clicontract.JSONToYAML(cmd.OutOrStdout(), buf.Bytes()); convErr != nil {
+				if runErr != nil {
+					return runErr
+				}
+				return convErr
+			}
+		}
+		return runErr
+	}
+	return run(cmd.OutOrStdout(), module.jsonOutput())
+}
 
 // Command builds the `ao goals` command tree with constructor-scoped flag
 // state. No package-level command or flag variable is used.
@@ -109,19 +134,21 @@ func (module Module) newMeasureCommand(resolveFile func() string, timeout func()
 		Short:   "Run goal checks and produce a snapshot",
 		GroupID: "measurement",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return goalsapp.RunMeasureScenarios(goalsapp.MeasureScenariosOptions{
-				GoalsFile:     resolveFile(),
-				ProjectRoot:   module.host.ProjectRoot(),
-				GoalID:        goalID,
-				ExcludeTag:    excludeTag,
-				Directives:    directives,
-				Timeout:       timeout(),
-				TotalTimeout:  time.Duration(totalTimeout) * time.Second,
-				ScenariosOnly: scenariosOnly,
-				JSON:          module.jsonOutput(),
-				Verbose:       module.host.Verbose(),
-				Stdout:        cmd.OutOrStdout(),
-				Stderr:        cmd.ErrOrStderr(),
+			return module.renderStructured(cmd, func(w io.Writer, asJSON bool) error {
+				return goalsapp.RunMeasureScenarios(goalsapp.MeasureScenariosOptions{
+					GoalsFile:     resolveFile(),
+					ProjectRoot:   module.host.ProjectRoot(),
+					GoalID:        goalID,
+					ExcludeTag:    excludeTag,
+					Directives:    directives,
+					Timeout:       timeout(),
+					TotalTimeout:  time.Duration(totalTimeout) * time.Second,
+					ScenariosOnly: scenariosOnly,
+					JSON:          asJSON,
+					Verbose:       module.host.Verbose(),
+					Stdout:        w,
+					Stderr:        cmd.ErrOrStderr(),
+				})
 			})
 		},
 	}
@@ -140,10 +167,12 @@ func (module Module) newValidateCommand(resolveFile func() string) *cobra.Comman
 		Short:   "Validate GOALS.yaml structure and wiring",
 		GroupID: "measurement",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return goalsapp.RunValidate(goalsapp.ValidateOptions{
-				GoalsFile: resolveFile(),
-				JSON:      module.jsonOutput(),
-				Stdout:    cmd.OutOrStdout(),
+			return module.renderStructured(cmd, func(w io.Writer, asJSON bool) error {
+				return goalsapp.RunValidate(goalsapp.ValidateOptions{
+					GoalsFile: resolveFile(),
+					JSON:      asJSON,
+					Stdout:    w,
+				})
 			})
 		},
 	}
@@ -155,11 +184,14 @@ func (module Module) newDriftCommand(resolveFile func() string, timeout func() t
 		Aliases: []string{"d"},
 		Short:   "Compare snapshots for regressions",
 		GroupID: "analysis",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return goalsapp.RunDrift(goalsapp.DriftOptions{
-				GoalsFile: resolveFile(),
-				Timeout:   timeout(),
-				JSON:      module.jsonOutput(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return module.renderStructured(cmd, func(w io.Writer, asJSON bool) error {
+				return goalsapp.RunDrift(goalsapp.DriftOptions{
+					GoalsFile: resolveFile(),
+					Timeout:   timeout(),
+					JSON:      asJSON,
+					Stdout:    w,
+				})
 			})
 		},
 	}
@@ -175,11 +207,14 @@ func (module Module) newHistoryCommand() *cobra.Command {
 		Aliases: []string{"h"},
 		Short:   "Show goal measurement history",
 		GroupID: "analysis",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return goalsapp.RunHistory(goalsapp.HistoryOptions{
-				GoalID: goalID,
-				Since:  since,
-				JSON:   module.jsonOutput(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return module.renderStructured(cmd, func(w io.Writer, asJSON bool) error {
+				return goalsapp.RunHistory(goalsapp.HistoryOptions{
+					GoalID: goalID,
+					Since:  since,
+					JSON:   asJSON,
+					Stdout: w,
+				})
 			})
 		},
 	}
@@ -194,10 +229,16 @@ func (module Module) newExportCommand(resolveFile func() string, timeout func() 
 		Aliases: []string{"e"},
 		Short:   "Export latest snapshot as JSON (for CI)",
 		GroupID: "analysis",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return goalsapp.RunExport(goalsapp.ExportOptions{
-				GoalsFile: resolveFile(),
-				Timeout:   timeout(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// export is always structured (its default is JSON, not a human
+			// table); honor -o yaml by capturing the JSON snapshot and re-emitting
+			// it as YAML.
+			return module.renderStructured(cmd, func(w io.Writer, _ bool) error {
+				return goalsapp.RunExport(goalsapp.ExportOptions{
+					GoalsFile: resolveFile(),
+					Timeout:   timeout(),
+					Stdout:    w,
+				})
 			})
 		},
 	}
@@ -243,20 +284,24 @@ spec/scenarios/ then .agents/holdout/ (see docs/adr/ADR-0003).
   ao goals scenarios --lint                report link-graph defects`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if lint {
-				return goalsapp.RunLint(goalsapp.LintOptions{
-					GoalsFile: resolveFile(),
-					Strict:    strict,
-					JSON:      module.jsonOutput(),
-					Stdout:    cmd.OutOrStdout(),
+				return module.renderStructured(cmd, func(w io.Writer, asJSON bool) error {
+					return goalsapp.RunLint(goalsapp.LintOptions{
+						GoalsFile: resolveFile(),
+						Strict:    strict,
+						JSON:      asJSON,
+						Stdout:    w,
+					})
 				})
 			}
-			return goalsapp.RunScenarios(goalsapp.ScenariosOptions{
-				GoalsFile:    resolveFile(),
-				DirectiveNum: directive,
-				DirectiveID:  directiveID,
-				JSON:         module.jsonOutput(),
-				Stdout:       cmd.OutOrStdout(),
-				Stderr:       cmd.ErrOrStderr(),
+			return module.renderStructured(cmd, func(w io.Writer, asJSON bool) error {
+				return goalsapp.RunScenarios(goalsapp.ScenariosOptions{
+					GoalsFile:    resolveFile(),
+					DirectiveNum: directive,
+					DirectiveID:  directiveID,
+					JSON:         asJSON,
+					Stdout:       w,
+					Stderr:       cmd.ErrOrStderr(),
+				})
 			})
 		},
 	}

--- a/cli/internal/commands/goals/module_test.go
+++ b/cli/internal/commands/goals/module_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 
 	goalsapp "github.com/boshu2/agentops/cli/internal/goals"
 )
@@ -16,7 +17,7 @@ import (
 // newTestModule builds the goals module with a fixed output mode, constructing
 // the command tree directly instead of mutating any package-global state.
 func newTestModule(outputMode string) Module {
-	return NewModule(HostOptions{
+	return NewModule(clicontract.HostOptions{
 		OutputMode: func() string { return outputMode },
 		Verbose:    func() bool { return false },
 		ProjectRoot: func() string {

--- a/cli/internal/commands/init/module.go
+++ b/cli/internal/commands/init/module.go
@@ -11,19 +11,13 @@ import (
 	"github.com/boshu2/agentops/cli/internal/initapp"
 )
 
-// HostOptions carries the ambient CLI seams the init command reads. The dry-run
-// selection comes from the global --dry-run flag.
-type HostOptions struct {
-	DryRun func() bool
-}
-
 // Module owns Cobra presentation for the init command.
 type Module struct {
-	host HostOptions
+	host clicontract.HostOptions
 }
 
 // NewModule constructs the init command module from its host seams.
-func NewModule(host HostOptions) Module {
+func NewModule(host clicontract.HostOptions) Module {
 	return Module{host: host}
 }
 

--- a/cli/internal/commands/init/module_test.go
+++ b/cli/internal/commands/init/module_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newTestModule(dryRun bool) Module {
-	return NewModule(HostOptions{DryRun: func() bool { return dryRun }})
+	return NewModule(clicontract.HostOptions{DryRun: func() bool { return dryRun }})
 }
 
 func TestModule_Contract(t *testing.T) {

--- a/cli/internal/commands/provenance/module.go
+++ b/cli/internal/commands/provenance/module.go
@@ -89,6 +89,32 @@ func (m *Module) ledgerStore() *provenancegraph.Store {
 	return provenancegraph.NewStore(m.host.LedgerPath())
 }
 
+// outputMode returns the negotiated global output mode, or "" when unset.
+func (m *Module) outputMode() string {
+	if m.host.OutputMode == nil {
+		return ""
+	}
+	return m.host.OutputMode()
+}
+
+// emitStructured writes value as pretty JSON or YAML for a single-document read
+// path, reporting whether it handled the output. The local --json flag and the
+// global -o json both select JSON (byte-identical to the prior hand-rolled
+// encoder); -o yaml selects YAML with keys mirroring the json tags. A non-
+// structured mode returns handled=false so the caller renders its human view —
+// there is no silent yaml→table fallback for a command that implements json.
+func (m *Module) emitStructured(out io.Writer, localJSON bool, value any) (handled bool, err error) {
+	if m.outputMode() == "yaml" {
+		return true, clicontract.WriteYAML(out, value)
+	}
+	if localJSON || m.outputMode() == "json" {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return true, enc.Encode(value)
+	}
+	return false, nil
+}
+
 // Command builds the `ao provenance` command tree.
 func (m *Module) Command() *cobra.Command {
 	root := &cobra.Command{
@@ -168,10 +194,8 @@ func (m *Module) runAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	out := cmd.OutOrStdout()
-	if m.addJSON {
-		enc := json.NewEncoder(out)
-		enc.SetIndent("", "  ")
-		return enc.Encode(res.Edge)
+	if handled, err := m.emitStructured(out, m.addJSON, res.Edge); handled || err != nil {
+		return err
 	}
 	if res.Skipped {
 		fmt.Fprintf(out, "edge already present (idempotent no-op): %s --%s--> %s\n",
@@ -223,10 +247,8 @@ func (m *Module) runList(cmd *cobra.Command, _ []string) error {
 	}
 
 	out := cmd.OutOrStdout()
-	if m.listJSON {
-		enc := json.NewEncoder(out)
-		enc.SetIndent("", "  ")
-		return enc.Encode(filtered)
+	if handled, err := m.emitStructured(out, m.listJSON, filtered); handled || err != nil {
+		return err
 	}
 	if len(filtered) == 0 {
 		fmt.Fprintln(out, "no provenance edges")
@@ -297,14 +319,15 @@ func (m *Module) runExport(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	if m.exportJSON {
-		enc := json.NewEncoder(out)
-		enc.SetIndent("", "  ")
-		// Always emit a concrete (possibly empty) array, never null.
+	// Always emit a concrete (possibly empty) array, never null, for the
+	// single-document structured forms.
+	if m.exportJSON || m.outputMode() == "json" || m.outputMode() == "yaml" {
 		if chain == nil {
 			chain = []provenancegraph.Edge{}
 		}
-		return enc.Encode(chain)
+		if handled, err := m.emitStructured(out, m.exportJSON, chain); handled || err != nil {
+			return err
+		}
 	}
 
 	// Default: deterministic JSONL — one compact line per edge, fixed field
@@ -393,10 +416,8 @@ func (m *Module) runShow(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if m.showJSON {
-		enc := json.NewEncoder(cmd.OutOrStdout())
-		enc.SetIndent("", "  ")
-		return enc.Encode(report)
+	if handled, err := m.emitStructured(cmd.OutOrStdout(), m.showJSON, report); handled || err != nil {
+		return err
 	}
 	renderShowReport(cmd.OutOrStdout(), report)
 	return nil
@@ -445,10 +466,8 @@ func (m *Module) runPosition(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("read provenance ledger: %w", err)
 	}
 	report := buildPositionReport(edges)
-	if m.positionJSON {
-		enc := json.NewEncoder(cmd.OutOrStdout())
-		enc.SetIndent("", "  ")
-		return enc.Encode(report)
+	if handled, err := m.emitStructured(cmd.OutOrStdout(), m.positionJSON, report); handled || err != nil {
+		return err
 	}
 	if report.Latest == nil {
 		fmt.Fprintln(cmd.OutOrStdout(), "provenance ledger is empty")
@@ -577,17 +596,17 @@ func (m *Module) runVerify(cmd *cobra.Command, _ []string) error {
 	}
 
 	out := cmd.OutOrStdout()
-	if m.verifyJSON {
-		enc := json.NewEncoder(out)
-		enc.SetIndent("", "  ")
-		if encErr := enc.Encode(res); encErr != nil {
-			return encErr
+	handled, err := m.emitStructured(out, m.verifyJSON, res)
+	if err != nil {
+		return err
+	}
+	if !handled {
+		if res.Pass {
+			fmt.Fprintf(out, "OK: provenance ledger chain intact (%d record(s))\n", res.RecordCount)
+		} else {
+			fmt.Fprintf(out, "BROKEN: provenance ledger chain breaks at line %d: %s\n",
+				res.FirstBrokenLine, res.Message)
 		}
-	} else if res.Pass {
-		fmt.Fprintf(out, "OK: provenance ledger chain intact (%d record(s))\n", res.RecordCount)
-	} else {
-		fmt.Fprintf(out, "BROKEN: provenance ledger chain breaks at line %d: %s\n",
-			res.FirstBrokenLine, res.Message)
 	}
 
 	if !res.Pass {

--- a/cli/internal/commands/provenance/module.go
+++ b/cli/internal/commands/provenance/module.go
@@ -19,19 +19,9 @@ import (
 	"github.com/boshu2/agentops/cli/internal/provenancegraph"
 )
 
-// HostOptions carries the ambient CLI seams the provenance commands read. The
-// ledger path and clock are host effects injected here so the module stays
-// free of direct filesystem and clock access.
-type HostOptions struct {
-	// LedgerPath resolves docs/provenance/ledger.jsonl for the current tree.
-	LedgerPath func() string
-	// Now supplies the wall clock for the default add timestamp.
-	Now func() time.Time
-}
-
 // Module owns Cobra presentation for the provenance command family.
 type Module struct {
-	host HostOptions
+	host clicontract.HostOptions
 
 	// add
 	addFromType  string
@@ -73,7 +63,7 @@ type Module struct {
 }
 
 // NewModule constructs the provenance command module from its host seams.
-func NewModule(host HostOptions) *Module {
+func NewModule(host clicontract.HostOptions) *Module {
 	return &Module{host: host}
 }
 

--- a/cli/internal/commands/provenance/module_test.go
+++ b/cli/internal/commands/provenance/module_test.go
@@ -2,6 +2,7 @@
 package provenance
 
 import (
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 	"bytes"
 	"encoding/json"
 	"os"
@@ -26,7 +27,7 @@ func testLedger(t *testing.T) string {
 // newTestModule builds a provenance Module whose ledger-path and clock seams are
 // pinned for the test, standing in for the package-main host wiring.
 func newTestModule(ledger string) *Module {
-	return NewModule(HostOptions{
+	return NewModule(clicontract.HostOptions{
 		LedgerPath: func() string { return ledger },
 		Now:        func() time.Time { return fixedNow },
 	})

--- a/cli/internal/commands/session/module.go
+++ b/cli/internal/commands/session/module.go
@@ -7,6 +7,9 @@
 package session
 
 import (
+	"bytes"
+	"io"
+
 	"github.com/spf13/cobra"
 
 	"github.com/boshu2/agentops/cli/internal/clicontract"
@@ -14,13 +17,24 @@ import (
 )
 
 // Module owns Cobra presentation for the session command family.
-type Module struct{}
+type Module struct {
+	host clicontract.HostOptions
+}
 
-// NewModule constructs the session command module. The session evidence
-// commands read no ambient CLI seams; the working directory is resolved inside
-// internal/sessionapp.
-func NewModule() Module {
-	return Module{}
+// NewModule constructs the session command module. The only ambient seam it
+// reads is the negotiated output mode (so the global -o json/-o yaml flags emit
+// structured output, not a silent human-table fallback); the working directory
+// is resolved inside internal/sessionapp.
+func NewModule(host clicontract.HostOptions) Module {
+	return Module{host: host}
+}
+
+// outputMode returns the negotiated global output mode, or "" when unset.
+func (m Module) outputMode() string {
+	if m.host.OutputMode == nil {
+		return ""
+	}
+	return m.host.OutputMode()
 }
 
 // Contract declares the session family's real behavior for the family
@@ -46,20 +60,36 @@ func (Module) Contract() clicontract.CommandContract {
 // Command builds the `ao session` command with its bootstrap and rehydrate
 // subcommands. The RunE closures delegate entirely to internal/sessionapp so
 // this module performs no direct filesystem effect.
-func (Module) Command() *cobra.Command {
+func (m Module) Command() *cobra.Command {
 	root := &cobra.Command{
 		Use:     "session",
 		Short:   "Inspect or export session evidence",
 		GroupID: "workflow",
 	}
-	root.AddCommand(bootstrapCommand())
-	root.AddCommand(rehydrateCommand())
+	root.AddCommand(m.bootstrapCommand())
+	root.AddCommand(m.rehydrateCommand())
 	return root
+}
+
+// emitStructured runs a sessionapp entry point and honors the negotiated output
+// mode. The local --json flag and global -o json both take the JSON path
+// directly; -o yaml captures the app's single JSON document and re-emits it as
+// YAML (the app emits exactly one JSON document in JSON mode), so `-o yaml` is
+// the same data yaml-marshaled rather than a silent human-table fallback.
+func (m Module) emitStructured(cmd *cobra.Command, localJSON bool, run func(w io.Writer, asJSON bool) error) error {
+	if m.outputMode() == "yaml" {
+		var buf bytes.Buffer
+		if err := run(&buf, true); err != nil {
+			return err
+		}
+		return clicontract.JSONToYAML(cmd.OutOrStdout(), buf.Bytes())
+	}
+	return run(cmd.OutOrStdout(), localJSON || m.outputMode() == "json")
 }
 
 // bootstrapCommand builds `ao session bootstrap` with a constructor-scoped
 // --json flag.
-func bootstrapCommand() *cobra.Command {
+func (m Module) bootstrapCommand() *cobra.Command {
 	var jsonOut bool
 	command := &cobra.Command{
 		Use:   "bootstrap",
@@ -68,9 +98,8 @@ func bootstrapCommand() *cobra.Command {
 trackers, selecting work, inspecting queues, or installing hooks.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return sessionapp.Bootstrap(sessionapp.BootstrapOptions{
-				JSON:   jsonOut,
-				Stdout: cmd.OutOrStdout(),
+			return m.emitStructured(cmd, jsonOut, func(w io.Writer, asJSON bool) error {
+				return sessionapp.Bootstrap(sessionapp.BootstrapOptions{JSON: asJSON, Stdout: w})
 			})
 		},
 	}
@@ -80,7 +109,7 @@ trackers, selecting work, inspecting queues, or installing hooks.`,
 
 // rehydrateCommand builds `ao session rehydrate` with a constructor-scoped
 // --json flag.
-func rehydrateCommand() *cobra.Command {
+func (m Module) rehydrateCommand() *cobra.Command {
 	var jsonOut bool
 	command := &cobra.Command{
 		Use:   "rehydrate",
@@ -88,10 +117,8 @@ func rehydrateCommand() *cobra.Command {
 		Long:  "Read a handoff without consuming it, claiming work, or choosing a next action.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return sessionapp.Rehydrate(sessionapp.RehydrateOptions{
-				JSON:   jsonOut,
-				Stdout: cmd.OutOrStdout(),
-				Stderr: cmd.ErrOrStderr(),
+			return m.emitStructured(cmd, jsonOut, func(w io.Writer, asJSON bool) error {
+				return sessionapp.Rehydrate(sessionapp.RehydrateOptions{JSON: asJSON, Stdout: w, Stderr: cmd.ErrOrStderr()})
 			})
 		},
 	}

--- a/cli/internal/commands/session/module_test.go
+++ b/cli/internal/commands/session/module_test.go
@@ -18,7 +18,7 @@ import (
 // module directly instead of mutating any package-global command state.
 func subcommand(t *testing.T, name string) (root, child *cobra.Command) {
 	t.Helper()
-	root = NewModule().Command()
+	root = NewModule(clicontract.HostOptions{}).Command()
 	for _, candidate := range root.Commands() {
 		if candidate.Name() == name {
 			return root, candidate
@@ -29,7 +29,7 @@ func subcommand(t *testing.T, name string) (root, child *cobra.Command) {
 }
 
 func TestModule_Contract(t *testing.T) {
-	contract := NewModule().Contract()
+	contract := NewModule(clicontract.HostOptions{}).Contract()
 	if contract.ID != "ao.session" {
 		t.Fatalf("contract ID = %q, want ao.session", contract.ID)
 	}
@@ -42,7 +42,7 @@ func TestModule_Contract(t *testing.T) {
 }
 
 func TestModule_CommandAttributes(t *testing.T) {
-	root := NewModule().Command()
+	root := NewModule(clicontract.HostOptions{}).Command()
 	if root.Use != "session" {
 		t.Fatalf("Use = %q, want session", root.Use)
 	}

--- a/cli/internal/commands/skills/find_test.go
+++ b/cli/internal/commands/skills/find_test.go
@@ -2,6 +2,7 @@
 package skills
 
 import (
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -84,7 +85,7 @@ func TestSkillsFind_InvalidLimitNamesCorrection(t *testing.T) {
 }
 
 func TestSkillsFind_RegisteredUnderSkills(t *testing.T) {
-	root := NewModule(HostOptions{DryRun: func() bool { return false }}).Command()
+	root := NewModule(clicontract.HostOptions{DryRun: func() bool { return false }}).Command()
 	found := false
 	for _, c := range root.Commands() {
 		if c.Name() == "find" {

--- a/cli/internal/commands/skills/help_test.go
+++ b/cli/internal/commands/skills/help_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 )
 
 // linkLong / unlinkLong fetch the built command's Long help so the help
 // contracts are asserted against the real module tree.
 func subcommandLong(t *testing.T, name string) string {
 	t.Helper()
-	root := NewModule(HostOptions{DryRun: func() bool { return false }}).Command()
+	root := NewModule(clicontract.HostOptions{DryRun: func() bool { return false }}).Command()
 	var found *cobra.Command
 	for _, c := range root.Commands() {
 		if c.Name() == name {

--- a/cli/internal/commands/skills/module.go
+++ b/cli/internal/commands/skills/module.go
@@ -7,6 +7,7 @@ package skills
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/spf13/cobra"
 
@@ -59,6 +60,32 @@ type Module struct {
 // NewModule constructs the skills command module from its host seams.
 func NewModule(host clicontract.HostOptions) *Module {
 	return &Module{host: host}
+}
+
+// outputMode returns the negotiated global output mode, or "" when unset.
+func (m *Module) outputMode() string {
+	if m.host.OutputMode == nil {
+		return ""
+	}
+	return m.host.OutputMode()
+}
+
+// emitStructured writes value as pretty JSON or YAML per the negotiated output,
+// reporting whether it handled the output. The local --json flag and the global
+// -o json both select JSON (byte-identical to the prior hand-rolled encoder);
+// -o yaml selects YAML with keys mirroring the json tags. A non-structured mode
+// returns handled=false so the caller renders its human view — there is no
+// silent yaml→table fallback for a subcommand that implements json.
+func (m *Module) emitStructured(out io.Writer, localJSON bool, value any) (handled bool, err error) {
+	if m.outputMode() == "yaml" {
+		return true, clicontract.WriteYAML(out, value)
+	}
+	if localJSON || m.outputMode() == "json" {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return true, enc.Encode(value)
+	}
+	return false, nil
 }
 
 // Contract declares skills's real behavior for the family architecture gate.
@@ -136,13 +163,11 @@ func (m *Module) runCheck(cmd *cobra.Command, _ []string) error {
 	}
 
 	out := cmd.OutOrStdout()
-	if m.checkJSON {
-		enc := json.NewEncoder(out)
-		enc.SetIndent("", "  ")
-		if err := enc.Encode(report); err != nil {
-			return err
-		}
-	} else {
+	handled, err := m.emitStructured(out, m.checkJSON, report)
+	if err != nil {
+		return err
+	}
+	if !handled {
 		fmt.Fprintf(out, "Skills audit (%s)\n", report.Generated)
 		fmt.Fprintf(out, "================\n")
 		fmt.Fprintf(out, "Skills audited: %d\n", len(report.Skills))
@@ -208,13 +233,11 @@ func (m *Module) runResolve(cmd *cobra.Command, _ []string) error {
 	}
 
 	out := cmd.OutOrStdout()
-	if m.resolveJSON {
-		enc := json.NewEncoder(out)
-		enc.SetIndent("", "  ")
-		if err := enc.Encode(report); err != nil {
-			return err
-		}
-	} else {
+	handled, err := m.emitStructured(out, m.resolveJSON, report)
+	if err != nil {
+		return err
+	}
+	if !handled {
 		fmt.Fprintf(out, "Skills MECE resolve (%s)\n", report.Generated)
 		fmt.Fprintf(out, "===================\n")
 		fmt.Fprintf(out, "Skills:               %d\n", report.SkillsCount)
@@ -292,9 +315,12 @@ func (m *Module) runFind(cmd *cobra.Command, args []string) error {
 
 	ranked := skills.Score(query, metas)
 	top := capResults(ranked, m.findLimit)
+	if top == nil {
+		top = []skills.Match{}
+	}
 
-	if m.findJSON {
-		return renderFindJSON(cmd, top)
+	if handled, err := m.emitStructured(cmd.OutOrStdout(), m.findJSON, top); handled || err != nil {
+		return err
 	}
 	return renderFindText(cmd, query, top)
 }
@@ -352,10 +378,8 @@ func (m *Module) runList(cmd *cobra.Command, _ []string) error {
 	matches := skills.List(cat.Skills, filter)
 
 	out := cmd.OutOrStdout()
-	if m.listJSON {
-		enc := json.NewEncoder(out)
-		enc.SetIndent("", "  ")
-		return enc.Encode(matches)
+	if handled, err := m.emitStructured(out, m.listJSON, matches); handled || err != nil {
+		return err
 	}
 	for _, e := range matches {
 		fmt.Fprintf(out, "%-28s %-16s %s\n", e.Name, e.HexagonalRole, e.Description)
@@ -389,7 +413,7 @@ func (m *Module) runConsumers(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	got := skills.Consumers(cat.Skills, args[0])
-	return renderNameList(cmd, got, m.consumersJSON,
+	return m.renderNameList(cmd, got, m.consumersJSON,
 		fmt.Sprintf("no skills consume %q", args[0]))
 }
 
@@ -416,7 +440,7 @@ func (m *Module) runProducers(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	got := skills.Producers(cat.Skills, args[0])
-	return renderNameList(cmd, got, m.producersJSON,
+	return m.renderNameList(cmd, got, m.producersJSON,
 		fmt.Sprintf("no skills produce %q", args[0]))
 }
 
@@ -638,17 +662,6 @@ func capResults(matches []skills.Match, limit int) []skills.Match {
 	return matches
 }
 
-// renderFindJSON writes the matches as a JSON array on stdout (data only;
-// diagnostics, if any, go to stderr).
-func renderFindJSON(cmd *cobra.Command, top []skills.Match) error {
-	if top == nil {
-		top = []skills.Match{}
-	}
-	enc := json.NewEncoder(cmd.OutOrStdout())
-	enc.SetIndent("", "  ")
-	return enc.Encode(top)
-}
-
 // renderFindText prints the positive-score matches as a ranked list on stdout.
 // When nothing scores above zero it reports gracefully on stderr and exits 0 —
 // an unmatched intent is not an error.
@@ -669,18 +682,16 @@ func renderFindText(cmd *cobra.Command, query string, top []skills.Match) error 
 	return nil
 }
 
-// renderNameList prints a sorted slice of skill names as JSON or one-per-line
-// text, with a stderr note when the list is empty (an empty result is not an
-// error — the query simply matched nothing).
-func renderNameList(cmd *cobra.Command, names []string, asJSON bool, emptyNote string) error {
+// renderNameList prints a sorted slice of skill names as JSON/YAML or
+// one-per-line text, with a stderr note when the list is empty (an empty result
+// is not an error — the query simply matched nothing).
+func (m *Module) renderNameList(cmd *cobra.Command, names []string, asJSON bool, emptyNote string) error {
 	out := cmd.OutOrStdout()
-	if asJSON {
-		if names == nil {
-			names = []string{}
-		}
-		enc := json.NewEncoder(out)
-		enc.SetIndent("", "  ")
-		return enc.Encode(names)
+	if names == nil {
+		names = []string{}
+	}
+	if handled, err := m.emitStructured(out, asJSON, names); handled || err != nil {
+		return err
 	}
 	for _, n := range names {
 		fmt.Fprintln(out, n)

--- a/cli/internal/commands/skills/module.go
+++ b/cli/internal/commands/skills/module.go
@@ -17,16 +17,9 @@ import (
 	"github.com/boshu2/agentops/cli/internal/skillsresolve"
 )
 
-// HostOptions carries the ambient CLI seams the skills commands read. The
-// global dry-run flag drives link/unlink; it is injected so the module stays
-// free of direct host access.
-type HostOptions struct {
-	DryRun func() bool
-}
-
 // Module owns Cobra presentation for the skills command family.
 type Module struct {
-	host HostOptions
+	host clicontract.HostOptions
 
 	// check
 	checkJSON   bool
@@ -64,7 +57,7 @@ type Module struct {
 }
 
 // NewModule constructs the skills command module from its host seams.
-func NewModule(host HostOptions) *Module {
+func NewModule(host clicontract.HostOptions) *Module {
 	return &Module{host: host}
 }
 

--- a/cli/internal/commands/skills/module_test.go
+++ b/cli/internal/commands/skills/module_test.go
@@ -2,6 +2,7 @@
 package skills
 
 import (
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 	"bytes"
 	"encoding/json"
 	"os"
@@ -15,7 +16,7 @@ import (
 // the former cmd/ao command-capture harness for this carved family.
 func execSkills(t *testing.T, args ...string) (stdout, stderr string, err error) {
 	t.Helper()
-	root := NewModule(HostOptions{DryRun: func() bool { return false }}).Command()
+	root := NewModule(clicontract.HostOptions{DryRun: func() bool { return false }}).Command()
 	var out, errb bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&errb)
@@ -40,7 +41,7 @@ func withCwd(t *testing.T, dir string, fn func()) {
 // TestSkillsCommandTreeRegistered asserts the module builds the full subcommand
 // tree with the documented flags.
 func TestSkillsCommandTreeRegistered(t *testing.T) {
-	root := NewModule(HostOptions{DryRun: func() bool { return false }}).Command()
+	root := NewModule(clicontract.HostOptions{DryRun: func() bool { return false }}).Command()
 	if root.Name() != "skills" {
 		t.Fatalf("root command = %q, want skills", root.Name())
 	}

--- a/cli/internal/commands/status/module.go
+++ b/cli/internal/commands/status/module.go
@@ -4,6 +4,8 @@
 package status
 
 import (
+	"bytes"
+
 	"github.com/spf13/cobra"
 
 	"github.com/boshu2/agentops/cli/internal/clicontract"
@@ -55,6 +57,16 @@ Examples:
   ao status --json`,
 		GroupID: "core",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if module.host.OutputMode() == "yaml" {
+				// statusapp emits exactly one JSON document to Stdout in JSON
+				// mode; capture it and re-emit as YAML so -o yaml is the same
+				// data yaml-marshaled rather than a silent human-table fallback.
+				var buf bytes.Buffer
+				if err := statusapp.Run(statusapp.RunOptions{JSON: true, Stdout: &buf}); err != nil {
+					return err
+				}
+				return clicontract.JSONToYAML(cmd.OutOrStdout(), buf.Bytes())
+			}
 			return statusapp.Run(statusapp.RunOptions{
 				JSON:   module.host.OutputMode() == "json",
 				Stdout: cmd.OutOrStdout(),

--- a/cli/internal/commands/status/module.go
+++ b/cli/internal/commands/status/module.go
@@ -10,20 +10,13 @@ import (
 	"github.com/boshu2/agentops/cli/internal/statusapp"
 )
 
-// HostOptions carries the ambient CLI seams the status command reads. Output
-// mode comes from the global -o/--output flag rather than a local flag so
-// status honors the same output selection as the rest of the CLI.
-type HostOptions struct {
-	OutputMode func() string
-}
-
 // Module owns Cobra presentation for the status command family.
 type Module struct {
-	host HostOptions
+	host clicontract.HostOptions
 }
 
 // NewModule constructs the status command module from its host seams.
-func NewModule(host HostOptions) Module {
+func NewModule(host clicontract.HostOptions) Module {
 	return Module{host: host}
 }
 

--- a/cli/internal/commands/status/module_test.go
+++ b/cli/internal/commands/status/module_test.go
@@ -16,7 +16,7 @@ import (
 // newTestModule builds the status module with a fixed output mode, constructing
 // the command directly instead of mutating any package-global command state.
 func newTestModule(outputMode string) Module {
-	return NewModule(HostOptions{OutputMode: func() string { return outputMode }})
+	return NewModule(clicontract.HostOptions{OutputMode: func() string { return outputMode }})
 }
 
 func TestModule_Contract(t *testing.T) {

--- a/cli/internal/commands/version/module.go
+++ b/cli/internal/commands/version/module.go
@@ -63,6 +63,9 @@ func (m Module) Command() *cobra.Command {
 		GroupID: "core",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			info := currentVersionInfo(m.host.Version())
+			if m.host.OutputMode() == "yaml" {
+				return clicontract.WriteYAML(cmd.OutOrStdout(), info)
+			}
 			if m.host.OutputMode() == "json" {
 				enc := json.NewEncoder(cmd.OutOrStdout())
 				enc.SetIndent("", "  ")

--- a/cli/internal/commands/version/module.go
+++ b/cli/internal/commands/version/module.go
@@ -25,21 +25,13 @@ type versionInfo struct {
 	Platform  string `json:"platform"`
 }
 
-// HostOptions carries the ambient CLI seams the version command reads. The
-// build-time version string and the global -o/--output mode are injected here
-// so the module reads no package-global build metadata directly.
-type HostOptions struct {
-	Version    func() string
-	OutputMode func() string
-}
-
 // Module owns Cobra presentation for the version command.
 type Module struct {
-	host HostOptions
+	host clicontract.HostOptions
 }
 
 // NewModule constructs the version command module from its host seams.
-func NewModule(host HostOptions) Module {
+func NewModule(host clicontract.HostOptions) Module {
 	return Module{host: host}
 }
 

--- a/cli/internal/commands/version/module_test.go
+++ b/cli/internal/commands/version/module_test.go
@@ -13,7 +13,7 @@ import (
 const testVersion = "9.9.9-test"
 
 func newTestModule(outputMode string) Module {
-	return NewModule(HostOptions{
+	return NewModule(clicontract.HostOptions{
 		Version:    func() string { return testVersion },
 		OutputMode: func() string { return outputMode },
 	})

--- a/cli/internal/flywheelapp/status.go
+++ b/cli/internal/flywheelapp/status.go
@@ -12,8 +12,7 @@ import (
 	"io"
 	"os"
 
-	"gopkg.in/yaml.v3"
-
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 	"github.com/boshu2/agentops/cli/internal/types"
 )
 
@@ -53,6 +52,8 @@ func Compare(w io.Writer, outputMode string, days int, shadowNamespace string, v
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
 		return enc.Encode(comp)
+	case "yaml":
+		return clicontract.WriteYAML(w, comp)
 	default:
 		printNamespaceComparison(w, comp)
 	}
@@ -101,46 +102,35 @@ func Status(w io.Writer, outputMode string, days int, statusNamespace string, ve
 	// Always compute golden signals — they provide the honest health assessment.
 	populateGoldenSignals(cwd, days, metrics)
 
+	// Build the structured payload once so -o json and -o yaml are the same data
+	// with the same keys — previously the yaml branch omitted "metrics" and, via
+	// a direct yaml.Marshal, lowercased the nested struct field names, so yaml
+	// and json disagreed. WriteYAML round-trips through the json tags, keeping
+	// yaml a truthful sibling of json.
+	payload := map[string]any{
+		"metric_namespace":            metricNamespace,
+		"status":                      metrics.HealthStatus(),
+		"delta":                       metrics.Delta,
+		"sigma":                       metrics.Sigma,
+		"rho":                         metrics.Rho,
+		"sigma_rho":                   metrics.SigmaRho,
+		"velocity":                    metrics.Velocity,
+		"compounding":                 metrics.HealthCompounding(),
+		"escape_velocity_status":      metrics.EscapeVelocityStatus(),
+		"escape_velocity_compounding": metrics.AboveEscapeVelocity,
+		"scorecard":                   metrics.StigmergicScorecard,
+		"golden_signals":              metrics.GoldenSignals,
+		"metrics":                     metrics,
+	}
+
 	switch outputMode {
 	case "json":
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
-		return enc.Encode(map[string]any{
-			"metric_namespace":            metricNamespace,
-			"status":                      metrics.HealthStatus(),
-			"delta":                       metrics.Delta,
-			"sigma":                       metrics.Sigma,
-			"rho":                         metrics.Rho,
-			"sigma_rho":                   metrics.SigmaRho,
-			"velocity":                    metrics.Velocity,
-			"compounding":                 metrics.HealthCompounding(),
-			"escape_velocity_status":      metrics.EscapeVelocityStatus(),
-			"escape_velocity_compounding": metrics.AboveEscapeVelocity,
-			"scorecard":                   metrics.StigmergicScorecard,
-			"golden_signals":              metrics.GoldenSignals,
-			"metrics":                     metrics,
-		})
+		return enc.Encode(payload)
 
 	case "yaml":
-		enc := yaml.NewEncoder(w)
-		if err := enc.Encode(map[string]any{
-			"metric_namespace":            metricNamespace,
-			"status":                      metrics.HealthStatus(),
-			"delta":                       metrics.Delta,
-			"sigma":                       metrics.Sigma,
-			"rho":                         metrics.Rho,
-			"sigma_rho":                   metrics.SigmaRho,
-			"velocity":                    metrics.Velocity,
-			"compounding":                 metrics.HealthCompounding(),
-			"escape_velocity_status":      metrics.EscapeVelocityStatus(),
-			"escape_velocity_compounding": metrics.AboveEscapeVelocity,
-			"scorecard":                   metrics.StigmergicScorecard,
-			"golden_signals":              metrics.GoldenSignals,
-		}); err != nil {
-			_ = enc.Close()
-			return err
-		}
-		return enc.Close()
+		return clicontract.WriteYAML(w, payload)
 
 	default:
 		printFlywheelStatus(w, metrics, days)

--- a/docs/architecture/go-cli.md
+++ b/docs/architecture/go-cli.md
@@ -28,15 +28,33 @@ no hidden build-tag variant, and no parallel root builder. (The experimental
 `internal/cliapp.BuildRoot` composition path was deleted in the post-Cathedral
 Cut cleanup; `internal/clicontract` remains the contract carrier.)
 
-Newer command families are **modules**: presentation lives in
-`cli/internal/commands/<family>` (returns a fresh `*cobra.Command` plus a
-`clicontract.CommandContract`), application services live in a focused package
-(for example `cli/internal/gate`), and effects live behind small
-consumer-owned ports implemented in `cli/internal/adapters/<family>`.
-`cmd/ao/<family>_composition.go` (or `<family>_module.go`) is the thin glue
-that wires module → service → adapters onto `rootCmd`. `config`, `doctor`,
-`gate`, `capabilities`, and `eval` follow this shape; older spine commands
-still keep presentation in `cmd/ao` and are extracted opportunistically.
+Every command family is a **module**: presentation lives in
+`cli/internal/commands/<family>` (each returns a fresh `*cobra.Command` plus a
+`clicontract.CommandContract`), and `cmd/ao/<family>_composition.go` (or
+`<family>_module.go`) is the thin glue that wires it onto `rootCmd`. A module
+receives all of its host wiring — output mode, verbosity, dry-run, project root,
+clock, version string, and flag-error enrichment — through the single shared
+`clicontract.HostOptions` seam. No family declares its own seam struct or passes
+host funcs positionally, and no module reaches for a direct host effect (`os`,
+`os/exec`, `time.Now`); the drift guards in
+`cmd/ao/carveout_regression_test.go` pin all of this.
+
+The tree is **intentionally two-tiered**, and both tiers are production shapes —
+not an unfinished carve-out:
+
+- **Five families run the full hexagonal stack, `module → service → adapters`.**
+  `capabilities`, `config`, `doctor`, `eval`, and `gate` each own a focused
+  application-service package (for example `cli/internal/gate`) and push effects
+  behind small consumer-owned ports implemented in
+  `cli/internal/adapters/<family>`. These are the families with real domain
+  logic or external effects worth isolating.
+- **The other twelve families run `module → app-seam`.** `demo`, `flywheel`,
+  `goals`, `init`, `provenance`, `quick-start`, `redact`, `robot-docs`,
+  `session`, `skills`, `status`, and `version` call a focused app package
+  directly through the host seams and carry no dedicated adapters layer, because
+  they have no effect boundary that a port would earn. Adding an adapters tier to
+  an app-seam family is a deliberate non-goal until that family grows an effect
+  worth isolating.
 
 ## Published surface
 


### PR DESCRIPTION
Eval-remediation epic age-6j9ee, two stacked beads (B2 yaml builds on B1 shared output helper). B1: one shared clicontract.HostOptions across all modules (4 divergent seams unified), shared WriteJSON+ExitError (3+2 copies deleted), config/doctor singletons→constructors, gate failure stderr silenced (labeled ExitError for genuine errors), 3 drift guards (shared-seam-type, no-direct-effect-imports, no-service-singletons) + seam-coverage guard w/ reasoned exemptions (demo/quickstart/redact/robotdocs pure), honest two-tier doctrine doc. B2: -o yaml real everywhere -o json is (shared WriteYAML JSON-round-trip, no new dep), zero silent table fallbacks, flywheel compare/status yaml fixed, 16-command probe test. capabilities json byte-identical. Sol fresh-context: B1 ACCEPT + B2 ACCEPT (B1 after remediation of gate-stderr + 5 seam holdouts). Full gate 67/67; uncapped lint 0; shuffle green. FF-push. Known pre-existing PR-CI red: age-sqjyl.