### PR TITLE
docs(gc): five-verb tending loop for orchestrating through the Mayor

### DIFF
--- a/images/gemini/skills/using-gc/SKILL.md
+++ b/images/gemini/skills/using-gc/SKILL.md
@@ -186,6 +186,24 @@ Create the replacement from the upstream Gas City template, install its pinned
 imports, and verify it with `gc cities --json`, `gc --city <new-city> status`,
 and `gc --city <new-city> doctor --json`.
 
+## Orchestrating through the Mayor: the tending loop
+
+After handing intent to the Mayor, the orchestrator runs five verbs. Each verb
+has one owner; crossing owners is the recurring failure class this section
+exists to stop.
+
+| Verb | Owner | Surface |
+|---|---|---|
+| Monitor | orchestrator | `$API/runs/census` and `$API/runs/<run-id>` on a fixed cadence, plus `gc mail inbox` for Mayor replies. `failed > 0` in the census, a run in `failed`/`canceled`, or unread Mayor mail is the act signal; everything else is a tick. |
+| Observe | orchestrator | On an act signal, walk the visibility layers in order — census, run detail, bead graph, session roster, pane truth — and stop at the first layer that explains. Do not start at pane truth. |
+| Nudge | orchestrator, once | A `ready` bead: dispatch once to its `gc.run_target`. A routed bead with a live session: `gc session wake <run_target>` once. A second nudge on the same subject means the diagnosis is wrong — mail the Mayor instead. |
+| Redirect | Mayor | Priority, scope, cancellation, or model/provider changes travel by mail with bead/run ids. The orchestrator never re-slings, edits workflow beads, or patches a live run. |
+| Rework | GC first, then Mayor | Failed review findings re-enter the run through its native fix loop (`review_fix_formula`, default `fix-loop-base`); bounded gated retries are `gc converge` loops. Only a TERMINAL `failed`/`canceled` run — or a completed run whose result misses caller acceptance — goes back: mail the Mayor the run id and the failure evidence for re-decompose and relaunch. |
+
+Rework the orchestrator performs by hand (editing a failed run's worktree,
+re-slinging its formula, closing its beads) creates a second uncoordinated
+author for the same intent; the Mayor's relaunch then races it.
+
 ## Stall protocol
 
 First classify the bead.

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -633,8 +633,8 @@
     {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
-      "source_hash": "a080a933aa37a5e070ce05698cf7f115e0cc30a1badc2902ef0bbdcf2ccba718",
-      "generated_hash": "6a685c64b70c8ace0248079dafe025438dbf67e85a380b266806cfcfd9e06c31"
+      "source_hash": "dabb5f1416c33b9053cdaac679bd5395012abb1c563515e75a7b1dbea65b9648",
+      "generated_hash": "03ce9b8f59592fe894eb0ba99f7c9cfc8d3d9632552358023d5fa0a0f840a86a"
     },
     {
       "name": "validate",

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/using-gc",
   "layout": "modular",
-  "source_hash": "a080a933aa37a5e070ce05698cf7f115e0cc30a1badc2902ef0bbdcf2ccba718",
-  "generated_hash": "6a685c64b70c8ace0248079dafe025438dbf67e85a380b266806cfcfd9e06c31"
+  "source_hash": "dabb5f1416c33b9053cdaac679bd5395012abb1c563515e75a7b1dbea65b9648",
+  "generated_hash": "03ce9b8f59592fe894eb0ba99f7c9cfc8d3d9632552358023d5fa0a0f840a86a"
 }

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -168,6 +168,24 @@ Create the replacement from the upstream Gas City template, install its pinned
 imports, and verify it with `gc cities --json`, `gc --city <new-city> status`,
 and `gc --city <new-city> doctor --json`.
 
+## Orchestrating through the Mayor: the tending loop
+
+After handing intent to the Mayor, the orchestrator runs five verbs. Each verb
+has one owner; crossing owners is the recurring failure class this section
+exists to stop.
+
+| Verb | Owner | Surface |
+|---|---|---|
+| Monitor | orchestrator | `$API/runs/census` and `$API/runs/<run-id>` on a fixed cadence, plus `gc mail inbox` for Mayor replies. `failed > 0` in the census, a run in `failed`/`canceled`, or unread Mayor mail is the act signal; everything else is a tick. |
+| Observe | orchestrator | On an act signal, walk the visibility layers in order — census, run detail, bead graph, session roster, pane truth — and stop at the first layer that explains. Do not start at pane truth. |
+| Nudge | orchestrator, once | A `ready` bead: dispatch once to its `gc.run_target`. A routed bead with a live session: `gc session wake <run_target>` once. A second nudge on the same subject means the diagnosis is wrong — mail the Mayor instead. |
+| Redirect | Mayor | Priority, scope, cancellation, or model/provider changes travel by mail with bead/run ids. The orchestrator never re-slings, edits workflow beads, or patches a live run. |
+| Rework | GC first, then Mayor | Failed review findings re-enter the run through its native fix loop (`review_fix_formula`, default `fix-loop-base`); bounded gated retries are `gc converge` loops. Only a TERMINAL `failed`/`canceled` run — or a completed run whose result misses caller acceptance — goes back: mail the Mayor the run id and the failure evidence for re-decompose and relaunch. |
+
+Rework the orchestrator performs by hand (editing a failed run's worktree,
+re-slinging its formula, closing its beads) creates a second uncoordinated
+author for the same intent; the Mayor's relaunch then races it.
+
 ## Stall protocol
 
 First classify the bead.

--- a/skills/using-gc/SKILL.md
+++ b/skills/using-gc/SKILL.md
@@ -186,6 +186,24 @@ Create the replacement from the upstream Gas City template, install its pinned
 imports, and verify it with `gc cities --json`, `gc --city <new-city> status`,
 and `gc --city <new-city> doctor --json`.
 
+## Orchestrating through the Mayor: the tending loop
+
+After handing intent to the Mayor, the orchestrator runs five verbs. Each verb
+has one owner; crossing owners is the recurring failure class this section
+exists to stop.
+
+| Verb | Owner | Surface |
+|---|---|---|
+| Monitor | orchestrator | `$API/runs/census` and `$API/runs/<run-id>` on a fixed cadence, plus `gc mail inbox` for Mayor replies. `failed > 0` in the census, a run in `failed`/`canceled`, or unread Mayor mail is the act signal; everything else is a tick. |
+| Observe | orchestrator | On an act signal, walk the visibility layers in order — census, run detail, bead graph, session roster, pane truth — and stop at the first layer that explains. Do not start at pane truth. |
+| Nudge | orchestrator, once | A `ready` bead: dispatch once to its `gc.run_target`. A routed bead with a live session: `gc session wake <run_target>` once. A second nudge on the same subject means the diagnosis is wrong — mail the Mayor instead. |
+| Redirect | Mayor | Priority, scope, cancellation, or model/provider changes travel by mail with bead/run ids. The orchestrator never re-slings, edits workflow beads, or patches a live run. |
+| Rework | GC first, then Mayor | Failed review findings re-enter the run through its native fix loop (`review_fix_formula`, default `fix-loop-base`); bounded gated retries are `gc converge` loops. Only a TERMINAL `failed`/`canceled` run — or a completed run whose result misses caller acceptance — goes back: mail the Mayor the run id and the failure evidence for re-decompose and relaunch. |
+
+Rework the orchestrator performs by hand (editing a failed run's worktree,
+re-slinging its formula, closing its beads) creates a second uncoordinated
+author for the same intent; the Mayor's relaunch then races it.
+
 ## Stall protocol
 
 First classify the bead.


### PR DESCRIPTION
Bo's ask: assess the meta-orchestration and encode how agents should monitor/observe/nudge/redirect/rework when driving GC through the Mayor.

Verified before documenting: failed review findings re-enter runs natively via `review_fix_formula` (default `fix-loop-base`); `gc converge` provides gated bounded retries — so rework is GC-owned except terminal failures, which return to the Mayor with evidence.

The new section gives each verb ONE owner with its concrete surface, the act-signal definition (census failed>0, terminal run states, unread Mayor mail), the ordered layer-walk for observation, the one-nudge rule, and the race hazard of hand-rework. Projections regenerated; regen + lint green.