### PR TITLE
fix(gc): route controls through primary rig dispatcher

### DIFF
--- a/deploy/gc/README.md
+++ b/deploy/gc/README.md
@@ -80,8 +80,14 @@ the executor pack supplies explicit suspended rig agents, so GC's documented
 "explicit wins" rule prevents those generic identities from being injected.
 Scaffold maintenance pools are suspended with ordinary patches because they
 already exist when patches run. Only roles explicitly supplied by the selected
-pack remain routable. Direct packet work uses the registered rig root. Factory Formula
-tasks instead stamp the exact absolute `work_dir` selected for that bead;
+pack remain routable. The city control dispatcher stays suspended; exactly the
+selected primary rig's `core.control-dispatcher` is active, while every extra
+rig dispatcher remains suspended. Immediately after each Formula cook, the
+feeder seals only the compiled control records to that rig's dispatcher and
+records its `gc.execution_rig_context`; it rejects foreign or incomplete
+routing before opening an admission gate. Direct packet work uses the
+registered rig root. Factory Formula tasks instead stamp the exact absolute
+`work_dir` selected for that bead;
 official GC v1.3.5 launches the fresh Terra/Opus/Sol session there. The 3.3
 factory does not create a second rig, Dolt server, or integration rig per
 candidate.

--- a/deploy/gc/bootstrap.sh
+++ b/deploy/gc/bootstrap.sh
@@ -1374,15 +1374,19 @@ managed_patches = [
     '[[patches.agent]]\nname = "bd.dog"\nsuspended = true',
     '[[patches.agent]]\nname = "core.control-dispatcher"\nsuspended = true',
 ]
-for rig in live_config.get("rigs", []):
+configured_rigs = live_config.get("rigs", [])
+if [rig.get("name") for rig in configured_rigs].count(requested_rig_name) > 1:
+    raise SystemExit("managed city has duplicate selected primary rigs")
+for rig in configured_rigs:
     rig_name = rig.get("name")
     if not isinstance(rig_name, str) or not rig_name:
         raise SystemExit("managed city contains a rig without a name")
+    suspended = rig_name != requested_rig_name
     managed_patches.append(
         "[[patches.agent]]\n"
         f'dir = "{rig_name}"\n'
         'name = "core.control-dispatcher"\n'
-        "suspended = true"
+        f"suspended = {str(suspended).lower()}"
     )
 
 parts = [policy]
@@ -1422,8 +1426,9 @@ for rig in config.get("rigs", []):
         patch for patch in patches
         if patch.get("name") == "core.control-dispatcher" and patch.get("dir") == rig["name"]
     ]
-    if control_matches != [{"dir": rig["name"], "name": "core.control-dispatcher", "suspended": True}]:
-        raise SystemExit(f"rig {rig['name']!r} must suspend the scaffold control dispatcher")
+    expected = {"dir": rig["name"], "name": "core.control-dispatcher", "suspended": rig["name"] != requested_rig_name}
+    if control_matches != [expected]:
+        raise SystemExit(f"rig {rig['name']!r} has an invalid primary control dispatcher projection")
 workspace = config.get("workspace", {})
 session = config.get("session", {})
 codex_provider = config.get("providers", {}).get("codex", {})
@@ -2000,9 +2005,10 @@ else:
     raise SystemExit(f"could not locate TOML block for rig {rig_name!r}")
 PY
 
-# The scaffold control dispatcher exists before patches are applied. Generic
-# provider agents do not: the selected executor pack must shadow those later
-# implicit identities with explicit suspended rig agents.
+# The scaffold control dispatcher exists before patches are applied. Exactly
+# the selected primary rig owns its Formula-v2 control queue; the city and any
+# extra rigs remain suspended. Generic provider agents do not exist yet, so the
+# selected executor pack must shadow those later implicit identities explicitly.
 python3 - "$city/city.toml" "$rig_name" <<'PY'
 import os
 import sys
@@ -2020,9 +2026,9 @@ matches = [
     if patch.get("name") == provider_name and patch.get("dir") == rig_name
 ]
 if matches:
-    if len(matches) != 1 or matches[0].get("suspended") is not True:
+    if len(matches) != 1 or matches[0].get("suspended") is not False:
         raise SystemExit(
-            f"rig {rig_name!r} has an invalid managed {provider_name} suspension patch"
+            f"rig {rig_name!r} has an invalid managed primary {provider_name} patch"
         )
 else:
     if text and not text.endswith("\n"):
@@ -2031,7 +2037,7 @@ else:
         "\n[[patches.agent]]\n"
         f'dir = "{rig_name}"\n'
         f'name = "{provider_name}"\n'
-        "suspended = true\n"
+        "suspended = false\n"
     )
     changed = True
 if not changed:
@@ -2052,16 +2058,38 @@ trap 'rm -f "$executor_agents"' EXIT
 # GC v1.3.5 reads each task's absolute work_dir. The checked Formula stamps
 # that task field directly, so bootstrap must preserve the imported role
 # configs instead of patching a shared base directory around gc.pack_workspace.
-python3 - "$executor_agents" "$rig_name" "$binding" <<'PY'
+python3 - "$executor_agents" "$city/city.toml" "$rig_name" "$binding" <<'PY'
 import json
 import sys
+import tomllib
 
-path, rig_name, binding = sys.argv[1:]
+path, config_path, rig_name, binding = sys.argv[1:]
 with open(path, encoding="utf-8") as handle:
     value = json.load(handle)
 agents = value.get("agents") if isinstance(value, dict) else None
 if not isinstance(agents, list):
     raise SystemExit("gc agent list returned no agent inventory")
+with open(config_path, "rb") as handle:
+    config = tomllib.load(handle)
+if [rig.get("name") for rig in config.get("rigs", [])].count(rig_name) != 1:
+    raise SystemExit("effective city inventory has no unique selected primary rig")
+dispatchers = [
+    agent for agent in agents
+    if isinstance(agent, dict) and (
+        agent.get("qualified_name") == "core.control-dispatcher"
+        or (isinstance(agent.get("qualified_name"), str)
+            and agent["qualified_name"].endswith("/core.control-dispatcher"))
+    )
+]
+active_dispatchers = [agent for agent in dispatchers if agent.get("suspended") is False]
+expected_dispatcher = {
+    "qualified_name": f"{rig_name}/core.control-dispatcher",
+    "dir": rig_name,
+}
+if len(active_dispatchers) != 1 or any(
+    active_dispatchers[0].get(key) != value for key, value in expected_dispatcher.items()
+):
+    raise SystemExit("effective agent inventory must expose exactly one active primary rig control dispatcher")
 for role in ("implementer", "implementer-claude", "validator"):
     qualified_name = f"{rig_name}/{binding}.{role}"
     matches = [

--- a/deploy/gc/city.toml
+++ b/deploy/gc/city.toml
@@ -239,8 +239,11 @@ default = "medium"
 # agents are injected only after patches are applied, so they cannot lawfully
 # be suspended with patches in GC v1.3.5. bootstrap.sh projects explicit,
 # suspended city convention agents and the executor pack supplies equivalent
-# rig agents; those exact identities shadow implicit injection. Only checked
-# AgentOps roles may consume bounded session capacity.
+# rig agents; those exact identities shadow implicit injection. The template
+# keeps the city control dispatcher suspended; after the primary rig import is
+# resolved, bootstrap activates exactly that rig's deterministic dispatcher and
+# leaves every other copy suspended. Only checked AgentOps roles may consume
+# model-backed session capacity.
 [[patches.agent]]
 name = "bd.dog"
 suspended = true

--- a/docs/architecture/gas-city-factory.md
+++ b/docs/architecture/gas-city-factory.md
@@ -133,7 +133,8 @@ landing. A landed PR is still not a release verdict.
 - interactive Claude with inherited `print_args` cleared;
 - a deployment-pinned `GC_BIN` in workspace session environment;
 - explicit suspended Codex and Claude identities shadow GC's late generic-target injection;
-- scaffold Dog and control-dispatcher pools suspended; and
+- scaffold Dog, city dispatcher, and non-primary rig dispatchers suspended,
+  with exactly the primary rig's deterministic control dispatcher active; and
 - a configurable `workspace.max_active_sessions` (default one; the release
   canary admits only a width-two semantic graph and sizes total role capacity
   explicitly).
@@ -145,6 +146,15 @@ reconciles and verifies the primary executor roles' packet-workspace base, and
 optionally starts the city. Packet workspaces are directory names relative to
 that base, so the base is the registered rig's parent rather than the rig
 itself. It does not start a Mayor, run an experiment, or infer completion.
+
+Formula cook and control execution must resolve to the same Beads store.
+Official GC v1.3.5 initially decorates Formula-v2 control rows with the city
+route, while AgentOps cooks the workflow in the primary rig store. The feeder
+therefore treats route sealing as part of admission: it accepts only the known
+compiler route or the already sealed primary-rig route, updates the exact Ralph
+and workflow-finalize controls, stamps the rig execution context used by later
+attempts, and re-reads every row. A missing, duplicate, foreign, or partially
+persisted binding leaves admission closed.
 
 `deploy/gc/materialize-toolchain.sh` checks out and builds the exact source pair
 before bootstrap. An ambient or same-version unlisted binary cannot become the
@@ -439,10 +449,10 @@ must pass their gates before raising that cap.
 
 Dynamic worktree rigs are route-minimized from the bead's admitted
 `factory.binding`. A candidate rig exposes its admitted Terra/Opus writer and a
-fresh Sol Validator; linked delivery exposes no model route or integration rig. Rig
-registration and the durable suspension patches share a city-config lock, and
-dispatch stops unless the resolved active inventory is exactly the expected
-set.
+fresh Sol Validator; linked delivery exposes no model route or integration rig.
+Rig registration and the durable suspension patches share a city-config lock,
+and dispatch stops unless the resolved inventory contains exactly one active
+control dispatcher at the primary rig plus the expected model roles.
 
 AgentOps skills remain semantic sources of truth. Thin role prompts inject the
 appropriate Mayor, plan-review, Implement, or Validate skill.

--- a/docs/contracts/gas-city-execution-adapter.md
+++ b/docs/contracts/gas-city-execution-adapter.md
@@ -50,8 +50,9 @@ The deployment is intentionally smaller than a traditional Gas Town:
   materialize SDK-defined generic targets after patch application, so explicit
   suspended city convention agents and executor-pack rig agents shadow those
   identities before GC's implicit-injection phase;
-- scaffold maintenance pools (`bd.dog` and `core.control-dispatcher`) are also
-  suspended so they cannot consume the execution-only city's session cap;
+- the scaffold `bd.dog`, city control dispatcher, and all non-primary rig
+  dispatchers are suspended; exactly the primary rig's providerless
+  `core.control-dispatcher` is active for Formula-v2 control work;
 - no always-on model session. The thin executor pack has no Mayor or Refiner;
   the optional factory pack exposes on-demand Fable Mayor and gated ambiguity
   sessions around the same packet boundary.
@@ -81,6 +82,14 @@ rejects an actual runtime that violates the requested fixed role policy or
 silently downgrades it; in particular validation is requested and actual
 Sol-high/Codex, and every fallback object is exactly `allowed=false`,
 `used=false`, and `reason=null`, never Terra-low.
+
+Stable GC v1.3.5 cooks Formula-v2 control rows with the unqualified city
+dispatcher route even when the workflow store is a rig. Before any admission
+gate opens, the one-shot feeder validates the exact compiled row set, rejects
+foreign routing, and seals only Ralph and workflow-finalize controls to
+`<rig>/core.control-dispatcher` with `gc.execution_rig_context=<rig>`. It then
+re-reads every mutation. Workflow roots, specs, and model attempts are not
+rewritten.
 
 ## SDK-owned configuration
 

--- a/packs/agentops-factory/assets/scripts/factory_feeder.py
+++ b/packs/agentops-factory/assets/scripts/factory_feeder.py
@@ -67,6 +67,26 @@ def formula_routes(rig_id: object) -> dict[str, str]:
     }
 
 
+def control_dispatcher_route(rig_id: object) -> tuple[str, str]:
+    """Return the one store-qualified Formula-v2 control route for this run."""
+    rig = sealed_rig_id(rig_id)
+    return f"{rig}/core.control-dispatcher", rig
+
+
+def formula_control_references(formula: str) -> dict[str, str]:
+    """Exact control-dispatcher-owned records synthesized by graph.v2 cook."""
+    if formula == "agentops-build":
+        roles = ("mayor", "plan")
+    elif formula == "agentops-experiment":
+        roles = ("implement", "validate")
+    else:
+        raise FeederError(f"unsupported workflow formula {formula!r}")
+    return {
+        **{f"{formula}.{role}": "ralph" for role in roles},
+        f"{formula}.workflow-finalize": "workflow-finalize",
+    }
+
+
 def validate_build_context(context: dict[str, Any]) -> None:
     validate_schema(context, "factory-build-context.v1.schema.json", "build context")
     if context.get("routes") != formula_routes(context.get("rig_id")):
@@ -246,6 +266,9 @@ def workflow_rows(bd_bin: str, root: Path, root_id: str, formula: str,
         if (attempt_meta.get("gc.step_id") != role or attempt_meta.get("gc.ralph_step_id") != role
                 or attempt_meta.get("gc.attempt") != "1" or attempt_meta.get("gc.logical_bead_id") != control["id"]):
             raise FeederError(f"workflow {root_id} {role} attempt metadata differs from stable Ralph contract")
+    finalizer = records[f"{formula}.workflow-finalize"]
+    if finalizer["metadata"].get("gc.kind") != "workflow-finalize":
+        raise FeederError(f"workflow {root_id} finalizer metadata differs from stable graph.v2 contract")
     return {key: str(row["id"]) for key, row in records.items()}, records
 
 
@@ -284,6 +307,60 @@ EXPERIMENT_STEP_REF_MAP = {
     "validate.iteration.1": "agentops-experiment.validate.iteration.1",
     "agentops-experiment.workflow-finalize": "agentops-experiment.workflow-finalize",
 }
+
+
+def seal_compiled_control_dispatcher_routes(bd_bin: str, root: Path, formula: str,
+                                            records: dict[str, dict[str, Any]], rig_id: object) -> dict[str, dict[str, Any]]:
+    """Bind every Formula-v2 control record to one sealed rig dispatcher.
+
+    GC v1.3.5 initially compiles controls with the known unqualified city
+    default.  The factory owns this post-cook bridge, but never overwrites an
+    arbitrary route or rig context: a foreign value is a failed admission.
+    Every target row is read again after mutation before any admission gate can
+    close.
+    """
+    route, context = control_dispatcher_route(rig_id)
+    controls = formula_control_references(formula)
+    if set(controls) - set(records):
+        raise FeederError(f"workflow {formula} is missing a compiled control record")
+    identifiers: list[str] = []
+    for reference, kind in controls.items():
+        row = records[reference]
+        identifier = row.get("id")
+        metadata = bead_metadata(row, f"compiled control {reference}")
+        if not isinstance(identifier, str) or not identifier or metadata.get("gc.kind") != kind:
+            raise FeederError(f"workflow {formula} has an invalid compiled control record {reference}")
+        if metadata.get("gc.routed_to") not in ("core.control-dispatcher", route):
+            raise FeederError(f"compiled control {reference} has a foreign route")
+        if metadata.get("gc.execution_rig_context") not in (None, context):
+            raise FeederError(f"compiled control {reference} has a foreign execution rig context")
+        identifiers.append(identifier)
+    if len(identifiers) != len(set(identifiers)):
+        raise FeederError(f"workflow {formula} has duplicate compiled control records")
+
+    sealed = dict(records)
+    for reference, kind in controls.items():
+        identifier = str(records[reference]["id"])
+        metadata = bead_metadata(records[reference], f"compiled control {reference}")
+        prior_route = metadata.get("gc.routed_to")
+        prior_context = metadata.get("gc.execution_rig_context")
+        if prior_route != route or prior_context != context:
+            run_checked([
+                bd_bin, "update", identifier,
+                "--set-metadata", "gc.routed_to=" + route,
+                "--set-metadata", "gc.execution_rig_context=" + context,
+                "--json",
+            ], root)
+        reread = show_bead(bd_bin, root, identifier, f"sealed compiled control {reference}")
+        reread_metadata = bead_metadata(reread, f"sealed compiled control {reference}")
+        if (reread_metadata.get("gc.kind") != kind
+                or any(reread_metadata.get(key) != metadata.get(key)
+                       for key in ("gc.step_ref", "gc.root_bead_id", "gc.step_id"))
+                or reread_metadata.get("gc.routed_to") != route
+                or reread_metadata.get("gc.execution_rig_context") != context):
+            raise FeederError(f"compiled control {reference} did not re-read with the sealed dispatcher binding")
+        sealed[reference] = reread
+    return sealed
 
 
 def executable(path: object, label: str) -> str:
@@ -447,6 +524,12 @@ def start(args: argparse.Namespace) -> int:
         }
         validate_build_context(context)
         atomic_write(context_path, context)
+
+    # This is deliberately immediately after the Formula cook/recovery read and
+    # before the inert admission can become eligible for a controller.
+    records = seal_compiled_control_dispatcher_routes(
+        bd_bin, root, "agentops-build", records, requested_rig_id,
+    )
 
     mayor_request = {
         "schema_version": "factory-role-request.v2", "request_id": program_id + ".mayor",
@@ -1865,6 +1948,9 @@ def admit(args: argparse.Namespace) -> int:
         if not isinstance(workflow_root, str) or not workflow_root:
             raise FeederError(f"gc formula cook returned no workflow root for {node['id']}")
         steps, records = workflow_rows(args.bd_bin, root, workflow_root, "agentops-experiment", EXPERIMENT_STEP_REF_MAP)
+        records = seal_compiled_control_dispatcher_routes(
+            args.bd_bin, root, "agentops-experiment", records, context["rig_id"],
+        )
         experiment_binding(records, steps, node, work_dir, implement_packet, validate_packet, routes)
         packet_raw = Path(implement_packet).read_bytes()
         admitted_nodes[node["id"]] = {

--- a/tests/python/test_gc33_factory_workflows.py
+++ b/tests/python/test_gc33_factory_workflows.py
@@ -107,7 +107,11 @@ class FactoryWorkflowTests(unittest.TestCase):
                     metadata.update({"gc.run_target": target, "gc.routed_to": target, "work_dir": "/work"})
             elif suffix in {"mayor", "plan", "implement", "validate"}:
                 controls[suffix] = f"{formula}-{suffix}"
-                metadata.update({"gc.kind": "ralph", "gc.step_id": suffix})
+                metadata.update({"gc.kind": "ralph", "gc.step_id": suffix,
+                                 "gc.routed_to": "core.control-dispatcher"})
+            elif suffix == "workflow-finalize":
+                metadata.update({"gc.kind": "workflow-finalize",
+                                 "gc.routed_to": "core.control-dispatcher"})
             rows.append({"id": f"{formula}-{suffix.replace('.', '-')}", "metadata": metadata})
         return rows
 
@@ -156,6 +160,86 @@ class FactoryWorkflowTests(unittest.TestCase):
         self.assertEqual(steps["agentops-build.mayor.iteration.1"], "agentops-build-mayor-iteration-1")
         self.assertEqual(records["agentops-build.plan.iteration.1"]["metadata"]["gc.step_ref"], "plan.iteration.1")
 
+    def test_control_dispatcher_routes_are_sealed_only_on_compiled_controls(self) -> None:
+        feeder = self.feeder()
+        rows = self.stable_workflow_rows("agentops-build", "build-root", self.routes())
+        original_all, original_run = feeder.all_beads, feeder.run_checked
+        updates: list[str] = []
+
+        def fake(argv, _cwd):
+            if argv[1] == "update":
+                row = next(item for item in rows if item["id"] == argv[2])
+                row["metadata"]["gc.routed_to"] = next(
+                    value.removeprefix("gc.routed_to=") for value in argv if value.startswith("gc.routed_to=")
+                )
+                row["metadata"]["gc.execution_rig_context"] = next(
+                    value.removeprefix("gc.execution_rig_context=") for value in argv if value.startswith("gc.execution_rig_context=")
+                )
+                updates.append(argv[2])
+                return canonical({"id": argv[2]})
+            if argv[1] == "show":
+                return canonical(next(item for item in rows if item["id"] == argv[2]))
+            raise AssertionError(argv)
+
+        feeder.all_beads = lambda *_args: rows
+        feeder.run_checked = fake
+        try:
+            _, records = feeder.workflow_rows("bd", Path("/repo"), "build-root", "agentops-build", feeder.BUILD_STEP_REF_MAP)
+            sealed = feeder.seal_compiled_control_dispatcher_routes("bd", Path("/repo"), "agentops-build", records, "named-rig")
+        finally:
+            feeder.all_beads, feeder.run_checked = original_all, original_run
+        controls = feeder.formula_control_references("agentops-build")
+        self.assertEqual(set(updates), {records[reference]["id"] for reference in controls})
+        for reference in controls:
+            metadata = sealed[reference]["metadata"]
+            self.assertEqual(metadata["gc.routed_to"], "named-rig/core.control-dispatcher")
+            self.assertEqual(metadata["gc.execution_rig_context"], "named-rig")
+        attempt = sealed["agentops-build.mayor.iteration.1"]["metadata"]
+        self.assertNotIn("gc.execution_rig_context", attempt)
+        self.assertEqual(attempt["gc.routed_to"], self.routes()["mayor"])
+
+    def test_control_dispatcher_route_rejects_foreign_compiler_drift(self) -> None:
+        feeder = self.feeder()
+        rows = self.stable_workflow_rows("agentops-experiment", "experiment-root", self.routes())
+        control = next(row for row in rows if row["metadata"].get("gc.step_ref") == "agentops-experiment.validate")
+        control["metadata"]["gc.routed_to"] = "other/core.control-dispatcher"
+        original = feeder.all_beads
+        feeder.all_beads = lambda *_args: rows
+        try:
+            _, records = feeder.workflow_rows("bd", Path("/repo"), "experiment-root", "agentops-experiment", feeder.EXPERIMENT_STEP_REF_MAP)
+            with self.assertRaisesRegex(feeder.FeederError, "foreign route"):
+                feeder.seal_compiled_control_dispatcher_routes("bd", Path("/repo"), "agentops-experiment", records, "named-rig")
+        finally:
+            feeder.all_beads = original
+
+    def test_control_dispatcher_route_requires_exact_persisted_reread(self) -> None:
+        feeder = self.feeder()
+        rows = self.stable_workflow_rows("agentops-build", "build-root", self.routes())
+        original_all, original_run = feeder.all_beads, feeder.run_checked
+        updates: list[str] = []
+
+        def fake(argv, _cwd):
+            if argv[1] == "update":
+                updates.append(argv[2])
+                return canonical({"id": argv[2]})
+            if argv[1] == "show":
+                return canonical(next(item for item in rows if item["id"] == argv[2]))
+            raise AssertionError(argv)
+
+        feeder.all_beads = lambda *_args: rows
+        feeder.run_checked = fake
+        try:
+            _, records = feeder.workflow_rows(
+                "bd", Path("/repo"), "build-root", "agentops-build", feeder.BUILD_STEP_REF_MAP,
+            )
+            with self.assertRaisesRegex(feeder.FeederError, "did not re-read"):
+                feeder.seal_compiled_control_dispatcher_routes(
+                    "bd", Path("/repo"), "agentops-build", records, "named-rig",
+                )
+        finally:
+            feeder.all_beads, feeder.run_checked = original_all, original_run
+        self.assertEqual(len(updates), 1)
+
     def test_workflow_rows_rejects_foreign_or_canonical_attempt_refs_and_bad_structure(self) -> None:
         feeder = self.feeder()
         cases: list[tuple[str, list[dict[str, object]]]] = []
@@ -195,12 +279,13 @@ class FactoryWorkflowTests(unittest.TestCase):
             tools = {}
             for name in ("bd", "gc", "git", "gh", "bash", "delivery", "role-adapter", "packet-adapter", "factory-check"):
                 path = root / name; path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8"); path.chmod(0o700); tools[name] = str(path.resolve())
-            state = {"cook": 0, "close": 0, "workspace": "", "mayor_request": "", "base": "a" * 40, "malformed": True}
+            state = {"cook": 0, "close": 0, "workspace": "", "mayor_request": "", "base": "a" * 40, "malformed": True, "sealed_controls": {}}
 
             def rows():
                 values = self.stable_workflow_rows("agentops-build", "workflow-1", self.routes())
                 for row in values:
                     metadata = row["metadata"]
+                    metadata.update(state["sealed_controls"].get(row["id"], {}))
                     description = ""
                     if metadata.get("gc.step_ref") == "mayor.iteration.1":
                         metadata.update({"work_dir": state["workspace"]})
@@ -225,6 +310,14 @@ class FactoryWorkflowTests(unittest.TestCase):
                     return canonical({"schema_version": "1", "ok": True, "formula": "agentops-build", "mode": "attach", "attach_bead_id": "source-1", "root_id": "workflow-1", "workflow_root_id": "workflow-1", "created": 9})
                 if argv[0] == tools["bd"] and argv[1] == "list":
                     return canonical(rows())
+                if argv[0] == tools["bd"] and argv[1] == "update":
+                    state["sealed_controls"][argv[2]] = {
+                        "gc.routed_to": next(value.removeprefix("gc.routed_to=") for value in argv if value.startswith("gc.routed_to=")),
+                        "gc.execution_rig_context": next(value.removeprefix("gc.execution_rig_context=") for value in argv if value.startswith("gc.execution_rig_context=")),
+                    }
+                    return canonical({"id": argv[2]})
+                if argv[0] == tools["bd"] and argv[1] == "show":
+                    return canonical(next(row for row in rows() if row["id"] == argv[2]))
                 if argv[0] == tools["bd"] and argv[1] == "close":
                     self.assertTrue(Path(state["mayor_request"]).is_file(), "request must exist before admission close")
                     state["close"] += 1
@@ -433,6 +526,7 @@ class FactoryWorkflowTests(unittest.TestCase):
                 rows = self.stable_workflow_rows("agentops-experiment", "experiment-root", self.routes())
                 for row in rows:
                     metadata = row["metadata"]
+                    metadata.update(state["sealed_controls"].get(row["id"], {}))
                     description = ""
                     if metadata.get("gc.step_ref") == "implement.iteration.1":
                         metadata.update({"work_dir": str(work_dir), "gc.packet_path": str(implement_packet)})
@@ -442,7 +536,7 @@ class FactoryWorkflowTests(unittest.TestCase):
                         description = "packet_path=" + str(validate_packet)
                     row.update({"status": "closed" if metadata.get("gc.step_ref") == "agentops-experiment.admission" and state["closed"] else "open", "assignee": None, "description": description})
                 return rows
-            state = {"created": False, "cooks": 0, "cooked": False, "closed": False}
+            state = {"created": False, "cooks": 0, "cooked": False, "closed": False, "sealed_controls": {}}
             original = feeder.run_checked
             original_workspace = feeder.prepare_node_workspace
             def fake(argv, _cwd):
@@ -462,6 +556,12 @@ class FactoryWorkflowTests(unittest.TestCase):
                     return canonical({"ok": True, "formula": "agentops-experiment", "attach_bead_id": "semantic-1", "workflow_root_id": "experiment-root"})
                 if argv[0] == tools["bd"] and argv[1:3] == ["dep", "list"]:
                     return b"[]\n"
+                if argv[0] == tools["bd"] and argv[1] == "update":
+                    state["sealed_controls"][argv[2]] = {
+                        "gc.routed_to": next(value.removeprefix("gc.routed_to=") for value in argv if value.startswith("gc.routed_to=")),
+                        "gc.execution_rig_context": next(value.removeprefix("gc.execution_rig_context=") for value in argv if value.startswith("gc.execution_rig_context=")),
+                    }
+                    return canonical({"id": argv[2]})
                 if argv[0] == tools["bd"] and argv[1] == "show":
                     if argv[2] == "semantic-1":
                         return canonical(semantic_row)

--- a/tests/scripts/gc-agentops-bootstrap.bats
+++ b/tests/scripts/gc-agentops-bootstrap.bats
@@ -314,6 +314,33 @@ for role, provider, qualified_name, scope, directory in (
         "provider": provider,
         "suspended": True,
     })
+city_controls = [
+    patch for patch in patches
+    if patch.get("name") == "core.control-dispatcher" and not patch.get("dir")
+]
+if city_controls != [{"name": "core.control-dispatcher", "suspended": True}]:
+    raise SystemExit("fake gc expected one suspended city control dispatcher")
+agents.append({
+    "name": "control-dispatcher",
+    "qualified_name": "core.control-dispatcher",
+    "dir": "",
+    "scope": "city",
+    "suspended": True,
+})
+for configured_rig in rigs:
+    directory = configured_rig["name"]
+    control_patches = [
+        patch for patch in patches
+        if patch.get("name") == "core.control-dispatcher" and patch.get("dir") == directory
+    ]
+    if len(control_patches) != 1 or not isinstance(control_patches[0].get("suspended"), bool):
+        raise SystemExit(f"fake gc expected one control dispatcher patch for {directory!r}")
+    agents.append({
+        "name": "control-dispatcher",
+        "qualified_name": f"{directory}/core.control-dispatcher",
+        "dir": directory,
+        "suspended": control_patches[0]["suspended"],
+    })
 for role, provider in (
     ("implementer", "codex"),
     ("implementer-claude", "claude"),
@@ -614,8 +641,8 @@ assert [
 assert not [patch for patch in patches if patch.get("name") in {"codex", "claude"}]
 assert [
     patch for patch in patches
-    if patch.get("name") == "core.control-dispatcher" and patch.get("dir") == "agentops" and patch.get("suspended") is True
-] == [{"dir": "agentops", "name": "core.control-dispatcher", "suspended": True}]
+    if patch.get("name") == "core.control-dispatcher" and patch.get("dir") == "agentops" and patch.get("suspended") is False
+] == [{"dir": "agentops", "name": "core.control-dispatcher", "suspended": False}]
 for role in ("implementer", "implementer-claude", "validator"):
     assert not [
         patch for patch in patches


### PR DESCRIPTION
## Summary

- keep the city dispatcher and non-primary rig dispatchers suspended
- activate exactly the selected primary rig dispatcher
- seal Formula control records to that dispatcher before admission and fail closed on malformed or foreign bindings
- verify the effective official GC agent inventory during bootstrap

## Evidence

- fresh Sol-high pre-delivery binding verdict: PASS
- candidate diff digest: c7362c701f417e259194b97572734aed18ebc022f17abcd907681926f9db6fc2
- Python workflow tests: 18/18
- bootstrap Bats: 30/30
- GC executor gate: PASS
- full local release gate: PASS
- two fresh official GC v1.3.5 / BD v1.1.0 zero-model qualifications: PASS

## Residual

Stable GC teardown sometimes leaves its private tmux session after gc stop. Qualification cleanup was scoped and reached zero processes; this upstream-owned residual is disclosed and is not changed here. The post-merge mixed-provider canary remains a separate release gate.