### PR TITLE
chore: track canonical bd project identity

### DIFF
--- a/.beads/identity.toml
+++ b/.beads/identity.toml
@@ -1,0 +1,5 @@
+# .beads/identity.toml — canonical, git-tracked.
+# Edited only at scope creation or by deliberate human/`gc` migration.
+
+[project]
+id = "ef0398e4-6485-4983-ae68-5c043f56073e"


### PR DESCRIPTION
## Summary
- Track the canonical `.beads/identity.toml` so bd/Gas City project identity travels with the repository.
- Bind it to the live bd project ID `ef0398e4-6485-4983-ae68-5c043f56073e`.

## Checks
- Exact-source AgentOps fast gate: 11/11
- Exact-source AgentOps full gate: 68/68
- Gas City `internal/beads/contract`: pass
- `git diff --check`: pass

## Validation
Fresh independent validation: PASS on exact commit `2fed5b83762bdb2a38b075a577eebbef37667aac`; all acceptance checked, no findings, no unchecked surface.