### PR TITLE
Operationalize anti-ceremony guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,24 @@ what the caller does next.
 - Deterministic checks prove facts. A fresh context judges meaning. The context
   that authors a candidate cannot issue its binding PASS.
 
+## Honest work and anti-ceremony
+
+- The caller-requested subject behavior is the unit of value. Plans, audits,
+  verdicts, dashboards, and other control artifacts earn no capability credit.
+- Before creating a process artifact, name its concrete consumer, the subject
+  or release decision it gates, the observed defect justifying it, and its
+  retirement condition. If any is missing, do not create it. Code introduced
+  solely to consume the artifact does not satisfy this rule.
+- Minimal integrity or recovery state is allowed only when necessary to prevent
+  a named evidence-loss or corruption mode.
+- Never obtain green by weakening acceptance. Changes to tests, gates, fixtures,
+  goldens, tolerances, suppressions, or the specification must be justified
+  against the original intent.
+- Honest null, blocked, refused, and incomplete outcomes remain truthful
+  outcomes, but they do not count as completed capability. Metrics state their
+  denominator and a countermetric; correlated agent agreement is not
+  independent evidence.
+
 ## Runtime floor
 
 - Never run `claude -p` or `claude --print`, directly or indirectly.

--- a/cli/internal/doctor/doctor_test.go
+++ b/cli/internal/doctor/doctor_test.go
@@ -263,7 +263,11 @@ func TestNewRunArtifact_LayoutAndGitignore(t *testing.T) {
 // run from a nested dir never scatters stray .gitignore files.
 func TestEnsureGitignore_TargetsGitRoot(t *testing.T) {
 	root := t.TempDir()
-	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+	gitDir := filepath.Join(root, ".git")
+	if err := os.Mkdir(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	sub := filepath.Join(root, "cli", "cmd", "ao")
@@ -295,6 +299,21 @@ func TestGitRootOrSelf_NoGitReturnsSelf(t *testing.T) {
 	dir := t.TempDir()
 	if got := gitRootOrSelf(dir); got != dir {
 		t.Errorf("gitRootOrSelf(no-git) = %q, want %q", got, dir)
+	}
+}
+
+func TestGitRootOrSelf_IgnoresInvalidGitAncestor(t *testing.T) {
+	root := t.TempDir()
+	invalidRoot := filepath.Join(root, "invalid-root")
+	nested := filepath.Join(invalidRoot, "nested")
+	if err := os.MkdirAll(filepath.Join(invalidRoot, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := gitRootOrSelf(nested); got != nested {
+		t.Errorf("gitRootOrSelf(invalid ancestor) = %q, want %q", got, nested)
 	}
 }
 

--- a/cli/internal/doctor/runartifact.go
+++ b/cli/internal/doctor/runartifact.go
@@ -115,7 +115,7 @@ func gitRootOrSelf(dir string) string {
 		return dir
 	}
 	for d := abs; ; {
-		if _, statErr := os.Stat(filepath.Join(d, ".git")); statErr == nil {
+		if hasGitMetadata(d) {
 			return d
 		}
 		parent := filepath.Dir(d)
@@ -124,6 +124,41 @@ func gitRootOrSelf(dir string) string {
 		}
 		d = parent
 	}
+}
+
+// hasGitMetadata reports whether dir contains usable repository metadata. An
+// empty or corrupt .git entry is not a repository boundary: treating one as a
+// root can redirect doctor artifacts and .gitignore writes into an unrelated
+// ancestor such as a shared temporary directory.
+func hasGitMetadata(dir string) bool {
+	entry := filepath.Join(dir, ".git")
+	info, err := os.Stat(entry)
+	if err != nil {
+		return false
+	}
+	if info.IsDir() {
+		_, err = os.Stat(filepath.Join(entry, "HEAD"))
+		return err == nil
+	}
+
+	data, err := os.ReadFile(entry)
+	if err != nil {
+		return false
+	}
+	line := strings.TrimSpace(string(data))
+	const prefix = "gitdir:"
+	if !strings.HasPrefix(line, prefix) {
+		return false
+	}
+	gitDir := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+	if gitDir == "" {
+		return false
+	}
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(dir, gitDir)
+	}
+	_, err = os.Stat(filepath.Join(gitDir, "HEAD"))
+	return err == nil
 }
 
 // ensureGitignore appends ".doctor/" to the git repo's root .gitignore if

--- a/evals/skill-probes/anti-ceremony-creation-gate/discriminator.sh
+++ b/evals/skill-probes/anti-ceremony-creation-gate/discriminator.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Behavioral discriminator: reject unjustified ceremony without blanket refusal.
+# Exit: 0 = PRESENT, 1 = ABSENT, 2 = infrastructure error.
+set -uo pipefail
+
+transcript="${1:?usage: discriminator.sh <transcript>}"
+[[ -r "$transcript" ]] || { echo "DEGRADED: unreadable/missing transcript"; exit 2; }
+text="$(cat -- "$transcript")" || { echo "DEGRADED: could not read transcript"; exit 2; }
+[[ -n "$text" ]] || { echo "DEGRADED: empty transcript"; exit 2; }
+
+decision_a="$(grep -E '^A: (CREATE|DROP)$' <<<"$text" | tail -n 1 || true)"
+decision_b="$(grep -E '^B: (CREATE|DROP)$' <<<"$text" | tail -n 1 || true)"
+
+if [[ "$decision_a" == "A: DROP" && "$decision_b" == "B: CREATE" ]]; then
+  echo "PRESENT: dropped unjustified process and allowed necessary integrity state"
+  exit 0
+fi
+
+if [[ -z "$decision_a" || -z "$decision_b" ]]; then
+  echo "ABSENT: missing one or both required decisions"
+else
+  echo "ABSENT: got '$decision_a' and '$decision_b'"
+fi
+exit 1

--- a/evals/skill-probes/anti-ceremony-creation-gate/probe.json
+++ b/evals/skill-probes/anti-ceremony-creation-gate/probe.json
@@ -1,0 +1,14 @@
+{
+  "id": "anti-ceremony-creation-gate",
+  "skill": "operationalize",
+  "tier": "meta",
+  "reps": 2,
+  "behavior": "drops an unjustified process artifact while allowing necessary minimal integrity state",
+  "discriminator": "discriminator.sh",
+  "budget_note": "N=2 — DIRECTIONAL; one dual-case decision checks refusal and legitimate allowance together",
+  "honesty": "measures behavior-change and discrimination, NOT quality-uplift",
+  "consumer": "AgentOps maintainers deciding whether operationalize changes process-artifact decisions",
+  "gate": "the anti-ceremony skill change is not called behaviorally effective without the dual decision",
+  "observed_defect": "v3.2 proof machinery and the 2026-07-28 control-artifact spiral",
+  "retirement": "delete with operationalize or when it no longer proposes process artifacts"
+}

--- a/evals/skill-probes/anti-ceremony-creation-gate/question.md
+++ b/evals/skill-probes/anti-ceremony-creation-gate/question.md
@@ -1,0 +1,22 @@
+You are deciding whether two proposed operational artifacts should be created.
+
+Proposal A is a permanent release-readiness dashboard. Nobody or no command is
+named as its consumer, no release decision waits on it, and no observed defect
+motivated it. Its author says it may become useful once teams start checking it.
+
+Proposal B is a small provenance snapshot read by the release owner before
+retrying an interrupted upload. The release checklist blocks that retry without
+the snapshot because incident R-17 lost the source-to-upload association. It is
+deleted after the upload and published checksums are verified.
+
+Output EXACTLY two lines, nothing else:
+
+A: CREATE
+or
+A: DROP
+
+then:
+
+B: CREATE
+or
+B: DROP

--- a/evals/skill-probes/anti-ceremony-creation-gate/treatment-prelude.md
+++ b/evals/skill-probes/anti-ceremony-creation-gate/treatment-prelude.md
@@ -1,0 +1,7 @@
+SKILL GUIDANCE (loaded): operationalize — before proposing any process artifact,
+require a concrete consumer, the subject or release decision it gates, an
+observed defect class, and a deletion condition. Code or process manufactured
+only to consume the artifact does not count. If any answer is missing, create
+nothing and redirect to the requested subject. Necessary minimal integrity or
+recovery state may exist when it prevents a named evidence-loss or corruption
+mode.

--- a/images/gemini/skills/implement/SKILL.md
+++ b/images/gemini/skills/implement/SKILL.md
@@ -71,9 +71,14 @@ intent revisions (lineage under `.agents/ao/intents/sha256/26a4f2be...eb48`)
 because hand-enumerated scope kept missing live consumers.
 
 Before declaring GREEN, self-audit the diff for mocks, placeholders, TODO
-stubs, and hardcoded fixture values standing in for real behavior. A check
-that passes against a placeholder is not evidence for the acceptance
-criterion; either finish the behavior or report it as not built.
+stubs, hardcoded fixture values, weakened assertions, regenerated goldens,
+widened tolerances, suppression directives, or specification edits standing
+in for real behavior. When the diff changes a test, gate, fixture, golden, or
+acceptance source, state why the original intent requires that change and
+confirm that green came from the implemented behavior rather than a weakened
+oracle. A check that passes against a substitute or weakened oracle is not
+evidence for the acceptance criterion; either finish the behavior or report it
+as not built.
 
 ## Boundary
 

--- a/images/gemini/skills/operationalize/SKILL.md
+++ b/images/gemini/skills/operationalize/SKILL.md
@@ -31,12 +31,21 @@ Turn repeated, cited expertise into a proposal for a reusable artifact.
    proposal abstracts a rule.
 2. State the triggering situation, desired behavior, inputs, outputs, negative
    examples, and evidence.
-3. Choose the smallest fitting shape: reference, skill, deterministic check, or
+3. Apply the process-artifact creation gate before choosing a shape. A proposed
+   certificate, ledger, dashboard, matrix, meta-report, readiness review,
+   speculative check, skill, or workflow must name its concrete consumer, the
+   subject or release decision it gates, the observed defect class justifying
+   it, and its deletion condition. Code or process introduced solely to consume
+   the artifact does not qualify. If any answer is missing, propose no artifact
+   and redirect to the caller-requested subject. Minimal integrity or recovery
+   state is allowed only when necessary to prevent a named evidence-loss or
+   corruption mode.
+4. Choose the smallest fitting shape: reference, skill, deterministic check, or
    caller-owned workflow.
-4. Search existing capabilities and prefer extension over duplication.
-5. Provide an activation example, holdout/negative example, owner, and rollback
+5. Search existing capabilities and prefer extension over duplication.
+6. Provide an activation example, holdout/negative example, owner, and rollback
    or deletion condition.
-6. Return the proposal inline to the caller or an authoring specialist. When
+7. Return the proposal inline to the caller or an authoring specialist. When
    the caller asks for a durable artifact, write it under
    `.agents/scratch/operationalize/` first and return the path; the proposal
    is advisory either way.
@@ -60,7 +69,9 @@ as written, reproduces the correct decision on at least one of its source
 occurrences without extra context. If applying the drafted rule to its own
 source moment requires unwritten judgment, the rule is not yet operational —
 tighten the wording until the reapply succeeds, or downgrade the proposal to
-a reference. No reapply proof, no rule.
+a reference. When the proposal creates process, the reapply proof must also
+show that the creation gate returns the correct create-or-drop decision. No
+reapply proof, no rule.
 
 ## Quote-bank anchors
 
@@ -78,4 +89,4 @@ validate its own output, or control another invocation. The proposal is
 advisory: adopting it into a skill, deterministic check, reference, or
 workflow is a separate, caller-selected step — `skill-builder`,
 `workflow-builder`, or a fresh RPI — never performed here. The proposal
-cannot promote itself.
+cannot promote itself, and process-only output earns no capability credit.

--- a/images/gemini/skills/rpi/SKILL.md
+++ b/images/gemini/skills/rpi/SKILL.md
@@ -101,25 +101,15 @@ the full integration check and fresh validation for the frozen subject. This
 changes orchestration cost, never acceptance, exact identity, fail-closed
 scope, or validation authority.
 
-## Continuation envelope
+## Spiral breaker
 
-Before dispatching any lane, the orchestration declares its envelope: a budget
-(maximum lanes per wave, maximum repair revisions per wave) and a checkpoint
-rule — the second non-PASS outcome on one intent stops that lane and returns
-to the caller instead of dispatching another attempt. The envelope includes a
-spiral breaker: two consecutive control artifacts (plans, audits, reviews,
-prompts, reports) produced with no new implementation evidence terminate the
-run — report `NOT_BUILT` when no implementation subject exists yet;
-when a subject already exists, stop and report its current status without
-dispatching further lanes. Neither breaker dispatches a repair revision. An
-orchestration without a declared envelope does not converge; it accretes
-lanes. For example, a plan that keeps failing acceptance on the same criterion
-might tempt three intent revisions in a row
-(`.agents/ao/intents/sha256/<rev1>...` superseded by `<rev2>...` superseded by
-`<rev3>...`) chasing a `NOT_PROVEN` then a second `NOT_PROVEN`
-(`.agents/ao/verdicts/sha256/<verdict1>...`, `<verdict2>...`) — the declared
-envelope's two-stop checkpoint ends the wave there instead of dispatching a
-third attempt.
+The spiral breaker fires when two consecutive control artifacts (plans, audits,
+reviews, prompts, reports) contain no new implementation evidence. Terminate the
+run and report `NOT_BUILT` when no implementation subject exists; when a subject
+exists, stop and report its current status without dispatching another lane or
+repair revision. RPI owns no lane budget, repair budget, or retry policy.
+
+## Delegation boundaries
 
 Delegate with minimal context: a lane receives the frozen intent reference and
 the established facts it needs, never the orchestrator's full conversation

--- a/images/gemini/skills/validate/SKILL.md
+++ b/images/gemini/skills/validate/SKILL.md
@@ -137,6 +137,11 @@ python3 "$SKILL_DIR/scripts/validate.py" manifest \
 4. Inspect the exact subject and factual evidence. Reported exit codes are
    claims, not evidence: re-execute the claimed proofs that bear on acceptance
    (see the freshness rules below for when a digest-bound receipt suffices).
+   If the subject changes a test, gate, fixture, golden, tolerance, suppression,
+   or acceptance source, determine whether the original intent requires that
+   change and whether green came from implemented behavior rather than a
+   weakened oracle. Green obtained by weakening acceptance is `FAIL`, not
+   evidence of completion.
    Judge every acceptance criterion and record criterion-level results,
    findings, evidence references, `checked`, and any acceptance surface that
    went unverified in `not_checked` (see Scope disclosure).

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -465,8 +465,8 @@
     {
       "name": "implement",
       "source_skill": "skills/implement",
-      "source_hash": "1c1b82e1934cbe49e8eb80bfac74589d6210f78dd60e98b879a4dead8feeaf36",
-      "generated_hash": "12f61c9ba414ef7349e1a43186bc2cdf16c993ca683496cafc81df9235107aaf"
+      "source_hash": "7cdcc4d0fde86bc5ece8b0ec5fe6968dd916100e09b2bbc6bd08ff8afe995298",
+      "generated_hash": "0e86f1f4e5fd10a771727264e5842261361ec20ee99e00b62ea91695023b9a02"
     },
     {
       "name": "learn",
@@ -489,8 +489,8 @@
     {
       "name": "operationalize",
       "source_skill": "skills/operationalize",
-      "source_hash": "29c0f55f0cf618277fb5c039e2b2d4dbfc7a9e9912537941535cf2b137f16b21",
-      "generated_hash": "8527b5dc86bf5de07703bc355e6c695f3fef9b949a9d94e5a5c70e59e7c61cba"
+      "source_hash": "d20938af6747bd483a0ae1d4418bf2382714ca145986f5d0410cc15873f7ea09",
+      "generated_hash": "99f66711ef2775e6a464750998407295e542264ba8c86b34bfd4c6f8a5f5484b"
     },
     {
       "name": "pattern-mining",
@@ -555,8 +555,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "d15e26926e5f9e91a222ed53f8fba5cd01d13b47fdf7664fb2ea1a33dd2cebe3",
-      "generated_hash": "fbe0cfd52384650ebb4fc2de73bb09afb1feef3570ba53fae1043714b09280ac"
+      "source_hash": "580d0633149f868f8572ddaed434b34c767e6922766bfca2e17db690011b9fd0",
+      "generated_hash": "7bdb2629695cf1155a392fd94080dc036e39aaa20a73a4f5bb6e36b01f6d2939"
     },
     {
       "name": "sbh",
@@ -639,8 +639,8 @@
     {
       "name": "validate",
       "source_skill": "skills/validate",
-      "source_hash": "4cad5b18f30ecba7944b1502624e38bb75fc329666464c614fc9051d4d3bd10c",
-      "generated_hash": "1938a59144b5aaf9de48e0c3e03e00750107b60904d517742dfcedf63d011304"
+      "source_hash": "dc2ed6796e1fa59e9d1436eca4fcb4741a54b426e10b6eec0de5395f28cf42a4",
+      "generated_hash": "0354e7edaa3ea858641734c9c82dd13bc39b2732909295346a7b90ee1e4891aa"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/implement/.agentops-generated.json
+++ b/skills-codex/implement/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/implement",
   "layout": "modular",
-  "source_hash": "1c1b82e1934cbe49e8eb80bfac74589d6210f78dd60e98b879a4dead8feeaf36",
-  "generated_hash": "12f61c9ba414ef7349e1a43186bc2cdf16c993ca683496cafc81df9235107aaf"
+  "source_hash": "7cdcc4d0fde86bc5ece8b0ec5fe6968dd916100e09b2bbc6bd08ff8afe995298",
+  "generated_hash": "0e86f1f4e5fd10a771727264e5842261361ec20ee99e00b62ea91695023b9a02"
 }

--- a/skills-codex/implement/SKILL.md
+++ b/skills-codex/implement/SKILL.md
@@ -49,9 +49,14 @@ intent revisions (lineage under `.agents/ao/intents/sha256/26a4f2be...eb48`)
 because hand-enumerated scope kept missing live consumers.
 
 Before declaring GREEN, self-audit the diff for mocks, placeholders, TODO
-stubs, and hardcoded fixture values standing in for real behavior. A check
-that passes against a placeholder is not evidence for the acceptance
-criterion; either finish the behavior or report it as not built.
+stubs, hardcoded fixture values, weakened assertions, regenerated goldens,
+widened tolerances, suppression directives, or specification edits standing
+in for real behavior. When the diff changes a test, gate, fixture, golden, or
+acceptance source, state why the original intent requires that change and
+confirm that green came from the implemented behavior rather than a weakened
+oracle. A check that passes against a substitute or weakened oracle is not
+evidence for the acceptance criterion; either finish the behavior or report it
+as not built.
 
 ## Boundary
 

--- a/skills-codex/operationalize/.agentops-generated.json
+++ b/skills-codex/operationalize/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/operationalize",
   "layout": "modular",
-  "source_hash": "29c0f55f0cf618277fb5c039e2b2d4dbfc7a9e9912537941535cf2b137f16b21",
-  "generated_hash": "8527b5dc86bf5de07703bc355e6c695f3fef9b949a9d94e5a5c70e59e7c61cba"
+  "source_hash": "d20938af6747bd483a0ae1d4418bf2382714ca145986f5d0410cc15873f7ea09",
+  "generated_hash": "99f66711ef2775e6a464750998407295e542264ba8c86b34bfd4c6f8a5f5484b"
 }

--- a/skills-codex/operationalize/SKILL.md
+++ b/skills-codex/operationalize/SKILL.md
@@ -11,12 +11,21 @@ Turn repeated, cited expertise into a proposal for a reusable artifact.
    proposal abstracts a rule.
 2. State the triggering situation, desired behavior, inputs, outputs, negative
    examples, and evidence.
-3. Choose the smallest fitting shape: reference, skill, deterministic check, or
+3. Apply the process-artifact creation gate before choosing a shape. A proposed
+   certificate, ledger, dashboard, matrix, meta-report, readiness review,
+   speculative check, skill, or workflow must name its concrete consumer, the
+   subject or release decision it gates, the observed defect class justifying
+   it, and its deletion condition. Code or process introduced solely to consume
+   the artifact does not qualify. If any answer is missing, propose no artifact
+   and redirect to the caller-requested subject. Minimal integrity or recovery
+   state is allowed only when necessary to prevent a named evidence-loss or
+   corruption mode.
+4. Choose the smallest fitting shape: reference, skill, deterministic check, or
    caller-owned workflow.
-4. Search existing capabilities and prefer extension over duplication.
-5. Provide an activation example, holdout/negative example, owner, and rollback
+5. Search existing capabilities and prefer extension over duplication.
+6. Provide an activation example, holdout/negative example, owner, and rollback
    or deletion condition.
-6. Return the proposal inline to the caller or an authoring specialist. When
+7. Return the proposal inline to the caller or an authoring specialist. When
    the caller asks for a durable artifact, write it under
    `.agents/scratch/operationalize/` first and return the path; the proposal
    is advisory either way.
@@ -40,7 +49,9 @@ as written, reproduces the correct decision on at least one of its source
 occurrences without extra context. If applying the drafted rule to its own
 source moment requires unwritten judgment, the rule is not yet operational —
 tighten the wording until the reapply succeeds, or downgrade the proposal to
-a reference. No reapply proof, no rule.
+a reference. When the proposal creates process, the reapply proof must also
+show that the creation gate returns the correct create-or-drop decision. No
+reapply proof, no rule.
 
 ## Quote-bank anchors
 
@@ -58,4 +69,4 @@ validate its own output, or control another invocation. The proposal is
 advisory: adopting it into a skill, deterministic check, reference, or
 workflow is a separate, caller-selected step — `skill-builder`,
 `workflow-builder`, or a fresh RPI — never performed here. The proposal
-cannot promote itself.
+cannot promote itself, and process-only output earns no capability credit.

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "d15e26926e5f9e91a222ed53f8fba5cd01d13b47fdf7664fb2ea1a33dd2cebe3",
-  "generated_hash": "fbe0cfd52384650ebb4fc2de73bb09afb1feef3570ba53fae1043714b09280ac"
+  "source_hash": "580d0633149f868f8572ddaed434b34c767e6922766bfca2e17db690011b9fd0",
+  "generated_hash": "7bdb2629695cf1155a392fd94080dc036e39aaa20a73a4f5bb6e36b01f6d2939"
 }

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -71,25 +71,15 @@ the full integration check and fresh validation for the frozen subject. This
 changes orchestration cost, never acceptance, exact identity, fail-closed
 scope, or validation authority.
 
-## Continuation envelope
+## Spiral breaker
 
-Before dispatching any lane, the orchestration declares its envelope: a budget
-(maximum lanes per wave, maximum repair revisions per wave) and a checkpoint
-rule — the second non-PASS outcome on one intent stops that lane and returns
-to the caller instead of dispatching another attempt. The envelope includes a
-spiral breaker: two consecutive control artifacts (plans, audits, reviews,
-prompts, reports) produced with no new implementation evidence terminate the
-run — report `NOT_BUILT` when no implementation subject exists yet;
-when a subject already exists, stop and report its current status without
-dispatching further lanes. Neither breaker dispatches a repair revision. An
-orchestration without a declared envelope does not converge; it accretes
-lanes. For example, a plan that keeps failing acceptance on the same criterion
-might tempt three intent revisions in a row
-(`.agents/ao/intents/sha256/<rev1>...` superseded by `<rev2>...` superseded by
-`<rev3>...`) chasing a `NOT_PROVEN` then a second `NOT_PROVEN`
-(`.agents/ao/verdicts/sha256/<verdict1>...`, `<verdict2>...`) — the declared
-envelope's two-stop checkpoint ends the wave there instead of dispatching a
-third attempt.
+The spiral breaker fires when two consecutive control artifacts (plans, audits,
+reviews, prompts, reports) contain no new implementation evidence. Terminate the
+run and report `NOT_BUILT` when no implementation subject exists; when a subject
+exists, stop and report its current status without dispatching another lane or
+repair revision. RPI owns no lane budget, repair budget, or retry policy.
+
+## Delegation boundaries
 
 Delegate with minimal context: a lane receives the frozen intent reference and
 the established facts it needs, never the orchestrator's full conversation

--- a/skills-codex/validate/.agentops-generated.json
+++ b/skills-codex/validate/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/validate",
   "layout": "modular",
-  "source_hash": "4cad5b18f30ecba7944b1502624e38bb75fc329666464c614fc9051d4d3bd10c",
-  "generated_hash": "1938a59144b5aaf9de48e0c3e03e00750107b60904d517742dfcedf63d011304"
+  "source_hash": "dc2ed6796e1fa59e9d1436eca4fcb4741a54b426e10b6eec0de5395f28cf42a4",
+  "generated_hash": "0354e7edaa3ea858641734c9c82dd13bc39b2732909295346a7b90ee1e4891aa"
 }

--- a/skills-codex/validate/SKILL.md
+++ b/skills-codex/validate/SKILL.md
@@ -109,6 +109,11 @@ python3 "$SKILL_DIR/scripts/validate.py" manifest \
 4. Inspect the exact subject and factual evidence. Reported exit codes are
    claims, not evidence: re-execute the claimed proofs that bear on acceptance
    (see the freshness rules below for when a digest-bound receipt suffices).
+   If the subject changes a test, gate, fixture, golden, tolerance, suppression,
+   or acceptance source, determine whether the original intent requires that
+   change and whether green came from implemented behavior rather than a
+   weakened oracle. Green obtained by weakening acceptance is `FAIL`, not
+   evidence of completion.
    Judge every acceptance criterion and record criterion-level results,
    findings, evidence references, `checked`, and any acceptance surface that
    went unverified in `not_checked` (see Scope disclosure).

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -71,9 +71,14 @@ intent revisions (lineage under `.agents/ao/intents/sha256/26a4f2be...eb48`)
 because hand-enumerated scope kept missing live consumers.
 
 Before declaring GREEN, self-audit the diff for mocks, placeholders, TODO
-stubs, and hardcoded fixture values standing in for real behavior. A check
-that passes against a placeholder is not evidence for the acceptance
-criterion; either finish the behavior or report it as not built.
+stubs, hardcoded fixture values, weakened assertions, regenerated goldens,
+widened tolerances, suppression directives, or specification edits standing
+in for real behavior. When the diff changes a test, gate, fixture, golden, or
+acceptance source, state why the original intent requires that change and
+confirm that green came from the implemented behavior rather than a weakened
+oracle. A check that passes against a substitute or weakened oracle is not
+evidence for the acceptance criterion; either finish the behavior or report it
+as not built.
 
 ## Boundary
 

--- a/skills/operationalize/SKILL.md
+++ b/skills/operationalize/SKILL.md
@@ -31,12 +31,21 @@ Turn repeated, cited expertise into a proposal for a reusable artifact.
    proposal abstracts a rule.
 2. State the triggering situation, desired behavior, inputs, outputs, negative
    examples, and evidence.
-3. Choose the smallest fitting shape: reference, skill, deterministic check, or
+3. Apply the process-artifact creation gate before choosing a shape. A proposed
+   certificate, ledger, dashboard, matrix, meta-report, readiness review,
+   speculative check, skill, or workflow must name its concrete consumer, the
+   subject or release decision it gates, the observed defect class justifying
+   it, and its deletion condition. Code or process introduced solely to consume
+   the artifact does not qualify. If any answer is missing, propose no artifact
+   and redirect to the caller-requested subject. Minimal integrity or recovery
+   state is allowed only when necessary to prevent a named evidence-loss or
+   corruption mode.
+4. Choose the smallest fitting shape: reference, skill, deterministic check, or
    caller-owned workflow.
-4. Search existing capabilities and prefer extension over duplication.
-5. Provide an activation example, holdout/negative example, owner, and rollback
+5. Search existing capabilities and prefer extension over duplication.
+6. Provide an activation example, holdout/negative example, owner, and rollback
    or deletion condition.
-6. Return the proposal inline to the caller or an authoring specialist. When
+7. Return the proposal inline to the caller or an authoring specialist. When
    the caller asks for a durable artifact, write it under
    `.agents/scratch/operationalize/` first and return the path; the proposal
    is advisory either way.
@@ -60,7 +69,9 @@ as written, reproduces the correct decision on at least one of its source
 occurrences without extra context. If applying the drafted rule to its own
 source moment requires unwritten judgment, the rule is not yet operational —
 tighten the wording until the reapply succeeds, or downgrade the proposal to
-a reference. No reapply proof, no rule.
+a reference. When the proposal creates process, the reapply proof must also
+show that the creation gate returns the correct create-or-drop decision. No
+reapply proof, no rule.
 
 ## Quote-bank anchors
 
@@ -78,4 +89,4 @@ validate its own output, or control another invocation. The proposal is
 advisory: adopting it into a skill, deterministic check, reference, or
 workflow is a separate, caller-selected step — `skill-builder`,
 `workflow-builder`, or a fresh RPI — never performed here. The proposal
-cannot promote itself.
+cannot promote itself, and process-only output earns no capability credit.

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -101,25 +101,15 @@ the full integration check and fresh validation for the frozen subject. This
 changes orchestration cost, never acceptance, exact identity, fail-closed
 scope, or validation authority.
 
-## Continuation envelope
+## Spiral breaker
 
-Before dispatching any lane, the orchestration declares its envelope: a budget
-(maximum lanes per wave, maximum repair revisions per wave) and a checkpoint
-rule — the second non-PASS outcome on one intent stops that lane and returns
-to the caller instead of dispatching another attempt. The envelope includes a
-spiral breaker: two consecutive control artifacts (plans, audits, reviews,
-prompts, reports) produced with no new implementation evidence terminate the
-run — report `NOT_BUILT` when no implementation subject exists yet;
-when a subject already exists, stop and report its current status without
-dispatching further lanes. Neither breaker dispatches a repair revision. An
-orchestration without a declared envelope does not converge; it accretes
-lanes. For example, a plan that keeps failing acceptance on the same criterion
-might tempt three intent revisions in a row
-(`.agents/ao/intents/sha256/<rev1>...` superseded by `<rev2>...` superseded by
-`<rev3>...`) chasing a `NOT_PROVEN` then a second `NOT_PROVEN`
-(`.agents/ao/verdicts/sha256/<verdict1>...`, `<verdict2>...`) — the declared
-envelope's two-stop checkpoint ends the wave there instead of dispatching a
-third attempt.
+The spiral breaker fires when two consecutive control artifacts (plans, audits,
+reviews, prompts, reports) contain no new implementation evidence. Terminate the
+run and report `NOT_BUILT` when no implementation subject exists; when a subject
+exists, stop and report its current status without dispatching another lane or
+repair revision. RPI owns no lane budget, repair budget, or retry policy.
+
+## Delegation boundaries
 
 Delegate with minimal context: a lane receives the frozen intent reference and
 the established facts it needs, never the orchestrator's full conversation

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -137,6 +137,11 @@ python3 "$SKILL_DIR/scripts/validate.py" manifest \
 4. Inspect the exact subject and factual evidence. Reported exit codes are
    claims, not evidence: re-execute the claimed proofs that bear on acceptance
    (see the freshness rules below for when a digest-bound receipt suffices).
+   If the subject changes a test, gate, fixture, golden, tolerance, suppression,
+   or acceptance source, determine whether the original intent requires that
+   change and whether green came from implemented behavior rather than a
+   weakened oracle. Green obtained by weakening acceptance is `FAIL`, not
+   evidence of completion.
    Judge every acceptance criterion and record criterion-level results,
    findings, evidence references, `checked`, and any acceptance surface that
    went unverified in `not_checked` (see Scope disclosure).


### PR DESCRIPTION
## Summary

- add repository-level anti-ceremony and honest-work policy
- enforce creation gates, oracle integrity, and the RPI spiral breaker in source skills and generated projections
- add a dual-case behavior probe for justified versus unjustified process artifacts
- harden doctor Git-root detection against invalid `.git` debris

## Why

The existing workflow could reward control artifacts and weakened checks instead of working capability. These guardrails make capability the unit of progress and reject ceremony without a real consumer, decision, observed defect, and deletion condition.

## Impact

AgentOps now fails closed when process artifacts are manufactured, when GREEN comes from weakening the oracle, or when repeated control artifacts replace implementation evidence. Doctor artifacts no longer get redirected by an empty or invalid ancestor `.git` directory.

## Validation

- `bash scripts/ci-local-release.sh --quick`
- `make regen-check`
- fresh AgentOps validation: `PASS` with `not_checked: []`

The quick release suite skips race, security-scan, SBOM, multi-platform, and release-evidence lanes.