### PR TITLE
fix(release): drop retired sync-hooks pre-hook from goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,9 +4,6 @@ project_name: ao
 builds:
   - id: ao
     dir: cli
-    hooks:
-      pre:
-        - make -C cli sync-hooks
     main: ./cmd/ao
     binary: ao
     goos:


### PR DESCRIPTION
v3.3.0's release workflow failed at goreleaser's build pre-hook: `make -C cli sync-hooks` was retired in PR #919 (July 18) and no tag has exercised the release path since v3.2.0 (July 3). Removes the stale hook; all other referenced release scripts (extract-release-notes, check-release-parity, retag-release) verified present. After merge: retag v3.3.0 on the new tip via scripts/retag-release.sh.