### PR TITLE
fix(cli): ao init creates the complete evidence layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ before upgrading.
 
 ### Fixed
 
+- `ao init` creates the complete evidence layout — both loop-evidence stores
+  `ao status` reads (intents, verdicts) and the sessions/index/provenance
+  substructure `ao doctor` enforces — so a fresh init is never flagged
+  incomplete by the CLI's own diagnostics.
 - `ao doctor` is now a fast installation-health check over binary identity,
   exact source-skill links, optional provenance integrity, and host safety. It
   no longer implicitly runs the 3.2 plugin/tracker/reviewer/fixer diagnostics,

--- a/cli/internal/initapp/initapp.go
+++ b/cli/internal/initapp/initapp.go
@@ -10,12 +10,21 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/boshu2/agentops/cli/internal/storage"
 )
 
 // evidenceDirs is the fixed, ordered set of local directories `ao init` creates.
+// It must cover both loop-evidence stores `ao status` reads (intents, verdicts)
+// and the knowledge-store substructure `ao doctor` enforces (the storage
+// package's sessions/index/provenance contract), so a fresh init is never
+// flagged incomplete by the CLI's own diagnostics.
 var evidenceDirs = []string{
-	filepath.Join(".agents", "ao", "verdicts", "sha256"),
-	filepath.Join(".agents", "ao", "provenance"),
+	filepath.Join(storage.DefaultBaseDir, "intents", "sha256"),
+	filepath.Join(storage.DefaultBaseDir, "verdicts", "sha256"),
+	filepath.Join(storage.DefaultBaseDir, storage.SessionsDir),
+	filepath.Join(storage.DefaultBaseDir, storage.IndexDir),
+	filepath.Join(storage.DefaultBaseDir, storage.ProvenanceDir),
 	filepath.Join(".agents", "handoff"),
 }
 

--- a/cli/internal/initapp/initapp_test.go
+++ b/cli/internal/initapp/initapp_test.go
@@ -1,0 +1,63 @@
+package initapp
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/storage"
+)
+
+// A fresh `ao init` must satisfy the CLI's own diagnostics: the knowledge-store
+// substructure doctor enforces (storage sessions/index/provenance contract) and
+// both loop-evidence stores status reads (intents, verdicts). Regression guard
+// for the 3.3 audit finding where doctor flagged a just-initialized store.
+func TestRun_CreatesLayoutSatisfyingDoctorAndStatusContracts(t *testing.T) {
+	t.Chdir(t.TempDir())
+	var out bytes.Buffer
+
+	if err := Run(RunOptions{Stdout: &out}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mustBeDir := func(rel string) {
+		t.Helper()
+		info, err := os.Stat(rel)
+		if err != nil || !info.IsDir() {
+			t.Errorf("init did not create directory %s (err=%v)", rel, err)
+		}
+	}
+
+	// Doctor's knowledge-store contract: sessions/index/provenance under the
+	// storage base (fm-knowledge-missing-substructure fires on any missing one).
+	for _, sub := range []string{storage.SessionsDir, storage.IndexDir, storage.ProvenanceDir} {
+		mustBeDir(filepath.Join(storage.DefaultBaseDir, sub))
+	}
+	// Status's loop-evidence stores: intents and verdicts content stores.
+	mustBeDir(filepath.Join(storage.DefaultBaseDir, "intents", "sha256"))
+	mustBeDir(filepath.Join(storage.DefaultBaseDir, "verdicts", "sha256"))
+	// Session handoff evidence directory.
+	mustBeDir(filepath.Join(".agents", "handoff"))
+
+	if got := strings.Count(out.String(), "created "); got != len(evidenceDirs) {
+		t.Errorf("expected %d 'created' lines, got %d:\n%s", len(evidenceDirs), got, out.String())
+	}
+}
+
+func TestRun_DryRunCreatesNothing(t *testing.T) {
+	t.Chdir(t.TempDir())
+	var out bytes.Buffer
+
+	if err := Run(RunOptions{DryRun: true, Stdout: &out}); err != nil {
+		t.Fatalf("Run dry-run: %v", err)
+	}
+
+	if got := strings.Count(out.String(), "would create "); got != len(evidenceDirs) {
+		t.Errorf("expected %d 'would create' lines, got %d:\n%s", len(evidenceDirs), got, out.String())
+	}
+	if _, err := os.Stat(".agents"); !os.IsNotExist(err) {
+		t.Errorf("dry-run created .agents (stat err=%v); want nothing on disk", err)
+	}
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,10 @@ before upgrading.
 
 ### Fixed
 
+- `ao init` creates the complete evidence layout — both loop-evidence stores
+  `ao status` reads (intents, verdicts) and the sessions/index/provenance
+  substructure `ao doctor` enforces — so a fresh init is never flagged
+  incomplete by the CLI's own diagnostics.
 - `ao doctor` is now a fast installation-health check over binary identity,
   exact source-skill links, optional provenance integrity, and host safety. It
   no longer implicitly runs the 3.2 plugin/tracker/reviewer/fixer diagnostics,


### PR DESCRIPTION
A fresh `ao init` was immediately flagged by the CLI's own diagnostics — `ao doctor diff` reported `fm-knowledge-missing-substructure` (sessions, index missing) and the `.agents/ao/intents/sha256` store that `ao status` reads was never created. This was the last first-run wart from the [3.3 release-readiness audit](docs/audits/release-readiness-3.3-2026-07-20.md) (agents-runtime minor 3).

**Fix:** `evidenceDirs` now derives the knowledge substructure from the storage package's exported contract (`DefaultBaseDir` + `SessionsDir`/`IndexDir`/`ProvenanceDir`) instead of a parallel hand-list, and adds the intents store — so init, status, and doctor agree on one layout by construction.

**Verified:** RED reproduced in a sandbox (P2 finding on fresh init), GREEN after fix (finding gone, status reads both stores); new initapp tests assert both contracts on the created tree and that dry-run touches nothing; full suite 61/61 packages; `ao gate check --full` 67/67 over this range.