### PR TITLE
feat(skills): using-flywheel — operating manual for the second supported factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `using-flywheel` skill: operating manual for the Agentic Coding Flywheel as
+  a caller-selected external software factory — provisioning via the upstream
+  wizard, AgentOps skill visibility across its worker runtimes, and the
+  evidence boundary (factory convergence is never an AgentOps verdict). Gives
+  the second supported factory an operating surface parallel to `using-gc`.
+
 ## [3.4.0] - 2026-07-30
 
 AgentOps 3.4 is the **honest-contract release**. All 50 shipped skills went

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ Two factory stacks are supported:
   [Agentic Coding Flywheel](https://agent-flywheel.com) — a supported
   alternative built from Beads, Agent Mail, NTM, and the wider Flywheel tool
   stack. Use its native workflow and let its agents consume the same AgentOps
-  skills.
+  skills. The [`using-flywheel`](skills/using-flywheel/SKILL.md) skill covers
+  provisioning, skill visibility, and the evidence boundary.
 
 AgentOps does not wrap either factory or translate factory completion into
 semantic PASS. When proof is required, a fresh `validate` context judges the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `using-flywheel` skill: operating manual for the Agentic Coding Flywheel as
+  a caller-selected external software factory — provisioning via the upstream
+  wizard, AgentOps skill visibility across its worker runtimes, and the
+  evidence boundary (factory convergence is never an AgentOps verdict). Gives
+  the second supported factory an operating surface parallel to `using-gc`.
+
 ## [3.4.0] - 2026-07-30
 
 AgentOps 3.4 is the **honest-contract release**. All 50 shipped skills went

--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -2,7 +2,7 @@
 
 # Skill Router
 
-50 live skills. Metadata is the sole inventory and graph source.
+51 live skills. Metadata is the sole inventory and graph source.
 
 ## keep
 
@@ -18,7 +18,7 @@
 
 ## keep_optional_adapter
 
-`agent-mail`, `agent-native`, `agy-native`, `automation-shape-routing`, `codex-exec`, `ntm`, `swarm`, `using-gc`
+`agent-mail`, `agent-native`, `agy-native`, `automation-shape-routing`, `codex-exec`, `ntm`, `swarm`, `using-flywheel`, `using-gc`
 
 ## keep_specialist
 
@@ -75,6 +75,7 @@
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
 | `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
+| `using-flywheel` | execution | `keep_optional_adapter` | - | `route_to_native_flywheel_workflow`, `expose_agentops_skills`, `observe_flywheel_runtime` | - |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `inspect_pack_registries`, `drive_mayor_door` | `operate_gas_city`, `configure_codex_trust` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `return_validation_result`, `persist_verdict` | `write_verdict_artifact` |
 | `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -2,7 +2,7 @@
 
 # Skill Router
 
-50 live skills. Metadata is the sole inventory and graph source.
+51 live skills. Metadata is the sole inventory and graph source.
 
 ## keep
 
@@ -18,7 +18,7 @@
 
 ## keep_optional_adapter
 
-`agent-mail`, `agent-native`, `agy-native`, `automation-shape-routing`, `codex-exec`, `ntm`, `swarm`, `using-gc`
+`agent-mail`, `agent-native`, `agy-native`, `automation-shape-routing`, `codex-exec`, `ntm`, `swarm`, `using-flywheel`, `using-gc`
 
 ## keep_specialist
 
@@ -75,6 +75,7 @@
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
 | `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
+| `using-flywheel` | execution | `keep_optional_adapter` | - | `route_to_native_flywheel_workflow`, `expose_agentops_skills`, `observe_flywheel_runtime` | - |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `inspect_pack_registries`, `drive_mayor_door` | `operate_gas_city`, `configure_codex_trust` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `return_validation_result`, `persist_verdict` | `write_verdict_artifact` |
 | `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -50,6 +50,7 @@
 | `scope` | `supplier-to` | `plan` |
 | `security` | `supplier-to` | `validate` |
 | `toil-mining` | `supplier-to` | `automation-shape-routing` |
+| `using-flywheel` | `partnership` | `using-gc` |
 | `using-gc` | `partnership` | `agent-native` |
 | `validate` | `customer-of` | `implement` |
 | `validate` | `customer-of` | `plan` |
@@ -142,6 +143,8 @@
 | `test` | consumes | `repo-context` |
 | `test` | produces | `test-evidence` |
 | `toil-mining` | produces | `toil-candidates-report` |
+| `using-flywheel` | consumes | `explicit-packets` |
+| `using-flywheel` | produces | `flywheel-runtime-evidence` |
 | `using-gc` | consumes | `explicit-packets` |
 | `using-gc` | produces | `gas-city-runtime-evidence` |
 | `validate` | consumes | `subject-manifest.v1` |

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -12,7 +12,7 @@
 
 ## driving-adapter
 
-`agy-native`, `bootstrap`, `codex-exec`, `implement`, `research`, `status`, `swarm`, `using-gc`, `validate`
+`agy-native`, `bootstrap`, `codex-exec`, `implement`, `research`, `status`, `swarm`, `using-flywheel`, `using-gc`, `validate`
 
 ## supporting
 
@@ -69,6 +69,7 @@
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
 | `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
+| `using-flywheel` | execution | `keep_optional_adapter` | - | `route_to_native_flywheel_workflow`, `expose_agentops_skills`, `observe_flywheel_runtime` | - |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `inspect_pack_registries`, `drive_mayor_door` | `operate_gas_city`, `configure_codex_trust` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `return_validation_result`, `persist_verdict` | `write_verdict_artifact` |
 | `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/docs/reference/agentops-skill-graph.md
+++ b/docs/reference/agentops-skill-graph.md
@@ -51,6 +51,7 @@ graph LR
   swarm["swarm"]
   test["test"]
   toil_mining["toil-mining"]
+  using_flywheel["using-flywheel"]
   using_gc["using-gc"]
   validate["validate"]
   workflow_builder["workflow-builder"]

--- a/images/claude/manifest.json
+++ b/images/claude/manifest.json
@@ -1,7 +1,7 @@
 {
   "image": "claude",
   "schema_version": "skill-image.v1",
-  "skill_count": 50,
+  "skill_count": 51,
   "skills": [
     {
       "disposition": "keep_specialist",
@@ -237,6 +237,11 @@
       "disposition": "keep_specialist",
       "path": "skills/toil-mining/",
       "slug": "toil-mining"
+    },
+    {
+      "disposition": "keep_optional_adapter",
+      "path": "skills/using-flywheel/",
+      "slug": "using-flywheel"
     },
     {
       "disposition": "keep_optional_adapter",

--- a/images/codex/manifest.json
+++ b/images/codex/manifest.json
@@ -1,7 +1,7 @@
 {
   "image": "codex",
   "schema_version": "skill-image.v1",
-  "skill_count": 50,
+  "skill_count": 51,
   "skills": [
     {
       "disposition": "keep_specialist",
@@ -284,6 +284,12 @@
       "slug": "toil-mining",
       "source_path": "skills/toil-mining/",
       "twin_path": "skills-codex/toil-mining/"
+    },
+    {
+      "disposition": "keep_optional_adapter",
+      "slug": "using-flywheel",
+      "source_path": "skills/using-flywheel/",
+      "twin_path": "skills-codex/using-flywheel/"
     },
     {
       "disposition": "keep_optional_adapter",

--- a/images/gemini/plugin.json
+++ b/images/gemini/plugin.json
@@ -1,6 +1,6 @@
 {
   "agents": "./agents",
-  "description": "AgentOps 50-skill metadata-derived bundle for Google Antigravity and Gemini.",
+  "description": "AgentOps 51-skill metadata-derived bundle for Google Antigravity and Gemini.",
   "hooks": "./hooks/hooks.json",
   "mcpServers": {
     "agent-mail": {

--- a/images/gemini/skills/using-flywheel/SKILL.md
+++ b/images/gemini/skills/using-flywheel/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: using-flywheel
+description: 'Operate the Agentic Coding Flywheel as a caller-selected external software factory: provision its stack, expose AgentOps skills to its agents, and keep Flywheel runtime state out of AgentOps verdicts. Triggers: "using flywheel", "agentic coding flywheel", "agent flywheel", "run this through the flywheel".'
+practices: [team-topologies, design-by-contract]
+skill_api_version: 1
+hexagonal_role: driving-adapter
+consumes: [explicit-packets]
+produces: [flywheel-runtime-evidence]
+context_rel:
+- kind: partnership
+  with: using-gc
+user-invocable: true
+metadata:
+  tier: execution
+  dependencies: []
+  capabilities: [route_to_native_flywheel_workflow, expose_agentops_skills, observe_flywheel_runtime]
+  effects: []
+  canonical_status: canonical
+  disposition: keep_optional_adapter
+  stability: experimental
+---
+
+# Using the Agentic Coding Flywheel
+
+Use the Flywheel only when the caller explicitly selects it. Treat it as a
+replaceable execution adapter, not a correctness or completion boundary.
+
+Insight: a factory's own completion signals — closed beads, converged agents, a
+quiet swarm — measure that its machinery finished, not that the result is
+semantically correct. This skill exists to prevent the failure mode of
+reporting Flywheel convergence as an AgentOps PASS.
+
+## Choose the factory first
+
+AgentOps supports two external software-factory runtimes: Gas City
+([using-gc](../using-gc/SKILL.md)) and the
+[Agentic Coding Flywheel](https://agent-flywheel.com). Use this skill only for
+the Flywheel. AgentOps supplies skills and evidence contracts to either
+factory; it does not wrap one factory in the other, and it owns no formulas,
+roles, or orchestration inside either.
+
+## What the Flywheel is
+
+Jeffrey Emanuel's free, open-source stack that turns a dedicated VPS into a
+supervised multi-agent factory: Claude Code, Codex CLI, and Antigravity CLI as
+worker runtimes, coordinated through NTM (orchestration), Agent Mail
+(coordination and file reservations), Beads/BV (task graph), and the wider
+Flywheel toolset. Its methodology is planning-first: decompose work into
+beads, run agent swarms against them, and detect convergence between agent
+outputs.
+
+Not for: single-session local work (use the default one-agent loop), Gas City
+cities (use [using-gc](../using-gc/SKILL.md)), or as a verdict source.
+
+## Inputs
+
+- An explicit caller selection of the Flywheel as the factory.
+- A provisioned Flywheel host, or authorization to provision one via the
+  upstream wizard.
+- The caller-owned work intent (beads or a decomposable goal).
+
+## Procedure
+
+1. Provision with the upstream wizard at
+   [agent-flywheel.com](https://agent-flywheel.com) (OS selection through
+   final verification; a single-curl install on a dedicated Ubuntu VPS), then
+   run its `onboard` tutorial once. AgentOps does not fork, pin, or mirror the
+   Flywheel stack; upstream owns its installer and versions.
+2. Make AgentOps skills visible to each worker runtime the Flywheel drives
+   (Claude Code, Codex CLI, Antigravity CLI), using the install paths in the
+   repository [README](../../README.md). Verify per runtime:
+
+   ```sh
+   ls ~/.claude/skills/validate ~/.codex/skills/validate 2>/dev/null
+   ```
+
+   A runtime that cannot list the skill will never invoke it.
+3. Run the Flywheel's native workflow — bead decomposition, swarm dispatch,
+   convergence — unchanged. Skill presence and skill invocation are different
+   facts: when an AgentOps skill's use is an acceptance condition, name it on
+   the work item or worker prompt, and check the transcript for its use.
+4. Read Flywheel runtime state (bead graph, Agent Mail threads, NTM pane
+   truth) as evidence pointers only. When agents disagree with tracker state,
+   trust the more direct observation: pane truth over roster claims, bead
+   state over prose.
+5. Two consecutive non-converging swarm rounds on the same intent is the stop
+   condition: stop, report the divergence to the caller, and do not dispatch a
+   third round on your own authority.
+
+## Output
+
+Runtime evidence pointers for the caller: which beads the Flywheel processed,
+where the candidate commits and worktrees live, and which AgentOps skills its
+agents actually invoked. Done when the caller holds those pointers and — if
+proof was requested — a fresh `validate` context has judged the exact
+candidate. Factory state alone is never the done signal.
+
+## Checks
+
+- Every runtime the Flywheel drives can list the AgentOps skills it is
+  expected to use (step 2 command exits 0).
+- No Flywheel bead close, convergence signal, or agent self-report was
+  translated into an AgentOps PASS, FAIL, or verdict.
+- Provenance: the factory boundary this skill applies is declared in
+  [README.md](../../README.md) ("Choose a software factory") and
+  [docs/operations/gas-city-reliability.md](../../docs/operations/gas-city-reliability.md).
+
+## Failure behavior
+
+Report the concrete failure — unreachable host, missing skill visibility,
+non-convergence, or an upstream installer change — and stop. Upstream Flywheel
+defects belong to its maintainer; the caller owns any revision, retry, or
+factory switch.

--- a/registry.json
+++ b/registry.json
@@ -516,6 +516,33 @@
     },
     {
       "driven_by_skills": [
+        "using-flywheel"
+      ],
+      "id": "skill:using-flywheel:route_to_native_flywheel_workflow",
+      "name": "route_to_native_flywheel_workflow",
+      "path": "skills/using-flywheel/SKILL.md",
+      "type": "skill"
+    },
+    {
+      "driven_by_skills": [
+        "using-flywheel"
+      ],
+      "id": "skill:using-flywheel:expose_agentops_skills",
+      "name": "expose_agentops_skills",
+      "path": "skills/using-flywheel/SKILL.md",
+      "type": "skill"
+    },
+    {
+      "driven_by_skills": [
+        "using-flywheel"
+      ],
+      "id": "skill:using-flywheel:observe_flywheel_runtime",
+      "name": "observe_flywheel_runtime",
+      "path": "skills/using-flywheel/SKILL.md",
+      "type": "skill"
+    },
+    {
+      "driven_by_skills": [
         "using-gc"
       ],
       "id": "skill:using-gc:dispatch_explicit_packet",
@@ -600,19 +627,19 @@
     "cli_commands": 0,
     "gates": 0,
     "reference_impls": 0,
-    "skills": 66,
-    "total": 66
+    "skills": 69,
+    "total": 69
   },
   "cli_top_level_commands": [],
   "schema_version": 3,
   "summary": {
-    "capabilities": 66,
+    "capabilities": 69,
     "cli_commands": 0,
     "eval_files": 0,
     "hooks": 0,
     "job_types": 0,
     "knowledge_stores": 0,
-    "skills": 50,
+    "skills": 51,
     "workflows": 0
   },
   "surfaces": {
@@ -1346,6 +1373,21 @@
         "path": "skills/toil-mining/",
         "reference_count": 0,
         "tier": "meta"
+      },
+      {
+        "capabilities": [
+          "route_to_native_flywheel_workflow",
+          "expose_agentops_skills",
+          "observe_flywheel_runtime"
+        ],
+        "disposition": "keep_optional_adapter",
+        "effects": [],
+        "has_references": false,
+        "has_skill_md": true,
+        "name": "using-flywheel",
+        "path": "skills/using-flywheel/",
+        "reference_count": 0,
+        "tier": "execution"
       },
       {
         "capabilities": [

--- a/skills-codex-overrides/catalog.json
+++ b/skills-codex-overrides/catalog.json
@@ -307,6 +307,12 @@
       "treatment": "parity_only",
       "wave": "catalog-parity",
       "reason": "Auto-generated parity twin (codex-sync): skills/fitness is the source of truth; no durable Codex-specific divergence yet."
+    },
+    {
+      "name": "using-flywheel",
+      "treatment": "parity_only",
+      "wave": "catalog-parity",
+      "reason": "Auto-generated parity twin (codex-sync): skills/using-flywheel is the source of truth; no durable Codex-specific divergence yet."
     }
   ]
 }

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -2,7 +2,7 @@
   "generator": "manual-maintained",
   "source_root": "skills",
   "layout": "modular",
-  "codex_override_catalog_hash": "d093b00a7e7880043ae4e0a0375d4f1e774f80347d5986f0eef6052cd7e37331",
+  "codex_override_catalog_hash": "a9840cf9e06c17b0a00615f50f6796bb45ecd84b6943fa82fa98aab455efc9db",
   "codex_override_catalog": {
     "version": 1,
     "description": "Machine-readable Codex treatment map for the full skill catalog.",
@@ -332,6 +332,12 @@
         "treatment": "parity_only",
         "wave": "catalog-parity",
         "reason": "Auto-generated parity twin (codex-sync): skills/fitness is the source of truth; no durable Codex-specific divergence yet."
+      },
+      {
+        "name": "using-flywheel",
+        "treatment": "parity_only",
+        "wave": "catalog-parity",
+        "reason": "Auto-generated parity twin (codex-sync): skills/using-flywheel is the source of truth; no durable Codex-specific divergence yet."
       }
     ]
   },
@@ -619,6 +625,12 @@
       "generated_hash": "11d4272652686c2da5ff11e15e510f5e56f30e5fc3f9dd2414dced0a00055f12"
     },
     {
+      "name": "using-flywheel",
+      "source_skill": "skills/using-flywheel",
+      "source_hash": "e6c229401acbee8d38528d908bfbce7b2dbbb954a6ef7003b643c4cdc3ef05ad",
+      "generated_hash": "80838a0d62f8ff93eb554d28cde88adb32ff52ff0daeb0db924d857f892f7d83"
+    },
+    {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
       "source_hash": "65211615c9c269a0e3e9814deee5a932d2c8dac646e82d4056e555a10e79be65",
@@ -637,5 +649,5 @@
       "generated_hash": "30f72769961a244749883e03cb04e329cd0feb03dd5b641d2a73a2e5dc8e9d42"
     }
   ],
-  "package_count": 50
+  "package_count": 51
 }

--- a/skills-codex/using-flywheel/.agentops-generated.json
+++ b/skills-codex/using-flywheel/.agentops-generated.json
@@ -1,0 +1,7 @@
+{
+  "generator": "codex-sync",
+  "source_skill": "skills/using-flywheel",
+  "layout": "modular",
+  "source_hash": "e6c229401acbee8d38528d908bfbce7b2dbbb954a6ef7003b643c4cdc3ef05ad",
+  "generated_hash": "80838a0d62f8ff93eb554d28cde88adb32ff52ff0daeb0db924d857f892f7d83"
+}

--- a/skills-codex/using-flywheel/SKILL.md
+++ b/skills-codex/using-flywheel/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: using-flywheel
+description: Operate the Agentic Coding Flywheel as a
+---
+# Using the Agentic Coding Flywheel
+
+Use the Flywheel only when the caller explicitly selects it. Treat it as a
+replaceable execution adapter, not a correctness or completion boundary.
+
+Insight: a factory's own completion signals — closed beads, converged agents, a
+quiet swarm — measure that its machinery finished, not that the result is
+semantically correct. This skill exists to prevent the failure mode of
+reporting Flywheel convergence as an AgentOps PASS.
+
+## Choose the factory first
+
+AgentOps supports two external software-factory runtimes: Gas City
+([using-gc](../using-gc/SKILL.md)) and the
+[Agentic Coding Flywheel](https://agent-flywheel.com). Use this skill only for
+the Flywheel. AgentOps supplies skills and evidence contracts to either
+factory; it does not wrap one factory in the other, and it owns no formulas,
+roles, or orchestration inside either.
+
+## What the Flywheel is
+
+Jeffrey Emanuel's free, open-source stack that turns a dedicated VPS into a
+supervised multi-agent factory: Codex, Codex CLI, and Antigravity CLI as
+worker runtimes, coordinated through NTM (orchestration), Agent Mail
+(coordination and file reservations), Beads/BV (task graph), and the wider
+Flywheel toolset. Its methodology is planning-first: decompose work into
+beads, run agent swarms against them, and detect convergence between agent
+outputs.
+
+Not for: single-session local work (use the default one-agent loop), Gas City
+cities (use [using-gc](../using-gc/SKILL.md)), or as a verdict source.
+
+## Inputs
+
+- An explicit caller selection of the Flywheel as the factory.
+- A provisioned Flywheel host, or authorization to provision one via the
+  upstream wizard.
+- The caller-owned work intent (beads or a decomposable goal).
+
+## Procedure
+
+1. Provision with the upstream wizard at
+   [agent-flywheel.com](https://agent-flywheel.com) (OS selection through
+   final verification; a single-curl install on a dedicated Ubuntu VPS), then
+   run its `onboard` tutorial once. AgentOps does not fork, pin, or mirror the
+   Flywheel stack; upstream owns its installer and versions.
+2. Make AgentOps skills visible to each worker runtime the Flywheel drives
+   (Codex, Codex CLI, Antigravity CLI), using the install paths in the
+   repository [README](../../README.md). Verify per runtime:
+
+   ```sh
+   ls ~/.codex/skills/validate ~/.codex/skills/validate 2>/dev/null
+   ```
+
+   A runtime that cannot list the skill will never invoke it.
+3. Run the Flywheel's native workflow — bead decomposition, swarm dispatch,
+   convergence — unchanged. Skill presence and skill invocation are different
+   facts: when an AgentOps skill's use is an acceptance condition, name it on
+   the work item or worker prompt, and check the transcript for its use.
+4. Read Flywheel runtime state (bead graph, Agent Mail threads, NTM pane
+   truth) as evidence pointers only. When agents disagree with tracker state,
+   trust the more direct observation: pane truth over roster claims, bead
+   state over prose.
+5. Two consecutive non-converging swarm rounds on the same intent is the stop
+   condition: stop, report the divergence to the caller, and do not dispatch a
+   third round on your own authority.
+
+## Output
+
+Runtime evidence pointers for the caller: which beads the Flywheel processed,
+where the candidate commits and worktrees live, and which AgentOps skills its
+agents actually invoked. Done when the caller holds those pointers and — if
+proof was requested — a fresh `validate` context has judged the exact
+candidate. Factory state alone is never the done signal.
+
+## Checks
+
+- Every runtime the Flywheel drives can list the AgentOps skills it is
+  expected to use (step 2 command exits 0).
+- No Flywheel bead close, convergence signal, or agent self-report was
+  translated into an AgentOps PASS, FAIL, or verdict.
+- Provenance: the factory boundary this skill applies is declared in
+  [README.md](../../README.md) ("Choose a software factory") and
+  [docs/operations/gas-city-reliability.md](../../docs/operations/gas-city-reliability.md).
+
+## Failure behavior
+
+Report the concrete failure — unreachable host, missing skill visibility,
+non-convergence, or an upstream installer change — and stop. Upstream Flywheel
+defects belong to its maintainer; the caller owns any revision, retry, or
+factory switch.

--- a/skills-codex/using-flywheel/prompt.md
+++ b/skills-codex/using-flywheel/prompt.md
@@ -1,0 +1,8 @@
+# using-flywheel
+
+Operate the Agentic Coding Flywheel as a caller-selected external software factory: provision its stack, expose AgentOps skills to its agents, and keep Flywheel runtime state out of AgentOps verdicts. Triggers: "using flywheel", "agentic coding flywheel", "agent flywheel", "run this through the flywheel".
+
+## Instructions
+
+Load and follow the skill instructions from the sibling `SKILL.md` file for this skill.
+Then read local files in `references/` and `scripts/` when needed.

--- a/skills-codex/using-flywheel/scripts/validate.sh
+++ b/skills-codex/using-flywheel/scripts/validate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../.." && pwd)"
+exec bash "$REPO_ROOT/skills/skill-builder/scripts/heal.sh" --check --strict "$SKILL_DIR"

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -8,7 +8,7 @@
 
 ## execution
 
-`account-rotation`, `agent-mail`, `cass`, `cc-hooks`, `codebase-recon`, `dcg`, `idea-genie`, `implement`, `learn`, `ms`, `ntm`, `pattern-mining`, `plan`, `rch`, `refactor`, `research`, `reverse-engineer`, `sbh`, `scaffold`, `swarm`, `test`, `using-gc`
+`account-rotation`, `agent-mail`, `cass`, `cc-hooks`, `codebase-recon`, `dcg`, `idea-genie`, `implement`, `learn`, `ms`, `ntm`, `pattern-mining`, `plan`, `rch`, `refactor`, `research`, `reverse-engineer`, `sbh`, `scaffold`, `swarm`, `test`, `using-flywheel`, `using-gc`
 
 ## judgment
 
@@ -89,6 +89,7 @@
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |
 | `test` | execution | `keep_specialist` | - | `test` | `write_test_files`, `write_test_evidence`, `modify_source_files` |
 | `toil-mining` | meta | `keep_specialist` | - | `toil_mining` | `write_toil_candidates` |
+| `using-flywheel` | execution | `keep_optional_adapter` | - | `route_to_native_flywheel_workflow`, `expose_agentops_skills`, `observe_flywheel_runtime` | - |
 | `using-gc` | execution | `keep_optional_adapter` | - | `dispatch_explicit_packet`, `observe_gc_runtime`, `inspect_pack_registries`, `drive_mayor_door` | `operate_gas_city`, `configure_codex_trust` |
 | `validate` | judgment | `keep` | - | `compute_subject_identity`, `judge_acceptance`, `return_validation_result`, `persist_verdict` | `write_verdict_artifact` |
 | `workflow-builder` | meta | `keep_specialist` | - | `workflow_builder` | `write_workflow_script` |

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "3",
-  "skill_count": 50,
+  "skill_count": 51,
   "skills": [
     {
       "canonical_status": "canonical",
@@ -1557,6 +1557,41 @@
       ],
       "references_count": 0,
       "tier": "meta",
+      "user_invocable": true
+    },
+    {
+      "canonical_status": "canonical",
+      "capabilities": [
+        "route_to_native_flywheel_workflow",
+        "expose_agentops_skills",
+        "observe_flywheel_runtime"
+      ],
+      "codex_override_present": true,
+      "consumes": [
+        "explicit-packets"
+      ],
+      "context_rel": [
+        {
+          "kind": "partnership",
+          "with": "using-gc"
+        }
+      ],
+      "dependencies": [],
+      "description": "Operate the Agentic Coding Flywheel as a caller-selected external software factory: provision its stack, expose AgentOps skills to its agents, and keep Flywheel runtime state out of AgentOps verdicts. Triggers: \"using flywheel\", \"agentic coding flywheel\", \"agent flywheel\", \"run this through the flywheel\".",
+      "disposition": "keep_optional_adapter",
+      "effects": [],
+      "graph_root": false,
+      "hexagonal_role": "driving-adapter",
+      "name": "using-flywheel",
+      "practices": [
+        "team-topologies",
+        "design-by-contract"
+      ],
+      "produces": [
+        "flywheel-runtime-evidence"
+      ],
+      "references_count": 0,
+      "tier": "execution",
       "user_invocable": true
     },
     {

--- a/skills/using-flywheel/SKILL.md
+++ b/skills/using-flywheel/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: using-flywheel
+description: 'Operate the Agentic Coding Flywheel as a caller-selected external software factory: provision its stack, expose AgentOps skills to its agents, and keep Flywheel runtime state out of AgentOps verdicts. Triggers: "using flywheel", "agentic coding flywheel", "agent flywheel", "run this through the flywheel".'
+practices: [team-topologies, design-by-contract]
+skill_api_version: 1
+hexagonal_role: driving-adapter
+consumes: [explicit-packets]
+produces: [flywheel-runtime-evidence]
+context_rel:
+- kind: partnership
+  with: using-gc
+user-invocable: true
+metadata:
+  tier: execution
+  dependencies: []
+  capabilities: [route_to_native_flywheel_workflow, expose_agentops_skills, observe_flywheel_runtime]
+  effects: []
+  canonical_status: canonical
+  disposition: keep_optional_adapter
+  stability: experimental
+---
+
+# Using the Agentic Coding Flywheel
+
+Use the Flywheel only when the caller explicitly selects it. Treat it as a
+replaceable execution adapter, not a correctness or completion boundary.
+
+Insight: a factory's own completion signals — closed beads, converged agents, a
+quiet swarm — measure that its machinery finished, not that the result is
+semantically correct. This skill exists to prevent the failure mode of
+reporting Flywheel convergence as an AgentOps PASS.
+
+## Choose the factory first
+
+AgentOps supports two external software-factory runtimes: Gas City
+([using-gc](../using-gc/SKILL.md)) and the
+[Agentic Coding Flywheel](https://agent-flywheel.com). Use this skill only for
+the Flywheel. AgentOps supplies skills and evidence contracts to either
+factory; it does not wrap one factory in the other, and it owns no formulas,
+roles, or orchestration inside either.
+
+## What the Flywheel is
+
+Jeffrey Emanuel's free, open-source stack that turns a dedicated VPS into a
+supervised multi-agent factory: Claude Code, Codex CLI, and Antigravity CLI as
+worker runtimes, coordinated through NTM (orchestration), Agent Mail
+(coordination and file reservations), Beads/BV (task graph), and the wider
+Flywheel toolset. Its methodology is planning-first: decompose work into
+beads, run agent swarms against them, and detect convergence between agent
+outputs.
+
+Not for: single-session local work (use the default one-agent loop), Gas City
+cities (use [using-gc](../using-gc/SKILL.md)), or as a verdict source.
+
+## Inputs
+
+- An explicit caller selection of the Flywheel as the factory.
+- A provisioned Flywheel host, or authorization to provision one via the
+  upstream wizard.
+- The caller-owned work intent (beads or a decomposable goal).
+
+## Procedure
+
+1. Provision with the upstream wizard at
+   [agent-flywheel.com](https://agent-flywheel.com) (OS selection through
+   final verification; a single-curl install on a dedicated Ubuntu VPS), then
+   run its `onboard` tutorial once. AgentOps does not fork, pin, or mirror the
+   Flywheel stack; upstream owns its installer and versions.
+2. Make AgentOps skills visible to each worker runtime the Flywheel drives
+   (Claude Code, Codex CLI, Antigravity CLI), using the install paths in the
+   repository [README](../../README.md). Verify per runtime:
+
+   ```sh
+   ls ~/.claude/skills/validate ~/.codex/skills/validate 2>/dev/null
+   ```
+
+   A runtime that cannot list the skill will never invoke it.
+3. Run the Flywheel's native workflow — bead decomposition, swarm dispatch,
+   convergence — unchanged. Skill presence and skill invocation are different
+   facts: when an AgentOps skill's use is an acceptance condition, name it on
+   the work item or worker prompt, and check the transcript for its use.
+4. Read Flywheel runtime state (bead graph, Agent Mail threads, NTM pane
+   truth) as evidence pointers only. When agents disagree with tracker state,
+   trust the more direct observation: pane truth over roster claims, bead
+   state over prose.
+5. Two consecutive non-converging swarm rounds on the same intent is the stop
+   condition: stop, report the divergence to the caller, and do not dispatch a
+   third round on your own authority.
+
+## Output
+
+Runtime evidence pointers for the caller: which beads the Flywheel processed,
+where the candidate commits and worktrees live, and which AgentOps skills its
+agents actually invoked. Done when the caller holds those pointers and — if
+proof was requested — a fresh `validate` context has judged the exact
+candidate. Factory state alone is never the done signal.
+
+## Checks
+
+- Every runtime the Flywheel drives can list the AgentOps skills it is
+  expected to use (step 2 command exits 0).
+- No Flywheel bead close, convergence signal, or agent self-report was
+  translated into an AgentOps PASS, FAIL, or verdict.
+- Provenance: the factory boundary this skill applies is declared in
+  [README.md](../../README.md) ("Choose a software factory") and
+  [docs/operations/gas-city-reliability.md](../../docs/operations/gas-city-reliability.md).
+
+## Failure behavior
+
+Report the concrete failure — unreachable host, missing skill visibility,
+non-convergence, or an upstream installer change — and stop. Upstream Flywheel
+defects belong to its maintainer; the caller owns any revision, retry, or
+factory switch.

--- a/skills/using-flywheel/scripts/validate.sh
+++ b/skills/using-flywheel/scripts/validate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../.." && pwd)"
+exec bash "$REPO_ROOT/skills/skill-builder/scripts/heal.sh" --check --strict "$SKILL_DIR"


### PR DESCRIPTION
Closes finding 3 from the GC-work analysis: the README presents two supported factories, but only Gas City had an operating manual (`using-gc`). The Flywheel's "supported" claim had no surface behind it.

- **agent-flywheel.com verified live**: Jeffrey Emanuel's open-source VPS factory (Claude Code / Codex CLI / Antigravity CLI + NTM, Agent Mail, Beads/BV) — matches the README's description.
- **New `using-flywheel` skill** (scaffolded via skill-builder, `heal --check --strict` clean): caller-selected adapter, upstream-wizard provisioning (no fork/pin — upstream owns its installer), skill-visibility check per runtime, presence≠invocation discipline, 2-round non-convergence stop, and the boundary that factory state never becomes an AgentOps verdict.
- README factory bullet now cross-links the skill; mesh/codex/gemini projections regenerated (51 skills); CHANGELOG Unreleased entry (move into the 3.4.0 section if the tag lands at tip after a readiness re-lap).

Verification: `regen-all.sh --check` all green; `go build/vet` + gates/cmd test packages 656 passed.