### PR TITLE
3.5.0 release prep: version bumps, changelog, curated notes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Fresh-context validation for coding-agent work: one behavior, one bounded experiment, one independent verdict.",
-    "version": "3.4.0"
+    "version": "3.5.0"
   },
   "plugins": [
     {
       "name": "agentops",
       "description": "Fresh-context validation for coding-agent work: one behavior, one bounded experiment, one independent verdict.",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "source": "./",
       "author": {
         "name": "Boden Fuller",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentops",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Fresh-context validation for coding-agent work: shape one behavior, run one bounded experiment, and persist an independent verdict.",
   "author": {
     "name": "Boden Fuller",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentops",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Fresh-context validation for coding-agent work: shape one behavior, run one bounded experiment, and persist an independent verdict.",
   "skills": "./skills-codex",
   "interface": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-07-31
+
+AgentOps 3.5 hardens the factory boundary 3.4 drew. The Gas City maintainer
+operations ship in the Go CLI as the `ao gc` command family, the operating
+doctrine for driving a factory through its coordinator is encoded in the
+runtime surfaces (the Mayor authors workflow beads and dispatches; the
+operator authors intent, mails, reads state, and judges), `plan` gains a
+substrate-neutral manifest mode for multi-behavior handoffs, and the verdict
+contract stops punishing honest scope disclosure.
+
+### Added
+
+- `ao gc` command family: `prepare`, read-only `check`, and
+  dry-run-by-default `recover-affinity` port the Gas City maintainer
+  operations into the CLI (ADR-0016); `scripts/gc-maintainer-ops.sh` remains
+  as a thin wrapper.
+- `plan` manifest mode: shape N bounded behaviors as one caller-owned
+  specification manifest (stable slugs, dependency edges, per-child
+  acceptance and write scopes, tracker IDs `TBD`) authoring zero beads; the
+  executing substrate materializes tracker state.
+- `using-gc` documents the supervisor's typed run-status API (run detail and
+  census endpoints) and the five-verb tending loop (monitor, observe, nudge,
+  redirect, rework) with one owner per verb.
+- `ao init` scaffolds a marker-delimited `.gitignore` block covering
+  machine-local loop scratch while leaving intents and verdicts trackable;
+  idempotent across re-runs.
+
+### Changed
+
+- Factory operating doctrine in `using-gc` and `AGENTS.md`: work enters a city
+  through the Mayor, which authors workflow beads and owns dispatch; direct
+  `gc sling` is demoted to a no-live-Mayor debugging tool; the operator lane
+  is a closed set and pack-owned session lifecycle belongs to the reconciler.
+- `rpi` states that factory work enters through the factory's coordinator;
+  RPI hands over intent and never dispatches factory runs itself.
+
+### Fixed
+
+- The verdict tool no longer pays validators to delete caveats: declared
+  non-goals, bounded criterion proofs, and residual risks have documented
+  disclosure homes; the PASS integrity finding names where each caveat
+  belongs instead of failing silently; `store-verdict` errors name the
+  allowed criteria fields.
+- Loop skill docs work verbatim in installed trees: install-agnostic
+  `validate.py` paths in `plan` and `validate`, real `manifest` flags
+  documented, the `rpi` report shape inlined instead of linking an unshipped
+  schema, and self-contained examples replace internal digests.
+- `ao gate check` explains an unborn HEAD instead of surfacing a raw git
+  exit-128; installed skill copies are excluded from user-repo gate scope;
+  native-check repair hints no longer reference source-checkout paths.
+- `ao doctor` gives installed users actionable advice without checkout-only
+  commands, and the skill-link census is tri-state so only genuinely dangling
+  links count as broken.
+
 ## [3.4.0] - 2026-07-30
 
 AgentOps 3.4 is the **honest-contract release**. All 50 shipped skills went

--- a/cli/cmd/ao/main.go
+++ b/cli/cmd/ao/main.go
@@ -5,7 +5,7 @@ package main
 // version is set at build time via ldflags (goreleaser: -X main.version={{ .Version }}).
 // The fallback identifies untagged source builds for the next release;
 // published binaries override it from the release tag via GoReleaser.
-var version = "3.4.0"
+var version = "3.5.0"
 
 func main() {
 	Execute()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-07-31
+
+AgentOps 3.5 hardens the factory boundary 3.4 drew. The Gas City maintainer
+operations ship in the Go CLI as the `ao gc` command family, the operating
+doctrine for driving a factory through its coordinator is encoded in the
+runtime surfaces (the Mayor authors workflow beads and dispatches; the
+operator authors intent, mails, reads state, and judges), `plan` gains a
+substrate-neutral manifest mode for multi-behavior handoffs, and the verdict
+contract stops punishing honest scope disclosure.
+
+### Added
+
+- `ao gc` command family: `prepare`, read-only `check`, and
+  dry-run-by-default `recover-affinity` port the Gas City maintainer
+  operations into the CLI (ADR-0016); `scripts/gc-maintainer-ops.sh` remains
+  as a thin wrapper.
+- `plan` manifest mode: shape N bounded behaviors as one caller-owned
+  specification manifest (stable slugs, dependency edges, per-child
+  acceptance and write scopes, tracker IDs `TBD`) authoring zero beads; the
+  executing substrate materializes tracker state.
+- `using-gc` documents the supervisor's typed run-status API (run detail and
+  census endpoints) and the five-verb tending loop (monitor, observe, nudge,
+  redirect, rework) with one owner per verb.
+- `ao init` scaffolds a marker-delimited `.gitignore` block covering
+  machine-local loop scratch while leaving intents and verdicts trackable;
+  idempotent across re-runs.
+
+### Changed
+
+- Factory operating doctrine in `using-gc` and `AGENTS.md`: work enters a city
+  through the Mayor, which authors workflow beads and owns dispatch; direct
+  `gc sling` is demoted to a no-live-Mayor debugging tool; the operator lane
+  is a closed set and pack-owned session lifecycle belongs to the reconciler.
+- `rpi` states that factory work enters through the factory's coordinator;
+  RPI hands over intent and never dispatches factory runs itself.
+
+### Fixed
+
+- The verdict tool no longer pays validators to delete caveats: declared
+  non-goals, bounded criterion proofs, and residual risks have documented
+  disclosure homes; the PASS integrity finding names where each caveat
+  belongs instead of failing silently; `store-verdict` errors name the
+  allowed criteria fields.
+- Loop skill docs work verbatim in installed trees: install-agnostic
+  `validate.py` paths in `plan` and `validate`, real `manifest` flags
+  documented, the `rpi` report shape inlined instead of linking an unshipped
+  schema, and self-contained examples replace internal digests.
+- `ao gate check` explains an unborn HEAD instead of surfacing a raw git
+  exit-128; installed skill copies are excluded from user-repo gate scope;
+  native-check repair hints no longer reference source-checkout paths.
+- `ao doctor` gives installed users actionable advice without checkout-only
+  commands, and the skill-link census is tri-state so only genuinely dangling
+  links count as broken.
+
 ## [3.4.0] - 2026-07-30
 
 AgentOps 3.4 is the **honest-contract release**. All 50 shipped skills went

--- a/docs/releases/2026-07-31-v3.5.0-notes.md
+++ b/docs/releases/2026-07-31-v3.5.0-notes.md
@@ -1,0 +1,87 @@
+## Highlights
+
+AgentOps 3.5 hardens the factory boundary that 3.4 drew. The Gas City
+maintainer operations ship in the CLI as the `ao gc` command family, the
+operating doctrine for driving a factory through its coordinator is encoded in
+the runtime surfaces (the Mayor authors workflow beads and dispatches; the
+operator authors intent, mails the coordinator, reads state, and judges),
+`plan` gains a substrate-neutral manifest mode for multi-behavior handoffs,
+and the verdict contract stops punishing honest scope disclosure: every
+caveat now has a documented home, and nothing is deleted to earn a PASS.
+
+## Upgrade Notes
+
+- `scripts/gc-maintainer-ops.sh` is now a thin wrapper; new callers should use
+  `ao gc prepare|check|recover-affinity` directly.
+- `ao init` now appends a marker-delimited ignore block to `.gitignore`
+  covering machine-local loop scratch; intents and verdicts stay trackable.
+  Re-running init is idempotent, and an edited block is respected.
+- No other manual action required.
+
+## At a Glance
+
+| Product Area | Added | Changed | Refactored | Fixed | Deprecated/Removed |
+|---|---:|---:|---:|---:|---:|
+| Skills and Workflows | 2 | 2 | 0 | 1 | 0 |
+| Eval, Validation, and Release Gates | 0 | 0 | 0 | 2 | 0 |
+| CLI and Operator Commands | 2 | 0 | 0 | 2 | 1 |
+| Docs and Onboarding | 1 | 1 | 0 | 0 | 0 |
+
+## Product Areas
+
+### Skills and Workflows
+
+- Added: `plan` manifest mode — shape many bounded behaviors as one
+  caller-owned specification manifest (stable slugs, dependency edges,
+  per-child acceptance and write scopes, tracker IDs `TBD`) authoring zero
+  beads; the executing substrate materializes tracker state
+- Added: `using-gc` documents the supervisor's typed run-status API and the
+  five-verb tending loop (monitor, observe, nudge, redirect, rework), one
+  owner per verb
+- Changed: factory operating doctrine — work enters a city through the Mayor,
+  which authors workflow beads and owns dispatch; direct `gc sling` is a
+  no-live-Mayor debugging tool; pack-owned session lifecycle belongs to the
+  reconciler; `rpi` hands factory work to the coordinator and never
+  dispatches runs itself
+- Changed: loop skill docs work verbatim in installed trees —
+  install-agnostic `validate.py` paths, real `manifest` flags, the `rpi`
+  report shape inlined, self-contained examples
+- Fixed: the verdict tool no longer pays validators to delete caveats —
+  declared non-goals, bounded criterion proofs, and residual risks have
+  documented disclosure homes, and the PASS integrity finding names where
+  each caveat belongs instead of failing silently
+
+### Eval, Validation, and Release Gates
+
+- Fixed: `ao gate check` explains an unborn HEAD instead of surfacing a raw
+  git exit-128, and installed skill copies are excluded from user-repo gate
+  scope with repair hints that no longer reference source-checkout paths
+- Fixed: `store-verdict` errors name the allowed criteria fields
+
+### CLI and Operator Commands
+
+- Added: `ao gc` command family — `prepare`, read-only `check`, and
+  dry-run-by-default `recover-affinity` — porting the Gas City maintainer
+  operations into Go per ADR-0016
+- Added: `ao init` scaffolds an idempotent, marker-delimited `.gitignore`
+  block for machine-local loop scratch
+- Fixed: `ao doctor` gives installed users actionable advice without
+  checkout-only commands
+- Fixed: the doctor skill-link census is tri-state, so only genuinely
+  dangling links count as broken
+- Deprecated: `scripts/gc-maintainer-ops.sh` becomes a compatibility wrapper
+  over `ao gc`
+
+### Docs and Onboarding
+
+- Added: the Ponytail whole-repo contraction plan
+  (`docs/plans/2026-07-30-ponytail-whole-repo-contraction.md`), the reference
+  example for plan manifest mode
+- Changed: `AGENTS.md` states the factory control-plane and dispatch
+  boundary for any selected factory
+
+## Known Issues
+
+- No release-blocking known issues.
+
+[Full changelog](../CHANGELOG.md)

--- a/images/claude/verify.sh
+++ b/images/claude/verify.sh
@@ -58,7 +58,7 @@ fi
 # Version guard: the Claude marketplace plugin manifest is the install entrypoint
 # for this image. Assert .claude-plugin/plugin.json declares the expected version
 # so a stale-version drift (plugin.json behind the release) fails the gate.
-EXPECTED_VERSION="${AGENTOPS_EXPECTED_VERSION:-3.4.0}"
+EXPECTED_VERSION="${AGENTOPS_EXPECTED_VERSION:-3.5.0}"
 plugin_manifest="$repo_root/.claude-plugin/plugin.json"
 if [ ! -f "$plugin_manifest" ]; then
   echo "FAIL: Claude plugin manifest not found: $plugin_manifest" >&2

--- a/images/gemini/plugin.json
+++ b/images/gemini/plugin.json
@@ -13,5 +13,5 @@
   "name": "agentops-core-gemini",
   "rules": "./rules",
   "skills": "./skills",
-  "version": "3.4.0"
+  "version": "3.5.0"
 }


### PR DESCRIPTION
Everything-but-tag for v3.5.0 (Bo's call: the post-3.4.0 delta carries two feature surfaces — `ao gc` and plan manifest mode — so minor, not patch).

- Version 3.4.0 → 3.5.0 across all seven surfaces (plugin manifests, marketplace, image verify pin, `ao` source fallback).
- CHANGELOG `[3.5.0]` section (root + docs mirror): ao gc family, manifest mode, Mayor-dispatch doctrine, honest-scoped-PASS, fresh-install fixes, init gitignore policy.
- Curated `docs/releases/2026-07-31-v3.5.0-notes.md`: validator PASS, tier minor, full area coverage; upgrade notes call out the gc-maintainer-ops wrapper deprecation and the new init gitignore block.

Verification: notes validator PASS · `regen-all.sh --check` all ✓ · skill-lint 0 · `go build/vet/test` 2947 passed / 73 packages. Post-merge: official-mode readiness lap at the merged SHA with real HIL, record in docs/audits/ before any tag.