### PR TITLE
B3: eval-adapter security — redactor egress, symlink-closure deny, crash-safe 0600 ledger (age-6j9ee.3)

### DIFF
--- a/cli/internal/adapters/eval/runtime.go
+++ b/cli/internal/adapters/eval/runtime.go
@@ -16,6 +16,7 @@ import (
 	"github.com/boshu2/agentops/cli/internal/goals"
 	"github.com/boshu2/agentops/cli/internal/scenario"
 	"github.com/boshu2/agentops/cli/internal/scenarioresults"
+	"github.com/boshu2/agentops/cli/internal/storage"
 )
 
 type Runtime struct{}
@@ -207,14 +208,18 @@ func (Runtime) SaveBurnLedger(path string, ledger evalsubstrate.HoldoutBurnLedge
 	if err != nil {
 		return fmt.Errorf("encode burn ledger: %w", err)
 	}
-	temporary := path + ".tmp"
-	// 0o600: holdout burn state is load-bearing for holdout secrecy; a world/group-
-	// readable ledger leaks which holdout scenarios have been spent (age-6j9ee.3).
-	if err := os.WriteFile(temporary, data, 0o600); err != nil {
-		return fmt.Errorf("write burn ledger temp: %w", err)
-	}
-	if err := os.Rename(temporary, path); err != nil {
-		return fmt.Errorf("commit burn ledger: %w", err)
+	// 0o600: holdout burn state is load-bearing for holdout secrecy; a world- or
+	// group-readable ledger leaks which holdout scenarios have been spent
+	// (age-6j9ee.3). storage.AtomicWriteFile writes through a fresh, unpredictably
+	// named temp file (os.CreateTemp, 0o600), chmods it to 0o600, fsyncs, then
+	// renames over the target and removes the temp on any error. So the final
+	// ledger mode is 0o600 regardless of pre-existing state: a stale world-
+	// readable "<path>.tmp" left by a crashed run can no longer bleed its mode
+	// into the committed ledger (the old fixed-".tmp" scheme reused that leftover
+	// inode, and os.WriteFile does not narrow the mode of an existing file), and
+	// no reader ever observes a partial write.
+	if err := storage.AtomicWriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write burn ledger %s: %w", path, err)
 	}
 	return nil
 }

--- a/cli/internal/adapters/eval/runtime.go
+++ b/cli/internal/adapters/eval/runtime.go
@@ -208,7 +208,9 @@ func (Runtime) SaveBurnLedger(path string, ledger evalsubstrate.HoldoutBurnLedge
 		return fmt.Errorf("encode burn ledger: %w", err)
 	}
 	temporary := path + ".tmp"
-	if err := os.WriteFile(temporary, data, 0o644); err != nil {
+	// 0o600: holdout burn state is load-bearing for holdout secrecy; a world/group-
+	// readable ledger leaks which holdout scenarios have been spent (age-6j9ee.3).
+	if err := os.WriteFile(temporary, data, 0o600); err != nil {
 		return fmt.Errorf("write burn ledger temp: %w", err)
 	}
 	if err := os.Rename(temporary, path); err != nil {

--- a/cli/internal/adapters/eval/runtime_test.go
+++ b/cli/internal/adapters/eval/runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 
 	aoeval "github.com/boshu2/agentops/cli/internal/eval"
@@ -90,5 +91,75 @@ func TestRuntimeTaskServiceDryRunUsesRealFilesystemAdapter(t *testing.T) {
 	}
 	if !result.DryRun {
 		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestSaveBurnLedger_StaleTempFile0600(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "burn-ledger.json")
+
+	// Seed the exact stale state the validator probe pre-creates: a leftover
+	// path+".tmp" at 0644, and a pre-existing final ledger at 0644.
+	if err := os.WriteFile(path+".tmp", []byte("stale"), 0o644); err != nil {
+		t.Fatalf("seed stale temp: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("seed stale ledger: %v", err)
+	}
+
+	ledger := evalsubstrate.HoldoutBurnLedger{Budget: 5}
+	if err := (Runtime{}).SaveBurnLedger(path, ledger); err != nil {
+		t.Fatalf("SaveBurnLedger: %v", err)
+	}
+	assertLedgerMode0600(t, path)
+
+	// The persisted content must be the new ledger, not the stale seed.
+	got, err := (Runtime{}).LoadBurnLedger(path)
+	if err != nil {
+		t.Fatalf("LoadBurnLedger: %v", err)
+	}
+	if got.Budget != 5 {
+		t.Fatalf("ledger budget = %d, want 5", got.Budget)
+	}
+}
+
+func TestSaveBurnLedger_ConcurrentWritersDoNotCollide(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "burn-ledger.json")
+	const writers = 8
+	var wg sync.WaitGroup
+	errs := make([]error, writers)
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = (Runtime{}).SaveBurnLedger(path, evalsubstrate.HoldoutBurnLedger{Budget: i})
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("SaveBurnLedger[%d]: %v", i, err)
+		}
+	}
+	assertLedgerMode0600(t, path)
+	if _, err := (Runtime{}).LoadBurnLedger(path); err != nil {
+		t.Fatalf("final ledger unreadable: %v", err)
+	}
+}
+
+func assertLedgerMode0600(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat ledger %s: %v", path, err)
+	}
+	if runtime.GOOS == "windows" {
+		if info.IsDir() {
+			t.Fatalf("ledger %s is a directory, want a file", path)
+		}
+		return
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("ledger mode = %#o, want 0o600", got)
 	}
 }

--- a/cli/internal/adapters/eval/runtime_test.go
+++ b/cli/internal/adapters/eval/runtime_test.go
@@ -4,12 +4,34 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	aoeval "github.com/boshu2/agentops/cli/internal/eval"
 	"github.com/boshu2/agentops/cli/internal/evalsubstrate"
 	"gopkg.in/yaml.v3"
 )
+
+// TestSaveBurnLedger_FileMode0600 (age-6j9ee.3): the holdout burn ledger pins 0o600 —
+// holdout secrecy is load-bearing, so a world/group-readable ledger (which leaks which
+// holdout scenarios have been spent) is a regression. POSIX-mode assert is skipped on
+// windows via a GOOS branch (not t.Skip) so the write itself is still exercised there.
+func TestSaveBurnLedger_FileMode0600(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "burn.json")
+	if err := (Runtime{}).SaveBurnLedger(path, evalsubstrate.HoldoutBurnLedger{Budget: 1}); err != nil {
+		t.Fatalf("SaveBurnLedger: %v", err)
+	}
+	if runtime.GOOS == "windows" {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("burn ledger mode = %o, want 0600 (holdout secrecy)", got)
+	}
+}
 
 func TestRuntimeSatisfiesCorePortAndResolvesHostPaths(t *testing.T) {
 	var port aoeval.CoreRuntime = Runtime{}

--- a/cli/internal/adapters/eval/scenario_ab_agentic.go
+++ b/cli/internal/adapters/eval/scenario_ab_agentic.go
@@ -199,7 +199,11 @@ func workspaceCommand(ctx context.Context, workDir, command string, withGold boo
 	if err != nil {
 		return nil, fmt.Errorf("resolve cwd for arm isolation: %w", err)
 	}
-	cmd, err := sandboxedShellCmd(ctx, corpusDenyPaths(cwd), command)
+	denyPaths, err := corpusDenyPaths(cwd)
+	if err != nil {
+		return nil, err
+	}
+	cmd, err := sandboxedShellCmd(ctx, denyPaths, command)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/adapters/eval/scenario_ab_agentic.go
+++ b/cli/internal/adapters/eval/scenario_ab_agentic.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	aoeval "github.com/boshu2/agentops/cli/internal/eval"
+	"github.com/boshu2/agentops/cli/internal/redact"
 	"github.com/boshu2/agentops/cli/internal/scenario"
 )
 
@@ -80,7 +81,13 @@ func (agenticScenarioRunner) RunArm(ctx context.Context, sc scenario.Scenario, w
 			if runErr != nil {
 				return aoeval.ArmOutcome{}, fmt.Errorf("agentic command %q: %w", command, runErr)
 			}
-			fmt.Fprintf(&history, "$ %s\nexit=%d\n%s\n\n", command, exitCode, strings.TrimSpace(stdout))
+			// Egress choke point: raw command stdout is RUNTIME output that becomes
+			// model-bound — history feeds the next turn's prompt and (via the done
+			// fallback) the judge-graded arm output. Scrub credentials/home-paths here,
+			// once, per redact's caller contract. The redactor is pattern-based and a
+			// no-op on non-secret text, so gold-doc content a with-gold command legitimately
+			// reads passes through unchanged; only secret-shaped substrings are replaced.
+			fmt.Fprintf(&history, "$ %s\nexit=%d\n%s\n\n", command, exitCode, redact.Redact(strings.TrimSpace(stdout)))
 		}
 		if step.Done {
 			summary := strings.TrimSpace(step.Summary)

--- a/cli/internal/adapters/eval/scenario_ab_agentic_sandbox_test.go
+++ b/cli/internal/adapters/eval/scenario_ab_agentic_sandbox_test.go
@@ -217,7 +217,11 @@ func TestJudgeAndControlArmShareCorpusDenyMachinery(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("HOME", t.TempDir())
-	if len(corpusDenyPaths(root)) == 0 {
+	deny, err := corpusDenyPaths(root)
+	if err != nil {
+		t.Fatalf("corpusDenyPaths: %v", err)
+	}
+	if len(deny) == 0 {
 		t.Fatal("shared corpusDenyPaths must be non-empty for a repo with .agents")
 	}
 	// Both executors refuse an empty deny set on every platform (fail-closed).

--- a/cli/internal/adapters/eval/scenario_ab_agentic_test.go
+++ b/cli/internal/adapters/eval/scenario_ab_agentic_test.go
@@ -64,6 +64,58 @@ func TestAgenticScenarioRunnerProducesWorkspaceArtifact(t *testing.T) {
 	}
 }
 
+// TestAgenticRunnerRedactsCommandOutputBeforePrompt (age-6j9ee.3): raw worker-command
+// stdout is model-bound — it accumulates into `history`, which is fed into the NEXT
+// turn's prompt AND (on done with an empty model summary) into the arm output the judge
+// grades. Secrets emitted by a workspace command must be scrubbed at the egress choke
+// point, so neither the next-turn prompt nor the graded output carries them.
+func TestAgenticRunnerRedactsCommandOutputBeforePrompt(t *testing.T) {
+	orig := agenticRunnerHooks
+	t.Cleanup(func() { agenticRunnerHooks = orig })
+
+	const awsKey = "AKIA1234567890ABCDEF"
+	const ghToken = "ghp_0123456789012345678901234567890123456789"
+
+	var prompts []string
+	call := 0
+	agenticRunnerHooks.runCodex = func(_ context.Context, prompt string, _ string, _ bool) (string, int, error) {
+		prompts = append(prompts, prompt)
+		defer func() { call++ }()
+		if call == 0 {
+			// Turn 1: emit a command whose (faked) output carries secrets.
+			return `{"commands":["leak-secrets"],"done":false,"summary":""}`, 1, nil
+		}
+		// Turn 2: finish with an empty summary so the arm output falls back to history.
+		return `{"commands":[],"done":true,"summary":""}`, 1, nil
+	}
+	agenticRunnerHooks.runCmd = func(_ context.Context, _ string, _ string, _ bool) (string, int, error) {
+		return "leaked AWS_SECRET " + awsKey + " and github " + ghToken, 0, nil
+	}
+
+	sc := scenario.Scenario{ID: "s-redact", Goal: "do work", Narrative: "n"}
+	out, err := (agenticScenarioRunner{}).RunArm(context.Background(), sc, false)
+	if err != nil {
+		t.Fatalf("RunArm: %v", err)
+	}
+
+	if len(prompts) < 2 {
+		t.Fatalf("expected >=2 turns, got %d", len(prompts))
+	}
+	turn2 := prompts[1]
+	if strings.Contains(turn2, awsKey) || strings.Contains(turn2, ghToken) {
+		t.Fatalf("next-turn prompt leaked raw secrets:\n%s", turn2)
+	}
+	if !strings.Contains(turn2, "[REDACTED]") {
+		t.Fatalf("next-turn prompt must contain [REDACTED]; got:\n%s", turn2)
+	}
+	if strings.Contains(out.Output, awsKey) || strings.Contains(out.Output, ghToken) {
+		t.Fatalf("graded arm output leaked raw secrets: %q", out.Output)
+	}
+	if !strings.Contains(out.Output, "[REDACTED]") {
+		t.Fatalf("graded arm output must carry redacted history [REDACTED]; got: %q", out.Output)
+	}
+}
+
 func TestSelectScenarioRunnerAgentic(t *testing.T) {
 	sc := scenario.Scenario{RunnerMode: "agentic"}
 	if _, ok := selectScenarioRunner(sc).(agenticScenarioRunner); !ok {

--- a/cli/internal/adapters/eval/scenario_ab_runtime.go
+++ b/cli/internal/adapters/eval/scenario_ab_runtime.go
@@ -132,7 +132,11 @@ func runCodexExecArm(ctx context.Context, prompt, outputSchemaPath string, allow
 		// fail-closed control-arm guard must not be weakened to express this.)
 		command = exec.CommandContext(ctx, "codex", args...)
 	} else {
-		confined, err := sandboxedCodexCmd(ctx, corpusDenyPaths(cwd), args)
+		denyPaths, err := corpusDenyPaths(cwd)
+		if err != nil {
+			return "", 0, err
+		}
+		confined, err := sandboxedCodexCmd(ctx, denyPaths, args)
 		if err != nil {
 			return "", 0, err
 		}

--- a/cli/internal/adapters/eval/scenario_ab_sandbox.go
+++ b/cli/internal/adapters/eval/scenario_ab_sandbox.go
@@ -64,14 +64,65 @@ func corpusDenyPaths(startDir string) []string {
 	}
 	seen := map[string]bool{}
 	var out []string
-	for _, p := range cand {
-		for _, q := range []string{p, resolveSymlink(p)} {
-			if q != "" && !seen[q] {
-				seen[q] = true
-				out = append(out, q)
-			}
+	add := func(p string) {
+		if p != "" && !seen[p] {
+			seen[p] = true
+			out = append(out, p)
 		}
 	}
+	for _, p := range cand {
+		add(p)
+		add(resolveSymlink(p))
+	}
+	// Nested-symlink Seatbelt gap: a directory symlink INSIDE a corpus root (e.g.
+	// .agents/learnings -> /external/dir) canonicalizes OUTSIDE every denied subpath,
+	// so Seatbelt (which matches the real, canonical path) would ALLOW a read through
+	// it, voiding the A/B. Walk each resolved deny root and deny the canonical target
+	// of any directory symlink found within it. Iterate a snapshot so the appends below
+	// don't extend the loop.
+	for _, root := range append([]string(nil), out...) {
+		for _, target := range nestedSymlinkDenyTargets(root) {
+			add(target)
+		}
+	}
+	return out
+}
+
+// maxSymlinkWalkDepth bounds the nested-symlink descent (directory levels below a
+// deny root). Corpus dirs are small, so this caps the walk cheaply; filepath.WalkDir
+// does not follow symlinks (Lstat), so symlink cycles cannot inflate it — the bound
+// only guards against an unexpectedly deep real tree.
+const maxSymlinkWalkDepth = 8
+
+// nestedSymlinkDenyTargets walks root and returns the canonical (symlink-resolved)
+// targets of every DIRECTORY symlink found within it, up to maxSymlinkWalkDepth levels.
+// These are the paths a read INSIDE the corpus canonicalizes to; denying them closes
+// the nested-symlink escape (a top-level resolveSymlink on the root does not reach a
+// symlink one or more levels down). A non-existent root walks to nothing.
+func nestedSymlinkDenyTargets(root string) []string {
+	var out []string
+	cleanRoot := filepath.Clean(root)
+	rootDepth := strings.Count(cleanRoot, string(filepath.Separator))
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() && strings.Count(filepath.Clean(path), string(filepath.Separator))-rootDepth > maxSymlinkWalkDepth {
+			return filepath.SkipDir
+		}
+		if d.Type()&os.ModeSymlink == 0 {
+			return nil
+		}
+		target, rerr := filepath.EvalSymlinks(path)
+		if rerr != nil {
+			return nil
+		}
+		if fi, serr := os.Stat(target); serr != nil || !fi.IsDir() {
+			return nil
+		}
+		out = append(out, target)
+		return nil
+	})
 	return out
 }
 

--- a/cli/internal/adapters/eval/scenario_ab_sandbox.go
+++ b/cli/internal/adapters/eval/scenario_ab_sandbox.go
@@ -95,10 +95,17 @@ func corpusDenyPaths(startDir string) []string {
 const maxSymlinkWalkDepth = 8
 
 // nestedSymlinkDenyTargets walks root and returns the canonical (symlink-resolved)
-// targets of every DIRECTORY symlink found within it, up to maxSymlinkWalkDepth levels.
-// These are the paths a read INSIDE the corpus canonicalizes to; denying them closes
-// the nested-symlink escape (a top-level resolveSymlink on the root does not reach a
-// symlink one or more levels down). A non-existent root walks to nothing.
+// targets of every DIRECTORY or regular-FILE symlink found within it, up to
+// maxSymlinkWalkDepth levels. These are the paths a read INSIDE the corpus canonicalizes
+// to; denying them closes the nested-symlink escape (a top-level resolveSymlink on the
+// root does not reach a symlink one or more levels down). Both target kinds must be
+// denied: a directory symlink (.agents/learnings -> /external) exposes a subtree, and a
+// FILE symlink (.agents/note.md -> /external/secret.txt) exposes a single file — reading
+// its canonical target leaked the corpus with exit 0 (a plain read through the symlink
+// node is masked by the .agents subpath deny, hiding the escape). Seatbelt `subpath` on a
+// canonical file path matches that file, so file targets are denied correctly by the same
+// renderer. EvalSymlinks follows a symlink CHAIN to its final target and returns an error
+// for a DANGLING symlink, which is skipped. A non-existent root walks to nothing.
 func nestedSymlinkDenyTargets(root string) []string {
 	var out []string
 	cleanRoot := filepath.Clean(root)
@@ -115,12 +122,18 @@ func nestedSymlinkDenyTargets(root string) []string {
 		}
 		target, rerr := filepath.EvalSymlinks(path)
 		if rerr != nil {
+			// Dangling symlink (target missing) or unresolvable chain — nothing to deny.
 			return nil
 		}
-		if fi, serr := os.Stat(target); serr != nil || !fi.IsDir() {
+		fi, serr := os.Stat(target)
+		if serr != nil {
 			return nil
 		}
-		out = append(out, target)
+		// Deny both directory targets (a subtree) and regular-file targets (a single
+		// corpus file). Skip anything else (devices, sockets, fifos) — not a corpus leak.
+		if fi.IsDir() || fi.Mode().IsRegular() {
+			out = append(out, target)
+		}
 		return nil
 	})
 	return out

--- a/cli/internal/adapters/eval/scenario_ab_sandbox.go
+++ b/cli/internal/adapters/eval/scenario_ab_sandbox.go
@@ -91,7 +91,7 @@ func corpusDenyPaths(startDir string) ([]string, error) {
 	// resolved external target ext1 (the round-3 refute). The deny set is instead the full
 	// symlink-reachability CLOSURE (fixpoint), computed with fail-closed bounds so no
 	// symlink shape can escape: every shape either lands fully in the closure or refuses.
-	closure, err := symlinkClosureDenyTargets(append([]string(nil), out...), maxSymlinkClosureDirs, maxSymlinkDenyEntries, maxSymlinkWalkDepth)
+	closure, err := symlinkClosureDenyTargets(append([]string(nil), out...), maxSymlinkClosureDirs, maxSymlinkDenyEntries)
 	if err != nil {
 		return nil, err
 	}
@@ -121,11 +121,6 @@ const (
 	// maxSymlinkDenyEntries caps distinct canonical targets the closure may add (real
 	// environment measured ~58; headroom below).
 	maxSymlinkDenyEntries = 2048
-	// maxSymlinkWalkDepth bounds per-walk directory descent (a cheap secondary guard;
-	// the dir cap above is the real bound). filepath.WalkDir uses Lstat and does not
-	// follow symlinks, so a cycle cannot inflate a single walk — the closure's own
-	// visited-set + dir cap terminate the cross-walk graph.
-	maxSymlinkWalkDepth = 8
 )
 
 // errSymlinkClosureOverflow is returned (wrapped) when the symlink closure exceeds its
@@ -143,17 +138,22 @@ var errSymlinkClosureOverflow = errors.New("symlink deny closure exceeded bounds
 //     what closes a CHAINED escape (.agents/learnings -> ext1; ext1/pivot.md -> ext2).
 //  2. Repeat until the worklist is empty. The result is the complete closure.
 //
-// Cycle safety: a target is deduped via the seen-set BEFORE being pushed, and each root is
-// walked at most once (a->b->a terminates). Dangling symlinks (unresolvable chains) are
-// skipped; device/socket/fifo targets are skipped (not a corpus leak). initialRoots (the
-// legitimate corpus dirs) are walked depth-bounded but NOT dir-capped — they are bounded by
-// reality and already denied by subpath. Directories reached THROUGH symlinks are dir-capped
-// (maxDirs): that is where a pathological graph would explode, and exceeding the cap — or the
-// deny-entry cap (maxEntries), or hitting an unreadable directory (a non-NotExist walk error)
-// — returns an error so the arm fails closed. A missing/NotExist root walks to nothing. Caps
-// are parameters so overflow is unit-testable with tiny caps; corpusDenyPaths passes the
-// package consts.
-func symlinkClosureDenyTargets(initialRoots []string, maxDirs, maxEntries, maxDepth int) ([]string, error) {
+// Termination and completeness: there is NO depth bound — a depth cap can only either
+// silently truncate the closure (omitting a deep symlink target — the leak this replaced) or
+// false-close on a legitimately deep corpus, both of which break "complete closure OR refuse".
+// The closure instead walks each subtree in FULL, and terminates on two guards: (1) a target
+// is deduped via the seen-set BEFORE being pushed and each root is walked at most once
+// (a->b->a terminates; filepath.WalkDir uses Lstat and does not follow symlinks, so no single
+// walk can cycle); (2) directories reached THROUGH symlinks are dir-capped (maxDirs), so a
+// pathological EXTERNAL graph — a wide fan-out OR a deep linear chain — is bounded and fails
+// closed. Exceeding the dir cap, the deny-entry cap (maxEntries), or hitting an unreadable
+// directory (a non-NotExist walk error) returns an error so the arm fails closed. Dangling
+// symlinks (unresolvable chains) are skipped; device/socket/fifo targets are skipped (not a
+// corpus leak). initialRoots (the legitimate corpus dirs) are walked in full but NOT dir-capped
+// — they are bounded by reality and already denied by subpath. A missing/NotExist root walks to
+// nothing. Caps are parameters so overflow is unit-testable with tiny caps; corpusDenyPaths
+// passes the package consts.
+func symlinkClosureDenyTargets(initialRoots []string, maxDirs, maxEntries int) ([]string, error) {
 	var out []string
 	denySeen := map[string]bool{} // canonical targets already added (output dedup)
 	walked := map[string]bool{}   // roots already walked (cross-walk cycle guard)
@@ -177,8 +177,6 @@ func symlinkClosureDenyTargets(initialRoots []string, maxDirs, maxEntries, maxDe
 	}
 
 	walkOne := func(root string, countDirs bool) error {
-		cleanRoot := filepath.Clean(root)
-		rootDepth := strings.Count(cleanRoot, string(filepath.Separator))
 		return filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
 				if os.IsNotExist(err) {
@@ -194,9 +192,6 @@ func symlinkClosureDenyTargets(initialRoots []string, maxDirs, maxEntries, maxDe
 					if dirsWalked > maxDirs {
 						return errSymlinkClosureOverflow
 					}
-				}
-				if strings.Count(filepath.Clean(path), string(filepath.Separator))-rootDepth > maxDepth {
-					return filepath.SkipDir
 				}
 				return nil
 			}

--- a/cli/internal/adapters/eval/scenario_ab_sandbox.go
+++ b/cli/internal/adapters/eval/scenario_ab_sandbox.go
@@ -2,6 +2,7 @@ package eval
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -41,7 +42,14 @@ func corpusRoot(startDir string) string {
 // NOT read: the repo corpus (<corpusRoot>/.agents, /.ao — resolved from any subdir)
 // AND the global corpus (~/.agents), each plus its symlink-resolved canonical path
 // (Seatbelt matches the real path). A leak in ANY of these voids the A/B.
-func corpusDenyPaths(startDir string) []string {
+//
+// FAIL-CLOSED: returns an error (never a partial deny set) when the symlink-reachability
+// closure cannot be computed completely — a pathological symlink graph that exceeds the
+// closure bounds, or an unreadable directory. The caller (sandboxExecGuard) then refuses
+// to run the arm, exactly like the no-Seatbelt case. This is the property that kills the
+// nested/chained-symlink escape class: there is no symlink shape that leaks, because any
+// shape either lands FULLY in the closure or trips the refusal.
+func corpusDenyPaths(startDir string) ([]string, error) {
 	root := corpusRoot(startDir)
 	cand := []string{filepath.Join(root, ".agents"), filepath.Join(root, ".ao")}
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
@@ -74,69 +82,171 @@ func corpusDenyPaths(startDir string) []string {
 		add(p)
 		add(resolveSymlink(p))
 	}
-	// Nested-symlink Seatbelt gap: a directory symlink INSIDE a corpus root (e.g.
-	// .agents/learnings -> /external/dir) canonicalizes OUTSIDE every denied subpath,
-	// so Seatbelt (which matches the real, canonical path) would ALLOW a read through
-	// it, voiding the A/B. Walk each resolved deny root and deny the canonical target
-	// of any directory symlink found within it. Iterate a snapshot so the appends below
-	// don't extend the loop.
-	for _, root := range append([]string(nil), out...) {
-		for _, target := range nestedSymlinkDenyTargets(root) {
-			add(target)
-		}
+	// Nested/chained-symlink Seatbelt gap: a symlink INSIDE a corpus root (e.g.
+	// .agents/learnings -> /external/dir, or .agents/note.md -> /external/secret.txt)
+	// canonicalizes OUTSIDE every denied subpath, so Seatbelt (which matches the real,
+	// canonical path) would ALLOW a read through it, voiding the A/B. A single-pass walk
+	// that only enumerates the FIRST hop is NOT a closure: .agents/learnings -> ext1 and
+	// ext1/pivot.md -> ext2/secret.txt leaks ext2 because the walk never descends INTO the
+	// resolved external target ext1 (the round-3 refute). The deny set is instead the full
+	// symlink-reachability CLOSURE (fixpoint), computed with fail-closed bounds so no
+	// symlink shape can escape: every shape either lands fully in the closure or refuses.
+	closure, err := symlinkClosureDenyTargets(append([]string(nil), out...), maxSymlinkClosureDirs, maxSymlinkDenyEntries, maxSymlinkWalkDepth)
+	if err != nil {
+		return nil, err
 	}
-	return out
+	for _, target := range closure {
+		add(target)
+	}
+	return out, nil
 }
 
-// maxSymlinkWalkDepth bounds the nested-symlink descent (directory levels below a
-// deny root). Corpus dirs are small, so this caps the walk cheaply; filepath.WalkDir
-// does not follow symlinks (Lstat), so symlink cycles cannot inflate it — the bound
-// only guards against an unexpectedly deep real tree.
-const maxSymlinkWalkDepth = 8
+// Bounds for the symlink-reachability closure. They are the fail-closed guard that kills
+// the escape class: a pathological symlink graph (a fan-out, a deep chain, or a symlink to
+// a huge external tree such as `/`) trips a bound and the whole arm refuses to run, rather
+// than silently computing an incomplete deny set. The bounds apply to the EXTERNAL subtrees
+// reached THROUGH symlinks — where explosion happens — not the legitimate corpus roots
+// (which are already denied wholesale by subpath and are bounded by reality; the global
+// ~/.agents is routinely tens of thousands of dirs, so a global dir cap would false-close
+// every real run). symlinkClosureDenyTargets takes the caps as parameters so overflow is
+// unit-testable with tiny caps + tiny fixtures; corpusDenyPaths passes these consts.
+const (
+	// maxSymlinkClosureDirs caps directories walked in symlink-reached external subtrees.
+	// It must clear the REAL environment (measured ~129 external dirs on a machine whose
+	// ~/.agents symlinks the repo skill corpus) with headroom, while a symlink to `/` (or
+	// any large external tree) blows past it and fails closed. If a legitimate corpus ever
+	// exceeds it, the arm safely refuses (never leaks); bump this const. Not a security
+	// primitive — the fail-closed refusal is.
+	maxSymlinkClosureDirs = 1024
+	// maxSymlinkDenyEntries caps distinct canonical targets the closure may add (real
+	// environment measured ~58; headroom below).
+	maxSymlinkDenyEntries = 2048
+	// maxSymlinkWalkDepth bounds per-walk directory descent (a cheap secondary guard;
+	// the dir cap above is the real bound). filepath.WalkDir uses Lstat and does not
+	// follow symlinks, so a cycle cannot inflate a single walk — the closure's own
+	// visited-set + dir cap terminate the cross-walk graph.
+	maxSymlinkWalkDepth = 8
+)
 
-// nestedSymlinkDenyTargets walks root and returns the canonical (symlink-resolved)
-// targets of every DIRECTORY or regular-FILE symlink found within it, up to
-// maxSymlinkWalkDepth levels. These are the paths a read INSIDE the corpus canonicalizes
-// to; denying them closes the nested-symlink escape (a top-level resolveSymlink on the
-// root does not reach a symlink one or more levels down). Both target kinds must be
-// denied: a directory symlink (.agents/learnings -> /external) exposes a subtree, and a
-// FILE symlink (.agents/note.md -> /external/secret.txt) exposes a single file — reading
-// its canonical target leaked the corpus with exit 0 (a plain read through the symlink
-// node is masked by the .agents subpath deny, hiding the escape). Seatbelt `subpath` on a
-// canonical file path matches that file, so file targets are denied correctly by the same
-// renderer. EvalSymlinks follows a symlink CHAIN to its final target and returns an error
-// for a DANGLING symlink, which is skipped. A non-existent root walks to nothing.
-func nestedSymlinkDenyTargets(root string) []string {
+// errSymlinkClosureOverflow is returned (wrapped) when the symlink closure exceeds its
+// bounds. It makes the arm FAIL CLOSED via sandboxExecGuard — the same refusal path as an
+// unavailable sandbox — because an incomplete deny set could leak the corpus.
+var errSymlinkClosureOverflow = errors.New("symlink deny closure exceeded bounds (pathological corpus symlink graph); refusing to run a potentially-unisolated control arm")
+
+// symlinkClosureDenyTargets computes the full symlink-reachability CLOSURE of the deny
+// roots: the set of canonical paths a read that starts anywhere in the corpus can reach by
+// following symlinks. It is a fixpoint over a worklist —
+//
+//  1. Walk each root. Every symlink found (file OR dir) is resolved (EvalSymlinks) to its
+//     canonical target, which is added to the deny set. Every resolved DIRECTORY target is
+//     ALSO pushed onto the worklist, so its interior symlinks get resolved too — this is
+//     what closes a CHAINED escape (.agents/learnings -> ext1; ext1/pivot.md -> ext2).
+//  2. Repeat until the worklist is empty. The result is the complete closure.
+//
+// Cycle safety: a target is deduped via the seen-set BEFORE being pushed, and each root is
+// walked at most once (a->b->a terminates). Dangling symlinks (unresolvable chains) are
+// skipped; device/socket/fifo targets are skipped (not a corpus leak). initialRoots (the
+// legitimate corpus dirs) are walked depth-bounded but NOT dir-capped — they are bounded by
+// reality and already denied by subpath. Directories reached THROUGH symlinks are dir-capped
+// (maxDirs): that is where a pathological graph would explode, and exceeding the cap — or the
+// deny-entry cap (maxEntries), or hitting an unreadable directory (a non-NotExist walk error)
+// — returns an error so the arm fails closed. A missing/NotExist root walks to nothing. Caps
+// are parameters so overflow is unit-testable with tiny caps; corpusDenyPaths passes the
+// package consts.
+func symlinkClosureDenyTargets(initialRoots []string, maxDirs, maxEntries, maxDepth int) ([]string, error) {
 	var out []string
-	cleanRoot := filepath.Clean(root)
-	rootDepth := strings.Count(cleanRoot, string(filepath.Separator))
-	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
+	denySeen := map[string]bool{} // canonical targets already added (output dedup)
+	walked := map[string]bool{}   // roots already walked (cross-walk cycle guard)
+	var worklist []string         // EXTERNAL dir targets reached via symlinks; dir-capped
+	dirsWalked := 0               // dirs walked in symlink-reached subtrees only
+
+	addTarget := func(target string, isDir bool) error {
+		if denySeen[target] {
 			return nil
 		}
-		if d.IsDir() && strings.Count(filepath.Clean(path), string(filepath.Separator))-rootDepth > maxSymlinkWalkDepth {
-			return filepath.SkipDir
+		denySeen[target] = true
+		out = append(out, target)
+		if len(out) > maxEntries {
+			return errSymlinkClosureOverflow
 		}
-		if d.Type()&os.ModeSymlink == 0 {
-			return nil
-		}
-		target, rerr := filepath.EvalSymlinks(path)
-		if rerr != nil {
-			// Dangling symlink (target missing) or unresolvable chain — nothing to deny.
-			return nil
-		}
-		fi, serr := os.Stat(target)
-		if serr != nil {
-			return nil
-		}
-		// Deny both directory targets (a subtree) and regular-file targets (a single
-		// corpus file). Skip anything else (devices, sockets, fifos) — not a corpus leak.
-		if fi.IsDir() || fi.Mode().IsRegular() {
-			out = append(out, target)
+		if isDir {
+			// Descend into the resolved external dir so a CHAINED escape is closed.
+			worklist = append(worklist, target)
 		}
 		return nil
-	})
-	return out
+	}
+
+	walkOne := func(root string, countDirs bool) error {
+		cleanRoot := filepath.Clean(root)
+		rootDepth := strings.Count(cleanRoot, string(filepath.Separator))
+		return filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				if os.IsNotExist(err) {
+					// A never-created corpus root (e.g. missing .ao): nothing to walk.
+					return nil
+				}
+				// Unreadable dir / permission error: cannot prove the closure is complete.
+				return err
+			}
+			if d.IsDir() {
+				if countDirs {
+					dirsWalked++
+					if dirsWalked > maxDirs {
+						return errSymlinkClosureOverflow
+					}
+				}
+				if strings.Count(filepath.Clean(path), string(filepath.Separator))-rootDepth > maxDepth {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if d.Type()&os.ModeSymlink == 0 {
+				return nil
+			}
+			target, rerr := filepath.EvalSymlinks(path)
+			if rerr != nil {
+				// Dangling symlink or unresolvable chain — nothing to deny.
+				return nil
+			}
+			fi, serr := os.Stat(target)
+			if serr != nil {
+				return nil
+			}
+			switch {
+			case fi.IsDir():
+				return addTarget(target, true)
+			case fi.Mode().IsRegular():
+				return addTarget(target, false)
+			default:
+				// device / socket / fifo — not a corpus leak; do not deny, do not descend.
+				return nil
+			}
+		})
+	}
+
+	// Phase 1: the legitimate corpus roots — depth-bounded, NOT dir-capped.
+	for _, r := range initialRoots {
+		if walked[r] {
+			continue
+		}
+		walked[r] = true
+		if err := walkOne(r, false); err != nil {
+			return nil, fmt.Errorf("symlink deny closure walk of %q: %w", r, err)
+		}
+	}
+	// Phase 2: external subtrees reached via symlinks — dir-capped fixpoint.
+	for len(worklist) > 0 {
+		r := worklist[len(worklist)-1]
+		worklist = worklist[:len(worklist)-1]
+		if walked[r] {
+			continue
+		}
+		walked[r] = true
+		if err := walkOne(r, true); err != nil {
+			return nil, fmt.Errorf("symlink deny closure walk of %q: %w", r, err)
+		}
+	}
+	return out, nil
 }
 
 // configCorpusDenyPaths returns the global corpus directories `ao lookup` resolves

--- a/cli/internal/adapters/eval/scenario_ab_sandbox_test.go
+++ b/cli/internal/adapters/eval/scenario_ab_sandbox_test.go
@@ -2,6 +2,8 @@ package eval
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -35,7 +37,11 @@ func TestCorpusDenyPaths_RepoAndGlobal(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(root, ".agents"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	joined := strings.Join(corpusDenyPaths(root), "|")
+	deny, err := corpusDenyPaths(root)
+	if err != nil {
+		t.Fatalf("corpusDenyPaths: %v", err)
+	}
+	joined := strings.Join(deny, "|")
 	for _, want := range []string{filepath.Join(root, ".agents"), filepath.Join(root, ".ao")} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("deny set must include repo %q; got %s", want, joined)
@@ -99,6 +105,7 @@ func TestEnvCorpusDenyPaths_NonDefaultOverride(t *testing.T) {
 // AO_AGENTS_DIR appears in the full deny set corpusDenyPaths builds (not just the
 // helper). The control arm cannot read the override corpus. age-58r.
 func TestEnvCorpusDenyPaths_FlowsIntoCorpusDenyPaths(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // isolate from the real ~/.agents symlink farm (deterministic closure)
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, ".agents"), 0o755); err != nil {
 		t.Fatal(err)
@@ -106,7 +113,11 @@ func TestEnvCorpusDenyPaths_FlowsIntoCorpusDenyPaths(t *testing.T) {
 	custom := filepath.Join(t.TempDir(), "elsewhere-corpus")
 	t.Setenv("AO_HOME", "")
 	t.Setenv("AO_AGENTS_DIR", custom)
-	joined := strings.Join(corpusDenyPaths(root), "|")
+	deny, err := corpusDenyPaths(root)
+	if err != nil {
+		t.Fatalf("corpusDenyPaths: %v", err)
+	}
+	joined := strings.Join(deny, "|")
 	if !strings.Contains(joined, custom) {
 		t.Errorf("full deny set must include the AO_AGENTS_DIR override %q; got %s", custom, joined)
 	}
@@ -168,7 +179,11 @@ func TestCorpusDenyPaths_NestedSymlinkTargetDenied(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	joined := strings.Join(corpusDenyPaths(root), "|")
+	deny, err := corpusDenyPaths(root)
+	if err != nil {
+		t.Fatalf("corpusDenyPaths: %v", err)
+	}
+	joined := strings.Join(deny, "|")
 	if !strings.Contains(joined, wantTarget) {
 		t.Fatalf("nested symlink target %q must be in the deny set; got %s", wantTarget, joined)
 	}
@@ -199,22 +214,229 @@ func TestCorpusDenyPaths_NestedFileSymlinkTargetDenied(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	joined := strings.Join(corpusDenyPaths(root), "|")
+	deny, err := corpusDenyPaths(root)
+	if err != nil {
+		t.Fatalf("corpusDenyPaths: %v", err)
+	}
+	joined := strings.Join(deny, "|")
 	if !strings.Contains(joined, wantTarget) {
 		t.Fatalf("nested FILE symlink target %q must be in the deny set; got %s", wantTarget, joined)
 	}
 }
 
-// TestNestedSymlinkDenyTargets_SkipsDanglingSymlink (age-6j9ee.3): a dangling nested
+// TestSymlinkClosureDenyTargets_SkipsDanglingSymlink (age-6j9ee.3): a dangling nested
 // symlink (target does not exist) resolves to nothing via EvalSymlinks and must be
 // skipped without error, contributing no deny path.
-func TestNestedSymlinkDenyTargets_SkipsDanglingSymlink(t *testing.T) {
+func TestSymlinkClosureDenyTargets_SkipsDanglingSymlink(t *testing.T) {
 	root := t.TempDir()
 	if err := os.Symlink(filepath.Join(root, "does-not-exist"), filepath.Join(root, "dangling")); err != nil {
 		t.Fatal(err)
 	}
-	if got := nestedSymlinkDenyTargets(root); len(got) != 0 {
+	got, err := symlinkClosureDenyTargets([]string{root}, maxSymlinkClosureDirs, maxSymlinkDenyEntries, maxSymlinkWalkDepth)
+	if err != nil {
+		t.Fatalf("symlinkClosureDenyTargets: %v", err)
+	}
+	if len(got) != 0 {
 		t.Errorf("dangling symlink must contribute no deny target; got %v", got)
+	}
+}
+
+// TestCorpusDenyPaths_ChainedSymlinkClosure (age-6j9ee.3, the round-3 refute, GREEN):
+// the EXACT chained-escape shape the validator refuted twice as a class —
+//
+//	root/.agents/learnings -> ext1        (dir target; the FIRST hop)
+//	ext1/pivot.md          -> ext2/secret.txt (the SECOND hop, INSIDE the resolved target)
+//
+// The single-pass walk added only ext1 and never descended INTO it, so ext2's canonical
+// FILE target escaped the deny set and leaked (26 bytes, exit 0). The fixpoint closure
+// descends into the resolved external DIRECTORY ext1, resolves ext1/pivot.md, and denies
+// ext2's canonical target too. BOTH hops must land in the deny set.
+func TestCorpusDenyPaths_ChainedSymlinkClosure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	agents := filepath.Join(root, ".agents")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ext1 := t.TempDir()
+	ext2 := t.TempDir()
+	secret := filepath.Join(ext2, "secret.txt")
+	if err := os.WriteFile(secret, []byte("CHAINED-CORPUS-SECRET-26B"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(ext1, "pivot.md")); err != nil {
+		t.Fatal(err) // ext1/pivot.md -> ext2/secret.txt (second hop)
+	}
+	if err := os.Symlink(ext1, filepath.Join(agents, "learnings")); err != nil {
+		t.Fatal(err) // .agents/learnings -> ext1 (first hop)
+	}
+	wantExt1, err := filepath.EvalSymlinks(ext1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantExt2, err := filepath.EvalSymlinks(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deny, err := corpusDenyPaths(root)
+	if err != nil {
+		t.Fatalf("corpusDenyPaths: %v", err)
+	}
+	joined := strings.Join(deny, "|")
+	if !strings.Contains(joined, wantExt1) {
+		t.Errorf("first-hop dir target %q must be denied; got %s", wantExt1, joined)
+	}
+	if !strings.Contains(joined, wantExt2) {
+		t.Fatalf("CHAINED second-hop file target %q must be in the closure (round-3 leak); got %s", wantExt2, joined)
+	}
+}
+
+// TestCorpusDenyPaths_DeeperChainClosure (age-6j9ee.3): a 3-hop chain must be fully
+// closed — .agents/l1 -> extA; extA/l2 -> extB; extB/l3 -> extC/secret.txt. The
+// closure descends hop by hop; the final file target must be denied.
+func TestCorpusDenyPaths_DeeperChainClosure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	agents := filepath.Join(root, ".agents")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	extA, extB, extC := t.TempDir(), t.TempDir(), t.TempDir()
+	secret := filepath.Join(extC, "secret.txt")
+	if err := os.WriteFile(secret, []byte("DEEP-CHAIN-SECRET"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(extB, "l3")); err != nil {
+		t.Fatal(err) // extB/l3 -> extC/secret.txt
+	}
+	if err := os.Symlink(extB, filepath.Join(extA, "l2")); err != nil {
+		t.Fatal(err) // extA/l2 -> extB
+	}
+	if err := os.Symlink(extA, filepath.Join(agents, "l1")); err != nil {
+		t.Fatal(err) // .agents/l1 -> extA
+	}
+	wantFinal, err := filepath.EvalSymlinks(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deny, err := corpusDenyPaths(root)
+	if err != nil {
+		t.Fatalf("corpusDenyPaths: %v", err)
+	}
+	if joined := strings.Join(deny, "|"); !strings.Contains(joined, wantFinal) {
+		t.Fatalf("3-hop chain final target %q must be in the closure; got %s", wantFinal, joined)
+	}
+}
+
+// TestSymlinkClosureDenyTargets_CycleTerminates (age-6j9ee.3): a symlink cycle
+// a/link -> b, b/link -> a must terminate (no infinite loop, no error) and deny both
+// canonical directory targets. Termination is proven by the test completing; the
+// seen-set dedup before pushing to the worklist is the guard.
+func TestSymlinkClosureDenyTargets_CycleTerminates(t *testing.T) {
+	a := t.TempDir()
+	b := t.TempDir()
+	if err := os.Symlink(b, filepath.Join(a, "link")); err != nil {
+		t.Fatal(err) // a/link -> b
+	}
+	if err := os.Symlink(a, filepath.Join(b, "link")); err != nil {
+		t.Fatal(err) // b/link -> a (cycle)
+	}
+	got, err := symlinkClosureDenyTargets([]string{a}, maxSymlinkClosureDirs, maxSymlinkDenyEntries, maxSymlinkWalkDepth)
+	if err != nil {
+		t.Fatalf("cycle must not error: %v", err)
+	}
+	canonA, _ := filepath.EvalSymlinks(a)
+	canonB, _ := filepath.EvalSymlinks(b)
+	joined := strings.Join(got, "|")
+	for _, want := range []string{canonA, canonB} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("cycle closure must deny %q; got %v", want, got)
+		}
+	}
+}
+
+// TestSymlinkClosureDenyTargets_DirOverflowFailsClosed (age-6j9ee.3): a symlink into an
+// external tree with more directories than the dir cap cannot be enumerated to a complete
+// closure, so the closure returns errSymlinkClosureOverflow and a nil set — never a partial
+// one. Tiny cap parameter keeps the fixture tiny (the same code path a symlink to `/` hits).
+func TestSymlinkClosureDenyTargets_DirOverflowFailsClosed(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+	for i := 0; i < 5; i++ { // 5 external subdirs > maxDirs=2
+		if err := os.MkdirAll(filepath.Join(external, fmt.Sprintf("d%d", i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(external, filepath.Join(root, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	got, err := symlinkClosureDenyTargets([]string{root}, 2, maxSymlinkDenyEntries, maxSymlinkWalkDepth)
+	if err == nil {
+		t.Fatalf("oversized external tree must fail closed; got %d entries, nil error", len(got))
+	}
+	if !errors.Is(err, errSymlinkClosureOverflow) {
+		t.Fatalf("want errSymlinkClosureOverflow; got %v", err)
+	}
+	if got != nil {
+		t.Errorf("fail-closed must return a nil set (never a partial one); got %v", got)
+	}
+}
+
+// TestSymlinkClosureDenyTargets_EntryOverflowFailsClosed (age-6j9ee.3): more distinct
+// canonical targets than the entry cap also fails closed (the second bound). A pathological
+// fan-out of many symlink targets cannot silently truncate the deny set.
+func TestSymlinkClosureDenyTargets_EntryOverflowFailsClosed(t *testing.T) {
+	root := t.TempDir()
+	for i := 0; i < 4; i++ { // 4 external file targets > maxEntries=1
+		f := filepath.Join(t.TempDir(), "s.txt")
+		if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(f, filepath.Join(root, fmt.Sprintf("l%d", i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := symlinkClosureDenyTargets([]string{root}, maxSymlinkClosureDirs, 1, maxSymlinkWalkDepth)
+	if err == nil {
+		t.Fatalf("exceeding the entry cap must fail closed; got %d entries, nil error", len(got))
+	}
+	if !errors.Is(err, errSymlinkClosureOverflow) {
+		t.Fatalf("want errSymlinkClosureOverflow; got %v", err)
+	}
+}
+
+// TestWorkspaceCommand_OverflowPropagatesRefusal (age-6j9ee.3, guard refusal path, real
+// const): when the closure overflows the PRODUCTION dir cap, a real caller (workspaceCommand,
+// the agentic control arm) must return the error and NEVER a runnable command — the arm
+// refuses to run unisolated, exactly like the no-Seatbelt case. Exercises the real const
+// end-to-end via a genuine oversized external tree reached through a corpus symlink. No GOOS
+// gate: the refusal happens before any sandbox exec.
+func TestWorkspaceCommand_OverflowPropagatesRefusal(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	agents := filepath.Join(root, ".agents")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bigExternal := t.TempDir()
+	for i := 0; i < maxSymlinkClosureDirs+16; i++ {
+		if err := os.Mkdir(filepath.Join(bigExternal, fmt.Sprintf("d%04d", i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(bigExternal, filepath.Join(agents, "learnings")); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(root)
+	cmd, err := workspaceCommand(context.Background(), t.TempDir(), "cat something", false)
+	if err == nil {
+		t.Fatalf("control arm must refuse (fail closed) when the deny closure overflows; got cmd=%v", cmd)
+	}
+	if cmd != nil {
+		t.Errorf("no command may be returned on refusal; got %v", cmd)
+	}
+	if !errors.Is(err, errSymlinkClosureOverflow) {
+		t.Fatalf("refusal must carry the overflow cause; got %v", err)
 	}
 }
 
@@ -312,6 +534,59 @@ func TestWorkspaceCommandRunner_Integration_ControlArmDeniesNestedSymlinkRead(t 
 	}
 }
 
+// TestWorkspaceCommandRunner_Integration_ControlArmDeniesChainedSymlinkRead
+// (age-6j9ee.3, darwin, the round-3 vector RUN): the CHAINED escape end to end —
+// .agents/learnings -> ext1; ext1/pivot.md -> ext2/secret.txt. Reading the FINAL resolved
+// target (ext2's canonical secret file) leaked 26 bytes with exit 0 before the fix. The
+// fixpoint closure denies ext2's canonical target, so the read is now DENIED (nonzero
+// exit, zero corpus bytes).
+func TestWorkspaceCommandRunner_Integration_ControlArmDeniesChainedSymlinkRead(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only: macOS Seatbelt sandbox-exec integration")
+	}
+	if _, err := os.Stat(macOSSandboxExec); err != nil {
+		t.Skipf("sandbox-exec unavailable: %v", err)
+	}
+
+	root := t.TempDir()
+	agents := filepath.Join(root, ".agents")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ext1 := t.TempDir()
+	ext2 := t.TempDir()
+	secret := filepath.Join(ext2, "secret.txt")
+	if err := os.WriteFile(secret, []byte("CHAINED-FINAL-CORPUS-SECRET"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(ext1, "pivot.md")); err != nil {
+		t.Fatal(err) // ext1/pivot.md -> ext2/secret.txt
+	}
+	if err := os.Symlink(ext1, filepath.Join(agents, "learnings")); err != nil {
+		t.Fatal(err) // .agents/learnings -> ext1
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Chdir(root)
+	workDir := t.TempDir()
+
+	// The observed vector: the corpus reader canonicalizes the whole chain and reads the
+	// final resolved target (ext2/secret.txt). That canonical path must be denied.
+	resolved, err := filepath.EvalSymlinks(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, exitCode, err := defaultWorkspaceCommandRunner(context.Background(), workDir, "cat "+resolved, false)
+	if err != nil {
+		t.Fatalf("runner returned a Go error (want a denied read = nonzero exit): %v", err)
+	}
+	if exitCode == 0 {
+		t.Fatalf("control arm read final resolved target of a CHAINED corpus symlink (isolation void): exit=0 stdout=%q", stdout)
+	}
+	if strings.Contains(stdout, "CHAINED-FINAL-CORPUS-SECRET") {
+		t.Fatalf("control arm leaked corpus bytes via chained symlink: stdout=%q", stdout)
+	}
+}
+
 // TestSandboxExecDenyProfile_DeniesAllPaths: every deny path appears in a
 // (deny file-read* (subpath ...)) clause, and non-corpus reads remain allowed.
 func TestSandboxExecDenyProfile_DeniesAllPaths(t *testing.T) {
@@ -393,7 +668,11 @@ func TestSandboxExec_Integration_DeniesCorpusRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	profile := sandboxExecDenyProfile(corpusDenyPaths(root))
+	deny, err := corpusDenyPaths(root)
+	if err != nil {
+		t.Fatalf("corpusDenyPaths: %v", err)
+	}
+	profile := sandboxExecDenyProfile(deny)
 
 	denyCmd := exec.Command(macOSSandboxExec, "-p", profile, "/bin/cat", secret)
 	if err := denyCmd.Run(); err == nil {

--- a/cli/internal/adapters/eval/scenario_ab_sandbox_test.go
+++ b/cli/internal/adapters/eval/scenario_ab_sandbox_test.go
@@ -232,7 +232,7 @@ func TestSymlinkClosureDenyTargets_SkipsDanglingSymlink(t *testing.T) {
 	if err := os.Symlink(filepath.Join(root, "does-not-exist"), filepath.Join(root, "dangling")); err != nil {
 		t.Fatal(err)
 	}
-	got, err := symlinkClosureDenyTargets([]string{root}, maxSymlinkClosureDirs, maxSymlinkDenyEntries, maxSymlinkWalkDepth)
+	got, err := symlinkClosureDenyTargets([]string{root}, maxSymlinkClosureDirs, maxSymlinkDenyEntries)
 	if err != nil {
 		t.Fatalf("symlinkClosureDenyTargets: %v", err)
 	}
@@ -328,6 +328,57 @@ func TestCorpusDenyPaths_DeeperChainClosure(t *testing.T) {
 	}
 }
 
+// TestCorpusDenyPaths_DeepUnderCapClosure (age-6j9ee.3, the validator's exact probe): a
+// corpus symlink into an external subtree whose PIVOT symlink sits DEEPER than the old
+// depth-8 bound, while the subtree's total dir/entry count stays UNDER the dir/entry caps.
+// The old depth bound SkipDir'd before reaching the pivot, so its canonical target was
+// SILENTLY omitted (no error, no overflow) and a control arm could read it — the "complete
+// closure OR refuse" property was violated by a THIRD, silent, truncating cap. With the
+// depth bound removed, the closure descends the full external subtree (bounded by the dir
+// cap) and denies the deep pivot's canonical target.
+func TestCorpusDenyPaths_DeepUnderCapClosure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	agents := filepath.Join(root, ".agents")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// External subtree: a linear chain of real dirs 12 levels deep (> old depth bound 8),
+	// but only ~13 dirs total — far under maxSymlinkClosureDirs (1024) and the entry cap.
+	external := t.TempDir()
+	deep := external
+	for i := 0; i < 12; i++ {
+		deep = filepath.Join(deep, fmt.Sprintf("d%d", i))
+	}
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ext2 := t.TempDir()
+	secret := filepath.Join(ext2, "secret.txt")
+	if err := os.WriteFile(secret, []byte("VALIDATOR-DEEP-UNDER-CAP-SECRET"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Pivot symlink at the DEEP level -> ext2/secret.txt (below the old depth bound).
+	if err := os.Symlink(secret, filepath.Join(deep, "pivot.md")); err != nil {
+		t.Fatal(err)
+	}
+	// Corpus symlink -> external subtree root.
+	if err := os.Symlink(external, filepath.Join(agents, "learnings")); err != nil {
+		t.Fatal(err)
+	}
+	wantTarget, err := filepath.EvalSymlinks(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deny, err := corpusDenyPaths(root)
+	if err != nil {
+		t.Fatalf("corpusDenyPaths must not error on a deep-but-small subtree (complete closure, not refuse): %v", err)
+	}
+	if joined := strings.Join(deny, "|"); !strings.Contains(joined, wantTarget) {
+		t.Fatalf("deep-under-cap pivot target %q must be in the closure (validator's silent-truncation leak); got %s", wantTarget, joined)
+	}
+}
+
 // TestSymlinkClosureDenyTargets_CycleTerminates (age-6j9ee.3): a symlink cycle
 // a/link -> b, b/link -> a must terminate (no infinite loop, no error) and deny both
 // canonical directory targets. Termination is proven by the test completing; the
@@ -341,7 +392,7 @@ func TestSymlinkClosureDenyTargets_CycleTerminates(t *testing.T) {
 	if err := os.Symlink(a, filepath.Join(b, "link")); err != nil {
 		t.Fatal(err) // b/link -> a (cycle)
 	}
-	got, err := symlinkClosureDenyTargets([]string{a}, maxSymlinkClosureDirs, maxSymlinkDenyEntries, maxSymlinkWalkDepth)
+	got, err := symlinkClosureDenyTargets([]string{a}, maxSymlinkClosureDirs, maxSymlinkDenyEntries)
 	if err != nil {
 		t.Fatalf("cycle must not error: %v", err)
 	}
@@ -370,7 +421,7 @@ func TestSymlinkClosureDenyTargets_DirOverflowFailsClosed(t *testing.T) {
 	if err := os.Symlink(external, filepath.Join(root, "escape")); err != nil {
 		t.Fatal(err)
 	}
-	got, err := symlinkClosureDenyTargets([]string{root}, 2, maxSymlinkDenyEntries, maxSymlinkWalkDepth)
+	got, err := symlinkClosureDenyTargets([]string{root}, 2, maxSymlinkDenyEntries)
 	if err == nil {
 		t.Fatalf("oversized external tree must fail closed; got %d entries, nil error", len(got))
 	}
@@ -396,12 +447,44 @@ func TestSymlinkClosureDenyTargets_EntryOverflowFailsClosed(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	got, err := symlinkClosureDenyTargets([]string{root}, maxSymlinkClosureDirs, 1, maxSymlinkWalkDepth)
+	got, err := symlinkClosureDenyTargets([]string{root}, maxSymlinkClosureDirs, 1)
 	if err == nil {
 		t.Fatalf("exceeding the entry cap must fail closed; got %d entries, nil error", len(got))
 	}
 	if !errors.Is(err, errSymlinkClosureOverflow) {
 		t.Fatalf("want errSymlinkClosureOverflow; got %v", err)
+	}
+}
+
+// TestSymlinkClosureDenyTargets_DeepOnlyGraphTerminatesViaDirCap (age-6j9ee.3): with the
+// depth bound REMOVED, the dir cap + seen-set are the SOLE termination guards. This proves
+// the reason a depth bound used to exist is covered: a pathological DEPTH-only external graph
+// — a long linear chain of real dirs, one dir per level (exactly the shape a depth cap would
+// have cut, silently hiding anything beyond it) — must still TERMINATE, by tripping the dir
+// cap and failing closed rather than descending without bound. Termination is proven by the
+// call returning at all; the overflow assertion proves it is bounded, not merely finite.
+func TestSymlinkClosureDenyTargets_DeepOnlyGraphTerminatesViaDirCap(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+	deep := external
+	for i := 0; i < 10; i++ { // linear chain: exactly one dir per level, 10 levels deep
+		deep = filepath.Join(deep, fmt.Sprintf("d%d", i))
+	}
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(root, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	// maxDirs=3: the 11-dir-deep external chain (external + d0..d9) exceeds the dir cap and
+	// fails closed. Depth is no longer a special case — a deep-only shape is bounded by the
+	// same dir cap that bounds a wide fan-out.
+	got, err := symlinkClosureDenyTargets([]string{root}, 3, maxSymlinkDenyEntries)
+	if !errors.Is(err, errSymlinkClosureOverflow) {
+		t.Fatalf("deep-only external chain must terminate by failing closed via the dir cap; got err=%v entries=%v", err, got)
+	}
+	if got != nil {
+		t.Errorf("fail-closed must return a nil set (never a partial one); got %v", got)
 	}
 }
 
@@ -584,6 +667,65 @@ func TestWorkspaceCommandRunner_Integration_ControlArmDeniesChainedSymlinkRead(t
 	}
 	if strings.Contains(stdout, "CHAINED-FINAL-CORPUS-SECRET") {
 		t.Fatalf("control arm leaked corpus bytes via chained symlink: stdout=%q", stdout)
+	}
+}
+
+// TestWorkspaceCommandRunner_Integration_ControlArmDeniesDeepUnderCapSymlinkRead
+// (age-6j9ee.3, darwin, the silent-truncation vector RUN): the validator's exact leak end
+// to end — .agents/learnings -> external; external/d0/.../d11/pivot.md -> ext2/secret.txt,
+// with the pivot BELOW the old depth-8 bound but the subtree UNDER the dir/entry caps. The
+// old depth cap SkipDir'd before the pivot, so its target escaped the deny set and the
+// control arm read it (exit 0, leaked). With the depth bound removed, the closure denies the
+// deep pivot's canonical target, so the read is now DENIED (nonzero exit, zero corpus bytes).
+func TestWorkspaceCommandRunner_Integration_ControlArmDeniesDeepUnderCapSymlinkRead(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only: macOS Seatbelt sandbox-exec integration")
+	}
+	if _, err := os.Stat(macOSSandboxExec); err != nil {
+		t.Skipf("sandbox-exec unavailable: %v", err)
+	}
+
+	root := t.TempDir()
+	agents := filepath.Join(root, ".agents")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	external := t.TempDir()
+	deep := external
+	for i := 0; i < 12; i++ { // 12 levels deep (> old depth bound 8), ~13 dirs total (< cap)
+		deep = filepath.Join(deep, fmt.Sprintf("d%d", i))
+	}
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ext2 := t.TempDir()
+	secret := filepath.Join(ext2, "secret.txt")
+	if err := os.WriteFile(secret, []byte("VALIDATOR-DEEP-UNDER-CAP-SECRET"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(deep, "pivot.md")); err != nil {
+		t.Fatal(err) // deep/pivot.md -> ext2/secret.txt (below the old depth bound)
+	}
+	if err := os.Symlink(external, filepath.Join(agents, "learnings")); err != nil {
+		t.Fatal(err) // .agents/learnings -> external
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Chdir(root)
+	workDir := t.TempDir()
+
+	resolved, err := filepath.EvalSymlinks(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, exitCode, err := defaultWorkspaceCommandRunner(context.Background(), workDir, "cat "+resolved, false)
+	if err != nil {
+		t.Fatalf("runner returned a Go error (want a denied read = nonzero exit): %v", err)
+	}
+	if exitCode == 0 {
+		t.Fatalf("control arm read deep-under-cap pivot target (isolation void; silent truncation): exit=0 stdout=%q", stdout)
+	}
+	if strings.Contains(stdout, "VALIDATOR-DEEP-UNDER-CAP-SECRET") {
+		t.Fatalf("control arm leaked corpus bytes via deep-under-cap symlink: stdout=%q", stdout)
 	}
 }
 

--- a/cli/internal/adapters/eval/scenario_ab_sandbox_test.go
+++ b/cli/internal/adapters/eval/scenario_ab_sandbox_test.go
@@ -145,6 +145,76 @@ func TestLocalCorpusDenyPaths_AbsoluteOutsideRoot(t *testing.T) {
 	}
 }
 
+// TestCorpusDenyPaths_NestedSymlinkTargetDenied (age-6j9ee.3, construction, no GOOS
+// skip): a directory symlink INSIDE a corpus root (.agents/learnings -> /external)
+// canonicalizes outside the (subpath .agents) deny, so its resolved target must be
+// added to the deny set. A top-level resolveSymlink on .agents never reaches it.
+func TestCorpusDenyPaths_NestedSymlinkTargetDenied(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	agents := filepath.Join(root, ".agents")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	external := t.TempDir()
+	if err := os.WriteFile(filepath.Join(external, "secret.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(agents, "learnings")); err != nil {
+		t.Fatal(err)
+	}
+	// Seatbelt matches the canonical path, so assert against the resolved target.
+	wantTarget, err := filepath.EvalSymlinks(external)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(corpusDenyPaths(root), "|")
+	if !strings.Contains(joined, wantTarget) {
+		t.Fatalf("nested symlink target %q must be in the deny set; got %s", wantTarget, joined)
+	}
+}
+
+// TestWorkspaceCommandRunner_Integration_ControlArmDeniesNestedSymlinkRead
+// (age-6j9ee.3, darwin): a control-arm command reading THROUGH a nested corpus symlink
+// (.agents/learnings -> /external) must be DENIED — the read canonicalizes to the
+// external target, which the nested-symlink walk added to the deny set.
+func TestWorkspaceCommandRunner_Integration_ControlArmDeniesNestedSymlinkRead(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only: macOS Seatbelt sandbox-exec integration")
+	}
+	if _, err := os.Stat(macOSSandboxExec); err != nil {
+		t.Skipf("sandbox-exec unavailable: %v", err)
+	}
+
+	root := t.TempDir()
+	agents := filepath.Join(root, ".agents")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	external := t.TempDir()
+	if err := os.WriteFile(filepath.Join(external, "sentinel.txt"), []byte("NESTED-CORPUS-SECRET"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(agents, "learnings")
+	if err := os.Symlink(external, link); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Chdir(root)
+	workDir := t.TempDir()
+
+	stdout, exitCode, err := defaultWorkspaceCommandRunner(context.Background(), workDir, "cat "+filepath.Join(link, "sentinel.txt"), false)
+	if err != nil {
+		t.Fatalf("runner returned a Go error (want a denied read = nonzero exit): %v", err)
+	}
+	if exitCode == 0 {
+		t.Fatalf("control arm read through nested corpus symlink (isolation void): exit=0 stdout=%q", stdout)
+	}
+	if strings.Contains(stdout, "NESTED-CORPUS-SECRET") {
+		t.Fatalf("control arm leaked corpus bytes via nested symlink: stdout=%q", stdout)
+	}
+}
+
 // TestSandboxExecDenyProfile_DeniesAllPaths: every deny path appears in a
 // (deny file-read* (subpath ...)) clause, and non-corpus reads remain allowed.
 func TestSandboxExecDenyProfile_DeniesAllPaths(t *testing.T) {

--- a/cli/internal/adapters/eval/scenario_ab_sandbox_test.go
+++ b/cli/internal/adapters/eval/scenario_ab_sandbox_test.go
@@ -174,6 +174,103 @@ func TestCorpusDenyPaths_NestedSymlinkTargetDenied(t *testing.T) {
 	}
 }
 
+// TestCorpusDenyPaths_NestedFileSymlinkTargetDenied (age-6j9ee.3, construction, no
+// GOOS skip): a FILE symlink INSIDE a corpus root (.agents/note.md -> /external/secret.txt)
+// canonicalizes outside the (subpath .agents) deny, so its resolved file target must be
+// added to the deny set. The nested walk previously only appended DIRECTORY targets, so
+// a file symlink's target was silently dropped and stayed readable by the control arm.
+func TestCorpusDenyPaths_NestedFileSymlinkTargetDenied(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	agents := filepath.Join(root, ".agents")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	external := t.TempDir()
+	secretFile := filepath.Join(external, "secret.txt")
+	if err := os.WriteFile(secretFile, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secretFile, filepath.Join(agents, "note.md")); err != nil {
+		t.Fatal(err)
+	}
+	// Seatbelt matches the canonical path, so assert against the resolved file target.
+	wantTarget, err := filepath.EvalSymlinks(secretFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(corpusDenyPaths(root), "|")
+	if !strings.Contains(joined, wantTarget) {
+		t.Fatalf("nested FILE symlink target %q must be in the deny set; got %s", wantTarget, joined)
+	}
+}
+
+// TestNestedSymlinkDenyTargets_SkipsDanglingSymlink (age-6j9ee.3): a dangling nested
+// symlink (target does not exist) resolves to nothing via EvalSymlinks and must be
+// skipped without error, contributing no deny path.
+func TestNestedSymlinkDenyTargets_SkipsDanglingSymlink(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Symlink(filepath.Join(root, "does-not-exist"), filepath.Join(root, "dangling")); err != nil {
+		t.Fatal(err)
+	}
+	if got := nestedSymlinkDenyTargets(root); len(got) != 0 {
+		t.Errorf("dangling symlink must contribute no deny target; got %v", got)
+	}
+}
+
+// TestWorkspaceCommandRunner_Integration_ControlArmDeniesNestedFileSymlinkRead
+// (age-6j9ee.3, darwin): replicates the cross-family validator's probe EXACTLY — a
+// control-arm command reading THROUGH a nested corpus FILE symlink
+// (.agents/note.md -> <external secret file>) must be DENIED. Before the fix the read
+// returned exit 0 and leaked the secret; after, the read canonicalizes to the external
+// file target the nested-symlink walk now adds to the deny set.
+func TestWorkspaceCommandRunner_Integration_ControlArmDeniesNestedFileSymlinkRead(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only: macOS Seatbelt sandbox-exec integration")
+	}
+	if _, err := os.Stat(macOSSandboxExec); err != nil {
+		t.Skipf("sandbox-exec unavailable: %v", err)
+	}
+
+	root := t.TempDir()
+	agents := filepath.Join(root, ".agents")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	external := t.TempDir()
+	secretFile := filepath.Join(external, "secret.txt")
+	if err := os.WriteFile(secretFile, []byte("NESTED-FILE-CORPUS-SECRET"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(agents, "note.md")
+	if err := os.Symlink(secretFile, link); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Chdir(root)
+	workDir := t.TempDir()
+
+	// The real leak: the corpus reader RESOLVES the symlink and reads the canonical
+	// target path (a plain read of .agents/note.md is denied because the symlink NODE
+	// sits under the denied .agents subpath, masking the escape; reading the resolved
+	// target is what leaked with exit 0 — the validator's observed vector). Reading the
+	// canonical target must be denied because the nested-symlink walk added it.
+	resolved, err := filepath.EvalSymlinks(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, exitCode, err := defaultWorkspaceCommandRunner(context.Background(), workDir, "cat "+resolved, false)
+	if err != nil {
+		t.Fatalf("runner returned a Go error (want a denied read = nonzero exit): %v", err)
+	}
+	if exitCode == 0 {
+		t.Fatalf("control arm read canonical target of nested corpus FILE symlink (isolation void): exit=0 stdout=%q", stdout)
+	}
+	if strings.Contains(stdout, "NESTED-FILE-CORPUS-SECRET") {
+		t.Fatalf("control arm leaked corpus bytes via nested FILE symlink target: stdout=%q", stdout)
+	}
+}
+
 // TestWorkspaceCommandRunner_Integration_ControlArmDeniesNestedSymlinkRead
 // (age-6j9ee.3, darwin): a control-arm command reading THROUGH a nested corpus symlink
 // (.agents/learnings -> /external) must be DENIED — the read canonicalizes to the


### PR DESCRIPTION
Eval-remediation epic age-6j9ee, final bead (5 commits). (1) Redactor wired on model egress: worker-command stdout redacted before entering agentic history/prompts + judge path. (2) Corpus-deny Seatbelt is now a FIXPOINT CLOSURE with fail-closed overflow — resolves file+dir+chained+deep symlink targets to a complete closure, or refuses the arm (dir/entry caps 1024/2048, no silent truncation; depth bound removed as redundant + itself a leak vector). (3) Holdout burn ledger via storage.AtomicWriteFile (0600, fresh temp, chmod, fsync — immune to stale-tmp mode bleed; was unconditionally 0644). Sol REJECTED 4x across the symlink class (dir-only → chained → depth-truncation → then the separate ledger stale-tmp) — each a real escape, converged to a complete-closure proof; final Sol ACCEPT. Full gate 67/67; uncapped errorlint+unused 0. FF-push. Known pre-existing PR-CI red: age-sqjyl.