### PR TITLE
ao gate check --dry-run: real plan-only mode

### DIFF
--- a/cli/internal/commands/gate/module.go
+++ b/cli/internal/commands/gate/module.go
@@ -47,7 +47,10 @@ func (Module) Contract() clicontract.CommandContract {
 // selected checks pass, 1 when a check fails, or 2 on an invalid gate
 // configuration (for example a bad --scope value). Command-line misuse such as
 // an unknown flag or an extra positional arg exits 1 via cobra, not 2, so exit
-// 2 is not a generic "usage" class.
+// 2 is not a generic "usage" class. Under the global --dry-run flag the command
+// instead projects the selection plan (which checks would run, with reasons)
+// WITHOUT executing any check, and exits 0 on a successful plan — the declared
+// effects below describe the default, non-dry-run path.
 func (Module) CheckContract() clicontract.CommandContract {
 	return clicontract.CommandContract{
 		ID:       "ao.gate.check",
@@ -107,12 +110,32 @@ func (module Module) newCheckCommand() *cobra.Command {
 			if module.useCases.Check == nil {
 				return &clicontract.ExitError{Code: 2, Message: "gate check: use case not configured", Label: "ao gate"}
 			}
+			dryRun := module.host.DryRun != nil && module.host.DryRun()
 			result, err := module.useCases.Check.Execute(command.Context(), gateapp.CheckRequest{
 				Full: full, Scope: scope, FailFast: failFast,
 				WorkflowCoverage: workflowCoverage, RequireWorkflowParity: requireWorkflowParity, WorkflowPath: workflowPath,
+				Plan: dryRun,
 			})
 			if err != nil {
 				return &clicontract.ExitError{Code: 2, Message: err.Error(), Label: "ao gate"}
+			}
+			if dryRun {
+				// Dry-run: render the selection plan and exit 0. No check ran, so
+				// there is no verdict to map — a successful plan is success
+				// regardless of what the planned checks would return.
+				if result.Plan == nil {
+					return &clicontract.ExitError{Code: 2, Message: "gate check: dry-run produced no plan", Label: "ao gate"}
+				}
+				if jsonOutput {
+					raw, jsonErr := result.Plan.JSON()
+					if jsonErr != nil {
+						return &clicontract.ExitError{Code: 2, Message: jsonErr.Error(), Label: "ao gate"}
+					}
+					fmt.Fprintln(command.OutOrStdout(), string(raw))
+				} else {
+					result.Plan.Human(command.OutOrStdout())
+				}
+				return nil
 			}
 			if jsonOutput {
 				raw, jsonErr := result.Report.JSON()

--- a/cli/internal/commands/gate/module_test.go
+++ b/cli/internal/commands/gate/module_test.go
@@ -1,19 +1,51 @@
 package gate
 
 import (
-	"github.com/boshu2/agentops/cli/internal/clicontract"
+	"bytes"
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/boshu2/agentops/cli/internal/clicontract"
 	gateapp "github.com/boshu2/agentops/cli/internal/gate"
 	"github.com/boshu2/agentops/cli/internal/gates"
 )
 
-type fakeChecks struct{ calls int }
+type fakeChecks struct {
+	calls    int
+	lastReq  gateapp.CheckRequest
+	planResp *gates.Plan
+	report   *gates.Report
+}
 
-func (fake *fakeChecks) Execute(context.Context, gateapp.CheckRequest) (gateapp.CheckResult, error) {
+func (fake *fakeChecks) Execute(_ context.Context, req gateapp.CheckRequest) (gateapp.CheckResult, error) {
 	fake.calls++
-	return gateapp.CheckResult{Report: &gates.Report{}}, nil
+	fake.lastReq = req
+	if req.Plan {
+		plan := fake.planResp
+		if plan == nil {
+			plan = &gates.Plan{}
+		}
+		return gateapp.CheckResult{Plan: plan}, nil
+	}
+	report := fake.report
+	if report == nil {
+		report = &gates.Report{}
+	}
+	return gateapp.CheckResult{Report: report}, nil
+}
+
+func runCheck(t *testing.T, fake *fakeChecks, host clicontract.HostOptions, args ...string) string {
+	t.Helper()
+	command := NewModule(UseCases{Check: fake}, host).Command()
+	var out bytes.Buffer
+	command.SetOut(&out)
+	command.SetErr(&out)
+	command.SetArgs(append([]string{"check"}, args...))
+	if err := command.Execute(); err != nil {
+		t.Fatalf("execute check %v: %v", args, err)
+	}
+	return out.String()
 }
 
 func TestGateExposesOnlyDeterministicCheck(t *testing.T) {
@@ -29,5 +61,63 @@ func TestGateExposesOnlyDeterministicCheck(t *testing.T) {
 	}
 	if fake.calls != 1 {
 		t.Fatalf("check calls = %d, want 1", fake.calls)
+	}
+	// No --dry-run seam wired means the module never requests a plan.
+	if fake.lastReq.Plan {
+		t.Fatalf("check requested a plan without a DryRun seam: %+v", fake.lastReq)
+	}
+}
+
+func TestGateCheckDryRunRequestsAndRendersPlan(t *testing.T) {
+	fake := &fakeChecks{planResp: &gates.Plan{
+		Mode:  gates.Fast,
+		Scope: gates.ScopeHead,
+		Selected: []gates.PlanCheck{{
+			Name: "go.vet", Tier: "fast,full", Blocking: true,
+			Reason:          "selected: changed file \"cli/main.go\" matched \"cli/**\"",
+			WorkflowBacking: "bash scripts/check-go.sh", ArtifactPath: "scripts/check-go.sh", RepairHint: "bash scripts/check-go.sh",
+		}},
+	}}
+	host := clicontract.HostOptions{DryRun: func() bool { return true }}
+
+	out := runCheck(t, fake, host)
+	if !fake.lastReq.Plan {
+		t.Fatalf("dry-run did not request a plan: %+v", fake.lastReq)
+	}
+	for _, want := range []string{"dry-run — no checks executed", "would run:", "RUN   go.vet", "blocking"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("human plan output missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestGateCheckDryRunJSONRendersPlan(t *testing.T) {
+	fake := &fakeChecks{planResp: &gates.Plan{
+		Mode:     gates.Fast,
+		Scope:    gates.ScopeHead,
+		Selected: []gates.PlanCheck{{Name: "go.vet", Tier: "fast,full", Blocking: true, Reason: "selected"}},
+	}}
+	host := clicontract.HostOptions{DryRun: func() bool { return true }}
+
+	out := runCheck(t, fake, host, "--json")
+	if !fake.lastReq.Plan {
+		t.Fatalf("dry-run --json did not request a plan: %+v", fake.lastReq)
+	}
+	for _, want := range []string{"\"dry_run\": true", "\"name\": \"go.vet\"", "\"selected_count\": 1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("json plan output missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestGateCheckWithoutDryRunRunsAndDoesNotRequestPlan(t *testing.T) {
+	fake := &fakeChecks{}
+	host := clicontract.HostOptions{DryRun: func() bool { return false }}
+	_ = runCheck(t, fake, host)
+	if fake.calls != 1 {
+		t.Fatalf("check calls = %d, want 1", fake.calls)
+	}
+	if fake.lastReq.Plan {
+		t.Fatalf("non-dry-run must not request a plan: %+v", fake.lastReq)
 	}
 }

--- a/cli/internal/gate/check_service.go
+++ b/cli/internal/gate/check_service.go
@@ -28,12 +28,22 @@ type CheckRequest struct {
 	WorkflowCoverage      bool
 	RequireWorkflowParity bool
 	WorkflowPath          string
+	// Plan requests a dry-run projection: resolve the checks that would run for
+	// this invocation and return them in CheckResult.Plan WITHOUT executing any
+	// check. Scope, tier, and changed-file routing are resolved exactly as a real
+	// run resolves them, so the plan can never drift from what a run would select.
+	Plan bool
 }
 
 type CheckResult struct {
 	Report                *gates.Report
 	ExitCode              int
 	WorkflowParityMissing int
+	// Plan is populated (and Report is nil) when the request set Plan: it is the
+	// dry-run projection of the run. A plan always carries ExitCode 0 — a
+	// successful plan is success regardless of what the planned checks would
+	// return.
+	Plan *gates.Plan
 }
 
 func (service CheckService) Execute(ctx context.Context, request CheckRequest) (CheckResult, error) {
@@ -55,6 +65,16 @@ func (service CheckService) Execute(ctx context.Context, request CheckRequest) (
 		mode = gates.Full
 	}
 	orchestrator := gates.NewOrchestrator(service.Registry, service.Runner, service.Files, service.RepoRoot)
+	if request.Plan {
+		// Dry-run: project the selection WITHOUT executing any check. Plan reuses
+		// the same tier filter and changed-file routing as Run, so it never runs a
+		// script runner and exits 0 on a successful plan.
+		plan, planErr := orchestrator.Plan(ctx, gates.RunOptions{Mode: mode, Scope: scope, FailFast: request.FailFast})
+		if planErr != nil {
+			return CheckResult{}, fmt.Errorf("gate check: %w", planErr)
+		}
+		return CheckResult{Plan: plan, ExitCode: 0}, nil
+	}
 	report, err := orchestrator.Run(ctx, gates.RunOptions{Mode: mode, Scope: scope, FailFast: request.FailFast})
 	if err != nil {
 		return CheckResult{}, fmt.Errorf("gate check: %w", err)

--- a/cli/internal/gate/check_service_test.go
+++ b/cli/internal/gate/check_service_test.go
@@ -89,6 +89,156 @@ func TestCheckServiceWorkflowParityCanFailResult(t *testing.T) {
 	}
 }
 
+// registryWithSideEffect registers a native check that records whether it ran
+// (a stand-in for any real filesystem/process effect) and returns status. Under
+// a dry-run plan the recorder must stay false.
+func registryWithSideEffect(t *testing.T, ran *bool, status ports.GateStatus, blocking bool) *gates.Registry {
+	t.Helper()
+	registry := gates.NewRegistry()
+	if err := registry.Add(gates.Check{
+		ID: "native", Tiers: gates.Fast | gates.Full, Blocking: blocking,
+		Run: func(context.Context, gates.RunContext) (ports.GateVerdict, error) {
+			*ran = true
+			return ports.GateVerdict{Status: status, Reason: "side effect fired"}, nil
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return registry
+}
+
+// TestCheckServicePlanExecutesNothingAndExitsZero is witness (1)+(3): under
+// --dry-run a check that would FAIL and fire a side effect does neither, the
+// plan is returned with exit 0, and the same request WITHOUT --dry-run is
+// unchanged (the check runs, the blocking FAIL maps to exit 1, no plan).
+func TestCheckServicePlanExecutesNothingAndExitsZero(t *testing.T) {
+	var ran bool
+	service := CheckService{
+		Registry: registryWithSideEffect(t, &ran, ports.GateStatusFail, true),
+		Files:    changedFilesStub{files: []string{"cli/main.go"}},
+		Runtime:  &checkRuntimeStub{},
+	}
+
+	planResult, err := service.Execute(context.Background(), CheckRequest{Full: true, Scope: "head", Plan: true})
+	if err != nil {
+		t.Fatalf("Execute(plan): %v", err)
+	}
+	if ran {
+		t.Fatal("dry-run executed the check: the side effect fired")
+	}
+	if planResult.Plan == nil {
+		t.Fatal("plan result carried no plan")
+	}
+	if planResult.Report != nil {
+		t.Fatal("plan result must not carry a run report")
+	}
+	if planResult.ExitCode != 0 {
+		t.Fatalf("plan exit = %d, want 0 even though the check would FAIL", planResult.ExitCode)
+	}
+	if len(planResult.Plan.Selected) != 1 || planResult.Plan.Selected[0].Name != "native" {
+		t.Fatalf("plan selected = %+v, want the native check", planResult.Plan.Selected)
+	}
+	if !planResult.Plan.Selected[0].Blocking {
+		t.Fatal("plan entry lost the blocking fact")
+	}
+
+	ran = false
+	runResult, err := service.Execute(context.Background(), CheckRequest{Full: true, Scope: "head"})
+	if err != nil {
+		t.Fatalf("Execute(run): %v", err)
+	}
+	if !ran {
+		t.Fatal("non-dry-run did not execute the check")
+	}
+	if runResult.Plan != nil {
+		t.Fatal("non-dry-run must not carry a plan")
+	}
+	if runResult.Report == nil || runResult.ExitCode != 1 {
+		t.Fatalf("non-dry-run result=%+v, want a report with exit 1", runResult)
+	}
+}
+
+// TestCheckServicePlanSelectionDiffersByInvocation is witness (2): the plan
+// lists the expected selection for two different invocations (default fast vs
+// --full).
+func TestCheckServicePlanSelectionDiffersByInvocation(t *testing.T) {
+	registry := gates.NewRegistry()
+	add := func(c gates.Check) {
+		if err := registry.Add(c); err != nil {
+			t.Fatal(err)
+		}
+	}
+	noop := func(context.Context, gates.RunContext) (ports.GateVerdict, error) {
+		return ports.GateVerdict{Status: ports.GateStatusPass, Reason: "ok"}, nil
+	}
+	add(gates.Check{ID: "always", Tiers: gates.Fast | gates.Full, Blocking: true, Run: noop})
+	add(gates.Check{ID: "fullonly", Tiers: gates.Full, Blocking: true, Run: noop})
+
+	service := CheckService{Registry: registry, Files: changedFilesStub{}, Runtime: &checkRuntimeStub{}}
+
+	fast, err := service.Execute(context.Background(), CheckRequest{Scope: "head", Plan: true})
+	if err != nil {
+		t.Fatalf("Execute(fast plan): %v", err)
+	}
+	full, err := service.Execute(context.Background(), CheckRequest{Full: true, Plan: true})
+	if err != nil {
+		t.Fatalf("Execute(full plan): %v", err)
+	}
+
+	if got := selectedNames(fast.Plan); !equalStrings(got, []string{"always"}) {
+		t.Fatalf("fast plan selected %v, want [always]", got)
+	}
+	if got := selectedNames(full.Plan); !equalStrings(got, []string{"always", "fullonly"}) {
+		t.Fatalf("full plan selected %v, want [always fullonly]", got)
+	}
+	if got := skippedNames(fast.Plan); !containsName(got, "fullonly") {
+		t.Fatalf("fast plan should skip fullonly (tier); skipped=%v", got)
+	}
+}
+
+func selectedNames(p *gates.Plan) []string {
+	if p == nil {
+		return nil
+	}
+	out := make([]string, 0, len(p.Selected))
+	for _, c := range p.Selected {
+		out = append(out, c.Name)
+	}
+	return out
+}
+
+func skippedNames(p *gates.Plan) []string {
+	if p == nil {
+		return nil
+	}
+	out := make([]string, 0, len(p.Skipped))
+	for _, c := range p.Skipped {
+		out = append(out, c.Name)
+	}
+	return out
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsName(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestCheckServiceReturnsRuntimeAndOrchestratorErrors(t *testing.T) {
 	t.Run("range environment", func(t *testing.T) {
 		_, err := (CheckService{Registry: gates.NewRegistry(), Runtime: &checkRuntimeStub{applyErr: errors.New("bad range")}}).Execute(context.Background(), CheckRequest{Scope: "range:HEAD"})

--- a/cli/internal/gates/plan.go
+++ b/cli/internal/gates/plan.go
@@ -1,0 +1,203 @@
+package gates
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// PlanCheck is one check the orchestrator would run (or skip) for an
+// invocation, projected WITHOUT executing the check or its script runner. It
+// carries only static registry facts plus the routing reason — never a verdict,
+// duration, or captured output, because no check runs to produce them.
+type PlanCheck struct {
+	// Name is the check ID (e.g. "go.vet").
+	Name string
+	// Tier renders the check's tier membership ("fast", "full", "fast,full").
+	Tier string
+	// Blocking is the failure semantics: a blocking check would fail the run on
+	// FAIL, an advisory one would not.
+	Blocking bool
+	// Reason is the selection reason (for Selected) or the skip reason (for
+	// Skipped) the orchestrator computed for this invocation.
+	Reason string
+	// WorkflowBacking is the command-shaped backing visible in CI/workflows.
+	WorkflowBacking string
+	// ArtifactPath is the local artifact that implements the check.
+	ArtifactPath string
+	// RepairHint is the operator-facing rerun/repair hint.
+	RepairHint string
+}
+
+func newPlanCheck(c Check, reason string) PlanCheck {
+	return PlanCheck{
+		Name:            c.ID,
+		Tier:            tierString(c.Tiers),
+		Blocking:        c.Blocking,
+		Reason:          reason,
+		WorkflowBacking: c.WorkflowBacking(),
+		ArtifactPath:    c.ArtifactPath(),
+		RepairHint:      c.EffectiveRepairHint(),
+	}
+}
+
+// Plan is the dry-run projection of a gate check invocation: the checks that
+// would run and the checks that would be skipped (each with its routing
+// reason), computed WITHOUT executing any check. It is the honest form of "show
+// what would happen" — the same tier filter and changed-file routing the real
+// run uses, minus every process/filesystem effect the checks themselves carry.
+type Plan struct {
+	Mode         Tier
+	Scope        Scope
+	ChangedCount int
+	Selected     []PlanCheck
+	Skipped      []PlanCheck
+	// ForeignRepo is true when the run root is not the agentops repository. Human
+	// suppresses the per-check skip wall there (it names agentops-internal
+	// backing scripts that do not exist in the user's repo); JSON always carries
+	// every row.
+	ForeignRepo bool
+}
+
+// Plan returns the dry-run projection of a run: which checks would run and which
+// would be skipped (with reasons), computed WITHOUT executing any check or its
+// script runner. It reuses the exact selection path the real run uses
+// (selectCheckPlans: tier filter, then Fast-mode changed-file routing with the
+// full-run invalidation escape hatch), so a plan can never drift from what an
+// actual run would select. It is the engine behind `ao gate check --dry-run`.
+func (o *Orchestrator) Plan(ctx context.Context, opts RunOptions) (*Plan, error) {
+	selected, skipped, changed, err := o.selectCheckPlans(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	plan := &Plan{
+		Mode:         opts.Mode,
+		Scope:        opts.Scope,
+		ChangedCount: len(changed),
+		Selected:     make([]PlanCheck, 0, len(selected)),
+		Skipped:      make([]PlanCheck, 0, len(skipped)),
+		ForeignRepo:  !IsAgentOpsRepo(o.repoRoot),
+	}
+	for _, sel := range selected {
+		plan.Selected = append(plan.Selected, newPlanCheck(sel.Check, sel.Reason))
+	}
+	for _, skip := range skipped {
+		plan.Skipped = append(plan.Skipped, newPlanCheck(skip.Check, skip.Reason))
+	}
+	return plan, nil
+}
+
+// ---- JSON wire format (a plan-shaped subset of the run report contract) ----
+
+type jsonPlan struct {
+	Plan     jsonPlanRun     `json:"plan"`
+	Selected []jsonPlanCheck `json:"selected"`
+	Skipped  []jsonPlanCheck `json:"skipped,omitempty"`
+}
+
+type jsonPlanRun struct {
+	// DryRun is always true; it lets a JSON consumer tell a plan from a run
+	// report (which has no such field) unambiguously.
+	DryRun            bool   `json:"dry_run"`
+	Mode              string `json:"mode"`
+	Scope             string `json:"scope"`
+	ChangedFilesCount int    `json:"changed_files_count"`
+	SelectedCount     int    `json:"selected_count"`
+	SkippedCount      int    `json:"skipped_count"`
+}
+
+type jsonPlanCheck struct {
+	Name            string `json:"name"`
+	Tier            string `json:"tier"`
+	Blocking        bool   `json:"blocking"`
+	Reason          string `json:"reason"`
+	WorkflowBacking string `json:"workflow_backing"`
+	ArtifactPath    string `json:"artifact_path"`
+	RepairHint      string `json:"repair_hint"`
+}
+
+// JSON renders the plan as the wire contract: a `plan` header plus `selected`
+// and `skipped` arrays. It mirrors the run report's shape minus the fields that
+// only exist after execution (status, log_tail, duration).
+func (p *Plan) JSON() ([]byte, error) {
+	jp := jsonPlan{
+		Plan: jsonPlanRun{
+			DryRun:            true,
+			Mode:              modeString(p.Mode),
+			Scope:             string(p.Scope),
+			ChangedFilesCount: p.ChangedCount,
+			SelectedCount:     len(p.Selected),
+			SkippedCount:      len(p.Skipped),
+		},
+		Selected: jsonPlanChecks(p.Selected),
+	}
+	if len(p.Skipped) > 0 {
+		jp.Skipped = jsonPlanChecks(p.Skipped)
+	}
+	out, err := json.MarshalIndent(jp, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("gates: marshal plan: %w", err)
+	}
+	return out, nil
+}
+
+func jsonPlanChecks(checks []PlanCheck) []jsonPlanCheck {
+	// PlanCheck and jsonPlanCheck are field-identical (same names, types, order);
+	// only the json tags differ, so a direct conversion is exact.
+	out := make([]jsonPlanCheck, 0, len(checks))
+	for _, c := range checks {
+		out = append(out, jsonPlanCheck(c))
+	}
+	return out
+}
+
+// Human writes a concise human-readable plan to w. It never claims a verdict:
+// every line describes what WOULD happen, and the header states plainly that no
+// checks executed.
+func (p *Plan) Human(w io.Writer) {
+	fmt.Fprintf(w, "%s/%s: would run %d checks, skip %d (dry-run — no checks executed)\n",
+		modeString(p.Mode), p.Scope, len(p.Selected), len(p.Skipped))
+	if len(p.Selected) > 0 {
+		fmt.Fprintln(w, "\nwould run:")
+		for _, c := range p.Selected {
+			fmt.Fprintf(w, "RUN   %s%s\n", c.Name, humanPlanDetails(c))
+		}
+	}
+	// In a foreign repo the per-check skip detail names agentops-internal backing
+	// scripts that do not exist in the user's repository — noise the aggregate
+	// line below already covers. JSON keeps every row.
+	if len(p.Skipped) > 0 && !p.ForeignRepo {
+		fmt.Fprintln(w, "\nwould skip:")
+		for _, c := range p.Skipped {
+			fmt.Fprintf(w, "SKIP  %s%s\n", c.Name, humanPlanDetails(c))
+		}
+	}
+	if len(p.Skipped) > 0 && p.ForeignRepo {
+		fmt.Fprintf(w, "\nwould skip %d checks (routing/tier)\n", len(p.Skipped))
+	}
+}
+
+func humanPlanDetails(c PlanCheck) string {
+	parts := []string{
+		"tier: " + c.Tier,
+		blockingLabel(c.Blocking),
+	}
+	if c.Reason != "" {
+		parts = append(parts, c.Reason)
+	}
+	parts = append(parts,
+		"backing: "+c.WorkflowBacking,
+		"artifact: "+c.ArtifactPath,
+		"repair: "+c.RepairHint,
+	)
+	return " | " + strings.Join(parts, " | ")
+}
+
+func blockingLabel(blocking bool) string {
+	if blocking {
+		return "blocking"
+	}
+	return "advisory"
+}

--- a/cli/internal/gates/plan.go
+++ b/cli/internal/gates/plan.go
@@ -45,7 +45,9 @@ func newPlanCheck(c Check, reason string) PlanCheck {
 
 // Plan is the dry-run projection of a gate check invocation: the checks that
 // would run and the checks that would be skipped (each with its routing
-// reason), computed WITHOUT executing any check. It is the honest form of "show
+// reason), computed WITHOUT executing any check. Selection itself still reads
+// repository state (git changed-file resolution, repo detection) — read-only
+// probes, never a check body. It is the honest form of "show
 // what would happen" — the same tier filter and changed-file routing the real
 // run uses, minus every process/filesystem effect the checks themselves carry.
 type Plan struct {

--- a/cli/internal/gates/plan_test.go
+++ b/cli/internal/gates/plan_test.go
@@ -1,0 +1,218 @@
+package gates
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/ports"
+)
+
+// panicRunner fails the test if any check is executed. Plan() must select
+// without ever routing a check through the runner, so a Plan run that touches
+// this runner is a bug.
+type panicRunner struct{ t *testing.T }
+
+func (r panicRunner) Run(context.Context, ports.GateRunRequest) (ports.GateVerdict, error) {
+	r.t.Fatalf("plan executed a check via the runner; dry-run must run nothing")
+	return ports.GateVerdict{}, nil
+}
+
+func planOrch(t *testing.T, files ChangedFilesPort) *Orchestrator {
+	t.Helper()
+	return NewOrchestrator(sampleRegistry(t), panicRunner{t}, files, "/repo")
+}
+
+func planIDs(checks []PlanCheck) map[string]PlanCheck {
+	m := map[string]PlanCheck{}
+	for _, c := range checks {
+		m[c.Name] = c
+	}
+	return m
+}
+
+func TestOrchestrator_PlanFullSelectsEveryTierMatchedWithoutExecuting(t *testing.T) {
+	o := planOrch(t, fakeFiles{})
+	plan, err := o.Plan(context.Background(), RunOptions{Mode: Full})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	sel := planIDs(plan.Selected)
+	for _, id := range []string{"go", "docs", "always", "fullonly"} {
+		if _, ok := sel[id]; !ok {
+			t.Errorf("full plan should select %q; selected=%v", id, keys(sel))
+		}
+	}
+	if len(plan.Selected) != 4 {
+		t.Fatalf("full plan selected %d checks, want 4", len(plan.Selected))
+	}
+	if len(plan.Skipped) != 0 {
+		t.Fatalf("full plan skipped %d checks, want 0", len(plan.Skipped))
+	}
+	// Selection facts are surfaced, not verdicts.
+	if got := sel["go"]; !got.Blocking || got.Tier != "fast,full" || got.Reason == "" {
+		t.Fatalf("go plan entry = %+v, want blocking fast,full with a reason", got)
+	}
+	if got := sel["docs"]; got.Blocking {
+		t.Fatalf("docs is advisory; plan marked it blocking: %+v", got)
+	}
+}
+
+func TestOrchestrator_PlanFastRoutesOnChangedFilesWithoutExecuting(t *testing.T) {
+	t.Run("no changed files selects only always-run", func(t *testing.T) {
+		o := planOrch(t, fakeFiles{})
+		plan, err := o.Plan(context.Background(), RunOptions{Mode: Fast, Scope: ScopeHead})
+		if err != nil {
+			t.Fatalf("Plan: %v", err)
+		}
+		sel := planIDs(plan.Selected)
+		if len(sel) != 1 {
+			t.Fatalf("fast plan (no changes) selected %v, want only always", keys(sel))
+		}
+		if _, ok := sel["always"]; !ok {
+			t.Fatalf("fast plan (no changes) should select always; got %v", keys(sel))
+		}
+		skip := planIDs(plan.Skipped)
+		for _, id := range []string{"go", "docs", "fullonly"} {
+			if _, ok := skip[id]; !ok {
+				t.Errorf("fast plan (no changes) should skip %q; skipped=%v", id, keys(skip))
+			}
+		}
+		if r := skip["fullonly"].Reason; !strings.Contains(r, "tier") {
+			t.Errorf("fullonly skip reason = %q, want a tier-mismatch reason", r)
+		}
+	})
+
+	t.Run("changed cli file additionally selects the routed check", func(t *testing.T) {
+		o := planOrch(t, fakeFiles{files: []string{"cli/main.go"}})
+		plan, err := o.Plan(context.Background(), RunOptions{Mode: Fast, Scope: ScopeHead})
+		if err != nil {
+			t.Fatalf("Plan: %v", err)
+		}
+		sel := planIDs(plan.Selected)
+		for _, id := range []string{"always", "go"} {
+			if _, ok := sel[id]; !ok {
+				t.Errorf("fast plan (cli change) should select %q; selected=%v", id, keys(sel))
+			}
+		}
+		if _, ok := sel["docs"]; ok {
+			t.Errorf("fast plan (cli change) must not select docs; selected=%v", keys(sel))
+		}
+		if plan.ChangedCount != 1 {
+			t.Fatalf("plan ChangedCount = %d, want 1", plan.ChangedCount)
+		}
+		if r := sel["go"].Reason; !strings.Contains(r, "cli/main.go") {
+			t.Errorf("go selection reason = %q, want it to cite the matched file", r)
+		}
+	})
+}
+
+func TestPlan_JSONIsAPlanShapedContract(t *testing.T) {
+	o := planOrch(t, fakeFiles{files: []string{"cli/main.go"}})
+	plan, err := o.Plan(context.Background(), RunOptions{Mode: Fast, Scope: ScopeHead})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	raw, err := plan.JSON()
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	var decoded struct {
+		Plan struct {
+			DryRun        bool   `json:"dry_run"`
+			Mode          string `json:"mode"`
+			Scope         string `json:"scope"`
+			SelectedCount int    `json:"selected_count"`
+			SkippedCount  int    `json:"skipped_count"`
+		} `json:"plan"`
+		Selected []struct {
+			Name     string `json:"name"`
+			Tier     string `json:"tier"`
+			Blocking bool   `json:"blocking"`
+			Reason   string `json:"reason"`
+		} `json:"selected"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal plan JSON: %v\n%s", err, raw)
+	}
+	if !decoded.Plan.DryRun {
+		t.Errorf("plan JSON dry_run = false, want true (must be distinguishable from a run report)")
+	}
+	if decoded.Plan.Mode != "fast" || decoded.Plan.Scope != "head" {
+		t.Errorf("plan JSON header = %+v, want fast/head", decoded.Plan)
+	}
+	if decoded.Plan.SelectedCount != len(decoded.Selected) {
+		t.Errorf("selected_count %d != len(selected) %d", decoded.Plan.SelectedCount, len(decoded.Selected))
+	}
+	byName := map[string]bool{}
+	for _, c := range decoded.Selected {
+		byName[c.Name] = true
+	}
+	if !byName["go"] || !byName["always"] {
+		t.Errorf("plan JSON selected = %v, want go and always", decoded.Selected)
+	}
+}
+
+func TestPlan_HumanRendersWouldRunAndSkip(t *testing.T) {
+	plan := &Plan{
+		Mode:  Fast,
+		Scope: ScopeHead,
+		Selected: []PlanCheck{
+			{Name: "go", Tier: "fast,full", Blocking: true, Reason: "selected: changed file \"cli/main.go\" matched \"cli/**\"", WorkflowBacking: "bash scripts/go", ArtifactPath: "scripts/go", RepairHint: "bash scripts/go"},
+		},
+		Skipped: []PlanCheck{
+			{Name: "docs", Tier: "fast,full", Blocking: false, Reason: "skipped: no changed file matched match globs docs/**", WorkflowBacking: "bash scripts/docs", ArtifactPath: "scripts/docs", RepairHint: "bash scripts/docs"},
+		},
+		ForeignRepo: false,
+	}
+	var b strings.Builder
+	plan.Human(&b)
+	out := b.String()
+	for _, want := range []string{
+		"dry-run — no checks executed",
+		"would run:",
+		"RUN   go",
+		"blocking",
+		"would skip:",
+		"SKIP  docs",
+		"advisory",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("human plan missing %q\n---\n%s", want, out)
+		}
+	}
+	// Dry-run output must never assert a verdict; no PASS/FAIL marks belong here.
+	for _, forbidden := range []string{"PASS", "FAIL"} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("human plan must not carry a verdict mark %q\n---\n%s", forbidden, out)
+		}
+	}
+}
+
+func TestPlan_HumanForeignRepoSuppressesSkipDetail(t *testing.T) {
+	plan := &Plan{
+		Mode:        Fast,
+		Scope:       ScopeHead,
+		Selected:    []PlanCheck{{Name: "always", Tier: "fast,full", Blocking: true, Reason: "selected: check has no match globs and always runs"}},
+		Skipped:     []PlanCheck{{Name: "go", Tier: "fast,full", Blocking: true, Reason: "skipped: no changed file matched match globs cli/**"}},
+		ForeignRepo: true,
+	}
+	var b strings.Builder
+	plan.Human(&b)
+	out := b.String()
+	if strings.Contains(out, "would skip:") || strings.Contains(out, "SKIP  go") {
+		t.Errorf("foreign-repo plan must aggregate skips, not name internal scripts\n---\n%s", out)
+	}
+	if !strings.Contains(out, "would skip 1 checks") {
+		t.Errorf("foreign-repo plan should carry an aggregate skip line\n---\n%s", out)
+	}
+}
+
+func keys(m map[string]PlanCheck) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Bead `age-gate-check-dryrun-y8hgz` — the last High from the 2026-07-24 Go audit's dry-run family that remained OPEN after #1008. `ao gate check --dry-run` accepted the global flag and silently executed the full registry; it is now a real plan.

- `gates.Plan` reuses the orchestrator's existing execution-free selection (`selectCheckPlans`) — the same scope/tier/changed-file routing as `Run`, inside one `CheckService.Execute`, so plan and run cannot drift structurally.
- Output: every selected and skipped check with name, tier, blocking/advisory, and the selection reason; `--json` emits a plan-shaped subset of the run-report contract marked `dry_run: true`; exit 0 on a successful plan, plan-construction errors exit 2.
- Selection performs read-only repo probes (git changed-file resolution, repo detection) but never a check body — stated in the contract comment.

## Witness tests

- A blocking would-FAIL check with a side-effect recorder neither runs nor affects exit code under `--dry-run`; the same request without the flag runs it and exits 1. A gates-level runner that fails the test if *any* check routes through it is never touched by `Plan`.
- Selection parity across default (fast), `--full`, and changed-file-routed invocations; skip reasons rendered; no PASS/FAIL marks leak into a plan.
- Binary smoke: fast plan 29 selected/40 skipped, full plan 68/1, valid JSON, ~0.28s (vs a real run spawning go build + python + git).

## Validation

- `go build`/`go vet` clean; `go test ./...` 2873 pass / 70 packages; golangci 0 issues; COMMANDS.md check current
- Cross-family review: round-1 findings 1–3 were diff artifacts of the pre-#1008 branch base (rebase resolved; nothing reverted — verifiable in this diff); finding 4 (scope of the "executes nothing" claim) addressed with the read-only-probes contract wording

Tracker: `age-gate-check-dryrun-y8hgz`