### PR TITLE
fix(cli): doctor coherence, config truthfulness, pruned-verb hints — novice edges 4/6/7/8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,19 @@ before upgrading.
 
 ### Fixed
 
+- Doctor sub-surfaces agree with each other: remediation and the
+  triage/next-steps recommendations instruct `--fix` only when a fixer can
+  actually act (non-fixable findings name their real manual action),
+  `ao doctor health` reports every severity bucket present, `ao doctor diff`
+  renders an explicit read-only fix plan, and `ao doctor explain` is a
+  superset of the finding's triage entry.
+- `ao config --show` stops rendering configuration for removed subsystems
+  (`rpi.*`, `dream.*`) and, during the legacy `~/.agentops` fallback, shows
+  the actually-read path labeled as deprecated with correct value
+  attribution. The unused `AGENTOPS_NO_SC` variable is no longer documented.
+- The pruned 3.2 bookkeeping verbs (`ao beads`, `ao wiki`, `ao ratchet`, and
+  family) now fail with a migration pointer like every other removed
+  surface, instead of a bare unknown-command error.
 - `ao gate check` in a repository other than agentops itself no longer fails
   with a wall of UNKNOWN rows for agentops-internal checks: those checks skip
   as first-class not-applicable, the human report aggregates them into one

--- a/cli/cmd/ao/config_test.go
+++ b/cli/cmd/ao/config_test.go
@@ -148,8 +148,10 @@ func TestRunConfig_ShowJSON(t *testing.T) {
 	if parsed.Output.Value == nil {
 		t.Error("expected output value in resolved config")
 	}
-	if parsed.DreamReportDir.Value == nil {
-		t.Error("expected dream_report_dir in resolved config")
+	// Removed-subsystem config (rpi.*, dream.*) must not serialize: no `ao rpi`
+	// or `ao dream` command exists in 3.3 (novice-test edge 6).
+	if strings.Contains(stdout, "dream_report_dir") || strings.Contains(stdout, "rpi_") {
+		t.Errorf("resolved config JSON leaks removed-subsystem keys:\n%s", stdout)
 	}
 }
 
@@ -181,8 +183,9 @@ func TestRunConfig_ShowTable(t *testing.T) {
 	if !strings.Contains(stdout, "output:") {
 		t.Errorf("expected 'output:' in resolved values, got: %q", stdout)
 	}
-	if !strings.Contains(stdout, "dream.report_dir:") {
-		t.Errorf("expected dream.report_dir in resolved values, got: %q", stdout)
+	// Removed-subsystem config (rpi.*, dream.*) must not render (edge 6).
+	if strings.Contains(stdout, "dream.") || strings.Contains(stdout, "rpi.") {
+		t.Errorf("resolved values render removed-subsystem keys, got: %q", stdout)
 	}
 	if !strings.Contains(stdout, "Environment variables") {
 		t.Errorf("expected 'Environment variables' section, got: %q", stdout)

--- a/cli/cmd/ao/removed_command_hint.go
+++ b/cli/cmd/ao/removed_command_hint.go
@@ -19,6 +19,16 @@ type removedCommand struct {
 	use string // what to use instead — one clause, plain words
 }
 
+// prunedFamilyHint is the shared replacement clause for the 3.2 bookkeeping
+// and knowledge family pruned from the default build without individual
+// tombstones (docs/MIGRATION.md "Other 3.2 bookkeeping and knowledge verbs").
+// There is no in-ao replacement, so every member points at the same escape
+// hatches. NOTE: `ao eval` returned in 3.3 as a live command and must never
+// appear here — cross-check any addition against the registered command tree
+// (TestHintedVerbsAreNotLiveCommands enforces this).
+const prunedFamilyHint = "it was pruned from the default build with no in-ao replacement; " +
+	"use your own tools, `ao gate check` for deterministic checks, or generic `ao provenance` records"
+
 // removedCommands maps every verb removed from the default `ao` build to its
 // replacement hint. Keep in lockstep with docs/MIGRATION.md — the drift test
 // (TestRemovedVerbsHaveMigrationRows) fails when a verb here has no row there.
@@ -42,6 +52,28 @@ var removedCommands = map[string]removedCommand{
 	"constraint": {use: "AgentOps no longer promotes findings into blocking policy; encode accepted rules in repository-owned checks"},
 	"inject":     {use: "AgentOps no longer retrieves prior knowledge; use the caller's own memory or context tooling"},
 	"verify":     {use: "the 3.2 verification front door was removed; semantic judgment is the Validate skill. If `ao verify init` installed a pre-push hook, delete the AGENTOPS-VERIFY-RATCHET block from .git/hooks/pre-push (see docs/UPGRADING.md)"},
+
+	// The pruned 3.2 bookkeeping/knowledge family — one shared clause, per the
+	// MIGRATION.md paragraph that lists them together (`eval` is deliberately
+	// absent: it returned in 3.3 as a live command).
+	"agents":    {use: prunedFamilyHint},
+	"beads":     {use: prunedFamilyHint},
+	"canon":     {use: prunedFamilyHint},
+	"ci":        {use: prunedFamilyHint},
+	"citation":  {use: prunedFamilyHint},
+	"findings":  {use: prunedFamilyHint},
+	"forge":     {use: prunedFamilyHint},
+	"knowledge": {use: prunedFamilyHint},
+	"mcp":       {use: prunedFamilyHint},
+	"metrics":   {use: prunedFamilyHint},
+	"notebook":  {use: prunedFamilyHint},
+	"patterns":  {use: prunedFamilyHint},
+	"pool":      {use: prunedFamilyHint},
+	"ratchet":   {use: prunedFamilyHint},
+	"registry":  {use: prunedFamilyHint},
+	"scope":     {use: prunedFamilyHint},
+	"sessions":  {use: prunedFamilyHint},
+	"wiki":      {use: prunedFamilyHint},
 }
 
 // removedChildCommands covers retired subcommands under retained parents.

--- a/cli/cmd/ao/removed_command_hint_test.go
+++ b/cli/cmd/ao/removed_command_hint_test.go
@@ -55,6 +55,30 @@ func TestRemovedCommandHint_TombstonedVerbs(t *testing.T) {
 				"memory or context tooling",
 			},
 		},
+		{
+			verb: "beads",
+			wantFrag: []string{
+				`"beads" was removed`,
+				"docs/MIGRATION.md",
+				"pruned from the default build with no in-ao replacement",
+			},
+		},
+		{
+			verb: "wiki",
+			wantFrag: []string{
+				`"wiki" was removed`,
+				"docs/MIGRATION.md",
+				"pruned from the default build with no in-ao replacement",
+			},
+		},
+		{
+			verb: "sessions",
+			wantFrag: []string{
+				`"sessions" was removed`,
+				"docs/MIGRATION.md",
+				"`ao provenance` records",
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.verb, func(t *testing.T) {
@@ -107,6 +131,29 @@ func TestRemovedVerbsHaveMigrationRows(t *testing.T) {
 	for verb := range removedCommands {
 		if !strings.Contains(doc, verb) {
 			t.Errorf("tombstoned verb %q has no mention in docs/MIGRATION.md — add a row or drop the tombstone", verb)
+		}
+	}
+}
+
+// TestHintedVerbsAreNotLiveCommands proves no hinted verb resolves to a live
+// registered command (name or alias) on the real root — a hint for a live verb
+// would either be suppressed at runtime (stale map) or, worse, mislabel a
+// usage error as removal. `eval` is the canonical trap: pruned in 3.2, it
+// returned in 3.3 as a live command, so it must never carry a removal hint.
+func TestHintedVerbsAreNotLiveCommands(t *testing.T) {
+	if _, hinted := removedCommands["eval"]; hinted {
+		t.Errorf(`"eval" is a live 3.3 command and must not carry a removal hint`)
+	}
+	live := map[string]string{}
+	for _, c := range rootCmd.Commands() {
+		live[c.Name()] = c.Name()
+		for _, alias := range c.Aliases {
+			live[alias] = c.Name()
+		}
+	}
+	for verb := range removedCommands {
+		if target, ok := live[verb]; ok {
+			t.Errorf("hinted verb %q resolves to live command %q — drop the hint or the command", verb, target)
 		}
 	}
 }

--- a/cli/internal/commands/config/module.go
+++ b/cli/internal/commands/config/module.go
@@ -12,8 +12,11 @@ import (
 	configapp "github.com/boshu2/agentops/cli/internal/config"
 )
 
+// showEnvironmentKeys deliberately omits AGENTOPS_NO_SC: it only toggles the
+// dead Search.UseSmartConnections config field (no consumer outside config
+// plumbing), so surfacing it would document a knob that does nothing.
 var showEnvironmentKeys = []string{
-	"AGENTOPS_CONFIG", "AGENTOPS_OUTPUT", "AGENTOPS_BASE_DIR", "AGENTOPS_VERBOSE", "AGENTOPS_NO_SC",
+	"AGENTOPS_CONFIG", "AGENTOPS_OUTPUT", "AGENTOPS_BASE_DIR", "AGENTOPS_VERBOSE",
 }
 
 var modelEnvironmentKeys = []string{"AGENTOPS_MODEL_TIER", "AGENTOPS_COUNCIL_MODEL_TIER", "COUNCIL_CLAUDE_MODEL"}
@@ -60,7 +63,11 @@ func (module Module) Command() *cobra.Command {
 		if !commandOptions.show {
 			return command.Help()
 		}
-		result, err := module.useCases.Show(command.Context(), module.host.OutputMode(), module.host.Verbose())
+		// Only attribute the output format to "flag" when -o/--json was
+		// actually passed; the host seam returns the cobra default ("table")
+		// even when no flag was set, which used to misattribute config- or
+		// default-sourced values as "(from flag)".
+		result, err := module.useCases.Show(command.Context(), outputFlagValue(command, module.host.OutputMode()), module.host.Verbose())
 		if err != nil {
 			return err
 		}
@@ -95,6 +102,18 @@ func (module Module) modelsCommand(commandOptions *options) *cobra.Command {
 	return command
 }
 
+// outputFlagValue returns the negotiated output mode only when the user
+// actually passed -o/--output or --json on the command line; otherwise it
+// returns "" so resolution falls through to env, config files, and defaults.
+func outputFlagValue(command *cobra.Command, negotiated string) string {
+	for _, name := range []string{"output", "json"} {
+		if flag := command.Flags().Lookup(name); flag != nil && flag.Changed {
+			return negotiated
+		}
+	}
+	return ""
+}
+
 func renderShow(command *cobra.Command, output string, result configapp.ShowResult) error {
 	if output == "yaml" {
 		return writeYAML(command, result.Resolved, "marshal config")
@@ -107,32 +126,31 @@ func renderShow(command *cobra.Command, output string, result configapp.ShowResu
 	fmt.Fprintln(w, "=====================")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Config files:")
-	printConfigFile(w, "Home:   ", result.ConfigFiles.HomePath, result.ConfigFiles.HomeExists)
-	printConfigFile(w, "Project:", result.ConfigFiles.ProjectPath, result.ConfigFiles.ProjectExists)
+	files := result.ConfigFiles
+	printConfigLayer(w, "Home:   ", files.HomePath, files.HomeExists, files.HomeReadPath, files.HomeLegacy)
+	printConfigLayer(w, "Project:", files.ProjectPath, files.ProjectExists, files.ProjectReadPath, files.ProjectLegacy)
 	r := result.Resolved
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Resolved values:")
 	fmt.Fprintf(w, "  output:   %v  (from %s)\n", r.Output.Value, r.Output.Source)
 	fmt.Fprintf(w, "  base_dir: %v  (from %s)\n", r.BaseDir.Value, r.BaseDir.Source)
 	fmt.Fprintf(w, "  verbose:  %v  (from %s)\n", r.Verbose.Value, r.Verbose.Source)
-	fmt.Fprintf(w, "  rpi.worktree_mode:  %v  (from %s)\n", r.RPIWorktreeMode.Value, r.RPIWorktreeMode.Source)
-	fmt.Fprintf(w, "  rpi.runtime_mode:   %v  (from %s)\n", r.RPIRuntimeMode.Value, r.RPIRuntimeMode.Source)
-	fmt.Fprintf(w, "  rpi.runtime_command: %v  (from %s)\n", r.RPIRuntimeCommand.Value, r.RPIRuntimeCommand.Source)
-	fmt.Fprintf(w, "  rpi.ao_command:     %v  (from %s)\n", r.RPIAOCommand.Value, r.RPIAOCommand.Source)
-	fmt.Fprintf(w, "  rpi.bd_command:     %v  (from %s)\n", r.RPIBDCommand.Value, r.RPIBDCommand.Source)
-	fmt.Fprintf(w, "  rpi.tmux_command:   %v  (from %s)\n", r.RPITmuxCommand.Value, r.RPITmuxCommand.Source)
-	fmt.Fprintf(w, "  dream.report_dir:   %v  (from %s)\n", r.DreamReportDir.Value, r.DreamReportDir.Source)
-	fmt.Fprintf(w, "  dream.run_timeout:  %v  (from %s)\n", r.DreamRunTimeout.Value, r.DreamRunTimeout.Source)
-	fmt.Fprintf(w, "  dream.keep_awake:   %v  (from %s)\n", r.DreamKeepAwake.Value, r.DreamKeepAwake.Source)
-	fmt.Fprintf(w, "  dream.runners:      %v  (from %s)\n", r.DreamRunners.Value, r.DreamRunners.Source)
-	fmt.Fprintf(w, "  dream.scheduler:    %v  (from %s)\n", r.DreamScheduler.Value, r.DreamScheduler.Source)
-	fmt.Fprintf(w, "  dream.schedule_at:  %v  (from %s)\n", r.DreamScheduleAt.Value, r.DreamScheduleAt.Source)
-	fmt.Fprintf(w, "  dream.consensus:    %v  (from %s)\n", r.DreamConsensus.Value, r.DreamConsensus.Source)
-	fmt.Fprintf(w, "  dream.creative:     %v  (from %s)\n", r.DreamCreativeLane.Value, r.DreamCreativeLane.Source)
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Environment variables (if set):")
 	printEnvironment(w, showEnvironmentKeys, result.Environment, "  ")
 	return nil
+}
+
+// printConfigLayer renders one config-file line. When the layer was read
+// through a deprecated legacy fallback it shows the path actually loaded,
+// labeled as deprecated, instead of reporting the canonical path as missing
+// right after the loader warned about the legacy read.
+func printConfigLayer(w interface{ Write([]byte) (int, error) }, label, path string, exists bool, readPath string, legacy bool) {
+	if legacy && readPath != "" {
+		fmt.Fprintf(w, "  ✓ %s %s (deprecated location; move to %s)\n", label, readPath, path)
+		return
+	}
+	printConfigFile(w, label, path, exists)
 }
 
 func renderModels(command *cobra.Command, output string, result configapp.ModelsResult) error {
@@ -277,7 +295,6 @@ Environment variables:
   AGENTOPS_OUTPUT     - Default output format (table, json, yaml)
   AGENTOPS_BASE_DIR   - Data directory path
   AGENTOPS_VERBOSE    - Enable verbose output (true/1)
-  AGENTOPS_NO_SC      - Disable Smart Connections (true/1)
 
 Examples:
   ao config --show           # Show resolved configuration

--- a/cli/internal/commands/config/module_test.go
+++ b/cli/internal/commands/config/module_test.go
@@ -3,9 +3,17 @@ package config
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
+	configadapter "github.com/boshu2/agentops/cli/internal/adapters/config"
 	"github.com/boshu2/agentops/cli/internal/clicontract"
 	configapp "github.com/boshu2/agentops/cli/internal/config"
 )
@@ -85,5 +93,196 @@ func TestModuleContractDeclaresConfigEffects(t *testing.T) {
 	}
 	if contract.Effects == 0 {
 		t.Fatal("config effects are undeclared")
+	}
+}
+
+// realHost returns host seams mirroring cmd/ao wiring for L2 tests.
+func realHost(outputMode string) clicontract.HostOptions {
+	return clicontract.HostOptions{
+		OutputMode: func() string { return outputMode },
+		Verbose:    func() bool { return false },
+		DryRun:     func() bool { return false },
+	}
+}
+
+// clearShowEnv blanks env vars that would leak into config resolution.
+func clearShowEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{"AGENTOPS_CONFIG", "AGENTOPS_OUTPUT", "AGENTOPS_BASE_DIR", "AGENTOPS_VERBOSE", "AGENTOPS_NO_SC"} {
+		t.Setenv(key, "")
+	}
+}
+
+// writeLegacyHome creates a sandbox HOME holding ONLY the deprecated
+// ~/.agentops/config.yaml and chdirs into an empty project dir.
+func writeLegacyHome(t *testing.T) (home, legacyPath string) {
+	t.Helper()
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir())
+	legacyPath = filepath.Join(home, ".agentops", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatalf("mkdir legacy dir: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("output: json\nbase_dir: /legacy-base\n"), 0o644); err != nil {
+		t.Fatalf("write legacy config: %v", err)
+	}
+	return home, legacyPath
+}
+
+func runRealShow(t *testing.T, outputMode string, args []string) string {
+	t.Helper()
+	command := NewModule(
+		configapp.NewCommandService(configadapter.Gateway{}),
+		realHost(outputMode),
+	).Command()
+	var stdout bytes.Buffer
+	command.SetOut(&stdout)
+	command.SetErr(&stdout)
+	command.SetArgs(args)
+	if err := command.Execute(); err != nil {
+		t.Fatalf("execute %v: %v", args, err)
+	}
+	return stdout.String()
+}
+
+// TestModuleShowLegacyFallbackTable_L2 pins novice edge 8 end to end: with
+// only the deprecated ~/.agentops/config.yaml present, the files panel names
+// the file actually read (labeled deprecated) and values loaded from it are
+// attributed to that path — not to a missing canonical file or to "flag".
+func TestModuleShowLegacyFallbackTable_L2(t *testing.T) {
+	clearShowEnv(t)
+	home, legacyPath := writeLegacyHome(t)
+
+	got := runRealShow(t, "table", []string{"--show"})
+
+	canonical := filepath.Join(home, ".agents", "ao", "config.yaml")
+	wantFiles := "  ✓ Home:    " + legacyPath + " (deprecated location; move to " + canonical + ")\n"
+	if !strings.Contains(got, wantFiles) {
+		t.Errorf("files panel missing legacy read path line %q in:\n%s", wantFiles, got)
+	}
+	if strings.Contains(got, canonical+" (not found)") {
+		t.Errorf("files panel still reports canonical home path as not found:\n%s", got)
+	}
+	if !strings.Contains(got, "output:   json  (from ~/.agentops/config.yaml (deprecated location))") {
+		t.Errorf("output value not attributed to the deprecated location:\n%s", got)
+	}
+	if !strings.Contains(got, "base_dir: /legacy-base  (from ~/.agentops/config.yaml (deprecated location))") {
+		t.Errorf("base_dir value not attributed to the deprecated location:\n%s", got)
+	}
+	if strings.Contains(got, "(from flag)") {
+		t.Errorf("no flag was passed, yet a value is attributed to flag:\n%s", got)
+	}
+}
+
+// TestModuleShowPrunesRPIAndDream_L2 pins novice edge 6: no `ao rpi` or
+// `ao dream` command exists, so --show must not render rpi.* / dream.*
+// resolved values in table or JSON output.
+func TestModuleShowPrunesRPIAndDream_L2(t *testing.T) {
+	clearShowEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir())
+
+	table := runRealShow(t, "table", []string{"--show"})
+	for _, banned := range []string{"rpi.", "dream."} {
+		if strings.Contains(table, banned) {
+			t.Errorf("table output still renders %q section:\n%s", banned, table)
+		}
+	}
+
+	raw := runRealShow(t, "json", []string{"--show"})
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		t.Fatalf("JSON output invalid: %v\n%s", err, raw)
+	}
+	gotKeys := make([]string, 0, len(parsed))
+	for key := range parsed {
+		gotKeys = append(gotKeys, key)
+	}
+	sort.Strings(gotKeys)
+	wantKeys := []string{"base_dir", "models_default_tier", "output", "verbose"}
+	if !slices.Equal(gotKeys, wantKeys) {
+		t.Errorf("JSON keys = %v, want exactly %v", gotKeys, wantKeys)
+	}
+}
+
+// TestModuleShowOutputFlagAttribution_L2 covers both sides of the flag
+// misattribution: no flag passed → source is default, flag actually passed
+// (via an inherited persistent --output, as cmd/ao mounts it) → source is flag.
+func TestModuleShowOutputFlagAttribution_L2(t *testing.T) {
+	t.Run("no flag passed resolves to default", func(t *testing.T) {
+		clearShowEnv(t)
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Chdir(t.TempDir())
+
+		raw := runRealShow(t, "json", []string{"--show"})
+		var parsed struct {
+			Output struct {
+				Value  string `json:"value"`
+				Source string `json:"source"`
+			} `json:"output"`
+		}
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			t.Fatalf("JSON output invalid: %v\n%s", err, raw)
+		}
+		if parsed.Output.Value != "table" || parsed.Output.Source != "default" {
+			t.Errorf("output = (%q, %q), want (table, default)", parsed.Output.Value, parsed.Output.Source)
+		}
+	})
+
+	t.Run("explicit --output attributes to flag", func(t *testing.T) {
+		clearShowEnv(t)
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Chdir(t.TempDir())
+
+		root := &cobra.Command{Use: "ao"}
+		root.PersistentFlags().StringP("output", "o", "table", "")
+		root.PersistentFlags().Bool("json", false, "")
+		module := NewModule(configapp.NewCommandService(configadapter.Gateway{}), realHost("json"))
+		root.AddCommand(module.Command())
+		var stdout bytes.Buffer
+		root.SetOut(&stdout)
+		root.SetErr(&stdout)
+		root.SetArgs([]string{"config", "--show", "--output", "json"})
+		if err := root.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		var parsed struct {
+			Output struct {
+				Value  string `json:"value"`
+				Source string `json:"source"`
+			} `json:"output"`
+		}
+		if err := json.Unmarshal(stdout.Bytes(), &parsed); err != nil {
+			t.Fatalf("JSON output invalid: %v\n%s", err, stdout.String())
+		}
+		if parsed.Output.Value != "json" || parsed.Output.Source != "flag" {
+			t.Errorf("output = (%q, %q), want (json, flag)", parsed.Output.Value, parsed.Output.Source)
+		}
+	})
+}
+
+// TestModuleShowOmitsDeadNoSCKey_L2: AGENTOPS_NO_SC only feeds the dead
+// Search.UseSmartConnections field, so --show must not surface it even when
+// set, and the help text must not document it.
+func TestModuleShowOmitsDeadNoSCKey_L2(t *testing.T) {
+	clearShowEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir())
+	t.Setenv("AGENTOPS_NO_SC", "1")
+
+	got := runRealShow(t, "table", []string{"--show"})
+	if strings.Contains(got, "AGENTOPS_NO_SC") {
+		t.Errorf("--show surfaces dead AGENTOPS_NO_SC key:\n%s", got)
+	}
+	if !strings.Contains(got, "(none set)") {
+		t.Errorf("environment section should report (none set) when only dead keys are set:\n%s", got)
+	}
+	if strings.Contains(configLong, "AGENTOPS_NO_SC") {
+		t.Error("config help text still documents dead AGENTOPS_NO_SC")
 	}
 }

--- a/cli/internal/commands/doctor/module.go
+++ b/cli/internal/commands/doctor/module.go
@@ -289,9 +289,40 @@ func (module Module) runExplain(command *cobra.Command, id string, jsonOutput bo
 	if jsonOutput {
 		return module.emitStructured(command, finding)
 	}
-	fmt.Fprintf(command.OutOrStdout(), "%s [%s] (%s)\n%s\n", finding.ID, finding.Severity, finding.Subsystem, finding.Title)
-	fmt.Fprintf(command.OutOrStdout(), "Remediation: %s\n", finding.Remediation.Command)
+	renderExplain(command, finding)
 	return nil
+}
+
+// renderExplain prints the full expansion of one finding — a superset of the
+// per-finding fields robot-triage emits: identity, confidence, every evidence
+// field, remediation, and fixability.
+func renderExplain(command *cobra.Command, finding *doctorapp.Finding) {
+	w := command.OutOrStdout()
+	fmt.Fprintf(w, "%s [%s] (%s)\n%s\n", finding.ID, finding.Severity, finding.Subsystem, finding.Title)
+	fmt.Fprintf(w, "Confidence: %.2f\n", finding.Confidence)
+	fmt.Fprintln(w, "Evidence:")
+	evidence := finding.Evidence
+	if evidence.File == "" && len(evidence.Lines) == 0 && evidence.Query == "" && evidence.Hash == "" {
+		fmt.Fprintln(w, "  (none recorded)")
+	}
+	if evidence.File != "" {
+		fmt.Fprintf(w, "  file: %s\n", evidence.File)
+	}
+	if len(evidence.Lines) > 0 {
+		fmt.Fprintf(w, "  lines: %v\n", evidence.Lines)
+	}
+	if evidence.Query != "" {
+		fmt.Fprintf(w, "  query: %s\n", evidence.Query)
+	}
+	if evidence.Hash != "" {
+		fmt.Fprintf(w, "  hash: %s\n", evidence.Hash)
+	}
+	fmt.Fprintf(w, "Remediation: %s\n", finding.Remediation.Command)
+	fmt.Fprintf(w, "Auto-fixable: %t (estimated actions: %d)\n",
+		finding.Remediation.AutoFixable, finding.Remediation.EstimatedActions)
+	if finding.Remediation.ExplainCommand != "" {
+		fmt.Fprintf(w, "Explain: %s\n", finding.Remediation.ExplainCommand)
+	}
 }
 
 func (module Module) fixCommand(options *rootOptions) *cobra.Command {
@@ -421,10 +452,32 @@ func (module Module) diffCommand(options *rootOptions) *cobra.Command {
 		if jsonOutput {
 			return module.emitStructured(command, report)
 		}
-		renderFindings(command, report)
-		if len(report.Findings) == 0 {
-			fmt.Fprintln(command.OutOrStdout(), "clean diff: --fix would change nothing")
-		}
+		renderFixPlan(command, report)
+		// Exit code stays 0 with findings present: diff is a read-only preview
+		// of the fix plan, not a health verdict — `ao doctor` / `ao doctor
+		// health` own the failing exit for findings.
 		return nil
 	}}
+}
+
+// renderFixPlan renders the diff output as an explicit fix PLAN: for each
+// finding it states whether --fix would act (and how many actions) or that
+// only a manual action exists. This keeps `ao doctor diff` distinct from the
+// plain findings list triage renders.
+func renderFixPlan(command *cobra.Command, report *doctorapp.Report) {
+	w := command.OutOrStdout()
+	if len(report.Findings) == 0 {
+		fmt.Fprintln(w, "clean diff: --fix would change nothing")
+		return
+	}
+	fmt.Fprintf(w, "Fix plan — what --fix would do (%d finding(s), read-only preview):\n", len(report.Findings))
+	for _, finding := range report.Findings {
+		fmt.Fprintf(w, "  [%s] %s — %s\n", finding.Severity, finding.ID, finding.Title)
+		if finding.Remediation.AutoFixable {
+			fmt.Fprintf(w, "      would auto-fix: %d estimated action(s) via %s\n",
+				finding.Remediation.EstimatedActions, finding.Remediation.Command)
+		} else {
+			fmt.Fprintf(w, "      no automatic fix; manual action: %s\n", finding.Remediation.Command)
+		}
+	}
 }

--- a/cli/internal/commands/doctor/module_test.go
+++ b/cli/internal/commands/doctor/module_test.go
@@ -65,10 +65,29 @@ func (fake *fakeMaintenance) GC(_ context.Context, request doctorapp.GCRequest) 
 	return doctorapp.GCResult{Matched: 2, DryRun: request.DryRun}, nil
 }
 
+// stubRead overrides the read seams a rendering test needs while inheriting
+// the inert fakeRead behavior for everything else.
+type stubRead struct {
+	fakeRead
+	diff    *doctorapp.Report
+	explain *doctorapp.Finding
+}
+
+func (stub stubRead) Diff(context.Context, doctorapp.ReadRequest) (*doctorapp.Report, error) {
+	return stub.diff, nil
+}
+func (stub stubRead) Explain(context.Context, string) (*doctorapp.Finding, error) {
+	return stub.explain, nil
+}
+
 func testModule(mutation *fakeMutation, maintenance *fakeMaintenance, globals GlobalOptions) Module {
+	return testModuleWithRead(fakeRead{}, mutation, maintenance, globals)
+}
+
+func testModuleWithRead(read ReadUseCases, mutation *fakeMutation, maintenance *fakeMaintenance, globals GlobalOptions) Module {
 	return NewModule(UseCases{
 		LegacyChecks: func(context.Context) []quality.Check { return nil },
-		Read:         fakeRead{}, Mutation: mutation, Maintenance: maintenance,
+		Read:         read, Mutation: mutation, Maintenance: maintenance,
 		DetectorCount: func() int { return 0 },
 	}, clicontract.HostOptions{
 		DryRun: func() bool { return globals.DryRun },
@@ -186,5 +205,112 @@ func TestDoctorFlagOwnershipRemainsLocal(t *testing.T) {
 	undo, _, _ := command.Find([]string{"undo"})
 	if undo.Flags().Lookup("dry-run") == nil || undo.Flags().Lookup("strict") == nil {
 		t.Fatal("undo local flags missing")
+	}
+}
+
+// TestDiffRendersFixPlan guards novice edge 4c: the human `ao doctor diff`
+// output must frame itself as the --fix PLAN — per finding it states whether
+// --fix would act (with the estimated action count) and prints an explicit
+// "no automatic fix; manual action: ..." line for non-fixable findings —
+// instead of the plain findings list triage already renders. The exit code
+// deliberately stays 0 with findings present: diff is a read-only preview of
+// the plan, not a health verdict — `ao doctor` / `ao doctor health` own the
+// failing exit for findings.
+func TestDiffRendersFixPlan(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		report  *doctorapp.Report
+		want    []string
+		notWant []string
+	}{
+		{
+			name: "findings render as plan with fixability per finding",
+			report: &doctorapp.Report{ExitCode: doctorapp.ExitFindings, Findings: []doctorapp.Finding{
+				{ID: "fm-manual-only", Severity: "P1", Title: "needs a human",
+					Remediation: doctorapp.Remediation{Command: "install skills manually: run `ao skills link`", AutoFixable: false, EstimatedActions: 0}},
+				{ID: "fm-auto", Severity: "P2", Title: "machine can fix",
+					Remediation: doctorapp.Remediation{Command: "ao doctor --fix --only fm-auto", AutoFixable: true, EstimatedActions: 3}},
+			}},
+			want: []string{
+				"Fix plan — what --fix would do (2 finding(s), read-only preview):",
+				"[P1] fm-manual-only — needs a human",
+				"no automatic fix; manual action: install skills manually: run `ao skills link`",
+				"[P2] fm-auto — machine can fix",
+				"would auto-fix: 3 estimated action(s) via ao doctor --fix --only fm-auto",
+			},
+		},
+		{
+			name:   "clean report renders clean-diff line",
+			report: &doctorapp.Report{},
+			want:   []string{"clean diff: --fix would change nothing"},
+			notWant: []string{
+				"Fix plan",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			command := testModuleWithRead(stubRead{diff: test.report}, &fakeMutation{}, &fakeMaintenance{}, GlobalOptions{}).Command()
+			var stdout bytes.Buffer
+			command.SetOut(&stdout)
+			command.SetArgs([]string{"diff"})
+			if err := command.Execute(); err != nil {
+				t.Fatalf("diff must exit 0 (read-only plan preview), got %v", err)
+			}
+			for _, want := range test.want {
+				if !bytes.Contains(stdout.Bytes(), []byte(want)) {
+					t.Fatalf("diff output missing %q:\n%s", want, stdout.String())
+				}
+			}
+			for _, notWant := range test.notWant {
+				if bytes.Contains(stdout.Bytes(), []byte(notWant)) {
+					t.Fatalf("diff output unexpectedly contains %q:\n%s", notWant, stdout.String())
+				}
+			}
+		})
+	}
+}
+
+// TestExplainRendersSupersetOfTriageFields guards novice edge 4d: the human
+// `ao doctor explain <id>` output must be a superset of the per-finding fields
+// robot-triage emits — identity, confidence, every evidence field,
+// remediation, and fixability — not just title plus remediation command.
+func TestExplainRendersSupersetOfTriageFields(t *testing.T) {
+	finding := &doctorapp.Finding{
+		ID: "fm-skills-missing", Severity: "P1", Subsystem: "skills",
+		Title:      "no installed skills found in any known install location",
+		Confidence: 1.0,
+		Evidence: doctorapp.Evidence{
+			File: ".claude/skills", Lines: []int{7, 9},
+			Query: "scan of 4 SkillInstallDirs found 0 SKILL.md subdirs",
+			Hash:  "deadbeef",
+		},
+		Remediation: doctorapp.Remediation{
+			Command:        "install skills manually: run `ao skills link`",
+			ExplainCommand: "ao doctor explain fm-skills-missing",
+			AutoFixable:    false, EstimatedActions: 0,
+		},
+	}
+	command := testModuleWithRead(stubRead{explain: finding}, &fakeMutation{}, &fakeMaintenance{}, GlobalOptions{}).Command()
+	var stdout bytes.Buffer
+	command.SetOut(&stdout)
+	command.SetArgs([]string{"explain", "fm-skills-missing"})
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"fm-skills-missing [P1] (skills)",
+		"no installed skills found in any known install location",
+		"Confidence: 1.00",
+		"file: .claude/skills",
+		"lines: [7 9]",
+		"query: scan of 4 SkillInstallDirs found 0 SKILL.md subdirs",
+		"hash: deadbeef",
+		"Remediation: install skills manually: run `ao skills link`",
+		"Auto-fixable: false (estimated actions: 0)",
+		"Explain: ao doctor explain fm-skills-missing",
+	} {
+		if !bytes.Contains(stdout.Bytes(), []byte(want)) {
+			t.Fatalf("explain output missing %q:\n%s", want, stdout.String())
+		}
 	}
 }

--- a/cli/internal/config/command_service.go
+++ b/cli/internal/config/command_service.go
@@ -6,8 +6,11 @@ import (
 	"strings"
 )
 
+// showEnvironmentKeys deliberately omits AGENTOPS_NO_SC: it only toggles
+// Search.UseSmartConnections, a dead field nothing outside config plumbing
+// consumes.
 var showEnvironmentKeys = []string{
-	"AGENTOPS_CONFIG", "AGENTOPS_OUTPUT", "AGENTOPS_BASE_DIR", "AGENTOPS_VERBOSE", "AGENTOPS_NO_SC",
+	"AGENTOPS_CONFIG", "AGENTOPS_OUTPUT", "AGENTOPS_BASE_DIR", "AGENTOPS_VERBOSE",
 }
 
 var modelEnvironmentKeys = []string{"AGENTOPS_MODEL_TIER", "AGENTOPS_COUNCIL_MODEL_TIER", "COUNCIL_CLAUDE_MODEL"}
@@ -17,6 +20,15 @@ type ConfigFiles struct {
 	HomeExists    bool
 	ProjectPath   string
 	ProjectExists bool
+	// HomeReadPath is the home-layer path actually consulted for reads. It
+	// equals HomePath normally; when the deprecated ~/.agentops/config.yaml
+	// fallback is active it is that legacy path and HomeLegacy is true.
+	HomeReadPath string
+	HomeLegacy   bool
+	// ProjectReadPath mirrors HomeReadPath for the project layer
+	// (legacy fallback: ./.agentops/config.yaml).
+	ProjectReadPath string
+	ProjectLegacy   bool
 }
 
 type ShowResult struct {
@@ -65,6 +77,11 @@ func (service *CommandService) Show(_ context.Context, output string, verbose bo
 	if err != nil {
 		return ShowResult{}, err
 	}
+	// Overlay the read paths actually consulted (config.go owns the legacy
+	// fallback) so the files panel reports the file that was really loaded
+	// instead of contradicting the deprecation warning.
+	files.HomeReadPath, files.HomeLegacy = homeConfigReadInfo()
+	files.ProjectReadPath, files.ProjectLegacy = projectConfigReadInfo()
 	return ShowResult{
 		Resolved: service.gateway.Resolve(output, verbose), ConfigFiles: files,
 		Environment: service.gateway.Environment(showEnvironmentKeys),

--- a/cli/internal/config/command_service_test.go
+++ b/cli/internal/config/command_service_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -80,5 +82,69 @@ func TestCommandServiceWriteModelsDryRunRejectsMalformedExistingConfig(t *testin
 	}
 	if gateway.saved != nil {
 		t.Fatalf("failed dry-run saved config: %+v", gateway.saved)
+	}
+}
+
+// TestCommandServiceShowReportsLegacyReadPaths pins the files-panel half of
+// novice edge 8: when the deprecated home fallback is active, ShowResult must
+// carry the path actually read so the renderer can label it instead of
+// reporting the canonical path as missing.
+func TestCommandServiceShowReportsLegacyReadPaths(t *testing.T) {
+	clearConfigEnv(t)
+	isolateLegacyWarnings(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir())
+
+	legacy := filepath.Join(home, ".agentops", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
+		t.Fatalf("mkdir legacy dir: %v", err)
+	}
+	if err := os.WriteFile(legacy, []byte("output: json\n"), 0o644); err != nil {
+		t.Fatalf("write legacy config: %v", err)
+	}
+
+	result, err := NewCommandService(&fakeCommandGateway{}).Show(context.Background(), "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := result.ConfigFiles
+	if !files.HomeLegacy {
+		t.Fatal("HomeLegacy = false, want true when only the legacy home config exists")
+	}
+	if files.HomeReadPath != legacy {
+		t.Errorf("HomeReadPath = %q, want %q", files.HomeReadPath, legacy)
+	}
+	if files.ProjectLegacy {
+		t.Error("ProjectLegacy = true, want false with no project config at all")
+	}
+}
+
+// TestCommandServiceShowCanonicalReadPath: with the canonical home config in
+// place the read path equals it and no legacy label is requested.
+func TestCommandServiceShowCanonicalReadPath(t *testing.T) {
+	clearConfigEnv(t)
+	isolateLegacyWarnings(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir())
+
+	canonical := filepath.Join(home, ".agents", "ao", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(canonical), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(canonical, []byte("output: json\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	result, err := NewCommandService(&fakeCommandGateway{}).Show(context.Background(), "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ConfigFiles.HomeLegacy {
+		t.Fatal("HomeLegacy = true, want false when the canonical home config exists")
+	}
+	if result.ConfigFiles.HomeReadPath != canonical {
+		t.Errorf("HomeReadPath = %q, want %q", result.ConfigFiles.HomeReadPath, canonical)
 	}
 }

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -283,6 +283,11 @@ type SearchConfig struct {
 	DefaultLimit int `yaml:"default_limit" json:"default_limit"`
 
 	// UseSmartConnections enables Smart Connections when available.
+	//
+	// Deprecated: dead knob. Nothing outside config plumbing (defaults,
+	// AGENTOPS_NO_SC applyEnv, merge) reads this field, so toggling it has
+	// no effect. It is no longer documented in `ao config` help; the field
+	// stays parseable so existing config files do not break.
 	UseSmartConnections bool `yaml:"use_smart_connections" json:"use_smart_connections"`
 
 	// UseSmartConnectionsSet tracks whether UseSmartConnections was explicitly set.
@@ -429,17 +434,26 @@ var (
 // stderr: the pre-3.3 `.agentops/` location is read-only compatibility for
 // this release. Writes (Save) always target the new path.
 func withLegacyFallback(newPath, legacyPath string) string {
+	path, _ := withLegacyFallbackInfo(newPath, legacyPath)
+	return path
+}
+
+// withLegacyFallbackInfo is withLegacyFallback plus a report of whether the
+// deprecated legacy fallback is the path actually being read, so display
+// surfaces (ao config --show) can label it instead of contradicting the
+// deprecation warning.
+func withLegacyFallbackInfo(newPath, legacyPath string) (string, bool) {
 	if newPath == "" || legacyPath == "" {
-		return newPath
+		return newPath, false
 	}
 	if _, err := os.Stat(newPath); err == nil {
-		return newPath
+		return newPath, false
 	}
 	if _, err := os.Stat(legacyPath); err != nil {
-		return newPath
+		return newPath, false
 	}
 	warnLegacyConfigOnce(legacyPath, newPath)
-	return legacyPath
+	return legacyPath, true
 }
 
 func warnLegacyConfigOnce(legacyPath, newPath string) {
@@ -457,11 +471,19 @@ func warnLegacyConfigOnce(legacyPath, newPath string) {
 // homeConfigReadPath returns the home config path for reads, falling back to
 // the legacy ~/.agentops/config.yaml location when the new path is absent.
 func homeConfigReadPath() string {
+	path, _ := homeConfigReadInfo()
+	return path
+}
+
+// homeConfigReadInfo returns the home config path actually consulted for
+// reads plus whether that path is the deprecated legacy fallback
+// (~/.agentops/config.yaml).
+func homeConfigReadInfo() (string, bool) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return ""
+		return "", false
 	}
-	return withLegacyFallback(
+	return withLegacyFallbackInfo(
 		filepath.Join(home, ".agents", "ao", "config.yaml"),
 		filepath.Join(home, ".agentops", "config.yaml"),
 	)
@@ -471,11 +493,20 @@ func homeConfigReadPath() string {
 // back to the legacy ./.agentops/config.yaml location when the new path is
 // absent. An explicit AGENTOPS_CONFIG override is returned verbatim.
 func projectConfigReadPath() string {
+	path, _ := projectConfigReadInfo()
+	return path
+}
+
+// projectConfigReadInfo returns the project config path actually consulted
+// for reads plus whether that path is the deprecated legacy fallback
+// (./.agentops/config.yaml). An explicit AGENTOPS_CONFIG override is
+// returned verbatim and is never legacy.
+func projectConfigReadInfo() (string, bool) {
 	newPath, legacyPath := projectConfigPaths()
 	if legacyPath == "" {
-		return newPath
+		return newPath, false
 	}
-	return withLegacyFallback(newPath, legacyPath)
+	return withLegacyFallbackInfo(newPath, legacyPath)
 }
 
 // getwdFunc is the function used to get the current working directory.
@@ -832,6 +863,13 @@ const (
 	SourceProject Source = ".agents/ao/config.yaml"
 	SourceEnv     Source = "environment"
 	SourceFlag    Source = "flag"
+	// SourceHomeLegacy labels values read through the deprecated home
+	// fallback so --show matches the deprecation warning instead of
+	// attributing them to a path that does not exist.
+	SourceHomeLegacy Source = "~/.agentops/config.yaml (deprecated location)"
+	// SourceProjectLegacy labels values read through the deprecated project
+	// fallback (./.agentops/config.yaml).
+	SourceProjectLegacy Source = ".agentops/config.yaml (deprecated location)"
 )
 
 // getEnvString returns the value and whether the env var was set.
@@ -907,32 +945,39 @@ func resolveStringSliceField(home, project []string, def []string) resolved {
 }
 
 // ResolvedConfig shows config values with their sources.
+//
+// The RPI* and Dream* fields are excluded from serialization (`json:"-"`):
+// no `ao rpi` or `ao dream` command exists, so `ao config --show` must not
+// render resolved values for subsystems a user cannot invoke. The fields
+// themselves are retained for now because callers outside this package
+// (e.g. cmd/ao tests) still reference them; deleting the underlying Config
+// struct sections is a separate pass.
 type ResolvedConfig struct {
 	Output                resolved `json:"output"`
 	BaseDir               resolved `json:"base_dir"`
 	Verbose               resolved `json:"verbose"`
-	RPIWorktreeMode       resolved `json:"rpi_worktree_mode"`
-	RPIRuntimeMode        resolved `json:"rpi_runtime_mode"`
-	RPIRuntimeCommand     resolved `json:"rpi_runtime_command"`
-	RPIAOCommand          resolved `json:"rpi_ao_command"`
-	RPIBDCommand          resolved `json:"rpi_bd_command"`
-	RPITmuxCommand        resolved `json:"rpi_tmux_command"`
+	RPIWorktreeMode       resolved `json:"-"`
+	RPIRuntimeMode        resolved `json:"-"`
+	RPIRuntimeCommand     resolved `json:"-"`
+	RPIAOCommand          resolved `json:"-"`
+	RPIBDCommand          resolved `json:"-"`
+	RPITmuxCommand        resolved `json:"-"`
 	ModelsDefaultTier     resolved `json:"models_default_tier"`
-	DreamReportDir        resolved `json:"dream_report_dir"`
-	DreamRunTimeout       resolved `json:"dream_run_timeout"`
-	DreamKeepAwake        resolved `json:"dream_keep_awake"`
-	DreamRunners          resolved `json:"dream_runners"`
-	DreamScheduler        resolved `json:"dream_scheduler_mode"`
-	DreamScheduleAt       resolved `json:"dream_schedule_at"`
-	DreamConsensus        resolved `json:"dream_consensus_policy"`
-	DreamCreativeLane     resolved `json:"dream_creative_lane"`
-	DreamCuratorEnabled   resolved `json:"dream_curator_enabled"`
-	DreamCuratorEngine    resolved `json:"dream_curator_engine"`
-	DreamCuratorOllamaURL resolved `json:"dream_curator_ollama_url"`
-	DreamCuratorModel     resolved `json:"dream_curator_model"`
-	DreamCuratorWorkerDir resolved `json:"dream_curator_worker_dir"`
-	DreamCuratorVaultDir  resolved `json:"dream_curator_vault_dir"`
-	DreamCuratorJobKinds  resolved `json:"dream_curator_allowed_job_kinds"`
+	DreamReportDir        resolved `json:"-"`
+	DreamRunTimeout       resolved `json:"-"`
+	DreamKeepAwake        resolved `json:"-"`
+	DreamRunners          resolved `json:"-"`
+	DreamScheduler        resolved `json:"-"`
+	DreamScheduleAt       resolved `json:"-"`
+	DreamConsensus        resolved `json:"-"`
+	DreamCreativeLane     resolved `json:"-"`
+	DreamCuratorEnabled   resolved `json:"-"`
+	DreamCuratorEngine    resolved `json:"-"`
+	DreamCuratorOllamaURL resolved `json:"-"`
+	DreamCuratorModel     resolved `json:"-"`
+	DreamCuratorWorkerDir resolved `json:"-"`
+	DreamCuratorVaultDir  resolved `json:"-"`
+	DreamCuratorJobKinds  resolved `json:"-"`
 }
 
 type resolved struct {
@@ -1100,6 +1145,7 @@ func Resolve(flagOutput, flagBaseDir string, flagVerbose bool) *ResolvedConfig {
 	// has no error channel, so a failed explicit override is surfaced as a warning
 	// here (Load() is the authoritative fail-closed loader).
 	var home, project configFields
+	var homeLegacy, projectLegacy bool
 	if override := strings.TrimSpace(os.Getenv("AGENTOPS_CONFIG")); override != "" {
 		oc, err := loadFromPath(override)
 		if err != nil {
@@ -1107,12 +1153,14 @@ func Resolve(flagOutput, flagBaseDir string, flagVerbose bool) *ResolvedConfig {
 		}
 		project = extractFields(oc)
 	} else {
+		_, homeLegacy = homeConfigReadInfo()
+		_, projectLegacy = projectConfigReadInfo()
 		home = extractFields(loadHomeConfig())
 		project = extractFields(loadProjectConfig())
 	}
 	env := loadEnvFields()
 
-	return &ResolvedConfig{
+	rc := &ResolvedConfig{
 		Output:            resolveStringField(home.output, project.output, env.output, flagOutput, defaultOutput),
 		BaseDir:           resolveStringField(home.baseDir, project.baseDir, env.baseDir, flagBaseDir, defaultBaseDir),
 		Verbose:           resolveVerbose(home, project, env, flagVerbose),
@@ -1153,5 +1201,38 @@ func Resolve(flagOutput, flagBaseDir string, flagVerbose bool) *ResolvedConfig {
 		DreamCuratorWorkerDir: resolveStringField(home.dreamCuratorWorkerDir, project.dreamCuratorWorkerDir, env.dreamCuratorWorkerDir, "", ""),
 		DreamCuratorVaultDir:  resolveStringField(home.dreamCuratorVaultDir, project.dreamCuratorVaultDir, env.dreamCuratorVaultDir, "", ""),
 		DreamCuratorJobKinds:  resolveStringSliceField(home.dreamCuratorJobKinds, project.dreamCuratorJobKinds, []string{}),
+	}
+	// When a layer was read through the deprecated fallback path, attribute
+	// its values to the path actually read so --show agrees with the
+	// deprecation warning instead of citing a file that does not exist.
+	if homeLegacy {
+		rc.relabelSource(SourceHome, SourceHomeLegacy)
+	}
+	if projectLegacy {
+		rc.relabelSource(SourceProject, SourceProjectLegacy)
+	}
+	return rc
+}
+
+// relabelSource rewrites every resolved field attributed to from so it is
+// attributed to to. Used to mark values loaded via a deprecated legacy
+// config location.
+func (rc *ResolvedConfig) relabelSource(from, to Source) {
+	fields := []*resolved{
+		&rc.Output, &rc.BaseDir, &rc.Verbose,
+		&rc.RPIWorktreeMode, &rc.RPIRuntimeMode, &rc.RPIRuntimeCommand,
+		&rc.RPIAOCommand, &rc.RPIBDCommand, &rc.RPITmuxCommand,
+		&rc.ModelsDefaultTier,
+		&rc.DreamReportDir, &rc.DreamRunTimeout, &rc.DreamKeepAwake,
+		&rc.DreamRunners, &rc.DreamScheduler, &rc.DreamScheduleAt,
+		&rc.DreamConsensus, &rc.DreamCreativeLane,
+		&rc.DreamCuratorEnabled, &rc.DreamCuratorEngine, &rc.DreamCuratorOllamaURL,
+		&rc.DreamCuratorModel, &rc.DreamCuratorWorkerDir, &rc.DreamCuratorVaultDir,
+		&rc.DreamCuratorJobKinds,
+	}
+	for _, field := range fields {
+		if field.Source == from {
+			field.Source = to
+		}
 	}
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -2767,3 +2767,74 @@ func TestSave_MigratesLegacyProjectConfigToNewPath(t *testing.T) {
 			"json", "/legacy/base", "quality")
 	}
 }
+
+// TestResolve_LegacyFallbackRelabelsSources pins novice edge 8: values loaded
+// through a deprecated legacy config location must be attributed to the path
+// actually read, not to the canonical path (which does not exist) or "flag".
+func TestResolve_LegacyFallbackRelabelsSources(t *testing.T) {
+	tests := []struct {
+		name       string
+		layer      string // "home" or "project"
+		wantSource Source
+	}{
+		{name: "home legacy fallback", layer: "home", wantSource: SourceHomeLegacy},
+		{name: "project legacy fallback", layer: "project", wantSource: SourceProjectLegacy},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			isolateLegacyWarnings(t)
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			project := t.TempDir()
+			t.Chdir(project)
+
+			root := home
+			if tt.layer == "project" {
+				root = project
+			}
+			legacy := filepath.Join(root, ".agentops", "config.yaml")
+			if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
+				t.Fatalf("mkdir legacy dir: %v", err)
+			}
+			if err := os.WriteFile(legacy, []byte("output: json\nbase_dir: /legacy-base\n"), 0o644); err != nil {
+				t.Fatalf("write legacy config: %v", err)
+			}
+
+			rc := Resolve("", "", false)
+			if rc.Output.Value != "json" || rc.Output.Source != tt.wantSource {
+				t.Errorf("Output = (%v, %q), want (json, %q)", rc.Output.Value, rc.Output.Source, tt.wantSource)
+			}
+			if rc.BaseDir.Value != "/legacy-base" || rc.BaseDir.Source != tt.wantSource {
+				t.Errorf("BaseDir = (%v, %q), want (/legacy-base, %q)", rc.BaseDir.Value, rc.BaseDir.Source, tt.wantSource)
+			}
+			// Untouched values keep their default attribution.
+			if rc.Verbose.Source != SourceDefault {
+				t.Errorf("Verbose.Source = %q, want %q", rc.Verbose.Source, SourceDefault)
+			}
+		})
+	}
+}
+
+// TestResolve_NewPathKeepsCanonicalSource guards the relabel against firing
+// when the canonical home config exists (no legacy fallback active).
+func TestResolve_NewPathKeepsCanonicalSource(t *testing.T) {
+	clearConfigEnv(t)
+	isolateLegacyWarnings(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir())
+
+	path := filepath.Join(home, ".agents", "ao", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("output: yaml\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	rc := Resolve("", "", false)
+	if rc.Output.Value != "yaml" || rc.Output.Source != SourceHome {
+		t.Errorf("Output = (%v, %q), want (yaml, %q)", rc.Output.Value, rc.Output.Source, SourceHome)
+	}
+}

--- a/cli/internal/doctor/engine.go
+++ b/cli/internal/doctor/engine.go
@@ -322,19 +322,40 @@ func buildReport(ra *RunArtifact, toolVersion, sha string, now time.Time, findin
 	}
 }
 
-// diagnoseNextSteps produces the next_steps hints for a diagnose run.
+// diagnoseNextSteps produces the next_steps hints for a diagnose run. It
+// recommends --fix only when at least one finding is auto-fixable — a
+// next-step instructing --fix over zero fixable findings is the edge-4a lie
+// one level up from the per-finding remediation.
 func diagnoseNextSteps(findings []Finding) []string {
 	if len(findings) == 0 {
 		return []string{"Workspace healthy. No action needed."}
 	}
-	steps := []string{"Run: ao doctor --fix"}
-	if len(findings) > 0 {
-		steps = append(steps,
-			"Or scope: ao doctor --fix --only "+findings[0].ID,
-			"Inspect: ao doctor explain "+findings[0].ID,
-		)
+	fixable := 0
+	for _, f := range findings {
+		if f.Remediation.AutoFixable {
+			fixable++
+		}
 	}
-	return steps
+	steps := []string{}
+	if fixable > 0 {
+		steps = append(steps,
+			"Run: ao doctor --fix",
+			"Or scope: ao doctor --fix --only "+firstFixableID(findings),
+		)
+	} else {
+		steps = append(steps, "No automatic fixes available; follow each finding's remediation.")
+	}
+	return append(steps, "Inspect: ao doctor explain "+findings[0].ID)
+}
+
+// firstFixableID returns the ID of the first auto-fixable finding.
+func firstFixableID(findings []Finding) string {
+	for _, f := range findings {
+		if f.Remediation.AutoFixable {
+			return f.ID
+		}
+	}
+	return findings[0].ID
 }
 
 // persistRun writes all run artifacts (report.json, report.md, stderr.log,
@@ -795,9 +816,12 @@ func Health(repoRoot, toolVersion string) (string, *HealthResult, error) {
 	if rep.Summary.TotalFindings > 0 {
 		hr.Status = "findings"
 		hr.ExitCode = ExitFindings
-		line := fmt.Sprintf("findings  ao=%s doctor=%s findings=%d P0=%d P2=%d last_run=%s run_id=%s",
+		// Report every severity bucket: omitting one (P1 was once dropped)
+		// hides the worst severity present from the one-line summary.
+		line := fmt.Sprintf("findings  ao=%s doctor=%s findings=%d P0=%d P1=%d P2=%d P3=%d last_run=%s run_id=%s",
 			toolVersion, DoctorVersion, rep.Summary.TotalFindings,
-			rep.Summary.BySeverity["P0"], rep.Summary.BySeverity["P2"], rep.StartedAt, rep.RunID)
+			rep.Summary.BySeverity["P0"], rep.Summary.BySeverity["P1"],
+			rep.Summary.BySeverity["P2"], rep.Summary.BySeverity["P3"], rep.StartedAt, rep.RunID)
 		return line, hr, nil
 	}
 	line := fmt.Sprintf("ok  ao=%s doctor=%s findings=0 last_run=%s run_id=%s",
@@ -900,7 +924,11 @@ func RobotTriage(opts Options) (*RobotTriageResult, *Report, error) {
 	sort.Strings(quick)
 	recommended := "ao doctor (healthy)"
 	if len(rep.Findings) > 0 {
-		recommended = "ao doctor --fix"
+		// Recommend --fix only when a fixer can actually act (edge 4a).
+		recommended = "ao doctor explain " + rep.Findings[0].ID
+		if rep.Summary.AutoFixable > 0 {
+			recommended = "ao doctor --fix"
+		}
 	}
 	return &RobotTriageResult{
 		SchemaVersion:      SchemaVersion,

--- a/cli/internal/doctor/engine_test.go
+++ b/cli/internal/doctor/engine_test.go
@@ -1,0 +1,42 @@
+package doctor
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestHealthLineReportsEverySeverityBucket guards novice edge 4b: the health
+// one-liner once printed only P0 and P2, silently dropping P1 — the worst
+// severity actually present. A persisted run whose only finding is the P1
+// fm-skills-missing must surface every bucket (P0..P3) in the line, so the
+// worst severity can never be omitted again. The fixture is the real
+// persistence round-trip: Diagnose writes report.json, Health reads it back.
+func TestHealthLineReportsEverySeverityBucket(t *testing.T) {
+	repo, home := t.TempDir(), t.TempDir()
+	rep, err := Diagnose(Options{
+		RepoRoot: repo, CWD: repo, HomeDir: home, ToolVersion: "9.9.9",
+		Only: []string{"fm-skills-missing"}, Now: time.Unix(1_700_000_000, 0),
+	})
+	if err != nil {
+		t.Fatalf("Diagnose: %v", err)
+	}
+	if rep.Summary.BySeverity["P1"] != 1 || rep.Summary.TotalFindings != 1 {
+		t.Fatalf("precondition: want exactly one P1 finding, got %+v", rep.Summary)
+	}
+	line, hr, err := Health(repo, "9.9.9")
+	if err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if hr.Findings != 1 || hr.Status != "findings" || hr.ExitCode != ExitFindings {
+		t.Fatalf("HealthResult = %+v", hr)
+	}
+	if !strings.HasPrefix(line, "findings  ao=9.9.9 doctor="+DoctorVersion+" findings=1 ") {
+		t.Fatalf("health line prefix wrong: %q", line)
+	}
+	for _, want := range []string{"P0=0", "P1=1", "P2=0", "P3=0"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("health line %q missing bucket %q", line, want)
+		}
+	}
+}

--- a/cli/internal/doctor/fix_bridges.go
+++ b/cli/internal/doctor/fix_bridges.go
@@ -77,12 +77,14 @@ func writeReport(ctx *MutateContext, name, content string) (int, error) {
 }
 
 // detectOnlyRemediation builds the standard detect-only remediation block.
+// Detect-only findings have no fixer, so the remediation must never instruct
+// --fix (novice-test edge 4a): the command points at the evidence instead.
 func detectOnlyRemediation(id string) Remediation {
 	return Remediation{
-		Command:          "ao doctor --fix --only " + id,
+		Command:          "no automatic fix; inspect: ao doctor explain " + id,
 		ExplainCommand:   "ao doctor explain " + id,
 		AutoFixable:      false,
-		EstimatedActions: 1,
+		EstimatedActions: 0,
 	}
 }
 
@@ -503,6 +505,12 @@ func (openclawSnapshotStaleDetector) Detect(env *DetectEnv) ([]Finding, error) {
 		ExplainCommand:   "ao doctor explain " + fmOpenClawSnapshotStale,
 		AutoFixable:      autoFixable,
 		EstimatedActions: 1,
+	}
+	if !autoFixable {
+		// Only the torn-latest sub-case has a fixer; every other stale kind
+		// needs the producing daemon regenerated, not --fix (edge 4a).
+		rem.Command = "regenerate the snapshot from its producer (restart the projection daemon), or inspect: ao doctor explain " + fmOpenClawSnapshotStale
+		rem.EstimatedActions = 0
 	}
 	return []Finding{{
 		ID:         fmOpenClawSnapshotStale,

--- a/cli/internal/doctor/fix_skills.go
+++ b/cli/internal/doctor/fix_skills.go
@@ -167,6 +167,19 @@ func remediation(id string, autoFixable bool, actions int) Remediation {
 	}
 }
 
+// manualOnlyRemediation builds a Remediation for a state the registered fixer
+// cannot repair. Invariant: a finding's remediation never instructs
+// `--fix` when auto_fixable is false — the command names the real manual
+// action instead.
+func manualOnlyRemediation(id, action string) Remediation {
+	return Remediation{
+		Command:          action,
+		ExplainCommand:   "ao doctor explain " + id,
+		AutoFixable:      false,
+		EstimatedActions: 0,
+	}
+}
+
 // ---------------------------------------------------------------------------
 // FM: fm-skills-missing (auto-fixable; refuses when no repo skills/ source)
 // ---------------------------------------------------------------------------
@@ -207,6 +220,14 @@ func (d skillsMissingDetector) Detect(env *DetectEnv) ([]Finding, error) {
 	for _, dir := range skillInstallDirs(env.HomeDir) {
 		scanned = append(scanned, fmt.Sprintf("%s=%d", dir, countSkillMDSubdirs(dir)))
 	}
+	rem := remediation(d.ID(), true, countSkillMDSubdirs(src))
+	if !autoFixable {
+		// The fixer refuses without a repo skills/ source tree, so pointing at
+		// `--fix` would be a lie. Name the real manual action instead.
+		rem = manualOnlyRemediation(d.ID(),
+			"install skills manually: clone an agentops checkout and run `ao skills link` "+
+				"(or install the AgentOps plugin); this repo has no skills/ source tree for the auto-fixer to mirror")
+	}
 	return []Finding{{
 		ID:         d.ID(),
 		Severity:   d.Severity(),
@@ -217,7 +238,7 @@ func (d skillsMissingDetector) Detect(env *DetectEnv) ([]Finding, error) {
 			File:  ".claude/skills",
 			Query: "scan of 4 SkillInstallDirs (symlinked entries resolved) found 0 SKILL.md subdirs: " + strings.Join(scanned, " "),
 		},
-		Remediation: remediation(d.ID(), autoFixable, countSkillMDSubdirs(src)),
+		Remediation: rem,
 	}}, nil
 }
 

--- a/cli/internal/doctor/fix_skills_test.go
+++ b/cli/internal/doctor/fix_skills_test.go
@@ -1144,3 +1144,59 @@ func TestSkillsHygieneSymlinkedReferencesDirExcluded(t *testing.T) {
 		t.Fatalf("bskill SKILL.md = %q err=%v, want byte-untouched", got, rerr)
 	}
 }
+
+// TestSkillsMissingRemediationMatchesFixability verifies the remediation
+// contract (novice edge 4a): the command instructs `--fix` only when the
+// registered fixer can actually act; the non-auto-fixable state (no repo
+// skills/ source tree) names the real manual action instead of an inert
+// `--fix` invocation.
+func TestSkillsMissingRemediationMatchesFixability(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		withSource bool
+		wantAuto   bool
+	}{
+		{name: "repo source present instructs --fix", withSource: true, wantAuto: true},
+		{name: "no repo source names manual action", withSource: false, wantAuto: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, home := t.TempDir(), t.TempDir()
+			if tc.withSource {
+				writeSkillsFile(t, filepath.Join(repo, "skills", "rpi", "SKILL.md"), "---\nname: rpi\n---\nbody\n")
+			}
+			findings, err := skillsMissingDetector{}.Detect(&DetectEnv{RepoRoot: repo, CWD: repo, HomeDir: home})
+			if err != nil {
+				t.Fatalf("Detect: %v", err)
+			}
+			if len(findings) != 1 {
+				t.Fatalf("expected exactly one finding, got %+v", findings)
+			}
+			rem := findings[0].Remediation
+			if rem.AutoFixable != tc.wantAuto {
+				t.Fatalf("AutoFixable = %t, want %t", rem.AutoFixable, tc.wantAuto)
+			}
+			if rem.ExplainCommand != "ao doctor explain fm-skills-missing" {
+				t.Fatalf("ExplainCommand = %q", rem.ExplainCommand)
+			}
+			if tc.wantAuto {
+				if rem.Command != "ao doctor --fix --only fm-skills-missing" {
+					t.Fatalf("auto-fixable Command = %q, want the --fix invocation", rem.Command)
+				}
+				if rem.EstimatedActions != 1 {
+					t.Fatalf("EstimatedActions = %d, want 1 (one repo skill to mirror)", rem.EstimatedActions)
+				}
+				return
+			}
+			// Non-auto-fixable: must never instruct --fix, must name the manual path.
+			if strings.Contains(rem.Command, "--fix") {
+				t.Fatalf("non-fixable remediation instructs --fix: %q", rem.Command)
+			}
+			if !strings.Contains(rem.Command, "ao skills link") {
+				t.Fatalf("non-fixable remediation names no manual action: %q", rem.Command)
+			}
+			if rem.EstimatedActions != 0 {
+				t.Fatalf("EstimatedActions = %d, want 0", rem.EstimatedActions)
+			}
+		})
+	}
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,19 @@ before upgrading.
 
 ### Fixed
 
+- Doctor sub-surfaces agree with each other: remediation and the
+  triage/next-steps recommendations instruct `--fix` only when a fixer can
+  actually act (non-fixable findings name their real manual action),
+  `ao doctor health` reports every severity bucket present, `ao doctor diff`
+  renders an explicit read-only fix plan, and `ao doctor explain` is a
+  superset of the finding's triage entry.
+- `ao config --show` stops rendering configuration for removed subsystems
+  (`rpi.*`, `dream.*`) and, during the legacy `~/.agentops` fallback, shows
+  the actually-read path labeled as deprecated with correct value
+  attribution. The unused `AGENTOPS_NO_SC` variable is no longer documented.
+- The pruned 3.2 bookkeeping verbs (`ao beads`, `ao wiki`, `ao ratchet`, and
+  family) now fail with a migration pointer like every other removed
+  surface, instead of a bare unknown-command error.
 - `ao gate check` in a repository other than agentops itself no longer fails
   with a wall of UNKNOWN rows for agentops-internal checks: those checks skip
   as first-class not-applicable, the human report aggregates them into one


### PR DESCRIPTION
Wave 2 of the new-user happy-path fixes (fresh-eyes novice test).

**Edge 4 — doctor sub-surfaces contradicted each other.** Remediation, `next_steps`, and robot-triage's `recommended_command` now instruct `--fix` only when a fixer can actually act — non-fixable findings name their real manual action (including the detect-only bridges class the verifier caught as the same lie one level up). `ao doctor health` reports every severity bucket present (it omitted P1 — the worst actually present). `ao doctor diff` renders an explicit read-only fix plan (would auto-fix vs manual action) instead of a findings copy. `ao doctor explain` is now a superset of the finding's triage entry.

**Edge 6 — `ao config --show` rendered config for commands that don't exist.** `rpi.*` and `dream.*` no longer serialize in human or JSON output (struct fields retained `json:"-"` pending a follow-up removal once nothing references them). `AGENTOPS_NO_SC` had zero behavioral consumers (evidence: rg over all non-test cli/ — only config plumbing/display) — undocumented and removed from the env panel; the field stays parseable so existing config files don't error.

**Edge 8 — legacy-config gaslighting.** With only `~/.agentops/config.yaml` present, `--show` used to print the deprecation warning and then claim the new path was "(not found)" and values came "(from flag)". It now shows the actually-read path labeled "(deprecated location)" with correct attribution.

**Edge 7 — `ao beads` bare error.** The whole pruned 3.2 bookkeeping family gets point-of-failure migration hints; a new guard test proves no hinted verb is a live command (the `eval` trap: pruned in 3.2, returned live in 3.3).

**Process:** three scoped implementers (disjoint files) + fresh adversarial verifier. The verifier refuted two lanes as incomplete (recommended-command layer, stale cmd/ao config tests asserting the old defect) — closed in integration before this PR.

**Verified:** full suite 61/61 pkgs; golangci-lint clean; `ao gate check --full` 67/67 over this range; per-fix RED→GREEN sandbox repros in the workflow logs.