### PR TITLE
docs(gc): document the typed run-status API in using-gc

### DIFF
--- a/images/gemini/skills/using-gc/SKILL.md
+++ b/images/gemini/skills/using-gc/SKILL.md
@@ -231,6 +231,20 @@ does not sling, retry, close, restart, or select work.
    `gc session list --json`. Run detail unifies the stage ladder, structured
    transcripts, token rate, and estimated burn rate. A roster may still report
    active while a provider is wedged.
+
+   Programmatic run status comes from the supervisor's typed run API — the
+   same data the dashboard renders. `gc status` prints the API base; neither
+   `gc status --json` nor any other CLI subcommand carries run objects.
+
+   ```sh
+   API="http://127.0.0.1:<port>/v0/city/<city-name>"
+   curl -s "$API/runs/<run-id>"   # {run_id, title, status, target, scope, started_at, updated_at}
+   curl -s "$API/runs/census"     # {status_counts: {pending, active, waiting, canceling, completed, failed, canceled, skipped}}
+   ```
+
+   Poll run status and census for progress; a nonzero `failed` count is the
+   first machine-readable failure signal. The dashboard's run page
+   (`/city/<city-name>/runs/<run-id>`) is the human view of the same objects.
 2. **Bead graph** — `gc bd --rig <rig> ready --json` and `show <id> --json`.
    This is workflow-state truth, but a claimed bead cannot reveal a wedged pane.
 3. **Pane truth** — `tmux -L <socket> capture-pane -pt <session>`. This exposes

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -633,8 +633,8 @@
     {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
-      "source_hash": "bbf831483f24f7c24aef25a0eb10141540890f498ffef762236ed095000d8a6b",
-      "generated_hash": "586fb441b6366a77baca6dd493a64a121d3a5092d586f846e6ebaf7cdf877997"
+      "source_hash": "a080a933aa37a5e070ce05698cf7f115e0cc30a1badc2902ef0bbdcf2ccba718",
+      "generated_hash": "6a685c64b70c8ace0248079dafe025438dbf67e85a380b266806cfcfd9e06c31"
     },
     {
       "name": "validate",

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/using-gc",
   "layout": "modular",
-  "source_hash": "bbf831483f24f7c24aef25a0eb10141540890f498ffef762236ed095000d8a6b",
-  "generated_hash": "586fb441b6366a77baca6dd493a64a121d3a5092d586f846e6ebaf7cdf877997"
+  "source_hash": "a080a933aa37a5e070ce05698cf7f115e0cc30a1badc2902ef0bbdcf2ccba718",
+  "generated_hash": "6a685c64b70c8ace0248079dafe025438dbf67e85a380b266806cfcfd9e06c31"
 }

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -213,6 +213,20 @@ does not sling, retry, close, restart, or select work.
    `gc session list --json`. Run detail unifies the stage ladder, structured
    transcripts, token rate, and estimated burn rate. A roster may still report
    active while a provider is wedged.
+
+   Programmatic run status comes from the supervisor's typed run API — the
+   same data the dashboard renders. `gc status` prints the API base; neither
+   `gc status --json` nor any other CLI subcommand carries run objects.
+
+   ```sh
+   API="http://127.0.0.1:<port>/v0/city/<city-name>"
+   curl -s "$API/runs/<run-id>"   # {run_id, title, status, target, scope, started_at, updated_at}
+   curl -s "$API/runs/census"     # {status_counts: {pending, active, waiting, canceling, completed, failed, canceled, skipped}}
+   ```
+
+   Poll run status and census for progress; a nonzero `failed` count is the
+   first machine-readable failure signal. The dashboard's run page
+   (`/city/<city-name>/runs/<run-id>`) is the human view of the same objects.
 2. **Bead graph** — `gc bd --rig <rig> ready --json` and `show <id> --json`.
    This is workflow-state truth, but a claimed bead cannot reveal a wedged pane.
 3. **Pane truth** — `tmux -L <socket> capture-pane -pt <session>`. This exposes

--- a/skills/using-gc/SKILL.md
+++ b/skills/using-gc/SKILL.md
@@ -231,6 +231,20 @@ does not sling, retry, close, restart, or select work.
    `gc session list --json`. Run detail unifies the stage ladder, structured
    transcripts, token rate, and estimated burn rate. A roster may still report
    active while a provider is wedged.
+
+   Programmatic run status comes from the supervisor's typed run API — the
+   same data the dashboard renders. `gc status` prints the API base; neither
+   `gc status --json` nor any other CLI subcommand carries run objects.
+
+   ```sh
+   API="http://127.0.0.1:<port>/v0/city/<city-name>"
+   curl -s "$API/runs/<run-id>"   # {run_id, title, status, target, scope, started_at, updated_at}
+   curl -s "$API/runs/census"     # {status_counts: {pending, active, waiting, canceling, completed, failed, canceled, skipped}}
+   ```
+
+   Poll run status and census for progress; a nonzero `failed` count is the
+   first machine-readable failure signal. The dashboard's run page
+   (`/city/<city-name>/runs/<run-id>`) is the human view of the same objects.
 2. **Bead graph** — `gc bd --rig <rig> ready --json` and `show <id> --json`.
    This is workflow-state truth, but a claimed bead cannot reveal a wedged pane.
 3. **Pane truth** — `tmux -L <socket> capture-pane -pt <session>`. This exposes


### PR DESCRIPTION
From operating the 3.4-fix streams: using-gc's visibility layer 1 mentioned the run APIs without endpoints, so run-status monitoring required probing the supervisor. Documents `$API/runs/<run-id>` and `$API/runs/census` with observed response shapes, the API-base discovery via `gc status`, the fact that no CLI subcommand carries run objects (verified: `gc status --json` has no runs key), and the dashboard run page as the human view. Projections regenerated; regen + lint green.