### PR TITLE
feat(gc): pre-seed Codex trust for materialized Gas City homes

### DIFF
--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -679,6 +679,7 @@ ao gc check [flags]
 
 ```
       --city string            Gas City root directory (required)
+      --codex-bin string       Codex CLI used to resolve hook trust identities (default: codex on PATH)
       --gc-bin string          Gas City 1.4 binary (default: gc on PATH)
   -h, --help                   help for check
       --pack-dir string        resolved official gascity pack root (normally auto-detected)
@@ -688,7 +689,7 @@ ao gc check [flags]
 
 #### `ao gc prepare`
 
-Stage the contained maintainer runtime and skill links for a rig
+Stage the contained maintainer runtime, skill links, and codex trust for a rig
 
 ```
 ao gc prepare [flags]
@@ -698,6 +699,7 @@ ao gc prepare [flags]
 
 ```
       --city string            Gas City root directory (required)
+      --codex-bin string       Codex CLI used to resolve hook trust identities (default: codex on PATH)
       --gc-bin string          Gas City 1.4 binary (default: gc on PATH)
   -h, --help                   help for prepare
       --pack-dir string        resolved official gascity pack root (normally auto-detected)

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -5,6 +5,7 @@ go 1.26
 toolchain go1.26.5
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/cli/internal/commands/gc/module.go
+++ b/cli/internal/commands/gc/module.go
@@ -21,6 +21,7 @@ type Module struct {
 	city         string
 	rig          string
 	gcBin        string
+	codexBin     string
 	packDir      string
 	skillsSource string
 	apply        bool
@@ -41,9 +42,13 @@ func (m *Module) Command() *cobra.Command {
 
 prepare verifies the official workflow and rig-role pins, snapshots upstream
 validation assets unchanged under the rig's ignored .gc directory, installs
-AgentOps-owned check wrappers, and links AgentOps skills into city/rig Codex
-sinks. check is read-only. recover-affinity only considers ready formula beads
-with gc.session_affinity=require and never re-slings work.`,
+AgentOps-owned check wrappers, links AgentOps skills into city/rig Codex
+sinks, and pre-seeds Codex workspace and hook trust for every session directory
+that exists, so an agent pane there does not block on the interactive trust
+dialog. A session home created after prepare is covered by the next run, which
+prepare warns about. check is read-only and runs no codex subprocess.
+recover-affinity only considers ready formula beads with
+gc.session_affinity=require and never re-slings work.`,
 	}
 	cmd.AddCommand(m.prepareCommand(), m.checkCommand(), m.recoverAffinityCommand())
 	return cmd
@@ -54,6 +59,7 @@ func (m *Module) options() gcmaintainer.Options {
 		City:         m.city,
 		Rig:          m.rig,
 		GCBin:        m.gcBin,
+		CodexBin:     m.codexBin,
 		PackDir:      m.packDir,
 		SkillsSource: m.skillsSource,
 		Apply:        m.apply,
@@ -72,13 +78,16 @@ func (m *Module) effectiveApply() bool {
 }
 
 // addCommonFlags wires the flags shared by every maintainer operation.
-func (m *Module) addCommonFlags(cmd *cobra.Command, withSkillsSource bool) {
+// withRuntimeFlags adds the flags that only the runtime-owning operations
+// (prepare and check) need: the skills source and the Codex trust binary.
+func (m *Module) addCommonFlags(cmd *cobra.Command, withRuntimeFlags bool) {
 	cmd.Flags().StringVar(&m.city, "city", "", "Gas City root directory (required)")
 	cmd.Flags().StringVar(&m.rig, "rig", "", "rig directory inside the city (required)")
 	cmd.Flags().StringVar(&m.gcBin, "gc-bin", "", "Gas City 1.4 binary (default: gc on PATH)")
 	cmd.Flags().StringVar(&m.packDir, "pack-dir", "", "resolved official gascity pack root (normally auto-detected)")
-	if withSkillsSource {
+	if withRuntimeFlags {
 		cmd.Flags().StringVar(&m.skillsSource, "skills-source", "", "AgentOps skills directory to link from (default: enclosing checkout, then installed skills root)")
+		cmd.Flags().StringVar(&m.codexBin, "codex-bin", "", "Codex CLI used to resolve hook trust identities (default: codex on PATH)")
 	}
 	_ = cmd.MarkFlagRequired("city")
 	_ = cmd.MarkFlagRequired("rig")
@@ -87,7 +96,7 @@ func (m *Module) addCommonFlags(cmd *cobra.Command, withSkillsSource bool) {
 func (m *Module) prepareCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "prepare",
-		Short: "Stage the contained maintainer runtime and skill links for a rig",
+		Short: "Stage the contained maintainer runtime, skill links, and codex trust for a rig",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if m.dryRun() {

--- a/cli/internal/gcmaintainer/codextrust.go
+++ b/cli/internal/gcmaintainer/codextrust.go
@@ -9,7 +9,6 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -17,6 +16,7 @@ import (
 	"unicode"
 
 	"github.com/BurntSushi/toml"
+	"github.com/boshu2/agentops/cli/internal/storage"
 )
 
 // Codex gates project-local configuration behind two independent, persisted
@@ -29,9 +29,9 @@ import (
 //     trusted_hash = "sha256:..."`, one entry per individual hook.
 //
 // A Gas City agent session home carries a `.codex/hooks.json`, so a first Codex
-// session in a fresh session home hits the interactive hooks-trust dialog
-// ("Press t to trust all") and blocks forever: dispatches queue as pending with
-// no active worker, and the wedge is invisible except through pane capture.
+// session in a fresh session home can hit the interactive hooks-trust dialog
+// ("Press t to trust all") and wait indefinitely: dispatches queue as pending
+// with no active worker, and the stall is invisible except through pane capture.
 //
 // Presence of a table is NOT trust. A `trust_level` that is not "trusted", a
 // missing or empty `trusted_hash`, or a hook Codex reports as "modified" all
@@ -538,12 +538,7 @@ func codexHooksList(bin, codexHome string, dirs []string) ([]codexHook, error) {
 
 	reader := bufio.NewReader(stdout)
 	send := func(message any) error {
-		data, err := json.Marshal(message)
-		if err != nil {
-			return err
-		}
-		_, err = stdin.Write(append(data, '\n'))
-		return err
+		return json.NewEncoder(stdin).Encode(message)
 	}
 
 	if err := send(map[string]any{
@@ -658,6 +653,23 @@ func lastLine(text string) string {
 //
 // Identities are compared, not counts: a stale home left behind by a removed
 // agent would make the counts agree while a real agent is still missing.
+type configuredAgent struct {
+	name          string
+	qualifiedName string
+}
+
+func (a configuredAgent) materialized(homes map[string]bool) bool {
+	return (a.name != "" && homes[a.name]) ||
+		(a.qualifiedName != "" && homes[a.qualifiedName])
+}
+
+func (a configuredAgent) displayName() string {
+	if a.qualifiedName != "" {
+		return a.qualifiedName
+	}
+	return a.name
+}
+
 func (o *ops) reportUnmaterializedHomes() {
 	configured, err := o.configuredAgents()
 	if err != nil || len(configured) == 0 {
@@ -673,10 +685,10 @@ func (o *ops) reportUnmaterializedHomes() {
 	}
 	var missing []string
 	for _, agent := range configured {
-		if materialized[agent] || materialized[path.Base(agent)] {
+		if agent.materialized(materialized) {
 			continue
 		}
-		missing = append(missing, agent)
+		missing = append(missing, agent.displayName())
 	}
 	if len(missing) == 0 {
 		return
@@ -688,10 +700,11 @@ func (o *ops) reportUnmaterializedHomes() {
 		len(missing), strings.Join(missing, ", "))
 }
 
-// configuredAgents lists the identities of the unsuspended agents the city
-// declares, preferring the qualified name because session homes nest the same
-// way (`<dir>/<name>`).
-func (o *ops) configuredAgents() ([]string, error) {
+// configuredAgents lists both identity forms for each unsuspended agent. Gas
+// City may return a dotted qualified name (for example `gastown.mayor`) while
+// storing the session at `.gc/agents/mayor`; nested providers may instead use
+// a slash-qualified home such as `.gc/agents/agentops/witness`.
+func (o *ops) configuredAgents() ([]configuredAgent, error) {
 	var payload struct {
 		Agents []struct {
 			Name          string `json:"name"`
@@ -702,17 +715,16 @@ func (o *ops) configuredAgents() ([]string, error) {
 	if err := o.gcJSON(&payload, "cannot list configured agents", "--city", o.city, "agent", "list", "--json"); err != nil {
 		return nil, err
 	}
-	var agents []string
+	var agents []configuredAgent
 	for _, agent := range payload.Agents {
 		if agent.Suspended {
 			continue
 		}
-		identity := agent.QualifiedName
-		if identity == "" {
-			identity = agent.Name
-		}
-		if identity != "" {
-			agents = append(agents, identity)
+		if agent.Name != "" || agent.QualifiedName != "" {
+			agents = append(agents, configuredAgent{
+				name:          agent.Name,
+				qualifiedName: agent.QualifiedName,
+			})
 		}
 	}
 	return agents, nil
@@ -742,24 +754,15 @@ func tomlQuote(value string) string {
 	return out.String()
 }
 
-// codexTrustBackupSuffix names the copy of the operator's original trust store
-// kept only for the instant between writing the replacement and renaming it in.
-const codexTrustBackupSuffix = ".agentops-bak"
-
 // appendCodexConfig appends whole table blocks to the trust store, creating it
 // when absent.
 //
 // The operator's config is never edited in place. The merged content is built
-// in memory, written to a temp file in the same directory, and PARSED THERE; a
-// merge that would not round-trip is rejected before the real file is touched
-// at all. Only a validated temp file is renamed over the original, atomically,
-// with a backup of the original kept until the rename succeeds. No failure path
-// can leave the operator with a corrupted codex config.
+// and parsed in memory; a merge that would not round-trip is rejected before
+// the real file is touched. The repository's canonical atomic writer then
+// installs the validated bytes durably while preserving the existing mode. No
+// failure path can leave the operator with a partially written Codex config.
 func appendCodexConfig(path, block string) error {
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("create codex home %s: %w", dir, err)
-	}
 	existing, err := os.ReadFile(path) // #nosec G304 -- operator-owned codex trust store resolved from CODEX_HOME.
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("read codex trust store %s: %w", path, err)
@@ -775,48 +778,13 @@ func appendCodexConfig(path, block string) error {
 	}
 	merged += block
 
-	tmp, err := os.CreateTemp(dir, ".config.toml.agentops.")
-	if err != nil {
-		return fmt.Errorf("stage codex trust store update: %w", err)
-	}
-	tmpName := tmp.Name()
-	cleanup := true
-	defer func() {
-		if cleanup {
-			_ = os.Remove(tmpName)
-		}
-	}()
-	if _, err := tmp.WriteString(merged); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("stage codex trust store update: %w", err)
-	}
-	if err := tmp.Chmod(mode); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("stage codex trust store update: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("stage codex trust store update: %w", err)
-	}
-
-	// Validate the staged replacement before the operator's file is at risk.
-	if _, err := readCodexTrustStore(tmpName); err != nil {
+	// Validate the replacement bytes before the operator's file is at risk.
+	var candidate trustStore
+	if err := toml.Unmarshal([]byte(merged), &candidate); err != nil {
 		return fmt.Errorf("refusing to update %s: the merged trust store would not be parsable: %w", path, err)
 	}
-
-	backup := path + codexTrustBackupSuffix
-	haveBackup := false
-	if len(existing) > 0 {
-		if err := os.WriteFile(backup, existing, mode); err != nil {
-			return fmt.Errorf("back up codex trust store %s: %w", path, err)
-		}
-		haveBackup = true
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		return fmt.Errorf("install codex trust store %s (original preserved at %s): %w", path, backup, err)
-	}
-	cleanup = false
-	if haveBackup {
-		_ = os.Remove(backup)
+	if err := storage.AtomicWriteFile(path, []byte(merged), mode); err != nil {
+		return fmt.Errorf("install codex trust store %s: %w", path, err)
 	}
 	return nil
 }

--- a/cli/internal/gcmaintainer/codextrust.go
+++ b/cli/internal/gcmaintainer/codextrust.go
@@ -1,0 +1,822 @@
+package gcmaintainer
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Codex gates project-local configuration behind two independent, persisted
+// trust decisions, both stored in `$CODEX_HOME/config.toml`:
+//
+//  1. Workspace trust — `[projects."<dir>"] trust_level = "trusted"`. Any other
+//     level (including an explicit "untrusted") makes Codex silently report the
+//     directory as having no hooks at all, with no warning and no error.
+//  2. Hook trust — `[hooks.state."<hooks.json>:<event>:<matcher>:<hook>"]
+//     trusted_hash = "sha256:..."`, one entry per individual hook.
+//
+// A Gas City agent session home carries a `.codex/hooks.json`, so a first Codex
+// session in a fresh session home hits the interactive hooks-trust dialog
+// ("Press t to trust all") and blocks forever: dispatches queue as pending with
+// no active worker, and the wedge is invisible except through pane capture.
+//
+// Presence of a table is NOT trust. A `trust_level` that is not "trusted", a
+// missing or empty `trusted_hash`, or a hook Codex reports as "modified" all
+// leave the wedge in place, so both prepare and check compare actual values.
+//
+// The `trusted_hash` value is derived from hook content by Codex itself and is
+// deliberately not reimplemented here — guessing the digest input is how this
+// silently rots on the next Codex release. prepare reads the exact identity
+// back from Codex's own `hooks/list` app-server method. check never runs a
+// subprocess: it derives the expected hook keys from each `hooks.json` and
+// verifies the stored values, so it stays a pure read of local state.
+//
+// Empirically (codex-cli 0.145.0) the hash is semantic: the same logical hooks
+// re-serialized with different key order or indentation produce the identical
+// hash. Only the key carries the path.
+const (
+	// codexTrustScanDepth bounds the search for Gas City session directories
+	// below the city's `.gc/agents` and `.gc/worktrees` roots.
+	codexTrustScanDepth = 4
+	// codexHookListTimeout bounds one `codex app-server` hooks/list exchange.
+	codexHookListTimeout = 90 * time.Second
+	// codexTrustedLevel is the only workspace trust level that loads a
+	// directory's project-local Codex configuration.
+	codexTrustedLevel = "trusted"
+	// codexWedgeHint explains, in one line, why a missing pre-seed matters.
+	codexWedgeHint = "the first codex session there blocks on the interactive trust dialog and the agent pane wedges with no visible error"
+)
+
+// codexHook is one hook identity as Codex itself reports it.
+type codexHook struct {
+	Key         string `json:"key"`
+	CurrentHash string `json:"currentHash"`
+	TrustStatus string `json:"trustStatus"`
+}
+
+// hookTrust is one recorded `[hooks.state."..."]` decision.
+type hookTrust struct {
+	TrustedHash string `toml:"trusted_hash"`
+	Enabled     *bool  `toml:"enabled"`
+}
+
+// projectTrust is one recorded `[projects."..."]` decision.
+type projectTrust struct {
+	TrustLevel string `toml:"trust_level"`
+}
+
+// trustStore is the decoded Codex trust state. It is read with a real TOML
+// parser so every valid spelling of a table header (trailing comments,
+// single-quoted keys, literal strings) is understood; writes stay append-only
+// and happen only where a real parse proved the entry absent.
+type trustStore struct {
+	Projects map[string]projectTrust `toml:"projects"`
+	Hooks    struct {
+		State map[string]hookTrust `toml:"state"`
+	} `toml:"hooks"`
+}
+
+// workspaceTrusted reports whether dir is actually trusted, not merely listed.
+func (s *trustStore) workspaceTrusted(dir string) bool {
+	return s.Projects[dir].TrustLevel == codexTrustedLevel
+}
+
+// workspaceLevel returns the recorded level for dir, or "" when absent.
+func (s *trustStore) workspaceLevel(dir string) string {
+	return s.Projects[dir].TrustLevel
+}
+
+// hookTrustSatisfied is THE completeness rule. prepare seeds until it holds
+// for every hook and check requires it for every derived key, so whatever one
+// accepts as done the other accepts too - including a hook Codex reports as
+// `managed`, which prepare records so check can round-trip it without asking
+// Codex.
+//
+// A hook recorded with `enabled = false` is not satisfied: it is a disabled
+// hook, not a trusted working one, and treating it as done would hide it.
+func (s *trustStore) hookTrustSatisfied(key string) bool {
+	return s.hookTrustDefect(key) == ""
+}
+
+// hookTrustDefect names why key is not satisfied, or "" when it is. Both
+// commands report using this text so they never disagree about what is wrong.
+func (s *trustStore) hookTrustDefect(key string) string {
+	entry, ok := s.Hooks.State[key]
+	switch {
+	case !ok:
+		return "has no recorded trust entry"
+	case strings.TrimSpace(entry.TrustedHash) == "":
+		return "has a trust entry with no usable trusted_hash"
+	case entry.Enabled != nil && !*entry.Enabled:
+		return "is recorded as enabled = false, so it is not a trusted working hook"
+	default:
+		return ""
+	}
+}
+
+// hookRecorded reports whether key has any recorded decision at all.
+func (s *trustStore) hookRecorded(key string) bool {
+	_, ok := s.Hooks.State[key]
+	return ok
+}
+
+// readCodexTrustStore decodes the trust store with a real TOML parser. A
+// missing store is an empty one; an unparsable store is an error, never an
+// empty result that would read as "nothing is trusted yet".
+func readCodexTrustStore(path string) (*trustStore, error) {
+	store := &trustStore{Projects: map[string]projectTrust{}}
+	store.Hooks.State = map[string]hookTrust{}
+	data, err := os.ReadFile(path) // #nosec G304 -- operator-owned codex trust store resolved from CODEX_HOME.
+	if err != nil {
+		if os.IsNotExist(err) {
+			return store, nil
+		}
+		return nil, fmt.Errorf("read codex trust store %s: %w", path, err)
+	}
+	if err := toml.Unmarshal(data, store); err != nil {
+		return nil, fmt.Errorf("parse codex trust store %s: %w", path, err)
+	}
+	if store.Projects == nil {
+		store.Projects = map[string]projectTrust{}
+	}
+	if store.Hooks.State == nil {
+		store.Hooks.State = map[string]hookTrust{}
+	}
+	return store, nil
+}
+
+// resolveCodexHome returns the Codex home directory that holds config.toml.
+// It is not required to exist yet; prepare creates it.
+func resolveCodexHome() (string, error) {
+	if explicit := os.Getenv("CODEX_HOME"); explicit != "" {
+		return filepath.Abs(explicit)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("HOME is required to locate the codex trust store: %w", err)
+	}
+	return filepath.Join(home, ".codex"), nil
+}
+
+// resolveCodexBin resolves the Codex CLI prepare uses to read hook identities.
+// An explicit path must be executable; auto-detection degrades to "".
+func resolveCodexBin(explicit string) (string, error) {
+	if explicit != "" {
+		if !isExecutableFile(explicit) {
+			return "", fmt.Errorf("codex binary is not executable: %s", explicit)
+		}
+		return canonical(explicit)
+	}
+	bin, err := exec.LookPath("codex")
+	if err != nil || !isExecutableFile(bin) {
+		return "", nil
+	}
+	resolved, err := canonical(bin)
+	if err != nil {
+		return "", nil
+	}
+	return resolved, nil
+}
+
+// codexTrustTargets lists the directories a Gas City provider session runs in:
+// the city and rig roots, every agent session home, and every rig worktree
+// root. Discovery is by filesystem marker, so it covers whatever the city has
+// materialized; homes created later are covered by the next prepare.
+func (o *ops) codexTrustTargets() []string {
+	seen := map[string]bool{}
+	var targets []string
+	add := func(dir string) {
+		resolved, err := canonical(dir)
+		if err != nil || seen[resolved] {
+			return
+		}
+		seen[resolved] = true
+		targets = append(targets, resolved)
+	}
+	add(o.city)
+	add(o.rig)
+
+	var discovered []string
+	for _, root := range []string{
+		filepath.Join(o.city, ".gc", "agents"),
+		filepath.Join(o.city, ".gc", "worktrees"),
+	} {
+		discovered = append(discovered, sessionDirsUnder(root)...)
+	}
+	sort.Strings(discovered)
+	for _, dir := range discovered {
+		add(dir)
+	}
+	return targets
+}
+
+// sessionDirsUnder finds directories below root that look like a workspace a
+// Codex session is launched in. A match is not descended into, which keeps the
+// walk off the inside of rig worktrees.
+func sessionDirsUnder(root string) []string {
+	if !isDir(root) {
+		return nil
+	}
+	var found []string
+	_ = filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil || entry == nil {
+			return nil //nolint:nilerr // an unreadable subtree is skipped, not fatal
+		}
+		if !entry.IsDir() || path == root {
+			return nil
+		}
+		if strings.HasPrefix(entry.Name(), ".") {
+			return fs.SkipDir
+		}
+		if isSessionDir(path) {
+			found = append(found, path)
+			return fs.SkipDir
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return fs.SkipDir
+		}
+		if len(strings.Split(rel, string(filepath.Separator))) >= codexTrustScanDepth {
+			return fs.SkipDir
+		}
+		return nil
+	})
+	return found
+}
+
+// isSessionDir reports whether path carries a marker that makes it a directory
+// a Codex session is launched in.
+func isSessionDir(path string) bool {
+	for _, marker := range []string{".codex", ".git"} {
+		if _, err := os.Lstat(filepath.Join(path, marker)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// hookFile returns the project-local hooks file for a session directory.
+func hookFile(dir string) string {
+	return filepath.Join(dir, ".codex", "hooks.json")
+}
+
+// seedCodexTrust pre-seeds workspace trust and hook trust for every Gas City
+// session directory. It appends only entries the store is missing, so an
+// operator decision is never rewritten; an entry that exists but does not
+// actually confer trust is a hard error naming that entry, because silently
+// skipping it would report success while leaving the wedge in place.
+func (o *ops) seedCodexTrust() error {
+	targets := o.codexTrustTargets()
+	store, err := readCodexTrustStore(o.codexConfig)
+	if err != nil {
+		return err
+	}
+
+	// Workspace trust first: Codex reports no hooks at all for a directory
+	// whose trust level is anything other than "trusted".
+	var block strings.Builder
+	addedProjects := 0
+	for _, dir := range targets {
+		if store.workspaceTrusted(dir) {
+			continue
+		}
+		if level := store.workspaceLevel(dir); level != "" {
+			return fmt.Errorf("codex workspace %s is recorded as trust_level %q, not %q; "+
+				"refusing to overwrite that decision - fix the [projects] entry in %s (%s)",
+				dir, level, codexTrustedLevel, o.codexConfig, codexWedgeHint)
+		}
+		addedProjects++
+		fmt.Fprintf(&block, "\n[projects.%s]\ntrust_level = \"trusted\"\n", tomlQuote(dir))
+	}
+	if block.Len() > 0 {
+		if err := appendCodexConfig(o.codexConfig, block.String()); err != nil {
+			return err
+		}
+	}
+
+	entries, err := o.listCodexHooks(targets)
+	if err != nil {
+		return err
+	}
+	var hookBlock strings.Builder
+	addedHooks := 0
+	for _, entry := range entries {
+		if entry.TrustStatus == "modified" {
+			return fmt.Errorf("codex hook %s changed since it was trusted; "+
+				"refusing to re-trust changed hook content automatically - review it and re-trust in codex (%s)",
+				entry.Key, codexWedgeHint)
+		}
+		if store.hookTrustSatisfied(entry.Key) {
+			if entry.TrustStatus == "untrusted" {
+				return fmt.Errorf("codex hook %s has a recorded trust entry that codex still reports as %q; "+
+					"refusing to overwrite that decision - fix the [hooks.state] entry in %s (%s)",
+					entry.Key, entry.TrustStatus, o.codexConfig, codexWedgeHint)
+			}
+			continue
+		}
+		if store.hookRecorded(entry.Key) {
+			return fmt.Errorf("codex hook %s %s; "+
+				"refusing to overwrite that decision - fix the [hooks.state] entry in %s (%s)",
+				entry.Key, store.hookTrustDefect(entry.Key), o.codexConfig, codexWedgeHint)
+		}
+		// A `managed` hook is recorded too, so `check` - which never asks
+		// Codex - can confirm it by the same rule prepare just applied.
+		addedHooks++
+		store.Hooks.State[entry.Key] = hookTrust{TrustedHash: entry.CurrentHash}
+		fmt.Fprintf(&hookBlock, "\n[hooks.state.%s]\ntrusted_hash = %s\n", tomlQuote(entry.Key), tomlQuote(entry.CurrentHash))
+	}
+	if hookBlock.Len() > 0 {
+		if err := appendCodexConfig(o.codexConfig, hookBlock.String()); err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprintf(o.stdout, "codex trust pre-seeded: %d workspace(s) and %d hook(s) added across %d session director(ies)\n",
+		addedProjects, addedHooks, len(targets))
+	o.reportUnmaterializedHomes()
+	return nil
+}
+
+// checkCodexTrust verifies, from local state only, that every Gas City session
+// directory is pre-seeded. It runs no subprocess and writes nothing, so it is
+// a pure read.
+//
+// NAMED LIMITATION: because it never asks Codex, it cannot judge hash
+// freshness. A recorded `trusted_hash` that no longer matches the hook's
+// current content reads as satisfied here and still raises the trust dialog in
+// a real session. Only `ao gc prepare`, which talks to Codex, detects that
+// (Codex reports the hook as `modified`, and prepare refuses).
+func (o *ops) checkCodexTrust() error {
+	targets := o.codexTrustTargets()
+	store, err := readCodexTrustStore(o.codexConfig)
+	if err != nil {
+		return err
+	}
+	for _, dir := range targets {
+		if store.workspaceTrusted(dir) {
+			continue
+		}
+		if level := store.workspaceLevel(dir); level != "" {
+			return fmt.Errorf("codex workspace %s is recorded as trust_level %q, not %q; run `ao gc prepare` (%s)",
+				dir, level, codexTrustedLevel, codexWedgeHint)
+		}
+		return fmt.Errorf("codex workspace trust is not pre-seeded for %s; run `ao gc prepare` (%s)", dir, codexWedgeHint)
+	}
+	for _, dir := range targets {
+		keys, err := derivedHookKeys(dir)
+		if err != nil {
+			return err
+		}
+		for _, key := range keys {
+			if defect := store.hookTrustDefect(key); defect != "" {
+				return fmt.Errorf("codex hook %s %s; run `ao gc prepare` (%s)", key, defect, codexWedgeHint)
+			}
+		}
+	}
+	return nil
+}
+
+// derivedHookKeys reconstructs the hook-state keys Codex uses for a session
+// directory's project-local hooks, so check can verify trust without asking
+// Codex. Events are visited in sorted order so a failure names the same hook
+// on every run.
+func derivedHookKeys(dir string) ([]string, error) {
+	path := hookFile(dir)
+	data, err := os.ReadFile(path) // #nosec G304 -- project-local hooks file inside a discovered Gas City session directory.
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var document struct {
+		Hooks map[string][]struct {
+			Hooks []json.RawMessage `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &document); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	events := make([]string, 0, len(document.Hooks))
+	for event := range document.Hooks {
+		events = append(events, event)
+	}
+	sort.Strings(events)
+	var keys []string
+	for _, event := range events {
+		for groupIndex, group := range document.Hooks[event] {
+			for hookIndex := range group.Hooks {
+				keys = append(keys, fmt.Sprintf("%s:%s:%d:%d", path, snakeCase(event), groupIndex, hookIndex))
+			}
+		}
+	}
+	return keys, nil
+}
+
+// snakeCase converts a Codex event name ("UserPromptSubmit") to the form used
+// in a hook-state key ("user_prompt_submit").
+func snakeCase(name string) string {
+	var out strings.Builder
+	for index, r := range name {
+		if unicode.IsUpper(r) {
+			if index > 0 {
+				out.WriteByte('_')
+			}
+			out.WriteRune(unicode.ToLower(r))
+			continue
+		}
+		out.WriteRune(r)
+	}
+	return out.String()
+}
+
+// listCodexHooks asks the Codex CLI for the hook identities visible from the
+// target directories, then drops any identity that is not rooted under one of
+// those directories - a `hooks/list` result also carries user-level and plugin
+// hooks, and trust must never be granted beyond the discovered session roots.
+func (o *ops) listCodexHooks(targets []string) ([]codexHook, error) {
+	if len(targets) == 0 {
+		return nil, nil
+	}
+	if o.codexBin == "" {
+		fmt.Fprintf(o.stderr, "warning: no codex binary on PATH; codex hook trust was not resolved (workspace trust still applies)\n")
+		return nil, nil
+	}
+	entries, err := codexHooksList(o.codexBin, o.codexHome, targets)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read codex hook trust state: %w", err)
+	}
+
+	owned := map[string]bool{}
+	for _, dir := range targets {
+		owned[hookFile(dir)] = true
+	}
+	var kept []codexHook
+	covered := map[string]bool{}
+	for _, entry := range entries {
+		source, ok := hookKeySourcePath(entry.Key)
+		if !ok || !owned[source] {
+			fmt.Fprintf(o.stderr, "note: ignoring codex hook outside the Gas City session directories: %s\n", entry.Key)
+			continue
+		}
+		kept = append(kept, entry)
+		covered[source] = true
+	}
+
+	// Fail closed: a session directory that has a hooks file must produce at
+	// least one hook identity. Zero means the response shape changed or the
+	// directory is not actually loading its project config - either way,
+	// continuing on an empty list would report success while the wedge remains.
+	for _, dir := range targets {
+		source := hookFile(dir)
+		if isRegularFile(source) && !covered[source] {
+			return nil, fmt.Errorf("codex reported no hooks for %s even though %s exists; "+
+				"refusing to continue on an empty hook list (%s)", dir, source, codexWedgeHint)
+		}
+	}
+	return kept, nil
+}
+
+// hookKeySourcePath extracts the hooks file path from a hook-state key of the
+// form `<path>:<event>:<matcher index>:<hook index>`.
+func hookKeySourcePath(key string) (string, bool) {
+	for i := 0; i < 3; i++ {
+		cut := strings.LastIndex(key, ":")
+		if cut < 0 {
+			return "", false
+		}
+		key = key[:cut]
+	}
+	if key == "" {
+		return "", false
+	}
+	return key, true
+}
+
+// codexHooksList drives one `codex app-server` stdio JSON-RPC exchange and
+// returns every hook Codex reports for the given working directories.
+func codexHooksList(bin, codexHome string, dirs []string) ([]codexHook, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), codexHookListTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, bin, "app-server")
+	cmd.Dir = dirs[0]
+	cmd.Env = append(os.Environ(), "CODEX_HOME="+codexHome)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open codex stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open codex stdout: %w", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start codex app-server: %w", err)
+	}
+	defer func() {
+		_ = stdin.Close()
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	}()
+
+	reader := bufio.NewReader(stdout)
+	send := func(message any) error {
+		data, err := json.Marshal(message)
+		if err != nil {
+			return err
+		}
+		_, err = stdin.Write(append(data, '\n'))
+		return err
+	}
+
+	if err := send(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "initialize",
+		"params": map[string]any{
+			"clientInfo":   map[string]any{"name": "agentops", "version": "1"},
+			"capabilities": map[string]any{"experimentalApi": true},
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("send codex initialize: %w", err)
+	}
+	if _, err := readRPCResult(reader, "1"); err != nil {
+		return nil, decorateCodexError(err, &stderr)
+	}
+	if err := send(map[string]any{"jsonrpc": "2.0", "method": "initialized"}); err != nil {
+		return nil, fmt.Errorf("send codex initialized: %w", err)
+	}
+	if err := send(map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "hooks/list",
+		"params": map[string]any{"cwds": dirs},
+	}); err != nil {
+		return nil, fmt.Errorf("send codex hooks/list: %w", err)
+	}
+	raw, err := readRPCResult(reader, "2")
+	if err != nil {
+		return nil, decorateCodexError(err, &stderr)
+	}
+	return decodeHooksList(raw)
+}
+
+// decodeHooksList validates the hooks/list result shape and rejects anything it
+// does not recognize, so a protocol change surfaces as a failure instead of an
+// empty, silently successful trust pass.
+func decodeHooksList(raw json.RawMessage) ([]codexHook, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("codex hooks/list returned no result payload")
+	}
+	var payload struct {
+		Data *[]struct {
+			Cwd   *string      `json:"cwd"`
+			Hooks *[]codexHook `json:"hooks"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, fmt.Errorf("codex hooks/list result has an unrecognized shape: %w", err)
+	}
+	if payload.Data == nil {
+		return nil, fmt.Errorf("codex hooks/list result is missing its data array")
+	}
+	var hooks []codexHook
+	for index, entry := range *payload.Data {
+		if entry.Cwd == nil || entry.Hooks == nil {
+			return nil, fmt.Errorf("codex hooks/list entry %d is missing cwd or hooks", index)
+		}
+		for _, hook := range *entry.Hooks {
+			if strings.TrimSpace(hook.Key) == "" || strings.TrimSpace(hook.CurrentHash) == "" {
+				return nil, fmt.Errorf("codex hooks/list reported a hook with no key or hash under %s", *entry.Cwd)
+			}
+			switch hook.TrustStatus {
+			case "trusted", "untrusted", "modified", "managed":
+			default:
+				return nil, fmt.Errorf("codex hooks/list reported unknown trustStatus %q for %s", hook.TrustStatus, hook.Key)
+			}
+			hooks = append(hooks, hook)
+		}
+	}
+	return hooks, nil
+}
+
+// readRPCResult consumes stdio JSON-RPC lines until the response carrying id
+// arrives, ignoring the server notifications interleaved with it.
+func readRPCResult(reader *bufio.Reader, id string) (json.RawMessage, error) {
+	for {
+		line, err := reader.ReadString('\n')
+		if len(strings.TrimSpace(line)) > 0 {
+			var message struct {
+				ID     json.RawMessage `json:"id"`
+				Result json.RawMessage `json:"result"`
+				Error  *struct {
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			if json.Unmarshal([]byte(line), &message) == nil && string(message.ID) == id {
+				if message.Error != nil {
+					return nil, fmt.Errorf("codex returned an error: %s", message.Error.Message)
+				}
+				return message.Result, nil
+			}
+		}
+		if err != nil {
+			return nil, fmt.Errorf("codex app-server ended before answering request %s", id)
+		}
+	}
+}
+
+func decorateCodexError(err error, stderr *bytes.Buffer) error {
+	detail := strings.TrimSpace(stderr.String())
+	if detail == "" {
+		return err
+	}
+	return fmt.Errorf("%w: %s", err, lastLine(detail))
+}
+
+func lastLine(text string) string {
+	lines := strings.Split(text, "\n")
+	return strings.TrimSpace(lines[len(lines)-1])
+}
+
+// reportUnmaterializedHomes names the configured agents that have no session
+// home yet. Those homes do not exist, so their hooks cannot be trusted in
+// advance and prepare must be re-run once they appear.
+//
+// Identities are compared, not counts: a stale home left behind by a removed
+// agent would make the counts agree while a real agent is still missing.
+func (o *ops) reportUnmaterializedHomes() {
+	configured, err := o.configuredAgents()
+	if err != nil || len(configured) == 0 {
+		return
+	}
+	root := filepath.Join(o.city, ".gc", "agents")
+	materialized := map[string]bool{}
+	for _, home := range sessionDirsUnder(root) {
+		if rel, relErr := filepath.Rel(root, home); relErr == nil {
+			materialized[filepath.ToSlash(rel)] = true
+			materialized[filepath.Base(rel)] = true
+		}
+	}
+	var missing []string
+	for _, agent := range configured {
+		if materialized[agent] || materialized[path.Base(agent)] {
+			continue
+		}
+		missing = append(missing, agent)
+	}
+	if len(missing) == 0 {
+		return
+	}
+	sort.Strings(missing)
+	fmt.Fprintf(o.stderr,
+		"warning: %d configured agent(s) have no session home yet (%s); "+
+			"a home created later carries untrusted hooks - re-run `ao gc prepare` after the city starts and before dispatching\n",
+		len(missing), strings.Join(missing, ", "))
+}
+
+// configuredAgents lists the identities of the unsuspended agents the city
+// declares, preferring the qualified name because session homes nest the same
+// way (`<dir>/<name>`).
+func (o *ops) configuredAgents() ([]string, error) {
+	var payload struct {
+		Agents []struct {
+			Name          string `json:"name"`
+			QualifiedName string `json:"qualified_name"`
+			Suspended     bool   `json:"suspended"`
+		} `json:"agents"`
+	}
+	if err := o.gcJSON(&payload, "cannot list configured agents", "--city", o.city, "agent", "list", "--json"); err != nil {
+		return nil, err
+	}
+	var agents []string
+	for _, agent := range payload.Agents {
+		if agent.Suspended {
+			continue
+		}
+		identity := agent.QualifiedName
+		if identity == "" {
+			identity = agent.Name
+		}
+		if identity != "" {
+			agents = append(agents, identity)
+		}
+	}
+	return agents, nil
+}
+
+// tomlQuote renders value as a TOML basic string.
+func tomlQuote(value string) string {
+	var out strings.Builder
+	out.WriteByte('"')
+	for _, r := range value {
+		switch r {
+		case '\\':
+			out.WriteString(`\\`)
+		case '"':
+			out.WriteString(`\"`)
+		case '\n':
+			out.WriteString(`\n`)
+		case '\t':
+			out.WriteString(`\t`)
+		case '\r':
+			out.WriteString(`\r`)
+		default:
+			out.WriteRune(r)
+		}
+	}
+	out.WriteByte('"')
+	return out.String()
+}
+
+// codexTrustBackupSuffix names the copy of the operator's original trust store
+// kept only for the instant between writing the replacement and renaming it in.
+const codexTrustBackupSuffix = ".agentops-bak"
+
+// appendCodexConfig appends whole table blocks to the trust store, creating it
+// when absent.
+//
+// The operator's config is never edited in place. The merged content is built
+// in memory, written to a temp file in the same directory, and PARSED THERE; a
+// merge that would not round-trip is rejected before the real file is touched
+// at all. Only a validated temp file is renamed over the original, atomically,
+// with a backup of the original kept until the rename succeeds. No failure path
+// can leave the operator with a corrupted codex config.
+func appendCodexConfig(path, block string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create codex home %s: %w", dir, err)
+	}
+	existing, err := os.ReadFile(path) // #nosec G304 -- operator-owned codex trust store resolved from CODEX_HOME.
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read codex trust store %s: %w", path, err)
+	}
+	mode := os.FileMode(0o600)
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode().Perm()
+	}
+
+	merged := string(existing)
+	if len(existing) > 0 && !strings.HasSuffix(merged, "\n") {
+		merged += "\n"
+	}
+	merged += block
+
+	tmp, err := os.CreateTemp(dir, ".config.toml.agentops.")
+	if err != nil {
+		return fmt.Errorf("stage codex trust store update: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.WriteString(merged); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("stage codex trust store update: %w", err)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("stage codex trust store update: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("stage codex trust store update: %w", err)
+	}
+
+	// Validate the staged replacement before the operator's file is at risk.
+	if _, err := readCodexTrustStore(tmpName); err != nil {
+		return fmt.Errorf("refusing to update %s: the merged trust store would not be parsable: %w", path, err)
+	}
+
+	backup := path + codexTrustBackupSuffix
+	haveBackup := false
+	if len(existing) > 0 {
+		if err := os.WriteFile(backup, existing, mode); err != nil {
+			return fmt.Errorf("back up codex trust store %s: %w", path, err)
+		}
+		haveBackup = true
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("install codex trust store %s (original preserved at %s): %w", path, backup, err)
+	}
+	cleanup = false
+	if haveBackup {
+		_ = os.Remove(backup)
+	}
+	return nil
+}

--- a/cli/internal/gcmaintainer/codextrust.go
+++ b/cli/internal/gcmaintainer/codextrust.go
@@ -423,6 +423,9 @@ func derivedHookKeys(dir string) ([]string, error) {
 			}
 		}
 	}
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("%s contains no hook identities; refusing to accept an empty hook set", path)
+	}
 	return keys, nil
 }
 

--- a/cli/internal/gcmaintainer/codextrust_test.go
+++ b/cli/internal/gcmaintainer/codextrust_test.go
@@ -513,6 +513,29 @@ func TestCheck_FailsWhenCodexHookTrustIsMissing(t *testing.T) {
 	wantErrContaining(t, err, hooks[0].Key)
 }
 
+func TestCheck_RejectsRegularHookFilesWithNoHookIdentities(t *testing.T) {
+	tests := map[string]string{
+		"empty object":    `{}`,
+		"null hooks":      `{"hooks":null}`,
+		"empty hooks map": `{"hooks":{}}`,
+	}
+	for name, document := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := newFixture(t)
+			home := f.addSessionHome(t, "implementer")
+			f.setCodexHooks(t, f.hooksFor(t, home)...)
+			if _, err := f.run(t, Prepare, nil); err != nil {
+				t.Fatalf("prepare: %v", err)
+			}
+
+			mustWrite(t, hookFile(home), document)
+			_, err := f.run(t, Check, nil)
+			wantErrContaining(t, err, "contains no hook identities")
+			wantErrContaining(t, err, hookFile(home))
+		})
+	}
+}
+
 // R3-F4 / F6: the residual timing gap must be reported by identity. A stale
 // home left behind by a removed agent makes the COUNTS agree while a real
 // agent is still missing, so counting would report a false all-clear.

--- a/cli/internal/gcmaintainer/codextrust_test.go
+++ b/cli/internal/gcmaintainer/codextrust_test.go
@@ -1,0 +1,888 @@
+package gcmaintainer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// realHooksDoc is the shape a Gas City per-provider overlay drops into a
+// session home: several events, one with two matcher groups, one group with
+// two hooks. Deriving keys from it exercises every index dimension.
+const realHooksDoc = `{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "startup", "hooks": [{"type": "command", "command": "gc prime"}]},
+      {"matcher": "", "hooks": [{"type": "command", "command": "gc prime --again"}]}
+    ],
+    "PreCompact": [
+      {"matcher": "", "hooks": [{"type": "command", "command": "gc handoff"}]}
+    ],
+    "UserPromptSubmit": [
+      {"matcher": "", "hooks": [
+        {"type": "command", "command": "gc nudge drain"},
+        {"type": "command", "command": "gc mail check"}
+      ]}
+    ]
+  }
+}`
+
+// addSessionHome materializes an agent session home carrying a Codex overlay,
+// the shape a Gas City pack drops into `<city>/.gc/agents/<name>`.
+func (f *fixture) addSessionHome(t *testing.T, name string) string {
+	t.Helper()
+	home := filepath.Join(f.city, ".gc", "agents", name)
+	mustWrite(t, filepath.Join(home, ".codex", "hooks.json"), realHooksDoc)
+	return home
+}
+
+// addRigWorktree materializes a rig worktree root, which a session recognizes
+// by its `.git` entry rather than a Codex overlay.
+func (f *fixture) addRigWorktree(t *testing.T, rig, name string) string {
+	t.Helper()
+	worktree := filepath.Join(f.city, ".gc", "worktrees", rig, name)
+	mustWrite(t, filepath.Join(worktree, ".git"), "gitdir: /elsewhere\n")
+	return worktree
+}
+
+// hooksFor builds the codex hooks/list answer for a session home by deriving
+// the real key set from its on-disk hooks.json, so the fixture can never claim
+// a key shape production would not produce.
+func (f *fixture) hooksFor(t *testing.T, dir string) []codexHook {
+	t.Helper()
+	keys, err := derivedHookKeys(mustCanonical(t, dir))
+	if err != nil {
+		t.Fatalf("derive keys for %s: %v", dir, err)
+	}
+	if len(keys) == 0 {
+		t.Fatalf("no hook keys derived for %s", dir)
+	}
+	hooks := make([]codexHook, 0, len(keys))
+	for index, key := range keys {
+		hooks = append(hooks, codexHook{
+			Key:         key,
+			CurrentHash: hashFor(dir, index),
+		})
+	}
+	return hooks
+}
+
+// hashFor produces a distinct, stable stand-in digest per hook identity.
+func hashFor(dir string, index int) string {
+	return "sha256:" + strings.ReplaceAll(filepath.Base(dir), "/", "_") + "-" + string(rune('a'+index%26))
+}
+
+func (f *fixture) trustStore(t *testing.T) string {
+	t.Helper()
+	return mustReadFile(t, f.codexTrust)
+}
+
+func (f *fixture) mustReadStore(t *testing.T) *trustStore {
+	t.Helper()
+	store, err := readCodexTrustStore(f.codexTrust)
+	if err != nil {
+		t.Fatalf("read trust store: %v", err)
+	}
+	return store
+}
+
+func TestPrepare_PreSeedsCodexWorkspaceAndHookTrustForEverySessionDirectory(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	nested := f.addSessionHome(t, filepath.Join("agentops", "witness"))
+	worktree := f.addRigWorktree(t, "smoke", "polecat")
+	hooks := append(f.hooksFor(t, home), f.hooksFor(t, nested)...)
+	f.setCodexHooks(t, hooks...)
+
+	if _, err := f.run(t, Prepare, nil); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	store := f.mustReadStore(t)
+	for _, dir := range []string{f.city, f.rig, home, nested, worktree} {
+		resolved := mustCanonical(t, dir)
+		if !store.workspaceTrusted(resolved) {
+			t.Errorf("workspace %s is not actually trusted (level=%q)", resolved, store.workspaceLevel(resolved))
+		}
+	}
+	for _, hook := range hooks {
+		if !store.hookTrustSatisfied(hook.Key) {
+			t.Errorf("hook %s is not trusted after prepare", hook.Key)
+		}
+		if got := store.Hooks.State[hook.Key].TrustedHash; got != hook.CurrentHash {
+			t.Errorf("hook %s recorded hash %q, want %q", hook.Key, got, hook.CurrentHash)
+		}
+	}
+	// The seeded store must be exactly the state `check` then accepts.
+	if _, err := f.run(t, Check, nil); err != nil {
+		t.Fatalf("check after prepare: %v", err)
+	}
+}
+
+func TestPrepare_CodexTrustIsIdempotentAndPreservesExistingDecisions(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	hooks := f.hooksFor(t, home)
+
+	// A pre-existing store: unrelated operator settings, an already trusted
+	// city, and one hook the operator already trusted.
+	settled := hooks[0]
+	preexisting := "model = \"gpt-5.6\"\n\n" +
+		"[projects." + tomlQuote(mustCanonical(t, f.city)) + "]\ntrust_level = \"trusted\"\n\n" +
+		"[hooks.state." + tomlQuote(settled.Key) + "]\ntrusted_hash = " + tomlQuote(settled.CurrentHash) + "\n"
+	mustWrite(t, f.codexTrust, preexisting)
+	// The fake derives status from the store, so it reports the recorded hook
+	// as trusted and the rest as new - exactly what codex would report.
+	f.setCodexHooks(t, hooks...)
+
+	if _, err := f.run(t, Prepare, nil); err != nil {
+		t.Fatalf("first prepare: %v", err)
+	}
+	afterFirst := f.trustStore(t)
+	if _, err := f.run(t, Prepare, nil); err != nil {
+		t.Fatalf("second prepare: %v", err)
+	}
+	afterSecond := f.trustStore(t)
+
+	if afterFirst != afterSecond {
+		t.Fatalf("second prepare mutated the trust store:\n--- first ---\n%s\n--- second ---\n%s", afterFirst, afterSecond)
+	}
+	if !strings.HasPrefix(afterSecond, preexisting) {
+		t.Fatal("prepare did not preserve the pre-existing trust store verbatim")
+	}
+	if got := strings.Count(afterSecond, "[hooks.state."+tomlQuote(settled.Key)+"]"); got != 1 {
+		t.Errorf("hook table appears %d times, want 1", got)
+	}
+	if got := f.mustReadStore(t).Hooks.State[settled.Key].TrustedHash; got != settled.CurrentHash {
+		t.Errorf("prepare rewrote the settled hook hash to %q", got)
+	}
+	if _, err := readCodexTrustStore(f.codexTrust); err != nil {
+		t.Fatalf("store is unparsable after two prepares: %v", err)
+	}
+}
+
+// R3-F1: a hook recorded `enabled = false` is a disabled hook, not a trusted
+// working one. prepare must surface it and check must name it.
+func TestPrepare_RefusesADisabledHookInsteadOfTreatingItAsTrusted(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	hooks := f.hooksFor(t, home)
+	f.setCodexHooks(t, hooks...)
+	mustWrite(t, f.codexTrust,
+		"[hooks.state."+tomlQuote(hooks[0].Key)+"]\ntrusted_hash = "+tomlQuote(hooks[0].CurrentHash)+"\nenabled = false\n")
+
+	_, err := f.run(t, Prepare, nil)
+	wantErrContaining(t, err, "is recorded as enabled = false")
+	wantErrContaining(t, err, hooks[0].Key)
+}
+
+func TestCheck_NamesADisabledHook(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	hooks := f.hooksFor(t, home)
+	f.setCodexHooks(t, hooks...)
+	if _, err := f.run(t, Prepare, nil); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	store := f.trustStore(t)
+	mustWrite(t, f.codexTrust, strings.Replace(store,
+		"[hooks.state."+tomlQuote(hooks[0].Key)+"]\ntrusted_hash = "+tomlQuote(hooks[0].CurrentHash)+"\n",
+		"[hooks.state."+tomlQuote(hooks[0].Key)+"]\ntrusted_hash = "+tomlQuote(hooks[0].CurrentHash)+"\nenabled = false\n", 1))
+
+	_, err := f.run(t, Check, nil)
+	wantErrContaining(t, err, "is recorded as enabled = false")
+	wantErrContaining(t, err, hooks[0].Key)
+}
+
+// R3-F3: whatever prepare accepts as complete, check must accept by the same
+// rule. A `managed` hook is the case where the two could drift apart.
+func TestPrepareThenCheck_RoundTripsAManagedHook(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	hooks := f.hooksFor(t, home)
+	f.setCodexHooks(t, hooks...)
+	f.forceCodexHookStatus(t, "managed")
+
+	if _, err := f.run(t, Prepare, nil); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	// prepare must have recorded it, because check cannot ask codex whether a
+	// hook is managed.
+	store := f.mustReadStore(t)
+	for _, hook := range hooks {
+		if !store.hookTrustSatisfied(hook.Key) {
+			t.Errorf("managed hook %s is not satisfied after prepare (%s)", hook.Key, store.hookTrustDefect(hook.Key))
+		}
+	}
+	if _, err := f.run(t, Check, nil); err != nil {
+		t.Fatalf("check must accept what prepare accepted for a managed hook: %v", err)
+	}
+}
+
+// R3-F2: no failure path may leave the operator's config corrupted.
+func TestAppendCodexConfig_LeavesTheOriginalIntactWhenTheMergeWouldNotParse(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	original := "model = \"gpt-5.6\"\n\n[projects.\"/a\"]\ntrust_level = \"trusted\"\n"
+	mustWrite(t, path, original)
+
+	// A duplicate table is exactly the corruption an append could introduce.
+	err := appendCodexConfig(path, "\n[projects.\"/a\"]\ntrust_level = \"trusted\"\n")
+	wantErrContaining(t, err, "would not be parsable")
+
+	if got := mustReadFile(t, path); got != original {
+		t.Fatalf("the operator's config was modified by a rejected append:\n%s", got)
+	}
+	if _, err := readCodexTrustStore(path); err != nil {
+		t.Fatalf("original config no longer parses: %v", err)
+	}
+	// No debris: neither the staged temp file nor a stale backup survives.
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != "config.toml" {
+			t.Errorf("rejected append left %s behind", entry.Name())
+		}
+	}
+}
+
+func TestAppendCodexConfig_PreservesModeAndLeavesNoBackupOnSuccess(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	mustWrite(t, path, "[projects.\"/a\"]\ntrust_level = \"trusted\"\n")
+	if err := os.Chmod(path, 0o640); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	if err := appendCodexConfig(path, "\n[projects.\"/b\"]\ntrust_level = \"trusted\"\n"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o640 {
+		t.Errorf("mode = %v, want 0640 preserved", info.Mode().Perm())
+	}
+	if _, err := os.Stat(path + codexTrustBackupSuffix); !os.IsNotExist(err) {
+		t.Errorf("backup survived a successful append: %v", err)
+	}
+	store, err := readCodexTrustStore(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !store.workspaceTrusted("/a") || !store.workspaceTrusted("/b") {
+		t.Error("append lost an entry")
+	}
+}
+
+// F1: an entry that exists but does not confer trust must not be treated as
+// trusted by either command.
+func TestPrepare_RefusesAnExplicitlyUntrustedWorkspaceInsteadOfReportingSuccess(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	mustWrite(t, f.codexTrust,
+		"[projects."+tomlQuote(mustCanonical(t, home))+"]\ntrust_level = \"untrusted\"\n")
+
+	_, err := f.run(t, Prepare, nil)
+	wantErrContaining(t, err, `is recorded as trust_level "untrusted"`)
+	wantErrContaining(t, err, mustCanonical(t, home))
+	if strings.Contains(f.trustStore(t), `"trusted"`) {
+		t.Fatal("prepare flipped an explicit untrusted decision")
+	}
+}
+
+func TestCheck_RejectsAnExplicitlyUntrustedWorkspace(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	f.setCodexHooks(t, f.hooksFor(t, home)...)
+	if _, err := f.run(t, Prepare, nil); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	// Flip the recorded level: the table is still present, but trust is gone.
+	store := f.trustStore(t)
+	target := "[projects." + tomlQuote(mustCanonical(t, home)) + "]\ntrust_level = \"trusted\""
+	if !strings.Contains(store, target) {
+		t.Fatalf("prepare did not write the expected project table:\n%s", store)
+	}
+	mustWrite(t, f.codexTrust, strings.Replace(store, target,
+		"[projects."+tomlQuote(mustCanonical(t, home))+"]\ntrust_level = \"untrusted\"", 1))
+
+	_, err := f.run(t, Check, nil)
+	wantErrContaining(t, err, `is recorded as trust_level "untrusted"`)
+	wantErrContaining(t, err, mustCanonical(t, home))
+}
+
+func TestCheck_RejectsAHookEntryWithNoUsableHash(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	hooks := f.hooksFor(t, home)
+	f.setCodexHooks(t, hooks...)
+	if _, err := f.run(t, Prepare, nil); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	// A present table whose hash is empty must not read as trusted.
+	store := f.trustStore(t)
+	mustWrite(t, f.codexTrust, strings.Replace(store,
+		"[hooks.state."+tomlQuote(hooks[0].Key)+"]\ntrusted_hash = "+tomlQuote(hooks[0].CurrentHash),
+		"[hooks.state."+tomlQuote(hooks[0].Key)+"]\ntrusted_hash = \"\"", 1))
+
+	_, err := f.run(t, Check, nil)
+	wantErrContaining(t, err, "no usable trusted_hash")
+	wantErrContaining(t, err, hooks[0].Key)
+}
+
+func TestPrepare_RefusesToSilentlyReTrustAModifiedHook(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	hooks := f.hooksFor(t, home)
+	f.setCodexHooks(t, hooks...)
+	mustWrite(t, f.codexTrust,
+		"[hooks.state."+tomlQuote(hooks[0].Key)+"]\ntrusted_hash = \"sha256:stale\"\n")
+
+	_, err := f.run(t, Prepare, nil)
+	wantErrContaining(t, err, "changed since it was trusted")
+	wantErrContaining(t, err, hooks[0].Key)
+	if strings.Contains(f.trustStore(t), hooks[0].CurrentHash) {
+		t.Fatal("prepare rewrote a modified hook's recorded hash")
+	}
+}
+
+func TestPrepare_RefusesAHookCodexStillReportsAsUntrusted(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	hooks := f.hooksFor(t, home)
+	f.setCodexHooks(t, hooks...)
+	// The entry exists but codex still does not consider it trusted, so
+	// skipping it would report success while the wedge remains.
+	f.forceCodexHookStatus(t, "untrusted")
+	mustWrite(t, f.codexTrust,
+		"[hooks.state."+tomlQuote(hooks[0].Key)+"]\ntrusted_hash = \"sha256:wrong\"\n")
+
+	_, err := f.run(t, Prepare, nil)
+	wantErrContaining(t, err, "recorded trust entry that codex still reports as")
+	wantErrContaining(t, err, hooks[0].Key)
+}
+
+// F2: an unexpected or empty hooks/list result must fail closed.
+func TestPrepare_FailsClosedWhenCodexReportsNoHooksForAHookedDirectory(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	f.setCodexHooks(t) // codex answers with an empty hook list
+
+	_, err := f.run(t, Prepare, nil)
+	wantErrContaining(t, err, "reported no hooks for")
+	wantErrContaining(t, err, mustCanonical(t, home))
+}
+
+func TestDecodeHooksList_RejectsUnexpectedShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"empty payload", ``, "no result payload"},
+		{"missing data", `{"items":[]}`, "missing its data array"},
+		{"null data", `{"data":null}`, "missing its data array"},
+		{"entry missing hooks", `{"data":[{"cwd":"/a"}]}`, "missing cwd or hooks"},
+		{"entry missing cwd", `{"data":[{"hooks":[]}]}`, "missing cwd or hooks"},
+		{"hook without key", `{"data":[{"cwd":"/a","hooks":[{"key":"","currentHash":"sha256:x","trustStatus":"untrusted"}]}]}`, "no key or hash"},
+		{"hook without hash", `{"data":[{"cwd":"/a","hooks":[{"key":"/a:stop:0:0","currentHash":"","trustStatus":"untrusted"}]}]}`, "no key or hash"},
+		{"unknown status", `{"data":[{"cwd":"/a","hooks":[{"key":"/a:stop:0:0","currentHash":"sha256:x","trustStatus":"weird"}]}]}`, "unknown trustStatus"},
+		{"not an object", `["data"]`, "unrecognized shape"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := decodeHooksList([]byte(tc.raw))
+			wantErrContaining(t, err, tc.want)
+		})
+	}
+}
+
+func TestDecodeHooksList_AcceptsTheRealShape(t *testing.T) {
+	raw := `{"data":[{"cwd":"/a","hooks":[
+      {"key":"/a/.codex/hooks.json:stop:0:0","currentHash":"sha256:x","trustStatus":"untrusted","enabled":true,"eventName":"stop"}
+    ],"warnings":[],"errors":[]}]}`
+	hooks, err := decodeHooksList([]byte(raw))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(hooks) != 1 {
+		t.Fatalf("got %d hooks, want 1", len(hooks))
+	}
+	if hooks[0].Key != "/a/.codex/hooks.json:stop:0:0" || hooks[0].CurrentHash != "sha256:x" {
+		t.Fatalf("decoded %+v", hooks[0])
+	}
+}
+
+// F4: trust must never be granted to a hook outside the target directories.
+func TestPrepare_IgnoresHookIdentitiesOutsideTheSessionDirectories(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	foreign := codexHook{
+		Key:         "/Users/someone/.codex/hooks.json:stop:0:0",
+		CurrentHash: "sha256:foreign",
+		TrustStatus: "untrusted",
+	}
+	f.setCodexHooks(t, append(f.hooksFor(t, home), foreign)...)
+
+	opts := f.options()
+	var stdout, stderr strings.Builder
+	opts.Stdout = &stdout
+	opts.Stderr = &stderr
+	if err := Prepare(opts); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if f.mustReadStore(t).hookRecorded(foreign.Key) {
+		t.Fatal("prepare granted trust to a hook outside the Gas City session directories")
+	}
+	if !strings.Contains(stderr.String(), "ignoring codex hook outside") {
+		t.Errorf("stderr %q does not report the ignored foreign hook", stderr.String())
+	}
+}
+
+// F5: check must be a pure local read - no codex subprocess at all.
+func TestCheck_RunsNoCodexSubprocess(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	f.setCodexHooks(t, f.hooksFor(t, home)...)
+	if _, err := f.run(t, Prepare, nil); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	codexLog := filepath.Join(filepath.Dir(f.codexHome), "codex.log")
+	if err := os.Remove(codexLog); err != nil {
+		t.Fatalf("reset codex log: %v", err)
+	}
+	before := mustReadFile(t, f.codexTrust)
+
+	if _, err := f.run(t, Check, nil); err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if _, err := os.Stat(codexLog); !os.IsNotExist(err) {
+		t.Fatalf("check invoked the codex binary; log exists: %v", err)
+	}
+	if got := mustReadFile(t, f.codexTrust); got != before {
+		t.Fatal("check wrote to the codex trust store; it must be read-only")
+	}
+}
+
+func TestCheck_FailsWhenCodexWorkspaceTrustIsMissing(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	f.setCodexHooks(t, f.hooksFor(t, home)...)
+	if _, err := f.run(t, Prepare, nil); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	store := f.trustStore(t)
+	drop := "[projects." + tomlQuote(mustCanonical(t, home)) + "]\ntrust_level = \"trusted\"\n"
+	if !strings.Contains(store, drop) {
+		t.Fatalf("prepare did not write the expected project table:\n%s", store)
+	}
+	mustWrite(t, f.codexTrust, strings.Replace(store, drop, "", 1))
+
+	_, err := f.run(t, Check, nil)
+	wantErrContaining(t, err, "codex workspace trust is not pre-seeded")
+	wantErrContaining(t, err, mustCanonical(t, home))
+	wantErrContaining(t, err, "blocks on the interactive trust dialog")
+}
+
+func TestCheck_FailsWhenCodexHookTrustIsMissing(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	hooks := f.hooksFor(t, home)
+	f.setCodexHooks(t, hooks...)
+	if _, err := f.run(t, Prepare, nil); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	store := f.trustStore(t)
+	hookTable := "[hooks.state." + tomlQuote(hooks[0].Key) + "]\ntrusted_hash = " + tomlQuote(hooks[0].CurrentHash) + "\n"
+	if !strings.Contains(store, hookTable) {
+		t.Fatalf("prepare did not write the expected hook table:\n%s", store)
+	}
+	mustWrite(t, f.codexTrust, strings.ReplaceAll(store, hookTable, ""))
+
+	_, err := f.run(t, Check, nil)
+	wantErrContaining(t, err, "has no recorded trust entry")
+	wantErrContaining(t, err, hooks[0].Key)
+}
+
+// R3-F4 / F6: the residual timing gap must be reported by identity. A stale
+// home left behind by a removed agent makes the COUNTS agree while a real
+// agent is still missing, so counting would report a false all-clear.
+func TestPrepare_NamesConfiguredAgentsWithNoSessionHomeDespiteAStaleHome(t *testing.T) {
+	f := newFixture(t)
+	f.setAgents(t,
+		map[string]any{"name": "mayor", "qualified_name": "mayor", "suspended": false},
+		map[string]any{"name": "implementer", "qualified_name": "implementer", "suspended": false},
+		map[string]any{"name": "retired", "qualified_name": "retired", "suspended": true},
+	)
+	mayor := f.addSessionHome(t, "mayor")
+	// A home for an agent the city no longer configures: counts now match
+	// (2 configured, 2 homes) while `implementer` still has none.
+	stale := f.addSessionHome(t, "decommissioned")
+	hooks := append(f.hooksFor(t, mayor), f.hooksFor(t, stale)...)
+	f.setCodexHooks(t, hooks...)
+
+	opts := f.options()
+	var stdout, stderr strings.Builder
+	opts.Stdout = &stdout
+	opts.Stderr = &stderr
+	if err := Prepare(opts); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "implementer") {
+		t.Fatalf("stderr %q does not name the agent with no session home", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "mayor") {
+		t.Errorf("stderr %q names an agent that does have a home", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "retired") {
+		t.Errorf("stderr %q names a suspended agent", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "re-run `ao gc prepare`") {
+		t.Errorf("stderr %q does not tell the operator what to do", stderr.String())
+	}
+}
+
+func TestPrepare_MatchesNestedSessionHomesByQualifiedName(t *testing.T) {
+	f := newFixture(t)
+	f.setAgents(t, map[string]any{"name": "witness", "qualified_name": "agentops/witness", "suspended": false})
+	home := f.addSessionHome(t, filepath.Join("agentops", "witness"))
+	f.setCodexHooks(t, f.hooksFor(t, home)...)
+
+	opts := f.options()
+	var stdout, stderr strings.Builder
+	opts.Stdout = &stdout
+	opts.Stderr = &stderr
+	if err := Prepare(opts); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if strings.Contains(stderr.String(), "no session home yet") {
+		t.Fatalf("stderr %q warns even though the nested home exists", stderr.String())
+	}
+}
+
+func TestPrepare_DoesNotWarnWhenEverySessionHomeExists(t *testing.T) {
+	f := newFixture(t)
+	f.setAgents(t, map[string]any{"name": "mayor", "qualified_name": "mayor", "suspended": false})
+	home := f.addSessionHome(t, "mayor")
+	f.setCodexHooks(t, f.hooksFor(t, home)...)
+
+	opts := f.options()
+	var stdout, stderr strings.Builder
+	opts.Stdout = &stdout
+	opts.Stderr = &stderr
+	if err := Prepare(opts); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if strings.Contains(stderr.String(), "no session home yet") {
+		t.Fatalf("stderr %q warns even though every home exists", stderr.String())
+	}
+}
+
+func TestPrepare_SeedsWorkspaceTrustWithoutACodexBinary(t *testing.T) {
+	f := newFixture(t)
+
+	opts := f.options()
+	opts.CodexBin = ""
+	var stdout, stderr strings.Builder
+	opts.Stdout = &stdout
+	opts.Stderr = &stderr
+	// A PATH holding the fixture binaries and the system utilities the fake gc
+	// script needs, but deliberately no codex.
+	t.Setenv("PATH", filepath.Dir(f.gcBin)+":/usr/bin:/bin")
+	if err := Prepare(opts); err != nil {
+		t.Fatalf("prepare without codex: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "no codex binary on PATH") {
+		t.Fatalf("stderr %q lacks the missing-codex warning", stderr.String())
+	}
+	if !f.mustReadStore(t).workspaceTrusted(mustCanonical(t, f.city)) {
+		t.Error("workspace trust was not seeded without codex")
+	}
+}
+
+func TestPrepare_RefusesAnUnusableExplicitCodexBinary(t *testing.T) {
+	f := newFixture(t)
+	_, err := f.run(t, Prepare, func(opts *Options) {
+		opts.CodexBin = filepath.Join(f.city, "no-such-codex")
+	})
+	wantErrContaining(t, err, "codex binary is not executable")
+	if _, statErr := os.Lstat(f.codexTrust); !os.IsNotExist(statErr) {
+		t.Fatalf("prepare wrote the trust store before refusing the bad binary: %v", statErr)
+	}
+}
+
+func TestCodexTrustTargets_DiscoversSessionDirsWithoutDescendingIntoThem(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	worktree := f.addRigWorktree(t, "smoke", "polecat")
+	// A directory nested inside a discovered session dir must not be reported
+	// separately: the walk stops at the session boundary.
+	mustWrite(t, filepath.Join(worktree, "vendor", "dep", ".git"), "gitdir: /elsewhere\n")
+	// A plain directory with no session marker is not a target.
+	mustMkdir(t, filepath.Join(f.city, ".gc", "agents", "scratch"))
+
+	o, err := resolve(f.options(), true)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	targets := o.codexTrustTargets()
+
+	want := []string{
+		mustCanonical(t, f.city),
+		mustCanonical(t, f.rig),
+		mustCanonical(t, home),
+		mustCanonical(t, worktree),
+	}
+	if len(targets) != len(want) {
+		t.Fatalf("targets = %v, want exactly %v", targets, want)
+	}
+	for _, dir := range want {
+		found := false
+		for _, target := range targets {
+			if target == dir {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("target %s is missing from %v", dir, targets)
+		}
+	}
+}
+
+// derivedHookKeys is what `check` verifies against, so its index math must
+// match the shape Codex reports. These expectations were captured from
+// codex-cli 0.145.0 driven against this exact document.
+func TestDerivedHookKeys_MatchesCodexIndexing(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ".codex", "hooks.json"), realHooksDoc)
+	keys, err := derivedHookKeys(dir)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	path := filepath.Join(dir, ".codex", "hooks.json")
+	want := []string{
+		path + ":pre_compact:0:0",
+		path + ":session_start:0:0",
+		path + ":session_start:1:0",
+		path + ":user_prompt_submit:0:0",
+		path + ":user_prompt_submit:0:1",
+	}
+	if len(keys) != len(want) {
+		t.Fatalf("keys = %q, want %q", keys, want)
+	}
+	for i := range want {
+		if keys[i] != want[i] {
+			t.Fatalf("keys = %q, want %q", keys, want)
+		}
+	}
+}
+
+func TestDerivedHookKeys_MissingFileIsNotAnErrorAndMalformedIs(t *testing.T) {
+	keys, err := derivedHookKeys(t.TempDir())
+	if err != nil {
+		t.Fatalf("missing hooks file: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("keys = %q, want none", keys)
+	}
+
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ".codex", "hooks.json"), "{not json")
+	if _, err := derivedHookKeys(dir); err == nil {
+		t.Fatal("a malformed hooks file must be an error, not an empty key set")
+	}
+}
+
+func TestSnakeCase(t *testing.T) {
+	tests := map[string]string{
+		"SessionStart":     "session_start",
+		"UserPromptSubmit": "user_prompt_submit",
+		"Stop":             "stop",
+		"PreToolUse":       "pre_tool_use",
+		"PostCompact":      "post_compact",
+	}
+	for input, want := range tests {
+		if got := snakeCase(input); got != want {
+			t.Errorf("snakeCase(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestHookKeySourcePath(t *testing.T) {
+	tests := []struct {
+		key   string
+		want  string
+		wantK bool
+	}{
+		{"/a/.codex/hooks.json:stop:0:0", "/a/.codex/hooks.json", true},
+		{"/a/b c/.codex/hooks.json:user_prompt_submit:1:2", "/a/b c/.codex/hooks.json", true},
+		{"nocolons", "", false},
+		{"only:two", "", false},
+		{":0:0:0", "", false},
+	}
+	for _, tc := range tests {
+		got, ok := hookKeySourcePath(tc.key)
+		if ok != tc.wantK || got != tc.want {
+			t.Errorf("hookKeySourcePath(%q) = (%q,%v), want (%q,%v)", tc.key, got, ok, tc.want, tc.wantK)
+		}
+	}
+}
+
+// F3: detection must use a real TOML parse, not a header scan, so valid
+// spellings a scanner would miss cannot cause a duplicate-table append.
+func TestReadCodexTrustStore_UnderstandsValidTOMLSpellings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	mustWrite(t, path, strings.Join([]string{
+		`[projects."/a"] # trailing comment after the header`,
+		`trust_level = "trusted"`,
+		`[projects.'/b/literal']`,
+		`trust_level = "untrusted"`,
+		`[ projects . "/c/spaced" ]`,
+		`trust_level = "trusted"`,
+		`[hooks.state."/a/.codex/hooks.json:stop:0:0"]  `,
+		`trusted_hash = "sha256:aaa"`,
+		`enabled = false`,
+		``,
+	}, "\n"))
+
+	store, err := readCodexTrustStore(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !store.workspaceTrusted("/a") {
+		t.Error("/a (trailing comment after header) not understood")
+	}
+	if store.workspaceTrusted("/b/literal") || store.workspaceLevel("/b/literal") != "untrusted" {
+		t.Errorf("/b/literal (single-quoted key) level = %q, want untrusted", store.workspaceLevel("/b/literal"))
+	}
+	if !store.workspaceTrusted("/c/spaced") {
+		t.Error("/c/spaced (spaced dotted key) not understood")
+	}
+	key := "/a/.codex/hooks.json:stop:0:0"
+	entry, ok := store.Hooks.State[key]
+	if !ok || entry.TrustedHash != "sha256:aaa" {
+		t.Errorf("hook entry not understood: %+v", entry)
+	}
+	if entry.Enabled == nil || *entry.Enabled {
+		t.Error("enabled = false not decoded")
+	}
+	// Decoded, but a disabled hook is not a satisfied one.
+	if store.hookTrustSatisfied(key) {
+		t.Error("a hook recorded enabled = false must not count as satisfied")
+	}
+	if got := store.hookTrustDefect(key); !strings.Contains(got, "enabled = false") {
+		t.Errorf("defect = %q, want it to name enabled = false", got)
+	}
+}
+
+func TestReadCodexTrustStore_MissingStoreIsEmptyAndBrokenStoreIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	store, err := readCodexTrustStore(filepath.Join(dir, "config.toml"))
+	if err != nil {
+		t.Fatalf("missing store: %v", err)
+	}
+	if len(store.Projects) != 0 || len(store.Hooks.State) != 0 {
+		t.Fatalf("missing store reported %d projects and %d hooks, want 0 and 0", len(store.Projects), len(store.Hooks.State))
+	}
+
+	broken := filepath.Join(dir, "broken.toml")
+	mustWrite(t, broken, "[projects.\"/a\"]\ntrust_level = \"trusted\"\n[projects.\"/a\"]\ntrust_level = \"trusted\"\n")
+	if _, err := readCodexTrustStore(broken); err == nil {
+		t.Fatal("a duplicate table must be an error, not an empty store")
+	}
+}
+
+func TestAppendCodexConfig_KeepsTheStoreParsableWithoutATrailingNewline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	mustWrite(t, path, `[projects."/a"]`+"\ntrust_level = \"trusted\"")
+
+	block := "\n[projects." + tomlQuote("/b") + "]\ntrust_level = \"trusted\"\n"
+	if err := appendCodexConfig(path, block); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	store, err := readCodexTrustStore(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	for _, want := range []string{"/a", "/b"} {
+		if !store.workspaceTrusted(want) {
+			t.Errorf("project %s is not trusted after the append; store:\n%s", want, mustReadFile(t, path))
+		}
+	}
+}
+
+func TestTomlQuote_EscapesPathologicalPaths(t *testing.T) {
+	tests := map[string]string{
+		`/a/b`:  `"/a/b"`,
+		`/a"b`:  `"/a\"b"`,
+		`/a\b`:  `"/a\\b"`,
+		"/a\tb": `"/a\tb"`,
+		"/a\nb": `"/a\nb"`,
+		`/a'b`:  `"/a'b"`,
+		`/a#b`:  `"/a#b"`,
+	}
+	for input, want := range tests {
+		if got := tomlQuote(input); got != want {
+			t.Errorf("tomlQuote(%q) = %s, want %s", input, got, want)
+		}
+	}
+	// A quoted pathological path must survive a real parse round trip.
+	path := filepath.Join(t.TempDir(), "config.toml")
+	weird := `/a"b\c#d`
+	if err := appendCodexConfig(path, "\n[projects."+tomlQuote(weird)+"]\ntrust_level = \"trusted\"\n"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	store, err := readCodexTrustStore(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !store.workspaceTrusted(weird) {
+		t.Fatalf("pathological path did not round trip; store:\n%s", mustReadFile(t, path))
+	}
+}
+
+// Fixture fidelity: the scripted codex answer must be exactly what the
+// production decoder accepts, so a passing test cannot rest on a shape codex
+// would never emit.
+func TestFixtureHooksAnswerMatchesProductionDecoder(t *testing.T) {
+	f := newFixture(t)
+	home := f.addSessionHome(t, "implementer")
+	hooks := f.hooksFor(t, home)
+	f.setCodexHooks(t, hooks...)
+
+	// Drive the real client against the fake server: the answer must survive
+	// the production JSON-RPC read and the production shape validation.
+	decoded, err := codexHooksList(f.codexBin, f.codexHome, []string{mustCanonical(t, home)})
+	if err != nil {
+		t.Fatalf("production client rejects the fixture answer: %v", err)
+	}
+	if len(decoded) != len(hooks) {
+		t.Fatalf("decoded %d hooks, want %d", len(decoded), len(hooks))
+	}
+	for index, hook := range decoded {
+		if hook.Key != hooks[index].Key || hook.CurrentHash != hooks[index].CurrentHash {
+			t.Fatalf("decoded[%d] = %+v, want key %q hash %q", index, hook, hooks[index].Key, hooks[index].CurrentHash)
+		}
+		if hook.TrustStatus != "untrusted" {
+			t.Errorf("decoded[%d] status = %q, want untrusted before any seeding", index, hook.TrustStatus)
+		}
+	}
+
+	// After seeding, the same fake must report them trusted - the property
+	// idempotency depends on.
+	if _, err := f.run(t, Prepare, nil); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	reseeded, err := codexHooksList(f.codexBin, f.codexHome, []string{mustCanonical(t, home)})
+	if err != nil {
+		t.Fatalf("second list: %v", err)
+	}
+	for _, hook := range reseeded {
+		if hook.TrustStatus != "trusted" {
+			t.Errorf("hook %s status = %q after prepare, want trusted", hook.Key, hook.TrustStatus)
+		}
+	}
+}

--- a/cli/internal/gcmaintainer/codextrust_test.go
+++ b/cli/internal/gcmaintainer/codextrust_test.go
@@ -236,7 +236,7 @@ func TestAppendCodexConfig_LeavesTheOriginalIntactWhenTheMergeWouldNotParse(t *t
 	if _, err := readCodexTrustStore(path); err != nil {
 		t.Fatalf("original config no longer parses: %v", err)
 	}
-	// No debris: neither the staged temp file nor a stale backup survives.
+	// No debris from a rejected atomic write survives.
 	entries, err := os.ReadDir(filepath.Dir(path))
 	if err != nil {
 		t.Fatalf("read dir: %v", err)
@@ -248,7 +248,7 @@ func TestAppendCodexConfig_LeavesTheOriginalIntactWhenTheMergeWouldNotParse(t *t
 	}
 }
 
-func TestAppendCodexConfig_PreservesModeAndLeavesNoBackupOnSuccess(t *testing.T) {
+func TestAppendCodexConfig_PreservesModeAndLeavesNoDebrisOnSuccess(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 	mustWrite(t, path, "[projects.\"/a\"]\ntrust_level = \"trusted\"\n")
 	if err := os.Chmod(path, 0o640); err != nil {
@@ -265,8 +265,14 @@ func TestAppendCodexConfig_PreservesModeAndLeavesNoBackupOnSuccess(t *testing.T)
 	if info.Mode().Perm() != 0o640 {
 		t.Errorf("mode = %v, want 0640 preserved", info.Mode().Perm())
 	}
-	if _, err := os.Stat(path + codexTrustBackupSuffix); !os.IsNotExist(err) {
-		t.Errorf("backup survived a successful append: %v", err)
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != "config.toml" {
+			t.Errorf("successful append left %s behind", entry.Name())
+		}
 	}
 	store, err := readCodexTrustStore(path)
 	if err != nil {
@@ -560,6 +566,24 @@ func TestPrepare_MatchesNestedSessionHomesByQualifiedName(t *testing.T) {
 	}
 	if strings.Contains(stderr.String(), "no session home yet") {
 		t.Fatalf("stderr %q warns even though the nested home exists", stderr.String())
+	}
+}
+
+func TestPrepare_MatchesFlatSessionHomeWhenQualifiedNameIsDotted(t *testing.T) {
+	f := newFixture(t)
+	f.setAgents(t, map[string]any{"name": "mayor", "qualified_name": "gastown.mayor", "suspended": false})
+	home := f.addSessionHome(t, "mayor")
+	f.setCodexHooks(t, f.hooksFor(t, home)...)
+
+	opts := f.options()
+	var stdout, stderr strings.Builder
+	opts.Stdout = &stdout
+	opts.Stderr = &stderr
+	if err := Prepare(opts); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if strings.Contains(stderr.String(), "no session home yet") {
+		t.Fatalf("stderr %q warns even though the unqualified home exists", stderr.String())
 	}
 }
 

--- a/cli/internal/gcmaintainer/gcmaintainer.go
+++ b/cli/internal/gcmaintainer/gcmaintainer.go
@@ -66,8 +66,9 @@ type ops struct {
 	packDir   string
 	pythonBin string
 	// codexBin, codexHome, and codexConfig locate the Codex trust store that
-	// prepare pre-seeds so no agent session ever meets the trust dialog.
-	// codexBin is empty when no Codex CLI is installed.
+	// prepare pre-seeds for session directories that exist when it runs. Homes
+	// materialized later require another prepare before dispatch. codexBin is
+	// empty when no Codex CLI is installed.
 	codexBin    string
 	codexHome   string
 	codexConfig string

--- a/cli/internal/gcmaintainer/gcmaintainer.go
+++ b/cli/internal/gcmaintainer/gcmaintainer.go
@@ -5,9 +5,12 @@
 //
 // prepare verifies the official workflow and rig-role pins, snapshots upstream
 // validation assets unchanged under the rig's ignored .gc directory, installs
-// AgentOps-owned check wrappers, and links AgentOps skills into city/rig Codex
-// sinks. check is read-only. recover-affinity only considers ready formula
-// beads with gc.session_affinity=require and never re-slings work.
+// AgentOps-owned check wrappers, links AgentOps skills into city/rig Codex
+// sinks, and pre-seeds Codex workspace and hook trust for every session
+// directory that exists, so an agent pane there does not block on the
+// interactive trust dialog. check is read-only and runs no codex subprocess.
+// recover-affinity only considers ready formula beads with
+// gc.session_affinity=require and never re-slings work.
 package gcmaintainer
 
 import (
@@ -38,6 +41,10 @@ type Options struct {
 	Rig string
 	// GCBin is the Gas City 1.4 binary; defaults to `gc` on PATH.
 	GCBin string
+	// CodexBin is the Codex CLI used to read hook trust identities; defaults
+	// to `codex` on PATH. When no Codex CLI is available, only workspace-level
+	// trust is pre-seeded.
+	CodexBin string
 	// PackDir overrides auto-detection of the resolved official pack root.
 	PackDir string
 	// SkillsSource overrides resolution of the AgentOps skills directory that
@@ -58,6 +65,12 @@ type ops struct {
 	gcBin     string
 	packDir   string
 	pythonBin string
+	// codexBin, codexHome, and codexConfig locate the Codex trust store that
+	// prepare pre-seeds so no agent session ever meets the trust dialog.
+	// codexBin is empty when no Codex CLI is installed.
+	codexBin    string
+	codexHome   string
+	codexConfig string
 	// skillsSource is the resolved AgentOps skills directory; empty for
 	// operations that do not touch skill links (recover-affinity).
 	skillsSource string
@@ -81,6 +94,9 @@ func Prepare(opts Options) error {
 	if err := o.prepareRuntime(); err != nil {
 		return err
 	}
+	if err := o.seedCodexTrust(); err != nil {
+		return err
+	}
 	if err := o.checkServiceBinary(); err != nil {
 		return err
 	}
@@ -101,6 +117,9 @@ func Check(opts Options) error {
 		return err
 	}
 	if err := o.checkSkillLinks(); err != nil {
+		return err
+	}
+	if err := o.checkCodexTrust(); err != nil {
 		return err
 	}
 	if err := o.checkServiceBinary(); err != nil {
@@ -165,6 +184,13 @@ func resolve(opts Options, needSkills bool) (*ops, error) {
 		if o.skillsSource, err = resolveSkillsSource(opts.SkillsSource); err != nil {
 			return nil, err
 		}
+		if o.codexBin, err = resolveCodexBin(opts.CodexBin); err != nil {
+			return nil, err
+		}
+		if o.codexHome, err = resolveCodexHome(); err != nil {
+			return nil, err
+		}
+		o.codexConfig = filepath.Join(o.codexHome, "config.toml")
 	}
 
 	if o.rigName, err = o.resolveRigName(); err != nil {

--- a/cli/internal/gcmaintainer/gcmaintainer_test.go
+++ b/cli/internal/gcmaintainer/gcmaintainer_test.go
@@ -30,18 +30,29 @@ type fixture struct {
 	gcBin  string
 	log    string
 	skills string
+	// codexBin is a scripted Codex CLI that answers the app-server JSON-RPC
+	// handshake from FAKE_CODEX_HOOKS_JSON, so the real trust-seeding code
+	// path runs against a temp CODEX_HOME instead of the host's.
+	codexBin   string
+	codexHome  string
+	codexTrust string
 }
 
 func newFixture(t *testing.T) *fixture {
 	t.Helper()
 	root := t.TempDir()
 	f := &fixture{
-		city:   filepath.Join(root, "city"),
-		rig:    filepath.Join(root, "city", "rigs", "smoke"),
-		pack:   filepath.Join(root, "pack", "gascity"),
-		gcBin:  filepath.Join(root, "bin", "gc"),
-		log:    filepath.Join(root, "gc.log"),
-		skills: filepath.Join(root, "skills"),
+		city:       filepath.Join(root, "city"),
+		rig:        filepath.Join(root, "city", "rigs", "smoke"),
+		pack:       filepath.Join(root, "pack", "gascity"),
+		gcBin:      filepath.Join(root, "bin", "gc"),
+		log:        filepath.Join(root, "gc.log"),
+		skills:     filepath.Join(root, "skills"),
+		// The fake codex lives outside the fixture bin dir so a test can build
+		// a PATH that finds gc but not codex.
+		codexBin:   filepath.Join(root, "codexbin", "codex"),
+		codexHome:  filepath.Join(root, "codexhome"),
+		codexTrust: filepath.Join(root, "codexhome", "config.toml"),
 	}
 	mustMkdir(t, f.rig)
 	mustMkdir(t, filepath.Join(root, "bin"))
@@ -59,10 +70,12 @@ func newFixture(t *testing.T) *fixture {
 		mustWrite(t, filepath.Join(f.skills, skill, "SKILL.md"), "# "+skill+"\n")
 	}
 	f.writeFakeGC(t)
+	f.writeFakeCodex(t)
 	python := filepath.Join(root, "bin", "python3")
 	mustWriteExecutable(t, python, "#!/bin/sh\nexit 0\n")
 
 	t.Setenv("AGENTOPS_GC_SKIP_SERVICE_CHECK", "1")
+	t.Setenv("CODEX_HOME", f.codexHome)
 	t.Setenv("GC_PYTHON_BIN", python)
 	t.Setenv("FAKE_GC_LOG", f.log)
 	t.Setenv("FAKE_PACK_COMMIT", maintainerCommit)
@@ -71,7 +84,100 @@ func newFixture(t *testing.T) *fixture {
 	f.setStatus(t, map[string]any{"ok": true, "partial": false, "health": map[string]any{"signals": []any{}}})
 	f.setReady(t, []any{})
 	f.setSessions(t, []any{})
+	f.setCodexHooks(t)
+	f.setAgents(t)
 	return f
+}
+
+// writeFakeCodex scripts a Codex CLI that speaks just enough of the app-server
+// stdio JSON-RPC protocol: it acknowledges initialize, then answers hooks/list.
+//
+// Its trustStatus is DERIVED from the trust store the way Codex derives it —
+// a key whose recorded trusted_hash matches its current hash is "trusted", a
+// recorded key with a different hash is "modified", an unrecorded key is
+// "untrusted". A static answer could never model idempotency honestly, because
+// the second prepare must see what the first one wrote.
+//
+// FAKE_CODEX_HOOK_SPEC carries one `key<TAB>hash` per line;
+// FAKE_CODEX_FORCE_STATUS pins the status for the cases that need one;
+// FAKE_CODEX_RAW_JSON replaces the whole answer. Every invocation is logged.
+func (f *fixture) writeFakeCodex(t *testing.T) {
+	t.Helper()
+	script := `#!/bin/sh
+printf '%s cwd=%s\n' "$*" "$PWD" >>"$FAKE_CODEX_LOG"
+emit_hooks() {
+  if [ -n "${FAKE_CODEX_RAW_JSON:-}" ]; then
+    printf '%s\n' "$FAKE_CODEX_RAW_JSON"
+    return
+  fi
+  config="$CODEX_HOME/config.toml"
+  body=""
+  sep=""
+  while IFS='	' read -r key hash; do
+    [ -z "$key" ] && continue
+    if [ -n "${FAKE_CODEX_FORCE_STATUS:-}" ]; then
+      status="$FAKE_CODEX_FORCE_STATUS"
+    elif grep -Fq "[hooks.state.\"$key\"]" "$config" 2>/dev/null; then
+      if grep -Fq "trusted_hash = \"$hash\"" "$config" 2>/dev/null; then
+        status="trusted"
+      else
+        status="modified"
+      fi
+    else
+      status="untrusted"
+    fi
+    body="$body$sep{\"key\":\"$key\",\"currentHash\":\"$hash\",\"trustStatus\":\"$status\"}"
+    sep=","
+  done <<SPEC
+$FAKE_CODEX_HOOK_SPEC
+SPEC
+  printf '{"jsonrpc":"2.0","id":2,"result":{"data":[{"cwd":"%s","hooks":[%s],"warnings":[],"errors":[]}]}}\n' "$PWD" "$body"
+}
+while IFS= read -r line; do
+  case "$line" in
+    *'"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":1,"result":{"codexHome":"%s"}}\n' "$CODEX_HOME"
+      printf '{"jsonrpc":"2.0","method":"remoteControl/status/changed","params":{}}\n'
+      ;;
+    *'"hooks/list"'*)
+      emit_hooks
+      ;;
+  esac
+done
+`
+	mustWriteExecutable(t, f.codexBin, script)
+	t.Setenv("FAKE_CODEX_LOG", filepath.Join(filepath.Dir(f.codexHome), "codex.log"))
+}
+
+// setCodexHooks scripts which hook identities the fake Codex reports. Their
+// trust status is derived from the live trust store, not pinned here.
+func (f *fixture) setCodexHooks(t *testing.T, hooks ...codexHook) {
+	t.Helper()
+	var spec strings.Builder
+	for _, hook := range hooks {
+		fmt.Fprintf(&spec, "%s\t%s\n", hook.Key, hook.CurrentHash)
+	}
+	t.Setenv("FAKE_CODEX_HOOK_SPEC", spec.String())
+	t.Setenv("FAKE_CODEX_FORCE_STATUS", "")
+	t.Setenv("FAKE_CODEX_RAW_JSON", "")
+}
+
+// forceCodexHookStatus pins the status the fake Codex reports for every hook,
+// for the cases that must exercise a specific status regardless of the store.
+func (f *fixture) forceCodexHookStatus(t *testing.T, status string) {
+	t.Helper()
+	t.Setenv("FAKE_CODEX_FORCE_STATUS", status)
+}
+
+// mustCanonical resolves path the same way the maintainer does, so tests
+// compare against the exact strings written into the trust store.
+func mustCanonical(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := canonical(path)
+	if err != nil {
+		t.Fatalf("canonical %s: %v", path, err)
+	}
+	return resolved
 }
 
 func (f *fixture) writePackMarker(t *testing.T, commit string) {
@@ -102,6 +208,9 @@ EOF
   *" rig list "*)
     printf '{"ok":true,"rigs":[{"name":"smoke","path":"%s","hq":false}]}\n' "$FAKE_RIG"
     ;;
+  *" agent list "*)
+    printf '%s\n' "$FAKE_AGENTS_JSON"
+    ;;
   *" doctor "*)
     printf '%s\n' "$FAKE_DOCTOR_JSON"
     ;;
@@ -126,6 +235,15 @@ esac
 	mustWriteExecutable(t, f.gcBin, script)
 }
 
+// setAgents scripts the city's configured agent roster.
+func (f *fixture) setAgents(t *testing.T, agents ...map[string]any) {
+	t.Helper()
+	if agents == nil {
+		agents = []map[string]any{}
+	}
+	setJSONEnv(t, "FAKE_AGENTS_JSON", map[string]any{"agents": agents})
+}
+
 func (f *fixture) setDoctor(t *testing.T, value any)   { setJSONEnv(t, "FAKE_DOCTOR_JSON", value) }
 func (f *fixture) setStatus(t *testing.T, value any)   { setJSONEnv(t, "FAKE_STATUS_JSON", value) }
 func (f *fixture) setReady(t *testing.T, value any)    { setJSONEnv(t, "FAKE_READY_JSON", value) }
@@ -147,6 +265,7 @@ func (f *fixture) options() Options {
 		City:         f.city,
 		Rig:          f.rig,
 		GCBin:        f.gcBin,
+		CodexBin:     f.codexBin,
 		PackDir:      f.pack,
 		SkillsSource: f.skills,
 	}

--- a/cli/internal/gcmaintainer/gcmaintainer_testmain_test.go
+++ b/cli/internal/gcmaintainer/gcmaintainer_testmain_test.go
@@ -1,0 +1,30 @@
+package gcmaintainer
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain prevents any fallback through os.UserHomeDir from reaching the
+// operator's real home when a test omits an explicit CODEX_HOME or GC_HOME.
+func TestMain(m *testing.M) {
+	testHome, err := os.MkdirTemp("", "gcmaintainer-test-home-*")
+	if err != nil {
+		panic("gcmaintainer TestMain: create isolated HOME: " + err.Error())
+	}
+	previousHome, hadHome := os.LookupEnv("HOME")
+	if err := os.Setenv("HOME", testHome); err != nil {
+		_ = os.RemoveAll(testHome)
+		panic("gcmaintainer TestMain: set isolated HOME: " + err.Error())
+	}
+
+	code := m.Run()
+
+	if hadHome {
+		_ = os.Setenv("HOME", previousHome)
+	} else {
+		_ = os.Unsetenv("HOME")
+	}
+	_ = os.RemoveAll(testHome)
+	os.Exit(code)
+}

--- a/cli/internal/gcmaintainer/gcmaintainer_testmain_test.go
+++ b/cli/internal/gcmaintainer/gcmaintainer_testmain_test.go
@@ -3,28 +3,12 @@ package gcmaintainer
 import (
 	"os"
 	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/testsupport"
 )
 
 // TestMain prevents any fallback through os.UserHomeDir from reaching the
 // operator's real home when a test omits an explicit CODEX_HOME or GC_HOME.
 func TestMain(m *testing.M) {
-	testHome, err := os.MkdirTemp("", "gcmaintainer-test-home-*")
-	if err != nil {
-		panic("gcmaintainer TestMain: create isolated HOME: " + err.Error())
-	}
-	previousHome, hadHome := os.LookupEnv("HOME")
-	if err := os.Setenv("HOME", testHome); err != nil {
-		_ = os.RemoveAll(testHome)
-		panic("gcmaintainer TestMain: set isolated HOME: " + err.Error())
-	}
-
-	code := m.Run()
-
-	if hadHome {
-		_ = os.Setenv("HOME", previousHome)
-	} else {
-		_ = os.Unsetenv("HOME")
-	}
-	_ = os.RemoveAll(testHome)
-	os.Exit(code)
+	os.Exit(testsupport.RunTestMainWithIsolatedHome(m.Run))
 }

--- a/cli/internal/testsupport/home.go
+++ b/cli/internal/testsupport/home.go
@@ -1,0 +1,30 @@
+package testsupport
+
+import "os"
+
+// RunTestMainWithIsolatedHome runs a package's tests with HOME rooted in a
+// temporary directory. Call it from TestMain: HOME is established before
+// m.Run starts and restored only after every package test has finished, so
+// parallel tests never observe a package-level environment transition.
+func RunTestMainWithIsolatedHome(run func() int) (code int) {
+	testHome, err := os.MkdirTemp("", "agentops-test-home-*")
+	if err != nil {
+		panic("testsupport: create isolated HOME: " + err.Error())
+	}
+
+	previousHome, hadHome := os.LookupEnv("HOME")
+	if err := os.Setenv("HOME", testHome); err != nil {
+		_ = os.RemoveAll(testHome)
+		panic("testsupport: set isolated HOME: " + err.Error())
+	}
+	defer func() {
+		if hadHome {
+			_ = os.Setenv("HOME", previousHome)
+		} else {
+			_ = os.Unsetenv("HOME")
+		}
+		_ = os.RemoveAll(testHome)
+	}()
+
+	return run()
+}

--- a/images/gemini/skills/using-gc/SKILL.md
+++ b/images/gemini/skills/using-gc/SKILL.md
@@ -98,8 +98,8 @@ rejects, or a hook recorded `enabled = false` (a disabled hook is not a trusted
 working hook). It never overwrites an operator decision, and re-running is a
 no-op. It also fails rather than continue if Codex returns an empty or
 unrecognized hook list. The trust store itself is never edited in place: the
-merged content is staged and parsed in a temp file first, then renamed in
-atomically, so no failure path can leave a corrupted Codex config.
+merged content is parsed in memory first, then installed with the CLI's durable
+atomic writer, so no failure path can leave a partially written Codex config.
 
 `ao gc check` verifies the same pre-seed from local state only — it runs no
 Codex subprocess and writes nothing, deriving each expected hook key from the

--- a/images/gemini/skills/using-gc/SKILL.md
+++ b/images/gemini/skills/using-gc/SKILL.md
@@ -78,6 +78,51 @@ modifies the GC binary, cache, formulas, roles, or upstream pack. `check`
 issues only native inspection commands, writes no adapter files, and fails
 before model spend when that runtime contract is missing or drifted.
 
+`prepare` also pre-seeds Codex trust for every session directory that exists
+when it runs — the city and rig roots, each `.gc/agents/**` session home, and
+each rig worktree root — so a Codex session in one of those directories does
+not block on the interactive trust dialog. Both persisted layers are seeded in
+`$CODEX_HOME/config.toml`: workspace trust (`[projects."<dir>"] trust_level =
+"trusted"`), without which Codex silently reports that directory as having no
+hooks at all, and per-hook trust
+(`[hooks.state."<hooks.json>:<event>:<m>:<h>"] trusted_hash = "sha256:..."`),
+which is what the pack's per-provider `.codex/hooks.json` would otherwise
+prompt for. Hook digests are read back from Codex's own `hooks/list`, never
+recomputed.
+
+Trust is judged by value, not by the presence of a table. `prepare` appends
+only entries that are missing and refuses, naming the entry, when one exists
+but does not confer trust — an explicit `trust_level = "untrusted"`, a hook
+Codex reports as changed since it was trusted, a recorded hook Codex still
+rejects, or a hook recorded `enabled = false` (a disabled hook is not a trusted
+working hook). It never overwrites an operator decision, and re-running is a
+no-op. It also fails rather than continue if Codex returns an empty or
+unrecognized hook list. The trust store itself is never edited in place: the
+merged content is staged and parsed in a temp file first, then renamed in
+atomically, so no failure path can leave a corrupted Codex config.
+
+`ao gc check` verifies the same pre-seed from local state only — it runs no
+Codex subprocess and writes nothing, deriving each expected hook key from the
+directory's own `hooks.json` — and names the specific deficient directory or
+hook using the same rule `prepare` seeds to.
+
+**Two named limitations.**
+
+1. **`check` cannot detect a stale hash.** Because it never asks Codex, a
+   recorded `trusted_hash` that no longer matches the hook's current content
+   reads as satisfied and still raises the trust dialog in a real session. Only
+   `prepare` sees that — Codex reports the hook as changed and `prepare`
+   refuses. A green `check` therefore means "trust is recorded", not "trust is
+   fresh".
+2. **Homes created after `prepare` are not covered.** Discovery is by
+   filesystem marker, so the guarantee covers session directories that exist at
+   `prepare` time. A session home Gas City materializes *later* still carries
+   untrusted hooks on its first spawn; `prepare` names the configured agents
+   that have no home yet.
+
+The operational rule that follows from both: run `prepare`, start the city,
+then run `prepare` again (it is idempotent) before dispatching.
+
 ## Preferred pack and registries
 
 The built-in `main` registry catalogs official packs. The community registry is
@@ -273,7 +318,16 @@ does not sling, retry, close, restart, or select work.
 2. **Bead graph** — `gc bd --rig <rig> ready --json` and `show <id> --json`.
    This is workflow-state truth, but a claimed bead cannot reveal a wedged pane.
 3. **Pane truth** — `tmux -L <socket> capture-pane -pt <session>`. This exposes
-   trust prompts, update nags, API/DNS failures, and interactive wedges.
+   trust prompts, update nags, API/DNS failures, and interactive wedges. A pane
+   parked on Codex's `Do you trust the contents of this directory?` (or the
+   later `Press t to trust all` hooks dialog) means that session directory was
+   not pre-seeded — the workflow queues dispatches as pending with no active
+   worker and reports no error. Almost always the home was created after the
+   last `ao gc prepare`; re-run `prepare`, then restart that session.
+   `ao gc check` names the untrusted directory or hook before you spend a
+   dispatch on it. Gas City also appears to auto-answer this dialog by sending
+   keys into the pane, so a wedge may clear on its own — treat that as a race
+   you do not want to depend on, not as a reason to skip the pre-seed.
 4. **Health machinery** — `gc doctor`, `gc order history`, storage health, and
    events. This proves metabolism, not semantic acceptance.
 

--- a/scripts/check-test-home-isolation.sh
+++ b/scripts/check-test-home-isolation.sh
@@ -11,7 +11,9 @@
 #   os.UserHomeDir, os.Getenv("HOME"), filepath.Join(home, ".claude" | ".codex" |
 #   ".agents") etc.) MUST also isolate HOME via either:
 #     (a) a per-test t.Setenv("HOME", ...), OR
-#     (b) a package-level TestMain that sets HOME before m.Run().
+#     (b) a package-level TestMain that calls
+#         testsupport.RunTestMainWithIsolatedHome(m.Run), OR
+#     (c) a legacy package-level TestMain that sets HOME before m.Run().
 #
 # Counter-rule: tests must not use os.Setenv("HOME", ...) inside a test
 # function. The Go testing.T helper t.Setenv is the only safe form because it
@@ -51,6 +53,10 @@ TRIGGER_PATTERN='os\.UserHomeDir\(\)|os\.Getenv\("HOME"\)|filepath\.Join\(home[A
 # call inside a TestMain. We detect both and let TestMain alone count.
 PER_TEST_ISOLATION='t\.Setenv\("HOME"'
 
+# Preferred package-wide isolation: the helper changes HOME before m.Run and
+# restores it only after every package test has finished.
+TESTMAIN_ISOLATION='testsupport\.RunTestMainWithIsolatedHome\(m\.Run\)'
+
 # Anti-pattern: os.Setenv("HOME", ...) inside a regular test function.
 # We greenlight it ONLY when used inside TestMain (the package-wide setup
 # helper, which runs before any t.Setenv-aware test machinery exists).
@@ -68,7 +74,7 @@ package_has_testmain_isolation() {
         [[ -f "$f" ]] || continue
         # Check if file has a TestMain function AND sets HOME within it.
         if grep -q '^func TestMain' "$f" 2>/dev/null && \
-           grep -qE "${PER_TEST_ISOLATION}|${RAW_HOME_SETENV}" "$f" 2>/dev/null; then
+           grep -qE "${TESTMAIN_ISOLATION}|${PER_TEST_ISOLATION}|${RAW_HOME_SETENV}" "$f" 2>/dev/null; then
             return 0
         fi
     done

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -633,8 +633,8 @@
     {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
-      "source_hash": "fa961808745dbb3304622af95164ff621d65f79c59acfbd4c411fdf21f5bba07",
-      "generated_hash": "122cfc099b6851ada7020e2d85730cf7c1137402a0a42dd54bbab63ec39b287d"
+      "source_hash": "f90559b2409d67bbf331a65b21ab9607674703296e27dc5f37cd2a8d319ca243",
+      "generated_hash": "698c77fbef14b142a5a9c27c822848ebd1711f039ec5e26838fe8bb190753410"
     },
     {
       "name": "validate",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -633,8 +633,8 @@
     {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
-      "source_hash": "f90559b2409d67bbf331a65b21ab9607674703296e27dc5f37cd2a8d319ca243",
-      "generated_hash": "698c77fbef14b142a5a9c27c822848ebd1711f039ec5e26838fe8bb190753410"
+      "source_hash": "fe4611b0533b7c64aa28571db6bf40009244910b445e6d7f85cf37fa497d72f7",
+      "generated_hash": "3494d26980cb439e1aed7cd8f02bef2acd7dcd5ab53ac7dd6db82b174557f44e"
     },
     {
       "name": "validate",

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/using-gc",
   "layout": "modular",
-  "source_hash": "fa961808745dbb3304622af95164ff621d65f79c59acfbd4c411fdf21f5bba07",
-  "generated_hash": "122cfc099b6851ada7020e2d85730cf7c1137402a0a42dd54bbab63ec39b287d"
+  "source_hash": "f90559b2409d67bbf331a65b21ab9607674703296e27dc5f37cd2a8d319ca243",
+  "generated_hash": "698c77fbef14b142a5a9c27c822848ebd1711f039ec5e26838fe8bb190753410"
 }

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/using-gc",
   "layout": "modular",
-  "source_hash": "f90559b2409d67bbf331a65b21ab9607674703296e27dc5f37cd2a8d319ca243",
-  "generated_hash": "698c77fbef14b142a5a9c27c822848ebd1711f039ec5e26838fe8bb190753410"
+  "source_hash": "fe4611b0533b7c64aa28571db6bf40009244910b445e6d7f85cf37fa497d72f7",
+  "generated_hash": "3494d26980cb439e1aed7cd8f02bef2acd7dcd5ab53ac7dd6db82b174557f44e"
 }

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -80,8 +80,8 @@ rejects, or a hook recorded `enabled = false` (a disabled hook is not a trusted
 working hook). It never overwrites an operator decision, and re-running is a
 no-op. It also fails rather than continue if Codex returns an empty or
 unrecognized hook list. The trust store itself is never edited in place: the
-merged content is staged and parsed in a temp file first, then renamed in
-atomically, so no failure path can leave a corrupted Codex config.
+merged content is parsed in memory first, then installed with the CLI's durable
+atomic writer, so no failure path can leave a partially written Codex config.
 
 `ao gc check` verifies the same pre-seed from local state only — it runs no
 Codex subprocess and writes nothing, deriving each expected hook key from the

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -60,6 +60,51 @@ modifies the GC binary, cache, formulas, roles, or upstream pack. `check`
 issues only native inspection commands, writes no adapter files, and fails
 before model spend when that runtime contract is missing or drifted.
 
+`prepare` also pre-seeds Codex trust for every session directory that exists
+when it runs — the city and rig roots, each `.gc/agents/**` session home, and
+each rig worktree root — so a Codex session in one of those directories does
+not block on the interactive trust dialog. Both persisted layers are seeded in
+`$CODEX_HOME/config.toml`: workspace trust (`[projects."<dir>"] trust_level =
+"trusted"`), without which Codex silently reports that directory as having no
+hooks at all, and per-hook trust
+(`[hooks.state."<hooks.json>:<event>:<m>:<h>"] trusted_hash = "sha256:..."`),
+which is what the pack's per-provider `.codex/hooks.json` would otherwise
+prompt for. Hook digests are read back from Codex's own `hooks/list`, never
+recomputed.
+
+Trust is judged by value, not by the presence of a table. `prepare` appends
+only entries that are missing and refuses, naming the entry, when one exists
+but does not confer trust — an explicit `trust_level = "untrusted"`, a hook
+Codex reports as changed since it was trusted, a recorded hook Codex still
+rejects, or a hook recorded `enabled = false` (a disabled hook is not a trusted
+working hook). It never overwrites an operator decision, and re-running is a
+no-op. It also fails rather than continue if Codex returns an empty or
+unrecognized hook list. The trust store itself is never edited in place: the
+merged content is staged and parsed in a temp file first, then renamed in
+atomically, so no failure path can leave a corrupted Codex config.
+
+`ao gc check` verifies the same pre-seed from local state only — it runs no
+Codex subprocess and writes nothing, deriving each expected hook key from the
+directory's own `hooks.json` — and names the specific deficient directory or
+hook using the same rule `prepare` seeds to.
+
+**Two named limitations.**
+
+1. **`check` cannot detect a stale hash.** Because it never asks Codex, a
+   recorded `trusted_hash` that no longer matches the hook's current content
+   reads as satisfied and still raises the trust dialog in a real session. Only
+   `prepare` sees that — Codex reports the hook as changed and `prepare`
+   refuses. A green `check` therefore means "trust is recorded", not "trust is
+   fresh".
+2. **Homes created after `prepare` are not covered.** Discovery is by
+   filesystem marker, so the guarantee covers session directories that exist at
+   `prepare` time. A session home Gas City materializes *later* still carries
+   untrusted hooks on its first spawn; `prepare` names the configured agents
+   that have no home yet.
+
+The operational rule that follows from both: run `prepare`, start the city,
+then run `prepare` again (it is idempotent) before dispatching.
+
 ## Preferred pack and registries
 
 The built-in `main` registry catalogs official packs. The community registry is
@@ -255,7 +300,16 @@ does not sling, retry, close, restart, or select work.
 2. **Bead graph** — `gc bd --rig <rig> ready --json` and `show <id> --json`.
    This is workflow-state truth, but a claimed bead cannot reveal a wedged pane.
 3. **Pane truth** — `tmux -L <socket> capture-pane -pt <session>`. This exposes
-   trust prompts, update nags, API/DNS failures, and interactive wedges.
+   trust prompts, update nags, API/DNS failures, and interactive wedges. A pane
+   parked on Codex's `Do you trust the contents of this directory?` (or the
+   later `Press t to trust all` hooks dialog) means that session directory was
+   not pre-seeded — the workflow queues dispatches as pending with no active
+   worker and reports no error. Almost always the home was created after the
+   last `ao gc prepare`; re-run `prepare`, then restart that session.
+   `ao gc check` names the untrusted directory or hook before you spend a
+   dispatch on it. Gas City also appears to auto-answer this dialog by sending
+   keys into the pane, so a wedge may clear on its own — treat that as a race
+   you do not want to depend on, not as a reason to skip the pre-seed.
 4. **Health machinery** — `gc doctor`, `gc order history`, storage health, and
    events. This proves metabolism, not semantic acceptance.
 

--- a/skills/using-gc/SKILL.md
+++ b/skills/using-gc/SKILL.md
@@ -98,8 +98,8 @@ rejects, or a hook recorded `enabled = false` (a disabled hook is not a trusted
 working hook). It never overwrites an operator decision, and re-running is a
 no-op. It also fails rather than continue if Codex returns an empty or
 unrecognized hook list. The trust store itself is never edited in place: the
-merged content is staged and parsed in a temp file first, then renamed in
-atomically, so no failure path can leave a corrupted Codex config.
+merged content is parsed in memory first, then installed with the CLI's durable
+atomic writer, so no failure path can leave a partially written Codex config.
 
 `ao gc check` verifies the same pre-seed from local state only — it runs no
 Codex subprocess and writes nothing, deriving each expected hook key from the

--- a/skills/using-gc/SKILL.md
+++ b/skills/using-gc/SKILL.md
@@ -78,6 +78,51 @@ modifies the GC binary, cache, formulas, roles, or upstream pack. `check`
 issues only native inspection commands, writes no adapter files, and fails
 before model spend when that runtime contract is missing or drifted.
 
+`prepare` also pre-seeds Codex trust for every session directory that exists
+when it runs — the city and rig roots, each `.gc/agents/**` session home, and
+each rig worktree root — so a Codex session in one of those directories does
+not block on the interactive trust dialog. Both persisted layers are seeded in
+`$CODEX_HOME/config.toml`: workspace trust (`[projects."<dir>"] trust_level =
+"trusted"`), without which Codex silently reports that directory as having no
+hooks at all, and per-hook trust
+(`[hooks.state."<hooks.json>:<event>:<m>:<h>"] trusted_hash = "sha256:..."`),
+which is what the pack's per-provider `.codex/hooks.json` would otherwise
+prompt for. Hook digests are read back from Codex's own `hooks/list`, never
+recomputed.
+
+Trust is judged by value, not by the presence of a table. `prepare` appends
+only entries that are missing and refuses, naming the entry, when one exists
+but does not confer trust — an explicit `trust_level = "untrusted"`, a hook
+Codex reports as changed since it was trusted, a recorded hook Codex still
+rejects, or a hook recorded `enabled = false` (a disabled hook is not a trusted
+working hook). It never overwrites an operator decision, and re-running is a
+no-op. It also fails rather than continue if Codex returns an empty or
+unrecognized hook list. The trust store itself is never edited in place: the
+merged content is staged and parsed in a temp file first, then renamed in
+atomically, so no failure path can leave a corrupted Codex config.
+
+`ao gc check` verifies the same pre-seed from local state only — it runs no
+Codex subprocess and writes nothing, deriving each expected hook key from the
+directory's own `hooks.json` — and names the specific deficient directory or
+hook using the same rule `prepare` seeds to.
+
+**Two named limitations.**
+
+1. **`check` cannot detect a stale hash.** Because it never asks Codex, a
+   recorded `trusted_hash` that no longer matches the hook's current content
+   reads as satisfied and still raises the trust dialog in a real session. Only
+   `prepare` sees that — Codex reports the hook as changed and `prepare`
+   refuses. A green `check` therefore means "trust is recorded", not "trust is
+   fresh".
+2. **Homes created after `prepare` are not covered.** Discovery is by
+   filesystem marker, so the guarantee covers session directories that exist at
+   `prepare` time. A session home Gas City materializes *later* still carries
+   untrusted hooks on its first spawn; `prepare` names the configured agents
+   that have no home yet.
+
+The operational rule that follows from both: run `prepare`, start the city,
+then run `prepare` again (it is idempotent) before dispatching.
+
 ## Preferred pack and registries
 
 The built-in `main` registry catalogs official packs. The community registry is
@@ -273,7 +318,16 @@ does not sling, retry, close, restart, or select work.
 2. **Bead graph** — `gc bd --rig <rig> ready --json` and `show <id> --json`.
    This is workflow-state truth, but a claimed bead cannot reveal a wedged pane.
 3. **Pane truth** — `tmux -L <socket> capture-pane -pt <session>`. This exposes
-   trust prompts, update nags, API/DNS failures, and interactive wedges.
+   trust prompts, update nags, API/DNS failures, and interactive wedges. A pane
+   parked on Codex's `Do you trust the contents of this directory?` (or the
+   later `Press t to trust all` hooks dialog) means that session directory was
+   not pre-seeded — the workflow queues dispatches as pending with no active
+   worker and reports no error. Almost always the home was created after the
+   last `ao gc prepare`; re-run `prepare`, then restart that session.
+   `ao gc check` names the untrusted directory or hook before you spend a
+   dispatch on it. Gas City also appears to auto-answer this dialog by sending
+   keys into the pane, so a wedge may clear on its own — treat that as a race
+   you do not want to depend on, not as a reason to skip the pre-seed.
 4. **Health machinery** — `gc doctor`, `gc order history`, storage health, and
    events. This proves metabolism, not semantic acceptance.
 


### PR DESCRIPTION
## Defect

Gas City materializes Codex session homes with project-local hooks. The first
Codex process in an untrusted home can stop at the interactive workspace/hook
trust dialog, leaving the agent pane alive but unable to take dispatched work.

Codex persists two independent decisions in `$CODEX_HOME/config.toml`:

1. workspace trust under `[projects."<dir>"]`
2. one content hash per hook under `[hooks.state."<hook-key>"]`

Trusting a parent directory does not trust a session home, and the hook digest
input is intentionally owned by Codex rather than reimplemented here.

## Change

`ao gc prepare` now discovers the Gas City directories that exist when it runs
(city and rig roots, materialized agent homes, and materialized rig worktrees)
and pre-seeds both trust layers for those exact targets.

- Hook identities and current hashes come from Codex's `hooks/list` app-server
  method.
- Returned hooks are restricted to the discovered targets; user- or
  plugin-level hooks are never granted trust by this command.
- Explicit operator decisions are preserved. An untrusted workspace, modified
  hook, disabled hook, unusable hash, malformed response, or malformed TOML
  fails loudly rather than being rewritten or accepted as complete.
- The merged TOML is validated in memory and installed with the CLI's durable
  atomic writer while preserving existing permissions.
- `ao gc check` verifies the same values from local files only. It starts no
  Codex subprocess and writes nothing.

## Deliberate boundary

Discovery is filesystem-based. A home Gas City creates *after* `prepare` is not
pre-seeded by an earlier invocation. `prepare` compares configured agent
identities with materialized homes and warns about missing homes, including the
real dotted-name shape (`gastown.mayor` → `.gc/agents/mayor`). The operational
rule is documented explicitly:

```text
prepare → start the city → prepare again → dispatch
```

This PR does not claim that one pre-start invocation covers future homes or
that every future pane can never encounter a prompt.

## Evidence

Automated tests cover:

- value-based workspace and hook trust, including `enabled = false`
- malformed/unexpected `hooks/list` responses
- regular local `hooks.json` files that derive zero hook identities (`{}`,
  `{"hooks":null}`, and `{"hooks":{}}`), keeping `prepare` and `check` aligned
- real TOML spellings, invalid merges, idempotence, and mode preservation
- target filtering and derived hook-key fidelity
- subprocess-free `check`
- missing-home identity reporting for nested and dotted qualified names
- operation with no Codex binary
- package-wide HOME isolation

An isolated real-Codex smoke on a disposable Gas City home established the
behavioral differential: with the home's trust entries removed, Codex rendered
the trust dialog; after seeding the same home, it reached the composer without
the prompt. This proves the existing-home mechanism, not future-home timing.

Final recovery checks on commit `a4b52b2354b9f96e5e10e07b2916339c87190bfc`:

```text
go test -count=1 ./internal/gcmaintainer
ok github.com/boshu2/agentops/cli/internal/gcmaintainer 11.943s

go test -race -shuffle=on -count=2 ./internal/gcmaintainer
PASS

go test -count=1 ./internal/testsupport
PASS

go vet ./internal/gcmaintainer ./internal/testsupport
PASS

scripts/check-test-home-isolation.sh
PASS

scripts/check-test-isolation.sh
PASS (raw os.Setenv remains at the 10/10 baseline)

GOCACHE=/private/tmp/agentops-gocache \
GOLANGCI_LINT_CACHE=/private/tmp/agentops-golangci-cache \
WORKTREE_DISPOSITION_CI_SKIP=1 \
./bin/ao gate check --full --workflow-coverage --require-workflow-parity
PASS (68/68 full/head checks)

GOCACHE=/private/tmp/agentops-gocache bash scripts/regen-all.sh --check
PASS

git diff --check
PASS
```

Recovery fixed the prior CI findings with `storage.AtomicWriteFile`, package-wide
HOME isolation, and `json.Encoder.Encode`. The first repaired CI replay exposed
one further ratchet: raw `os.Setenv` calls in the new `_test.go` TestMain raised
the repository baseline from 10 to 12. The final commit moves that one-time
setup into the existing shared test-support boundary, keeps environment changes
outside `m.Run`, and teaches the HOME-isolation gate only the exact safe helper
shape. CI will rerun on the exact pushed commit.
