### PR TITLE
feat(plan): manifest mode — many behaviors, zero beads, substrate-neutral

### DIFF
--- a/images/gemini/skills/plan/SKILL.md
+++ b/images/gemini/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: 'Shape or refine the existing bead or caller intent without creating a second planning artifact. Triggers: "plan", "discover and plan", "shape this goal".'
+description: 'Shape or refine the existing bead or caller intent without a second planning artifact. Triggers: "plan", "discover and plan", "shape this goal", "plan manifest".'
 practices:
 - bdd-gherkin
 - design-by-contract
@@ -54,6 +54,25 @@ is derived automatically and is not another model-authored planning artifact.
 Bound the work around the caller-visible outcome, not individual files, gates,
 or reviewer comments. Decomposition is useful only when it reduces reasoning
 cost; it must not multiply invocations or proof artifacts.
+
+## Manifest mode (many behaviors, zero beads)
+
+When the caller's goal genuinely decomposes into several bounded behaviors —
+an audit remediation, an epic, a contraction — shape one caller-owned
+specification manifest instead of one behavior:
+
+- One document in the caller's location (commonly `docs/plans/<date>-<slug>.md`)
+  holding a manifest table (stable slug, type, priority, parent, dependency
+  edges) plus one section per child with acceptance, non-goals, write scope,
+  and evidence commands. Each child must satisfy the same bar as a
+  single-behavior plan.
+- Tracker IDs stay `TBD`: manifest mode authors zero beads. The executing
+  substrate materializes tracker state — the caller's session in the default
+  loop, or the selected factory's coordinator (for Gas City the Mayor, per
+  [using-gc](../using-gc/SKILL.md); for the Flywheel, its native workflow per
+  [using-flywheel](../using-flywheel/SKILL.md)).
+- Reference example:
+  [2026-07-30-ponytail-whole-repo-contraction.md](../../docs/plans/2026-07-30-ponytail-whole-repo-contraction.md).
 
 ## Scope admission
 

--- a/images/gemini/skills/using-gc/SKILL.md
+++ b/images/gemini/skills/using-gc/SKILL.md
@@ -133,6 +133,13 @@ Or, in an interactive Mayor session:
 Use skill gc.mayor
 ```
 
+A multi-behavior intent arrives as a plan manifest (see plan's manifest mode):
+one caller-owned document with stable slugs, dependency edges, and per-child
+acceptance and write scopes, tracker IDs left `TBD`. Mail the Mayor the
+document path once it is on the rig's mainline; the Mayor materializes the
+epic and children from the manifest and owns their dispatch order. Reference
+example: `docs/plans/2026-07-30-ponytail-whole-repo-contraction.md`.
+
 Direct `gc sling` remains a debugging tool for a city with no live Mayor; a
 run started that way has no coordinator and the operator inherits its tending.
 

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -501,8 +501,8 @@
     {
       "name": "plan",
       "source_skill": "skills/plan",
-      "source_hash": "a6adecafcd6855f518889904c6a61a4ea1ccf69bc3cbbc79a0f7c6f13e2d02ea",
-      "generated_hash": "42f3a346eae257e2e7b9a1a3962607cd3d8e6794a79000803a1ab615fe331748"
+      "source_hash": "1daf1e1217f13de0dcec04c630823cbd8f99be89109071d204b0c8622b359b4c",
+      "generated_hash": "df6fbe2aa4c8d76178aeda56d99ef2f1eec857ee50c8c4a9c3c2ec3499bebce6"
     },
     {
       "name": "postmortem",
@@ -633,8 +633,8 @@
     {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
-      "source_hash": "dabb5f1416c33b9053cdaac679bd5395012abb1c563515e75a7b1dbea65b9648",
-      "generated_hash": "03ce9b8f59592fe894eb0ba99f7c9cfc8d3d9632552358023d5fa0a0f840a86a"
+      "source_hash": "fa961808745dbb3304622af95164ff621d65f79c59acfbd4c411fdf21f5bba07",
+      "generated_hash": "122cfc099b6851ada7020e2d85730cf7c1137402a0a42dd54bbab63ec39b287d"
     },
     {
       "name": "validate",

--- a/skills-codex/plan/.agentops-generated.json
+++ b/skills-codex/plan/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/plan",
   "layout": "modular",
-  "source_hash": "a6adecafcd6855f518889904c6a61a4ea1ccf69bc3cbbc79a0f7c6f13e2d02ea",
-  "generated_hash": "42f3a346eae257e2e7b9a1a3962607cd3d8e6794a79000803a1ab615fe331748"
+  "source_hash": "1daf1e1217f13de0dcec04c630823cbd8f99be89109071d204b0c8622b359b4c",
+  "generated_hash": "df6fbe2aa4c8d76178aeda56d99ef2f1eec857ee50c8c4a9c3c2ec3499bebce6"
 }

--- a/skills-codex/plan/SKILL.md
+++ b/skills-codex/plan/SKILL.md
@@ -36,6 +36,25 @@ Bound the work around the caller-visible outcome, not individual files, gates,
 or reviewer comments. Decomposition is useful only when it reduces reasoning
 cost; it must not multiply invocations or proof artifacts.
 
+## Manifest mode (many behaviors, zero beads)
+
+When the caller's goal genuinely decomposes into several bounded behaviors —
+an audit remediation, an epic, a contraction — shape one caller-owned
+specification manifest instead of one behavior:
+
+- One document in the caller's location (commonly `docs/plans/<date>-<slug>.md`)
+  holding a manifest table (stable slug, type, priority, parent, dependency
+  edges) plus one section per child with acceptance, non-goals, write scope,
+  and evidence commands. Each child must satisfy the same bar as a
+  single-behavior plan.
+- Tracker IDs stay `TBD`: manifest mode authors zero beads. The executing
+  substrate materializes tracker state — the caller's session in the default
+  loop, or the selected factory's coordinator (for Gas City the Mayor, per
+  [using-gc](../using-gc/SKILL.md); for the Flywheel, its native workflow per
+  [using-flywheel](../using-flywheel/SKILL.md)).
+- Reference example:
+  [2026-07-30-ponytail-whole-repo-contraction.md](../../docs/plans/2026-07-30-ponytail-whole-repo-contraction.md).
+
 ## Scope admission
 
 In a repository with generated projections, write scope names generator-owned

--- a/skills-codex/plan/prompt.md
+++ b/skills-codex/plan/prompt.md
@@ -1,6 +1,6 @@
 # plan
 
-Shape or refine the existing bead or caller intent without creating a second planning artifact. Triggers: "plan", "discover and plan", "shape this goal".
+Shape or refine the existing bead or caller intent without a second planning artifact. Triggers: "plan", "discover and plan", "shape this goal", "plan manifest".
 
 ## Instructions
 

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/using-gc",
   "layout": "modular",
-  "source_hash": "dabb5f1416c33b9053cdaac679bd5395012abb1c563515e75a7b1dbea65b9648",
-  "generated_hash": "03ce9b8f59592fe894eb0ba99f7c9cfc8d3d9632552358023d5fa0a0f840a86a"
+  "source_hash": "fa961808745dbb3304622af95164ff621d65f79c59acfbd4c411fdf21f5bba07",
+  "generated_hash": "122cfc099b6851ada7020e2d85730cf7c1137402a0a42dd54bbab63ec39b287d"
 }

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -115,6 +115,13 @@ Or, in an interactive Mayor session:
 Use skill gc.mayor
 ```
 
+A multi-behavior intent arrives as a plan manifest (see plan's manifest mode):
+one caller-owned document with stable slugs, dependency edges, and per-child
+acceptance and write scopes, tracker IDs left `TBD`. Mail the Mayor the
+document path once it is on the rig's mainline; the Mayor materializes the
+epic and children from the manifest and owns their dispatch order. Reference
+example: `docs/plans/2026-07-30-ponytail-whole-repo-contraction.md`.
+
 Direct `gc sling` remains a debugging tool for a city with no live Mayor; a
 run started that way has no coordinator and the operator inherits its tending.
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -907,7 +907,7 @@
       "consumes": [],
       "context_rel": [],
       "dependencies": [],
-      "description": "Shape or refine the existing bead or caller intent without creating a second planning artifact. Triggers: \"plan\", \"discover and plan\", \"shape this goal\".",
+      "description": "Shape or refine the existing bead or caller intent without a second planning artifact. Triggers: \"plan\", \"discover and plan\", \"shape this goal\", \"plan manifest\".",
       "disposition": "keep",
       "effects": [
         "update_intent_source"

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: 'Shape or refine the existing bead or caller intent without creating a second planning artifact. Triggers: "plan", "discover and plan", "shape this goal".'
+description: 'Shape or refine the existing bead or caller intent without a second planning artifact. Triggers: "plan", "discover and plan", "shape this goal", "plan manifest".'
 practices:
 - bdd-gherkin
 - design-by-contract
@@ -54,6 +54,25 @@ is derived automatically and is not another model-authored planning artifact.
 Bound the work around the caller-visible outcome, not individual files, gates,
 or reviewer comments. Decomposition is useful only when it reduces reasoning
 cost; it must not multiply invocations or proof artifacts.
+
+## Manifest mode (many behaviors, zero beads)
+
+When the caller's goal genuinely decomposes into several bounded behaviors —
+an audit remediation, an epic, a contraction — shape one caller-owned
+specification manifest instead of one behavior:
+
+- One document in the caller's location (commonly `docs/plans/<date>-<slug>.md`)
+  holding a manifest table (stable slug, type, priority, parent, dependency
+  edges) plus one section per child with acceptance, non-goals, write scope,
+  and evidence commands. Each child must satisfy the same bar as a
+  single-behavior plan.
+- Tracker IDs stay `TBD`: manifest mode authors zero beads. The executing
+  substrate materializes tracker state — the caller's session in the default
+  loop, or the selected factory's coordinator (for Gas City the Mayor, per
+  [using-gc](../using-gc/SKILL.md); for the Flywheel, its native workflow per
+  [using-flywheel](../using-flywheel/SKILL.md)).
+- Reference example:
+  [2026-07-30-ponytail-whole-repo-contraction.md](../../docs/plans/2026-07-30-ponytail-whole-repo-contraction.md).
 
 ## Scope admission
 

--- a/skills/using-gc/SKILL.md
+++ b/skills/using-gc/SKILL.md
@@ -133,6 +133,13 @@ Or, in an interactive Mayor session:
 Use skill gc.mayor
 ```
 
+A multi-behavior intent arrives as a plan manifest (see plan's manifest mode):
+one caller-owned document with stable slugs, dependency edges, and per-child
+acceptance and write scopes, tracker IDs left `TBD`. Mail the Mayor the
+document path once it is on the rig's mainline; the Mayor materializes the
+epic and children from the manifest and owns their dispatch order. Reference
+example: `docs/plans/2026-07-30-ponytail-whole-repo-contraction.md`.
+
 Direct `gc sling` remains a debugging tool for a city with no live Mayor; a
 run started that way has no coordinator and the operator inherits its tending.
 


### PR DESCRIPTION
Design decision from Bo's question ('not everyone will use gc… do we create separate skills?'): **no siblings** — substrate-neutral core + factory adapters, the repo's existing shape.

- **plan** gains *manifest mode*: one caller-owned specification manifest (stable slugs, dependency edges, per-child acceptance/non-goals/write scope/evidence commands, tracker IDs `TBD`) and authors **zero** beads; the executing substrate materializes tracker state. Trigger "plan manifest" added (desc within budget). Non-GC users lose nothing; the mode also serves swarm/NTM/human handoffs.
- **using-gc** documents the manifest→Mayor handoff (mail the path once it's on the rig mainline; Mayor materializes epic+children and owns dispatch order), citing the ponytail plan as the live reference example — which was just handed to the Mayor this way.

Projections regenerated; regen + skill-lint green.