### PR TITLE
W8 coherence: corpus-level trigger separation, effects vocabulary, plan closeout

### DIFF
--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -61,14 +61,14 @@
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
 | `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
 | `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `authorized_binary_execution`, `write_teardown_artifacts` |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | `delete_reclaimable_files`, `release_disk_ballast`, `modify_host_storage_config` |
 | `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
 | `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `write_skill_source`, `write_build_report`, `regenerate_skill_projections`, `repair_skill_projections` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -61,14 +61,14 @@
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
 | `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
 | `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `authorized_binary_execution`, `write_teardown_artifacts` |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | `delete_reclaimable_files`, `release_disk_ballast`, `modify_host_storage_config` |
 | `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
 | `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `write_skill_source`, `write_build_report`, `regenerate_skill_projections`, `repair_skill_projections` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |

--- a/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w8.md
+++ b/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w8.md
@@ -1,0 +1,42 @@
+# W8 coherence — closing report
+
+Bead: `age-skill-overhaul-reboot-sjv7v.9`. Ran after all seven content
+waves merged (#998–#1005).
+
+## Deterministic checks
+
+- Regeneration byte-idempotence: `scripts/regen-all.sh` run twice on merged
+  main — zero dirty files after either run.
+- `check-scenario-test-linkage.sh` PASS (75 scenarios / 23 linked / 15
+  doc-only files).
+- `validate-skill-frontmatter.sh --strict` 49/49, zero warnings.
+- `codex-desc-avg-budget.bats` 3/3.
+- Effects survey: 43/49 skills declare concrete effects; the six
+  `effects: []` (automation-shape-routing, craft-goal, domain, scope,
+  shared, standards) are all response-only by design.
+
+## Closing corpus-level review (cross-family, one round)
+
+Seven findings, judged only on corpus-level properties no per-wave review
+could see. All seven applied:
+
+1. rpi↔implement trigger collision ("execute this plan"/"build this plan")
+   — implement's trigger narrowed to "implement this bead", with an
+   explicit route-to-rpi note.
+2. `authorized_` effect-prefix inconsistency — `execute_authorized_binary`
+   renamed `authorized_binary_execution`.
+3. skill-builder effects normalized to the corpus imperative forms
+   (`write_skill_source`, `regenerate_skill_projections`,
+   `repair_skill_projections`).
+4. plan↔craft-goal trigger collision — craft-goal's triggers now name the
+   Mayor/goal-runner distinction and drop the generic "turn this into a
+   goal" forms.
+5. status↔reality-check overlap — reality-check now requires a claim to
+   test ("is this claim actually done").
+6. research↔codebase-recon overlap — bare "investigate" narrowed to
+   "investigate this question" with a route-to-recon note.
+7. shared reachability — description now states "Triggers: none — internal
+   library, not user-routable" (user-invocable was already false).
+
+No authority violations found: only validate claims verdict persistence,
+only rpi claims loop dispatch, no specialist claims to start RPI.

--- a/docs/plans/2026-07-28-skill-overhaul-reboot.md
+++ b/docs/plans/2026-07-28-skill-overhaul-reboot.md
@@ -2,7 +2,7 @@
 id: plan-2026-07-28-skill-overhaul-reboot
 type: plan
 date: 2026-07-28
-status: in_progress
+status: complete
 goal: Enhance every canonical skill per the 2026-07-24 overhaul findings, in lean waves, without the proof-epoch machinery
 supersedes: plan-2026-07-24-skill-system-overhaul
 inputs:
@@ -113,3 +113,15 @@ A wave is done when:
 - `docs/plans/2026-07-24-skill-system-overhaul.md` and this plan both marked
   superseded/complete, with the skill sources themselves as the only
   authority — no plan document owns any live placement fact.
+
+## Completion record (2026-07-28)
+
+Executed same-day: W0+W1 in PR #998, W2 #999, W3a #1000, W5 #1001, W3b
+#1002, W4 #1003, W6 #1004, W7 #1005, W8 coherence in the final PR. Every
+wave passed deterministic gates plus a two-round-capped cross-family
+review; per-item dispositions live in
+`docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/`. The three
+structural beads remain open under epic `age-skill-overhaul-reboot-sjv7v`
+(.10 goals→fitness rename, .11 shared retirement, .12 Go-CLI residue) —
+explicitly deferred as tracked work, not part of wave scope. No live
+placement fact is owned by this document.

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -55,14 +55,14 @@
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
 | `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
 | `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `authorized_binary_execution`, `write_teardown_artifacts` |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | `delete_reclaimable_files`, `release_disk_ballast`, `modify_host_storage_config` |
 | `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
 | `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `write_skill_source`, `write_build_report`, `regenerate_skill_projections`, `repair_skill_projections` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |

--- a/images/gemini/skills/craft-goal/SKILL.md
+++ b/images/gemini/skills/craft-goal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: craft-goal
-description: 'Compile or lint a persistent Mayor-style goal that ratchets a bead graph through bounded RPI experiments toward one larger outcome. Triggers: "craft a goal prompt", "turn this into a goal", "create a bounded goal", "lint this goal", "is this goal safe".'
+description: 'Compile or lint a persistent Mayor-style goal prompt that ratchets a bead graph through bounded RPI experiments toward one larger outcome. Triggers: "craft a goal prompt", "mayor goal", "goal-runner prompt", "lint this goal", "is this goal safe". (Shaping one experiment''s intent routes to plan.)'
 practices:
 - lean-startup
 - design-by-contract

--- a/images/gemini/skills/implement/SKILL.md
+++ b/images/gemini/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: 'Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "build this plan", "run the experiment".'
+description: 'Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "implement this bead", "run the experiment". ("execute this plan" routes to rpi, which dispatches the whole loop.)'
 practices:
 - tdd
 - refactoring

--- a/images/gemini/skills/reality-check/SKILL.md
+++ b/images/gemini/skills/reality-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reality-check
-description: 'Compare a claimed state with observable repository evidence and report concrete gaps. Triggers: "reality check", "what is actually done", "compare claim to repo".'
+description: 'Compare a claimed state with observable repository evidence and report concrete gaps. Requires a claim or expected state to test. Triggers: "reality check", "is this claim actually done", "compare claim to repo".'
 practices: [design-by-contract, evidence-based-engineering]
 hexagonal_role: domain
 consumes: [claim, repository-evidence]

--- a/images/gemini/skills/research/SKILL.md
+++ b/images/gemini/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: 'Answer a bounded question with current cited evidence. Triggers: "research", "investigate", "find evidence".'
+description: 'Answer a bounded question with current cited evidence. Triggers: "research", "investigate this question", "find evidence". (Investigating a repository routes to codebase-recon.)'
 practices:
 - pragmatic-programmer
 - ddd-bounded-context

--- a/images/gemini/skills/reverse-engineer/SKILL.md
+++ b/images/gemini/skills/reverse-engineer/SKILL.md
@@ -22,7 +22,7 @@ context:
 metadata:
   dependencies: []
   capabilities: [reverse_engineer]
-  effects: [clone_upstream_repo, execute_authorized_binary, write_teardown_artifacts]
+  effects: [clone_upstream_repo, authorized_binary_execution, write_teardown_artifacts]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution

--- a/images/gemini/skills/shared/SKILL.md
+++ b/images/gemini/skills/shared/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shared
-description: 'Shared runtime and evidence references loaded only by a consuming skill. Triggers: internal shared contracts.'
+description: 'Shared runtime and evidence references loaded only by a consuming skill. Triggers: none — internal library, not user-routable.'
 practices: [design-by-contract, pragmatic-programmer]
 hexagonal_role: domain
 consumes: []

--- a/images/gemini/skills/skill-builder/SKILL.md
+++ b/images/gemini/skills/skill-builder/SKILL.md
@@ -21,7 +21,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [skill_builder, heal_skill]
-  effects: [writes_skill_source, write_build_report, regenerates_skill_projections, optional_skill_projection_repair]
+  effects: [write_skill_source, write_build_report, regenerate_skill_projections, repair_skill_projections]
   canonical_status: canonical
   disposition: keep_specialist
   tier: meta

--- a/packs/agentops-executor/agents/implementer-claude/skills/implement/SKILL.md
+++ b/packs/agentops-executor/agents/implementer-claude/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: 'Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "build this plan", "run the experiment".'
+description: 'Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "implement this bead", "run the experiment". ("execute this plan" routes to rpi, which dispatches the whole loop.)'
 practices:
 - tdd
 - refactoring

--- a/packs/agentops-executor/agents/implementer/skills/implement/SKILL.md
+++ b/packs/agentops-executor/agents/implementer/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: 'Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "build this plan", "run the experiment".'
+description: 'Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "implement this bead", "run the experiment". ("execute this plan" routes to rpi, which dispatches the whole loop.)'
 practices:
 - tdd
 - refactoring

--- a/packs/agentops-executor/assets/generated-skill-manifest.json
+++ b/packs/agentops-executor/assets/generated-skill-manifest.json
@@ -6,8 +6,8 @@
     {
       "source": "skills/implement/SKILL.md",
       "destination": "packs/agentops-executor/agents/implementer-claude/skills/implement/SKILL.md",
-      "source_sha256": "16a3faa2d3608fe75c03baa355996547b7c65f54334cd0d238e55134d9f929a8",
-      "sha256": "16a3faa2d3608fe75c03baa355996547b7c65f54334cd0d238e55134d9f929a8",
+      "source_sha256": "ada81165711dc36b8e660a380b6b9173ecb646cda8f1a3905d12d26fa6612c8f",
+      "sha256": "ada81165711dc36b8e660a380b6b9173ecb646cda8f1a3905d12d26fa6612c8f",
       "mode": "0644"
     },
     {
@@ -27,8 +27,8 @@
     {
       "source": "skills/implement/SKILL.md",
       "destination": "packs/agentops-executor/agents/implementer/skills/implement/SKILL.md",
-      "source_sha256": "16a3faa2d3608fe75c03baa355996547b7c65f54334cd0d238e55134d9f929a8",
-      "sha256": "16a3faa2d3608fe75c03baa355996547b7c65f54334cd0d238e55134d9f929a8",
+      "source_sha256": "ada81165711dc36b8e660a380b6b9173ecb646cda8f1a3905d12d26fa6612c8f",
+      "sha256": "ada81165711dc36b8e660a380b6b9173ecb646cda8f1a3905d12d26fa6612c8f",
       "mode": "0644"
     },
     {

--- a/registry.json
+++ b/registry.json
@@ -1135,7 +1135,7 @@
         "disposition": "keep_specialist",
         "effects": [
           "clone_upstream_repo",
-          "execute_authorized_binary",
+          "authorized_binary_execution",
           "write_teardown_artifacts"
         ],
         "has_references": true,
@@ -1241,10 +1241,10 @@
         ],
         "disposition": "keep_specialist",
         "effects": [
-          "writes_skill_source",
+          "write_skill_source",
           "write_build_report",
-          "regenerates_skill_projections",
-          "optional_skill_projection_repair"
+          "regenerate_skill_projections",
+          "repair_skill_projections"
         ],
         "has_references": true,
         "has_skill_md": true,

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -405,8 +405,8 @@
     {
       "name": "craft-goal",
       "source_skill": "skills/craft-goal",
-      "source_hash": "b142e207fa6386caa7178185af2aed9dc6c4f4e1bb7d8d453917da67ed5ebd7e",
-      "generated_hash": "65bc3e02640cc2d6f720efd1e45047cbd5595dc31c944cfa188b548e95f0dfec"
+      "source_hash": "714ba85897319c69e5b39a6de0541bed968b03043ba96ec5df4c11550757fdb6",
+      "generated_hash": "b2ea9d9bf5f9b51bb9699a32e1f1b3c49a89e2b3d3ea3f9758b0f7b99bcc89b0"
     },
     {
       "name": "dcg",
@@ -447,8 +447,8 @@
     {
       "name": "implement",
       "source_skill": "skills/implement",
-      "source_hash": "0e5a114ae21d79513428c6ce5768048a71fe56dbc1c161a207f7c578c1eca95e",
-      "generated_hash": "5bfefe1a54cc66526656cca805e7e84cb36526d4a72d7834741c762fef40f977"
+      "source_hash": "c8054730f0c42489d77c20261b3f3ebba8b24b83cd000d03fab4e52b0c3b5a73",
+      "generated_hash": "5fbbb9f75b956e19758d304e2eb2627fdaf6c71c92359b5430f5b3d6b5330ff0"
     },
     {
       "name": "learn",
@@ -513,8 +513,8 @@
     {
       "name": "reality-check",
       "source_skill": "skills/reality-check",
-      "source_hash": "a2d7e5ab9bf7da978fdef17f19a5e7dd28fed28b5d3a1513ef92b5042e4068cd",
-      "generated_hash": "a65522fa3b24fca1f367a883f2eb904a2606a4f2a21ee688b1b6c106d7efefb2"
+      "source_hash": "d79b843f8f6cc71d3fbe08b8ba6db458c9d886763750a38b2bc29fa8a505fc56",
+      "generated_hash": "2efce800c15a5c024a58cfe9dc1bb33c41dbaac9e0840f0661dbc00dd68153a5"
     },
     {
       "name": "refactor",
@@ -525,13 +525,13 @@
     {
       "name": "research",
       "source_skill": "skills/research",
-      "source_hash": "0d74ded7960b70ace4db089b49b78126c05572d808e1b640a330614545ffce13",
-      "generated_hash": "37be6a0296ae07b6e62ef6fdba2115651d5bdd66881b33442afc10249a77d672"
+      "source_hash": "801e2f77a762e424d24608de9b37d671888e33c340b5bb18d5a620a395f2c36c",
+      "generated_hash": "228a40a29d5c2e43cff2235713a94842af4de7f9ebd2547e8de01607ffbd3c23"
     },
     {
       "name": "reverse-engineer",
       "source_skill": "skills/reverse-engineer",
-      "source_hash": "8b308ebdba1e4e45a0987adf15b25ae69f03553a971f75d144885f263326f3c5",
+      "source_hash": "d9ca7efb322681204dbd09f31ecbd6c3bd5a1e1ab142344297f89dff8812a3e2",
       "generated_hash": "22eb63b54f3a1b67829dbdb057990abeb03dd03bab3ba9d62c00484edcd3c491"
     },
     {
@@ -567,13 +567,13 @@
     {
       "name": "shared",
       "source_skill": "skills/shared",
-      "source_hash": "22d81954843dff1019e74cb47ff9f6ec6af3a6cb0fe91daa083da7fe19a4c14f",
-      "generated_hash": "748ffbe5ac32af1bea316461195ea73122a5f2510b10ac2679043b4d8a106ec3"
+      "source_hash": "8a7bb52408d7def6f9360feeef8b1d01a75cde0df3a3f1da869efb040d84dd92",
+      "generated_hash": "340b5e356593682d0abe103e101d62649b8c7fa35ce18566c30ba9c2e2886895"
     },
     {
       "name": "skill-builder",
       "source_skill": "skills/skill-builder",
-      "source_hash": "7ccbbe127470335d424b1ceb01bbe9cb16faf77cbf5e31f6215d31ce9a3dc39b",
+      "source_hash": "775e73f3ebe87960a245790645cb2ba9083f18e0c8d0ee60569e6b747529b830",
       "generated_hash": "9ab3978eca5991203690b4c5ae36c75b12e2d860002d8ccff5e4ceb5cdfdc6c5"
     },
     {

--- a/skills-codex/craft-goal/.agentops-generated.json
+++ b/skills-codex/craft-goal/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/craft-goal",
   "layout": "modular",
-  "source_hash": "b142e207fa6386caa7178185af2aed9dc6c4f4e1bb7d8d453917da67ed5ebd7e",
-  "generated_hash": "65bc3e02640cc2d6f720efd1e45047cbd5595dc31c944cfa188b548e95f0dfec"
+  "source_hash": "714ba85897319c69e5b39a6de0541bed968b03043ba96ec5df4c11550757fdb6",
+  "generated_hash": "b2ea9d9bf5f9b51bb9699a32e1f1b3c49a89e2b3d3ea3f9758b0f7b99bcc89b0"
 }

--- a/skills-codex/craft-goal/prompt.md
+++ b/skills-codex/craft-goal/prompt.md
@@ -1,6 +1,6 @@
 # craft-goal
 
-Compile or lint a persistent Mayor-style goal that ratchets a bead graph through bounded RPI experiments toward one larger outcome. Triggers: "craft a goal prompt", "turn this into a goal", "create a bounded goal", "lint this goal", "is this goal safe".
+Compile or lint a persistent Mayor-style goal prompt that ratchets a bead graph through bounded RPI experiments toward one larger outcome. Triggers: "craft a goal prompt", "mayor goal", "goal-runner prompt", "lint this goal", "is this goal safe". (Shaping one experiment's intent routes to plan.)
 
 ## Instructions
 

--- a/skills-codex/implement/.agentops-generated.json
+++ b/skills-codex/implement/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/implement",
   "layout": "modular",
-  "source_hash": "0e5a114ae21d79513428c6ce5768048a71fe56dbc1c161a207f7c578c1eca95e",
-  "generated_hash": "5bfefe1a54cc66526656cca805e7e84cb36526d4a72d7834741c762fef40f977"
+  "source_hash": "c8054730f0c42489d77c20261b3f3ebba8b24b83cd000d03fab4e52b0c3b5a73",
+  "generated_hash": "5fbbb9f75b956e19758d304e2eb2627fdaf6c71c92359b5430f5b3d6b5330ff0"
 }

--- a/skills-codex/implement/prompt.md
+++ b/skills-codex/implement/prompt.md
@@ -1,6 +1,6 @@
 # implement
 
-Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "build this plan", "run the experiment".
+Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "implement this bead", "run the experiment". ("execute this plan" routes to rpi, which dispatches the whole loop.)
 
 ## Instructions
 

--- a/skills-codex/reality-check/.agentops-generated.json
+++ b/skills-codex/reality-check/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/reality-check",
   "layout": "modular",
-  "source_hash": "a2d7e5ab9bf7da978fdef17f19a5e7dd28fed28b5d3a1513ef92b5042e4068cd",
-  "generated_hash": "a65522fa3b24fca1f367a883f2eb904a2606a4f2a21ee688b1b6c106d7efefb2"
+  "source_hash": "d79b843f8f6cc71d3fbe08b8ba6db458c9d886763750a38b2bc29fa8a505fc56",
+  "generated_hash": "2efce800c15a5c024a58cfe9dc1bb33c41dbaac9e0840f0661dbc00dd68153a5"
 }

--- a/skills-codex/reality-check/prompt.md
+++ b/skills-codex/reality-check/prompt.md
@@ -1,6 +1,6 @@
 # reality-check
 
-Compare a claimed state with observable repository evidence and report concrete gaps. Triggers: "reality check", "what is actually done", "compare claim to repo".
+Compare a claimed state with observable repository evidence and report concrete gaps. Requires a claim or expected state to test. Triggers: "reality check", "is this claim actually done", "compare claim to repo".
 
 ## Instructions
 

--- a/skills-codex/research/.agentops-generated.json
+++ b/skills-codex/research/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/research",
   "layout": "modular",
-  "source_hash": "0d74ded7960b70ace4db089b49b78126c05572d808e1b640a330614545ffce13",
-  "generated_hash": "37be6a0296ae07b6e62ef6fdba2115651d5bdd66881b33442afc10249a77d672"
+  "source_hash": "801e2f77a762e424d24608de9b37d671888e33c340b5bb18d5a620a395f2c36c",
+  "generated_hash": "228a40a29d5c2e43cff2235713a94842af4de7f9ebd2547e8de01607ffbd3c23"
 }

--- a/skills-codex/research/prompt.md
+++ b/skills-codex/research/prompt.md
@@ -1,6 +1,6 @@
 # research
 
-Answer a bounded question with current cited evidence. Triggers: "research", "investigate", "find evidence".
+Answer a bounded question with current cited evidence. Triggers: "research", "investigate this question", "find evidence". (Investigating a repository routes to codebase-recon.)
 
 ## Instructions
 

--- a/skills-codex/reverse-engineer/.agentops-generated.json
+++ b/skills-codex/reverse-engineer/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/reverse-engineer",
   "layout": "modular",
-  "source_hash": "8b308ebdba1e4e45a0987adf15b25ae69f03553a971f75d144885f263326f3c5",
+  "source_hash": "d9ca7efb322681204dbd09f31ecbd6c3bd5a1e1ab142344297f89dff8812a3e2",
   "generated_hash": "22eb63b54f3a1b67829dbdb057990abeb03dd03bab3ba9d62c00484edcd3c491"
 }

--- a/skills-codex/shared/.agentops-generated.json
+++ b/skills-codex/shared/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/shared",
   "layout": "modular",
-  "source_hash": "22d81954843dff1019e74cb47ff9f6ec6af3a6cb0fe91daa083da7fe19a4c14f",
-  "generated_hash": "748ffbe5ac32af1bea316461195ea73122a5f2510b10ac2679043b4d8a106ec3"
+  "source_hash": "8a7bb52408d7def6f9360feeef8b1d01a75cde0df3a3f1da869efb040d84dd92",
+  "generated_hash": "340b5e356593682d0abe103e101d62649b8c7fa35ce18566c30ba9c2e2886895"
 }

--- a/skills-codex/shared/prompt.md
+++ b/skills-codex/shared/prompt.md
@@ -1,6 +1,6 @@
 # shared
 
-Shared runtime and evidence references loaded only by a consuming skill. Triggers: internal shared contracts.
+Shared runtime and evidence references loaded only by a consuming skill. Triggers: none — internal library, not user-routable.
 
 ## Instructions
 

--- a/skills-codex/skill-builder/.agentops-generated.json
+++ b/skills-codex/skill-builder/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/skill-builder",
   "layout": "modular",
-  "source_hash": "7ccbbe127470335d424b1ceb01bbe9cb16faf77cbf5e31f6215d31ce9a3dc39b",
+  "source_hash": "775e73f3ebe87960a245790645cb2ba9083f18e0c8d0ee60569e6b747529b830",
   "generated_hash": "9ab3978eca5991203690b4c5ae36c75b12e2d860002d8ccff5e4ceb5cdfdc6c5"
 }

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -75,14 +75,14 @@
 | `reality-check` | judgment | `keep_strategy` | - | `compare_claim_to_evidence` | `write_advisory_gap_report` |
 | `refactor` | execution | `keep_specialist` | - | `refactor` | `modify_source_files` |
 | `research` | execution | `keep_specialist` | - | `research` | `write_research_report` |
-| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `execute_authorized_binary`, `write_teardown_artifacts` |
+| `reverse-engineer` | execution | `keep_specialist` | - | `reverse_engineer` | `clone_upstream_repo`, `authorized_binary_execution`, `write_teardown_artifacts` |
 | `rpi` | meta | `keep` | `plan`, `implement`, `validate` | `orchestrate_once`, `report` | `dispatch_core_phases` |
 | `sbh` | execution | `keep_specialist` | - | `sbh` | `delete_reclaimable_files`, `release_disk_ballast`, `modify_host_storage_config` |
 | `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
 | `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
-| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `writes_skill_source`, `write_build_report`, `regenerates_skill_projections`, `optional_skill_projection_repair` |
+| `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `write_skill_source`, `write_build_report`, `regenerate_skill_projections`, `repair_skill_projections` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -441,7 +441,7 @@
         }
       ],
       "dependencies": [],
-      "description": "Compile or lint a persistent Mayor-style goal that ratchets a bead graph through bounded RPI experiments toward one larger outcome. Triggers: \"craft a goal prompt\", \"turn this into a goal\", \"create a bounded goal\", \"lint this goal\", \"is this goal safe\".",
+      "description": "Compile or lint a persistent Mayor-style goal prompt that ratchets a bead graph through bounded RPI experiments toward one larger outcome. Triggers: \"craft a goal prompt\", \"mayor goal\", \"goal-runner prompt\", \"lint this goal\", \"is this goal safe\". (Shaping one experiment's intent routes to plan.)",
       "disposition": "keep_specialist",
       "effects": [],
       "graph_root": false,
@@ -667,7 +667,7 @@
         }
       ],
       "dependencies": [],
-      "description": "Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: \"implement\", \"build this plan\", \"run the experiment\".",
+      "description": "Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: \"implement\", \"implement this bead\", \"run the experiment\". (\"execute this plan\" routes to rpi, which dispatches the whole loop.)",
       "disposition": "keep",
       "effects": [
         "modify_declared_subject",
@@ -1039,7 +1039,7 @@
         }
       ],
       "dependencies": [],
-      "description": "Compare a claimed state with observable repository evidence and report concrete gaps. Triggers: \"reality check\", \"what is actually done\", \"compare claim to repo\".",
+      "description": "Compare a claimed state with observable repository evidence and report concrete gaps. Requires a claim or expected state to test. Triggers: \"reality check\", \"is this claim actually done\", \"compare claim to repo\".",
       "disposition": "keep_strategy",
       "effects": [
         "write_advisory_gap_report"
@@ -1100,7 +1100,7 @@
       ],
       "context_rel": [],
       "dependencies": [],
-      "description": "Answer a bounded question with current cited evidence. Triggers: \"research\", \"investigate\", \"find evidence\".",
+      "description": "Answer a bounded question with current cited evidence. Triggers: \"research\", \"investigate this question\", \"find evidence\". (Investigating a repository routes to codebase-recon.)",
       "disposition": "keep_specialist",
       "effects": [
         "write_research_report"
@@ -1132,7 +1132,7 @@
       "disposition": "keep_specialist",
       "effects": [
         "clone_upstream_repo",
-        "execute_authorized_binary",
+        "authorized_binary_execution",
         "write_teardown_artifacts"
       ],
       "graph_root": false,
@@ -1337,7 +1337,7 @@
       "consumes": [],
       "context_rel": [],
       "dependencies": [],
-      "description": "Shared runtime and evidence references loaded only by a consuming skill. Triggers: internal shared contracts.",
+      "description": "Shared runtime and evidence references loaded only by a consuming skill. Triggers: none \u2014 internal library, not user-routable.",
       "disposition": "keep_specialist",
       "effects": [],
       "graph_root": false,
@@ -1367,10 +1367,10 @@
       "description": "Create a metadata-complete AgentOps skill source package, regenerate its derived projections, and check or repair structural hygiene in skill packages. Triggers: \"create a skill\", \"scaffold skill\", \"absorb external skill\", \"new skill\", \"heal skill\", \"repair skill hygiene\", \"audit skill structure\", \"check skill package\".",
       "disposition": "keep_specialist",
       "effects": [
-        "writes_skill_source",
+        "write_skill_source",
         "write_build_report",
-        "regenerates_skill_projections",
-        "optional_skill_projection_repair"
+        "regenerate_skill_projections",
+        "repair_skill_projections"
       ],
       "graph_root": false,
       "hexagonal_role": "supporting",

--- a/skills/craft-goal/SKILL.md
+++ b/skills/craft-goal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: craft-goal
-description: 'Compile or lint a persistent Mayor-style goal that ratchets a bead graph through bounded RPI experiments toward one larger outcome. Triggers: "craft a goal prompt", "turn this into a goal", "create a bounded goal", "lint this goal", "is this goal safe".'
+description: 'Compile or lint a persistent Mayor-style goal prompt that ratchets a bead graph through bounded RPI experiments toward one larger outcome. Triggers: "craft a goal prompt", "mayor goal", "goal-runner prompt", "lint this goal", "is this goal safe". (Shaping one experiment''s intent routes to plan.)'
 practices:
 - lean-startup
 - design-by-contract

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: 'Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "build this plan", "run the experiment".'
+description: 'Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "implement this bead", "run the experiment". ("execute this plan" routes to rpi, which dispatches the whole loop.)'
 practices:
 - tdd
 - refactoring

--- a/skills/reality-check/SKILL.md
+++ b/skills/reality-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reality-check
-description: 'Compare a claimed state with observable repository evidence and report concrete gaps. Triggers: "reality check", "what is actually done", "compare claim to repo".'
+description: 'Compare a claimed state with observable repository evidence and report concrete gaps. Requires a claim or expected state to test. Triggers: "reality check", "is this claim actually done", "compare claim to repo".'
 practices: [design-by-contract, evidence-based-engineering]
 hexagonal_role: domain
 consumes: [claim, repository-evidence]

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: 'Answer a bounded question with current cited evidence. Triggers: "research", "investigate", "find evidence".'
+description: 'Answer a bounded question with current cited evidence. Triggers: "research", "investigate this question", "find evidence". (Investigating a repository routes to codebase-recon.)'
 practices:
 - pragmatic-programmer
 - ddd-bounded-context

--- a/skills/reverse-engineer/SKILL.md
+++ b/skills/reverse-engineer/SKILL.md
@@ -22,7 +22,7 @@ context:
 metadata:
   dependencies: []
   capabilities: [reverse_engineer]
-  effects: [clone_upstream_repo, execute_authorized_binary, write_teardown_artifacts]
+  effects: [clone_upstream_repo, authorized_binary_execution, write_teardown_artifacts]
   canonical_status: canonical
   disposition: keep_specialist
   tier: execution

--- a/skills/shared/SKILL.md
+++ b/skills/shared/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shared
-description: 'Shared runtime and evidence references loaded only by a consuming skill. Triggers: internal shared contracts.'
+description: 'Shared runtime and evidence references loaded only by a consuming skill. Triggers: none — internal library, not user-routable.'
 practices: [design-by-contract, pragmatic-programmer]
 hexagonal_role: domain
 consumes: []

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -21,7 +21,7 @@ context:
   intel_scope: topic
 metadata:
   capabilities: [skill_builder, heal_skill]
-  effects: [writes_skill_source, write_build_report, regenerates_skill_projections, optional_skill_projection_repair]
+  effects: [write_skill_source, write_build_report, regenerate_skill_projections, repair_skill_projections]
   canonical_status: canonical
   disposition: keep_specialist
   tier: meta


### PR DESCRIPTION
## Summary

Final wave of the skill-overhaul reboot (`age-skill-overhaul-reboot-sjv7v.9`), run after #998–#1005 merged.

**Closing corpus-level review** (the one check no per-wave review could do — trigger routing, effects vocabulary, authority coherence, reachability across all 49 skills): seven findings, all applied.

- Trigger separations: rpi↔implement ("execute this plan" = the loop; "implement this bead" = the phase), plan↔craft-goal (Mayor/goal-runner distinction made decisive), status↔reality-check (reality-check now requires a claim to test), research↔codebase-recon (bare "investigate" narrowed).
- Effects vocabulary: imperative `write_*`/`regenerate_*` forms normalized (skill-builder), `authorized_` prefix made consistent (reverse-engineer).
- `shared` marked explicitly non-routable.
- Authority coherence verified clean: only validate persists verdicts, only rpi dispatches the loop, no specialist starts RPI.

**Deterministic evidence**: regen byte-idempotent (two runs, zero drift); strict frontmatter 49/49 zero warnings; scenario-linkage PASS; description budgets green; all skill validators pass.

**Plan closeout**: reboot plan marked complete with a completion record (8 PRs, per-wave ledgers); structural beads .10/.11/.12 remain open as explicitly deferred tracked work.

Full report: `docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/w8.md`

Tracker: `age-skill-overhaul-reboot-sjv7v.9`