### PR TITLE
ci(release): goreleaser snapshot smoke between releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,6 +70,17 @@ jobs:
       - name: Run retrieval quality smoke
         run: bash evals/agentops-core/fixtures/retrieval-quality-smoke.sh
 
+  # The release path is otherwise exercised only by a real `v*` tag push, which
+  # is how a retired .goreleaser.yml before-hook stayed broken for 20 days
+  # (docs/audits/release-readiness-v3.3.0.md, "Process lesson"). The nightly run
+  # is the STANDING lane: it catches breakage from toolchain/action drift that
+  # no diff-triggered gate can see.
+  release-path-smoke:
+    name: Release Path Smoke
+    uses: ./.github/workflows/release-path-smoke.yml
+    permissions:
+      contents: read
+
   security-toolchain:
     name: Security Toolchain
     runs-on: ubuntu-latest
@@ -134,7 +145,7 @@ jobs:
 
   summary:
     name: Summary
-    needs: [cli-tests, static-validation, retrieval-bench, security-toolchain]
+    needs: [cli-tests, static-validation, retrieval-bench, release-path-smoke, security-toolchain]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -150,13 +161,14 @@ jobs:
             echo "| CLI tests | ${{ needs.cli-tests.result }} |"
             echo "| Static validation | ${{ needs.static-validation.result }} |"
             echo "| Retrieval bench | ${{ needs.retrieval-bench.result }} |"
+            echo "| Release path smoke | ${{ needs.release-path-smoke.result }} |"
             echo "| Security toolchain | ${{ needs.security-toolchain.result }} |"
             echo ""
             echo "Run completed at $(date -u)"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create issue on failure
-        if: needs.cli-tests.result == 'failure' || needs.static-validation.result == 'failure' || needs.retrieval-bench.result == 'failure' || needs.security-toolchain.result == 'failure'
+        if: needs.cli-tests.result == 'failure' || needs.static-validation.result == 'failure' || needs.retrieval-bench.result == 'failure' || needs.release-path-smoke.result == 'failure' || needs.security-toolchain.result == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -168,6 +180,7 @@ jobs:
           | CLI tests | ${{ needs.cli-tests.result }} |
           | Static validation | ${{ needs.static-validation.result }} |
           | Retrieval bench | ${{ needs.retrieval-bench.result }} |
+          | Release path smoke | ${{ needs.release-path-smoke.result }} |
           | Security toolchain | ${{ needs.security-toolchain.result }} |
 
           **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -188,5 +201,5 @@ jobs:
           fi
 
       - name: Check for failures
-        if: needs.cli-tests.result == 'failure' || needs.static-validation.result == 'failure' || needs.retrieval-bench.result == 'failure' || needs.security-toolchain.result == 'failure'
+        if: needs.cli-tests.result == 'failure' || needs.static-validation.result == 'failure' || needs.retrieval-bench.result == 'failure' || needs.release-path-smoke.result == 'failure' || needs.security-toolchain.result == 'failure'
         run: exit 1

--- a/.github/workflows/release-path-smoke.yml
+++ b/.github/workflows/release-path-smoke.yml
@@ -1,0 +1,104 @@
+name: release-path-smoke
+
+# The release path (.goreleaser.yml -> Release Publisher) is otherwise executed
+# ONLY by a real `v*` tag push, so a break in it is invisible until the next
+# release. That is not hypothetical: a retired `before.hooks` entry sat broken
+# for 20 days and surfaced only at tag time
+# (docs/audits/release-readiness-v3.3.0.md, "Process lesson").
+#
+# This workflow runs the same GoReleaser pipeline the publisher runs — config
+# load, before-hooks, cross-platform builds, archives, checksums, Homebrew
+# formula render — with publishing skipped, BETWEEN releases:
+#   * nightly (via workflow_call from nightly.yml), and
+#   * on every PR / main push that touches a release-plumbing input.
+#
+# It shares one script with its negative witness (tests/scripts/lib/
+# release-snapshot-smoke.sh + tests/scripts/release-path-smoke.bats), so the
+# proof that the gate can FAIL is a proof about the path CI actually runs.
+#
+# Isolated from validate.yml on purpose (no shared job registry to drift), same
+# as workflow-scripts-syntax.yml.
+
+on:
+  pull_request:
+    paths:
+      - '.goreleaser.yml'
+      - '.github/workflows/release.yml'
+      - '.github/workflows/release-path-smoke.yml'
+      - 'cli/go.mod'
+      - 'cli/Formula/**'
+      - 'tests/scripts/lib/release-snapshot-smoke.sh'
+      - 'tests/scripts/release-path-smoke.bats'
+  push:
+    branches:
+      - main
+    paths:
+      - '.goreleaser.yml'
+      - '.github/workflows/release.yml'
+      - '.github/workflows/release-path-smoke.yml'
+      - 'cli/go.mod'
+      - 'cli/Formula/**'
+      - 'tests/scripts/lib/release-snapshot-smoke.sh'
+      - 'tests/scripts/release-path-smoke.bats'
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-path-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  snapshot:
+    name: GoReleaser snapshot (publish skipped)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # GoReleaser reads git history to derive the snapshot version.
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26.5'
+          cache-dependency-path: cli/go.sum
+
+      # Same action + same version constraint the Release Publisher uses, so the
+      # smoke exercises the binary the publisher would actually get.
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
+        with:
+          version: '~> v2'
+          install-only: true
+
+      - name: Install bats
+        run: sudo npm install -g bats@1.12.0
+
+      # Full six-target matrix (darwin/linux/windows x amd64/arm64) — the same
+      # set the publisher builds. Measured ~12s locally end-to-end for this
+      # config, so there is no reason to partial-build: a single-platform
+      # snapshot would leave five publisher targets unexercised.
+      - name: Release-path smoke (green leg)
+        run: bash tests/scripts/lib/release-snapshot-smoke.sh
+
+      # Negative witness: prove the smoke can FAIL. Runs the same script against
+      # a deliberately broken temp copy of .goreleaser.yml (retired before-hook,
+      # invalid build stanza) and asserts non-zero.
+      - name: Release-path smoke negative witness
+        env:
+          AGENTOPS_RELEASE_SMOKE_FULL: '1'
+        run: bats --print-output-on-failure tests/scripts/release-path-smoke.bats
+
+      - name: Summarize
+        if: always()
+        run: |
+          {
+            echo "## Release-path smoke"
+            echo ""
+            echo "GoReleaser snapshot of \`.goreleaser.yml\` with publishing skipped."
+            echo "Runs between releases so a broken release path cannot sit undetected until the next tag."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Between-releases release-path smoke: `.github/workflows/release-path-smoke.yml`
+  runs a full GoReleaser snapshot (`goreleaser release --snapshot --clean
+  --skip=publish`) nightly and on every change to a release-plumbing input
+  (`.goreleaser.yml`, `.github/workflows/release.yml`, `cli/go.mod`,
+  `cli/Formula/**`). This closes the process commitment recorded in
+  `docs/audits/release-readiness-v3.3.0.md`: the release path was previously
+  executed only by a real `v*` tag push, which is how a retired
+  `.goreleaser.yml` before-hook stayed broken for 20 days. The smoke and its
+  negative witness share one script (`tests/scripts/lib/release-snapshot-smoke.sh`,
+  proven able to fail by `tests/scripts/release-path-smoke.bats`).
+
 ## [3.5.0] - 2026-07-31
 
 AgentOps 3.5 hardens the factory boundary 3.4 drew. The Gas City maintainer

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Between-releases release-path smoke: `.github/workflows/release-path-smoke.yml`
+  runs a full GoReleaser snapshot (`goreleaser release --snapshot --clean
+  --skip=publish`) nightly and on every change to a release-plumbing input
+  (`.goreleaser.yml`, `.github/workflows/release.yml`, `cli/go.mod`,
+  `cli/Formula/**`). This closes the process commitment recorded in
+  `docs/audits/release-readiness-v3.3.0.md`: the release path was previously
+  executed only by a real `v*` tag push, which is how a retired
+  `.goreleaser.yml` before-hook stayed broken for 20 days. The smoke and its
+  negative witness share one script (`tests/scripts/lib/release-snapshot-smoke.sh`,
+  proven able to fail by `tests/scripts/release-path-smoke.bats`).
+
 ## [3.5.0] - 2026-07-31
 
 AgentOps 3.5 hardens the factory boundary 3.4 drew. The Gas City maintainer

--- a/tests/scripts/lib/release-snapshot-smoke.sh
+++ b/tests/scripts/lib/release-snapshot-smoke.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# release-snapshot-smoke.sh — exercise the goreleaser RELEASE PATH between releases.
+#
+# WHY: the release path is only executed by a real `v*` tag push. A break in it
+# is therefore invisible until the next release. That is not hypothetical: a
+# retired `before.hooks` entry in .goreleaser.yml sat broken for 20 days and was
+# only found when the tag was pushed (docs/audits/release-readiness-v3.3.0.md,
+# "Process lesson"). This script runs the same GoReleaser pipeline the publisher
+# runs — config load, before-hooks, cross-platform builds, archives, checksums,
+# Homebrew formula render — with publishing skipped, so CI can prove the path
+# still works without cutting a release.
+#
+# WHY NOT `goreleaser check`: `check` exits non-zero on DEPRECATION warnings
+# alone (the current config's `brews:` block), so it cannot serve as the
+# between-releases gate without changing release behavior. It also never runs
+# hooks, builds, archives, or the formula template — precisely the stages that
+# broke. The snapshot is the real path; use it.
+#
+# Usage:
+#   bash tests/scripts/lib/release-snapshot-smoke.sh [--config PATH] [--timeout DUR]
+#
+# Options:
+#   --config PATH   GoReleaser config to exercise (default: <repo>/.goreleaser.yml)
+#   --timeout DUR   GoReleaser --timeout value (default: 20m)
+#   --help          Print this usage and exit 0
+#
+# Exit codes:
+#   0 - the release path built end-to-end (publishing skipped)
+#   1 - the release path is BROKEN (bad config, failing hook, build/archive error)
+#   2 - usage error, or goreleaser is not installed (cannot judge)
+#
+# Must run from the repository root: the config's build `dir: cli` and archive
+# `files:` entries are resolved relative to the working directory, not relative
+# to the config file.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../../.." && pwd)"
+
+CONFIG="$REPO_ROOT/.goreleaser.yml"
+TIMEOUT="20m"
+
+usage() {
+    sed -n '2,36p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --config)
+            [ "$#" -ge 2 ] || { echo "ERROR: --config requires a path" >&2; exit 2; }
+            CONFIG="$2"
+            shift 2
+            ;;
+        --config=*)
+            CONFIG="${1#--config=}"
+            shift
+            ;;
+        --timeout)
+            [ "$#" -ge 2 ] || { echo "ERROR: --timeout requires a duration" >&2; exit 2; }
+            TIMEOUT="$2"
+            shift 2
+            ;;
+        --timeout=*)
+            TIMEOUT="${1#--timeout=}"
+            shift
+            ;;
+        --help | -h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ ! -f "$CONFIG" ]; then
+    echo "ERROR: config not found: $CONFIG" >&2
+    exit 2
+fi
+
+if ! command -v goreleaser > /dev/null 2>&1; then
+    echo "ERROR: goreleaser is not installed; cannot exercise the release path" >&2
+    exit 2
+fi
+
+cd "$REPO_ROOT"
+
+echo "== release-path smoke: goreleaser snapshot =="
+echo "config:  $CONFIG"
+echo "version: $(goreleaser --version 2>/dev/null | tr -d '\r' | grep -i 'GitVersion' || echo 'unknown')"
+
+# --snapshot: no tag required, so this runs on any commit.
+# --clean:    start from an empty dist/, exactly like the publisher.
+# --skip=publish: never touch GitHub releases or the Homebrew tap. The formula
+#                 is still RENDERED to dist/, so a broken brews template is
+#                 still caught here.
+set +e
+goreleaser release \
+    --snapshot \
+    --clean \
+    --skip=publish \
+    --config "$CONFIG" \
+    --timeout "$TIMEOUT"
+rc=$?
+set -e
+
+if [ "$rc" -ne 0 ]; then
+    echo "FAIL  release path is broken (goreleaser exited $rc)" >&2
+    echo "      A real 'v*' tag push would fail the same way." >&2
+    exit 1
+fi
+
+echo "OK    release path built end-to-end (publish skipped)"
+exit 0

--- a/tests/scripts/release-path-smoke.bats
+++ b/tests/scripts/release-path-smoke.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+# Negative witness for the between-releases release-path smoke
+# (tests/scripts/lib/release-snapshot-smoke.sh, .github/workflows/release-path-smoke.yml).
+#
+# Repo law: every gate must be proven able to FAIL on the thing it claims to
+# detect. A release-path smoke that only ever ran on a healthy config would be
+# indistinguishable from `exit 0` — which is exactly how the retired
+# `before.hooks` entry survived 20 days undetected
+# (docs/audits/release-readiness-v3.3.0.md, "Process lesson").
+#
+# RED : a .goreleaser.yml copy carrying a retired before-hook -> smoke exits 1.
+# RED : a structurally invalid .goreleaser.yml copy            -> smoke exits 1.
+# GREEN: the real, current .goreleaser.yml                     -> smoke exits 0.
+#
+# The GREEN case is a full cross-platform snapshot build. It is skipped unless
+# AGENTOPS_RELEASE_SMOKE_FULL=1 so the generic `bats tests/scripts/*.bats` job
+# stays fast; the release-path-smoke workflow sets it and runs this file after
+# installing goreleaser, so the green leg is genuinely exercised in CI.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SMOKE="$REPO_ROOT/tests/scripts/lib/release-snapshot-smoke.sh"
+    WORKFLOW="$REPO_ROOT/.github/workflows/release-path-smoke.yml"
+    REAL_CONFIG="$REPO_ROOT/.goreleaser.yml"
+    FIX="$(mktemp -d "${BATS_TMPDIR:-/tmp}/relsmoke.XXXXXX")"
+}
+
+teardown() {
+    [ -n "${FIX:-}" ] && [ -d "$FIX" ] && rm -rf "$FIX"
+    return 0
+}
+
+require_goreleaser() {
+    command -v goreleaser > /dev/null 2>&1 || skip "goreleaser not installed"
+}
+
+@test "smoke script exists and is executable" {
+    [ -f "$SMOKE" ]
+    [ -x "$SMOKE" ]
+}
+
+@test "--help prints usage and exits 0" {
+    run bash "$SMOKE" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--config"* ]]
+    [[ "$output" == *"--timeout"* ]]
+}
+
+@test "usage error: unknown flag exits 2 (not confused with a broken release path)" {
+    run bash "$SMOKE" --nope
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"unknown argument"* ]]
+}
+
+@test "usage error: missing config exits 2" {
+    run bash "$SMOKE" --config "$FIX/does-not-exist.yml"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"config not found"* ]]
+}
+
+@test "the real .goreleaser.yml is structurally parseable and declares the release path" {
+    # Cheap structural assertion that runs everywhere, goreleaser or not: the
+    # config the smoke exercises must still be the release config.
+    [ -f "$REAL_CONFIG" ]
+    grep -q '^project_name: ao$' "$REAL_CONFIG"
+    grep -q '^builds:' "$REAL_CONFIG"
+    grep -q '^archives:' "$REAL_CONFIG"
+}
+
+@test "red: a retired before-hook makes the release path FAIL" {
+    # Reproduces the exact 20-day-undetected break: .goreleaser.yml referencing
+    # a script that no longer exists. Hooks run before any build, so this is
+    # fast even though it drives the real pipeline.
+    require_goreleaser
+    {
+        echo "before:"
+        echo "  hooks:"
+        echo "    - ./scripts/this-script-was-retired.sh"
+        cat "$REAL_CONFIG"
+    } > "$FIX/broken-hook.yml"
+
+    run bash "$SMOKE" --config "$FIX/broken-hook.yml" --timeout 5m
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"release path is broken"* ]]
+}
+
+@test "red: a structurally invalid config makes the release path FAIL" {
+    require_goreleaser
+    printf 'version: 2\nproject_name: ao\nbuilds:\n  - id: ao\n    goos: not-a-list\n' \
+        > "$FIX/invalid.yml"
+
+    run bash "$SMOKE" --config "$FIX/invalid.yml" --timeout 5m
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"release path is broken"* ]]
+}
+
+@test "green: the current .goreleaser.yml builds end-to-end" {
+    require_goreleaser
+    [ "${AGENTOPS_RELEASE_SMOKE_FULL:-0}" = "1" ] \
+        || skip "full snapshot build: set AGENTOPS_RELEASE_SMOKE_FULL=1"
+
+    run bash "$SMOKE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"release path built end-to-end"* ]]
+}
+
+@test "the release-path smoke workflow runs the shared smoke script" {
+    # Guards drift between the negative witness above and what CI actually runs.
+    [ -f "$WORKFLOW" ]
+    grep -q 'tests/scripts/lib/release-snapshot-smoke.sh' "$WORKFLOW"
+    grep -q 'tests/scripts/release-path-smoke.bats' "$WORKFLOW"
+}
+
+@test "nightly calls the release-path smoke workflow" {
+    nightly="$REPO_ROOT/.github/workflows/nightly.yml"
+    [ -f "$nightly" ]
+    grep -q './.github/workflows/release-path-smoke.yml' "$nightly"
+}


### PR DESCRIPTION
Closes the release-record commitment carried across three releases (`docs/audits/release-readiness-v3.3.0.md`, "Process lesson"): **CI must exercise the goreleaser release path between releases.** A retired `.goreleaser.yml` `before.hooks` entry once sat broken for 20 days because only a real `v*` tag runs that path.

## What lands

- `.github/workflows/release-path-smoke.yml` — full GoReleaser snapshot, publishing skipped.
- `tests/scripts/lib/release-snapshot-smoke.sh` — the one smoke path, shared by CI and its negative witness.
- `tests/scripts/release-path-smoke.bats` — the negative witness (10 tests).
- `.github/workflows/nightly.yml` — calls the smoke via `workflow_call`, wired into the summary table + failure-issue condition.
- `CHANGELOG.md` + `docs/CHANGELOG.md` — `[Unreleased]` entry (byte-identical mirror).

## Exact invocation, and why

```
goreleaser release --snapshot --clean --skip=publish --config <cfg> --timeout 20m
```

Installed with the **same** pinned `goreleaser/goreleaser-action@f06c13b6…  # v7` and `version: '~> v2'` that `release.yml` uses (`install-only: true`), so the smoke exercises the binary the publisher would actually get.

**`goreleaser check` is deliberately not the gate.** Verified against the repo's config on goreleaser 2.16.0: `goreleaser check` exits **1** on deprecation warnings alone (the config's `brews:` block), so it cannot gate without changing release behavior — and it never runs hooks, builds, archives, or the Homebrew formula template, which are precisely the stages that broke. The snapshot exits 0 on the same config. So the evidence below is from the **real snapshot**, not the cheap proxy.

## Acceptance → evidence

**1. Nightly + release-plumbing-input triggers.**
- Nightly: `nightly.yml` gains `release-path-smoke: uses: ./.github/workflows/release-path-smoke.yml`, added to `summary.needs`, the summary table, and both failure conditions.
- PR/push: `paths:` filter on `.goreleaser.yml`, `.github/workflows/release.yml`, `cli/go.mod`, `cli/Formula/**`, plus the smoke script and its bats file (so edits to the gate re-run the gate). A **dedicated workflow** rather than a `validate.yml` filter branch — same isolation rationale as `workflow-scripts-syntax.yml` ("no shared job registry to drift"), and it keeps `validate.yml`'s `changes` output list untouched.
- **Runtime choice: full six-target matrix, no split.** Measured locally: `11.5s` wall for `darwin/linux/windows × amd64/arm64` end-to-end (build + archive + checksums + formula render). A single-platform snapshot would leave five publisher targets unexercised for no meaningful time saving. Job `timeout-minutes: 20`.

**2. Negative witness.** `tests/scripts/release-path-smoke.bats` runs **the CI smoke path itself** against deliberately broken temp copies of `.goreleaser.yml`:
- `red: a retired before-hook makes the release path FAIL` — reproduces the exact 20-day bug (config prepended with `before: hooks: - ./scripts/this-script-was-retired.sh`), asserts `status -eq 1`.
- `red: a structurally invalid config makes the release path FAIL` — asserts `status -eq 1`.
- Plus usage-error legs asserting **exit 2** so "goreleaser missing / bad flags" is never mistaken for "release path broken".

```
$ AGENTOPS_RELEASE_SMOKE_FULL=1 bats tests/scripts/release-path-smoke.bats
1..10   … ok 1 … ok 10        # all 10 pass, both RED legs fire
```

The job is workflow-only (no new registry gate), so per the intent I confirmed the ratchet stays green:

```
$ cd cli && go test ./internal/gates/checks/ -run TestBlockingGatesHaveProvenNegativeWitness
ok   (1 passed)
```

**3. Passes against current main's config.** The green leg is the real snapshot, not `goreleaser check`:

```
$ bash tests/scripts/lib/release-snapshot-smoke.sh
… building binaries (6 targets) … archives … checksums … homebrew formula
release succeeded after 11s
OK    release path built end-to-end (publish skipped)     # rc=0
```

Also covered as the bats `green:` test (gated behind `AGENTOPS_RELEASE_SMOKE_FULL=1` so the generic `bats tests/scripts/*.bats` job stays fast; the smoke workflow sets it).

**4. CHANGELOG.** `[Unreleased] → Added` entry in `CHANGELOG.md`, mirrored byte-identically to `docs/CHANGELOG.md` (`diff` clean).

## Local gates (all rc=0)

| Check | Result |
|---|---|
| `cd cli && go build ./...` | 0 |
| `cd cli && go vet ./...` | 0 |
| `cd cli && go test ./...` | 0 |
| `bash scripts/regen-all.sh --check` | 0 — "All generated projections are current." |
| `bats --jobs 4 tests/scripts/*.bats` | 0 — 953 ok, 0 not ok |
| `ao gate check --full --workflow-coverage --require-workflow-parity` | 0 — 68/68 passed |
| `shellcheck tests/scripts/lib/release-snapshot-smoke.sh` | clean |
| YAML parse (both workflows) | OK |

## Scope

Write scope honored: `.github/workflows/**`, `tests/scripts/**`, `CHANGELOG.md`, `docs/CHANGELOG.md`. **`.goreleaser.yml` is read/verified only — not modified.** No `cli/**` Go code, no `skills/**`.

## Residual risk

- The `brews:` deprecation is left in place (out of scope). It is a warning today; if GoReleaser v3 removes it, this smoke is exactly what will surface it between releases instead of at tag time — which is the point.
- Nightly `workflow_call` inherits caller permissions; the reusable workflow declares `permissions: contents: read` and the nightly job pins the same.
