### PR TITLE
fix(storage): searchindex retros typing, quote-trim order, surfaced walk errors

### DIFF
--- a/cli/internal/storage/searchindex.go
+++ b/cli/internal/storage/searchindex.go
@@ -58,11 +58,17 @@ type SearchIndexStats struct {
 // ArtifactSubdirs lists the subdirectories under .agents/ that contain indexable artifacts.
 var ArtifactSubdirs = []string{"learnings", "patterns", "research", "retros", "candidates"}
 
-// WalkIndexableFiles returns all .md and .jsonl files under dir.
+// WalkIndexableFiles returns all .md and .jsonl files under dir. A walk error
+// (for example, a missing root or an unreadable subdirectory) is surfaced to
+// the caller rather than swallowed, so an empty result unambiguously means
+// "no indexable files" instead of masking a failed traversal.
 func WalkIndexableFiles(dir string) ([]string, error) {
 	var files []string
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
 			return nil
 		}
 		if strings.HasSuffix(path, ".md") || strings.HasSuffix(path, ".jsonl") {
@@ -82,6 +88,7 @@ func ArtifactTypeFromPath(path string) string {
 		{"/learnings/", "learning"},
 		{"/patterns/", "pattern"},
 		{"/research/", "research"},
+		{"/retros/", "retro"},
 		{"/retro/", "retro"},
 		{"/candidates/", "candidate"},
 	}
@@ -215,7 +222,7 @@ func ParseBracketedList(s string) []string {
 	inner := strings.TrimSuffix(strings.TrimPrefix(s, "["), "]")
 	var out []string
 	for _, t := range strings.Split(inner, ",") {
-		tt := strings.TrimSpace(strings.Trim(t, "\"'"))
+		tt := strings.Trim(strings.TrimSpace(t), "\"'")
 		if tt != "" {
 			out = append(out, tt)
 		}

--- a/cli/internal/storage/searchindex_test.go
+++ b/cli/internal/storage/searchindex_test.go
@@ -58,16 +58,13 @@ func TestWalkIndexableFiles(t *testing.T) {
 	}
 }
 
-func TestWalkIndexableFiles_MissingDirSwallowsError(t *testing.T) {
-	// Documents current behavior: the walkFn returns nil on any error, so a
-	// missing root yields an empty list and a nil error rather than surfacing
-	// the lstat failure.
-	got, err := WalkIndexableFiles(filepath.Join(t.TempDir(), "does-not-exist"))
-	if err != nil {
-		t.Fatalf("expected nil error (errors are swallowed), got %v", err)
-	}
-	if len(got) != 0 {
-		t.Errorf("expected empty result for missing dir, got %v", got)
+func TestWalkIndexableFiles_MissingDirSurfacesError(t *testing.T) {
+	// A missing root must surface the underlying lstat failure rather than
+	// silently returning an empty list, so callers can distinguish "no
+	// indexable files" from "the directory does not exist".
+	_, err := WalkIndexableFiles(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err == nil {
+		t.Fatal("expected an error for a missing root, got nil")
 	}
 }
 
@@ -81,10 +78,10 @@ func TestArtifactTypeFromPath(t *testing.T) {
 		{"patterns", "/x/patterns/foo.md", "pattern"},
 		{"research", "/x/research/foo.md", "research"},
 		{"retro singular", "/x/retro/foo.md", "retro"},
-		// Documents a real mismatch: ArtifactSubdirs uses "retros" (plural) but
-		// ArtifactTypeFromPath only matches "/retro/", so a retros/ artifact is
-		// classified "unknown". See BUG report in the B5 handoff.
-		{"retros plural falls through", "/x/retros/foo.md", "unknown"},
+		// ArtifactSubdirs uses "retros" (plural), the real production directory
+		// name (see doctor/fix_workspace.go mapping "retros" -> "retro"), so a
+		// retros/ artifact must be typed "retro", not "unknown".
+		{"retros plural", "/x/retros/foo.md", "retro"},
 		{"candidates", "/x/candidates/foo.md", "candidate"},
 		{"unknown", "/x/misc/foo.md", "unknown"},
 	}
@@ -259,10 +256,9 @@ func TestParseBracketedList(t *testing.T) {
 		in   string
 		want []string
 	}{
-		// Trim(quotes) runs BEFORE TrimSpace, so a quote guarded by a leading
-		// space survives: " 'c'" -> Trim removes only the trailing quote -> " 'c"
-		// -> TrimSpace -> "'c". Documents that quirk (see BUG report).
-		{"quoted, spacing leaves inner quote", `["a", b, 'c']`, []string{"a", "b", "'c"}},
+		// TrimSpace runs BEFORE Trim(quotes), so a quoted token with leading
+		// space is fully unwrapped: " 'c'" -> TrimSpace -> "'c'" -> Trim -> "c".
+		{"quoted tokens fully unwrapped", `["a", b, 'c']`, []string{"a", "b", "c"}},
 		{"empty brackets", "[]", nil},
 		{"not a list", "a, b", nil},
 		{"blanks dropped", "[a, , b]", []string{"a", "b"}},


### PR DESCRIPTION
Bead age-hbbpv (epic age-uch6d, go-cli debt paydown). Fixes the 3 behavioral bugs the B5 searchindex tests pinned as current behavior, flipping each documenting test:

1. **ArtifactTypeFromPath**: `retros/` (the real production dir per ArtifactSubdirs and doctor fix_workspace mapping) now types as `retro` instead of `unknown`; singular `/retro/` retained.
2. **ParseBracketedList**: TrimSpace now runs before quote-Trim, so space-guarded quoted tokens fully unwrap (no more stray leading quote).
3. **WalkIndexableFiles**: walk errors surface instead of being swallowed — a missing root now returns the lstat failure. Zero production callers depended on the lenient contract (verified by grep); godoc documents the new contract.

Scope: exactly `cli/internal/storage/searchindex.go` + `searchindex_test.go` (+24/−21).

Validation: full suite 2758 pass; storage 164 pass; vet/lint clean; full gate 67/67 on 780591fb4; independent cross-family verdict **ACCEPT** (fresh context, adversarial probes incl. retrospectives-substring hazard and quote-nesting edges).

Lands via FF-push (repo forbids merge commits).