### PR TITLE
docs(gc): Mayor authors workflow beads and dispatches — callers hand it intent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,9 +106,11 @@ A selected factory's internal control plane is operated only through that
 factory's own doors: its coordinator (for Gas City, the Mayor via mail), its
 doctor, and its supervisor start/stop from outside. An agent never creates,
 scales, or repairs factory-internal sessions by hand — a hand-made session can
-squat a canonical name and block the factory's own reconciler. The agent lane
-into a factory is: author beads, mail the coordinator, read state, judge
-results.
+squat a canonical name and block the factory's own reconciler. Dispatch
+belongs to the coordinator too: the agent authors one source intent bead and
+hands its id over; the coordinator authors the workflow beads and launches the
+runs. The agent lane into a factory is: author source intent, mail the
+coordinator, read state, judge results.
 
 ## Concurrency
 

--- a/images/gemini/skills/rpi/SKILL.md
+++ b/images/gemini/skills/rpi/SKILL.md
@@ -139,6 +139,10 @@ disjoint regen surfaces may run in parallel.
   explicit freshness attestation.
 - Optional Premortem, Postmortem, Council, genie, factory, tracker, and runtime
   adapters are caller-selected. They do not alter phase order or core outcomes.
+  When a factory adapter is selected, work enters it through that factory's
+  coordinator (for Gas City, the Mayor — see
+  [using-gc](../using-gc/SKILL.md)); RPI hands over intent and never dispatches
+  factory runs itself.
 - Learn is an optional later consumer of verdict collections and is not part of
   this invocation.
 

--- a/images/gemini/skills/using-gc/SKILL.md
+++ b/images/gemini/skills/using-gc/SKILL.md
@@ -52,7 +52,8 @@ The normal AgentOps path is:
 1. Install and pin the upstream `gascity` workflow and rig-role imports.
 2. Add the project as a rig, prepare its stock maintainer runtime, and make
    AgentOps skills visible to its provider sessions.
-3. Create a caller-owned bead and launch the upstream `build-basic`,
+3. Create a caller-owned source intent bead and hand its id to the Mayor,
+   which authors the workflow beads and dispatches the upstream `build-basic`,
    continuation, review, or implementation formula that matches the available
    artifacts.
 4. Read run, session, bead, artifact, and verdict state. Completion is never
@@ -114,19 +115,26 @@ that runs work, following the exact commands returned by
 `gc pack registry show main:gascity`. Keep the stock `gc.*` namespace; do not
 nest or rename the roles behind an AgentOps pack.
 
-For a starter build:
+Work enters the city through the Mayor. The caller authors ONE source intent
+bead with acceptance, then hands the Mayor its id — the Mayor decomposes,
+authors the workflow beads, and dispatches. The caller never runs `gc sling`
+itself; an operator-slung run bypasses the coordinator that owns retries,
+re-dispatch, and tending for that workflow.
 
 ```sh
 gc bd create "Add a --json flag to the export command"
-gc sling gc.run-operator <bead-id> --on build-basic \
-  --var artifact_root=plans/json-flag/build
+gc mail send mayor -s "Build ago-XXXX" \
+  -m "Decompose and launch build-basic for bead ago-XXXX with push=true open_pr=true." --notify
 ```
 
-For guided requirements, planning, and launch, tell the active agent:
+Or, in an interactive Mayor session:
 
 ```text
 Use skill gc.mayor
 ```
+
+Direct `gc sling` remains a debugging tool for a city with no live Mayor; a
+run started that way has no coordinator and the operator inherits its tending.
 
 AgentOps skills are tools available to those factory agents, not a replacement
 workflow. Explicitly name a skill in the bead or prompt when its behavior is
@@ -255,8 +263,10 @@ anchor worktree. Neither state is semantic completion by itself.
   context issues the semantic result or, when requested, persists `verdict.v2`.
 - This skill performs no automatic selection, retry, semantic validation, Git,
   integration, closure, release, or delivery.
-- The operator lane into a city is a closed set: author beads, `gc sling`,
-  `gc mail` (city tending goes to the Mayor), `gc doctor [--fix]`, supervisor
-  start/stop from outside, `ao gc prepare|check|recover-affinity`, and reading
-  state. Creating, scaling, or repairing pack-owned sessions by hand is outside
-  the lane; the reconciler owns session lifecycle.
+- The operator lane into a city is a closed set: author source intent beads,
+  `gc mail` (work dispatch and city tending both go to the Mayor),
+  `gc doctor [--fix]`, supervisor start/stop from outside,
+  `ao gc prepare|check|recover-affinity`, and reading state. The Mayor authors
+  workflow beads and dispatches; creating, scaling, or repairing pack-owned
+  sessions by hand is outside the lane, and the reconciler owns session
+  lifecycle.

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -555,8 +555,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "b061835709f18d89368212bf58456909144356f49f6b4c7d95a288a9f0381580",
-      "generated_hash": "223b2f7a659f8991421d11d54f790914206b356bce7e4e1f037cbd55cae5e7bc"
+      "source_hash": "db1f499ecbeef631e579117df746e319ef15840ac41c28cd65248bdfde4069d0",
+      "generated_hash": "09fe5c875800bd1ebbe86b8b8a586492e62062f743037f24d5b65782e1463a8d"
     },
     {
       "name": "sbh",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -633,8 +633,8 @@
     {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
-      "source_hash": "f60f446ecf571326b48da1b8d6594b14592a34cf8eb3fdcaffd33c862dd60fb9",
-      "generated_hash": "531e2e2f3a322bb24d14a23c6d2fdddc9bf1b37a49e07b48175ce4e2995d3ee4"
+      "source_hash": "bbf831483f24f7c24aef25a0eb10141540890f498ffef762236ed095000d8a6b",
+      "generated_hash": "586fb441b6366a77baca6dd493a64a121d3a5092d586f846e6ebaf7cdf877997"
     },
     {
       "name": "validate",

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "b061835709f18d89368212bf58456909144356f49f6b4c7d95a288a9f0381580",
-  "generated_hash": "223b2f7a659f8991421d11d54f790914206b356bce7e4e1f037cbd55cae5e7bc"
+  "source_hash": "db1f499ecbeef631e579117df746e319ef15840ac41c28cd65248bdfde4069d0",
+  "generated_hash": "09fe5c875800bd1ebbe86b8b8a586492e62062f743037f24d5b65782e1463a8d"
 }

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -109,6 +109,10 @@ disjoint regen surfaces may run in parallel.
   explicit freshness attestation.
 - Optional Premortem, Postmortem, Council, genie, factory, tracker, and runtime
   adapters are caller-selected. They do not alter phase order or core outcomes.
+  When a factory adapter is selected, work enters it through that factory's
+  coordinator (for Gas City, the Mayor — see
+  [using-gc](../using-gc/SKILL.md)); RPI hands over intent and never dispatches
+  factory runs itself.
 - Learn is an optional later consumer of verdict collections and is not part of
   this invocation.
 

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/using-gc",
   "layout": "modular",
-  "source_hash": "f60f446ecf571326b48da1b8d6594b14592a34cf8eb3fdcaffd33c862dd60fb9",
-  "generated_hash": "531e2e2f3a322bb24d14a23c6d2fdddc9bf1b37a49e07b48175ce4e2995d3ee4"
+  "source_hash": "bbf831483f24f7c24aef25a0eb10141540890f498ffef762236ed095000d8a6b",
+  "generated_hash": "586fb441b6366a77baca6dd493a64a121d3a5092d586f846e6ebaf7cdf877997"
 }

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -34,7 +34,8 @@ The normal AgentOps path is:
 1. Install and pin the upstream `gascity` workflow and rig-role imports.
 2. Add the project as a rig, prepare its stock maintainer runtime, and make
    AgentOps skills visible to its provider sessions.
-3. Create a caller-owned bead and launch the upstream `build-basic`,
+3. Create a caller-owned source intent bead and hand its id to the Mayor,
+   which authors the workflow beads and dispatches the upstream `build-basic`,
    continuation, review, or implementation formula that matches the available
    artifacts.
 4. Read run, session, bead, artifact, and verdict state. Completion is never
@@ -96,19 +97,26 @@ that runs work, following the exact commands returned by
 `gc pack registry show main:gascity`. Keep the stock `gc.*` namespace; do not
 nest or rename the roles behind an AgentOps pack.
 
-For a starter build:
+Work enters the city through the Mayor. The caller authors ONE source intent
+bead with acceptance, then hands the Mayor its id — the Mayor decomposes,
+authors the workflow beads, and dispatches. The caller never runs `gc sling`
+itself; an operator-slung run bypasses the coordinator that owns retries,
+re-dispatch, and tending for that workflow.
 
 ```sh
 gc bd create "Add a --json flag to the export command"
-gc sling gc.run-operator <bead-id> --on build-basic \
-  --var artifact_root=plans/json-flag/build
+gc mail send mayor -s "Build ago-XXXX" \
+  -m "Decompose and launch build-basic for bead ago-XXXX with push=true open_pr=true." --notify
 ```
 
-For guided requirements, planning, and launch, tell the active agent:
+Or, in an interactive Mayor session:
 
 ```text
 Use skill gc.mayor
 ```
+
+Direct `gc sling` remains a debugging tool for a city with no live Mayor; a
+run started that way has no coordinator and the operator inherits its tending.
 
 AgentOps skills are tools available to those factory agents, not a replacement
 workflow. Explicitly name a skill in the bead or prompt when its behavior is
@@ -237,8 +245,10 @@ anchor worktree. Neither state is semantic completion by itself.
   context issues the semantic result or, when requested, persists `verdict.v2`.
 - This skill performs no automatic selection, retry, semantic validation, Git,
   integration, closure, release, or delivery.
-- The operator lane into a city is a closed set: author beads, `gc sling`,
-  `gc mail` (city tending goes to the Mayor), `gc doctor [--fix]`, supervisor
-  start/stop from outside, `ao gc prepare|check|recover-affinity`, and reading
-  state. Creating, scaling, or repairing pack-owned sessions by hand is outside
-  the lane; the reconciler owns session lifecycle.
+- The operator lane into a city is a closed set: author source intent beads,
+  `gc mail` (work dispatch and city tending both go to the Mayor),
+  `gc doctor [--fix]`, supervisor start/stop from outside,
+  `ao gc prepare|check|recover-affinity`, and reading state. The Mayor authors
+  workflow beads and dispatches; creating, scaling, or repairing pack-owned
+  sessions by hand is outside the lane, and the reconciler owns session
+  lifecycle.

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -139,6 +139,10 @@ disjoint regen surfaces may run in parallel.
   explicit freshness attestation.
 - Optional Premortem, Postmortem, Council, genie, factory, tracker, and runtime
   adapters are caller-selected. They do not alter phase order or core outcomes.
+  When a factory adapter is selected, work enters it through that factory's
+  coordinator (for Gas City, the Mayor — see
+  [using-gc](../using-gc/SKILL.md)); RPI hands over intent and never dispatches
+  factory runs itself.
 - Learn is an optional later consumer of verdict collections and is not part of
   this invocation.
 

--- a/skills/using-gc/SKILL.md
+++ b/skills/using-gc/SKILL.md
@@ -52,7 +52,8 @@ The normal AgentOps path is:
 1. Install and pin the upstream `gascity` workflow and rig-role imports.
 2. Add the project as a rig, prepare its stock maintainer runtime, and make
    AgentOps skills visible to its provider sessions.
-3. Create a caller-owned bead and launch the upstream `build-basic`,
+3. Create a caller-owned source intent bead and hand its id to the Mayor,
+   which authors the workflow beads and dispatches the upstream `build-basic`,
    continuation, review, or implementation formula that matches the available
    artifacts.
 4. Read run, session, bead, artifact, and verdict state. Completion is never
@@ -114,19 +115,26 @@ that runs work, following the exact commands returned by
 `gc pack registry show main:gascity`. Keep the stock `gc.*` namespace; do not
 nest or rename the roles behind an AgentOps pack.
 
-For a starter build:
+Work enters the city through the Mayor. The caller authors ONE source intent
+bead with acceptance, then hands the Mayor its id — the Mayor decomposes,
+authors the workflow beads, and dispatches. The caller never runs `gc sling`
+itself; an operator-slung run bypasses the coordinator that owns retries,
+re-dispatch, and tending for that workflow.
 
 ```sh
 gc bd create "Add a --json flag to the export command"
-gc sling gc.run-operator <bead-id> --on build-basic \
-  --var artifact_root=plans/json-flag/build
+gc mail send mayor -s "Build ago-XXXX" \
+  -m "Decompose and launch build-basic for bead ago-XXXX with push=true open_pr=true." --notify
 ```
 
-For guided requirements, planning, and launch, tell the active agent:
+Or, in an interactive Mayor session:
 
 ```text
 Use skill gc.mayor
 ```
+
+Direct `gc sling` remains a debugging tool for a city with no live Mayor; a
+run started that way has no coordinator and the operator inherits its tending.
 
 AgentOps skills are tools available to those factory agents, not a replacement
 workflow. Explicitly name a skill in the bead or prompt when its behavior is
@@ -255,8 +263,10 @@ anchor worktree. Neither state is semantic completion by itself.
   context issues the semantic result or, when requested, persists `verdict.v2`.
 - This skill performs no automatic selection, retry, semantic validation, Git,
   integration, closure, release, or delivery.
-- The operator lane into a city is a closed set: author beads, `gc sling`,
-  `gc mail` (city tending goes to the Mayor), `gc doctor [--fix]`, supervisor
-  start/stop from outside, `ao gc prepare|check|recover-affinity`, and reading
-  state. Creating, scaling, or repairing pack-owned sessions by hand is outside
-  the lane; the reconciler owns session lifecycle.
+- The operator lane into a city is a closed set: author source intent beads,
+  `gc mail` (work dispatch and city tending both go to the Mayor),
+  `gc doctor [--fix]`, supervisor start/stop from outside,
+  `ao gc prepare|check|recover-affinity`, and reading state. The Mayor authors
+  workflow beads and dispatches; creating, scaling, or repairing pack-owned
+  sessions by hand is outside the lane, and the reconciler owns session
+  lifecycle.


### PR DESCRIPTION
Doctrine correction from Bo, third recurrence of the bypass-the-Mayor class (see the 2026-07-22 substrate-adoption lesson): during the fix-stream orchestration the operator ran `gc sling` directly, doing the Mayor's job — then inherited its tending (stale affinities, re-dispatch) when the city restarted.

- **using-gc**: the normal path and starter example now route through the Mayor (`gc bd create` → `gc mail send mayor` with the bead id); direct `gc sling` is demoted to a no-live-Mayor debugging tool with its cost stated; the operator-lane closed set names dispatch as Mayor-owned.
- **AGENTS.md/CLAUDE.md**: the factory control-plane paragraph now covers dispatch: agent authors source intent, coordinator authors workflow beads and launches.

Projections regenerated; regen-all + skill-lint green locally.