### PR TITLE
feat(workflows): rpi — the product loop with structurally enforced fresh validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ before upgrading.
   project-local `.claude/workflows/` registry — a Claude-only runtime adapter,
   same doctrine as `skills-codex/`, with the same refuse-foreign link
   semantics as `ao skills link`.
+- An `rpi` workflow script (`workflows/rpi.js`) running the one-pass core loop
+  as a conveyor: Plan snapshots exact intent bytes under SHA-256 identity,
+  Implement runs one bounded RED->GREEN experiment inside its write scope, and
+  a structurally separate fresh Validate context — receiving only derived
+  facts, never the author's narrative — persists `verdict.v2` with distinct
+  context ids. Any dead stage degrades to `NOT_PROVEN`; no retry, no
+  lifecycle authority.
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,13 @@ before upgrading.
   project-local `.claude/workflows/` registry — a Claude-only runtime adapter,
   same doctrine as `skills-codex/`, with the same refuse-foreign link
   semantics as `ao skills link`.
+- An `rpi` workflow script (`workflows/rpi.js`) running the one-pass core loop
+  as a conveyor: Plan snapshots exact intent bytes under SHA-256 identity,
+  Implement runs one bounded RED->GREEN experiment inside its write scope, and
+  a structurally separate fresh Validate context — receiving only derived
+  facts, never the author's narrative — persists `verdict.v2` with distinct
+  context ids. Any dead stage degrades to `NOT_PROVEN`; no retry, no
+  lifecycle authority.
 
 ### Changed
 

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -12,6 +12,7 @@ Three generic conveyor shapes:
 | `audit-dimensions` | pipeline: finder → skeptic, per dimension | auditing a subject across independent lenses |
 | `verify-fixes` | parallel adversarial verifiers, one per group | refuting "it's fixed" claims after a change |
 | `implement-wave` | parallel disjoint-scope lanes → one fresh verifier | executing a wave of bead-shaped work items |
+| `rpi` | pipeline: plan → implement → fresh validate | one intent through the core loop to a durable verdict |
 
 Four repo-doctrine conveyors also live here: `bdd-foundry` (behavior-first
 planning → acceptance-gated beads), `operating-loop` (one capability through
@@ -104,5 +105,32 @@ Workflow({ name: 'implement-wave', args: {
       acceptance: 'go test ./cli/internal/parse/... passes including a new case-insensitivity test that fails before the change.' },
   ],
   verify: { brief: 'Persist each lane verdict via the Validate skill (verdict.v2).' },
+}})
+```
+
+## rpi
+
+One caller intent through the core loop, once: Plan shapes one active behavior
+and snapshots the exact intent bytes under SHA-256 identity (validate tooling's
+`snapshot-intent`), Implement runs one bounded RED→GREEN experiment strictly
+inside the write scope, then a separately spawned Validate context re-verifies
+the intent digest, computes the subject manifest over the changed paths, judges
+every acceptance criterion with fresh evidence, and persists `verdict.v2` via
+`store-verdict` with distinct author/validator context ids and a freshness
+attestation. The script is the wall: the validator receives only the intent
+identity, acceptance, write scope, changed paths, check receipts, and author
+context id — never the implementer's narrative. Any dead stage degrades the
+result to `NOT_PROVEN` with an `error` naming the stage.
+
+Doctrine: one pass, no retry loop, no revision path, no lifecycle ownership —
+the authoring context structurally cannot issue its own binding PASS.
+
+Args: `{ intent: string, root?: string, writeScope?: [string], acceptance?: string }` — `writeScope`/`acceptance` are caller-fixed when given, otherwise Plan derives them.
+Returns: `{ verdict: PASS|FAIL|NOT_PROVEN, verdictPath, intentDigest, changedPaths, filesSummary, criteria: [{ criterion, result, evidence }] }` (plus `error` when a stage died; `filesSummary` is the implementer's caller-facing note — it never reaches the validator).
+
+```js
+Workflow({ name: 'rpi', args: {
+  intent: 'ao doctor should exit non-zero and name the missing hook when the pre-push hook is absent',
+  writeScope: ['cli/internal/doctor/**'],
 }})
 ```

--- a/workflows/rpi.js
+++ b/workflows/rpi.js
@@ -1,0 +1,265 @@
+export const meta = {
+  name: 'rpi',
+  description:
+    'One pass of the AgentOps core loop: Plan shapes one behavior and snapshots intent identity, Implement runs one bounded RED->GREEN experiment, then a structurally fresh Validate context judges the exact content and persists verdict.v2. No retry, no revision, no lifecycle.',
+  whenToUse: 'When a caller intent (behavior request or bead text) should be driven through Plan -> Implement -> fresh Validate exactly once, ending in a durable PASS | FAIL | NOT_PROVEN verdict. Not for multi-lane waves (implement-wave) or verdict-only re-checks (verify-fixes).',
+  phases: [
+    { title: 'Plan', detail: 'shape one active behavior; snapshot exact intent bytes under SHA-256 identity' },
+    { title: 'Implement', detail: 'one bounded RED->GREEN experiment strictly inside write scope' },
+    { title: 'Validate', detail: 'fresh context re-verifies identity, judges acceptance, persists verdict.v2' },
+  ],
+};
+
+const PLAN_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['acceptance', 'writeScope', 'intentDigest', 'intentPath'],
+  properties: {
+    acceptance: { type: 'string' },
+    writeScope: { type: 'array', items: { type: 'string' } },
+    intentDigest: { type: 'string' },
+    intentPath: { type: 'string' },
+  },
+};
+
+// CONTRACT: no free narrative field beyond filesSummary — and the script never
+// forwards filesSummary to the validator. The author's story must not be able
+// to reach the judging context.
+const IMPLEMENT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['contextId', 'changedPaths', 'checkReceipts', 'filesSummary'],
+  properties: {
+    contextId: { type: 'string' },
+    changedPaths: { type: 'array', items: { type: 'string' } },
+    checkReceipts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['name', 'command', 'outcome'],
+        properties: {
+          name: { type: 'string' },
+          command: { type: 'string' },
+          outcome: { type: 'string' },
+        },
+      },
+    },
+    filesSummary: { type: 'string' },
+  },
+};
+
+const VALIDATE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['verdict', 'verdictPath', 'criteria', 'validatorContextId'],
+  properties: {
+    verdict: { enum: ['PASS', 'FAIL', 'NOT_PROVEN'] },
+    verdictPath: { type: 'string' },
+    criteria: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['criterion', 'result', 'evidence'],
+        properties: {
+          criterion: { type: 'string' },
+          result: { type: 'string' },
+          evidence: { type: 'string' },
+        },
+      },
+    },
+    validatorContextId: { type: 'string' },
+  },
+};
+
+function badArgs(detail) {
+  throw new Error(
+    'rpi: bad args (' + detail + '). Expected ' +
+      '{ intent: string, root?: string, writeScope?: [string, ...], acceptance?: string }'
+  );
+}
+
+// The harness may deliver args as a JSON-encoded string (see Workflow tool
+// docs); normalize before validating so both shapes work.
+const input = typeof args === 'string' ? JSON.parse(args) : args;
+log('args received as ' + (typeof args) + (input ? ' (normalized ok)' : ' (empty)'));
+if (!input || typeof input !== 'object') badArgs('args missing');
+if (typeof input.intent !== 'string' || !input.intent.trim()) badArgs('intent must be a non-empty string');
+if (input.root !== undefined && typeof input.root !== 'string') badArgs('root must be a string when given');
+if (
+  input.writeScope !== undefined &&
+  (!Array.isArray(input.writeScope) || input.writeScope.length === 0 ||
+    input.writeScope.some((s) => typeof s !== 'string' || !s.trim()))
+) {
+  badArgs('writeScope must be a non-empty array of path globs when given');
+}
+if (input.acceptance !== undefined && (typeof input.acceptance !== 'string' || !input.acceptance.trim())) {
+  badArgs('acceptance must be a non-empty string when given');
+}
+
+const where = input.root
+  ? 'Work in ' + input.root + '.'
+  : 'Work in the current repository (the session working directory).';
+
+// The product's deterministic tooling does identity and persistence; agents
+// drive it, never hand-roll it. Every stage prompt carries the same locator.
+const toolingBlock =
+  'Deterministic tooling (drive it, never hand-roll identity or persistence): ' +
+  'the installed validate skill ships scripts/validate.py with subcommands ' +
+  'snapshot-intent, manifest, verify-manifest, digest, store-verdict. Locate it at the installed ' +
+  'skill root (e.g. ~/.claude/skills/validate/scripts/validate.py) or at ' +
+  'skills/validate/scripts/validate.py in a checkout. If you cannot find or run it, do not ' +
+  'improvise a substitute: report the stage as failed with the real error text.';
+
+phase('Plan');
+
+const plan = await agent(
+  'You are the Plan stage of a one-pass Plan -> Implement -> fresh Validate loop.\n\n' +
+    'Caller intent (behavior request or bead text):\n' + input.intent + '\n\n' +
+    (input.acceptance
+      ? 'The caller fixed the acceptance criteria — adopt them verbatim as your acceptance output:\n' + input.acceptance + '\n\n'
+      : '') +
+    (input.writeScope
+      ? 'The caller fixed the write scope — adopt these globs verbatim as your writeScope output:\n' +
+        input.writeScope.map((s) => '  - ' + s).join('\n') + '\n\n'
+      : '') +
+    'Your job:\n' +
+    '- ' + where + '\n' +
+    '- Shape ONE active behavior from the intent: read whatever you need to understand the subject, ' +
+    'then produce acceptance criteria (normal case AND edge case, each independently checkable) ' +
+    (input.acceptance ? '(caller-fixed above) ' : '') +
+    'and a write scope of path globs the implementation may touch ' +
+    (input.writeScope ? '(caller-fixed above).\n' : '(as tight as honestly possible).\n') +
+    '- Snapshot the EXACT intent bytes: write the caller intent text verbatim to a scratch file and run the ' +
+    'validate tooling\'s snapshot-intent subcommand on it, so the bytes persist under their SHA-256 content ' +
+    'identity. Return the digest as intentDigest and the persisted snapshot path as intentPath.\n' +
+    '- ' + toolingBlock + '\n' +
+    '- Read-only otherwise: the intent snapshot is the only thing you persist. Do not implement, do not edit ' +
+    'the subject, do not commit.',
+  { label: 'plan', phase: 'Plan', schema: PLAN_SCHEMA }
+);
+
+// CONTRACT: a failed stage degrades to NOT_PROVEN — never to a retry.
+if (!plan) {
+  return {
+    verdict: 'NOT_PROVEN',
+    verdictPath: null,
+    intentDigest: null,
+    changedPaths: [],
+    criteria: [],
+    error: 'Plan stage failed; no acceptance or intent identity exists, so nothing can be proven',
+  };
+}
+
+// CONTRACT: caller-fixed acceptance/writeScope are pinned by the script, not
+// by trusting the Plan agent to have echoed them verbatim.
+const acceptance = input.acceptance !== undefined ? input.acceptance : plan.acceptance;
+const writeScope = input.writeScope !== undefined ? input.writeScope : plan.writeScope;
+
+phase('Implement');
+
+const impl = await agent(
+  'You are the Implement stage of a one-pass Plan -> Implement -> fresh Validate loop. ' +
+    'A separate fresh context will judge your work against the acceptance below using only derived facts — ' +
+    'it will never see your narrative, so evidence lives in receipts, not prose.\n\n' +
+    'Caller intent:\n' + input.intent + '\n\n' +
+    'Acceptance — the contract the fresh validator will judge against:\n' + acceptance + '\n\n' +
+    'Write scope — you may create or edit ONLY paths matching:\n' +
+    writeScope.map((s) => '  - ' + s).join('\n') + '\n\n' +
+    'Process rules (non-negotiable):\n' +
+    '- ' + where + '\n' +
+    '- One bounded RED -> GREEN experiment: before editing, reproduce the failing behavior (test, command, ' +
+    'or observation); after editing, rerun the same repro and the repository\'s real checks (its own test/build/lint ' +
+    'commands, not ad-hoc substitutes). Record each as a checkReceipts entry {name, command, outcome} with the ' +
+    'exact command and its observed outcome.\n' +
+    '- Stay strictly inside the write scope. If the work seems to require touching any path outside it, do NOT ' +
+    'edit it — finish what you can inside scope and record the unmet need as a checkReceipts entry whose outcome ' +
+    'names the out-of-scope path.\n' +
+    '- Generate your own author context id: read random bytes via bash (e.g. from /dev/urandom, hex-encoded) and ' +
+    'return it as contextId. The validator asserts its own id is distinct from yours.\n' +
+    '- List every path you changed under changedPaths.\n' +
+    '- filesSummary is a short human-facing note for the caller only; the validator never receives it.\n' +
+    '- No lifecycle: do not commit, push, tag, or close anything. Leave changes in the working tree.',
+  { label: 'implement', phase: 'Implement', schema: IMPLEMENT_SCHEMA }
+);
+
+if (!impl) {
+  return {
+    verdict: 'NOT_PROVEN',
+    verdictPath: null,
+    intentDigest: plan.intentDigest,
+    changedPaths: [],
+    criteria: [],
+    error: 'Implement stage failed; no candidate exists to judge',
+  };
+}
+
+phase('Validate');
+
+// FRESHNESS WALL: this prompt is built ONLY from Plan outputs plus the
+// implement stage's derived facts (changedPaths, checkReceipts, contextId).
+// The author's narrative (filesSummary or anything else) must never cross —
+// the context that authors a candidate cannot issue its binding PASS.
+const validation = await agent(
+  'You are a fresh, independent Validate context. You did not author the candidate and you have not seen ' +
+    'the author\'s reasoning — only the facts below. Judge the exact content; the author\'s claims do not exist ' +
+    'for you.\n\n' +
+    'Intent identity:\n' +
+    '- intentDigest: ' + plan.intentDigest + '\n' +
+    '- intent snapshot path: ' + plan.intentPath + '\n\n' +
+    'Acceptance criteria to judge:\n' + acceptance + '\n\n' +
+    'Declared write scope:\n' + writeScope.map((s) => '  - ' + s).join('\n') + '\n\n' +
+    'Author context id: ' + impl.contextId + '\n\n' +
+    'Changed paths (derived, judge these exact files):\n' +
+    (impl.changedPaths.length ? impl.changedPaths.map((p) => '  - ' + p).join('\n') : '  (none reported)') + '\n\n' +
+    'Check receipts (factual command outcomes, re-derivable — rerun them yourself):\n' +
+    JSON.stringify(impl.checkReceipts, null, 2) + '\n\n' +
+    'Procedure:\n' +
+    '- ' + where + '\n' +
+    '- ' + toolingBlock + '\n' +
+    '- Verify intent identity: read the snapshot at the path above and confirm its bytes hash to intentDigest ' +
+    '(the tooling\'s digest subcommand). A mismatch or missing snapshot is NOT_PROVEN.\n' +
+    '- Compute the subject manifest over the changed paths with the tooling\'s manifest subcommand, so the ' +
+    'verdict binds to exact content.\n' +
+    '- Judge EVERY acceptance criterion with your own fresh evidence: open the files, rerun the receipts\' ' +
+    'commands and the repository\'s real checks. Record each as a criteria entry {criterion, result, evidence}.\n' +
+    '- Coverage: every changed path must fall inside the declared write scope and be accounted for by the ' +
+    'acceptance. A PROVEN out-of-scope change is FAIL. Empty checked scope, missing identity, or coverage you ' +
+    'could not establish is NOT_PROVEN.\n' +
+    '- Generate your own validator context id (random bytes via bash, hex-encoded) and assert it is distinct ' +
+    'from the author context id above; if you cannot assert distinctness, the verdict is NOT_PROVEN.\n' +
+    '- PASS only when: the intent digest verifies, checked scope is nonempty, changed-path coverage is complete ' +
+    'inside write scope, and every criterion has evidence.\n' +
+    '- Persist the verdict as verdict.v2 via the tooling\'s store-verdict subcommand — read its --help for the ' +
+    'exact flags and input shape rather than guessing. Record BOTH context ids and an explicit freshness ' +
+    'attestation (you judged from a fresh context, not the authoring one). Return the persisted path as ' +
+    'verdictPath.\n' +
+    '- Read-only over the subject: fix nothing, commit nothing. The verdict file is the only thing you persist.\n' +
+    '- If the tooling is absent or persistence fails, the verdict is NOT_PROVEN with the real error in the ' +
+    'evidence of a criteria entry.',
+  { label: 'validate', phase: 'Validate', schema: VALIDATE_SCHEMA, effort: 'high' }
+);
+
+if (!validation) {
+  return {
+    verdict: 'NOT_PROVEN',
+    verdictPath: null,
+    intentDigest: plan.intentDigest,
+    changedPaths: impl.changedPaths,
+    filesSummary: impl.filesSummary,
+    criteria: [],
+    error: 'Validate stage failed; the candidate exists but was never freshly judged',
+  };
+}
+
+// Report and stop: script-assembled, no fourth agent, no next action.
+// filesSummary reaches only this caller-facing report — never the validator.
+return {
+  verdict: validation.verdict,
+  verdictPath: validation.verdictPath,
+  intentDigest: plan.intentDigest,
+  changedPaths: impl.changedPaths,
+  filesSummary: impl.filesSummary,
+  criteria: validation.criteria,
+};


### PR DESCRIPTION
Wave 6, closing the arc: the flagship workflow the skill/workflow doctrine pointed at.

**What it is:** `workflows/rpi.js` runs Plan → Implement → Validate as *separate spawned contexts*. The validator receives only the intent snapshot digest+path, acceptance, changed paths, and check receipts — never the implementer's narrative (the script is the wall; the implement schema's one narrative field is deliberately never threaded into the validate prompt). Caller-fixed acceptance/writeScope are script-pinned so the Plan agent's echo can't drift them. One pass; any dead stage degrades to NOT_PROVEN; no retry, no lifecycle. All identity and persistence drive the validate skill's own deterministic tooling (`snapshot-intent`, `manifest`, `store-verdict` with `--author-context-id`/`--validator-context-id`/freshness attestation).

**Why it matters:** the product's central attestation — *the context that authors a candidate cannot issue its binding PASS* — has until now been a trust fact recorded in `verdict.v2`. For Claude users invoking `/rpi` through this workflow, it is now a runtime guarantee: author≠validator is structural, because they are different processes with controlled inputs.

**Smoke-proven end-to-end** on a toy repo: PASS `verdict.v2` persisted under `.agents/ao/verdicts/sha256/` with distinct author (`8d386df3…`) and validator (`7a477683…`) context ids in the persisted bytes, byte-exact criterion evidence (cmp + hex dump + manifest digests), correct handling of pre-existing untracked scaffolding in the edge criterion, and `ao status` reading the closed loop (1 intent, 1 verdict, `verdict_is_latest_evidence`).

**Process:** authored + adversarially contract-reviewed with fix authority — 3 defects fixed pre-merge (the recurring null-args trap, a subtle plan-echo drift channel through the freshness wall, a dead schema field). Gate sweep 66/67 with only the known `workflow.install-drift` local-environment finding (post-merge estate reinstall documented on #945).