### PR TITLE
Align skill contracts with operating contract and regenerate projections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,15 +81,19 @@ Edit source owners and regenerate projections through the owning command.
 
 Active constraints (ADRs in `docs/adr/`, blocking gates in
 `cli/internal/gates/` and `scripts/check-*.sh`, this contract) are inputs to
-any authoritative plan or design; a synthesis frozen without them is invalid.
-Skill logic ships in Go via `ao`; no new `skills/*/scripts/**/*.py`.
-Skill tests retain their documented exemption (ADR-0016, gate-enforced).
+any authoritative plan or design.
+A synthesis frozen without an active constraint is invalid.
+Skill logic ships in Go via `ao`;
+`scripts/check-skill-python-ratchet.sh` enforces no new
+`skills/*/scripts/**/*.py`. Skill tests retain their documented exemption
+(ADR-0016, gate-enforced).
 
 ## Standard RPI traversal
 
 1. **Plan once.** Shape one active behavior in the existing bead or caller
-   intent — acceptance, non-goals, scope, first check. Once accepted, further
-   planning over the same intent needs new explicit authorization.
+   intent — acceptance, non-goals, scope, first check. Once the caller accepts
+   the acceptance and scope, Plan is closed for that intent; further planning
+   over the same intent needs new explicit authorization.
 2. **Implement once.** One bounded RED -> GREEN -> refactor experiment; the
    runtime derives the manifest, changed paths, and check receipts.
 3. **Validate once, fresh.** A distinct context verifies subject identity,
@@ -98,11 +102,11 @@ Skill tests retain their documented exemption (ADR-0016, gate-enforced).
    digest mismatch, and incomplete changed-path coverage are `NOT_PROVEN`;
    proven out-of-scope change is `FAIL`. PASS requires nonempty checked scope,
    top-level evidence, evidence for every criterion, and an empty
-   `not_checked`. Persist `verdict.v2` only for a caller request or declared
-   consumer.
+   `not_checked`. Persist `verdict.v2` only when requested by a caller or
+   required by a declared consumer.
 4. **Report and stop.** Report the result; emit no next action; no automatic
-   revision. Two consecutive control artifacts with no new implementation
-   evidence end the run. Reports lead with the subject, never artifact counts.
+   revision. Two consecutive control artifacts with no new implementation evidence end the run.
+   Reports lead with the subject, never artifact counts.
 
 A caller may revise the intent and start a new invocation. Learn is an
 optional later consumer and cannot change core outcomes.

--- a/docs/agent-workflow-reference.md
+++ b/docs/agent-workflow-reference.md
@@ -16,10 +16,12 @@ Resolve one active behavior in the caller-owned tracker, issue, or conversation.
 Keep acceptance, important non-goals, required evidence, write scope, and the
 first useful check in that source. Do not create a second planning artifact.
 
-The runtime snapshots the exact resolved source bytes under
-`.agents/ao/intents/sha256/<digest>.intent`. This is derived identity, not a
-model-authored packet, and makes conversation-only intent readable by a fresh
-validator. The pure helper accepts a file or stdin:
+The runtime leaves a durable caller-owned source in place and carries its
+reference plus the digest of its exact resolved bytes. Only when no durable
+source exists does it snapshot those bytes under
+`.agents/ao/intents/sha256/<digest>.intent`. This fallback is derived identity,
+not a model-authored packet, and makes conversation-only intent readable by a
+fresh validator. The pure fallback helper accepts a file or stdin:
 
 ```bash
 python3 skills/validate/scripts/validate.py snapshot-intent --source PATH  # use - for stdin

--- a/docs/architecture/rpi-traversal.md
+++ b/docs/architecture/rpi-traversal.md
@@ -46,10 +46,12 @@ That source records:
 - a first acceptance command or artifact path;
 - optional decomposition with no scheduling semantics.
 
-The runtime stores the exact resolved source bytes under
-`.agents/ao/intents/sha256/<digest>.intent` and derives the acceptance digest
-from those bytes. This also makes conversation-only intent available to a fresh
-validator. The model does not author a second PlanPacket.
+The runtime leaves a durable caller-owned source in place and carries its
+reference plus the acceptance digest derived from its exact resolved bytes.
+Only when no durable source exists does it store those bytes under
+`.agents/ao/intents/sha256/<digest>.intent`. This fallback makes
+conversation-only intent available to a fresh validator. The model does not
+author a second PlanPacket.
 
 Owner, ready, claim, priority, attempt, wave, queue, lease, admission, next
 action, close, release, and delivery fields are outside the contract.

--- a/images/gemini/skills/automation-shape-routing/SKILL.md
+++ b/images/gemini/skills/automation-shape-routing/SKILL.md
@@ -105,8 +105,8 @@ Return exactly one of:
 - `using-gc` with explicit operator choice
 - `operationalize:gate`
 
-Name the deciding axis and invoke the owner. Do not copy the delegated workflow
-into this router.
+Name the deciding axis and owner, then stop. The caller may invoke that owner
+separately; do not copy or start the delegated workflow from this router.
 
 ## Output Specification
 
@@ -134,8 +134,9 @@ into this router.
     END { exit !(NR == 1 && !extra && valid) }
   '
   ```
-- **Downstream handoff:** invoke the named owner only after returning the verdict;
-  `inline` remains in the current agent and `bounded-fanout` remains in-session.
+- **Downstream handoff:** return the named owner to the caller without invoking
+  it; `inline` and `bounded-fanout` describe the recommended execution shape but
+  do not authorize this routing skill to begin execution.
 
 ## Quality Rubric
 

--- a/images/gemini/skills/bootstrap/SKILL.md
+++ b/images/gemini/skills/bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bootstrap
-description: 'Initialize minimal AgentOps documentation and verdict storage without taking over repository workflow. Triggers: "bootstrap AgentOps", "initialize AgentOps docs".'
+description: 'Initialize explicitly requested, missing AgentOps documentation and optional verdict storage without taking over repository workflow. Triggers: "bootstrap AgentOps", "initialize AgentOps docs".'
 practices:
 - hermetic-builds
 - code-complete
@@ -26,13 +26,14 @@ metadata:
   graph_root: true
   tier: session
   dependencies: []
-output_contract: minimal project docs and .agents/ao/verdicts directory
+output_contract: explicitly requested missing project docs and optional .agents/ao/verdicts directory
 ---
 # Bootstrap — minimal project setup
 
-Bootstrap fills only missing AgentOps entry documents and the default durable
-verdict directory. It does not initialize Git, install hooks, create tracker
-state, start runtimes, or impose a delivery workflow.
+Bootstrap fills only explicitly requested, missing AgentOps entry documents and,
+when requested, the durable verdict directory. It does not initialize Git,
+install hooks, create tracker state, start runtimes, or impose a delivery
+workflow.
 
 Never-overwrite is what makes bootstrap safe to run on any repository: a setup
 step that can only add is idempotent by construction, while one that can

--- a/images/gemini/skills/implement/SKILL.md
+++ b/images/gemini/skills/implement/SKILL.md
@@ -65,10 +65,8 @@ proof.
 On discovering a live consumer of the change outside the declared write scope
 — a test asserting the old path, a generated twin, a gate reading the moved
 file — stop and report the exact file and line to the caller. Do not silently
-expand scope to absorb it. One repair revision of the intent is the maximum
-before escalating to the caller; the 2026-07-15 heal-skill fold took three
-intent revisions (lineage under `.agents/ao/intents/sha256/26a4f2be...eb48`)
-because hand-enumerated scope kept missing live consumers.
+expand scope to absorb it or revise the intent from Implement. The caller may
+revise the source intent and start a separate invocation.
 
 Before declaring GREEN, self-audit the diff for mocks, placeholders, TODO
 stubs, hardcoded fixture values, weakened assertions, regenerated goldens,

--- a/images/gemini/skills/plan/SKILL.md
+++ b/images/gemini/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: 'Shape or refine the existing bead or caller intent without a second planning artifact. Triggers: "plan", "discover and plan", "shape this goal", "plan manifest".'
+description: 'Shape or refine the existing bead or caller intent without a second planning artifact. Triggers: "plan", "discover and plan", "shape this goal".'
 practices:
 - bdd-gherkin
 - design-by-contract
@@ -58,25 +58,6 @@ is derived automatically and is not another model-authored planning artifact.
 Bound the work around the caller-visible outcome, not individual files, gates,
 or reviewer comments. Decomposition is useful only when it reduces reasoning
 cost; it must not multiply invocations or proof artifacts.
-
-## Manifest mode (many behaviors, zero beads)
-
-When the caller's goal genuinely decomposes into several bounded behaviors —
-an audit remediation, an epic, a contraction — shape one caller-owned
-specification manifest instead of one behavior:
-
-- One document in the caller's location (commonly `docs/plans/<date>-<slug>.md`)
-  holding a manifest table (stable slug, type, priority, parent, dependency
-  edges) plus one section per child with acceptance, non-goals, write scope,
-  and evidence commands. Each child must satisfy the same bar as a
-  single-behavior plan.
-- Tracker IDs stay `TBD`: manifest mode authors zero beads. The executing
-  substrate materializes tracker state — the caller's session in the default
-  loop, or the selected factory's coordinator (for Gas City the Mayor, per
-  [using-gc](../using-gc/SKILL.md); for the Flywheel, its native workflow per
-  [using-flywheel](../using-flywheel/SKILL.md)).
-- Reference example:
-  [2026-07-30-ponytail-whole-repo-contraction.md](../../docs/plans/2026-07-30-ponytail-whole-repo-contraction.md).
 
 ## Scope admission
 

--- a/images/gemini/skills/plan/SKILL.md
+++ b/images/gemini/skills/plan/SKILL.md
@@ -24,10 +24,11 @@ metadata:
 # Plan
 
 Turn the caller's intent into one bounded, testable behavior in the place that
-already owns the work. Prefer the caller's tracker, if any. When no tracker is
-available, use the caller's conversation or supplied issue text; the runtime
-snapshots the resolved intent bytes automatically so later contexts can read
-and hash the same source. Do not make the model restate those facts in a packet.
+already owns the work. Prefer the caller's tracker, if any. When no durable
+tracker or issue reference is available, use the caller's conversation or
+supplied text; the runtime snapshots those resolved intent bytes so later
+contexts can read and hash the same source. Do not make the model restate those
+facts in a packet.
 
 ## Workflow
 
@@ -51,9 +52,12 @@ and hash the same source. Do not make the model restate those facts in a packet.
 5. If authorized and the source is writable, update that bead or issue in
    place. Otherwise return a concise proposed amendment to the caller.
 
-Planning produces no AgentOps packet. The runtime stores and hashes the resolved
-source bytes to detect later acceptance drift. That content-addressed snapshot
-is derived automatically and is not another model-authored planning artifact.
+Planning produces no AgentOps packet. A durable caller-owned source stays in
+place; the runtime carries its reference and the digest of its exact resolved
+bytes to detect later acceptance drift. Only when no durable source exists does
+the runtime store those bytes under their digest as a content-addressed
+snapshot. That fallback is derived automatically and is not another
+model-authored planning artifact.
 
 Bound the work around the caller-visible outcome, not individual files, gates,
 or reviewer comments. Decomposition is useful only when it reduces reasoning

--- a/images/gemini/skills/rpi/SKILL.md
+++ b/images/gemini/skills/rpi/SKILL.md
@@ -68,10 +68,11 @@ authorization by itself.
 
 1. Resolve the existing bead or caller intent. Invoke Plan once only if that
    source needs shaping; Plan updates the same source or proposes an amendment.
-   It creates no AgentOps packet. The runtime snapshots the exact resolved
-   source bytes under their digest, including when the conversation is the only
-   source, before dispatching Implement or a fresh Validate context. If usable
-   intent cannot be established, report `NOT_PLANNED` and stop.
+   It creates no AgentOps packet. Preserve a durable caller-owned source by
+   reference and digest; only when no durable source exists does the runtime
+   snapshot the exact resolved source bytes under their digest before
+   dispatching Implement or a fresh Validate context. If usable intent cannot
+   be established, report `NOT_PLANNED` and stop.
 2. Invoke Implement once with the resolved intent. It performs one bounded
    experiment; the runtime derives subject identity and check receipts. If no
    subject is built, report `NOT_BUILT` and stop.
@@ -113,9 +114,9 @@ repair revision. RPI owns no lane budget, repair budget, or retry policy.
 
 Delegate with minimal context: a lane receives the frozen intent reference and
 the established facts it needs, never the orchestrator's full conversation
-history. If a lane cannot proceed from the intent alone, the plan failed the
-fresh-context test and should be repaired at the source, not padded with chat
-transcript.
+history. If a lane cannot proceed from the intent alone, report that the plan
+failed the fresh-context test and stop; do not pad it with chat transcript or
+start another planning lane without explicit caller authorization.
 
 Lanes whose write scopes share a regen surface (the same generated outputs,
 mirrors, or manifests) serialize; only lanes with disjoint source scopes and

--- a/images/gemini/skills/rpi/SKILL.md
+++ b/images/gemini/skills/rpi/SKILL.md
@@ -154,7 +154,7 @@ RPI has one required report surface and one optional representation:
    {
      "schema_version": "rpi-report.v1",
      "status": "PASS",
-     "intent_ref": ".agents/ao/intents/sha256/<64-hex-digest>.intent",
+     "intent_ref": "<durable-source-ref-or-fallback-snapshot-ref>",
      "acceptance_digest": "<64-hex-char-sha256-or-null>",
      "subject_manifest_digest": "<64-hex-char-sha256-or-null>",
      "verdict_ref": "<verdict-location-or-null>",
@@ -164,10 +164,12 @@ RPI has one required report surface and one optional representation:
    }
    ```
 
-   `status` is one of `PASS | FAIL | NOT_PROVEN | NOT_PLANNED | NOT_BUILT`; the
-   three digest fields, when present, are 64-character lowercase hex SHA-256
-   strings; `checked` and `not_checked` are arrays of strings. All nine keys
-   are required (use `null` for an inapplicable ref or digest), and no
+   `intent_ref` remains required: it names the durable caller-owned source when
+   one exists, otherwise the content-addressed fallback snapshot. `status` is
+   one of `PASS | FAIL | NOT_PROVEN | NOT_PLANNED | NOT_BUILT`; the three digest
+   fields, when present, are 64-character lowercase hex SHA-256 strings;
+   `checked` and `not_checked` are arrays of strings. All nine keys are required
+   (use `null` for an inapplicable ref or digest), and no
    additional properties are allowed.
 
 Lead the interactive response with the status and one sentence stating the

--- a/images/gemini/skills/swarm/SKILL.md
+++ b/images/gemini/skills/swarm/SKILL.md
@@ -41,7 +41,8 @@ silently ignored, because the proof cannot honor it.
 
 Exactly-once dispatch over proven-disjoint scopes is why parallel failures stay
 independent: no packet can observe, block, or corrupt another, so N packets
-yield N verdicts about N experiments rather than one tangle.
+yield N factual results about N experiments rather than one tangle. Those
+results are not semantic verdicts.
 
 Named failure mode — **partial-batch launch**: dispatching valid packets before
 discovering an invalid one, leaving the batch half-run; validate the entire

--- a/images/gemini/skills/using-gc/SKILL.md
+++ b/images/gemini/skills/using-gc/SKILL.md
@@ -179,13 +179,6 @@ Or, in an interactive Mayor session:
 Use skill gc.mayor
 ```
 
-A multi-behavior intent arrives as a plan manifest (see plan's manifest mode):
-one caller-owned document with stable slugs, dependency edges, and per-child
-acceptance and write scopes, tracker IDs left `TBD`. Mail the Mayor the
-document path once it is on the rig's mainline; the Mayor materializes the
-epic and children from the manifest and owns their dispatch order. Reference
-example: `docs/plans/2026-07-30-ponytail-whole-repo-contraction.md`.
-
 Direct `gc sling` remains a debugging tool for a city with no live Mayor; a
 run started that way has no coordinator and the operator inherits its tending.
 

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -370,13 +370,13 @@
       "name": "automation-shape-routing",
       "source_skill": "skills/automation-shape-routing",
       "source_hash": "0c070794c5a9a91024d14a6bc5a18e6305b488401dfcb79bb83c41e789ba7bc3",
-      "generated_hash": "3557b4efca4fd0e7587d873a435085a0ceda8a425b72cd5bf1d1a0310077739f"
+      "generated_hash": "913bd809a83b2710547512f2a887459372fb18f6d2d96d420acadecdebff5b7f"
     },
     {
       "name": "bootstrap",
       "source_skill": "skills/bootstrap",
       "source_hash": "41ccae0b12098a33057fa9d7082763787ecb7f317e814dc1e34708740c8d7b05",
-      "generated_hash": "581c79d73b2f552230f58270e4c27284d56b1aea7836e929a451afa6a87aedb4"
+      "generated_hash": "dd8f84f19a0522c6d9cdf030de9c371d18a994c8b7cb64d953c2292fcc363e96"
     },
     {
       "name": "cass",
@@ -466,7 +466,7 @@
       "name": "implement",
       "source_skill": "skills/implement",
       "source_hash": "5aa7e7b5b988a8f192d64ef7347ea7ca715f4979f325ed0507556ac0ff5ee82d",
-      "generated_hash": "e9f04c9e201be44a7e6d787145725bfff02595684a2e36baab8029f5b778c9cc"
+      "generated_hash": "8b7f0c9f95ce32043dc9bf287313987027f557f2dbfcec6fbc67e852442d239e"
     },
     {
       "name": "learn",
@@ -502,7 +502,7 @@
       "name": "plan",
       "source_skill": "skills/plan",
       "source_hash": "750583fc4ef821c11144ec15fb85988d47b84b691a072911fe7366adb9c26584",
-      "generated_hash": "bba18e1c382b2937bf185185a4f0fc1c6b68469da836cacfe87647f3cfae3de5"
+      "generated_hash": "6293bb0b1aae0f25cd03c4577a208dbbf390d5128ef6d3caf6dc3cb49ef37b28"
     },
     {
       "name": "postmortem",
@@ -556,7 +556,7 @@
       "name": "rpi",
       "source_skill": "skills/rpi",
       "source_hash": "15dab600e62da4d414e9deac42a9131380da3d6241a6cc879d56efe78e0ef22c",
-      "generated_hash": "f93f020b5251a1972f932d353cb4acd855fb7149916aa65915bfd22eb72897a5"
+      "generated_hash": "bf17b412c5ac6d29f4a25f7a9d747037f2284809afd8da881482a8903f214945"
     },
     {
       "name": "sbh",
@@ -610,7 +610,7 @@
       "name": "swarm",
       "source_skill": "skills/swarm",
       "source_hash": "258d63e5499e210003605b6947841913131094a0015d21ab27c8281973364be2",
-      "generated_hash": "edca9587669802663b04b091be159fcc10b763072715333a71f44f797e6a65b2"
+      "generated_hash": "cf023c0baac3989aaf2ea69fd19dfdc4fdd0b4f2392dcb6209d5e51f2b1e8afc"
     },
     {
       "name": "test",
@@ -634,7 +634,7 @@
       "name": "using-gc",
       "source_skill": "skills/using-gc",
       "source_hash": "bf15cd25cc11a2778b434ecefe9fa4c1d46f08d6162a367a2ec348e231e9fd8f",
-      "generated_hash": "dbb1fd1ac8e278a6603478d4dfd0b7b1e7b7271089be6ddcbea70e3da93f8fbb"
+      "generated_hash": "e4e3061d249cba8be354ad8d15427b2d7f3faf7885307d6dd8c8a0ae8e35d149"
     },
     {
       "name": "validate",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -501,8 +501,8 @@
     {
       "name": "plan",
       "source_skill": "skills/plan",
-      "source_hash": "750583fc4ef821c11144ec15fb85988d47b84b691a072911fe7366adb9c26584",
-      "generated_hash": "6293bb0b1aae0f25cd03c4577a208dbbf390d5128ef6d3caf6dc3cb49ef37b28"
+      "source_hash": "16026fda4df366feaa3c99980f6a49d78d331e8563f8b0a7a4c0f45d0a60338b",
+      "generated_hash": "4144d7daa581c0352c5cb4231363bd19e99dd4a53dfe1a8daa9baee1a72d8d41"
     },
     {
       "name": "postmortem",
@@ -555,8 +555,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "15dab600e62da4d414e9deac42a9131380da3d6241a6cc879d56efe78e0ef22c",
-      "generated_hash": "bf17b412c5ac6d29f4a25f7a9d747037f2284809afd8da881482a8903f214945"
+      "source_hash": "88d6447a288d335faa25a7d8628e9ebd877d5c761c2af6bb765c96afab984730",
+      "generated_hash": "f8686fc7915991a903f7bfbe1d24e7d2c3c0e6c5f30a8bed4bd4d2c4ac31c0f9"
     },
     {
       "name": "sbh",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -369,14 +369,14 @@
     {
       "name": "automation-shape-routing",
       "source_skill": "skills/automation-shape-routing",
-      "source_hash": "6a1d4df0589901acdd6a66541c1027697e31c0273f931f863b8c7c82e520f933",
-      "generated_hash": "022a51640c617822e180d87f2e1da75b151df74473301a820969fc2181d548e0"
+      "source_hash": "0c070794c5a9a91024d14a6bc5a18e6305b488401dfcb79bb83c41e789ba7bc3",
+      "generated_hash": "3557b4efca4fd0e7587d873a435085a0ceda8a425b72cd5bf1d1a0310077739f"
     },
     {
       "name": "bootstrap",
       "source_skill": "skills/bootstrap",
-      "source_hash": "1d0ea0b4fece12f39ce899f8ae25baf15f33978d3bcf890fa928976813e622fc",
-      "generated_hash": "212064b80e8107f3177c9ddd6cc381d96b1d35887330a96ee7b887ac70d4be6d"
+      "source_hash": "41ccae0b12098a33057fa9d7082763787ecb7f317e814dc1e34708740c8d7b05",
+      "generated_hash": "581c79d73b2f552230f58270e4c27284d56b1aea7836e929a451afa6a87aedb4"
     },
     {
       "name": "cass",
@@ -465,8 +465,8 @@
     {
       "name": "implement",
       "source_skill": "skills/implement",
-      "source_hash": "7cdcc4d0fde86bc5ece8b0ec5fe6968dd916100e09b2bbc6bd08ff8afe995298",
-      "generated_hash": "0e86f1f4e5fd10a771727264e5842261361ec20ee99e00b62ea91695023b9a02"
+      "source_hash": "5aa7e7b5b988a8f192d64ef7347ea7ca715f4979f325ed0507556ac0ff5ee82d",
+      "generated_hash": "e9f04c9e201be44a7e6d787145725bfff02595684a2e36baab8029f5b778c9cc"
     },
     {
       "name": "learn",
@@ -501,8 +501,8 @@
     {
       "name": "plan",
       "source_skill": "skills/plan",
-      "source_hash": "7d6e5e80eb29e59b680912229c2d9e72efbb51f06a9824995959bfb441da6eae",
-      "generated_hash": "f5bca26d0cdeef7d12fd138d23813c470f1e1f7743b6e1103b3464b5f55b76d0"
+      "source_hash": "750583fc4ef821c11144ec15fb85988d47b84b691a072911fe7366adb9c26584",
+      "generated_hash": "bba18e1c382b2937bf185185a4f0fc1c6b68469da836cacfe87647f3cfae3de5"
     },
     {
       "name": "postmortem",
@@ -555,8 +555,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "ccc1c4a5034bc549cd63f424ea3497fb6d0ea3a3d52327e31dd54aee7dbfbe01",
-      "generated_hash": "85a987391c2eb901990d54a2164c5e89d899eaa6ae689eea7cbb01423ff304bb"
+      "source_hash": "15dab600e62da4d414e9deac42a9131380da3d6241a6cc879d56efe78e0ef22c",
+      "generated_hash": "f93f020b5251a1972f932d353cb4acd855fb7149916aa65915bfd22eb72897a5"
     },
     {
       "name": "sbh",
@@ -609,8 +609,8 @@
     {
       "name": "swarm",
       "source_skill": "skills/swarm",
-      "source_hash": "0ab257679d52e3ec38985d7d81a5b05749363d4f3170a169ac7b74b911fa3f7f",
-      "generated_hash": "31dadb68c36be6a43c61374aa37f32f29f67adc7a85170076c6f1e797a9362c1"
+      "source_hash": "258d63e5499e210003605b6947841913131094a0015d21ab27c8281973364be2",
+      "generated_hash": "edca9587669802663b04b091be159fcc10b763072715333a71f44f797e6a65b2"
     },
     {
       "name": "test",
@@ -633,8 +633,8 @@
     {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
-      "source_hash": "ae9a7e669ad218f471bf3435dbc9614924ea27edd742d3cb9c528a5fd4f137a1",
-      "generated_hash": "822fc4619b9e7a0e9acce03176189cf99fec36437cf6ae1f423a5381b9d2172c"
+      "source_hash": "bf15cd25cc11a2778b434ecefe9fa4c1d46f08d6162a367a2ec348e231e9fd8f",
+      "generated_hash": "dbb1fd1ac8e278a6603478d4dfd0b7b1e7b7271089be6ddcbea70e3da93f8fbb"
     },
     {
       "name": "validate",

--- a/skills-codex/automation-shape-routing/.agentops-generated.json
+++ b/skills-codex/automation-shape-routing/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/automation-shape-routing",
   "layout": "modular",
   "source_hash": "0c070794c5a9a91024d14a6bc5a18e6305b488401dfcb79bb83c41e789ba7bc3",
-  "generated_hash": "3557b4efca4fd0e7587d873a435085a0ceda8a425b72cd5bf1d1a0310077739f"
+  "generated_hash": "913bd809a83b2710547512f2a887459372fb18f6d2d96d420acadecdebff5b7f"
 }

--- a/skills-codex/automation-shape-routing/.agentops-generated.json
+++ b/skills-codex/automation-shape-routing/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/automation-shape-routing",
   "layout": "modular",
-  "source_hash": "6a1d4df0589901acdd6a66541c1027697e31c0273f931f863b8c7c82e520f933",
-  "generated_hash": "022a51640c617822e180d87f2e1da75b151df74473301a820969fc2181d548e0"
+  "source_hash": "0c070794c5a9a91024d14a6bc5a18e6305b488401dfcb79bb83c41e789ba7bc3",
+  "generated_hash": "3557b4efca4fd0e7587d873a435085a0ceda8a425b72cd5bf1d1a0310077739f"
 }

--- a/skills-codex/automation-shape-routing/SKILL.md
+++ b/skills-codex/automation-shape-routing/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "automation-shape-routing"
-description: "Front door for agent automation: choose"
+name: automation-shape-routing
+description: 'Front door for agent automation: choose'
 ---
 # Automation Shape Routing
 

--- a/skills-codex/automation-shape-routing/SKILL.md
+++ b/skills-codex/automation-shape-routing/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: automation-shape-routing
-description: 'Front door for agent automation: choose'
+name: "automation-shape-routing"
+description: "Front door for agent automation: choose"
 ---
 # Automation Shape Routing
 
@@ -70,8 +70,8 @@ Return exactly one of:
 - `using-gc` with explicit operator choice
 - `operationalize:gate`
 
-Name the deciding axis and invoke the owner. Do not copy the delegated workflow
-into this router.
+Name the deciding axis and owner, then stop. The caller may invoke that owner
+separately; do not copy or start the delegated workflow from this router.
 
 ## Output Specification
 
@@ -99,8 +99,9 @@ into this router.
     END { exit !(NR == 1 && !extra && valid) }
   '
   ```
-- **Downstream handoff:** invoke the named owner only after returning the verdict;
-  `inline` remains in the current agent and `bounded-fanout` remains in-session.
+- **Downstream handoff:** return the named owner to the caller without invoking
+  it; `inline` and `bounded-fanout` describe the recommended execution shape but
+  do not authorize this routing skill to begin execution.
 
 ## Quality Rubric
 

--- a/skills-codex/bootstrap/.agentops-generated.json
+++ b/skills-codex/bootstrap/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/bootstrap",
   "layout": "modular",
-  "source_hash": "1d0ea0b4fece12f39ce899f8ae25baf15f33978d3bcf890fa928976813e622fc",
-  "generated_hash": "212064b80e8107f3177c9ddd6cc381d96b1d35887330a96ee7b887ac70d4be6d"
+  "source_hash": "41ccae0b12098a33057fa9d7082763787ecb7f317e814dc1e34708740c8d7b05",
+  "generated_hash": "581c79d73b2f552230f58270e4c27284d56b1aea7836e929a451afa6a87aedb4"
 }

--- a/skills-codex/bootstrap/.agentops-generated.json
+++ b/skills-codex/bootstrap/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/bootstrap",
   "layout": "modular",
   "source_hash": "41ccae0b12098a33057fa9d7082763787ecb7f317e814dc1e34708740c8d7b05",
-  "generated_hash": "581c79d73b2f552230f58270e4c27284d56b1aea7836e929a451afa6a87aedb4"
+  "generated_hash": "dd8f84f19a0522c6d9cdf030de9c371d18a994c8b7cb64d953c2292fcc363e96"
 }

--- a/skills-codex/bootstrap/SKILL.md
+++ b/skills-codex/bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "bootstrap"
-description: "Initialize explicitly requested, missing"
+name: bootstrap
+description: Initialize explicitly requested, missing
 ---
 # Bootstrap — minimal project setup
 

--- a/skills-codex/bootstrap/SKILL.md
+++ b/skills-codex/bootstrap/SKILL.md
@@ -1,12 +1,13 @@
 ---
-name: bootstrap
-description: Initialize minimal AgentOps documentation
+name: "bootstrap"
+description: "Initialize explicitly requested, missing"
 ---
 # Bootstrap — minimal project setup
 
-Bootstrap fills only missing AgentOps entry documents and the default durable
-verdict directory. It does not initialize Git, install hooks, create tracker
-state, start runtimes, or impose a delivery workflow.
+Bootstrap fills only explicitly requested, missing AgentOps entry documents and,
+when requested, the durable verdict directory. It does not initialize Git,
+install hooks, create tracker state, start runtimes, or impose a delivery
+workflow.
 
 Never-overwrite is what makes bootstrap safe to run on any repository: a setup
 step that can only add is idempotent by construction, while one that can

--- a/skills-codex/bootstrap/prompt.md
+++ b/skills-codex/bootstrap/prompt.md
@@ -1,6 +1,6 @@
 # bootstrap
 
-Initialize minimal AgentOps documentation and verdict storage without taking over repository workflow. Triggers: "bootstrap AgentOps", "initialize AgentOps docs".
+Initialize explicitly requested, missing AgentOps documentation and optional verdict storage without taking over repository workflow. Triggers: "bootstrap AgentOps", "initialize AgentOps docs".
 
 ## Instructions
 

--- a/skills-codex/implement/.agentops-generated.json
+++ b/skills-codex/implement/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/implement",
   "layout": "modular",
   "source_hash": "5aa7e7b5b988a8f192d64ef7347ea7ca715f4979f325ed0507556ac0ff5ee82d",
-  "generated_hash": "e9f04c9e201be44a7e6d787145725bfff02595684a2e36baab8029f5b778c9cc"
+  "generated_hash": "8b7f0c9f95ce32043dc9bf287313987027f557f2dbfcec6fbc67e852442d239e"
 }

--- a/skills-codex/implement/.agentops-generated.json
+++ b/skills-codex/implement/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/implement",
   "layout": "modular",
-  "source_hash": "7cdcc4d0fde86bc5ece8b0ec5fe6968dd916100e09b2bbc6bd08ff8afe995298",
-  "generated_hash": "0e86f1f4e5fd10a771727264e5842261361ec20ee99e00b62ea91695023b9a02"
+  "source_hash": "5aa7e7b5b988a8f192d64ef7347ea7ca715f4979f325ed0507556ac0ff5ee82d",
+  "generated_hash": "e9f04c9e201be44a7e6d787145725bfff02595684a2e36baab8029f5b778c9cc"
 }

--- a/skills-codex/implement/SKILL.md
+++ b/skills-codex/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: implement
-description: Execute one bounded RED to GREEN experiment
+name: "implement"
+description: "Execute one bounded RED to GREEN experiment"
 ---
 # Implement
 
@@ -43,10 +43,8 @@ proof.
 On discovering a live consumer of the change outside the declared write scope
 — a test asserting the old path, a generated twin, a gate reading the moved
 file — stop and report the exact file and line to the caller. Do not silently
-expand scope to absorb it. One repair revision of the intent is the maximum
-before escalating to the caller; the 2026-07-15 heal-skill fold took three
-intent revisions (lineage under `.agents/ao/intents/sha256/26a4f2be...eb48`)
-because hand-enumerated scope kept missing live consumers.
+expand scope to absorb it or revise the intent from Implement. The caller may
+revise the source intent and start a separate invocation.
 
 Before declaring GREEN, self-audit the diff for mocks, placeholders, TODO
 stubs, hardcoded fixture values, weakened assertions, regenerated goldens,

--- a/skills-codex/implement/SKILL.md
+++ b/skills-codex/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "implement"
-description: "Execute one bounded RED to GREEN experiment"
+name: implement
+description: Execute one bounded RED to GREEN experiment
 ---
 # Implement
 

--- a/skills-codex/plan/.agentops-generated.json
+++ b/skills-codex/plan/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/plan",
   "layout": "modular",
-  "source_hash": "7d6e5e80eb29e59b680912229c2d9e72efbb51f06a9824995959bfb441da6eae",
-  "generated_hash": "f5bca26d0cdeef7d12fd138d23813c470f1e1f7743b6e1103b3464b5f55b76d0"
+  "source_hash": "750583fc4ef821c11144ec15fb85988d47b84b691a072911fe7366adb9c26584",
+  "generated_hash": "bba18e1c382b2937bf185185a4f0fc1c6b68469da836cacfe87647f3cfae3de5"
 }

--- a/skills-codex/plan/.agentops-generated.json
+++ b/skills-codex/plan/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/plan",
   "layout": "modular",
-  "source_hash": "750583fc4ef821c11144ec15fb85988d47b84b691a072911fe7366adb9c26584",
-  "generated_hash": "6293bb0b1aae0f25cd03c4577a208dbbf390d5128ef6d3caf6dc3cb49ef37b28"
+  "source_hash": "16026fda4df366feaa3c99980f6a49d78d331e8563f8b0a7a4c0f45d0a60338b",
+  "generated_hash": "4144d7daa581c0352c5cb4231363bd19e99dd4a53dfe1a8daa9baee1a72d8d41"
 }

--- a/skills-codex/plan/.agentops-generated.json
+++ b/skills-codex/plan/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/plan",
   "layout": "modular",
   "source_hash": "750583fc4ef821c11144ec15fb85988d47b84b691a072911fe7366adb9c26584",
-  "generated_hash": "bba18e1c382b2937bf185185a4f0fc1c6b68469da836cacfe87647f3cfae3de5"
+  "generated_hash": "6293bb0b1aae0f25cd03c4577a208dbbf390d5128ef6d3caf6dc3cb49ef37b28"
 }

--- a/skills-codex/plan/SKILL.md
+++ b/skills-codex/plan/SKILL.md
@@ -5,10 +5,11 @@ description: Shape or refine the existing bead or caller
 # Plan
 
 Turn the caller's intent into one bounded, testable behavior in the place that
-already owns the work. Prefer the caller's tracker, if any. When no tracker is
-available, use the caller's conversation or supplied issue text; the runtime
-snapshots the resolved intent bytes automatically so later contexts can read
-and hash the same source. Do not make the model restate those facts in a packet.
+already owns the work. Prefer the caller's tracker, if any. When no durable
+tracker or issue reference is available, use the caller's conversation or
+supplied text; the runtime snapshots those resolved intent bytes so later
+contexts can read and hash the same source. Do not make the model restate those
+facts in a packet.
 
 ## Workflow
 
@@ -32,9 +33,12 @@ and hash the same source. Do not make the model restate those facts in a packet.
 5. If authorized and the source is writable, update that bead or issue in
    place. Otherwise return a concise proposed amendment to the caller.
 
-Planning produces no AgentOps packet. The runtime stores and hashes the resolved
-source bytes to detect later acceptance drift. That content-addressed snapshot
-is derived automatically and is not another model-authored planning artifact.
+Planning produces no AgentOps packet. A durable caller-owned source stays in
+place; the runtime carries its reference and the digest of its exact resolved
+bytes to detect later acceptance drift. Only when no durable source exists does
+the runtime store those bytes under their digest as a content-addressed
+snapshot. That fallback is derived automatically and is not another
+model-authored planning artifact.
 
 Bound the work around the caller-visible outcome, not individual files, gates,
 or reviewer comments. Decomposition is useful only when it reduces reasoning

--- a/skills-codex/plan/SKILL.md
+++ b/skills-codex/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: plan
-description: Shape or refine the existing bead or caller
+name: "plan"
+description: "Shape or refine the existing bead or caller"
 ---
 # Plan
 
@@ -39,25 +39,6 @@ is derived automatically and is not another model-authored planning artifact.
 Bound the work around the caller-visible outcome, not individual files, gates,
 or reviewer comments. Decomposition is useful only when it reduces reasoning
 cost; it must not multiply invocations or proof artifacts.
-
-## Manifest mode (many behaviors, zero beads)
-
-When the caller's goal genuinely decomposes into several bounded behaviors —
-an audit remediation, an epic, a contraction — shape one caller-owned
-specification manifest instead of one behavior:
-
-- One document in the caller's location (commonly `docs/plans/<date>-<slug>.md`)
-  holding a manifest table (stable slug, type, priority, parent, dependency
-  edges) plus one section per child with acceptance, non-goals, write scope,
-  and evidence commands. Each child must satisfy the same bar as a
-  single-behavior plan.
-- Tracker IDs stay `TBD`: manifest mode authors zero beads. The executing
-  substrate materializes tracker state — the caller's session in the default
-  loop, or the selected factory's coordinator (for Gas City the Mayor, per
-  [using-gc](../using-gc/SKILL.md); for the Flywheel, its native workflow per
-  [using-flywheel](../using-flywheel/SKILL.md)).
-- Reference example:
-  [2026-07-30-ponytail-whole-repo-contraction.md](../../docs/plans/2026-07-30-ponytail-whole-repo-contraction.md).
 
 ## Scope admission
 

--- a/skills-codex/plan/SKILL.md
+++ b/skills-codex/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "plan"
-description: "Shape or refine the existing bead or caller"
+name: plan
+description: Shape or refine the existing bead or caller
 ---
 # Plan
 

--- a/skills-codex/plan/prompt.md
+++ b/skills-codex/plan/prompt.md
@@ -1,6 +1,6 @@
 # plan
 
-Shape or refine the existing bead or caller intent without a second planning artifact. Triggers: "plan", "discover and plan", "shape this goal", "plan manifest".
+Shape or refine the existing bead or caller intent without a second planning artifact. Triggers: "plan", "discover and plan", "shape this goal".
 
 ## Instructions
 

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/rpi",
   "layout": "modular",
   "source_hash": "15dab600e62da4d414e9deac42a9131380da3d6241a6cc879d56efe78e0ef22c",
-  "generated_hash": "f93f020b5251a1972f932d353cb4acd855fb7149916aa65915bfd22eb72897a5"
+  "generated_hash": "bf17b412c5ac6d29f4a25f7a9d747037f2284809afd8da881482a8903f214945"
 }

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "15dab600e62da4d414e9deac42a9131380da3d6241a6cc879d56efe78e0ef22c",
-  "generated_hash": "bf17b412c5ac6d29f4a25f7a9d747037f2284809afd8da881482a8903f214945"
+  "source_hash": "88d6447a288d335faa25a7d8628e9ebd877d5c761c2af6bb765c96afab984730",
+  "generated_hash": "f8686fc7915991a903f7bfbe1d24e7d2c3c0e6c5f30a8bed4bd4d2c4ac31c0f9"
 }

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "ccc1c4a5034bc549cd63f424ea3497fb6d0ea3a3d52327e31dd54aee7dbfbe01",
-  "generated_hash": "85a987391c2eb901990d54a2164c5e89d899eaa6ae689eea7cbb01423ff304bb"
+  "source_hash": "15dab600e62da4d414e9deac42a9131380da3d6241a6cc879d56efe78e0ef22c",
+  "generated_hash": "f93f020b5251a1972f932d353cb4acd855fb7149916aa65915bfd22eb72897a5"
 }

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "rpi"
-description: "Coordinate one RPI traversal: one bounded"
+name: rpi
+description: 'Coordinate one RPI traversal: one bounded'
 ---
 # RPI
 

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: rpi
-description: 'Coordinate one RPI traversal: one bounded'
+name: "rpi"
+description: "Coordinate one RPI traversal: one bounded"
 ---
 # RPI
 
@@ -38,10 +38,11 @@ authorization by itself.
 
 1. Resolve the existing bead or caller intent. Invoke Plan once only if that
    source needs shaping; Plan updates the same source or proposes an amendment.
-   It creates no AgentOps packet. The runtime snapshots the exact resolved
-   source bytes under their digest, including when the conversation is the only
-   source, before dispatching Implement or a fresh Validate context. If usable
-   intent cannot be established, report `NOT_PLANNED` and stop.
+   It creates no AgentOps packet. Preserve a durable caller-owned source by
+   reference and digest; only when no durable source exists does the runtime
+   snapshot the exact resolved source bytes under their digest before
+   dispatching Implement or a fresh Validate context. If usable intent cannot
+   be established, report `NOT_PLANNED` and stop.
 2. Invoke Implement once with the resolved intent. It performs one bounded
    experiment; the runtime derives subject identity and check receipts. If no
    subject is built, report `NOT_BUILT` and stop.
@@ -83,9 +84,9 @@ repair revision. RPI owns no lane budget, repair budget, or retry policy.
 
 Delegate with minimal context: a lane receives the frozen intent reference and
 the established facts it needs, never the orchestrator's full conversation
-history. If a lane cannot proceed from the intent alone, the plan failed the
-fresh-context test and should be repaired at the source, not padded with chat
-transcript.
+history. If a lane cannot proceed from the intent alone, report that the plan
+failed the fresh-context test and stop; do not pad it with chat transcript or
+start another planning lane without explicit caller authorization.
 
 Lanes whose write scopes share a regen surface (the same generated outputs,
 mirrors, or manifests) serialize; only lanes with disjoint source scopes and

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -124,7 +124,7 @@ RPI has one required report surface and one optional representation:
    {
      "schema_version": "rpi-report.v1",
      "status": "PASS",
-     "intent_ref": ".agents/ao/intents/sha256/<64-hex-digest>.intent",
+     "intent_ref": "<durable-source-ref-or-fallback-snapshot-ref>",
      "acceptance_digest": "<64-hex-char-sha256-or-null>",
      "subject_manifest_digest": "<64-hex-char-sha256-or-null>",
      "verdict_ref": "<verdict-location-or-null>",
@@ -134,10 +134,12 @@ RPI has one required report surface and one optional representation:
    }
    ```
 
-   `status` is one of `PASS | FAIL | NOT_PROVEN | NOT_PLANNED | NOT_BUILT`; the
-   three digest fields, when present, are 64-character lowercase hex SHA-256
-   strings; `checked` and `not_checked` are arrays of strings. All nine keys
-   are required (use `null` for an inapplicable ref or digest), and no
+   `intent_ref` remains required: it names the durable caller-owned source when
+   one exists, otherwise the content-addressed fallback snapshot. `status` is
+   one of `PASS | FAIL | NOT_PROVEN | NOT_PLANNED | NOT_BUILT`; the three digest
+   fields, when present, are 64-character lowercase hex SHA-256 strings;
+   `checked` and `not_checked` are arrays of strings. All nine keys are required
+   (use `null` for an inapplicable ref or digest), and no
    additional properties are allowed.
 
 Lead the interactive response with the status and one sentence stating the

--- a/skills-codex/swarm/.agentops-generated.json
+++ b/skills-codex/swarm/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/swarm",
   "layout": "modular",
-  "source_hash": "0ab257679d52e3ec38985d7d81a5b05749363d4f3170a169ac7b74b911fa3f7f",
-  "generated_hash": "31dadb68c36be6a43c61374aa37f32f29f67adc7a85170076c6f1e797a9362c1"
+  "source_hash": "258d63e5499e210003605b6947841913131094a0015d21ab27c8281973364be2",
+  "generated_hash": "edca9587669802663b04b091be159fcc10b763072715333a71f44f797e6a65b2"
 }

--- a/skills-codex/swarm/.agentops-generated.json
+++ b/skills-codex/swarm/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/swarm",
   "layout": "modular",
   "source_hash": "258d63e5499e210003605b6947841913131094a0015d21ab27c8281973364be2",
-  "generated_hash": "edca9587669802663b04b091be159fcc10b763072715333a71f44f797e6a65b2"
+  "generated_hash": "cf023c0baac3989aaf2ea69fd19dfdc4fdd0b4f2392dcb6209d5e51f2b1e8afc"
 }

--- a/skills-codex/swarm/SKILL.md
+++ b/skills-codex/swarm/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: swarm
-description: Dispatch explicit disjoint packets exactly
+name: "swarm"
+description: "Dispatch explicit disjoint packets exactly"
 ---
 # Swarm
 
@@ -25,7 +25,8 @@ silently ignored, because the proof cannot honor it.
 
 Exactly-once dispatch over proven-disjoint scopes is why parallel failures stay
 independent: no packet can observe, block, or corrupt another, so N packets
-yield N verdicts about N experiments rather than one tangle.
+yield N factual results about N experiments rather than one tangle. Those
+results are not semantic verdicts.
 
 Named failure mode — **partial-batch launch**: dispatching valid packets before
 discovering an invalid one, leaving the batch half-run; validate the entire

--- a/skills-codex/swarm/SKILL.md
+++ b/skills-codex/swarm/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "swarm"
-description: "Dispatch explicit disjoint packets exactly"
+name: swarm
+description: Dispatch explicit disjoint packets exactly
 ---
 # Swarm
 

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/using-gc",
   "layout": "modular",
   "source_hash": "bf15cd25cc11a2778b434ecefe9fa4c1d46f08d6162a367a2ec348e231e9fd8f",
-  "generated_hash": "dbb1fd1ac8e278a6603478d4dfd0b7b1e7b7271089be6ddcbea70e3da93f8fbb"
+  "generated_hash": "e4e3061d249cba8be354ad8d15427b2d7f3faf7885307d6dd8c8a0ae8e35d149"
 }

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/using-gc",
   "layout": "modular",
-  "source_hash": "ae9a7e669ad218f471bf3435dbc9614924ea27edd742d3cb9c528a5fd4f137a1",
-  "generated_hash": "822fc4619b9e7a0e9acce03176189cf99fec36437cf6ae1f423a5381b9d2172c"
+  "source_hash": "bf15cd25cc11a2778b434ecefe9fa4c1d46f08d6162a367a2ec348e231e9fd8f",
+  "generated_hash": "dbb1fd1ac8e278a6603478d4dfd0b7b1e7b7271089be6ddcbea70e3da93f8fbb"
 }

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "using-gc"
-description: "Operate a caller-selected Gas City 1.4 with"
+name: using-gc
+description: Operate a caller-selected Gas City 1.4 with
 ---
 # Using GC
 

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: using-gc
-description: Operate a caller-selected Gas City 1.4 with
+name: "using-gc"
+description: "Operate a caller-selected Gas City 1.4 with"
 ---
 # Using GC
 
@@ -160,13 +160,6 @@ Or, in an interactive Mayor session:
 ```text
 Use skill gc.mayor
 ```
-
-A multi-behavior intent arrives as a plan manifest (see plan's manifest mode):
-one caller-owned document with stable slugs, dependency edges, and per-child
-acceptance and write scopes, tracker IDs left `TBD`. Mail the Mayor the
-document path once it is on the rig's mainline; the Mayor materializes the
-epic and children from the manifest and owns their dispatch order. Reference
-example: `docs/plans/2026-07-30-ponytail-whole-repo-contraction.md`.
 
 Direct `gc sling` remains a debugging tool for a city with no live Mayor; a
 run started that way has no coordinator and the operator inherits its tending.

--- a/skills/automation-shape-routing/SKILL.md
+++ b/skills/automation-shape-routing/SKILL.md
@@ -105,8 +105,8 @@ Return exactly one of:
 - `using-gc` with explicit operator choice
 - `operationalize:gate`
 
-Name the deciding axis and invoke the owner. Do not copy the delegated workflow
-into this router.
+Name the deciding axis and owner, then stop. The caller may invoke that owner
+separately; do not copy or start the delegated workflow from this router.
 
 ## Output Specification
 
@@ -134,8 +134,9 @@ into this router.
     END { exit !(NR == 1 && !extra && valid) }
   '
   ```
-- **Downstream handoff:** invoke the named owner only after returning the verdict;
-  `inline` remains in the current agent and `bounded-fanout` remains in-session.
+- **Downstream handoff:** return the named owner to the caller without invoking
+  it; `inline` and `bounded-fanout` describe the recommended execution shape but
+  do not authorize this routing skill to begin execution.
 
 ## Quality Rubric
 

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bootstrap
-description: 'Initialize minimal AgentOps documentation and verdict storage without taking over repository workflow. Triggers: "bootstrap AgentOps", "initialize AgentOps docs".'
+description: 'Initialize explicitly requested, missing AgentOps documentation and optional verdict storage without taking over repository workflow. Triggers: "bootstrap AgentOps", "initialize AgentOps docs".'
 practices:
 - hermetic-builds
 - code-complete
@@ -26,13 +26,14 @@ metadata:
   graph_root: true
   tier: session
   dependencies: []
-output_contract: minimal project docs and .agents/ao/verdicts directory
+output_contract: explicitly requested missing project docs and optional .agents/ao/verdicts directory
 ---
 # Bootstrap — minimal project setup
 
-Bootstrap fills only missing AgentOps entry documents and the default durable
-verdict directory. It does not initialize Git, install hooks, create tracker
-state, start runtimes, or impose a delivery workflow.
+Bootstrap fills only explicitly requested, missing AgentOps entry documents and,
+when requested, the durable verdict directory. It does not initialize Git,
+install hooks, create tracker state, start runtimes, or impose a delivery
+workflow.
 
 Never-overwrite is what makes bootstrap safe to run on any repository: a setup
 step that can only add is idempotent by construction, while one that can

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -210,7 +210,7 @@
       ],
       "context_rel": [],
       "dependencies": [],
-      "description": "Initialize minimal AgentOps documentation and verdict storage without taking over repository workflow. Triggers: \"bootstrap AgentOps\", \"initialize AgentOps docs\".",
+      "description": "Initialize explicitly requested, missing AgentOps documentation and optional verdict storage without taking over repository workflow. Triggers: \"bootstrap AgentOps\", \"initialize AgentOps docs\".",
       "disposition": "keep_specialist",
       "effects": [
         "write_project_docs"
@@ -907,7 +907,7 @@
       "consumes": [],
       "context_rel": [],
       "dependencies": [],
-      "description": "Shape or refine the existing bead or caller intent without a second planning artifact. Triggers: \"plan\", \"discover and plan\", \"shape this goal\", \"plan manifest\".",
+      "description": "Shape or refine the existing bead or caller intent without a second planning artifact. Triggers: \"plan\", \"discover and plan\", \"shape this goal\".",
       "disposition": "keep",
       "effects": [
         "update_intent_source"

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -65,10 +65,8 @@ proof.
 On discovering a live consumer of the change outside the declared write scope
 — a test asserting the old path, a generated twin, a gate reading the moved
 file — stop and report the exact file and line to the caller. Do not silently
-expand scope to absorb it. One repair revision of the intent is the maximum
-before escalating to the caller; the 2026-07-15 heal-skill fold took three
-intent revisions (lineage under `.agents/ao/intents/sha256/26a4f2be...eb48`)
-because hand-enumerated scope kept missing live consumers.
+expand scope to absorb it or revise the intent from Implement. The caller may
+revise the source intent and start a separate invocation.
 
 Before declaring GREEN, self-audit the diff for mocks, placeholders, TODO
 stubs, hardcoded fixture values, weakened assertions, regenerated goldens,

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: 'Shape or refine the existing bead or caller intent without a second planning artifact. Triggers: "plan", "discover and plan", "shape this goal", "plan manifest".'
+description: 'Shape or refine the existing bead or caller intent without a second planning artifact. Triggers: "plan", "discover and plan", "shape this goal".'
 practices:
 - bdd-gherkin
 - design-by-contract
@@ -58,25 +58,6 @@ is derived automatically and is not another model-authored planning artifact.
 Bound the work around the caller-visible outcome, not individual files, gates,
 or reviewer comments. Decomposition is useful only when it reduces reasoning
 cost; it must not multiply invocations or proof artifacts.
-
-## Manifest mode (many behaviors, zero beads)
-
-When the caller's goal genuinely decomposes into several bounded behaviors —
-an audit remediation, an epic, a contraction — shape one caller-owned
-specification manifest instead of one behavior:
-
-- One document in the caller's location (commonly `docs/plans/<date>-<slug>.md`)
-  holding a manifest table (stable slug, type, priority, parent, dependency
-  edges) plus one section per child with acceptance, non-goals, write scope,
-  and evidence commands. Each child must satisfy the same bar as a
-  single-behavior plan.
-- Tracker IDs stay `TBD`: manifest mode authors zero beads. The executing
-  substrate materializes tracker state — the caller's session in the default
-  loop, or the selected factory's coordinator (for Gas City the Mayor, per
-  [using-gc](../using-gc/SKILL.md); for the Flywheel, its native workflow per
-  [using-flywheel](../using-flywheel/SKILL.md)).
-- Reference example:
-  [2026-07-30-ponytail-whole-repo-contraction.md](../../docs/plans/2026-07-30-ponytail-whole-repo-contraction.md).
 
 ## Scope admission
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -24,10 +24,11 @@ metadata:
 # Plan
 
 Turn the caller's intent into one bounded, testable behavior in the place that
-already owns the work. Prefer the caller's tracker, if any. When no tracker is
-available, use the caller's conversation or supplied issue text; the runtime
-snapshots the resolved intent bytes automatically so later contexts can read
-and hash the same source. Do not make the model restate those facts in a packet.
+already owns the work. Prefer the caller's tracker, if any. When no durable
+tracker or issue reference is available, use the caller's conversation or
+supplied text; the runtime snapshots those resolved intent bytes so later
+contexts can read and hash the same source. Do not make the model restate those
+facts in a packet.
 
 ## Workflow
 
@@ -51,9 +52,12 @@ and hash the same source. Do not make the model restate those facts in a packet.
 5. If authorized and the source is writable, update that bead or issue in
    place. Otherwise return a concise proposed amendment to the caller.
 
-Planning produces no AgentOps packet. The runtime stores and hashes the resolved
-source bytes to detect later acceptance drift. That content-addressed snapshot
-is derived automatically and is not another model-authored planning artifact.
+Planning produces no AgentOps packet. A durable caller-owned source stays in
+place; the runtime carries its reference and the digest of its exact resolved
+bytes to detect later acceptance drift. Only when no durable source exists does
+the runtime store those bytes under their digest as a content-addressed
+snapshot. That fallback is derived automatically and is not another
+model-authored planning artifact.
 
 Bound the work around the caller-visible outcome, not individual files, gates,
 or reviewer comments. Decomposition is useful only when it reduces reasoning

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -68,10 +68,11 @@ authorization by itself.
 
 1. Resolve the existing bead or caller intent. Invoke Plan once only if that
    source needs shaping; Plan updates the same source or proposes an amendment.
-   It creates no AgentOps packet. The runtime snapshots the exact resolved
-   source bytes under their digest, including when the conversation is the only
-   source, before dispatching Implement or a fresh Validate context. If usable
-   intent cannot be established, report `NOT_PLANNED` and stop.
+   It creates no AgentOps packet. Preserve a durable caller-owned source by
+   reference and digest; only when no durable source exists does the runtime
+   snapshot the exact resolved source bytes under their digest before
+   dispatching Implement or a fresh Validate context. If usable intent cannot
+   be established, report `NOT_PLANNED` and stop.
 2. Invoke Implement once with the resolved intent. It performs one bounded
    experiment; the runtime derives subject identity and check receipts. If no
    subject is built, report `NOT_BUILT` and stop.
@@ -113,9 +114,9 @@ repair revision. RPI owns no lane budget, repair budget, or retry policy.
 
 Delegate with minimal context: a lane receives the frozen intent reference and
 the established facts it needs, never the orchestrator's full conversation
-history. If a lane cannot proceed from the intent alone, the plan failed the
-fresh-context test and should be repaired at the source, not padded with chat
-transcript.
+history. If a lane cannot proceed from the intent alone, report that the plan
+failed the fresh-context test and stop; do not pad it with chat transcript or
+start another planning lane without explicit caller authorization.
 
 Lanes whose write scopes share a regen surface (the same generated outputs,
 mirrors, or manifests) serialize; only lanes with disjoint source scopes and

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -154,7 +154,7 @@ RPI has one required report surface and one optional representation:
    {
      "schema_version": "rpi-report.v1",
      "status": "PASS",
-     "intent_ref": ".agents/ao/intents/sha256/<64-hex-digest>.intent",
+     "intent_ref": "<durable-source-ref-or-fallback-snapshot-ref>",
      "acceptance_digest": "<64-hex-char-sha256-or-null>",
      "subject_manifest_digest": "<64-hex-char-sha256-or-null>",
      "verdict_ref": "<verdict-location-or-null>",
@@ -164,10 +164,12 @@ RPI has one required report surface and one optional representation:
    }
    ```
 
-   `status` is one of `PASS | FAIL | NOT_PROVEN | NOT_PLANNED | NOT_BUILT`; the
-   three digest fields, when present, are 64-character lowercase hex SHA-256
-   strings; `checked` and `not_checked` are arrays of strings. All nine keys
-   are required (use `null` for an inapplicable ref or digest), and no
+   `intent_ref` remains required: it names the durable caller-owned source when
+   one exists, otherwise the content-addressed fallback snapshot. `status` is
+   one of `PASS | FAIL | NOT_PROVEN | NOT_PLANNED | NOT_BUILT`; the three digest
+   fields, when present, are 64-character lowercase hex SHA-256 strings;
+   `checked` and `not_checked` are arrays of strings. All nine keys are required
+   (use `null` for an inapplicable ref or digest), and no
    additional properties are allowed.
 
 Lead the interactive response with the status and one sentence stating the

--- a/skills/swarm/SKILL.md
+++ b/skills/swarm/SKILL.md
@@ -41,7 +41,8 @@ silently ignored, because the proof cannot honor it.
 
 Exactly-once dispatch over proven-disjoint scopes is why parallel failures stay
 independent: no packet can observe, block, or corrupt another, so N packets
-yield N verdicts about N experiments rather than one tangle.
+yield N factual results about N experiments rather than one tangle. Those
+results are not semantic verdicts.
 
 Named failure mode — **partial-batch launch**: dispatching valid packets before
 discovering an invalid one, leaving the batch half-run; validate the entire

--- a/skills/using-gc/SKILL.md
+++ b/skills/using-gc/SKILL.md
@@ -179,13 +179,6 @@ Or, in an interactive Mayor session:
 Use skill gc.mayor
 ```
 
-A multi-behavior intent arrives as a plan manifest (see plan's manifest mode):
-one caller-owned document with stable slugs, dependency edges, and per-child
-acceptance and write scopes, tracker IDs left `TBD`. Mail the Mayor the
-document path once it is on the rig's mainline; the Mayor materializes the
-epic and children from the manifest and owns their dispatch order. Reference
-example: `docs/plans/2026-07-30-ponytail-whole-repo-contraction.md`.
-
 Direct `gc sling` remains a debugging tool for a city with no live Mayor; a
 run started that way has no coordinator and the operator inherits its tending.
 


### PR DESCRIPTION
### Motivation

- Resolve inconsistencies between skill contracts and the repository operating contract and README, where some skills implied starting downstream execution, multi-behavior planning, or implicit durable state creation. 
- Make routing decisions advisory-only and ensure orchestration and factory adapters remain owner-operated rather than implicitly started by routers. 
- Ensure RPI, Plan, and Implement respect a single caller-owned intent source, fresh-validation boundaries, and explicit caller authorization for scope or multi-lane changes. 
- Keep Bootstrap explicitly opt-in for creating durable verdict storage and project docs to avoid unexpected repo changes.

### Description

- Updated skill contracts to enforce the operating contract: `skills/plan/SKILL.md` removed the manifest-mode trigger and now consistently shapes one active behavior in the existing intent source. 
- Clarified RPI semantics in `skills/rpi/SKILL.md` to preserve durable caller-owned intent by reference and only snapshot when no durable source exists, and to stop/report when a fresh-context test fails rather than auto-starting new planning lanes. 
- Made routing advisory-only in `skills/automation-shape-routing/SKILL.md` so the router returns the chosen owner without copying or starting the delegated workflow. 
- Constrained `bootstrap` in `skills/bootstrap/SKILL.md` to create only explicitly requested project docs and optional `.agents/ao/verdicts` storage, and adjusted `implement` and `swarm` wording to stop/return factual evidence rather than implicitly revise or declare semantic verdicts. 
- Regenerated derived projections and parity twins (Codex and Gemini artifacts), updated `skills-codex/*` generated metadata, and updated the `skills/catalog.json` to reflect the revised descriptions and hashes.

### Testing

- Ran regenerated-projections and parity checks with `PYTHONPATH=/tmp bash scripts/regen-all.sh --check --skills automation-shape-routing,bootstrap,implement,plan,rpi,swarm,using-gc` which completed and reported projections current. ✅
- Validated Codex artifacts and coverage with `bash scripts/validate-codex-generated-artifacts.sh` and `bash scripts/validate-codex-override-coverage.sh` which passed. ✅
- Ran repository checks including `scripts/check-skill-size.sh`, `scripts/check-doc-skill-refs.sh`, `scripts/check-orchestration-skill-boundaries.sh`, `scripts/check-skill-python-ratchet.sh`, and per-skill validators `skills/plan/scripts/validate.sh` and `skills/implement/scripts/validate.sh`, all of which passed. ✅
- Frontmatter/schema checks initially failed due to missing Python packages (`PyYAML`, `jsonschema`) in the environment and network restrictions prevented installation, but parity, mesh generation, lint, and the metadata-driven regeneration were completed using a local shim so the main automated validation suite passed with the noted environment limitation. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e8a00a680832b808af3ef40055848)