### PR TITLE
Make fresh validation persistence optional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,13 @@ Detailed workflow mechanics: [docs/agent-workflow-reference.md](docs/agent-workf
 AgentOps turns one explicit intent into one independently judged experiment:
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> report and stop
 ```
 
-No evidence-backed verdict means the experiment is not proven. AgentOps does
-not own what the caller does next.
+No fresh independent judgment over the exact subject means the experiment is
+not proven. Persist `verdict.v2` only when the caller requests machine-readable
+evidence or a declared downstream consumer requires it. AgentOps does not own
+what the caller does next.
 
 ## Authority and trust
 
@@ -66,11 +68,13 @@ Edit source owners and regenerate projections through the owning command.
    completeness, and factual check receipts; the model does not transcribe a
    candidate packet.
 3. **Validate once, fresh.** A distinct context verifies the intent-source
-   digest, subject identity, scope, evidence, and acceptance, then writes one `verdict.v2` with
-   `PASS | FAIL | NOT_PROVEN`. Missing or colliding context identities,
+   digest, subject identity, scope, evidence, and acceptance, then returns one
+   `PASS | FAIL | NOT_PROVEN` result. Missing or colliding context identities,
    unattested freshness, subject mutation, or incomplete changed-path coverage
    is `NOT_PROVEN`; proven out-of-scope change is `FAIL`. PASS requires nonempty
    checked scope, top-level evidence, and evidence for every criterion.
+   Persistence is conditional: Validate writes `verdict.v2` only for a caller
+   request or a declared downstream consumer.
 4. **Report and stop.** RPI reports `PASS | FAIL | NOT_PROVEN`, or the report-only
    statuses `NOT_PLANNED | NOT_BUILT`. It emits no next action and performs no
    automatic revision. Two consecutive control artifacts (plans, audits,
@@ -86,8 +90,9 @@ cannot change core outcomes.
 
 ## Product boundary
 
-AgentOps reads or refines caller-owned intent, runs one bounded experiment, exact content identity,
-fresh independent judgment, and a standalone durable verdict. It owns no retry,
+AgentOps reads or refines caller-owned intent, runs one bounded experiment,
+establishes exact content identity, and obtains fresh independent judgment. It
+can persist that judgment as standalone evidence when requested. It owns no retry,
 budget, queue, work ownership, Git, closure, release, landing, or delivery
 transition. Consumer repositories keep their own direct-push, PR, CI, merge,
 rollback, and release policy.
@@ -117,6 +122,7 @@ AgentOps work ownership.
 ## Closeout
 
 Inspect the final subject, map acceptance to evidence, disclose `checked` and
-`not_checked`, and obtain one fresh verdict over the exact content. Report
-residual risk plainly. Git status, pushing, merging, release, and rollback are
-handled by the caller's repository policy, outside semantic completion.
+`not_checked`, and obtain one fresh validation result over the exact content.
+Include a verdict reference only when persistence was requested. Report residual
+risk plainly. Git status, pushing, merging, release, and rollback are handled
+by the caller's repository policy, outside semantic completion.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -10,7 +10,7 @@ can independently judge.
 The product boundary is deliberately small:
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> report and stop
 ```
 
 ## Proven floor
@@ -21,11 +21,11 @@ AgentOps provides:
 - one bounded RED -> GREEN -> refactor experiment;
 - deterministic content identity independent of Git;
 - one fresh, author-distinct semantic judgment;
-- a standalone, content-addressed `PASS | FAIL | NOT_PROVEN` verdict.
+- a `PASS | FAIL | NOT_PROVEN` result with optional content-addressed storage.
 
-No fresh evidence-backed verdict means the experiment is not proven. The
-verdict's context separation is explicitly attested; it is not claimed as
-cryptographic proof of model isolation.
+No fresh evidence-backed judgment means the experiment is not proven. Context
+separation is explicitly attested; it is not claimed as cryptographic proof of
+model isolation.
 
 ## What AgentOps does not own
 
@@ -34,7 +34,7 @@ release manager, scheduler, or autonomous retry controller. It does not own:
 
 - retries, budgets, queues, claims, leases, work ownership, or next actions;
 - Git commits, branches, pushes, PRs, merges, rollback, closure, or release;
-- the caller's decision after a verdict;
+- the caller's decision after a validation result;
 - mandatory provenance or learning on the validation critical path.
 
 Repositories and callers keep those policies. They may use direct pushes, PRs,
@@ -50,7 +50,7 @@ Four load-bearing skills define the core:
 | `rpi` | dispatch Plan, Implement, and Validate once; report and stop |
 | `plan` | shape acceptance, evidence, and write scope |
 | `implement` | run one bounded experiment and produce a candidate |
-| `validate` | independently judge exact content and persist the verdict |
+| `validate` | independently judge exact content; persist only for a declared consumer |
 
 `learn` remains an optional off-path consumer of verdict collections. Strategy
 skills such as Premortem, Postmortem, Council, and idea genies add judgment when
@@ -64,11 +64,12 @@ not a CLI state machine.
 
 ## Sovereign evidence
 
-The durable verdict is plain JSON under caller-controlled storage. It binds
-acceptance, exact subject content, author and validator identities, criterion
-results, evidence, checked scope, and omissions. A generic provenance ledger
-may copy or reference it later, but ledger availability is never required for
-validity.
+Fresh validation binds acceptance, exact subject content, author and validator
+identities, criterion results, evidence, checked scope, and omissions. When a
+caller or declared downstream consumer needs durable machine-readable evidence,
+the same result is plain `verdict.v2` JSON under caller-controlled storage. A
+generic provenance ledger may copy or reference it later, but verdict storage
+and ledger availability are never required for validity.
 
 ## Learning thesis
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # AgentOps
 
 AgentOps is the operating loop a coding agent follows: one intent, one bounded
-build, one fresh judge, one durable verdict. It also ships skills to orchestrate
+build, one fresh judge, then report and stop. It also ships skills to orchestrate
 multi-agent systems. For contested calls, opt into
 [`council`](skills/council/SKILL.md) (independent judges) or
 [`idea-genie`](skills/idea-genie/SKILL.md) duel mode (sealed perspectives
 before Plan).
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> report and stop
 ```
 
 ## Quickstart
@@ -148,8 +148,8 @@ run in a fresh context and may use a different model. It issues `PASS`,
 
 A single context can share blind spots with the author. Opt into
 [`idea-genie`](skills/idea-genie/SKILL.md) or [`council`](skills/council/SKILL.md)
-for sealed or multi-judge review. They return a report;
-[`validate`](skills/validate/SKILL.md) writes `verdict.v2`.
+for sealed or multi-judge review. They return a report; an author-distinct
+[`validate`](skills/validate/SKILL.md) context issues the binding result.
 
 ### 3. Acceptance drifted mid-flight
 
@@ -159,9 +159,11 @@ phases bind to that digest.
 
 ### 4. Nobody can replay what was judged
 
-Chat scrolls away. `validate` writes a content-addressed `verdict.v2` under
-`.agents/ao/verdicts/sha256/` with checked scope, omissions, and evidence
-refs. Plain JSON. No hosted service required.
+Chat scrolls away. When replay or automation needs durable evidence, `validate`
+writes a content-addressed `verdict.v2` under
+`.agents/ao/verdicts/sha256/` with checked scope, omissions, and evidence refs.
+Plain JSON. No hosted service required. Interactive validation does not create
+one unless requested.
 
 ## Core skills
 
@@ -170,7 +172,7 @@ refs. Plain JSON. No hosted service required.
 | [`rpi`](skills/rpi/SKILL.md) | run Plan, Implement, and fresh Validate at most once |
 | [`plan`](skills/plan/SKILL.md) | create the bead (BDD + DDD ubiquitous language) |
 | [`implement`](skills/implement/SKILL.md) | TDD against the bead: RED → GREEN → refactor |
-| [`validate`](skills/validate/SKILL.md) | fresh context (optionally different model); persist `verdict.v2` |
+| [`validate`](skills/validate/SKILL.md) | fresh context (optionally different model); optionally persist `verdict.v2` |
 
 Optional later: [`learn`](skills/learn/SKILL.md). Strategies:
 [`council`](skills/council/SKILL.md), [`idea-genie`](skills/idea-genie/SKILL.md),

--- a/cli/README.md
+++ b/cli/README.md
@@ -4,7 +4,7 @@
 AgentOps semantic loop lives in the skills:
 
 ```text
-RPI → Plan → Implement → fresh Validate → durable verdict → report and stop
+RPI → Plan → Implement → fresh Validate → report and stop
 ```
 
 The CLI does not own retries, queues, work claims, Git delivery, release,
@@ -38,8 +38,9 @@ make test
 ```
 
 Add deterministic utilities only when they do not become lifecycle or delivery
-authorities. Keep semantic judgment in the Validate skill and external delivery
-in the consumer repository.
+authorities. Keep semantic judgment in the Validate skill, optional verdict
+persistence with declared consumers, and external delivery in the consumer
+repository.
 
 ## References
 

--- a/cli/internal/commands/demo/module.go
+++ b/cli/internal/commands/demo/module.go
@@ -53,7 +53,7 @@ func (Module) Command() *cobra.Command {
 		Short: "Show the one-pass AgentOps evidence loop",
 		Long: `Show the AgentOps product boundary:
 
-  RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report
+  RPI -> Plan -> Implement -> fresh Validate -> report and stop
 
 The repository keeps its own Git, CI, tracker, release, and delivery policy.`,
 		GroupID: "start",
@@ -73,8 +73,8 @@ func showConcepts(w io.Writer) error {
 	fmt.Fprintln(w, `AGENTOPS PRODUCT BOUNDARY
 
 AgentOps shapes one behavior, runs one bounded implementation experiment,
-obtains one fresh independent judgment over exact content, persists the verdict,
-reports it, and stops.
+obtains one fresh independent judgment over exact content, reports it, and
+stops. Machine-readable verdict persistence is optional and consumer-driven.
 
 It does not own retries, budgets, queues, work ownership, Git, closure, release,
 or delivery. Learn and multi-agent strategies are optional callers.`)
@@ -88,7 +88,7 @@ func quickDemo(w io.Writer) error {
 2. Implement runs one bounded RED -> GREEN -> refactor experiment.
 3. The runtime derives changed paths, check receipts, and subject-manifest.v1.
 4. A distinct fresh context validates the exact intent and subject once.
-5. Validate atomically stores verdict.v2 under .agents/ao/verdicts/sha256/.
+5. Validate returns one fresh validation result; verdict.v2 persistence is optional.
 6. RPI reports PASS, FAIL, NOT_PROVEN, NOT_PLANNED, or NOT_BUILT and stops.
 
 No Git repository or ao binary is required for this semantic loop.`)

--- a/cli/internal/commands/demo/module_test.go
+++ b/cli/internal/commands/demo/module_test.go
@@ -37,7 +37,7 @@ func TestDemoShowsOnePassBoundary(t *testing.T) {
 	if err := quickDemo(&out); err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"AGENTOPS ONE-PASS DEMO", "existing intent source", "runtime derives", "subject-manifest.v1", "verdict.v2", "stops"} {
+	for _, want := range []string{"AGENTOPS ONE-PASS DEMO", "existing intent source", "runtime derives", "subject-manifest.v1", "fresh validation result", "persistence is optional", "stops"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("demo missing %q:\n%s", want, out.String())
 		}

--- a/cli/internal/commands/quickstart/module.go
+++ b/cli/internal/commands/quickstart/module.go
@@ -45,7 +45,7 @@ func (Module) Command() *cobra.Command {
 		Long: `AgentOps is a small semantic evidence layer around agent work.
 
 Run the RPI skill for one pass:
-  Plan -> Implement -> fresh Validate -> durable verdict -> report and stop
+  Plan -> Implement -> fresh Validate -> report and stop
 
 The CLI does not claim work, retry, manage Git, or deliver changes. Use
 ao gate check for deterministic repository checks and ao provenance for
@@ -53,9 +53,10 @@ generic evidence inspection.`,
 		Args:    cobra.NoArgs,
 		GroupID: "start",
 		Run: func(cmd *cobra.Command, _ []string) {
-			fmt.Fprintln(cmd.OutOrStdout(), "RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop")
+			fmt.Fprintln(cmd.OutOrStdout(), "RPI -> Plan -> Implement -> fresh Validate -> report and stop")
 			fmt.Fprintln(cmd.OutOrStdout(), "Deterministic checks: ao gate check")
 			fmt.Fprintln(cmd.OutOrStdout(), "Semantic judgment: invoke the Validate skill from a fresh context")
+			fmt.Fprintln(cmd.OutOrStdout(), "Artifact persistence: optional; request verdict.v2 only for machine-readable evidence")
 		},
 	}
 }

--- a/cli/internal/commands/quickstart/module_test.go
+++ b/cli/internal/commands/quickstart/module_test.go
@@ -46,9 +46,10 @@ func TestCommand_RunPrintsWorkflow(t *testing.T) {
 	command.SetOut(&out)
 	command.Run(command, nil)
 	for _, want := range []string{
-		"RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop",
+		"RPI -> Plan -> Implement -> fresh Validate -> report and stop",
 		"Deterministic checks: ao gate check",
 		"Semantic judgment: invoke the Validate skill from a fresh context",
+		"Artifact persistence: optional",
 	} {
 		if !strings.Contains(out.String(), want) {
 			t.Errorf("quick-start output missing %q, got:\n%s", want, out.String())

--- a/cli/testdata/compatibility-baseline/families/quickstart/case.json
+++ b/cli/testdata/compatibility-baseline/families/quickstart/case.json
@@ -4,7 +4,7 @@
   "checks": [
     {
       "id": "quickstart-black-box",
-      "command": "tmp=$(mktemp -d /tmp/ao-quickstart.XXXXXX); (cd cli && go build -o \"$tmp/ao\" ./cmd/ao); \"$tmp/ao\" quick-start --help >\"$tmp/help\"; grep -Fq 'Show the single-pass AgentOps workflow' \"$tmp/help\"; grep -Fq 'AgentOps is a small semantic evidence layer around agent work' \"$tmp/help\"; \"$tmp/ao\" quick-start >\"$tmp/text\"; grep -Fq 'RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop' \"$tmp/text\"; grep -Fq 'Deterministic checks: ao gate check' \"$tmp/text\"; grep -Fq 'Semantic judgment: invoke the Validate skill from a fresh context' \"$tmp/text\"; if \"$tmp/ao\" quick-start extra-arg >/dev/null 2>&1; then echo 'quick-start accepted a positional arg' >&2; exit 1; fi"
+      "command": "tmp=$(mktemp -d /tmp/ao-quickstart.XXXXXX); (cd cli && go build -o \"$tmp/ao\" ./cmd/ao); \"$tmp/ao\" quick-start --help >\"$tmp/help\"; grep -Fq 'Show the single-pass AgentOps workflow' \"$tmp/help\"; grep -Fq 'AgentOps is a small semantic evidence layer around agent work' \"$tmp/help\"; \"$tmp/ao\" quick-start >\"$tmp/text\"; grep -Fq 'RPI -> Plan -> Implement -> fresh Validate -> report and stop' \"$tmp/text\"; grep -Fq 'Deterministic checks: ao gate check' \"$tmp/text\"; grep -Fq 'Semantic judgment: invoke the Validate skill from a fresh context' \"$tmp/text\"; grep -Fq 'Artifact persistence: optional' \"$tmp/text\"; if \"$tmp/ao\" quick-start extra-arg >/dev/null 2>&1; then echo 'quick-start accepted a positional arg' >&2; exit 1; fi"
     },
     {
       "id": "quickstart-go-behavior",

--- a/docs/3.3.md
+++ b/docs/3.3.md
@@ -10,7 +10,7 @@ expensive proof.
 Version 3.3 removes that control plane.
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> report and stop
 ```
 
 ## What AgentOps owns

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@ existing bead or caller intent
   -> one bounded implementation experiment
   -> runtime-derived subject-manifest.v1 + check receipts
   -> fresh Validate
-  -> verdict.v2
+  -> PASS | FAIL | NOT_PROVEN
   -> RPI report and stop
 ```
 
@@ -19,8 +19,9 @@ existing bead or caller intent
   returns runtime-derived subject identity, actual changed paths, and factual
   check receipts.
 - **Validate** identifies the exact subject without Git, checks scope and
-  acceptance, obtains one judgment from a distinct declared context, and stores
-  a content-addressed verdict atomically.
+  acceptance, and obtains one judgment from a distinct declared context. It
+  stores a content-addressed verdict atomically only when requested by the
+  caller or a declared downstream consumer.
 - **RPI** invokes each core phase at most once and reports the result.
 
 `FAIL` and `NOT_PROVEN` are terminal results for that invocation. A caller may
@@ -34,8 +35,8 @@ managed agents, Git metadata, trackers, provenance, and councils are optional
 adapters or strategies. Missing or corrupt adapters cannot change a core
 outcome.
 
-Generic provenance may record a verdict after it is written. Provenance
-availability is never required for verdict validity.
+Generic provenance may record a verdict after one is persisted. Provenance and
+artifact storage are never required for a fresh validation result to be valid.
 
 ## Repository boundary
 

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -4,15 +4,16 @@ Repository authority and the core work boundary are defined in [AGENTS.md](../AG
 
 AgentOps reads or refines the existing bead/caller intent, runs one bounded
 implementation experiment, derives exact content identity, obtains one
-author-distinct Validate verdict, and stores that verdict. It does not own Git
-delivery, merge policy, retries, queues, work ownership, or release transitions.
+author-distinct Validate result, and optionally stores that result when a caller
+or declared downstream consumer requests it. It does not own Git delivery,
+merge policy, retries, queues, work ownership, or release transitions.
 
 Repositories own delivery policy for local and cloud agents.
 
 ## Separation of responsibilities
 
 ```text
-AgentOps: Plan -> Implement once -> Validate once -> verdict.v2 -> stop
+AgentOps: Plan -> Implement once -> Validate once -> report and stop
 Repository: deterministic checks -> repository-selected Git/CI/release policy
 ```
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -9,7 +9,8 @@
 | RPI | The one-pass wrapper around Plan, Implement, and Validate. |
 | Subject manifest | Deterministic content identity over paths, kinds, executable bits, and content or symlink digests. |
 | Validate | Independent semantic judgment over exact acceptance and subject identities. |
-| Verdict | `PASS`, `FAIL`, or `NOT_PROVEN` in `verdict.v2`. |
+| Validation result | `PASS`, `FAIL`, or `NOT_PROVEN` returned by a fresh validator. |
+| `verdict.v2` | Optional content-addressed representation of a validation result for machine consumers. |
 | Strategy | Optional advice such as premortem, postmortem, council, or an idea genie. |
 | Adapter | Optional runtime or transport that cannot change core semantics. |
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -3,7 +3,7 @@
 AgentOps now owns one small product boundary:
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> report and stop
 ```
 
 The caller owns whether to revise, run another invocation, schedule work, use a
@@ -74,10 +74,11 @@ mkdir -p ~/.agents/ao && mv ~/.agentops/config.yaml ~/.agents/ao/config.yaml
 
 ## Verdicts and identity
 
-`verdict.v2` binds acceptance and a deterministic `subject-manifest.v1` to
-distinct declared author and validator context identities. Freshness is an
-attested trust fact, not cryptographic proof of process isolation. Verdicts are
-stored atomically by content digest under `.agents/ao/verdicts/sha256/` unless a
+When persistence is requested, `verdict.v2` binds acceptance and a deterministic
+`subject-manifest.v1` to distinct declared author and validator context
+identities. Freshness is an attested trust fact, not cryptographic proof of
+process isolation. Verdicts are stored atomically by content digest under
+`.agents/ao/verdicts/sha256/` unless a
 caller supplies another directory.
 
 Historical Pawl, queue, claim, landing, and lifecycle artifacts remain inert

--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -76,5 +76,5 @@
 | `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `inspect_pack_registries`, `drive_mayor_door` | `operate_gas_city`, `configure_codex_trust` |
-| `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
+| `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `return_validation_result`, `persist_verdict` | `write_verdict_artifact` |
 | `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -76,5 +76,5 @@
 | `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `inspect_pack_registries`, `drive_mayor_door` | `operate_gas_city`, `configure_codex_trust` |
-| `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
+| `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `return_validation_result`, `persist_verdict` | `write_verdict_artifact` |
 | `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -28,7 +28,7 @@ Three actions prevent broken workflows after upgrading:
 The semantic loop is now:
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> report and stop
 ```
 
 AgentOps no longer owns retry, queue, work-claim, Git, closure, release, or
@@ -79,11 +79,11 @@ Use:
 
 ### Migrate verdict consumers
 
-Replace `verdict.v1`, Pawl receipts, admission records, and delivery receipts
-with `verdict.v2`. A PASS requires distinct declared author and validator context
-IDs, explicit freshness attestation, acceptance and subject digests, checked and
-unchecked scope, and criterion-level results. Missing identity or incomplete
-subject proof produces `NOT_PROVEN`.
+Replace persisted `verdict.v1`, Pawl receipts, admission records, and delivery
+receipts with optional `verdict.v2`. A PASS still requires distinct declared
+author and validator context IDs, explicit freshness attestation, acceptance
+and subject digests, checked and unchecked scope, and criterion-level results.
+Missing identity or incomplete subject proof produces `NOT_PROVEN`.
 
 Historical lifecycle artifacts may remain as inert evidence. They must not
 influence current phase sequencing or verdict validity.

--- a/docs/agent-workflow-reference.md
+++ b/docs/agent-workflow-reference.md
@@ -5,7 +5,7 @@ This document expands the repository contract in [AGENTS.md](../AGENTS.md).
 The public AgentOps workflow has one pass:
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> report and stop
 ```
 
 ## 1. Plan
@@ -33,13 +33,16 @@ or deliver.
 
 ## 3. Validate
 
-An author-distinct context judges the exact subject against acceptance and
-writes one content-addressed `verdict.v2`. Validate is the only verdict writer.
-It returns `PASS`, `FAIL`, or `NOT_PROVEN`, lists checked and unchecked scope,
-and stops. PASS requires nonempty checked scope, top-level evidence, and evidence
+An author-distinct context judges the exact subject against acceptance. It
+returns `PASS`, `FAIL`, or `NOT_PROVEN`, lists checked and unchecked scope, and
+stops. PASS requires nonempty checked scope, top-level evidence, and evidence
 for every criterion. A `NOT_PROVEN` finding states the concrete missing runtime
 precondition or examined uncertainty; it does not manufacture a next action.
 Validate does not repair, re-plan, choose a next action, or authorize Git.
+
+The returned result is sufficient for interactive use. Validate persists the
+same result as content-addressed `verdict.v2` only when the caller requests a
+machine-readable artifact or a declared downstream consumer requires one.
 
 ## 4. Caller continuation
 

--- a/docs/architecture/component-map.md
+++ b/docs/architecture/component-map.md
@@ -7,8 +7,8 @@
 | Intent | One experiment in a caller-owned bead or issue, single-mint exact snapshot, stable criterion IDs, write scope | A duplicate AgentOps planning artifact or campaign graph |
 | Experiment | One bounded candidate, complete actual changed paths, factual checks, and observed effect receipts | Repair loops, Git, delivery, or later work selection |
 | Identity | Exact intent, before/final subject manifests, and proof-contract digests | Commit, branch, or tracker authority |
-| Judgment | Fresh-context evaluation and `verdict.v2` under an activated proof contract | Candidate edits, self-activation, continuation, closure, or release |
-| Evidence | Atomic content-addressed verdict storage, proof transitions, and generic provenance | Admission or lifecycle state |
+| Judgment | Fresh-context evaluation over exact intent and subject; optional `verdict.v2` persistence | Candidate edits, self-activation, continuation, closure, or release |
+| Evidence | Optional atomic content-addressed verdict storage and generic provenance | Admission or lifecycle state |
 | Capability evolution | Recurrence, causal, toil, and pattern observations; reusable-capability proposals | Automatic promotion or policy mutation |
 | Repository checks | Deterministic `ao gate check` execution | Semantic judgment |
 | Optional adapters | Explicit packet execution, runtime coordination, and runtime facts | Selection, retries, integration, or validation authority |

--- a/docs/architecture/operating-loop.md
+++ b/docs/architecture/operating-loop.md
@@ -9,7 +9,7 @@ intent
   -> one bounded implementation experiment
   -> runtime-derived subject-manifest.v1 + check receipts
   -> one fresh independent validation
-  -> durable verdict.v2
+  -> PASS | FAIL | NOT_PROVEN
   -> report and stop
 ```
 
@@ -20,7 +20,7 @@ intent
 | Caller | intent source, invocation, optional strategies, any later revision or delivery | semantic PASS unless acting in a fresh validator context |
 | Plan | refining acceptance and write boundary in the existing source | a duplicate planning artifact, scheduling, ownership, readiness |
 | Implement | one subject change and factual evidence | validation, repair loop, Git, closure, delivery |
-| Validate | exact identity, independent judgment, durable verdict | subject edits, retries, next actions, release |
+| Validate | exact identity, independent judgment, optional durable evidence | subject edits, retries, next actions, release |
 | RPI | one ordered dispatch and report | a controller around repeated invocations |
 
 One model may fill multiple roles across distinct contexts. PASS requires
@@ -82,18 +82,20 @@ the evidence, and judges every acceptance criterion.
 - Complete evidence satisfying every criterion, with nonempty checked scope and
   evidence references: `PASS`.
 
-The verdict records criterion results, findings, evidence references, checked
-and not-checked surfaces, timestamp, identities, freshness, and artifact digest.
-It carries no WARN, confidence, disposition, learning, owner, next action,
-retry, closure, release, or delivery state.
+The validation result records criterion results, findings, evidence references,
+checked and not-checked surfaces, identities, and freshness. It carries no
+WARN, confidence, disposition, learning, owner, next action, retry, closure,
+release, or delivery state. Returning that result to the caller completes
+Validate; storage is not a precondition for semantic judgment.
 
-Validate alone persists verdicts. Default storage is
-`.agents/ao/verdicts/sha256/<digest>.json`; a caller may provide `verdict_dir`.
-The digest is SHA-256 over canonical JSON without `artifact_digest`. Writes are
-same-directory, flushed, fsynced, and atomically renamed. Exact existing content
-is idempotent. Conflicting content is an integrity failure and cannot produce
-PASS. Provenance may record a verdict afterward, but ledger availability never
-affects validity.
+When the caller requests machine-readable evidence or a declared downstream
+consumer requires it, Validate alone may persist `verdict.v2`. Default storage
+is `.agents/ao/verdicts/sha256/<digest>.json`; a caller may provide
+`verdict_dir`. The digest is SHA-256 over canonical JSON without
+`artifact_digest`. Writes are same-directory, flushed, fsynced, and atomically
+renamed. Exact existing content is idempotent. Conflicting content is an
+integrity failure and cannot produce PASS. Provenance may record a persisted
+verdict afterward, but ledger availability never affects validity.
 
 ## Stop boundary and revision
 
@@ -103,9 +105,9 @@ a second phase. `NOT_PLANNED` and `NOT_BUILT` describe RPI progress only and are
 not verdict values.
 
 If a caller wants another experiment, it updates the existing bead or caller
-intent and starts a new invocation. Prior verdicts and manifests remain durable
-evidence, but AgentOps does not require a model-authored revision packet.
-Changed acceptance is represented once in the intent source.
+intent and starts a new invocation. Any persisted verdicts and manifests remain
+durable evidence, but AgentOps does not require a model-authored revision
+packet. Changed acceptance is represented once in the intent source.
 
 ## Optional ports
 

--- a/docs/architecture/ports-and-adapters.md
+++ b/docs/architecture/ports-and-adapters.md
@@ -6,15 +6,16 @@ The core has four ports:
 |---|---|---|
 | Plan | Existing bead or caller intent | Same source refined in place, or a concise proposed amendment |
 | Implement | Resolved intent | Runtime-derived subject manifest and check receipts, or `NOT_BUILT` |
-| Validate | Intent digest, exact subject, receipts, independent context identity | durable `verdict.v2` |
-| Report | Phase outputs | `rpi-report.v1` |
+| Validate | Intent digest, exact subject, receipts, independent context identity | `PASS | FAIL | NOT_PROVEN`; optional `verdict.v2` |
+| Report | Phase outputs | Interactive result; optional `rpi-report.v1` |
 
 The pure subject-manifest helper is bundled with Validate and requires no Git,
 tracker, queue, network, release, or delivery executable.
 
-Optional adapters may execute explicitly supplied intent slices or append generic
-provenance after a verdict exists. Adapter availability, corruption, ordering,
-or failure cannot change phase sequencing or semantic outcomes.
+Optional adapters may execute explicitly supplied intent slices or append
+generic provenance after a persisted verdict exists. Adapter availability,
+corruption, ordering, or failure cannot change phase sequencing or semantic
+outcomes.
 
 The caller may use a tracker as the intent source; AgentOps does not become the
 tracker. Git, CI, release systems, and delivery mechanisms are outside the

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -146,5 +146,6 @@
 | `using-gc` | produces | `gas-city-runtime-evidence` |
 | `validate` | consumes | `subject-manifest.v1` |
 | `validate` | produces | `subject-manifest.v1` |
+| `validate` | produces | `validation-result` |
 | `validate` | produces | `verdict.v2` |
 | `workflow-builder` | produces | `workflow-script` |

--- a/docs/contracts/local-pre-push-gate-retirement.md
+++ b/docs/contracts/local-pre-push-gate-retirement.md
@@ -11,15 +11,15 @@ trying to publish, which made ordinary delivery slow and fragile.
 ## Current decision
 
 AgentOps stops after one exact candidate has deterministic evidence and one
-durable verdict from fresh context. The consumer repository owns delivery for
-local and cloud agents. It may use direct push, a PR, hosted CI, or a small
-deterministic hook.
+fresh-context validation result. Persisted verdict evidence is optional. The
+consumer repository owns delivery for local and cloud agents. It may use direct
+push, a PR, hosted CI, or a small deterministic hook.
 
 A repository hook or CI job may run deterministic repository checks. It must
 not treat AgentOps as the delivery controller or:
 
 - invoke a model or perform another semantic review;
-- mutate or upgrade the Validate verdict;
+- mutate or upgrade the Validate result;
 - close tracker work as a side effect of Git;
 - create an AgentOps delivery queue or receipt; or
 - replay an unchanged full suite merely because delivery started.

--- a/docs/contracts/skill-ports-and-adapters.md
+++ b/docs/contracts/skill-ports-and-adapters.md
@@ -48,7 +48,8 @@ A terminal caller outcome that may require several evidence-driven experiments
 belongs to a Goal / Mayor. The campaign freezes terminal acceptance and
 authority, stores experiments as caller-owned graph nodes, and selects one
 bounded experiment at a time. Each selected experiment ends in its own RPI
-report and, when a subject exists, immutable `verdict.v2`.
+report and fresh validation result. A declared campaign consumer may additionally
+require immutable `verdict.v2` evidence.
 
 The Goal may continue after an informative red result when all of these remain
 true:
@@ -74,8 +75,8 @@ single-mint resolved intent bytes
   -> before/final subject manifests + complete changed paths
   -> factual receipts + effect-receipt.v1
   -> one author-distinct Validate
-  -> verdict.v2 under an activated proof contract
-  -> rpi-report.v2
+  -> PASS | FAIL | NOT_PROVEN
+  -> optional verdict.v2 / rpi-report.v2 for declared consumers
   -> stop
 ```
 
@@ -192,7 +193,8 @@ skill metadata. They are never edited as architecture sources.
 ## Invariants
 
 - Only RPI depends on all three core phases.
-- Only Validate writes `verdict.v2`.
+- Only Validate may write `verdict.v2`, and only for a caller request or
+  declared downstream consumer.
 - Only the caller or Goal selects another experiment.
 - A runtime adapter never changes a semantic outcome.
 - A strategy report never masquerades as readiness or PASS.

--- a/docs/first-value-path.md
+++ b/docs/first-value-path.md
@@ -6,12 +6,13 @@
 3. Implement runs one bounded experiment and records actual changed paths and
    factual checks.
 4. A fresh context runs Validate against the exact subject manifest.
-5. Validate stores `verdict.v2`; RPI reports it and stops.
+5. Validate returns the result; RPI reports it and stops. Persist `verdict.v2`
+   only when machine-readable evidence was requested.
 
 For a small task this should be one reviewable change and one independent
 judgment—not a project-management ceremony. Optional premortems, councils,
 specialists, trackers, and factory adapters are chosen by the caller only when
 they add value.
 
-Success is a durable verdict bound to acceptance and content identities. Pushing
-or releasing that content is a separate repository decision.
+Success is fresh independent judgment bound to acceptance and content
+identities. Pushing or releasing that content is a separate repository decision.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ AgentOps helps coding agents turn one intent into one evidence-bound engineering
 judgment:
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> report and stop
 ```
 
 The product supplies behavior-first planning, one bounded implementation

--- a/docs/knowledge-flywheel.md
+++ b/docs/knowledge-flywheel.md
@@ -1,12 +1,12 @@
 # Optional Learning Loop
 
-AgentOps core ends when Validate writes a durable verdict and RPI reports it.
-Learning is deliberately off the critical path.
+AgentOps core ends when Validate returns a fresh judgment and RPI reports it.
+Learning and durable verdict storage are deliberately off the critical path.
 
 When a caller wants longitudinal analysis, it may explicitly invoke Learn over
-a collection of immutable `verdict.v2` artifacts. Learn can group concrete
-finding observations, identify recurrence across distinct objectives, and
-suggest an advisory producer-rule candidate.
+a collection of immutable `verdict.v2` artifacts that prior callers elected to
+persist. Learn can group concrete finding observations, identify recurrence
+across distinct objectives, and suggest an advisory producer-rule candidate.
 
 Learn does not:
 

--- a/docs/newcomer-guide.md
+++ b/docs/newcomer-guide.md
@@ -8,7 +8,7 @@ small behavior and use RPI when you want the full loop.
 - Plan makes acceptance and scope explicit.
 - Implement performs one bounded experiment.
 - A fresh validator judges exact content.
-- A durable verdict records checked and unchecked claims.
+- The result records checked and unchecked claims; durable storage is optional.
 - The invocation stops.
 
 The one thing you do need is a coding agent to run the skills in: AgentOps

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -2,7 +2,7 @@
 
 {% block announce %}
 <div class="md-announce">
-  <span>AgentOps 3.3 — one intent, one bounded build, one fresh judge, one durable verdict.</span>
+  <span>AgentOps 3.3 — one intent, one bounded build, one fresh judge, then stop.</span>
   <a href="https://github.com/boshu2/agentops" target="_blank" rel="noopener">Star on GitHub &rarr;</a>
 </div>
 {% endblock %}

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -10,14 +10,16 @@ own work. AgentOps therefore provides a small evidence protocol:
 
 ```text
 intent -> one bounded experiment -> exact subject identity
-       -> fresh independent judgment -> durable verdict
+       -> fresh independent judgment -> report and stop
 ```
 
 The protocol is behavior-first. Plan expresses one behavior as normal and edge
 Given/When/Then scenarios, non-goals, write scope, and required evidence.
 Implement performs one bounded RED-to-GREEN-to-refactor experiment. Validate
-binds criterion-level judgment to a deterministic content manifest and stores
-the result as `verdict.v2`. RPI invokes those responsibilities once and stops.
+binds criterion-level judgment to a deterministic content manifest. It stores
+the result as `verdict.v2` only when the caller requests a machine-readable
+artifact or a declared downstream consumer needs one. RPI invokes those
+responsibilities once and stops.
 
 This is a trust floor, not a workflow engine. AgentOps does not own retries,
 budgets, queues, claims, leases, Git, CI, closure, release, or delivery. A FAIL

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -70,5 +70,5 @@
 | `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `inspect_pack_registries`, `drive_mayor_door` | `operate_gas_city`, `configure_codex_trust` |
-| `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
+| `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `return_validation_result`, `persist_verdict` | `write_verdict_artifact` |
 | `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/docs/scale-without-swarms.md
+++ b/docs/scale-without-swarms.md
@@ -3,7 +3,7 @@
 AgentOps deliberately keeps its core experiment small:
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> report and stop
 ```
 
 Plan names one active behavior and its write scope. Implement performs one

--- a/docs/seed-definition.md
+++ b/docs/seed-definition.md
@@ -6,16 +6,18 @@ The product seed is the smallest useful trust boundary for agent-created work:
    and write scope in the caller-owned intent source.
 2. Implement performs one bounded experiment while the runtime derives the
    subject manifest, changed paths, and check receipts.
-3. Validate independently judges the exact content manifest once.
-4. The durable `verdict.v2` artifact records what was and was not proven.
+3. Validate independently judges the exact content manifest once and reports
+   what was and was not proven.
+4. A caller or declared downstream consumer may request a durable `verdict.v2`
+   representation of that result.
 
 RPI composes those phases exactly once and reports the result. A repository may
 add its own tracker, Git workflow, CI, release policy, factory runtime, or
 learning process around that seed. None is required for AgentOps correctness.
 
-The seed works in a non-Git directory without the `ao` binary. Its only durable
-core state is the resolved intent, derived content identity, and
-content-addressed verdict.
+The seed works in a non-Git directory without the `ao` binary. The resolved
+intent and derived content identity can be passed directly between contexts;
+content-addressed verdict storage is an optional evidence surface.
 
 See [the operating loop](architecture/operating-loop.md) and
 [product boundary](../PRODUCT.md).

--- a/docs/software-factory.md
+++ b/docs/software-factory.md
@@ -9,7 +9,7 @@ software factory or own its queue.
 |---|---|---|
 | Planner | caller intent | refined intent in its existing source |
 | Implementer | exact resolved intent | derived manifest and factual evidence |
-| Validator | exact intent, subject, and evidence in a fresh context | one durable verdict |
+| Validator | exact intent, subject, and evidence in a fresh context | one semantic result; optional durable verdict |
 
 One runtime may fill the roles in separate contexts. PASS still requires
 distinct nonempty author and validator context IDs plus an explicit freshness
@@ -31,9 +31,10 @@ select, persist, retry, validate, integrate, commit, close, release, or deliver.
 ## Integration boundary
 
 A factory may combine returned candidates using its own repository policy. Each
-semantic candidate still needs exact identity and a fresh Validate verdict.
+semantic candidate still needs exact identity and a fresh Validate result.
 AgentOps does not convert factory completion, worker success, or deterministic
-checks into PASS.
+checks into PASS. A factory may require persisted `verdict.v2` as its declared
+machine-readable evidence contract; ordinary interactive validation does not.
 
 Git, trackers, pull requests, merge queues, CI, deployment, and release remain
 owned by the caller's environment.

--- a/docs/templates/kernel.template.md
+++ b/docs/templates/kernel.template.md
@@ -12,7 +12,7 @@
 ## AgentOps loop
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> report and stop
 ```
 
 The caller owns revisions, retries, work organization, Git, CI, release, and

--- a/docs/templates/slice-validation.md
+++ b/docs/templates/slice-validation.md
@@ -31,11 +31,14 @@ independent Validate review. The current machine contracts are
 - Validator context ID: `<distinct nonempty identity>`
 - Freshness source: `runtime | caller`
 - Freshness attester: `<identity>`
+- Validation result: `<PASS | FAIL | NOT_PROVEN>`
 - Criterion results: `<PASS | FAIL | NOT_PROVEN with evidence>`
 - Checked: `<claims and surfaces>`
 - Not checked: `<claims and surfaces>`
-- Verdict artifact: `<content-addressed path>`
+- Verdict artifact (optional): `<content-addressed path when requested>`
 
 Any subject edit invalidates the review. A proven out-of-scope path is FAIL;
-incomplete changed-path coverage is NOT_PROVEN. Validate persists one verdict
-and stops without repair, retry, Git, closure, release, or delivery.
+incomplete changed-path coverage is NOT_PROVEN. Validate returns one fresh result and stops
+without repair, retry, Git, closure, release, or delivery.
+Persist `verdict.v2` only when the caller requests machine-readable evidence or
+a declared downstream consumer requires it.

--- a/docs/trust-factory.md
+++ b/docs/trust-factory.md
@@ -15,7 +15,8 @@ The boundary has four facts:
 - the requested behavior and acceptance are explicit;
 - the exact subject is identified by content, not by a mutable branch name;
 - a distinct fresh context judges that subject against the acceptance;
-- the result is written as a standalone content-addressed `verdict.v2`.
+- the result identifies checked and unchecked scope and can be persisted as a
+  standalone content-addressed `verdict.v2` when a consumer requires it.
 
 This is evidence, not permission to ship. AgentOps does not own Git, CI,
 tracking, retries, queues, release, or recovery. The consumer system decides

--- a/images/gemini/skills/council/SKILL.md
+++ b/images/gemini/skills/council/SKILL.md
@@ -97,4 +97,5 @@ Council does not mint a verdict of any version — no `PASS`/`FAIL`/`NOT_PROVEN`
 no `verdict.v*` — edit the subject, retry work, choose a next action, or
 authorize Git, closure, release, or delivery. When Council is used as a Validate
 strategy, one accountable fresh validator consumes its report and Validate
-remains the sole durable verdict writer.
+remains the sole semantic result owner and the only optional `verdict.v2`
+writer.

--- a/images/gemini/skills/craft-goal/SKILL.md
+++ b/images/gemini/skills/craft-goal/SKILL.md
@@ -103,7 +103,8 @@ outcome; do not invent one universal budget.
   goal ledger. Root epic = outer intent; child bead = one experiment/RPI.
   **Why:** compaction must not erase the scientific record.
 - **RPI membrane:** One candidate gets one bounded RPI and an author-distinct
-  durable verdict. The goal consumes verdicts but never rewrites them.
+  fresh validation result. The goal may request durable verdict evidence but
+  never rewrites it.
   **Why:** orchestration cannot author its own proof.
 - **Brownian ratchet:** Continue only when a result adds non-duplicative,
   decision-relevant knowledge or advances acceptance. **Why:** activity without

--- a/images/gemini/skills/implement/SKILL.md
+++ b/images/gemini/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: 'Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "implement this bead", "run the experiment". ("execute this plan" routes to rpi, which dispatches the whole loop.)'
+description: 'Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "implement this bead", "run the experiment". Full plan-to-validation requests route to rpi.'
 practices:
 - tdd
 - refactoring

--- a/images/gemini/skills/rpi/SKILL.md
+++ b/images/gemini/skills/rpi/SKILL.md
@@ -29,7 +29,7 @@ metadata:
   effects: [dispatch_core_phases]
   canonical_status: canonical
   disposition: keep
-output_contract: 'rpi-report.v1 machine artifact plus a concise human-readable interactive summary'
+output_contract: 'concise human-readable result; optional rpi-report.v1 when a caller or declared consumer requests machine-readable evidence'
 ---
 
 # RPI
@@ -78,8 +78,10 @@ authorization by itself.
 3. Invoke Validate once in a context distinct from the author's context. Pass
    the intent reference and digest, exact subject manifest, factual receipts,
    validator identity, and freshness attestation.
-4. Return the durable `verdict.v2` reference and a short report. Stop regardless
-   of `PASS`, `FAIL`, or `NOT_PROVEN`.
+4. Return the fresh validation result and a short report. Persist and link
+   `verdict.v2` only when the caller requests machine-readable evidence or a
+   declared downstream consumer requires it. Stop regardless of `PASS`, `FAIL`,
+   or `NOT_PROVEN`.
 
 `NOT_PLANNED` and `NOT_BUILT` are report statuses, never semantic verdicts.
 A caller may revise the bead or caller intent and start a new invocation. RPI
@@ -95,9 +97,9 @@ one outcome and one acceptance boundary.
 If control artifacts or fresh-validation cycles are multiplying faster than
 implementation evidence, stop dispatching more lanes. Return to one
 outcome-level intent and continue with targeted deterministic checks, reserving
-the full integration check and fresh verdict for the frozen subject. This
+the full integration check and fresh validation for the frozen subject. This
 changes orchestration cost, never acceptance, exact identity, fail-closed
-scope, or verdict authority.
+scope, or validation authority.
 
 ## Continuation envelope
 
@@ -142,13 +144,14 @@ disjoint regen surfaces may run in parallel.
 
 ## Report
 
-RPI has two report surfaces. Keep them distinct:
+RPI has one required report surface and one optional representation:
 
-1. **Machine artifact:** return or persist the exact
-   [`rpi-report.v1`](../../schemas/rpi-report.v1.schema.json) object for
-   adapters, automation, and audit.
-2. **Interactive response:** summarize that object for the caller in natural
+1. **Interactive response:** return the result to the caller in natural
    language. This is the default assistant response.
+2. **Machine artifact:** return or persist the exact
+   [`rpi-report.v1`](../../schemas/rpi-report.v1.schema.json) object only when
+   the caller requests machine-readable evidence or a declared adapter consumes
+   it.
 
 Lead the interactive response with the status and one sentence stating the
 caller-visible outcome. Lead with the subject, not the process: production
@@ -159,10 +162,8 @@ unchecked scope, and a clickable verdict reference when one exists. Name why
 no subject exists for `NOT_PLANNED` or `NOT_BUILT`. Keep the response to one
 short paragraph or at most four bullets.
 
-The machine artifact remains behind the verdict/report link. Emit its full
-JSON or YAML object only when the caller explicitly requests machine-readable
-output or an adapter consumes the response. Raw digests, schema fields, and
-exhaustive check lists stay in the artifact unless an integrity failure makes
-one necessary to explain the result.
+When no machine artifact was requested, do not create a hidden one. Raw digests,
+schema fields, and exhaustive check lists stay out of the interactive response
+unless an integrity failure makes one necessary to explain the result.
 
 Do not append a next action. The caller owns continuation.

--- a/images/gemini/skills/using-gc/SKILL.md
+++ b/images/gemini/skills/using-gc/SKILL.md
@@ -165,6 +165,6 @@ session wedge, bead/run state over prose for workflow completion.
 - GC quests, runs, attempts, stalls, cancellations, and internal close state
   stay in GC. They never become AgentOps Plan, Candidate, RPI, or verdict state.
 - A GC close or completed run is not AgentOps completion. Only a fresh Validate
-  context writes `verdict.v2`.
+  context issues the semantic result or, when requested, persists `verdict.v2`.
 - This skill performs no automatic selection, retry, semantic validation, Git,
   integration, closure, release, or delivery.

--- a/images/gemini/skills/validate/SKILL.md
+++ b/images/gemini/skills/validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validate
-description: 'Freshly judge exact subject content against bead or caller acceptance, persist verdict.v2, and stop. Triggers: "validate", "independently validate", "vibe".'
+description: 'Freshly judge exact subject content against bead or caller acceptance, optionally persist verdict.v2 for a declared consumer, and stop. Triggers: "validate", "independently validate", "vibe".'
 practices:
 - design-by-contract
 - llm-eval-harness
@@ -10,6 +10,7 @@ consumes:
 - subject-manifest.v1
 produces:
 - subject-manifest.v1
+- validation-result
 - verdict.v2
 context_rel:
 - kind: customer-of
@@ -22,19 +23,19 @@ metadata:
   graph_root: true
   tier: judgment
   dependencies: []
-  capabilities: [compute_subject_identity, judge_acceptance, persist_verdict]
+  capabilities: [compute_subject_identity, judge_acceptance, return_validation_result, persist_verdict]
   effects: [write_verdict_artifact]
   canonical_status: canonical
   disposition: keep
-output_contract: schemas/verdict.v2.schema.json
+output_contract: 'PASS | FAIL | NOT_PROVEN with criteria, evidence, checked/not_checked, identity, and freshness; optional schemas/verdict.v2.schema.json persistence'
 ---
 
 # Validate
 
 Independently judge one exact subject against the acceptance in its existing
-bead or caller source, write one durable verdict, and stop. Validate is the sole
-verdict writer. It never asks the model to reconstruct Plan or Candidate
-packets.
+bead or caller source, return one semantic result, and stop. Validate is the
+sole `verdict.v2` writer when persistence is requested. It never asks the model
+to reconstruct Plan or Candidate packets.
 
 ## Preconditions
 
@@ -95,22 +96,27 @@ committed subject, never the judged working tree.
    (see the freshness rules below for when a digest-bound receipt suffices).
    Judge every acceptance criterion and record criterion-level results,
    findings, evidence references, `checked`, and `not_checked`.
-5. Choose exactly one semantic result: `PASS`, `FAIL`, or `NOT_PROVEN`. PASS
-   requires distinct identities, explicit freshness, nonempty checked scope,
-   top-level evidence, and evidence for every criterion.
-6. Persist canonical `verdict.v2` with `store-verdict --draft <draft.json>
-   --intent-source <resolved-intent> --subject-manifest <manifest.json>
-   --author-context-id <id> --validator-context-id <id>
-   --freshness-source <runtime|caller> --freshness-attester-id <id>
-   --scope-result <PASS|FAIL|NOT_PROVEN>`. The helper
-   snapshots the exact resolved intent under
+5. Choose exactly one semantic result: `PASS`, `FAIL`, or `NOT_PROVEN`. Return
+   it with criterion results, findings, evidence references, `checked`,
+   `not_checked`, the acceptance and subject identities, distinct author and
+   validator context IDs, and the freshness attestation. PASS requires distinct
+   identities, explicit freshness, nonempty checked scope, top-level evidence,
+   and evidence for every criterion.
+6. Only when the caller requests machine-readable evidence or a declared
+   downstream consumer requires it, persist canonical `verdict.v2` with
+   `store-verdict --draft <draft.json> --intent-source <resolved-intent>
+   --subject-manifest <manifest.json> --author-context-id <id>
+   --validator-context-id <id> --freshness-source <runtime|caller>
+   --freshness-attester-id <id> --scope-result <PASS|FAIL|NOT_PROVEN>`. The
+   helper snapshots the exact resolved intent under
    `<workspace>/.agents/ao/intents/sha256/<digest>.intent`, then computes and
    injects intent and subject digests plus author, validator, and freshness
    facts. Identity and changed-path facts come from runtime-derived inputs and
-   receipts, not model transcription. Verdict
-   storage defaults to `<workspace>/.agents/ao/verdicts/sha256/<digest>.json`;
-   callers may provide `verdict_dir`.
-7. Return the artifact path and digest. Stop.
+   receipts, not model transcription. Storage defaults to
+   `<workspace>/.agents/ao/verdicts/sha256/<digest>.json`; callers may provide
+   `verdict_dir`.
+7. Return the semantic result and, when persisted, the artifact path and digest.
+   Stop.
 
 The digest is SHA-256 over canonical JSON with `artifact_digest` omitted. Writes
 use a same-directory temporary file, flush, fsync, and atomic rename. Identical

--- a/packs/agentops-executor/agents/implementer-claude/skills/implement/SKILL.md
+++ b/packs/agentops-executor/agents/implementer-claude/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: 'Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "implement this bead", "run the experiment". ("execute this plan" routes to rpi, which dispatches the whole loop.)'
+description: 'Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "implement this bead", "run the experiment". Full plan-to-validation requests route to rpi.'
 practices:
 - tdd
 - refactoring

--- a/packs/agentops-executor/agents/implementer/skills/implement/SKILL.md
+++ b/packs/agentops-executor/agents/implementer/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: 'Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "implement this bead", "run the experiment". ("execute this plan" routes to rpi, which dispatches the whole loop.)'
+description: 'Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "implement this bead", "run the experiment". Full plan-to-validation requests route to rpi.'
 practices:
 - tdd
 - refactoring

--- a/packs/agentops-executor/agents/validator/skills/validate/SKILL.md
+++ b/packs/agentops-executor/agents/validator/skills/validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validate
-description: 'Freshly judge exact subject content against bead or caller acceptance, persist verdict.v2, and stop. Triggers: "validate", "independently validate", "vibe".'
+description: 'Freshly judge exact subject content against bead or caller acceptance, optionally persist verdict.v2 for a declared consumer, and stop. Triggers: "validate", "independently validate", "vibe".'
 practices:
 - design-by-contract
 - llm-eval-harness
@@ -10,6 +10,7 @@ consumes:
 - subject-manifest.v1
 produces:
 - subject-manifest.v1
+- validation-result
 - verdict.v2
 context_rel:
 - kind: customer-of
@@ -22,19 +23,19 @@ metadata:
   graph_root: true
   tier: judgment
   dependencies: []
-  capabilities: [compute_subject_identity, judge_acceptance, persist_verdict]
+  capabilities: [compute_subject_identity, judge_acceptance, return_validation_result, persist_verdict]
   effects: [write_verdict_artifact]
   canonical_status: canonical
   disposition: keep
-output_contract: schemas/verdict.v2.schema.json
+output_contract: 'PASS | FAIL | NOT_PROVEN with criteria, evidence, checked/not_checked, identity, and freshness; optional schemas/verdict.v2.schema.json persistence'
 ---
 
 # Validate
 
 Independently judge one exact subject against the acceptance in its existing
-bead or caller source, write one durable verdict, and stop. Validate is the sole
-verdict writer. It never asks the model to reconstruct Plan or Candidate
-packets.
+bead or caller source, return one semantic result, and stop. Validate is the
+sole `verdict.v2` writer when persistence is requested. It never asks the model
+to reconstruct Plan or Candidate packets.
 
 ## Preconditions
 
@@ -95,22 +96,27 @@ committed subject, never the judged working tree.
    (see the freshness rules below for when a digest-bound receipt suffices).
    Judge every acceptance criterion and record criterion-level results,
    findings, evidence references, `checked`, and `not_checked`.
-5. Choose exactly one semantic result: `PASS`, `FAIL`, or `NOT_PROVEN`. PASS
-   requires distinct identities, explicit freshness, nonempty checked scope,
-   top-level evidence, and evidence for every criterion.
-6. Persist canonical `verdict.v2` with `store-verdict --draft <draft.json>
-   --intent-source <resolved-intent> --subject-manifest <manifest.json>
-   --author-context-id <id> --validator-context-id <id>
-   --freshness-source <runtime|caller> --freshness-attester-id <id>
-   --scope-result <PASS|FAIL|NOT_PROVEN>`. The helper
-   snapshots the exact resolved intent under
+5. Choose exactly one semantic result: `PASS`, `FAIL`, or `NOT_PROVEN`. Return
+   it with criterion results, findings, evidence references, `checked`,
+   `not_checked`, the acceptance and subject identities, distinct author and
+   validator context IDs, and the freshness attestation. PASS requires distinct
+   identities, explicit freshness, nonempty checked scope, top-level evidence,
+   and evidence for every criterion.
+6. Only when the caller requests machine-readable evidence or a declared
+   downstream consumer requires it, persist canonical `verdict.v2` with
+   `store-verdict --draft <draft.json> --intent-source <resolved-intent>
+   --subject-manifest <manifest.json> --author-context-id <id>
+   --validator-context-id <id> --freshness-source <runtime|caller>
+   --freshness-attester-id <id> --scope-result <PASS|FAIL|NOT_PROVEN>`. The
+   helper snapshots the exact resolved intent under
    `<workspace>/.agents/ao/intents/sha256/<digest>.intent`, then computes and
    injects intent and subject digests plus author, validator, and freshness
    facts. Identity and changed-path facts come from runtime-derived inputs and
-   receipts, not model transcription. Verdict
-   storage defaults to `<workspace>/.agents/ao/verdicts/sha256/<digest>.json`;
-   callers may provide `verdict_dir`.
-7. Return the artifact path and digest. Stop.
+   receipts, not model transcription. Storage defaults to
+   `<workspace>/.agents/ao/verdicts/sha256/<digest>.json`; callers may provide
+   `verdict_dir`.
+7. Return the semantic result and, when persisted, the artifact path and digest.
+   Stop.
 
 The digest is SHA-256 over canonical JSON with `artifact_digest` omitted. Writes
 use a same-directory temporary file, flush, fsync, and atomic rename. Identical

--- a/packs/agentops-executor/agents/validator/skills/validate/references/validate.feature
+++ b/packs/agentops-executor/agents/validator/skills/validate/references/validate.feature
@@ -1,4 +1,4 @@
-Feature: Validate writes one fresh verdict over exact content
+Feature: Validate returns one fresh judgment over exact content
   @covered-by:skills/validate/scripts/test_validate.py::test_verdict_identity_floor_and_idempotence
   Scenario: Identity gaps stay unproven
     Given missing, colliding, or unattested author and validator identities
@@ -24,8 +24,14 @@ Feature: Validate writes one fresh verdict over exact content
     Then the snapshot path is its SHA-256 identity
 
   @covered-by:skills/validate/scripts/test_validate.py::test_verdict_identity_floor_and_idempotence
-  Scenario: Validation stops after persistence
+  Scenario: Validation stops without requiring persistence
     Given any PASS, FAIL, or NOT_PROVEN verdict
-    When Validate atomically persists it
-    Then Validate returns the artifact digest and path
+    When Validate returns the fresh result
+    Then Validate does not require an artifact digest or path
     And performs no repair, retry, Git, closure, release, or delivery action
+
+  @covered-by:skills/validate/scripts/test_validate.py::test_verdict_identity_floor_and_idempotence
+  Scenario: Declared consumers may request durable evidence
+    Given a caller or declared downstream consumer requests machine-readable evidence
+    When Validate atomically persists the result
+    Then Validate returns the verdict.v2 artifact digest and path

--- a/packs/agentops-executor/agents/validator/skills/validate/scripts/validate.sh
+++ b/packs/agentops-executor/agents/validator/skills/validate/scripts/validate.sh
@@ -6,8 +6,8 @@ repo_root="$(cd "$skill_dir/../.." && pwd)"
 
 grep -q '^name: validate$' "$skill_dir/SKILL.md"
 grep -Fq 'PASS`, `FAIL`, or `NOT_PROVEN`' "$skill_dir/SKILL.md"
-grep -Fq 'sole' "$skill_dir/SKILL.md"
-grep -Fq 'verdict writer' "$skill_dir/SKILL.md"
+grep -Fq 'sole `verdict.v2` writer when persistence is requested' "$skill_dir/SKILL.md"
+grep -Fq 'Only when the caller requests machine-readable evidence' "$skill_dir/SKILL.md"
 grep -Fq 'nonempty implementation candidate' "$skill_dir/SKILL.md"
 
 python3 "$skill_dir/scripts/validate.py" --help >/dev/null

--- a/packs/agentops-executor/assets/generated-skill-manifest.json
+++ b/packs/agentops-executor/assets/generated-skill-manifest.json
@@ -6,8 +6,8 @@
     {
       "source": "skills/implement/SKILL.md",
       "destination": "packs/agentops-executor/agents/implementer-claude/skills/implement/SKILL.md",
-      "source_sha256": "ada81165711dc36b8e660a380b6b9173ecb646cda8f1a3905d12d26fa6612c8f",
-      "sha256": "ada81165711dc36b8e660a380b6b9173ecb646cda8f1a3905d12d26fa6612c8f",
+      "source_sha256": "1e1402a2bd2e781e943050aa650b401443a615b4e48ead119bd8ee9bce42a02b",
+      "sha256": "1e1402a2bd2e781e943050aa650b401443a615b4e48ead119bd8ee9bce42a02b",
       "mode": "0644"
     },
     {
@@ -27,8 +27,8 @@
     {
       "source": "skills/implement/SKILL.md",
       "destination": "packs/agentops-executor/agents/implementer/skills/implement/SKILL.md",
-      "source_sha256": "ada81165711dc36b8e660a380b6b9173ecb646cda8f1a3905d12d26fa6612c8f",
-      "sha256": "ada81165711dc36b8e660a380b6b9173ecb646cda8f1a3905d12d26fa6612c8f",
+      "source_sha256": "1e1402a2bd2e781e943050aa650b401443a615b4e48ead119bd8ee9bce42a02b",
+      "sha256": "1e1402a2bd2e781e943050aa650b401443a615b4e48ead119bd8ee9bce42a02b",
       "mode": "0644"
     },
     {
@@ -48,15 +48,15 @@
     {
       "source": "skills/validate/SKILL.md",
       "destination": "packs/agentops-executor/agents/validator/skills/validate/SKILL.md",
-      "source_sha256": "84f75ef2903c6de56906be12ea6f5066321390b5d90fbcc6bff67ccb6a0743b8",
-      "sha256": "84f75ef2903c6de56906be12ea6f5066321390b5d90fbcc6bff67ccb6a0743b8",
+      "source_sha256": "27e0db21270e26b0ccdb8e133c09d4bde5d78111351fb56b3dd50f9e8b41cfcc",
+      "sha256": "27e0db21270e26b0ccdb8e133c09d4bde5d78111351fb56b3dd50f9e8b41cfcc",
       "mode": "0644"
     },
     {
       "source": "skills/validate/references/validate.feature",
       "destination": "packs/agentops-executor/agents/validator/skills/validate/references/validate.feature",
-      "source_sha256": "c1cdc81c1c1ec7cd0dedcb70c6e3e28e64ec60b37b90e2c38bf803b7325d484a",
-      "sha256": "c1cdc81c1c1ec7cd0dedcb70c6e3e28e64ec60b37b90e2c38bf803b7325d484a",
+      "source_sha256": "e1c908ff720d877a47f7be1b3359ed61079172647ea2dcc8c06c21a8f2732134",
+      "sha256": "e1c908ff720d877a47f7be1b3359ed61079172647ea2dcc8c06c21a8f2732134",
       "mode": "0644"
     },
     {
@@ -83,15 +83,15 @@
     {
       "source": "skills/validate/scripts/validate.sh",
       "destination": "packs/agentops-executor/agents/validator/skills/validate/scripts/validate.sh",
-      "source_sha256": "507549239d488a77d545dd9cd008230415d739e2b0d0058ccd941ccdb0185e95",
-      "sha256": "507549239d488a77d545dd9cd008230415d739e2b0d0058ccd941ccdb0185e95",
+      "source_sha256": "57715c411e7102c736278f51de08e660cbe71953690f59820a6acdf5cc7cc6fc",
+      "sha256": "57715c411e7102c736278f51de08e660cbe71953690f59820a6acdf5cc7cc6fc",
       "mode": "0755"
     },
     {
       "source": "skills/using-gc/SKILL.md",
       "destination": "packs/agentops-executor/skills/using-gc/SKILL.md",
-      "source_sha256": "b5ff5ef9c3518d95e96e4e7e460759681e14b66659ca2fbd7e4ab109dbf86d8a",
-      "sha256": "b5ff5ef9c3518d95e96e4e7e460759681e14b66659ca2fbd7e4ab109dbf86d8a",
+      "source_sha256": "a85dd0fea3415ca2bf3608293a5b1fe7eaf6b9b4cf4bc427785a47e894558add",
+      "sha256": "a85dd0fea3415ca2bf3608293a5b1fe7eaf6b9b4cf4bc427785a47e894558add",
       "mode": "0644"
     }
   ]

--- a/packs/agentops-executor/skills/using-gc/SKILL.md
+++ b/packs/agentops-executor/skills/using-gc/SKILL.md
@@ -165,6 +165,6 @@ session wedge, bead/run state over prose for workflow completion.
 - GC quests, runs, attempts, stalls, cancellations, and internal close state
   stay in GC. They never become AgentOps Plan, Candidate, RPI, or verdict state.
 - A GC close or completed run is not AgentOps completion. Only a fresh Validate
-  context writes `verdict.v2`.
+  context issues the semantic result or, when requested, persists `verdict.v2`.
 - This skill performs no automatic selection, retry, semantic validation, Git,
   integration, closure, release, or delivery.

--- a/registry.json
+++ b/registry.json
@@ -572,6 +572,15 @@
       "driven_by_skills": [
         "validate"
       ],
+      "id": "skill:validate:return_validation_result",
+      "name": "return_validation_result",
+      "path": "skills/validate/SKILL.md",
+      "type": "skill"
+    },
+    {
+      "driven_by_skills": [
+        "validate"
+      ],
       "id": "skill:validate:persist_verdict",
       "name": "persist_verdict",
       "path": "skills/validate/SKILL.md",
@@ -591,13 +600,13 @@
     "cli_commands": 0,
     "gates": 0,
     "reference_impls": 0,
-    "skills": 65,
-    "total": 65
+    "skills": 66,
+    "total": 66
   },
   "cli_top_level_commands": [],
   "schema_version": 3,
   "summary": {
-    "capabilities": 65,
+    "capabilities": 66,
     "cli_commands": 0,
     "eval_files": 0,
     "hooks": 0,
@@ -1361,6 +1370,7 @@
         "capabilities": [
           "compute_subject_identity",
           "judge_acceptance",
+          "return_validation_result",
           "persist_verdict"
         ],
         "disposition": "keep",

--- a/scripts/check-cathedral-cut-conformance.py
+++ b/scripts/check-cathedral-cut-conformance.py
@@ -396,6 +396,9 @@ def probe_no_substrate_calls() -> None:
                 "subject_manifest_digest": artifact["subject_manifest_digest"],
                 "verdict_digest": artifact["artifact_digest"],
                 "verdict_ref": str(verdict_path),
+                "author_context_id": artifact["author_context_id"],
+                "validator_context_id": artifact["validator_context_id"],
+                "freshness_attestation": artifact["freshness_attestation"],
                 "checked": artifact["checked"],
                 "not_checked": artifact["not_checked"],
             }

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -405,14 +405,14 @@
     {
       "name": "council",
       "source_skill": "skills/council",
-      "source_hash": "c7c7353211c3baa0a342a2618c8cc3fc01e4c5629e39b9e9c26dbbfceb0c56c0",
-      "generated_hash": "0ec7ad04f8b7062bb96d9dd336caa42f85261ae4e4be88a25596898f5b11a229"
+      "source_hash": "2c8dd5df1754f9897ba40122751e4e64cf5cb098238857ef6209e970e19c3f3e",
+      "generated_hash": "50cc0e2b63f5314b96da6e63e0aaa1a7e181af3b651b6603772aa22f5af9d3fd"
     },
     {
       "name": "craft-goal",
       "source_skill": "skills/craft-goal",
-      "source_hash": "714ba85897319c69e5b39a6de0541bed968b03043ba96ec5df4c11550757fdb6",
-      "generated_hash": "b2ea9d9bf5f9b51bb9699a32e1f1b3c49a89e2b3d3ea3f9758b0f7b99bcc89b0"
+      "source_hash": "fb70646294d4838d2e5d27401e88255c9b4653f8062f461d182f622be87dfbf4",
+      "generated_hash": "46f494df66ed3147d576f14014d92932fdf18f7c4b6cfb9347df6a4a416c87d9"
     },
     {
       "name": "dcg",
@@ -459,8 +459,8 @@
     {
       "name": "implement",
       "source_skill": "skills/implement",
-      "source_hash": "c8054730f0c42489d77c20261b3f3ebba8b24b83cd000d03fab4e52b0c3b5a73",
-      "generated_hash": "5fbbb9f75b956e19758d304e2eb2627fdaf6c71c92359b5430f5b3d6b5330ff0"
+      "source_hash": "1c1b82e1934cbe49e8eb80bfac74589d6210f78dd60e98b879a4dead8feeaf36",
+      "generated_hash": "12f61c9ba414ef7349e1a43186bc2cdf16c993ca683496cafc81df9235107aaf"
     },
     {
       "name": "learn",
@@ -549,8 +549,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "11034be604c47474bbe6f1ad569c9b07aedc923aefee9b55075c299ea8bf7878",
-      "generated_hash": "c04896fc4384c9cadf4d418e9078d0df3e4e35358fe5e8a71e984da8634c6bdc"
+      "source_hash": "b061835709f18d89368212bf58456909144356f49f6b4c7d95a288a9f0381580",
+      "generated_hash": "223b2f7a659f8991421d11d54f790914206b356bce7e4e1f037cbd55cae5e7bc"
     },
     {
       "name": "sbh",
@@ -591,8 +591,8 @@
     {
       "name": "standards",
       "source_skill": "skills/standards",
-      "source_hash": "7c3a56b967362d322e1a7a46a6b6cfa7eba32ec1bf74a6227b4a21c74b6ad0fc",
-      "generated_hash": "d20037de93aeb9bbd9dfb35bfe831897057bb9e59145656ab68c4cea7d6a9341"
+      "source_hash": "7805d1f62160f932ae5d8e7469a738ee48a40bfead9a773cf0b9e3a136100290",
+      "generated_hash": "69e07aaa8314fb4e53b778f914f4cd566a2e17139b421ffb76b1f05e61080310"
     },
     {
       "name": "status",
@@ -621,14 +621,14 @@
     {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
-      "source_hash": "1c2e689d6c988622d67c46b5a3e3f3c103d9f419d6fc351661a6870f417ccf92",
-      "generated_hash": "23319383c4e2202c761b82f1edc184050e556e83da0db8a99fa8e8cb8e760750"
+      "source_hash": "61c5030f76e3afb27525c0213ebc1bf326e76f08c3ae00989e49ab6307ce5970",
+      "generated_hash": "186390451ef61b71495a5340fe9c358679ce8b0912a23429d7f8c9610ccf17c5"
     },
     {
       "name": "validate",
       "source_skill": "skills/validate",
-      "source_hash": "1603ca540e734f88fef542d1a322593d3194dec8af0a9316a62a386064c63c4b",
-      "generated_hash": "0451d7e06a47acfdd7dff1cd1afd3f3e6a2aba6bac32721b8aaa9ecf0de89920"
+      "source_hash": "3f8fd13efb33dabd114dbb66deb0eea5d3762de888b081c753a27c1fba557e03",
+      "generated_hash": "93b79b850fe0c6581305e1357ad2e83923d3a83cd3d3c23be342e70c9e0902ca"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/council/.agentops-generated.json
+++ b/skills-codex/council/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/council",
   "layout": "modular",
-  "source_hash": "c7c7353211c3baa0a342a2618c8cc3fc01e4c5629e39b9e9c26dbbfceb0c56c0",
-  "generated_hash": "0ec7ad04f8b7062bb96d9dd336caa42f85261ae4e4be88a25596898f5b11a229"
+  "source_hash": "2c8dd5df1754f9897ba40122751e4e64cf5cb098238857ef6209e970e19c3f3e",
+  "generated_hash": "50cc0e2b63f5314b96da6e63e0aaa1a7e181af3b651b6603772aa22f5af9d3fd"
 }

--- a/skills-codex/council/SKILL.md
+++ b/skills-codex/council/SKILL.md
@@ -80,4 +80,5 @@ Council does not mint a verdict of any version — no `PASS`/`FAIL`/`NOT_PROVEN`
 no `verdict.v*` — edit the subject, retry work, choose a next action, or
 authorize Git, closure, release, or delivery. When Council is used as a Validate
 strategy, one accountable fresh validator consumes its report and Validate
-remains the sole durable verdict writer.
+remains the sole semantic result owner and the only optional `verdict.v2`
+writer.

--- a/skills-codex/craft-goal/.agentops-generated.json
+++ b/skills-codex/craft-goal/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/craft-goal",
   "layout": "modular",
-  "source_hash": "714ba85897319c69e5b39a6de0541bed968b03043ba96ec5df4c11550757fdb6",
-  "generated_hash": "b2ea9d9bf5f9b51bb9699a32e1f1b3c49a89e2b3d3ea3f9758b0f7b99bcc89b0"
+  "source_hash": "fb70646294d4838d2e5d27401e88255c9b4653f8062f461d182f622be87dfbf4",
+  "generated_hash": "46f494df66ed3147d576f14014d92932fdf18f7c4b6cfb9347df6a4a416c87d9"
 }

--- a/skills-codex/craft-goal/SKILL.md
+++ b/skills-codex/craft-goal/SKILL.md
@@ -73,7 +73,8 @@ outcome; do not invent one universal budget.
   goal ledger. Root epic = outer intent; child bead = one experiment/RPI.
   **Why:** compaction must not erase the scientific record.
 - **RPI membrane:** One candidate gets one bounded RPI and an author-distinct
-  durable verdict. The goal consumes verdicts but never rewrites them.
+  fresh validation result. The goal may request durable verdict evidence but
+  never rewrites it.
   **Why:** orchestration cannot author its own proof.
 - **Brownian ratchet:** Continue only when a result adds non-duplicative,
   decision-relevant knowledge or advances acceptance. **Why:** activity without

--- a/skills-codex/implement/.agentops-generated.json
+++ b/skills-codex/implement/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/implement",
   "layout": "modular",
-  "source_hash": "c8054730f0c42489d77c20261b3f3ebba8b24b83cd000d03fab4e52b0c3b5a73",
-  "generated_hash": "5fbbb9f75b956e19758d304e2eb2627fdaf6c71c92359b5430f5b3d6b5330ff0"
+  "source_hash": "1c1b82e1934cbe49e8eb80bfac74589d6210f78dd60e98b879a4dead8feeaf36",
+  "generated_hash": "12f61c9ba414ef7349e1a43186bc2cdf16c993ca683496cafc81df9235107aaf"
 }

--- a/skills-codex/implement/prompt.md
+++ b/skills-codex/implement/prompt.md
@@ -1,6 +1,6 @@
 # implement
 
-Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "implement this bead", "run the experiment". ("execute this plan" routes to rpi, which dispatches the whole loop.)
+Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "implement this bead", "run the experiment". Full plan-to-validation requests route to rpi.
 
 ## Instructions
 

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "11034be604c47474bbe6f1ad569c9b07aedc923aefee9b55075c299ea8bf7878",
-  "generated_hash": "c04896fc4384c9cadf4d418e9078d0df3e4e35358fe5e8a71e984da8634c6bdc"
+  "source_hash": "b061835709f18d89368212bf58456909144356f49f6b4c7d95a288a9f0381580",
+  "generated_hash": "223b2f7a659f8991421d11d54f790914206b356bce7e4e1f037cbd55cae5e7bc"
 }

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -48,8 +48,10 @@ authorization by itself.
 3. Invoke Validate once in a context distinct from the author's context. Pass
    the intent reference and digest, exact subject manifest, factual receipts,
    validator identity, and freshness attestation.
-4. Return the durable `verdict.v2` reference and a short report. Stop regardless
-   of `PASS`, `FAIL`, or `NOT_PROVEN`.
+4. Return the fresh validation result and a short report. Persist and link
+   `verdict.v2` only when the caller requests machine-readable evidence or a
+   declared downstream consumer requires it. Stop regardless of `PASS`, `FAIL`,
+   or `NOT_PROVEN`.
 
 `NOT_PLANNED` and `NOT_BUILT` are report statuses, never semantic verdicts.
 A caller may revise the bead or caller intent and start a new invocation. RPI
@@ -65,9 +67,9 @@ one outcome and one acceptance boundary.
 If control artifacts or fresh-validation cycles are multiplying faster than
 implementation evidence, stop dispatching more lanes. Return to one
 outcome-level intent and continue with targeted deterministic checks, reserving
-the full integration check and fresh verdict for the frozen subject. This
+the full integration check and fresh validation for the frozen subject. This
 changes orchestration cost, never acceptance, exact identity, fail-closed
-scope, or verdict authority.
+scope, or validation authority.
 
 ## Continuation envelope
 
@@ -112,13 +114,14 @@ disjoint regen surfaces may run in parallel.
 
 ## Report
 
-RPI has two report surfaces. Keep them distinct:
+RPI has one required report surface and one optional representation:
 
-1. **Machine artifact:** return or persist the exact
-   [`rpi-report.v1`](../../schemas/rpi-report.v1.schema.json) object for
-   adapters, automation, and audit.
-2. **Interactive response:** summarize that object for the caller in natural
+1. **Interactive response:** return the result to the caller in natural
    language. This is the default assistant response.
+2. **Machine artifact:** return or persist the exact
+   [`rpi-report.v1`](../../schemas/rpi-report.v1.schema.json) object only when
+   the caller requests machine-readable evidence or a declared adapter consumes
+   it.
 
 Lead the interactive response with the status and one sentence stating the
 caller-visible outcome. Lead with the subject, not the process: production
@@ -129,10 +132,8 @@ unchecked scope, and a clickable verdict reference when one exists. Name why
 no subject exists for `NOT_PLANNED` or `NOT_BUILT`. Keep the response to one
 short paragraph or at most four bullets.
 
-The machine artifact remains behind the verdict/report link. Emit its full
-JSON or YAML object only when the caller explicitly requests machine-readable
-output or an adapter consumes the response. Raw digests, schema fields, and
-exhaustive check lists stay in the artifact unless an integrity failure makes
-one necessary to explain the result.
+When no machine artifact was requested, do not create a hidden one. Raw digests,
+schema fields, and exhaustive check lists stay out of the interactive response
+unless an integrity failure makes one necessary to explain the result.
 
 Do not append a next action. The caller owns continuation.

--- a/skills-codex/rpi/references/rpi.feature
+++ b/skills-codex/rpi/references/rpi.feature
@@ -13,9 +13,10 @@ Feature: RPI runs one bounded experiment
     Then RPI stops without repair, replan, helper, retry, or delivery
 
   @covered-by:skills/rpi/scripts/validate.sh
-  Scenario: Interactive output summarizes the machine artifact
-    Given RPI has produced an rpi-report.v1 machine artifact
+  Scenario: Interactive output does not require a machine artifact
+    Given RPI has received one fresh validation result
     When RPI responds to an interactive caller
     Then the response leads with status and the caller-visible outcome
-    And it includes only the strongest proof, material unchecked scope, and verdict link
-    And the full schema object is emitted only when machine-readable output was requested
+    And it includes only the strongest proof and material unchecked scope
+    And no hidden rpi-report.v1 or verdict.v2 is created
+    And a machine artifact is emitted only when a caller or declared consumer requested it

--- a/skills-codex/rpi/scripts/run_once.py
+++ b/skills-codex/rpi/scripts/run_once.py
@@ -102,10 +102,36 @@ def invoke_once(
     if validation.get("acceptance_digest") != acceptance_digest:
         raise ValueError("Validate verdict does not match the resolved intent digest")
     subject_digest = validation.get("subject_manifest_digest")
+    if not valid_digest(subject_digest):
+        raise ValueError("Validate must return the exact subject manifest digest")
+    candidate_digest = subject.get("subject_manifest_digest")
+    if candidate_digest is not None and subject_digest != candidate_digest:
+        raise ValueError("Validate result does not match the implemented subject digest")
+    author_context_id = validation.get("author_context_id")
+    validator_context_id = validation.get("validator_context_id")
+    freshness = validation.get("freshness_attestation")
+    if (
+        not isinstance(author_context_id, str)
+        or not author_context_id
+        or not isinstance(validator_context_id, str)
+        or not validator_context_id
+        or author_context_id == validator_context_id
+        or not isinstance(freshness, Mapping)
+        or freshness.get("source") not in {"runtime", "caller"}
+        or not isinstance(freshness.get("attester_identity"), str)
+        or not freshness.get("attester_identity")
+    ):
+        raise ValueError("Validate must return distinct context identities and explicit freshness")
     verdict_digest = validation.get("verdict_digest")
     verdict_ref = validation.get("verdict_ref")
-    if not all(isinstance(value, str) and value for value in (subject_digest, verdict_digest, verdict_ref)):
-        raise ValueError("Validate must return durable verdict and subject identities")
+    if (verdict_digest is None) != (verdict_ref is None):
+        raise ValueError("Validate must return both verdict_ref and verdict_digest when persistence is requested")
+    if verdict_ref is not None and (
+        not isinstance(verdict_ref, str)
+        or not verdict_ref
+        or not valid_digest(verdict_digest)
+    ):
+        raise ValueError("Persisted verdict identity is invalid")
     return report(
         status,
         intent_ref=intent_ref,

--- a/skills-codex/rpi/scripts/validate.sh
+++ b/skills-codex/rpi/scripts/validate.sh
@@ -9,8 +9,8 @@ grep -Fq 'Plan is closed for that intent' "$skill_dir/SKILL.md"
 grep -Fq 'spiral breaker' "$skill_dir/SKILL.md"
 grep -Fq 'A rising artifact count over an unchanged subject is a stop' "$skill_dir/SKILL.md"
 grep -Fq 'This is the default assistant response.' "$skill_dir/SKILL.md"
-grep -Fq 'only when the caller explicitly requests machine-readable' "$skill_dir/SKILL.md"
-grep -Fq 'The machine artifact remains behind the verdict/report link.' "$skill_dir/SKILL.md"
+grep -Fq 'only when the caller requests machine-readable evidence' "$skill_dir/SKILL.md"
+grep -Fq 'When no machine artifact was requested, do not create a hidden one.' "$skill_dir/SKILL.md"
 if grep -Fq 'plan_packet_digest' "$skill_dir/SKILL.md"; then
   echo 'rpi contract references a model-authored plan packet digest' >&2
   exit 1

--- a/skills-codex/rpi/tests/test_run_once.py
+++ b/skills-codex/rpi/tests/test_run_once.py
@@ -53,6 +53,12 @@ class RunOnceTests(unittest.TestCase):
                 "verdict": verdict,
                 "acceptance_digest": INTENT_DIGEST,
                 "subject_manifest_digest": "a" * 64,
+                "author_context_id": "author-ctx",
+                "validator_context_id": "validator-ctx",
+                "freshness_attestation": {
+                    "source": "runtime",
+                    "attester_identity": "runtime:rpi-test",
+                },
                 "verdict_digest": "b" * 64,
                 "verdict_ref": "/tmp/verdict.json",
                 "checked": ["acceptance"],
@@ -75,6 +81,39 @@ class RunOnceTests(unittest.TestCase):
         result = MODULE.invoke_once("intent", plan, implement, validate)
         self.assertEqual(calls, ["plan", "implement", "validate"])
         self.assertEqual(result["status"], "FAIL")
+
+    def test_fresh_validation_does_not_require_persisted_verdict(self):
+        calls, plan, implement, validate = self.phases()
+
+        def inline_result(resolved, subject):
+            result = validate(resolved, subject)
+            result.pop("verdict_digest")
+            result.pop("verdict_ref")
+            return result
+
+        result = MODULE.invoke_once("intent", plan, implement, inline_result)
+
+        self.assertEqual(calls, ["plan", "implement", "validate"])
+        self.assertEqual(result["status"], "PASS")
+        self.assertEqual(result["subject_manifest_digest"], "a" * 64)
+        self.assertIsNone(result["verdict_ref"])
+        self.assertIsNone(result["verdict_digest"])
+
+    def test_fresh_validation_requires_distinct_contexts_and_attestation(self):
+        _calls, plan, implement, validate = self.phases()
+
+        for field, value in (
+            ("validator_context_id", "author-ctx"),
+            ("freshness_attestation", None),
+        ):
+            with self.subTest(field=field):
+                def invalid(resolved, subject, field=field, value=value):
+                    result = validate(resolved, subject)
+                    result[field] = value
+                    return result
+
+                with self.assertRaisesRegex(ValueError, "distinct context identities"):
+                    MODULE.invoke_once("intent", plan, implement, invalid)
 
     def test_missing_plan_stops_before_implement(self):
         calls: list[str] = []
@@ -191,6 +230,12 @@ class ComposedIdentityContractTests(unittest.TestCase):
                     "verdict": "PASS",
                     "acceptance_digest": bound["acceptance_digest"],
                     "subject_manifest_digest": "a" * 64,
+                    "author_context_id": "author-ctx",
+                    "validator_context_id": "validator-ctx",
+                    "freshness_attestation": {
+                        "source": "runtime",
+                        "attester_identity": "runtime:composed-test",
+                    },
                     "verdict_digest": "b" * 64,
                     "verdict_ref": str(Path(tmp) / "verdict.json"),
                     "checked": ["acceptance"],

--- a/skills-codex/standards/.agentops-generated.json
+++ b/skills-codex/standards/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/standards",
   "layout": "modular",
-  "source_hash": "7c3a56b967362d322e1a7a46a6b6cfa7eba32ec1bf74a6227b4a21c74b6ad0fc",
-  "generated_hash": "d20037de93aeb9bbd9dfb35bfe831897057bb9e59145656ab68c4cea7d6a9341"
+  "source_hash": "7805d1f62160f932ae5d8e7469a738ee48a40bfead9a773cf0b9e3a136100290",
+  "generated_hash": "69e07aaa8314fb4e53b778f914f4cd566a2e17139b421ffb76b1f05e61080310"
 }

--- a/skills-codex/standards/references/skill-structure.md
+++ b/skills-codex/standards/references/skill-structure.md
@@ -110,7 +110,9 @@ path, schema, filename, validator, and downstream handoff.
 
 Structured outputs should name their schema and identity rules. Factual inline
 outputs should name the fields or sentence shape. Never imply PASS, readiness,
-or continuation unless the skill is Validate producing `verdict.v2`.
+or continuation unless the skill is Validate returning a fresh semantic result.
+`verdict.v2` is an optional representation for declared consumers, not the
+source of Validate's authority.
 
 The reference example of a structured-output validator is
 `skills/pattern-mining/scripts/validate-output.sh` — a small `jq` predicate that

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/using-gc",
   "layout": "modular",
-  "source_hash": "1c2e689d6c988622d67c46b5a3e3f3c103d9f419d6fc351661a6870f417ccf92",
-  "generated_hash": "23319383c4e2202c761b82f1edc184050e556e83da0db8a99fa8e8cb8e760750"
+  "source_hash": "61c5030f76e3afb27525c0213ebc1bf326e76f08c3ae00989e49ab6307ce5970",
+  "generated_hash": "186390451ef61b71495a5340fe9c358679ce8b0912a23429d7f8c9610ccf17c5"
 }

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -147,6 +147,6 @@ session wedge, bead/run state over prose for workflow completion.
 - GC quests, runs, attempts, stalls, cancellations, and internal close state
   stay in GC. They never become AgentOps Plan, Candidate, RPI, or verdict state.
 - A GC close or completed run is not AgentOps completion. Only a fresh Validate
-  context writes `verdict.v2`.
+  context issues the semantic result or, when requested, persists `verdict.v2`.
 - This skill performs no automatic selection, retry, semantic validation, Git,
   integration, closure, release, or delivery.

--- a/skills-codex/validate/.agentops-generated.json
+++ b/skills-codex/validate/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/validate",
   "layout": "modular",
-  "source_hash": "1603ca540e734f88fef542d1a322593d3194dec8af0a9316a62a386064c63c4b",
-  "generated_hash": "0451d7e06a47acfdd7dff1cd1afd3f3e6a2aba6bac32721b8aaa9ecf0de89920"
+  "source_hash": "3f8fd13efb33dabd114dbb66deb0eea5d3762de888b081c753a27c1fba557e03",
+  "generated_hash": "93b79b850fe0c6581305e1357ad2e83923d3a83cd3d3c23be342e70c9e0902ca"
 }

--- a/skills-codex/validate/SKILL.md
+++ b/skills-codex/validate/SKILL.md
@@ -5,9 +5,9 @@ description: Freshly judge exact subject content against
 # Validate
 
 Independently judge one exact subject against the acceptance in its existing
-bead or caller source, write one durable verdict, and stop. Validate is the sole
-verdict writer. It never asks the model to reconstruct Plan or Candidate
-packets.
+bead or caller source, return one semantic result, and stop. Validate is the
+sole `verdict.v2` writer when persistence is requested. It never asks the model
+to reconstruct Plan or Candidate packets.
 
 ## Preconditions
 
@@ -68,22 +68,27 @@ committed subject, never the judged working tree.
    (see the freshness rules below for when a digest-bound receipt suffices).
    Judge every acceptance criterion and record criterion-level results,
    findings, evidence references, `checked`, and `not_checked`.
-5. Choose exactly one semantic result: `PASS`, `FAIL`, or `NOT_PROVEN`. PASS
-   requires distinct identities, explicit freshness, nonempty checked scope,
-   top-level evidence, and evidence for every criterion.
-6. Persist canonical `verdict.v2` with `store-verdict --draft <draft.json>
-   --intent-source <resolved-intent> --subject-manifest <manifest.json>
-   --author-context-id <id> --validator-context-id <id>
-   --freshness-source <runtime|caller> --freshness-attester-id <id>
-   --scope-result <PASS|FAIL|NOT_PROVEN>`. The helper
-   snapshots the exact resolved intent under
+5. Choose exactly one semantic result: `PASS`, `FAIL`, or `NOT_PROVEN`. Return
+   it with criterion results, findings, evidence references, `checked`,
+   `not_checked`, the acceptance and subject identities, distinct author and
+   validator context IDs, and the freshness attestation. PASS requires distinct
+   identities, explicit freshness, nonempty checked scope, top-level evidence,
+   and evidence for every criterion.
+6. Only when the caller requests machine-readable evidence or a declared
+   downstream consumer requires it, persist canonical `verdict.v2` with
+   `store-verdict --draft <draft.json> --intent-source <resolved-intent>
+   --subject-manifest <manifest.json> --author-context-id <id>
+   --validator-context-id <id> --freshness-source <runtime|caller>
+   --freshness-attester-id <id> --scope-result <PASS|FAIL|NOT_PROVEN>`. The
+   helper snapshots the exact resolved intent under
    `<workspace>/.agents/ao/intents/sha256/<digest>.intent`, then computes and
    injects intent and subject digests plus author, validator, and freshness
    facts. Identity and changed-path facts come from runtime-derived inputs and
-   receipts, not model transcription. Verdict
-   storage defaults to `<workspace>/.agents/ao/verdicts/sha256/<digest>.json`;
-   callers may provide `verdict_dir`.
-7. Return the artifact path and digest. Stop.
+   receipts, not model transcription. Storage defaults to
+   `<workspace>/.agents/ao/verdicts/sha256/<digest>.json`; callers may provide
+   `verdict_dir`.
+7. Return the semantic result and, when persisted, the artifact path and digest.
+   Stop.
 
 The digest is SHA-256 over canonical JSON with `artifact_digest` omitted. Writes
 use a same-directory temporary file, flush, fsync, and atomic rename. Identical

--- a/skills-codex/validate/prompt.md
+++ b/skills-codex/validate/prompt.md
@@ -1,6 +1,6 @@
 # validate
 
-Freshly judge exact subject content against bead or caller acceptance, persist verdict.v2, and stop. Triggers: "validate", "independently validate", "vibe".
+Freshly judge exact subject content against bead or caller acceptance, optionally persist verdict.v2 for a declared consumer, and stop. Triggers: "validate", "independently validate", "vibe".
 
 ## Instructions
 

--- a/skills-codex/validate/references/validate.feature
+++ b/skills-codex/validate/references/validate.feature
@@ -1,4 +1,4 @@
-Feature: Validate writes one fresh verdict over exact content
+Feature: Validate returns one fresh judgment over exact content
   @covered-by:skills/validate/scripts/test_validate.py::test_verdict_identity_floor_and_idempotence
   Scenario: Identity gaps stay unproven
     Given missing, colliding, or unattested author and validator identities
@@ -24,8 +24,14 @@ Feature: Validate writes one fresh verdict over exact content
     Then the snapshot path is its SHA-256 identity
 
   @covered-by:skills/validate/scripts/test_validate.py::test_verdict_identity_floor_and_idempotence
-  Scenario: Validation stops after persistence
+  Scenario: Validation stops without requiring persistence
     Given any PASS, FAIL, or NOT_PROVEN verdict
-    When Validate atomically persists it
-    Then Validate returns the artifact digest and path
+    When Validate returns the fresh result
+    Then Validate does not require an artifact digest or path
     And performs no repair, retry, Git, closure, release, or delivery action
+
+  @covered-by:skills/validate/scripts/test_validate.py::test_verdict_identity_floor_and_idempotence
+  Scenario: Declared consumers may request durable evidence
+    Given a caller or declared downstream consumer requests machine-readable evidence
+    When Validate atomically persists the result
+    Then Validate returns the verdict.v2 artifact digest and path

--- a/skills-codex/validate/scripts/validate.sh
+++ b/skills-codex/validate/scripts/validate.sh
@@ -6,8 +6,8 @@ repo_root="$(cd "$skill_dir/../.." && pwd)"
 
 grep -q '^name: validate$' "$skill_dir/SKILL.md"
 grep -Fq 'PASS`, `FAIL`, or `NOT_PROVEN`' "$skill_dir/SKILL.md"
-grep -Fq 'sole' "$skill_dir/SKILL.md"
-grep -Fq 'verdict writer' "$skill_dir/SKILL.md"
+grep -Fq 'sole `verdict.v2` writer when persistence is requested' "$skill_dir/SKILL.md"
+grep -Fq 'Only when the caller requests machine-readable evidence' "$skill_dir/SKILL.md"
 grep -Fq 'nonempty implementation candidate' "$skill_dir/SKILL.md"
 
 python3 "$skill_dir/scripts/validate.py" --help >/dev/null

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -90,5 +90,5 @@
 | `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `inspect_pack_registries`, `drive_mayor_door` | `operate_gas_city`, `configure_codex_trust` |
-| `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `persist_verdict` | `write_verdict_artifact` |
+| `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `return_validation_result`, `persist_verdict` | `write_verdict_artifact` |
 | `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -692,7 +692,7 @@
         }
       ],
       "dependencies": [],
-      "description": "Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: \"implement\", \"implement this bead\", \"run the experiment\". (\"execute this plan\" routes to rpi, which dispatches the whole loop.)",
+      "description": "Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: \"implement\", \"implement this bead\", \"run the experiment\". Full plan-to-validation requests route to rpi.",
       "disposition": "keep",
       "effects": [
         "modify_declared_subject",
@@ -1603,6 +1603,7 @@
       "capabilities": [
         "compute_subject_identity",
         "judge_acceptance",
+        "return_validation_result",
         "persist_verdict"
       ],
       "codex_override_present": true,
@@ -1620,7 +1621,7 @@
         }
       ],
       "dependencies": [],
-      "description": "Freshly judge exact subject content against bead or caller acceptance, persist verdict.v2, and stop. Triggers: \"validate\", \"independently validate\", \"vibe\".",
+      "description": "Freshly judge exact subject content against bead or caller acceptance, optionally persist verdict.v2 for a declared consumer, and stop. Triggers: \"validate\", \"independently validate\", \"vibe\".",
       "disposition": "keep",
       "effects": [
         "write_verdict_artifact"
@@ -1635,6 +1636,7 @@
       ],
       "produces": [
         "subject-manifest.v1",
+        "validation-result",
         "verdict.v2"
       ],
       "references_count": 1,

--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -97,4 +97,5 @@ Council does not mint a verdict of any version — no `PASS`/`FAIL`/`NOT_PROVEN`
 no `verdict.v*` — edit the subject, retry work, choose a next action, or
 authorize Git, closure, release, or delivery. When Council is used as a Validate
 strategy, one accountable fresh validator consumes its report and Validate
-remains the sole durable verdict writer.
+remains the sole semantic result owner and the only optional `verdict.v2`
+writer.

--- a/skills/craft-goal/SKILL.md
+++ b/skills/craft-goal/SKILL.md
@@ -103,7 +103,8 @@ outcome; do not invent one universal budget.
   goal ledger. Root epic = outer intent; child bead = one experiment/RPI.
   **Why:** compaction must not erase the scientific record.
 - **RPI membrane:** One candidate gets one bounded RPI and an author-distinct
-  durable verdict. The goal consumes verdicts but never rewrites them.
+  fresh validation result. The goal may request durable verdict evidence but
+  never rewrites it.
   **Why:** orchestration cannot author its own proof.
 - **Brownian ratchet:** Continue only when a result adds non-duplicative,
   decision-relevant knowledge or advances acceptance. **Why:** activity without

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: 'Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "implement this bead", "run the experiment". ("execute this plan" routes to rpi, which dispatches the whole loop.)'
+description: 'Execute one bounded RED to GREEN experiment from bead or caller intent; return derived subject identity and check facts. Triggers: "implement", "implement this bead", "run the experiment". Full plan-to-validation requests route to rpi.'
 practices:
 - tdd
 - refactoring

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -29,7 +29,7 @@ metadata:
   effects: [dispatch_core_phases]
   canonical_status: canonical
   disposition: keep
-output_contract: 'rpi-report.v1 machine artifact plus a concise human-readable interactive summary'
+output_contract: 'concise human-readable result; optional rpi-report.v1 when a caller or declared consumer requests machine-readable evidence'
 ---
 
 # RPI
@@ -78,8 +78,10 @@ authorization by itself.
 3. Invoke Validate once in a context distinct from the author's context. Pass
    the intent reference and digest, exact subject manifest, factual receipts,
    validator identity, and freshness attestation.
-4. Return the durable `verdict.v2` reference and a short report. Stop regardless
-   of `PASS`, `FAIL`, or `NOT_PROVEN`.
+4. Return the fresh validation result and a short report. Persist and link
+   `verdict.v2` only when the caller requests machine-readable evidence or a
+   declared downstream consumer requires it. Stop regardless of `PASS`, `FAIL`,
+   or `NOT_PROVEN`.
 
 `NOT_PLANNED` and `NOT_BUILT` are report statuses, never semantic verdicts.
 A caller may revise the bead or caller intent and start a new invocation. RPI
@@ -95,9 +97,9 @@ one outcome and one acceptance boundary.
 If control artifacts or fresh-validation cycles are multiplying faster than
 implementation evidence, stop dispatching more lanes. Return to one
 outcome-level intent and continue with targeted deterministic checks, reserving
-the full integration check and fresh verdict for the frozen subject. This
+the full integration check and fresh validation for the frozen subject. This
 changes orchestration cost, never acceptance, exact identity, fail-closed
-scope, or verdict authority.
+scope, or validation authority.
 
 ## Continuation envelope
 
@@ -142,13 +144,14 @@ disjoint regen surfaces may run in parallel.
 
 ## Report
 
-RPI has two report surfaces. Keep them distinct:
+RPI has one required report surface and one optional representation:
 
-1. **Machine artifact:** return or persist the exact
-   [`rpi-report.v1`](../../schemas/rpi-report.v1.schema.json) object for
-   adapters, automation, and audit.
-2. **Interactive response:** summarize that object for the caller in natural
+1. **Interactive response:** return the result to the caller in natural
    language. This is the default assistant response.
+2. **Machine artifact:** return or persist the exact
+   [`rpi-report.v1`](../../schemas/rpi-report.v1.schema.json) object only when
+   the caller requests machine-readable evidence or a declared adapter consumes
+   it.
 
 Lead the interactive response with the status and one sentence stating the
 caller-visible outcome. Lead with the subject, not the process: production
@@ -159,10 +162,8 @@ unchecked scope, and a clickable verdict reference when one exists. Name why
 no subject exists for `NOT_PLANNED` or `NOT_BUILT`. Keep the response to one
 short paragraph or at most four bullets.
 
-The machine artifact remains behind the verdict/report link. Emit its full
-JSON or YAML object only when the caller explicitly requests machine-readable
-output or an adapter consumes the response. Raw digests, schema fields, and
-exhaustive check lists stay in the artifact unless an integrity failure makes
-one necessary to explain the result.
+When no machine artifact was requested, do not create a hidden one. Raw digests,
+schema fields, and exhaustive check lists stay out of the interactive response
+unless an integrity failure makes one necessary to explain the result.
 
 Do not append a next action. The caller owns continuation.

--- a/skills/rpi/references/rpi.feature
+++ b/skills/rpi/references/rpi.feature
@@ -13,9 +13,10 @@ Feature: RPI runs one bounded experiment
     Then RPI stops without repair, replan, helper, retry, or delivery
 
   @covered-by:skills/rpi/scripts/validate.sh
-  Scenario: Interactive output summarizes the machine artifact
-    Given RPI has produced an rpi-report.v1 machine artifact
+  Scenario: Interactive output does not require a machine artifact
+    Given RPI has received one fresh validation result
     When RPI responds to an interactive caller
     Then the response leads with status and the caller-visible outcome
-    And it includes only the strongest proof, material unchecked scope, and verdict link
-    And the full schema object is emitted only when machine-readable output was requested
+    And it includes only the strongest proof and material unchecked scope
+    And no hidden rpi-report.v1 or verdict.v2 is created
+    And a machine artifact is emitted only when a caller or declared consumer requested it

--- a/skills/rpi/scripts/run_once.py
+++ b/skills/rpi/scripts/run_once.py
@@ -102,10 +102,36 @@ def invoke_once(
     if validation.get("acceptance_digest") != acceptance_digest:
         raise ValueError("Validate verdict does not match the resolved intent digest")
     subject_digest = validation.get("subject_manifest_digest")
+    if not valid_digest(subject_digest):
+        raise ValueError("Validate must return the exact subject manifest digest")
+    candidate_digest = subject.get("subject_manifest_digest")
+    if candidate_digest is not None and subject_digest != candidate_digest:
+        raise ValueError("Validate result does not match the implemented subject digest")
+    author_context_id = validation.get("author_context_id")
+    validator_context_id = validation.get("validator_context_id")
+    freshness = validation.get("freshness_attestation")
+    if (
+        not isinstance(author_context_id, str)
+        or not author_context_id
+        or not isinstance(validator_context_id, str)
+        or not validator_context_id
+        or author_context_id == validator_context_id
+        or not isinstance(freshness, Mapping)
+        or freshness.get("source") not in {"runtime", "caller"}
+        or not isinstance(freshness.get("attester_identity"), str)
+        or not freshness.get("attester_identity")
+    ):
+        raise ValueError("Validate must return distinct context identities and explicit freshness")
     verdict_digest = validation.get("verdict_digest")
     verdict_ref = validation.get("verdict_ref")
-    if not all(isinstance(value, str) and value for value in (subject_digest, verdict_digest, verdict_ref)):
-        raise ValueError("Validate must return durable verdict and subject identities")
+    if (verdict_digest is None) != (verdict_ref is None):
+        raise ValueError("Validate must return both verdict_ref and verdict_digest when persistence is requested")
+    if verdict_ref is not None and (
+        not isinstance(verdict_ref, str)
+        or not verdict_ref
+        or not valid_digest(verdict_digest)
+    ):
+        raise ValueError("Persisted verdict identity is invalid")
     return report(
         status,
         intent_ref=intent_ref,

--- a/skills/rpi/scripts/validate.sh
+++ b/skills/rpi/scripts/validate.sh
@@ -9,8 +9,8 @@ grep -Fq 'Plan is closed for that intent' "$skill_dir/SKILL.md"
 grep -Fq 'spiral breaker' "$skill_dir/SKILL.md"
 grep -Fq 'A rising artifact count over an unchanged subject is a stop' "$skill_dir/SKILL.md"
 grep -Fq 'This is the default assistant response.' "$skill_dir/SKILL.md"
-grep -Fq 'only when the caller explicitly requests machine-readable' "$skill_dir/SKILL.md"
-grep -Fq 'The machine artifact remains behind the verdict/report link.' "$skill_dir/SKILL.md"
+grep -Fq 'only when the caller requests machine-readable evidence' "$skill_dir/SKILL.md"
+grep -Fq 'When no machine artifact was requested, do not create a hidden one.' "$skill_dir/SKILL.md"
 if grep -Fq 'plan_packet_digest' "$skill_dir/SKILL.md"; then
   echo 'rpi contract references a model-authored plan packet digest' >&2
   exit 1

--- a/skills/rpi/tests/test_run_once.py
+++ b/skills/rpi/tests/test_run_once.py
@@ -53,6 +53,12 @@ class RunOnceTests(unittest.TestCase):
                 "verdict": verdict,
                 "acceptance_digest": INTENT_DIGEST,
                 "subject_manifest_digest": "a" * 64,
+                "author_context_id": "author-ctx",
+                "validator_context_id": "validator-ctx",
+                "freshness_attestation": {
+                    "source": "runtime",
+                    "attester_identity": "runtime:rpi-test",
+                },
                 "verdict_digest": "b" * 64,
                 "verdict_ref": "/tmp/verdict.json",
                 "checked": ["acceptance"],
@@ -75,6 +81,39 @@ class RunOnceTests(unittest.TestCase):
         result = MODULE.invoke_once("intent", plan, implement, validate)
         self.assertEqual(calls, ["plan", "implement", "validate"])
         self.assertEqual(result["status"], "FAIL")
+
+    def test_fresh_validation_does_not_require_persisted_verdict(self):
+        calls, plan, implement, validate = self.phases()
+
+        def inline_result(resolved, subject):
+            result = validate(resolved, subject)
+            result.pop("verdict_digest")
+            result.pop("verdict_ref")
+            return result
+
+        result = MODULE.invoke_once("intent", plan, implement, inline_result)
+
+        self.assertEqual(calls, ["plan", "implement", "validate"])
+        self.assertEqual(result["status"], "PASS")
+        self.assertEqual(result["subject_manifest_digest"], "a" * 64)
+        self.assertIsNone(result["verdict_ref"])
+        self.assertIsNone(result["verdict_digest"])
+
+    def test_fresh_validation_requires_distinct_contexts_and_attestation(self):
+        _calls, plan, implement, validate = self.phases()
+
+        for field, value in (
+            ("validator_context_id", "author-ctx"),
+            ("freshness_attestation", None),
+        ):
+            with self.subTest(field=field):
+                def invalid(resolved, subject, field=field, value=value):
+                    result = validate(resolved, subject)
+                    result[field] = value
+                    return result
+
+                with self.assertRaisesRegex(ValueError, "distinct context identities"):
+                    MODULE.invoke_once("intent", plan, implement, invalid)
 
     def test_missing_plan_stops_before_implement(self):
         calls: list[str] = []
@@ -191,6 +230,12 @@ class ComposedIdentityContractTests(unittest.TestCase):
                     "verdict": "PASS",
                     "acceptance_digest": bound["acceptance_digest"],
                     "subject_manifest_digest": "a" * 64,
+                    "author_context_id": "author-ctx",
+                    "validator_context_id": "validator-ctx",
+                    "freshness_attestation": {
+                        "source": "runtime",
+                        "attester_identity": "runtime:composed-test",
+                    },
                     "verdict_digest": "b" * 64,
                     "verdict_ref": str(Path(tmp) / "verdict.json"),
                     "checked": ["acceptance"],

--- a/skills/standards/references/skill-structure.md
+++ b/skills/standards/references/skill-structure.md
@@ -110,7 +110,9 @@ path, schema, filename, validator, and downstream handoff.
 
 Structured outputs should name their schema and identity rules. Factual inline
 outputs should name the fields or sentence shape. Never imply PASS, readiness,
-or continuation unless the skill is Validate producing `verdict.v2`.
+or continuation unless the skill is Validate returning a fresh semantic result.
+`verdict.v2` is an optional representation for declared consumers, not the
+source of Validate's authority.
 
 The reference example of a structured-output validator is
 `skills/pattern-mining/scripts/validate-output.sh` — a small `jq` predicate that

--- a/skills/using-gc/SKILL.md
+++ b/skills/using-gc/SKILL.md
@@ -165,6 +165,6 @@ session wedge, bead/run state over prose for workflow completion.
 - GC quests, runs, attempts, stalls, cancellations, and internal close state
   stay in GC. They never become AgentOps Plan, Candidate, RPI, or verdict state.
 - A GC close or completed run is not AgentOps completion. Only a fresh Validate
-  context writes `verdict.v2`.
+  context issues the semantic result or, when requested, persists `verdict.v2`.
 - This skill performs no automatic selection, retry, semantic validation, Git,
   integration, closure, release, or delivery.

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validate
-description: 'Freshly judge exact subject content against bead or caller acceptance, persist verdict.v2, and stop. Triggers: "validate", "independently validate", "vibe".'
+description: 'Freshly judge exact subject content against bead or caller acceptance, optionally persist verdict.v2 for a declared consumer, and stop. Triggers: "validate", "independently validate", "vibe".'
 practices:
 - design-by-contract
 - llm-eval-harness
@@ -10,6 +10,7 @@ consumes:
 - subject-manifest.v1
 produces:
 - subject-manifest.v1
+- validation-result
 - verdict.v2
 context_rel:
 - kind: customer-of
@@ -22,19 +23,19 @@ metadata:
   graph_root: true
   tier: judgment
   dependencies: []
-  capabilities: [compute_subject_identity, judge_acceptance, persist_verdict]
+  capabilities: [compute_subject_identity, judge_acceptance, return_validation_result, persist_verdict]
   effects: [write_verdict_artifact]
   canonical_status: canonical
   disposition: keep
-output_contract: schemas/verdict.v2.schema.json
+output_contract: 'PASS | FAIL | NOT_PROVEN with criteria, evidence, checked/not_checked, identity, and freshness; optional schemas/verdict.v2.schema.json persistence'
 ---
 
 # Validate
 
 Independently judge one exact subject against the acceptance in its existing
-bead or caller source, write one durable verdict, and stop. Validate is the sole
-verdict writer. It never asks the model to reconstruct Plan or Candidate
-packets.
+bead or caller source, return one semantic result, and stop. Validate is the
+sole `verdict.v2` writer when persistence is requested. It never asks the model
+to reconstruct Plan or Candidate packets.
 
 ## Preconditions
 
@@ -95,22 +96,27 @@ committed subject, never the judged working tree.
    (see the freshness rules below for when a digest-bound receipt suffices).
    Judge every acceptance criterion and record criterion-level results,
    findings, evidence references, `checked`, and `not_checked`.
-5. Choose exactly one semantic result: `PASS`, `FAIL`, or `NOT_PROVEN`. PASS
-   requires distinct identities, explicit freshness, nonempty checked scope,
-   top-level evidence, and evidence for every criterion.
-6. Persist canonical `verdict.v2` with `store-verdict --draft <draft.json>
-   --intent-source <resolved-intent> --subject-manifest <manifest.json>
-   --author-context-id <id> --validator-context-id <id>
-   --freshness-source <runtime|caller> --freshness-attester-id <id>
-   --scope-result <PASS|FAIL|NOT_PROVEN>`. The helper
-   snapshots the exact resolved intent under
+5. Choose exactly one semantic result: `PASS`, `FAIL`, or `NOT_PROVEN`. Return
+   it with criterion results, findings, evidence references, `checked`,
+   `not_checked`, the acceptance and subject identities, distinct author and
+   validator context IDs, and the freshness attestation. PASS requires distinct
+   identities, explicit freshness, nonempty checked scope, top-level evidence,
+   and evidence for every criterion.
+6. Only when the caller requests machine-readable evidence or a declared
+   downstream consumer requires it, persist canonical `verdict.v2` with
+   `store-verdict --draft <draft.json> --intent-source <resolved-intent>
+   --subject-manifest <manifest.json> --author-context-id <id>
+   --validator-context-id <id> --freshness-source <runtime|caller>
+   --freshness-attester-id <id> --scope-result <PASS|FAIL|NOT_PROVEN>`. The
+   helper snapshots the exact resolved intent under
    `<workspace>/.agents/ao/intents/sha256/<digest>.intent`, then computes and
    injects intent and subject digests plus author, validator, and freshness
    facts. Identity and changed-path facts come from runtime-derived inputs and
-   receipts, not model transcription. Verdict
-   storage defaults to `<workspace>/.agents/ao/verdicts/sha256/<digest>.json`;
-   callers may provide `verdict_dir`.
-7. Return the artifact path and digest. Stop.
+   receipts, not model transcription. Storage defaults to
+   `<workspace>/.agents/ao/verdicts/sha256/<digest>.json`; callers may provide
+   `verdict_dir`.
+7. Return the semantic result and, when persisted, the artifact path and digest.
+   Stop.
 
 The digest is SHA-256 over canonical JSON with `artifact_digest` omitted. Writes
 use a same-directory temporary file, flush, fsync, and atomic rename. Identical

--- a/skills/validate/references/validate.feature
+++ b/skills/validate/references/validate.feature
@@ -1,4 +1,4 @@
-Feature: Validate writes one fresh verdict over exact content
+Feature: Validate returns one fresh judgment over exact content
   @covered-by:skills/validate/scripts/test_validate.py::test_verdict_identity_floor_and_idempotence
   Scenario: Identity gaps stay unproven
     Given missing, colliding, or unattested author and validator identities
@@ -24,8 +24,14 @@ Feature: Validate writes one fresh verdict over exact content
     Then the snapshot path is its SHA-256 identity
 
   @covered-by:skills/validate/scripts/test_validate.py::test_verdict_identity_floor_and_idempotence
-  Scenario: Validation stops after persistence
+  Scenario: Validation stops without requiring persistence
     Given any PASS, FAIL, or NOT_PROVEN verdict
-    When Validate atomically persists it
-    Then Validate returns the artifact digest and path
+    When Validate returns the fresh result
+    Then Validate does not require an artifact digest or path
     And performs no repair, retry, Git, closure, release, or delivery action
+
+  @covered-by:skills/validate/scripts/test_validate.py::test_verdict_identity_floor_and_idempotence
+  Scenario: Declared consumers may request durable evidence
+    Given a caller or declared downstream consumer requests machine-readable evidence
+    When Validate atomically persists the result
+    Then Validate returns the verdict.v2 artifact digest and path

--- a/skills/validate/scripts/validate.sh
+++ b/skills/validate/scripts/validate.sh
@@ -6,8 +6,8 @@ repo_root="$(cd "$skill_dir/../.." && pwd)"
 
 grep -q '^name: validate$' "$skill_dir/SKILL.md"
 grep -Fq 'PASS`, `FAIL`, or `NOT_PROVEN`' "$skill_dir/SKILL.md"
-grep -Fq 'sole' "$skill_dir/SKILL.md"
-grep -Fq 'verdict writer' "$skill_dir/SKILL.md"
+grep -Fq 'sole `verdict.v2` writer when persistence is requested' "$skill_dir/SKILL.md"
+grep -Fq 'Only when the caller requests machine-readable evidence' "$skill_dir/SKILL.md"
 grep -Fq 'nonempty implementation candidate' "$skill_dir/SKILL.md"
 
 python3 "$skill_dir/scripts/validate.py" --help >/dev/null

--- a/tests/scripts/agentops-product-boundary.bats
+++ b/tests/scripts/agentops-product-boundary.bats
@@ -38,7 +38,9 @@ require_text() {
   done
 
   require_text AGENTS.md \
-    "RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop"
+    "RPI -> Plan -> Implement -> fresh Validate -> report and stop"
+  require_text AGENTS.md \
+    "Persist \`verdict.v2\` only when"
   require_text PRODUCT.md \
     "AgentOps is not a new GitLab, CI service, tracker, merge queue, delivery system"
   require_text docs/architecture/operating-loop.md \
@@ -63,6 +65,21 @@ if actual != expected:
     raise SystemExit(actual)
 PY
   [ "$status" -eq 0 ]
+}
+
+@test "validation worksheet requires fresh judgment and makes persistence optional" {
+  require_text docs/templates/slice-validation.md \
+    '- Validation result: `<PASS | FAIL | NOT_PROVEN>`'
+  require_text docs/templates/slice-validation.md \
+    '- Verdict artifact (optional): `<content-addressed path when requested>`'
+  require_text docs/templates/slice-validation.md \
+    "Validate returns one fresh result and stops"
+  require_text docs/templates/slice-validation.md \
+    "Persist \`verdict.v2\` only when"
+
+  run grep -F "Validate persists one verdict" \
+    "$REPO_ROOT/docs/templates/slice-validation.md"
+  [ "$status" -eq 1 ]
 }
 
 @test "negative fixtures reject semantic Git authority and automatic continuation" {

--- a/tests/scripts/agents-operating-contract.bats
+++ b/tests/scripts/agents-operating-contract.bats
@@ -6,7 +6,8 @@
   [ -f "$contract" ]
 
   for required in \
-    "RPI -> Plan -> Implement -> fresh Validate -> durable verdict -> report and stop" \
+    "RPI -> Plan -> Implement -> fresh Validate -> report and stop" \
+    "Persist \`verdict.v2\` only when" \
     "It owns no retry" \
     "fresh independent judgment" \
     "docs/architecture/operating-loop.md"; do


### PR DESCRIPTION
## Summary

- keep fresh, author-distinct validation mandatory while making `verdict.v2` and `rpi-report.v1` persistence consumer-driven
- preserve exact-subject binding, freshness, identity, mutation invalidation, and report-and-stop semantics
- align RPI/Validate skills, executable reference behavior, current docs, CLI guidance, tests, and generated projections
- close the stale validation worksheet and duplicate `execute this plan` trigger gaps
- reconcile the change with the Gas City 1.4 update already on `main`

## Validation

- `scripts/ci-local-release.sh --quick`
- RPI tests: 11/11
- Validate tests: 16/16
- skill suite: 53/53, zero alias collisions
- generated projection and Codex parity checks
- fresh Fable validation over commit `6f3588dbb420ecedd1c1381165fa6fcf542dc459`: PASS, no findings

Exact diff digest against `main`: `d54eee57e071d332b3cb24ea55dfbffae2a0dff232dd46a6018ae09ff5523a9a`.