### PR TITLE
Structural: goals→fitness rename with compatibility alias; shared retired to a declared contract owner

### DIFF
--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -2,7 +2,7 @@
 
 # Skill Router
 
-49 live skills. Metadata is the sole inventory and graph source.
+50 live skills. Metadata is the sole inventory and graph source.
 
 ## keep
 
@@ -10,7 +10,7 @@
 
 ## keep_off_path
 
-`learn`
+`goals`, `learn`
 
 ## keep_strategy
 
@@ -22,7 +22,7 @@
 
 ## keep_specialist
 
-`account-rotation`, `bootstrap`, `cass`, `cc-hooks`, `codebase-recon`, `converter`, `craft-goal`, `dcg`, `doc`, `domain`, `goals`, `handoff`, `ms`, `operationalize`, `pattern-mining`, `product`, `rch`, `refactor`, `research`, `reverse-engineer`, `sbh`, `scaffold`, `scope`, `security`, `shared`, `skill-builder`, `standards`, `status`, `test`, `toil-mining`, `workflow-builder`
+`account-rotation`, `bootstrap`, `cass`, `cc-hooks`, `codebase-recon`, `converter`, `craft-goal`, `dcg`, `doc`, `domain`, `fitness`, `handoff`, `ms`, `operationalize`, `pattern-mining`, `product`, `rch`, `refactor`, `research`, `reverse-engineer`, `sbh`, `scaffold`, `scope`, `security`, `shared`, `skill-builder`, `standards`, `status`, `test`, `toil-mining`, `workflow-builder`
 
 ## Complete inventory
 
@@ -44,7 +44,8 @@
 | `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
 | `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
-| `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
+| `fitness` | product | `keep_specialist` | - | `fitness` | `write_goal_snapshot`, `write_rendered_spec` |
+| `goals` | product | `keep_off_path` | - | - | - |
 | `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state`, `read_clock` |
 | `idea-genie` | execution | `keep_strategy` | - | `generate_evidenced_options`, `dueling_idea_genies` | `write_idea_portfolio` |
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |

--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -10,7 +10,7 @@
 
 ## keep_off_path
 
-`goals`, `learn`
+`goals`, `learn`, `shared`
 
 ## keep_strategy
 
@@ -22,7 +22,7 @@
 
 ## keep_specialist
 
-`account-rotation`, `bootstrap`, `cass`, `cc-hooks`, `codebase-recon`, `converter`, `craft-goal`, `dcg`, `doc`, `domain`, `fitness`, `handoff`, `ms`, `operationalize`, `pattern-mining`, `product`, `rch`, `refactor`, `research`, `reverse-engineer`, `sbh`, `scaffold`, `scope`, `security`, `shared`, `skill-builder`, `standards`, `status`, `test`, `toil-mining`, `workflow-builder`
+`account-rotation`, `bootstrap`, `cass`, `cc-hooks`, `codebase-recon`, `converter`, `craft-goal`, `dcg`, `doc`, `domain`, `fitness`, `handoff`, `ms`, `operationalize`, `pattern-mining`, `product`, `rch`, `refactor`, `research`, `reverse-engineer`, `sbh`, `scaffold`, `scope`, `security`, `skill-builder`, `standards`, `status`, `test`, `toil-mining`, `workflow-builder`
 
 ## Complete inventory
 
@@ -68,7 +68,7 @@
 | `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
 | `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
-| `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
+| `shared` | library | `keep_off_path` | - | - | - |
 | `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `write_skill_source`, `write_build_report`, `regenerate_skill_projections`, `repair_skill_projections` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -2,7 +2,7 @@
 
 # Skill Router
 
-49 live skills. Metadata is the sole inventory and graph source.
+50 live skills. Metadata is the sole inventory and graph source.
 
 ## keep
 
@@ -10,7 +10,7 @@
 
 ## keep_off_path
 
-`learn`
+`goals`, `learn`
 
 ## keep_strategy
 
@@ -22,7 +22,7 @@
 
 ## keep_specialist
 
-`account-rotation`, `bootstrap`, `cass`, `cc-hooks`, `codebase-recon`, `converter`, `craft-goal`, `dcg`, `doc`, `domain`, `goals`, `handoff`, `ms`, `operationalize`, `pattern-mining`, `product`, `rch`, `refactor`, `research`, `reverse-engineer`, `sbh`, `scaffold`, `scope`, `security`, `shared`, `skill-builder`, `standards`, `status`, `test`, `toil-mining`, `workflow-builder`
+`account-rotation`, `bootstrap`, `cass`, `cc-hooks`, `codebase-recon`, `converter`, `craft-goal`, `dcg`, `doc`, `domain`, `fitness`, `handoff`, `ms`, `operationalize`, `pattern-mining`, `product`, `rch`, `refactor`, `research`, `reverse-engineer`, `sbh`, `scaffold`, `scope`, `security`, `shared`, `skill-builder`, `standards`, `status`, `test`, `toil-mining`, `workflow-builder`
 
 ## Complete inventory
 
@@ -44,7 +44,8 @@
 | `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
 | `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
-| `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
+| `fitness` | product | `keep_specialist` | - | `fitness` | `write_goal_snapshot`, `write_rendered_spec` |
+| `goals` | product | `keep_off_path` | - | - | - |
 | `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state`, `read_clock` |
 | `idea-genie` | execution | `keep_strategy` | - | `generate_evidenced_options`, `dueling_idea_genies` | `write_idea_portfolio` |
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -10,7 +10,7 @@
 
 ## keep_off_path
 
-`goals`, `learn`
+`goals`, `learn`, `shared`
 
 ## keep_strategy
 
@@ -22,7 +22,7 @@
 
 ## keep_specialist
 
-`account-rotation`, `bootstrap`, `cass`, `cc-hooks`, `codebase-recon`, `converter`, `craft-goal`, `dcg`, `doc`, `domain`, `fitness`, `handoff`, `ms`, `operationalize`, `pattern-mining`, `product`, `rch`, `refactor`, `research`, `reverse-engineer`, `sbh`, `scaffold`, `scope`, `security`, `shared`, `skill-builder`, `standards`, `status`, `test`, `toil-mining`, `workflow-builder`
+`account-rotation`, `bootstrap`, `cass`, `cc-hooks`, `codebase-recon`, `converter`, `craft-goal`, `dcg`, `doc`, `domain`, `fitness`, `handoff`, `ms`, `operationalize`, `pattern-mining`, `product`, `rch`, `refactor`, `research`, `reverse-engineer`, `sbh`, `scaffold`, `scope`, `security`, `skill-builder`, `standards`, `status`, `test`, `toil-mining`, `workflow-builder`
 
 ## Complete inventory
 
@@ -68,7 +68,7 @@
 | `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
 | `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
-| `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
+| `shared` | library | `keep_off_path` | - | - | - |
 | `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `write_skill_source`, `write_build_report`, `regenerate_skill_projections`, `repair_skill_projections` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -29,7 +29,8 @@
 | `codebase-recon` | `customer-of` | `validate` |
 | `codex-exec` | `supplier-to` | `validate` |
 | `craft-goal` | `supplier-to` | `plan` |
-| `goals` | `shared-kernel` | `standards` |
+| `fitness` | `shared-kernel` | `standards` |
+| `goals` | `alias-of` | `fitness` |
 | `idea-genie` | `customer-of` | `research` |
 | `idea-genie` | `supplier-to` | `plan` |
 | `implement` | `customer-of` | `plan` |
@@ -91,7 +92,7 @@
 | `doc` | consumes | `repo-context` |
 | `doc` | produces | `documentation` |
 | `domain` | produces | `stdout` |
-| `goals` | produces | `goal-measurement-report` |
+| `fitness` | produces | `goal-measurement-report` |
 | `handoff` | produces | `.agents/handoff/*.md` |
 | `idea-genie` | consumes | `repo-context` |
 | `idea-genie` | consumes | `task-question` |

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -71,10 +71,9 @@
 | `agy-native` | produces | `agy-run-evidence` |
 | `automation-shape-routing` | consumes | `task-intent` |
 | `automation-shape-routing` | produces | `automation-shape-verdict` |
-| `bootstrap` | consumes | `goals` |
+| `bootstrap` | consumes | `fitness` |
 | `bootstrap` | consumes | `product` |
 | `bootstrap` | consumes | `doc` |
-| `bootstrap` | consumes | `shared` |
 | `codebase-recon` | consumes | `repo-context` |
 | `codebase-recon` | consumes | `existing-docs` |
 | `codebase-recon` | produces | `codebase-recon.v1` |
@@ -133,7 +132,6 @@
 | `security` | produces | `security-gate-summary.json` |
 | `security` | produces | `suite-summary.json` |
 | `security` | produces | `redteam-results.json` |
-| `shared` | produces | `reference-documents` |
 | `skill-builder` | produces | `skill-source-package` |
 | `skill-builder` | produces | `skill-hygiene-report` |
 | `standards` | produces | `stdout` |

--- a/docs/contracts/runtime-neutrality.md
+++ b/docs/contracts/runtime-neutrality.md
@@ -1,0 +1,31 @@
+# Runtime Neutrality Contract
+
+Status: active · Owner: this document (moved from the retired `shared` skill,
+2026-07-29, bead `age-skill-overhaul-reboot-sjv7v.11`)
+
+The rules below governed any reference context a consuming skill loads. They
+are corpus doctrine, not skill behavior, so they live here — a declared
+contract owner — instead of inside a skill that bundles nothing.
+
+## The contract
+
+- Default to the current agent and local shell.
+- Use a runtime-native fresh context only when the caller or consuming
+  workflow requests it.
+- Treat runtime and factory state as adapter evidence; never translate it
+  into core Plan, Candidate, RPI, or verdict state.
+- Missing optional tools degrade only the optional capability that needs
+  them.
+- Source skill contracts and executable behavior outrank shared prose.
+
+Shared context is context, not permission: reading a reference never
+authorizes starting a runtime, tracker, substrate, network call, or external
+mutation. Authority comes from the caller or the consuming skill's contract.
+
+Named failure mode — **reference promotion**: shared prose quietly outranking
+a source skill contract because it was read more recently. Just-in-time
+loading is the counter-discipline: a reference read only when needed cannot
+silently become a dependency, while anything loaded by default eventually
+gets treated as one.
+
+The core loop has no hard dependency on this document.

--- a/docs/contracts/runtime-neutrality.md
+++ b/docs/contracts/runtime-neutrality.md
@@ -3,9 +3,10 @@
 Status: active · Owner: this document (moved from the retired `shared` skill,
 2026-07-29, bead `age-skill-overhaul-reboot-sjv7v.11`)
 
-The rules below governed any reference context a consuming skill loads. They
-are corpus doctrine, not skill behavior, so they live here — a declared
-contract owner — instead of inside a skill that bundles nothing.
+The rules below govern any shared reference a consuming skill loads — the
+same scope the `shared` skill declared. They are corpus doctrine, not skill
+behavior, so they live here — a declared contract owner — instead of inside
+a skill that bundles nothing.
 
 ## The contract
 
@@ -18,7 +19,7 @@ contract owner — instead of inside a skill that bundles nothing.
   them.
 - Source skill contracts and executable behavior outrank shared prose.
 
-Shared context is context, not permission: reading a reference never
+Shared context is context, not permission: reading a shared reference never
 authorizes starting a runtime, tracker, substrate, network call, or external
 mutation. Authority comes from the caller or the consuming skill's contract.
 

--- a/docs/contracts/scenario-test-linkage.md
+++ b/docs/contracts/scenario-test-linkage.md
@@ -97,7 +97,7 @@ gated on changes to `skills/**`, `**/*.sh`, or `.github/**`.
 | Feature | Covering test |
 |---|---|
 | `skills/rpi/references/rpi.feature` | `tests/e2e/rpi-phased-domain.sh` |
-| `skills/goals/references/goals.feature` | `tests/e2e/goals-measure-scenarios.sh`, `goals-steer-auto.sh`, `goals-trace-chain.sh` |
+| ~~`skills/goals/references/goals.feature`~~ (removed with the feature file; the skill is now `fitness`, 2026-07-29) | `tests/e2e/goals-measure-scenarios.sh`, `goals-trace-chain.sh` still execute against the `ao goals` CLI |
 | ~~`skills/scenario/references/scenario.feature`~~ (removed: `scenario` folded into `eval-outcomes`, 2026-06-12) | `tests/e2e/goals-scenarios-link.sh` |
 
 The remaining 68 files are allowlisted in `scripts/.scenario-linkage-allow` with

--- a/docs/contracts/scenario-test-linkage.md
+++ b/docs/contracts/scenario-test-linkage.md
@@ -97,7 +97,7 @@ gated on changes to `skills/**`, `**/*.sh`, or `.github/**`.
 | Feature | Covering test |
 |---|---|
 | `skills/rpi/references/rpi.feature` | `tests/e2e/rpi-phased-domain.sh` |
-| ~~`skills/goals/references/goals.feature`~~ (removed with the feature file; the skill is now `fitness`, 2026-07-29) | `tests/e2e/goals-measure-scenarios.sh`, `goals-trace-chain.sh` still execute against the `ao goals` CLI |
+| ~~`skills/goals/references/goals.feature`~~ (stale row: the feature file was already absent from the tree before 2026-07-29; the skill is now `fitness`) | `tests/e2e/goals-measure-scenarios.sh`, `goals-trace-chain.sh` still execute against the `ao goals` CLI |
 | ~~`skills/scenario/references/scenario.feature`~~ (removed: `scenario` folded into `eval-outcomes`, 2026-06-12) | `tests/e2e/goals-scenarios-link.sh` |
 
 The remaining 68 files are allowlisted in `scripts/.scenario-linkage-allow` with

--- a/docs/contracts/skill-ports-and-adapters.md
+++ b/docs/contracts/skill-ports-and-adapters.md
@@ -130,8 +130,10 @@ start a new RPI.
 
 `shared` is not a durable miscellaneous seam owner. Runtime-neutral contracts
 belong under declared contract owners, while adapter mechanics remain with
-their adapters. The current empty `shared` skill is retired only after its
-hidden prose and generated consumers move safely.
+their adapters. Executed 2026-07-29: the runtime-neutrality contract moved to
+`docs/contracts/runtime-neutrality.md`, its last consumer edge was migrated,
+and the `shared` skill is a non-routable tombstone pending the observed-zero
+deletion window.
 
 ## Execution shape is orthogonal
 

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -46,6 +46,7 @@ Dated plans, audits, releases, and archive material are historical evidence, not
 - [Generated skill projections](contracts/registry-as-derived.md)
 - [Release Notes Contract](contracts/release-notes.md)
 - [Retrieval Comparison Contract](contracts/retrieval-comparison.md)
+- [Runtime Neutrality Contract](contracts/runtime-neutrality.md)
 - [Scenario → Test Linkage Contract](contracts/scenario-test-linkage.md)
 - [Scope Escape Report Template](contracts/scope-escape-report.md)
 - [Skill system architecture](contracts/skill-ports-and-adapters.md)

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -62,7 +62,7 @@
 | `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
 | `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
-| `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
+| `shared` | library | `keep_off_path` | - | - | - |
 | `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `write_skill_source`, `write_build_report`, `regenerate_skill_projections`, `repair_skill_projections` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -4,7 +4,7 @@
 
 ## domain
 
-`council`, `domain`, `goals`, `idea-genie`, `plan`, `postmortem`, `premortem`, `product`, `reality-check`, `rpi`, `shared`
+`council`, `domain`, `fitness`, `goals`, `idea-genie`, `plan`, `postmortem`, `premortem`, `product`, `reality-check`, `rpi`, `shared`
 
 ## driven-adapter
 
@@ -38,7 +38,8 @@
 | `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
 | `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
-| `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
+| `fitness` | product | `keep_specialist` | - | `fitness` | `write_goal_snapshot`, `write_rendered_spec` |
+| `goals` | product | `keep_off_path` | - | - | - |
 | `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state`, `read_clock` |
 | `idea-genie` | execution | `keep_strategy` | - | `generate_evidenced_options`, `dueling_idea_genies` | `write_idea_portfolio` |
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |

--- a/docs/reference/agentops-skill-graph.md
+++ b/docs/reference/agentops-skill-graph.md
@@ -20,6 +20,7 @@ graph LR
   dcg["dcg"]
   doc["doc"]
   domain["domain"]
+  fitness["fitness"]
   goals["goals"]
   handoff["handoff"]
   idea_genie["idea-genie"]

--- a/images/claude/manifest.json
+++ b/images/claude/manifest.json
@@ -1,7 +1,7 @@
 {
   "image": "claude",
   "schema_version": "skill-image.v1",
-  "skill_count": 49,
+  "skill_count": 50,
   "skills": [
     {
       "disposition": "keep_specialist",
@@ -85,6 +85,11 @@
     },
     {
       "disposition": "keep_specialist",
+      "path": "skills/fitness/",
+      "slug": "fitness"
+    },
+    {
+      "disposition": "keep_off_path",
       "path": "skills/goals/",
       "slug": "goals"
     },

--- a/images/claude/manifest.json
+++ b/images/claude/manifest.json
@@ -204,7 +204,7 @@
       "slug": "security"
     },
     {
-      "disposition": "keep_specialist",
+      "disposition": "keep_off_path",
       "path": "skills/shared/",
       "slug": "shared"
     },

--- a/images/codex/manifest.json
+++ b/images/codex/manifest.json
@@ -244,7 +244,7 @@
       "twin_path": "skills-codex/security/"
     },
     {
-      "disposition": "keep_specialist",
+      "disposition": "keep_off_path",
       "slug": "shared",
       "source_path": "skills/shared/",
       "twin_path": "skills-codex/shared/"

--- a/images/codex/manifest.json
+++ b/images/codex/manifest.json
@@ -1,7 +1,7 @@
 {
   "image": "codex",
   "schema_version": "skill-image.v1",
-  "skill_count": 49,
+  "skill_count": 50,
   "skills": [
     {
       "disposition": "keep_specialist",
@@ -101,6 +101,12 @@
     },
     {
       "disposition": "keep_specialist",
+      "slug": "fitness",
+      "source_path": "skills/fitness/",
+      "twin_path": "skills-codex/fitness/"
+    },
+    {
+      "disposition": "keep_off_path",
       "slug": "goals",
       "source_path": "skills/goals/",
       "twin_path": "skills-codex/goals/"

--- a/images/gemini/plugin.json
+++ b/images/gemini/plugin.json
@@ -1,6 +1,6 @@
 {
   "agents": "./agents",
-  "description": "AgentOps 49-skill metadata-derived bundle for Google Antigravity and Gemini.",
+  "description": "AgentOps 50-skill metadata-derived bundle for Google Antigravity and Gemini.",
   "hooks": "./hooks/hooks.json",
   "mcpServers": {
     "agent-mail": {

--- a/images/gemini/skills/bootstrap/SKILL.md
+++ b/images/gemini/skills/bootstrap/SKILL.md
@@ -6,10 +6,9 @@ practices:
 - code-complete
 hexagonal_role: driving-adapter
 consumes:
-- goals
+- fitness
 - product
 - doc
-- shared
 produces: []
 context_rel: []
 skill_api_version: 1
@@ -83,7 +82,7 @@ failed writes, and validation observations. Do not include a next action.
 
 ## References
 
-- [Goals](../goals/SKILL.md)
+- [Fitness](../fitness/SKILL.md)
 - [Product](../product/SKILL.md)
 - [Documentation](../doc/SKILL.md)
 - [Examples](references/examples.md)

--- a/images/gemini/skills/fitness/SKILL.md
+++ b/images/gemini/skills/fitness/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: fitness
+description: 'Measure declared project fitness goals without recommending or applying work. Triggers: "fitness", "check project fitness", "measure goals".'
+practices:
+- dora-metrics
+- lean-startup
+hexagonal_role: domain
+consumes: []
+produces:
+- goal-measurement-report
+context_rel:
+- kind: shared-kernel
+  with: standards
+skill_api_version: 1
+context:
+  window: fork
+  intent:
+    mode: task
+  intel_scope: topic
+metadata:
+  capabilities: [fitness]
+  effects: [write_goal_snapshot, write_rendered_spec]
+  canonical_status: canonical
+  disposition: keep_specialist
+  tier: product
+  dependencies: []
+output_contract: read-only goal measurement report
+---
+# Fitness — read-only goal measurement
+
+Inspect the active goals document and run only the caller-selected measurement,
+validation, drift, history, export, or meta-goal command.
+
+Renamed from `goals` (2026-07-29): the semantic skill is `fitness`; the
+`ao goals` CLI command family is a separate product surface and keeps its
+name. A thin `goals` compatibility alias resolves to this skill.
+
+Measurement stays trustworthy only because it cannot mutate what it measures;
+the moment a fitness report edits a goal, the next report measures the editor,
+not the project.
+
+Named failure mode — **advice creep**: a measurement report that ends with
+"you should…" has silently become work selection.
+
+Anti-pattern: padding the report with recommendations to look helpful.
+Corrective: return the numbers, the evidence gaps, and checked/not-checked
+scope, and let the caller decide.
+
+## Boundary
+
+- Prefer `GOALS.md` when both Markdown and legacy YAML exist.
+- Preserve stable directive and gate identities in the report.
+- Every measured gate must name its executable check and observed outcome.
+- Do not add, remove, prioritize, recommend, apply, prune, migrate, or otherwise
+  mutate goals.
+- Do not translate a fitness gap into work selection or a next action.
+- No subcommand edits the goals source through its own logic. `measure`,
+  `drift`, and `export` persist a best-effort JSON snapshot under the fixed
+  derived path `.agents/ao/goals/baselines/`. `render --out <file>` writes a
+  Gherkin spec to whatever path the caller names — the CLI does not constrain
+  it, so never point `--out` at the goals source or any non-derived file.
+
+## Commands
+
+All eight subcommands read the goals source without mutating it. The snapshot
+write (fixed derived path) and the `render --out` write (caller-chosen path,
+caller's responsibility) are the only side effects.
+
+```bash
+ao goals measure --json
+ao goals validate --json
+ao goals drift
+ao goals history
+ao goals export
+ao goals meta --json
+ao goals scenarios
+ao goals render          # append --out <file> to write the spec instead of stdout
+```
+
+Run the requested command once. Return the command, exit code, goal-level
+results, aggregate measurement, missing evidence, and checked/not-checked scope.
+Then stop.

--- a/images/gemini/skills/goals/SKILL.md
+++ b/images/gemini/skills/goals/SKILL.md
@@ -1,78 +1,34 @@
 ---
 name: goals
-description: 'Measure declared project fitness goals without recommending or applying work. Triggers: "measure goals", "check project fitness".'
+description: 'Compatibility alias — renamed to fitness. Use fitness to measure declared project fitness goals. Triggers: "goals" (deprecated).'
 practices:
 - dora-metrics
-- lean-startup
 hexagonal_role: domain
 consumes: []
-produces:
-- goal-measurement-report
+produces: []
 context_rel:
-- kind: shared-kernel
-  with: standards
+- kind: alias-of
+  with: fitness
 skill_api_version: 1
-context:
-  window: fork
-  intent:
-    mode: task
-  intel_scope: topic
+user-invocable: true
 metadata:
-  capabilities: [goals]
-  effects: [write_goal_snapshot, write_rendered_spec]
+  capabilities: []
+  effects: []
   canonical_status: canonical
-  disposition: keep_specialist
+  disposition: keep_off_path
   tier: product
   dependencies: []
-output_contract: read-only goal measurement report
+output_contract: none — delegates to fitness
 ---
-# Goals — read-only fitness measurement
+# Goals — compatibility alias for fitness
 
-Inspect the active goals document and run only the caller-selected measurement,
-validation, drift, history, export, or meta-goal command.
+This skill was renamed to `fitness` on 2026-07-29. Everything it did lives
+there unchanged; the `ao goals` CLI command family keeps its name.
 
-Measurement stays trustworthy only because it cannot mutate what it measures;
-the moment a fitness report edits a goal, the next report measures the editor,
-not the project.
+When invoked, apply `skills/fitness/SKILL.md` exactly as written — this
+alias adds no behavior, grants no authority, and produces nothing of its
+own. It exists so existing references and habits keep resolving, and it is
+deliberately not advertised as a destination.
 
-Named failure mode — **advice creep**: a measurement report that ends with
-"you should…" has silently become work selection.
-
-Anti-pattern: padding the report with recommendations to look helpful.
-Corrective: return the numbers, the evidence gaps, and checked/not-checked
-scope, and let the caller decide.
-
-## Boundary
-
-- Prefer `GOALS.md` when both Markdown and legacy YAML exist.
-- Preserve stable directive and gate identities in the report.
-- Every measured gate must name its executable check and observed outcome.
-- Do not add, remove, prioritize, recommend, apply, prune, migrate, or otherwise
-  mutate goals.
-- Do not translate a fitness gap into work selection or a next action.
-- No subcommand edits the goals source through its own logic. `measure`,
-  `drift`, and `export` persist a best-effort JSON snapshot under the fixed
-  derived path `.agents/ao/goals/baselines/`. `render --out <file>` writes a
-  Gherkin spec to whatever path the caller names — the CLI does not constrain
-  it, so never point `--out` at the goals source or any non-derived file.
-
-## Commands
-
-All eight subcommands read the goals source without mutating it. The snapshot
-write (fixed derived path) and the `render --out` write (caller-chosen path,
-caller's responsibility) are the only side effects.
-
-```bash
-ao goals measure --json
-ao goals validate --json
-ao goals drift
-ao goals history
-ao goals export
-ao goals meta --json
-ao goals scenarios
-ao goals render          # append --out <file> to write the spec instead of stdout
-```
-
-Run the requested command once. Return the command, exit code, goal-level
-results, aggregate measurement, missing evidence, and checked/not-checked scope.
-Then stop.
+Physical deletion follows the observed-zero policy: this alias is removed
+only after a declared observation window shows no remaining use.

--- a/images/gemini/skills/shared/SKILL.md
+++ b/images/gemini/skills/shared/SKILL.md
@@ -1,48 +1,31 @@
 ---
 name: shared
-description: 'Shared runtime and evidence references loaded only by a consuming skill. Triggers: none — internal library, not user-routable.'
-practices: [design-by-contract, pragmatic-programmer]
+description: 'Retired — its runtime-neutrality contract moved to docs/contracts/runtime-neutrality.md. Triggers: none — not routable.'
+practices: [design-by-contract]
 hexagonal_role: domain
 consumes: []
-produces: [reference-documents]
+produces: []
 context_rel: []
 skill_api_version: 1
 user-invocable: false
 metadata:
   tier: library
   dependencies: []
-  capabilities: [provide_reference_context]
+  capabilities: []
   effects: []
   canonical_status: canonical
-  disposition: keep_specialist
+  disposition: keep_off_path
   internal: true
-output_contract: no reference documents are bundled at present; the contract governs any reference a consuming skill inlines
+output_contract: none — retired; see docs/contracts/runtime-neutrality.md
 ---
 
-# Shared References
+# Shared — retired
 
-This library bundles no standalone reference files today; consuming skills inline
-the runtime and evidence context they need. The contract below governs any shared
-reference a consuming skill does load: it is context, not permission to start a
-runtime, tracker, substrate, network call, or external mutation.
+Semantically retired 2026-07-29 (bead `age-skill-overhaul-reboot-sjv7v.11`).
+The runtime-neutrality contract this library carried now lives at its
+declared owner: [docs/contracts/runtime-neutrality.md](../../docs/contracts/runtime-neutrality.md).
 
-Just-in-time loading works because a reference read only when a consuming
-skill needs it cannot silently become a dependency; anything loaded by default
-eventually gets treated as one.
-
-Named failure mode — **reference promotion**: shared prose quietly outranking
-a source skill contract because it was read more recently.
-
-Anti-pattern: citing a shared file as authority for starting a tool or
-runtime. Corrective: authority comes from the caller or the consuming skill's
-contract; shared files only describe.
-
-- Default to the current agent and local shell.
-- Use a runtime-native fresh context only when the caller or consuming workflow
-  requests it.
-- Treat runtime and factory state as adapter evidence; never translate it into
-  core Plan, Candidate, RPI, or verdict state.
-- Missing optional tools degrade only the optional capability that needs them.
-- Source skill contracts and executable behavior outrank shared prose.
-
-The core loop has no hard dependency on this library.
+This skill bundles nothing, produces nothing, grants nothing, and is loaded
+by nothing. The directory remains only for the observed-zero window: physical
+deletion follows once a declared observation period shows no remaining
+references resolve here.

--- a/registry.json
+++ b/registry.json
@@ -192,11 +192,11 @@
     },
     {
       "driven_by_skills": [
-        "goals"
+        "fitness"
       ],
-      "id": "skill:goals:goals",
-      "name": "goals",
-      "path": "skills/goals/SKILL.md",
+      "id": "skill:fitness:fitness",
+      "name": "fitness",
+      "path": "skills/fitness/SKILL.md",
       "type": "skill"
     },
     {
@@ -603,7 +603,7 @@
     "hooks": 0,
     "job_types": 0,
     "knowledge_stores": 0,
-    "skills": 49,
+    "skills": 50,
     "workflows": 0
   },
   "surfaces": {
@@ -862,13 +862,24 @@
       },
       {
         "capabilities": [
-          "goals"
+          "fitness"
         ],
         "disposition": "keep_specialist",
         "effects": [
           "write_goal_snapshot",
           "write_rendered_spec"
         ],
+        "has_references": false,
+        "has_skill_md": true,
+        "name": "fitness",
+        "path": "skills/fitness/",
+        "reference_count": 0,
+        "tier": "product"
+      },
+      {
+        "capabilities": [],
+        "disposition": "keep_off_path",
+        "effects": [],
         "has_references": false,
         "has_skill_md": true,
         "name": "goals",

--- a/registry.json
+++ b/registry.json
@@ -453,15 +453,6 @@
     },
     {
       "driven_by_skills": [
-        "shared"
-      ],
-      "id": "skill:shared:provide_reference_context",
-      "name": "provide_reference_context",
-      "path": "skills/shared/SKILL.md",
-      "type": "skill"
-    },
-    {
-      "driven_by_skills": [
         "skill-builder"
       ],
       "id": "skill:skill-builder:skill_builder",
@@ -591,13 +582,13 @@
     "cli_commands": 0,
     "gates": 0,
     "reference_impls": 0,
-    "skills": 65,
-    "total": 65
+    "skills": 64,
+    "total": 64
   },
   "cli_top_level_commands": [],
   "schema_version": 3,
   "summary": {
-    "capabilities": 65,
+    "capabilities": 64,
     "cli_commands": 0,
     "eval_files": 0,
     "hooks": 0,
@@ -1233,10 +1224,8 @@
         "tier": "product"
       },
       {
-        "capabilities": [
-          "provide_reference_context"
-        ],
-        "disposition": "keep_specialist",
+        "capabilities": [],
+        "disposition": "keep_off_path",
         "effects": [],
         "has_references": false,
         "has_skill_md": true,

--- a/schemas/skill-frontmatter.v1.schema.json
+++ b/schemas/skill-frontmatter.v1.schema.json
@@ -95,7 +95,7 @@
         "properties": {
           "kind": {
             "type": "string",
-            "enum": ["shared-kernel", "customer-of", "supplier-to", "conformist-to", "acl-wraps", "separate-ways", "partnership"]
+            "enum": ["shared-kernel", "customer-of", "supplier-to", "conformist-to", "acl-wraps", "separate-ways", "partnership", "alias-of"]
           },
           "with": { "type": "string", "description": "skill slug" }
         }

--- a/schemas/skill-frontmatter.v2.schema.json
+++ b/schemas/skill-frontmatter.v2.schema.json
@@ -44,7 +44,7 @@
         "properties": {
           "kind": {
             "type": "string",
-            "enum": ["shared-kernel", "customer-of", "supplier-to", "conformist-to", "acl-wraps", "separate-ways", "partnership"]
+            "enum": ["shared-kernel", "customer-of", "supplier-to", "conformist-to", "acl-wraps", "separate-ways", "partnership", "alias-of"]
           },
           "with": {"type": "string", "description": "skill slug"}
         }

--- a/skills-codex-overrides/catalog.json
+++ b/skills-codex-overrides/catalog.json
@@ -301,6 +301,12 @@
       "treatment": "parity_only",
       "wave": "catalog-parity",
       "reason": "Auto-generated parity twin (codex-sync): skills/craft-goal is the source of truth; no durable Codex-specific divergence yet."
+    },
+    {
+      "name": "fitness",
+      "treatment": "parity_only",
+      "wave": "catalog-parity",
+      "reason": "Auto-generated parity twin (codex-sync): skills/fitness is the source of truth; no durable Codex-specific divergence yet."
     }
   ]
 }

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -2,7 +2,7 @@
   "generator": "manual-maintained",
   "source_root": "skills",
   "layout": "modular",
-  "codex_override_catalog_hash": "fae62f93c46c2111ea890e25afff256a081b6b07c6944f8f5ac2a94115943437",
+  "codex_override_catalog_hash": "d093b00a7e7880043ae4e0a0375d4f1e774f80347d5986f0eef6052cd7e37331",
   "codex_override_catalog": {
     "version": 1,
     "description": "Machine-readable Codex treatment map for the full skill catalog.",
@@ -326,6 +326,12 @@
         "treatment": "parity_only",
         "wave": "catalog-parity",
         "reason": "Auto-generated parity twin (codex-sync): skills/craft-goal is the source of truth; no durable Codex-specific divergence yet."
+      },
+      {
+        "name": "fitness",
+        "treatment": "parity_only",
+        "wave": "catalog-parity",
+        "reason": "Auto-generated parity twin (codex-sync): skills/fitness is the source of truth; no durable Codex-specific divergence yet."
       }
     ]
   },
@@ -427,10 +433,16 @@
       "generated_hash": "6180b39f53cf7cfcc2ef567f84f59416fe40e5a27c26b6b956285137d216e814"
     },
     {
+      "name": "fitness",
+      "source_skill": "skills/fitness",
+      "source_hash": "c23854f00cdaf45fdefe04265036bca0539559a247dd88bcd13eff5004dbc361",
+      "generated_hash": "d3f01847b297aaef08bf5d7fc7df1717ea0ca2e59e0407e61f702fdccc2cabae"
+    },
+    {
       "name": "goals",
       "source_skill": "skills/goals",
-      "source_hash": "050c7d539c56668a1a92e7694d6a356329859f1eac01a7b4944718444beb70f7",
-      "generated_hash": "31b0b008feedaa8953613f35acb57687845a6c60cd5931bf4b551c8abc5c8c88"
+      "source_hash": "53c201871da29d8962c26fcd3ff563296726fc71626fec8b819be1a7857ce28c",
+      "generated_hash": "6a26e0fd34317e30a312d9009b3e8abd4ce6310f463ce2d3489a38d82fc61f14"
     },
     {
       "name": "handoff",
@@ -625,5 +637,5 @@
       "generated_hash": "30f72769961a244749883e03cb04e329cd0feb03dd5b641d2a73a2e5dc8e9d42"
     }
   ],
-  "package_count": 49
+  "package_count": 50
 }

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -369,8 +369,8 @@
     {
       "name": "bootstrap",
       "source_skill": "skills/bootstrap",
-      "source_hash": "895dc489d5dbecfc4a562efe24d01a6347caef562f8eef78bff08a12810e4f67",
-      "generated_hash": "c47b8e84781c855a7203040c1b8f1462818882c543774de498fcf24d06ec334b"
+      "source_hash": "72a0d1c24a2d5d0cb2711c479bf27bf4b54664d6297ed6ddfeb77d1d5d8a835a",
+      "generated_hash": "5f1e6b6fb72563de6b0df6097b9295ff6e4166a6734c75561052995c77d1ba39"
     },
     {
       "name": "cass",
@@ -579,8 +579,8 @@
     {
       "name": "shared",
       "source_skill": "skills/shared",
-      "source_hash": "8a7bb52408d7def6f9360feeef8b1d01a75cde0df3a3f1da869efb040d84dd92",
-      "generated_hash": "340b5e356593682d0abe103e101d62649b8c7fa35ce18566c30ba9c2e2886895"
+      "source_hash": "0e093accb57d583bc53556923e6e6f3110e96d122dc43b90b6ebfcc9711821b0",
+      "generated_hash": "0feead7579441b8286e69bab8c0b9e4ce90dd3dc6009e57f24693ac3ff314f51"
     },
     {
       "name": "skill-builder",

--- a/skills-codex/bootstrap/.agentops-generated.json
+++ b/skills-codex/bootstrap/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/bootstrap",
   "layout": "modular",
-  "source_hash": "895dc489d5dbecfc4a562efe24d01a6347caef562f8eef78bff08a12810e4f67",
-  "generated_hash": "c47b8e84781c855a7203040c1b8f1462818882c543774de498fcf24d06ec334b"
+  "source_hash": "72a0d1c24a2d5d0cb2711c479bf27bf4b54664d6297ed6ddfeb77d1d5d8a835a",
+  "generated_hash": "5f1e6b6fb72563de6b0df6097b9295ff6e4166a6734c75561052995c77d1ba39"
 }

--- a/skills-codex/bootstrap/SKILL.md
+++ b/skills-codex/bootstrap/SKILL.md
@@ -56,7 +56,7 @@ failed writes, and validation observations. Do not include a next action.
 
 ## References
 
-- [Goals](../goals/SKILL.md)
+- [Fitness](../fitness/SKILL.md)
 - [Product](../product/SKILL.md)
 - [Documentation](../doc/SKILL.md)
 - [Examples](references/examples.md)

--- a/skills-codex/fitness/.agentops-generated.json
+++ b/skills-codex/fitness/.agentops-generated.json
@@ -1,0 +1,7 @@
+{
+  "generator": "codex-sync",
+  "source_skill": "skills/fitness",
+  "layout": "modular",
+  "source_hash": "c23854f00cdaf45fdefe04265036bca0539559a247dd88bcd13eff5004dbc361",
+  "generated_hash": "d3f01847b297aaef08bf5d7fc7df1717ea0ca2e59e0407e61f702fdccc2cabae"
+}

--- a/skills-codex/fitness/SKILL.md
+++ b/skills-codex/fitness/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: fitness
+description: Measure declared project fitness goals
+---
+# Fitness — read-only goal measurement
+
+Inspect the active goals document and run only the caller-selected measurement,
+validation, drift, history, export, or meta-goal command.
+
+Renamed from `goals` (2026-07-29): the semantic skill is `fitness`; the
+`ao goals` CLI command family is a separate product surface and keeps its
+name. A thin `goals` compatibility alias resolves to this skill.
+
+Measurement stays trustworthy only because it cannot mutate what it measures;
+the moment a fitness report edits a goal, the next report measures the editor,
+not the project.
+
+Named failure mode — **advice creep**: a measurement report that ends with
+"you should…" has silently become work selection.
+
+Anti-pattern: padding the report with recommendations to look helpful.
+Corrective: return the numbers, the evidence gaps, and checked/not-checked
+scope, and let the caller decide.
+
+## Boundary
+
+- Prefer `GOALS.md` when both Markdown and legacy YAML exist.
+- Preserve stable directive and gate identities in the report.
+- Every measured gate must name its executable check and observed outcome.
+- Do not add, remove, prioritize, recommend, apply, prune, migrate, or otherwise
+  mutate goals.
+- Do not translate a fitness gap into work selection or a next action.
+- No subcommand edits the goals source through its own logic. `measure`,
+  `drift`, and `export` persist a best-effort JSON snapshot under the fixed
+  derived path `.agents/ao/goals/baselines/`. `render --out <file>` writes a
+  Gherkin spec to whatever path the caller names — the CLI does not constrain
+  it, so never point `--out` at the goals source or any non-derived file.
+
+## Commands
+
+All eight subcommands read the goals source without mutating it. The snapshot
+write (fixed derived path) and the `render --out` write (caller-chosen path,
+caller's responsibility) are the only side effects.
+
+```bash
+ao goals measure --json
+ao goals validate --json
+ao goals drift
+ao goals history
+ao goals export
+ao goals meta --json
+ao goals scenarios
+ao goals render          # append --out <file> to write the spec instead of stdout
+```
+
+Run the requested command once. Return the command, exit code, goal-level
+results, aggregate measurement, missing evidence, and checked/not-checked scope.
+Then stop.

--- a/skills-codex/fitness/prompt.md
+++ b/skills-codex/fitness/prompt.md
@@ -1,6 +1,6 @@
-# goals
+# fitness
 
-Compatibility alias — renamed to fitness. Use fitness to measure declared project fitness goals. Triggers: "goals" (deprecated).
+Measure declared project fitness goals without recommending or applying work. Triggers: "fitness", "check project fitness", "measure goals".
 
 ## Instructions
 

--- a/skills-codex/goals/.agentops-generated.json
+++ b/skills-codex/goals/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/goals",
   "layout": "modular",
-  "source_hash": "050c7d539c56668a1a92e7694d6a356329859f1eac01a7b4944718444beb70f7",
-  "generated_hash": "31b0b008feedaa8953613f35acb57687845a6c60cd5931bf4b551c8abc5c8c88"
+  "source_hash": "53c201871da29d8962c26fcd3ff563296726fc71626fec8b819be1a7857ce28c",
+  "generated_hash": "6a26e0fd34317e30a312d9009b3e8abd4ce6310f463ce2d3489a38d82fc61f14"
 }

--- a/skills-codex/goals/SKILL.md
+++ b/skills-codex/goals/SKILL.md
@@ -1,54 +1,16 @@
 ---
 name: goals
-description: Measure declared project fitness goals
+description: Compatibility alias — renamed to fitness.
 ---
-# Goals — read-only fitness measurement
+# Goals — compatibility alias for fitness
 
-Inspect the active goals document and run only the caller-selected measurement,
-validation, drift, history, export, or meta-goal command.
+This skill was renamed to `fitness` on 2026-07-29. Everything it did lives
+there unchanged; the `ao goals` CLI command family keeps its name.
 
-Measurement stays trustworthy only because it cannot mutate what it measures;
-the moment a fitness report edits a goal, the next report measures the editor,
-not the project.
+When invoked, apply `skills/fitness/SKILL.md` exactly as written — this
+alias adds no behavior, grants no authority, and produces nothing of its
+own. It exists so existing references and habits keep resolving, and it is
+deliberately not advertised as a destination.
 
-Named failure mode — **advice creep**: a measurement report that ends with
-"you should…" has silently become work selection.
-
-Anti-pattern: padding the report with recommendations to look helpful.
-Corrective: return the numbers, the evidence gaps, and checked/not-checked
-scope, and let the caller decide.
-
-## Boundary
-
-- Prefer `GOALS.md` when both Markdown and legacy YAML exist.
-- Preserve stable directive and gate identities in the report.
-- Every measured gate must name its executable check and observed outcome.
-- Do not add, remove, prioritize, recommend, apply, prune, migrate, or otherwise
-  mutate goals.
-- Do not translate a fitness gap into work selection or a next action.
-- No subcommand edits the goals source through its own logic. `measure`,
-  `drift`, and `export` persist a best-effort JSON snapshot under the fixed
-  derived path `.agents/ao/goals/baselines/`. `render --out <file>` writes a
-  Gherkin spec to whatever path the caller names — the CLI does not constrain
-  it, so never point `--out` at the goals source or any non-derived file.
-
-## Commands
-
-All eight subcommands read the goals source without mutating it. The snapshot
-write (fixed derived path) and the `render --out` write (caller-chosen path,
-caller's responsibility) are the only side effects.
-
-```bash
-ao goals measure --json
-ao goals validate --json
-ao goals drift
-ao goals history
-ao goals export
-ao goals meta --json
-ao goals scenarios
-ao goals render          # append --out <file> to write the spec instead of stdout
-```
-
-Run the requested command once. Return the command, exit code, goal-level
-results, aggregate measurement, missing evidence, and checked/not-checked scope.
-Then stop.
+Physical deletion follows the observed-zero policy: this alias is removed
+only after a declared observation window shows no remaining use.

--- a/skills-codex/shared/.agentops-generated.json
+++ b/skills-codex/shared/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/shared",
   "layout": "modular",
-  "source_hash": "8a7bb52408d7def6f9360feeef8b1d01a75cde0df3a3f1da869efb040d84dd92",
-  "generated_hash": "340b5e356593682d0abe103e101d62649b8c7fa35ce18566c30ba9c2e2886895"
+  "source_hash": "0e093accb57d583bc53556923e6e6f3110e96d122dc43b90b6ebfcc9711821b0",
+  "generated_hash": "0feead7579441b8286e69bab8c0b9e4ce90dd3dc6009e57f24693ac3ff314f51"
 }

--- a/skills-codex/shared/SKILL.md
+++ b/skills-codex/shared/SKILL.md
@@ -1,31 +1,14 @@
 ---
 name: shared
-description: Shared runtime and evidence references
+description: Retired — its runtime-neutrality contract
 ---
-# Shared References
+# Shared — retired
 
-This library bundles no standalone reference files today; consuming skills inline
-the runtime and evidence context they need. The contract below governs any shared
-reference a consuming skill does load: it is context, not permission to start a
-runtime, tracker, substrate, network call, or external mutation.
+Semantically retired 2026-07-29 (bead `age-skill-overhaul-reboot-sjv7v.11`).
+The runtime-neutrality contract this library carried now lives at its
+declared owner: [docs/contracts/runtime-neutrality.md](../../docs/contracts/runtime-neutrality.md).
 
-Just-in-time loading works because a reference read only when a consuming
-skill needs it cannot silently become a dependency; anything loaded by default
-eventually gets treated as one.
-
-Named failure mode — **reference promotion**: shared prose quietly outranking
-a source skill contract because it was read more recently.
-
-Anti-pattern: citing a shared file as authority for starting a tool or
-runtime. Corrective: authority comes from the caller or the consuming skill's
-contract; shared files only describe.
-
-- Default to the current agent and local shell.
-- Use a runtime-native fresh context only when the caller or consuming workflow
-  requests it.
-- Treat runtime and factory state as adapter evidence; never translate it into
-  core Plan, Candidate, RPI, or verdict state.
-- Missing optional tools degrade only the optional capability that needs them.
-- Source skill contracts and executable behavior outrank shared prose.
-
-The core loop has no hard dependency on this library.
+This skill bundles nothing, produces nothing, grants nothing, and is loaded
+by nothing. The directory remains only for the observed-zero window: physical
+deletion follows once a declared observation period shows no remaining
+references resolve here.

--- a/skills-codex/shared/prompt.md
+++ b/skills-codex/shared/prompt.md
@@ -1,6 +1,6 @@
 # shared
 
-Shared runtime and evidence references loaded only by a consuming skill. Triggers: none — internal library, not user-routable.
+Retired — its runtime-neutrality contract moved to docs/contracts/runtime-neutrality.md. Triggers: none — not routable.
 
 ## Instructions
 

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -32,7 +32,7 @@
 
 ## product
 
-`doc`, `goals`, `product`, `security`
+`doc`, `fitness`, `goals`, `product`, `security`
 
 ## session
 
@@ -58,7 +58,8 @@
 | `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
 | `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |
-| `goals` | product | `keep_specialist` | - | `goals` | `write_goal_snapshot`, `write_rendered_spec` |
+| `fitness` | product | `keep_specialist` | - | `fitness` | `write_goal_snapshot`, `write_rendered_spec` |
+| `goals` | product | `keep_off_path` | - | - | - |
 | `handoff` | session | `keep_specialist` | - | `handoff` | `write_handoff_artifact`, `read_git_state`, `read_clock` |
 | `idea-genie` | execution | `keep_strategy` | - | `generate_evidenced_options`, `dueling_idea_genies` | `write_idea_portfolio` |
 | `implement` | execution | `keep` | - | `execute_one_experiment`, `collect_factual_evidence` | `modify_declared_subject`, `derive_subject_manifest` |

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -82,7 +82,7 @@
 | `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `scope` | meta | `keep_specialist` | - | `scope_review` | - |
 | `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
-| `shared` | library | `keep_specialist` | - | `provide_reference_context` | - |
+| `shared` | library | `keep_off_path` | - | - | - |
 | `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `write_skill_source`, `write_build_report`, `regenerate_skill_projections`, `repair_skill_projections` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -6,10 +6,9 @@ practices:
 - code-complete
 hexagonal_role: driving-adapter
 consumes:
-- goals
+- fitness
 - product
 - doc
-- shared
 produces: []
 context_rel: []
 skill_api_version: 1
@@ -83,7 +82,7 @@ failed writes, and validation observations. Do not include a next action.
 
 ## References
 
-- [Goals](../goals/SKILL.md)
+- [Fitness](../fitness/SKILL.md)
 - [Product](../product/SKILL.md)
 - [Documentation](../doc/SKILL.md)
 - [Examples](references/examples.md)

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "3",
-  "skill_count": 49,
+  "skill_count": 50,
   "skills": [
     {
       "canonical_status": "canonical",
@@ -544,7 +544,7 @@
     {
       "canonical_status": "canonical",
       "capabilities": [
-        "goals"
+        "fitness"
       ],
       "codex_override_present": true,
       "consumes": [],
@@ -555,7 +555,7 @@
         }
       ],
       "dependencies": [],
-      "description": "Measure declared project fitness goals without recommending or applying work. Triggers: \"measure goals\", \"check project fitness\".",
+      "description": "Measure declared project fitness goals without recommending or applying work. Triggers: \"fitness\", \"check project fitness\", \"measure goals\".",
       "disposition": "keep_specialist",
       "effects": [
         "write_goal_snapshot",
@@ -563,7 +563,7 @@
       ],
       "graph_root": false,
       "hexagonal_role": "domain",
-      "name": "goals",
+      "name": "fitness",
       "practices": [
         "dora-metrics",
         "lean-startup"
@@ -574,6 +574,32 @@
       "references_count": 0,
       "tier": "product",
       "user_invocable": false
+    },
+    {
+      "canonical_status": "canonical",
+      "capabilities": [],
+      "codex_override_present": true,
+      "consumes": [],
+      "context_rel": [
+        {
+          "kind": "alias-of",
+          "with": "fitness"
+        }
+      ],
+      "dependencies": [],
+      "description": "Compatibility alias \u2014 renamed to fitness. Use fitness to measure declared project fitness goals. Triggers: \"goals\" (deprecated).",
+      "disposition": "keep_off_path",
+      "effects": [],
+      "graph_root": false,
+      "hexagonal_role": "domain",
+      "name": "goals",
+      "practices": [
+        "dora-metrics"
+      ],
+      "produces": [],
+      "references_count": 0,
+      "tier": "product",
+      "user_invocable": true
     },
     {
       "canonical_status": "canonical",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -204,10 +204,9 @@
       ],
       "codex_override_present": true,
       "consumes": [
-        "goals",
+        "fitness",
         "product",
-        "doc",
-        "shared"
+        "doc"
       ],
       "context_rel": [],
       "dependencies": [],
@@ -1356,26 +1355,21 @@
     },
     {
       "canonical_status": "canonical",
-      "capabilities": [
-        "provide_reference_context"
-      ],
+      "capabilities": [],
       "codex_override_present": true,
       "consumes": [],
       "context_rel": [],
       "dependencies": [],
-      "description": "Shared runtime and evidence references loaded only by a consuming skill. Triggers: none \u2014 internal library, not user-routable.",
-      "disposition": "keep_specialist",
+      "description": "Retired \u2014 its runtime-neutrality contract moved to docs/contracts/runtime-neutrality.md. Triggers: none \u2014 not routable.",
+      "disposition": "keep_off_path",
       "effects": [],
       "graph_root": false,
       "hexagonal_role": "domain",
       "name": "shared",
       "practices": [
-        "design-by-contract",
-        "pragmatic-programmer"
+        "design-by-contract"
       ],
-      "produces": [
-        "reference-documents"
-      ],
+      "produces": [],
       "references_count": 0,
       "tier": "library",
       "user_invocable": false

--- a/skills/fitness/SKILL.md
+++ b/skills/fitness/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: fitness
+description: 'Measure declared project fitness goals without recommending or applying work. Triggers: "fitness", "check project fitness", "measure goals".'
+practices:
+- dora-metrics
+- lean-startup
+hexagonal_role: domain
+consumes: []
+produces:
+- goal-measurement-report
+context_rel:
+- kind: shared-kernel
+  with: standards
+skill_api_version: 1
+context:
+  window: fork
+  intent:
+    mode: task
+  intel_scope: topic
+metadata:
+  capabilities: [fitness]
+  effects: [write_goal_snapshot, write_rendered_spec]
+  canonical_status: canonical
+  disposition: keep_specialist
+  tier: product
+  dependencies: []
+output_contract: read-only goal measurement report
+---
+# Fitness — read-only goal measurement
+
+Inspect the active goals document and run only the caller-selected measurement,
+validation, drift, history, export, or meta-goal command.
+
+Renamed from `goals` (2026-07-29): the semantic skill is `fitness`; the
+`ao goals` CLI command family is a separate product surface and keeps its
+name. A thin `goals` compatibility alias resolves to this skill.
+
+Measurement stays trustworthy only because it cannot mutate what it measures;
+the moment a fitness report edits a goal, the next report measures the editor,
+not the project.
+
+Named failure mode — **advice creep**: a measurement report that ends with
+"you should…" has silently become work selection.
+
+Anti-pattern: padding the report with recommendations to look helpful.
+Corrective: return the numbers, the evidence gaps, and checked/not-checked
+scope, and let the caller decide.
+
+## Boundary
+
+- Prefer `GOALS.md` when both Markdown and legacy YAML exist.
+- Preserve stable directive and gate identities in the report.
+- Every measured gate must name its executable check and observed outcome.
+- Do not add, remove, prioritize, recommend, apply, prune, migrate, or otherwise
+  mutate goals.
+- Do not translate a fitness gap into work selection or a next action.
+- No subcommand edits the goals source through its own logic. `measure`,
+  `drift`, and `export` persist a best-effort JSON snapshot under the fixed
+  derived path `.agents/ao/goals/baselines/`. `render --out <file>` writes a
+  Gherkin spec to whatever path the caller names — the CLI does not constrain
+  it, so never point `--out` at the goals source or any non-derived file.
+
+## Commands
+
+All eight subcommands read the goals source without mutating it. The snapshot
+write (fixed derived path) and the `render --out` write (caller-chosen path,
+caller's responsibility) are the only side effects.
+
+```bash
+ao goals measure --json
+ao goals validate --json
+ao goals drift
+ao goals history
+ao goals export
+ao goals meta --json
+ao goals scenarios
+ao goals render          # append --out <file> to write the spec instead of stdout
+```
+
+Run the requested command once. Return the command, exit code, goal-level
+results, aggregate measurement, missing evidence, and checked/not-checked scope.
+Then stop.

--- a/skills/goals/SKILL.md
+++ b/skills/goals/SKILL.md
@@ -1,78 +1,34 @@
 ---
 name: goals
-description: 'Measure declared project fitness goals without recommending or applying work. Triggers: "measure goals", "check project fitness".'
+description: 'Compatibility alias — renamed to fitness. Use fitness to measure declared project fitness goals. Triggers: "goals" (deprecated).'
 practices:
 - dora-metrics
-- lean-startup
 hexagonal_role: domain
 consumes: []
-produces:
-- goal-measurement-report
+produces: []
 context_rel:
-- kind: shared-kernel
-  with: standards
+- kind: alias-of
+  with: fitness
 skill_api_version: 1
-context:
-  window: fork
-  intent:
-    mode: task
-  intel_scope: topic
+user-invocable: true
 metadata:
-  capabilities: [goals]
-  effects: [write_goal_snapshot, write_rendered_spec]
+  capabilities: []
+  effects: []
   canonical_status: canonical
-  disposition: keep_specialist
+  disposition: keep_off_path
   tier: product
   dependencies: []
-output_contract: read-only goal measurement report
+output_contract: none — delegates to fitness
 ---
-# Goals — read-only fitness measurement
+# Goals — compatibility alias for fitness
 
-Inspect the active goals document and run only the caller-selected measurement,
-validation, drift, history, export, or meta-goal command.
+This skill was renamed to `fitness` on 2026-07-29. Everything it did lives
+there unchanged; the `ao goals` CLI command family keeps its name.
 
-Measurement stays trustworthy only because it cannot mutate what it measures;
-the moment a fitness report edits a goal, the next report measures the editor,
-not the project.
+When invoked, apply `skills/fitness/SKILL.md` exactly as written — this
+alias adds no behavior, grants no authority, and produces nothing of its
+own. It exists so existing references and habits keep resolving, and it is
+deliberately not advertised as a destination.
 
-Named failure mode — **advice creep**: a measurement report that ends with
-"you should…" has silently become work selection.
-
-Anti-pattern: padding the report with recommendations to look helpful.
-Corrective: return the numbers, the evidence gaps, and checked/not-checked
-scope, and let the caller decide.
-
-## Boundary
-
-- Prefer `GOALS.md` when both Markdown and legacy YAML exist.
-- Preserve stable directive and gate identities in the report.
-- Every measured gate must name its executable check and observed outcome.
-- Do not add, remove, prioritize, recommend, apply, prune, migrate, or otherwise
-  mutate goals.
-- Do not translate a fitness gap into work selection or a next action.
-- No subcommand edits the goals source through its own logic. `measure`,
-  `drift`, and `export` persist a best-effort JSON snapshot under the fixed
-  derived path `.agents/ao/goals/baselines/`. `render --out <file>` writes a
-  Gherkin spec to whatever path the caller names — the CLI does not constrain
-  it, so never point `--out` at the goals source or any non-derived file.
-
-## Commands
-
-All eight subcommands read the goals source without mutating it. The snapshot
-write (fixed derived path) and the `render --out` write (caller-chosen path,
-caller's responsibility) are the only side effects.
-
-```bash
-ao goals measure --json
-ao goals validate --json
-ao goals drift
-ao goals history
-ao goals export
-ao goals meta --json
-ao goals scenarios
-ao goals render          # append --out <file> to write the spec instead of stdout
-```
-
-Run the requested command once. Return the command, exit code, goal-level
-results, aggregate measurement, missing evidence, and checked/not-checked scope.
-Then stop.
+Physical deletion follows the observed-zero policy: this alias is removed
+only after a declared observation window shows no remaining use.

--- a/skills/shared/SKILL.md
+++ b/skills/shared/SKILL.md
@@ -1,48 +1,31 @@
 ---
 name: shared
-description: 'Shared runtime and evidence references loaded only by a consuming skill. Triggers: none — internal library, not user-routable.'
-practices: [design-by-contract, pragmatic-programmer]
+description: 'Retired — its runtime-neutrality contract moved to docs/contracts/runtime-neutrality.md. Triggers: none — not routable.'
+practices: [design-by-contract]
 hexagonal_role: domain
 consumes: []
-produces: [reference-documents]
+produces: []
 context_rel: []
 skill_api_version: 1
 user-invocable: false
 metadata:
   tier: library
   dependencies: []
-  capabilities: [provide_reference_context]
+  capabilities: []
   effects: []
   canonical_status: canonical
-  disposition: keep_specialist
+  disposition: keep_off_path
   internal: true
-output_contract: no reference documents are bundled at present; the contract governs any reference a consuming skill inlines
+output_contract: none — retired; see docs/contracts/runtime-neutrality.md
 ---
 
-# Shared References
+# Shared — retired
 
-This library bundles no standalone reference files today; consuming skills inline
-the runtime and evidence context they need. The contract below governs any shared
-reference a consuming skill does load: it is context, not permission to start a
-runtime, tracker, substrate, network call, or external mutation.
+Semantically retired 2026-07-29 (bead `age-skill-overhaul-reboot-sjv7v.11`).
+The runtime-neutrality contract this library carried now lives at its
+declared owner: [docs/contracts/runtime-neutrality.md](../../docs/contracts/runtime-neutrality.md).
 
-Just-in-time loading works because a reference read only when a consuming
-skill needs it cannot silently become a dependency; anything loaded by default
-eventually gets treated as one.
-
-Named failure mode — **reference promotion**: shared prose quietly outranking
-a source skill contract because it was read more recently.
-
-Anti-pattern: citing a shared file as authority for starting a tool or
-runtime. Corrective: authority comes from the caller or the consuming skill's
-contract; shared files only describe.
-
-- Default to the current agent and local shell.
-- Use a runtime-native fresh context only when the caller or consuming workflow
-  requests it.
-- Treat runtime and factory state as adapter evidence; never translate it into
-  core Plan, Candidate, RPI, or verdict state.
-- Missing optional tools degrade only the optional capability that needs them.
-- Source skill contracts and executable behavior outrank shared prose.
-
-The core loop has no hard dependency on this library.
+This skill bundles nothing, produces nothing, grants nothing, and is loaded
+by nothing. The directory remains only for the observed-zero window: physical
+deletion follows once a declared observation period shows no remaining
+references resolve here.


### PR DESCRIPTION
## Summary

The two structural beads deferred from the skill-overhaul reboot waves.

**goals → fitness** (`age-skill-overhaul-reboot-sjv7v.10`, 07-24 plan D9)
- The semantic skill is now `fitness`; the `ao goals` CLI command family deliberately keeps its name.
- `skills/goals` remains a thin, non-advertised compatibility alias: user-invocable, zero capabilities/effects/dependencies, an `alias-of` context_rel edge to fitness, physical deletion only under the observed-zero policy.
- `alias-of` added to the frontmatter schema enums (the catalog schema's own description already listed it as valid relationship vocabulary; the enum lagged).
- bootstrap's `goals` consumer edge migrated; the stale `goals.feature` row in the scenario-linkage contract corrected (the feature file was already absent).

**shared retirement** (`age-skill-overhaul-reboot-sjv7v.11`, 07-24 plan D9)
- The runtime-neutrality contract moved to its declared owner: `docs/contracts/runtime-neutrality.md`, scope unchanged (shared references a consuming skill loads).
- The last consumer edge (`bootstrap consumes: shared`) removed; `skills/shared` reduced to a non-routable tombstone pending the observed-zero deletion window; the ports-and-adapters contract updated to executed state.

## Validation

- Strict frontmatter 50/50 (fitness + alias); regen byte-current; scenario-linkage PASS; liveness/anti-spiral/desc-budget bats green; `cli/internal/skills` Go tests pass
- Cross-family review, two rounds: round 1 — one finding fixed (unintended contract-scope broadening reverted), one rejected with evidence (the reviewer inferred a pre-existing feature file from a stale doc row; the pre-change tree had none); round 2 delta **VERDICT: PASS**

Tracker: `age-skill-overhaul-reboot-sjv7v.10`, `.11`