### PR TITLE
fix(ci): golangci-lint v2.13.1 for Go 1.27; stop archcheck TempDir race

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -91,7 +91,7 @@ jobs:
           GOBIN=/usr/local/bin go install github.com/zricethezav/gitleaks/v8@v8.30.1
 
           # golangci-lint
-          GOBIN=/usr/local/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+          GOBIN=/usr/local/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1
 
           # govulncheck — known-CVE reachability over the module graph + stdlib
           # (sweep 2026-07-09 M-2: the blind spot that let GO-2026-4970 sit a week).

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -608,7 +608,7 @@ jobs:
           retry python -m pip install semgrep==1.169.0 ruff==0.15.21 radon==6.0.1
           retry env GOBIN=/usr/local/bin go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
           retry env GOBIN=/usr/local/bin go install github.com/zricethezav/gitleaks/v8@v8.30.1
-          retry env GOBIN=/usr/local/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+          retry env GOBIN=/usr/local/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1
           retry env GOBIN=/usr/local/bin go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
           # trivy — pinned tag, download-then-execute (mirrors nightly.yml; piping a
           # mutable-branch script into sh is the gha-curl-pipe-shell supply-chain class).

--- a/cli/internal/archcheck/checker_test.go
+++ b/cli/internal/archcheck/checker_test.go
@@ -543,9 +543,23 @@ func scrubbedGitEnv() []string {
 	return env
 }
 
+// fixtureGitArgs scopes a fixture git command to root and disables background
+// maintenance: `git commit` may detach a `gc --auto`/`maintenance run --auto`
+// child that outlives the test body and races t.TempDir cleanup — RemoveAll
+// then fails with ".git: directory not empty" (nightly 2026-08-10 #1055,
+// 2026-08-21 #1077).
+func fixtureGitArgs(root string, args ...string) []string {
+	return append([]string{
+		"-C", root,
+		"-c", "gc.auto=0",
+		"-c", "gc.autodetach=false",
+		"-c", "maintenance.auto=false",
+	}, args...)
+}
+
 func runFixtureGit(t *testing.T, root string, args ...string) {
 	t.Helper()
-	command := exec.Command("git", append([]string{"-C", root}, args...)...)
+	command := exec.Command("git", fixtureGitArgs(root, args...)...)
 	command.Env = scrubbedGitEnv()
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, output)
@@ -554,7 +568,7 @@ func runFixtureGit(t *testing.T, root string, args ...string) {
 
 func fixtureGitOutput(t *testing.T, root string, args ...string) string {
 	t.Helper()
-	command := exec.Command("git", append([]string{"-C", root}, args...)...)
+	command := exec.Command("git", fixtureGitArgs(root, args...)...)
 	command.Env = scrubbedGitEnv()
 	output, err := command.Output()
 	if err != nil {

--- a/scripts/golangci-lint-v2.sh
+++ b/scripts/golangci-lint-v2.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION="${GOLANGCI_LINT_VERSION:-v2.11.4}"
+VERSION="${GOLANGCI_LINT_VERSION:-v2.13.1}"
 DISPLAY_VERSION="${VERSION#v}"
 MODULE="github.com/golangci/golangci-lint/v2/cmd/golangci-lint"
 


### PR DESCRIPTION
## What

Bumps the repo-pinned golangci-lint from v2.11.4 to v2.13.1 (in `scripts/golangci-lint-v2.sh` plus the toolchain installs in `validate.yml` and `nightly.yml`), and hardens `cli/internal/archcheck`'s fixture git helpers against a `t.TempDir` cleanup race by disabling background git maintenance (`gc.auto=0`, `gc.autodetach=false`, `maintenance.auto=false`).

## Why

Fixes #1055. Fixes #1077.

Two independent failures were blocking CI:

- **go-gate-shadow red on the open Renovate PRs (#1076, #1074).** golangci-lint v2.11.4's vendored `x/tools` cannot decode Go 1.27's export data (`export data version 4 is greater than maximum supported version 2`), so the `go.lint` gate fails with `typecheck` errors on any PR that moves CI or the `toolchain` directive to go 1.27.0. v2.13.1 ships `x/tools` v0.49.0 with Go 1.27 support while keeping a `go 1.26.0` directive, so it still bootstraps under the current go 1.26.6 CI toolchain with `GOTOOLCHAIN=local`.

- **Nightly failures #1055 (CLI tests, 2026-08-10) and #1077 (security toolchain go-test lane, 2026-08-21).** Both are the same root cause: `git commit` in `TestGoCLIArchitectureAcceptedBoundaryOwnsModuleIntroduction`'s fixture repo can detach an auto-maintenance child that outlives the test body and races `t.TempDir` cleanup, failing `RemoveAll` with `.git: directory not empty`. The fixture git helpers now disable auto gc/maintenance so no background child is ever spawned.

## How I tested

- `cd cli && go build ./... && go vet ./... && go test ./...` — exit 0 (65 packages ok).
- `scripts/check-go-lint.sh` with golangci-lint v2.13.1: clean (0 findings) under **both** `GOTOOLCHAIN=go1.26.6` (current CI) and `GOTOOLCHAIN=go1.27.0` (the environment of the Renovate PRs), on the final tree.
- Reproduced the v2.11.4 failure locally under go1.27.0 (same two `typecheck` findings as CI) before the bump.
- `go test ./internal/archcheck/ -run 'TestGoCLIArchitecture...' -count=3` — pass.

## Checklist

- [x] `make build && make test` passes (if Go changes)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none

---
_Generated by [Claude Code](https://claude.ai/code/session_011Kjsu6s8w9su671g6zCSQw)_