### PR TITLE
feat(gc): add crash-only delivery thin slice

### DIFF
--- a/cli/cmd/agentops-gc-delivery/main.go
+++ b/cli/cmd/agentops-gc-delivery/main.go
@@ -1,0 +1,59 @@
+// Command agentops-gc-delivery is the optional, pack-selected GC33 delivery
+// reducer. It is intentionally separate from the ao command tree.
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/boshu2/agentops/cli/internal/gcadapter/delivery"
+)
+
+func main() {
+	if len(os.Args) < 2 || os.Args[1] != "step" {
+		fmt.Fprintln(os.Stderr, "usage: agentops-gc-delivery step --root DIR --certificate FILE --semantic-bead ID --terminal-ref REF --rig ID --repository OWNER/REPO --remote NAME --epoch N --mode auto|manual --deadline RFC3339 --prepared-at RFC3339 --committed-at RFC3339 --base-ref REF --base-oid SHA --fake-terminal-ref REF")
+		os.Exit(2)
+	}
+	flags := flag.NewFlagSet("step", flag.ExitOnError)
+	root, certificatePath := flags.String("root", "", "immutable evidence root"), flags.String("certificate", "", "exact admission certificate bytes")
+	semantic, terminalRef, rig, repository, remote := flags.String("semantic-bead", "", "semantic bead"), flags.String("terminal-ref", "", "terminal semantic reference"), flags.String("rig", "", "rig identity"), flags.String("repository", "", "repository identity"), flags.String("remote", "", "remote identity")
+	epoch := flags.Int("epoch", 0, "delivery epoch")
+	mode, deadline, preparedAt, committedAt := flags.String("mode", "", "mode"), flags.String("deadline", "", "deadline"), flags.String("prepared-at", "", "prepared timestamp"), flags.String("committed-at", "", "committed timestamp")
+	baseRef, baseOID, fakeRef := flags.String("base-ref", "", "base ref"), flags.String("base-oid", "", "base oid"), flags.String("fake-terminal-ref", "", "explicit fake terminal ref for this thin-slice boundary")
+	fixtureState := flags.String("fixture-state", "", "explicit offline fake-provider state path")
+	if err := flags.Parse(os.Args[2:]); err != nil {
+		fail(err)
+	}
+	bytes, err := os.ReadFile(*certificatePath)
+	if err != nil {
+		fail(err)
+	}
+	var certificate delivery.AdmissionCertificate
+	if err := json.Unmarshal(bytes, &certificate); err != nil {
+		fail(err)
+	}
+	sum := sha256.Sum256(bytes)
+	request := delivery.Request{Root: *root, Certificate: certificate, CertificateBytes: bytes, CertificateDigest: hex.EncodeToString(sum[:]), Target: delivery.Target{SemanticBeadID: *semantic, SemanticTerminalRef: *terminalRef, RigID: *rig, Repository: *repository, Remote: *remote, Epoch: *epoch, Mode: *mode, Deadline: *deadline, PreparedAt: *preparedAt, CommittedAt: *committedAt, BaseRef: *baseRef, BaseOID: *baseOID}}
+	// GC33-6 deliberately exposes only the fake boundary. GC33-7 can add a
+	// caller-owned real adapter after this exact transition contract is proven.
+	if *fakeRef == "" || *fixtureState == "" {
+		fail(fmt.Errorf("--fake-terminal-ref and --fixture-state are required by the GC33-6 offline thin slice"))
+	}
+	providers, err := delivery.OpenFixtureProviders(*fixtureState, delivery.Terminal{BeadID: *semantic, Ref: *fakeRef, Verdict: "PASS", CertificateDigest: request.CertificateDigest})
+	if err != nil {
+		fail(err)
+	}
+	result, err := delivery.NewReducer(providers, nil).Step(context.Background(), request)
+	if err != nil {
+		fail(err)
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
+		fail(err)
+	}
+}
+func fail(err error) { fmt.Fprintln(os.Stderr, "agentops-gc-delivery:", err); os.Exit(1) }

--- a/cli/internal/gcadapter/delivery/fake.go
+++ b/cli/internal/gcadapter/delivery/fake.go
@@ -1,0 +1,167 @@
+package delivery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FakeProviders is an in-memory conformance boundary for deterministic tests.
+// It is intentionally not wired into the optional binary's production mode.
+type FakeProviders struct {
+	terminal             Terminal
+	deliveries           map[string]DeliveryBead
+	branches             map[string]Branch
+	prs                  map[string]PullRequest
+	initiallyNonRoutable bool
+	mutations            int
+	publishGuard         func() error
+	fixtureStatePath     string
+}
+
+func NewFakeProviders(terminal Terminal) *FakeProviders {
+	return &FakeProviders{terminal: terminal, deliveries: map[string]DeliveryBead{}, branches: map[string]Branch{}, prs: map[string]PullRequest{}}
+}
+
+// OpenFixtureProviders is an explicitly offline fake boundary. Its state is a
+// test fixture, never a production delivery ledger or a Beads replacement.
+func OpenFixtureProviders(path string, terminal Terminal) (*FakeProviders, error) {
+	provider := NewFakeProviders(terminal)
+	provider.fixtureStatePath = path
+	bytes, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return provider, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var state fixtureState
+	if err := json.Unmarshal(bytes, &state); err != nil {
+		return nil, err
+	}
+	if state.Terminal != terminal {
+		return nil, fmt.Errorf("fixture terminal does not match exact invocation")
+	}
+	provider.deliveries, provider.branches, provider.prs, provider.initiallyNonRoutable = state.Deliveries, state.Branches, state.PRs, state.InitiallyNonRoutable
+	if provider.deliveries == nil {
+		provider.deliveries = map[string]DeliveryBead{}
+	}
+	if provider.branches == nil {
+		provider.branches = map[string]Branch{}
+	}
+	if provider.prs == nil {
+		provider.prs = map[string]PullRequest{}
+	}
+	return provider, nil
+}
+
+type fixtureState struct {
+	Terminal             Terminal                `json:"terminal"`
+	Deliveries           map[string]DeliveryBead `json:"deliveries"`
+	Branches             map[string]Branch       `json:"branches"`
+	PRs                  map[string]PullRequest  `json:"prs"`
+	InitiallyNonRoutable bool                    `json:"initially_non_routable"`
+}
+
+func (f *FakeProviders) persist() error {
+	if f.fixtureStatePath == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(f.fixtureStatePath), 0o755); err != nil {
+		return err
+	}
+	bytes, err := json.Marshal(fixtureState{Terminal: f.terminal, Deliveries: f.deliveries, Branches: f.branches, PRs: f.prs, InitiallyNonRoutable: f.initiallyNonRoutable})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(f.fixtureStatePath, append(bytes, '\n'), 0o600)
+}
+func (f *FakeProviders) Clone() *FakeProviders                              { return NewFakeProviders(f.terminal) }
+func (f *FakeProviders) Terminal(context.Context, string) (Terminal, error) { return f.terminal, nil }
+func (f *FakeProviders) FindDelivery(_ context.Context, id string) (DeliveryBead, bool, error) {
+	value, ok := f.deliveries[id]
+	return value, ok, nil
+}
+func (f *FakeProviders) CreateDelivery(_ context.Context, expected DeliveryBead) (DeliveryBead, error) {
+	if current, ok := f.deliveries[expected.ID]; ok {
+		if current != expected {
+			return DeliveryBead{}, fmt.Errorf("delivery exists with different identity")
+		}
+		return current, nil
+	}
+	if expected.Route != "" {
+		return DeliveryBead{}, fmt.Errorf("delivery must start non-routable")
+	}
+	f.deliveries[expected.ID] = expected
+	f.initiallyNonRoutable = true
+	f.mutations++
+	if err := f.persist(); err != nil {
+		return DeliveryBead{}, err
+	}
+	return expected, nil
+}
+func (f *FakeProviders) PublishDelivery(_ context.Context, id string) error {
+	if f.publishGuard != nil {
+		if err := f.publishGuard(); err != nil {
+			return err
+		}
+	}
+	value, ok := f.deliveries[id]
+	if !ok {
+		return fmt.Errorf("delivery does not exist")
+	}
+	value.Route = "agentops.delivery"
+	f.deliveries[id] = value
+	f.mutations++
+	if err := f.persist(); err != nil {
+		return err
+	}
+	return nil
+}
+func (f *FakeProviders) FindBranch(_ context.Context, name string) (Branch, bool, error) {
+	value, ok := f.branches[name]
+	return value, ok, nil
+}
+func (f *FakeProviders) PrepareBranch(_ context.Context, expected Branch) (Branch, error) {
+	if current, ok := f.branches[expected.Name]; ok {
+		if current != expected {
+			return Branch{}, fmt.Errorf("branch exists with different identity")
+		}
+		return current, nil
+	}
+	f.branches[expected.Name] = expected
+	f.mutations++
+	if err := f.persist(); err != nil {
+		return Branch{}, err
+	}
+	return expected, nil
+}
+func (f *FakeProviders) FindPR(_ context.Context, id string) (PullRequest, bool, error) {
+	value, ok := f.prs[id]
+	return value, ok, nil
+}
+func (f *FakeProviders) CreatePR(_ context.Context, expected PullRequest) (PullRequest, error) {
+	if current, ok := f.prs[expected.ID]; ok {
+		if current != expected {
+			return PullRequest{}, fmt.Errorf("PR exists with different identity")
+		}
+		return current, nil
+	}
+	f.prs[expected.ID] = expected
+	f.mutations++
+	if err := f.persist(); err != nil {
+		return PullRequest{}, err
+	}
+	return expected, nil
+}
+func (f *FakeProviders) DeliveryCount() int                        { return len(f.deliveries) }
+func (f *FakeProviders) BranchCount() int                          { return len(f.branches) }
+func (f *FakeProviders) PRCount() int                              { return len(f.prs) }
+func (f *FakeProviders) OnlyDeliveryWasInitiallyNonRoutable() bool { return f.initiallyNonRoutable }
+func (f *FakeProviders) MutationCount() int                        { return f.mutations }
+func (f *FakeProviders) SetPublishGuard(guard func() error)        { f.publishGuard = guard }
+func (f *FakeProviders) PutDelivery(value DeliveryBead)            { f.deliveries[value.ID] = value }
+func (f *FakeProviders) PutBranch(value Branch)                    { f.branches[value.Name] = value }
+func (f *FakeProviders) PutPR(value PullRequest)                   { f.prs[value.ID] = value }

--- a/cli/internal/gcadapter/delivery/reducer.go
+++ b/cli/internal/gcadapter/delivery/reducer.go
@@ -1,0 +1,872 @@
+// Package delivery provides the optional, caller-selected GC delivery reducer.
+// It deliberately has no dependency on ao commands or AgentOps ports.
+package delivery
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+)
+
+const (
+	preparedFile    = "handoff-prepared.json"
+	nonRoutableFile = "delivery.non-routable.json"
+	publishedFile   = "delivery.published.json"
+	committedFile   = "handoff-committed.json"
+)
+
+var ErrCrash = errors.New("delivery reducer crash cut")
+
+func IsCrash(err error) bool { return errors.Is(err, ErrCrash) }
+
+// AdmissionCertificate is the strict subset required to admit delivery. The
+// caller must pass the exact certificate digest calculated from its bytes.
+type AdmissionCertificate struct {
+	SchemaVersion       string       `json:"schema_version"`
+	SemanticBeadID      string       `json:"semantic_bead_id"`
+	IntentDigest        string       `json:"intent_digest"`
+	Verdict             string       `json:"verdict"`
+	Candidate           Candidate    `json:"candidate"`
+	Store               Store        `json:"store"`
+	ChangedPathManifest string       `json:"changed_path_manifest"`
+	VerdictDigest       string       `json:"verdict_digest"`
+	EvidenceDigest      string       `json:"evidence_digest"`
+	Attestations        Attestations `json:"attestations"`
+	DeliveryGroupID     string       `json:"delivery_group_id"`
+	PrefixSafety        string       `json:"prefix_safety"`
+}
+
+type Candidate struct {
+	Commit        string `json:"commit"`
+	Tree          string `json:"tree"`
+	ContentDigest string `json:"content_digest"`
+}
+
+type Store struct {
+	Identity string `json:"identity"`
+	Digest   string `json:"digest"`
+}
+type Attestations struct {
+	Author    Runtime `json:"author"`
+	Validator Runtime `json:"validator"`
+}
+type Runtime struct {
+	ContextID          string    `json:"context_id"`
+	RequestedModel     string    `json:"requested_model"`
+	RequestedReasoning string    `json:"requested_reasoning"`
+	RequestedProvider  string    `json:"requested_provider"`
+	ActualModel        string    `json:"actual_model"`
+	ActualReasoning    string    `json:"actual_reasoning"`
+	ActualProvider     string    `json:"actual_provider"`
+	ActualEffort       string    `json:"actual_effort"`
+	Fallback           *Fallback `json:"fallback"`
+}
+type Fallback struct {
+	Allowed *bool           `json:"allowed"`
+	Used    *bool           `json:"used"`
+	Reason  json.RawMessage `json:"reason"`
+}
+
+type Target struct {
+	SemanticBeadID      string
+	SemanticTerminalRef string
+	RigID               string
+	Repository          string
+	Remote              string
+	Epoch               int
+	Mode                string
+	Deadline            string
+	PreparedAt          string
+	CommittedAt         string
+	BaseRef             string
+	BaseOID             string
+}
+
+type Request struct {
+	Root              string
+	Certificate       AdmissionCertificate
+	CertificateBytes  []byte
+	CertificateDigest string
+	Target            Target
+}
+
+type Terminal struct {
+	BeadID            string
+	Ref               string
+	Verdict           string
+	CertificateDigest string
+}
+
+type DeliveryBead struct {
+	ID          string
+	ExternalRef string
+	Route       string
+}
+
+type Branch struct{ Name, BaseRef, BaseOID, Head string }
+type PullRequest struct{ ID, Branch, BaseRef, BaseOID, Head, EffectID string }
+
+// Providers makes all mutable boundaries explicit. Production wiring may use
+// its own caller-selected adapters; this thin slice proves only fake boundaries.
+type Providers interface {
+	Terminal(context.Context, string) (Terminal, error)
+	FindDelivery(context.Context, string) (DeliveryBead, bool, error)
+	CreateDelivery(context.Context, DeliveryBead) (DeliveryBead, error)
+	PublishDelivery(context.Context, string) error
+	FindBranch(context.Context, string) (Branch, bool, error)
+	PrepareBranch(context.Context, Branch) (Branch, error)
+	FindPR(context.Context, string) (PullRequest, bool, error)
+	CreatePR(context.Context, PullRequest) (PullRequest, error)
+}
+
+type Result struct {
+	Status string `json:"status"`
+	Effect string `json:"effect,omitempty"`
+}
+type Crash func(string) error
+
+func CrashAt(cut string) Crash {
+	return func(point string) error {
+		if cut == point {
+			return ErrCrash
+		}
+		return nil
+	}
+}
+
+func AllCrashCuts() []string {
+	return []string{
+		"before_prepared", "after_prepared", "before_terminal", "after_terminal",
+		"before_successor_create", "after_successor_create", "before_publication", "after_publication",
+		"before_committed", "after_committed", "before_branch", "after_branch", "before_pr", "after_pr",
+	}
+}
+
+type Reducer struct {
+	providers Providers
+	crash     Crash
+}
+
+func NewReducer(providers Providers, crash Crash) *Reducer {
+	return &Reducer{providers: providers, crash: crash}
+}
+
+func (r *Reducer) Step(ctx context.Context, request Request) (Result, error) {
+	request, err := exactRequest(request)
+	if err != nil {
+		return Result{}, err
+	}
+	state := markerStore{root: request.Root}
+	prepared := makePrepared(request)
+	if result, done, err := r.ensurePrepared(state, prepared); err != nil || done {
+		return result, err
+	}
+	if err := r.requireTerminal(ctx, request); err != nil {
+		return Result{}, err
+	}
+	bead, result, done, err := r.ensureSuccessor(ctx, prepared)
+	if err != nil || done {
+		return result, err
+	}
+	if result, done, err := ensureNonRoutable(state, prepared, bead); err != nil || done {
+		return result, err
+	}
+	if result, done, err := ensurePublicationPrepared(state, prepared); err != nil || done {
+		return result, err
+	}
+	if result, done, err := r.ensureCommitted(state, prepared, request); err != nil || done {
+		return result, err
+	}
+	if result, done, err := r.publish(ctx, prepared, bead); err != nil || done {
+		return result, err
+	}
+	branch, result, done, err := r.ensureBranch(ctx, state, prepared, request)
+	if err != nil || done {
+		return result, err
+	}
+	return r.ensurePR(ctx, state, prepared, request, branch)
+}
+
+func exactRequest(request Request) (Request, error) {
+	certificate, err := decodeCertificate(request.CertificateBytes)
+	if err != nil {
+		return Request{}, err
+	}
+	if !reflect.DeepEqual(certificate, request.Certificate) {
+		return Request{}, errors.New("certificate bytes and parsed certificate disagree")
+	}
+	request.Certificate = certificate
+	return request, validateRequest(request)
+}
+
+func (r *Reducer) ensurePrepared(state markerStore, prepared Prepared) (Result, bool, error) {
+	found, err := state.read(preparedFile, &Prepared{})
+	if err != nil {
+		return Result{}, true, err
+	}
+	if found {
+		return Result{}, false, state.matches(preparedFile, prepared)
+	}
+	if err := r.cut("before_prepared"); err != nil {
+		return Result{}, true, err
+	}
+	if err := state.writeImmutable(preparedFile, prepared); err != nil {
+		return Result{}, true, err
+	}
+	if err := r.cut("after_prepared"); err != nil {
+		return Result{}, true, err
+	}
+	return Result{Status: "prepared"}, true, nil
+}
+
+func (r *Reducer) requireTerminal(ctx context.Context, request Request) error {
+	if err := r.cut("before_terminal"); err != nil {
+		return err
+	}
+	terminal, err := r.providers.Terminal(ctx, request.Target.SemanticBeadID)
+	if err != nil {
+		return err
+	}
+	if !matchesTerminal(terminal, request) {
+		return errors.New("terminal semantic identity does not match PASS certificate")
+	}
+	return r.cut("after_terminal")
+}
+
+func matchesTerminal(terminal Terminal, request Request) bool {
+	return terminal.BeadID == request.Target.SemanticBeadID && terminal.Ref == request.Target.SemanticTerminalRef && terminal.Verdict == "PASS" && terminal.CertificateDigest == request.CertificateDigest
+}
+
+func (r *Reducer) ensureSuccessor(ctx context.Context, prepared Prepared) (DeliveryBead, Result, bool, error) {
+	bead, found, err := r.providers.FindDelivery(ctx, prepared.DeliveryBeadID)
+	if err != nil {
+		return DeliveryBead{}, Result{}, true, err
+	}
+	if found {
+		if !matchesDelivery(bead, prepared) {
+			return DeliveryBead{}, Result{}, true, errors.New("conflicting delivery bead identity")
+		}
+		return bead, Result{}, false, nil
+	}
+	if err := r.cut("before_successor_create"); err != nil {
+		return DeliveryBead{}, Result{}, true, err
+	}
+	created, err := r.providers.CreateDelivery(ctx, DeliveryBead{ID: prepared.DeliveryBeadID, ExternalRef: prepared.ExternalRef})
+	if err != nil {
+		return DeliveryBead{}, Result{}, true, err
+	}
+	if created.ID != prepared.DeliveryBeadID || created.ExternalRef != prepared.ExternalRef || created.Route != "" {
+		return DeliveryBead{}, Result{}, true, errors.New("delivery create returned a conflicting identity")
+	}
+	if err := r.cut("after_successor_create"); err != nil {
+		return DeliveryBead{}, Result{}, true, err
+	}
+	return DeliveryBead{}, Result{Status: "successor_created", Effect: "beads.create"}, true, nil
+}
+
+func matchesDelivery(bead DeliveryBead, prepared Prepared) bool {
+	return bead.ID == prepared.DeliveryBeadID && bead.ExternalRef == prepared.ExternalRef && (bead.Route == "" || bead.Route == "agentops.delivery")
+}
+
+func ensureNonRoutable(state markerStore, prepared Prepared, bead DeliveryBead) (Result, bool, error) {
+	artifact := makeDelivery(prepared, "non_routable")
+	if state.exists(nonRoutableFile) {
+		return Result{}, false, state.matches(nonRoutableFile, artifact)
+	}
+	if bead.Route != "" {
+		return Result{}, true, errors.New("expected non-routable successor")
+	}
+	if err := state.writeImmutable(nonRoutableFile, artifact); err != nil {
+		return Result{}, true, err
+	}
+	return Result{Status: "non_routable_recorded"}, true, nil
+}
+
+func ensurePublicationPrepared(state markerStore, prepared Prepared) (Result, bool, error) {
+	artifact := makeDelivery(prepared, "published")
+	if state.exists(publishedFile) {
+		return Result{}, false, state.matches(publishedFile, artifact)
+	}
+	if err := state.writeImmutable(publishedFile, artifact); err != nil {
+		return Result{}, true, err
+	}
+	return Result{Status: "publication_prepared"}, true, nil
+}
+
+func (r *Reducer) ensureCommitted(state markerStore, prepared Prepared, request Request) (Result, bool, error) {
+	committed := makeCommitted(prepared, state.digest(preparedFile), state.digest(publishedFile), request.Target.CommittedAt)
+	if state.exists(committedFile) {
+		return Result{}, false, state.matches(committedFile, committed)
+	}
+	if err := r.cut("before_committed"); err != nil {
+		return Result{}, true, err
+	}
+	if err := state.writeImmutable(committedFile, committed); err != nil {
+		return Result{}, true, err
+	}
+	if err := r.cut("after_committed"); err != nil {
+		return Result{}, true, err
+	}
+	return Result{Status: "committed"}, true, nil
+}
+
+func (r *Reducer) publish(ctx context.Context, prepared Prepared, bead DeliveryBead) (Result, bool, error) {
+	if bead.Route == "agentops.delivery" {
+		return Result{}, false, nil
+	}
+	if bead.Route != "" {
+		return Result{}, true, errors.New("published delivery has an unexpected route")
+	}
+	if err := r.cut("before_publication"); err != nil {
+		return Result{}, true, err
+	}
+	if err := r.providers.PublishDelivery(ctx, prepared.DeliveryBeadID); err != nil {
+		return Result{}, true, err
+	}
+	if err := r.cut("after_publication"); err != nil {
+		return Result{}, true, err
+	}
+	return Result{Status: "published", Effect: "beads.publish"}, true, nil
+}
+
+func (r *Reducer) ensureBranch(ctx context.Context, state markerStore, prepared Prepared, request Request) (Branch, Result, bool, error) {
+	branch := expectedBranch(prepared, request)
+	stored, found, err := r.providers.FindBranch(ctx, branch.Name)
+	if err != nil {
+		return Branch{}, Result{}, true, err
+	}
+	if !found {
+		return r.createBranch(ctx, state, prepared, request.Target, branch)
+	}
+	if stored != branch {
+		return Branch{}, Result{}, true, errors.New("conflicting branch identity")
+	}
+	result, done, err := receiptBranch(state, prepared, request.Target, stored, "adopted")
+	return stored, result, done, err
+}
+
+func expectedBranch(prepared Prepared, request Request) Branch {
+	return Branch{Name: "delivery/" + prepared.HandoffID[:20], BaseRef: request.Target.BaseRef, BaseOID: request.Target.BaseOID, Head: request.Certificate.Candidate.Commit}
+}
+
+func (r *Reducer) createBranch(ctx context.Context, state markerStore, prepared Prepared, target Target, branch Branch) (Branch, Result, bool, error) {
+	if err := r.cut("before_branch"); err != nil {
+		return Branch{}, Result{}, true, err
+	}
+	created, err := r.providers.PrepareBranch(ctx, branch)
+	if err != nil {
+		return Branch{}, Result{}, true, err
+	}
+	if created != branch {
+		return Branch{}, Result{}, true, errors.New("branch prepare returned a conflicting identity")
+	}
+	if err := r.cut("after_branch"); err != nil {
+		return Branch{}, Result{}, true, err
+	}
+	if _, _, err := receiptBranch(state, prepared, target, created, "created"); err != nil {
+		return Branch{}, Result{}, true, err
+	}
+	return Branch{}, Result{Status: "branch_prepared", Effect: "git.branch"}, true, nil
+}
+
+func receiptBranch(state markerStore, prepared Prepared, target Target, branch Branch, outcome string) (Result, bool, error) {
+	if state.exists("receipts/branch.json") {
+		ok, err := state.branchReceiptMatches("receipts/branch.json", prepared, target, branch)
+		if err != nil || !ok {
+			if err == nil {
+				err = errors.New("branch receipt identity conflict")
+			}
+			return Result{}, true, err
+		}
+		return Result{}, false, nil
+	}
+	receipt, err := makeBranchReceipt(prepared, target, branch, outcome)
+	if err != nil {
+		return Result{}, true, err
+	}
+	if err := state.writeImmutable("receipts/branch.json", receipt); err != nil {
+		return Result{}, true, err
+	}
+	return Result{Status: "branch_receipted"}, true, nil
+}
+
+func (r *Reducer) ensurePR(ctx context.Context, state markerStore, prepared Prepared, request Request, branch Branch) (Result, error) {
+	pr := expectedPR(prepared, branch)
+	stored, found, err := r.providers.FindPR(ctx, pr.ID)
+	if err != nil {
+		return Result{}, err
+	}
+	if !found {
+		return r.createPR(ctx, state, prepared, request.Target, pr)
+	}
+	if stored != pr {
+		return Result{}, errors.New("conflicting PR identity")
+	}
+	if result, done, err := receiptPR(state, prepared, request.Target, stored, "adopted"); done {
+		return result, err
+	}
+	return Result{Status: "converged"}, nil
+}
+
+func expectedPR(prepared Prepared, branch Branch) PullRequest {
+	effectID := identifier(prepared.HandoffID, "pr")
+	return PullRequest{ID: "pr-" + effectID[:20], Branch: branch.Name, BaseRef: branch.BaseRef, BaseOID: branch.BaseOID, Head: branch.Head, EffectID: effectID}
+}
+
+func (r *Reducer) createPR(ctx context.Context, state markerStore, prepared Prepared, target Target, pr PullRequest) (Result, error) {
+	if err := r.cut("before_pr"); err != nil {
+		return Result{}, err
+	}
+	created, err := r.providers.CreatePR(ctx, pr)
+	if err != nil {
+		return Result{}, err
+	}
+	if created != pr {
+		return Result{}, errors.New("PR create returned a conflicting identity")
+	}
+	if err := r.cut("after_pr"); err != nil {
+		return Result{}, err
+	}
+	if _, _, err := receiptPR(state, prepared, target, created, "created"); err != nil {
+		return Result{}, err
+	}
+	return Result{Status: "pr_opened", Effect: "forge.pr"}, nil
+}
+
+func receiptPR(state markerStore, prepared Prepared, target Target, pr PullRequest, outcome string) (Result, bool, error) {
+	if state.exists("receipts/pr-open.json") {
+		ok, err := state.prReceiptMatches("receipts/pr-open.json", prepared, target, pr)
+		if err != nil || !ok {
+			if err == nil {
+				err = errors.New("PR receipt identity conflict")
+			}
+			return Result{}, true, err
+		}
+		return Result{}, false, nil
+	}
+	receipt, err := makePROpenReceipt(prepared, target, pr, outcome)
+	if err != nil {
+		return Result{}, true, err
+	}
+	if err := state.writeImmutable("receipts/pr-open.json", receipt); err != nil {
+		return Result{}, true, err
+	}
+	return Result{Status: "pr_receipted"}, true, nil
+}
+
+func (r *Reducer) cut(point string) error {
+	if r.crash == nil {
+		return nil
+	}
+	return r.crash(point)
+}
+
+func validateRequest(request Request) error {
+	checks := []func(Request) error{
+		validateTarget, validateCertificateDigest, validateCertificateIdentity,
+		validateCertificateProvenance, validateDeliveryPolicy,
+	}
+	for _, check := range checks {
+		if err := check(request); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateTarget(request Request) error {
+	values := []string{request.Root, request.Target.SemanticBeadID, request.Target.SemanticTerminalRef, request.Target.RigID, request.Target.Repository, request.Target.Remote, request.Target.BaseRef}
+	if hasEmpty(values) || !isHex(request.Target.BaseOID, 40) {
+		return errors.New("delivery target identity is required")
+	}
+	return nil
+}
+
+func hasEmpty(values []string) bool {
+	for _, value := range values {
+		if value == "" {
+			return true
+		}
+	}
+	return false
+}
+
+func validateCertificateDigest(request Request) error {
+	actual := sha256.Sum256(request.CertificateBytes)
+	if len(request.CertificateBytes) == 0 || request.CertificateDigest != hex.EncodeToString(actual[:]) {
+		return errors.New("certificate digest does not match exact bytes")
+	}
+	return nil
+}
+
+func validateCertificateIdentity(request Request) error {
+	certificate := request.Certificate
+	if certificate.SchemaVersion != "admission-certificate.v2" || certificate.Verdict != "PASS" || certificate.SemanticBeadID != request.Target.SemanticBeadID {
+		return errors.New("certificate is not an exact PASS for target")
+	}
+	if !validCertificateDigests(certificate, request.CertificateDigest) {
+		return errors.New("certificate identity digest is malformed")
+	}
+	return nil
+}
+
+func validCertificateDigests(certificate AdmissionCertificate, certificateDigest string) bool {
+	values := []struct {
+		value string
+		width int
+	}{
+		{certificate.IntentDigest, 64}, {certificate.Candidate.Commit, 40}, {certificate.Candidate.Tree, 40},
+		{certificate.Candidate.ContentDigest, 64}, {certificate.Store.Digest, 64}, {certificate.ChangedPathManifest, 64},
+		{certificate.VerdictDigest, 64}, {certificate.EvidenceDigest, 64}, {certificateDigest, 64},
+	}
+	if certificate.Store.Identity == "" {
+		return false
+	}
+	for _, value := range values {
+		if !isHex(value.value, value.width) {
+			return false
+		}
+	}
+	return true
+}
+
+func validateCertificateProvenance(request Request) error {
+	attestations := request.Certificate.Attestations
+	if request.Certificate.DeliveryGroupID == "" || !validPrefixSafety(request.Certificate.PrefixSafety) || !validRuntime(attestations.Author, "author") || !validRuntime(attestations.Validator, "validator") || attestations.Author.ContextID == attestations.Validator.ContextID {
+		return errors.New("certificate provenance is not an exact admitted profile")
+	}
+	return nil
+}
+
+func validPrefixSafety(value string) bool {
+	return value == "safe" || value == "atomic_group" || value == "externally_gated"
+}
+
+func validateDeliveryPolicy(request Request) error {
+	target := request.Target
+	if target.Epoch < 1 || !validMode(target.Mode) || !isTime(target.Deadline) || !isTime(target.PreparedAt) || !isTime(target.CommittedAt) {
+		return errors.New("delivery epoch or mode is invalid")
+	}
+	return nil
+}
+
+func validMode(value string) bool { return value == "auto" || value == "manual" }
+
+func decodeCertificate(value []byte) (AdmissionCertificate, error) {
+	var certificate AdmissionCertificate
+	if err := decodeStrict(value, &certificate); err != nil {
+		return AdmissionCertificate{}, fmt.Errorf("invalid exact certificate bytes: %w", err)
+	}
+	return certificate, nil
+}
+func decodeStrict(value []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(value))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}
+
+func isTime(value string) bool { _, err := time.Parse(time.RFC3339, value); return err == nil }
+
+type runtimeProfile struct {
+	requestedModel, requestedReasoning, requestedProvider      string
+	actualModel, actualReasoning, actualProvider, actualEffort string
+}
+
+var runtimeProfiles = map[string][]runtimeProfile{
+	"author": {
+		{"terra", "high", "codex", "gpt-5.6-terra", "high", "codex", "high"},
+		{"opus", "medium", "claude", "claude-opus-4-8", "medium", "claude", "medium"},
+	},
+	"validator": {{"sol", "high", "codex", "gpt-5.6-sol", "high", "codex", "high"}},
+}
+
+func validRuntime(runtime Runtime, role string) bool {
+	if runtime.ContextID == "" || !validFallback(runtime.Fallback) {
+		return false
+	}
+	for _, expected := range runtimeProfiles[role] {
+		if profileOf(runtime) == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func validFallback(fallback *Fallback) bool {
+	return fallback != nil && fallback.Allowed != nil && fallback.Used != nil && !*fallback.Allowed && !*fallback.Used && bytes.Equal(fallback.Reason, []byte("null"))
+}
+
+func profileOf(runtime Runtime) runtimeProfile {
+	return runtimeProfile{runtime.RequestedModel, runtime.RequestedReasoning, runtime.RequestedProvider, runtime.ActualModel, runtime.ActualReasoning, runtime.ActualProvider, runtime.ActualEffort}
+}
+
+func isHex(value string, width int) bool {
+	if len(value) != width {
+		return false
+	}
+	for i := range value {
+		if (value[i] < '0' || value[i] > '9') && (value[i] < 'a' || value[i] > 'f') {
+			return false
+		}
+	}
+	return true
+}
+func identifier(parts ...string) string {
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return hex.EncodeToString(sum[:])
+}
+
+type Prepared struct {
+	SchemaVersion              string `json:"schema_version"`
+	HandoffID                  string `json:"handoff_id"`
+	SemanticBeadID             string `json:"semantic_bead_id"`
+	SemanticTerminalRef        string `json:"semantic_terminal_ref"`
+	AdmissionCertificateRef    string `json:"admission_certificate_ref"`
+	AdmissionCertificateDigest string `json:"admission_certificate_digest"`
+	DeliveryBeadID             string `json:"expected_delivery_bead_id"`
+	ExternalRef                string `json:"expected_external_ref"`
+	Epoch                      int    `json:"epoch"`
+	Mode                       string `json:"mode"`
+	State                      string `json:"state"`
+	Deadline                   string `json:"deadline"`
+	PreparedAt                 string `json:"prepared_at"`
+}
+type DeliveryArtifact struct {
+	SchemaVersion              string  `json:"schema_version"`
+	Kind                       string  `json:"kind"`
+	HandoffID                  string  `json:"handoff_id"`
+	SemanticBeadID             string  `json:"semantic_bead_id"`
+	SemanticTerminalRef        string  `json:"semantic_terminal_ref"`
+	AdmissionCertificateDigest string  `json:"admission_certificate_digest"`
+	DeliveryBeadID             string  `json:"delivery_bead_id"`
+	ExternalRef                string  `json:"external_ref"`
+	Epoch                      int     `json:"epoch"`
+	PredecessorReceiptDigest   *string `json:"predecessor_receipt_digest"`
+	Mode                       string  `json:"mode"`
+	State                      string  `json:"state"`
+	Publication                string  `json:"publication"`
+	Deadline                   string  `json:"deadline"`
+	EffectGate                 any     `json:"effect_gate"`
+	SuccessorBeadID            *string `json:"successor_bead_id"`
+}
+type Committed struct {
+	SchemaVersion              string `json:"schema_version"`
+	HandoffID                  string `json:"handoff_id"`
+	PreparedDigest             string `json:"prepared_digest"`
+	SemanticBeadID             string `json:"semantic_bead_id"`
+	SemanticTerminalVerdict    string `json:"semantic_terminal_verdict"`
+	SemanticTerminalRef        string `json:"semantic_terminal_ref"`
+	AdmissionCertificateDigest string `json:"admission_certificate_digest"`
+	DeliveryBeadID             string `json:"delivery_bead_id"`
+	ExternalRef                string `json:"expected_external_ref"`
+	Epoch                      int    `json:"epoch"`
+	DeliveryPayloadRef         string `json:"delivery_payload_ref"`
+	DeliveryPayloadDigest      string `json:"delivery_payload_digest"`
+	Mode                       string `json:"mode"`
+	State                      string `json:"state"`
+	Deadline                   string `json:"deadline"`
+	CommittedAt                string `json:"committed_at"`
+}
+type BranchReceipt struct {
+	SchemaVersion  string `json:"schema_version"`
+	HandoffID      string `json:"handoff_id"`
+	Epoch          int    `json:"epoch"`
+	RigID          string `json:"rig_id"`
+	Repository     string `json:"repository"`
+	Remote         string `json:"remote"`
+	Branch         string `json:"branch"`
+	BaseRef        string `json:"base_ref"`
+	BaseOID        string `json:"base_oid"`
+	ExpectedHead   string `json:"expected_head"`
+	Outcome        string `json:"outcome"`
+	ResponseDigest string `json:"response_digest"`
+}
+type PROpenReceipt struct {
+	SchemaVersion  string `json:"schema_version"`
+	HandoffID      string `json:"handoff_id"`
+	Epoch          int    `json:"epoch"`
+	RigID          string `json:"rig_id"`
+	Repository     string `json:"repository"`
+	Remote         string `json:"remote"`
+	PRID           string `json:"pr_id"`
+	Branch         string `json:"branch"`
+	BaseRef        string `json:"base_ref"`
+	BaseOID        string `json:"base_oid"`
+	ExpectedHead   string `json:"expected_head"`
+	EffectID       string `json:"effect_id"`
+	Outcome        string `json:"outcome"`
+	ResponseDigest string `json:"response_digest"`
+}
+
+func makePrepared(r Request) Prepared {
+	handoff := identifier("agentops.gc.delivery.handoff.v1", r.CertificateDigest, r.Target.SemanticBeadID, r.Target.SemanticTerminalRef, r.Target.RigID, r.Target.Repository, r.Target.Remote, r.Target.BaseRef, r.Target.BaseOID, r.Target.Mode, fmt.Sprint(r.Target.Epoch))
+	return Prepared{SchemaVersion: "handoff-prepared.v1", HandoffID: handoff, SemanticBeadID: r.Target.SemanticBeadID, SemanticTerminalRef: r.Target.SemanticTerminalRef, AdmissionCertificateRef: "certificate:sha256:" + r.CertificateDigest, AdmissionCertificateDigest: r.CertificateDigest, DeliveryBeadID: "delivery-" + handoff[:20] + fmt.Sprintf("-e%06d", r.Target.Epoch), ExternalRef: "handoff:" + handoff + fmt.Sprintf(":epoch:%d", r.Target.Epoch), Epoch: r.Target.Epoch, Mode: r.Target.Mode, State: "queued", Deadline: r.Target.Deadline, PreparedAt: r.Target.PreparedAt}
+}
+func makeDelivery(p Prepared, publication string) DeliveryArtifact {
+	return DeliveryArtifact{SchemaVersion: "delivery.v1", Kind: "delivery", HandoffID: p.HandoffID, SemanticBeadID: p.SemanticBeadID, SemanticTerminalRef: p.SemanticTerminalRef, AdmissionCertificateDigest: p.AdmissionCertificateDigest, DeliveryBeadID: p.DeliveryBeadID, ExternalRef: p.ExternalRef, Epoch: p.Epoch, Mode: p.Mode, State: p.State, Publication: publication, Deadline: p.Deadline}
+}
+func makeCommitted(p Prepared, preparedDigest, publishedDigest, committedAt string) Committed {
+	return Committed{SchemaVersion: "handoff-committed.v1", HandoffID: p.HandoffID, PreparedDigest: preparedDigest, SemanticBeadID: p.SemanticBeadID, SemanticTerminalVerdict: "PASS", SemanticTerminalRef: p.SemanticTerminalRef, AdmissionCertificateDigest: p.AdmissionCertificateDigest, DeliveryBeadID: p.DeliveryBeadID, ExternalRef: p.ExternalRef, Epoch: p.Epoch, DeliveryPayloadRef: publishedFile, DeliveryPayloadDigest: publishedDigest, Mode: p.Mode, State: p.State, Deadline: p.Deadline, CommittedAt: committedAt}
+}
+func makeBranchReceipt(p Prepared, target Target, branch Branch, outcome string) (BranchReceipt, error) {
+	digest, err := valueDigest(branch)
+	if err != nil {
+		return BranchReceipt{}, err
+	}
+	return BranchReceipt{SchemaVersion: "branch-receipt.v1", HandoffID: p.HandoffID, Epoch: p.Epoch, RigID: target.RigID, Repository: target.Repository, Remote: target.Remote, Branch: branch.Name, BaseRef: branch.BaseRef, BaseOID: branch.BaseOID, ExpectedHead: branch.Head, Outcome: outcome, ResponseDigest: digest}, nil
+}
+func makePROpenReceipt(p Prepared, target Target, pr PullRequest, outcome string) (PROpenReceipt, error) {
+	digest, err := valueDigest(pr)
+	if err != nil {
+		return PROpenReceipt{}, err
+	}
+	return PROpenReceipt{SchemaVersion: "pr-open-receipt.v1", HandoffID: p.HandoffID, Epoch: p.Epoch, RigID: target.RigID, Repository: target.Repository, Remote: target.Remote, PRID: pr.ID, Branch: pr.Branch, BaseRef: pr.BaseRef, BaseOID: pr.BaseOID, ExpectedHead: pr.Head, EffectID: pr.EffectID, Outcome: outcome, ResponseDigest: digest}, nil
+}
+func valueDigest(value any) (string, error) {
+	bytes, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(bytes)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+type markerStore struct{ root string }
+
+func (s markerStore) path(name string) string { return filepath.Join(s.root, name) }
+func (s markerStore) exists(name string) bool { _, err := os.Stat(s.path(name)); return err == nil }
+func (s markerStore) read(name string, into any) (bool, error) {
+	bytes, err := os.ReadFile(s.path(name))
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if err := decodeStrict(bytes, into); err != nil {
+		return false, fmt.Errorf("invalid immutable artifact %s: %w", name, err)
+	}
+	return true, nil
+}
+func (s markerStore) branchReceiptMatches(name string, prepared Prepared, target Target, branch Branch) (bool, error) {
+	var receipt BranchReceipt
+	found, err := s.read(name, &receipt)
+	if err != nil || !found {
+		return false, err
+	}
+	digest, err := valueDigest(branch)
+	if err != nil {
+		return false, err
+	}
+	return receipt.SchemaVersion == "branch-receipt.v1" && (receipt.Outcome == "created" || receipt.Outcome == "adopted") && receipt.HandoffID == prepared.HandoffID && receipt.Epoch == prepared.Epoch && receipt.RigID == target.RigID && receipt.Repository == target.Repository && receipt.Remote == target.Remote && receipt.Branch == branch.Name && receipt.BaseRef == branch.BaseRef && receipt.BaseOID == branch.BaseOID && receipt.ExpectedHead == branch.Head && receipt.ResponseDigest == digest, nil
+}
+func (s markerStore) prReceiptMatches(name string, prepared Prepared, target Target, pr PullRequest) (bool, error) {
+	var receipt PROpenReceipt
+	found, err := s.read(name, &receipt)
+	if err != nil || !found {
+		return false, err
+	}
+	digest, err := valueDigest(pr)
+	if err != nil {
+		return false, err
+	}
+	return receipt.SchemaVersion == "pr-open-receipt.v1" && (receipt.Outcome == "created" || receipt.Outcome == "adopted") && receipt.HandoffID == prepared.HandoffID && receipt.Epoch == prepared.Epoch && receipt.RigID == target.RigID && receipt.Repository == target.Repository && receipt.Remote == target.Remote && receipt.PRID == pr.ID && receipt.Branch == pr.Branch && receipt.BaseRef == pr.BaseRef && receipt.BaseOID == pr.BaseOID && receipt.ExpectedHead == pr.Head && receipt.EffectID == pr.EffectID && receipt.ResponseDigest == digest, nil
+}
+func (s markerStore) bytes(value any) ([]byte, error) {
+	bytes, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return append(bytes, '\n'), nil
+}
+func (s markerStore) writeImmutable(name string, value any) error {
+	expected, err := s.bytes(value)
+	if err != nil {
+		return err
+	}
+	path := s.path(name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err == nil {
+		written, writeErr := file.Write(expected)
+		syncErr := file.Sync()
+		closeErr := file.Close()
+		if writeErr != nil {
+			return writeErr
+		}
+		if written != len(expected) {
+			return io.ErrShortWrite
+		}
+		if syncErr != nil {
+			return syncErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		parent, openErr := os.Open(filepath.Dir(path))
+		if openErr != nil {
+			return openErr
+		}
+		syncErr = parent.Sync()
+		closeErr = parent.Close()
+		if syncErr != nil {
+			return syncErr
+		}
+		return closeErr
+	}
+	if !errors.Is(err, os.ErrExist) {
+		return err
+	}
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if string(existing) != string(expected) {
+		return fmt.Errorf("immutable artifact conflict: %s", name)
+	}
+	return nil
+}
+func (s markerStore) matches(name string, value any) error {
+	expected, err := s.bytes(value)
+	if err != nil {
+		return err
+	}
+	actual, err := os.ReadFile(s.path(name))
+	if err != nil {
+		return err
+	}
+	if string(actual) != string(expected) {
+		return fmt.Errorf("immutable artifact conflict: %s", name)
+	}
+	return nil
+}
+func (s markerStore) digest(name string) string {
+	bytes, err := os.ReadFile(s.path(name))
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(bytes)
+	return hex.EncodeToString(sum[:])
+}

--- a/cli/internal/gcadapter/delivery/reducer_test.go
+++ b/cli/internal/gcadapter/delivery/reducer_test.go
@@ -1,0 +1,547 @@
+package delivery_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/gcadapter/delivery"
+)
+
+func TestReducerKillAnywhereConvergesToOneBeadAndOnePROutsideAO(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	certificate := certificateFor("semantic-42")
+	certificateBytes, err := json.Marshal(certificate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificateDigest := digest(certificateBytes)
+	request := delivery.Request{
+		Root:              root,
+		Certificate:       certificate,
+		CertificateBytes:  certificateBytes,
+		CertificateDigest: certificateDigest,
+		Target:            delivery.Target{SemanticBeadID: "semantic-42", SemanticTerminalRef: "beads:semantic-42#terminal", RigID: "rig-a", Repository: "boshu2/agentops", Remote: "origin", Epoch: 1, Mode: "auto", Deadline: "2026-07-22T00:00:00Z", PreparedAt: "2026-07-21T00:00:00Z", CommittedAt: "2026-07-21T00:00:01Z", BaseRef: "main", BaseOID: strings.Repeat("d", 40)},
+	}
+	providers := delivery.NewFakeProviders(delivery.Terminal{BeadID: "semantic-42", Ref: "beads:semantic-42#terminal", Verdict: "PASS", CertificateDigest: certificateDigest})
+	cuts := delivery.AllCrashCuts()
+	for _, cut := range cuts {
+		t.Run(cut, func(t *testing.T) {
+			trialRoot := filepath.Join(root, cut)
+			if err := os.MkdirAll(trialRoot, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			trial := request
+			trial.Root = trialRoot
+			fake := providers.Clone()
+			fake.SetPublishGuard(func() error { _, err := os.Stat(filepath.Join(trialRoot, "delivery.published.json")); return err })
+			before := fake.MutationCount()
+			_, err := delivery.NewReducer(fake, delivery.CrashAt(cut)).Step(context.Background(), trial)
+			if got := fake.MutationCount() - before; got > 1 {
+				t.Fatalf("crash invocation performed %d provider mutations", got)
+			}
+			if err != nil && !delivery.IsCrash(err) {
+				t.Fatalf("crash step: %v", err)
+			}
+			for i := 0; i < 32; i++ {
+				before := fake.MutationCount()
+				result, runErr := delivery.NewReducer(fake, nil).Step(context.Background(), trial)
+				if got := fake.MutationCount() - before; got > 1 {
+					t.Fatalf("replay %d performed %d provider mutations", i, got)
+				}
+				if runErr != nil {
+					t.Fatalf("replay %d: %v", i, runErr)
+				}
+				if result.Status == "converged" {
+					break
+				}
+			}
+			if got := fake.DeliveryCount(); got != 1 {
+				t.Fatalf("delivery beads = %d, want 1", got)
+			}
+			if got := fake.BranchCount(); got != 1 {
+				t.Fatalf("branches = %d, want 1", got)
+			}
+			if got := fake.PRCount(); got != 1 {
+				t.Fatalf("prs = %d, want 1", got)
+			}
+			if !fake.OnlyDeliveryWasInitiallyNonRoutable() {
+				t.Fatal("delivery bead was not non-routable before publication")
+			}
+			if _, err := os.Stat(filepath.Join(trialRoot, "receipts", "pr-open.json")); err != nil {
+				t.Fatalf("immutable PR receipt: %v", err)
+			}
+			for _, artifact := range []string{"handoff-prepared.json", "delivery.non-routable.json", "delivery.published.json", "handoff-committed.json", "receipts/branch.json", "receipts/pr-open.json"} {
+				bytes, readErr := os.ReadFile(filepath.Join(trialRoot, artifact))
+				if readErr != nil {
+					t.Fatalf("read %s: %v", artifact, readErr)
+				}
+				var object map[string]any
+				if unmarshalErr := json.Unmarshal(bytes, &object); unmarshalErr != nil {
+					t.Fatalf("decode %s: %v", artifact, unmarshalErr)
+				}
+				if _, ok := object["schema_version"]; !ok {
+					t.Fatalf("%s has no schema_version", artifact)
+				}
+				for key := range object {
+					if key != strings.ToLower(key) {
+						t.Fatalf("%s emitted non-schema field %q", artifact, key)
+					}
+				}
+			}
+		})
+	}
+
+	for _, forbidden := range []string{"cli/cmd/ao", "cli/internal/ports"} {
+		if _, err := os.Stat(filepath.Join("..", "..", "..", "..", forbidden)); err == nil {
+			// The reducer package must not import either forbidden surface.
+			bytes, readErr := os.ReadFile("reducer.go")
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if strings.Contains(string(bytes), forbidden) {
+				t.Fatalf("reducer imports forbidden surface %q", forbidden)
+			}
+		}
+	}
+}
+
+func TestReducerRejectsCertificateTargetAndRouteMutations(t *testing.T) {
+	certificate := certificateFor("semantic-42")
+	certificateBytes, err := json.Marshal(certificate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := delivery.Request{Root: t.TempDir(), Certificate: certificate, CertificateBytes: certificateBytes, CertificateDigest: digest(certificateBytes), Target: delivery.Target{SemanticBeadID: "semantic-42", SemanticTerminalRef: "beads:semantic-42#terminal", RigID: "rig-a", Repository: "boshu2/agentops", Remote: "origin", Epoch: 1, Mode: "auto", Deadline: "2026-07-22T00:00:00Z", PreparedAt: "2026-07-21T00:00:00Z", CommittedAt: "2026-07-21T00:00:01Z", BaseRef: "main", BaseOID: strings.Repeat("d", 40)}}
+	terminal := delivery.Terminal{BeadID: "semantic-42", Ref: "beads:semantic-42#terminal", Verdict: "PASS", CertificateDigest: base.CertificateDigest}
+	for name, mutate := range map[string]func(*delivery.Request){
+		"bytes_extra_field": func(r *delivery.Request) {
+			r.CertificateBytes = append(append([]byte{}, r.CertificateBytes[:len(r.CertificateBytes)-1]...), []byte(`,"extra":true}`)...)
+			r.CertificateDigest = digest(r.CertificateBytes)
+		},
+		"bytes_struct_mismatch": func(r *delivery.Request) { r.Certificate.SemanticBeadID = "other" },
+		"same_author_validator_context": func(r *delivery.Request) {
+			r.Certificate.Attestations.Validator.ContextID = r.Certificate.Attestations.Author.ContextID
+			bytes, _ := json.Marshal(r.Certificate)
+			r.CertificateBytes = bytes
+			r.CertificateDigest = digest(bytes)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			request := base
+			request.Root = t.TempDir()
+			mutate(&request)
+			if _, got := delivery.NewReducer(delivery.NewFakeProviders(terminal), nil).Step(context.Background(), request); got == nil {
+				t.Fatal("mutation was accepted")
+			}
+		})
+	}
+	for name, mutate := range map[string]func(*delivery.Target){
+		"rig": func(target *delivery.Target) { target.RigID = "rig-b" }, "repository": func(target *delivery.Target) { target.Repository = "other/repo" }, "remote": func(target *delivery.Target) { target.Remote = "upstream" }, "base_ref": func(target *delivery.Target) { target.BaseRef = "release" }, "base_oid": func(target *delivery.Target) { target.BaseOID = strings.Repeat("e", 40) }, "mode": func(target *delivery.Target) { target.Mode = "manual" }, "epoch": func(target *delivery.Target) { target.Epoch = 2 },
+	} {
+		t.Run("handoff_binds_"+name, func(t *testing.T) {
+			left := base
+			left.Root = t.TempDir()
+			right := base
+			right.Root = t.TempDir()
+			mutate(&right.Target)
+			leftFake, rightFake := delivery.NewFakeProviders(terminal), delivery.NewFakeProviders(terminal)
+			if _, err := delivery.NewReducer(leftFake, nil).Step(context.Background(), left); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := delivery.NewReducer(rightFake, nil).Step(context.Background(), right); err != nil {
+				t.Fatal(err)
+			}
+			if handoffID(t, left.Root) == handoffID(t, right.Root) {
+				t.Fatalf("%s did not change handoff identity", name)
+			}
+		})
+	}
+	request := base
+	request.Root = t.TempDir()
+	fake := delivery.NewFakeProviders(terminal)
+	if _, err := delivery.NewReducer(fake, nil).Step(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	var prepared struct {
+		DeliveryBeadID string `json:"expected_delivery_bead_id"`
+		ExternalRef    string `json:"expected_external_ref"`
+	}
+	bytes, err := os.ReadFile(filepath.Join(request.Root, "handoff-prepared.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(bytes, &prepared); err != nil {
+		t.Fatal(err)
+	}
+	fake.PutDelivery(delivery.DeliveryBead{ID: prepared.DeliveryBeadID, ExternalRef: prepared.ExternalRef, Route: "wrong.pool"})
+	if _, err := delivery.NewReducer(fake, nil).Step(context.Background(), request); err == nil {
+		t.Fatal("mismatched delivery route was accepted")
+	}
+	for i := 0; i < 12; i++ {
+		result, runErr := delivery.NewReducer(fake, nil).Step(context.Background(), request)
+		if runErr != nil {
+			break
+		}
+		if result.Status == "committed" {
+			break
+		}
+	}
+	// A fresh fixture keeps the later identity-collision checks independent of
+	// the deliberately bad route above.
+	fixture := delivery.NewFakeProviders(terminal)
+	reachedPublished := false
+	for i := 0; i < 12; i++ {
+		result, runErr := delivery.NewReducer(fixture, nil).Step(context.Background(), request)
+		if runErr != nil {
+			t.Fatal(runErr)
+		}
+		if result.Status == "published" {
+			reachedPublished = true
+			break
+		}
+	}
+	if !reachedPublished {
+		t.Fatal("did not reach committed route publication before branch collision")
+	}
+	handoff := handoffID(t, request.Root)
+	branchName := "delivery/" + handoff[:20]
+	fixture.PutBranch(delivery.Branch{Name: branchName, BaseRef: "evil", BaseOID: strings.Repeat("d", 40), Head: strings.Repeat("a", 40)})
+	if result, err := delivery.NewReducer(fixture, nil).Step(context.Background(), request); err == nil {
+		t.Fatalf("branch collision was accepted at status %s for %s", result.Status, branchName)
+	}
+
+	request.Root = t.TempDir()
+	fixture = delivery.NewFakeProviders(terminal)
+	for i := 0; i < 16; i++ {
+		result, runErr := delivery.NewReducer(fixture, nil).Step(context.Background(), request)
+		if runErr != nil {
+			t.Fatal(runErr)
+		}
+		if result.Status == "branch_prepared" {
+			break
+		}
+	}
+	if _, err := delivery.NewReducer(fixture, delivery.CrashAt("before_pr")).Step(context.Background(), request); !delivery.IsCrash(err) {
+		t.Fatalf("before_pr cut = %v", err)
+	}
+	handoff = handoffID(t, request.Root)
+	prID := "pr-" + identifierForTest(handoff, "pr")[:20]
+	fixture.PutPR(delivery.PullRequest{ID: prID, Branch: "wrong", BaseRef: "main", BaseOID: strings.Repeat("d", 40), Head: strings.Repeat("a", 40), EffectID: identifierForTest(handoff, "pr")})
+	if _, err := delivery.NewReducer(fixture, nil).Step(context.Background(), request); err == nil {
+		t.Fatal("PR collision was accepted")
+	}
+}
+
+func TestOfflineFixtureColdReplayConverges(t *testing.T) {
+	certificate := certificateFor("semantic-42")
+	bytes, err := json.Marshal(certificate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := delivery.Request{Root: filepath.Join(t.TempDir(), "evidence"), Certificate: certificate, CertificateBytes: bytes, CertificateDigest: digest(bytes), Target: delivery.Target{SemanticBeadID: "semantic-42", SemanticTerminalRef: "beads:semantic-42#terminal", RigID: "rig-a", Repository: "boshu2/agentops", Remote: "origin", Epoch: 1, Mode: "auto", Deadline: "2026-07-22T00:00:00Z", PreparedAt: "2026-07-21T00:00:00Z", CommittedAt: "2026-07-21T00:00:01Z", BaseRef: "main", BaseOID: strings.Repeat("d", 40)}}
+	fixture := filepath.Join(t.TempDir(), "offline-fixture.json")
+	terminal := delivery.Terminal{BeadID: request.Target.SemanticBeadID, Ref: request.Target.SemanticTerminalRef, Verdict: "PASS", CertificateDigest: request.CertificateDigest}
+	for i := 0; i < 16; i++ {
+		providers, openErr := delivery.OpenFixtureProviders(fixture, terminal)
+		if openErr != nil {
+			t.Fatal(openErr)
+		}
+		result, stepErr := delivery.NewReducer(providers, nil).Step(context.Background(), request)
+		if stepErr != nil {
+			t.Fatal(stepErr)
+		}
+		if result.Status == "converged" {
+			return
+		}
+	}
+	t.Fatal("fresh fixture providers did not converge")
+}
+
+func TestReducerRejectsMissingFallbackFieldsBeforePreparedMarker(t *testing.T) {
+	for _, role := range []string{"author", "validator"} {
+		for _, field := range []string{"fallback", "allowed", "used", "reason"} {
+			t.Run(role+"_"+field, func(t *testing.T) {
+				bytes := missingFallbackField(t, certificateFor("semantic-42"), role, field)
+				var certificate delivery.AdmissionCertificate
+				if err := json.Unmarshal(bytes, &certificate); err != nil {
+					t.Fatal(err)
+				}
+				root := t.TempDir()
+				request := delivery.Request{Root: root, Certificate: certificate, CertificateBytes: bytes, CertificateDigest: digest(bytes), Target: delivery.Target{SemanticBeadID: "semantic-42", SemanticTerminalRef: "beads:semantic-42#terminal", RigID: "rig-a", Repository: "boshu2/agentops", Remote: "origin", Epoch: 1, Mode: "auto", Deadline: "2026-07-22T00:00:00Z", PreparedAt: "2026-07-21T00:00:00Z", CommittedAt: "2026-07-21T00:00:01Z", BaseRef: "main", BaseOID: strings.Repeat("d", 40)}}
+				terminal := delivery.Terminal{BeadID: "semantic-42", Ref: "beads:semantic-42#terminal", Verdict: "PASS", CertificateDigest: request.CertificateDigest}
+				if _, err := delivery.NewReducer(delivery.NewFakeProviders(terminal), nil).Step(context.Background(), request); err == nil {
+					t.Fatal("missing required fallback field was accepted")
+				}
+				if _, err := os.Stat(filepath.Join(root, "handoff-prepared.json")); !os.IsNotExist(err) {
+					t.Fatalf("prepared marker exists after rejected fallback: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func missingFallbackField(t *testing.T, certificate delivery.AdmissionCertificate, role, field string) []byte {
+	t.Helper()
+	bytes, err := json.Marshal(certificate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(bytes, &document); err != nil {
+		t.Fatal(err)
+	}
+	runtime := document["attestations"].(map[string]any)[role].(map[string]any)
+	if field == "fallback" {
+		delete(runtime, field)
+	} else {
+		delete(runtime["fallback"].(map[string]any), field)
+	}
+	bytes, err = json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bytes
+}
+
+func TestReducerRejectsCorruptedImmutableMarkers(t *testing.T) {
+	for _, marker := range []string{
+		"handoff-prepared.json", "delivery.non-routable.json", "delivery.published.json", "handoff-committed.json",
+	} {
+		t.Run(marker, func(t *testing.T) {
+			certificate := certificateFor("semantic-42")
+			certificateBytes, err := json.Marshal(certificate)
+			if err != nil {
+				t.Fatal(err)
+			}
+			root := t.TempDir()
+			request := delivery.Request{Root: root, Certificate: certificate, CertificateBytes: certificateBytes, CertificateDigest: digest(certificateBytes), Target: delivery.Target{SemanticBeadID: "semantic-42", SemanticTerminalRef: "beads:semantic-42#terminal", RigID: "rig-a", Repository: "boshu2/agentops", Remote: "origin", Epoch: 1, Mode: "auto", Deadline: "2026-07-22T00:00:00Z", PreparedAt: "2026-07-21T00:00:00Z", CommittedAt: "2026-07-21T00:00:01Z", BaseRef: "main", BaseOID: strings.Repeat("d", 40)}}
+			terminal := delivery.Terminal{BeadID: "semantic-42", Ref: "beads:semantic-42#terminal", Verdict: "PASS", CertificateDigest: request.CertificateDigest}
+			fake := delivery.NewFakeProviders(terminal)
+			markerPath := filepath.Join(root, marker)
+			for i := 0; i < 16; i++ {
+				if _, err := os.Stat(markerPath); err == nil {
+					break
+				}
+				if _, err := delivery.NewReducer(fake, nil).Step(context.Background(), request); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := os.Stat(markerPath); err != nil {
+				t.Fatalf("did not reach marker %s: %v", marker, err)
+			}
+			if err := os.WriteFile(markerPath, []byte(`{"corrupted":true}`+"\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if result, err := delivery.NewReducer(fake, nil).Step(context.Background(), request); err == nil {
+				t.Fatalf("corrupted %s advanced as %q", marker, result.Status)
+			}
+		})
+	}
+}
+
+func TestReducerRejectsUppercaseIdentifiersBeforePreparedMarker(t *testing.T) {
+	for name, mutate := range map[string]func(*delivery.AdmissionCertificate, *delivery.Target){
+		"certificate_intent_digest": func(certificate *delivery.AdmissionCertificate, _ *delivery.Target) {
+			certificate.IntentDigest = strings.ToUpper(certificate.IntentDigest)
+		},
+		"target_base_oid": func(_ *delivery.AdmissionCertificate, target *delivery.Target) {
+			target.BaseOID = strings.ToUpper(target.BaseOID)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			certificate := certificateFor("semantic-42")
+			target := targetForTest()
+			mutate(&certificate, &target)
+			bytes, err := json.Marshal(certificate)
+			if err != nil {
+				t.Fatal(err)
+			}
+			request := delivery.Request{Root: t.TempDir(), Certificate: certificate, CertificateBytes: bytes, CertificateDigest: digest(bytes), Target: target}
+			if _, err := delivery.NewReducer(delivery.NewFakeProviders(terminalFor(request)), nil).Step(context.Background(), request); err == nil {
+				t.Fatal("uppercase identifier was accepted")
+			}
+			if _, err := os.Stat(filepath.Join(request.Root, "handoff-prepared.json")); !os.IsNotExist(err) {
+				t.Fatalf("prepared marker exists after rejected identifier: %v", err)
+			}
+		})
+	}
+}
+
+func TestReducerRejectsReceiptSchemaVersionMutation(t *testing.T) {
+	for _, phase := range []struct {
+		name, status, path string
+	}{
+		{"branch", "branch_prepared", "receipts/branch.json"},
+		{"pr", "pr_opened", "receipts/pr-open.json"},
+	} {
+		for _, schema := range []string{"missing", "wrong"} {
+			t.Run(phase.name+"_"+schema, func(t *testing.T) {
+				request := requestForTest(t, t.TempDir())
+				fake := delivery.NewFakeProviders(terminalFor(request))
+				reachStatus(t, fake, request, phase.status)
+				mutateReceiptSchema(t, filepath.Join(request.Root, phase.path), schema)
+				before := fake.MutationCount()
+				if result, err := delivery.NewReducer(fake, nil).Step(context.Background(), request); err == nil {
+					t.Fatalf("corrupted %s receipt advanced as %q", phase.name, result.Status)
+				}
+				if got := fake.MutationCount(); got != before {
+					t.Fatalf("corrupted %s receipt mutated provider: before=%d after=%d", phase.name, before, got)
+				}
+			})
+		}
+	}
+}
+
+func mutateReceiptSchema(t *testing.T, path, schema string) {
+	t.Helper()
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt map[string]any
+	if err := json.Unmarshal(bytes, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if schema == "missing" {
+		delete(receipt, "schema_version")
+	} else {
+		receipt["schema_version"] = "wrong.v1"
+	}
+	bytes, err = json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(bytes, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func reachStatus(t *testing.T, fake *delivery.FakeProviders, request delivery.Request, want string) {
+	t.Helper()
+	for i := 0; i < 16; i++ {
+		result, err := delivery.NewReducer(fake, nil).Step(context.Background(), request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Status == want {
+			return
+		}
+	}
+	t.Fatalf("did not reach status %q", want)
+}
+
+func TestDeliveryBinaryColdProcessFixtureReplayEmitsLowercaseResult(t *testing.T) {
+	certificate := certificateFor("semantic-42")
+	bytes, err := json.Marshal(certificate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	certificatePath := filepath.Join(root, "certificate.json")
+	if err := os.WriteFile(certificatePath, bytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cliRoot, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	binary := filepath.Join(root, "agentops-gc-delivery")
+	build := exec.Command("go", "build", "-o", binary, "./cmd/agentops-gc-delivery")
+	build.Dir = cliRoot
+	if output, buildErr := build.CombinedOutput(); buildErr != nil {
+		t.Fatalf("build binary: %v: %s", buildErr, output)
+	}
+	fixture, evidence := filepath.Join(root, "fixture.json"), filepath.Join(root, "evidence")
+	status := ""
+	for i := 0; i < 16; i++ {
+		command := exec.Command(binary, "step", "--root", evidence, "--certificate", certificatePath, "--semantic-bead", "semantic-42", "--terminal-ref", "beads:semantic-42#terminal", "--rig", "rig-a", "--repository", "boshu2/agentops", "--remote", "origin", "--epoch", "1", "--mode", "auto", "--deadline", "2026-07-22T00:00:00Z", "--prepared-at", "2026-07-21T00:00:00Z", "--committed-at", "2026-07-21T00:00:01Z", "--base-ref", "main", "--base-oid", strings.Repeat("d", 40), "--fake-terminal-ref", "beads:semantic-42#terminal", "--fixture-state", fixture)
+		command.Dir = cliRoot
+		output, runErr := command.Output()
+		if runErr != nil {
+			t.Fatalf("run %d: %v", i, runErr)
+		}
+		var result map[string]any
+		if err := json.Unmarshal(output, &result); err != nil {
+			t.Fatal(err)
+		}
+		if _, bad := result["Status"]; bad {
+			t.Fatal("binary emitted Go-cased result")
+		}
+		status, _ = result["status"].(string)
+		if status == "converged" {
+			break
+		}
+	}
+	if status != "converged" {
+		t.Fatalf("final status = %q", status)
+	}
+	var state struct {
+		Deliveries map[string]any `json:"deliveries"`
+		Branches   map[string]any `json:"branches"`
+		PRs        map[string]any `json:"prs"`
+	}
+	stateBytes, err := os.ReadFile(fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(stateBytes, &state); err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Deliveries) != 1 || len(state.Branches) != 1 || len(state.PRs) != 1 {
+		t.Fatalf("fixture final state deliveries=%d branches=%d prs=%d", len(state.Deliveries), len(state.Branches), len(state.PRs))
+	}
+}
+
+func handoffID(t *testing.T, root string) string {
+	t.Helper()
+	bytes, err := os.ReadFile(filepath.Join(root, "handoff-prepared.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var artifact struct {
+		HandoffID string `json:"handoff_id"`
+	}
+	if err := json.Unmarshal(bytes, &artifact); err != nil {
+		t.Fatal(err)
+	}
+	return artifact.HandoffID
+}
+func identifierForTest(parts ...string) string { return digest([]byte(strings.Join(parts, "\x00"))) }
+
+func digest(value []byte) string { sum := sha256.Sum256(value); return hex.EncodeToString(sum[:]) }
+
+func requestForTest(t *testing.T, root string) delivery.Request {
+	t.Helper()
+	certificate := certificateFor("semantic-42")
+	bytes, err := json.Marshal(certificate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return delivery.Request{Root: root, Certificate: certificate, CertificateBytes: bytes, CertificateDigest: digest(bytes), Target: targetForTest()}
+}
+
+func targetForTest() delivery.Target {
+	return delivery.Target{SemanticBeadID: "semantic-42", SemanticTerminalRef: "beads:semantic-42#terminal", RigID: "rig-a", Repository: "boshu2/agentops", Remote: "origin", Epoch: 1, Mode: "auto", Deadline: "2026-07-22T00:00:00Z", PreparedAt: "2026-07-21T00:00:00Z", CommittedAt: "2026-07-21T00:00:01Z", BaseRef: "main", BaseOID: strings.Repeat("d", 40)}
+}
+
+func terminalFor(request delivery.Request) delivery.Terminal {
+	return delivery.Terminal{BeadID: request.Target.SemanticBeadID, Ref: request.Target.SemanticTerminalRef, Verdict: "PASS", CertificateDigest: request.CertificateDigest}
+}
+
+func certificateFor(beadID string) delivery.AdmissionCertificate {
+	noFallback := noFallbackProfile()
+	return delivery.AdmissionCertificate{SchemaVersion: "admission-certificate.v2", SemanticBeadID: beadID, IntentDigest: strings.Repeat("a", 64), Verdict: "PASS", Candidate: delivery.Candidate{Commit: strings.Repeat("a", 40), Tree: strings.Repeat("b", 40), ContentDigest: strings.Repeat("c", 64)}, Store: delivery.Store{Identity: "beads", Digest: strings.Repeat("d", 64)}, ChangedPathManifest: strings.Repeat("e", 64), VerdictDigest: strings.Repeat("f", 64), EvidenceDigest: strings.Repeat("0", 64), Attestations: delivery.Attestations{Author: delivery.Runtime{ContextID: "author", RequestedModel: "terra", RequestedReasoning: "high", RequestedProvider: "codex", ActualModel: "gpt-5.6-terra", ActualReasoning: "high", ActualProvider: "codex", ActualEffort: "high", Fallback: noFallback}, Validator: delivery.Runtime{ContextID: "validator", RequestedModel: "sol", RequestedReasoning: "high", RequestedProvider: "codex", ActualModel: "gpt-5.6-sol", ActualReasoning: "high", ActualProvider: "codex", ActualEffort: "high", Fallback: noFallback}}, DeliveryGroupID: "group", PrefixSafety: "safe"}
+}
+
+func noFallbackProfile() *delivery.Fallback {
+	allowed, used := false, false
+	return &delivery.Fallback{Allowed: &allowed, Used: &used, Reason: json.RawMessage("null")}
+}

--- a/docs/architecture/gas-city-factory.md
+++ b/docs/architecture/gas-city-factory.md
@@ -110,7 +110,7 @@ worker pool, or base/main mutex.
 | Session | A disposable live process for one configured agent identity or pool member |
 | Packet | One explicit AgentOps Implement or Validate request with exact identity and boundaries |
 | Experiment | One bounded Implement plus fresh Validate cycle ending in a durable result |
-| Program graph | Mayor proposal that admission atomically materializes as program, semantic experiment, dependency, and linked delivery beads |
+| Program graph | Mayor proposal that admission atomically materializes program, semantic experiment, and dependency beads; a linked delivery bead is created only after the exact semantic PASS terminal and admission certificate are observable |
 | Admission certificate | Deterministic reference proving that exact component verdicts satisfy intake policy |
 | Delivery record | Immutable effect and epoch evidence connecting one admitted candidate, delivery state, and landed SHA; the linked delivery bead remains lifecycle truth |
 

--- a/docs/plans/2026-07-17-gas-city-factory-operationalization.md
+++ b/docs/plans/2026-07-17-gas-city-factory-operationalization.md
@@ -290,9 +290,10 @@ Implementation is limited to these ownership classes:
 
 - AgentOps GC deployment sources under `deploy/gc/`, including lock/provenance,
   bootstrap, teardown, reliability, and their generated qualification outputs;
-- focused `ao gc delivery` command and internal Go packages under `cli/cmd/ao/`
-  and `cli/internal/`, plus the generated command documentation owned by that
-  surface;
+- focused optional `agentops-gc-delivery` binary and its one typed adapter
+  package under `cli/cmd/agentops-gc-delivery/` and
+  `cli/internal/gcadapter/delivery/`; it is pack-selected delivery policy, not
+  an `ao` command or default-installed surface;
 - the `agentops-factory` and thin `agentops-executor` pack sources, including
   pack-generated schemas, command projections, role prompts, and doctor checks;
 - Gas City architecture, execution-adapter, operations, release, migration,
@@ -346,7 +347,7 @@ to change in one run.
 | GC33-3 Role pack | Install only the approved Fable/Sol/Terra/Opus/Luna matrix, native sling/claim paths, and exact runtime attestation. |
 | GC33-4 Isolation/routing | Prove disjoint width-two writers, conflict-domain serialization, worktree/process containment, writer-pool capacity policy, disjoint delivery/ambiguity schemas, construction-interleaving safety, composed-config predicate isolation, and zero clean-path Refiner wakes. |
 | GC33-5 Merge selection | Record forge protection and distinct identity authority; run bounded controller-merge versus forge-auto conformance probes on protected fixture branches; select exactly one engine and delete the loser. |
-| GC33-6 Thin vertical slice | Implement certificate -> prepared handoff -> non-routable linked bead -> committed publication -> fake-forge branch preparation -> PR create/adopt. Enforce the complexity and prohibited-surface tripwires before continuing. |
+| GC33-6 Thin vertical slice | Implement the separately built optional `agentops-gc-delivery` adapter: exact certificate bytes -> prepared handoff -> route-empty linked bead -> validated published payload -> committed marker -> exact delivery route -> fake branch -> fake PR. The rig-scoped cooldown Order invokes one reducer transition through explicit pinned reducer and `GC_BIN` paths. No `ao gc`, default install, real forge, CI, moving-main, merge, daemon, or scheduler; enforce the complexity tripwire before continuing. |
 | GC33-7 Crash-only Refinery | Complete the typed one-step reducer, moving-main epochs, current-base gates, PR adoption, selected merge actor, landed verification, auto/manual modes, liveness, repair/fresh-verdict, successor, and bounded infrastructure lanes. Port only allowlisted helpers and delete the old lifecycle center and obsolete routes before qualification. |
 | GC33-8 OTel baseline | Enable both native signal paths, reachability/degraded policy, and qualification receipts without making telemetry lifecycle authority. |
 | GC33-9 External qualification | Run deterministic transition, handoff, route, Git/forge, authority, replay, deadline, provenance-differential, inventory/deletion, kill-anywhere, and cold-resurrection gates from clean external Codex/shell. Qualification fails if opposite-provider binding validation, integration-train lifecycle, clean-rebase Sol revalidation, or other superseded v17 authority remains normative. Generate and verify the exact-subject qualification capsule. |

--- a/packs/agentops-executor/agents/implementer-claude/prompt.template.md
+++ b/packs/agentops-executor/agents/implementer-claude/prompt.template.md
@@ -6,13 +6,9 @@ envelope was handled; it is not an AgentOps verdict or completion claim.
 
 ## Start
 
-1. Require the deployment-pinned binary with `test -x "$GC_BIN"`, then run
-   `"$GC_BIN" hook --claim --drain-ack --json` exactly once.
-2. Exit only if it explicitly reports `action=drain, reason=no_work`.
-   `action=work`, `claimed`, or `existing_assignment` always means a packet was
-   assigned. If output display is delayed or ambiguous, use the nonempty
-   `$GC_TRIGGER_WORK_BEAD_ID` as the transport bead ID and continue; never
-   reinterpret it as no work.
+1. Run `gc agentops claim` exactly once; it is the only authorized claim path.
+2. Exit only for normalized `action=drain, reason=no_work`. Normalized
+   `action=assigned` carries the exact bead ID; `uncertain` stops fail-closed.
 3. Record the returned transport bead ID. Read the bead description to obtain
    the absolute adapter path, packet path, and packet digest. If the hook
    response omits the description, require nonempty `$GC_RIG`, then run

--- a/packs/agentops-executor/agents/implementer/prompt.template.md
+++ b/packs/agentops-executor/agents/implementer/prompt.template.md
@@ -6,13 +6,9 @@ envelope was handled; it is not an AgentOps verdict or completion claim.
 
 ## Start
 
-1. Require the deployment-pinned binary with `test -x "$GC_BIN"`, then run
-   `"$GC_BIN" hook --claim --drain-ack --json` exactly once.
-2. Exit only if it explicitly reports `action=drain, reason=no_work`.
-   `action=work`, `claimed`, or `existing_assignment` always means a packet was
-   assigned. If output display is delayed or ambiguous, use the nonempty
-   `$GC_TRIGGER_WORK_BEAD_ID` as the transport bead ID and continue; never
-   reinterpret it as no work.
+1. Run `gc agentops claim` exactly once; it is the only authorized claim path.
+2. Exit only for normalized `action=drain, reason=no_work`. Normalized
+   `action=assigned` carries the exact bead ID; `uncertain` stops fail-closed.
 3. Record the returned transport bead ID. Read the bead description to obtain
    the absolute adapter path, packet path, and packet digest. If the hook
    response omits the description, require nonempty `$GC_RIG`, then run

--- a/packs/agentops-executor/agents/validator/prompt.template.md
+++ b/packs/agentops-executor/agents/validator/prompt.template.md
@@ -6,13 +6,9 @@ only the assigned `validate` skill may write `verdict.v2`.
 
 ## Start
 
-1. Require the deployment-pinned binary with `test -x "$GC_BIN"`, then run
-   `"$GC_BIN" hook --claim --drain-ack --json` exactly once.
-2. Exit only if it explicitly reports `action=drain, reason=no_work`.
-   `action=work`, `claimed`, or `existing_assignment` always means a packet was
-   assigned. If output display is delayed or ambiguous, use the nonempty
-   `$GC_TRIGGER_WORK_BEAD_ID` as the transport bead ID and continue; never
-   reinterpret it as no work.
+1. Run `gc agentops claim` exactly once; it is the only authorized claim path.
+2. Exit only for normalized `action=drain, reason=no_work`. Normalized
+   `action=assigned` carries the exact bead ID; `uncertain` stops fail-closed.
 3. Record the returned transport bead ID. Read the bead description to obtain
    the absolute adapter path, packet path, and packet digest. If the hook
    response omits the description, require nonempty `$GC_RIG`, then run

--- a/packs/agentops-executor/assets/scripts/claim.py
+++ b/packs/agentops-executor/assets/scripts/claim.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""One-shot fail-closed wrapper for the native GC hook claim protocol."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+
+def fail(code: str, message: str) -> int:
+    print(json.dumps({"schema_version": "agentops-claim.v1", "ok": False, "action": "uncertain", "reason": code, "message": message}, sort_keys=True))
+    return 1
+
+
+def main() -> int:
+    gc = os.environ.get("GC_BIN", "")
+    if not gc.startswith("/") or not os.access(gc, os.X_OK):
+        return fail("invalid_gc_bin", "GC_BIN must be an absolute executable path")
+    result = subprocess.run([gc, "hook", "--claim", "--drain-ack", "--json"], text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        return fail("hook_nonzero", result.stderr.strip() or "hook claim failed")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return fail("hook_invalid_json", "hook claim did not emit one JSON object")
+    required = {"schema_version", "ok", "command", "action", "reason"}
+    optional = {"bead_id", "assignee", "route", "root_bead_id", "continuation_group", "continuation_assigned", "drain_acknowledged"}
+    if not isinstance(value, dict) or not required.issubset(value) or set(value) - required - optional or value.get("schema_version") != "1" or value.get("ok") is not True or value.get("command") != "hook" or not isinstance(value.get("action"), str) or not isinstance(value.get("reason"), str):
+        return fail("hook_schema", "hook result is not the official hook schema")
+    if any(not isinstance(value[key], str) for key in {"bead_id", "assignee", "route", "root_bead_id", "continuation_group"} & set(value)) or ("continuation_assigned" in value and (not isinstance(value["continuation_assigned"], list) or any(not isinstance(item, str) for item in value["continuation_assigned"]))) or ("drain_acknowledged" in value and not isinstance(value["drain_acknowledged"], bool)):
+        return fail("hook_schema", "hook optional fields have invalid types")
+    if value["action"] == "drain" and value["reason"] == "no_work" and value.get("drain_acknowledged") is True and "bead_id" not in value and "assignee" not in value:
+        output = {"schema_version": "agentops-claim.v1", "ok": True, "action": "drain", "reason": "no_work"}
+    elif value["action"] == "work" and value["reason"] in {"claimed", "existing_assignment", "ready_assignment"} and isinstance(value.get("bead_id"), str) and value["bead_id"] and isinstance(value.get("assignee"), str) and value["assignee"]:
+        output = {"schema_version": "agentops-claim.v1", "ok": True, "action": "assigned", "reason": value["reason"], "bead_id": value["bead_id"], "assignee": value["assignee"]}
+    else:
+        return fail("hook_ambiguous", "hook result is not an exact assigned or no-work result")
+    print(json.dumps(output, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packs/agentops-executor/commands/claim/command.toml
+++ b/packs/agentops-executor/commands/claim/command.toml
@@ -1,0 +1,2 @@
+description = "Claim exactly one GC transport bead through the centralized AgentOps protocol"
+command = ["claim"]

--- a/packs/agentops-executor/commands/claim/help.md
+++ b/packs/agentops-executor/commands/claim/help.md
@@ -1,0 +1,7 @@
+# Claim one transport bead
+
+`gc agentops claim` invokes the deployment-pinned absolute `GC_BIN hook --claim
+--drain-ack --json` exactly once. It accepts only the exact `{action,reason}`
+hook schema, returns normalized `assigned` or `drain/no_work`, and fails closed
+as `uncertain` for every nonzero, malformed, or ambiguous result. It never
+retries or selects another bead.

--- a/packs/agentops-executor/commands/claim/run.sh
+++ b/packs/agentops-executor/commands/claim/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PACK_DIR="${GC_PACK_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+exec python3 "$PACK_DIR/assets/scripts/claim.py"

--- a/packs/agentops-factory/agents/mayor/prompt.template.md
+++ b/packs/agentops-factory/agents/mayor/prompt.template.md
@@ -8,14 +8,10 @@ an effort flag for Claude Fable 5.
 
 ## Handle one request
 
-1. Run `test -x "$GC_BIN"` as its own command, then run
-   `"$GC_BIN" hook --claim --drain-ack --json` exactly once. Do not run
+1. Run `gc agentops claim` exactly once. Do not run
    `gc prime`, combine the claim with another command, or repeat the claim after
-   either `claimed` or `existing_assignment`; the startup prompt is complete.
-   `action=work` or either of those reasons always means work was assigned. If
-   the JSON display is delayed or ambiguous, use the nonempty
-   `$GC_TRIGGER_WORK_BEAD_ID` as the claimed ID and continue with `bd show`.
-   Exit for emptiness only on explicit `action=drain, reason=no_work`.
+   normalized `action=assigned`; use its returned bead ID and assignee exactly.
+   Exit only for normalized `action=drain, reason=no_work`; `uncertain` stops fail-closed and never retries.
 2. Read the assigned planning bead with
    `"$GC_BIN" bd show <claimed-bead-id> --json`. Do not use `gc work show` or
    any generic task picker. Obtain `adapter_path` and `request_path` only from

--- a/packs/agentops-factory/agents/plan-reviewer/prompt.template.md
+++ b/packs/agentops-factory/agents/plan-reviewer/prompt.template.md
@@ -5,12 +5,10 @@ write only the requested plan-binding artifact. You do not edit product bytes,
 repair, dispatch work, implement, validate candidates, mutate graph state, or
 issue a validation verdict.
 
-Before reading skills or repository context, require `test -x "$GC_BIN"` and
-run `"$GC_BIN" hook --claim --drain-ack --json` exactly once. If it reports no
-work with explicit `action=drain, reason=no_work`, exit. `action=work`,
-`claimed`, or `existing_assignment` always means work was assigned. If output
-display is ambiguous, use nonempty `$GC_TRIGGER_WORK_BEAD_ID` as the claimed
-ID; never reinterpret it as no work. Never substitute `gc status`, `gc inbox`,
+Before reading skills or repository context, run `gc agentops claim` exactly once. If it reports no
+work with normalized `action=drain, reason=no_work`, exit. Normalized
+`action=assigned` means work was assigned; use its exact bead ID. `uncertain`
+stops fail-closed and never retries or means no work. Never substitute `gc status`, `gc inbox`,
 or a generic task picker for this claim. Read the bead with
 `"$GC_BIN" bd --rig "$GC_RIG" show <claimed-bead-id> --json`; do not use `gc work show`.
 Obtain `adapter_path` and `request_path` from the claimed bead's description,

--- a/packs/agentops-factory/agents/refiner/prompt.template.md
+++ b/packs/agentops-factory/agents/refiner/prompt.template.md
@@ -9,11 +9,10 @@ Do not invent or report an effort flag for Fable.
 
 ## Handle one request
 
-1. Require the deployment-pinned binary with `test -x "$GC_BIN"`, then run
-   `"$GC_BIN" hook --claim --drain-ack --json` exactly once. Exit only for an
-   explicit `action=drain, reason=no_work`. Treat `action=work`, `claimed`, or
-   `existing_assignment` as assigned work. If display is ambiguous, use the
-   nonempty `$GC_TRIGGER_WORK_BEAD_ID`; never claim a second bead.
+1. Run `gc agentops claim` exactly once. Exit only for an
+   normalized `action=drain, reason=no_work`. Treat normalized `action=assigned`
+   as assigned work; use its exact bead ID. `uncertain` stops fail-closed,
+   never retries, and never means no work.
 2. Read only that bead with `"$GC_BIN" bd --rig "$GC_RIG" show <claimed-bead-id> --json`.
    Obtain the absolute adapter and request paths only from the bead. Run
    `python3 <adapter_path> inspect-role-v2 --request <request_path>` and refuse

--- a/packs/agentops-factory/assets/schemas/branch-receipt.v1.schema.json
+++ b/packs/agentops-factory/assets/schemas/branch-receipt.v1.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentops.local/schemas/branch-receipt.v1.schema.json",
+  "title": "GC33 immutable branch preparation receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "handoff_id", "epoch", "rig_id", "repository", "remote", "branch", "base_ref", "base_oid", "expected_head", "outcome", "response_digest"],
+  "properties": {
+    "schema_version": {"const": "branch-receipt.v1"},
+    "handoff_id": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "epoch": {"type": "integer", "minimum": 1},
+    "rig_id": {"type": "string", "minLength": 1},
+    "repository": {"type": "string", "minLength": 1},
+    "remote": {"type": "string", "minLength": 1},
+    "branch": {"type": "string", "minLength": 1},
+    "base_ref": {"type": "string", "minLength": 1},
+    "base_oid": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "expected_head": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "outcome": {"enum": ["created", "adopted"]},
+    "response_digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+  }
+}

--- a/packs/agentops-factory/assets/schemas/pr-open-receipt.v1.schema.json
+++ b/packs/agentops-factory/assets/schemas/pr-open-receipt.v1.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentops.local/schemas/pr-open-receipt.v1.schema.json",
+  "title": "GC33 immutable forge PR open/adopt receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "handoff_id", "epoch", "rig_id", "repository", "remote", "pr_id", "branch", "base_ref", "base_oid", "expected_head", "effect_id", "outcome", "response_digest"],
+  "properties": {
+    "schema_version": {"const": "pr-open-receipt.v1"},
+    "handoff_id": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "epoch": {"type": "integer", "minimum": 1},
+    "rig_id": {"type": "string", "minLength": 1},
+    "repository": {"type": "string", "minLength": 1},
+    "remote": {"type": "string", "minLength": 1},
+    "pr_id": {"type": "string", "minLength": 1},
+    "branch": {"type": "string", "minLength": 1},
+    "base_ref": {"type": "string", "minLength": 1},
+    "base_oid": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "expected_head": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "effect_id": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "outcome": {"enum": ["created", "adopted"]},
+    "response_digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+  }
+}

--- a/packs/agentops-factory/assets/scripts/delivery-step.sh
+++ b/packs/agentops-factory/assets/scripts/delivery-step.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The Order owns only the periodic trigger. The separately pinned reducer owns
+# one transition; it never receives an event wake and never runs a loop here.
+: "${AGENTOPS_GC_DELIVERY_BIN:?absolute pack-selected reducer binary required}"
+: "${GC_BIN:?deployment-pinned Gas City binary required}"
+: "${AGENTOPS_GC_DELIVERY_ROOT:?rig-scoped evidence root required}"
+: "${AGENTOPS_GC_DELIVERY_CERTIFICATE:?exact certificate path required}"
+: "${AGENTOPS_GC_DELIVERY_SEMANTIC_BEAD:?semantic bead required}"
+: "${AGENTOPS_GC_DELIVERY_TERMINAL_REF:?terminal ref required}"
+: "${AGENTOPS_GC_DELIVERY_RIG:?rig identity required}"
+: "${AGENTOPS_GC_DELIVERY_REPOSITORY:?repository identity required}"
+: "${AGENTOPS_GC_DELIVERY_REMOTE:?remote identity required}"
+: "${AGENTOPS_GC_DELIVERY_EPOCH:?epoch required}"
+: "${AGENTOPS_GC_DELIVERY_MODE:?mode required}"
+: "${AGENTOPS_GC_DELIVERY_DEADLINE:?deadline required}"
+: "${AGENTOPS_GC_DELIVERY_PREPARED_AT:?prepared timestamp required}"
+: "${AGENTOPS_GC_DELIVERY_COMMITTED_AT:?committed timestamp required}"
+: "${AGENTOPS_GC_DELIVERY_BASE_REF:?base ref required}"
+: "${AGENTOPS_GC_DELIVERY_BASE_OID:?base oid required}"
+: "${AGENTOPS_GC_DELIVERY_FAKE_TERMINAL_REF:?GC33-6 fake boundary terminal ref required}"
+[[ "$AGENTOPS_GC_DELIVERY_BIN" = /* && -x "$AGENTOPS_GC_DELIVERY_BIN" ]] || { echo "AGENTOPS_GC_DELIVERY_BIN must be an absolute executable" >&2; exit 2; }
+[[ "$GC_BIN" = /* && -x "$GC_BIN" ]] || { echo "GC_BIN must be an absolute executable" >&2; exit 2; }
+: "${AGENTOPS_GC_DELIVERY_FIXTURE_STATE:?explicit offline fixture state required in GC33-6}"
+
+exec "$AGENTOPS_GC_DELIVERY_BIN" step \
+  --root "$AGENTOPS_GC_DELIVERY_ROOT" --certificate "$AGENTOPS_GC_DELIVERY_CERTIFICATE" \
+  --semantic-bead "$AGENTOPS_GC_DELIVERY_SEMANTIC_BEAD" --terminal-ref "$AGENTOPS_GC_DELIVERY_TERMINAL_REF" \
+  --rig "$AGENTOPS_GC_DELIVERY_RIG" --repository "$AGENTOPS_GC_DELIVERY_REPOSITORY" --remote "$AGENTOPS_GC_DELIVERY_REMOTE" \
+  --epoch "$AGENTOPS_GC_DELIVERY_EPOCH" --mode "$AGENTOPS_GC_DELIVERY_MODE" --deadline "$AGENTOPS_GC_DELIVERY_DEADLINE" \
+  --prepared-at "$AGENTOPS_GC_DELIVERY_PREPARED_AT" --committed-at "$AGENTOPS_GC_DELIVERY_COMMITTED_AT" \
+  --base-ref "$AGENTOPS_GC_DELIVERY_BASE_REF" --base-oid "$AGENTOPS_GC_DELIVERY_BASE_OID" \
+  --fake-terminal-ref "$AGENTOPS_GC_DELIVERY_FAKE_TERMINAL_REF" --fixture-state "$AGENTOPS_GC_DELIVERY_FIXTURE_STATE"

--- a/packs/agentops-factory/commands/claim/command.toml
+++ b/packs/agentops-factory/commands/claim/command.toml
@@ -1,0 +1,2 @@
+description = "Proxy the single central AgentOps claim protocol through the factory binding"
+command = ["claim"]

--- a/packs/agentops-factory/commands/claim/help.md
+++ b/packs/agentops-factory/commands/claim/help.md
@@ -1,0 +1,4 @@
+# Claim one transport bead
+
+This factory-binding proxy delegates to the one executor-owned AgentOps claim
+protocol. It adds no retry, schema, or provider behavior.

--- a/packs/agentops-factory/commands/claim/run.sh
+++ b/packs/agentops-factory/commands/claim/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PACK_DIR="${GC_PACK_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+exec python3 "$PACK_DIR/../agentops-executor/assets/scripts/claim.py"

--- a/packs/agentops-factory/commands/delivery-step/command.toml
+++ b/packs/agentops-factory/commands/delivery-step/command.toml
@@ -1,0 +1,2 @@
+description = "Advance exactly one caller-selected AgentOps GC delivery transition"
+command = ["delivery"]

--- a/packs/agentops-factory/commands/delivery-step/help.md
+++ b/packs/agentops-factory/commands/delivery-step/help.md
@@ -1,0 +1,6 @@
+# Advance one delivery transition
+
+This optional pack command invokes exactly one crash-only reducer transition.
+It requires explicit deployment-pinned `AGENTOPS_GC_DELIVERY_BIN` and `GC_BIN`
+paths plus the rig-scoped identity environment. It does not start a city, route
+semantic work, or run a delivery loop.

--- a/packs/agentops-factory/commands/delivery-step/run.sh
+++ b/packs/agentops-factory/commands/delivery-step/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PACK_DIR="${GC_PACK_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+exec "$PACK_DIR/assets/scripts/delivery-step.sh"

--- a/packs/agentops-factory/formulas/agentops-build.toml
+++ b/packs/agentops-factory/formulas/agentops-build.toml
@@ -1,0 +1,22 @@
+formula = "agentops-build"
+description = "Compile an admitted AgentOps build into separately drained experiment units."
+
+[requires]
+formula_compiler = ">=2.0.0"
+
+[[steps]]
+id = "admit"
+title = "Admit the caller-supplied build graph"
+metadata = { "gc.run_target" = "agentops.mayor" }
+
+[[steps]]
+id = "drain-experiments"
+title = "Drain admitted experiment units into isolated sessions"
+needs = ["admit"]
+metadata = { "gc.run_target" = "agentops.implementer" }
+
+[steps.drain]
+context = "separate"
+formula = "agentops-experiment"
+member_access = "exclusive"
+max_units = 20

--- a/packs/agentops-factory/formulas/agentops-experiment.toml
+++ b/packs/agentops-factory/formulas/agentops-experiment.toml
@@ -1,0 +1,16 @@
+formula = "agentops-experiment"
+description = "Run one already-admitted AgentOps experiment with the selected cohort target."
+
+[requires]
+formula_compiler = ">=2.0.0"
+
+[[steps]]
+id = "execute"
+title = "Execute one admitted experiment"
+metadata = { "gc.run_target" = "agentops.implementer" }
+
+[[steps]]
+id = "validate"
+title = "Fresh Sol validation for the exact subject"
+needs = ["execute"]
+metadata = { "gc.run_target" = "agentops.validator" }

--- a/packs/agentops-factory/orders/agentops-delivery-sweep.toml
+++ b/packs/agentops-factory/orders/agentops-delivery-sweep.toml
@@ -1,0 +1,9 @@
+[order]
+description = "Advance one rig-scoped AgentOps delivery reducer transition; this is intentionally non-idempotent."
+exec = "$PACK_DIR/assets/scripts/delivery-step.sh"
+scope = "rig"
+enabled = false
+idempotent = false
+trigger = "cooldown"
+interval = "30s"
+timeout = "60s"

--- a/tests/python/test_gc33_delivery_contracts.py
+++ b/tests/python/test_gc33_delivery_contracts.py
@@ -36,10 +36,42 @@ class GC33DeliveryContractTest(unittest.TestCase):
         return {"allowed": allowed, "used": used, "reason": reason}
 
     def test_every_33_schema_is_a_valid_draft_2020_12_schema(self) -> None:
-        names = ("program-graph.v2.schema.json", "admission-certificate.v2.schema.json", "handoff-prepared.v1.schema.json", "handoff-committed.v1.schema.json", "delivery.v1.schema.json", "ambiguity-request.v1.schema.json", "epoch-receipt.v1.schema.json", "effect-receipt.v1.schema.json", "factory-role-request.v2.schema.json", "factory-role-response.v2.schema.json")
+        names = ("program-graph.v2.schema.json", "admission-certificate.v2.schema.json", "handoff-prepared.v1.schema.json", "handoff-committed.v1.schema.json", "delivery.v1.schema.json", "branch-receipt.v1.schema.json", "pr-open-receipt.v1.schema.json", "ambiguity-request.v1.schema.json", "epoch-receipt.v1.schema.json", "effect-receipt.v1.schema.json", "factory-role-request.v2.schema.json", "factory-role-response.v2.schema.json")
         for name in names:
             with self.subTest(name=name):
                 Draft202012Validator.check_schema(self.load(name))
+
+    def test_branch_and_pr_receipts_bind_exact_target_identity(self) -> None:
+        branch = {"schema_version": "branch-receipt.v1", "handoff_id": DIGEST, "epoch": 1, "rig_id": "rig", "repository": "boshu2/agentops", "remote": "origin", "branch": "delivery/abc", "base_ref": "main", "base_oid": "a" * 40, "expected_head": "b" * 40, "outcome": "created", "response_digest": "c" * 64}
+        pr = {"schema_version": "pr-open-receipt.v1", "handoff_id": DIGEST, "epoch": 1, "rig_id": "rig", "repository": "boshu2/agentops", "remote": "origin", "pr_id": "pr-abc", "branch": "delivery/abc", "base_ref": "main", "base_oid": "a" * 40, "expected_head": "b" * 40, "effect_id": "d" * 64, "outcome": "adopted", "response_digest": "c" * 64}
+        self.assertTrue(self.validator("branch-receipt.v1.schema.json").is_valid(branch))
+        self.assertTrue(self.validator("pr-open-receipt.v1.schema.json").is_valid(pr))
+        for schema, payload in (("branch-receipt.v1.schema.json", branch), ("pr-open-receipt.v1.schema.json", pr)):
+            broken = deepcopy(payload); broken["invented"] = True
+            self.assertFalse(self.validator(schema).is_valid(broken))
+
+    def test_native_formula_and_one_step_order_surfaces_remain_pack_owned(self) -> None:
+        pack = ROOT / "packs" / "agentops-factory"
+        build = (pack / "formulas" / "agentops-build.toml").read_text(encoding="utf-8")
+        experiment = (pack / "formulas" / "agentops-experiment.toml").read_text(encoding="utf-8")
+        order = (pack / "orders" / "agentops-delivery-sweep.toml").read_text(encoding="utf-8")
+        script = (pack / "assets" / "scripts" / "delivery-step.sh").read_text(encoding="utf-8")
+        command = (pack / "commands" / "delivery-step" / "command.toml").read_text(encoding="utf-8")
+        self.assertIn('formula = "agentops-build"', build)
+        self.assertIn('formula = "agentops-experiment"', build)
+        self.assertIn('context = "separate"', build)
+        self.assertIn('max_units = 20', build)
+        self.assertIn('formula = "agentops-experiment"', experiment)
+        self.assertIn('command = ["delivery"]', command)
+        self.assertIn('trigger = "cooldown"', order)
+        self.assertIn('enabled = false', order)
+        self.assertIn('idempotent = false', order)
+        self.assertIn('AGENTOPS_GC_DELIVERY_BIN', script)
+        self.assertIn('GC_BIN', script)
+        self.assertIn('FIXTURE_STATE', script)
+        self.assertIn('must be an absolute executable', script)
+        self.assertNotIn('factory.py', script)
+        self.assertNotIn('ao gc', script)
 
     def test_actual_marker_artifacts_are_schema_conformant(self) -> None:
         cases = (("handoff-prepared.v1.schema.json", self.prepared()), ("delivery.v1.schema.json", self.delivery()), ("delivery.v1.schema.json", self.delivery("published")), ("handoff-committed.v1.schema.json", self.committed()))

--- a/tests/python/test_gc33_role_pack.py
+++ b/tests/python/test_gc33_role_pack.py
@@ -9,6 +9,8 @@ from copy import deepcopy
 from pathlib import Path
 import tempfile
 import unittest
+import os
+import subprocess
 from unittest import mock
 
 from jsonschema import Draft202012Validator
@@ -44,6 +46,34 @@ def graph() -> dict:
 
 
 class GC33RolePackTest(unittest.TestCase):
+    def test_central_claim_is_one_shot_and_fails_closed(self) -> None:
+        claim = ROOT / "packs/agentops-executor/assets/scripts/claim.py"
+        self.assertIn('command = ["claim"]', (ROOT / "packs/agentops-executor/commands/claim/command.toml").read_text(encoding="utf-8"))
+        self.assertIn('command = ["claim"]', (ROOT / "packs/agentops-factory/commands/claim/command.toml").read_text(encoding="utf-8"))
+        self.assertIn("../agentops-executor/assets/scripts/claim.py", (ROOT / "packs/agentops-factory/commands/claim/run.sh").read_text(encoding="utf-8"))
+        prompts = [ROOT / path for path in ("packs/agentops-executor/agents/implementer/prompt.template.md", "packs/agentops-executor/agents/implementer-claude/prompt.template.md", "packs/agentops-executor/agents/validator/prompt.template.md", "packs/agentops-factory/agents/mayor/prompt.template.md", "packs/agentops-factory/agents/plan-reviewer/prompt.template.md", "packs/agentops-factory/agents/refiner/prompt.template.md")]
+        for prompt in prompts:
+            body = prompt.read_text(encoding="utf-8")
+            self.assertIn("gc agentops claim", body)
+            self.assertNotIn("hook --claim", body)
+            self.assertNotIn("action=work", body)
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory); calls = root / "calls"; fake = root / "gc"
+            fake.write_text("#!/usr/bin/env bash\necho x >> \"$GC_FAKE_CALLS\"\nprintf '%s' \"$GC_FAKE_OUTPUT\"\nexit \"${GC_FAKE_EXIT:-0}\"\n", encoding="utf-8")
+            fake.chmod(0o755)
+            base = {"GC_BIN": str(fake), "GC_FAKE_CALLS": str(calls)}
+            work = '{"schema_version":"1","ok":true,"command":"hook","action":"work","reason":"claimed","bead_id":"b-1","assignee":"agent"}'
+            ready = '{"schema_version":"1","ok":true,"command":"hook","action":"work","reason":"ready_assignment","bead_id":"b-1","assignee":"agent","route":"agentops"}'
+            drain = '{"schema_version":"1","ok":true,"command":"hook","action":"drain","reason":"no_work","drain_acknowledged":true}'
+            bad_extra = '{"schema_version":"1","ok":true,"command":"hook","action":"work","reason":"claimed","bead_id":"b-1","assignee":"agent","extra":true}'
+            for label, output, code, expected_ok, expected_action in (("assigned", work, "0", True, "assigned"), ("ready", ready, "0", True, "assigned"), ("drain", drain, "0", True, "drain"), ("extra", bad_extra, "0", False, "uncertain"), ("invalid", 'not-json', "0", False, "uncertain"), ("nonzero", work, "7", False, "uncertain")):
+                with self.subTest(label=label):
+                    calls.unlink(missing_ok=True)
+                    result = subprocess.run(["python3", str(claim)], env={**os.environ, **base, "GC_FAKE_OUTPUT": output, "GC_FAKE_EXIT": code}, text=True, capture_output=True, check=False)
+                    value = json.loads(result.stdout)
+                    self.assertEqual(value["ok"], expected_ok)
+                    self.assertEqual(value["action"], expected_action)
+                    self.assertEqual(calls.read_text(encoding="utf-8").count("x\n"), 1)
     def test_delivery_policy_is_absent_at_every_composition_boundary(self) -> None:
         factory_agents = ROOT / "packs/agentops-factory/agents"
         self.assertEqual({p.name for p in factory_agents.iterdir() if (p / "agent.toml").is_file()}, {"mayor", "plan-reviewer", "refiner"})


### PR DESCRIPTION
## Outcome

Adds the bounded GC33-6 delivery slice outside core ao: a separately built crash-only reducer, strict admission certificate binding, immutable handoff and branch/PR receipts, native graph.v2 formulas, one-step disabled Order glue, and one centralized stock claim wrapper.

Semantic bead: ag-agentops-33-gc-refinery-4km81.7 (closed after independent validation).
Binding PASS: d3ac5a566e0f5197814e2dbcf04d0540849f58636ed8bb49a0faca7d6af94639 over manifest 155a089b4b461bda61a7f1ad1987c66f5755ac7c5628aa648e70740be2580a5a.

## Verification

- Full cli Go suite: PASS (2,887 tests)
- Focused race-enabled reducer suite: PASS
- GC factory/executor Python contracts: PASS
- Full executor gate: PASS (123 Python + 25 Bats)
- Exact official GC v1.3.5 pack lint and no-start discovery: PASS
- Cold replay: exactly one delivery, branch, and PR; six emitted artifacts validate against shipped schemas
- Production Go surface: 922 lines, under 3,000 tripwire

## Boundaries

No ao command, core port, default install, live city, real Git/forge/CI/merge adapter, daemon, scheduler, or factory.py import. Real adapters and delivery completion remain GC33-7.