### PR TITLE
W4 specialists wave: converter destructive path closed, authority grants stripped, honest effects

### DIFF
--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -34,9 +34,9 @@
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | - |
+| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
 | `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
 | `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
@@ -60,13 +60,13 @@
 | `rch` | execution | `keep_specialist` | - | `rch` | - |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
 | `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
-| `research` | execution | `keep_specialist` | - | `research` | - |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
+| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | - |
 | `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | - |
+| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
 | `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |

--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -34,15 +34,15 @@
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
+| `cass` | execution | `keep_specialist` | - | `cass` | - |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
 | `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | - |
-| `doc` | product | `keep_specialist` | - | `doc` | - |
+| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
 | `handoff` | session | `keep_specialist` | - | `handoff` | - |
@@ -59,21 +59,21 @@
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
 | `rch` | execution | `keep_specialist` | - | `rch` | - |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
-| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
+| `research` | execution | `keep_specialist` | - | `research` | - |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | - |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
+| `security` | product | `keep_specialist` | - | `security` | - |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | - |
+| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -72,7 +72,7 @@
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence` |
+| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -34,9 +34,9 @@
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | - |
+| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
 | `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
 | `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
@@ -60,13 +60,13 @@
 | `rch` | execution | `keep_specialist` | - | `rch` | - |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
 | `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
-| `research` | execution | `keep_specialist` | - | `research` | - |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
+| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | - |
 | `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | - |
+| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
 | `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -34,15 +34,15 @@
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
+| `cass` | execution | `keep_specialist` | - | `cass` | - |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
 | `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | - |
-| `doc` | product | `keep_specialist` | - | `doc` | - |
+| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
 | `handoff` | session | `keep_specialist` | - | `handoff` | - |
@@ -59,21 +59,21 @@
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
 | `rch` | execution | `keep_specialist` | - | `rch` | - |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
-| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
+| `research` | execution | `keep_specialist` | - | `research` | - |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | - |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
+| `security` | product | `keep_specialist` | - | `security` | - |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | - |
+| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -72,7 +72,7 @@
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence` |
+| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |

--- a/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w4.md
+++ b/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w4.md
@@ -1,0 +1,234 @@
+# Wave W4 report — specialists
+
+Bead: `age-skill-overhaul-reboot-sjv7v.5`. Branch: `claude/sor-w4-specialists`.
+Skills: `converter`, `doc`, `refactor`, `scaffold`, `skill-builder`, `test`,
+`workflow-builder`.
+
+Every checklist item for these seven slugs
+(`checklists/adapters-13.md` → `converter`; `checklists/outcomes-12.md` → `doc`,
+`skill-builder`; `checklists/workflow-12.md` → `refactor`, `scaffold`, `test`,
+`workflow-builder`) is dispositioned below. Each hypothesis was verified against
+the live tree first; the `Verified` note records what the live file actually
+showed.
+
+Specialist doctrine enforced across the group: mutating specialists act only
+under caller/Implement authority; no specialist commits, reverts, schedules RPI,
+or decides the next action; effects are declared truthfully; artifact writes land
+in the ADR-0016 closed set (`.agents/scratch/<skill>/` or
+`.agents/projections/<skill>/`).
+
+## Disposition summary
+
+- **Fixed: 30** · **Rejected (stale/refuted): 3** · **Deferred (with reason): 15**
+- Gates: all in-scope `validate.sh` PASS; `validate-skill-frontmatter.sh --strict`
+  = 49/49, 0 warnings; `regen-all.sh --check` all current; the three bats gates
+  23/23 green; `check-skill-python-ratchet.sh` PASS, 24 grandfathered, no growth;
+  every touched shell shellcheck `-S warning` clean.
+
+---
+
+## converter
+
+- **CV-1 `rm -rf "$output_dir"` destroys the source `[P0 defect]` — fixed.**
+  Verified: `write_output()` clean-writes `output_dir` with `rm -rf`, and
+  `convert_one_skill` accepts a caller-supplied `output_dir` verbatim, so
+  `convert.sh <skill> codex <skill>` (output == source) deletes the package it
+  is reading. Reproduced in a disposable fixture (4 files → refusal). Fixed by
+  **refusal**, not by appending a subdir: `assert_safe_output_dir()` (with a
+  portable `resolve_physical` that collapses `..`/symlinks against the deepest
+  existing ancestor) `die`s when the resolved output equals the source, is an
+  ancestor of it, or is the repo root — before the `rm -rf`. `scripts/validate.sh`
+  is now a self-test that proves all three refusals and that the source survives
+  (2 files in → 2 files out). Legitimate re-conversion clean-write of a distinct
+  output dir is preserved.
+- **CV-2 validator vacuous `[defect]` — fixed.** Verified: old `validate.sh`
+  only checked "SKILL.md exists / has frontmatter" (2 passed) while the pipeline
+  could delete its own source. Replaced with the behavioral self-test above
+  (happy-path conversion writes target + passthrough files; destructive paths
+  refused; source intact).
+- **S1 `effects: []` false `[defect]` — fixed.** Verified: the pipeline writes
+  converted files. Declared `effects: [write_converted_skill_projection]` and
+  relocated the default output from the non-closed `.agents/converter/` to the
+  ADR-0016 projection tier `.agents/projections/converter/<target>/<skill>/`
+  (no consumers of the old path — only the audit doc referenced it).
+- **N2 not the shipped Codex-projection owner `[defect]` — fixed.** Added an
+  ownership-boundary paragraph: the shipped `skills-codex/**` is generated and
+  gated by `codex-sync.sh` via `regen-all.sh`; this converter is an ad-hoc
+  out-of-tree exporter that never mutates `skills-codex/**`; the shipped path
+  wins on disagreement.
+- **CV-8 `local -n` nameref unrunnable on stock macOS bash 3.2 `[defect]` —
+  fixed.** Added a `BASH_VERSINFO` preflight that fails closed with a clear
+  diagnostic below 4.3 instead of the opaque "invalid option" abort.
+- **N9 `skill-bundle-schema.md` contradicts the code `[defect]` — fixed.** The
+  adapter table claimed codex "flattens into single agents.md" and cursor
+  "splits into .cursor/rules/ files"; the code emits `SKILL.md` + `prompt.md`
+  and a single `<name>.mdc`. Corrected the table to the real outputs.
+- **CV-7 `collect_files` non-recursive vs recursive passthrough `[defect]` —
+  fixed by declaration.** Verified: `collect_files` globs top-level only while
+  `copy_passthrough_resources` copies recursively; the two serve different
+  stages (inline vs preserve). Declared the top-level scope in a comment; nested
+  resources survive via the recursive passthrough, so no behavior change is
+  warranted.
+- **CV-9 unquoted Cursor `description:` yields invalid YAML `[enhance]` —
+  fixed.** Now single-quoted and escaped via `yaml_escape_single_quote`, matching
+  the codex adapter.
+- **CV-5 single-skill output should refuse `[enhance]` — fixed.** Subsumed by
+  the CV-1 refusal guard.
+- **N1 `codex_rewrite_text` deletes whole lines; parity is name-only `[P0
+  defect]` — deferred.** Verified: the line-strip is intentional (inline comment:
+  "Strip lines with Claude primitives — no Codex equivalent, empirically
+  verified"). Making parity content-aware is a projection-semantics redesign;
+  the shipped Codex path is owned by `codex-sync.sh` (N2), so the exporter's
+  content fidelity is secondary. Deferred as out-of-wave.
+- **CV-10 codex rewrites applied to cursor/test passthrough `[enhance]` —
+  deferred.** Threading `target` through the copy pipeline is a behavior change
+  to secondary targets; the authoritative Codex path is `codex-sync.sh`.
+- **N20 Cursor budget counts characters not bytes `[enhance]` — deferred.**
+  Multibyte-only edge case; low impact.
+
+## doc
+
+- **P0-EFFECTS `effects: []` false `[defect]` — fixed.** Declared
+  `effects: [write_documentation]` (README/OSS writes stay confirmation-gated
+  per the existing output contract).
+- **P1-N-D work-creation authority `[defect]` — fixed.** Deleted the
+  `## --create-issues Flag` section (`bd create` / `gh issue create`) from
+  `references/validation-rules.md` and the `## Next Steps` action-box from the
+  report template in `references/default-mode.md`. Verified `--create-issues`
+  had no other references, so no dangling flag remains.
+- **P1-LAYOUT `.agents/doc/` off the closed set `[defect]` — fixed.** Relocated
+  every `.agents/doc/` write to `.agents/scratch/doc/` (SKILL.md + default-mode.md).
+- **P1-DOC-VAL "validator is all prose-grep, cannot fail on behavior"
+  `[disputed]` — rejected.** Verified: `scripts/validate.sh` checks 14 things,
+  and checks 17–21 pin real authority-boundary invariants (OSS scaffold is
+  missing-only; existing-doc writes require explicit confirmation; the
+  `refresh`/feature-spec confirmation boundary). Deleting the "missing-only" or
+  "explicit confirmation" language turns it red. The audit's "cannot fail on
+  behavior" is inaccurate — exactly what the `[disputed]` tag warned. Left intact.
+- **P1-N-E seven stale surface names `[defect]` — deferred.** Verified: the two
+  most-cited "legacy" surfaces (`/readme`, `/oss-docs`) are *documented,
+  intentional* legacy-routing aliases (readme-craft.md:15, oss-pack.md:12), not
+  stale. The audit's specific "five skill names" could not be reconciled against
+  the seed-era source; remaining hits (`subagents/explorer.md`, the
+  `audit-oss-docs.sh` hint) are cosmetic. Deferred rather than guess.
+- **P2-N-H hygiene batch `[defect]` — deferred.** `audit-oss-docs.sh` `set -e`
+  vs `set -euo pipefail`, unlinked reference, H1s, an unclosed fence, missing
+  `@covered-by` — cosmetic markdown / test-harness hygiene. Touching the 10.8K
+  `audit-oss-docs.sh` for a `set -e` cosmetic adds shellcheck risk for no
+  behavioral gain; deferred.
+
+## refactor
+
+- **`references/refactor.feature` grants commit authority `[defect]` — fixed.**
+- **Same feature grants automatic revert authority `[defect]` — fixed.**
+- **SKILL.md:74–75 "explain or revert" vs :47–49 "does not revert"
+  contradiction `[defect]` — fixed (SKILL governs).** Reworded to "a behavior
+  diff to surface and explain … the caller decides whether to keep, narrow, or
+  reverse" — the skill never reverts; the caller does.
+- **Feature header `consumes: complexity / produces: git-changes` drift
+  `[defect]` — fixed.** Header now matches frontmatter (`repo-context` →
+  `code-changes`).
+- **Dangling `/complexity` + `--sweep` route `[defect]` — fixed.** Removed from
+  the rewritten feature (no such route exists).
+- **`effects: []` `[enhance]` — fixed.** `effects: [modify_source_files]`.
+- **0/4 scenario coverage `@covered-by` `[enhance]` — deferred.** The four
+  scenarios were rewritten to match SKILL.md, but `@covered-by` tags need real
+  covering tests; refactor is guidance with no harness, and no corpus gate
+  requires the tags (most features carry none). Dangling tags would be
+  fabrication.
+- **Neutrality harness witness `[enhance]` — deferred.** New test infrastructure.
+
+## scaffold
+
+- **`generic-templates.md:189-199` Step 5 Initial Commit `[defect]` — fixed.**
+  Deleted; replaced with a caller-owns-Git statement.
+- **`generic-templates.md:353-356` "Next steps:" continuation `[defect]` —
+  fixed.** Deleted; also removed the `Commit:` summary line and the Git-init
+  error-recovery row for coherence with "does not mutate Git".
+- **Validator scans only SKILL.md, references pass unseen `[defect]` — fixed.**
+  `scripts/validate.sh` now sweeps `references/**` for `initial commit`,
+  `git commit`, `git push`, and `next steps:` and fails if any reappears (proven
+  live: seeding a grant into a copy fails the validator; unseeded passes). Uses
+  the `if grep …; then exit 1; fi` form — no `!`-negation.
+- **`effects: []` `[enhance]` — fixed.** `effects: [write_project_files]`; the
+  now-false `grep '^  effects: \[\]$'` assertion was removed from the validator
+  in the same change. `skill-validator-liveness.bats` scaffold tests stay green.
+- **0/4 `@covered-by` `[enhance]` — deferred** (same reason as refactor;
+  `scaffold.feature` was already authority-clean, so no rewrite needed).
+- **Exemplar-selection / one-way-sync witnesses `[enhance]` — deferred.** New
+  test infrastructure.
+
+## test
+
+- **`produces: [result.json]` unbacked `[defect]` — fixed.** No code path or
+  Output Spec writes `result.json`; corrected to `produces: [test-evidence]`.
+- **`scripts/validate.sh` vacuous `[defect]` — fixed.** Old validator passed on
+  five prose words even with the Workflow section deleted. Replaced with
+  load-bearing section checks (Critical Constraints, Oracle-strength hierarchy,
+  Mutation-kill proof, Harness health floors, Workflow, Output Specification),
+  the four-mode table, and reference-link resolution. Proven: deleting `##
+  Workflow` now turns it red.
+- **check-scenario-coverage mandate vs its own 0/3 feature `[defect]` — fixed.**
+  Verified the checker exists (`scripts/check-scenario-coverage.sh`); the mandate
+  is valid tool-guidance for a *caller-supplied* feature, not a self-proof of
+  `test.feature`. Reworded so the example targets `<path-to-caller-feature>` and
+  says "not this skill's own spec". `test.feature`'s own `@covered-by` is
+  deferred (no harness for a guidance skill's own spec).
+- **`.agents/tests/` off the closed set `[possibly-landed]` — fixed.** Relocated
+  every `.agents/tests/` write to `.agents/scratch/tests/` (SKILL.md + six
+  reference files + test.feature).
+- **`effects: []` `[enhance]` — fixed.**
+  `effects: [write_test_files, write_test_evidence]`.
+- **Three doctrine witnesses `[enhance]` — deferred.** New test infrastructure
+  (oracle hierarchy / mutation-kill / harness-health behavioral witnesses).
+- **`golden-artifacts.md` ↔ `golden-artifact-strategy.md` overlap `[enhance]` —
+  deferred.** Content-merge, low value.
+
+## skill-builder
+
+- **P0-EFFECTS undeclared build-report write `[defect]` — fixed.** Verified
+  `init.sh:149-150` + `build.sh:32` write `.agents/audits/<slug>-build.json`
+  (SKILL.md:152 declared it) with no effect covering it. Declared
+  `write_build_report` and relocated the write into the closed set
+  `.agents/scratch/skill-builder/<slug>-build.json` (only init.sh/build.sh
+  reference the path; the doctor test's `.agents/audits/matrix.md` is unrelated).
+- **Missing `context_rel` (pre-existing strict warning) `[defect]` — fixed.**
+  Added `context_rel: []` (honest — no declared cross-skill contract); strict
+  frontmatter is now 49/49 with zero warnings.
+- **P0-RATCHET five execution-path `.py` fail the ADR-0016 ratchet `[defect]` —
+  rejected (stale/refuted).** Verified: the five named files
+  (`check_migration_readiness.py`, `compile_contracts.py`, `contract_v3.py`,
+  `probe_runtime.py`, `run_contract_probe.py`) **do not exist** in the live tree.
+  The live `.py` (`authoring_scan`, `conformance_profile`, `craft_score`,
+  `scan_descriptions`, `score_agentops_skill`) are on the grandfather snapshot
+  and the ratchet **PASSES on main today**. Not touched. Promotion-to-Go of the
+  grandfathered files is a separate, deferred effort (the task's instruction).
+- **P0-HEAL-N-A "auto-fixing `heal.sh` does not exist" `[defect]` — rejected.**
+  Verified: `scripts/heal.sh` exists (3.4K), is referenced by SKILL.md:100 and
+  invoked by `validate.sh:32`.
+- **P1-N-B `test-mutation-boundaries.sh` red / unwired `[defect]` — deferred.**
+  Broken sibling test script, not on the user execution path; the audit assigns
+  its repair to the plan's D7 transactional-projection owner.
+- **P1 heal/audit batch (HEAL-MESH, HEAL-SUBSET, HEAL-CRASH, GUARD-RG, PROFILE,
+  INIT-OC) + P2 batch `[defect]` — deferred.** These require rewriting the
+  grandfathered `.py` and deep heal/audit shell; the task's instruction is not
+  to rewrite the grandfathered `.py` this wave. Deferred with the promotion-to-Go
+  note above.
+
+## workflow-builder
+
+- **`effects: []` while doing `filesystem.write` `[enhance]` — fixed.**
+  `effects: [write_workflow_script]`.
+- **At-most-once dispatch witness `[enhance]` — deferred.** workflow-builder has
+  no `scripts/`; a dispatch-count witness is new test infrastructure for a
+  guidance skill and no corpus gate requires it.
+
+---
+
+## Anti-spiral note
+
+One verification pass; only this wave's red checks were fixed. Two classes were
+stopped at the "unverifiable/contradictory" boundary and recorded deferred
+rather than ground out: doc's seed-era stale-name set (P1-N-E) and skill-builder's
+grandfathered-`.py` promotion (P0-RATCHET / P1 heal batch). No new `.py` under
+`skills/`; no hand-edited generated files (all projections via `regen-all.sh`).

--- a/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w4.md
+++ b/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w4.md
@@ -232,3 +232,39 @@ stopped at the "unverifiable/contradictory" boundary and recorded deferred
 rather than ground out: doc's seed-era stale-name set (P1-N-E) and skill-builder's
 grandfathered-`.py` promotion (P0-RATCHET / P1 heal batch). No new `.py` under
 `skills/`; no hand-edited generated files (all projections via `regen-all.sh`).
+
+## Review round 1 (cross-family) — REQUEST_CHANGES, five findings, all fixed
+
+1. **[P0] Converter guard was one-directional — fixed.** The guard rejected
+   output equal to or above the source but permitted output *inside* the source
+   (e.g. `<source>/references`), a symlink resolving into it, and (for an
+   external source) an output *above* the repository (only equality with
+   `REPO_ROOT` was checked). Rewrote `assert_safe_output_dir` around a `within`
+   helper on canonical (`pwd -P` / `resolve_physical`, symlink- and `..`-resolved)
+   paths: refuse when output is the source, an ancestor of it, OR a descendant
+   of it; and refuse when output is or contains (is an ancestor of) the repo
+   root. Symlinked outputs are canonicalized before comparison.
+2. **Self-test didn't prove the claim — fixed.** `scripts/validate.sh` now
+   asserts source survival by a **content digest** (not file count), and adds
+   the descendant-output, repository-ancestor-output, and symlink-into-source
+   cases. Each refusal case asserts the refusal happened **before any deletion**
+   (source digest unchanged AND nonzero exit). 8/8 self-test assertions pass.
+3. **Scaffold sweep incomplete — fixed.** Extended the forbidden pattern to
+   `initial commit | create a commit | git commit | git add | git init |
+   git push | commit: | next step | bare verb-`push``. Bare `push` is matched
+   only as a verb (followed by space/period/EOL), so the CI-trigger key `push:`
+   and `pushd` do not false-fire. Rewrote the Step-5-replacement disclaimer so
+   it no longer contains the literal tokens it disclaims (which the stricter
+   pattern would otherwise flag). Verified: passes on the cleaned references and
+   fails on each of six restored grants (Step 5, `Commit:`, `Git init`,
+   `Next steps:`, `git add`, `git push`).
+4. **`test.feature` still declared `produces result.json` — fixed.** Reconciled
+   the header comment to `produces test-evidence`, matching the frontmatter.
+5. **Test effects understated TDD production edits — fixed.** TDD mode instructs
+   implementing production code to pass the test, so added `modify_source_files`
+   (corpus vocabulary, as `refactor` uses) alongside `write_test_files` and
+   `write_test_evidence`.
+
+Round-1 gates: in-scope validators PASS (converter self-test 8/8); frontmatter
+`--strict` 49/49, 0 warnings; `regen-all --check` all current; bats 23/23;
+python ratchet PASS, 24 grandfathered, no growth; touched shell shellcheck clean.

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -140,7 +140,7 @@
 | `swarm` | produces | `per-packet-results` |
 | `test` | consumes | `standards` |
 | `test` | consumes | `repo-context` |
-| `test` | produces | `result.json` |
+| `test` | produces | `test-evidence` |
 | `toil-mining` | produces | `toil-candidates-report` |
 | `using-gc` | consumes | `explicit-packets` |
 | `using-gc` | produces | `gas-city-runtime-evidence` |

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -28,9 +28,9 @@
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | - |
+| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
 | `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
 | `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
@@ -54,13 +54,13 @@
 | `rch` | execution | `keep_specialist` | - | `rch` | - |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
 | `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
-| `research` | execution | `keep_specialist` | - | `research` | - |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
+| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | - |
 | `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | - |
+| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
 | `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -28,15 +28,15 @@
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
+| `cass` | execution | `keep_specialist` | - | `cass` | - |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
 | `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | - |
-| `doc` | product | `keep_specialist` | - | `doc` | - |
+| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
 | `handoff` | session | `keep_specialist` | - | `handoff` | - |
@@ -53,21 +53,21 @@
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
 | `rch` | execution | `keep_specialist` | - | `rch` | - |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
-| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
+| `research` | execution | `keep_specialist` | - | `research` | - |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | - |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
+| `security` | product | `keep_specialist` | - | `security` | - |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | - |
+| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -66,7 +66,7 @@
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence` |
+| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |

--- a/images/gemini/skills/converter/SKILL.md
+++ b/images/gemini/skills/converter/SKILL.md
@@ -22,7 +22,7 @@ context:
   intel_scope: none
 metadata:
   capabilities: [converter]
-  effects: []
+  effects: [write_converted_skill_projection]
   canonical_status: canonical
   disposition: keep_specialist
   tier: cross-vendor
@@ -34,6 +34,8 @@ output_contract: converted skill files for target platform
 Parse AgentOps skills into a universal SkillBundle format, then convert to target agent platforms.
 
 The intermediate SkillBundle is what keeps conversions honest: every target reads the same parsed contract, so a rendering bug is a target-adapter bug, never a silent reinterpretation of the source. If two targets disagree about a skill's content, the bundle — not either output — arbitrates.
+
+This is **not** the owner of the shipped `skills-codex/**` projection: that path is generated and gated by `scripts/codex-sync.sh` via `scripts/regen-all.sh`. This converter is an ad-hoc, out-of-tree exporter (Codex, Cursor) that writes under `.agents/projections/converter/`; it never mutates `skills-codex/**`. When the shipped Codex twin and this exporter disagree, the shipped path wins.
 
 Named failure mode — **projection editing**: fixing a rendering problem by hand-editing the converted output, which the next conversion clean-writes away.
 
@@ -79,8 +81,9 @@ The Cursor adapter produces a `<name>.mdc` rule file with YAML frontmatter (`des
 
 Write the converted output to disk.
 
-- **Default output directory:** `.agents/converter/<target>/<skill-name>/`
+- **Default output directory:** `.agents/projections/converter/<target>/<skill-name>/`
 - **Write semantics:** Clean-write. The target directory is deleted before writing. No merge with existing content.
+- **Refusal guard:** the write stage refuses — it does not silently redirect — when the resolved output directory equals the source package, contains it (an ancestor), or is the repository root, because the clean-write would otherwise delete the very files the conversion must read.
 
 ## CLI Usage
 
@@ -99,7 +102,7 @@ bash skills/converter/scripts/convert.sh --all <target> [output-dir]
 |----------|----------|-------------|
 | `skill-dir` | Yes (or `--all`) | Path to skill directory (e.g. `skills/council`) |
 | `target` | Yes | Target platform: `codex`, `cursor`, or `test` |
-| `output-dir` | No | Override output location. Default: `.agents/converter/<target>/<skill-name>/` |
+| `output-dir` | No | Override output location. Default: `.agents/projections/converter/<target>/<skill-name>/` |
 | `--all` | No | Convert all skills in `skills/` directory |
 | `--codex-layout` | No | Codex-only layout mode: `modular` (default) or `inline` (legacy inlined refs/scripts) |
 
@@ -126,7 +129,7 @@ To add a new target platform:
 **What happens:**
 1. The converter parses `skills/council/SKILL.md` frontmatter, markdown body, and any `references/` and `scripts/` files into a SkillBundle.
 2. The Codex adapter transforms the bundle into a `SKILL.md` (body + inlined references + scripts as code blocks) and a `prompt.md` (Codex prompt referencing the skill).
-3. Output is written to `.agents/converter/codex/council/`.
+3. Output is written to `.agents/projections/converter/codex/council/`.
 
 **Result:** A Codex-compatible skill package ready to use with OpenAI Codex CLI.
 
@@ -137,7 +140,7 @@ To add a new target platform:
 **What happens:**
 1. The converter scans every directory under `skills/` and parses each into a SkillBundle.
 2. The Cursor adapter transforms each bundle into a `.mdc` rule file with YAML frontmatter and body content, budget-fitted to 100KB max. Skills referencing MCP servers also get a `mcp.json` stub.
-3. Each skill's output is written to `.agents/converter/cursor/<skill-name>/`.
+3. Each skill's output is written to `.agents/projections/converter/cursor/<skill-name>/`.
 
 **Result:** All skills are available as Cursor rules, ready to drop into a `.cursor/rules/` directory.
 
@@ -147,14 +150,14 @@ To add a new target platform:
 |---------|-------|----------|
 | `parse error: no frontmatter found` | SKILL.md is missing the `---` delimited YAML frontmatter block | Add frontmatter with at least `name:` and `description:` fields, or run Heal Skill on the source package first |
 | Cursor `.mdc` output is missing references | Total bundle size exceeded the 100KB budget limit | The converter omits references largest-first to fit the budget. Split large reference files or move non-essential content to external docs |
-| Output directory already has old files | Previous conversion artifacts remain | This is expected -- the converter clean-writes by deleting the target directory before writing. If old files persist, manually delete `.agents/converter/<target>/<skill>/` |
+| Output directory already has old files | Previous conversion artifacts remain | This is expected -- the converter clean-writes by deleting the target directory before writing. If old files persist, manually delete `.agents/projections/converter/<target>/<skill>/` |
 | `--all` skips a skill directory | The directory has no `SKILL.md` file | Ensure each skill directory contains a valid `SKILL.md`. Run Heal Skill to detect empty directories |
 | Codex `prompt.md` description is truncated | The skill description exceeds 1024 characters | This is by design. The converter truncates at a word boundary to fit Codex limits. Shorten the description in SKILL.md frontmatter if the truncation point is awkward |
 | Conversion fails with passthrough parity check | A resource entry from source skill wasn't copied to output | Ensure source entries are readable and copyable (including nested files). Re-run conversion; failure is intentional to prevent drift between `skills/` and converted output |
 
 ## Output Specification
 
-- **Path:** `.agents/converter/<target>/<skill-name>/` by default, or the exact caller-supplied output directory.
+- **Path:** `.agents/projections/converter/<target>/<skill-name>/` by default, or the exact caller-supplied output directory.
 - **Filename:** Codex emits `SKILL.md`, `prompt.md`, and copied resources; Cursor emits `<skill-name>.mdc` and optional `mcp.json`; `test` emits the raw bundle representation.
 - **Format:** target-valid UTF-8 text with required frontmatter, rewritten runtime references, and byte-present passthrough resources; Cursor output remains within 100KB.
 - **Exit code:** run `bash skills/converter/scripts/convert.sh <skill-dir> <target> <output-dir>` and require zero; treat parse, budget, write, or passthrough-parity failure as nonzero and incomplete.

--- a/images/gemini/skills/doc/SKILL.md
+++ b/images/gemini/skills/doc/SKILL.md
@@ -22,7 +22,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [doc]
-  effects: []
+  effects: [write_documentation]
   canonical_status: canonical
   disposition: keep_specialist
   tier: product
@@ -69,7 +69,7 @@ Default mode is deliberately thin. Given a Doc command and target:
 
 1. **Detect project type** — `ls package.json pyproject.toml go.mod Cargo.toml` + existing `docs/`; classify CODING / INFORMATIONAL / OPS.
 2. **Run the command** — `discover` (grep undocumented funcs), `coverage` (documented vs total), `gen [feature]` (read code → stamp function/class markdown), `all`, or `validate`.
-3. **Write the report** to `.agents/doc/YYYY-MM-DD-<target>.md` (coverage %, generated, gaps, validation issues), then report coverage + gaps to the user.
+3. **Write the report** to `.agents/scratch/doc/YYYY-MM-DD-<target>.md` (coverage %, generated, gaps, validation issues), then report coverage + gaps to the user.
 
 Full step-by-step detail — grep recipes, function/class + code-map templates, the report skeleton, key rules, worked examples, and the troubleshooting table — lives in **[references/default-mode.md](references/default-mode.md)** (moved there in the generic-craft trim). Read it when you need the exact shapes; otherwise just do the three steps.
 
@@ -97,7 +97,7 @@ doc** failure mode — accurate, complete, and useless.
 
 ## Output Specification
 
-- **Path:** default-mode reports go to the artifact directory `.agents/doc/`; README mode updates the repository `README.md`; OSS scaffold mode creates missing root documentation only by default. The separate OSS `refresh` path may update an existing doc only after explicit user confirmation.
+- **Path:** default-mode reports go to the artifact directory `.agents/scratch/doc/`; README mode updates the repository `README.md`; OSS scaffold mode creates missing root documentation only by default. The separate OSS `refresh` path may update an existing doc only after explicit user confirmation.
 - **Filename:** default reports use the filename convention `YYYY-MM-DD-<target>.md`; README and OSS filenames follow their mode references.
 - **Format:** outputs are Markdown; the default report schema records coverage percentage, generated artifacts, gaps, and validation issues.
 - **Validation command:** validate the skill contract with `bash skills/doc/scripts/validate.sh`, then run the mode-specific validation required by its reference before reporting completion.

--- a/images/gemini/skills/refactor/SKILL.md
+++ b/images/gemini/skills/refactor/SKILL.md
@@ -22,7 +22,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [refactor]
-  effects: []
+  effects: [modify_source_files]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
@@ -72,7 +72,8 @@ transformation on behavior-identical proof:
 - For output-producing surfaces (generators, serializers, formatters, reports),
   hash the outputs: capture golden-output hashes over identical inputs before
   the change and compare byte-for-byte after. A hash mismatch is a behavior
-  diff to explain or revert, never to shrug at.
+  diff to surface and explain, never to shrug at; the caller decides whether to
+  keep, narrow, or reverse the change.
 - Observable error messages, exit codes, and public signatures on the changed
   surface are part of behavior unless the caller excluded them.
 

--- a/images/gemini/skills/scaffold/SKILL.md
+++ b/images/gemini/skills/scaffold/SKILL.md
@@ -21,7 +21,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [scaffold]
-  effects: []
+  effects: [write_project_files]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution

--- a/images/gemini/skills/skill-builder/SKILL.md
+++ b/images/gemini/skills/skill-builder/SKILL.md
@@ -9,6 +9,7 @@ consumes: []
 produces:
 - skill-source-package
 - skill-hygiene-report
+context_rel: []
 skill_api_version: 1
 context:
   window: fork
@@ -20,7 +21,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [skill_builder, heal_skill]
-  effects: [writes_skill_source, regenerates_skill_projections, optional_skill_projection_repair]
+  effects: [writes_skill_source, write_build_report, regenerates_skill_projections, optional_skill_projection_repair]
   canonical_status: canonical
   disposition: keep_specialist
   tier: meta
@@ -149,8 +150,8 @@ skills/<slug>/
 └── scripts/validate.sh
 ```
 
-The build report is `.agents/audits/<slug>-build.json` and conforms to
-`schemas/build-report.json`. Deep audit JSON conforms to
+The build report is `.agents/scratch/skill-builder/<slug>-build.json` and
+conforms to `schemas/build-report.json`. Deep audit JSON conforms to
 `schemas/audit-report.json`. Generated inventories and runtime projections are
 not additional sources of truth. The caller owns any subsequent edit or
 invocation.

--- a/images/gemini/skills/test/SKILL.md
+++ b/images/gemini/skills/test/SKILL.md
@@ -10,7 +10,7 @@ consumes:
 - standards
 - repo-context
 produces:
-- result.json
+- test-evidence
 context_rel: []
 skill_api_version: 1
 context:
@@ -23,7 +23,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [test]
-  effects: []
+  effects: [write_test_files, write_test_evidence]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
@@ -76,7 +76,7 @@ is the **oracle downgrade** failure mode: the test runs the code but proves
 almost nothing about it. Stop condition: no acceptance scenario may be covered
 only by smoke-tier tests when a stronger oracle is practical; if only smoke is
 practical (e.g. nondeterministic external output), record why in
-`.agents/tests/summary.md` so the gap is a visible decision, not an accident.
+`.agents/scratch/tests/summary.md` so the gap is a visible decision, not an accident.
 
 ## Mutation-kill proof
 
@@ -108,12 +108,14 @@ coverage claims on top of it.
 
 ### 1. Bind tests to behavior
 
-When a caller-supplied `.feature` file has scenarios, work forward from each
-Given/When/Then. Name one covering test after the behavior, and add
-`@covered-by:<test-path>[::<TestName>]` above the scenario. Prove the mapping:
+When the caller supplies a `.feature` file with scenarios, work forward from
+each Given/When/Then. Name one covering test after the behavior, and add
+`@covered-by:<test-path>[::<TestName>]` above the scenario. Prove the mapping by
+running the coverage checker against that caller-supplied feature (not this
+skill's own spec):
 
 ```bash
-bash scripts/check-scenario-coverage.sh skills/<skill>/references/<name>.feature --run
+bash scripts/check-scenario-coverage.sh <path-to-caller-feature> --run
 ```
 
 Without scenarios, inventory public behavior, error paths, branches, and edge
@@ -130,8 +132,8 @@ Stop at the first applicable project marker and consult the Standards skill for 
 | `package.json` | Jest/Vitest | `npx jest --coverage` or `npx vitest run --coverage` |
 | `Cargo.toml` | cargo test | `cargo tarpaulin --out Lcov` |
 
-Write raw coverage to `.agents/tests/coverage-raw.txt`, a ranked gap inventory
-to `.agents/tests/gaps.md`, and language-native machine output where available.
+Write raw coverage to `.agents/scratch/tests/coverage-raw.txt`, a ranked gap inventory
+to `.agents/scratch/tests/gaps.md`, and language-native machine output where available.
 
 ### 3. Write the smallest valuable tests
 
@@ -158,7 +160,7 @@ In `tdd` mode:
 2. Implement only enough to pass that test.
 3. Refactor under green without changing the test contract.
 4. Run the focused test and the relevant suite after each cycle.
-5. Append the exact commands and outcomes to `.agents/tests/tdd-log.md`.
+5. Append the exact commands and outcomes to `.agents/scratch/tests/tdd-log.md`.
 
 In other mutating modes, run each new test immediately, then the owning package
 or module, then the relevant project suite. A failure caused by a wrong test is
@@ -171,7 +173,7 @@ relevant suite are green and the recorded RED evidence names the intended behavi
 
 Re-run the baseline coverage command. Summarize before/after coverage, tests
 added, remaining high-risk gaps, bugs found, and exact validation commands in
-`.agents/tests/summary.md`. Supply that evidence to Validate when the test
+`.agents/scratch/tests/summary.md`. Supply that evidence to Validate when the test
 change accompanies a product slice or is ready for acceptance.
 
 ## Language Rules
@@ -187,12 +189,12 @@ change accompanies a product slice or is ready for acceptance.
 ## Strategy Mode
 
 Inventory test files, functions, assertion density, unit/integration/e2e split,
-fixtures, and CI wiring. Write `.agents/tests/strategy.md` with prioritized
+fixtures, and CI wiring. Write `.agents/scratch/tests/strategy.md` with prioritized
 structural gaps and a test architecture; do not generate code in this mode.
 
 ## Output Specification
 
-- **Artifact directory:** `.agents/tests/` plus test files in the target's
+- **Artifact directory:** `.agents/scratch/tests/` plus test files in the target's
   language-native locations.
 - **Filename convention:** `coverage-raw.txt`, `coverage-func.txt` or
   `coverage.json`, `gaps.md`, `summary.md`, `tdd-log.md`, and `strategy.md`.

--- a/images/gemini/skills/test/SKILL.md
+++ b/images/gemini/skills/test/SKILL.md
@@ -23,7 +23,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [test]
-  effects: [write_test_files, write_test_evidence]
+  effects: [write_test_files, write_test_evidence, modify_source_files]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution

--- a/images/gemini/skills/workflow-builder/SKILL.md
+++ b/images/gemini/skills/workflow-builder/SKILL.md
@@ -25,7 +25,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [workflow_builder]
-  effects: []
+  effects: [write_workflow_script]
   canonical_status: canonical
   disposition: keep_specialist
   tier: meta

--- a/registry.json
+++ b/registry.json
@@ -1266,7 +1266,8 @@
         "disposition": "keep_specialist",
         "effects": [
           "write_test_files",
-          "write_test_evidence"
+          "write_test_evidence",
+          "modify_source_files"
         ],
         "has_references": true,
         "has_skill_md": true,

--- a/registry.json
+++ b/registry.json
@@ -762,7 +762,9 @@
           "converter"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "write_converted_skill_projection"
+        ],
         "has_references": true,
         "has_skill_md": true,
         "name": "converter",
@@ -818,7 +820,9 @@
           "doc"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "write_documentation"
+        ],
         "has_references": true,
         "has_skill_md": true,
         "name": "doc",
@@ -1068,7 +1072,9 @@
           "refactor"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "modify_source_files"
+        ],
         "has_references": true,
         "has_skill_md": true,
         "name": "refactor",
@@ -1142,7 +1148,9 @@
           "scaffold"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "write_project_files"
+        ],
         "has_references": true,
         "has_skill_md": true,
         "name": "scaffold",
@@ -1199,6 +1207,7 @@
         "disposition": "keep_specialist",
         "effects": [
           "writes_skill_source",
+          "write_build_report",
           "regenerates_skill_projections",
           "optional_skill_projection_repair"
         ],
@@ -1255,7 +1264,10 @@
           "test"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "write_test_files",
+          "write_test_evidence"
+        ],
         "has_references": true,
         "has_skill_md": true,
         "name": "test",
@@ -1317,7 +1329,9 @@
           "workflow_builder"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "write_workflow_script"
+        ],
         "has_references": false,
         "has_skill_md": true,
         "name": "workflow-builder",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -393,8 +393,8 @@
     {
       "name": "converter",
       "source_skill": "skills/converter",
-      "source_hash": "ee0a1bcc00f422dbf864d04a8972b8578056947b625e7e94d3632a40cee159ab",
-      "generated_hash": "ceb7e7f216b1c23c2fb78be27fda84fb0fc36d798145c5b490768ceeb6e6f9e2"
+      "source_hash": "abc9e6aec41184373a9e80a0baa047fde51b02f971b841a45ac323bafcde3b4a",
+      "generated_hash": "1d4a319edc74e19f18351d5cdb5b6cf128b0b2b97adcf89f85752f75f44f83f3"
     },
     {
       "name": "council",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -393,8 +393,8 @@
     {
       "name": "converter",
       "source_skill": "skills/converter",
-      "source_hash": "af311e6964a8ddaa4b1d880ed281deafac13f38ab4f7345d959dd59032179ab7",
-      "generated_hash": "714ef1de6292ea4747621fead2ab440044e8a782abde4e237366427bcd398468"
+      "source_hash": "163a055ef4c016e1cd731ee8d79dc9d9d0cd9137f6c997a8181326bb33c29ea7",
+      "generated_hash": "4b7d970cc6179f2aa7e73da2d01960cb079bc403c8867993c416b669ea77fa98"
     },
     {
       "name": "council",
@@ -417,8 +417,8 @@
     {
       "name": "doc",
       "source_skill": "skills/doc",
-      "source_hash": "2c8bac339d06f5fd1f712a1bb1cb7cb5bf4441be20fd07176e557fac8b44e62f",
-      "generated_hash": "02cbcf8758647c0ae661300748a1709883c05cb44b80e6076a624247bb82419f"
+      "source_hash": "1036ed6ce055af0629829f2ef71328f171d4f207a41231e2e505b854366c8022",
+      "generated_hash": "8ea5904dbffb81c25aa99cc7f5534ad063b1d7bf60de736d1289a03ecc613e1b"
     },
     {
       "name": "domain",
@@ -519,8 +519,8 @@
     {
       "name": "refactor",
       "source_skill": "skills/refactor",
-      "source_hash": "6ea99148467a48e1a0a397ce2b65a0890ba506c4e7b8b44c75d0e3212c2ece86",
-      "generated_hash": "a766c44c64307a8f67cb27396ad04788a36ff21dea50b14c0170ba5a8d9083a3"
+      "source_hash": "19aededa001917f28711593f30a0a01f2c9d6218db189abf5148535c51152098",
+      "generated_hash": "8586c4c6bd56e9b30189255e7e81d883de1c5e6c4da90001622cfe6779a94a40"
     },
     {
       "name": "research",
@@ -549,8 +549,8 @@
     {
       "name": "scaffold",
       "source_skill": "skills/scaffold",
-      "source_hash": "16abdb744b91faa2e54c9e4728ef34dab88aa06cc2117c39ec60ee8d3642ee04",
-      "generated_hash": "f59f6827a82fd596934597ddb24fd1e4e2e041b45bd3869d327acac28a770667"
+      "source_hash": "9194602a1b458b480de8d29f848264c7986de8a21105d9cb43780f22d4018f43",
+      "generated_hash": "c35c231d6a801e15922fde16b7be7c290574239e8360ce497f2670fbe58cdb44"
     },
     {
       "name": "scope",
@@ -573,8 +573,8 @@
     {
       "name": "skill-builder",
       "source_skill": "skills/skill-builder",
-      "source_hash": "27030e0e4c61867128c880c6fda1d8d187c8dec374e83dff8fd1bec47497ecdd",
-      "generated_hash": "8bd153ce168a79900d5e8b0c4b717c441c8ab12064592bb29e1b702cde804428"
+      "source_hash": "7ccbbe127470335d424b1ceb01bbe9cb16faf77cbf5e31f6215d31ce9a3dc39b",
+      "generated_hash": "9ab3978eca5991203690b4c5ae36c75b12e2d860002d8ccff5e4ceb5cdfdc6c5"
     },
     {
       "name": "standards",
@@ -597,8 +597,8 @@
     {
       "name": "test",
       "source_skill": "skills/test",
-      "source_hash": "dbbafbde1d401820937979725c57dee0bbee663f04c85648f8f0cb79b5ba3772",
-      "generated_hash": "0406e09c6634f50232bd51782431bb18f4c186ed5f1b5ec08b399e7c841dfe57"
+      "source_hash": "4336c618821968a95d2a83559344bbfb52becdf59564b1ab4b8a76991d87ebd0",
+      "generated_hash": "8bbdaf96e17d48436bf1a08f9fda55e946e7ef5d0769d94d1c3736fe800a1a49"
     },
     {
       "name": "toil-mining",
@@ -621,7 +621,7 @@
     {
       "name": "workflow-builder",
       "source_skill": "skills/workflow-builder",
-      "source_hash": "533e301e0cc9965b0ec2d5db064442aa0855615e4b3c21874cfdd0ee31df3f60",
+      "source_hash": "e5c1e9bb10ea95138d53aa7071b3d6cee41c34cfde323efc4ceda5b21a6f93ee",
       "generated_hash": "30f72769961a244749883e03cb04e329cd0feb03dd5b641d2a73a2e5dc8e9d42"
     }
   ],

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -393,8 +393,8 @@
     {
       "name": "converter",
       "source_skill": "skills/converter",
-      "source_hash": "163a055ef4c016e1cd731ee8d79dc9d9d0cd9137f6c997a8181326bb33c29ea7",
-      "generated_hash": "4b7d970cc6179f2aa7e73da2d01960cb079bc403c8867993c416b669ea77fa98"
+      "source_hash": "ee0a1bcc00f422dbf864d04a8972b8578056947b625e7e94d3632a40cee159ab",
+      "generated_hash": "ceb7e7f216b1c23c2fb78be27fda84fb0fc36d798145c5b490768ceeb6e6f9e2"
     },
     {
       "name": "council",
@@ -549,8 +549,8 @@
     {
       "name": "scaffold",
       "source_skill": "skills/scaffold",
-      "source_hash": "9194602a1b458b480de8d29f848264c7986de8a21105d9cb43780f22d4018f43",
-      "generated_hash": "c35c231d6a801e15922fde16b7be7c290574239e8360ce497f2670fbe58cdb44"
+      "source_hash": "3842025470fcf184e2fd96f7306f14de37b67864a42d8021f33f953bb76afce6",
+      "generated_hash": "9452dce2fd5026b986db3ca03cbc503dcf499b09dca909a6cbe8b8d025d9e57a"
     },
     {
       "name": "scope",
@@ -597,8 +597,8 @@
     {
       "name": "test",
       "source_skill": "skills/test",
-      "source_hash": "4336c618821968a95d2a83559344bbfb52becdf59564b1ab4b8a76991d87ebd0",
-      "generated_hash": "8bbdaf96e17d48436bf1a08f9fda55e946e7ef5d0769d94d1c3736fe800a1a49"
+      "source_hash": "c074c59a2e4ccae27f2a4f514b9e5a16a6d87465be8429405878e0641ec5d096",
+      "generated_hash": "be6eb93094d43ee18b0d87412661e0cc08724fa3d64e0724c0dd908dfa9dca22"
     },
     {
       "name": "toil-mining",

--- a/skills-codex/converter/.agentops-generated.json
+++ b/skills-codex/converter/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/converter",
   "layout": "modular",
-  "source_hash": "163a055ef4c016e1cd731ee8d79dc9d9d0cd9137f6c997a8181326bb33c29ea7",
-  "generated_hash": "4b7d970cc6179f2aa7e73da2d01960cb079bc403c8867993c416b669ea77fa98"
+  "source_hash": "ee0a1bcc00f422dbf864d04a8972b8578056947b625e7e94d3632a40cee159ab",
+  "generated_hash": "ceb7e7f216b1c23c2fb78be27fda84fb0fc36d798145c5b490768ceeb6e6f9e2"
 }

--- a/skills-codex/converter/.agentops-generated.json
+++ b/skills-codex/converter/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/converter",
   "layout": "modular",
-  "source_hash": "ee0a1bcc00f422dbf864d04a8972b8578056947b625e7e94d3632a40cee159ab",
-  "generated_hash": "ceb7e7f216b1c23c2fb78be27fda84fb0fc36d798145c5b490768ceeb6e6f9e2"
+  "source_hash": "abc9e6aec41184373a9e80a0baa047fde51b02f971b841a45ac323bafcde3b4a",
+  "generated_hash": "1d4a319edc74e19f18351d5cdb5b6cf128b0b2b97adcf89f85752f75f44f83f3"
 }

--- a/skills-codex/converter/.agentops-generated.json
+++ b/skills-codex/converter/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/converter",
   "layout": "modular",
-  "source_hash": "af311e6964a8ddaa4b1d880ed281deafac13f38ab4f7345d959dd59032179ab7",
-  "generated_hash": "714ef1de6292ea4747621fead2ab440044e8a782abde4e237366427bcd398468"
+  "source_hash": "163a055ef4c016e1cd731ee8d79dc9d9d0cd9137f6c997a8181326bb33c29ea7",
+  "generated_hash": "4b7d970cc6179f2aa7e73da2d01960cb079bc403c8867993c416b669ea77fa98"
 }

--- a/skills-codex/converter/SKILL.md
+++ b/skills-codex/converter/SKILL.md
@@ -8,6 +8,8 @@ Parse AgentOps skills into a universal SkillBundle format, then convert to targe
 
 The intermediate SkillBundle is what keeps conversions honest: every target reads the same parsed contract, so a rendering bug is a target-adapter bug, never a silent reinterpretation of the source. If two targets disagree about a skill's content, the bundle — not either output — arbitrates.
 
+This is **not** the owner of the shipped `skills-codex/**` projection: that path is generated and gated by `scripts/codex-sync.sh` via `scripts/regen-all.sh`. This converter is an ad-hoc, out-of-tree exporter (Codex, Cursor) that writes under `.agents/projections/converter/`; it never mutates `skills-codex/**`. When the shipped Codex twin and this exporter disagree, the shipped path wins.
+
 Named failure mode — **projection editing**: fixing a rendering problem by hand-editing the converted output, which the next conversion clean-writes away.
 
 Anti-pattern: merging new output into an existing target directory to preserve local tweaks. Corrective: fix the source skill or the adapter, then re-run the clean-write conversion.
@@ -52,8 +54,9 @@ The Cursor adapter produces a `<name>.mdc` rule file with YAML frontmatter (`des
 
 Write the converted output to disk.
 
-- **Default output directory:** `.agents/converter/<target>/<skill-name>/`
+- **Default output directory:** `.agents/projections/converter/<target>/<skill-name>/`
 - **Write semantics:** Clean-write. The target directory is deleted before writing. No merge with existing content.
+- **Refusal guard:** the write stage refuses — it does not silently redirect — when the resolved output directory equals the source package, contains it (an ancestor), or is the repository root, because the clean-write would otherwise delete the very files the conversion must read.
 
 ## CLI Usage
 
@@ -72,7 +75,7 @@ bash skills/converter/scripts/convert.sh --all <target> [output-dir]
 |----------|----------|-------------|
 | `skill-dir` | Yes (or `--all`) | Path to skill directory (e.g. `skills/council`) |
 | `target` | Yes | Target platform: `codex`, `cursor`, or `test` |
-| `output-dir` | No | Override output location. Default: `.agents/converter/<target>/<skill-name>/` |
+| `output-dir` | No | Override output location. Default: `.agents/projections/converter/<target>/<skill-name>/` |
 | `--all` | No | Convert all skills in `skills/` directory |
 | `--codex-layout` | No | Codex-only layout mode: `modular` (default) or `inline` (legacy inlined refs/scripts) |
 
@@ -99,7 +102,7 @@ To add a new target platform:
 **What happens:**
 1. The converter parses `skills/council/SKILL.md` frontmatter, markdown body, and any `references/` and `scripts/` files into a SkillBundle.
 2. The Codex adapter transforms the bundle into a `SKILL.md` (body + inlined references + scripts as code blocks) and a `prompt.md` (Codex prompt referencing the skill).
-3. Output is written to `.agents/converter/codex/council/`.
+3. Output is written to `.agents/projections/converter/codex/council/`.
 
 **Result:** A Codex-compatible skill package ready to use with OpenAI Codex CLI.
 
@@ -110,7 +113,7 @@ To add a new target platform:
 **What happens:**
 1. The converter scans every directory under `skills/` and parses each into a SkillBundle.
 2. The Cursor adapter transforms each bundle into a `.mdc` rule file with YAML frontmatter and body content, budget-fitted to 100KB max. Skills referencing MCP servers also get a `mcp.json` stub.
-3. Each skill's output is written to `.agents/converter/cursor/<skill-name>/`.
+3. Each skill's output is written to `.agents/projections/converter/cursor/<skill-name>/`.
 
 **Result:** All skills are available as Cursor rules, ready to drop into a `.cursor/rules/` directory.
 
@@ -120,14 +123,14 @@ To add a new target platform:
 |---------|-------|----------|
 | `parse error: no frontmatter found` | SKILL.md is missing the `---` delimited YAML frontmatter block | Add frontmatter with at least `name:` and `description:` fields, or run Heal Skill on the source package first |
 | Cursor `.mdc` output is missing references | Total bundle size exceeded the 100KB budget limit | The converter omits references largest-first to fit the budget. Split large reference files or move non-essential content to external docs |
-| Output directory already has old files | Previous conversion artifacts remain | This is expected -- the converter clean-writes by deleting the target directory before writing. If old files persist, manually delete `.agents/converter/<target>/<skill>/` |
+| Output directory already has old files | Previous conversion artifacts remain | This is expected -- the converter clean-writes by deleting the target directory before writing. If old files persist, manually delete `.agents/projections/converter/<target>/<skill>/` |
 | `--all` skips a skill directory | The directory has no `SKILL.md` file | Ensure each skill directory contains a valid `SKILL.md`. Run Heal Skill to detect empty directories |
 | Codex `prompt.md` description is truncated | The skill description exceeds 1024 characters | This is by design. The converter truncates at a word boundary to fit Codex limits. Shorten the description in SKILL.md frontmatter if the truncation point is awkward |
 | Conversion fails with passthrough parity check | A resource entry from source skill wasn't copied to output | Ensure source entries are readable and copyable (including nested files). Re-run conversion; failure is intentional to prevent drift between `skills/` and converted output |
 
 ## Output Specification
 
-- **Path:** `.agents/converter/<target>/<skill-name>/` by default, or the exact caller-supplied output directory.
+- **Path:** `.agents/projections/converter/<target>/<skill-name>/` by default, or the exact caller-supplied output directory.
 - **Filename:** Codex emits `SKILL.md`, `prompt.md`, and copied resources; Cursor emits `<skill-name>.mdc` and optional `mcp.json`; `test` emits the raw bundle representation.
 - **Format:** target-valid UTF-8 text with required frontmatter, rewritten runtime references, and byte-present passthrough resources; Cursor output remains within 100KB.
 - **Exit code:** run `bash skills/converter/scripts/convert.sh <skill-dir> <target> <output-dir>` and require zero; treat parse, budget, write, or passthrough-parity failure as nonzero and incomplete.

--- a/skills-codex/converter/references/skill-bundle-schema.md
+++ b/skills-codex/converter/references/skill-bundle-schema.md
@@ -75,9 +75,9 @@ Target adapters receive the SkillBundle and decide which fields to use:
 
 | Adapter | Fields Used | Notes |
 |---------|-------------|-------|
-| codex | name, description, body, references | Flattens into single agents.md |
-| cursor | name, description, body, references | Splits into .cursor/rules/ files |
-| test | all | Dumps full bundle for inspection |
+| codex | name, description, body, references, scripts | Emits `SKILL.md` + `prompt.md`; modular by default (copies + links resources), `--codex-layout inline` appends them |
+| cursor | name, description, body, references, scripts | Emits a single `<name>.mdc` rule (+ optional `mcp.json`), budget-fitted to 100KB |
+| test | all | Dumps the full bundle as structured markdown for inspection |
 
 ## Serialization
 

--- a/skills-codex/converter/scripts/convert.sh
+++ b/skills-codex/converter/scripts/convert.sh
@@ -659,6 +659,9 @@ resolve_physical() {
 # Both arguments must already be canonical (symlink/.. resolved).
 within() {
   local child="$1" parent="$2"
+  # Root is the ancestor of everything; the general glob below would build
+  # the broken pattern "//*" for it.
+  [[ "$parent" == "/" ]] && return 0
   case "$child/" in
     "$parent"/*) return 0 ;;
   esac

--- a/skills-codex/converter/scripts/convert.sh
+++ b/skills-codex/converter/scripts/convert.sh
@@ -4,6 +4,16 @@
 #        bash skills/converter/scripts/convert.sh --all <target> [output-dir]
 set -euo pipefail
 
+# This script uses namerefs (`local -n`), which require Bash >= 4.3. On stock
+# macOS /bin/bash (3.2.57) a nameref is an invalid option that aborts under
+# `set -e` with an opaque message and zero files written. Fail closed with a
+# clear diagnostic instead of an unrunnable surprise.
+if (( BASH_VERSINFO[0] < 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 3) )); then
+  echo "ERROR: convert.sh requires Bash >= 4.3 (namerefs); found ${BASH_VERSION}." >&2
+  echo "       On macOS install a newer bash ('brew install bash') and invoke it explicitly." >&2
+  exit 2
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 SKILL_PATTERN=""
@@ -278,6 +288,10 @@ parse_skill_md() {
 
 # Collect files from a subdirectory into parallel arrays.
 # Args: <dir> <array-name-names> <array-name-contents>
+# Scope: top-level regular files of <dir> only. Nested reference/script files
+# are NOT inlined here; copy_passthrough_resources() preserves them recursively
+# in the written output, so nested resources survive a conversion even though
+# they are not flattened into the target SKILL.md body.
 collect_files() {
   local dir="$1"
   local -n names_arr="$2"
@@ -454,8 +468,10 @@ convert_cursor() {
   local out=""
 
   # ── YAML frontmatter ──
+  # Single-quote and escape the description: an unquoted value containing a
+  # colon, quote, or leading special char yields invalid Cursor YAML (CV-9).
   out+="---"$'\n'
-  out+="description: ${BUNDLE_DESC}"$'\n'
+  out+="description: '$(yaml_escape_single_quote "$BUNDLE_DESC")'"$'\n'
   out+="globs: "$'\n'
   out+="alwaysApply: false"$'\n'
   out+="---"$'\n\n'
@@ -622,9 +638,54 @@ verify_passthrough_resources() {
   fi
 }
 
+# Resolve a possibly-nonexistent absolute path to its physical form, collapsing
+# `..` and symlinks against the deepest existing ancestor. Used before any
+# destructive comparison so the guard cannot be fooled by an unresolved path.
+resolve_physical() {
+  local target="$1" suffix=""
+  while [[ ! -e "$target" ]]; do
+    suffix="/$(basename "$target")$suffix"
+    target="$(dirname "$target")"
+    [[ "$target" == "/" ]] && break
+  done
+  if [[ -d "$target" ]]; then
+    printf '%s%s\n' "$(cd "$target" && pwd -P)" "$suffix"
+  else
+    printf '%s/%s%s\n' "$(cd "$(dirname "$target")" && pwd -P)" "$(basename "$target")" "$suffix"
+  fi
+}
+
+# Refuse a clean-write target that would destroy the source or a parent. The
+# write stage rm -rf's output_dir; if output_dir is the source package, an
+# ancestor of it, or the repo root, that rm -rf deletes files this conversion
+# must read (CV-1: a source-dir output went 4 files -> 2 at exit 0). Fix by
+# refusal, never by silently appending a subdir.
+assert_safe_output_dir() {
+  local output_dir="$1" source_dir="$2"
+  local out_abs src_abs repo_abs
+  out_abs="$(resolve_physical "$output_dir")"
+  src_abs="$(cd "$source_dir" && pwd -P)"
+  repo_abs="$(cd "$REPO_ROOT" && pwd -P)"
+
+  if [[ "$out_abs" == "$repo_abs" ]]; then
+    die "refusing to clean-write the repository root: $out_abs"
+  fi
+  if [[ "$out_abs" == "$src_abs" ]]; then
+    die "refusing to clean-write the source package itself: $out_abs (choose a distinct output dir)"
+  fi
+  case "$src_abs/" in
+    "$out_abs"/*)
+      die "refusing to clean-write '$out_abs': it contains the source package '$src_abs'"
+      ;;
+  esac
+}
+
 write_output() {
   local output_dir="$1"
   local source_dir="$2"
+
+  # Guard BEFORE the destructive clean-write below.
+  assert_safe_output_dir "$output_dir" "$source_dir"
 
   # Clean-write: delete target dir before writing
   if [[ -d "$output_dir" ]]; then
@@ -664,9 +725,9 @@ convert_one_skill() {
 
   [[ -n "$BUNDLE_NAME" ]] || die "Failed to parse name from $skill_dir/SKILL.md"
 
-  # Default output dir
+  # Default output dir (ADR-0016 closed set: generated projection tier)
   if [[ -z "$output_dir" ]]; then
-    output_dir="$REPO_ROOT/.agents/converter/$target/$BUNDLE_NAME"
+    output_dir="$REPO_ROOT/.agents/projections/converter/$target/$BUNDLE_NAME"
   elif [[ "$output_dir" != /* ]]; then
     output_dir="$REPO_ROOT/$output_dir"
   fi

--- a/skills-codex/converter/scripts/convert.sh
+++ b/skills-codex/converter/scripts/convert.sh
@@ -655,11 +655,26 @@ resolve_physical() {
   fi
 }
 
-# Refuse a clean-write target that would destroy the source or a parent. The
-# write stage rm -rf's output_dir; if output_dir is the source package, an
-# ancestor of it, or the repo root, that rm -rf deletes files this conversion
-# must read (CV-1: a source-dir output went 4 files -> 2 at exit 0). Fix by
-# refusal, never by silently appending a subdir.
+# within CHILD PARENT -> 0 if CHILD equals PARENT or is nested under PARENT.
+# Both arguments must already be canonical (symlink/.. resolved).
+within() {
+  local child="$1" parent="$2"
+  case "$child/" in
+    "$parent"/*) return 0 ;;
+  esac
+  return 1
+}
+
+# Refuse a clean-write target that would destroy the source or the repository.
+# The write stage rm -rf's output_dir; both paths are canonicalized (symlinks
+# and `..` resolved via resolve_physical / `pwd -P`) before comparison so the
+# guard cannot be bypassed by an alias. The containment test is BIDIRECTIONAL:
+# refuse when the output equals the source, contains it (ancestor), OR lives
+# inside it (descendant) — any of those puts source files under the rm -rf — and
+# refuse when the output is, or is an ancestor of, the repository root (an output
+# above the repo would take the whole tree with it). CV-1: a source-dir output
+# went 4 files -> 2 at exit 0. Fix by refusal, never by silently appending a
+# subdir.
 assert_safe_output_dir() {
   local output_dir="$1" source_dir="$2"
   local out_abs src_abs repo_abs
@@ -667,17 +682,15 @@ assert_safe_output_dir() {
   src_abs="$(cd "$source_dir" && pwd -P)"
   repo_abs="$(cd "$REPO_ROOT" && pwd -P)"
 
-  if [[ "$out_abs" == "$repo_abs" ]]; then
-    die "refusing to clean-write the repository root: $out_abs"
+  if within "$out_abs" "$src_abs"; then
+    die "refusing to clean-write '$out_abs': it is the source package, or lives inside it ('$src_abs')"
   fi
-  if [[ "$out_abs" == "$src_abs" ]]; then
-    die "refusing to clean-write the source package itself: $out_abs (choose a distinct output dir)"
+  if within "$src_abs" "$out_abs"; then
+    die "refusing to clean-write '$out_abs': it contains the source package '$src_abs'"
   fi
-  case "$src_abs/" in
-    "$out_abs"/*)
-      die "refusing to clean-write '$out_abs': it contains the source package '$src_abs'"
-      ;;
-  esac
+  if within "$repo_abs" "$out_abs"; then
+    die "refusing to clean-write '$out_abs': it is, or contains, the repository root '$repo_abs'"
+  fi
 }
 
 write_output() {

--- a/skills-codex/converter/scripts/validate.sh
+++ b/skills-codex/converter/scripts/validate.sh
@@ -3,16 +3,40 @@
 # ("SKILL.md exists" only, which passed while the pipeline could delete its own
 # source) with real proofs (CV-2):
 #   1. a happy-path conversion writes the expected target + passthrough files;
-#   2. the destructive clean-write path is CLOSED — an output dir equal to, or
-#      an ancestor of, the source package is refused and the source survives
-#      (CV-1: a source-dir output previously went 4 files -> 2 at exit 0).
+#   2. the destructive clean-write path is CLOSED in BOTH directions — an output
+#      dir equal to, an ancestor of, a descendant of, or a symlink into the
+#      source package is refused; and an output that is or contains the repo
+#      root is refused (CV-1). Each refusal is proven to happen BEFORE any
+#      deletion: the source content digest is unchanged AND the exit is nonzero.
 set -euo pipefail
 
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CONVERT="$SKILL_DIR/scripts/convert.sh"
+REPO_ROOT="$(cd "$SKILL_DIR/../.." && pwd -P)"
 FAIL=0
 pass() { printf 'PASS: %s\n' "$1"; }
 fail() { printf 'FAIL: %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+# Content + structure digest of a directory tree (path-relative, order-stable).
+dir_digest() {
+  ( cd "$1" && find . -type f -exec shasum -a 256 {} + | LC_ALL=C sort ) \
+    | shasum -a 256 | awk '{print $1}'
+}
+
+# assert_refused DESC OUTPUT — the conversion must exit nonzero AND leave the
+# source content digest unchanged (refusal before any deletion).
+assert_refused() {
+  local desc="$1" out="$2"
+  if bash "$CONVERT" "$FIX" codex "$out" >/dev/null 2>&1; then
+    fail "$desc: expected refusal, got success"
+    return
+  fi
+  if [[ "$(dir_digest "$FIX")" == "$SRC_DIGEST" ]]; then
+    pass "$desc: refused before any deletion; source content intact"
+  else
+    fail "$desc: source content changed — refusal came too late"
+  fi
+}
 
 if [[ -f "$SKILL_DIR/SKILL.md" ]]; then pass "SKILL.md exists"; else fail "SKILL.md exists"; fi
 if [[ -f "$CONVERT" ]]; then pass "convert.sh exists"; else fail "convert.sh exists"; fi
@@ -21,39 +45,32 @@ if [[ -f "$CONVERT" ]]; then pass "convert.sh exists"; else fail "convert.sh exi
 # must never be handed a destructive cleanup to imitate.
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/converter-selftest.XXXXXX")"
 FIX="$WORK/fixture-skill"
-mkdir -p "$FIX/references"
+mkdir -p "$FIX/references" "$FIX/scripts"
 printf -- '---\nname: fixture-skill\ndescription: converter self-test fixture\n---\n# Body\n' > "$FIX/SKILL.md"
 printf 'reference payload\n' > "$FIX/references/note.md"
-before_count="$(find "$FIX" -type f | wc -l | tr -d ' ')"
+printf 'echo fixture\n' > "$FIX/scripts/tool.sh"
+SRC_DIGEST="$(dir_digest "$FIX")"
 
-# 1. Happy path: a distinct output dir converts and writes the target files.
+# 1. Happy path: a distinct output dir converts, writes the target files, and
+# does not touch the source.
 out="$WORK/out"
 if bash "$CONVERT" "$FIX" codex "$out" >/dev/null 2>&1 \
-  && [[ -f "$out/SKILL.md" && -f "$out/prompt.md" && -f "$out/references/note.md" ]]; then
-  pass "happy-path conversion writes target + passthrough files"
+  && [[ -f "$out/SKILL.md" && -f "$out/prompt.md" && -f "$out/references/note.md" && -f "$out/scripts/tool.sh" ]] \
+  && [[ "$(dir_digest "$FIX")" == "$SRC_DIGEST" ]]; then
+  pass "happy-path conversion writes target + passthrough files; source intact"
 else
-  fail "happy-path conversion writes target + passthrough files"
+  fail "happy-path conversion writes target + passthrough files; source intact"
 fi
 
-# 2. Destructive path closed: output == source must be refused (nonzero) AND
-# leave every source file intact.
-if bash "$CONVERT" "$FIX" codex "$FIX" >/dev/null 2>&1; then
-  fail "clean-write onto the source package is refused"
-else
-  after_count="$(find "$FIX" -type f | wc -l | tr -d ' ')"
-  if [[ "$after_count" == "$before_count" ]]; then
-    pass "clean-write onto the source package is refused; source intact ($after_count files)"
-  else
-    fail "source package damaged by clean-write onto itself ($before_count -> $after_count files)"
-  fi
-fi
+# 2. Bidirectional + repo containment refusals.
+assert_refused "output == source"                 "$FIX"
+assert_refused "output is an ancestor of source"  "$WORK"
+assert_refused "output is a descendant of source" "$FIX/references"
+assert_refused "output is an ancestor of the repo root" "$(dirname "$REPO_ROOT")"
 
-# 3. Ancestor output dir (contains the source) must also be refused.
-if bash "$CONVERT" "$FIX" codex "$WORK" >/dev/null 2>&1; then
-  fail "clean-write onto an ancestor of the source is refused"
-else
-  pass "clean-write onto an ancestor of the source is refused"
-fi
+# Symlink resolving into the source must be canonicalized and refused.
+ln -s "$FIX/references" "$WORK/link-into-src"
+assert_refused "output is a symlink into the source" "$WORK/link-into-src"
 
 echo ""
 if [[ "$FAIL" -eq 0 ]]; then

--- a/skills-codex/converter/scripts/validate.sh
+++ b/skills-codex/converter/scripts/validate.sh
@@ -1,12 +1,64 @@
 #!/usr/bin/env bash
+# Behavioral self-test for the converter. Replaces the prior vacuous check
+# ("SKILL.md exists" only, which passed while the pipeline could delete its own
+# source) with real proofs (CV-2):
+#   1. a happy-path conversion writes the expected target + passthrough files;
+#   2. the destructive clean-write path is CLOSED — an output dir equal to, or
+#      an ancestor of, the source package is refused and the source survives
+#      (CV-1: a source-dir output previously went 4 files -> 2 at exit 0).
 set -euo pipefail
-SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-PASS=0; FAIL=0
 
-check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONVERT="$SKILL_DIR/scripts/convert.sh"
+FAIL=0
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1"; FAIL=$((FAIL + 1)); }
 
-check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
-check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+if [[ -f "$SKILL_DIR/SKILL.md" ]]; then pass "SKILL.md exists"; else fail "SKILL.md exists"; fi
+if [[ -f "$CONVERT" ]]; then pass "convert.sh exists"; else fail "convert.sh exists"; fi
 
-echo ""; echo "Results: $PASS passed, $FAIL failed"
-[ $FAIL -eq 0 ] && exit 0 || exit 1
+# Disposable fixture, left in place on exit (no rm -rf): the guard under test
+# must never be handed a destructive cleanup to imitate.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/converter-selftest.XXXXXX")"
+FIX="$WORK/fixture-skill"
+mkdir -p "$FIX/references"
+printf -- '---\nname: fixture-skill\ndescription: converter self-test fixture\n---\n# Body\n' > "$FIX/SKILL.md"
+printf 'reference payload\n' > "$FIX/references/note.md"
+before_count="$(find "$FIX" -type f | wc -l | tr -d ' ')"
+
+# 1. Happy path: a distinct output dir converts and writes the target files.
+out="$WORK/out"
+if bash "$CONVERT" "$FIX" codex "$out" >/dev/null 2>&1 \
+  && [[ -f "$out/SKILL.md" && -f "$out/prompt.md" && -f "$out/references/note.md" ]]; then
+  pass "happy-path conversion writes target + passthrough files"
+else
+  fail "happy-path conversion writes target + passthrough files"
+fi
+
+# 2. Destructive path closed: output == source must be refused (nonzero) AND
+# leave every source file intact.
+if bash "$CONVERT" "$FIX" codex "$FIX" >/dev/null 2>&1; then
+  fail "clean-write onto the source package is refused"
+else
+  after_count="$(find "$FIX" -type f | wc -l | tr -d ' ')"
+  if [[ "$after_count" == "$before_count" ]]; then
+    pass "clean-write onto the source package is refused; source intact ($after_count files)"
+  else
+    fail "source package damaged by clean-write onto itself ($before_count -> $after_count files)"
+  fi
+fi
+
+# 3. Ancestor output dir (contains the source) must also be refused.
+if bash "$CONVERT" "$FIX" codex "$WORK" >/dev/null 2>&1; then
+  fail "clean-write onto an ancestor of the source is refused"
+else
+  pass "clean-write onto an ancestor of the source is refused"
+fi
+
+echo ""
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "converter self-test: PASS"
+  exit 0
+fi
+echo "converter self-test: FAIL ($FAIL failed)" >&2
+exit 1

--- a/skills-codex/doc/.agentops-generated.json
+++ b/skills-codex/doc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/doc",
   "layout": "modular",
-  "source_hash": "2c8bac339d06f5fd1f712a1bb1cb7cb5bf4441be20fd07176e557fac8b44e62f",
-  "generated_hash": "02cbcf8758647c0ae661300748a1709883c05cb44b80e6076a624247bb82419f"
+  "source_hash": "1036ed6ce055af0629829f2ef71328f171d4f207a41231e2e505b854366c8022",
+  "generated_hash": "8ea5904dbffb81c25aa99cc7f5534ad063b1d7bf60de736d1289a03ecc613e1b"
 }

--- a/skills-codex/doc/SKILL.md
+++ b/skills-codex/doc/SKILL.md
@@ -42,7 +42,7 @@ Default mode is deliberately thin. Given a Doc command and target:
 
 1. **Detect project type** — `ls package.json pyproject.toml go.mod Cargo.toml` + existing `docs/`; classify CODING / INFORMATIONAL / OPS.
 2. **Run the command** — `discover` (grep undocumented funcs), `coverage` (documented vs total), `gen [feature]` (read code → stamp function/class markdown), `all`, or `validate`.
-3. **Write the report** to `.agents/doc/YYYY-MM-DD-<target>.md` (coverage %, generated, gaps, validation issues), then report coverage + gaps to the user.
+3. **Write the report** to `.agents/scratch/doc/YYYY-MM-DD-<target>.md` (coverage %, generated, gaps, validation issues), then report coverage + gaps to the user.
 
 Full step-by-step detail — grep recipes, function/class + code-map templates, the report skeleton, key rules, worked examples, and the troubleshooting table — lives in **[references/default-mode.md](references/default-mode.md)** (moved there in the generic-craft trim). Read it when you need the exact shapes; otherwise just do the three steps.
 
@@ -70,7 +70,7 @@ doc** failure mode — accurate, complete, and useless.
 
 ## Output Specification
 
-- **Path:** default-mode reports go to the artifact directory `.agents/doc/`; README mode updates the repository `README.md`; OSS scaffold mode creates missing root documentation only by default. The separate OSS `refresh` path may update an existing doc only after explicit user confirmation.
+- **Path:** default-mode reports go to the artifact directory `.agents/scratch/doc/`; README mode updates the repository `README.md`; OSS scaffold mode creates missing root documentation only by default. The separate OSS `refresh` path may update an existing doc only after explicit user confirmation.
 - **Filename:** default reports use the filename convention `YYYY-MM-DD-<target>.md`; README and OSS filenames follow their mode references.
 - **Format:** outputs are Markdown; the default report schema records coverage percentage, generated artifacts, gaps, and validation issues.
 - **Validation command:** validate the skill contract with `bash skills/doc/scripts/validate.sh`, then run the mode-specific validation required by its reference before reporting completion.

--- a/skills-codex/doc/references/default-mode.md
+++ b/skills-codex/doc/references/default-mode.md
@@ -145,7 +145,7 @@ Check for:
 
 ## Step 6: Write Report
 
-**Write to:** `.agents/doc/YYYY-MM-DD-<target>.md`
+**Write to:** `.agents/scratch/doc/YYYY-MM-DD-<target>.md`
 
 ```markdown
 # Documentation Report: <Target>
@@ -168,10 +168,6 @@ Check for:
 ## Validation Issues
 - <issue 1>
 - <issue 2>
-
-## Next Steps
-- [ ] Document remaining gaps
-- [ ] Fix validation issues
 ```
 
 ## Step 7: Report to User
@@ -225,7 +221,7 @@ Tell the user:
 2. Agent counts total functions/classes with `grep -r "^def \|^class "`
 3. Agent counts documented items by searching for docstrings (`"""`)
 4. Agent calculates coverage: 45/67 items = 67% coverage
-5. Agent writes report to `.agents/doc/2026-02-13-coverage.md`
+5. Agent writes report to `.agents/scratch/doc/2026-02-13-coverage.md`
 6. Agent lists 22 undocumented functions as gaps
 
 **Result:** Documentation coverage report shows 67% coverage with specific list of 22 functions needing docs.

--- a/skills-codex/doc/references/validation-rules.md
+++ b/skills-codex/doc/references/validation-rules.md
@@ -131,22 +131,6 @@ ORPHANED DOCUMENTATION
 
 ---
 
-## --create-issues Flag
-
-Auto-create tracking issues for gaps:
-
-```bash
-# Prefer beads
-bd create --title "docs: create code-map for $FEATURE" \
-          --type task --priority P1
-
-# Fallback to GitHub
-gh issue create --title "docs: create code-map for $FEATURE" \
-                --label documentation
-```
-
----
-
 ## Semantic Validation (CODING repos)
 
 **Structure vs Semantic:** Structural validation checks formatting. Semantic validation checks if claims are TRUE.

--- a/skills-codex/refactor/.agentops-generated.json
+++ b/skills-codex/refactor/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/refactor",
   "layout": "modular",
-  "source_hash": "6ea99148467a48e1a0a397ce2b65a0890ba506c4e7b8b44c75d0e3212c2ece86",
-  "generated_hash": "a766c44c64307a8f67cb27396ad04788a36ff21dea50b14c0170ba5a8d9083a3"
+  "source_hash": "19aededa001917f28711593f30a0a01f2c9d6218db189abf5148535c51152098",
+  "generated_hash": "8586c4c6bd56e9b30189255e7e81d883de1c5e6c4da90001622cfe6779a94a40"
 }

--- a/skills-codex/refactor/SKILL.md
+++ b/skills-codex/refactor/SKILL.md
@@ -45,7 +45,8 @@ transformation on behavior-identical proof:
 - For output-producing surfaces (generators, serializers, formatters, reports),
   hash the outputs: capture golden-output hashes over identical inputs before
   the change and compare byte-for-byte after. A hash mismatch is a behavior
-  diff to explain or revert, never to shrug at.
+  diff to surface and explain, never to shrug at; the caller decides whether to
+  keep, narrow, or reverse the change.
 - Observable error messages, exit codes, and public signatures on the changed
   surface are part of behavior unless the caller excluded them.
 

--- a/skills-codex/refactor/references/refactor.feature
+++ b/skills-codex/refactor/references/refactor.feature
@@ -1,27 +1,32 @@
-# Executable spec for the /refactor skill — safe incremental refactoring (supporting role).
-# /refactor transforms code one step at a time with test verification — one transformation, one
-# test run, one commit, never batched — preserving behavior. Target mode refactors a chosen unit;
-# sweep mode (--sweep) runs /complexity first to pick targets. Hexagon: supporting; consumes
-# complexity (sweep targeting) + repo-context (the code it transforms); produces git-changes. (soc-qk4b)
+# Executable spec for the refactor skill — one behavior-preserving transformation (supporting role).
+# refactor applies ONE caller-selected structural transformation, runs the focused check plus the
+# smallest justified regression check, and reports the diff, commands, results, and behavior not
+# checked. It does not commit, revert, retry, validate, or route subsequent work — a red result is
+# evidence returned to the caller, who owns version control and what happens next. Hexagon:
+# supporting; consumes repo-context (the code it transforms); produces code-changes.
 
-Feature: Refactor executes safe incremental transformations
-  As the safe-refactoring step
-  I want each transformation verified by tests before the next
-  So that refactors never silently change behavior
+Feature: Refactor executes one behavior-preserving transformation and reports evidence
+  As the behavior-preserving transformation step
+  I want one bounded structural change proven behavior-identical
+  So that structure improves without silently changing observable behavior
 
-  Scenario: one transformation, one test run, one commit
-    When /refactor applies a transformation
-    Then it runs the tests, then commits that single transformation
-    And transformations are not batched together
+  Scenario: one bounded transformation, then report
+    When refactor applies one caller-selected transformation
+    Then it runs the focused check and the smallest justified regression check
+    And it reports the diff summary, commands, results, and behavior not checked
+    And it does not commit the change or route any subsequent work
 
-  Scenario: a failing test reverts the transformation
-    When a transformation makes a test fail
-    Then that transformation is reverted and behavior is preserved
+  Scenario: a red result is reported, not reverted
+    When the focused or regression check comes back red
+    Then refactor returns that result to the caller as evidence
+    And it does not automatically revert, narrow, or retry the transformation
 
-  Scenario: sweep mode targets by complexity
-    When /refactor --sweep runs over a directory
-    Then it runs /complexity first to identify targets and works highest-complexity first
+  Scenario: neutrality gate rejects new or vanished red
+    When the same pre-existing failures do not hold before and after
+    Then refactor reports the behavior difference rather than accepting the change
+    And a test that stopped running counts as a behavior change
 
-  Scenario: target mode refactors a chosen unit
-    When /refactor runs on a specific file, function, or class
-    Then it refactors that unit directly, step by step
+  Scenario: seams are probed in disposable isolation before cutting
+    When more than one candidate seam exists for the transformation
+    Then refactor probes at most two seams in disposable isolation and keeps only the knowledge
+    And it reports both findings to the caller rather than trying a third

--- a/skills-codex/scaffold/.agentops-generated.json
+++ b/skills-codex/scaffold/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/scaffold",
   "layout": "modular",
-  "source_hash": "9194602a1b458b480de8d29f848264c7986de8a21105d9cb43780f22d4018f43",
-  "generated_hash": "c35c231d6a801e15922fde16b7be7c290574239e8360ce497f2670fbe58cdb44"
+  "source_hash": "3842025470fcf184e2fd96f7306f14de37b67864a42d8021f33f953bb76afce6",
+  "generated_hash": "9452dce2fd5026b986db3ca03cbc503dcf499b09dca909a6cbe8b8d025d9e57a"
 }

--- a/skills-codex/scaffold/.agentops-generated.json
+++ b/skills-codex/scaffold/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/scaffold",
   "layout": "modular",
-  "source_hash": "16abdb744b91faa2e54c9e4728ef34dab88aa06cc2117c39ec60ee8d3642ee04",
-  "generated_hash": "f59f6827a82fd596934597ddb24fd1e4e2e041b45bd3869d327acac28a770667"
+  "source_hash": "9194602a1b458b480de8d29f848264c7986de8a21105d9cb43780f22d4018f43",
+  "generated_hash": "c35c231d6a801e15922fde16b7be7c290574239e8360ce497f2670fbe58cdb44"
 }

--- a/skills-codex/scaffold/references/generic-templates.md
+++ b/skills-codex/scaffold/references/generic-templates.md
@@ -186,17 +186,9 @@ Run these checks in order. Stop and fix if any fail.
 
 If a tool is not installed (e.g., `ruff`, `golangci-lint`), note it as a warning but do not fail the scaffold.
 
-## Step 5: Initial Commit
-
-After verification passes, create the initial commit:
-
-```
-bootstrap(<name>): scaffold <language> <type> project
-```
-
-Example: `bootstrap(my-cli): scaffold go cli project`
-
-Do NOT push. The user decides when to push.
+Report the generated files and the command results, then stop. The caller owns
+version control, revision, and delivery — this scaffold does not `git init`,
+stage, commit, push, or decide what happens next.
 
 ## Component Mode
 
@@ -336,7 +328,6 @@ Include caching directives and artifact definitions.
 | Directory already exists | Ask user: overwrite, merge, or abort |
 | Build tool not installed | Note missing tool, generate files anyway, warn user |
 | Test fails on generated code | Fix the generated code (this is a scaffold bug) |
-| Git init fails | Verify not inside existing repo, handle accordingly |
 
 ## Output Summary
 
@@ -348,9 +339,4 @@ Scaffold complete: <name> (<language> <type>)
   Build: PASS
   Tests: PASS (<count> tests)
   Lint:  PASS | WARN (tool not installed)
-  Commit: bootstrap(<name>): scaffold <language> <type> project
-
-Next steps:
-  cd <name>
-  <language-specific "run" command>
 ```

--- a/skills-codex/scaffold/references/generic-templates.md
+++ b/skills-codex/scaffold/references/generic-templates.md
@@ -186,9 +186,9 @@ Run these checks in order. Stop and fix if any fail.
 
 If a tool is not installed (e.g., `ruff`, `golangci-lint`), note it as a warning but do not fail the scaffold.
 
-Report the generated files and the command results, then stop. The caller owns
-version control, revision, and delivery — this scaffold does not `git init`,
-stage, commit, push, or decide what happens next.
+Report the generated files and the command results, then stop. Version control,
+revision, and delivery stay with the caller; this scaffold writes files only and
+takes no source-control or continuation action.
 
 ## Component Mode
 

--- a/skills-codex/scaffold/scripts/validate.sh
+++ b/skills-codex/scaffold/scripts/validate.sh
@@ -6,12 +6,21 @@ SKILL="$SKILL_DIR/SKILL.md"
 
 [[ -s "$SKILL" ]]
 grep -q '^name: scaffold$' "$SKILL"
-grep -q '^  effects: \[\]$' "$SKILL"
 grep -q '^## Contract$' "$SKILL"
 grep -q '^## Evidence$' "$SKILL"
 grep -Fq 'The caller owns version control, revision, and delivery.' "$SKILL"
 if grep -Eiq 'AUTO-REDO|ONE-HELPER|HELPER-ESCALATE|ao land|next_action' "$SKILL"; then
   echo 'scaffold contract contains retired lifecycle vocabulary' >&2
+  exit 1
+fi
+
+# References must not re-grant the Git-mutation or continuation authority the
+# contract denies ("does not schedule RPI, create work ownership, mutate Git,
+# or decide what happens next"). This sweep covers references/** because a grant
+# hidden in a template file passes unseen when only SKILL.md is scanned.
+if [[ -d "$SKILL_DIR/references" ]] \
+  && grep -rEiq 'initial commit|git commit|git push|next steps:' "$SKILL_DIR/references"; then
+  echo 'scaffold references confer Git-commit or continuation authority the contract denies' >&2
   exit 1
 fi
 

--- a/skills-codex/scaffold/scripts/validate.sh
+++ b/skills-codex/scaffold/scripts/validate.sh
@@ -18,8 +18,14 @@ fi
 # contract denies ("does not schedule RPI, create work ownership, mutate Git,
 # or decide what happens next"). This sweep covers references/** because a grant
 # hidden in a template file passes unseen when only SKILL.md is scanned.
+#
+# The pattern covers the deleted grants (Step 5 "Initial Commit", the summary
+# "Commit:" line, the "Git init fails" row) and equivalent forms. Bare `push` is
+# matched only when it is a verb (followed by space, period, or end-of-line), so
+# the legitimate CI-trigger key `push:` and the word `pushd` do NOT false-fire.
+FORBIDDEN='initial commit|create a commit|git commit|git add|git init|git push|commit:|next step|\bpush([[:space:]]|[.]|$)'
 if [[ -d "$SKILL_DIR/references" ]] \
-  && grep -rEiq 'initial commit|git commit|git push|next steps:' "$SKILL_DIR/references"; then
+  && grep -rEiq "$FORBIDDEN" "$SKILL_DIR/references"; then
   echo 'scaffold references confer Git-commit or continuation authority the contract denies' >&2
   exit 1
 fi

--- a/skills-codex/skill-builder/.agentops-generated.json
+++ b/skills-codex/skill-builder/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/skill-builder",
   "layout": "modular",
-  "source_hash": "27030e0e4c61867128c880c6fda1d8d187c8dec374e83dff8fd1bec47497ecdd",
-  "generated_hash": "8bd153ce168a79900d5e8b0c4b717c441c8ab12064592bb29e1b702cde804428"
+  "source_hash": "7ccbbe127470335d424b1ceb01bbe9cb16faf77cbf5e31f6215d31ce9a3dc39b",
+  "generated_hash": "9ab3978eca5991203690b4c5ae36c75b12e2d860002d8ccff5e4ceb5cdfdc6c5"
 }

--- a/skills-codex/skill-builder/SKILL.md
+++ b/skills-codex/skill-builder/SKILL.md
@@ -122,8 +122,8 @@ skills/<slug>/
 └── scripts/validate.sh
 ```
 
-The build report is `.agents/audits/<slug>-build.json` and conforms to
-`schemas/build-report.json`. Deep audit JSON conforms to
+The build report is `.agents/scratch/skill-builder/<slug>-build.json` and
+conforms to `schemas/build-report.json`. Deep audit JSON conforms to
 `schemas/audit-report.json`. Generated inventories and runtime projections are
 not additional sources of truth. The caller owns any subsequent edit or
 invocation.

--- a/skills-codex/skill-builder/scripts/build.sh
+++ b/skills-codex/skill-builder/scripts/build.sh
@@ -29,7 +29,7 @@ esac
 
 bash "$SCRIPT_DIR/init.sh" "$init_mode" "$slug" "$@"
 
-report="$REPO_ROOT/.agents/audits/${slug}-build.json"
+report="$REPO_ROOT/.agents/scratch/skill-builder/${slug}-build.json"
 if ! HEAL_REPO_ROOT="$REPO_ROOT" bash "$REPO_ROOT/skills/skill-builder/scripts/heal.sh" \
   --check --strict "$REPO_ROOT/skills/$slug"; then
   echo "skill-builder: structural check failed" >&2

--- a/skills-codex/skill-builder/scripts/init.sh
+++ b/skills-codex/skill-builder/scripts/init.sh
@@ -146,8 +146,8 @@ exec bash "$REPO_ROOT/skills/skill-builder/scripts/heal.sh" --check --strict "$S
 EOF
 chmod +x "$target/scripts/validate.sh"
 
-mkdir -p "$REPO_ROOT/.agents/audits"
-report="$REPO_ROOT/.agents/audits/${slug}-build.json"
+mkdir -p "$REPO_ROOT/.agents/scratch/skill-builder"
+report="$REPO_ROOT/.agents/scratch/skill-builder/${slug}-build.json"
 python3 - "$report" "$mode" "$slug" "$source_hint" <<'PY'
 import json
 from pathlib import Path

--- a/skills-codex/test/.agentops-generated.json
+++ b/skills-codex/test/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/test",
   "layout": "modular",
-  "source_hash": "dbbafbde1d401820937979725c57dee0bbee663f04c85648f8f0cb79b5ba3772",
-  "generated_hash": "0406e09c6634f50232bd51782431bb18f4c186ed5f1b5ec08b399e7c841dfe57"
+  "source_hash": "4336c618821968a95d2a83559344bbfb52becdf59564b1ab4b8a76991d87ebd0",
+  "generated_hash": "8bbdaf96e17d48436bf1a08f9fda55e946e7ef5d0769d94d1c3736fe800a1a49"
 }

--- a/skills-codex/test/.agentops-generated.json
+++ b/skills-codex/test/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/test",
   "layout": "modular",
-  "source_hash": "4336c618821968a95d2a83559344bbfb52becdf59564b1ab4b8a76991d87ebd0",
-  "generated_hash": "8bbdaf96e17d48436bf1a08f9fda55e946e7ef5d0769d94d1c3736fe800a1a49"
+  "source_hash": "c074c59a2e4ccae27f2a4f514b9e5a16a6d87465be8429405878e0641ec5d096",
+  "generated_hash": "be6eb93094d43ee18b0d87412661e0cc08724fa3d64e0724c0dd908dfa9dca22"
 }

--- a/skills-codex/test/SKILL.md
+++ b/skills-codex/test/SKILL.md
@@ -48,7 +48,7 @@ is the **oracle downgrade** failure mode: the test runs the code but proves
 almost nothing about it. Stop condition: no acceptance scenario may be covered
 only by smoke-tier tests when a stronger oracle is practical; if only smoke is
 practical (e.g. nondeterministic external output), record why in
-`.agents/tests/summary.md` so the gap is a visible decision, not an accident.
+`.agents/scratch/tests/summary.md` so the gap is a visible decision, not an accident.
 
 ## Mutation-kill proof
 
@@ -80,12 +80,14 @@ coverage claims on top of it.
 
 ### 1. Bind tests to behavior
 
-When a caller-supplied `.feature` file has scenarios, work forward from each
-Given/When/Then. Name one covering test after the behavior, and add
-`@covered-by:<test-path>[::<TestName>]` above the scenario. Prove the mapping:
+When the caller supplies a `.feature` file with scenarios, work forward from
+each Given/When/Then. Name one covering test after the behavior, and add
+`@covered-by:<test-path>[::<TestName>]` above the scenario. Prove the mapping by
+running the coverage checker against that caller-supplied feature (not this
+skill's own spec):
 
 ```bash
-bash scripts/check-scenario-coverage.sh skills/<skill>/references/<name>.feature --run
+bash scripts/check-scenario-coverage.sh <path-to-caller-feature> --run
 ```
 
 Without scenarios, inventory public behavior, error paths, branches, and edge
@@ -102,8 +104,8 @@ Stop at the first applicable project marker and consult the Standards skill for 
 | `package.json` | Jest/Vitest | `npx jest --coverage` or `npx vitest run --coverage` |
 | `Cargo.toml` | cargo test | `cargo tarpaulin --out Lcov` |
 
-Write raw coverage to `.agents/tests/coverage-raw.txt`, a ranked gap inventory
-to `.agents/tests/gaps.md`, and language-native machine output where available.
+Write raw coverage to `.agents/scratch/tests/coverage-raw.txt`, a ranked gap inventory
+to `.agents/scratch/tests/gaps.md`, and language-native machine output where available.
 
 ### 3. Write the smallest valuable tests
 
@@ -130,7 +132,7 @@ In `tdd` mode:
 2. Implement only enough to pass that test.
 3. Refactor under green without changing the test contract.
 4. Run the focused test and the relevant suite after each cycle.
-5. Append the exact commands and outcomes to `.agents/tests/tdd-log.md`.
+5. Append the exact commands and outcomes to `.agents/scratch/tests/tdd-log.md`.
 
 In other mutating modes, run each new test immediately, then the owning package
 or module, then the relevant project suite. A failure caused by a wrong test is
@@ -143,7 +145,7 @@ relevant suite are green and the recorded RED evidence names the intended behavi
 
 Re-run the baseline coverage command. Summarize before/after coverage, tests
 added, remaining high-risk gaps, bugs found, and exact validation commands in
-`.agents/tests/summary.md`. Supply that evidence to Validate when the test
+`.agents/scratch/tests/summary.md`. Supply that evidence to Validate when the test
 change accompanies a product slice or is ready for acceptance.
 
 ## Language Rules
@@ -159,12 +161,12 @@ change accompanies a product slice or is ready for acceptance.
 ## Strategy Mode
 
 Inventory test files, functions, assertion density, unit/integration/e2e split,
-fixtures, and CI wiring. Write `.agents/tests/strategy.md` with prioritized
+fixtures, and CI wiring. Write `.agents/scratch/tests/strategy.md` with prioritized
 structural gaps and a test architecture; do not generate code in this mode.
 
 ## Output Specification
 
-- **Artifact directory:** `.agents/tests/` plus test files in the target's
+- **Artifact directory:** `.agents/scratch/tests/` plus test files in the target's
   language-native locations.
 - **Filename convention:** `coverage-raw.txt`, `coverage-func.txt` or
   `coverage.json`, `gaps.md`, `summary.md`, `tdd-log.md`, and `strategy.md`.

--- a/skills-codex/test/references/conformance-harnesses.md
+++ b/skills-codex/test/references/conformance-harnesses.md
@@ -33,7 +33,7 @@ Choose conformance testing when the target has a contract that can be exercised 
 
 ## Output
 
-Add a short conformance section to `.agents/tests/summary.md`:
+Add a short conformance section to `.agents/scratch/tests/summary.md`:
 
 ```markdown
 ## Conformance Coverage

--- a/skills-codex/test/references/fuzzing.md
+++ b/skills-codex/test/references/fuzzing.md
@@ -44,7 +44,7 @@ When fuzzing finds a failure:
 
 ## Output
 
-Record fuzz coverage in `.agents/tests/summary.md`:
+Record fuzz coverage in `.agents/scratch/tests/summary.md`:
 
 ```markdown
 ## Fuzz Targets

--- a/skills-codex/test/references/golden-artifact-strategy.md
+++ b/skills-codex/test/references/golden-artifact-strategy.md
@@ -40,7 +40,7 @@ Do not refresh a golden artifact just to make a test pass.
 
 ## Output
 
-Add an acceptance table to `.agents/tests/summary.md` when golden files change:
+Add an acceptance table to `.agents/scratch/tests/summary.md` when golden files change:
 
 ```markdown
 ## Golden Artifact Review

--- a/skills-codex/test/references/golden-artifacts.md
+++ b/skills-codex/test/references/golden-artifacts.md
@@ -36,7 +36,7 @@ Never update golden files as the first move.
 
 ## Output
 
-Add this to `.agents/tests/summary.md` when golden files change:
+Add this to `.agents/scratch/tests/summary.md` when golden files change:
 
 ```markdown
 ## Golden Changes

--- a/skills-codex/test/references/metamorphic-testing.md
+++ b/skills-codex/test/references/metamorphic-testing.md
@@ -41,7 +41,7 @@ golden artifact strategy for that case.
 
 ## Output
 
-Record the invariant and generated cases in `.agents/tests/summary.md`:
+Record the invariant and generated cases in `.agents/scratch/tests/summary.md`:
 
 ```markdown
 ## Metamorphic Coverage

--- a/skills-codex/test/references/real-service-e2e.md
+++ b/skills-codex/test/references/real-service-e2e.md
@@ -32,7 +32,7 @@ If any safety check is unknown, stop and ask for an explicit test environment.
 
 ## Output
 
-Record real-service test safety in `.agents/tests/summary.md`:
+Record real-service test safety in `.agents/scratch/tests/summary.md`:
 
 ```markdown
 ## Real-Service Safety

--- a/skills-codex/test/references/test.feature
+++ b/skills-codex/test/references/test.feature
@@ -1,7 +1,7 @@
 # Executable spec for the /test skill — test generation + coverage (supporting role).
 # /test loads the language's test standards, generates REAL tests for existing code, runs them to
 # verify they pass (it does not stop at a plan), and fills coverage gaps — writing artifacts to
-# .agents/tests/. Hexagon: supporting; consumes standards (test conventions) + repo-context (the
+# .agents/scratch/tests/. Hexagon: supporting; consumes standards (test conventions) + repo-context (the
 # code under test); produces result.json. (soc-qk4b)
 
 Feature: Test generates real, passing tests and coverage
@@ -20,4 +20,4 @@ Feature: Test generates real, passing tests and coverage
 
   Scenario: coverage analyzes and fills gaps
     When /test coverage runs
-    Then it analyzes coverage gaps and fills them, writing a coverage report to .agents/tests/
+    Then it analyzes coverage gaps and fills them, writing a coverage report to .agents/scratch/tests/

--- a/skills-codex/test/references/test.feature
+++ b/skills-codex/test/references/test.feature
@@ -2,7 +2,7 @@
 # /test loads the language's test standards, generates REAL tests for existing code, runs them to
 # verify they pass (it does not stop at a plan), and fills coverage gaps — writing artifacts to
 # .agents/scratch/tests/. Hexagon: supporting; consumes standards (test conventions) + repo-context (the
-# code under test); produces result.json. (soc-qk4b)
+# code under test); produces test-evidence. (soc-qk4b)
 
 Feature: Test generates real, passing tests and coverage
   As the test-generation step

--- a/skills-codex/test/scripts/validate.sh
+++ b/skills-codex/test/scripts/validate.sh
@@ -1,15 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
-SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-PASS=0; FAIL=0
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILL="$SKILL_DIR/SKILL.md"
 
-check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+# Structural contract checks. Bare greps run under `set -e`, so a missing
+# section fails the script — unlike the prior prose-word greps, which passed
+# even after the load-bearing sections were deleted.
+[[ -s "$SKILL" ]]
+head -1 "$SKILL" | grep -q '^---$'
+grep -q '^name: test$' "$SKILL"
 
-check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
-check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
-check "SKILL.md has name: test" "grep -q '^name: test' '$SKILL_DIR/SKILL.md'"
-check "SKILL.md mentions TDD workflow" "grep -qi 'tdd' '$SKILL_DIR/SKILL.md'"
-check "SKILL.md mentions coverage analysis" "grep -qi 'coverage' '$SKILL_DIR/SKILL.md'"
+# Load-bearing doctrine sections. Deleting any one must turn this validator red.
+grep -q '^## Critical Constraints$' "$SKILL"
+grep -q '^## Oracle-strength hierarchy$' "$SKILL"
+grep -q '^## Mutation-kill proof$' "$SKILL"
+grep -q '^## Harness health floors$' "$SKILL"
+grep -q '^## Workflow$' "$SKILL"
+grep -q '^## Output Specification$' "$SKILL"
 
-echo ""; echo "Results: $PASS passed, $FAIL failed"
-[ $FAIL -eq 0 ] && exit 0 || exit 1
+# The mode table must enumerate the four real modes.
+for mode in generate coverage tdd strategy; do
+  grep -Eq "^\| \`${mode}\`" "$SKILL"
+done
+
+# Every referenced local doc must resolve on disk.
+while IFS= read -r ref; do
+  [[ -f "$SKILL_DIR/$ref" ]] || { echo "test contract: dangling reference $ref" >&2; exit 1; }
+done < <(grep -oE 'references/[A-Za-z0-9._-]+' "$SKILL" | sort -u)
+
+echo "test contract: PASS"

--- a/skills-codex/workflow-builder/.agentops-generated.json
+++ b/skills-codex/workflow-builder/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/workflow-builder",
   "layout": "modular",
-  "source_hash": "533e301e0cc9965b0ec2d5db064442aa0855615e4b3c21874cfdd0ee31df3f60",
+  "source_hash": "e5c1e9bb10ea95138d53aa7071b3d6cee41c34cfde323efc4ceda5b21a6f93ee",
   "generated_hash": "30f72769961a244749883e03cb04e329cd0feb03dd5b641d2a73a2e5dc8e9d42"
 }

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -48,9 +48,9 @@
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | - |
+| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
 | `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
 | `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
@@ -74,13 +74,13 @@
 | `rch` | execution | `keep_specialist` | - | `rch` | - |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
 | `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
-| `research` | execution | `keep_specialist` | - | `research` | - |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
+| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | - |
 | `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | - |
+| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
 | `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -86,7 +86,7 @@
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence` |
+| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -48,15 +48,15 @@
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
+| `cass` | execution | `keep_specialist` | - | `cass` | - |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
 | `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | - |
-| `doc` | product | `keep_specialist` | - | `doc` | - |
+| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
 | `handoff` | session | `keep_specialist` | - | `handoff` | - |
@@ -73,21 +73,21 @@
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
 | `rch` | execution | `keep_specialist` | - | `rch` | - |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
-| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
+| `research` | execution | `keep_specialist` | - | `research` | - |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | - |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
+| `security` | product | `keep_specialist` | - | `security` | - |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | - |
+| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -357,7 +357,9 @@
       "dependencies": [],
       "description": "Convert AgentOps skill formats. Triggers: \"converter\", \"convert agentops skill formats.\", \"converter skill\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "write_converted_skill_projection"
+      ],
       "graph_root": false,
       "hexagonal_role": "driven-adapter",
       "name": "converter",
@@ -476,7 +478,9 @@
       "dependencies": [],
       "description": "Generate and validate repo docs, READMEs, and OSS doc packs. Triggers: \"doc\", \"generate and validate repo docs\", \"doc skill\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "write_documentation"
+      ],
       "graph_root": false,
       "hexagonal_role": "supporting",
       "name": "doc",
@@ -1034,7 +1038,9 @@
       "dependencies": [],
       "description": "Execute one behavior-preserving structural transformation and report evidence. Triggers: \"refactor this\", \"simplify without changing behavior\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "modify_source_files"
+      ],
       "graph_root": false,
       "hexagonal_role": "supporting",
       "name": "refactor",
@@ -1196,7 +1202,9 @@
       "dependencies": [],
       "description": "Stamp a bounded project, component, or CI scaffold and verify the generated result once. Triggers: \"scaffold\", \"create project component or boilerplate\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "write_project_files"
+      ],
       "graph_root": false,
       "hexagonal_role": "supporting",
       "name": "scaffold",
@@ -1323,6 +1331,7 @@
       "disposition": "keep_specialist",
       "effects": [
         "writes_skill_source",
+        "write_build_report",
         "regenerates_skill_projections",
         "optional_skill_projection_repair"
       ],
@@ -1437,7 +1446,10 @@
       "dependencies": [],
       "description": "Generate tests and coverage plans. Triggers: \"test\", \"generate tests and coverage plans.\", \"test skill\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "write_test_files",
+        "write_test_evidence"
+      ],
       "graph_root": false,
       "hexagonal_role": "supporting",
       "name": "test",
@@ -1447,7 +1459,7 @@
         "bdd-gherkin"
       ],
       "produces": [
-        "result.json"
+        "test-evidence"
       ],
       "references_count": 7,
       "tier": "execution",
@@ -1586,7 +1598,9 @@
       "dependencies": [],
       "description": "Scaffold an explicit one-shot workflow adapter without lifecycle authority. Triggers: \"build a workflow adapter\", \"scaffold a one-shot workflow\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "write_workflow_script"
+      ],
       "graph_root": false,
       "hexagonal_role": "supporting",
       "name": "workflow-builder",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1448,7 +1448,8 @@
       "disposition": "keep_specialist",
       "effects": [
         "write_test_files",
-        "write_test_evidence"
+        "write_test_evidence",
+        "modify_source_files"
       ],
       "graph_root": false,
       "hexagonal_role": "supporting",

--- a/skills/converter/SKILL.md
+++ b/skills/converter/SKILL.md
@@ -22,7 +22,7 @@ context:
   intel_scope: none
 metadata:
   capabilities: [converter]
-  effects: []
+  effects: [write_converted_skill_projection]
   canonical_status: canonical
   disposition: keep_specialist
   tier: cross-vendor
@@ -34,6 +34,8 @@ output_contract: converted skill files for target platform
 Parse AgentOps skills into a universal SkillBundle format, then convert to target agent platforms.
 
 The intermediate SkillBundle is what keeps conversions honest: every target reads the same parsed contract, so a rendering bug is a target-adapter bug, never a silent reinterpretation of the source. If two targets disagree about a skill's content, the bundle — not either output — arbitrates.
+
+This is **not** the owner of the shipped `skills-codex/**` projection: that path is generated and gated by `scripts/codex-sync.sh` via `scripts/regen-all.sh`. This converter is an ad-hoc, out-of-tree exporter (Codex, Cursor) that writes under `.agents/projections/converter/`; it never mutates `skills-codex/**`. When the shipped Codex twin and this exporter disagree, the shipped path wins.
 
 Named failure mode — **projection editing**: fixing a rendering problem by hand-editing the converted output, which the next conversion clean-writes away.
 
@@ -79,8 +81,9 @@ The Cursor adapter produces a `<name>.mdc` rule file with YAML frontmatter (`des
 
 Write the converted output to disk.
 
-- **Default output directory:** `.agents/converter/<target>/<skill-name>/`
+- **Default output directory:** `.agents/projections/converter/<target>/<skill-name>/`
 - **Write semantics:** Clean-write. The target directory is deleted before writing. No merge with existing content.
+- **Refusal guard:** the write stage refuses — it does not silently redirect — when the resolved output directory equals the source package, contains it (an ancestor), or is the repository root, because the clean-write would otherwise delete the very files the conversion must read.
 
 ## CLI Usage
 
@@ -99,7 +102,7 @@ bash skills/converter/scripts/convert.sh --all <target> [output-dir]
 |----------|----------|-------------|
 | `skill-dir` | Yes (or `--all`) | Path to skill directory (e.g. `skills/council`) |
 | `target` | Yes | Target platform: `codex`, `cursor`, or `test` |
-| `output-dir` | No | Override output location. Default: `.agents/converter/<target>/<skill-name>/` |
+| `output-dir` | No | Override output location. Default: `.agents/projections/converter/<target>/<skill-name>/` |
 | `--all` | No | Convert all skills in `skills/` directory |
 | `--codex-layout` | No | Codex-only layout mode: `modular` (default) or `inline` (legacy inlined refs/scripts) |
 
@@ -126,7 +129,7 @@ To add a new target platform:
 **What happens:**
 1. The converter parses `skills/council/SKILL.md` frontmatter, markdown body, and any `references/` and `scripts/` files into a SkillBundle.
 2. The Codex adapter transforms the bundle into a `SKILL.md` (body + inlined references + scripts as code blocks) and a `prompt.md` (Codex prompt referencing the skill).
-3. Output is written to `.agents/converter/codex/council/`.
+3. Output is written to `.agents/projections/converter/codex/council/`.
 
 **Result:** A Codex-compatible skill package ready to use with OpenAI Codex CLI.
 
@@ -137,7 +140,7 @@ To add a new target platform:
 **What happens:**
 1. The converter scans every directory under `skills/` and parses each into a SkillBundle.
 2. The Cursor adapter transforms each bundle into a `.mdc` rule file with YAML frontmatter and body content, budget-fitted to 100KB max. Skills referencing MCP servers also get a `mcp.json` stub.
-3. Each skill's output is written to `.agents/converter/cursor/<skill-name>/`.
+3. Each skill's output is written to `.agents/projections/converter/cursor/<skill-name>/`.
 
 **Result:** All skills are available as Cursor rules, ready to drop into a `.cursor/rules/` directory.
 
@@ -147,14 +150,14 @@ To add a new target platform:
 |---------|-------|----------|
 | `parse error: no frontmatter found` | SKILL.md is missing the `---` delimited YAML frontmatter block | Add frontmatter with at least `name:` and `description:` fields, or run Heal Skill on the source package first |
 | Cursor `.mdc` output is missing references | Total bundle size exceeded the 100KB budget limit | The converter omits references largest-first to fit the budget. Split large reference files or move non-essential content to external docs |
-| Output directory already has old files | Previous conversion artifacts remain | This is expected -- the converter clean-writes by deleting the target directory before writing. If old files persist, manually delete `.agents/converter/<target>/<skill>/` |
+| Output directory already has old files | Previous conversion artifacts remain | This is expected -- the converter clean-writes by deleting the target directory before writing. If old files persist, manually delete `.agents/projections/converter/<target>/<skill>/` |
 | `--all` skips a skill directory | The directory has no `SKILL.md` file | Ensure each skill directory contains a valid `SKILL.md`. Run Heal Skill to detect empty directories |
 | Codex `prompt.md` description is truncated | The skill description exceeds 1024 characters | This is by design. The converter truncates at a word boundary to fit Codex limits. Shorten the description in SKILL.md frontmatter if the truncation point is awkward |
 | Conversion fails with passthrough parity check | A resource entry from source skill wasn't copied to output | Ensure source entries are readable and copyable (including nested files). Re-run conversion; failure is intentional to prevent drift between `skills/` and converted output |
 
 ## Output Specification
 
-- **Path:** `.agents/converter/<target>/<skill-name>/` by default, or the exact caller-supplied output directory.
+- **Path:** `.agents/projections/converter/<target>/<skill-name>/` by default, or the exact caller-supplied output directory.
 - **Filename:** Codex emits `SKILL.md`, `prompt.md`, and copied resources; Cursor emits `<skill-name>.mdc` and optional `mcp.json`; `test` emits the raw bundle representation.
 - **Format:** target-valid UTF-8 text with required frontmatter, rewritten runtime references, and byte-present passthrough resources; Cursor output remains within 100KB.
 - **Exit code:** run `bash skills/converter/scripts/convert.sh <skill-dir> <target> <output-dir>` and require zero; treat parse, budget, write, or passthrough-parity failure as nonzero and incomplete.

--- a/skills/converter/references/skill-bundle-schema.md
+++ b/skills/converter/references/skill-bundle-schema.md
@@ -75,9 +75,9 @@ Target adapters receive the SkillBundle and decide which fields to use:
 
 | Adapter | Fields Used | Notes |
 |---------|-------------|-------|
-| codex | name, description, body, references | Flattens into single agents.md |
-| cursor | name, description, body, references | Splits into .cursor/rules/ files |
-| test | all | Dumps full bundle for inspection |
+| codex | name, description, body, references, scripts | Emits `SKILL.md` + `prompt.md`; modular by default (copies + links resources), `--codex-layout inline` appends them |
+| cursor | name, description, body, references, scripts | Emits a single `<name>.mdc` rule (+ optional `mcp.json`), budget-fitted to 100KB |
+| test | all | Dumps the full bundle as structured markdown for inspection |
 
 ## Serialization
 

--- a/skills/converter/scripts/convert.sh
+++ b/skills/converter/scripts/convert.sh
@@ -659,6 +659,9 @@ resolve_physical() {
 # Both arguments must already be canonical (symlink/.. resolved).
 within() {
   local child="$1" parent="$2"
+  # Root is the ancestor of everything; the general glob below would build
+  # the broken pattern "//*" for it.
+  [[ "$parent" == "/" ]] && return 0
   case "$child/" in
     "$parent"/*) return 0 ;;
   esac

--- a/skills/converter/scripts/convert.sh
+++ b/skills/converter/scripts/convert.sh
@@ -4,6 +4,16 @@
 #        bash skills/converter/scripts/convert.sh --all <target> [output-dir]
 set -euo pipefail
 
+# This script uses namerefs (`local -n`), which require Bash >= 4.3. On stock
+# macOS /bin/bash (3.2.57) a nameref is an invalid option that aborts under
+# `set -e` with an opaque message and zero files written. Fail closed with a
+# clear diagnostic instead of an unrunnable surprise.
+if (( BASH_VERSINFO[0] < 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 3) )); then
+  echo "ERROR: convert.sh requires Bash >= 4.3 (namerefs); found ${BASH_VERSION}." >&2
+  echo "       On macOS install a newer bash ('brew install bash') and invoke it explicitly." >&2
+  exit 2
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 SKILL_PATTERN=""
@@ -278,6 +288,10 @@ parse_skill_md() {
 
 # Collect files from a subdirectory into parallel arrays.
 # Args: <dir> <array-name-names> <array-name-contents>
+# Scope: top-level regular files of <dir> only. Nested reference/script files
+# are NOT inlined here; copy_passthrough_resources() preserves them recursively
+# in the written output, so nested resources survive a conversion even though
+# they are not flattened into the target SKILL.md body.
 collect_files() {
   local dir="$1"
   local -n names_arr="$2"
@@ -454,8 +468,10 @@ convert_cursor() {
   local out=""
 
   # ── YAML frontmatter ──
+  # Single-quote and escape the description: an unquoted value containing a
+  # colon, quote, or leading special char yields invalid Cursor YAML (CV-9).
   out+="---"$'\n'
-  out+="description: ${BUNDLE_DESC}"$'\n'
+  out+="description: '$(yaml_escape_single_quote "$BUNDLE_DESC")'"$'\n'
   out+="globs: "$'\n'
   out+="alwaysApply: false"$'\n'
   out+="---"$'\n\n'
@@ -622,9 +638,54 @@ verify_passthrough_resources() {
   fi
 }
 
+# Resolve a possibly-nonexistent absolute path to its physical form, collapsing
+# `..` and symlinks against the deepest existing ancestor. Used before any
+# destructive comparison so the guard cannot be fooled by an unresolved path.
+resolve_physical() {
+  local target="$1" suffix=""
+  while [[ ! -e "$target" ]]; do
+    suffix="/$(basename "$target")$suffix"
+    target="$(dirname "$target")"
+    [[ "$target" == "/" ]] && break
+  done
+  if [[ -d "$target" ]]; then
+    printf '%s%s\n' "$(cd "$target" && pwd -P)" "$suffix"
+  else
+    printf '%s/%s%s\n' "$(cd "$(dirname "$target")" && pwd -P)" "$(basename "$target")" "$suffix"
+  fi
+}
+
+# Refuse a clean-write target that would destroy the source or a parent. The
+# write stage rm -rf's output_dir; if output_dir is the source package, an
+# ancestor of it, or the repo root, that rm -rf deletes files this conversion
+# must read (CV-1: a source-dir output went 4 files -> 2 at exit 0). Fix by
+# refusal, never by silently appending a subdir.
+assert_safe_output_dir() {
+  local output_dir="$1" source_dir="$2"
+  local out_abs src_abs repo_abs
+  out_abs="$(resolve_physical "$output_dir")"
+  src_abs="$(cd "$source_dir" && pwd -P)"
+  repo_abs="$(cd "$REPO_ROOT" && pwd -P)"
+
+  if [[ "$out_abs" == "$repo_abs" ]]; then
+    die "refusing to clean-write the repository root: $out_abs"
+  fi
+  if [[ "$out_abs" == "$src_abs" ]]; then
+    die "refusing to clean-write the source package itself: $out_abs (choose a distinct output dir)"
+  fi
+  case "$src_abs/" in
+    "$out_abs"/*)
+      die "refusing to clean-write '$out_abs': it contains the source package '$src_abs'"
+      ;;
+  esac
+}
+
 write_output() {
   local output_dir="$1"
   local source_dir="$2"
+
+  # Guard BEFORE the destructive clean-write below.
+  assert_safe_output_dir "$output_dir" "$source_dir"
 
   # Clean-write: delete target dir before writing
   if [[ -d "$output_dir" ]]; then
@@ -664,9 +725,9 @@ convert_one_skill() {
 
   [[ -n "$BUNDLE_NAME" ]] || die "Failed to parse name from $skill_dir/SKILL.md"
 
-  # Default output dir
+  # Default output dir (ADR-0016 closed set: generated projection tier)
   if [[ -z "$output_dir" ]]; then
-    output_dir="$REPO_ROOT/.agents/converter/$target/$BUNDLE_NAME"
+    output_dir="$REPO_ROOT/.agents/projections/converter/$target/$BUNDLE_NAME"
   elif [[ "$output_dir" != /* ]]; then
     output_dir="$REPO_ROOT/$output_dir"
   fi

--- a/skills/converter/scripts/convert.sh
+++ b/skills/converter/scripts/convert.sh
@@ -655,11 +655,26 @@ resolve_physical() {
   fi
 }
 
-# Refuse a clean-write target that would destroy the source or a parent. The
-# write stage rm -rf's output_dir; if output_dir is the source package, an
-# ancestor of it, or the repo root, that rm -rf deletes files this conversion
-# must read (CV-1: a source-dir output went 4 files -> 2 at exit 0). Fix by
-# refusal, never by silently appending a subdir.
+# within CHILD PARENT -> 0 if CHILD equals PARENT or is nested under PARENT.
+# Both arguments must already be canonical (symlink/.. resolved).
+within() {
+  local child="$1" parent="$2"
+  case "$child/" in
+    "$parent"/*) return 0 ;;
+  esac
+  return 1
+}
+
+# Refuse a clean-write target that would destroy the source or the repository.
+# The write stage rm -rf's output_dir; both paths are canonicalized (symlinks
+# and `..` resolved via resolve_physical / `pwd -P`) before comparison so the
+# guard cannot be bypassed by an alias. The containment test is BIDIRECTIONAL:
+# refuse when the output equals the source, contains it (ancestor), OR lives
+# inside it (descendant) — any of those puts source files under the rm -rf — and
+# refuse when the output is, or is an ancestor of, the repository root (an output
+# above the repo would take the whole tree with it). CV-1: a source-dir output
+# went 4 files -> 2 at exit 0. Fix by refusal, never by silently appending a
+# subdir.
 assert_safe_output_dir() {
   local output_dir="$1" source_dir="$2"
   local out_abs src_abs repo_abs
@@ -667,17 +682,15 @@ assert_safe_output_dir() {
   src_abs="$(cd "$source_dir" && pwd -P)"
   repo_abs="$(cd "$REPO_ROOT" && pwd -P)"
 
-  if [[ "$out_abs" == "$repo_abs" ]]; then
-    die "refusing to clean-write the repository root: $out_abs"
+  if within "$out_abs" "$src_abs"; then
+    die "refusing to clean-write '$out_abs': it is the source package, or lives inside it ('$src_abs')"
   fi
-  if [[ "$out_abs" == "$src_abs" ]]; then
-    die "refusing to clean-write the source package itself: $out_abs (choose a distinct output dir)"
+  if within "$src_abs" "$out_abs"; then
+    die "refusing to clean-write '$out_abs': it contains the source package '$src_abs'"
   fi
-  case "$src_abs/" in
-    "$out_abs"/*)
-      die "refusing to clean-write '$out_abs': it contains the source package '$src_abs'"
-      ;;
-  esac
+  if within "$repo_abs" "$out_abs"; then
+    die "refusing to clean-write '$out_abs': it is, or contains, the repository root '$repo_abs'"
+  fi
 }
 
 write_output() {

--- a/skills/converter/scripts/validate.sh
+++ b/skills/converter/scripts/validate.sh
@@ -3,16 +3,40 @@
 # ("SKILL.md exists" only, which passed while the pipeline could delete its own
 # source) with real proofs (CV-2):
 #   1. a happy-path conversion writes the expected target + passthrough files;
-#   2. the destructive clean-write path is CLOSED — an output dir equal to, or
-#      an ancestor of, the source package is refused and the source survives
-#      (CV-1: a source-dir output previously went 4 files -> 2 at exit 0).
+#   2. the destructive clean-write path is CLOSED in BOTH directions — an output
+#      dir equal to, an ancestor of, a descendant of, or a symlink into the
+#      source package is refused; and an output that is or contains the repo
+#      root is refused (CV-1). Each refusal is proven to happen BEFORE any
+#      deletion: the source content digest is unchanged AND the exit is nonzero.
 set -euo pipefail
 
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CONVERT="$SKILL_DIR/scripts/convert.sh"
+REPO_ROOT="$(cd "$SKILL_DIR/../.." && pwd -P)"
 FAIL=0
 pass() { printf 'PASS: %s\n' "$1"; }
 fail() { printf 'FAIL: %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+# Content + structure digest of a directory tree (path-relative, order-stable).
+dir_digest() {
+  ( cd "$1" && find . -type f -exec shasum -a 256 {} + | LC_ALL=C sort ) \
+    | shasum -a 256 | awk '{print $1}'
+}
+
+# assert_refused DESC OUTPUT — the conversion must exit nonzero AND leave the
+# source content digest unchanged (refusal before any deletion).
+assert_refused() {
+  local desc="$1" out="$2"
+  if bash "$CONVERT" "$FIX" codex "$out" >/dev/null 2>&1; then
+    fail "$desc: expected refusal, got success"
+    return
+  fi
+  if [[ "$(dir_digest "$FIX")" == "$SRC_DIGEST" ]]; then
+    pass "$desc: refused before any deletion; source content intact"
+  else
+    fail "$desc: source content changed — refusal came too late"
+  fi
+}
 
 if [[ -f "$SKILL_DIR/SKILL.md" ]]; then pass "SKILL.md exists"; else fail "SKILL.md exists"; fi
 if [[ -f "$CONVERT" ]]; then pass "convert.sh exists"; else fail "convert.sh exists"; fi
@@ -21,39 +45,32 @@ if [[ -f "$CONVERT" ]]; then pass "convert.sh exists"; else fail "convert.sh exi
 # must never be handed a destructive cleanup to imitate.
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/converter-selftest.XXXXXX")"
 FIX="$WORK/fixture-skill"
-mkdir -p "$FIX/references"
+mkdir -p "$FIX/references" "$FIX/scripts"
 printf -- '---\nname: fixture-skill\ndescription: converter self-test fixture\n---\n# Body\n' > "$FIX/SKILL.md"
 printf 'reference payload\n' > "$FIX/references/note.md"
-before_count="$(find "$FIX" -type f | wc -l | tr -d ' ')"
+printf 'echo fixture\n' > "$FIX/scripts/tool.sh"
+SRC_DIGEST="$(dir_digest "$FIX")"
 
-# 1. Happy path: a distinct output dir converts and writes the target files.
+# 1. Happy path: a distinct output dir converts, writes the target files, and
+# does not touch the source.
 out="$WORK/out"
 if bash "$CONVERT" "$FIX" codex "$out" >/dev/null 2>&1 \
-  && [[ -f "$out/SKILL.md" && -f "$out/prompt.md" && -f "$out/references/note.md" ]]; then
-  pass "happy-path conversion writes target + passthrough files"
+  && [[ -f "$out/SKILL.md" && -f "$out/prompt.md" && -f "$out/references/note.md" && -f "$out/scripts/tool.sh" ]] \
+  && [[ "$(dir_digest "$FIX")" == "$SRC_DIGEST" ]]; then
+  pass "happy-path conversion writes target + passthrough files; source intact"
 else
-  fail "happy-path conversion writes target + passthrough files"
+  fail "happy-path conversion writes target + passthrough files; source intact"
 fi
 
-# 2. Destructive path closed: output == source must be refused (nonzero) AND
-# leave every source file intact.
-if bash "$CONVERT" "$FIX" codex "$FIX" >/dev/null 2>&1; then
-  fail "clean-write onto the source package is refused"
-else
-  after_count="$(find "$FIX" -type f | wc -l | tr -d ' ')"
-  if [[ "$after_count" == "$before_count" ]]; then
-    pass "clean-write onto the source package is refused; source intact ($after_count files)"
-  else
-    fail "source package damaged by clean-write onto itself ($before_count -> $after_count files)"
-  fi
-fi
+# 2. Bidirectional + repo containment refusals.
+assert_refused "output == source"                 "$FIX"
+assert_refused "output is an ancestor of source"  "$WORK"
+assert_refused "output is a descendant of source" "$FIX/references"
+assert_refused "output is an ancestor of the repo root" "$(dirname "$REPO_ROOT")"
 
-# 3. Ancestor output dir (contains the source) must also be refused.
-if bash "$CONVERT" "$FIX" codex "$WORK" >/dev/null 2>&1; then
-  fail "clean-write onto an ancestor of the source is refused"
-else
-  pass "clean-write onto an ancestor of the source is refused"
-fi
+# Symlink resolving into the source must be canonicalized and refused.
+ln -s "$FIX/references" "$WORK/link-into-src"
+assert_refused "output is a symlink into the source" "$WORK/link-into-src"
 
 echo ""
 if [[ "$FAIL" -eq 0 ]]; then

--- a/skills/converter/scripts/validate.sh
+++ b/skills/converter/scripts/validate.sh
@@ -1,12 +1,64 @@
 #!/usr/bin/env bash
+# Behavioral self-test for the converter. Replaces the prior vacuous check
+# ("SKILL.md exists" only, which passed while the pipeline could delete its own
+# source) with real proofs (CV-2):
+#   1. a happy-path conversion writes the expected target + passthrough files;
+#   2. the destructive clean-write path is CLOSED — an output dir equal to, or
+#      an ancestor of, the source package is refused and the source survives
+#      (CV-1: a source-dir output previously went 4 files -> 2 at exit 0).
 set -euo pipefail
-SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-PASS=0; FAIL=0
 
-check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONVERT="$SKILL_DIR/scripts/convert.sh"
+FAIL=0
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1"; FAIL=$((FAIL + 1)); }
 
-check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
-check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
+if [[ -f "$SKILL_DIR/SKILL.md" ]]; then pass "SKILL.md exists"; else fail "SKILL.md exists"; fi
+if [[ -f "$CONVERT" ]]; then pass "convert.sh exists"; else fail "convert.sh exists"; fi
 
-echo ""; echo "Results: $PASS passed, $FAIL failed"
-[ $FAIL -eq 0 ] && exit 0 || exit 1
+# Disposable fixture, left in place on exit (no rm -rf): the guard under test
+# must never be handed a destructive cleanup to imitate.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/converter-selftest.XXXXXX")"
+FIX="$WORK/fixture-skill"
+mkdir -p "$FIX/references"
+printf -- '---\nname: fixture-skill\ndescription: converter self-test fixture\n---\n# Body\n' > "$FIX/SKILL.md"
+printf 'reference payload\n' > "$FIX/references/note.md"
+before_count="$(find "$FIX" -type f | wc -l | tr -d ' ')"
+
+# 1. Happy path: a distinct output dir converts and writes the target files.
+out="$WORK/out"
+if bash "$CONVERT" "$FIX" codex "$out" >/dev/null 2>&1 \
+  && [[ -f "$out/SKILL.md" && -f "$out/prompt.md" && -f "$out/references/note.md" ]]; then
+  pass "happy-path conversion writes target + passthrough files"
+else
+  fail "happy-path conversion writes target + passthrough files"
+fi
+
+# 2. Destructive path closed: output == source must be refused (nonzero) AND
+# leave every source file intact.
+if bash "$CONVERT" "$FIX" codex "$FIX" >/dev/null 2>&1; then
+  fail "clean-write onto the source package is refused"
+else
+  after_count="$(find "$FIX" -type f | wc -l | tr -d ' ')"
+  if [[ "$after_count" == "$before_count" ]]; then
+    pass "clean-write onto the source package is refused; source intact ($after_count files)"
+  else
+    fail "source package damaged by clean-write onto itself ($before_count -> $after_count files)"
+  fi
+fi
+
+# 3. Ancestor output dir (contains the source) must also be refused.
+if bash "$CONVERT" "$FIX" codex "$WORK" >/dev/null 2>&1; then
+  fail "clean-write onto an ancestor of the source is refused"
+else
+  pass "clean-write onto an ancestor of the source is refused"
+fi
+
+echo ""
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "converter self-test: PASS"
+  exit 0
+fi
+echo "converter self-test: FAIL ($FAIL failed)" >&2
+exit 1

--- a/skills/doc/SKILL.md
+++ b/skills/doc/SKILL.md
@@ -22,7 +22,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [doc]
-  effects: []
+  effects: [write_documentation]
   canonical_status: canonical
   disposition: keep_specialist
   tier: product
@@ -69,7 +69,7 @@ Default mode is deliberately thin. Given a Doc command and target:
 
 1. **Detect project type** — `ls package.json pyproject.toml go.mod Cargo.toml` + existing `docs/`; classify CODING / INFORMATIONAL / OPS.
 2. **Run the command** — `discover` (grep undocumented funcs), `coverage` (documented vs total), `gen [feature]` (read code → stamp function/class markdown), `all`, or `validate`.
-3. **Write the report** to `.agents/doc/YYYY-MM-DD-<target>.md` (coverage %, generated, gaps, validation issues), then report coverage + gaps to the user.
+3. **Write the report** to `.agents/scratch/doc/YYYY-MM-DD-<target>.md` (coverage %, generated, gaps, validation issues), then report coverage + gaps to the user.
 
 Full step-by-step detail — grep recipes, function/class + code-map templates, the report skeleton, key rules, worked examples, and the troubleshooting table — lives in **[references/default-mode.md](references/default-mode.md)** (moved there in the generic-craft trim). Read it when you need the exact shapes; otherwise just do the three steps.
 
@@ -97,7 +97,7 @@ doc** failure mode — accurate, complete, and useless.
 
 ## Output Specification
 
-- **Path:** default-mode reports go to the artifact directory `.agents/doc/`; README mode updates the repository `README.md`; OSS scaffold mode creates missing root documentation only by default. The separate OSS `refresh` path may update an existing doc only after explicit user confirmation.
+- **Path:** default-mode reports go to the artifact directory `.agents/scratch/doc/`; README mode updates the repository `README.md`; OSS scaffold mode creates missing root documentation only by default. The separate OSS `refresh` path may update an existing doc only after explicit user confirmation.
 - **Filename:** default reports use the filename convention `YYYY-MM-DD-<target>.md`; README and OSS filenames follow their mode references.
 - **Format:** outputs are Markdown; the default report schema records coverage percentage, generated artifacts, gaps, and validation issues.
 - **Validation command:** validate the skill contract with `bash skills/doc/scripts/validate.sh`, then run the mode-specific validation required by its reference before reporting completion.

--- a/skills/doc/references/default-mode.md
+++ b/skills/doc/references/default-mode.md
@@ -145,7 +145,7 @@ Check for:
 
 ## Step 6: Write Report
 
-**Write to:** `.agents/doc/YYYY-MM-DD-<target>.md`
+**Write to:** `.agents/scratch/doc/YYYY-MM-DD-<target>.md`
 
 ```markdown
 # Documentation Report: <Target>
@@ -168,10 +168,6 @@ Check for:
 ## Validation Issues
 - <issue 1>
 - <issue 2>
-
-## Next Steps
-- [ ] Document remaining gaps
-- [ ] Fix validation issues
 ```
 
 ## Step 7: Report to User
@@ -225,7 +221,7 @@ Tell the user:
 2. Agent counts total functions/classes with `grep -r "^def \|^class "`
 3. Agent counts documented items by searching for docstrings (`"""`)
 4. Agent calculates coverage: 45/67 items = 67% coverage
-5. Agent writes report to `.agents/doc/2026-02-13-coverage.md`
+5. Agent writes report to `.agents/scratch/doc/2026-02-13-coverage.md`
 6. Agent lists 22 undocumented functions as gaps
 
 **Result:** Documentation coverage report shows 67% coverage with specific list of 22 functions needing docs.

--- a/skills/doc/references/validation-rules.md
+++ b/skills/doc/references/validation-rules.md
@@ -131,22 +131,6 @@ ORPHANED DOCUMENTATION
 
 ---
 
-## --create-issues Flag
-
-Auto-create tracking issues for gaps:
-
-```bash
-# Prefer beads
-bd create --title "docs: create code-map for $FEATURE" \
-          --type task --priority P1
-
-# Fallback to GitHub
-gh issue create --title "docs: create code-map for $FEATURE" \
-                --label documentation
-```
-
----
-
 ## Semantic Validation (CODING repos)
 
 **Structure vs Semantic:** Structural validation checks formatting. Semantic validation checks if claims are TRUE.

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -22,7 +22,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [refactor]
-  effects: []
+  effects: [modify_source_files]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
@@ -72,7 +72,8 @@ transformation on behavior-identical proof:
 - For output-producing surfaces (generators, serializers, formatters, reports),
   hash the outputs: capture golden-output hashes over identical inputs before
   the change and compare byte-for-byte after. A hash mismatch is a behavior
-  diff to explain or revert, never to shrug at.
+  diff to surface and explain, never to shrug at; the caller decides whether to
+  keep, narrow, or reverse the change.
 - Observable error messages, exit codes, and public signatures on the changed
   surface are part of behavior unless the caller excluded them.
 

--- a/skills/refactor/references/refactor.feature
+++ b/skills/refactor/references/refactor.feature
@@ -1,27 +1,32 @@
-# Executable spec for the /refactor skill — safe incremental refactoring (supporting role).
-# /refactor transforms code one step at a time with test verification — one transformation, one
-# test run, one commit, never batched — preserving behavior. Target mode refactors a chosen unit;
-# sweep mode (--sweep) runs /complexity first to pick targets. Hexagon: supporting; consumes
-# complexity (sweep targeting) + repo-context (the code it transforms); produces git-changes. (soc-qk4b)
+# Executable spec for the refactor skill — one behavior-preserving transformation (supporting role).
+# refactor applies ONE caller-selected structural transformation, runs the focused check plus the
+# smallest justified regression check, and reports the diff, commands, results, and behavior not
+# checked. It does not commit, revert, retry, validate, or route subsequent work — a red result is
+# evidence returned to the caller, who owns version control and what happens next. Hexagon:
+# supporting; consumes repo-context (the code it transforms); produces code-changes.
 
-Feature: Refactor executes safe incremental transformations
-  As the safe-refactoring step
-  I want each transformation verified by tests before the next
-  So that refactors never silently change behavior
+Feature: Refactor executes one behavior-preserving transformation and reports evidence
+  As the behavior-preserving transformation step
+  I want one bounded structural change proven behavior-identical
+  So that structure improves without silently changing observable behavior
 
-  Scenario: one transformation, one test run, one commit
-    When /refactor applies a transformation
-    Then it runs the tests, then commits that single transformation
-    And transformations are not batched together
+  Scenario: one bounded transformation, then report
+    When refactor applies one caller-selected transformation
+    Then it runs the focused check and the smallest justified regression check
+    And it reports the diff summary, commands, results, and behavior not checked
+    And it does not commit the change or route any subsequent work
 
-  Scenario: a failing test reverts the transformation
-    When a transformation makes a test fail
-    Then that transformation is reverted and behavior is preserved
+  Scenario: a red result is reported, not reverted
+    When the focused or regression check comes back red
+    Then refactor returns that result to the caller as evidence
+    And it does not automatically revert, narrow, or retry the transformation
 
-  Scenario: sweep mode targets by complexity
-    When /refactor --sweep runs over a directory
-    Then it runs /complexity first to identify targets and works highest-complexity first
+  Scenario: neutrality gate rejects new or vanished red
+    When the same pre-existing failures do not hold before and after
+    Then refactor reports the behavior difference rather than accepting the change
+    And a test that stopped running counts as a behavior change
 
-  Scenario: target mode refactors a chosen unit
-    When /refactor runs on a specific file, function, or class
-    Then it refactors that unit directly, step by step
+  Scenario: seams are probed in disposable isolation before cutting
+    When more than one candidate seam exists for the transformation
+    Then refactor probes at most two seams in disposable isolation and keeps only the knowledge
+    And it reports both findings to the caller rather than trying a third

--- a/skills/scaffold/SKILL.md
+++ b/skills/scaffold/SKILL.md
@@ -21,7 +21,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [scaffold]
-  effects: []
+  effects: [write_project_files]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution

--- a/skills/scaffold/references/generic-templates.md
+++ b/skills/scaffold/references/generic-templates.md
@@ -186,17 +186,9 @@ Run these checks in order. Stop and fix if any fail.
 
 If a tool is not installed (e.g., `ruff`, `golangci-lint`), note it as a warning but do not fail the scaffold.
 
-## Step 5: Initial Commit
-
-After verification passes, create the initial commit:
-
-```
-bootstrap(<name>): scaffold <language> <type> project
-```
-
-Example: `bootstrap(my-cli): scaffold go cli project`
-
-Do NOT push. The user decides when to push.
+Report the generated files and the command results, then stop. The caller owns
+version control, revision, and delivery — this scaffold does not `git init`,
+stage, commit, push, or decide what happens next.
 
 ## Component Mode
 
@@ -336,7 +328,6 @@ Include caching directives and artifact definitions.
 | Directory already exists | Ask user: overwrite, merge, or abort |
 | Build tool not installed | Note missing tool, generate files anyway, warn user |
 | Test fails on generated code | Fix the generated code (this is a scaffold bug) |
-| Git init fails | Verify not inside existing repo, handle accordingly |
 
 ## Output Summary
 
@@ -348,9 +339,4 @@ Scaffold complete: <name> (<language> <type>)
   Build: PASS
   Tests: PASS (<count> tests)
   Lint:  PASS | WARN (tool not installed)
-  Commit: bootstrap(<name>): scaffold <language> <type> project
-
-Next steps:
-  cd <name>
-  <language-specific "run" command>
 ```

--- a/skills/scaffold/references/generic-templates.md
+++ b/skills/scaffold/references/generic-templates.md
@@ -186,9 +186,9 @@ Run these checks in order. Stop and fix if any fail.
 
 If a tool is not installed (e.g., `ruff`, `golangci-lint`), note it as a warning but do not fail the scaffold.
 
-Report the generated files and the command results, then stop. The caller owns
-version control, revision, and delivery — this scaffold does not `git init`,
-stage, commit, push, or decide what happens next.
+Report the generated files and the command results, then stop. Version control,
+revision, and delivery stay with the caller; this scaffold writes files only and
+takes no source-control or continuation action.
 
 ## Component Mode
 

--- a/skills/scaffold/scripts/validate.sh
+++ b/skills/scaffold/scripts/validate.sh
@@ -6,12 +6,21 @@ SKILL="$SKILL_DIR/SKILL.md"
 
 [[ -s "$SKILL" ]]
 grep -q '^name: scaffold$' "$SKILL"
-grep -q '^  effects: \[\]$' "$SKILL"
 grep -q '^## Contract$' "$SKILL"
 grep -q '^## Evidence$' "$SKILL"
 grep -Fq 'The caller owns version control, revision, and delivery.' "$SKILL"
 if grep -Eiq 'AUTO-REDO|ONE-HELPER|HELPER-ESCALATE|ao land|next_action' "$SKILL"; then
   echo 'scaffold contract contains retired lifecycle vocabulary' >&2
+  exit 1
+fi
+
+# References must not re-grant the Git-mutation or continuation authority the
+# contract denies ("does not schedule RPI, create work ownership, mutate Git,
+# or decide what happens next"). This sweep covers references/** because a grant
+# hidden in a template file passes unseen when only SKILL.md is scanned.
+if [[ -d "$SKILL_DIR/references" ]] \
+  && grep -rEiq 'initial commit|git commit|git push|next steps:' "$SKILL_DIR/references"; then
+  echo 'scaffold references confer Git-commit or continuation authority the contract denies' >&2
   exit 1
 fi
 

--- a/skills/scaffold/scripts/validate.sh
+++ b/skills/scaffold/scripts/validate.sh
@@ -18,8 +18,14 @@ fi
 # contract denies ("does not schedule RPI, create work ownership, mutate Git,
 # or decide what happens next"). This sweep covers references/** because a grant
 # hidden in a template file passes unseen when only SKILL.md is scanned.
+#
+# The pattern covers the deleted grants (Step 5 "Initial Commit", the summary
+# "Commit:" line, the "Git init fails" row) and equivalent forms. Bare `push` is
+# matched only when it is a verb (followed by space, period, or end-of-line), so
+# the legitimate CI-trigger key `push:` and the word `pushd` do NOT false-fire.
+FORBIDDEN='initial commit|create a commit|git commit|git add|git init|git push|commit:|next step|\bpush([[:space:]]|[.]|$)'
 if [[ -d "$SKILL_DIR/references" ]] \
-  && grep -rEiq 'initial commit|git commit|git push|next steps:' "$SKILL_DIR/references"; then
+  && grep -rEiq "$FORBIDDEN" "$SKILL_DIR/references"; then
   echo 'scaffold references confer Git-commit or continuation authority the contract denies' >&2
   exit 1
 fi

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -9,6 +9,7 @@ consumes: []
 produces:
 - skill-source-package
 - skill-hygiene-report
+context_rel: []
 skill_api_version: 1
 context:
   window: fork
@@ -20,7 +21,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [skill_builder, heal_skill]
-  effects: [writes_skill_source, regenerates_skill_projections, optional_skill_projection_repair]
+  effects: [writes_skill_source, write_build_report, regenerates_skill_projections, optional_skill_projection_repair]
   canonical_status: canonical
   disposition: keep_specialist
   tier: meta
@@ -149,8 +150,8 @@ skills/<slug>/
 └── scripts/validate.sh
 ```
 
-The build report is `.agents/audits/<slug>-build.json` and conforms to
-`schemas/build-report.json`. Deep audit JSON conforms to
+The build report is `.agents/scratch/skill-builder/<slug>-build.json` and
+conforms to `schemas/build-report.json`. Deep audit JSON conforms to
 `schemas/audit-report.json`. Generated inventories and runtime projections are
 not additional sources of truth. The caller owns any subsequent edit or
 invocation.

--- a/skills/skill-builder/scripts/build.sh
+++ b/skills/skill-builder/scripts/build.sh
@@ -29,7 +29,7 @@ esac
 
 bash "$SCRIPT_DIR/init.sh" "$init_mode" "$slug" "$@"
 
-report="$REPO_ROOT/.agents/audits/${slug}-build.json"
+report="$REPO_ROOT/.agents/scratch/skill-builder/${slug}-build.json"
 if ! HEAL_REPO_ROOT="$REPO_ROOT" bash "$REPO_ROOT/skills/skill-builder/scripts/heal.sh" \
   --check --strict "$REPO_ROOT/skills/$slug"; then
   echo "skill-builder: structural check failed" >&2

--- a/skills/skill-builder/scripts/init.sh
+++ b/skills/skill-builder/scripts/init.sh
@@ -146,8 +146,8 @@ exec bash "$REPO_ROOT/skills/skill-builder/scripts/heal.sh" --check --strict "$S
 EOF
 chmod +x "$target/scripts/validate.sh"
 
-mkdir -p "$REPO_ROOT/.agents/audits"
-report="$REPO_ROOT/.agents/audits/${slug}-build.json"
+mkdir -p "$REPO_ROOT/.agents/scratch/skill-builder"
+report="$REPO_ROOT/.agents/scratch/skill-builder/${slug}-build.json"
 python3 - "$report" "$mode" "$slug" "$source_hint" <<'PY'
 import json
 from pathlib import Path

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -10,7 +10,7 @@ consumes:
 - standards
 - repo-context
 produces:
-- result.json
+- test-evidence
 context_rel: []
 skill_api_version: 1
 context:
@@ -23,7 +23,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [test]
-  effects: []
+  effects: [write_test_files, write_test_evidence]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
@@ -76,7 +76,7 @@ is the **oracle downgrade** failure mode: the test runs the code but proves
 almost nothing about it. Stop condition: no acceptance scenario may be covered
 only by smoke-tier tests when a stronger oracle is practical; if only smoke is
 practical (e.g. nondeterministic external output), record why in
-`.agents/tests/summary.md` so the gap is a visible decision, not an accident.
+`.agents/scratch/tests/summary.md` so the gap is a visible decision, not an accident.
 
 ## Mutation-kill proof
 
@@ -108,12 +108,14 @@ coverage claims on top of it.
 
 ### 1. Bind tests to behavior
 
-When a caller-supplied `.feature` file has scenarios, work forward from each
-Given/When/Then. Name one covering test after the behavior, and add
-`@covered-by:<test-path>[::<TestName>]` above the scenario. Prove the mapping:
+When the caller supplies a `.feature` file with scenarios, work forward from
+each Given/When/Then. Name one covering test after the behavior, and add
+`@covered-by:<test-path>[::<TestName>]` above the scenario. Prove the mapping by
+running the coverage checker against that caller-supplied feature (not this
+skill's own spec):
 
 ```bash
-bash scripts/check-scenario-coverage.sh skills/<skill>/references/<name>.feature --run
+bash scripts/check-scenario-coverage.sh <path-to-caller-feature> --run
 ```
 
 Without scenarios, inventory public behavior, error paths, branches, and edge
@@ -130,8 +132,8 @@ Stop at the first applicable project marker and consult the Standards skill for 
 | `package.json` | Jest/Vitest | `npx jest --coverage` or `npx vitest run --coverage` |
 | `Cargo.toml` | cargo test | `cargo tarpaulin --out Lcov` |
 
-Write raw coverage to `.agents/tests/coverage-raw.txt`, a ranked gap inventory
-to `.agents/tests/gaps.md`, and language-native machine output where available.
+Write raw coverage to `.agents/scratch/tests/coverage-raw.txt`, a ranked gap inventory
+to `.agents/scratch/tests/gaps.md`, and language-native machine output where available.
 
 ### 3. Write the smallest valuable tests
 
@@ -158,7 +160,7 @@ In `tdd` mode:
 2. Implement only enough to pass that test.
 3. Refactor under green without changing the test contract.
 4. Run the focused test and the relevant suite after each cycle.
-5. Append the exact commands and outcomes to `.agents/tests/tdd-log.md`.
+5. Append the exact commands and outcomes to `.agents/scratch/tests/tdd-log.md`.
 
 In other mutating modes, run each new test immediately, then the owning package
 or module, then the relevant project suite. A failure caused by a wrong test is
@@ -171,7 +173,7 @@ relevant suite are green and the recorded RED evidence names the intended behavi
 
 Re-run the baseline coverage command. Summarize before/after coverage, tests
 added, remaining high-risk gaps, bugs found, and exact validation commands in
-`.agents/tests/summary.md`. Supply that evidence to Validate when the test
+`.agents/scratch/tests/summary.md`. Supply that evidence to Validate when the test
 change accompanies a product slice or is ready for acceptance.
 
 ## Language Rules
@@ -187,12 +189,12 @@ change accompanies a product slice or is ready for acceptance.
 ## Strategy Mode
 
 Inventory test files, functions, assertion density, unit/integration/e2e split,
-fixtures, and CI wiring. Write `.agents/tests/strategy.md` with prioritized
+fixtures, and CI wiring. Write `.agents/scratch/tests/strategy.md` with prioritized
 structural gaps and a test architecture; do not generate code in this mode.
 
 ## Output Specification
 
-- **Artifact directory:** `.agents/tests/` plus test files in the target's
+- **Artifact directory:** `.agents/scratch/tests/` plus test files in the target's
   language-native locations.
 - **Filename convention:** `coverage-raw.txt`, `coverage-func.txt` or
   `coverage.json`, `gaps.md`, `summary.md`, `tdd-log.md`, and `strategy.md`.

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -23,7 +23,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [test]
-  effects: [write_test_files, write_test_evidence]
+  effects: [write_test_files, write_test_evidence, modify_source_files]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution

--- a/skills/test/references/conformance-harnesses.md
+++ b/skills/test/references/conformance-harnesses.md
@@ -33,7 +33,7 @@ Choose conformance testing when the target has a contract that can be exercised 
 
 ## Output
 
-Add a short conformance section to `.agents/tests/summary.md`:
+Add a short conformance section to `.agents/scratch/tests/summary.md`:
 
 ```markdown
 ## Conformance Coverage

--- a/skills/test/references/fuzzing.md
+++ b/skills/test/references/fuzzing.md
@@ -44,7 +44,7 @@ When fuzzing finds a failure:
 
 ## Output
 
-Record fuzz coverage in `.agents/tests/summary.md`:
+Record fuzz coverage in `.agents/scratch/tests/summary.md`:
 
 ```markdown
 ## Fuzz Targets

--- a/skills/test/references/golden-artifact-strategy.md
+++ b/skills/test/references/golden-artifact-strategy.md
@@ -40,7 +40,7 @@ Do not refresh a golden artifact just to make a test pass.
 
 ## Output
 
-Add an acceptance table to `.agents/tests/summary.md` when golden files change:
+Add an acceptance table to `.agents/scratch/tests/summary.md` when golden files change:
 
 ```markdown
 ## Golden Artifact Review

--- a/skills/test/references/golden-artifacts.md
+++ b/skills/test/references/golden-artifacts.md
@@ -36,7 +36,7 @@ Never update golden files as the first move.
 
 ## Output
 
-Add this to `.agents/tests/summary.md` when golden files change:
+Add this to `.agents/scratch/tests/summary.md` when golden files change:
 
 ```markdown
 ## Golden Changes

--- a/skills/test/references/metamorphic-testing.md
+++ b/skills/test/references/metamorphic-testing.md
@@ -41,7 +41,7 @@ golden artifact strategy for that case.
 
 ## Output
 
-Record the invariant and generated cases in `.agents/tests/summary.md`:
+Record the invariant and generated cases in `.agents/scratch/tests/summary.md`:
 
 ```markdown
 ## Metamorphic Coverage

--- a/skills/test/references/real-service-e2e.md
+++ b/skills/test/references/real-service-e2e.md
@@ -32,7 +32,7 @@ If any safety check is unknown, stop and ask for an explicit test environment.
 
 ## Output
 
-Record real-service test safety in `.agents/tests/summary.md`:
+Record real-service test safety in `.agents/scratch/tests/summary.md`:
 
 ```markdown
 ## Real-Service Safety

--- a/skills/test/references/test.feature
+++ b/skills/test/references/test.feature
@@ -1,7 +1,7 @@
 # Executable spec for the /test skill — test generation + coverage (supporting role).
 # /test loads the language's test standards, generates REAL tests for existing code, runs them to
 # verify they pass (it does not stop at a plan), and fills coverage gaps — writing artifacts to
-# .agents/tests/. Hexagon: supporting; consumes standards (test conventions) + repo-context (the
+# .agents/scratch/tests/. Hexagon: supporting; consumes standards (test conventions) + repo-context (the
 # code under test); produces result.json. (soc-qk4b)
 
 Feature: Test generates real, passing tests and coverage
@@ -20,4 +20,4 @@ Feature: Test generates real, passing tests and coverage
 
   Scenario: coverage analyzes and fills gaps
     When /test coverage runs
-    Then it analyzes coverage gaps and fills them, writing a coverage report to .agents/tests/
+    Then it analyzes coverage gaps and fills them, writing a coverage report to .agents/scratch/tests/

--- a/skills/test/references/test.feature
+++ b/skills/test/references/test.feature
@@ -2,7 +2,7 @@
 # /test loads the language's test standards, generates REAL tests for existing code, runs them to
 # verify they pass (it does not stop at a plan), and fills coverage gaps — writing artifacts to
 # .agents/scratch/tests/. Hexagon: supporting; consumes standards (test conventions) + repo-context (the
-# code under test); produces result.json. (soc-qk4b)
+# code under test); produces test-evidence. (soc-qk4b)
 
 Feature: Test generates real, passing tests and coverage
   As the test-generation step

--- a/skills/test/scripts/validate.sh
+++ b/skills/test/scripts/validate.sh
@@ -1,15 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
-SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-PASS=0; FAIL=0
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILL="$SKILL_DIR/SKILL.md"
 
-check() { if bash -c "$2"; then echo "PASS: $1"; PASS=$((PASS + 1)); else echo "FAIL: $1"; FAIL=$((FAIL + 1)); fi; }
+# Structural contract checks. Bare greps run under `set -e`, so a missing
+# section fails the script — unlike the prior prose-word greps, which passed
+# even after the load-bearing sections were deleted.
+[[ -s "$SKILL" ]]
+head -1 "$SKILL" | grep -q '^---$'
+grep -q '^name: test$' "$SKILL"
 
-check "SKILL.md exists" "[ -f '$SKILL_DIR/SKILL.md' ]"
-check "SKILL.md has YAML frontmatter" "head -1 '$SKILL_DIR/SKILL.md' | grep -q '^---$'"
-check "SKILL.md has name: test" "grep -q '^name: test' '$SKILL_DIR/SKILL.md'"
-check "SKILL.md mentions TDD workflow" "grep -qi 'tdd' '$SKILL_DIR/SKILL.md'"
-check "SKILL.md mentions coverage analysis" "grep -qi 'coverage' '$SKILL_DIR/SKILL.md'"
+# Load-bearing doctrine sections. Deleting any one must turn this validator red.
+grep -q '^## Critical Constraints$' "$SKILL"
+grep -q '^## Oracle-strength hierarchy$' "$SKILL"
+grep -q '^## Mutation-kill proof$' "$SKILL"
+grep -q '^## Harness health floors$' "$SKILL"
+grep -q '^## Workflow$' "$SKILL"
+grep -q '^## Output Specification$' "$SKILL"
 
-echo ""; echo "Results: $PASS passed, $FAIL failed"
-[ $FAIL -eq 0 ] && exit 0 || exit 1
+# The mode table must enumerate the four real modes.
+for mode in generate coverage tdd strategy; do
+  grep -Eq "^\| \`${mode}\`" "$SKILL"
+done
+
+# Every referenced local doc must resolve on disk.
+while IFS= read -r ref; do
+  [[ -f "$SKILL_DIR/$ref" ]] || { echo "test contract: dangling reference $ref" >&2; exit 1; }
+done < <(grep -oE 'references/[A-Za-z0-9._-]+' "$SKILL" | sort -u)
+
+echo "test contract: PASS"

--- a/skills/workflow-builder/SKILL.md
+++ b/skills/workflow-builder/SKILL.md
@@ -25,7 +25,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [workflow_builder]
-  effects: []
+  effects: [write_workflow_script]
   canonical_status: canonical
   disposition: keep_specialist
   tier: meta


### PR DESCRIPTION
## Summary

Wave W4 of the skill-overhaul reboot (`age-skill-overhaul-reboot-sjv7v.5`) — seven candidate-producing specialists, every checklist item verified against the live tree; heavyweights reproduced before fixing.

- **converter** [P0] — `convert.sh` could `rm -rf` a caller-supplied output dir and destroy the source package (reproduced). Now refuses when the canonicalized output equals, contains, or is contained by the source, or is/contains the repo root — symlinks resolved, root special-cased. Behavioral self-test (8 assertions) proves each refusal happens before any deletion, with source survival checked by content digest. Default output moved to `.agents/projections/converter/`.
- **scaffold** — deleted the commit/continuation authority grants from `generic-templates.md`; validator now sweeps `references/**` for the full grant vocabulary (proven failing on six restored variants).
- **refactor** — feature file stripped of commit + auto-revert authority; revert contradiction resolved; `modify_source_files` declared.
- **doc** — `--create-issues` tracker authority and Next-Steps work-creation removed; artifact dir into the closed set. The `[disputed]` vacuous-validator claim was verified false and rejected.
- **skill-builder** — build-report write declared and relocated; `context_rel` added — **strict frontmatter is now 49/49 with zero warnings corpus-wide**. The five-Python-files ratchet claim was verified stale (files don't exist; live ones grandfathered).
- **test** — validator replaced with load-bearing checks (fails on removed sections); `produces` reconciled everywhere incl. the feature file; effects now include `modify_source_files` (TDD mode edits production code).
- **workflow-builder** — `write_workflow_script` declared.

Ledger (30 fixed / 3 rejected-stale / 15 deferred-with-reason): `docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w4.md`.

## Validation

- Converter self-test 8/8 (descendant, repo-ancestor, symlink-into-source cases; digest-based survival); in-scope validators PASS
- Strict frontmatter 49/49 zero warnings; regen clean; 23/23 bats; scenario-linkage PASS; python ratchet no-growth; shellcheck clean
- Cross-family review, two rounds (ceiling): round 1 five findings all fixed (bidirectional guard, self-test hardening, sweep completeness, feature reconciliation, effects); round 2's one residual (`within()` breaking for parent=/) fixed and witnessed

Tracker: `age-skill-overhaul-reboot-sjv7v.5`