### PR TITLE
fix(gates): atomic-write ratchet fails closed on scan-helper death — no silent PASS

### DIFF
--- a/scripts/check-atomic-write-ratchet.sh
+++ b/scripts/check-atomic-write-ratchet.sh
@@ -133,12 +133,35 @@ strip_go_comments() {
 # file_trips PATH -> 0 if the WHOLE FILE trips: a non-comment os.Rename(
 # invocation AND a non-comment temp-file signal (os.CreateTemp( or ".tmp
 # literal), evaluated AFTER strip_go_comments.
+# Tri-state: 0 trips · 1 does not trip (incl. path absent from the worktree —
+# a deleted file is no new site) · 2 helper failure, refusing to certify.
+# A dying awk/grep (fork failure, stray signal under parallel CI load) must
+# never read as "no signal": that exact conflation let the gate print a clean
+# PASS over an unchecked diff once on CI (run 29785505667, bats 4-way parallel)
+# — the same swallowed-failure class the ratchet-lib collectors guard against.
+# The signal greps read their whole input (no -q early-exit) so pipefail can
+# never surface a SIGPIPE'd printf as a phantom helper failure on large files.
 file_trips() {
-  local p="$1" stripped
+  local p="$1" stripped rc
   [[ -f "$p" ]] || return 1
-  stripped="$(strip_go_comments < "$p")" || return 1
-  printf '%s\n' "$stripped" | grep -q 'os\.Rename(' || return 1
-  printf '%s\n' "$stripped" | grep -qE 'os\.CreateTemp\(|"\.tmp' || return 1
+  if ! stripped="$(strip_go_comments < "$p")"; then
+    echo "check-atomic-write-ratchet: comment strip failed for '$p' — refusing to certify" >&2
+    return 2
+  fi
+  rc=0
+  printf '%s\n' "$stripped" | grep 'os\.Rename(' >/dev/null || rc=$?
+  if [[ "$rc" -gt 1 ]]; then
+    echo "check-atomic-write-ratchet: signal scan failed (rc $rc) for '$p' — refusing to certify" >&2
+    return 2
+  fi
+  [[ "$rc" -eq 0 ]] || return 1
+  rc=0
+  printf '%s\n' "$stripped" | grep -E 'os\.CreateTemp\(|"\.tmp' >/dev/null || rc=$?
+  if [[ "$rc" -gt 1 ]]; then
+    echo "check-atomic-write-ratchet: signal scan failed (rc $rc) for '$p' — refusing to certify" >&2
+    return 2
+  fi
+  [[ "$rc" -eq 0 ]] || return 1
   return 0
 }
 
@@ -146,10 +169,18 @@ file_trips() {
 # tripping, sorted. Same heuristic as the flagger, so a fresh regenerate is
 # authoritative for "what is grandfathered now".
 compute_grandfather_set() {
-  local f
+  local f rc
   while IFS= read -r f; do
     is_exempt_path "$f" && continue
-    file_trips "$f" || continue
+    rc=0
+    file_trips "$f" || rc=$?
+    # A helper failure must abort the regenerate (ratchet_regenerate then
+    # leaves the pinned file untouched) — a swallowed rc 2 here would silently
+    # drop entries and emit a truncated grandfather list.
+    if [[ "$rc" -eq 2 ]]; then
+      return 1
+    fi
+    [[ "$rc" -eq 0 ]] || continue
     printf '%s\n' "$f"
   done < <(grep -rl 'os\.Rename(' cli --include='*.go' 2>/dev/null || true) | LC_ALL=C sort
 }
@@ -208,11 +239,25 @@ elif [[ "$_shrink_rc" -ne 0 ]]; then
   done <<< "$added_entries"
 fi
 
+# Collect the changed set BEFORE iterating: a collector failure inside a
+# `< <(...)` process substitution is silently discarded and the loop would
+# certify an EMPTY change set — the exact fail-open the ratchet-lib header
+# warns about (and the silent-PASS shape of CI flake 29785505667). Captured
+# under pipefail, a collector rc 2 aborts loudly instead.
+changed_list="$(ratchet_changed_files "$SCOPE" | LC_ALL=C sort -u)" \
+  || { echo "check-atomic-write-ratchet: changed-file collection failed — refusing to certify an unchecked change set" >&2; exit 2; }
+
 new_hits=()
 while IFS= read -r f; do
   [[ -z "$f" ]] && continue
   is_exempt_path "$f" && continue
-  file_trips "$f" || continue
+  trip_rc=0
+  file_trips "$f" || trip_rc=$?
+  if [[ "$trip_rc" -eq 2 ]]; then
+    exit 2
+  elif [[ "$trip_rc" -ne 0 ]]; then
+    continue
+  fi
   # The added-hunk guard applies to EVERY tripping file — grandfathered or
   # not: a new rename site never rides an old exemption (premortem FM7).
   # It fires when the added hunk introduces EITHER half of the signature —
@@ -222,9 +267,16 @@ while IFS= read -r f; do
   # with NO // earlier on the added line (comment-only additions never trip);
   # an added line inside a multi-line /* block */ cannot be classified from a
   # diff hunk and MAY false-trip — advisory, pre-declared.
-  ratchet_added_hunk_matches "$SCOPE" "$f" '^([^/]|/[^/])*(os\.Rename\(|os\.CreateTemp\(|"\.tmp)' || continue
+  hunk_rc=0
+  ratchet_added_hunk_matches "$SCOPE" "$f" '^([^/]|/[^/])*(os\.Rename\(|os\.CreateTemp\(|"\.tmp)' || hunk_rc=$?
+  if [[ "$hunk_rc" -eq 1 ]]; then
+    continue
+  elif [[ "$hunk_rc" -ne 0 ]]; then
+    echo "check-atomic-write-ratchet: added-hunk guard failed (rc $hunk_rc) for '$f' — refusing to certify" >&2
+    exit 2
+  fi
   new_hits+=("$f")
-done < <(ratchet_changed_files "$SCOPE" | LC_ALL=C sort -u)
+done <<< "$changed_list"
 
 if [[ "${#new_hits[@]}" -gt 0 ]]; then
   rc=1
@@ -242,7 +294,11 @@ fi
 # SHRINK RATCHET: a grandfathered file that no longer trips must be pruned.
 stale=()
 for g in "${GRANDFATHER[@]}"; do
-  if ! file_trips "$g"; then
+  trip_rc=0
+  file_trips "$g" || trip_rc=$?
+  if [[ "$trip_rc" -eq 2 ]]; then
+    exit 2
+  elif [[ "$trip_rc" -ne 0 ]]; then
     stale+=("$g")
   fi
 done

--- a/scripts/lib/ratchet.sh
+++ b/scripts/lib/ratchet.sh
@@ -451,6 +451,7 @@ ratchet_changed_files_status() {
 # changed-content guard: editing a file without adding a matching line does
 # not re-flag it. A path with NO diff (untracked in worktree scope, missing
 # HEAD~1) is treated as entirely added and matched whole-file.
+# 1 = no added match · 2 = scan helper failed (loud; never conflated with 1).
 ratchet_added_hunk_matches() {
   local scope="${1:?ratchet_added_hunk_matches: scope required}"
   local p="${2:?ratchet_added_hunk_matches: path required}"
@@ -478,20 +479,35 @@ ratchet_added_hunk_matches() {
   esac
   local diff_out
   diff_out="$("${diffcmd[@]}" 2>/dev/null || true)"
+  # Tri-state from here down: 0 match · 1 no match · 2 helper failure. A grep
+  # or awk that DIES (fork failure, stray signal under parallel CI load) must
+  # never read as "no added match" — that conflation let a consumer gate
+  # certify a clean PASS over an unchecked diff (atomic-write ratchet, CI run
+  # 29785505667). Callers using `|| continue` still skip on rc 2 exactly as
+  # they did on the old passthrough rc, but the failure is now loud.
   if [[ -z "$diff_out" ]]; then
-    grep -Eq -- "$ere" "$p" 2>/dev/null && return 0
-    return 1
+    local grep_rc=0
+    grep -Eq -- "$ere" "$p" 2>/dev/null || grep_rc=$?
+    [[ "$grep_rc" -eq 0 ]] && return 0
+    [[ "$grep_rc" -eq 1 ]] && return 1
+    echo "ratchet_added_hunk_matches: whole-file scan failed (rc $grep_rc) for '$p' — refusing to certify" >&2
+    return 2
   fi
   # True iff an ADDED line (single leading '+', not the '+++' header) matches.
   # awk sidesteps the BSD-grep '+'-quantifier portability trap. The ERE rides
   # ENVIRON, not -v: -v applies C-escape processing that corrupts patterns
   # like 'os\.Rename\(' (the backslashes are load-bearing).
+  local awk_rc=0
   printf '%s\n' "$diff_out" | RATCHET_HUNK_ERE="$ere" awk '
     BEGIN { ere = ENVIRON["RATCHET_HUNK_ERE"] }
     /^\+\+\+/ { next }
     /^\+/ { if (substr($0, 2) ~ ere) found = 1 }
     END { exit found ? 0 : 1 }
-  '
+  ' || awk_rc=$?
+  [[ "$awk_rc" -eq 0 ]] && return 0
+  [[ "$awk_rc" -eq 1 ]] && return 1
+  echo "ratchet_added_hunk_matches: added-hunk scan failed (rc $awk_rc) for '$p' — refusing to certify" >&2
+  return 2
 }
 
 # --- regenerate ----------------------------------------------------------------

--- a/tests/scripts/check-atomic-write-ratchet.bats
+++ b/tests/scripts/check-atomic-write-ratchet.bats
@@ -347,3 +347,23 @@ GO
     [ "$status" -eq 1 ]
     [[ "$output" == *"cli/internal/thing/gainer.go"* ]]
 }
+
+@test "a dying scan helper is rc 2 refusing to certify — never a silent PASS (CI flake 29785505667)" {
+    # Root of the one-off CI false-PASS: a helper (awk/grep) killed or failing
+    # under parallel-runner load used to read as "no signal" and the gate
+    # printed a clean PASS over an unchecked diff. Pin the tri-state: helper
+    # death is loud rc 2, never certification.
+    write_writer_shape "cli/internal/thing/writer.go"
+    commit_all "add writer"
+    mkdir -p "$TMP_DIR/bin"
+    cat > "$TMP_DIR/bin/awk" <<'SHIM'
+#!/usr/bin/env bash
+# Simulate the CI class: the scan helper dies (stray signal / fork pressure).
+kill -TERM $$
+SHIM
+    chmod +x "$TMP_DIR/bin/awk"
+    run bash -c "cd '$TMP_DIR' && PATH=\"$TMP_DIR/bin:\$PATH\" bash scripts/check-atomic-write-ratchet.sh --scope head"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"refusing to certify"* ]]
+    [[ "$output" != *"PASS"* ]]
+}

--- a/tests/scripts/ratchet-lib.bats
+++ b/tests/scripts/ratchet-lib.bats
@@ -291,6 +291,24 @@ SHIM
     [ "$status" -eq 0 ]
 }
 
+@test "added_hunk_matches with a DYING awk is rc 2 (helper failure never reads as no-match)" {
+    # Pin for the atomic-write CI false-PASS class (run 29785505667): a scan
+    # helper killed under parallel-runner load must be a loud rc 2, not rc 1 —
+    # rc 1 lets a consumer gate certify an unchecked diff as clean.
+    ( cd "$TMP_DIR" && printf 'package x\n' > f.go )
+    seed_commit "base f.go"
+    ( cd "$TMP_DIR" && printf 'package x\nfunc a() { os.Rename(p, q) }\n' > f.go && git add f.go && git commit -qm "add rename" )
+    mkdir -p "$TMP_DIR/binawk"
+    cat > "$TMP_DIR/binawk/awk" <<'SHIM'
+#!/usr/bin/env bash
+kill -TERM $$
+SHIM
+    chmod +x "$TMP_DIR/binawk/awk"
+    run bash -c "cd '$TMP_DIR' && source '$LIB' && PATH=\"$TMP_DIR/binawk:\$PATH\" ratchet_added_hunk_matches head f.go 'os\\.Rename\\('"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"refusing to certify"* ]]
+}
+
 # --- regenerate --------------------------------------------------------------
 
 @test "regenerate writes header + LC_ALL=C sorted body" {


### PR DESCRIPTION
## Root cause (CI flake, run 29785505667 attempt 1, PR #944)

The bats test `adding only the temp-signal half to a file with an EXISTING rename still trips` failed once on ubuntu with the ratchet printing a clean `PASS … grandfathered=0` where the fixture deterministically trips. Diagnosed by analysis per the test-isolation discipline (not repro-chasing):

- bats errexit proves every fixture `git commit` succeeded; the fixture repo is fully isolated.
- `grandfathered=0` in the PASS line fingerprints the run as in-fixture (real repo = 4).
- Zero stderr in the captured output rules out every loud failure handler.

What remains: **three silent paths where a scan helper (grep/awk/git) dying under 4-way-parallel runner load reads as "no finding"** — the gate then certifies an unchecked diff:

1. `file_trips`: strip/grep failure returned 1 ("does not trip") → file silently skipped.
2. Detector loop read from `< <(ratchet_changed_files | sort)` — a collector rc 2 inside process substitution is discarded, certifying an EMPTY change set (the exact fail-open the ratchet-lib header warns about).
3. `ratchet_added_hunk_matches`: helper death propagated as arbitrary nonzero, swallowed by `|| continue`.

## Fix

- `file_trips` is tri-state (0 trips / 1 no / 2 refuse-to-certify, loud); signal greps read full input (no `-q` early-exit) so pipefail can never surface a SIGPIPE'd printf as a phantom failure on large files.
- Changed files are collected into a variable under pipefail with an explicit `exit 2` handler.
- `ratchet_added_hunk_matches` maps fallback-grep/awk death to loud rc 2 (0/1 unchanged; existing `|| continue` consumers skip on 2 exactly as before, now loudly).
- `compute_grandfather_set` aborts `--regenerate` on helper failure — never a truncated grandfather list.

## Pinned

Dying-awk PATH-shim tests at gate and lib level: helper death is rc 2 "refusing to certify", never PASS. Same fail-closed class as the pawl-refuted empty-stream certify (2026-07-10).

## Validation

- 58/58 in `check-atomic-write-ratchet.bats` + `ratchet-lib.bats` on fresh origin/main
- All six ratchet-lib consumer gate suites green
- `shellcheck -S warning` clean; real-repo gate PASS (grandfathered=4); `--regenerate` byte-identical
- 65 repetitions of the formerly-flaky test green

Residual: the external kill source is unprovable from one occurrence; a recurrence now exits 2 naming the failed helper + file instead of printing PASS.