### PR TITLE
fix(gc): enter city before pack dispatch

### DIFF
--- a/deploy/gc/README.md
+++ b/deploy/gc/README.md
@@ -179,8 +179,11 @@ deploy/gc/invoke.sh --city /path/to/city -- agentops program start --source-bead
 The managed invoker reads the bootstrap marker, verifies the exact recorded
 Gas City binary digest, selects the private supervisor, projects the effective
 telemetry pair (or explicit disabled state), and clears an ambient generic OTLP
-fallback. Its `--` is the wrapper boundary and is consumed; do not put another
-`--` between the discovered `program start` leaf and `--source-bead`.
+fallback. It enters the exact managed city before executing GC because GC v1.3.5
+discovers imported commands while constructing its command tree, before a later
+`--city` flag is parsed. Its `--` is the wrapper boundary and is consumed; do
+not put another `--` between the discovered `program start` leaf and
+`--source-bead`.
 
 The command snapshots that exact source Bead once, freezes the first observed
 base OID for the program, runs Fable Mayor and fresh Sol plan binding, and then

--- a/deploy/gc/invoke.sh
+++ b/deploy/gc/invoke.sh
@@ -13,7 +13,8 @@ Required:
 
 This executes the exact gc binary recorded by the managed-city marker. It binds
 the city's private supervisor home and effective telemetry policy and removes an
-ambient generic OTLP fallback before invoking `gc --city PATH ...`.
+ambient generic OTLP fallback. It executes from the managed city directory so
+GC can register imported pack commands before parsing their leaf flags.
 EOF
 }
 
@@ -186,4 +187,5 @@ else
   export BD_OTEL_LOGS_URL=""
 fi
 
+cd -- "$city" || die "cannot enter managed city directory: $city"
 exec "$gc_bin" --city "$city" "$@"

--- a/deploy/gc/known-errors.json
+++ b/deploy/gc/known-errors.json
@@ -275,6 +275,23 @@
       "disposition": "Resolved in the AgentOps managed invocation boundary; direct ambient gc invocation remains outside the qualified deployment path."
     },
     {
+      "id": "gascity-v1.3.5-city-flag-pack-command-discovery",
+      "kind": "verified_upstream_defect",
+      "observed": "2026-07-22",
+      "location": "Gas City cmd/gc root construction and lazy discovered-command fallback",
+      "identities": {"gc_release": "v1.3.5", "gc_source_commit": "8ffc009ded781a2ada2077f3a29bd712b2def0bf", "agentops_landed_subject": "c0a68c29ea62a4c6680ef1011def0f950a745973"},
+      "symptom": "From outside a city, gc --city PATH BINDING COMMAND --leaf-flag rejects the pack leaf flag at Cobra root parsing. Adding a literal -- reaches lazy dispatch but forwards that separator to the pack script.",
+      "reproduction": "Invoke the AgentOps program-start leaf from outside the managed city. Direct --source-bead is rejected as an unknown GC flag; a literal separator is forwarded and makes argparse report --source-bead missing.",
+      "owner": "gascity",
+      "fix_location": "Gas City eager pack-command discovery must account for an explicit --city before Cobra parses pack leaf flags, or lazy dispatch must define and remove an argument boundary.",
+      "build": "AgentOps deploy/gc/invoke.sh enters the exact marker-bound city before exec so GC v1.3.5 eager discovery registers the imported leaf with DisableFlagParsing=true.",
+      "deterministic_test": "gc-agentops-invoke.bats models GC v1.3.5 rejecting pack leaf flags outside the city and proves the managed invoker executes from the exact marker city while forwarding no literal separator.",
+      "live_check": "The next corrected-subject canary must admit the exact source bead through the managed invoker without either unknown-flag or argparse boundary errors.",
+      "upstream": "Real Gas City v1.3.5 CLI discovery defect. Keep AgentOps on the official release; propose an upstream-focused test/fix separately rather than patching the local fork for 3.3.",
+      "release_relevance": "Blocks AgentOps 3.3 program admission only when the imported command is invoked from outside the city through --city.",
+      "disposition": "Work around deterministically in AgentOps 3.3; retain exact provenance for a bounded upstream contribution after release stabilization."
+    },
+    {
       "id": "environment-production-rig-reserved-dolt-database",
       "kind": "configuration_migration_required",
       "observed": "2026-07-19",

--- a/docs/audits/gas-city-factory-live-bead-canary.md
+++ b/docs/audits/gas-city-factory-live-bead-canary.md
@@ -78,7 +78,7 @@ Dolt service, tmux socket, and city-scoped processes cleanly.
 
 ## Qualification boundary
 
-### 3.3 release canary entrypoint stop
+### First 3.3 release canary entrypoint stop
 
 The first post-merge 3.3 release-canary entrypoint stopped before admission on
 2026-07-22. The exact landed subject was `faff55ac2a6df3fd862be100ff46df9f568bbb2c`
@@ -96,6 +96,32 @@ v1.148.0 and VictoriaLogs v1.52.0 assets. This is an AgentOps operator-entrypoin
 and regression-coverage defect, not a GC or Beads source defect. The stopped
 subject is `NOT_READY` and is not retried; a corrected subject must repeat the
 external qualification chain before another live attempt is authorized.
+
+### Second 3.3 release canary entrypoint stop
+
+The corrected landed subject `c0a68c29ea62a4c6680ef1011def0f950a745973`
+used the same official GC and Beads source commits in a new standalone root with
+fresh telemetry stores and source bead `ag-gc33c0`. The managed invoker removed
+the literal separator and passed direct leaf flags, but the call originated
+outside the city. GC rejected `--source-bead` as an unknown root flag before the
+pack script ran. The canary stopped immediately and was not retried.
+
+Official GC source establishes the exact ownership boundary. GC v1.3.5 performs
+best-effort imported-command discovery while constructing the Cobra root,
+before its persistent `--city` flag is parsed. Outside the city the command is
+therefore absent from the eager tree; lazy dispatch cannot receive flag-like
+arguments without a separator, and it forwards that separator unchanged. The
+AgentOps managed invocation correction is to enter the exact marker-bound city
+before exec so eager discovery registers the imported leaf and its
+`DisableFlagParsing` contract.
+
+Again, no planning, program, semantic, delivery, or session bead was created;
+the disposable rig contained only `ag-gc33c0`, and no factory evidence directory
+existed. Required native telemetry produced the same eight GC/BD metric families
+and structured logs. City, collectors, and scoped processes then stopped
+cleanly. This stopped subject is `NOT_READY`. The GC behavior is a verified
+upstream defect, but 3.3 changes no GC or Beads fork: AgentOps uses the bounded
+managed-cwd workaround and retains the exact upstream provenance separately.
 
 Together these canaries prove the real single-bead protected-delivery path,
 provider interchange across author and judge roles, two simultaneous isolated

--- a/tests/scripts/gc-agentops-invoke.bats
+++ b/tests/scripts/gc-agentops-invoke.bats
@@ -16,6 +16,20 @@ setup() {
 #!/usr/bin/env bash
 set -euo pipefail
 root="$(cd "$(dirname "$0")/.." && pwd)"
+requested_city=""
+if [ "${1-}" = "--city" ] && [ -n "${2-}" ]; then
+  requested_city="$(cd "$2" && pwd -P)"
+fi
+current_dir="$(pwd -P)"
+if [ "$current_dir" != "$requested_city" ]; then
+  for argument in "$@"; do
+    if [ "$argument" = "--source-bead" ]; then
+      printf 'gc: unknown flag: --source-bead\n' >&2
+      exit 1
+    fi
+  done
+fi
+printf 'CWD <%s>\n' "$current_dir" >>"$root/gc.log"
 printf 'ENV GC_HOME=<%s> GC_ISOLATED=<%s> OTEL_SDK_DISABLED=<%s> OTEL_EXPORTER_OTLP_ENDPOINT=<%s> GC_OTEL_METRICS_URL=<%s> GC_OTEL_LOGS_URL=<%s> BD_OTEL_METRICS_URL=<%s> BD_OTEL_LOGS_URL=<%s>\n' \
   "${GC_HOME-}" "${GC_ISOLATED-}" "${OTEL_SDK_DISABLED-}" \
   "${OTEL_EXPORTER_OTLP_ENDPOINT-}" "${GC_OTEL_METRICS_URL-}" \
@@ -77,6 +91,7 @@ teardown() {
 
   [ "$status" -eq 0 ]
   canonical_city="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$CITY")"
+  grep -Fq "CWD <$canonical_city>" "$LOG"
   grep -Fq "ENV GC_HOME=<$canonical_city/.gc-home> GC_ISOLATED=<1> OTEL_SDK_DISABLED=<false> OTEL_EXPORTER_OTLP_ENDPOINT=<> GC_OTEL_METRICS_URL=<http://127.0.0.1:8428/opentelemetry/api/v1/push> GC_OTEL_LOGS_URL=<http://127.0.0.1:9428/insert/opentelemetry/v1/logs> BD_OTEL_METRICS_URL=<http://127.0.0.1:8428/opentelemetry/api/v1/push> BD_OTEL_LOGS_URL=<http://127.0.0.1:9428/insert/opentelemetry/v1/logs>" "$LOG"
   grep -Fq "ARGS <--city> <$canonical_city> <agentops> <program> <start> <--source-bead> <ag-blj> <--max-parallel> <2>" "$LOG"
   ! grep -Fq ' <--> ' "$LOG"
@@ -127,5 +142,6 @@ PY
 
   rg -Fq 'deploy/gc/invoke.sh --city /path/to/city --' "$README"
   rg -Fq 'agentops program start --source-bead age-example --max-parallel 2' "$README"
+  rg -Fq 'enters the exact managed city before executing GC' "$README"
   rg -Fq 'gc agentops program start --source-bead ID' "$HELP"
 }


### PR DESCRIPTION
## Summary

- enter the exact marker-bound managed city before dispatching imported AgentOps pack commands
- preserve direct leaf arguments without a literal `--` separator
- document the verified official GC v1.3.5 discovery limitation and the bounded AgentOps workaround
- add a parser-shaped regression test that fails when dispatch occurs outside the requested city

## Why

The second bounded 3.3 live canary exposed an official GC v1.3.5 CLI-ordering limitation: imported pack commands are discovered before persistent `--city` is parsed. From outside the city, direct leaf flags are rejected by GC; the lazy fallback reached with `--` forwards that separator to the pack script. The managed invoker now enters the already validated marker city before exact GC exec, allowing eager pack discovery without changing the GC or Beads forks.

## Evidence

- exact candidate: `6eff4767297178c4cd9d7945795526d2e61d0e0b`
- exact tree: `8e57f213f9253e6880ee5f183783500dad729abb`
- invoker Bats: 4/4 PASS
- adjacent teardown/toolchain Bats: 16/16 PASS
- real official-GC read-only pack-help proof from outside the city: PASS
- full local release: `.agents/releases/local-ci/20260722T144624Z` PASS
- two clean exact qualification cycles: PASS
- fresh Sol-high binding verdict: PASS (10/10 criteria)

## Deferred

One entirely fresh live mixed-provider canary remains after hosted CI and exact protected-main landing. The upstream CLI defect is retained under the canonical 3.3.1 bead for a bounded contribution only if current upstream still reproduces it.