### PR TITLE
feat(skills): ground-truth routing in plan + derivation-diff challenge in premortem

### DIFF
--- a/images/gemini/skills/plan/SKILL.md
+++ b/images/gemini/skills/plan/SKILL.md
@@ -35,8 +35,10 @@ and hash the same source. Do not make the model restate those facts in a packet.
    is not already durable, have the runtime pass its exact bytes to
    `python3 skills/validate/scripts/validate.py snapshot-intent --source -` and
    use the returned `intent_ref` for later phases.
-2. Inspect only enough real context to make paths, interfaces, and evidence
-   concrete. Existing research and specialist skills are advisory inputs.
+2. Route the work by type (see **Ground-truth routing**) and name its ground
+   truth first. Then inspect only enough real context to make paths, interfaces,
+   and evidence concrete. Existing research and specialist skills are advisory
+   inputs.
 3. Ensure the source contains acceptance examples, important non-goals, and the
    allowed write scope. Use lightweight prose or Given/When/Then only where it
    removes ambiguity; do not require both normal and edge ceremony for every
@@ -69,6 +71,29 @@ generated companions, parity twins (for example a `skills-codex/` mirror), and
 test files that assert on the paths being changed. Anything this pass finds
 that the scope does not admit will surface later as an out-of-scope diff or a
 broken gate.
+
+## Ground-truth routing
+
+Every plan needs a ground truth outside the planner's own reasoning. Before
+freezing acceptance, classify the work and name its ground truth, its control
+experiment, and its deviation ledger from the row below.
+
+| Work type | Ground truth | Control experiment | Deviation ledger |
+|---|---|---|---|
+| Integrate an external substrate, runtime, tracker, or service | the vendor's own docs plus stock behavior | run their vanilla quickstart on pinned versions with zero local code, before designing | each deviation from the documented flow, each justified; and every component you write that has a native counterpart in the substrate |
+| Extend this project | the repo's existing patterns and behavior spec | the simplest version that satisfies acceptance, and why it is insufficient | each novelty introduced — new abstraction, dependency, or pattern |
+| Greenfield | reference experience and domain prior art | a walking skeleton | each deviation from the boring default, ~one novelty per change |
+
+The Extend row is already the repo's default discipline: behavior-first
+acceptance, RED -> GREEN, the smallest real change. The Integrate row is the one
+that is cheap to skip and expensive to have skipped — run the stock control
+experiment *before* you design, or you will re-plumb what the substrate already
+documents and inherit bugs you built yourself.
+
+Trigger: the Integrate-row mechanics — the stock-quickstart control run and the
+deviation ledger from the documented flow — apply only to integration-class work
+(adopting or wiring in an external substrate, runtime, tracker, or service).
+Routine feature work on this project uses the Extend row and does not incur them.
 
 A plan is done only when it passes the fresh-context test: a cold context,
 given the intent source alone, could execute it without the author's

--- a/images/gemini/skills/premortem/SKILL.md
+++ b/images/gemini/skills/premortem/SKILL.md
@@ -55,6 +55,32 @@ condition: every reported finding is backed by a defeat attempt — constructed,
 or attempted with the blocking fact cited; a finding with neither is deleted,
 not softened.
 
+## Derivation-diff challenge
+
+A challenger that critiques the handed plan is a yes-man with extra steps: it
+anchors on the author's design and rationalizes it. Derive independently, then
+diff. Give one fresh context ONLY the intent source and the plan's declared
+ground truth — the vendor docs and stock behavior for integration work, the
+repo's patterns and behavior spec for extension — and never the author's design.
+Have it sketch its own design from that ground truth alone. The diff between that
+independent design and the working plan is the challenge artifact; each
+divergence is a finding to defend or adopt. Convergence is weak evidence the plan
+follows the ground truth; divergence names where it may not.
+
+Two questions the challenger answers with an artifact, not an opinion:
+
+- Cathedral: is this the smallest real thing, or does it rebuild what already
+  exists? Artifact — the simplest version that satisfies acceptance, plus the
+  named reason it is insufficient. No named reason means build the simple one.
+- Grain: for integration work, does every component the plan writes have a native
+  counterpart in the substrate? Artifact — the native-counterpart list, one row
+  per component the plan authors, naming the substrate feature it duplicates or
+  the reason none exists.
+
+These are integration- and extension-class checks. The Grain question's
+native-counterpart list applies only to integration-class work; do not impose it
+on routine feature work.
+
 ## Boundary
 
 - Emit advisory findings, not `verdict.v2`, readiness, admission, or permission.

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -471,8 +471,8 @@
     {
       "name": "plan",
       "source_skill": "skills/plan",
-      "source_hash": "52b1a430e92c6e0758d8bfb63a7b7fb5a7bcde2580a877b2139f0d81164054e8",
-      "generated_hash": "1a45337fb4092eaee0bf2f17b74516014efc7a9891ed7b8843af9b0f337b1a7f"
+      "source_hash": "1c9c85fd6634c58aa41d16b24f7f3e5e1b49d1e0204b1b85d24c3e1ce56d4952",
+      "generated_hash": "1786e7562de5d20e408cc5e3ea5ba8dc1e7b1f89873545906843f9f22b85e844"
     },
     {
       "name": "postmortem",
@@ -483,8 +483,8 @@
     {
       "name": "premortem",
       "source_skill": "skills/premortem",
-      "source_hash": "c57717b51b943e8ca3883643f45b596eef1e9b4b39fd282dbe32914861bee42c",
-      "generated_hash": "8c37dedba4b3c042beb19dc30cacc370565fbe4635a8a01db65758cd5c66e0da"
+      "source_hash": "06fa5f32dd993d969371c99aabd78a2d5c5057b409c75323bfe372048a2c191c",
+      "generated_hash": "4aba81740a48d49fa43412609d235e8ea9f23a915945b7f11301bf3671f4b6a6"
     },
     {
       "name": "product",

--- a/skills-codex/plan/.agentops-generated.json
+++ b/skills-codex/plan/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/plan",
   "layout": "modular",
-  "source_hash": "52b1a430e92c6e0758d8bfb63a7b7fb5a7bcde2580a877b2139f0d81164054e8",
-  "generated_hash": "1a45337fb4092eaee0bf2f17b74516014efc7a9891ed7b8843af9b0f337b1a7f"
+  "source_hash": "1c9c85fd6634c58aa41d16b24f7f3e5e1b49d1e0204b1b85d24c3e1ce56d4952",
+  "generated_hash": "1786e7562de5d20e408cc5e3ea5ba8dc1e7b1f89873545906843f9f22b85e844"
 }

--- a/skills-codex/plan/SKILL.md
+++ b/skills-codex/plan/SKILL.md
@@ -16,8 +16,10 @@ and hash the same source. Do not make the model restate those facts in a packet.
    is not already durable, have the runtime pass its exact bytes to
    `python3 skills/validate/scripts/validate.py snapshot-intent --source -` and
    use the returned `intent_ref` for later phases.
-2. Inspect only enough real context to make paths, interfaces, and evidence
-   concrete. Existing research and specialist skills are advisory inputs.
+2. Route the work by type (see **Ground-truth routing**) and name its ground
+   truth first. Then inspect only enough real context to make paths, interfaces,
+   and evidence concrete. Existing research and specialist skills are advisory
+   inputs.
 3. Ensure the source contains acceptance examples, important non-goals, and the
    allowed write scope. Use lightweight prose or Given/When/Then only where it
    removes ambiguity; do not require both normal and edge ceremony for every
@@ -50,6 +52,29 @@ generated companions, parity twins (for example a `skills-codex/` mirror), and
 test files that assert on the paths being changed. Anything this pass finds
 that the scope does not admit will surface later as an out-of-scope diff or a
 broken gate.
+
+## Ground-truth routing
+
+Every plan needs a ground truth outside the planner's own reasoning. Before
+freezing acceptance, classify the work and name its ground truth, its control
+experiment, and its deviation ledger from the row below.
+
+| Work type | Ground truth | Control experiment | Deviation ledger |
+|---|---|---|---|
+| Integrate an external substrate, runtime, tracker, or service | the vendor's own docs plus stock behavior | run their vanilla quickstart on pinned versions with zero local code, before designing | each deviation from the documented flow, each justified; and every component you write that has a native counterpart in the substrate |
+| Extend this project | the repo's existing patterns and behavior spec | the simplest version that satisfies acceptance, and why it is insufficient | each novelty introduced — new abstraction, dependency, or pattern |
+| Greenfield | reference experience and domain prior art | a walking skeleton | each deviation from the boring default, ~one novelty per change |
+
+The Extend row is already the repo's default discipline: behavior-first
+acceptance, RED -> GREEN, the smallest real change. The Integrate row is the one
+that is cheap to skip and expensive to have skipped — run the stock control
+experiment *before* you design, or you will re-plumb what the substrate already
+documents and inherit bugs you built yourself.
+
+Trigger: the Integrate-row mechanics — the stock-quickstart control run and the
+deviation ledger from the documented flow — apply only to integration-class work
+(adopting or wiring in an external substrate, runtime, tracker, or service).
+Routine feature work on this project uses the Extend row and does not incur them.
 
 A plan is done only when it passes the fresh-context test: a cold context,
 given the intent source alone, could execute it without the author's

--- a/skills-codex/premortem/.agentops-generated.json
+++ b/skills-codex/premortem/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/premortem",
   "layout": "modular",
-  "source_hash": "c57717b51b943e8ca3883643f45b596eef1e9b4b39fd282dbe32914861bee42c",
-  "generated_hash": "8c37dedba4b3c042beb19dc30cacc370565fbe4635a8a01db65758cd5c66e0da"
+  "source_hash": "06fa5f32dd993d969371c99aabd78a2d5c5057b409c75323bfe372048a2c191c",
+  "generated_hash": "4aba81740a48d49fa43412609d235e8ea9f23a915945b7f11301bf3671f4b6a6"
 }

--- a/skills-codex/premortem/SKILL.md
+++ b/skills-codex/premortem/SKILL.md
@@ -36,6 +36,32 @@ condition: every reported finding is backed by a defeat attempt — constructed,
 or attempted with the blocking fact cited; a finding with neither is deleted,
 not softened.
 
+## Derivation-diff challenge
+
+A challenger that critiques the handed plan is a yes-man with extra steps: it
+anchors on the author's design and rationalizes it. Derive independently, then
+diff. Give one fresh context ONLY the intent source and the plan's declared
+ground truth — the vendor docs and stock behavior for integration work, the
+repo's patterns and behavior spec for extension — and never the author's design.
+Have it sketch its own design from that ground truth alone. The diff between that
+independent design and the working plan is the challenge artifact; each
+divergence is a finding to defend or adopt. Convergence is weak evidence the plan
+follows the ground truth; divergence names where it may not.
+
+Two questions the challenger answers with an artifact, not an opinion:
+
+- Cathedral: is this the smallest real thing, or does it rebuild what already
+  exists? Artifact — the simplest version that satisfies acceptance, plus the
+  named reason it is insufficient. No named reason means build the simple one.
+- Grain: for integration work, does every component the plan writes have a native
+  counterpart in the substrate? Artifact — the native-counterpart list, one row
+  per component the plan authors, naming the substrate feature it duplicates or
+  the reason none exists.
+
+These are integration- and extension-class checks. The Grain question's
+native-counterpart list applies only to integration-class work; do not impose it
+on routine feature work.
+
 ## Boundary
 
 - Emit advisory findings, not `verdict.v2`, readiness, admission, or permission.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -35,8 +35,10 @@ and hash the same source. Do not make the model restate those facts in a packet.
    is not already durable, have the runtime pass its exact bytes to
    `python3 skills/validate/scripts/validate.py snapshot-intent --source -` and
    use the returned `intent_ref` for later phases.
-2. Inspect only enough real context to make paths, interfaces, and evidence
-   concrete. Existing research and specialist skills are advisory inputs.
+2. Route the work by type (see **Ground-truth routing**) and name its ground
+   truth first. Then inspect only enough real context to make paths, interfaces,
+   and evidence concrete. Existing research and specialist skills are advisory
+   inputs.
 3. Ensure the source contains acceptance examples, important non-goals, and the
    allowed write scope. Use lightweight prose or Given/When/Then only where it
    removes ambiguity; do not require both normal and edge ceremony for every
@@ -69,6 +71,29 @@ generated companions, parity twins (for example a `skills-codex/` mirror), and
 test files that assert on the paths being changed. Anything this pass finds
 that the scope does not admit will surface later as an out-of-scope diff or a
 broken gate.
+
+## Ground-truth routing
+
+Every plan needs a ground truth outside the planner's own reasoning. Before
+freezing acceptance, classify the work and name its ground truth, its control
+experiment, and its deviation ledger from the row below.
+
+| Work type | Ground truth | Control experiment | Deviation ledger |
+|---|---|---|---|
+| Integrate an external substrate, runtime, tracker, or service | the vendor's own docs plus stock behavior | run their vanilla quickstart on pinned versions with zero local code, before designing | each deviation from the documented flow, each justified; and every component you write that has a native counterpart in the substrate |
+| Extend this project | the repo's existing patterns and behavior spec | the simplest version that satisfies acceptance, and why it is insufficient | each novelty introduced — new abstraction, dependency, or pattern |
+| Greenfield | reference experience and domain prior art | a walking skeleton | each deviation from the boring default, ~one novelty per change |
+
+The Extend row is already the repo's default discipline: behavior-first
+acceptance, RED -> GREEN, the smallest real change. The Integrate row is the one
+that is cheap to skip and expensive to have skipped — run the stock control
+experiment *before* you design, or you will re-plumb what the substrate already
+documents and inherit bugs you built yourself.
+
+Trigger: the Integrate-row mechanics — the stock-quickstart control run and the
+deviation ledger from the documented flow — apply only to integration-class work
+(adopting or wiring in an external substrate, runtime, tracker, or service).
+Routine feature work on this project uses the Extend row and does not incur them.
 
 A plan is done only when it passes the fresh-context test: a cold context,
 given the intent source alone, could execute it without the author's

--- a/skills/premortem/SKILL.md
+++ b/skills/premortem/SKILL.md
@@ -55,6 +55,32 @@ condition: every reported finding is backed by a defeat attempt — constructed,
 or attempted with the blocking fact cited; a finding with neither is deleted,
 not softened.
 
+## Derivation-diff challenge
+
+A challenger that critiques the handed plan is a yes-man with extra steps: it
+anchors on the author's design and rationalizes it. Derive independently, then
+diff. Give one fresh context ONLY the intent source and the plan's declared
+ground truth — the vendor docs and stock behavior for integration work, the
+repo's patterns and behavior spec for extension — and never the author's design.
+Have it sketch its own design from that ground truth alone. The diff between that
+independent design and the working plan is the challenge artifact; each
+divergence is a finding to defend or adopt. Convergence is weak evidence the plan
+follows the ground truth; divergence names where it may not.
+
+Two questions the challenger answers with an artifact, not an opinion:
+
+- Cathedral: is this the smallest real thing, or does it rebuild what already
+  exists? Artifact — the simplest version that satisfies acceptance, plus the
+  named reason it is insufficient. No named reason means build the simple one.
+- Grain: for integration work, does every component the plan writes have a native
+  counterpart in the substrate? Artifact — the native-counterpart list, one row
+  per component the plan authors, naming the substrate feature it duplicates or
+  the reason none exists.
+
+These are integration- and extension-class checks. The Grain question's
+native-counterpart list applies only to integration-class work; do not impose it
+on routine feature work.
+
 ## Boundary
 
 - Emit advisory findings, not `verdict.v2`, readiness, admission, or permission.


### PR DESCRIPTION
Installs the GC frame-error lesson as loop doctrine (RPI-validated: fresh Opus validator, PASS on all 10 acceptance criteria, verdict.v2 persisted; deterministic gates re-run green after rebase onto main).

- skills/plan: **Ground-truth routing** — every plan names its ground truth, control experiment, and deviation ledger by work type (Integrate / Extend / Greenfield); the Integrate-row mechanics (stock-quickstart control, deviation ledger) are trigger-scoped to integration-class work only.
- skills/premortem: **Derivation-diff challenge** — the challenger receives only intent + ground truth, never the author's design; the diff is the artifact. Plus the Cathedral question (simplest-version artifact) and Grain question (native-counterpart list, integration-scoped).

Proportionate additions to two lean contracts; frontmatter byte-stable; mesh projections unchanged; codex twins + body projections regenerated.