### PR TITLE
Bounded, cancellable eval subprocess runner with process-group reaping

### DIFF
--- a/cli/internal/adapters/eval/runtime.go
+++ b/cli/internal/adapters/eval/runtime.go
@@ -1,6 +1,7 @@
 package eval
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,17 +22,17 @@ import (
 
 type Runtime struct{}
 
-func (Runtime) RunSuite(options aoeval.RunOptions) (*aoeval.RunRecord, error) {
-	return aoeval.RunSuite(options)
+func (Runtime) RunSuite(ctx context.Context, options aoeval.RunOptions) (*aoeval.RunRecord, error) {
+	return aoeval.RunSuiteContext(ctx, options)
 }
-func (Runtime) RunBaselineAB(options aoeval.RunOptions) (aoeval.DeltaScorecard, *aoeval.RunRecord, *aoeval.RunRecord, error) {
-	return aoeval.RunBaselineAB(options)
+func (Runtime) RunBaselineAB(ctx context.Context, options aoeval.RunOptions) (aoeval.DeltaScorecard, *aoeval.RunRecord, *aoeval.RunRecord, error) {
+	return aoeval.RunBaselineABContext(ctx, options)
 }
 func (Runtime) WriteDeltaScorecard(card aoeval.DeltaScorecard, path string) error {
 	return aoeval.WriteDeltaScorecard(card, path)
 }
-func (Runtime) RunContextAB(options aoeval.RunOptions, contextOptions aoeval.ContextABOptions) (aoeval.ContextDeltaScorecard, *aoeval.RunRecord, *aoeval.RunRecord, error) {
-	return aoeval.RunContextAB(options, contextOptions)
+func (Runtime) RunContextAB(ctx context.Context, options aoeval.RunOptions, contextOptions aoeval.ContextABOptions) (aoeval.ContextDeltaScorecard, *aoeval.RunRecord, *aoeval.RunRecord, error) {
+	return aoeval.RunContextABContext(ctx, options, contextOptions)
 }
 func (Runtime) WriteContextDeltaScorecard(card aoeval.ContextDeltaScorecard, path string) error {
 	return aoeval.WriteContextDeltaScorecard(card, path)

--- a/cli/internal/eval/baseline_ab.go
+++ b/cli/internal/eval/baseline_ab.go
@@ -1,6 +1,7 @@
 package eval
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -73,6 +74,12 @@ type DeltaScorecard struct {
 // OutputPath: the function does not mutate opts; instead each leg gets a
 // derived OutputPath when opts.OutputPath != "".
 func RunBaselineAB(opts RunOptions) (DeltaScorecard, *RunRecord, *RunRecord, error) {
+	return RunBaselineABContext(context.Background(), opts)
+}
+
+// RunBaselineABContext is the context-threading variant of RunBaselineAB; it
+// propagates ctx into both suite legs so cancellation reaps their child trees.
+func RunBaselineABContext(ctx context.Context, opts RunOptions) (DeltaScorecard, *RunRecord, *RunRecord, error) {
 	baseRunID, err := baselineABRunIDBase(opts)
 	if err != nil {
 		return DeltaScorecard{}, nil, nil, fmt.Errorf("baseline A/B run id: %w", err)
@@ -84,7 +91,7 @@ func RunBaselineAB(opts RunOptions) (DeltaScorecard, *RunRecord, *RunRecord, err
 	if opts.OutputPath != "" {
 		onOpts.OutputPath = appendBaselineSuffix(opts.OutputPath, "skill-on")
 	}
-	onRecord, err := RunSuite(onOpts)
+	onRecord, err := RunSuiteContext(ctx, onOpts)
 	if err != nil {
 		return DeltaScorecard{}, nil, nil, fmt.Errorf("skill-on run: %w", err)
 	}
@@ -95,7 +102,7 @@ func RunBaselineAB(opts RunOptions) (DeltaScorecard, *RunRecord, *RunRecord, err
 	if opts.OutputPath != "" {
 		offOpts.OutputPath = appendBaselineSuffix(opts.OutputPath, "skill-off")
 	}
-	offRecord, err := RunSuite(offOpts)
+	offRecord, err := RunSuiteContext(ctx, offOpts)
 	if err != nil {
 		return DeltaScorecard{}, nil, nil, fmt.Errorf("skill-off run: %w", err)
 	}

--- a/cli/internal/eval/baseline_ab.go
+++ b/cli/internal/eval/baseline_ab.go
@@ -95,6 +95,10 @@ func RunBaselineABContext(ctx context.Context, opts RunOptions) (DeltaScorecard,
 	if err != nil {
 		return DeltaScorecard{}, nil, nil, fmt.Errorf("skill-on run: %w", err)
 	}
+	// Do not start the second leg if the caller cancelled after the first.
+	if err := ctx.Err(); err != nil {
+		return DeltaScorecard{}, nil, nil, fmt.Errorf("baseline A/B cancelled: %w", err)
+	}
 
 	offOpts := opts
 	offOpts.OverrideDisableHooks = true

--- a/cli/internal/eval/context_ab.go
+++ b/cli/internal/eval/context_ab.go
@@ -1,6 +1,7 @@
 package eval
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -41,6 +42,12 @@ func IsValidContextMode(s string) bool {
 // intentionally does not set OverrideDisableHooks: context-off means no
 // context packet input, not skill/hook suppression.
 func RunContextAB(opts RunOptions, contextOpts ContextABOptions) (ContextDeltaScorecard, *RunRecord, *RunRecord, error) {
+	return RunContextABContext(context.Background(), opts, contextOpts)
+}
+
+// RunContextABContext is the context-threading variant of RunContextAB; it
+// propagates ctx into both context legs so cancellation reaps their child trees.
+func RunContextABContext(ctx context.Context, opts RunOptions, contextOpts ContextABOptions) (ContextDeltaScorecard, *RunRecord, *RunRecord, error) {
 	baseOpts, err := withContextABBaseRunID(opts)
 	if err != nil {
 		return ContextDeltaScorecard{}, nil, nil, err
@@ -48,13 +55,13 @@ func RunContextAB(opts RunOptions, contextOpts ContextABOptions) (ContextDeltaSc
 	offLabel := defaultContextRootLabel(contextOpts.ContextOffLabel, ContextVariantOff)
 	onLabel := defaultContextRootLabel(contextOpts.ContextOnLabel, ContextVariantOn)
 	offOpts := contextVariantRunOptions(baseOpts, ContextVariantOff, "context-off", contextOpts.ContextOffAgentsDir)
-	offRecord, err := RunSuite(offOpts)
+	offRecord, err := RunSuiteContext(ctx, offOpts)
 	if err != nil {
 		return ContextDeltaScorecard{}, nil, nil, fmt.Errorf("context-off run: %w", err)
 	}
 
 	onOpts := contextVariantRunOptions(baseOpts, ContextVariantOn, "context-on", contextOpts.ContextOnAgentsDir)
-	onRecord, err := RunSuite(onOpts)
+	onRecord, err := RunSuiteContext(ctx, onOpts)
 	if err != nil {
 		return ContextDeltaScorecard{}, nil, nil, fmt.Errorf("context-on run: %w", err)
 	}

--- a/cli/internal/eval/context_ab.go
+++ b/cli/internal/eval/context_ab.go
@@ -59,6 +59,10 @@ func RunContextABContext(ctx context.Context, opts RunOptions, contextOpts Conte
 	if err != nil {
 		return ContextDeltaScorecard{}, nil, nil, fmt.Errorf("context-off run: %w", err)
 	}
+	// Do not start the second leg if the caller cancelled after the first.
+	if err := ctx.Err(); err != nil {
+		return ContextDeltaScorecard{}, nil, nil, fmt.Errorf("context A/B cancelled: %w", err)
+	}
 
 	onOpts := contextVariantRunOptions(baseOpts, ContextVariantOn, "context-on", contextOpts.ContextOnAgentsDir)
 	onRecord, err := RunSuiteContext(ctx, onOpts)

--- a/cli/internal/eval/core_service.go
+++ b/cli/internal/eval/core_service.go
@@ -8,10 +8,10 @@ import (
 )
 
 type CoreRuntime interface {
-	RunSuite(RunOptions) (*RunRecord, error)
-	RunBaselineAB(RunOptions) (DeltaScorecard, *RunRecord, *RunRecord, error)
+	RunSuite(context.Context, RunOptions) (*RunRecord, error)
+	RunBaselineAB(context.Context, RunOptions) (DeltaScorecard, *RunRecord, *RunRecord, error)
 	WriteDeltaScorecard(DeltaScorecard, string) error
-	RunContextAB(RunOptions, ContextABOptions) (ContextDeltaScorecard, *RunRecord, *RunRecord, error)
+	RunContextAB(context.Context, RunOptions, ContextABOptions) (ContextDeltaScorecard, *RunRecord, *RunRecord, error)
 	WriteContextDeltaScorecard(ContextDeltaScorecard, string) error
 	LoadRun(string) (*RunRecord, error)
 	CompareRuns(*RunRecord, *RunRecord, CompareOptions) (*RunRecord, error)
@@ -75,7 +75,7 @@ type CoreCoverageRequest struct {
 	RequiredDomains, RequiredEvidenceKinds, RequiredDimensions, RequiredRuntimes []string
 }
 
-func (service CoreService) Run(_ context.Context, request CoreRunRequest) (CoreRunResult, error) {
+func (service CoreService) Run(ctx context.Context, request CoreRunRequest) (CoreRunResult, error) {
 	runtimeName, err := parseCoreRuntime(request.Runtime)
 	if err != nil {
 		return CoreRunResult{}, err
@@ -94,7 +94,7 @@ func (service CoreService) Run(_ context.Context, request CoreRunRequest) (CoreR
 			return CoreRunResult{}, fmt.Errorf("--context-mode=ab cannot be combined with --baseline-mode=%s", mode)
 		}
 		contextOptions := service.contextOptions(request.SuitePath, request.ContextOffDir, request.ContextOnDir)
-		scorecard, offRun, onRun, err := service.Runtime.RunContextAB(options, contextOptions)
+		scorecard, offRun, onRun, err := service.Runtime.RunContextAB(ctx, options, contextOptions)
 		if err != nil {
 			return CoreRunResult{}, err
 		}
@@ -104,7 +104,7 @@ func (service CoreService) Run(_ context.Context, request CoreRunRequest) (CoreR
 		return CoreRunResult{Mode: CoreRunContextAB, FirstRun: offRun, SecondRun: onRun, ContextDelta: &scorecard, OutputPath: request.DeltaOut}, nil
 	}
 	if mode == BaselineModeBoth {
-		scorecard, onRun, offRun, err := service.Runtime.RunBaselineAB(options)
+		scorecard, onRun, offRun, err := service.Runtime.RunBaselineAB(ctx, options)
 		if err != nil {
 			return CoreRunResult{}, err
 		}
@@ -114,7 +114,7 @@ func (service CoreService) Run(_ context.Context, request CoreRunRequest) (CoreR
 		return CoreRunResult{Mode: CoreRunBaselineAB, FirstRun: onRun, SecondRun: offRun, Delta: &scorecard, OutputPath: request.DeltaOut}, nil
 	}
 	options.OverrideDisableHooks = mode == BaselineModeSkillOff
-	run, err := service.Runtime.RunSuite(options)
+	run, err := service.Runtime.RunSuite(ctx, options)
 	if err != nil {
 		return CoreRunResult{}, err
 	}

--- a/cli/internal/eval/core_service_test.go
+++ b/cli/internal/eval/core_service_test.go
@@ -10,15 +10,15 @@ type coreRuntimeSpy struct {
 	runCalls int
 }
 
-func (runtime *coreRuntimeSpy) RunSuite(options RunOptions) (*RunRecord, error) {
+func (runtime *coreRuntimeSpy) RunSuite(_ context.Context, options RunOptions) (*RunRecord, error) {
 	runtime.runCalls++
 	return &RunRecord{RunID: options.RunID, Status: StatusPass}, nil
 }
-func (*coreRuntimeSpy) RunBaselineAB(RunOptions) (DeltaScorecard, *RunRecord, *RunRecord, error) {
+func (*coreRuntimeSpy) RunBaselineAB(context.Context, RunOptions) (DeltaScorecard, *RunRecord, *RunRecord, error) {
 	return DeltaScorecard{}, &RunRecord{}, &RunRecord{}, nil
 }
 func (*coreRuntimeSpy) WriteDeltaScorecard(DeltaScorecard, string) error { return nil }
-func (*coreRuntimeSpy) RunContextAB(RunOptions, ContextABOptions) (ContextDeltaScorecard, *RunRecord, *RunRecord, error) {
+func (*coreRuntimeSpy) RunContextAB(context.Context, RunOptions, ContextABOptions) (ContextDeltaScorecard, *RunRecord, *RunRecord, error) {
 	return ContextDeltaScorecard{}, &RunRecord{}, &RunRecord{}, nil
 }
 func (*coreRuntimeSpy) WriteContextDeltaScorecard(ContextDeltaScorecard, string) error { return nil }

--- a/cli/internal/eval/engine.go
+++ b/cli/internal/eval/engine.go
@@ -29,6 +29,14 @@ func RunSuite(opts RunOptions) (*RunRecord, error) {
 // RunSuiteContext runs a deterministic suite, threading ctx down to every
 // command case so a cancelled or timed-out caller reaps the child process tree.
 func RunSuiteContext(ctx context.Context, opts RunOptions) (*RunRecord, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// Honor cancellation before any work: a cancelled caller must not start the
+	// suite at all, and this catches the pre-cancelled / zero-case cases.
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("suite run cancelled: %w", err)
+	}
 	if strings.TrimSpace(opts.SuitePath) == "" {
 		return nil, fmt.Errorf("suite path is required")
 	}
@@ -71,6 +79,12 @@ func RunSuiteContext(ctx context.Context, opts RunOptions) (*RunRecord, error) {
 	runEnv := cloneStringMap(opts.Env)
 	caseResults := make([]CaseResult, 0, len(suite.Cases))
 	for _, evalCase := range suite.Cases {
+		// Stop the suite on cancellation instead of running remaining cases and
+		// scoring a partial run: a cancelled run is a terminal error, distinct
+		// from ordinary case failures.
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("suite run cancelled: %w", err)
+		}
 		caseResults = append(caseResults, runCase(ctx, *suite, suiteDir, evalCase, runEnv))
 	}
 	aggregate, dimensions := scoreRun(*suite, caseResults)

--- a/cli/internal/eval/engine.go
+++ b/cli/internal/eval/engine.go
@@ -87,6 +87,11 @@ func RunSuiteContext(ctx context.Context, opts RunOptions) (*RunRecord, error) {
 		}
 		caseResults = append(caseResults, runCase(ctx, *suite, suiteDir, evalCase, runEnv))
 	}
+	// A cancellation that lands during the final (or only) case must also be
+	// terminal — never scored as an ordinary case failure.
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("suite run cancelled: %w", err)
+	}
 	aggregate, dimensions := scoreRun(*suite, caseResults)
 	status := runStatus(*suite, caseResults, aggregate, dimensions)
 	verdict := VerdictPass

--- a/cli/internal/eval/engine.go
+++ b/cli/internal/eval/engine.go
@@ -1,7 +1,6 @@
 package eval
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -13,11 +12,23 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/boshu2/agentops/cli/internal/procrun"
 )
 
 const defaultTimeoutSeconds = 30
 
+// RunSuite runs a deterministic suite with a background context. It is retained
+// for callers and tests that do not carry a cancellation context; production
+// entry points thread the caller context through RunSuiteContext so command
+// cases honor cancellation and timeouts.
 func RunSuite(opts RunOptions) (*RunRecord, error) {
+	return RunSuiteContext(context.Background(), opts)
+}
+
+// RunSuiteContext runs a deterministic suite, threading ctx down to every
+// command case so a cancelled or timed-out caller reaps the child process tree.
+func RunSuiteContext(ctx context.Context, opts RunOptions) (*RunRecord, error) {
 	if strings.TrimSpace(opts.SuitePath) == "" {
 		return nil, fmt.Errorf("suite path is required")
 	}
@@ -60,7 +71,7 @@ func RunSuite(opts RunOptions) (*RunRecord, error) {
 	runEnv := cloneStringMap(opts.Env)
 	caseResults := make([]CaseResult, 0, len(suite.Cases))
 	for _, evalCase := range suite.Cases {
-		caseResults = append(caseResults, runCase(*suite, suiteDir, evalCase, runEnv))
+		caseResults = append(caseResults, runCase(ctx, *suite, suiteDir, evalCase, runEnv))
 	}
 	aggregate, dimensions := scoreRun(*suite, caseResults)
 	status := runStatus(*suite, caseResults, aggregate, dimensions)
@@ -115,16 +126,17 @@ func RunSuite(opts RunOptions) (*RunRecord, error) {
 	return record, nil
 }
 
-func runCase(suite Suite, suiteDir string, evalCase Case, runEnv map[string]string) CaseResult {
+func runCase(parent context.Context, suite Suite, suiteDir string, evalCase Case, runEnv map[string]string) CaseResult {
 	start := time.Now()
 	ctx := caseContext{
 		suite:    &suite,
 		suiteDir: suiteDir,
 		evalCase: evalCase,
 		exitCode: 0,
+		ctx:      parent,
 	}
 	if evalCase.Kind == "command" {
-		output, err := executeCaseCommand(suite, suiteDir, evalCase, runEnv)
+		output, err := executeCaseCommand(parent, suite, suiteDir, evalCase, runEnv)
 		ctx.stdout = output.stdout
 		ctx.stderr = output.stderr
 		ctx.exitCode = output.exitCode
@@ -188,7 +200,7 @@ type commandOutput struct {
 	infrastructureError bool
 }
 
-func executeCaseCommand(suite Suite, suiteDir string, evalCase Case, runEnv map[string]string) (commandOutput, error) {
+func executeCaseCommand(parent context.Context, suite Suite, suiteDir string, evalCase Case, runEnv map[string]string) (commandOutput, error) {
 	spec, err := commandSpecFromInputs(evalCase.Inputs)
 	if err != nil {
 		return commandOutput{exitCode: -1, infrastructureError: true}, err
@@ -200,7 +212,10 @@ func executeCaseCommand(suite Suite, suiteDir string, evalCase Case, runEnv map[
 	if timeout == 0 {
 		timeout = defaultTimeoutSeconds
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, time.Duration(timeout)*time.Second)
 	defer cancel()
 
 	name := spec.name
@@ -221,15 +236,15 @@ func executeCaseCommand(suite Suite, suiteDir string, evalCase Case, runEnv map[
 	if spec.stdin != "" {
 		cmd.Stdin = strings.NewReader(spec.stdin)
 	}
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
 
-	err = cmd.Run()
+	// procrun.Run bounds per-stream capture, threads the case context so a
+	// cancelled caller or the per-case deadline reaps the whole child group
+	// (not just the direct child), and applies a WaitDelay so Wait cannot hang
+	// on pipes a surviving grandchild holds open.
+	res, startErr := procrun.Run(ctx, cmd, procrun.Options{})
 	output := commandOutput{
-		stdout:   stdout.String(),
-		stderr:   stderr.String(),
+		stdout:   string(res.Stdout),
+		stderr:   string(res.Stderr),
 		exitCode: 0,
 	}
 	if ctx.Err() == context.DeadlineExceeded {
@@ -237,17 +252,21 @@ func executeCaseCommand(suite Suite, suiteDir string, evalCase Case, runEnv map[
 		output.infrastructureError = true
 		return output, fmt.Errorf("command timed out after %ds", timeout)
 	}
-	if err == nil {
+	runErr := startErr
+	if startErr == nil {
+		runErr = res.Err
+	}
+	if runErr == nil {
 		return output, nil
 	}
 	var exitErr *exec.ExitError
-	if ok := errors.As(err, &exitErr); ok {
+	if ok := errors.As(runErr, &exitErr); ok {
 		output.exitCode = exitErr.ExitCode()
 		return output, nil
 	}
 	output.exitCode = -1
 	output.infrastructureError = true
-	return output, fmt.Errorf("run command %q: %w", name, err)
+	return output, fmt.Errorf("run command %q: %w", name, runErr)
 }
 
 type commandSpec struct {

--- a/cli/internal/eval/engine_test.go
+++ b/cli/internal/eval/engine_test.go
@@ -1,7 +1,9 @@
 package eval
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -256,6 +258,75 @@ func TestRunSuiteExpectationFailureFailsRun(t *testing.T) {
 	if run.CaseResults[0].FailureMessage == "" {
 		t.Fatalf("expected failure message, got %+v", run.CaseResults[0])
 	}
+}
+
+// TestRunSuiteContext_CancelStopsRemainingCases is the review-round-1 finding-4
+// witness: a suite of 3 command cases cancelled during case 1 must run no
+// further cases and return a terminal cancellation error, not score a partial
+// run.
+func TestRunSuiteContext_CancelStopsRemainingCases(t *testing.T) {
+	dir := t.TempDir()
+	mark1 := filepath.Join(dir, "case1.ran")
+	mark2 := filepath.Join(dir, "case2.ran")
+	mark3 := filepath.Join(dir, "case3.ran")
+	suitePath := writeEvalSuite(t, dir, fmt.Sprintf(`{
+  "schema_version": 1,
+  "id": "cancel.suite",
+  "name": "Cancel suite",
+  "domain": "cli",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "scoring": {"aggregate_threshold": 1, "dimensions": [{"name":"correctness","weight":1,"threshold":1}]},
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {"id":"c1","title":"c1","kind":"command","runtime":"shell","objective":"o","inputs":{"shell":%q},"expectations":[{"type":"exit_code","value":0}]},
+    {"id":"c2","title":"c2","kind":"command","runtime":"shell","objective":"o","inputs":{"shell":%q},"expectations":[{"type":"exit_code","value":0}]},
+    {"id":"c3","title":"c3","kind":"command","runtime":"shell","objective":"o","inputs":{"shell":%q},"expectations":[{"type":"exit_code","value":0}]}
+  ]
+}`,
+		"echo 1 > "+mark1+"; sleep 5",
+		"echo 2 > "+mark2,
+		"echo 3 > "+mark3,
+	))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := RunSuiteContext(ctx, RunOptions{SuitePath: suitePath, RunID: "cancel-run", Now: fixedEvalTime})
+		done <- err
+	}()
+
+	waitForEvalFile(t, mark1) // case 1 is now running
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil || !errors.Is(err, context.Canceled) {
+			t.Fatalf("RunSuiteContext error = %v, want context.Canceled", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunSuiteContext did not return within 10s of cancel")
+	}
+
+	if _, err := os.Stat(mark2); err == nil {
+		t.Fatal("case 2 ran after cancellation; suite did not stop")
+	}
+	if _, err := os.Stat(mark3); err == nil {
+		t.Fatal("case 3 ran after cancellation; suite did not stop")
+	}
+}
+
+func waitForEvalFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("file %s never appeared", path)
 }
 
 func TestRunSuiteRejectsLiveTier(t *testing.T) {

--- a/cli/internal/eval/engine_test.go
+++ b/cli/internal/eval/engine_test.go
@@ -317,6 +317,57 @@ func TestRunSuiteContext_CancelStopsRemainingCases(t *testing.T) {
 	}
 }
 
+func TestRunSuiteContext_CancelDuringOnlyCaseIsTerminal(t *testing.T) {
+	// A cancellation landing during the final (here: only) case must surface as
+	// the terminal cancelled error, never be scored as an ordinary case failure.
+	dir := t.TempDir()
+	mark := filepath.Join(dir, "only.ran")
+	suitePath := writeEvalSuite(t, dir, fmt.Sprintf(`{
+  "schema_version": 1,
+  "id": "cancel.single",
+  "name": "Cancel single",
+  "domain": "cli",
+  "visibility": "public_canary",
+  "tier": "deterministic",
+  "scoring": {"aggregate_threshold": 1, "dimensions": [{"name":"correctness","weight":1,"threshold":1}]},
+  "baseline_policy": {"mode": "none"},
+  "cases": [
+    {"id":"only","title":"only","kind":"command","runtime":"shell","objective":"o","inputs":{"shell":%q},"expectations":[{"type":"exit_code","value":0}]}
+  ]
+}`,
+		"echo 1 > "+mark+"; sleep 5",
+	))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct {
+		record *RunRecord
+		err    error
+	}, 1)
+	go func() {
+		record, err := RunSuiteContext(ctx, RunOptions{SuitePath: suitePath, RunID: "cancel-single", Now: fixedEvalTime})
+		done <- struct {
+			record *RunRecord
+			err    error
+		}{record, err}
+	}()
+
+	waitForEvalFile(t, mark) // the only case is now running
+	cancel()
+
+	select {
+	case res := <-done:
+		if res.err == nil || !errors.Is(res.err, context.Canceled) {
+			t.Fatalf("RunSuiteContext error = %v, want context.Canceled", res.err)
+		}
+		if res.record != nil {
+			t.Fatalf("cancelled single-case run returned a scored record: %+v", res.record)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunSuiteContext did not return within 10s of cancel")
+	}
+}
+
 func waitForEvalFile(t *testing.T, path string) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)

--- a/cli/internal/eval/expectations.go
+++ b/cli/internal/eval/expectations.go
@@ -541,6 +541,11 @@ func runAutoDetectCommand(ctx caseContext, command string) (string, error) {
 	if cctx.Err() == context.DeadlineExceeded {
 		return string(res.Combined), fmt.Errorf("auto-detect command timed out after %ds", timeout)
 	}
+	if cctx.Err() != nil {
+		// Caller cancellation: surface it rather than a partial captured value
+		// that would silently pin the wrong auto-detected number.
+		return string(res.Combined), fmt.Errorf("auto-detect command cancelled: %w", cctx.Err())
+	}
 	if runtime.GOOS == "windows" && len(res.Combined) == 0 {
 		return "", fmt.Errorf("auto-detect command produced no output (windows)")
 	}

--- a/cli/internal/eval/expectations.go
+++ b/cli/internal/eval/expectations.go
@@ -1,7 +1,6 @@
 package eval
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -14,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/boshu2/agentops/cli/internal/procrun"
 )
 
 type caseContext struct {
@@ -23,6 +24,9 @@ type caseContext struct {
 	stdout   string
 	stderr   string
 	exitCode int
+	// ctx carries the caller/run context so auto-detect subprocesses honor
+	// cancellation and timeouts instead of running under a background context.
+	ctx context.Context
 }
 
 type expectationResult struct {
@@ -509,7 +513,11 @@ func runAutoDetectCommand(ctx caseContext, command string) (string, error) {
 	} else if ctx.suite != nil && ctx.suite.Environment.TimeoutSeconds > 0 {
 		timeout = ctx.suite.Environment.TimeoutSeconds
 	}
-	cctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	parent := ctx.ctx
+	if parent == nil {
+		parent = context.Background()
+	}
+	cctx, cancel := context.WithTimeout(parent, time.Duration(timeout)*time.Second)
 	defer cancel()
 	name, args := shellCommand(command)
 	cmd := exec.CommandContext(cctx, name, args...)
@@ -524,21 +532,19 @@ func runAutoDetectCommand(ctx caseContext, command string) (string, error) {
 	if cmd.Dir == "" {
 		cmd.Dir = ctx.suiteDir
 	}
-	var combined bytes.Buffer
-	cmd.Stdout = &combined
-	cmd.Stderr = &combined
-	runErr := cmd.Run()
+	// procrun.Run bounds the combined capture and reaps the child's process
+	// group on cctx cancel/timeout. The run error is informational — many of
+	// these commands legitimately exit non-zero yet still emit the line we need
+	// to capture — so it (and any start error) is discarded; the regex match is
+	// the authoritative signal.
+	res, _ := procrun.Run(cctx, cmd, procrun.Options{Combined: true})
 	if cctx.Err() == context.DeadlineExceeded {
-		return combined.String(), fmt.Errorf("auto-detect command timed out after %ds", timeout)
+		return string(res.Combined), fmt.Errorf("auto-detect command timed out after %ds", timeout)
 	}
-	// runErr is informational — many of these commands legitimately exit
-	// non-zero (e.g. an unrelated failing test) yet still emit the line we
-	// need to capture. The regex match is the authoritative signal.
-	_ = runErr
-	if runtime.GOOS == "windows" && combined.Len() == 0 {
+	if runtime.GOOS == "windows" && len(res.Combined) == 0 {
 		return "", fmt.Errorf("auto-detect command produced no output (windows)")
 	}
-	return combined.String(), nil
+	return string(res.Combined), nil
 }
 
 func autoDetectTolerated(haystack string, re *regexp.Regexp, spec autoDetectSpec, fresh string) (bool, string) {

--- a/cli/internal/gates/scriptrunner.go
+++ b/cli/internal/gates/scriptrunner.go
@@ -1,7 +1,6 @@
 package gates
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -11,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/boshu2/agentops/cli/internal/ports"
+	"github.com/boshu2/agentops/cli/internal/procrun"
 )
 
 // ScriptRunner runs a script-backed check and maps its exit code to a
@@ -144,10 +144,15 @@ func (s *ScriptRunner) Run(ctx context.Context, req ports.GateRunRequest) (ports
 	cmd := exec.CommandContext(ctx, interpreter, interpreterArgs...)
 	cmd.Dir = s.repoRoot
 	cmd.Env = buildCheckEnv(cmd.Environ(), req.Env)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	runErr := cmd.Run()
+	// procrun.Run bounds captured output (the 4 KiB LogTail tail is preserved),
+	// runs the check in its own process group, and reaps the group (with a
+	// WaitDelay) on ctx cancel/timeout so a hung sub-check cannot orphan
+	// descendants or leave Wait blocked on an inherited pipe.
+	res, startErr := procrun.Run(ctx, cmd, procrun.Options{Combined: true})
+	runErr := startErr
+	if startErr == nil {
+		runErr = res.Err
+	}
 
 	code := 0
 	var exitErr *exec.ExitError
@@ -155,7 +160,7 @@ func (s *ScriptRunner) Run(ctx context.Context, req ports.GateRunRequest) (ports
 		code = exitErr.ExitCode()
 	} else if runErr != nil {
 		reason := fmt.Sprintf("subprocess error: %v", runErr)
-		logTail := tailBytes(out.Bytes(), 4096)
+		logTail := tailBytes(res.Combined, 4096)
 		if strings.TrimSpace(logTail) == "" {
 			logTail = reason
 		}
@@ -166,7 +171,7 @@ func (s *ScriptRunner) Run(ctx context.Context, req ports.GateRunRequest) (ports
 		}, nil
 	}
 	v := exitCodeToVerdict(code)
-	v.LogTail = tailBytes(out.Bytes(), 4096)
+	v.LogTail = tailBytes(res.Combined, 4096)
 	return v, nil
 }
 

--- a/cli/internal/goals/measure.go
+++ b/cli/internal/goals/measure.go
@@ -1,7 +1,6 @@
 package goals
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"os"
@@ -14,6 +13,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/boshu2/agentops/cli/internal/procrun"
 	"github.com/boshu2/agentops/cli/internal/shellutil"
 )
 
@@ -151,29 +151,27 @@ func MeasureOneContext(parent context.Context, goal Goal, timeout time.Duration)
 	// SanitizedBashCommand bypasses ~/.bashrc and BASH_ENV so user shell
 	// aliases cannot silently change the meaning of goal check strings.
 	cmd := shellutil.SanitizedBashCommand(ctx, goal.Check)
-	configureProcGroup(cmd)
-	cmd.WaitDelay = 3 * time.Second
 
-	// Capture combined stdout+stderr via buffer so we can track the PID
-	// between Start and Wait for signal-based cleanup.
-	var buf bytes.Buffer
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
-
-	if err := cmd.Start(); err != nil {
-		m.Duration = time.Since(start).Seconds()
-		m.Output = err.Error()
-		m.Result = classifyResult(ctx.Err(), err)
+	// procrun.Run captures combined stdout+stderr under a hard byte ceiling
+	// (bounding peak memory for noisy checks), starts the child in its own
+	// process group, and kills the whole group on timeout/cancel with a
+	// WaitDelay backstop. OnStart/OnExit feed the package signal handler's
+	// child tracker so SIGINT still reaps in-flight gate groups.
+	res, startErr := procrun.Run(ctx, cmd, procrun.Options{
+		Combined:  true,
+		WaitDelay: 3 * time.Second,
+		OnStart:   trackChild,
+		OnExit:    untrackChild,
+	})
+	m.Duration = time.Since(start).Seconds()
+	if startErr != nil {
+		m.Output = startErr.Error()
+		m.Result = classifyResult(ctx.Err(), startErr)
 		return m
 	}
 
-	trackChild(cmd.Process.Pid)
-	err := cmd.Wait()
-	untrackChild(cmd.Process.Pid)
-
-	m.Duration = time.Since(start).Seconds()
-	m.Output = truncateOutput(buf.Bytes())
-	m.Result = classifyResult(ctx.Err(), err)
+	m.Output = truncateOutput(res.Combined)
+	m.Result = classifyResult(ctx.Err(), res.Err)
 	applyContinuousMetric(&m, goal)
 	return m
 }

--- a/cli/internal/procrun/procrun.go
+++ b/cli/internal/procrun/procrun.go
@@ -1,0 +1,288 @@
+// Package procrun runs child subprocesses with a bounded output capture, a
+// caller context that is honored end-to-end, and process-group termination so
+// that cancelling or timing out a run reaps the whole descendant tree rather
+// than orphaning grandchildren.
+//
+// # Bounded capture semantics
+//
+// The output writer retains at most a fixed head+tail window of the child's
+// stream and DISCARDS the middle, so peak retained memory is bounded to
+// head+tail+len(marker) no matter how many bytes a runaway child emits. The
+// runner never stops reading the child (it keeps draining the pipe so the child
+// cannot deadlock on a full pipe) — it simply forgets the middle. When any
+// bytes were discarded the assembled output is `head + truncationMarker + tail`
+// and Result.Truncated is true; otherwise the output is the child's exact bytes.
+//
+// Because the retained window is generous (DefaultMaxCaptureBytes) and every
+// downstream truncation window in the callers (goals' 500-rune head+tail, gates'
+// 4 KiB tail) is far smaller, any output that fits within the cap is returned
+// byte-for-byte, and even oversize output preserves the true head and true tail
+// — so a caller that keeps the last N bytes still sees the real last N bytes.
+//
+// # Cancellation
+//
+// Run relies on the standard library's context-driven cancellation: callers
+// MUST build cmd with exec.CommandContext(ctx, ...) using the SAME ctx they pass
+// to Run. Run installs a process-group Cancel (unix: kill(-pgid); windows:
+// taskkill /T) and a WaitDelay so that when ctx is cancelled or its deadline
+// expires the entire group is killed and Wait cannot hang forever on pipes still
+// held open by a surviving grandchild. Run itself starts no background
+// goroutine, so it adds no goroutine-leak surface.
+package procrun
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+// DefaultMaxCaptureBytes is the default per-stream retained output ceiling
+// (split evenly between a head window and a tail window). One mebibyte is far
+// above any legitimate check output yet bounds peak memory hard.
+const DefaultMaxCaptureBytes = 1 << 20
+
+// DefaultWaitDelay bounds how long Wait blocks draining inherited pipes after
+// the context is cancelled or the process exits, before the pipes are force
+// closed. It matches the proven value used by the goals measurement path.
+const DefaultWaitDelay = 3 * time.Second
+
+// truncationMarker is inserted between the retained head and tail when middle
+// bytes were discarded. It is intentionally distinct and self-describing so a
+// human reading truncated output can tell capture bounding occurred.
+const truncationMarker = "\n…[procrun: output truncated]…\n"
+
+// Options configures a Run.
+type Options struct {
+	// MaxCaptureBytes caps retained output per stream (head+tail combined).
+	// Values <= 0 select DefaultMaxCaptureBytes.
+	MaxCaptureBytes int
+	// Combined routes both stdout and stderr into a single capture surfaced as
+	// Result.Combined (Result.Stdout/Stderr stay nil). When false the two
+	// streams are captured separately.
+	Combined bool
+	// WaitDelay overrides the post-cancellation pipe-drain bound. Values <= 0
+	// select DefaultWaitDelay.
+	WaitDelay time.Duration
+	// OnStart, if set, is called with the child PID immediately after a
+	// successful Start (before Wait). Used by callers that track live children
+	// for signal-driven cleanup.
+	OnStart func(pid int)
+	// OnExit, if set, is called with the child PID immediately after Wait
+	// returns.
+	OnExit func(pid int)
+}
+
+// Result holds the outcome of a Run.
+type Result struct {
+	// Stdout and Stderr hold the separately captured streams (nil when the run
+	// used Options.Combined).
+	Stdout, Stderr []byte
+	// Combined holds the merged stdout+stderr stream (nil unless Options.Combined).
+	Combined []byte
+	// ExitCode is 0 on success, the child's exit status for a normal non-zero
+	// exit, and -1 when the child failed to run or was terminated by a signal.
+	ExitCode int
+	// Err is the raw error returned by Wait: nil, an *exec.ExitError for a
+	// non-zero exit, or another error for an infrastructure failure. Callers
+	// classify timeout/cancellation from their own ctx.Err(), which takes
+	// precedence over Err.
+	Err error
+	// Truncated reports whether any captured stream discarded middle bytes.
+	Truncated bool
+	// Duration is the wall-clock time from Start to Wait return.
+	Duration time.Duration
+}
+
+// Run starts cmd under ctx, captures its output within a hard byte ceiling, and
+// waits for it to finish, killing the child's whole process group on
+// cancellation or timeout.
+//
+// cmd MUST have been created with exec.CommandContext(ctx, ...) using the same
+// ctx passed here; Run wires the process-group Cancel and WaitDelay onto it and
+// sets cmd.Stdout/cmd.Stderr. The returned error is non-nil only when the child
+// could not be started; a child that starts and then fails reports through
+// Result.Err and Result.ExitCode.
+func Run(ctx context.Context, cmd *exec.Cmd, opts Options) (Result, error) {
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+
+	maxBytes := opts.MaxCaptureBytes
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxCaptureBytes
+	}
+	head := maxBytes / 2
+	tail := maxBytes - head
+
+	var stdoutCap, stderrCap, combinedCap *capture
+	if opts.Combined {
+		combinedCap = newCapture(head, tail)
+		cmd.Stdout = combinedCap
+		cmd.Stderr = combinedCap
+	} else {
+		stdoutCap = newCapture(head, tail)
+		stderrCap = newCapture(head, tail)
+		cmd.Stdout = stdoutCap
+		cmd.Stderr = stderrCap
+	}
+
+	configureProcessGroup(cmd)
+	waitDelay := opts.WaitDelay
+	if waitDelay <= 0 {
+		waitDelay = DefaultWaitDelay
+	}
+	cmd.WaitDelay = waitDelay
+
+	start := time.Now()
+	if err := cmd.Start(); err != nil {
+		return Result{Duration: time.Since(start)}, fmt.Errorf("start command: %w", err)
+	}
+	pid := cmd.Process.Pid
+	if opts.OnStart != nil {
+		opts.OnStart(pid)
+	}
+
+	waitErr := cmd.Wait()
+	if opts.OnExit != nil {
+		opts.OnExit(pid)
+	}
+
+	res := Result{Duration: time.Since(start), Err: waitErr}
+	if combinedCap != nil {
+		res.Combined = combinedCap.Bytes()
+		res.Truncated = combinedCap.Truncated()
+	} else {
+		res.Stdout = stdoutCap.Bytes()
+		res.Stderr = stderrCap.Bytes()
+		res.Truncated = stdoutCap.Truncated() || stderrCap.Truncated()
+	}
+
+	var exitErr *exec.ExitError
+	switch {
+	case waitErr == nil:
+		res.ExitCode = 0
+	case errors.As(waitErr, &exitErr):
+		res.ExitCode = exitErr.ExitCode()
+	default:
+		res.ExitCode = -1
+	}
+	return res, nil
+}
+
+// capture is an io.Writer that retains at most headCap bytes of the beginning
+// and tailCap bytes of the end of the stream written to it, discarding whatever
+// falls in between. Retained memory is bounded to headCap+tailCap regardless of
+// total bytes written.
+//
+// os/exec serializes writes to a single writer (one copy goroutine per pipe;
+// stdout and stderr routed to the same writer share one pipe), so the mutex only
+// guards against callers that deliberately share a capture across goroutines and
+// keeps the race detector satisfied unconditionally.
+type capture struct {
+	mu      sync.Mutex
+	headCap int
+	tailCap int
+	head    []byte // first headCap bytes, in order
+	ring    []byte // fixed-size ring of the last tailCap post-head bytes
+	ringLen int    // valid bytes in ring (<= tailCap)
+	ringPos int    // next write index into ring
+	total   int64  // total bytes written
+}
+
+func newCapture(headCap, tailCap int) *capture {
+	if headCap < 0 {
+		headCap = 0
+	}
+	if tailCap < 0 {
+		tailCap = 0
+	}
+	return &capture{
+		headCap: headCap,
+		tailCap: tailCap,
+		head:    make([]byte, 0, headCap),
+	}
+}
+
+// Write implements io.Writer. It never returns an error and always reports the
+// full length as written so the child is never back-pressured by the cap.
+func (c *capture) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := len(p)
+	c.total += int64(n)
+
+	if len(c.head) < c.headCap {
+		take := c.headCap - len(c.head)
+		if take > len(p) {
+			take = len(p)
+		}
+		c.head = append(c.head, p[:take]...)
+		p = p[take:]
+	}
+	if len(p) == 0 || c.tailCap == 0 {
+		return n, nil
+	}
+	if c.ring == nil {
+		c.ring = make([]byte, c.tailCap)
+	}
+	// If this write alone exceeds the tail window, only its last tailCap bytes
+	// can survive; drop straight to them.
+	if len(p) >= c.tailCap {
+		copy(c.ring, p[len(p)-c.tailCap:])
+		c.ringPos = 0
+		c.ringLen = c.tailCap
+		return n, nil
+	}
+	for _, b := range p {
+		c.ring[c.ringPos] = b
+		c.ringPos = (c.ringPos + 1) % c.tailCap
+		if c.ringLen < c.tailCap {
+			c.ringLen++
+		}
+	}
+	return n, nil
+}
+
+// Truncated reports whether any middle bytes were discarded.
+func (c *capture) Truncated() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.total > int64(c.headCap+c.tailCap)
+}
+
+// Total returns the total number of bytes written, including discarded ones.
+func (c *capture) Total() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.total
+}
+
+// Bytes assembles the retained output: the exact stream when nothing was
+// discarded, otherwise head + truncationMarker + tail.
+func (c *capture) Bytes() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.ringLen == 0 {
+		return append([]byte(nil), c.head...)
+	}
+	tail := make([]byte, c.ringLen)
+	if c.ringLen < c.tailCap {
+		// Never wrapped: bytes sit at ring[0:ringLen] in order.
+		copy(tail, c.ring[:c.ringLen])
+	} else {
+		// Wrapped: oldest retained byte is at ringPos.
+		copy(tail, c.ring[c.ringPos:])
+		copy(tail[c.tailCap-c.ringPos:], c.ring[:c.ringPos])
+	}
+	truncated := c.total > int64(c.headCap+c.tailCap)
+	out := make([]byte, 0, len(c.head)+len(tail)+len(truncationMarker))
+	out = append(out, c.head...)
+	if truncated {
+		out = append(out, truncationMarker...)
+	}
+	out = append(out, tail...)
+	return out
+}

--- a/cli/internal/procrun/procrun.go
+++ b/cli/internal/procrun/procrun.go
@@ -19,21 +19,40 @@
 // byte-for-byte, and even oversize output preserves the true head and true tail
 // — so a caller that keeps the last N bytes still sees the real last N bytes.
 //
-// # Cancellation
+// # Cancellation and reaping
 //
 // Run relies on the standard library's context-driven cancellation: callers
 // MUST build cmd with exec.CommandContext(ctx, ...) using the SAME ctx they pass
-// to Run. Run installs a process-group Cancel (unix: kill(-pgid); windows:
-// taskkill /T) and a WaitDelay so that when ctx is cancelled or its deadline
-// expires the entire group is killed and Wait cannot hang forever on pipes still
-// held open by a surviving grandchild. Run itself starts no background
-// goroutine, so it adds no goroutine-leak surface.
+// to Run. Run installs a process-group Cancel and a WaitDelay so that when ctx
+// is cancelled or its deadline expires the whole group is killed and Wait cannot
+// hang forever on pipes a surviving grandchild holds open.
+//
+// Cancellation is not the only way a descendant can outlive the direct child: a
+// child can spawn a grandchild that holds the output pipe open and then exit
+// normally, in which case Cancel never fires and only WaitDelay unblocks Wait.
+// So Run ALSO reaps the process group unconditionally after Wait returns, on
+// every path (success, failure, timeout, cancel). On unix that is a
+// kill(-pgid, SIGKILL) whose ESRCH ("group already gone") result is the success
+// case. Run itself starts no background goroutine, so it adds no goroutine-leak
+// surface.
+//
+// # Platform support
+//
+// On unix the process-group guarantee is strong: Setpgid isolates the child and
+// its descendants into one group that kill(-pgid) reaps atomically, and an ESRCH
+// from a group that already exited is mapped to success so a completed command
+// racing a cancellation never surfaces a spurious cancel error. On Windows the
+// guarantee is weaker and best-effort: the child starts in a new process group
+// (CREATE_NEW_PROCESS_GROUP is a Ctrl-Break domain, not a containment boundary)
+// and cancellation/reaping shell out to `taskkill /T /F` under a short internal
+// timeout. taskkill after the root has exited can miss re-parented descendants,
+// and no Job Object is used, so a Windows descendant is not guaranteed reaped.
+// This limitation is documented rather than faked.
 package procrun
 
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os/exec"
 	"sync"
 	"time"
@@ -138,7 +157,9 @@ func Run(ctx context.Context, cmd *exec.Cmd, opts Options) (Result, error) {
 
 	start := time.Now()
 	if err := cmd.Start(); err != nil {
-		return Result{Duration: time.Since(start)}, fmt.Errorf("start command: %w", err)
+		// Return the raw start error unwrapped so migrated call sites keep their
+		// pre-existing, byte-identical start-failure diagnostics.
+		return Result{Duration: time.Since(start)}, err
 	}
 	pid := cmd.Process.Pid
 	if opts.OnStart != nil {
@@ -146,6 +167,11 @@ func Run(ctx context.Context, cmd *exec.Cmd, opts Options) (Result, error) {
 	}
 
 	waitErr := cmd.Wait()
+	// Always reap the group, even on a clean exit: a grandchild that outlived
+	// the direct child (so Cancel never fired) is otherwise orphaned once
+	// WaitDelay unblocks Wait. Best-effort; ESRCH means the group is already
+	// gone.
+	reapProcessGroup(pid)
 	if opts.OnExit != nil {
 		opts.OnExit(pid)
 	}

--- a/cli/internal/procrun/procrun_reap_unix_test.go
+++ b/cli/internal/procrun/procrun_reap_unix_test.go
@@ -172,14 +172,18 @@ func TestRun_CompletedCommandNotReportedCancelledUnderRace(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cmd := shellCmd(ctx, "echo done > "+marker)
 		go cancel() // race the child's completion against cancellation
-		res, _ := Run(ctx, cmd, Options{Combined: true})
-		// A marker on disk does not prove the shell finished exiting — the
-		// kill can land between the redirect and the shell's own exit, and
-		// that outcome (killed, error) is a legitimate result of this race.
-		// The finding-3 regression is a MIXED state: a wait that observed a
-		// clean exit surfacing a spurious cancel error, or a killed process
-		// reported as clean. Assert the two outcomes stay unmixed.
-		if res.Err == nil {
+		res, outerErr := Run(ctx, cmd, Options{Combined: true})
+		// Three legitimate outcomes; the finding-3 regression is any MIXED
+		// state between them:
+		//   cancel before start  -> outerErr = ctx.Err, zero Result;
+		//   killed mid-run       -> res.Err set, killed ExitCode;
+		//   completed            -> no errors, ExitCode 0, work done.
+		// (A marker on disk alone does not prove the shell finished exiting —
+		// the kill can land between the redirect and the shell's own exit.)
+		switch {
+		case outerErr != nil:
+			// Cancelled before start: nothing ran, nothing to assert.
+		case res.Err == nil:
 			if res.ExitCode != 0 {
 				t.Fatalf("iter %d: no error but ExitCode = %d, want 0", i, res.ExitCode)
 			}
@@ -187,7 +191,7 @@ func TestRun_CompletedCommandNotReportedCancelledUnderRace(t *testing.T) {
 			if readErr != nil || strings.TrimSpace(string(data)) != "done" {
 				t.Fatalf("iter %d: clean run without its work completed (marker read: %v)", i, readErr)
 			}
-		} else if res.ExitCode == 0 {
+		case res.ExitCode == 0:
 			t.Fatalf("iter %d: clean exit 0 surfaced spurious error %v", i, res.Err)
 		}
 		cancel()

--- a/cli/internal/procrun/procrun_reap_unix_test.go
+++ b/cli/internal/procrun/procrun_reap_unix_test.go
@@ -4,7 +4,9 @@ package procrun
 
 import (
 	"context"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -118,4 +120,69 @@ func TestRun_TimeoutReapsGrandchild(t *testing.T) {
 		t.Fatalf("ctx.Err() = %v, want DeadlineExceeded", ctx.Err())
 	}
 	assertReaped(t, grandchild)
+}
+
+// TestRun_ReapsSleeperAfterNormalChildExit is the review-round-1 finding-1
+// witness: the direct child backgrounds a sleeper and exits NORMALLY (ctx is
+// never cancelled, so Cancel never fires). Only the unconditional post-Wait reap
+// can kill the orphan; without it the sleeper survives past WaitDelay.
+func TestRun_ReapsSleeperAfterNormalChildExit(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "sleeper.pid")
+	ctx := context.Background()
+	// Note: no `wait` — the shell exits immediately, leaving the sleeper holding
+	// the stdout pipe until WaitDelay unblocks Wait.
+	cmd := shellCmd(ctx, "sleep 60 & echo $! > "+pidFile)
+	res, err := Run(ctx, cmd, Options{Combined: true, WaitDelay: 500 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("Run start error: %v", err)
+	}
+	_ = res
+	sleeper := waitForPIDFile(t, pidFile)
+	assertReaped(t, sleeper)
+}
+
+// TestCancelHook_ESRCHMapsToProcessDone is the deterministic finding-3 witness:
+// after the child and its group have fully exited, kill(-pgid) returns ESRCH,
+// which the Cancel hook must report as ErrProcessDone (success), never as a
+// failure that Wait would surface as "exec: canceling Cmd".
+func TestCancelHook_ESRCHMapsToProcessDone(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "true")
+	configureProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	// The group is now empty; kill(-pgid) yields ESRCH.
+	if err := cmd.Cancel(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("Cancel after exit = %v, want nil or ErrProcessDone", err)
+	}
+}
+
+// TestRun_CompletedCommandNotReportedCancelledUnderRace is the finding-3 race
+// witness: a fast command whose completion races an immediate cancel must never
+// surface a spurious error when it actually completed. Run under -race.
+func TestRun_CompletedCommandNotReportedCancelledUnderRace(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 50; i++ {
+		marker := filepath.Join(dir, "done-"+strconv.Itoa(i))
+		ctx, cancel := context.WithCancel(context.Background())
+		cmd := shellCmd(ctx, "echo done > "+marker)
+		go cancel() // race the child's completion against cancellation
+		res, _ := Run(ctx, cmd, Options{Combined: true})
+		data, readErr := os.ReadFile(marker)
+		if readErr == nil && strings.TrimSpace(string(data)) == "done" {
+			// The command provably completed; it must not report as failed.
+			if res.Err != nil {
+				t.Fatalf("iter %d: completed command reported error %v (ExitCode %d)", i, res.Err, res.ExitCode)
+			}
+			if res.ExitCode != 0 {
+				t.Fatalf("iter %d: completed command ExitCode = %d, want 0", i, res.ExitCode)
+			}
+		}
+		cancel()
+	}
 }

--- a/cli/internal/procrun/procrun_reap_unix_test.go
+++ b/cli/internal/procrun/procrun_reap_unix_test.go
@@ -1,0 +1,121 @@
+//go:build !windows
+
+package procrun
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// processAlive reports whether pid is still a live process. kill(pid, 0)
+// performs no signal delivery but returns ESRCH when the process (and any
+// zombie has been reaped) no longer exists.
+func processAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}
+
+// waitForPIDFile polls path until it contains a parseable PID or the deadline
+// passes.
+func waitForPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(path); err == nil {
+			if s := strings.TrimSpace(string(data)); s != "" {
+				pid, err := strconv.Atoi(s)
+				if err == nil {
+					return pid
+				}
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("grandchild PID file %s never populated", path)
+	return 0
+}
+
+// assertReaped polls until pid is gone, failing if it survives.
+func assertReaped(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if !processAlive(pid) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// Best-effort cleanup so a failed run does not leave a 60s sleeper behind.
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+	t.Fatalf("grandchild pid %d still alive; process group was not reaped", pid)
+}
+
+// grandchildScript backgrounds a long sleeper (a grandchild of the test: child
+// = the shell, grandchild = sleep), records the sleeper's PID to pidFile, then
+// waits — so the shell holds the pipe open until the sleeper is killed, exactly
+// the orphaning hazard the runner must defeat.
+func grandchildScript(pidFile string) string {
+	return "sleep 60 & echo $! > " + pidFile + "; wait"
+}
+
+// TestRun_CancelReapsGrandchild is witness (2): cancelling the caller context
+// terminates the child AND its spawned grandchild.
+func TestRun_CancelReapsGrandchild(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := shellCmd(ctx, grandchildScript(pidFile))
+	done := make(chan Result, 1)
+	go func() {
+		res, _ := Run(ctx, cmd, Options{Combined: true})
+		done <- res
+	}()
+
+	grandchild := waitForPIDFile(t, pidFile)
+	if !processAlive(grandchild) {
+		t.Fatalf("grandchild pid %d not alive before cancel", grandchild)
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Run did not return within 5s of cancel (Wait hung on inherited pipe)")
+	}
+	assertReaped(t, grandchild)
+}
+
+// TestRun_TimeoutReapsGrandchild is witness (3): a context deadline behaves like
+// an explicit cancel, reaping the whole tree.
+func TestRun_TimeoutReapsGrandchild(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	cmd := shellCmd(ctx, grandchildScript(pidFile))
+	done := make(chan Result, 1)
+	go func() {
+		res, _ := Run(ctx, cmd, Options{Combined: true})
+		done <- res
+	}()
+
+	grandchild := waitForPIDFile(t, pidFile)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Run did not return within 5s of timeout")
+	}
+	if ctx.Err() != context.DeadlineExceeded {
+		t.Fatalf("ctx.Err() = %v, want DeadlineExceeded", ctx.Err())
+	}
+	assertReaped(t, grandchild)
+}

--- a/cli/internal/procrun/procrun_reap_unix_test.go
+++ b/cli/internal/procrun/procrun_reap_unix_test.go
@@ -173,15 +173,22 @@ func TestRun_CompletedCommandNotReportedCancelledUnderRace(t *testing.T) {
 		cmd := shellCmd(ctx, "echo done > "+marker)
 		go cancel() // race the child's completion against cancellation
 		res, _ := Run(ctx, cmd, Options{Combined: true})
-		data, readErr := os.ReadFile(marker)
-		if readErr == nil && strings.TrimSpace(string(data)) == "done" {
-			// The command provably completed; it must not report as failed.
-			if res.Err != nil {
-				t.Fatalf("iter %d: completed command reported error %v (ExitCode %d)", i, res.Err, res.ExitCode)
-			}
+		// A marker on disk does not prove the shell finished exiting — the
+		// kill can land between the redirect and the shell's own exit, and
+		// that outcome (killed, error) is a legitimate result of this race.
+		// The finding-3 regression is a MIXED state: a wait that observed a
+		// clean exit surfacing a spurious cancel error, or a killed process
+		// reported as clean. Assert the two outcomes stay unmixed.
+		if res.Err == nil {
 			if res.ExitCode != 0 {
-				t.Fatalf("iter %d: completed command ExitCode = %d, want 0", i, res.ExitCode)
+				t.Fatalf("iter %d: no error but ExitCode = %d, want 0", i, res.ExitCode)
 			}
+			data, readErr := os.ReadFile(marker)
+			if readErr != nil || strings.TrimSpace(string(data)) != "done" {
+				t.Fatalf("iter %d: clean run without its work completed (marker read: %v)", i, readErr)
+			}
+		} else if res.ExitCode == 0 {
+			t.Fatalf("iter %d: clean exit 0 surfaced spurious error %v", i, res.Err)
 		}
 		cancel()
 	}

--- a/cli/internal/procrun/procrun_test.go
+++ b/cli/internal/procrun/procrun_test.go
@@ -1,0 +1,169 @@
+package procrun
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// shellCmd builds a ctx-bound command running script through the platform shell.
+func shellCmd(ctx context.Context, script string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.CommandContext(ctx, "cmd", "/C", script)
+	}
+	return exec.CommandContext(ctx, "sh", "-c", script)
+}
+
+// TestCapture_ByteIdenticalWhenUnderCap is witness (4): a fast successful run
+// under the cap yields output byte-identical to the child's raw bytes, with no
+// truncation.
+func TestRun_FastSuccessIsByteIdentical(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell")
+	}
+	ctx := context.Background()
+	cmd := shellCmd(ctx, "printf 'hello world'")
+	res, err := Run(ctx, cmd, Options{Combined: true, MaxCaptureBytes: 4096})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := string(res.Combined); got != "hello world" {
+		t.Fatalf("Combined = %q, want %q", got, "hello world")
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0", res.ExitCode)
+	}
+	if res.Truncated {
+		t.Fatalf("Truncated = true, want false")
+	}
+	if res.Err != nil {
+		t.Fatalf("Err = %v, want nil", res.Err)
+	}
+}
+
+// TestRun_SeparateStreams verifies stdout and stderr are captured distinctly and
+// that a non-zero exit is reported through ExitCode, not the top-level error.
+func TestRun_SeparateStreamsAndExitCode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell")
+	}
+	ctx := context.Background()
+	cmd := shellCmd(ctx, "printf out; printf err 1>&2; exit 3")
+	res, err := Run(ctx, cmd, Options{MaxCaptureBytes: 4096})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if string(res.Stdout) != "out" {
+		t.Fatalf("Stdout = %q, want %q", res.Stdout, "out")
+	}
+	if string(res.Stderr) != "err" {
+		t.Fatalf("Stderr = %q, want %q", res.Stderr, "err")
+	}
+	if res.ExitCode != 3 {
+		t.Fatalf("ExitCode = %d, want 3", res.ExitCode)
+	}
+}
+
+// TestRun_BoundedCaptureUnderRunawayOutput is witness (1): a child that emits
+// far more than the cap does not grow retained memory unboundedly and the result
+// reflects the documented head+marker+tail truncation semantics.
+func TestRun_BoundedCaptureUnderRunawayOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell")
+	}
+	ctx := context.Background()
+	// Emit ~2 MiB of 'x' framed by a distinct head and tail so we can prove the
+	// true head and true tail survive.
+	script := "printf HEADSTART; " +
+		"for i in $(seq 1 2048); do printf '%1024d' 0 | tr ' ' x; done; " +
+		"printf TAILEND"
+	cmd := shellCmd(ctx, script)
+	const cap = 64
+	res, err := Run(ctx, cmd, Options{Combined: true, MaxCaptureBytes: cap})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !res.Truncated {
+		t.Fatalf("Truncated = false, want true for runaway output")
+	}
+	// Retained bytes are bounded to head+tail+marker regardless of the ~2 MiB
+	// emitted.
+	maxRetained := cap + len(truncationMarker)
+	if len(res.Combined) > maxRetained {
+		t.Fatalf("retained %d bytes, want <= %d (memory not bounded)", len(res.Combined), maxRetained)
+	}
+	if !bytes.HasPrefix(res.Combined, []byte("HEADSTART")) {
+		t.Fatalf("retained head lost: %q", head64(res.Combined))
+	}
+	if !bytes.HasSuffix(res.Combined, []byte("TAILEND")) {
+		t.Fatalf("retained tail lost: %q", tail64(res.Combined))
+	}
+	if !bytes.Contains(res.Combined, []byte(truncationMarker)) {
+		t.Fatalf("truncation marker missing from %q", res.Combined)
+	}
+}
+
+// TestCapture_HeadTailAssembly exercises the capture ring directly across the
+// boundary cases: everything-in-head, head+tail-no-loss, and wrapped-with-loss.
+func TestCapture_HeadTailAssembly(t *testing.T) {
+	tests := []struct {
+		name       string
+		head, tail int
+		writes     []string
+		want       string
+		truncated  bool
+	}{
+		{name: "all in head", head: 4, tail: 4, writes: []string{"ab"}, want: "ab", truncated: false},
+		{name: "exact head only", head: 4, tail: 4, writes: []string{"abcd"}, want: "abcd", truncated: false},
+		{name: "head plus tail no loss", head: 4, tail: 4, writes: []string{"abcdWXYZ"}, want: "abcdWXYZ", truncated: false},
+		{name: "partial tail no loss", head: 4, tail: 4, writes: []string{"abcdWX"}, want: "abcdWX", truncated: false},
+		{name: "wrapped with loss", head: 4, tail: 4, writes: []string{"abcd", "1234567", "WXYZ"}, want: "abcd" + truncationMarker + "WXYZ", truncated: true},
+		{name: "single oversize write", head: 4, tail: 4, writes: []string{"abcdefghijkWXYZ"}, want: "abcd" + truncationMarker + "WXYZ", truncated: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newCapture(tc.head, tc.tail)
+			for _, w := range tc.writes {
+				n, err := c.Write([]byte(w))
+				if err != nil || n != len(w) {
+					t.Fatalf("Write(%q) = %d, %v", w, n, err)
+				}
+			}
+			if got := string(c.Bytes()); got != tc.want {
+				t.Fatalf("Bytes() = %q, want %q", got, tc.want)
+			}
+			if c.Truncated() != tc.truncated {
+				t.Fatalf("Truncated() = %v, want %v", c.Truncated(), tc.truncated)
+			}
+		})
+	}
+}
+
+func head64(b []byte) string {
+	if len(b) > 64 {
+		return string(b[:64])
+	}
+	return string(b)
+}
+
+func tail64(b []byte) string {
+	if len(b) > 64 {
+		return string(b[len(b)-64:])
+	}
+	return string(b)
+}
+
+// TestRun_RejectsPreCancelledContext confirms the fail-fast guard.
+func TestRun_RejectsPreCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd := shellCmd(ctx, "true")
+	if _, err := Run(ctx, cmd, Options{Combined: true}); err == nil {
+		t.Fatalf("Run with cancelled ctx = nil error, want ctx error")
+	} else if !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("Run error = %v, want context canceled", err)
+	}
+}

--- a/cli/internal/procrun/procrun_unix.go
+++ b/cli/internal/procrun/procrun_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package procrun
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// configureProcessGroup starts the child in its own process group (Setpgid) and
+// installs a Cancel that kills the ENTIRE group (kill(-pgid)), so cancelling or
+// timing out a run reaps grandchildren the direct child spawned instead of
+// orphaning them. Cancel tolerates a not-yet-started process.
+func configureProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		// Negative PID targets the process group whose leader is the child;
+		// with Setpgid the child's PGID equals its PID.
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}

--- a/cli/internal/procrun/procrun_unix.go
+++ b/cli/internal/procrun/procrun_unix.go
@@ -3,6 +3,7 @@
 package procrun
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
 )
@@ -19,6 +20,25 @@ func configureProcessGroup(cmd *exec.Cmd) {
 		}
 		// Negative PID targets the process group whose leader is the child;
 		// with Setpgid the child's PGID equals its PID.
-		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			// ESRCH means the group already exited between the ctx cancellation
+			// and this kill — that is the success case. Report ErrProcessDone so
+			// Wait surfaces the real exit status instead of a spurious
+			// "exec: canceling Cmd" error for a command that actually completed.
+			if err == syscall.ESRCH {
+				return os.ErrProcessDone
+			}
+			return err
+		}
+		return nil
 	}
+}
+
+// reapProcessGroup best-effort kills any process still alive in the child's
+// group after Wait returned, so a grandchild that outlived the direct child
+// (holding a pipe past WaitDelay) is always reaped. ESRCH — the group is already
+// gone — is the success case; all errors are ignored because this runs as
+// post-Wait cleanup.
+func reapProcessGroup(pid int) {
+	_ = syscall.Kill(-pid, syscall.SIGKILL)
 }

--- a/cli/internal/procrun/procrun_windows.go
+++ b/cli/internal/procrun/procrun_windows.go
@@ -3,16 +3,23 @@
 package procrun
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strconv"
 	"syscall"
+	"time"
 )
 
+// taskkillTimeout bounds each taskkill invocation so a hung taskkill cannot make
+// Run (via Cancel) or the post-Wait reap block indefinitely.
+const taskkillTimeout = 5 * time.Second
+
 // configureProcessGroup starts the child in a new process group
-// (CREATE_NEW_PROCESS_GROUP) and installs a Cancel that terminates the whole
-// process tree via `taskkill /T /F`, the Windows analogue of kill(-pgid). Cancel
-// tolerates a not-yet-started process.
+// (CREATE_NEW_PROCESS_GROUP) and installs a Cancel that terminates the process
+// tree via `taskkill /T /F`. Note this is a best-effort tree kill, NOT a
+// containment guarantee (no Job Object); see the package doc. Cancel tolerates a
+// not-yet-started process.
 func configureProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
@@ -25,11 +32,23 @@ func configureProcessGroup(cmd *exec.Cmd) {
 	}
 }
 
-// killProcessTree terminates a process and all its descendants on Windows.
+// killProcessTree best-effort terminates a process and its descendants via
+// taskkill /T /F, under its own timeout so a hung taskkill cannot stall the
+// caller. Best-effort only — taskkill after the root exits can miss re-parented
+// descendants.
 func killProcessTree(pid int) error {
-	kill := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid))
+	ctx, cancel := context.WithTimeout(context.Background(), taskkillTimeout)
+	defer cancel()
+	kill := exec.CommandContext(ctx, "taskkill", "/T", "/F", "/PID", strconv.Itoa(pid))
 	if out, err := kill.CombinedOutput(); err != nil {
 		return fmt.Errorf("taskkill PID %d: %w (%s)", pid, err, out)
 	}
 	return nil
+}
+
+// reapProcessGroup best-effort terminates any surviving descendants after Wait
+// returned. Errors are ignored — this runs as post-Wait cleanup and, on Windows,
+// is only a best-effort guarantee.
+func reapProcessGroup(pid int) {
+	_ = killProcessTree(pid)
 }

--- a/cli/internal/procrun/procrun_windows.go
+++ b/cli/internal/procrun/procrun_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package procrun
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"syscall"
+)
+
+// configureProcessGroup starts the child in a new process group
+// (CREATE_NEW_PROCESS_GROUP) and installs a Cancel that terminates the whole
+// process tree via `taskkill /T /F`, the Windows analogue of kill(-pgid). Cancel
+// tolerates a not-yet-started process.
+func configureProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return killProcessTree(cmd.Process.Pid)
+	}
+}
+
+// killProcessTree terminates a process and all its descendants on Windows.
+func killProcessTree(pid int) error {
+	kill := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid))
+	if out, err := kill.CombinedOutput(); err != nil {
+		return fmt.Errorf("taskkill PID %d: %w (%s)", pid, err, out)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Bead `age-eval-subprocess-lifecycle-uf9d6` — the 2026-07-24 Go audit's G2 program, the last OPEN High-adjacent residue. New `cli/internal/procrun` runner, migrated onto all four unbounded sites.

**The runner:**
- Head+tail bounded capture: fixed peak memory regardless of child output; keeps draining so the child never blocks on a full pipe; under-cap output byte-identical; over-cap preserves true head and true tail with a discard marker.
- `Run(ctx, ...)`: process-group start (`Setpgid` / windows process group), cancel kills the group, 3s `WaitDelay` so `Wait` can't hang on pipes a grandchild holds, and — post-review — the group is reaped **unconditionally after Wait on every path**, so a descendant surviving a normal child exit is still killed (witnessed: backgrounded no-`wait` sleeper reaped).
- Unix ESRCH race mapped to `os.ErrProcessDone` (50× completion-vs-cancel race under `-race`: a completed command never reports an error). Windows `taskkill` bounded by its own 5s timeout with the best-effort no-Job-Object guarantee documented rather than faked.

**Migrated sites:** goals `MeasureOneContext` (SIGINT child-tracker hooks preserved), gates `ScriptRunner` (gains group-kill + WaitDelay, 4KiB LogTail preserved), eval `executeCaseCommand` and expectations autodetect — caller ctx threaded end-to-end via `RunSuiteContext`/`RunBaselineABContext`/`RunContextABContext` + `CoreRuntime`; no `context.Background()` remains on these paths. Cancellation is semantic: guards before the suite, before each case, **and after the loop** (a cancel during the final/only case is terminal, never scored — single-case witness), A/B never starts its second leg cancelled. Start-failure error text verified byte-identical at all three consumer sites. Live-runtime capture and the adapter RunStats call are explicitly out of scope (noted in commit).

## Validation

- `go build`/`go vet` clean; full `go test ./...` green; `-race -count=1` clean on procrun/eval/goals; golangci 0 issues on five touched packages; `GOOS=windows` build ok
- Cross-family review two rounds: round 1 five findings all fixed (always-reap, bounded windows cancel, ESRCH race, semantic cancellation, error-text compat); round 2's one residual (final-case cancellation) fixed with witness

Tracker: `age-eval-subprocess-lifecycle-uf9d6`