### PR TITLE
test(gates): scrub inherited AGENTOPS_GATE_RANGE in pairing self-test

### DIFF
--- a/tests/scripts/test-go-command-test-pair.sh
+++ b/tests/scripts/test-go-command-test-pair.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 # test-go-command-test-pair.sh
 # Integration tests for scripts/check-go-command-test-pair.sh.
 
+# The gate under test honors AGENTOPS_GATE_RANGE as an authoritative push
+# scope. A caller-exported range (e.g. an official release run scoping the
+# real gate to v<prev>..HEAD) refers to refs that do not exist in these
+# fixture repos, silently turning expected-FAIL scenarios into SKIPs. The
+# fixtures own their scope; scrub the inherited one.
+unset AGENTOPS_GATE_RANGE
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CHECK_SCRIPT="$REPO_ROOT/scripts/check-go-command-test-pair.sh"


### PR DESCRIPTION
Found during the v3.4.0 official-mode readiness run: exporting `AGENTOPS_GATE_RANGE=v3.3.0..HEAD` (the documented way to scope `check-go-command-test-pair.sh` to the release train) leaks into the gate's own self-test fixtures, where the range cannot resolve — expected-FAIL scenarios become SKIPs and the self-test fails.

Fix: the self-test unsets the inherited range; fixtures own their scope. Same env-hermeticity class as `ScrubGitDiscoveryEnv`.

Proof: `AGENTOPS_GATE_RANGE=v3.3.0..HEAD bash tests/scripts/test-go-command-test-pair.sh` → 5/5 PASS (previously failed); clean-env run unchanged 5/5.