### PR TITLE
fix(skills): preserve portable Codex activation metadata

### DIFF
--- a/docs/contracts/codex-skill-api.md
+++ b/docs/contracts/codex-skill-api.md
@@ -12,7 +12,8 @@
 
 ## SKILL.md Frontmatter
 
-Codex recognizes **only** these frontmatter fields:
+Every generated AgentOps Codex projection emits only the two fields Codex uses
+for discovery:
 
 ```yaml
 ---
@@ -21,8 +22,12 @@ description: 'Explain when this skill triggers and when it does not.'
 ---
 ```
 
-**Required:** `name`, `description`
-**Everything else is ignored.** Fields like `skill_api_version`, `context`, `metadata`, `allowed-tools`, `model`, `user-invocable`, and `output_contract` are AgentOps-internal and must be stripped from Codex output.
+The portable Agent Skills specification requires `name` and `description`
+and also permits `license`, `compatibility`, string-to-string `metadata`,
+and the experimental space-separated `allowed-tools` field. The AgentOps
+generator does not currently emit those optional fields. AgentOps-only fields
+such as `skill_api_version`, `context`, `model`, `user-invocable`, and
+`output_contract` must be stripped from Codex output.
 
 ---
 
@@ -78,7 +83,12 @@ are symlinks to this repository's canonical `skills/` tree.
 | System | Bundled with Codex | Built-in skills |
 
 Development symlinks may point directly at `skills/<name>/`; checked-in
-`skills-codex/` packages are the release projection. Plugin caches are neither
+`skills-codex/` packages are the portable Agent Skills release projection.
+Canonical `skills/` frontmatter is intentionally host-extended and is evaluated
+against the AgentOps profile, not mislabeled as portable. The release gate
+`scripts/validate-codex-api-conformance.sh` validates every projected package
+against the portable field, type, identity, body, and relative-resource-link
+contract before applying Codex-specific checks. Plugin caches are neither
 source nor an installation target and may be deleted without affecting the
 canonical repository skills.
 
@@ -91,7 +101,12 @@ canonical repository skills.
 | Explicit | `$skill-name` or `/skills` menu | User directly requests the skill |
 | Implicit | Automatic | Codex matches task to skill description |
 
-Skills are loaded via **progressive disclosure**: metadata first (name, description), full SKILL.md only when activated.
+Skills are loaded via **progressive disclosure**: metadata first (name,
+description), full SKILL.md only when activated. Because the description is
+the implicit-routing surface, a projection must preserve the source's complete
+`Triggers:` clause while keeping its introductory prose within the catalog
+budget; a generic summary or dropped trigger is a behavioral defect, even when
+the body remains byte-complete.
 
 ---
 
@@ -198,7 +213,9 @@ Skills referencing these primitives produce **broken instructions** in Codex.
 
 When generating Codex skills from source skills:
 
-1. **Strip all non-Codex frontmatter** — emit only `name` + `description`
+1. **Strip all non-Codex frontmatter** — emit only `name` + `description`,
+   compacting introductory prose while preserving the complete source
+   `Triggers:` clause as the activation catalog signal
 2. **Map Claude tools to Codex tools** — Read→read_file, Edit→apply_patch, Grep→rg, Glob→glob_file_search
 3. **Rewrite `Skill(skill="X")` to `$X`** — Codex uses dollar-prefix invocation
 4. **Strip ALL task/team primitives** — TaskCreate, TaskList, TeamCreate, SendMessage (none have working Codex equivalents as direct tool calls — `todo_write`/`update_plan` empirically unavailable, and `send_input` is follow-up-only)

--- a/scripts/codex-sync.sh
+++ b/scripts/codex-sync.sh
@@ -302,27 +302,36 @@ The CLI records startup once per thread and skips duplicates automatically."""
 
 
 def codex_catalog_description(name: str, source_description: str) -> str:
-    """Terse but skill-specific always-loaded Codex catalog text.
+    """Skill-specific Codex activation catalog text.
 
-    The full source description remains available in prompt.md; SKILL.md
-    frontmatter is loaded as an activation catalog, so keep enough routing
-    signal to choose the skill while staying under the average token budget.
+    The catalog description is the model's routing signal. Preserve the full
+    source ``Triggers:`` clause while compacting the prose before it to the
+    repository's 44-character per-entry target. Trigger aliases have their own
+    collision budget; the prose remains inside the always-loaded catalog
+    budget enforced by tests/skills/test-token-budgets.sh.
     """
     import re
 
-    desc = re.sub(r"\s+[Tt]riggers?:.*", "", source_description).strip()
-    desc = re.sub(r"\s+", " ", desc).strip(" '\"")
+    desc = re.sub(r"\s+", " ", source_description).strip(" '\"")
     if not desc:
         return f"Run {name}."
 
-    max_chars = 44
-    if len(desc) <= max_chars:
-        return desc
+    trigger_match = re.search(r"\s+[Tt]riggers?:", desc)
+    if trigger_match:
+        prose = desc[: trigger_match.start()].strip()
+        triggers = desc[trigger_match.start() :].strip()
+    else:
+        prose = desc
+        triggers = ""
 
-    shortened = desc[: max_chars + 1].rsplit(" ", 1)[0].strip(" ,;:-")
-    if len(shortened) < 18:
-        shortened = desc[:max_chars].rstrip(" ,;:-")
-    return shortened
+    max_chars = 44
+    if len(prose) > max_chars:
+        shortened = prose[: max_chars + 1].rsplit(" ", 1)[0].strip(" ,;:-")
+        if len(shortened) < 18:
+            shortened = prose[:max_chars].rstrip(" ,;:-")
+        prose = shortened
+
+    return " ".join(part for part in (prose, triggers) if part)
 
 
 def twin_skill_md(

--- a/scripts/regen-all.sh
+++ b/scripts/regen-all.sh
@@ -65,7 +65,8 @@ else
   step "skill mesh" python3 scripts/generate-skill-mesh.py --check
   step "Codex parity" bash scripts/audit-codex-parity.sh
   step "Codex runtime sections" bash scripts/validate-codex-runtime-sections.sh
-    step "CLI reference" bash scripts/generate-cli-reference.sh --check
+  step "portable Agent Skills conformance" bash scripts/validate-codex-api-conformance.sh
+  step "CLI reference" bash scripts/generate-cli-reference.sh --check
   step "command heading projections" bash scripts/regen-command-surfaces.sh --check
   step "CLI surface inventory" bash scripts/check-cmdao-surface-parity.sh
   step "documentation index" python3 scripts/generate-documentation-index.py --check

--- a/scripts/validate-codex-api-conformance.sh
+++ b/scripts/validate-codex-api-conformance.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-SKILLS_ROOT="$REPO_ROOT/skills-codex"
+SKILLS_ROOT="${CODEX_SKILLS_ROOT:-$REPO_ROOT/skills-codex}"
 
 # Cross-runtime skills legitimately reference non-Codex runtimes/paths (cc-hooks
 # documents ~/.claude/settings.json). Shared exemption list with codex-sync and
@@ -30,22 +30,196 @@ if [[ ! -d "$SKILLS_ROOT" ]]; then
   exit 1
 fi
 
-# --- Check 1: Frontmatter must only contain name + description ---
-echo "=== Check 1: Frontmatter fields ==="
-while IFS= read -r skill_md; do
-  skill_name="$(basename "$(dirname "$skill_md")")"
-  is_bespoke "$skill_name" || continue  # parity twins are generator/drift-verified
+# --- Check 1: Portable Agent Skills package contract ---
+# The checked-in Codex tree is the portable release projection. Validate every
+# generated and bespoke package here; generator parity alone cannot establish
+# portable conformance. This intentionally enforces the normative specification
+# rather than the narrower behavior of any one reference implementation.
+echo "=== Check 1: Portable Agent Skills contract ==="
+portable_output=""
+if ! portable_output="$(python3 - "$SKILLS_ROOT" "$REPO_ROOT" 2>&1 <<'PY'
+import re
+import sys
+from pathlib import Path
 
-  # Extract frontmatter between first and second ---
-  fm=$(awk 'NR==1 && /^---$/{in_fm=1; next} in_fm && /^---$/{exit} in_fm{print}' "$skill_md")
+import yaml
+from yaml.constructor import ConstructorError
+from yaml.resolver import BaseResolver
 
-  # Check for non-Codex fields
-  bad_fields=$(echo "$fm" | grep -oE '^[a-z_-]+:' | sed 's/:$//' | grep -vE '^(name|description)$' || true)
-  if [[ -n "$bad_fields" ]]; then
-    echo "  FAIL [$skill_name] Non-Codex frontmatter fields: $(echo "$bad_fields" | tr '\n' ', ')"
-    failures=$((failures + 1))
+skills_root = Path(sys.argv[1]).resolve()
+repo_root = Path(sys.argv[2]).resolve()
+try:
+    skills_root.relative_to(repo_root)
+    link_root = repo_root
+except ValueError:
+    # A detached catalog bundle is its own containment boundary. Cross-skill
+    # links may resolve to sibling packages inside that catalog.
+    link_root = skills_root
+allowed = {"name", "description", "license", "compatibility", "metadata", "allowed-tools"}
+name_re = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+link_re = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+errors: list[tuple[str, str]] = []
+checked = 0
+
+
+class UniqueKeyLoader(yaml.SafeLoader):
+    pass
+
+
+def construct_unique_mapping(loader: UniqueKeyLoader, node: yaml.Node, deep: bool = False) -> dict:
+    mapping: dict = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in mapping
+        except TypeError as exc:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "found an unhashable mapping key",
+                key_node.start_mark,
+            ) from exc
+        if duplicate:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+UniqueKeyLoader.add_constructor(
+    BaseResolver.DEFAULT_MAPPING_TAG,
+    construct_unique_mapping,
+)
+
+
+def fail(skill: str, message: str) -> None:
+    errors.append((skill, message))
+
+
+for skill_dir in sorted(path for path in skills_root.iterdir() if path.is_dir()):
+    skill = skill_dir.name
+    if skill_dir.is_symlink():
+        fail(skill, "skill package directory must not be a symlink")
+        continue
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file() or skill_md.is_symlink():
+        fail(skill, "missing regular SKILL.md")
+        continue
+    checked += 1
+    try:
+        text = skill_md.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        fail(skill, f"SKILL.md is not loadable UTF-8: {exc}")
+        continue
+    if not text.startswith("---\n"):
+        fail(skill, "SKILL.md must start with YAML frontmatter")
+        continue
+    marker = text.find("\n---\n", 4)
+    if marker < 0:
+        fail(skill, "SKILL.md frontmatter is not closed")
+        continue
+    raw_frontmatter = text[4:marker]
+    body = text[marker + 5 :]
+    try:
+        metadata = yaml.load(raw_frontmatter, Loader=UniqueKeyLoader)
+    except yaml.YAMLError as exc:
+        fail(skill, f"invalid YAML frontmatter: {exc}")
+        continue
+    if not isinstance(metadata, dict):
+        fail(skill, "frontmatter must be a mapping")
+        continue
+    unexpected = sorted(set(metadata) - allowed)
+    if unexpected:
+        fail(skill, f"host-only frontmatter fields: {', '.join(unexpected)}")
+    name = metadata.get("name")
+    if not isinstance(name, str) or not name_re.fullmatch(name) or len(name) > 64:
+        fail(skill, "name must be 1-64 lowercase ASCII letters/digits/hyphens without edge or repeated hyphens")
+    elif name != skill:
+        fail(skill, f"name {name!r} does not match directory {skill!r}")
+    description = metadata.get("description")
+    if not isinstance(description, str) or not description.strip() or len(description) > 1024:
+        fail(skill, "description must be a nonempty string of at most 1024 characters")
+    if "license" in metadata and (
+        not isinstance(metadata["license"], str) or not metadata["license"].strip()
+    ):
+        fail(skill, "license must be a nonempty string")
+    if "compatibility" in metadata:
+        compatibility = metadata["compatibility"]
+        if not isinstance(compatibility, str) or not compatibility.strip() or len(compatibility) > 500:
+            fail(skill, "compatibility must be a nonempty string of at most 500 characters")
+    if "metadata" in metadata:
+        extension = metadata["metadata"]
+        if not isinstance(extension, dict) or any(
+            not isinstance(key, str) or not isinstance(value, str)
+            for key, value in (extension.items() if isinstance(extension, dict) else ())
+        ):
+            fail(skill, "metadata must map strings to strings")
+    if "allowed-tools" in metadata:
+        tools = metadata["allowed-tools"]
+        if not isinstance(tools, str) or not tools.strip() or "," in tools or "\t" in tools or "\n" in tools:
+            fail(skill, "allowed-tools must be a nonempty space-separated string without comma delimiters")
+    if not body.strip():
+        fail(skill, "SKILL.md body must be nonempty")
+
+    for resource in sorted(skill_dir.rglob("*")):
+        if resource.is_symlink():
+            fail(skill, f"resource must not be a symlink: {resource.relative_to(skill_dir)}")
+
+    # Validate actual Markdown resource links after removing code, where text
+    # such as errors.AsType[T](err) is not a link. External URLs and anchors are
+    # valid but do not identify bundled resources.
+    for markdown in sorted(skill_dir.rglob("*.md")):
+        if markdown.is_symlink():
+            continue
+        try:
+            markdown_text = markdown.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            fail(skill, f"resource is not loadable UTF-8: {markdown.relative_to(skill_dir)}: {exc}")
+            continue
+        markdown_text = re.sub(r"```.*?```", "", markdown_text, flags=re.S)
+        markdown_text = re.sub(r"`[^`\n]*`", "", markdown_text)
+        for match in link_re.finditer(markdown_text):
+            raw_target = match.group(1).strip()
+            target = raw_target.split(maxsplit=1)[0].strip("<>")
+            if not target or target.startswith("#") or re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", target):
+                continue
+            if target.startswith(("/", "~")) or re.match(r"^[A-Za-z]:[\\/]", target):
+                fail(skill, f"resource link must be relative: {target}")
+                continue
+            path_part = target.split("#", 1)[0].split("?", 1)[0]
+            resolved = (markdown.parent / path_part).resolve()
+            try:
+                resolved.relative_to(link_root)
+            except ValueError:
+                fail(skill, f"resource link escapes catalog: {target}")
+                continue
+            if not resolved.exists():
+                fail(skill, f"resource link does not resolve: {markdown.relative_to(skill_dir)} -> {target}")
+
+if checked == 0:
+    fail("<root>", "no skill packages found")
+
+for skill, message in errors:
+    print(f"  FAIL [{skill}] {message}")
+if errors:
+    raise SystemExit(1)
+print(f"  PASS [portable] {checked} package(s)")
+PY
+)"; then
+  printf '%s\n' "$portable_output"
+  portable_failures="$(printf '%s\n' "$portable_output" | grep -c '^  FAIL \[' || true)"
+  if [[ "$portable_failures" -eq 0 ]]; then
+    echo "  FAIL [portable-validator] validator did not complete"
+    portable_failures=1
   fi
-done < <(find "$SKILLS_ROOT" -mindepth 2 -maxdepth 2 -name 'SKILL.md' -type f | sort)
+  failures=$((failures + portable_failures))
+else
+  printf '%s\n' "$portable_output"
+fi
 
 # --- Check 2: No Claude-only primitive names ---
 echo "=== Check 2: Claude primitive references ==="

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -352,313 +352,313 @@
       "name": "account-rotation",
       "source_skill": "skills/account-rotation",
       "source_hash": "0929b03a8b42808ee604f53653e7887e8509bebffc2f2e7648a6c7c269fcac8e",
-      "generated_hash": "0571b4e1b80b089be179a82f1c713977e7e68966ae50c0bf91ead69e977714d1"
+      "generated_hash": "8a22457af268c08baaf24d21207f4892a8c8daff12447f617a5d78df4ce95fde"
     },
     {
       "name": "agent-mail",
       "source_skill": "skills/agent-mail",
       "source_hash": "f21a53e9da7bfc6047763d1a17552de25eb8d48f1a4aab6c4adb66f5f81118a5",
-      "generated_hash": "86fedf4d643ca4b375305c846cbbb6d8883116bf74b6990b3e63975592e598f2"
+      "generated_hash": "c39278195441c2543efe9817a4ac8fb8112a43067af13ba443b1e9647adeca59"
     },
     {
       "name": "agent-native",
       "source_skill": "skills/agent-native",
       "source_hash": "597bfaf6f186c52b14f1b6d60112e9305785a63ab4f24bb25b5b87fba2110b91",
-      "generated_hash": "c20f151e90f517bbc14e4239964740210aa3232ceae7c1514d3c1fc9e2789594"
+      "generated_hash": "1fe991fb2bebdca94aa88d398bfc5e3aedc7ce1e9d16788016fc75ee6985f3ba"
     },
     {
       "name": "agy-native",
       "source_skill": "skills/agy-native",
       "source_hash": "e1506ab3711bd362b032624f0a11f5cbbd9372da101f86195f42a6d375bb6430",
-      "generated_hash": "cd08d16a52d7f9d5bc7d19c3a70e449982ee32c560487761b6af8ddfe4ded2fe"
+      "generated_hash": "3685c1be3d3fbec6a35e9d4bb29df3bb8ca2f05d3bdcb0e4155712b299303f51"
     },
     {
       "name": "anti-ceremony",
       "source_skill": "skills/anti-ceremony",
       "source_hash": "7e2212dfc04997fe8883d18afe8fd07de801370a94a9597f445a6920390ba359",
-      "generated_hash": "8c2c0c6469a6294ab5bd9a9073951d524d6f39c6e62f58eee048cf4ec6dc17e1"
+      "generated_hash": "1d5e6bcf991ad8b2e712e78652d78230e15eba1ffb01e75bf381e1a195a986f2"
     },
     {
       "name": "automation-shape-routing",
       "source_skill": "skills/automation-shape-routing",
       "source_hash": "0c070794c5a9a91024d14a6bc5a18e6305b488401dfcb79bb83c41e789ba7bc3",
-      "generated_hash": "913bd809a83b2710547512f2a887459372fb18f6d2d96d420acadecdebff5b7f"
+      "generated_hash": "92ef43973b35c9aa8edc247eff130efac2e522cf1b7af99234a3540c3c79a284"
     },
     {
       "name": "bootstrap",
       "source_skill": "skills/bootstrap",
       "source_hash": "41ccae0b12098a33057fa9d7082763787ecb7f317e814dc1e34708740c8d7b05",
-      "generated_hash": "dd8f84f19a0522c6d9cdf030de9c371d18a994c8b7cb64d953c2292fcc363e96"
+      "generated_hash": "f2d91ee26afce8543a5c3a005edf7e14c0de25e4c9e9d6163383eedadd2fcca3"
     },
     {
       "name": "cass",
       "source_skill": "skills/cass",
       "source_hash": "87bd3747933a20e2dbc90191812d855a9b73bde5a966a576fbd6022907bf8e13",
-      "generated_hash": "5e3f910fad6ec1d78460e999785c5a987733391840723d843cdf8d69cfb4bdb9"
+      "generated_hash": "a73abfc56cde3fe759f17b4868b2fe3415224044d499a78bb870eb25c0716d92"
     },
     {
       "name": "cc-hooks",
       "source_skill": "skills/cc-hooks",
       "source_hash": "1c1a15fb1170fe1ce8e6a99e2fedcc8e878de92a93bf79698bb604f0861cb2f4",
-      "generated_hash": "dd4a41bd24cc7ab986ee1f24e8609aa8447ed2345094b44bb757d93064afe5ff"
+      "generated_hash": "2083d461e866b78ef4bf69c316fa35112d31e5b89635ce66b064360f0136c551"
     },
     {
       "name": "codebase-recon",
       "source_skill": "skills/codebase-recon",
       "source_hash": "2ee84ce6be213b02db860d9206e0a6307a53c5718c75311a2e69830b89ebd327",
-      "generated_hash": "26238e641ee39ee94d39dc3ddd21726d1db2c7e26e689c2092f217f3abda108e"
+      "generated_hash": "9dfa7e4ab14b85fee4d49371d1aaea11ff2f9c618c2fa5f9c4a293b0f39aaec1"
     },
     {
       "name": "codex-exec",
       "source_skill": "skills/codex-exec",
       "source_hash": "db1eda768d56f20bd92d333b3e45124a5afbbf3a5653b8b9d39bb285edeefc89",
-      "generated_hash": "75df66a57666eea344dac4254cc5926054bab8677aabfdb9ead003db58370181"
+      "generated_hash": "8ab3a3240fac697ee1f38cf6b9b82d94ab3cd9fa9a4775075770e81450b10250"
     },
     {
       "name": "converter",
       "source_skill": "skills/converter",
       "source_hash": "abc9e6aec41184373a9e80a0baa047fde51b02f971b841a45ac323bafcde3b4a",
-      "generated_hash": "1d4a319edc74e19f18351d5cdb5b6cf128b0b2b97adcf89f85752f75f44f83f3"
+      "generated_hash": "7445751ec953396475e7ab697b1a871fca403adbada549a10db23ebe2a42eca7"
     },
     {
       "name": "council",
       "source_skill": "skills/council",
       "source_hash": "2c8dd5df1754f9897ba40122751e4e64cf5cb098238857ef6209e970e19c3f3e",
-      "generated_hash": "50cc0e2b63f5314b96da6e63e0aaa1a7e181af3b651b6603772aa22f5af9d3fd"
+      "generated_hash": "9be18d6c5521e016375c2d50bc3eff5b8370562c07a934fb294749753882d4c4"
     },
     {
       "name": "craft-goal",
       "source_skill": "skills/craft-goal",
       "source_hash": "fb70646294d4838d2e5d27401e88255c9b4653f8062f461d182f622be87dfbf4",
-      "generated_hash": "46f494df66ed3147d576f14014d92932fdf18f7c4b6cfb9347df6a4a416c87d9"
+      "generated_hash": "025096448232ca9786f56be82cd8c689fe9103184218ac8ba69b2e638e34b5b3"
     },
     {
       "name": "dcg",
       "source_skill": "skills/dcg",
       "source_hash": "ad40fd9b845fc38464b4086a67563e0f65ab978032eed4c3a450720c9d6e1b3a",
-      "generated_hash": "f2377e290fec00a80816def3cb38d5dfb722075a0cbe542a9b04d1b4a8294d5d"
+      "generated_hash": "270a3c8a1600ffde2010ffab2a3d865f60c0a1f170b99506abb21eef7a962390"
     },
     {
       "name": "doc",
       "source_skill": "skills/doc",
       "source_hash": "b078e307850e633e3366a2feacc40d51fe998a2d1f4c9a6619398fac6cbff871",
-      "generated_hash": "e38305defd87206473a53f3399e7a493b6af80874429ba7bbff12cd488246f43"
+      "generated_hash": "147981c88c470bab37b71ec01eb3a2f3d3ddb84cb5433a11b1b12f245d1607c5"
     },
     {
       "name": "domain",
       "source_skill": "skills/domain",
       "source_hash": "b082f03a32a392ac035d3b00a6312f0cfde3e85f6b361f0067e6328368eb5d0c",
-      "generated_hash": "701e69b45deab257dd702160b4c05916f7bf51772b62bdd11e747f4be90bf810"
+      "generated_hash": "cb8a242301b6d51bb09b6e4decad0f29e7d9e7ff0efbee3fa3adfc9efe5860ed"
     },
     {
       "name": "fitness",
       "source_skill": "skills/fitness",
       "source_hash": "c23854f00cdaf45fdefe04265036bca0539559a247dd88bcd13eff5004dbc361",
-      "generated_hash": "d3f01847b297aaef08bf5d7fc7df1717ea0ca2e59e0407e61f702fdccc2cabae"
+      "generated_hash": "20094083a08b626f2a4a14ab2718d51d2a4c19c8bd3d17b9d2404bb35dd05b91"
     },
     {
       "name": "goals",
       "source_skill": "skills/goals",
       "source_hash": "53c201871da29d8962c26fcd3ff563296726fc71626fec8b819be1a7857ce28c",
-      "generated_hash": "6a26e0fd34317e30a312d9009b3e8abd4ce6310f463ce2d3489a38d82fc61f14"
+      "generated_hash": "22be2b390dae3de8a7054eb6e859a12bf356c5761e5219e8cecbefc473446a7a"
     },
     {
       "name": "handoff",
       "source_skill": "skills/handoff",
       "source_hash": "8bf6b07f4db91ac2a7f13b27ee5bee1cd960b6bca7f2b4716ccf904de04561ad",
-      "generated_hash": "49d4e2099d491b52c7d7440f3d1d70f2ae9cad9850df484f1ffe6605efbb3098"
+      "generated_hash": "2ae25a11e7beed2bad87065c39969061408d5d6dd1037efc4f0a9e10bbeeea04"
     },
     {
       "name": "idea-genie",
       "source_skill": "skills/idea-genie",
       "source_hash": "a3beedc9da108209b19a2ee290b583e474e26de32e5c8e3c7de70858c058c280",
-      "generated_hash": "ac5d01f46e7a960b3504aab9329c2679858db598a5bfcd6536f02c05c697b79c"
+      "generated_hash": "a791d6f6f4f22792e7ef94458dfda11050b6800c9ae5ba90f6171258b3277615"
     },
     {
       "name": "implement",
       "source_skill": "skills/implement",
       "source_hash": "2a01b04555e02e0ccae7d670da6b6db67f26e6123d65103b68eb513f10d5026f",
-      "generated_hash": "8b7f0c9f95ce32043dc9bf287313987027f557f2dbfcec6fbc67e852442d239e"
+      "generated_hash": "3a7c261713b8092b497ec7f1393ed7118168d82a7162648c2d575c7cb981a9b5"
     },
     {
       "name": "learn",
       "source_skill": "skills/learn",
       "source_hash": "53067b9717740db5e7b7c4f116e5c728f48893556789020c602a02a53723683c",
-      "generated_hash": "2cdb8ec214c209920dd724a2efd9dc5b2889835beb90e6490f315a69a5a22813"
+      "generated_hash": "9590a94eca1c89ac68b56d504c7e6730bd3daab95c10f05aa95ba894493fb788"
     },
     {
       "name": "ms",
       "source_skill": "skills/ms",
       "source_hash": "8634a28c128d80d574da339747315ed4af5e047081c20d7647f69d08f7c88e71",
-      "generated_hash": "95cad0eb98d21cf7c1124b387188ce35d8ea322377d46ef0f19642c6ffeecbf6"
+      "generated_hash": "871bf24cafda06ecb22a0f6e9d0e38a6a2fdd204a4f1c7f9fc9209bd8c11a7c0"
     },
     {
       "name": "ntm",
       "source_skill": "skills/ntm",
       "source_hash": "848facd36e19091df95e562f631fb3c25cf73fc39ba1af999766412756b43151",
-      "generated_hash": "d87d9f9d8a12e4e1a9fdaf8dfbc5a1ac683a087733218988812ef4aa6fc6ac80"
+      "generated_hash": "d4bc77f68b1a9f80848762206d9f389b113a7f9f6a7bc160ecc3e7df3e052b05"
     },
     {
       "name": "operationalize",
       "source_skill": "skills/operationalize",
       "source_hash": "d20938af6747bd483a0ae1d4418bf2382714ca145986f5d0410cc15873f7ea09",
-      "generated_hash": "99f66711ef2775e6a464750998407295e542264ba8c86b34bfd4c6f8a5f5484b"
+      "generated_hash": "9a4ffe1b16da81916f02d457b9c5505f773d0adfa1b898f7d9865d64d0f0f5c9"
     },
     {
       "name": "pattern-mining",
       "source_skill": "skills/pattern-mining",
       "source_hash": "b35118568b471c41e0a9b68e8aedb0491553ba26fc348014f52e4a0939e531b5",
-      "generated_hash": "ebea87d16f82ab1699283479826ab0d427d56b2ebd1f920fbb79660e06cb8769"
+      "generated_hash": "11fbe805050cb4ccf39da01ef1ae0d88c38150f8067ecb5700472b51756e0dd6"
     },
     {
       "name": "plan",
       "source_skill": "skills/plan",
       "source_hash": "6133824e806dd44f5c3fcfec39ed46251d951802d573e16fb02ffac9074e23aa",
-      "generated_hash": "4144d7daa581c0352c5cb4231363bd19e99dd4a53dfe1a8daa9baee1a72d8d41"
+      "generated_hash": "72fae8db7fb2635e3a2d536b28b8314c75c3e0b5610c17fbeccd38d39811f580"
     },
     {
       "name": "postmortem",
       "source_skill": "skills/postmortem",
       "source_hash": "e1b37de32fb537d06ecc56a1801b3eee3ae9b7574718eaf6048fe470d3fc285b",
-      "generated_hash": "55cc73eba32d0f60b6d8fa6707f8566de3393716345f7be558e08219cfbfe339"
+      "generated_hash": "51cc9e5ac630d8c070ce0152ed3776f2db25bd09859411aa891bd360bed05fe0"
     },
     {
       "name": "premortem",
       "source_skill": "skills/premortem",
       "source_hash": "e882fd13bb037adec58b7484ddd34477cf882f088169dbac2225e04d532195dd",
-      "generated_hash": "20ba86016b8b2b6c40f48a15766f847a4677f1e59f9373aa54f614104d72a617"
+      "generated_hash": "bb365fd13d085c76b90eb3cc75fcce5e7c30dc65735956739ea67b40000d8170"
     },
     {
       "name": "product",
       "source_skill": "skills/product",
       "source_hash": "0415ea5bf6e58cf21a31b9672dd6e2c18832536bf803814b9964f460d9b63e86",
-      "generated_hash": "b4c4023dda45c6f08cbe4db1d10f090bb78ce2a7b5f84e3f04b8133707c40b12"
+      "generated_hash": "318e57dbda4f8e2a4afd6494b20c648bb3c98a62451671f346dff93f6d177e9a"
     },
     {
       "name": "rch",
       "source_skill": "skills/rch",
       "source_hash": "3af677e66c6a1ed663e733461d9153922b7dd6123bc011fbae9bc831a2d3c2c1",
-      "generated_hash": "bb6606aa0c44726a8f67021fbe6bdf767ca31773e57fc274201f7ae32f51b42a"
+      "generated_hash": "8983f1db7849b8517017ee1aa23f25bee8c473d08138c011d282cd92a9119c21"
     },
     {
       "name": "reality-check",
       "source_skill": "skills/reality-check",
       "source_hash": "d79b843f8f6cc71d3fbe08b8ba6db458c9d886763750a38b2bc29fa8a505fc56",
-      "generated_hash": "2efce800c15a5c024a58cfe9dc1bb33c41dbaac9e0840f0661dbc00dd68153a5"
+      "generated_hash": "b4097981ff6741acdfbef3096eed9d3173836b7ba760359bc5a92244a988c83d"
     },
     {
       "name": "refactor",
       "source_skill": "skills/refactor",
       "source_hash": "19aededa001917f28711593f30a0a01f2c9d6218db189abf5148535c51152098",
-      "generated_hash": "8586c4c6bd56e9b30189255e7e81d883de1c5e6c4da90001622cfe6779a94a40"
+      "generated_hash": "da7627f940e456ce983eb10cb0ebf8ef7eef2aa9f78339fc1cd18777cef13c66"
     },
     {
       "name": "research",
       "source_skill": "skills/research",
       "source_hash": "adba28d813cad60df3f1e389eed9d750cd4845ff44ef0f3e79666bc55d4e36ad",
-      "generated_hash": "15b02e785eba49d182bb1866edeb06ff28d6495110a3b62681a4da1746e1ec6e"
+      "generated_hash": "033ce223a5d0c5ada5c5348ab85e92c64cae44ea52428af785abc6e524ecd9de"
     },
     {
       "name": "reverse-engineer",
       "source_skill": "skills/reverse-engineer",
       "source_hash": "c4c1d351deda610d6a848b31aca64559d603d065b719a1a91cda3504d7ede98a",
-      "generated_hash": "e2330646793a9d980ebed4a2d10438ebef90ae790265520a10595192f3e564e8"
+      "generated_hash": "996489a23ad67969ef19b303aa74d051069aa2946c68125d4b9d9b387c7e6ff6"
     },
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
       "source_hash": "4870c343799f313706c7928b59d3b55cb2b4f8bd34b972dddf57e4859b999695",
-      "generated_hash": "20c93a0cbd9f0a5a3cae66f7afdc4a8c06c4b628886508bd127aabdd4c4bb266"
+      "generated_hash": "19890dc9ca1af9d8585c9b91d792c378c148824c538ff6fce3eee1f75cb28f7f"
     },
     {
       "name": "sbh",
       "source_skill": "skills/sbh",
       "source_hash": "1e938f203fc92290da03306ad803586159748d4d69c0aa4748f0af8864d7f9f4",
-      "generated_hash": "55e22b4db1245feab5a38ab8c571b77ad435047e2511d132e4c4b179f03a4fc9"
+      "generated_hash": "0020dd0d27506322c401b0f5e0237e63864d0877a27e01c4af18cf5d323be62e"
     },
     {
       "name": "scaffold",
       "source_skill": "skills/scaffold",
       "source_hash": "3842025470fcf184e2fd96f7306f14de37b67864a42d8021f33f953bb76afce6",
-      "generated_hash": "9452dce2fd5026b986db3ca03cbc503dcf499b09dca909a6cbe8b8d025d9e57a"
+      "generated_hash": "8cceff6c3efe7b430ed733462245e8af93cdc21f6493e3f0145b377006985297"
     },
     {
       "name": "scope",
       "source_skill": "skills/scope",
       "source_hash": "a710df7df3c89ac7cf0416cb8dc4bc1ab63ab11e730bafb23f5682243b6ac128",
-      "generated_hash": "41b71b9c7b1e4978a47810199f1886d75ee5e6b6b8415a156d04cd7bc2093816"
+      "generated_hash": "f96abc9efe2c81149e74a7eaa9674ad879b2ae8ade49c30250970bdf7141e8d4"
     },
     {
       "name": "security",
       "source_skill": "skills/security",
       "source_hash": "183e3eb73292146855adbd10765ac0bee41f35a745900908f47573e317b20ab2",
-      "generated_hash": "0f1b44f2688511728dfcca04eadaf30b701ee17f2896e940d0a0e66ca39d22da"
+      "generated_hash": "bc6d8a3bcfff9170fe070b0c425a926a1c32539818cf589c0739a741df9ea2aa"
     },
     {
       "name": "shared",
       "source_skill": "skills/shared",
       "source_hash": "0e093accb57d583bc53556923e6e6f3110e96d122dc43b90b6ebfcc9711821b0",
-      "generated_hash": "0feead7579441b8286e69bab8c0b9e4ce90dd3dc6009e57f24693ac3ff314f51"
+      "generated_hash": "9a66038526a8eb2971c1c5ae0655d35a9ce48aea7cc15c301c1d956a1b745e6d"
     },
     {
       "name": "skill-builder",
       "source_skill": "skills/skill-builder",
       "source_hash": "b500ca18d663bf8b11a4bfa4c27ba82f8335f73560212a81d003e7eff4b68d3a",
-      "generated_hash": "d42c6cee0783ec810a8a9723bd606770d2f52587438894a4143035d7d31b03a8"
+      "generated_hash": "35c9ee3b875f16800f2cd6a10f9ee1fbc9958792bd67f88589d00cf4853fd1e6"
     },
     {
       "name": "standards",
       "source_skill": "skills/standards",
       "source_hash": "d493ba253d8eaafcd19c3e62b98328a535f3a8d9720bd17a144fa77b1c369268",
-      "generated_hash": "bec8e7c8b82b76ea771c6264783e4561e7d9eec61f52a7415e196f018cc8de2c"
+      "generated_hash": "db544dc9cea88e8a1cdd7051bb611dec3f46c13095a1ba1df8178021abbf33a7"
     },
     {
       "name": "status",
       "source_skill": "skills/status",
       "source_hash": "e53d8400425c9bf1fb3d3e944fa81fa6d388c7dc1d57e045d0f49c2b606f5923",
-      "generated_hash": "789321c0ed3d849ff54f888943796fab966a4a1a86109e512a1d6c68cab8bec8"
+      "generated_hash": "f18f5d3aeafe2db1329128545547bd925c47c9093f06928576757fc6553d66ec"
     },
     {
       "name": "swarm",
       "source_skill": "skills/swarm",
       "source_hash": "258d63e5499e210003605b6947841913131094a0015d21ab27c8281973364be2",
-      "generated_hash": "cf023c0baac3989aaf2ea69fd19dfdc4fdd0b4f2392dcb6209d5e51f2b1e8afc"
+      "generated_hash": "4cd3f5a682d31d463b4b7c8505e118dd7a9b1e255e2b770d0a5311da11cce247"
     },
     {
       "name": "test",
       "source_skill": "skills/test",
       "source_hash": "c074c59a2e4ccae27f2a4f514b9e5a16a6d87465be8429405878e0641ec5d096",
-      "generated_hash": "be6eb93094d43ee18b0d87412661e0cc08724fa3d64e0724c0dd908dfa9dca22"
+      "generated_hash": "0f5b0f731e595e2fed396631a49f429654ea17060ab515c5d0896c03be82063d"
     },
     {
       "name": "toil-mining",
       "source_skill": "skills/toil-mining",
       "source_hash": "a95c554be75d0791eb71bad60bee508807d50af96006480d5bbface2611a8691",
-      "generated_hash": "11d4272652686c2da5ff11e15e510f5e56f30e5fc3f9dd2414dced0a00055f12"
+      "generated_hash": "3b27e8e26657132ab1f8da85dddf71a966c82b136bea49dfbe353ff2c9a6a6f9"
     },
     {
       "name": "using-flywheel",
       "source_skill": "skills/using-flywheel",
       "source_hash": "876ddaec0998ca32f917b49101ffaed1248ac1c676deb985914efaea342cbae5",
-      "generated_hash": "ccc09a1240f753a136cf1e337d60ebd03c7dc705224720a1421dbedc7452d797"
+      "generated_hash": "d6a50c7e61769ac7f211b05e90ef01015d9b2f58a64df10bf91816dbc7fe5ff8"
     },
     {
       "name": "using-gc",
       "source_skill": "skills/using-gc",
       "source_hash": "bf15cd25cc11a2778b434ecefe9fa4c1d46f08d6162a367a2ec348e231e9fd8f",
-      "generated_hash": "e4e3061d249cba8be354ad8d15427b2d7f3faf7885307d6dd8c8a0ae8e35d149"
+      "generated_hash": "210d8193303b5e58a56e83ceebf81c7eeed359ba97d8eed453a1429c25971a8f"
     },
     {
       "name": "validate",
       "source_skill": "skills/validate",
       "source_hash": "dc2ed6796e1fa59e9d1436eca4fcb4741a54b426e10b6eec0de5395f28cf42a4",
-      "generated_hash": "0354e7edaa3ea858641734c9c82dd13bc39b2732909295346a7b90ee1e4891aa"
+      "generated_hash": "fd41631f52f8c9c2311b1dfb86035c6782d53ccefde4453f7978ebb8c11d3b12"
     },
     {
       "name": "workflow-builder",
       "source_skill": "skills/workflow-builder",
       "source_hash": "e5c1e9bb10ea95138d53aa7071b3d6cee41c34cfde323efc4ceda5b21a6f93ee",
-      "generated_hash": "30f72769961a244749883e03cb04e329cd0feb03dd5b641d2a73a2e5dc8e9d42"
+      "generated_hash": "386479200813515ba0a1d5fe7b9a7406037a62daaa5419aa7471310b221712f9"
     }
   ],
   "package_count": 52

--- a/skills-codex/account-rotation/.agentops-generated.json
+++ b/skills-codex/account-rotation/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/account-rotation",
   "layout": "modular",
   "source_hash": "0929b03a8b42808ee604f53653e7887e8509bebffc2f2e7648a6c7c269fcac8e",
-  "generated_hash": "0571b4e1b80b089be179a82f1c713977e7e68966ae50c0bf91ead69e977714d1"
+  "generated_hash": "8a22457af268c08baaf24d21207f4892a8c8daff12447f617a5d78df4ce95fde"
 }

--- a/skills-codex/account-rotation/SKILL.md
+++ b/skills-codex/account-rotation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: account-rotation
-description: Switch a caller-selected coding-agent
+description: 'Switch a caller-selected coding-agent Triggers: "switch account", "rotate coding-agent account".'
 ---
 # Account rotation — credential adapter
 

--- a/skills-codex/agent-mail/.agentops-generated.json
+++ b/skills-codex/agent-mail/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/agent-mail",
   "layout": "modular",
   "source_hash": "f21a53e9da7bfc6047763d1a17552de25eb8d48f1a4aab6c4adb66f5f81118a5",
-  "generated_hash": "86fedf4d643ca4b375305c846cbbb6d8883116bf74b6990b3e63975592e598f2"
+  "generated_hash": "c39278195441c2543efe9817a4ac8fb8112a43067af13ba443b1e9647adeca59"
 }

--- a/skills-codex/agent-mail/SKILL.md
+++ b/skills-codex/agent-mail/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-mail
-description: Use Agent Mail as an optional messaging and
+description: 'Use Agent Mail as an optional messaging and Triggers: "coordinate writers", "reserve files".'
 ---
 # Agent Mail — optional coordination adapter
 

--- a/skills-codex/agent-native/.agentops-generated.json
+++ b/skills-codex/agent-native/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/agent-native",
   "layout": "modular",
   "source_hash": "597bfaf6f186c52b14f1b6d60112e9305785a63ab4f24bb25b5b87fba2110b91",
-  "generated_hash": "c20f151e90f517bbc14e4239964740210aa3232ceae7c1514d3c1fc9e2789594"
+  "generated_hash": "1fe991fb2bebdca94aa88d398bfc5e3aedc7ce1e9d16788016fc75ee6985f3ba"
 }

--- a/skills-codex/agent-native/SKILL.md
+++ b/skills-codex/agent-native/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-native
-description: Operate explicit orchestrator, implementer
+description: 'Operate explicit orchestrator, implementer Triggers: "agent-native factory", "role-shaped agent panes", "persistent workers".'
 ---
 # Agent Native
 

--- a/skills-codex/agy-native/.agentops-generated.json
+++ b/skills-codex/agy-native/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/agy-native",
   "layout": "modular",
   "source_hash": "e1506ab3711bd362b032624f0a11f5cbbd9372da101f86195f42a6d375bb6430",
-  "generated_hash": "cd08d16a52d7f9d5bc7d19c3a70e449982ee32c560487761b6af8ddfe4ded2fe"
+  "generated_hash": "3685c1be3d3fbec6a35e9d4bb29df3bb8ca2f05d3bdcb0e4155712b299303f51"
 }

--- a/skills-codex/agy-native/SKILL.md
+++ b/skills-codex/agy-native/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agy-native
-description: Use an explicitly selected AGY runtime for
+description: 'Use an explicitly selected AGY runtime for Triggers: "agy", "antigravity", "AGY evidence".'
 ---
 # AGY Native
 

--- a/skills-codex/anti-ceremony/.agentops-generated.json
+++ b/skills-codex/anti-ceremony/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/anti-ceremony",
   "layout": "modular",
   "source_hash": "7e2212dfc04997fe8883d18afe8fd07de801370a94a9597f445a6920390ba359",
-  "generated_hash": "8c2c0c6469a6294ab5bd9a9073951d524d6f39c6e62f58eee048cf4ec6dc17e1"
+  "generated_hash": "1d5e6bcf991ad8b2e712e78652d78230e15eba1ffb01e75bf381e1a195a986f2"
 }

--- a/skills-codex/anti-ceremony/SKILL.md
+++ b/skills-codex/anti-ceremony/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: anti-ceremony
-description: Guard outcome work against process overhead.
+description: 'Guard outcome work against process overhead. Triggers: RPI pre-Plan guard; explicit "full anti-ceremony audit" requests.'
 ---
 # Anti-Ceremony
 

--- a/skills-codex/automation-shape-routing/.agentops-generated.json
+++ b/skills-codex/automation-shape-routing/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/automation-shape-routing",
   "layout": "modular",
   "source_hash": "0c070794c5a9a91024d14a6bc5a18e6305b488401dfcb79bb83c41e789ba7bc3",
-  "generated_hash": "913bd809a83b2710547512f2a887459372fb18f6d2d96d420acadecdebff5b7f"
+  "generated_hash": "92ef43973b35c9aa8edc247eff130efac2e522cf1b7af99234a3540c3c79a284"
 }

--- a/skills-codex/automation-shape-routing/SKILL.md
+++ b/skills-codex/automation-shape-routing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: automation-shape-routing
-description: 'Front door for agent automation: choose'
+description: 'Front door for agent automation: choose Triggers: "build automation", "which orchestration shape", "should this use NTM".'
 ---
 # Automation Shape Routing
 

--- a/skills-codex/bootstrap/.agentops-generated.json
+++ b/skills-codex/bootstrap/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/bootstrap",
   "layout": "modular",
   "source_hash": "41ccae0b12098a33057fa9d7082763787ecb7f317e814dc1e34708740c8d7b05",
-  "generated_hash": "dd8f84f19a0522c6d9cdf030de9c371d18a994c8b7cb64d953c2292fcc363e96"
+  "generated_hash": "f2d91ee26afce8543a5c3a005edf7e14c0de25e4c9e9d6163383eedadd2fcca3"
 }

--- a/skills-codex/bootstrap/SKILL.md
+++ b/skills-codex/bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bootstrap
-description: Initialize explicitly requested, missing
+description: 'Initialize explicitly requested, missing Triggers: "bootstrap AgentOps", "initialize AgentOps docs".'
 ---
 # Bootstrap — minimal project setup
 

--- a/skills-codex/cass/.agentops-generated.json
+++ b/skills-codex/cass/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/cass",
   "layout": "modular",
   "source_hash": "87bd3747933a20e2dbc90191812d855a9b73bde5a966a576fbd6022907bf8e13",
-  "generated_hash": "5e3f910fad6ec1d78460e999785c5a987733391840723d843cdf8d69cfb4bdb9"
+  "generated_hash": "a73abfc56cde3fe759f17b4868b2fe3415224044d499a78bb870eb25c0716d92"
 }

--- a/skills-codex/cass/SKILL.md
+++ b/skills-codex/cass/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cass
-description: Mine past agent sessions for working
+description: 'Mine past agent sessions for working Triggers: "cass", "mine past agent sessions for", "cass skill".'
 ---
 # cass Session Search
 

--- a/skills-codex/cc-hooks/.agentops-generated.json
+++ b/skills-codex/cc-hooks/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/cc-hooks",
   "layout": "modular",
   "source_hash": "1c1a15fb1170fe1ce8e6a99e2fedcc8e878de92a93bf79698bb604f0861cb2f4",
-  "generated_hash": "dd4a41bd24cc7ab986ee1f24e8609aa8447ed2345094b44bb757d93064afe5ff"
+  "generated_hash": "2083d461e866b78ef4bf69c316fa35112d31e5b89635ce66b064360f0136c551"
 }

--- a/skills-codex/cc-hooks/SKILL.md
+++ b/skills-codex/cc-hooks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-hooks
-description: Configure default Claude Code enforcement
+description: 'Configure default Claude Code enforcement Triggers: "cc-hooks", "configure Claude Code hooks", "install hooks".'
 ---
 # Claude Code Hooks
 

--- a/skills-codex/codebase-recon/.agentops-generated.json
+++ b/skills-codex/codebase-recon/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/codebase-recon",
   "layout": "modular",
   "source_hash": "2ee84ce6be213b02db860d9206e0a6307a53c5718c75311a2e69830b89ebd327",
-  "generated_hash": "26238e641ee39ee94d39dc3ddd21726d1db2c7e26e689c2092f217f3abda108e"
+  "generated_hash": "9dfa7e4ab14b85fee4d49371d1aaea11ff2f9c618c2fa5f9c4a293b0f39aaec1"
 }

--- a/skills-codex/codebase-recon/SKILL.md
+++ b/skills-codex/codebase-recon/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-recon
-description: Reconstruct a repository as cited
+description: 'Reconstruct a repository as cited Triggers: "codebase recon", "trace this codebase", "repository audit", "refresh the prior recon".'
 ---
 # Codebase Recon
 

--- a/skills-codex/codex-exec/.agentops-generated.json
+++ b/skills-codex/codex-exec/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/codex-exec",
   "layout": "modular",
   "source_hash": "db1eda768d56f20bd92d333b3e45124a5afbbf3a5653b8b9d39bb285edeefc89",
-  "generated_hash": "75df66a57666eea344dac4254cc5926054bab8677aabfdb9ead003db58370181"
+  "generated_hash": "8ab3a3240fac697ee1f38cf6b9b82d94ab3cd9fa9a4775075770e81450b10250"
 }

--- a/skills-codex/codex-exec/SKILL.md
+++ b/skills-codex/codex-exec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codex-exec
-description: Run one caller-supplied Codex command
+description: 'Run one caller-supplied Codex command Triggers: "run Codex headless", "capture Codex evidence".'
 ---
 # Codex Exec — one-shot runtime adapter
 

--- a/skills-codex/converter/.agentops-generated.json
+++ b/skills-codex/converter/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/converter",
   "layout": "modular",
   "source_hash": "abc9e6aec41184373a9e80a0baa047fde51b02f971b841a45ac323bafcde3b4a",
-  "generated_hash": "1d4a319edc74e19f18351d5cdb5b6cf128b0b2b97adcf89f85752f75f44f83f3"
+  "generated_hash": "7445751ec953396475e7ab697b1a871fca403adbada549a10db23ebe2a42eca7"
 }

--- a/skills-codex/converter/SKILL.md
+++ b/skills-codex/converter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: converter
-description: Convert AgentOps skill formats.
+description: 'Convert AgentOps skill formats. Triggers: "converter", "convert agentops skill formats.", "converter skill".'
 ---
 # Converter — Cross-Platform Skill Converter
 

--- a/skills-codex/council/.agentops-generated.json
+++ b/skills-codex/council/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/council",
   "layout": "modular",
   "source_hash": "2c8dd5df1754f9897ba40122751e4e64cf5cb098238857ef6209e970e19c3f3e",
-  "generated_hash": "50cc0e2b63f5314b96da6e63e0aaa1a7e181af3b651b6603772aa22f5af9d3fd"
+  "generated_hash": "9be18d6c5521e016375c2d50bc3eff5b8370562c07a934fb294749753882d4c4"
 }

--- a/skills-codex/council/SKILL.md
+++ b/skills-codex/council/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: council
-description: Collect independent perspectives for an
+description: 'Collect independent perspectives for an Triggers: "council", "multi-judge review", "independent perspectives".'
 ---
 # Council
 

--- a/skills-codex/craft-goal/.agentops-generated.json
+++ b/skills-codex/craft-goal/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/craft-goal",
   "layout": "modular",
   "source_hash": "fb70646294d4838d2e5d27401e88255c9b4653f8062f461d182f622be87dfbf4",
-  "generated_hash": "46f494df66ed3147d576f14014d92932fdf18f7c4b6cfb9347df6a4a416c87d9"
+  "generated_hash": "025096448232ca9786f56be82cd8c689fe9103184218ac8ba69b2e638e34b5b3"
 }

--- a/skills-codex/craft-goal/SKILL.md
+++ b/skills-codex/craft-goal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: craft-goal
-description: Compile or lint a persistent Mayor-style
+description: 'Compile or lint a persistent Mayor-style Triggers: "craft a goal prompt", "mayor goal", "goal-runner prompt", "lint this goal", "is this goal safe". (Shaping one experiment''s intent routes to plan.)'
 ---
 # Craft Goal
 

--- a/skills-codex/dcg/.agentops-generated.json
+++ b/skills-codex/dcg/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/dcg",
   "layout": "modular",
   "source_hash": "ad40fd9b845fc38464b4086a67563e0f65ab978032eed4c3a450720c9d6e1b3a",
-  "generated_hash": "f2377e290fec00a80816def3cb38d5dfb722075a0cbe542a9b04d1b4a8294d5d"
+  "generated_hash": "270a3c8a1600ffde2010ffab2a3d865f60c0a1f170b99506abb21eef7a962390"
 }

--- a/skills-codex/dcg/SKILL.md
+++ b/skills-codex/dcg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dcg
-description: Handle blocked destructive commands and
+description: 'Handle blocked destructive commands and Triggers: "dcg", "handle a DCG block", "configure agent safety guardrails".'
 ---
 <!-- TOC: Core Insight | THE EXACT WORKFLOW | Quick Reference | Safe Alternatives | What Gets Blocked | Anti-Patterns | Configuration | References -->
 

--- a/skills-codex/doc/.agentops-generated.json
+++ b/skills-codex/doc/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/doc",
   "layout": "modular",
   "source_hash": "b078e307850e633e3366a2feacc40d51fe998a2d1f4c9a6619398fac6cbff871",
-  "generated_hash": "e38305defd87206473a53f3399e7a493b6af80874429ba7bbff12cd488246f43"
+  "generated_hash": "147981c88c470bab37b71ec01eb3a2f3d3ddb84cb5433a11b1b12f245d1607c5"
 }

--- a/skills-codex/doc/SKILL.md
+++ b/skills-codex/doc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doc
-description: Generate and validate repo docs, READMEs
+description: 'Generate and validate repo docs, READMEs Triggers: "doc", "generate and validate repo docs", "doc skill".'
 ---
 # Doc Skill
 

--- a/skills-codex/domain/.agentops-generated.json
+++ b/skills-codex/domain/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/domain",
   "layout": "modular",
   "source_hash": "b082f03a32a392ac035d3b00a6312f0cfde3e85f6b361f0067e6328368eb5d0c",
-  "generated_hash": "701e69b45deab257dd702160b4c05916f7bf51772b62bdd11e747f4be90bf810"
+  "generated_hash": "cb8a242301b6d51bb09b6e4decad0f29e7d9e7ff0efbee3fa3adfc9efe5860ed"
 }

--- a/skills-codex/domain/SKILL.md
+++ b/skills-codex/domain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: domain
-description: Load the AgentOps language and
+description: 'Load the AgentOps language and Triggers: "define this domain term", "check the bounded context".'
 ---
 # Domain — ubiquitous language
 

--- a/skills-codex/fitness/.agentops-generated.json
+++ b/skills-codex/fitness/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/fitness",
   "layout": "modular",
   "source_hash": "c23854f00cdaf45fdefe04265036bca0539559a247dd88bcd13eff5004dbc361",
-  "generated_hash": "d3f01847b297aaef08bf5d7fc7df1717ea0ca2e59e0407e61f702fdccc2cabae"
+  "generated_hash": "20094083a08b626f2a4a14ab2718d51d2a4c19c8bd3d17b9d2404bb35dd05b91"
 }

--- a/skills-codex/fitness/SKILL.md
+++ b/skills-codex/fitness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fitness
-description: Measure declared project fitness goals
+description: 'Measure declared project fitness goals Triggers: "fitness", "check project fitness", "measure goals".'
 ---
 # Fitness — read-only goal measurement
 

--- a/skills-codex/goals/.agentops-generated.json
+++ b/skills-codex/goals/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/goals",
   "layout": "modular",
   "source_hash": "53c201871da29d8962c26fcd3ff563296726fc71626fec8b819be1a7857ce28c",
-  "generated_hash": "6a26e0fd34317e30a312d9009b3e8abd4ce6310f463ce2d3489a38d82fc61f14"
+  "generated_hash": "22be2b390dae3de8a7054eb6e859a12bf356c5761e5219e8cecbefc473446a7a"
 }

--- a/skills-codex/goals/SKILL.md
+++ b/skills-codex/goals/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goals
-description: Compatibility alias — renamed to fitness.
+description: 'Compatibility alias — renamed to fitness. Triggers: "goals" (deprecated).'
 ---
 # Goals — compatibility alias for fitness
 

--- a/skills-codex/handoff/.agentops-generated.json
+++ b/skills-codex/handoff/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/handoff",
   "layout": "modular",
   "source_hash": "8bf6b07f4db91ac2a7f13b27ee5bee1cd960b6bca7f2b4716ccf904de04561ad",
-  "generated_hash": "49d4e2099d491b52c7d7440f3d1d70f2ae9cad9850df484f1ffe6605efbb3098"
+  "generated_hash": "2ae25a11e7beed2bad87065c39969061408d5d6dd1037efc4f0a9e10bbeeea04"
 }

--- a/skills-codex/handoff/SKILL.md
+++ b/skills-codex/handoff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: handoff
-description: Write compact caller-authored session
+description: 'Write compact caller-authored session Triggers: "handoff", "write compact session handoff".'
 ---
 # Handoff
 

--- a/skills-codex/idea-genie/.agentops-generated.json
+++ b/skills-codex/idea-genie/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/idea-genie",
   "layout": "modular",
   "source_hash": "a3beedc9da108209b19a2ee290b583e474e26de32e5c8e3c7de70858c058c280",
-  "generated_hash": "ac5d01f46e7a960b3504aab9329c2679858db598a5bfcd6536f02c05c697b79c"
+  "generated_hash": "a791d6f6f4f22792e7ef94458dfda11050b6800c9ae5ba90f6171258b3277615"
 }

--- a/skills-codex/idea-genie/SKILL.md
+++ b/skills-codex/idea-genie/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: idea-genie
-description: Generate evidenced opportunities or
+description: 'Generate evidenced opportunities or Triggers: "idea genie", "what should we build", "challenge this idea", "compare proposals".'
 ---
 # Idea Genie
 

--- a/skills-codex/implement/.agentops-generated.json
+++ b/skills-codex/implement/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/implement",
   "layout": "modular",
   "source_hash": "2a01b04555e02e0ccae7d670da6b6db67f26e6123d65103b68eb513f10d5026f",
-  "generated_hash": "8b7f0c9f95ce32043dc9bf287313987027f557f2dbfcec6fbc67e852442d239e"
+  "generated_hash": "3a7c261713b8092b497ec7f1393ed7118168d82a7162648c2d575c7cb981a9b5"
 }

--- a/skills-codex/implement/SKILL.md
+++ b/skills-codex/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: Execute one bounded RED to GREEN experiment
+description: 'Execute one bounded RED to GREEN experiment Triggers: "implement", "implement this bead", "run the experiment". Full plan-to-validation requests route to rpi.'
 ---
 # Implement
 

--- a/skills-codex/learn/.agentops-generated.json
+++ b/skills-codex/learn/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/learn",
   "layout": "modular",
   "source_hash": "53067b9717740db5e7b7c4f116e5c728f48893556789020c602a02a53723683c",
-  "generated_hash": "2cdb8ec214c209920dd724a2efd9dc5b2889835beb90e6490f315a69a5a22813"
+  "generated_hash": "9590a94eca1c89ac68b56d504c7e6730bd3daab95c10f05aa95ba894493fb788"
 }

--- a/skills-codex/learn/SKILL.md
+++ b/skills-codex/learn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: learn
-description: Optionally analyze collections of durable
+description: 'Optionally analyze collections of durable Triggers: "learn from verdicts", "mine validation history".'
 ---
 # Learn
 

--- a/skills-codex/ms/.agentops-generated.json
+++ b/skills-codex/ms/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/ms",
   "layout": "modular",
   "source_hash": "8634a28c128d80d574da339747315ed4af5e047081c20d7647f69d08f7c88e71",
-  "generated_hash": "95cad0eb98d21cf7c1124b387188ce35d8ea322377d46ef0f19642c6ffeecbf6"
+  "generated_hash": "871bf24cafda06ecb22a0f6e9d0e38a6a2fdd204a4f1c7f9fc9209bd8c11a7c0"
 }

--- a/skills-codex/ms/SKILL.md
+++ b/skills-codex/ms/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ms
-description: meta_skill (ms) — the skill-search/load
+description: 'meta_skill (ms) — the skill-search/load Triggers: "ms", "meta_skill", "skill search", "find a skill for", "load skill guidance".'
 ---
 <!-- TOC: Core Insight | Constraints | Quick Start | Consume (MCP) | Write/Admin (CLI) | Output | Production Skill Handoff | Footguns | Concurrency | Scenarios | Quality | References -->
 

--- a/skills-codex/ntm/.agentops-generated.json
+++ b/skills-codex/ntm/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/ntm",
   "layout": "modular",
   "source_hash": "848facd36e19091df95e562f631fb3c25cf73fc39ba1af999766412756b43151",
-  "generated_hash": "d87d9f9d8a12e4e1a9fdaf8dfbc5a1ac683a087733218988812ef4aa6fc6ac80"
+  "generated_hash": "d4bc77f68b1a9f80848762206d9f389b113a7f9f6a7bc160ecc3e7df3e052b05"
 }

--- a/skills-codex/ntm/SKILL.md
+++ b/skills-codex/ntm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ntm
-description: Use NTM as an optional pane adapter for
+description: 'Use NTM as an optional pane adapter for Triggers: "ntm", "tmux panes", "ntm robot state".'
 ---
 # NTM — optional pane adapter
 

--- a/skills-codex/operationalize/.agentops-generated.json
+++ b/skills-codex/operationalize/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/operationalize",
   "layout": "modular",
   "source_hash": "d20938af6747bd483a0ae1d4418bf2382714ca145986f5d0410cc15873f7ea09",
-  "generated_hash": "99f66711ef2775e6a464750998407295e542264ba8c86b34bfd4c6f8a5f5484b"
+  "generated_hash": "9a4ffe1b16da81916f02d457b9c5505f773d0adfa1b898f7d9865d64d0f0f5c9"
 }

--- a/skills-codex/operationalize/SKILL.md
+++ b/skills-codex/operationalize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: operationalize
-description: Distill repeated, evidence-backed expertise
+description: 'Distill repeated, evidence-backed expertise Triggers: "operationalize this", "turn this expertise into a reusable capability".'
 ---
 # Operationalize
 

--- a/skills-codex/pattern-mining/.agentops-generated.json
+++ b/skills-codex/pattern-mining/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/pattern-mining",
   "layout": "modular",
   "source_hash": "b35118568b471c41e0a9b68e8aedb0491553ba26fc348014f52e4a0939e531b5",
-  "generated_hash": "ebea87d16f82ab1699283479826ab0d427d56b2ebd1f920fbb79660e06cb8769"
+  "generated_hash": "11fbe805050cb4ccf39da01ef1ae0d88c38150f8067ecb5700472b51756e0dd6"
 }

--- a/skills-codex/pattern-mining/SKILL.md
+++ b/skills-codex/pattern-mining/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pattern-mining
-description: Test repeated implementation shapes against
+description: 'Test repeated implementation shapes against Triggers: "mine a recurring code pattern", "is this abstraction earned", "extract invariants from implementations".'
 ---
 # Pattern Mining
 

--- a/skills-codex/plan/.agentops-generated.json
+++ b/skills-codex/plan/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/plan",
   "layout": "modular",
   "source_hash": "6133824e806dd44f5c3fcfec39ed46251d951802d573e16fb02ffac9074e23aa",
-  "generated_hash": "4144d7daa581c0352c5cb4231363bd19e99dd4a53dfe1a8daa9baee1a72d8d41"
+  "generated_hash": "72fae8db7fb2635e3a2d536b28b8314c75c3e0b5610c17fbeccd38d39811f580"
 }

--- a/skills-codex/plan/SKILL.md
+++ b/skills-codex/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: Shape or refine the existing bead or caller
+description: 'Shape or refine the existing bead or caller Triggers: "plan", "discover and plan", "shape this goal".'
 ---
 # Plan
 

--- a/skills-codex/postmortem/.agentops-generated.json
+++ b/skills-codex/postmortem/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/postmortem",
   "layout": "modular",
   "source_hash": "e1b37de32fb537d06ecc56a1801b3eee3ae9b7574718eaf6048fe470d3fc285b",
-  "generated_hash": "55cc73eba32d0f60b6d8fa6707f8566de3393716345f7be558e08219cfbfe339"
+  "generated_hash": "51cc9e5ac630d8c070ce0152ed3776f2db25bd09859411aa891bd360bed05fe0"
 }

--- a/skills-codex/postmortem/SKILL.md
+++ b/skills-codex/postmortem/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: postmortem
-description: Optionally test a retrospective causal
+description: 'Optionally test a retrospective causal Triggers: "postmortem", "causal retrospective", "test a retrospective hypothesis".'
 ---
 # Postmortem
 

--- a/skills-codex/premortem/.agentops-generated.json
+++ b/skills-codex/premortem/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/premortem",
   "layout": "modular",
   "source_hash": "e882fd13bb037adec58b7484ddd34477cf882f088169dbac2225e04d532195dd",
-  "generated_hash": "20ba86016b8b2b6c40f48a15766f847a4677f1e59f9373aa54f614104d72a617"
+  "generated_hash": "bb365fd13d085c76b90eb3cc75fcce5e7c30dc65735956739ea67b40000d8170"
 }

--- a/skills-codex/premortem/SKILL.md
+++ b/skills-codex/premortem/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: premortem
-description: Optionally challenge a frozen plan with one
+description: 'Optionally challenge a frozen plan with one Triggers: "premortem", "challenge this plan", "what could make this plan fail".'
 ---
 # Premortem
 

--- a/skills-codex/product/.agentops-generated.json
+++ b/skills-codex/product/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/product",
   "layout": "modular",
   "source_hash": "0415ea5bf6e58cf21a31b9672dd6e2c18832536bf803814b9964f460d9b63e86",
-  "generated_hash": "b4c4023dda45c6f08cbe4db1d10f090bb78ce2a7b5f84e3f04b8133707c40b12"
+  "generated_hash": "318e57dbda4f8e2a4afd6494b20c648bb3c98a62451671f346dff93f6d177e9a"
 }

--- a/skills-codex/product/SKILL.md
+++ b/skills-codex/product/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: product
-description: Create or refine PRODUCT.md while separating
+description: 'Create or refine PRODUCT.md while separating Triggers: "product", "create PRODUCT.md", "product boundary".'
 ---
 # Product
 

--- a/skills-codex/rch/.agentops-generated.json
+++ b/skills-codex/rch/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/rch",
   "layout": "modular",
   "source_hash": "3af677e66c6a1ed663e733461d9153922b7dd6123bc011fbae9bc831a2d3c2c1",
-  "generated_hash": "bb6606aa0c44726a8f67021fbe6bdf767ca31773e57fc274201f7ae32f51b42a"
+  "generated_hash": "8983f1db7849b8517017ee1aa23f25bee8c473d08138c011d282cd92a9119c21"
 }

--- a/skills-codex/rch/SKILL.md
+++ b/skills-codex/rch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rch
-description: Use RCH once to offload a build or collect
+description: 'Use RCH once to offload a build or collect Triggers: "use RCH", "offload this build".'
 ---
 # RCH — remote compilation specialist
 

--- a/skills-codex/reality-check/.agentops-generated.json
+++ b/skills-codex/reality-check/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/reality-check",
   "layout": "modular",
   "source_hash": "d79b843f8f6cc71d3fbe08b8ba6db458c9d886763750a38b2bc29fa8a505fc56",
-  "generated_hash": "2efce800c15a5c024a58cfe9dc1bb33c41dbaac9e0840f0661dbc00dd68153a5"
+  "generated_hash": "b4097981ff6741acdfbef3096eed9d3173836b7ba760359bc5a92244a988c83d"
 }

--- a/skills-codex/reality-check/SKILL.md
+++ b/skills-codex/reality-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reality-check
-description: Compare a claimed state with observable
+description: 'Compare a claimed state with observable Triggers: "reality check", "is this claim actually done", "compare claim to repo".'
 ---
 # Reality Check
 

--- a/skills-codex/refactor/.agentops-generated.json
+++ b/skills-codex/refactor/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/refactor",
   "layout": "modular",
   "source_hash": "19aededa001917f28711593f30a0a01f2c9d6218db189abf5148535c51152098",
-  "generated_hash": "8586c4c6bd56e9b30189255e7e81d883de1c5e6c4da90001622cfe6779a94a40"
+  "generated_hash": "da7627f940e456ce983eb10cb0ebf8ef7eef2aa9f78339fc1cd18777cef13c66"
 }

--- a/skills-codex/refactor/SKILL.md
+++ b/skills-codex/refactor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refactor
-description: Execute one behavior-preserving structural
+description: 'Execute one behavior-preserving structural Triggers: "refactor this", "simplify without changing behavior".'
 ---
 # Refactor — one structural experiment
 

--- a/skills-codex/research/.agentops-generated.json
+++ b/skills-codex/research/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/research",
   "layout": "modular",
   "source_hash": "adba28d813cad60df3f1e389eed9d750cd4845ff44ef0f3e79666bc55d4e36ad",
-  "generated_hash": "15b02e785eba49d182bb1866edeb06ff28d6495110a3b62681a4da1746e1ec6e"
+  "generated_hash": "033ce223a5d0c5ada5c5348ab85e92c64cae44ea52428af785abc6e524ecd9de"
 }

--- a/skills-codex/research/SKILL.md
+++ b/skills-codex/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: Answer a bounded question with current cited
+description: 'Answer a bounded question with current cited Triggers: "research", "investigate this question", "find evidence". (Investigating a repository routes to codebase-recon.)'
 ---
 # Research
 

--- a/skills-codex/reverse-engineer/.agentops-generated.json
+++ b/skills-codex/reverse-engineer/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/reverse-engineer",
   "layout": "modular",
   "source_hash": "c4c1d351deda610d6a848b31aca64559d603d065b719a1a91cda3504d7ede98a",
-  "generated_hash": "e2330646793a9d980ebed4a2d10438ebef90ae790265520a10595192f3e564e8"
+  "generated_hash": "996489a23ad67969ef19b303aa74d051069aa2946c68125d4b9d9b387c7e6ff6"
 }

--- a/skills-codex/reverse-engineer/SKILL.md
+++ b/skills-codex/reverse-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reverse-engineer
-description: Reverse-engineer an authorized repo, binary
+description: 'Reverse-engineer an authorized repo, binary Triggers: "reverse-engineer X", "tear down Y", "what should we steal from Z", "evaluate competitor/upstream", "should we fork/adopt/build-native".'
 ---
 # Reverse Engineer
 

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/rpi",
   "layout": "modular",
   "source_hash": "4870c343799f313706c7928b59d3b55cb2b4f8bd34b972dddf57e4859b999695",
-  "generated_hash": "20c93a0cbd9f0a5a3cae66f7afdc4a8c06c4b628886508bd127aabdd4c4bb266"
+  "generated_hash": "19890dc9ca1af9d8585c9b91d792c378c148824c538ff6fce3eee1f75cb28f7f"
 }

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rpi
-description: 'Coordinate one RPI traversal: one bounded'
+description: 'Coordinate one RPI traversal: one bounded Triggers: "run rpi", "run one traversal", "execute this plan", orchestration or worker delegation that implements changes.'
 ---
 # RPI
 

--- a/skills-codex/sbh/.agentops-generated.json
+++ b/skills-codex/sbh/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/sbh",
   "layout": "modular",
   "source_hash": "1e938f203fc92290da03306ad803586159748d4d69c0aa4748f0af8864d7f9f4",
-  "generated_hash": "55e22b4db1245feab5a38ab8c571b77ad435047e2511d132e4c4b179f03a4fc9"
+  "generated_hash": "0020dd0d27506322c401b0f5e0237e63864d0877a27e01c4af18cf5d323be62e"
 }

--- a/skills-codex/sbh/SKILL.md
+++ b/skills-codex/sbh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sbh
-description: Inspect disk pressure with SBH and run one
+description: 'Inspect disk pressure with SBH and run one Triggers: "check disk pressure", "run SBH".'
 ---
 # SBH — storage pressure specialist
 

--- a/skills-codex/scaffold/.agentops-generated.json
+++ b/skills-codex/scaffold/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/scaffold",
   "layout": "modular",
   "source_hash": "3842025470fcf184e2fd96f7306f14de37b67864a42d8021f33f953bb76afce6",
-  "generated_hash": "9452dce2fd5026b986db3ca03cbc503dcf499b09dca909a6cbe8b8d025d9e57a"
+  "generated_hash": "8cceff6c3efe7b430ed733462245e8af93cdc21f6493e3f0145b377006985297"
 }

--- a/skills-codex/scaffold/SKILL.md
+++ b/skills-codex/scaffold/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scaffold
-description: Stamp a bounded project, component, or CI
+description: 'Stamp a bounded project, component, or CI Triggers: "scaffold", "create project component or boilerplate".'
 ---
 # Scaffold
 

--- a/skills-codex/scope/.agentops-generated.json
+++ b/skills-codex/scope/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/scope",
   "layout": "modular",
   "source_hash": "a710df7df3c89ac7cf0416cb8dc4bc1ab63ab11e730bafb23f5682243b6ac128",
-  "generated_hash": "41b71b9c7b1e4978a47810199f1886d75ee5e6b6b8415a156d04cd7bc2093816"
+  "generated_hash": "f96abc9efe2c81149e74a7eaa9674ad879b2ae8ade49c30250970bdf7141e8d4"
 }

--- a/skills-codex/scope/SKILL.md
+++ b/skills-codex/scope/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scope
-description: Review the bead or caller intent write scope
+description: 'Review the bead or caller intent write scope Triggers: "review write scope", "check scope boundaries", "scope this change".'
 ---
 # Scope — Review a proposed write scope
 

--- a/skills-codex/security/.agentops-generated.json
+++ b/skills-codex/security/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/security",
   "layout": "modular",
   "source_hash": "183e3eb73292146855adbd10765ac0bee41f35a745900908f47573e317b20ab2",
-  "generated_hash": "0f1b44f2688511728dfcca04eadaf30b701ee17f2896e940d0a0e66ca39d22da"
+  "generated_hash": "bc6d8a3bcfff9170fe070b0c425a926a1c32539818cf589c0739a741df9ea2aa"
 }

--- a/skills-codex/security/SKILL.md
+++ b/skills-codex/security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security
-description: Run authorized repository security scans for
+description: 'Run authorized repository security scans for Triggers: "security", "run repository security scans for", "security skill".'
 ---
 # Security Skill
 

--- a/skills-codex/shared/.agentops-generated.json
+++ b/skills-codex/shared/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/shared",
   "layout": "modular",
   "source_hash": "0e093accb57d583bc53556923e6e6f3110e96d122dc43b90b6ebfcc9711821b0",
-  "generated_hash": "0feead7579441b8286e69bab8c0b9e4ce90dd3dc6009e57f24693ac3ff314f51"
+  "generated_hash": "9a66038526a8eb2971c1c5ae0655d35a9ce48aea7cc15c301c1d956a1b745e6d"
 }

--- a/skills-codex/shared/SKILL.md
+++ b/skills-codex/shared/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shared
-description: Retired — its runtime-neutrality contract
+description: 'Retired — its runtime-neutrality contract Triggers: none — not routable.'
 ---
 # Shared — retired
 

--- a/skills-codex/skill-builder/.agentops-generated.json
+++ b/skills-codex/skill-builder/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/skill-builder",
   "layout": "modular",
   "source_hash": "b500ca18d663bf8b11a4bfa4c27ba82f8335f73560212a81d003e7eff4b68d3a",
-  "generated_hash": "d42c6cee0783ec810a8a9723bd606770d2f52587438894a4143035d7d31b03a8"
+  "generated_hash": "35c9ee3b875f16800f2cd6a10f9ee1fbc9958792bd67f88589d00cf4853fd1e6"
 }

--- a/skills-codex/skill-builder/SKILL.md
+++ b/skills-codex/skill-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-builder
-description: Create a metadata-complete AgentOps skill
+description: 'Create a metadata-complete AgentOps skill Triggers: "create a skill", "scaffold skill", "absorb external skill", "new skill", "heal skill", "repair skill hygiene", "audit skill structure", "check skill package".'
 ---
 # Skill Builder — Create, heal, and audit skill packages
 

--- a/skills-codex/standards/.agentops-generated.json
+++ b/skills-codex/standards/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/standards",
   "layout": "modular",
   "source_hash": "d493ba253d8eaafcd19c3e62b98328a535f3a8d9720bd17a144fa77b1c369268",
-  "generated_hash": "bec8e7c8b82b76ea771c6264783e4561e7d9eec61f52a7415e196f018cc8de2c"
+  "generated_hash": "db544dc9cea88e8a1cdd7051bb611dec3f46c13095a1ba1df8178021abbf33a7"
 }

--- a/skills-codex/standards/SKILL.md
+++ b/skills-codex/standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: standards
-description: Load only the standards relevant to a
+description: 'Load only the standards relevant to a Triggers: "check standards", "which standards apply".'
 ---
 # Standards — focused engineering guidance
 

--- a/skills-codex/status/.agentops-generated.json
+++ b/skills-codex/status/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/status",
   "layout": "modular",
   "source_hash": "e53d8400425c9bf1fb3d3e944fa81fa6d388c7dc1d57e045d0f49c2b606f5923",
-  "generated_hash": "789321c0ed3d849ff54f888943796fab966a4a1a86109e512a1d6c68cab8bec8"
+  "generated_hash": "f18f5d3aeafe2db1329128545547bd925c47c9093f06928576757fc6553d66ec"
 }

--- a/skills-codex/status/SKILL.md
+++ b/skills-codex/status/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: status
-description: Report observable AgentOps evidence without
+description: 'Report observable AgentOps evidence without Triggers: "status", "show AgentOps status".'
 ---
 # Status
 

--- a/skills-codex/swarm/.agentops-generated.json
+++ b/skills-codex/swarm/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/swarm",
   "layout": "modular",
   "source_hash": "258d63e5499e210003605b6947841913131094a0015d21ab27c8281973364be2",
-  "generated_hash": "cf023c0baac3989aaf2ea69fd19dfdc4fdd0b4f2392dcb6209d5e51f2b1e8afc"
+  "generated_hash": "4cd3f5a682d31d463b4b7c8505e118dd7a9b1e255e2b770d0a5311da11cce247"
 }

--- a/skills-codex/swarm/SKILL.md
+++ b/skills-codex/swarm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swarm
-description: Dispatch explicit disjoint packets exactly
+description: 'Dispatch explicit disjoint packets exactly Triggers: "swarm", "dispatch disjoint packets", "parallel explicit tasks".'
 ---
 # Swarm
 

--- a/skills-codex/test/.agentops-generated.json
+++ b/skills-codex/test/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/test",
   "layout": "modular",
   "source_hash": "c074c59a2e4ccae27f2a4f514b9e5a16a6d87465be8429405878e0641ec5d096",
-  "generated_hash": "be6eb93094d43ee18b0d87412661e0cc08724fa3d64e0724c0dd908dfa9dca22"
+  "generated_hash": "0f5b0f731e595e2fed396631a49f429654ea17060ab515c5d0896c03be82063d"
 }

--- a/skills-codex/test/SKILL.md
+++ b/skills-codex/test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test
-description: Generate tests and coverage plans.
+description: 'Generate tests and coverage plans. Triggers: "test", "generate tests and coverage plans.", "test skill".'
 ---
 # Test Skill
 

--- a/skills-codex/toil-mining/.agentops-generated.json
+++ b/skills-codex/toil-mining/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/toil-mining",
   "layout": "modular",
   "source_hash": "a95c554be75d0791eb71bad60bee508807d50af96006480d5bbface2611a8691",
-  "generated_hash": "11d4272652686c2da5ff11e15e510f5e56f30e5fc3f9dd2414dced0a00055f12"
+  "generated_hash": "3b27e8e26657132ab1f8da85dddf71a966c82b136bea49dfbe353ff2c9a6a6f9"
 }

--- a/skills-codex/toil-mining/SKILL.md
+++ b/skills-codex/toil-mining/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: toil-mining
-description: Mine caller-supplied usage history for
+description: 'Mine caller-supplied usage history for Triggers: "mine toil", "find repeated operational work".'
 ---
 # Toil Mining — rank repeated friction
 

--- a/skills-codex/using-flywheel/.agentops-generated.json
+++ b/skills-codex/using-flywheel/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/using-flywheel",
   "layout": "modular",
   "source_hash": "876ddaec0998ca32f917b49101ffaed1248ac1c676deb985914efaea342cbae5",
-  "generated_hash": "ccc09a1240f753a136cf1e337d60ebd03c7dc705224720a1421dbedc7452d797"
+  "generated_hash": "d6a50c7e61769ac7f211b05e90ef01015d9b2f58a64df10bf91816dbc7fe5ff8"
 }

--- a/skills-codex/using-flywheel/SKILL.md
+++ b/skills-codex/using-flywheel/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-flywheel
-description: Operate the Agentic Coding Flywheel as a
+description: 'Operate the Agentic Coding Flywheel as a Triggers: "using flywheel", "agent flywheel".'
 ---
 # Using the Agentic Coding Flywheel
 

--- a/skills-codex/using-gc/.agentops-generated.json
+++ b/skills-codex/using-gc/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/using-gc",
   "layout": "modular",
   "source_hash": "bf15cd25cc11a2778b434ecefe9fa4c1d46f08d6162a367a2ec348e231e9fd8f",
-  "generated_hash": "e4e3061d249cba8be354ad8d15427b2d7f3faf7885307d6dd8c8a0ae8e35d149"
+  "generated_hash": "210d8193303b5e58a56e83ceebf81c7eeed359ba97d8eed453a1429c25971a8f"
 }

--- a/skills-codex/using-gc/SKILL.md
+++ b/skills-codex/using-gc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-gc
-description: Operate a caller-selected Gas City 1.4 with
+description: 'Operate a caller-selected Gas City 1.4 with Triggers: "using gc", "gas city", "drive the mayor", "dispatch through gc".'
 ---
 # Using GC
 

--- a/skills-codex/validate/.agentops-generated.json
+++ b/skills-codex/validate/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/validate",
   "layout": "modular",
   "source_hash": "dc2ed6796e1fa59e9d1436eca4fcb4741a54b426e10b6eec0de5395f28cf42a4",
-  "generated_hash": "0354e7edaa3ea858641734c9c82dd13bc39b2732909295346a7b90ee1e4891aa"
+  "generated_hash": "fd41631f52f8c9c2311b1dfb86035c6782d53ccefde4453f7978ebb8c11d3b12"
 }

--- a/skills-codex/validate/SKILL.md
+++ b/skills-codex/validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validate
-description: Freshly judge exact subject content against
+description: 'Freshly judge exact subject content against Triggers: "validate", "independently validate", "vibe".'
 ---
 # Validate
 

--- a/skills-codex/workflow-builder/.agentops-generated.json
+++ b/skills-codex/workflow-builder/.agentops-generated.json
@@ -3,5 +3,5 @@
   "source_skill": "skills/workflow-builder",
   "layout": "modular",
   "source_hash": "e5c1e9bb10ea95138d53aa7071b3d6cee41c34cfde323efc4ceda5b21a6f93ee",
-  "generated_hash": "30f72769961a244749883e03cb04e329cd0feb03dd5b641d2a73a2e5dc8e9d42"
+  "generated_hash": "386479200813515ba0a1d5fe7b9a7406037a62daaa5419aa7471310b221712f9"
 }

--- a/skills-codex/workflow-builder/SKILL.md
+++ b/skills-codex/workflow-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-builder
-description: Scaffold an explicit one-shot workflow
+description: 'Scaffold an explicit one-shot workflow Triggers: "build a workflow adapter", "scaffold a one-shot workflow".'
 ---
 # Workflow Builder — one-shot adapter authoring
 

--- a/tests/scripts/codex-portable-conformance.bats
+++ b/tests/scripts/codex-portable-conformance.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  GATE="$REPO_ROOT/scripts/validate-codex-api-conformance.sh"
+  FIXTURE_ROOT="$BATS_TEST_TMPDIR/skills-codex"
+  mkdir -p "$FIXTURE_ROOT/portable-skill"
+}
+
+write_skill() {
+  printf '%s' "$1" > "$FIXTURE_ROOT/portable-skill/SKILL.md"
+}
+
+@test "checked-in Codex release projection is portable" {
+  run bash "$GATE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS [portable] 52 package(s)"* ]]
+}
+
+@test "portable gate accepts the minimal Agent Skills package" {
+  write_skill $'---\nname: portable-skill\ndescription: Use when a portable fixture is needed.\n---\n# Portable skill\n'
+
+  run env CODEX_SKILLS_ROOT="$FIXTURE_ROOT" bash "$GATE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS [portable] 1 package(s)"* ]]
+}
+
+@test "portable gate rejects host-only frontmatter" {
+  write_skill $'---\nname: portable-skill\ndescription: Use when a portable fixture is needed.\noutput_contract: result.v1\n---\n# Portable skill\n'
+
+  run env CODEX_SKILLS_ROOT="$FIXTURE_ROOT" bash "$GATE"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"host-only frontmatter fields: output_contract"* ]]
+}
+
+@test "portable gate rejects non-string metadata and comma-delimited tools" {
+  write_skill $'---\nname: portable-skill\ndescription: Use when a portable fixture is needed.\nmetadata:\n  effects: [write]\nallowed-tools: Read, Grep\n---\n# Portable skill\n'
+
+  run env CODEX_SKILLS_ROOT="$FIXTURE_ROOT" bash "$GATE"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"metadata must map strings to strings"* ]]
+  [[ "$output" == *"allowed-tools must be a nonempty space-separated string"* ]]
+}
+
+@test "portable gate rejects missing and escaping resource links" {
+  write_skill $'---\nname: portable-skill\ndescription: Use when a portable fixture is needed.\n---\n# Portable skill\n[missing](references/missing.md)\n[escape](../../../../outside.md)\n'
+
+  run env CODEX_SKILLS_ROOT="$FIXTURE_ROOT" bash "$GATE"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"resource link does not resolve"* ]]
+  [[ "$output" == *"resource link escapes catalog"* ]]
+}
+
+@test "portable gate rejects a missing image resource" {
+  write_skill $'---\nname: portable-skill\ndescription: Use when a portable fixture is needed.\n---\n# Portable skill\n![diagram](assets/missing.png)\n'
+
+  run env CODEX_SKILLS_ROOT="$FIXTURE_ROOT" bash "$GATE"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"resource link does not resolve: SKILL.md -> assets/missing.png"* ]]
+}
+
+@test "portable gate rejects a symlinked package" {
+  write_skill $'---\nname: portable-skill\ndescription: Use when a portable fixture is needed.\n---\n# Portable skill\n'
+  external="$BATS_TEST_TMPDIR/external"
+  mkdir -p "$external"
+  printf '%s' $'---\nname: linked-skill\ndescription: Use when a linked fixture is needed.\n---\n# Linked skill\n' > "$external/SKILL.md"
+  ln -s "$external" "$FIXTURE_ROOT/linked-skill"
+
+  run env CODEX_SKILLS_ROOT="$FIXTURE_ROOT" bash "$GATE"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"skill package directory must not be a symlink"* ]]
+}
+
+@test "portable gate rejects duplicate frontmatter keys" {
+  write_skill $'---\nname: wrong-name\nname: portable-skill\ndescription: Use when a portable fixture is needed.\n---\n# Portable skill\n'
+
+  run env CODEX_SKILLS_ROOT="$FIXTURE_ROOT" bash "$GATE"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"found duplicate key"* ]]
+}

--- a/tests/scripts/test-codex-sync-generator.sh
+++ b/tests/scripts/test-codex-sync-generator.sh
@@ -119,6 +119,15 @@ fm_fields="$(awk 'NR==1&&/^---$/{f=1;next} f&&/^---$/{exit} f{print}' "$TWIN_DIR
 [[ -z "$fm_fields" ]] && pass "twin frontmatter is name+description only" \
   || fail "twin frontmatter has stray fields: $fm_fields"
 
+grep -q 'Triggers: "zzz codex sync accept probe"' "$TWIN_DIR/SKILL.md" 2>/dev/null \
+  && pass "twin catalog preserves the source activation trigger" \
+  || fail "twin catalog discarded or truncated the source activation trigger"
+
+generated_description="$(awk '/^description:/{print; exit}' "$TWIN_DIR/SKILL.md")"
+[[ "$generated_description" != *"acceptance test."* ]] \
+  && pass "twin catalog compacts prose before the trigger" \
+  || fail "twin catalog left pre-trigger prose above its target: $generated_description"
+
 # Registered in the gate-enforced 1:1 surface.
 if jq -e --arg n "$PROBE" '.skills[]|select(.name==$n)' "$OVERRIDES" >/dev/null; then
   pass "registered in skills-codex-overrides/catalog.json"


### PR DESCRIPTION
## What changed

- preserve canonical trigger text while compacting generated Codex descriptions
- harden portable skill validation for duplicate YAML keys, symlink containment, and current optional-field rules
- regenerate all owned Codex projections and hashes
- add focused negative and generator regression coverage

## Verification

- portable conformance: 52/52
- portable Bats: 8/8
- generator acceptance: 18/18
- `scripts/regen-all.sh --check`
- Bash syntax, blocking ShellCheck, and `git diff --check`

The interrupted all-skills remediation snapshot is deliberately excluded: it remains preserved on `codex/all-skills-pass-20260816` and is not merge-safe.