### PR TITLE
docs(gc): enforce the operator-lane boundary (Mayor dispatches, reconciler owns sessions)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,14 @@ strategies. NTM, Agent Mail, Gas City, swarms, and other factory tools are
 optional adapters. Optional strategies and adapters never become core
 dependencies or lifecycle authorities.
 
+A selected factory's internal control plane is operated only through that
+factory's own doors: its coordinator (for Gas City, the Mayor via mail), its
+doctor, and its supervisor start/stop from outside. An agent never creates,
+scales, or repairs factory-internal sessions by hand — a hand-made session can
+squat a canonical name and block the factory's own reconciler. The agent lane
+into a factory is: author beads, mail the coordinator, read state, judge
+results.
+
 ## Concurrency
 
 One agent and one writer are the default. Use multiple lanes only when the user

--- a/images/gemini/skills/using-gc/SKILL.md
+++ b/images/gemini/skills/using-gc/SKILL.md
@@ -193,6 +193,18 @@ First classify the bead.
 Then capture the exact tmux pane named by session state and run `gc doctor`.
 Never repair a city from inside that city.
 
+Never create pack-owned sessions by hand. `gc session new` for a singleton or
+scaled agent (`core.control-dispatcher`, role workers) makes a mis-scoped
+session that squats the canonical name in `start-pending` and blocks the
+reconciler from spawning the real one — extending the exact stall being
+repaired. Session lifecycle belongs to the reconciler and demand scaling.
+When the city itself needs tending (a stalled reconciler, sessions that never
+leave draining, model or provider rewiring), send the request to the Mayor:
+
+```sh
+gc mail send mayor -s "<subject>" -m "<request with bead ids>" --notify
+```
+
 The upstream pack may leave a future affinity-bound step assigned to a session
 that has already drain-acked. Diagnose this only from outside the city:
 
@@ -243,3 +255,8 @@ anchor worktree. Neither state is semantic completion by itself.
   context issues the semantic result or, when requested, persists `verdict.v2`.
 - This skill performs no automatic selection, retry, semantic validation, Git,
   integration, closure, release, or delivery.
+- The operator lane into a city is a closed set: author beads, `gc sling`,
+  `gc mail` (city tending goes to the Mayor), `gc doctor [--fix]`, supervisor
+  start/stop from outside, `ao gc prepare|check|recover-affinity`, and reading
+  state. Creating, scaling, or repairing pack-owned sessions by hand is outside
+  the lane; the reconciler owns session lifecycle.

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -633,8 +633,8 @@
     {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
-      "source_hash": "2a10c20c4d20bae81d0bb10b17510c7f0af420d4f97e35a5730d8d5a12fdb707",
-      "generated_hash": "a057193c5a52a5f581d1e836c06939bee1f2e2fd45a96fee25842d94a0eaac72"
+      "source_hash": "f60f446ecf571326b48da1b8d6594b14592a34cf8eb3fdcaffd33c862dd60fb9",
+      "generated_hash": "531e2e2f3a322bb24d14a23c6d2fdddc9bf1b37a49e07b48175ce4e2995d3ee4"
     },
     {
       "name": "validate",

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/using-gc",
   "layout": "modular",
-  "source_hash": "2a10c20c4d20bae81d0bb10b17510c7f0af420d4f97e35a5730d8d5a12fdb707",
-  "generated_hash": "a057193c5a52a5f581d1e836c06939bee1f2e2fd45a96fee25842d94a0eaac72"
+  "source_hash": "f60f446ecf571326b48da1b8d6594b14592a34cf8eb3fdcaffd33c862dd60fb9",
+  "generated_hash": "531e2e2f3a322bb24d14a23c6d2fdddc9bf1b37a49e07b48175ce4e2995d3ee4"
 }

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -175,6 +175,18 @@ First classify the bead.
 Then capture the exact tmux pane named by session state and run `gc doctor`.
 Never repair a city from inside that city.
 
+Never create pack-owned sessions by hand. `gc session new` for a singleton or
+scaled agent (`core.control-dispatcher`, role workers) makes a mis-scoped
+session that squats the canonical name in `start-pending` and blocks the
+reconciler from spawning the real one — extending the exact stall being
+repaired. Session lifecycle belongs to the reconciler and demand scaling.
+When the city itself needs tending (a stalled reconciler, sessions that never
+leave draining, model or provider rewiring), send the request to the Mayor:
+
+```sh
+gc mail send mayor -s "<subject>" -m "<request with bead ids>" --notify
+```
+
 The upstream pack may leave a future affinity-bound step assigned to a session
 that has already drain-acked. Diagnose this only from outside the city:
 
@@ -225,3 +237,8 @@ anchor worktree. Neither state is semantic completion by itself.
   context issues the semantic result or, when requested, persists `verdict.v2`.
 - This skill performs no automatic selection, retry, semantic validation, Git,
   integration, closure, release, or delivery.
+- The operator lane into a city is a closed set: author beads, `gc sling`,
+  `gc mail` (city tending goes to the Mayor), `gc doctor [--fix]`, supervisor
+  start/stop from outside, `ao gc prepare|check|recover-affinity`, and reading
+  state. Creating, scaling, or repairing pack-owned sessions by hand is outside
+  the lane; the reconciler owns session lifecycle.

--- a/skills/using-gc/SKILL.md
+++ b/skills/using-gc/SKILL.md
@@ -193,6 +193,18 @@ First classify the bead.
 Then capture the exact tmux pane named by session state and run `gc doctor`.
 Never repair a city from inside that city.
 
+Never create pack-owned sessions by hand. `gc session new` for a singleton or
+scaled agent (`core.control-dispatcher`, role workers) makes a mis-scoped
+session that squats the canonical name in `start-pending` and blocks the
+reconciler from spawning the real one — extending the exact stall being
+repaired. Session lifecycle belongs to the reconciler and demand scaling.
+When the city itself needs tending (a stalled reconciler, sessions that never
+leave draining, model or provider rewiring), send the request to the Mayor:
+
+```sh
+gc mail send mayor -s "<subject>" -m "<request with bead ids>" --notify
+```
+
 The upstream pack may leave a future affinity-bound step assigned to a session
 that has already drain-acked. Diagnose this only from outside the city:
 
@@ -243,3 +255,8 @@ anchor worktree. Neither state is semantic completion by itself.
   context issues the semantic result or, when requested, persists `verdict.v2`.
 - This skill performs no automatic selection, retry, semantic validation, Git,
   integration, closure, release, or delivery.
+- The operator lane into a city is a closed set: author beads, `gc sling`,
+  `gc mail` (city tending goes to the Mayor), `gc doctor [--fix]`, supervisor
+  start/stop from outside, `ao gc prepare|check|recover-affinity`, and reading
+  state. Creating, scaling, or repairing pack-owned sessions by hand is outside
+  the lane; the reconciler owns session lifecycle.


### PR DESCRIPTION
Bo's directive after today's incident: the rule that agents never hand-drive a factory's internal control plane must live in the skills and the operating contract, not just in operator memory.

**The incident it encodes:** during the 3.4-fix streams, a hand-run `gc session new core.control-dispatcher` created a mis-scoped session (city dir, not the rig) that squatted the canonical singleton name in `start-pending` and blocked the reconciler from spawning the real dispatcher — extending the exact stall being repaired.

- **using-gc**: stall protocol now prohibits `gc session new` for pack-owned singletons/scaled agents with the named failure mode, and routes city tending to the Mayor via `gc mail send mayor --notify`; Boundaries gains the closed operator-lane set (beads, sling, mail, doctor, supervisor-from-outside, `ao gc *`, read state).
- **AGENTS.md** (+ CLAUDE.md symlink): the factory-adapter paragraph now states the control-plane rule generically for any selected factory.
- Projections regenerated; regen-all and skill-lint green locally.