### PR TITLE
fix(gc): bind Mayor attempt to city session

### DIFF
--- a/packs/agentops-factory/assets/scripts/factory_feeder.py
+++ b/packs/agentops-factory/assets/scripts/factory_feeder.py
@@ -441,6 +441,52 @@ def close_inert_step(bd_bin: str, root: Path, record: dict[str, Any], reason: st
     run_checked([bd_bin, "close", str(record["id"]), "--reason", reason, "--json"], root)
 
 
+def bind_city_mayor_attempt(bd_bin: str, root: Path, records: dict[str, dict[str, Any]],
+                            context: dict[str, Any]) -> dict[str, Any]:
+    """Direct the one ready Mayor attempt to its configured city named session."""
+    attempt_ref = "agentops-build.mayor.iteration.1"
+    control_ref = "agentops-build.mayor"
+    attempt_id = context["workflow_steps"][attempt_ref]
+    control_id = context["workflow_steps"][control_ref]
+    root_id = context["workflow_root_id"]
+    route = context["routes"]["mayor"]
+    control = records.get(control_ref)
+    if not isinstance(control, dict) or control.get("id") != control_id:
+        raise FeederError("Mayor control identity differs from the stable workflow")
+    control_metadata = bead_metadata(control, "Mayor control")
+    if (control_metadata.get("gc.kind") != "ralph"
+            or control_metadata.get("gc.step_id") != "mayor"
+            or control_metadata.get("gc.root_bead_id") != root_id):
+        raise FeederError("Mayor control relationship differs from the stable workflow")
+
+    def exact_attempt(row: dict[str, Any], require_assignee: bool) -> None:
+        metadata = bead_metadata(row, "Mayor attempt")
+        if (row.get("id") != attempt_id or row.get("status") != "open"
+                or metadata.get("gc.root_bead_id") != root_id
+                or metadata.get("gc.logical_bead_id") != control_id
+                or metadata.get("gc.step_ref") != "mayor.iteration.1"
+                or metadata.get("gc.step_id") != "mayor"
+                or metadata.get("gc.ralph_step_id") != "mayor"
+                or metadata.get("gc.attempt") != "1"
+                or metadata.get("gc.run_target") != route
+                or metadata.get("gc.routed_to") != route
+                or metadata.get("work_dir") != context["workspace"]):
+            raise FeederError("Mayor attempt differs from the sealed ready workflow")
+        if require_assignee and row.get("assignee") != route:
+            raise FeederError("Mayor attempt did not re-read with the configured named assignee")
+
+    mayor = show_bead(bd_bin, root, attempt_id, "Mayor attempt")
+    exact_attempt(mayor, require_assignee=False)
+    assignee = mayor.get("assignee")
+    if assignee in (None, ""):
+        run_checked([bd_bin, "update", attempt_id, "--assignee", route, "--json"], root)
+        mayor = show_bead(bd_bin, root, attempt_id, "assigned Mayor attempt")
+    elif assignee != route:
+        raise FeederError("Mayor attempt has a foreign assignee")
+    exact_attempt(mayor, require_assignee=True)
+    return mayor
+
+
 def start(args: argparse.Namespace) -> int:
     root = Path(args.root).resolve(strict=True)
     repository = Path(args.repository).resolve(strict=True)
@@ -530,6 +576,7 @@ def start(args: argparse.Namespace) -> int:
     records = seal_compiled_control_dispatcher_routes(
         bd_bin, root, "agentops-build", records, requested_rig_id,
     )
+    mayor_row = bind_city_mayor_attempt(bd_bin, root, records, context)
 
     mayor_request = {
         "schema_version": "factory-role-request.v2", "request_id": program_id + ".mayor",
@@ -542,7 +589,6 @@ def start(args: argparse.Namespace) -> int:
     }
     validate_schema(mayor_request, "factory-role-request.v2.schema.json", "Mayor request")
     atomic_write(mayor_request_path, mayor_request)
-    mayor_row = records["agentops-build.mayor.iteration.1"]
     mayor_meta = mayor_row.get("metadata") if isinstance(mayor_row.get("metadata"), dict) else {}
     if (mayor_meta.get("gc.run_target") != context["routes"]["mayor"]
             or mayor_meta.get("gc.routed_to") != context["routes"]["mayor"]

--- a/tests/python/test_gc33_factory_workflows.py
+++ b/tests/python/test_gc33_factory_workflows.py
@@ -270,7 +270,7 @@ class FactoryWorkflowTests(unittest.TestCase):
         # replay-adoptable workflow instead of an unbound duplicate.
         self.assertIn("{{convoy_id}}", experiment)
 
-    def test_start_binds_mayor_request_before_releasing_build_admission(self) -> None:
+    def test_start_binds_city_mayor_assignment_before_releasing_build_admission(self) -> None:
         feeder = self.feeder()
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -279,7 +279,8 @@ class FactoryWorkflowTests(unittest.TestCase):
             tools = {}
             for name in ("bd", "gc", "git", "gh", "bash", "delivery", "role-adapter", "packet-adapter", "factory-check"):
                 path = root / name; path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8"); path.chmod(0o700); tools[name] = str(path.resolve())
-            state = {"cook": 0, "close": 0, "workspace": "", "mayor_request": "", "base": "a" * 40, "malformed": True, "sealed_controls": {}}
+            state = {"cook": 0, "close": 0, "workspace": "", "mayor_request": "", "base": "a" * 40,
+                     "malformed": True, "sealed_controls": {}, "mayor_assignee": None, "mayor_assigns": 0}
 
             def rows():
                 values = self.stable_workflow_rows("agentops-build", "workflow-1", self.routes())
@@ -294,7 +295,9 @@ class FactoryWorkflowTests(unittest.TestCase):
                         metadata.update({"work_dir": state["workspace"]})
                     if state["malformed"] and metadata.get("gc.step_ref") == "mayor.iteration.1":
                         metadata["gc.step_ref"] = "agentops-build.mayor.iteration.1"
-                    row.update({"status": "closed" if metadata.get("gc.step_ref") == "agentops-build.admission" and state["close"] else "open", "assignee": None, "description": description})
+                    row.update({"status": "closed" if metadata.get("gc.step_ref") == "agentops-build.admission" and state["close"] else "open",
+                                "assignee": state["mayor_assignee"] if metadata.get("gc.step_ref") == "mayor.iteration.1" else None,
+                                "description": description})
                 return values
 
             original = feeder.run_checked
@@ -311,6 +314,11 @@ class FactoryWorkflowTests(unittest.TestCase):
                 if argv[0] == tools["bd"] and argv[1] == "list":
                     return canonical(rows())
                 if argv[0] == tools["bd"] and argv[1] == "update":
+                    if argv[2] == "agentops-build-mayor-iteration-1":
+                        self.assertEqual(argv[3:], ["--assignee", "agentops.mayor", "--json"])
+                        state["mayor_assignee"] = "agentops.mayor"
+                        state["mayor_assigns"] += 1
+                        return canonical({"id": argv[2]})
                     state["sealed_controls"][argv[2]] = {
                         "gc.routed_to": next(value.removeprefix("gc.routed_to=") for value in argv if value.startswith("gc.routed_to=")),
                         "gc.execution_rig_context": next(value.removeprefix("gc.execution_rig_context=") for value in argv if value.startswith("gc.execution_rig_context=")),
@@ -333,9 +341,16 @@ class FactoryWorkflowTests(unittest.TestCase):
                 state["malformed"] = False
                 with redirect_stdout(io.StringIO()):
                     self.assertEqual(feeder.start(args), 0)
+                self.assertEqual(state["mayor_assignee"], "agentops.mayor")
+                self.assertEqual(state["mayor_assigns"], 1)
                 state["base"] = "b" * 40
                 with redirect_stdout(io.StringIO()):
                     self.assertEqual(feeder.start(args), 0)
+                self.assertEqual(state["mayor_assigns"], 1, "exact Mayor assignment must be adopted")
+                state["mayor_assignee"] = "foreign.mayor"
+                with self.assertRaises(feeder.FeederError):
+                    feeder.start(args)
+                self.assertEqual(state["close"], 1, "foreign Mayor assignment must stop before admission close")
             finally:
                 feeder.run_checked = original
             self.assertEqual((state["cook"], state["close"]), (2, 1))


### PR DESCRIPTION
## Outcome

Bind the exact ready rig-store Mayor attempt to the configured city-scoped named Fable session before build admission closes. Exact replay assignments are adopted; foreign assignments and route, workspace, or workflow identity drift fail closed.

## Scope

- packs/agentops-factory/assets/scripts/factory_feeder.py
- tests/python/test_gc33_factory_workflows.py

No Mayor rescope, dispatcher change, GC/BD source change, model policy change, or release/canary work.

## Evidence

- bounded RPI status: PASS
- acceptance digest: `9e0e776157ddba27a89ef1f79ff2240fd3ffec90e5108ef2d7a9c2a9a26fea82`
- subject manifest: `75e247a656e30a9f2f6f77281f6be505b77364a9f1390e6af5afee4f85ff8ecb`
- fresh Sol-high verdict: `8199cd5a0ce96fb920a52e8aae334613ddf2536e92a06de6c4b0429f995ac10d`
- focused RED then GREEN
- complete FactoryWorkflowTests: 18 PASS
- diff check and manifest verification: PASS

## Tracker

`age-gc-scope-failclosed-release-gktia.3`