### PR TITLE
feat: add craft-goal and humanize RPI reports

### DIFF
--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -2,7 +2,7 @@
 
 # Skill Router
 
-48 live skills. Metadata is the sole inventory and graph source.
+49 live skills. Metadata is the sole inventory and graph source.
 
 ## keep
 
@@ -22,7 +22,7 @@
 
 ## keep_specialist
 
-`account-rotation`, `bootstrap`, `cass`, `cc-hooks`, `codebase-recon`, `converter`, `dcg`, `doc`, `domain`, `goals`, `handoff`, `ms`, `operationalize`, `pattern-mining`, `product`, `rch`, `refactor`, `research`, `reverse-engineer`, `sbh`, `scaffold`, `scope`, `security`, `shared`, `skill-builder`, `standards`, `status`, `test`, `toil-mining`, `workflow-builder`
+`account-rotation`, `bootstrap`, `cass`, `cc-hooks`, `codebase-recon`, `converter`, `craft-goal`, `dcg`, `doc`, `domain`, `goals`, `handoff`, `ms`, `operationalize`, `pattern-mining`, `product`, `rch`, `refactor`, `research`, `reverse-engineer`, `sbh`, `scaffold`, `scope`, `security`, `shared`, `skill-builder`, `standards`, `status`, `test`, `toil-mining`, `workflow-builder`
 
 ## Complete inventory
 
@@ -40,6 +40,7 @@
 | `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
 | `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
+| `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | - |
 | `doc` | product | `keep_specialist` | - | `doc` | - |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -2,7 +2,7 @@
 
 # Skill Router
 
-48 live skills. Metadata is the sole inventory and graph source.
+49 live skills. Metadata is the sole inventory and graph source.
 
 ## keep
 
@@ -22,7 +22,7 @@
 
 ## keep_specialist
 
-`account-rotation`, `bootstrap`, `cass`, `cc-hooks`, `codebase-recon`, `converter`, `dcg`, `doc`, `domain`, `goals`, `handoff`, `ms`, `operationalize`, `pattern-mining`, `product`, `rch`, `refactor`, `research`, `reverse-engineer`, `sbh`, `scaffold`, `scope`, `security`, `shared`, `skill-builder`, `standards`, `status`, `test`, `toil-mining`, `workflow-builder`
+`account-rotation`, `bootstrap`, `cass`, `cc-hooks`, `codebase-recon`, `converter`, `craft-goal`, `dcg`, `doc`, `domain`, `goals`, `handoff`, `ms`, `operationalize`, `pattern-mining`, `product`, `rch`, `refactor`, `research`, `reverse-engineer`, `sbh`, `scaffold`, `scope`, `security`, `shared`, `skill-builder`, `standards`, `status`, `test`, `toil-mining`, `workflow-builder`
 
 ## Complete inventory
 
@@ -40,6 +40,7 @@
 | `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
 | `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
+| `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | - |
 | `doc` | product | `keep_specialist` | - | `doc` | - |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -28,6 +28,7 @@
 | `codebase-recon` | `customer-of` | `research` |
 | `codebase-recon` | `customer-of` | `validate` |
 | `codex-exec` | `supplier-to` | `validate` |
+| `craft-goal` | `supplier-to` | `plan` |
 | `goals` | `shared-kernel` | `standards` |
 | `idea-genie` | `customer-of` | `research` |
 | `idea-genie` | `supplier-to` | `plan` |
@@ -82,6 +83,10 @@
 | `council` | consumes | `explicit-question` |
 | `council` | consumes | `evidence` |
 | `council` | produces | `council-report.v1` |
+| `craft-goal` | consumes | `caller-outcome` |
+| `craft-goal` | consumes | `goal-acceptance` |
+| `craft-goal` | produces | `outer-goal-prompt` |
+| `craft-goal` | produces | `goal-safety-report` |
 | `doc` | consumes | `repo-context` |
 | `doc` | produces | `documentation` |
 | `domain` | produces | `stdout` |

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -16,7 +16,7 @@
 
 ## supporting
 
-`account-rotation`, `agent-mail`, `agent-native`, `automation-shape-routing`, `cass`, `cc-hooks`, `codebase-recon`, `dcg`, `doc`, `handoff`, `learn`, `ms`, `ntm`, `operationalize`, `pattern-mining`, `rch`, `refactor`, `reverse-engineer`, `sbh`, `scaffold`, `scope`, `skill-builder`, `standards`, `test`, `toil-mining`, `workflow-builder`
+`account-rotation`, `agent-mail`, `agent-native`, `automation-shape-routing`, `cass`, `cc-hooks`, `codebase-recon`, `craft-goal`, `dcg`, `doc`, `handoff`, `learn`, `ms`, `ntm`, `operationalize`, `pattern-mining`, `rch`, `refactor`, `reverse-engineer`, `sbh`, `scaffold`, `scope`, `skill-builder`, `standards`, `test`, `toil-mining`, `workflow-builder`
 
 ## Inventory
 
@@ -34,6 +34,7 @@
 | `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
 | `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
+| `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | - |
 | `doc` | product | `keep_specialist` | - | `doc` | - |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |

--- a/docs/reference/agentops-skill-graph.md
+++ b/docs/reference/agentops-skill-graph.md
@@ -16,6 +16,7 @@ graph LR
   codex_exec["codex-exec"]
   converter["converter"]
   council["council"]
+  craft_goal["craft-goal"]
   dcg["dcg"]
   doc["doc"]
   domain["domain"]

--- a/images/claude/manifest.json
+++ b/images/claude/manifest.json
@@ -1,7 +1,7 @@
 {
   "image": "claude",
   "schema_version": "skill-image.v1",
-  "skill_count": 48,
+  "skill_count": 49,
   "skills": [
     {
       "disposition": "keep_specialist",
@@ -62,6 +62,11 @@
       "disposition": "keep_strategy",
       "path": "skills/council/",
       "slug": "council"
+    },
+    {
+      "disposition": "keep_specialist",
+      "path": "skills/craft-goal/",
+      "slug": "craft-goal"
     },
     {
       "disposition": "keep_specialist",

--- a/images/codex/manifest.json
+++ b/images/codex/manifest.json
@@ -1,7 +1,7 @@
 {
   "image": "codex",
   "schema_version": "skill-image.v1",
-  "skill_count": 48,
+  "skill_count": 49,
   "skills": [
     {
       "disposition": "keep_specialist",
@@ -74,6 +74,12 @@
       "slug": "council",
       "source_path": "skills/council/",
       "twin_path": "skills-codex/council/"
+    },
+    {
+      "disposition": "keep_specialist",
+      "slug": "craft-goal",
+      "source_path": "skills/craft-goal/",
+      "twin_path": "skills-codex/craft-goal/"
     },
     {
       "disposition": "keep_specialist",

--- a/images/gemini/plugin.json
+++ b/images/gemini/plugin.json
@@ -1,6 +1,6 @@
 {
   "agents": "./agents",
-  "description": "AgentOps 48-skill metadata-derived bundle for Google Antigravity and Gemini.",
+  "description": "AgentOps 49-skill metadata-derived bundle for Google Antigravity and Gemini.",
   "hooks": "./hooks/hooks.json",
   "mcpServers": {
     "agent-mail": {

--- a/images/gemini/skills/craft-goal/SKILL.md
+++ b/images/gemini/skills/craft-goal/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: craft-goal
+description: 'Compile or lint a persistent Mayor-style goal that ratchets a bead graph through bounded RPI experiments toward one larger outcome. Triggers: "craft a goal prompt", "turn this into a goal", "create a bounded goal", "lint this goal", "is this goal safe".'
+practices:
+- lean-startup
+- design-by-contract
+skill_api_version: 1
+hexagonal_role: supporting
+consumes:
+- caller-outcome
+- goal-acceptance
+produces:
+- outer-goal-prompt
+- goal-safety-report
+context_rel:
+- kind: supplier-to
+  with: plan
+user-invocable: true
+metadata:
+  tier: judgment
+  dependencies: []
+  capabilities: ["goal_prompt_design","goal_prompt_lint"]
+  effects: []
+  canonical_status: canonical
+  disposition: keep_specialist
+  stability: experimental
+output_contract: 'human-readable SAFE_TO_CREATE, USE_RPI, or UNSAFE_GOAL decision; copy-paste outer-goal prompt when safe; exact budgets, assumptions, and lint findings'
+---
+
+# Craft Goal
+
+Craft the autonomy contract above AgentOps RPI. A goal is a persistent
+Mayor over a bead-shaped experiment graph. Each RPI is one scientific trial;
+the goal selects the next useful trial, preserves what was learned, and
+ratchets toward a larger outcome.
+
+```text
+Goal / Mayor: observe graph → choose bounded wave → consume verdicts → ratchet
+  └─ Bead: durable experiment intent, context, scratch, evidence, and links
+       └─ RPI: plan → implement → fresh validate → verdict → report and stop
+            └─ Implementation: one RED → GREEN → refactor experiment
+```
+
+The number of RPIs need not be known in advance. The goal is safe when success
+is decidable, every experiment is bounded, knowledge is monotonic, and the
+authorization envelope cannot silently renew itself.
+
+**Insight:** bounded waves shorten the feedback loop; one hard, non-renewing
+campaign envelope prevents those waves from becoming infinite continuation.
+
+Named failure mode — **completion treadmill**: discoveries recursively become
+requirements and activity continues without new information. Its opposite is
+**first-red abandonment**: one falsified hypothesis ends a viable campaign.
+Anti-pattern: choose endless retries or stop on the first red. Corrective:
+continue while experiments produce a defined ratchet and remain
+inside the envelope; invoke an andon on churn, judgment, or exhaustion.
+Stop when the goal reports `ACHIEVED`, `NOT_ACHIEVED`, or `NEEDS_OPERATOR`.
+
+## Modes
+
+| Caller wording | Mode | Result |
+|---|---|---|
+| "craft a goal", "turn this into a goal" | craft | Compile a Mayor-style goal prompt and settings. |
+| "lint/review this goal", "is this safe" | lint | Return findings and a rewrite when supplied facts permit one. |
+
+Stop after 1 compilation pass. Never create a goal or mutate beads.
+
+## Admission and sizing
+
+**Fuzzy route is acceptable; fuzzy success is not.** Before goal creation, the
+caller must know the outcome, what evidence would prove it, non-goals, and
+authority. The exact experiment graph may still be unknown.
+
+- Return `USE_RPI` for one shaped experiment with no verdict-driven follow-on.
+- Use a goal for a terminal outcome that may need several related experiments.
+- A shaped goal with no beads may begin with 1 bounded discovery wave that
+  creates the root and initial experiment beads.
+- Return `UNSAFE_GOAL` when no falsifiable first question or terminal evidence
+  can be named. Route that intent to idea/plan work.
+- Return `UNSAFE_GOAL` for indefinite monitoring or event reaction; that is an
+  automation, not a terminal goal.
+
+Goals may be different sizes. Size the wave and hard campaign envelopes to the
+outcome; do not invent one universal budget.
+
+## Critical constraints
+
+- **Closed outcome, adaptive route:** Freeze terminal acceptance. New facts may
+  change hypotheses and dependencies, never silently enlarge success.
+  **Why:** discovery should steer the route, not redefine the finish line.
+- **Bead knowledge graph:** Use the tracker as durable memory, not a parallel
+  goal ledger. Root epic = outer intent; child bead = one experiment/RPI.
+  **Why:** compaction must not erase the scientific record.
+- **RPI membrane:** One candidate gets one bounded RPI and an author-distinct
+  durable verdict. The goal consumes verdicts but never rewrites them.
+  **Why:** orchestration cannot author its own proof.
+- **Brownian ratchet:** Continue only when a result adds non-duplicative,
+  decision-relevant knowledge or advances acceptance. **Why:** activity without
+  information is churn.
+- **Two-level bounds:** Every RPI is bounded; every dispatch wave is bounded;
+  the full goal also has monotonic hard ceilings. **Why:** a new wave must not
+  mint a new campaign.
+- **Earned andon:** Ordinary red may change the route. Repeated no-information
+  failure, oscillation, scope pressure, or exhaustion enters HOLD and gets
+  exactly 1 bounded fresh helper before `UNSTUCK` or `ESCALATE`.
+- **Operator legibility:** At each wave boundary, report the acceptance matrix,
+  graph frontier, verdicts, ratchets, churn, remaining budget, and next thesis.
+- **Exterior self-repair:** Repair an unstable factory from an ordinary
+  shell/worktree and use the factory only for a declared bounded canary.
+
+Stop when the goal reports `ACHIEVED`, `NOT_ACHIEVED`, or `NEEDS_OPERATOR`.
+
+## Bead graph contract
+
+Record each experiment in a bead with:
+
+- question or hypothesis and the acceptance gap it addresses;
+- method, expected observation, falsifier, scope, and non-goals;
+- notes/scratch sufficient to resume after compaction;
+- exact RPI verdict/evidence references and observed learning.
+
+Use graph semantics deliberately:
+
+- `parent-child` for goal → experiment membership;
+- `blocks` only for real execution ordering;
+- `related` for alternatives or correlated observations;
+- `discovered-from` for provenance of newly exposed work.
+
+Use live `bd`/`br` state as authority and `bv --robot-*` output for
+prioritization, parallel tracks, bottlenecks, and graph insight. Never treat a
+static plan as fresher than the graph.
+
+## What counts as a ratchet
+
+An RPI makes progress when its durable result does at least one:
+
+1. proves part of terminal acceptance;
+2. falsifies a live hypothesis with discriminating evidence and prunes it;
+3. resolves an uncertainty or owner so the next experiment is materially
+   different.
+
+More code, another commit, a repeated error, or a rewritten plan is not itself
+progress. A NOT_PROVEN result counts only when its evidence narrows the next
+question; repetition without new information increments the no-progress
+counter. Stop when no ratchet remains inside the envelope.
+
+## Mayor loop
+
+1. **Observe.** Reconstruct the root outcome, acceptance matrix, ready graph,
+   prior verdicts, unresolved uncertainties, and remaining budgets.
+2. **Select one bounded wave.** Choose the smallest set of high-information
+   ready experiments. Parallelize only disjoint write and regeneration scopes.
+3. **Run RPIs.** Each selected bead goes through exactly one RPI, ending in its
+   independent verdict and human-readable summary.
+4. **Ratchet the graph.** Preserve evidence and learning. PASS may satisfy a
+   criterion. Red may revise a hypothesis or expose a child experiment.
+5. **Classify discoveries.**
+   - Necessary for frozen acceptance, within authority and remaining budget:
+     add a `discovered-from` child and consider it in a later wave.
+   - Useful but not necessary: record/link it; do not execute it in this goal.
+   - Changes acceptance, exceeds authority, or cannot fit the envelope: HOLD.
+6. **Checkpoint.** Measure ratchet versus churn, then continue, invoke the
+   breaker, or emit a terminal report.
+
+Every newly selected RPI must address an unmet criterion or a named uncertainty
+blocking one. A new commit, subject, bead, helper, or wave never resets totals.
+
+## Convergence and andons
+
+Specify both:
+
+- **Wave envelope:** RPIs, concurrency, wall time/tokens, live attempts, and a
+  checkpoint at its end.
+- **Goal envelope:** total RPIs, wall time/tokens, live attempts, compactions,
+  and any patch/surface limit for the whole campaign.
+
+Dispatch budget: every wave declares numeric RPI, token, time, and concurrency
+limits before any work is selected. Fresh-helper budget: exactly 1 per HOLD.
+
+Continue automatically across waves only while a ratchet exists and the next
+experiment fits frozen acceptance, authority, and remaining envelope.
+
+Enter HOLD on any declared trigger: repeated blocker, no ratchet for the
+configured number of RPIs, oscillation between prior approaches, repeated live
+failure class, requested acceptance change, operator-reserved decision, or
+hard-ceiling exhaustion. HOLD permits exactly 1 bounded fresh-context helper:
+
+- `UNSTUCK` must name a materially different bounded experiment, then resume.
+- `ESCALATE` emits `NEEDS_OPERATOR` and performs no more implementation.
+
+Current Codex goals lack an agent-triggered pause/checkpoint state. A
+`NEEDS_OPERATOR` report therefore also tells the operator to pause the goal;
+the prompt alone cannot guarantee that product-level pause.
+Stop when any terminal report is emitted.
+
+## Frozen prompt
+
+Read and fill [the copy-paste-only goal prompt](references/goal-prompt.md).
+Preserve its headings and terminal semantics; replace every angle-bracket field.
+
+## Quality
+
+Lead with `SAFE_TO_CREATE`, `USE_RPI`, or `UNSAFE_GOAL`. Return the copy-paste
+prompt, separate goal-tool token budget, assumptions, and one lint line for:
+outcome, evidence, admission, bead graph, RPI boundary, ratchet, discovery,
+wave budget, hard budget, breaker, operator andon, scope, self-hosting, and
+terminal reports.
+
+Done when:
+
+- success is finite but the route may adapt;
+- the tracker can reconstruct intent, experiments, evidence, and provenance;
+- informative red can continue but repeated non-information cannot;
+- recursion cannot expand acceptance or reset monotonic ceilings;
+- both successful and non-success terminal reports exist.
+
+Stop after 1 lint pass and zero goal executions. Paired evidence:
+`docs/learnings/2026-07-12-go-cli-goal-stall-tracker-layer-confusion.md` and
+`skills/rpi/SKILL.md`.
+
+## Failure behavior
+
+Return `UNSAFE_GOAL` with missing decisions. Do not invent acceptance,
+authority, graph semantics, or campaign size. The caller owns revision and goal
+creation.

--- a/images/gemini/skills/rpi/SKILL.md
+++ b/images/gemini/skills/rpi/SKILL.md
@@ -29,7 +29,7 @@ metadata:
   effects: [dispatch_core_phases]
   canonical_status: canonical
   disposition: keep
-output_contract: rpi-report.v1
+output_contract: 'rpi-report.v1 machine artifact plus a concise human-readable interactive summary'
 ---
 
 # RPI
@@ -120,18 +120,24 @@ disjoint regen surfaces may run in parallel.
 
 ## Report
 
-Return exactly the useful boundary facts:
+RPI has two report surfaces. Keep them distinct:
 
-```yaml
-schema_version: rpi-report.v1
-status: PASS | FAIL | NOT_PROVEN | NOT_PLANNED | NOT_BUILT
-intent_ref: <bead, issue, conversation, or null>
-acceptance_digest: <sha256 or null>
-subject_manifest_digest: <sha256 or null>
-verdict_ref: <path or null>
-verdict_digest: <sha256 or null>
-checked: []
-not_checked: []
-```
+1. **Machine artifact:** return or persist the exact
+   [`rpi-report.v1`](../../schemas/rpi-report.v1.schema.json) object for
+   adapters, automation, and audit.
+2. **Interactive response:** summarize that object for the caller in natural
+   language. This is the default assistant response.
+
+Lead the interactive response with the status and one sentence stating the
+caller-visible outcome. Follow with only the strongest proof, any material
+unchecked scope, and a clickable verdict reference when one exists. Name why
+no subject exists for `NOT_PLANNED` or `NOT_BUILT`. Keep the response to one
+short paragraph or at most four bullets.
+
+The machine artifact remains behind the verdict/report link. Emit its full
+JSON or YAML object only when the caller explicitly requests machine-readable
+output or an adapter consumes the response. Raw digests, schema fields, and
+exhaustive check lists stay in the artifact unless an integrity failure makes
+one necessary to explain the result.
 
 Do not append a next action. The caller owns continuation.

--- a/registry.json
+++ b/registry.json
@@ -147,6 +147,24 @@
     },
     {
       "driven_by_skills": [
+        "craft-goal"
+      ],
+      "id": "skill:craft-goal:goal_prompt_design",
+      "name": "goal_prompt_design",
+      "path": "skills/craft-goal/SKILL.md",
+      "type": "skill"
+    },
+    {
+      "driven_by_skills": [
+        "craft-goal"
+      ],
+      "id": "skill:craft-goal:goal_prompt_lint",
+      "name": "goal_prompt_lint",
+      "path": "skills/craft-goal/SKILL.md",
+      "type": "skill"
+    },
+    {
+      "driven_by_skills": [
         "dcg"
       ],
       "id": "skill:dcg:dcg",
@@ -573,19 +591,19 @@
     "cli_commands": 0,
     "gates": 0,
     "reference_impls": 0,
-    "skills": 63,
-    "total": 63
+    "skills": 65,
+    "total": 65
   },
   "cli_top_level_commands": [],
   "schema_version": 3,
   "summary": {
-    "capabilities": 63,
+    "capabilities": 65,
     "cli_commands": 0,
     "eval_files": 0,
     "hooks": 0,
     "job_types": 0,
     "knowledge_stores": 0,
-    "skills": 48,
+    "skills": 49,
     "workflows": 0
   },
   "surfaces": {
@@ -760,6 +778,20 @@
         "name": "council",
         "path": "skills/council/",
         "reference_count": 0,
+        "tier": "judgment"
+      },
+      {
+        "capabilities": [
+          "goal_prompt_design",
+          "goal_prompt_lint"
+        ],
+        "disposition": "keep_specialist",
+        "effects": [],
+        "has_references": true,
+        "has_skill_md": true,
+        "name": "craft-goal",
+        "path": "skills/craft-goal/",
+        "reference_count": 1,
         "tier": "judgment"
       },
       {

--- a/skills-codex-overrides/catalog.json
+++ b/skills-codex-overrides/catalog.json
@@ -295,6 +295,12 @@
       "treatment": "parity_only",
       "wave": "catalog-parity",
       "reason": "Live source skill; generate a parity twin and keep runtime-specific behavior in the source contract."
+    },
+    {
+      "name": "craft-goal",
+      "treatment": "parity_only",
+      "wave": "catalog-parity",
+      "reason": "Auto-generated parity twin (codex-sync): skills/craft-goal is the source of truth; no durable Codex-specific divergence yet."
     }
   ]
 }

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -2,7 +2,7 @@
   "generator": "manual-maintained",
   "source_root": "skills",
   "layout": "modular",
-  "codex_override_catalog_hash": "d05da256388554908b917c51baebc47425925df7cbee17d004dcc1e124f04edc",
+  "codex_override_catalog_hash": "fae62f93c46c2111ea890e25afff256a081b6b07c6944f8f5ac2a94115943437",
   "codex_override_catalog": {
     "version": 1,
     "description": "Machine-readable Codex treatment map for the full skill catalog.",
@@ -320,6 +320,12 @@
         "treatment": "parity_only",
         "wave": "catalog-parity",
         "reason": "Live source skill; generate a parity twin and keep runtime-specific behavior in the source contract."
+      },
+      {
+        "name": "craft-goal",
+        "treatment": "parity_only",
+        "wave": "catalog-parity",
+        "reason": "Auto-generated parity twin (codex-sync): skills/craft-goal is the source of truth; no durable Codex-specific divergence yet."
       }
     ]
   },
@@ -395,6 +401,12 @@
       "source_skill": "skills/council",
       "source_hash": "99b8347b53316514350139dcae1ffdd11ca025820395bc72c700e86823ba914e",
       "generated_hash": "7f43f5ac4f8fe296e36370245c4c9db44f56b841c5c5139c1b06abde1619ae2a"
+    },
+    {
+      "name": "craft-goal",
+      "source_skill": "skills/craft-goal",
+      "source_hash": "5f5ce0aa57b749cbd7367e55c2afabcc0c977f9c0b6a8daa89aeab2ec76d964f",
+      "generated_hash": "dcf692b00ca40f83b7ec56ad980692e7cf3de060a599079f0207be7100decd3d"
     },
     {
       "name": "dcg",
@@ -525,8 +537,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "8483b9800e8c0d0a9247271cc67f8c7bb51fe8ed50fc1f6dcd379006530c53fc",
-      "generated_hash": "98669531f0481581d7ad115c54371dbf88b16dd7ff8a9cf0476c641f9d07eee4"
+      "source_hash": "927af465bfa536352c3364921fbe99c40ae6fb3d79fba13f012005937ba4391f",
+      "generated_hash": "3a5b79fcfd13ac1d36a7c9d74729b2277c914a104954f3690d78f9baf10bc00c"
     },
     {
       "name": "sbh",
@@ -613,5 +625,5 @@
       "generated_hash": "30f72769961a244749883e03cb04e329cd0feb03dd5b641d2a73a2e5dc8e9d42"
     }
   ],
-  "package_count": 48
+  "package_count": 49
 }

--- a/skills-codex/craft-goal/.agentops-generated.json
+++ b/skills-codex/craft-goal/.agentops-generated.json
@@ -1,0 +1,7 @@
+{
+  "generator": "codex-sync",
+  "source_skill": "skills/craft-goal",
+  "layout": "modular",
+  "source_hash": "5f5ce0aa57b749cbd7367e55c2afabcc0c977f9c0b6a8daa89aeab2ec76d964f",
+  "generated_hash": "dcf692b00ca40f83b7ec56ad980692e7cf3de060a599079f0207be7100decd3d"
+}

--- a/skills-codex/craft-goal/SKILL.md
+++ b/skills-codex/craft-goal/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: craft-goal
+description: Compile or lint a persistent Mayor-style
+---
+# Craft Goal
+
+Craft the autonomy contract above AgentOps RPI. A goal is a persistent
+Mayor over a bead-shaped experiment graph. Each RPI is one scientific trial;
+the goal selects the next useful trial, preserves what was learned, and
+ratchets toward a larger outcome.
+
+```text
+Goal / Mayor: observe graph → choose bounded wave → consume verdicts → ratchet
+  └─ Bead: durable experiment intent, context, scratch, evidence, and links
+       └─ RPI: plan → implement → fresh validate → verdict → report and stop
+            └─ Implementation: one RED → GREEN → refactor experiment
+```
+
+The number of RPIs need not be known in advance. The goal is safe when success
+is decidable, every experiment is bounded, knowledge is monotonic, and the
+authorization envelope cannot silently renew itself.
+
+**Insight:** bounded waves shorten the feedback loop; one hard, non-renewing
+campaign envelope prevents those waves from becoming infinite continuation.
+
+Named failure mode — **completion treadmill**: discoveries recursively become
+requirements and activity continues without new information. Its opposite is
+**first-red abandonment**: one falsified hypothesis ends a viable campaign.
+Anti-pattern: choose endless retries or stop on the first red. Corrective:
+continue while experiments produce a defined ratchet and remain
+inside the envelope; invoke an andon on churn, judgment, or exhaustion.
+Stop when the goal reports `ACHIEVED`, `NOT_ACHIEVED`, or `NEEDS_OPERATOR`.
+
+## Modes
+
+| Caller wording | Mode | Result |
+|---|---|---|
+| "craft a goal", "turn this into a goal" | craft | Compile a Mayor-style goal prompt and settings. |
+| "lint/review this goal", "is this safe" | lint | Return findings and a rewrite when supplied facts permit one. |
+
+Stop after 1 compilation pass. Never create a goal or mutate beads.
+
+## Admission and sizing
+
+**Fuzzy route is acceptable; fuzzy success is not.** Before goal creation, the
+caller must know the outcome, what evidence would prove it, non-goals, and
+authority. The exact experiment graph may still be unknown.
+
+- Return `USE_RPI` for one shaped experiment with no verdict-driven follow-on.
+- Use a goal for a terminal outcome that may need several related experiments.
+- A shaped goal with no beads may begin with 1 bounded discovery wave that
+  creates the root and initial experiment beads.
+- Return `UNSAFE_GOAL` when no falsifiable first question or terminal evidence
+  can be named. Route that intent to idea/plan work.
+- Return `UNSAFE_GOAL` for indefinite monitoring or event reaction; that is an
+  automation, not a terminal goal.
+
+Goals may be different sizes. Size the wave and hard campaign envelopes to the
+outcome; do not invent one universal budget.
+
+## Critical constraints
+
+- **Closed outcome, adaptive route:** Freeze terminal acceptance. New facts may
+  change hypotheses and dependencies, never silently enlarge success.
+  **Why:** discovery should steer the route, not redefine the finish line.
+- **Bead knowledge graph:** Use the tracker as durable memory, not a parallel
+  goal ledger. Root epic = outer intent; child bead = one experiment/RPI.
+  **Why:** compaction must not erase the scientific record.
+- **RPI membrane:** One candidate gets one bounded RPI and an author-distinct
+  durable verdict. The goal consumes verdicts but never rewrites them.
+  **Why:** orchestration cannot author its own proof.
+- **Brownian ratchet:** Continue only when a result adds non-duplicative,
+  decision-relevant knowledge or advances acceptance. **Why:** activity without
+  information is churn.
+- **Two-level bounds:** Every RPI is bounded; every dispatch wave is bounded;
+  the full goal also has monotonic hard ceilings. **Why:** a new wave must not
+  mint a new campaign.
+- **Earned andon:** Ordinary red may change the route. Repeated no-information
+  failure, oscillation, scope pressure, or exhaustion enters HOLD and gets
+  exactly 1 bounded fresh helper before `UNSTUCK` or `ESCALATE`.
+- **Operator legibility:** At each wave boundary, report the acceptance matrix,
+  graph frontier, verdicts, ratchets, churn, remaining budget, and next thesis.
+- **Exterior self-repair:** Repair an unstable factory from an ordinary
+  shell/worktree and use the factory only for a declared bounded canary.
+
+Stop when the goal reports `ACHIEVED`, `NOT_ACHIEVED`, or `NEEDS_OPERATOR`.
+
+## Bead graph contract
+
+Record each experiment in a bead with:
+
+- question or hypothesis and the acceptance gap it addresses;
+- method, expected observation, falsifier, scope, and non-goals;
+- notes/scratch sufficient to resume after compaction;
+- exact RPI verdict/evidence references and observed learning.
+
+Use graph semantics deliberately:
+
+- `parent-child` for goal → experiment membership;
+- `blocks` only for real execution ordering;
+- `related` for alternatives or correlated observations;
+- `discovered-from` for provenance of newly exposed work.
+
+Use live `bd`/`br` state as authority and `bv --robot-*` output for
+prioritization, parallel tracks, bottlenecks, and graph insight. Never treat a
+static plan as fresher than the graph.
+
+## What counts as a ratchet
+
+An RPI makes progress when its durable result does at least one:
+
+1. proves part of terminal acceptance;
+2. falsifies a live hypothesis with discriminating evidence and prunes it;
+3. resolves an uncertainty or owner so the next experiment is materially
+   different.
+
+More code, another commit, a repeated error, or a rewritten plan is not itself
+progress. A NOT_PROVEN result counts only when its evidence narrows the next
+question; repetition without new information increments the no-progress
+counter. Stop when no ratchet remains inside the envelope.
+
+## Mayor loop
+
+1. **Observe.** Reconstruct the root outcome, acceptance matrix, ready graph,
+   prior verdicts, unresolved uncertainties, and remaining budgets.
+2. **Select one bounded wave.** Choose the smallest set of high-information
+   ready experiments. Parallelize only disjoint write and regeneration scopes.
+3. **Run RPIs.** Each selected bead goes through exactly one RPI, ending in its
+   independent verdict and human-readable summary.
+4. **Ratchet the graph.** Preserve evidence and learning. PASS may satisfy a
+   criterion. Red may revise a hypothesis or expose a child experiment.
+5. **Classify discoveries.**
+   - Necessary for frozen acceptance, within authority and remaining budget:
+     add a `discovered-from` child and consider it in a later wave.
+   - Useful but not necessary: record/link it; do not execute it in this goal.
+   - Changes acceptance, exceeds authority, or cannot fit the envelope: HOLD.
+6. **Checkpoint.** Measure ratchet versus churn, then continue, invoke the
+   breaker, or emit a terminal report.
+
+Every newly selected RPI must address an unmet criterion or a named uncertainty
+blocking one. A new commit, subject, bead, helper, or wave never resets totals.
+
+## Convergence and andons
+
+Specify both:
+
+- **Wave envelope:** RPIs, concurrency, wall time/tokens, live attempts, and a
+  checkpoint at its end.
+- **Goal envelope:** total RPIs, wall time/tokens, live attempts, compactions,
+  and any patch/surface limit for the whole campaign.
+
+Dispatch budget: every wave declares numeric RPI, token, time, and concurrency
+limits before any work is selected. Fresh-helper budget: exactly 1 per HOLD.
+
+Continue automatically across waves only while a ratchet exists and the next
+experiment fits frozen acceptance, authority, and remaining envelope.
+
+Enter HOLD on any declared trigger: repeated blocker, no ratchet for the
+configured number of RPIs, oscillation between prior approaches, repeated live
+failure class, requested acceptance change, operator-reserved decision, or
+hard-ceiling exhaustion. HOLD permits exactly 1 bounded fresh-context helper:
+
+- `UNSTUCK` must name a materially different bounded experiment, then resume.
+- `ESCALATE` emits `NEEDS_OPERATOR` and performs no more implementation.
+
+Current Codex goals lack an agent-triggered pause/checkpoint state. A
+`NEEDS_OPERATOR` report therefore also tells the operator to pause the goal;
+the prompt alone cannot guarantee that product-level pause.
+Stop when any terminal report is emitted.
+
+## Frozen prompt
+
+Read and fill [the copy-paste-only goal prompt](references/goal-prompt.md).
+Preserve its headings and terminal semantics; replace every angle-bracket field.
+
+## Quality
+
+Lead with `SAFE_TO_CREATE`, `USE_RPI`, or `UNSAFE_GOAL`. Return the copy-paste
+prompt, separate goal-tool token budget, assumptions, and one lint line for:
+outcome, evidence, admission, bead graph, RPI boundary, ratchet, discovery,
+wave budget, hard budget, breaker, operator andon, scope, self-hosting, and
+terminal reports.
+
+Done when:
+
+- success is finite but the route may adapt;
+- the tracker can reconstruct intent, experiments, evidence, and provenance;
+- informative red can continue but repeated non-information cannot;
+- recursion cannot expand acceptance or reset monotonic ceilings;
+- both successful and non-success terminal reports exist.
+
+Stop after 1 lint pass and zero goal executions. Paired evidence:
+`docs/learnings/2026-07-12-go-cli-goal-stall-tracker-layer-confusion.md` and
+`skills/rpi/SKILL.md`.
+
+## Failure behavior
+
+Return `UNSAFE_GOAL` with missing decisions. Do not invent acceptance,
+authority, graph semantics, or campaign size. The caller owns revision and goal
+creation.

--- a/skills-codex/craft-goal/prompt.md
+++ b/skills-codex/craft-goal/prompt.md
@@ -1,0 +1,8 @@
+# craft-goal
+
+Compile or lint a persistent Mayor-style goal that ratchets a bead graph through bounded RPI experiments toward one larger outcome. Triggers: "craft a goal prompt", "turn this into a goal", "create a bounded goal", "lint this goal", "is this goal safe".
+
+## Instructions
+
+Load and follow the skill instructions from the sibling `SKILL.md` file for this skill.
+Then read local files in `references/` and `scripts/` when needed.

--- a/skills-codex/craft-goal/references/goal-prompt.md
+++ b/skills-codex/craft-goal/references/goal-prompt.md
@@ -1,0 +1,49 @@
+# Mayor-style goal prompt
+
+Copy this prompt verbatim, replacing every angle-bracket field. Do not delete
+the wave, hard-envelope, and terminal-report sections.
+
+```text
+Goal outcome:
+<larger caller-visible result>
+
+Terminal acceptance and evidence:
+1. <criterion> — <authoritative proof>
+
+Non-goals and authority:
+- <excluded outcomes/mechanisms>
+- Reads/writes/external/Git authority: <exact scope>
+
+Bead graph:
+- Root epic/mol: <existing id or bounded bootstrap rule>
+- Initial experiments, if known: <bead → criterion/uncertainty>
+- Record notes, scratch, evidence, verdict refs, and dependency/provenance links.
+
+Experiment policy:
+- One bead is one RPI experiment.
+- Select only work tied to an unmet criterion or named blocking uncertainty.
+- Consume each verdict unchanged and apply the ratchet definition.
+- Classify discoveries as necessary-now, linked-follow-up, or HOLD/rescope.
+
+Wave envelope:
+- <numeric RPI/concurrency/time/token/live-attempt limits>
+
+Hard goal envelope:
+- <numeric total RPI/time/token/live-attempt/compaction/surface limits>
+- No artifact, repair, helper, subject, or wave resets a total.
+
+Breaker and andon:
+- Ordinary informative red may produce a materially different next experiment.
+- <threshold> non-ratcheting results, oscillation, scope pressure, or exhaustion:
+  HOLD and consult exactly one bounded fresh helper.
+- UNSTUCK resumes with a different experiment; ESCALATE reports NEEDS_OPERATOR.
+
+Wave checkpoint:
+- acceptance matrix; graph frontier; verdict/evidence summary;
+- ratchets versus non-progress; remaining budgets; next thesis.
+
+Terminal reports:
+- ACHIEVED: every terminal criterion is proven.
+- NOT_ACHIEVED: envelope or permitted search is exhausted; report exact gaps.
+- NEEDS_OPERATOR: judgment, rescope, or helper escalation; stop implementation.
+```

--- a/skills-codex/craft-goal/scripts/validate.sh
+++ b/skills-codex/craft-goal/scripts/validate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../.." && pwd)"
+exec bash "$REPO_ROOT/skills/skill-builder/scripts/heal.sh" --check --strict "$SKILL_DIR"

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "8483b9800e8c0d0a9247271cc67f8c7bb51fe8ed50fc1f6dcd379006530c53fc",
-  "generated_hash": "98669531f0481581d7ad115c54371dbf88b16dd7ff8a9cf0476c641f9d07eee4"
+  "source_hash": "927af465bfa536352c3364921fbe99c40ae6fb3d79fba13f012005937ba4391f",
+  "generated_hash": "3a5b79fcfd13ac1d36a7c9d74729b2277c914a104954f3690d78f9baf10bc00c"
 }

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -90,18 +90,24 @@ disjoint regen surfaces may run in parallel.
 
 ## Report
 
-Return exactly the useful boundary facts:
+RPI has two report surfaces. Keep them distinct:
 
-```yaml
-schema_version: rpi-report.v1
-status: PASS | FAIL | NOT_PROVEN | NOT_PLANNED | NOT_BUILT
-intent_ref: <bead, issue, conversation, or null>
-acceptance_digest: <sha256 or null>
-subject_manifest_digest: <sha256 or null>
-verdict_ref: <path or null>
-verdict_digest: <sha256 or null>
-checked: []
-not_checked: []
-```
+1. **Machine artifact:** return or persist the exact
+   [`rpi-report.v1`](../../schemas/rpi-report.v1.schema.json) object for
+   adapters, automation, and audit.
+2. **Interactive response:** summarize that object for the caller in natural
+   language. This is the default assistant response.
+
+Lead the interactive response with the status and one sentence stating the
+caller-visible outcome. Follow with only the strongest proof, any material
+unchecked scope, and a clickable verdict reference when one exists. Name why
+no subject exists for `NOT_PLANNED` or `NOT_BUILT`. Keep the response to one
+short paragraph or at most four bullets.
+
+The machine artifact remains behind the verdict/report link. Emit its full
+JSON or YAML object only when the caller explicitly requests machine-readable
+output or an adapter consumes the response. Raw digests, schema fields, and
+exhaustive check lists stay in the artifact unless an integrity failure makes
+one necessary to explain the result.
 
 Do not append a next action. The caller owns continuation.

--- a/skills-codex/rpi/references/rpi.feature
+++ b/skills-codex/rpi/references/rpi.feature
@@ -11,3 +11,11 @@ Feature: RPI runs one bounded experiment
     Given Validate returns FAIL or NOT_PROVEN
     When RPI reports the verdict
     Then RPI stops without repair, replan, helper, retry, or delivery
+
+  @covered-by:skills/rpi/scripts/validate.sh
+  Scenario: Interactive output summarizes the machine artifact
+    Given RPI has produced an rpi-report.v1 machine artifact
+    When RPI responds to an interactive caller
+    Then the response leads with status and the caller-visible outcome
+    And it includes only the strongest proof, material unchecked scope, and verdict link
+    And the full schema object is emitted only when machine-readable output was requested

--- a/skills-codex/rpi/scripts/validate.sh
+++ b/skills-codex/rpi/scripts/validate.sh
@@ -5,5 +5,8 @@ grep -q '^name: rpi$' "$skill_dir/SKILL.md"
 grep -Fq 'Plan -> Implement -> fresh Validate -> report' "$skill_dir/SKILL.md"
 grep -Fq 'dispatches each core phase at most once' "$skill_dir/SKILL.md"
 grep -Fq 'creates no AgentOps packet' "$skill_dir/SKILL.md"
+grep -Fq 'This is the default assistant response.' "$skill_dir/SKILL.md"
+grep -Fq 'only when the caller explicitly requests machine-readable' "$skill_dir/SKILL.md"
+grep -Fq 'The machine artifact remains behind the verdict/report link.' "$skill_dir/SKILL.md"
 ! grep -Fq 'plan_packet_digest' "$skill_dir/SKILL.md"
 echo 'rpi skill contract: PASS'

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -12,7 +12,7 @@
 
 ## judgment
 
-`council`, `postmortem`, `premortem`, `reality-check`, `validate`
+`council`, `craft-goal`, `postmortem`, `premortem`, `reality-check`, `validate`
 
 ## knowledge
 
@@ -54,6 +54,7 @@
 | `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
 | `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
+| `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | - |
 | `doc` | product | `keep_specialist` | - | `doc` | - |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "3",
-  "skill_count": 48,
+  "skill_count": 49,
   "skills": [
     {
       "canonical_status": "canonical",
@@ -395,6 +395,42 @@
         "council-report.v1"
       ],
       "references_count": 0,
+      "tier": "judgment",
+      "user_invocable": true
+    },
+    {
+      "canonical_status": "canonical",
+      "capabilities": [
+        "goal_prompt_design",
+        "goal_prompt_lint"
+      ],
+      "codex_override_present": true,
+      "consumes": [
+        "caller-outcome",
+        "goal-acceptance"
+      ],
+      "context_rel": [
+        {
+          "kind": "supplier-to",
+          "with": "plan"
+        }
+      ],
+      "dependencies": [],
+      "description": "Compile or lint a persistent Mayor-style goal that ratchets a bead graph through bounded RPI experiments toward one larger outcome. Triggers: \"craft a goal prompt\", \"turn this into a goal\", \"create a bounded goal\", \"lint this goal\", \"is this goal safe\".",
+      "disposition": "keep_specialist",
+      "effects": [],
+      "graph_root": false,
+      "hexagonal_role": "supporting",
+      "name": "craft-goal",
+      "practices": [
+        "lean-startup",
+        "design-by-contract"
+      ],
+      "produces": [
+        "outer-goal-prompt",
+        "goal-safety-report"
+      ],
+      "references_count": 1,
       "tier": "judgment",
       "user_invocable": true
     },

--- a/skills/craft-goal/SKILL.md
+++ b/skills/craft-goal/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: craft-goal
+description: 'Compile or lint a persistent Mayor-style goal that ratchets a bead graph through bounded RPI experiments toward one larger outcome. Triggers: "craft a goal prompt", "turn this into a goal", "create a bounded goal", "lint this goal", "is this goal safe".'
+practices:
+- lean-startup
+- design-by-contract
+skill_api_version: 1
+hexagonal_role: supporting
+consumes:
+- caller-outcome
+- goal-acceptance
+produces:
+- outer-goal-prompt
+- goal-safety-report
+context_rel:
+- kind: supplier-to
+  with: plan
+user-invocable: true
+metadata:
+  tier: judgment
+  dependencies: []
+  capabilities: ["goal_prompt_design","goal_prompt_lint"]
+  effects: []
+  canonical_status: canonical
+  disposition: keep_specialist
+  stability: experimental
+output_contract: 'human-readable SAFE_TO_CREATE, USE_RPI, or UNSAFE_GOAL decision; copy-paste outer-goal prompt when safe; exact budgets, assumptions, and lint findings'
+---
+
+# Craft Goal
+
+Craft the autonomy contract above AgentOps RPI. A goal is a persistent
+Mayor over a bead-shaped experiment graph. Each RPI is one scientific trial;
+the goal selects the next useful trial, preserves what was learned, and
+ratchets toward a larger outcome.
+
+```text
+Goal / Mayor: observe graph → choose bounded wave → consume verdicts → ratchet
+  └─ Bead: durable experiment intent, context, scratch, evidence, and links
+       └─ RPI: plan → implement → fresh validate → verdict → report and stop
+            └─ Implementation: one RED → GREEN → refactor experiment
+```
+
+The number of RPIs need not be known in advance. The goal is safe when success
+is decidable, every experiment is bounded, knowledge is monotonic, and the
+authorization envelope cannot silently renew itself.
+
+**Insight:** bounded waves shorten the feedback loop; one hard, non-renewing
+campaign envelope prevents those waves from becoming infinite continuation.
+
+Named failure mode — **completion treadmill**: discoveries recursively become
+requirements and activity continues without new information. Its opposite is
+**first-red abandonment**: one falsified hypothesis ends a viable campaign.
+Anti-pattern: choose endless retries or stop on the first red. Corrective:
+continue while experiments produce a defined ratchet and remain
+inside the envelope; invoke an andon on churn, judgment, or exhaustion.
+Stop when the goal reports `ACHIEVED`, `NOT_ACHIEVED`, or `NEEDS_OPERATOR`.
+
+## Modes
+
+| Caller wording | Mode | Result |
+|---|---|---|
+| "craft a goal", "turn this into a goal" | craft | Compile a Mayor-style goal prompt and settings. |
+| "lint/review this goal", "is this safe" | lint | Return findings and a rewrite when supplied facts permit one. |
+
+Stop after 1 compilation pass. Never create a goal or mutate beads.
+
+## Admission and sizing
+
+**Fuzzy route is acceptable; fuzzy success is not.** Before goal creation, the
+caller must know the outcome, what evidence would prove it, non-goals, and
+authority. The exact experiment graph may still be unknown.
+
+- Return `USE_RPI` for one shaped experiment with no verdict-driven follow-on.
+- Use a goal for a terminal outcome that may need several related experiments.
+- A shaped goal with no beads may begin with 1 bounded discovery wave that
+  creates the root and initial experiment beads.
+- Return `UNSAFE_GOAL` when no falsifiable first question or terminal evidence
+  can be named. Route that intent to idea/plan work.
+- Return `UNSAFE_GOAL` for indefinite monitoring or event reaction; that is an
+  automation, not a terminal goal.
+
+Goals may be different sizes. Size the wave and hard campaign envelopes to the
+outcome; do not invent one universal budget.
+
+## Critical constraints
+
+- **Closed outcome, adaptive route:** Freeze terminal acceptance. New facts may
+  change hypotheses and dependencies, never silently enlarge success.
+  **Why:** discovery should steer the route, not redefine the finish line.
+- **Bead knowledge graph:** Use the tracker as durable memory, not a parallel
+  goal ledger. Root epic = outer intent; child bead = one experiment/RPI.
+  **Why:** compaction must not erase the scientific record.
+- **RPI membrane:** One candidate gets one bounded RPI and an author-distinct
+  durable verdict. The goal consumes verdicts but never rewrites them.
+  **Why:** orchestration cannot author its own proof.
+- **Brownian ratchet:** Continue only when a result adds non-duplicative,
+  decision-relevant knowledge or advances acceptance. **Why:** activity without
+  information is churn.
+- **Two-level bounds:** Every RPI is bounded; every dispatch wave is bounded;
+  the full goal also has monotonic hard ceilings. **Why:** a new wave must not
+  mint a new campaign.
+- **Earned andon:** Ordinary red may change the route. Repeated no-information
+  failure, oscillation, scope pressure, or exhaustion enters HOLD and gets
+  exactly 1 bounded fresh helper before `UNSTUCK` or `ESCALATE`.
+- **Operator legibility:** At each wave boundary, report the acceptance matrix,
+  graph frontier, verdicts, ratchets, churn, remaining budget, and next thesis.
+- **Exterior self-repair:** Repair an unstable factory from an ordinary
+  shell/worktree and use the factory only for a declared bounded canary.
+
+Stop when the goal reports `ACHIEVED`, `NOT_ACHIEVED`, or `NEEDS_OPERATOR`.
+
+## Bead graph contract
+
+Record each experiment in a bead with:
+
+- question or hypothesis and the acceptance gap it addresses;
+- method, expected observation, falsifier, scope, and non-goals;
+- notes/scratch sufficient to resume after compaction;
+- exact RPI verdict/evidence references and observed learning.
+
+Use graph semantics deliberately:
+
+- `parent-child` for goal → experiment membership;
+- `blocks` only for real execution ordering;
+- `related` for alternatives or correlated observations;
+- `discovered-from` for provenance of newly exposed work.
+
+Use live `bd`/`br` state as authority and `bv --robot-*` output for
+prioritization, parallel tracks, bottlenecks, and graph insight. Never treat a
+static plan as fresher than the graph.
+
+## What counts as a ratchet
+
+An RPI makes progress when its durable result does at least one:
+
+1. proves part of terminal acceptance;
+2. falsifies a live hypothesis with discriminating evidence and prunes it;
+3. resolves an uncertainty or owner so the next experiment is materially
+   different.
+
+More code, another commit, a repeated error, or a rewritten plan is not itself
+progress. A NOT_PROVEN result counts only when its evidence narrows the next
+question; repetition without new information increments the no-progress
+counter. Stop when no ratchet remains inside the envelope.
+
+## Mayor loop
+
+1. **Observe.** Reconstruct the root outcome, acceptance matrix, ready graph,
+   prior verdicts, unresolved uncertainties, and remaining budgets.
+2. **Select one bounded wave.** Choose the smallest set of high-information
+   ready experiments. Parallelize only disjoint write and regeneration scopes.
+3. **Run RPIs.** Each selected bead goes through exactly one RPI, ending in its
+   independent verdict and human-readable summary.
+4. **Ratchet the graph.** Preserve evidence and learning. PASS may satisfy a
+   criterion. Red may revise a hypothesis or expose a child experiment.
+5. **Classify discoveries.**
+   - Necessary for frozen acceptance, within authority and remaining budget:
+     add a `discovered-from` child and consider it in a later wave.
+   - Useful but not necessary: record/link it; do not execute it in this goal.
+   - Changes acceptance, exceeds authority, or cannot fit the envelope: HOLD.
+6. **Checkpoint.** Measure ratchet versus churn, then continue, invoke the
+   breaker, or emit a terminal report.
+
+Every newly selected RPI must address an unmet criterion or a named uncertainty
+blocking one. A new commit, subject, bead, helper, or wave never resets totals.
+
+## Convergence and andons
+
+Specify both:
+
+- **Wave envelope:** RPIs, concurrency, wall time/tokens, live attempts, and a
+  checkpoint at its end.
+- **Goal envelope:** total RPIs, wall time/tokens, live attempts, compactions,
+  and any patch/surface limit for the whole campaign.
+
+Dispatch budget: every wave declares numeric RPI, token, time, and concurrency
+limits before any work is selected. Fresh-helper budget: exactly 1 per HOLD.
+
+Continue automatically across waves only while a ratchet exists and the next
+experiment fits frozen acceptance, authority, and remaining envelope.
+
+Enter HOLD on any declared trigger: repeated blocker, no ratchet for the
+configured number of RPIs, oscillation between prior approaches, repeated live
+failure class, requested acceptance change, operator-reserved decision, or
+hard-ceiling exhaustion. HOLD permits exactly 1 bounded fresh-context helper:
+
+- `UNSTUCK` must name a materially different bounded experiment, then resume.
+- `ESCALATE` emits `NEEDS_OPERATOR` and performs no more implementation.
+
+Current Codex goals lack an agent-triggered pause/checkpoint state. A
+`NEEDS_OPERATOR` report therefore also tells the operator to pause the goal;
+the prompt alone cannot guarantee that product-level pause.
+Stop when any terminal report is emitted.
+
+## Frozen prompt
+
+Read and fill [the copy-paste-only goal prompt](references/goal-prompt.md).
+Preserve its headings and terminal semantics; replace every angle-bracket field.
+
+## Quality
+
+Lead with `SAFE_TO_CREATE`, `USE_RPI`, or `UNSAFE_GOAL`. Return the copy-paste
+prompt, separate goal-tool token budget, assumptions, and one lint line for:
+outcome, evidence, admission, bead graph, RPI boundary, ratchet, discovery,
+wave budget, hard budget, breaker, operator andon, scope, self-hosting, and
+terminal reports.
+
+Done when:
+
+- success is finite but the route may adapt;
+- the tracker can reconstruct intent, experiments, evidence, and provenance;
+- informative red can continue but repeated non-information cannot;
+- recursion cannot expand acceptance or reset monotonic ceilings;
+- both successful and non-success terminal reports exist.
+
+Stop after 1 lint pass and zero goal executions. Paired evidence:
+`docs/learnings/2026-07-12-go-cli-goal-stall-tracker-layer-confusion.md` and
+`skills/rpi/SKILL.md`.
+
+## Failure behavior
+
+Return `UNSAFE_GOAL` with missing decisions. Do not invent acceptance,
+authority, graph semantics, or campaign size. The caller owns revision and goal
+creation.

--- a/skills/craft-goal/references/goal-prompt.md
+++ b/skills/craft-goal/references/goal-prompt.md
@@ -1,0 +1,49 @@
+# Mayor-style goal prompt
+
+Copy this prompt verbatim, replacing every angle-bracket field. Do not delete
+the wave, hard-envelope, and terminal-report sections.
+
+```text
+Goal outcome:
+<larger caller-visible result>
+
+Terminal acceptance and evidence:
+1. <criterion> — <authoritative proof>
+
+Non-goals and authority:
+- <excluded outcomes/mechanisms>
+- Reads/writes/external/Git authority: <exact scope>
+
+Bead graph:
+- Root epic/mol: <existing id or bounded bootstrap rule>
+- Initial experiments, if known: <bead → criterion/uncertainty>
+- Record notes, scratch, evidence, verdict refs, and dependency/provenance links.
+
+Experiment policy:
+- One bead is one RPI experiment.
+- Select only work tied to an unmet criterion or named blocking uncertainty.
+- Consume each verdict unchanged and apply the ratchet definition.
+- Classify discoveries as necessary-now, linked-follow-up, or HOLD/rescope.
+
+Wave envelope:
+- <numeric RPI/concurrency/time/token/live-attempt limits>
+
+Hard goal envelope:
+- <numeric total RPI/time/token/live-attempt/compaction/surface limits>
+- No artifact, repair, helper, subject, or wave resets a total.
+
+Breaker and andon:
+- Ordinary informative red may produce a materially different next experiment.
+- <threshold> non-ratcheting results, oscillation, scope pressure, or exhaustion:
+  HOLD and consult exactly one bounded fresh helper.
+- UNSTUCK resumes with a different experiment; ESCALATE reports NEEDS_OPERATOR.
+
+Wave checkpoint:
+- acceptance matrix; graph frontier; verdict/evidence summary;
+- ratchets versus non-progress; remaining budgets; next thesis.
+
+Terminal reports:
+- ACHIEVED: every terminal criterion is proven.
+- NOT_ACHIEVED: envelope or permitted search is exhausted; report exact gaps.
+- NEEDS_OPERATOR: judgment, rescope, or helper escalation; stop implementation.
+```

--- a/skills/craft-goal/scripts/validate.sh
+++ b/skills/craft-goal/scripts/validate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../.." && pwd)"
+exec bash "$REPO_ROOT/skills/skill-builder/scripts/heal.sh" --check --strict "$SKILL_DIR"

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -29,7 +29,7 @@ metadata:
   effects: [dispatch_core_phases]
   canonical_status: canonical
   disposition: keep
-output_contract: rpi-report.v1
+output_contract: 'rpi-report.v1 machine artifact plus a concise human-readable interactive summary'
 ---
 
 # RPI
@@ -120,18 +120,24 @@ disjoint regen surfaces may run in parallel.
 
 ## Report
 
-Return exactly the useful boundary facts:
+RPI has two report surfaces. Keep them distinct:
 
-```yaml
-schema_version: rpi-report.v1
-status: PASS | FAIL | NOT_PROVEN | NOT_PLANNED | NOT_BUILT
-intent_ref: <bead, issue, conversation, or null>
-acceptance_digest: <sha256 or null>
-subject_manifest_digest: <sha256 or null>
-verdict_ref: <path or null>
-verdict_digest: <sha256 or null>
-checked: []
-not_checked: []
-```
+1. **Machine artifact:** return or persist the exact
+   [`rpi-report.v1`](../../schemas/rpi-report.v1.schema.json) object for
+   adapters, automation, and audit.
+2. **Interactive response:** summarize that object for the caller in natural
+   language. This is the default assistant response.
+
+Lead the interactive response with the status and one sentence stating the
+caller-visible outcome. Follow with only the strongest proof, any material
+unchecked scope, and a clickable verdict reference when one exists. Name why
+no subject exists for `NOT_PLANNED` or `NOT_BUILT`. Keep the response to one
+short paragraph or at most four bullets.
+
+The machine artifact remains behind the verdict/report link. Emit its full
+JSON or YAML object only when the caller explicitly requests machine-readable
+output or an adapter consumes the response. Raw digests, schema fields, and
+exhaustive check lists stay in the artifact unless an integrity failure makes
+one necessary to explain the result.
 
 Do not append a next action. The caller owns continuation.

--- a/skills/rpi/references/rpi.feature
+++ b/skills/rpi/references/rpi.feature
@@ -11,3 +11,11 @@ Feature: RPI runs one bounded experiment
     Given Validate returns FAIL or NOT_PROVEN
     When RPI reports the verdict
     Then RPI stops without repair, replan, helper, retry, or delivery
+
+  @covered-by:skills/rpi/scripts/validate.sh
+  Scenario: Interactive output summarizes the machine artifact
+    Given RPI has produced an rpi-report.v1 machine artifact
+    When RPI responds to an interactive caller
+    Then the response leads with status and the caller-visible outcome
+    And it includes only the strongest proof, material unchecked scope, and verdict link
+    And the full schema object is emitted only when machine-readable output was requested

--- a/skills/rpi/scripts/validate.sh
+++ b/skills/rpi/scripts/validate.sh
@@ -5,5 +5,8 @@ grep -q '^name: rpi$' "$skill_dir/SKILL.md"
 grep -Fq 'Plan -> Implement -> fresh Validate -> report' "$skill_dir/SKILL.md"
 grep -Fq 'dispatches each core phase at most once' "$skill_dir/SKILL.md"
 grep -Fq 'creates no AgentOps packet' "$skill_dir/SKILL.md"
+grep -Fq 'This is the default assistant response.' "$skill_dir/SKILL.md"
+grep -Fq 'only when the caller explicitly requests machine-readable' "$skill_dir/SKILL.md"
+grep -Fq 'The machine artifact remains behind the verdict/report link.' "$skill_dir/SKILL.md"
 ! grep -Fq 'plan_packet_digest' "$skill_dir/SKILL.md"
 echo 'rpi skill contract: PASS'


### PR DESCRIPTION
## What changed

- add `craft-goal`, a bounded Mayor-style goal compiler/linter for persistent campaigns over bead-shaped RPI experiments
- add its Codex and Gemini runtime projections plus generated catalogs, manifests, router, graph, maps, tiers, and registry entries
- split RPI reporting into two explicit surfaces: concise human-readable interactive output by default, with the full `rpi-report.v1` object retained as the machine/audit artifact
- add feature and validation assertions that prevent raw schema dumps from becoming the default interactive response again

## Why

Recent AgentOps history repeatedly showed long-running goal campaigns confusing the outer goal with one RPI experiment. It also exposed a presentation bug where the RPI skill instructed agents to paste the transport-shaped YAML report into chat. This change captures the corrected goal model and keeps machine evidence separate from the operator-facing response.

## Validation

- `bash scripts/regen-all.sh --check`
- `bash skills/craft-goal/scripts/validate.sh`
- `bash skills/rpi/scripts/validate.sh`
- `python3 -m unittest skills/rpi/tests/test_run_once.py`
- Codex parity, generated-artifact, and override-coverage checks
- `git diff --check origin/main...HEAD`
- `bash scripts/ci-local-release.sh --fast` ran all branch-relevant checks successfully; its aggregate exit remained nonzero only for the pre-existing `skills/using-gc` description-budget violation, which is unchanged from `origin/main`
