### PR TITLE
feat(gc): pin the 3.3 bootstrap toolchain

### DIFF
--- a/deploy/gc/README.md
+++ b/deploy/gc/README.md
@@ -14,8 +14,8 @@ configuration and bootstrap require an explicit caller-supplied target.
 ## Exact toolchain
 
 AgentOps does not trust a version string or the ambient `PATH` to select Gas
-City. `toolchain.lock.json` lists the exact GC and official Beads source commits
-that this deployment accepts. Materialize the default, fully qualified pair
+City. `toolchain.lock.json` pins the official Gas City v1.3.5 and Beads v1.1.0
+source commits and their official release-checksum asset digests. Materialize the default pair
 from those commits into a new directory:
 
 ```sh
@@ -29,12 +29,10 @@ binary digests. It never edits an installed Homebrew or user binary. Use
 `--describe` to inspect the default pair or `--pair ID --describe` to inspect
 another accepted entry without building it.
 
-The first lock entry with `status=qualified` is the default. It is the exact
-AgentOps fork commit that passed the mixed Codex/Claude parallel factory
-canary. A `compatible` entry satisfies the SDK and command contracts but has
-not passed that same AgentOps qualification matrix. Bootstrap accepts either
-only because both are explicit lock entries; an unlisted build is rejected even
-when it reports the same version.
+The first lock entry with `status=qualified` is the default. The PR #3985
+exception is deliberately absent: it may be admitted only after an exact,
+current reproducer proves stable v1.3.5 fails and the exact PR head passes.
+An unlisted build is rejected even when it reports the same version.
 
 ## Bootstrap
 
@@ -48,6 +46,7 @@ deploy/gc/bootstrap.sh \
   --rig /path/to/disposable/agentops-rig \
   --pack /path/to/agentops-factory-pack \
   --gc-bin /path/to/agentops-gc-toolchain/bin/gc \
+  --ao-bin /path/to/agentops-gc-toolchain/bin/ao \
   --codex-auth /path/to/codex/auth.json
 ```
 
@@ -82,12 +81,16 @@ The private `CODEX_HOME` contains a symlink to the explicitly selected existing
 `auth.json`; credentials are not copied. When `--codex-auth` is omitted, the
 bootstrap uses the `auth.json` under the caller's original `CODEX_HOME` (or
 `$HOME/.codex`). It fails before starting unless `codex login status` succeeds
-through the private home. `--gc-bin` must have its paired `bd` beside it. Both
-runtime identities must match one exact entry in `toolchain.lock.json` before
-the city is created. The marker records the selected qualification id, full
-source commits, runtime identities, paths, and binary digests; workspace
-sessions inherit the same pair and cannot drift to another `gc` or `bd` on
-`PATH`. Moving an existing managed city to a different pair or binary path
+through the private home. `--gc-bin` and `--ao-bin` are explicit paths;
+bootstrap never resolves `gc`, `bd`, or `ao` from ambient `PATH` after
+admission. `--gc-bin` must have its paired `bd` beside it. Both runtime
+identities must match one exact entry in `toolchain.lock.json` before the city
+is created. The marker records selected source commits, release checksum
+provenance, runtime paths/digests, the built ao source commit/exact committed
+`cli` tree and reported build version, exact pack
+content, `AO_BIN`, reducer and schema/config digests, and the Gas City-generated `packs.lock`
+digest; workspace sessions inherit the same pair and cannot drift to another
+`gc`, `bd`, or `ao` on `PATH`. Moving an existing managed city to a different pair or binary path
 requires `--replace-gc-bin --start`; every other recorded city identity field
 must still match, and bootstrap replaces the supervisor then verifies the new
 pair before rewriting the marker. Bootstrap prepends the pair's directory to
@@ -194,7 +197,7 @@ supplied, must match the exact paired toolchain recorded by bootstrap.
 | `<city>/.gc-home` | Gas City runtime | Remaining private supervisor/store discovery state |
 | `<city>/.gc/codex-home` | Codex runtime | Private session state plus a symlink to the selected external `auth.json` |
 | Caller home | Claude runtime | Existing authenticated interactive Claude state; no auth material is copied into the city |
-| `<city>/.gc/agentops-bootstrap.json` | Bootstrap | Exact city/rig/pack/auth/paired-toolchain identity, qualification, binary digests, and recovery state |
+| `<city>/.gc/agentops-bootstrap.json` | Bootstrap | Exact city/rig/pack/auth/paired-toolchain and reducer identity, `packs.lock` digest, qualification, binary digests, and recovery state |
 
 Do not source-control `.gc/site.toml`, `.gc-home`, or the generated city. To
 promote a stable release, point `--pack` at a clean committed pack and let the

--- a/deploy/gc/bootstrap.sh
+++ b/deploy/gc/bootstrap.sh
@@ -15,7 +15,8 @@ Required:
 Options:
   --rig-name NAME   Logical rig name (default: agentops)
   --binding NAME    Pack import binding at city and rig scopes (default: agentops)
-  --gc-bin PATH     Gas City CLI (default: gc from PATH)
+  --gc-bin PATH     Absolute Gas City CLI path (required; never resolved from PATH)
+  --ao-bin PATH     Absolute built AgentOps reducer path (required; never resolved from PATH)
   --replace-gc-bin  Permit a managed city to move to the supplied --gc-bin path
   --codex-auth PATH Existing Codex auth.json to link into the private home
   --max-active-sessions N  City-wide concurrent session cap (default: 1)
@@ -35,7 +36,8 @@ rig=""
 pack=""
 rig_name="agentops"
 binding="agentops"
-gc_bin="gc"
+gc_bin=""
+ao_bin=""
 replace_gc_bin=0
 codex_auth=""
 source_codex_home="${CODEX_HOME:-${HOME:?HOME is required}/.codex}"
@@ -75,6 +77,11 @@ while [ "$#" -gt 0 ]; do
       gc_bin="$2"
       shift 2
       ;;
+    --ao-bin)
+      [ "$#" -ge 2 ] || die "--ao-bin requires a path"
+      ao_bin="$2"
+      shift 2
+      ;;
     --replace-gc-bin)
       replace_gc_bin=1
       shift
@@ -111,6 +118,8 @@ done
 [ -n "$city" ] || die "--city is required"
 [ -n "$rig" ] || die "--rig is required"
 [ -n "$pack" ] || die "--pack is required"
+[ -n "$gc_bin" ] || die "--gc-bin is required"
+[ -n "$ao_bin" ] || die "--ao-bin is required"
 [[ "$rig_name" =~ ^[A-Za-z0-9_-]+$ ]] || die "--rig-name must contain only letters, digits, underscore, or hyphen"
 [[ "$binding" =~ ^[A-Za-z0-9_-]+$ ]] || die "--binding must contain only letters, digits, underscore, or hyphen"
 [[ "$max_active_sessions" =~ ^[1-9][0-9]*$ ]] || die "--max-active-sessions must be a positive integer"
@@ -228,13 +237,12 @@ if [ "$city_has_content" -eq 1 ] && [ ! -f "$marker" ]; then
   die "refusing existing unmanaged city: $city"
 fi
 
-if [[ "$gc_bin" == */* ]]; then
-  [ -x "$gc_bin" ] || die "Gas City CLI is not executable: $gc_bin"
-  gc_bin="$(canonical_path "$gc_bin")"
-else
-  gc_bin="$(command -v "$gc_bin" || true)"
-  [ -n "$gc_bin" ] || die "Gas City CLI not found on PATH"
-fi
+[[ "$gc_bin" == */* ]] || die "--gc-bin must be an absolute or explicit path; PATH resolution is forbidden"
+[[ "$ao_bin" == */* ]] || die "--ao-bin must be an absolute or explicit path; PATH resolution is forbidden"
+[ -x "$gc_bin" ] || die "Gas City CLI is not executable: $gc_bin"
+[ -x "$ao_bin" ] || die "AgentOps reducer is not executable: $ao_bin"
+gc_bin="$(canonical_path "$gc_bin")"
+ao_bin="$(canonical_path "$ao_bin")"
 
 # Development builds commonly place the matched gc and bd binaries together
 # outside the ambient PATH. Keep Gas City's Beads subprocesses on that pinned
@@ -246,6 +254,8 @@ bd_bin="$gc_bin_dir/bd"
 bd_bin="$(canonical_path "$bd_bin")"
 [ "$(dirname "$bd_bin")" = "$gc_bin_dir" ] || \
   die "paired Beads CLI must resolve beside gc: $bd_bin"
+
+ao_reducer_json=""
 
 toolchain_json=""
 if ! toolchain_json="$(python3 - "$gc_bin" "$bd_bin" <<'PY'
@@ -386,20 +396,130 @@ PY
 fi
 toolchain_json="$qualified_toolchain_json"
 
+# AO is admitted only from the same materialized toolchain receipt as gc/bd.
+# The receipt, not this checkout's current HEAD, is the authority for the
+# reducer source commit and committed CLI tree.
+toolchain_receipt="$(dirname "$gc_bin_dir")/toolchain.json"
+if ! ao_reducer_json="$(python3 - "$toolchain_receipt" "$toolchain_lock" "$toolchain_json" "$ao_bin" "$gc_bin" "$bd_bin" "$pack" "$city_template" "$script_dir/../.." <<'PY'
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+
+receipt_path, lock_path, runtime_json, ao_bin, gc_bin, bd_bin, pack, city_template, repository = sys.argv[1:]
+receipt_path, lock_path, ao_bin, gc_bin, bd_bin, pack, city_template, repository = map(
+    os.path.realpath,
+    (receipt_path, lock_path, ao_bin, gc_bin, bd_bin, pack, city_template, repository),
+)
+if not os.path.isfile(receipt_path) or os.path.islink(receipt_path):
+    raise SystemExit("admitted gc/bd pair has no regular toolchain.json receipt beside bin")
+
+def digest(path):
+    value = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            value.update(chunk)
+    return value.hexdigest()
+
+def portable_path(value, label):
+    if not isinstance(value, str) or not value or os.path.isabs(value):
+        raise SystemExit(f"toolchain receipt has invalid {label}.path")
+    normalized = os.path.normpath(value)
+    if normalized.startswith(".." + os.sep) or normalized == "..":
+        raise SystemExit(f"toolchain receipt has escaping {label}.path")
+    return normalized
+
+def exact_digest(value, label):
+    if not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{64}", value) is None:
+        raise SystemExit(f"toolchain receipt has invalid {label} sha256")
+    return value
+
+try:
+    receipt = json.load(open(receipt_path, encoding="utf-8"))
+    lock = json.load(open(lock_path, encoding="utf-8"))
+    runtime = json.loads(runtime_json)
+except (OSError, json.JSONDecodeError) as exc:
+    raise SystemExit(f"cannot read toolchain receipt: {exc}") from exc
+if receipt.get("schema_version") != 2:
+    raise SystemExit("toolchain receipt schema_version must be 2")
+qualification = runtime.get("qualification", {})
+pair_id = qualification.get("id")
+selected = next((entry for entry in lock.get("accepted_pairs", []) if entry.get("id") == pair_id), None)
+if not isinstance(selected, dict) or receipt.get("pair") != selected:
+    raise SystemExit("toolchain receipt pair does not match admitted gc/bd pair")
+entries = receipt.get("runtime")
+if not isinstance(entries, dict) or set(entries) != {"gc", "bd", "ao"}:
+    raise SystemExit("toolchain receipt runtime must contain exactly gc, bd, and ao")
+root = os.path.dirname(receipt_path)
+for label, actual in (("gc", gc_bin), ("bd", bd_bin), ("ao", ao_bin)):
+    item = entries.get(label)
+    if not isinstance(item, dict):
+        raise SystemExit(f"toolchain receipt has no {label} runtime")
+    path = portable_path(item.get("path"), label)
+    if os.path.realpath(os.path.join(root, path)) != actual:
+        raise SystemExit(f"toolchain receipt {label} path does not match admitted binary")
+    if exact_digest(item.get("sha256"), label) != digest(actual):
+        raise SystemExit(f"toolchain receipt {label} digest does not match admitted binary")
+for label in ("gc", "bd"):
+    item = entries[label]
+    observed = runtime[label]
+    if item.get("version") != observed.get("version") or item.get("commit") != observed.get("commit"):
+        raise SystemExit(f"toolchain receipt {label} runtime identity does not match admitted binary")
+ao = entries["ao"]
+source_commit = ao.get("source_commit")
+cli_tree = ao.get("cli_tree")
+build_version = ao.get("build_version")
+if not isinstance(source_commit, str) or re.fullmatch(r"[0-9a-f]{40}", source_commit) is None:
+    raise SystemExit("toolchain receipt has invalid ao source_commit")
+if not isinstance(cli_tree, str) or re.fullmatch(r"[0-9a-f]{40}", cli_tree) is None:
+    raise SystemExit("toolchain receipt has invalid ao cli_tree")
+if not isinstance(build_version, str) or not build_version:
+    raise SystemExit("toolchain receipt has invalid ao build_version")
+result = subprocess.run(["git", "-C", repository, "rev-parse", "--verify", source_commit + ":cli"], capture_output=True, text=True)
+if result.returncode or result.stdout.strip() != cli_tree:
+    raise SystemExit("toolchain receipt ao cli_tree does not resolve from its source_commit")
+inputs = [city_template, lock_path]
+pack_inputs = []
+for current_root, _dirs, files in os.walk(pack):
+    for name in files:
+        path = os.path.join(current_root, name)
+        if not os.path.isfile(path) or os.path.islink(path):
+            raise SystemExit(f"ao reducer pack input is not a regular file: {path}")
+        pack_inputs.append(path)
+        if name.endswith((".toml", ".json", ".py")):
+            inputs.append(path)
+config_entries = [(path, digest(path)) for path in sorted(set(inputs))]
+pack_entries = [(os.path.relpath(path, pack).replace(os.sep, "/"), digest(path)) for path in sorted(pack_inputs)]
+print(json.dumps({
+    "path": ao_bin,
+    "binary_sha256": digest(ao_bin),
+    "source_commit": source_commit,
+    "cli_tree": cli_tree,
+    "build_version": build_version,
+    "pack_content_sha256": hashlib.sha256(json.dumps(pack_entries, separators=(",", ":"), ensure_ascii=True).encode()).hexdigest(),
+    "schema_config_sha256": hashlib.sha256(json.dumps(config_entries, separators=(",", ":"), ensure_ascii=True).encode()).hexdigest(),
+}, sort_keys=True))
+PY
+)"; then
+  die "invalid admitted ao reducer identity: $ao_reducer_json"
+fi
+
 previous_gc_bin=""
 toolchain_replacement=0
 if [ -f "$marker" ]; then
   marker_identity=""
-  if ! marker_identity="$(python3 - "$marker" "$city" "$rig" "$pack" "$rig_name" "$binding" "$codex_auth" "$max_active_sessions" "$replace_gc_bin" "$toolchain_json" <<'PY'
+  if ! marker_identity="$(python3 - "$marker" "$city" "$rig" "$pack" "$rig_name" "$binding" "$codex_auth" "$max_active_sessions" "$replace_gc_bin" "$toolchain_json" "$ao_reducer_json" <<'PY'
 import json
 import os
 import sys
 
-marker_path, city, rig, pack, rig_name, binding, codex_auth, max_active_sessions, replace_gc_bin, toolchain_json = sys.argv[1:]
+marker_path, city, rig, pack, rig_name, binding, codex_auth, max_active_sessions, replace_gc_bin, toolchain_json, ao_reducer_json = sys.argv[1:]
 with open(marker_path, encoding="utf-8") as handle:
     marker = json.load(handle)
 schema_version = marker.get("schema_version")
-if schema_version not in {2, 3}:
+if schema_version not in {2, 3, 4}:
     raise SystemExit(f"managed city marker has unsupported schema_version {schema_version!r}")
 expected = {
     "city": city,
@@ -430,6 +550,18 @@ else:
     replacement = marker.get("toolchain") != requested_toolchain
     if replace_gc_bin != "1" and replacement:
         raise SystemExit("managed city mismatch for paired gc/bd toolchain identity")
+if schema_version != 4 or marker.get("ao_reducer") != json.loads(ao_reducer_json):
+    raise SystemExit("managed city mismatch for ao reducer identity")
+packs_lock = os.path.join(city, "packs.lock")
+recorded_lock = marker.get("packs_lock_sha256")
+if not isinstance(recorded_lock, str) or len(recorded_lock) != 64:
+    raise SystemExit("managed city marker has no packs.lock digest")
+if not os.path.isfile(packs_lock) or os.path.islink(packs_lock):
+    raise SystemExit("managed city packs.lock is missing or unsafe")
+import hashlib
+actual_lock = hashlib.sha256(open(packs_lock, "rb").read()).hexdigest()
+if actual_lock != recorded_lock:
+    raise SystemExit("managed city mismatch for packs.lock identity")
 if not isinstance(actual_gc, str) or not actual_gc.strip():
     raise SystemExit("managed city marker has no prior gc binary path")
 print(f"{os.path.realpath(os.path.expanduser(actual_gc))}\t{int(replacement)}")
@@ -451,6 +583,7 @@ export GC_HOME="$city/.gc-home"
 export GC_ISOLATED=1
 export CODEX_HOME="$city/.gc/codex-home"
 export GC_BIN="$gc_bin"
+export AO_BIN="$ao_bin"
 # A managed test/production city must not inherit desktop-wide OTLP endpoints.
 # Role sessions also receive this through city.toml, but bootstrap and the
 # supervisor perform foreground Beads/Dolt work before any role is launched.
@@ -466,15 +599,19 @@ export BEADS_DOLT_SYNC_CLI_REMOTES=false
 write_marker() {
   local state="$1"
   mkdir -p "$city/.gc"
-  python3 - "$marker" "$city" "$rig" "$pack" "$rig_name" "$binding" "$codex_auth" "$max_active_sessions" "$state" "$toolchain_json" <<'PY'
+  python3 - "$marker" "$city" "$rig" "$pack" "$rig_name" "$binding" "$codex_auth" "$max_active_sessions" "$state" "$toolchain_json" "$ao_reducer_json" "$city/packs.lock" <<'PY'
 import json
 import os
 import sys
 import tempfile
 
-path, city, rig, pack, rig_name, binding, codex_auth, max_active_sessions, state, toolchain_json = sys.argv[1:]
+path, city, rig, pack, rig_name, binding, codex_auth, max_active_sessions, state, toolchain_json, ao_reducer_json, packs_lock = sys.argv[1:]
+if not os.path.isfile(packs_lock) or os.path.islink(packs_lock):
+    raise SystemExit("managed city must have a regular packs.lock generated by Gas City")
+with open(packs_lock, "rb") as handle:
+    packs_lock_sha256 = __import__("hashlib").sha256(handle.read()).hexdigest()
 payload = {
-    "schema_version": 3,
+    "schema_version": 4,
     "state": state,
     "city": city,
     "rig": rig,
@@ -484,6 +621,8 @@ payload = {
     "codex_auth": codex_auth,
     "max_active_sessions": int(max_active_sessions),
     "toolchain": json.loads(toolchain_json),
+    "ao_reducer": json.loads(ao_reducer_json),
+    "packs_lock_sha256": packs_lock_sha256,
 }
 fd, tmp = tempfile.mkstemp(prefix=".agentops-bootstrap.", dir=os.path.dirname(path))
 with os.fdopen(fd, "w", encoding="utf-8") as handle:
@@ -785,7 +924,7 @@ finally:
         os.unlink(temporary)
 PY
 
-python3 - "$city/city.toml" "$city_template" "$CODEX_HOME" "$gc_bin" "$city" "$rig" "$max_active_sessions" "$claude_wrapper" <<'PY'
+python3 - "$city/city.toml" "$city_template" "$CODEX_HOME" "$gc_bin" "$ao_bin" "$city" "$rig" "$max_active_sessions" "$claude_wrapper" <<'PY'
 import json
 import hashlib
 import os
@@ -794,7 +933,7 @@ import sys
 import tempfile
 import tomllib
 
-path, template_path, codex_home, gc_bin, city, requested_rig, max_active_sessions, claude_wrapper = sys.argv[1:]
+path, template_path, codex_home, gc_bin, ao_bin, city, requested_rig, max_active_sessions, claude_wrapper = sys.argv[1:]
 with open(path, encoding="utf-8") as handle:
     text = handle.read()
 with open(template_path, encoding="utf-8") as handle:
@@ -809,6 +948,7 @@ policy = re.sub(
 replacements = {
     "__GC_AGENTOPS_CODEX_HOME__": codex_home,
     "__GC_AGENTOPS_GC_BIN__": gc_bin,
+    "__GC_AGENTOPS_AO_BIN__": ao_bin,
     "__GC_AGENTOPS_CLAUDE_WRAPPER__": claude_wrapper,
     "__GC_AGENTOPS_TMUX_SOCKET__": (
         "agentops-" + hashlib.sha256(os.path.realpath(city).encode()).hexdigest()[:20]

--- a/deploy/gc/city.toml
+++ b/deploy/gc/city.toml
@@ -5,7 +5,7 @@
 max_active_sessions = 1
 # Managed local sessions must not inherit a stale machine-wide OTLP endpoint.
 # A dead collector otherwise delays nearly every GC/bd command.
-env = { GC_BIN = "__GC_AGENTOPS_GC_BIN__", OTEL_SDK_DISABLED = "true" }
+env = { GC_BIN = "__GC_AGENTOPS_GC_BIN__", AO_BIN = "__GC_AGENTOPS_AO_BIN__", OTEL_SDK_DISABLED = "true" }
 
 [session]
 # The bootstrap replaces this with a stable digest of the canonical city path.

--- a/deploy/gc/materialize-toolchain.sh
+++ b/deploy/gc/materialize-toolchain.sh
@@ -10,10 +10,10 @@ usage() {
   cat <<'EOF'
 Usage: materialize-toolchain.sh --output DIR [options]
 
-Build one exact gc/bd pair from deploy/gc/toolchain.lock.json.
+Build one exact gc/bd/ao toolchain from deploy/gc/toolchain.lock.json.
 
 Options:
-  --output DIR  New or empty directory that will receive bin/gc, bin/bd,
+  --output DIR  New or empty directory that will receive bin/gc, bin/bd, bin/ao,
                 and toolchain.json
   --pair ID     Accepted pair id (default: first pair with status=qualified)
   --lock PATH   Alternate lock for isolated testing (default: adjacent lock)
@@ -23,6 +23,7 @@ EOF
 }
 
 script_dir="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+agentops_root="$(CDPATH='' cd -- "$script_dir/../.." && pwd)"
 lock="$script_dir/toolchain.lock.json"
 output=""
 pair_id=""
@@ -65,6 +66,7 @@ command -v python3 >/dev/null 2>&1 || die "python3 is required"
 selection=""
 if ! selection="$(python3 - "$lock" "$pair_id" <<'PY'
 import json
+import re
 import sys
 
 path, requested = sys.argv[1:]
@@ -88,10 +90,12 @@ for component in ("gc", "bd"):
     value = selected.get(component)
     if not isinstance(value, dict):
         raise SystemExit(f"selected pair has no {component} object")
-    for field in ("repository", "ref", "version", "source_commit", "runtime_commit"):
+    for field in ("repository", "ref", "version", "source_commit", "runtime_commit", "release_checksum_asset", "release_checksum_sha256"):
         item = value.get(field)
         if not isinstance(item, str) or not item or "\n" in item:
             raise SystemExit(f"selected pair has invalid {component}.{field}")
+    if not re.fullmatch(r"[0-9a-f]{64}", value["release_checksum_sha256"]):
+        raise SystemExit(f"selected pair has invalid {component}.release_checksum_sha256")
 print(json.dumps(selected, sort_keys=True, separators=(",", ":")))
 PY
 )"; then
@@ -107,6 +111,20 @@ fi
 for command_name in git go make install; do
   command -v "$command_name" >/dev/null 2>&1 || die "$command_name is required"
 done
+
+# The AO receipt may claim only the exact committed CLI tree that was built.
+# A changed or untracked CLI source would make that claim unverifiable, while
+# writing the build into cli/bin would mutate the source checkout.
+git -C "$agentops_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || \
+  die "AgentOps checkout is not a Git worktree: $agentops_root"
+git -C "$agentops_root" diff --quiet HEAD -- cli || \
+  die "committed CLI subtree does not match working CLI subtree"
+if [ -n "$(git -C "$agentops_root" ls-files --others --exclude-standard -- cli)" ]; then
+  die "untracked CLI source could affect the ao build"
+fi
+ao_source_commit="$(git -C "$agentops_root" rev-parse HEAD)"
+ao_cli_tree="$(git -C "$agentops_root" rev-parse HEAD:cli)"
+ao_build_version="$(git -C "$agentops_root" describe --tags --always "$ao_source_commit")"
 
 output="$(python3 - "$output" <<'PY'
 import os
@@ -149,9 +167,11 @@ selected_id="${fields[0]}"
 selected_status="${fields[1]}"
 gc_repository="${fields[2]}"
 gc_ref="${fields[3]}"
+gc_version="${fields[4]}"
 gc_source_commit="${fields[5]}"
 bd_repository="${fields[7]}"
 bd_ref="${fields[8]}"
+bd_version="${fields[9]}"
 bd_source_commit="${fields[10]}"
 
 parent="$(dirname "$output")"
@@ -166,8 +186,9 @@ trap cleanup EXIT
 checkout_exact() {
   local repository="$1"
   local ref="$2"
-  local commit="$3"
-  local destination="$4"
+  local version="$3"
+  local commit="$4"
+  local destination="$5"
   git init -q "$destination"
   git -C "$destination" remote add origin "$repository"
   # Fetch the immutable lock identity directly. A qualified pair may pin a
@@ -175,28 +196,44 @@ checkout_exact() {
   # materializing the pair as soon as the branch advances.
   git -C "$destination" fetch -q --depth=1 origin "$commit" || \
     die "cannot fetch exact commit $commit locked from $ref"
+  # Official release builds derive their runtime version from an exact local
+  # tag. Fetch that immutable tag ref explicitly, then prove it dereferences
+  # to the separately locked commit before allowing Make to observe it.
+  if [ "$ref" = "v$version" ]; then
+    git -C "$destination" fetch -q --depth=1 origin \
+      "refs/tags/$ref:refs/tags/$ref" || \
+      die "cannot fetch locked release tag $ref"
+    [ "$(git -C "$destination" rev-parse "$ref^{}")" = "$commit" ] || \
+      die "locked release tag $ref does not dereference to $commit"
+    # A commit-first shallow fetch can leave the verified annotated tag outside
+    # `git describe`'s shallow history walk. Recreate the local tag only after
+    # dereference verification so the upstream Makefile sees the proven release
+    # identity without consulting a mutable remote ref.
+    git -C "$destination" tag -f "$ref" "$commit"
+  fi
   git -C "$destination" checkout -q --detach "$commit"
   [ "$(git -C "$destination" rev-parse HEAD)" = "$commit" ] || \
     die "source checkout did not resolve exact commit $commit"
 }
 
-checkout_exact "$gc_repository" "$gc_ref" "$gc_source_commit" "$sources/gc"
-checkout_exact "$bd_repository" "$bd_ref" "$bd_source_commit" "$sources/bd"
+checkout_exact "$gc_repository" "$gc_ref" "$gc_version" "$gc_source_commit" "$sources/gc"
+checkout_exact "$bd_repository" "$bd_ref" "$bd_version" "$bd_source_commit" "$sources/bd"
 
 make -s -C "$sources/gc" build
 make -s -C "$sources/bd" build
 mkdir -p "$stage/bin"
 install -m 0755 "$sources/gc/bin/gc" "$stage/bin/gc"
 install -m 0755 "$sources/bd/bd" "$stage/bin/bd"
+go -C "$agentops_root/cli" build -ldflags "-X main.version=$ao_build_version" -o "$stage/bin/ao" ./cmd/ao
 
-python3 - "$stage/bin/gc" "$stage/bin/bd" "$selection" "$stage/toolchain.json" <<'PY'
+python3 - "$stage/bin/gc" "$stage/bin/bd" "$stage/bin/ao" "$selection" "$stage/toolchain.json" "$ao_source_commit" "$ao_cli_tree" <<'PY'
 import hashlib
 import json
 import re
 import subprocess
 import sys
 
-gc_path, bd_path, selection_json, receipt_path = sys.argv[1:]
+gc_path, bd_path, ao_path, selection_json, receipt_path, ao_source_commit, ao_cli_tree = sys.argv[1:]
 selected = json.loads(selection_json)
 
 
@@ -222,6 +259,11 @@ expected_bd = selected["bd"]
 if match.group(1) != expected_bd["version"] or not expected_bd["source_commit"].startswith(match.group(2)):
     raise SystemExit(f"built bd identity mismatch: {bd_output.strip()}")
 
+ao = json.loads(run([ao_path, "-o", "json", "version"]))
+ao_version = ao.get("version")
+if not isinstance(ao_version, str) or not ao_version:
+    raise SystemExit(f"cannot parse built ao version: {ao}")
+
 
 def digest(path):
     value = hashlib.sha256()
@@ -232,11 +274,12 @@ def digest(path):
 
 
 receipt = {
-    "schema_version": 1,
+    "schema_version": 2,
     "pair": selected,
     "runtime": {
-        "gc": {"version": gc["version"], "commit": gc["commit"], "sha256": digest(gc_path)},
-        "bd": {"version": match.group(1), "commit": match.group(2), "sha256": digest(bd_path)},
+        "gc": {"path": "bin/gc", "version": gc["version"], "commit": gc["commit"], "sha256": digest(gc_path)},
+        "bd": {"path": "bin/bd", "version": match.group(1), "commit": match.group(2), "sha256": digest(bd_path)},
+        "ao": {"path": "bin/ao", "sha256": digest(ao_path), "source_commit": ao_source_commit, "cli_tree": ao_cli_tree, "build_version": ao_version},
     },
 }
 with open(receipt_path, "w", encoding="utf-8") as handle:

--- a/deploy/gc/teardown.sh
+++ b/deploy/gc/teardown.sh
@@ -86,8 +86,10 @@ marker_path, expected_city = sys.argv[1:]
 with open(marker_path, encoding="utf-8") as handle:
     marker = json.load(handle)
 schema_version = marker.get("schema_version")
-if schema_version not in {2, 3}:
-    raise SystemExit("managed-city marker schema_version must be 2 or 3")
+if schema_version not in {2, 3, 4}:
+    raise SystemExit("managed-city marker schema_version must be 2, 3, or 4")
+ao_bin = ""
+ao_sha256 = ""
 actual_city = os.path.realpath(os.path.expanduser(str(marker.get("city", ""))))
 if actual_city != expected_city:
     raise SystemExit(f"managed-city marker city mismatch: {actual_city!r} != {expected_city!r}")
@@ -108,6 +110,9 @@ else:
     gc_sha256 = gc.get("sha256")
     bd_bin = bd.get("path")
     bd_sha256 = bd.get("sha256")
+    ao = marker.get("ao_reducer", {}) if schema_version == 4 else {}
+    ao_bin = ao.get("path", "")
+    ao_sha256 = ao.get("binary_sha256", "")
 if not isinstance(gc_bin, str) or not gc_bin.strip():
     raise SystemExit("managed-city marker has no gc path")
 for label, value in (("gc", gc_sha256), ("bd", bd_sha256)):
@@ -119,24 +124,29 @@ for label, value in (("gc", gc_sha256), ("bd", bd_sha256)):
         raise SystemExit(f"managed-city marker has invalid {label} sha256")
 if schema_version == 3 and (not isinstance(bd_bin, str) or not bd_bin.strip()):
     raise SystemExit("managed-city marker has no bd path")
+if schema_version == 4:
+    if not isinstance(ao_bin, str) or not ao_bin.strip():
+        raise SystemExit("managed-city marker has no ao reducer path")
+    if not isinstance(ao_sha256, str) or len(ao_sha256) != 64 or any(char not in "0123456789abcdef" for char in ao_sha256):
+        raise SystemExit("managed-city marker has invalid ao reducer sha256")
 print("\t".join((
     os.path.realpath(os.path.expanduser(gc_bin)),
     gc_sha256,
     os.path.realpath(os.path.expanduser(bd_bin)) if bd_bin else "",
     bd_sha256,
+    os.path.realpath(os.path.expanduser(ao_bin)) if ao_bin else "",
+    ao_sha256,
 )))
 PY
 )" || die "invalid managed-city marker: $marker"
-IFS=$'\t' read -r marker_gc_bin marker_gc_sha256 marker_bd_bin marker_bd_sha256 <<<"$marker_toolchain"
+IFS=$'\t' read -r marker_gc_bin marker_gc_sha256 marker_bd_bin marker_bd_sha256 marker_ao_bin marker_ao_sha256 <<<"$marker_toolchain"
 
 if [ -z "$gc_bin" ]; then
   gc_bin="$marker_gc_bin"
 elif [[ "$gc_bin" == */* ]]; then
   gc_bin="$(canonical_path "$gc_bin")"
 else
-  gc_bin="$(command -v "$gc_bin" || true)"
-  [ -n "$gc_bin" ] || die "Gas City CLI not found on PATH"
-  gc_bin="$(canonical_path "$gc_bin")"
+  die "--gc-bin must be an absolute or explicit path; PATH resolution is forbidden"
 fi
 [ "$gc_bin" = "$marker_gc_bin" ] || die "--gc-bin does not match managed-city marker: $gc_bin != $marker_gc_bin"
 [ -x "$gc_bin" ] || die "Gas City CLI is not executable: $gc_bin"
@@ -169,6 +179,22 @@ PY
 )"
   [ "$actual_bd_sha256" = "$marker_bd_sha256" ] || \
     die "managed bd binary digest mismatch: $actual_bd_sha256 != $marker_bd_sha256"
+  if [ -n "$marker_ao_bin" ]; then
+    [ -x "$marker_ao_bin" ] || die "managed ao reducer is not executable: $marker_ao_bin"
+    actual_ao_sha256="$(python3 - "$marker_ao_bin" <<'PY'
+import hashlib
+import sys
+
+digest = hashlib.sha256()
+with open(sys.argv[1], "rb") as handle:
+    for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+        digest.update(chunk)
+print(digest.hexdigest())
+PY
+)"
+    [ "$actual_ao_sha256" = "$marker_ao_sha256" ] || \
+      die "managed ao reducer binary digest mismatch: $actual_ao_sha256 != $marker_ao_sha256"
+  fi
 fi
 
 # A teardown must resolve the same private supervisor and store namespace as

--- a/deploy/gc/toolchain.lock.json
+++ b/deploy/gc/toolchain.lock.json
@@ -2,57 +2,25 @@
   "schema_version": 1,
   "accepted_pairs": [
     {
-      "id": "agentops-gc-v16-20260719",
+      "id": "gascity-v1.3.5-beads-v1.1.0",
       "status": "qualified",
-      "gc": {
-        "repository": "https://github.com/boshu2/gascity.git",
-        "ref": "codex/deterministic-toolchain",
-        "version": "dev",
-        "source_commit": "8dc1f0dfc8164b751d0c63bed051a468a44a3d51",
-        "runtime_commit": "8dc1f0dfc"
-      },
-      "bd": {
-        "repository": "https://github.com/steveyegge/beads.git",
-        "ref": "v1.1.0",
-        "version": "1.1.0",
-        "source_commit": "8e4e59d39f3459a43cf21a3236a13eca4dd874f7",
-        "runtime_commit": "8e4e59d39"
-      }
-    },
-    {
-      "id": "agentops-gc-v15-20260719",
-      "status": "compatible",
-      "gc": {
-        "repository": "https://github.com/boshu2/gascity.git",
-        "ref": "codex/deterministic-toolchain",
-        "version": "dev",
-        "source_commit": "33aacacef08fa3ef35ed34d74d3fcb99f4d42f33",
-        "runtime_commit": "33aacacef"
-      },
-      "bd": {
-        "repository": "https://github.com/steveyegge/beads.git",
-        "ref": "v1.1.0",
-        "version": "1.1.0",
-        "source_commit": "8e4e59d39f3459a43cf21a3236a13eca4dd874f7",
-        "runtime_commit": "8e4e59d39"
-      }
-    },
-    {
-      "id": "gascity-v1.3.5-sdk-release",
-      "status": "compatible",
       "gc": {
         "repository": "https://github.com/gastownhall/gascity.git",
         "ref": "v1.3.5",
         "version": "1.3.5",
         "source_commit": "8ffc009ded781a2ada2077f3a29bd712b2def0bf",
-        "runtime_commit": "8ffc009d"
+        "runtime_commit": "8ffc009d",
+        "release_checksum_asset": "gascity_1.3.5_checksums.txt",
+        "release_checksum_sha256": "aefe5b1defa6ab383e27cd933c76e5118f3c920dab911ba19d807f1f89053d3f"
       },
       "bd": {
         "repository": "https://github.com/steveyegge/beads.git",
         "ref": "v1.1.0",
         "version": "1.1.0",
         "source_commit": "8e4e59d39f3459a43cf21a3236a13eca4dd874f7",
-        "runtime_commit": "8e4e59d39"
+        "runtime_commit": "8e4e59d39",
+        "release_checksum_asset": "checksums.txt",
+        "release_checksum_sha256": "b3684128bf6af985ee2148ca50dc22ff19e29b43227aefef48219fdbad8cbe52"
       }
     }
   ]

--- a/tests/scripts/gc-agentops-bootstrap.bats
+++ b/tests/scripts/gc-agentops-bootstrap.bats
@@ -75,6 +75,13 @@ printf '%s\n' 'bd version 1.1.0 (8e4e59d39: test-build)'
 EOF
   chmod +x "$BIN/bd"
 
+  cat >"$BIN/ao" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' 'ao fixture reducer'
+EOF
+  chmod +x "$BIN/ao"
+
   FAKE_GC="$BIN/gc"
   cat >"$FAKE_GC" <<'EOF'
 #!/usr/bin/env bash
@@ -145,6 +152,12 @@ case "$command_name" in
       'source = "builtin:core"' \
       'version = "sha:generated"' >"$target/pack.toml"
     cp "$template" "$target/city.toml"
+    printf '%s\n' \
+      'schema = 1' \
+      '' \
+      '[packs."builtin:fixture"]' \
+      'version = "sha:fixture"' \
+      'commit = "fixture"' >"$target/packs.lock"
     printf '%s\n' 'workspace_name = "generated-city"' >"$target/.gc/site.toml"
     ;;
   rig)
@@ -350,6 +363,31 @@ esac
 EOF
   chmod +x "$FAKE_GC"
 
+  python3 - "$TMP/toolchain.json" "$REPO_ROOT" "$FAKE_GC" "$BIN/bd" "$BIN/ao" <<'PY'
+import hashlib
+import json
+import os
+import subprocess
+import sys
+
+path, repository, gc, bd, ao = sys.argv[1:]
+pair = json.load(open(os.path.join(repository, "deploy/gc/toolchain.lock.json"), encoding="utf-8"))["accepted_pairs"][0]
+digest = lambda item: hashlib.sha256(open(item, "rb").read()).hexdigest()
+commit = subprocess.check_output(["git", "-C", repository, "rev-parse", "HEAD"], text=True).strip()
+cli_tree = subprocess.check_output(["git", "-C", repository, "rev-parse", "HEAD:cli"], text=True).strip()
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump({
+        "schema_version": 2,
+        "pair": pair,
+        "runtime": {
+            "gc": {"path": "bin/gc", "version": "1.3.5", "commit": "8ffc009d", "sha256": digest(gc)},
+            "bd": {"path": "bin/bd", "version": "1.1.0", "commit": "8e4e59d39", "sha256": digest(bd)},
+            "ao": {"path": "bin/ao", "sha256": digest(ao), "source_commit": commit, "cli_tree": cli_tree, "build_version": "fixture"},
+        },
+    }, handle, sort_keys=True)
+    handle.write("\n")
+PY
+
 }
 
 teardown() {
@@ -362,8 +400,36 @@ run_bootstrap() {
     --rig "$RIG" \
     --pack "$PACK" \
     --gc-bin "$FAKE_GC" \
+    --ao-bin "$BIN/ao" \
     --codex-auth "$CODEX_AUTH" \
     "$@"
+}
+
+@test "bootstrap refuses ambient gc or ao selection before admission" {
+  run env PATH="$BIN:$PATH" "$BOOTSTRAP" \
+    --city "$CITY" --rig "$RIG" --pack "$PACK" --codex-auth "$CODEX_AUTH"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--gc-bin is required"* ]]
+  [ ! -s "$FAKE_LOG" ]
+
+  run env PATH="$BIN:$PATH" "$BOOTSTRAP" \
+    --city "$CITY" --rig "$RIG" --pack "$PACK" --gc-bin "$FAKE_GC" \
+    --codex-auth "$CODEX_AUTH"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--ao-bin is required"* ]]
+  [ ! -s "$FAKE_LOG" ]
+}
+
+@test "bootstrap refuses an arbitrary ao binary without a matching toolchain receipt" {
+  rm -f "$TMP/toolchain.json"
+
+  run run_bootstrap
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no regular toolchain.json receipt"* ]]
+  [ ! -e "$CITY/.gc/agentops-bootstrap.json" ]
 }
 
 @test "bootstrap rejects a Beads-unsafe city root before invoking gc" {
@@ -399,7 +465,7 @@ run_bootstrap() {
   [ -f "$CITY/.gc-home/supervisor.toml" ]
   [ ! -e "$FAKE_STATE/started" ]
 
-  python3 - "$CITY/.gc/agentops-bootstrap.json" "$FAKE_GC" "$BIN/bd" <<'PY'
+  python3 - "$CITY/.gc/agentops-bootstrap.json" "$FAKE_GC" "$BIN/bd" "$BIN/ao" <<'PY'
 import json
 import os
 import re
@@ -407,17 +473,24 @@ import sys
 
 with open(sys.argv[1], encoding="utf-8") as handle:
     marker = json.load(handle)
-assert marker["schema_version"] == 3
+assert marker["schema_version"] == 4
 assert marker["toolchain"]["gc"]["path"] == os.path.realpath(sys.argv[2])
 assert marker["toolchain"]["gc"]["version"] == "1.3.5"
 assert marker["toolchain"]["gc"]["commit"] == "8ffc009d"
 assert marker["toolchain"]["bd"]["path"] == os.path.realpath(sys.argv[3])
 assert marker["toolchain"]["bd"]["version"] == "1.1.0"
 assert marker["toolchain"]["bd"]["commit"] == "8e4e59d39"
-assert marker["toolchain"]["qualification"]["id"] == "gascity-v1.3.5-sdk-release"
-assert marker["toolchain"]["qualification"]["status"] == "compatible"
+assert marker["toolchain"]["qualification"]["id"] == "gascity-v1.3.5-beads-v1.1.0"
+assert marker["toolchain"]["qualification"]["status"] == "qualified"
 assert re.fullmatch(r"[0-9a-f]{64}", marker["toolchain"]["gc"]["sha256"])
 assert re.fullmatch(r"[0-9a-f]{64}", marker["toolchain"]["bd"]["sha256"])
+assert marker["ao_reducer"]["path"] == os.path.realpath(sys.argv[4])
+assert re.fullmatch(r"[0-9a-f]{64}", marker["ao_reducer"]["binary_sha256"])
+assert re.fullmatch(r"[0-9a-f]{40}", marker["ao_reducer"]["source_commit"])
+assert re.fullmatch(r"[0-9a-f]{40}", marker["ao_reducer"]["cli_tree"])
+assert marker["ao_reducer"]["build_version"] == "fixture"
+assert re.fullmatch(r"[0-9a-f]{64}", marker["ao_reducer"]["pack_content_sha256"])
+assert re.fullmatch(r"[0-9a-f]{64}", marker["ao_reducer"]["schema_config_sha256"])
 PY
 
   grep -Fq '[supervisor]' "$CITY/.gc-home/supervisor.toml"
@@ -595,6 +668,17 @@ PY
   grep -Fq '<import> <status> <--json>' "$FAKE_LOG"
 }
 
+@test "bootstrap refuses a changed admitted ao reducer binary" {
+  run run_bootstrap
+  [ "$status" -eq 0 ]
+
+  printf '%s\n' '# changed' >>"$BIN/ao"
+  run run_bootstrap
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ao reducer identity"* ]]
+}
+
 @test "cities with the same basename receive different tmux sockets" {
   run run_bootstrap
   [ "$status" -eq 0 ]
@@ -615,6 +699,7 @@ PY
     --rig "$RIG" \
     --pack "$PACK" \
     --gc-bin "$FAKE_GC" \
+    --ao-bin "$BIN/ao" \
     --codex-auth "$CODEX_AUTH"
   [ "$status" -eq 0 ]
 
@@ -714,7 +799,22 @@ PY
 
   run run_bootstrap --gc-bin "$upgraded_gc"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"managed city mismatch for paired gc/bd toolchain identity"* ]]
+  [[ "$output" == *"toolchain receipt gc path does not match admitted binary"* ]]
+
+  python3 - "$TMP/toolchain.json" "$upgraded_gc" <<'PY'
+import hashlib
+import json
+import sys
+
+path, gc = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    receipt = json.load(handle)
+receipt["runtime"]["gc"]["path"] = "bin/gc-upgraded"
+receipt["runtime"]["gc"]["sha256"] = hashlib.sha256(open(gc, "rb").read()).hexdigest()
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(receipt, handle, sort_keys=True)
+    handle.write("\n")
+PY
 
   run run_bootstrap --gc-bin "$upgraded_gc" --replace-gc-bin --start
   [ "$status" -eq 0 ]
@@ -732,7 +832,7 @@ with open(marker_path, encoding="utf-8") as handle:
     marker = json.load(handle)
 with open(city_config_path, "rb") as handle:
     city_config = tomllib.load(handle)
-assert marker["schema_version"] == 3
+assert marker["schema_version"] == 4
 assert marker["toolchain"]["gc"]["path"] == expected
 assert city_config["workspace"]["env"]["GC_BIN"] == expected
 PY
@@ -746,7 +846,21 @@ PY
 
   run run_bootstrap
   [ "$status" -ne 0 ]
-  [[ "$output" == *"managed city mismatch for paired gc/bd toolchain identity"* ]]
+  [[ "$output" == *"toolchain receipt gc digest does not match admitted binary"* ]]
+
+  python3 - "$TMP/toolchain.json" "$FAKE_GC" <<'PY'
+import hashlib
+import json
+import sys
+
+path, gc = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    receipt = json.load(handle)
+receipt["runtime"]["gc"]["sha256"] = hashlib.sha256(open(gc, "rb").read()).hexdigest()
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(receipt, handle, sort_keys=True)
+    handle.write("\n")
+PY
 
   run run_bootstrap --replace-gc-bin --start
   [ "$status" -eq 0 ]

--- a/tests/scripts/gc-agentops-teardown.bats
+++ b/tests/scripts/gc-agentops-teardown.bats
@@ -67,6 +67,14 @@ printf '%s\n' 'bd version 1.1.0 (test)'
 EOF
   chmod +x "$FAKE_BD"
 
+  FAKE_AO="$BIN/ao"
+  cat >"$FAKE_AO" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' 'ao fixture reducer'
+EOF
+  chmod +x "$FAKE_AO"
+
   cat >"$BIN/tmux" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -91,13 +99,13 @@ EOF
 socket = "agentops-teardown-test"
 EOF
 	CANONICAL_CITY="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$CITY")"
-  python3 - "$CITY/.gc/agentops-bootstrap.json" "$CITY" "$FAKE_GC" "$FAKE_BD" <<'PY'
+  python3 - "$CITY/.gc/agentops-bootstrap.json" "$CITY" "$FAKE_GC" "$FAKE_BD" "$FAKE_AO" <<'PY'
 import hashlib
 import json
 import os
 import sys
 
-path, city, gc_bin, bd_bin = sys.argv[1:]
+path, city, gc_bin, bd_bin, ao_bin = sys.argv[1:]
 
 
 def sha256(filename):
@@ -106,7 +114,7 @@ def sha256(filename):
 
 with open(path, "w", encoding="utf-8") as handle:
     json.dump({
-        "schema_version": 3,
+        "schema_version": 4,
         "state": "ready",
         "city": os.path.realpath(city),
         "toolchain": {
@@ -118,6 +126,13 @@ with open(path, "w", encoding="utf-8") as handle:
                 "path": os.path.realpath(bd_bin),
                 "sha256": sha256(bd_bin),
             },
+        },
+        "ao_reducer": {
+            "path": os.path.realpath(ao_bin),
+            "binary_sha256": sha256(ao_bin),
+            "source_commit": "0" * 40,
+            "source_tree": "0" * 40,
+            "schema_config_sha256": "0" * 64,
         },
     }, handle)
     handle.write("\n")
@@ -169,6 +184,21 @@ teardown() {
 
   [ "$status" -ne 0 ]
   [[ "$output" == *"managed gc binary digest mismatch"* ]]
+  [ ! -e "$STATE/supervisor-stopped" ]
+}
+
+@test "teardown refuses ambient gc substitution and changed reducer bytes" {
+  run env PATH="$BIN:$PATH" "$TEARDOWN" --city "$CITY" --gc-bin gc
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"PATH resolution is forbidden"* ]]
+  [ ! -e "$STATE/supervisor-stopped" ]
+
+  printf '%s\n' '# replaced' >>"$FAKE_AO"
+  run env PATH="$BIN:$PATH" "$TEARDOWN" --city "$CITY"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ao reducer binary digest mismatch"* ]]
   [ ! -e "$STATE/supervisor-stopped" ]
 }
 

--- a/tests/scripts/gc-agentops-toolchain.bats
+++ b/tests/scripts/gc-agentops-toolchain.bats
@@ -6,18 +6,18 @@ setup() {
   LOCK="$REPO_ROOT/deploy/gc/toolchain.lock.json"
 }
 
-@test "materializer describes the qualified pair by default" {
+@test "materializer describes the official release pair by default" {
   run "$MATERIALIZE" --describe
 
   [ "$status" -eq 0 ]
-  python3 -c 'import json,sys; value=json.load(sys.stdin); assert value["id"] == "agentops-gc-v16-20260719"; assert value["status"] == "qualified"' <<<"$output"
+  python3 -c 'import json,sys; value=json.load(sys.stdin); assert value["id"] == "gascity-v1.3.5-beads-v1.1.0"; assert value["status"] == "qualified"; assert value["gc"]["source_commit"] == "8ffc009ded781a2ada2077f3a29bd712b2def0bf"; assert value["bd"]["source_commit"] == "8e4e59d39f3459a43cf21a3236a13eca4dd874f7"; assert value["gc"]["release_checksum_sha256"] == "aefe5b1defa6ab383e27cd933c76e5118f3c920dab911ba19d807f1f89053d3f"; assert value["bd"]["release_checksum_sha256"] == "b3684128bf6af985ee2148ca50dc22ff19e29b43227aefef48219fdbad8cbe52"' <<<"$output"
 }
 
-@test "materializer can select the compatible official release" {
-  run "$MATERIALIZE" --pair gascity-v1.3.5-sdk-release --describe
+@test "materializer refuses the stale PR 3985 exception identity" {
+  run "$MATERIALIZE" --pair agentops-gc-pr3985-347c66b1-bd-v1.1.0 --describe
 
-  [ "$status" -eq 0 ]
-  python3 -c 'import json,sys; value=json.load(sys.stdin); assert value["gc"]["ref"] == "v1.3.5"; assert value["bd"]["ref"] == "v1.1.0"' <<<"$output"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown pair id"* ]]
 }
 
 @test "materializer fails closed for an unknown pair" {
@@ -39,7 +39,7 @@ setup() {
   [ "$(cat "$destination/user-file")" = preserve ]
 }
 
-@test "materializer fetches the locked commit after its branch advances" {
+@test "materializer fetches and verifies the locked release tag after its branch advances" {
   source_repo="$BATS_TEST_TMPDIR/source"
   output_dir="$BATS_TEST_TMPDIR/output"
   lock="$BATS_TEST_TMPDIR/toolchain.lock.json"
@@ -57,15 +57,22 @@ import pathlib
 import subprocess
 
 commit = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], text=True).strip()
+tag = subprocess.run(
+    ["git", "describe", "--tags", "--exact-match"],
+    check=False,
+    capture_output=True,
+    text=True,
+).stdout.strip()
+version = tag.removeprefix("v") if tag == "v1.0.0" else "dev"
 pathlib.Path("bin").mkdir(exist_ok=True)
 pathlib.Path("bin/gc").write_text(
     "#!/bin/sh\nprintf '%s\\n' '" +
-    '{"ok":true,"version":"test","commit":"' + commit + '"}' +
+    '{"ok":true,"version":"' + version + '","commit":"' + commit + '"}' +
     "'\n",
     encoding="utf-8",
 )
 pathlib.Path("bd").write_text(
-    "#!/bin/sh\nprintf '%s\\n' 'bd version test (" + commit + ")'\n",
+    "#!/bin/sh\nprintf '%s\\n' 'bd version " + version + " (" + commit + ")'\n",
     encoding="utf-8",
 )
 os.chmod("bin/gc", 0o755)
@@ -74,6 +81,7 @@ PY
   git -C "$source_repo" add Makefile build.py
   git -C "$source_repo" commit -qm initial
   locked_commit="$(git -C "$source_repo" rev-parse HEAD)"
+  git -C "$source_repo" tag v1.0.0 "$locked_commit"
   printf '%s\n' moved >"$source_repo/branch-moved"
   git -C "$source_repo" add branch-moved
   git -C "$source_repo" commit -qm moved
@@ -84,10 +92,12 @@ import sys
 path, repository, commit = sys.argv[1:]
 component = {
     "repository": repository,
-    "ref": "main",
-    "version": "test",
+    "ref": "v1.0.0",
+    "version": "1.0.0",
     "source_commit": commit,
     "runtime_commit": commit,
+    "release_checksum_asset": "fixture-checksums.txt",
+    "release_checksum_sha256": "0" * 64,
 }
 with open(path, "w", encoding="utf-8") as handle:
     json.dump({
@@ -104,14 +114,25 @@ PY
   run "$MATERIALIZE" --lock "$lock" --output "$output_dir"
 
   [ "$status" -eq 0 ]
-  python3 - "$output_dir/toolchain.json" "$locked_commit" <<'PY'
+  python3 - "$output_dir/toolchain.json" "$locked_commit" "$REPO_ROOT" <<'PY'
 import json
+import os
+import subprocess
 import sys
 
 with open(sys.argv[1], encoding="utf-8") as handle:
     receipt = json.load(handle)
+root = sys.argv[3]
 assert receipt["pair"]["gc"]["source_commit"] == sys.argv[2]
+assert receipt["schema_version"] == 2
 assert receipt["runtime"]["gc"]["commit"] == sys.argv[2][:7]
 assert receipt["runtime"]["bd"]["commit"] == sys.argv[2][:7]
+assert receipt["runtime"]["gc"]["path"] == "bin/gc"
+assert receipt["runtime"]["bd"]["path"] == "bin/bd"
+assert receipt["runtime"]["ao"]["path"] == "bin/ao"
+assert os.path.isfile(os.path.join(os.path.dirname(sys.argv[1]), "bin", "ao"))
+assert receipt["runtime"]["ao"]["source_commit"] == subprocess.check_output(["git", "-C", root, "rev-parse", "HEAD"], text=True).strip()
+assert receipt["runtime"]["ao"]["cli_tree"] == subprocess.check_output(["git", "-C", root, "rev-parse", "HEAD:cli"], text=True).strip()
+assert receipt["runtime"]["ao"]["build_version"]
 PY
 }


### PR DESCRIPTION
## Summary

- pin the qualified AgentOps Gas City bootstrap to official Gas City v1.3.5 and Beads v1.1.0
- materialize exact `gc`, `bd`, and repository-built `ao` binaries with a portable identity receipt
- make bootstrap and teardown reject ambient substitution and persisted identity drift
- prove repeat bootstrap projections and ownership-safe teardown

Bead: `ag-agentops-33-gc-refinery-4km81.2`

## Binding validation

Fresh Sol/high verdict: `PASS`

- verdict digest: `abc7654f5e68d1d562a5e7b612d7d0cef3941f14bc7e02bbf22f4191a7f1c645`
- subject manifest: `78011e248dda437bd0ac39a912cb6195df24d2789ed6c58016873f0f891775b2`
- exact changed scope: nine paths in `deploy/gc` and `tests/scripts`

A prior fresh verdict found that commit-only shallow fetches built Gas City as `dev`. The repair now fetches and verifies each locked release tag against the independently pinned commit before building. The prior FAIL remains preserved as evidence.

## Checks

- real clean materialization: GC `1.3.5@8ffc009`, Beads `1.1.0@8e4e59d`, receipt-bound AO source/tree/digest
- `37 tests, 0 failures` across toolchain, bootstrap, and teardown Bats suites
- `bash -n deploy/gc/materialize-toolchain.sh deploy/gc/bootstrap.sh deploy/gc/teardown.sh`
- `git diff --check`

No Gas City, Dolt, or suspended v17 city was started.
