### PR TITLE
docs(readme): add anti-ceremony guard and 3.6.0 judgment skills to the inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,14 +156,18 @@ one unless requested.
 
 | Skill | Job |
 |---|---|
-| [`rpi`](skills/rpi/SKILL.md) | run Plan, Implement, and fresh Validate at most once |
+| [`rpi`](skills/rpi/SKILL.md) | run the anti-ceremony guard, then Plan, Implement, and fresh Validate at most once |
+| [`anti-ceremony`](skills/anti-ceremony/SKILL.md) | STOP/CONTINUE guard before Plan: name the consumer, the decision, the defect, and the retirement condition, or do not create the artifact |
 | [`plan`](skills/plan/SKILL.md) | create the bead (BDD + DDD ubiquitous language) |
 | [`implement`](skills/implement/SKILL.md) | TDD against the bead: RED → GREEN → refactor |
 | [`validate`](skills/validate/SKILL.md) | fresh context (optionally different model); optionally persist `verdict.v2` |
 
 Optional later: [`learn`](skills/learn/SKILL.md). Strategies:
 [`council`](skills/council/SKILL.md), [`idea-genie`](skills/idea-genie/SKILL.md),
-[`premortem`](skills/premortem/SKILL.md), [`postmortem`](skills/postmortem/SKILL.md).
+[`premortem`](skills/premortem/SKILL.md), [`postmortem`](skills/postmortem/SKILL.md),
+[`one-way-door`](skills/one-way-door/SKILL.md) (is this decision reversible?),
+[`reality-check`](skills/reality-check/SKILL.md) (does the repo match the claim?).
+Not sure which skill owns a request? Ask [`route`](skills/route/SKILL.md).
 
 ## One skill, many shapes
 


### PR DESCRIPTION
## What

Updates the README skill inventory to match what ships since 3.6.0: the `rpi` row now says it runs the anti-ceremony guard before Plan, `anti-ceremony` gets its own row in the Core skills table, and the strategies list gains `one-way-door` and `reality-check`, with a pointer to `route` for picking the owning skill.

## Why

The Core skills table and the strategies list predated 3.6.0. `rpi` takes `anti-ceremony` as a hard dependency (`skills/rpi/SKILL.md`), and `one-way-door`, `reality-check`, and `route` are listed in `docs/SKILL-ROUTER.md` but were never named in the README. Every other README link, install path, and mode table was verified against the tree and left unchanged.

## How I tested

- `markdownlint README.md` passes with the repo config.
- `scripts/check-honest-voice.sh` passes (216 files, no forbidden claims).
- Every `skills/*/SKILL.md` link in the README resolves to an existing file.

## Checklist

- [x] `make build && make test` passes (if Go changes) — no Go changes
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXPTKX8F44SGvoHB39F8zY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXPTKX8F44SGvoHB39F8zY)_