### PR TITLE
fix(gc): route pack intake through rig-scoped dispatch (official GC pattern)

### DIFF
--- a/deploy/gc/README.md
+++ b/deploy/gc/README.md
@@ -28,18 +28,15 @@ The adjacent lock pins Gas City v1.3.5 at
 
 ## Known upstream issues (Gas City v1.3.5)
 
-**Cross-store claim failure — the default automated feed loop does not work on
-v1.3.5.** The pack's default automated path feeds a rig-owned source bead to the
-city-scoped Mayor: `invoke.sh` (line ~69) runs `gc sling agentops.mayor BEAD
---nudge`, and the Mayor is `scope = "city"` (`agents/mayor/agent.toml` line 1,
-wired through `packs/agentops-factory/pack.toml` line ~8). On v1.3.5 the
-city-scoped Mayor federated-reads the bead across rig stores and finds it, but
-the claim mutation runs against the Mayor's own city store and returns `bead not
-found`. This is deterministic: the first Mayor claim of a rig-fed bead fails
-every time, for every default user. The preview is usable at v1.3.5 for
-bootstrap, inspection, teardown, and manual flows; the automated feed loop
-becomes functional at the next official Gas City release (fix already merged
-upstream in commits `a135117945e2` and `3fa9bb38e916`).
+**Cross-store claim bug — not exercised by the pack's default flow.** On v1.3.5,
+a *city-scoped* agent that claims a *rig-homed* bead federated-reads it across
+rig stores and finds it, but the claim mutation runs against the agent's own
+city store and returns `bead not found`. The pack's default intake never does
+this: `invoke.sh feed` homes the source bead in the rig store and slings the
+native `agentops-experiment` formula to the *rig-scoped* planner, so only rig
+roles ever claim it (a rig-scoped agent claiming a rig-homed bead is unchanged
+and safe). The bug affects only city-scoped agents that claim — for example a
+custom Mayor rewired to claim source beads. It is fixed upstream after v1.3.5.
 
 **Teardown hang.** On v1.3.5 the tmux teardown can rarely hang under process
 churn, from a recursive live process-walk with PID reuse. Workaround: kill the
@@ -67,18 +64,47 @@ deploy/gc/bootstrap.sh \
 `manual` delivery leaves a checked PR open. `auto` asks GitHub to merge it after
 hosted checks. The bootstrap uses the user default Git and GitHub identity.
 
-## Feed and observe
+## Default flow: create, feed, observe, refine, teardown
+
+After bootstrap, the loop is create a bead, feed it, watch it flow through the
+native formula onto `main`, then tear the city down:
 
 ```sh
+# 1. Create a source bead directly in the managed rig store.
+deploy/gc/invoke.sh --city /path/to/city create "Add a widget" -d "why and how"
+
+# 2. Feed it. This homes the bead in the rig store, prepares one isolated
+#    worktree, and slings the native agentops-experiment formula to the
+#    rig-scoped planner (plan -> implement -> validate -> deliver).
 deploy/gc/invoke.sh --city /path/to/city feed BEAD-ID
+
+# 3. Observe.
 deploy/gc/invoke.sh --city /path/to/city status
 deploy/gc/invoke.sh --city /path/to/city doctor
+
+# 4. The Refiner rebases the validated candidate and delivers it. In auto mode
+#    GitHub merges it onto main after hosted checks; in manual mode a checked PR
+#    is left open.
+
+# 5. Teardown (see below).
 ```
 
-`feed` is intentionally a small wrapper around native `gc sling
-agentops.mayor BEAD-ID --nudge`. The Mayor creates Beads and attaches the native
-`agentops-experiment` formula. No AgentOps program graph or delivery ledger is
-created.
+`create` writes one `task` bead into the city's single managed Dolt server —
+the same store `feed`, the rig roles, and the formula read — using the pinned
+`bd` binary and the exact server environment the bootstrap uses. It prints the
+new bead id (or the raw `bd` JSON with `--json`). This removes any need to drive
+`bd` by hand.
+
+`feed` is the official single-bead intake: `gc sling
+RIG/agentops.plan-reviewer BEAD --on agentops-experiment --nudge`, plus the role
+targets as formula vars. Because the bead is rig-homed and only rig-scoped roles
+claim it, the v1.3.5 cross-store claim bug is never exercised (see Known upstream
+issues). No AgentOps program graph or delivery ledger is created. The Beads
+graph is the program graph.
+
+The city-scoped Mayor is now an optional, observe-only coordinator: intake does
+not route through it, and it never claims, routes, or edits. You can leave it
+unused, or wake it to summarize ready, in-flight, blocked, and stuck work.
 
 ## Teardown
 

--- a/deploy/gc/bootstrap.sh
+++ b/deploy/gc/bootstrap.sh
@@ -157,7 +157,7 @@ PY
 
 marker="$city/.gc/agentops-bootstrap.json"
 if [ -f "$marker" ]; then
-  python3 - "$marker" "$city" "$rig" "$pack" "$pair_id" "$delivery_mode" "$bead_prefix" "$bead_database" "$request_digest" <<'PY'
+  python3 - "$marker" "$city" "$rig" "$pack" "$pair_id" "$delivery_mode" "$bead_prefix" "$bead_database" "$request_digest" "$gc_bin" "$gc_sha" "$bd_bin" "$bd_sha" <<'PY'
 import hashlib, json, os, sys
 m = json.load(open(sys.argv[1], encoding="utf-8"))
 expected = {"city": sys.argv[2], "rig": sys.argv[3], "pack_source": sys.argv[4], "toolchain_pair": sys.argv[5], "delivery_mode": sys.argv[6], "bead_prefix": sys.argv[7], "bead_database": sys.argv[8]}
@@ -165,6 +165,27 @@ if m.get("schema_version") != 1 or any(m.get(k) != v for k, v in expected.items(
     raise SystemExit("existing managed city identity differs from request")
 if m.get("configuration_digest") != sys.argv[9]:
     raise SystemExit("existing managed city configuration differs from current request or source bytes")
+def sha(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for b in iter(lambda: f.read(1024 * 1024), b""): h.update(b)
+    return h.hexdigest()
+# Re-materializing the toolchain can move it or change its bytes. The existing
+# marker's fast path must not silently succeed while pointing at a stale or
+# deleted toolchain: compare the marker's recorded gc/bd paths and digests to
+# this invocation's toolchain, and confirm both binaries still exist and match.
+gc_now, gc_now_sha, bd_now, bd_now_sha = sys.argv[10:14]
+tc = m.get("toolchain", {})
+recorded = {"gc": (tc.get("gc", {}).get("path"), tc.get("gc", {}).get("sha256")),
+            "bd": (tc.get("bd", {}).get("path"), tc.get("bd", {}).get("sha256"))}
+requested = {"gc": (gc_now, gc_now_sha), "bd": (bd_now, bd_now_sha)}
+if recorded != requested:
+    raise SystemExit("existing managed city points at a different toolchain (paths or digests changed); re-materializing moves it — re-bootstrap a fresh --city, or restore the toolchain at the marker's recorded path")
+for name, (path, expected_sha) in recorded.items():
+    if not path or not os.path.exists(path):
+        raise SystemExit(f"managed {name} binary is missing at {path}; re-bootstrap a fresh --city")
+    if sha(path) != expected_sha:
+        raise SystemExit(f"managed {name} binary changed on disk; re-bootstrap a fresh --city")
 def tree_sha(root):
     h=hashlib.sha256()
     for parent,dirs,files in os.walk(root):

--- a/deploy/gc/invoke.sh
+++ b/deploy/gc/invoke.sh
@@ -13,6 +13,16 @@ Usage:
   invoke.sh --city PATH -- GC_COMMAND [ARG...]
 EOF
 }
+# The running pack (this script's own directory) is the trust anchor: its
+# toolchain.lock.json pins the accepted pair and its worktree.sh is the
+# canonical helper. Expected digests are verified against these, never against
+# the mutable managed-city marker (which carries paths for convenience only).
+script_dir="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+lock="$script_dir/toolchain.lock.json"
+worktree_src="$script_dir/worktree.sh"
+[ -f "$lock" ] || die "pack toolchain lock is missing: $lock"
+[ -f "$worktree_src" ] || die "pack worktree helper source is missing: $worktree_src"
+
 city=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -29,17 +39,37 @@ PY
 )"
 marker="$city/.gc/agentops-bootstrap.json"
 [ -f "$marker" ] || die "managed bootstrap marker is missing: $marker"
-identity="$(python3 - "$marker" "$city" <<'PY'
+identity="$(python3 - "$marker" "$city" "$lock" "$worktree_src" <<'PY'
 import hashlib,json,os,sys
-m=json.load(open(sys.argv[1],encoding="utf-8"))
-if m.get("schema_version") != 1 or m.get("state") != "ready" or m.get("city") != sys.argv[2]: raise SystemExit("invalid managed city marker")
+marker_path,city,lock_path,worktree_src=sys.argv[1:5]
+m=json.load(open(marker_path,encoding="utf-8"))
+if m.get("schema_version") != 1 or m.get("state") != "ready" or m.get("city") != city: raise SystemExit("invalid managed city marker")
 def sha(path):
  h=hashlib.sha256()
  with open(path,"rb") as f:
   for b in iter(lambda:f.read(1024*1024),b""): h.update(b)
  return h.hexdigest()
-gc=m["toolchain"]["gc"]
-if sha(gc["path"]) != gc["sha256"]: raise SystemExit("managed gc binary changed")
+# Anchor 1: the running pack's own lock pins the accepted source commits.
+lock=json.load(open(lock_path,encoding="utf-8"))
+pairs=lock.get("accepted_pairs") or []
+if lock.get("schema_version") != 1 or len(pairs) != 1: raise SystemExit("pack toolchain lock is malformed")
+gc_commit=pairs[0]["gc"]["source_commit"]; bd_commit=pairs[0]["bd"]["source_commit"]
+# Locate the toolchain receipt from the marker's gc path, but trust the RECEIPT
+# (cross-checked to the lock), never the marker, for binary paths and digests.
+gc_path=os.path.realpath(m["toolchain"]["gc"]["path"])
+toolchain_root=os.path.dirname(os.path.dirname(gc_path))
+r=json.load(open(os.path.join(toolchain_root,"toolchain.json"),encoding="utf-8"))
+if r.get("schema_version") != 2 or set(r.get("runtime",{})) != {"gc","bd"}: raise SystemExit("toolchain receipt is malformed")
+if r.get("pair",{}).get("status") != "qualified": raise SystemExit("toolchain receipt pair is not qualified")
+if r["pair"]["gc"]["source_commit"] != gc_commit or r["pair"]["bd"]["source_commit"] != bd_commit: raise SystemExit("toolchain receipt does not match the pack lock")
+def anchored(name):
+ spec=r["runtime"][name]
+ return os.path.realpath(os.path.join(toolchain_root,spec["path"])),spec["sha256"]
+gc_anchor,gc_anchor_sha=anchored("gc")
+if gc_anchor != gc_path: raise SystemExit("marked gc path is not the receipt gc binary")
+if sha(gc_path) != gc_anchor_sha: raise SystemExit("gc binary does not match the toolchain receipt")
+bd_path,bd_sha=anchored("bd")
+if not os.path.exists(bd_path): raise SystemExit("receipt bd binary is missing")
 def tree_sha(root):
  h=hashlib.sha256()
  for parent,dirs,files in os.walk(root):
@@ -50,26 +80,65 @@ def tree_sha(root):
  return h.hexdigest()
 if tree_sha(os.path.dirname(m["pack_snapshot"])) != m.get("pack_sha256"): raise SystemExit("managed pack snapshot changed")
 if sha(os.path.join(m["city"],"city.toml")) != m.get("city_config_sha256"): raise SystemExit("managed city config changed")
+# Anchor 2: the installed worktree helper must match the running pack source.
+worktree_expected=sha(worktree_src)
 t=m["telemetry"]
-bd=m["toolchain"]["bd"]
-print("\x1f".join((gc["path"],t["metrics_url"],t["logs_url"],str(t.get("sdk_disabled",False)).lower(),m["rig"],m["rig_name"],m["base_ref"],m["worktree_root"],bd["path"],bd["sha256"],m["bead_database"])))
+print("\x1f".join((gc_path,t["metrics_url"],t["logs_url"],str(t.get("sdk_disabled",False)).lower(),m["rig"],m["rig_name"],m["base_ref"],m["worktree_root"],bd_path,bd_sha,m["bead_database"],worktree_expected)))
 PY
 )" || die "invalid managed city identity"
-IFS=$'\x1f' read -r gc_bin metrics_url logs_url otel_disabled rig rig_name base_ref worktree_root bd_bin bd_sha bead_database <<<"$identity"
+IFS=$'\x1f' read -r gc_bin metrics_url logs_url otel_disabled rig rig_name base_ref worktree_root bd_bin bd_sha bead_database worktree_expected_sha <<<"$identity"
 GC_BIN="$gc_bin"
 export GC_BIN
 export GC_HOME="$city/.gc-home"
 gc_bin_dir="$(dirname "$gc_bin")"
 PATH="$gc_bin_dir:$PATH"; export PATH
 export GC_OTEL_METRICS_URL="$metrics_url" GC_OTEL_LOGS_URL="$logs_url" OTEL_EXPORTER_OTLP_ENDPOINT="" OTEL_SDK_DISABLED="$otel_disabled"
+
+# Verify a file's sha256 against an expected digest (from the trust anchor).
+verify_sha() {
+  python3 - "$1" "$2" <<'PY'
+import hashlib,sys
+h=hashlib.sha256()
+with open(sys.argv[1],"rb") as f:
+ for b in iter(lambda:f.read(1024*1024),b""): h.update(b)
+raise SystemExit(0 if h.hexdigest()==sys.argv[2] else 1)
+PY
+}
+# Verify the pinned bd binary against the receipt-anchored digest.
+verify_bd() {
+  [ -x "$bd_bin" ] || die "managed bd binary is missing: $bd_bin"
+  verify_sha "$bd_bin" "$bd_sha" || die "managed bd binary does not match the toolchain receipt"
+}
+# Run the pinned bd against the single managed rig Dolt server, mirroring the
+# exact environment the bootstrap uses.
+run_bd() {
+  local port_file="$city/.beads/dolt-server.port" port
+  [ -f "$port_file" ] || die "managed Dolt port file is missing: $port_file"
+  port="$(tr -d '[:space:]' <"$port_file")"
+  { [[ "$port" =~ ^[1-9][0-9]{0,4}$ ]] && [ "$port" -le 65535 ]; } || die "managed Dolt port is invalid"
+  env BD_NON_INTERACTIVE=1 BD_EXPORT_AUTO=false BD_BACKUP_ENABLED=false \
+    BEADS_DOLT_AUTO_START=0 BEADS_DOLT_SERVER_MODE=1 BEADS_DOLT_SERVER_HOST=127.0.0.1 \
+    BEADS_DOLT_SERVER_PORT="$port" BEADS_DOLT_SERVER_DATABASE="$bead_database" \
+    "$bd_bin" -C "$rig" "$@"
+}
+
 command="$1"; shift
 cd "$city"
 case "$command" in
   feed)
     [ "$#" -eq 1 ] || die "feed requires exactly one bead id"
     [[ "$1" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$ ]] || die "unsafe bead id"
+    # Guard: on GC v1.3.5 `gc sling` treats an unknown id as inline text and
+    # auto-creates a task, silently dispatching the wrong work. Require the bead
+    # to already exist in the rig store with an exact id match before slinging.
+    verify_bd
+    lookup="$(run_bd show "$1" --json 2>/dev/null)" || die "bead not found in the rig store: $1"
+    printf '%s' "$lookup" | python3 -c 'import json,sys
+data=json.load(sys.stdin)
+if not isinstance(data,list) or len(data) != 1 or data[0].get("id") != sys.argv[1]: raise SystemExit(1)' "$1" || die "bead lookup did not return an exact single match: $1"
     worktree_script="$city/.gc/scripts/agentops-worktree"
     [ -x "$worktree_script" ] || die "managed worktree helper is missing: $worktree_script"
+    verify_sha "$worktree_script" "$worktree_expected_sha" || die "managed worktree helper does not match the pack source"
     worktree_receipt="$("$worktree_script" prepare --repo "$rig" --root "$worktree_root" --bead "$1" --base-ref "$base_ref")" || die "cannot prepare an isolated worktree for $1"
     work_dir="$(printf '%s' "$worktree_receipt" | python3 -c 'import json,sys; print(json.load(sys.stdin)["worktree"])')" || die "worktree helper returned an unreadable receipt"
     # Official single-bead intake: home the source bead in the rig store and
@@ -96,26 +165,10 @@ case "$command" in
         *) die "unknown create argument: $1" ;;
       esac
     done
-    [ -x "$bd_bin" ] || die "managed bd binary is missing: $bd_bin"
-    python3 - "$bd_bin" "$bd_sha" <<'PY' || die "managed bd binary changed"
-import hashlib,sys
-h=hashlib.sha256()
-with open(sys.argv[1],"rb") as f:
- for b in iter(lambda:f.read(1024*1024),b""): h.update(b)
-raise SystemExit(0 if h.hexdigest()==sys.argv[2] else 1)
-PY
-    port_file="$city/.beads/dolt-server.port"
-    [ -f "$port_file" ] || die "managed Dolt port file is missing: $port_file"
-    managed_port="$(tr -d '[:space:]' <"$port_file")"
-    { [[ "$managed_port" =~ ^[1-9][0-9]{0,4}$ ]] && [ "$managed_port" -le 65535 ]; } || die "managed Dolt port is invalid"
-    # Mirror the exact bd environment the bootstrap uses for the managed rig
-    # store: the single running Dolt server, no auto-start, no export churn.
-    bd_env=(env BD_NON_INTERACTIVE=1 BD_EXPORT_AUTO=false BD_BACKUP_ENABLED=false
-      BEADS_DOLT_AUTO_START=0 BEADS_DOLT_SERVER_MODE=1 BEADS_DOLT_SERVER_HOST=127.0.0.1
-      BEADS_DOLT_SERVER_PORT="$managed_port" BEADS_DOLT_SERVER_DATABASE="$bead_database")
-    create_args=(-C "$rig" create --title "$title" --type task --json)
+    verify_bd
+    create_args=(create --title "$title" --type task --json)
     [ -n "$description" ] && create_args+=(-d "$description")
-    receipt="$("${bd_env[@]}" "$bd_bin" "${create_args[@]}")" || die "bd create failed"
+    receipt="$(run_bd "${create_args[@]}")" || die "bd create failed"
     if [ "$json_mode" -eq 1 ]; then
       printf '%s\n' "$receipt"
     else

--- a/deploy/gc/invoke.sh
+++ b/deploy/gc/invoke.sh
@@ -7,6 +7,7 @@ usage() {
   cat <<'EOF'
 Usage:
   invoke.sh --city PATH feed BEAD
+  invoke.sh --city PATH create TITLE [-d DESCRIPTION] [--json]
   invoke.sh --city PATH status
   invoke.sh --city PATH doctor
   invoke.sh --city PATH -- GC_COMMAND [ARG...]
@@ -50,10 +51,11 @@ def tree_sha(root):
 if tree_sha(os.path.dirname(m["pack_snapshot"])) != m.get("pack_sha256"): raise SystemExit("managed pack snapshot changed")
 if sha(os.path.join(m["city"],"city.toml")) != m.get("city_config_sha256"): raise SystemExit("managed city config changed")
 t=m["telemetry"]
-print("\x1f".join((gc["path"],t["metrics_url"],t["logs_url"],str(t.get("sdk_disabled",False)).lower())))
+bd=m["toolchain"]["bd"]
+print("\x1f".join((gc["path"],t["metrics_url"],t["logs_url"],str(t.get("sdk_disabled",False)).lower(),m["rig"],m["rig_name"],m["base_ref"],m["worktree_root"],bd["path"],bd["sha256"],m["bead_database"])))
 PY
 )" || die "invalid managed city identity"
-IFS=$'\x1f' read -r gc_bin metrics_url logs_url otel_disabled <<<"$identity"
+IFS=$'\x1f' read -r gc_bin metrics_url logs_url otel_disabled rig rig_name base_ref worktree_root bd_bin bd_sha bead_database <<<"$identity"
 GC_BIN="$gc_bin"
 export GC_BIN
 export GC_HOME="$city/.gc-home"
@@ -66,7 +68,59 @@ case "$command" in
   feed)
     [ "$#" -eq 1 ] || die "feed requires exactly one bead id"
     [[ "$1" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$ ]] || die "unsafe bead id"
-    exec "$gc_bin" sling agentops.mayor "$1" --nudge --json
+    worktree_script="$city/.gc/scripts/agentops-worktree"
+    [ -x "$worktree_script" ] || die "managed worktree helper is missing: $worktree_script"
+    worktree_receipt="$("$worktree_script" prepare --repo "$rig" --root "$worktree_root" --bead "$1" --base-ref "$base_ref")" || die "cannot prepare an isolated worktree for $1"
+    work_dir="$(printf '%s' "$worktree_receipt" | python3 -c 'import json,sys; print(json.load(sys.stdin)["worktree"])')" || die "worktree helper returned an unreadable receipt"
+    # Official single-bead intake: home the source bead in the rig store and
+    # attach the native formula to the rig-scoped planner. No city-scoped agent
+    # ever claims this rig-homed bead, so the v1.3.5 cross-store claim bug is not
+    # exercised. The Mayor is an optional monitor and is not on this path.
+    exec "$gc_bin" sling "$rig_name/agentops.plan-reviewer" "$1" \
+      --on agentops-experiment --nudge --json \
+      --var work_dir="$work_dir" \
+      --var plan_target="$rig_name/agentops.plan-reviewer" \
+      --var implement_target="$rig_name/agentops.implementer" \
+      --var validate_target="$rig_name/agentops.validator" \
+      --var refiner_target="$rig_name/agentops.refiner"
+    ;;
+  create)
+    [ "$#" -ge 1 ] || { usage; exit 2; }
+    title="$1"; shift
+    case "$title" in -*) die "create requires a title as the first argument" ;; esac
+    description=""; json_mode=0
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -d|--description) description="${2:?-d requires a value}"; shift 2 ;;
+        --json) json_mode=1; shift ;;
+        *) die "unknown create argument: $1" ;;
+      esac
+    done
+    [ -x "$bd_bin" ] || die "managed bd binary is missing: $bd_bin"
+    python3 - "$bd_bin" "$bd_sha" <<'PY' || die "managed bd binary changed"
+import hashlib,sys
+h=hashlib.sha256()
+with open(sys.argv[1],"rb") as f:
+ for b in iter(lambda:f.read(1024*1024),b""): h.update(b)
+raise SystemExit(0 if h.hexdigest()==sys.argv[2] else 1)
+PY
+    port_file="$city/.beads/dolt-server.port"
+    [ -f "$port_file" ] || die "managed Dolt port file is missing: $port_file"
+    managed_port="$(tr -d '[:space:]' <"$port_file")"
+    { [[ "$managed_port" =~ ^[1-9][0-9]{0,4}$ ]] && [ "$managed_port" -le 65535 ]; } || die "managed Dolt port is invalid"
+    # Mirror the exact bd environment the bootstrap uses for the managed rig
+    # store: the single running Dolt server, no auto-start, no export churn.
+    bd_env=(env BD_NON_INTERACTIVE=1 BD_EXPORT_AUTO=false BD_BACKUP_ENABLED=false
+      BEADS_DOLT_AUTO_START=0 BEADS_DOLT_SERVER_MODE=1 BEADS_DOLT_SERVER_HOST=127.0.0.1
+      BEADS_DOLT_SERVER_PORT="$managed_port" BEADS_DOLT_SERVER_DATABASE="$bead_database")
+    create_args=(-C "$rig" create --title "$title" --type task --json)
+    [ -n "$description" ] && create_args+=(-d "$description")
+    receipt="$("${bd_env[@]}" "$bd_bin" "${create_args[@]}")" || die "bd create failed"
+    if [ "$json_mode" -eq 1 ]; then
+      printf '%s\n' "$receipt"
+    else
+      printf '%s' "$receipt" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' || die "bd create returned an unreadable receipt"
+    fi
     ;;
   status)
     [ "$#" -eq 0 ] || die "status accepts no arguments"

--- a/packs/agentops-factory/agents/mayor/prompt.template.md
+++ b/packs/agentops-factory/agents/mayor/prompt.template.md
@@ -1,40 +1,29 @@
-# AgentOps Mayor
+# AgentOps Mayor (optional coordinator)
 
-You are the city-scoped Fable Mayor. Gas City and Beads are the control plane.
-Handle exactly one claimed source bead. You refine and route work; you never
-edit product files, validate candidates, or merge pull requests.
+You are the optional city-scoped coordinator. Gas City and Beads are the control
+plane. Intake no longer routes through you: operators feed a source bead
+directly to the rig planner with `invoke.sh feed`, which homes the bead in the
+rig store and attaches the native `agentops-experiment` formula. Your only job
+when woken is to observe and report. You never claim work, never edit product
+files, never validate candidates, and never route or merge.
 
-1. Run `"$GC_BIN" hook --claim --json` once. If no work is ready, acknowledge
-   drain and exit. Never select an unassigned bead.
-2. Read the claimed bead with `"$GC_BIN" bd show <id> --json` and preserve its
-   acceptance and non-goals. Resolve true ambiguity in the same bead.
-3. Create the smallest useful set of child work beads directly in Beads. Each
-   child must contain one outcome, acceptance, write scope, dependencies, and
-   a chosen implementation pool. Terra-high is the default. Opus-medium is
-   overflow for work whose stated reason benefits from it. Luna is support-only.
-4. For each child, prepare one worktree using:
+Do not run `gc hook --claim`. A city-scoped claim of a rig-homed bead is exactly
+the mutation the pack avoids; claiming is the rig roles' job, not yours.
+
+1. Read city and rig health without mutating anything:
 
    ```sh
-   "$AGENTOPS_GC_WORKTREE" prepare --repo "$AGENTOPS_GC_PRIMARY_RIG_ROOT" \
-     --root "$AGENTOPS_GC_WORKTREE_ROOT" --bead <child-id> \
-     --base-ref "$AGENTOPS_GC_BASE_REF"
+   "$GC_BIN" status --json
+   "$GC_BIN" bd ready --json
+   "$GC_BIN" bd blocked --json
    ```
 
-5. Attach and route the native formula. Use the returned worktree and exactly
-   these role targets:
+2. Summarize what is ready, in flight, blocked, and drained. Name any bead that
+   looks stuck — no recent heartbeat, a failed formula step, or a `deliver` step
+   that failed rework — so a human can decide.
 
-   ```sh
-   "$GC_BIN" sling "$AGENTOPS_GC_PLAN_TARGET" <child-id> \
-     --on agentops-experiment --nudge \
-     --var work_dir=<absolute-worktree> \
-     --var plan_target="$AGENTOPS_GC_PLAN_TARGET" \
-     --var implement_target=<terra-or-opus-target> \
-     --var validate_target="$AGENTOPS_GC_VALIDATE_TARGET" \
-     --var refiner_target="$AGENTOPS_GC_REFINER_TARGET"
-   ```
+3. Do not claim, sling, create, or close any bead, and do not build a parallel
+   graph. Then run `"$GC_BIN" runtime drain-ack --json` and exit.
 
-6. Close only the claimed source bead after every child workflow is durable.
-   Then run `"$GC_BIN" runtime drain-ack --json` and exit.
-
-Do not create a parallel JSON graph, transport bead protocol, request packet,
-admission receipt, or retry loop. The Beads graph is the program graph.
+The Beads graph is the program graph. Dispatch is `invoke.sh feed` to the rig
+planner, not the Mayor.

--- a/packs/agentops-factory/agents/mayor/prompt.template.md
+++ b/packs/agentops-factory/agents/mayor/prompt.template.md
@@ -10,17 +10,22 @@ files, never validate candidates, and never route or merge.
 Do not run `gc hook --claim`. A city-scoped claim of a rig-homed bead is exactly
 the mutation the pack avoids; claiming is the rig roles' job, not yours.
 
-1. Read city and rig health without mutating anything:
+1. Read city and rig health without mutating anything. Work lives in the
+   per-rig stores, not the city store, so enumerate the rigs and read each one
+   explicitly — a bare `gc bd ready` resolves to the city store and would miss
+   all rig-homed work:
 
    ```sh
    "$GC_BIN" status --json
-   "$GC_BIN" bd ready --json
-   "$GC_BIN" bd blocked --json
+   "$GC_BIN" rig list --json          # each .rigs[].name is a rig to inspect
+   # then, for every rig name N:
+   "$GC_BIN" bd --rig N ready --json
+   "$GC_BIN" bd --rig N blocked --json
    ```
 
-2. Summarize what is ready, in flight, blocked, and drained. Name any bead that
-   looks stuck — no recent heartbeat, a failed formula step, or a `deliver` step
-   that failed rework — so a human can decide.
+2. Summarize, per rig, what is ready, in flight, blocked, and drained. Name any
+   bead that looks stuck — no recent heartbeat, a failed formula step, or a
+   `deliver` step that failed rework — so a human can decide.
 
 3. Do not claim, sling, create, or close any bead, and do not build a parallel
    graph. Then run `"$GC_BIN" runtime drain-ack --json` and exit.

--- a/packs/agentops-factory/agents/refiner/prompt.template.md
+++ b/packs/agentops-factory/agents/refiner/prompt.template.md
@@ -21,8 +21,11 @@ the fresh Sol verdict. You own only delivery of one claimed `deliver` step.
    the delivery step. Auto mode merges after hosted checks; manual mode leaves
    the ready PR open. Semantic bead closure never waits for delivery.
 5. If the helper reports a stale or conflicting candidate, create one rework
-   bead that references the current source and PR, sling it to the Mayor, and
-   close the delivery step as failed. Do not lock main or repair product bytes.
+   bead that references the current source and PR, and close the delivery step
+   as failed. Do not route or sling it yourself: the operator re-enters it
+   through the normal intake path (`invoke.sh feed <rework-bead>`), which homes
+   it in the rig store and attaches the formula to the rig planner. Do not lock
+   main or repair product bytes.
 6. Acknowledge drain and exit.
 
 Git and GitHub own branch, CI, PR, and merge state. Do not mirror them into a

--- a/tests/python/test_gc33_thin_pack.py
+++ b/tests/python/test_gc33_thin_pack.py
@@ -111,7 +111,11 @@ class ThinPackTests(unittest.TestCase):
         )
 
         invoke = (DEPLOY / "invoke.sh").read_text(encoding="utf-8")
-        self.assertIn('sling agentops.mayor "$1" --nudge --json', invoke)
+        # Official single-bead intake: feed slings to the rig-scoped planner with
+        # the native formula attached; it never slings to the city-scoped Mayor.
+        self.assertIn('sling "$rig_name/agentops.plan-reviewer" "$1"', invoke)
+        self.assertIn("--on agentops-experiment", invoke)
+        self.assertNotIn("sling agentops.mayor", invoke)
         for obsolete in ("program start", "factory_feeder", "role_adapter", "run-packet"):
             self.assertNotIn(obsolete, invoke)
 
@@ -419,6 +423,169 @@ class ThinPackTests(unittest.TestCase):
             text = (DEPLOY / name).read_text(encoding="utf-8")
             self.assertIn("export GC_BIN\n", text, name)
 
+    def test_intake_never_routes_through_the_city_scoped_mayor(self) -> None:
+        # Static consistency proof: no default-flow surface in deploy/gc or the
+        # factory pack slings work to agentops.mayor, and the Mayor prompt no
+        # longer claims. Intake homes rig beads on the rig planner instead.
+        surfaces = list(DEPLOY.glob("*.sh")) + list(FACTORY.rglob("*.md"))
+        for path in surfaces:
+            text = path.read_text(encoding="utf-8")
+            self.assertNotIn("sling agentops.mayor", text, path)
+        mayor_prompt = (FACTORY / "agents/mayor/prompt.template.md").read_text(encoding="utf-8")
+        # The Mayor is an observe-only coordinator: it explicitly forbids the
+        # cross-store claim and never carries an instruction to run it.
+        self.assertIn("Do not run `gc hook --claim`", mayor_prompt)
+        self.assertNotIn('Run `"$GC_BIN" hook --claim', mayor_prompt)
+
+    @staticmethod
+    def _sha256_file(path: Path) -> str:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+
+    @staticmethod
+    def _tree_sha(root: Path) -> str:
+        h = hashlib.sha256()
+        for parent, dirs, files in os.walk(root):
+            dirs.sort()
+            for name in sorted(files):
+                p = os.path.join(parent, name)
+                rel = os.path.relpath(p, root)
+                h.update(rel.encode() + b"\0" + Path(p).read_bytes() + b"\0")
+        return h.hexdigest()
+
+    def _managed_city_fixture(
+        self, root: Path, *, gc_script: str, bd_script: str, worktree_script: str
+    ) -> dict[str, object]:
+        """Build the minimal on-disk managed-city surface invoke.sh validates.
+
+        Mirrors the exact marker identity checks in invoke.sh: gc/bd binary
+        digests, the pack-snapshot tree digest, and the city.toml digest. Stub
+        binaries stand in for gc and bd so feed/create are exercised fully
+        offline with no network and no live gc/bd.
+        """
+        city = root / "city"
+        (city / ".gc/agentops-packs/agentops-factory").mkdir(parents=True)
+        (city / ".gc/agentops-packs/agentops-factory/pack.toml").write_text("name = 'x'\n", encoding="utf-8")
+        (city / ".gc/scripts").mkdir(parents=True)
+        (city / ".beads").mkdir(parents=True)
+        (city / "city.toml").write_text("[workspace]\n", encoding="utf-8")
+        (city / ".beads/dolt-server.port").write_text("3306\n", encoding="utf-8")
+
+        gc_bin = root / "gc"
+        gc_bin.write_text(gc_script, encoding="utf-8")
+        gc_bin.chmod(0o755)
+        bd_bin = root / "bd"
+        bd_bin.write_text(bd_script, encoding="utf-8")
+        bd_bin.chmod(0o755)
+        wt = city / ".gc/scripts/agentops-worktree"
+        wt.write_text(worktree_script, encoding="utf-8")
+        wt.chmod(0o755)
+
+        rig = root / "rig"
+        rig.mkdir()
+        workers = root / "workers"
+
+        marker = city / ".gc/agentops-bootstrap.json"
+        marker.write_text(json.dumps({
+            "schema_version": 1,
+            "state": "ready",
+            "city": str(city.resolve()),
+            "rig": str(rig.resolve()),
+            "rig_name": "testrig",
+            "base_ref": "main",
+            "worktree_root": str(workers.resolve()),
+            "bead_database": "testdb",
+            "pack_snapshot": str((city / ".gc/agentops-packs/agentops-factory").resolve()),
+            "pack_sha256": self._tree_sha(city / ".gc/agentops-packs"),
+            "city_config_sha256": self._sha256_file(city / "city.toml"),
+            "toolchain": {
+                "gc": {"path": str(gc_bin.resolve()), "sha256": self._sha256_file(gc_bin)},
+                "bd": {"path": str(bd_bin.resolve()), "sha256": self._sha256_file(bd_bin)},
+            },
+            "telemetry": {"metrics_url": "", "logs_url": "", "sdk_disabled": True},
+        }), encoding="utf-8")
+        return {"city": city, "rig": rig, "workers": workers, "gc_bin": gc_bin, "bd_bin": bd_bin}
+
+    def test_feed_prepares_worktree_and_slings_rig_formula(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            gc_log = root / "gc.log"
+            worktree_out = root / "worker-tree"
+            gc_script = f'#!/bin/sh\nprintf \'%s\\n\' "$*" >> "{gc_log}"\nexit 0\n'
+            worktree_script = (
+                '#!/bin/sh\n'
+                f'printf \'{{"bead":"b","branch":"gc/b","worktree":"{worktree_out}"}}\\n\'\n'
+                'exit 0\n'
+            )
+            fixture = self._managed_city_fixture(
+                root, gc_script=gc_script, bd_script="#!/bin/sh\nexit 1\n",
+                worktree_script=worktree_script,
+            )
+            result = run(
+                str(DEPLOY / "invoke.sh"), "--city", str(fixture["city"]), "feed", "testrig-1",
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            logged = gc_log.read_text(encoding="utf-8")
+            self.assertIn("sling testrig/agentops.plan-reviewer testrig-1", logged)
+            self.assertIn("--on agentops-experiment", logged)
+            self.assertIn("--nudge", logged)
+            self.assertIn("--json", logged)
+            self.assertIn(f"--var work_dir={worktree_out}", logged)
+            self.assertIn("--var plan_target=testrig/agentops.plan-reviewer", logged)
+            self.assertIn("--var implement_target=testrig/agentops.implementer", logged)
+            self.assertIn("--var validate_target=testrig/agentops.validator", logged)
+            self.assertIn("--var refiner_target=testrig/agentops.refiner", logged)
+            self.assertNotIn("agentops.mayor", logged)
+
+    def test_feed_rejects_unsafe_bead_id(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fixture = self._managed_city_fixture(
+                root, gc_script="#!/bin/sh\nexit 0\n", bd_script="#!/bin/sh\nexit 1\n",
+                worktree_script="#!/bin/sh\nexit 0\n",
+            )
+            result = run(
+                str(DEPLOY / "invoke.sh"), "--city", str(fixture["city"]), "feed", "bad id;rm",
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unsafe bead id", result.stderr)
+
+    def test_create_writes_managed_rig_store_and_prints_id(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            bd_log = root / "bd.log"
+            bd_script = (
+                '#!/bin/sh\n'
+                f'printf \'%s\\n\' "$*" >> "{bd_log}"\n'
+                'printf \'{"id":"testrig-9"}\\n\'\n'
+                'exit 0\n'
+            )
+            fixture = self._managed_city_fixture(
+                root, gc_script="#!/bin/sh\nexit 1\n", bd_script=bd_script,
+                worktree_script="#!/bin/sh\nexit 0\n",
+            )
+            plain = run(
+                str(DEPLOY / "invoke.sh"), "--city", str(fixture["city"]),
+                "create", "add a widget", "-d", "with a description",
+            )
+            self.assertEqual(plain.returncode, 0, plain.stderr)
+            self.assertEqual(plain.stdout, "testrig-9\n")
+            logged = bd_log.read_text(encoding="utf-8")
+            self.assertIn(f"-C {fixture['rig'].resolve()} create", logged)
+            self.assertIn("--title add a widget", logged)
+            self.assertIn("--type task", logged)
+            self.assertIn("--json", logged)
+            self.assertIn("-d with a description", logged)
+
+            json_out = run(
+                str(DEPLOY / "invoke.sh"), "--city", str(fixture["city"]),
+                "create", "no description", "--json",
+            )
+            self.assertEqual(json_out.returncode, 0, json_out.stderr)
+            self.assertEqual(json.loads(json_out.stdout)["id"], "testrig-9")
+            # No description supplied -> no -d flag forwarded to bd.
+            second = bd_log.read_text(encoding="utf-8").splitlines()[-1]
+            self.assertNotIn("-d ", second)
+
     def test_teardown_waits_for_scoped_drain_and_fails_with_exact_residue(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -666,12 +833,15 @@ class ThinPackTests(unittest.TestCase):
             )
             self.assertEqual(compiled.returncode, 0, compiled.stderr)
             self.assertEqual(json.loads(compiled.stdout)["name"], "agentops-experiment")
+            # Intake resolves to the rig-scoped planner (official single-bead
+            # dispatch), not the city-scoped Mayor.
+            planner_target = f"{marker['rig_name']}/agentops.plan-reviewer"
             route = run(
-                str(gc_bin), "--city", str(city), "sling", "agentops.mayor", source_bead,
-                "--dry-run", "--force", "--json", env=native_env,
+                str(gc_bin), "--city", str(city), "sling", planner_target, source_bead,
+                "--dry-run", "--json", env=native_env,
             )
             self.assertEqual(route.returncode, 0, route.stderr)
-            self.assertEqual(json.loads(route.stdout)["target"], "agentops.mayor")
+            self.assertIn("agentops.plan-reviewer", json.loads(route.stdout)["target"])
             status = run(str(DEPLOY / "invoke.sh"), "--city", str(city), "status", env=native_env)
             self.assertEqual(status.returncode, 0, status.stderr)
             self.assertEqual(json.loads(status.stdout)["schema_version"], "1")

--- a/tests/python/test_gc33_thin_pack.py
+++ b/tests/python/test_gc33_thin_pack.py
@@ -452,38 +452,92 @@ class ThinPackTests(unittest.TestCase):
                 h.update(rel.encode() + b"\0" + Path(p).read_bytes() + b"\0")
         return h.hexdigest()
 
-    def _managed_city_fixture(
-        self, root: Path, *, gc_script: str, bd_script: str, worktree_script: str
-    ) -> dict[str, object]:
-        """Build the minimal on-disk managed-city surface invoke.sh validates.
+    # gc/bd stubs record one argv element per line so tests assert on exact argv
+    # arrays (argument boundaries and quoting survive), never a flattened "$*".
+    # Content is constant so its digest is stable; behavior is driven by env.
+    _GC_STUB = (
+        "#!/usr/bin/env python3\n"
+        "import os, sys\n"
+        "log = os.environ.get('GC_ARGV_LOG')\n"
+        "if log:\n"
+        "    with open(log, 'a', encoding='utf-8') as f:\n"
+        "        f.write('\\n'.join(sys.argv[1:]) + '\\n')\n"
+        "sys.exit(0)\n"
+    )
+    _BD_STUB = (
+        "#!/usr/bin/env python3\n"
+        "import json, os, sys\n"
+        "argv = sys.argv[1:]\n"
+        "log = os.environ.get('BD_ARGV_LOG')\n"
+        "if log:\n"
+        "    with open(log, 'a', encoding='utf-8') as f:\n"
+        "        f.write('\\n'.join(argv) + '\\n---\\n')\n"
+        "mode = os.environ.get('BD_STUB_MODE', 'ok')\n"
+        "if 'create' in argv:\n"
+        "    print(json.dumps({'id': 'testrig-9'})); sys.exit(0)\n"
+        "if 'show' in argv:\n"
+        "    bead = argv[argv.index('show') + 1]\n"
+        "    if mode == 'notfound':\n"
+        "        sys.stderr.write('Issue %s not found\\n' % bead); sys.exit(1)\n"
+        "    returned = 'totally-different' if mode == 'mismatch' else bead\n"
+        "    print(json.dumps([{'id': returned}])); sys.exit(0)\n"
+        "sys.exit(2)\n"
+    )
 
-        Mirrors the exact marker identity checks in invoke.sh: gc/bd binary
-        digests, the pack-snapshot tree digest, and the city.toml digest. Stub
-        binaries stand in for gc and bd so feed/create are exercised fully
-        offline with no network and no live gc/bd.
+    def _invoke_env(
+        self, *, gc_log: Path | None = None, bd_log: Path | None = None, bd_mode: str = "ok"
+    ) -> dict[str, str]:
+        env = os.environ.copy()
+        if gc_log is not None:
+            env["GC_ARGV_LOG"] = str(gc_log)
+        if bd_log is not None:
+            env["BD_ARGV_LOG"] = str(bd_log)
+        env["BD_STUB_MODE"] = bd_mode
+        return env
+
+    def _managed_city_fixture(self, base: Path, *, rig: Path) -> dict[str, object]:
+        """Build a managed-city surface invoke.sh accepts, anchored to the real
+        pack lock and the toolchain receipt (not the mutable marker).
+
+        gc and bd are stub binaries whose digests are recorded in a schema-2
+        receipt whose pinned pair matches deploy/gc/toolchain.lock.json. The
+        worktree helper is the real deploy/gc/worktree.sh, so feed's provenance
+        check passes and a real isolated worktree is prepared, fully offline.
         """
-        city = root / "city"
+        toolchain = base / "toolchain"
+        (toolchain / "bin").mkdir(parents=True)
+        gc_bin = toolchain / "bin/gc"
+        gc_bin.write_text(self._GC_STUB, encoding="utf-8")
+        gc_bin.chmod(0o755)
+        bd_bin = toolchain / "bin/bd"
+        bd_bin.write_text(self._BD_STUB, encoding="utf-8")
+        bd_bin.chmod(0o755)
+        receipt = {
+            "schema_version": 2,
+            "runtime": {
+                "gc": {"path": "bin/gc", "sha256": self._sha256_file(gc_bin)},
+                "bd": {"path": "bin/bd", "sha256": self._sha256_file(bd_bin)},
+            },
+            "pair": {
+                "status": "qualified",
+                "gc": {"source_commit": GC_COMMIT},
+                "bd": {"source_commit": BD_COMMIT},
+            },
+        }
+        (toolchain / "toolchain.json").write_text(json.dumps(receipt), encoding="utf-8")
+
+        city = base / "city"
         (city / ".gc/agentops-packs/agentops-factory").mkdir(parents=True)
         (city / ".gc/agentops-packs/agentops-factory/pack.toml").write_text("name = 'x'\n", encoding="utf-8")
         (city / ".gc/scripts").mkdir(parents=True)
         (city / ".beads").mkdir(parents=True)
         (city / "city.toml").write_text("[workspace]\n", encoding="utf-8")
         (city / ".beads/dolt-server.port").write_text("3306\n", encoding="utf-8")
+        installed_wt = city / ".gc/scripts/agentops-worktree"
+        installed_wt.write_bytes((DEPLOY / "worktree.sh").read_bytes())
+        installed_wt.chmod(0o755)
 
-        gc_bin = root / "gc"
-        gc_bin.write_text(gc_script, encoding="utf-8")
-        gc_bin.chmod(0o755)
-        bd_bin = root / "bd"
-        bd_bin.write_text(bd_script, encoding="utf-8")
-        bd_bin.chmod(0o755)
-        wt = city / ".gc/scripts/agentops-worktree"
-        wt.write_text(worktree_script, encoding="utf-8")
-        wt.chmod(0o755)
-
-        rig = root / "rig"
-        rig.mkdir()
-        workers = root / "workers"
-
+        workers = base / "workers"
         marker = city / ".gc/agentops-bootstrap.json"
         marker.write_text(json.dumps({
             "schema_version": 1,
@@ -503,88 +557,120 @@ class ThinPackTests(unittest.TestCase):
             },
             "telemetry": {"metrics_url": "", "logs_url": "", "sdk_disabled": True},
         }), encoding="utf-8")
-        return {"city": city, "rig": rig, "workers": workers, "gc_bin": gc_bin, "bd_bin": bd_bin}
+        return {"city": city, "rig": rig, "workers": workers, "gc_bin": gc_bin, "bd_bin": bd_bin, "toolchain": toolchain}
 
-    def test_feed_prepares_worktree_and_slings_rig_formula(self) -> None:
+    def test_feed_verifies_bead_then_slings_full_flag_set(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            gc_log = root / "gc.log"
-            worktree_out = root / "worker-tree"
-            gc_script = f'#!/bin/sh\nprintf \'%s\\n\' "$*" >> "{gc_log}"\nexit 0\n'
-            worktree_script = (
-                '#!/bin/sh\n'
-                f'printf \'{{"bead":"b","branch":"gc/b","worktree":"{worktree_out}"}}\\n\'\n'
-                'exit 0\n'
-            )
-            fixture = self._managed_city_fixture(
-                root, gc_script=gc_script, bd_script="#!/bin/sh\nexit 1\n",
-                worktree_script=worktree_script,
-            )
+            base = Path(temporary) / "has space"  # exercises argv quoting
+            base.mkdir()
+            repo, _ = self.make_repository(base)
+            fixture = self._managed_city_fixture(base, rig=repo)
+            gc_log = base / "gc.argv"
+            bd_log = base / "bd.argv"
+            env = self._invoke_env(gc_log=gc_log, bd_log=bd_log)
             result = run(
                 str(DEPLOY / "invoke.sh"), "--city", str(fixture["city"]), "feed", "testrig-1",
+                env=env,
             )
             self.assertEqual(result.returncode, 0, result.stderr)
-            logged = gc_log.read_text(encoding="utf-8")
-            self.assertIn("sling testrig/agentops.plan-reviewer testrig-1", logged)
-            self.assertIn("--on agentops-experiment", logged)
-            self.assertIn("--nudge", logged)
-            self.assertIn("--json", logged)
-            self.assertIn(f"--var work_dir={worktree_out}", logged)
-            self.assertIn("--var plan_target=testrig/agentops.plan-reviewer", logged)
-            self.assertIn("--var implement_target=testrig/agentops.implementer", logged)
-            self.assertIn("--var validate_target=testrig/agentops.validator", logged)
-            self.assertIn("--var refiner_target=testrig/agentops.refiner", logged)
-            self.assertNotIn("agentops.mayor", logged)
+            # Bead existence was verified in the rig store before any sling.
+            self.assertEqual(
+                bd_log.read_text(encoding="utf-8").splitlines(),
+                ["-C", str(repo.resolve()), "show", "testrig-1", "--json", "---"],
+            )
+            # The full production sling flag set, one argv element per line.
+            expected_worktree = str(Path(os.path.realpath(fixture["workers"])) / "testrig-1")
+            self.assertEqual(gc_log.read_text(encoding="utf-8").splitlines(), [
+                "sling", "testrig/agentops.plan-reviewer", "testrig-1",
+                "--on", "agentops-experiment", "--nudge", "--json",
+                "--var", f"work_dir={expected_worktree}",
+                "--var", "plan_target=testrig/agentops.plan-reviewer",
+                "--var", "implement_target=testrig/agentops.implementer",
+                "--var", "validate_target=testrig/agentops.validator",
+                "--var", "refiner_target=testrig/agentops.refiner",
+            ])
+            # The worktree was really prepared by the pinned pack helper.
+            self.assertTrue((Path(expected_worktree) / ".git").exists())
+
+    def test_feed_refuses_missing_bead_without_slinging(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary) / "has space"
+            base.mkdir()
+            repo, _ = self.make_repository(base)
+            fixture = self._managed_city_fixture(base, rig=repo)
+            gc_log = base / "gc.argv"
+            env = self._invoke_env(gc_log=gc_log, bd_log=base / "bd.argv", bd_mode="notfound")
+            result = run(
+                str(DEPLOY / "invoke.sh"), "--city", str(fixture["city"]), "feed", "testrig-404",
+                env=env,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("bead not found in the rig store", result.stderr)
+            self.assertFalse(gc_log.exists(), "sling must not run for a missing bead")
+            self.assertFalse((Path(str(fixture["workers"])) / "testrig-404").exists())
+
+    def test_feed_refuses_bead_id_mismatch_without_slinging(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary) / "has space"
+            base.mkdir()
+            repo, _ = self.make_repository(base)
+            fixture = self._managed_city_fixture(base, rig=repo)
+            gc_log = base / "gc.argv"
+            env = self._invoke_env(gc_log=gc_log, bd_log=base / "bd.argv", bd_mode="mismatch")
+            result = run(
+                str(DEPLOY / "invoke.sh"), "--city", str(fixture["city"]), "feed", "testrig-1",
+                env=env,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("exact single match", result.stderr)
+            self.assertFalse(gc_log.exists(), "sling must not run on an inexact match")
 
     def test_feed_rejects_unsafe_bead_id(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            fixture = self._managed_city_fixture(
-                root, gc_script="#!/bin/sh\nexit 0\n", bd_script="#!/bin/sh\nexit 1\n",
-                worktree_script="#!/bin/sh\nexit 0\n",
-            )
+            base = Path(temporary)
+            rig = base / "rig"
+            rig.mkdir()
+            fixture = self._managed_city_fixture(base, rig=rig)
             result = run(
                 str(DEPLOY / "invoke.sh"), "--city", str(fixture["city"]), "feed", "bad id;rm",
+                env=self._invoke_env(),
             )
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("unsafe bead id", result.stderr)
 
     def test_create_writes_managed_rig_store_and_prints_id(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            bd_log = root / "bd.log"
-            bd_script = (
-                '#!/bin/sh\n'
-                f'printf \'%s\\n\' "$*" >> "{bd_log}"\n'
-                'printf \'{"id":"testrig-9"}\\n\'\n'
-                'exit 0\n'
-            )
-            fixture = self._managed_city_fixture(
-                root, gc_script="#!/bin/sh\nexit 1\n", bd_script=bd_script,
-                worktree_script="#!/bin/sh\nexit 0\n",
-            )
+            base = Path(temporary) / "has space"  # exercises argv quoting
+            base.mkdir()
+            rig = base / "rig"
+            rig.mkdir()
+            fixture = self._managed_city_fixture(base, rig=rig)
+            bd_log = base / "bd.argv"
+            env = self._invoke_env(bd_log=bd_log)
             plain = run(
                 str(DEPLOY / "invoke.sh"), "--city", str(fixture["city"]),
-                "create", "add a widget", "-d", "with a description",
+                "create", "add a widget", "-d", "with a description", env=env,
             )
             self.assertEqual(plain.returncode, 0, plain.stderr)
             self.assertEqual(plain.stdout, "testrig-9\n")
-            logged = bd_log.read_text(encoding="utf-8")
-            self.assertIn(f"-C {fixture['rig'].resolve()} create", logged)
-            self.assertIn("--title add a widget", logged)
-            self.assertIn("--type task", logged)
-            self.assertIn("--json", logged)
-            self.assertIn("-d with a description", logged)
+            first_call = bd_log.read_text(encoding="utf-8").split("---\n")[0].splitlines()
+            self.assertEqual(first_call, [
+                "-C", str(rig.resolve()), "create", "--title", "add a widget",
+                "--type", "task", "--json", "-d", "with a description",
+            ])
 
             json_out = run(
                 str(DEPLOY / "invoke.sh"), "--city", str(fixture["city"]),
-                "create", "no description", "--json",
+                "create", "no description", "--json", env=env,
             )
             self.assertEqual(json_out.returncode, 0, json_out.stderr)
             self.assertEqual(json.loads(json_out.stdout)["id"], "testrig-9")
-            # No description supplied -> no -d flag forwarded to bd.
-            second = bd_log.read_text(encoding="utf-8").splitlines()[-1]
-            self.assertNotIn("-d ", second)
+            # No description supplied -> no -d flag forwarded to bd (exact argv).
+            calls = [c for c in bd_log.read_text(encoding="utf-8").split("---\n") if c.strip()]
+            self.assertEqual(calls[-1].splitlines(), [
+                "-C", str(rig.resolve()), "create", "--title", "no description",
+                "--type", "task", "--json",
+            ])
 
     def test_teardown_waits_for_scoped_drain_and_fails_with_exact_residue(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Why

Verified against GC v1.3.5 source + docs: the stock Mayor **dispatches and never claims** (mayor.md prompt, swarm example, reference mayor-dispatch.sh); the blessed single-bead intake is `gc sling <rig>/<agent> <bead> --on <formula>`, with claims happening rig-scoped — the byte-for-byte unchanged-safe path on v1.3.5. Our pack inverted this by slinging to the city-scoped `agentops.mayor`, which is exactly (and only) the shape that hits the v1.3.5 cross-store claim defect. This aligns intake with the official pattern: the loop works on official v1.3.5 binaries, beads stay rig-homed and git-synced.

## What

1. **4f31a35e6** `fix(gc)`: `invoke.sh feed` slings to `<rig>/agentops.plan-reviewer --on agentops-experiment` with rig-scoped role vars; new `invoke.sh create` writes the work bead into the rig store via the pinned bd against the managed Dolt server; Mayor demoted to optional observe-only coordinator (explicit do-not-claim); refiner rework path re-pointed off the Mayor. Static proof: zero `agentops.mayor` routing left; the only executable sling targets the rig role.
2. **e766d05a5** `docs(gc)`: README default flow = create → feed → observe → refine → teardown on the official pattern; cross-store claim bug demoted to "not exercised by the default flow"; preview label + promotion criteria unchanged.
3. **ae7664496** `fix(gc)` (from cross-family review — 1 BLOCKER + 4 MAJORs, all fixed): executable provenance anchored to the pack's own lock/receipt chain instead of the mutable marker; re-bootstrap now detects stale toolchain paths/digests; feed verifies the bead exists exactly before sling (v1.3.5 `gc sling` auto-creates a task from unknown text — a typo would have dispatched garbage); Mayor observe surface uses `gc rig list` + per-rig `gc bd --rig N ready/blocked` (bare city reads miss rig work); test stubs record exact argv under space-containing paths, guards proven to bite.

## Verification

- `tests.python.test_gc33_thin_pack`: 23 run, OK (2 integration skips — need booted city)
- `shellcheck -S warning deploy/gc/*.sh`: clean; `bash -n` all scripts
- Codex adversarial review round: all findings fixed
- **Not yet proven live**: the full booted-city flow (`--nudge` wake, formula execution, refine landing). That is the immediate next phase — a dogfood run sending the RPI human-summary bead through a real city on official v1.3.5.