### PR TITLE
W5 evolution wave: honest effects, closed-set artifact dirs, provenance decay enforced

### DIFF
--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -52,7 +52,7 @@
 | `ms` | execution | `keep_specialist` | - | `ms` | - |
 | `ntm` | execution | `keep_optional_adapter` | - | `ntm` | - |
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
-| `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | - |
+| `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | `write_pattern_evidence` |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
 | `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
@@ -73,7 +73,7 @@
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
 | `test` | execution | `keep_specialist` | - | `test` | - |
-| `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | - |
+| `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
 | `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -52,7 +52,7 @@
 | `ms` | execution | `keep_specialist` | - | `ms` | - |
 | `ntm` | execution | `keep_optional_adapter` | - | `ntm` | - |
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
-| `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | - |
+| `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | `write_pattern_evidence` |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
 | `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
@@ -73,7 +73,7 @@
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
 | `test` | execution | `keep_specialist` | - | `test` | - |
-| `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | - |
+| `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
 | `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |

--- a/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w5.md
+++ b/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w5.md
@@ -1,0 +1,192 @@
+# Wave W5 report — evolution
+
+Bead: `age-skill-overhaul-reboot-sjv7v.6`. Branch: `claude/sor-w5-evolution`.
+Skills: `learn`, `operationalize`, `pattern-mining`, `toil-mining`.
+
+Every checklist item for these four slugs (`checklists/core-12.md` → `learn`;
+`checklists/outcomes-12.md` → `operationalize`, `pattern-mining`, `toil-mining`)
+is dispositioned below. Each was verified against the live tree first; the
+`Verified` line records what the live file actually showed.
+
+Evolution-skill doctrine enforced across the group: observations preserve
+source verdict/history lineage; recurrence, sample size, uncertainty, and decay
+stay visible; proposals are advisory and cannot self-promote into skills,
+gates, tracker work, or campaign choices; any adoption is a later
+caller-selected step. All artifact writes now land in the ADR-0016 closed set
+(`.agents/scratch/<skill>/`).
+
+## learn
+
+- **`scripts/validate.sh:6` false-passing `!`-negation guard** `[defect]` —
+  **rejected (already fixed on main, PR #998).**
+  Verified: line 6 is already `if grep -Eiq 'receipt|plan_impact|next_action|retry|delivery|closure' … ; then … exit 1; fi`,
+  not the inert `! grep` form; `SKILL.md:35` already reads "mint lifecycle
+  artifacts" (not "emit a lifecycle receipt"). `skill-validator-liveness.bats`
+  test 5 (`learn validator fails on seeded forbidden token`) pins the repair
+  and is green. No action — deliberately not undone.
+
+- **`SKILL.md:44-47` cites two dead verdict digests** `[defect]` — **fixed.**
+  Verified: `.agents/ao/verdicts/` does not exist in this tree, so
+  `b6e759dd…cb6a` and `e9b6cdb8…37b9` resolve 0/2 — the skill was violating its
+  own "dead citations get pruned" decay rule. Pruned both concrete digest
+  citations while keeping the teaching point (a subject destroyed by a mutating
+  check mid-validation teaches a more durable rule than the PASS that follows).
+  The general decay rule still names `.agents/ao/verdicts/` as the resolution
+  target, now phrased as a rule rather than a dead example.
+
+- **v2 vocabulary should be v3** `[defect]` — **rejected (stale).**
+  Verified: `schemas/` carries `verdict.v2.schema.json` only; no `verdict.v3`,
+  `validate_v3.py`, or `kernel_v3.py` exists on this tree. `consumes: [verdict.v2]`
+  is correct; the v3 claim is seed-era.
+
+- **No scenario coverage (`check-scenario-coverage.sh` 0/2)** `[enhance]` —
+  **deferred (allowlisted, non-blocking).**
+  Verified: `skills/learn/references/learn.feature` is listed in
+  `scripts/.scenario-linkage-allow` (documentation-only by design). The two
+  scenarios ("missing Learn never changes a verdict", "learning remains
+  advisory") are runtime-behavioral, not mechanically replayable in repo CI;
+  wiring an executing test is out of lean-wave scope.
+
+- **Effects honesty (not in checklist; wave authority/effects tightening)** —
+  **applied.** `effects: [write_advisory_observations]` was declared with no
+  destination in the body. Added an honest optional-write clause: when the
+  caller asks for a durable artifact, write observations under
+  `.agents/scratch/learn/` and return the path; otherwise return inline. The
+  write is advisory, TTL'd, never a source of record, and its absence never
+  changes candidate validity.
+
+## operationalize
+
+- **P1-OP-V1 `produces: [operationalization-proposal.v1]` names a versioned
+  contract with no schema/validator** `[defect]` — **fixed (dropped the
+  suffix).** Verified: no `operationalization*` schema or validator exists
+  anywhere in the tree (package is a single `SKILL.md`). Dropped the `.v1`
+  suffix — `produces: [operationalization-proposal]`, `output_contract:
+  advisory operationalization proposal` (prose contract, mirroring `learn`).
+  The `.v1` promised a versioned contract that does not exist; a full JSON
+  schema + validator is disproportionate for a free-form advisory proposal and
+  would need new code the no-new-`.py` constraint blocks.
+
+- **P1-OP-RETURN `effects: [write_advisory_proposal]` vs body "Return the
+  proposal to the caller"** `[enhance]` — **fixed (resolved the boundary).**
+  Verified: step 6 said return-to-caller while the effect declared a write —
+  the mutation boundary was unknowable. Resolved to an explicit conditional
+  write: return inline by default; when the caller asks for a durable artifact,
+  write under `.agents/scratch/operationalize/` first and return the path. This
+  makes `write_advisory_proposal` honest and matches `toil-mining`'s
+  conditional pattern.
+
+- **No `context:` block; `user-invocable` at top level while metadata is
+  nested** `[enhance]` — **rejected (stale) / deferred.**
+  Verified: top-level `user-invocable` is the corpus convention — every skill
+  (`learn`, `pattern-mining`, `toil-mining`, and the wider corpus) places it at
+  top level, not under `metadata`; frontmatter validation is 49/49 green.
+  "Normalize" is a non-issue. The `context:` block is optional (`learn` also
+  omits it); adding one changes no behavior and is deferred as low-value.
+
+- **Boundary tightening (wave authority dimension)** — **applied.** Extended the
+  Boundary to state the proposal is advisory and cannot promote itself; adoption
+  into a skill, check, reference, or workflow is a separate caller-selected step
+  (`skill-builder`, `workflow-builder`, or a fresh RPI).
+
+## pattern-mining
+
+- **P0-EFFECTS `effects: []` is false** `[defect]` — **fixed.**
+  Verified: the Output Specification writes `pattern-mining.json` to an artifact
+  directory. Declared `effects: [write_pattern_evidence]`.
+
+- **P1-LAYOUT `.agents/patterns/` violates the closed layout** `[defect]` —
+  **fixed.** Verified: `.agents/patterns/<run-id>/` is outside the ADR-0016
+  closed set (`ao/`, `scratch/`, `projections/`). Relocated to
+  `.agents/scratch/pattern-mining/<run-id>/`. Only `SKILL.md` referenced the old
+  path inside `skills/`; `validate-output.sh` validates JSON content, not the
+  path, and `agentops-native-skills.bats` fixtures use inline exemplars — both
+  unaffected (bats tests 7-8 green).
+
+- **`jq` undeclared, fails closed silently** `[enhance]` — **fixed.**
+  Verified: `validate-output.sh` uses `jq -e`; a missing `jq` (exit 127) was
+  caught by the trailing `|| { echo "invalid …"; }` and misreported as an
+  invalid artifact. Added an explicit `command -v jq` guard emitting a clear
+  "requires jq" message and `exit 2`. `shellcheck -S warning` clean; no
+  `!`-line-start negation.
+
+- **Register the validator in `standards`' canonical-owners table** `[enhance]`
+  — **deferred (cross-skill).** Verified: this edits the `standards` skill
+  (out of W5 scope) and its owners table; per the "touches another skill →
+  defer" constraint it belongs to `standards`' own wave (W3/W8). The audit also
+  labels pattern-mining "best-validated; declined further behavioral work."
+
+## toil-mining
+
+- **P0-EFFECTS `effects: []` is false (conditional write)** `[defect]` —
+  **fixed.** Verified: the Output section conditionally writes a candidates
+  file. Declared `effects: [write_toil_candidates]`.
+
+- **P1-TOIL-OUT three-way output mismatch** `[defect]` — **fixed.**
+  Verified: `produces: [result.json]` (never written) vs `output_contract`
+  (`.agents/toil-mining/`) vs the body's inline-by-default `candidates.md`.
+  Reconciled to actual behavior: `produces: [toil-candidates-report]`;
+  `output_contract` now reads "ranked toil evidence report, inline by default;
+  optional artifact under .agents/scratch/toil-mining/". (`result.json` in the
+  helper example is the helper's stdout, not the skill's deliverable — left
+  as-is.)
+
+- **P1-LAYOUT `.agents/toil-mining/` violates the closed layout** `[defect]` —
+  **fixed.** Relocated the optional artifact to
+  `.agents/scratch/toil-mining/YYYY-MM-DD-candidates.md` (output_contract + body).
+
+- **P2-INVOCABLE `user-invocable: false` while the description advertises
+  triggers** `[defect]` — **fixed.** Verified: the description carries explicit
+  caller triggers ("mine toil", "find repeated operational work") yet
+  `user-invocable: false`. Set `user-invocable: true` — matching the advertised
+  triggers and the sibling analysis skills. Nothing pins it false (no test or
+  gate references it; `registry.json` does not carry the field). Regenerated
+  projections reflect `user_invocable: true`.
+
+- **`audit.sh` WARN (`constraints-frontloaded`, `quality-rubric`)** `[defect]`
+  — **fixed.** Verified: SKILL.md (>100 lines) had no `## Constraints` heading
+  and no `## Quality` rubric, tripping both WARNs. Added a frontloaded
+  `## Constraints` section (four rationale-carrying bullets — read-only, no work
+  creation, measured-not-remembered, observations-vs-recommendations) and a
+  `## Quality` section (three bullets). `audit.sh` verdict is now PASS with 0
+  warns; `rationale-present` and `references-modularization` stay green (140
+  lines, well under the 250 kernel cap).
+
+- **Ranking contract is prose-only; add a fixture-based ranking validator**
+  `[defect]` — **deferred (out of lean scope + blocked by no-new-`.py`).**
+  Verified: clustering equivalent actions and scoring `frequency × cost ×
+  error-proneness` are caller judgment, not mechanically extractable; the helper
+  (`recent_human.py`) is deliberately retrieval-only and the skill discloses this
+  in its own `not_checked`. A ranking validator would require new scoring code
+  (the no-new-`.py`-under-`skills/` gate blocks it) and would replicate the
+  judgment the skill exists to exercise. The existing `validate.sh` still runs
+  the deterministic extraction unit tests. Recorded for a possible Go-hosted
+  follow-up.
+
+## Disposition counts
+
+- **learn:** 1 fixed, 2 rejected, 1 deferred, +1 out-of-checklist tightening applied.
+- **operationalize:** 2 fixed, 1 rejected/deferred, +1 boundary tightening applied.
+- **pattern-mining:** 3 fixed, 1 deferred.
+- **toil-mining:** 5 fixed, 1 deferred.
+- **Group totals:** 11 defect/enhance items fixed, 3 rejected-as-stale/moot,
+  4 deferred-with-reason, 2 additional in-place tightenings.
+
+## Gate results (one verification pass)
+
+- Per-skill validators: `learn`, `toil-mining` PASS; `pattern-mining`
+  `validate-output.sh` accepts a valid `promote` fixture; `operationalize` has
+  no validator (single-file package, expected).
+- `scripts/validate-skill-frontmatter.sh` — 49/49 ok (the pre-existing
+  `skill-builder` `context_rel` warning is unrelated).
+- `scripts/check-skill-python-ratchet.sh` — PASS (no new Python; 24
+  grandfathered).
+- `bats skill-validator-liveness.bats` (9/9), `anti-spiral-contract.bats`
+  (6/6), `agentops-native-skills.bats` (8/8) — all green.
+- `scripts/regen-all.sh` then `--check` — all generated projections current.
+- `scripts/test-token-budgets.sh` — not present in this tree (skipped).
+- `shellcheck -S warning` on the changed `pattern-mining/scripts/validate-output.sh`
+  — clean.
+
+The wave-level fresh cross-family review is the PR-acceptance step (owned by the
+orchestrator), not run inside this scoped implementation pass.

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -104,7 +104,7 @@
 | `ntm` | produces | `ntm-robot-state` |
 | `ntm` | produces | `agent-worker-transcript` |
 | `operationalize` | consumes | `evidence-backed-expertise` |
-| `operationalize` | produces | `operationalization-proposal.v1` |
+| `operationalize` | produces | `operationalization-proposal` |
 | `pattern-mining` | consumes | `repo-context` |
 | `pattern-mining` | consumes | `task-question` |
 | `pattern-mining` | produces | `pattern-mining.v1` |
@@ -139,7 +139,7 @@
 | `test` | consumes | `standards` |
 | `test` | consumes | `repo-context` |
 | `test` | produces | `result.json` |
-| `toil-mining` | produces | `result.json` |
+| `toil-mining` | produces | `toil-candidates-report` |
 | `using-gc` | consumes | `explicit-packets` |
 | `using-gc` | produces | `gas-city-runtime-evidence` |
 | `validate` | consumes | `subject-manifest.v1` |

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -46,7 +46,7 @@
 | `ms` | execution | `keep_specialist` | - | `ms` | - |
 | `ntm` | execution | `keep_optional_adapter` | - | `ntm` | - |
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
-| `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | - |
+| `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | `write_pattern_evidence` |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
 | `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
@@ -67,7 +67,7 @@
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
 | `test` | execution | `keep_specialist` | - | `test` | - |
-| `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | - |
+| `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
 | `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |

--- a/images/gemini/skills/learn/SKILL.md
+++ b/images/gemini/skills/learn/SKILL.md
@@ -41,12 +41,16 @@ size, and stop at advisory evidence.
 
 Overweight failures: a `NOT_PROVEN` or `FAIL` verdict carries more teaching
 value than a PASS, because it names a rule the loop lacked. Harvest kernels
-from failed lanes first — the 2026-07-15 `NOT_PROVEN`
-(`.agents/ao/verdicts/sha256/b6e759dd...cb6a`, a subject destroyed by a
-mutating check mid-validation) produced more durable rules than the PASS
-(`e9b6cdb8...37b9`) that followed it.
+from failed lanes first — a subject destroyed by a mutating check
+mid-validation teaches a more durable rule than the PASS that follows it.
 
 Prune for provenance decay: every cited artifact must still resolve — the
-file exists or the verdict digest is present in `.agents/ao/verdicts/`. Dead
-citations get pruned rather than paraphrased, and confidence in a lesson that
-has not been reproduced since its source decayed goes down, not sideways.
+file exists or the verdict digest is present under `.agents/ao/verdicts/`. A
+citation that no longer resolves gets pruned rather than paraphrased, and
+confidence in a lesson that has not been reproduced since its source decayed
+goes down, not sideways.
+
+When the caller asks for a durable artifact, write the observations under
+`.agents/scratch/learn/` and return the path; otherwise return them inline.
+The write is advisory and TTL'd — it is never a source of record, and its
+absence never changes whether a candidate is valid.

--- a/images/gemini/skills/learn/SKILL.md
+++ b/images/gemini/skills/learn/SKILL.md
@@ -41,8 +41,9 @@ size, and stop at advisory evidence.
 
 Overweight failures: a `NOT_PROVEN` or `FAIL` verdict carries more teaching
 value than a PASS, because it names a rule the loop lacked. Harvest kernels
-from failed lanes first — a subject destroyed by a mutating check
-mid-validation teaches a more durable rule than the PASS that follows it.
+from failed lanes first — the canonical example is the mutating-check
+quarantine in `skills/validate/SKILL.md`, a durable rule minted from a
+`NOT_PROVEN`-then-`PASS` verdict pair.
 
 Prune for provenance decay: every cited artifact must still resolve — the
 file exists or the verdict digest is present under `.agents/ao/verdicts/`. A

--- a/images/gemini/skills/operationalize/SKILL.md
+++ b/images/gemini/skills/operationalize/SKILL.md
@@ -4,7 +4,7 @@ description: 'Distill repeated, evidence-backed expertise into a proposed skill,
 practices: [continuous-learning, design-by-contract]
 hexagonal_role: supporting
 consumes: [evidence-backed-expertise]
-produces: [operationalization-proposal.v1]
+produces: [operationalization-proposal]
 context_rel:
 - kind: supplier-to
   with: skill-builder
@@ -19,7 +19,7 @@ metadata:
   effects: [write_advisory_proposal]
   canonical_status: canonical
   disposition: keep_specialist
-output_contract: operationalization-proposal.v1
+output_contract: advisory operationalization proposal
 ---
 
 # Operationalize
@@ -36,7 +36,10 @@ Turn repeated, cited expertise into a proposal for a reusable artifact.
 4. Search existing capabilities and prefer extension over duplication.
 5. Provide an activation example, holdout/negative example, owner, and rollback
    or deletion condition.
-6. Return the proposal to the caller or an authoring specialist.
+6. Return the proposal inline to the caller or an authoring specialist. When
+   the caller asks for a durable artifact, write it under
+   `.agents/scratch/operationalize/` first and return the path; the proposal
+   is advisory either way.
 
 ## Three-instance floor
 
@@ -71,4 +74,8 @@ matches what actually happened, instead of trusting the abstraction.
 ## Boundary
 
 Operationalize does not create tracker work, promote policy, start a factory,
-validate its own output, or control another invocation.
+validate its own output, or control another invocation. The proposal is
+advisory: adopting it into a skill, deterministic check, reference, or
+workflow is a separate, caller-selected step — `skill-builder`,
+`workflow-builder`, or a fresh RPI — never performed here. The proposal
+cannot promote itself.

--- a/images/gemini/skills/pattern-mining/SKILL.md
+++ b/images/gemini/skills/pattern-mining/SKILL.md
@@ -30,7 +30,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [pattern_mining]
-  effects: []
+  effects: [write_pattern_evidence]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
@@ -115,7 +115,7 @@ evidence into architecture the same way skipping the holdout would.
 
 ## Output Specification
 
-- **Artifact directory:** `.agents/patterns/<run-id>/`
+- **Artifact directory:** `.agents/scratch/pattern-mining/<run-id>/`
 - **Filename convention:** `pattern-mining.json`
 - **Format:** `pattern-mining.v1` JSON containing the outcome, distinct
   exemplars, invariants, variations, incidental details, holdout result,

--- a/images/gemini/skills/toil-mining/SKILL.md
+++ b/images/gemini/skills/toil-mining/SKILL.md
@@ -7,12 +7,12 @@ practices:
 hexagonal_role: supporting
 consumes: []
 produces:
-- result.json
+- toil-candidates-report
 context_rel:
 - kind: supplier-to
   with: automation-shape-routing
 skill_api_version: 1
-user-invocable: false
+user-invocable: true
 context:
   window: fork
   intent:
@@ -23,19 +23,30 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [toil_mining]
-  effects: []
+  effects: [write_toil_candidates]
   canonical_status: canonical
   disposition: keep_specialist
   tier: meta
   dependencies: []
   stability: experimental
-output_contract: ranked evidence report under .agents/toil-mining/
+output_contract: ranked toil evidence report, inline by default; optional artifact under .agents/scratch/toil-mining/
 ---
 # Toil Mining — rank repeated friction
 
 Mine explicitly supplied session, shell, RTK, or CASS history without modifying
 the sources. The result is evidence for a caller; this skill does not file work,
 schedule automation, or mutate a tracker.
+
+## Constraints
+
+- Read-only over the supplied sources, because the skill gathers evidence and
+  must never become a mutation lane.
+- No work creation: it never files a tracker item, schedules automation, or
+  names an owner, because those are caller decisions the evidence informs.
+- Measured, not remembered: every count, cost, and error rate is read from the
+  supplied history, so recency and salience cannot masquerade as frequency.
+- Observations stay separate from recommendations, so a caller can re-weigh the
+  ranking without inheriting an unstated conclusion.
 
 ## Procedure
 
@@ -116,10 +127,19 @@ retrieval/report-only.
 
 ## Output
 
-Write `.agents/toil-mining/YYYY-MM-DD-candidates.md` only when the caller asks for
-a local artifact; otherwise return the report inline. Include checked and
+Write `.agents/scratch/toil-mining/YYYY-MM-DD-candidates.md` only when the caller
+asks for a local artifact; otherwise return the report inline. Include checked and
 not-checked sources. Do not include owners, priorities, claims, queues, or a next
 action.
+
+## Quality
+
+- Every ranked candidate shows its measured frequency, cost, and
+  error-proneness inputs beside the composite score.
+- Sources are cited and resolvable; a factor the history cannot support is
+  reported at the floor, never guessed at the midpoint.
+- Observations and recommendations stay separate, and the report names both its
+  checked and not-checked sources.
 
 ## References
 

--- a/registry.json
+++ b/registry.json
@@ -957,7 +957,9 @@
           "pattern_mining"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "write_pattern_evidence"
+        ],
         "has_references": true,
         "has_skill_md": true,
         "name": "pattern-mining",
@@ -1252,7 +1254,9 @@
           "toil_mining"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "write_toil_candidates"
+        ],
         "has_references": false,
         "has_skill_md": true,
         "name": "toil-mining",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -453,8 +453,8 @@
     {
       "name": "learn",
       "source_skill": "skills/learn",
-      "source_hash": "0a6d4e2c79acf1a7de1fd99def116ce7409ad45510cacc2bee5948f2223e6368",
-      "generated_hash": "bc43e0a2cfc0f22838d594eed769e24e0f582b31eb8726d07aa4fed6cfb9b457"
+      "source_hash": "53067b9717740db5e7b7c4f116e5c728f48893556789020c602a02a53723683c",
+      "generated_hash": "2cdb8ec214c209920dd724a2efd9dc5b2889835beb90e6490f315a69a5a22813"
     },
     {
       "name": "ms",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -453,8 +453,8 @@
     {
       "name": "learn",
       "source_skill": "skills/learn",
-      "source_hash": "c9311e708794759b667e19ce56701ceaa2ca1817fdcedcba3d5e7fb0b53f3f79",
-      "generated_hash": "d57ad13358d144376d93c7ef5cd4e72f52fea9ad4fa2966380e21ccf56b7e5fa"
+      "source_hash": "0a6d4e2c79acf1a7de1fd99def116ce7409ad45510cacc2bee5948f2223e6368",
+      "generated_hash": "bc43e0a2cfc0f22838d594eed769e24e0f582b31eb8726d07aa4fed6cfb9b457"
     },
     {
       "name": "ms",
@@ -471,14 +471,14 @@
     {
       "name": "operationalize",
       "source_skill": "skills/operationalize",
-      "source_hash": "6d7181d96cf5b1c41db7887c3989328b89f114705d2e4e51843b96c516ba5923",
-      "generated_hash": "b8c4754c0650125d304fc4bedbd138aee2d33f6b2e5625ef182008ddae606ecd"
+      "source_hash": "29c0f55f0cf618277fb5c039e2b2d4dbfc7a9e9912537941535cf2b137f16b21",
+      "generated_hash": "8527b5dc86bf5de07703bc355e6c695f3fef9b949a9d94e5a5c70e59e7c61cba"
     },
     {
       "name": "pattern-mining",
       "source_skill": "skills/pattern-mining",
-      "source_hash": "85f75016516098dcc5b269d6bfc89ac3097edd18feef179aa15f814c95a42b32",
-      "generated_hash": "c86c60cc26b2da475799b89d437283f0bffdab0439b9d193aee00b764224c5e0"
+      "source_hash": "b35118568b471c41e0a9b68e8aedb0491553ba26fc348014f52e4a0939e531b5",
+      "generated_hash": "ebea87d16f82ab1699283479826ab0d427d56b2ebd1f920fbb79660e06cb8769"
     },
     {
       "name": "plan",
@@ -603,8 +603,8 @@
     {
       "name": "toil-mining",
       "source_skill": "skills/toil-mining",
-      "source_hash": "1c9893f35c98c1f498837bae08e66f6b268da0e7ea5d3239844f7ba969158448",
-      "generated_hash": "a0da070a0196ca49caeff2c0d6a0d86b1066c8a017f5bf15b2833b5dacdf53a5"
+      "source_hash": "a95c554be75d0791eb71bad60bee508807d50af96006480d5bbface2611a8691",
+      "generated_hash": "11d4272652686c2da5ff11e15e510f5e56f30e5fc3f9dd2414dced0a00055f12"
     },
     {
       "name": "using-gc",

--- a/skills-codex/learn/.agentops-generated.json
+++ b/skills-codex/learn/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/learn",
   "layout": "modular",
-  "source_hash": "c9311e708794759b667e19ce56701ceaa2ca1817fdcedcba3d5e7fb0b53f3f79",
-  "generated_hash": "d57ad13358d144376d93c7ef5cd4e72f52fea9ad4fa2966380e21ccf56b7e5fa"
+  "source_hash": "0a6d4e2c79acf1a7de1fd99def116ce7409ad45510cacc2bee5948f2223e6368",
+  "generated_hash": "bc43e0a2cfc0f22838d594eed769e24e0f582b31eb8726d07aa4fed6cfb9b457"
 }

--- a/skills-codex/learn/.agentops-generated.json
+++ b/skills-codex/learn/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/learn",
   "layout": "modular",
-  "source_hash": "0a6d4e2c79acf1a7de1fd99def116ce7409ad45510cacc2bee5948f2223e6368",
-  "generated_hash": "bc43e0a2cfc0f22838d594eed769e24e0f582b31eb8726d07aa4fed6cfb9b457"
+  "source_hash": "53067b9717740db5e7b7c4f116e5c728f48893556789020c602a02a53723683c",
+  "generated_hash": "2cdb8ec214c209920dd724a2efd9dc5b2889835beb90e6490f315a69a5a22813"
 }

--- a/skills-codex/learn/SKILL.md
+++ b/skills-codex/learn/SKILL.md
@@ -18,12 +18,16 @@ size, and stop at advisory evidence.
 
 Overweight failures: a `NOT_PROVEN` or `FAIL` verdict carries more teaching
 value than a PASS, because it names a rule the loop lacked. Harvest kernels
-from failed lanes first — the 2026-07-15 `NOT_PROVEN`
-(`.agents/ao/verdicts/sha256/b6e759dd...cb6a`, a subject destroyed by a
-mutating check mid-validation) produced more durable rules than the PASS
-(`e9b6cdb8...37b9`) that followed it.
+from failed lanes first — a subject destroyed by a mutating check
+mid-validation teaches a more durable rule than the PASS that follows it.
 
 Prune for provenance decay: every cited artifact must still resolve — the
-file exists or the verdict digest is present in `.agents/ao/verdicts/`. Dead
-citations get pruned rather than paraphrased, and confidence in a lesson that
-has not been reproduced since its source decayed goes down, not sideways.
+file exists or the verdict digest is present under `.agents/ao/verdicts/`. A
+citation that no longer resolves gets pruned rather than paraphrased, and
+confidence in a lesson that has not been reproduced since its source decayed
+goes down, not sideways.
+
+When the caller asks for a durable artifact, write the observations under
+`.agents/scratch/learn/` and return the path; otherwise return them inline.
+The write is advisory and TTL'd — it is never a source of record, and its
+absence never changes whether a candidate is valid.

--- a/skills-codex/learn/SKILL.md
+++ b/skills-codex/learn/SKILL.md
@@ -18,8 +18,9 @@ size, and stop at advisory evidence.
 
 Overweight failures: a `NOT_PROVEN` or `FAIL` verdict carries more teaching
 value than a PASS, because it names a rule the loop lacked. Harvest kernels
-from failed lanes first — a subject destroyed by a mutating check
-mid-validation teaches a more durable rule than the PASS that follows it.
+from failed lanes first — the canonical example is the mutating-check
+quarantine in `skills/validate/SKILL.md`, a durable rule minted from a
+`NOT_PROVEN`-then-`PASS` verdict pair.
 
 Prune for provenance decay: every cited artifact must still resolve — the
 file exists or the verdict digest is present under `.agents/ao/verdicts/`. A

--- a/skills-codex/operationalize/.agentops-generated.json
+++ b/skills-codex/operationalize/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/operationalize",
   "layout": "modular",
-  "source_hash": "6d7181d96cf5b1c41db7887c3989328b89f114705d2e4e51843b96c516ba5923",
-  "generated_hash": "b8c4754c0650125d304fc4bedbd138aee2d33f6b2e5625ef182008ddae606ecd"
+  "source_hash": "29c0f55f0cf618277fb5c039e2b2d4dbfc7a9e9912537941535cf2b137f16b21",
+  "generated_hash": "8527b5dc86bf5de07703bc355e6c695f3fef9b949a9d94e5a5c70e59e7c61cba"
 }

--- a/skills-codex/operationalize/SKILL.md
+++ b/skills-codex/operationalize/SKILL.md
@@ -16,7 +16,10 @@ Turn repeated, cited expertise into a proposal for a reusable artifact.
 4. Search existing capabilities and prefer extension over duplication.
 5. Provide an activation example, holdout/negative example, owner, and rollback
    or deletion condition.
-6. Return the proposal to the caller or an authoring specialist.
+6. Return the proposal inline to the caller or an authoring specialist. When
+   the caller asks for a durable artifact, write it under
+   `.agents/scratch/operationalize/` first and return the path; the proposal
+   is advisory either way.
 
 ## Three-instance floor
 
@@ -51,4 +54,8 @@ matches what actually happened, instead of trusting the abstraction.
 ## Boundary
 
 Operationalize does not create tracker work, promote policy, start a factory,
-validate its own output, or control another invocation.
+validate its own output, or control another invocation. The proposal is
+advisory: adopting it into a skill, deterministic check, reference, or
+workflow is a separate, caller-selected step — `skill-builder`,
+`workflow-builder`, or a fresh RPI — never performed here. The proposal
+cannot promote itself.

--- a/skills-codex/pattern-mining/.agentops-generated.json
+++ b/skills-codex/pattern-mining/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/pattern-mining",
   "layout": "modular",
-  "source_hash": "85f75016516098dcc5b269d6bfc89ac3097edd18feef179aa15f814c95a42b32",
-  "generated_hash": "c86c60cc26b2da475799b89d437283f0bffdab0439b9d193aee00b764224c5e0"
+  "source_hash": "b35118568b471c41e0a9b68e8aedb0491553ba26fc348014f52e4a0939e531b5",
+  "generated_hash": "ebea87d16f82ab1699283479826ab0d427d56b2ebd1f920fbb79660e06cb8769"
 }

--- a/skills-codex/pattern-mining/SKILL.md
+++ b/skills-codex/pattern-mining/SKILL.md
@@ -79,7 +79,7 @@ evidence into architecture the same way skipping the holdout would.
 
 ## Output Specification
 
-- **Artifact directory:** `.agents/patterns/<run-id>/`
+- **Artifact directory:** `.agents/scratch/pattern-mining/<run-id>/`
 - **Filename convention:** `pattern-mining.json`
 - **Format:** `pattern-mining.v1` JSON containing the outcome, distinct
   exemplars, invariants, variations, incidental details, holdout result,

--- a/skills-codex/pattern-mining/scripts/validate-output.sh
+++ b/skills-codex/pattern-mining/scripts/validate-output.sh
@@ -6,6 +6,11 @@ if [[ $# -ne 1 || ! -f "$1" ]]; then
   exit 2
 fi
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "pattern-mining validator requires jq, which is not on PATH" >&2
+  exit 2
+fi
+
 jq -e '
   def text: type == "string" and length > 0;
   . as $result

--- a/skills-codex/toil-mining/.agentops-generated.json
+++ b/skills-codex/toil-mining/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/toil-mining",
   "layout": "modular",
-  "source_hash": "1c9893f35c98c1f498837bae08e66f6b268da0e7ea5d3239844f7ba969158448",
-  "generated_hash": "a0da070a0196ca49caeff2c0d6a0d86b1066c8a017f5bf15b2833b5dacdf53a5"
+  "source_hash": "a95c554be75d0791eb71bad60bee508807d50af96006480d5bbface2611a8691",
+  "generated_hash": "11d4272652686c2da5ff11e15e510f5e56f30e5fc3f9dd2414dced0a00055f12"
 }

--- a/skills-codex/toil-mining/SKILL.md
+++ b/skills-codex/toil-mining/SKILL.md
@@ -8,6 +8,17 @@ Mine explicitly supplied session, shell, RTK, or CASS history without modifying
 the sources. The result is evidence for a caller; this skill does not file work,
 schedule automation, or mutate a tracker.
 
+## Constraints
+
+- Read-only over the supplied sources, because the skill gathers evidence and
+  must never become a mutation lane.
+- No work creation: it never files a tracker item, schedules automation, or
+  names an owner, because those are caller decisions the evidence informs.
+- Measured, not remembered: every count, cost, and error rate is read from the
+  supplied history, so recency and salience cannot masquerade as frequency.
+- Observations stay separate from recommendations, so a caller can re-weigh the
+  ranking without inheriting an unstated conclusion.
+
 ## Procedure
 
 1. Record the input sources, time window, filters, and query.
@@ -87,10 +98,19 @@ retrieval/report-only.
 
 ## Output
 
-Write `.agents/toil-mining/YYYY-MM-DD-candidates.md` only when the caller asks for
-a local artifact; otherwise return the report inline. Include checked and
+Write `.agents/scratch/toil-mining/YYYY-MM-DD-candidates.md` only when the caller
+asks for a local artifact; otherwise return the report inline. Include checked and
 not-checked sources. Do not include owners, priorities, claims, queues, or a next
 action.
+
+## Quality
+
+- Every ranked candidate shows its measured frequency, cost, and
+  error-proneness inputs beside the composite score.
+- Sources are cited and resolvable; a factor the history cannot support is
+  reported at the floor, never guessed at the midpoint.
+- Observations and recommendations stay separate, and the report names both its
+  checked and not-checked sources.
 
 ## References
 

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -66,7 +66,7 @@
 | `ms` | execution | `keep_specialist` | - | `ms` | - |
 | `ntm` | execution | `keep_optional_adapter` | - | `ntm` | - |
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
-| `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | - |
+| `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | `write_pattern_evidence` |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
 | `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
@@ -87,7 +87,7 @@
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
 | `test` | execution | `keep_specialist` | - | `test` | - |
-| `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | - |
+| `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
 | `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -780,7 +780,7 @@
         "design-by-contract"
       ],
       "produces": [
-        "operationalization-proposal.v1"
+        "operationalization-proposal"
       ],
       "references_count": 0,
       "tier": "meta",
@@ -813,7 +813,9 @@
       "dependencies": [],
       "description": "Test repeated implementation shapes against independent exemplars and a holdout before routing an earned abstraction. Triggers: \"mine a recurring code pattern\", \"is this abstraction earned\", \"extract invariants from implementations\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "write_pattern_evidence"
+      ],
       "graph_root": false,
       "hexagonal_role": "supporting",
       "name": "pattern-mining",
@@ -1451,7 +1453,9 @@
       "dependencies": [],
       "description": "Mine caller-supplied usage history for repeated toil and emit ranked evidence. Triggers: \"mine toil\", \"find repeated operational work\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "write_toil_candidates"
+      ],
       "graph_root": false,
       "hexagonal_role": "supporting",
       "name": "toil-mining",
@@ -1460,11 +1464,11 @@
         "lean-startup"
       ],
       "produces": [
-        "result.json"
+        "toil-candidates-report"
       ],
       "references_count": 0,
       "tier": "meta",
-      "user_invocable": false
+      "user_invocable": true
     },
     {
       "canonical_status": "canonical",

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -41,12 +41,16 @@ size, and stop at advisory evidence.
 
 Overweight failures: a `NOT_PROVEN` or `FAIL` verdict carries more teaching
 value than a PASS, because it names a rule the loop lacked. Harvest kernels
-from failed lanes first — the 2026-07-15 `NOT_PROVEN`
-(`.agents/ao/verdicts/sha256/b6e759dd...cb6a`, a subject destroyed by a
-mutating check mid-validation) produced more durable rules than the PASS
-(`e9b6cdb8...37b9`) that followed it.
+from failed lanes first — a subject destroyed by a mutating check
+mid-validation teaches a more durable rule than the PASS that follows it.
 
 Prune for provenance decay: every cited artifact must still resolve — the
-file exists or the verdict digest is present in `.agents/ao/verdicts/`. Dead
-citations get pruned rather than paraphrased, and confidence in a lesson that
-has not been reproduced since its source decayed goes down, not sideways.
+file exists or the verdict digest is present under `.agents/ao/verdicts/`. A
+citation that no longer resolves gets pruned rather than paraphrased, and
+confidence in a lesson that has not been reproduced since its source decayed
+goes down, not sideways.
+
+When the caller asks for a durable artifact, write the observations under
+`.agents/scratch/learn/` and return the path; otherwise return them inline.
+The write is advisory and TTL'd — it is never a source of record, and its
+absence never changes whether a candidate is valid.

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -41,8 +41,9 @@ size, and stop at advisory evidence.
 
 Overweight failures: a `NOT_PROVEN` or `FAIL` verdict carries more teaching
 value than a PASS, because it names a rule the loop lacked. Harvest kernels
-from failed lanes first — a subject destroyed by a mutating check
-mid-validation teaches a more durable rule than the PASS that follows it.
+from failed lanes first — the canonical example is the mutating-check
+quarantine in `skills/validate/SKILL.md`, a durable rule minted from a
+`NOT_PROVEN`-then-`PASS` verdict pair.
 
 Prune for provenance decay: every cited artifact must still resolve — the
 file exists or the verdict digest is present under `.agents/ao/verdicts/`. A

--- a/skills/operationalize/SKILL.md
+++ b/skills/operationalize/SKILL.md
@@ -4,7 +4,7 @@ description: 'Distill repeated, evidence-backed expertise into a proposed skill,
 practices: [continuous-learning, design-by-contract]
 hexagonal_role: supporting
 consumes: [evidence-backed-expertise]
-produces: [operationalization-proposal.v1]
+produces: [operationalization-proposal]
 context_rel:
 - kind: supplier-to
   with: skill-builder
@@ -19,7 +19,7 @@ metadata:
   effects: [write_advisory_proposal]
   canonical_status: canonical
   disposition: keep_specialist
-output_contract: operationalization-proposal.v1
+output_contract: advisory operationalization proposal
 ---
 
 # Operationalize
@@ -36,7 +36,10 @@ Turn repeated, cited expertise into a proposal for a reusable artifact.
 4. Search existing capabilities and prefer extension over duplication.
 5. Provide an activation example, holdout/negative example, owner, and rollback
    or deletion condition.
-6. Return the proposal to the caller or an authoring specialist.
+6. Return the proposal inline to the caller or an authoring specialist. When
+   the caller asks for a durable artifact, write it under
+   `.agents/scratch/operationalize/` first and return the path; the proposal
+   is advisory either way.
 
 ## Three-instance floor
 
@@ -71,4 +74,8 @@ matches what actually happened, instead of trusting the abstraction.
 ## Boundary
 
 Operationalize does not create tracker work, promote policy, start a factory,
-validate its own output, or control another invocation.
+validate its own output, or control another invocation. The proposal is
+advisory: adopting it into a skill, deterministic check, reference, or
+workflow is a separate, caller-selected step — `skill-builder`,
+`workflow-builder`, or a fresh RPI — never performed here. The proposal
+cannot promote itself.

--- a/skills/pattern-mining/SKILL.md
+++ b/skills/pattern-mining/SKILL.md
@@ -30,7 +30,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [pattern_mining]
-  effects: []
+  effects: [write_pattern_evidence]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
@@ -115,7 +115,7 @@ evidence into architecture the same way skipping the holdout would.
 
 ## Output Specification
 
-- **Artifact directory:** `.agents/patterns/<run-id>/`
+- **Artifact directory:** `.agents/scratch/pattern-mining/<run-id>/`
 - **Filename convention:** `pattern-mining.json`
 - **Format:** `pattern-mining.v1` JSON containing the outcome, distinct
   exemplars, invariants, variations, incidental details, holdout result,

--- a/skills/pattern-mining/scripts/validate-output.sh
+++ b/skills/pattern-mining/scripts/validate-output.sh
@@ -6,6 +6,11 @@ if [[ $# -ne 1 || ! -f "$1" ]]; then
   exit 2
 fi
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "pattern-mining validator requires jq, which is not on PATH" >&2
+  exit 2
+fi
+
 jq -e '
   def text: type == "string" and length > 0;
   . as $result

--- a/skills/toil-mining/SKILL.md
+++ b/skills/toil-mining/SKILL.md
@@ -7,12 +7,12 @@ practices:
 hexagonal_role: supporting
 consumes: []
 produces:
-- result.json
+- toil-candidates-report
 context_rel:
 - kind: supplier-to
   with: automation-shape-routing
 skill_api_version: 1
-user-invocable: false
+user-invocable: true
 context:
   window: fork
   intent:
@@ -23,19 +23,30 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [toil_mining]
-  effects: []
+  effects: [write_toil_candidates]
   canonical_status: canonical
   disposition: keep_specialist
   tier: meta
   dependencies: []
   stability: experimental
-output_contract: ranked evidence report under .agents/toil-mining/
+output_contract: ranked toil evidence report, inline by default; optional artifact under .agents/scratch/toil-mining/
 ---
 # Toil Mining — rank repeated friction
 
 Mine explicitly supplied session, shell, RTK, or CASS history without modifying
 the sources. The result is evidence for a caller; this skill does not file work,
 schedule automation, or mutate a tracker.
+
+## Constraints
+
+- Read-only over the supplied sources, because the skill gathers evidence and
+  must never become a mutation lane.
+- No work creation: it never files a tracker item, schedules automation, or
+  names an owner, because those are caller decisions the evidence informs.
+- Measured, not remembered: every count, cost, and error rate is read from the
+  supplied history, so recency and salience cannot masquerade as frequency.
+- Observations stay separate from recommendations, so a caller can re-weigh the
+  ranking without inheriting an unstated conclusion.
 
 ## Procedure
 
@@ -116,10 +127,19 @@ retrieval/report-only.
 
 ## Output
 
-Write `.agents/toil-mining/YYYY-MM-DD-candidates.md` only when the caller asks for
-a local artifact; otherwise return the report inline. Include checked and
+Write `.agents/scratch/toil-mining/YYYY-MM-DD-candidates.md` only when the caller
+asks for a local artifact; otherwise return the report inline. Include checked and
 not-checked sources. Do not include owners, priorities, claims, queues, or a next
 action.
+
+## Quality
+
+- Every ranked candidate shows its measured frequency, cost, and
+  error-proneness inputs beside the composite score.
+- Sources are cited and resolvable; a factor the history cannot support is
+  reported at the floor, never guessed at the midpoint.
+- Observations and recommendations stay separate, and the report names both its
+  checked and not-checked sources.
 
 ## References
 


### PR DESCRIPTION
## Summary

Wave W5 of the skill-overhaul reboot (`age-skill-overhaul-reboot-sjv7v.6`) — the four evolution skills, every checklist item verified against the live tree first.

- **learn** — pruned two dead `.agents/ao/verdicts/` digest citations per the skill's own decay rule; the harvest example now cites the living mutating-check quarantine rule in `skills/validate/SKILL.md` instead of an uncited paraphrase (review round 1); declared the optional write under `.agents/scratch/learn/`.
- **operationalize** — dropped the unbacked `.v1` contract suffix; bounded its conditional write to `.agents/scratch/operationalize/`; boundary tightened so advisory proposals cannot self-promote.
- **pattern-mining** — `effects: [write_pattern_evidence]` declared; artifact dir moved to the ADR-0016 closed set; jq-presence guard added to its output validator.
- **toil-mining** — real write effect declared; 3-way output-name mismatch reconciled to `toil-candidates-report`; artifact dir relocated; `user-invocable` flipped to match advertised triggers; frontloaded Constraints/Quality sections.

Ledger (11 fixed / 3 rejected-stale / 4 deferred-with-reason, zero silent drops): `docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w5.md`.

## Validation

- Skill validators green; 23/23 bats; 49/49 frontmatter; `regen-all.sh --check` clean; python ratchet PASS (no new Python)
- Cross-family (Codex) review round 1: one finding (paraphrased pruned incident) — fixed in 40339a81d with resolvable lineage

Tracker: `age-skill-overhaul-reboot-sjv7v.6`