### PR TITLE
docs(onboarding): coding-agent prerequisite, npx-only quickstart, codex plugin remove — novice edges 5/9/10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,12 @@ before upgrading.
 
 ### Fixed
 
+- Onboarding docs name the one real prerequisite: the loop runs as skills
+  inside a coding agent (Claude Code, Codex, Cursor, …) and `/rpi` is typed
+  in that agent's chat. The README Quickstart leads with the universal npx
+  install alone (beads is introduced as the optional tracker it is), and the
+  Codex plugin uninstall uses `codex plugin remove` with the manual cache
+  removal demoted to a fallback for older Codex.
 - Doctor sub-surfaces agree with each other: remediation and the
   triage/next-steps recommendations instruct `--fix` only when a fixer can
   actually act (non-fixable findings name their real manual action),

--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop
 ## Quickstart
 
 ```bash
-brew install beads
 npx skills@latest add boshu2/agentops --all -g
 ```
 
 One command, every coding agent — `npx skills` installs the corpus into all
-your agents at once. Then use `plan`, `implement`, `validate`, and `learn` — or
-`rpi` to run the loop once.
+your agents at once. The loop runs as skills **inside your coding agent**
+(Claude Code, Codex, Cursor, …): type `/rpi` — or ask for `plan`,
+`implement`, `validate`, `learn` by name — in that agent's chat. No other
+runtime is required.
 
 ## Plugins (Claude Code / Codex)
 
@@ -64,7 +65,8 @@ directories.
 
 ## Intent lives in a bead
 
-[Beads](https://github.com/steveyegge/beads) is the preferred tracker. Plan
+[Beads](https://github.com/steveyegge/beads) is the preferred tracker
+(optional — `brew install beads`). Plan
 writes [BDD](https://cucumber.io/docs/bdd/) acceptance and DDD [ubiquitous
 language](https://martinfowler.com/bliki/UbiquitousLanguage.html) into the bead;
 Implement builds against it; Validate judges a hashed snapshot under

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,12 @@ before upgrading.
 
 ### Fixed
 
+- Onboarding docs name the one real prerequisite: the loop runs as skills
+  inside a coding agent (Claude Code, Codex, Cursor, …) and `/rpi` is typed
+  in that agent's chat. The README Quickstart leads with the universal npx
+  install alone (beads is introduced as the optional tracker it is), and the
+  Codex plugin uninstall uses `codex plugin remove` with the manual cache
+  removal demoted to a fallback for older Codex.
 - Doctor sub-surfaces agree with each other: remediation and the
   triage/next-steps recommendations instruct `--fix` only when a fixer can
   actually act (non-fixable findings name their real manual action),

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -109,9 +109,11 @@ that runtime before linking the checkout so only one corpus is visible:
 
 - Claude Code: `claude plugin uninstall agentops@agentops-marketplace`, then
   `claude plugin marketplace remove agentops-marketplace`.
-- Codex: remove `~/.codex/plugins/cache/agentops-marketplace` and
-  `~/.codex/.agentops-codex-install.json`, then remove the AgentOps plugin enable
-  entry from `~/.codex/config.toml`.
+- Codex: `codex plugin remove agentops@agentops-marketplace`, then
+  `codex plugin marketplace remove agentops-marketplace`. (Older Codex without
+  the plugin verb: remove `~/.codex/plugins/cache/agentops-marketplace` and
+  `~/.codex/.agentops-codex-install.json`, then remove the AgentOps plugin
+  enable entry from `~/.codex/config.toml`.)
 - Gemini/Antigravity: `agy plugin disable agentops-core-gemini`, then
   `agy plugin uninstall agentops-core-gemini`.
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,7 +1,9 @@
 # Getting started
 
-Install or expose the AgentOps skills to your agent runtime, then invoke RPI with
-one behavior:
+AgentOps runs as skills inside a coding agent — Claude Code, Codex, Cursor, or
+any runtime that loads skills. Install the skills into your agent
+(`npx skills@latest add boshu2/agentops --all -g`, a runtime plugin, or a
+source checkout), then invoke RPI **in that agent's chat** with one behavior:
 
 ```text
 /rpi Add an edge-case-safe parser for the supplied format.

--- a/docs/install-day2-ops.md
+++ b/docs/install-day2-ops.md
@@ -79,8 +79,14 @@ claude plugin marketplace remove agentops-marketplace
 
 ### Codex
 
-Remove the old cache and install manifest, then delete the AgentOps plugin enable
-entry from `~/.codex/config.toml`:
+```bash
+codex plugin remove agentops@agentops-marketplace
+codex plugin marketplace remove agentops-marketplace
+```
+
+If the `codex plugin` verb is unavailable (older Codex), remove the cache and
+install manifest by hand, then delete the AgentOps plugin enable entry from
+`~/.codex/config.toml`:
 
 ```bash
 rm -rf ~/.codex/plugins/cache/agentops-marketplace

--- a/docs/newcomer-guide.md
+++ b/docs/newcomer-guide.md
@@ -11,9 +11,12 @@ small behavior and use RPI when you want the full loop.
 - A durable verdict records checked and unchecked claims.
 - The invocation stops.
 
-You do not need a tracker, Git repository, multi-agent substrate, or `ao` binary
-for the semantic loop. If your project has those systems, keep using their native
-workflow after AgentOps reports its verdict.
+The one thing you do need is a coding agent to run the skills in: AgentOps
+skills execute inside your agent runtime (Claude Code, Codex, Cursor, …), and
+`/rpi` is typed in that agent's chat. You do not need a tracker, Git
+repository, multi-agent substrate, or `ao` binary for the semantic loop. If
+your project has those systems, keep using their native workflow after
+AgentOps reports its verdict.
 
 Use [premortem](https://github.com/boshu2/agentops/blob/main/skills/premortem/SKILL.md)
 when a plan deserves an advisory challenge,


### PR DESCRIPTION
Wave 3 (final) of the new-user happy-path fixes from the fresh-eyes novice test.

**Edge 5** — no doc ever named the one real prerequisite (a coding agent) or where `/rpi` is typed; the newcomer guide only listed what you *don't* need. README Quickstart, newcomer-guide, and getting-started now say it plainly: the loop runs as skills inside your coding agent (Claude Code, Codex, Cursor, …) and `/rpi` goes in that agent's chat.

**Edge 10** — the Quickstart's first command was `brew install beads` while the same README insists no tracker is needed. The first block is now the universal npx line alone; beads is introduced in the bead section as the optional tracker it is.

**Edge 9** — Codex installed via the `codex plugin` verb but uninstalled via manual `rm -rf` + config.toml hand-editing. `codex plugin remove` (verified in `codex plugin --help`: "Remove an installed plugin from local config and cache") is now primary in install-day2-ops and MIGRATION; the manual path is an explicit older-Codex fallback.

**Verified:** `ao gate check --full` 67/67 over this range (changelog sync, doc-release checks, skill snippets). Doc-only — no binary changes.