### PR TITLE
fix(skills): trim using-flywheel description to the 180-char budget

### DIFF
--- a/images/gemini/skills/using-flywheel/SKILL.md
+++ b/images/gemini/skills/using-flywheel/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-flywheel
-description: 'Operate the Agentic Coding Flywheel as a caller-selected external software factory: provision its stack, expose AgentOps skills to its agents, and keep Flywheel runtime state out of AgentOps verdicts. Triggers: "using flywheel", "agentic coding flywheel", "agent flywheel", "run this through the flywheel".'
+description: 'Operate the Agentic Coding Flywheel as a caller-selected software factory; keep its runtime state out of AgentOps verdicts. Triggers: "using flywheel", "agent flywheel".'
 practices: [team-topologies, design-by-contract]
 skill_api_version: 1
 hexagonal_role: driving-adapter

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -627,8 +627,8 @@
     {
       "name": "using-flywheel",
       "source_skill": "skills/using-flywheel",
-      "source_hash": "e6c229401acbee8d38528d908bfbce7b2dbbb954a6ef7003b643c4cdc3ef05ad",
-      "generated_hash": "80838a0d62f8ff93eb554d28cde88adb32ff52ff0daeb0db924d857f892f7d83"
+      "source_hash": "3a3952c0040141e358f41e4e576c4322a4469bc3102b0f27899058ee6d594aaf",
+      "generated_hash": "deab3c2e6555c0ec62391100178cc33ecfe501b20cb774f39ab7338012d18dbb"
     },
     {
       "name": "using-gc",

--- a/skills-codex/using-flywheel/.agentops-generated.json
+++ b/skills-codex/using-flywheel/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/using-flywheel",
   "layout": "modular",
-  "source_hash": "e6c229401acbee8d38528d908bfbce7b2dbbb954a6ef7003b643c4cdc3ef05ad",
-  "generated_hash": "80838a0d62f8ff93eb554d28cde88adb32ff52ff0daeb0db924d857f892f7d83"
+  "source_hash": "3a3952c0040141e358f41e4e576c4322a4469bc3102b0f27899058ee6d594aaf",
+  "generated_hash": "deab3c2e6555c0ec62391100178cc33ecfe501b20cb774f39ab7338012d18dbb"
 }

--- a/skills-codex/using-flywheel/prompt.md
+++ b/skills-codex/using-flywheel/prompt.md
@@ -1,6 +1,6 @@
 # using-flywheel
 
-Operate the Agentic Coding Flywheel as a caller-selected external software factory: provision its stack, expose AgentOps skills to its agents, and keep Flywheel runtime state out of AgentOps verdicts. Triggers: "using flywheel", "agentic coding flywheel", "agent flywheel", "run this through the flywheel".
+Operate the Agentic Coding Flywheel as a caller-selected software factory; keep its runtime state out of AgentOps verdicts. Triggers: "using flywheel", "agent flywheel".
 
 ## Instructions
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1577,7 +1577,7 @@
         }
       ],
       "dependencies": [],
-      "description": "Operate the Agentic Coding Flywheel as a caller-selected external software factory: provision its stack, expose AgentOps skills to its agents, and keep Flywheel runtime state out of AgentOps verdicts. Triggers: \"using flywheel\", \"agentic coding flywheel\", \"agent flywheel\", \"run this through the flywheel\".",
+      "description": "Operate the Agentic Coding Flywheel as a caller-selected software factory; keep its runtime state out of AgentOps verdicts. Triggers: \"using flywheel\", \"agent flywheel\".",
       "disposition": "keep_optional_adapter",
       "effects": [],
       "graph_root": false,

--- a/skills/using-flywheel/SKILL.md
+++ b/skills/using-flywheel/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-flywheel
-description: 'Operate the Agentic Coding Flywheel as a caller-selected external software factory: provision its stack, expose AgentOps skills to its agents, and keep Flywheel runtime state out of AgentOps verdicts. Triggers: "using flywheel", "agentic coding flywheel", "agent flywheel", "run this through the flywheel".'
+description: 'Operate the Agentic Coding Flywheel as a caller-selected software factory; keep its runtime state out of AgentOps verdicts. Triggers: "using flywheel", "agent flywheel".'
 practices: [team-topologies, design-by-contract]
 skill_api_version: 1
 hexagonal_role: driving-adapter


### PR DESCRIPTION
Found by the v3.4.0 readiness re-lap: `tests/skills/run-all.sh` (local-ci lane, not in PR CI) enforces a 180-char frontmatter description budget; `using-flywheel` shipped at 200. Trimmed to 169 chars, same meaning; mesh/codex projections regenerated. Full skill-lint harness now exits 0.