### PR TITLE
Go CLI audit residue: eval id containment hardened, dry-run honored, owned temp dirs

### DIFF
--- a/cli/cmd/ao/provenance_composition.go
+++ b/cli/cmd/ao/provenance_composition.go
@@ -24,6 +24,7 @@ func newProvenanceCommand() *cobra.Command {
 		LedgerPath: resolveLedgerPath,
 		Now:        time.Now,
 		OutputMode: GetOutput,
+		DryRun:     GetDryRun,
 	})
 	return module.Command()
 }

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -638,7 +638,7 @@ ao eval task run <task-id> [flags]
   -h, --help                     help for run
       --inspect-command string   Inspect command recorded into the Run manifest (not executed yet)
       --inspect-version string   Inspect AI version stamped into manifest (default "0.3.216")
-      --model-spec string        ModelSpec id (already captured via ao eval models capture)
+      --model-spec string        ModelSpec id, resolved from <evals-root>/models/<id>/spec.yaml
       --n-samples int            Override Suite.n_samples
       --quick                    Mark Run as quick_session=true (excluded from --vs auto-baseline pool)
       --rig-id string            Rig identifier stamped into the Run manifest

--- a/cli/internal/commands/eval/module.go
+++ b/cli/internal/commands/eval/module.go
@@ -489,7 +489,7 @@ func (module Module) taskRunCommand() *cobra.Command {
 	flags.StringVar(&options.Seeds, "seeds", "", "Comma-separated seeds (>=3, per §4)")
 	flags.StringVar(&options.HarnessRef, "harness", "", "Harness id (recorded into manifest)")
 	flags.StringVar(&options.HarnessDir, "harness-dir", "", "Path to harness source dir for snapshot + gate #8")
-	flags.StringVar(&options.ModelSpecID, "model-spec", "", "ModelSpec id (already captured via ao eval models capture)")
+	flags.StringVar(&options.ModelSpecID, "model-spec", "", "ModelSpec id, resolved from <evals-root>/models/<id>/spec.yaml")
 	flags.StringVar(&options.GroundTruthRef, "ground-truth", "", "Ground-truth row id (head of supersession chain)")
 	flags.StringVar(&options.SampleSplit, "sample-split", "", "Sample split (dev|holdout); default from suite")
 	flags.IntVar(&options.NSamples, "n-samples", 0, "Override Suite.n_samples")

--- a/cli/internal/commands/provenance/module.go
+++ b/cli/internal/commands/provenance/module.go
@@ -188,6 +188,21 @@ func (m *Module) runAdd(cmd *cobra.Command, args []string) error {
 		TS:          ts,
 	}
 
+	// --dry-run is an advertised global safety control; provenance add is an
+	// effectful (ledger-writing) leaf, so it must honor it and perform no write
+	// (2026-07-24 Go CLI audit, High: global --dry-run does not reliably suppress
+	// effects). Emit the edge that WOULD be appended under the same output
+	// contract, then stop before Append.
+	if m.host.DryRun != nil && m.host.DryRun() {
+		out := cmd.OutOrStdout()
+		if handled, err := m.emitStructured(out, m.addJSON, edge); handled || err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "[dry-run] would append edge %s --%s--> %s (not written)\n",
+			edge.FromID, edge.Relation, edge.ToID)
+		return nil
+	}
+
 	res, err := m.ledgerStore().Append(edge)
 	if err != nil {
 		return fmt.Errorf("append provenance edge: %w", err)

--- a/cli/internal/commands/provenance/module_test.go
+++ b/cli/internal/commands/provenance/module_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -119,6 +120,29 @@ func TestProvenanceAdd_ProducesSchemaValidEdgeAndReadsBack(t *testing.T) {
 	}
 	if listed[0].Hash != emitted.Hash {
 		t.Fatalf("round-trip hash mismatch: %q vs %q", listed[0].Hash, emitted.Hash)
+	}
+}
+
+func TestProvenanceAdd_DryRunSuppressesLedgerWrite(t *testing.T) {
+	ledger := testLedger(t)
+	module := NewModule(clicontract.HostOptions{
+		LedgerPath: func() string { return ledger },
+		Now:        func() time.Time { return fixedNow },
+		DryRun:     func() bool { return true },
+	})
+	root := module.Command()
+	var out, errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"add", "decision-42", "artifact-1", "--relation", "wasGeneratedBy"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("dry-run add returned error: %v (stderr %q)", err, errBuf.String())
+	}
+	if _, err := os.Stat(ledger); !os.IsNotExist(err) {
+		t.Fatalf("dry-run add wrote the ledger at %s (stat err=%v); want no write", ledger, err)
+	}
+	if !strings.Contains(out.String(), "[dry-run]") {
+		t.Fatalf("dry-run add output missing [dry-run] notice: %q", out.String())
 	}
 }
 

--- a/cli/internal/eval/runtime.go
+++ b/cli/internal/eval/runtime.go
@@ -196,9 +196,17 @@ func RunLiveRuntime(ctx context.Context, opts LiveRuntimeOptions) (*RunRecord, e
 		return finishLiveRuntimeRun(opts, record, now)
 	}
 
-	env, hostNotes, err := liveRuntimeEnv(opts, suite)
+	env, hostNotes, ownedIsolationRoot, err := liveRuntimeEnv(opts, suite)
 	if err != nil {
 		return nil, err
+	}
+	if ownedIsolationRoot != "" {
+		// The isolation root was created internally (no caller IsolationRoot).
+		// Own its lifecycle: remove it once the run completes so runtime-written
+		// HOME and CODEX_HOME data does not leak in temp storage on success,
+		// error, or timeout (2026-07-24 Go CLI audit, Medium: live-runtime
+		// isolation dirs leak). A caller-supplied IsolationRoot is never removed.
+		defer removeOwnedRoot(ownedIsolationRoot)
 	}
 	record.Environment.HostNotes = append(record.Environment.HostNotes, hostNotes...)
 
@@ -359,26 +367,33 @@ func liveEnvironmentRecord(opts LiveRuntimeOptions, suite Suite) EnvironmentReco
 	}
 }
 
-func liveRuntimeEnv(opts LiveRuntimeOptions, suite Suite) ([]string, []string, error) {
+// liveRuntimeEnv builds the scrubbed, isolation-aware environment for a live
+// runtime run. When the suite requests home/Codex-home isolation and the caller
+// supplied no IsolationRoot, it creates one under the system temp dir and
+// reports its path as ownedRoot so the caller can remove it after the run; a
+// caller-supplied IsolationRoot is never reported and never removed here
+// (2026-07-24 Go CLI audit, Medium: auto-created live-runtime isolation
+// directories leak). ownedRoot is "" whenever nothing was internally created.
+func liveRuntimeEnv(opts LiveRuntimeOptions, suite Suite) (env []string, notes []string, ownedRoot string, err error) {
 	base := opts.Env
 	if base == nil {
 		base = os.Environ()
 	}
-	env := scrubbedEnv(base, liveScrubPrefixes(suite))
-	var notes []string
+	env = scrubbedEnv(base, liveScrubPrefixes(suite))
 	if suite.Environment.IsolateHome || suite.Environment.IsolateCodexHome {
 		root := opts.IsolationRoot
 		if root == "" {
-			var err error
-			root, err = os.MkdirTemp("", "agentops-eval-runtime-*")
-			if err != nil {
-				return nil, nil, fmt.Errorf("create runtime isolation root: %w", err)
+			created, mkErr := os.MkdirTemp("", "agentops-eval-runtime-*")
+			if mkErr != nil {
+				return nil, nil, "", fmt.Errorf("create runtime isolation root: %w", mkErr)
 			}
+			root, ownedRoot = created, created
 		}
 		if suite.Environment.IsolateHome {
 			home := filepath.Join(root, "home")
-			if err := os.MkdirAll(home, 0o700); err != nil {
-				return nil, nil, fmt.Errorf("create isolated home: %w", err)
+			if mkErr := os.MkdirAll(home, 0o700); mkErr != nil {
+				removeOwnedRoot(ownedRoot)
+				return nil, nil, "", fmt.Errorf("create isolated home: %w", mkErr)
 			}
 			env = setEnvValue(env, "HOME", home)
 			if goruntime.GOOS == "windows" {
@@ -388,8 +403,9 @@ func liveRuntimeEnv(opts LiveRuntimeOptions, suite Suite) ([]string, []string, e
 		}
 		if suite.Environment.IsolateCodexHome {
 			codexHome := filepath.Join(root, "codex-home")
-			if err := os.MkdirAll(codexHome, 0o700); err != nil {
-				return nil, nil, fmt.Errorf("create isolated Codex home: %w", err)
+			if mkErr := os.MkdirAll(codexHome, 0o700); mkErr != nil {
+				removeOwnedRoot(ownedRoot)
+				return nil, nil, "", fmt.Errorf("create isolated Codex home: %w", mkErr)
 			}
 			env = setEnvValue(env, "CODEX_HOME", codexHome)
 			notes = append(notes, "CODEX_HOME isolated")
@@ -400,7 +416,16 @@ func liveRuntimeEnv(opts LiveRuntimeOptions, suite Suite) ([]string, []string, e
 		env = append(env, "AGENTOPS_HOOKS_DISABLED=1")
 		notes = append(notes, "hooks disabled (AGENTOPS_HOOKS_DISABLED=1)")
 	}
-	return env, notes, nil
+	return env, notes, ownedRoot, nil
+}
+
+// removeOwnedRoot deletes an internally created isolation root on a partial-setup
+// error path. It is a no-op for the empty string (a caller-supplied root), so it
+// never removes a directory the caller owns.
+func removeOwnedRoot(ownedRoot string) {
+	if ownedRoot != "" {
+		_ = os.RemoveAll(ownedRoot)
+	}
 }
 
 func liveScrubPrefixes(suite Suite) []string {

--- a/cli/internal/eval/runtime_test.go
+++ b/cli/internal/eval/runtime_test.go
@@ -3,6 +3,7 @@ package eval
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
@@ -487,7 +488,7 @@ func TestEffectiveDisableHooksOrsSuiteAndOverride(t *testing.T) {
 func TestLiveRuntimeEnvEmitsAgentopsHooksDisabled(t *testing.T) {
 	suite := Suite{Environment: SuiteEnvironment{DisableHooks: true}}
 	opts := LiveRuntimeOptions{Env: []string{}}
-	env, notes, err := liveRuntimeEnv(opts, suite)
+	env, notes, _, err := liveRuntimeEnv(opts, suite)
 	if err != nil {
 		t.Fatalf("liveRuntimeEnv: %v", err)
 	}
@@ -500,7 +501,7 @@ func TestLiveRuntimeEnvEmitsAgentopsHooksDisabled(t *testing.T) {
 func TestLiveRuntimeEnvOmitsHooksDisabledWhenInactive(t *testing.T) {
 	suite := Suite{Environment: SuiteEnvironment{}}
 	opts := LiveRuntimeOptions{Env: []string{}}
-	env, _, err := liveRuntimeEnv(opts, suite)
+	env, _, _, err := liveRuntimeEnv(opts, suite)
 	if err != nil {
 		t.Fatalf("liveRuntimeEnv: %v", err)
 	}
@@ -514,11 +515,43 @@ func TestLiveRuntimeEnvOmitsHooksDisabledWhenInactive(t *testing.T) {
 func TestLiveRuntimeEnvHonorsOverrideDisableHooks(t *testing.T) {
 	suite := Suite{Environment: SuiteEnvironment{}}
 	opts := LiveRuntimeOptions{Env: []string{}, OverrideDisableHooks: true}
-	env, _, err := liveRuntimeEnv(opts, suite)
+	env, _, _, err := liveRuntimeEnv(opts, suite)
 	if err != nil {
 		t.Fatalf("liveRuntimeEnv: %v", err)
 	}
 	assertEnvContains(t, env, "AGENTOPS_HOOKS_DISABLED=1")
+}
+
+func TestLiveRuntimeEnvOwnsInternallyCreatedIsolationRoot(t *testing.T) {
+	suite := Suite{Environment: SuiteEnvironment{IsolateHome: true, IsolateCodexHome: true}}
+	// No IsolationRoot supplied: liveRuntimeEnv must create one and report it.
+	_, _, ownedRoot, err := liveRuntimeEnv(LiveRuntimeOptions{Env: []string{}}, suite)
+	if err != nil {
+		t.Fatalf("liveRuntimeEnv: %v", err)
+	}
+	if ownedRoot == "" {
+		t.Fatal("liveRuntimeEnv did not report an owned isolation root; the auto-created temp dir would leak")
+	}
+	if _, statErr := os.Stat(filepath.Join(ownedRoot, "home")); statErr != nil {
+		t.Fatalf("owned root missing isolated home: %v", statErr)
+	}
+	// The caller removes it after the run; prove that leaves nothing behind.
+	removeOwnedRoot(ownedRoot)
+	if _, statErr := os.Stat(ownedRoot); !os.IsNotExist(statErr) {
+		t.Fatalf("owned root not cleaned: stat err=%v", statErr)
+	}
+}
+
+func TestLiveRuntimeEnvDoesNotOwnCallerIsolationRoot(t *testing.T) {
+	callerRoot := t.TempDir()
+	suite := Suite{Environment: SuiteEnvironment{IsolateHome: true}}
+	_, _, ownedRoot, err := liveRuntimeEnv(LiveRuntimeOptions{Env: []string{}, IsolationRoot: callerRoot}, suite)
+	if err != nil {
+		t.Fatalf("liveRuntimeEnv: %v", err)
+	}
+	if ownedRoot != "" {
+		t.Fatalf("liveRuntimeEnv claimed ownership of caller-supplied root %q (ownedRoot=%q); it must never remove it", callerRoot, ownedRoot)
+	}
 }
 
 func TestLiveRuntimePromptAppendsNegationWhenDisabled(t *testing.T) {

--- a/cli/internal/eval/suite_service.go
+++ b/cli/internal/eval/suite_service.go
@@ -87,6 +87,9 @@ func (service SuiteService) NRequired(_ context.Context, request SuiteNRequiredR
 func (service SuiteService) loadSuite(id string) (*evalsubstrate.Suite, error) {
 	path := id
 	if !strings.HasSuffix(id, ".yaml") && !strings.HasSuffix(id, ".yml") {
+		if err := evalsubstrate.ValidateID(id); err != nil {
+			return nil, fmt.Errorf("loadSuite: %w", err)
+		}
 		path = filepath.Join(service.Runtime.Root(), "suites", id, "suite.yaml")
 	}
 	raw, err := service.Runtime.ReadFile(path)

--- a/cli/internal/eval/task_service.go
+++ b/cli/internal/eval/task_service.go
@@ -73,6 +73,9 @@ func (service TaskService) Add(_ context.Context, request TaskAddRequest) (TaskA
 	if task.ID == "" {
 		return TaskAddResult{}, fmt.Errorf("eval task add: missing required field id")
 	}
+	if err := evalsubstrate.ValidateID(task.ID); err != nil {
+		return TaskAddResult{}, fmt.Errorf("eval task add: %w", err)
+	}
 	if task.Stats.MinNSamples <= 0 {
 		return TaskAddResult{}, fmt.Errorf("eval task add: task %q has no stats.min_n_samples (gate #6 cannot enforce)", task.ID)
 	}
@@ -186,6 +189,9 @@ func (failure *TaskGateError) Error() string {
 }
 
 func (service TaskService) loadTask(id string) (*evalsubstrate.Task, error) {
+	if err := evalsubstrate.ValidateID(id); err != nil {
+		return nil, fmt.Errorf("loadTask: %w", err)
+	}
 	path := filepath.Join(service.Runtime.Root(), "tasks", id, "task.yaml")
 	raw, err := service.Runtime.ReadFile(path)
 	if err != nil {
@@ -201,6 +207,9 @@ func (service TaskService) loadTask(id string) (*evalsubstrate.Task, error) {
 func (service TaskService) loadSuite(ref string) (*evalsubstrate.Suite, error) {
 	path := ref
 	if !strings.HasSuffix(ref, ".yaml") && !strings.HasSuffix(ref, ".yml") {
+		if err := evalsubstrate.ValidateID(ref); err != nil {
+			return nil, fmt.Errorf("loadSuite: %w", err)
+		}
 		path = filepath.Join(service.Runtime.Root(), "suites", ref, "suite.yaml")
 	}
 	raw, err := service.Runtime.ReadFile(path)

--- a/cli/internal/eval/task_service_test.go
+++ b/cli/internal/eval/task_service_test.go
@@ -33,6 +33,27 @@ func (*taskRuntimeSpy) OpenRun(string, string, evalsubstrate.Manifest) (TaskRunW
 }
 func (*taskRuntimeSpy) Now() time.Time { return time.Unix(1_000, 0).UTC() }
 
+func TestTaskServiceAddRejectsTraversalIDWithoutWriting(t *testing.T) {
+	runtime := &taskRuntimeSpy{
+		files:  map[string][]byte{"task.yaml": []byte("id: ../../escape\nschema_version: 1\nstats:\n  min_n_samples: 3\n")},
+		writes: map[string][]byte{},
+	}
+	_, err := (TaskService{Runtime: runtime}).Add(context.Background(), TaskAddRequest{SourcePath: "task.yaml"})
+	if err == nil {
+		t.Fatal("Add accepted a traversal id; want rejection")
+	}
+	if len(runtime.writes) != 0 {
+		t.Fatalf("traversal id produced a write: %v", runtime.writes)
+	}
+}
+
+func TestTaskServiceShowRejectsTraversalID(t *testing.T) {
+	runtime := &taskRuntimeSpy{files: map[string][]byte{}, writes: map[string][]byte{}}
+	if _, err := (TaskService{Runtime: runtime}).Show(context.Background(), "../../../etc/passwd"); err == nil {
+		t.Fatal("Show accepted a traversal id; want rejection")
+	}
+}
+
 func TestTaskServiceAddCanonicalizesAndWritesOwnedDestination(t *testing.T) {
 	runtime := &taskRuntimeSpy{files: map[string][]byte{"task.yaml": []byte("id: task-1\nschema_version: 1\nstats:\n  min_n_samples: 3\n")}, writes: map[string][]byte{}}
 	result, err := (TaskService{Runtime: runtime}).Add(context.Background(), TaskAddRequest{SourcePath: "task.yaml"})

--- a/cli/internal/evalsubstrate/id.go
+++ b/cli/internal/evalsubstrate/id.go
@@ -1,0 +1,42 @@
+package evalsubstrate
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ValidateID rejects an eval-store identifier (task, suite, run, or model-spec
+// ID) that could escape its declared subtree once it is interpolated into a
+// store path such as filepath.Join(root, "<kind>", id, "<file>").
+//
+// A valid ID is a single, non-empty path component: it contains no path
+// separator, is not the "." or ".." traversal component, is not an absolute
+// path or a volume/drive reference, and contains no control characters. This
+// closes the 2026-07-24 Go CLI audit's High "eval IDs permit filesystem escape"
+// finding, where a YAML-supplied id such as "../../escape" was cleaned by
+// filepath.Join and written or read outside the eval root.
+//
+// Colons are intentionally permitted: legitimate model-spec IDs use them
+// (for example "ms:stable"). Windows drive references (for example "C:") are
+// still rejected via filepath.VolumeName, which returns "" for a plain colon.
+func ValidateID(id string) error {
+	if id == "" {
+		return fmt.Errorf("id is empty")
+	}
+	if strings.ContainsAny(id, `/\`) {
+		return fmt.Errorf("id %q contains a path separator", id)
+	}
+	if id == "." || id == ".." {
+		return fmt.Errorf("id %q is a path-traversal component", id)
+	}
+	if filepath.IsAbs(id) || filepath.VolumeName(id) != "" {
+		return fmt.Errorf("id %q is an absolute path or volume reference", id)
+	}
+	for _, r := range id {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("id %q contains a control character", id)
+		}
+	}
+	return nil
+}

--- a/cli/internal/evalsubstrate/id.go
+++ b/cli/internal/evalsubstrate/id.go
@@ -4,39 +4,69 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/text/unicode/norm"
 )
 
+// maxIDBytes caps the length of an eval-store identifier once it is the final,
+// encoding-applied path component. 128 bytes stays well under every common
+// filesystem's per-component limit while allowing dated, descriptive IDs.
+const maxIDBytes = 128
+
 // ValidateID rejects an eval-store identifier (task, suite, run, or model-spec
-// ID) that could escape its declared subtree once it is interpolated into a
-// store path such as filepath.Join(root, "<kind>", id, "<file>").
+// ID) that is not a safe, canonical, single path component — the form that may
+// become a directory name once interpolated into filepath.Join(root, "<kind>",
+// id, "<file>"). It closes the 2026-07-24 Go CLI audit's High "eval IDs permit
+// filesystem escape" finding and the cross-family round-1 portability findings.
 //
-// A valid ID is a single, non-empty path component: it contains no path
-// separator, is not the "." or ".." traversal component, is not an absolute
-// path or a volume/drive reference, and contains no control characters. This
-// closes the 2026-07-24 Go CLI audit's High "eval IDs permit filesystem escape"
-// finding, where a YAML-supplied id such as "../../escape" was cleaned by
-// filepath.Join and written or read outside the eval root.
-//
-// Colons are intentionally permitted: legitimate model-spec IDs use them
-// (for example "ms:stable"). Windows drive references (for example "C:") are
-// still rejected via filepath.VolumeName, which returns "" for a plain colon.
+// An ID is valid only when it:
+//   - is non-empty and at most maxIDBytes bytes;
+//   - is valid UTF-8 in Unicode NFC form (non-NFC input is REJECTED, not
+//     silently normalized, so two visually identical IDs can never address two
+//     distinct on-disk entries);
+//   - contains no path separator ('/' or '\'), and is neither an absolute path
+//     nor a volume/drive reference (filepath.VolumeName);
+//   - has no leading or trailing space or dot — Win32 path normalization strips
+//     trailing spaces and dots, so ".. " would otherwise renormalize to the
+//     ".." traversal component; this rule also subsumes "." and "..";
+//   - contains no control characters (C0 0x00–0x1F, DEL 0x7F, or C1 0x80–0x9F);
+//   - contains no ':' — ':' denotes a Windows alternate-data-stream and must be
+//     percent-encoded away (see ModelSpecPath) BEFORE an ID becomes a path
+//     component, never passed through raw. Model-spec IDs such as "ms:stable"
+//     are therefore validated in their encoded ("ms%3Astable") form.
 func ValidateID(id string) error {
 	if id == "" {
 		return fmt.Errorf("id is empty")
 	}
+	if len(id) > maxIDBytes {
+		return fmt.Errorf("id is %d bytes, exceeds the %d-byte cap", len(id), maxIDBytes)
+	}
+	if !utf8.ValidString(id) {
+		return fmt.Errorf("id %q is not valid UTF-8", id)
+	}
 	if strings.ContainsAny(id, `/\`) {
 		return fmt.Errorf("id %q contains a path separator", id)
-	}
-	if id == "." || id == ".." {
-		return fmt.Errorf("id %q is a path-traversal component", id)
 	}
 	if filepath.IsAbs(id) || filepath.VolumeName(id) != "" {
 		return fmt.Errorf("id %q is an absolute path or volume reference", id)
 	}
+	if strings.ContainsRune(id, ':') {
+		return fmt.Errorf("id %q contains a reserved ':' character (must be encoded before path use)", id)
+	}
+	first, _ := utf8.DecodeRuneInString(id)
+	last, _ := utf8.DecodeLastRuneInString(id)
+	if first == '.' || last == '.' || unicode.IsSpace(first) || unicode.IsSpace(last) {
+		return fmt.Errorf("id %q has a leading or trailing space or dot", id)
+	}
 	for _, r := range id {
-		if r < 0x20 || r == 0x7f {
+		if r < 0x20 || (r >= 0x7f && r <= 0x9f) {
 			return fmt.Errorf("id %q contains a control character", id)
 		}
+	}
+	if !norm.NFC.IsNormalString(id) {
+		return fmt.Errorf("id %q is not in Unicode NFC form", id)
 	}
 	return nil
 }

--- a/cli/internal/evalsubstrate/id_test.go
+++ b/cli/internal/evalsubstrate/id_test.go
@@ -1,36 +1,54 @@
 package evalsubstrate
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func TestValidateID_RejectsTraversalAndSeparators(t *testing.T) {
-	rejected := []string{
-		"",              // empty
-		".",             // self-reference
-		"..",            // parent traversal
-		"../../escape",  // classic traversal
-		"a/b",           // forward separator
-		`a\b`,           // backslash separator (Windows)
-		"/etc/passwd",   // absolute
-		"tasks/../evil", // embedded traversal
-		"bad\x00id",     // NUL control char
-		"tab\tid",       // control char
+func TestValidateID_RejectsUnsafeComponents(t *testing.T) {
+	c1 := "a" + string(rune(0x0080)) + "b"                   // C1 control; a C0-only check misses it
+	del := "a" + string(rune(0x007f)) + "b"                  // DEL
+	nfd := "caf" + string(rune('e')) + string(rune(0x0301))  // 'e' + combining acute (not NFC)
+	rejected := map[string]string{
+		"empty":               "",
+		"self-reference":      ".",
+		"parent traversal":    "..",
+		"classic traversal":   "../../escape",
+		"forward separator":   "a/b",
+		"backslash separator": `a\b`,
+		"absolute":            "/etc/passwd",
+		"embedded traversal":  "tasks/../evil",
+		"NUL control":         "bad\x00id",
+		"tab control":         "tab\tid",
+		"C1 control":          c1,
+		"DEL control":         del,
+		"trailing space":      ".. ", // Win32 strips the trailing space -> ".." traversal
+		"leading space":       " ok",
+		"trailing dot":        "foo.",
+		"leading dot":         ".foo",
+		"whitespace only":     "   ",
+		"reserved colon":      "ms:stable", // ':' is a Windows ADS separator; must be encoded first
+		"drive colon":         "a:b",
+		"overlong":            strings.Repeat("a", 129), // exceeds the 128-byte cap
+		"non-NFC (NFD)":       nfd,
 	}
-	for _, id := range rejected {
+	for name, id := range rejected {
 		if err := ValidateID(id); err == nil {
-			t.Errorf("ValidateID(%q) = nil, want rejection", id)
+			t.Errorf("%s: ValidateID(%q) = nil, want rejection", name, id)
 		}
 	}
 }
 
-func TestValidateID_AcceptsLegitimateIDs(t *testing.T) {
+func TestValidateID_AcceptsCanonicalIDs(t *testing.T) {
+	nfc := "caf" + string(rune(0x00e9)) // precomposed e-acute (NFC)
 	accepted := []string{
 		"task-1",
 		"finance-categorize-txn",
-		"ms:stable",              // model-spec IDs use colons
-		"ms:test-2026-05-01",     // dated model-spec id
 		"2026-05-01-qwen-vs-c47", // dated suite id
-		"..leading-dots",         // dots that are not the ".." component
-		"trailing..",
+		"qwen3.6-vs-claude4.7",   // interior dots are fine
+		nfc,                      // precomposed (NFC) e-acute
+		"ms%3Astable",            // model-spec id in its encoded, path-safe form
+		strings.Repeat("a", maxIDBytes), // exactly at the cap
 	}
 	for _, id := range accepted {
 		if err := ValidateID(id); err != nil {

--- a/cli/internal/evalsubstrate/id_test.go
+++ b/cli/internal/evalsubstrate/id_test.go
@@ -1,0 +1,40 @@
+package evalsubstrate
+
+import "testing"
+
+func TestValidateID_RejectsTraversalAndSeparators(t *testing.T) {
+	rejected := []string{
+		"",              // empty
+		".",             // self-reference
+		"..",            // parent traversal
+		"../../escape",  // classic traversal
+		"a/b",           // forward separator
+		`a\b`,           // backslash separator (Windows)
+		"/etc/passwd",   // absolute
+		"tasks/../evil", // embedded traversal
+		"bad\x00id",     // NUL control char
+		"tab\tid",       // control char
+	}
+	for _, id := range rejected {
+		if err := ValidateID(id); err == nil {
+			t.Errorf("ValidateID(%q) = nil, want rejection", id)
+		}
+	}
+}
+
+func TestValidateID_AcceptsLegitimateIDs(t *testing.T) {
+	accepted := []string{
+		"task-1",
+		"finance-categorize-txn",
+		"ms:stable",              // model-spec IDs use colons
+		"ms:test-2026-05-01",     // dated model-spec id
+		"2026-05-01-qwen-vs-c47", // dated suite id
+		"..leading-dots",         // dots that are not the ".." component
+		"trailing..",
+	}
+	for _, id := range accepted {
+		if err := ValidateID(id); err != nil {
+			t.Errorf("ValidateID(%q) = %v, want nil", id, err)
+		}
+	}
+}

--- a/cli/internal/evalsubstrate/modelspec.go
+++ b/cli/internal/evalsubstrate/modelspec.go
@@ -4,19 +4,34 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
 )
 
-func ModelSpecPath(evalsRoot, specID string) string {
-	return filepath.Join(evalsRoot, "models", specID, "spec.yaml")
+// ModelSpecPath is the single checked sink for model-spec paths: it validates
+// and encodes the id, so there is no way to build a model-spec path from an
+// unvalidated id. Model-spec ids may contain ':' (for example "ms:stable"),
+// which is a Windows alternate-data-stream separator, so ':' is percent-encoded
+// to "%3A" before it becomes a directory name. The encoding is one-way and
+// internal: both CaptureModelSpec (write) and LoadModelSpec (read) resolve
+// through here, so the raw ':' form never reaches the filesystem and is never
+// decoded back — no decoder is needed. Returns an error for any id that is not a
+// safe single path component after encoding.
+func ModelSpecPath(evalsRoot, specID string) (string, error) {
+	component := strings.ReplaceAll(specID, ":", "%3A")
+	if err := ValidateID(component); err != nil {
+		return "", fmt.Errorf("model-spec id %q: %w", specID, err)
+	}
+	return filepath.Join(evalsRoot, "models", component, "spec.yaml"), nil
 }
 
 // CaptureModelSpec writes the ModelSpec to disk after stamping content_hash.
 // Returns (specID, contentHash) for Manifest.ModelSpecRef + Manifest.ModelSpecHash.
 func CaptureModelSpec(evalsRoot string, spec *ModelSpec) (string, string, error) {
-	if err := ValidateID(spec.ID); err != nil {
+	dest, err := ModelSpecPath(evalsRoot, spec.ID)
+	if err != nil {
 		return "", "", fmt.Errorf("CaptureModelSpec: %w", err)
 	}
 	if spec.SchemaVersion == 0 {
@@ -49,7 +64,6 @@ func CaptureModelSpec(evalsRoot string, spec *ModelSpec) (string, string, error)
 	if err != nil {
 		return "", "", fmt.Errorf("CaptureModelSpec: re-canonicalize: %w", err)
 	}
-	dest := ModelSpecPath(evalsRoot, spec.ID)
 	if err := WriteAtomic(dest, finalCanon); err != nil {
 		return "", "", fmt.Errorf("CaptureModelSpec: write: %w", err)
 	}
@@ -57,10 +71,11 @@ func CaptureModelSpec(evalsRoot string, spec *ModelSpec) (string, string, error)
 }
 
 func LoadModelSpec(evalsRoot, specID string) (*ModelSpec, error) {
-	if err := ValidateID(specID); err != nil {
+	path, err := ModelSpecPath(evalsRoot, specID)
+	if err != nil {
 		return nil, fmt.Errorf("LoadModelSpec: %w", err)
 	}
-	raw, err := os.ReadFile(ModelSpecPath(evalsRoot, specID))
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("LoadModelSpec: %w", err)
 	}

--- a/cli/internal/evalsubstrate/modelspec.go
+++ b/cli/internal/evalsubstrate/modelspec.go
@@ -20,6 +20,12 @@ import (
 // decoded back — no decoder is needed. Returns an error for any id that is not a
 // safe single path component after encoding.
 func ModelSpecPath(evalsRoot, specID string) (string, error) {
+	// '%' is reserved in raw ids so the ':'→"%3A" encoding stays injective:
+	// otherwise the raw id "ms%3Astable" would alias the encoded form of
+	// "ms:stable" and two distinct ids could address one on-disk entry.
+	if strings.Contains(specID, "%") {
+		return "", fmt.Errorf("model-spec id %q contains a reserved '%%' character", specID)
+	}
 	component := strings.ReplaceAll(specID, ":", "%3A")
 	if err := ValidateID(component); err != nil {
 		return "", fmt.Errorf("model-spec id %q: %w", specID, err)

--- a/cli/internal/evalsubstrate/modelspec.go
+++ b/cli/internal/evalsubstrate/modelspec.go
@@ -16,8 +16,8 @@ func ModelSpecPath(evalsRoot, specID string) string {
 // CaptureModelSpec writes the ModelSpec to disk after stamping content_hash.
 // Returns (specID, contentHash) for Manifest.ModelSpecRef + Manifest.ModelSpecHash.
 func CaptureModelSpec(evalsRoot string, spec *ModelSpec) (string, string, error) {
-	if spec.ID == "" {
-		return "", "", fmt.Errorf("CaptureModelSpec: empty id")
+	if err := ValidateID(spec.ID); err != nil {
+		return "", "", fmt.Errorf("CaptureModelSpec: %w", err)
 	}
 	if spec.SchemaVersion == 0 {
 		spec.SchemaVersion = SchemaVersion
@@ -57,6 +57,9 @@ func CaptureModelSpec(evalsRoot string, spec *ModelSpec) (string, string, error)
 }
 
 func LoadModelSpec(evalsRoot, specID string) (*ModelSpec, error) {
+	if err := ValidateID(specID); err != nil {
+		return nil, fmt.Errorf("LoadModelSpec: %w", err)
+	}
 	raw, err := os.ReadFile(ModelSpecPath(evalsRoot, specID))
 	if err != nil {
 		return nil, fmt.Errorf("LoadModelSpec: %w", err)

--- a/cli/internal/evalsubstrate/modelspec_test.go
+++ b/cli/internal/evalsubstrate/modelspec_test.go
@@ -3,6 +3,7 @@ package evalsubstrate
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -31,9 +32,13 @@ func TestCaptureModelSpec_StampsHashAndPersists(t *testing.T) {
 	if spec.ContentHash != hash {
 		t.Fatalf("spec.ContentHash not stamped: %s vs %s", spec.ContentHash, hash)
 	}
-	dest := ModelSpecPath(root, spec.ID)
-	if dest != filepath.Join(root, "models", spec.ID, "spec.yaml") {
-		t.Fatalf("unexpected path: %s", dest)
+	dest, err := ModelSpecPath(root, spec.ID)
+	if err != nil {
+		t.Fatalf("ModelSpecPath: %v", err)
+	}
+	wantDest := filepath.Join(root, "models", strings.ReplaceAll(spec.ID, ":", "%3A"), "spec.yaml")
+	if dest != wantDest {
+		t.Fatalf("unexpected path: %s (want %s)", dest, wantDest)
 	}
 	loaded, err := LoadModelSpec(root, spec.ID)
 	if err != nil {
@@ -86,6 +91,44 @@ func TestCaptureModelSpec_RejectsTraversalIDWithoutWriting(t *testing.T) {
 func TestLoadModelSpec_RejectsTraversalID(t *testing.T) {
 	if _, err := LoadModelSpec(t.TempDir(), "../../../etc/passwd"); err == nil {
 		t.Fatal("LoadModelSpec accepted a traversal id; want rejection")
+	}
+}
+
+func TestModelSpecPath_IsCheckedAndEncodesColon(t *testing.T) {
+	// The colon in a legitimate model-spec id is encoded to a path-safe token, so
+	// no raw ':' (a Windows alternate-data-stream separator) reaches the filesystem.
+	got, err := ModelSpecPath("/root", "ms:stable")
+	if err != nil {
+		t.Fatalf("ModelSpecPath(ms:stable) = %v, want success", err)
+	}
+	want := filepath.Join("/root", "models", "ms%3Astable", "spec.yaml")
+	if got != want {
+		t.Fatalf("ModelSpecPath encoding: got %q, want %q", got, want)
+	}
+	if strings.ContainsRune(got, ':') && filepath.VolumeName(got) == "" {
+		t.Fatalf("encoded model-spec path still contains a raw ':': %q", got)
+	}
+	// The sink is the only constructor and it rejects unsafe ids: there is no
+	// unchecked join to bypass.
+	for _, bad := range []string{"../../escape", "..", "a/b", ""} {
+		if _, err := ModelSpecPath("/root", bad); err == nil {
+			t.Errorf("ModelSpecPath(%q) = nil error; the checked sink must reject it", bad)
+		}
+	}
+}
+
+func TestCaptureLoadModelSpec_ColonIDRoundTripsThroughEncoding(t *testing.T) {
+	root := t.TempDir()
+	spec := &ModelSpec{ID: "ms:stable", Provider: "local-mlx", ModelName: "test"}
+	if _, _, err := CaptureModelSpec(root, spec); err != nil {
+		t.Fatalf("CaptureModelSpec(ms:stable): %v", err)
+	}
+	// On-disk directory is the encoded form; the raw-colon path never exists.
+	if _, err := os.Stat(filepath.Join(root, "models", "ms%3Astable", "spec.yaml")); err != nil {
+		t.Fatalf("encoded spec file missing: %v", err)
+	}
+	if _, err := LoadModelSpec(root, "ms:stable"); err != nil {
+		t.Fatalf("LoadModelSpec(ms:stable) did not round-trip through the encoder: %v", err)
 	}
 }
 

--- a/cli/internal/evalsubstrate/modelspec_test.go
+++ b/cli/internal/evalsubstrate/modelspec_test.go
@@ -109,8 +109,10 @@ func TestModelSpecPath_IsCheckedAndEncodesColon(t *testing.T) {
 		t.Fatalf("encoded model-spec path still contains a raw ':': %q", got)
 	}
 	// The sink is the only constructor and it rejects unsafe ids: there is no
-	// unchecked join to bypass.
-	for _, bad := range []string{"../../escape", "..", "a/b", ""} {
+	// unchecked join to bypass. "ms%3Astable" must be rejected, not aliased:
+	// accepting it would let a raw id collide with the encoded form of
+	// "ms:stable" (the encoding must stay injective).
+	for _, bad := range []string{"../../escape", "..", "a/b", "", "ms%3Astable", "50%"} {
 		if _, err := ModelSpecPath("/root", bad); err == nil {
 			t.Errorf("ModelSpecPath(%q) = nil error; the checked sink must reject it", bad)
 		}

--- a/cli/internal/evalsubstrate/modelspec_test.go
+++ b/cli/internal/evalsubstrate/modelspec_test.go
@@ -1,6 +1,7 @@
 package evalsubstrate
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -66,6 +67,25 @@ func TestCaptureModelSpec_StableAcrossRecaptures(t *testing.T) {
 	}
 	if h1 != h2 {
 		t.Fatalf("re-capture hash mismatch: %s vs %s", h1, h2)
+	}
+}
+
+func TestCaptureModelSpec_RejectsTraversalIDWithoutWriting(t *testing.T) {
+	root := t.TempDir()
+	spec := &ModelSpec{ID: "../../escape", Provider: "local-mlx", ModelName: "test"}
+	if _, _, err := CaptureModelSpec(root, spec); err == nil {
+		t.Fatal("CaptureModelSpec accepted a traversal id; want rejection")
+	}
+	// The would-be escape target (root/../escape/spec.yaml) must not exist.
+	escaped := filepath.Join(root, "..", "escape", "spec.yaml")
+	if _, err := os.Stat(escaped); err == nil {
+		t.Fatalf("traversal id escaped the eval root: %s exists", escaped)
+	}
+}
+
+func TestLoadModelSpec_RejectsTraversalID(t *testing.T) {
+	if _, err := LoadModelSpec(t.TempDir(), "../../../etc/passwd"); err == nil {
+		t.Fatal("LoadModelSpec accepted a traversal id; want rejection")
 	}
 }
 

--- a/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/s12-go-residue.md
+++ b/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/s12-go-residue.md
@@ -78,3 +78,27 @@ reaped on timeout.
 - `cd cli && go test ./...` — 2870 passed across 70 packages.
 - `scripts/golangci-lint-v2.sh run` (touched packages) — 0 issues.
 - `scripts/generate-cli-reference.sh --check` — `cli/docs/COMMANDS.md` up to date.
+
+## Cross-family review round 1 — disposition
+
+Cross-family review returned REQUEST_CHANGES with three findings on the finding-1
+`ValidateID`. All three addressed in commit 2 (`fix(eval): harden id validation —
+portable grammar, checked path sinks`).
+
+| Review finding | Verdict | Change |
+|---|---|---|
+| [High] Windows traversal: `ValidateID(".. ")` passed but Win32 strips trailing spaces/dots → `".."`; and raw `:` (allowed for `ms:*`) is a Windows alternate-data-stream separator reaching the path join. | **FIXED** | `ValidateID` now rejects any leading/trailing space or dot (subsumes `.`/`..`) and rejects raw `:`. `:` is handled by encoding, not by banning `ms:*` ids: `ModelSpecPath` percent-encodes `:` → `%3A` (documented one-way, never decoded — reads and writes both route through it) so the raw `:` never becomes a path component. Design chosen as the smallest sound option and documented in both function comments. |
+| [Medium] Canonicality & bounds: whitespace-only, overlong, C1 controls (U+0080–U+009F, missed by a C0-only check), and non-NFC input. | **FIXED** | `ValidateID` now rejects empty/whitespace-only (via leading/trailing-space rule), ids > 128 bytes (`maxIDBytes`), invalid UTF-8, C0 + DEL + **C1** controls (`r < 0x20 || (r >= 0x7f && r <= 0x9f)`), and non-NFC input via `golang.org/x/text/unicode/norm` (`norm.NFC.IsNormalString`). NFC input is **rejected, not normalized** (documented), so two visually identical ids can never address two distinct on-disk entries. `golang.org/x/text v0.40.0` was already in `go.mod` — no new dependency. |
+| [Medium] Enforce at the sink: exported `ModelSpecPath(evalsRoot, specID)` still did an unchecked join. | **FIXED** | `ModelSpecPath` now returns `(string, error)`, validates + encodes inside, and is the only model-spec path constructor (no bypass). Its two callers (`CaptureModelSpec`, `LoadModelSpec`) were migrated to the error-returning form. **Sweep of other exported evalsubstrate id→path joiners:** `ManifestPath`/`RunDir` take run ids produced by `GenerateRunID` (which already sanitizes `/`, ` `, `:` → `-` and truncates rig-id to 8, so its output is always a safe single component) or read back from trusted on-disk `runs/` listings — never a raw external identifier — so they are not an id-injection sink and were left unchanged. `CanonicalizePath` canonicalizes an already-formed path, not an id, and is out of scope. |
+
+New rejection/acceptance classes are witnessed in `id_test.go`
+(`TestValidateID_RejectsUnsafeComponents` / `TestValidateID_AcceptsCanonicalIDs`:
+trailing/leading dot & space, whitespace-only, overlong, C1 control, DEL, raw
+colon, non-NFC-rejected vs NFC-accepted, encoded-colon accepted) and in
+`modelspec_test.go` (`TestModelSpecPath_IsCheckedAndEncodesColon` — encoding +
+no-bypass; `TestCaptureLoadModelSpec_ColonIDRoundTripsThroughEncoding` — the
+`ms:stable` alias round-trips to the encoded on-disk name).
+
+Round-1 gates: `go build ./...` Success; `go vet ./...` no issues; `go test ./...`
+2872 passed across 70 packages; `golangci-lint-v2.sh run` (evalsubstrate, eval) 0
+issues.

--- a/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/s12-go-residue.md
+++ b/docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/s12-go-residue.md
@@ -1,0 +1,80 @@
+# S12 — Go CLI audit residue reconciliation
+
+- Bead: `age-skill-overhaul-reboot-sjv7v.12`
+- Date: 2026-07-28
+- Branch: `claude/sor-s12-go-residue`
+- Source audit: `docs/audits/2026-07-24-go-cli-deep-audit.md` (8 findings, one G0/G1/G2 release program)
+- Method: reconcile each audit finding against today's `main` (audit ran on an
+  older tree; `main` has since merged the eval hardening wave — LAW-0 spawn
+  guard, crash-safe 0600 burn-ledger writes — the CLI "residue wave", and skill
+  PRs #998–#1006). Verdict per finding: FIXED (already landed), FIXED-HERE,
+  NOT-APPLICABLE, or OPEN. Still-present findings that are small and bounded were
+  fixed here with a focused test; findings whose honest fix is a cross-package
+  refactor are recorded OPEN with a reproduction and a fix sketch.
+
+## Result: 4 fixed here, 1 already landed, 3 open
+
+| # | Finding (severity) | Verdict | Evidence |
+|---|---|---|---|
+| 1 | eval IDs permit filesystem escape (High) | **FIXED-HERE** | Was still-present: `task_service.go` / `suite_service.go` / `evalsubstrate/modelspec.go` joined caller-supplied YAML IDs into store paths with only a non-empty check, and `adapters/eval/runtime.go` `ReadFile`=`os.ReadFile`, `Root()`=`~/.agents/evals`. Added `evalsubstrate.ValidateID` (rejects separators, `.`/`..`, absolute paths, Windows volume names, control chars; permits colons for `ms:*` IDs) and applied it at `TaskService.Add`, `TaskService.loadTask`, `TaskService.loadSuite` (id branch), `SuiteService.loadSuite` (id branch), `CaptureModelSpec`, `LoadModelSpec`. Tests prove `../../escape` is rejected before any write escapes. |
+| 2a | global `--dry-run` ignored — `provenance add` (High) | **FIXED-HERE** | `provenance_composition.go` never wired `DryRun`; `runAdd` unconditionally called `ledgerStore().Append`. Wired `DryRun: GetDryRun` and made `runAdd` honor it (emit the would-be edge, perform no write). Test asserts the ledger file is not created under `--dry-run`. |
+| 2b | global `--dry-run` ignored — `gate check` (High) | **OPEN** | `gate_composition.go:26` wires `DryRun`, but `commands/gate/module.go` `newCheckCommand` RunE never consults `module.host.DryRun`; `ao gate check --dry-run` still executes the check registry (process/filesystem effects). Fix crosses into the check service (a plan-only "which checks would run" mode) — larger than a bounded leaf fix. |
+| 3 | `--json` and `-o json` not equivalent across read commands (Medium) | **FIXED** (already landed) | The carve-out's `emitStructured` (`commands/provenance/module.go:106-116`) and the skills module now honor **both** the local `--json` and global `-o json`/`-o yaml`. Runtime probes on this tree: `provenance list`, `skills list`, and `skills check` emit byte-identical JSON for `--json` and `-o json`. Residuals (minor, not fixed): `config --json` and `config -o json` both print human help with exit 0 (`config` is a pure parent group, now consistent, not a data leaf); and `eval scenario-ab`/`scenario-moat`/`session-outcome` still define a **local** `--output` that means a file path for two of them and a text/json format for the third (`commands/eval/module.go:787,834,863`) — a cosmetic shadow of the global `--output`, not an automation break. |
+| 4 | output limits applied after unbounded buffering (Medium) | **OPEN** | Still-present: `goals/measure.go:159-161`, `gates/scriptrunner.go:147-149`, `eval/engine.go:224-227`, `eval/expectations.go:527` each capture into an unbounded `bytes.Buffer` and truncate/tail only after `Wait`/`Run`. Cross-package; fix is a shared bounded tail/ring writer. |
+| 5 | eval cancellation orphans descendants / ignores caller ctx (Medium) | **OPEN** | Still-present: `eval/core_service.go:78` `Run(_ context.Context, …)` discards the caller context; `eval/engine.go:20` `RunSuite` has no context parameter; `engine.go:203` and `expectations.go:512` derive timeouts from `context.Background()`; `engine.go:211` and `expectations.go:515` use `exec.CommandContext` with no process-group cleanup or `WaitDelay`. Cross-package subprocess-runner refactor (goals already has the reference pattern). |
+| 6 | auto-created live-runtime isolation dirs leak (Medium) | **FIXED-HERE** | Was still-present: `eval/runtime.go` `liveRuntimeEnv` created `agentops-eval-runtime-*` via `os.MkdirTemp` when no `IsolationRoot` was supplied and returned only `(env, notes, err)`; the caller had no cleanup path. `liveRuntimeEnv` now reports an `ownedRoot` (empty for caller-supplied roots), the caller defers `removeOwnedRoot`, and partial-setup errors clean up the temp dir. Tests prove ownership detection and that a caller-supplied root is never claimed. |
+| 7 | eval help references a nonexistent command (Low) | **FIXED-HERE** | Was still-present: `commands/eval/module.go:492` `--model-spec` help said "already captured via `ao eval models capture`" — a command that is not registered. Replaced with accurate text ("resolved from `<evals-root>/models/<id>/spec.yaml`") and regenerated `cli/docs/COMMANDS.md` through its owning generator (`scripts/generate-cli-reference.sh`). |
+
+## Fixes landed in this branch
+
+- `cli/internal/evalsubstrate/id.go` (new) — `ValidateID` containment helper.
+- `cli/internal/evalsubstrate/id_test.go` (new) — rejection + acceptance table (incl. `ms:stable` colon IDs).
+- `cli/internal/eval/task_service.go` — `ValidateID` at `Add`, `loadTask`, `loadSuite`.
+- `cli/internal/eval/suite_service.go` — `ValidateID` at `loadSuite`.
+- `cli/internal/evalsubstrate/modelspec.go` — `ValidateID` at `CaptureModelSpec`, `LoadModelSpec`.
+- `cli/internal/eval/task_service_test.go`, `cli/internal/evalsubstrate/modelspec_test.go` — traversal-rejection boundary tests (assert no escaping write).
+- `cli/cmd/ao/provenance_composition.go` + `cli/internal/commands/provenance/module.go` (+ test) — `--dry-run` now suppresses the provenance-add ledger write.
+- `cli/internal/eval/runtime.go` (+ test) — internally created live-runtime isolation roots are owned and removed after the run.
+- `cli/internal/commands/eval/module.go` + `cli/docs/COMMANDS.md` — corrected `--model-spec` help.
+
+## OPEN items — reproductions and fix sketches
+
+### 2b — `ao gate check --dry-run` runs the checks
+Reproduction: `ao gate check --dry-run` executes the full deterministic check
+registry (process spawns, `go build`, git ops) exactly as without the flag,
+because `commands/gate/module.go` `newCheckCommand` never reads
+`module.host.DryRun`. Sketch: add a `Plan`/dry-run request field to
+`gateapp.CheckRequest`; when set, the check service returns the selected check
+IDs and their declared effects **without** executing script runners, and the
+module renders that plan. This is the honest form of "show what would happen"
+and it also unblocks the audit's effect-metadata roadmap item.
+
+### 4 — unbounded subprocess output buffering
+Reproduction: a check/goal/eval command whose subprocess writes gigabytes to
+stdout is buffered in full (`bytes.Buffer`) before the 4 KiB / `truncateOutput`
+trim, so peak CLI memory is unbounded regardless of the post-trim cap. Sketch:
+a shared `boundedTailWriter` (fixed ring capacity + a "truncated, original N
+bytes" flag) used as `cmd.Stdout`/`cmd.Stderr` across `goals/measure.go`,
+`gates/scriptrunner.go`, and `eval/engine.go` + `eval/expectations.go`. Test: a
+child that emits > cap bytes; assert bounded retained size and a truncation
+marker.
+
+### 5 — caller cancellation ignored, grandchildren orphaned
+Reproduction: cancelling the context passed to `CoreService.Run` (or any
+`engine.RunSuite` path) does not stop the eval subprocess, and a timed-out
+command that spawned a grandchild leaves it running with pipes open, because the
+timeout comes from `context.Background()` and `exec.CommandContext` kills only
+the direct child. Sketch: thread the caller context through `RunSuite` and the
+`core_service` use cases, and route all eval subprocess launches through the
+same runner `goals/measure.go` already uses (`configureProcGroup` +
+`cmd.WaitDelay` + PID tracking + signal-based process-group cleanup). Test: a
+child that starts a grandchild keeping stdout open; assert the grandchild is
+reaped on timeout.
+
+## Gates (this branch)
+
+- `cd cli && go build ./...` — Success.
+- `cd cli && go vet ./...` — no issues.
+- `cd cli && go test ./...` — 2870 passed across 70 packages.
+- `scripts/golangci-lint-v2.sh run` (touched packages) — 0 issues.
+- `scripts/generate-cli-reference.sh --check` — `cli/docs/COMMANDS.md` up to date.


### PR DESCRIPTION
## Summary

Bead `age-skill-overhaul-reboot-sjv7v.12` — reconciliation of the 2026-07-24 Go CLI deep audit against current main. Full table with evidence: `docs/audits/2026-07-28-skill-overhaul-reboot/wave-reports/s12-go-residue.md`.

**Fixed here (4):**
- **Eval identifier path containment** [High] — new `evalsubstrate.ValidateID` at every identifier-to-path join, hardened through two review rounds: rejects separators, absolute/volume refs, leading/trailing space-or-dot (defeats Win32 trailing-strip renormalization), C0+C1+DEL controls, non-UTF-8, non-NFC, whitespace-only, >128 bytes; `ms:*` colons handled by injective one-way `%3A` encoding at the checked `ModelSpecPath` sink (raw `%` reserved so encoding cannot alias), both callers migrated, no unchecked join remains.
- **`provenance add --dry-run`** [High] — was wired but never read; now honored with a no-write witness test.
- **Live-runtime isolation dirs** — owned, cleaned on all paths, never claims a caller-supplied root.
- **Stale eval help text** — corrected; COMMANDS.md regenerated via its owner.

**Already landed (1):** the `--json`/`-o json` divergence for provenance/skills was resolved by the cmd/ao carve-out (probes confirm identical output).

**Recorded OPEN with reproductions (3):** `gate check --dry-run` plan-only mode, bounded subprocess output streaming, and context/process-group cancellation — each a cross-package refactor (the audit's own G1/G2 programs), documented with fix sketches rather than half-fixed here.

## Validation

- `go build` / `go vet` clean; `go test ./...` 2872+ pass across 70 packages; golangci-lint 0 issues on touched packages; CLI reference check current
- Cross-family review two rounds: round 1 three findings (Windows renormalization traversal, canonicality bounds, unchecked sink) all fixed; round 2's one residual (non-injective colon encoding) fixed with witness cases

Tracker: `age-skill-overhaul-reboot-sjv7v.12`