### PR TITLE
fix(gc): bind pinned lifecycle and drain teardown

### DIFF
--- a/deploy/gc/bootstrap.sh
+++ b/deploy/gc/bootstrap.sh
@@ -55,6 +55,8 @@ PY
 }
 city="$(canonical "$city")"; rig="$(canonical "$rig")"; pack="$(canonical "$pack")"; gc_bin="$(canonical "$gc_bin")"
 gc_bin_dir="$(dirname "$gc_bin")"
+GC_BIN="$gc_bin"
+export GC_BIN
 [ -d "$rig/.git" ] || git -C "$rig" rev-parse --git-dir >/dev/null 2>&1 || die "rig is not a Git repository: $rig"
 [ -f "$rig/.beads/metadata.json" ] && [ -f "$rig/.beads/config.yaml" ] || die "rig must already contain a GC-compatible Beads store and the source bead"
 bead_prefix="$(python3 - "$rig/.beads/config.yaml" <<'PY'

--- a/deploy/gc/invoke.sh
+++ b/deploy/gc/invoke.sh
@@ -54,6 +54,8 @@ print("\x1f".join((gc["path"],t["metrics_url"],t["logs_url"],str(t.get("sdk_disa
 PY
 )" || die "invalid managed city identity"
 IFS=$'\x1f' read -r gc_bin metrics_url logs_url otel_disabled <<<"$identity"
+GC_BIN="$gc_bin"
+export GC_BIN
 export GC_HOME="$city/.gc-home"
 gc_bin_dir="$(dirname "$gc_bin")"
 PATH="$gc_bin_dir:$PATH"; export PATH

--- a/deploy/gc/teardown.sh
+++ b/deploy/gc/teardown.sh
@@ -32,9 +32,11 @@ PY
 IFS=$'\t' read -r gc_bin port otel_disabled <<<"$identity"
 [ -x "$gc_bin" ] || die "managed gc binary is unavailable"
 gc_bin_dir="$(dirname "$gc_bin")"
+GC_BIN="$gc_bin"
+export GC_BIN
 GC_HOME="$city/.gc-home"; PATH="$gc_bin_dir:$PATH"; export GC_HOME PATH
 export OTEL_SDK_DISABLED="$otel_disabled"
-"$gc_bin" --city "$city" stop >/dev/null 2>&1 || true
+"$gc_bin" --city "$city" stop --force >/dev/null 2>&1 || true
 "$gc_bin" supervisor stop --wait --wait-timeout "${wait_timeout}s" >/dev/null 2>&1 || true
 python3 - "$port" <<'PY'
 import socket,sys
@@ -43,14 +45,25 @@ try: s.connect(("127.0.0.1",int(sys.argv[1])))
 except OSError: raise SystemExit(0)
 raise SystemExit("private supervisor still accepts connections")
 PY
-python3 - "$city" "$$" "$PPID" <<'PY'
-import os,subprocess,sys
-root=os.path.realpath(sys.argv[1]); excluded={os.getpid(), *(int(x) for x in sys.argv[2:])}
-rows=subprocess.check_output(["ps","-axo","pid=,command="],text=True).splitlines()
-live=[]
-for row in rows:
-    fields=row.strip().split(None,1)
-    if len(fields)==2 and int(fields[0]) not in excluded and root in fields[1]: live.append(row.strip())
-if live: raise SystemExit("managed city processes remain:\n"+"\n".join(live))
+python3 - "$city" "$wait_timeout" "$$" "$PPID" <<'PY'
+import os,subprocess,sys,time
+root=os.path.realpath(sys.argv[1]); timeout=float(sys.argv[2])
+excluded={os.getpid(), *(int(x) for x in sys.argv[3:])}
+deadline=time.monotonic()+timeout; quiet_since=None; live=[]
+while True:
+    rows=subprocess.check_output(["ps","-axo","pid=,command="],text=True).splitlines()
+    live=[]
+    for row in rows:
+        fields=row.strip().split(None,1)
+        if len(fields)==2 and int(fields[0]) not in excluded and root in fields[1]: live.append(row.strip())
+    now=time.monotonic()
+    if live:
+        quiet_since=None
+    else:
+        quiet_since=quiet_since or now
+        if now-quiet_since >= .5 or now >= deadline: break
+    if now >= deadline:
+        raise SystemExit("managed city processes remain:\n"+"\n".join(live))
+    time.sleep(.1)
 PY
 printf 'Gas City stopped cleanly: %s\n' "$city"

--- a/tests/python/test_gc33_thin_pack.py
+++ b/tests/python/test_gc33_thin_pack.py
@@ -8,6 +8,7 @@ import stat
 import subprocess
 import tempfile
 import textwrap
+import time
 import tomllib
 import unittest
 
@@ -172,6 +173,66 @@ class ThinPackTests(unittest.TestCase):
             self.assertTrue(path.stat().st_mode & stat.S_IXUSR, path)
             result = run("/bin/bash", "-n", str(path))
             self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_lifecycle_helpers_export_the_pinned_gc_binary(self) -> None:
+        for name in ("bootstrap.sh", "invoke.sh", "teardown.sh"):
+            text = (DEPLOY / name).read_text(encoding="utf-8")
+            self.assertIn("export GC_BIN\n", text, name)
+
+    def test_teardown_waits_for_scoped_drain_and_fails_with_exact_residue(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            city = root / "city"
+            marker = city / ".gc/agentops-bootstrap.json"
+            marker.parent.mkdir(parents=True)
+            fake_gc = root / "gc-stub.sh"
+            calls = root / "gc.log"
+            fake_gc.write_text(textwrap.dedent("""\
+                #!/bin/sh
+                printf '%s\\t%s\\n' "${GC_BIN:-}" "$*" >> "$FAKE_GC_LOG"
+                exit 0
+                """), encoding="utf-8")
+            fake_gc.chmod(0o755)
+            marker.write_text(json.dumps({
+                "schema_version": 1,
+                "city": str(city.resolve()),
+                "toolchain": {"gc": {"path": str(fake_gc.resolve())}},
+                "supervisor_port": 65534,
+                "telemetry": {"sdk_disabled": True},
+            }), encoding="utf-8")
+            env = os.environ.copy()
+            env["FAKE_GC_LOG"] = str(calls)
+
+            draining = subprocess.Popen([
+                "python3", "-c", "import time; time.sleep(0.8)", str(city.resolve()),
+            ])
+            started = time.monotonic()
+            result = run(
+                str(DEPLOY / "teardown.sh"), "--city", str(city), "--wait-timeout", "3",
+                env=env,
+            )
+            elapsed = time.monotonic() - started
+            draining.wait(timeout=3)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertGreaterEqual(elapsed, 0.3)
+            log = calls.read_text(encoding="utf-8")
+            self.assertIn(f"{fake_gc.resolve()}\t--city {city.resolve()} stop --force", log)
+            self.assertIn(f"{fake_gc.resolve()}\tsupervisor stop --wait --wait-timeout 3s", log)
+
+            stuck = subprocess.Popen([
+                "python3", "-c", "import time; time.sleep(10)", str(city.resolve()),
+            ])
+            try:
+                failed = run(
+                    str(DEPLOY / "teardown.sh"), "--city", str(city), "--wait-timeout", "1",
+                    env=env,
+                )
+                self.assertNotEqual(failed.returncode, 0)
+                self.assertIn("managed city processes remain", failed.stderr)
+                self.assertIn(str(city.resolve()), failed.stderr)
+            finally:
+                stuck.terminate()
+                stuck.wait(timeout=3)
 
     def test_worktree_helper_creates_one_isolated_idempotent_branch(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Outcome

Repairs the single lifecycle boundary exposed by the first post-merge AgentOps Gas City canary.

- Exports the exact marker/toolchain-bound `GC_BIN` from bootstrap, invoke, and teardown before official GC behavior.
- Uses official `gc stop --force`, then stops the private supervisor.
- Waits up to the declared timeout for processes scoped to the exact canonical city root to drain.
- Reports the exact remaining process rows on timeout.

No GC/BD fork change, role/formula/model change, new daemon, or live-city repair is included.

## Evidence

- Focused regressions: 2/2 passed.
- ShellCheck warning severity: passed.
- Thin-pack gate against pinned GC: 11 tests passed, 2 expected skips.
- Exact pinned native integration: 11/11 passed in 115.638s.
- Subject manifest: `3d9a7816ed6807f843fd805e0462a16ff9589eb9a3a0b572da4d4039d5ed319a`.
- Fresh Sol-high verdict: PASS, `230bd8e56d29bcf926ef772b749d1fb9c1f7550a92ccb6f6653630ddfdad1c4c`.
- Validated candidate head: `fe5a1248fa9eaa97aa6bc97f86d551c5bdbbd66c`.

## Release boundary

Hosted CI and one wholly fresh terminal mixed-provider canary remain required after this repair merges. There will be no third canary or in-city repair loop.
