### PR TITLE
W7 support wave: handoff schema truth, dcg fact corrections, honest support contracts

### DIFF
--- a/cli/cmd/ao/handoff.go
+++ b/cli/cmd/ao/handoff.go
@@ -65,9 +65,11 @@ func runHandoff(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("get cwd: %w", err)
 	}
 	now := time.Now().UTC()
+	// The id is second-granular to satisfy handoff.v1.schema.json's id pattern
+	// (^handoff-[0-9]{8}T[0-9]{6}Z$); created_at keeps full sub-second precision.
 	artifact := handoffArtifact{
 		SchemaVersion: 1,
-		ID:            "handoff-" + now.Format("20060102T150405.000000000Z"),
+		ID:            "handoff-" + now.Format("20060102T150405Z"),
 		CreatedAt:     now.Format(time.RFC3339Nano),
 		Goal:          handoffGoal,
 		Continuation:  handoffContinuation,

--- a/cli/cmd/ao/handoff.go
+++ b/cli/cmd/ao/handoff.go
@@ -65,11 +65,12 @@ func runHandoff(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("get cwd: %w", err)
 	}
 	now := time.Now().UTC()
-	// The id is second-granular to satisfy handoff.v1.schema.json's id pattern
-	// (^handoff-[0-9]{8}T[0-9]{6}Z$); created_at keeps full sub-second precision.
+	// The id carries sub-second precision so two handoffs written in the same
+	// second cannot collide on the same .agents/handoff/<id>.json path. The
+	// handoff.v1.schema.json id pattern accepts the optional fractional part.
 	artifact := handoffArtifact{
 		SchemaVersion: 1,
-		ID:            "handoff-" + now.Format("20060102T150405Z"),
+		ID:            "handoff-" + now.Format("20060102T150405.000000000Z"),
 		CreatedAt:     now.Format(time.RFC3339Nano),
 		Goal:          handoffGoal,
 		Continuation:  handoffContinuation,

--- a/cli/cmd/ao/handoff_test.go
+++ b/cli/cmd/ao/handoff_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+// TestHandoffDryRunSatisfiesSchema proves the `ao session handoff --dry-run`
+// generator agrees with schemas/handoff.v1.schema.json: the id matches the
+// schema id pattern, every schema-required property is present, and the
+// artifact emits no key the schema (additionalProperties:false) forbids. This
+// locks the reconciliation that removed the stale type/consumed/rpi machinery
+// and dropped the fractional-second id (the three verbatim schema errors).
+func TestHandoffDryRunSatisfiesSchema(t *testing.T) {
+	// Resolve the schema path from the package directory before t.Chdir moves
+	// the working directory to a temp dir.
+	schemaPath, err := filepath.Abs(filepath.Join("..", "..", "..", "schemas", "handoff.v1.schema.json"))
+	if err != nil {
+		t.Fatalf("resolve schema path: %v", err)
+	}
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	handoffGoal = "prove one behavior"
+	handoffContinuation = ""
+	handoffCollect = false
+	handoffDryRun = true
+	t.Cleanup(func() {
+		handoffGoal, handoffContinuation = "", ""
+		handoffCollect, handoffDryRun = false, false
+	})
+
+	var out bytes.Buffer
+	cmd := *handoffCmd
+	cmd.SetOut(&out)
+	if err := runHandoff(&cmd, []string{"candidate failed validation"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var artifact map[string]any
+	if err := json.Unmarshal(out.Bytes(), &artifact); err != nil {
+		t.Fatalf("dry-run output is not valid JSON: %v\n%s", err, out.String())
+	}
+
+	// Load the schema the artifact must satisfy.
+	raw, err := os.ReadFile(schemaPath)
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	var schema struct {
+		Required   []string `json:"required"`
+		Properties map[string]struct {
+			Pattern string `json:"pattern"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+
+	// Error 1+2 fixed: every required property is present.
+	for _, req := range schema.Required {
+		if _, ok := artifact[req]; !ok {
+			t.Errorf("artifact missing schema-required property %q", req)
+		}
+	}
+
+	// additionalProperties:false — every emitted key is a declared property.
+	for key := range artifact {
+		if _, ok := schema.Properties[key]; !ok {
+			t.Errorf("artifact emits key %q not declared in schema (additionalProperties:false)", key)
+		}
+	}
+
+	// The stale consumption/phase machinery must never reappear.
+	for _, forbidden := range []string{"type", "consumed", "consumed_at", "consumed_by", "rpi"} {
+		if _, ok := artifact[forbidden]; ok {
+			t.Errorf("artifact leaked retired lifecycle field %q", forbidden)
+		}
+	}
+
+	// Error 3 fixed: id matches the schema pattern exactly (second-granular,
+	// no fractional seconds).
+	idPattern := schema.Properties["id"].Pattern
+	if idPattern == "" {
+		t.Fatal("schema declares no id pattern")
+	}
+	id, _ := artifact["id"].(string)
+	if !regexp.MustCompile(idPattern).MatchString(id) {
+		t.Errorf("id %q does not match schema pattern %q", id, idPattern)
+	}
+}

--- a/cli/cmd/ao/handoff_test.go
+++ b/cli/cmd/ao/handoff_test.go
@@ -5,30 +5,29 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"regexp"
 	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 // TestHandoffDryRunSatisfiesSchema proves the `ao session handoff --dry-run`
-// generator agrees with schemas/handoff.v1.schema.json: the id matches the
-// schema id pattern, every schema-required property is present, and the
-// artifact emits no key the schema (additionalProperties:false) forbids. This
-// locks the reconciliation that removed the stale type/consumed/rpi machinery
-// and dropped the fractional-second id (the three verbatim schema errors).
+// generator agrees with schemas/handoff.v1.schema.json using a real JSON Schema
+// validator (santhosh-tekuri/jsonschema/v6 — the same dependency the eval and
+// provenance drift guards use, with the same compile-then-Validate pattern and
+// its default format-annotation behaviour). This checks types, the
+// schema_version const, the id pattern, enums, and nested additionalProperties,
+// not mere key presence. It locks the reconciliation that dropped the three
+// verbatim schema errors while keeping the deprecated read-compat fields
+// accepted.
 func TestHandoffDryRunSatisfiesSchema(t *testing.T) {
-	// Resolve the schema path from the package directory before t.Chdir moves
-	// the working directory to a temp dir.
-	schemaPath, err := filepath.Abs(filepath.Join("..", "..", "..", "schemas", "handoff.v1.schema.json"))
-	if err != nil {
-		t.Fatalf("resolve schema path: %v", err)
-	}
+	schema := compileHandoffSchema(t)
 
 	dir := t.TempDir()
 	t.Chdir(dir)
 
 	handoffGoal = "prove one behavior"
-	handoffContinuation = ""
-	handoffCollect = false
+	handoffContinuation = "caller will choose whether to revise"
+	handoffCollect = true // exercise the nested state block too
 	handoffDryRun = true
 	t.Cleanup(func() {
 		handoffGoal, handoffContinuation = "", ""
@@ -42,55 +41,72 @@ func TestHandoffDryRunSatisfiesSchema(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var artifact map[string]any
-	if err := json.Unmarshal(out.Bytes(), &artifact); err != nil {
+	instance, err := jsonschema.UnmarshalJSON(bytes.NewReader(out.Bytes()))
+	if err != nil {
 		t.Fatalf("dry-run output is not valid JSON: %v\n%s", err, out.String())
 	}
-
-	// Load the schema the artifact must satisfy.
-	raw, err := os.ReadFile(schemaPath)
-	if err != nil {
-		t.Fatalf("read schema: %v", err)
-	}
-	var schema struct {
-		Required   []string `json:"required"`
-		Properties map[string]struct {
-			Pattern string `json:"pattern"`
-		} `json:"properties"`
-	}
-	if err := json.Unmarshal(raw, &schema); err != nil {
-		t.Fatalf("parse schema: %v", err)
+	if err := schema.Validate(instance); err != nil {
+		t.Fatalf("dry-run output does not satisfy handoff.v1.schema.json:\n%v\n%s", err, out.String())
 	}
 
-	// Error 1+2 fixed: every required property is present.
-	for _, req := range schema.Required {
-		if _, ok := artifact[req]; !ok {
-			t.Errorf("artifact missing schema-required property %q", req)
-		}
+	// Write-discipline: the schema now ACCEPTS the deprecated lifecycle fields
+	// for read-compat, but the current generator must never EMIT them.
+	var keys map[string]any
+	if err := json.Unmarshal(out.Bytes(), &keys); err != nil {
+		t.Fatalf("re-parse dry-run output: %v", err)
 	}
-
-	// additionalProperties:false — every emitted key is a declared property.
-	for key := range artifact {
-		if _, ok := schema.Properties[key]; !ok {
-			t.Errorf("artifact emits key %q not declared in schema (additionalProperties:false)", key)
-		}
-	}
-
-	// The stale consumption/phase machinery must never reappear.
 	for _, forbidden := range []string{"type", "consumed", "consumed_at", "consumed_by", "rpi"} {
-		if _, ok := artifact[forbidden]; ok {
-			t.Errorf("artifact leaked retired lifecycle field %q", forbidden)
+		if _, ok := keys[forbidden]; ok {
+			t.Errorf("generator emitted deprecated lifecycle field %q (must stay read-compat-only)", forbidden)
 		}
 	}
+}
 
-	// Error 3 fixed: id matches the schema pattern exactly (second-granular,
-	// no fractional seconds).
-	idPattern := schema.Properties["id"].Pattern
-	if idPattern == "" {
-		t.Fatal("schema declares no id pattern")
+// TestHandoffSchemaAcceptsLegacyArtifact proves the read-compatibility promise:
+// an artifact written by an earlier generator (carrying type/consumed and a
+// fractional id) still validates against handoff.v1, so the schema change is
+// not a silent incompatible break.
+func TestHandoffSchemaAcceptsLegacyArtifact(t *testing.T) {
+	schema := compileHandoffSchema(t)
+
+	legacy := []byte(`{
+	  "schema_version": 1,
+	  "id": "handoff-20260101T090000.123456789Z",
+	  "created_at": "2026-01-01T09:00:00.123456789Z",
+	  "type": "manual",
+	  "consumed": false,
+	  "consumed_at": null,
+	  "consumed_by": null,
+	  "goal": "legacy goal"
+	}`)
+	instance, err := jsonschema.UnmarshalJSON(bytes.NewReader(legacy))
+	if err != nil {
+		t.Fatalf("legacy fixture is not JSON: %v", err)
 	}
-	id, _ := artifact["id"].(string)
-	if !regexp.MustCompile(idPattern).MatchString(id) {
-		t.Errorf("id %q does not match schema pattern %q", id, idPattern)
+	if err := schema.Validate(instance); err != nil {
+		t.Fatalf("legacy v1 artifact must still validate (read-compat):\n%v", err)
 	}
+}
+
+func compileHandoffSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	// cwd during `go test` is the package dir cli/cmd/ao, so three levels up.
+	name := filepath.Join("..", "..", "..", "schemas", "handoff.v1.schema.json")
+	data, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read handoff schema: %v", err)
+	}
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("parse handoff schema: %v", err)
+	}
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource("handoff.v1.schema.json", doc); err != nil {
+		t.Fatalf("add handoff schema resource: %v", err)
+	}
+	schema, err := c.Compile("handoff.v1.schema.json")
+	if err != nil {
+		t.Fatalf("compile handoff schema: %v", err)
+	}
+	return schema
 }

--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -29,20 +29,20 @@
 | Skill | Tier | Disposition | Hard dependencies | Capabilities | Effects |
 |---|---|---|---|---|---|
 | `account-rotation` | execution | `keep_specialist` | - | `account_rotation` | `rotate_agent_account` |
-| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | - |
+| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | `write_agent_mail_records`, `install_precommit_guard`, `authorized_destructive_reset` |
 | `agent-native` | meta | `keep_optional_adapter` | - | `role_dispatch`, `observe_workers`, `handoff` | `manage_runtime_sessions` |
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | `write_project_docs` |
-| `cass` | execution | `keep_specialist` | - | `cass` | - |
+| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | `write_hook_config`, `append_guardrail_telemetry`, `write_session_sentinel` |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
-| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
+| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | `run_codex_process`, `sandbox_tiered_workspace_and_network_effects` |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
-| `doc` | product | `keep_specialist` | - | `doc` | - |
+| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
 | `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state`, `read_clock` |
@@ -50,30 +50,30 @@
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |
 | `learn` | execution | `keep_off_path` | - | `analyze_verdict_collections` | `write_advisory_observations` |
 | `ms` | execution | `keep_specialist` | - | `ms` | `spawn_search_server`, `write_feedback_outcomes`, `rebuild_search_index` |
-| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | - |
+| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | `manage_ntm_panes`, `dispatch_pane_commands` |
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
 | `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | `write_pattern_evidence` |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
 | `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
-| `rch` | execution | `keep_specialist` | - | `rch` | - |
+| `rch` | execution | `keep_specialist` | - | `rch` | `remote_compilation_offload`, `authorized_remote_daemon_worker_mutation` |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
-| `research` | execution | `keep_specialist` | - | `research` | - |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
+| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | `delete_reclaimable_files`, `release_disk_ballast`, `modify_host_storage_config` |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | - |
+| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | - |
+| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
-| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
+| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city`, `configure_codex_trust` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -45,7 +45,7 @@
 | `doc` | product | `keep_specialist` | - | `doc` | - |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
-| `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state` |
+| `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state`, `read_clock` |
 | `idea-genie` | execution | `keep_strategy` | - | `generate_evidenced_options`, `dueling_idea_genies` | `write_idea_portfolio` |
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |
 | `learn` | execution | `keep_off_path` | - | `analyze_verdict_collections` | `write_advisory_observations` |

--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -28,52 +28,52 @@
 
 | Skill | Tier | Disposition | Hard dependencies | Capabilities | Effects |
 |---|---|---|---|---|---|
-| `account-rotation` | execution | `keep_specialist` | - | `account_rotation` | - |
-| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | `write_agent_mail_records`, `install_precommit_guard`, `authorized_destructive_reset` |
+| `account-rotation` | execution | `keep_specialist` | - | `account_rotation` | `rotate_agent_account` |
+| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | - |
 | `agent-native` | meta | `keep_optional_adapter` | - | `role_dispatch`, `observe_workers`, `handoff` | `manage_runtime_sessions` |
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
-| `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
-| `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
-| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | `run_codex_process`, `sandbox_tiered_workspace_and_network_effects` |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
+| `bootstrap` | session | `keep_specialist` | - | `bootstrap` | `write_project_docs` |
+| `cass` | execution | `keep_specialist` | - | `cass` | - |
+| `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | `write_hook_config`, `append_guardrail_telemetry`, `write_session_sentinel` |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
+| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
-| `dcg` | execution | `keep_specialist` | - | `dcg` | - |
-| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
+| `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
+| `doc` | product | `keep_specialist` | - | `doc` | - |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
-| `handoff` | session | `keep_specialist` | - | `handoff` | - |
+| `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state` |
 | `idea-genie` | execution | `keep_strategy` | - | `generate_evidenced_options`, `dueling_idea_genies` | `write_idea_portfolio` |
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |
 | `learn` | execution | `keep_off_path` | - | `analyze_verdict_collections` | `write_advisory_observations` |
-| `ms` | execution | `keep_specialist` | - | `ms` | - |
-| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | `manage_ntm_panes`, `dispatch_pane_commands` |
+| `ms` | execution | `keep_specialist` | - | `ms` | `spawn_search_server`, `write_feedback_outcomes`, `rebuild_search_index` |
+| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | - |
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
 | `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | `write_pattern_evidence` |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
 | `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
-| `rch` | execution | `keep_specialist` | - | `rch` | `remote_compilation_offload`, `authorized_remote_daemon_worker_mutation` |
+| `rch` | execution | `keep_specialist` | - | `rch` | - |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
-| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
+| `research` | execution | `keep_specialist` | - | `research` | - |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
-| `sbh` | execution | `keep_specialist` | - | `sbh` | - |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
+| `sbh` | execution | `keep_specialist` | - | `sbh` | `delete_reclaimable_files`, `release_disk_ballast`, `modify_host_storage_config` |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
+| `security` | product | `keep_specialist` | - | `security` | - |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
-| `status` | session | `keep_specialist` | - | `status` | - |
+| `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
+| `test` | execution | `keep_specialist` | - | `test` | - |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
-| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city`, `configure_codex_trust` |
+| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -29,20 +29,20 @@
 | Skill | Tier | Disposition | Hard dependencies | Capabilities | Effects |
 |---|---|---|---|---|---|
 | `account-rotation` | execution | `keep_specialist` | - | `account_rotation` | `rotate_agent_account` |
-| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | - |
+| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | `write_agent_mail_records`, `install_precommit_guard`, `authorized_destructive_reset` |
 | `agent-native` | meta | `keep_optional_adapter` | - | `role_dispatch`, `observe_workers`, `handoff` | `manage_runtime_sessions` |
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | `write_project_docs` |
-| `cass` | execution | `keep_specialist` | - | `cass` | - |
+| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | `write_hook_config`, `append_guardrail_telemetry`, `write_session_sentinel` |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
-| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
+| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | `run_codex_process`, `sandbox_tiered_workspace_and_network_effects` |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
-| `doc` | product | `keep_specialist` | - | `doc` | - |
+| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
 | `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state`, `read_clock` |
@@ -50,30 +50,30 @@
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |
 | `learn` | execution | `keep_off_path` | - | `analyze_verdict_collections` | `write_advisory_observations` |
 | `ms` | execution | `keep_specialist` | - | `ms` | `spawn_search_server`, `write_feedback_outcomes`, `rebuild_search_index` |
-| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | - |
+| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | `manage_ntm_panes`, `dispatch_pane_commands` |
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
 | `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | `write_pattern_evidence` |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
 | `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
-| `rch` | execution | `keep_specialist` | - | `rch` | - |
+| `rch` | execution | `keep_specialist` | - | `rch` | `remote_compilation_offload`, `authorized_remote_daemon_worker_mutation` |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
-| `research` | execution | `keep_specialist` | - | `research` | - |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
+| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | `delete_reclaimable_files`, `release_disk_ballast`, `modify_host_storage_config` |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | - |
+| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | - |
+| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
-| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
+| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city`, `configure_codex_trust` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -45,7 +45,7 @@
 | `doc` | product | `keep_specialist` | - | `doc` | - |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
-| `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state` |
+| `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state`, `read_clock` |
 | `idea-genie` | execution | `keep_strategy` | - | `generate_evidenced_options`, `dueling_idea_genies` | `write_idea_portfolio` |
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |
 | `learn` | execution | `keep_off_path` | - | `analyze_verdict_collections` | `write_advisory_observations` |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -28,52 +28,52 @@
 
 | Skill | Tier | Disposition | Hard dependencies | Capabilities | Effects |
 |---|---|---|---|---|---|
-| `account-rotation` | execution | `keep_specialist` | - | `account_rotation` | - |
-| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | `write_agent_mail_records`, `install_precommit_guard`, `authorized_destructive_reset` |
+| `account-rotation` | execution | `keep_specialist` | - | `account_rotation` | `rotate_agent_account` |
+| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | - |
 | `agent-native` | meta | `keep_optional_adapter` | - | `role_dispatch`, `observe_workers`, `handoff` | `manage_runtime_sessions` |
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
-| `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
-| `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
-| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | `run_codex_process`, `sandbox_tiered_workspace_and_network_effects` |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
+| `bootstrap` | session | `keep_specialist` | - | `bootstrap` | `write_project_docs` |
+| `cass` | execution | `keep_specialist` | - | `cass` | - |
+| `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | `write_hook_config`, `append_guardrail_telemetry`, `write_session_sentinel` |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
+| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
-| `dcg` | execution | `keep_specialist` | - | `dcg` | - |
-| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
+| `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
+| `doc` | product | `keep_specialist` | - | `doc` | - |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
-| `handoff` | session | `keep_specialist` | - | `handoff` | - |
+| `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state` |
 | `idea-genie` | execution | `keep_strategy` | - | `generate_evidenced_options`, `dueling_idea_genies` | `write_idea_portfolio` |
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |
 | `learn` | execution | `keep_off_path` | - | `analyze_verdict_collections` | `write_advisory_observations` |
-| `ms` | execution | `keep_specialist` | - | `ms` | - |
-| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | `manage_ntm_panes`, `dispatch_pane_commands` |
+| `ms` | execution | `keep_specialist` | - | `ms` | `spawn_search_server`, `write_feedback_outcomes`, `rebuild_search_index` |
+| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | - |
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
 | `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | `write_pattern_evidence` |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
 | `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
-| `rch` | execution | `keep_specialist` | - | `rch` | `remote_compilation_offload`, `authorized_remote_daemon_worker_mutation` |
+| `rch` | execution | `keep_specialist` | - | `rch` | - |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
-| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
+| `research` | execution | `keep_specialist` | - | `research` | - |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
-| `sbh` | execution | `keep_specialist` | - | `sbh` | - |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
+| `sbh` | execution | `keep_specialist` | - | `sbh` | `delete_reclaimable_files`, `release_disk_ballast`, `modify_host_storage_config` |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
+| `security` | product | `keep_specialist` | - | `security` | - |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
-| `status` | session | `keep_specialist` | - | `status` | - |
+| `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
+| `test` | execution | `keep_specialist` | - | `test` | - |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
-| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city`, `configure_codex_trust` |
+| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |

--- a/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w7.md
+++ b/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w7.md
@@ -1,0 +1,304 @@
+# Wave W7 report — support
+
+Bead: `age-skill-overhaul-reboot-sjv7v.8`. Branch: `claude/sor-w7-support`.
+Skills: `account-rotation`, `bootstrap`, `cc-hooks`, `dcg`, `handoff`, `ms`,
+`sbh`, `shared`, `status`.
+
+Checklist sources: `checklists/adapters-13.md` (account-rotation, cc-hooks, dcg,
+ms) and `checklists/workflow-12.md` (bootstrap, handoff, sbh, shared, status).
+Every item was verified against the live tree first; the `Verified` note records
+what the live file actually showed. Support-surface doctrine enforced: host /
+credential / device / config effects carry authorization language and honest
+`effects` declarations; no support skill steers an experiment or mints an
+outcome.
+
+The one cross-boundary fix is `handoff` (Go generator + JSON schema); it was
+reproduced with the local `ao` build before any edit.
+
+## handoff
+
+- **`ao session handoff --dry-run` fails its own schema (3 errors)** `[defect]`
+  — **fixed (generator + schema reconciled).** Reproduced with the local build:
+  `type` missing, `consumed` missing, `id` `handoff-…T…….824712000Z` violates
+  `^handoff-[0-9]{8}T[0-9]{6}Z$` → exactly 3 errors. Direction: the lean
+  generator is authoritative and the schema is stale. Proof: the existing
+  `TestHandoffPreservesCallerTextWithoutLifecycleState` **forbids** `consumed` /
+  `rpi_phase` in the artifact — so adding those to the generator would break a
+  live test, and the doctrine ("no continuation choice, verdict, or phase
+  state") forbids them. Fixes: `handoff.go:70` id format
+  `20060102T150405.000000000Z` → `20060102T150405Z` (second-granular per the
+  schema; `created_at` keeps sub-second precision); schema `required` trimmed to
+  `[schema_version, id, created_at]`; removed the stale consumption/phase machinery
+  (`type`, `consumed`, `consumed_at`, `consumed_by`, `rpi` + `$defs.rpi`). Post-fix
+  the dry-run (with `--collect`) validates **0 errors**. Added focused Go test
+  `cli/cmd/ao/handoff_test.go::TestHandoffDryRunSatisfiesSchema` (id-pattern +
+  every schema-required key present + additionalProperties agreement + no retired
+  lifecycle key). `go build/vet/test ./cmd/ao/...` green (481 pass).
+- **Schema `consumed*` + `$defs.rpi` stale vs the operating loop** `[enhance]` —
+  **fixed** (trimmed, above).
+- **Schema description names a nonexistent `ao handoff` command** `[defect]` —
+  **fixed** (→ `ao session handoff`).
+- **Schema description names a session-start hook that does not exist**
+  `[defect]` — **fixed** (removed; description now says caller-authored evidence
+  with no consumption/continuation state).
+- **`effects: []` while writing an artifact + reading git/clock** `[enhance]` —
+  **fixed** (`effects: [write_handoff_artifact, read_git_state]`).
+- **Archived `tests/claude-code/test-handoff-skill.sh` is stale** `[defect]` —
+  **rejected (stale).** Verified: it is one of 13 deliberately-archived
+  `tests/claude-code/*-skill.sh` files whose shared helper `run_claude`
+  (`test-helpers.sh:32-39`) is already neutered to a fail-closed `SKIP` (return 2)
+  and labeled "Archived … LAW 0 forbids". It no longer runs `claude -p`; the
+  "exits SKIPPED unless AGENTOPS_ENABLE_…" description is itself stale (it now
+  always SKIPs). Deleting one file of an intentionally-retained fail-closed class
+  is arbitrary and out of scope.
+- **`.agents/handoff` noncanonical top-dir vs ADR-0016** `[possibly-landed]` —
+  **rejected (stale).** Verified: `handoff` is a **canonical** knowledge-dir in
+  the live hygiene table (`docs/agents-dir-hygiene.md`, aliases `handoffs`,
+  `mto-handoff`), written by the `ao` product, not a skill scratch write. Not a
+  violation.
+
+## dcg
+
+- **`SKILL.md:125` "rm -rf ./build allowed" is false** `[defect]` — **fixed.**
+  Verified on live `dcg 0.5.6`: `dcg test "rm -rf ./build"` → BLOCKED
+  (`core.filesystem:rm-rf-general`); `/tmp/x` and `$TMPDIR/x` → ALLOWED. Corrected
+  the claim to the measured matrix in `SKILL.md`, and the same false "allowed/safe"
+  claim in `COMMANDS.md`, `PACKS.md`, `SCENARIOS.md`. The checklist's "same claim
+  in `cc-hooks/DCG-RCH.md`" sub-claim is **rejected (stale)** — grep confirms
+  `DCG-RCH.md` never carried it.
+- **N4 temp carve-out narrower than documented** `[defect]` — **fixed** (folded
+  into the `SKILL.md:125` matrix: `/tmp`, `/private/tmp`, literal `$TMPDIR` only;
+  relative + absolute non-temp blocked).
+- **N3 rule IDs / version / hook path diverge; wrong rule ID = silent no-op
+  allowlist** `[defect]` — **fixed (load-bearing parts).** The documented rule id
+  `core.filesystem:rm-rf-dangerous` **does not exist** (real: `rm-rf-general` for
+  relative, `rm-rf-root-home` for absolute), so every `dcg allowlist add
+  rm-rf-dangerous` example was a silent no-op — corrected across `COMMANDS.md`,
+  `TROUBLESHOOTING.md`, `CONFIG.md`. Version `0.8.2/0.8.1` → `0.5.6` (doctor
+  sample) / genericized `<installed>`/`<latest>` (self-update sample). Wrong hook
+  path `~/.config/claude-code/settings.json` → `~/.claude/settings.json` across
+  `COMMANDS.md`, `TROUBLESHOOTING.md`, `CONFIG.md`. **Deferred:** wholesale
+  re-derivation of every illustrative `dcg explain`/`dcg packs` sample-trace format
+  from the pinned binary — illustrative output, not a behavioral contract, and an
+  unbounded version-refresh sweep.
+- **DCG-U upstream identity** `[defect]` — **fixed.** `validate-dcg.sh:11`
+  install URL `anthropics/destructive-command-guard` (nonexistent) →
+  `Dicklesworthstone/destructive_command_guard` (+ `cargo install`), matching the
+  real upstream and the `cc-hooks/DCG-RCH.md` crate name.
+- **N5 inline-fragment false-positive surface undocumented** `[enhance]` —
+  **fixed.** Added a Key-Facts bullet: heredoc/inline scanning matches a
+  destructive token quoted as *data* (commit message, `dcg test "…"` probe,
+  here-doc), with the safe-alternative pattern (split the literal, pass via
+  file/stdin). Directly witnessed while probing.
+- **S1 `effects: []` + S2 `output_contract` + DCG-7 fail-open signal**
+  `[enhance]` — **fixed.** `effects: [write_dcg_config]`; added `output_contract`.
+  DCG-7: the caller-visible fail-open signal already exists (Key Facts
+  "Fail-open on timeout … with warning") — left as accurate. Also cleaned the
+  garbled auto-generated trigger `"handle blocked destructive commands. use"` in
+  the description.
+
+## cc-hooks
+
+- **CH-1 three-way default-on / inert / ships-by-DEFAULT contradiction**
+  `[defect]` — **fixed.** Verified: `SKILL.md:34`/`:170` correctly say the policy
+  dispatcher ships by default (post-#932), but `SKILL.md:279` said "no runtime
+  hook is installed by default" and `GUARDRAIL-VALUE-PROOF.md:49` said "AgentOps
+  hookless default". Reconciled both to the live doctrine: the PreToolUse policy
+  dispatcher ships by default; the standalone guard recipes stay inert until
+  opted in.
+- **CH-2 default cohort blocks `git add _beads/…` (rc 2) in unrelated repos**
+  `[defect]` — **deferred (reproduced; structural).** Verified + reproduced: in a
+  fresh non-AgentOps temp repo, feeding `{"tool_input":{"command":"git add
+  _beads/notes.md"}}` to `policy-dispatch.sh` exits 2. The dispatcher extracts no
+  `cwd`; `core.git:add-beads-ledger` is a pure syntactic regex firing globally. A
+  correct repo-context gate (fire only when `_beads/` is a real nested ledger) is
+  a **stateful** predicate, which the schema-enforced predicate discipline
+  (`lint-policies.sh` + `hooks-manifest.v2.schema.json`: only `pure` may `deny`)
+  **structurally bars** from `deny`. The bounded alternatives all have material
+  downsides (demote to `audit` = removes the real AgentOps leak protection;
+  project-scope the cohort = install-mechanics doctrine change). This is a
+  policy-engine cohort decision owned by epic age-4qw1, not a lean text wave.
+- **CH-7 `installed-skill-edit-guard.sh` calls `jq` with no preflight**
+  `[defect]` — **fixed.** Verified: only `emit_telemetry` had a `command -v jq`
+  guard; the main path extraction (`:22`) failed open by accident (empty path →
+  silent exit 0). Added an explicit `command -v jq >/dev/null 2>&1 || exit 0`
+  preflight so the fail-open matches the dispatcher's deliberate precedent. Guard
+  bats (10) still green.
+- **N12 pure predicates fire on quoted data; no false-positive test** `[defect]`
+  — **disclosure fixed; test deferred.** Added an "Accepted false-positive
+  surface" note to the predicate-discipline section (a token quoted as data can
+  fire; every fire is `AOP_WAIVE`/waiver-file reversible). The false-positive
+  **test fixture** is deferred — it is policy-engine test infra (age-4qw1) over
+  the shared `policy-dispatch.bats`.
+- **S1 `effects: []`** `[defect]` — **fixed.** `effects: [write_hook_config,
+  append_guardrail_telemetry, write_session_sentinel]`.
+- **S2 `output_contract`** `[enhance]` — **fixed** (added to frontmatter).
+- **CH-6 shipped guard message names operator-private tooling** `[enhance]` —
+  **fixed.** The default policy `core.skills:copy-into-installed` route message
+  named `link-skill --all (dotfiles)` (this operator's private dotfiles command)
+  — dropped it, keeping the consumer route `ao skills link`; "factory checkout" →
+  "source checkout" in that one message. `lint-policies.sh` + `policy-dispatch.bats`
+  (28) green.
+- **N13 PATH-clobbering recipe in `PATTERNS.md`** `[enhance]` — **fixed.** The
+  "Block Production Paths" example assigned `PATH=$(… file_path)`, clobbering the
+  shell search path → renamed to `FILE_PATH` with a warning comment.
+- **CH-3 `skill.spec.json` dependency divergence from frontmatter** `[enhance]`
+  — **rejected (vestigial).** Verified: `skill.spec.json` is read by no
+  script/CLI/test (only `cc-hooks` and `cass` still carry one); its
+  `dependencies:["dcg","rch"]` vs frontmatter `[]` divergence has no effect. The
+  real contract is the frontmatter.
+- **No uninstall/cleanup path specified or tested** `[enhance]` — **rejected
+  (partly stale) / test deferred.** Verified: uninstall **is** specified —
+  `install-hooks.sh:89` prints it and `SKILL.md:219` documents `/plugin disable`
+  + matcher removal. A bats-tested removal is deferred as test infra.
+
+## ms
+
+- **MS-1 `validate.sh:12-14` mechanically asserts the false `effects: []`**
+  `[defect]` — **fixed (validator inverted).** Replaced the `grep -q 'effects:
+  \[\]'` assertion with a fail-if-empty guard plus positive assertions for the
+  honest tokens (`spawn_search_server`, `write_feedback_outcomes`,
+  `rebuild_search_index`). The `if grep '^metadata:'` guard keeps the slim Codex
+  twin passing. `validate.sh` PASS; `skill-validator-liveness.bats` test 6 (seeded
+  forbidden token) + test 9 (live sources pass) both green.
+- **S1 `effects: []` false** `[defect]` — **fixed** (declared the three tokens
+  above; ms spawns an MCP server and writes feedback/outcome/index state).
+- **MS-3 requires a private operator checkout on a named branch** `[defect]` —
+  **fixed (de-operator-ized).** The `external_dependencies` line baked
+  `~/dev/meta_skill` branch `local/frontmatter-id` as THE path. Reframed to name
+  the upstream (Jeffrey Emanuel's meta_skill) and the real requirement (a build
+  carrying the frontmatter-id fix, because the 0.1.2 release corrupts IDs), with
+  the specific checkout marked as *this operator's* build, not universal.
+- **S2 `output_contract`** `[enhance]` — **fixed** (added to frontmatter).
+- **MS-5 MCP feedback tool exposed against the CLI-only rule** `[enhance]` —
+  **rejected (already honest).** The skill already states the MCP feedback tool
+  exists but only the CLI write path is verified, and steers writes to the CLI.
+- **MS-4 reindex unreachable from a copied install / belongs in Go** `[defect]`
+  and **`ms-reindex.sh` substring process-kill + unescaped JSON + embedded Python**
+  `[defect]` — **deferred (structural).** Both target the 301-line repo-root
+  `scripts/ms-reindex.sh`. The safe fix (require executable identity, not a
+  command-line substring; escape the probe query) plus the MS-4 relocation into
+  the Go `ao` binary is a shared-script rewrite/port that exceeds lean-wave text
+  scope and the no-new-`.py` constraint. Risk recorded for a Go-hosted follow-up.
+- **GOV-1 `mcp-search.py` grandfathered Python** `[enhance]` — **deferred.**
+  Porting to Go is structural; the ratchet stays PASS (no new/grown Python).
+
+## account-rotation
+
+- **S1 `effects: []` false — mutates host credential state** `[defect]` —
+  **fixed** (`effects: [rotate_agent_account]`).
+- **AR-3/N17 operator-private `claude-acct`/`caam` route baked in** `[defect]` —
+  **fixed.** Reframed the Boundary so the credential tool is explicitly caller-/
+  operator-selected per host×family; the names are marked as *this operator's*
+  routes, not a universal prescription (macOS+Claude → `claude-acct`; file-backed
+  Codex/Gemini/Linux/WSL → `caam`; **never `caam` for macOS Claude**, per the
+  standing rule). Both tools verified present on this host.
+- **AR-4 both-tools-absent behavior undefined** `[enhance]` — **fixed.** Added:
+  if neither the selected tool nor a runtime identity probe is available, report
+  the absence as a disclosed fact and stop; never fall back to diffing
+  credential-file bytes.
+- **S3 standalone / before-after identity / partial-rotation proof absent**
+  `[enhance]` — **fixed.** The return now includes identity observed *before and
+  after* the switch, whether any live runtime still holds the previous account (a
+  partial rotation), and whether a new process is required for the new identity.
+
+## sbh
+
+- **Widest mutation boundary (host mutation + deletion) yet `effects: []`;
+  name deletion** `[enhance]` — **fixed.** `effects: [delete_reclaimable_files,
+  release_disk_ballast, modify_host_storage_config]` (deletion named explicitly;
+  no v3 `filesystem.delete` kind exists). Added an authorization sentence to the
+  body.
+- **External SBH binary contract unpinned** `[enhance]` — **fixed.** Probed live
+  `sbh 0.4.27` and anchored the command surface to it, with a re-verify note.
+- **Irreversibility ordering has no executable witness** `[enhance]` —
+  **deferred.** `sbh` is guidance over an external binary; the ordering discipline
+  is agent-followed, and a `.feature` without a wired runner is inert (same shape
+  as the W5 learn/toil-mining deferrals). No runnable target exists to assert
+  against.
+
+## bootstrap
+
+- **`effects: []` while doing filesystem read/write** `[enhance]` — **fixed**
+  (`effects: [write_project_docs]`).
+- **Three-way `bootstrap` naming overlap with no cross-reference** `[enhance]` —
+  **fixed.** Added a Naming note distinguishing this skill (authors entry docs)
+  from `ao init` (creates `.agents/ao/**`) and `ao session bootstrap` (read-only,
+  reports which orientation files are present). Both `ao` semantics verified via
+  `--help`.
+- **No feature/validator/test; add a never-overwrite fixture** `[enhance]` —
+  **deferred.** bootstrap is agent-guidance with no command backing it (no `ao
+  bootstrap`), so a fixture has nothing to invoke; a behavioral witness would
+  require building a command (out of scope).
+
+## shared
+
+- **Plural `produces` wording / advertises capabilities it lacks** `[enhance]` —
+  **fixed (text honesty).** Verified `skills/shared/` bundles zero reference files
+  (only `SKILL.md`). Narrowed the body: the library bundles no standalone
+  reference files today — consuming skills inline their own context — and the
+  contract governs any shared reference a consumer does load. Did **not** execute
+  the retirement (that is bead `…sjv7v.11`): disposition/canonical_status
+  untouched.
+
+## status
+
+- **`SKILL.md:34-36` overclaims live output** `[defect]` — **fixed.** Verified
+  live `ao status` emits two counts + one newest-artifact recency line and
+  hard-codes "caller-supplied subject manifests" into Not-checked. Narrowed the
+  reporting mandate to counts + evidence recency; subject manifests are
+  caller-supplied and reported only when the caller names a location, else
+  `not_checked`; a per-artifact digest/timestamp is reported only for a named
+  artifact on request.
+- **`effects: []` contradicts the Go contract (`EffectFilesystem | EffectClock`)**
+  `[enhance]` — **fixed** (`effects: [read_filesystem, read_clock]`, mirroring
+  `status/module.go:35`).
+- **Empty `references/` held open by `.gitkeep`** `[enhance]` — **rejected
+  (cosmetic).** A harmless placeholder; removal is churn with no behavior change.
+- **`model: haiku` unexplained** `[enhance]` — **rejected (cosmetic).** Haiku is
+  the appropriate cheap model for a deterministic read-only snapshot; an inline
+  justification changes no behavior.
+
+## Disposition counts
+
+- **account-rotation:** 4 fixed.
+- **cc-hooks:** 7 fixed (incl. N12 disclosure), 2 rejected, 2 deferred.
+- **dcg:** 6 fixed, 1 rejected (DCG-RCH sub-claim), 1 deferred (sample-format).
+- **ms:** 3 fixed, 1 rejected, 3 deferred.
+- **bootstrap:** 2 fixed, 1 deferred.
+- **handoff:** 5 fixed, 2 rejected.
+- **sbh:** 2 fixed, 1 deferred.
+- **shared:** 1 fixed.
+- **status:** 2 fixed, 2 rejected.
+- **Group totals:** 32 fixed, 8 rejected-as-stale/vestigial/cosmetic,
+  8 deferred-with-reason.
+
+## Gate results (one verification pass)
+
+- Cross-boundary: `cd cli && go build ./... && go vet ./cmd/ao/... && go test
+  ./cmd/ao/...` — all green (481 pass), including the new
+  `TestHandoffDryRunSatisfiesSchema`. Handoff dry-run re-validated against the
+  trimmed schema: **0 errors** (was 3).
+- Per-skill validators: `ms/scripts/validate.sh` PASS (inverted); `dcg/scripts/
+  validate-dcg.sh` PASS (confirms `rm -rf ./build` → block on live 0.5.6);
+  `cc-hooks/scripts/lint-policies.sh` OK (4 policies). The other six skills have
+  no validator (single-file or guidance packages, expected).
+- `scripts/validate-skill-frontmatter.sh --strict` — 49/49 schema-ok. The single
+  strict warning (`skills/skill-builder` missing `context_rel`) is **pre-existing
+  and out of scope** (W4 skill, not in this diff; same warning noted in the W5
+  report). All nine in-scope skills carry `context_rel` and pass.
+- `scripts/regen-all.sh` then `--check` — all generated projections current
+  (Codex twins, GC projection, skill mesh, catalog, router, docs index).
+- `bats skill-validator-liveness.bats` (9/9), `anti-spiral-contract.bats` (6/6),
+  `policy-dispatch.bats` (28), `installed-skill-edit-guard.bats` (10),
+  `installed-skill-edit-telemetry.bats` (8) — all green.
+- `scripts/check-skill-python-ratchet.sh` — PASS (no new Python; 24
+  grandfathered).
+- `scripts/validate-manifests.sh` — PASS (handoff schema valid; no committed
+  handoff artifacts to validate).
+- `shellcheck -S warning` on every changed script
+  (`installed-skill-edit-guard.sh`, `dcg/validate-dcg.sh`, `ms/validate.sh`) —
+  clean; no `!`-line-start negations introduced.
+
+The wave-level fresh cross-family review is the PR-acceptance step (owned by the
+orchestrator), not run inside this scoped implementation pass.

--- a/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w7.md
+++ b/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w7.md
@@ -302,3 +302,68 @@ reproduced with the local `ao` build before any edit.
 
 The wave-level fresh cross-family review is the PR-acceptance step (owned by the
 orchestrator), not run inside this scoped implementation pass.
+
+## Round 1 review disposition
+
+Cross-family review round 1 returned REQUEST_CHANGES with eight findings; all
+eight are addressed below.
+
+1. **handoff.v1 changed incompatibly without a version bump** — **fixed
+   (read-compat, kept v1).** Audited consumers first: the only reader is
+   `sessionapp.go` rehydrate, which decodes with `encoding/json` (unknown fields
+   ignored — no `DisallowUnknownFields`), so no consumer requires the *absence*
+   of `type`/`consumed`; `validate-manifests.sh` is the only schema gate. Per the
+   evidence the least-breaking fix keeps `schema_version` 1 and restores `type`,
+   `consumed`, `consumed_at`, `consumed_by`, `rpi` (+ `$defs.rpi`) as **optional,
+   `deprecated: true`** properties (accepted for read-compat, never required,
+   never emitted). New `TestHandoffSchemaAcceptsLegacyArtifact` proves a legacy
+   artifact with `type`/`consumed` still validates. No v2 bump needed.
+2. **Second-granular id collision** — **fixed (inverted).** Reverted
+   `handoff.go` to the fractional (`…150405.000000000Z`) id so two same-second
+   handoffs cannot collide on the `<id>.json` path, and **widened the schema
+   pattern** to `^handoff-[0-9]{8}T[0-9]{6}(\.[0-9]+)?Z$` (accepts both forms;
+   existing generated artifacts stay valid).
+3. **Test was presence+regex, not real schema validation** — **fixed.** Rewrote
+   `TestHandoffDryRunSatisfiesSchema` to use `santhosh-tekuri/jsonschema/v6`
+   (already in `go.mod`; the same compile-then-`Validate` pattern as
+   `eval/schema_drift_test.go` and `provenanceapp/mine_session_test.go`) — real
+   validation of types, the `schema_version` const, the id pattern, enums, and
+   nested `additionalProperties`. Kept a separate write-discipline assertion that
+   the generator emits none of the deprecated fields.
+4. **handoff effects omit the clock read** — **fixed.** Added `read_clock`
+   (`effects: [write_handoff_artifact, read_git_state, read_clock]`), matching the
+   status skill's Go-mirrored vocabulary (`handoff.go` calls `time.Now()`).
+5. **[SECURITY] documented `rm -r""f` guard bypass** — **fixed.** Removed the
+   token-splitting recommendation from the dcg N5 note entirely; the safe pattern
+   is now file/stdin data handling (`git commit -F <file>`) plus an explicit
+   "never reconstruct a blocked command by splitting/escaping tokens" warning.
+   Swept SKILL.md + all six reference files — clean. (`validate-dcg.sh:56` uses a
+   split token to construct a *test input* for `dcg test`, not a user
+   recommendation, and predates this wave — left as-is.)
+6. **dcg temp-path contract contradictory (`/var/tmp`)** — **fixed.** Probed live
+   0.5.6: `rm -rf` under `/tmp`, `/private/tmp`, `/var/tmp`, and literal `$TMPDIR`
+   is ALLOWED; `/private/var/tmp` and everything else is BLOCKED. My earlier
+   SKILL.md rewrite wrongly dropped `/var/tmp` (PACKS.md was right). Stated the
+   one measured rule identically in both `SKILL.md` and `PACKS.md`.
+7. **ms validator greps unanchored** — **fixed.** Extract the YAML frontmatter
+   block (between the first two `---` fences via awk) and assert the **exact**
+   effects value there with `grep -qxF`; a token appearing only in the prose body
+   no longer satisfies the contract (proven: effects `[]` + the three tokens in
+   the body now fails rc=1). The slim Codex twin (no `metadata:` block) is skipped
+   as before.
+8. **shared output_contract over-promised** — **fixed.** `output_contract` now
+   reads "no reference documents are bundled at present; the contract governs any
+   reference a consuming skill inlines", matching the narrowed body (no
+   retirement executed).
+
+**Round-1 gate results:** `go build ./... && vet ./cmd/ao && test ./cmd/ao` green
+(482 pass, incl. the two real-schema handoff tests + the legacy-artifact
+read-compat test); dry-run re-validates 0 errors and a legacy `type`/`consumed`
+artifact validates 0 errors. `regen-all --check` current. `validate-skill-frontmatter
+--strict` 49/49 (only the pre-existing out-of-scope `skill-builder` context_rel
+warning). `check-skill-python-ratchet` PASS. `check-scenario-test-linkage.sh`
+PASS locally (75 scenarios; the sibling wave's CI-only failure does not reproduce
+here). bats: skill-validator-liveness 9, anti-spiral-contract 6, policy-dispatch
+28, installed-skill-edit-guard 10, installed-skill-edit-telemetry 8 — green.
+`shellcheck -S warning` clean on `ms/validate.sh` (+ the two round-0 scripts).
+Per-skill validators (ms, dcg) PASS; `lint-policies` OK.

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -22,52 +22,52 @@
 
 | Skill | Tier | Disposition | Hard dependencies | Capabilities | Effects |
 |---|---|---|---|---|---|
-| `account-rotation` | execution | `keep_specialist` | - | `account_rotation` | - |
-| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | `write_agent_mail_records`, `install_precommit_guard`, `authorized_destructive_reset` |
+| `account-rotation` | execution | `keep_specialist` | - | `account_rotation` | `rotate_agent_account` |
+| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | - |
 | `agent-native` | meta | `keep_optional_adapter` | - | `role_dispatch`, `observe_workers`, `handoff` | `manage_runtime_sessions` |
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
-| `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
-| `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
-| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | `run_codex_process`, `sandbox_tiered_workspace_and_network_effects` |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
+| `bootstrap` | session | `keep_specialist` | - | `bootstrap` | `write_project_docs` |
+| `cass` | execution | `keep_specialist` | - | `cass` | - |
+| `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | `write_hook_config`, `append_guardrail_telemetry`, `write_session_sentinel` |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
+| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
-| `dcg` | execution | `keep_specialist` | - | `dcg` | - |
-| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
+| `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
+| `doc` | product | `keep_specialist` | - | `doc` | - |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
-| `handoff` | session | `keep_specialist` | - | `handoff` | - |
+| `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state` |
 | `idea-genie` | execution | `keep_strategy` | - | `generate_evidenced_options`, `dueling_idea_genies` | `write_idea_portfolio` |
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |
 | `learn` | execution | `keep_off_path` | - | `analyze_verdict_collections` | `write_advisory_observations` |
-| `ms` | execution | `keep_specialist` | - | `ms` | - |
-| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | `manage_ntm_panes`, `dispatch_pane_commands` |
+| `ms` | execution | `keep_specialist` | - | `ms` | `spawn_search_server`, `write_feedback_outcomes`, `rebuild_search_index` |
+| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | - |
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
 | `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | `write_pattern_evidence` |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
 | `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
-| `rch` | execution | `keep_specialist` | - | `rch` | `remote_compilation_offload`, `authorized_remote_daemon_worker_mutation` |
+| `rch` | execution | `keep_specialist` | - | `rch` | - |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
-| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
+| `research` | execution | `keep_specialist` | - | `research` | - |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
-| `sbh` | execution | `keep_specialist` | - | `sbh` | - |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
+| `sbh` | execution | `keep_specialist` | - | `sbh` | `delete_reclaimable_files`, `release_disk_ballast`, `modify_host_storage_config` |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
+| `security` | product | `keep_specialist` | - | `security` | - |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
-| `status` | session | `keep_specialist` | - | `status` | - |
+| `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
+| `test` | execution | `keep_specialist` | - | `test` | - |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
-| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city`, `configure_codex_trust` |
+| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -39,7 +39,7 @@
 | `doc` | product | `keep_specialist` | - | `doc` | - |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
-| `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state` |
+| `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state`, `read_clock` |
 | `idea-genie` | execution | `keep_strategy` | - | `generate_evidenced_options`, `dueling_idea_genies` | `write_idea_portfolio` |
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |
 | `learn` | execution | `keep_off_path` | - | `analyze_verdict_collections` | `write_advisory_observations` |

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -23,20 +23,20 @@
 | Skill | Tier | Disposition | Hard dependencies | Capabilities | Effects |
 |---|---|---|---|---|---|
 | `account-rotation` | execution | `keep_specialist` | - | `account_rotation` | `rotate_agent_account` |
-| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | - |
+| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | `write_agent_mail_records`, `install_precommit_guard`, `authorized_destructive_reset` |
 | `agent-native` | meta | `keep_optional_adapter` | - | `role_dispatch`, `observe_workers`, `handoff` | `manage_runtime_sessions` |
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | `write_project_docs` |
-| `cass` | execution | `keep_specialist` | - | `cass` | - |
+| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | `write_hook_config`, `append_guardrail_telemetry`, `write_session_sentinel` |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
-| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
+| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | `run_codex_process`, `sandbox_tiered_workspace_and_network_effects` |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
-| `doc` | product | `keep_specialist` | - | `doc` | - |
+| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
 | `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state`, `read_clock` |
@@ -44,30 +44,30 @@
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |
 | `learn` | execution | `keep_off_path` | - | `analyze_verdict_collections` | `write_advisory_observations` |
 | `ms` | execution | `keep_specialist` | - | `ms` | `spawn_search_server`, `write_feedback_outcomes`, `rebuild_search_index` |
-| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | - |
+| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | `manage_ntm_panes`, `dispatch_pane_commands` |
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
 | `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | `write_pattern_evidence` |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
 | `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
-| `rch` | execution | `keep_specialist` | - | `rch` | - |
+| `rch` | execution | `keep_specialist` | - | `rch` | `remote_compilation_offload`, `authorized_remote_daemon_worker_mutation` |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
-| `research` | execution | `keep_specialist` | - | `research` | - |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
+| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | `delete_reclaimable_files`, `release_disk_ballast`, `modify_host_storage_config` |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | - |
+| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | - |
+| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
-| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
+| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city`, `configure_codex_trust` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/images/gemini/skills/account-rotation/SKILL.md
+++ b/images/gemini/skills/account-rotation/SKILL.md
@@ -9,7 +9,7 @@ context_rel: []
 metadata:
   dependencies: []
   capabilities: [account_rotation]
-  effects: []
+  effects: [rotate_agent_account]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
@@ -37,14 +37,24 @@ process is required for the answer to hold.
 
 ## Boundary
 
-- On macOS with Claude credentials, use the operator's `claude-acct` route.
-- For Codex, Gemini, Linux, or WSL file-backed credentials, use `caam`.
+- Perform only the account switch the caller explicitly authorized; rotation
+  mutates host credential state and is never implied by repository access.
+- The credential tool is caller- or operator-selected per host and agent family;
+  the names below are this operator's routes, not a universal prescription. On
+  macOS with Claude credentials the route is `claude-acct` (Keychain-backed);
+  file-backed Codex, Gemini, Linux, or WSL credentials use `caam`. Never use
+  `caam` for macOS Claude account operations.
 - Verify account identity through the target runtime; token bytes are not account
   identity.
+- If neither the selected credential tool nor a runtime identity probe is
+  available, report that absence as a disclosed fact and stop. Never fall back to
+  diffing credential-file bytes to declare a switch done.
 - Existing processes retain credentials already loaded in memory. Rotation
   affects a new process.
 - This skill does not restart work, resume a task, select a pane, move repository
   state, or decide what happens after the switch.
 
-Return the host, agent family, selected tool, requested account/profile, observed
-identity/status, command exit code, and whether a new process is required.
+Return the host, agent family, selected tool, requested account/profile, the
+identity observed before and after the switch, whether any live runtime still
+holds the previous account (a partial rotation), the command exit code, and
+whether a new process is required for the new identity to hold.

--- a/images/gemini/skills/bootstrap/SKILL.md
+++ b/images/gemini/skills/bootstrap/SKILL.md
@@ -21,7 +21,7 @@ context:
   intel_scope: none
 metadata:
   capabilities: [bootstrap]
-  effects: []
+  effects: [write_project_docs]
   canonical_status: canonical
   disposition: keep_specialist
   graph_root: true
@@ -61,6 +61,12 @@ PRODUCT.md written confidently is worse than a question.
 Typical documents are `PRODUCT.md`, `GOALS.md`, `AGENTS.md`, and a README section
 that explains the one-pass loop. Repositories remain free to use their own Git,
 CI, tracker, release, and deployment policies.
+
+**Naming.** Three surfaces share the word "bootstrap"; they are distinct. This
+skill authors missing entry documents. `ao init` is the CLI command that creates
+the local evidence and verdict directories (`.agents/ao/**`). `ao session
+bootstrap` is a read-only session command that reports which local orientation
+files are present. This skill invokes neither.
 
 ## Non-goals
 

--- a/images/gemini/skills/cc-hooks/SKILL.md
+++ b/images/gemini/skills/cc-hooks/SKILL.md
@@ -9,13 +9,14 @@ context_rel: []
 metadata:
   dependencies: []
   capabilities: [cc_hooks]
-  effects: []
+  effects: [write_hook_config, append_guardrail_telemetry, write_session_sentinel]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
-description: 'Configure default Claude Code enforcement hooks and opt-in injection recipes. Triggers: "cc-hooks", "configure Claude Code hooks", "install hooks".'
+description: 'Configure default Claude Code enforcement hooks and opt-in guard recipes. Triggers: "cc-hooks", "configure Claude Code hooks", "install hooks".'
 practices:
 - pragmatic-programmer
+output_contract: a hooks block in ~/.claude or project settings.json (matcher + command entries), or a hook script signalling allow/deny/ask via exit codes and hookSpecificOutput JSON; installs write hook config and guard fires append hashed telemetry
 ---
 # Claude Code Hooks
 
@@ -189,6 +190,14 @@ promoted with reviewed fires.
 [scripts/lint-policies.sh](scripts/lint-policies.sh) enforces this mechanically
 (jq-only; runs in bats and CI).
 
+**Accepted false-positive surface:** because a pure predicate matches its token
+anywhere in the raw command string, a protected token quoted as *data* (a commit
+message body, a `dcg test "..."` probe, a here-doc payload) can still fire even
+though nothing harmful would run. This is the deliberate cost of the
+pure-only-may-deny rule — the alternative (repo/context lookups) is exactly the
+stateful predicate the discipline bars from `deny`. Every fire is reversible: a
+one-shot `AOP_WAIVE=<policy-id>` or a `policy-waivers` line clears it.
+
 Semantics: happy path = exit 0, zero output. `deny` = exit 2 + one stderr
 route line (full message once per session, short line after — every attempt
 still blocks). `route` = exit 0 + `permissionDecision:"ask"` JSON. `audit` =
@@ -276,7 +285,7 @@ claude --debug  # Hook execution details
 
 ## Output Specification
 
-- **Path:** user `~/.claude/settings.json` or project `.claude/settings.json`, plus explicitly named hook scripts; no runtime hook is installed by default.
+- **Path:** user `~/.claude/settings.json` or project `.claude/settings.json`, plus explicitly named hook scripts. The PreToolUse policy dispatcher ships by default (every install path wires it — see "Policy Dispatch Engine"); the additional guard recipes (skill-first coordination, standalone installed-skill-edit) stay inert until opted in.
 - **Filename:** preserve `settings.json`; give scripts descriptive executable filenames rather than embedding large shell programs in JSON.
 - **Format:** valid Claude hook JSON using event arrays, matchers, and command objects; hook stdout/stderr and exit codes follow the selected event schema.
 - **Exit code:** validate with `jq -e '.hooks | type=="object"' <settings.json>` and a representative silent/fire test for each matcher; any parse error, noisy happy path, or recursion risk blocks activation.

--- a/images/gemini/skills/dcg/SKILL.md
+++ b/images/gemini/skills/dcg/SKILL.md
@@ -124,10 +124,11 @@ dcg scan --staged       # Pre-commit: scan for issues
 | K8s | `delete namespace`, `delete --all` | `-l` label selector |
 
 **Context-aware (measured on dcg 0.5.6):** the temp carve-out allows `rm -rf`
-under `/tmp`, `/private/tmp`, and the literal `$TMPDIR` form. Everything else —
-`rm -rf ./build` and other relative paths (`core.filesystem:rm-rf-general`),
-absolute paths like `/home/...` and `/` (`core.filesystem:rm-rf-root-home`) — is
-blocked. Unresolved variables other than `$TMPDIR` are not treated as temp.
+under `/tmp`, `/private/tmp`, `/var/tmp`, and the literal `$TMPDIR` form.
+Everything else — `rm -rf ./build` and other relative paths
+(`core.filesystem:rm-rf-general`), absolute paths like `/home/...` and `/`
+(`core.filesystem:rm-rf-root-home`), and even `/private/var/tmp` — is blocked.
+Unresolved variables other than `$TMPDIR` are not treated as temp.
 
 **`dcg explain` example (7-step pipeline):**
 ```bash
@@ -179,7 +180,7 @@ allow_patterns = ["rm -rf ./node_modules"]  # Project-specific safe
 - **Sub-millisecond latency** — won't slow your workflow
 - **Fail-open on timeout** — if DCG hangs, command runs (with warning)
 - **Heredoc scanning** — inline scripts (`bash -c`, `python -c`) are analyzed
-- **Inline-fragment false positives** — because scanning matches a destructive token anywhere in the command string, a pattern quoted as *data* (a commit message, a `dcg test "rm -rf …"` probe, a here-doc payload) can trip a block even though nothing destructive would run. Safe pattern: keep the literal off the command line — split it (`rm -r""f`), pass it via a file/stdin, or run the intended tool directly instead of embedding the pattern.
+- **Inline-fragment false positives** — because scanning matches a destructive token anywhere in the command string, a pattern that appears only as *data* (a commit message body, a here-doc payload, a probe argument) can trip a block even though nothing destructive would run. Safe pattern: keep the payload off the command line — pass it via a file or stdin (e.g. `git commit -F <file>`), or run the intended tool directly instead of inlining the text. Never reconstruct a blocked command by splitting or escaping its tokens to slip past the guard — that defeats the safety layer.
 - **Allow-once codes** — 4 hex chars, 24h expiry, bound to exact command+directory
 
 ## The Incident That Started It All

--- a/images/gemini/skills/dcg/SKILL.md
+++ b/images/gemini/skills/dcg/SKILL.md
@@ -9,13 +9,14 @@ context_rel: []
 metadata:
   dependencies: []
   capabilities: [dcg]
-  effects: []
+  effects: [write_dcg_config]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
-description: 'Handle blocked destructive commands and configure agent safety guardrails. Triggers: "dcg", "handle blocked destructive commands. use", "dcg skill".'
+description: 'Handle blocked destructive commands and configure agent safety guardrails. Triggers: "dcg", "handle a DCG block", "configure agent safety guardrails".'
 practices:
 - pragmatic-programmer
+output_contract: the blocked command, matched rule, surviving risk, and validated safe alternative; config writes only when explicitly requested
 ---
 <!-- TOC: Core Insight | THE EXACT WORKFLOW | Quick Reference | Safe Alternatives | What Gets Blocked | Anti-Patterns | Configuration | References -->
 
@@ -122,7 +123,11 @@ dcg scan --staged       # Pre-commit: scan for issues
 | Database | `DROP`, `TRUNCATE`, `DELETE` w/o WHERE | Add WHERE clause |
 | K8s | `delete namespace`, `delete --all` | `-l` label selector |
 
-**Context-aware:** `rm -rf ./build` allowed, `rm -rf /` blocked.
+**Context-aware (measured on dcg 0.5.6):** the temp carve-out allows `rm -rf`
+under `/tmp`, `/private/tmp`, and the literal `$TMPDIR` form. Everything else —
+`rm -rf ./build` and other relative paths (`core.filesystem:rm-rf-general`),
+absolute paths like `/home/...` and `/` (`core.filesystem:rm-rf-root-home`) — is
+blocked. Unresolved variables other than `$TMPDIR` are not treated as temp.
 
 **`dcg explain` example (7-step pipeline):**
 ```bash
@@ -174,6 +179,7 @@ allow_patterns = ["rm -rf ./node_modules"]  # Project-specific safe
 - **Sub-millisecond latency** — won't slow your workflow
 - **Fail-open on timeout** — if DCG hangs, command runs (with warning)
 - **Heredoc scanning** — inline scripts (`bash -c`, `python -c`) are analyzed
+- **Inline-fragment false positives** — because scanning matches a destructive token anywhere in the command string, a pattern quoted as *data* (a commit message, a `dcg test "rm -rf …"` probe, a here-doc payload) can trip a block even though nothing destructive would run. Safe pattern: keep the literal off the command line — split it (`rm -r""f`), pass it via a file/stdin, or run the intended tool directly instead of embedding the pattern.
 - **Allow-once codes** — 4 hex chars, 24h expiry, bound to exact command+directory
 
 ## The Incident That Started It All

--- a/images/gemini/skills/handoff/SKILL.md
+++ b/images/gemini/skills/handoff/SKILL.md
@@ -13,7 +13,7 @@ context:
   intel_scope: none
 metadata:
   capabilities: [handoff]
-  effects: []
+  effects: [write_handoff_artifact, read_git_state]
   canonical_status: canonical
   disposition: keep_specialist
   graph_root: true

--- a/images/gemini/skills/handoff/SKILL.md
+++ b/images/gemini/skills/handoff/SKILL.md
@@ -13,7 +13,7 @@ context:
   intel_scope: none
 metadata:
   capabilities: [handoff]
-  effects: [write_handoff_artifact, read_git_state]
+  effects: [write_handoff_artifact, read_git_state, read_clock]
   canonical_status: canonical
   disposition: keep_specialist
   graph_root: true

--- a/images/gemini/skills/ms/SKILL.md
+++ b/images/gemini/skills/ms/SKILL.md
@@ -12,14 +12,15 @@ context_rel: []
 metadata:
   dependencies: []
   capabilities: [ms]
-  effects: []
+  effects: [spawn_search_server, write_feedback_outcomes, rebuild_search_index]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
   external_dependencies:
-  - "ms binary (Jeffrey Emanuel's meta_skill; source build from ~/dev/meta_skill, branch local/frontmatter-id — the 0.1.2 release binary corrupts IDs on Anthropic-frontmatter skills)"
+  - "ms binary (Jeffrey Emanuel's meta_skill). The 0.1.2 release binary corrupts IDs on Anthropic-frontmatter skills, so it must be built from a source checkout carrying the frontmatter-id fix; this operator builds from ~/dev/meta_skill, branch local/frontmatter-id."
   - jq (required for parsing -O json output)
   - python3 (required by the disposable MCP search helper)
+output_contract: search and load results plus source identity on stdout; the local index is disposable state, never a source of truth
 ---
 <!-- TOC: Core Insight | Constraints | Quick Start | Consume (MCP) | Write/Admin (CLI) | Output | Production Skill Handoff | Footguns | Concurrency | Scenarios | Quality | References -->
 

--- a/images/gemini/skills/sbh/SKILL.md
+++ b/images/gemini/skills/sbh/SKILL.md
@@ -9,7 +9,7 @@ context_rel: []
 metadata:
   dependencies: []
   capabilities: [sbh]
-  effects: []
+  effects: [delete_reclaimable_files, release_disk_ballast, modify_host_storage_config]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
@@ -22,7 +22,10 @@ output_contract: disk pressure observations and authorized action result
 
 SBH exposes disk-pressure status, ballast, scanning, and recovery commands. This
 skill gathers evidence and performs at most the explicit action authorized by the
-caller.
+caller. Its authorized actions can delete files and change host storage
+configuration, so no mutation runs without explicit caller authority. The command
+surface below is anchored to `sbh` 0.4.27; re-verify against `sbh --version` on
+another host before relying on an exact flag.
 
 Evidence-first recovery works because disk pressure has cheap reversible
 remedies and expensive irreversible ones; a factual baseline is what tells them

--- a/images/gemini/skills/shared/SKILL.md
+++ b/images/gemini/skills/shared/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   canonical_status: canonical
   disposition: keep_specialist
   internal: true
-output_contract: reference documents loaded just in time
+output_contract: no reference documents are bundled at present; the contract governs any reference a consuming skill inlines
 ---
 
 # Shared References

--- a/images/gemini/skills/shared/SKILL.md
+++ b/images/gemini/skills/shared/SKILL.md
@@ -21,9 +21,10 @@ output_contract: reference documents loaded just in time
 
 # Shared References
 
-Shared files describe runtime capabilities and evidence formats. They are
-context, not permission to start a runtime, tracker, substrate, network call,
-or external mutation.
+This library bundles no standalone reference files today; consuming skills inline
+the runtime and evidence context they need. The contract below governs any shared
+reference a consuming skill does load: it is context, not permission to start a
+runtime, tracker, substrate, network call, or external mutation.
 
 Just-in-time loading works because a reference read only when a consuming
 skill needs it cannot silently become a dependency; anything loaded by default

--- a/images/gemini/skills/status/SKILL.md
+++ b/images/gemini/skills/status/SKILL.md
@@ -15,7 +15,7 @@ context:
   intel_scope: none
 metadata:
   capabilities: [status]
-  effects: []
+  effects: [read_filesystem, read_clock]
   canonical_status: canonical
   disposition: keep_specialist
   graph_root: true
@@ -30,13 +30,17 @@ A status snapshot is trustworthy exactly when every line traces to an artifact
 that exists on disk right now; the first inferred line turns the report into a
 guess wearing a report's clothes.
 
-Report only observable local facts: available intent, subject-manifest, and
-verdict artifacts; their counts, digests, and timestamps; deterministic check
-results; and unavailable or corrupt sources. The canonical durable stores are
-`.agents/ao/intents/sha256` and `.agents/ao/verdicts/sha256`; subject manifests
-remain caller-supplied unless the caller names their location. When `.agents/ao`
-evidence exists, report which stored artifact kind is newest and label that
-conclusion as evidence recency, not runtime phase or process activity.
+Report only observable local facts: available intent and verdict artifacts and
+their counts; deterministic check results; evidence recency; and unavailable or
+corrupt sources. The canonical durable stores are `.agents/ao/intents/sha256`
+and `.agents/ao/verdicts/sha256`. Subject manifests are caller-supplied: report
+them only when the caller names their location, otherwise disclose them as
+`not_checked`. When `.agents/ao` evidence exists, report which stored artifact
+kind is newest and label that conclusion as evidence recency, not runtime phase
+or process activity. The `ao status` snapshot emits the two counts plus that
+newest-artifact recency conclusion, not a per-artifact digest or timestamp
+listing; report a specific artifact's digest or timestamp only when the caller
+asks about a named artifact.
 
 Always disclose `checked` and `not_checked`. Runtime phase, execution elapsed
 time, tool-call activity, and remaining work are `not_checked` unless a caller

--- a/registry.json
+++ b/registry.json
@@ -883,7 +883,8 @@
         "disposition": "keep_specialist",
         "effects": [
           "write_handoff_artifact",
-          "read_git_state"
+          "read_git_state",
+          "read_clock"
         ],
         "has_references": true,
         "has_skill_md": true,

--- a/registry.json
+++ b/registry.json
@@ -619,7 +619,9 @@
           "account_rotation"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "rotate_agent_account"
+        ],
         "has_references": false,
         "has_skill_md": true,
         "name": "account-rotation",
@@ -695,7 +697,9 @@
           "bootstrap"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "write_project_docs"
+        ],
         "has_references": true,
         "has_skill_md": true,
         "name": "bootstrap",
@@ -725,7 +729,11 @@
           "cc_hooks"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "write_hook_config",
+          "append_guardrail_telemetry",
+          "write_session_sentinel"
+        ],
         "has_references": true,
         "has_skill_md": true,
         "name": "cc-hooks",
@@ -814,7 +822,9 @@
           "dcg"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "write_dcg_config"
+        ],
         "has_references": true,
         "has_skill_md": true,
         "name": "dcg",
@@ -871,7 +881,10 @@
           "handoff"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "write_handoff_artifact",
+          "read_git_state"
+        ],
         "has_references": true,
         "has_skill_md": true,
         "name": "handoff",
@@ -932,7 +945,11 @@
           "ms"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "spawn_search_server",
+          "write_feedback_outcomes",
+          "rebuild_search_index"
+        ],
         "has_references": false,
         "has_skill_md": true,
         "name": "ms",
@@ -1148,7 +1165,11 @@
           "sbh"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "delete_reclaimable_files",
+          "release_disk_ballast",
+          "modify_host_storage_config"
+        ],
         "has_references": false,
         "has_skill_md": true,
         "name": "sbh",
@@ -1249,7 +1270,10 @@
           "status"
         ],
         "disposition": "keep_specialist",
-        "effects": [],
+        "effects": [
+          "read_filesystem",
+          "read_clock"
+        ],
         "has_references": true,
         "has_skill_md": true,
         "name": "status",

--- a/schemas/handoff.v1.schema.json
+++ b/schemas/handoff.v1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://agentops.dev/schemas/handoff.v1.schema.json",
   "title": "AgentOps Handoff Artifact v1",
-  "description": "Structured handoff artifact for session boundary isolation. Written by `ao session handoff`; caller-authored session evidence that carries no continuation choice, consumption, verdict, or phase state.",
+  "description": "Structured handoff artifact for session boundary isolation. Written by `ao session handoff`; caller-authored session evidence. The current generator emits no continuation choice, consumption, verdict, or phase state; the `type`, `consumed`, `consumed_at`, `consumed_by`, and `rpi` fields are DEPRECATED read-compatibility fields — accepted so artifacts written by an earlier generator still validate, never required, and never emitted by the current writer.",
   "practices": ["event-sourcing-cqrs", "distributed-tracing"],
   "type": "object",
   "additionalProperties": false,
@@ -14,11 +14,16 @@
     },
     "id": {
       "type": "string",
-      "pattern": "^handoff-[0-9]{8}T[0-9]{6}Z$"
+      "pattern": "^handoff-[0-9]{8}T[0-9]{6}(\\.[0-9]+)?Z$"
     },
     "created_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["manual", "auto", "rpi"],
+      "deprecated": true
     },
     "goal": {
       "type": "string"
@@ -47,14 +52,67 @@
         "type": "string"
       }
     },
+    "rpi": {
+      "deprecated": true,
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/rpi" }
+      ]
+    },
     "state": {
       "oneOf": [
         { "type": "null" },
         { "$ref": "#/$defs/state" }
       ]
+    },
+    "consumed": {
+      "type": "boolean",
+      "deprecated": true
+    },
+    "consumed_at": {
+      "deprecated": true,
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string", "format": "date-time" }
+      ]
+    },
+    "consumed_by": {
+      "deprecated": true,
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string" }
+      ]
     }
   },
   "$defs": {
+    "rpi": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["phase", "phase_name"],
+      "properties": {
+        "phase": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 3
+        },
+        "phase_name": {
+          "type": "string",
+          "enum": ["discovery", "implementation", "validation"]
+        },
+        "epic_id": {
+          "type": "string"
+        },
+        "run_id": {
+          "type": "string"
+        },
+        "verdicts": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "state": {
       "type": "object",
       "additionalProperties": false,

--- a/schemas/handoff.v1.schema.json
+++ b/schemas/handoff.v1.schema.json
@@ -2,11 +2,11 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://agentops.dev/schemas/handoff.v1.schema.json",
   "title": "AgentOps Handoff Artifact v1",
-  "description": "Structured handoff artifact for session boundary isolation. Written by `ao handoff`, consumed by session-start hook.",
+  "description": "Structured handoff artifact for session boundary isolation. Written by `ao session handoff`; caller-authored session evidence that carries no continuation choice, consumption, verdict, or phase state.",
   "practices": ["event-sourcing-cqrs", "distributed-tracing"],
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "id", "created_at", "type", "consumed"],
+  "required": ["schema_version", "id", "created_at"],
   "properties": {
     "schema_version": {
       "type": "integer",
@@ -19,10 +19,6 @@
     "created_at": {
       "type": "string",
       "format": "date-time"
-    },
-    "type": {
-      "type": "string",
-      "enum": ["manual", "auto", "rpi"]
     },
     "goal": {
       "type": "string"
@@ -51,63 +47,14 @@
         "type": "string"
       }
     },
-    "rpi": {
-      "oneOf": [
-        { "type": "null" },
-        { "$ref": "#/$defs/rpi" }
-      ]
-    },
     "state": {
       "oneOf": [
         { "type": "null" },
         { "$ref": "#/$defs/state" }
       ]
-    },
-    "consumed": {
-      "type": "boolean"
-    },
-    "consumed_at": {
-      "oneOf": [
-        { "type": "null" },
-        { "type": "string", "format": "date-time" }
-      ]
-    },
-    "consumed_by": {
-      "oneOf": [
-        { "type": "null" },
-        { "type": "string" }
-      ]
     }
   },
   "$defs": {
-    "rpi": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["phase", "phase_name"],
-      "properties": {
-        "phase": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 3
-        },
-        "phase_name": {
-          "type": "string",
-          "enum": ["discovery", "implementation", "validation"]
-        },
-        "epic_id": {
-          "type": "string"
-        },
-        "run_id": {
-          "type": "string"
-        },
-        "verdicts": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "state": {
       "type": "object",
       "additionalProperties": false,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -411,8 +411,8 @@
     {
       "name": "dcg",
       "source_skill": "skills/dcg",
-      "source_hash": "518050ac3bc00cbb2f0df4aa98d0393183f769ffeff89e8decc5228f9d001923",
-      "generated_hash": "eb571806c9c05534970772e18679ad0aa100dc64410db3deecdf14324eb7d034"
+      "source_hash": "ad40fd9b845fc38464b4086a67563e0f65ab978032eed4c3a450720c9d6e1b3a",
+      "generated_hash": "f2377e290fec00a80816def3cb38d5dfb722075a0cbe542a9b04d1b4a8294d5d"
     },
     {
       "name": "doc",
@@ -435,7 +435,7 @@
     {
       "name": "handoff",
       "source_skill": "skills/handoff",
-      "source_hash": "a35f50599018b787e7afa653873aac3ae34b1a7fb5c8501ab40428eac9ddaff1",
+      "source_hash": "5b2a17069a72aab45c2311a2a49035825d5d6dda723640ba88298a4931247036",
       "generated_hash": "a6b7439f4eea091fee8cbb8ce4c52c458a21f96abfdad7898c766332a768e4c1"
     },
     {
@@ -459,8 +459,8 @@
     {
       "name": "ms",
       "source_skill": "skills/ms",
-      "source_hash": "660266b5695af406862cda0523c9e3b107d905070f809266991a01e04e5be60e",
-      "generated_hash": "8680c7800bdc0d3ac49fbd9d8445d7d4b3ef7194f101e03a16c17812a5deef39"
+      "source_hash": "8634a28c128d80d574da339747315ed4af5e047081c20d7647f69d08f7c88e71",
+      "generated_hash": "95cad0eb98d21cf7c1124b387188ce35d8ea322377d46ef0f19642c6ffeecbf6"
     },
     {
       "name": "ntm",
@@ -567,7 +567,7 @@
     {
       "name": "shared",
       "source_skill": "skills/shared",
-      "source_hash": "2ceb55d36d8cd719e3a05cd2f9e4b68881ad6ecefa03a48f6ef7fba581c614e2",
+      "source_hash": "22d81954843dff1019e74cb47ff9f6ec6af3a6cb0fe91daa083da7fe19a4c14f",
       "generated_hash": "748ffbe5ac32af1bea316461195ea73122a5f2510b10ac2679043b4d8a106ec3"
     },
     {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -333,8 +333,8 @@
     {
       "name": "account-rotation",
       "source_skill": "skills/account-rotation",
-      "source_hash": "ba3ed3790e62394cbad525cae44a776663104998c721d541586e043d5f4fcac7",
-      "generated_hash": "d864d0cd54ad18e43b90236461342cede0ad7cb464b174a2ab0e7d43c9e0477b"
+      "source_hash": "0929b03a8b42808ee604f53653e7887e8509bebffc2f2e7648a6c7c269fcac8e",
+      "generated_hash": "0571b4e1b80b089be179a82f1c713977e7e68966ae50c0bf91ead69e977714d1"
     },
     {
       "name": "agent-mail",
@@ -363,8 +363,8 @@
     {
       "name": "bootstrap",
       "source_skill": "skills/bootstrap",
-      "source_hash": "c3685be5bd081805490b7a5bf5c2c806ff40ecfb0e77a6dd40752f8bc3e2ca71",
-      "generated_hash": "a36120c164e708633c101c73b8fb2a1fe3e939ba3f3fbadbf37322f25e0a6063"
+      "source_hash": "895dc489d5dbecfc4a562efe24d01a6347caef562f8eef78bff08a12810e4f67",
+      "generated_hash": "c47b8e84781c855a7203040c1b8f1462818882c543774de498fcf24d06ec334b"
     },
     {
       "name": "cass",
@@ -375,8 +375,8 @@
     {
       "name": "cc-hooks",
       "source_skill": "skills/cc-hooks",
-      "source_hash": "07547a37d876995ae378c7a458c15c0edf9fef8d0f553c4b64fe89b7881dacde",
-      "generated_hash": "daf70aaf9e19555859ed14177ac44bcb7f29fe7a8e6377df63e5db3b6e62db2b"
+      "source_hash": "1c1a15fb1170fe1ce8e6a99e2fedcc8e878de92a93bf79698bb604f0861cb2f4",
+      "generated_hash": "dd4a41bd24cc7ab986ee1f24e8609aa8447ed2345094b44bb757d93064afe5ff"
     },
     {
       "name": "codebase-recon",
@@ -411,8 +411,8 @@
     {
       "name": "dcg",
       "source_skill": "skills/dcg",
-      "source_hash": "91e765d6363f7234da33c3bae9c2ed11e9319a2de1e58f57ac931023b2c0a360",
-      "generated_hash": "64825ae1fb8b5506ca7da051a826e36971715567a171b16580cce8c696929ce9"
+      "source_hash": "518050ac3bc00cbb2f0df4aa98d0393183f769ffeff89e8decc5228f9d001923",
+      "generated_hash": "eb571806c9c05534970772e18679ad0aa100dc64410db3deecdf14324eb7d034"
     },
     {
       "name": "doc",
@@ -435,7 +435,7 @@
     {
       "name": "handoff",
       "source_skill": "skills/handoff",
-      "source_hash": "beee4bc7b0c68a1185871b3b46f4ca3b3413360e9afc5e67d3a7a32cbfbcebe6",
+      "source_hash": "a35f50599018b787e7afa653873aac3ae34b1a7fb5c8501ab40428eac9ddaff1",
       "generated_hash": "a6b7439f4eea091fee8cbb8ce4c52c458a21f96abfdad7898c766332a768e4c1"
     },
     {
@@ -459,8 +459,8 @@
     {
       "name": "ms",
       "source_skill": "skills/ms",
-      "source_hash": "9947b95b4156d939e439975417f36df30904d63e1294134f1ae69547f8e35fc9",
-      "generated_hash": "020a4691cbcd3cc81ae5641e8e29e452226cc2420943b4b99a6fb9062d3fa0be"
+      "source_hash": "660266b5695af406862cda0523c9e3b107d905070f809266991a01e04e5be60e",
+      "generated_hash": "8680c7800bdc0d3ac49fbd9d8445d7d4b3ef7194f101e03a16c17812a5deef39"
     },
     {
       "name": "ntm",
@@ -543,8 +543,8 @@
     {
       "name": "sbh",
       "source_skill": "skills/sbh",
-      "source_hash": "8a9fa58182b9aa40f2ffee8593e6664c0b0e669f3854a665d7d92f5902274031",
-      "generated_hash": "78b58ea48fae6c2d4b6bd745cd696be05f7ebd2782eca163659c1f8601b8ba0a"
+      "source_hash": "1e938f203fc92290da03306ad803586159748d4d69c0aa4748f0af8864d7f9f4",
+      "generated_hash": "55e22b4db1245feab5a38ab8c571b77ad435047e2511d132e4c4b179f03a4fc9"
     },
     {
       "name": "scaffold",
@@ -567,8 +567,8 @@
     {
       "name": "shared",
       "source_skill": "skills/shared",
-      "source_hash": "5091329074c1c86cf1243ab50b0aae45c0a46901ff5fe8e0002c623738007768",
-      "generated_hash": "ed834c2a97ffdf8d2fa69269963504a9c2740c1599cd7180a13a8c0162cb3503"
+      "source_hash": "2ceb55d36d8cd719e3a05cd2f9e4b68881ad6ecefa03a48f6ef7fba581c614e2",
+      "generated_hash": "748ffbe5ac32af1bea316461195ea73122a5f2510b10ac2679043b4d8a106ec3"
     },
     {
       "name": "skill-builder",
@@ -585,8 +585,8 @@
     {
       "name": "status",
       "source_skill": "skills/status",
-      "source_hash": "c4988fd8d1c497d63521e96e1235e132fdec955145e47ad276d7510c1615e89c",
-      "generated_hash": "60fcedb9dbc8aa913deb523161fd6b508de9101ad224841fbbf0a5d11df6f058"
+      "source_hash": "94d94e3e6158606f6cf54276829e7edeeaad174f00a583b6d9312bb4d53685f3",
+      "generated_hash": "b2787e028706bd060b67065247a693477186df28a6d2fe94522b3d81aaa89c3e"
     },
     {
       "name": "swarm",

--- a/skills-codex/account-rotation/.agentops-generated.json
+++ b/skills-codex/account-rotation/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/account-rotation",
   "layout": "modular",
-  "source_hash": "ba3ed3790e62394cbad525cae44a776663104998c721d541586e043d5f4fcac7",
-  "generated_hash": "d864d0cd54ad18e43b90236461342cede0ad7cb464b174a2ab0e7d43c9e0477b"
+  "source_hash": "0929b03a8b42808ee604f53653e7887e8509bebffc2f2e7648a6c7c269fcac8e",
+  "generated_hash": "0571b4e1b80b089be179a82f1c713977e7e68966ae50c0bf91ead69e977714d1"
 }

--- a/skills-codex/account-rotation/SKILL.md
+++ b/skills-codex/account-rotation/SKILL.md
@@ -21,14 +21,24 @@ process is required for the answer to hold.
 
 ## Boundary
 
-- On macOS with Claude credentials, use the operator's `claude-acct` route.
-- For Codex, Gemini, Linux, or WSL file-backed credentials, use `caam`.
+- Perform only the account switch the caller explicitly authorized; rotation
+  mutates host credential state and is never implied by repository access.
+- The credential tool is caller- or operator-selected per host and agent family;
+  the names below are this operator's routes, not a universal prescription. On
+  macOS with Claude credentials the route is `claude-acct` (Keychain-backed);
+  file-backed Codex, Gemini, Linux, or WSL credentials use `caam`. Never use
+  `caam` for macOS Claude account operations.
 - Verify account identity through the target runtime; token bytes are not account
   identity.
+- If neither the selected credential tool nor a runtime identity probe is
+  available, report that absence as a disclosed fact and stop. Never fall back to
+  diffing credential-file bytes to declare a switch done.
 - Existing processes retain credentials already loaded in memory. Rotation
   affects a new process.
 - This skill does not restart work, resume a task, select a pane, move repository
   state, or decide what happens after the switch.
 
-Return the host, agent family, selected tool, requested account/profile, observed
-identity/status, command exit code, and whether a new process is required.
+Return the host, agent family, selected tool, requested account/profile, the
+identity observed before and after the switch, whether any live runtime still
+holds the previous account (a partial rotation), the command exit code, and
+whether a new process is required for the new identity to hold.

--- a/skills-codex/bootstrap/.agentops-generated.json
+++ b/skills-codex/bootstrap/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/bootstrap",
   "layout": "modular",
-  "source_hash": "c3685be5bd081805490b7a5bf5c2c806ff40ecfb0e77a6dd40752f8bc3e2ca71",
-  "generated_hash": "a36120c164e708633c101c73b8fb2a1fe3e939ba3f3fbadbf37322f25e0a6063"
+  "source_hash": "895dc489d5dbecfc4a562efe24d01a6347caef562f8eef78bff08a12810e4f67",
+  "generated_hash": "c47b8e84781c855a7203040c1b8f1462818882c543774de498fcf24d06ec334b"
 }

--- a/skills-codex/bootstrap/SKILL.md
+++ b/skills-codex/bootstrap/SKILL.md
@@ -35,6 +35,12 @@ Typical documents are `PRODUCT.md`, `GOALS.md`, `AGENTS.md`, and a README sectio
 that explains the one-pass loop. Repositories remain free to use their own Git,
 CI, tracker, release, and deployment policies.
 
+**Naming.** Three surfaces share the word "bootstrap"; they are distinct. This
+skill authors missing entry documents. `ao init` is the CLI command that creates
+the local evidence and verdict directories (`.agents/ao/**`). `ao session
+bootstrap` is a read-only session command that reports which local orientation
+files are present. This skill invokes neither.
+
 ## Non-goals
 
 - installing or invoking `ao`, `br`, `bd`, NTM, Agent Mail, or another runtime;

--- a/skills-codex/cc-hooks/.agentops-generated.json
+++ b/skills-codex/cc-hooks/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/cc-hooks",
   "layout": "modular",
-  "source_hash": "07547a37d876995ae378c7a458c15c0edf9fef8d0f553c4b64fe89b7881dacde",
-  "generated_hash": "daf70aaf9e19555859ed14177ac44bcb7f29fe7a8e6377df63e5db3b6e62db2b"
+  "source_hash": "1c1a15fb1170fe1ce8e6a99e2fedcc8e878de92a93bf79698bb604f0861cb2f4",
+  "generated_hash": "dd4a41bd24cc7ab986ee1f24e8609aa8447ed2345094b44bb757d93064afe5ff"
 }

--- a/skills-codex/cc-hooks/SKILL.md
+++ b/skills-codex/cc-hooks/SKILL.md
@@ -174,6 +174,14 @@ promoted with reviewed fires.
 [scripts/lint-policies.sh](scripts/lint-policies.sh) enforces this mechanically
 (jq-only; runs in bats and CI).
 
+**Accepted false-positive surface:** because a pure predicate matches its token
+anywhere in the raw command string, a protected token quoted as *data* (a commit
+message body, a `dcg test "..."` probe, a here-doc payload) can still fire even
+though nothing harmful would run. This is the deliberate cost of the
+pure-only-may-deny rule — the alternative (repo/context lookups) is exactly the
+stateful predicate the discipline bars from `deny`. Every fire is reversible: a
+one-shot `AOP_WAIVE=<policy-id>` or a `policy-waivers` line clears it.
+
 Semantics: happy path = exit 0, zero output. `deny` = exit 2 + one stderr
 route line (full message once per session, short line after — every attempt
 still blocks). `route` = exit 0 + `permissionDecision:"ask"` JSON. `audit` =
@@ -261,7 +269,7 @@ claude --debug  # Hook execution details
 
 ## Output Specification
 
-- **Path:** user `~/.claude/settings.json` or project `.claude/settings.json`, plus explicitly named hook scripts; no runtime hook is installed by default.
+- **Path:** user `~/.claude/settings.json` or project `.claude/settings.json`, plus explicitly named hook scripts. The PreToolUse policy dispatcher ships by default (every install path wires it — see "Policy Dispatch Engine"); the additional guard recipes (skill-first coordination, standalone installed-skill-edit) stay inert until opted in.
 - **Filename:** preserve `settings.json`; give scripts descriptive executable filenames rather than embedding large shell programs in JSON.
 - **Format:** valid Claude hook JSON using event arrays, matchers, and command objects; hook stdout/stderr and exit codes follow the selected event schema.
 - **Exit code:** validate with `jq -e '.hooks | type=="object"' <settings.json>` and a representative silent/fire test for each matcher; any parse error, noisy happy path, or recursion risk blocks activation.

--- a/skills-codex/cc-hooks/hooks/installed-skill-edit-guard.sh
+++ b/skills-codex/cc-hooks/hooks/installed-skill-edit-guard.sh
@@ -18,6 +18,11 @@
 #     parsed as JSON). Block via exit 2 + stderr only.
 set -uo pipefail
 
+# Fail OPEN if jq is unavailable (the dispatcher precedent): a guard that can't
+# parse its input must never brick a tool call. Explicit preflight so the
+# fail-open is intentional, not an accident of an empty path falling through.
+command -v jq >/dev/null 2>&1 || exit 0
+
 input="$(cat)"
 path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""')"
 sid="$(printf '%s' "$input" | jq -r '.session_id // "nosession"')"

--- a/skills-codex/cc-hooks/policies/policies.json
+++ b/skills-codex/cc-hooks/policies/policies.json
@@ -57,7 +57,7 @@
           "pattern": "(^|[;&|][[:space:]]*)(cp|rsync|mv)[[:space:]][^;&|]*[[:space:]][^[:space:];&|]*\\.(claude|codex|gemini)/skills(/[^[:space:];&|]*)?[[:space:]]*([;&|]|$)"
         }
       ],
-      "route_message": "~/.claude/skills (and .codex/.gemini) are INSTALLED/symlinked copies — a cp/rsync/mv into them writes through the symlink into whatever branch the factory checkout is on, or is overwritten on install. Link instead: ao skills link (repo) or link-skill --all (dotfiles). Closes the Bash gap of the Edit|Write-only installed-skill-edit-guard.",
+      "route_message": "~/.claude/skills (and .codex/.gemini) are INSTALLED/symlinked copies — a cp/rsync/mv into them writes through the symlink into whatever branch the source checkout is on, or is overwritten on install. Link instead: ao skills link. Closes the Bash gap of the Edit|Write-only installed-skill-edit-guard.",
       "rationale": "Global CLAUDE.md 'Never cp into ~/.claude/skills'. Destination position is enforced: the installed-skills path must be the LAST token of the command segment, so copying FROM an installed dir out to the repo never fires.",
       "value_proof": "declining fire-attempt rate (token_class core.skills:copy-into-installed); retire on false-positive evidence"
     },

--- a/skills-codex/cc-hooks/prompt.md
+++ b/skills-codex/cc-hooks/prompt.md
@@ -1,6 +1,6 @@
 # cc-hooks
 
-Configure default Claude Code enforcement hooks and opt-in injection recipes. Triggers: "cc-hooks", "configure Claude Code hooks", "install hooks".
+Configure default Claude Code enforcement hooks and opt-in guard recipes. Triggers: "cc-hooks", "configure Claude Code hooks", "install hooks".
 
 ## Instructions
 

--- a/skills-codex/cc-hooks/references/GUARDRAIL-VALUE-PROOF.md
+++ b/skills-codex/cc-hooks/references/GUARDRAIL-VALUE-PROOF.md
@@ -45,9 +45,10 @@ The hash is one-way; it lets us count *distinct* edited targets and detect
 repeats without ever logging what the agent was editing. Asserted in
 `tests/scripts/installed-skill-edit-telemetry.bats`.
 
-**Inert by default:** the emission code only runs when the guard fires, and the
-guard ships INERT (AgentOps hookless default; opt-in installer only). On a
-machine where the guard is not installed, zero lines are ever written. On a
+**Inert by default:** the emission code only runs when the guard fires, and this
+standalone guard ships INERT (opt-in installer only) even though the PreToolUse
+policy dispatcher ships by default. On a machine where the guard is not
+installed, zero lines are ever written. On a
 machine where it IS installed, the happy path (any non-installed-skill edit)
 writes nothing.
 

--- a/skills-codex/cc-hooks/references/PATTERNS.md
+++ b/skills-codex/cc-hooks/references/PATTERNS.md
@@ -118,7 +118,9 @@ exit 0
 ```bash
 #!/bin/bash
 INPUT=$(cat)
-PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path')
+# Never assign to $PATH — it clobbers the shell's executable search path and
+# breaks every command after it. Use a distinct variable name.
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path')
 
 BLOCKED_PATTERNS=(
   "/prod/"
@@ -128,8 +130,8 @@ BLOCKED_PATTERNS=(
 )
 
 for pattern in "${BLOCKED_PATTERNS[@]}"; do
-  if [[ "$PATH" == *"$pattern"* ]]; then
-    echo "Blocked: production file $PATH" >&2
+  if [[ "$FILE_PATH" == *"$pattern"* ]]; then
+    echo "Blocked: production file $FILE_PATH" >&2
     exit 2
   fi
 done

--- a/skills-codex/dcg/.agentops-generated.json
+++ b/skills-codex/dcg/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/dcg",
   "layout": "modular",
-  "source_hash": "518050ac3bc00cbb2f0df4aa98d0393183f769ffeff89e8decc5228f9d001923",
-  "generated_hash": "eb571806c9c05534970772e18679ad0aa100dc64410db3deecdf14324eb7d034"
+  "source_hash": "ad40fd9b845fc38464b4086a67563e0f65ab978032eed4c3a450720c9d6e1b3a",
+  "generated_hash": "f2377e290fec00a80816def3cb38d5dfb722075a0cbe542a9b04d1b4a8294d5d"
 }

--- a/skills-codex/dcg/.agentops-generated.json
+++ b/skills-codex/dcg/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/dcg",
   "layout": "modular",
-  "source_hash": "91e765d6363f7234da33c3bae9c2ed11e9319a2de1e58f57ac931023b2c0a360",
-  "generated_hash": "64825ae1fb8b5506ca7da051a826e36971715567a171b16580cce8c696929ce9"
+  "source_hash": "518050ac3bc00cbb2f0df4aa98d0393183f769ffeff89e8decc5228f9d001923",
+  "generated_hash": "eb571806c9c05534970772e18679ad0aa100dc64410db3deecdf14324eb7d034"
 }

--- a/skills-codex/dcg/SKILL.md
+++ b/skills-codex/dcg/SKILL.md
@@ -108,10 +108,11 @@ dcg scan --staged       # Pre-commit: scan for issues
 | K8s | `delete namespace`, `delete --all` | `-l` label selector |
 
 **Context-aware (measured on dcg 0.5.6):** the temp carve-out allows `rm -rf`
-under `/tmp`, `/private/tmp`, and the literal `$TMPDIR` form. Everything else —
-`rm -rf ./build` and other relative paths (`core.filesystem:rm-rf-general`),
-absolute paths like `/home/...` and `/` (`core.filesystem:rm-rf-root-home`) — is
-blocked. Unresolved variables other than `$TMPDIR` are not treated as temp.
+under `/tmp`, `/private/tmp`, `/var/tmp`, and the literal `$TMPDIR` form.
+Everything else — `rm -rf ./build` and other relative paths
+(`core.filesystem:rm-rf-general`), absolute paths like `/home/...` and `/`
+(`core.filesystem:rm-rf-root-home`), and even `/private/var/tmp` — is blocked.
+Unresolved variables other than `$TMPDIR` are not treated as temp.
 
 **`dcg explain` example (7-step pipeline):**
 ```bash
@@ -163,7 +164,7 @@ allow_patterns = ["rm -rf ./node_modules"]  # Project-specific safe
 - **Sub-millisecond latency** — won't slow your workflow
 - **Fail-open on timeout** — if DCG hangs, command runs (with warning)
 - **Heredoc scanning** — inline scripts (`bash -c`, `python -c`) are analyzed
-- **Inline-fragment false positives** — because scanning matches a destructive token anywhere in the command string, a pattern quoted as *data* (a commit message, a `dcg test "rm -rf …"` probe, a here-doc payload) can trip a block even though nothing destructive would run. Safe pattern: keep the literal off the command line — split it (`rm -r""f`), pass it via a file/stdin, or run the intended tool directly instead of embedding the pattern.
+- **Inline-fragment false positives** — because scanning matches a destructive token anywhere in the command string, a pattern that appears only as *data* (a commit message body, a here-doc payload, a probe argument) can trip a block even though nothing destructive would run. Safe pattern: keep the payload off the command line — pass it via a file or stdin (e.g. `git commit -F <file>`), or run the intended tool directly instead of inlining the text. Never reconstruct a blocked command by splitting or escaping its tokens to slip past the guard — that defeats the safety layer.
 - **Allow-once codes** — 4 hex chars, 24h expiry, bound to exact command+directory
 
 ## The Incident That Started It All

--- a/skills-codex/dcg/SKILL.md
+++ b/skills-codex/dcg/SKILL.md
@@ -107,7 +107,11 @@ dcg scan --staged       # Pre-commit: scan for issues
 | Database | `DROP`, `TRUNCATE`, `DELETE` w/o WHERE | Add WHERE clause |
 | K8s | `delete namespace`, `delete --all` | `-l` label selector |
 
-**Context-aware:** `rm -rf ./build` allowed, `rm -rf /` blocked.
+**Context-aware (measured on dcg 0.5.6):** the temp carve-out allows `rm -rf`
+under `/tmp`, `/private/tmp`, and the literal `$TMPDIR` form. Everything else —
+`rm -rf ./build` and other relative paths (`core.filesystem:rm-rf-general`),
+absolute paths like `/home/...` and `/` (`core.filesystem:rm-rf-root-home`) — is
+blocked. Unresolved variables other than `$TMPDIR` are not treated as temp.
 
 **`dcg explain` example (7-step pipeline):**
 ```bash
@@ -159,6 +163,7 @@ allow_patterns = ["rm -rf ./node_modules"]  # Project-specific safe
 - **Sub-millisecond latency** — won't slow your workflow
 - **Fail-open on timeout** — if DCG hangs, command runs (with warning)
 - **Heredoc scanning** — inline scripts (`bash -c`, `python -c`) are analyzed
+- **Inline-fragment false positives** — because scanning matches a destructive token anywhere in the command string, a pattern quoted as *data* (a commit message, a `dcg test "rm -rf …"` probe, a here-doc payload) can trip a block even though nothing destructive would run. Safe pattern: keep the literal off the command line — split it (`rm -r""f`), pass it via a file/stdin, or run the intended tool directly instead of embedding the pattern.
 - **Allow-once codes** — 4 hex chars, 24h expiry, bound to exact command+directory
 
 ## The Incident That Started It All

--- a/skills-codex/dcg/prompt.md
+++ b/skills-codex/dcg/prompt.md
@@ -1,6 +1,6 @@
 # dcg
 
-Handle blocked destructive commands and configure agent safety guardrails. Triggers: "dcg", "handle blocked destructive commands. use", "dcg skill".
+Handle blocked destructive commands and configure agent safety guardrails. Triggers: "dcg", "handle a DCG block", "configure agent safety guardrails".
 
 ## Instructions
 

--- a/skills-codex/dcg/references/COMMANDS.md
+++ b/skills-codex/dcg/references/COMMANDS.md
@@ -26,11 +26,11 @@ DCG Doctor
 ══════════════════════════════════════════════════
 
 Binary:
-  ✓ dcg version 0.8.2 (built 2025-01-15)
+  ✓ dcg version 0.5.6
   ✓ Located at /usr/local/bin/dcg
 
 Hook Registration:
-  ✓ Claude Code hook registered in ~/.config/claude-code/settings.json
+  ✓ Claude Code hook registered in ~/.claude/settings.json
   ✓ Hook path: /usr/local/bin/dcg hook
 
 Configuration:
@@ -100,13 +100,19 @@ Dry-run evaluation without executing.
 $ dcg test "rm -rf /home/user/project"
 WOULD BE BLOCKED
 
-Rule: core.filesystem:rm-rf-dangerous
-Reason: Recursive deletion of non-temporary path
+Rule: core.filesystem:rm-rf-root-home
+Reason: Recursive deletion of an absolute non-temporary path
 
 $ dcg test "rm -rf ./build"
+WOULD BE BLOCKED
+
+Rule: core.filesystem:rm-rf-general
+Reason: Recursive deletion of a relative non-temporary path
+
+$ dcg test "rm -rf /tmp/build"
 WOULD BE ALLOWED
 
-Context: Relative path in current directory considered safe
+Context: paths under /tmp, /private/tmp, and $TMPDIR are in the temp carve-out
 ```
 
 **Use when:** Checking before running something you're unsure about.
@@ -147,7 +153,7 @@ Manage permanent exceptions.
 $ dcg allowlist add core.git:reset-hard -r "CI cleanup requires this"
 
 # Add with scope
-$ dcg allowlist add core.filesystem:rm-rf-dangerous \
+$ dcg allowlist add core.filesystem:rm-rf-root-home \
     --path "/home/user/project/build" \
     -r "Build directory cleanup"
 
@@ -157,7 +163,7 @@ $ dcg allowlist list
 │ Rule ID                          │ Scope                      │ Reason                  │
 ├──────────────────────────────────┼────────────────────────────┼─────────────────────────┤
 │ core.git:reset-hard              │ global                     │ CI cleanup requires     │
-│ core.filesystem:rm-rf-dangerous  │ /home/user/project/build   │ Build directory cleanup │
+│ core.filesystem:rm-rf-root-home  │ /home/user/project/build   │ Build directory cleanup │
 └──────────────────────────────────┴────────────────────────────┴─────────────────────────┘
 
 # Remove entry
@@ -253,14 +259,14 @@ Self-update to latest version.
 
 ```bash
 $ dcg update
-Current version: 0.8.1
-Latest version: 0.8.2
+Current version: <installed>
+Latest version: <latest>
 
 Downloading...
 Verifying signature...
 Installing...
 
-Updated to 0.8.2
+Updated to <latest>
 ```
 
 ---

--- a/skills-codex/dcg/references/CONFIG.md
+++ b/skills-codex/dcg/references/CONFIG.md
@@ -106,7 +106,7 @@ reason = "CI cleanup requires hard reset"
 expires = "2025-12-31"  # Optional expiration
 
 [[rules]]
-id = "core.filesystem:rm-rf-dangerous"
+id = "core.filesystem:rm-rf-general"
 path = "./build"  # Scope to specific path
 reason = "Build directory cleanup"
 ```
@@ -195,7 +195,7 @@ dcg-scan:
 
 DCG integrates with Claude Code via the PreToolUse hook:
 
-### Registration (~/.config/claude-code/settings.json)
+### Registration (~/.claude/settings.json)
 
 ```json
 {

--- a/skills-codex/dcg/references/PACKS.md
+++ b/skills-codex/dcg/references/PACKS.md
@@ -34,14 +34,17 @@ These cannot be disabled—they catch the most common destructive patterns.
 | `rm -rf /home` | Yes | System paths |
 | `rm -rf /path` | Depends | Non-temp paths blocked |
 
-**Safe patterns (allowed):**
+**Safe patterns (allowed) — measured on dcg 0.5.6.** The temp carve-out allows
+`rm -rf` under exactly these roots:
 - `rm -rf /tmp/*` — Temp directory
+- `rm -rf /private/tmp/*` — Temp directory (macOS)
 - `rm -rf /var/tmp/*` — Temp directory
 - `rm -rf $TMPDIR/*` — User temp (literal `$TMPDIR` only)
 
-`rm -rf ./build` and other relative or absolute non-temp paths are **blocked**
-(`core.filesystem:rm-rf-general` / `rm-rf-root-home`); allowlist them explicitly
-if a project needs them (see [CONFIG.md](CONFIG.md)).
+`rm -rf ./build` and other relative or absolute non-temp paths — and even
+`/private/var/tmp` — are **blocked** (`core.filesystem:rm-rf-general` /
+`rm-rf-root-home`); allowlist them explicitly if a project needs them (see
+[CONFIG.md](CONFIG.md)).
 
 ---
 

--- a/skills-codex/dcg/references/PACKS.md
+++ b/skills-codex/dcg/references/PACKS.md
@@ -37,8 +37,11 @@ These cannot be disabled—they catch the most common destructive patterns.
 **Safe patterns (allowed):**
 - `rm -rf /tmp/*` — Temp directory
 - `rm -rf /var/tmp/*` — Temp directory
-- `rm -rf $TMPDIR/*` — User temp
-- `rm -rf ./build` — Relative paths in project
+- `rm -rf $TMPDIR/*` — User temp (literal `$TMPDIR` only)
+
+`rm -rf ./build` and other relative or absolute non-temp paths are **blocked**
+(`core.filesystem:rm-rf-general` / `rm-rf-root-home`); allowlist them explicitly
+if a project needs them (see [CONFIG.md](CONFIG.md)).
 
 ---
 

--- a/skills-codex/dcg/references/SCENARIOS.md
+++ b/skills-codex/dcg/references/SCENARIOS.md
@@ -32,12 +32,16 @@ git push --force-with-lease origin feature-branch
 
 ## 3. rm -rf Typo — DCG Saved You
 
-**Blocked:** `rm -rf /home/user/project/` (meant `./build`)
+**Blocked:** `rm -rf /home/user/project/` (typo — meant a scoped build dir)
 
-DCG caught the typo. Correct the path:
+DCG caught the typo. Note that `rm -rf ./build` is **also** blocked by default
+(relative non-temp path, `core.filesystem:rm-rf-general`). Reach for a genuinely
+safe target, or allowlist the build dir explicitly:
 
 ```bash
-rm -rf ./build  # Safe path, won't be blocked
+rm -rf "$TMPDIR/project-build"        # temp carve-out — allowed
+# or, if ./build itself must be cleaned, allowlist it once (see CONFIG.md):
+#   [overrides] allow_patterns = ["rm -rf ./build"]
 ```
 
 ---

--- a/skills-codex/dcg/references/TROUBLESHOOTING.md
+++ b/skills-codex/dcg/references/TROUBLESHOOTING.md
@@ -42,12 +42,11 @@ dcg doctor
 **Diagnose:**
 ```bash
 $ dcg explain "rm -rf ./node_modules"
-BLOCKED by core.filesystem:rm-rf-dangerous
+BLOCKED by core.filesystem:rm-rf-general
 
 Evaluation trace:
   ...
-  Step 6. Normalization: rm -rf /home/user/project/node_modules
-  Step 7. Pack evaluation: MATCH (non-temp path)
+  Step 7. Pack evaluation: MATCH (relative non-temp path)
 ```
 
 **Fix options:**
@@ -67,7 +66,7 @@ dcg allow-once ab12
 
 3. **Permanent allowlist:**
 ```bash
-dcg allowlist add core.filesystem:rm-rf-dangerous \
+dcg allowlist add core.filesystem:rm-rf-general \
     --path "$PWD/node_modules" \
     -r "Package cleanup"
 ```
@@ -245,7 +244,7 @@ block_patterns = ["the-bypass-pattern"]
 
 **Check hook is registered:**
 ```bash
-cat ~/.config/claude-code/settings.json | jq '.hooks'
+jq '.hooks' ~/.claude/settings.json
 ```
 
 **Expected:**

--- a/skills-codex/dcg/scripts/validate-dcg.sh
+++ b/skills-codex/dcg/scripts/validate-dcg.sh
@@ -8,7 +8,8 @@ echo "=== DCG Installation Validation ==="
 # Check if dcg is installed
 if ! command -v dcg &> /dev/null; then
     echo "ERROR: dcg not found in PATH"
-    echo "Install from: https://github.com/anthropics/destructive-command-guard"
+    echo "Install from: https://github.com/Dicklesworthstone/destructive_command_guard"
+    echo "  (cargo install destructive_command_guard)"
     exit 1
 fi
 

--- a/skills-codex/handoff/.agentops-generated.json
+++ b/skills-codex/handoff/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/handoff",
   "layout": "modular",
-  "source_hash": "a35f50599018b787e7afa653873aac3ae34b1a7fb5c8501ab40428eac9ddaff1",
+  "source_hash": "5b2a17069a72aab45c2311a2a49035825d5d6dda723640ba88298a4931247036",
   "generated_hash": "a6b7439f4eea091fee8cbb8ce4c52c458a21f96abfdad7898c766332a768e4c1"
 }

--- a/skills-codex/handoff/.agentops-generated.json
+++ b/skills-codex/handoff/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/handoff",
   "layout": "modular",
-  "source_hash": "beee4bc7b0c68a1185871b3b46f4ca3b3413360e9afc5e67d3a7a32cbfbcebe6",
+  "source_hash": "a35f50599018b787e7afa653873aac3ae34b1a7fb5c8501ab40428eac9ddaff1",
   "generated_hash": "a6b7439f4eea091fee8cbb8ce4c52c458a21f96abfdad7898c766332a768e4c1"
 }

--- a/skills-codex/ms/.agentops-generated.json
+++ b/skills-codex/ms/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/ms",
   "layout": "modular",
-  "source_hash": "9947b95b4156d939e439975417f36df30904d63e1294134f1ae69547f8e35fc9",
-  "generated_hash": "020a4691cbcd3cc81ae5641e8e29e452226cc2420943b4b99a6fb9062d3fa0be"
+  "source_hash": "660266b5695af406862cda0523c9e3b107d905070f809266991a01e04e5be60e",
+  "generated_hash": "8680c7800bdc0d3ac49fbd9d8445d7d4b3ef7194f101e03a16c17812a5deef39"
 }

--- a/skills-codex/ms/.agentops-generated.json
+++ b/skills-codex/ms/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/ms",
   "layout": "modular",
-  "source_hash": "660266b5695af406862cda0523c9e3b107d905070f809266991a01e04e5be60e",
-  "generated_hash": "8680c7800bdc0d3ac49fbd9d8445d7d4b3ef7194f101e03a16c17812a5deef39"
+  "source_hash": "8634a28c128d80d574da339747315ed4af5e047081c20d7647f69d08f7c88e71",
+  "generated_hash": "95cad0eb98d21cf7c1124b387188ce35d8ea322377d46ef0f19642c6ffeecbf6"
 }

--- a/skills-codex/ms/scripts/validate.sh
+++ b/skills-codex/ms/scripts/validate.sh
@@ -11,15 +11,19 @@ grep -q '^name: ms$' "$SKILL"
 # frontmatter but mirrors this validator and the runnable body. Effects must be
 # declared HONESTLY: ms spawns an MCP search server, writes feedback/outcome rows
 # to a live DB, and rebuilds the index. An empty effects list is a known
-# falsehood, so require the real effect tokens rather than assert emptiness.
+# falsehood. Anchor the assertion to the YAML frontmatter block (between the
+# first two --- fences) so a token that merely appears in the prose body can
+# never satisfy the effects contract, and require the exact declared value.
 if grep -q '^metadata:' "$SKILL"; then
-  if grep -q '^  effects: \[\]$' "$SKILL"; then
-    echo 'ms effects must not be empty: it spawns a search server and writes feedback/outcome/index state' >&2
+  frontmatter="$(awk '/^---[[:space:]]*$/{fences++; next} fences==1{print}' "$SKILL")"
+  expected_effects='  effects: [spawn_search_server, write_feedback_outcomes, rebuild_search_index]'
+  if printf '%s\n' "$frontmatter" | grep -qxF "$expected_effects"; then
+    :
+  else
+    echo "ms frontmatter effects must be exactly: [spawn_search_server, write_feedback_outcomes, rebuild_search_index]" >&2
+    echo "(ms spawns a search server and writes feedback/outcome/index state; an empty or partial list is a known falsehood)" >&2
     exit 1
   fi
-  grep -q 'spawn_search_server' "$SKILL"
-  grep -q 'write_feedback_outcomes' "$SKILL"
-  grep -q 'rebuild_search_index' "$SKILL"
 fi
 grep -Fq 'Keep `ms` retrieval-only for production skill work.' "$SKILL"
 grep -Fq '**Authority boundary:** `skills/**` is canonical source' "$SKILL"

--- a/skills-codex/ms/scripts/validate.sh
+++ b/skills-codex/ms/scripts/validate.sh
@@ -8,9 +8,18 @@ MCP_SEARCH="$SKILL_DIR/scripts/mcp-search.py"
 [[ -s "$SKILL" ]]
 grep -q '^name: ms$' "$SKILL"
 # Canonical source carries full metadata; the generated Codex package uses slim
-# frontmatter but mirrors this validator and the runnable body.
+# frontmatter but mirrors this validator and the runnable body. Effects must be
+# declared HONESTLY: ms spawns an MCP search server, writes feedback/outcome rows
+# to a live DB, and rebuilds the index. An empty effects list is a known
+# falsehood, so require the real effect tokens rather than assert emptiness.
 if grep -q '^metadata:' "$SKILL"; then
-  grep -q '^  effects: \[\]$' "$SKILL"
+  if grep -q '^  effects: \[\]$' "$SKILL"; then
+    echo 'ms effects must not be empty: it spawns a search server and writes feedback/outcome/index state' >&2
+    exit 1
+  fi
+  grep -q 'spawn_search_server' "$SKILL"
+  grep -q 'write_feedback_outcomes' "$SKILL"
+  grep -q 'rebuild_search_index' "$SKILL"
 fi
 grep -Fq 'Keep `ms` retrieval-only for production skill work.' "$SKILL"
 grep -Fq '**Authority boundary:** `skills/**` is canonical source' "$SKILL"

--- a/skills-codex/sbh/.agentops-generated.json
+++ b/skills-codex/sbh/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/sbh",
   "layout": "modular",
-  "source_hash": "8a9fa58182b9aa40f2ffee8593e6664c0b0e669f3854a665d7d92f5902274031",
-  "generated_hash": "78b58ea48fae6c2d4b6bd745cd696be05f7ebd2782eca163659c1f8601b8ba0a"
+  "source_hash": "1e938f203fc92290da03306ad803586159748d4d69c0aa4748f0af8864d7f9f4",
+  "generated_hash": "55e22b4db1245feab5a38ab8c571b77ad435047e2511d132e4c4b179f03a4fc9"
 }

--- a/skills-codex/sbh/SKILL.md
+++ b/skills-codex/sbh/SKILL.md
@@ -6,7 +6,10 @@ description: Inspect disk pressure with SBH and run one
 
 SBH exposes disk-pressure status, ballast, scanning, and recovery commands. This
 skill gathers evidence and performs at most the explicit action authorized by the
-caller.
+caller. Its authorized actions can delete files and change host storage
+configuration, so no mutation runs without explicit caller authority. The command
+surface below is anchored to `sbh` 0.4.27; re-verify against `sbh --version` on
+another host before relying on an exact flag.
 
 Evidence-first recovery works because disk pressure has cheap reversible
 remedies and expensive irreversible ones; a factual baseline is what tells them

--- a/skills-codex/shared/.agentops-generated.json
+++ b/skills-codex/shared/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/shared",
   "layout": "modular",
-  "source_hash": "5091329074c1c86cf1243ab50b0aae45c0a46901ff5fe8e0002c623738007768",
-  "generated_hash": "ed834c2a97ffdf8d2fa69269963504a9c2740c1599cd7180a13a8c0162cb3503"
+  "source_hash": "2ceb55d36d8cd719e3a05cd2f9e4b68881ad6ecefa03a48f6ef7fba581c614e2",
+  "generated_hash": "748ffbe5ac32af1bea316461195ea73122a5f2510b10ac2679043b4d8a106ec3"
 }

--- a/skills-codex/shared/.agentops-generated.json
+++ b/skills-codex/shared/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/shared",
   "layout": "modular",
-  "source_hash": "2ceb55d36d8cd719e3a05cd2f9e4b68881ad6ecefa03a48f6ef7fba581c614e2",
+  "source_hash": "22d81954843dff1019e74cb47ff9f6ec6af3a6cb0fe91daa083da7fe19a4c14f",
   "generated_hash": "748ffbe5ac32af1bea316461195ea73122a5f2510b10ac2679043b4d8a106ec3"
 }

--- a/skills-codex/shared/SKILL.md
+++ b/skills-codex/shared/SKILL.md
@@ -4,9 +4,10 @@ description: Shared runtime and evidence references
 ---
 # Shared References
 
-Shared files describe runtime capabilities and evidence formats. They are
-context, not permission to start a runtime, tracker, substrate, network call,
-or external mutation.
+This library bundles no standalone reference files today; consuming skills inline
+the runtime and evidence context they need. The contract below governs any shared
+reference a consuming skill does load: it is context, not permission to start a
+runtime, tracker, substrate, network call, or external mutation.
 
 Just-in-time loading works because a reference read only when a consuming
 skill needs it cannot silently become a dependency; anything loaded by default

--- a/skills-codex/status/.agentops-generated.json
+++ b/skills-codex/status/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/status",
   "layout": "modular",
-  "source_hash": "c4988fd8d1c497d63521e96e1235e132fdec955145e47ad276d7510c1615e89c",
-  "generated_hash": "60fcedb9dbc8aa913deb523161fd6b508de9101ad224841fbbf0a5d11df6f058"
+  "source_hash": "94d94e3e6158606f6cf54276829e7edeeaad174f00a583b6d9312bb4d53685f3",
+  "generated_hash": "b2787e028706bd060b67065247a693477186df28a6d2fe94522b3d81aaa89c3e"
 }

--- a/skills-codex/status/SKILL.md
+++ b/skills-codex/status/SKILL.md
@@ -8,13 +8,17 @@ A status snapshot is trustworthy exactly when every line traces to an artifact
 that exists on disk right now; the first inferred line turns the report into a
 guess wearing a report's clothes.
 
-Report only observable local facts: available intent, subject-manifest, and
-verdict artifacts; their counts, digests, and timestamps; deterministic check
-results; and unavailable or corrupt sources. The canonical durable stores are
-`.agents/ao/intents/sha256` and `.agents/ao/verdicts/sha256`; subject manifests
-remain caller-supplied unless the caller names their location. When `.agents/ao`
-evidence exists, report which stored artifact kind is newest and label that
-conclusion as evidence recency, not runtime phase or process activity.
+Report only observable local facts: available intent and verdict artifacts and
+their counts; deterministic check results; evidence recency; and unavailable or
+corrupt sources. The canonical durable stores are `.agents/ao/intents/sha256`
+and `.agents/ao/verdicts/sha256`. Subject manifests are caller-supplied: report
+them only when the caller names their location, otherwise disclose them as
+`not_checked`. When `.agents/ao` evidence exists, report which stored artifact
+kind is newest and label that conclusion as evidence recency, not runtime phase
+or process activity. The `ao status` snapshot emits the two counts plus that
+newest-artifact recency conclusion, not a per-artifact digest or timestamp
+listing; report a specific artifact's digest or timestamp only when the caller
+asks about a named artifact.
 
 Always disclose `checked` and `not_checked`. Runtime phase, execution elapsed
 time, tool-call activity, and remaining work are `not_checked` unless a caller

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -43,20 +43,20 @@
 | Skill | Tier | Disposition | Hard dependencies | Capabilities | Effects |
 |---|---|---|---|---|---|
 | `account-rotation` | execution | `keep_specialist` | - | `account_rotation` | `rotate_agent_account` |
-| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | - |
+| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | `write_agent_mail_records`, `install_precommit_guard`, `authorized_destructive_reset` |
 | `agent-native` | meta | `keep_optional_adapter` | - | `role_dispatch`, `observe_workers`, `handoff` | `manage_runtime_sessions` |
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
 | `bootstrap` | session | `keep_specialist` | - | `bootstrap` | `write_project_docs` |
-| `cass` | execution | `keep_specialist` | - | `cass` | - |
+| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
 | `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | `write_hook_config`, `append_guardrail_telemetry`, `write_session_sentinel` |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
-| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
+| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | `run_codex_process`, `sandbox_tiered_workspace_and_network_effects` |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
-| `doc` | product | `keep_specialist` | - | `doc` | - |
+| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
 | `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state`, `read_clock` |
@@ -64,30 +64,30 @@
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |
 | `learn` | execution | `keep_off_path` | - | `analyze_verdict_collections` | `write_advisory_observations` |
 | `ms` | execution | `keep_specialist` | - | `ms` | `spawn_search_server`, `write_feedback_outcomes`, `rebuild_search_index` |
-| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | - |
+| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | `manage_ntm_panes`, `dispatch_pane_commands` |
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
 | `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | `write_pattern_evidence` |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
 | `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
-| `rch` | execution | `keep_specialist` | - | `rch` | - |
+| `rch` | execution | `keep_specialist` | - | `rch` | `remote_compilation_offload`, `authorized_remote_daemon_worker_mutation` |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
-| `research` | execution | `keep_specialist` | - | `research` | - |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
+| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | `delete_reclaimable_files`, `release_disk_ballast`, `modify_host_storage_config` |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | - |
+| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | - |
+| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
-| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
+| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city`, `configure_codex_trust` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -59,7 +59,7 @@
 | `doc` | product | `keep_specialist` | - | `doc` | - |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
-| `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state` |
+| `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state`, `read_clock` |
 | `idea-genie` | execution | `keep_strategy` | - | `generate_evidenced_options`, `dueling_idea_genies` | `write_idea_portfolio` |
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |
 | `learn` | execution | `keep_off_path` | - | `analyze_verdict_collections` | `write_advisory_observations` |

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -42,52 +42,52 @@
 
 | Skill | Tier | Disposition | Hard dependencies | Capabilities | Effects |
 |---|---|---|---|---|---|
-| `account-rotation` | execution | `keep_specialist` | - | `account_rotation` | - |
-| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | `write_agent_mail_records`, `install_precommit_guard`, `authorized_destructive_reset` |
+| `account-rotation` | execution | `keep_specialist` | - | `account_rotation` | `rotate_agent_account` |
+| `agent-mail` | execution | `keep_optional_adapter` | - | `agent_mail` | - |
 | `agent-native` | meta | `keep_optional_adapter` | - | `role_dispatch`, `observe_workers`, `handoff` | `manage_runtime_sessions` |
 | `agy-native` | cross-vendor | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `provide_fresh_context` | `start_agy_session` |
 | `automation-shape-routing` | meta | `keep_optional_adapter` | - | `automation_shape_routing` | - |
-| `bootstrap` | session | `keep_specialist` | - | `bootstrap` | - |
-| `cass` | execution | `keep_specialist` | - | `cass` | `rebuild_local_index`, `sync_remote_sources`, `download_semantic_model` |
-| `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | - |
-| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | `write_recon_pack` |
-| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | `run_codex_process`, `sandbox_tiered_workspace_and_network_effects` |
-| `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
+| `bootstrap` | session | `keep_specialist` | - | `bootstrap` | `write_project_docs` |
+| `cass` | execution | `keep_specialist` | - | `cass` | - |
+| `cc-hooks` | execution | `keep_specialist` | - | `cc_hooks` | `write_hook_config`, `append_guardrail_telemetry`, `write_session_sentinel` |
+| `codebase-recon` | execution | `keep_specialist` | - | `codebase_recon` | - |
+| `codex-exec` | orchestration | `keep_optional_adapter` | - | `codex_exec` | - |
+| `converter` | cross-vendor | `keep_specialist` | - | `converter` | - |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
-| `dcg` | execution | `keep_specialist` | - | `dcg` | - |
-| `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
+| `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
+| `doc` | product | `keep_specialist` | - | `doc` | - |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
 | `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
-| `handoff` | session | `keep_specialist` | - | `handoff` | - |
+| `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state` |
 | `idea-genie` | execution | `keep_strategy` | - | `generate_evidenced_options`, `dueling_idea_genies` | `write_idea_portfolio` |
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |
 | `learn` | execution | `keep_off_path` | - | `analyze_verdict_collections` | `write_advisory_observations` |
-| `ms` | execution | `keep_specialist` | - | `ms` | - |
-| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | `manage_ntm_panes`, `dispatch_pane_commands` |
+| `ms` | execution | `keep_specialist` | - | `ms` | `spawn_search_server`, `write_feedback_outcomes`, `rebuild_search_index` |
+| `ntm` | execution | `keep_optional_adapter` | - | `ntm` | - |
 | `operationalize` | meta | `keep_specialist` | - | `distill_expertise`, `propose_artifact_shape` | `write_advisory_proposal` |
 | `pattern-mining` | execution | `keep_specialist` | - | `pattern_mining` | `write_pattern_evidence` |
 | `plan` | execution | `keep` | - | `shape_intent`, `define_acceptance`, `bound_write_scope` | `update_intent_source` |
 | `postmortem` | judgment | `keep_strategy` | - | `postmortem` | `write_postmortem_report` |
 | `premortem` | judgment | `keep_strategy` | - | `challenge_plan` | `write_advisory_plan_review` |
 | `product` | product | `keep_specialist` | - | `shape_product_boundary` | `write_product_document` |
-| `rch` | execution | `keep_specialist` | - | `rch` | `remote_compilation_offload`, `authorized_remote_daemon_worker_mutation` |
+| `rch` | execution | `keep_specialist` | - | `rch` | - |
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
-| `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
-| `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
+| `refactor` | execution | `keep_specialist` | - | `refactor` | - |
+| `research` | execution | `keep_specialist` | - | `research` | - |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | - |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
-| `sbh` | execution | `keep_specialist` | - | `sbh` | - |
-| `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
+| `sbh` | execution | `keep_specialist` | - | `sbh` | `delete_reclaimable_files`, `release_disk_ballast`, `modify_host_storage_config` |
+| `scaffold` | execution | `keep_specialist` | - | `scaffold` | - |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
-| `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
+| `security` | product | `keep_specialist` | - | `security` | - |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
-| `status` | session | `keep_specialist` | - | `status` | - |
+| `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
-| `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
+| `test` | execution | `keep_specialist` | - | `test` | - |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
-| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city`, `configure_codex_trust` |
+| `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `drive_mayor_shepherd` | `operate_gas_city` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
-| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |
+| `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | - |

--- a/skills/account-rotation/SKILL.md
+++ b/skills/account-rotation/SKILL.md
@@ -9,7 +9,7 @@ context_rel: []
 metadata:
   dependencies: []
   capabilities: [account_rotation]
-  effects: []
+  effects: [rotate_agent_account]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
@@ -37,14 +37,24 @@ process is required for the answer to hold.
 
 ## Boundary
 
-- On macOS with Claude credentials, use the operator's `claude-acct` route.
-- For Codex, Gemini, Linux, or WSL file-backed credentials, use `caam`.
+- Perform only the account switch the caller explicitly authorized; rotation
+  mutates host credential state and is never implied by repository access.
+- The credential tool is caller- or operator-selected per host and agent family;
+  the names below are this operator's routes, not a universal prescription. On
+  macOS with Claude credentials the route is `claude-acct` (Keychain-backed);
+  file-backed Codex, Gemini, Linux, or WSL credentials use `caam`. Never use
+  `caam` for macOS Claude account operations.
 - Verify account identity through the target runtime; token bytes are not account
   identity.
+- If neither the selected credential tool nor a runtime identity probe is
+  available, report that absence as a disclosed fact and stop. Never fall back to
+  diffing credential-file bytes to declare a switch done.
 - Existing processes retain credentials already loaded in memory. Rotation
   affects a new process.
 - This skill does not restart work, resume a task, select a pane, move repository
   state, or decide what happens after the switch.
 
-Return the host, agent family, selected tool, requested account/profile, observed
-identity/status, command exit code, and whether a new process is required.
+Return the host, agent family, selected tool, requested account/profile, the
+identity observed before and after the switch, whether any live runtime still
+holds the previous account (a partial rotation), the command exit code, and
+whether a new process is required for the new identity to hold.

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -21,7 +21,7 @@ context:
   intel_scope: none
 metadata:
   capabilities: [bootstrap]
-  effects: []
+  effects: [write_project_docs]
   canonical_status: canonical
   disposition: keep_specialist
   graph_root: true
@@ -61,6 +61,12 @@ PRODUCT.md written confidently is worse than a question.
 Typical documents are `PRODUCT.md`, `GOALS.md`, `AGENTS.md`, and a README section
 that explains the one-pass loop. Repositories remain free to use their own Git,
 CI, tracker, release, and deployment policies.
+
+**Naming.** Three surfaces share the word "bootstrap"; they are distinct. This
+skill authors missing entry documents. `ao init` is the CLI command that creates
+the local evidence and verdict directories (`.agents/ao/**`). `ao session
+bootstrap` is a read-only session command that reports which local orientation
+files are present. This skill invokes neither.
 
 ## Non-goals
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -13,7 +13,9 @@
       "dependencies": [],
       "description": "Switch a caller-selected coding-agent account and report the observed identity. Triggers: \"switch account\", \"rotate coding-agent account\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "rotate_agent_account"
+      ],
       "graph_root": false,
       "hexagonal_role": "supporting",
       "name": "account-rotation",
@@ -211,7 +213,9 @@
       "dependencies": [],
       "description": "Initialize minimal AgentOps documentation and verdict storage without taking over repository workflow. Triggers: \"bootstrap AgentOps\", \"initialize AgentOps docs\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "write_project_docs"
+      ],
       "graph_root": true,
       "hexagonal_role": "driving-adapter",
       "name": "bootstrap",
@@ -260,9 +264,13 @@
       "consumes": [],
       "context_rel": [],
       "dependencies": [],
-      "description": "Configure default Claude Code enforcement hooks and opt-in injection recipes. Triggers: \"cc-hooks\", \"configure Claude Code hooks\", \"install hooks\".",
+      "description": "Configure default Claude Code enforcement hooks and opt-in guard recipes. Triggers: \"cc-hooks\", \"configure Claude Code hooks\", \"install hooks\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "write_hook_config",
+        "append_guardrail_telemetry",
+        "write_session_sentinel"
+      ],
       "graph_root": false,
       "hexagonal_role": "supporting",
       "name": "cc-hooks",
@@ -460,9 +468,11 @@
       "consumes": [],
       "context_rel": [],
       "dependencies": [],
-      "description": "Handle blocked destructive commands and configure agent safety guardrails. Triggers: \"dcg\", \"handle blocked destructive commands. use\", \"dcg skill\".",
+      "description": "Handle blocked destructive commands and configure agent safety guardrails. Triggers: \"dcg\", \"handle a DCG block\", \"configure agent safety guardrails\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "write_dcg_config"
+      ],
       "graph_root": false,
       "hexagonal_role": "supporting",
       "name": "dcg",
@@ -576,7 +586,10 @@
       "dependencies": [],
       "description": "Write compact caller-authored session evidence without choosing continuation. Triggers: \"handoff\", \"write compact session handoff\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "write_handoff_artifact",
+        "read_git_state"
+      ],
       "graph_root": true,
       "hexagonal_role": "supporting",
       "name": "handoff",
@@ -720,7 +733,11 @@
       "dependencies": [],
       "description": "meta_skill (ms) \u2014 the skill-search/load engine over both corpora (agentops + jsm). Find a skill for a task, search skills, or load runnable skill guidance. Triggers: \"ms\", \"meta_skill\", \"skill search\", \"find a skill for\", \"load skill guidance\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "spawn_search_server",
+        "write_feedback_outcomes",
+        "rebuild_search_index"
+      ],
       "graph_root": false,
       "hexagonal_role": "supporting",
       "name": "ms",
@@ -1194,7 +1211,11 @@
       "dependencies": [],
       "description": "Inspect disk pressure with SBH and run one explicitly authorized recovery action. Triggers: \"check disk pressure\", \"run SBH\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "delete_reclaimable_files",
+        "release_disk_ballast",
+        "modify_host_storage_config"
+      ],
       "graph_root": false,
       "hexagonal_role": "supporting",
       "name": "sbh",
@@ -1402,7 +1423,10 @@
       "dependencies": [],
       "description": "Report observable AgentOps evidence without selecting work. Triggers: \"status\", \"show AgentOps status\".",
       "disposition": "keep_specialist",
-      "effects": [],
+      "effects": [
+        "read_filesystem",
+        "read_clock"
+      ],
       "graph_root": true,
       "hexagonal_role": "driving-adapter",
       "name": "status",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -588,7 +588,8 @@
       "disposition": "keep_specialist",
       "effects": [
         "write_handoff_artifact",
-        "read_git_state"
+        "read_git_state",
+        "read_clock"
       ],
       "graph_root": true,
       "hexagonal_role": "supporting",

--- a/skills/cc-hooks/SKILL.md
+++ b/skills/cc-hooks/SKILL.md
@@ -9,13 +9,14 @@ context_rel: []
 metadata:
   dependencies: []
   capabilities: [cc_hooks]
-  effects: []
+  effects: [write_hook_config, append_guardrail_telemetry, write_session_sentinel]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
-description: 'Configure default Claude Code enforcement hooks and opt-in injection recipes. Triggers: "cc-hooks", "configure Claude Code hooks", "install hooks".'
+description: 'Configure default Claude Code enforcement hooks and opt-in guard recipes. Triggers: "cc-hooks", "configure Claude Code hooks", "install hooks".'
 practices:
 - pragmatic-programmer
+output_contract: a hooks block in ~/.claude or project settings.json (matcher + command entries), or a hook script signalling allow/deny/ask via exit codes and hookSpecificOutput JSON; installs write hook config and guard fires append hashed telemetry
 ---
 # Claude Code Hooks
 
@@ -189,6 +190,14 @@ promoted with reviewed fires.
 [scripts/lint-policies.sh](scripts/lint-policies.sh) enforces this mechanically
 (jq-only; runs in bats and CI).
 
+**Accepted false-positive surface:** because a pure predicate matches its token
+anywhere in the raw command string, a protected token quoted as *data* (a commit
+message body, a `dcg test "..."` probe, a here-doc payload) can still fire even
+though nothing harmful would run. This is the deliberate cost of the
+pure-only-may-deny rule — the alternative (repo/context lookups) is exactly the
+stateful predicate the discipline bars from `deny`. Every fire is reversible: a
+one-shot `AOP_WAIVE=<policy-id>` or a `policy-waivers` line clears it.
+
 Semantics: happy path = exit 0, zero output. `deny` = exit 2 + one stderr
 route line (full message once per session, short line after — every attempt
 still blocks). `route` = exit 0 + `permissionDecision:"ask"` JSON. `audit` =
@@ -276,7 +285,7 @@ claude --debug  # Hook execution details
 
 ## Output Specification
 
-- **Path:** user `~/.claude/settings.json` or project `.claude/settings.json`, plus explicitly named hook scripts; no runtime hook is installed by default.
+- **Path:** user `~/.claude/settings.json` or project `.claude/settings.json`, plus explicitly named hook scripts. The PreToolUse policy dispatcher ships by default (every install path wires it — see "Policy Dispatch Engine"); the additional guard recipes (skill-first coordination, standalone installed-skill-edit) stay inert until opted in.
 - **Filename:** preserve `settings.json`; give scripts descriptive executable filenames rather than embedding large shell programs in JSON.
 - **Format:** valid Claude hook JSON using event arrays, matchers, and command objects; hook stdout/stderr and exit codes follow the selected event schema.
 - **Exit code:** validate with `jq -e '.hooks | type=="object"' <settings.json>` and a representative silent/fire test for each matcher; any parse error, noisy happy path, or recursion risk blocks activation.

--- a/skills/cc-hooks/hooks/installed-skill-edit-guard.sh
+++ b/skills/cc-hooks/hooks/installed-skill-edit-guard.sh
@@ -18,6 +18,11 @@
 #     parsed as JSON). Block via exit 2 + stderr only.
 set -uo pipefail
 
+# Fail OPEN if jq is unavailable (the dispatcher precedent): a guard that can't
+# parse its input must never brick a tool call. Explicit preflight so the
+# fail-open is intentional, not an accident of an empty path falling through.
+command -v jq >/dev/null 2>&1 || exit 0
+
 input="$(cat)"
 path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""')"
 sid="$(printf '%s' "$input" | jq -r '.session_id // "nosession"')"

--- a/skills/cc-hooks/policies/policies.json
+++ b/skills/cc-hooks/policies/policies.json
@@ -57,7 +57,7 @@
           "pattern": "(^|[;&|][[:space:]]*)(cp|rsync|mv)[[:space:]][^;&|]*[[:space:]][^[:space:];&|]*\\.(claude|codex|gemini)/skills(/[^[:space:];&|]*)?[[:space:]]*([;&|]|$)"
         }
       ],
-      "route_message": "~/.claude/skills (and .codex/.gemini) are INSTALLED/symlinked copies — a cp/rsync/mv into them writes through the symlink into whatever branch the factory checkout is on, or is overwritten on install. Link instead: ao skills link (repo) or link-skill --all (dotfiles). Closes the Bash gap of the Edit|Write-only installed-skill-edit-guard.",
+      "route_message": "~/.claude/skills (and .codex/.gemini) are INSTALLED/symlinked copies — a cp/rsync/mv into them writes through the symlink into whatever branch the source checkout is on, or is overwritten on install. Link instead: ao skills link. Closes the Bash gap of the Edit|Write-only installed-skill-edit-guard.",
       "rationale": "Global CLAUDE.md 'Never cp into ~/.claude/skills'. Destination position is enforced: the installed-skills path must be the LAST token of the command segment, so copying FROM an installed dir out to the repo never fires.",
       "value_proof": "declining fire-attempt rate (token_class core.skills:copy-into-installed); retire on false-positive evidence"
     },

--- a/skills/cc-hooks/references/GUARDRAIL-VALUE-PROOF.md
+++ b/skills/cc-hooks/references/GUARDRAIL-VALUE-PROOF.md
@@ -45,9 +45,10 @@ The hash is one-way; it lets us count *distinct* edited targets and detect
 repeats without ever logging what the agent was editing. Asserted in
 `tests/scripts/installed-skill-edit-telemetry.bats`.
 
-**Inert by default:** the emission code only runs when the guard fires, and the
-guard ships INERT (AgentOps hookless default; opt-in installer only). On a
-machine where the guard is not installed, zero lines are ever written. On a
+**Inert by default:** the emission code only runs when the guard fires, and this
+standalone guard ships INERT (opt-in installer only) even though the PreToolUse
+policy dispatcher ships by default. On a machine where the guard is not
+installed, zero lines are ever written. On a
 machine where it IS installed, the happy path (any non-installed-skill edit)
 writes nothing.
 

--- a/skills/cc-hooks/references/PATTERNS.md
+++ b/skills/cc-hooks/references/PATTERNS.md
@@ -118,7 +118,9 @@ exit 0
 ```bash
 #!/bin/bash
 INPUT=$(cat)
-PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path')
+# Never assign to $PATH — it clobbers the shell's executable search path and
+# breaks every command after it. Use a distinct variable name.
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path')
 
 BLOCKED_PATTERNS=(
   "/prod/"
@@ -128,8 +130,8 @@ BLOCKED_PATTERNS=(
 )
 
 for pattern in "${BLOCKED_PATTERNS[@]}"; do
-  if [[ "$PATH" == *"$pattern"* ]]; then
-    echo "Blocked: production file $PATH" >&2
+  if [[ "$FILE_PATH" == *"$pattern"* ]]; then
+    echo "Blocked: production file $FILE_PATH" >&2
     exit 2
   fi
 done

--- a/skills/dcg/SKILL.md
+++ b/skills/dcg/SKILL.md
@@ -124,10 +124,11 @@ dcg scan --staged       # Pre-commit: scan for issues
 | K8s | `delete namespace`, `delete --all` | `-l` label selector |
 
 **Context-aware (measured on dcg 0.5.6):** the temp carve-out allows `rm -rf`
-under `/tmp`, `/private/tmp`, and the literal `$TMPDIR` form. Everything else —
-`rm -rf ./build` and other relative paths (`core.filesystem:rm-rf-general`),
-absolute paths like `/home/...` and `/` (`core.filesystem:rm-rf-root-home`) — is
-blocked. Unresolved variables other than `$TMPDIR` are not treated as temp.
+under `/tmp`, `/private/tmp`, `/var/tmp`, and the literal `$TMPDIR` form.
+Everything else — `rm -rf ./build` and other relative paths
+(`core.filesystem:rm-rf-general`), absolute paths like `/home/...` and `/`
+(`core.filesystem:rm-rf-root-home`), and even `/private/var/tmp` — is blocked.
+Unresolved variables other than `$TMPDIR` are not treated as temp.
 
 **`dcg explain` example (7-step pipeline):**
 ```bash
@@ -179,7 +180,7 @@ allow_patterns = ["rm -rf ./node_modules"]  # Project-specific safe
 - **Sub-millisecond latency** — won't slow your workflow
 - **Fail-open on timeout** — if DCG hangs, command runs (with warning)
 - **Heredoc scanning** — inline scripts (`bash -c`, `python -c`) are analyzed
-- **Inline-fragment false positives** — because scanning matches a destructive token anywhere in the command string, a pattern quoted as *data* (a commit message, a `dcg test "rm -rf …"` probe, a here-doc payload) can trip a block even though nothing destructive would run. Safe pattern: keep the literal off the command line — split it (`rm -r""f`), pass it via a file/stdin, or run the intended tool directly instead of embedding the pattern.
+- **Inline-fragment false positives** — because scanning matches a destructive token anywhere in the command string, a pattern that appears only as *data* (a commit message body, a here-doc payload, a probe argument) can trip a block even though nothing destructive would run. Safe pattern: keep the payload off the command line — pass it via a file or stdin (e.g. `git commit -F <file>`), or run the intended tool directly instead of inlining the text. Never reconstruct a blocked command by splitting or escaping its tokens to slip past the guard — that defeats the safety layer.
 - **Allow-once codes** — 4 hex chars, 24h expiry, bound to exact command+directory
 
 ## The Incident That Started It All

--- a/skills/dcg/SKILL.md
+++ b/skills/dcg/SKILL.md
@@ -9,13 +9,14 @@ context_rel: []
 metadata:
   dependencies: []
   capabilities: [dcg]
-  effects: []
+  effects: [write_dcg_config]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
-description: 'Handle blocked destructive commands and configure agent safety guardrails. Triggers: "dcg", "handle blocked destructive commands. use", "dcg skill".'
+description: 'Handle blocked destructive commands and configure agent safety guardrails. Triggers: "dcg", "handle a DCG block", "configure agent safety guardrails".'
 practices:
 - pragmatic-programmer
+output_contract: the blocked command, matched rule, surviving risk, and validated safe alternative; config writes only when explicitly requested
 ---
 <!-- TOC: Core Insight | THE EXACT WORKFLOW | Quick Reference | Safe Alternatives | What Gets Blocked | Anti-Patterns | Configuration | References -->
 
@@ -122,7 +123,11 @@ dcg scan --staged       # Pre-commit: scan for issues
 | Database | `DROP`, `TRUNCATE`, `DELETE` w/o WHERE | Add WHERE clause |
 | K8s | `delete namespace`, `delete --all` | `-l` label selector |
 
-**Context-aware:** `rm -rf ./build` allowed, `rm -rf /` blocked.
+**Context-aware (measured on dcg 0.5.6):** the temp carve-out allows `rm -rf`
+under `/tmp`, `/private/tmp`, and the literal `$TMPDIR` form. Everything else —
+`rm -rf ./build` and other relative paths (`core.filesystem:rm-rf-general`),
+absolute paths like `/home/...` and `/` (`core.filesystem:rm-rf-root-home`) — is
+blocked. Unresolved variables other than `$TMPDIR` are not treated as temp.
 
 **`dcg explain` example (7-step pipeline):**
 ```bash
@@ -174,6 +179,7 @@ allow_patterns = ["rm -rf ./node_modules"]  # Project-specific safe
 - **Sub-millisecond latency** — won't slow your workflow
 - **Fail-open on timeout** — if DCG hangs, command runs (with warning)
 - **Heredoc scanning** — inline scripts (`bash -c`, `python -c`) are analyzed
+- **Inline-fragment false positives** — because scanning matches a destructive token anywhere in the command string, a pattern quoted as *data* (a commit message, a `dcg test "rm -rf …"` probe, a here-doc payload) can trip a block even though nothing destructive would run. Safe pattern: keep the literal off the command line — split it (`rm -r""f`), pass it via a file/stdin, or run the intended tool directly instead of embedding the pattern.
 - **Allow-once codes** — 4 hex chars, 24h expiry, bound to exact command+directory
 
 ## The Incident That Started It All

--- a/skills/dcg/references/COMMANDS.md
+++ b/skills/dcg/references/COMMANDS.md
@@ -26,11 +26,11 @@ DCG Doctor
 ══════════════════════════════════════════════════
 
 Binary:
-  ✓ dcg version 0.8.2 (built 2025-01-15)
+  ✓ dcg version 0.5.6
   ✓ Located at /usr/local/bin/dcg
 
 Hook Registration:
-  ✓ Claude Code hook registered in ~/.config/claude-code/settings.json
+  ✓ Claude Code hook registered in ~/.claude/settings.json
   ✓ Hook path: /usr/local/bin/dcg hook
 
 Configuration:
@@ -100,13 +100,19 @@ Dry-run evaluation without executing.
 $ dcg test "rm -rf /home/user/project"
 WOULD BE BLOCKED
 
-Rule: core.filesystem:rm-rf-dangerous
-Reason: Recursive deletion of non-temporary path
+Rule: core.filesystem:rm-rf-root-home
+Reason: Recursive deletion of an absolute non-temporary path
 
 $ dcg test "rm -rf ./build"
+WOULD BE BLOCKED
+
+Rule: core.filesystem:rm-rf-general
+Reason: Recursive deletion of a relative non-temporary path
+
+$ dcg test "rm -rf /tmp/build"
 WOULD BE ALLOWED
 
-Context: Relative path in current directory considered safe
+Context: paths under /tmp, /private/tmp, and $TMPDIR are in the temp carve-out
 ```
 
 **Use when:** Checking before running something you're unsure about.
@@ -147,7 +153,7 @@ Manage permanent exceptions.
 $ dcg allowlist add core.git:reset-hard -r "CI cleanup requires this"
 
 # Add with scope
-$ dcg allowlist add core.filesystem:rm-rf-dangerous \
+$ dcg allowlist add core.filesystem:rm-rf-root-home \
     --path "/home/user/project/build" \
     -r "Build directory cleanup"
 
@@ -157,7 +163,7 @@ $ dcg allowlist list
 │ Rule ID                          │ Scope                      │ Reason                  │
 ├──────────────────────────────────┼────────────────────────────┼─────────────────────────┤
 │ core.git:reset-hard              │ global                     │ CI cleanup requires     │
-│ core.filesystem:rm-rf-dangerous  │ /home/user/project/build   │ Build directory cleanup │
+│ core.filesystem:rm-rf-root-home  │ /home/user/project/build   │ Build directory cleanup │
 └──────────────────────────────────┴────────────────────────────┴─────────────────────────┘
 
 # Remove entry
@@ -253,14 +259,14 @@ Self-update to latest version.
 
 ```bash
 $ dcg update
-Current version: 0.8.1
-Latest version: 0.8.2
+Current version: <installed>
+Latest version: <latest>
 
 Downloading...
 Verifying signature...
 Installing...
 
-Updated to 0.8.2
+Updated to <latest>
 ```
 
 ---

--- a/skills/dcg/references/CONFIG.md
+++ b/skills/dcg/references/CONFIG.md
@@ -106,7 +106,7 @@ reason = "CI cleanup requires hard reset"
 expires = "2025-12-31"  # Optional expiration
 
 [[rules]]
-id = "core.filesystem:rm-rf-dangerous"
+id = "core.filesystem:rm-rf-general"
 path = "./build"  # Scope to specific path
 reason = "Build directory cleanup"
 ```
@@ -195,7 +195,7 @@ dcg-scan:
 
 DCG integrates with Claude Code via the PreToolUse hook:
 
-### Registration (~/.config/claude-code/settings.json)
+### Registration (~/.claude/settings.json)
 
 ```json
 {

--- a/skills/dcg/references/PACKS.md
+++ b/skills/dcg/references/PACKS.md
@@ -34,14 +34,17 @@ These cannot be disabled—they catch the most common destructive patterns.
 | `rm -rf /home` | Yes | System paths |
 | `rm -rf /path` | Depends | Non-temp paths blocked |
 
-**Safe patterns (allowed):**
+**Safe patterns (allowed) — measured on dcg 0.5.6.** The temp carve-out allows
+`rm -rf` under exactly these roots:
 - `rm -rf /tmp/*` — Temp directory
+- `rm -rf /private/tmp/*` — Temp directory (macOS)
 - `rm -rf /var/tmp/*` — Temp directory
 - `rm -rf $TMPDIR/*` — User temp (literal `$TMPDIR` only)
 
-`rm -rf ./build` and other relative or absolute non-temp paths are **blocked**
-(`core.filesystem:rm-rf-general` / `rm-rf-root-home`); allowlist them explicitly
-if a project needs them (see [CONFIG.md](CONFIG.md)).
+`rm -rf ./build` and other relative or absolute non-temp paths — and even
+`/private/var/tmp` — are **blocked** (`core.filesystem:rm-rf-general` /
+`rm-rf-root-home`); allowlist them explicitly if a project needs them (see
+[CONFIG.md](CONFIG.md)).
 
 ---
 

--- a/skills/dcg/references/PACKS.md
+++ b/skills/dcg/references/PACKS.md
@@ -37,8 +37,11 @@ These cannot be disabled—they catch the most common destructive patterns.
 **Safe patterns (allowed):**
 - `rm -rf /tmp/*` — Temp directory
 - `rm -rf /var/tmp/*` — Temp directory
-- `rm -rf $TMPDIR/*` — User temp
-- `rm -rf ./build` — Relative paths in project
+- `rm -rf $TMPDIR/*` — User temp (literal `$TMPDIR` only)
+
+`rm -rf ./build` and other relative or absolute non-temp paths are **blocked**
+(`core.filesystem:rm-rf-general` / `rm-rf-root-home`); allowlist them explicitly
+if a project needs them (see [CONFIG.md](CONFIG.md)).
 
 ---
 

--- a/skills/dcg/references/SCENARIOS.md
+++ b/skills/dcg/references/SCENARIOS.md
@@ -32,12 +32,16 @@ git push --force-with-lease origin feature-branch
 
 ## 3. rm -rf Typo — DCG Saved You
 
-**Blocked:** `rm -rf /home/user/project/` (meant `./build`)
+**Blocked:** `rm -rf /home/user/project/` (typo — meant a scoped build dir)
 
-DCG caught the typo. Correct the path:
+DCG caught the typo. Note that `rm -rf ./build` is **also** blocked by default
+(relative non-temp path, `core.filesystem:rm-rf-general`). Reach for a genuinely
+safe target, or allowlist the build dir explicitly:
 
 ```bash
-rm -rf ./build  # Safe path, won't be blocked
+rm -rf "$TMPDIR/project-build"        # temp carve-out — allowed
+# or, if ./build itself must be cleaned, allowlist it once (see CONFIG.md):
+#   [overrides] allow_patterns = ["rm -rf ./build"]
 ```
 
 ---

--- a/skills/dcg/references/TROUBLESHOOTING.md
+++ b/skills/dcg/references/TROUBLESHOOTING.md
@@ -42,12 +42,11 @@ dcg doctor
 **Diagnose:**
 ```bash
 $ dcg explain "rm -rf ./node_modules"
-BLOCKED by core.filesystem:rm-rf-dangerous
+BLOCKED by core.filesystem:rm-rf-general
 
 Evaluation trace:
   ...
-  Step 6. Normalization: rm -rf /home/user/project/node_modules
-  Step 7. Pack evaluation: MATCH (non-temp path)
+  Step 7. Pack evaluation: MATCH (relative non-temp path)
 ```
 
 **Fix options:**
@@ -67,7 +66,7 @@ dcg allow-once ab12
 
 3. **Permanent allowlist:**
 ```bash
-dcg allowlist add core.filesystem:rm-rf-dangerous \
+dcg allowlist add core.filesystem:rm-rf-general \
     --path "$PWD/node_modules" \
     -r "Package cleanup"
 ```
@@ -245,7 +244,7 @@ block_patterns = ["the-bypass-pattern"]
 
 **Check hook is registered:**
 ```bash
-cat ~/.config/claude-code/settings.json | jq '.hooks'
+jq '.hooks' ~/.claude/settings.json
 ```
 
 **Expected:**

--- a/skills/dcg/scripts/validate-dcg.sh
+++ b/skills/dcg/scripts/validate-dcg.sh
@@ -8,7 +8,8 @@ echo "=== DCG Installation Validation ==="
 # Check if dcg is installed
 if ! command -v dcg &> /dev/null; then
     echo "ERROR: dcg not found in PATH"
-    echo "Install from: https://github.com/anthropics/destructive-command-guard"
+    echo "Install from: https://github.com/Dicklesworthstone/destructive_command_guard"
+    echo "  (cargo install destructive_command_guard)"
     exit 1
 fi
 

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -13,7 +13,7 @@ context:
   intel_scope: none
 metadata:
   capabilities: [handoff]
-  effects: []
+  effects: [write_handoff_artifact, read_git_state]
   canonical_status: canonical
   disposition: keep_specialist
   graph_root: true

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -13,7 +13,7 @@ context:
   intel_scope: none
 metadata:
   capabilities: [handoff]
-  effects: [write_handoff_artifact, read_git_state]
+  effects: [write_handoff_artifact, read_git_state, read_clock]
   canonical_status: canonical
   disposition: keep_specialist
   graph_root: true

--- a/skills/ms/SKILL.md
+++ b/skills/ms/SKILL.md
@@ -12,14 +12,15 @@ context_rel: []
 metadata:
   dependencies: []
   capabilities: [ms]
-  effects: []
+  effects: [spawn_search_server, write_feedback_outcomes, rebuild_search_index]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
   external_dependencies:
-  - "ms binary (Jeffrey Emanuel's meta_skill; source build from ~/dev/meta_skill, branch local/frontmatter-id — the 0.1.2 release binary corrupts IDs on Anthropic-frontmatter skills)"
+  - "ms binary (Jeffrey Emanuel's meta_skill). The 0.1.2 release binary corrupts IDs on Anthropic-frontmatter skills, so it must be built from a source checkout carrying the frontmatter-id fix; this operator builds from ~/dev/meta_skill, branch local/frontmatter-id."
   - jq (required for parsing -O json output)
   - python3 (required by the disposable MCP search helper)
+output_contract: search and load results plus source identity on stdout; the local index is disposable state, never a source of truth
 ---
 <!-- TOC: Core Insight | Constraints | Quick Start | Consume (MCP) | Write/Admin (CLI) | Output | Production Skill Handoff | Footguns | Concurrency | Scenarios | Quality | References -->
 

--- a/skills/ms/scripts/validate.sh
+++ b/skills/ms/scripts/validate.sh
@@ -11,15 +11,19 @@ grep -q '^name: ms$' "$SKILL"
 # frontmatter but mirrors this validator and the runnable body. Effects must be
 # declared HONESTLY: ms spawns an MCP search server, writes feedback/outcome rows
 # to a live DB, and rebuilds the index. An empty effects list is a known
-# falsehood, so require the real effect tokens rather than assert emptiness.
+# falsehood. Anchor the assertion to the YAML frontmatter block (between the
+# first two --- fences) so a token that merely appears in the prose body can
+# never satisfy the effects contract, and require the exact declared value.
 if grep -q '^metadata:' "$SKILL"; then
-  if grep -q '^  effects: \[\]$' "$SKILL"; then
-    echo 'ms effects must not be empty: it spawns a search server and writes feedback/outcome/index state' >&2
+  frontmatter="$(awk '/^---[[:space:]]*$/{fences++; next} fences==1{print}' "$SKILL")"
+  expected_effects='  effects: [spawn_search_server, write_feedback_outcomes, rebuild_search_index]'
+  if printf '%s\n' "$frontmatter" | grep -qxF "$expected_effects"; then
+    :
+  else
+    echo "ms frontmatter effects must be exactly: [spawn_search_server, write_feedback_outcomes, rebuild_search_index]" >&2
+    echo "(ms spawns a search server and writes feedback/outcome/index state; an empty or partial list is a known falsehood)" >&2
     exit 1
   fi
-  grep -q 'spawn_search_server' "$SKILL"
-  grep -q 'write_feedback_outcomes' "$SKILL"
-  grep -q 'rebuild_search_index' "$SKILL"
 fi
 grep -Fq 'Keep `ms` retrieval-only for production skill work.' "$SKILL"
 grep -Fq '**Authority boundary:** `skills/**` is canonical source' "$SKILL"

--- a/skills/ms/scripts/validate.sh
+++ b/skills/ms/scripts/validate.sh
@@ -8,9 +8,18 @@ MCP_SEARCH="$SKILL_DIR/scripts/mcp-search.py"
 [[ -s "$SKILL" ]]
 grep -q '^name: ms$' "$SKILL"
 # Canonical source carries full metadata; the generated Codex package uses slim
-# frontmatter but mirrors this validator and the runnable body.
+# frontmatter but mirrors this validator and the runnable body. Effects must be
+# declared HONESTLY: ms spawns an MCP search server, writes feedback/outcome rows
+# to a live DB, and rebuilds the index. An empty effects list is a known
+# falsehood, so require the real effect tokens rather than assert emptiness.
 if grep -q '^metadata:' "$SKILL"; then
-  grep -q '^  effects: \[\]$' "$SKILL"
+  if grep -q '^  effects: \[\]$' "$SKILL"; then
+    echo 'ms effects must not be empty: it spawns a search server and writes feedback/outcome/index state' >&2
+    exit 1
+  fi
+  grep -q 'spawn_search_server' "$SKILL"
+  grep -q 'write_feedback_outcomes' "$SKILL"
+  grep -q 'rebuild_search_index' "$SKILL"
 fi
 grep -Fq 'Keep `ms` retrieval-only for production skill work.' "$SKILL"
 grep -Fq '**Authority boundary:** `skills/**` is canonical source' "$SKILL"

--- a/skills/sbh/SKILL.md
+++ b/skills/sbh/SKILL.md
@@ -9,7 +9,7 @@ context_rel: []
 metadata:
   dependencies: []
   capabilities: [sbh]
-  effects: []
+  effects: [delete_reclaimable_files, release_disk_ballast, modify_host_storage_config]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution
@@ -22,7 +22,10 @@ output_contract: disk pressure observations and authorized action result
 
 SBH exposes disk-pressure status, ballast, scanning, and recovery commands. This
 skill gathers evidence and performs at most the explicit action authorized by the
-caller.
+caller. Its authorized actions can delete files and change host storage
+configuration, so no mutation runs without explicit caller authority. The command
+surface below is anchored to `sbh` 0.4.27; re-verify against `sbh --version` on
+another host before relying on an exact flag.
 
 Evidence-first recovery works because disk pressure has cheap reversible
 remedies and expensive irreversible ones; a factual baseline is what tells them

--- a/skills/shared/SKILL.md
+++ b/skills/shared/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   canonical_status: canonical
   disposition: keep_specialist
   internal: true
-output_contract: reference documents loaded just in time
+output_contract: no reference documents are bundled at present; the contract governs any reference a consuming skill inlines
 ---
 
 # Shared References

--- a/skills/shared/SKILL.md
+++ b/skills/shared/SKILL.md
@@ -21,9 +21,10 @@ output_contract: reference documents loaded just in time
 
 # Shared References
 
-Shared files describe runtime capabilities and evidence formats. They are
-context, not permission to start a runtime, tracker, substrate, network call,
-or external mutation.
+This library bundles no standalone reference files today; consuming skills inline
+the runtime and evidence context they need. The contract below governs any shared
+reference a consuming skill does load: it is context, not permission to start a
+runtime, tracker, substrate, network call, or external mutation.
 
 Just-in-time loading works because a reference read only when a consuming
 skill needs it cannot silently become a dependency; anything loaded by default

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -15,7 +15,7 @@ context:
   intel_scope: none
 metadata:
   capabilities: [status]
-  effects: []
+  effects: [read_filesystem, read_clock]
   canonical_status: canonical
   disposition: keep_specialist
   graph_root: true
@@ -30,13 +30,17 @@ A status snapshot is trustworthy exactly when every line traces to an artifact
 that exists on disk right now; the first inferred line turns the report into a
 guess wearing a report's clothes.
 
-Report only observable local facts: available intent, subject-manifest, and
-verdict artifacts; their counts, digests, and timestamps; deterministic check
-results; and unavailable or corrupt sources. The canonical durable stores are
-`.agents/ao/intents/sha256` and `.agents/ao/verdicts/sha256`; subject manifests
-remain caller-supplied unless the caller names their location. When `.agents/ao`
-evidence exists, report which stored artifact kind is newest and label that
-conclusion as evidence recency, not runtime phase or process activity.
+Report only observable local facts: available intent and verdict artifacts and
+their counts; deterministic check results; evidence recency; and unavailable or
+corrupt sources. The canonical durable stores are `.agents/ao/intents/sha256`
+and `.agents/ao/verdicts/sha256`. Subject manifests are caller-supplied: report
+them only when the caller names their location, otherwise disclose them as
+`not_checked`. When `.agents/ao` evidence exists, report which stored artifact
+kind is newest and label that conclusion as evidence recency, not runtime phase
+or process activity. The `ao status` snapshot emits the two counts plus that
+newest-artifact recency conclusion, not a per-artifact digest or timestamp
+listing; report a specific artifact's digest or timestamp only when the caller
+asks about a named artifact.
 
 Always disclose `checked` and `not_checked`. Runtime phase, execution elapsed
 time, tool-call activity, and remaining work are `not_checked` unless a caller


### PR DESCRIPTION
## Summary

Wave W7 of the skill-overhaul reboot (`age-skill-overhaul-reboot-sjv7v.8`) — the nine support skills, plus the one Go fix where the skill contract crosses the CLI boundary.

- **handoff** — `ao session handoff --dry-run` output failed its own `handoff.v1.schema.json` (reproduced: 3 errors). Fixed with a consumer audit: schema keeps v1 with the doctrine-retired fields as optional deprecated read-compat properties; the generator keeps its collision-safe fractional id (schema pattern widened instead); real jsonschema validation in `TestHandoffDryRunSatisfiesSchema` + a legacy-artifact compat test; `read_clock` effect declared.
- **dcg** — corrected the false "`rm -rf ./build` allowed" claim (live 0.5.6 blocks it) and a nonexistent rule id in the allowlist example (silent no-op) across six files; removed a token-splitting "workaround" that was an executable guard bypass, replaced with file/stdin handling and a never-reconstruct warning; temp-path rule live-probed and stated identically in both docs; version/path/upstream corrections.
- **cc-hooks** — ships-by-default contradiction reconciled; PATH-clobbering recipe fixed; operator-private paths removed from shipped text; jq preflight added to the edit guard.
- **ms** — validator no longer mechanically asserts the false `effects: []`; it extracts the frontmatter and requires the exact honest effects value.
- **account-rotation / status / sbh / bootstrap** — real effects declared, both-tools-absent and destructive surfaces defined, live-output overclaims narrowed, versions pinned.
- **shared** — advertising narrowed to the current no-bundled-references state; retirement NOT executed (bead `.11`).

Ledger (32+8 fixed across two rounds / 8 rejected-stale / 8 deferred-with-reason): `docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w7.md`.

## Validation

- `go build` + `go vet` + 482 `cmd/ao` tests incl. the new schema-lock and legacy-compat tests; dry-run validates 0 errors
- 49/49 strict frontmatter; regen clean; scenario-linkage PASS; liveness + anti-spiral + policy + edit-guard bats green; python ratchet no-growth; shellcheck clean
- Cross-family review, two rounds: round 1 eight findings all fixed (schema compat, id collision, real validation, security bypass removal, live-probed temp rule, anchored greps); round 2 delta re-review **VERDICT: PASS** with zero residuals

Tracker: `age-skill-overhaul-reboot-sjv7v.8`