### PR TITLE
3.6.0 release prep: version bumps, changelog, curated notes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "The operations layer for agentic engineering: portable skills and evidence contracts connecting intent, coding agents, software factories, and independent judgment.",
-    "version": "3.5.0"
+    "version": "3.6.0"
   },
   "plugins": [
     {
       "name": "agentops",
       "description": "The operations layer for agentic engineering: portable skills and evidence contracts connecting intent, coding agents, software factories, and independent judgment.",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "source": "./",
       "author": {
         "name": "Boden Fuller",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentops",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "The operations layer for agentic engineering: portable skills and evidence contracts connecting intent, coding agents, software factories, and independent judgment.",
   "author": {
     "name": "Boden Fuller",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentops",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "The operations layer for agentic engineering: portable skills and evidence contracts connecting intent, coding agents, software factories, and independent judgment.",
   "skills": "./skills-codex",
   "interface": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,31 +7,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Removed
+## [3.6.0] - 2026-08-17
 
-- The consumer-free `dream:` config block (the retired overnight subsystem's
-  settings; existing config files still parse and the key is ignored), the
-  vacuous retrieval-quality canary and its smoke (every Go test it named was
-  already deleted; the retrieval-comparison contract is now explicitly
-  dormant and the blocking manifest-paths gate remains the live retrieval
-  guard), and the dormant `check-pillar-coverage.sh` GOALS.yaml script.
-  Remaining scratch-tier writers (`mine-all-sessions.sh`, `team-runner.sh`,
-  `bin/ralph`) now write under `.agents/scratch/`.
+AgentOps 3.6 is the **operations-layer alignment** release, and most of the
+alignment was deletion. The product is now stated one way on every surface that
+reads it: AgentOps is the operations layer for agentic engineering, the topology
+is a federated integration graph, the interoperability contract is the semantic
+work-and-proof protocol, and the standard path is one RPI traversal (Plan,
+Implement, fresh Validate, report and stop). The knowledge-flywheel product
+surface is gone — command family, app package, build profile, gates, config
+block — the seven-move operating-loop workflow is a tombstone, `.agents/`
+writers are narrowed to declared destinations, and 25 skills plus every
+generated projection were realigned against the operating contract.
 
-- The `ao flywheel` command family (`status`, `compare`) and the whole live
-  knowledge-flywheel product surface: `cli/internal/flywheelapp`, the
-  flywheel-only metric helpers and types, the `flywheel` build-profile bit,
-  the `flywheel-compounding` gate scripts, and the `flywheel:` config block
-  (existing config files still parse; the key is ignored). AgentOps no longer
-  computes or reports knowledge-compounding state (`COMPOUNDING`, `DECAYING`,
-  escape velocity). Invoking `ao flywheel` now fails with a migration pointer
-  (see `docs/MIGRATION.md`). Learning remains an optional off-path consumer of
-  durable verdicts via the `learn` skill. The compatibility baseline records
-  the family as intentionally `retired` rather than freezing the old product
-  claim.
+Two enforcement layers ride on top. Anti-ceremony guardrails fail closed when a
+process artifact cannot name its consumer, its decision, the observed defect,
+and its retirement condition, and `rpi` runs that STOP/CONTINUE guard once
+before Plan. The eval program gives the skill harness measurement instead of
+self-report: a 12-decision eval architecture, a probe harness with a fail-closed
+v3 evidence contract, routing probes, a tier-2 flawed-plan corpus with hidden
+holdout scoring, and estate ablation sweeps whose predictions were registered
+before the runs. That same evidence contract is why measured probe coverage now
+reads an honest 0/12 — the earlier wave-1 classifications are retained as
+`LEGACY-UNVERIFIED` rather than counted.
 
 ### Added
 
+- The `anti-ceremony` skill: a clean-room, artifact-free STOP/CONTINUE guard
+  over the creation gate — name the consumer, the decision it gates, the
+  observed defect, and the retirement condition, or do not create it. `rpi`
+  takes it as a hard dependency and invokes it exactly once before Plan. On STOP
+  it dispatches no core phase and reports `NOT_PLANNED` with the guard's reason;
+  on CONTINUE the full Plan, Implement, fresh Validate path runs unchanged.
+  AgentOps now fails closed when process artifacts are manufactured, when GREEN
+  comes from weakening the oracle, and when repeated control artifacts replace
+  implementation evidence.
+- `ao session prune-agents` applies `.agents` retention policies from Go. It is
+  a read-only dry run by default; `--execute` mutates and `--quiet` prints only
+  the summary. The global `--dry-run` seam always wins over `--execute`.
+  `scripts/prune-agents.sh` becomes a compatibility wrapper.
+- `ao gc prepare` pre-seeds Codex trust for materialized Gas City session homes.
+  Codex persists two independent decisions in `$CODEX_HOME/config.toml` —
+  workspace trust under `[projects."<dir>"]` and one Codex-owned content hash
+  per hook under `[hooks.state."<hook-key>"]` — and trusting a parent directory
+  does not trust a session home. Hook identities and hashes come from Codex's
+  own `hooks/list` app-server method rather than being reimplemented. Without
+  this, the first Codex process in a fresh home could sit on the interactive
+  trust dialog with a live pane that can never take dispatched work. `ao gc
+  prepare` and `ao gc check` take `--codex-bin` to name the Codex CLI; the
+  default is `codex` on PATH.
+- The eval program for the skill harness: a 12-decision eval architecture
+  (`docs/architecture/eval-architecture.md`) and the probe harness that runs
+  control-versus-treatment behavioral probes and records replayable scorecards
+  (`bash scripts/probe-skill.sh --probe <id> --replay`).
+- Routing probes measure P(skill loaded | applicable task), the multiplier every
+  skill-efficacy number depends on. Committed scenarios are templates with
+  dispatch-time instantiation so an agent cannot read the fixture off disk and
+  contaminate the run. Task-noun skills route and judgment-posture skills do
+  not; the Codex runtime routed 4/4 against 2/6 for Claude-in-repo, because
+  `.claude/rules` auto-load already delivers the content without routing.
+- A tier-2 task-embedded corpus of flawed-plan execution fixtures with hidden
+  holdout tests injected only at scoring, across four live flaw classes (quiet
+  edge, vacuous green, burned compatibility bridge, opaque sentinel errors). The
+  scorer emits `visible_pass`, `hidden_pass`, `claimed_done`, `false_pass`, and
+  `flagged_gap`, and its selftest against planted references caught a real
+  scorer bug before any spend.
+- Estate ablation sweeps that apply delete-everything-and-measure-what-returns
+  to this repository's own estate, with predictions registered before results.
+- A dual-case anti-ceremony behavior probe that separates a justified process
+  artifact from an unjustified one, with its discriminator under test.
 - Between-releases release-path smoke: `.github/workflows/release-path-smoke.yml`
   runs a full GoReleaser snapshot (`goreleaser release --snapshot --clean
   --skip=publish`) nightly and on every change to a release-plumbing input
@@ -42,6 +86,147 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.goreleaser.yml` before-hook stayed broken for 20 days. The smoke and its
   negative witness share one script (`tests/scripts/lib/release-snapshot-smoke.sh`,
   proven able to fail by `tests/scripts/release-path-smoke.bats`).
+- `reverse-engineer` ships an output validator and a self-test, so its artifacts
+  are checked by an executable rather than by assertion.
+- `docs/contracts/ubiquitous-language.md` gains the product-architecture
+  vocabulary and four forbidden conflations, including that check success is not
+  a semantic PASS and that runtime completion is not validation.
+- `docs/reference/skill-system-evolution.md` traces the skill system across
+  releases, names seven evolution regimes, diagrams the present authority graph,
+  and records falsifiable predictions.
+- The canonical bd project identity is tracked at `.beads/identity.toml`, so
+  project identity travels with the repository instead of being reconstructed
+  per checkout.
+
+### Changed
+
+- The core architecture page is `docs/architecture/rpi-traversal.md`, with a
+  compatibility redirect left at the old operating-loop path.
+- Skill contracts match the operating contract. `rpi` preserves a durable
+  caller-owned intent source by reference and digest and snapshots bytes only
+  when no durable source exists. `automation-shape-routing` is advisory-only and
+  returns the chosen owner without copying or starting the delegated workflow.
+  `bootstrap` creates durable verdict storage and project docs only when
+  explicitly requested. `implement` and `swarm` return factual evidence instead
+  of implicitly revising or declaring semantic verdicts.
+- `ao init` scaffolds only the requested-proof stores that have declared
+  consumers: `.agents/ao/intents/sha256` and `.agents/ao/verdicts/sha256`. The
+  former session-transcript, search-index, provenance, and handoff directories
+  had no declared consumer and are no longer minted. The managed `.gitignore`
+  block now covers `.agents/scratch/`, `.agents/projections/`, and
+  `__pycache__/` instead of the retired knowledge-store paths.
+- `ao session handoff` writes JSON to `.agents/ao/handoff/` instead of
+  `.agents/handoff/`. `ao session rehydrate` searches both roots and selects the
+  newest lexical handoff id, with the canonical copy winning a filename tie. No
+  command moves or deletes the legacy files.
+- `codebase-recon` binds evidence to the exact Git commit its manifest declares.
+  Citations must be safe repository-relative regular files at that commit, a
+  supplied line number must exist in the committed blob, delta manifests must
+  match Git's own prior-to-current changed-path diff rather than a self-reported
+  boolean, and dirty tracked, staged, or untracked source outside `.agents/` is
+  refused. New packs default to `.agents/scratch/codebase-recon/<run-id>/`;
+  earlier packs stay where they are and remain discoverable.
+- `agent-mail` requires one mailbox owner and access mode per storage root, so
+  an HTTP/MCP daemon and the direct `am` CLI never contend for the same
+  database. A busy activity lock or bounded read timeout is a degraded adapter
+  result, not permission to restart the service or switch roots.
+- `status`, `using-flywheel`, and `using-gc` keep the state classes separate.
+  Factory-complete, checks-green, and AgentOps PASS are reported as three
+  different facts, never blended into one health claim.
+- The probe-coverage gate reads a hand-maintained ledger at
+  `evals/skill-probes/LEDGER.md` instead of the generated
+  `skills/SKILL-TIERS.md`, which a regeneration had silently wiped. A row counts
+  only if it names exactly one v3 scorecard whose fixture manifest, bound
+  inputs, prompt events, transcript hashes, canonical skill source,
+  non-overrideable runtime identity, reps, treatment mode, and recomputed
+  discriminator result all agree.
+- Cathedral-cut conformance scans linked skill references for retired identity
+  claims, with Markdown fence, raw-HTML, and percent-encoding handling so the
+  scan cannot be evaded by formatting.
+- `scripts/extract-release-notes.sh` reflows hard-wrapped curated notes into
+  logical Markdown lines before publishing, leaving headings, tables, code,
+  HTML, block quotes, and explicit hard breaks intact. GitHub's renderer
+  preserves soft line breaks, so copying the hard-wrapped source byte-for-byte
+  produced a narrow ragged column in the published release.
+- Handoff publishing is descriptor-anchored: it opens `.agents/ao/handoff` one
+  component at a time, refuses any component that is a symlink or not a real
+  directory, re-verifies that each opened descriptor still identifies the
+  component it inspected, and publishes by hard link rather than rename, so a
+  parent-directory swap mid-write cannot redirect the write and an existing
+  handoff id is never clobbered.
+- Prune path confinement runs traversal inside an `os.Root` with a final
+  current-path identity check immediately before each descriptor-rooted delete.
+  The contract states its own boundary honestly: intermediate-directory
+  traversal is bound, and it does not claim a final basename is immutable
+  against an adversarial replacement.
+- Portable Codex skill validation rejects duplicate YAML keys, enforces symlink
+  containment, and applies the current optional-field rules.
+- `AGENTS.md` is compressed against current-main evidence (about 10.5KB to
+  8.3KB) while preserving the honest-work and anti-ceremony doctrine, federated
+  source authority, the factory and concurrency boundaries, and the Triggered
+  Sources links that `validate-agents-split` requires. The estate-ablation
+  aggregate counts that motivated the trim are labeled legacy-unverified and
+  non-promotable.
+- ADR-0016 is amended for federated source authority and corrects an overclaim:
+  the three-directory `.agents/` layout is a target, not a currently enforced
+  closed set.
+- The Homebrew formula and the Codex plugin manifest state the operations-layer
+  identity instead of advertising a knowledge-flywheel CLI.
+- Dependencies: Go toolchain directive 1.26.5 to 1.26.6, `golang.org/x/text`
+  0.40.0 to 0.41.0, `github.com/santhosh-tekuri/jsonschema/v6` 6.0.2 to 6.0.3,
+  `github.com/BurntSushi/toml` 1.6.0 added for Codex `config.toml` handling, and
+  the pinned GitHub Actions digests refreshed.
+
+### Fixed
+
+- Generated Codex descriptions are compacted without dropping canonical trigger
+  text, so a compacted projection cannot lose the phrases that activate the
+  skill. All owned Codex projections and hashes were regenerated against that
+  rule (portable conformance 52/52).
+- Skill audit grades are evidence-honest: static readiness is scored and labeled
+  separately from measured safety and effectiveness, so a static score can no
+  longer be read as a behavioral one.
+- `ao doctor` Git-root detection no longer gets redirected by an empty or
+  otherwise invalid ancestor `.git` directory, which previously sent doctor
+  artifacts to the wrong place.
+- The eval command-surface fixture failed when it was actually executed: it
+  asserted `#{3,4}` where the surface produces `#{3,5}`. The fixture now matches
+  the real surface.
+- The bats lane provisions Python with jsonschema and PyYAML once, instead of
+  reinstalling PyYAML in a later job after `setup-python` shadowed the runner
+  interpreter.
+
+### Removed
+
+- The `ao flywheel` command family (`status`, `compare`) and the whole live
+  knowledge-flywheel product surface: `cli/internal/flywheelapp`, the
+  flywheel-only metric helpers and types, the `flywheel` build-profile bit, the
+  `flywheel-compounding` gate scripts, and the `flywheel:` config block
+  (existing config files still parse; the key is ignored). AgentOps no longer
+  computes or reports knowledge-compounding state (`COMPOUNDING`, `DECAYING`,
+  escape velocity). Invoking `ao flywheel` now exits 1 as an unknown command and
+  prints a migration pointer (see `docs/MIGRATION.md`). Learning remains an
+  optional off-path consumer of durable verdicts via the `learn` skill. The
+  compatibility baseline records the family as intentionally `retired` rather
+  than freezing the old product claim.
+- `plan` manifest mode, added in 3.5.0, along with its "plan manifest" trigger.
+  `plan` shapes one active behavior in the existing intent source; a
+  multi-behavior specification stays a document the caller owns.
+- The seven-move operating-loop workflow is a tombstone that fails with a
+  deterministic migration message instead of silently running retired doctrine.
+- The consumer-free `dream:` config block (the retired overnight subsystem's
+  settings; existing config files still parse and the key is ignored) and its
+  exclusive helpers, the vacuous retrieval-quality canary and the nightly job
+  that ran it (every Go test it named was already deleted; the
+  retrieval-comparison contract is now explicitly dormant and the blocking
+  manifest-paths gate remains the live retrieval guard), the dormant
+  `check-pillar-coverage.sh` GOALS.yaml script, `check-thesis-stability.sh`, and
+  `generate-index.sh`. Remaining scratch-tier writers (`mine-all-sessions.sh`,
+  `team-runner.sh`, `bin/ralph`) now write under `.agents/scratch/`. `bin/ralph`
+  still resumes legacy `.agents/ralph/` checkpoints, so the documented
+  backwards-compatibility contract holds without a migration.
+- The dated skill-quality audit report, which had no runtime consumer and bound
+  a superseded audit snapshot; all functional skill-quality changes stayed.
 
 ## [3.5.0] - 2026-07-31
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-07-14
+last_reviewed: 2026-08-17
 ---
 
 # AgentOps

--- a/cli/cmd/ao/main.go
+++ b/cli/cmd/ao/main.go
@@ -5,7 +5,7 @@ package main
 // version is set at build time via ldflags (goreleaser: -X main.version={{ .Version }}).
 // The fallback identifies untagged source builds for the next release;
 // published binaries override it from the release tag via GoReleaser.
-var version = "3.5.0"
+var version = "3.6.0"
 
 func main() {
 	Execute()

--- a/cli/cmd/ao/version_manifest_parity_test.go
+++ b/cli/cmd/ao/version_manifest_parity_test.go
@@ -1,0 +1,136 @@
+// practices: [continuous-delivery, supply-chain-integrity]
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// findReleaseManifestRoot walks up from the package directory looking for the
+// AgentOps repo root, identified by the co-presence of the Go module file and
+// the Claude plugin manifest. Both are tracked, so this works in a fresh clone.
+// Returns "" when the test is not running inside a checkout.
+func findReleaseManifestRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		_, modErr := os.Stat(filepath.Join(dir, "cli", "go.mod"))
+		_, pluginErr := os.Stat(filepath.Join(dir, ".claude-plugin", "plugin.json"))
+		if modErr == nil && pluginErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// jsonVersionAt walks a slash-separated path through a decoded JSON document
+// and returns the string found there. A numeric element indexes an array
+// (e.g. "plugins/0/version").
+func jsonVersionAt(doc any, path string) (string, bool) {
+	cur := doc
+	for _, seg := range strings.Split(path, "/") {
+		switch node := cur.(type) {
+		case map[string]any:
+			next, ok := node[seg]
+			if !ok {
+				return "", false
+			}
+			cur = next
+		case []any:
+			idx, err := strconv.Atoi(seg)
+			if err != nil || idx < 0 || idx >= len(node) {
+				return "", false
+			}
+			cur = node[idx]
+		default:
+			return "", false
+		}
+	}
+	s, ok := cur.(string)
+	return s, ok
+}
+
+// TestVersion_FallbackMatchesReleaseManifests guards the release-cut invariant
+// that every version-bearing release surface agrees with the checked-in
+// `version` fallback in main.go.
+//
+// This closes a real drift class, not a hypothetical one. At the 3.5.0 -> 3.6.0
+// cut, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`,
+// `.codex-plugin/plugin.json`, and `images/gemini/plugin.json` were bumped
+// while `images/claude/verify.sh`'s EXPECTED_VERSION default was missed. The
+// guard whose whole job is catching plugin.json drift behind the release then
+// rejected the CORRECT version, so a user following `images/claude/README.md`
+// on the shipped tag would have hit a hard FAIL. The
+// `check_manifest_version_consistency` step in `scripts/ci-local-release.sh`
+// compares only the two Claude manifests to each other, so it could not see
+// this.
+//
+// ldflags-injected git-describe builds are exempt: they carry a "-g<hash>"
+// commit segment or a "-dirty" suffix and are not the checked-in fallback.
+func TestVersion_FallbackMatchesReleaseManifests(t *testing.T) {
+	if strings.Contains(version, "-g") || strings.HasSuffix(version, "-dirty") {
+		t.Skipf("version %q is an ldflags-injected build-describe string, not the checked-in fallback", version)
+	}
+
+	root := findReleaseManifestRoot(t)
+	if root == "" {
+		t.Skip("not running inside an AgentOps checkout; no release manifests to compare")
+	}
+
+	jsonSurfaces := map[string][]string{
+		filepath.Join(".claude-plugin", "plugin.json"):      {"version"},
+		filepath.Join(".claude-plugin", "marketplace.json"): {"metadata/version", "plugins/0/version"},
+		filepath.Join(".codex-plugin", "plugin.json"):       {"version"},
+		filepath.Join("images", "gemini", "plugin.json"):    {"version"},
+	}
+	for rel, paths := range jsonSurfaces {
+		raw, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Errorf("release manifest %s is unreadable: %v", rel, err)
+			continue
+		}
+		var doc any
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			t.Errorf("release manifest %s is not valid JSON: %v", rel, err)
+			continue
+		}
+		for _, path := range paths {
+			got, ok := jsonVersionAt(doc, path)
+			if !ok {
+				t.Errorf("%s: no string value at JSON path %q", rel, path)
+				continue
+			}
+			if got != version {
+				t.Errorf("%s: %s = %q, want %q (main.go release fallback)", rel, path, got, version)
+			}
+		}
+	}
+
+	// images/claude/verify.sh hard-codes the expected release as the default of
+	// an env-overridable variable, so it needs a textual read, not a JSON one.
+	verifyRel := filepath.Join("images", "claude", "verify.sh")
+	raw, err := os.ReadFile(filepath.Join(root, verifyRel))
+	if err != nil {
+		t.Fatalf("read %s: %v", verifyRel, err)
+	}
+	expectedVersionRe := regexp.MustCompile(`EXPECTED_VERSION="\$\{AGENTOPS_EXPECTED_VERSION:-([^}"]+)\}"`)
+	match := expectedVersionRe.FindSubmatch(raw)
+	if match == nil {
+		t.Fatalf("%s: no EXPECTED_VERSION default found; the version guard was renamed or removed", verifyRel)
+	}
+	if got := string(match[1]); got != version {
+		t.Errorf("%s: EXPECTED_VERSION default = %q, want %q (main.go release fallback)", verifyRel, got, version)
+	}
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,31 +7,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Removed
+## [3.6.0] - 2026-08-17
 
-- The consumer-free `dream:` config block (the retired overnight subsystem's
-  settings; existing config files still parse and the key is ignored), the
-  vacuous retrieval-quality canary and its smoke (every Go test it named was
-  already deleted; the retrieval-comparison contract is now explicitly
-  dormant and the blocking manifest-paths gate remains the live retrieval
-  guard), and the dormant `check-pillar-coverage.sh` GOALS.yaml script.
-  Remaining scratch-tier writers (`mine-all-sessions.sh`, `team-runner.sh`,
-  `bin/ralph`) now write under `.agents/scratch/`.
+AgentOps 3.6 is the **operations-layer alignment** release, and most of the
+alignment was deletion. The product is now stated one way on every surface that
+reads it: AgentOps is the operations layer for agentic engineering, the topology
+is a federated integration graph, the interoperability contract is the semantic
+work-and-proof protocol, and the standard path is one RPI traversal (Plan,
+Implement, fresh Validate, report and stop). The knowledge-flywheel product
+surface is gone — command family, app package, build profile, gates, config
+block — the seven-move operating-loop workflow is a tombstone, `.agents/`
+writers are narrowed to declared destinations, and 25 skills plus every
+generated projection were realigned against the operating contract.
 
-- The `ao flywheel` command family (`status`, `compare`) and the whole live
-  knowledge-flywheel product surface: `cli/internal/flywheelapp`, the
-  flywheel-only metric helpers and types, the `flywheel` build-profile bit,
-  the `flywheel-compounding` gate scripts, and the `flywheel:` config block
-  (existing config files still parse; the key is ignored). AgentOps no longer
-  computes or reports knowledge-compounding state (`COMPOUNDING`, `DECAYING`,
-  escape velocity). Invoking `ao flywheel` now fails with a migration pointer
-  (see `docs/MIGRATION.md`). Learning remains an optional off-path consumer of
-  durable verdicts via the `learn` skill. The compatibility baseline records
-  the family as intentionally `retired` rather than freezing the old product
-  claim.
+Two enforcement layers ride on top. Anti-ceremony guardrails fail closed when a
+process artifact cannot name its consumer, its decision, the observed defect,
+and its retirement condition, and `rpi` runs that STOP/CONTINUE guard once
+before Plan. The eval program gives the skill harness measurement instead of
+self-report: a 12-decision eval architecture, a probe harness with a fail-closed
+v3 evidence contract, routing probes, a tier-2 flawed-plan corpus with hidden
+holdout scoring, and estate ablation sweeps whose predictions were registered
+before the runs. That same evidence contract is why measured probe coverage now
+reads an honest 0/12 — the earlier wave-1 classifications are retained as
+`LEGACY-UNVERIFIED` rather than counted.
 
 ### Added
 
+- The `anti-ceremony` skill: a clean-room, artifact-free STOP/CONTINUE guard
+  over the creation gate — name the consumer, the decision it gates, the
+  observed defect, and the retirement condition, or do not create it. `rpi`
+  takes it as a hard dependency and invokes it exactly once before Plan. On STOP
+  it dispatches no core phase and reports `NOT_PLANNED` with the guard's reason;
+  on CONTINUE the full Plan, Implement, fresh Validate path runs unchanged.
+  AgentOps now fails closed when process artifacts are manufactured, when GREEN
+  comes from weakening the oracle, and when repeated control artifacts replace
+  implementation evidence.
+- `ao session prune-agents` applies `.agents` retention policies from Go. It is
+  a read-only dry run by default; `--execute` mutates and `--quiet` prints only
+  the summary. The global `--dry-run` seam always wins over `--execute`.
+  `scripts/prune-agents.sh` becomes a compatibility wrapper.
+- `ao gc prepare` pre-seeds Codex trust for materialized Gas City session homes.
+  Codex persists two independent decisions in `$CODEX_HOME/config.toml` —
+  workspace trust under `[projects."<dir>"]` and one Codex-owned content hash
+  per hook under `[hooks.state."<hook-key>"]` — and trusting a parent directory
+  does not trust a session home. Hook identities and hashes come from Codex's
+  own `hooks/list` app-server method rather than being reimplemented. Without
+  this, the first Codex process in a fresh home could sit on the interactive
+  trust dialog with a live pane that can never take dispatched work. `ao gc
+  prepare` and `ao gc check` take `--codex-bin` to name the Codex CLI; the
+  default is `codex` on PATH.
+- The eval program for the skill harness: a 12-decision eval architecture
+  (`docs/architecture/eval-architecture.md`) and the probe harness that runs
+  control-versus-treatment behavioral probes and records replayable scorecards
+  (`bash scripts/probe-skill.sh --probe <id> --replay`).
+- Routing probes measure P(skill loaded | applicable task), the multiplier every
+  skill-efficacy number depends on. Committed scenarios are templates with
+  dispatch-time instantiation so an agent cannot read the fixture off disk and
+  contaminate the run. Task-noun skills route and judgment-posture skills do
+  not; the Codex runtime routed 4/4 against 2/6 for Claude-in-repo, because
+  `.claude/rules` auto-load already delivers the content without routing.
+- A tier-2 task-embedded corpus of flawed-plan execution fixtures with hidden
+  holdout tests injected only at scoring, across four live flaw classes (quiet
+  edge, vacuous green, burned compatibility bridge, opaque sentinel errors). The
+  scorer emits `visible_pass`, `hidden_pass`, `claimed_done`, `false_pass`, and
+  `flagged_gap`, and its selftest against planted references caught a real
+  scorer bug before any spend.
+- Estate ablation sweeps that apply delete-everything-and-measure-what-returns
+  to this repository's own estate, with predictions registered before results.
+- A dual-case anti-ceremony behavior probe that separates a justified process
+  artifact from an unjustified one, with its discriminator under test.
 - Between-releases release-path smoke: `.github/workflows/release-path-smoke.yml`
   runs a full GoReleaser snapshot (`goreleaser release --snapshot --clean
   --skip=publish`) nightly and on every change to a release-plumbing input
@@ -42,6 +86,147 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.goreleaser.yml` before-hook stayed broken for 20 days. The smoke and its
   negative witness share one script (`tests/scripts/lib/release-snapshot-smoke.sh`,
   proven able to fail by `tests/scripts/release-path-smoke.bats`).
+- `reverse-engineer` ships an output validator and a self-test, so its artifacts
+  are checked by an executable rather than by assertion.
+- `docs/contracts/ubiquitous-language.md` gains the product-architecture
+  vocabulary and four forbidden conflations, including that check success is not
+  a semantic PASS and that runtime completion is not validation.
+- `docs/reference/skill-system-evolution.md` traces the skill system across
+  releases, names seven evolution regimes, diagrams the present authority graph,
+  and records falsifiable predictions.
+- The canonical bd project identity is tracked at `.beads/identity.toml`, so
+  project identity travels with the repository instead of being reconstructed
+  per checkout.
+
+### Changed
+
+- The core architecture page is `docs/architecture/rpi-traversal.md`, with a
+  compatibility redirect left at the old operating-loop path.
+- Skill contracts match the operating contract. `rpi` preserves a durable
+  caller-owned intent source by reference and digest and snapshots bytes only
+  when no durable source exists. `automation-shape-routing` is advisory-only and
+  returns the chosen owner without copying or starting the delegated workflow.
+  `bootstrap` creates durable verdict storage and project docs only when
+  explicitly requested. `implement` and `swarm` return factual evidence instead
+  of implicitly revising or declaring semantic verdicts.
+- `ao init` scaffolds only the requested-proof stores that have declared
+  consumers: `.agents/ao/intents/sha256` and `.agents/ao/verdicts/sha256`. The
+  former session-transcript, search-index, provenance, and handoff directories
+  had no declared consumer and are no longer minted. The managed `.gitignore`
+  block now covers `.agents/scratch/`, `.agents/projections/`, and
+  `__pycache__/` instead of the retired knowledge-store paths.
+- `ao session handoff` writes JSON to `.agents/ao/handoff/` instead of
+  `.agents/handoff/`. `ao session rehydrate` searches both roots and selects the
+  newest lexical handoff id, with the canonical copy winning a filename tie. No
+  command moves or deletes the legacy files.
+- `codebase-recon` binds evidence to the exact Git commit its manifest declares.
+  Citations must be safe repository-relative regular files at that commit, a
+  supplied line number must exist in the committed blob, delta manifests must
+  match Git's own prior-to-current changed-path diff rather than a self-reported
+  boolean, and dirty tracked, staged, or untracked source outside `.agents/` is
+  refused. New packs default to `.agents/scratch/codebase-recon/<run-id>/`;
+  earlier packs stay where they are and remain discoverable.
+- `agent-mail` requires one mailbox owner and access mode per storage root, so
+  an HTTP/MCP daemon and the direct `am` CLI never contend for the same
+  database. A busy activity lock or bounded read timeout is a degraded adapter
+  result, not permission to restart the service or switch roots.
+- `status`, `using-flywheel`, and `using-gc` keep the state classes separate.
+  Factory-complete, checks-green, and AgentOps PASS are reported as three
+  different facts, never blended into one health claim.
+- The probe-coverage gate reads a hand-maintained ledger at
+  `evals/skill-probes/LEDGER.md` instead of the generated
+  `skills/SKILL-TIERS.md`, which a regeneration had silently wiped. A row counts
+  only if it names exactly one v3 scorecard whose fixture manifest, bound
+  inputs, prompt events, transcript hashes, canonical skill source,
+  non-overrideable runtime identity, reps, treatment mode, and recomputed
+  discriminator result all agree.
+- Cathedral-cut conformance scans linked skill references for retired identity
+  claims, with Markdown fence, raw-HTML, and percent-encoding handling so the
+  scan cannot be evaded by formatting.
+- `scripts/extract-release-notes.sh` reflows hard-wrapped curated notes into
+  logical Markdown lines before publishing, leaving headings, tables, code,
+  HTML, block quotes, and explicit hard breaks intact. GitHub's renderer
+  preserves soft line breaks, so copying the hard-wrapped source byte-for-byte
+  produced a narrow ragged column in the published release.
+- Handoff publishing is descriptor-anchored: it opens `.agents/ao/handoff` one
+  component at a time, refuses any component that is a symlink or not a real
+  directory, re-verifies that each opened descriptor still identifies the
+  component it inspected, and publishes by hard link rather than rename, so a
+  parent-directory swap mid-write cannot redirect the write and an existing
+  handoff id is never clobbered.
+- Prune path confinement runs traversal inside an `os.Root` with a final
+  current-path identity check immediately before each descriptor-rooted delete.
+  The contract states its own boundary honestly: intermediate-directory
+  traversal is bound, and it does not claim a final basename is immutable
+  against an adversarial replacement.
+- Portable Codex skill validation rejects duplicate YAML keys, enforces symlink
+  containment, and applies the current optional-field rules.
+- `AGENTS.md` is compressed against current-main evidence (about 10.5KB to
+  8.3KB) while preserving the honest-work and anti-ceremony doctrine, federated
+  source authority, the factory and concurrency boundaries, and the Triggered
+  Sources links that `validate-agents-split` requires. The estate-ablation
+  aggregate counts that motivated the trim are labeled legacy-unverified and
+  non-promotable.
+- ADR-0016 is amended for federated source authority and corrects an overclaim:
+  the three-directory `.agents/` layout is a target, not a currently enforced
+  closed set.
+- The Homebrew formula and the Codex plugin manifest state the operations-layer
+  identity instead of advertising a knowledge-flywheel CLI.
+- Dependencies: Go toolchain directive 1.26.5 to 1.26.6, `golang.org/x/text`
+  0.40.0 to 0.41.0, `github.com/santhosh-tekuri/jsonschema/v6` 6.0.2 to 6.0.3,
+  `github.com/BurntSushi/toml` 1.6.0 added for Codex `config.toml` handling, and
+  the pinned GitHub Actions digests refreshed.
+
+### Fixed
+
+- Generated Codex descriptions are compacted without dropping canonical trigger
+  text, so a compacted projection cannot lose the phrases that activate the
+  skill. All owned Codex projections and hashes were regenerated against that
+  rule (portable conformance 52/52).
+- Skill audit grades are evidence-honest: static readiness is scored and labeled
+  separately from measured safety and effectiveness, so a static score can no
+  longer be read as a behavioral one.
+- `ao doctor` Git-root detection no longer gets redirected by an empty or
+  otherwise invalid ancestor `.git` directory, which previously sent doctor
+  artifacts to the wrong place.
+- The eval command-surface fixture failed when it was actually executed: it
+  asserted `#{3,4}` where the surface produces `#{3,5}`. The fixture now matches
+  the real surface.
+- The bats lane provisions Python with jsonschema and PyYAML once, instead of
+  reinstalling PyYAML in a later job after `setup-python` shadowed the runner
+  interpreter.
+
+### Removed
+
+- The `ao flywheel` command family (`status`, `compare`) and the whole live
+  knowledge-flywheel product surface: `cli/internal/flywheelapp`, the
+  flywheel-only metric helpers and types, the `flywheel` build-profile bit, the
+  `flywheel-compounding` gate scripts, and the `flywheel:` config block
+  (existing config files still parse; the key is ignored). AgentOps no longer
+  computes or reports knowledge-compounding state (`COMPOUNDING`, `DECAYING`,
+  escape velocity). Invoking `ao flywheel` now exits 1 as an unknown command and
+  prints a migration pointer (see `docs/MIGRATION.md`). Learning remains an
+  optional off-path consumer of durable verdicts via the `learn` skill. The
+  compatibility baseline records the family as intentionally `retired` rather
+  than freezing the old product claim.
+- `plan` manifest mode, added in 3.5.0, along with its "plan manifest" trigger.
+  `plan` shapes one active behavior in the existing intent source; a
+  multi-behavior specification stays a document the caller owns.
+- The seven-move operating-loop workflow is a tombstone that fails with a
+  deterministic migration message instead of silently running retired doctrine.
+- The consumer-free `dream:` config block (the retired overnight subsystem's
+  settings; existing config files still parse and the key is ignored) and its
+  exclusive helpers, the vacuous retrieval-quality canary and the nightly job
+  that ran it (every Go test it named was already deleted; the
+  retrieval-comparison contract is now explicitly dormant and the blocking
+  manifest-paths gate remains the live retrieval guard), the dormant
+  `check-pillar-coverage.sh` GOALS.yaml script, `check-thesis-stability.sh`, and
+  `generate-index.sh`. Remaining scratch-tier writers (`mine-all-sessions.sh`,
+  `team-runner.sh`, `bin/ralph`) now write under `.agents/scratch/`. `bin/ralph`
+  still resumes legacy `.agents/ralph/` checkpoints, so the documented
+  backwards-compatibility contract holds without a migration.
+- The dated skill-quality audit report, which had no runtime consumer and bound
+  a superseded audit snapshot; all functional skill-quality changes stayed.
 
 ## [3.5.0] - 2026-07-31
 

--- a/docs/reference/skill-system-evolution.md
+++ b/docs/reference/skill-system-evolution.md
@@ -1,8 +1,8 @@
 # Skill-system evolution: from autonomous flywheel to federated proof graph
 
-**As of:** 2026-08-16
-**Scope:** every release represented in `CHANGELOG.md` (`2.16.0` through
-`3.5.0`) plus the current unreleased tree
+**As of:** 2026-08-17
+**Scope:** every release represented in `CHANGELOG.md`, `2.16.0` through
+`3.6.0`
 **Question:** what meta-loops and graphs did the skill system actually build,
 and where can skills still create compounding improvement in agent harnesses?
 
@@ -298,7 +298,7 @@ modes that shaped the later architecture.
 | 3.3.0 | Performed the Cathedral Cut; defined the four-skill one-pass core, exact manifests, fresh validation, optional adapters, and report-and-stop. | Judgment boundary—not orchestration—is the product invariant. |
 | 3.4.0 | Overhauled all 50 skill contracts, externalized factories, made verdict storage optional, and enforced honest effects. | Skills become semantic adapters in a federated graph. |
 | 3.5.0 | Added factory-coordinator doctrine, plan manifests, bounded caveat homes, and CLI-backed GC maintenance. | AgentOps describes handoffs without acquiring foreign lifecycle authority. |
-| Unreleased | Retires the live flywheel product/status and consumer-free artifacts; Learn remains optional. | Compounding is no longer a product state AgentOps can self-declare. |
+| 3.6.0 | Retired the live flywheel product/status and consumer-free artifacts, aligned the estate on the operations-layer identity, and added the behavioral eval program with a fail-closed evidence contract. | Compounding is no longer a product state AgentOps can self-declare, and skill efficacy becomes a measured claim rather than an asserted one. |
 
 The release entries are changelog-level summaries and should not be read as
 file-exact diffs; the reachable Git history does not contain the pre-3.3

--- a/docs/releases/2026-08-17-v3.6.0-notes.md
+++ b/docs/releases/2026-08-17-v3.6.0-notes.md
@@ -1,0 +1,131 @@
+## Highlights
+
+AgentOps 3.6 is the operations-layer alignment release, and most of the alignment was deletion. The product is now stated one way on every surface that reads it: AgentOps is the operations layer for agentic engineering, the topology is a federated integration graph, the interoperability contract is the semantic work-and-proof protocol, and the standard path is one RPI traversal. The knowledge-flywheel product surface is gone, the seven-move operating-loop workflow is a tombstone, and 25 skills plus every generated projection were realigned against the operating contract.
+
+Two enforcement layers ride on top. Anti-ceremony guardrails fail closed when a process artifact cannot name its consumer, its decision, the observed defect, and its retirement condition, and `rpi` runs that STOP/CONTINUE guard once before Plan. The eval program gives the skill harness measurement instead of self-report: an eval architecture, a probe harness with a fail-closed v3 evidence contract, routing probes, a tier-2 flawed-plan corpus with hidden holdout scoring, and estate ablation sweeps with predictions registered before the runs. That same evidence contract is why measured probe coverage now reads an honest 0/12 rather than a flattering number.
+
+## Upgrade Notes
+
+- Remove any `ao flywheel` invocation from scripts and CI. There is no replacement command; AgentOps no longer computes knowledge-compounding state. Learning stays available as an optional off-path consumer of durable verdicts through the `learn` skill. `flywheel:` config keys can be left in place — they parse and are ignored.
+- If anything reads `.agents/handoff/*.json` written by `ao session handoff`, repoint it to `.agents/ao/handoff/`. Existing files stay put as read-only evidence and `ao session rehydrate` already reads both roots, so no migration step is required.
+- The `ao init` .gitignore block is idempotent on its begin marker, so a repository initialized before 3.6 keeps its old block and re-running `ao init` will not update it. To adopt the current lines, edit the block by hand: replace `.agents/ao/index/`, `.agents/ao/sessions/`, and `.agents/ao/provenance/` with `.agents/scratch/` and `.agents/projections/`. `.agents/ao/intents/` and `.agents/ao/verdicts/` remain deliberately un-ignored; whether loop evidence is committed is your repository's policy.
+- `ao gc prepare` now writes Codex trust entries into `$CODEX_HOME/config.toml` for the Gas City directories that exist when it runs. Pass `--codex-bin` if `codex` is not on PATH; the same flag exists on `ao gc check`.
+- Callers of `plan` that used manifest mode should keep the multi-behavior specification in their own document and hand `plan` one behavior at a time.
+- The behavioral probe ledger moved from the generated `skills/SKILL-TIERS.md` to the hand-maintained `evals/skill-probes/LEDGER.md`. `SKILL_PROBE_TIERS_FILE` still works as an alias; prefer `SKILL_PROBE_LEDGER_FILE`.
+- The Go toolchain directive is 1.26.6. Local builds on an older toolchain will fetch or fail per your `GOTOOLCHAIN` setting.
+- Otherwise no manual action is required. Existing installs upgrade in place with `brew upgrade agentops` or by re-running the install one-liner for your runtime.
+
+## Breaking Changes
+
+This is a minor release, but it removes retired surfaces rather than freezing them. Each removal is a deliberate retirement with a migration pointer, not a regression.
+
+- `ao flywheel` (`status`, `compare`) is removed. The command exits 1 as an unknown command and prints a migration pointer. There is no replacement.
+- `plan` manifest mode, added in 3.5.0, is removed along with its "plan manifest" trigger.
+- The seven-move `operating-loop` workflow is a tombstone; invoking it fails with a deterministic migration message.
+- `ao session handoff` writes new JSON to `.agents/ao/handoff/` instead of `.agents/handoff/`. Reads are unaffected — `ao session rehydrate` searches both roots and nothing moves or deletes legacy files.
+- `ao init` no longer creates `.agents/ao/sessions/`, `.agents/ao/index/`, `.agents/ao/provenance/`, or `.agents/handoff/`. It creates only `.agents/ao/intents/sha256` and `.agents/ao/verdicts/sha256`.
+- `codebase-recon` writes new packs to `.agents/scratch/codebase-recon/<run-id>/` instead of `.agents/recon/<run-id>/`. Earlier packs stay where they are and remain discoverable; do not move them, because a delta manifest cites the prior pack's exact path.
+
+## At a Glance
+
+| Product Area | Added | Changed | Refactored | Fixed | Deprecated/Removed |
+|---|---:|---:|---:|---:|---:|
+| Install, Upgrade, and Distribution | 0 | 2 | 0 | 0 | 0 |
+| CLI and Operator Commands | 1 | 3 | 0 | 1 | 1 |
+| Daemon, Scheduling, and Factory | 2 | 0 | 0 | 0 | 0 |
+| Skills and Workflows | 2 | 5 | 0 | 1 | 2 |
+| Codex and Runtime Integrations | 0 | 2 | 0 | 1 | 0 |
+| Eval, Validation, and Release Gates | 5 | 4 | 0 | 2 | 1 |
+| Docs and Onboarding | 4 | 3 | 0 | 0 | 1 |
+| Security, Privacy, and Supply Chain | 0 | 4 | 0 | 0 | 0 |
+| Contributor/Internal Refactors | 2 | 1 | 0 | 0 | 2 |
+
+## Product Areas
+
+### Install, Upgrade, and Distribution
+
+- Changed: The Homebrew formula description no longer advertises a knowledge-flywheel CLI. It reads "Optional AgentOps CLI for deterministic repository checks and evidence linking," which is what the binary actually does.
+- Changed: The release workflow builds on Go 1.26.6, matching the toolchain directive in `cli/go.mod`.
+
+### CLI and Operator Commands
+
+- Added: `ao session prune-agents` applies `.agents` retention policies from Go. It is a read-only dry run by default; `--execute` mutates and `--quiet` prints only the summary. The global `--dry-run` seam always wins over `--execute`, and `scripts/prune-agents.sh` becomes a compatibility wrapper.
+- Changed: `ao init` scaffolds only the requested-proof stores that have declared consumers — `.agents/ao/intents/sha256` and `.agents/ao/verdicts/sha256`. The former session-transcript, search-index, provenance, and handoff directories had no declared consumer and are no longer minted.
+- Changed: `ao session handoff` writes JSON to `.agents/ao/handoff/`. `ao session rehydrate` searches both the canonical and legacy roots and selects the newest lexical handoff id, with the canonical copy winning a filename tie.
+- Changed: The managed `.gitignore` block written by `ao init` covers `.agents/scratch/`, `.agents/projections/`, and `__pycache__/` instead of the retired knowledge-store paths.
+- Fixed: `ao doctor` Git-root detection no longer gets redirected by an empty or otherwise invalid ancestor `.git` directory, which previously sent doctor artifacts to the wrong place.
+- Removed: The `ao flywheel` command family (`status`, `compare`) and the flywheel-only metric helpers, app package, and build-profile bit. Existing `flywheel:` config sections still parse and are ignored.
+
+### Daemon, Scheduling, and Factory
+
+- Added: `ao gc prepare` pre-seeds Codex trust for materialized Gas City session homes, writing both decisions Codex persists independently in `$CODEX_HOME/config.toml` — workspace trust under `[projects."<dir>"]` and one Codex-owned content hash per hook under `[hooks.state."<hook-key>"]`. Trusting a parent directory does not trust a session home, and hook identities come from Codex's own `hooks/list` app-server method rather than being reimplemented. Without this, the first Codex process in a fresh home could sit on the interactive trust dialog with a live pane that can never take dispatched work.
+- Added: `ao gc prepare` and `ao gc check` take `--codex-bin` to name the Codex CLI used to resolve hook trust identities; the default is `codex` on PATH.
+
+### Skills and Workflows
+
+- Added: The `anti-ceremony` skill, a clean-room artifact-free STOP/CONTINUE guard over the creation gate. `rpi` takes it as a hard dependency and invokes it exactly once before Plan. On STOP it dispatches no core phase and reports `NOT_PLANNED` with the guard's reason; on CONTINUE the full traversal runs unchanged.
+- Added: `reverse-engineer` ships an output validator and a self-test, so its artifacts are checked by an executable rather than by assertion.
+- Changed: Skill contracts match the operating contract. `rpi` preserves a durable caller-owned intent source by reference and digest and snapshots bytes only when no durable source exists. `automation-shape-routing` is advisory-only. `bootstrap` creates durable verdict storage and project docs only when explicitly requested. `implement` and `swarm` return factual evidence instead of implicitly declaring semantic verdicts.
+- Changed: `codebase-recon` binds evidence to the exact Git commit its manifest declares. Citations must be safe repository-relative regular files at that commit, delta manifests must match Git's own changed-path diff rather than a self-reported boolean, and dirty source outside `.agents/` is refused.
+- Changed: `agent-mail` requires one mailbox owner and access mode per storage root, so an HTTP/MCP daemon and the direct `am` CLI never contend for the same database. A busy activity lock or bounded read timeout is a degraded adapter result, not permission to restart the service.
+- Changed: `status`, `using-flywheel`, and `using-gc` keep the state classes separate. Factory-complete, checks-green, and AgentOps PASS are three different facts, never blended into one health claim.
+- Changed: `handoff` declares its output contract as the caller-selected path or `.agents/ao/handoff/`, and states the compatibility rule in the owning skill: legacy artifacts stay as read-only evidence and no separate migration artifact is required.
+- Fixed: Skill audit grades are evidence-honest. Static readiness is scored and labeled separately from measured safety and effectiveness, so a static score can no longer be read as a behavioral one.
+- Removed: `plan` manifest mode and its "plan manifest" trigger. `plan` shapes one active behavior in the existing intent source.
+- Removed: The seven-move operating-loop workflow is a tombstone that fails with a deterministic migration message instead of silently running retired doctrine.
+
+### Codex and Runtime Integrations
+
+- Changed: Portable skill validation rejects duplicate YAML keys, enforces symlink containment, and applies the current optional-field rules, with negative and generator regression coverage behind it.
+- Changed: The Codex plugin manifest states the operations-layer identity instead of the narrower fresh-context-validation framing.
+- Fixed: Generated Codex descriptions are compacted without dropping canonical trigger text, so a compacted projection cannot lose the phrases that activate the skill. All owned Codex projections and hashes were regenerated against that rule.
+
+### Eval, Validation, and Release Gates
+
+- Added: A 12-decision eval architecture for the skill harness, plus the probe harness that runs control-versus-treatment behavioral probes and records replayable scorecards.
+- Added: Routing probes measure P(skill loaded | applicable task), the multiplier every skill-efficacy number depends on. Committed scenarios are templates with dispatch-time instantiation so an agent cannot read the fixture off disk and contaminate the run.
+- Added: A tier-2 task-embedded corpus of flawed-plan execution fixtures with hidden holdout tests injected only at scoring, across four live flaw classes. The scorer's selftest against planted references caught a real scorer bug before any spend.
+- Added: Estate ablation sweeps with predictions registered before results, applying delete-everything-and-measure-what-returns to this repository's own estate.
+- Added: Between-releases release-path smoke. `.github/workflows/release-path-smoke.yml` runs a full GoReleaser snapshot nightly and on every change to a release-plumbing input, closing the commitment recorded in `docs/audits/release-readiness-v3.3.0.md`. The release path previously ran only on a real `v*` tag push, which is how a retired before-hook stayed broken for 20 days. CI and the negative witness share one script.
+- Changed: The probe-coverage gate reads a hand-maintained ledger at `evals/skill-probes/LEDGER.md` instead of the generated `skills/SKILL-TIERS.md`, which a regeneration had silently wiped. A row counts only if it names exactly one v3 scorecard whose fixture manifest, bound inputs, transcript hashes, canonical skill source, runtime identity, reps, treatment mode, and recomputed discriminator result all agree.
+- Changed: Cathedral-cut conformance scans linked skill references for retired identity claims, with Markdown fence, raw-HTML, and percent-encoding handling so the scan cannot be evaded by formatting.
+- Changed: `scripts/extract-release-notes.sh` reflows hard-wrapped curated notes into logical Markdown lines before publishing, leaving headings, tables, code, HTML, block quotes, and explicit hard breaks intact.
+- Changed: The bats lane provisions Python with jsonschema and PyYAML once, instead of reinstalling PyYAML after `setup-python` shadowed the runner interpreter.
+- Fixed: The eval command-surface fixture failed when it was actually executed, asserting `#{3,4}` where the surface produces `#{3,5}`. The fixture now matches the real surface.
+- Fixed: A version-parity regression test now asserts the checked-in `version` fallback agrees with every version-bearing release surface, including `images/claude/verify.sh`. The existing manifest-consistency check compared only the two Claude manifests to each other and could not see that drift.
+- Removed: The vacuous retrieval-quality canary and the nightly job that ran it, the flywheel-compounding gate scripts and their bats suite, and the dormant `check-pillar-coverage.sh`, `check-thesis-stability.sh`, and `generate-index.sh` scripts.
+
+### Docs and Onboarding
+
+- Added: `docs/contracts/ubiquitous-language.md` gains the product-architecture vocabulary and four forbidden conflations, including that check success is not a semantic PASS and that runtime completion is not validation.
+- Added: `docs/reference/skill-system-evolution.md` traces the skill system across releases, names seven evolution regimes, diagrams the present authority graph, and records falsifiable predictions.
+- Added: Two research reports land as durable references — the skill-eval SOTA standards survey the eval architecture is built on, and a formal-verification-for-agent-code survey.
+- Added: The operations-layer alignment plan is committed as the reference for what changed and why.
+- Changed: The core architecture page is `docs/architecture/rpi-traversal.md`, with a compatibility redirect at the old operating-loop path.
+- Changed: `AGENTS.md` is compressed against current-main evidence while preserving the honest-work and anti-ceremony doctrine, federated source authority, the factory and concurrency boundaries, and the Triggered Sources links. The estate-ablation aggregate counts that motivated the trim are labeled legacy-unverified and non-promotable.
+- Changed: ADR-0016 is amended for federated source authority and corrects an overclaim: the three-directory `.agents/` layout is a target, not a currently enforced closed set.
+- Removed: The dated skill-quality audit report, which had no runtime consumer and bound a superseded audit snapshot. All functional skill-quality changes stayed.
+
+### Security, Privacy, and Supply Chain
+
+- Changed: Handoff publishing is descriptor-anchored. It opens `.agents/ao/handoff` one component at a time, refuses any component that is a symlink or not a real directory, re-verifies that each opened descriptor still identifies the component it inspected, and publishes by hard link rather than rename, so a parent-directory swap mid-write cannot redirect the write and an existing handoff id is never clobbered.
+- Changed: Prune path confinement runs traversal inside an `os.Root` with a final current-path identity check immediately before each descriptor-rooted delete. The contract states its own boundary honestly: intermediate-directory traversal is bound, and it does not claim a final basename is immutable against an adversarial replacement.
+- Changed: Portable Codex skill validation enforces symlink containment and rejects duplicate YAML keys, so a projected skill package cannot reach outside its own tree or carry a key whose second definition silently wins.
+- Changed: Pinned GitHub Actions digests were refreshed, including `actions/attest-build-provenance` on the release provenance step and `dorny/paths-filter` in the validate workflow.
+
+### Contributor/Internal Refactors
+
+- Added: The canonical bd project identity is tracked at `.beads/identity.toml` and bound to the live project id, so project identity travels with the repository instead of being reconstructed per checkout.
+- Added: A `.gitattributes` file lands so evidence fixtures and generated projections get deterministic treatment across checkouts.
+- Changed: Dependencies — Go toolchain directive 1.26.5 to 1.26.6, `golang.org/x/text` 0.40.0 to 0.41.0, `github.com/santhosh-tekuri/jsonschema/v6` 6.0.2 to 6.0.3, and `github.com/BurntSushi/toml` 1.6.0 added for Codex `config.toml` handling.
+- Removed: Knowledge-flywheel internals were deleted with their tests: `cli/internal/flywheelapp`, `cli/cmd/ao/flywheel_composition.go`, `scripts/lib/flywheel-compile.sh`, `scripts/snapshot-flywheel-compounding.sh`, `scripts/log-telemetry.sh`, and `tests/skills/test-artifact-consistency.sh`.
+- Removed: The consumer-free `dream:` config block and its exclusive helpers. Existing config files still parse and the key is ignored. Remaining scratch-tier writers now write under `.agents/scratch/`, and `bin/ralph` still resumes legacy `.agents/ralph/` checkpoints so the documented backwards-compatibility contract holds without a migration.
+
+## Known Issues
+
+- Measured behavioral probe coverage is an honest 0/12 under the v3 evidence contract. The wave-1 classifications from earlier in this cycle are retained as `LEGACY-UNVERIFIED` rather than counted, because the probe harness did not isolate the skill corpus between control and treatment arms. Skill-efficacy claims in this release are directional, not proven.
+- The estate-ablation aggregate counts are labeled legacy-unverified and non-promotable: useful as hypotheses, not proof of causal effects, generalized token cost, or executor behavior.
+- `tests/docs/validate-goal-count.sh` exits 1 with no diagnostic because its pipe-table parser predates the current prose-plus-list `GOALS.md`. It is wired into `tests/run-all.sh`, which is not in CI or the release path, so it gates nothing.
+- `scripts/check-product-freshness.sh` is advisory and wired into no gate.
+
+[Full changelog](../CHANGELOG.md)

--- a/images/claude/verify.sh
+++ b/images/claude/verify.sh
@@ -58,7 +58,7 @@ fi
 # Version guard: the Claude marketplace plugin manifest is the install entrypoint
 # for this image. Assert .claude-plugin/plugin.json declares the expected version
 # so a stale-version drift (plugin.json behind the release) fails the gate.
-EXPECTED_VERSION="${AGENTOPS_EXPECTED_VERSION:-3.5.0}"
+EXPECTED_VERSION="${AGENTOPS_EXPECTED_VERSION:-3.6.0}"
 plugin_manifest="$repo_root/.claude-plugin/plugin.json"
 if [ ! -f "$plugin_manifest" ]; then
   echo "FAIL: Claude plugin manifest not found: $plugin_manifest" >&2

--- a/images/gemini/plugin.json
+++ b/images/gemini/plugin.json
@@ -13,5 +13,5 @@
   "name": "agentops-core-gemini",
   "rules": "./rules",
   "skills": "./skills",
-  "version": "3.5.0"
+  "version": "3.6.0"
 }


### PR DESCRIPTION
Everything-but-tag for **v3.6.0**. Minor, not major: the post-3.5.0 delta retires the knowledge-flywheel product surface and aligns the estate on the operations-layer identity, matching the 3.4.0 precedent where the orchestration pack was removed in a minor.

## What this carries

- **Version 3.5.0 -> 3.6.0 across all seven surfaces**: Claude plugin manifest, marketplace metadata + plugin entry, Codex manifest, Gemini image manifest, Claude image verify pin, and the `ao` source fallback.
- **CHANGELOG `[3.6.0]`** (root + docs mirror): operations-layer alignment, anti-ceremony enforcement, the behavioral eval program, the flywheel retirement, and the honest 0/12 measured probe coverage.
- **Curated `docs/releases/2026-08-17-v3.6.0-notes.md`**: validator PASS, tier minor, full changed-path area coverage. The Breaking Changes section lists all six removals and the handoff write-path move rather than burying them in a minor.
- **New regression test `cli/cmd/ao/version_manifest_parity_test.go`** binding the `version` fallback to every version-bearing release surface.
- **PRODUCT.md** reviewed against the 3.6 surface and re-stamped; **`docs/reference/skill-system-evolution.md`** gains its 3.6.0 row and drops the "current unreleased tree" framing that the tag would falsify.

## Why the new test exists

This cut missed `images/claude/verify.sh`. Its version guard — whose entire stated purpose is catching plugin.json drift *behind* the release — then rejected the **correct** version, so a user following the shipped `images/claude/README.md` on the v3.6.0 tag would have hit a hard FAIL. `check_manifest_version_consistency` in `ci-local-release.sh` compares only the two Claude manifests to each other, so it structurally could not see this.

The test fails on the drift and passes when correct; both directions were exercised before committing.

## Honesty notes carried into the release

- Measured behavioral probe coverage is stated as **0/12** under the v3 evidence contract. The earlier wave-1 classifications are retained as `LEGACY-UNVERIFIED` rather than counted, because the probe harness did not isolate the skill corpus between control and treatment arms. Skill-efficacy claims in these notes are directional, not proven.
- The estate-ablation aggregate counts are labeled legacy-unverified and non-promotable.

## Verification

Full `scripts/ci-local-release.sh --release-version 3.6.0 --readiness-mode official --security-mode full`: **PASSED — 72 checks, 0 failures**.

| Dimension | Status |
|---|---|
| SIL (race suite, 75.8% coverage) | pass |
| VIL (gates, regen, digital twin) | pass |
| HIL (real Darwin/arm64 target) | pass |
| Artifacts (CycloneDX + SPDX SBOM) | pass |
| Security (full mode) | pass |

Readiness **9.0** against threshold 8. HIL used a real target with **no waiver**: `ao` built from this tree reported `ao version 3.6.0` (`version_verified=true`) and ran a full `ao init` scaffold plus `ao status` in a scratch repo. Security full mode: 0 critical, 0 high, 3 medium (non-blocking). Notes validator PASS, doc-release gate PASS.

## Post-merge

Readiness lap at the merged SHA, audit record in `docs/audits/`, then the tag — per the binding process rule that the record exists **before** the tag.