### PR TITLE
3.4.0 release prep: upstream-factories pivot, version bumps, release notes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Fresh-context validation for coding-agent work: one behavior, one bounded experiment, one independent verdict.",
-    "version": "3.3.0"
+    "version": "3.4.0"
   },
   "plugins": [
     {
       "name": "agentops",
       "description": "Fresh-context validation for coding-agent work: one behavior, one bounded experiment, one independent verdict.",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "source": "./",
       "author": {
         "name": "Boden Fuller",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentops",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Fresh-context validation for coding-agent work: shape one behavior, run one bounded experiment, and persist an independent verdict.",
   "author": {
     "name": "Boden Fuller",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentops",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Fresh-context validation for coding-agent work: shape one behavior, run one bounded experiment, and persist an independent verdict.",
   "skills": "./skills-codex",
   "interface": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-07-30
+
+AgentOps 3.4 is the **honest-contract release**. All 50 shipped skills went
+through an eight-wave contract overhaul — declared real effects, honest output
+contracts, closed artifact directories, authority claims stripped — and the
+factory boundary is now explicit: AgentOps no longer carries its own
+orchestration pack as the product path. The supported software factories are
+the upstream Gas City build pack and the Agentic Coding Flywheel; AgentOps
+supplies the skills and evidence discipline either factory executes.
+
+### Added
+
+- Negative-witness ratchet: every blocking gate must carry a test proving it
+  fails on what it detects, with a shrink-only grandfather list.
+- `ao gate check --dry-run`: a real plan-only mode that mutates nothing.
+
 ### Changed
 
-- Upgrade the optional Gas City factory from v1.3.5 to the checksummed v1.4.0
-  release, compose the registry-pinned `gascity` 0.1.6 workflows and roles used
-  by Maintainer City, remove the v1.3 Mayor heartbeat workaround, require
-  scope-local `core.control-dispatcher` propulsion, and expose the supervisor
-  dashboard plus pack-registry inspection through the managed invoke surface.
+- All 50 skill contracts overhauled across waves W2–W8: real effects, honest
+  output contracts, scratch-tier artifact directories, authority grants
+  stripped, fail-closed deadlines, corpus-level trigger separation.
+- `goals` renamed to `fitness` with a compatibility alias; `shared` retired to
+  a declared contract owner.
+- Fresh validation persistence is optional: `verdict.v2` is written only for a
+  caller request or a declared downstream consumer.
+- The README and `using-gc` skill present the upstream Gas City build pack and
+  the Agentic Coding Flywheel as the supported factory choices; `using-gc`
+  teaches stock `gascity` workflows and roles.
+- Gas City factory qualification pins and fail-closes on the checksummed
+  v1.4.0 release and the registry-pinned `gascity` 0.1.6 workflows and roles
+  used by Maintainer City, removes the v1.3 Mayor heartbeat workaround, and
+  requires scope-local `core.control-dispatcher` propulsion.
+- The eval subprocess runner is bounded and cancellable with process-group
+  reaping; eval id containment hardened and temp directories owned by the run.
+- ADR-0016 shipped-Python rule is enforced by a blocking gate.
+
+### Fixed
+
+- RPI and Validate no longer disagree on the intent-source digest.
+- `handoff` schema matches what the command writes; `dcg` guidance corrected.
+- The orchestration-skill-boundaries gate no longer references adapter files
+  deleted by the 3.3 single-pass refactor.
+
+### Deprecated
+
+- The in-repo Gas City factory prototype (`deploy/gc/`) is retired in place;
+  upstream factories are the supported path.
 
 ## [3.3.0] - 2026-07-23
 

--- a/README.md
+++ b/README.md
@@ -83,42 +83,31 @@ The default loop is one agent, one writer. When you need a fleet,
 [`ntm`](skills/ntm/SKILL.md), and [`using-gc`](skills/using-gc/SKILL.md)
 orchestrate multi-agent work. They dispatch; they do not own the verdict.
 
-### The Gas City pack (preview)
+### Choose a software factory
 
-[Gas City](https://github.com/gastownhall/gascity) runs teams of coding agents
-as long-lived, supervised sessions. The pack in
-[`deploy/gc/`](deploy/gc/README.md) stands up a "city" that runs the AgentOps
-loop end to end: workers implement in isolated worktrees, a fresh agent
-validates, a refiner merges to your repo's main branch. The installer fetches
-official checksummed Gas City and Beads binaries; you build nothing.
+AgentOps supplies skills and evidence contracts, not another software-factory
+runtime or a competing Gas City pack. Install the skills in the agent runtime
+used by the factory you choose; its Mayor, coordinator, and workers can then use
+`plan`, `implement`, `test`, `validate`, and the rest of the catalog.
 
-Gas City 1.4 runs the flow through a scope-local control dispatcher and exposes
-each formula as a dashboard/API run. The Mayor remains an optional on-demand
-human/agent door for inspection or one manual dispatch.
+Two factory stacks are supported:
 
-```bash
-deploy/gc/invoke.sh --city <city> create "task title"       # define work
-deploy/gc/invoke.sh --city <city> feed <bead-id>            # hand it to the city
-deploy/gc/invoke.sh --city <city> dashboard                 # print the run UI
-deploy/gc/invoke.sh --city <city> mayor tell "dispatch <bead-id>"
-```
+- [Gas City](https://github.com/gastownhall/gascity) — the preferred choice for
+  durable, supervised workflows. Use the upstream
+  [`gascity` build pack](https://github.com/gastownhall/gascity-packs/tree/main/gascity),
+  the workflow family used by Maintainer City. It owns formulas, roles,
+  worktrees, dispatch, draining, and run state. The
+  [`using-gc`](skills/using-gc/SKILL.md) skill covers installation, launch,
+  observation, and recovery.
+- Jeffrey Emanuel's
+  [Agentic Coding Flywheel](https://agent-flywheel.com) — a supported
+  alternative built from Beads, Agent Mail, NTM, and the wider Flywheel tool
+  stack. Use its native workflow and let its agents consume the same AgentOps
+  skills.
 
-The [`using-gc`](skills/using-gc/SKILL.md) skill is the operating manual,
-including the four observability layers and what to do when they disagree.
-**Preview:** pinned to official Gas City v1.4.0 and the registry-pinned
-`gascity` 0.1.6 workflow used by the public Maintainer City. Deterministic native
-qualification is required here; the preview label comes off after one clean
-mixed-provider canary over the final candidate.
-Setup and details: [`deploy/gc/README.md`](deploy/gc/README.md) and the
-[v3.3.0 release notes](https://github.com/boshu2/agentops/releases/tag/v3.3.0).
-
-AgentOps already borrows heavily from that ecosystem. Two stacks people run
-around the same loop:
-
-- [Gas City](https://github.com/gastownhall/gascity) — orchestration-builder for
-  multi-agent coding workflows
-- Jeffrey Emanuel's [Agentic Coding Flywheel](https://agent-flywheel.com) —
-  coordinated multi-agent tooling (mail, beads, NTM, and friends)
+AgentOps does not wrap either factory or translate factory completion into
+semantic PASS. When proof is required, a fresh `validate` context judges the
+exact candidate and evidence.
 
 ## Optional: `ao` CLI
 

--- a/cli/cmd/ao/main.go
+++ b/cli/cmd/ao/main.go
@@ -5,7 +5,7 @@ package main
 // version is set at build time via ldflags (goreleaser: -X main.version={{ .Version }}).
 // The fallback identifies untagged source builds for the next release;
 // published binaries override it from the release tag via GoReleaser.
-var version = "3.3.0"
+var version = "3.4.0"
 
 func main() {
 	Execute()

--- a/deploy/gc/README.md
+++ b/deploy/gc/README.md
@@ -1,13 +1,21 @@
-# AgentOps Gas City pack
+# Retired AgentOps Gas City pack prototype
 
-**Status: preview — this is the Gas City 1.4 supported-candidate flow.** Gas City 1.4 is
-pinned and deterministically qualified below. Promotion to supported remains
-gated on one clean mixed-provider canary over the final candidate.
+**Status: retired on 2026-07-29. Do not use this as the supported setup path.**
+AgentOps now recommends the upstream
+[`gascity` build pack](https://github.com/gastownhall/gascity-packs/tree/main/gascity)
+and contributes skills through the provider runtime instead of owning formulas
+or roles. See [`using-gc`](../../skills/using-gc/SKILL.md).
 
-This is a thin AgentOps role pack over official Gas City. Gas City owns
-sessions, routing, formulas, orders, and OTEL. Beads owns work and dependencies.
-Git owns candidate commits, AgentOps owns the final semantic verdict, and
-GitHub owns PR, CI, and merge state.
+The scripts and notes below are retained temporarily as migration and test
+evidence for the former prototype. They do not define current product behavior.
+
+## Historical prototype
+
+Gas City 1.4 is pinned and deterministically qualified below. This prototype
+was a thin AgentOps role pack over official Gas City. Gas City owns sessions,
+routing, formulas, orders, and OTEL. Beads owns work and dependencies. Git owns
+candidate commits, AgentOps owns the final semantic verdict, and GitHub owns PR,
+CI, and merge state.
 
 ## Materialize the official pair
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-07-30
+
+AgentOps 3.4 is the **honest-contract release**. All 50 shipped skills went
+through an eight-wave contract overhaul — declared real effects, honest output
+contracts, closed artifact directories, authority claims stripped — and the
+factory boundary is now explicit: AgentOps no longer carries its own
+orchestration pack as the product path. The supported software factories are
+the upstream Gas City build pack and the Agentic Coding Flywheel; AgentOps
+supplies the skills and evidence discipline either factory executes.
+
+### Added
+
+- Negative-witness ratchet: every blocking gate must carry a test proving it
+  fails on what it detects, with a shrink-only grandfather list.
+- `ao gate check --dry-run`: a real plan-only mode that mutates nothing.
+
 ### Changed
 
-- Upgrade the optional Gas City factory from v1.3.5 to the checksummed v1.4.0
-  release, compose the registry-pinned `gascity` 0.1.6 workflows and roles used
-  by Maintainer City, remove the v1.3 Mayor heartbeat workaround, require
-  scope-local `core.control-dispatcher` propulsion, and expose the supervisor
-  dashboard plus pack-registry inspection through the managed invoke surface.
+- All 50 skill contracts overhauled across waves W2–W8: real effects, honest
+  output contracts, scratch-tier artifact directories, authority grants
+  stripped, fail-closed deadlines, corpus-level trigger separation.
+- `goals` renamed to `fitness` with a compatibility alias; `shared` retired to
+  a declared contract owner.
+- Fresh validation persistence is optional: `verdict.v2` is written only for a
+  caller request or a declared downstream consumer.
+- The README and `using-gc` skill present the upstream Gas City build pack and
+  the Agentic Coding Flywheel as the supported factory choices; `using-gc`
+  teaches stock `gascity` workflows and roles.
+- Gas City factory qualification pins and fail-closes on the checksummed
+  v1.4.0 release and the registry-pinned `gascity` 0.1.6 workflows and roles
+  used by Maintainer City, removes the v1.3 Mayor heartbeat workaround, and
+  requires scope-local `core.control-dispatcher` propulsion.
+- The eval subprocess runner is bounded and cancellable with process-group
+  reaping; eval id containment hardened and temp directories owned by the run.
+- ADR-0016 shipped-Python rule is enforced by a blocking gate.
+
+### Fixed
+
+- RPI and Validate no longer disagree on the intent-source digest.
+- `handoff` schema matches what the command writes; `dcg` guidance corrected.
+- The orchestration-skill-boundaries gate no longer references adapter files
+  deleted by the 3.3 single-pass refactor.
+
+### Deprecated
+
+- The in-repo Gas City factory prototype (`deploy/gc/`) is retired in place;
+  upstream factories are the supported path.
 
 ## [3.3.0] - 2026-07-23
 

--- a/docs/adr/ADR-0015-gas-city-fenced-steward.md
+++ b/docs/adr/ADR-0015-gas-city-fenced-steward.md
@@ -1,6 +1,7 @@
 # ADR-0015: Gas City Fenced Steward Factory
 
-- **Status:** Superseded on 2026-07-22 by the thin native pack boundary
+- **Status:** Historical; the 2026-07-22 thin-pack replacement was itself
+  superseded on 2026-07-29 by the upstream-pack, skills-only boundary
 - **Scope:** Historical record of the rejected GC33 control-plane expansion
 - **Current authority:** [Gas City reliability boundary](../operations/gas-city-reliability.md)
 - **Migration evidence:** [GC33 migration provenance](../contracts/gc33-migration-provenance.md)
@@ -44,3 +45,11 @@ The former implementation remains available in Git history, not in the active
 runtime. Development uses a fast offline contract and one opt-in native
 qualification at a candidate boundary. A live mixed-provider canary is allowed
 only after fresh validation and protected delivery.
+
+## Current direction
+
+AgentOps no longer offers an AgentOps-owned Gas City workflow or role pack as
+its supported path. Operators use the official `gascity` pack—or another
+independently selected software factory such as the Agentic Coding Flywheel—and
+make AgentOps skills available to that factory's agents. AgentOps owns the
+skills and semantic evidence boundary; the selected factory owns orchestration.

--- a/docs/operations/gas-city-reliability.md
+++ b/docs/operations/gas-city-reliability.md
@@ -1,7 +1,7 @@
 # Gas City reliability boundary
 
-AgentOps ships configuration and small operational helpers, not an
-orchestration backend.
+AgentOps ships skills, evidence contracts, and small operational guidance, not
+an orchestration backend or a competing Gas City pack.
 
 | Fact | Authority |
 |---|---|
@@ -12,30 +12,30 @@ orchestration backend.
 | Semantic acceptance | AgentOps `subject-manifest.v1` and `verdict.v2` |
 | Pull request, hosted checks, merge | GitHub |
 
-The source bead flows through one native formula: fresh Sol planning, one
-isolated Terra-high or Opus-medium implementation, fresh Sol validation, then
-a separate Fable Refiner delivery step. Validation may close the semantic bead
-before delivery completes. Moving main never blocks semantic work; the Refiner
-rebases once and returns stale or conflicting work to the Mayor.
+Caller-owned work flows through the upstream pack selected by the operator.
+AgentOps prefers the official `gascity` build pack used by Maintainer City, but
+also supports the Agentic Coding Flywheel as an independent factory choice.
+Agents inside either factory consume AgentOps skills through their provider
+runtime's normal skill discovery.
 
-Operational scripts must remain bounded. They may materialize the pinned
-official pair, render a city, set up one worktree, invoke native GC commands,
-perform one delivery attempt, and stop the city. They must not mirror Beads,
-GC, Git, or GitHub state in a schema family, daemon, reducer, or receipt graph.
+Operational guidance must remain bounded. It may install a pinned upstream
+pack, configure providers, invoke native commands, observe runs, and stop a
+city. It must not mirror Beads, Gas City, Git, or GitHub state in an AgentOps
+schema family, daemon, reducer, receipt graph, formula, or role pack.
 
-The AgentOps pack composes the registry-pinned `gascity` workflow used by
-Maintainer City and binds its sibling role pack at the stock default-rig
-namespace, `gc.*`, while keeping `agentops-experiment` as its bounded default.
-Every graph-owning scope retains an unsuspended `core.control-dispatcher`; the
-optional Mayor is on-demand and no longer runs a v1.3 heartbeat workaround.
+For Gas City, install the registry-pinned `gascity` workflow at city scope and
+its sibling role pack at rig scope, preserving the stock `gc.*` namespace.
+Every graph-owning scope retains an unsuspended
+`core.control-dispatcher`. The upstream `gc.mayor` skill and
+`gc.run-operator` own guided coordination and formula launch.
 
-Release qualification uses deterministic toolchain, registry, pack, config,
-formula, scoped-dispatcher, and worktree checks before any model session. A live
-canary is disposable, uses required OTEL, and is repaired only from outside GC.
-Two failed canaries reject the release shape.
+Compatibility qualification uses deterministic toolchain, registry, import
+lock, config, formula, scoped-dispatcher, and worktree checks before any model
+session. A live canary is disposable, uses required OTEL, and is repaired only
+from outside Gas City. It qualifies the selected upstream pack plus AgentOps
+skill availability; it does not qualify an AgentOps-owned factory.
 
 Development is two-speed by design. The offline unit and lint contract is the
-inner loop. The pinned native bootstrap, formula preview and route, doctor, and
-quiescent teardown suite runs once at a candidate boundary. It does not launch
-model sessions. Only a green, freshly validated and merged candidate reaches a
-mixed-provider canary.
+inner loop. Native import, formula preview and route, doctor, and quiescent
+teardown checks run at a candidate boundary. Live model sessions remain an
+explicit compatibility test.

--- a/docs/releases/2026-07-30-v3.4.0-notes.md
+++ b/docs/releases/2026-07-30-v3.4.0-notes.md
@@ -1,0 +1,85 @@
+## Highlights
+
+AgentOps 3.4 is the **honest-contract release**. Every one of the 50 shipped
+skills went through an eight-wave overhaul that makes each contract state only
+what it really does: declared effects, real output contracts, closed artifact
+directories, and authority claims stripped where no authority exists. On the
+factory side, AgentOps stops carrying its own orchestration pack as the product
+path: the supported software factories are the upstream
+[Gas City build pack](https://github.com/gastownhall/gascity-packs/tree/main/gascity)
+and the [Agentic Coding Flywheel](https://agent-flywheel.com/) — AgentOps
+supplies the skills and the evidence discipline they execute, and the
+[`using-gc`](../../skills/using-gc/SKILL.md) skill now teaches stock `gascity`
+workflows and roles. Release gates gained a shrink-only ratchet requiring every
+blocking gate to prove it can fail, and the eval subprocess runner is now
+bounded, cancellable, and reaps its whole process group.
+
+## Upgrade Notes
+
+- The `goals` skill is renamed `fitness`; the `goals` trigger remains as a
+  compatibility alias, so no manual action is required.
+- If you ran the 3.3 Gas City pack preview from `deploy/gc/`, that prototype is
+  retired in place: keep using it if it works for you, but new setups should
+  follow the upstream Gas City build pack or the Agentic Coding Flywheel.
+
+## At a Glance
+
+| Product Area | Added | Changed | Refactored | Fixed | Deprecated/Removed |
+|---|---:|---:|---:|---:|---:|
+| Skills and Workflows | 0 | 4 | 0 | 0 | 1 |
+| Eval, Validation, and Release Gates | 1 | 3 | 0 | 2 | 0 |
+| CLI and Operator Commands | 0 | 2 | 0 | 1 | 0 |
+| Docs and Onboarding | 0 | 2 | 0 | 0 | 0 |
+
+## Product Areas
+
+### Skills and Workflows
+
+- Changed: all 50 skill contracts overhauled across eight waves — declared real
+  effects, honest output contracts, scratch-tier artifact directories,
+  authority grants stripped, fail-closed deadlines, and corpus-level trigger
+  separation (W2–W8)
+- Changed: `using-gc` now teaches the stock upstream `gascity` workflows and
+  roles instead of an in-repo experiment pack
+- Changed: `goals` renamed to `fitness` with a compatibility alias; `shared`
+  retired to a declared contract owner
+- Changed: fresh validation persistence is optional — `verdict.v2` is written
+  only for a caller request or a declared downstream consumer
+- Deprecated: the in-repo Gas City factory prototype (`deploy/gc/`) is retired
+  in place; upstream factories are the supported path
+
+### Eval, Validation, and Release Gates
+
+- Added: a negative-witness ratchet requiring every blocking gate to prove it
+  can fail on what it detects, with a shrink-only grandfather list
+- Changed: the eval subprocess runner is bounded and cancellable with
+  process-group reaping
+- Changed: ADR-0016 shipped-Python rule is enforced by a blocking gate
+- Changed: Gas City factory qualification pins and fail-closes on the official
+  v1.4.0 release and the registry-pinned `gascity` 0.1.6 workflow
+- Fixed: RPI and Validate no longer disagree on the intent-source digest
+- Fixed: the orchestration-skill-boundaries gate no longer references adapter
+  files deleted by the 3.3 single-pass refactor
+
+### CLI and Operator Commands
+
+- Changed: `ao gate check --dry-run` is a real plan-only mode that mutates
+  nothing
+- Changed: eval id containment hardened and temp directories owned by the
+  invoking run
+- Fixed: `handoff` schema now matches what the command actually writes; `dcg`
+  guidance corrected to match observed behavior
+
+### Docs and Onboarding
+
+- Changed: the README presents the upstream Gas City build pack and the Agentic
+  Coding Flywheel as the supported factory choices, with AgentOps as the
+  skills-and-evidence layer either factory executes
+- Changed: the Gas City reliability boundary doc assigns orchestration to the
+  selected factory and skills/evidence to AgentOps
+
+## Known Issues
+
+- No release-blocking known issues.
+
+[Full changelog](../CHANGELOG.md)

--- a/images/claude/verify.sh
+++ b/images/claude/verify.sh
@@ -58,7 +58,7 @@ fi
 # Version guard: the Claude marketplace plugin manifest is the install entrypoint
 # for this image. Assert .claude-plugin/plugin.json declares the expected version
 # so a stale-version drift (plugin.json behind the release) fails the gate.
-EXPECTED_VERSION="${AGENTOPS_EXPECTED_VERSION:-3.3.0}"
+EXPECTED_VERSION="${AGENTOPS_EXPECTED_VERSION:-3.4.0}"
 plugin_manifest="$repo_root/.claude-plugin/plugin.json"
 if [ ! -f "$plugin_manifest" ]; then
   echo "FAIL: Claude plugin manifest not found: $plugin_manifest" >&2

--- a/images/gemini/plugin.json
+++ b/images/gemini/plugin.json
@@ -13,5 +13,5 @@
   "name": "agentops-core-gemini",
   "rules": "./rules",
   "skills": "./skills",
-  "version": "3.3.0"
+  "version": "3.4.0"
 }

--- a/images/gemini/skills/using-gc/SKILL.md
+++ b/images/gemini/skills/using-gc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-gc
-description: 'Operate a caller-selected Gas City 1.4 through run-centered, registry-aware native surfaces while keeping GC runtime state out of AgentOps verdicts. Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".'
+description: 'Operate a caller-selected Gas City 1.4 with upstream registry packs and native run-centered surfaces while keeping GC runtime state out of AgentOps verdicts. Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".'
 practices: [team-topologies, design-by-contract]
 hexagonal_role: driving-adapter
 consumes: [explicit-packets]
@@ -25,37 +25,40 @@ output_contract: runtime evidence per supplied packet
 Use Gas City only when the caller explicitly selects it. Treat it as a
 replaceable execution adapter, not a correctness or completion boundary.
 
+## Choose the factory first
+
+AgentOps supports both Gas City and the
+[Agentic Coding Flywheel](https://agent-flywheel.com) as external
+software-factory runtimes. Use this skill only for Gas City. If the caller
+selects the Flywheel, use its native workflow instead of wrapping it in Gas
+City.
+
+AgentOps supplies skills and evidence contracts to either factory. It does not
+need its own Gas City formula or role pack. Install or link AgentOps skills into
+the provider runtime before starting workers; the upstream Mayor, coordinator,
+and workers can then discover and select `plan`, `implement`, `test`,
+`validate`, and other AgentOps skills normally.
+
 ## Gas City 1.4 operating model
 
 Gas City 1.4 is run-centered. The supervisor serves the dashboard and typed,
 paginated session/run APIs. Every graph-owning city or rig scope needs its own
 `core.control-dispatcher`; that deterministic worker advances formula control
-beads. Agent workers claim routed work. The optional AgentOps Mayor is an
-on-demand human/agent door for status and one manual dispatch, not a polling
-control plane.
+beads. Agent workers claim routed work. The upstream `gc.mayor` skill is the
+guided coordinator; `gc.run-operator` launches and supervises formulas.
 
 The normal AgentOps path is:
 
-1. `invoke.sh --city C create "<title>" -d "<acceptance>"` writes one
-   caller-owned source bead.
-2. `invoke.sh --city C feed <bead-id>` homes it in the rig and starts the native
-   `agentops-experiment` formula. `gc sling` returns a run id and dashboard deep
-   link.
-3. `invoke.sh --city C dashboard` prints the embedded supervisor dashboard URL.
-4. Read run, session, bead, and verdict state. Completion is never inferred from
-   chat or pane prose.
+1. Install and pin the upstream `gascity` workflow and rig-role imports.
+2. Add the project as a rig and make AgentOps skills visible to its provider
+   sessions.
+3. Create a caller-owned bead and launch the upstream `build-basic`,
+   continuation, review, or implementation formula that matches the available
+   artifacts.
+4. Read run, session, bead, artifact, and verdict state. Completion is never
+   inferred from chat or pane prose.
 
-The Mayor remains available when explicitly useful:
-
-```sh
-invoke.sh --city C mayor start
-invoke.sh --city C mayor status
-invoke.sh --city C mayor tell "dispatch <bead-id>"
-```
-
-Hand it bead ids only. It never authors or claims work.
-
-## Packs and registries
+## Preferred pack and registries
 
 The built-in `main` registry catalogs official packs. The community registry is
 optional configuration:
@@ -74,22 +77,41 @@ exact import commands. `gc import add` declares a source/version, and `gc import
 install` resolves it into `packs.lock`. Prefer an exact accepted release for
 reproducible cities.
 
-AgentOps composes the official `gascity` 0.1.6 workflow at commit
-`3b3b89f2011e06d84459aa7bea1552382f13930a`, plus its rig roles. This is the
-workflow family visible in the public Maintainer City factory:
+AgentOps prefers the official `gascity` build pack, the workflow family visible
+in the public Maintainer City factory. The current accepted reference is
+`gascity` 0.1.6 at commit
+`3b3b89f2011e06d84459aa7bea1552382f13930a`:
 
 - dashboard: `https://factory.gascity.com`;
-- official roles, bound at the stock default-rig namespace:
-  `gc.run-operator` and `gc.implementation-worker`;
+- workflows: `build-basic`, `build-from-*`, `implement`, review, issue, and PR
+  flows;
+- stock rig roles: `gc.run-operator`, `gc.implementation-worker`, planners,
+  reviewers, and publisher;
 - scope-local formula control: `core.control-dispatcher`;
-- production formulas including `do-work`, build, review, issue, and PR flows.
+- guided coordination: the upstream `gc.mayor` skill.
 
-The workflow pack is composed into `agentops-factory`; its sibling role pack is
-instead imported as `defaults.rig.imports.gc`. Keep that split: nesting the roles
-inside `agentops-factory` renames them to `agentops.*`, while the stock formulas
-still target `gc.*`. AgentOps keeps `agentops-experiment` as its bounded
-default. The imported pack is compositional access to upstream workflows, not
-permission to replace the AgentOps verdict boundary.
+Install the workflow pack at city scope and its sibling roles pack on every rig
+that runs work, following the exact commands returned by
+`gc pack registry show main:gascity`. Keep the stock `gc.*` namespace; do not
+nest or rename the roles behind an AgentOps pack.
+
+For a starter build:
+
+```sh
+gc bd create "Add a --json flag to the export command"
+gc sling gc.run-operator <bead-id> --on build-basic \
+  --var artifact_root=plans/json-flag/build
+```
+
+For guided requirements, planning, and launch, tell the active agent:
+
+```text
+Use skill gc.mayor
+```
+
+AgentOps skills are tools available to those factory agents, not a replacement
+workflow. Explicitly name a skill in the bead or prompt when its behavior is
+required.
 
 ## Upgrade an existing city to 1.4
 
@@ -125,9 +147,9 @@ gc cities --json
 
 `unregister` fails rather than silently accepting an unknown target. Preserve
 the city directory until its Beads state is backed up or confirmed disposable.
-Then use `deploy/gc/bootstrap.sh ... --start` for the new city and verify it with
-`gc cities --json`, `gc --city <new-city> status`, and
-`gc --city <new-city> doctor --json`.
+Create the replacement from the upstream Gas City template, install its pinned
+imports, and verify it with `gc cities --json`, `gc --city <new-city> status`,
+and `gc --city <new-city> doctor --json`.
 
 ## Stall protocol
 

--- a/packs/agentops-executor/assets/generated-skill-manifest.json
+++ b/packs/agentops-executor/assets/generated-skill-manifest.json
@@ -90,8 +90,8 @@
     {
       "source": "skills/using-gc/SKILL.md",
       "destination": "packs/agentops-executor/skills/using-gc/SKILL.md",
-      "source_sha256": "a85dd0fea3415ca2bf3608293a5b1fe7eaf6b9b4cf4bc427785a47e894558add",
-      "sha256": "a85dd0fea3415ca2bf3608293a5b1fe7eaf6b9b4cf4bc427785a47e894558add",
+      "source_sha256": "6bdab8234e953f7795cc02f40bbb5a9aa6758043fe5dc40ddf097a1dcd55caed",
+      "sha256": "6bdab8234e953f7795cc02f40bbb5a9aa6758043fe5dc40ddf097a1dcd55caed",
       "mode": "0644"
     }
   ]

--- a/packs/agentops-executor/skills/using-gc/SKILL.md
+++ b/packs/agentops-executor/skills/using-gc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-gc
-description: 'Operate a caller-selected Gas City 1.4 through run-centered, registry-aware native surfaces while keeping GC runtime state out of AgentOps verdicts. Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".'
+description: 'Operate a caller-selected Gas City 1.4 with upstream registry packs and native run-centered surfaces while keeping GC runtime state out of AgentOps verdicts. Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".'
 practices: [team-topologies, design-by-contract]
 hexagonal_role: driving-adapter
 consumes: [explicit-packets]
@@ -25,37 +25,40 @@ output_contract: runtime evidence per supplied packet
 Use Gas City only when the caller explicitly selects it. Treat it as a
 replaceable execution adapter, not a correctness or completion boundary.
 
+## Choose the factory first
+
+AgentOps supports both Gas City and the
+[Agentic Coding Flywheel](https://agent-flywheel.com) as external
+software-factory runtimes. Use this skill only for Gas City. If the caller
+selects the Flywheel, use its native workflow instead of wrapping it in Gas
+City.
+
+AgentOps supplies skills and evidence contracts to either factory. It does not
+need its own Gas City formula or role pack. Install or link AgentOps skills into
+the provider runtime before starting workers; the upstream Mayor, coordinator,
+and workers can then discover and select `plan`, `implement`, `test`,
+`validate`, and other AgentOps skills normally.
+
 ## Gas City 1.4 operating model
 
 Gas City 1.4 is run-centered. The supervisor serves the dashboard and typed,
 paginated session/run APIs. Every graph-owning city or rig scope needs its own
 `core.control-dispatcher`; that deterministic worker advances formula control
-beads. Agent workers claim routed work. The optional AgentOps Mayor is an
-on-demand human/agent door for status and one manual dispatch, not a polling
-control plane.
+beads. Agent workers claim routed work. The upstream `gc.mayor` skill is the
+guided coordinator; `gc.run-operator` launches and supervises formulas.
 
 The normal AgentOps path is:
 
-1. `invoke.sh --city C create "<title>" -d "<acceptance>"` writes one
-   caller-owned source bead.
-2. `invoke.sh --city C feed <bead-id>` homes it in the rig and starts the native
-   `agentops-experiment` formula. `gc sling` returns a run id and dashboard deep
-   link.
-3. `invoke.sh --city C dashboard` prints the embedded supervisor dashboard URL.
-4. Read run, session, bead, and verdict state. Completion is never inferred from
-   chat or pane prose.
+1. Install and pin the upstream `gascity` workflow and rig-role imports.
+2. Add the project as a rig and make AgentOps skills visible to its provider
+   sessions.
+3. Create a caller-owned bead and launch the upstream `build-basic`,
+   continuation, review, or implementation formula that matches the available
+   artifacts.
+4. Read run, session, bead, artifact, and verdict state. Completion is never
+   inferred from chat or pane prose.
 
-The Mayor remains available when explicitly useful:
-
-```sh
-invoke.sh --city C mayor start
-invoke.sh --city C mayor status
-invoke.sh --city C mayor tell "dispatch <bead-id>"
-```
-
-Hand it bead ids only. It never authors or claims work.
-
-## Packs and registries
+## Preferred pack and registries
 
 The built-in `main` registry catalogs official packs. The community registry is
 optional configuration:
@@ -74,22 +77,41 @@ exact import commands. `gc import add` declares a source/version, and `gc import
 install` resolves it into `packs.lock`. Prefer an exact accepted release for
 reproducible cities.
 
-AgentOps composes the official `gascity` 0.1.6 workflow at commit
-`3b3b89f2011e06d84459aa7bea1552382f13930a`, plus its rig roles. This is the
-workflow family visible in the public Maintainer City factory:
+AgentOps prefers the official `gascity` build pack, the workflow family visible
+in the public Maintainer City factory. The current accepted reference is
+`gascity` 0.1.6 at commit
+`3b3b89f2011e06d84459aa7bea1552382f13930a`:
 
 - dashboard: `https://factory.gascity.com`;
-- official roles, bound at the stock default-rig namespace:
-  `gc.run-operator` and `gc.implementation-worker`;
+- workflows: `build-basic`, `build-from-*`, `implement`, review, issue, and PR
+  flows;
+- stock rig roles: `gc.run-operator`, `gc.implementation-worker`, planners,
+  reviewers, and publisher;
 - scope-local formula control: `core.control-dispatcher`;
-- production formulas including `do-work`, build, review, issue, and PR flows.
+- guided coordination: the upstream `gc.mayor` skill.
 
-The workflow pack is composed into `agentops-factory`; its sibling role pack is
-instead imported as `defaults.rig.imports.gc`. Keep that split: nesting the roles
-inside `agentops-factory` renames them to `agentops.*`, while the stock formulas
-still target `gc.*`. AgentOps keeps `agentops-experiment` as its bounded
-default. The imported pack is compositional access to upstream workflows, not
-permission to replace the AgentOps verdict boundary.
+Install the workflow pack at city scope and its sibling roles pack on every rig
+that runs work, following the exact commands returned by
+`gc pack registry show main:gascity`. Keep the stock `gc.*` namespace; do not
+nest or rename the roles behind an AgentOps pack.
+
+For a starter build:
+
+```sh
+gc bd create "Add a --json flag to the export command"
+gc sling gc.run-operator <bead-id> --on build-basic \
+  --var artifact_root=plans/json-flag/build
+```
+
+For guided requirements, planning, and launch, tell the active agent:
+
+```text
+Use skill gc.mayor
+```
+
+AgentOps skills are tools available to those factory agents, not a replacement
+workflow. Explicitly name a skill in the bead or prompt when its behavior is
+required.
 
 ## Upgrade an existing city to 1.4
 
@@ -125,9 +147,9 @@ gc cities --json
 
 `unregister` fails rather than silently accepting an unknown target. Preserve
 the city directory until its Beads state is backed up or confirmed disposable.
-Then use `deploy/gc/bootstrap.sh ... --start` for the new city and verify it with
-`gc cities --json`, `gc --city <new-city> status`, and
-`gc --city <new-city> doctor --json`.
+Create the replacement from the upstream Gas City template, install its pinned
+imports, and verify it with `gc cities --json`, `gc --city <new-city> status`,
+and `gc --city <new-city> doctor --json`.
 
 ## Stall protocol
 

--- a/scripts/check-orchestration-skill-boundaries.sh
+++ b/scripts/check-orchestration-skill-boundaries.sh
@@ -13,9 +13,4 @@ if rg -n -i '\bATM\b|using-atm|vibing-with-ntm' "${active[@]}"; then
   exit 1
 fi
 
-rg -q '"ntm", "--robot-help"' cli/internal/adapters/agentworker_ntm/ntm.go
-rg -q '"am", "capabilities", "--json"' cli/internal/adapters/agentmail_cli/agentmail.go
-rg -q 'single worker pays no coordination tax' skills/agent-native/SKILL.md
-rg -q 'external NTM binary' skills/ntm/SKILL.md
-rg -q 'CLI self-describes' skills/agent-mail/SKILL.md
 echo "orchestration skill boundaries: PASS"

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -621,8 +621,8 @@
     {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
-      "source_hash": "61c5030f76e3afb27525c0213ebc1bf326e76f08c3ae00989e49ab6307ce5970",
-      "generated_hash": "186390451ef61b71495a5340fe9c358679ce8b0912a23429d7f8c9610ccf17c5"
+      "source_hash": "08b2319f768154c52a07d47f12ddcd57c27835a79a00434e75bea688c89ce277",
+      "generated_hash": "0083ea577fcd4024140c76fbd2765408cddeec5347e782ab45afefc59ccad099"
     },
     {
       "name": "validate",

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/using-gc",
   "layout": "modular",
-  "source_hash": "61c5030f76e3afb27525c0213ebc1bf326e76f08c3ae00989e49ab6307ce5970",
-  "generated_hash": "186390451ef61b71495a5340fe9c358679ce8b0912a23429d7f8c9610ccf17c5"
+  "source_hash": "08b2319f768154c52a07d47f12ddcd57c27835a79a00434e75bea688c89ce277",
+  "generated_hash": "0083ea577fcd4024140c76fbd2765408cddeec5347e782ab45afefc59ccad099"
 }

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -1,43 +1,46 @@
 ---
 name: using-gc
-description: Operate a caller-selected Gas City 1.4
+description: Operate a caller-selected Gas City 1.4 with
 ---
 # Using GC
 
 Use Gas City only when the caller explicitly selects it. Treat it as a
 replaceable execution adapter, not a correctness or completion boundary.
 
+## Choose the factory first
+
+AgentOps supports both Gas City and the
+[Agentic Coding Flywheel](https://agent-flywheel.com) as external
+software-factory runtimes. Use this skill only for Gas City. If the caller
+selects the Flywheel, use its native workflow instead of wrapping it in Gas
+City.
+
+AgentOps supplies skills and evidence contracts to either factory. It does not
+need its own Gas City formula or role pack. Install or link AgentOps skills into
+the provider runtime before starting workers; the upstream Mayor, coordinator,
+and workers can then discover and select `plan`, `implement`, `test`,
+`validate`, and other AgentOps skills normally.
+
 ## Gas City 1.4 operating model
 
 Gas City 1.4 is run-centered. The supervisor serves the dashboard and typed,
 paginated session/run APIs. Every graph-owning city or rig scope needs its own
 `core.control-dispatcher`; that deterministic worker advances formula control
-beads. Agent workers claim routed work. The optional AgentOps Mayor is an
-on-demand human/agent door for status and one manual dispatch, not a polling
-control plane.
+beads. Agent workers claim routed work. The upstream `gc.mayor` skill is the
+guided coordinator; `gc.run-operator` launches and supervises formulas.
 
 The normal AgentOps path is:
 
-1. `invoke.sh --city C create "<title>" -d "<acceptance>"` writes one
-   caller-owned source bead.
-2. `invoke.sh --city C feed <bead-id>` homes it in the rig and starts the native
-   `agentops-experiment` formula. `gc sling` returns a run id and dashboard deep
-   link.
-3. `invoke.sh --city C dashboard` prints the embedded supervisor dashboard URL.
-4. Read run, session, bead, and verdict state. Completion is never inferred from
-   chat or pane prose.
+1. Install and pin the upstream `gascity` workflow and rig-role imports.
+2. Add the project as a rig and make AgentOps skills visible to its provider
+   sessions.
+3. Create a caller-owned bead and launch the upstream `build-basic`,
+   continuation, review, or implementation formula that matches the available
+   artifacts.
+4. Read run, session, bead, artifact, and verdict state. Completion is never
+   inferred from chat or pane prose.
 
-The Mayor remains available when explicitly useful:
-
-```sh
-invoke.sh --city C mayor start
-invoke.sh --city C mayor status
-invoke.sh --city C mayor tell "dispatch <bead-id>"
-```
-
-Hand it bead ids only. It never authors or claims work.
-
-## Packs and registries
+## Preferred pack and registries
 
 The built-in `main` registry catalogs official packs. The community registry is
 optional configuration:
@@ -56,22 +59,41 @@ exact import commands. `gc import add` declares a source/version, and `gc import
 install` resolves it into `packs.lock`. Prefer an exact accepted release for
 reproducible cities.
 
-AgentOps composes the official `gascity` 0.1.6 workflow at commit
-`3b3b89f2011e06d84459aa7bea1552382f13930a`, plus its rig roles. This is the
-workflow family visible in the public Maintainer City factory:
+AgentOps prefers the official `gascity` build pack, the workflow family visible
+in the public Maintainer City factory. The current accepted reference is
+`gascity` 0.1.6 at commit
+`3b3b89f2011e06d84459aa7bea1552382f13930a`:
 
 - dashboard: `https://factory.gascity.com`;
-- official roles, bound at the stock default-rig namespace:
-  `gc.run-operator` and `gc.implementation-worker`;
+- workflows: `build-basic`, `build-from-*`, `implement`, review, issue, and PR
+  flows;
+- stock rig roles: `gc.run-operator`, `gc.implementation-worker`, planners,
+  reviewers, and publisher;
 - scope-local formula control: `core.control-dispatcher`;
-- production formulas including `do-work`, build, review, issue, and PR flows.
+- guided coordination: the upstream `gc.mayor` skill.
 
-The workflow pack is composed into `agentops-factory`; its sibling role pack is
-instead imported as `defaults.rig.imports.gc`. Keep that split: nesting the roles
-inside `agentops-factory` renames them to `agentops.*`, while the stock formulas
-still target `gc.*`. AgentOps keeps `agentops-experiment` as its bounded
-default. The imported pack is compositional access to upstream workflows, not
-permission to replace the AgentOps verdict boundary.
+Install the workflow pack at city scope and its sibling roles pack on every rig
+that runs work, following the exact commands returned by
+`gc pack registry show main:gascity`. Keep the stock `gc.*` namespace; do not
+nest or rename the roles behind an AgentOps pack.
+
+For a starter build:
+
+```sh
+gc bd create "Add a --json flag to the export command"
+gc sling gc.run-operator <bead-id> --on build-basic \
+  --var artifact_root=plans/json-flag/build
+```
+
+For guided requirements, planning, and launch, tell the active agent:
+
+```text
+Use skill gc.mayor
+```
+
+AgentOps skills are tools available to those factory agents, not a replacement
+workflow. Explicitly name a skill in the bead or prompt when its behavior is
+required.
 
 ## Upgrade an existing city to 1.4
 
@@ -107,9 +129,9 @@ gc cities --json
 
 `unregister` fails rather than silently accepting an unknown target. Preserve
 the city directory until its Beads state is backed up or confirmed disposable.
-Then use `deploy/gc/bootstrap.sh ... --start` for the new city and verify it with
-`gc cities --json`, `gc --city <new-city> status`, and
-`gc --city <new-city> doctor --json`.
+Create the replacement from the upstream Gas City template, install its pinned
+imports, and verify it with `gc cities --json`, `gc --city <new-city> status`,
+and `gc --city <new-city> doctor --json`.
 
 ## Stall protocol
 

--- a/skills-codex/using-gc/prompt.md
+++ b/skills-codex/using-gc/prompt.md
@@ -1,6 +1,6 @@
 # using-gc
 
-Operate a caller-selected Gas City 1.4 through run-centered, registry-aware native surfaces while keeping GC runtime state out of AgentOps verdicts. Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".
+Operate a caller-selected Gas City 1.4 with upstream registry packs and native run-centered surfaces while keeping GC runtime state out of AgentOps verdicts. Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".
 
 ## Instructions
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1578,7 +1578,7 @@
         }
       ],
       "dependencies": [],
-      "description": "Operate a caller-selected Gas City 1.4 through run-centered, registry-aware native surfaces while keeping GC runtime state out of AgentOps verdicts. Triggers: \"using gc\", \"gas city\", \"drive the mayor\", \"dispatch through gc\".",
+      "description": "Operate a caller-selected Gas City 1.4 with upstream registry packs and native run-centered surfaces while keeping GC runtime state out of AgentOps verdicts. Triggers: \"using gc\", \"gas city\", \"drive the mayor\", \"dispatch through gc\".",
       "disposition": "keep_optional_adapter",
       "effects": [
         "operate_gas_city",

--- a/skills/using-gc/SKILL.md
+++ b/skills/using-gc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-gc
-description: 'Operate a caller-selected Gas City 1.4 through run-centered, registry-aware native surfaces while keeping GC runtime state out of AgentOps verdicts. Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".'
+description: 'Operate a caller-selected Gas City 1.4 with upstream registry packs and native run-centered surfaces while keeping GC runtime state out of AgentOps verdicts. Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".'
 practices: [team-topologies, design-by-contract]
 hexagonal_role: driving-adapter
 consumes: [explicit-packets]
@@ -25,37 +25,40 @@ output_contract: runtime evidence per supplied packet
 Use Gas City only when the caller explicitly selects it. Treat it as a
 replaceable execution adapter, not a correctness or completion boundary.
 
+## Choose the factory first
+
+AgentOps supports both Gas City and the
+[Agentic Coding Flywheel](https://agent-flywheel.com) as external
+software-factory runtimes. Use this skill only for Gas City. If the caller
+selects the Flywheel, use its native workflow instead of wrapping it in Gas
+City.
+
+AgentOps supplies skills and evidence contracts to either factory. It does not
+need its own Gas City formula or role pack. Install or link AgentOps skills into
+the provider runtime before starting workers; the upstream Mayor, coordinator,
+and workers can then discover and select `plan`, `implement`, `test`,
+`validate`, and other AgentOps skills normally.
+
 ## Gas City 1.4 operating model
 
 Gas City 1.4 is run-centered. The supervisor serves the dashboard and typed,
 paginated session/run APIs. Every graph-owning city or rig scope needs its own
 `core.control-dispatcher`; that deterministic worker advances formula control
-beads. Agent workers claim routed work. The optional AgentOps Mayor is an
-on-demand human/agent door for status and one manual dispatch, not a polling
-control plane.
+beads. Agent workers claim routed work. The upstream `gc.mayor` skill is the
+guided coordinator; `gc.run-operator` launches and supervises formulas.
 
 The normal AgentOps path is:
 
-1. `invoke.sh --city C create "<title>" -d "<acceptance>"` writes one
-   caller-owned source bead.
-2. `invoke.sh --city C feed <bead-id>` homes it in the rig and starts the native
-   `agentops-experiment` formula. `gc sling` returns a run id and dashboard deep
-   link.
-3. `invoke.sh --city C dashboard` prints the embedded supervisor dashboard URL.
-4. Read run, session, bead, and verdict state. Completion is never inferred from
-   chat or pane prose.
+1. Install and pin the upstream `gascity` workflow and rig-role imports.
+2. Add the project as a rig and make AgentOps skills visible to its provider
+   sessions.
+3. Create a caller-owned bead and launch the upstream `build-basic`,
+   continuation, review, or implementation formula that matches the available
+   artifacts.
+4. Read run, session, bead, artifact, and verdict state. Completion is never
+   inferred from chat or pane prose.
 
-The Mayor remains available when explicitly useful:
-
-```sh
-invoke.sh --city C mayor start
-invoke.sh --city C mayor status
-invoke.sh --city C mayor tell "dispatch <bead-id>"
-```
-
-Hand it bead ids only. It never authors or claims work.
-
-## Packs and registries
+## Preferred pack and registries
 
 The built-in `main` registry catalogs official packs. The community registry is
 optional configuration:
@@ -74,22 +77,41 @@ exact import commands. `gc import add` declares a source/version, and `gc import
 install` resolves it into `packs.lock`. Prefer an exact accepted release for
 reproducible cities.
 
-AgentOps composes the official `gascity` 0.1.6 workflow at commit
-`3b3b89f2011e06d84459aa7bea1552382f13930a`, plus its rig roles. This is the
-workflow family visible in the public Maintainer City factory:
+AgentOps prefers the official `gascity` build pack, the workflow family visible
+in the public Maintainer City factory. The current accepted reference is
+`gascity` 0.1.6 at commit
+`3b3b89f2011e06d84459aa7bea1552382f13930a`:
 
 - dashboard: `https://factory.gascity.com`;
-- official roles, bound at the stock default-rig namespace:
-  `gc.run-operator` and `gc.implementation-worker`;
+- workflows: `build-basic`, `build-from-*`, `implement`, review, issue, and PR
+  flows;
+- stock rig roles: `gc.run-operator`, `gc.implementation-worker`, planners,
+  reviewers, and publisher;
 - scope-local formula control: `core.control-dispatcher`;
-- production formulas including `do-work`, build, review, issue, and PR flows.
+- guided coordination: the upstream `gc.mayor` skill.
 
-The workflow pack is composed into `agentops-factory`; its sibling role pack is
-instead imported as `defaults.rig.imports.gc`. Keep that split: nesting the roles
-inside `agentops-factory` renames them to `agentops.*`, while the stock formulas
-still target `gc.*`. AgentOps keeps `agentops-experiment` as its bounded
-default. The imported pack is compositional access to upstream workflows, not
-permission to replace the AgentOps verdict boundary.
+Install the workflow pack at city scope and its sibling roles pack on every rig
+that runs work, following the exact commands returned by
+`gc pack registry show main:gascity`. Keep the stock `gc.*` namespace; do not
+nest or rename the roles behind an AgentOps pack.
+
+For a starter build:
+
+```sh
+gc bd create "Add a --json flag to the export command"
+gc sling gc.run-operator <bead-id> --on build-basic \
+  --var artifact_root=plans/json-flag/build
+```
+
+For guided requirements, planning, and launch, tell the active agent:
+
+```text
+Use skill gc.mayor
+```
+
+AgentOps skills are tools available to those factory agents, not a replacement
+workflow. Explicitly name a skill in the bead or prompt when its behavior is
+required.
 
 ## Upgrade an existing city to 1.4
 
@@ -125,9 +147,9 @@ gc cities --json
 
 `unregister` fails rather than silently accepting an unknown target. Preserve
 the city directory until its Beads state is backed up or confirmed disposable.
-Then use `deploy/gc/bootstrap.sh ... --start` for the new city and verify it with
-`gc cities --json`, `gc --city <new-city> status`, and
-`gc --city <new-city> doctor --json`.
+Create the replacement from the upstream Gas City template, install its pinned
+imports, and verify it with `gc cities --json`, `gc --city <new-city> status`,
+and `gc --city <new-city> doctor --json`.
 
 ## Stall protocol
 


### PR DESCRIPTION
## Summary

Everything-but-the-tag for v3.4.0, in four commits:

- **docs(gc)**: the factory pivot — README and `using-gc` present the upstream [Gas City build pack](https://github.com/gastownhall/gascity-packs/tree/main/gascity) and [Agentic Coding Flywheel](https://agent-flywheel.com/) as the supported factory choices; the in-repo prototype (`deploy/gc/`) is retired in place. AgentOps' lane is the skills + evidence discipline either factory executes.
- **chore(release)**: version 3.3.0 → 3.4.0 across all six surfaces (claude/codex/gemini plugin manifests, marketplace, image verify pin, `ao` source fallback).
- **fix(gates)**: `check-orchestration-skill-boundaries.sh` exited 2 on every run — it probed adapter files deleted by the 3.3 single-pass refactor and three contract phrases removed by the skill-overhaul waves. The live ratchets (retired-skill absence, ATM-era naming) are kept.
- **docs(release)**: 3.4.0 CHANGELOG section (root + docs mirror) and curated release notes; `validate-release-notes.sh` passes (tier minor, full area coverage).

## Verification

- Full Go gate in a clean worktree: build ✓ vet ✓ test **2902 passed / 0 failed** (71 packages)
- `scripts/regen-all.sh --check`: all 11 projection/doc checks ✓ (including the doc-release freeze gate)
- `scripts/validate-release-notes.sh v3.4.0 --since v3.3.0`: PASS
- `scripts/check-orchestration-skill-boundaries.sh`: exit 0 (was exit 2 on main)

## Notes

- The earlier read that `go.cli-reference` needed unpinning from the negative-witness grandfather list was a **false positive**: gitignored session logs under `tests/claude-code/logs/` pollute the witness scan in a dirty checkout. On a clean tree the pin is correct; a follow-up task exists to make the scanner read only tracked files.
- Tagging + Release Publisher run happen after merge, separately; an official-mode readiness artifact gets produced at the merged SHA **before** any tag (binding rule from the v3.3.0 record).