### PR TITLE
docs(gc): teach the four-layer visibility doctrine

### DIFF
--- a/deploy/gc/README.md
+++ b/deploy/gc/README.md
@@ -150,6 +150,21 @@ the rig and worktree-root paths must be trusted in `~/.codex/config.toml` as
 exact-path `trust_level` entries; the bootstrap does not yet write them, so add
 them yourself before the first run.
 
+### Visibility
+
+Four observability layers; each lies in its own way, so cycle all four:
+
+- **Robot state** — `invoke.sh --city C status` / `gc session list`: lifecycle
+  shape only; reports "active" through a wedged pane or dead network.
+- **Bead graph** — `gc bd --rig <rig> ready|show <id>`: the only completion truth.
+- **Pane truth** — `tmux -L <socket> capture-pane -t <session> -p`: ground truth
+  for wedges (update nags, trust prompts, API/DNS failures print here first).
+- **Health machinery** — `gc doctor`, `gc order history <order>`: the city's
+  metabolism, not any specific work's progress.
+
+Robot state lies by omission; pane capture is ground truth — when they disagree,
+trust the pane. Full discipline: the `using-gc` skill.
+
 ## Teardown
 
 ```sh

--- a/images/gemini/skills/using-gc/SKILL.md
+++ b/images/gemini/skills/using-gc/SKILL.md
@@ -109,6 +109,29 @@ Ground-truth every stall before you report it: capture the pane (`tmux -L
 hidden retries, no lifecycle bypass. **Never repair the city from inside the
 city** — diagnose from the invoke surface and hand the finding out.
 
+## Visibility: the four layers
+
+Every canary stall was invisible to at least one layer and visible in another.
+Cycle all four; each lies in its own way.
+
+- **Layer 1 — Robot state.** `gc session list` / `invoke.sh --city C status` —
+  reports "active" even when the provider pane is wedged on a prompt or the
+  network is dead. Lifecycle shape only, never proof of thinking.
+- **Layer 2 — Bead graph.** `gc bd --rig <rig> ready` / `gc bd --rig <rig> show
+  <id>` (workflow/step statuses) — the only completion truth; but a claimed step
+  with a wedged worker looks identical to a working one from here.
+- **Layer 3 — Pane truth.** `tmux -L <socket> capture-pane -t <session> -p` —
+  ground truth for wedges (update nags, trust prompts, API/DNS failures print
+  here first). It is a snapshot, not history.
+- **Layer 4 — Health machinery.** `gc doctor`, `gc order history <order>` (e.g.
+  shepherd-heartbeat) — proves the city's metabolism (orders firing, stores
+  resolving), not whether any specific work is progressing.
+
+Native `gc dashboard` aggregates layers 1-2; the metrics/logs plane (OTel to
+local collectors, Grafana) is the 3.3.1 roadmap layer and not required for
+operating a city today. When layers disagree, trust the LOWER layer (pane over
+robot state) and run the Stall protocol.
+
 ## Boundaries (kept)
 
 - GC state stays in GC. GC quests, attempts, stalls, and internal `close` do not

--- a/packs/agentops-executor/assets/generated-skill-manifest.json
+++ b/packs/agentops-executor/assets/generated-skill-manifest.json
@@ -90,8 +90,8 @@
     {
       "source": "skills/using-gc/SKILL.md",
       "destination": "packs/agentops-executor/skills/using-gc/SKILL.md",
-      "source_sha256": "482a25c6fce8d0a84b65d5770bd98c5229084d4a40520d71751833465b2fecc8",
-      "sha256": "482a25c6fce8d0a84b65d5770bd98c5229084d4a40520d71751833465b2fecc8",
+      "source_sha256": "277c56846658aecafbd3ec62b48279e898dd84311e51a892f077daf38eb3e911",
+      "sha256": "277c56846658aecafbd3ec62b48279e898dd84311e51a892f077daf38eb3e911",
       "mode": "0644"
     }
   ]

--- a/packs/agentops-executor/skills/using-gc/SKILL.md
+++ b/packs/agentops-executor/skills/using-gc/SKILL.md
@@ -109,6 +109,29 @@ Ground-truth every stall before you report it: capture the pane (`tmux -L
 hidden retries, no lifecycle bypass. **Never repair the city from inside the
 city** — diagnose from the invoke surface and hand the finding out.
 
+## Visibility: the four layers
+
+Every canary stall was invisible to at least one layer and visible in another.
+Cycle all four; each lies in its own way.
+
+- **Layer 1 — Robot state.** `gc session list` / `invoke.sh --city C status` —
+  reports "active" even when the provider pane is wedged on a prompt or the
+  network is dead. Lifecycle shape only, never proof of thinking.
+- **Layer 2 — Bead graph.** `gc bd --rig <rig> ready` / `gc bd --rig <rig> show
+  <id>` (workflow/step statuses) — the only completion truth; but a claimed step
+  with a wedged worker looks identical to a working one from here.
+- **Layer 3 — Pane truth.** `tmux -L <socket> capture-pane -t <session> -p` —
+  ground truth for wedges (update nags, trust prompts, API/DNS failures print
+  here first). It is a snapshot, not history.
+- **Layer 4 — Health machinery.** `gc doctor`, `gc order history <order>` (e.g.
+  shepherd-heartbeat) — proves the city's metabolism (orders firing, stores
+  resolving), not whether any specific work is progressing.
+
+Native `gc dashboard` aggregates layers 1-2; the metrics/logs plane (OTel to
+local collectors, Grafana) is the 3.3.1 roadmap layer and not required for
+operating a city today. When layers disagree, trust the LOWER layer (pane over
+robot state) and run the Stall protocol.
+
 ## Boundaries (kept)
 
 - GC state stays in GC. GC quests, attempts, stalls, and internal `close` do not

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -597,8 +597,8 @@
     {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
-      "source_hash": "ffcc0bf8b7ab2029711292086b1b65adf5b88a86fb5f3296df117574ef58e465",
-      "generated_hash": "338f53414a61b42ff1b8e224f6eedcd145196e8ecf26749bad27ffed78b9814e"
+      "source_hash": "5fda6596d3435c99da7a2fe1c4b595e9dabb13a4fe856fe0139eb73531a90e9c",
+      "generated_hash": "3688f6ebfab4e3a774e70b28b14e11af117fc500a6164434e0ffeeaa962a191f"
     },
     {
       "name": "validate",

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/using-gc",
   "layout": "modular",
-  "source_hash": "ffcc0bf8b7ab2029711292086b1b65adf5b88a86fb5f3296df117574ef58e465",
-  "generated_hash": "338f53414a61b42ff1b8e224f6eedcd145196e8ecf26749bad27ffed78b9814e"
+  "source_hash": "5fda6596d3435c99da7a2fe1c4b595e9dabb13a4fe856fe0139eb73531a90e9c",
+  "generated_hash": "3688f6ebfab4e3a774e70b28b14e11af117fc500a6164434e0ffeeaa962a191f"
 }

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -91,6 +91,29 @@ Ground-truth every stall before you report it: capture the pane (`tmux -L
 hidden retries, no lifecycle bypass. **Never repair the city from inside the
 city** — diagnose from the invoke surface and hand the finding out.
 
+## Visibility: the four layers
+
+Every canary stall was invisible to at least one layer and visible in another.
+Cycle all four; each lies in its own way.
+
+- **Layer 1 — Robot state.** `gc session list` / `invoke.sh --city C status` —
+  reports "active" even when the provider pane is wedged on a prompt or the
+  network is dead. Lifecycle shape only, never proof of thinking.
+- **Layer 2 — Bead graph.** `gc bd --rig <rig> ready` / `gc bd --rig <rig> show
+  <id>` (workflow/step statuses) — the only completion truth; but a claimed step
+  with a wedged worker looks identical to a working one from here.
+- **Layer 3 — Pane truth.** `tmux -L <socket> capture-pane -t <session> -p` —
+  ground truth for wedges (update nags, trust prompts, API/DNS failures print
+  here first). It is a snapshot, not history.
+- **Layer 4 — Health machinery.** `gc doctor`, `gc order history <order>` (e.g.
+  shepherd-heartbeat) — proves the city's metabolism (orders firing, stores
+  resolving), not whether any specific work is progressing.
+
+Native `gc dashboard` aggregates layers 1-2; the metrics/logs plane (OTel to
+local collectors, Grafana) is the 3.3.1 roadmap layer and not required for
+operating a city today. When layers disagree, trust the LOWER layer (pane over
+robot state) and run the Stall protocol.
+
 ## Boundaries (kept)
 
 - GC state stays in GC. GC quests, attempts, stalls, and internal `close` do not

--- a/skills/using-gc/SKILL.md
+++ b/skills/using-gc/SKILL.md
@@ -109,6 +109,29 @@ Ground-truth every stall before you report it: capture the pane (`tmux -L
 hidden retries, no lifecycle bypass. **Never repair the city from inside the
 city** — diagnose from the invoke surface and hand the finding out.
 
+## Visibility: the four layers
+
+Every canary stall was invisible to at least one layer and visible in another.
+Cycle all four; each lies in its own way.
+
+- **Layer 1 — Robot state.** `gc session list` / `invoke.sh --city C status` —
+  reports "active" even when the provider pane is wedged on a prompt or the
+  network is dead. Lifecycle shape only, never proof of thinking.
+- **Layer 2 — Bead graph.** `gc bd --rig <rig> ready` / `gc bd --rig <rig> show
+  <id>` (workflow/step statuses) — the only completion truth; but a claimed step
+  with a wedged worker looks identical to a working one from here.
+- **Layer 3 — Pane truth.** `tmux -L <socket> capture-pane -t <session> -p` —
+  ground truth for wedges (update nags, trust prompts, API/DNS failures print
+  here first). It is a snapshot, not history.
+- **Layer 4 — Health machinery.** `gc doctor`, `gc order history <order>` (e.g.
+  shepherd-heartbeat) — proves the city's metabolism (orders firing, stores
+  resolving), not whether any specific work is progressing.
+
+Native `gc dashboard` aggregates layers 1-2; the metrics/logs plane (OTel to
+local collectors, Grafana) is the 3.3.1 roadmap layer and not required for
+operating a city today. When layers disagree, trust the LOWER layer (pane over
+robot state) and run the Stall protocol.
+
 ## Boundaries (kept)
 
 - GC state stays in GC. GC quests, attempts, stalls, and internal `close` do not


### PR DESCRIPTION
Adds the four-layer visibility doctrine to the GC pack teaching surfaces, distilled from the 2026-07-22/23 live canary arc where every stall was invisible to at least one observability layer and visible in another (three provider wedge classes, all reported "active" by robot state).

- skills/using-gc: "Visibility: the four layers" — robot state / bead graph / pane truth / health machinery, each with its command and its when-it-lies note; disagreement rule (trust the lower layer) tied to the stall protocol; gc dashboard noted as native aggregation, OTel/Grafana deferred to 3.3.1.
- deploy/gc/README.md: matching 15-line Visibility block with the core warning.
- All skill projections regenerated; insertion-only; frontmatter and mesh projections byte-stable.

RPI: Opus implement, fresh Sol (codex) validator — PASS on all 7 acceptance criteria, verdict.v2 persisted. regen-all --check and docs-check green (run fresh by both author and validator).