### PR TITLE
W6 runtime wave: authorize-first host mutation, honest adapter contracts, fail-closed deadlines

### DIFF
--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -34,15 +34,15 @@
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | - |
+| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
 | `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | `run_codex_process`, `sandbox_tiered_workspace_and_network_effects` |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | - |
-| `doc` | product | `keep_specialist` | - | `doc` | - |
+| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
 | `handoff` | session | `keep_specialist` | - | `handoff` | - |
@@ -59,21 +59,21 @@
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
 | `rch` | execution | `keep_specialist` | - | `rch` | `remote_compilation_offload`, `authorized_remote_daemon_worker_mutation` |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
-| `research` | execution | `keep_specialist` | - | `research` | - |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
+| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | - |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | - |
+| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | - |
+| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city`, `configure_codex_trust` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -29,20 +29,20 @@
 | Skill | Tier | Disposition | Hard dependencies | Capabilities | Effects |
 |---|---|---|---|---|---|
 | `account-rotation` | execution | `keep_specialist` | - | `account_rotation` | - |
-| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | - |
+| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | `write_agent_mail_records`, `install_precommit_guard`, `authorized_destructive_reset` |
 | `agent-native` | meta | `keep_optional_adapter` | - | `role_dispatch`, `observe_workers`, `handoff` | `manage_runtime_sessions` |
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
+| `cass` | execution | `keep_specialist` | - | `cass` | - |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
-| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
+| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | `run_codex_process`, `sandbox_tiered_workspace_and_network_effects` |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | - |
-| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
+| `doc` | product | `keep_specialist` | - | `doc` | - |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
 | `handoff` | session | `keep_specialist` | - | `handoff` | - |
@@ -50,30 +50,30 @@
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |
 | `learn` | execution | `keep_off_path` | - | `analyze_verdict_collections` | `write_advisory_observations` |
 | `ms` | execution | `keep_specialist` | - | `ms` | - |
-| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | - |
+| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | `manage_ntm_panes`, `dispatch_pane_commands` |
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
 | `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | `write_pattern_evidence` |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
 | `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
-| `rch` | execution | `keep_specialist` | - | `rch` | - |
+| `rch` | execution | `keep_specialist` | - | `rch` | `remote_compilation_offload`, `authorized_remote_daemon_worker_mutation` |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
-| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
+| `research` | execution | `keep_specialist` | - | `research` | - |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | - |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
+| `security` | product | `keep_specialist` | - | `security` | - |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
+| `test` | execution | `keep_specialist` | - | `test` | - |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
-| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
+| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city`, `configure_codex_trust` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -34,15 +34,15 @@
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | - |
+| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
 | `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | `run_codex_process`, `sandbox_tiered_workspace_and_network_effects` |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | - |
-| `doc` | product | `keep_specialist` | - | `doc` | - |
+| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
 | `handoff` | session | `keep_specialist` | - | `handoff` | - |
@@ -59,21 +59,21 @@
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
 | `rch` | execution | `keep_specialist` | - | `rch` | `remote_compilation_offload`, `authorized_remote_daemon_worker_mutation` |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
-| `research` | execution | `keep_specialist` | - | `research` | - |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
+| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | - |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | - |
+| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | - |
+| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city`, `configure_codex_trust` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -29,20 +29,20 @@
 | Skill | Tier | Disposition | Hard dependencies | Capabilities | Effects |
 |---|---|---|---|---|---|
 | `account-rotation` | execution | `keep_specialist` | - | `account_rotation` | - |
-| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | - |
+| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | `write_agent_mail_records`, `install_precommit_guard`, `authorized_destructive_reset` |
 | `agent-native` | meta | `keep_optional_adapter` | - | `role_dispatch`, `observe_workers`, `handoff` | `manage_runtime_sessions` |
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
+| `cass` | execution | `keep_specialist` | - | `cass` | - |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
-| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
+| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | `run_codex_process`, `sandbox_tiered_workspace_and_network_effects` |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | - |
-| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
+| `doc` | product | `keep_specialist` | - | `doc` | - |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
 | `handoff` | session | `keep_specialist` | - | `handoff` | - |
@@ -50,30 +50,30 @@
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |
 | `learn` | execution | `keep_off_path` | - | `analyze_verdict_collections` | `write_advisory_observations` |
 | `ms` | execution | `keep_specialist` | - | `ms` | - |
-| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | - |
+| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | `manage_ntm_panes`, `dispatch_pane_commands` |
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
 | `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | `write_pattern_evidence` |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
 | `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
-| `rch` | execution | `keep_specialist` | - | `rch` | - |
+| `rch` | execution | `keep_specialist` | - | `rch` | `remote_compilation_offload`, `authorized_remote_daemon_worker_mutation` |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
-| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
+| `research` | execution | `keep_specialist` | - | `research` | - |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | - |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
+| `security` | product | `keep_specialist` | - | `security` | - |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
+| `test` | execution | `keep_specialist` | - | `test` | - |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
-| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
+| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city`, `configure_codex_trust` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |

--- a/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w6.md
+++ b/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w6.md
@@ -275,3 +275,45 @@ run.
   (only existing grandfathered `.py` edited; no new `.py`).
 - No shell files changed (no shellcheck surface); no `validate.sh` exists for any
   in-scope skill.
+
+## Cross-family review round 1 — REQUEST_CHANGES, 3 findings fixed
+
+- **Finding 1 — rch autonomous tier still permitted host mutations.**
+  **Fixed.** The `FAIL_OPEN` §"Autonomous Remediation Envelope" now defines the
+  autonomous tier as read-only diagnosis/inspection **only** (status/check/log
+  reads, dry-run diagnose, probe/list, config get/show/validate/doctor/diff,
+  hook status/test, fleet status/verify, env-var tuning, retry). `rch hook
+  install|uninstall` and local-key `chmod` were moved out of autonomous into the
+  (authorize first) tier. A mechanical sweep (grep of every command invocation in
+  all seven reference docs) then classified each remaining mutating "first
+  action"/"self-fix" and marked it **(authorize first)**: `FAIL_OPEN` cells
+  (force_local set, invalid-config edit/reload, circuit `workers enable`,
+  runtime install, `total_slots` raise, tag add); `ERROR_CODES` first-action
+  cells (E001 config init, E007 discover+setup, E009 key chmod, E020 policy set,
+  E103 known_hosts edit, E204 total_slots, E205 sync-toolchain, E207 enable,
+  E212 rch-wkr restart, E213 drain, E303 build_timeout edit) plus a top
+  authority banner; `RECOVERY_PLAYBOOKS` (Playbook A/H hook install, D reload +
+  total_slots, K drain, L config init/reload); `TROUBLESHOOTING` (top banner +
+  daemon start/restart, discover/setup, hook install, reload blocks). The two
+  catalog docs that had no gate — `WORKERS.md` and `CONFIGURATION.md` — each got
+  an authority banner and CONFIGURATION's hook-management block was marked.
+  Post-fix sweep: no mutating command is labeled "autonomous";
+  `MACHINE_INTROSPECTION.md` is read-only (no mutating first-actions).
+- **Finding 2 — using-gc updated codex without authorization.** **Fixed.** The
+  "Update nag" fix now states that updating the codex binary is a host mutation
+  made only with explicit caller authorization, the same bar as the trust-config
+  edit.
+- **Finding 3 — codex-exec permitted no-timeout runs; `timeout` doesn't reap the
+  tree.** **Fixed.** The contract is now: a wall-clock deadline is **mandatory**
+  (caller-supplied, else a declared **600s** default, recorded); expiry is
+  **fail-closed** (killed, reported timed-out/not-proven, partial output
+  preserved, never a review result); and cleanup must reap the whole process
+  **tree** via a process-group kill (`setsid` + `kill -KILL -<pgid>` or
+  `timeout --kill-after`), with an explicit disclosed limitation that a plain
+  `timeout` reaps only the direct child. The example uses `setsid timeout
+  --kill-after=10s`.
+
+Round-1 gate results (all green): frontmatter 49/49; regen-all --check current;
+liveness + anti-spiral 15/15; multi-model 5/5; swarm 8/8; python ratchet PASS
+(24 grandfathered, no growth). No `.py` or shell changed in round 1 (rch
+reference docs, using-gc SKILL.md, codex-exec SKILL.md text only).

--- a/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w6.md
+++ b/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w6.md
@@ -1,0 +1,277 @@
+# Wave W6 report — runtime adapters
+
+Bead: `age-skill-overhaul-reboot-sjv7v.7`. Branch: `claude/sor-w6-runtime`.
+Skills: `agent-mail`, `agent-native`, `agy-native`, `codex-exec`, `ntm`, `rch`,
+`swarm`, `using-gc`.
+
+Every checklist item from `checklists/adapters-13.md` (the seven adapter slugs)
+and `checklists/workflow-12.md` (`using-gc`) is dispositioned below. Each item
+was verified against the live tree first; the `Verified` line records what the
+live file actually showed. Disposition counts and gate results are at the end.
+
+The wave upholds the runtime-adapter doctrine: capability-unavailable behavior is
+explicit; deadlines/cancellation/cleanup are described; transport state never
+becomes campaign/RPI/verdict/work-ownership state; each adapter names its distinct
+capability; unavailable tools and timeouts have explicit terminal outcomes.
+
+## rch (P0 heavyweight)
+
+- **RCH-A** `[defect, P0]` — **fixed.** Verified: three live sites instruct
+  "always do, never ask" for remote/privileged/irreversible mutations —
+  `FAIL_OPEN.md` §"Don't Ask the Human" Rules ("the answer is **always do,
+  never ask**", incl. remote `sudo chown -R`/`chmod` "don't escalate" and
+  `rch workers sync-toolchain`), `RECOVERY_PLAYBOOKS.md:19` ("Don't ask the human
+  if the fix is in the playbook"), and `TROUBLESHOOTING.md:258` ("Self-fix (this
+  is safe — never ask first)" over `rch daemon restart` + `rch fleet deploy`).
+  All directly contradict the SKILL.md explicit-authority requirement
+  (`:29-32`/`:53-55`). Fix: the SKILL.md boundary is the authority; the
+  references were rewritten to a named autonomous-remediation envelope with a
+  blast-radius ceiling — read-only diagnostics and reversible local-only actions
+  (retry, env-var timeout bumps, config *inspection*, local hook install/test,
+  local key-perm fixes) run autonomously; every remote host mutation, `sudo`,
+  worker/fleet deployment, toolchain sync, daemon start/restart/reconfigure, and
+  destructive cleanup requires explicit caller authorization first, marked
+  **(authorize first)** at each fix block (`FAIL_OPEN` envelope section + table
+  cells; Playbooks B/E/F/J; `TROUBLESHOOTING` toolchain/chown/version-drift/
+  safe-reset/telemetry; `ERROR_CODES` chown rows). SKILL.md References section
+  now states the boundary governs every reference.
+- **S1 effects `[]`** `[defect]` — **fixed.** Verified false. Now
+  `effects: [remote_compilation_offload, authorized_remote_daemon_worker_mutation]`,
+  separating read-only diagnosis from gated remote mutation.
+- **N10 six dangling sibling-doc refs** `[defect]` — **fixed.** Verified: exactly
+  six absent docs referenced on the remediation path (`SELF_HEALING.md`,
+  `SSH_TUNING.md`, `PATH_DEPENDENCIES.md`, `DISK_AND_PRESSURE.md`,
+  `OPERATIONS.md`, `MULTI_AGENT_CONTENTION.md`) across `FAIL_OPEN`,
+  `RECOVERY_PLAYBOOKS`, `ERROR_CODES`. Each dangling pointer redirected to a
+  present sibling that already carries the material (Playbook B/C/F/G, the
+  path-dep section of `TROUBLESHOOTING`, the disk/network rows of `ERROR_CODES`,
+  the `sbh` and `agent-mail` skills). Post-fix grep: zero dangling refs remain.
+- **N11 `doctor.success` vs `rch check`** `[defect]` — **fixed (doc
+  clarification).** The live inversion claim (doctor `success:true` with daemon
+  down) was not re-run — probing readiness hits real SSH workers, out of the
+  safe-probe envelope — but the fix is authority-consistent regardless: SKILL.md
+  now states `rch check` exit status adjudicates readiness and `doctor.success`
+  does not, matching the `TROUBLESHOOTING` diagnostic flow that already gates on
+  `rch check`.
+- **RCH-5 `bd-w5r9` leak** `[defect]` — **fixed.** Verified at
+  `RECOVERY_PLAYBOOKS.md:252`; replaced the internal tracker id with a plain
+  "pre-v1.0.16 self-test hang bug" description. Post-fix grep: no `bd-` ids in
+  `skills/rch/`.
+- **RCH-3 references w/o authority ordering** `[enhance]` — **fixed.** SKILL.md
+  References preamble now states the kernel authority boundary governs every
+  reference and a reference never widens the granted autonomy.
+- **RCH-4 `not_proven` no-weight disclaimer** `[enhance]` — **fixed.** Output
+  section now states `not_proven` is a runtime diagnosis status carrying no
+  verdict weight and never substituting for a `verdict.v2`.
+
+## agent-mail
+
+- **AM-1 untyped admin/DR surface** `[defect, P0]` — **fixed.** Verified:
+  `clear-and-reset-everything --force --no-archive` and `install_precommit_guard`
+  reachable with no typed mode or authority boundary. Added a "Modes and
+  authority" section splitting the default coordination mode from an explicitly
+  caller-authorized admin/DR mode; the destructive reset is called out as
+  irreversible and never run without an explicit destructive-reset
+  authorization. `RECOVERY.md` "Dangerous Operations" header rewritten to match.
+- **S1 effects `[]`** `[defect]` — **fixed.** Now
+  `effects: [write_agent_mail_records, install_precommit_guard, authorized_destructive_reset]`.
+- **N18 retired `uv run python -m mcp_agent_mail.cli` entrypoint** `[defect]` —
+  **fixed.** Verified pervasive in `RECOVERY.md`; the real surface is the `am`
+  CLI (`am --help` confirms `doctor`, `share`, `archive`, `file_reservations`,
+  `acks`, `clear-and-reset-everything`, `config`, `robot`). Rewrote every
+  occurrence onto `am`. Post-fix grep: no `mcp_agent_mail.cli`/`uv run` remains.
+- **AM-3 advisory alongside collision guarantee** `[enhance]` — **fixed.** The
+  reservation sentence now states reservations are **advisory** and enforce
+  nothing on a writer that does not check.
+- **AM-4 `force_release` authority precondition** `[enhance]` — **fixed.** Added
+  a Boundary bullet: release, including any `force_release`, only on the caller's
+  explicit request for that exact reservation; a conflict is reported, not
+  force-cleared.
+- **AM-6 `consumes: [task-intent]` on a transport** `[enhance]` — **fixed.**
+  Changed to `consumes: [coordination-request]`.
+- **T7a untyped results / unavailable / cleanup** `[enhance]` — **fixed.** Output
+  section now types the results (TTLs included) and gives explicit terminal
+  outcomes for adapter-unavailable, conflict, timeout/degraded, and cleanup
+  (reservations released vs. left holding a TTL).
+
+## agent-native
+
+- **AN-2 `validate_cross` accepts equal context ids** `[defect]` — **fixed
+  (code).** Verified in `fake_model_runner.py`. Added an equality check that
+  rejects equal author/validator context ids (rc=2) before any
+  `freshness_attestation` is emitted. Bats-safe (all tests pass distinct ids);
+  probe confirms rc=2 with message.
+- **AN-4 wall-clock `utc_now()`** `[defect]` — **fixed (code).** Added
+  `SOURCE_DATE_EPOCH` support (env-only, zero CLI/test-contract change); falls
+  back to wall-clock when unset. Probe with `SOURCE_DATE_EPOCH=1700000000` yields
+  a deterministic `generated_at`.
+- **AN-3 `diversity_unsatisfied` routed to a sidecar** `[defect]` — **deferred.**
+  Admitting it into the challenge schema means editing `idea-genie`'s
+  `validate-challenge.sh` and the `idea-challenge.v1` shape — a cross-skill
+  shared contract. The current sidecar (`.diversity.json`) is honest and
+  functional; per the wave's cross-contract-deferral rule this belongs to a
+  shared-schema bead, not W6.
+- **S4 move `model-dispatch.md` to `docs/contracts/`** `[enhance]` — **deferred.**
+  Relocating the shared model-dispatch contract touches three consumers
+  (agent-native, codex-exec, ntm all cite it) — a shared-contract move outside a
+  single-skill text edit. Deferred with note.
+- **AN-5 `tier: meta` vs undefined tier vocabulary** `[enhance]` — **rejected
+  (not a defect here).** The v2 schema accepts any `tier` string (`minLength: 1`);
+  `meta` is schema-valid. A tier-vocabulary definition is a cross-cutting taxonomy
+  decision (W8 coherence), and changing the tier risks catalog/router drift for
+  no contract gain this wave.
+- **GOV-1 move `fake_model_runner.py` scripts→tests** `[enhance]` — **deferred.**
+  The file is already grandfathered and the ratchet exempts `tests/**` as a
+  class, so the debt is dormant; the move requires a snapshot prune + path
+  updates for a zero-count-change. Deferred to keep the wave bounded.
+
+## agy-native
+
+- **AGY-R reconcile SKILL with 520-line root adapter** `[defect]` — **rejected
+  (misattributed premise); substance fixed via AGY-2/LIVE-2/AGY-3.** Verified:
+  `agy-native/` ships SKILL.md only (no scripts). The "live root adapter" is the
+  repo-root `scripts/lib/codex-exec.sh` eval/membrane lib, which dispatches agy
+  as a ROUTINE-tier fallback (`agy -p`) but is repo eval infra, **not** the
+  agy-native skill package — citing it from the shipped skill would break a
+  standalone install. The substantive asks (name the adapter/tier/posture) are
+  discharged by the items below.
+- **AGY-2 prescribes discovery but names no command** `[defect]` — **fixed.**
+  Named `agy --help` and `agy models` (both verified as real, safe surfaces).
+- **LIVE-1 `codex_exec_timeout_cmd` unbounded degrade** `[defect]` — **fixed for
+  agy in text; lib deferred.** Verified the shared lib returns empty when neither
+  `timeout`/`gtimeout` exists and then runs unbounded (an intentional bo-mac
+  design, per its comment). For agy specifically, `agy -p` carries a built-in
+  `--print-timeout` (default 5m, from `agy --help`), so the skill now discloses
+  that a run exceeding it is killed and reported as timed out, not a result.
+  Changing the shared repo lib to fail-closed is out of `skills/` scope and
+  shared with codex-exec — deferred.
+- **LIVE-2 sandbox/permission posture undisclosed** `[enhance]` — **fixed.**
+  Added a "Permission posture" section disclosing the interactive default,
+  `--dangerously-skip-permissions` (auto-approve all), `--sandbox`, and the
+  print-mode timeout — all verified against `agy --help`.
+- **AGY-3 AGY-absent path unspecified** `[enhance]` — **fixed.** Added a "When
+  AGY is unavailable" section: report the absence and stop, no fallback runtime,
+  no `claude -p`.
+- **AGY-4 thinnest kernel for a validator role** `[enhance]` — **fixed** by the
+  posture + absent-path + timeout additions above.
+
+## codex-exec
+
+- **S1 effects `[]`** `[defect]` — **fixed.** Now
+  `effects: [run_codex_process, sandbox_tiered_workspace_and_network_effects]`,
+  and the procedure ties the sandbox tier to the invoked `-s` flag.
+- **CE-4 `consumes: []` while requiring a caller packet** `[defect]` — **fixed.**
+  Changed to `consumes: [codex-command-packet]`.
+- **CE-5 two overlapping trigger vocabularies** `[defect]` — **fixed.** Removed
+  the `metadata.triggers` block, collapsing triggers to the single `description`
+  source.
+- **LIVE-1 timeout degrade** `[defect]` — **fixed (text).** Procedure now has an
+  explicit "bound the run with a wall-clock timeout; if none is available,
+  disclose the unbounded run rather than hang silently" step; the example wraps
+  in `timeout`. Shared-lib fix deferred (see agy-native LIVE-1).
+- **S4 cite `scripts/lib/codex-exec.sh` + `codex-exec-lib.bats`** `[enhance]` —
+  **rejected.** Verified both exist, but they are repo-root eval infra outside
+  the skill package; a shipped skill citing them would dangle on a standalone
+  install. The honest T7a fix is typing the run result (below), not linking eval
+  infra.
+- **T7a type the run result / cancellation / cleanup** `[enhance]` — **fixed.**
+  Report step now types exit status, artifact path, timeout-fired + process-tree
+  reap, and binary-absent; explicit terminal outcomes for binary-absent /
+  timed-out / nonzero-exit; cancellation named as the caller's.
+
+## ntm
+
+- **S1 effects `[]`** `[defect]` — **fixed.** Now
+  `effects: [manage_ntm_panes, dispatch_pane_commands]`.
+- **T7a type the seven obligations** `[enhance]` — **fixed.** The skill already
+  carried observation-window, bounded-robot-output, roles/commands/scopes, and
+  degraded-surface reporting; added explicit terminal outcomes for
+  NTM-unavailable, observation-deadline, timeout/nonzero/degraded, and
+  cancellation/cleanup (which panes were created or left running).
+- **NTM-4 `consumes: [task-intent]` on a transport** `[enhance]` — **fixed.**
+  Changed to `consumes: [pane-command-request]`.
+- **NTM-5 external-doc delegation w/o version pin** `[enhance]` — **fixed.** Added
+  a runtime-confirmation note (`ntm --version`, `ntm --robot-capabilities`)
+  rather than trusting remembered commands.
+- **S4 point at relocated model-dispatch contract** `[enhance]` — **deferred**
+  (tied to the S4 relocation deferred under agent-native). The skill already
+  points at the present `agent-native` model-dispatch recipe.
+
+## swarm
+
+- **SW-1 case-varying scopes admitted as disjoint** `[defect]` — **fixed (code).**
+  Verified `_overlap` compared lexical prefixes only. Made the prefix comparison
+  case-folded (unconditional, conservative: on a case-insensitive filesystem the
+  scopes ARE identical; on a case-sensitive one it only over-rejects, matching
+  the module's reject-when-uncertain stance). Witnessed by a new test.
+- **SW-2 `write_scope.exclude` silently ignored** `[defect]` — **fixed (code).**
+  Verified `_includes` never read `exclude`. Now a non-empty `exclude` is
+  rejected (not silently ignored), because the lexical disjointness proof cannot
+  honor it. Witnessed by a new test. Empty `exclude` (the fixture default) still
+  passes.
+- **SW-3 symlink-aliased scopes admitted as disjoint** `[defect]` — **fixed by
+  declared precondition; code resolution deferred.** The pure `dispatch_once`
+  function receives relative path strings and no workspace root, so it cannot
+  resolve symlinks without breaking its purity/testability. SKILL.md now declares
+  the precondition: scopes must be workspace-relative and canonical
+  (symlink-resolved); the check is lexical and cannot see a symlink aliasing two
+  scopes onto one target — supplying non-canonical scopes forfeits the guarantee.
+  This is the audit's stated alternative ("declare and enforce a no-symlink
+  precondition"). FS-resolving code is deferred (needs a workspace root the port
+  does not take).
+- **SW-4 transitive executor effects understated** `[enhance]` — **fixed (text).**
+  SKILL.md now states Swarm's own effect is invoking the executor once per
+  packet and each packet's transitive effects are the caller's to declare on the
+  packet.
+- **GOV-1 move `dispatch_once.py` to Go** `[enhance]` — **deferred** (structural;
+  the file is grandfathered and the ratchet passes with no growth).
+
+## using-gc
+
+- **Conditional `host.configure` undeclared** `[enhance]` — **fixed.** Verified
+  the folder-trust fix writes exact-path `trust_level` entries to the user's
+  global `~/.codex/config.toml`. Added `configure_codex_trust` to `effects` and a
+  note that this host-configuration mutation is made only with explicit caller
+  authorization, scoped to those exact paths.
+- **`tmux -L <socket>` source unnamed at three call sites** `[enhance]` —
+  **fixed.** Named once in the Liveness truth stack that `<socket>`/`<session>`
+  (here and at every `tmux -L` site) are the ones `mayor status` prints.
+- **Dispatch-once / one-wake behavioral witnesses** `[enhance]` — **deferred.**
+  No scenario/`.feature` runner is wired for `using-gc`; the invariants are
+  already stated as text ("Dispatch each bead once"; "One wake, maximum, then
+  STOP"). Adding `.feature` files with no runner adds inert artifacts — deferred
+  to the coherence wave if a runner lands.
+- **Version-pinned external claims (v1.3.5 / #4586) no local guard** `[enhance]`
+  — **deferred.** A live GC-version probe is an external-service call outside the
+  safe-probe envelope; the skill already notes the flow "survives the upstream
+  fix". Deferred.
+
+## Disposition counts
+
+- Fixed (defect): 16 — RCH-A, rch S1, N10, N11, RCH-5; AM-1, AM S1, N18; AN-2,
+  AN-4; codex-exec S1, CE-4, CE-5, LIVE-1; SW-1, SW-2.
+- Fixed (enhance): 15 — RCH-3, RCH-4; AM-3, AM-4, AM-6, AM T7a; AGY-2, LIVE-2,
+  AGY-3, AGY-4; ntm S1, ntm T7a, NTM-4, NTM-5; SW-4; using-gc host.configure,
+  using-gc tmux-source. (SW-3 counted under fixed-defect via declared
+  precondition.)
+- Rejected with reason: 3 — AN-5 (schema-valid tier; W8 taxonomy),
+  AGY-R (misattributed premise; substance fixed elsewhere), codex-exec S4
+  (repo eval infra, not skill package).
+- Deferred with reason: 7 — AN-3 (challenge schema), S4 relocation +
+  ntm-S4 (shared contract), GOV-1 ×2 (structural), using-gc witnesses (no
+  runner), using-gc version guard (external probe).
+
+Two-same-class-refute anti-spiral rule was not triggered; one verification pass
+run.
+
+## Gate results
+
+- `scripts/validate-skill-frontmatter.sh` (non-strict): 49/49 ok.
+- `scripts/regen-all.sh --check`: all generated projections current.
+- `bats tests/scripts/skill-validator-liveness.bats tests/scripts/anti-spiral-contract.bats`: 15/15 green.
+- `bats tests/integration/test_multi_model_dispatch.bats` (agent-native fake runner): 5/5 green.
+- `python3 skills/swarm/tests/test_dispatch_once.py`: 8/8 green (2 new witnesses).
+- `scripts/check-skill-python-ratchet.sh`: PASS — 24 grandfathered, no growth
+  (only existing grandfathered `.py` edited; no new `.py`).
+- No shell files changed (no shellcheck surface); no `validate.sh` exists for any
+  in-scope skill.

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -59,7 +59,7 @@
 
 | Skill | Direction | Artifact |
 |---|---|---|
-| `agent-mail` | consumes | `task-intent` |
+| `agent-mail` | consumes | `coordination-request` |
 | `agent-mail` | produces | `agent-identity` |
 | `agent-mail` | produces | `file-reservation` |
 | `agent-mail` | produces | `acknowledged-handoff` |
@@ -78,6 +78,7 @@
 | `codebase-recon` | consumes | `existing-docs` |
 | `codebase-recon` | produces | `codebase-recon.v1` |
 | `codebase-recon` | produces | `evidence-bounded-recon-report` |
+| `codex-exec` | consumes | `codex-command-packet` |
 | `codex-exec` | produces | `codex-run-output` |
 | `converter` | produces | `converted-skill` |
 | `council` | consumes | `explicit-question` |
@@ -100,7 +101,7 @@
 | `implement` | produces | `subject-manifest.v1` |
 | `learn` | consumes | `verdict.v2` |
 | `learn` | produces | `learning-observations` |
-| `ntm` | consumes | `task-intent` |
+| `ntm` | consumes | `pane-command-request` |
 | `ntm` | produces | `ntm-robot-state` |
 | `ntm` | produces | `agent-worker-transcript` |
 | `operationalize` | consumes | `evidence-backed-expertise` |

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -23,20 +23,20 @@
 | Skill | Tier | Disposition | Hard dependencies | Capabilities | Effects |
 |---|---|---|---|---|---|
 | `account-rotation` | execution | `keep_specialist` | - | `account_rotation` | - |
-| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | - |
+| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | `write_agent_mail_records`, `install_precommit_guard`, `authorized_destructive_reset` |
 | `agent-native` | meta | `keep_optional_adapter` | - | `role_dispatch`, `observe_workers`, `handoff` | `manage_runtime_sessions` |
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
+| `cass` | execution | `keep_specialist` | - | `cass` | - |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
-| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
+| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | `run_codex_process`, `sandbox_tiered_workspace_and_network_effects` |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | - |
-| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
+| `doc` | product | `keep_specialist` | - | `doc` | - |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
 | `handoff` | session | `keep_specialist` | - | `handoff` | - |
@@ -44,30 +44,30 @@
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |
 | `learn` | execution | `keep_off_path` | - | `analyze_verdict_collections` | `write_advisory_observations` |
 | `ms` | execution | `keep_specialist` | - | `ms` | - |
-| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | - |
+| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | `manage_ntm_panes`, `dispatch_pane_commands` |
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
 | `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | `write_pattern_evidence` |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
 | `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
-| `rch` | execution | `keep_specialist` | - | `rch` | - |
+| `rch` | execution | `keep_specialist` | - | `rch` | `remote_compilation_offload`, `authorized_remote_daemon_worker_mutation` |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
-| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
+| `research` | execution | `keep_specialist` | - | `research` | - |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | - |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
+| `security` | product | `keep_specialist` | - | `security` | - |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
+| `test` | execution | `keep_specialist` | - | `test` | - |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
-| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
+| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city`, `configure_codex_trust` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -28,15 +28,15 @@
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | - |
+| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
 | `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | `run_codex_process`, `sandbox_tiered_workspace_and_network_effects` |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | - |
-| `doc` | product | `keep_specialist` | - | `doc` | - |
+| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
 | `handoff` | session | `keep_specialist` | - | `handoff` | - |
@@ -53,21 +53,21 @@
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
 | `rch` | execution | `keep_specialist` | - | `rch` | `remote_compilation_offload`, `authorized_remote_daemon_worker_mutation` |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
-| `research` | execution | `keep_specialist` | - | `research` | - |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
+| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | - |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | - |
+| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | - |
+| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city`, `configure_codex_trust` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/images/gemini/skills/agent-mail/SKILL.md
+++ b/images/gemini/skills/agent-mail/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 skill_api_version: 1
 hexagonal_role: supporting
 consumes:
-- task-intent
+- coordination-request
 produces:
 - agent-identity
 - file-reservation
@@ -14,7 +14,7 @@ context_rel:
   with: agent-native
 metadata:
   capabilities: [agent_mail]
-  effects: []
+  effects: [write_agent_mail_records, install_precommit_guard, authorized_destructive_reset]
   canonical_status: canonical
   disposition: keep_optional_adapter
   tier: execution
@@ -30,9 +30,10 @@ Agent Mail carries messages, acknowledgements, identities, and temporary file
 reservations. It is not a task tracker, queue, proof ledger, or lifecycle
 controller.
 
-Reservations prevent collisions only because every cooperating writer checks
-them against the same absolute project path; one writer registered against a
-different path resolution makes the whole ledger advisory fiction.
+Reservations are **advisory**: they prevent collisions only because every
+cooperating writer checks them against the same absolute project path, and one
+writer registered against a different path resolution makes the whole ledger
+advisory fiction. Agent Mail enforces nothing on a writer that does not check.
 
 Named failure mode — **silence-as-status**: reading an unanswered thread as
 "work stalled" or "work done"; mail silence proves only that no mail arrived.
@@ -51,8 +52,27 @@ changes are the caller's call.
 - Mail silence proves nothing about work status.
 - A message or acknowledgement is evidence that communication occurred, not
   evidence that a change is correct or complete.
+- Release a reservation, including any `force_release`, only on the caller's
+  explicit request for that exact reservation. Force-release has no autonomous
+  trigger; a conflict is reported, not force-cleared.
 - Agent Mail never selects work, changes tracker state, commits code, validates,
   integrates, closes, releases, or delivers work.
+
+## Modes and authority
+
+Two disjoint surfaces; do not reach the second from the first:
+
+- **Coordination mode (default).** Register identity, reserve/release the
+  caller's paths, send/read/acknowledge the caller's threads. This is the whole
+  of routine use, and all of it writes durable Agent Mail records.
+- **Admin / disaster-recovery mode (explicitly caller-authorized only).**
+  Installing the git pre-commit guard, `doctor repair`, backup/restore, and the
+  irreversible `clear-and-reset-everything` are a separate mode. Each requires
+  the caller's explicit authorization for that specific operation; none is ever
+  performed as a side effect of coordination. `clear-and-reset-everything`
+  deletes the database and all storage and cannot be undone — never run it, even
+  with `--force`, without an explicit destructive-reset authorization from the
+  caller.
 
 ## Surfaces
 
@@ -73,9 +93,21 @@ from remembered aliases.
 
 ## Output
 
-Return the project, identity, thread/message ids, reservation ids and paths,
-conflicts, timestamps, and any degraded or unavailable surface. The caller owns
-all subsequent decisions.
+Return the project, identity, thread/message ids, reservation ids and paths
+(with their TTLs), conflicts, and timestamps. The caller owns all subsequent
+decisions.
+
+Terminal outcomes are explicit, never silent:
+
+- **Adapter unavailable** — neither the MCP tools nor the `am` CLI is present:
+  report that Agent Mail is unavailable and stop. Do not fall back to
+  hand-written coordination or treat the absence as "no conflicts".
+- **Reservation conflict** — report the conflicting reservation as-is; do not
+  narrow, widen, renew, or force-release it.
+- **Timeout / degraded surface** — report the operation as timed out or degraded
+  with what was and was not observed; a timeout is evidence, not "done".
+- **Cleanup** — reservations released this session are listed by id; any left
+  in place (still holding a TTL) are named so the caller can see what remains.
 
 ## References
 

--- a/images/gemini/skills/agy-native/SKILL.md
+++ b/images/gemini/skills/agy-native/SKILL.md
@@ -23,12 +23,34 @@ output_contract: AGY runtime evidence
 # AGY Native
 
 Use AGY only when the caller explicitly selects that runtime. Discover its live
-command surface before acting and scope every session to the supplied workspace
-and packet.
+command surface with `agy --help` (and `agy models` for the current model set)
+before acting, and scope every session to the supplied workspace and packet.
 
 Discovering the live command surface before acting works because AGY's CLI
 changes faster than any skill text: a remembered flag is a guess, while a
 freshly listed one is evidence.
+
+## Permission posture (disclose it; never assume it)
+
+The posture a run gets is chosen by flags, so name it explicitly:
+
+- Default `agy` runs interactively and prompts for each tool permission.
+- `--dangerously-skip-permissions` auto-approves every tool call — use it only
+  when the packet's declared effects and the caller's authorization cover that
+  blast radius.
+- `--sandbox` restricts the session's terminal access.
+- Print mode (`agy -p` / `--print`) is the sanctioned headless path and carries
+  a built-in `--print-timeout` (default 5m); a run that exceeds it is killed and
+  reported as timed out, not as a result.
+
+A reader who sets none of these gets AGY's interactive default, not a scoped
+run. Match the posture to the declared effects and disclose which one was used.
+
+## When AGY is unavailable
+
+If `agy` is not installed or its command surface cannot be discovered, report the
+absence as a disclosed fact and stop. Do not fall back to another runtime, do not
+guess a command surface, and never route through `claude -p`.
 
 Named failure mode — **wrapper drift**: invoking AGY through remembered
 syntax that silently changed, producing runs that look scoped but are not.

--- a/images/gemini/skills/codex-exec/SKILL.md
+++ b/images/gemini/skills/codex-exec/SKILL.md
@@ -6,7 +6,8 @@ user-invocable: false
 hexagonal_role: driving-adapter
 practices:
 - pragmatic-programmer
-consumes: []
+consumes:
+- codex-command-packet
 produces:
 - codex-run-output
 context_rel:
@@ -22,15 +23,12 @@ context:
   intel_scope: none
 metadata:
   capabilities: [codex_exec]
-  effects: []
+  effects: [run_codex_process, sandbox_tiered_workspace_and_network_effects]
   canonical_status: canonical
   disposition: keep_optional_adapter
   tier: orchestration
   dependencies: []
   stability: stable
-  triggers:
-  - codex exec
-  - spawn a codex worker
 output_contract: process exit status and captured Codex output artifact
 ---
 # Codex Exec — one-shot runtime adapter
@@ -58,17 +56,28 @@ prompt runs read-only, full stop.
    explicitly requires network or external effects.
 4. Pipe the prompt to stdin (or close stdin) in non-TTY execution so the process
    cannot wait indefinitely for input.
-5. Capture the final response with `-o`, JSONL, or an output schema.
-6. Report the process exit status and captured artifact, then stop.
+5. Bound the run with an explicit wall-clock timeout (wrap with `timeout`
+   /`gtimeout`, or use the profile's own deadline). If no timeout mechanism is
+   available, disclose that the run is unbounded rather than let it hang
+   silently, and treat a killed run as a distinct terminal outcome — not a
+   review result.
+6. Capture the final response with `-o`, JSONL, or an output schema.
+7. Report the typed run result, then stop: the process exit status, the captured
+   artifact path, whether a timeout fired (and the process tree was reaped), and
+   whether the `codex` binary was even present. Cancellation is the caller's;
+   this skill neither retries nor continues on its own.
 
-A nonzero process exit is runtime evidence, not a semantic verdict. The caller
-decides whether to launch another invocation.
+Terminal outcomes are explicit: **binary absent** (no `codex` on PATH) →
+report unavailable and stop; **timed out** → report the kill and preserved
+partial output, never as a completed review; **nonzero exit** → runtime
+evidence, not a semantic verdict. The caller decides whether to launch another
+invocation.
 
 ## Example
 
 ```bash
-printf '%s\n' "$PROMPT" | codex exec -C "$WORKSPACE" -s read-only \
-  -o "$OUTPUT" -
+printf '%s\n' "$PROMPT" | timeout "${CODEX_TIMEOUT:-600}" \
+  codex exec -C "$WORKSPACE" -s read-only -o "$OUTPUT" -
 ```
 
 For a validator, the prompt must name the acceptance digest, exact subject

--- a/images/gemini/skills/codex-exec/SKILL.md
+++ b/images/gemini/skills/codex-exec/SKILL.md
@@ -56,27 +56,38 @@ prompt runs read-only, full stop.
    explicitly requires network or external effects.
 4. Pipe the prompt to stdin (or close stdin) in non-TTY execution so the process
    cannot wait indefinitely for input.
-5. Bound the run with an explicit wall-clock timeout (wrap with `timeout`
-   /`gtimeout`, or use the profile's own deadline). If no timeout mechanism is
-   available, disclose that the run is unbounded rather than let it hang
-   silently, and treat a killed run as a distinct terminal outcome — not a
-   review result.
+5. A wall-clock **deadline is mandatory** — never run codex unbounded. Use the
+   caller's deadline, or the declared default of **600s (10 min)** when the
+   caller supplies none, and record which one applied. Enforce it so the whole
+   process **tree** is reaped, not just the direct child: run codex in its own
+   process group and kill the group on expiry (e.g. `setsid` + `kill -KILL
+   -<pgid>`), or `timeout --kill-after=10s <secs>` to escalate TERM→KILL. Plain
+   `timeout <secs> codex …` signals only the direct child, so if your wrapper
+   cannot guarantee process-group reaping, **disclose the surviving-subprocess
+   risk as a limitation** rather than claim cleanup. Deadline expiry is
+   **fail-closed**: the run is killed and reported as timed-out / not proven,
+   partial output preserved — never a completed review.
 6. Capture the final response with `-o`, JSONL, or an output schema.
 7. Report the typed run result, then stop: the process exit status, the captured
-   artifact path, whether a timeout fired (and the process tree was reaped), and
-   whether the `codex` binary was even present. Cancellation is the caller's;
-   this skill neither retries nor continues on its own.
+   artifact path, which deadline applied and whether it fired, whether the
+   process tree was reaped (or the surviving-subprocess limitation), and whether
+   the `codex` binary was present at all. Cancellation is the caller's; this
+   skill neither retries nor continues on its own.
 
-Terminal outcomes are explicit: **binary absent** (no `codex` on PATH) →
-report unavailable and stop; **timed out** → report the kill and preserved
-partial output, never as a completed review; **nonzero exit** → runtime
+Terminal outcomes are explicit: **binary absent** (no `codex` on PATH) → report
+unavailable and stop; **deadline expiry** → fail-closed, report the kill and
+preserved partial output, never a completed review; **nonzero exit** → runtime
 evidence, not a semantic verdict. The caller decides whether to launch another
 invocation.
 
 ## Example
 
 ```bash
-printf '%s\n' "$PROMPT" | timeout "${CODEX_TIMEOUT:-600}" \
+# Deadline mandatory; default 600s. `setsid` puts codex in its own process
+# group; on expiry `--kill-after` escalates TERM->KILL to reap the tree, not
+# just the direct child. (If you cannot run setsid, disclose that a plain
+# `timeout` reaps only the direct child.)
+printf '%s\n' "$PROMPT" | setsid timeout --kill-after=10s "${CODEX_TIMEOUT:-600}" \
   codex exec -C "$WORKSPACE" -s read-only -o "$OUTPUT" -
 ```
 

--- a/images/gemini/skills/codex-exec/SKILL.md
+++ b/images/gemini/skills/codex-exec/SKILL.md
@@ -60,17 +60,18 @@ prompt runs read-only, full stop.
    caller's deadline, or the declared default of **600s (10 min)** when the
    caller supplies none, and record which one applied. Enforce it so the whole
    process **tree** is reaped, not just the direct child: run codex in its own
-   process group and kill the group on expiry (e.g. `setsid` + `kill -KILL
-   -<pgid>`), or `timeout --kill-after=10s <secs>` to escalate TERM→KILL. Plain
-   `timeout <secs> codex …` signals only the direct child, so if your wrapper
-   cannot guarantee process-group reaping, **disclose the surviving-subprocess
-   risk as a limitation** rather than claim cleanup. Deadline expiry is
+   process group and kill the group on expiry: `setsid` (own process group) +
+   `kill -KILL -<pgid>` on the group; `--kill-after` only escalates TERM→KILL
+   and plain `timeout <secs> codex …` signals only the direct child. If the
+   wrapper cannot guarantee process-group reaping, **do not execute** — that
+   host lacks the cleanup capability this skill requires (capability
+   unavailable, fail closed). Deadline expiry is
    **fail-closed**: the run is killed and reported as timed-out / not proven,
    partial output preserved — never a completed review.
 6. Capture the final response with `-o`, JSONL, or an output schema.
 7. Report the typed run result, then stop: the process exit status, the captured
-   artifact path, which deadline applied and whether it fired, whether the
-   process tree was reaped (or the surviving-subprocess limitation), and whether
+   artifact path, which deadline applied and whether it fired, that the
+   process tree was reaped (a run without guaranteed reaping never starts), and whether
    the `codex` binary was present at all. Cancellation is the caller's; this
    skill neither retries nor continues on its own.
 
@@ -84,9 +85,9 @@ invocation.
 
 ```bash
 # Deadline mandatory; default 600s. `setsid` puts codex in its own process
-# group; on expiry `--kill-after` escalates TERM->KILL to reap the tree, not
-# just the direct child. (If you cannot run setsid, disclose that a plain
-# `timeout` reaps only the direct child.)
+# group so expiry kills the whole tree, with `--kill-after` escalating
+# TERM->KILL. No setsid (or equivalent group kill) available -> do not run:
+# fail closed as capability-unavailable.
 printf '%s\n' "$PROMPT" | setsid timeout --kill-after=10s "${CODEX_TIMEOUT:-600}" \
   codex exec -C "$WORKSPACE" -s read-only -o "$OUTPUT" -
 ```

--- a/images/gemini/skills/ntm/SKILL.md
+++ b/images/gemini/skills/ntm/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 skill_api_version: 1
 hexagonal_role: supporting
 consumes:
-- task-intent
+- pane-command-request
 produces:
 - ntm-robot-state
 - agent-worker-transcript
@@ -13,7 +13,7 @@ context_rel:
   with: agent-native
 metadata:
   capabilities: [ntm]
-  effects: []
+  effects: [manage_ntm_panes, dispatch_pane_commands]
   canonical_status: canonical
   disposition: keep_optional_adapter
   tier: execution
@@ -92,8 +92,17 @@ Return:
 - degraded or unavailable substrate surfaces;
 - effects that were and were not observed.
 
-A timeout, nonzero exit, or degraded source is reported as evidence. The caller
-decides whether to invoke another experiment.
+Terminal outcomes are explicit, never a silent hang:
+
+- **NTM unavailable** — `ntm` absent or the robot surface unreachable: report it
+  and stop; do not fall back to blind key injection or assume the pane is idle.
+- **Observation-window deadline reached** — report the last observed robot state
+  and transcript reference; the window ending is a stop, not a failure verdict.
+- **Timeout / nonzero exit / degraded source** — reported as evidence with what
+  was and was not observed.
+- **Cancellation and cleanup** — the caller decides whether to invoke another
+  experiment; report which panes were created or left running so nothing is
+  orphaned silently. NTM never retries or reaps on its own.
 
 ## Useful live surfaces
 
@@ -103,4 +112,6 @@ caller explicitly requests an interactive action and no robot command provides
 the needed behavior.
 
 External NTM documentation and examples remain the authority for command syntax;
-this skill owns only the AgentOps boundary above.
+this skill owns only the AgentOps boundary above. NTM's CLI drifts across
+versions, so confirm the surface at runtime (`ntm --version`,
+`ntm --robot-capabilities`) rather than trusting a remembered command.

--- a/images/gemini/skills/rch/SKILL.md
+++ b/images/gemini/skills/rch/SKILL.md
@@ -9,7 +9,7 @@ context_rel: []
 metadata:
   dependencies: []
   capabilities: [rch]
-  effects: []
+  effects: [remote_compilation_offload, authorized_remote_daemon_worker_mutation]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
@@ -54,13 +54,28 @@ fails deterministically, not moodily.
 when the local build succeeds. Destructive cleanup, worker deployment, daemon
 configuration, and remote mutation require explicit caller authority.
 
+`rch check` exit status adjudicates readiness (0 = ready, nonzero = not
+offload-ready). Do not read `rch doctor --json` `success: true` as readiness — a
+successful diagnostic report can coexist with a down daemon or unreachable
+workers. Adjudicate on `rch check`; use `doctor` for the reasons behind it.
+
 ## Output
 
 Return a factual packet with status (`remote`, `local_fallback`, `failed`, or
 `not_proven`), commands and exit codes, worker, summary line, and checked/not
-checked surfaces. Do not include a next action.
+checked surfaces. Do not include a next action. `not_proven` here is a runtime
+diagnosis status, not an AgentOps verdict; it carries no verdict weight and never
+substitutes for a `verdict.v2`.
 
 ## References
+
+The SKILL.md authority boundary above governs every reference below. Where a
+reference lists a remediation, its read-only diagnostics run autonomously but its
+remote, privileged, or irreversible steps (remote/`sudo` mutation, daemon
+start/restart/reconfigure, worker or fleet deployment, toolchain sync,
+destructive cleanup) still require explicit caller authorization first. A
+reference never widens the autonomy the kernel grants.
+
 
 - [Fail-open reasons](references/FAIL_OPEN.md)
 - [Error catalog](references/ERROR_CODES.md)

--- a/images/gemini/skills/swarm/SKILL.md
+++ b/images/gemini/skills/swarm/SKILL.md
@@ -31,6 +31,14 @@ The caller supplies every complete packet, proves their write scopes disjoint,
 and chooses the executor. Swarm dispatches each packet once, preserves packet and
 context identities, collects results, and stops.
 
+Write scopes must be **workspace-relative and canonical** — symlink-resolved and
+already normalized. The disjointness check is lexical: it case-folds prefixes so
+scopes differing only by case are treated as a collision (safe on
+case-insensitive filesystems), but it cannot see a symlink that aliases two
+scopes onto one target. Supplying non-canonical or symlinked scopes forfeits the
+disjointness guarantee; a non-empty `write_scope.exclude` is rejected, not
+silently ignored, because the proof cannot honor it.
+
 Exactly-once dispatch over proven-disjoint scopes is why parallel failures stay
 independent: no packet can observe, block, or corrupt another, so N packets
 yield N verdicts about N experiments rather than one tangle.
@@ -47,6 +55,11 @@ The reference implementation is [`scripts/dispatch_once.py`](scripts/dispatch_on
 It validates the entire explicit batch before the first call, invokes the supplied
 executor exactly once for each packet, and returns executor exceptions as factual
 per-packet errors.
+
+Swarm's own effect is invoking the selected executor once per packet; the real
+blast radius rides on the packets. Each packet's transitive effects — whatever
+its executor writes, runs, or reaches — are the caller's to declare on the
+packet, not Swarm's to bound.
 
 Swarm does not select work, create packets, schedule from a backlog, persist a
 queue, claim ownership, retry, validate, integrate, close, use Git, or deliver.

--- a/images/gemini/skills/using-gc/SKILL.md
+++ b/images/gemini/skills/using-gc/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   tier: execution
   dependencies: []
   capabilities: [dispatch_explicit_packet, observe_gc_runtime, drive_mayor_shepherd]
-  effects: [operate_gas_city]
+  effects: [operate_gas_city, configure_codex_trust]
   canonical_status: canonical
   disposition: keep_optional_adapter
 output_contract: runtime evidence per supplied packet
@@ -75,12 +75,16 @@ wedged on an interactive prompt doing nothing. Trust ground truth:
 
 - `gc session list --json` / `mayor status` is the roster claim.
 - `tmux -L <socket> capture-pane -pt <session>` is ground truth — read the pane.
+  The `<socket>` and `<session>` here (and at every `tmux -L` site below) are the
+  ones `mayor status` prints in its `tmux -L <socket> attach -t <session>` line.
 - Two known codex wedge classes and their durable fixes:
   - **Update nag:** codex blocks on an "update available" prompt. Fix: update
     codex so no pending-update prompt exists before the run.
   - **Folder trust:** codex blocks asking to trust the working directory. Fix:
     add exact-path `trust_level` entries for the rig and worktree-root in
-    `~/.codex/config.toml` (bootstrap does not write them yet).
+    `~/.codex/config.toml` (bootstrap does not write them yet). This edits the
+    user's global codex config — a host-configuration mutation; make it only
+    with explicit caller authorization, scoped to those exact paths.
 
 When the roster says active but the pane is wedged, the pane wins.
 

--- a/images/gemini/skills/using-gc/SKILL.md
+++ b/images/gemini/skills/using-gc/SKILL.md
@@ -79,7 +79,9 @@ wedged on an interactive prompt doing nothing. Trust ground truth:
   ones `mayor status` prints in its `tmux -L <socket> attach -t <session>` line.
 - Two known codex wedge classes and their durable fixes:
   - **Update nag:** codex blocks on an "update available" prompt. Fix: update
-    codex so no pending-update prompt exists before the run.
+    codex so no pending-update prompt exists before the run. Updating the codex
+    binary is a host mutation — make it only with explicit caller authorization,
+    the same bar as the trust-config edit below.
   - **Folder trust:** codex blocks asking to trust the working directory. Fix:
     add exact-path `trust_level` entries for the rig and worktree-root in
     `~/.codex/config.toml` (bootstrap does not write them yet). This edits the

--- a/packs/agentops-executor/assets/generated-skill-manifest.json
+++ b/packs/agentops-executor/assets/generated-skill-manifest.json
@@ -90,8 +90,8 @@
     {
       "source": "skills/using-gc/SKILL.md",
       "destination": "packs/agentops-executor/skills/using-gc/SKILL.md",
-      "source_sha256": "fdc43cd8c2645fcbf6a1e5348a5fe9aa2da0ded8cfdfbc4775566e2d684fcaf2",
-      "sha256": "fdc43cd8c2645fcbf6a1e5348a5fe9aa2da0ded8cfdfbc4775566e2d684fcaf2",
+      "source_sha256": "e6fbc6df7274b4c5d28176c516321f720751a8be694b827fbe44c398786a367f",
+      "sha256": "e6fbc6df7274b4c5d28176c516321f720751a8be694b827fbe44c398786a367f",
       "mode": "0644"
     }
   ]

--- a/packs/agentops-executor/assets/generated-skill-manifest.json
+++ b/packs/agentops-executor/assets/generated-skill-manifest.json
@@ -90,8 +90,8 @@
     {
       "source": "skills/using-gc/SKILL.md",
       "destination": "packs/agentops-executor/skills/using-gc/SKILL.md",
-      "source_sha256": "7c621b5284402881c99f576fa12ccb79debbae565364029ed3b66cd0cdf9f607",
-      "sha256": "7c621b5284402881c99f576fa12ccb79debbae565364029ed3b66cd0cdf9f607",
+      "source_sha256": "fdc43cd8c2645fcbf6a1e5348a5fe9aa2da0ded8cfdfbc4775566e2d684fcaf2",
+      "sha256": "fdc43cd8c2645fcbf6a1e5348a5fe9aa2da0ded8cfdfbc4775566e2d684fcaf2",
       "mode": "0644"
     }
   ]

--- a/packs/agentops-executor/skills/using-gc/SKILL.md
+++ b/packs/agentops-executor/skills/using-gc/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   tier: execution
   dependencies: []
   capabilities: [dispatch_explicit_packet, observe_gc_runtime, drive_mayor_shepherd]
-  effects: [operate_gas_city]
+  effects: [operate_gas_city, configure_codex_trust]
   canonical_status: canonical
   disposition: keep_optional_adapter
 output_contract: runtime evidence per supplied packet
@@ -75,12 +75,16 @@ wedged on an interactive prompt doing nothing. Trust ground truth:
 
 - `gc session list --json` / `mayor status` is the roster claim.
 - `tmux -L <socket> capture-pane -pt <session>` is ground truth — read the pane.
+  The `<socket>` and `<session>` here (and at every `tmux -L` site below) are the
+  ones `mayor status` prints in its `tmux -L <socket> attach -t <session>` line.
 - Two known codex wedge classes and their durable fixes:
   - **Update nag:** codex blocks on an "update available" prompt. Fix: update
     codex so no pending-update prompt exists before the run.
   - **Folder trust:** codex blocks asking to trust the working directory. Fix:
     add exact-path `trust_level` entries for the rig and worktree-root in
-    `~/.codex/config.toml` (bootstrap does not write them yet).
+    `~/.codex/config.toml` (bootstrap does not write them yet). This edits the
+    user's global codex config — a host-configuration mutation; make it only
+    with explicit caller authorization, scoped to those exact paths.
 
 When the roster says active but the pane is wedged, the pane wins.
 

--- a/packs/agentops-executor/skills/using-gc/SKILL.md
+++ b/packs/agentops-executor/skills/using-gc/SKILL.md
@@ -79,7 +79,9 @@ wedged on an interactive prompt doing nothing. Trust ground truth:
   ones `mayor status` prints in its `tmux -L <socket> attach -t <session>` line.
 - Two known codex wedge classes and their durable fixes:
   - **Update nag:** codex blocks on an "update available" prompt. Fix: update
-    codex so no pending-update prompt exists before the run.
+    codex so no pending-update prompt exists before the run. Updating the codex
+    binary is a host mutation — make it only with explicit caller authorization,
+    the same bar as the trust-config edit below.
   - **Folder trust:** codex blocks asking to trust the working directory. Fix:
     add exact-path `trust_level` entries for the rig and worktree-root in
     `~/.codex/config.toml` (bootstrap does not write them yet). This edits the

--- a/registry.json
+++ b/registry.json
@@ -632,7 +632,11 @@
           "agent_mail"
         ],
         "disposition": "keep_optional_adapter",
-        "effects": [],
+        "effects": [
+          "write_agent_mail_records",
+          "install_precommit_guard",
+          "authorized_destructive_reset"
+        ],
         "has_references": true,
         "has_skill_md": true,
         "name": "agent-mail",
@@ -749,7 +753,10 @@
           "codex_exec"
         ],
         "disposition": "keep_optional_adapter",
-        "effects": [],
+        "effects": [
+          "run_codex_process",
+          "sandbox_tiered_workspace_and_network_effects"
+        ],
         "has_references": false,
         "has_skill_md": true,
         "name": "codex-exec",
@@ -938,7 +945,10 @@
           "ntm"
         ],
         "disposition": "keep_optional_adapter",
-        "effects": [],
+        "effects": [
+          "manage_ntm_panes",
+          "dispatch_pane_commands"
+        ],
         "has_references": false,
         "has_skill_md": true,
         "name": "ntm",
@@ -1044,7 +1054,10 @@
           "rch"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "remote_compilation_offload",
+          "authorized_remote_daemon_worker_mutation"
+        ],
         "has_references": true,
         "has_skill_md": true,
         "name": "rch",
@@ -1299,7 +1312,8 @@
         ],
         "disposition": "keep_optional_adapter",
         "effects": [
-          "operate_gas_city"
+          "operate_gas_city",
+          "configure_codex_trust"
         ],
         "has_references": false,
         "has_skill_md": true,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -387,8 +387,8 @@
     {
       "name": "codex-exec",
       "source_skill": "skills/codex-exec",
-      "source_hash": "3e67f02d3992ba28bb9d42f2a7ab0f52fc3db35a160e32938cc2ebf1e65d657f",
-      "generated_hash": "5f8f15b870dea813b49ef0eb4a29382f5918c8bd5e55e5a8ad98513fb31695e1"
+      "source_hash": "3dc9df272422263ebf9f9ce620a542a3db8c73704fe1862aae5873531c6d8138",
+      "generated_hash": "3e72020f6df165ca2cf4bf6a89350ea61509b1e88aea5fa6599728c3219e80a3"
     },
     {
       "name": "converter",
@@ -507,8 +507,8 @@
     {
       "name": "rch",
       "source_skill": "skills/rch",
-      "source_hash": "6e7d47c4d1e44bcfb761fd05edaedececcde552519912581891a34609fdda798",
-      "generated_hash": "5e25c8e835b99f4370009f4e2940201db8e8765bd6136e13625a2a3de6a38e78"
+      "source_hash": "5a4e3a005eb6f62ebdb1d1dde6e521945dd7d09048462259728cca286fe9db3c",
+      "generated_hash": "bfa4cab644948545f43f51c6eccb9aba660fbd7f7d920789656287960e93b345"
     },
     {
       "name": "reality-check",
@@ -609,8 +609,8 @@
     {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
-      "source_hash": "f51ea2cdeb1bec02b84045767a9ff6b095bc45918b28c77e3342de8f1f384783",
-      "generated_hash": "0f2dbc05aecde36e4ed390beb9d65e7c75c2ac70fb4fb70870d00ad7eca6c67d"
+      "source_hash": "9157f6ec6c0c6b75fd91dff9e0c09645aff069d545b89c3b0c887745c4d7c8c2",
+      "generated_hash": "80f9faaf4f4fcb38b6b46d5d9a54e594a14d25624a061057d05be493f275b75a"
     },
     {
       "name": "validate",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -339,20 +339,20 @@
     {
       "name": "agent-mail",
       "source_skill": "skills/agent-mail",
-      "source_hash": "2eda6493d5fd3a918b4e844f31cb72bdee10f4887b23bda3132f74cdfbdbf29b",
-      "generated_hash": "5d427d2d180a2d5db10fea1bdc98f79adf11c5a827dfb6c3ce26cdd0819d66af"
+      "source_hash": "e51201a4f1a236b0616eb678c8ba119ba03987e4398a66e44db8fc4b2712967f",
+      "generated_hash": "24fc6a89c6c0b07a215bde6b60ce9daf339732617b128b379b04b18d385c0954"
     },
     {
       "name": "agent-native",
       "source_skill": "skills/agent-native",
-      "source_hash": "281f66ca51b712cadbc4630f7809c57a721e49838243a5d4346638038305a58d",
-      "generated_hash": "b6d6685acb03edc9bf703b33d9c2185ef3b3c905af55328f2325f5f7be871563"
+      "source_hash": "45bf50ee5a52ff30fe94688add8df74f4a1c631d424f903c621504d135aca709",
+      "generated_hash": "50a5422973e9f9de810bb840d5931a33c8619dec421f65c8d92837529c99ad7e"
     },
     {
       "name": "agy-native",
       "source_skill": "skills/agy-native",
-      "source_hash": "88c8779c7665b8810000b35dbd41892b9dd2fd2a541adce1c24847234fd82fe9",
-      "generated_hash": "4d4527f31f2256f4dcb6b0c9b78dd956a732317fab954592a167cb2a38a426c3"
+      "source_hash": "e1506ab3711bd362b032624f0a11f5cbbd9372da101f86195f42a6d375bb6430",
+      "generated_hash": "cd08d16a52d7f9d5bc7d19c3a70e449982ee32c560487761b6af8ddfe4ded2fe"
     },
     {
       "name": "automation-shape-routing",
@@ -387,8 +387,8 @@
     {
       "name": "codex-exec",
       "source_skill": "skills/codex-exec",
-      "source_hash": "c82ac6972a5ce30065a13824ddf84b5fe9d650bae1a77344ad89cd670249c887",
-      "generated_hash": "2bbf08f7bd34bcf865fe35d8832c15b3acfa4aa3b57bc86724329ad481ca8f4d"
+      "source_hash": "3e67f02d3992ba28bb9d42f2a7ab0f52fc3db35a160e32938cc2ebf1e65d657f",
+      "generated_hash": "5f8f15b870dea813b49ef0eb4a29382f5918c8bd5e55e5a8ad98513fb31695e1"
     },
     {
       "name": "converter",
@@ -465,8 +465,8 @@
     {
       "name": "ntm",
       "source_skill": "skills/ntm",
-      "source_hash": "64bbab4341caf4f10671acb761b865c2bab35095f3818d782e93862b9e423866",
-      "generated_hash": "6cd15025d6ca0c1ffdf7062a4d2f698545bf204cecac3cc9b43dae28d2b9ac2f"
+      "source_hash": "00030ed2957cf39b7f97bccc5fe3be7a93948571ff0815d90f2c57cf0f435661",
+      "generated_hash": "9d7052b83a5a1276bcc6d581e98d58986eadda314fc860923ae3c56d4badec0f"
     },
     {
       "name": "operationalize",
@@ -507,8 +507,8 @@
     {
       "name": "rch",
       "source_skill": "skills/rch",
-      "source_hash": "b1181403f349967821fadf1daa1140035707b2f88f9602dc53fe0ef0519b37f0",
-      "generated_hash": "b57b475bfada95fcfe66665ab45dd977d74d58e36179856c054fd40a90b8ecec"
+      "source_hash": "6e7d47c4d1e44bcfb761fd05edaedececcde552519912581891a34609fdda798",
+      "generated_hash": "5e25c8e835b99f4370009f4e2940201db8e8765bd6136e13625a2a3de6a38e78"
     },
     {
       "name": "reality-check",
@@ -591,8 +591,8 @@
     {
       "name": "swarm",
       "source_skill": "skills/swarm",
-      "source_hash": "460a78219f0470cfc5423298dd3b3e4bc1a5a6704866564838a79aafb69cb231",
-      "generated_hash": "1a3ffdc203fea5bad5e70b13a06992f3c033c57f28dbab9cae26c963d8088c39"
+      "source_hash": "e8ddab659c2ad4500bb2d2fd996b7e741199cba2ee602cc605fbb983216c5441",
+      "generated_hash": "6320a426d70b27346b32f599445ac8e986d3f68847614fe59537b0a313012705"
     },
     {
       "name": "test",
@@ -609,8 +609,8 @@
     {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
-      "source_hash": "0cb0e528e918fda28e1bb45b599f47013db377d7793c761eae7e6ff26750872d",
-      "generated_hash": "aca67da82384024023ff901b57ef7baebad71097dc152638c65afa52861222e9"
+      "source_hash": "f51ea2cdeb1bec02b84045767a9ff6b095bc45918b28c77e3342de8f1f384783",
+      "generated_hash": "0f2dbc05aecde36e4ed390beb9d65e7c75c2ac70fb4fb70870d00ad7eca6c67d"
     },
     {
       "name": "validate",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -387,8 +387,8 @@
     {
       "name": "codex-exec",
       "source_skill": "skills/codex-exec",
-      "source_hash": "3dc9df272422263ebf9f9ce620a542a3db8c73704fe1862aae5873531c6d8138",
-      "generated_hash": "3e72020f6df165ca2cf4bf6a89350ea61509b1e88aea5fa6599728c3219e80a3"
+      "source_hash": "db1eda768d56f20bd92d333b3e45124a5afbbf3a5653b8b9d39bb285edeefc89",
+      "generated_hash": "75df66a57666eea344dac4254cc5926054bab8677aabfdb9ead003db58370181"
     },
     {
       "name": "converter",
@@ -507,8 +507,8 @@
     {
       "name": "rch",
       "source_skill": "skills/rch",
-      "source_hash": "5a4e3a005eb6f62ebdb1d1dde6e521945dd7d09048462259728cca286fe9db3c",
-      "generated_hash": "bfa4cab644948545f43f51c6eccb9aba660fbd7f7d920789656287960e93b345"
+      "source_hash": "3af677e66c6a1ed663e733461d9153922b7dd6123bc011fbae9bc831a2d3c2c1",
+      "generated_hash": "bb6606aa0c44726a8f67021fbe6bdf767ca31773e57fc274201f7ae32f51b42a"
     },
     {
       "name": "reality-check",

--- a/skills-codex/agent-mail/.agentops-generated.json
+++ b/skills-codex/agent-mail/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/agent-mail",
   "layout": "modular",
-  "source_hash": "2eda6493d5fd3a918b4e844f31cb72bdee10f4887b23bda3132f74cdfbdbf29b",
-  "generated_hash": "5d427d2d180a2d5db10fea1bdc98f79adf11c5a827dfb6c3ce26cdd0819d66af"
+  "source_hash": "e51201a4f1a236b0616eb678c8ba119ba03987e4398a66e44db8fc4b2712967f",
+  "generated_hash": "24fc6a89c6c0b07a215bde6b60ce9daf339732617b128b379b04b18d385c0954"
 }

--- a/skills-codex/agent-mail/SKILL.md
+++ b/skills-codex/agent-mail/SKILL.md
@@ -8,9 +8,10 @@ Agent Mail carries messages, acknowledgements, identities, and temporary file
 reservations. It is not a task tracker, queue, proof ledger, or lifecycle
 controller.
 
-Reservations prevent collisions only because every cooperating writer checks
-them against the same absolute project path; one writer registered against a
-different path resolution makes the whole ledger advisory fiction.
+Reservations are **advisory**: they prevent collisions only because every
+cooperating writer checks them against the same absolute project path, and one
+writer registered against a different path resolution makes the whole ledger
+advisory fiction. Agent Mail enforces nothing on a writer that does not check.
 
 Named failure mode — **silence-as-status**: reading an unanswered thread as
 "work stalled" or "work done"; mail silence proves only that no mail arrived.
@@ -29,8 +30,27 @@ changes are the caller's call.
 - Mail silence proves nothing about work status.
 - A message or acknowledgement is evidence that communication occurred, not
   evidence that a change is correct or complete.
+- Release a reservation, including any `force_release`, only on the caller's
+  explicit request for that exact reservation. Force-release has no autonomous
+  trigger; a conflict is reported, not force-cleared.
 - Agent Mail never selects work, changes tracker state, commits code, validates,
   integrates, closes, releases, or delivers work.
+
+## Modes and authority
+
+Two disjoint surfaces; do not reach the second from the first:
+
+- **Coordination mode (default).** Register identity, reserve/release the
+  caller's paths, send/read/acknowledge the caller's threads. This is the whole
+  of routine use, and all of it writes durable Agent Mail records.
+- **Admin / disaster-recovery mode (explicitly caller-authorized only).**
+  Installing the git pre-commit guard, `doctor repair`, backup/restore, and the
+  irreversible `clear-and-reset-everything` are a separate mode. Each requires
+  the caller's explicit authorization for that specific operation; none is ever
+  performed as a side effect of coordination. `clear-and-reset-everything`
+  deletes the database and all storage and cannot be undone — never run it, even
+  with `--force`, without an explicit destructive-reset authorization from the
+  caller.
 
 ## Surfaces
 
@@ -51,9 +71,21 @@ from remembered aliases.
 
 ## Output
 
-Return the project, identity, thread/message ids, reservation ids and paths,
-conflicts, timestamps, and any degraded or unavailable surface. The caller owns
-all subsequent decisions.
+Return the project, identity, thread/message ids, reservation ids and paths
+(with their TTLs), conflicts, and timestamps. The caller owns all subsequent
+decisions.
+
+Terminal outcomes are explicit, never silent:
+
+- **Adapter unavailable** — neither the MCP tools nor the `am` CLI is present:
+  report that Agent Mail is unavailable and stop. Do not fall back to
+  hand-written coordination or treat the absence as "no conflicts".
+- **Reservation conflict** — report the conflicting reservation as-is; do not
+  narrow, widen, renew, or force-release it.
+- **Timeout / degraded surface** — report the operation as timed out or degraded
+  with what was and was not observed; a timeout is evidence, not "done".
+- **Cleanup** — reservations released this session are listed by id; any left
+  in place (still holding a TTL) are named so the caller can see what remains.
 
 ## References
 

--- a/skills-codex/agent-mail/references/RECOVERY.md
+++ b/skills-codex/agent-mail/references/RECOVERY.md
@@ -20,16 +20,16 @@ curl http://127.0.0.1:8765/health   # only if the HTTP MCP server is running (am
 
 ```bash
 # Basic check
-uv run python -m mcp_agent_mail.cli doctor check
+am doctor check
 
 # Verbose with details
-uv run python -m mcp_agent_mail.cli doctor check --verbose
+am doctor check --verbose
 
 # JSON output for automation
-uv run python -m mcp_agent_mail.cli doctor check --json
+am doctor check --json
 
 # Check specific project
-uv run python -m mcp_agent_mail.cli doctor check /abs/path/project
+am doctor check /abs/path/project
 ```
 
 **Checks performed:**
@@ -42,7 +42,7 @@ uv run python -m mcp_agent_mail.cli doctor check /abs/path/project
 ### Preview Repairs (Dry Run)
 
 ```bash
-uv run python -m mcp_agent_mail.cli doctor repair --dry-run
+am doctor repair --dry-run
 ```
 
 Shows what would be fixed without making changes.
@@ -51,13 +51,13 @@ Shows what would be fixed without making changes.
 
 ```bash
 # Interactive (prompts for confirmation)
-uv run python -m mcp_agent_mail.cli doctor repair
+am doctor repair
 
 # Auto-confirm (creates backup first)
-uv run python -m mcp_agent_mail.cli doctor repair --yes
+am doctor repair --yes
 
 # With custom backup directory
-uv run python -m mcp_agent_mail.cli doctor repair --yes --backup-dir /tmp/backups
+am doctor repair --yes --backup-dir /tmp/backups
 ```
 
 ---
@@ -68,29 +68,29 @@ uv run python -m mcp_agent_mail.cli doctor repair --yes --backup-dir /tmp/backup
 
 ```bash
 # With label
-uv run python -m mcp_agent_mail.cli archive save --label nightly
+am archive save --label nightly
 
 # Default label (timestamp)
-uv run python -m mcp_agent_mail.cli archive save
+am archive save
 ```
 
 ### List Backups
 
 ```bash
-uv run python -m mcp_agent_mail.cli doctor backups
+am doctor backups
 
 # JSON format
-uv run python -m mcp_agent_mail.cli doctor backups --json
+am doctor backups --json
 ```
 
 ### Restore from Backup
 
 ```bash
 # Preview what would be restored
-uv run python -m mcp_agent_mail.cli doctor restore /path/to/backup.zip --dry-run
+am doctor restore /path/to/backup.zip --dry-run
 
 # Perform restore
-uv run python -m mcp_agent_mail.cli doctor restore /path/to/backup.zip --yes
+am doctor restore /path/to/backup.zip --yes
 ```
 
 ---
@@ -102,7 +102,7 @@ Export mailbox for auditors, stakeholders, or archives.
 ### Interactive Wizard (Recommended)
 
 ```bash
-uv run python -m mcp_agent_mail.cli share wizard
+am share wizard
 ```
 
 Guides you through export options, signing, encryption, and deployment.
@@ -111,20 +111,20 @@ Guides you through export options, signing, encryption, and deployment.
 
 ```bash
 # Basic export
-uv run python -m mcp_agent_mail.cli share export --output ./bundle
+am share export --output ./bundle
 
 # With cryptographic signing
-uv run python -m mcp_agent_mail.cli share export \
+am share export \
   --output ./bundle \
   --signing-key ./keys/signing.key
 
 # With age encryption
-uv run python -m mcp_agent_mail.cli share export \
+am share export \
   --output ./bundle \
   --age-recipient age1abc...xyz
 
 # Scrub sensitive content
-uv run python -m mcp_agent_mail.cli share export \
+am share export \
   --output ./bundle \
   --scrub-preset strict  # or 'standard'
 ```
@@ -132,42 +132,49 @@ uv run python -m mcp_agent_mail.cli share export \
 ### Preview Exported Bundle
 
 ```bash
-uv run python -m mcp_agent_mail.cli share preview ./bundle --port 9000 --open-browser
+am share preview ./bundle --port 9000 --open-browser
 ```
 
 ### Verify Bundle Integrity
 
 ```bash
-uv run python -m mcp_agent_mail.cli share verify ./bundle
+am share verify ./bundle
 ```
 
 ### Refresh Existing Bundle
 
 ```bash
-uv run python -m mcp_agent_mail.cli share update ./bundle
+am share update ./bundle
 ```
 
 ### Decrypt Age-Encrypted Bundle
 
 ```bash
-uv run python -m mcp_agent_mail.cli share decrypt bundle.zip.age --identity ~/.age/key.txt
+am share decrypt bundle.zip.age --identity ~/.age/key.txt
 ```
 
 ---
 
-## Dangerous Operations
+## Dangerous Operations (admin/DR mode — explicit caller authorization required)
 
-### Full Reset (Destructive!)
+These are the admin/disaster-recovery surface, not coordination. Each needs the
+caller's explicit authorization for that specific operation; none runs as a side
+effect of coordination. `doctor repair`, backup/restore, and especially the full
+reset below cross from advisory into destructive.
+
+### Full Reset (Destructive, irreversible!)
 
 ```bash
-# Prompts for archive first
-uv run python -m mcp_agent_mail.cli clear-and-reset-everything
+# Prompts for archive first — run only with explicit destructive-reset authorization
+am clear-and-reset-everything
 
-# Skip prompts (automation)
-uv run python -m mcp_agent_mail.cli clear-and-reset-everything --force --no-archive
+# Skips prompts — NEVER run without an explicit destructive-reset authorization
+am clear-and-reset-everything --force --no-archive
 ```
 
-**WARNING:** Deletes SQLite database and all storage contents.
+**WARNING:** Deletes the SQLite database and all storage contents and cannot be
+undone. `--force --no-archive` also skips the safety archive. Do not run either
+form on your own initiative; report the situation and let the caller authorize.
 
 ---
 
@@ -177,20 +184,20 @@ uv run python -m mcp_agent_mail.cli clear-and-reset-everything --force --no-arch
 
 ```bash
 # All reservations
-uv run python -m mcp_agent_mail.cli file_reservations list /abs/path/project
+am file_reservations list /abs/path/project
 
 # Active only
-uv run python -m mcp_agent_mail.cli file_reservations list /abs/path/project --active-only
+am file_reservations list /abs/path/project --active-only
 
 # Active with limit
-uv run python -m mcp_agent_mail.cli file_reservations active /abs/path/project --limit 10
+am file_reservations active /abs/path/project --limit 10
 ```
 
 ### Expiring Soon
 
 ```bash
 # Reservations expiring within 30 minutes
-uv run python -m mcp_agent_mail.cli file_reservations soon /abs/path/project --minutes 30
+am file_reservations soon /abs/path/project --minutes 30
 ```
 
 ---
@@ -200,19 +207,19 @@ uv run python -m mcp_agent_mail.cli file_reservations soon /abs/path/project --m
 ### Pending Acknowledgments
 
 ```bash
-uv run python -m mcp_agent_mail.cli acks pending /abs/path/project GreenCastle --limit 10
+am acks pending /abs/path/project GreenCastle --limit 10
 ```
 
 ### Overdue ACKs
 
 ```bash
-uv run python -m mcp_agent_mail.cli acks overdue /abs/path/project GreenCastle --ttl-minutes 60
+am acks overdue /abs/path/project GreenCastle --ttl-minutes 60
 ```
 
 ### Remind About Old ACKs
 
 ```bash
-uv run python -m mcp_agent_mail.cli acks remind /abs/path/project GreenCastle --min-age-minutes 30
+am acks remind /abs/path/project GreenCastle --min-age-minutes 30
 ```
 
 ---

--- a/skills-codex/agent-native/.agentops-generated.json
+++ b/skills-codex/agent-native/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/agent-native",
   "layout": "modular",
-  "source_hash": "281f66ca51b712cadbc4630f7809c57a721e49838243a5d4346638038305a58d",
-  "generated_hash": "b6d6685acb03edc9bf703b33d9c2185ef3b3c905af55328f2325f5f7be871563"
+  "source_hash": "45bf50ee5a52ff30fe94688add8df74f4a1c631d424f903c621504d135aca709",
+  "generated_hash": "50a5422973e9f9de810bb840d5931a33c8619dec421f65c8d92837529c99ad7e"
 }

--- a/skills-codex/agent-native/scripts/fake_model_runner.py
+++ b/skills-codex/agent-native/scripts/fake_model_runner.py
@@ -10,12 +10,20 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
 
 def utc_now() -> str:
+    # Honor SOURCE_DATE_EPOCH so fixture output is reproducible; fall back to
+    # wall-clock only when it is unset.
+    epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if epoch:
+        return datetime.fromtimestamp(int(epoch), tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
@@ -156,6 +164,14 @@ def duel(args: argparse.Namespace) -> int:
 
 
 def validate_cross(args: argparse.Namespace) -> int:
+    # A shared context id forfeits the fresh-judgment guarantee the attestation
+    # is supposed to certify — reject it before emitting anything.
+    if args.author_context_id == args.validator_context_id:
+        print(
+            "validate-cross requires distinct author/validator context ids",
+            file=sys.stderr,
+        )
+        return 2
     author_model = args.author_model
     validator_model = args.validator_model
     available = {p.strip() for p in (args.available or "").split(",") if p.strip()}

--- a/skills-codex/agy-native/.agentops-generated.json
+++ b/skills-codex/agy-native/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/agy-native",
   "layout": "modular",
-  "source_hash": "88c8779c7665b8810000b35dbd41892b9dd2fd2a541adce1c24847234fd82fe9",
-  "generated_hash": "4d4527f31f2256f4dcb6b0c9b78dd956a732317fab954592a167cb2a38a426c3"
+  "source_hash": "e1506ab3711bd362b032624f0a11f5cbbd9372da101f86195f42a6d375bb6430",
+  "generated_hash": "cd08d16a52d7f9d5bc7d19c3a70e449982ee32c560487761b6af8ddfe4ded2fe"
 }

--- a/skills-codex/agy-native/SKILL.md
+++ b/skills-codex/agy-native/SKILL.md
@@ -5,12 +5,34 @@ description: Use an explicitly selected AGY runtime for
 # AGY Native
 
 Use AGY only when the caller explicitly selects that runtime. Discover its live
-command surface before acting and scope every session to the supplied workspace
-and packet.
+command surface with `agy --help` (and `agy models` for the current model set)
+before acting, and scope every session to the supplied workspace and packet.
 
 Discovering the live command surface before acting works because AGY's CLI
 changes faster than any skill text: a remembered flag is a guess, while a
 freshly listed one is evidence.
+
+## Permission posture (disclose it; never assume it)
+
+The posture a run gets is chosen by flags, so name it explicitly:
+
+- Default `agy` runs interactively and prompts for each tool permission.
+- `--dangerously-skip-permissions` auto-approves every tool call — use it only
+  when the packet's declared effects and the caller's authorization cover that
+  blast radius.
+- `--sandbox` restricts the session's terminal access.
+- Print mode (`agy -p` / `--print`) is the sanctioned headless path and carries
+  a built-in `--print-timeout` (default 5m); a run that exceeds it is killed and
+  reported as timed out, not as a result.
+
+A reader who sets none of these gets AGY's interactive default, not a scoped
+run. Match the posture to the declared effects and disclose which one was used.
+
+## When AGY is unavailable
+
+If `agy` is not installed or its command surface cannot be discovered, report the
+absence as a disclosed fact and stop. Do not fall back to another runtime, do not
+guess a command surface, and never route through `claude -p`.
 
 Named failure mode — **wrapper drift**: invoking AGY through remembered
 syntax that silently changed, producing runs that look scoped but are not.

--- a/skills-codex/codex-exec/.agentops-generated.json
+++ b/skills-codex/codex-exec/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/codex-exec",
   "layout": "modular",
-  "source_hash": "3dc9df272422263ebf9f9ce620a542a3db8c73704fe1862aae5873531c6d8138",
-  "generated_hash": "3e72020f6df165ca2cf4bf6a89350ea61509b1e88aea5fa6599728c3219e80a3"
+  "source_hash": "db1eda768d56f20bd92d333b3e45124a5afbbf3a5653b8b9d39bb285edeefc89",
+  "generated_hash": "75df66a57666eea344dac4254cc5926054bab8677aabfdb9ead003db58370181"
 }

--- a/skills-codex/codex-exec/.agentops-generated.json
+++ b/skills-codex/codex-exec/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/codex-exec",
   "layout": "modular",
-  "source_hash": "3e67f02d3992ba28bb9d42f2a7ab0f52fc3db35a160e32938cc2ebf1e65d657f",
-  "generated_hash": "5f8f15b870dea813b49ef0eb4a29382f5918c8bd5e55e5a8ad98513fb31695e1"
+  "source_hash": "3dc9df272422263ebf9f9ce620a542a3db8c73704fe1862aae5873531c6d8138",
+  "generated_hash": "3e72020f6df165ca2cf4bf6a89350ea61509b1e88aea5fa6599728c3219e80a3"
 }

--- a/skills-codex/codex-exec/.agentops-generated.json
+++ b/skills-codex/codex-exec/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/codex-exec",
   "layout": "modular",
-  "source_hash": "c82ac6972a5ce30065a13824ddf84b5fe9d650bae1a77344ad89cd670249c887",
-  "generated_hash": "2bbf08f7bd34bcf865fe35d8832c15b3acfa4aa3b57bc86724329ad481ca8f4d"
+  "source_hash": "3e67f02d3992ba28bb9d42f2a7ab0f52fc3db35a160e32938cc2ebf1e65d657f",
+  "generated_hash": "5f8f15b870dea813b49ef0eb4a29382f5918c8bd5e55e5a8ad98513fb31695e1"
 }

--- a/skills-codex/codex-exec/SKILL.md
+++ b/skills-codex/codex-exec/SKILL.md
@@ -27,17 +27,28 @@ prompt runs read-only, full stop.
    explicitly requires network or external effects.
 4. Pipe the prompt to stdin (or close stdin) in non-TTY execution so the process
    cannot wait indefinitely for input.
-5. Capture the final response with `-o`, JSONL, or an output schema.
-6. Report the process exit status and captured artifact, then stop.
+5. Bound the run with an explicit wall-clock timeout (wrap with `timeout`
+   /`gtimeout`, or use the profile's own deadline). If no timeout mechanism is
+   available, disclose that the run is unbounded rather than let it hang
+   silently, and treat a killed run as a distinct terminal outcome — not a
+   review result.
+6. Capture the final response with `-o`, JSONL, or an output schema.
+7. Report the typed run result, then stop: the process exit status, the captured
+   artifact path, whether a timeout fired (and the process tree was reaped), and
+   whether the `codex` binary was even present. Cancellation is the caller's;
+   this skill neither retries nor continues on its own.
 
-A nonzero process exit is runtime evidence, not a semantic verdict. The caller
-decides whether to launch another invocation.
+Terminal outcomes are explicit: **binary absent** (no `codex` on PATH) →
+report unavailable and stop; **timed out** → report the kill and preserved
+partial output, never as a completed review; **nonzero exit** → runtime
+evidence, not a semantic verdict. The caller decides whether to launch another
+invocation.
 
 ## Example
 
 ```bash
-printf '%s\n' "$PROMPT" | codex exec -C "$WORKSPACE" -s read-only \
-  -o "$OUTPUT" -
+printf '%s\n' "$PROMPT" | timeout "${CODEX_TIMEOUT:-600}" \
+  codex exec -C "$WORKSPACE" -s read-only -o "$OUTPUT" -
 ```
 
 For a validator, the prompt must name the acceptance digest, exact subject

--- a/skills-codex/codex-exec/SKILL.md
+++ b/skills-codex/codex-exec/SKILL.md
@@ -31,17 +31,18 @@ prompt runs read-only, full stop.
    caller's deadline, or the declared default of **600s (10 min)** when the
    caller supplies none, and record which one applied. Enforce it so the whole
    process **tree** is reaped, not just the direct child: run codex in its own
-   process group and kill the group on expiry (e.g. `setsid` + `kill -KILL
-   -<pgid>`), or `timeout --kill-after=10s <secs>` to escalate TERM→KILL. Plain
-   `timeout <secs> codex …` signals only the direct child, so if your wrapper
-   cannot guarantee process-group reaping, **disclose the surviving-subprocess
-   risk as a limitation** rather than claim cleanup. Deadline expiry is
+   process group and kill the group on expiry: `setsid` (own process group) +
+   `kill -KILL -<pgid>` on the group; `--kill-after` only escalates TERM→KILL
+   and plain `timeout <secs> codex …` signals only the direct child. If the
+   wrapper cannot guarantee process-group reaping, **do not execute** — that
+   host lacks the cleanup capability this skill requires (capability
+   unavailable, fail closed). Deadline expiry is
    **fail-closed**: the run is killed and reported as timed-out / not proven,
    partial output preserved — never a completed review.
 6. Capture the final response with `-o`, JSONL, or an output schema.
 7. Report the typed run result, then stop: the process exit status, the captured
-   artifact path, which deadline applied and whether it fired, whether the
-   process tree was reaped (or the surviving-subprocess limitation), and whether
+   artifact path, which deadline applied and whether it fired, that the
+   process tree was reaped (a run without guaranteed reaping never starts), and whether
    the `codex` binary was present at all. Cancellation is the caller's; this
    skill neither retries nor continues on its own.
 
@@ -55,9 +56,9 @@ invocation.
 
 ```bash
 # Deadline mandatory; default 600s. `setsid` puts codex in its own process
-# group; on expiry `--kill-after` escalates TERM->KILL to reap the tree, not
-# just the direct child. (If you cannot run setsid, disclose that a plain
-# `timeout` reaps only the direct child.)
+# group so expiry kills the whole tree, with `--kill-after` escalating
+# TERM->KILL. No setsid (or equivalent group kill) available -> do not run:
+# fail closed as capability-unavailable.
 printf '%s\n' "$PROMPT" | setsid timeout --kill-after=10s "${CODEX_TIMEOUT:-600}" \
   codex exec -C "$WORKSPACE" -s read-only -o "$OUTPUT" -
 ```

--- a/skills-codex/codex-exec/SKILL.md
+++ b/skills-codex/codex-exec/SKILL.md
@@ -27,27 +27,38 @@ prompt runs read-only, full stop.
    explicitly requires network or external effects.
 4. Pipe the prompt to stdin (or close stdin) in non-TTY execution so the process
    cannot wait indefinitely for input.
-5. Bound the run with an explicit wall-clock timeout (wrap with `timeout`
-   /`gtimeout`, or use the profile's own deadline). If no timeout mechanism is
-   available, disclose that the run is unbounded rather than let it hang
-   silently, and treat a killed run as a distinct terminal outcome — not a
-   review result.
+5. A wall-clock **deadline is mandatory** — never run codex unbounded. Use the
+   caller's deadline, or the declared default of **600s (10 min)** when the
+   caller supplies none, and record which one applied. Enforce it so the whole
+   process **tree** is reaped, not just the direct child: run codex in its own
+   process group and kill the group on expiry (e.g. `setsid` + `kill -KILL
+   -<pgid>`), or `timeout --kill-after=10s <secs>` to escalate TERM→KILL. Plain
+   `timeout <secs> codex …` signals only the direct child, so if your wrapper
+   cannot guarantee process-group reaping, **disclose the surviving-subprocess
+   risk as a limitation** rather than claim cleanup. Deadline expiry is
+   **fail-closed**: the run is killed and reported as timed-out / not proven,
+   partial output preserved — never a completed review.
 6. Capture the final response with `-o`, JSONL, or an output schema.
 7. Report the typed run result, then stop: the process exit status, the captured
-   artifact path, whether a timeout fired (and the process tree was reaped), and
-   whether the `codex` binary was even present. Cancellation is the caller's;
-   this skill neither retries nor continues on its own.
+   artifact path, which deadline applied and whether it fired, whether the
+   process tree was reaped (or the surviving-subprocess limitation), and whether
+   the `codex` binary was present at all. Cancellation is the caller's; this
+   skill neither retries nor continues on its own.
 
-Terminal outcomes are explicit: **binary absent** (no `codex` on PATH) →
-report unavailable and stop; **timed out** → report the kill and preserved
-partial output, never as a completed review; **nonzero exit** → runtime
+Terminal outcomes are explicit: **binary absent** (no `codex` on PATH) → report
+unavailable and stop; **deadline expiry** → fail-closed, report the kill and
+preserved partial output, never a completed review; **nonzero exit** → runtime
 evidence, not a semantic verdict. The caller decides whether to launch another
 invocation.
 
 ## Example
 
 ```bash
-printf '%s\n' "$PROMPT" | timeout "${CODEX_TIMEOUT:-600}" \
+# Deadline mandatory; default 600s. `setsid` puts codex in its own process
+# group; on expiry `--kill-after` escalates TERM->KILL to reap the tree, not
+# just the direct child. (If you cannot run setsid, disclose that a plain
+# `timeout` reaps only the direct child.)
+printf '%s\n' "$PROMPT" | setsid timeout --kill-after=10s "${CODEX_TIMEOUT:-600}" \
   codex exec -C "$WORKSPACE" -s read-only -o "$OUTPUT" -
 ```
 

--- a/skills-codex/ntm/.agentops-generated.json
+++ b/skills-codex/ntm/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/ntm",
   "layout": "modular",
-  "source_hash": "64bbab4341caf4f10671acb761b865c2bab35095f3818d782e93862b9e423866",
-  "generated_hash": "6cd15025d6ca0c1ffdf7062a4d2f698545bf204cecac3cc9b43dae28d2b9ac2f"
+  "source_hash": "00030ed2957cf39b7f97bccc5fe3be7a93948571ff0815d90f2c57cf0f435661",
+  "generated_hash": "9d7052b83a5a1276bcc6d581e98d58986eadda314fc860923ae3c56d4badec0f"
 }

--- a/skills-codex/ntm/SKILL.md
+++ b/skills-codex/ntm/SKILL.md
@@ -71,8 +71,17 @@ Return:
 - degraded or unavailable substrate surfaces;
 - effects that were and were not observed.
 
-A timeout, nonzero exit, or degraded source is reported as evidence. The caller
-decides whether to invoke another experiment.
+Terminal outcomes are explicit, never a silent hang:
+
+- **NTM unavailable** — `ntm` absent or the robot surface unreachable: report it
+  and stop; do not fall back to blind key injection or assume the pane is idle.
+- **Observation-window deadline reached** — report the last observed robot state
+  and transcript reference; the window ending is a stop, not a failure verdict.
+- **Timeout / nonzero exit / degraded source** — reported as evidence with what
+  was and was not observed.
+- **Cancellation and cleanup** — the caller decides whether to invoke another
+  experiment; report which panes were created or left running so nothing is
+  orphaned silently. NTM never retries or reaps on its own.
 
 ## Useful live surfaces
 
@@ -82,4 +91,6 @@ caller explicitly requests an interactive action and no robot command provides
 the needed behavior.
 
 External NTM documentation and examples remain the authority for command syntax;
-this skill owns only the AgentOps boundary above.
+this skill owns only the AgentOps boundary above. NTM's CLI drifts across
+versions, so confirm the surface at runtime (`ntm --version`,
+`ntm --robot-capabilities`) rather than trusting a remembered command.

--- a/skills-codex/rch/.agentops-generated.json
+++ b/skills-codex/rch/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rch",
   "layout": "modular",
-  "source_hash": "5a4e3a005eb6f62ebdb1d1dde6e521945dd7d09048462259728cca286fe9db3c",
-  "generated_hash": "bfa4cab644948545f43f51c6eccb9aba660fbd7f7d920789656287960e93b345"
+  "source_hash": "3af677e66c6a1ed663e733461d9153922b7dd6123bc011fbae9bc831a2d3c2c1",
+  "generated_hash": "bb6606aa0c44726a8f67021fbe6bdf767ca31773e57fc274201f7ae32f51b42a"
 }

--- a/skills-codex/rch/.agentops-generated.json
+++ b/skills-codex/rch/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rch",
   "layout": "modular",
-  "source_hash": "b1181403f349967821fadf1daa1140035707b2f88f9602dc53fe0ef0519b37f0",
-  "generated_hash": "b57b475bfada95fcfe66665ab45dd977d74d58e36179856c054fd40a90b8ecec"
+  "source_hash": "6e7d47c4d1e44bcfb761fd05edaedececcde552519912581891a34609fdda798",
+  "generated_hash": "5e25c8e835b99f4370009f4e2940201db8e8765bd6136e13625a2a3de6a38e78"
 }

--- a/skills-codex/rch/.agentops-generated.json
+++ b/skills-codex/rch/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rch",
   "layout": "modular",
-  "source_hash": "6e7d47c4d1e44bcfb761fd05edaedececcde552519912581891a34609fdda798",
-  "generated_hash": "5e25c8e835b99f4370009f4e2940201db8e8765bd6136e13625a2a3de6a38e78"
+  "source_hash": "5a4e3a005eb6f62ebdb1d1dde6e521945dd7d09048462259728cca286fe9db3c",
+  "generated_hash": "bfa4cab644948545f43f51c6eccb9aba660fbd7f7d920789656287960e93b345"
 }

--- a/skills-codex/rch/SKILL.md
+++ b/skills-codex/rch/SKILL.md
@@ -38,13 +38,28 @@ fails deterministically, not moodily.
 when the local build succeeds. Destructive cleanup, worker deployment, daemon
 configuration, and remote mutation require explicit caller authority.
 
+`rch check` exit status adjudicates readiness (0 = ready, nonzero = not
+offload-ready). Do not read `rch doctor --json` `success: true` as readiness — a
+successful diagnostic report can coexist with a down daemon or unreachable
+workers. Adjudicate on `rch check`; use `doctor` for the reasons behind it.
+
 ## Output
 
 Return a factual packet with status (`remote`, `local_fallback`, `failed`, or
 `not_proven`), commands and exit codes, worker, summary line, and checked/not
-checked surfaces. Do not include a next action.
+checked surfaces. Do not include a next action. `not_proven` here is a runtime
+diagnosis status, not an AgentOps verdict; it carries no verdict weight and never
+substitutes for a `verdict.v2`.
 
 ## References
+
+The SKILL.md authority boundary above governs every reference below. Where a
+reference lists a remediation, its read-only diagnostics run autonomously but its
+remote, privileged, or irreversible steps (remote/`sudo` mutation, daemon
+start/restart/reconfigure, worker or fleet deployment, toolchain sync,
+destructive cleanup) still require explicit caller authorization first. A
+reference never widens the autonomy the kernel grants.
+
 
 - [Fail-open reasons](references/FAIL_OPEN.md)
 - [Error catalog](references/ERROR_CODES.md)

--- a/skills-codex/rch/references/CONFIGURATION.md
+++ b/skills-codex/rch/references/CONFIGURATION.md
@@ -10,6 +10,13 @@
 - [Validation and Diagnostics](#validation-and-diagnostics)
 - [Runtime Data Paths](#runtime-data-paths)
 
+> **Authority:** reading config is autonomous (`rch config get|show|validate|
+> doctor|diff`, `rch hook status`). Writing it is not — editing
+> `~/.config/rch/config.toml` or `workers.toml`, `rch config set|edit|init`, and
+> `rch hook install|uninstall` (which write `~/.claude/settings.json`) are host
+> mutations requiring explicit caller authorization first (see `FAIL_OPEN.md`
+> §"Autonomous Remediation Envelope").
+
 ## Precedence and File Locations
 
 RCH resolves settings in this order (highest to lowest):
@@ -152,9 +159,9 @@ Location: `~/.claude/settings.json`
 Recommended management commands:
 
 ```bash
-rch hook install
-rch hook status
-rch hook uninstall
+rch hook status       # autonomous
+rch hook install      # (authorize first) — writes ~/.claude/settings.json
+rch hook uninstall    # (authorize first) — edits ~/.claude/settings.json
 ```
 
 ---

--- a/skills-codex/rch/references/ERROR_CODES.md
+++ b/skills-codex/rch/references/ERROR_CODES.md
@@ -42,7 +42,7 @@ jq '.errors[] | select(.code=="RCH-E210") | {code, message, remediation}' /tmp/r
 | Range | Category | Lives in |
 |---|---|---|
 | 001–099 | Configuration | TOML, env vars, profile resolution, path topology, closure plan validation |
-| 100–199 | Network | SSH, DNS, TCP — see `SSH_TUNING.md` |
+| 100–199 | Network | SSH, DNS, TCP — see the Network rows below and `RECOVERY_PLAYBOOKS.md` Playbook C |
 | 200–299 | Worker | Selection, health, slots, disk pressure |
 | 300–399 | Build | Compilation, toolchain, process triage, cancellation |
 | 400–499 | Transfer | rsync, checksums, disk space, perms |
@@ -66,7 +66,7 @@ These are the codes agents actually see in practice. The rest are in the schema 
 | RCH-E013 | Cargo manifest parse failure during path-dep resolution | `cargo metadata --no-deps --format-version 1 > /dev/null` to see the parser error. |
 | RCH-E014 | Path dependency declared but target dir missing | The `path = "..."` in a `Cargo.toml` points nowhere. Resolve before retry. |
 | RCH-E015 | Cyclic path dependency | Break the cycle in the workspace. |
-| RCH-E016 | Path dep violates canonical-root topology | Sibling repo lives outside `[path_topology] canonical_root`. Either move it under the canonical root, or set `[path_topology] canonical_root` to a parent that contains both repos. See `PATH_DEPENDENCIES.md`. |
+| RCH-E016 | Path dep violates canonical-root topology | Sibling repo lives outside `[path_topology] canonical_root`. Either move it under the canonical root, or set `[path_topology] canonical_root` to a parent that contains both repos. See the path-dep section of `TROUBLESHOOTING.md`. |
 | RCH-E017 | `cargo metadata` invocation failed | Run `cargo metadata --format-version 1` and read the error directly. |
 | RCH-E019 | Closure plan computation failed | Re-run with `RCH_LOG_LEVEL=debug rch diagnose --dry-run "<command>"`. |
 | RCH-E020 | Closure entered fail-open due to unverifiable data | RCH refuses to ship unsafe closure. Either fix the workspace topology or set `[deps] policy = "permissive"` (only if you accept the risk). |
@@ -92,7 +92,7 @@ These are the codes agents actually see in practice. The rest are in the schema 
 | RCH-E204 | Worker at maximum capacity | Queueing is on by default; if seen, the wait timed out. Bump `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` or raise `total_slots`. |
 | RCH-E205 | Worker missing required toolchain | `rch workers sync-toolchain --all`. |
 | RCH-E207 | Worker circuit breaker open | Triggered by repeated failures. Inspect daemon logs; circuit auto-closes after cooldown, or `rch workers enable <id>` after fixing the underlying cause. |
-| **RCH-E210** | **Worker disk usage critically high** | **Hand off to `sbh`.** See `DISK_AND_PRESSURE.md`. |
+| **RCH-E210** | **Worker disk usage critically high** | **Hand off to the `sbh` skill.** See the disk rows in this table and `RECOVERY_PLAYBOOKS.md` Playbook G. |
 | RCH-E211 | Worker disk usage above warning threshold | `sbh` recommended. |
 | RCH-E212 | Disk pressure telemetry stale | Worker not reporting; restart `rch-wkr` on the worker, or wait one telemetry tick. |
 | RCH-E213 | Worker disk I/O too high | Transient — wait or `rch workers drain <id>` for maintenance. |
@@ -107,7 +107,7 @@ These are the codes agents actually see in practice. The rest are in the schema 
 |---|---|---|
 | RCH-E300 | Remote compilation failed | Read the actual rustc/cargo error in stderr. |
 | RCH-E303 | Build operation timed out | Raise `[compilation] build_timeout_sec` or split the build. |
-| RCH-E305 | Remote working dir error | Often = mirror perms broken. See `OPERATIONS.md` chown recipe. |
+| RCH-E305 | Remote working dir error | Often = mirror perms broken. See `RECOVERY_PLAYBOOKS.md` Playbook F — the chown fix is a remote `sudo` command, authorize first. |
 | RCH-E307 | Build environment setup failed | Missing system package on worker. Detected automatically when stderr names `pkg-config` or `library .pc`. |
 
 ### Transfer
@@ -117,14 +117,14 @@ These are the codes agents actually see in practice. The rest are in the schema 
 | RCH-E400 | Rsync transfer failed | Check `rch daemon logs -n 200` for full rsync stderr. |
 | RCH-E401 | Sync timed out | Big workspace + slow link. Tighten excludes or increase compression. |
 | RCH-E404 | Insufficient disk on worker | `sbh` on worker. |
-| RCH-E405 | Permission denied during transfer | Mirror ownership broken. Run the chown recipe from `OPERATIONS.md` §6. |
-| RCH-E406 | Transfer checksum mismatch | Re-run; if persistent, suspect concurrent agent writes during sync. Use file reservations (see `MULTI_AGENT_CONTENTION.md`). |
+| RCH-E405 | Permission denied during transfer | Mirror ownership broken. See `RECOVERY_PLAYBOOKS.md` Playbook F — the chown fix is a remote `sudo` command, authorize first. |
+| RCH-E406 | Transfer checksum mismatch | Re-run; if persistent, suspect concurrent agent writes during sync. Coordinate writers with file reservations via the `agent-mail` skill. |
 
 ### Internal
 
 | Code | Meaning | First action |
 |---|---|---|
-| RCH-E500 | Failed to connect to daemon socket | `rch daemon start`. If it spins, see `SELF_HEALING.md` cooldown section. |
+| RCH-E500 | Failed to connect to daemon socket | Wait out the auto-start cooldown and retry; manually starting the daemon needs caller authorization. If it spins, see `RECOVERY_PLAYBOOKS.md` Playbook B (cooldown/stale-socket). |
 | RCH-E502 | Daemon not running | Same. |
 | RCH-E506 | Hook execution failed | `rch hook test` reproduces; capture `RCH_LOG_LEVEL=debug rch hook test`. |
 
@@ -132,11 +132,11 @@ These are the codes agents actually see in practice. The rest are in the schema 
 
 ## Cross-References
 
-- Path-dep family (RCH-E013–E024): `PATH_DEPENDENCIES.md`
-- Disk-pressure family (RCH-E210–E217): `DISK_AND_PRESSURE.md` + `sbh` skill
-- SSH family (RCH-E100–E109): `SSH_TUNING.md`
+- Path-dep family (RCH-E013–E024): the path-dep section of `TROUBLESHOOTING.md`
+- Disk-pressure family (RCH-E210–E217): the disk rows above + the `sbh` skill
+- SSH family (RCH-E100–E109): `RECOVERY_PLAYBOOKS.md` Playbook C
 - Selection family (RCH-E200–E209): `FAIL_OPEN.md`
-- Daemon/internal (RCH-E500–E509): `SELF_HEALING.md` + `OPERATIONS.md`
+- Daemon/internal (RCH-E500–E509): `RECOVERY_PLAYBOOKS.md` Playbook B + `TROUBLESHOOTING.md`
 
 ---
 

--- a/skills-codex/rch/references/ERROR_CODES.md
+++ b/skills-codex/rch/references/ERROR_CODES.md
@@ -18,6 +18,12 @@ RCH ships a stable error catalog of 94 codes in the `RCH-Exxx` namespace. Every 
 
 Treat the code as the **stable handle**. Don't grep for the human-readable summary, which can be reworded between releases.
 
+> **Authority:** only read-only diagnosis is autonomous. Every "First action"
+> below that starts/restarts/reconfigures the daemon, adds/provisions/drains/
+> enables a worker or its toolchain, edits config, or mutates a remote host
+> requires explicit caller authorization first — see `FAIL_OPEN.md` §"Autonomous
+> Remediation Envelope". Mutating first actions are marked **(authorize first)**.
+
 ---
 
 ## Live Catalog
@@ -58,18 +64,18 @@ These are the codes agents actually see in practice. The rest are in the schema 
 
 | Code | Meaning | First action |
 |---|---|---|
-| RCH-E001 | Config file not found | `rch config init` (creates `~/.config/rch/config.toml`). |
-| RCH-E003 | Invalid TOML syntax | `rch config validate` to get the line. |
-| RCH-E007 | No workers configured | `rch workers discover --add --yes && rch workers setup --all`. |
-| RCH-E008 | Worker config invalid | `rch config doctor` shows which `[[workers]]` block is bad. |
-| RCH-E009 | SSH key path invalid/inaccessible | Check `identity_file` exists; run `chmod 600 <key>`. |
+| RCH-E001 | Config file not found | `rch config init` creates `~/.config/rch/config.toml` — **(authorize first)**. |
+| RCH-E003 | Invalid TOML syntax | `rch config validate` to get the line (autonomous). |
+| RCH-E007 | No workers configured | `rch workers discover --add --yes && rch workers setup --all` adds/provisions workers — **(authorize first)**. |
+| RCH-E008 | Worker config invalid | `rch config doctor` shows which `[[workers]]` block is bad (autonomous). |
+| RCH-E009 | SSH key path invalid/inaccessible | Check `identity_file` exists (autonomous); `chmod 600 <key>` mutates a local file — **(authorize first)**. |
 | RCH-E013 | Cargo manifest parse failure during path-dep resolution | `cargo metadata --no-deps --format-version 1 > /dev/null` to see the parser error. |
 | RCH-E014 | Path dependency declared but target dir missing | The `path = "..."` in a `Cargo.toml` points nowhere. Resolve before retry. |
 | RCH-E015 | Cyclic path dependency | Break the cycle in the workspace. |
 | RCH-E016 | Path dep violates canonical-root topology | Sibling repo lives outside `[path_topology] canonical_root`. Either move it under the canonical root, or set `[path_topology] canonical_root` to a parent that contains both repos. See the path-dep section of `TROUBLESHOOTING.md`. |
 | RCH-E017 | `cargo metadata` invocation failed | Run `cargo metadata --format-version 1` and read the error directly. |
 | RCH-E019 | Closure plan computation failed | Re-run with `RCH_LOG_LEVEL=debug rch diagnose --dry-run "<command>"`. |
-| RCH-E020 | Closure entered fail-open due to unverifiable data | RCH refuses to ship unsafe closure. Either fix the workspace topology or set `[deps] policy = "permissive"` (only if you accept the risk). |
+| RCH-E020 | Closure entered fail-open due to unverifiable data | RCH refuses to ship unsafe closure. Fix the workspace topology, or set `[deps] policy = "permissive"` (a config edit that accepts the risk) — **(authorize first)**. |
 
 ### Network
 
@@ -77,7 +83,7 @@ These are the codes agents actually see in practice. The rest are in the schema 
 |---|---|---|
 | RCH-E100 | SSH connection failed | `ssh -v ubuntu@<host>` reproduces. Check host reachability. |
 | RCH-E101 | SSH auth failed | Wrong key or wrong user. `ssh-add -l` to confirm agent has the right key; `rch config get` for `identity_file`. |
-| RCH-E103 | Host key verification failed | Worker rebuilt? Compare with `ssh-keygen -F <host>`; remove the old entry only if you trust the new fingerprint. |
+| RCH-E103 | Host key verification failed | Worker rebuilt? Compare with `ssh-keygen -F <host>` (autonomous); removing the old `known_hosts` entry mutates local state — **(authorize first)**, and only if you trust the new fingerprint. |
 | RCH-E104 | SSH command timed out | Network or remote slowdown. Bump `RCH_SSH_SERVER_ALIVE_INTERVAL_SECS=15` and retry. |
 | RCH-E108 | Connection refused | sshd not running or wrong port. |
 | RCH-E109 | TCP connect timeout | Firewall, NAT, or worker down. |
@@ -89,13 +95,13 @@ These are the codes agents actually see in practice. The rest are in the schema 
 | RCH-E200 | No workers available for selection | See `FAIL_OPEN.md` selection-reasons table. |
 | RCH-E202 | Worker failed health check | `rch workers probe <id>` reproduces; inspect `rch workers list --speedscore`. |
 | RCH-E203 | Worker self-test failed | `rch self-test --worker <id>`; inspect `rch self-test history --limit 5`. |
-| RCH-E204 | Worker at maximum capacity | Queueing is on by default; if seen, the wait timed out. Bump `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` or raise `total_slots`. |
-| RCH-E205 | Worker missing required toolchain | `rch workers sync-toolchain --all`. |
-| RCH-E207 | Worker circuit breaker open | Triggered by repeated failures. Inspect daemon logs; circuit auto-closes after cooldown, or `rch workers enable <id>` after fixing the underlying cause. |
+| RCH-E204 | Worker at maximum capacity | Queueing is on by default; if seen, the wait timed out. Bump `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` (autonomous); raising `total_slots` edits config — **(authorize first)**. |
+| RCH-E205 | Worker missing required toolchain | `rch workers sync-toolchain --all` mutates the worker — **(authorize first)**. |
+| RCH-E207 | Worker circuit breaker open | Triggered by repeated failures. Inspect daemon logs (autonomous); circuit auto-closes after cooldown, or force `rch workers enable <id>` after fixing the cause — **(authorize first)**. |
 | **RCH-E210** | **Worker disk usage critically high** | **Hand off to the `sbh` skill.** See the disk rows in this table and `RECOVERY_PLAYBOOKS.md` Playbook G. |
 | RCH-E211 | Worker disk usage above warning threshold | `sbh` recommended. |
-| RCH-E212 | Disk pressure telemetry stale | Worker not reporting; restart `rch-wkr` on the worker, or wait one telemetry tick. |
-| RCH-E213 | Worker disk I/O too high | Transient — wait or `rch workers drain <id>` for maintenance. |
+| RCH-E212 | Disk pressure telemetry stale | Worker not reporting; wait one telemetry tick (autonomous). Restarting `rch-wkr` on the worker is remote mutation — **(authorize first)**. |
+| RCH-E213 | Worker disk I/O too high | Transient — wait (autonomous), or `rch workers drain <id>` for maintenance — **(authorize first)**. |
 | RCH-E214 | Worker memory pressure too high | Same; check what else is running on the worker. |
 | RCH-E215 | Disk reclaim failed | sbh ran but couldn't free enough. Manual triage. |
 | RCH-E216 | Insufficient disk headroom for build reservation | Free space, or steer to a different worker via `tags`. |
@@ -106,7 +112,7 @@ These are the codes agents actually see in practice. The rest are in the schema 
 | Code | Meaning | First action |
 |---|---|---|
 | RCH-E300 | Remote compilation failed | Read the actual rustc/cargo error in stderr. |
-| RCH-E303 | Build operation timed out | Raise `[compilation] build_timeout_sec` or split the build. |
+| RCH-E303 | Build operation timed out | Splitting the build is autonomous; raising `[compilation] build_timeout_sec` edits config — **(authorize first)**. |
 | RCH-E305 | Remote working dir error | Often = mirror perms broken. See `RECOVERY_PLAYBOOKS.md` Playbook F — the chown fix is a remote `sudo` command, authorize first. |
 | RCH-E307 | Build environment setup failed | Missing system package on worker. Detected automatically when stderr names `pkg-config` or `library .pc`. |
 

--- a/skills-codex/rch/references/FAIL_OPEN.md
+++ b/skills-codex/rch/references/FAIL_OPEN.md
@@ -59,8 +59,8 @@ Every reason in the parens comes from one of two sources:
 | `daemon unavailable` | Daemon socket can't be reached (and auto-start failed or is disabled) | Wait out the auto-start cooldown and retry (autonomous). If still failing, confirm with `rch --json daemon status` and check `~/.cache/rch/rch.sock`; manually starting the daemon needs caller authorization. See `RECOVERY_PLAYBOOKS.md` Playbook B. |
 | `force_local` | `[general] force_local = true` is set | This is intentional. `rch config get general.force_local --sources` shows where it came from (autonomous). Reverting with `rch config set general.force_local false` edits config — **(authorize first)**. |
 | `invalid config: force_local+force_remote` | Both flags set simultaneously | `rch config edit` to unset one, then `rch daemon reload` — both mutate config/daemon, **(authorize first)**. |
-| `confidence below threshold` | Classifier flagged the command but only weakly (e.g., wrapped in shell pipelines). Threshold is `[compilation] confidence_threshold` (default 0.85). | If the command really should offload, lower the threshold or set `[general] force_remote = true` in `.rch/config.toml`. Better: run `rch diagnose "<the command>"` to see classifier confidence. |
-| `command '<base>' not in allowlist` | `[execution] allowlist` excludes this command base | `rch --json config get execution.allowlist` to inspect. Add the command base if you control the project's `.rch/config.toml`. |
+| `confidence below threshold` | Classifier flagged the command but only weakly (e.g., wrapped in shell pipelines). Threshold is `[compilation] confidence_threshold` (default 0.85). | Run `rch diagnose "<the command>"` to see classifier confidence (autonomous). Lowering the threshold or setting `[general] force_remote = true` in `.rch/config.toml` are config mutations — **(authorize first)**. |
+| `command '<base>' not in allowlist` | `[execution] allowlist` excludes this command base | `rch --json config get execution.allowlist` to inspect (autonomous). Adding the command base to `.rch/config.toml` is a config mutation — **(authorize first)**. |
 | `dependency preflight <RCH-Exxx>: <remediation>` | The closure planner refused to ship the workspace (cycle, missing manifest, off-canonical-root path dep). See the RCH-E013–E020 rows in `ERROR_CODES.md` and the path-dep section of `TROUBLESHOOTING.md`. | The remediation message is actionable; follow it. Then re-run `rch diagnose --dry-run "<command>"`. |
 | `<TransferSkipped reason>` | Transfer pipeline opted out (e.g., empty workspace, all paths excluded). | Run `RCH_LOG_LEVEL=debug rch exec -- <command>` and look for `Transfer skipped:` log lines. |
 | `remote execution failed` | Generic catch-all for transfer/exec errors | Re-run with `RCH_LOG_LEVEL=debug` to surface the real error, and check `rch daemon logs -n 200` for the daemon side. |
@@ -73,7 +73,7 @@ These come from the daemon's `SelectionReason` enum. The `[RCH] local (...)` sum
 | Snake_case tag (JSON) | Human form in `local (...)` summary | Self-fix |
 |---|---|---|
 | `no_workers_configured` | `no workers configured` | `rch workers discover --add --yes && rch workers setup --all` adds and provisions workers — a fleet mutation; get caller authorization first. |
-| `all_workers_unreachable` | `all workers unreachable` | `rch workers probe --all` and read the SSH errors (autonomous); fixing a local key's permissions is local, but changing anything on a worker is remote mutation → authorize first. See `RECOVERY_PLAYBOOKS.md` Playbook C and the Network rows of `ERROR_CODES.md`. |
+| `all_workers_unreachable` | `all workers unreachable` | `rch workers probe --all` and read the SSH errors (autonomous). Any fix beyond reading — repairing a local key's permissions included — is a host mutation → **(authorize first)**; changing anything on a worker is remote mutation → **(authorize first)**. See `RECOVERY_PLAYBOOKS.md` Playbook C and the Network rows of `ERROR_CODES.md`. |
 | `all_circuits_open` | `all worker circuits open` | A worker hit repeated failures and tripped its circuit. Inspect with `rch --json status --workers \| jq '.data.daemon.workers[] \| {id, circuit_state, last_error, recovery_in_secs}'` and `rch daemon logs -n 200` (autonomous). Circuits auto-close after the cooldown; forcing `rch workers enable <id>` mutates worker state — **(authorize first)**. |
 | `all_workers_busy` | `all workers at capacity` | Queueing is **on by default** (`RCH_QUEUE_WHEN_BUSY=1`); seeing this means the wait timed out. Bump `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` for the next invocation (autonomous). Raising `total_slots` edits worker config — **(authorize first)**. Check `rch queue --watch` to see backlog. |
 | `all_workers_failed_preflight` | `all workers failed preflight checks` | Path-topology check, repo presence, or toolchain probe failed on every candidate. Re-run with `rch diagnose --dry-run "<command>"` to see the preflight pipeline; hits `RCH-E013..024`, `RCH-E205`, `RCH-E305`. |
@@ -155,8 +155,11 @@ filesystem state:
   status|verify`, `rch queue`, `rch self-test`;
 - tuning env vars for the *next* invocation (`RCH_VISIBILITY`, `RCH_LOG_LEVEL`,
   `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120`, `RCH_SSH_SERVER_ALIVE_INTERVAL_SECS`);
-- re-running the original command, including waiting out an auto-start cooldown
-  (the built-in `try_auto_start_daemon` handles stale sockets — do not `rm` them).
+- re-running the original command *only when that command is itself read-only*,
+  including waiting out an auto-start cooldown (the built-in
+  `try_auto_start_daemon` handles stale sockets — do not `rm` them). A
+  mutating original command re-runs only under the authorization that covered
+  it in the first place.
 
 **Requires explicit caller authorization first — even when a reason maps
 straight to one of these commands.** Every host, worker, daemon, config, or

--- a/skills-codex/rch/references/FAIL_OPEN.md
+++ b/skills-codex/rch/references/FAIL_OPEN.md
@@ -57,8 +57,8 @@ Every reason in the parens comes from one of two sources:
 | Reason text | Triggered when | Self-fix |
 |---|---|---|
 | `daemon unavailable` | Daemon socket can't be reached (and auto-start failed or is disabled) | Wait out the auto-start cooldown and retry (autonomous). If still failing, confirm with `rch --json daemon status` and check `~/.cache/rch/rch.sock`; manually starting the daemon needs caller authorization. See `RECOVERY_PLAYBOOKS.md` Playbook B. |
-| `force_local` | `[general] force_local = true` is set | This is intentional. If you didn't expect it: `rch config get general.force_local --sources` shows where it came from. `rch config set general.force_local false` to revert. |
-| `invalid config: force_local+force_remote` | Both flags set simultaneously | `rch config edit` and unset one. Then `rch daemon reload`. |
+| `force_local` | `[general] force_local = true` is set | This is intentional. `rch config get general.force_local --sources` shows where it came from (autonomous). Reverting with `rch config set general.force_local false` edits config — **(authorize first)**. |
+| `invalid config: force_local+force_remote` | Both flags set simultaneously | `rch config edit` to unset one, then `rch daemon reload` — both mutate config/daemon, **(authorize first)**. |
 | `confidence below threshold` | Classifier flagged the command but only weakly (e.g., wrapped in shell pipelines). Threshold is `[compilation] confidence_threshold` (default 0.85). | If the command really should offload, lower the threshold or set `[general] force_remote = true` in `.rch/config.toml`. Better: run `rch diagnose "<the command>"` to see classifier confidence. |
 | `command '<base>' not in allowlist` | `[execution] allowlist` excludes this command base | `rch --json config get execution.allowlist` to inspect. Add the command base if you control the project's `.rch/config.toml`. |
 | `dependency preflight <RCH-Exxx>: <remediation>` | The closure planner refused to ship the workspace (cycle, missing manifest, off-canonical-root path dep). See the RCH-E013–E020 rows in `ERROR_CODES.md` and the path-dep section of `TROUBLESHOOTING.md`. | The remediation message is actionable; follow it. Then re-run `rch diagnose --dry-run "<command>"`. |
@@ -74,12 +74,12 @@ These come from the daemon's `SelectionReason` enum. The `[RCH] local (...)` sum
 |---|---|---|
 | `no_workers_configured` | `no workers configured` | `rch workers discover --add --yes && rch workers setup --all` adds and provisions workers — a fleet mutation; get caller authorization first. |
 | `all_workers_unreachable` | `all workers unreachable` | `rch workers probe --all` and read the SSH errors (autonomous); fixing a local key's permissions is local, but changing anything on a worker is remote mutation → authorize first. See `RECOVERY_PLAYBOOKS.md` Playbook C and the Network rows of `ERROR_CODES.md`. |
-| `all_circuits_open` | `all worker circuits open` | A worker hit repeated failures and tripped its circuit. Inspect with `rch --json status --workers \| jq '.data.daemon.workers[] \| {id, circuit_state, last_error, recovery_in_secs}'` and `rch daemon logs -n 200`. Use `rch workers enable <id>` after fixing the underlying cause; circuits also auto-close after the cooldown. |
-| `all_workers_busy` | `all workers at capacity` | Queueing is **on by default** (`RCH_QUEUE_WHEN_BUSY=1`); seeing this means the wait timed out. Bump `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` for the next invocation, or raise `total_slots`. Check `rch queue --watch` to see backlog. |
+| `all_circuits_open` | `all worker circuits open` | A worker hit repeated failures and tripped its circuit. Inspect with `rch --json status --workers \| jq '.data.daemon.workers[] \| {id, circuit_state, last_error, recovery_in_secs}'` and `rch daemon logs -n 200` (autonomous). Circuits auto-close after the cooldown; forcing `rch workers enable <id>` mutates worker state — **(authorize first)**. |
+| `all_workers_busy` | `all workers at capacity` | Queueing is **on by default** (`RCH_QUEUE_WHEN_BUSY=1`); seeing this means the wait timed out. Bump `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` for the next invocation (autonomous). Raising `total_slots` edits worker config — **(authorize first)**. Check `rch queue --watch` to see backlog. |
 | `all_workers_failed_preflight` | `all workers failed preflight checks` | Path-topology check, repo presence, or toolchain probe failed on every candidate. Re-run with `rch diagnose --dry-run "<command>"` to see the preflight pipeline; hits `RCH-E013..024`, `RCH-E205`, `RCH-E305`. |
 | `all_workers_failed_convergence` | `all workers failed repo convergence checks` | The repo updater contract couldn't bring required repos to a target state on any worker. Check that the sibling repos exist on workers under the canonical root. See the RCH-E013–E020 rows in `ERROR_CODES.md` and the path-dep section of `TROUBLESHOOTING.md`. |
-| `no_matching_workers` | `no matching workers found` | The project requires tags (e.g., `tags = ["bun"]`) and no worker carries them. `rch workers list --json` to inspect tags; add the tag to a capable worker. |
-| `no_workers_with_runtime` (value = runtime name) | `no workers with bun installed` (or `node`, `rust`, …) | Install the runtime on a worker, then `rch workers capabilities --refresh`. |
+| `no_matching_workers` | `no matching workers found` | The project requires tags (e.g., `tags = ["bun"]`) and no worker carries them. `rch workers list --json` to inspect tags (autonomous); adding the tag edits worker config — **(authorize first)**. |
+| `no_workers_with_runtime` (value = runtime name) | `no workers with bun installed` (or `node`, `rust`, …) | Installing the runtime on a worker and `rch workers capabilities --refresh` both mutate worker state — **(authorize first)**. |
 | `selection_error` (value = error text) | `selection error: <msg>` | An internal error during selection. Check `rch daemon logs -n 200`. Likely a code-side bug; capture `rch doctor --json` and `rch --json daemon status` for escalation. |
 
 Two more variants — `affinity_pinned` and `affinity_fallback` — are *success* paths (a worker was assigned via affinity), not fail-opens, so they never appear in `[RCH] local (...)` output.
@@ -144,32 +144,37 @@ If that prints `[RCH] remote <worker> (...)`, the offload path is healthy and th
 The skill resolves diagnosis autonomously — but the SKILL.md authority boundary
 governs, and this file does not widen it. Two tiers:
 
-**Autonomous (no need to ask) — the blast-radius ceiling.** Read-only diagnosis
-and reversible, local-only actions on *this* machine:
+**Autonomous (no need to ask) — the blast-radius ceiling is read-only.** Only
+diagnosis and inspection that mutates no host, worker, daemon, config, or
+filesystem state:
 
 - reading summary lines, stderr, and `rch daemon logs`;
-- `rch check`, `rch diagnose`, `rch --json ... probe/status/get/show`, `rch
-  config validate|doctor|show|get` — inspection, never mutation;
+- status/inspection commands: `rch check`, `rch status`, `rch --json daemon
+  status`, `rch diagnose`/`--dry-run`, `rch --json workers probe|list`, `rch
+  config get|show|validate|doctor|diff`, `rch hook status|test`, `rch fleet
+  status|verify`, `rch queue`, `rch self-test`;
 - tuning env vars for the *next* invocation (`RCH_VISIBILITY`, `RCH_LOG_LEVEL`,
   `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120`, `RCH_SSH_SERVER_ALIVE_INTERVAL_SECS`);
 - re-running the original command, including waiting out an auto-start cooldown
-  (the built-in `try_auto_start_daemon` handles stale sockets — do not `rm` them);
-- local, reversible hook repair on this machine (`rch hook status|install|test`);
-- fixing permissions on a **local** key file you own (`chmod 600 ~/.ssh/<key>`).
+  (the built-in `try_auto_start_daemon` handles stale sockets — do not `rm` them).
 
 **Requires explicit caller authorization first — even when a reason maps
-straight to one of these commands.** Anything remote, privileged, deployment-
-scale, daemon-lifecycle, or destructive crosses the ceiling:
+straight to one of these commands.** Every host, worker, daemon, config, or
+filesystem mutation crosses the ceiling. It does not matter that a table cell
+below lists the command — a listed command is not a pre-authorized one:
 
+- **local host mutation** — `rch hook install|uninstall` (writes
+  `~/.claude/settings.json`), `chmod` on a local key file, `rch config
+  set|edit|init`, and any edit to `~/.config/rch/*.toml`;
 - **remote host mutation** — any `ssh … sudo …`, remote `chown`/`chmod`/`rm`,
-  remote installs, changing a worker's `authorized_keys` or its host-key entry;
-- **worker / fleet deployment** — `rch workers sync-toolchain`, `workers
-  setup`, `workers deploy-binary`, `workers discover --add`, `workers
-  drain|disable|enable`, `rch fleet deploy|rollback`;
-- **daemon lifecycle / configuration** — manually `rch daemon start|restart|
-  reload`, `rch config set`, editing `~/.config/rch/*.toml`;
-- **destructive local cleanup** — removing sockets, cooldown/lock files, caches,
-  or moving the telemetry DB aside.
+  remote installs, restarting `sshd` or `rch-wkr` on a worker, changing a
+  worker's `authorized_keys` or its host-key entry;
+- **worker / fleet operations** — `rch workers
+  sync-toolchain|setup|deploy-binary|discover --add|drain|disable|enable|capabilities --refresh`,
+  `rch fleet deploy|rollback`;
+- **daemon lifecycle** — `rch daemon start|restart|reload|stop`;
+- **destructive cleanup** — removing sockets, cooldown/lock files, caches, or
+  moving the telemetry DB aside.
 
 For each reason, run the autonomous diagnosis, then, if the fix is above the
 ceiling, capture the evidence and get authorization before running it:
@@ -178,9 +183,9 @@ ceiling, capture the evidence and get authorization before running it:
   the auto-start cooldown and retry (autonomous). Manually starting/restarting
   the daemon, or removing the cooldown file, needs authorization.
 - **"all workers unreachable"** → `rch workers probe --all` and read the SSH
-  errors (autonomous); fixing a local key's permissions is local. Changing
-  anything **on** a worker (host-key entry, `authorized_keys`, restarting
-  `sshd`) is remote mutation → get authorization.
+  errors (autonomous). Every fix mutates state and needs authorization first:
+  `chmod` on a local key, and anything **on** a worker (host-key entry,
+  `authorized_keys`, restarting `sshd`).
 - **"all workers at capacity"** → queueing is on by default; bump
   `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` for the next run (autonomous).
   Raising `total_slots` edits worker config → authorization.

--- a/skills-codex/rch/references/FAIL_OPEN.md
+++ b/skills-codex/rch/references/FAIL_OPEN.md
@@ -7,11 +7,11 @@
 - [Fail-Open Reasons (and What To Do)](#fail-open-reasons-and-what-to-do)
 - [Detection Snippets](#detection-snippets)
 - [Force the Issue](#force-the-issue)
-- ["Don't Ask the Human" Rules](#dont-ask-the-human-rules)
+- [Autonomous Remediation Envelope (and Where It Stops)](#autonomous-remediation-envelope-and-where-it-stops)
 
 RCH's most expensive failure mode for agents is **silent fall-back to local execution**. The build "succeeded" — but it ran on the local machine, slowly, while the worker fleet sat idle. If you don't notice, you bake hours of extra latency into every iteration.
 
-This file is the canonical guide for: (1) how to *see* a fail-open, (2) what each fail-open reason means, and (3) what to do about it before asking the human.
+This file is the canonical guide for: (1) how to *see* a fail-open, (2) what each fail-open reason means, and (3) how to remediate it within the autonomous envelope — and where that envelope stops and explicit caller authorization begins.
 
 ---
 
@@ -56,15 +56,15 @@ Every reason in the parens comes from one of two sources:
 
 | Reason text | Triggered when | Self-fix |
 |---|---|---|
-| `daemon unavailable` | Daemon socket can't be reached (and auto-start failed or is disabled) | `rch daemon start && rch --json daemon status`. If still failing, check `~/.cache/rch/rch.sock` and look for stale auto-start cooldown (see `SELF_HEALING.md`). |
+| `daemon unavailable` | Daemon socket can't be reached (and auto-start failed or is disabled) | Wait out the auto-start cooldown and retry (autonomous). If still failing, confirm with `rch --json daemon status` and check `~/.cache/rch/rch.sock`; manually starting the daemon needs caller authorization. See `RECOVERY_PLAYBOOKS.md` Playbook B. |
 | `force_local` | `[general] force_local = true` is set | This is intentional. If you didn't expect it: `rch config get general.force_local --sources` shows where it came from. `rch config set general.force_local false` to revert. |
 | `invalid config: force_local+force_remote` | Both flags set simultaneously | `rch config edit` and unset one. Then `rch daemon reload`. |
 | `confidence below threshold` | Classifier flagged the command but only weakly (e.g., wrapped in shell pipelines). Threshold is `[compilation] confidence_threshold` (default 0.85). | If the command really should offload, lower the threshold or set `[general] force_remote = true` in `.rch/config.toml`. Better: run `rch diagnose "<the command>"` to see classifier confidence. |
 | `command '<base>' not in allowlist` | `[execution] allowlist` excludes this command base | `rch --json config get execution.allowlist` to inspect. Add the command base if you control the project's `.rch/config.toml`. |
-| `dependency preflight <RCH-Exxx>: <remediation>` | The closure planner refused to ship the workspace (cycle, missing manifest, off-canonical-root path dep). See `PATH_DEPENDENCIES.md`. | The remediation message is actionable; follow it. Then re-run `rch diagnose --dry-run "<command>"`. |
+| `dependency preflight <RCH-Exxx>: <remediation>` | The closure planner refused to ship the workspace (cycle, missing manifest, off-canonical-root path dep). See the RCH-E013–E020 rows in `ERROR_CODES.md` and the path-dep section of `TROUBLESHOOTING.md`. | The remediation message is actionable; follow it. Then re-run `rch diagnose --dry-run "<command>"`. |
 | `<TransferSkipped reason>` | Transfer pipeline opted out (e.g., empty workspace, all paths excluded). | Run `RCH_LOG_LEVEL=debug rch exec -- <command>` and look for `Transfer skipped:` log lines. |
 | `remote execution failed` | Generic catch-all for transfer/exec errors | Re-run with `RCH_LOG_LEVEL=debug` to surface the real error, and check `rch daemon logs -n 200` for the daemon side. |
-| `toolchain missing on <worker>` | Remote `rustup`/`cargo` not present, or no default toolchain | `rch workers sync-toolchain --all` (or just for that worker). Then `rch workers capabilities --refresh`. |
+| `toolchain missing on <worker>` | Remote `rustup`/`cargo` not present, or no default toolchain | Diagnose the gap (autonomous). `rch workers sync-toolchain --all` (or one worker) mutates the worker — get caller authorization first; then `rch workers capabilities --refresh`. |
 
 ### Daemon-decision fail-opens (selection reasons)
 
@@ -72,12 +72,12 @@ These come from the daemon's `SelectionReason` enum. The `[RCH] local (...)` sum
 
 | Snake_case tag (JSON) | Human form in `local (...)` summary | Self-fix |
 |---|---|---|
-| `no_workers_configured` | `no workers configured` | `rch workers discover --add --yes && rch workers setup --all`. |
-| `all_workers_unreachable` | `all workers unreachable` | `rch workers probe --all`; fix SSH (key path, host, port). See `SSH_TUNING.md`. |
+| `no_workers_configured` | `no workers configured` | `rch workers discover --add --yes && rch workers setup --all` adds and provisions workers — a fleet mutation; get caller authorization first. |
+| `all_workers_unreachable` | `all workers unreachable` | `rch workers probe --all` and read the SSH errors (autonomous); fixing a local key's permissions is local, but changing anything on a worker is remote mutation → authorize first. See `RECOVERY_PLAYBOOKS.md` Playbook C and the Network rows of `ERROR_CODES.md`. |
 | `all_circuits_open` | `all worker circuits open` | A worker hit repeated failures and tripped its circuit. Inspect with `rch --json status --workers \| jq '.data.daemon.workers[] \| {id, circuit_state, last_error, recovery_in_secs}'` and `rch daemon logs -n 200`. Use `rch workers enable <id>` after fixing the underlying cause; circuits also auto-close after the cooldown. |
 | `all_workers_busy` | `all workers at capacity` | Queueing is **on by default** (`RCH_QUEUE_WHEN_BUSY=1`); seeing this means the wait timed out. Bump `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` for the next invocation, or raise `total_slots`. Check `rch queue --watch` to see backlog. |
 | `all_workers_failed_preflight` | `all workers failed preflight checks` | Path-topology check, repo presence, or toolchain probe failed on every candidate. Re-run with `rch diagnose --dry-run "<command>"` to see the preflight pipeline; hits `RCH-E013..024`, `RCH-E205`, `RCH-E305`. |
-| `all_workers_failed_convergence` | `all workers failed repo convergence checks` | The repo updater contract couldn't bring required repos to a target state on any worker. Check that the sibling repos exist on workers under the canonical root. See `PATH_DEPENDENCIES.md`. |
+| `all_workers_failed_convergence` | `all workers failed repo convergence checks` | The repo updater contract couldn't bring required repos to a target state on any worker. Check that the sibling repos exist on workers under the canonical root. See the RCH-E013–E020 rows in `ERROR_CODES.md` and the path-dep section of `TROUBLESHOOTING.md`. |
 | `no_matching_workers` | `no matching workers found` | The project requires tags (e.g., `tags = ["bun"]`) and no worker carries them. `rch workers list --json` to inspect tags; add the tag to a capable worker. |
 | `no_workers_with_runtime` (value = runtime name) | `no workers with bun installed` (or `node`, `rust`, …) | Install the runtime on a worker, then `rch workers capabilities --refresh`. |
 | `selection_error` (value = error text) | `selection error: <msg>` | An internal error during selection. Check `rch daemon logs -n 200`. Likely a code-side bug; capture `rch doctor --json` and `rch --json daemon status` for escalation. |
@@ -139,15 +139,59 @@ If that prints `[RCH] remote <worker> (...)`, the offload path is healthy and th
 
 ---
 
-## "Don't Ask the Human" Rules
+## Autonomous Remediation Envelope (and Where It Stops)
 
-The skill exists so agents resolve these things autonomously. Concrete cases where the answer is **always do, never ask**:
+The skill resolves diagnosis autonomously — but the SKILL.md authority boundary
+governs, and this file does not widen it. Two tiers:
 
-- **"daemon unavailable"** → `rch daemon start && rch --json daemon status`. If the auto-start cooldown is active, wait or remove `${XDG_RUNTIME_DIR:-/tmp}/rch/hook_autostart.cooldown` and try again.
-- **"all workers unreachable"** → `rch workers probe --all` and inspect SSH errors. Don't ask "should I fix this?" — fix what's fixable (key permissions, missing host entries, dead daemon).
-- **"all workers at capacity"** → queueing is already on by default; bump `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` to wait longer, or raise `total_slots` if the fleet is genuinely undersized.
-- **"toolchain missing on X"** → `rch workers sync-toolchain --all`. The skill is designed for you to do this without confirmation.
-- **Stale unix socket detected** (auto-start log message) → already handled by `try_auto_start_daemon`. Don't manually `rm` the socket; just retry.
-- **Permission denied on `/data/projects/<repo>` over rsync** → if the repo on the worker is owned by `root`: `ssh ubuntu@<host> 'sudo chown -R ubuntu:ubuntu /data/projects/<repo> && sudo chmod 775 /data/projects/<repo>'`. This is a known recovery; don't escalate.
+**Autonomous (no need to ask) — the blast-radius ceiling.** Read-only diagnosis
+and reversible, local-only actions on *this* machine:
 
-When in genuine doubt — escalate after collecting `rch doctor --json`, `rch --json daemon status`, `rch --json workers probe --all`, and the failing command's stderr. That packet lets the human resolve in one round trip.
+- reading summary lines, stderr, and `rch daemon logs`;
+- `rch check`, `rch diagnose`, `rch --json ... probe/status/get/show`, `rch
+  config validate|doctor|show|get` — inspection, never mutation;
+- tuning env vars for the *next* invocation (`RCH_VISIBILITY`, `RCH_LOG_LEVEL`,
+  `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120`, `RCH_SSH_SERVER_ALIVE_INTERVAL_SECS`);
+- re-running the original command, including waiting out an auto-start cooldown
+  (the built-in `try_auto_start_daemon` handles stale sockets — do not `rm` them);
+- local, reversible hook repair on this machine (`rch hook status|install|test`);
+- fixing permissions on a **local** key file you own (`chmod 600 ~/.ssh/<key>`).
+
+**Requires explicit caller authorization first — even when a reason maps
+straight to one of these commands.** Anything remote, privileged, deployment-
+scale, daemon-lifecycle, or destructive crosses the ceiling:
+
+- **remote host mutation** — any `ssh … sudo …`, remote `chown`/`chmod`/`rm`,
+  remote installs, changing a worker's `authorized_keys` or its host-key entry;
+- **worker / fleet deployment** — `rch workers sync-toolchain`, `workers
+  setup`, `workers deploy-binary`, `workers discover --add`, `workers
+  drain|disable|enable`, `rch fleet deploy|rollback`;
+- **daemon lifecycle / configuration** — manually `rch daemon start|restart|
+  reload`, `rch config set`, editing `~/.config/rch/*.toml`;
+- **destructive local cleanup** — removing sockets, cooldown/lock files, caches,
+  or moving the telemetry DB aside.
+
+For each reason, run the autonomous diagnosis, then, if the fix is above the
+ceiling, capture the evidence and get authorization before running it:
+
+- **"daemon unavailable"** → confirm with `rch --json daemon status`; wait out
+  the auto-start cooldown and retry (autonomous). Manually starting/restarting
+  the daemon, or removing the cooldown file, needs authorization.
+- **"all workers unreachable"** → `rch workers probe --all` and read the SSH
+  errors (autonomous); fixing a local key's permissions is local. Changing
+  anything **on** a worker (host-key entry, `authorized_keys`, restarting
+  `sshd`) is remote mutation → get authorization.
+- **"all workers at capacity"** → queueing is on by default; bump
+  `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` for the next run (autonomous).
+  Raising `total_slots` edits worker config → authorization.
+- **"toolchain missing on X"** → diagnose the gap (autonomous); running `rch
+  workers sync-toolchain` mutates the worker → get authorization first.
+- **Permission denied on `/data/projects/<repo>` over rsync** → the fix is a
+  remote privileged command (`ssh … 'sudo chown -R …'`). Report it to the
+  caller with the failing `stat` and get explicit authorization before running
+  it — remote `sudo` is never autonomous.
+
+When a fix is above the ceiling or you are in genuine doubt, surface the packet —
+`rch doctor --json`, `rch --json daemon status`, `rch --json workers probe
+--all`, the failing command's stderr, and the exact command you propose — so the
+caller can authorize (or decline) in one round trip.

--- a/skills-codex/rch/references/RECOVERY_PLAYBOOKS.md
+++ b/skills-codex/rch/references/RECOVERY_PLAYBOOKS.md
@@ -42,7 +42,7 @@ RCH_VISIBILITY=verbose cargo check 2>&1 | grep -E '^\[RCH\]'
 **Fix attempts:**
 
 1. If you see `[RCH] local (...)` — open `references/FAIL_OPEN.md` and look up the parenthetical reason. Apply the matching self-fix.
-2. If you see no `[RCH]` line at all — the hook isn't intercepting. Run `rch hook status`. If not installed: `rch hook install`. If installed but not firing: `rch hook test`.
+2. If you see no `[RCH]` line at all — the hook isn't intercepting. Run `rch hook status` and `rch hook test` (autonomous). If not installed, `rch hook install` writes `~/.claude/settings.json` — **(authorize first)**.
 3. If you see `[RCH] remote ...` — RCH is doing what it can; the slowness is real. Inspect `rch speedscore --all` and consider whether the project warrants a faster worker.
 
 **Verify:**
@@ -107,7 +107,7 @@ rch --json workers probe --all | jq '.data[] | {id, status, last_error}'
 1. **Verify queueing is on** — `RCH_QUEUE_WHEN_BUSY` is **already enabled by default** in current rch (only set `=0` to disable). If you still see `all workers at capacity`, queueing didn't help — the wait timed out.
 2. Bump the wait timeout for the next invocation: `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120 <your-command>`.
 3. Check whether one worker is hot and others are cold (uneven distribution): `rch --json status --workers | jq '.data.daemon.workers[] | {id, used: .used_slots, total: .total_slots}'`.
-4. If aggregate capacity is the problem, raise `total_slots` on top workers in `~/.config/rch/workers.toml`, then `rch daemon reload`.
+4. If aggregate capacity is the problem, raising `total_slots` on top workers in `~/.config/rch/workers.toml` and `rch daemon reload` both mutate config/daemon — **(authorize first)**.
 5. Watch the backlog drain: `rch queue --watch` (this is an interactive polling view, not a TUI — Ctrl-C exits cleanly).
 
 **Verify:** Next `rch exec` lands `[RCH] remote <worker> (...)`.
@@ -188,8 +188,8 @@ cat ~/.claude/settings.json 2>/dev/null | jq '.hooks.PreToolUse'
 
 **Fix attempts:**
 
-1. Hook not installed → `rch hook install` (or `rch agents install-hook claude-code`).
-2. Hook command path is wrong → `rch hook install` re-resolves to the current absolute path.
+1. Hook not installed → `rch hook install` (or `rch agents install-hook claude-code`) writes `~/.claude/settings.json` — **(authorize first)**.
+2. Hook command path is wrong → `rch hook install` re-resolves to the current absolute path — same host write, **(authorize first)**.
 3. The Claude Code session predates the hook install → restart Claude Code (the harness only loads hooks on startup).
 4. Hook installed but fires for a different agent → confirm `rch agents list --json` includes the agent you're running under.
 
@@ -262,7 +262,7 @@ rch self-test history --limit 5 --json
 **Fix attempts:**
 
 1. Try a single worker with `--timeout 120 --debug`. If that works, the `--all` mode is hitting a slow worker — narrow down with `rch speedscore --all`.
-2. If self-test hangs against any single worker, that worker has a deeper problem. `rch workers probe <id>`, then drain it (`rch workers drain <id>`) and continue without it.
+2. If self-test hangs against any single worker, that worker has a deeper problem. `rch workers probe <id>` (autonomous); draining it (`rch workers drain <id>`) mutates worker state — **(authorize first)** — then continue without it.
 3. Capture a full doctor report: `rch doctor --json > /tmp/rch-doctor.json`. The pre-v1.0.16 self-test hang bug is fixed; if you reproduce on current rch, escalate with the doctor output.
 
 ---
@@ -278,7 +278,7 @@ rch config show --sources
 rch config diff                      # what differs from defaults
 ```
 
-If `rch config validate` flags an issue, fix the indicated line and `rch daemon reload`. If you can't see what's wrong, `git diff` of the config (if you keep it under version control) is your friend. Otherwise `rch config init` writes a clean baseline you can compare against.
+The four `rch config` inspection commands above are autonomous. If `rch config validate` flags an issue, fixing the indicated line and `rch daemon reload` both mutate config/daemon — **(authorize first)**. `git diff` of the config (if version-controlled) is a read-only aid; `rch config init` overwrites a clean baseline — **(authorize first)**.
 
 ---
 

--- a/skills-codex/rch/references/RECOVERY_PLAYBOOKS.md
+++ b/skills-codex/rch/references/RECOVERY_PLAYBOOKS.md
@@ -16,7 +16,15 @@
 - [Playbook L: TOML/config edit broke things](#playbook-l-tomlconfig-edit-broke-things)
 - [When the Playbook Doesn't Apply](#when-the-playbook-doesnt-apply)
 
-Each playbook is structured as: **observed signal → one-shot diagnostic → ordered fix attempts → verification**. Run them in order. Don't skip the diagnostic. Don't ask the human if the fix is in the playbook.
+Each playbook is structured as: **observed signal → one-shot diagnostic → ordered fix attempts → verification**. Run them in order; don't skip the diagnostic.
+
+Diagnostics and reversible, local-only fixes run autonomously. Any step that
+mutates a remote worker, runs `sudo`, starts/restarts/reconfigures the daemon,
+deploys binaries or toolchains, or deletes state requires explicit caller
+authorization **first** — the SKILL.md authority boundary governs, and a playbook
+listing a command does not pre-authorize it (see `FAIL_OPEN.md` §"Autonomous
+Remediation Envelope"). Where a step below crosses that ceiling it is marked
+**(authorize first)**.
 
 For unknown symptoms or a stuck loop, fall through to the bottom of this file ("When the Playbook Doesn't Apply") for the escalation packet.
 
@@ -62,8 +70,8 @@ ls -la "${XDG_RUNTIME_DIR:-/tmp}/rch/" 2>&1
 1. If `which rchd` is empty → daemon binary missing. Install rch (see project README).
 2. If autostart cooldown is recent → wait 5–10 seconds and retry the original command.
 3. If autostart lock is held by no process → it's stale. Ask user authorization, then `rm "${XDG_RUNTIME_DIR:-/tmp}/rch/hook_autostart.lock"`.
-4. Foreground spawn to surface the real error: `rch daemon start`. Read its stderr.
-5. If `rch daemon start` succeeds but the hook still doesn't see the daemon, check socket consistency: `rch --json config get general.socket_path` and `rch --json daemon status | jq '.data.socket_path'` must match. If they don't: `rch daemon restart -y`.
+4. Foreground spawn to surface the real error: `rch daemon start` **(authorize first)** — starting the daemon is a lifecycle mutation. Read its stderr.
+5. If `rch daemon start` succeeds but the hook still doesn't see the daemon, check socket consistency: `rch --json config get general.socket_path` and `rch --json daemon status | jq '.data.socket_path'` must match (autonomous inspection). If they don't: `rch daemon restart -y` **(authorize first)**.
 
 **Verify:** `rch check` returns `ready`.
 
@@ -118,9 +126,9 @@ RCH_LOG_LEVEL=debug rch exec -- env CARGO_TARGET_DIR="${TMPDIR:-/tmp}/rch_target
 
 **Fix attempts:**
 
-1. If a path-dep error (RCH-E013..016) → see `PATH_DEPENDENCIES.md` for the exact code.
-2. If `RCH_TOPOLOGY_ERR_CANONICAL_NOT_DIRECTORY` or `_ALIAS_NOT_SYMLINK` in worker stderr → fix the topology on the worker (`/data/projects` should be a directory; `/dp` should be a symlink to it).
-3. If `RCH-E205 Worker missing toolchain` → `rch workers sync-toolchain --all`.
+1. If a path-dep error (RCH-E013..016) → see the RCH-E013–E020 rows in `ERROR_CODES.md` and the path-dep section of `TROUBLESHOOTING.md` for the exact code.
+2. If `RCH_TOPOLOGY_ERR_CANONICAL_NOT_DIRECTORY` or `_ALIAS_NOT_SYMLINK` in worker stderr → fixing the topology on the worker (`/data/projects` should be a directory; `/dp` should be a symlink to it) is remote mutation **(authorize first)**.
+3. If `RCH-E205 Worker missing toolchain` → `rch workers sync-toolchain --all` **(authorize first)** — it mutates the worker.
 4. If `RCH-E305 Remote working dir error` → typically mirror perms broken; see Playbook F.
 
 **Verify:** `rch diagnose --dry-run "<command>"` reports `Ready` for the closure plan.
@@ -136,9 +144,12 @@ RCH_LOG_LEVEL=debug rch exec -- env CARGO_TARGET_DIR="${TMPDIR:-/tmp}/rch_target
 ssh ubuntu@<worker> "stat -c '%U:%G %a %n' /data/projects/<repo>"
 ```
 
-**Fix:**
+**Fix (authorize first):** the repair is a remote privileged command. Report the
+failing `stat` and the exact command to the caller and get explicit
+authorization before running it — remote `sudo` is never autonomous.
 
 ```bash
+# after explicit caller authorization only:
 ssh ubuntu@<worker> 'sudo chown -R ubuntu:ubuntu /data/projects/<repo> && sudo chmod 775 /data/projects/<repo>'
 rch exec -- env CARGO_TARGET_DIR="${TMPDIR:-/tmp}/rch_target_$(basename "$PWD")" cargo check
 ```
@@ -151,7 +162,7 @@ If you see this on multiple repos, audit who's doing `sudo git clone` or running
 
 **Signal:** `[RCH] remote <worker> failed [RCH-E210]` (or `E211/E215/E216/E217`); or `rch status` calls out a worker as critical.
 
-See the dedicated `DISK_AND_PRESSURE.md`. TL;DR:
+See the RCH-E210–E217 rows in `ERROR_CODES.md` and hand disk reclaim to the `sbh` skill. TL;DR:
 
 ```bash
 rch --json status --workers | jq '.data.daemon.workers[] | select(.pressure_state != "healthy") | {id, pressure_state, pressure_reason_code, pressure_disk_free_gb}'
@@ -220,18 +231,21 @@ rch fleet status --json    # exact JSON shape varies by version; inspect first
 rch fleet verify           # human-readable comparison of installed binaries
 ```
 
-**Fix:**
+**Fix (authorize first):** fleet deployment mutates every worker binary. Present
+the `rch fleet status`/`verify` evidence and the proposed rollout to the caller
+and get explicit authorization before any `deploy`/`rollback`.
 
 ```bash
+# after explicit caller authorization only:
 rch fleet deploy --canary 25 --canary-wait 60 --verify
 # observe output, then
 rch fleet deploy --verify           # full rollout
 rch fleet verify                    # confirm uniform
 ```
 
-If rollback is needed: `rch fleet rollback --verify`.
+If rollback is needed (also authorize first): `rch fleet rollback --verify`.
 
-For a single worker, `rch fleet deploy --worker <id> --verify` (deploy, single host).
+For a single worker, `rch fleet deploy --worker <id> --verify` (deploy, single host) — still authorize first.
 
 ---
 
@@ -249,7 +263,7 @@ rch self-test history --limit 5 --json
 
 1. Try a single worker with `--timeout 120 --debug`. If that works, the `--all` mode is hitting a slow worker — narrow down with `rch speedscore --all`.
 2. If self-test hangs against any single worker, that worker has a deeper problem. `rch workers probe <id>`, then drain it (`rch workers drain <id>`) and continue without it.
-3. Capture a full doctor report: `rch doctor --json > /tmp/rch-doctor.json`. The pre-v1.0.16 hang bug `bd-w5r9` is fixed; if you reproduce on current rch, escalate with the doctor output.
+3. Capture a full doctor report: `rch doctor --json > /tmp/rch-doctor.json`. The pre-v1.0.16 self-test hang bug is fixed; if you reproduce on current rch, escalate with the doctor output.
 
 ---
 

--- a/skills-codex/rch/references/TROUBLESHOOTING.md
+++ b/skills-codex/rch/references/TROUBLESHOOTING.md
@@ -89,7 +89,11 @@ rch workers setup --all
 
 **Cause:** missing toolchain on one or more workers.
 
+`rch workers sync-toolchain --all` mutates the workers — get explicit caller
+authorization first (`rch workers capabilities --refresh` after is read-only):
+
 ```bash
+# after explicit caller authorization only:
 rch workers sync-toolchain --all
 rch workers capabilities --refresh
 ```
@@ -142,9 +146,12 @@ Check:
 ssh ubuntu@<host> "stat -c '%U:%G %a %n' /data/projects/<repo>"
 ```
 
-Fix:
+Fix (authorize first): this is a remote privileged command. Report the failing
+`stat` output and the exact command to the caller and get explicit authorization
+before running it — remote `sudo` is never autonomous.
 
 ```bash
+# after explicit caller authorization only:
 ssh ubuntu@<host> 'sudo chown -R ubuntu:ubuntu /data/projects/<repo> && sudo chmod 775 /data/projects/<repo>'
 ```
 
@@ -219,8 +226,12 @@ RCH_LOG_LEVEL=debug printf '%s\n' \
 
 ## Safe Reset Sequence
 
+The `rch daemon restart -y` that opens this sequence is a daemon-lifecycle
+mutation — get explicit caller authorization before running it; the remaining
+steps are read-only.
+
 ```bash
-rch daemon restart -y
+rch daemon restart -y          # authorize first
 rch config validate
 rch config doctor
 rch workers probe --all
@@ -255,25 +266,28 @@ If a circuit doesn't auto-clear after 60 seconds and the underlying probe is hea
 
 **Symptom:** New rch CLI features behave inconsistently; `rch --version` differs from the daemon's reported version.
 
-**Self-fix (this is safe — never ask first):**
+**Diagnosis is autonomous; the restart is a daemon-lifecycle mutation — authorize first.**
 
-The daemon's running version is reported by `rch --json status` at `.data.daemon.daemon.version` (the `rch --json daemon status` endpoint deliberately returns only running/socket/uptime — not version). Compare:
+The daemon's running version is reported by `rch --json status` at `.data.daemon.daemon.version` (the `rch --json daemon status` endpoint deliberately returns only running/socket/uptime — not version). Compare (read-only):
 
 ```bash
 rch --version | awk '{print $2}'
 rch --json status | jq -r '.data.daemon.daemon.version'
-# If they differ:
+# If they differ, restart AFTER explicit caller authorization:
 rch daemon restart -y                                    # drains in-flight builds gracefully
 rch --json status | jq -r '.data.daemon.daemon.version'  # confirm equal
 ```
 
-`rch daemon restart -y` is the **documented upgrade path**. It drains active builds before stopping. The `-y` skips the interactive prompt — but it does *not* skip the drain.
+`rch daemon restart -y` is the **documented upgrade path**. It drains active builds before stopping. The `-y` skips the interactive prompt — but it does *not* skip the drain, and it does *not* skip the caller-authorization requirement.
 
-If a worker shows mismatched binary version after a host upgrade:
+If a worker shows mismatched binary version after a host upgrade, diagnose with
+`status`/`verify` (read-only), then deploy only after explicit caller
+authorization — fleet deploy mutates every worker binary:
 
 ```bash
-rch fleet status              # human-readable per-worker status
-rch fleet verify              # compare installed vs expected
+rch fleet status              # human-readable per-worker status (read-only)
+rch fleet verify              # compare installed vs expected (read-only)
+# after explicit caller authorization only:
 rch fleet deploy --canary 25 --canary-wait 60 --verify
 rch fleet deploy --verify
 ```
@@ -284,7 +298,7 @@ rch fleet deploy --verify
 
 **Symptom:** Recurring `RCH-E507`, `Telemetry database integrity check failed`, empty `rch speedscore --history`, daemon log lines mentioning `database disk image is malformed`.
 
-**Self-fix:** Stop the daemon, move `~/.local/share/rch/telemetry/telemetry.db*` aside, restart. Telemetry is derived data; you lose history but nothing operational.
+**Fix (authorize first):** stopping the daemon, moving `~/.local/share/rch/telemetry/telemetry.db*` aside, and restarting is a daemon-lifecycle mutation plus local file removal — get explicit caller authorization first. Telemetry is derived data; you lose history but nothing operational.
 
 ---
 

--- a/skills-codex/rch/references/TROUBLESHOOTING.md
+++ b/skills-codex/rch/references/TROUBLESHOOTING.md
@@ -52,14 +52,20 @@ Compilation running locally instead of remotely?
 
 ## Common Errors
 
+> **Authority:** only read-only diagnosis is autonomous. Any recipe below that
+> starts/restarts/reloads the daemon, adds/provisions/drains a worker or its
+> toolchain, edits config, installs the hook, or mutates a remote host requires
+> explicit caller authorization first — see `FAIL_OPEN.md` §"Autonomous
+> Remediation Envelope". Such steps are called out per block.
+
 ### Daemon not running / `check` says not ready
 
 **Cause:** daemon process absent or startup failure.
 
 ```bash
-rch daemon start
-rch --json daemon status
-rch daemon logs -n 200
+rch --json daemon status          # autonomous
+rch daemon logs -n 200            # autonomous
+rch daemon start                  # (authorize first) — daemon lifecycle
 ```
 
 ### Socket mismatch between config and daemon
@@ -67,10 +73,10 @@ rch daemon logs -n 200
 **Cause:** `general.socket_path` differs from active daemon socket.
 
 ```bash
-rch --json config get general.socket_path
-rch --json daemon status
-# then align and restart:
-rch daemon restart -y
+rch --json config get general.socket_path   # autonomous
+rch --json daemon status                     # autonomous
+# then align and restart AFTER explicit caller authorization:
+rch daemon restart -y                        # (authorize first)
 ```
 
 ### "No workers available" / probe failures
@@ -78,11 +84,12 @@ rch daemon restart -y
 **Cause:** no workers configured, SSH/auth failures, or workers are disabled/drained.
 
 ```bash
-rch workers list
-rch workers probe --all
-rch workers discover --probe
-rch workers discover --add --yes
-rch workers setup --all
+rch workers list                  # autonomous
+rch workers probe --all           # autonomous
+rch workers discover --probe      # autonomous (probe only)
+# adding/provisioning workers mutates the fleet — authorize first:
+rch workers discover --add --yes  # (authorize first)
+rch workers setup --all           # (authorize first)
 ```
 
 ### "rustup: not found" / "cargo: not found" on worker
@@ -105,10 +112,10 @@ If still failing, SSH to the specific worker and validate `rustup`, `cargo`, and
 **Cause:** hook missing, wrong binary path, or command classified as local.
 
 ```bash
-rch hook status
-rch hook install
-rch hook test
-rch diagnose "cargo build --release"
+rch hook status                        # autonomous
+rch hook test                          # autonomous
+rch diagnose "cargo build --release"   # autonomous
+rch hook install                       # (authorize first) — writes ~/.claude/settings.json
 ```
 
 ### Sync/transfer fails under active target churn
@@ -116,9 +123,10 @@ rch diagnose "cargo build --release"
 **Cause:** build artifacts changing during rsync.
 
 ```bash
-# Add target-like excludes in ~/.config/rch/config.toml [transfer].exclude_patterns
-rch daemon reload
-rch config show --sources
+# Editing ~/.config/rch/config.toml [transfer].exclude_patterns and reloading
+# both mutate config/daemon — (authorize first):
+rch daemon reload                 # (authorize first)
+rch config show --sources         # autonomous
 ```
 
 Also inspect the worker directly:
@@ -314,7 +322,7 @@ rch fleet deploy --verify
    printf '%s\n' '{"tool_name":"Bash","tool_input":{"command":"<your-command>"}}' | rch
    ```
    If stdout is empty, the classifier is rejecting your command. Common causes: shell pipe (`cargo build | tee log`), backgrounded with `&`, env-prefixed in an unusual form. Restructure or use `rch exec -- <cmd>` directly.
-3. If the hook fires but the command still runs locally, the rewrite isn't being honored — check that `~/.claude/settings.json` has the right hook command path (`rch hook install` re-resolves it).
+3. If the hook fires but the command still runs locally, the rewrite isn't being honored — check that `~/.claude/settings.json` has the right hook command path (reading it is autonomous; `rch hook install` re-resolves it but writes that file — **(authorize first)**).
 
 See `references/FAIL_OPEN.md` for the full taxonomy.
 

--- a/skills-codex/rch/references/WORKERS.md
+++ b/skills-codex/rch/references/WORKERS.md
@@ -10,6 +10,15 @@
 - [Worker Selection Notes](#worker-selection-notes)
 - [SSH Verification Shortcuts](#ssh-verification-shortcuts)
 
+> **Authority:** this is a command catalog, not a licence to run it. Only the
+> read-only probes here (`rch workers list`, `rch workers probe`, `rch fleet
+> status`, `rch fleet verify`) are autonomous. Everything that adds, sets up,
+> drains, disables, enables, syncs a toolchain to, or deploys a binary to a
+> worker — and every `rch fleet deploy|rollback` — is a host mutation requiring
+> explicit caller authorization first (see `FAIL_OPEN.md` §"Autonomous
+> Remediation Envelope"). The `--dry-run` variants shown are the read-only way to
+> preview before you ask.
+
 ## Worker Lifecycle
 
 ### 1) Discover and add workers

--- a/skills-codex/swarm/.agentops-generated.json
+++ b/skills-codex/swarm/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/swarm",
   "layout": "modular",
-  "source_hash": "460a78219f0470cfc5423298dd3b3e4bc1a5a6704866564838a79aafb69cb231",
-  "generated_hash": "1a3ffdc203fea5bad5e70b13a06992f3c033c57f28dbab9cae26c963d8088c39"
+  "source_hash": "e8ddab659c2ad4500bb2d2fd996b7e741199cba2ee602cc605fbb983216c5441",
+  "generated_hash": "6320a426d70b27346b32f599445ac8e986d3f68847614fe59537b0a313012705"
 }

--- a/skills-codex/swarm/SKILL.md
+++ b/skills-codex/swarm/SKILL.md
@@ -15,6 +15,14 @@ The caller supplies every complete packet, proves their write scopes disjoint,
 and chooses the executor. Swarm dispatches each packet once, preserves packet and
 context identities, collects results, and stops.
 
+Write scopes must be **workspace-relative and canonical** — symlink-resolved and
+already normalized. The disjointness check is lexical: it case-folds prefixes so
+scopes differing only by case are treated as a collision (safe on
+case-insensitive filesystems), but it cannot see a symlink that aliases two
+scopes onto one target. Supplying non-canonical or symlinked scopes forfeits the
+disjointness guarantee; a non-empty `write_scope.exclude` is rejected, not
+silently ignored, because the proof cannot honor it.
+
 Exactly-once dispatch over proven-disjoint scopes is why parallel failures stay
 independent: no packet can observe, block, or corrupt another, so N packets
 yield N verdicts about N experiments rather than one tangle.
@@ -31,6 +39,11 @@ The reference implementation is [`scripts/dispatch_once.py`](scripts/dispatch_on
 It validates the entire explicit batch before the first call, invokes the supplied
 executor exactly once for each packet, and returns executor exceptions as factual
 per-packet errors.
+
+Swarm's own effect is invoking the selected executor once per packet; the real
+blast radius rides on the packets. Each packet's transitive effects — whatever
+its executor writes, runs, or reaches — are the caller's to declare on the
+packet, not Swarm's to bound.
 
 Swarm does not select work, create packets, schedule from a backlog, persist a
 queue, claim ownership, retry, validate, integrate, close, use Git, or deliver.

--- a/skills-codex/swarm/scripts/dispatch_once.py
+++ b/skills-codex/swarm/scripts/dispatch_once.py
@@ -19,6 +19,14 @@ def _includes(packet: Mapping[str, Any]) -> tuple[str, ...]:
     scope = packet.get("write_scope")
     if not isinstance(scope, Mapping):
         raise ValueError(f"{_packet_id(packet)}: write_scope must be an object")
+    # `exclude` is not honored by the lexical disjointness proof below. Admitting
+    # it silently would let a packet look narrower than it dispatches, so reject
+    # its presence rather than ignore it.
+    if scope.get("exclude"):
+        raise ValueError(
+            f"{_packet_id(packet)}: write_scope.exclude is not honored by the "
+            "disjointness proof — remove it or narrow include instead"
+        )
     raw = scope.get("include")
     if not isinstance(raw, list) or not raw:
         raise ValueError(f"{_packet_id(packet)}: write_scope.include must be nonempty")
@@ -49,8 +57,14 @@ def _overlap(left: str, right: str) -> bool:
             parts.append(part)
         return PurePosixPath(*parts).as_posix() if parts else "."
 
-    left_prefix = literal_prefix(left)
-    right_prefix = literal_prefix(right)
+    # Case-fold the comparison so scopes differing only by case ("src/Auth" vs
+    # "src/auth") are treated as a possible collision. On a case-insensitive
+    # filesystem they ARE the same path; on a case-sensitive one this only
+    # over-rejects, matching this module's reject-when-uncertain stance. Paths
+    # must already be workspace-relative and canonical (symlink-resolved): the
+    # check is lexical and cannot detect a symlink alias to a shared target.
+    left_prefix = literal_prefix(left).casefold()
+    right_prefix = literal_prefix(right).casefold()
     if left_prefix == "." or right_prefix == ".":
         return True
     return (

--- a/skills-codex/swarm/tests/test_dispatch_once.py
+++ b/skills-codex/swarm/tests/test_dispatch_once.py
@@ -87,6 +87,34 @@ class DispatchOnceTests(unittest.TestCase):
                 lambda _value: None,
             )
 
+    def test_case_only_scope_difference_is_rejected(self) -> None:
+        calls = 0
+
+        def executor(_value: dict) -> None:
+            nonlocal calls
+            calls += 1
+
+        with self.assertRaisesRegex(ValueError, "write scopes overlap"):
+            MODULE.dispatch_once(
+                [packet("a", "src/Auth"), packet("b", "src/auth")], executor
+            )
+        self.assertEqual(calls, 0)
+
+    def test_nonempty_exclude_is_rejected_not_ignored(self) -> None:
+        with self.assertRaisesRegex(ValueError, "exclude is not honored"):
+            MODULE.dispatch_once(
+                [
+                    {
+                        "packet_id": "a",
+                        "write_scope": {
+                            "include": ["src/a"],
+                            "exclude": ["src/a/skip"],
+                        },
+                    }
+                ],
+                lambda _value: None,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/using-gc",
   "layout": "modular",
-  "source_hash": "f51ea2cdeb1bec02b84045767a9ff6b095bc45918b28c77e3342de8f1f384783",
-  "generated_hash": "0f2dbc05aecde36e4ed390beb9d65e7c75c2ac70fb4fb70870d00ad7eca6c67d"
+  "source_hash": "9157f6ec6c0c6b75fd91dff9e0c09645aff069d545b89c3b0c887745c4d7c8c2",
+  "generated_hash": "80f9faaf4f4fcb38b6b46d5d9a54e594a14d25624a061057d05be493f275b75a"
 }

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/using-gc",
   "layout": "modular",
-  "source_hash": "0cb0e528e918fda28e1bb45b599f47013db377d7793c761eae7e6ff26750872d",
-  "generated_hash": "aca67da82384024023ff901b57ef7baebad71097dc152638c65afa52861222e9"
+  "source_hash": "f51ea2cdeb1bec02b84045767a9ff6b095bc45918b28c77e3342de8f1f384783",
+  "generated_hash": "0f2dbc05aecde36e4ed390beb9d65e7c75c2ac70fb4fb70870d00ad7eca6c67d"
 }

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -61,7 +61,9 @@ wedged on an interactive prompt doing nothing. Trust ground truth:
   ones `mayor status` prints in its `tmux -L <socket> attach -t <session>` line.
 - Two known codex wedge classes and their durable fixes:
   - **Update nag:** codex blocks on an "update available" prompt. Fix: update
-    codex so no pending-update prompt exists before the run.
+    codex so no pending-update prompt exists before the run. Updating the codex
+    binary is a host mutation — make it only with explicit caller authorization,
+    the same bar as the trust-config edit below.
   - **Folder trust:** codex blocks asking to trust the working directory. Fix:
     add exact-path `trust_level` entries for the rig and worktree-root in
     `~/.codex/config.toml` (bootstrap does not write them yet). This edits the

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -57,12 +57,16 @@ wedged on an interactive prompt doing nothing. Trust ground truth:
 
 - `gc session list --json` / `mayor status` is the roster claim.
 - `tmux -L <socket> capture-pane -pt <session>` is ground truth — read the pane.
+  The `<socket>` and `<session>` here (and at every `tmux -L` site below) are the
+  ones `mayor status` prints in its `tmux -L <socket> attach -t <session>` line.
 - Two known codex wedge classes and their durable fixes:
   - **Update nag:** codex blocks on an "update available" prompt. Fix: update
     codex so no pending-update prompt exists before the run.
   - **Folder trust:** codex blocks asking to trust the working directory. Fix:
     add exact-path `trust_level` entries for the rig and worktree-root in
-    `~/.codex/config.toml` (bootstrap does not write them yet).
+    `~/.codex/config.toml` (bootstrap does not write them yet). This edits the
+    user's global codex config — a host-configuration mutation; make it only
+    with explicit caller authorization, scoped to those exact paths.
 
 When the roster says active but the pane is wedged, the pane wins.
 

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -48,15 +48,15 @@
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | - |
+| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
 | `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | `run_codex_process`, `sandbox_tiered_workspace_and_network_effects` |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | - |
-| `doc` | product | `keep_specialist` | - | `doc` | - |
+| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
 | `handoff` | session | `keep_specialist` | - | `handoff` | - |
@@ -73,21 +73,21 @@
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
 | `rch` | execution | `keep_specialist` | - | `rch` | `remote_compilation_offload`, `authorized_remote_daemon_worker_mutation` |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
-| `research` | execution | `keep_specialist` | - | `research` | - |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
+| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | - |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | - |
+| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | - |
+| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city`, `configure_codex_trust` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -43,20 +43,20 @@
 | Skill | Tier | Disposition | Hard dependencies | Capabilities | Effects |
 |---|---|---|---|---|---|
 | `account-rotation` | execution | `keep_specialist` | - | `account_rotation` | - |
-| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | - |
+| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | `write_agent_mail_records`, `install_precommit_guard`, `authorized_destructive_reset` |
 | `agent-native` | meta | `keep_optional_adapter` | - | `role_dispatch`, `observe_workers`, `handoff` | `manage_runtime_sessions` |
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
+| `cass` | execution | `keep_specialist` | - | `cass` | - |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
-| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
+| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | `run_codex_process`, `sandbox_tiered_workspace_and_network_effects` |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | - |
-| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
+| `doc` | product | `keep_specialist` | - | `doc` | - |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
 | `handoff` | session | `keep_specialist` | - | `handoff` | - |
@@ -64,30 +64,30 @@
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |
 | `learn` | execution | `keep_off_path` | - | `analyze_verdict_collections` | `write_advisory_observations` |
 | `ms` | execution | `keep_specialist` | - | `ms` | - |
-| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | - |
+| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | `manage_ntm_panes`, `dispatch_pane_commands` |
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
 | `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | `write_pattern_evidence` |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
 | `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
-| `rch` | execution | `keep_specialist` | - | `rch` | - |
+| `rch` | execution | `keep_specialist` | - | `rch` | `remote_compilation_offload`, `authorized_remote_daemon_worker_mutation` |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
-| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
+| `research` | execution | `keep_specialist` | - | `research` | - |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | - |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
+| `security` | product | `keep_specialist` | - | `security` | - |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | - |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
+| `test` | execution | `keep_specialist` | - | `test` | - |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
-| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
+| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city`, `configure_codex_trust` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |

--- a/skills/agent-mail/SKILL.md
+++ b/skills/agent-mail/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 skill_api_version: 1
 hexagonal_role: supporting
 consumes:
-- task-intent
+- coordination-request
 produces:
 - agent-identity
 - file-reservation
@@ -14,7 +14,7 @@ context_rel:
   with: agent-native
 metadata:
   capabilities: [agent_mail]
-  effects: []
+  effects: [write_agent_mail_records, install_precommit_guard, authorized_destructive_reset]
   canonical_status: canonical
   disposition: keep_optional_adapter
   tier: execution
@@ -30,9 +30,10 @@ Agent Mail carries messages, acknowledgements, identities, and temporary file
 reservations. It is not a task tracker, queue, proof ledger, or lifecycle
 controller.
 
-Reservations prevent collisions only because every cooperating writer checks
-them against the same absolute project path; one writer registered against a
-different path resolution makes the whole ledger advisory fiction.
+Reservations are **advisory**: they prevent collisions only because every
+cooperating writer checks them against the same absolute project path, and one
+writer registered against a different path resolution makes the whole ledger
+advisory fiction. Agent Mail enforces nothing on a writer that does not check.
 
 Named failure mode — **silence-as-status**: reading an unanswered thread as
 "work stalled" or "work done"; mail silence proves only that no mail arrived.
@@ -51,8 +52,27 @@ changes are the caller's call.
 - Mail silence proves nothing about work status.
 - A message or acknowledgement is evidence that communication occurred, not
   evidence that a change is correct or complete.
+- Release a reservation, including any `force_release`, only on the caller's
+  explicit request for that exact reservation. Force-release has no autonomous
+  trigger; a conflict is reported, not force-cleared.
 - Agent Mail never selects work, changes tracker state, commits code, validates,
   integrates, closes, releases, or delivers work.
+
+## Modes and authority
+
+Two disjoint surfaces; do not reach the second from the first:
+
+- **Coordination mode (default).** Register identity, reserve/release the
+  caller's paths, send/read/acknowledge the caller's threads. This is the whole
+  of routine use, and all of it writes durable Agent Mail records.
+- **Admin / disaster-recovery mode (explicitly caller-authorized only).**
+  Installing the git pre-commit guard, `doctor repair`, backup/restore, and the
+  irreversible `clear-and-reset-everything` are a separate mode. Each requires
+  the caller's explicit authorization for that specific operation; none is ever
+  performed as a side effect of coordination. `clear-and-reset-everything`
+  deletes the database and all storage and cannot be undone — never run it, even
+  with `--force`, without an explicit destructive-reset authorization from the
+  caller.
 
 ## Surfaces
 
@@ -73,9 +93,21 @@ from remembered aliases.
 
 ## Output
 
-Return the project, identity, thread/message ids, reservation ids and paths,
-conflicts, timestamps, and any degraded or unavailable surface. The caller owns
-all subsequent decisions.
+Return the project, identity, thread/message ids, reservation ids and paths
+(with their TTLs), conflicts, and timestamps. The caller owns all subsequent
+decisions.
+
+Terminal outcomes are explicit, never silent:
+
+- **Adapter unavailable** — neither the MCP tools nor the `am` CLI is present:
+  report that Agent Mail is unavailable and stop. Do not fall back to
+  hand-written coordination or treat the absence as "no conflicts".
+- **Reservation conflict** — report the conflicting reservation as-is; do not
+  narrow, widen, renew, or force-release it.
+- **Timeout / degraded surface** — report the operation as timed out or degraded
+  with what was and was not observed; a timeout is evidence, not "done".
+- **Cleanup** — reservations released this session are listed by id; any left
+  in place (still holding a TTL) are named so the caller can see what remains.
 
 ## References
 

--- a/skills/agent-mail/references/RECOVERY.md
+++ b/skills/agent-mail/references/RECOVERY.md
@@ -20,16 +20,16 @@ curl http://127.0.0.1:8765/health   # only if the HTTP MCP server is running (am
 
 ```bash
 # Basic check
-uv run python -m mcp_agent_mail.cli doctor check
+am doctor check
 
 # Verbose with details
-uv run python -m mcp_agent_mail.cli doctor check --verbose
+am doctor check --verbose
 
 # JSON output for automation
-uv run python -m mcp_agent_mail.cli doctor check --json
+am doctor check --json
 
 # Check specific project
-uv run python -m mcp_agent_mail.cli doctor check /abs/path/project
+am doctor check /abs/path/project
 ```
 
 **Checks performed:**
@@ -42,7 +42,7 @@ uv run python -m mcp_agent_mail.cli doctor check /abs/path/project
 ### Preview Repairs (Dry Run)
 
 ```bash
-uv run python -m mcp_agent_mail.cli doctor repair --dry-run
+am doctor repair --dry-run
 ```
 
 Shows what would be fixed without making changes.
@@ -51,13 +51,13 @@ Shows what would be fixed without making changes.
 
 ```bash
 # Interactive (prompts for confirmation)
-uv run python -m mcp_agent_mail.cli doctor repair
+am doctor repair
 
 # Auto-confirm (creates backup first)
-uv run python -m mcp_agent_mail.cli doctor repair --yes
+am doctor repair --yes
 
 # With custom backup directory
-uv run python -m mcp_agent_mail.cli doctor repair --yes --backup-dir /tmp/backups
+am doctor repair --yes --backup-dir /tmp/backups
 ```
 
 ---
@@ -68,29 +68,29 @@ uv run python -m mcp_agent_mail.cli doctor repair --yes --backup-dir /tmp/backup
 
 ```bash
 # With label
-uv run python -m mcp_agent_mail.cli archive save --label nightly
+am archive save --label nightly
 
 # Default label (timestamp)
-uv run python -m mcp_agent_mail.cli archive save
+am archive save
 ```
 
 ### List Backups
 
 ```bash
-uv run python -m mcp_agent_mail.cli doctor backups
+am doctor backups
 
 # JSON format
-uv run python -m mcp_agent_mail.cli doctor backups --json
+am doctor backups --json
 ```
 
 ### Restore from Backup
 
 ```bash
 # Preview what would be restored
-uv run python -m mcp_agent_mail.cli doctor restore /path/to/backup.zip --dry-run
+am doctor restore /path/to/backup.zip --dry-run
 
 # Perform restore
-uv run python -m mcp_agent_mail.cli doctor restore /path/to/backup.zip --yes
+am doctor restore /path/to/backup.zip --yes
 ```
 
 ---
@@ -102,7 +102,7 @@ Export mailbox for auditors, stakeholders, or archives.
 ### Interactive Wizard (Recommended)
 
 ```bash
-uv run python -m mcp_agent_mail.cli share wizard
+am share wizard
 ```
 
 Guides you through export options, signing, encryption, and deployment.
@@ -111,20 +111,20 @@ Guides you through export options, signing, encryption, and deployment.
 
 ```bash
 # Basic export
-uv run python -m mcp_agent_mail.cli share export --output ./bundle
+am share export --output ./bundle
 
 # With cryptographic signing
-uv run python -m mcp_agent_mail.cli share export \
+am share export \
   --output ./bundle \
   --signing-key ./keys/signing.key
 
 # With age encryption
-uv run python -m mcp_agent_mail.cli share export \
+am share export \
   --output ./bundle \
   --age-recipient age1abc...xyz
 
 # Scrub sensitive content
-uv run python -m mcp_agent_mail.cli share export \
+am share export \
   --output ./bundle \
   --scrub-preset strict  # or 'standard'
 ```
@@ -132,42 +132,49 @@ uv run python -m mcp_agent_mail.cli share export \
 ### Preview Exported Bundle
 
 ```bash
-uv run python -m mcp_agent_mail.cli share preview ./bundle --port 9000 --open-browser
+am share preview ./bundle --port 9000 --open-browser
 ```
 
 ### Verify Bundle Integrity
 
 ```bash
-uv run python -m mcp_agent_mail.cli share verify ./bundle
+am share verify ./bundle
 ```
 
 ### Refresh Existing Bundle
 
 ```bash
-uv run python -m mcp_agent_mail.cli share update ./bundle
+am share update ./bundle
 ```
 
 ### Decrypt Age-Encrypted Bundle
 
 ```bash
-uv run python -m mcp_agent_mail.cli share decrypt bundle.zip.age --identity ~/.age/key.txt
+am share decrypt bundle.zip.age --identity ~/.age/key.txt
 ```
 
 ---
 
-## Dangerous Operations
+## Dangerous Operations (admin/DR mode — explicit caller authorization required)
 
-### Full Reset (Destructive!)
+These are the admin/disaster-recovery surface, not coordination. Each needs the
+caller's explicit authorization for that specific operation; none runs as a side
+effect of coordination. `doctor repair`, backup/restore, and especially the full
+reset below cross from advisory into destructive.
+
+### Full Reset (Destructive, irreversible!)
 
 ```bash
-# Prompts for archive first
-uv run python -m mcp_agent_mail.cli clear-and-reset-everything
+# Prompts for archive first — run only with explicit destructive-reset authorization
+am clear-and-reset-everything
 
-# Skip prompts (automation)
-uv run python -m mcp_agent_mail.cli clear-and-reset-everything --force --no-archive
+# Skips prompts — NEVER run without an explicit destructive-reset authorization
+am clear-and-reset-everything --force --no-archive
 ```
 
-**WARNING:** Deletes SQLite database and all storage contents.
+**WARNING:** Deletes the SQLite database and all storage contents and cannot be
+undone. `--force --no-archive` also skips the safety archive. Do not run either
+form on your own initiative; report the situation and let the caller authorize.
 
 ---
 
@@ -177,20 +184,20 @@ uv run python -m mcp_agent_mail.cli clear-and-reset-everything --force --no-arch
 
 ```bash
 # All reservations
-uv run python -m mcp_agent_mail.cli file_reservations list /abs/path/project
+am file_reservations list /abs/path/project
 
 # Active only
-uv run python -m mcp_agent_mail.cli file_reservations list /abs/path/project --active-only
+am file_reservations list /abs/path/project --active-only
 
 # Active with limit
-uv run python -m mcp_agent_mail.cli file_reservations active /abs/path/project --limit 10
+am file_reservations active /abs/path/project --limit 10
 ```
 
 ### Expiring Soon
 
 ```bash
 # Reservations expiring within 30 minutes
-uv run python -m mcp_agent_mail.cli file_reservations soon /abs/path/project --minutes 30
+am file_reservations soon /abs/path/project --minutes 30
 ```
 
 ---
@@ -200,19 +207,19 @@ uv run python -m mcp_agent_mail.cli file_reservations soon /abs/path/project --m
 ### Pending Acknowledgments
 
 ```bash
-uv run python -m mcp_agent_mail.cli acks pending /abs/path/project GreenCastle --limit 10
+am acks pending /abs/path/project GreenCastle --limit 10
 ```
 
 ### Overdue ACKs
 
 ```bash
-uv run python -m mcp_agent_mail.cli acks overdue /abs/path/project GreenCastle --ttl-minutes 60
+am acks overdue /abs/path/project GreenCastle --ttl-minutes 60
 ```
 
 ### Remind About Old ACKs
 
 ```bash
-uv run python -m mcp_agent_mail.cli acks remind /abs/path/project GreenCastle --min-age-minutes 30
+am acks remind /abs/path/project GreenCastle --min-age-minutes 30
 ```
 
 ---

--- a/skills/agent-native/scripts/fake_model_runner.py
+++ b/skills/agent-native/scripts/fake_model_runner.py
@@ -10,12 +10,20 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
 
 def utc_now() -> str:
+    # Honor SOURCE_DATE_EPOCH so fixture output is reproducible; fall back to
+    # wall-clock only when it is unset.
+    epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if epoch:
+        return datetime.fromtimestamp(int(epoch), tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
@@ -156,6 +164,14 @@ def duel(args: argparse.Namespace) -> int:
 
 
 def validate_cross(args: argparse.Namespace) -> int:
+    # A shared context id forfeits the fresh-judgment guarantee the attestation
+    # is supposed to certify — reject it before emitting anything.
+    if args.author_context_id == args.validator_context_id:
+        print(
+            "validate-cross requires distinct author/validator context ids",
+            file=sys.stderr,
+        )
+        return 2
     author_model = args.author_model
     validator_model = args.validator_model
     available = {p.strip() for p in (args.available or "").split(",") if p.strip()}

--- a/skills/agy-native/SKILL.md
+++ b/skills/agy-native/SKILL.md
@@ -23,12 +23,34 @@ output_contract: AGY runtime evidence
 # AGY Native
 
 Use AGY only when the caller explicitly selects that runtime. Discover its live
-command surface before acting and scope every session to the supplied workspace
-and packet.
+command surface with `agy --help` (and `agy models` for the current model set)
+before acting, and scope every session to the supplied workspace and packet.
 
 Discovering the live command surface before acting works because AGY's CLI
 changes faster than any skill text: a remembered flag is a guess, while a
 freshly listed one is evidence.
+
+## Permission posture (disclose it; never assume it)
+
+The posture a run gets is chosen by flags, so name it explicitly:
+
+- Default `agy` runs interactively and prompts for each tool permission.
+- `--dangerously-skip-permissions` auto-approves every tool call — use it only
+  when the packet's declared effects and the caller's authorization cover that
+  blast radius.
+- `--sandbox` restricts the session's terminal access.
+- Print mode (`agy -p` / `--print`) is the sanctioned headless path and carries
+  a built-in `--print-timeout` (default 5m); a run that exceeds it is killed and
+  reported as timed out, not as a result.
+
+A reader who sets none of these gets AGY's interactive default, not a scoped
+run. Match the posture to the declared effects and disclose which one was used.
+
+## When AGY is unavailable
+
+If `agy` is not installed or its command surface cannot be discovered, report the
+absence as a disclosed fact and stop. Do not fall back to another runtime, do not
+guess a command surface, and never route through `claude -p`.
 
 Named failure mode — **wrapper drift**: invoking AGY through remembered
 syntax that silently changed, producing runs that look scoped but are not.

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -32,7 +32,7 @@
       ],
       "codex_override_present": true,
       "consumes": [
-        "task-intent"
+        "coordination-request"
       ],
       "context_rel": [
         {
@@ -43,7 +43,11 @@
       "dependencies": [],
       "description": "Use Agent Mail as an optional messaging and file-reservation adapter for explicitly coordinated writers. Triggers: \"coordinate writers\", \"reserve files\".",
       "disposition": "keep_optional_adapter",
-      "effects": [],
+      "effects": [
+        "write_agent_mail_records",
+        "install_precommit_guard",
+        "authorized_destructive_reset"
+      ],
       "graph_root": false,
       "hexagonal_role": "supporting",
       "name": "agent-mail",
@@ -322,7 +326,9 @@
         "codex_exec"
       ],
       "codex_override_present": true,
-      "consumes": [],
+      "consumes": [
+        "codex-command-packet"
+      ],
       "context_rel": [
         {
           "kind": "supplier-to",
@@ -332,7 +338,10 @@
       "dependencies": [],
       "description": "Run one caller-supplied Codex command non-interactively and capture evidence. Triggers: \"run Codex headless\", \"capture Codex evidence\".",
       "disposition": "keep_optional_adapter",
-      "effects": [],
+      "effects": [
+        "run_codex_process",
+        "sandbox_tiered_workspace_and_network_effects"
+      ],
       "graph_root": false,
       "hexagonal_role": "driving-adapter",
       "name": "codex-exec",
@@ -730,7 +739,7 @@
       ],
       "codex_override_present": true,
       "consumes": [
-        "task-intent"
+        "pane-command-request"
       ],
       "context_rel": [
         {
@@ -741,7 +750,10 @@
       "dependencies": [],
       "description": "Use NTM as an optional pane adapter for caller-supplied roles and commands. Triggers: \"ntm\", \"tmux panes\", \"ntm robot state\".",
       "disposition": "keep_optional_adapter",
-      "effects": [],
+      "effects": [
+        "manage_ntm_panes",
+        "dispatch_pane_commands"
+      ],
       "graph_root": false,
       "hexagonal_role": "supporting",
       "name": "ntm",
@@ -977,7 +989,10 @@
       "dependencies": [],
       "description": "Use RCH once to offload a build or collect remote-compilation diagnostics. Triggers: \"use RCH\", \"offload this build\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "remote_compilation_offload",
+        "authorized_remote_daemon_worker_mutation"
+      ],
       "graph_root": false,
       "hexagonal_role": "supporting",
       "name": "rch",
@@ -1520,7 +1535,8 @@
       "description": "Drive a caller-selected Gas City through its Mayor dispatch shepherd; keep GC runtime state out of AgentOps verdicts. Triggers: \"using gc\", \"gas city\", \"drive the mayor\", \"dispatch through gc\".",
       "disposition": "keep_optional_adapter",
       "effects": [
-        "operate_gas_city"
+        "operate_gas_city",
+        "configure_codex_trust"
       ],
       "graph_root": false,
       "hexagonal_role": "driving-adapter",

--- a/skills/codex-exec/SKILL.md
+++ b/skills/codex-exec/SKILL.md
@@ -6,7 +6,8 @@ user-invocable: false
 hexagonal_role: driving-adapter
 practices:
 - pragmatic-programmer
-consumes: []
+consumes:
+- codex-command-packet
 produces:
 - codex-run-output
 context_rel:
@@ -22,15 +23,12 @@ context:
   intel_scope: none
 metadata:
   capabilities: [codex_exec]
-  effects: []
+  effects: [run_codex_process, sandbox_tiered_workspace_and_network_effects]
   canonical_status: canonical
   disposition: keep_optional_adapter
   tier: orchestration
   dependencies: []
   stability: stable
-  triggers:
-  - codex exec
-  - spawn a codex worker
 output_contract: process exit status and captured Codex output artifact
 ---
 # Codex Exec — one-shot runtime adapter
@@ -58,17 +56,28 @@ prompt runs read-only, full stop.
    explicitly requires network or external effects.
 4. Pipe the prompt to stdin (or close stdin) in non-TTY execution so the process
    cannot wait indefinitely for input.
-5. Capture the final response with `-o`, JSONL, or an output schema.
-6. Report the process exit status and captured artifact, then stop.
+5. Bound the run with an explicit wall-clock timeout (wrap with `timeout`
+   /`gtimeout`, or use the profile's own deadline). If no timeout mechanism is
+   available, disclose that the run is unbounded rather than let it hang
+   silently, and treat a killed run as a distinct terminal outcome — not a
+   review result.
+6. Capture the final response with `-o`, JSONL, or an output schema.
+7. Report the typed run result, then stop: the process exit status, the captured
+   artifact path, whether a timeout fired (and the process tree was reaped), and
+   whether the `codex` binary was even present. Cancellation is the caller's;
+   this skill neither retries nor continues on its own.
 
-A nonzero process exit is runtime evidence, not a semantic verdict. The caller
-decides whether to launch another invocation.
+Terminal outcomes are explicit: **binary absent** (no `codex` on PATH) →
+report unavailable and stop; **timed out** → report the kill and preserved
+partial output, never as a completed review; **nonzero exit** → runtime
+evidence, not a semantic verdict. The caller decides whether to launch another
+invocation.
 
 ## Example
 
 ```bash
-printf '%s\n' "$PROMPT" | codex exec -C "$WORKSPACE" -s read-only \
-  -o "$OUTPUT" -
+printf '%s\n' "$PROMPT" | timeout "${CODEX_TIMEOUT:-600}" \
+  codex exec -C "$WORKSPACE" -s read-only -o "$OUTPUT" -
 ```
 
 For a validator, the prompt must name the acceptance digest, exact subject

--- a/skills/codex-exec/SKILL.md
+++ b/skills/codex-exec/SKILL.md
@@ -56,27 +56,38 @@ prompt runs read-only, full stop.
    explicitly requires network or external effects.
 4. Pipe the prompt to stdin (or close stdin) in non-TTY execution so the process
    cannot wait indefinitely for input.
-5. Bound the run with an explicit wall-clock timeout (wrap with `timeout`
-   /`gtimeout`, or use the profile's own deadline). If no timeout mechanism is
-   available, disclose that the run is unbounded rather than let it hang
-   silently, and treat a killed run as a distinct terminal outcome — not a
-   review result.
+5. A wall-clock **deadline is mandatory** — never run codex unbounded. Use the
+   caller's deadline, or the declared default of **600s (10 min)** when the
+   caller supplies none, and record which one applied. Enforce it so the whole
+   process **tree** is reaped, not just the direct child: run codex in its own
+   process group and kill the group on expiry (e.g. `setsid` + `kill -KILL
+   -<pgid>`), or `timeout --kill-after=10s <secs>` to escalate TERM→KILL. Plain
+   `timeout <secs> codex …` signals only the direct child, so if your wrapper
+   cannot guarantee process-group reaping, **disclose the surviving-subprocess
+   risk as a limitation** rather than claim cleanup. Deadline expiry is
+   **fail-closed**: the run is killed and reported as timed-out / not proven,
+   partial output preserved — never a completed review.
 6. Capture the final response with `-o`, JSONL, or an output schema.
 7. Report the typed run result, then stop: the process exit status, the captured
-   artifact path, whether a timeout fired (and the process tree was reaped), and
-   whether the `codex` binary was even present. Cancellation is the caller's;
-   this skill neither retries nor continues on its own.
+   artifact path, which deadline applied and whether it fired, whether the
+   process tree was reaped (or the surviving-subprocess limitation), and whether
+   the `codex` binary was present at all. Cancellation is the caller's; this
+   skill neither retries nor continues on its own.
 
-Terminal outcomes are explicit: **binary absent** (no `codex` on PATH) →
-report unavailable and stop; **timed out** → report the kill and preserved
-partial output, never as a completed review; **nonzero exit** → runtime
+Terminal outcomes are explicit: **binary absent** (no `codex` on PATH) → report
+unavailable and stop; **deadline expiry** → fail-closed, report the kill and
+preserved partial output, never a completed review; **nonzero exit** → runtime
 evidence, not a semantic verdict. The caller decides whether to launch another
 invocation.
 
 ## Example
 
 ```bash
-printf '%s\n' "$PROMPT" | timeout "${CODEX_TIMEOUT:-600}" \
+# Deadline mandatory; default 600s. `setsid` puts codex in its own process
+# group; on expiry `--kill-after` escalates TERM->KILL to reap the tree, not
+# just the direct child. (If you cannot run setsid, disclose that a plain
+# `timeout` reaps only the direct child.)
+printf '%s\n' "$PROMPT" | setsid timeout --kill-after=10s "${CODEX_TIMEOUT:-600}" \
   codex exec -C "$WORKSPACE" -s read-only -o "$OUTPUT" -
 ```
 

--- a/skills/codex-exec/SKILL.md
+++ b/skills/codex-exec/SKILL.md
@@ -60,17 +60,18 @@ prompt runs read-only, full stop.
    caller's deadline, or the declared default of **600s (10 min)** when the
    caller supplies none, and record which one applied. Enforce it so the whole
    process **tree** is reaped, not just the direct child: run codex in its own
-   process group and kill the group on expiry (e.g. `setsid` + `kill -KILL
-   -<pgid>`), or `timeout --kill-after=10s <secs>` to escalate TERM→KILL. Plain
-   `timeout <secs> codex …` signals only the direct child, so if your wrapper
-   cannot guarantee process-group reaping, **disclose the surviving-subprocess
-   risk as a limitation** rather than claim cleanup. Deadline expiry is
+   process group and kill the group on expiry: `setsid` (own process group) +
+   `kill -KILL -<pgid>` on the group; `--kill-after` only escalates TERM→KILL
+   and plain `timeout <secs> codex …` signals only the direct child. If the
+   wrapper cannot guarantee process-group reaping, **do not execute** — that
+   host lacks the cleanup capability this skill requires (capability
+   unavailable, fail closed). Deadline expiry is
    **fail-closed**: the run is killed and reported as timed-out / not proven,
    partial output preserved — never a completed review.
 6. Capture the final response with `-o`, JSONL, or an output schema.
 7. Report the typed run result, then stop: the process exit status, the captured
-   artifact path, which deadline applied and whether it fired, whether the
-   process tree was reaped (or the surviving-subprocess limitation), and whether
+   artifact path, which deadline applied and whether it fired, that the
+   process tree was reaped (a run without guaranteed reaping never starts), and whether
    the `codex` binary was present at all. Cancellation is the caller's; this
    skill neither retries nor continues on its own.
 
@@ -84,9 +85,9 @@ invocation.
 
 ```bash
 # Deadline mandatory; default 600s. `setsid` puts codex in its own process
-# group; on expiry `--kill-after` escalates TERM->KILL to reap the tree, not
-# just the direct child. (If you cannot run setsid, disclose that a plain
-# `timeout` reaps only the direct child.)
+# group so expiry kills the whole tree, with `--kill-after` escalating
+# TERM->KILL. No setsid (or equivalent group kill) available -> do not run:
+# fail closed as capability-unavailable.
 printf '%s\n' "$PROMPT" | setsid timeout --kill-after=10s "${CODEX_TIMEOUT:-600}" \
   codex exec -C "$WORKSPACE" -s read-only -o "$OUTPUT" -
 ```

--- a/skills/ntm/SKILL.md
+++ b/skills/ntm/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 skill_api_version: 1
 hexagonal_role: supporting
 consumes:
-- task-intent
+- pane-command-request
 produces:
 - ntm-robot-state
 - agent-worker-transcript
@@ -13,7 +13,7 @@ context_rel:
   with: agent-native
 metadata:
   capabilities: [ntm]
-  effects: []
+  effects: [manage_ntm_panes, dispatch_pane_commands]
   canonical_status: canonical
   disposition: keep_optional_adapter
   tier: execution
@@ -92,8 +92,17 @@ Return:
 - degraded or unavailable substrate surfaces;
 - effects that were and were not observed.
 
-A timeout, nonzero exit, or degraded source is reported as evidence. The caller
-decides whether to invoke another experiment.
+Terminal outcomes are explicit, never a silent hang:
+
+- **NTM unavailable** — `ntm` absent or the robot surface unreachable: report it
+  and stop; do not fall back to blind key injection or assume the pane is idle.
+- **Observation-window deadline reached** — report the last observed robot state
+  and transcript reference; the window ending is a stop, not a failure verdict.
+- **Timeout / nonzero exit / degraded source** — reported as evidence with what
+  was and was not observed.
+- **Cancellation and cleanup** — the caller decides whether to invoke another
+  experiment; report which panes were created or left running so nothing is
+  orphaned silently. NTM never retries or reaps on its own.
 
 ## Useful live surfaces
 
@@ -103,4 +112,6 @@ caller explicitly requests an interactive action and no robot command provides
 the needed behavior.
 
 External NTM documentation and examples remain the authority for command syntax;
-this skill owns only the AgentOps boundary above.
+this skill owns only the AgentOps boundary above. NTM's CLI drifts across
+versions, so confirm the surface at runtime (`ntm --version`,
+`ntm --robot-capabilities`) rather than trusting a remembered command.

--- a/skills/rch/SKILL.md
+++ b/skills/rch/SKILL.md
@@ -9,7 +9,7 @@ context_rel: []
 metadata:
   dependencies: []
   capabilities: [rch]
-  effects: []
+  effects: [remote_compilation_offload, authorized_remote_daemon_worker_mutation]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
@@ -54,13 +54,28 @@ fails deterministically, not moodily.
 when the local build succeeds. Destructive cleanup, worker deployment, daemon
 configuration, and remote mutation require explicit caller authority.
 
+`rch check` exit status adjudicates readiness (0 = ready, nonzero = not
+offload-ready). Do not read `rch doctor --json` `success: true` as readiness — a
+successful diagnostic report can coexist with a down daemon or unreachable
+workers. Adjudicate on `rch check`; use `doctor` for the reasons behind it.
+
 ## Output
 
 Return a factual packet with status (`remote`, `local_fallback`, `failed`, or
 `not_proven`), commands and exit codes, worker, summary line, and checked/not
-checked surfaces. Do not include a next action.
+checked surfaces. Do not include a next action. `not_proven` here is a runtime
+diagnosis status, not an AgentOps verdict; it carries no verdict weight and never
+substitutes for a `verdict.v2`.
 
 ## References
+
+The SKILL.md authority boundary above governs every reference below. Where a
+reference lists a remediation, its read-only diagnostics run autonomously but its
+remote, privileged, or irreversible steps (remote/`sudo` mutation, daemon
+start/restart/reconfigure, worker or fleet deployment, toolchain sync,
+destructive cleanup) still require explicit caller authorization first. A
+reference never widens the autonomy the kernel grants.
+
 
 - [Fail-open reasons](references/FAIL_OPEN.md)
 - [Error catalog](references/ERROR_CODES.md)

--- a/skills/rch/references/CONFIGURATION.md
+++ b/skills/rch/references/CONFIGURATION.md
@@ -10,6 +10,13 @@
 - [Validation and Diagnostics](#validation-and-diagnostics)
 - [Runtime Data Paths](#runtime-data-paths)
 
+> **Authority:** reading config is autonomous (`rch config get|show|validate|
+> doctor|diff`, `rch hook status`). Writing it is not — editing
+> `~/.config/rch/config.toml` or `workers.toml`, `rch config set|edit|init`, and
+> `rch hook install|uninstall` (which write `~/.claude/settings.json`) are host
+> mutations requiring explicit caller authorization first (see `FAIL_OPEN.md`
+> §"Autonomous Remediation Envelope").
+
 ## Precedence and File Locations
 
 RCH resolves settings in this order (highest to lowest):
@@ -152,9 +159,9 @@ Location: `~/.claude/settings.json`
 Recommended management commands:
 
 ```bash
-rch hook install
-rch hook status
-rch hook uninstall
+rch hook status       # autonomous
+rch hook install      # (authorize first) — writes ~/.claude/settings.json
+rch hook uninstall    # (authorize first) — edits ~/.claude/settings.json
 ```
 
 ---

--- a/skills/rch/references/ERROR_CODES.md
+++ b/skills/rch/references/ERROR_CODES.md
@@ -42,7 +42,7 @@ jq '.errors[] | select(.code=="RCH-E210") | {code, message, remediation}' /tmp/r
 | Range | Category | Lives in |
 |---|---|---|
 | 001–099 | Configuration | TOML, env vars, profile resolution, path topology, closure plan validation |
-| 100–199 | Network | SSH, DNS, TCP — see `SSH_TUNING.md` |
+| 100–199 | Network | SSH, DNS, TCP — see the Network rows below and `RECOVERY_PLAYBOOKS.md` Playbook C |
 | 200–299 | Worker | Selection, health, slots, disk pressure |
 | 300–399 | Build | Compilation, toolchain, process triage, cancellation |
 | 400–499 | Transfer | rsync, checksums, disk space, perms |
@@ -66,7 +66,7 @@ These are the codes agents actually see in practice. The rest are in the schema 
 | RCH-E013 | Cargo manifest parse failure during path-dep resolution | `cargo metadata --no-deps --format-version 1 > /dev/null` to see the parser error. |
 | RCH-E014 | Path dependency declared but target dir missing | The `path = "..."` in a `Cargo.toml` points nowhere. Resolve before retry. |
 | RCH-E015 | Cyclic path dependency | Break the cycle in the workspace. |
-| RCH-E016 | Path dep violates canonical-root topology | Sibling repo lives outside `[path_topology] canonical_root`. Either move it under the canonical root, or set `[path_topology] canonical_root` to a parent that contains both repos. See `PATH_DEPENDENCIES.md`. |
+| RCH-E016 | Path dep violates canonical-root topology | Sibling repo lives outside `[path_topology] canonical_root`. Either move it under the canonical root, or set `[path_topology] canonical_root` to a parent that contains both repos. See the path-dep section of `TROUBLESHOOTING.md`. |
 | RCH-E017 | `cargo metadata` invocation failed | Run `cargo metadata --format-version 1` and read the error directly. |
 | RCH-E019 | Closure plan computation failed | Re-run with `RCH_LOG_LEVEL=debug rch diagnose --dry-run "<command>"`. |
 | RCH-E020 | Closure entered fail-open due to unverifiable data | RCH refuses to ship unsafe closure. Either fix the workspace topology or set `[deps] policy = "permissive"` (only if you accept the risk). |
@@ -92,7 +92,7 @@ These are the codes agents actually see in practice. The rest are in the schema 
 | RCH-E204 | Worker at maximum capacity | Queueing is on by default; if seen, the wait timed out. Bump `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` or raise `total_slots`. |
 | RCH-E205 | Worker missing required toolchain | `rch workers sync-toolchain --all`. |
 | RCH-E207 | Worker circuit breaker open | Triggered by repeated failures. Inspect daemon logs; circuit auto-closes after cooldown, or `rch workers enable <id>` after fixing the underlying cause. |
-| **RCH-E210** | **Worker disk usage critically high** | **Hand off to `sbh`.** See `DISK_AND_PRESSURE.md`. |
+| **RCH-E210** | **Worker disk usage critically high** | **Hand off to the `sbh` skill.** See the disk rows in this table and `RECOVERY_PLAYBOOKS.md` Playbook G. |
 | RCH-E211 | Worker disk usage above warning threshold | `sbh` recommended. |
 | RCH-E212 | Disk pressure telemetry stale | Worker not reporting; restart `rch-wkr` on the worker, or wait one telemetry tick. |
 | RCH-E213 | Worker disk I/O too high | Transient — wait or `rch workers drain <id>` for maintenance. |
@@ -107,7 +107,7 @@ These are the codes agents actually see in practice. The rest are in the schema 
 |---|---|---|
 | RCH-E300 | Remote compilation failed | Read the actual rustc/cargo error in stderr. |
 | RCH-E303 | Build operation timed out | Raise `[compilation] build_timeout_sec` or split the build. |
-| RCH-E305 | Remote working dir error | Often = mirror perms broken. See `OPERATIONS.md` chown recipe. |
+| RCH-E305 | Remote working dir error | Often = mirror perms broken. See `RECOVERY_PLAYBOOKS.md` Playbook F — the chown fix is a remote `sudo` command, authorize first. |
 | RCH-E307 | Build environment setup failed | Missing system package on worker. Detected automatically when stderr names `pkg-config` or `library .pc`. |
 
 ### Transfer
@@ -117,14 +117,14 @@ These are the codes agents actually see in practice. The rest are in the schema 
 | RCH-E400 | Rsync transfer failed | Check `rch daemon logs -n 200` for full rsync stderr. |
 | RCH-E401 | Sync timed out | Big workspace + slow link. Tighten excludes or increase compression. |
 | RCH-E404 | Insufficient disk on worker | `sbh` on worker. |
-| RCH-E405 | Permission denied during transfer | Mirror ownership broken. Run the chown recipe from `OPERATIONS.md` §6. |
-| RCH-E406 | Transfer checksum mismatch | Re-run; if persistent, suspect concurrent agent writes during sync. Use file reservations (see `MULTI_AGENT_CONTENTION.md`). |
+| RCH-E405 | Permission denied during transfer | Mirror ownership broken. See `RECOVERY_PLAYBOOKS.md` Playbook F — the chown fix is a remote `sudo` command, authorize first. |
+| RCH-E406 | Transfer checksum mismatch | Re-run; if persistent, suspect concurrent agent writes during sync. Coordinate writers with file reservations via the `agent-mail` skill. |
 
 ### Internal
 
 | Code | Meaning | First action |
 |---|---|---|
-| RCH-E500 | Failed to connect to daemon socket | `rch daemon start`. If it spins, see `SELF_HEALING.md` cooldown section. |
+| RCH-E500 | Failed to connect to daemon socket | Wait out the auto-start cooldown and retry; manually starting the daemon needs caller authorization. If it spins, see `RECOVERY_PLAYBOOKS.md` Playbook B (cooldown/stale-socket). |
 | RCH-E502 | Daemon not running | Same. |
 | RCH-E506 | Hook execution failed | `rch hook test` reproduces; capture `RCH_LOG_LEVEL=debug rch hook test`. |
 
@@ -132,11 +132,11 @@ These are the codes agents actually see in practice. The rest are in the schema 
 
 ## Cross-References
 
-- Path-dep family (RCH-E013–E024): `PATH_DEPENDENCIES.md`
-- Disk-pressure family (RCH-E210–E217): `DISK_AND_PRESSURE.md` + `sbh` skill
-- SSH family (RCH-E100–E109): `SSH_TUNING.md`
+- Path-dep family (RCH-E013–E024): the path-dep section of `TROUBLESHOOTING.md`
+- Disk-pressure family (RCH-E210–E217): the disk rows above + the `sbh` skill
+- SSH family (RCH-E100–E109): `RECOVERY_PLAYBOOKS.md` Playbook C
 - Selection family (RCH-E200–E209): `FAIL_OPEN.md`
-- Daemon/internal (RCH-E500–E509): `SELF_HEALING.md` + `OPERATIONS.md`
+- Daemon/internal (RCH-E500–E509): `RECOVERY_PLAYBOOKS.md` Playbook B + `TROUBLESHOOTING.md`
 
 ---
 

--- a/skills/rch/references/ERROR_CODES.md
+++ b/skills/rch/references/ERROR_CODES.md
@@ -18,6 +18,12 @@ RCH ships a stable error catalog of 94 codes in the `RCH-Exxx` namespace. Every 
 
 Treat the code as the **stable handle**. Don't grep for the human-readable summary, which can be reworded between releases.
 
+> **Authority:** only read-only diagnosis is autonomous. Every "First action"
+> below that starts/restarts/reconfigures the daemon, adds/provisions/drains/
+> enables a worker or its toolchain, edits config, or mutates a remote host
+> requires explicit caller authorization first — see `FAIL_OPEN.md` §"Autonomous
+> Remediation Envelope". Mutating first actions are marked **(authorize first)**.
+
 ---
 
 ## Live Catalog
@@ -58,18 +64,18 @@ These are the codes agents actually see in practice. The rest are in the schema 
 
 | Code | Meaning | First action |
 |---|---|---|
-| RCH-E001 | Config file not found | `rch config init` (creates `~/.config/rch/config.toml`). |
-| RCH-E003 | Invalid TOML syntax | `rch config validate` to get the line. |
-| RCH-E007 | No workers configured | `rch workers discover --add --yes && rch workers setup --all`. |
-| RCH-E008 | Worker config invalid | `rch config doctor` shows which `[[workers]]` block is bad. |
-| RCH-E009 | SSH key path invalid/inaccessible | Check `identity_file` exists; run `chmod 600 <key>`. |
+| RCH-E001 | Config file not found | `rch config init` creates `~/.config/rch/config.toml` — **(authorize first)**. |
+| RCH-E003 | Invalid TOML syntax | `rch config validate` to get the line (autonomous). |
+| RCH-E007 | No workers configured | `rch workers discover --add --yes && rch workers setup --all` adds/provisions workers — **(authorize first)**. |
+| RCH-E008 | Worker config invalid | `rch config doctor` shows which `[[workers]]` block is bad (autonomous). |
+| RCH-E009 | SSH key path invalid/inaccessible | Check `identity_file` exists (autonomous); `chmod 600 <key>` mutates a local file — **(authorize first)**. |
 | RCH-E013 | Cargo manifest parse failure during path-dep resolution | `cargo metadata --no-deps --format-version 1 > /dev/null` to see the parser error. |
 | RCH-E014 | Path dependency declared but target dir missing | The `path = "..."` in a `Cargo.toml` points nowhere. Resolve before retry. |
 | RCH-E015 | Cyclic path dependency | Break the cycle in the workspace. |
 | RCH-E016 | Path dep violates canonical-root topology | Sibling repo lives outside `[path_topology] canonical_root`. Either move it under the canonical root, or set `[path_topology] canonical_root` to a parent that contains both repos. See the path-dep section of `TROUBLESHOOTING.md`. |
 | RCH-E017 | `cargo metadata` invocation failed | Run `cargo metadata --format-version 1` and read the error directly. |
 | RCH-E019 | Closure plan computation failed | Re-run with `RCH_LOG_LEVEL=debug rch diagnose --dry-run "<command>"`. |
-| RCH-E020 | Closure entered fail-open due to unverifiable data | RCH refuses to ship unsafe closure. Either fix the workspace topology or set `[deps] policy = "permissive"` (only if you accept the risk). |
+| RCH-E020 | Closure entered fail-open due to unverifiable data | RCH refuses to ship unsafe closure. Fix the workspace topology, or set `[deps] policy = "permissive"` (a config edit that accepts the risk) — **(authorize first)**. |
 
 ### Network
 
@@ -77,7 +83,7 @@ These are the codes agents actually see in practice. The rest are in the schema 
 |---|---|---|
 | RCH-E100 | SSH connection failed | `ssh -v ubuntu@<host>` reproduces. Check host reachability. |
 | RCH-E101 | SSH auth failed | Wrong key or wrong user. `ssh-add -l` to confirm agent has the right key; `rch config get` for `identity_file`. |
-| RCH-E103 | Host key verification failed | Worker rebuilt? Compare with `ssh-keygen -F <host>`; remove the old entry only if you trust the new fingerprint. |
+| RCH-E103 | Host key verification failed | Worker rebuilt? Compare with `ssh-keygen -F <host>` (autonomous); removing the old `known_hosts` entry mutates local state — **(authorize first)**, and only if you trust the new fingerprint. |
 | RCH-E104 | SSH command timed out | Network or remote slowdown. Bump `RCH_SSH_SERVER_ALIVE_INTERVAL_SECS=15` and retry. |
 | RCH-E108 | Connection refused | sshd not running or wrong port. |
 | RCH-E109 | TCP connect timeout | Firewall, NAT, or worker down. |
@@ -89,13 +95,13 @@ These are the codes agents actually see in practice. The rest are in the schema 
 | RCH-E200 | No workers available for selection | See `FAIL_OPEN.md` selection-reasons table. |
 | RCH-E202 | Worker failed health check | `rch workers probe <id>` reproduces; inspect `rch workers list --speedscore`. |
 | RCH-E203 | Worker self-test failed | `rch self-test --worker <id>`; inspect `rch self-test history --limit 5`. |
-| RCH-E204 | Worker at maximum capacity | Queueing is on by default; if seen, the wait timed out. Bump `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` or raise `total_slots`. |
-| RCH-E205 | Worker missing required toolchain | `rch workers sync-toolchain --all`. |
-| RCH-E207 | Worker circuit breaker open | Triggered by repeated failures. Inspect daemon logs; circuit auto-closes after cooldown, or `rch workers enable <id>` after fixing the underlying cause. |
+| RCH-E204 | Worker at maximum capacity | Queueing is on by default; if seen, the wait timed out. Bump `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` (autonomous); raising `total_slots` edits config — **(authorize first)**. |
+| RCH-E205 | Worker missing required toolchain | `rch workers sync-toolchain --all` mutates the worker — **(authorize first)**. |
+| RCH-E207 | Worker circuit breaker open | Triggered by repeated failures. Inspect daemon logs (autonomous); circuit auto-closes after cooldown, or force `rch workers enable <id>` after fixing the cause — **(authorize first)**. |
 | **RCH-E210** | **Worker disk usage critically high** | **Hand off to the `sbh` skill.** See the disk rows in this table and `RECOVERY_PLAYBOOKS.md` Playbook G. |
 | RCH-E211 | Worker disk usage above warning threshold | `sbh` recommended. |
-| RCH-E212 | Disk pressure telemetry stale | Worker not reporting; restart `rch-wkr` on the worker, or wait one telemetry tick. |
-| RCH-E213 | Worker disk I/O too high | Transient — wait or `rch workers drain <id>` for maintenance. |
+| RCH-E212 | Disk pressure telemetry stale | Worker not reporting; wait one telemetry tick (autonomous). Restarting `rch-wkr` on the worker is remote mutation — **(authorize first)**. |
+| RCH-E213 | Worker disk I/O too high | Transient — wait (autonomous), or `rch workers drain <id>` for maintenance — **(authorize first)**. |
 | RCH-E214 | Worker memory pressure too high | Same; check what else is running on the worker. |
 | RCH-E215 | Disk reclaim failed | sbh ran but couldn't free enough. Manual triage. |
 | RCH-E216 | Insufficient disk headroom for build reservation | Free space, or steer to a different worker via `tags`. |
@@ -106,7 +112,7 @@ These are the codes agents actually see in practice. The rest are in the schema 
 | Code | Meaning | First action |
 |---|---|---|
 | RCH-E300 | Remote compilation failed | Read the actual rustc/cargo error in stderr. |
-| RCH-E303 | Build operation timed out | Raise `[compilation] build_timeout_sec` or split the build. |
+| RCH-E303 | Build operation timed out | Splitting the build is autonomous; raising `[compilation] build_timeout_sec` edits config — **(authorize first)**. |
 | RCH-E305 | Remote working dir error | Often = mirror perms broken. See `RECOVERY_PLAYBOOKS.md` Playbook F — the chown fix is a remote `sudo` command, authorize first. |
 | RCH-E307 | Build environment setup failed | Missing system package on worker. Detected automatically when stderr names `pkg-config` or `library .pc`. |
 

--- a/skills/rch/references/FAIL_OPEN.md
+++ b/skills/rch/references/FAIL_OPEN.md
@@ -59,8 +59,8 @@ Every reason in the parens comes from one of two sources:
 | `daemon unavailable` | Daemon socket can't be reached (and auto-start failed or is disabled) | Wait out the auto-start cooldown and retry (autonomous). If still failing, confirm with `rch --json daemon status` and check `~/.cache/rch/rch.sock`; manually starting the daemon needs caller authorization. See `RECOVERY_PLAYBOOKS.md` Playbook B. |
 | `force_local` | `[general] force_local = true` is set | This is intentional. `rch config get general.force_local --sources` shows where it came from (autonomous). Reverting with `rch config set general.force_local false` edits config — **(authorize first)**. |
 | `invalid config: force_local+force_remote` | Both flags set simultaneously | `rch config edit` to unset one, then `rch daemon reload` — both mutate config/daemon, **(authorize first)**. |
-| `confidence below threshold` | Classifier flagged the command but only weakly (e.g., wrapped in shell pipelines). Threshold is `[compilation] confidence_threshold` (default 0.85). | If the command really should offload, lower the threshold or set `[general] force_remote = true` in `.rch/config.toml`. Better: run `rch diagnose "<the command>"` to see classifier confidence. |
-| `command '<base>' not in allowlist` | `[execution] allowlist` excludes this command base | `rch --json config get execution.allowlist` to inspect. Add the command base if you control the project's `.rch/config.toml`. |
+| `confidence below threshold` | Classifier flagged the command but only weakly (e.g., wrapped in shell pipelines). Threshold is `[compilation] confidence_threshold` (default 0.85). | Run `rch diagnose "<the command>"` to see classifier confidence (autonomous). Lowering the threshold or setting `[general] force_remote = true` in `.rch/config.toml` are config mutations — **(authorize first)**. |
+| `command '<base>' not in allowlist` | `[execution] allowlist` excludes this command base | `rch --json config get execution.allowlist` to inspect (autonomous). Adding the command base to `.rch/config.toml` is a config mutation — **(authorize first)**. |
 | `dependency preflight <RCH-Exxx>: <remediation>` | The closure planner refused to ship the workspace (cycle, missing manifest, off-canonical-root path dep). See the RCH-E013–E020 rows in `ERROR_CODES.md` and the path-dep section of `TROUBLESHOOTING.md`. | The remediation message is actionable; follow it. Then re-run `rch diagnose --dry-run "<command>"`. |
 | `<TransferSkipped reason>` | Transfer pipeline opted out (e.g., empty workspace, all paths excluded). | Run `RCH_LOG_LEVEL=debug rch exec -- <command>` and look for `Transfer skipped:` log lines. |
 | `remote execution failed` | Generic catch-all for transfer/exec errors | Re-run with `RCH_LOG_LEVEL=debug` to surface the real error, and check `rch daemon logs -n 200` for the daemon side. |
@@ -73,7 +73,7 @@ These come from the daemon's `SelectionReason` enum. The `[RCH] local (...)` sum
 | Snake_case tag (JSON) | Human form in `local (...)` summary | Self-fix |
 |---|---|---|
 | `no_workers_configured` | `no workers configured` | `rch workers discover --add --yes && rch workers setup --all` adds and provisions workers — a fleet mutation; get caller authorization first. |
-| `all_workers_unreachable` | `all workers unreachable` | `rch workers probe --all` and read the SSH errors (autonomous); fixing a local key's permissions is local, but changing anything on a worker is remote mutation → authorize first. See `RECOVERY_PLAYBOOKS.md` Playbook C and the Network rows of `ERROR_CODES.md`. |
+| `all_workers_unreachable` | `all workers unreachable` | `rch workers probe --all` and read the SSH errors (autonomous). Any fix beyond reading — repairing a local key's permissions included — is a host mutation → **(authorize first)**; changing anything on a worker is remote mutation → **(authorize first)**. See `RECOVERY_PLAYBOOKS.md` Playbook C and the Network rows of `ERROR_CODES.md`. |
 | `all_circuits_open` | `all worker circuits open` | A worker hit repeated failures and tripped its circuit. Inspect with `rch --json status --workers \| jq '.data.daemon.workers[] \| {id, circuit_state, last_error, recovery_in_secs}'` and `rch daemon logs -n 200` (autonomous). Circuits auto-close after the cooldown; forcing `rch workers enable <id>` mutates worker state — **(authorize first)**. |
 | `all_workers_busy` | `all workers at capacity` | Queueing is **on by default** (`RCH_QUEUE_WHEN_BUSY=1`); seeing this means the wait timed out. Bump `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` for the next invocation (autonomous). Raising `total_slots` edits worker config — **(authorize first)**. Check `rch queue --watch` to see backlog. |
 | `all_workers_failed_preflight` | `all workers failed preflight checks` | Path-topology check, repo presence, or toolchain probe failed on every candidate. Re-run with `rch diagnose --dry-run "<command>"` to see the preflight pipeline; hits `RCH-E013..024`, `RCH-E205`, `RCH-E305`. |
@@ -155,8 +155,11 @@ filesystem state:
   status|verify`, `rch queue`, `rch self-test`;
 - tuning env vars for the *next* invocation (`RCH_VISIBILITY`, `RCH_LOG_LEVEL`,
   `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120`, `RCH_SSH_SERVER_ALIVE_INTERVAL_SECS`);
-- re-running the original command, including waiting out an auto-start cooldown
-  (the built-in `try_auto_start_daemon` handles stale sockets — do not `rm` them).
+- re-running the original command *only when that command is itself read-only*,
+  including waiting out an auto-start cooldown (the built-in
+  `try_auto_start_daemon` handles stale sockets — do not `rm` them). A
+  mutating original command re-runs only under the authorization that covered
+  it in the first place.
 
 **Requires explicit caller authorization first — even when a reason maps
 straight to one of these commands.** Every host, worker, daemon, config, or

--- a/skills/rch/references/FAIL_OPEN.md
+++ b/skills/rch/references/FAIL_OPEN.md
@@ -57,8 +57,8 @@ Every reason in the parens comes from one of two sources:
 | Reason text | Triggered when | Self-fix |
 |---|---|---|
 | `daemon unavailable` | Daemon socket can't be reached (and auto-start failed or is disabled) | Wait out the auto-start cooldown and retry (autonomous). If still failing, confirm with `rch --json daemon status` and check `~/.cache/rch/rch.sock`; manually starting the daemon needs caller authorization. See `RECOVERY_PLAYBOOKS.md` Playbook B. |
-| `force_local` | `[general] force_local = true` is set | This is intentional. If you didn't expect it: `rch config get general.force_local --sources` shows where it came from. `rch config set general.force_local false` to revert. |
-| `invalid config: force_local+force_remote` | Both flags set simultaneously | `rch config edit` and unset one. Then `rch daemon reload`. |
+| `force_local` | `[general] force_local = true` is set | This is intentional. `rch config get general.force_local --sources` shows where it came from (autonomous). Reverting with `rch config set general.force_local false` edits config — **(authorize first)**. |
+| `invalid config: force_local+force_remote` | Both flags set simultaneously | `rch config edit` to unset one, then `rch daemon reload` — both mutate config/daemon, **(authorize first)**. |
 | `confidence below threshold` | Classifier flagged the command but only weakly (e.g., wrapped in shell pipelines). Threshold is `[compilation] confidence_threshold` (default 0.85). | If the command really should offload, lower the threshold or set `[general] force_remote = true` in `.rch/config.toml`. Better: run `rch diagnose "<the command>"` to see classifier confidence. |
 | `command '<base>' not in allowlist` | `[execution] allowlist` excludes this command base | `rch --json config get execution.allowlist` to inspect. Add the command base if you control the project's `.rch/config.toml`. |
 | `dependency preflight <RCH-Exxx>: <remediation>` | The closure planner refused to ship the workspace (cycle, missing manifest, off-canonical-root path dep). See the RCH-E013–E020 rows in `ERROR_CODES.md` and the path-dep section of `TROUBLESHOOTING.md`. | The remediation message is actionable; follow it. Then re-run `rch diagnose --dry-run "<command>"`. |
@@ -74,12 +74,12 @@ These come from the daemon's `SelectionReason` enum. The `[RCH] local (...)` sum
 |---|---|---|
 | `no_workers_configured` | `no workers configured` | `rch workers discover --add --yes && rch workers setup --all` adds and provisions workers — a fleet mutation; get caller authorization first. |
 | `all_workers_unreachable` | `all workers unreachable` | `rch workers probe --all` and read the SSH errors (autonomous); fixing a local key's permissions is local, but changing anything on a worker is remote mutation → authorize first. See `RECOVERY_PLAYBOOKS.md` Playbook C and the Network rows of `ERROR_CODES.md`. |
-| `all_circuits_open` | `all worker circuits open` | A worker hit repeated failures and tripped its circuit. Inspect with `rch --json status --workers \| jq '.data.daemon.workers[] \| {id, circuit_state, last_error, recovery_in_secs}'` and `rch daemon logs -n 200`. Use `rch workers enable <id>` after fixing the underlying cause; circuits also auto-close after the cooldown. |
-| `all_workers_busy` | `all workers at capacity` | Queueing is **on by default** (`RCH_QUEUE_WHEN_BUSY=1`); seeing this means the wait timed out. Bump `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` for the next invocation, or raise `total_slots`. Check `rch queue --watch` to see backlog. |
+| `all_circuits_open` | `all worker circuits open` | A worker hit repeated failures and tripped its circuit. Inspect with `rch --json status --workers \| jq '.data.daemon.workers[] \| {id, circuit_state, last_error, recovery_in_secs}'` and `rch daemon logs -n 200` (autonomous). Circuits auto-close after the cooldown; forcing `rch workers enable <id>` mutates worker state — **(authorize first)**. |
+| `all_workers_busy` | `all workers at capacity` | Queueing is **on by default** (`RCH_QUEUE_WHEN_BUSY=1`); seeing this means the wait timed out. Bump `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` for the next invocation (autonomous). Raising `total_slots` edits worker config — **(authorize first)**. Check `rch queue --watch` to see backlog. |
 | `all_workers_failed_preflight` | `all workers failed preflight checks` | Path-topology check, repo presence, or toolchain probe failed on every candidate. Re-run with `rch diagnose --dry-run "<command>"` to see the preflight pipeline; hits `RCH-E013..024`, `RCH-E205`, `RCH-E305`. |
 | `all_workers_failed_convergence` | `all workers failed repo convergence checks` | The repo updater contract couldn't bring required repos to a target state on any worker. Check that the sibling repos exist on workers under the canonical root. See the RCH-E013–E020 rows in `ERROR_CODES.md` and the path-dep section of `TROUBLESHOOTING.md`. |
-| `no_matching_workers` | `no matching workers found` | The project requires tags (e.g., `tags = ["bun"]`) and no worker carries them. `rch workers list --json` to inspect tags; add the tag to a capable worker. |
-| `no_workers_with_runtime` (value = runtime name) | `no workers with bun installed` (or `node`, `rust`, …) | Install the runtime on a worker, then `rch workers capabilities --refresh`. |
+| `no_matching_workers` | `no matching workers found` | The project requires tags (e.g., `tags = ["bun"]`) and no worker carries them. `rch workers list --json` to inspect tags (autonomous); adding the tag edits worker config — **(authorize first)**. |
+| `no_workers_with_runtime` (value = runtime name) | `no workers with bun installed` (or `node`, `rust`, …) | Installing the runtime on a worker and `rch workers capabilities --refresh` both mutate worker state — **(authorize first)**. |
 | `selection_error` (value = error text) | `selection error: <msg>` | An internal error during selection. Check `rch daemon logs -n 200`. Likely a code-side bug; capture `rch doctor --json` and `rch --json daemon status` for escalation. |
 
 Two more variants — `affinity_pinned` and `affinity_fallback` — are *success* paths (a worker was assigned via affinity), not fail-opens, so they never appear in `[RCH] local (...)` output.
@@ -144,32 +144,37 @@ If that prints `[RCH] remote <worker> (...)`, the offload path is healthy and th
 The skill resolves diagnosis autonomously — but the SKILL.md authority boundary
 governs, and this file does not widen it. Two tiers:
 
-**Autonomous (no need to ask) — the blast-radius ceiling.** Read-only diagnosis
-and reversible, local-only actions on *this* machine:
+**Autonomous (no need to ask) — the blast-radius ceiling is read-only.** Only
+diagnosis and inspection that mutates no host, worker, daemon, config, or
+filesystem state:
 
 - reading summary lines, stderr, and `rch daemon logs`;
-- `rch check`, `rch diagnose`, `rch --json ... probe/status/get/show`, `rch
-  config validate|doctor|show|get` — inspection, never mutation;
+- status/inspection commands: `rch check`, `rch status`, `rch --json daemon
+  status`, `rch diagnose`/`--dry-run`, `rch --json workers probe|list`, `rch
+  config get|show|validate|doctor|diff`, `rch hook status|test`, `rch fleet
+  status|verify`, `rch queue`, `rch self-test`;
 - tuning env vars for the *next* invocation (`RCH_VISIBILITY`, `RCH_LOG_LEVEL`,
   `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120`, `RCH_SSH_SERVER_ALIVE_INTERVAL_SECS`);
 - re-running the original command, including waiting out an auto-start cooldown
-  (the built-in `try_auto_start_daemon` handles stale sockets — do not `rm` them);
-- local, reversible hook repair on this machine (`rch hook status|install|test`);
-- fixing permissions on a **local** key file you own (`chmod 600 ~/.ssh/<key>`).
+  (the built-in `try_auto_start_daemon` handles stale sockets — do not `rm` them).
 
 **Requires explicit caller authorization first — even when a reason maps
-straight to one of these commands.** Anything remote, privileged, deployment-
-scale, daemon-lifecycle, or destructive crosses the ceiling:
+straight to one of these commands.** Every host, worker, daemon, config, or
+filesystem mutation crosses the ceiling. It does not matter that a table cell
+below lists the command — a listed command is not a pre-authorized one:
 
+- **local host mutation** — `rch hook install|uninstall` (writes
+  `~/.claude/settings.json`), `chmod` on a local key file, `rch config
+  set|edit|init`, and any edit to `~/.config/rch/*.toml`;
 - **remote host mutation** — any `ssh … sudo …`, remote `chown`/`chmod`/`rm`,
-  remote installs, changing a worker's `authorized_keys` or its host-key entry;
-- **worker / fleet deployment** — `rch workers sync-toolchain`, `workers
-  setup`, `workers deploy-binary`, `workers discover --add`, `workers
-  drain|disable|enable`, `rch fleet deploy|rollback`;
-- **daemon lifecycle / configuration** — manually `rch daemon start|restart|
-  reload`, `rch config set`, editing `~/.config/rch/*.toml`;
-- **destructive local cleanup** — removing sockets, cooldown/lock files, caches,
-  or moving the telemetry DB aside.
+  remote installs, restarting `sshd` or `rch-wkr` on a worker, changing a
+  worker's `authorized_keys` or its host-key entry;
+- **worker / fleet operations** — `rch workers
+  sync-toolchain|setup|deploy-binary|discover --add|drain|disable|enable|capabilities --refresh`,
+  `rch fleet deploy|rollback`;
+- **daemon lifecycle** — `rch daemon start|restart|reload|stop`;
+- **destructive cleanup** — removing sockets, cooldown/lock files, caches, or
+  moving the telemetry DB aside.
 
 For each reason, run the autonomous diagnosis, then, if the fix is above the
 ceiling, capture the evidence and get authorization before running it:
@@ -178,9 +183,9 @@ ceiling, capture the evidence and get authorization before running it:
   the auto-start cooldown and retry (autonomous). Manually starting/restarting
   the daemon, or removing the cooldown file, needs authorization.
 - **"all workers unreachable"** → `rch workers probe --all` and read the SSH
-  errors (autonomous); fixing a local key's permissions is local. Changing
-  anything **on** a worker (host-key entry, `authorized_keys`, restarting
-  `sshd`) is remote mutation → get authorization.
+  errors (autonomous). Every fix mutates state and needs authorization first:
+  `chmod` on a local key, and anything **on** a worker (host-key entry,
+  `authorized_keys`, restarting `sshd`).
 - **"all workers at capacity"** → queueing is on by default; bump
   `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` for the next run (autonomous).
   Raising `total_slots` edits worker config → authorization.

--- a/skills/rch/references/FAIL_OPEN.md
+++ b/skills/rch/references/FAIL_OPEN.md
@@ -7,11 +7,11 @@
 - [Fail-Open Reasons (and What To Do)](#fail-open-reasons-and-what-to-do)
 - [Detection Snippets](#detection-snippets)
 - [Force the Issue](#force-the-issue)
-- ["Don't Ask the Human" Rules](#dont-ask-the-human-rules)
+- [Autonomous Remediation Envelope (and Where It Stops)](#autonomous-remediation-envelope-and-where-it-stops)
 
 RCH's most expensive failure mode for agents is **silent fall-back to local execution**. The build "succeeded" — but it ran on the local machine, slowly, while the worker fleet sat idle. If you don't notice, you bake hours of extra latency into every iteration.
 
-This file is the canonical guide for: (1) how to *see* a fail-open, (2) what each fail-open reason means, and (3) what to do about it before asking the human.
+This file is the canonical guide for: (1) how to *see* a fail-open, (2) what each fail-open reason means, and (3) how to remediate it within the autonomous envelope — and where that envelope stops and explicit caller authorization begins.
 
 ---
 
@@ -56,15 +56,15 @@ Every reason in the parens comes from one of two sources:
 
 | Reason text | Triggered when | Self-fix |
 |---|---|---|
-| `daemon unavailable` | Daemon socket can't be reached (and auto-start failed or is disabled) | `rch daemon start && rch --json daemon status`. If still failing, check `~/.cache/rch/rch.sock` and look for stale auto-start cooldown (see `SELF_HEALING.md`). |
+| `daemon unavailable` | Daemon socket can't be reached (and auto-start failed or is disabled) | Wait out the auto-start cooldown and retry (autonomous). If still failing, confirm with `rch --json daemon status` and check `~/.cache/rch/rch.sock`; manually starting the daemon needs caller authorization. See `RECOVERY_PLAYBOOKS.md` Playbook B. |
 | `force_local` | `[general] force_local = true` is set | This is intentional. If you didn't expect it: `rch config get general.force_local --sources` shows where it came from. `rch config set general.force_local false` to revert. |
 | `invalid config: force_local+force_remote` | Both flags set simultaneously | `rch config edit` and unset one. Then `rch daemon reload`. |
 | `confidence below threshold` | Classifier flagged the command but only weakly (e.g., wrapped in shell pipelines). Threshold is `[compilation] confidence_threshold` (default 0.85). | If the command really should offload, lower the threshold or set `[general] force_remote = true` in `.rch/config.toml`. Better: run `rch diagnose "<the command>"` to see classifier confidence. |
 | `command '<base>' not in allowlist` | `[execution] allowlist` excludes this command base | `rch --json config get execution.allowlist` to inspect. Add the command base if you control the project's `.rch/config.toml`. |
-| `dependency preflight <RCH-Exxx>: <remediation>` | The closure planner refused to ship the workspace (cycle, missing manifest, off-canonical-root path dep). See `PATH_DEPENDENCIES.md`. | The remediation message is actionable; follow it. Then re-run `rch diagnose --dry-run "<command>"`. |
+| `dependency preflight <RCH-Exxx>: <remediation>` | The closure planner refused to ship the workspace (cycle, missing manifest, off-canonical-root path dep). See the RCH-E013–E020 rows in `ERROR_CODES.md` and the path-dep section of `TROUBLESHOOTING.md`. | The remediation message is actionable; follow it. Then re-run `rch diagnose --dry-run "<command>"`. |
 | `<TransferSkipped reason>` | Transfer pipeline opted out (e.g., empty workspace, all paths excluded). | Run `RCH_LOG_LEVEL=debug rch exec -- <command>` and look for `Transfer skipped:` log lines. |
 | `remote execution failed` | Generic catch-all for transfer/exec errors | Re-run with `RCH_LOG_LEVEL=debug` to surface the real error, and check `rch daemon logs -n 200` for the daemon side. |
-| `toolchain missing on <worker>` | Remote `rustup`/`cargo` not present, or no default toolchain | `rch workers sync-toolchain --all` (or just for that worker). Then `rch workers capabilities --refresh`. |
+| `toolchain missing on <worker>` | Remote `rustup`/`cargo` not present, or no default toolchain | Diagnose the gap (autonomous). `rch workers sync-toolchain --all` (or one worker) mutates the worker — get caller authorization first; then `rch workers capabilities --refresh`. |
 
 ### Daemon-decision fail-opens (selection reasons)
 
@@ -72,12 +72,12 @@ These come from the daemon's `SelectionReason` enum. The `[RCH] local (...)` sum
 
 | Snake_case tag (JSON) | Human form in `local (...)` summary | Self-fix |
 |---|---|---|
-| `no_workers_configured` | `no workers configured` | `rch workers discover --add --yes && rch workers setup --all`. |
-| `all_workers_unreachable` | `all workers unreachable` | `rch workers probe --all`; fix SSH (key path, host, port). See `SSH_TUNING.md`. |
+| `no_workers_configured` | `no workers configured` | `rch workers discover --add --yes && rch workers setup --all` adds and provisions workers — a fleet mutation; get caller authorization first. |
+| `all_workers_unreachable` | `all workers unreachable` | `rch workers probe --all` and read the SSH errors (autonomous); fixing a local key's permissions is local, but changing anything on a worker is remote mutation → authorize first. See `RECOVERY_PLAYBOOKS.md` Playbook C and the Network rows of `ERROR_CODES.md`. |
 | `all_circuits_open` | `all worker circuits open` | A worker hit repeated failures and tripped its circuit. Inspect with `rch --json status --workers \| jq '.data.daemon.workers[] \| {id, circuit_state, last_error, recovery_in_secs}'` and `rch daemon logs -n 200`. Use `rch workers enable <id>` after fixing the underlying cause; circuits also auto-close after the cooldown. |
 | `all_workers_busy` | `all workers at capacity` | Queueing is **on by default** (`RCH_QUEUE_WHEN_BUSY=1`); seeing this means the wait timed out. Bump `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` for the next invocation, or raise `total_slots`. Check `rch queue --watch` to see backlog. |
 | `all_workers_failed_preflight` | `all workers failed preflight checks` | Path-topology check, repo presence, or toolchain probe failed on every candidate. Re-run with `rch diagnose --dry-run "<command>"` to see the preflight pipeline; hits `RCH-E013..024`, `RCH-E205`, `RCH-E305`. |
-| `all_workers_failed_convergence` | `all workers failed repo convergence checks` | The repo updater contract couldn't bring required repos to a target state on any worker. Check that the sibling repos exist on workers under the canonical root. See `PATH_DEPENDENCIES.md`. |
+| `all_workers_failed_convergence` | `all workers failed repo convergence checks` | The repo updater contract couldn't bring required repos to a target state on any worker. Check that the sibling repos exist on workers under the canonical root. See the RCH-E013–E020 rows in `ERROR_CODES.md` and the path-dep section of `TROUBLESHOOTING.md`. |
 | `no_matching_workers` | `no matching workers found` | The project requires tags (e.g., `tags = ["bun"]`) and no worker carries them. `rch workers list --json` to inspect tags; add the tag to a capable worker. |
 | `no_workers_with_runtime` (value = runtime name) | `no workers with bun installed` (or `node`, `rust`, …) | Install the runtime on a worker, then `rch workers capabilities --refresh`. |
 | `selection_error` (value = error text) | `selection error: <msg>` | An internal error during selection. Check `rch daemon logs -n 200`. Likely a code-side bug; capture `rch doctor --json` and `rch --json daemon status` for escalation. |
@@ -139,15 +139,59 @@ If that prints `[RCH] remote <worker> (...)`, the offload path is healthy and th
 
 ---
 
-## "Don't Ask the Human" Rules
+## Autonomous Remediation Envelope (and Where It Stops)
 
-The skill exists so agents resolve these things autonomously. Concrete cases where the answer is **always do, never ask**:
+The skill resolves diagnosis autonomously — but the SKILL.md authority boundary
+governs, and this file does not widen it. Two tiers:
 
-- **"daemon unavailable"** → `rch daemon start && rch --json daemon status`. If the auto-start cooldown is active, wait or remove `${XDG_RUNTIME_DIR:-/tmp}/rch/hook_autostart.cooldown` and try again.
-- **"all workers unreachable"** → `rch workers probe --all` and inspect SSH errors. Don't ask "should I fix this?" — fix what's fixable (key permissions, missing host entries, dead daemon).
-- **"all workers at capacity"** → queueing is already on by default; bump `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` to wait longer, or raise `total_slots` if the fleet is genuinely undersized.
-- **"toolchain missing on X"** → `rch workers sync-toolchain --all`. The skill is designed for you to do this without confirmation.
-- **Stale unix socket detected** (auto-start log message) → already handled by `try_auto_start_daemon`. Don't manually `rm` the socket; just retry.
-- **Permission denied on `/data/projects/<repo>` over rsync** → if the repo on the worker is owned by `root`: `ssh ubuntu@<host> 'sudo chown -R ubuntu:ubuntu /data/projects/<repo> && sudo chmod 775 /data/projects/<repo>'`. This is a known recovery; don't escalate.
+**Autonomous (no need to ask) — the blast-radius ceiling.** Read-only diagnosis
+and reversible, local-only actions on *this* machine:
 
-When in genuine doubt — escalate after collecting `rch doctor --json`, `rch --json daemon status`, `rch --json workers probe --all`, and the failing command's stderr. That packet lets the human resolve in one round trip.
+- reading summary lines, stderr, and `rch daemon logs`;
+- `rch check`, `rch diagnose`, `rch --json ... probe/status/get/show`, `rch
+  config validate|doctor|show|get` — inspection, never mutation;
+- tuning env vars for the *next* invocation (`RCH_VISIBILITY`, `RCH_LOG_LEVEL`,
+  `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120`, `RCH_SSH_SERVER_ALIVE_INTERVAL_SECS`);
+- re-running the original command, including waiting out an auto-start cooldown
+  (the built-in `try_auto_start_daemon` handles stale sockets — do not `rm` them);
+- local, reversible hook repair on this machine (`rch hook status|install|test`);
+- fixing permissions on a **local** key file you own (`chmod 600 ~/.ssh/<key>`).
+
+**Requires explicit caller authorization first — even when a reason maps
+straight to one of these commands.** Anything remote, privileged, deployment-
+scale, daemon-lifecycle, or destructive crosses the ceiling:
+
+- **remote host mutation** — any `ssh … sudo …`, remote `chown`/`chmod`/`rm`,
+  remote installs, changing a worker's `authorized_keys` or its host-key entry;
+- **worker / fleet deployment** — `rch workers sync-toolchain`, `workers
+  setup`, `workers deploy-binary`, `workers discover --add`, `workers
+  drain|disable|enable`, `rch fleet deploy|rollback`;
+- **daemon lifecycle / configuration** — manually `rch daemon start|restart|
+  reload`, `rch config set`, editing `~/.config/rch/*.toml`;
+- **destructive local cleanup** — removing sockets, cooldown/lock files, caches,
+  or moving the telemetry DB aside.
+
+For each reason, run the autonomous diagnosis, then, if the fix is above the
+ceiling, capture the evidence and get authorization before running it:
+
+- **"daemon unavailable"** → confirm with `rch --json daemon status`; wait out
+  the auto-start cooldown and retry (autonomous). Manually starting/restarting
+  the daemon, or removing the cooldown file, needs authorization.
+- **"all workers unreachable"** → `rch workers probe --all` and read the SSH
+  errors (autonomous); fixing a local key's permissions is local. Changing
+  anything **on** a worker (host-key entry, `authorized_keys`, restarting
+  `sshd`) is remote mutation → get authorization.
+- **"all workers at capacity"** → queueing is on by default; bump
+  `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120` for the next run (autonomous).
+  Raising `total_slots` edits worker config → authorization.
+- **"toolchain missing on X"** → diagnose the gap (autonomous); running `rch
+  workers sync-toolchain` mutates the worker → get authorization first.
+- **Permission denied on `/data/projects/<repo>` over rsync** → the fix is a
+  remote privileged command (`ssh … 'sudo chown -R …'`). Report it to the
+  caller with the failing `stat` and get explicit authorization before running
+  it — remote `sudo` is never autonomous.
+
+When a fix is above the ceiling or you are in genuine doubt, surface the packet —
+`rch doctor --json`, `rch --json daemon status`, `rch --json workers probe
+--all`, the failing command's stderr, and the exact command you propose — so the
+caller can authorize (or decline) in one round trip.

--- a/skills/rch/references/RECOVERY_PLAYBOOKS.md
+++ b/skills/rch/references/RECOVERY_PLAYBOOKS.md
@@ -42,7 +42,7 @@ RCH_VISIBILITY=verbose cargo check 2>&1 | grep -E '^\[RCH\]'
 **Fix attempts:**
 
 1. If you see `[RCH] local (...)` — open `references/FAIL_OPEN.md` and look up the parenthetical reason. Apply the matching self-fix.
-2. If you see no `[RCH]` line at all — the hook isn't intercepting. Run `rch hook status`. If not installed: `rch hook install`. If installed but not firing: `rch hook test`.
+2. If you see no `[RCH]` line at all — the hook isn't intercepting. Run `rch hook status` and `rch hook test` (autonomous). If not installed, `rch hook install` writes `~/.claude/settings.json` — **(authorize first)**.
 3. If you see `[RCH] remote ...` — RCH is doing what it can; the slowness is real. Inspect `rch speedscore --all` and consider whether the project warrants a faster worker.
 
 **Verify:**
@@ -107,7 +107,7 @@ rch --json workers probe --all | jq '.data[] | {id, status, last_error}'
 1. **Verify queueing is on** — `RCH_QUEUE_WHEN_BUSY` is **already enabled by default** in current rch (only set `=0` to disable). If you still see `all workers at capacity`, queueing didn't help — the wait timed out.
 2. Bump the wait timeout for the next invocation: `RCH_DAEMON_WAIT_RESPONSE_TIMEOUT_SECS=120 <your-command>`.
 3. Check whether one worker is hot and others are cold (uneven distribution): `rch --json status --workers | jq '.data.daemon.workers[] | {id, used: .used_slots, total: .total_slots}'`.
-4. If aggregate capacity is the problem, raise `total_slots` on top workers in `~/.config/rch/workers.toml`, then `rch daemon reload`.
+4. If aggregate capacity is the problem, raising `total_slots` on top workers in `~/.config/rch/workers.toml` and `rch daemon reload` both mutate config/daemon — **(authorize first)**.
 5. Watch the backlog drain: `rch queue --watch` (this is an interactive polling view, not a TUI — Ctrl-C exits cleanly).
 
 **Verify:** Next `rch exec` lands `[RCH] remote <worker> (...)`.
@@ -188,8 +188,8 @@ cat ~/.claude/settings.json 2>/dev/null | jq '.hooks.PreToolUse'
 
 **Fix attempts:**
 
-1. Hook not installed → `rch hook install` (or `rch agents install-hook claude-code`).
-2. Hook command path is wrong → `rch hook install` re-resolves to the current absolute path.
+1. Hook not installed → `rch hook install` (or `rch agents install-hook claude-code`) writes `~/.claude/settings.json` — **(authorize first)**.
+2. Hook command path is wrong → `rch hook install` re-resolves to the current absolute path — same host write, **(authorize first)**.
 3. The Claude Code session predates the hook install → restart Claude Code (the harness only loads hooks on startup).
 4. Hook installed but fires for a different agent → confirm `rch agents list --json` includes the agent you're running under.
 
@@ -262,7 +262,7 @@ rch self-test history --limit 5 --json
 **Fix attempts:**
 
 1. Try a single worker with `--timeout 120 --debug`. If that works, the `--all` mode is hitting a slow worker — narrow down with `rch speedscore --all`.
-2. If self-test hangs against any single worker, that worker has a deeper problem. `rch workers probe <id>`, then drain it (`rch workers drain <id>`) and continue without it.
+2. If self-test hangs against any single worker, that worker has a deeper problem. `rch workers probe <id>` (autonomous); draining it (`rch workers drain <id>`) mutates worker state — **(authorize first)** — then continue without it.
 3. Capture a full doctor report: `rch doctor --json > /tmp/rch-doctor.json`. The pre-v1.0.16 self-test hang bug is fixed; if you reproduce on current rch, escalate with the doctor output.
 
 ---
@@ -278,7 +278,7 @@ rch config show --sources
 rch config diff                      # what differs from defaults
 ```
 
-If `rch config validate` flags an issue, fix the indicated line and `rch daemon reload`. If you can't see what's wrong, `git diff` of the config (if you keep it under version control) is your friend. Otherwise `rch config init` writes a clean baseline you can compare against.
+The four `rch config` inspection commands above are autonomous. If `rch config validate` flags an issue, fixing the indicated line and `rch daemon reload` both mutate config/daemon — **(authorize first)**. `git diff` of the config (if version-controlled) is a read-only aid; `rch config init` overwrites a clean baseline — **(authorize first)**.
 
 ---
 

--- a/skills/rch/references/RECOVERY_PLAYBOOKS.md
+++ b/skills/rch/references/RECOVERY_PLAYBOOKS.md
@@ -16,7 +16,15 @@
 - [Playbook L: TOML/config edit broke things](#playbook-l-tomlconfig-edit-broke-things)
 - [When the Playbook Doesn't Apply](#when-the-playbook-doesnt-apply)
 
-Each playbook is structured as: **observed signal → one-shot diagnostic → ordered fix attempts → verification**. Run them in order. Don't skip the diagnostic. Don't ask the human if the fix is in the playbook.
+Each playbook is structured as: **observed signal → one-shot diagnostic → ordered fix attempts → verification**. Run them in order; don't skip the diagnostic.
+
+Diagnostics and reversible, local-only fixes run autonomously. Any step that
+mutates a remote worker, runs `sudo`, starts/restarts/reconfigures the daemon,
+deploys binaries or toolchains, or deletes state requires explicit caller
+authorization **first** — the SKILL.md authority boundary governs, and a playbook
+listing a command does not pre-authorize it (see `FAIL_OPEN.md` §"Autonomous
+Remediation Envelope"). Where a step below crosses that ceiling it is marked
+**(authorize first)**.
 
 For unknown symptoms or a stuck loop, fall through to the bottom of this file ("When the Playbook Doesn't Apply") for the escalation packet.
 
@@ -62,8 +70,8 @@ ls -la "${XDG_RUNTIME_DIR:-/tmp}/rch/" 2>&1
 1. If `which rchd` is empty → daemon binary missing. Install rch (see project README).
 2. If autostart cooldown is recent → wait 5–10 seconds and retry the original command.
 3. If autostart lock is held by no process → it's stale. Ask user authorization, then `rm "${XDG_RUNTIME_DIR:-/tmp}/rch/hook_autostart.lock"`.
-4. Foreground spawn to surface the real error: `rch daemon start`. Read its stderr.
-5. If `rch daemon start` succeeds but the hook still doesn't see the daemon, check socket consistency: `rch --json config get general.socket_path` and `rch --json daemon status | jq '.data.socket_path'` must match. If they don't: `rch daemon restart -y`.
+4. Foreground spawn to surface the real error: `rch daemon start` **(authorize first)** — starting the daemon is a lifecycle mutation. Read its stderr.
+5. If `rch daemon start` succeeds but the hook still doesn't see the daemon, check socket consistency: `rch --json config get general.socket_path` and `rch --json daemon status | jq '.data.socket_path'` must match (autonomous inspection). If they don't: `rch daemon restart -y` **(authorize first)**.
 
 **Verify:** `rch check` returns `ready`.
 
@@ -118,9 +126,9 @@ RCH_LOG_LEVEL=debug rch exec -- env CARGO_TARGET_DIR="${TMPDIR:-/tmp}/rch_target
 
 **Fix attempts:**
 
-1. If a path-dep error (RCH-E013..016) → see `PATH_DEPENDENCIES.md` for the exact code.
-2. If `RCH_TOPOLOGY_ERR_CANONICAL_NOT_DIRECTORY` or `_ALIAS_NOT_SYMLINK` in worker stderr → fix the topology on the worker (`/data/projects` should be a directory; `/dp` should be a symlink to it).
-3. If `RCH-E205 Worker missing toolchain` → `rch workers sync-toolchain --all`.
+1. If a path-dep error (RCH-E013..016) → see the RCH-E013–E020 rows in `ERROR_CODES.md` and the path-dep section of `TROUBLESHOOTING.md` for the exact code.
+2. If `RCH_TOPOLOGY_ERR_CANONICAL_NOT_DIRECTORY` or `_ALIAS_NOT_SYMLINK` in worker stderr → fixing the topology on the worker (`/data/projects` should be a directory; `/dp` should be a symlink to it) is remote mutation **(authorize first)**.
+3. If `RCH-E205 Worker missing toolchain` → `rch workers sync-toolchain --all` **(authorize first)** — it mutates the worker.
 4. If `RCH-E305 Remote working dir error` → typically mirror perms broken; see Playbook F.
 
 **Verify:** `rch diagnose --dry-run "<command>"` reports `Ready` for the closure plan.
@@ -136,9 +144,12 @@ RCH_LOG_LEVEL=debug rch exec -- env CARGO_TARGET_DIR="${TMPDIR:-/tmp}/rch_target
 ssh ubuntu@<worker> "stat -c '%U:%G %a %n' /data/projects/<repo>"
 ```
 
-**Fix:**
+**Fix (authorize first):** the repair is a remote privileged command. Report the
+failing `stat` and the exact command to the caller and get explicit
+authorization before running it — remote `sudo` is never autonomous.
 
 ```bash
+# after explicit caller authorization only:
 ssh ubuntu@<worker> 'sudo chown -R ubuntu:ubuntu /data/projects/<repo> && sudo chmod 775 /data/projects/<repo>'
 rch exec -- env CARGO_TARGET_DIR="${TMPDIR:-/tmp}/rch_target_$(basename "$PWD")" cargo check
 ```
@@ -151,7 +162,7 @@ If you see this on multiple repos, audit who's doing `sudo git clone` or running
 
 **Signal:** `[RCH] remote <worker> failed [RCH-E210]` (or `E211/E215/E216/E217`); or `rch status` calls out a worker as critical.
 
-See the dedicated `DISK_AND_PRESSURE.md`. TL;DR:
+See the RCH-E210–E217 rows in `ERROR_CODES.md` and hand disk reclaim to the `sbh` skill. TL;DR:
 
 ```bash
 rch --json status --workers | jq '.data.daemon.workers[] | select(.pressure_state != "healthy") | {id, pressure_state, pressure_reason_code, pressure_disk_free_gb}'
@@ -220,18 +231,21 @@ rch fleet status --json    # exact JSON shape varies by version; inspect first
 rch fleet verify           # human-readable comparison of installed binaries
 ```
 
-**Fix:**
+**Fix (authorize first):** fleet deployment mutates every worker binary. Present
+the `rch fleet status`/`verify` evidence and the proposed rollout to the caller
+and get explicit authorization before any `deploy`/`rollback`.
 
 ```bash
+# after explicit caller authorization only:
 rch fleet deploy --canary 25 --canary-wait 60 --verify
 # observe output, then
 rch fleet deploy --verify           # full rollout
 rch fleet verify                    # confirm uniform
 ```
 
-If rollback is needed: `rch fleet rollback --verify`.
+If rollback is needed (also authorize first): `rch fleet rollback --verify`.
 
-For a single worker, `rch fleet deploy --worker <id> --verify` (deploy, single host).
+For a single worker, `rch fleet deploy --worker <id> --verify` (deploy, single host) — still authorize first.
 
 ---
 
@@ -249,7 +263,7 @@ rch self-test history --limit 5 --json
 
 1. Try a single worker with `--timeout 120 --debug`. If that works, the `--all` mode is hitting a slow worker — narrow down with `rch speedscore --all`.
 2. If self-test hangs against any single worker, that worker has a deeper problem. `rch workers probe <id>`, then drain it (`rch workers drain <id>`) and continue without it.
-3. Capture a full doctor report: `rch doctor --json > /tmp/rch-doctor.json`. The pre-v1.0.16 hang bug `bd-w5r9` is fixed; if you reproduce on current rch, escalate with the doctor output.
+3. Capture a full doctor report: `rch doctor --json > /tmp/rch-doctor.json`. The pre-v1.0.16 self-test hang bug is fixed; if you reproduce on current rch, escalate with the doctor output.
 
 ---
 

--- a/skills/rch/references/TROUBLESHOOTING.md
+++ b/skills/rch/references/TROUBLESHOOTING.md
@@ -89,7 +89,11 @@ rch workers setup --all
 
 **Cause:** missing toolchain on one or more workers.
 
+`rch workers sync-toolchain --all` mutates the workers — get explicit caller
+authorization first (`rch workers capabilities --refresh` after is read-only):
+
 ```bash
+# after explicit caller authorization only:
 rch workers sync-toolchain --all
 rch workers capabilities --refresh
 ```
@@ -142,9 +146,12 @@ Check:
 ssh ubuntu@<host> "stat -c '%U:%G %a %n' /data/projects/<repo>"
 ```
 
-Fix:
+Fix (authorize first): this is a remote privileged command. Report the failing
+`stat` output and the exact command to the caller and get explicit authorization
+before running it — remote `sudo` is never autonomous.
 
 ```bash
+# after explicit caller authorization only:
 ssh ubuntu@<host> 'sudo chown -R ubuntu:ubuntu /data/projects/<repo> && sudo chmod 775 /data/projects/<repo>'
 ```
 
@@ -219,8 +226,12 @@ RCH_LOG_LEVEL=debug printf '%s\n' \
 
 ## Safe Reset Sequence
 
+The `rch daemon restart -y` that opens this sequence is a daemon-lifecycle
+mutation — get explicit caller authorization before running it; the remaining
+steps are read-only.
+
 ```bash
-rch daemon restart -y
+rch daemon restart -y          # authorize first
 rch config validate
 rch config doctor
 rch workers probe --all
@@ -255,25 +266,28 @@ If a circuit doesn't auto-clear after 60 seconds and the underlying probe is hea
 
 **Symptom:** New rch CLI features behave inconsistently; `rch --version` differs from the daemon's reported version.
 
-**Self-fix (this is safe — never ask first):**
+**Diagnosis is autonomous; the restart is a daemon-lifecycle mutation — authorize first.**
 
-The daemon's running version is reported by `rch --json status` at `.data.daemon.daemon.version` (the `rch --json daemon status` endpoint deliberately returns only running/socket/uptime — not version). Compare:
+The daemon's running version is reported by `rch --json status` at `.data.daemon.daemon.version` (the `rch --json daemon status` endpoint deliberately returns only running/socket/uptime — not version). Compare (read-only):
 
 ```bash
 rch --version | awk '{print $2}'
 rch --json status | jq -r '.data.daemon.daemon.version'
-# If they differ:
+# If they differ, restart AFTER explicit caller authorization:
 rch daemon restart -y                                    # drains in-flight builds gracefully
 rch --json status | jq -r '.data.daemon.daemon.version'  # confirm equal
 ```
 
-`rch daemon restart -y` is the **documented upgrade path**. It drains active builds before stopping. The `-y` skips the interactive prompt — but it does *not* skip the drain.
+`rch daemon restart -y` is the **documented upgrade path**. It drains active builds before stopping. The `-y` skips the interactive prompt — but it does *not* skip the drain, and it does *not* skip the caller-authorization requirement.
 
-If a worker shows mismatched binary version after a host upgrade:
+If a worker shows mismatched binary version after a host upgrade, diagnose with
+`status`/`verify` (read-only), then deploy only after explicit caller
+authorization — fleet deploy mutates every worker binary:
 
 ```bash
-rch fleet status              # human-readable per-worker status
-rch fleet verify              # compare installed vs expected
+rch fleet status              # human-readable per-worker status (read-only)
+rch fleet verify              # compare installed vs expected (read-only)
+# after explicit caller authorization only:
 rch fleet deploy --canary 25 --canary-wait 60 --verify
 rch fleet deploy --verify
 ```
@@ -284,7 +298,7 @@ rch fleet deploy --verify
 
 **Symptom:** Recurring `RCH-E507`, `Telemetry database integrity check failed`, empty `rch speedscore --history`, daemon log lines mentioning `database disk image is malformed`.
 
-**Self-fix:** Stop the daemon, move `~/.local/share/rch/telemetry/telemetry.db*` aside, restart. Telemetry is derived data; you lose history but nothing operational.
+**Fix (authorize first):** stopping the daemon, moving `~/.local/share/rch/telemetry/telemetry.db*` aside, and restarting is a daemon-lifecycle mutation plus local file removal — get explicit caller authorization first. Telemetry is derived data; you lose history but nothing operational.
 
 ---
 

--- a/skills/rch/references/TROUBLESHOOTING.md
+++ b/skills/rch/references/TROUBLESHOOTING.md
@@ -52,14 +52,20 @@ Compilation running locally instead of remotely?
 
 ## Common Errors
 
+> **Authority:** only read-only diagnosis is autonomous. Any recipe below that
+> starts/restarts/reloads the daemon, adds/provisions/drains a worker or its
+> toolchain, edits config, installs the hook, or mutates a remote host requires
+> explicit caller authorization first — see `FAIL_OPEN.md` §"Autonomous
+> Remediation Envelope". Such steps are called out per block.
+
 ### Daemon not running / `check` says not ready
 
 **Cause:** daemon process absent or startup failure.
 
 ```bash
-rch daemon start
-rch --json daemon status
-rch daemon logs -n 200
+rch --json daemon status          # autonomous
+rch daemon logs -n 200            # autonomous
+rch daemon start                  # (authorize first) — daemon lifecycle
 ```
 
 ### Socket mismatch between config and daemon
@@ -67,10 +73,10 @@ rch daemon logs -n 200
 **Cause:** `general.socket_path` differs from active daemon socket.
 
 ```bash
-rch --json config get general.socket_path
-rch --json daemon status
-# then align and restart:
-rch daemon restart -y
+rch --json config get general.socket_path   # autonomous
+rch --json daemon status                     # autonomous
+# then align and restart AFTER explicit caller authorization:
+rch daemon restart -y                        # (authorize first)
 ```
 
 ### "No workers available" / probe failures
@@ -78,11 +84,12 @@ rch daemon restart -y
 **Cause:** no workers configured, SSH/auth failures, or workers are disabled/drained.
 
 ```bash
-rch workers list
-rch workers probe --all
-rch workers discover --probe
-rch workers discover --add --yes
-rch workers setup --all
+rch workers list                  # autonomous
+rch workers probe --all           # autonomous
+rch workers discover --probe      # autonomous (probe only)
+# adding/provisioning workers mutates the fleet — authorize first:
+rch workers discover --add --yes  # (authorize first)
+rch workers setup --all           # (authorize first)
 ```
 
 ### "rustup: not found" / "cargo: not found" on worker
@@ -105,10 +112,10 @@ If still failing, SSH to the specific worker and validate `rustup`, `cargo`, and
 **Cause:** hook missing, wrong binary path, or command classified as local.
 
 ```bash
-rch hook status
-rch hook install
-rch hook test
-rch diagnose "cargo build --release"
+rch hook status                        # autonomous
+rch hook test                          # autonomous
+rch diagnose "cargo build --release"   # autonomous
+rch hook install                       # (authorize first) — writes ~/.claude/settings.json
 ```
 
 ### Sync/transfer fails under active target churn
@@ -116,9 +123,10 @@ rch diagnose "cargo build --release"
 **Cause:** build artifacts changing during rsync.
 
 ```bash
-# Add target-like excludes in ~/.config/rch/config.toml [transfer].exclude_patterns
-rch daemon reload
-rch config show --sources
+# Editing ~/.config/rch/config.toml [transfer].exclude_patterns and reloading
+# both mutate config/daemon — (authorize first):
+rch daemon reload                 # (authorize first)
+rch config show --sources         # autonomous
 ```
 
 Also inspect the worker directly:
@@ -314,7 +322,7 @@ rch fleet deploy --verify
    printf '%s\n' '{"tool_name":"Bash","tool_input":{"command":"<your-command>"}}' | rch
    ```
    If stdout is empty, the classifier is rejecting your command. Common causes: shell pipe (`cargo build | tee log`), backgrounded with `&`, env-prefixed in an unusual form. Restructure or use `rch exec -- <cmd>` directly.
-3. If the hook fires but the command still runs locally, the rewrite isn't being honored — check that `~/.claude/settings.json` has the right hook command path (`rch hook install` re-resolves it).
+3. If the hook fires but the command still runs locally, the rewrite isn't being honored — check that `~/.claude/settings.json` has the right hook command path (reading it is autonomous; `rch hook install` re-resolves it but writes that file — **(authorize first)**).
 
 See `references/FAIL_OPEN.md` for the full taxonomy.
 

--- a/skills/rch/references/WORKERS.md
+++ b/skills/rch/references/WORKERS.md
@@ -10,6 +10,15 @@
 - [Worker Selection Notes](#worker-selection-notes)
 - [SSH Verification Shortcuts](#ssh-verification-shortcuts)
 
+> **Authority:** this is a command catalog, not a licence to run it. Only the
+> read-only probes here (`rch workers list`, `rch workers probe`, `rch fleet
+> status`, `rch fleet verify`) are autonomous. Everything that adds, sets up,
+> drains, disables, enables, syncs a toolchain to, or deploys a binary to a
+> worker — and every `rch fleet deploy|rollback` — is a host mutation requiring
+> explicit caller authorization first (see `FAIL_OPEN.md` §"Autonomous
+> Remediation Envelope"). The `--dry-run` variants shown are the read-only way to
+> preview before you ask.
+
 ## Worker Lifecycle
 
 ### 1) Discover and add workers

--- a/skills/swarm/SKILL.md
+++ b/skills/swarm/SKILL.md
@@ -31,6 +31,14 @@ The caller supplies every complete packet, proves their write scopes disjoint,
 and chooses the executor. Swarm dispatches each packet once, preserves packet and
 context identities, collects results, and stops.
 
+Write scopes must be **workspace-relative and canonical** — symlink-resolved and
+already normalized. The disjointness check is lexical: it case-folds prefixes so
+scopes differing only by case are treated as a collision (safe on
+case-insensitive filesystems), but it cannot see a symlink that aliases two
+scopes onto one target. Supplying non-canonical or symlinked scopes forfeits the
+disjointness guarantee; a non-empty `write_scope.exclude` is rejected, not
+silently ignored, because the proof cannot honor it.
+
 Exactly-once dispatch over proven-disjoint scopes is why parallel failures stay
 independent: no packet can observe, block, or corrupt another, so N packets
 yield N verdicts about N experiments rather than one tangle.
@@ -47,6 +55,11 @@ The reference implementation is [`scripts/dispatch_once.py`](scripts/dispatch_on
 It validates the entire explicit batch before the first call, invokes the supplied
 executor exactly once for each packet, and returns executor exceptions as factual
 per-packet errors.
+
+Swarm's own effect is invoking the selected executor once per packet; the real
+blast radius rides on the packets. Each packet's transitive effects — whatever
+its executor writes, runs, or reaches — are the caller's to declare on the
+packet, not Swarm's to bound.
 
 Swarm does not select work, create packets, schedule from a backlog, persist a
 queue, claim ownership, retry, validate, integrate, close, use Git, or deliver.

--- a/skills/swarm/scripts/dispatch_once.py
+++ b/skills/swarm/scripts/dispatch_once.py
@@ -19,6 +19,14 @@ def _includes(packet: Mapping[str, Any]) -> tuple[str, ...]:
     scope = packet.get("write_scope")
     if not isinstance(scope, Mapping):
         raise ValueError(f"{_packet_id(packet)}: write_scope must be an object")
+    # `exclude` is not honored by the lexical disjointness proof below. Admitting
+    # it silently would let a packet look narrower than it dispatches, so reject
+    # its presence rather than ignore it.
+    if scope.get("exclude"):
+        raise ValueError(
+            f"{_packet_id(packet)}: write_scope.exclude is not honored by the "
+            "disjointness proof — remove it or narrow include instead"
+        )
     raw = scope.get("include")
     if not isinstance(raw, list) or not raw:
         raise ValueError(f"{_packet_id(packet)}: write_scope.include must be nonempty")
@@ -49,8 +57,14 @@ def _overlap(left: str, right: str) -> bool:
             parts.append(part)
         return PurePosixPath(*parts).as_posix() if parts else "."
 
-    left_prefix = literal_prefix(left)
-    right_prefix = literal_prefix(right)
+    # Case-fold the comparison so scopes differing only by case ("src/Auth" vs
+    # "src/auth") are treated as a possible collision. On a case-insensitive
+    # filesystem they ARE the same path; on a case-sensitive one this only
+    # over-rejects, matching this module's reject-when-uncertain stance. Paths
+    # must already be workspace-relative and canonical (symlink-resolved): the
+    # check is lexical and cannot detect a symlink alias to a shared target.
+    left_prefix = literal_prefix(left).casefold()
+    right_prefix = literal_prefix(right).casefold()
     if left_prefix == "." or right_prefix == ".":
         return True
     return (

--- a/skills/swarm/tests/test_dispatch_once.py
+++ b/skills/swarm/tests/test_dispatch_once.py
@@ -87,6 +87,34 @@ class DispatchOnceTests(unittest.TestCase):
                 lambda _value: None,
             )
 
+    def test_case_only_scope_difference_is_rejected(self) -> None:
+        calls = 0
+
+        def executor(_value: dict) -> None:
+            nonlocal calls
+            calls += 1
+
+        with self.assertRaisesRegex(ValueError, "write scopes overlap"):
+            MODULE.dispatch_once(
+                [packet("a", "src/Auth"), packet("b", "src/auth")], executor
+            )
+        self.assertEqual(calls, 0)
+
+    def test_nonempty_exclude_is_rejected_not_ignored(self) -> None:
+        with self.assertRaisesRegex(ValueError, "exclude is not honored"):
+            MODULE.dispatch_once(
+                [
+                    {
+                        "packet_id": "a",
+                        "write_scope": {
+                            "include": ["src/a"],
+                            "exclude": ["src/a/skip"],
+                        },
+                    }
+                ],
+                lambda _value: None,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/using-gc/SKILL.md
+++ b/skills/using-gc/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   tier: execution
   dependencies: []
   capabilities: [dispatch_explicit_packet, observe_gc_runtime, drive_mayor_shepherd]
-  effects: [operate_gas_city]
+  effects: [operate_gas_city, configure_codex_trust]
   canonical_status: canonical
   disposition: keep_optional_adapter
 output_contract: runtime evidence per supplied packet
@@ -75,12 +75,16 @@ wedged on an interactive prompt doing nothing. Trust ground truth:
 
 - `gc session list --json` / `mayor status` is the roster claim.
 - `tmux -L <socket> capture-pane -pt <session>` is ground truth — read the pane.
+  The `<socket>` and `<session>` here (and at every `tmux -L` site below) are the
+  ones `mayor status` prints in its `tmux -L <socket> attach -t <session>` line.
 - Two known codex wedge classes and their durable fixes:
   - **Update nag:** codex blocks on an "update available" prompt. Fix: update
     codex so no pending-update prompt exists before the run.
   - **Folder trust:** codex blocks asking to trust the working directory. Fix:
     add exact-path `trust_level` entries for the rig and worktree-root in
-    `~/.codex/config.toml` (bootstrap does not write them yet).
+    `~/.codex/config.toml` (bootstrap does not write them yet). This edits the
+    user's global codex config — a host-configuration mutation; make it only
+    with explicit caller authorization, scoped to those exact paths.
 
 When the roster says active but the pane is wedged, the pane wins.
 

--- a/skills/using-gc/SKILL.md
+++ b/skills/using-gc/SKILL.md
@@ -79,7 +79,9 @@ wedged on an interactive prompt doing nothing. Trust ground truth:
   ones `mayor status` prints in its `tmux -L <socket> attach -t <session>` line.
 - Two known codex wedge classes and their durable fixes:
   - **Update nag:** codex blocks on an "update available" prompt. Fix: update
-    codex so no pending-update prompt exists before the run.
+    codex so no pending-update prompt exists before the run. Updating the codex
+    binary is a host mutation — make it only with explicit caller authorization,
+    the same bar as the trust-config edit below.
   - **Folder trust:** codex blocks asking to trust the working directory. Fix:
     add exact-path `trust_level` entries for the rig and worktree-root in
     `~/.codex/config.toml` (bootstrap does not write them yet). This edits the


### PR DESCRIPTION
## Summary

Wave W6 of the skill-overhaul reboot (`age-skill-overhaul-reboot-sjv7v.7`) — the eight runtime-adapter skills, every checklist item verified against the live tree first.

- **rch** [P0] — shipped reference docs instructed "always do, never ask" for remote `sudo chown -R`/`chmod`, daemon lifecycle, and fleet toolchain sync. Now: a strictly read-only autonomous diagnosis tier; every mutating first-action/self-fix across all seven reference docs marked **(authorize first)** (mechanical sweep); authority banners on the previously-ungated catalog docs; re-running the original command is autonomous only when that command is itself read-only; config-threshold/force_remote/allowlist edits and local key repair all gated.
- **agent-mail** [P0] — default coordination mode split from an explicitly-authorized admin/DR mode (gating `clear-and-reset-everything`); retired `python -m` CLI rewritten onto the verified `am` CLI; typed unavailable/timeout/cleanup outcomes.
- **codex-exec** — wall-clock deadline is mandatory (declared 600s default), expiry is fail-closed, and process-group tree reaping is a precondition: a host that cannot guarantee it does not run (capability unavailable) — no disclosure escape hatch.
- **using-gc** — the conditional `~/.codex/config.toml` trust write and the codex binary update are both gated behind explicit caller authorization.
- **agent-native** — equal author/validator context ids rejected before any freshness attestation; reproducibility via `SOURCE_DATE_EPOCH`.
- **swarm** — disjointness check case-folded; non-empty `write_scope.exclude` rejected instead of ignored; two new test witnesses.
- **agy-native / ntm** — discovery commands named, unavailable/deadline/cleanup behavior explicit, effects declared.

Ledger (31 fixed / 3 rejected-with-reason / 7 deferred-with-reason): `docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w6.md`.

## Validation

- 49/49 strict frontmatter; regen clean; liveness + anti-spiral bats green; scenario-linkage PASS; swarm tests 8/8 (2 new witnesses); agent-native fake-runner 5/5; python ratchet no-growth
- Cross-family review, two rounds (ceiling): round 1 three findings fixed (read-only autonomous tier, gated updates, mandatory deadlines); round 2 residuals fixed with the exact prescriptions (read-only re-run rule, config-mutation gates, fail-closed reaping — the disclosure escape hatch removed)

Tracker: `age-skill-overhaul-reboot-sjv7v.7`