### PR TITLE
docs(skills): install-agnostic loop commands and self-contained rpi examples

### DIFF
--- a/cli/cmd/ao/root.go
+++ b/cli/cmd/ao/root.go
@@ -38,8 +38,10 @@ For AI agents:
   ao robot-docs       Paste-ready agent handbook.
   Append --json to any read-side command for structured output.
 
-If a command you relied on is gone, see docs/MIGRATION.md — every removed
+If a command you relied on is gone, see
+https://github.com/boshu2/agentops/blob/main/docs/MIGRATION.md — every removed
 surface has a row naming its replacement (and the restore path when one exists).
+A repository checkout also has this at docs/MIGRATION.md.
 
 Use "ao <command> --help" for more information about a command.`,
 	SilenceUsage: true,

--- a/images/gemini/skills/plan/SKILL.md
+++ b/images/gemini/skills/plan/SKILL.md
@@ -32,9 +32,12 @@ and hash the same source. Do not make the model restate those facts in a packet.
 ## Workflow
 
 1. Resolve the intent source and choose one active behavior. When that source
-   is not already durable, have the runtime pass its exact bytes to
-   `python3 skills/validate/scripts/validate.py snapshot-intent --source -` and
-   use the returned `intent_ref` for later phases.
+   is not already durable, have the runtime pass its exact bytes to the
+   validate skill's `scripts/validate.py snapshot-intent --source -`, resolved
+   relative to wherever that skill package is installed (a repo checkout:
+   `skills/validate/scripts/validate.py`; an installed skill package:
+   `.agents/skills/validate/scripts/validate.py`), and use the returned
+   `intent_ref` for later phases.
 2. Route the work by type (see **Ground-truth routing**) and name its ground
    truth first. Then inspect only enough real context to make paths, interfaces,
    and evidence concrete. Existing research and specialist skills are advisory

--- a/images/gemini/skills/rpi/SKILL.md
+++ b/images/gemini/skills/rpi/SKILL.md
@@ -113,11 +113,13 @@ run — report `NOT_BUILT` when no implementation subject exists yet;
 when a subject already exists, stop and report its current status without
 dispatching further lanes. Neither breaker dispatches a repair revision. An
 orchestration without a declared envelope does not converge; it accretes
-lanes. The 2026-07-15
-heal-skill fold ran three intent revisions
-(`.agents/ao/intents/sha256/26a4f2be...eb48` lineage) and a `NOT_PROVEN` then
-PASS verdict pair (`.agents/ao/verdicts/sha256/b6e759dd...cb6a`,
-`e9b6cdb8...37b9`) before an enforced two-stop checkpoint ended the wave.
+lanes. For example, a plan that keeps failing acceptance on the same criterion
+might tempt three intent revisions in a row
+(`.agents/ao/intents/sha256/<rev1>...` superseded by `<rev2>...` superseded by
+`<rev3>...`) chasing a `NOT_PROVEN` then a second `NOT_PROVEN`
+(`.agents/ao/verdicts/sha256/<verdict1>...`, `<verdict2>...`) — the declared
+envelope's two-stop checkpoint ends the wave there instead of dispatching a
+third attempt.
 
 Delegate with minimal context: a lane receives the frozen intent reference and
 the established facts it needs, never the orchestrator's full conversation
@@ -152,10 +154,30 @@ RPI has one required report surface and one optional representation:
 
 1. **Interactive response:** return the result to the caller in natural
    language. This is the default assistant response.
-2. **Machine artifact:** return or persist the exact
-   [`rpi-report.v1`](../../schemas/rpi-report.v1.schema.json) object only when
-   the caller requests machine-readable evidence or a declared adapter consumes
-   it.
+2. **Machine artifact:** return or persist the exact `rpi-report.v1` object
+   only when the caller requests machine-readable evidence or a declared
+   adapter consumes it. The schema ships in a repo checkout at
+   `schemas/rpi-report.v1.schema.json`; the minimal required shape is:
+
+   ```json
+   {
+     "schema_version": "rpi-report.v1",
+     "status": "PASS",
+     "intent_ref": ".agents/ao/intents/sha256/<64-hex-digest>.intent",
+     "acceptance_digest": "<64-hex-char-sha256-or-null>",
+     "subject_manifest_digest": "<64-hex-char-sha256-or-null>",
+     "verdict_ref": "<verdict-location-or-null>",
+     "verdict_digest": "<64-hex-char-sha256-or-null>",
+     "checked": ["<criterion satisfied by evidence>"],
+     "not_checked": ["<criterion not covered>"]
+   }
+   ```
+
+   `status` is one of `PASS | FAIL | NOT_PROVEN | NOT_PLANNED | NOT_BUILT`; the
+   three digest fields, when present, are 64-character lowercase hex SHA-256
+   strings; `checked` and `not_checked` are arrays of strings. All nine keys
+   are required (use `null` for an inapplicable ref or digest), and no
+   additional properties are allowed.
 
 Lead the interactive response with the status and one sentence stating the
 caller-visible outcome. Lead with the subject, not the process: production

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -501,8 +501,8 @@
     {
       "name": "plan",
       "source_skill": "skills/plan",
-      "source_hash": "1daf1e1217f13de0dcec04c630823cbd8f99be89109071d204b0c8622b359b4c",
-      "generated_hash": "df6fbe2aa4c8d76178aeda56d99ef2f1eec857ee50c8c4a9c3c2ec3499bebce6"
+      "source_hash": "cac2270ad512a4a98545188d4d0226cb20b7ee171869a26087aa54b4214b6e94",
+      "generated_hash": "13442700ba62845ded07bc8dbb4753ad76f03d839a24ac60bb1d269f9de3edf8"
     },
     {
       "name": "postmortem",
@@ -555,8 +555,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "db1f499ecbeef631e579117df746e319ef15840ac41c28cd65248bdfde4069d0",
-      "generated_hash": "09fe5c875800bd1ebbe86b8b8a586492e62062f743037f24d5b65782e1463a8d"
+      "source_hash": "d15e26926e5f9e91a222ed53f8fba5cd01d13b47fdf7664fb2ea1a33dd2cebe3",
+      "generated_hash": "fbe0cfd52384650ebb4fc2de73bb09afb1feef3570ba53fae1043714b09280ac"
     },
     {
       "name": "sbh",

--- a/skills-codex/plan/.agentops-generated.json
+++ b/skills-codex/plan/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/plan",
   "layout": "modular",
-  "source_hash": "1daf1e1217f13de0dcec04c630823cbd8f99be89109071d204b0c8622b359b4c",
-  "generated_hash": "df6fbe2aa4c8d76178aeda56d99ef2f1eec857ee50c8c4a9c3c2ec3499bebce6"
+  "source_hash": "cac2270ad512a4a98545188d4d0226cb20b7ee171869a26087aa54b4214b6e94",
+  "generated_hash": "13442700ba62845ded07bc8dbb4753ad76f03d839a24ac60bb1d269f9de3edf8"
 }

--- a/skills-codex/plan/SKILL.md
+++ b/skills-codex/plan/SKILL.md
@@ -13,9 +13,12 @@ and hash the same source. Do not make the model restate those facts in a packet.
 ## Workflow
 
 1. Resolve the intent source and choose one active behavior. When that source
-   is not already durable, have the runtime pass its exact bytes to
-   `python3 skills/validate/scripts/validate.py snapshot-intent --source -` and
-   use the returned `intent_ref` for later phases.
+   is not already durable, have the runtime pass its exact bytes to the
+   validate skill's `scripts/validate.py snapshot-intent --source -`, resolved
+   relative to wherever that skill package is installed (a repo checkout:
+   `skills/validate/scripts/validate.py`; an installed skill package:
+   `.agents/skills/validate/scripts/validate.py`), and use the returned
+   `intent_ref` for later phases.
 2. Route the work by type (see **Ground-truth routing**) and name its ground
    truth first. Then inspect only enough real context to make paths, interfaces,
    and evidence concrete. Existing research and specialist skills are advisory

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "db1f499ecbeef631e579117df746e319ef15840ac41c28cd65248bdfde4069d0",
-  "generated_hash": "09fe5c875800bd1ebbe86b8b8a586492e62062f743037f24d5b65782e1463a8d"
+  "source_hash": "d15e26926e5f9e91a222ed53f8fba5cd01d13b47fdf7664fb2ea1a33dd2cebe3",
+  "generated_hash": "fbe0cfd52384650ebb4fc2de73bb09afb1feef3570ba53fae1043714b09280ac"
 }

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -83,11 +83,13 @@ run — report `NOT_BUILT` when no implementation subject exists yet;
 when a subject already exists, stop and report its current status without
 dispatching further lanes. Neither breaker dispatches a repair revision. An
 orchestration without a declared envelope does not converge; it accretes
-lanes. The 2026-07-15
-heal-skill fold ran three intent revisions
-(`.agents/ao/intents/sha256/26a4f2be...eb48` lineage) and a `NOT_PROVEN` then
-PASS verdict pair (`.agents/ao/verdicts/sha256/b6e759dd...cb6a`,
-`e9b6cdb8...37b9`) before an enforced two-stop checkpoint ended the wave.
+lanes. For example, a plan that keeps failing acceptance on the same criterion
+might tempt three intent revisions in a row
+(`.agents/ao/intents/sha256/<rev1>...` superseded by `<rev2>...` superseded by
+`<rev3>...`) chasing a `NOT_PROVEN` then a second `NOT_PROVEN`
+(`.agents/ao/verdicts/sha256/<verdict1>...`, `<verdict2>...`) — the declared
+envelope's two-stop checkpoint ends the wave there instead of dispatching a
+third attempt.
 
 Delegate with minimal context: a lane receives the frozen intent reference and
 the established facts it needs, never the orchestrator's full conversation
@@ -122,10 +124,30 @@ RPI has one required report surface and one optional representation:
 
 1. **Interactive response:** return the result to the caller in natural
    language. This is the default assistant response.
-2. **Machine artifact:** return or persist the exact
-   [`rpi-report.v1`](../../schemas/rpi-report.v1.schema.json) object only when
-   the caller requests machine-readable evidence or a declared adapter consumes
-   it.
+2. **Machine artifact:** return or persist the exact `rpi-report.v1` object
+   only when the caller requests machine-readable evidence or a declared
+   adapter consumes it. The schema ships in a repo checkout at
+   `schemas/rpi-report.v1.schema.json`; the minimal required shape is:
+
+   ```json
+   {
+     "schema_version": "rpi-report.v1",
+     "status": "PASS",
+     "intent_ref": ".agents/ao/intents/sha256/<64-hex-digest>.intent",
+     "acceptance_digest": "<64-hex-char-sha256-or-null>",
+     "subject_manifest_digest": "<64-hex-char-sha256-or-null>",
+     "verdict_ref": "<verdict-location-or-null>",
+     "verdict_digest": "<64-hex-char-sha256-or-null>",
+     "checked": ["<criterion satisfied by evidence>"],
+     "not_checked": ["<criterion not covered>"]
+   }
+   ```
+
+   `status` is one of `PASS | FAIL | NOT_PROVEN | NOT_PLANNED | NOT_BUILT`; the
+   three digest fields, when present, are 64-character lowercase hex SHA-256
+   strings; `checked` and `not_checked` are arrays of strings. All nine keys
+   are required (use `null` for an inapplicable ref or digest), and no
+   additional properties are allowed.
 
 Lead the interactive response with the status and one sentence stating the
 caller-visible outcome. Lead with the subject, not the process: production

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -32,9 +32,12 @@ and hash the same source. Do not make the model restate those facts in a packet.
 ## Workflow
 
 1. Resolve the intent source and choose one active behavior. When that source
-   is not already durable, have the runtime pass its exact bytes to
-   `python3 skills/validate/scripts/validate.py snapshot-intent --source -` and
-   use the returned `intent_ref` for later phases.
+   is not already durable, have the runtime pass its exact bytes to the
+   validate skill's `scripts/validate.py snapshot-intent --source -`, resolved
+   relative to wherever that skill package is installed (a repo checkout:
+   `skills/validate/scripts/validate.py`; an installed skill package:
+   `.agents/skills/validate/scripts/validate.py`), and use the returned
+   `intent_ref` for later phases.
 2. Route the work by type (see **Ground-truth routing**) and name its ground
    truth first. Then inspect only enough real context to make paths, interfaces,
    and evidence concrete. Existing research and specialist skills are advisory

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -113,11 +113,13 @@ run — report `NOT_BUILT` when no implementation subject exists yet;
 when a subject already exists, stop and report its current status without
 dispatching further lanes. Neither breaker dispatches a repair revision. An
 orchestration without a declared envelope does not converge; it accretes
-lanes. The 2026-07-15
-heal-skill fold ran three intent revisions
-(`.agents/ao/intents/sha256/26a4f2be...eb48` lineage) and a `NOT_PROVEN` then
-PASS verdict pair (`.agents/ao/verdicts/sha256/b6e759dd...cb6a`,
-`e9b6cdb8...37b9`) before an enforced two-stop checkpoint ended the wave.
+lanes. For example, a plan that keeps failing acceptance on the same criterion
+might tempt three intent revisions in a row
+(`.agents/ao/intents/sha256/<rev1>...` superseded by `<rev2>...` superseded by
+`<rev3>...`) chasing a `NOT_PROVEN` then a second `NOT_PROVEN`
+(`.agents/ao/verdicts/sha256/<verdict1>...`, `<verdict2>...`) — the declared
+envelope's two-stop checkpoint ends the wave there instead of dispatching a
+third attempt.
 
 Delegate with minimal context: a lane receives the frozen intent reference and
 the established facts it needs, never the orchestrator's full conversation
@@ -152,10 +154,30 @@ RPI has one required report surface and one optional representation:
 
 1. **Interactive response:** return the result to the caller in natural
    language. This is the default assistant response.
-2. **Machine artifact:** return or persist the exact
-   [`rpi-report.v1`](../../schemas/rpi-report.v1.schema.json) object only when
-   the caller requests machine-readable evidence or a declared adapter consumes
-   it.
+2. **Machine artifact:** return or persist the exact `rpi-report.v1` object
+   only when the caller requests machine-readable evidence or a declared
+   adapter consumes it. The schema ships in a repo checkout at
+   `schemas/rpi-report.v1.schema.json`; the minimal required shape is:
+
+   ```json
+   {
+     "schema_version": "rpi-report.v1",
+     "status": "PASS",
+     "intent_ref": ".agents/ao/intents/sha256/<64-hex-digest>.intent",
+     "acceptance_digest": "<64-hex-char-sha256-or-null>",
+     "subject_manifest_digest": "<64-hex-char-sha256-or-null>",
+     "verdict_ref": "<verdict-location-or-null>",
+     "verdict_digest": "<64-hex-char-sha256-or-null>",
+     "checked": ["<criterion satisfied by evidence>"],
+     "not_checked": ["<criterion not covered>"]
+   }
+   ```
+
+   `status` is one of `PASS | FAIL | NOT_PROVEN | NOT_PLANNED | NOT_BUILT`; the
+   three digest fields, when present, are 64-character lowercase hex SHA-256
+   strings; `checked` and `not_checked` are arrays of strings. All nine keys
+   are required (use `null` for an inapplicable ref or digest), and no
+   additional properties are allowed.
 
 Lead the interactive response with the status and one sentence stating the
 caller-visible outcome. Lead with the subject, not the process: production


### PR DESCRIPTION
## Summary

Fresh-install smoke testing found four commands/links in skills and CLI help that fail verbatim for an installed user (only `skills/**` — not the full repo tree — ships to an install; `.agents/skills/**` is the installed skill root).

| # | Defect | Fix | Verified |
|---|---|---|---|
| 1 | `skills/plan/SKILL.md` step 1 told the runtime to run `python3 skills/validate/scripts/validate.py snapshot-intent ...` — a checkout-only path. In an installed tree the real path is `.agents/skills/validate/scripts/validate.py`. | Reworded to name both paths explicitly (checkout: `skills/validate/scripts/validate.py`; installed: `.agents/skills/validate/scripts/validate.py`), install-agnostic. | Copied `skills/{validate,plan,rpi}` into a scratch `.agents/skills/` layout and ran `echo '{"foo":"bar"}' \| python3 .agents/skills/validate/scripts/validate.py snapshot-intent --source -` verbatim — produced a valid `intent_ref`. Re-ran the checkout-relative form too. |
| 2 | `skills/rpi/SKILL.md` linked `../../schemas/rpi-report.v1.schema.json` — `schemas/` isn't shipped to installs, so the link 404s for an installed user. | Inlined the minimal required `rpi-report.v1` shape as a fenced JSON block (with field semantics), plus a note that the schema itself ships in a repo checkout. No new files added to the skill package. | Validated the exact inlined shape (with a concrete instance) against `schemas/rpi-report.v1.schema.json` via `jsonschema.validate()` — passes. Confirmed all 9 required keys and digest patterns match the real schema. |
| 3 | `skills/rpi/SKILL.md`'s continuation-envelope example (~lines 115-121) cited this repo's own internal 2026-07-15 intent/verdict digests (`26a4f2be...eb48`, `b6e759dd...cb6a`, etc.) as a normative example — not reproducible by an installed user. | Replaced with a generic, self-contained example (placeholder revisions/verdicts) that illustrates the same two-stop-checkpoint behavior without citing this repo's private history. | Reviewed the replaced prose reads correctly in context; `bash tests/skills/run-all.sh` still passes (no broken frontmatter/budget). |
| 4 | `ao --help` root epilog (`cli/cmd/ao/root.go`) pointed at `docs/MIGRATION.md`, a relative path that doesn't exist for a user who only has the `ao` binary (no `docs/` directory ships with it). | Changed the epilog to the GitHub blob URL (`https://github.com/boshu2/agentops/blob/main/docs/MIGRATION.md`), with a note that a repo checkout also has it locally at `docs/MIGRATION.md`. Left the internal `removedCommandHint()` machinery (and its `docs/MIGRATION.md`-literal test assertions) untouched — that's a separate, heavily-tested mechanism not covered by this defect. | `go run ./cmd/ao --help` shows the new URL. Confirmed `boshu2/agentops` is the correct remote and `docs/MIGRATION.md` exists at that path on `main`. |

## Process / regen

- `scripts/codex-sync.sh --only plan`, `--only rpi`
- `scripts/regen-codex-hashes.sh --only plan`, `--only rpi`
- `python3 scripts/generate-skill-mesh.py`
- `scripts/generate-cli-reference.sh` (no diff — root epilog text isn't captured in `COMMANDS.md`)
- `scripts/regen-all.sh --check` — all projections current

## Test plan

- [x] `cd cli && go build ./...` — success
- [x] `cd cli && go vet ./...` — no issues
- [x] `cd cli && go test ./...` — 2923 passed, 0 failed, 73 packages
- [x] `bash tests/skills/run-all.sh` — 54/54 skills pass, 0 failed
- [x] Simulated install (`.agents/skills/...`) and ran the exact documented `validate.py snapshot-intent` command verbatim — works
- [x] Validated the inlined `rpi-report.v1` JSON shape against the real schema with `jsonschema.validate()`
- [x] `go run ./cmd/ao --help` shows the corrected epilog

Write scope respected: `skills/plan/SKILL.md`, `skills/rpi/SKILL.md`, `cli/cmd/ao/root.go` (help text only), and regenerated projections (`skills-codex/**`, `images/gemini/skills/**`). No changes to `skills/validate/**`, `CLAUDE.md`, `AGENTS.md`, `cli/internal/gates/**`, or `cli/internal/doctor/**`.