### PR TITLE
fix(skills): restore cc-hooks description budget

### DIFF
--- a/images/gemini/skills/cc-hooks/SKILL.md
+++ b/images/gemini/skills/cc-hooks/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
-description: 'Claude Code hooks and the AgentOps admission-control layer. Enforcement hooks ship by DEFAULT: the plugin auto-wires the policy dispatcher; skill copies carry scripts/install-hooks.sh. Injection hooks stay dead (#511). Triggers: "cc-hooks", "configure Claude Code hooks", "install hooks".'
+description: 'Configure default Claude Code enforcement hooks and opt-in injection recipes. Triggers: "cc-hooks", "configure Claude Code hooks", "install hooks".'
 practices:
 - pragmatic-programmer
 ---

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -369,8 +369,8 @@
     {
       "name": "cc-hooks",
       "source_skill": "skills/cc-hooks",
-      "source_hash": "1e17e091dea81183aef666cf27321f8f03992ef1cdcdfbc7b3890d842a474b51",
-      "generated_hash": "06a47649e0d36e8ec423031df8f769a181ea10f1d2bcc369063f9bf11017d227"
+      "source_hash": "07547a37d876995ae378c7a458c15c0edf9fef8d0f553c4b64fe89b7881dacde",
+      "generated_hash": "daf70aaf9e19555859ed14177ac44bcb7f29fe7a8e6377df63e5db3b6e62db2b"
     },
     {
       "name": "codebase-recon",

--- a/skills-codex/cc-hooks/.agentops-generated.json
+++ b/skills-codex/cc-hooks/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/cc-hooks",
   "layout": "modular",
-  "source_hash": "1e17e091dea81183aef666cf27321f8f03992ef1cdcdfbc7b3890d842a474b51",
-  "generated_hash": "06a47649e0d36e8ec423031df8f769a181ea10f1d2bcc369063f9bf11017d227"
+  "source_hash": "07547a37d876995ae378c7a458c15c0edf9fef8d0f553c4b64fe89b7881dacde",
+  "generated_hash": "daf70aaf9e19555859ed14177ac44bcb7f29fe7a8e6377df63e5db3b6e62db2b"
 }

--- a/skills-codex/cc-hooks/SKILL.md
+++ b/skills-codex/cc-hooks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-hooks
-description: Claude Code hooks and the AgentOps
+description: Configure default Claude Code enforcement
 ---
 # Claude Code Hooks
 

--- a/skills-codex/cc-hooks/prompt.md
+++ b/skills-codex/cc-hooks/prompt.md
@@ -1,6 +1,6 @@
 # cc-hooks
 
-Claude Code hooks and the AgentOps admission-control layer. Enforcement hooks ship by DEFAULT: the plugin auto-wires the policy dispatcher; skill copies carry scripts/install-hooks.sh. Injection hooks stay dead (#511). Triggers: "cc-hooks", "configure Claude Code hooks", "install hooks".
+Configure default Claude Code enforcement hooks and opt-in injection recipes. Triggers: "cc-hooks", "configure Claude Code hooks", "install hooks".
 
 ## Instructions
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -252,7 +252,7 @@
       "consumes": [],
       "context_rel": [],
       "dependencies": [],
-      "description": "Claude Code hooks and the AgentOps admission-control layer. Enforcement hooks ship by DEFAULT: the plugin auto-wires the policy dispatcher; skill copies carry scripts/install-hooks.sh. Injection hooks stay dead (#511). Triggers: \"cc-hooks\", \"configure Claude Code hooks\", \"install hooks\".",
+      "description": "Configure default Claude Code enforcement hooks and opt-in injection recipes. Triggers: \"cc-hooks\", \"configure Claude Code hooks\", \"install hooks\".",
       "disposition": "keep_specialist",
       "effects": [],
       "graph_root": false,

--- a/skills/cc-hooks/SKILL.md
+++ b/skills/cc-hooks/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
-description: 'Claude Code hooks and the AgentOps admission-control layer. Enforcement hooks ship by DEFAULT: the plugin auto-wires the policy dispatcher; skill copies carry scripts/install-hooks.sh. Injection hooks stay dead (#511). Triggers: "cc-hooks", "configure Claude Code hooks", "install hooks".'
+description: 'Configure default Claude Code enforcement hooks and opt-in injection recipes. Triggers: "cc-hooks", "configure Claude Code hooks", "install hooks".'
 practices:
 - pragmatic-programmer
 ---


### PR DESCRIPTION
## Summary
- shorten only the cc-hooks frontmatter description from 218 to 147 characters
- preserve shipped-by-default enforcement policy and all three triggers
- unblock the 3.3 release skill-budget gate

## Evidence
- `bash tests/skills/run-all.sh`
- fresh Sol-high binding verdict: PASS

Bead: age-4qw1.1