### PR TITLE
chore(release): prepare v3.3.0 changelog and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.3.0] - 2026-07-20
+## [3.3.0] - 2026-07-23
 
-AgentOps 3.3 is the Cathedral Cut: the product returns to one small trust
-boundary—shape one behavior, run one bounded experiment, validate the exact
-result from fresh context, persist the verdict, and stop. Git, CI, retries,
-queues, work ownership, closure, release, and delivery are caller-owned.
-This release removes public command surfaces despite the minor version
-number; read [docs/UPGRADING.md](https://github.com/boshu2/agentops/blob/main/docs/UPGRADING.md)
+AgentOps 3.3 is the **Cathedral Cut**: the deliberate subtraction of the
+guardrail machinery built to steer weaker models. Strict verbose step contracts,
+enforcement gates, injection hooks, one-release command tombstones, retired
+lifecycle command surfaces, and the heavy out-of-session orchestration layer are
+gone — that scaffolding does not help a frontier-class model and actively
+degrades one, turning dense process into meta-work it spirals on. What remains is
+the judgment-boundary membrane: shape one behavior, run one bounded experiment,
+validate the exact result from a fresh independent context, persist a durable
+verdict, and stop — caller-owned intent in, pinned provenance out. Git, CI,
+retries, queues, work ownership, closure, release, and delivery stay caller-owned.
+
+The subtraction is concrete: the Go CLI shed 36 of its 79 internal packages
+(79 -> 43), and the reference out-of-session orchestrator collapsed from a
+~29k-line layer to a ~1,300-line thin pack (one commit removed 29,418 lines for
+1,334). On that lean base the release keeps terse metadata-owned skill contracts
+(48 skills, audited for concise executable contracts, not ceremonial length),
+adds the Gas City factory pack as a labeled **preview**, and grounds plan and
+premortem judgment in executable ground truth. This release removes public
+command surfaces despite the minor version number; read
+[docs/UPGRADING.md](https://github.com/boshu2/agentops/blob/main/docs/UPGRADING.md)
 before upgrading.
 
 ### Added
@@ -61,6 +75,40 @@ before upgrading.
   own ruling — no verdict laundering (an ambiguous ruling is `NOT_PROVEN`),
   no silent fallback to the spawned judge, and the broker attests under its
   own context id, distinct from both the author and the external validator.
+- **Gas City factory pack (preview)** — a thin AgentOps role pack over official
+  Gas City that runs the one-loop factory (`deploy/gc/`, `packs/agentops-*`).
+  `deploy/gc/materialize-toolchain.sh` fetches the official prebuilt
+  gastownhall/gascity v1.3.5 and steveyegge/beads v1.1.0 release archives and
+  verifies each through a fail-closed checksum chain (pinned sha256 of the
+  official checksums asset -> archive digest -> installed-binary version/commit
+  binding); no compiler, `git`, or `make` is required — only `curl`, `tar`,
+  `python3`, and `shasum`. Gas City owns sessions/routing/formulas/OTEL, Beads
+  owns work, Git owns candidate commits, GitHub owns PR/CI/merge, and AgentOps
+  owns only the final semantic verdict — GC runtime state never enters an
+  AgentOps verdict.
+- **Mayor-driven door with a heartbeat shepherd.** The city runs one standing
+  city-scoped Mayor that is a dispatch shepherd: it watches ready rig step beads
+  and sling-nudges each to its run-target (workers claim; the Mayor never claims
+  and never authors work), propelled by a scheduled heartbeat dispatch pass. Two
+  doors reach the one session — a human attaches to the tmux session and drives
+  interactively, or an orchestrating agent drives it by handing bead ids through
+  native GC mail/sling (`mayor tell "dispatch <id>"`), with no keystroke
+  injection.
+- **`using-gc` mayor-orchestration skill** documents the drive loop (author
+  intent as a bead -> feed -> dispatch by id -> read state from GC rather than
+  prose -> completion is bead/verdict state, never pane output) and a four-layer
+  visibility doctrine: robot/session state, the bead graph, tmux pane truth, and
+  health machinery. Pack intake routes through rig-scoped dispatch per the stock
+  Gas City mayor pattern, so the flow survives the upstream fix.
+- The pack is labeled **preview** and discloses three Gas City v1.3.5 upstream
+  defects it is built around: demand-driven worker spawn is broken for rig work
+  (the shepherd nudge is the workaround; upstream #4586), a cross-store
+  city-scoped claim returns `bead not found` (never exercised by the pack's
+  rig-scoped flow; claim fix landed upstream after v1.3.5), and a rare tmux
+  teardown hang under process churn (upstream PR gastownhall/gascity#3985).
+  Preview is promoted to supported only after the next official Gas City release
+  is pinned, deterministically qualified, and one clean mixed-provider canary
+  passes.
 
 ### Changed
 
@@ -93,6 +141,11 @@ before upgrading.
   discovered/indexed/error accounting instead of a hard-coded corpus floor.
 - CASS guidance distinguishes authoritative rebuild fallback and timed-out
   concurrent reads from empty results or source loss.
+- Plan and premortem now route their judgment to executable ground truth: Plan
+  binds acceptance to the real runnable check surface rather than a narrative
+  restatement, and premortem adds a derivation-diff challenge that tests a
+  proposed change against the diff it would actually produce — keeping planning
+  and pre-mortem reasoning anchored to evidence, not prose.
 
 ### Removed
 

--- a/cli/cmd/ao/main.go
+++ b/cli/cmd/ao/main.go
@@ -5,7 +5,7 @@ package main
 // version is set at build time via ldflags (goreleaser: -X main.version={{ .Version }}).
 // The fallback identifies untagged source builds for the next release;
 // published binaries override it from the release tag via GoReleaser.
-var version = "3.3.0-rc"
+var version = "3.3.0"
 
 func main() {
 	Execute()

--- a/cli/cmd/ao/version_test.go
+++ b/cli/cmd/ao/version_test.go
@@ -19,6 +19,27 @@ func TestVersion_VersionVariableHasDefault(t *testing.T) {
 	}
 }
 
+// TestVersion_ReleaseFallbackHasNoPrereleaseMarker guards the release-cut
+// invariant that the checked-in `version` fallback (what `go install` builds
+// self-report, since they carry no ldflags-injected tag) is a clean release
+// string, never a pre-release like "3.3.0-rc". Release-readiness audit
+// (docs/audits/release-readiness-3.3-2026-07-20.md, minor 1) flagged a stale
+// "-rc" fallback shipping against 3.3.0 manifests. ldflags-injected
+// git-describe strings (e.g. "v3.2.0-901-g<sha>-dirty") are exempt: they are
+// build-injected, not the checked-in release fallback.
+func TestVersion_ReleaseFallbackHasNoPrereleaseMarker(t *testing.T) {
+	// git-describe strings carry a "-g<hash>" commit segment or a "-dirty"
+	// suffix; the checked-in release fallback does not.
+	if strings.Contains(version, "-g") || strings.HasSuffix(version, "-dirty") {
+		t.Skipf("version %q is an ldflags-injected build-describe string, not the checked-in fallback", version)
+	}
+	for _, marker := range []string{"-rc", "-alpha", "-beta", "-pre", "-dev", "-snapshot"} {
+		if strings.Contains(version, marker) {
+			t.Errorf("release fallback version %q carries pre-release marker %q; a tagged release fallback must be a clean MAJOR.MINOR.PATCH", version, marker)
+		}
+	}
+}
+
 func TestVersion_RegisteredOnRoot(t *testing.T) {
 	found := false
 	for _, cmd := range rootCmd.Commands() {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,14 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.3.0] - 2026-07-20
+## [3.3.0] - 2026-07-23
 
-AgentOps 3.3 is the Cathedral Cut: the product returns to one small trust
-boundary—shape one behavior, run one bounded experiment, validate the exact
-result from fresh context, persist the verdict, and stop. Git, CI, retries,
-queues, work ownership, closure, release, and delivery are caller-owned.
-This release removes public command surfaces despite the minor version
-number; read [docs/UPGRADING.md](https://github.com/boshu2/agentops/blob/main/docs/UPGRADING.md)
+AgentOps 3.3 is the **Cathedral Cut**: the deliberate subtraction of the
+guardrail machinery built to steer weaker models. Strict verbose step contracts,
+enforcement gates, injection hooks, one-release command tombstones, retired
+lifecycle command surfaces, and the heavy out-of-session orchestration layer are
+gone — that scaffolding does not help a frontier-class model and actively
+degrades one, turning dense process into meta-work it spirals on. What remains is
+the judgment-boundary membrane: shape one behavior, run one bounded experiment,
+validate the exact result from a fresh independent context, persist a durable
+verdict, and stop — caller-owned intent in, pinned provenance out. Git, CI,
+retries, queues, work ownership, closure, release, and delivery stay caller-owned.
+
+The subtraction is concrete: the Go CLI shed 36 of its 79 internal packages
+(79 -> 43), and the reference out-of-session orchestrator collapsed from a
+~29k-line layer to a ~1,300-line thin pack (one commit removed 29,418 lines for
+1,334). On that lean base the release keeps terse metadata-owned skill contracts
+(48 skills, audited for concise executable contracts, not ceremonial length),
+adds the Gas City factory pack as a labeled **preview**, and grounds plan and
+premortem judgment in executable ground truth. This release removes public
+command surfaces despite the minor version number; read
+[docs/UPGRADING.md](https://github.com/boshu2/agentops/blob/main/docs/UPGRADING.md)
 before upgrading.
 
 ### Added
@@ -61,6 +75,40 @@ before upgrading.
   own ruling — no verdict laundering (an ambiguous ruling is `NOT_PROVEN`),
   no silent fallback to the spawned judge, and the broker attests under its
   own context id, distinct from both the author and the external validator.
+- **Gas City factory pack (preview)** — a thin AgentOps role pack over official
+  Gas City that runs the one-loop factory (`deploy/gc/`, `packs/agentops-*`).
+  `deploy/gc/materialize-toolchain.sh` fetches the official prebuilt
+  gastownhall/gascity v1.3.5 and steveyegge/beads v1.1.0 release archives and
+  verifies each through a fail-closed checksum chain (pinned sha256 of the
+  official checksums asset -> archive digest -> installed-binary version/commit
+  binding); no compiler, `git`, or `make` is required — only `curl`, `tar`,
+  `python3`, and `shasum`. Gas City owns sessions/routing/formulas/OTEL, Beads
+  owns work, Git owns candidate commits, GitHub owns PR/CI/merge, and AgentOps
+  owns only the final semantic verdict — GC runtime state never enters an
+  AgentOps verdict.
+- **Mayor-driven door with a heartbeat shepherd.** The city runs one standing
+  city-scoped Mayor that is a dispatch shepherd: it watches ready rig step beads
+  and sling-nudges each to its run-target (workers claim; the Mayor never claims
+  and never authors work), propelled by a scheduled heartbeat dispatch pass. Two
+  doors reach the one session — a human attaches to the tmux session and drives
+  interactively, or an orchestrating agent drives it by handing bead ids through
+  native GC mail/sling (`mayor tell "dispatch <id>"`), with no keystroke
+  injection.
+- **`using-gc` mayor-orchestration skill** documents the drive loop (author
+  intent as a bead -> feed -> dispatch by id -> read state from GC rather than
+  prose -> completion is bead/verdict state, never pane output) and a four-layer
+  visibility doctrine: robot/session state, the bead graph, tmux pane truth, and
+  health machinery. Pack intake routes through rig-scoped dispatch per the stock
+  Gas City mayor pattern, so the flow survives the upstream fix.
+- The pack is labeled **preview** and discloses three Gas City v1.3.5 upstream
+  defects it is built around: demand-driven worker spawn is broken for rig work
+  (the shepherd nudge is the workaround; upstream #4586), a cross-store
+  city-scoped claim returns `bead not found` (never exercised by the pack's
+  rig-scoped flow; claim fix landed upstream after v1.3.5), and a rare tmux
+  teardown hang under process churn (upstream PR gastownhall/gascity#3985).
+  Preview is promoted to supported only after the next official Gas City release
+  is pinned, deterministically qualified, and one clean mixed-provider canary
+  passes.
 
 ### Changed
 
@@ -93,6 +141,11 @@ before upgrading.
   discovered/indexed/error accounting instead of a hard-coded corpus floor.
 - CASS guidance distinguishes authoritative rebuild fallback and timed-out
   concurrent reads from empty results or source loss.
+- Plan and premortem now route their judgment to executable ground truth: Plan
+  binds acceptance to the real runnable check surface rather than a narrative
+  restatement, and premortem adds a derivation-diff challenge that tests a
+  proposed change against the diff it would actually produce — keeping planning
+  and pre-mortem reasoning anchored to evidence, not prose.
 
 ### Removed
 

--- a/images/gemini/skills/using-gc/SKILL.md
+++ b/images/gemini/skills/using-gc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-gc
-description: 'Orchestrate a caller-selected Gas City through its Mayor: drive the standing dispatch shepherd (human attaches, or an agent tells it bead ids), and keep GC runtime state out of AgentOps verdicts. Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".'
+description: 'Drive a caller-selected Gas City through its Mayor dispatch shepherd; keep GC runtime state out of AgentOps verdicts. Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".'
 practices: [team-topologies, design-by-contract]
 hexagonal_role: driving-adapter
 consumes: [explicit-packets]

--- a/packs/agentops-executor/assets/generated-skill-manifest.json
+++ b/packs/agentops-executor/assets/generated-skill-manifest.json
@@ -90,8 +90,8 @@
     {
       "source": "skills/using-gc/SKILL.md",
       "destination": "packs/agentops-executor/skills/using-gc/SKILL.md",
-      "source_sha256": "277c56846658aecafbd3ec62b48279e898dd84311e51a892f077daf38eb3e911",
-      "sha256": "277c56846658aecafbd3ec62b48279e898dd84311e51a892f077daf38eb3e911",
+      "source_sha256": "7c621b5284402881c99f576fa12ccb79debbae565364029ed3b66cd0cdf9f607",
+      "sha256": "7c621b5284402881c99f576fa12ccb79debbae565364029ed3b66cd0cdf9f607",
       "mode": "0644"
     }
   ]

--- a/packs/agentops-executor/skills/using-gc/SKILL.md
+++ b/packs/agentops-executor/skills/using-gc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-gc
-description: 'Orchestrate a caller-selected Gas City through its Mayor: drive the standing dispatch shepherd (human attaches, or an agent tells it bead ids), and keep GC runtime state out of AgentOps verdicts. Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".'
+description: 'Drive a caller-selected Gas City through its Mayor dispatch shepherd; keep GC runtime state out of AgentOps verdicts. Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".'
 practices: [team-topologies, design-by-contract]
 hexagonal_role: driving-adapter
 consumes: [explicit-packets]

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -597,8 +597,8 @@
     {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
-      "source_hash": "5fda6596d3435c99da7a2fe1c4b595e9dabb13a4fe856fe0139eb73531a90e9c",
-      "generated_hash": "3688f6ebfab4e3a774e70b28b14e11af117fc500a6164434e0ffeeaa962a191f"
+      "source_hash": "0cb0e528e918fda28e1bb45b599f47013db377d7793c761eae7e6ff26750872d",
+      "generated_hash": "aca67da82384024023ff901b57ef7baebad71097dc152638c65afa52861222e9"
     },
     {
       "name": "validate",

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/using-gc",
   "layout": "modular",
-  "source_hash": "5fda6596d3435c99da7a2fe1c4b595e9dabb13a4fe856fe0139eb73531a90e9c",
-  "generated_hash": "3688f6ebfab4e3a774e70b28b14e11af117fc500a6164434e0ffeeaa962a191f"
+  "source_hash": "0cb0e528e918fda28e1bb45b599f47013db377d7793c761eae7e6ff26750872d",
+  "generated_hash": "aca67da82384024023ff901b57ef7baebad71097dc152638c65afa52861222e9"
 }

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-gc
-description: Orchestrate a caller-selected Gas City
+description: Drive a caller-selected Gas City through its
 ---
 # Using GC
 

--- a/skills-codex/using-gc/prompt.md
+++ b/skills-codex/using-gc/prompt.md
@@ -1,6 +1,6 @@
 # using-gc
 
-Orchestrate a caller-selected Gas City through its Mayor: drive the standing dispatch shepherd (human attaches, or an agent tells it bead ids), and keep GC runtime state out of AgentOps verdicts. Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".
+Drive a caller-selected Gas City through its Mayor dispatch shepherd; keep GC runtime state out of AgentOps verdicts. Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".
 
 ## Instructions
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1443,7 +1443,7 @@
         }
       ],
       "dependencies": [],
-      "description": "Orchestrate a caller-selected Gas City through its Mayor: drive the standing dispatch shepherd (human attaches, or an agent tells it bead ids), and keep GC runtime state out of AgentOps verdicts. Triggers: \"using gc\", \"gas city\", \"drive the mayor\", \"dispatch through gc\".",
+      "description": "Drive a caller-selected Gas City through its Mayor dispatch shepherd; keep GC runtime state out of AgentOps verdicts. Triggers: \"using gc\", \"gas city\", \"drive the mayor\", \"dispatch through gc\".",
       "disposition": "keep_optional_adapter",
       "effects": [
         "operate_gas_city"

--- a/skills/using-gc/SKILL.md
+++ b/skills/using-gc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-gc
-description: 'Orchestrate a caller-selected Gas City through its Mayor: drive the standing dispatch shepherd (human attaches, or an agent tells it bead ids), and keep GC runtime state out of AgentOps verdicts. Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".'
+description: 'Drive a caller-selected Gas City through its Mayor dispatch shepherd; keep GC runtime state out of AgentOps verdicts. Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".'
 practices: [team-topologies, design-by-contract]
 hexagonal_role: driving-adapter
 consumes: [explicit-packets]


### PR DESCRIPTION
## What

Prepares the **v3.3.0** release cut (last shipped tag: `v3.2.0`, 2026-07-03). No tag and no GitHub release are created here — tagging is gated on the live GC canary and the operator's go.

- **Changelog reframe.** The `[3.3.0]` headline now leads with the deliberate subtraction of the guardrail cathedral (strict verbose step contracts, enforcement gates, injection hooks, command tombstones, retired lifecycle surfaces, the heavy out-of-session orchestration layer) — removed because that scaffolding degrades frontier-class models rather than helping them. What remains is the judgment-boundary membrane: caller-owned intent, one fresh independent validation, durable verdicts, pinned provenance. Subtraction is git-concrete: `cli/internal` packages **79 → 43**; reference orchestrator **~29k lines → ~1,300-line thin pack** (one commit removed 29,418 lines for 1,334).
- **Post-07-17 delta folded in:** Gas City factory pack (preview) — official checksummed GC/Beads binaries fetched by the installer (no compile), mayor-driven door (human attach or agent drive via mail/sling) with heartbeat shepherd, the `using-gc` mayor-orchestration skill + four-layer visibility doctrine, rig-scoped dispatch intake, three disclosed upstream v1.3.5 defects (#4586, the cross-store claim fix, gastownhall/gascity#3985) with the preview→supported promotion criteria, and plan/premortem ground-truth routing.
- **Version bump:** source fallback `3.3.0-rc → 3.3.0` (`cli/cmd/ao/main.go`); plugin manifests were already `3.3.0`. Adds a release-guard test asserting the fallback carries no pre-release marker (resolves audit minor 1).
- **Release-gate fix:** trimmed the `using-gc` skill description (195 → 117 prose chars) to satisfy the 180-char budget — a blocker that landed with the GC arc — and regenerated its Codex/Gemini/pack projections.

## Recommended version: **v3.3.0**

`v3.3.0` was an in-progress RC (`main.go` at `3.3.0-rc`, plugin manifests at `3.3.0`, changelog `[3.3.0]` drafted) that was never tagged; the GC pack + loop doctrine landed on the RC line. This cut finalizes it.

## Go / No-Go checklist (deterministic bar: docs/audits/release-readiness-3.3-2026-07-20.md + docs/runbooks/release-process.md)

| # | Criterion | Status | Evidence |
|---|---|---|---|
| 1 | `go build ./...` | PASS | exit 0 |
| 2 | `go vet ./...` | PASS | exit 0 |
| 3 | Full Go test suite (`go test ./... -count=1`) | PASS | 63 packages `ok`, 0 FAIL |
| 4 | Cathedral Cut conformance (`check-cathedral-cut-conformance.py`) | PASS | "Cathedral Cut conformance: PASS" |
| 5 | Skill-mesh drift (`generate-skill-mesh.py --check`) | PASS | "up to date (48 skills)" |
| 6 | Derived-artifact drift (`make regen-check`) | PASS | "All generated projections are current." |
| 7 | Docs + release-doc gate (`make docs-check`) | PASS | CLI ref current; 395 links, 0 broken; skill count 48; release freeze intact |
| 8 | `ao gate check --full` | PASS* | 66/67 pass. Sole fail = `workflow.install-drift`, a worktree-local symlink artifact (tracked `workflows/` is byte-identical to origin/main; passes in a clean CI clone — the audit's 67/67) |
| 9 | Fast release gate (`ci-local-release.sh --quick`) | PASS | "LOCAL CI QUICK SANITY PASSED": 44/44 install-surface smoke, 33/33 release smoke, init smoke |
| 10 | Skill token budgets / lint | PASS | 100 budgets pass (fixed `using-gc` 195→117 prose) |
| 11 | Install story smoke | PASS | README/MIGRATION document `ao skills link`; all 6 curl installers are refusing tombstones; `ao version` runs; npx-first |
| 12 | Plugin manifest ↔ corpus parity | PASS | manifests carry 48 skills, 0 drift |
| 13 | Version bump applied to owners | PASS | `main.go` 3.3.0-rc→3.3.0; manifests already 3.3.0 |
| 14 | Changelog updated + synced | PASS | `CHANGELOG.md` == `docs/CHANGELOG.md` (changelog.sync gate) |
| 15 | Command/test pairing gate | PASS | main.go bump paired with `version_test.go` release-guard test |
| 16 | Full release gate (`ci-local-release.sh`: race + security + SBOM + readiness) | PASS | "LOCAL CI PASSED [102s]"; release-artifact manifest resolved `v3.3.0` |

\* `workflow.install-drift` is an environment artifact of running the gate inside a nested worktree whose `.claude/workflows/` symlinks resolve to the primary checkout. It is not release content: `git diff origin/main -- workflows/` is empty, and the check passes in a fresh CI checkout (audit reported 67/67 at origin/main).

## Operator items (require a human or a live tag — NOT attempted here)

- **Live GC canary** on the next official Gas City pin — the preview→supported promotion gate.
- **Git tag `v3.3.0` + goreleaser publish** — gated on the canary and operator go.
- **Docs-site publish** (mkdocs pipeline) — separate from this cut.

No tag. No release.
