### PR TITLE
fix(cli): residue wave — doctor dev-version coherence, diff --only, config-models removal, dual-root stragglers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ before upgrading.
 
 ### Fixed
 
+- A from-source `ao` build whose version matches its checkout is no longer
+  flagged by doctor: the dev-version detector reuses the Binary Freshness
+  resolution and fires only on genuine drift, shadowed duplicate binaries,
+  or (outside a checkout) an informational from-source note. `ao doctor
+  diff --only <id>` scopes the fix-plan preview.
+- The dead `ao config models` surface was removed (nothing consumed model
+  tiers); existing `models:` config sections still parse and are ignored,
+  and the removed subcommand points at the migration map.
+- The remaining single-rooted knowledge readers follow the canonical
+  `.agents/ao/<section>` directories alongside the legacy roots: the
+  learning-coherence gate, constraint counting, and the eval sandbox
+  corpus deny-list.
+- The strict docs-link backstop's allowlist was refreshed (all 53 entries
+  referenced Cathedral-Cut-deleted docs); ROADMAP, the documentation
+  index generator, and the doc skill's references no longer point at
+  files that don't exist.
 - Onboarding docs name the one real prerequisite: the loop runs as skills
   inside a coding agent (Claude Code, Codex, Cursor, …) and `/rpi` is typed
   in that agent's chat. The README Quickstart leads with the universal npx

--- a/cli/cmd/ao/config_test.go
+++ b/cli/cmd/ao/config_test.go
@@ -100,26 +100,28 @@ func TestRunConfig_NoFlags_ShowsHelp(t *testing.T) {
 	}
 }
 
-func TestConfigModuleHonorsGlobalDryRun(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("AGENTOPS_CONFIG", filepath.Join(home, "config.yaml"))
-	originalDryRun, originalOutput := dryRun, output
-	dryRun, output = true, "table"
-	t.Cleanup(func() { dryRun, output = originalDryRun, originalOutput })
-
+// TestConfigModelsRemoved_UnknownCommand pins the removal of the `ao config
+// models` surface: "models" must now be rejected exactly like any other
+// unknown token under config, and the config tree must not register a models
+// subcommand or its --set-tier/--set-skill flags.
+func TestConfigModelsRemoved_UnknownCommand(t *testing.T) {
 	command := newConfigCommand()
-	var stdout strings.Builder
-	command.SetOut(&stdout)
-	command.SetArgs([]string{"models", "--set-tier", "quality"})
-	if err := command.Execute(); err != nil {
-		t.Fatal(err)
+	for _, child := range command.Commands() {
+		if child.Name() == "models" {
+			t.Fatal("config still registers a models subcommand")
+		}
 	}
-	if _, err := os.Stat(os.Getenv("AGENTOPS_CONFIG")); !os.IsNotExist(err) {
-		t.Fatalf("global dry-run wrote config: %v", err)
+
+	fresh := newConfigCommand()
+	fresh.SetOut(&strings.Builder{})
+	fresh.SetErr(&strings.Builder{})
+	fresh.SetArgs([]string{"models"})
+	err := fresh.Execute()
+	if err == nil {
+		t.Fatal("expected error for removed `config models` subcommand, got nil")
 	}
-	if !strings.Contains(stdout.String(), "Would set default model tier") {
-		t.Fatalf("dry-run preview missing: %q", stdout.String())
+	if want := `unknown command "models" for "config"`; err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
 	}
 }
 
@@ -243,255 +245,6 @@ func TestRunConfig_ShowTable_WithEnvVars(t *testing.T) {
 	}
 }
 
-func TestRunConfigModels_Table(t *testing.T) {
-	dir := t.TempDir()
-	t.Chdir(dir)
-
-	oldOutput := output
-	output = "table"
-	defer func() { output = oldOutput }()
-
-	stdout, err := captureStdout(t, func() error {
-		return runConfigModels(&cobra.Command{}, nil)
-	})
-	if err != nil {
-		t.Fatalf("runConfigModels: %v", err)
-	}
-
-	if !strings.Contains(stdout, "Model Cost Tiers") {
-		t.Errorf("expected 'Model Cost Tiers' header, got: %q", stdout)
-	}
-	if !strings.Contains(stdout, "Default tier: balanced") {
-		t.Errorf("expected default tier balanced, got: %q", stdout)
-	}
-	if !strings.Contains(stdout, "quality") {
-		t.Errorf("expected 'quality' tier listed, got: %q", stdout)
-	}
-	if !strings.Contains(stdout, "opus") {
-		t.Errorf("expected 'opus' model for quality tier, got: %q", stdout)
-	}
-}
-
-func TestRunConfigModels_JSON(t *testing.T) {
-	dir := t.TempDir()
-	t.Chdir(dir)
-
-	oldOutput := output
-	output = "json"
-	defer func() { output = oldOutput }()
-
-	stdout, err := captureStdout(t, func() error {
-		return runConfigModels(&cobra.Command{}, nil)
-	})
-	if err != nil {
-		t.Fatalf("runConfigModels --json: %v", err)
-	}
-
-	var parsed config.ModelsConfig
-	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
-		t.Fatalf("expected valid JSON, got: %q (%v)", stdout, err)
-	}
-
-	if parsed.DefaultTier != "balanced" {
-		t.Errorf("expected default_tier=balanced, got %q", parsed.DefaultTier)
-	}
-	if len(parsed.Tiers) != 3 {
-		t.Errorf("expected 3 tiers, got %d", len(parsed.Tiers))
-	}
-}
-
-func TestRunConfigModels_WithEnvOverride(t *testing.T) {
-	dir := t.TempDir()
-	t.Chdir(dir)
-
-	t.Setenv("AGENTOPS_MODEL_TIER", "budget")
-
-	oldOutput := output
-	output = "table"
-	defer func() { output = oldOutput }()
-
-	stdout, err := captureStdout(t, func() error {
-		return runConfigModels(&cobra.Command{}, nil)
-	})
-	if err != nil {
-		t.Fatalf("runConfigModels: %v", err)
-	}
-
-	if !strings.Contains(stdout, "Default tier: budget") {
-		t.Errorf("expected default tier budget from env, got: %q", stdout)
-	}
-	if !strings.Contains(stdout, "AGENTOPS_MODEL_TIER=budget") {
-		t.Errorf("expected env var in output, got: %q", stdout)
-	}
-}
-
-func TestConfigModels_SetTier(t *testing.T) {
-	dir := t.TempDir()
-	t.Chdir(dir)
-
-	// Clear env so project config is used from cwd
-	t.Setenv("AGENTOPS_CONFIG", "")
-
-	oldSetTier := modelsSetTier
-	oldSetSkill := modelsSetSkill
-	modelsSetTier = "quality"
-	modelsSetSkill = ""
-	defer func() {
-		modelsSetTier = oldSetTier
-		modelsSetSkill = oldSetSkill
-	}()
-
-	stdout, err := captureStdout(t, func() error {
-		return runConfigModels(&cobra.Command{}, nil)
-	})
-	if err != nil {
-		t.Fatalf("runConfigModels --set-tier: %v", err)
-	}
-
-	if !strings.Contains(stdout, `Set default model tier to "quality"`) {
-		t.Errorf("expected confirmation message, got: %q", stdout)
-	}
-
-	// Verify config was written
-	cfg, loadErr := config.Load(nil)
-	if loadErr != nil {
-		t.Fatalf("Load after set-tier: %v", loadErr)
-	}
-	if cfg.Models.DefaultTier != "quality" {
-		t.Errorf("saved DefaultTier = %q, want %q", cfg.Models.DefaultTier, "quality")
-	}
-}
-
-func TestConfigModels_SetSkill(t *testing.T) {
-	dir := t.TempDir()
-	t.Chdir(dir)
-
-	t.Setenv("AGENTOPS_CONFIG", "")
-
-	oldSetTier := modelsSetTier
-	oldSetSkill := modelsSetSkill
-	modelsSetTier = ""
-	modelsSetSkill = "council=quality"
-	defer func() {
-		modelsSetTier = oldSetTier
-		modelsSetSkill = oldSetSkill
-	}()
-
-	stdout, err := captureStdout(t, func() error {
-		return runConfigModels(&cobra.Command{}, nil)
-	})
-	if err != nil {
-		t.Fatalf("runConfigModels --set-skill: %v", err)
-	}
-
-	if !strings.Contains(stdout, `Set skill "council" tier to "quality"`) {
-		t.Errorf("expected confirmation message, got: %q", stdout)
-	}
-
-	cfg, loadErr := config.Load(nil)
-	if loadErr != nil {
-		t.Fatalf("Load after set-skill: %v", loadErr)
-	}
-	if cfg.Models.SkillOverrides["council"] != "quality" {
-		t.Errorf("saved SkillOverrides[council] = %q, want %q", cfg.Models.SkillOverrides["council"], "quality")
-	}
-}
-
-func TestConfigModels_SetTierAndSkill_JSON(t *testing.T) {
-	dir := t.TempDir()
-	t.Chdir(dir)
-
-	t.Setenv("AGENTOPS_CONFIG", "")
-
-	oldOutput := output
-	oldSetTier := modelsSetTier
-	oldSetSkill := modelsSetSkill
-	output = "json"
-	modelsSetTier = "budget"
-	modelsSetSkill = "council=quality"
-	defer func() {
-		output = oldOutput
-		modelsSetTier = oldSetTier
-		modelsSetSkill = oldSetSkill
-	}()
-
-	stdout, err := captureStdout(t, func() error {
-		return runConfigModels(&cobra.Command{}, nil)
-	})
-	if err != nil {
-		t.Fatalf("runConfigModels --set-tier --set-skill --json: %v", err)
-	}
-	if strings.Contains(stdout, "Set default model tier") || strings.Contains(stdout, "Set skill") {
-		t.Fatalf("expected JSON-only output, got human text: %q", stdout)
-	}
-
-	var parsed configModelsWriteResult
-	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
-		t.Fatalf("expected valid JSON, got: %q (%v)", stdout, err)
-	}
-	if !parsed.Updated {
-		t.Fatal("expected updated=true")
-	}
-	if parsed.DefaultTier != "budget" {
-		t.Errorf("default_tier = %q, want %q", parsed.DefaultTier, "budget")
-	}
-	if parsed.SkillOverrides["council"] != "quality" {
-		t.Errorf("skill_overrides[council] = %q, want %q", parsed.SkillOverrides["council"], "quality")
-	}
-
-	cfg, loadErr := config.Load(nil)
-	if loadErr != nil {
-		t.Fatalf("Load after JSON write: %v", loadErr)
-	}
-	if cfg.Models.DefaultTier != "budget" {
-		t.Errorf("saved DefaultTier = %q, want %q", cfg.Models.DefaultTier, "budget")
-	}
-	if cfg.Models.SkillOverrides["council"] != "quality" {
-		t.Errorf("saved SkillOverrides[council] = %q, want %q", cfg.Models.SkillOverrides["council"], "quality")
-	}
-}
-
-func TestConfigModels_SetTier_InvalidTier(t *testing.T) {
-	oldSetTier := modelsSetTier
-	oldSetSkill := modelsSetSkill
-	defer func() {
-		modelsSetTier = oldSetTier
-		modelsSetSkill = oldSetSkill
-	}()
-
-	tests := []struct {
-		name    string
-		tier    string
-		wantErr string
-	}{
-		{
-			name:    "unknown tier",
-			tier:    "premium",
-			wantErr: "invalid tier",
-		},
-		{
-			name:    "inherit not allowed for default",
-			tier:    "inherit",
-			wantErr: "inherit",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			modelsSetTier = tt.tier
-			modelsSetSkill = ""
-
-			err := runConfigModels(&cobra.Command{}, nil)
-			if err == nil {
-				t.Fatal("expected error for invalid tier, got nil")
-			}
-			if !strings.Contains(err.Error(), tt.wantErr) {
-				t.Errorf("error = %q, want to contain %q", err.Error(), tt.wantErr)
-			}
-		})
-	}
-}
-
 func TestRunConfig_ShowTable_NoEnvVars(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -531,33 +284,5 @@ func TestRunConfig_ShowTable_NoEnvVars(t *testing.T) {
 func TestConfigCommandsRejectPositionalArgs(t *testing.T) {
 	if err := configCmd.Args(configCmd, []string{"junk"}); err == nil {
 		t.Fatal("config accepted an unexpected positional argument")
-	}
-	if err := configModelsCmd.Args(configModelsCmd, []string{"junk"}); err == nil {
-		t.Fatal("config models accepted an unexpected positional argument")
-	}
-}
-
-func TestRunConfigModelsSortsSkillOverrides(t *testing.T) {
-	dir := t.TempDir()
-	t.Chdir(dir)
-	t.Setenv("AGENTOPS_CONFIG", "")
-	if err := os.MkdirAll(filepath.Join(dir, ".agents", "ao"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	body := "models:\n  skill_overrides:\n    zebra: budget\n    alpha: quality\n"
-	if err := os.WriteFile(filepath.Join(dir, ".agents", "ao", "config.yaml"), []byte(body), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	oldOutput := output
-	output = "table"
-	defer func() { output = oldOutput }()
-	stdout, err := captureStdout(t, func() error { return runConfigModels(&cobra.Command{}, nil) })
-	if err != nil {
-		t.Fatal(err)
-	}
-	alpha := strings.Index(stdout, "alpha")
-	zebra := strings.Index(stdout, "zebra")
-	if alpha < 0 || zebra < 0 || alpha > zebra {
-		t.Fatalf("skill overrides are not sorted:\n%s", stdout)
 	}
 }

--- a/cli/cmd/ao/config_test_shims_test.go
+++ b/cli/cmd/ao/config_test_shims_test.go
@@ -3,25 +3,13 @@ package main
 import (
 	"os"
 
-	configapp "github.com/boshu2/agentops/cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
 var (
-	configShow      bool
-	modelsSetTier   string
-	modelsSetSkill  string
-	configCmd       = newConfigCommand()
-	configModelsCmd = func() *cobra.Command {
-		command, _, err := configCmd.Find([]string{"models"})
-		if err != nil {
-			panic(err)
-		}
-		return command
-	}()
+	configShow bool
+	configCmd  = newConfigCommand()
 )
-
-type configModelsWriteResult = configapp.ModelsWriteResult
 
 func runConfig(command *cobra.Command, args []string) error {
 	fresh := newConfigCommand()
@@ -30,20 +18,4 @@ func runConfig(command *cobra.Command, args []string) error {
 	}
 	fresh.SetOut(os.Stdout)
 	return fresh.RunE(command, args)
-}
-
-func runConfigModels(command *cobra.Command, args []string) error {
-	fresh := newConfigCommand()
-	models, _, err := fresh.Find([]string{"models"})
-	if err != nil {
-		return err
-	}
-	if modelsSetTier != "" {
-		_ = models.Flags().Set("set-tier", modelsSetTier)
-	}
-	if modelsSetSkill != "" {
-		_ = models.Flags().Set("set-skill", modelsSetSkill)
-	}
-	models.SetOut(os.Stdout)
-	return models.RunE(command, args)
 }

--- a/cli/cmd/ao/removed_command_hint.go
+++ b/cli/cmd/ao/removed_command_hint.go
@@ -78,6 +78,9 @@ var removedCommands = map[string]removedCommand{
 
 // removedChildCommands covers retired subcommands under retained parents.
 var removedChildCommands = map[string]map[string]removedCommand{
+	"config": {
+		"models": {use: "model-tier configuration was removed; nothing consumed it — model choice belongs to the caller's runtime"},
+	},
 	"goals": {
 		"trace": {use: "the directive-to-bead lifecycle chain was retired; inspect current goal and scenario artifacts directly"},
 	},

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -109,6 +109,13 @@ Show what --fix would change (read-only)
 ao doctor diff [flags]
 ```
 
+**Flags:**
+
+```
+  -h, --help           help for diff
+      --only strings   Scope the fix-plan preview to finding ids or subsystems (comma-separated), mirroring --fix --only
+```
+
 #### `ao doctor explain`
 
 Expand a single finding with full evidence
@@ -875,7 +882,7 @@ ao completion [bash|zsh|fish|powershell]
 View and manage AgentOps configuration.
 
 ```
-ao config [command]
+ao config [flags]
 ```
 
 **Flags:**
@@ -883,24 +890,6 @@ ao config [command]
 ```
   -h, --help   help for config
       --show   Show resolved configuration with sources
-```
-
-**Subcommands:**
-
-#### `ao config models`
-
-Display the current model cost tier settings with sources.
-
-```
-ao config models [flags]
-```
-
-**Flags:**
-
-```
-  -h, --help               help for models
-      --set-skill string   Set a skill-specific tier override (e.g. council=quality)
-      --set-tier string    Set the default model cost tier (quality, balanced, budget)
 ```
 
 ---

--- a/cli/internal/adapters/eval/scenario_ab_sandbox.go
+++ b/cli/internal/adapters/eval/scenario_ab_sandbox.go
@@ -253,12 +253,31 @@ func symlinkClosureDenyTargets(initialRoots []string, maxDirs, maxEntries int) (
 func configCorpusDenyPaths(globalLearningsDir, globalPatternsDir string) []string {
 	var out []string
 	if d := strings.TrimSpace(globalLearningsDir); d != "" {
-		out = append(out, d, filepath.Join(filepath.Dir(d), "findings"))
+		out = appendWithCanonicalAo(out, d)
+		out = appendWithCanonicalAo(out, filepath.Join(filepath.Dir(d), "findings"))
 	}
 	if d := strings.TrimSpace(globalPatternsDir); d != "" {
-		out = append(out, d)
+		out = appendWithCanonicalAo(out, d)
 	}
 	return out
+}
+
+// appendWithCanonicalAo appends the section dir d AND its canonical ao
+// counterpart (<parent>/ao/<section>). The config Paths defaults are
+// single-rooted LEGACY section dirs (<base>/learnings etc.), but doctor's
+// split fixer migrates the corpus to the canonical <base>/ao/<section>; a deny
+// set built only from the legacy dirs leaves the migrated canonical dirs
+// readable by the control arm. A dir that is already canonical (its parent is
+// named "ao") gets no ao/ao echo. Extra deny entries for a counterpart that
+// does not exist on disk are harmless: the closure walk treats NotExist roots
+// as empty and Seatbelt subpath denies of absent paths deny nothing.
+func appendWithCanonicalAo(out []string, d string) []string {
+	out = append(out, d)
+	parent := filepath.Dir(d)
+	if filepath.Base(parent) == "ao" {
+		return out
+	}
+	return append(out, filepath.Join(parent, "ao", filepath.Base(d)))
 }
 
 // envCorpusDenyPaths returns the corpus dir an AO_AGENTS_DIR / AO_HOME env override
@@ -294,7 +313,10 @@ func localCorpusDenyPaths(root, learningsDir, patternsDir string) []string {
 		if within(d, filepath.Join(root, ".agents")) {
 			continue
 		}
-		out = append(out, d)
+		// Deny the canonical ao counterpart too (see appendWithCanonicalAo): the
+		// config default is the legacy single-rooted dir, but a doctor-migrated
+		// corpus lives at <parent>/ao/<section>.
+		out = appendWithCanonicalAo(out, d)
 	}
 	return out
 }

--- a/cli/internal/adapters/eval/scenario_ab_sandbox_test.go
+++ b/cli/internal/adapters/eval/scenario_ab_sandbox_test.go
@@ -70,6 +70,57 @@ func TestConfigCorpusDenyPaths_CustomGlobalRoots(t *testing.T) {
 	}
 }
 
+// TestConfigCorpusDenyPaths_CanonicalAoCounterparts: the config Paths defaults are
+// single-rooted legacy section dirs (<base>/learnings etc.), but doctor's split
+// fixer migrates the corpus to the CANONICAL <base>/ao/<section>. A deny set built
+// only from the legacy config dirs leaves the migrated canonical dirs readable by
+// the control arm. The deny set must contain BOTH roots for every config-resolved
+// section (learnings, derived findings, patterns).
+func TestConfigCorpusDenyPaths_CanonicalAoCounterparts(t *testing.T) {
+	got := configCorpusDenyPaths("/data/corpus/learnings", "/opt/patterns")
+	joined := strings.Join(got, "|")
+	for _, want := range []string{
+		"/data/corpus/learnings", // legacy root
+		filepath.Join("/data/corpus", "ao", "learnings"),
+		filepath.Join("/data/corpus", "findings"),
+		filepath.Join("/data/corpus", "ao", "findings"),
+		"/opt/patterns", // legacy root
+		filepath.Join("/opt", "ao", "patterns"),
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("deny set must contain both legacy and canonical ao roots; missing %q in %v", want, got)
+		}
+	}
+}
+
+// TestLocalCorpusDenyPaths_CanonicalAoCounterparts: an absolute config-local
+// section dir outside <root>/.agents must be denied together with its canonical
+// ao counterpart (<parent>/ao/<section>), so a doctor-migrated local corpus is
+// not readable by the control arm.
+func TestLocalCorpusDenyPaths_CanonicalAoCounterparts(t *testing.T) {
+	root := t.TempDir()
+	got := localCorpusDenyPaths(root, "/custom/learnings", "/opt/patterns")
+	joined := strings.Join(got, "|")
+	for _, want := range []string{
+		"/custom/learnings",
+		filepath.Join("/custom", "ao", "learnings"),
+		"/opt/patterns",
+		filepath.Join("/opt", "ao", "patterns"),
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("deny set must contain both legacy and canonical ao roots; missing %q in %v", want, got)
+		}
+	}
+
+	// A dir that IS already canonical (<parent>/ao/<section>) gets no ao/ao/... echo.
+	got = localCorpusDenyPaths(root, "/custom/ao/learnings", "")
+	for _, p := range got {
+		if strings.Contains(p, filepath.Join("ao", "ao")) {
+			t.Errorf("already-canonical dir must not produce an ao/ao counterpart; got %v", got)
+		}
+	}
+}
+
 // TestEnvCorpusDenyPaths_NonDefaultOverride: a NON-DEFAULT AO_AGENTS_DIR (or AO_HOME)
 // redirects where `ao` reads the corpus OUTSIDE <root>/.agents, so the resolved
 // override must enter the deny set; with no override (or the default), nothing is

--- a/cli/internal/commands/config/module.go
+++ b/cli/internal/commands/config/module.go
@@ -4,7 +4,6 @@ package config
 import (
 	"context"
 	"fmt"
-	"sort"
 
 	"github.com/spf13/cobra"
 
@@ -19,12 +18,8 @@ var showEnvironmentKeys = []string{
 	"AGENTOPS_CONFIG", "AGENTOPS_OUTPUT", "AGENTOPS_BASE_DIR", "AGENTOPS_VERBOSE",
 }
 
-var modelEnvironmentKeys = []string{"AGENTOPS_MODEL_TIER", "AGENTOPS_COUNCIL_MODEL_TIER", "COUNCIL_CLAUDE_MODEL"}
-
 type UseCases interface {
 	Show(context.Context, string, bool) (configapp.ShowResult, error)
-	Models(context.Context) (configapp.ModelsResult, error)
-	WriteModels(context.Context, configapp.ModelsWriteRequest) (configapp.ModelsWriteResult, error)
 }
 
 type Module struct {
@@ -33,9 +28,7 @@ type Module struct {
 }
 
 type options struct {
-	show     bool
-	setTier  string
-	setSkill string
+	show bool
 }
 
 func NewModule(useCases UseCases, host clicontract.HostOptions) Module {
@@ -73,33 +66,7 @@ func (module Module) Command() *cobra.Command {
 		}
 		return renderShow(command, module.host.OutputMode(), result)
 	}
-	models := module.modelsCommand(&commandOptions)
-	root.AddCommand(models)
 	return root
-}
-
-func (module Module) modelsCommand(commandOptions *options) *cobra.Command {
-	command := &cobra.Command{Use: "models", Short: "Show model cost tier configuration", Long: modelsLong, Args: cobra.NoArgs}
-	command.Flags().StringVar(&commandOptions.setTier, "set-tier", "", "Set the default model cost tier (quality, balanced, budget)")
-	command.Flags().StringVar(&commandOptions.setSkill, "set-skill", "", "Set a skill-specific tier override (e.g. council=quality)")
-	_ = command.RegisterFlagCompletionFunc("set-tier", staticValues("quality", "balanced", "budget"))
-	command.RunE = func(command *cobra.Command, _ []string) error {
-		if commandOptions.setTier != "" || commandOptions.setSkill != "" {
-			result, err := module.useCases.WriteModels(command.Context(), configapp.ModelsWriteRequest{
-				DefaultTier: commandOptions.setTier, Skill: commandOptions.setSkill, DryRun: module.host.DryRun != nil && module.host.DryRun(),
-			})
-			if err != nil {
-				return err
-			}
-			return renderModelsWrite(command, module.host.OutputMode(), commandOptions.setTier, commandOptions.setSkill, result)
-		}
-		result, err := module.useCases.Models(command.Context())
-		if err != nil {
-			return err
-		}
-		return renderModels(command, module.host.OutputMode(), result)
-	}
-	return command
 }
 
 // outputFlagValue returns the negotiated output mode only when the user
@@ -153,91 +120,6 @@ func printConfigLayer(w interface{ Write([]byte) (int, error) }, label, path str
 	printConfigFile(w, label, path, exists)
 }
 
-func renderModels(command *cobra.Command, output string, result configapp.ModelsResult) error {
-	if output == "yaml" {
-		return writeYAML(command, result.Config.Models, "marshal models config")
-	}
-	if output == "json" {
-		return writeJSON(command, result.Config.Models, "marshal models config")
-	}
-	w := command.OutOrStdout()
-	cfg := result.Config
-	fmt.Fprintln(w, "Model Cost Tiers")
-	fmt.Fprintln(w, "================")
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  Default tier: %s\n\n", cfg.Models.DefaultTier)
-	fmt.Fprintln(w, "  Available tiers:")
-	for _, name := range []string{"quality", "balanced", "budget"} {
-		tier, ok := cfg.Models.Tiers[name]
-		if !ok {
-			continue
-		}
-		marker := " "
-		if name == cfg.ResolveTier("") {
-			marker = "*"
-		}
-		codex := tier.Codex
-		if codex == "" {
-			codex = "(default)"
-		}
-		fmt.Fprintf(w, "  %s %-10s  claude=%-8s  codex=%s\n", marker, name, tier.Claude, codex)
-	}
-	fmt.Fprintln(w)
-	if len(cfg.Models.SkillOverrides) == 0 {
-		fmt.Fprintln(w, "  Skill overrides: (none)")
-	} else {
-		fmt.Fprintln(w, "  Skill overrides:")
-		skills := make([]string, 0, len(cfg.Models.SkillOverrides))
-		for skill := range cfg.Models.SkillOverrides {
-			skills = append(skills, skill)
-		}
-		sort.Strings(skills)
-		for _, skill := range skills {
-			tier, resolved := cfg.Models.SkillOverrides[skill], cfg.ResolveTier(skill)
-			if tier == resolved {
-				fmt.Fprintf(w, "    %-12s → %s\n", skill, tier)
-			} else {
-				fmt.Fprintf(w, "    %-12s → %s (resolves to %s)\n", skill, tier, resolved)
-			}
-		}
-	}
-	fmt.Fprintln(w)
-	fmt.Fprintln(w, "  Environment overrides:")
-	printEnvironment(w, modelEnvironmentKeys, result.Environment, "    ")
-	return nil
-}
-
-func renderModelsWrite(command *cobra.Command, output, tier, skill string, result configapp.ModelsWriteResult) error {
-	if output == "yaml" {
-		return writeYAML(command, result, "marshal models write result")
-	}
-	if output == "json" {
-		return writeJSON(command, result, "marshal models write result")
-	}
-	w := command.OutOrStdout()
-	verb := "Set"
-	if result.DryRun {
-		verb = "Would set"
-	}
-	if tier != "" {
-		fmt.Fprintf(w, "%s default model tier to %q\n", verb, tier)
-	}
-	if skill != "" {
-		parts := splitSkill(skill)
-		fmt.Fprintf(w, "%s skill %q tier to %q\n", verb, parts[0], parts[1])
-	}
-	return nil
-}
-
-func splitSkill(value string) []string {
-	for index := 0; index < len(value); index++ {
-		if value[index] == '=' {
-			return []string{value[:index], value[index+1:]}
-		}
-	}
-	return []string{value, ""}
-}
-
 func writeJSON(command *cobra.Command, value any, label string) error {
 	if err := clicontract.WriteJSON(command.OutOrStdout(), value); err != nil {
 		return fmt.Errorf("%s: %w", label, err)
@@ -273,14 +155,6 @@ func printEnvironment(w interface{ Write([]byte) (int, error) }, keys []string, 
 	}
 }
 
-func staticValues(values ...string) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
-	sorted := append([]string(nil), values...)
-	sort.Strings(sorted)
-	return func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
-		return sorted, cobra.ShellCompDirectiveNoFileComp
-	}
-}
-
 const configLong = `View and manage AgentOps configuration.
 
 Configuration priority (highest to lowest):
@@ -299,22 +173,3 @@ Environment variables:
 Examples:
   ao config --show           # Show resolved configuration
   ao config --show --json   # Output as JSON`
-
-const modelsLong = `Display the current model cost tier settings with sources.
-
-Cost tiers map to model quality levels:
-  quality  → opus   (high-stakes decisions, architecture)
-  balanced → sonnet (default, routine reviews)
-  budget   → haiku  (quick checks, simple tasks)
-  inherit  → uses default tier (falls back to balanced)
-
-Configure in .agents/ao/config.yaml:
-  models:
-    default_tier: balanced
-    skill_overrides:
-      council: quality
-      crank: budget
-
-Or via environment variables:
-  AGENTOPS_MODEL_TIER=budget
-  AGENTOPS_COUNCIL_MODEL_TIER=quality`

--- a/cli/internal/commands/config/module_test.go
+++ b/cli/internal/commands/config/module_test.go
@@ -19,23 +19,11 @@ import (
 )
 
 type fakeUseCases struct {
-	showResult   configapp.ShowResult
-	modelsResult configapp.ModelsResult
-	writeRequest configapp.ModelsWriteRequest
-	writeResult  configapp.ModelsWriteResult
+	showResult configapp.ShowResult
 }
 
 func (useCases *fakeUseCases) Show(context.Context, string, bool) (configapp.ShowResult, error) {
 	return useCases.showResult, nil
-}
-
-func (useCases *fakeUseCases) Models(context.Context) (configapp.ModelsResult, error) {
-	return useCases.modelsResult, nil
-}
-
-func (useCases *fakeUseCases) WriteModels(_ context.Context, request configapp.ModelsWriteRequest) (configapp.ModelsWriteResult, error) {
-	useCases.writeRequest = request
-	return useCases.writeResult, nil
 }
 
 func TestModuleShowJSONUsesCommandWriter(t *testing.T) {
@@ -52,37 +40,25 @@ func TestModuleShowJSONUsesCommandWriter(t *testing.T) {
 	}
 }
 
-func TestModuleModelsWriteParsesDelegatesAndRenders(t *testing.T) {
-	useCases := &fakeUseCases{writeResult: configapp.ModelsWriteResult{Updated: true, DefaultTier: "quality"}}
-	command := NewModule(useCases, clicontract.HostOptions{OutputMode: func() string { return "table" }, Verbose: func() bool { return false }, DryRun: func() bool { return false }}).Command()
+// TestModuleModelsSubcommandRemoved pins the retirement of `ao config models`:
+// the module tree registers no models child, so cobra rejects the token via
+// the root's NoArgs validator exactly like any unknown token.
+func TestModuleModelsSubcommandRemoved(t *testing.T) {
+	useCases := &fakeUseCases{showResult: configapp.ShowResult{Resolved: &configapp.ResolvedConfig{}}}
+	command := NewModule(useCases, realHost("table")).Command()
+	if command.HasSubCommands() {
+		t.Fatalf("config registers subcommands, want none: %v", command.Commands())
+	}
 	var stdout bytes.Buffer
 	command.SetOut(&stdout)
-	command.SetArgs([]string{"models", "--set-tier", "quality", "--set-skill", "council=budget"})
-	if err := command.Execute(); err != nil {
-		t.Fatal(err)
+	command.SetErr(&stdout)
+	command.SetArgs([]string{"models"})
+	err := command.Execute()
+	if err == nil {
+		t.Fatal("expected error for removed `models` subcommand, got nil")
 	}
-	if useCases.writeRequest.DefaultTier != "quality" || useCases.writeRequest.Skill != "council=budget" {
-		t.Fatalf("request = %+v", useCases.writeRequest)
-	}
-	if got := stdout.String(); got != "Set default model tier to \"quality\"\nSet skill \"council\" tier to \"budget\"\n" {
-		t.Fatalf("stdout = %q", got)
-	}
-}
-
-func TestModuleModelsDryRunDelegatesAndRendersPreview(t *testing.T) {
-	useCases := &fakeUseCases{writeResult: configapp.ModelsWriteResult{DryRun: true, DefaultTier: "quality"}}
-	command := NewModule(useCases, clicontract.HostOptions{OutputMode: func() string { return "table" }, Verbose: func() bool { return false }, DryRun: func() bool { return true }}).Command()
-	var stdout bytes.Buffer
-	command.SetOut(&stdout)
-	command.SetArgs([]string{"models", "--set-tier", "quality"})
-	if err := command.Execute(); err != nil {
-		t.Fatal(err)
-	}
-	if !useCases.writeRequest.DryRun {
-		t.Fatal("dry-run was not passed to the use case")
-	}
-	if got := stdout.String(); got != "Would set default model tier to \"quality\"\n" {
-		t.Fatalf("stdout = %q", got)
+	if want := `unknown command "models" for "config"`; err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
 	}
 }
 

--- a/cli/internal/commands/doctor/module.go
+++ b/cli/internal/commands/doctor/module.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -443,11 +445,30 @@ func (module Module) listCommand(options *rootOptions) *cobra.Command {
 }
 
 func (module Module) diffCommand(options *rootOptions) *cobra.Command {
-	return &cobra.Command{Use: "diff", Short: "Show what --fix would change (read-only)", Args: cobra.NoArgs, RunE: func(command *cobra.Command, _ []string) error {
+	var only []string
+	command := &cobra.Command{Use: "diff", Short: "Show what --fix would change (read-only)", Args: cobra.NoArgs}
+	// --only mirrors `ao doctor --fix --only <id[,id...]>` (same StringSlice
+	// parsing) so the remediation text's scoped fix has a scoped preview.
+	command.Flags().StringSliceVar(&only, "only", nil, "Scope the fix-plan preview to finding ids or subsystems (comma-separated), mirroring --fix --only")
+	command.RunE = func(command *cobra.Command, _ []string) error {
 		jsonOutput := module.wantsJSON(command, options)
-		report, err := module.useCases.Read.Diff(command.Context(), readRequest(*options, true, jsonOutput))
+		request := readRequest(*options, true, jsonOutput)
+		request.Only = append(request.Only, only...)
+		report, err := module.useCases.Read.Diff(command.Context(), request)
 		if err != nil {
 			return exit(doctorapp.ExitIOError, err.Error())
+		}
+		if len(only) > 0 {
+			kept, unknown := filterFindingsByOnly(report.Findings, only)
+			if len(unknown) > 0 {
+				// A typo'd id gets a clear message; the exit code stays
+				// unchanged (0) because diff is a read-only preview.
+				fmt.Fprintf(command.ErrOrStderr(),
+					"ao doctor diff: unknown --only id(s): %s — no such detector, subsystem, or finding; list detector ids with: ao doctor capabilities\n",
+					strings.Join(unknown, ", "))
+				return nil
+			}
+			report.Findings = kept
 		}
 		if jsonOutput {
 			return module.emitStructured(command, report)
@@ -457,7 +478,40 @@ func (module Module) diffCommand(options *rootOptions) *cobra.Command {
 		// of the fix plan, not a health verdict — `ao doctor` / `ao doctor
 		// health` own the failing exit for findings.
 		return nil
-	}}
+	}
+	return command
+}
+
+// filterFindingsByOnly filters the fix-plan findings to the requested --only
+// values (finding/detector ids or subsystems, the same vocabulary --fix --only
+// scopes by) and reports values naming no registered detector, subsystem, or
+// rendered finding as unknown.
+func filterFindingsByOnly(findings []doctorapp.Finding, only []string) (kept []doctorapp.Finding, unknown []string) {
+	want := make(map[string]bool, len(only))
+	for _, value := range only {
+		if value = strings.TrimSpace(value); value != "" {
+			want[value] = true
+		}
+	}
+	known := make(map[string]bool)
+	for _, detector := range doctorapp.Detectors() {
+		known[detector.ID()] = true
+		known[detector.Subsystem()] = true
+	}
+	for _, finding := range findings {
+		known[finding.ID] = true
+		known[finding.Subsystem] = true
+		if want[finding.ID] || want[finding.Subsystem] {
+			kept = append(kept, finding)
+		}
+	}
+	for value := range want {
+		if !known[value] {
+			unknown = append(unknown, value)
+		}
+	}
+	sort.Strings(unknown)
+	return kept, unknown
 }
 
 // renderFixPlan renders the diff output as an explicit fix PLAN: for each

--- a/cli/internal/commands/doctor/module_test.go
+++ b/cli/internal/commands/doctor/module_test.go
@@ -270,6 +270,73 @@ func TestDiffRendersFixPlan(t *testing.T) {
 	}
 }
 
+// TestDiffOnlyScopesFixPlan guards wave-4 residual 2: `ao doctor diff` must
+// accept --only <id[,id...]> (mirroring `--fix --only`) so a scoped fix-plan
+// preview is possible — remediation text tells operators to run
+// `--fix --only <id>`, so the read-only preview must scope the same way.
+func TestDiffOnlyScopesFixPlan(t *testing.T) {
+	diffReport := func() *doctorapp.Report {
+		return &doctorapp.Report{ExitCode: doctorapp.ExitFindings, Findings: []doctorapp.Finding{
+			{ID: "fm-manual-only", Severity: "P1", Title: "needs a human",
+				Remediation: doctorapp.Remediation{Command: "install skills manually: run `ao skills link`"}},
+			{ID: "fm-auto", Severity: "P2", Title: "machine can fix",
+				Remediation: doctorapp.Remediation{Command: "ao doctor --fix --only fm-auto", AutoFixable: true, EstimatedActions: 3}},
+		}}
+	}
+	t.Run("--only filters the rendered plan to the named finding", func(t *testing.T) {
+		command := testModuleWithRead(stubRead{diff: diffReport()}, &fakeMutation{}, &fakeMaintenance{}, GlobalOptions{}).Command()
+		var stdout, stderr bytes.Buffer
+		command.SetOut(&stdout)
+		command.SetErr(&stderr)
+		command.SetArgs([]string{"diff", "--only", "fm-auto"})
+		if err := command.Execute(); err != nil {
+			t.Fatalf("diff --only must exit 0, got %v (stderr: %s)", err, stderr.String())
+		}
+		for _, want := range []string{
+			"Fix plan — what --fix would do (1 finding(s), read-only preview):",
+			"[P2] fm-auto — machine can fix",
+			"would auto-fix: 3 estimated action(s) via ao doctor --fix --only fm-auto",
+		} {
+			if !bytes.Contains(stdout.Bytes(), []byte(want)) {
+				t.Fatalf("diff --only output missing %q:\n%s", want, stdout.String())
+			}
+		}
+		if bytes.Contains(stdout.Bytes(), []byte("fm-manual-only")) {
+			t.Fatalf("diff --only fm-auto must not render fm-manual-only:\n%s", stdout.String())
+		}
+	})
+	t.Run("--only accepts a comma-separated list like --fix --only", func(t *testing.T) {
+		command := testModuleWithRead(stubRead{diff: diffReport()}, &fakeMutation{}, &fakeMaintenance{}, GlobalOptions{}).Command()
+		var stdout bytes.Buffer
+		command.SetOut(&stdout)
+		command.SetArgs([]string{"diff", "--only", "fm-auto,fm-manual-only"})
+		if err := command.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Contains(stdout.Bytes(), []byte("(2 finding(s)")) ||
+			!bytes.Contains(stdout.Bytes(), []byte("fm-auto")) ||
+			!bytes.Contains(stdout.Bytes(), []byte("fm-manual-only")) {
+			t.Fatalf("comma-separated --only must keep both findings:\n%s", stdout.String())
+		}
+	})
+	t.Run("unknown id yields a clear message and leaves the exit unchanged", func(t *testing.T) {
+		command := testModuleWithRead(stubRead{diff: diffReport()}, &fakeMutation{}, &fakeMaintenance{}, GlobalOptions{}).Command()
+		var stdout, stderr bytes.Buffer
+		command.SetOut(&stdout)
+		command.SetErr(&stderr)
+		command.SetArgs([]string{"diff", "--only", "fm-does-not-exist"})
+		if err := command.Execute(); err != nil {
+			t.Fatalf("unknown --only id must leave the exit unchanged (0), got %v", err)
+		}
+		if !bytes.Contains(stderr.Bytes(), []byte("unknown --only id(s): fm-does-not-exist")) {
+			t.Fatalf("stderr lacks the unknown-id message:\n%s", stderr.String())
+		}
+		if bytes.Contains(stdout.Bytes(), []byte("Fix plan")) {
+			t.Fatalf("unknown --only id must not render a plan:\n%s", stdout.String())
+		}
+	})
+}
+
 // TestExplainRendersSupersetOfTriageFields guards novice edge 4d: the human
 // `ao doctor explain <id>` output must be a superset of the per-finding fields
 // robot-triage emits — identity, confidence, every evidence field,

--- a/cli/internal/config/command_service.go
+++ b/cli/internal/config/command_service.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"context"
-	"fmt"
-	"strings"
 )
 
 // showEnvironmentKeys deliberately omits AGENTOPS_NO_SC: it only toggles
@@ -12,8 +10,6 @@ import (
 var showEnvironmentKeys = []string{
 	"AGENTOPS_CONFIG", "AGENTOPS_OUTPUT", "AGENTOPS_BASE_DIR", "AGENTOPS_VERBOSE",
 }
-
-var modelEnvironmentKeys = []string{"AGENTOPS_MODEL_TIER", "AGENTOPS_COUNCIL_MODEL_TIER", "COUNCIL_CLAUDE_MODEL"}
 
 type ConfigFiles struct {
 	HomePath      string
@@ -37,31 +33,10 @@ type ShowResult struct {
 	Environment map[string]string
 }
 
-type ModelsResult struct {
-	Config      *Config
-	Environment map[string]string
-}
-
-type ModelsWriteRequest struct {
-	DefaultTier string
-	Skill       string
-	DryRun      bool
-}
-
-type ModelsWriteResult struct {
-	Updated        bool              `json:"updated"`
-	DryRun         bool              `json:"dry_run"`
-	DefaultTier    string            `json:"default_tier,omitempty"`
-	SkillOverrides map[string]string `json:"skill_overrides,omitempty"`
-}
-
 type CommandGateway interface {
 	Resolve(string, bool) *ResolvedConfig
 	Files() (ConfigFiles, error)
 	Environment([]string) map[string]string
-	Load() (*Config, error)
-	Save(*Config) error
-	PreviewSave(*Config) error
 }
 
 type CommandService struct {
@@ -86,49 +61,4 @@ func (service *CommandService) Show(_ context.Context, output string, verbose bo
 		Resolved: service.gateway.Resolve(output, verbose), ConfigFiles: files,
 		Environment: service.gateway.Environment(showEnvironmentKeys),
 	}, nil
-}
-
-func (service *CommandService) Models(_ context.Context) (ModelsResult, error) {
-	loaded, err := service.gateway.Load()
-	if err != nil {
-		return ModelsResult{}, fmt.Errorf("load config: %w", err)
-	}
-	return ModelsResult{Config: loaded, Environment: service.gateway.Environment(modelEnvironmentKeys)}, nil
-}
-
-func (service *CommandService) WriteModels(_ context.Context, request ModelsWriteRequest) (ModelsWriteResult, error) {
-	save := &Config{}
-	result := ModelsWriteResult{Updated: !request.DryRun, DryRun: request.DryRun}
-	if request.DefaultTier != "" {
-		if request.DefaultTier == "inherit" {
-			return ModelsWriteResult{}, fmt.Errorf("invalid tier %q for default: \"inherit\" is only valid for skill overrides", request.DefaultTier)
-		}
-		if !ValidTiers[request.DefaultTier] {
-			return ModelsWriteResult{}, fmt.Errorf("invalid tier %q: must be one of quality, balanced, budget", request.DefaultTier)
-		}
-		save.Models.DefaultTier = request.DefaultTier
-		result.DefaultTier = request.DefaultTier
-	}
-	if request.Skill != "" {
-		parts := strings.SplitN(request.Skill, "=", 2)
-		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-			return ModelsWriteResult{}, fmt.Errorf("invalid --set-skill format %q: expected skill=tier (e.g. council=quality)", request.Skill)
-		}
-		skill, tier := parts[0], parts[1]
-		if !ValidTiers[tier] {
-			return ModelsWriteResult{}, fmt.Errorf("invalid tier %q for skill %q: must be one of quality, balanced, budget, inherit", tier, skill)
-		}
-		save.Models.SkillOverrides = map[string]string{skill: tier}
-		result.SkillOverrides = map[string]string{skill: tier}
-	}
-	if request.DryRun {
-		if err := service.gateway.PreviewSave(save); err != nil {
-			return ModelsWriteResult{}, fmt.Errorf("preview config save: %w", err)
-		}
-		return result, nil
-	}
-	if err := service.gateway.Save(save); err != nil {
-		return ModelsWriteResult{}, fmt.Errorf("saving config: %w", err)
-	}
-	return result, nil
 }

--- a/cli/internal/config/command_service_test.go
+++ b/cli/internal/config/command_service_test.go
@@ -2,87 +2,17 @@ package config
 
 import (
 	"context"
-	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
-type fakeCommandGateway struct {
-	saved      *Config
-	previewErr error
-}
+type fakeCommandGateway struct{}
 
 func (gateway *fakeCommandGateway) Resolve(string, bool) *ResolvedConfig { return &ResolvedConfig{} }
 func (gateway *fakeCommandGateway) Files() (ConfigFiles, error)          { return ConfigFiles{}, nil }
 func (gateway *fakeCommandGateway) Environment([]string) map[string]string {
 	return map[string]string{}
-}
-func (gateway *fakeCommandGateway) Load() (*Config, error) { return Default(), nil }
-func (gateway *fakeCommandGateway) Save(value *Config) error {
-	gateway.saved = value
-	return nil
-}
-func (gateway *fakeCommandGateway) PreviewSave(_ *Config) error { return gateway.previewErr }
-
-func TestCommandServiceWriteModelsValidatesAndBuildsPatch(t *testing.T) {
-	gateway := &fakeCommandGateway{}
-	service := NewCommandService(gateway)
-	result, err := service.WriteModels(context.Background(), ModelsWriteRequest{DefaultTier: "budget", Skill: "council=quality"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.DefaultTier != "budget" || result.SkillOverrides["council"] != "quality" {
-		t.Fatalf("result = %+v", result)
-	}
-	if gateway.saved == nil || gateway.saved.Models.DefaultTier != "budget" || gateway.saved.Models.SkillOverrides["council"] != "quality" {
-		t.Fatalf("saved patch = %+v", gateway.saved)
-	}
-}
-
-func TestCommandServiceWriteModelsRejectsInvalidInputBeforeSave(t *testing.T) {
-	for _, request := range []ModelsWriteRequest{{DefaultTier: "inherit"}, {DefaultTier: "premium"}, {Skill: "broken"}, {Skill: "council=premium"}} {
-		gateway := &fakeCommandGateway{}
-		_, err := NewCommandService(gateway).WriteModels(context.Background(), request)
-		if err == nil || !strings.Contains(err.Error(), "invalid") {
-			t.Fatalf("request %+v error = %v", request, err)
-		}
-		if gateway.saved != nil {
-			t.Fatalf("invalid request %+v reached save", request)
-		}
-	}
-}
-
-func TestCommandServiceWriteModelsDryRunDoesNotSave(t *testing.T) {
-	gateway := &fakeCommandGateway{}
-	result, err := NewCommandService(gateway).WriteModels(context.Background(), ModelsWriteRequest{
-		DefaultTier: "quality",
-		DryRun:      true,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if gateway.saved != nil {
-		t.Fatalf("dry-run saved config: %+v", gateway.saved)
-	}
-	if result.Updated || !result.DryRun || result.DefaultTier != "quality" {
-		t.Fatalf("dry-run result = %+v", result)
-	}
-}
-
-func TestCommandServiceWriteModelsDryRunRejectsMalformedExistingConfig(t *testing.T) {
-	gateway := &fakeCommandGateway{previewErr: errors.New("malformed yaml")}
-	_, err := NewCommandService(gateway).WriteModels(context.Background(), ModelsWriteRequest{
-		DefaultTier: "quality",
-		DryRun:      true,
-	})
-	if err == nil || !strings.Contains(err.Error(), "preview config save") {
-		t.Fatalf("dry-run error = %v", err)
-	}
-	if gateway.saved != nil {
-		t.Fatalf("failed dry-run saved config: %+v", gateway.saved)
-	}
 }
 
 // TestCommandServiceShowReportsLegacyReadPaths pins the files-panel half of

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -154,6 +154,11 @@ type PathsConfig struct {
 }
 
 // ModelsConfig holds model tier configuration.
+//
+// Deprecated: dead section. The `ao config models` subcommand that displayed
+// and wrote these fields was removed; nothing outside config plumbing
+// (defaults, applyEnv, merge, ResolveTier) reads them. The struct stays
+// parseable so existing config files with a models: section do not break.
 type ModelsConfig struct {
 	// DefaultTier is the default model tier (quality, balanced, budget, inherit).
 	DefaultTier string `yaml:"default_tier" json:"default_tier"`

--- a/cli/internal/doctor/fix_cliconfig.go
+++ b/cli/internal/doctor/fix_cliconfig.go
@@ -89,17 +89,17 @@ func lookPathAll(name string) []string {
 // agentopsModuleLine identifies the agentops CLI module in cli/go.mod.
 const agentopsModuleLine = "module github.com/boshu2/agentops/cli"
 
-// insideAgentopsRepo reports whether dir is within an agentops repo clone,
-// walking up a bounded number of parents looking for cli/go.mod declaring the
-// agentops module. It is read-only. An empty dir is treated as "not in repo".
-func insideAgentopsRepo(dir string) bool {
+// agentopsRepoRootFrom walks up a bounded number of parents from dir looking
+// for cli/go.mod declaring the agentops module, and returns the repo root.
+// It is read-only. An empty dir is treated as "not in repo".
+func agentopsRepoRootFrom(dir string) (string, bool) {
 	if dir == "" {
-		return false
+		return "", false
 	}
 	for range 12 {
 		data, err := os.ReadFile(filepath.Join(dir, "cli", "go.mod"))
 		if err == nil && strings.Contains(string(data), agentopsModuleLine) {
-			return true
+			return dir, true
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
@@ -107,7 +107,13 @@ func insideAgentopsRepo(dir string) bool {
 		}
 		dir = parent
 	}
-	return false
+	return "", false
+}
+
+// insideAgentopsRepo reports whether dir is within an agentops repo clone.
+func insideAgentopsRepo(dir string) bool {
+	_, ok := agentopsRepoRootFrom(dir)
+	return ok
 }
 
 // installHintFor returns a platform-specific install command for a CLI.
@@ -446,9 +452,47 @@ const fmDevVersionBuildIntegrity = "fm-cli-config-dev-version-build-integrity"
 // documented source fallback used before the v3.1.0 tag is cut ("3.1.0-rc").
 var aoReleaseVersion = regexp.MustCompile(`^v?\d+\.\d+\.\d+(-rc(\.\d+)?)?$`)
 
-// devVersionBuildIntegrityDetector flags an `ao` binary that reports a
-// non-release version (dev/empty/non-semver) or is shadowed by another `ao`
-// on PATH. This is a build-time / install-integrity concern.
+// repoDeclaredVersionPattern mirrors the legacy "Binary Freshness" check's
+// resolution of the repo's declared CLI version (adapters/doctor
+// RepoDeclaredVersion): `var version = "..."` in cli/cmd/ao/main.go. The
+// adapters package imports this one, so the resolution is mirrored here
+// rather than imported.
+var repoDeclaredVersionPattern = regexp.MustCompile(`var version = "([^"]+)"`)
+
+// repoDeclaredCLIVersion returns the repo's declared CLI version at root,
+// resolved exactly the way Binary Freshness resolves it. Read-only.
+func repoDeclaredCLIVersion(root string) (string, bool) {
+	data, err := os.ReadFile(filepath.Join(root, "cli", "cmd", "ao", "main.go"))
+	if err != nil {
+		return "", false
+	}
+	match := repoDeclaredVersionPattern.FindSubmatch(data)
+	if len(match) != 2 {
+		return "", false
+	}
+	return string(match[1]), true
+}
+
+// versionMatchesRepoDeclared mirrors the Binary Freshness PASS conditions: the
+// reported version equals the repo's declared version, or is the release build
+// of the declared "-rc" source series.
+func versionMatchesRepoDeclared(reported, repoDeclared string) bool {
+	return reported == repoDeclared || strings.TrimSuffix(repoDeclared, "-rc") == reported
+}
+
+// devVersionBuildIntegrityDetector flags an `ao` binary whose version drifts
+// from the repo's declared CLI version (inside a checkout), a non-release
+// version outside any checkout (informational: a from-source build), or an
+// `ao` shadowed by another `ao` on PATH.
+//
+// Coherence rule (wave-4 residual 1): inside a repo checkout the legacy
+// "Binary Freshness" check is the authority on version health. A binary whose
+// reported version equals the repo's declared version is a healthy from-source
+// build — the documented no-Homebrew install path — dev/rc-shaped or not, so a
+// dev version alone is NOT a finding there. The detector fires only on genuine
+// drift (binary != declared repo version) or on shadowed duplicates. The two
+// surfaces must never disagree ("non-release version" P2 while Binary
+// Freshness passes).
 type devVersionBuildIntegrityDetector struct{}
 
 func (devVersionBuildIntegrityDetector) ID() string           { return fmDevVersionBuildIntegrity }
@@ -458,18 +502,37 @@ func (devVersionBuildIntegrityDetector) EstimatedCostMS() int { return 40 }
 func (devVersionBuildIntegrityDetector) OnlineRequired() bool { return false }
 func (devVersionBuildIntegrityDetector) QuickPath() bool      { return false }
 func (devVersionBuildIntegrityDetector) Describe() string {
-	return "Detects an ao binary reporting a non-release version, or multiple ao binaries shadowing each other."
+	return "Detects an ao binary drifting from the repo's declared version (or a non-release version outside a checkout), or multiple ao binaries shadowing each other; a from-source build matching its checkout is healthy."
 }
 
-// Detect inspects the running binary's reported version (via env.ToolVersion)
-// and resolves every `ao` on PATH. All read-only.
-func (devVersionBuildIntegrityDetector) Detect(_ *DetectEnv) ([]Finding, error) {
+// Detect inspects the reported version of the `ao` resolved on PATH, compares
+// it against the repo's declared CLI version when inside a checkout (reusing
+// the Binary Freshness resolution), and resolves every `ao` on PATH for
+// shadowing. All read-only.
+func (devVersionBuildIntegrityDetector) Detect(env *DetectEnv) ([]Finding, error) {
 	reported := aoReportedVersion()
-	suspect := reported == "" || reported == "dev" || reported == "vdev" ||
+	nonRelease := reported == "" || reported == "dev" || reported == "vdev" ||
 		!aoReleaseVersion.MatchString(reported)
 
 	aoPaths := lookPathAll("ao")
 	shadowed := len(aoPaths) > 1
+
+	repoDeclared := ""
+	if env != nil {
+		if root, ok := agentopsRepoRootFrom(env.RepoRoot); ok {
+			repoDeclared, _ = repoDeclaredCLIVersion(root)
+		}
+	}
+	drift := false
+	suspect := nonRelease
+	if reported != "" && repoDeclared != "" {
+		// Inside a checkout with a resolvable declared version, Binary
+		// Freshness is the authority: only genuine drift is suspect. A
+		// dev/rc version equal to the declared version is a healthy
+		// from-source build and never a finding.
+		drift = !versionMatchesRepoDeclared(reported, repoDeclared)
+		suspect = drift
+	}
 
 	if !suspect && !shadowed {
 		return nil, nil
@@ -480,26 +543,48 @@ func (devVersionBuildIntegrityDetector) Detect(_ *DetectEnv) ([]Finding, error) 
 	} else {
 		pathDesc = describeAOPaths(aoPaths)
 	}
+	title, remediation := devVersionFindingText(reported, repoDeclared, drift, suspect)
 	return []Finding{{
 		ID:         fmDevVersionBuildIntegrity,
 		Severity:   "P2",
 		Subsystem:  "cli-config",
-		Title:      "`ao` reports a non-release version, or multiple `ao` binaries shadow each other",
+		Title:      title,
 		Confidence: 0.9,
 		Evidence: Evidence{
-			Query: fmt.Sprintf("reported_version=%q suspect_version=%t shadowed=%t ao_paths=[%s]",
-				reported, suspect, shadowed, pathDesc),
+			Query: fmt.Sprintf("reported_version=%q suspect_version=%t shadowed=%t repo_declared_version=%q drift_from_repo=%t ao_paths=[%s]",
+				reported, suspect, shadowed, repoDeclared, drift, pathDesc),
 		},
 		Remediation: Remediation{
-			Command: "Reinstall a release build: " +
-				"brew upgrade agentops " +
-				"— or, if developing, rebuild with ldflags: cd cli && make build. " +
-				"If `which -a ao` shows duplicates, remove the stale one from PATH.",
+			Command:          remediation,
 			ExplainCommand:   "ao doctor explain " + fmDevVersionBuildIntegrity,
 			AutoFixable:      false,
 			EstimatedActions: 0,
 		},
 	}}, nil
+}
+
+// devVersionFindingText picks title and remediation wording per cause, keeping
+// the finding coherent with the Binary Freshness check: genuine drift names
+// both versions, a non-release version outside a checkout is stated plainly as
+// an informational from-source build (never a failure), and a shadow-only
+// finding talks about the duplicate binaries, not about version quality.
+func devVersionFindingText(reported, repoDeclared string, drift, suspect bool) (title, remediation string) {
+	const dedupe = "If `which -a ao` shows duplicates, remove the stale one from PATH."
+	switch {
+	case drift:
+		title = fmt.Sprintf("`ao` reports %s but this checkout declares %s — the binary drifts from the repo", reported, repoDeclared)
+		remediation = "Rebuild and reinstall from this checkout: cd cli && make build " +
+			"(or scripts/preflight-uat-binary.sh) — or reinstall a release build: brew upgrade agentops. " + dedupe
+	case suspect:
+		title = "`ao` reports a non-release version — you are running a from-source build (informational)"
+		remediation = "Informational: you are running a from-source build. For a release build: " +
+			"brew upgrade agentops — or, if developing, rebuild with ldflags: cd cli && make build. " + dedupe
+	default: // shadow-only: version itself is healthy
+		title = "multiple `ao` binaries shadow each other on PATH"
+		remediation = dedupe + " The first-resolved binary's version is healthy; " +
+			"if developing, rebuild with ldflags: cd cli && make build."
+	}
+	return title, remediation
 }
 
 // aoReportedVersion returns the `ao` binary's reported version string by
@@ -664,7 +749,7 @@ func init() {
 	})
 	RegisterFixer(cliConfigRefuser{
 		id:          fmDevVersionBuildIntegrity,
-		reason:      "ao reports a non-release version; the doctor does not recompile or replace binaries",
+		reason:      "the ao binary drifts from the repo's declared version or is shadowed on PATH; the doctor does not recompile or replace binaries",
 		operatorCmd: "ao doctor explain " + fmDevVersionBuildIntegrity,
 	})
 	RegisterFixer(cliConfigRefuser{

--- a/cli/internal/doctor/fix_cliconfig_test.go
+++ b/cli/internal/doctor/fix_cliconfig_test.go
@@ -532,6 +532,132 @@ func TestCliConfigDevVersion_DuplicateAOEvidenceIncludesPerPathVersions(t *testi
 	}
 }
 
+// TestCliConfigDevVersion_CoherentWithBinaryFreshness locks in the wave-4
+// residual-1 decision rule: inside a repo checkout the detector reuses the
+// legacy "Binary Freshness" resolution (cli/cmd/ao/main.go `var version`) and
+// a binary whose reported version equals the repo's declared version is a
+// healthy from-source build — a dev/rc-shaped version alone is NOT a finding.
+// The detector fires only on genuine drift (binary != declared repo version)
+// or on shadowed duplicate `ao` binaries. Outside any checkout a bare
+// dev-version binary stays a finding but is worded as informational-grade
+// ("from-source build"), never as a failure Binary Freshness would pass.
+func TestCliConfigDevVersion_CoherentWithBinaryFreshness(t *testing.T) {
+	writeRepo := func(t *testing.T, declared string) string {
+		t.Helper()
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "cli", "go.mod"), agentopsModuleLine+"\n\ngo 1.24\n")
+		writeFile(t, filepath.Join(root, "cli", "cmd", "ao", "main.go"),
+			"package main\n\nvar version = \""+declared+"\"\n")
+		return root
+	}
+	stubAO := func(t *testing.T, dir, reports string) {
+		t.Helper()
+		path := filepath.Join(dir, "ao")
+		writeFile(t, path, "#!/bin/sh\necho 'ao version "+reports+"'\n")
+		if err := os.Chmod(path, 0o755); err != nil {
+			t.Fatalf("chmod %s: %v", path, err)
+		}
+	}
+	tests := []struct {
+		name         string
+		declared     string // "" = outside any agentops checkout
+		reported     string
+		secondAO     string // "" = no shadowing duplicate
+		wantFinding  bool
+		wantTitleSub string
+		wantQuerySub []string
+	}{
+		{
+			name: "dev build matching checkout declared version is healthy",
+			declared: "9.9.9-dev", reported: "9.9.9-dev",
+			wantFinding: false,
+		},
+		{
+			name: "rc source fallback matching checkout is healthy",
+			declared: "3.3.0-rc", reported: "3.3.0-rc",
+			wantFinding: false,
+		},
+		{
+			name: "release build of the declared rc series is healthy",
+			declared: "3.3.0-rc", reported: "3.3.0",
+			wantFinding: false,
+		},
+		{
+			name: "git-describe binary inside checkout is genuine drift",
+			declared: "3.3.0-rc", reported: "v3.2.0-64-gabc123",
+			wantFinding:  true,
+			wantTitleSub: "drift",
+			wantQuerySub: []string{`repo_declared_version="3.3.0-rc"`, "drift_from_repo=true"},
+		},
+		{
+			name: "stale release binary inside checkout is genuine drift",
+			declared: "3.3.0-rc", reported: "3.1.0",
+			wantFinding:  true,
+			wantTitleSub: "drift",
+			wantQuerySub: []string{`reported_version="3.1.0"`, "drift_from_repo=true"},
+		},
+		{
+			name: "shadowed duplicates stay a finding even when versions match",
+			declared: "9.9.9-dev", reported: "9.9.9-dev", secondAO: "2.41.1",
+			wantFinding:  true,
+			wantTitleSub: "shadow",
+			wantQuerySub: []string{"shadowed=true", "drift_from_repo=false"},
+		},
+		{
+			name: "outside checkout dev build is an informational from-source finding",
+			declared: "", reported: "dev",
+			wantFinding:  true,
+			wantTitleSub: "from-source build",
+			wantQuerySub: []string{`reported_version="dev"`, "suspect_version=true"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			fakebin := filepath.Join(tmp, "fakebin")
+			stubAO(t, fakebin, test.reported)
+			path := fakebin
+			if test.secondAO != "" {
+				secondbin := filepath.Join(tmp, "secondbin")
+				stubAO(t, secondbin, test.secondAO)
+				path = fakebin + string(os.PathListSeparator) + secondbin
+			}
+			t.Setenv("PATH", path)
+			env := &DetectEnv{}
+			if test.declared != "" {
+				env.RepoRoot = writeRepo(t, test.declared)
+			}
+			fs, err := devVersionBuildIntegrityDetector{}.Detect(env)
+			if err != nil {
+				t.Fatalf("Detect error: %v", err)
+			}
+			if !test.wantFinding {
+				if len(fs) != 0 {
+					t.Fatalf("expected 0 findings, got %d: %+v", len(fs), fs)
+				}
+				return
+			}
+			f := findByID(t, fs, fmDevVersionBuildIntegrity)
+			if !strings.Contains(f.Title, test.wantTitleSub) {
+				t.Errorf("Title = %q, want substring %q", f.Title, test.wantTitleSub)
+			}
+			for _, sub := range test.wantQuerySub {
+				if !strings.Contains(f.Evidence.Query, sub) {
+					t.Errorf("Evidence.Query lacks %q: %q", sub, f.Evidence.Query)
+				}
+			}
+			// Wording coherence: never call a non-release version a failure in
+			// a state where Binary Freshness passes; drift wording must name
+			// both versions so the operator sees the disagreement.
+			if strings.Contains(test.wantTitleSub, "drift") {
+				if !strings.Contains(f.Title, test.reported) || !strings.Contains(f.Title, test.declared) {
+					t.Errorf("drift Title must name both versions, got %q", f.Title)
+				}
+			}
+		})
+	}
+}
+
 func TestCliConfigDevVersion_FixerRefuses(t *testing.T) {
 	fx := FixerByID(fmDevVersionBuildIntegrity)
 	if fx == nil {

--- a/cli/internal/gates/checks/native_inline.go
+++ b/cli/internal/gates/checks/native_inline.go
@@ -19,7 +19,7 @@ func init() {
 	gates.Register(gates.Check{ID: "go.vet", Tiers: gates.Fast | gates.Full, Match: []string{"cli/**", "go.mod", "go.sum"}, Blocking: true, Run: runGoVet})
 	gates.Register(gates.Check{ID: "changelog.sync", Tiers: gates.Fast | gates.Full, Match: []string{"CHANGELOG.md", "docs/CHANGELOG.md"}, Blocking: true, Run: runChangelogSync})
 	gates.Register(gates.Check{ID: "shell.shellcheck-changed", Tiers: gates.Fast | gates.Full, Match: []string{"**/*.sh"}, Blocking: true, Run: runShellcheckChanged})
-	gates.Register(gates.Check{ID: "learning.coherence", Tiers: gates.Fast | gates.Full, Match: []string{".agents/learnings/**"}, Blocking: true, Run: runLearningCoherence})
+	gates.Register(gates.Check{ID: "learning.coherence", Tiers: gates.Fast | gates.Full, Match: learningRootGlobs, Blocking: true, Run: runLearningCoherence})
 }
 
 // changedFilesFor returns the routed change set, falling back to the diff vs
@@ -106,10 +106,30 @@ func runShellcheckChanged(ctx context.Context, rc gates.RunContext) (ports.GateV
 	return ports.GateVerdict{Status: ports.GateStatusPass, Reason: "shellcheck clean (changed .sh)"}, nil
 }
 
+// Learnings live under BOTH roots: the canonical .agents/ao/learnings (where
+// doctor's split fixer migrates files) and the legacy .agents/learnings. The
+// routing globs and the Run func prefix filter must stay in lockstep — a root
+// present in one but not the other either never routes or routes-then-skips.
+var (
+	learningRootPrefixes = []string{".agents/ao/learnings/", ".agents/learnings/"}
+	learningRootGlobs    = []string{".agents/ao/learnings/**", ".agents/learnings/**"}
+)
+
+// underLearningRoot reports whether a repo-relative path sits under either
+// learnings root.
+func underLearningRoot(f string) bool {
+	for _, p := range learningRootPrefixes {
+		if strings.HasPrefix(f, p) {
+			return true
+		}
+	}
+	return false
+}
+
 func runLearningCoherence(ctx context.Context, rc gates.RunContext) (ports.GateVerdict, error) {
 	var missing []string
 	for _, f := range changedFilesFor(ctx, rc) {
-		if !strings.HasPrefix(f, ".agents/learnings/") || !strings.HasSuffix(f, ".md") {
+		if !underLearningRoot(f) || !strings.HasSuffix(f, ".md") {
 			continue
 		}
 		data, err := os.ReadFile(filepath.Join(rc.RepoRoot, f))

--- a/cli/internal/gates/checks/native_inline_test.go
+++ b/cli/internal/gates/checks/native_inline_test.go
@@ -110,6 +110,69 @@ func TestRunShellcheckChanged_MissingShellcheckFailsClosed(t *testing.T) {
 	}
 }
 
+// TestLearningCoherence_RoutesBothLearningRoots pins the routing globs of the
+// learning.coherence gate: a learning changed under the CANONICAL
+// .agents/ao/learnings/ (where doctor's split fixer migrates files) must select
+// the gate exactly like the legacy .agents/learnings/ root — otherwise a
+// migrated learning silently skips the frontmatter check.
+func TestLearningCoherence_RoutesBothLearningRoots(t *testing.T) {
+	var check gates.Check
+	found := false
+	for _, c := range gates.Default.All() {
+		if c.ID == "learning.coherence" {
+			check, found = c, true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("learning.coherence is not registered in the default gate registry")
+	}
+	for _, f := range []string{".agents/ao/learnings/x.md", ".agents/learnings/x.md"} {
+		if !gates.PathMatchesAny(check.Match, f) {
+			t.Errorf("learning.coherence Match %v must route changed file %q", check.Match, f)
+		}
+	}
+}
+
+// TestRunLearningCoherence_ChecksCanonicalAoRoot: the Run func must inspect a
+// changed learning under the canonical .agents/ao/learnings/ root, not only the
+// legacy .agents/learnings/ one. A frontmatter-less file under the canonical
+// root is a FAIL; adding frontmatter turns it PASS.
+func TestRunLearningCoherence_ChecksCanonicalAoRoot(t *testing.T) {
+	root := t.TempDir()
+	rel := filepath.Join(".agents", "ao", "learnings", "bad.md")
+	full := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte("no frontmatter here\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rc := gates.RunContext{RepoRoot: root, ChangedFiles: []string{".agents/ao/learnings/bad.md"}}
+	verdict, err := runLearningCoherence(context.Background(), rc)
+	if err != nil {
+		t.Fatalf("runLearningCoherence: %v", err)
+	}
+	if verdict.Status != ports.GateStatusFail {
+		t.Fatalf("status = %s, want FAIL for a frontmatter-less canonical-root learning", verdict.Status)
+	}
+	if !strings.Contains(verdict.Reason, ".agents/ao/learnings/bad.md") {
+		t.Fatalf("reason = %q, want the canonical-root file listed", verdict.Reason)
+	}
+
+	if err := os.WriteFile(full, []byte("---\ntitle: x\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	verdict, err = runLearningCoherence(context.Background(), rc)
+	if err != nil {
+		t.Fatalf("runLearningCoherence: %v", err)
+	}
+	if verdict.Status != ports.GateStatusPass {
+		t.Fatalf("status = %s, want PASS once frontmatter is present (reason %q)", verdict.Status, verdict.Reason)
+	}
+}
+
 // equalSetChecks reports whether a and b hold the same elements (order-independent).
 func equalSetChecks(a, b []string) bool {
 	if len(a) != len(b) {

--- a/cli/internal/quality/metrics_health.go
+++ b/cli/internal/quality/metrics_health.go
@@ -54,21 +54,25 @@ func ComputeHealthDelta(baseDir string) float64 {
 	return totalAge / float64(count)
 }
 
-// CountConstraints counts constraint files in .agents/constraints/.
+// CountConstraints counts constraint files in both constraint roots — the
+// canonical .agents/ao/constraints (where doctor's split fixer migrates files)
+// and the legacy .agents/constraints — via KnowledgeSectionDirs, like every
+// other section, so a migrated corpus does not hide constraints.
 func CountConstraints(baseDir string) int {
-	constraintsDir := filepath.Join(baseDir, ".agents", "constraints")
-	if _, err := os.Stat(constraintsDir); os.IsNotExist(err) {
-		return 0
-	}
 	count := 0
-	mdFiles, _ := filepath.Glob(filepath.Join(constraintsDir, "*.md"))
-	count += len(mdFiles)
-	yamlFiles, _ := filepath.Glob(filepath.Join(constraintsDir, "*.yaml"))
-	count += len(yamlFiles)
-	jsonFiles, _ := filepath.Glob(filepath.Join(constraintsDir, "*.json"))
-	for _, f := range jsonFiles {
-		if filepath.Base(f) != "index.json" {
-			count++
+	for _, constraintsDir := range KnowledgeSectionDirs(baseDir, "constraints") {
+		if _, err := os.Stat(constraintsDir); os.IsNotExist(err) {
+			continue
+		}
+		mdFiles, _ := filepath.Glob(filepath.Join(constraintsDir, "*.md"))
+		count += len(mdFiles)
+		yamlFiles, _ := filepath.Glob(filepath.Join(constraintsDir, "*.yaml"))
+		count += len(yamlFiles)
+		jsonFiles, _ := filepath.Glob(filepath.Join(constraintsDir, "*.json"))
+		for _, f := range jsonFiles {
+			if filepath.Base(f) != "index.json" {
+				count++
+			}
 		}
 	}
 	return count

--- a/cli/internal/quality/metrics_health_test.go
+++ b/cli/internal/quality/metrics_health_test.go
@@ -1,0 +1,60 @@
+package quality
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCountConstraints_DualRoot: constraints live in BOTH the canonical
+// .agents/ao/constraints (where doctor's split fixer migrates files) and the
+// legacy .agents/constraints — CountConstraints must count both roots, exactly
+// like every other section routed through KnowledgeSectionDirs. A constraint
+// that exists ONLY under the canonical root must count.
+func TestCountConstraints_DualRoot(t *testing.T) {
+	base := t.TempDir()
+	canonical := filepath.Join(base, ".agents", "ao", "constraints")
+	if err := os.MkdirAll(canonical, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(canonical, "only-canonical.md"), []byte("# c\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := CountConstraints(base); got != 1 {
+		t.Fatalf("CountConstraints = %d, want 1 (constraint only under canonical .agents/ao/constraints must count)", got)
+	}
+
+	// Legacy root still counts, and the two roots SUM.
+	legacy := filepath.Join(base, ".agents", "constraints")
+	if err := os.MkdirAll(legacy, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "legacy.yaml"), []byte("k: v\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := CountConstraints(base); got != 2 {
+		t.Fatalf("CountConstraints = %d, want 2 (canonical + legacy)", got)
+	}
+
+	// index.json stays excluded in BOTH roots; other .json files count.
+	if err := os.WriteFile(filepath.Join(canonical, "index.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "index.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(canonical, "real.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := CountConstraints(base); got != 3 {
+		t.Fatalf("CountConstraints = %d, want 3 (index.json excluded in both roots)", got)
+	}
+}
+
+// TestCountConstraints_MissingDirsCountZero: neither root existing is 0, not an error.
+func TestCountConstraints_MissingDirsCountZero(t *testing.T) {
+	if got := CountConstraints(t.TempDir()); got != 0 {
+		t.Fatalf("CountConstraints = %d, want 0 for missing constraint dirs", got)
+	}
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,22 @@ before upgrading.
 
 ### Fixed
 
+- A from-source `ao` build whose version matches its checkout is no longer
+  flagged by doctor: the dev-version detector reuses the Binary Freshness
+  resolution and fires only on genuine drift, shadowed duplicate binaries,
+  or (outside a checkout) an informational from-source note. `ao doctor
+  diff --only <id>` scopes the fix-plan preview.
+- The dead `ao config models` surface was removed (nothing consumed model
+  tiers); existing `models:` config sections still parse and are ignored,
+  and the removed subcommand points at the migration map.
+- The remaining single-rooted knowledge readers follow the canonical
+  `.agents/ao/<section>` directories alongside the legacy roots: the
+  learning-coherence gate, constraint counting, and the eval sandbox
+  corpus deny-list.
+- The strict docs-link backstop's allowlist was refreshed (all 53 entries
+  referenced Cathedral-Cut-deleted docs); ROADMAP, the documentation
+  index generator, and the doc skill's references no longer point at
+  files that don't exist.
 - Onboarding docs name the one real prerequisite: the loop runs as skills
   inside a coding agent (Claude Code, Codex, Cursor, …) and `/rpi` is typed
   in that agent's chat. The README Quickstart leads with the universal npx

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -31,6 +31,7 @@ under `ao gate check`; semantic judgment is the Validate skill.
 | `ao goals trace` | Inspect current goal/scenario artifacts directly; the retired directive-to-bead lifecycle chain has no replacement. |
 | `ao inject` | AgentOps no longer retrieves prior knowledge; use the caller's own memory or context tooling. |
 | `ao session memory` | Use caller-authored `ao session handoff` evidence or maintain repository memory through the caller's own policy. |
+| `ao config models` | Model-tier configuration was removed; nothing consumed it. Model choice belongs to the caller's runtime. Existing `models:` config sections still parse and are ignored. |
 | `ao verify` | Use the Validate skill for semantic judgment and `ao gate check` for deterministic checks. Delete any `ao verify init` pre-push ratchet from `.git/hooks/pre-push` (restore `pre-push.agentops-orig` if one was set aside); `ao verify init --remove` no longer exists, and `git push --no-verify` bypasses a stale hook once. |
 
 These names are no longer registered commands. Invoking one fails as an

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap (planned, not committed)
 
-> Features designed or discussed but **not yet implemented**. Nothing here has a committed timeline; items may change or be dropped. If a command or capability is documented elsewhere as available, that doc is the source of truth — this page is only for what is *not* built yet. The 3.0 north star is [docs/3.0.md](3.0.md).
+> Features designed or discussed but **not yet implemented**. Nothing here has a committed timeline; items may change or be dropped. If a command or capability is documented elsewhere as available, that doc is the source of truth — this page is only for what is *not* built yet. The 3.0 north-star map (`docs/3.0.md`) was retired in the Cathedral Cut; its history lives in the 3.0 entries of [docs/CHANGELOG.md](CHANGELOG.md).
 
 ## CLI — designed, not implemented
 
@@ -14,11 +14,11 @@ If you hit an error invoking one of these, it does not exist yet — that is exp
 
 ## Curation pipeline — later stages
 
-The curation pipeline is a six-stage design: CATALOG, VERIFY, INDEX, SCORE, REJECT, CONSTRAIN. The former curation CLI was retired; none of these stages is a live `ao` command on current `main`. The orthogonal prevention lane is the finding-compiler (`.agents/findings/registry.jsonl` → constraints + planning rules), which is separate from this pipeline. See [docs/curation-pipeline.md](curation-pipeline.md).
+The curation pipeline is a six-stage design: CATALOG, VERIFY, INDEX, SCORE, REJECT, CONSTRAIN. The former curation CLI was retired; none of these stages is a live `ao` command on current `main`. The orthogonal prevention lane is the finding-compiler (`.agents/findings/registry.jsonl` → constraints + planning rules), which is separate from this pipeline. The standalone curation-pipeline design doc was retired with the curation CLI; this section is the surviving summary.
 
 ## Hookless default install (ADR-0002 S2–S5)
 
-The 3.0 north star demotes hooks to optional adapters ([docs/3.0.md](3.0.md)). The remaining lift — a default install path that requires **zero** hooks, and an RPI lifecycle that runs discovery→validation hookless — is tracked as ADR-0002 stages S2–S5. It is a follow-on, not part of the 3.0 reconciliation close.
+The 3.0 north star demotes hooks to optional adapters (per the retired 3.0 map — see the 3.0 entries in [docs/CHANGELOG.md](CHANGELOG.md)). The remaining lift — a default install path that requires **zero** hooks, and an RPI lifecycle that runs discovery→validation hookless — is tracked as ADR-0002 stages S2–S5. It is a follow-on, not part of the 3.0 reconciliation close.
 
 ## Legacy RPI lane removal
 

--- a/docs/cli-surface.json
+++ b/docs/cli-surface.json
@@ -24,7 +24,7 @@
     },
     {
       "category": "public-tested",
-      "command": "config models",
+      "command": "config",
       "coverage_status": "covered",
       "kind": "leaf",
       "reason": "Covered by release smoke tests, direct command tests, or command handler tests."

--- a/docs/cli-surface.md
+++ b/docs/cli-surface.md
@@ -7,7 +7,7 @@
 |---------|----------|----------|--------|
 | `ao capabilities` | `public-tested` | `allowlisted` | Covered by capability contract tests. |
 | `ao completion` | `public-tested` | `allowlisted` | Framework completion root has focused generation tests. |
-| `ao config models` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
+| `ao config` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao demo` | `manual-only` | `allowlisted` | Interactive demonstration requires a TTY. |
 | `ao doctor capabilities` | `public-stateful-fixture-needed` | `allowlisted` | Inspects local installation state. |
 | `ao doctor diff` | `public-stateful-fixture-needed` | `allowlisted` | Compares local installation state. |

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -5,10 +5,10 @@ Dated plans, audits, releases, and archive material are historical evidence, not
 
 ## Product and workflow
 
-- [README](../README.md)
-- [Product boundary](../PRODUCT.md)
-- [Fitness goals](../GOALS.md)
-- [Program boundary](../PROGRAM.md)
+- [README](https://github.com/boshu2/agentops/blob/main/README.md)
+- [Product boundary](https://github.com/boshu2/agentops/blob/main/PRODUCT.md)
+- [Fitness goals](https://github.com/boshu2/agentops/blob/main/GOALS.md)
+- [Program boundary](https://github.com/boshu2/agentops/blob/main/PROGRAM.md)
 - [Operating loop](architecture/operating-loop.md)
 - [Gas City factory](architecture/gas-city-factory.md)
 - [Agent workflow](agent-workflow-reference.md)

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=19 sub=54 all=86"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=19 sub=53 all=85"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,4} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "19" || "$sub_count" != "54" || "$all_count" != "86" ]]; then
+if [[ "$top_count" != "19" || "$sub_count" != "53" || "$all_count" != "85" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,4} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 86 ]]; then
+if [[ "${#commands[@]}" -ne 85 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/scripts/docs-build.sh
+++ b/scripts/docs-build.sh
@@ -59,8 +59,15 @@ case "$mode" in
         # DISPOSITIONED warnings — intentional cross-references from docs/ pages to real
         # repo artifacts outside the published site (skills/, scripts/, schemas/, evals/,
         # repo-root docs). Any strict warning NOT in the allowlist still fails the check,
-        # so new/accidental broken links break the build. See
-        # docs/docs-build-dispositions.md + tests/docs/mkdocs-strict-allowlist.txt.
+        # so new/accidental broken links break the build.
+        #
+        # Policy consistency with mkdocs.yml: the PUBLISHED build declares
+        # `strict: false` (docs deliberately link outside docs_dir), and
+        # tests/docs/validate-links.sh owns link checking for the doc-release
+        # checks. This mode is the deliberate strict BACKSTOP layered on top:
+        # strict-with-curated-allowlist, per-entry rationale in
+        # tests/docs/mkdocs-strict-allowlist.txt (its header is the disposition
+        # doc).
         allowlist="$REPO_ROOT/tests/docs/mkdocs-strict-allowlist.txt"
         tmp_site="$(mktemp -d)"
         build_log="$(mktemp)"

--- a/scripts/generate-documentation-index.py
+++ b/scripts/generate-documentation-index.py
@@ -11,6 +11,10 @@ import sys
 ROOT = Path(__file__).resolve().parents[1]
 TARGET = ROOT / "docs" / "documentation-index.md"
 
+# Repo-root files sit OUTSIDE the MkDocs docs_dir, so a relative ../README.md
+# link 404s on the published site. Emit absolute GitHub URLs for those targets.
+GITHUB_BLOB = "https://github.com/boshu2/agentops/blob/main"
+
 
 def title(path: Path) -> str:
     if path.suffix == ".md":
@@ -29,10 +33,10 @@ def render() -> str:
         "",
         "## Product and workflow",
         "",
-        "- [README](../README.md)",
-        "- [Product boundary](../PRODUCT.md)",
-        "- [Fitness goals](../GOALS.md)",
-        "- [Program boundary](../PROGRAM.md)",
+        f"- [README]({GITHUB_BLOB}/README.md)",
+        f"- [Product boundary]({GITHUB_BLOB}/PRODUCT.md)",
+        f"- [Fitness goals]({GITHUB_BLOB}/GOALS.md)",
+        f"- [Program boundary]({GITHUB_BLOB}/PROGRAM.md)",
         "- [Operating loop](architecture/operating-loop.md)",
         "- [Gas City factory](architecture/gas-city-factory.md)",
         "- [Agent workflow](agent-workflow-reference.md)",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -405,8 +405,8 @@
     {
       "name": "doc",
       "source_skill": "skills/doc",
-      "source_hash": "6ebe03e1bade16684819e9b2dddc7b55d06513904d19f946099615266bd91f8e",
-      "generated_hash": "1743038084a42d861465d7c6bae53f45919da7b43df004ed36fa36e21cce2499"
+      "source_hash": "2c8bac339d06f5fd1f712a1bb1cb7cb5bf4441be20fd07176e557fac8b44e62f",
+      "generated_hash": "02cbcf8758647c0ae661300748a1709883c05cb44b80e6076a624247bb82419f"
     },
     {
       "name": "domain",

--- a/skills-codex/doc/.agentops-generated.json
+++ b/skills-codex/doc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/doc",
   "layout": "modular",
-  "source_hash": "6ebe03e1bade16684819e9b2dddc7b55d06513904d19f946099615266bd91f8e",
-  "generated_hash": "1743038084a42d861465d7c6bae53f45919da7b43df004ed36fa36e21cce2499"
+  "source_hash": "2c8bac339d06f5fd1f712a1bb1cb7cb5bf4441be20fd07176e557fac8b44e62f",
+  "generated_hash": "02cbcf8758647c0ae661300748a1709883c05cb44b80e6076a624247bb82419f"
 }

--- a/skills-codex/doc/references/architecture-report.md
+++ b/skills-codex/doc/references/architecture-report.md
@@ -33,16 +33,13 @@ Include file:line references. Output as markdown I can reference later.
 
 ## Quick Start
 
-```bash
-# Option 1: Auto-scaffold (fills what it can detect)
-./scripts/scaffold-report.py /path/to/project > ARCHITECTURE.md
+No scaffold script ships with this skill — explore manually, then fill the
+template from the structure below:
 
-# Option 2: Manual exploration
+```bash
 cat README.md AGENTS.md 2>/dev/null | head -200
 ls src/ lib/ cmd/ pkg/ 2>/dev/null
 rg "fn main|func main|if __name__" --type-add 'all:*.*' -l | head -5
-
-# Then fill template from the structure below
 ```
 
 ---
@@ -130,23 +127,11 @@ The subagent explores in read-only mode and returns findings in report-ready for
 
 ## Integration
 
-### With Hooks
+### With New Projects
 
-Auto-generate report stub on new project:
-
-```json
-{
-  "hooks": {
-    "PostToolUse": [{
-      "matcher": "Bash",
-      "hooks": [{
-        "type": "command",
-        "command": "if echo \"$TOOL_INPUT\" | grep -q 'git clone'; then ./scripts/scaffold-report.py . > ARCHITECTURE.md; fi"
-      }]
-    }]
-  }
-}
-```
+On a fresh clone, start the report by hand: copy the section structure from
+this reference into `ARCHITECTURE.md`, then fill it from manual exploration
+(Quick Start above). There is no auto-scaffold script.
 
 ### With Other Skills
 
@@ -165,9 +150,12 @@ Auto-generate report stub on new project:
 
 ## Scripts
 
+Shipped with the doc skill (`skills/doc/scripts/`):
+
 | Script | Purpose |
 |--------|---------|
-| `scripts/scaffold-report.py` | Auto-generate report skeleton |
+| `scripts/audit-oss-docs.sh` | Audit OSS documentation coverage by tier |
+| `scripts/validate.sh` | Self-check the doc skill package structure |
 
 ## Subagents
 

--- a/skills-codex/doc/references/validation-rules.md
+++ b/skills-codex/doc/references/validation-rules.md
@@ -15,11 +15,12 @@
 
 ## INFORMATIONAL Validation
 
-Use Python validator for fast, exhaustive checking:
-
-```bash
-python3 ~/.claude/scripts/doc-validate.py docs/
-```
+No standalone validator script ships with this skill. Run the checks below
+manually — for doc-file presence coverage use the shipped
+`skills/doc/scripts/audit-oss-docs.sh`; for link/orphan/path checks write a
+short throwaway Python script in the target repo (not bash: bash loops are
+O(n*m) and time out on large repos, while Python processes 350+ files in
+seconds with cleaner regex extraction).
 
 ### Checks Performed
 
@@ -27,12 +28,6 @@ python3 ~/.claude/scripts/doc-validate.py docs/
 2. **Orphaned Docs** - Files not referenced from any index
 3. **Index Completeness** - READMEs reference all subdirectories
 4. **Hardcoded Paths** - Absolute paths like /Users/, /home/
-
-### Why Python, Not Bash?
-
-- Bash loops are O(n*m) and timeout on large repos
-- Python processes 350+ files in <5 seconds
-- Regex extraction is cleaner and more reliable
 
 ### Output Format
 

--- a/skills/doc/references/architecture-report.md
+++ b/skills/doc/references/architecture-report.md
@@ -33,16 +33,13 @@ Include file:line references. Output as markdown I can reference later.
 
 ## Quick Start
 
-```bash
-# Option 1: Auto-scaffold (fills what it can detect)
-./scripts/scaffold-report.py /path/to/project > ARCHITECTURE.md
+No scaffold script ships with this skill — explore manually, then fill the
+template from the structure below:
 
-# Option 2: Manual exploration
+```bash
 cat README.md AGENTS.md 2>/dev/null | head -200
 ls src/ lib/ cmd/ pkg/ 2>/dev/null
 rg "fn main|func main|if __name__" --type-add 'all:*.*' -l | head -5
-
-# Then fill template from the structure below
 ```
 
 ---
@@ -130,23 +127,11 @@ The subagent explores in read-only mode and returns findings in report-ready for
 
 ## Integration
 
-### With Hooks
+### With New Projects
 
-Auto-generate report stub on new project:
-
-```json
-{
-  "hooks": {
-    "PostToolUse": [{
-      "matcher": "Bash",
-      "hooks": [{
-        "type": "command",
-        "command": "if echo \"$TOOL_INPUT\" | grep -q 'git clone'; then ./scripts/scaffold-report.py . > ARCHITECTURE.md; fi"
-      }]
-    }]
-  }
-}
-```
+On a fresh clone, start the report by hand: copy the section structure from
+this reference into `ARCHITECTURE.md`, then fill it from manual exploration
+(Quick Start above). There is no auto-scaffold script.
 
 ### With Other Skills
 
@@ -165,9 +150,12 @@ Auto-generate report stub on new project:
 
 ## Scripts
 
+Shipped with the doc skill (`skills/doc/scripts/`):
+
 | Script | Purpose |
 |--------|---------|
-| `scripts/scaffold-report.py` | Auto-generate report skeleton |
+| `scripts/audit-oss-docs.sh` | Audit OSS documentation coverage by tier |
+| `scripts/validate.sh` | Self-check the doc skill package structure |
 
 ## Subagents
 

--- a/skills/doc/references/validation-rules.md
+++ b/skills/doc/references/validation-rules.md
@@ -15,11 +15,12 @@
 
 ## INFORMATIONAL Validation
 
-Use Python validator for fast, exhaustive checking:
-
-```bash
-python3 ~/.claude/scripts/doc-validate.py docs/
-```
+No standalone validator script ships with this skill. Run the checks below
+manually — for doc-file presence coverage use the shipped
+`skills/doc/scripts/audit-oss-docs.sh`; for link/orphan/path checks write a
+short throwaway Python script in the target repo (not bash: bash loops are
+O(n*m) and time out on large repos, while Python processes 350+ files in
+seconds with cleaner regex extraction).
 
 ### Checks Performed
 
@@ -27,12 +28,6 @@ python3 ~/.claude/scripts/doc-validate.py docs/
 2. **Orphaned Docs** - Files not referenced from any index
 3. **Index Completeness** - READMEs reference all subdirectories
 4. **Hardcoded Paths** - Absolute paths like /Users/, /home/
-
-### Why Python, Not Bash?
-
-- Bash loops are O(n*m) and timeout on large repos
-- Python processes 350+ files in <5 seconds
-- Regex extraction is cleaner and more reliable
 
 ### Output Format
 

--- a/tests/docs/mkdocs-strict-allowlist.txt
+++ b/tests/docs/mkdocs-strict-allowlist.txt
@@ -4,69 +4,37 @@
 # --check tolerates because it is an INTENTIONAL cross-reference from a docs/ page
 # to a real repo artifact that lives OUTSIDE the published site (docs_dir). These
 # links resolve for repo/GitHub readers; mkdocs cannot resolve them because the
-# target is not part of the built site. See docs/docs-build-dispositions.md for the
-# per-class rationale.
+# target is not part of the built site.
+#
+# Policy consistency: mkdocs.yml declares `strict: false` for the PUBLISHED build
+# (docs deliberately link outside docs_dir); tests/docs/validate-links.sh owns
+# link checking for the doc-release checks. `scripts/docs-build.sh --check` is the
+# deliberate strict BACKSTOP on top of that: strict mode with this curated
+# allowlist, so new/accidental broken links still fail while the accepted
+# out-of-tree cross-references pass.
 #
 # Format: the verbatim `WARNING -  ...` line mkdocs emits (whole-line, exact match).
 # The check FAILS on any strict warning NOT listed here, so NEW/accidental broken
 # links still break the build — this is a baseline, not a blanket suppression.
 # Add a line here ONLY after confirming the target is a real repo artifact that is
 # deliberately outside the docs site; prefer FIXING the link when a docs-site target
-# exists. Blank lines and lines starting with '#' are ignored.
+# exists. NEVER allowlist a link whose target exists nowhere in the repo — that is
+# a dead link to fix at the source. Blank lines and '#' lines are ignored.
+#
+# Refreshed 2026-07-20: the previous 53 entries all referenced source docs deleted
+# in the Cathedral Cut and could no longer fire; replaced with the verified
+# accepted-class warnings the current tree emits.
 #
 # Regenerate/refresh after an intentional doc move:
 #   scripts/docs-build.sh --check   # prints any un-dispositioned warning verbatim
 
-WARNING -  Doc file 'GLOSSARY.md' contains a link '../skills/beads-br/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'GLOSSARY.md' contains a link '../skills/council/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'GLOSSARY.md' contains a link '../skills/crank/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'GLOSSARY.md' contains a link '../skills/handoff/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'GLOSSARY.md' contains a link '../skills/operationalize/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'GLOSSARY.md' contains a link '../skills/postmortem/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'GLOSSARY.md' contains a link '../skills/premortem/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'GLOSSARY.md' contains a link '../skills/research/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'GLOSSARY.md' contains a link '../skills/standards/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'GLOSSARY.md' contains a link '../skills/swarm/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'GLOSSARY.md' contains a link '../skills/validate/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'SKILL-ROUTER.md' contains a link '../skills/ms/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'SKILLS.md' contains a link '../skills/ms/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'architecture/codebase-overview.md' contains a link '../../GOALS.md', but the target '../GOALS.md' is not found among documentation files.
-WARNING -  Doc file 'architecture/codebase-overview.md' contains a link '../../cli/docs/COMMANDS.md', but the target '../cli/docs/COMMANDS.md' is not found among documentation files.
-WARNING -  Doc file 'architecture/codebase-overview.md' contains a link '../../skills/SKILL-TIERS.md', but the target '../skills/SKILL-TIERS.md' is not found among documentation files.
-WARNING -  Doc file 'architecture/control-loop-model.md' contains a link '../../PRODUCT.md', but the target '../PRODUCT.md' is not found among documentation files.
-WARNING -  Doc file 'architecture/operating-loop.md' contains a link '../../skills/automation-shape-routing/SKILL.md', but the target '../skills/automation-shape-routing/SKILL.md' is not found among documentation files.
-WARNING -  Doc file 'architecture/operating-loop.md' contains a link '../../skills/rpi/references/agile-replan-loop.md', but the target '../skills/rpi/references/agile-replan-loop.md' is not found among documentation files.
-WARNING -  Doc file 'architecture/operating-loop.md' contains a link '../../skills/using-atm/SKILL.md#when-to-use-atm-vs-am-the-4-case-matrix', but the target '../skills/using-atm/SKILL.md' is not found among documentation files.
-WARNING -  Doc file 'architecture/workflow-conformance-pattern.md' contains a link '../../.claude/workflows/operating-loop.js', but the target '../.claude/workflows/operating-loop.js' is not found among documentation files.
-WARNING -  Doc file 'architecture/workflow-conformance-pattern.md' contains a link '../../skills/workflow-builder/SKILL.md', but the target '../skills/workflow-builder/SKILL.md' is not found among documentation files.
-WARNING -  Doc file 'comparisons/vs-hosted-code-review.md' contains a link '../../README.md#the-honest-version', but the target '../README.md' is not found among documentation files.
-WARNING -  Doc file 'context-lifecycle.md' contains a link '../skills/council/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'context-lifecycle.md' contains a link '../skills/postmortem/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'context-lifecycle.md' contains a link '../skills/premortem/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'context-lifecycle.md' contains a link '../skills/validate/SKILL.md', but the target is not found among documentation files.
-WARNING -  Doc file 'contracts/corpus-learning-seam.md' contains a link '../../schemas/learning.v1.schema.json', but the target '../schemas/learning.v1.schema.json' is not found among documentation files.
-WARNING -  Doc file 'contracts/pawls.md' contains a link '../../scripts/evolve/halt-check.sh', but the target '../scripts/evolve/halt-check.sh' is not found among documentation files.
-WARNING -  Doc file 'contracts/pawls.md' contains a link '../../scripts/pawl-review.sh', but the target '../scripts/pawl-review.sh' is not found among documentation files.
-WARNING -  Doc file 'contracts/pawls.md' contains a link '../../scripts/pawl.sh', but the target '../scripts/pawl.sh' is not found among documentation files.
-WARNING -  Doc file 'contracts/pawls.md' contains a link '../../skills/dcg/SKILL.md', but the target '../skills/dcg/SKILL.md' is not found among documentation files.
-WARNING -  Doc file 'contracts/pawls.md' contains a link '../../skills/discovery/SKILL.md', but the target '../skills/discovery/SKILL.md' is not found among documentation files.
-WARNING -  Doc file 'contracts/pawls.md' contains a link '../../skills/pre-land-refuters/SKILL.md', but the target '../skills/pre-land-refuters/SKILL.md' is not found among documentation files.
-WARNING -  Doc file 'contracts/pawls.md' contains a link '../../skills/scope/SKILL.md', but the target '../skills/scope/SKILL.md' is not found among documentation files.
-WARNING -  Doc file 'doctrine/lineage-and-theory.md' contains a link '../../PRODUCT.md#strategic-bet', but the target '../PRODUCT.md' is not found among documentation files.
-WARNING -  Doc file 'doctrine/lineage-and-theory.md' contains a link '../../PRODUCT.md', but the target '../PRODUCT.md' is not found among documentation files.
-WARNING -  Doc file 'doctrine/operating-discipline.md' contains a link '../../scripts/pawl-verdict.sh', but the target '../scripts/pawl-verdict.sh' is not found among documentation files.
-WARNING -  Doc file 'doctrine/operating-discipline.md' contains a link '../../scripts/reconcile-pr.sh', but the target '../scripts/reconcile-pr.sh' is not found among documentation files.
-WARNING -  Doc file 'evals/harvest-2026-06-22-escape-series-for-e5.md' contains a link '../../evals/membrane/harvest-2026-06-22/derived-check-rfd-nested-schema.md', but the target '../evals/membrane/harvest-2026-06-22/derived-check-rfd-nested-schema.md' is not found among documentation files.
-WARNING -  Doc file 'evals/harvest-2026-06-22-escape-series-for-e5.md' contains a link '../../evals/membrane/harvest-2026-06-22/escape-rate-series.jsonl', but the target '../evals/membrane/harvest-2026-06-22/escape-rate-series.jsonl' is not found among documentation files.
-WARNING -  Doc file 'evals/harvest-2026-06-22-escape-series-for-e5.md' contains a link '../../evals/membrane/harvest-2026-06-22/harvest-to-ledger.sh', but the target '../evals/membrane/harvest-2026-06-22/harvest-to-ledger.sh' is not found among documentation files.
-WARNING -  Doc file 'evals/harvest-2026-06-22-escape-series-for-e5.md' contains a link '../../evals/membrane/harvest-2026-06-22/run-harvest-series.sh', but the target '../evals/membrane/harvest-2026-06-22/run-harvest-series.sh' is not found among documentation files.
-WARNING -  Doc file 'evals/harvest-2026-06-22-escape-series-for-e5.md' contains a link '../../evals/membrane/harvest-2026-06-22/scorecard.json', but the target '../evals/membrane/harvest-2026-06-22/scorecard.json' is not found among documentation files.
-WARNING -  Doc file 'evals/harvest-2026-06-22-escape-series-for-e5.md' contains a link '../../evals/membrane/harvest-2026-06-22/summarize-series.py', but the target '../evals/membrane/harvest-2026-06-22/summarize-series.py' is not found among documentation files.
-WARNING -  Doc file 'evals/local-membrane-vs-codex-2026-06-23.md' contains a link '../../evals/membrane/membrane-compare-2026-06-23/A-local-qwen.json', but the target '../evals/membrane/membrane-compare-2026-06-23/A-local-qwen.json' is not found among documentation files.
-WARNING -  Doc file 'evals/local-membrane-vs-codex-2026-06-23.md' contains a link '../../evals/membrane/membrane-compare-2026-06-23/B-codex.json', but the target '../evals/membrane/membrane-compare-2026-06-23/B-codex.json' is not found among documentation files.
-WARNING -  Doc file 'evals/local-membrane-vs-codex-2026-06-23.md' contains a link '../../evals/membrane/subtle-escape-2026-06-23/A-local.json', but the target '../evals/membrane/subtle-escape-2026-06-23/A-local.json' is not found among documentation files.
-WARNING -  Doc file 'evals/local-membrane-vs-codex-2026-06-23.md' contains a link '../../evals/membrane/subtle-escape-2026-06-23/B-codex.json', but the target '../evals/membrane/subtle-escape-2026-06-23/B-codex.json' is not found among documentation files.
-WARNING -  Doc file 'evals/local-membrane-vs-codex-2026-06-23.md' contains a link '../../evals/membrane/subtle-escape-2026-06-23/full-A-local.json', but the target '../evals/membrane/subtle-escape-2026-06-23/full-A-local.json' is not found among documentation files.
-WARNING -  Doc file 'evals/local-membrane-vs-codex-2026-06-23.md' contains a link '../../evals/membrane/subtle-escape-2026-06-23/full-B-codex.json', but the target '../evals/membrane/subtle-escape-2026-06-23/full-B-codex.json' is not found among documentation files.
-WARNING -  Doc file 'evals/membrane-escape-harvest-no-escape.md' contains a link '../../evals/membrane/flywheel-harvest.workflow.js', but the target '../evals/membrane/flywheel-harvest.workflow.js' is not found among documentation files.
-WARNING -  Doc file 'evals/membrane-escape-harvest-no-escape.md' contains a link '../../evals/membrane/harvest.sh', but the target '../evals/membrane/harvest.sh' is not found among documentation files.
+WARNING -  Doc file 'CI-CD.md' contains a link '../AGENTS.md', but the target is not found among documentation files.
+WARNING -  Doc file 'agent-workflow-reference.md' contains a link '../AGENTS.md', but the target is not found among documentation files.
+WARNING -  Doc file 'dependencies.md' contains a link '../README.md', but the target is not found among documentation files.
+WARNING -  Doc file 'seed-definition.md' contains a link '../PRODUCT.md', but the target is not found among documentation files.
+WARNING -  Doc file 'trust-factory.md' contains a link '../PRODUCT.md', but the target is not found among documentation files.
+WARNING -  Doc file 'wiki-for-agents.md' contains a link '../PRODUCT.md', but the target is not found among documentation files.
+WARNING -  Doc file 'contracts/codex-skill-api.md' contains a link '../../AGENTS.md', but the target '../AGENTS.md' is not found among documentation files.
+WARNING -  Doc file 'releases/2026-07-17-v3.3.0-notes.md' contains a link '../../CHANGELOG.md', but the target '../CHANGELOG.md' is not found among documentation files. Did you mean '../CHANGELOG.md'?
+WARNING -  Doc file 'skills/cc-hooks.md' contains a link 'hooks/policy-dispatch.sh', but the target 'skills/hooks/policy-dispatch.sh' is not found among documentation files.
+WARNING -  Doc file 'skills/cc-hooks.md' contains a link 'policies/policies.json', but the target 'skills/policies/policies.json' is not found among documentation files.


### PR DESCRIPTION
Wave 4 (residue) of the new-user happy-path arc. Three scoped implementer lanes + fresh adversarial verifier (4 RESOLVED; 1 INCOMPLETE = stale generated projections, closed in integration).

**Doctor**: the dev-version detector now reuses the Binary Freshness resolution — a from-source build matching its checkout is healthy (a novice building from source can finally see `ao doctor` exit 0); findings fire only on genuine drift, shadowed duplicate `ao` binaries, or an informational from-source note outside any checkout. `ao doctor diff` gains `--only` so the fix-plan preview can be scoped the way remediation text implies.

**Config**: the dead `ao config models` surface is removed end-to-end (lane re-verified zero consumers before deleting; `--show` proven byte-identical before/after; removed-child hint + MIGRATION row; existing `models:` config sections still parse and are ignored).

**Dual-root stragglers**: learning-coherence gate globs, `quality.CountConstraints`, and the eval sandbox corpus deny-list now cover canonical `.agents/ao/<section>` alongside legacy roots.

**Doc-link hygiene**: the strict docs-link backstop's allowlist was 100% stale (53/53 entries referenced Cathedral-Cut-deleted docs) — refreshed to 10 verified accepted-class entries; ROADMAP dead links fixed; documentation-index generator emits GitHub URLs for repo-root targets; doc-skill references instruct only shipped scripts; codex twins + CLI-surface projections + surface-count fixture regenerated.

**Deferred by design**: the `3.3.0-rc` fallback version bump belongs inside the v3.3.0 tag-cut commit.

**Verified**: full suite 61/61 pkgs (2825 tests); golangci-lint clean; `ao gate check --full` 67/67 over this range; Test-Removal-Reason trailer covers the 6 deliberately deleted models tests.