### PR TITLE
fix(cli): three novice-test majors — foreign-repo gates, symlinked skills, benign PATH shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,20 @@ before upgrading.
 
 ### Fixed
 
+- `ao gate check` in a repository other than agentops itself no longer fails
+  with a wall of UNKNOWN rows for agentops-internal checks: those checks skip
+  as first-class not-applicable, the human report aggregates them into one
+  honest line, and the summary now counts UNKNOWN in its own bucket so it can
+  never read all-clear while unknowns exist. Inside the agentops repo a
+  missing backing script remains fail-closed UNKNOWN.
+- `ao doctor` no longer reports a permanent false `fm-skills-missing` P1 for
+  source-linked installs: the detector follows symlinked skill directories
+  (dangling links still count as absent), matching the `ao skills link`
+  install path.
+- `ao doctor` no longer raises a P1 for benign PATH shadowing of a required
+  CLI (e.g. Homebrew git alongside Apple's `/usr/bin/git`), and the
+  missing-CLI remediation renders only when a CLI is actually missing —
+  eliminating the empty "Install the missing CLI yourself — —" template.
 - `ao init` creates the complete evidence layout — both loop-evidence stores
   `ao status` reads (intents, verdicts) and the sessions/index/provenance
   substructure `ao doctor` enforces — so a fresh init is never flagged

--- a/cli/internal/doctor/fix_cliconfig.go
+++ b/cli/internal/doctor/fix_cliconfig.go
@@ -355,11 +355,20 @@ func probeConfigSourceShape(repoRoot string) bool {
 
 const fmMissingRequiredCLI = "fm-cli-config-missing-required-cli"
 
-// missingRequiredCLIDetector flags a required external CLI absent from PATH, or
-// shadowed by a duplicate earlier on PATH. Only `git` is universally required;
-// `br` (this repo's own tracker) is required only when running inside an
-// agentops repo clone — an installed user who tracks work with `bd` (or nothing)
-// must never see `br` reported as a missing "required" CLI.
+// missingRequiredCLIDetector flags a required external CLI absent from PATH.
+// Only `git` is universally required; `br` (this repo's own tracker) is
+// required only when running inside an agentops repo clone — an installed user
+// who tracks work with `bd` (or nothing) must never see `br` reported as a
+// missing "required" CLI.
+//
+// PATH shadowing alone (multiple installs of a required CLI, the first
+// resolving fine) is NOT a failure mode: it is the default state of a macOS
+// dev machine (Homebrew git ahead of Apple's /usr/bin/git shim) and is usually
+// harmless. Any finding — even P3 — flips the doctor exit code, so a
+// shadow-only condition must stay silent on a pristine install (same policy as
+// the retired optional-codex FM below; novice-test edge 3). When a CLI is
+// genuinely missing, duplicate-resolution context still rides along in the
+// evidence query as informational detail.
 type missingRequiredCLIDetector struct{}
 
 func (missingRequiredCLIDetector) ID() string           { return fmMissingRequiredCLI }
@@ -369,7 +378,7 @@ func (missingRequiredCLIDetector) EstimatedCostMS() int { return 5 }
 func (missingRequiredCLIDetector) OnlineRequired() bool { return false }
 func (missingRequiredCLIDetector) QuickPath() bool      { return true }
 func (missingRequiredCLIDetector) Describe() string {
-	return "Detects required external CLIs (git always; br inside an agentops clone) missing from PATH or shadowed by a duplicate."
+	return "Detects required external CLIs (git always; br inside an agentops clone) missing from PATH; benign PATH shadowing alone is not flagged."
 }
 
 // Detect resolves every match for the required CLIs on PATH. It is pure:
@@ -391,18 +400,19 @@ func (missingRequiredCLIDetector) Detect(env *DetectEnv) ([]Finding, error) {
 			shadowed = append(shadowed, name+" -> "+strings.Join(resolved, ", "))
 		}
 	}
-	if len(missing) == 0 && len(shadowed) == 0 {
-		return nil, nil
-	}
-	title := "required external CLI missing from PATH"
+	// Shadow-only (nothing missing, first-resolved CLI works) is the default
+	// macOS dev-machine state — multiple installs on PATH with the first
+	// resolving first is usually harmless, so it never becomes a finding.
+	// The missing-CLI remediation template below therefore only renders when
+	// missing_clis is non-empty, with real CLI names interpolated.
 	if len(missing) == 0 {
-		title = "required external CLI shadowed by a duplicate on PATH"
+		return nil, nil
 	}
 	return []Finding{{
 		ID:         fmMissingRequiredCLI,
 		Severity:   "P1",
 		Subsystem:  "cli-config",
-		Title:      title,
+		Title:      "required external CLI missing from PATH",
 		Confidence: 1.0,
 		Evidence: Evidence{
 			Query: "missing_clis=" + strings.Join(missing, ",") +

--- a/cli/internal/doctor/fix_cliconfig_test.go
+++ b/cli/internal/doctor/fix_cliconfig_test.go
@@ -306,6 +306,99 @@ func TestCliConfigMissingRequiredCLI_SymlinkEquivalentPathIsNotShadowed(t *testi
 	}
 }
 
+// Two REAL duplicate git installs on PATH (the Homebrew-git-ahead-of-Apple-shim
+// shape) with nothing missing is the DEFAULT state of a macOS dev machine.
+// Shadow-only must not produce a finding at all: the first-resolved CLI works,
+// so this is usually harmless, and any finding here would flip the doctor exit
+// code on every pristine Mac (novice-test edge 3).
+func TestCliConfigMissingRequiredCLI_ShadowOnlyDuplicateGitIsNotAFinding(t *testing.T) {
+	tmp := t.TempDir()
+	brewbin := filepath.Join(tmp, "opt", "homebrew", "bin")
+	usrbin := filepath.Join(tmp, "usr", "bin")
+	for _, dir := range []string{brewbin, usrbin} {
+		p := filepath.Join(dir, "git")
+		writeFile(t, p, "#!/bin/sh\nexit 0\n")
+		if err := os.Chmod(p, 0o755); err != nil {
+			t.Fatalf("chmod: %v", err)
+		}
+	}
+	t.Setenv("PATH", brewbin+string(os.PathListSeparator)+usrbin)
+
+	fs, err := missingRequiredCLIDetector{}.Detect(&DetectEnv{})
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if len(fs) != 0 {
+		t.Fatalf("shadow-only duplicate git must yield 0 findings, got %d: %+v", len(fs), fs)
+	}
+}
+
+// A genuinely missing CLI must render the missing-CLI remediation with the
+// actual CLI name interpolated — never the empty-slot "yourself —  — then"
+// rendering the shadow-only case used to produce (novice-test edge 3b).
+func TestCliConfigMissingRequiredCLI_MissingRemediationNamesTheCLI(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PATH", filepath.Join(tmp, "empty"))
+
+	fs, err := missingRequiredCLIDetector{}.Detect(&DetectEnv{})
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	f := findByID(t, fs, fmMissingRequiredCLI)
+	if f.Title != "required external CLI missing from PATH" {
+		t.Errorf("Title = %q, want %q", f.Title, "required external CLI missing from PATH")
+	}
+	if !strings.Contains(f.Remediation.Command, "git:") {
+		t.Errorf("Remediation.Command lacks interpolated git install hint: %q", f.Remediation.Command)
+	}
+	if strings.Contains(f.Remediation.Command, "—  —") {
+		t.Errorf("Remediation.Command rendered an empty hint slot: %q", f.Remediation.Command)
+	}
+}
+
+// When a CLI is genuinely missing, the finding still fires as P1 and duplicate
+// evidence for another required CLI rides along in the evidence query — the
+// shadow signal is informational context, not its own failure mode.
+func TestCliConfigMissingRequiredCLI_MissingBrKeepsShadowedGitEvidence(t *testing.T) {
+	tmp := t.TempDir()
+	binA := filepath.Join(tmp, "binA")
+	binB := filepath.Join(tmp, "binB")
+	for _, dir := range []string{binA, binB} {
+		p := filepath.Join(dir, "git")
+		writeFile(t, p, "#!/bin/sh\nexit 0\n")
+		if err := os.Chmod(p, 0o755); err != nil {
+			t.Fatalf("chmod: %v", err)
+		}
+	}
+	t.Setenv("PATH", binA+string(os.PathListSeparator)+binB)
+
+	repoRoot := filepath.Join(tmp, "repo")
+	writeFakeCLIRepoRoot(t, repoRoot)
+	fs, err := missingRequiredCLIDetector{}.Detect(&DetectEnv{RepoRoot: repoRoot})
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	f := findByID(t, fs, fmMissingRequiredCLI)
+	if f.Severity != "P1" {
+		t.Errorf("Severity = %q, want P1", f.Severity)
+	}
+	if f.Title != "required external CLI missing from PATH" {
+		t.Errorf("Title = %q, want missing title even with shadow evidence", f.Title)
+	}
+	if !strings.Contains(f.Evidence.Query, "missing_clis=br") {
+		t.Errorf("Evidence.Query missing br: %q", f.Evidence.Query)
+	}
+	if !strings.Contains(f.Evidence.Query, "shadowed_clis=git -> ") {
+		t.Errorf("Evidence.Query lacks shadowed git context: %q", f.Evidence.Query)
+	}
+	if !strings.Contains(f.Remediation.Command, "beads_rust") {
+		t.Errorf("Remediation.Command lacks br install hint: %q", f.Remediation.Command)
+	}
+	if strings.Contains(f.Remediation.Command, "—  —") {
+		t.Errorf("Remediation.Command rendered an empty hint slot: %q", f.Remediation.Command)
+	}
+}
+
 func TestCliConfigMissingRequiredCLI_FixerRefuses(t *testing.T) {
 	fx := FixerByID(fmMissingRequiredCLI)
 	if fx == nil {

--- a/cli/internal/doctor/fix_skills.go
+++ b/cli/internal/doctor/fix_skills.go
@@ -89,7 +89,9 @@ func countSkillMDSubdirs(dir string) int {
 }
 
 // skillMDSubdirNames returns the sorted names of immediate subdirectories of
-// dir that contain a SKILL.md file. A missing dir yields nil.
+// dir that contain a SKILL.md file. A missing dir yields nil. Entries that are
+// symlinks are resolved (os.Stat follows links), so a symlink farm like the
+// canonical `ao skills link` layout counts; a dangling symlink does not.
 func skillMDSubdirNames(dir string) []string {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -98,7 +100,12 @@ func skillMDSubdirNames(dir string) []string {
 	var out []string
 	for _, e := range entries {
 		if !e.IsDir() {
-			continue
+			// e.IsDir is Lstat-based and false for symlinks; resolve
+			// through the link before rejecting the entry.
+			st, serr := os.Stat(filepath.Join(dir, e.Name()))
+			if serr != nil || !st.IsDir() {
+				continue
+			}
 		}
 		if st, serr := os.Stat(filepath.Join(dir, e.Name(), "SKILL.md")); serr == nil && !st.IsDir() {
 			out = append(out, e.Name())
@@ -208,7 +215,7 @@ func (d skillsMissingDetector) Detect(env *DetectEnv) ([]Finding, error) {
 		Confidence: 1.0,
 		Evidence: Evidence{
 			File:  ".claude/skills",
-			Query: "scan of 4 SkillInstallDirs found 0 SKILL.md subdirs: " + strings.Join(scanned, " "),
+			Query: "scan of 4 SkillInstallDirs (symlinked entries resolved) found 0 SKILL.md subdirs: " + strings.Join(scanned, " "),
 		},
 		Remediation: remediation(d.ID(), autoFixable, countSkillMDSubdirs(src)),
 	}}, nil

--- a/cli/internal/doctor/fix_skills_test.go
+++ b/cli/internal/doctor/fix_skills_test.go
@@ -344,6 +344,73 @@ func TestSkillsMissingNoFindingWhenPopulated(t *testing.T) {
 	}
 }
 
+// TestSkillsMissingSymlinkResolution verifies the detector counts a skill as
+// present when the install-dir entry is a symlink that resolves to a directory
+// containing SKILL.md (the canonical `ao skills link` layout), while a dangling
+// symlink still counts as absent.
+func TestSkillsMissingSymlinkResolution(t *testing.T) {
+	cases := []struct {
+		name         string
+		populate     func(t *testing.T, home string)
+		wantFindings int
+	}{
+		{
+			name: "real dir with SKILL.md counts as present",
+			populate: func(t *testing.T, home string) {
+				writeSkillsFile(t, filepath.Join(home, ".agents", "skills", "rpi", "SKILL.md"), "x\n")
+			},
+			wantFindings: 0,
+		},
+		{
+			name: "symlink resolving to dir with SKILL.md counts as present",
+			populate: func(t *testing.T, home string) {
+				src := filepath.Join(home, "checkout", "skills", "rpi")
+				writeSkillsFile(t, filepath.Join(src, "SKILL.md"), "x\n")
+				install := filepath.Join(home, ".agents", "skills")
+				if err := os.MkdirAll(install, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(src, filepath.Join(install, "rpi")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantFindings: 0,
+		},
+		{
+			name: "dangling symlink still counts as absent",
+			populate: func(t *testing.T, home string) {
+				install := filepath.Join(home, ".agents", "skills")
+				if err := os.MkdirAll(install, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				gone := filepath.Join(home, "checkout", "skills", "gone")
+				if err := os.Symlink(gone, filepath.Join(install, "rpi")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantFindings: 1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			home := t.TempDir()
+			tc.populate(t, home)
+			env := &DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: home}
+			findings, err := skillsMissingDetector{}.Detect(env)
+			if err != nil {
+				t.Fatalf("Detect: %v", err)
+			}
+			if len(findings) != tc.wantFindings {
+				t.Fatalf("findings = %d, want %d: %+v", len(findings), tc.wantFindings, findings)
+			}
+			if tc.wantFindings == 1 && findings[0].ID != "fm-skills-missing" {
+				t.Fatalf("finding ID = %q, want fm-skills-missing", findings[0].ID)
+			}
+		})
+	}
+}
+
 // --- fm-skills-integrity-hygiene -------------------------------------------
 
 // TestSkillsIntegrityHygieneFixer verifies the partial fixer appends a link for

--- a/cli/internal/gates/applicability.go
+++ b/cli/internal/gates/applicability.go
@@ -1,0 +1,46 @@
+package gates
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// agentopsCLIModulePath is the module path declared by the agentops repo's own
+// CLI module. Its presence at <root>/cli/go.mod is the deterministic
+// "this IS the agentops repo" marker used by NotApplicableOutsideAgentOps.
+const agentopsCLIModulePath = "github.com/boshu2/agentops/cli"
+
+// NotApplicableReason is the first-class SKIP reason emitted when an
+// agentops-internal check runs in a foreign repository whose tree does not
+// contain the check's backing artifact. Report aggregation keys on this exact
+// string, so it is a single shared constant.
+const NotApplicableReason = "not applicable: agentops-repo check; backing artifact not present in this repository"
+
+// IsAgentOpsRepo reports whether root is the agentops repository itself.
+//
+// Marker: <root>/cli/go.mod whose `module` directive is exactly
+// github.com/boshu2/agentops/cli. This is unambiguous (module paths are
+// globally unique by convention and this one names the agentops repo),
+// deterministic (a plain tracked file, present in every checkout and linked
+// worktree), and cheap (one bounded file read). It deliberately does NOT use
+// git metadata (remotes can be renamed or absent) or the presence of scripts/
+// (which is exactly what a foreign repo may or may not have).
+//
+// Inside the agentops repo a missing backing script stays UNKNOWN and
+// fail-closed — that guard protects agentops CI from silently losing a gate.
+// Outside it, the same condition is a first-class not-applicable SKIP
+// (see ScriptRunner.Run).
+func IsAgentOpsRepo(root string) bool {
+	raw, err := os.ReadFile(filepath.Join(root, "cli", "go.mod"))
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		line = strings.TrimSpace(line)
+		if rest, ok := strings.CutPrefix(line, "module "); ok {
+			return strings.TrimSpace(rest) == agentopsCLIModulePath
+		}
+	}
+	return false
+}

--- a/cli/internal/gates/applicability_test.go
+++ b/cli/internal/gates/applicability_test.go
@@ -1,0 +1,211 @@
+package gates
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/boshu2/agentops/cli/internal/ports"
+)
+
+func TestIsAgentOpsRepo(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, root string)
+		want  bool
+	}{
+		{name: "empty dir is foreign", setup: func(*testing.T, string) {}, want: false},
+		{name: "agentops marker", setup: writeAgentopsMarker, want: true},
+		{
+			name: "cli/go.mod with a different module is foreign",
+			setup: func(t *testing.T, root string) {
+				if err := os.MkdirAll(filepath.Join(root, "cli"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(root, "cli", "go.mod"), []byte("module example.com/other/cli\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: false,
+		},
+		{
+			name: "root go.mod alone is not the marker",
+			setup: func(t *testing.T, root string) {
+				if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module "+agentopsCLIModulePath+"\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			tc.setup(t, root)
+			if got := IsAgentOpsRepo(root); got != tc.want {
+				t.Fatalf("IsAgentOpsRepo(%s) = %v, want %v", root, got, tc.want)
+			}
+		})
+	}
+}
+
+// foreignRepoRegistry mirrors the real always-run shape: a blocking
+// script-backed structural check plus a native check that is applicable in any
+// repo (the constraints.enforce analogue).
+func foreignRepoRegistry(t *testing.T) *Registry {
+	t.Helper()
+	r := NewRegistry()
+	for _, c := range []Check{
+		{ID: "always.agentops-internal", Tiers: Fast | Full, Blocking: true, Backing: "check-agentops-internal.sh"},
+		{ID: "native.portable", Tiers: Fast | Full, Blocking: true, Run: func(context.Context, RunContext) (ports.GateVerdict, error) {
+			return ports.GateVerdict{Status: ports.GateStatusPass, Reason: "ok"}, nil
+		}},
+	} {
+		if err := r.Add(c); err != nil {
+			t.Fatalf("Add(%s): %v", c.ID, err)
+		}
+	}
+	return r
+}
+
+// runForeignRepoOrchestrator is the L2 entry point: a real orchestrator over a
+// real ScriptRunner rooted at root, fast mode, no changed files.
+func runForeignRepoOrchestrator(t *testing.T, root string) *Report {
+	t.Helper()
+	o := NewOrchestrator(foreignRepoRegistry(t), NewScriptRunner(root), fakeFiles{}, root)
+	rep, err := o.Run(context.Background(), RunOptions{Mode: Fast, Scope: ScopeHead})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return rep
+}
+
+// TestGateCheck_ForeignRepo_NotApplicableSkip is the novice-test edge 1
+// acceptance: in a repo that is NOT the agentops repo, a script-backed
+// always-run check whose backing artifact does not exist becomes a first-class
+// not-applicable SKIP, the run passes (exit 0), the summary counts it in the
+// skip bucket, and the human report ends with one honest aggregate line.
+func TestGateCheck_ForeignRepo_NotApplicableSkip(t *testing.T) {
+	rep := runForeignRepoOrchestrator(t, t.TempDir()) // no marker: foreign repo
+
+	res, ok := resultByID(rep, "always.agentops-internal")
+	if !ok {
+		t.Fatal("always-run check should still be selected and reported")
+	}
+	if res.Verdict.Status != ports.GateStatusSkip {
+		t.Fatalf("status = %s, want SKIP", res.Verdict.Status)
+	}
+	if res.Verdict.Reason != NotApplicableReason {
+		t.Fatalf("reason = %q, want %q", res.Verdict.Reason, NotApplicableReason)
+	}
+	if rep.ExitCode() != 0 {
+		t.Fatalf("ExitCode = %d, want 0 (everything else passes)", rep.ExitCode())
+	}
+	if s := rep.Summary(); s != (Summary{Total: 2, Passed: 1, Skipped: 1}) {
+		t.Fatalf("summary = %+v, want 2 total / 1 pass / 1 skip", s)
+	}
+
+	var out bytes.Buffer
+	rep.Human(&out)
+	human := out.String()
+	for _, want := range []string{
+		"2 checks — 1 pass, 0 warn, 0 fail, 0 unknown, 1 skip",
+		"1 agentops-repo checks not applicable outside the agentops repository",
+	} {
+		if !strings.Contains(human, want) {
+			t.Errorf("human output missing %q:\n%s", want, human)
+		}
+	}
+	// Foreign-repo human output aggregates not-applicable rows instead of
+	// printing them (they name backing scripts that don't exist in the user's
+	// repo); JSON keeps every row.
+	if strings.Contains(human, NotApplicableReason) {
+		t.Errorf("human output should suppress per-row not-applicable detail in a foreign repo:\n%s", human)
+	}
+	if strings.Contains(human, "skipped gates:") {
+		t.Errorf("human output should suppress the routing-skip detail block in a foreign repo:\n%s", human)
+	}
+	raw, err := rep.JSON()
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	if !strings.Contains(string(raw), NotApplicableReason) {
+		t.Errorf("JSON output must keep the not-applicable row; got:\n%s", raw)
+	}
+}
+
+// TestGateCheck_AgentopsRepo_MissingScriptStaysUnknown pins the unchanged
+// in-repo guard: with the agentops marker present but a backing script missing,
+// the check stays UNKNOWN and the blocking run still fails (exit 1) — agentops
+// CI must never silently lose a gate.
+func TestGateCheck_AgentopsRepo_MissingScriptStaysUnknown(t *testing.T) {
+	root := t.TempDir()
+	writeAgentopsMarker(t, root)
+	rep := runForeignRepoOrchestrator(t, root)
+
+	res, ok := resultByID(rep, "always.agentops-internal")
+	if !ok {
+		t.Fatal("always-run check should be reported")
+	}
+	if res.Verdict.Status != ports.GateStatusUnknown {
+		t.Fatalf("status = %s, want UNKNOWN (fail-closed inside agentops repo)", res.Verdict.Status)
+	}
+	if rep.ExitCode() != 1 {
+		t.Fatalf("ExitCode = %d, want 1 (blocking UNKNOWN fails closed)", rep.ExitCode())
+	}
+	if s := rep.Summary(); s != (Summary{Total: 2, Passed: 1, Unknown: 1}) {
+		t.Fatalf("summary = %+v, want 2 total / 1 pass / 1 unknown", s)
+	}
+
+	var out bytes.Buffer
+	rep.Human(&out)
+	human := out.String()
+	if want := "2 checks — 1 pass, 0 warn, 0 fail, 1 unknown, 0 skip"; !strings.Contains(human, want) {
+		t.Errorf("human summary missing %q:\n%s", want, human)
+	}
+	if strings.Contains(human, "not applicable outside the agentops repository") {
+		t.Errorf("in-repo run must not claim not-applicable:\n%s", human)
+	}
+}
+
+// TestReport_UnknownCountedInOwnBucket pins that UNKNOWN renders as its own
+// bucket in both the human summary line and the JSON run summary — the line can
+// never again claim all-clear while UNKNOWN results exist.
+func TestReport_UnknownCountedInOwnBucket(t *testing.T) {
+	rep := &Report{
+		Mode:      Fast,
+		Scope:     ScopeHead,
+		StartedAt: time.Unix(0, 0),
+		Results: []CheckResult{
+			{Check: Check{ID: "ok", Blocking: true}, Verdict: ports.GateVerdict{Status: ports.GateStatusPass, Reason: "ok"}},
+			{Check: Check{ID: "lost.a", Blocking: true}, Verdict: ports.GateVerdict{Status: ports.GateStatusUnknown, Reason: "no script"}},
+			{Check: Check{ID: "lost.b", Blocking: true}, Verdict: ports.GateVerdict{Status: ports.GateStatusUnknown, Reason: "no script"}},
+		},
+	}
+	if s := rep.Summary(); s != (Summary{Total: 3, Passed: 1, Unknown: 2}) {
+		t.Fatalf("summary = %+v, want 3 total / 1 pass / 2 unknown", s)
+	}
+
+	var out bytes.Buffer
+	rep.Human(&out)
+	if want := "3 checks — 1 pass, 0 warn, 0 fail, 2 unknown, 0 skip"; !strings.Contains(out.String(), want) {
+		t.Fatalf("human summary missing %q:\n%s", want, out.String())
+	}
+
+	raw, err := rep.JSON()
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	var parsed jsonReport
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.Run.Summary.Unknown != 2 {
+		t.Fatalf("json summary.unknown = %d, want 2", parsed.Run.Summary.Unknown)
+	}
+}

--- a/cli/internal/gates/orchestrator.go
+++ b/cli/internal/gates/orchestrator.go
@@ -101,6 +101,7 @@ func (o *Orchestrator) Run(ctx context.Context, opts RunOptions) (*Report, error
 		Elapsed:      o.now().Sub(started),
 		Results:      results,
 		Skipped:      skipped,
+		ForeignRepo:  !IsAgentOpsRepo(o.repoRoot),
 	}, nil
 }
 

--- a/cli/internal/gates/report.go
+++ b/cli/internal/gates/report.go
@@ -21,6 +21,11 @@ type Report struct {
 	Results      []CheckResult
 	Skipped      []SkippedCheck
 	Coverage     *WorkflowCoverage
+	// ForeignRepo is true when the run root is not the agentops repository.
+	// Human suppresses per-check agentops-internal detail there (the
+	// not-applicable rows and the routing-skip wall name backing scripts that
+	// do not exist in the user's repo); JSON always carries every row.
+	ForeignRepo bool
 }
 
 // ExitCode is 1 if any blocking check failed the run, else 0. A blocking check
@@ -59,6 +64,20 @@ func (r *Report) Summary() Summary {
 		}
 	}
 	return s
+}
+
+// NotApplicableCount tallies checks that SKIPped as not-applicable outside the
+// agentops repository (see NotApplicableReason), so Human can end the report
+// with one honest aggregate line instead of leaving N per-check SKIP rows
+// unexplained.
+func (r *Report) NotApplicableCount() int {
+	n := 0
+	for _, res := range r.Results {
+		if res.Verdict.Status == ports.GateStatusSkip && res.Verdict.Reason == NotApplicableReason {
+			n++
+		}
+	}
+	return n
 }
 
 // Summary is the per-status tally of a run.
@@ -207,10 +226,16 @@ func lastLines(s string, n int) string {
 func (r *Report) Human(w io.Writer) {
 	s := r.Summary()
 	for _, res := range r.Results {
+		if r.ForeignRepo && res.Verdict.Status == ports.GateStatusSkip && res.Verdict.Reason == NotApplicableReason {
+			continue // aggregated into the not-applicable line below
+		}
 		mark := string(res.Verdict.Status)
 		fmt.Fprintf(w, "%-5s %s%s\n", mark, res.Check.ID, humanCheckDetails(res.Check, res.SelectedReason))
 	}
-	if len(r.Skipped) > 0 {
+	// In a foreign repo the per-gate routing-skip detail names agentops-internal
+	// backing scripts that do not exist in the user's repository — noise for the
+	// novice the summary lines below already cover. JSON keeps every row.
+	if len(r.Skipped) > 0 && !r.ForeignRepo {
 		fmt.Fprintln(w, "\nskipped gates:")
 		for _, skip := range r.Skipped {
 			fmt.Fprintf(w, "SKIP  %s | %s | backing: %s | artifact: %s | repair: %s\n",
@@ -222,8 +247,14 @@ func (r *Report) Human(w io.Writer) {
 			)
 		}
 	}
-	fmt.Fprintf(w, "\n%s/%s: %d checks — %d pass, %d warn, %d fail, %d skip (%dms)\n",
-		modeString(r.Mode), r.Scope, s.Total, s.Passed, s.Warned, s.Failed, s.Skipped, r.Elapsed.Milliseconds())
+	// The summary counts UNKNOWN in its own bucket: a run with blocking
+	// UNKNOWNs exits 1, so the one-line summary must never read all-clear
+	// ("0 fail, 0 skip") while UNKNOWN rows exist above it.
+	fmt.Fprintf(w, "\n%s/%s: %d checks — %d pass, %d warn, %d fail, %d unknown, %d skip (%dms)\n",
+		modeString(r.Mode), r.Scope, s.Total, s.Passed, s.Warned, s.Failed, s.Unknown, s.Skipped, r.Elapsed.Milliseconds())
+	if n := r.NotApplicableCount(); n > 0 {
+		fmt.Fprintf(w, "%d agentops-repo checks not applicable outside the agentops repository\n", n)
+	}
 	if len(r.Skipped) > 0 {
 		fmt.Fprintf(w, "not run: %d gates (routing/tier/fail-fast)\n", len(r.Skipped))
 	}

--- a/cli/internal/gates/scriptrunner.go
+++ b/cli/internal/gates/scriptrunner.go
@@ -122,6 +122,17 @@ func (s *ScriptRunner) Run(ctx context.Context, req ports.GateRunRequest) (ports
 		script = filepath.Join(s.repoRoot, name)
 	}
 	if fi, err := os.Stat(script); err != nil || fi.IsDir() {
+		// A missing backing artifact means two different things depending on
+		// which repository the gate is running in. Inside the agentops repo it
+		// is a lost gate: stay UNKNOWN, which is fail-closed for blocking
+		// checks (isBlockingFail) and protects agentops CI. In a FOREIGN repo
+		// the agentops-internal scripts legitimately do not exist, so the
+		// check is a first-class not-applicable SKIP (novice-test edge 1:
+		// `ao gate check` in any other repo used to print ~10 blocking
+		// UNKNOWNs and exit 1).
+		if !IsAgentOpsRepo(s.repoRoot) {
+			return ports.GateVerdict{Status: ports.GateStatusSkip, Reason: NotApplicableReason}, nil
+		}
 		return ports.GateVerdict{Status: ports.GateStatusUnknown, Reason: fmt.Sprintf("no script %s", script)}, nil
 	}
 

--- a/cli/internal/gates/scriptrunner_test.go
+++ b/cli/internal/gates/scriptrunner_test.go
@@ -48,15 +48,53 @@ func writeScript(t *testing.T, root, name, body string) {
 	}
 }
 
-func TestScriptRunner_MissingScriptIsUnknown(t *testing.T) {
-	r := NewScriptRunner(t.TempDir())
-	v, err := r.Run(context.Background(), ports.GateRunRequest{Name: "does-not-exist.sh"})
-	if err != nil {
-		t.Fatalf("Run: %v", err)
+// writeAgentopsMarker stamps root with the deterministic "this IS the agentops
+// repo" marker IsAgentOpsRepo keys on: cli/go.mod declaring the agentops CLI
+// module path.
+func writeAgentopsMarker(t *testing.T, root string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, "cli"), 0o755); err != nil {
+		t.Fatalf("mkdir cli: %v", err)
 	}
-	if v.Status != ports.GateStatusUnknown {
-		t.Errorf("missing script -> %s, want UNKNOWN", v.Status)
+	gomod := "module " + agentopsCLIModulePath + "\n\ngo 1.22\n"
+	if err := os.WriteFile(filepath.Join(root, "cli", "go.mod"), []byte(gomod), 0o644); err != nil {
+		t.Fatalf("write cli/go.mod: %v", err)
 	}
+}
+
+// TestScriptRunner_MissingScript pins the two worlds a missing backing script
+// lives in: inside the agentops repo it is a lost gate (UNKNOWN, fail-closed);
+// in a foreign repo it is a first-class not-applicable SKIP (novice-test
+// edge 1 — foreign repos used to get ~10 blocking UNKNOWNs and exit 1).
+func TestScriptRunner_MissingScript(t *testing.T) {
+	t.Run("agentops repo stays UNKNOWN", func(t *testing.T) {
+		root := t.TempDir()
+		writeAgentopsMarker(t, root)
+		r := NewScriptRunner(root)
+		v, err := r.Run(context.Background(), ports.GateRunRequest{Name: "does-not-exist.sh"})
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if v.Status != ports.GateStatusUnknown {
+			t.Errorf("missing script in agentops repo -> %s, want UNKNOWN", v.Status)
+		}
+		if want := "no script " + filepath.Join(root, "scripts", "does-not-exist.sh"); v.Reason != want {
+			t.Errorf("reason = %q, want %q", v.Reason, want)
+		}
+	})
+	t.Run("foreign repo is not-applicable SKIP", func(t *testing.T) {
+		r := NewScriptRunner(t.TempDir()) // no marker: foreign repo
+		v, err := r.Run(context.Background(), ports.GateRunRequest{Name: "does-not-exist.sh"})
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if v.Status != ports.GateStatusSkip {
+			t.Errorf("missing script in foreign repo -> %s, want SKIP", v.Status)
+		}
+		if v.Reason != NotApplicableReason {
+			t.Errorf("reason = %q, want %q", v.Reason, NotApplicableReason)
+		}
+	})
 }
 
 func TestScriptRunner_PassAndFail(t *testing.T) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,20 @@ before upgrading.
 
 ### Fixed
 
+- `ao gate check` in a repository other than agentops itself no longer fails
+  with a wall of UNKNOWN rows for agentops-internal checks: those checks skip
+  as first-class not-applicable, the human report aggregates them into one
+  honest line, and the summary now counts UNKNOWN in its own bucket so it can
+  never read all-clear while unknowns exist. Inside the agentops repo a
+  missing backing script remains fail-closed UNKNOWN.
+- `ao doctor` no longer reports a permanent false `fm-skills-missing` P1 for
+  source-linked installs: the detector follows symlinked skill directories
+  (dangling links still count as absent), matching the `ao skills link`
+  install path.
+- `ao doctor` no longer raises a P1 for benign PATH shadowing of a required
+  CLI (e.g. Homebrew git alongside Apple's `/usr/bin/git`), and the
+  missing-CLI remediation renders only when a CLI is actually missing —
+  eliminating the empty "Install the missing CLI yourself — —" template.
 - `ao init` creates the complete evidence layout — both loop-evidence stores
   `ao status` reads (intents, verdicts) and the sessions/index/provenance
   substructure `ao doctor` enforces — so a fresh init is never flagged


### PR DESCRIPTION
Wave 1 of the new-user happy-path fixes (fresh-eyes novice test, follow-up to the [3.3 release audit](docs/audits/release-readiness-3.3-2026-07-20.md)).

**Edge 1 — `ao gate check` in a foreign repo.** Was: ~10 blocking UNKNOWN rows naming agentops-internal scripts, a summary that counted none of them, exit 1 — the product's own suggested next command failed in every repo but this one. Now: a deterministic repo marker (`cli/go.mod` module identity) routes those checks to first-class not-applicable SKIPs outside agentops; human output aggregates them into one honest line and suppresses the routing-skip wall (70 lines → 5); the summary counts UNKNOWN in its own bucket everywhere; `--json` keeps every row. Inside agentops, a missing backing script stays fail-closed UNKNOWN (guard pinned by test).

**Edge 2 — permanent false `fm-skills-missing` P1.** The detector's Lstat-based scan counted the canonical `ao skills link` symlink farm as zero skills. Now resolves symlinked skill dirs; dangling links still count as absent.

**Edge 3 — P1 on every default dev Mac.** Benign PATH shadowing (Homebrew git + Apple `/usr/bin/git`) raised a P1 with a broken empty-slot remediation ("Install the missing CLI yourself — —"). Shadow-only now produces no finding; the missing-CLI template renders only with real names.

**Process:** three scoped implementer agents (disjoint file ownership) + fresh adversarial verifier (4× RESOLVED, incl. dangling-symlink and genuinely-missing-CLI negative cases). **Verified:** per-fix RED→GREEN shell repros; foreign-repo first contact now 5 lines + exit 0 with JSON parity; 61/61 test pkgs; golangci-lint clean; `ao gate check --full` 67/67 over this range.