### PR TITLE
fix(gc): bind managed canary invocation

### DIFF
--- a/deploy/gc/README.md
+++ b/deploy/gc/README.md
@@ -173,9 +173,14 @@ makes delivery a condition of semantic bead closure.
 Start one bounded factory program through the imported pack command:
 
 ```sh
-gc --city /path/to/city agentops program start -- \
-  --source-bead age-example --max-parallel 2
+deploy/gc/invoke.sh --city /path/to/city -- agentops program start --source-bead age-example --max-parallel 2
 ```
+
+The managed invoker reads the bootstrap marker, verifies the exact recorded
+Gas City binary digest, selects the private supervisor, projects the effective
+telemetry pair (or explicit disabled state), and clears an ambient generic OTLP
+fallback. Its `--` is the wrapper boundary and is consumed; do not put another
+`--` between the discovered `program start` leaf and `--source-bead`.
 
 The command snapshots that exact source Bead once, freezes the first observed
 base OID for the program, runs Fable Mayor and fresh Sol plan binding, and then
@@ -210,6 +215,7 @@ recorded by bootstrap.
 | `deploy/gc/agents/*/agent.toml` | AgentOps source | Explicit suspended city agents that shadow GC's late implicit provider injection |
 | `deploy/gc/toolchain.lock.json` | AgentOps source | Accepted exact GC/Beads source pairs and their qualification state |
 | `deploy/gc/materialize-toolchain.sh` | AgentOps source | Fail-closed source checkout, canonical builds, runtime verification, and local receipt |
+| `deploy/gc/invoke.sh` | AgentOps source | Marker-bound operator invocation, private supervisor selection, exact GC digest, and effective telemetry environment |
 | `<city>/pack.toml` | `gc init`, then bootstrap | Current built-in pins plus the city-scoped `agentops` import |
 | `<city>/city.toml` | `gc init`, `gc rig add`, then bootstrap | Portable runtime policy, logical rig declaration, and rig-scoped `agentops` import |
 | `<city>/.gc/site.toml` | Gas City SDK/CLI | Machine-local workspace identity and physical rig path |
@@ -228,9 +234,7 @@ documented read-in-place case.
 After starting, inspect the deployment with the same isolated environment:
 
 ```sh
-GC_HOME=/Users/bo/dev/gc-agentops/.gc-home \
-GC_ISOLATED=1 \
-/path/to/gc --city /Users/bo/dev/gc-agentops status
+deploy/gc/invoke.sh --city /Users/bo/dev/gc-agentops -- status
 ```
 
 See `docs/contracts/gas-city-execution-adapter.md` for the semantic boundary

--- a/deploy/gc/invoke.sh
+++ b/deploy/gc/invoke.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# preamble-exempt: standalone managed-city invoker; intentionally runs outside a repo checkout.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  invoke.sh --city PATH -- GC_COMMAND [ARG...]
+
+Required:
+  --city PATH  City previously created by deploy/gc/bootstrap.sh
+  --           Explicit boundary before the Gas City command and its arguments
+
+This executes the exact gc binary recorded by the managed-city marker. It binds
+the city's private supervisor home and effective telemetry policy and removes an
+ambient generic OTLP fallback before invoking `gc --city PATH ...`.
+EOF
+}
+
+die() {
+  printf 'gc-agentops invoke: %s\n' "$*" >&2
+  exit 1
+}
+
+city=""
+boundary_seen=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --city)
+      [ "$#" -ge 2 ] || die "--city requires a path"
+      city="$2"
+      shift 2
+      ;;
+    --)
+      boundary_seen=1
+      shift
+      break
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "expected -- before the Gas City command; found: $1"
+      ;;
+  esac
+done
+
+[ -n "$city" ] || die "--city is required"
+[ "$boundary_seen" -eq 1 ] || die "expected -- before the Gas City command"
+[ "$#" -gt 0 ] || die "a Gas City command is required after --"
+command -v python3 >/dev/null 2>&1 || die "python3 is required"
+
+canonical_path() {
+  python3 - "$1" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(os.path.expanduser(sys.argv[1])))
+PY
+}
+
+city="$(canonical_path "$city")"
+marker="$city/.gc/agentops-bootstrap.json"
+[ -d "$city" ] || die "city directory does not exist: $city"
+[ -f "$marker" ] && [ ! -L "$marker" ] || \
+  die "refusing unmanaged city without a regular bootstrap marker: $city"
+
+marker_identity="$(python3 - "$marker" "$city" <<'PY'
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+marker_path, expected_city = sys.argv[1:]
+with open(marker_path, encoding="utf-8") as handle:
+    marker = json.load(handle)
+
+if marker.get("schema_version") != 5:
+    raise SystemExit("managed-city marker schema_version must be 5")
+if marker.get("state") != "ready":
+    raise SystemExit("managed-city marker state must be ready")
+actual_city = os.path.realpath(os.path.expanduser(str(marker.get("city", ""))))
+if actual_city != expected_city:
+    raise SystemExit(f"managed-city marker city mismatch: {actual_city!r} != {expected_city!r}")
+
+toolchain = marker.get("toolchain")
+gc = toolchain.get("gc") if isinstance(toolchain, dict) else None
+if not isinstance(gc, dict):
+    raise SystemExit("managed-city marker has no gc toolchain identity")
+gc_bin = gc.get("path")
+gc_sha256 = gc.get("sha256")
+if not isinstance(gc_bin, str) or not gc_bin.strip():
+    raise SystemExit("managed-city marker has no gc path")
+if (
+    not isinstance(gc_sha256, str)
+    or len(gc_sha256) != 64
+    or any(char not in "0123456789abcdef" for char in gc_sha256)
+):
+    raise SystemExit("managed-city marker has invalid gc sha256")
+
+telemetry = marker.get("telemetry")
+if not isinstance(telemetry, dict):
+    raise SystemExit("managed-city marker has no telemetry policy")
+mode = telemetry.get("mode")
+status = telemetry.get("status")
+metrics = telemetry.get("effective_metrics_url")
+logs = telemetry.get("effective_logs_url")
+if mode not in {"auto", "required", "off"}:
+    raise SystemExit("managed-city marker has invalid telemetry mode")
+if status not in {"enabled", "degraded", "off"}:
+    raise SystemExit("managed-city marker has invalid telemetry status")
+if (mode, status) not in {
+    ("auto", "enabled"),
+    ("auto", "degraded"),
+    ("required", "enabled"),
+    ("off", "off"),
+}:
+    raise SystemExit("managed-city marker has inconsistent telemetry mode and status")
+if not isinstance(metrics, str) or not isinstance(logs, str):
+    raise SystemExit("managed-city marker telemetry endpoints must be strings")
+if status == "enabled":
+    if mode == "off" or not metrics or not logs:
+        raise SystemExit("enabled telemetry requires two effective endpoints")
+    for label, value in (("metrics", metrics), ("logs", logs)):
+        parsed = urlparse(value)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise SystemExit(f"managed-city marker has invalid {label} endpoint")
+elif metrics or logs:
+    raise SystemExit("disabled or degraded telemetry cannot have effective endpoints")
+if mode == "required" and status != "enabled":
+    raise SystemExit("required telemetry must be enabled")
+if mode == "off" and status != "off":
+    raise SystemExit("off telemetry must have off status")
+
+values = (
+    os.path.realpath(os.path.expanduser(gc_bin)),
+    gc_sha256,
+    mode,
+    status,
+    metrics,
+    logs,
+)
+if any("\x1f" in value or "\n" in value or "\r" in value for value in values):
+    raise SystemExit("managed-city marker contains unsafe control characters")
+print("\x1f".join(values))
+PY
+)" || die "invalid managed-city marker: $marker"
+IFS=$'\x1f' read -r gc_bin gc_sha256 telemetry_mode telemetry_status metrics_url logs_url <<<"$marker_identity"
+[ "$telemetry_mode" != "required" ] || [ "$telemetry_status" = "enabled" ] || \
+  die "required telemetry is not enabled"
+
+[ -x "$gc_bin" ] || die "managed gc binary is not executable: $gc_bin"
+actual_gc_sha256="$(python3 - "$gc_bin" <<'PY'
+import hashlib
+import sys
+
+digest = hashlib.sha256()
+with open(sys.argv[1], "rb") as handle:
+    for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+        digest.update(chunk)
+print(digest.hexdigest())
+PY
+)"
+[ "$actual_gc_sha256" = "$gc_sha256" ] || \
+  die "managed gc binary digest mismatch: $actual_gc_sha256 != $gc_sha256"
+
+export GC_HOME="$city/.gc-home"
+export GC_ISOLATED=1
+export GC_BIN="$gc_bin"
+export OTEL_EXPORTER_OTLP_ENDPOINT=""
+unset OTEL_EXPORTER_OTLP_METRICS_ENDPOINT OTEL_EXPORTER_OTLP_LOGS_ENDPOINT || true
+
+if [ "$telemetry_status" = "enabled" ]; then
+  export OTEL_SDK_DISABLED=false
+  export GC_OTEL_METRICS_URL="$metrics_url"
+  export GC_OTEL_LOGS_URL="$logs_url"
+  export BD_OTEL_METRICS_URL="$metrics_url"
+  export BD_OTEL_LOGS_URL="$logs_url"
+else
+  export OTEL_SDK_DISABLED=true
+  export GC_OTEL_METRICS_URL=""
+  export GC_OTEL_LOGS_URL=""
+  export BD_OTEL_METRICS_URL=""
+  export BD_OTEL_LOGS_URL=""
+fi
+
+exec "$gc_bin" --city "$city" "$@"

--- a/deploy/gc/known-errors.json
+++ b/deploy/gc/known-errors.json
@@ -267,12 +267,12 @@
       "reproduction": "Run status with that explicit telemetry configuration while the endpoint is closed.",
       "owner": "agentops",
       "fix_location": "AgentOps deployment telemetry configuration or optional-collector policy",
-      "build": "No build.",
-      "deterministic_test": "Bootstrap/resolved-config test must declare whether telemetry is disabled or reachable.",
-      "live_check": "No telemetry error during the bounded clean canary, or explicit disabled state.",
+      "build": "deploy/gc/invoke.sh reads the schema-5 bootstrap marker, verifies the exact GC digest, selects the private supervisor, projects the effective GC/BD signal pair or explicit disabled state, and clears the ambient generic OTLP fallback.",
+      "deterministic_test": "gc-agentops-invoke.bats seeds a conflicting localhost:4318 ambient endpoint and proves exact marker-bound GC/BD metrics/logs URLs, disabled-mode behavior, binary identity, and discovered-command argument forwarding.",
+      "live_check": "The bounded clean canary must use the managed invoker and produce native metrics/logs at the marker-bound endpoints without an ambient 4318 error.",
       "upstream": "Not a Gas City core or Beads defect.",
       "release_relevance": "3.3 OTel gate must either collect at the declared endpoint or prove an explicit intentional disabled state.",
-      "disposition": "Resolve in AgentOps configuration before live qualification."
+      "disposition": "Resolved in the AgentOps managed invocation boundary; direct ambient gc invocation remains outside the qualified deployment path."
     },
     {
       "id": "environment-production-rig-reserved-dolt-database",

--- a/docs/audits/gas-city-factory-live-bead-canary.md
+++ b/docs/audits/gas-city-factory-live-bead-canary.md
@@ -78,6 +78,25 @@ Dolt service, tmux socket, and city-scoped processes cleanly.
 
 ## Qualification boundary
 
+### 3.3 release canary entrypoint stop
+
+The first post-merge 3.3 release-canary entrypoint stopped before admission on
+2026-07-22. The exact landed subject was `faff55ac2a6df3fd862be100ff46df9f568bbb2c`
+with official GC `8ffc009ded781a2ada2077f3a29bd712b2def0bf` and official Beads
+`8e4e59d39f3459a43cf21a3236a13eca4dd874f7`. The deployment README put a
+literal `--` after the discovered `program start` leaf. GC correctly forwarded
+that literal argument; Python `argparse` treated it as the end of options and
+reported required `--source-bead` missing.
+
+No planning, program, semantic, delivery, or session bead was created; the
+disposable rig still contained only source bead `ag-blj`. The city then tore
+down cleanly. Required native telemetry had already produced eight GC/BD metric
+families and 21 structured log records through the verified VictoriaMetrics
+v1.148.0 and VictoriaLogs v1.52.0 assets. This is an AgentOps operator-entrypoint
+and regression-coverage defect, not a GC or Beads source defect. The stopped
+subject is `NOT_READY` and is not retried; a corrected subject must repeat the
+external qualification chain before another live attempt is authorized.
+
 Together these canaries prove the real single-bead protected-delivery path,
 provider interchange across author and judge roles, two simultaneous isolated
 writers with disjoint scopes, exact-subject validation, fenced integration,

--- a/scripts/check-gc-executor.sh
+++ b/scripts/check-gc-executor.sh
@@ -12,7 +12,7 @@ python3 scripts/sync-gc-pack.py --check
 python3 -m unittest discover -s tests/python -p 'test_gc_packet.py' -v
 python3 -m unittest discover -s tests/python -p 'test_gc33_*.py' -v
 python3 -m unittest discover -s tests/python -p 'test_sync_gc_pack.py' -v
-bats tests/scripts/gc-agentops-bootstrap.bats
+bats tests/scripts/gc-agentops-bootstrap.bats tests/scripts/gc-agentops-invoke.bats
 
 PACK="$REPO_ROOT/packs/agentops-executor"
 FACTORY="$REPO_ROOT/packs/agentops-factory"

--- a/tests/scripts/gc-agentops-invoke.bats
+++ b/tests/scripts/gc-agentops-invoke.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  INVOKE="$REPO_ROOT/deploy/gc/invoke.sh"
+  README="$REPO_ROOT/deploy/gc/README.md"
+  HELP="$REPO_ROOT/packs/agentops-factory/commands/program-start/help.md"
+  TMP="$(mktemp -d "${TMPDIR:-/tmp}/gc-agentops-invoke.XXXXXX")"
+  CITY="$TMP/city"
+  BIN="$TMP/bin"
+  LOG="$TMP/gc.log"
+  mkdir -p "$CITY/.gc" "$CITY/.gc-home" "$BIN"
+
+  FAKE_GC="$BIN/gc"
+  cat >"$FAKE_GC" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+root="$(cd "$(dirname "$0")/.." && pwd)"
+printf 'ENV GC_HOME=<%s> GC_ISOLATED=<%s> OTEL_SDK_DISABLED=<%s> OTEL_EXPORTER_OTLP_ENDPOINT=<%s> GC_OTEL_METRICS_URL=<%s> GC_OTEL_LOGS_URL=<%s> BD_OTEL_METRICS_URL=<%s> BD_OTEL_LOGS_URL=<%s>\n' \
+  "${GC_HOME-}" "${GC_ISOLATED-}" "${OTEL_SDK_DISABLED-}" \
+  "${OTEL_EXPORTER_OTLP_ENDPOINT-}" "${GC_OTEL_METRICS_URL-}" \
+  "${GC_OTEL_LOGS_URL-}" "${BD_OTEL_METRICS_URL-}" \
+  "${BD_OTEL_LOGS_URL-}" >>"$root/gc.log"
+printf 'ARGS' >>"$root/gc.log"
+printf ' <%s>' "$@" >>"$root/gc.log"
+printf '\n' >>"$root/gc.log"
+EOF
+  chmod +x "$FAKE_GC"
+
+  python3 - "$CITY/.gc/agentops-bootstrap.json" "$CITY" "$FAKE_GC" <<'PY'
+import hashlib
+import json
+import os
+import sys
+
+path, city, gc_bin = sys.argv[1:]
+with open(gc_bin, "rb") as handle:
+    gc_digest = hashlib.sha256(handle.read()).hexdigest()
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump({
+        "schema_version": 5,
+        "state": "ready",
+        "city": os.path.realpath(city),
+        "telemetry": {
+            "mode": "required",
+            "status": "enabled",
+            "requested_metrics_url": "http://127.0.0.1:8428/opentelemetry/api/v1/push",
+            "requested_logs_url": "http://127.0.0.1:9428/insert/opentelemetry/v1/logs",
+            "effective_metrics_url": "http://127.0.0.1:8428/opentelemetry/api/v1/push",
+            "effective_logs_url": "http://127.0.0.1:9428/insert/opentelemetry/v1/logs",
+        },
+        "toolchain": {
+            "gc": {
+                "path": os.path.realpath(gc_bin),
+                "sha256": gc_digest,
+            },
+        },
+    }, handle)
+    handle.write("\n")
+PY
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+@test "invoke binds the managed binary, city, telemetry, and direct pack arguments" {
+  run env \
+    OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+    OTEL_SDK_DISABLED=true \
+    GC_OTEL_METRICS_URL=http://ambient.invalid/metrics \
+    GC_OTEL_LOGS_URL=http://ambient.invalid/logs \
+    BD_OTEL_METRICS_URL=http://ambient.invalid/bd-metrics \
+    BD_OTEL_LOGS_URL=http://ambient.invalid/bd-logs \
+    "$INVOKE" --city "$CITY" -- \
+      agentops program start --source-bead ag-blj --max-parallel 2
+
+  [ "$status" -eq 0 ]
+  canonical_city="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$CITY")"
+  grep -Fq "ENV GC_HOME=<$canonical_city/.gc-home> GC_ISOLATED=<1> OTEL_SDK_DISABLED=<false> OTEL_EXPORTER_OTLP_ENDPOINT=<> GC_OTEL_METRICS_URL=<http://127.0.0.1:8428/opentelemetry/api/v1/push> GC_OTEL_LOGS_URL=<http://127.0.0.1:9428/insert/opentelemetry/v1/logs> BD_OTEL_METRICS_URL=<http://127.0.0.1:8428/opentelemetry/api/v1/push> BD_OTEL_LOGS_URL=<http://127.0.0.1:9428/insert/opentelemetry/v1/logs>" "$LOG"
+  grep -Fq "ARGS <--city> <$canonical_city> <agentops> <program> <start> <--source-bead> <ag-blj> <--max-parallel> <2>" "$LOG"
+  ! grep -Fq ' <--> ' "$LOG"
+}
+
+@test "invoke disables telemetry for an explicitly off managed city" {
+  python3 - "$CITY/.gc/agentops-bootstrap.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    value = json.load(handle)
+value["telemetry"] = {
+    "mode": "off",
+    "status": "off",
+    "requested_metrics_url": "",
+    "requested_logs_url": "",
+    "effective_metrics_url": "",
+    "effective_logs_url": "",
+}
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(value, handle)
+    handle.write("\n")
+PY
+
+  run env OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 "$INVOKE" --city "$CITY" -- status --json
+
+  [ "$status" -eq 0 ]
+  grep -Fq 'OTEL_SDK_DISABLED=<true> OTEL_EXPORTER_OTLP_ENDPOINT=<> GC_OTEL_METRICS_URL=<> GC_OTEL_LOGS_URL=<> BD_OTEL_METRICS_URL=<> BD_OTEL_LOGS_URL=<>' "$LOG"
+}
+
+@test "invoke refuses changed managed binary bytes and an ambiguous command boundary" {
+  printf '%s\n' '# replaced' >>"$FAKE_GC"
+
+  run "$INVOKE" --city "$CITY" -- status
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"managed gc binary digest mismatch"* ]]
+
+  run "$INVOKE" --city "$CITY" status
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"expected -- before the Gas City command"* ]]
+}
+
+@test "operator docs use the managed invocation boundary and direct discovered-command flags" {
+  run rg -n 'program start -- --source-bead' "$README" "$HELP"
+  [ "$status" -eq 1 ]
+
+  rg -Fq 'deploy/gc/invoke.sh --city /path/to/city --' "$README"
+  rg -Fq 'agentops program start --source-bead age-example --max-parallel 2' "$README"
+  rg -Fq 'gc agentops program start --source-bead ID' "$HELP"
+}


### PR DESCRIPTION
## Outcome

Correct the one AgentOps-owned defect exposed by the first post-merge 3.3 canary: the operator README placed a literal argument boundary inside the discovered Gas City command, so Python never received source-bead.

This adds a managed invocation boundary that:
- consumes its own explicit wrapper separator and forwards discovered-command flags directly;
- binds the schema-5 city marker, exact GC digest, private supervisor home, and isolated mode;
- projects the marker-selected GC/BD telemetry endpoints or an explicit disabled state;
- clears ambient generic OTLP fallback configuration;
- records the stopped pre-admission canary without claiming a Gas City or Beads defect.

## Evidence

- focused managed-invocation Bats: 4/4 PASS
- combined Gas City contract gate: PASS (33 Bats plus Python/static contracts)
- adjacent teardown/toolchain Bats: 16/16 PASS
- exact full local release gate: PASS at .agents/releases/local-ci/20260722T141141Z
- two fresh exact-toolchain bootstrap/start/status/teardown cycles: PASS, zero workers/sessions, clean teardown
- fresh Sol-high pre-delivery binding: PASS, 11/11 criteria

## Deferred boundary

This PR does not claim final 3.3 release readiness. After protected merge and post-merge conformance, exactly one new required-telemetry mixed Terra-high/Opus-medium live canary remains.