### PR TITLE
fix(cli): four fresh-install defects in gate check, doctor, and init

### DIFF
--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -37,7 +37,7 @@ ao demo [flags]
 
 ### `ao init`
 
-Create local evidence and verdict directories. This command does not
+Create local evidence and verdict directories, then add one commented,
 
 ```
 ao init [flags]

--- a/cli/internal/adapters/doctor/legacy.go
+++ b/cli/internal/adapters/doctor/legacy.go
@@ -85,14 +85,20 @@ func CheckSkillLinks(repoRoot, home string) quality.Check {
 	}
 	if repoRoot == "" {
 		portable := filepath.Join(home, ".agents", "skills")
-		live, broken := countLiveSkillLinks(portable)
-		if broken > 0 {
+		counts := countLiveSkillLinks(portable)
+		if counts.Broken > 0 {
 			check.Status = quality.StatusWarn
-			check.Detail = fmt.Sprintf("%d live portable skill link(s), %d broken; run from the AgentOps checkout and inspect `ao skills link --dry-run`", live, broken)
+			// Installed-user audience: no agentops checkout exists here, so the
+			// remedy must be performable from where the reader stands. `ao skills
+			// link` is checkout-only (it resolves the repo's skills/ dir and fails
+			// closed outside it), so naming it here was advice the reader could not
+			// take. Removing the dead links is the whole fix; reinstalling restores
+			// them from whichever install method placed them.
+			check.Detail = fmt.Sprintf("%d live portable skill link(s), %d dangling (target no longer exists) under %s; remove the dangling link(s), then reinstall skills the way you installed them (plugin, brew, or npx)", counts.Live, counts.Broken, portable)
 			return check
 		}
 		check.Status = quality.StatusInfo
-		check.Detail = fmt.Sprintf("%d live portable skill link(s); exact source identity is checked from an AgentOps checkout", live)
+		check.Detail = fmt.Sprintf("%d live portable skill link(s); exact source identity is checked from an AgentOps checkout", counts.Live)
 		return check
 	}
 
@@ -198,10 +204,38 @@ func staleLinksToSource(dest, source string, canonical []string) int {
 	return stale
 }
 
-func countLiveSkillLinks(dir string) (live, broken int) {
+// skillLinkCounts is the tri-state census of a portable skill root. The three
+// buckets are deliberately distinct because they have three different remedies.
+type skillLinkCounts struct {
+	// Live is a symlink that resolves to a directory containing SKILL.md — a
+	// working skill.
+	Live int
+	// Broken is a DANGLING symlink: the target path does not exist. This is the
+	// only condition doctor reports as broken, and it is exactly what
+	// `find -L <root> -maxdepth 1 -type l` prints.
+	Broken int
+	// Foreign is a symlink that RESOLVES fine but does not name a skill package
+	// (no SKILL.md — e.g. a link to a shared reference dir, or to a file). It is
+	// not broken: nothing is dangling and nothing needs repair. Counting it as
+	// broken is the overcount this type exists to prevent — doctor reported
+	// "2 broken" while a dangling-symlink sweep of the same tree found none.
+	Foreign int
+}
+
+// countLiveSkillLinks censuses the symlinks directly under dir.
+//
+// "Broken" means dangling, and only dangling. The previous implementation
+// derived brokenness from a single os.Stat(<link>/SKILL.md) probe, which fails
+// for three unrelated reasons — the link dangles, the link resolves to
+// something that is not a skill package, or the target directory is
+// unreadable — and reported all three as broken. Non-symlink entries (a real
+// directory installed by a plugin or copied in by hand) are not links and are
+// counted in no bucket.
+func countLiveSkillLinks(dir string) skillLinkCounts {
+	var counts skillLinkCounts
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return 0, 0
+		return counts
 	}
 	for _, entry := range entries {
 		path := filepath.Join(dir, entry.Name())
@@ -209,13 +243,18 @@ func countLiveSkillLinks(dir string) (live, broken int) {
 		if err != nil || info.Mode()&os.ModeSymlink == 0 {
 			continue
 		}
-		if _, err := os.Stat(filepath.Join(path, "SKILL.md")); err != nil {
-			broken++
-		} else {
-			live++
+		// os.Stat follows the link: an error here is the link failing to resolve.
+		if _, err := os.Stat(path); err != nil {
+			counts.Broken++
+			continue
 		}
+		if _, err := os.Stat(filepath.Join(path, "SKILL.md")); err != nil {
+			counts.Foreign++
+			continue
+		}
+		counts.Live++
 	}
-	return live, broken
+	return counts
 }
 
 const agentopsModuleLine = "module github.com/boshu2/agentops/cli"

--- a/cli/internal/adapters/doctor/legacy_test.go
+++ b/cli/internal/adapters/doctor/legacy_test.go
@@ -232,6 +232,158 @@ func TestCheckSkillLinksExactMissingAndStale(t *testing.T) {
 	}
 }
 
+// checkoutOnlyCommands are commands an installed user cannot run: `ao skills
+// link` resolves the repository's own skills/ directory and fails closed
+// outside a checkout, so naming it to a reader who has no checkout is advice
+// they cannot take. Observed live: doctor told an installed user to "run from
+// the AgentOps checkout and inspect `ao skills link --dry-run`".
+var checkoutOnlyCommands = []string{"ao skills link", "ao skills unlink", "from the AgentOps checkout", "from the repo checkout"}
+
+// TestCheckSkillLinks_InstalledUserAdviceIsActionable is the acceptance for the
+// audience defect: outside any agentops checkout, the Skill Links check may not
+// tell the reader to do something only a checkout owner can do. It must name
+// the affected root and a remedy performable from where the reader stands.
+func TestCheckSkillLinks_InstalledUserAdviceIsActionable(t *testing.T) {
+	home := t.TempDir()
+	portable := filepath.Join(home, ".agents", "skills")
+	if err := os.MkdirAll(portable, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A dangling link: the target was deleted (a skill retired upstream).
+	if err := os.Symlink(filepath.Join(t.TempDir(), "gone"), filepath.Join(portable, "retired")); err != nil {
+		t.Fatal(err)
+	}
+
+	check := CheckSkillLinks("", home)
+	if check.Status != quality.StatusWarn {
+		t.Fatalf("dangling portable link status = %q, want warn (%+v)", check.Status, check)
+	}
+	for _, banned := range checkoutOnlyCommands {
+		if strings.Contains(check.Detail, banned) {
+			t.Errorf("installed-user detail names checkout-only advice %q: %s", banned, check.Detail)
+		}
+		if strings.Contains(check.Fix, banned) {
+			t.Errorf("installed-user fix names checkout-only advice %q: %s", banned, check.Fix)
+		}
+	}
+	if !strings.Contains(check.Detail, "1 dangling") {
+		t.Errorf("detail does not report the dangling count: %s", check.Detail)
+	}
+	if !strings.Contains(check.Detail, portable) {
+		t.Errorf("detail does not name the affected root %s: %s", portable, check.Detail)
+	}
+	if !strings.Contains(check.Detail, "reinstall") {
+		t.Errorf("detail offers no remedy the reader can perform: %s", check.Detail)
+	}
+}
+
+// TestCountLiveSkillLinks_BrokenMeansDanglingOnly pins the semantics of
+// "broken" after the overcount fix: broken == the symlink does not resolve,
+// exactly what `find -L <root> -maxdepth 1 -type l` prints. The previous
+// implementation derived brokenness from a single stat of <link>/SKILL.md,
+// which also failed for links that resolve perfectly well but do not name a
+// skill package — so doctor could report "N broken" while a dangling-symlink
+// sweep of the same tree found fewer, or none.
+func TestCountLiveSkillLinks_BrokenMeansDanglingOnly(t *testing.T) {
+	source := t.TempDir()
+	root := t.TempDir()
+
+	mkSkill := func(name string) string {
+		dir := filepath.Join(source, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# "+name+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return dir
+	}
+	link := func(target, name string) {
+		if err := os.Symlink(target, filepath.Join(root, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Live: resolves to a directory holding SKILL.md.
+	link(mkSkill("plan"), "plan")
+	link(mkSkill("validate"), "validate")
+	// Dangling: target does not exist. The ONLY broken condition.
+	link(filepath.Join(source, "deleted-upstream"), "retired")
+	// Foreign: resolves fine, but is not a skill package. Nothing to repair —
+	// counting this as broken is the overcount under test.
+	sharedDir := filepath.Join(source, "shared")
+	if err := os.MkdirAll(sharedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link(sharedDir, "shared")
+	// Foreign: a link to a regular FILE. <link>/SKILL.md cannot stat, but the
+	// link resolves — also not broken.
+	regular := filepath.Join(source, "notes.md")
+	if err := os.WriteFile(regular, []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link(regular, "notes.md")
+	// Not a link at all: a real directory (a plugin copy). Counted nowhere.
+	if err := os.MkdirAll(filepath.Join(root, "copied"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := countLiveSkillLinks(root)
+	want := skillLinkCounts{Live: 2, Broken: 1, Foreign: 2}
+	if got != want {
+		t.Fatalf("countLiveSkillLinks = %+v, want %+v", got, want)
+	}
+}
+
+// TestCountLiveSkillLinks_AgreesWithDanglingSweep is the cross-check that
+// closes the reported contradiction ("doctor says 2 broken, find says 0
+// dangling"): the Broken count must equal an independent dangling-symlink
+// sweep of the same directory, computed here without touching production code.
+func TestCountLiveSkillLinks_AgreesWithDanglingSweep(t *testing.T) {
+	source := t.TempDir()
+	root := t.TempDir()
+	skill := filepath.Join(source, "plan")
+	if err := os.MkdirAll(skill, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skill, "SKILL.md"), []byte("# plan\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	shared := filepath.Join(source, "shared")
+	if err := os.MkdirAll(shared, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for target, name := range map[string]string{
+		skill:                            "plan",
+		shared:                           "shared",
+		filepath.Join(source, "vanished"): "vanished",
+	} {
+		if err := os.Symlink(target, filepath.Join(root, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dangling := 0
+	for _, entry := range entries {
+		path := filepath.Join(root, entry.Name())
+		info, lerr := os.Lstat(path)
+		if lerr != nil || info.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+		if _, serr := os.Stat(path); serr != nil {
+			dangling++
+		}
+	}
+
+	if got := countLiveSkillLinks(root).Broken; got != dangling {
+		t.Fatalf("doctor Broken = %d but the dangling sweep found %d", got, dangling)
+	}
+}
+
 func TestBinaryFreshnessCheck(t *testing.T) {
 	root := makeFakeAgentopsRepo(t, "9.9.9")
 	if check := BinaryFreshnessCheck(filepath.Join(root, "cli", "cmd"), "9.9.9"); check.Status != "pass" {

--- a/cli/internal/commands/init/module.go
+++ b/cli/internal/commands/init/module.go
@@ -46,8 +46,22 @@ func (m Module) Command() *cobra.Command {
 	return &cobra.Command{
 		Use:   "init",
 		Short: "Create local AgentOps evidence directories",
-		Long: `Create local evidence and verdict directories. This command does not
-initialize Git, edit ignore files, install hooks, select work, or start a runtime.`,
+		Long: `Create local evidence and verdict directories, then add one commented,
+marker-delimited block to this directory's .gitignore (creating the file if it
+does not exist). The block ignores only machine-local scratch the loop writes:
+
+  .agents/ao/index/       derived search index
+  .agents/ao/sessions/    local session transcripts
+  .agents/ao/provenance/  machine-local provenance ledger
+  __pycache__/            Python bytecode caches
+
+It deliberately does NOT ignore .agents/ao/intents/ or .agents/ao/verdicts/:
+whether loop evidence belongs in version control is your repository's policy,
+not this CLI's. Delete the block to track everything.
+
+Running init again is safe — the block is appended once and never duplicated,
+and an edited block is left alone. This command does not initialize Git,
+install hooks, select work, or start a runtime.`,
 		Args:    cobra.NoArgs,
 		GroupID: "start",
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cli/internal/commands/init/module_test.go
+++ b/cli/internal/commands/init/module_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/boshu2/agentops/cli/internal/clicontract"
+	"github.com/boshu2/agentops/cli/internal/initapp"
 )
 
 func newTestModule(dryRun bool) Module {
@@ -56,8 +57,58 @@ func TestInitCreatesEvidenceStorageWithoutGitMutation(t *testing.T) {
 			t.Fatalf("missing %s: %v", relative, err)
 		}
 	}
-	if _, err := os.Stat(filepath.Join(dir, ".gitignore")); !os.IsNotExist(err) {
-		t.Fatal("init must not edit Git ignore state")
+	// The ignore block is the ONLY Git-adjacent effect: no repository is
+	// initialized, no hook installed, no index touched.
+	if _, err := os.Stat(filepath.Join(dir, ".git")); !os.IsNotExist(err) {
+		t.Fatalf("init initialized a Git repository (stat err=%v)", err)
+	}
+}
+
+// TestInitAppendsGitignoreBlockExactlyOnce is the L2 acceptance for the
+// no-ignore-guidance defect, driven through the command entry point: running
+// `ao init` twice in a fresh directory leaves the managed block present exactly
+// once. Before this, init scaffolded .agents/ao/** and left the user to invent
+// the same ignore rules by hand after their first loop.
+func TestInitAppendsGitignoreBlockExactlyOnce(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	runInit := func() string {
+		t.Helper()
+		var output bytes.Buffer
+		command := newTestModule(false).Command()
+		command.SetOut(&output)
+		command.SetArgs(nil)
+		if err := command.Execute(); err != nil {
+			t.Fatalf("ao init: %v", err)
+		}
+		return output.String()
+	}
+
+	runInit()
+	runInit()
+
+	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	body := string(data)
+	if got := strings.Count(body, initapp.GitignoreBeginMarker); got != 1 {
+		t.Fatalf("AgentOps block appears %d times after two inits, want 1:\n%s", got, body)
+	}
+	if !strings.Contains(body, ".agents/ao/sessions/") {
+		t.Fatalf(".gitignore is missing the scratch patterns:\n%s", body)
+	}
+}
+
+// TestInitHelpDocumentsTheIgnorePolicy: the policy is only usable if the
+// command says what it ignores and what it deliberately leaves trackable.
+func TestInitHelpDocumentsTheIgnorePolicy(t *testing.T) {
+	long := newTestModule(false).Command().Long
+	for _, want := range []string{".gitignore", ".agents/ao/sessions/", ".agents/ao/intents/", ".agents/ao/verdicts/"} {
+		if !strings.Contains(long, want) {
+			t.Errorf("init help does not document %q:\n%s", want, long)
+		}
 	}
 }
 

--- a/cli/internal/gates/changedfiles.go
+++ b/cli/internal/gates/changedfiles.go
@@ -2,6 +2,7 @@ package gates
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -103,6 +104,29 @@ func ValidateRangeSpec(spec string) error {
 	return nil
 }
 
+// ErrUnbornHead is the sentinel returned when a scope needs a commit to
+// compare against but the repository has none yet (an "unborn HEAD": `git
+// init` with no commit, or a fresh orphan branch). Without it the caller sees
+// git's raw plumbing failure — "git show --name-only --pretty=format: HEAD:
+// exit status 128" — which reads as a broken tool rather than the ordinary,
+// self-inflicted state it is. Callers match with errors.Is.
+var ErrUnbornHead = errors.New("no commits yet (unborn HEAD)")
+
+// scopeNeedsHead reports whether a scope's git invocation resolves HEAD and so
+// cannot work before the first commit. `staged` is deliberately excluded: `git
+// diff --cached` compares the index against the empty tree when HEAD is
+// unborn, which is exactly the pre-first-commit escape hatch the friendly
+// message points at.
+func scopeNeedsHead(scope Scope) bool {
+	switch scope {
+	case ScopeHead, ScopeWorktree, ScopeUpstream:
+		return true
+	default:
+		_, isRange := ScopeRange(scope)
+		return isRange
+	}
+}
+
 // ChangedFilesPort reports the set of changed files (repo-relative, deduped)
 // for a scope.
 type ChangedFilesPort interface {
@@ -146,9 +170,35 @@ func (g *GitChangedFiles) Changed(ctx context.Context, scope Scope) ([]string, e
 	}
 	out, err := g.exec(ctx, args...)
 	if err != nil {
+		if unborn := g.unbornHeadError(ctx, scope); unborn != nil {
+			return nil, unborn
+		}
 		return nil, err
 	}
 	return dedupeLines(out), nil
+}
+
+// unbornHeadError translates a failed change-set computation into the friendly
+// ErrUnbornHead message when — and only when — the cause really is "this repo
+// has no commits yet". It runs only on the failure path, so the happy path
+// keeps its single git invocation.
+//
+// Both probes matter. `rev-parse --git-dir` separates "not a git repository at
+// all" (keep git's own error; the remedy is different) from "a repository
+// without commits". `rev-parse --verify HEAD` then confirms HEAD is
+// unresolvable rather than the scope's revision being bad (e.g. a range whose
+// base does not exist), which must keep its own error too.
+func (g *GitChangedFiles) unbornHeadError(ctx context.Context, scope Scope) error {
+	if !scopeNeedsHead(scope) {
+		return nil
+	}
+	if _, err := g.exec(ctx, "rev-parse", "--git-dir"); err != nil {
+		return nil
+	}
+	if _, err := g.exec(ctx, "rev-parse", "--verify", "HEAD"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w: scope %q needs a commit to compare against — make an initial commit, or run with an explicit scope such as --scope staged after 'git add'", ErrUnbornHead, scope)
 }
 
 // scopeArgs maps a Scope to its git diff arguments.

--- a/cli/internal/gates/changedfiles_test.go
+++ b/cli/internal/gates/changedfiles_test.go
@@ -2,6 +2,7 @@ package gates
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -217,6 +218,110 @@ func TestGitChangedFiles_PollutedGitDirResolvesCorrectRepo(t *testing.T) {
 	want := []string{"correct_file.go"}
 	if !equalSet(got, want) {
 		t.Fatalf("polluted GIT_DIR routed changed-set to %v, want %v (from cmd.Dir repo)", got, want)
+	}
+}
+
+// initRepoNoCommits builds a temp git repository with an unborn HEAD: `git
+// init` ran, a file exists and may even be staged, but no commit was ever
+// made. This is the state of every repository between `git init` and the first
+// commit — the state a brand-new user of the CLI is in.
+func initRepoNoCommits(t *testing.T, stage bool) string {
+	t.Helper()
+	root := t.TempDir()
+	run := func(args ...string) {
+		c := exec.Command("git", args...)
+		c.Dir = root
+		c.Env = append(os.Environ(),
+			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com")
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if stage {
+		run("add", "-A")
+	}
+	return root
+}
+
+// TestGitChangedFiles_UnbornHeadReportsFriendlyError is the acceptance for the
+// zero-commit crash: `ao gate check` in a freshly `git init`ed repo died with
+// the raw plumbing failure "git show --name-only --pretty=format: HEAD: exit
+// status 128", which reads as a broken tool rather than the ordinary state it
+// is. Every HEAD-resolving scope must instead return ErrUnbornHead with a
+// remedy, leaking no git exit status.
+func TestGitChangedFiles_UnbornHeadReportsFriendlyError(t *testing.T) {
+	root := initRepoNoCommits(t, false)
+	g := NewGitChangedFiles(root)
+
+	for _, scope := range []Scope{ScopeHead, ScopeWorktree, ScopeUpstream, Scope(ScopeRangePrefix + "HEAD~1..HEAD")} {
+		t.Run(string(scope), func(t *testing.T) {
+			_, err := g.Changed(context.Background(), scope)
+			if err == nil {
+				t.Fatalf("Changed(%q) on an unborn HEAD returned no error", scope)
+			}
+			if !errors.Is(err, ErrUnbornHead) {
+				t.Fatalf("Changed(%q) err = %v, want errors.Is ErrUnbornHead", scope, err)
+			}
+			for _, banned := range []string{"exit status", "--pretty=format"} {
+				if strings.Contains(err.Error(), banned) {
+					t.Errorf("Changed(%q) message leaks raw git plumbing %q: %v", scope, banned, err)
+				}
+			}
+			for _, want := range []string{"no commits yet", "initial commit", "--scope staged"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("Changed(%q) message missing %q: %v", scope, want, err)
+				}
+			}
+		})
+	}
+}
+
+// TestGitChangedFiles_UnbornHeadStagedScopeWorks pins the escape hatch the
+// friendly message advertises: `--scope staged` compares the index against the
+// empty tree and works before the first commit. A message pointing at a scope
+// that also failed would be worse than the raw error.
+func TestGitChangedFiles_UnbornHeadStagedScopeWorks(t *testing.T) {
+	root := initRepoNoCommits(t, true)
+	got, err := NewGitChangedFiles(root).Changed(context.Background(), ScopeStaged)
+	if err != nil {
+		t.Fatalf("Changed(staged) on an unborn HEAD: %v", err)
+	}
+	if !equalSet(got, []string{"README.md"}) {
+		t.Fatalf("Changed(staged) = %v, want [README.md]", got)
+	}
+}
+
+// TestGitChangedFiles_NonRepoKeepsGitError is the negative witness for the
+// unborn-HEAD translation: outside a git repository the cause is different and
+// so is the remedy, so git's own error must survive rather than be relabelled
+// "no commits yet".
+func TestGitChangedFiles_NonRepoKeepsGitError(t *testing.T) {
+	_, err := NewGitChangedFiles(t.TempDir()).Changed(context.Background(), ScopeHead)
+	if err == nil {
+		t.Fatal("Changed outside a git repo returned no error")
+	}
+	if errors.Is(err, ErrUnbornHead) {
+		t.Fatalf("non-repo error was mislabelled as an unborn HEAD: %v", err)
+	}
+}
+
+// TestGitChangedFiles_BadRangeBaseKeepsGitError is the second negative witness:
+// in a repo WITH commits, a range naming a revision that does not exist is a
+// bad-scope error, not an unborn HEAD.
+func TestGitChangedFiles_BadRangeBaseKeepsGitError(t *testing.T) {
+	root, _, _, c2 := gitCommits(t)
+	_, err := NewGitChangedFiles(root).Changed(context.Background(), Scope(ScopeRangePrefix+"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef.."+c2))
+	if err == nil {
+		t.Fatal("Changed with a nonexistent range base returned no error")
+	}
+	if errors.Is(err, ErrUnbornHead) {
+		t.Fatalf("bad-range error was mislabelled as an unborn HEAD: %v", err)
 	}
 }
 

--- a/cli/internal/gates/checks/native_inline.go
+++ b/cli/internal/gates/checks/native_inline.go
@@ -16,14 +16,26 @@ import (
 // Native ports of the bash gate's INLINE checks (no backing script). ag-3n71 PB1.
 
 func init() {
-	gates.Register(gates.Check{ID: "go.vet", Tiers: gates.Fast | gates.Full, Match: []string{"cli/**", "go.mod", "go.sum"}, Blocking: true, Run: runGoVet})
-	gates.Register(gates.Check{ID: "changelog.sync", Tiers: gates.Fast | gates.Full, Match: []string{"CHANGELOG.md", "docs/CHANGELOG.md"}, Blocking: true, Run: runChangelogSync})
-	gates.Register(gates.Check{ID: "shell.shellcheck-changed", Tiers: gates.Fast | gates.Full, Match: []string{"**/*.sh"}, Blocking: true, Run: runShellcheckChanged})
-	gates.Register(gates.Check{ID: "learning.coherence", Tiers: gates.Fast | gates.Full, Match: learningRootGlobs, Blocking: true, Run: runLearningCoherence})
+	// Every native check carries an explicit RepairHint phrased as something the
+	// reader can do from wherever they are. The derived fallback names the gate
+	// ID and the published docs; neither form may name a path that exists only
+	// inside an agentops source checkout.
+	gates.Register(gates.Check{ID: "go.vet", Tiers: gates.Fast | gates.Full, Match: []string{"cli/**", "go.mod", "go.sum"}, Blocking: true, Run: runGoVet,
+		RepairHint: "run 'go vet ./...' in the cli module and fix what it reports"})
+	gates.Register(gates.Check{ID: "changelog.sync", Tiers: gates.Fast | gates.Full, Match: []string{"CHANGELOG.md", "docs/CHANGELOG.md"}, Blocking: true, Run: runChangelogSync,
+		RepairHint: "make the two changelog copies identical: cp CHANGELOG.md docs/CHANGELOG.md"})
+	gates.Register(gates.Check{ID: "shell.shellcheck-changed", Tiers: gates.Fast | gates.Full, Match: []string{"**/*.sh"}, Blocking: true, Run: runShellcheckChanged,
+		RepairHint: "run 'shellcheck -S warning <file>' on each reported shell file and fix the warnings (install shellcheck if it is missing)"})
+	gates.Register(gates.Check{ID: "learning.coherence", Tiers: gates.Fast | gates.Full, Match: learningRootGlobs, Blocking: true, Run: runLearningCoherence,
+		RepairHint: "give each reported learning file YAML frontmatter: a leading '---' line at the top"})
 }
 
 // changedFilesFor returns the routed change set, falling back to the diff vs
 // origin/main when the orchestrator didn't route (Full mode).
+// The orchestrator already filtered installed skill copies out of
+// rc.ChangedFiles; the origin/main fallback below computes its own set, so it
+// applies the same filter — otherwise a Full-mode run would shellcheck the
+// installed copies the routed path deliberately excluded.
 func changedFilesFor(ctx context.Context, rc gates.RunContext) []string {
 	if len(rc.ChangedFiles) > 0 {
 		return rc.ChangedFiles
@@ -43,7 +55,7 @@ func changedFilesFor(ctx context.Context, rc gates.RunContext) []string {
 			files = append(files, l)
 		}
 	}
-	return files
+	return gates.FilterInstalledSkillCopies(files)
 }
 
 func runGoVet(ctx context.Context, rc gates.RunContext) (ports.GateVerdict, error) {

--- a/cli/internal/gates/checks/native_inline_test.go
+++ b/cli/internal/gates/checks/native_inline_test.go
@@ -193,6 +193,133 @@ func equalSetChecks(a, b []string) bool {
 	return true
 }
 
+// shellcheckTriggeringScript is a shell body shellcheck flags at the gate's
+// own -S warning threshold (SC2164: an unguarded `cd`). SC2086-style quoting
+// findings are only "info" and would not trip the gate.
+const shellcheckTriggeringScript = "#!/usr/bin/env bash\ncd /tmp\n"
+
+// initRepoWithHeadCommit builds a temp git repo whose single HEAD commit adds
+// every path in files (rel -> body), returning the repo root. `--scope head`
+// in it yields exactly those paths — the shape of a user's first commit after
+// installing AgentOps into their own project.
+func initRepoWithHeadCommit(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	run := func(args ...string) {
+		c := exec.Command("git", args...)
+		c.Dir = root
+		c.Env = append(os.Environ(),
+			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com")
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	for rel, body := range files {
+		full := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o755); err != nil { // #nosec G306 -- fixture shell scripts.
+			t.Fatal(err)
+		}
+	}
+	run("add", "-A")
+	run("commit", "-q", "-m", "first commit")
+	return root
+}
+
+// runRealShellGate runs the REAL registered shell.shellcheck-changed check
+// through the real orchestrator against a fixture repo, exactly as `ao gate
+// check` does, and returns the report's exit code.
+func runRealShellGate(t *testing.T, root string) int {
+	t.Helper()
+	registered, ok := gates.Default.Get("shell.shellcheck-changed")
+	if !ok {
+		t.Fatal("shell.shellcheck-changed is not registered")
+	}
+	reg := gates.NewRegistry()
+	if err := reg.Add(registered); err != nil {
+		t.Fatal(err)
+	}
+	report, err := gates.NewOrchestrator(reg, nil, gates.NewGitChangedFiles(root), root).
+		Run(context.Background(), gates.RunOptions{Mode: gates.Fast, Scope: gates.ScopeHead})
+	if err != nil {
+		t.Fatalf("orchestrator Run: %v", err)
+	}
+	return report.ExitCode()
+}
+
+// TestRunShellcheckChanged_SkipsInstalledSkillCopies is the L2 acceptance for
+// the observed fresh-install failure: after `ao init` + a first commit, `ao
+// gate check` FAILED shellcheck on AgentOps' OWN installed skill scripts
+// (.agents/skills/cass/scripts/multi_machine_search.sh matched `**/*.sh`) — a
+// gate the user had no way to repair, on files they did not write. Installed
+// skill copies must not be gated; the user's own shell files still must be.
+func TestRunShellcheckChanged_SkipsInstalledSkillCopies(t *testing.T) {
+	if _, err := exec.LookPath("shellcheck"); err != nil {
+		t.Skip("shellcheck not installed")
+	}
+
+	installedOnly := initRepoWithHeadCommit(t, map[string]string{
+		"README.md": "hello\n",
+		".agents/skills/cass/scripts/multi_machine_search.sh": shellcheckTriggeringScript,
+		".claude/skills/plan/scripts/run.sh":                  shellcheckTriggeringScript,
+	})
+	if got := runRealShellGate(t, installedOnly); got != 0 {
+		t.Fatalf("exit code = %d, want 0 (installed skill copies must not fail a user's gate)", got)
+	}
+
+	// Negative witness: the same bad script under a first-party path still FAILs,
+	// so the exclusion narrows scope rather than defanging the gate.
+	firstParty := initRepoWithHeadCommit(t, map[string]string{
+		"README.md":           "hello\n",
+		"scripts/deploy.sh":   shellcheckTriggeringScript,
+		".agents/skills/x.sh": shellcheckTriggeringScript,
+	})
+	if got := runRealShellGate(t, firstParty); got != 1 {
+		t.Fatalf("exit code = %d, want 1 (a first-party shell file must still fail)", got)
+	}
+}
+
+// TestRegisteredNativeChecks_RepairHintsAreAudienceSafe is the registry-wide
+// invariant behind the second half of the same defect: the failing gate's
+// repair text said "inspect native gate shell.shellcheck-changed in
+// cli/internal/gates" — a path that does not exist on a machine that installed
+// the CLI.
+//
+// Scope is the NATIVE checks, and deliberately so. A script-backed check runs
+// only inside the agentops repository (ScriptRunner returns a first-class
+// not-applicable SKIP elsewhere, gates.NotApplicableReason), so its
+// `bash scripts/...` rerun hint addresses a reader who has the checkout by
+// construction. The native checks carry no such guard: they execute in a user's
+// own repository, so their repair text must be actionable from there.
+func TestRegisteredNativeChecks_RepairHintsAreAudienceSafe(t *testing.T) {
+	sourceOnly := []string{"cli/internal/", "cli/cmd/"}
+	checked := 0
+	for _, check := range gates.Default.All() {
+		if check.Run == nil {
+			continue
+		}
+		checked++
+		hint := check.EffectiveRepairHint()
+		if hint == "" {
+			t.Errorf("native check %q has an empty repair hint", check.ID)
+			continue
+		}
+		for _, needle := range sourceOnly {
+			if strings.Contains(hint, needle) {
+				t.Errorf("native check %q repair hint names source-checkout path %q: %s", check.ID, needle, hint)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no native checks registered; the invariant proved nothing")
+	}
+}
+
 func TestRunChangelogSync_ReadFailureFailsClosed(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "CHANGELOG.md"), []byte("current\n"), 0o644); err != nil {

--- a/cli/internal/gates/gates.go
+++ b/cli/internal/gates/gates.go
@@ -123,14 +123,26 @@ func (c Check) WorkflowBacking() string {
 	return strings.Join(append([]string{backingInterpreter(artifactPath), artifactPath}, c.Args...), " ")
 }
 
+// GateDocsURL is the published page describing the deterministic check
+// registry. Repair hints point here instead of at a source path: a repair hint
+// is read by whoever runs `ao gate check`, and most of them installed the CLI
+// and have no agentops checkout to inspect.
+const GateDocsURL = "https://boshu2.github.io/agentops/CI-CD/"
+
 // EffectiveRepairHint returns an explicit repair hint or derives a rerun hint
 // from the check backing.
+//
+// The derived native-check hint names the gate ID and the published docs, never
+// a path inside the agentops source checkout: `cli/internal/gates` does not
+// exist on an installed user's machine, so "inspect native gate X in
+// cli/internal/gates" was an instruction they could not follow. A check with a
+// remedy the reader can actually perform should set RepairHint explicitly.
 func (c Check) EffectiveRepairHint() string {
 	if c.RepairHint != "" {
 		return c.RepairHint
 	}
 	if c.Run != nil {
-		return "inspect native gate " + c.ID + " in cli/internal/gates"
+		return "gate " + c.ID + " failed; see " + GateDocsURL
 	}
 	return c.WorkflowBacking()
 }

--- a/cli/internal/gates/gates_test.go
+++ b/cli/internal/gates/gates_test.go
@@ -1,0 +1,84 @@
+package gates
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/ports"
+)
+
+// sourceOnlyPathNeedles are substrings that only exist inside an agentops
+// SOURCE checkout. A repair hint is read by whoever ran `ao gate check`, and
+// most of them installed the CLI (brew, npx, plugin) and have no checkout, so a
+// hint naming one of these is an instruction they cannot follow. Observed live:
+// a fresh install's failing shell gate said "inspect native gate
+// shell.shellcheck-changed in cli/internal/gates".
+var sourceOnlyPathNeedles = []string{"cli/internal/", "cli/cmd/"}
+
+// TestCheck_EffectiveRepairHintNamesNoSourceCheckoutPath is the acceptance for
+// the derived native-check hint: with no explicit RepairHint it must name the
+// gate ID and the published docs, never a Go source path.
+func TestCheck_EffectiveRepairHintNamesNoSourceCheckoutPath(t *testing.T) {
+	native := Check{
+		ID:    "shell.shellcheck-changed",
+		Tiers: Fast,
+		Run:   func(context.Context, RunContext) (ports.GateVerdict, error) { return ports.GateVerdict{}, nil },
+	}
+	hint := native.EffectiveRepairHint()
+	for _, needle := range sourceOnlyPathNeedles {
+		if strings.Contains(hint, needle) {
+			t.Fatalf("derived native hint %q names source-checkout path %q", hint, needle)
+		}
+	}
+	if !strings.Contains(hint, native.ID) {
+		t.Errorf("derived native hint %q does not name the gate ID %q", hint, native.ID)
+	}
+	if !strings.Contains(hint, GateDocsURL) {
+		t.Errorf("derived native hint %q does not point at %s", hint, GateDocsURL)
+	}
+}
+
+// TestCheck_EffectiveRepairHintPrefersExplicitHint pins the precedence: an
+// explicit, plain-language remedy always wins over the derived fallback.
+func TestCheck_EffectiveRepairHintPrefersExplicitHint(t *testing.T) {
+	want := "run 'shellcheck -S warning <file>' and fix the warnings"
+	native := Check{
+		ID:         "shell.shellcheck-changed",
+		Tiers:      Fast,
+		RepairHint: want,
+		Run:        func(context.Context, RunContext) (ports.GateVerdict, error) { return ports.GateVerdict{}, nil },
+	}
+	if got := native.EffectiveRepairHint(); got != want {
+		t.Fatalf("EffectiveRepairHint() = %q, want %q", got, want)
+	}
+}
+
+// TestOrchestrator_UnbornHeadSurfacesFriendlyError proves the friendly
+// unborn-HEAD message survives the orchestrator's wrap and reaches the surface
+// the user reads: `ao gate check` in a zero-commit repo previously printed
+// "gates: detect changed files: git show --name-only --pretty=format: HEAD:
+// exit status 128".
+func TestOrchestrator_UnbornHeadSurfacesFriendlyError(t *testing.T) {
+	root := initRepoNoCommits(t, false)
+	reg := NewRegistry()
+	if err := reg.Add(Check{ID: "shell", Tiers: Fast, Match: []string{"**/*.sh"}, Backing: "noop.sh"}); err != nil {
+		t.Fatal(err)
+	}
+	o := NewOrchestrator(reg, nil, NewGitChangedFiles(root), root)
+
+	_, err := o.Run(context.Background(), RunOptions{Mode: Fast, Scope: ScopeHead})
+	if err == nil {
+		t.Fatal("Run on a zero-commit repo returned no error")
+	}
+	if !errors.Is(err, ErrUnbornHead) {
+		t.Fatalf("Run err = %v, want errors.Is ErrUnbornHead", err)
+	}
+	if strings.Contains(err.Error(), "exit status") {
+		t.Errorf("orchestrator error leaks a git exit status: %v", err)
+	}
+	if !strings.Contains(err.Error(), "no commits yet") {
+		t.Errorf("orchestrator error missing the friendly cause: %v", err)
+	}
+}

--- a/cli/internal/gates/orchestrator.go
+++ b/cli/internal/gates/orchestrator.go
@@ -159,6 +159,10 @@ func (o *Orchestrator) selectCheckPlans(ctx context.Context, opts RunOptions) ([
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("gates: detect changed files: %w", err)
 	}
+	// Installed skill copies are not repository source (see
+	// installedSkillCopyPrefixes). Drop them once, here, so both routing and the
+	// RunContext every check reads describe the same in-scope change set.
+	changed = FilterInstalledSkillCopies(changed)
 	if invalidatingFile := firstInvalidatingFile(changed); invalidatingFile != "" {
 		selected := make([]checkSelection, 0, len(tierMatched))
 		for _, c := range tierMatched {

--- a/cli/internal/gates/routing.go
+++ b/cli/internal/gates/routing.go
@@ -2,6 +2,56 @@ package gates
 
 import "strings"
 
+// installedSkillCopyPrefixes are the repo-relative roots where an agent
+// runtime materializes INSTALLED copies of skill packages (`ao skills link`,
+// a plugin install, or a vendored copy). Files under them are distribution
+// artifacts owned by their upstream source, never first-party source of the
+// repository being gated: a user who installs AgentOps into their own project
+// gets AgentOps' own shell scripts on disk, and the shellcheck gate then fails
+// the user's clean commit on OUR files with no repair the user can perform.
+//
+// The agentops repository itself tracks nothing under these prefixes (skills
+// live in skills/), so excluding them cannot hide a first-party change from a
+// gate — the #634 silent-drop hazard does not apply here.
+var installedSkillCopyPrefixes = []string{
+	".agents/skills/",
+	".claude/skills/",
+	".codex/skills/",
+	".gemini/skills/",
+	".cursor/skills/",
+	".pi/skills/",
+	"agent/skills/",
+}
+
+// IsInstalledSkillCopy reports whether a repo-relative path is an installed
+// copy of a skill package rather than repository source.
+func IsInstalledSkillCopy(path string) bool {
+	for _, prefix := range installedSkillCopyPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterInstalledSkillCopies drops installed skill copies from a change set.
+// Every change set the gates consume passes through it — the orchestrator's
+// routed set and the native checks' own fallback set — so a check can never
+// see a path that routing already declared out of scope.
+func FilterInstalledSkillCopies(paths []string) []string {
+	kept := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if IsInstalledSkillCopy(p) {
+			continue
+		}
+		kept = append(kept, p)
+	}
+	if len(kept) == 0 {
+		return nil
+	}
+	return kept
+}
+
 // matchGlob reports whether a repo-relative path matches a single glob pattern.
 // It supports the small set of forms the seed registry actually uses (ported
 // faithfully from the bash gate's anchored regexes):

--- a/cli/internal/gates/routing_test.go
+++ b/cli/internal/gates/routing_test.go
@@ -96,6 +96,94 @@ func TestGitChangedFiles_ScopeMappingAndDedupe(t *testing.T) {
 	}
 }
 
+// TestIsInstalledSkillCopy pins which paths count as an installed copy of a
+// skill package. The false rows matter most: a path that merely CONTAINS one of
+// the runtime names, or the agentops repo's own skills/ source, must stay in
+// the change set — over-filtering silently drops a gate.
+func TestIsInstalledSkillCopy(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{".agents/skills/cass/scripts/multi_machine_search.sh", true},
+		{".claude/skills/plan/SKILL.md", true},
+		{".codex/skills/validate/scripts/run.sh", true},
+		{".gemini/skills/x/y.sh", true},
+		{".cursor/skills/x/y.sh", true},
+		{".pi/skills/x/y.sh", true},
+		{"agent/skills/x/y.sh", true},
+		{"skills/cass/scripts/multi_machine_search.sh", false},
+		{"scripts/check-x.sh", false},
+		{".agents/ao/learnings/x.md", false},
+		{".agents/handoff/x.md", false},
+		{"vendor/.claude/skills/x/y.sh", false},
+		{"cli/internal/skillsapp/link.go", false},
+	}
+	for _, tc := range tests {
+		if got := IsInstalledSkillCopy(tc.path); got != tc.want {
+			t.Errorf("IsInstalledSkillCopy(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestFilterInstalledSkillCopies(t *testing.T) {
+	got := FilterInstalledSkillCopies([]string{
+		".agents/skills/cass/scripts/multi_machine_search.sh",
+		"scripts/deploy.sh",
+		".claude/skills/plan/SKILL.md",
+		"README.md",
+	})
+	want := []string{"scripts/deploy.sh", "README.md"}
+	if len(got) != len(want) {
+		t.Fatalf("FilterInstalledSkillCopies = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("FilterInstalledSkillCopies[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if got := FilterInstalledSkillCopies([]string{".claude/skills/plan/x.sh"}); got != nil {
+		t.Fatalf("all-filtered set = %v, want nil", got)
+	}
+}
+
+// TestOrchestrator_InstalledSkillCopiesDoNotRouteChecks is the routing-layer
+// acceptance: a commit whose ONLY shell file is an installed skill copy must
+// not select the shell gate. Observed live — a user's first commit after
+// installing AgentOps failed shellcheck on AgentOps' own
+// .agents/skills/cass/scripts/multi_machine_search.sh via the `**/*.sh` glob.
+func TestOrchestrator_InstalledSkillCopiesDoNotRouteChecks(t *testing.T) {
+	reg := NewRegistry()
+	shell := Check{ID: "shell.shellcheck-changed", Tiers: Fast, Match: []string{"**/*.sh"}, Backing: "noop.sh"}
+	if err := reg.Add(shell); err != nil {
+		t.Fatal(err)
+	}
+	files := fakeFiles{files: []string{".agents/skills/cass/scripts/multi_machine_search.sh", "README.md"}}
+	o := NewOrchestrator(reg, nil, files, t.TempDir())
+
+	selected, changed, err := o.Select(context.Background(), RunOptions{Mode: Fast, Scope: ScopeHead})
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if len(selected) != 0 {
+		t.Fatalf("selected %v, want none (only in-scope change is README.md)", selected)
+	}
+	if !equalSet(changed, []string{"README.md"}) {
+		t.Fatalf("routed change set = %v, want [README.md]", changed)
+	}
+
+	// Negative witness: a first-party shell file still routes the same check, so
+	// the filter narrows the change set rather than disabling the gate.
+	o = NewOrchestrator(reg, nil, fakeFiles{files: []string{"scripts/deploy.sh"}}, t.TempDir())
+	selected, _, err = o.Select(context.Background(), RunOptions{Mode: Fast, Scope: ScopeHead})
+	if err != nil {
+		t.Fatalf("Select first-party: %v", err)
+	}
+	if len(selected) != 1 || selected[0].ID != shell.ID {
+		t.Fatalf("first-party shell change selected %v, want [%s]", selected, shell.ID)
+	}
+}
+
 func TestGitChangedFiles_UnknownScope(t *testing.T) {
 	g := NewGitChangedFiles("/repo")
 	if _, err := g.Changed(context.Background(), Scope("bogus")); err == nil {

--- a/cli/internal/initapp/initapp.go
+++ b/cli/internal/initapp/initapp.go
@@ -1,8 +1,9 @@
 // Package initapp owns the filesystem effects behind the `ao init` command. It
-// creates the local AgentOps evidence and verdict directories, keeping the init
-// command module a thin Cobra presentation seam that performs no direct
-// filesystem effect. It never initializes Git, edits ignore files, installs
-// hooks, selects work, or starts a runtime.
+// creates the local AgentOps evidence and verdict directories and writes one
+// idempotent ignore block into the working directory's .gitignore, keeping the
+// init command module a thin Cobra presentation seam that performs no direct
+// filesystem effect. It never initializes Git, installs hooks, selects work, or
+// starts a runtime.
 package initapp
 
 import (
@@ -10,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/boshu2/agentops/cli/internal/storage"
 )
@@ -28,6 +30,48 @@ var evidenceDirs = []string{
 	filepath.Join(".agents", "handoff"),
 }
 
+// The ignore policy.
+//
+// Before this, `ao init` scaffolded .agents/ao/** and said nothing about git.
+// One loop later the working tree was littered with untracked scratch — a
+// derived search index, local session transcripts, a machine-local provenance
+// ledger, Python bytecode caches — and every user had to invent the same
+// .gitignore lines. So init now writes them once, as a marker-delimited block.
+//
+// What is ignored is only machine-local scratch: derived, private, or
+// per-machine files that would conflict on merge and mean nothing in another
+// checkout. What is deliberately NOT ignored is the loop's evidence —
+// .agents/ao/intents/ and .agents/ao/verdicts/ — because whether an intent
+// digest or a verdict.v2 belongs in version control is the consumer
+// repository's policy, and AgentOps owns no policy there (product boundary).
+// A repository that wants everything tracked deletes the block; a repository
+// that wants evidence ignored adds its own lines outside it.
+const (
+	// GitignoreBeginMarker opens the managed block. It is the idempotency key:
+	// its presence anywhere in .gitignore means the block is already installed,
+	// and init leaves the file untouched — including when a user has edited the
+	// lines inside, which is an intentional local override, not drift to repair.
+	GitignoreBeginMarker = "# --- AgentOps (ao init): machine-local scratch ---"
+	// GitignoreEndMarker closes the managed block so a later tool (or a human)
+	// can find its bounds.
+	GitignoreEndMarker = "# --- end AgentOps ---"
+)
+
+// gitignoreBlock is the exact text appended to .gitignore, marker to marker.
+var gitignoreBlock = strings.Join([]string{
+	GitignoreBeginMarker,
+	"# Derived, private, or per-machine files the AgentOps loop writes.",
+	"# NOT ignored, on purpose: .agents/ao/intents/ and .agents/ao/verdicts/ —",
+	"# whether to commit loop evidence is your repository's policy, not the CLI's.",
+	"# Delete this block to track everything.",
+	".agents/ao/index/",
+	".agents/ao/sessions/",
+	".agents/ao/provenance/",
+	"__pycache__/",
+	GitignoreEndMarker,
+	"",
+}, "\n")
+
 // RunOptions carries the presentation choices resolved by the command module.
 // The working directory is resolved inside Run so the module never performs a
 // direct filesystem effect.
@@ -38,8 +82,8 @@ type RunOptions struct {
 	Stdout io.Writer
 }
 
-// Run creates the local evidence and verdict directories, or reports what it
-// would create under DryRun.
+// Run creates the local evidence and verdict directories and installs the
+// managed .gitignore block, or reports what it would do under DryRun.
 func Run(opts RunOptions) error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -55,5 +99,43 @@ func Run(opts RunOptions) error {
 		}
 		fmt.Fprintf(opts.Stdout, "created %s\n", relative)
 	}
+	return ensureGitignoreBlock(cwd, opts)
+}
+
+// ensureGitignoreBlock appends the managed ignore block to <dir>/.gitignore,
+// creating the file when absent. It is idempotent on GitignoreBeginMarker: a
+// second `ao init` in the same directory appends nothing, so the block is
+// present exactly once no matter how many times init runs.
+//
+// The file targeted is the working directory's, not the enclosing git root's —
+// the block's patterns are relative to the same directory whose .agents/ao/**
+// this run just created, so writing it anywhere else would produce patterns
+// that match nothing.
+func ensureGitignoreBlock(dir string, opts RunOptions) error {
+	path := filepath.Join(dir, ".gitignore")
+	existing, err := os.ReadFile(path) // #nosec G304 -- path is <cwd>/.gitignore, not caller-controlled.
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read .gitignore: %w", err)
+	}
+	if strings.Contains(string(existing), GitignoreBeginMarker) {
+		fmt.Fprintln(opts.Stdout, ".gitignore already has the AgentOps block (left unchanged)")
+		return nil
+	}
+	if opts.DryRun {
+		fmt.Fprintln(opts.Stdout, "would append the AgentOps block to .gitignore")
+		return nil
+	}
+	content := string(existing)
+	if content != "" && !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	if content != "" {
+		content += "\n"
+	}
+	content += gitignoreBlock
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil { // #nosec G306 -- .gitignore is a tracked, world-readable repo file.
+		return fmt.Errorf("write .gitignore: %w", err)
+	}
+	fmt.Fprintln(opts.Stdout, "appended the AgentOps block to .gitignore")
 	return nil
 }

--- a/cli/internal/initapp/initapp_test.go
+++ b/cli/internal/initapp/initapp_test.go
@@ -46,6 +46,121 @@ func TestRun_CreatesLayoutSatisfyingDoctorAndStatusContracts(t *testing.T) {
 	}
 }
 
+// TestRun_GitignoreBlockIsWrittenOnceAndIsIdempotent is the acceptance for the
+// scaffold-without-ignore-guidance defect: `ao init` created .agents/ao/** and
+// said nothing about git, so one loop later the tree was full of untracked
+// scratch. Init now writes the block, and running init again must not duplicate
+// it — the file is appended to, and a repeated init is a normal thing to do.
+func TestRun_GitignoreBlockIsWrittenOnceAndIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	var first bytes.Buffer
+
+	if err := Run(RunOptions{Stdout: &first}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	body := string(data)
+	if got := strings.Count(body, GitignoreBeginMarker); got != 1 {
+		t.Fatalf("begin marker appears %d times after one init, want 1:\n%s", got, body)
+	}
+	if got := strings.Count(body, GitignoreEndMarker); got != 1 {
+		t.Fatalf("end marker appears %d times after one init, want 1:\n%s", got, body)
+	}
+	for _, want := range []string{".agents/ao/index/", ".agents/ao/sessions/", ".agents/ao/provenance/", "__pycache__/"} {
+		if !strings.Contains(body, want) {
+			t.Errorf(".gitignore missing scratch pattern %q:\n%s", want, body)
+		}
+	}
+	// Loop evidence stays trackable: that call belongs to the consumer repo.
+	for _, tracked := range []string{".agents/ao/intents/", ".agents/ao/verdicts/"} {
+		for _, line := range strings.Split(body, "\n") {
+			if strings.TrimSpace(line) == tracked {
+				t.Errorf(".gitignore ignores loop evidence %q, which is repo policy, not the CLI's:\n%s", tracked, body)
+			}
+		}
+	}
+
+	var second bytes.Buffer
+	if err := Run(RunOptions{Stdout: &second}); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	after, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore after second init: %v", err)
+	}
+	if string(after) != body {
+		t.Fatalf("second init changed .gitignore:\nbefore:\n%s\nafter:\n%s", body, after)
+	}
+	if got := strings.Count(string(after), GitignoreBeginMarker); got != 1 {
+		t.Fatalf("begin marker appears %d times after two inits, want exactly 1", got)
+	}
+	if !strings.Contains(second.String(), "already has the AgentOps block") {
+		t.Errorf("second init did not report the block as already present: %s", second.String())
+	}
+}
+
+// TestRun_GitignoreBlockPreservesExistingContent: init appends, never rewrites.
+// An existing .gitignore keeps every line it had, and a file that did not end
+// in a newline does not get its last rule glued to the block's first comment.
+func TestRun_GitignoreBlockPreservesExistingContent(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("node_modules\n*.log"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if err := Run(RunOptions{Stdout: &out}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(data)
+	if !strings.HasPrefix(body, "node_modules\n*.log\n") {
+		t.Fatalf("existing rules were not preserved verbatim:\n%s", body)
+	}
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "*.log") && strings.TrimSpace(line) != "*.log" {
+			t.Fatalf("last existing rule was glued to the appended block: %q", line)
+		}
+	}
+	if !strings.Contains(body, GitignoreBeginMarker) {
+		t.Fatalf("block not appended:\n%s", body)
+	}
+}
+
+// TestRun_GitignoreBlockRespectsUserEdits: the marker is the idempotency key,
+// not the block body. A user who edits or trims the lines inside has made a
+// local decision; a second init must respect it rather than "repair" it.
+func TestRun_GitignoreBlockRespectsUserEdits(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	edited := GitignoreBeginMarker + "\n.agents/ao/index/\n" + GitignoreEndMarker + "\n"
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(edited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if err := Run(RunOptions{Stdout: &out}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != edited {
+		t.Fatalf("init rewrote a user-edited block:\nwant:\n%s\ngot:\n%s", edited, data)
+	}
+}
+
 func TestRun_DryRunCreatesNothing(t *testing.T) {
 	t.Chdir(t.TempDir())
 	var out bytes.Buffer
@@ -59,5 +174,11 @@ func TestRun_DryRunCreatesNothing(t *testing.T) {
 	}
 	if _, err := os.Stat(".agents"); !os.IsNotExist(err) {
 		t.Errorf("dry-run created .agents (stat err=%v); want nothing on disk", err)
+	}
+	if _, err := os.Stat(".gitignore"); !os.IsNotExist(err) {
+		t.Errorf("dry-run wrote .gitignore (stat err=%v); want nothing on disk", err)
+	}
+	if !strings.Contains(out.String(), "would append the AgentOps block to .gitignore") {
+		t.Errorf("dry-run did not announce the .gitignore block: %s", out.String())
 	}
 }


### PR DESCRIPTION
Four defects observed live in a fresh-install smoke test of the `ao` CLI: two in `ao gate check`, one in `ao doctor`, one in `ao init`. Each is fixed at its root and pinned by L2 tests driven through the real entry points in fixture repos.

## 1. `ao gate check` in a zero-commit repo died raw

**Observed** — in a repository between `git init` and the first commit:

```
gates: detect changed files: git show --name-only --pretty=format: HEAD: exit status 128
```

**Fix** (`cli/internal/gates/changedfiles.go`) — `GitChangedFiles.Changed` translates the failure into the `ErrUnbornHead` sentinel with a remedy. Translation runs only on the failure path (the happy path keeps its single git invocation) and only for HEAD-resolving scopes. Two probes keep the neighbouring causes distinct: `rev-parse --git-dir` separates "not a git repository", `rev-parse --verify HEAD` separates "bad revision in an explicit range". `--scope staged` is excluded on purpose — `git diff --cached` works before the first commit, which is why the message points there.

Live, after the fix:

```
ao gate: gate check: gates: detect changed files: no commits yet (unborn HEAD): scope "head"
needs a commit to compare against — make an initial commit, or run with an explicit scope
such as --scope staged after 'git add'
```

**Tests** (`changedfiles_test.go`, `gates_test.go`) — unborn-HEAD fixture across `head`/`worktree`/`upstream`/`range`: `errors.Is(ErrUnbornHead)`, no leaked git exit status, remedy text present. Plus: the advertised `--scope staged` escape hatch actually returns the staged set; two negative witnesses (non-repo, nonexistent range base) keep git's own error; an orchestrator-level test proves the message survives the `gates: detect changed files: %w` wrap.

## 2. Gate failed shellcheck on AgentOps' own installed skill scripts, with an unusable repair hint

**Observed** — after `ao init` and a first commit in a user's own repo, `shell.shellcheck-changed` FAILED on `.agents/skills/cass/scripts/multi_machine_search.sh` (matched by the `**/*.sh` glob), and the repair text read `inspect native gate shell.shellcheck-changed in cli/internal/gates` — a path that does not exist on a machine that installed the CLI.

**Fix A — scope** (`gates/routing.go`, `gates/orchestrator.go`, `checks/native_inline.go`): paths under `.agents/skills/`, `.claude/skills/`, `.codex/skills/`, `.gemini/skills/`, `.cursor/skills/`, `.pi/skills/`, `agent/skills/` are installed copies owned by their upstream source, never repository source. They are dropped from the change set once, in the orchestrator, so routing and every check's `RunContext` describe the same in-scope set; the native checks' own `origin/main...HEAD` fallback applies the same filter so Full mode cannot re-admit them. The agentops repository tracks nothing under those prefixes (`git ls-files` → 0), so the exclusion cannot hide a first-party change from a gate.

**Fix B — hints** (`gates/gates.go`, `checks/native_inline.go`): the derived native-check hint now names the gate ID and the published docs (`GateDocsURL`) instead of a Go source path, and all four native checks carry an explicit plain-language remedy. Script-backed hints are unchanged by design — `ScriptRunner` returns a first-class not-applicable SKIP outside the agentops repo, so their `bash scripts/...` rerun addresses a reader who has the checkout by construction.

Live, after the fix — installed copies pass, a first-party file still fails:

```
FAIL  shell.shellcheck-changed | selected: changed file "scripts/deploy.sh" matched "**/*.sh"
      | repair: run 'shellcheck -S warning <file>' on each reported shell file and fix the
        warnings (install shellcheck if it is missing)
```

**Tests** (`checks/native_inline_test.go`, `gates/routing_test.go`, `gates/gates_test.go`) — L2 through the real registry + real orchestrator + real git + real shellcheck: a fixture repo whose only shellcheck-triggering files are installed skill copies exits 0; **negative witness** — the same bad script under `scripts/` still exits 1, so the filter narrows scope rather than defanging the gate. Plus a routing-layer selection test with the same witness, a path-classification table including near-misses (`skills/`, `vendor/.claude/skills/`, `.agents/ao/learnings/`), and a registry-wide invariant that no native check's effective repair hint names a source-checkout path.

## 3. `ao doctor` gave installed users checkout-only advice and could overcount broken links

**Observed** — audience `installed-user` was told to run `ao skills link --dry-run` "from the AgentOps checkout" (they have none, and the command fails closed outside one), alongside a "2 broken" count that a dangling-symlink sweep did not corroborate.

**Fix** (`cli/internal/adapters/doctor/legacy.go`):

- *Advice*: the no-checkout branch now names the affected root and the dangling count, and gives a remedy performable from where the reader stands — remove the dangling links, then reinstall skills the way they were installed (plugin, brew, or npx).
- *Counting*: `countLiveSkillLinks` derived brokenness from a single `os.Stat(<link>/SKILL.md)` probe, which fails for **three** unrelated reasons — the link dangles, the link resolves to something that is not a skill package (a shared reference dir, or a plain file), or the target is unreadable — and reported all three as broken. That conflation is the overcount. It now returns a tri-state census: `Broken` means **dangling and only dangling** (exactly what `find -L <root> -maxdepth 1 -type l` prints), `Foreign` is a link that resolves but names no skill package, `Live` is a working skill. Non-symlink entries (a plugin's real directory) are counted in no bucket.

Live, after the fix — and the two reported links are genuinely dangling, which the new wording now makes checkable:

```
! Skill Links  48 live portable skill link(s), 2 dangling (target no longer exists) under
               /Users/…/.agents/skills; remove the dangling link(s), then reinstall skills
               the way you installed them (plugin, brew, or npx)
```

**Tests** (`legacy_test.go`) — installed-user detail/Fix contain no checkout-only command and *do* name the root, the count, and a remedy; a fixture holding live + dangling + foreign-dir + foreign-file + real-dir entries pins the exact census `{Live:2, Broken:1, Foreign:2}`; a cross-check computes the dangling count independently (not via production code) and asserts doctor's `Broken` equals it — the test that closes the "doctor says N, find says fewer" contradiction.

## 4. `ao init` scaffolded `.agents/ao/**` with no ignore guidance

**Observed** — after one loop the tree was full of untracked scratch and every user had to invent the same `.gitignore` rules by hand.

**Policy decision** (`cli/internal/initapp/initapp.go`): `ao init` appends one commented, marker-delimited block to the working directory's `.gitignore`, creating the file if absent. It ignores only machine-local scratch — `.agents/ao/index/` (derived), `.agents/ao/sessions/` (private), `.agents/ao/provenance/` (per-machine, merge-hostile), `__pycache__/`. It **deliberately does not** ignore `.agents/ao/intents/` or `.agents/ao/verdicts/`: whether loop evidence belongs in version control is the consumer repository's policy, and AgentOps owns no policy there (product boundary). Delete the block to track everything.

The block targets the working directory rather than the enclosing git root, so its relative patterns match the `.agents/ao/**` the same run just created. Idempotency keys on the begin marker, not the body — a user who trims the lines inside has made a local decision, and a second init reports and respects it. Documented in the command's `Long` help and the regenerated `cli/docs/COMMANDS.md`.

**Tests** (`initapp_test.go`, `commands/init/module_test.go`) — init twice in a fresh dir leaves the marker present exactly once, both at the app layer and L2 through the cobra command; existing `.gitignore` content is preserved verbatim with no glued last line; an edited block is left untouched; dry-run writes nothing and announces the append; help documents both what is ignored and what is deliberately trackable. The pre-existing assertion that init never touches ignore state was replaced by a narrower one — no repository is initialized — since the ignore block is now the intended behavior.

---

## Verification

- `cd cli && go build ./... && go vet ./... && go test ./...` → **2947 passed in 73 packages**, exit 0 (captured to a file; not piped).
- `golangci-lint run` → no issues.
- `bash scripts/regen-all.sh --check` → all generated projections current (`cli/docs/COMMANDS.md` regenerated via `scripts/generate-cli-reference.sh`).
- All four defects re-smoked end-to-end against a freshly built binary in a throwaway repo.

Write scope stayed inside `cli/**` plus the generated `cli/docs/COMMANDS.md`. No `skills/**`, `AGENTS.md`, or `docs/architecture/**` changes.
