### PR TITLE
fix(gc): fetch official toolchain archives and label pack preview

### DIFF
--- a/deploy/gc/README.md
+++ b/deploy/gc/README.md
@@ -1,5 +1,9 @@
 # AgentOps Gas City pack
 
+**Status: preview.** This pack is promoted to supported after the next official
+Gas City release is pinned, deterministically qualified, and one clean canary
+passes.
+
 This is a thin AgentOps role pack over official Gas City. Gas City owns
 sessions, routing, formulas, orders, and OTEL. Beads owns work and dependencies.
 Git owns candidate commits, AgentOps owns the final semantic verdict, and
@@ -11,9 +15,36 @@ GitHub owns PR, CI, and merge state.
 deploy/gc/materialize-toolchain.sh --output /path/to/toolchain
 ```
 
+This downloads the official prebuilt Gas City and Beads release archives,
+verifies each against its pinned official checksums file, installs `bin/gc` and
+`bin/bd`, and writes `toolchain.json`. No compiler, `git`, or `make` is
+required; the tools it uses are `curl`, `tar`, `python3`, and
+`shasum`/`sha256sum`. It fetches the plain GitHub release download URLs, so no
+`gh` authentication is needed.
+
 The adjacent lock pins Gas City v1.3.5 at
 `8ffc009ded781a2ada2077f3a29bd712b2def0bf` and Beads v1.1.0 at
 `8e4e59d39f3459a43cf21a3236a13eca4dd874f7`.
+
+## Known upstream issues (Gas City v1.3.5)
+
+**Cross-store claim failure — the default automated feed loop does not work on
+v1.3.5.** The pack's default automated path feeds a rig-owned source bead to the
+city-scoped Mayor: `invoke.sh` (line ~69) runs `gc sling agentops.mayor BEAD
+--nudge`, and the Mayor is `scope = "city"` (`agents/mayor/agent.toml` line 1,
+wired through `packs/agentops-factory/pack.toml` line ~8). On v1.3.5 the
+city-scoped Mayor federated-reads the bead across rig stores and finds it, but
+the claim mutation runs against the Mayor's own city store and returns `bead not
+found`. This is deterministic: the first Mayor claim of a rig-fed bead fails
+every time, for every default user. The preview is usable at v1.3.5 for
+bootstrap, inspection, teardown, and manual flows; the automated feed loop
+becomes functional at the next official Gas City release (fix already merged
+upstream in commits `a135117945e2` and `3fa9bb38e916`).
+
+**Teardown hang.** On v1.3.5 the tmux teardown can rarely hang under process
+churn, from a recursive live process-walk with PID reuse. Workaround: kill the
+hung teardown and re-run `teardown.sh`. The fix is in upstream review
+(gastownhall/gascity PR #3985).
 
 ## Bootstrap
 

--- a/deploy/gc/materialize-toolchain.sh
+++ b/deploy/gc/materialize-toolchain.sh
@@ -6,8 +6,14 @@ usage() {
   cat <<'EOF'
 Usage: materialize-toolchain.sh --output DIR [--pair ID] [--lock FILE] [--describe]
 
-Build only the exact official Gas City and Beads pair selected from the lock.
-The output contains bin/gc, bin/bd, and toolchain.json.
+Fetch only the exact official Gas City and Beads pair selected from the lock.
+Official prebuilt release archives are downloaded, verified against the pinned
+official checksums, and installed as bin/gc, bin/bd, and toolchain.json. No
+source is compiled and no fork or custom binary is produced.
+
+Set AGENTOPS_GC_ARCHIVE_CACHE=DIR to install pre-placed release assets from DIR
+(each asset named exactly as its upstream release asset) instead of downloading.
+The checksum verification chain is identical in both modes.
 EOF
 }
 
@@ -27,7 +33,14 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-for tool in python3 git make install; do command -v "$tool" >/dev/null || die "$tool is required"; done
+for tool in python3 curl tar; do command -v "$tool" >/dev/null || die "$tool is required"; done
+if command -v shasum >/dev/null; then
+  sha256_of() { shasum -a 256 "$1" | awk '{print $1}'; }
+elif command -v sha256sum >/dev/null; then
+  sha256_of() { sha256sum "$1" | awk '{print $1}'; }
+else
+  die "shasum or sha256sum is required"
+fi
 [ -f "$lock" ] || die "lock not found: $lock"
 selection="$(python3 - "$lock" "$pair_id" <<'PY'
 import json, re, sys
@@ -41,12 +54,16 @@ if not isinstance(selected, dict):
     raise SystemExit("requested or qualified toolchain pair not found")
 for name in ("gc", "bd"):
     item = selected.get(name)
-    for field in ("repository", "ref", "version", "source_commit", "release_checksum_asset", "release_checksum_sha256"):
+    for field in ("repository", "ref", "version", "source_commit", "runtime_commit", "release_checksum_asset", "release_checksum_sha256"):
         value = item.get(field) if isinstance(item, dict) else None
         if not isinstance(value, str) or not value:
             raise SystemExit(f"invalid {name}.{field}")
     if not re.fullmatch(r"[0-9a-f]{40}", item["source_commit"]):
         raise SystemExit(f"invalid {name}.source_commit")
+    if not re.fullmatch(r"[0-9a-f]{7,40}", item["runtime_commit"]):
+        raise SystemExit(f"invalid {name}.runtime_commit")
+    if not item["source_commit"].startswith(item["runtime_commit"]):
+        raise SystemExit(f"{name}.runtime_commit is not a prefix of source_commit")
     if not re.fullmatch(r"[0-9a-f]{64}", item["release_checksum_sha256"]):
         raise SystemExit(f"invalid {name}.release_checksum_sha256")
 print(json.dumps(selected, sort_keys=True, separators=(",", ":")))
@@ -65,44 +82,94 @@ if [ -e "$output" ]; then
   [ -z "$(find "$output" -mindepth 1 -maxdepth 1 -print -quit)" ] || die "output is not empty: $output"
 fi
 
-fields=()
+# Detect the running platform and map it to the official release archive tag.
+os_raw="$(uname -s)"; arch_raw="$(uname -m)"
+case "$os_raw" in
+  Darwin) os_tag="darwin" ;;
+  Linux) os_tag="linux" ;;
+  *) die "unsupported operating system: $os_raw (supported: Darwin, Linux)" ;;
+esac
+case "$arch_raw" in
+  arm64|aarch64) arch_tag="arm64" ;;
+  x86_64|amd64) arch_tag="amd64" ;;
+  *) die "unsupported architecture: $arch_raw (supported: arm64/aarch64, x86_64/amd64)" ;;
+esac
+platform="${os_tag}_${arch_tag}"
+
+# Project the exact download coordinates for each tool from the verified lock.
+meta=()
 while IFS= read -r field; do
-  fields[${#fields[@]}]="$field"
+  meta[${#meta[@]}]="$field"
 done < <(python3 - "$selection" <<'PY'
 import json, sys
 s = json.loads(sys.argv[1])
-for value in (s["id"], s["status"], s["gc"]["repository"], s["gc"]["ref"], s["gc"]["version"], s["gc"]["source_commit"], s["bd"]["repository"], s["bd"]["ref"], s["bd"]["version"], s["bd"]["source_commit"]):
+def coords(item):
+    repo = item["repository"]
+    slug = repo[len("https://github.com/"):] if repo.startswith("https://github.com/") else repo
+    if slug.endswith(".git"):
+        slug = slug[:-len(".git")]
+    name = slug.rsplit("/", 1)[-1]
+    return [slug, item["ref"], item["version"], name, item["release_checksum_asset"], item["release_checksum_sha256"]]
+for value in coords(s["gc"]) + coords(s["bd"]):
     print(value)
 PY
 )
-[ "${#fields[@]}" -eq 10 ] || die "selected pair projection is incomplete"
+[ "${#meta[@]}" -eq 12 ] || die "selected pair projection is incomplete"
+
 parent="$(dirname "$output")"
 mkdir -p "$parent"
 sources="$(mktemp -d "$parent/.gc-sources.XXXXXX")"
 stage="$(mktemp -d "$parent/.gc-stage.XXXXXX")"
 cleanup() { rm -rf "$sources" "$stage"; }
 trap cleanup EXIT
-
-checkout_exact() {
-  local repository="$1" ref="$2" version="$3" commit="$4" destination="$5"
-  git init -q "$destination"
-  git -C "$destination" remote add origin "$repository"
-  git -C "$destination" fetch -q --depth=1 origin "$commit" || die "cannot fetch $commit"
-  if [ "$ref" = "v$version" ]; then
-    git -C "$destination" fetch -q --depth=1 origin "refs/tags/$ref:refs/tags/$ref" || die "cannot fetch $ref"
-    [ "$(git -C "$destination" rev-parse "$ref^{}")" = "$commit" ] || die "$ref does not resolve to $commit"
-    git -C "$destination" tag -f "$ref" "$commit" >/dev/null
-  fi
-  git -C "$destination" checkout -q --detach "$commit"
-}
-checkout_exact "${fields[2]}" "${fields[3]}" "${fields[4]}" "${fields[5]}" "$sources/gc"
-checkout_exact "${fields[6]}" "${fields[7]}" "${fields[8]}" "${fields[9]}" "$sources/bd"
-make -s -C "$sources/gc" build
-make -s -C "$sources/bd" build
 mkdir -p "$stage/bin"
-install -m 0755 "$sources/gc/bin/gc" "$stage/bin/gc"
-install -m 0755 "$sources/bd/bd" "$stage/bin/bd"
 
+fetch_asset() {
+  local slug="$1" ref="$2" asset="$3" dest="$4"
+  if [ -n "${AGENTOPS_GC_ARCHIVE_CACHE:-}" ]; then
+    local cached="$AGENTOPS_GC_ARCHIVE_CACHE/$asset"
+    [ -f "$cached" ] || die "cached asset not found: $cached"
+    cp "$cached" "$dest"
+  else
+    curl -fsSL -o "$dest" "https://github.com/$slug/releases/download/$ref/$asset" || die "cannot download $asset from $slug $ref"
+  fi
+}
+
+install_tool() {
+  local slug="$1" ref="$2" version="$3" name="$4" ck_asset="$5" ck_sha="$6" binname="$7"
+  local archive="${name}_${version}_${platform}.tar.gz"
+
+  # 1. Fetch the official checksums asset and verify it against the lock.
+  local ck_file="$sources/${name}.checksums"
+  fetch_asset "$slug" "$ref" "$ck_asset" "$ck_file"
+  local got_ck_sha; got_ck_sha="$(sha256_of "$ck_file")"
+  [ "$got_ck_sha" = "$ck_sha" ] || die "$name checksums asset $ck_asset sha256 mismatch: got $got_ck_sha want $ck_sha"
+
+  # 2. Fetch the platform archive and verify it against the verified checksums.
+  local archive_path="$sources/$archive"
+  fetch_asset "$slug" "$ref" "$archive" "$archive_path"
+  local expected_sha
+  expected_sha="$(awk -v want="$archive" '{f=$2; sub(/^\*/,"",f); if (f==want) print $1}' "$ck_file" | head -n1)"
+  [ -n "$expected_sha" ] || die "$name archive $archive is not listed in verified checksums $ck_asset (unsupported platform?)"
+  local got_sha; got_sha="$(sha256_of "$archive_path")"
+  [ "$got_sha" = "$expected_sha" ] || die "$name archive $archive sha256 mismatch: got $got_sha want $expected_sha"
+
+  # 3. Extract and install the exact binary.
+  local extract="$sources/${name}.extract"
+  mkdir -p "$extract"
+  tar -xzf "$archive_path" -C "$extract" || die "cannot extract $archive"
+  local bin_src
+  bin_src="$(find "$extract" -type f -name "$binname" | LC_ALL=C sort | head -n1)"
+  [ -n "$bin_src" ] || die "$binname binary not found inside $archive"
+  cp "$bin_src" "$stage/bin/$binname"
+  chmod 0755 "$stage/bin/$binname"
+}
+
+install_tool "${meta[0]}" "${meta[1]}" "${meta[2]}" "${meta[3]}" "${meta[4]}" "${meta[5]}" gc
+install_tool "${meta[6]}" "${meta[7]}" "${meta[8]}" "${meta[9]}" "${meta[10]}" "${meta[11]}" bd
+
+# 4. Verify each installed binary reports the locked version and commit, then
+#    write the toolchain receipt. Any identity drift is a hard error.
 python3 - "$stage/bin/gc" "$stage/bin/bd" "$selection" "$stage/toolchain.json" <<'PY'
 import hashlib, json, re, subprocess, sys
 gc_path, bd_path, selection, receipt_path = sys.argv[1:]
@@ -110,7 +177,7 @@ selected = json.loads(selection)
 def run(argv):
     result = subprocess.run(argv, check=False, capture_output=True, text=True)
     if result.returncode:
-        raise SystemExit((result.stderr or result.stdout).strip())
+        raise SystemExit((result.stderr or result.stdout).strip() or f"{argv[0]} version failed")
     return result.stdout
 def sha(path):
     h = hashlib.sha256()
@@ -118,14 +185,34 @@ def sha(path):
         for block in iter(lambda: f.read(1024 * 1024), b""):
             h.update(block)
     return h.hexdigest()
+def commit_hex(text):
+    match = re.match(r"[0-9a-f]+", text.strip().lower())
+    return match.group(0) if match else ""
+def verify(name, version, reported_commit):
+    locked = selected[name]
+    if version != locked["version"]:
+        raise SystemExit(f"installed {name} version {version!r} differs from locked {locked['version']!r}")
+    if not reported_commit:
+        raise SystemExit(f"installed {name} binary reports no commit")
+    if not locked["source_commit"].startswith(reported_commit):
+        raise SystemExit(f"installed {name} commit {reported_commit!r} is not the locked source commit {locked['source_commit']!r}")
+    if not reported_commit.startswith(locked["runtime_commit"]):
+        raise SystemExit(f"installed {name} commit {reported_commit!r} does not match locked runtime commit {locked['runtime_commit']!r}")
+
 gc = json.loads(run([gc_path, "version", "--json"]))
+gc_version = str(gc.get("version", ""))
+gc_commit = commit_hex(str(gc.get("commit", "")))
+verify("gc", gc_version, gc_commit)
+
 bd_text = run([bd_path, "version"])
-match = re.search(r"^bd version (\S+) \(([^:)]+)", bd_text, re.M)
-if gc.get("version") != selected["gc"]["version"] or not selected["gc"]["source_commit"].startswith(str(gc.get("commit", ""))):
-    raise SystemExit("built Gas City identity differs from lock")
-if match is None or match.group(1) != selected["bd"]["version"] or not selected["bd"]["source_commit"].startswith(match.group(2)):
-    raise SystemExit("built Beads identity differs from lock")
-receipt = {"schema_version": 2, "pair": selected, "runtime": {"gc": {"path": "bin/gc", "version": gc["version"], "commit": gc["commit"], "sha256": sha(gc_path)}, "bd": {"path": "bin/bd", "version": match.group(1), "commit": match.group(2), "sha256": sha(bd_path)}}}
+match = re.search(r"^bd version (\S+) \(([0-9a-f]+)", bd_text, re.M)
+if match is None:
+    raise SystemExit("cannot parse Beads version output")
+bd_version = match.group(1)
+bd_commit = commit_hex(match.group(2))
+verify("bd", bd_version, bd_commit)
+
+receipt = {"schema_version": 2, "pair": selected, "runtime": {"gc": {"path": "bin/gc", "version": gc_version, "commit": gc_commit, "sha256": sha(gc_path)}, "bd": {"path": "bin/bd", "version": bd_version, "commit": bd_commit, "sha256": sha(bd_path)}}}
 with open(receipt_path, "w", encoding="utf-8") as f:
     json.dump(receipt, f, indent=2, sort_keys=True); f.write("\n")
 PY
@@ -135,4 +222,4 @@ mv "$stage" "$output"
 stage="$parent/.gc-stage.consumed"
 trap - EXIT
 rm -rf "$sources"
-printf 'materialized %s (%s) at %s\n' "${fields[0]}" "${fields[1]}" "$output"
+printf 'materialized %s (%s) at %s\n' "${meta[3]}" "$platform" "$output"

--- a/tests/python/test_gc33_thin_pack.py
+++ b/tests/python/test_gc33_thin_pack.py
@@ -4,8 +4,10 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import platform
 import stat
 import subprocess
+import tarfile
 import tempfile
 import textwrap
 import time
@@ -164,6 +166,203 @@ class ThinPackTests(unittest.TestCase):
         self.assertIn(BD_COMMIT, bootstrap)
         self.assertIn('--prefix "$bead_prefix" --start-suspended --adopt', bootstrap)
         self.assertNotIn('"$bd_bin" init', bootstrap)
+
+    # --- Offline materialize-toolchain fixtures -------------------------------
+    #
+    # materialize-toolchain.sh downloads official prebuilt release archives and
+    # verifies them against the pinned official checksums. These fixtures drive
+    # the identical verification chain fully offline: AGENTOPS_GC_ARCHIVE_CACHE
+    # supplies pre-placed assets instead of the network, and --lock supplies a
+    # fixture lock that pins the fabricated fixture shas. No test hits GitHub.
+
+    @staticmethod
+    def platform_tag() -> str | None:
+        system = {"Darwin": "darwin", "Linux": "linux"}.get(platform.system())
+        machine = {"arm64": "arm64", "aarch64": "arm64", "x86_64": "amd64", "amd64": "amd64"}.get(platform.machine())
+        if not system or not machine:
+            return None
+        return f"{system}_{machine}"
+
+    def build_offline_fixture(self, root: Path) -> dict[str, object]:
+        tag = self.platform_tag()
+        if tag is None:
+            self.skipTest(f"no release-archive mapping for {platform.system()}/{platform.machine()}")
+        cache = root / "cache"
+        cache.mkdir()
+        gc_script = (
+            '#!/bin/sh\n'
+            'if [ "$1" = "version" ] && [ "$2" = "--json" ]; then\n'
+            '  printf \'{"version":"1.3.5","commit":"%s-dirty","ok":true}\\n\' '
+            '"8ffc009ded781a2ada2077f3a29bd712b2def0bf"\n'
+            '  exit 0\n'
+            'fi\n'
+            'exit 1\n'
+        )
+        bd_script = (
+            '#!/bin/sh\n'
+            'if [ "$1" = "version" ]; then\n'
+            '  printf \'bd version 1.1.0 (8e4e59d39: fixture@8e4e59d39f34)\\n\'\n'
+            '  exit 0\n'
+            'fi\n'
+            'exit 1\n'
+        )
+
+        def make_archive(archive_name: str, binname: str, script: str) -> Path:
+            src = root / (binname + "_src")
+            src.mkdir(exist_ok=True)
+            binpath = src / binname
+            binpath.write_text(script, encoding="utf-8")
+            binpath.chmod(0o755)
+            archive_path = cache / archive_name
+            with tarfile.open(archive_path, "w:gz") as tf:
+                tf.add(binpath, arcname=binname)
+            return archive_path
+
+        def sha256(path: Path) -> str:
+            return hashlib.sha256(path.read_bytes()).hexdigest()
+
+        gc_archive_name = f"gascity_1.3.5_{tag}.tar.gz"
+        bd_archive_name = f"beads_1.1.0_{tag}.tar.gz"
+        gc_archive = make_archive(gc_archive_name, "gc", gc_script)
+        bd_archive = make_archive(bd_archive_name, "bd", bd_script)
+
+        gc_ck = cache / "gascity_1.3.5_checksums.txt"
+        gc_ck.write_text(f"{sha256(gc_archive)}  {gc_archive_name}\n", encoding="utf-8")
+        bd_ck = cache / "checksums.txt"
+        bd_ck.write_text(f"{sha256(bd_archive)}  {bd_archive_name}\n", encoding="utf-8")
+
+        lock = {
+            "schema_version": 1,
+            "accepted_pairs": [
+                {
+                    "id": "gascity-v1.3.5-beads-v1.1.0",
+                    "status": "qualified",
+                    "gc": {
+                        "repository": "https://github.com/gastownhall/gascity.git",
+                        "ref": "v1.3.5",
+                        "version": "1.3.5",
+                        "source_commit": GC_COMMIT,
+                        "runtime_commit": "8ffc009d",
+                        "release_checksum_asset": "gascity_1.3.5_checksums.txt",
+                        "release_checksum_sha256": sha256(gc_ck),
+                    },
+                    "bd": {
+                        "repository": "https://github.com/steveyegge/beads.git",
+                        "ref": "v1.1.0",
+                        "version": "1.1.0",
+                        "source_commit": BD_COMMIT,
+                        "runtime_commit": "8e4e59d39",
+                        "release_checksum_asset": "checksums.txt",
+                        "release_checksum_sha256": sha256(bd_ck),
+                    },
+                }
+            ],
+        }
+        lock_path = root / "toolchain.lock.json"
+        lock_path.write_text(json.dumps(lock, indent=2), encoding="utf-8")
+        return {
+            "cache": cache,
+            "lock": lock_path,
+            "gc_ck": gc_ck,
+            "bd_ck": bd_ck,
+            "gc_archive_name": gc_archive_name,
+            "bd_archive_name": bd_archive_name,
+            "tag": tag,
+        }
+
+    def run_materialize(self, output: Path, lock: Path, cache: Path, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["AGENTOPS_GC_ARCHIVE_CACHE"] = str(cache)
+        if extra_env:
+            env.update(extra_env)
+        return run(
+            str(DEPLOY / "materialize-toolchain.sh"), "--output", str(output), "--lock", str(lock),
+            env=env,
+        )
+
+    def test_materialize_offline_happy_path_installs_verified_pair(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fixture = self.build_offline_fixture(root)
+            output = root / "toolchain"
+            result = self.run_materialize(output, fixture["lock"], fixture["cache"])
+            self.assertEqual(result.returncode, 0, result.stderr)
+            gc_bin = output / "bin/gc"
+            bd_bin = output / "bin/bd"
+            self.assertTrue(gc_bin.is_file())
+            self.assertTrue(bd_bin.is_file())
+            self.assertTrue(gc_bin.stat().st_mode & stat.S_IXUSR)
+            self.assertTrue(bd_bin.stat().st_mode & stat.S_IXUSR)
+            receipt = json.loads((output / "toolchain.json").read_text(encoding="utf-8"))
+            self.assertEqual(receipt["schema_version"], 2)
+            self.assertEqual(set(receipt["runtime"]), {"gc", "bd"})
+            self.assertEqual(receipt["runtime"]["gc"]["path"], "bin/gc")
+            self.assertEqual(receipt["runtime"]["bd"]["path"], "bin/bd")
+            self.assertEqual(receipt["runtime"]["gc"]["version"], "1.3.5")
+            self.assertEqual(receipt["runtime"]["bd"]["version"], "1.1.0")
+            self.assertEqual(receipt["runtime"]["gc"]["commit"], GC_COMMIT)
+            self.assertEqual(receipt["runtime"]["bd"]["commit"], "8e4e59d39")
+            self.assertEqual(receipt["runtime"]["gc"]["sha256"], hashlib.sha256(gc_bin.read_bytes()).hexdigest())
+            self.assertEqual(receipt["runtime"]["bd"]["sha256"], hashlib.sha256(bd_bin.read_bytes()).hexdigest())
+            self.assertEqual(receipt["pair"]["status"], "qualified")
+            self.assertEqual(receipt["pair"]["gc"]["source_commit"], GC_COMMIT)
+            self.assertEqual(receipt["pair"]["bd"]["source_commit"], BD_COMMIT)
+
+    def test_materialize_offline_rejects_checksums_file_tamper(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fixture = self.build_offline_fixture(root)
+            lock_path = fixture["lock"]
+            lock = json.loads(lock_path.read_text(encoding="utf-8"))
+            lock["accepted_pairs"][0]["gc"]["release_checksum_sha256"] = "0" * 64
+            lock_path.write_text(json.dumps(lock, indent=2), encoding="utf-8")
+            output = root / "toolchain"
+            result = self.run_materialize(output, lock_path, fixture["cache"])
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("checksums asset", result.stderr)
+            self.assertIn("sha256 mismatch", result.stderr)
+            self.assertFalse(output.exists())
+
+    def test_materialize_offline_rejects_archive_tamper(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fixture = self.build_offline_fixture(root)
+            # Point the checksums file at a wrong archive digest, then re-pin the
+            # lock to the tampered checksums file so its own digest still passes.
+            gc_ck = fixture["gc_ck"]
+            tampered = f"{'0' * 64}  {fixture['gc_archive_name']}\n"
+            gc_ck.write_text(tampered, encoding="utf-8")
+            lock_path = fixture["lock"]
+            lock = json.loads(lock_path.read_text(encoding="utf-8"))
+            lock["accepted_pairs"][0]["gc"]["release_checksum_sha256"] = hashlib.sha256(tampered.encode()).hexdigest()
+            lock_path.write_text(json.dumps(lock, indent=2), encoding="utf-8")
+            output = root / "toolchain"
+            result = self.run_materialize(output, lock_path, fixture["cache"])
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("archive", result.stderr)
+            self.assertIn("sha256 mismatch", result.stderr)
+            self.assertFalse(output.exists())
+
+    def test_materialize_rejects_unsupported_platform(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fixture = self.build_offline_fixture(root)
+            stub_dir = root / "stub"
+            stub_dir.mkdir()
+            uname = stub_dir / "uname"
+            uname.write_text(
+                '#!/bin/sh\nif [ "$1" = "-s" ]; then echo Plan9; else echo sparc; fi\n',
+                encoding="utf-8",
+            )
+            uname.chmod(0o755)
+            output = root / "toolchain"
+            result = self.run_materialize(
+                output, fixture["lock"], fixture["cache"],
+                extra_env={"PATH": f"{stub_dir}:{os.environ['PATH']}"},
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unsupported operating system", result.stderr)
+            self.assertFalse(output.exists())
 
     def test_executable_helper_budget_and_shell_syntax(self) -> None:
         scripts = sorted(DEPLOY.glob("*.sh"))

--- a/tests/python/test_gc33_thin_pack.py
+++ b/tests/python/test_gc33_thin_pack.py
@@ -183,7 +183,20 @@ class ThinPackTests(unittest.TestCase):
             return None
         return f"{system}_{machine}"
 
-    def build_offline_fixture(self, root: Path) -> dict[str, object]:
+    def build_offline_fixture(
+        self,
+        root: Path,
+        *,
+        gc_reported_version: str = "1.3.5",
+        gc_reported_commit: str = "8ffc009ded781a2ada2077f3a29bd712b2def0bf",
+        bd_reported_version: str = "1.1.0",
+        bd_reported_commit: str = "8e4e59d39",
+    ) -> dict[str, object]:
+        # The lock always pins the correct locked identity; only what the stub
+        # binaries *report* varies. The checksum chain stays internally valid for
+        # any stub content (checksums file and lock are derived from the actual
+        # archive digests), so a reported-identity mismatch isolates the final
+        # version/commit binding step from the earlier hash links.
         tag = self.platform_tag()
         if tag is None:
             self.skipTest(f"no release-archive mapping for {platform.system()}/{platform.machine()}")
@@ -192,8 +205,8 @@ class ThinPackTests(unittest.TestCase):
         gc_script = (
             '#!/bin/sh\n'
             'if [ "$1" = "version" ] && [ "$2" = "--json" ]; then\n'
-            '  printf \'{"version":"1.3.5","commit":"%s-dirty","ok":true}\\n\' '
-            '"8ffc009ded781a2ada2077f3a29bd712b2def0bf"\n'
+            '  printf \'{"version":"' + gc_reported_version + '","commit":"'
+            + gc_reported_commit + '-dirty","ok":true}\\n\'\n'
             '  exit 0\n'
             'fi\n'
             'exit 1\n'
@@ -201,7 +214,8 @@ class ThinPackTests(unittest.TestCase):
         bd_script = (
             '#!/bin/sh\n'
             'if [ "$1" = "version" ]; then\n'
-            '  printf \'bd version 1.1.0 (8e4e59d39: fixture@8e4e59d39f34)\\n\'\n'
+            '  printf \'bd version ' + bd_reported_version + ' ('
+            + bd_reported_commit + ': fixture)\\n\'\n'
             '  exit 0\n'
             'fi\n'
             'exit 1\n'
@@ -362,6 +376,33 @@ class ThinPackTests(unittest.TestCase):
             )
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("unsupported operating system", result.stderr)
+            self.assertFalse(output.exists())
+
+    def test_materialize_offline_rejects_gc_commit_mismatch(self) -> None:
+        # Valid checksum chain, but the installed gc binary reports a different
+        # commit than the lock pins. Exercises the gc version/commit binding.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fixture = self.build_offline_fixture(
+                root, gc_reported_commit="1234567890abcdef1234567890abcdef12345678",
+            )
+            output = root / "toolchain"
+            result = self.run_materialize(output, fixture["lock"], fixture["cache"])
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("installed gc commit", result.stderr)
+            self.assertFalse(output.exists())
+
+    def test_materialize_offline_rejects_bd_version_mismatch(self) -> None:
+        # Valid checksum chain, but the installed bd binary reports a different
+        # version than the lock pins. Exercises the bd version/commit binding.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fixture = self.build_offline_fixture(root, bd_reported_version="9.9.9")
+            output = root / "toolchain"
+            result = self.run_materialize(output, fixture["lock"], fixture["cache"])
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("installed bd version", result.stderr)
+            self.assertIn("9.9.9", result.stderr)
             self.assertFalse(output.exists())
 
     def test_executable_helper_budget_and_shell_syntax(self) -> None:


### PR DESCRIPTION
## What

Three commits executing the official-artifacts-only GC pack release path:

1. **c07d10d66** `fix(gc)`: `materialize-toolchain.sh` now downloads the official gastownhall/gascity v1.3.5 and steveyegge/beads v1.1.0 release archives instead of compiling from source. Fail-closed verification chain: lock-pinned sha256 of the official checksums asset → archive sha256 against the verified checksums file → installed binary must report the locked version/commit. Users need curl+tar+shasum; no git/make/compiler. Offline test mode via `AGENTOPS_GC_ARCHIVE_CACHE` with the identical verification path.
2. **95e83f8d8** `docs(gc)`: README labels the pack **preview** and discloses the two v1.3.5 upstream defects: the default automated feed→claim loop fails deterministically (city-scoped Mayor claims a rig-fed bead against the city store → `bead not found`; fixed upstream in a135117945e2/3fa9bb38e916, arrives at the next official release) and the rare tmux teardown hang (upstream PR gastownhall/gascity#3985). Preview → supported after the next official pin bump, deterministic qualification, and one clean canary.
3. **0318a2429** `test(gc)`: negative tests proving the binary version/commit binding fails closed (added after cross-family review found the guard untested; verified the tests fail when the guard is neutered).

## Verification

- `python3 -m unittest tests.python.test_gc33_thin_pack`: 17 tests, 15 pass + 2 integration skips (need materialized GC_BIN)
- Live network run: downloaded, checksum-verified, and version-bound both official binaries (gc 1.3.5 @ 8ffc009d…, bd 1.1.0 @ 8e4e59d39…)
- `shellcheck -S warning deploy/gc/*.sh` clean
- Cross-family (Codex) adversarial review: 1 MAJOR found → fixed in commit 3; no fail-open findings in the verification chain

## Scope

`deploy/gc/materialize-toolchain.sh`, `deploy/gc/README.md`, `tests/python/test_gc33_thin_pack.py` only. No fork artifacts, no lock change — pin stays official v1.3.5.