### PR TITLE
docs(release): 3.4.0 close-out — changelog consolidation, cross-links, README de-slop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- `using-flywheel` skill: operating manual for the Agentic Coding Flywheel as
-  a caller-selected external software factory — provisioning via the upstream
-  wizard, AgentOps skill visibility across its worker runtimes, and the
-  evidence boundary (factory convergence is never an AgentOps verdict). Gives
-  the second supported factory an operating surface parallel to `using-gc`.
-
 ## [3.4.0] - 2026-07-30
 
 AgentOps 3.4 is the **honest-contract release**. All 50 shipped skills went
@@ -30,6 +22,16 @@ supplies the skills and evidence discipline either factory executes.
 - Negative-witness ratchet: every blocking gate must carry a test proving it
   fails on what it detects, with a shrink-only grandfather list.
 - `ao gate check --dry-run`: a real plan-only mode that mutates nothing.
+- `using-flywheel` skill: operating manual for the Agentic Coding Flywheel as
+  a caller-selected external software factory, covering provisioning via the
+  upstream wizard, AgentOps skill visibility across its worker runtimes, and
+  the evidence boundary (factory convergence is never an AgentOps verdict).
+  Gives the second supported factory an operating surface parallel to
+  `using-gc`.
+- `scripts/gc-maintainer-ops.sh`: a narrow operational adapter for stock Gas
+  City rigs, with `prepare` (pin verification, contained runtime snapshot,
+  skill linking), read-only `check`, and dry-run-by-default
+  `recover-affinity`. It is not a pack, formula, role, daemon, or GC fork.
 
 ### Changed
 
@@ -57,6 +59,11 @@ supplies the skills and evidence discipline either factory executes.
 - `handoff` schema matches what the command writes; `dcg` guidance corrected.
 - The orchestration-skill-boundaries gate no longer references adapter files
   deleted by the 3.3 single-pass refactor.
+- The negative-witness scan reads only git-tracked files under `tests/`, so
+  ignored local logs can no longer flip its verdict between checkouts.
+- Retired Gas City prototype wiring decayed to frozen bytes: the skill
+  projection into the retired pack copy stopped, and the
+  `adapter.gc-maintainer` gate replaces `adapter.gc-executor`.
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ RPI -> Plan -> Implement -> fresh Validate -> report and stop
 npx skills@latest add boshu2/agentops --all -g
 ```
 
-One command, every coding agent — `npx skills` installs the corpus into all
-your agents at once. The loop runs as skills **inside your coding agent**
-(Claude Code, Codex, Cursor, …): type `/rpi` — or ask for `plan`,
-`implement`, `validate`, `learn` by name — in that agent's chat. No other
-runtime is required.
+One command installs the corpus into every coding agent you use. The loop runs
+as skills **inside your coding agent** (Claude Code, Codex, Cursor, …): type
+`/rpi` in that agent's chat, or ask for `plan`, `implement`, `validate`, and
+`learn` by name. No other runtime is required.
 
 ## Plugins (Claude Code / Codex)
 
@@ -39,20 +38,20 @@ codex plugin add agentops@agentops-marketplace
 
 Three install paths:
 
-- **npx / [skills.sh](https://skills.sh)** — universal; copies skills you can edit.
-- **Plugins** — a read-only bundle that stays current with the repo.
-- **Checkout + `ao skills link`** — source-tracked symlinks for contributors
+- **npx / [skills.sh](https://skills.sh)**: universal; copies skills you can edit.
+- **Plugins**: a read-only bundle that stays current with the repo.
+- **Checkout + `ao skills link`**: source-tracked symlinks for contributors
   (see [Install and day-2 operations](docs/install-day2-ops.md)).
 
 ## Admission-control hooks (on by default)
 
-AgentOps ships a PreToolUse **policy dispatcher** — deterministic guards that
+AgentOps ships a PreToolUse **policy dispatcher**: deterministic guards that
 block a small set of known-destructive commands (staging the private bead
 ledger, hand-editing the hash-chained provenance ledger, overwriting installed
 skill copies) and route you to the correct tool instead. Silent on every clean
 call; every block is one line.
 
-- **Claude Code plugin installs:** active automatically — nothing to run.
+- **Claude Code plugin installs:** active automatically; nothing to run.
 - **npx / skills.sh copies:** run `~/.claude/skills/cc-hooks/scripts/install-hooks.sh` once.
 - **git clone / brew:** run `scripts/install-policy-dispatch.sh` once.
 
@@ -66,15 +65,15 @@ directories.
 ## Intent lives in a bead
 
 [Beads](https://github.com/steveyegge/beads) is the preferred tracker
-(optional — `brew install beads`). Plan
+(optional; `brew install beads`). Plan
 writes [BDD](https://cucumber.io/docs/bdd/) acceptance and DDD [ubiquitous
 language](https://martinfowler.com/bliki/UbiquitousLanguage.html) into the bead;
 Implement builds against it; Validate judges a hashed snapshot under
 `.agents/ao/intents/sha256/`. No beads? Plan shapes the caller's issue or chat
 text and the runtime snapshots those bytes the same way.
 
-`validate` must run in a fresh context (not the author session). Same model or
-a different one — both are supported.
+`validate` must run in a fresh context (not the author session). It can use
+the same model as the author or a different one.
 
 ## Multi-agent systems
 
@@ -92,15 +91,15 @@ used by the factory you choose; its Mayor, coordinator, and workers can then use
 
 Two factory stacks are supported:
 
-- [Gas City](https://github.com/gastownhall/gascity) — the preferred choice for
-  durable, supervised workflows. Use the upstream
+- [Gas City](https://github.com/gastownhall/gascity) is the preferred choice
+  for durable, supervised workflows. Use the upstream
   [`gascity` build pack](https://github.com/gastownhall/gascity-packs/tree/main/gascity),
   the workflow family used by Maintainer City. It owns formulas, roles,
   worktrees, dispatch, draining, and run state. The
   [`using-gc`](skills/using-gc/SKILL.md) skill covers installation, launch,
   observation, and recovery.
 - Jeffrey Emanuel's
-  [Agentic Coding Flywheel](https://agent-flywheel.com) — a supported
+  [Agentic Coding Flywheel](https://agent-flywheel.com) is a supported
   alternative built from Beads, Agent Mail, NTM, and the wider Flywheel tool
   stack. Use its native workflow and let its agents consume the same AgentOps
   skills. The [`using-flywheel`](skills/using-flywheel/SKILL.md) skill covers

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- `using-flywheel` skill: operating manual for the Agentic Coding Flywheel as
-  a caller-selected external software factory — provisioning via the upstream
-  wizard, AgentOps skill visibility across its worker runtimes, and the
-  evidence boundary (factory convergence is never an AgentOps verdict). Gives
-  the second supported factory an operating surface parallel to `using-gc`.
-
 ## [3.4.0] - 2026-07-30
 
 AgentOps 3.4 is the **honest-contract release**. All 50 shipped skills went
@@ -30,6 +22,16 @@ supplies the skills and evidence discipline either factory executes.
 - Negative-witness ratchet: every blocking gate must carry a test proving it
   fails on what it detects, with a shrink-only grandfather list.
 - `ao gate check --dry-run`: a real plan-only mode that mutates nothing.
+- `using-flywheel` skill: operating manual for the Agentic Coding Flywheel as
+  a caller-selected external software factory, covering provisioning via the
+  upstream wizard, AgentOps skill visibility across its worker runtimes, and
+  the evidence boundary (factory convergence is never an AgentOps verdict).
+  Gives the second supported factory an operating surface parallel to
+  `using-gc`.
+- `scripts/gc-maintainer-ops.sh`: a narrow operational adapter for stock Gas
+  City rigs, with `prepare` (pin verification, contained runtime snapshot,
+  skill linking), read-only `check`, and dry-run-by-default
+  `recover-affinity`. It is not a pack, formula, role, daemon, or GC fork.
 
 ### Changed
 
@@ -57,6 +59,11 @@ supplies the skills and evidence discipline either factory executes.
 - `handoff` schema matches what the command writes; `dcg` guidance corrected.
 - The orchestration-skill-boundaries gate no longer references adapter files
   deleted by the 3.3 single-pass refactor.
+- The negative-witness scan reads only git-tracked files under `tests/`, so
+  ignored local logs can no longer flip its verdict between checkouts.
+- Retired Gas City prototype wiring decayed to frozen bytes: the skill
+  projection into the retired pack copy stopped, and the
+  `adapter.gc-maintainer` gate replaces `adapter.gc-executor`.
 
 ### Deprecated
 

--- a/docs/releases/2026-07-30-v3.4.0-notes.md
+++ b/docs/releases/2026-07-30-v3.4.0-notes.md
@@ -26,15 +26,17 @@ bounded, cancellable, and reaps its whole process group.
 
 | Product Area | Added | Changed | Refactored | Fixed | Deprecated/Removed |
 |---|---:|---:|---:|---:|---:|
-| Skills and Workflows | 0 | 4 | 0 | 0 | 1 |
-| Eval, Validation, and Release Gates | 1 | 3 | 0 | 2 | 0 |
-| CLI and Operator Commands | 0 | 2 | 0 | 1 | 0 |
+| Skills and Workflows | 1 | 4 | 0 | 0 | 1 |
+| Eval, Validation, and Release Gates | 1 | 4 | 0 | 3 | 0 |
+| CLI and Operator Commands | 1 | 2 | 0 | 1 | 0 |
 | Docs and Onboarding | 0 | 2 | 0 | 0 | 0 |
 
 ## Product Areas
 
 ### Skills and Workflows
 
+- Added: `using-flywheel`, the operating manual for the Agentic Coding
+  Flywheel as a caller-selected factory, parallel to `using-gc`
 - Changed: all 50 skill contracts overhauled across eight waves — declared real
   effects, honest output contracts, scratch-tier artifact directories,
   authority grants stripped, fail-closed deadlines, and corpus-level trigger
@@ -57,12 +59,19 @@ bounded, cancellable, and reaps its whole process group.
 - Changed: ADR-0016 shipped-Python rule is enforced by a blocking gate
 - Changed: Gas City factory qualification pins and fail-closes on the official
   v1.4.0 release and the registry-pinned `gascity` 0.1.6 workflow
+- Changed: retired Gas City prototype wiring decayed to frozen bytes, with the
+  `adapter.gc-maintainer` gate replacing `adapter.gc-executor`
 - Fixed: RPI and Validate no longer disagree on the intent-source digest
 - Fixed: the orchestration-skill-boundaries gate no longer references adapter
   files deleted by the 3.3 single-pass refactor
+- Fixed: the negative-witness scan reads only git-tracked files under
+  `tests/`, so ignored local logs cannot flip its verdict between checkouts
 
 ### CLI and Operator Commands
 
+- Added: `scripts/gc-maintainer-ops.sh`, a narrow operational adapter for
+  stock Gas City rigs (`prepare`, read-only `check`, dry-run-by-default
+  `recover-affinity`); not a pack, formula, role, daemon, or GC fork
 - Changed: `ao gate check --dry-run` is a real plan-only mode that mutates
   nothing
 - Changed: eval id containment hardened and temp directories owned by the

--- a/images/gemini/skills/using-gc/SKILL.md
+++ b/images/gemini/skills/using-gc/SKILL.md
@@ -30,8 +30,8 @@ replaceable execution adapter, not a correctness or completion boundary.
 AgentOps supports both Gas City and the
 [Agentic Coding Flywheel](https://agent-flywheel.com) as external
 software-factory runtimes. Use this skill only for Gas City. If the caller
-selects the Flywheel, use its native workflow instead of wrapping it in Gas
-City.
+selects the Flywheel, switch to [using-flywheel](../using-flywheel/SKILL.md)
+and its native workflow instead of wrapping it in Gas City.
 
 AgentOps supplies skills and evidence contracts to either factory. It does not
 need its own Gas City formula or role pack. Install or link AgentOps skills into

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -633,8 +633,8 @@
     {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
-      "source_hash": "65211615c9c269a0e3e9814deee5a932d2c8dac646e82d4056e555a10e79be65",
-      "generated_hash": "a4b37029d716a6451525b639c16b7f9e8351a646da6deff22882bfcbb084f602"
+      "source_hash": "39bb5bca49bd6761dfae466f12da62d5e657ce7bdda8f921a2df58f4f5616314",
+      "generated_hash": "199f9c716bcf9cc0b31eae0782c58b9455b5aeb284cb0c70596bccf840d5db62"
     },
     {
       "name": "validate",

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/using-gc",
   "layout": "modular",
-  "source_hash": "65211615c9c269a0e3e9814deee5a932d2c8dac646e82d4056e555a10e79be65",
-  "generated_hash": "a4b37029d716a6451525b639c16b7f9e8351a646da6deff22882bfcbb084f602"
+  "source_hash": "39bb5bca49bd6761dfae466f12da62d5e657ce7bdda8f921a2df58f4f5616314",
+  "generated_hash": "199f9c716bcf9cc0b31eae0782c58b9455b5aeb284cb0c70596bccf840d5db62"
 }

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -12,8 +12,8 @@ replaceable execution adapter, not a correctness or completion boundary.
 AgentOps supports both Gas City and the
 [Agentic Coding Flywheel](https://agent-flywheel.com) as external
 software-factory runtimes. Use this skill only for Gas City. If the caller
-selects the Flywheel, use its native workflow instead of wrapping it in Gas
-City.
+selects the Flywheel, switch to [using-flywheel](../using-flywheel/SKILL.md)
+and its native workflow instead of wrapping it in Gas City.
 
 AgentOps supplies skills and evidence contracts to either factory. It does not
 need its own Gas City formula or role pack. Install or link AgentOps skills into

--- a/skills/using-gc/SKILL.md
+++ b/skills/using-gc/SKILL.md
@@ -30,8 +30,8 @@ replaceable execution adapter, not a correctness or completion boundary.
 AgentOps supports both Gas City and the
 [Agentic Coding Flywheel](https://agent-flywheel.com) as external
 software-factory runtimes. Use this skill only for Gas City. If the caller
-selects the Flywheel, use its native workflow instead of wrapping it in Gas
-City.
+selects the Flywheel, switch to [using-flywheel](../using-flywheel/SKILL.md)
+and its native workflow instead of wrapping it in Gas City.
 
 AgentOps supplies skills and evidence contracts to either factory. It does not
 need its own Gas City formula or role pack. Install or link AgentOps skills into


### PR DESCRIPTION
Three pieces, all documentation:

1. **CHANGELOG + notes consolidation**: the four commits that landed after the readiness record (`using-flywheel`, `gc-maintainer-ops.sh`, prototype decay, witness-scan fix) now appear in the 3.4.0 section and the curated notes; `[Unreleased]` is empty again. `validate-release-notes.sh v3.4.0` PASS.
2. **`using-gc` back-link**: its factory-choice section routes Flywheel callers to `using-flywheel` (codex twin + hashes regenerated).
3. **README pass** per /readme-writing + /de-slopify: zero em-dashes remain, quickstart paragraph tightened, bullet leads normalized to colons. Deliberate deviations from /readme-writing: no structural re-expansion (the lean layout is an explicit prior decision) and no imported contributions-policy text (it is another author's personal policy; this repo accepts PRs per docs/CONTRIBUTING.md).

Verification: `regen-all.sh --check` all green; gates test packages 174 passed; notes validator PASS; `grep — README.md` returns zero.