### PR TITLE
W3a judgment wave: real output contracts, honest effects, scratch-tier artifact dirs

### DIFF
--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -54,7 +54,7 @@
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
 | `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | - |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
-| `postmortem` | judgment | `keep_strategy` | - | `postmortem` | - |
+| `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
 | `rch` | execution | `keep_specialist` | - | `rch` | - |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -54,7 +54,7 @@
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
 | `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | - |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
-| `postmortem` | judgment | `keep_strategy` | - | `postmortem` | - |
+| `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
 | `rch` | execution | `keep_specialist` | - | `rch` | - |

--- a/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w3a.md
+++ b/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w3a.md
@@ -1,0 +1,126 @@
+# Wave W3a — evidence/judgment skills (first half)
+
+Bead: `age-skill-overhaul-reboot-sjv7v.4` (first half). Branch: `claude/sor-w3a-judgment`.
+Skills in scope (6): **council, premortem, postmortem, scope, reality-check, idea-genie**.
+
+Method: verify every checklist item against the live tree → fix confirmed `[defect]`s →
+apply `[enhance]` tightenings or defer/reject with a one-line reason. No silent drops.
+
+## Decisive verification finding (governs several items)
+
+**This reboot tree is on `verdict.v2`.** There is no `validate_v3.py`, no `kernel_v3.py`,
+no `verdict.v3` / `subject-manifest.v2` / `scope-index.v1` schema anywhere. `skills/validate`
+produces `verdict.v2` (`schemas/verdict.v2.schema.json`; SKILL.md line 61: "do not change
+`verdict.v2` schema"). The checklist's cross-cutting "the executable loop emits `verdict.v3`
+via `validate_v3.py`" claim describes the abandoned `codex/skill-overhaul-20260724` branch,
+**not** this tree. Consequence: a skill that *consumes* verdict evidence correctly names
+`verdict.v2` here; only a skill that must never *mint* a verdict gets its denial broadened.
+
+## Disposition
+
+### council
+- **[defect] dangling `council-report.v1` (zero schema hits)** — FIXED. Added
+  `skills/council/schemas/council-report.v1.schema.json` (closed-key object: question,
+  subject_digest, ≥2 judges each with context_id/methodology/judgment/evidence, and a
+  consensus/divergence/minority/unresolved synthesis) + `scripts/validate-output.sh` (jq).
+  `output_contract` now names the validator.
+- **[defect] v2 vocabulary (SKILL.md:78)** — FIXED. "does not write `verdict.v2`" →
+  "does not mint a verdict of any version — no `PASS`/`FAIL`/`NOT_PROVEN`, no `verdict.v*`".
+- **[enhance] no `scripts/validate.sh`, no feature file — give a schema+validator** — APPLIED
+  (schema + validate-output.sh above) and added `scripts/validate.sh` contract guard (pins the
+  boundary line; strip-tested: fails when the pin is removed). Feature file not added — the
+  schema+validator satisfies the contract need; an optional BDD projection is out of scope.
+- (tightening) added a negative trigger (do not convene for a routine/reversible decision) and
+  a failure line (a timed-out / evidence-free judge is excluded and counted as non-returning;
+  <2 independent judgments → report the round insufficient, not a thin consensus). Added an
+  Output section with the artifact dir under `.agents/scratch/council/` (ADR-0016 closed set).
+
+### premortem
+- **[defect] v2 vocabulary (SKILL.md:86) "not `verdict.v2`"** — FIXED →
+  "no verdict of any version". Retains the `advisory findings` phrase its validator pins.
+- **[enhance] no scenario coverage (fail 0/2)** — REJECTED (stale). `references/premortem.feature`
+  already carries 2 scenarios ("A fresh judge returns advisory findings", "Premortem stops
+  after the review"). The 0/2 count is from the seed-era tree.
+
+### postmortem
+- **[defect] `output_contract` points at a `.feature` file** — FIXED. `output_contract` now
+  describes the actual markdown artifact (`postmortem-report.md`, matching `produces`); the
+  `.feature` remains linked from the body as executable behavior, which is its real role.
+- **[defect] v2 vocabulary: `consumes: [verdict.v2]`** — REJECTED (stale). This tree emits
+  `verdict.v2`; postmortem correctly consumes the real artifact. Changing to `verdict.v3`
+  would point at a schema that does not exist here.
+- **[enhance] `effects: []` while it writes `postmortem-report.md`** — APPLIED.
+  `effects: [write_postmortem_report]` (matches its sibling `write_advisory_*` declarations).
+- **[enhance] artifact dir `.agents/postmortem/` outside ADR-0016 closed set** — APPLIED.
+  Moved to `.agents/scratch/postmortem/` (ADR-0016 §1: closed set = `ao/`, `scratch/`,
+  `projections/`; convention `scratch/WRITER/…`).
+- **[possibly-landed] `fm-ws-noncanonical-topdir` detector absent from `cli/`/`scripts/`** —
+  DEFERRED. Verified still absent, but it is an `ao doctor` (Go CLI) concern, not skill text;
+  out of scope for a skill-text wave. The skill-side fix is the dir move above.
+- **[enhance] no scenario coverage (fail 0/2)** — REJECTED (stale). `references/postmortem.feature`
+  already carries 2 scenarios.
+
+### scope
+- **[enhance] YAML output block is prose-only — add an output validator** — REJECTED. scope is
+  response-only (`effects: []`, `output_contract: 'response: …'`); it persists no artifact, so
+  there is nothing on disk to validate. An output validator would require inventing a persisted
+  artifact contract (new `produces`/`effects`), changing the skill's declared nature — beyond a
+  text-enhancement wave. (scope already has a `scripts/validate.sh` contract guard, contrary to
+  the checklist's stale "no validator" premise.)
+- **[enhance] no feature file** — DEFERRED. Optional BDD projection; scope's contract is already
+  pinned by its `validate.sh` (heal `--check --strict` + forbidden-authority grep). Adding one
+  is a low-value projection with no defect behind it.
+- No file change to scope: it has zero `[defect]`s and an already-tight contract (distinct
+  intent, supplier-to-plan placement, advisory boundary, explicit failure-behavior section).
+
+### reality-check
+- **[defect] dangling `reality-check-report.v1` (zero schema hits)** — FIXED. Added
+  `skills/reality-check/schemas/reality-check-report.v1.schema.json` (closed-key object: claim,
+  findings each categorized confirmed/gap/incomplete-evidence/changed-assumption with evidence,
+  optional goal-coverage dispositions) + `scripts/validate-output.sh` (jq). `output_contract`
+  now names the validator.
+- **[enhance] one tracked file, no `validate.sh` — give a schema+validator** — APPLIED
+  (schema + validate-output.sh above) and added `scripts/validate.sh` contract guard
+  (strip-tested: fails when the boundary pin is removed).
+- (tightening) added a "no verdict/`PASS` of any version" boundary and a failure line (an
+  untestable claim is reported incomplete-evidence with the missing artifact named, never
+  resolved as confirmed). Added an Output section with the artifact dir under
+  `.agents/scratch/reality-check/`.
+
+### idea-genie
+- **[enhance] artifact dir `.agents/ideas/<run-id>/` violates ADR-0016 closed set** — APPLIED.
+  Moved to `.agents/scratch/ideas/<run-id>/`; updated `tests/scripts/agentops-native-skills.bats`
+  fixtures (`.agents/ideas/run-1|2` → `.agents/scratch/ideas/run-1|2`). Validator logic unchanged
+  (it only asserts `handoff.artifact_dir` is a nonempty string).
+- **[enhance] add a shared context-isolation reference linked from both council and idea-genie**
+  — DEFERRED. Introduces a new shared reference artifact whose canonical home is contested — the
+  `shared` skill is slated for semantic retirement per this reboot plan's structural beads — and
+  both skills already specify their isolation requirements inline (distinct context IDs, sealed
+  generation, fresh sessions per round). Defer to a dedicated follow-up once `shared`'s
+  disposition is settled.
+
+## Cross-cutting item (not a W3a skill)
+- The checklist's cross-cutting `[defect]` (AGENTS.md / operating-loop.md v1/v2 vocabulary vs a
+  claimed v3 executable) is **not** a W3a skill file and is moot here: this tree is on v2 (see
+  the verification finding). Any doctrine-doc rewrite belongs to the kernel wave (W1), not W3a.
+
+## Disposition counts (17 checklist items total)
+- Fixed (defect): 5 — council×2, premortem×1, postmortem×1 (output_contract), reality-check×1.
+- Applied (enhance): 5 — council validator/guard, postmortem effects, postmortem dir,
+  reality-check validator/guard, idea-genie dir+fixtures.
+- Rejected (stale/structural, with reason): 4 — postmortem `consumes: [verdict.v2]` (defect;
+  tree is v2), premortem scenario coverage, postmortem scenario coverage, scope output-validator.
+- Deferred (with reason): 3 — scope feature file, postmortem `fm-ws-noncanonical-topdir`
+  detector (CLI concern), idea-genie shared context-isolation reference.
+
+## Gate results (all green)
+- `bash skills/{council,reality-check,premortem,postmortem,scope}/scripts/validate.sh` — PASS (5/5).
+- Output validators smoke-tested: valid artifacts pass; smuggled `verdict`/`readiness` field,
+  single-judge council, bad category, and empty findings all rejected.
+- Contract guards strip-tested: council & reality-check `validate.sh` fail when the pinned
+  boundary line is removed; no inert `!`-negation in any new script.
+- `bash scripts/validate-skill-frontmatter.sh` (non-strict) — 49/49 ok.
+- `bash scripts/regen-all.sh` then `--check` — all generated projections current.
+- `bats skill-validator-liveness.bats anti-spiral-contract.bats agentops-native-skills.bats` — 23/23.
+- `bash tests/skills/test-token-budgets.sh` — 0 failures (descriptions ≤180; codex avg 39/45).
+- `bash scripts/check-skill-python-ratchet.sh` — PASS; no new `.py` under `skills/`.

--- a/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w3a.md
+++ b/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w3a.md
@@ -113,6 +113,18 @@ via `validate_v3.py`" claim describes the abandoned `codex/skill-overhaul-202607
 - Deferred (with reason): 3 — scope feature file, postmortem `fm-ws-noncanonical-topdir`
   detector (CLI concern), idea-genie shared context-isolation reference.
 
+## Review round 1 (cross-family) — all three findings fixed
+- **F1 council validator nested-field gap** — FIXED. `validate-output.sh` now enforces a closed
+  key set + types on each `consensus` and `divergence` entry and on the optional
+  `model_identity`/`omissions`/`diversity_unsatisfied` fields, so a nested `verdict`/`PASS` or a
+  wrong-typed value inside those structures is rejected. Added reject smoke cases (nested verdict
+  in consensus, nested readiness in divergence, number `model_identity`, string `omissions`,
+  string `methodologies`) — the schema and the jq validator now agree on all of them.
+- **F2 reality-check empty evidence** — FIXED. Every finding now requires nonempty `evidence`
+  (jq `length > 0` + schema `minItems: 1`); an empty-evidence finding is rejected (new case).
+- **F3 postmortem naming mismatch** — FIXED. Frontmatter `output_contract` now names the body's
+  documented convention `YYYY-MM-DD-postmortem-<topic>.md` instead of the bare `postmortem-report.md`.
+
 ## Gate results (all green)
 - `bash skills/{council,reality-check,premortem,postmortem,scope}/scripts/validate.sh` — PASS (5/5).
 - Output validators smoke-tested: valid artifacts pass; smuggled `verdict`/`readiness` field,

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -48,7 +48,7 @@
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
 | `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | - |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
-| `postmortem` | judgment | `keep_strategy` | - | `postmortem` | - |
+| `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
 | `rch` | execution | `keep_specialist` | - | `rch` | - |

--- a/images/gemini/skills/council/SKILL.md
+++ b/images/gemini/skills/council/SKILL.md
@@ -16,14 +16,16 @@ metadata:
   effects: [write_advisory_council_report]
   canonical_status: canonical
   disposition: keep_strategy
-output_contract: council-report.v1
+output_contract: council-report.v1 JSON validated by skills/council/scripts/validate-output.sh
 ---
 
 # Council
 
 Council is an optional judgment strategy, not a lifecycle or delivery gate. Use
 it when one fresh validator is insufficient for a named irreversible,
-high-blast-radius, or genuinely contested decision.
+high-blast-radius, or genuinely contested decision. Do not convene a council for
+a routine or reversible decision that a single fresh validator can settle: the
+cost of independent contexts is warranted only by a named one-way door.
 
 1. Freeze one question, acceptance surface, evidence set, and subject digest.
 2. Give each judge an independent context and the same bounded packet.
@@ -73,9 +75,26 @@ unresolved assumptions. Synthesis is complete when every judge finding lands
 in exactly one of those buckets; a finding silently dropped from synthesis is
 majority laundering.
 
+## Output
+
+- **Artifact directory:** `.agents/scratch/council/<run-id>/`.
+- **Filename:** `council-report.json`.
+- **Format:** `council-report.v1` JSON — the frozen question and subject digest,
+  every judge's context ID, evidence methodology, cited evidence, and disclosed
+  omissions, plus the consensus/divergence/minority/unresolved synthesis. It
+  carries no `verdict`, `readiness`, or `PASS` field; the validator rejects one.
+- **Validation command:**
+  `skills/council/scripts/validate-output.sh <council-report.json>`.
+
+A judge that times out, errors, or returns an evidence-free judgment is excluded
+from agreement counting and recorded as non-returning; if fewer than two
+independent judgments remain, report the round as insufficient rather than
+synthesize a thin consensus.
+
 ## Boundary
 
-Council does not write `verdict.v2`, edit the subject, retry work, choose a next
-action, or authorize Git, closure, release, or delivery. When Council is used as
-a Validate strategy, one accountable fresh validator consumes its report and
-Validate remains the sole durable verdict writer.
+Council does not mint a verdict of any version — no `PASS`/`FAIL`/`NOT_PROVEN`,
+no `verdict.v*` — edit the subject, retry work, choose a next action, or
+authorize Git, closure, release, or delivery. When Council is used as a Validate
+strategy, one accountable fresh validator consumes its report and Validate
+remains the sole durable verdict writer.

--- a/images/gemini/skills/idea-genie/SKILL.md
+++ b/images/gemini/skills/idea-genie/SKILL.md
@@ -95,7 +95,7 @@ challenge. Do not manufacture panel ceremony.
 
 ### Output Specification
 
-- **Artifact directory:** `.agents/ideas/<run-id>/`
+- **Artifact directory:** `.agents/scratch/ideas/<run-id>/`
 - **Filename:** `idea-challenge.json`
 - **Format:** `idea-challenge.v1` JSON with route-specific fields enforced by
   the validator

--- a/images/gemini/skills/postmortem/SKILL.md
+++ b/images/gemini/skills/postmortem/SKILL.md
@@ -27,7 +27,7 @@ context:
     exclude:
     - HISTORY
   intel_scope: full
-output_contract: 'postmortem-report.md — markdown causal analysis (causal question, pinned inputs, timeline, hypotheses, counterfactuals, unknowns, experiments)'
+output_contract: 'YYYY-MM-DD-postmortem-<topic>.md — markdown causal analysis (causal question, pinned inputs, timeline, hypotheses, counterfactuals, unknowns, experiments)'
 ---
 
 # Postmortem

--- a/images/gemini/skills/postmortem/SKILL.md
+++ b/images/gemini/skills/postmortem/SKILL.md
@@ -14,7 +14,7 @@ skill_api_version: 1
 user-invocable: true
 metadata:
   capabilities: [postmortem]
-  effects: []
+  effects: [write_postmortem_report]
   canonical_status: canonical
   disposition: keep_strategy
   tier: judgment
@@ -27,7 +27,7 @@ context:
     exclude:
     - HISTORY
   intel_scope: full
-output_contract: skills/postmortem/references/postmortem.feature
+output_contract: 'postmortem-report.md — markdown causal analysis (causal question, pinned inputs, timeline, hypotheses, counterfactuals, unknowns, experiments)'
 ---
 
 # Postmortem
@@ -88,7 +88,7 @@ is filed under correlations or unknowns, never silently promoted.
 
 ## Output Specification
 
-- **Artifact directory:** `.agents/postmortem/`.
+- **Artifact directory:** `.agents/scratch/postmortem/`.
 - **Filename convention:** `YYYY-MM-DD-postmortem-<topic>.md`.
 - **Serialization/schema format:** Markdown with causal question, pinned inputs,
   timeline, hypotheses, evidence, counterfactuals, unknowns, and experiments.

--- a/images/gemini/skills/premortem/SKILL.md
+++ b/images/gemini/skills/premortem/SKILL.md
@@ -83,7 +83,7 @@ on routine feature work.
 
 ## Boundary
 
-- Emit advisory findings, not `verdict.v2`, readiness, admission, or permission.
+- Emit advisory findings, no verdict of any version, readiness, admission, or permission.
 - Do not implement, validate the candidate, retry, repair, schedule, claim,
   change acceptance, operate Git, close work, release, or deliver.
 - Any plan edit creates a new subject for a later caller-initiated Premortem.

--- a/images/gemini/skills/reality-check/SKILL.md
+++ b/images/gemini/skills/reality-check/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   effects: [write_advisory_gap_report]
   canonical_status: canonical
   disposition: keep_strategy
-output_contract: reality-check-report.v1
+output_contract: reality-check-report.v1 JSON validated by skills/reality-check/scripts/validate-output.sh
 ---
 
 # Reality Check
@@ -58,8 +58,25 @@ is reported as an escalation gap, exactly like a missing behavior. Reality
 Check reports the escalation; the caller decides whether the ambition or the
 stated goal changes.
 
+## Output
+
+- **Artifact directory:** `.agents/scratch/reality-check/<run-id>/`.
+- **Filename:** `reality-check-report.json`.
+- **Format:** `reality-check-report.v1` JSON — the checked claim, one finding per
+  confirmed behavior, concrete gap, incomplete-evidence item, or changed
+  assumption (each with cited evidence), and, for a completion or status claim,
+  the goal-by-goal coverage disposition. It carries no `verdict`, `readiness`, or
+  `PASS` field; the validator rejects one.
+- **Validation command:**
+  `skills/reality-check/scripts/validate-output.sh <reality-check-report.json>`.
+
+If the claim cannot be tested against any observable evidence, report it as
+incomplete-evidence with the missing artifact named — never resolve an
+untestable claim as confirmed.
+
 ## Boundary
 
 Return the report to the caller. Plan may use concrete gaps to refine the
-existing bead or caller intent. Reality Check does not create work, schedule,
-claim, implement, validate, retry, or deliver.
+existing bead or caller intent. Reality Check reports observations; it does not
+mint a verdict or `PASS` of any version, create work, schedule, claim,
+implement, validate, retry, or deliver.

--- a/registry.json
+++ b/registry.json
@@ -987,7 +987,9 @@
           "postmortem"
         ],
         "disposition": "keep_strategy",
-        "effects": [],
+        "effects": [
+          "write_postmortem_report"
+        ],
         "has_references": true,
         "has_skill_md": true,
         "name": "postmortem",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -399,8 +399,8 @@
     {
       "name": "council",
       "source_skill": "skills/council",
-      "source_hash": "07034f09ac2683713eb294164dac21df8cc69cbe9f4ae12e2b55a823d4defa18",
-      "generated_hash": "862f0ed645d283918a940fba0eef0c9322e45909b0d617aade067b707b9abda7"
+      "source_hash": "c7c7353211c3baa0a342a2618c8cc3fc01e4c5629e39b9e9c26dbbfceb0c56c0",
+      "generated_hash": "0ec7ad04f8b7062bb96d9dd336caa42f85261ae4e4be88a25596898f5b11a229"
     },
     {
       "name": "craft-goal",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -399,8 +399,8 @@
     {
       "name": "council",
       "source_skill": "skills/council",
-      "source_hash": "b8c6951caf7719f0d738cac225c61dc26678567889f2c68fa1643d8f922f4965",
-      "generated_hash": "725b45ef5ee0f0fb66bcbb81dd06d7adacdc9cb6284921f938e0a0e1f5df2b70"
+      "source_hash": "07034f09ac2683713eb294164dac21df8cc69cbe9f4ae12e2b55a823d4defa18",
+      "generated_hash": "862f0ed645d283918a940fba0eef0c9322e45909b0d617aade067b707b9abda7"
     },
     {
       "name": "craft-goal",
@@ -489,7 +489,7 @@
     {
       "name": "postmortem",
       "source_skill": "skills/postmortem",
-      "source_hash": "935e95b44f578c3aace0ec14ccc5941fa6d67603e0324a4e6c30583244dfd450",
+      "source_hash": "e1b37de32fb537d06ecc56a1801b3eee3ae9b7574718eaf6048fe470d3fc285b",
       "generated_hash": "55cc73eba32d0f60b6d8fa6707f8566de3393716345f7be558e08219cfbfe339"
     },
     {
@@ -513,8 +513,8 @@
     {
       "name": "reality-check",
       "source_skill": "skills/reality-check",
-      "source_hash": "65f4591de8b5ad1910e11533d5fd95d885a4f5d84dc4239f7bce581d4c9ade49",
-      "generated_hash": "1b53b64b56a1445cc9bee58b5cf1e435718ace9aa8e283f3b73ecf9808a6662f"
+      "source_hash": "a2d7e5ab9bf7da978fdef17f19a5e7dd28fed28b5d3a1513ef92b5042e4068cd",
+      "generated_hash": "a65522fa3b24fca1f367a883f2eb904a2606a4f2a21ee688b1b6c106d7efefb2"
     },
     {
       "name": "refactor",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -399,8 +399,8 @@
     {
       "name": "council",
       "source_skill": "skills/council",
-      "source_hash": "99b8347b53316514350139dcae1ffdd11ca025820395bc72c700e86823ba914e",
-      "generated_hash": "7f43f5ac4f8fe296e36370245c4c9db44f56b841c5c5139c1b06abde1619ae2a"
+      "source_hash": "b8c6951caf7719f0d738cac225c61dc26678567889f2c68fa1643d8f922f4965",
+      "generated_hash": "725b45ef5ee0f0fb66bcbb81dd06d7adacdc9cb6284921f938e0a0e1f5df2b70"
     },
     {
       "name": "craft-goal",
@@ -441,8 +441,8 @@
     {
       "name": "idea-genie",
       "source_skill": "skills/idea-genie",
-      "source_hash": "5b17cb112c1d32875435911d7796b5886f9973fa491bbf22845bb3fe4c23b735",
-      "generated_hash": "457fc1e75959fdff25554592d3a72106919bf8cf1730c725fb8ba92375e1061e"
+      "source_hash": "905538c2b43536f0f3d062b1fc2008cfb699b7911fd78b10b77ac8ff276bf69a",
+      "generated_hash": "f97b8f16999217f7bc68c315a877b1d18edce13d39742d24af3a6f253181b663"
     },
     {
       "name": "implement",
@@ -489,14 +489,14 @@
     {
       "name": "postmortem",
       "source_skill": "skills/postmortem",
-      "source_hash": "20d7ad1188766fb023cb6fa4cae9eea49900492a09b37d61a06354fb66455f87",
-      "generated_hash": "2a90385f0cde31403f350960492a56ef383c66f3730147f641adcc722cb304b0"
+      "source_hash": "935e95b44f578c3aace0ec14ccc5941fa6d67603e0324a4e6c30583244dfd450",
+      "generated_hash": "55cc73eba32d0f60b6d8fa6707f8566de3393716345f7be558e08219cfbfe339"
     },
     {
       "name": "premortem",
       "source_skill": "skills/premortem",
-      "source_hash": "06fa5f32dd993d969371c99aabd78a2d5c5057b409c75323bfe372048a2c191c",
-      "generated_hash": "4aba81740a48d49fa43412609d235e8ea9f23a915945b7f11301bf3671f4b6a6"
+      "source_hash": "266f8d28e76457681e78f4e682a4594dcd14ba3aaddb14090a82b1b73f2afb9a",
+      "generated_hash": "c6c4e95a727089560a025c7a9f2d96f4e22e5bd8a8a3f2affbea656e220b8c41"
     },
     {
       "name": "product",
@@ -513,8 +513,8 @@
     {
       "name": "reality-check",
       "source_skill": "skills/reality-check",
-      "source_hash": "fa47b54614fefc41bfb076dba3a13b5b52f04360600ddf6042c5b5afd48b5d63",
-      "generated_hash": "3c94ff7df132747beb01b9c7d3a6c75adc02c0d80a9931a3bb7782f6dbe61f2d"
+      "source_hash": "65f4591de8b5ad1910e11533d5fd95d885a4f5d84dc4239f7bce581d4c9ade49",
+      "generated_hash": "1b53b64b56a1445cc9bee58b5cf1e435718ace9aa8e283f3b73ecf9808a6662f"
     },
     {
       "name": "refactor",

--- a/skills-codex/council/.agentops-generated.json
+++ b/skills-codex/council/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/council",
   "layout": "modular",
-  "source_hash": "99b8347b53316514350139dcae1ffdd11ca025820395bc72c700e86823ba914e",
-  "generated_hash": "7f43f5ac4f8fe296e36370245c4c9db44f56b841c5c5139c1b06abde1619ae2a"
+  "source_hash": "b8c6951caf7719f0d738cac225c61dc26678567889f2c68fa1643d8f922f4965",
+  "generated_hash": "725b45ef5ee0f0fb66bcbb81dd06d7adacdc9cb6284921f938e0a0e1f5df2b70"
 }

--- a/skills-codex/council/.agentops-generated.json
+++ b/skills-codex/council/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/council",
   "layout": "modular",
-  "source_hash": "b8c6951caf7719f0d738cac225c61dc26678567889f2c68fa1643d8f922f4965",
-  "generated_hash": "725b45ef5ee0f0fb66bcbb81dd06d7adacdc9cb6284921f938e0a0e1f5df2b70"
+  "source_hash": "07034f09ac2683713eb294164dac21df8cc69cbe9f4ae12e2b55a823d4defa18",
+  "generated_hash": "862f0ed645d283918a940fba0eef0c9322e45909b0d617aade067b707b9abda7"
 }

--- a/skills-codex/council/.agentops-generated.json
+++ b/skills-codex/council/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/council",
   "layout": "modular",
-  "source_hash": "07034f09ac2683713eb294164dac21df8cc69cbe9f4ae12e2b55a823d4defa18",
-  "generated_hash": "862f0ed645d283918a940fba0eef0c9322e45909b0d617aade067b707b9abda7"
+  "source_hash": "c7c7353211c3baa0a342a2618c8cc3fc01e4c5629e39b9e9c26dbbfceb0c56c0",
+  "generated_hash": "0ec7ad04f8b7062bb96d9dd336caa42f85261ae4e4be88a25596898f5b11a229"
 }

--- a/skills-codex/council/SKILL.md
+++ b/skills-codex/council/SKILL.md
@@ -6,7 +6,9 @@ description: Collect independent perspectives for an
 
 Council is an optional judgment strategy, not a lifecycle or delivery gate. Use
 it when one fresh validator is insufficient for a named irreversible,
-high-blast-radius, or genuinely contested decision.
+high-blast-radius, or genuinely contested decision. Do not convene a council for
+a routine or reversible decision that a single fresh validator can settle: the
+cost of independent contexts is warranted only by a named one-way door.
 
 1. Freeze one question, acceptance surface, evidence set, and subject digest.
 2. Give each judge an independent context and the same bounded packet.
@@ -56,9 +58,26 @@ unresolved assumptions. Synthesis is complete when every judge finding lands
 in exactly one of those buckets; a finding silently dropped from synthesis is
 majority laundering.
 
+## Output
+
+- **Artifact directory:** `.agents/scratch/council/<run-id>/`.
+- **Filename:** `council-report.json`.
+- **Format:** `council-report.v1` JSON — the frozen question and subject digest,
+  every judge's context ID, evidence methodology, cited evidence, and disclosed
+  omissions, plus the consensus/divergence/minority/unresolved synthesis. It
+  carries no `verdict`, `readiness`, or `PASS` field; the validator rejects one.
+- **Validation command:**
+  `skills/council/scripts/validate-output.sh <council-report.json>`.
+
+A judge that times out, errors, or returns an evidence-free judgment is excluded
+from agreement counting and recorded as non-returning; if fewer than two
+independent judgments remain, report the round as insufficient rather than
+synthesize a thin consensus.
+
 ## Boundary
 
-Council does not write `verdict.v2`, edit the subject, retry work, choose a next
-action, or authorize Git, closure, release, or delivery. When Council is used as
-a Validate strategy, one accountable fresh validator consumes its report and
-Validate remains the sole durable verdict writer.
+Council does not mint a verdict of any version — no `PASS`/`FAIL`/`NOT_PROVEN`,
+no `verdict.v*` — edit the subject, retry work, choose a next action, or
+authorize Git, closure, release, or delivery. When Council is used as a Validate
+strategy, one accountable fresh validator consumes its report and Validate
+remains the sole durable verdict writer.

--- a/skills-codex/council/schemas/council-report.v1.schema.json
+++ b/skills-codex/council/schemas/council-report.v1.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentops.local/schemas/council-report.v1.schema.json",
+  "title": "Council Report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "question", "subject_digest", "judges", "synthesis"],
+  "properties": {
+    "schema_version": {"const": "council-report.v1"},
+    "question": {"type": "string", "minLength": 1},
+    "subject_digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "diversity_unsatisfied": {"type": "boolean"},
+    "judges": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["context_id", "methodology", "judgment", "evidence"],
+        "properties": {
+          "context_id": {"type": "string", "minLength": 1},
+          "methodology": {"type": "string", "minLength": 1},
+          "model_identity": {"type": "string", "minLength": 1},
+          "judgment": {"type": "string", "minLength": 1},
+          "evidence": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "string", "minLength": 1}
+          },
+          "omissions": {"type": "array", "items": {"type": "string", "minLength": 1}}
+        }
+      }
+    },
+    "synthesis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["consensus", "divergence", "minority", "unresolved"],
+      "properties": {
+        "consensus": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["claim", "methodologies"],
+            "properties": {
+              "claim": {"type": "string", "minLength": 1},
+              "methodologies": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"type": "string", "minLength": 1}
+              }
+            }
+          }
+        },
+        "divergence": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["point", "positions"],
+            "properties": {
+              "point": {"type": "string", "minLength": 1},
+              "positions": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"type": "string", "minLength": 1}
+              }
+            }
+          }
+        },
+        "minority": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "unresolved": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    }
+  }
+}

--- a/skills-codex/council/scripts/validate-output.sh
+++ b/skills-codex/council/scripts/validate-output.sh
@@ -12,6 +12,7 @@ jq -e '
   and .schema_version == "council-report.v1"
   and (.question | text)
   and (.subject_digest | type == "string" and test("^[a-f0-9]{64}$"))
+  and ((.diversity_unsatisfied == null) or (.diversity_unsatisfied | type == "boolean"))
   and (.judges
     | type == "array" and length >= 2
     and all(.[];
@@ -19,17 +20,25 @@ jq -e '
       and (.context_id | text)
       and (.methodology | text)
       and (.judgment | text)
-      and (.evidence | type == "array" and length > 0 and all(.[]; text))))
+      and ((.model_identity == null) or (.model_identity | text))
+      and (.evidence | type == "array" and length > 0 and all(.[]; text))
+      and ((.omissions == null) or (.omissions | type == "array" and all(.[]; text)))))
   and ((.judges | map(.context_id) | unique | length) == (.judges | length))
   and (.synthesis | type == "object")
   and ((.synthesis | keys - ["consensus","divergence","minority","unresolved"]) | length == 0)
   and (.synthesis | has("consensus") and has("divergence") and has("minority") and has("unresolved"))
   and (.synthesis.consensus
     | type == "array"
-    and all(.[]; (.claim | text) and (.methodologies | type == "array" and length > 0 and all(.[]; text))))
+    and all(.[];
+      ((keys - ["claim","methodologies"]) | length == 0)
+      and (.claim | text)
+      and (.methodologies | type == "array" and length > 0 and all(.[]; text))))
   and (.synthesis.divergence
     | type == "array"
-    and all(.[]; (.point | text) and (.positions | type == "array" and length > 0 and all(.[]; text))))
+    and all(.[];
+      ((keys - ["point","positions"]) | length == 0)
+      and (.point | text)
+      and (.positions | type == "array" and length > 0 and all(.[]; text))))
   and (.synthesis.minority | type == "array" and all(.[]; text))
   and (.synthesis.unresolved | type == "array" and all(.[]; text))
 ' "$1" >/dev/null || {

--- a/skills-codex/council/scripts/validate-output.sh
+++ b/skills-codex/council/scripts/validate-output.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 || ! -f "$1" ]]; then
+  echo "usage: $0 <council-report.json>" >&2
+  exit 2
+fi
+
+jq -e '
+  def text: type == "string" and length > 0;
+  ((keys - ["schema_version","question","subject_digest","judges","synthesis","diversity_unsatisfied"]) | length == 0)
+  and .schema_version == "council-report.v1"
+  and (.question | text)
+  and (.subject_digest | type == "string" and test("^[a-f0-9]{64}$"))
+  and (.judges
+    | type == "array" and length >= 2
+    and all(.[];
+      ((keys - ["context_id","methodology","model_identity","judgment","evidence","omissions"]) | length == 0)
+      and (.context_id | text)
+      and (.methodology | text)
+      and (.judgment | text)
+      and (.evidence | type == "array" and length > 0 and all(.[]; text))))
+  and ((.judges | map(.context_id) | unique | length) == (.judges | length))
+  and (.synthesis | type == "object")
+  and ((.synthesis | keys - ["consensus","divergence","minority","unresolved"]) | length == 0)
+  and (.synthesis | has("consensus") and has("divergence") and has("minority") and has("unresolved"))
+  and (.synthesis.consensus
+    | type == "array"
+    and all(.[]; (.claim | text) and (.methodologies | type == "array" and length > 0 and all(.[]; text))))
+  and (.synthesis.divergence
+    | type == "array"
+    and all(.[]; (.point | text) and (.positions | type == "array" and length > 0 and all(.[]; text))))
+  and (.synthesis.minority | type == "array" and all(.[]; text))
+  and (.synthesis.unresolved | type == "array" and all(.[]; text))
+' "$1" >/dev/null || {
+  echo "invalid council-report.v1 artifact: $1" >&2
+  exit 1
+}
+
+echo "valid council-report.v1: $1"

--- a/skills-codex/council/scripts/validate-output.sh
+++ b/skills-codex/council/scripts/validate-output.sh
@@ -12,7 +12,7 @@ jq -e '
   and .schema_version == "council-report.v1"
   and (.question | text)
   and (.subject_digest | type == "string" and test("^[a-f0-9]{64}$"))
-  and ((.diversity_unsatisfied == null) or (.diversity_unsatisfied | type == "boolean"))
+  and (if has("diversity_unsatisfied") then (.diversity_unsatisfied | type == "boolean") else true end)
   and (.judges
     | type == "array" and length >= 2
     and all(.[];
@@ -20,9 +20,9 @@ jq -e '
       and (.context_id | text)
       and (.methodology | text)
       and (.judgment | text)
-      and ((.model_identity == null) or (.model_identity | text))
+      and (if has("model_identity") then (.model_identity | text) else true end)
       and (.evidence | type == "array" and length > 0 and all(.[]; text))
-      and ((.omissions == null) or (.omissions | type == "array" and all(.[]; text)))))
+      and (if has("omissions") then (.omissions | type == "array" and all(.[]; text)) else true end)))
   and ((.judges | map(.context_id) | unique | length) == (.judges | length))
   and (.synthesis | type == "object")
   and ((.synthesis | keys - ["consensus","divergence","minority","unresolved"]) | length == 0)

--- a/skills-codex/council/scripts/validate.sh
+++ b/skills-codex/council/scripts/validate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+skill_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+grep -q '^name: council$' "$skill_dir/SKILL.md"
+grep -Fq 'optional judgment strategy' "$skill_dir/SKILL.md"
+grep -Fq 'does not mint a verdict of any version' "$skill_dir/SKILL.md"
+test -f "$skill_dir/schemas/council-report.v1.schema.json"
+test -x "$skill_dir/scripts/validate-output.sh"
+
+if grep -Eiq 'ao (pawl|land)|git (commit|push)|br (close|update)|auto-redo' \
+  "$skill_dir/SKILL.md"; then
+  echo 'council contract contains forbidden lifecycle authority' >&2
+  exit 1
+fi
+
+echo 'council skill contract: PASS'

--- a/skills-codex/idea-genie/.agentops-generated.json
+++ b/skills-codex/idea-genie/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/idea-genie",
   "layout": "modular",
-  "source_hash": "5b17cb112c1d32875435911d7796b5886f9973fa491bbf22845bb3fe4c23b735",
-  "generated_hash": "457fc1e75959fdff25554592d3a72106919bf8cf1730c725fb8ba92375e1061e"
+  "source_hash": "905538c2b43536f0f3d062b1fc2008cfb699b7911fd78b10b77ac8ff276bf69a",
+  "generated_hash": "f97b8f16999217f7bc68c315a877b1d18edce13d39742d24af3a6f253181b663"
 }

--- a/skills-codex/idea-genie/SKILL.md
+++ b/skills-codex/idea-genie/SKILL.md
@@ -75,7 +75,7 @@ challenge. Do not manufacture panel ceremony.
 
 ### Output Specification
 
-- **Artifact directory:** `.agents/ideas/<run-id>/`
+- **Artifact directory:** `.agents/scratch/ideas/<run-id>/`
 - **Filename:** `idea-challenge.json`
 - **Format:** `idea-challenge.v1` JSON with route-specific fields enforced by
   the validator

--- a/skills-codex/postmortem/.agentops-generated.json
+++ b/skills-codex/postmortem/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/postmortem",
   "layout": "modular",
-  "source_hash": "20d7ad1188766fb023cb6fa4cae9eea49900492a09b37d61a06354fb66455f87",
-  "generated_hash": "2a90385f0cde31403f350960492a56ef383c66f3730147f641adcc722cb304b0"
+  "source_hash": "935e95b44f578c3aace0ec14ccc5941fa6d67603e0324a4e6c30583244dfd450",
+  "generated_hash": "55cc73eba32d0f60b6d8fa6707f8566de3393716345f7be558e08219cfbfe339"
 }

--- a/skills-codex/postmortem/.agentops-generated.json
+++ b/skills-codex/postmortem/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/postmortem",
   "layout": "modular",
-  "source_hash": "935e95b44f578c3aace0ec14ccc5941fa6d67603e0324a4e6c30583244dfd450",
+  "source_hash": "e1b37de32fb537d06ecc56a1801b3eee3ae9b7574718eaf6048fe470d3fc285b",
   "generated_hash": "55cc73eba32d0f60b6d8fa6707f8566de3393716345f7be558e08219cfbfe339"
 }

--- a/skills-codex/postmortem/SKILL.md
+++ b/skills-codex/postmortem/SKILL.md
@@ -60,7 +60,7 @@ is filed under correlations or unknowns, never silently promoted.
 
 ## Output Specification
 
-- **Artifact directory:** `.agents/postmortem/`.
+- **Artifact directory:** `.agents/scratch/postmortem/`.
 - **Filename convention:** `YYYY-MM-DD-postmortem-<topic>.md`.
 - **Serialization/schema format:** Markdown with causal question, pinned inputs,
   timeline, hypotheses, evidence, counterfactuals, unknowns, and experiments.

--- a/skills-codex/premortem/.agentops-generated.json
+++ b/skills-codex/premortem/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/premortem",
   "layout": "modular",
-  "source_hash": "06fa5f32dd993d969371c99aabd78a2d5c5057b409c75323bfe372048a2c191c",
-  "generated_hash": "4aba81740a48d49fa43412609d235e8ea9f23a915945b7f11301bf3671f4b6a6"
+  "source_hash": "266f8d28e76457681e78f4e682a4594dcd14ba3aaddb14090a82b1b73f2afb9a",
+  "generated_hash": "c6c4e95a727089560a025c7a9f2d96f4e22e5bd8a8a3f2affbea656e220b8c41"
 }

--- a/skills-codex/premortem/SKILL.md
+++ b/skills-codex/premortem/SKILL.md
@@ -64,7 +64,7 @@ on routine feature work.
 
 ## Boundary
 
-- Emit advisory findings, not `verdict.v2`, readiness, admission, or permission.
+- Emit advisory findings, no verdict of any version, readiness, admission, or permission.
 - Do not implement, validate the candidate, retry, repair, schedule, claim,
   change acceptance, operate Git, close work, release, or deliver.
 - Any plan edit creates a new subject for a later caller-initiated Premortem.

--- a/skills-codex/reality-check/.agentops-generated.json
+++ b/skills-codex/reality-check/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/reality-check",
   "layout": "modular",
-  "source_hash": "fa47b54614fefc41bfb076dba3a13b5b52f04360600ddf6042c5b5afd48b5d63",
-  "generated_hash": "3c94ff7df132747beb01b9c7d3a6c75adc02c0d80a9931a3bb7782f6dbe61f2d"
+  "source_hash": "65f4591de8b5ad1910e11533d5fd95d885a4f5d84dc4239f7bce581d4c9ade49",
+  "generated_hash": "1b53b64b56a1445cc9bee58b5cf1e435718ace9aa8e283f3b73ecf9808a6662f"
 }

--- a/skills-codex/reality-check/.agentops-generated.json
+++ b/skills-codex/reality-check/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/reality-check",
   "layout": "modular",
-  "source_hash": "65f4591de8b5ad1910e11533d5fd95d885a4f5d84dc4239f7bce581d4c9ade49",
-  "generated_hash": "1b53b64b56a1445cc9bee58b5cf1e435718ace9aa8e283f3b73ecf9808a6662f"
+  "source_hash": "a2d7e5ab9bf7da978fdef17f19a5e7dd28fed28b5d3a1513ef92b5042e4068cd",
+  "generated_hash": "a65522fa3b24fca1f367a883f2eb904a2606a4f2a21ee688b1b6c106d7efefb2"
 }

--- a/skills-codex/reality-check/SKILL.md
+++ b/skills-codex/reality-check/SKILL.md
@@ -40,8 +40,25 @@ is reported as an escalation gap, exactly like a missing behavior. Reality
 Check reports the escalation; the caller decides whether the ambition or the
 stated goal changes.
 
+## Output
+
+- **Artifact directory:** `.agents/scratch/reality-check/<run-id>/`.
+- **Filename:** `reality-check-report.json`.
+- **Format:** `reality-check-report.v1` JSON — the checked claim, one finding per
+  confirmed behavior, concrete gap, incomplete-evidence item, or changed
+  assumption (each with cited evidence), and, for a completion or status claim,
+  the goal-by-goal coverage disposition. It carries no `verdict`, `readiness`, or
+  `PASS` field; the validator rejects one.
+- **Validation command:**
+  `skills/reality-check/scripts/validate-output.sh <reality-check-report.json>`.
+
+If the claim cannot be tested against any observable evidence, report it as
+incomplete-evidence with the missing artifact named — never resolve an
+untestable claim as confirmed.
+
 ## Boundary
 
 Return the report to the caller. Plan may use concrete gaps to refine the
-existing bead or caller intent. Reality Check does not create work, schedule,
-claim, implement, validate, retry, or deliver.
+existing bead or caller intent. Reality Check reports observations; it does not
+mint a verdict or `PASS` of any version, create work, schedule, claim,
+implement, validate, retry, or deliver.

--- a/skills-codex/reality-check/schemas/reality-check-report.v1.schema.json
+++ b/skills-codex/reality-check/schemas/reality-check-report.v1.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentops.local/schemas/reality-check-report.v1.schema.json",
+  "title": "Reality Check Report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "claim", "findings"],
+  "properties": {
+    "schema_version": {"const": "reality-check-report.v1"},
+    "claim": {"type": "string", "minLength": 1},
+    "findings": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["category", "statement", "evidence"],
+        "properties": {
+          "category": {"enum": ["confirmed", "gap", "incomplete-evidence", "changed-assumption"]},
+          "statement": {"type": "string", "minLength": 1},
+          "evidence": {"type": "array", "items": {"type": "string", "minLength": 1}}
+        }
+      }
+    },
+    "coverage": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["goal", "disposition"],
+        "properties": {
+          "goal": {"type": "string", "minLength": 1},
+          "disposition": {"enum": ["confirmed", "gap", "unverifiable"]},
+          "evidence": {"type": "array", "items": {"type": "string", "minLength": 1}}
+        }
+      }
+    }
+  }
+}

--- a/skills-codex/reality-check/schemas/reality-check-report.v1.schema.json
+++ b/skills-codex/reality-check/schemas/reality-check-report.v1.schema.json
@@ -18,7 +18,7 @@
         "properties": {
           "category": {"enum": ["confirmed", "gap", "incomplete-evidence", "changed-assumption"]},
           "statement": {"type": "string", "minLength": 1},
-          "evidence": {"type": "array", "items": {"type": "string", "minLength": 1}}
+          "evidence": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
         }
       }
     },

--- a/skills-codex/reality-check/scripts/validate-output.sh
+++ b/skills-codex/reality-check/scripts/validate-output.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 || ! -f "$1" ]]; then
+  echo "usage: $0 <reality-check-report.json>" >&2
+  exit 2
+fi
+
+jq -e '
+  def text: type == "string" and length > 0;
+  ((keys - ["schema_version","claim","findings","coverage"]) | length == 0)
+  and .schema_version == "reality-check-report.v1"
+  and (.claim | text)
+  and (.findings
+    | type == "array" and length > 0
+    and all(.[];
+      ((keys - ["category","statement","evidence"]) | length == 0)
+      and (.category == "confirmed" or .category == "gap"
+        or .category == "incomplete-evidence" or .category == "changed-assumption")
+      and (.statement | text)
+      and (.evidence | type == "array" and all(.[]; text))))
+  and (if has("coverage") then
+        (.coverage
+          | type == "array"
+          and all(.[];
+            ((keys - ["goal","disposition","evidence"]) | length == 0)
+            and (.goal | text)
+            and (.disposition == "confirmed" or .disposition == "gap" or .disposition == "unverifiable")
+            and (.evidence | (. == null) or (type == "array" and all(.[]; text)))))
+      else true end)
+' "$1" >/dev/null || {
+  echo "invalid reality-check-report.v1 artifact: $1" >&2
+  exit 1
+}
+
+echo "valid reality-check-report.v1: $1"

--- a/skills-codex/reality-check/scripts/validate-output.sh
+++ b/skills-codex/reality-check/scripts/validate-output.sh
@@ -18,7 +18,7 @@ jq -e '
       and (.category == "confirmed" or .category == "gap"
         or .category == "incomplete-evidence" or .category == "changed-assumption")
       and (.statement | text)
-      and (.evidence | type == "array" and all(.[]; text))))
+      and (.evidence | type == "array" and length > 0 and all(.[]; text))))
   and (if has("coverage") then
         (.coverage
           | type == "array"

--- a/skills-codex/reality-check/scripts/validate.sh
+++ b/skills-codex/reality-check/scripts/validate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+skill_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+grep -q '^name: reality-check$' "$skill_dir/SKILL.md"
+grep -Fq 'Compare an explicit claim with observable evidence' "$skill_dir/SKILL.md"
+grep -Fq 'mint a verdict or' "$skill_dir/SKILL.md"
+test -f "$skill_dir/schemas/reality-check-report.v1.schema.json"
+test -x "$skill_dir/scripts/validate-output.sh"
+
+if grep -Eiq 'ao (pawl|land)|git (commit|push)|br (close|update)|auto-redo|next[_ -]action' \
+  "$skill_dir/SKILL.md"; then
+  echo 'reality-check contract contains forbidden lifecycle authority' >&2
+  exit 1
+fi
+
+echo 'reality-check skill contract: PASS'

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -68,7 +68,7 @@
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
 | `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | - |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
-| `postmortem` | judgment | `keep_strategy` | - | `postmortem` | - |
+| `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
 | `rch` | execution | `keep_specialist` | - | `rch` | - |

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -871,7 +871,9 @@
       "dependencies": [],
       "description": "Optionally test a retrospective causal question against durable verdict evidence. Triggers: \"postmortem\", \"causal retrospective\", \"test a retrospective hypothesis\".",
       "disposition": "keep_strategy",
-      "effects": [],
+      "effects": [
+        "write_postmortem_report"
+      ],
       "graph_root": false,
       "hexagonal_role": "domain",
       "name": "postmortem",

--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -16,14 +16,16 @@ metadata:
   effects: [write_advisory_council_report]
   canonical_status: canonical
   disposition: keep_strategy
-output_contract: council-report.v1
+output_contract: council-report.v1 JSON validated by skills/council/scripts/validate-output.sh
 ---
 
 # Council
 
 Council is an optional judgment strategy, not a lifecycle or delivery gate. Use
 it when one fresh validator is insufficient for a named irreversible,
-high-blast-radius, or genuinely contested decision.
+high-blast-radius, or genuinely contested decision. Do not convene a council for
+a routine or reversible decision that a single fresh validator can settle: the
+cost of independent contexts is warranted only by a named one-way door.
 
 1. Freeze one question, acceptance surface, evidence set, and subject digest.
 2. Give each judge an independent context and the same bounded packet.
@@ -73,9 +75,26 @@ unresolved assumptions. Synthesis is complete when every judge finding lands
 in exactly one of those buckets; a finding silently dropped from synthesis is
 majority laundering.
 
+## Output
+
+- **Artifact directory:** `.agents/scratch/council/<run-id>/`.
+- **Filename:** `council-report.json`.
+- **Format:** `council-report.v1` JSON — the frozen question and subject digest,
+  every judge's context ID, evidence methodology, cited evidence, and disclosed
+  omissions, plus the consensus/divergence/minority/unresolved synthesis. It
+  carries no `verdict`, `readiness`, or `PASS` field; the validator rejects one.
+- **Validation command:**
+  `skills/council/scripts/validate-output.sh <council-report.json>`.
+
+A judge that times out, errors, or returns an evidence-free judgment is excluded
+from agreement counting and recorded as non-returning; if fewer than two
+independent judgments remain, report the round as insufficient rather than
+synthesize a thin consensus.
+
 ## Boundary
 
-Council does not write `verdict.v2`, edit the subject, retry work, choose a next
-action, or authorize Git, closure, release, or delivery. When Council is used as
-a Validate strategy, one accountable fresh validator consumes its report and
-Validate remains the sole durable verdict writer.
+Council does not mint a verdict of any version — no `PASS`/`FAIL`/`NOT_PROVEN`,
+no `verdict.v*` — edit the subject, retry work, choose a next action, or
+authorize Git, closure, release, or delivery. When Council is used as a Validate
+strategy, one accountable fresh validator consumes its report and Validate
+remains the sole durable verdict writer.

--- a/skills/council/schemas/council-report.v1.schema.json
+++ b/skills/council/schemas/council-report.v1.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentops.local/schemas/council-report.v1.schema.json",
+  "title": "Council Report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "question", "subject_digest", "judges", "synthesis"],
+  "properties": {
+    "schema_version": {"const": "council-report.v1"},
+    "question": {"type": "string", "minLength": 1},
+    "subject_digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "diversity_unsatisfied": {"type": "boolean"},
+    "judges": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["context_id", "methodology", "judgment", "evidence"],
+        "properties": {
+          "context_id": {"type": "string", "minLength": 1},
+          "methodology": {"type": "string", "minLength": 1},
+          "model_identity": {"type": "string", "minLength": 1},
+          "judgment": {"type": "string", "minLength": 1},
+          "evidence": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "string", "minLength": 1}
+          },
+          "omissions": {"type": "array", "items": {"type": "string", "minLength": 1}}
+        }
+      }
+    },
+    "synthesis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["consensus", "divergence", "minority", "unresolved"],
+      "properties": {
+        "consensus": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["claim", "methodologies"],
+            "properties": {
+              "claim": {"type": "string", "minLength": 1},
+              "methodologies": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"type": "string", "minLength": 1}
+              }
+            }
+          }
+        },
+        "divergence": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["point", "positions"],
+            "properties": {
+              "point": {"type": "string", "minLength": 1},
+              "positions": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"type": "string", "minLength": 1}
+              }
+            }
+          }
+        },
+        "minority": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "unresolved": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    }
+  }
+}

--- a/skills/council/scripts/validate-output.sh
+++ b/skills/council/scripts/validate-output.sh
@@ -12,6 +12,7 @@ jq -e '
   and .schema_version == "council-report.v1"
   and (.question | text)
   and (.subject_digest | type == "string" and test("^[a-f0-9]{64}$"))
+  and ((.diversity_unsatisfied == null) or (.diversity_unsatisfied | type == "boolean"))
   and (.judges
     | type == "array" and length >= 2
     and all(.[];
@@ -19,17 +20,25 @@ jq -e '
       and (.context_id | text)
       and (.methodology | text)
       and (.judgment | text)
-      and (.evidence | type == "array" and length > 0 and all(.[]; text))))
+      and ((.model_identity == null) or (.model_identity | text))
+      and (.evidence | type == "array" and length > 0 and all(.[]; text))
+      and ((.omissions == null) or (.omissions | type == "array" and all(.[]; text)))))
   and ((.judges | map(.context_id) | unique | length) == (.judges | length))
   and (.synthesis | type == "object")
   and ((.synthesis | keys - ["consensus","divergence","minority","unresolved"]) | length == 0)
   and (.synthesis | has("consensus") and has("divergence") and has("minority") and has("unresolved"))
   and (.synthesis.consensus
     | type == "array"
-    and all(.[]; (.claim | text) and (.methodologies | type == "array" and length > 0 and all(.[]; text))))
+    and all(.[];
+      ((keys - ["claim","methodologies"]) | length == 0)
+      and (.claim | text)
+      and (.methodologies | type == "array" and length > 0 and all(.[]; text))))
   and (.synthesis.divergence
     | type == "array"
-    and all(.[]; (.point | text) and (.positions | type == "array" and length > 0 and all(.[]; text))))
+    and all(.[];
+      ((keys - ["point","positions"]) | length == 0)
+      and (.point | text)
+      and (.positions | type == "array" and length > 0 and all(.[]; text))))
   and (.synthesis.minority | type == "array" and all(.[]; text))
   and (.synthesis.unresolved | type == "array" and all(.[]; text))
 ' "$1" >/dev/null || {

--- a/skills/council/scripts/validate-output.sh
+++ b/skills/council/scripts/validate-output.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 || ! -f "$1" ]]; then
+  echo "usage: $0 <council-report.json>" >&2
+  exit 2
+fi
+
+jq -e '
+  def text: type == "string" and length > 0;
+  ((keys - ["schema_version","question","subject_digest","judges","synthesis","diversity_unsatisfied"]) | length == 0)
+  and .schema_version == "council-report.v1"
+  and (.question | text)
+  and (.subject_digest | type == "string" and test("^[a-f0-9]{64}$"))
+  and (.judges
+    | type == "array" and length >= 2
+    and all(.[];
+      ((keys - ["context_id","methodology","model_identity","judgment","evidence","omissions"]) | length == 0)
+      and (.context_id | text)
+      and (.methodology | text)
+      and (.judgment | text)
+      and (.evidence | type == "array" and length > 0 and all(.[]; text))))
+  and ((.judges | map(.context_id) | unique | length) == (.judges | length))
+  and (.synthesis | type == "object")
+  and ((.synthesis | keys - ["consensus","divergence","minority","unresolved"]) | length == 0)
+  and (.synthesis | has("consensus") and has("divergence") and has("minority") and has("unresolved"))
+  and (.synthesis.consensus
+    | type == "array"
+    and all(.[]; (.claim | text) and (.methodologies | type == "array" and length > 0 and all(.[]; text))))
+  and (.synthesis.divergence
+    | type == "array"
+    and all(.[]; (.point | text) and (.positions | type == "array" and length > 0 and all(.[]; text))))
+  and (.synthesis.minority | type == "array" and all(.[]; text))
+  and (.synthesis.unresolved | type == "array" and all(.[]; text))
+' "$1" >/dev/null || {
+  echo "invalid council-report.v1 artifact: $1" >&2
+  exit 1
+}
+
+echo "valid council-report.v1: $1"

--- a/skills/council/scripts/validate-output.sh
+++ b/skills/council/scripts/validate-output.sh
@@ -12,7 +12,7 @@ jq -e '
   and .schema_version == "council-report.v1"
   and (.question | text)
   and (.subject_digest | type == "string" and test("^[a-f0-9]{64}$"))
-  and ((.diversity_unsatisfied == null) or (.diversity_unsatisfied | type == "boolean"))
+  and (if has("diversity_unsatisfied") then (.diversity_unsatisfied | type == "boolean") else true end)
   and (.judges
     | type == "array" and length >= 2
     and all(.[];
@@ -20,9 +20,9 @@ jq -e '
       and (.context_id | text)
       and (.methodology | text)
       and (.judgment | text)
-      and ((.model_identity == null) or (.model_identity | text))
+      and (if has("model_identity") then (.model_identity | text) else true end)
       and (.evidence | type == "array" and length > 0 and all(.[]; text))
-      and ((.omissions == null) or (.omissions | type == "array" and all(.[]; text)))))
+      and (if has("omissions") then (.omissions | type == "array" and all(.[]; text)) else true end)))
   and ((.judges | map(.context_id) | unique | length) == (.judges | length))
   and (.synthesis | type == "object")
   and ((.synthesis | keys - ["consensus","divergence","minority","unresolved"]) | length == 0)

--- a/skills/council/scripts/validate.sh
+++ b/skills/council/scripts/validate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+skill_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+grep -q '^name: council$' "$skill_dir/SKILL.md"
+grep -Fq 'optional judgment strategy' "$skill_dir/SKILL.md"
+grep -Fq 'does not mint a verdict of any version' "$skill_dir/SKILL.md"
+test -f "$skill_dir/schemas/council-report.v1.schema.json"
+test -x "$skill_dir/scripts/validate-output.sh"
+
+if grep -Eiq 'ao (pawl|land)|git (commit|push)|br (close|update)|auto-redo' \
+  "$skill_dir/SKILL.md"; then
+  echo 'council contract contains forbidden lifecycle authority' >&2
+  exit 1
+fi
+
+echo 'council skill contract: PASS'

--- a/skills/idea-genie/SKILL.md
+++ b/skills/idea-genie/SKILL.md
@@ -95,7 +95,7 @@ challenge. Do not manufacture panel ceremony.
 
 ### Output Specification
 
-- **Artifact directory:** `.agents/ideas/<run-id>/`
+- **Artifact directory:** `.agents/scratch/ideas/<run-id>/`
 - **Filename:** `idea-challenge.json`
 - **Format:** `idea-challenge.v1` JSON with route-specific fields enforced by
   the validator

--- a/skills/postmortem/SKILL.md
+++ b/skills/postmortem/SKILL.md
@@ -27,7 +27,7 @@ context:
     exclude:
     - HISTORY
   intel_scope: full
-output_contract: 'postmortem-report.md — markdown causal analysis (causal question, pinned inputs, timeline, hypotheses, counterfactuals, unknowns, experiments)'
+output_contract: 'YYYY-MM-DD-postmortem-<topic>.md — markdown causal analysis (causal question, pinned inputs, timeline, hypotheses, counterfactuals, unknowns, experiments)'
 ---
 
 # Postmortem

--- a/skills/postmortem/SKILL.md
+++ b/skills/postmortem/SKILL.md
@@ -14,7 +14,7 @@ skill_api_version: 1
 user-invocable: true
 metadata:
   capabilities: [postmortem]
-  effects: []
+  effects: [write_postmortem_report]
   canonical_status: canonical
   disposition: keep_strategy
   tier: judgment
@@ -27,7 +27,7 @@ context:
     exclude:
     - HISTORY
   intel_scope: full
-output_contract: skills/postmortem/references/postmortem.feature
+output_contract: 'postmortem-report.md — markdown causal analysis (causal question, pinned inputs, timeline, hypotheses, counterfactuals, unknowns, experiments)'
 ---
 
 # Postmortem
@@ -88,7 +88,7 @@ is filed under correlations or unknowns, never silently promoted.
 
 ## Output Specification
 
-- **Artifact directory:** `.agents/postmortem/`.
+- **Artifact directory:** `.agents/scratch/postmortem/`.
 - **Filename convention:** `YYYY-MM-DD-postmortem-<topic>.md`.
 - **Serialization/schema format:** Markdown with causal question, pinned inputs,
   timeline, hypotheses, evidence, counterfactuals, unknowns, and experiments.

--- a/skills/premortem/SKILL.md
+++ b/skills/premortem/SKILL.md
@@ -83,7 +83,7 @@ on routine feature work.
 
 ## Boundary
 
-- Emit advisory findings, not `verdict.v2`, readiness, admission, or permission.
+- Emit advisory findings, no verdict of any version, readiness, admission, or permission.
 - Do not implement, validate the candidate, retry, repair, schedule, claim,
   change acceptance, operate Git, close work, release, or deliver.
 - Any plan edit creates a new subject for a later caller-initiated Premortem.

--- a/skills/reality-check/SKILL.md
+++ b/skills/reality-check/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   effects: [write_advisory_gap_report]
   canonical_status: canonical
   disposition: keep_strategy
-output_contract: reality-check-report.v1
+output_contract: reality-check-report.v1 JSON validated by skills/reality-check/scripts/validate-output.sh
 ---
 
 # Reality Check
@@ -58,8 +58,25 @@ is reported as an escalation gap, exactly like a missing behavior. Reality
 Check reports the escalation; the caller decides whether the ambition or the
 stated goal changes.
 
+## Output
+
+- **Artifact directory:** `.agents/scratch/reality-check/<run-id>/`.
+- **Filename:** `reality-check-report.json`.
+- **Format:** `reality-check-report.v1` JSON — the checked claim, one finding per
+  confirmed behavior, concrete gap, incomplete-evidence item, or changed
+  assumption (each with cited evidence), and, for a completion or status claim,
+  the goal-by-goal coverage disposition. It carries no `verdict`, `readiness`, or
+  `PASS` field; the validator rejects one.
+- **Validation command:**
+  `skills/reality-check/scripts/validate-output.sh <reality-check-report.json>`.
+
+If the claim cannot be tested against any observable evidence, report it as
+incomplete-evidence with the missing artifact named — never resolve an
+untestable claim as confirmed.
+
 ## Boundary
 
 Return the report to the caller. Plan may use concrete gaps to refine the
-existing bead or caller intent. Reality Check does not create work, schedule,
-claim, implement, validate, retry, or deliver.
+existing bead or caller intent. Reality Check reports observations; it does not
+mint a verdict or `PASS` of any version, create work, schedule, claim,
+implement, validate, retry, or deliver.

--- a/skills/reality-check/schemas/reality-check-report.v1.schema.json
+++ b/skills/reality-check/schemas/reality-check-report.v1.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentops.local/schemas/reality-check-report.v1.schema.json",
+  "title": "Reality Check Report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "claim", "findings"],
+  "properties": {
+    "schema_version": {"const": "reality-check-report.v1"},
+    "claim": {"type": "string", "minLength": 1},
+    "findings": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["category", "statement", "evidence"],
+        "properties": {
+          "category": {"enum": ["confirmed", "gap", "incomplete-evidence", "changed-assumption"]},
+          "statement": {"type": "string", "minLength": 1},
+          "evidence": {"type": "array", "items": {"type": "string", "minLength": 1}}
+        }
+      }
+    },
+    "coverage": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["goal", "disposition"],
+        "properties": {
+          "goal": {"type": "string", "minLength": 1},
+          "disposition": {"enum": ["confirmed", "gap", "unverifiable"]},
+          "evidence": {"type": "array", "items": {"type": "string", "minLength": 1}}
+        }
+      }
+    }
+  }
+}

--- a/skills/reality-check/schemas/reality-check-report.v1.schema.json
+++ b/skills/reality-check/schemas/reality-check-report.v1.schema.json
@@ -18,7 +18,7 @@
         "properties": {
           "category": {"enum": ["confirmed", "gap", "incomplete-evidence", "changed-assumption"]},
           "statement": {"type": "string", "minLength": 1},
-          "evidence": {"type": "array", "items": {"type": "string", "minLength": 1}}
+          "evidence": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
         }
       }
     },

--- a/skills/reality-check/scripts/validate-output.sh
+++ b/skills/reality-check/scripts/validate-output.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 || ! -f "$1" ]]; then
+  echo "usage: $0 <reality-check-report.json>" >&2
+  exit 2
+fi
+
+jq -e '
+  def text: type == "string" and length > 0;
+  ((keys - ["schema_version","claim","findings","coverage"]) | length == 0)
+  and .schema_version == "reality-check-report.v1"
+  and (.claim | text)
+  and (.findings
+    | type == "array" and length > 0
+    and all(.[];
+      ((keys - ["category","statement","evidence"]) | length == 0)
+      and (.category == "confirmed" or .category == "gap"
+        or .category == "incomplete-evidence" or .category == "changed-assumption")
+      and (.statement | text)
+      and (.evidence | type == "array" and all(.[]; text))))
+  and (if has("coverage") then
+        (.coverage
+          | type == "array"
+          and all(.[];
+            ((keys - ["goal","disposition","evidence"]) | length == 0)
+            and (.goal | text)
+            and (.disposition == "confirmed" or .disposition == "gap" or .disposition == "unverifiable")
+            and (.evidence | (. == null) or (type == "array" and all(.[]; text)))))
+      else true end)
+' "$1" >/dev/null || {
+  echo "invalid reality-check-report.v1 artifact: $1" >&2
+  exit 1
+}
+
+echo "valid reality-check-report.v1: $1"

--- a/skills/reality-check/scripts/validate-output.sh
+++ b/skills/reality-check/scripts/validate-output.sh
@@ -18,7 +18,7 @@ jq -e '
       and (.category == "confirmed" or .category == "gap"
         or .category == "incomplete-evidence" or .category == "changed-assumption")
       and (.statement | text)
-      and (.evidence | type == "array" and all(.[]; text))))
+      and (.evidence | type == "array" and length > 0 and all(.[]; text))))
   and (if has("coverage") then
         (.coverage
           | type == "array"

--- a/skills/reality-check/scripts/validate.sh
+++ b/skills/reality-check/scripts/validate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+skill_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+grep -q '^name: reality-check$' "$skill_dir/SKILL.md"
+grep -Fq 'Compare an explicit claim with observable evidence' "$skill_dir/SKILL.md"
+grep -Fq 'mint a verdict or' "$skill_dir/SKILL.md"
+test -f "$skill_dir/schemas/reality-check-report.v1.schema.json"
+test -x "$skill_dir/scripts/validate-output.sh"
+
+if grep -Eiq 'ao (pawl|land)|git (commit|push)|br (close|update)|auto-redo|next[_ -]action' \
+  "$skill_dir/SKILL.md"; then
+  echo 'reality-check contract contains forbidden lifecycle authority' >&2
+  exit 1
+fi
+
+echo 'reality-check skill contract: PASS'

--- a/tests/scripts/agentops-native-skills.bats
+++ b/tests/scripts/agentops-native-skills.bats
@@ -45,15 +45,15 @@ assert_rejects() {
 # B2.1
 @test "idea-genie duel mode emits sealed advisory evidence for Plan" {
   v="$REPO_ROOT/skills/idea-genie/scripts/validate-challenge.sh"
-  assert_accepts "$v" '{"schema_version":"idea-challenge.v1","door_class":"one-way","sealed_generation":true,"perspectives":[{"id":"P1","context_id":"c1"},{"id":"P2","context_id":"c2"}],"cross_reviews":[{"reviewer":"P1","subject":"P2","dimensions":{"evidence":"WARN"}}],"disagreements":["port ownership"],"refutations":[{"claim":"P1","attempt":"existing seam","result":"survived"}],"handoff":{"owner":"plan","artifact_dir":".agents/ideas/run-1"}}'
+  assert_accepts "$v" '{"schema_version":"idea-challenge.v1","door_class":"one-way","sealed_generation":true,"perspectives":[{"id":"P1","context_id":"c1"},{"id":"P2","context_id":"c2"}],"cross_reviews":[{"reviewer":"P1","subject":"P2","dimensions":{"evidence":"WARN"}}],"disagreements":["port ownership"],"refutations":[{"claim":"P1","attempt":"existing seam","result":"survived"}],"handoff":{"owner":"plan","artifact_dir":".agents/scratch/ideas/run-1"}}'
   assert_rejects "$v" '{"schema_version":"idea-challenge.v1","door_class":"one-way","sealed_generation":false,"perspectives":[{"id":"P1","context_id":"same"},{"id":"P2","context_id":"same"}],"cross_reviews":[],"disagreements":[],"refutations":[],"handoff":{"owner":"self-score"}}'
-  assert_rejects "$v" '{"schema_version":"idea-challenge.v1","door_class":"one-way","sealed_generation":true,"perspectives":[{"id":"P1","context_id":"c1"},{"id":"P2","context_id":"c2"}],"cross_reviews":[{"reviewer":"P1","subject":"P2","dimensions":{"evidence":"WARN"}}],"disagreements":["x"],"refutations":[{"claim":"P1","attempt":"x","result":"survived"}],"handoff":{"owner":"plan","artifact_dir":".agents/ideas/run-1"},"readiness":"PASS"}'
+  assert_rejects "$v" '{"schema_version":"idea-challenge.v1","door_class":"one-way","sealed_generation":true,"perspectives":[{"id":"P1","context_id":"c1"},{"id":"P2","context_id":"c2"}],"cross_reviews":[{"reviewer":"P1","subject":"P2","dimensions":{"evidence":"WARN"}}],"disagreements":["x"],"refutations":[{"claim":"P1","attempt":"x","result":"survived"}],"handoff":{"owner":"plan","artifact_dir":".agents/scratch/ideas/run-1"},"readiness":"PASS"}'
 }
 
 # B2.2
 @test "idea-genie duel mode routes reversible choices without NTM ceremony" {
   v="$REPO_ROOT/skills/idea-genie/scripts/validate-challenge.sh"
-  assert_accepts "$v" '{"schema_version":"idea-challenge.v1","door_class":"two-way","sealed_generation":false,"perspectives":[],"cross_reviews":[],"disagreements":[],"refutations":[],"handoff":{"owner":"plan","artifact_dir":".agents/ideas/run-2","route":"single-fresh-context"},"requires_ntm":false}'
+  assert_accepts "$v" '{"schema_version":"idea-challenge.v1","door_class":"two-way","sealed_generation":false,"perspectives":[],"cross_reviews":[],"disagreements":[],"refutations":[],"handoff":{"owner":"plan","artifact_dir":".agents/scratch/ideas/run-2","route":"single-fresh-context"},"requires_ntm":false}'
   assert_rejects "$v" '{"schema_version":"idea-challenge.v1","door_class":"two-way","sealed_generation":true,"perspectives":[],"cross_reviews":[],"disagreements":[],"refutations":[],"handoff":{"owner":"ntm"},"requires_ntm":true}'
 }
 


### PR DESCRIPTION
## Summary

Wave W3a of the skill-overhaul reboot (`age-skill-overhaul-reboot-sjv7v.4`, judgment half) — six judgment skills, every checklist item verified against the live tree first.

- **council** — the dangling `council-report.v1` contract is now real: skill-local schema + jq `validate-output.sh` (rejects smuggled verdict/readiness fields, single-judge panels, empty findings) + validator contract guard; boundary broadened to "does not mint a verdict of any version"; negative trigger, judge-timeout failure semantics, output location under `.agents/scratch/council/`.
- **reality-check** — same treatment for the dangling `reality-check-report.v1`; adds no-verdict boundary and untestable-claim failure line.
- **postmortem** — `output_contract` now names the real markdown report (was a `.feature` path); `effects: []` → `[write_postmortem_report]`; artifact dir moved to the ADR-0016 closed set (`.agents/scratch/postmortem/`).
- **idea-genie** — artifact dir moved to `.agents/scratch/ideas/<run-id>/` with bats fixtures updated.
- **premortem** — boundary fixed to deny any verdict version.
- **scope** — zero changes: verified already-tight; its checklist enhances dispositioned reject/defer with reasons.

Notable: the checklist's cross-cutting "live loop emits verdict.v3" claim was **verified stale** (main is verdict.v2; no validate_v3.py exists) and rejected — the reboot's verify-before-edit rule doing its job.

Ledger (17 items: fixed 5 / applied 5 / rejected 4 / deferred 3, zero silent drops): `docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w3a.md`.

## Validation

- 23/23 bats (liveness + anti-spiral + native-skills fixtures); output validators smoke-tested both directions; contract guards strip-tested
- 49/49 frontmatter; `regen-all.sh --check` clean; `check-skill-python-ratchet.sh` PASS (no new Python — validators are jq/shell); token budgets green
- Cross-family (Codex) review in flight; two-round ceiling per plan

Tracker: `age-skill-overhaul-reboot-sjv7v.4` (closes with W3b)