### PR TITLE
Loop restore: converge and crank as control flow under the verdict contract (ADR-0017)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ AgentOps joins them as a federated integration graph and adds the judgment
 step, one RPI traversal at a time:
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> repair to convergence -> report
 ```
 
 No fresh independent judgment over the exact subject means the experiment is
@@ -127,9 +127,14 @@ Skill logic ships in Go via `ao`;
    top-level evidence, evidence for every criterion, and an empty
    `not_checked`. Persist `verdict.v2` only when requested by a caller or
    required by a declared consumer.
-4. **Report and stop.** Report the result; emit no next action; no automatic
-   revision. Two consecutive control artifacts with no new implementation evidence end the run.
-   Reports lead with the subject, never artifact counts.
+4. **Repair to convergence, then report.** On `FAIL` or `NOT_PROVEN` with
+   findings, repair and re-validate freshly while the convergence law admits
+   another round (caller-declared `repair_rounds`, default 2; open finding
+   ids non-growing; no closed id reopens; the subject digest or the evidence
+   changed). Stop when converged, stopped by the law, or out of rounds
+   (ADR-0017). Report the result; emit no next action. Two consecutive
+   rounds with no subject or evidence change end the run. Reports lead with
+   the subject, never artifact counts.
 
 A caller may revise the intent and start a new invocation. Learn is an
 optional later consumer and cannot change core outcomes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ Skill logic ships in Go via `ao`;
    ids non-growing; no closed id reopens; the subject digest or the evidence
    changed). Stop when converged, stopped by the law, or out of rounds
    (ADR-0017). Report the result; emit no next action. Two consecutive
-   rounds with no subject or evidence change end the run. Reports lead with
+   rounds with no new implementation evidence end the run. Reports lead with
    the subject, never artifact counts.
 
 A caller may revise the intent and start a new invocation. Learn is an

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -16,7 +16,7 @@ handoffs — and the product boundary is deliberately small. The standard
 traversal through the graph is:
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> repair to convergence -> report
 ```
 
 ## Proven floor
@@ -53,7 +53,7 @@ Four load-bearing skills define the core:
 
 | Skill | Responsibility |
 |---|---|
-| `rpi` | dispatch Plan, Implement, and Validate once; report and stop |
+| `rpi` | dispatch Plan and Implement once, Validate freshly, repair to convergence under the caller's bound; report |
 | `plan` | shape acceptance, evidence, and write scope |
 | `implement` | run one bounded experiment and produce a candidate |
 | `validate` | independently judge exact content; persist only for a declared consumer |

--- a/PROGRAM.md
+++ b/PROGRAM.md
@@ -1,6 +1,6 @@
 # Program
 
-This repository self-hosts the same single-pass boundary it ships. PROGRAM is
+This repository self-hosts the same bounded-repair RPI boundary it ships (ADR-0017). PROGRAM is
 repository execution guidance, not a product retry or delivery controller.
 
 ## Experiment unit
@@ -11,10 +11,12 @@ One invocation consumes and produces:
 2. one bounded RED -> GREEN -> refactor implementation experiment;
 3. one runtime-derived subject manifest and factual check receipts with
    complete or honestly incomplete changed-path proof;
-4. one fresh author-distinct Validate judgment over exact content;
+4. one fresh author-distinct Validate judgment over exact content, repeated
+   only inside the bounded repair phase under the convergence law;
 5. one durable verdict and report.
 
-The invocation stops after the report. A later revision is a caller-created new
+The invocation stops when converged, stopped by the law, or out of the caller's
+repair rounds. A later revision is a caller-created new
 invocation. Repository Git and release procedures remain separate.
 
 ## Mutable scope

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ the exact change and returns `PASS`, `FAIL`, or `NOT_PROVEN`. The standard
 path is one RPI traversal:
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> repair to convergence -> report
 ```
 
 ## Quickstart

--- a/cli/README.md
+++ b/cli/README.md
@@ -5,7 +5,7 @@ is the optional checks/linking CLI of the AgentOps operations layer; the
 semantic protocol lives in the skills:
 
 ```text
-RPI → Plan → Implement → fresh Validate → report and stop
+RPI → Plan → Implement → fresh Validate → repair to convergence → report
 ```
 
 The CLI does not own retries, queues, work claims, Git delivery, release,

--- a/cli/cmd/ao/testdata/seamless-module-exemptions.json
+++ b/cli/cmd/ao/testdata/seamless-module-exemptions.json
@@ -2,7 +2,7 @@
   "_comment": "Seam-coverage exemptions (bead age-6j9ee.1 / B1). Every internal/commands/<family>/module.go NewModule MUST either take a clicontract.HostOptions parameter (the shared host seam) OR appear here with a one-line reason justifying why it is genuinely seam-less (pure static text or a pure deterministic transform with no output-mode / dry-run / verbose / project-root / clock dependency). TestEveryModuleTakesHostSeamOrIsExempt (carveout_regression_test.go) fails three ways so this list cannot rot: (1) a zero-seam module missing from this list, (2) a module that gained a HostOptions seam but is still listed here (stale), and (3) an exemption for a module that no longer exists. Do NOT add an entry to dodge wiring a real seam: if a module reads output mode, dry-run, verbose, the project root, or the clock, it takes clicontract.HostOptions instead.",
   "exempt": [
     { "module": "demo", "reason": "pure static text: renders fixed explanatory strings to stdout; no output-mode, dry-run, verbose, project-root, or clock dependency" },
-    { "module": "quickstart", "reason": "pure static text: prints a fixed single-pass workflow summary to stdout; no host seam of any kind" },
+    { "module": "quickstart", "reason": "pure static text: prints a fixed RPI workflow summary to stdout; no host seam of any kind" },
     { "module": "robotdocs", "reason": "pure read of the live cobra command tree: renders a Markdown-only handbook; no JSON/YAML variant and no other host seam" }
   ]
 }

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -30,7 +30,7 @@ ao demo [flags]
 ```
       --concepts   explain the product boundary
   -h, --help       help for demo
-      --quick      show the compact one-pass example
+      --quick      show the compact RPI example
 ```
 
 ---

--- a/cli/internal/commands/demo/module.go
+++ b/cli/internal/commands/demo/module.go
@@ -53,7 +53,7 @@ func (Module) Command() *cobra.Command {
 		Short: "Show one RPI traversal",
 		Long: `Show the AgentOps product boundary:
 
-  RPI -> Plan -> Implement -> fresh Validate -> report and stop
+  RPI -> Plan -> Implement -> fresh Validate -> repair to convergence -> report
 
 The repository keeps its own Git, CI, tracker, release, and delivery policy.`,
 		GroupID: "start",

--- a/cli/internal/commands/demo/module.go
+++ b/cli/internal/commands/demo/module.go
@@ -64,7 +64,7 @@ The repository keeps its own Git, CI, tracker, release, and delivery policy.`,
 			return quickDemo(cmd.OutOrStdout())
 		},
 	}
-	command.Flags().BoolVar(&quick, "quick", false, "show the compact one-pass example")
+	command.Flags().BoolVar(&quick, "quick", false, "show the compact RPI example")
 	command.Flags().BoolVar(&concepts, "concepts", false, "explain the product boundary")
 	return command
 }
@@ -82,14 +82,15 @@ or delivery. Learn and multi-agent strategies are optional callers.`)
 }
 
 func quickDemo(w io.Writer) error {
-	fmt.Fprintln(w, `AGENTOPS ONE-PASS DEMO
+	fmt.Fprintln(w, `AGENTOPS RPI DEMO
 
 1. Plan refines one active behavior and write scope in the existing intent source.
 2. Implement runs one bounded RED -> GREEN -> refactor experiment.
 3. The runtime derives changed paths, check receipts, and subject-manifest.v1.
-4. A distinct fresh context validates the exact intent and subject once.
+4. A distinct fresh context validates the exact intent and subject.
 5. Validate returns one fresh validation result; verdict.v2 persistence is optional.
-6. RPI reports PASS, FAIL, NOT_PROVEN, NOT_PLANNED, or NOT_BUILT and stops.
+6. FAIL or NOT_PROVEN with findings repairs and re-validates under the convergence law
+   within the caller's repair_rounds; RPI reports PASS, FAIL, NOT_PROVEN, NOT_PLANNED, or NOT_BUILT.
 
 No Git repository or ao binary is required for this semantic traversal.`)
 	return nil

--- a/cli/internal/commands/demo/module_test.go
+++ b/cli/internal/commands/demo/module_test.go
@@ -32,12 +32,12 @@ func TestModule_CommandAttributes(t *testing.T) {
 	}
 }
 
-func TestDemoShowsOnePassBoundary(t *testing.T) {
+func TestDemoShowsBoundedRepairBoundary(t *testing.T) {
 	var out bytes.Buffer
 	if err := quickDemo(&out); err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"AGENTOPS ONE-PASS DEMO", "existing intent source", "runtime derives", "subject-manifest.v1", "fresh validation result", "persistence is optional", "stops"} {
+	for _, want := range []string{"AGENTOPS RPI DEMO", "existing intent source", "runtime derives", "subject-manifest.v1", "fresh validation result", "persistence is optional", "stops"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("demo missing %q:\n%s", want, out.String())
 		}
@@ -69,8 +69,8 @@ func TestPublishedDemoQuick(t *testing.T) {
 	if err := command.Execute(); err != nil {
 		t.Fatalf("ao demo --quick failed: %v\n%s", err, out.String())
 	}
-	if !strings.Contains(out.String(), "AGENTOPS ONE-PASS DEMO") {
-		t.Fatalf("demo output missing one-pass example:\n%s", out.String())
+	if !strings.Contains(out.String(), "AGENTOPS RPI DEMO") {
+		t.Fatalf("demo output missing the RPI example:\n%s", out.String())
 	}
 }
 

--- a/cli/internal/commands/demo/module_test.go
+++ b/cli/internal/commands/demo/module_test.go
@@ -37,7 +37,7 @@ func TestDemoShowsBoundedRepairBoundary(t *testing.T) {
 	if err := quickDemo(&out); err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"AGENTOPS RPI DEMO", "existing intent source", "runtime derives", "subject-manifest.v1", "fresh validation result", "persistence is optional", "stops"} {
+	for _, want := range []string{"AGENTOPS RPI DEMO", "existing intent source", "runtime derives", "subject-manifest.v1", "fresh validation result", "persistence is optional", "convergence law"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("demo missing %q:\n%s", want, out.String())
 		}

--- a/cli/internal/commands/quickstart/module.go
+++ b/cli/internal/commands/quickstart/module.go
@@ -1,5 +1,5 @@
 // Package quickstart owns Cobra presentation for the `ao quick-start` command.
-// The command prints a static single-pass workflow summary, so it performs no
+// The command prints a static RPI workflow summary, so it performs no
 // filesystem, process, or clock effect.
 package quickstart
 
@@ -41,11 +41,11 @@ func (Module) Contract() clicontract.CommandContract {
 func (Module) Command() *cobra.Command {
 	return &cobra.Command{
 		Use:   "quick-start",
-		Short: "Show the single-pass AgentOps workflow",
+		Short: "Show the AgentOps RPI workflow",
 		Long: `AgentOps is a small semantic evidence layer around agent work.
 
-Run the RPI skill for one pass:
-  Plan -> Implement -> fresh Validate -> report and stop
+Run the RPI skill for one traversal:
+  Plan -> Implement -> fresh Validate -> repair to convergence -> report
 
 The CLI does not claim work, retry, manage Git, or deliver changes. Use
 ao gate check for deterministic repository checks and ao provenance for
@@ -53,7 +53,7 @@ generic evidence inspection.`,
 		Args:    cobra.NoArgs,
 		GroupID: "start",
 		Run: func(cmd *cobra.Command, _ []string) {
-			fmt.Fprintln(cmd.OutOrStdout(), "RPI -> Plan -> Implement -> fresh Validate -> report and stop")
+			fmt.Fprintln(cmd.OutOrStdout(), "RPI -> Plan -> Implement -> fresh Validate -> repair to convergence -> report")
 			fmt.Fprintln(cmd.OutOrStdout(), "Deterministic checks: ao gate check")
 			fmt.Fprintln(cmd.OutOrStdout(), "Semantic judgment: invoke the Validate skill from a fresh context")
 			fmt.Fprintln(cmd.OutOrStdout(), "Artifact persistence: optional; request verdict.v2 only for machine-readable evidence")

--- a/cli/internal/commands/quickstart/module_test.go
+++ b/cli/internal/commands/quickstart/module_test.go
@@ -35,7 +35,7 @@ func TestModule_CommandAttributes(t *testing.T) {
 	if command.GroupID != "start" {
 		t.Errorf("GroupID = %q, want start", command.GroupID)
 	}
-	if command.Short != "Show the single-pass AgentOps workflow" {
+	if command.Short != "Show the AgentOps RPI workflow" {
 		t.Errorf("Short = %q", command.Short)
 	}
 }
@@ -46,7 +46,7 @@ func TestCommand_RunPrintsWorkflow(t *testing.T) {
 	command.SetOut(&out)
 	command.Run(command, nil)
 	for _, want := range []string{
-		"RPI -> Plan -> Implement -> fresh Validate -> report and stop",
+		"RPI -> Plan -> Implement -> fresh Validate -> repair to convergence -> report",
 		"Deterministic checks: ao gate check",
 		"Semantic judgment: invoke the Validate skill from a fresh context",
 		"Artifact persistence: optional",

--- a/cli/testdata/compatibility-baseline/families/demo/case.json
+++ b/cli/testdata/compatibility-baseline/families/demo/case.json
@@ -4,7 +4,7 @@
   "checks": [
     {
       "id": "demo-black-box",
-      "command": "tmp=$(mktemp -d /tmp/ao-demo.XXXXXX); (cd cli && go build -o \"$tmp/ao\" ./cmd/ao); \"$tmp/ao\" demo --help >\"$tmp/help\"; grep -Fq 'Show the one-pass AgentOps evidence loop' \"$tmp/help\"; grep -Fq 'RPI -> Plan -> Implement -> fresh Validate' \"$tmp/help\"; grep -Fq 'quick' \"$tmp/help\"; grep -Fq 'concepts' \"$tmp/help\"; \"$tmp/ao\" demo >\"$tmp/default\"; grep -Fq 'AGENTOPS ONE-PASS DEMO' \"$tmp/default\"; \"$tmp/ao\" demo --quick >\"$tmp/quick\"; grep -Fq 'AGENTOPS ONE-PASS DEMO' \"$tmp/quick\"; grep -Fq 'subject-manifest.v1' \"$tmp/quick\"; \"$tmp/ao\" demo --concepts >\"$tmp/concepts\"; grep -Fq 'AGENTOPS PRODUCT BOUNDARY' \"$tmp/concepts\"; grep -Fq 'does not own retries' \"$tmp/concepts\""
+      "command": "tmp=$(mktemp -d /tmp/ao-demo.XXXXXX); (cd cli && go build -o \"$tmp/ao\" ./cmd/ao); \"$tmp/ao\" demo --help >\"$tmp/help\"; grep -Fq 'Show the one-pass AgentOps evidence loop' \"$tmp/help\"; grep -Fq 'RPI -> Plan -> Implement -> fresh Validate' \"$tmp/help\"; grep -Fq 'quick' \"$tmp/help\"; grep -Fq 'concepts' \"$tmp/help\"; \"$tmp/ao\" demo >\"$tmp/default\"; grep -Fq 'AGENTOPS RPI DEMO' \"$tmp/default\"; \"$tmp/ao\" demo --quick >\"$tmp/quick\"; grep -Fq 'AGENTOPS RPI DEMO' \"$tmp/quick\"; grep -Fq 'subject-manifest.v1' \"$tmp/quick\"; \"$tmp/ao\" demo --concepts >\"$tmp/concepts\"; grep -Fq 'AGENTOPS PRODUCT BOUNDARY' \"$tmp/concepts\"; grep -Fq 'does not own retries' \"$tmp/concepts\""
     },
     {
       "id": "demo-go-behavior",

--- a/cli/testdata/compatibility-baseline/families/quickstart/case.json
+++ b/cli/testdata/compatibility-baseline/families/quickstart/case.json
@@ -4,7 +4,7 @@
   "checks": [
     {
       "id": "quickstart-black-box",
-      "command": "tmp=$(mktemp -d /tmp/ao-quickstart.XXXXXX); (cd cli && go build -o \"$tmp/ao\" ./cmd/ao); \"$tmp/ao\" quick-start --help >\"$tmp/help\"; grep -Fq 'Show the single-pass AgentOps workflow' \"$tmp/help\"; grep -Fq 'AgentOps is a small semantic evidence layer around agent work' \"$tmp/help\"; \"$tmp/ao\" quick-start >\"$tmp/text\"; grep -Fq 'RPI -> Plan -> Implement -> fresh Validate -> report and stop' \"$tmp/text\"; grep -Fq 'Deterministic checks: ao gate check' \"$tmp/text\"; grep -Fq 'Semantic judgment: invoke the Validate skill from a fresh context' \"$tmp/text\"; grep -Fq 'Artifact persistence: optional' \"$tmp/text\"; if \"$tmp/ao\" quick-start extra-arg >/dev/null 2>&1; then echo 'quick-start accepted a positional arg' >&2; exit 1; fi"
+      "command": "tmp=$(mktemp -d /tmp/ao-quickstart.XXXXXX); (cd cli && go build -o \"$tmp/ao\" ./cmd/ao); \"$tmp/ao\" quick-start --help >\"$tmp/help\"; grep -Fq 'Show the AgentOps RPI workflow' \"$tmp/help\"; grep -Fq 'AgentOps is a small semantic evidence layer around agent work' \"$tmp/help\"; \"$tmp/ao\" quick-start >\"$tmp/text\"; grep -Fq 'RPI -> Plan -> Implement -> fresh Validate -> repair to convergence -> report' \"$tmp/text\"; grep -Fq 'Deterministic checks: ao gate check' \"$tmp/text\"; grep -Fq 'Semantic judgment: invoke the Validate skill from a fresh context' \"$tmp/text\"; grep -Fq 'Artifact persistence: optional' \"$tmp/text\"; if \"$tmp/ao\" quick-start extra-arg >/dev/null 2>&1; then echo 'quick-start accepted a positional arg' >&2; exit 1; fi"
     },
     {
       "id": "quickstart-go-behavior",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,11 +22,14 @@ existing bead or caller intent
   acceptance, and obtains one judgment from a distinct declared context. It
   stores a content-addressed verdict atomically only when requested by the
   caller or a declared downstream consumer.
-- **RPI** invokes each core phase at most once and reports the result.
+- **RPI** invokes Plan and Implement at most once, validates freshly, and on
+  `FAIL` or `NOT_PROVEN` with findings repairs and re-validates under the
+  convergence law within the caller's `repair_rounds` (ADR-0017).
 
-`FAIL` and `NOT_PROVEN` are terminal results for that invocation. A caller may
-update the existing intent source and start a new invocation. RPI never creates
-a parallel revision record or revises the subject automatically.
+`FAIL` and `NOT_PROVEN` are terminal when the law stops the repair phase or the
+rounds are spent. A caller may update the existing intent source and start a new
+invocation. RPI never creates a parallel revision record and never widens the
+caller's bound.
 
 ## Hexagonal boundary
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,8 @@ existing bead or caller intent
   -> runtime-derived subject-manifest.v1 + check receipts
   -> fresh Validate
   -> PASS | FAIL | NOT_PROVEN
-  -> RPI report and stop
+  -> bounded repair under the convergence law (ADR-0017)
+  -> RPI report
 ```
 
 ## Core

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -13,7 +13,7 @@ Repositories own delivery policy for local and cloud agents.
 ## Separation of responsibilities
 
 ```text
-AgentOps: Plan -> Implement once -> Validate once -> report and stop
+AgentOps: Plan -> Implement once -> fresh Validate -> bounded repair -> report
 Repository: deterministic checks -> repository-selected Git/CI/release policy
 ```
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -6,7 +6,7 @@
 | Check receipt | Factual result of a deterministic check over an identified input. |
 | Fresh validator | A declared context identity distinct from the subject author. |
 | Intent source | The caller-owned bead, issue, or conversation containing acceptance, non-goals, evidence needs, and write scope. |
-| RPI | The one-pass wrapper around Plan, Implement, and Validate. |
+| RPI | The wrapper around Plan, Implement, fresh Validate, and a bounded repair phase under the convergence law. |
 | Subject manifest | Deterministic content identity over paths, kinds, executable bits, and content or symlink digests. |
 | Validate | Independent semantic judgment over exact acceptance and subject identities. |
 | Validation result | `PASS`, `FAIL`, or `NOT_PROVEN` returned by a fresh validator. |

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -3,8 +3,11 @@
 AgentOps now owns one small product boundary:
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> repair to convergence -> report
 ```
+
+(The 3.0 through 3.6 releases stopped after one validation; ADR-0017 added the
+bounded repair phase.)
 
 The caller owns whether to revise, run another invocation, schedule work, use a
 tracker, manage Git, or deliver the result. Deterministic repository checks stay

--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -42,7 +42,7 @@
 | `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
-| `crank` | meta | `keep` | - | `execute_wave` | `dispatch_rpi_per_lane` |
+| `crank` | meta | `keep` | `rpi` | `execute_wave` | `dispatch_rpi_per_lane` |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
 | `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |

--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -2,11 +2,11 @@
 
 # Skill Router
 
-56 live skills. Metadata is the sole inventory and graph source.
+57 live skills. Metadata is the sole inventory and graph source.
 
 ## keep
 
-`implement`, `plan`, `rpi`, `validate`
+`crank`, `implement`, `plan`, `rpi`, `validate`
 
 ## keep_off_path
 
@@ -42,6 +42,7 @@
 | `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
+| `crank` | meta | `keep` | - | `execute_wave` | `dispatch_rpi_per_lane` |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
 | `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -42,7 +42,7 @@
 | `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
-| `crank` | meta | `keep` | - | `execute_wave` | `dispatch_rpi_per_lane` |
+| `crank` | meta | `keep` | `rpi` | `execute_wave` | `dispatch_rpi_per_lane` |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
 | `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -2,11 +2,11 @@
 
 # Skill Router
 
-56 live skills. Metadata is the sole inventory and graph source.
+57 live skills. Metadata is the sole inventory and graph source.
 
 ## keep
 
-`implement`, `plan`, `rpi`, `validate`
+`crank`, `implement`, `plan`, `rpi`, `validate`
 
 ## keep_off_path
 
@@ -42,6 +42,7 @@
 | `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
+| `crank` | meta | `keep` | - | `execute_wave` | `dispatch_rpi_per_lane` |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
 | `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -25,11 +25,16 @@ Three actions prevent broken workflows after upgrading:
    scripts are refusing tombstones. To track skills from source instead, see
    the next section.
 
-The semantic loop is now:
+The semantic loop became (3.0 through 3.6):
 
 ```text
 RPI -> Plan -> Implement -> fresh Validate -> report and stop
 ```
+
+As of ADR-0017 (2026-09-03) a bounded repair phase follows Validate:
+`FAIL` or `NOT_PROVEN` with findings repairs and re-validates under the
+convergence law within the caller's `repair_rounds`; the single-pass line above
+is historical.
 
 AgentOps no longer owns retry, queue, work-claim, Git, closure, release, or
 delivery state. Plan shapes one behavior, Implement runs one bounded experiment,

--- a/docs/adr/ADR-0017-loop-as-control-flow-not-knowledge.md
+++ b/docs/adr/ADR-0017-loop-as-control-flow-not-knowledge.md
@@ -1,0 +1,109 @@
+# ADR-0017: The Loop Is Control Flow, Not Knowledge
+
+- **Status:** Accepted (2026-09-03)
+- **Author:** AgentOps maintainers
+- **Builds on:** [ADR-0004](ADR-0004-corpus-moat-unproven-position-on-the-system.md) (corpus moat unproven, position on the verification system), [ADR-0011](ADR-0011-escape-corpus-compounding-unproven-structural-starvation.md) (escape-corpus compounding demoted to hypothesis)
+- **Origin:** `docs/plans/2026-09-03-loop-restore.md` (this decision's intent source), and the 2026-09-02 Train 1 run, where the repair loop had to be improvised by hand
+
+## Context
+
+The 2026-07-14 cut (`482307762`, 2,433 files, −416K lines) removed the
+compounding-knowledge machinery and the iterate loop in the same pass. It took
+out `converge`, `crank`, `discovery`, `evolve`, and the learn write-half
+together, as one class.
+
+They were not one class. ADR-0004 and ADR-0011 demoted a knowledge claim: that
+an escape corpus accrues and compounds into an advantage. Neither ADR said
+anything about control flow. Converge was not a knowledge store: it was the
+criterion for when repair stops. Crank was not a corpus: it was a wave
+executor. The cut removed them because they sat next to the unproven claim, not
+because anything demoted them.
+
+What that costs showed up on 2026-09-02. The Train 1 run needed repair and
+re-validation, and the contract had no repair phase, so the loop was improvised
+by hand: 8 validators and 2 stops, with the stopping rule living in an
+orchestrator's judgment instead of in the contract. An improvised loop is not
+reproducible and cannot be judged.
+
+## Decision
+
+Restore the control flow the cut over-reached on, and only that.
+
+1. **Converge's criterion returns as RPI's repair phase**, bounded by the
+   convergence law from the plan. A repair round is admitted only while all
+   hold:
+   1. `rounds_used < repair_rounds` (caller-declared, default 2).
+   2. The open finding set, keyed by the validators' stable `findings[].id`
+      (union across the fresh and, when used, cross-family validators), is not
+      larger than the previous round's.
+   3. No finding id closed in an earlier round reopens.
+   4. Between rounds either the subject-manifest digest changed
+      (generated-only changes count when they change the digest) or, for
+      `NOT_PROVEN`, new digest-bound evidence was supplied that resolves a
+      named gap.
+
+   Converged means the fresh validator returns PASS and, when the diff touches
+   a risky surface, the cross-family validator also returns PASS. On any
+   violation RPI stops and reports the current status. No third judge, no
+   escalation, no auto-replan.
+
+2. **Crank's shape returns as a thin wave executor.** One invocation executes
+   one caller-selected wave, runs the wave's acceptance once, returns wave
+   evidence, and stops. It owns no wave selection, retry, budget, queue, claim,
+   lease, Git, closure, or next work.
+
+3. **Cross-family validation is the default on risky surfaces**
+   (`cli/internal/gates/**`, `scripts/check-*.sh`, `tests/**`,
+   `skills/*/scripts/**`, `skills/cc-hooks/policies/**`, `lib/**`, anything
+   `security-gate.sh` scans), caller-elected elsewhere. Dispatch obeys the
+   runtime floor: orchestrating in Claude, the judge leg is a read-only
+   `codex exec`; orchestrating in Codex, the judge leg is a caller-selected
+   interactive Claude session in an NTM pane. `claude -p` and `claude --print`
+   are never used, directly or indirectly. With no authorized live adapter the
+   request is disclosed as `diversity_unsatisfied`, and on a risky surface that
+   is `NOT_PROVEN` rather than same-family convergence.
+
+### Conformance assertions flipped
+
+This ADR is the sole authority for flipping the assertions below. They encode
+the cut's over-reach, not a demoted claim, and they are flipped by lane L-A of
+the plan:
+
+- `scripts/check-cathedral-cut-conformance.py`: crank listed as removed; RPI
+  required to contain "Stop regardless"; loops in `run_once.py` rejected.
+- `workflows/rpi.js`: single-pass traversal.
+- `skills/rpi/scripts/validate.sh`: single-pass assertion.
+- `skills/rpi/tests/test_run_once.py`: stop-on-FAIL.
+- `evals/agentops-core/rpi-behavior.json`: single-pass behavior expectation.
+
+### What stays unproven
+
+- Compounding stays unproven. ADR-0004 and ADR-0011 remain in force; nothing
+  here reopens a corpus, a knowledge store, or an accrual claim.
+- The loop's own effect on outcomes is unproven. Restoring a repair phase is a
+  contract change, not evidence that repair produces better subjects. That is
+  owed a seeded-defect probe, and until one runs, the loop is justified by the
+  improvisation it replaces, not by measured lift.
+
+### What stays removed
+
+- `ao converge` and `ao crank` as root commands.
+- `evolve`, and the ADR-0007 operator-stop rules.
+- The learn write-half.
+- Discovery's packet machinery.
+- Converge's Go command, its canary, and its findings registry; crank's flags,
+  lifecycle tiers, and Sisyphus markers.
+
+## Consequences
+
+- RPI can end in a repaired PASS instead of only a first-pass verdict, and the
+  stopping rule is in the contract where a validator can check it, rather than
+  in an orchestrator's judgment.
+- A repair round that cannot show a subject or evidence change is a stop, not a
+  retry. That is the anti-ceremony guard: rounds that produce only control
+  artifacts end the run.
+- Risky-surface changes cost a second judge leg. When no legal adapter is
+  available, the honest outcome is `NOT_PROVEN` and the change waits.
+- The removed surfaces stay removed. A future proposal to bring back a
+  knowledge store or a lifecycle command does not inherit this ADR's
+  permission; it needs its own, with evidence.

--- a/docs/adr/ADR-0017-loop-as-control-flow-not-knowledge.md
+++ b/docs/adr/ADR-0017-loop-as-control-flow-not-knowledge.md
@@ -94,6 +94,11 @@ the plan:
 - Converge's Go command, its canary, and its findings registry; crank's flags,
   lifecycle tiers, and Sisyphus markers.
 
+Two narrow authorizations ride on this decision: the skill mesh permits exactly
+one non-core hard dependency, `crank` on `rpi` (`scripts/generate-skill-mesh.py`),
+and the Claude conveyor's cross-family leg is a caller-supplied read-only command
+whose model family the script cannot verify and does not claim to.
+
 ## Consequences
 
 - RPI can end in a repaired PASS instead of only a first-pass verdict, and the

--- a/docs/agent-workflow-reference.md
+++ b/docs/agent-workflow-reference.md
@@ -7,7 +7,7 @@ traversal through its federated integration graph is one pass
 (exact semantics: [rpi-traversal.md](architecture/rpi-traversal.md)):
 
 ```text
-RPI -> anti-ceremony guard -> Plan -> Implement -> fresh Validate -> report and stop
+RPI -> anti-ceremony guard -> Plan -> Implement -> fresh Validate -> bounded repair -> report
 ```
 
 ## 1. Pre-dispatch guard

--- a/docs/architecture/component-map.md
+++ b/docs/architecture/component-map.md
@@ -19,7 +19,7 @@ work-and-proof protocol between the nodes; it absorbs none of their state.
 
 The standard traversal across these nodes is the
 [RPI traversal](rpi-traversal.md): Plan -> Implement -> fresh Validate ->
-report and stop. Vocabulary is fixed in
+bounded repair to convergence -> report. Vocabulary is fixed in
 [the ubiquitous language](../contracts/ubiquitous-language.md).
 
 ## Responsibilities

--- a/docs/architecture/rpi-traversal.md
+++ b/docs/architecture/rpi-traversal.md
@@ -130,9 +130,12 @@ verdict afterward, but ledger availability never affects validity.
 ## Stop boundary and revision
 
 RPI invokes the anti-ceremony guard exactly once. On `CONTINUE`, RPI invokes
-Plan, Implement, and Validate at most once and then stops; on `STOP`, it invokes
-none of them. A FAIL or NOT_PROVEN report does not repair, replan, consult a
-helper, escalate, or invoke a second phase. `NOT_PLANNED` and `NOT_BUILT`
+Plan and Implement at most once; on `STOP`, it invokes none of them. Validate
+repeats only inside the bounded repair phase (ADR-0017): a `FAIL` or
+`NOT_PROVEN` with findings is repaired and re-validated freshly while the
+convergence law admits another round, and RPI stops when converged, stopped by
+the law, or out of the caller's `repair_rounds`. The law is stated once, in
+`skills/rpi/SKILL.md`. RPI does not replan, consult a helper, or escalate. `NOT_PLANNED` and `NOT_BUILT`
 describe RPI progress only and are not verdict values.
 
 If a caller wants another experiment, it updates the existing bead or caller

--- a/docs/architecture/rpi-traversal.md
+++ b/docs/architecture/rpi-traversal.md
@@ -16,11 +16,13 @@ intent
           -> runtime-derived subject-manifest.v1 + check receipts
           -> one fresh independent validation
           -> PASS | FAIL | NOT_PROVEN
-          -> report and stop
+          -> FAIL / NOT_PROVEN with findings: bounded repair under the
+             convergence law (caller's repair_rounds), re-validate freshly
+          -> report when converged, stopped by the law, or out of rounds
 ```
 
-One traversal is one experiment. The caller, a Goal, or a factory decides
-whether to start another; the traversal itself never continues.
+One traversal is one experiment plus its bounded repair. The caller, a Goal, or
+a factory decides whether to start another; the traversal never selects it.
 
 ## Roles
 

--- a/docs/contracts/bounded-contexts.yaml
+++ b/docs/contracts/bounded-contexts.yaml
@@ -17,8 +17,8 @@ bounded_contexts:
 
   - id: BC3
     name: Experiment
-    product_layer: "One-pass RPI"
-    responsibility: "Shape one behavior, run one bounded experiment, report one verdict, and stop."
+    product_layer: "Bounded-repair RPI"
+    responsibility: "Shape one behavior, run one bounded experiment, repair to convergence under the caller's bound, report one verdict."
     center_of_gravity: [rpi, plan, implement]
     ports: [PlanPort, ImplementPort, ValidatePort]
 

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -6,6 +6,7 @@
 
 | Source | Target |
 |---|---|
+| `crank` | `rpi` |
 | `rpi` | `anti-ceremony` |
 | `rpi` | `implement` |
 | `rpi` | `plan` |

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -30,6 +30,7 @@
 | `codebase-recon` | `customer-of` | `validate` |
 | `codex-exec` | `supplier-to` | `validate` |
 | `craft-goal` | `supplier-to` | `plan` |
+| `crank` | `customer-of` | `rpi` |
 | `fitness` | `shared-kernel` | `standards` |
 | `goals` | `alias-of` | `fitness` |
 | `idea-genie` | `customer-of` | `research` |
@@ -98,6 +99,9 @@
 | `craft-goal` | consumes | `goal-acceptance` |
 | `craft-goal` | produces | `outer-goal-prompt` |
 | `craft-goal` | produces | `goal-safety-report` |
+| `crank` | consumes | `rpi` |
+| `crank` | consumes | `caller-selected-wave` |
+| `crank` | produces | `wave-evidence` |
 | `doc` | consumes | `repo-context` |
 | `doc` | produces | `documentation` |
 | `domain` | produces | `stdout` |

--- a/docs/contracts/skill-ports-and-adapters.md
+++ b/docs/contracts/skill-ports-and-adapters.md
@@ -10,7 +10,7 @@ an AgentOps-owned control level.
 caller product boundary + fitness evidence
   -> caller-selected Goal / Mayor campaign (execution orchestrator)
        -> select one experiment intent
-       -> RPI traversal: anti-ceremony guard -> Plan -> Implement -> fresh Validate -> report and stop
+       -> RPI traversal: anti-ceremony guard -> Plan -> Implement -> fresh Validate -> bounded repair -> report
        -> consume the immutable report and verdict
        -> ratchet the graph, select another experiment, or stop
   -> optional post-verdict learning

--- a/docs/contracts/ubiquitous-language.md
+++ b/docs/contracts/ubiquitous-language.md
@@ -7,7 +7,7 @@
 | Operations layer | The product category: the portable layer that makes heterogeneous agentic engineering systems interoperate semantically. |
 | Federated integration graph | The topology: caller-owned intent, source systems, agents, factories, checks, and judgments remain separate nodes joined by typed handoffs. |
 | Semantic work-and-proof protocol | The interoperability contract: exact intent, exact subject, evidence, fresh judgment, and honest outcomes. |
-| RPI traversal | One standard path through the graph: Plan -> Implement -> fresh Validate -> report and stop. |
+| RPI traversal | One standard path through the graph: Plan -> Implement -> fresh Validate -> bounded repair to convergence -> report. |
 
 The traversal is RPI. The graph is the topology. The protocol defines
 interoperability. The operations layer is the product.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,9 +1,9 @@
 # How it works
 
-RPI is a thin one-pass coordinator.
+RPI is a thin coordinator with one bounded repair loop (ADR-0017).
 
 ```text
-Plan once -> Implement once -> Validate once -> Report -> Stop
+Plan once -> Implement once -> fresh Validate -> repair under the convergence law -> Report
 ```
 
 Plan turns intent into testable acceptance and a bounded write scope. Implement

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ that own work, execution, or delivery. It turns one intent into one
 evidence-bound engineering judgment:
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> repair to convergence -> report
 ```
 
 The product supplies behavior-first planning, one bounded implementation

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -10,7 +10,7 @@ own work. AgentOps therefore provides a small evidence protocol:
 
 ```text
 intent -> one bounded experiment -> exact subject identity
-       -> fresh independent judgment -> report and stop
+       -> fresh independent judgment -> bounded repair -> report
 ```
 
 The protocol is behavior-first. Plan expresses one behavior as normal and edge

--- a/docs/plans/2026-09-02-legible-membrane-plan.md
+++ b/docs/plans/2026-09-02-legible-membrane-plan.md
@@ -6,12 +6,6 @@
 > r5; execution proceeded on Bo's instruction. Fresh per-lane validators PASS;
 > two cross-family train reviews, all findings closed on the landed tip.
 > Train 2 (corpus reorganization) is a named successor,
-> **Train state (09-02 evening):** branch `legible/l2` @ `7e9edc770`, 8 commits
-> on `b0c81349d` (L1 ×4, L2 ×3, I-1 seam fix ×1); L3 excluded (second fresh
-> validation FAIL, awaiting Bo). L1 PASS (fresh), L2 PASS (fresh), I-1 FAIL →
-> one seam fix (stale literal) → re-validation pending; cross-family train
-> review r1 FAIL (7) → all 7 closed on tip → r2 pending. Full gate 71/71 (HEAD
-> binary), run-all green, Go bar green, security quick PASS, lint clean.
 > not part of this intent. · **Intent source:** this document, once Bo
 > accepts. **Provenance:** 2026-09-02 five-lane field audit, artifact
 > <https://claude.ai/code/artifact/b7dfc5c2-e1a9-4ac0-a613-dcbdee5833b8>;
@@ -27,6 +21,13 @@
 > `skills/*/scripts/**/*.py`; no advisory gate promoted to blocking; the one
 > acceptance change (the Codex catalog average) is named, measured, and
 > justified in the commit body against its original intent.
+>
+> **Train state (09-02 evening):** branch `legible/l2` @ `7e9edc770`, 8 commits
+> on `b0c81349d` (L1 ×4, L2 ×3, I-1 seam fix ×1); L3 excluded (second fresh
+> validation FAIL, awaiting Bo). L1 PASS (fresh), L2 PASS (fresh), I-1 FAIL →
+> one seam fix (stale literal) → re-validation pending; cross-family train
+> review r1 FAIL (7) → all 7 closed on tip → r2 pending. Full gate 71/71 (HEAD
+> binary), run-all green, Go bar green, security quick PASS, lint clean.
 
 ## Caller-visible outcome (the one behavior)
 

--- a/docs/plans/2026-09-03-loop-restore.md
+++ b/docs/plans/2026-09-03-loop-restore.md
@@ -1,0 +1,202 @@
+# Loop restore: converge and crank as control flow under the verdict contract
+
+> **Status:** r2 2026-09-03, EXECUTED on Bo's "do it" (landed with this PR; lanes A, B, C plus per-lane regen commits). r1 had one cross-family
+> read (13 findings, all folded here; that read is the only plan review this
+> intent gets). · **Intent source:** this document. **Provenance:** the
+> 2026-09-03 finding that the 2026-07-14 single-pass cut (`482307762`) removed
+> the iterate loop together with the unproven compounding claim, although
+> ADR-0011 demoted only the latter; and the 2026-09-02 Train 1 run, where the
+> loop was improvised by hand (8 validators, 2 stops) because the contract had
+> no repair phase. **Retirement:** superseded when the lanes merge.
+> **Consumer:** the lanes, one fresh validator on the final tip, one
+> cross-family read of the integrated diff.
+> **Constraint floor:** no new `ao` root command (`ao converge` / `ao crank`
+> stay removed); no new `skills/*/scripts/**/*.py` (editing grandfathered
+> `run_once.py` is allowed; its tests are exempt; the grandfather file is not
+> touched); `schemas/**` byte-identical; ADR-0004 and ADR-0011 stay in force;
+> **ADR-0017** records the narrow reversal of the cut's over-reach and is the
+> authority for every conformance assertion this plan flips.
+
+## The one behavior
+
+An RPI invocation that gets `FAIL` or `NOT_PROVEN` with findings repairs and
+re-validates under a convergence law bounded by the caller, and stops only
+when converged, stopped by the law, or out of budget. A multi-wave intent is
+executed one wave per `crank` invocation; the caller selects the wave and the
+repair bound, crank forwards them and returns wave evidence. Validate is
+cross-family by default when the diff touches a risky surface, with a
+LAW-0-safe dispatch shape per direction. Premortem stays a single advisory
+judge; Plan names the first check and Implement runs it RED — those phase
+boundaries do not move.
+
+Countermetrics: `ao gate check --full` green (with a HEAD-built binary); CI's
+literal bats command green once on the final integrated tip; routing goldens
+green; no description > 180 chars; the Claude catalog grows by exactly one
+description (crank); `schemas/**` unchanged; the Go build bar green (a Go
+file changes in L-A).
+
+## Ground truth
+
+- Old `converge` (`git show '482307762~1:skills/converge/SKILL.md'`): converged
+  ⇔ ≥ 2 distinct non-author contexts PASS with zero FAIL, each citing the
+  executed acceptance; BLOCK after 3 consecutive failing rounds; the fix step
+  is the orchestrator's; judge legs never mutate. Restored: the criterion.
+  Not restored: the Go command, the canary, the findings registry.
+- Old `crank`: one ready wave, acceptance once, evidence returned, no retry or
+  re-plan inside. Restored: that shape. Not restored: flags, lifecycle tiers,
+  Sisyphus markers, eight references.
+- Assertions that currently forbid the restoration and are flipped ONLY under
+  ADR-0017, all owned by L-A: `scripts/check-cathedral-cut-conformance.py:57-59,991-993,1066-1073`
+  (crank listed as removed; RPI must contain "Stop regardless"; loops in
+  `run_once.py` rejected), `workflows/rpi.js:4-9,179-180` (single-pass),
+  `skills/rpi/scripts/validate.sh:9`, `skills/rpi/tests/test_run_once.py:149`
+  (stop-on-FAIL), `evals/agentops-core/rpi-behavior.json:31-52`. Public
+  single-pass surfaces that must agree: `PRODUCT.md:19,56`, `docs/CI-CD.md:16`,
+  `docs/agent-workflow-reference.md:10`, `cli/internal/commands/quickstart/module.go:44-56`,
+  `tests/scripts/agents-operating-contract.bats:3-20`,
+  `tests/scripts/legible-l1-codex-descriptions.bats:154-168` (the rpi literal).
+- Dispatch legality (`AGENTS.md:74`, `skills/agent-native/references/model-dispatch.md:8,38-46`):
+  Codex is the only permitted headless leg; Claude must be interactive.
+- `verdict.v2` carries `findings[].id` (`schemas/verdict.v2.schema.json:44-54`);
+  categories are neither stable nor present. `not_checked` means unverified
+  in-scope acceptance only (`skills/validate/SKILL.md:82-99`).
+- A new skill must satisfy `schemas/skill-frontmatter.v2.schema.json` (fields
+  `practices`, `hexagonal_role`, `metadata.tier/dependencies/capabilities/effects/canonical_status/disposition`)
+  and `python3 scripts/generate-skill-mesh.py --check`; the probe-coverage
+  denominator excludes meta tier by construction, so no exclusion line.
+- Routing goldens are JSON under `evals/routing-probes/goldens/` per
+  `schemas/pack-quality-expectations.v1.schema.json`; the
+  `tests/explicit-skill-requests` runner is archived and is not proof.
+
+## The convergence law (rpi; crank forwards the caller's bound)
+
+A repair round is admitted only while all hold:
+
+1. `rounds_used < repair_rounds` (caller-declared, default 2).
+2. The open finding set, keyed by the validators' stable `findings[].id`
+   (union across the fresh and, when used, cross-family validators), is not
+   larger than the previous round's.
+3. No finding id closed in an earlier round reopens.
+4. Between rounds either the subject-manifest digest changed (generated-only
+   changes count when they change the digest) or, for `NOT_PROVEN`, new
+   digest-bound evidence was supplied that resolves a named gap.
+
+Converged ⇔ the fresh validator returns PASS and, when the diff touches a
+risky surface, the cross-family validator also returns PASS. On any violation
+of 1-4 RPI stops and reports the current status; `checked` carries one line
+per round (`repair round N: k open findings`), the open findings ride in the
+validation result and the interactive report, and `not_checked` keeps its
+meaning. No third judge, no escalation, no auto-replan.
+
+Risky surface (cross-family default): `cli/internal/gates/**`,
+`scripts/check-*.sh`, `tests/**`, `skills/*/scripts/**`,
+`skills/cc-hooks/policies/**`, `lib/**`, anything `security-gate.sh` scans.
+
+Cross-family dispatch (LAW 0): orchestrating in Claude → judge leg is
+read-only `codex exec`; orchestrating in Codex → judge leg is a caller-selected
+interactive Claude session in an NTM pane, never `claude -p` / `--print`. No
+authorized live adapter ⇒ `diversity_unsatisfied`; on a risky surface that
+stops as `NOT_PROVEN` rather than converging same-family.
+
+## Lanes (parallel build, serialized regen: A → B → C)
+
+Each lane regenerates locally to run its checks but commits regenerated
+outputs only after rebasing onto the previous lane's final tip (A commits its
+own immediately; B rebases onto A then regenerates and commits; C onto B).
+
+**L-A — the RPI contract and every surface that asserts single-pass** (L)
+- `skills/rpi/SKILL.md`: step 5 becomes the repair phase under the law; the
+  spiral breaker fires on a law violation or two consecutive rounds without a
+  subject/evidence change, never on verdict count; new §"Waves" pointing at
+  crank; §"Cross-family" pointing at the dispatch table in validate.
+  Description ≤ 180 with the triggers kept.
+- `skills/rpi/scripts/run_once.py`: model the loop as pure data (validate
+  results with `findings[].id`, subject digest, evidence refs, `repair_rounds`);
+  implement the law; `checked` per-round lines; open findings returned in the
+  result object. RED first in `skills/rpi/tests/test_run_once.py`: converge in
+  one round; stop at budget; stop on growing set; stop on reopened id; stop on
+  unchanged digest without evidence; NOT_PROVEN resolved by evidence only;
+  reworded summaries with the same id are the same finding; cross-family union;
+  generated-only digest change counts; NOT_PLANNED/NOT_BUILT unchanged;
+  replace the old stop-on-FAIL test at `:149`.
+- Flip, under ADR-0017 (cite it in each): `scripts/check-cathedral-cut-conformance.py`
+  (crank restored; "Stop regardless" replaced by the law; bounded loop in
+  `run_once.py` allowed with positive canaries for the law), `workflows/rpi.js`
+  (repair phase), `skills/rpi/scripts/validate.sh:9`, `evals/agentops-core/rpi-behavior.json`.
+- Public surfaces: `AGENTS.md` §"Standard RPI traversal" step 4; `docs/architecture/rpi-traversal.md`
+  §"Stop boundary and revision"; `PRODUCT.md:19,56`; `docs/CI-CD.md:16`;
+  `docs/agent-workflow-reference.md:10`; `cli/internal/commands/quickstart/module.go:44-56`
+  (+ its test if any); `tests/scripts/agents-operating-contract.bats`;
+  `tests/scripts/legible-l1-codex-descriptions.bats` rpi literal.
+- Acceptance: `python3 -m pytest skills/rpi/tests -q` green (≥ 9 new tests);
+  `bash skills/rpi/scripts/validate.sh`; `python3 scripts/check-cathedral-cut-conformance.py`
+  green; `bash scripts/check-skill-python-ratchet.sh --scope head` green with
+  the grandfather file untouched; `cd cli && go build ./... && go vet ./... && go test ./...`;
+  `bats tests/scripts/agents-operating-contract.bats tests/scripts/legible-l1-codex-descriptions.bats`;
+  `bash scripts/regen-all.sh --check` clean after committing regen; `ao gate check --scope head`.
+
+**L-B — crank, thin** (M)
+- New `skills/crank/SKILL.md` ≤ 120 lines: v2-complete frontmatter modelled on
+  `skills/rpi/SKILL.md` (tier meta, disposition keep, dependencies [rpi],
+  capabilities [execute_wave], effects [dispatch_rpi_per_lane]); `## Prompt`
+  and `## It's working if` blocks. Contract: input = the caller's selected wave
+  (a list of lanes with scope, brief, acceptance) and the caller's
+  `repair_rounds`; one invocation executes that wave by invoking RPI per lane
+  (parallel only on disjoint write scopes and disjoint regen surfaces,
+  otherwise serial), runs the wave's acceptance once, returns wave evidence
+  (per-lane status, open findings, subject digests) and stops. Crank owns no
+  wave selection, retry, budget, queue, claim, lease, Git, closure, or next
+  work; it names `workflows/implement-wave.js` as the Claude conveyor only.
+  No reference to `ship-beads`.
+- Routing golden: a complete JSON under `evals/routing-probes/goldens/`
+  (schema `pack-quality-expectations.v1`) expecting crank for "execute the
+  next wave of this plan" and omitting validate; rewrite
+  `tests/explicit-skill-requests/prompts/crank.txt` to the one-wave boundary
+  if it exists; do not cite the archived runner as proof.
+- Acceptance: `bash scripts/validate-skill-frontmatter.sh --strict`;
+  `bash scripts/validate-skill-schema.sh`; `bash scripts/validate-skill-triggers.sh`;
+  `python3 scripts/generate-skill-mesh.py --check` after regen;
+  `bash scripts/check-routing-probe-goldens.sh` green (the new golden green);
+  `bash tests/skills/test-token-budgets.sh`; `bash scripts/check-skill-probe-coverage.sh`
+  green with NO change to the exclusions file; `python3 scripts/check-cathedral-cut-conformance.py`
+  green only after rebasing onto L-A; `ao gate check --scope head`.
+
+**L-C — validate's cross-family default, ADR-0017, doc repairs** (S)
+- `skills/validate/SKILL.md`: §"Cross-model fresh validator" becomes
+  default-on for the risky-surface list with the LAW-0 dispatch table above
+  and the `diversity_unsatisfied` ⇒ `NOT_PROVEN` rule; routine rounds keep the
+  bounded, receipt-driven freshness contract; the full literal CI command set
+  is required once, on the final integrated subject. Description ≤ 180.
+- `docs/adr/ADR-0017-loop-as-control-flow-not-knowledge.md`: Accepted; builds
+  on ADR-0004/0011; records that the 07-14 cut removed control flow the ADRs
+  never demoted; restores converge's criterion and crank's shape under the
+  verdict contract; lists every conformance assertion flipped; states what
+  stays unproven (compounding; the loop's own effect, owed a seeded probe) and
+  what stays removed (`ao converge`, `ao crank`, evolve, the learn write-half).
+  Built by MkDocs: `scripts/docs-build.sh --check` green, links fixed rather
+  than allowlisted.
+- `README.md` traversal line; `docs/plans/2026-09-02-legible-membrane-plan.md`
+  header de-mangled (lines 8-15).
+- Acceptance: `scripts/docs-build.sh --check`; doc-link gate; `ao gate check --scope head`;
+  `rg -n 'report and stop' README.md` shows the amended line.
+
+**I — integration:** rebase B onto A, C onto B; regen after each; final tip:
+`bash scripts/regen-all.sh --check` clean; `ao gate check --full` with a
+HEAD-built binary; CI's literal bats command; Go bar; lint; security quick;
+one fresh validator over the whole diff against this document; one
+cross-family read of the integrated diff (it touches `tests/**` and
+`skills/*/scripts/**`); repair under the law with `repair_rounds = 2`; PR;
+auto-merge.
+
+## Non-goals
+
+No knowledge store, no learn write-half, no `ao converge`/`ao crank`, no
+canary, no evolve or operator-stop rules, no crank flags or lifecycle tiers,
+no premortem loop, no Plan exit change, no `verdict.v2`/`rpi-report.v1`
+change, no Train 2 legibility, no measurement work (move 2), no
+`ship-beads` changes.
+
+## First useful check
+
+`skills/rpi/tests/test_run_once.py::test_repair_stops_when_a_closed_finding_reopens`
+— RED on `main` because `run_once.py` has no repair loop.

--- a/docs/plans/2026-09-03-loop-restore.md
+++ b/docs/plans/2026-09-03-loop-restore.md
@@ -90,7 +90,7 @@ meaning. No third judge, no escalation, no auto-replan.
 
 Risky surface (cross-family default): `cli/internal/gates/**`,
 `scripts/check-*.sh`, `tests/**`, `skills/*/scripts/**`,
-`skills/cc-hooks/policies/**`, `lib/**`, anything `security-gate.sh` scans.
+`skills/cc-hooks/policies/**`, `lib/**`, `.github/workflows/**`, `scripts/security-gate.sh`.
 
 Cross-family dispatch (LAW 0): orchestrating in Claude → judge leg is
 read-only `codex exec`; orchestrating in Codex → judge leg is a caller-selected

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -36,7 +36,7 @@
 | `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
-| `crank` | meta | `keep` | - | `execute_wave` | `dispatch_rpi_per_lane` |
+| `crank` | meta | `keep` | `rpi` | `execute_wave` | `dispatch_rpi_per_lane` |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
 | `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -4,7 +4,7 @@
 
 ## domain
 
-`council`, `domain`, `fitness`, `goals`, `idea-genie`, `one-way-door`, `plan`, `postmortem`, `premortem`, `product`, `reality-check`, `rpi`, `shared`
+`council`, `crank`, `domain`, `fitness`, `goals`, `idea-genie`, `one-way-door`, `plan`, `postmortem`, `premortem`, `product`, `reality-check`, `rpi`, `shared`
 
 ## driven-adapter
 
@@ -36,6 +36,7 @@
 | `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
+| `crank` | meta | `keep` | - | `execute_wave` | `dispatch_rpi_per_lane` |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
 | `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |

--- a/docs/reference/agentops-skill-graph.md
+++ b/docs/reference/agentops-skill-graph.md
@@ -18,6 +18,7 @@ graph LR
   converter["converter"]
   council["council"]
   craft_goal["craft-goal"]
+  crank["crank"]
   dcg["dcg"]
   doc["doc"]
   domain["domain"]

--- a/docs/reference/agentops-skill-graph.md
+++ b/docs/reference/agentops-skill-graph.md
@@ -61,6 +61,7 @@ graph LR
   using_gc["using-gc"]
   validate["validate"]
   workflow_builder["workflow-builder"]
+  crank --> rpi
   rpi --> anti_ceremony
   rpi --> implement
   rpi --> plan

--- a/docs/scale-without-swarms.md
+++ b/docs/scale-without-swarms.md
@@ -3,13 +3,14 @@
 AgentOps deliberately keeps its core experiment small:
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> repair to convergence -> report
 ```
 
 Plan names one active behavior and its write scope. Implement performs one
 bounded experiment. Validate independently judges the exact content described
-by the candidate manifest. RPI dispatches each phase once and reports the
-result without deciding what happens next.
+by the candidate manifest. RPI dispatches Plan and Implement once, repairs and
+re-validates under the convergence law within the caller's bound, and reports
+the result without deciding what happens next.
 
 Fresh context is valuable because the author cannot turn its own claim into the
 binding semantic verdict. More agents are not automatically better. One fresh

--- a/docs/templates/kernel.template.md
+++ b/docs/templates/kernel.template.md
@@ -12,7 +12,7 @@
 ## AgentOps loop
 
 ```text
-RPI -> Plan -> Implement -> fresh Validate -> report and stop
+RPI -> Plan -> Implement -> fresh Validate -> repair to convergence -> report
 ```
 
 The caller owns revisions, retries, work organization, Git, CI, release, and

--- a/evals/agentops-core/rpi-behavior.json
+++ b/evals/agentops-core/rpi-behavior.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "id": "agentops-core.rpi-behavior",
-  "name": "AgentOps Single-Pass RPI Canary",
-  "description": "Offline public canary for the Plan, Implement, fresh Validate, durable verdict, report-and-stop boundary.",
+  "name": "AgentOps Bounded-Repair RPI Canary",
+  "description": "Offline public canary for the Plan, Implement, fresh Validate, bounded repair under the convergence law, durable verdict boundary (ADR-0017).",
   "practices": [
     "llm-eval-harness",
     "agile-manifesto"
@@ -17,8 +17,8 @@
     "canary",
     "offline",
     "rpi",
-    "single-pass",
-    "verdict"
+    "verdict",
+    "bounded-repair"
   ],
   "allowed_runtimes": [
     "static",

--- a/evals/agentops-core/rpi-behavior.json
+++ b/evals/agentops-core/rpi-behavior.json
@@ -3,55 +3,120 @@
   "id": "agentops-core.rpi-behavior",
   "name": "AgentOps Single-Pass RPI Canary",
   "description": "Offline public canary for the Plan, Implement, fresh Validate, durable verdict, report-and-stop boundary.",
-  "practices": ["llm-eval-harness", "agile-manifesto"],
+  "practices": [
+    "llm-eval-harness",
+    "agile-manifesto"
+  ],
   "domain": "rpi",
   "visibility": "public_canary",
   "tier": "deterministic",
-  "owners": ["agentops"],
-  "tags": ["canary", "offline", "rpi", "single-pass", "verdict"],
-  "allowed_runtimes": ["static", "shell"],
+  "owners": [
+    "agentops"
+  ],
+  "tags": [
+    "canary",
+    "offline",
+    "rpi",
+    "single-pass",
+    "verdict"
+  ],
+  "allowed_runtimes": [
+    "static",
+    "shell"
+  ],
   "environment": {
     "offline_required": true,
     "network": "forbidden",
-    "scrub_env_prefixes": ["AGENTOPS_RPI_RUNTIME", "ANTHROPIC_", "OPENAI_"],
+    "scrub_env_prefixes": [
+      "AGENTOPS_RPI_RUNTIME",
+      "ANTHROPIC_",
+      "OPENAI_"
+    ],
     "timeout_seconds": 30
   },
   "scoring": {
     "aggregate_threshold": 1,
     "dimensions": [
-      {"name": "correctness", "weight": 2, "threshold": 1, "critical": true},
-      {"name": "process_adherence", "weight": 1, "threshold": 1, "critical": true},
-      {"name": "artifact_quality", "weight": 1, "threshold": 1},
-      {"name": "safety", "weight": 1, "threshold": 1, "critical": true}
+      {
+        "name": "correctness",
+        "weight": 2,
+        "threshold": 1,
+        "critical": true
+      },
+      {
+        "name": "process_adherence",
+        "weight": 1,
+        "threshold": 1,
+        "critical": true
+      },
+      {
+        "name": "artifact_quality",
+        "weight": 1,
+        "threshold": 1
+      },
+      {
+        "name": "safety",
+        "weight": 1,
+        "threshold": 1,
+        "critical": true
+      }
     ]
   },
-  "baseline_policy": {"mode": "compare", "baseline_path": ".agents/evals/baselines/agentops-core.rpi-behavior.baseline.json", "blocking_gate": "none"},
+  "baseline_policy": {
+    "mode": "compare",
+    "baseline_path": ".agents/evals/baselines/agentops-core.rpi-behavior.baseline.json",
+    "blocking_gate": "none"
+  },
   "cases": [
     {
-      "id": "single-pass-reference-tests",
-      "title": "RPI dispatches each core phase at most once",
+      "id": "bounded-repair-reference-tests",
+      "title": "RPI dispatches Plan and Implement once and repairs under the convergence law",
       "kind": "command",
-      "objective": "Prove PASS and FAIL both stop after one Plan, one Implement, and one Validate dispatch.",
+      "objective": "Prove PASS converges, FAIL/NOT_PROVEN repair under the law, and the law's four stop conditions hold (ADR-0017).",
       "runtime": "shell",
       "inputs": {
         "cwd": "../..",
         "shell": "python3 skills/rpi/tests/test_run_once.py && python3 scripts/check-cathedral-cut-conformance.py"
       },
-      "expectations": [{"type": "exit_code", "value": 0}],
-      "dimensions": ["correctness", "process_adherence", "safety"],
+      "expectations": [
+        {
+          "type": "exit_code",
+          "value": 0
+        }
+      ],
+      "dimensions": [
+        "correctness",
+        "process_adherence",
+        "safety"
+      ],
       "critical": true
     },
     {
       "id": "rpi-skill-stop-contract",
-      "title": "RPI reports and stops without continuation authority",
+      "title": "RPI stops when converged, stopped by the law, or out of repair_rounds",
       "kind": "artifact_check",
-      "objective": "Keep the public wrapper anchored to one ordered invocation and caller-owned continuation.",
+      "objective": "Keep the public wrapper anchored to one traversal with a bounded repair phase and caller-owned continuation (ADR-0017).",
       "expectations": [
-        {"type": "artifact_contains", "target": "../../skills/rpi/SKILL.md", "value": "Plan -> Implement -> fresh Validate -> report"},
-        {"type": "artifact_contains", "target": "../../skills/rpi/SKILL.md", "value": "Stop regardless"},
-        {"type": "artifact_contains", "target": "../../skills/rpi/SKILL.md", "value": "Do not append a next action"}
+        {
+          "type": "artifact_contains",
+          "target": "../../skills/rpi/SKILL.md",
+          "value": "Plan -> Implement -> fresh Validate -> bounded repair -> report"
+        },
+        {
+          "type": "artifact_contains",
+          "target": "../../skills/rpi/SKILL.md",
+          "value": "## The convergence law"
+        },
+        {
+          "type": "artifact_contains",
+          "target": "../../skills/rpi/SKILL.md",
+          "value": "Do not append a next action"
+        }
       ],
-      "dimensions": ["process_adherence", "artifact_quality"],
+      "dimensions": [
+        "process_adherence",
+        "artifact_quality"
+      ],
       "critical": true
     },
     {
@@ -64,8 +129,16 @@
         "cwd": "../..",
         "shell": "grep -q NOT_PROVEN schemas/verdict.v2.schema.json && ! grep -q NOT_BUILT schemas/verdict.v2.schema.json && grep -q NOT_BUILT schemas/rpi-report.v1.schema.json"
       },
-      "expectations": [{"type": "exit_code", "value": 0}],
-      "dimensions": ["correctness", "artifact_quality"],
+      "expectations": [
+        {
+          "type": "exit_code",
+          "value": 0
+        }
+      ],
+      "dimensions": [
+        "correctness",
+        "artifact_quality"
+      ],
       "critical": true
     }
   ]

--- a/evals/routing-probes/goldens/rq-07-wave-execution.json
+++ b/evals/routing-probes/goldens/rq-07-wave-execution.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../schemas/pack-quality-expectations.v1.schema.json",
+  "schema_version": 1,
+  "id": "rq-07-wave-execution",
+  "retrieval_surface": "ao-skills-find",
+  "task": "A caller holds an accepted multi-wave plan and wants the next wave run now, with each lane's result reported back rather than a judgment on the whole plan.",
+  "query": "execute the next wave of this plan and report per-lane evidence",
+  "top_k": 3,
+  "expected_selected_ids": ["crank"],
+  "critical_omitted_ids": ["validate"],
+  "forbidden_leaks": ["^(rpi|implement|swarm)$"],
+  "min_provenance_density": 1.0,
+  "max_tokens": 90,
+  "rationale": "crank is the only skill that executes one caller-selected wave lane by lane and returns wave evidence; the request names the wave and the evidence, which is crank's contract verbatim. validate must stay out of the pack: the caller asked for execution, and a wave's semantic results belong to each lane's own fresh validator, never to a wave-level judge. rpi, implement, and swarm are the plausible misroutes — rpi is one lane's traversal, implement is one experiment inside a lane, and swarm dispatches packets with no wave acceptance or evidence contract — so they are pinned out of rank 1 rather than out of the pack.",
+  "notes": "Authored 2026-09-03 with the restored thin crank (docs/plans/2026-09-03-loop-restore.md, lane L-B). Observed pack at authoring: crank, codex-exec, plan at 64 tokens; the 90-token ceiling leaves headroom for one longer neighbour entering ranks 2-3."
+}

--- a/images/claude/manifest.json
+++ b/images/claude/manifest.json
@@ -1,7 +1,7 @@
 {
   "image": "claude",
   "schema_version": "skill-image.v1",
-  "skill_count": 56,
+  "skill_count": 57,
   "skills": [
     {
       "disposition": "keep_specialist",
@@ -72,6 +72,11 @@
       "disposition": "keep_specialist",
       "path": "skills/craft-goal/",
       "slug": "craft-goal"
+    },
+    {
+      "disposition": "keep",
+      "path": "skills/crank/",
+      "slug": "crank"
     },
     {
       "disposition": "keep_specialist",

--- a/images/codex/manifest.json
+++ b/images/codex/manifest.json
@@ -1,7 +1,7 @@
 {
   "image": "codex",
   "schema_version": "skill-image.v1",
-  "skill_count": 56,
+  "skill_count": 57,
   "skills": [
     {
       "disposition": "keep_specialist",
@@ -86,6 +86,12 @@
       "slug": "craft-goal",
       "source_path": "skills/craft-goal/",
       "twin_path": "skills-codex/craft-goal/"
+    },
+    {
+      "disposition": "keep",
+      "slug": "crank",
+      "source_path": "skills/crank/",
+      "twin_path": "skills-codex/crank/"
     },
     {
       "disposition": "keep_specialist",

--- a/images/gemini/plugin.json
+++ b/images/gemini/plugin.json
@@ -1,6 +1,6 @@
 {
   "agents": "./agents",
-  "description": "AgentOps 56-skill metadata-derived bundle for Google Antigravity and Gemini.",
+  "description": "AgentOps 57-skill metadata-derived bundle for Google Antigravity and Gemini.",
   "hooks": "./hooks/hooks.json",
   "mcpServers": {
     "agent-mail": {

--- a/images/gemini/skills/agent-native/SKILL.md
+++ b/images/gemini/skills/agent-native/SKILL.md
@@ -29,8 +29,9 @@ output_contract: runtime evidence for explicit packets
 Operate caller-selected agent sessions as explicit roles without turning the
 runtime into AgentOps lifecycle authority.
 
-For caller-elected multi-model judgment (mixed council, dueling perspectives,
-cross-model validate), follow
+For multi-model judgment (mixed council, dueling perspectives, cross-model
+validate, which is default on risky surfaces per ADR-0017 and caller-elected
+otherwise), follow
 [references/model-dispatch.md](references/model-dispatch.md): the working
 session is the controller; probe `codex-exec` and `ntm` at runtime; never
 require either; never use Agent Mail for judgment; never invoke `claude -p`.

--- a/images/gemini/skills/craft-goal/SKILL.md
+++ b/images/gemini/skills/craft-goal/SKILL.md
@@ -42,7 +42,7 @@ ratchets toward a larger outcome.
 ```text
 Goal / Mayor: observe graph → choose bounded wave → consume verdicts → ratchet
   └─ Bead: durable experiment intent, context, scratch, evidence, and links
-       └─ RPI: plan → implement → fresh validate → verdict → report and stop
+       └─ RPI: plan → implement → fresh validate → bounded repair → verdict → report
             └─ Implementation: one RED → GREEN → refactor experiment
 ```
 

--- a/images/gemini/skills/crank/SKILL.md
+++ b/images/gemini/skills/crank/SKILL.md
@@ -19,7 +19,7 @@ user-invocable: true
 metadata:
   graph_root: true
   tier: meta
-  dependencies: []
+  dependencies: [rpi]
   capabilities: [execute_wave]
   effects: [dispatch_rpi_per_lane]
   canonical_status: canonical

--- a/images/gemini/skills/crank/SKILL.md
+++ b/images/gemini/skills/crank/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: crank
+description: 'Execute one caller-selected wave by invoking RPI once per lane and return the wave evidence, then stop. Triggers: "crank", "execute the next wave", "run this wave".'
+practices:
+- small-batch-flow
+- design-by-contract
+- team-topologies
+hexagonal_role: domain
+consumes:
+- rpi
+- caller-selected-wave
+produces:
+- wave-evidence
+context_rel:
+- kind: customer-of
+  with: rpi
+skill_api_version: 1
+user-invocable: true
+metadata:
+  graph_root: true
+  tier: meta
+  dependencies: []
+  capabilities: [execute_wave]
+  effects: [dispatch_rpi_per_lane]
+  canonical_status: canonical
+  disposition: keep
+output_contract: 'wave evidence: per-lane status, the open findings each lane''s validator left, each lane''s subject manifest digest, and the wave acceptance result'
+---
+
+# Crank
+
+Crank executes exactly one wave. The caller selects the wave and the repair
+bound; crank runs that wave and returns what happened.
+
+```text
+caller's wave + repair_rounds -> RPI per lane -> wave acceptance once -> evidence -> stop
+```
+
+## Input
+
+The caller supplies all three:
+
+- **The wave** — a list of lanes, each with a write `scope`, a `brief`, and its
+  own executable `acceptance`.
+- **`repair_rounds`** — the caller's repair bound, forwarded unchanged to every
+  lane. Crank neither chooses it nor spends it.
+- **The wave acceptance** — the one command set that judges the wave as a whole.
+
+If a lane arrives without a scope, a brief, or an executable acceptance, report
+the wave as unrunnable and stop. Crank does not shape the missing part itself.
+
+## Contract
+
+1. Read the caller's wave as given. Do not select, extend, drop, or re-rank
+   lanes; the wave arrives already decided.
+2. Partition the lanes. Two lanes may run in parallel only when their write
+   scopes are disjoint **and** their regen surfaces (generated outputs,
+   mirrors, manifests) are disjoint. Any shared surface serializes them;
+   unknown overlap counts as overlap.
+3. Invoke [`rpi`](../rpi/SKILL.md) once per lane with that lane's intent,
+   scope, acceptance, and the caller's `repair_rounds`. Each lane's traversal
+   owns its own repair loop. Crank never repairs a lane itself, never
+   re-invokes a returned lane, and never re-plans one.
+4. Run the wave acceptance once, after every lane has returned. A lane that
+   returned `FAIL` or `NOT_PROVEN` does not suppress it; both results are
+   reported side by side.
+5. Return the wave evidence and stop — per-lane status
+   (`PASS | FAIL | NOT_PROVEN | NOT_PLANNED | NOT_BUILT`), the open findings
+   each lane's validator left keyed by their `findings[].id`, each lane's
+   subject manifest digest, and the wave acceptance result.
+
+Append no next action. The caller reads the evidence and decides whether there
+is another wave.
+
+## Boundary
+
+Crank owns no wave selection, retry, budget, queue, claim, lease, Git, closure,
+delivery, or next work, and it mints no verdict of its own. Every semantic
+result in the wave evidence is the one that lane's fresh validator returned,
+cited unchanged; a green wave acceptance is a fact, not a `PASS`.
+
+## Conveyor
+
+In Claude, [`workflows/implement-wave.js`](../../workflows/implement-wave.js)
+is one conveyor for step 3's parallel leg: it runs disjoint-ownership
+implementers over the lanes the caller supplied. It is transport, never a
+substitute for a lane's own fresh validation, and crank runs without it.
+
+## Prompt
+
+```text
+Crank this wave, repair_rounds=2.
+Lane A - scope cli/internal/gates/**, brief "add the probe-coverage gate row",
+acceptance: cd cli && go test ./internal/gates/...
+Lane B - scope docs/CI-CD.md, brief "document that gate row",
+acceptance: bash scripts/docs-build.sh --check
+Wave acceptance: bash tests/run-all.sh. Report per-lane evidence and stop.
+```
+
+## It's working if
+
+Observable in the trace, without reading the prose — and the rubric a fresh
+independent judge scores this skill against:
+
+- The transcript shows exactly one `rpi` invocation per lane in the caller's
+  wave, and no lane appears twice.
+- Two lanes that share a regen surface (both reaching `skills-codex/`, say) run
+  one after the other, never concurrently.
+- The wave acceptance command runs exactly once, after the last lane returns.
+- The returned evidence carries a status and a subject manifest digest for
+  every caller-supplied lane, and for no lane crank invented.
+- The response ends with the evidence: no next wave, no `git` action, and no
+  proposed follow-up work.

--- a/images/gemini/skills/rpi/SKILL.md
+++ b/images/gemini/skills/rpi/SKILL.md
@@ -128,7 +128,7 @@ never mutate the subject. No third judge, no escalation, no auto-replan.
 
 Risky surfaces default to a cross-family fresh validator: `cli/internal/gates/**`,
 `scripts/check-*.sh`, `tests/**`, `skills/*/scripts/**`,
-`skills/cc-hooks/policies/**`, `lib/**`, anything `security-gate.sh` scans.
+`skills/cc-hooks/policies/**`, `lib/**`, `.github/workflows/**`, `scripts/security-gate.sh`.
 [`validate`](../validate/SKILL.md) owns the dispatch table. No authorized live
 adapter means `diversity_unsatisfied`, which on a risky surface is `NOT_PROVEN`.
 

--- a/images/gemini/skills/rpi/SKILL.md
+++ b/images/gemini/skills/rpi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rpi
-description: 'Coordinate one RPI traversal: one bounded Plan, Implement, and fresh Validate experiment, then report and stop. Triggers: "run rpi", "run one traversal", "execute this plan", orchestration or worker delegation that implements changes.'
+description: 'Coordinate one RPI traversal: one bounded Plan and Implement experiment, then fresh Validate and a bounded repair phase to convergence. Triggers: "run rpi", "run one traversal", "execute this plan", orchestration or worker delegation that implements changes.'
 practices:
 - bdd-gherkin
 - tdd
@@ -41,17 +41,21 @@ Run one experiment from the caller's existing intent source through three
 responsibilities and stop:
 
 ```text
-anti-ceremony guard -> Plan -> Implement -> fresh Validate -> report
+anti-ceremony guard -> Plan -> Implement -> fresh Validate -> bounded repair -> report
 ```
 
 On `CONTINUE`, the core path remains Plan -> Implement -> fresh Validate ->
-report. RPI invokes the guard exactly once before Plan. It preserves the
-original intent and dispatches each core phase at most once.
-It does not own retries, budgets, queues, claims, leases, Git, delivery, release,
-closure, or the caller's next decision.
+bounded repair -> report. RPI invokes the guard exactly once before Plan. It
+preserves the original intent and dispatches Plan and Implement at most once.
+Validate repeats only inside the repair phase below, under the convergence law
+and the caller's `repair_rounds` bound. RPI does not own retries, budgets,
+queues, claims, leases, Git, delivery, release, closure, or the caller's next
+decision; `repair_rounds` is the caller's declaration, not RPI's budget.
 
 The pure [`scripts/run_once.py`](scripts/run_once.py) reference behavior makes
-the dispatch and stop semantics executable without Git, `ao`, or a tracker.
+the dispatch, repair, and stop semantics executable without Git, `ao`, or a
+tracker: `invoke_once` for the one bounded experiment, `run_repair_phase` for
+the law.
 
 ## Admission and phase lock
 
@@ -89,14 +93,60 @@ authorization by itself.
 4. Invoke Validate once in a context distinct from the author's context. Pass
    the intent reference and digest, exact subject manifest, factual receipts,
    validator identity, and freshness attestation.
-5. Return the fresh validation result and a short report. Persist and link
-   `verdict.v2` only when the caller requests machine-readable evidence or a
-   declared downstream consumer requires it. Stop regardless of `PASS`, `FAIL`,
-   or `NOT_PROVEN`.
+5. Enter the bounded repair phase. On a converged result, report and stop. On
+   `FAIL` or `NOT_PROVEN` with findings, repair the named findings and
+   re-validate freshly while the convergence law admits another round; stop
+   when converged, stopped by the law, or out of `repair_rounds`. Return the
+   current validation result, the open findings, and a short report. Persist
+   and link `verdict.v2` only when the caller requests machine-readable
+   evidence or a declared downstream consumer requires it.
 
 `NOT_PLANNED` and `NOT_BUILT` are report statuses, never semantic verdicts.
 A caller may revise the bead or caller intent and start a new invocation. RPI
 never creates a parallel revision artifact or selects the next work itself.
+
+## The convergence law
+
+A repair round is admitted only while all hold:
+
+1. `rounds_used < repair_rounds` (caller-declared, default 2).
+2. The open finding set, keyed by the validators' stable `findings[].id`
+   (union across the fresh and, when used, cross-family validators), is not
+   larger than the previous round's.
+3. No finding id closed in an earlier round reopens.
+4. Between rounds either the subject-manifest digest changed (generated-only
+   changes count when they change the digest) or, for `NOT_PROVEN`, new
+   digest-bound evidence was supplied that resolves a named gap.
+
+Converged ⇔ the fresh validator returns PASS and, when the diff touches a
+risky surface, the cross-family validator also returns PASS. On any violation
+of 1-4 RPI stops and reports the current status; `checked` carries one line
+per round (`repair round N: k open findings`), the open findings ride in the
+validation result and the interactive report, and `not_checked` keeps its
+meaning. No third judge, no escalation, no auto-replan.
+
+A reworded finding with the same id is the same finding. The fix step belongs
+to the orchestrating context; every judge leg stays non-mutating, so a verdict
+never rewrites the artifact it is judging.
+
+## Cross-family validation
+
+Risky surfaces default to a cross-family fresh validator: `cli/internal/gates/**`,
+`scripts/check-*.sh`, `tests/**`, `skills/*/scripts/**`,
+`skills/cc-hooks/policies/**`, `lib/**`, and anything `security-gate.sh` scans.
+The dispatch table — which direction may run headless and which must route to
+an interactive pane — is owned by [`validate`](../validate/SKILL.md); RPI
+selects when it applies, never how the leg is launched. With no authorized
+live adapter the result is `diversity_unsatisfied`, and on a risky surface that
+stops as `NOT_PROVEN` rather than converging same-family.
+
+## Waves
+
+RPI executes one traversal. A multi-wave intent is executed one wave per
+`crank` invocation: the caller selects the wave and the
+`repair_rounds` bound, crank forwards both and invokes RPI per lane, then
+returns wave evidence and stops. RPI itself never selects a wave, queues the
+next one, or widens the bound it was given.
 
 ## Anti-ceremony boundary
 
@@ -116,11 +166,16 @@ scope, or validation authority.
 
 ## Spiral breaker
 
-The spiral breaker fires when two consecutive control artifacts (plans, audits,
-reviews, prompts, reports) contain no new implementation evidence. Terminate the
-run and report `NOT_BUILT` when no implementation subject exists; when a subject
-exists, stop and report its current status without dispatching another lane or
-repair revision. RPI owns no lane budget, repair budget, or retry policy.
+The spiral breaker fires on a convergence-law violation, or when two
+consecutive rounds produce no change to the subject digest and no new
+digest-bound evidence. It never fires on a verdict count: a `FAIL` or a
+`NOT_PROVEN` that is being repaired under the law is progress, not a spiral,
+and repeated control artifacts (plans, audits, reviews, prompts, reports) with
+no new implementation evidence are the spiral. Terminate the run and report
+`NOT_BUILT` when no implementation subject exists; when a subject exists, stop
+and report its current status without dispatching another lane. RPI owns no
+lane budget and no retry policy, and never extends the caller's
+`repair_rounds`.
 
 ## Delegation boundaries
 
@@ -136,7 +191,8 @@ disjoint regen surfaces may run in parallel.
 
 ## Invariants
 
-- Acceptance and its runtime-derived digest do not change between phases.
+- Acceptance and its runtime-derived digest do not change between phases or
+  between repair rounds; a repair moves the subject, never the acceptance.
 - The anti-ceremony guard runs once before Plan; `STOP` dispatches none of Plan,
   Implement, or Validate, while `CONTINUE` preserves their order.
 - The runtime derives complete changed-path coverage or Validate returns

--- a/images/gemini/skills/rpi/SKILL.md
+++ b/images/gemini/skills/rpi/SKILL.md
@@ -110,43 +110,34 @@ never creates a parallel revision artifact or selects the next work itself.
 A repair round is admitted only while all hold:
 
 1. `rounds_used < repair_rounds` (caller-declared, default 2).
-2. The open finding set, keyed by the validators' stable `findings[].id`
-   (union across the fresh and, when used, cross-family validators), is not
-   larger than the previous round's.
+2. The open finding set, keyed by stable `findings[].id` (union of the fresh
+   and cross-family validators), is not larger than the previous round's.
 3. No finding id closed in an earlier round reopens.
-4. Between rounds either the subject-manifest digest changed (generated-only
-   changes count when they change the digest) or, for `NOT_PROVEN`, new
-   digest-bound evidence was supplied that resolves a named gap.
+4. Between rounds the subject-manifest digest changed (generated-only changes
+   count) or, for `NOT_PROVEN`, new digest-bound evidence resolved a named gap.
 
-Converged ⇔ the fresh validator returns PASS and, when the diff touches a
-risky surface, the cross-family validator also returns PASS. On any violation
-of 1-4 RPI stops and reports the current status; `checked` carries one line
-per round (`repair round N: k open findings`), the open findings ride in the
-validation result and the interactive report, and `not_checked` keeps its
-meaning. No third judge, no escalation, no auto-replan.
-
-A reworded finding with the same id is the same finding. The fix step belongs
-to the orchestrating context; every judge leg stays non-mutating, so a verdict
-never rewrites the artifact it is judging.
+Converged: the fresh validator returns PASS and, on a risky surface, the
+cross-family validator also returns PASS. On any violation of 1-4 RPI stops and
+reports the current status. `checked` carries one line per round
+(`repair round N: k open findings`); open findings ride in the validation
+result and the report; `not_checked` keeps its meaning. A reworded finding with
+the same id is the same finding. The orchestrating context fixes; judge legs
+never mutate the subject. No third judge, no escalation, no auto-replan.
 
 ## Cross-family validation
 
 Risky surfaces default to a cross-family fresh validator: `cli/internal/gates/**`,
 `scripts/check-*.sh`, `tests/**`, `skills/*/scripts/**`,
-`skills/cc-hooks/policies/**`, `lib/**`, and anything `security-gate.sh` scans.
-The dispatch table — which direction may run headless and which must route to
-an interactive pane — is owned by [`validate`](../validate/SKILL.md); RPI
-selects when it applies, never how the leg is launched. With no authorized
-live adapter the result is `diversity_unsatisfied`, and on a risky surface that
-stops as `NOT_PROVEN` rather than converging same-family.
+`skills/cc-hooks/policies/**`, `lib/**`, anything `security-gate.sh` scans.
+[`validate`](../validate/SKILL.md) owns the dispatch table. No authorized live
+adapter means `diversity_unsatisfied`, which on a risky surface is `NOT_PROVEN`.
 
 ## Waves
 
-RPI executes one traversal. A multi-wave intent is executed one wave per
-`crank` invocation: the caller selects the wave and the
-`repair_rounds` bound, crank forwards both and invokes RPI per lane, then
-returns wave evidence and stops. RPI itself never selects a wave, queues the
-next one, or widens the bound it was given.
+RPI executes one traversal. A multi-wave intent runs one wave per `crank`
+invocation: the caller selects the wave and the `repair_rounds` bound, crank
+forwards both, invokes RPI per lane, returns wave evidence, and stops. RPI never
+selects a wave or queues the next one, and never extends the caller's bound.
 
 ## Anti-ceremony boundary
 

--- a/images/gemini/skills/validate/SKILL.md
+++ b/images/gemini/skills/validate/SKILL.md
@@ -84,9 +84,10 @@ freshness attestation notes; do not change the `verdict.v2` schema.
 
 When no authorized live adapter is available, disclose the unsatisfied
 diversity request as `diversity_unsatisfied`. Off a risky surface that
-disclosure rides along with a same-model result. On a risky surface it is an
-unverified acceptance surface: the result is `NOT_PROVEN`, and same-family
-agreement never counts as convergence.
+disclosure rides along with a same-model result. On a risky surface a
+single-family PASS is an unverified acceptance surface: the result is
+`NOT_PROVEN`, and same-family agreement never counts as convergence. A
+single-family FAIL stands as FAIL; a wrong subject needs no second judge.
 
 ## Mutating-check quarantine
 

--- a/images/gemini/skills/validate/SKILL.md
+++ b/images/gemini/skills/validate/SKILL.md
@@ -64,7 +64,7 @@ the diff touches a risky surface:
 - `skills/*/scripts/**`
 - `skills/cc-hooks/policies/**`
 - `lib/**`
-- anything `security-gate.sh` scans
+- `.github/workflows/**` and `scripts/security-gate.sh` (the gate scans the whole tree, so "anything it scans" is not a predicate)
 
 Outside that list the second validator is caller-elected and a single fresh
 validator remains the default shape.

--- a/images/gemini/skills/validate/SKILL.md
+++ b/images/gemini/skills/validate/SKILL.md
@@ -53,16 +53,40 @@ to reconstruct Plan or Candidate packets.
 Missing, colliding, or unattested identities produce `NOT_PROVEN`. This is a
 declared trust fact, not cryptographic proof that contexts were isolated.
 
-## Cross-model fresh validator (caller-elected)
+## Cross-family fresh validator (default on risky surfaces)
 
-A caller may request that the fresh validator run on a different model than
-the author. Dispatch via the controller-session recipe in
-the `agent-native` model-dispatch recipe (`codex-exec` and/or `ntm`,
-probed at runtime). Record author and validator `model_identity` in evidence
-refs and freshness attestation notes — do not change `verdict.v2` schema. If
-the requested validator model has no live adapter, disclose the unsatisfied
-diversity request and proceed same-model; never invoke `claude -p` /
-`claude --print`. Single fresh validator remains the default shape.
+A second fresh validator from a different model family runs by default whenever
+the diff touches a risky surface:
+
+- `cli/internal/gates/**`
+- `scripts/check-*.sh`
+- `tests/**`
+- `skills/*/scripts/**`
+- `skills/cc-hooks/policies/**`
+- `lib/**`
+- anything `security-gate.sh` scans
+
+Outside that list the second validator is caller-elected and a single fresh
+validator remains the default shape.
+
+Dispatch is fixed by the runtime floor: never `claude -p` or `claude --print`,
+directly or indirectly.
+
+| Orchestrating runtime | Cross-family judge leg |
+|---|---|
+| Claude | a read-only `codex exec` judge leg |
+| Codex | a caller-selected interactive Claude session in an NTM pane |
+
+Probe the adapters at runtime through the `agent-native` model-dispatch recipe
+(`codex-exec` and/or `ntm`). The judge leg reads and judges; it never mutates
+the subject. Record author and validator `model_identity` in evidence refs and
+freshness attestation notes; do not change the `verdict.v2` schema.
+
+When no authorized live adapter is available, disclose the unsatisfied
+diversity request as `diversity_unsatisfied`. Off a risky surface that
+disclosure rides along with a same-model result. On a risky surface it is an
+unverified acceptance surface: the result is `NOT_PROVEN`, and same-family
+agreement never counts as convergence.
 
 ## Mutating-check quarantine
 
@@ -169,6 +193,10 @@ python3 "$SKILL_DIR/scripts/validate.py" manifest \
    `verdict_dir`.
 7. Return the semantic result and, when persisted, the artifact path and digest.
    Stop.
+
+Routine rounds keep the bounded, receipt-driven freshness contract below, and
+the repository's full literal CI command set, as quoted in `AGENTS.md`, is
+required once, on the final integrated subject.
 
 The digest is SHA-256 over canonical JSON with `artifact_digest` omitted. Writes
 use a same-directory temporary file, flush, fsync, and atomic rename. Identical

--- a/registry.json
+++ b/registry.json
@@ -183,6 +183,15 @@
     },
     {
       "driven_by_skills": [
+        "crank"
+      ],
+      "id": "skill:crank:execute_wave",
+      "name": "execute_wave",
+      "path": "skills/crank/SKILL.md",
+      "type": "skill"
+    },
+    {
+      "driven_by_skills": [
         "dcg"
       ],
       "id": "skill:dcg:dcg",
@@ -699,19 +708,19 @@
     "cli_commands": 0,
     "gates": 0,
     "reference_impls": 0,
-    "skills": 77,
-    "total": 77
+    "skills": 78,
+    "total": 78
   },
   "cli_top_level_commands": [],
   "schema_version": 3,
   "summary": {
-    "capabilities": 77,
+    "capabilities": 78,
     "cli_commands": 0,
     "eval_files": 0,
     "hooks": 0,
     "job_types": 0,
     "knowledge_stores": 0,
-    "skills": 56,
+    "skills": 57,
     "workflows": 0
   },
   "surfaces": {
@@ -938,6 +947,21 @@
         "path": "skills/craft-goal/",
         "reference_count": 1,
         "tier": "judgment"
+      },
+      {
+        "capabilities": [
+          "execute_wave"
+        ],
+        "disposition": "keep",
+        "effects": [
+          "dispatch_rpi_per_lane"
+        ],
+        "has_references": false,
+        "has_skill_md": true,
+        "name": "crank",
+        "path": "skills/crank/",
+        "reference_count": 0,
+        "tier": "meta"
       },
       {
         "capabilities": [

--- a/scripts/check-cathedral-cut-conformance.py
+++ b/scripts/check-cathedral-cut-conformance.py
@@ -1115,9 +1115,51 @@ def check_bounded_repair_contract() -> None:
         for node in ast.walk(tree)
         if isinstance(node, ast.FunctionDef) and node.name == "run_repair_phase"
     )
-    assert any(isinstance(node, (ast.For, ast.While)) for node in ast.walk(repair)), (
-        "the repair phase must actually iterate the validation rounds"
+    loops = [node for node in ast.walk(repair) if isinstance(node, (ast.For, ast.While))]
+    assert loops, "the repair phase must actually iterate the validation rounds"
+    # Bounded, not merely looping: the caller's bound must gate the loop. The
+    # repair function must compare against `repair_rounds` (condition 1) and
+    # every loop must be a `for` over the supplied rounds, never `while True`.
+    compares_bound = any(
+        isinstance(node, ast.Compare)
+        and any(isinstance(n, ast.Name) and n.id == "repair_rounds" for n in ast.walk(node))
+        for node in ast.walk(repair)
     )
+    assert compares_bound, "the repair phase never compares against the caller's repair_rounds bound"
+    assert all(isinstance(node, ast.For) for node in loops), (
+        "the repair phase may only iterate the supplied rounds; an open-ended while loop is an unbounded grind"
+    )
+    # Execute the law's canaries against the reference behavior itself: budget,
+    # growth, reopen, no-change, and the flip-to-PASS case must all STOP.
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("rpi_run_once_canary", runner)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    dg = lambda ch: ch * 64  # noqa: E731
+    def leg(status, ids, digest, evidence=()):
+        return {
+            "status": status,
+            "findings": [{"id": i, "summary": i} for i in ids],
+            "subject_digest": digest,
+            "evidence_refs": list(evidence),
+            "validator_family": "fresh",
+        }
+    canaries = {
+        "repair_budget_exhausted": ([leg("FAIL", ["a"], dg("a")), leg("FAIL", ["a"], dg("b")), leg("FAIL", ["a"], dg("c"))], 1),
+        "finding_set_grew": ([leg("FAIL", ["a"], dg("a")), leg("FAIL", ["a", "b"], dg("b"))], 2),
+        "reopened_finding": ([leg("FAIL", ["a", "b"], dg("a")), leg("FAIL", ["b"], dg("b")), leg("FAIL", ["a"], dg("c"))], 3),
+        "no_subject_or_evidence_change": ([leg("FAIL", ["a"], dg("a")), leg("PASS", [], dg("a"))], 2),
+        "converged": ([leg("FAIL", ["a"], dg("a")), leg("PASS", [], dg("b"))], 2),
+    }
+    for expected, (rounds, bound) in canaries.items():
+        outcome = module.run_repair_phase(rounds, repair_rounds=bound)
+        assert outcome["stop_reason"] == expected, (
+            f"law canary {expected}: reference behavior stopped with {outcome['stop_reason']!r}"
+        )
+    flip = module.run_repair_phase(canaries["no_subject_or_evidence_change"][0], repair_rounds=2)
+    assert flip["report"]["status"] == "NOT_PROVEN", "a PASS over unchanged bytes after a FAIL must not certify"
+    assert canaries and module.run_repair_phase([leg("FAIL", ["a"], dg("a"))], repair_rounds=0)["stop_reason"] == "repair_budget_exhausted"
     assert not any(
         isinstance(node, (ast.For, ast.While))
         for name in ("invoke_once",)

--- a/scripts/check-cathedral-cut-conformance.py
+++ b/scripts/check-cathedral-cut-conformance.py
@@ -54,8 +54,13 @@ FORBIDDEN_SCHEMA_STATE = {
     "retry", "retries", "budget", "queue", "claim", "lease", "admission",
     "next_action", "next-action", "closure", "release", "delivery",
 }
+# ADR-0017 (loop as control flow, not knowledge): `crank` is restored as a thin
+# wave skill — one caller-selected wave per invocation, forwarding the caller's
+# repair bound to RPI. The `ao crank` ROOT COMMAND stays removed and is still
+# tombstoned in REMOVED_COMMANDS below; `converge` stays removed as a skill
+# because its criterion now lives inside RPI's convergence law.
 REMOVED_SKILLS = {
-    "discovery", "behavior-first-planning", "goal-design", "crank", "converge",
+    "discovery", "behavior-first-planning", "goal-design", "converge",
     "evolve", "gc-membrane", "pawl-review", "push", "release", "pr-prep",
     "beads-br", "beads-bv",
 }
@@ -1063,17 +1068,77 @@ def check_packet_free_narrative() -> None:
     )
 
 
-def check_single_pass_contract() -> None:
-    text = (ROOT / "skills" / "rpi" / "SKILL.md").read_text(encoding="utf-8")
-    assert "Stop regardless" in text
-    runner = ROOT / "skills" / "rpi" / "scripts" / "run_once.py"
-    assert runner.is_file(), "RPI has no executable single-pass reference behavior"
-    tree = ast.parse(runner.read_text(encoding="utf-8"), filename=str(runner))
-    assert not any(isinstance(node, (ast.For, ast.While)) for node in ast.walk(tree)), (
-        "RPI reference behavior must not contain a dispatch loop"
+def check_bounded_repair_contract() -> None:
+    """RPI stops under the convergence law, not after exactly one validation.
+
+    ADR-0017 narrows the 2026-07-14 cut: it removed the iterate loop along with
+    the unproven compounding claim, although ADR-0011 demoted only the latter.
+    The blanket "Stop regardless" assertion and the ban on any loop in
+    `run_once.py` are replaced here by positive canaries — the law's four
+    conditions must be present BY NAME, so a bounded repair phase is allowed
+    while an unbounded grind still fails this gate.
+    """
+    raw = (ROOT / "skills" / "rpi" / "SKILL.md").read_text(encoding="utf-8")
+    # Whitespace-normalized so a canary phrase may wrap across source lines.
+    text = " ".join(raw.split())
+    assert "Stop regardless" not in text, (
+        "RPI still asserts the retired single-pass stop; ADR-0017 replaced it with the law"
     )
+    for phrase in (
+        "stop when converged, stopped by the law, or out of `repair_rounds`",
+        "## The convergence law",
+        "rounds_used < repair_rounds",
+        "larger than the previous round",
+        "No finding id closed in an earlier round reopens.",
+        "the subject-manifest digest changed",
+        "repair round N: k open findings",
+    ):
+        assert phrase in text, f"RPI contract is missing a convergence-law canary: {phrase}"
+    # Plan and Implement keep their single-dispatch lock; only Validate repeats.
+    assert "dispatches Plan and Implement at most once" in text
+    assert "never extends the caller's" in text, "RPI does not disclaim the caller's repair bound"
+
+    runner = ROOT / "skills" / "rpi" / "scripts" / "run_once.py"
+    assert runner.is_file(), "RPI has no executable reference behavior"
+    source = runner.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(runner))
+    functions = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    # The bounded loop is now allowed, and required: it must live in the repair
+    # phase, be fed already-produced validate rounds, and consult the law.
+    assert {"run_repair_phase", "law_violation", "normalize_round"} <= functions, (
+        "RPI reference behavior has no bounded repair phase implementing the law"
+    )
+    repair = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "run_repair_phase"
+    )
+    assert any(isinstance(node, (ast.For, ast.While)) for node in ast.walk(repair)), (
+        "the repair phase must actually iterate the validation rounds"
+    )
+    assert not any(
+        isinstance(node, (ast.For, ast.While))
+        for name in ("invoke_once",)
+        for func in [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == name]
+        for node in ast.walk(func)
+    ), "the one bounded experiment must not loop; only the repair phase may"
+    for reason in (
+        "repair_budget_exhausted",
+        "reopened_finding",
+        "finding_set_grew",
+        "no_subject_or_evidence_change",
+        "diversity_unsatisfied",
+        "converged",
+    ):
+        assert f'"{reason}"' in source, f"repair phase never reports the stop reason {reason}"
+
     report = json.loads((ROOT / "schemas" / "rpi-report.v1.schema.json").read_text())
     assert "next_action" not in property_names(report)
+    # The law rides in the report's `checked` lines; it must not smuggle a
+    # tenth key into rpi-report.v1.
+    assert len(property_names(report)) == 9, "rpi-report.v1 is no longer the nine-key shape"
 
 
 def check_validate_helper() -> None:
@@ -1344,7 +1409,7 @@ def main() -> int:
         check_generated_skill_inventory,
         check_core_schemas,
         check_packet_free_narrative,
-        check_single_pass_contract,
+        check_bounded_repair_contract,
         check_validate_helper,
         check_tombstones,
         check_operations_layer_identity,

--- a/scripts/check-cathedral-cut-conformance.py
+++ b/scripts/check-cathedral-cut-conformance.py
@@ -989,10 +989,15 @@ def check_skill_graph() -> None:
         for name in CORE
     }
     assert actual == expected, f"core dependency graph mismatch: {actual}"
+    # ADR-0017: crank is the one non-core skill with a hard dependency, on rpi
+    # alone; the skill mesh generator carries the same allowance.
+    allowed_extra = {"crank": {"rpi"}}
     for name, entry in entries.items():
         deps = set((entry.get("metadata") or {}).get("dependencies") or [])
         if name != "rpi":
-            assert not deps, f"{name}: only rpi may declare hard dependencies: {sorted(deps)}"
+            assert deps == allowed_extra.get(name, set()), (
+                f"{name}: only rpi (and crank on rpi, ADR-0017) may declare hard dependencies: {sorted(deps)}"
+            )
     for name in REMOVED_SKILLS:
         assert not (ROOT / "skills" / name / "SKILL.md").exists(), f"removed skill is live: {name}"
         assert not (ROOT / "skills-codex" / name / "SKILL.md").exists(), f"removed Codex skill is live: {name}"

--- a/scripts/check-cathedral-cut-conformance.py
+++ b/scripts/check-cathedral-cut-conformance.py
@@ -1174,6 +1174,16 @@ def check_bounded_repair_contract() -> None:
         )
     flip = module.run_repair_phase(canaries["no_subject_or_evidence_change"][0], repair_rounds=2)
     assert flip["report"]["status"] == "NOT_PROVEN", "a PASS over unchanged bytes after a FAIL must not certify"
+    # The bound must CONTROL admission, not merely be mentioned: a poison round
+    # past repair_rounds is never normalized (it would raise), and rounds_used
+    # never exceeds the bound.
+    poison = module.run_repair_phase(
+        [leg("FAIL", ["a"], dg("a")), leg("FAIL", ["a"], dg("b")), {"status": "poison-not-a-round"}],
+        repair_rounds=1,
+    )
+    assert poison["stop_reason"] == "repair_budget_exhausted" and poison["rounds_used"] == 1, (
+        "the repair phase consumed a round past the caller's bound"
+    )
     assert canaries and module.run_repair_phase([leg("FAIL", ["a"], dg("a"))], repair_rounds=0)["stop_reason"] == "repair_budget_exhausted"
     assert not any(
         isinstance(node, (ast.For, ast.While))

--- a/scripts/check-cathedral-cut-conformance.py
+++ b/scripts/check-cathedral-cut-conformance.py
@@ -1129,6 +1129,16 @@ def check_bounded_repair_contract() -> None:
     assert all(isinstance(node, ast.For) for node in loops), (
         "the repair phase may only iterate the supplied rounds; an open-ended while loop is an unbounded grind"
     )
+    # Finite by construction: every loop iterates the `validations` parameter
+    # (directly or via enumerate), never a synthetic range or a constant.
+    def iterates_validations(node: ast.For) -> bool:
+        target = node.iter
+        if isinstance(target, ast.Call) and target.args:
+            target = target.args[0]
+        return isinstance(target, ast.Name) and target.id == "validations"
+    assert all(iterates_validations(node) for node in loops), (
+        "every repair-phase loop must iterate the supplied validation rounds; nothing else is finite by construction"
+    )
     # Execute the law's canaries against the reference behavior itself: budget,
     # growth, reopen, no-change, and the flip-to-PASS case must all STOP.
     import importlib.util

--- a/scripts/generate-skill-mesh.py
+++ b/scripts/generate-skill-mesh.py
@@ -77,9 +77,16 @@ def validate_graph(entries: list[dict[str, Any]]) -> None:
     expected = {"rpi": {"anti-ceremony", "plan", "implement", "validate"}, "plan": set(), "implement": set(), "validate": set()}
     if core != expected:
         raise ValueError(f"core dependency graph mismatch: {core!r}")
-    extra = {entry["name"]: entry["dependencies"] for entry in entries if entry["name"] != "rpi" and entry["dependencies"]}
+    # ADR-0017: crank is the one non-core skill with a hard dependency, on rpi
+    # alone (it executes a wave by invoking RPI per lane). Nothing else may.
+    allowed_extra = {"crank": ["rpi"]}
+    extra = {
+        entry["name"]: entry["dependencies"]
+        for entry in entries
+        if entry["name"] != "rpi" and entry["dependencies"] and allowed_extra.get(entry["name"]) != list(entry["dependencies"])
+    }
     if extra:
-        raise ValueError(f"only rpi may declare hard dependencies: {extra!r}")
+        raise ValueError(f"only rpi (and crank on rpi, ADR-0017) may declare hard dependencies: {extra!r}")
 
 
 def catalog(entries: list[dict[str, Any]]) -> dict[str, Any]:

--- a/skills-codex-overrides/catalog.json
+++ b/skills-codex-overrides/catalog.json
@@ -343,6 +343,12 @@
       "treatment": "parity_only",
       "wave": "catalog-parity",
       "reason": "Auto-generated parity twin (codex-sync): skills/human-only-skills is the source of truth; no durable Codex-specific divergence yet."
+    },
+    {
+      "name": "crank",
+      "treatment": "parity_only",
+      "wave": "catalog-parity",
+      "reason": "Auto-generated parity twin (codex-sync): skills/crank is the source of truth; no durable Codex-specific divergence yet."
     }
   ]
 }

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -621,8 +621,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "d7db72af73f50f6bdd006dcf02a1375145fae4f2bd584fc4ba365e6269b63623",
-      "generated_hash": "7951c4234924d8bf19fac27574d30fcd136818d7812b26172d1e896c4c36c7c8"
+      "source_hash": "4c5ad428c141cec452262ddff4b5554301bd266352c3879c366334a3dbbf797a",
+      "generated_hash": "8142877cca5c15dfb9472493bbc1ab6e74b472348d434b3e7f5c45972bd11562"
     },
     {
       "name": "sbh",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -2,7 +2,7 @@
   "generator": "manual-maintained",
   "source_root": "skills",
   "layout": "modular",
-  "codex_override_catalog_hash": "7d023129d7469c29c17c2b1e1efac0d38708f103dac38a3ec146e0e9a5ff7283",
+  "codex_override_catalog_hash": "f3aa9c82ab71916ac7dfbf218238d18c157337a13ea2c393ea62bbb2f23bb685",
   "codex_override_catalog": {
     "version": 1,
     "description": "Machine-readable Codex treatment map for the full skill catalog.",
@@ -368,6 +368,12 @@
         "treatment": "parity_only",
         "wave": "catalog-parity",
         "reason": "Auto-generated parity twin (codex-sync): skills/human-only-skills is the source of truth; no durable Codex-specific divergence yet."
+      },
+      {
+        "name": "crank",
+        "treatment": "parity_only",
+        "wave": "catalog-parity",
+        "reason": "Auto-generated parity twin (codex-sync): skills/crank is the source of truth; no durable Codex-specific divergence yet."
       }
     ]
   },
@@ -455,6 +461,12 @@
       "source_skill": "skills/craft-goal",
       "source_hash": "7cb5678a3cf55ead80a0e43afdc62ead5d8cd36ff2a41d2d803b6bd74e1215bb",
       "generated_hash": "10fbf5148de2ab8d9d4d9b57a72f3964b977f0705abe2ade4ace316074439539"
+    },
+    {
+      "name": "crank",
+      "source_skill": "skills/crank",
+      "source_hash": "5ee822745134ef2c965798579b264d4f91b10969aec1966cc8c93473803e8046",
+      "generated_hash": "5184ca0499afe98dcf69bf5e13dc7e94604657518012e09e4b0bd5f3d2501966"
     },
     {
       "name": "dcg",
@@ -709,5 +721,5 @@
       "generated_hash": "dbb4d3af123f40bb4d20f0dbfea708d0be83763c1cef5d0f240798789bf84a28"
     }
   ],
-  "package_count": 56
+  "package_count": 57
 }

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -609,8 +609,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "4870c343799f313706c7928b59d3b55cb2b4f8bd34b972dddf57e4859b999695",
-      "generated_hash": "9c3535ca09ce15b45a96c960153a9f2130fec4ad24aa19fe78dc435a1bd6e77d"
+      "source_hash": "48c6504d5ae7f54b0cc8c019b290fb869ec655c9a0511e2d56fb64ba3b722c1d",
+      "generated_hash": "151e9c8727140a702156e0bb41ad1a97ee6d0f231a6e0d5b0df6099425be3655"
     },
     {
       "name": "sbh",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -465,7 +465,7 @@
     {
       "name": "crank",
       "source_skill": "skills/crank",
-      "source_hash": "5ee822745134ef2c965798579b264d4f91b10969aec1966cc8c93473803e8046",
+      "source_hash": "49311a4e3f5e04ee235b915e6c742a71dc250bb63dfdb3eb16e2fedcca4cca70",
       "generated_hash": "5184ca0499afe98dcf69bf5e13dc7e94604657518012e09e4b0bd5f3d2501966"
     },
     {
@@ -621,8 +621,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "4c5ad428c141cec452262ddff4b5554301bd266352c3879c366334a3dbbf797a",
-      "generated_hash": "8142877cca5c15dfb9472493bbc1ab6e74b472348d434b3e7f5c45972bd11562"
+      "source_hash": "a8fc21b100fa5b05ce8e6af5f08dea2e521561194eac4f63421736d9211d8590",
+      "generated_hash": "deda17a4ee72c6b5e0f8decedfa5de334afe744c730833bc3e9a46bc456a793e"
     },
     {
       "name": "sbh",
@@ -711,8 +711,8 @@
     {
       "name": "validate",
       "source_skill": "skills/validate",
-      "source_hash": "c53bf864ff846bf3b6a4f0b9f2e8869065107a94134e74f315e2f9a33a4cf4ab",
-      "generated_hash": "e7ca06334abab48f2caec64823d534c904454420cbd0e977f20dd64bd6d5acf8"
+      "source_hash": "da24e39ccab4bb4936988ca66329695f5dabd8c1dd618bf91f58e0d62e1b1f63",
+      "generated_hash": "1ed841f5634c1b9d7a21c0970902f0b997ae2104a5891d04761dc4d8af2c204c"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -459,8 +459,8 @@
     {
       "name": "craft-goal",
       "source_skill": "skills/craft-goal",
-      "source_hash": "7cb5678a3cf55ead80a0e43afdc62ead5d8cd36ff2a41d2d803b6bd74e1215bb",
-      "generated_hash": "10fbf5148de2ab8d9d4d9b57a72f3964b977f0705abe2ade4ace316074439539"
+      "source_hash": "30726392ad17a3316f5c2c32c9f4a1039ece4e2f55c7ccaa7e183c2c2432837f",
+      "generated_hash": "6458422d18684ac270bc1c8570d16e4bed80e8fa17895d5f8da79b41677a19bb"
     },
     {
       "name": "crank",
@@ -621,8 +621,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "34a594f554f0c3c2cf6fc68dabf81a06fb1fd6830e1f6b15eed75c188cbef899",
-      "generated_hash": "9329ab2ed19205f05bb416ea788173dd1823d4dde9c72024b2cebb26e44375ea"
+      "source_hash": "d7db72af73f50f6bdd006dcf02a1375145fae4f2bd584fc4ba365e6269b63623",
+      "generated_hash": "7951c4234924d8bf19fac27574d30fcd136818d7812b26172d1e896c4c36c7c8"
     },
     {
       "name": "sbh",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -609,8 +609,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "48c6504d5ae7f54b0cc8c019b290fb869ec655c9a0511e2d56fb64ba3b722c1d",
-      "generated_hash": "151e9c8727140a702156e0bb41ad1a97ee6d0f231a6e0d5b0df6099425be3655"
+      "source_hash": "34a594f554f0c3c2cf6fc68dabf81a06fb1fd6830e1f6b15eed75c188cbef899",
+      "generated_hash": "9329ab2ed19205f05bb416ea788173dd1823d4dde9c72024b2cebb26e44375ea"
     },
     {
       "name": "sbh",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -711,8 +711,8 @@
     {
       "name": "validate",
       "source_skill": "skills/validate",
-      "source_hash": "6784d431811b29d9196fe61caf9d220ee91315a8fc9a08b1893990fe0c421250",
-      "generated_hash": "8ceccb3f2183b4dd59a7470edeae93c44393bfe68adefee3f792b4b14b512ec5"
+      "source_hash": "c53bf864ff846bf3b6a4f0b9f2e8869065107a94134e74f315e2f9a33a4cf4ab",
+      "generated_hash": "e7ca06334abab48f2caec64823d534c904454420cbd0e977f20dd64bd6d5acf8"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -393,8 +393,8 @@
     {
       "name": "agent-native",
       "source_skill": "skills/agent-native",
-      "source_hash": "597bfaf6f186c52b14f1b6d60112e9305785a63ab4f24bb25b5b87fba2110b91",
-      "generated_hash": "ad4ad8f732f1f6ec81a4b33a49f12f139eda18cecbb1a581897e9b752d604a39"
+      "source_hash": "907fbf538921e939138493a649fc539d99132139723aa1d1446b221d3869c5ba",
+      "generated_hash": "7beea77b9216d6bb8c9cb1b7d0c66356b5560c05666783458424dfef9c4ad73c"
     },
     {
       "name": "agy-native",
@@ -621,8 +621,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "a8fc21b100fa5b05ce8e6af5f08dea2e521561194eac4f63421736d9211d8590",
-      "generated_hash": "deda17a4ee72c6b5e0f8decedfa5de334afe744c730833bc3e9a46bc456a793e"
+      "source_hash": "032a23898cfee4cf8b45d463e551e54b12eb4eeb611588d18bd7bfcf432c881a",
+      "generated_hash": "c859895c1c3a8e146a9a03510bccb46131bbc7d1b97898cee1e09ed983798363"
     },
     {
       "name": "sbh",
@@ -711,8 +711,8 @@
     {
       "name": "validate",
       "source_skill": "skills/validate",
-      "source_hash": "da24e39ccab4bb4936988ca66329695f5dabd8c1dd618bf91f58e0d62e1b1f63",
-      "generated_hash": "1ed841f5634c1b9d7a21c0970902f0b997ae2104a5891d04761dc4d8af2c204c"
+      "source_hash": "c6b05c98c47ee74f23c1786d10b4f78d1452e440d271b8b3a7287ca4269e41db",
+      "generated_hash": "fbbf0c9053c437287226311177738031ac493b0e5b19153da1a6ea5d5e1014d8"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/agent-native/.agentops-generated.json
+++ b/skills-codex/agent-native/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/agent-native",
   "layout": "modular",
-  "source_hash": "597bfaf6f186c52b14f1b6d60112e9305785a63ab4f24bb25b5b87fba2110b91",
-  "generated_hash": "ad4ad8f732f1f6ec81a4b33a49f12f139eda18cecbb1a581897e9b752d604a39"
+  "source_hash": "907fbf538921e939138493a649fc539d99132139723aa1d1446b221d3869c5ba",
+  "generated_hash": "7beea77b9216d6bb8c9cb1b7d0c66356b5560c05666783458424dfef9c4ad73c"
 }

--- a/skills-codex/agent-native/SKILL.md
+++ b/skills-codex/agent-native/SKILL.md
@@ -7,8 +7,9 @@ description: 'Operate explicit orchestrator, implementer, validator, and scribe 
 Operate caller-selected agent sessions as explicit roles without turning the
 runtime into AgentOps lifecycle authority.
 
-For caller-elected multi-model judgment (mixed council, dueling perspectives,
-cross-model validate), follow
+For multi-model judgment (mixed council, dueling perspectives, cross-model
+validate, which is default on risky surfaces per ADR-0017 and caller-elected
+otherwise), follow
 [references/model-dispatch.md](references/model-dispatch.md): the working
 session is the controller; probe `codex-exec` and `ntm` at runtime; never
 require either; never use Agent Mail for judgment; never invoke `claude -p`.

--- a/skills-codex/agent-native/references/model-dispatch.md
+++ b/skills-codex/agent-native/references/model-dispatch.md
@@ -4,8 +4,12 @@ Caller-elected multi-model judgment from the session you are already in.
 No mailbox, no queue, no Agent Mail path for judgment. The working session
 is the orchestrator: it starts workers, observes them, and collects artifacts.
 
-This recipe is optional. Absent adapters, consumers stay single-model and
-disclose that fact. Multi-model dispatch never starts unless the caller asks.
+This recipe is optional off risky surfaces. Absent adapters, consumers stay
+single-model and disclose that fact. Multi-model dispatch never starts unless
+the caller asks, with one carve-out (ADR-0017): `validate` runs a cross-family
+leg by default when the diff touches a risky surface (gates, tests, validators,
+hook policies, workflows); absent an authorized adapter that is
+`diversity_unsatisfied`, and a single-family PASS there is `NOT_PROVEN`.
 
 ## Request shape
 
@@ -63,4 +67,4 @@ notes.
 
 - `council` — per-judge model identity beside methodology; cross-model agreement is an extra diversity axis.
 - `idea-genie` (duel) — per-perspective model identity; optional distinct-model pins.
-- `validate` — optional cross-model fresh validator; author and validator model identities in evidence/attestation.
+- `validate` — cross-model fresh validator, default on risky surfaces (ADR-0017), caller-elected otherwise; author and validator model identities in evidence/attestation.

--- a/skills-codex/craft-goal/.agentops-generated.json
+++ b/skills-codex/craft-goal/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/craft-goal",
   "layout": "modular",
-  "source_hash": "7cb5678a3cf55ead80a0e43afdc62ead5d8cd36ff2a41d2d803b6bd74e1215bb",
-  "generated_hash": "10fbf5148de2ab8d9d4d9b57a72f3964b977f0705abe2ade4ace316074439539"
+  "source_hash": "30726392ad17a3316f5c2c32c9f4a1039ece4e2f55c7ccaa7e183c2c2432837f",
+  "generated_hash": "6458422d18684ac270bc1c8570d16e4bed80e8fa17895d5f8da79b41677a19bb"
 }

--- a/skills-codex/craft-goal/SKILL.md
+++ b/skills-codex/craft-goal/SKILL.md
@@ -12,7 +12,7 @@ ratchets toward a larger outcome.
 ```text
 Goal / Mayor: observe graph → choose bounded wave → consume verdicts → ratchet
   └─ Bead: durable experiment intent, context, scratch, evidence, and links
-       └─ RPI: plan → implement → fresh validate → verdict → report and stop
+       └─ RPI: plan → implement → fresh validate → bounded repair → verdict → report
             └─ Implementation: one RED → GREEN → refactor experiment
 ```
 

--- a/skills-codex/crank/.agentops-generated.json
+++ b/skills-codex/crank/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/crank",
   "layout": "modular",
-  "source_hash": "5ee822745134ef2c965798579b264d4f91b10969aec1966cc8c93473803e8046",
+  "source_hash": "49311a4e3f5e04ee235b915e6c742a71dc250bb63dfdb3eb16e2fedcca4cca70",
   "generated_hash": "5184ca0499afe98dcf69bf5e13dc7e94604657518012e09e4b0bd5f3d2501966"
 }

--- a/skills-codex/crank/.agentops-generated.json
+++ b/skills-codex/crank/.agentops-generated.json
@@ -1,0 +1,7 @@
+{
+  "generator": "codex-sync",
+  "source_skill": "skills/crank",
+  "layout": "modular",
+  "source_hash": "5ee822745134ef2c965798579b264d4f91b10969aec1966cc8c93473803e8046",
+  "generated_hash": "5184ca0499afe98dcf69bf5e13dc7e94604657518012e09e4b0bd5f3d2501966"
+}

--- a/skills-codex/crank/SKILL.md
+++ b/skills-codex/crank/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: crank
+description: 'Execute one caller-selected wave by invoking RPI once per lane and return the wave evidence, then stop. Triggers: "crank", "execute the next wave", "run this wave".'
+---
+# Crank
+
+Crank executes exactly one wave. The caller selects the wave and the repair
+bound; crank runs that wave and returns what happened.
+
+```text
+caller's wave + repair_rounds -> RPI per lane -> wave acceptance once -> evidence -> stop
+```
+
+## Input
+
+The caller supplies all three:
+
+- **The wave** — a list of lanes, each with a write `scope`, a `brief`, and its
+  own executable `acceptance`.
+- **`repair_rounds`** — the caller's repair bound, forwarded unchanged to every
+  lane. Crank neither chooses it nor spends it.
+- **The wave acceptance** — the one command set that judges the wave as a whole.
+
+If a lane arrives without a scope, a brief, or an executable acceptance, report
+the wave as unrunnable and stop. Crank does not shape the missing part itself.
+
+## Contract
+
+1. Read the caller's wave as given. Do not select, extend, drop, or re-rank
+   lanes; the wave arrives already decided.
+2. Partition the lanes. Two lanes may run in parallel only when their write
+   scopes are disjoint **and** their regen surfaces (generated outputs,
+   mirrors, manifests) are disjoint. Any shared surface serializes them;
+   unknown overlap counts as overlap.
+3. Invoke [`rpi`](../rpi/SKILL.md) once per lane with that lane's intent,
+   scope, acceptance, and the caller's `repair_rounds`. Each lane's traversal
+   owns its own repair loop. Crank never repairs a lane itself, never
+   re-invokes a returned lane, and never re-plans one.
+4. Run the wave acceptance once, after every lane has returned. A lane that
+   returned `FAIL` or `NOT_PROVEN` does not suppress it; both results are
+   reported side by side.
+5. Return the wave evidence and stop — per-lane status
+   (`PASS | FAIL | NOT_PROVEN | NOT_PLANNED | NOT_BUILT`), the open findings
+   each lane's validator left keyed by their `findings[].id`, each lane's
+   subject manifest digest, and the wave acceptance result.
+
+Append no next action. The caller reads the evidence and decides whether there
+is another wave.
+
+## Boundary
+
+Crank owns no wave selection, retry, budget, queue, claim, lease, Git, closure,
+delivery, or next work, and it mints no verdict of its own. Every semantic
+result in the wave evidence is the one that lane's fresh validator returned,
+cited unchanged; a green wave acceptance is a fact, not a `PASS`.
+
+## Conveyor
+
+In Claude, [`workflows/implement-wave.js`](../../workflows/implement-wave.js)
+is one conveyor for step 3's parallel leg: it runs disjoint-ownership
+implementers over the lanes the caller supplied. It is transport, never a
+substitute for a lane's own fresh validation, and crank runs without it.
+
+## Prompt
+
+```text
+Crank this wave, repair_rounds=2.
+Lane A - scope cli/internal/gates/**, brief "add the probe-coverage gate row",
+acceptance: cd cli && go test ./internal/gates/...
+Lane B - scope docs/CI-CD.md, brief "document that gate row",
+acceptance: bash scripts/docs-build.sh --check
+Wave acceptance: bash tests/run-all.sh. Report per-lane evidence and stop.
+```
+
+## It's working if
+
+Observable in the trace, without reading the prose — and the rubric a fresh
+independent judge scores this skill against:
+
+- The transcript shows exactly one `rpi` invocation per lane in the caller's
+  wave, and no lane appears twice.
+- Two lanes that share a regen surface (both reaching `skills-codex/`, say) run
+  one after the other, never concurrently.
+- The wave acceptance command runs exactly once, after the last lane returns.
+- The returned evidence carries a status and a subject manifest digest for
+  every caller-supplied lane, and for no lane crank invented.
+- The response ends with the evidence: no next wave, no `git` action, and no
+  proposed follow-up work.

--- a/skills-codex/crank/prompt.md
+++ b/skills-codex/crank/prompt.md
@@ -1,0 +1,8 @@
+# crank
+
+Execute one caller-selected wave by invoking RPI once per lane and return the wave evidence, then stop. Triggers: "crank", "execute the next wave", "run this wave".
+
+## Instructions
+
+Load and follow the skill instructions from the sibling `SKILL.md` file for this skill.
+Then read local files in `references/` and `scripts/` when needed.

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "48c6504d5ae7f54b0cc8c019b290fb869ec655c9a0511e2d56fb64ba3b722c1d",
-  "generated_hash": "151e9c8727140a702156e0bb41ad1a97ee6d0f231a6e0d5b0df6099425be3655"
+  "source_hash": "34a594f554f0c3c2cf6fc68dabf81a06fb1fd6830e1f6b15eed75c188cbef899",
+  "generated_hash": "9329ab2ed19205f05bb416ea788173dd1823d4dde9c72024b2cebb26e44375ea"
 }

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "d7db72af73f50f6bdd006dcf02a1375145fae4f2bd584fc4ba365e6269b63623",
-  "generated_hash": "7951c4234924d8bf19fac27574d30fcd136818d7812b26172d1e896c4c36c7c8"
+  "source_hash": "4c5ad428c141cec452262ddff4b5554301bd266352c3879c366334a3dbbf797a",
+  "generated_hash": "8142877cca5c15dfb9472493bbc1ab6e74b472348d434b3e7f5c45972bd11562"
 }

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "4c5ad428c141cec452262ddff4b5554301bd266352c3879c366334a3dbbf797a",
-  "generated_hash": "8142877cca5c15dfb9472493bbc1ab6e74b472348d434b3e7f5c45972bd11562"
+  "source_hash": "a8fc21b100fa5b05ce8e6af5f08dea2e521561194eac4f63421736d9211d8590",
+  "generated_hash": "deda17a4ee72c6b5e0f8decedfa5de334afe744c730833bc3e9a46bc456a793e"
 }

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "4870c343799f313706c7928b59d3b55cb2b4f8bd34b972dddf57e4859b999695",
-  "generated_hash": "9c3535ca09ce15b45a96c960153a9f2130fec4ad24aa19fe78dc435a1bd6e77d"
+  "source_hash": "48c6504d5ae7f54b0cc8c019b290fb869ec655c9a0511e2d56fb64ba3b722c1d",
+  "generated_hash": "151e9c8727140a702156e0bb41ad1a97ee6d0f231a6e0d5b0df6099425be3655"
 }

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "a8fc21b100fa5b05ce8e6af5f08dea2e521561194eac4f63421736d9211d8590",
-  "generated_hash": "deda17a4ee72c6b5e0f8decedfa5de334afe744c730833bc3e9a46bc456a793e"
+  "source_hash": "032a23898cfee4cf8b45d463e551e54b12eb4eeb611588d18bd7bfcf432c881a",
+  "generated_hash": "c859895c1c3a8e146a9a03510bccb46131bbc7d1b97898cee1e09ed983798363"
 }

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "34a594f554f0c3c2cf6fc68dabf81a06fb1fd6830e1f6b15eed75c188cbef899",
-  "generated_hash": "9329ab2ed19205f05bb416ea788173dd1823d4dde9c72024b2cebb26e44375ea"
+  "source_hash": "d7db72af73f50f6bdd006dcf02a1375145fae4f2bd584fc4ba365e6269b63623",
+  "generated_hash": "7951c4234924d8bf19fac27574d30fcd136818d7812b26172d1e896c4c36c7c8"
 }

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -77,43 +77,34 @@ never creates a parallel revision artifact or selects the next work itself.
 A repair round is admitted only while all hold:
 
 1. `rounds_used < repair_rounds` (caller-declared, default 2).
-2. The open finding set, keyed by the validators' stable `findings[].id`
-   (union across the fresh and, when used, cross-family validators), is not
-   larger than the previous round's.
+2. The open finding set, keyed by stable `findings[].id` (union of the fresh
+   and cross-family validators), is not larger than the previous round's.
 3. No finding id closed in an earlier round reopens.
-4. Between rounds either the subject-manifest digest changed (generated-only
-   changes count when they change the digest) or, for `NOT_PROVEN`, new
-   digest-bound evidence was supplied that resolves a named gap.
+4. Between rounds the subject-manifest digest changed (generated-only changes
+   count) or, for `NOT_PROVEN`, new digest-bound evidence resolved a named gap.
 
-Converged ⇔ the fresh validator returns PASS and, when the diff touches a
-risky surface, the cross-family validator also returns PASS. On any violation
-of 1-4 RPI stops and reports the current status; `checked` carries one line
-per round (`repair round N: k open findings`), the open findings ride in the
-validation result and the interactive report, and `not_checked` keeps its
-meaning. No third judge, no escalation, no auto-replan.
-
-A reworded finding with the same id is the same finding. The fix step belongs
-to the orchestrating context; every judge leg stays non-mutating, so a verdict
-never rewrites the artifact it is judging.
+Converged: the fresh validator returns PASS and, on a risky surface, the
+cross-family validator also returns PASS. On any violation of 1-4 RPI stops and
+reports the current status. `checked` carries one line per round
+(`repair round N: k open findings`); open findings ride in the validation
+result and the report; `not_checked` keeps its meaning. A reworded finding with
+the same id is the same finding. The orchestrating context fixes; judge legs
+never mutate the subject. No third judge, no escalation, no auto-replan.
 
 ## Cross-family validation
 
 Risky surfaces default to a cross-family fresh validator: `cli/internal/gates/**`,
 `scripts/check-*.sh`, `tests/**`, `skills/*/scripts/**`,
-`skills/cc-hooks/policies/**`, `lib/**`, and anything `security-gate.sh` scans.
-The dispatch table — which direction may run headless and which must route to
-an interactive pane — is owned by [`validate`](../validate/SKILL.md); RPI
-selects when it applies, never how the leg is launched. With no authorized
-live adapter the result is `diversity_unsatisfied`, and on a risky surface that
-stops as `NOT_PROVEN` rather than converging same-family.
+`skills/cc-hooks/policies/**`, `lib/**`, anything `security-gate.sh` scans.
+[`validate`](../validate/SKILL.md) owns the dispatch table. No authorized live
+adapter means `diversity_unsatisfied`, which on a risky surface is `NOT_PROVEN`.
 
 ## Waves
 
-RPI executes one traversal. A multi-wave intent is executed one wave per
-`crank` invocation: the caller selects the wave and the
-`repair_rounds` bound, crank forwards both and invokes RPI per lane, then
-returns wave evidence and stops. RPI itself never selects a wave, queues the
-next one, or widens the bound it was given.
+RPI executes one traversal. A multi-wave intent runs one wave per `crank`
+invocation: the caller selects the wave and the `repair_rounds` bound, crank
+forwards both, invokes RPI per lane, returns wave evidence, and stops. RPI never
+selects a wave or queues the next one, and never extends the caller's bound.
 
 ## Anti-ceremony boundary
 

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rpi
-description: 'Coordinate one RPI traversal: one bounded Plan, Implement, and fresh Validate experiment, then report and stop. Triggers: "run rpi", "run one traversal", "execute this plan", orchestration or worker delegation that implements changes.'
+description: 'Coordinate one RPI traversal: one bounded Plan and Implement experiment, then fresh Validate and a bounded repair phase to convergence. Triggers: "run rpi", "run one traversal", "execute this plan", orchestration or worker delegation that implements changes.'
 ---
 # RPI
 
@@ -8,17 +8,21 @@ Run one experiment from the caller's existing intent source through three
 responsibilities and stop:
 
 ```text
-anti-ceremony guard -> Plan -> Implement -> fresh Validate -> report
+anti-ceremony guard -> Plan -> Implement -> fresh Validate -> bounded repair -> report
 ```
 
 On `CONTINUE`, the core path remains Plan -> Implement -> fresh Validate ->
-report. RPI invokes the guard exactly once before Plan. It preserves the
-original intent and dispatches each core phase at most once.
-It does not own retries, budgets, queues, claims, leases, Git, delivery, release,
-closure, or the caller's next decision.
+bounded repair -> report. RPI invokes the guard exactly once before Plan. It
+preserves the original intent and dispatches Plan and Implement at most once.
+Validate repeats only inside the repair phase below, under the convergence law
+and the caller's `repair_rounds` bound. RPI does not own retries, budgets,
+queues, claims, leases, Git, delivery, release, closure, or the caller's next
+decision; `repair_rounds` is the caller's declaration, not RPI's budget.
 
 The pure [`scripts/run_once.py`](scripts/run_once.py) reference behavior makes
-the dispatch and stop semantics executable without Git, `ao`, or a tracker.
+the dispatch, repair, and stop semantics executable without Git, `ao`, or a
+tracker: `invoke_once` for the one bounded experiment, `run_repair_phase` for
+the law.
 
 ## Admission and phase lock
 
@@ -56,14 +60,60 @@ authorization by itself.
 4. Invoke Validate once in a context distinct from the author's context. Pass
    the intent reference and digest, exact subject manifest, factual receipts,
    validator identity, and freshness attestation.
-5. Return the fresh validation result and a short report. Persist and link
-   `verdict.v2` only when the caller requests machine-readable evidence or a
-   declared downstream consumer requires it. Stop regardless of `PASS`, `FAIL`,
-   or `NOT_PROVEN`.
+5. Enter the bounded repair phase. On a converged result, report and stop. On
+   `FAIL` or `NOT_PROVEN` with findings, repair the named findings and
+   re-validate freshly while the convergence law admits another round; stop
+   when converged, stopped by the law, or out of `repair_rounds`. Return the
+   current validation result, the open findings, and a short report. Persist
+   and link `verdict.v2` only when the caller requests machine-readable
+   evidence or a declared downstream consumer requires it.
 
 `NOT_PLANNED` and `NOT_BUILT` are report statuses, never semantic verdicts.
 A caller may revise the bead or caller intent and start a new invocation. RPI
 never creates a parallel revision artifact or selects the next work itself.
+
+## The convergence law
+
+A repair round is admitted only while all hold:
+
+1. `rounds_used < repair_rounds` (caller-declared, default 2).
+2. The open finding set, keyed by the validators' stable `findings[].id`
+   (union across the fresh and, when used, cross-family validators), is not
+   larger than the previous round's.
+3. No finding id closed in an earlier round reopens.
+4. Between rounds either the subject-manifest digest changed (generated-only
+   changes count when they change the digest) or, for `NOT_PROVEN`, new
+   digest-bound evidence was supplied that resolves a named gap.
+
+Converged ⇔ the fresh validator returns PASS and, when the diff touches a
+risky surface, the cross-family validator also returns PASS. On any violation
+of 1-4 RPI stops and reports the current status; `checked` carries one line
+per round (`repair round N: k open findings`), the open findings ride in the
+validation result and the interactive report, and `not_checked` keeps its
+meaning. No third judge, no escalation, no auto-replan.
+
+A reworded finding with the same id is the same finding. The fix step belongs
+to the orchestrating context; every judge leg stays non-mutating, so a verdict
+never rewrites the artifact it is judging.
+
+## Cross-family validation
+
+Risky surfaces default to a cross-family fresh validator: `cli/internal/gates/**`,
+`scripts/check-*.sh`, `tests/**`, `skills/*/scripts/**`,
+`skills/cc-hooks/policies/**`, `lib/**`, and anything `security-gate.sh` scans.
+The dispatch table — which direction may run headless and which must route to
+an interactive pane — is owned by [`validate`](../validate/SKILL.md); RPI
+selects when it applies, never how the leg is launched. With no authorized
+live adapter the result is `diversity_unsatisfied`, and on a risky surface that
+stops as `NOT_PROVEN` rather than converging same-family.
+
+## Waves
+
+RPI executes one traversal. A multi-wave intent is executed one wave per
+`crank` invocation: the caller selects the wave and the
+`repair_rounds` bound, crank forwards both and invokes RPI per lane, then
+returns wave evidence and stops. RPI itself never selects a wave, queues the
+next one, or widens the bound it was given.
 
 ## Anti-ceremony boundary
 
@@ -83,11 +133,16 @@ scope, or validation authority.
 
 ## Spiral breaker
 
-The spiral breaker fires when two consecutive control artifacts (plans, audits,
-reviews, prompts, reports) contain no new implementation evidence. Terminate the
-run and report `NOT_BUILT` when no implementation subject exists; when a subject
-exists, stop and report its current status without dispatching another lane or
-repair revision. RPI owns no lane budget, repair budget, or retry policy.
+The spiral breaker fires on a convergence-law violation, or when two
+consecutive rounds produce no change to the subject digest and no new
+digest-bound evidence. It never fires on a verdict count: a `FAIL` or a
+`NOT_PROVEN` that is being repaired under the law is progress, not a spiral,
+and repeated control artifacts (plans, audits, reviews, prompts, reports) with
+no new implementation evidence are the spiral. Terminate the run and report
+`NOT_BUILT` when no implementation subject exists; when a subject exists, stop
+and report its current status without dispatching another lane. RPI owns no
+lane budget and no retry policy, and never extends the caller's
+`repair_rounds`.
 
 ## Delegation boundaries
 
@@ -103,7 +158,8 @@ disjoint regen surfaces may run in parallel.
 
 ## Invariants
 
-- Acceptance and its runtime-derived digest do not change between phases.
+- Acceptance and its runtime-derived digest do not change between phases or
+  between repair rounds; a repair moves the subject, never the acceptance.
 - The anti-ceremony guard runs once before Plan; `STOP` dispatches none of Plan,
   Implement, or Validate, while `CONTINUE` preserves their order.
 - The runtime derives complete changed-path coverage or Validate returns

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -95,7 +95,7 @@ never mutate the subject. No third judge, no escalation, no auto-replan.
 
 Risky surfaces default to a cross-family fresh validator: `cli/internal/gates/**`,
 `scripts/check-*.sh`, `tests/**`, `skills/*/scripts/**`,
-`skills/cc-hooks/policies/**`, `lib/**`, anything `security-gate.sh` scans.
+`skills/cc-hooks/policies/**`, `lib/**`, `.github/workflows/**`, `scripts/security-gate.sh`.
 [`validate`](../validate/SKILL.md) owns the dispatch table. No authorized live
 adapter means `diversity_unsatisfied`, which on a risky surface is `NOT_PROVEN`.
 

--- a/skills-codex/rpi/prompt.md
+++ b/skills-codex/rpi/prompt.md
@@ -1,6 +1,6 @@
 # rpi
 
-Coordinate one RPI traversal: one bounded Plan, Implement, and fresh Validate experiment, then report and stop. Triggers: "run rpi", "run one traversal", "execute this plan", orchestration or worker delegation that implements changes.
+Coordinate one RPI traversal: one bounded Plan and Implement experiment, then fresh Validate and a bounded repair phase to convergence. Triggers: "run rpi", "run one traversal", "execute this plan", orchestration or worker delegation that implements changes.
 
 ## Instructions
 

--- a/skills-codex/rpi/references/rpi.feature
+++ b/skills-codex/rpi/references/rpi.feature
@@ -14,11 +14,17 @@ Feature: RPI runs one bounded experiment
     Then Plan, Implement, and Validate are not dispatched
     And RPI reports NOT_PLANNED and stops
 
-  @covered-by:skills/rpi/tests/test_run_once.py::test_fail_reports_and_stops_without_another_dispatch
-  Scenario: Validation failure does not loop
-    Given Validate returns FAIL or NOT_PROVEN
-    When RPI reports the verdict
-    Then RPI stops without repair, replan, helper, retry, or delivery
+  @covered-by:skills/rpi/tests/test_run_once.py::test_fail_from_one_experiment_feeds_the_repair_phase
+  Scenario: Validation failure enters the bounded repair phase
+    Given Validate returns FAIL or NOT_PROVEN with findings
+    When the convergence law admits another round
+    Then RPI repairs the named findings and re-validates freshly, without replan, helper, or delivery
+
+  @covered-by:skills/rpi/tests/test_run_once.py::test_repair_stops_when_a_closed_finding_reopens
+  Scenario: The convergence law stops a repair spiral
+    Given a repair round reopens a closed finding id, grows the open set, or changes nothing
+    When RPI evaluates the law
+    Then RPI stops and reports the current status with the open findings
 
   @covered-by:skills/rpi/scripts/validate.sh
   Scenario: Interactive output does not require a machine artifact

--- a/skills-codex/rpi/references/rpi.feature
+++ b/skills-codex/rpi/references/rpi.feature
@@ -1,6 +1,6 @@
 Feature: RPI runs one bounded experiment
   @covered-by:skills/rpi/tests/test_run_once.py::test_anti_ceremony_guard_runs_once_before_plan
-  Scenario: Guard CONTINUE preserves the single-pass core order
+  Scenario: Guard CONTINUE preserves the core phase order
     Given one intent
     When RPI is invoked
     Then the anti-ceremony guard is invoked exactly once before Plan

--- a/skills-codex/rpi/references/rpi.feature
+++ b/skills-codex/rpi/references/rpi.feature
@@ -4,7 +4,7 @@ Feature: RPI runs one bounded experiment
     Given one intent
     When RPI is invoked
     Then the anti-ceremony guard is invoked exactly once before Plan
-    And Plan, Implement, and fresh Validate are each dispatched at most once in that order
+    And Plan and Implement are each dispatched at most once in that order, and fresh Validate repeats only inside the bounded repair phase
     And the final report contains no next action
 
   @covered-by:skills/rpi/tests/test_run_once.py::test_anti_ceremony_stop_dispatches_no_core_phase

--- a/skills-codex/rpi/scripts/run_once.py
+++ b/skills-codex/rpi/scripts/run_once.py
@@ -299,9 +299,29 @@ def normalize_round(value: Any) -> dict[str, Any]:
         family = leg.get("validator_family")
         if isinstance(family, str) and family and family not in families:
             families.append(family)
-        for ref in leg.get("evidence_refs") or []:
-            if ref not in evidence_refs:
-                evidence_refs.append(ref)
+        raw_evidence = leg.get("evidence_refs")
+        if raw_evidence is None:
+            raw_evidence = []
+        if not isinstance(raw_evidence, (list, tuple)):
+            raise ValueError("evidence_refs must be a list")
+        for ref in raw_evidence:
+            # Evidence is either a bare label (unbound; it can never admit an
+            # unchanged digest) or a binding {ref, subject_digest, resolves}.
+            if isinstance(ref, str):
+                entry: dict[str, Any] = {"ref": ref}
+            elif isinstance(ref, Mapping):
+                if not isinstance(ref.get("ref"), str) or not ref["ref"].strip():
+                    raise ValueError("each evidence binding must carry a nonempty ref")
+                entry = dict(ref)
+                resolves = entry.get("resolves")
+                if resolves is not None and not valid_string_list(resolves):
+                    raise ValueError("evidence.resolves must be a list of finding ids")
+                if "subject_digest" in entry and not valid_digest(entry["subject_digest"]):
+                    raise ValueError("evidence.subject_digest must be a valid digest")
+            else:
+                raise ValueError("each evidence ref must be a string or a binding mapping")
+            if entry["ref"] not in {e["ref"] for e in evidence_refs}:
+                evidence_refs.append(entry)
         leg_digest = leg.get("subject_digest", leg.get("subject_manifest_digest"))
         if not valid_digest(leg_digest):
             raise ValueError("each validate leg must carry a valid subject digest")
@@ -341,19 +361,24 @@ def law_violation(
         return "finding_set_grew"
     if current["subject_digest"] != previous["subject_digest"]:
         return None
-    new_evidence = [
-        ref for ref in current["evidence_refs"] if ref not in set(previous["evidence_refs"])
-    ]
+    previous_refs = {e["ref"] for e in previous["evidence_refs"]}
+    resolved = previous["open_ids"] - current["open_ids"]
     # The evidence branch is NOT_PROVEN-only by construction, on both sides: a
     # FAIL says the subject is wrong, and no amount of new evidence over
-    # unchanged bytes repairs a wrong subject. The new evidence must also have
-    # RESOLVED something: at least one previously open finding id is closed.
-    resolved = previous["open_ids"] - current["open_ids"]
+    # unchanged bytes repairs a wrong subject. The new evidence must be BOUND:
+    # it names this exact subject digest and at least one finding id that this
+    # round actually closed. A bare new label admits nothing.
+    binding_evidence = [
+        e
+        for e in current["evidence_refs"]
+        if e["ref"] not in previous_refs
+        and e.get("subject_digest") == current["subject_digest"]
+        and resolved & set(e.get("resolves") or [])
+    ]
     if (
         previous["status"] == "NOT_PROVEN"
         and current["status"] != "FAIL"
-        and new_evidence
-        and resolved
+        and binding_evidence
     ):
         return None
     return "no_subject_or_evidence_change"

--- a/skills-codex/rpi/scripts/run_once.py
+++ b/skills-codex/rpi/scripts/run_once.py
@@ -274,9 +274,9 @@ def normalize_round(value: Any) -> dict[str, Any]:
         leg_status = _leg_status(leg)
         if _STATUS_RANK[leg_status] > _STATUS_RANK[status]:
             status = leg_status
-        raw_findings = leg.get("findings")
-        if raw_findings is None:
-            raw_findings = []
+        if "findings" not in leg:
+            raise ValueError("each validate leg must carry a findings list (empty on PASS)")
+        raw_findings = leg["findings"]
         if not isinstance(raw_findings, (list, tuple)):
             raise ValueError("findings must be a list")
         leg_ids: set[str] = set()
@@ -299,9 +299,9 @@ def normalize_round(value: Any) -> dict[str, Any]:
         family = leg.get("validator_family")
         if isinstance(family, str) and family and family not in families:
             families.append(family)
-        raw_evidence = leg.get("evidence_refs")
-        if raw_evidence is None:
-            raw_evidence = []
+        if "evidence_refs" not in leg:
+            raise ValueError("each validate leg must carry an evidence_refs list (empty if none)")
+        raw_evidence = leg["evidence_refs"]
         if not isinstance(raw_evidence, (list, tuple)):
             raise ValueError("evidence_refs must be a list")
         for ref in raw_evidence:
@@ -328,8 +328,11 @@ def normalize_round(value: Any) -> dict[str, Any]:
         if digest is not None and leg_digest != digest:
             raise ValueError("validate legs disagree about the subject digest")
         digest = leg_digest
-        checked.extend(str(item) for item in leg.get("checked") or [])
-        not_checked.extend(str(item) for item in leg.get("not_checked") or [])
+        for key, sink in (("checked", checked), ("not_checked", not_checked)):
+            items = leg.get(key, [])
+            if not valid_string_list(items):
+                raise ValueError(f"{key} must be a list of strings")
+            sink.extend(items)
 
     return {
         "status": status,

--- a/skills-codex/rpi/scripts/run_once.py
+++ b/skills-codex/rpi/scripts/run_once.py
@@ -274,15 +274,28 @@ def normalize_round(value: Any) -> dict[str, Any]:
         leg_status = _leg_status(leg)
         if _STATUS_RANK[leg_status] > _STATUS_RANK[status]:
             status = leg_status
-        for finding in leg.get("findings") or []:
+        raw_findings = leg.get("findings")
+        if raw_findings is None:
+            raw_findings = []
+        if not isinstance(raw_findings, (list, tuple)):
+            raise ValueError("findings must be a list")
+        leg_ids: set[str] = set()
+        for finding in raw_findings:
             if not isinstance(finding, Mapping):
                 raise ValueError("each finding must be a mapping")
             finding_id = finding.get("id")
             if not isinstance(finding_id, str) or not finding_id.strip():
                 raise ValueError("each finding must carry a stable nonempty id")
+            if finding_id in leg_ids:
+                raise ValueError(f"finding id {finding_id!r} appears twice in one validate leg")
+            leg_ids.add(finding_id)
             # Last leg wins on wording; the id is the identity, so a reworded
             # summary is the same finding and never counts as a new one.
             open_findings[finding_id] = dict(finding)
+        if leg_status == "PASS" and leg_ids:
+            raise ValueError("a PASS leg cannot carry open findings")
+        if leg_status == "FAIL" and not leg_ids:
+            raise ValueError("a FAIL leg must name at least one finding")
         family = leg.get("validator_family")
         if isinstance(family, str) and family and family not in families:
             families.append(family)
@@ -290,10 +303,11 @@ def normalize_round(value: Any) -> dict[str, Any]:
             if ref not in evidence_refs:
                 evidence_refs.append(ref)
         leg_digest = leg.get("subject_digest", leg.get("subject_manifest_digest"))
-        if leg_digest is not None:
-            if digest is not None and leg_digest != digest:
-                raise ValueError("validate legs disagree about the subject digest")
-            digest = leg_digest
+        if not valid_digest(leg_digest):
+            raise ValueError("each validate leg must carry a valid subject digest")
+        if digest is not None and leg_digest != digest:
+            raise ValueError("validate legs disagree about the subject digest")
+        digest = leg_digest
         checked.extend(str(item) for item in leg.get("checked") or [])
         not_checked.extend(str(item) for item in leg.get("not_checked") or [])
 
@@ -330,10 +344,17 @@ def law_violation(
     new_evidence = [
         ref for ref in current["evidence_refs"] if ref not in set(previous["evidence_refs"])
     ]
-    # The evidence branch is NOT_PROVEN-only by construction: a FAIL says the
-    # subject is wrong, and no amount of new evidence over unchanged bytes
-    # repairs a wrong subject.
-    if previous["status"] == "NOT_PROVEN" and new_evidence:
+    # The evidence branch is NOT_PROVEN-only by construction, on both sides: a
+    # FAIL says the subject is wrong, and no amount of new evidence over
+    # unchanged bytes repairs a wrong subject. The new evidence must also have
+    # RESOLVED something: at least one previously open finding id is closed.
+    resolved = previous["open_ids"] - current["open_ids"]
+    if (
+        previous["status"] == "NOT_PROVEN"
+        and current["status"] != "FAIL"
+        and new_evidence
+        and resolved
+    ):
         return None
     return "no_subject_or_evidence_change"
 
@@ -364,8 +385,7 @@ def run_repair_phase(
       round 0 and spends none).
     - ``stop_reason``: one of :data:`STOP_REASONS`.
     """
-    rounds = [normalize_round(entry) for entry in validations]
-    if not rounds:
+    if not validations:
         raise ValueError("the repair phase needs at least one validation round")
     if not isinstance(repair_rounds, int) or isinstance(repair_rounds, bool) or repair_rounds < 0:
         raise ValueError("repair_rounds must be a non-negative integer")
@@ -373,16 +393,19 @@ def run_repair_phase(
     checked: list[str] = []
     closed_ids: set[str] = set()
     rounds_used = 0
-    current = rounds[0]
-    previous = rounds[0]
+    current = normalize_round(validations[0])
+    previous = current
     stop_reason = "not_converged"
+    law_stopped = False
 
-    for index, candidate in enumerate(rounds):
+    for index, raw_candidate in enumerate(validations):
         if index > 0:
-            # Condition 1: the caller's bound, checked before the round counts.
+            # Condition 1: the caller's bound, checked before the round is even
+            # normalized, so a round past the bound is never consumed.
             if rounds_used >= repair_rounds:
                 stop_reason = "repair_budget_exhausted"
                 break
+            candidate = normalize_round(raw_candidate)
             rounds_used += 1
             current = candidate
             checked.append(
@@ -391,10 +414,10 @@ def run_repair_phase(
             violation = law_violation(previous, current, closed_ids)
             if violation is not None:
                 stop_reason = violation
+                law_stopped = True
                 break
             closed_ids |= previous["open_ids"] - current["open_ids"]
         else:
-            current = candidate
             checked.append(f"repair round 0: {len(current['open_ids'])} open findings")
 
         converged, reason = _converged(current, risky_surface)
@@ -408,8 +431,15 @@ def run_repair_phase(
     else:
         stop_reason = "not_converged"
 
+    if stop_reason == "not_converged" and rounds_used >= repair_rounds and current["open_ids"]:
+        # Findings remain and the caller's bound is spent: name it as such.
+        stop_reason = "repair_budget_exhausted"
+
     status = current["status"]
-    if stop_reason == "diversity_unsatisfied":
+    if stop_reason == "diversity_unsatisfied" or (law_stopped and status == "PASS"):
+        # A PASS produced by a law-violating round cannot certify anything: a
+        # PASS over unchanged bytes after a FAIL is a flip, not a proof. A FAIL
+        # that also broke the law stays a FAIL; the subject is still wrong.
         status = "NOT_PROVEN"
 
     return {

--- a/skills-codex/rpi/scripts/run_once.py
+++ b/skills-codex/rpi/scripts/run_once.py
@@ -1,14 +1,21 @@
 #!/usr/bin/env python3
-"""Pure reference behavior for one RPI invocation.
+"""Pure reference behavior for one RPI invocation and its bounded repair phase.
 
 The caller supplies one anti-ceremony guard and the three core phase functions.
-This module invokes the guard once before Plan, dispatches each core phase at
-most once, and never chooses a retry or next action.
+This module invokes the guard once before Plan, dispatches Plan and Implement at
+most once, and never chooses a retry, a budget, or a next action.
+
+Under ADR-0017 (loop as control flow, not knowledge) the traversal no longer
+ends at the first validation result. `run_repair_phase` models the bounded
+repair phase as pure data: it consumes validate rounds that already happened and
+decides, under the convergence law, whether another repair round is admitted.
+It performs no I/O, dispatches nothing, and owns no budget of its own — the
+caller declares `repair_rounds`.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 import re
 from typing import Any
 
@@ -194,3 +201,240 @@ def invoke_once(
         checked=list(validation.get("checked") or []),
         not_checked=list(validation.get("not_checked") or []),
     )
+
+
+# ---------------------------------------------------------------------------
+# The bounded repair phase (ADR-0017)
+# ---------------------------------------------------------------------------
+#
+# The 2026-07-14 cathedral cut removed the iterate loop together with the
+# unproven compounding claim, although ADR-0011 demoted only the latter. What
+# comes back is control flow, not knowledge: a repair round is admitted only
+# while every condition of the convergence law holds, so the loop cannot grind,
+# cannot re-open settled ground, and cannot spin without moving the subject.
+#
+# Condition ordering is deliberate. A reopened id is diagnosed before a grown
+# set, so the operator is told the specific regression rather than the generic
+# symptom; progress is checked last because it is the only condition that can
+# be satisfied by evidence instead of by bytes.
+
+REPAIR_ROUNDS_DEFAULT = 2
+
+#: Terminal reasons `run_repair_phase` may report. `converged` is the only
+#: success; the rest are law stops the caller owns the response to.
+STOP_REASONS = (
+    "converged",
+    "diversity_unsatisfied",
+    "repair_budget_exhausted",
+    "reopened_finding",
+    "finding_set_grew",
+    "no_subject_or_evidence_change",
+    "not_converged",
+)
+
+_STATUS_RANK = {"PASS": 0, "NOT_PROVEN": 1, "FAIL": 2}
+
+
+def _leg_status(leg: Mapping[str, Any]) -> str:
+    """Read a validate leg's semantic verdict under either spelling."""
+    status = leg.get("status", leg.get("verdict"))
+    if status not in _STATUS_RANK:
+        raise ValueError("each validate result must report PASS, FAIL, or NOT_PROVEN")
+    return str(status)
+
+
+def normalize_round(value: Any) -> dict[str, Any]:
+    """Fold one validation round's legs into the facts the law reasons over.
+
+    A round is one or more validate results (the fresh validator, plus the
+    cross-family validator when the diff touches a risky surface). Open findings
+    are the UNION of the legs' stable `findings[].id`; the round's status is the
+    worst leg's; the digest is the subject every leg judged.
+    """
+    legs: list[Mapping[str, Any]]
+    if isinstance(value, Mapping):
+        legs = [value]
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        legs = list(value)
+    else:
+        raise ValueError("a validation round must be a validate result or a list of them")
+    if not legs:
+        raise ValueError("a validation round must contain at least one validate result")
+
+    open_findings: dict[str, dict[str, Any]] = {}
+    families: list[str] = []
+    evidence_refs: list[str] = []
+    checked: list[str] = []
+    not_checked: list[str] = []
+    digest: Any = None
+    status = "PASS"
+    for leg in legs:
+        if not isinstance(leg, Mapping):
+            raise ValueError("each validate result must be a mapping")
+        leg_status = _leg_status(leg)
+        if _STATUS_RANK[leg_status] > _STATUS_RANK[status]:
+            status = leg_status
+        for finding in leg.get("findings") or []:
+            if not isinstance(finding, Mapping):
+                raise ValueError("each finding must be a mapping")
+            finding_id = finding.get("id")
+            if not isinstance(finding_id, str) or not finding_id.strip():
+                raise ValueError("each finding must carry a stable nonempty id")
+            # Last leg wins on wording; the id is the identity, so a reworded
+            # summary is the same finding and never counts as a new one.
+            open_findings[finding_id] = dict(finding)
+        family = leg.get("validator_family")
+        if isinstance(family, str) and family and family not in families:
+            families.append(family)
+        for ref in leg.get("evidence_refs") or []:
+            if ref not in evidence_refs:
+                evidence_refs.append(ref)
+        leg_digest = leg.get("subject_digest", leg.get("subject_manifest_digest"))
+        if leg_digest is not None:
+            if digest is not None and leg_digest != digest:
+                raise ValueError("validate legs disagree about the subject digest")
+            digest = leg_digest
+        checked.extend(str(item) for item in leg.get("checked") or [])
+        not_checked.extend(str(item) for item in leg.get("not_checked") or [])
+
+    return {
+        "status": status,
+        "open_findings": list(open_findings.values()),
+        "open_ids": set(open_findings),
+        "subject_digest": digest,
+        "evidence_refs": evidence_refs,
+        "families": families,
+        "checked": checked,
+        "not_checked": not_checked,
+    }
+
+
+def law_violation(
+    previous: Mapping[str, Any],
+    current: Mapping[str, Any],
+    closed_ids: set[str],
+) -> str | None:
+    """Return the violated convergence-law condition, or None when all hold.
+
+    Condition 1 (the caller's `repair_rounds`) is a precondition on admission
+    and is checked by `run_repair_phase` before a round is consumed; conditions
+    2, 3, and 4 are properties of the round that was produced.
+    """
+    reopened = current["open_ids"] & closed_ids
+    if reopened:
+        return "reopened_finding"
+    if len(current["open_ids"]) > len(previous["open_ids"]):
+        return "finding_set_grew"
+    if current["subject_digest"] != previous["subject_digest"]:
+        return None
+    new_evidence = [
+        ref for ref in current["evidence_refs"] if ref not in set(previous["evidence_refs"])
+    ]
+    # The evidence branch is NOT_PROVEN-only by construction: a FAIL says the
+    # subject is wrong, and no amount of new evidence over unchanged bytes
+    # repairs a wrong subject.
+    if previous["status"] == "NOT_PROVEN" and new_evidence:
+        return None
+    return "no_subject_or_evidence_change"
+
+
+def run_repair_phase(
+    validations: Sequence[Any],
+    *,
+    repair_rounds: int = REPAIR_ROUNDS_DEFAULT,
+    risky_surface: bool = False,
+    intent_ref: str | None = None,
+    acceptance_digest: str | None = None,
+    verdict_ref: str | None = None,
+    verdict_digest: str | None = None,
+) -> dict[str, Any]:
+    """Walk already-produced validation rounds under the convergence law.
+
+    `validations[0]` is the traversal's first fresh validation; every later
+    element is a repair round the orchestrator produced after fixing findings.
+
+    Returns a mapping with:
+
+    - ``report``: the exact nine-key `rpi-report.v1` object. `checked` opens
+      with one `repair round N: k open findings` line per round; open findings
+      never enter `not_checked`, which keeps its meaning (unverified in-scope
+      acceptance).
+    - ``open_findings``: the findings still open at the stop, deduplicated by id.
+    - ``rounds_used``: repair rounds actually spent (the first validation is
+      round 0 and spends none).
+    - ``stop_reason``: one of :data:`STOP_REASONS`.
+    """
+    rounds = [normalize_round(entry) for entry in validations]
+    if not rounds:
+        raise ValueError("the repair phase needs at least one validation round")
+    if not isinstance(repair_rounds, int) or isinstance(repair_rounds, bool) or repair_rounds < 0:
+        raise ValueError("repair_rounds must be a non-negative integer")
+
+    checked: list[str] = []
+    closed_ids: set[str] = set()
+    rounds_used = 0
+    current = rounds[0]
+    previous = rounds[0]
+    stop_reason = "not_converged"
+
+    for index, candidate in enumerate(rounds):
+        if index > 0:
+            # Condition 1: the caller's bound, checked before the round counts.
+            if rounds_used >= repair_rounds:
+                stop_reason = "repair_budget_exhausted"
+                break
+            rounds_used += 1
+            current = candidate
+            checked.append(
+                f"repair round {rounds_used}: {len(current['open_ids'])} open findings"
+            )
+            violation = law_violation(previous, current, closed_ids)
+            if violation is not None:
+                stop_reason = violation
+                break
+            closed_ids |= previous["open_ids"] - current["open_ids"]
+        else:
+            current = candidate
+            checked.append(f"repair round 0: {len(current['open_ids'])} open findings")
+
+        converged, reason = _converged(current, risky_surface)
+        previous = current
+        if converged:
+            stop_reason = "converged"
+            break
+        if reason is not None:
+            stop_reason = reason
+            break
+    else:
+        stop_reason = "not_converged"
+
+    status = current["status"]
+    if stop_reason == "diversity_unsatisfied":
+        status = "NOT_PROVEN"
+
+    return {
+        "report": report(
+            status,
+            intent_ref=intent_ref,
+            acceptance_digest=acceptance_digest,
+            subject_digest=current["subject_digest"],
+            verdict_ref=verdict_ref,
+            verdict_digest=verdict_digest,
+            checked=checked + current["checked"],
+            not_checked=list(current["not_checked"]),
+        ),
+        "open_findings": list(current["open_findings"]),
+        "rounds_used": rounds_used,
+        "stop_reason": stop_reason,
+    }
+
+
+def _converged(current: Mapping[str, Any], risky_surface: bool) -> tuple[bool, str | None]:
+    """Converged ⇔ fresh PASS, plus a cross-family PASS on a risky surface."""
+    if current["status"] != "PASS":
+        return False, None
+    if risky_surface and len(current["families"]) < 2:
+        # No authorized second family judged the risky surface, so same-family
+        # agreement is not independence: NOT_PROVEN, never a convergence.
+        return False, "diversity_unsatisfied"
+    return True, None

--- a/skills-codex/rpi/scripts/validate.sh
+++ b/skills-codex/rpi/scripts/validate.sh
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 skill_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# ADR-0017: RPI is no longer single-pass. Validate repeats inside the bounded
+# repair phase, so this contract asserts the phase lock that survives (Plan and
+# Implement once) plus positive canaries that each condition of the convergence
+# law is present by name.
 grep -q '^name: rpi$' "$skill_dir/SKILL.md"
-grep -Fq 'Plan -> Implement -> fresh Validate -> report' "$skill_dir/SKILL.md"
+grep -Fq 'Plan -> Implement -> fresh Validate -> bounded repair -> report' "$skill_dir/SKILL.md"
 grep -Fq 'dependencies: [anti-ceremony, plan, implement, validate]' "$skill_dir/SKILL.md"
 grep -Fq 'invokes the guard exactly once before Plan' "$skill_dir/SKILL.md"
 grep -Fq '`STOP`, dispatch no core phase' "$skill_dir/SKILL.md"
-grep -Fq 'dispatches each core phase at most once' "$skill_dir/SKILL.md"
+grep -Fq 'dispatches Plan and Implement at most once' "$skill_dir/SKILL.md"
+grep -Fq '## The convergence law' "$skill_dir/SKILL.md"
+grep -Fq 'rounds_used < repair_rounds' "$skill_dir/SKILL.md"
+grep -Fq "larger than the previous round" "$skill_dir/SKILL.md"
+grep -Fq 'No finding id closed in an earlier round reopens.' "$skill_dir/SKILL.md"
+grep -Fq 'the subject-manifest digest changed' "$skill_dir/SKILL.md"
+grep -Fq 'repair round N: k open findings' "$skill_dir/SKILL.md"
+grep -Fq '## Waves' "$skill_dir/SKILL.md"
+grep -Fq '## Cross-family validation' "$skill_dir/SKILL.md"
 grep -Fq 'creates no AgentOps packet' "$skill_dir/SKILL.md"
 grep -Fq 'Plan is closed for that intent' "$skill_dir/SKILL.md"
 grep -Fq 'spiral breaker' "$skill_dir/SKILL.md"

--- a/skills-codex/rpi/tests/test_run_once.py
+++ b/skills-codex/rpi/tests/test_run_once.py
@@ -329,10 +329,41 @@ class RepairPhaseTests(unittest.TestCase):
         outcome = self.repair(
             [
                 validation_round("NOT_PROVEN", ["gap"], digest="a" * 64),
-                validation_round("NOT_PROVEN", ["gap"], digest="a" * 64, evidence=("receipt-2",)),
+                validation_round(
+                    "NOT_PROVEN", ["gap"], digest="a" * 64,
+                    evidence=({"ref": "receipt-2", "subject_digest": "a" * 64, "resolves": ["gap"]},),
+                ),
+            ]
+        )
+        # "resolves" claims gap, but gap is still open: nothing was resolved.
+        self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
+
+    def test_a_bare_new_evidence_label_does_not_admit_an_unchanged_digest(self):
+        outcome = self.repair(
+            [
+                validation_round("NOT_PROVEN", ["gap", "other"], digest="a" * 64),
+                validation_round("NOT_PROVEN", ["other"], digest="a" * 64, evidence=("receipt-2",)),
             ]
         )
         self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
+
+    def test_evidence_bound_to_another_digest_does_not_admit(self):
+        outcome = self.repair(
+            [
+                validation_round("NOT_PROVEN", ["gap", "other"], digest="a" * 64),
+                validation_round(
+                    "NOT_PROVEN", ["other"], digest="a" * 64,
+                    evidence=({"ref": "receipt-2", "subject_digest": "b" * 64, "resolves": ["gap"]},),
+                ),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
+
+    def test_scalar_evidence_refs_are_rejected(self):
+        bad = validation_round("FAIL", ["f1"])
+        bad["evidence_refs"] = "receipt-1"
+        with self.assertRaisesRegex(ValueError, "evidence_refs must be a list"):
+            self.repair([bad])
 
     def test_new_evidence_does_not_admit_a_current_fail_over_unchanged_bytes(self):
         outcome = self.repair(
@@ -439,7 +470,10 @@ class RepairPhaseTests(unittest.TestCase):
                 validation_round(
                     "NOT_PROVEN", ["gap1"], digest="a" * 64, evidence=["r1"]
                 ),
-                validation_round("PASS", [], digest="a" * 64, evidence=["r1", "r2"]),
+                validation_round(
+                    "PASS", [], digest="a" * 64,
+                    evidence=["r1", {"ref": "r2", "subject_digest": "a" * 64, "resolves": ["gap1"]}],
+                ),
             ]
         )
         self.assertEqual(outcome["stop_reason"], "converged")

--- a/skills-codex/rpi/tests/test_run_once.py
+++ b/skills-codex/rpi/tests/test_run_once.py
@@ -309,6 +309,67 @@ class RepairPhaseTests(unittest.TestCase):
         kwargs.setdefault("acceptance_digest", INTENT_DIGEST)
         return MODULE.run_repair_phase(rounds, **kwargs)
 
+    def test_repair_rounds_zero_with_findings_is_budget_exhausted(self):
+        outcome = self.repair([validation_round("FAIL", ["f1"])], repair_rounds=0)
+        self.assertEqual(outcome["stop_reason"], "repair_budget_exhausted")
+        self.assertEqual(outcome["rounds_used"], 0)
+        self.assertEqual(outcome["report"]["status"], "FAIL")
+
+    def test_a_pass_over_unchanged_bytes_after_a_fail_is_a_flip_not_a_proof(self):
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1"], digest="a" * 64),
+                validation_round("PASS", [], digest="a" * 64),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
+        self.assertEqual(outcome["report"]["status"], "NOT_PROVEN")
+
+    def test_new_evidence_must_resolve_a_prior_finding_to_admit_an_unchanged_digest(self):
+        outcome = self.repair(
+            [
+                validation_round("NOT_PROVEN", ["gap"], digest="a" * 64),
+                validation_round("NOT_PROVEN", ["gap"], digest="a" * 64, evidence=("receipt-2",)),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
+
+    def test_new_evidence_does_not_admit_a_current_fail_over_unchanged_bytes(self):
+        outcome = self.repair(
+            [
+                validation_round("NOT_PROVEN", ["gap", "bug"], digest="a" * 64),
+                validation_round("FAIL", ["bug"], digest="a" * 64, evidence=("receipt-2",)),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
+        self.assertEqual(outcome["report"]["status"], "FAIL")
+
+    def test_malformed_rounds_are_rejected_not_swallowed(self):
+        cases = {
+            "pass with findings": validation_round("PASS", ["f1"]),
+            "fail without findings": validation_round("FAIL", []),
+            "missing digest": validation_round("FAIL", ["f1"], digest=None),
+        }
+        for name, bad in cases.items():
+            with self.subTest(case=name):
+                with self.assertRaises(ValueError):
+                    self.repair([bad])
+        duplicate = validation_round("FAIL", ["f1"])
+        duplicate["findings"].append({"id": "f1", "summary": "again"})
+        with self.assertRaisesRegex(ValueError, "twice"):
+            self.repair([duplicate])
+
+    def test_rounds_past_the_bound_are_never_normalized(self):
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1"], digest="a" * 64),
+                validation_round("FAIL", ["f1"], digest="b" * 64),
+                {"status": "garbage-that-would-raise"},
+            ],
+            repair_rounds=1,
+        )
+        self.assertEqual(outcome["stop_reason"], "repair_budget_exhausted")
+
     def test_a_first_round_pass_converges_without_spending_a_repair_round(self):
         outcome = self.repair([validation_round("PASS", [])])
         self.assertEqual(outcome["stop_reason"], "converged")

--- a/skills-codex/rpi/tests/test_run_once.py
+++ b/skills-codex/rpi/tests/test_run_once.py
@@ -359,6 +359,18 @@ class RepairPhaseTests(unittest.TestCase):
         )
         self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
 
+    def test_missing_findings_or_evidence_keys_are_rejected(self):
+        for key in ("findings", "evidence_refs"):
+            with self.subTest(missing=key):
+                bad = validation_round("PASS", [])
+                del bad[key]
+                with self.assertRaisesRegex(ValueError, key):
+                    self.repair([bad])
+        bad = validation_round("PASS", [])
+        bad["checked"] = "acceptance"
+        with self.assertRaisesRegex(ValueError, "checked must be a list"):
+            self.repair([bad])
+
     def test_scalar_evidence_refs_are_rejected(self):
         bad = validation_round("FAIL", ["f1"])
         bad["evidence_refs"] = "receipt-1"

--- a/skills-codex/rpi/tests/test_run_once.py
+++ b/skills-codex/rpi/tests/test_run_once.py
@@ -30,6 +30,33 @@ VALIDATE_SPEC.loader.exec_module(VALIDATE)
 INTENT_DIGEST = "c" * 64
 
 
+def validation_round(
+    status,
+    finding_ids,
+    *,
+    digest="a" * 64,
+    evidence=(),
+    family="fresh",
+    summaries=None,
+    checked=("acceptance",),
+    not_checked=(),
+):
+    """One validate leg's result, as the repair phase consumes it (pure data)."""
+    summaries = summaries or {}
+    return {
+        "status": status,
+        "findings": [
+            {"id": fid, "summary": summaries.get(fid, f"finding {fid}")}
+            for fid in finding_ids
+        ],
+        "subject_digest": digest,
+        "evidence_refs": list(evidence),
+        "validator_family": family,
+        "checked": list(checked),
+        "not_checked": list(not_checked),
+    }
+
+
 def continue_guard(intent):
     return {
         "decision": "CONTINUE",
@@ -146,11 +173,30 @@ class RunOnceTests(unittest.TestCase):
         self.assertEqual(result["acceptance_digest"], INTENT_DIGEST)
         self.assertNotIn("next_action", result)
 
-    def test_fail_reports_and_stops_without_another_dispatch(self):
+    def test_fail_from_one_experiment_feeds_the_repair_phase(self):
+        """Replaces the old stop-on-FAIL test (ADR-0017).
+
+        One experiment still dispatches Plan and Implement exactly once, and the
+        FAIL it produces is no longer terminal by itself: it is the first round
+        handed to the bounded repair phase, which owns the stop decision.
+        """
         calls, plan, implement, validate = self.phases("FAIL")
         result = MODULE.invoke_once("intent", continue_guard, plan, implement, validate)
         self.assertEqual(calls, ["plan", "implement", "validate"])
         self.assertEqual(result["status"], "FAIL")
+
+        outcome = MODULE.run_repair_phase(
+            [
+                validation_round("FAIL", ["f1"], digest="a" * 64),
+                validation_round("PASS", [], digest="d" * 64),
+            ],
+            repair_rounds=2,
+            intent_ref=result["intent_ref"],
+            acceptance_digest=result["acceptance_digest"],
+        )
+        self.assertEqual(outcome["stop_reason"], "converged")
+        self.assertEqual(outcome["report"]["status"], "PASS")
+        self.assertEqual(outcome["rounds_used"], 1)
 
     def test_fresh_validation_does_not_require_persisted_verdict(self):
         calls, plan, implement, validate = self.phases()
@@ -247,6 +293,223 @@ class RunOnceTests(unittest.TestCase):
 
                 with self.assertRaisesRegex(ValueError, "acceptance_digest"):
                     MODULE.invoke_once("intent", continue_guard, undeclared, implement, validate)
+
+
+class RepairPhaseTests(unittest.TestCase):
+    """The bounded repair phase and its convergence law (ADR-0017).
+
+    RPI is no longer single-pass: a `FAIL` or `NOT_PROVEN` with findings may be
+    repaired and re-validated while all four law conditions hold. The loop is
+    modelled here as pure data — a sequence of already-produced validate rounds
+    — so the stop semantics are executable without Git, `ao`, or a tracker.
+    """
+
+    def repair(self, rounds, **kwargs):
+        kwargs.setdefault("intent_ref", "bead:agentops-test")
+        kwargs.setdefault("acceptance_digest", INTENT_DIGEST)
+        return MODULE.run_repair_phase(rounds, **kwargs)
+
+    def test_a_first_round_pass_converges_without_spending_a_repair_round(self):
+        outcome = self.repair([validation_round("PASS", [])])
+        self.assertEqual(outcome["stop_reason"], "converged")
+        self.assertEqual(outcome["report"]["status"], "PASS")
+        self.assertEqual(outcome["rounds_used"], 0)
+        self.assertEqual(outcome["open_findings"], [])
+        self.assertEqual(
+            outcome["report"]["checked"][0], "repair round 0: 0 open findings"
+        )
+
+    def test_repair_stops_at_the_declared_repair_rounds_budget(self):
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1"], digest="a" * 64),
+                validation_round("FAIL", ["f1"], digest="b" * 64),
+                validation_round("FAIL", ["f1"], digest="c" * 64),
+            ],
+            repair_rounds=1,
+        )
+        self.assertEqual(outcome["stop_reason"], "repair_budget_exhausted")
+        self.assertEqual(outcome["rounds_used"], 1)
+        self.assertEqual(outcome["report"]["status"], "FAIL")
+        self.assertEqual(
+            outcome["report"]["checked"][:2],
+            ["repair round 0: 1 open findings", "repair round 1: 1 open findings"],
+        )
+
+    def test_repair_stops_when_the_open_finding_set_grows(self):
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1"], digest="a" * 64),
+                validation_round("FAIL", ["f1", "f2"], digest="b" * 64),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "finding_set_grew")
+        self.assertEqual(outcome["report"]["status"], "FAIL")
+        self.assertEqual(outcome["rounds_used"], 1)
+        self.assertEqual(
+            sorted(f["id"] for f in outcome["open_findings"]), ["f1", "f2"]
+        )
+
+    def test_repair_stops_when_a_closed_finding_reopens(self):
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1", "f2"], digest="a" * 64),
+                validation_round("FAIL", ["f1"], digest="b" * 64),
+                validation_round("FAIL", ["f2"], digest="c" * 64),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "reopened_finding")
+        self.assertEqual(outcome["rounds_used"], 2)
+        self.assertEqual(outcome["report"]["status"], "FAIL")
+
+    def test_repair_stops_when_the_digest_is_unchanged_and_no_new_evidence(self):
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1"], digest="a" * 64, evidence=["r1"]),
+                validation_round("FAIL", ["f1"], digest="a" * 64, evidence=["r1"]),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
+        self.assertEqual(outcome["rounds_used"], 1)
+
+    def test_not_proven_is_resolved_by_new_evidence_with_an_unchanged_digest(self):
+        outcome = self.repair(
+            [
+                validation_round(
+                    "NOT_PROVEN", ["gap1"], digest="a" * 64, evidence=["r1"]
+                ),
+                validation_round("PASS", [], digest="a" * 64, evidence=["r1", "r2"]),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "converged")
+        self.assertEqual(outcome["report"]["status"], "PASS")
+        self.assertEqual(outcome["rounds_used"], 1)
+        self.assertEqual(outcome["report"]["subject_manifest_digest"], "a" * 64)
+
+    def test_new_evidence_does_not_rescue_a_fail_round(self):
+        """Condition 4's evidence branch is NOT_PROVEN-only.
+
+        A FAIL means the subject is wrong, so only a moved subject digest is
+        progress; extra evidence over the same bytes is not.
+        """
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1"], digest="a" * 64, evidence=["r1"]),
+                validation_round("FAIL", ["f1"], digest="a" * 64, evidence=["r1", "r2"]),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
+
+    def test_a_reworded_summary_with_the_same_id_is_the_same_finding(self):
+        outcome = self.repair(
+            [
+                validation_round(
+                    "FAIL", ["f1"], digest="a" * 64, summaries={"f1": "gate fails"}
+                ),
+                validation_round(
+                    "FAIL",
+                    ["f1"],
+                    digest="b" * 64,
+                    summaries={"f1": "the deterministic gate still rejects the tree"},
+                ),
+            ]
+        )
+        self.assertEqual(outcome["rounds_used"], 1)
+        self.assertEqual(outcome["stop_reason"], "not_converged")
+        self.assertEqual([f["id"] for f in outcome["open_findings"]], ["f1"])
+        self.assertEqual(
+            outcome["open_findings"][0]["summary"],
+            "the deterministic gate still rejects the tree",
+        )
+
+    def test_open_findings_are_the_union_of_fresh_and_cross_family_ids(self):
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1", "f2", "f3"], digest="a" * 64),
+                [
+                    validation_round("FAIL", ["f1"], digest="b" * 64, family="fresh"),
+                    validation_round("FAIL", ["f2"], digest="b" * 64, family="codex"),
+                ],
+            ]
+        )
+        self.assertEqual(outcome["rounds_used"], 1)
+        self.assertEqual(sorted(f["id"] for f in outcome["open_findings"]), ["f1", "f2"])
+        self.assertEqual(
+            outcome["report"]["checked"][1], "repair round 1: 2 open findings"
+        )
+
+    def test_a_generated_only_change_that_moves_the_digest_counts_as_a_round(self):
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1"], digest="a" * 64),
+                validation_round("PASS", [], digest="b" * 64),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "converged")
+        self.assertEqual(outcome["rounds_used"], 1)
+        self.assertEqual(
+            outcome["report"]["checked"][:2],
+            ["repair round 0: 1 open findings", "repair round 1: 0 open findings"],
+        )
+
+    def test_open_findings_never_land_in_not_checked(self):
+        outcome = self.repair(
+            [
+                validation_round(
+                    "FAIL",
+                    ["f1"],
+                    digest="a" * 64,
+                    not_checked=["edge case acceptance"],
+                )
+            ],
+            repair_rounds=0,
+        )
+        self.assertEqual(outcome["report"]["not_checked"], ["edge case acceptance"])
+        self.assertEqual([f["id"] for f in outcome["open_findings"]], ["f1"])
+        self.assertNotIn("finding f1", outcome["report"]["not_checked"])
+
+    def test_a_risky_surface_needs_a_second_validator_family_to_converge(self):
+        single = self.repair(
+            [validation_round("PASS", [], family="fresh")], risky_surface=True
+        )
+        self.assertEqual(single["stop_reason"], "diversity_unsatisfied")
+        self.assertEqual(single["report"]["status"], "NOT_PROVEN")
+
+        crossed = self.repair(
+            [
+                [
+                    validation_round("PASS", [], family="fresh"),
+                    validation_round("PASS", [], family="codex"),
+                ]
+            ],
+            risky_surface=True,
+        )
+        self.assertEqual(crossed["stop_reason"], "converged")
+        self.assertEqual(crossed["report"]["status"], "PASS")
+
+    def test_the_report_keeps_the_nine_key_rpi_report_shape(self):
+        outcome = self.repair([validation_round("PASS", [])])
+        self.assertEqual(
+            sorted(outcome["report"]),
+            sorted(
+                [
+                    "schema_version",
+                    "status",
+                    "intent_ref",
+                    "acceptance_digest",
+                    "subject_manifest_digest",
+                    "verdict_ref",
+                    "verdict_digest",
+                    "checked",
+                    "not_checked",
+                ]
+            ),
+        )
+        self.assertEqual(outcome["report"]["schema_version"], "rpi-report.v1")
+
+    def test_the_repair_phase_needs_at_least_one_validation_round(self):
+        with self.assertRaisesRegex(ValueError, "at least one validation round"):
+            self.repair([])
 
 
 class ComposedIdentityContractTests(unittest.TestCase):

--- a/skills-codex/validate/.agentops-generated.json
+++ b/skills-codex/validate/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/validate",
   "layout": "modular",
-  "source_hash": "da24e39ccab4bb4936988ca66329695f5dabd8c1dd618bf91f58e0d62e1b1f63",
-  "generated_hash": "1ed841f5634c1b9d7a21c0970902f0b997ae2104a5891d04761dc4d8af2c204c"
+  "source_hash": "c6b05c98c47ee74f23c1786d10b4f78d1452e440d271b8b3a7287ca4269e41db",
+  "generated_hash": "fbbf0c9053c437287226311177738031ac493b0e5b19153da1a6ea5d5e1014d8"
 }

--- a/skills-codex/validate/.agentops-generated.json
+++ b/skills-codex/validate/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/validate",
   "layout": "modular",
-  "source_hash": "6784d431811b29d9196fe61caf9d220ee91315a8fc9a08b1893990fe0c421250",
-  "generated_hash": "8ceccb3f2183b4dd59a7470edeae93c44393bfe68adefee3f792b4b14b512ec5"
+  "source_hash": "c53bf864ff846bf3b6a4f0b9f2e8869065107a94134e74f315e2f9a33a4cf4ab",
+  "generated_hash": "e7ca06334abab48f2caec64823d534c904454420cbd0e977f20dd64bd6d5acf8"
 }

--- a/skills-codex/validate/.agentops-generated.json
+++ b/skills-codex/validate/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/validate",
   "layout": "modular",
-  "source_hash": "c53bf864ff846bf3b6a4f0b9f2e8869065107a94134e74f315e2f9a33a4cf4ab",
-  "generated_hash": "e7ca06334abab48f2caec64823d534c904454420cbd0e977f20dd64bd6d5acf8"
+  "source_hash": "da24e39ccab4bb4936988ca66329695f5dabd8c1dd618bf91f58e0d62e1b1f63",
+  "generated_hash": "1ed841f5634c1b9d7a21c0970902f0b997ae2104a5891d04761dc4d8af2c204c"
 }

--- a/skills-codex/validate/SKILL.md
+++ b/skills-codex/validate/SKILL.md
@@ -25,16 +25,40 @@ to reconstruct Plan or Candidate packets.
 Missing, colliding, or unattested identities produce `NOT_PROVEN`. This is a
 declared trust fact, not cryptographic proof that contexts were isolated.
 
-## Cross-model fresh validator (caller-elected)
+## Cross-family fresh validator (default on risky surfaces)
 
-A caller may request that the fresh validator run on a different model than
-the author. Dispatch via the controller-session recipe in
-the `agent-native` model-dispatch recipe (`codex-exec` and/or `ntm`,
-probed at runtime). Record author and validator `model_identity` in evidence
-refs and freshness attestation notes — do not change `verdict.v2` schema. If
-the requested validator model has no live adapter, disclose the unsatisfied
-diversity request and proceed same-model; never invoke `claude -p` /
-`claude --print`. Single fresh validator remains the default shape.
+A second fresh validator from a different model family runs by default whenever
+the diff touches a risky surface:
+
+- `cli/internal/gates/**`
+- `scripts/check-*.sh`
+- `tests/**`
+- `skills/*/scripts/**`
+- `skills/cc-hooks/policies/**`
+- `lib/**`
+- anything `security-gate.sh` scans
+
+Outside that list the second validator is caller-elected and a single fresh
+validator remains the default shape.
+
+Dispatch is fixed by the runtime floor: never `claude -p` or `claude --print`,
+directly or indirectly.
+
+| Orchestrating runtime | Cross-family judge leg |
+|---|---|
+| Claude | a read-only `codex exec` judge leg |
+| Codex | a caller-selected interactive Claude session in an NTM pane |
+
+Probe the adapters at runtime through the `agent-native` model-dispatch recipe
+(`codex-exec` and/or `ntm`). The judge leg reads and judges; it never mutates
+the subject. Record author and validator `model_identity` in evidence refs and
+freshness attestation notes; do not change the `verdict.v2` schema.
+
+When no authorized live adapter is available, disclose the unsatisfied
+diversity request as `diversity_unsatisfied`. Off a risky surface that
+disclosure rides along with a same-model result. On a risky surface it is an
+unverified acceptance surface: the result is `NOT_PROVEN`, and same-family
+agreement never counts as convergence.
 
 ## Mutating-check quarantine
 
@@ -141,6 +165,10 @@ python3 "$SKILL_DIR/scripts/validate.py" manifest \
    `verdict_dir`.
 7. Return the semantic result and, when persisted, the artifact path and digest.
    Stop.
+
+Routine rounds keep the bounded, receipt-driven freshness contract below, and
+the repository's full literal CI command set, as quoted in `AGENTS.md`, is
+required once, on the final integrated subject.
 
 The digest is SHA-256 over canonical JSON with `artifact_digest` omitted. Writes
 use a same-directory temporary file, flush, fsync, and atomic rename. Identical

--- a/skills-codex/validate/SKILL.md
+++ b/skills-codex/validate/SKILL.md
@@ -36,7 +36,7 @@ the diff touches a risky surface:
 - `skills/*/scripts/**`
 - `skills/cc-hooks/policies/**`
 - `lib/**`
-- anything `security-gate.sh` scans
+- `.github/workflows/**` and `scripts/security-gate.sh` (the gate scans the whole tree, so "anything it scans" is not a predicate)
 
 Outside that list the second validator is caller-elected and a single fresh
 validator remains the default shape.

--- a/skills-codex/validate/SKILL.md
+++ b/skills-codex/validate/SKILL.md
@@ -56,9 +56,10 @@ freshness attestation notes; do not change the `verdict.v2` schema.
 
 When no authorized live adapter is available, disclose the unsatisfied
 diversity request as `diversity_unsatisfied`. Off a risky surface that
-disclosure rides along with a same-model result. On a risky surface it is an
-unverified acceptance surface: the result is `NOT_PROVEN`, and same-family
-agreement never counts as convergence.
+disclosure rides along with a same-model result. On a risky surface a
+single-family PASS is an unverified acceptance surface: the result is
+`NOT_PROVEN`, and same-family agreement never counts as convergence. A
+single-family FAIL stands as FAIL; a wrong subject needs no second judge.
 
 ## Mutating-check quarantine
 

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -24,7 +24,7 @@
 
 ## meta
 
-`agent-native`, `automation-shape-routing`, `human-only-skills`, `operationalize`, `route`, `rpi`, `scope`, `skill-builder`, `skill-eval`, `toil-mining`, `workflow-builder`
+`agent-native`, `automation-shape-routing`, `crank`, `human-only-skills`, `operationalize`, `route`, `rpi`, `scope`, `skill-builder`, `skill-eval`, `toil-mining`, `workflow-builder`
 
 ## orchestration
 
@@ -56,6 +56,7 @@
 | `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
+| `crank` | meta | `keep` | - | `execute_wave` | `dispatch_rpi_per_lane` |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
 | `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -56,7 +56,7 @@
 | `converter` | cross-vendor | `keep_specialist` | - | `converter` | `write_converted_skill_projection` |
 | `council` | judgment | `keep_strategy` | - | `collect_independent_judgments`, `synthesize_disagreement` | `write_advisory_council_report` |
 | `craft-goal` | judgment | `keep_specialist` | - | `goal_prompt_design`, `goal_prompt_lint` | - |
-| `crank` | meta | `keep` | - | `execute_wave` | `dispatch_rpi_per_lane` |
+| `crank` | meta | `keep` | `rpi` | `execute_wave` | `dispatch_rpi_per_lane` |
 | `dcg` | execution | `keep_specialist` | - | `dcg` | `write_dcg_config` |
 | `doc` | product | `keep_specialist` | - | `doc` | `write_documentation` |
 | `domain` | knowledge | `keep_specialist` | - | `domain` | - |

--- a/skills/agent-native/SKILL.md
+++ b/skills/agent-native/SKILL.md
@@ -29,8 +29,9 @@ output_contract: runtime evidence for explicit packets
 Operate caller-selected agent sessions as explicit roles without turning the
 runtime into AgentOps lifecycle authority.
 
-For caller-elected multi-model judgment (mixed council, dueling perspectives,
-cross-model validate), follow
+For multi-model judgment (mixed council, dueling perspectives, cross-model
+validate, which is default on risky surfaces per ADR-0017 and caller-elected
+otherwise), follow
 [references/model-dispatch.md](references/model-dispatch.md): the working
 session is the controller; probe `codex-exec` and `ntm` at runtime; never
 require either; never use Agent Mail for judgment; never invoke `claude -p`.

--- a/skills/agent-native/references/model-dispatch.md
+++ b/skills/agent-native/references/model-dispatch.md
@@ -4,8 +4,12 @@ Caller-elected multi-model judgment from the session you are already in.
 No mailbox, no queue, no Agent Mail path for judgment. The working session
 is the orchestrator: it starts workers, observes them, and collects artifacts.
 
-This recipe is optional. Absent adapters, consumers stay single-model and
-disclose that fact. Multi-model dispatch never starts unless the caller asks.
+This recipe is optional off risky surfaces. Absent adapters, consumers stay
+single-model and disclose that fact. Multi-model dispatch never starts unless
+the caller asks, with one carve-out (ADR-0017): `validate` runs a cross-family
+leg by default when the diff touches a risky surface (gates, tests, validators,
+hook policies, workflows); absent an authorized adapter that is
+`diversity_unsatisfied`, and a single-family PASS there is `NOT_PROVEN`.
 
 ## Request shape
 
@@ -63,4 +67,4 @@ notes.
 
 - `council` — per-judge model identity beside methodology; cross-model agreement is an extra diversity axis.
 - `idea-genie` (duel) — per-perspective model identity; optional distinct-model pins.
-- `validate` — optional cross-model fresh validator; author and validator model identities in evidence/attestation.
+- `validate` — cross-model fresh validator, default on risky surfaces (ADR-0017), caller-elected otherwise; author and validator model identities in evidence/attestation.

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -505,7 +505,9 @@
           "with": "rpi"
         }
       ],
-      "dependencies": [],
+      "dependencies": [
+        "rpi"
+      ],
       "description": "Execute one caller-selected wave by invoking RPI once per lane and return the wave evidence, then stop. Triggers: \"crank\", \"execute the next wave\", \"run this wave\".",
       "disposition": "keep",
       "effects": [

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1331,7 +1331,7 @@
         "implement",
         "validate"
       ],
-      "description": "Coordinate one RPI traversal: one bounded Plan, Implement, and fresh Validate experiment, then report and stop. Triggers: \"run rpi\", \"run one traversal\", \"execute this plan\", orchestration or worker delegation that implements changes.",
+      "description": "Coordinate one RPI traversal: one bounded Plan and Implement experiment, then fresh Validate and a bounded repair phase to convergence. Triggers: \"run rpi\", \"run one traversal\", \"execute this plan\", orchestration or worker delegation that implements changes.",
       "disposition": "keep",
       "effects": [
         "invoke_anti_ceremony_guard",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "3",
-  "skill_count": 56,
+  "skill_count": 57,
   "skills": [
     {
       "canonical_status": "canonical",
@@ -487,6 +487,43 @@
       ],
       "references_count": 1,
       "tier": "judgment",
+      "user_invocable": true
+    },
+    {
+      "canonical_status": "canonical",
+      "capabilities": [
+        "execute_wave"
+      ],
+      "codex_override_present": true,
+      "consumes": [
+        "rpi",
+        "caller-selected-wave"
+      ],
+      "context_rel": [
+        {
+          "kind": "customer-of",
+          "with": "rpi"
+        }
+      ],
+      "dependencies": [],
+      "description": "Execute one caller-selected wave by invoking RPI once per lane and return the wave evidence, then stop. Triggers: \"crank\", \"execute the next wave\", \"run this wave\".",
+      "disposition": "keep",
+      "effects": [
+        "dispatch_rpi_per_lane"
+      ],
+      "graph_root": true,
+      "hexagonal_role": "domain",
+      "name": "crank",
+      "practices": [
+        "small-batch-flow",
+        "design-by-contract",
+        "team-topologies"
+      ],
+      "produces": [
+        "wave-evidence"
+      ],
+      "references_count": 0,
+      "tier": "meta",
       "user_invocable": true
     },
     {

--- a/skills/craft-goal/SKILL.md
+++ b/skills/craft-goal/SKILL.md
@@ -42,7 +42,7 @@ ratchets toward a larger outcome.
 ```text
 Goal / Mayor: observe graph → choose bounded wave → consume verdicts → ratchet
   └─ Bead: durable experiment intent, context, scratch, evidence, and links
-       └─ RPI: plan → implement → fresh validate → verdict → report and stop
+       └─ RPI: plan → implement → fresh validate → bounded repair → verdict → report
             └─ Implementation: one RED → GREEN → refactor experiment
 ```
 

--- a/skills/crank/SKILL.md
+++ b/skills/crank/SKILL.md
@@ -19,7 +19,7 @@ user-invocable: true
 metadata:
   graph_root: true
   tier: meta
-  dependencies: []
+  dependencies: [rpi]
   capabilities: [execute_wave]
   effects: [dispatch_rpi_per_lane]
   canonical_status: canonical

--- a/skills/crank/SKILL.md
+++ b/skills/crank/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: crank
+description: 'Execute one caller-selected wave by invoking RPI once per lane and return the wave evidence, then stop. Triggers: "crank", "execute the next wave", "run this wave".'
+practices:
+- small-batch-flow
+- design-by-contract
+- team-topologies
+hexagonal_role: domain
+consumes:
+- rpi
+- caller-selected-wave
+produces:
+- wave-evidence
+context_rel:
+- kind: customer-of
+  with: rpi
+skill_api_version: 1
+user-invocable: true
+metadata:
+  graph_root: true
+  tier: meta
+  dependencies: []
+  capabilities: [execute_wave]
+  effects: [dispatch_rpi_per_lane]
+  canonical_status: canonical
+  disposition: keep
+output_contract: 'wave evidence: per-lane status, the open findings each lane''s validator left, each lane''s subject manifest digest, and the wave acceptance result'
+---
+
+# Crank
+
+Crank executes exactly one wave. The caller selects the wave and the repair
+bound; crank runs that wave and returns what happened.
+
+```text
+caller's wave + repair_rounds -> RPI per lane -> wave acceptance once -> evidence -> stop
+```
+
+## Input
+
+The caller supplies all three:
+
+- **The wave** — a list of lanes, each with a write `scope`, a `brief`, and its
+  own executable `acceptance`.
+- **`repair_rounds`** — the caller's repair bound, forwarded unchanged to every
+  lane. Crank neither chooses it nor spends it.
+- **The wave acceptance** — the one command set that judges the wave as a whole.
+
+If a lane arrives without a scope, a brief, or an executable acceptance, report
+the wave as unrunnable and stop. Crank does not shape the missing part itself.
+
+## Contract
+
+1. Read the caller's wave as given. Do not select, extend, drop, or re-rank
+   lanes; the wave arrives already decided.
+2. Partition the lanes. Two lanes may run in parallel only when their write
+   scopes are disjoint **and** their regen surfaces (generated outputs,
+   mirrors, manifests) are disjoint. Any shared surface serializes them;
+   unknown overlap counts as overlap.
+3. Invoke [`rpi`](../rpi/SKILL.md) once per lane with that lane's intent,
+   scope, acceptance, and the caller's `repair_rounds`. Each lane's traversal
+   owns its own repair loop. Crank never repairs a lane itself, never
+   re-invokes a returned lane, and never re-plans one.
+4. Run the wave acceptance once, after every lane has returned. A lane that
+   returned `FAIL` or `NOT_PROVEN` does not suppress it; both results are
+   reported side by side.
+5. Return the wave evidence and stop — per-lane status
+   (`PASS | FAIL | NOT_PROVEN | NOT_PLANNED | NOT_BUILT`), the open findings
+   each lane's validator left keyed by their `findings[].id`, each lane's
+   subject manifest digest, and the wave acceptance result.
+
+Append no next action. The caller reads the evidence and decides whether there
+is another wave.
+
+## Boundary
+
+Crank owns no wave selection, retry, budget, queue, claim, lease, Git, closure,
+delivery, or next work, and it mints no verdict of its own. Every semantic
+result in the wave evidence is the one that lane's fresh validator returned,
+cited unchanged; a green wave acceptance is a fact, not a `PASS`.
+
+## Conveyor
+
+In Claude, [`workflows/implement-wave.js`](../../workflows/implement-wave.js)
+is one conveyor for step 3's parallel leg: it runs disjoint-ownership
+implementers over the lanes the caller supplied. It is transport, never a
+substitute for a lane's own fresh validation, and crank runs without it.
+
+## Prompt
+
+```text
+Crank this wave, repair_rounds=2.
+Lane A - scope cli/internal/gates/**, brief "add the probe-coverage gate row",
+acceptance: cd cli && go test ./internal/gates/...
+Lane B - scope docs/CI-CD.md, brief "document that gate row",
+acceptance: bash scripts/docs-build.sh --check
+Wave acceptance: bash tests/run-all.sh. Report per-lane evidence and stop.
+```
+
+## It's working if
+
+Observable in the trace, without reading the prose — and the rubric a fresh
+independent judge scores this skill against:
+
+- The transcript shows exactly one `rpi` invocation per lane in the caller's
+  wave, and no lane appears twice.
+- Two lanes that share a regen surface (both reaching `skills-codex/`, say) run
+  one after the other, never concurrently.
+- The wave acceptance command runs exactly once, after the last lane returns.
+- The returned evidence carries a status and a subject manifest digest for
+  every caller-supplied lane, and for no lane crank invented.
+- The response ends with the evidence: no next wave, no `git` action, and no
+  proposed follow-up work.

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -128,7 +128,7 @@ never mutate the subject. No third judge, no escalation, no auto-replan.
 
 Risky surfaces default to a cross-family fresh validator: `cli/internal/gates/**`,
 `scripts/check-*.sh`, `tests/**`, `skills/*/scripts/**`,
-`skills/cc-hooks/policies/**`, `lib/**`, anything `security-gate.sh` scans.
+`skills/cc-hooks/policies/**`, `lib/**`, `.github/workflows/**`, `scripts/security-gate.sh`.
 [`validate`](../validate/SKILL.md) owns the dispatch table. No authorized live
 adapter means `diversity_unsatisfied`, which on a risky surface is `NOT_PROVEN`.
 

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rpi
-description: 'Coordinate one RPI traversal: one bounded Plan, Implement, and fresh Validate experiment, then report and stop. Triggers: "run rpi", "run one traversal", "execute this plan", orchestration or worker delegation that implements changes.'
+description: 'Coordinate one RPI traversal: one bounded Plan and Implement experiment, then fresh Validate and a bounded repair phase to convergence. Triggers: "run rpi", "run one traversal", "execute this plan", orchestration or worker delegation that implements changes.'
 practices:
 - bdd-gherkin
 - tdd
@@ -41,17 +41,21 @@ Run one experiment from the caller's existing intent source through three
 responsibilities and stop:
 
 ```text
-anti-ceremony guard -> Plan -> Implement -> fresh Validate -> report
+anti-ceremony guard -> Plan -> Implement -> fresh Validate -> bounded repair -> report
 ```
 
 On `CONTINUE`, the core path remains Plan -> Implement -> fresh Validate ->
-report. RPI invokes the guard exactly once before Plan. It preserves the
-original intent and dispatches each core phase at most once.
-It does not own retries, budgets, queues, claims, leases, Git, delivery, release,
-closure, or the caller's next decision.
+bounded repair -> report. RPI invokes the guard exactly once before Plan. It
+preserves the original intent and dispatches Plan and Implement at most once.
+Validate repeats only inside the repair phase below, under the convergence law
+and the caller's `repair_rounds` bound. RPI does not own retries, budgets,
+queues, claims, leases, Git, delivery, release, closure, or the caller's next
+decision; `repair_rounds` is the caller's declaration, not RPI's budget.
 
 The pure [`scripts/run_once.py`](scripts/run_once.py) reference behavior makes
-the dispatch and stop semantics executable without Git, `ao`, or a tracker.
+the dispatch, repair, and stop semantics executable without Git, `ao`, or a
+tracker: `invoke_once` for the one bounded experiment, `run_repair_phase` for
+the law.
 
 ## Admission and phase lock
 
@@ -89,14 +93,60 @@ authorization by itself.
 4. Invoke Validate once in a context distinct from the author's context. Pass
    the intent reference and digest, exact subject manifest, factual receipts,
    validator identity, and freshness attestation.
-5. Return the fresh validation result and a short report. Persist and link
-   `verdict.v2` only when the caller requests machine-readable evidence or a
-   declared downstream consumer requires it. Stop regardless of `PASS`, `FAIL`,
-   or `NOT_PROVEN`.
+5. Enter the bounded repair phase. On a converged result, report and stop. On
+   `FAIL` or `NOT_PROVEN` with findings, repair the named findings and
+   re-validate freshly while the convergence law admits another round; stop
+   when converged, stopped by the law, or out of `repair_rounds`. Return the
+   current validation result, the open findings, and a short report. Persist
+   and link `verdict.v2` only when the caller requests machine-readable
+   evidence or a declared downstream consumer requires it.
 
 `NOT_PLANNED` and `NOT_BUILT` are report statuses, never semantic verdicts.
 A caller may revise the bead or caller intent and start a new invocation. RPI
 never creates a parallel revision artifact or selects the next work itself.
+
+## The convergence law
+
+A repair round is admitted only while all hold:
+
+1. `rounds_used < repair_rounds` (caller-declared, default 2).
+2. The open finding set, keyed by the validators' stable `findings[].id`
+   (union across the fresh and, when used, cross-family validators), is not
+   larger than the previous round's.
+3. No finding id closed in an earlier round reopens.
+4. Between rounds either the subject-manifest digest changed (generated-only
+   changes count when they change the digest) or, for `NOT_PROVEN`, new
+   digest-bound evidence was supplied that resolves a named gap.
+
+Converged ⇔ the fresh validator returns PASS and, when the diff touches a
+risky surface, the cross-family validator also returns PASS. On any violation
+of 1-4 RPI stops and reports the current status; `checked` carries one line
+per round (`repair round N: k open findings`), the open findings ride in the
+validation result and the interactive report, and `not_checked` keeps its
+meaning. No third judge, no escalation, no auto-replan.
+
+A reworded finding with the same id is the same finding. The fix step belongs
+to the orchestrating context; every judge leg stays non-mutating, so a verdict
+never rewrites the artifact it is judging.
+
+## Cross-family validation
+
+Risky surfaces default to a cross-family fresh validator: `cli/internal/gates/**`,
+`scripts/check-*.sh`, `tests/**`, `skills/*/scripts/**`,
+`skills/cc-hooks/policies/**`, `lib/**`, and anything `security-gate.sh` scans.
+The dispatch table — which direction may run headless and which must route to
+an interactive pane — is owned by [`validate`](../validate/SKILL.md); RPI
+selects when it applies, never how the leg is launched. With no authorized
+live adapter the result is `diversity_unsatisfied`, and on a risky surface that
+stops as `NOT_PROVEN` rather than converging same-family.
+
+## Waves
+
+RPI executes one traversal. A multi-wave intent is executed one wave per
+`crank` invocation: the caller selects the wave and the
+`repair_rounds` bound, crank forwards both and invokes RPI per lane, then
+returns wave evidence and stops. RPI itself never selects a wave, queues the
+next one, or widens the bound it was given.
 
 ## Anti-ceremony boundary
 
@@ -116,11 +166,16 @@ scope, or validation authority.
 
 ## Spiral breaker
 
-The spiral breaker fires when two consecutive control artifacts (plans, audits,
-reviews, prompts, reports) contain no new implementation evidence. Terminate the
-run and report `NOT_BUILT` when no implementation subject exists; when a subject
-exists, stop and report its current status without dispatching another lane or
-repair revision. RPI owns no lane budget, repair budget, or retry policy.
+The spiral breaker fires on a convergence-law violation, or when two
+consecutive rounds produce no change to the subject digest and no new
+digest-bound evidence. It never fires on a verdict count: a `FAIL` or a
+`NOT_PROVEN` that is being repaired under the law is progress, not a spiral,
+and repeated control artifacts (plans, audits, reviews, prompts, reports) with
+no new implementation evidence are the spiral. Terminate the run and report
+`NOT_BUILT` when no implementation subject exists; when a subject exists, stop
+and report its current status without dispatching another lane. RPI owns no
+lane budget and no retry policy, and never extends the caller's
+`repair_rounds`.
 
 ## Delegation boundaries
 
@@ -136,7 +191,8 @@ disjoint regen surfaces may run in parallel.
 
 ## Invariants
 
-- Acceptance and its runtime-derived digest do not change between phases.
+- Acceptance and its runtime-derived digest do not change between phases or
+  between repair rounds; a repair moves the subject, never the acceptance.
 - The anti-ceremony guard runs once before Plan; `STOP` dispatches none of Plan,
   Implement, or Validate, while `CONTINUE` preserves their order.
 - The runtime derives complete changed-path coverage or Validate returns

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -110,43 +110,34 @@ never creates a parallel revision artifact or selects the next work itself.
 A repair round is admitted only while all hold:
 
 1. `rounds_used < repair_rounds` (caller-declared, default 2).
-2. The open finding set, keyed by the validators' stable `findings[].id`
-   (union across the fresh and, when used, cross-family validators), is not
-   larger than the previous round's.
+2. The open finding set, keyed by stable `findings[].id` (union of the fresh
+   and cross-family validators), is not larger than the previous round's.
 3. No finding id closed in an earlier round reopens.
-4. Between rounds either the subject-manifest digest changed (generated-only
-   changes count when they change the digest) or, for `NOT_PROVEN`, new
-   digest-bound evidence was supplied that resolves a named gap.
+4. Between rounds the subject-manifest digest changed (generated-only changes
+   count) or, for `NOT_PROVEN`, new digest-bound evidence resolved a named gap.
 
-Converged ⇔ the fresh validator returns PASS and, when the diff touches a
-risky surface, the cross-family validator also returns PASS. On any violation
-of 1-4 RPI stops and reports the current status; `checked` carries one line
-per round (`repair round N: k open findings`), the open findings ride in the
-validation result and the interactive report, and `not_checked` keeps its
-meaning. No third judge, no escalation, no auto-replan.
-
-A reworded finding with the same id is the same finding. The fix step belongs
-to the orchestrating context; every judge leg stays non-mutating, so a verdict
-never rewrites the artifact it is judging.
+Converged: the fresh validator returns PASS and, on a risky surface, the
+cross-family validator also returns PASS. On any violation of 1-4 RPI stops and
+reports the current status. `checked` carries one line per round
+(`repair round N: k open findings`); open findings ride in the validation
+result and the report; `not_checked` keeps its meaning. A reworded finding with
+the same id is the same finding. The orchestrating context fixes; judge legs
+never mutate the subject. No third judge, no escalation, no auto-replan.
 
 ## Cross-family validation
 
 Risky surfaces default to a cross-family fresh validator: `cli/internal/gates/**`,
 `scripts/check-*.sh`, `tests/**`, `skills/*/scripts/**`,
-`skills/cc-hooks/policies/**`, `lib/**`, and anything `security-gate.sh` scans.
-The dispatch table — which direction may run headless and which must route to
-an interactive pane — is owned by [`validate`](../validate/SKILL.md); RPI
-selects when it applies, never how the leg is launched. With no authorized
-live adapter the result is `diversity_unsatisfied`, and on a risky surface that
-stops as `NOT_PROVEN` rather than converging same-family.
+`skills/cc-hooks/policies/**`, `lib/**`, anything `security-gate.sh` scans.
+[`validate`](../validate/SKILL.md) owns the dispatch table. No authorized live
+adapter means `diversity_unsatisfied`, which on a risky surface is `NOT_PROVEN`.
 
 ## Waves
 
-RPI executes one traversal. A multi-wave intent is executed one wave per
-`crank` invocation: the caller selects the wave and the
-`repair_rounds` bound, crank forwards both and invokes RPI per lane, then
-returns wave evidence and stops. RPI itself never selects a wave, queues the
-next one, or widens the bound it was given.
+RPI executes one traversal. A multi-wave intent runs one wave per `crank`
+invocation: the caller selects the wave and the `repair_rounds` bound, crank
+forwards both, invokes RPI per lane, returns wave evidence, and stops. RPI never
+selects a wave or queues the next one, and never extends the caller's bound.
 
 ## Anti-ceremony boundary
 

--- a/skills/rpi/references/rpi.feature
+++ b/skills/rpi/references/rpi.feature
@@ -14,11 +14,17 @@ Feature: RPI runs one bounded experiment
     Then Plan, Implement, and Validate are not dispatched
     And RPI reports NOT_PLANNED and stops
 
-  @covered-by:skills/rpi/tests/test_run_once.py::test_fail_reports_and_stops_without_another_dispatch
-  Scenario: Validation failure does not loop
-    Given Validate returns FAIL or NOT_PROVEN
-    When RPI reports the verdict
-    Then RPI stops without repair, replan, helper, retry, or delivery
+  @covered-by:skills/rpi/tests/test_run_once.py::test_fail_from_one_experiment_feeds_the_repair_phase
+  Scenario: Validation failure enters the bounded repair phase
+    Given Validate returns FAIL or NOT_PROVEN with findings
+    When the convergence law admits another round
+    Then RPI repairs the named findings and re-validates freshly, without replan, helper, or delivery
+
+  @covered-by:skills/rpi/tests/test_run_once.py::test_repair_stops_when_a_closed_finding_reopens
+  Scenario: The convergence law stops a repair spiral
+    Given a repair round reopens a closed finding id, grows the open set, or changes nothing
+    When RPI evaluates the law
+    Then RPI stops and reports the current status with the open findings
 
   @covered-by:skills/rpi/scripts/validate.sh
   Scenario: Interactive output does not require a machine artifact

--- a/skills/rpi/references/rpi.feature
+++ b/skills/rpi/references/rpi.feature
@@ -1,6 +1,6 @@
 Feature: RPI runs one bounded experiment
   @covered-by:skills/rpi/tests/test_run_once.py::test_anti_ceremony_guard_runs_once_before_plan
-  Scenario: Guard CONTINUE preserves the single-pass core order
+  Scenario: Guard CONTINUE preserves the core phase order
     Given one intent
     When RPI is invoked
     Then the anti-ceremony guard is invoked exactly once before Plan

--- a/skills/rpi/references/rpi.feature
+++ b/skills/rpi/references/rpi.feature
@@ -4,7 +4,7 @@ Feature: RPI runs one bounded experiment
     Given one intent
     When RPI is invoked
     Then the anti-ceremony guard is invoked exactly once before Plan
-    And Plan, Implement, and fresh Validate are each dispatched at most once in that order
+    And Plan and Implement are each dispatched at most once in that order, and fresh Validate repeats only inside the bounded repair phase
     And the final report contains no next action
 
   @covered-by:skills/rpi/tests/test_run_once.py::test_anti_ceremony_stop_dispatches_no_core_phase

--- a/skills/rpi/scripts/run_once.py
+++ b/skills/rpi/scripts/run_once.py
@@ -299,9 +299,29 @@ def normalize_round(value: Any) -> dict[str, Any]:
         family = leg.get("validator_family")
         if isinstance(family, str) and family and family not in families:
             families.append(family)
-        for ref in leg.get("evidence_refs") or []:
-            if ref not in evidence_refs:
-                evidence_refs.append(ref)
+        raw_evidence = leg.get("evidence_refs")
+        if raw_evidence is None:
+            raw_evidence = []
+        if not isinstance(raw_evidence, (list, tuple)):
+            raise ValueError("evidence_refs must be a list")
+        for ref in raw_evidence:
+            # Evidence is either a bare label (unbound; it can never admit an
+            # unchanged digest) or a binding {ref, subject_digest, resolves}.
+            if isinstance(ref, str):
+                entry: dict[str, Any] = {"ref": ref}
+            elif isinstance(ref, Mapping):
+                if not isinstance(ref.get("ref"), str) or not ref["ref"].strip():
+                    raise ValueError("each evidence binding must carry a nonempty ref")
+                entry = dict(ref)
+                resolves = entry.get("resolves")
+                if resolves is not None and not valid_string_list(resolves):
+                    raise ValueError("evidence.resolves must be a list of finding ids")
+                if "subject_digest" in entry and not valid_digest(entry["subject_digest"]):
+                    raise ValueError("evidence.subject_digest must be a valid digest")
+            else:
+                raise ValueError("each evidence ref must be a string or a binding mapping")
+            if entry["ref"] not in {e["ref"] for e in evidence_refs}:
+                evidence_refs.append(entry)
         leg_digest = leg.get("subject_digest", leg.get("subject_manifest_digest"))
         if not valid_digest(leg_digest):
             raise ValueError("each validate leg must carry a valid subject digest")
@@ -341,19 +361,24 @@ def law_violation(
         return "finding_set_grew"
     if current["subject_digest"] != previous["subject_digest"]:
         return None
-    new_evidence = [
-        ref for ref in current["evidence_refs"] if ref not in set(previous["evidence_refs"])
-    ]
+    previous_refs = {e["ref"] for e in previous["evidence_refs"]}
+    resolved = previous["open_ids"] - current["open_ids"]
     # The evidence branch is NOT_PROVEN-only by construction, on both sides: a
     # FAIL says the subject is wrong, and no amount of new evidence over
-    # unchanged bytes repairs a wrong subject. The new evidence must also have
-    # RESOLVED something: at least one previously open finding id is closed.
-    resolved = previous["open_ids"] - current["open_ids"]
+    # unchanged bytes repairs a wrong subject. The new evidence must be BOUND:
+    # it names this exact subject digest and at least one finding id that this
+    # round actually closed. A bare new label admits nothing.
+    binding_evidence = [
+        e
+        for e in current["evidence_refs"]
+        if e["ref"] not in previous_refs
+        and e.get("subject_digest") == current["subject_digest"]
+        and resolved & set(e.get("resolves") or [])
+    ]
     if (
         previous["status"] == "NOT_PROVEN"
         and current["status"] != "FAIL"
-        and new_evidence
-        and resolved
+        and binding_evidence
     ):
         return None
     return "no_subject_or_evidence_change"

--- a/skills/rpi/scripts/run_once.py
+++ b/skills/rpi/scripts/run_once.py
@@ -274,9 +274,9 @@ def normalize_round(value: Any) -> dict[str, Any]:
         leg_status = _leg_status(leg)
         if _STATUS_RANK[leg_status] > _STATUS_RANK[status]:
             status = leg_status
-        raw_findings = leg.get("findings")
-        if raw_findings is None:
-            raw_findings = []
+        if "findings" not in leg:
+            raise ValueError("each validate leg must carry a findings list (empty on PASS)")
+        raw_findings = leg["findings"]
         if not isinstance(raw_findings, (list, tuple)):
             raise ValueError("findings must be a list")
         leg_ids: set[str] = set()
@@ -299,9 +299,9 @@ def normalize_round(value: Any) -> dict[str, Any]:
         family = leg.get("validator_family")
         if isinstance(family, str) and family and family not in families:
             families.append(family)
-        raw_evidence = leg.get("evidence_refs")
-        if raw_evidence is None:
-            raw_evidence = []
+        if "evidence_refs" not in leg:
+            raise ValueError("each validate leg must carry an evidence_refs list (empty if none)")
+        raw_evidence = leg["evidence_refs"]
         if not isinstance(raw_evidence, (list, tuple)):
             raise ValueError("evidence_refs must be a list")
         for ref in raw_evidence:
@@ -328,8 +328,11 @@ def normalize_round(value: Any) -> dict[str, Any]:
         if digest is not None and leg_digest != digest:
             raise ValueError("validate legs disagree about the subject digest")
         digest = leg_digest
-        checked.extend(str(item) for item in leg.get("checked") or [])
-        not_checked.extend(str(item) for item in leg.get("not_checked") or [])
+        for key, sink in (("checked", checked), ("not_checked", not_checked)):
+            items = leg.get(key, [])
+            if not valid_string_list(items):
+                raise ValueError(f"{key} must be a list of strings")
+            sink.extend(items)
 
     return {
         "status": status,

--- a/skills/rpi/scripts/run_once.py
+++ b/skills/rpi/scripts/run_once.py
@@ -274,15 +274,28 @@ def normalize_round(value: Any) -> dict[str, Any]:
         leg_status = _leg_status(leg)
         if _STATUS_RANK[leg_status] > _STATUS_RANK[status]:
             status = leg_status
-        for finding in leg.get("findings") or []:
+        raw_findings = leg.get("findings")
+        if raw_findings is None:
+            raw_findings = []
+        if not isinstance(raw_findings, (list, tuple)):
+            raise ValueError("findings must be a list")
+        leg_ids: set[str] = set()
+        for finding in raw_findings:
             if not isinstance(finding, Mapping):
                 raise ValueError("each finding must be a mapping")
             finding_id = finding.get("id")
             if not isinstance(finding_id, str) or not finding_id.strip():
                 raise ValueError("each finding must carry a stable nonempty id")
+            if finding_id in leg_ids:
+                raise ValueError(f"finding id {finding_id!r} appears twice in one validate leg")
+            leg_ids.add(finding_id)
             # Last leg wins on wording; the id is the identity, so a reworded
             # summary is the same finding and never counts as a new one.
             open_findings[finding_id] = dict(finding)
+        if leg_status == "PASS" and leg_ids:
+            raise ValueError("a PASS leg cannot carry open findings")
+        if leg_status == "FAIL" and not leg_ids:
+            raise ValueError("a FAIL leg must name at least one finding")
         family = leg.get("validator_family")
         if isinstance(family, str) and family and family not in families:
             families.append(family)
@@ -290,10 +303,11 @@ def normalize_round(value: Any) -> dict[str, Any]:
             if ref not in evidence_refs:
                 evidence_refs.append(ref)
         leg_digest = leg.get("subject_digest", leg.get("subject_manifest_digest"))
-        if leg_digest is not None:
-            if digest is not None and leg_digest != digest:
-                raise ValueError("validate legs disagree about the subject digest")
-            digest = leg_digest
+        if not valid_digest(leg_digest):
+            raise ValueError("each validate leg must carry a valid subject digest")
+        if digest is not None and leg_digest != digest:
+            raise ValueError("validate legs disagree about the subject digest")
+        digest = leg_digest
         checked.extend(str(item) for item in leg.get("checked") or [])
         not_checked.extend(str(item) for item in leg.get("not_checked") or [])
 
@@ -330,10 +344,17 @@ def law_violation(
     new_evidence = [
         ref for ref in current["evidence_refs"] if ref not in set(previous["evidence_refs"])
     ]
-    # The evidence branch is NOT_PROVEN-only by construction: a FAIL says the
-    # subject is wrong, and no amount of new evidence over unchanged bytes
-    # repairs a wrong subject.
-    if previous["status"] == "NOT_PROVEN" and new_evidence:
+    # The evidence branch is NOT_PROVEN-only by construction, on both sides: a
+    # FAIL says the subject is wrong, and no amount of new evidence over
+    # unchanged bytes repairs a wrong subject. The new evidence must also have
+    # RESOLVED something: at least one previously open finding id is closed.
+    resolved = previous["open_ids"] - current["open_ids"]
+    if (
+        previous["status"] == "NOT_PROVEN"
+        and current["status"] != "FAIL"
+        and new_evidence
+        and resolved
+    ):
         return None
     return "no_subject_or_evidence_change"
 
@@ -364,8 +385,7 @@ def run_repair_phase(
       round 0 and spends none).
     - ``stop_reason``: one of :data:`STOP_REASONS`.
     """
-    rounds = [normalize_round(entry) for entry in validations]
-    if not rounds:
+    if not validations:
         raise ValueError("the repair phase needs at least one validation round")
     if not isinstance(repair_rounds, int) or isinstance(repair_rounds, bool) or repair_rounds < 0:
         raise ValueError("repair_rounds must be a non-negative integer")
@@ -373,16 +393,19 @@ def run_repair_phase(
     checked: list[str] = []
     closed_ids: set[str] = set()
     rounds_used = 0
-    current = rounds[0]
-    previous = rounds[0]
+    current = normalize_round(validations[0])
+    previous = current
     stop_reason = "not_converged"
+    law_stopped = False
 
-    for index, candidate in enumerate(rounds):
+    for index, raw_candidate in enumerate(validations):
         if index > 0:
-            # Condition 1: the caller's bound, checked before the round counts.
+            # Condition 1: the caller's bound, checked before the round is even
+            # normalized, so a round past the bound is never consumed.
             if rounds_used >= repair_rounds:
                 stop_reason = "repair_budget_exhausted"
                 break
+            candidate = normalize_round(raw_candidate)
             rounds_used += 1
             current = candidate
             checked.append(
@@ -391,10 +414,10 @@ def run_repair_phase(
             violation = law_violation(previous, current, closed_ids)
             if violation is not None:
                 stop_reason = violation
+                law_stopped = True
                 break
             closed_ids |= previous["open_ids"] - current["open_ids"]
         else:
-            current = candidate
             checked.append(f"repair round 0: {len(current['open_ids'])} open findings")
 
         converged, reason = _converged(current, risky_surface)
@@ -408,8 +431,15 @@ def run_repair_phase(
     else:
         stop_reason = "not_converged"
 
+    if stop_reason == "not_converged" and rounds_used >= repair_rounds and current["open_ids"]:
+        # Findings remain and the caller's bound is spent: name it as such.
+        stop_reason = "repair_budget_exhausted"
+
     status = current["status"]
-    if stop_reason == "diversity_unsatisfied":
+    if stop_reason == "diversity_unsatisfied" or (law_stopped and status == "PASS"):
+        # A PASS produced by a law-violating round cannot certify anything: a
+        # PASS over unchanged bytes after a FAIL is a flip, not a proof. A FAIL
+        # that also broke the law stays a FAIL; the subject is still wrong.
         status = "NOT_PROVEN"
 
     return {

--- a/skills/rpi/scripts/run_once.py
+++ b/skills/rpi/scripts/run_once.py
@@ -1,14 +1,21 @@
 #!/usr/bin/env python3
-"""Pure reference behavior for one RPI invocation.
+"""Pure reference behavior for one RPI invocation and its bounded repair phase.
 
 The caller supplies one anti-ceremony guard and the three core phase functions.
-This module invokes the guard once before Plan, dispatches each core phase at
-most once, and never chooses a retry or next action.
+This module invokes the guard once before Plan, dispatches Plan and Implement at
+most once, and never chooses a retry, a budget, or a next action.
+
+Under ADR-0017 (loop as control flow, not knowledge) the traversal no longer
+ends at the first validation result. `run_repair_phase` models the bounded
+repair phase as pure data: it consumes validate rounds that already happened and
+decides, under the convergence law, whether another repair round is admitted.
+It performs no I/O, dispatches nothing, and owns no budget of its own — the
+caller declares `repair_rounds`.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 import re
 from typing import Any
 
@@ -194,3 +201,240 @@ def invoke_once(
         checked=list(validation.get("checked") or []),
         not_checked=list(validation.get("not_checked") or []),
     )
+
+
+# ---------------------------------------------------------------------------
+# The bounded repair phase (ADR-0017)
+# ---------------------------------------------------------------------------
+#
+# The 2026-07-14 cathedral cut removed the iterate loop together with the
+# unproven compounding claim, although ADR-0011 demoted only the latter. What
+# comes back is control flow, not knowledge: a repair round is admitted only
+# while every condition of the convergence law holds, so the loop cannot grind,
+# cannot re-open settled ground, and cannot spin without moving the subject.
+#
+# Condition ordering is deliberate. A reopened id is diagnosed before a grown
+# set, so the operator is told the specific regression rather than the generic
+# symptom; progress is checked last because it is the only condition that can
+# be satisfied by evidence instead of by bytes.
+
+REPAIR_ROUNDS_DEFAULT = 2
+
+#: Terminal reasons `run_repair_phase` may report. `converged` is the only
+#: success; the rest are law stops the caller owns the response to.
+STOP_REASONS = (
+    "converged",
+    "diversity_unsatisfied",
+    "repair_budget_exhausted",
+    "reopened_finding",
+    "finding_set_grew",
+    "no_subject_or_evidence_change",
+    "not_converged",
+)
+
+_STATUS_RANK = {"PASS": 0, "NOT_PROVEN": 1, "FAIL": 2}
+
+
+def _leg_status(leg: Mapping[str, Any]) -> str:
+    """Read a validate leg's semantic verdict under either spelling."""
+    status = leg.get("status", leg.get("verdict"))
+    if status not in _STATUS_RANK:
+        raise ValueError("each validate result must report PASS, FAIL, or NOT_PROVEN")
+    return str(status)
+
+
+def normalize_round(value: Any) -> dict[str, Any]:
+    """Fold one validation round's legs into the facts the law reasons over.
+
+    A round is one or more validate results (the fresh validator, plus the
+    cross-family validator when the diff touches a risky surface). Open findings
+    are the UNION of the legs' stable `findings[].id`; the round's status is the
+    worst leg's; the digest is the subject every leg judged.
+    """
+    legs: list[Mapping[str, Any]]
+    if isinstance(value, Mapping):
+        legs = [value]
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        legs = list(value)
+    else:
+        raise ValueError("a validation round must be a validate result or a list of them")
+    if not legs:
+        raise ValueError("a validation round must contain at least one validate result")
+
+    open_findings: dict[str, dict[str, Any]] = {}
+    families: list[str] = []
+    evidence_refs: list[str] = []
+    checked: list[str] = []
+    not_checked: list[str] = []
+    digest: Any = None
+    status = "PASS"
+    for leg in legs:
+        if not isinstance(leg, Mapping):
+            raise ValueError("each validate result must be a mapping")
+        leg_status = _leg_status(leg)
+        if _STATUS_RANK[leg_status] > _STATUS_RANK[status]:
+            status = leg_status
+        for finding in leg.get("findings") or []:
+            if not isinstance(finding, Mapping):
+                raise ValueError("each finding must be a mapping")
+            finding_id = finding.get("id")
+            if not isinstance(finding_id, str) or not finding_id.strip():
+                raise ValueError("each finding must carry a stable nonempty id")
+            # Last leg wins on wording; the id is the identity, so a reworded
+            # summary is the same finding and never counts as a new one.
+            open_findings[finding_id] = dict(finding)
+        family = leg.get("validator_family")
+        if isinstance(family, str) and family and family not in families:
+            families.append(family)
+        for ref in leg.get("evidence_refs") or []:
+            if ref not in evidence_refs:
+                evidence_refs.append(ref)
+        leg_digest = leg.get("subject_digest", leg.get("subject_manifest_digest"))
+        if leg_digest is not None:
+            if digest is not None and leg_digest != digest:
+                raise ValueError("validate legs disagree about the subject digest")
+            digest = leg_digest
+        checked.extend(str(item) for item in leg.get("checked") or [])
+        not_checked.extend(str(item) for item in leg.get("not_checked") or [])
+
+    return {
+        "status": status,
+        "open_findings": list(open_findings.values()),
+        "open_ids": set(open_findings),
+        "subject_digest": digest,
+        "evidence_refs": evidence_refs,
+        "families": families,
+        "checked": checked,
+        "not_checked": not_checked,
+    }
+
+
+def law_violation(
+    previous: Mapping[str, Any],
+    current: Mapping[str, Any],
+    closed_ids: set[str],
+) -> str | None:
+    """Return the violated convergence-law condition, or None when all hold.
+
+    Condition 1 (the caller's `repair_rounds`) is a precondition on admission
+    and is checked by `run_repair_phase` before a round is consumed; conditions
+    2, 3, and 4 are properties of the round that was produced.
+    """
+    reopened = current["open_ids"] & closed_ids
+    if reopened:
+        return "reopened_finding"
+    if len(current["open_ids"]) > len(previous["open_ids"]):
+        return "finding_set_grew"
+    if current["subject_digest"] != previous["subject_digest"]:
+        return None
+    new_evidence = [
+        ref for ref in current["evidence_refs"] if ref not in set(previous["evidence_refs"])
+    ]
+    # The evidence branch is NOT_PROVEN-only by construction: a FAIL says the
+    # subject is wrong, and no amount of new evidence over unchanged bytes
+    # repairs a wrong subject.
+    if previous["status"] == "NOT_PROVEN" and new_evidence:
+        return None
+    return "no_subject_or_evidence_change"
+
+
+def run_repair_phase(
+    validations: Sequence[Any],
+    *,
+    repair_rounds: int = REPAIR_ROUNDS_DEFAULT,
+    risky_surface: bool = False,
+    intent_ref: str | None = None,
+    acceptance_digest: str | None = None,
+    verdict_ref: str | None = None,
+    verdict_digest: str | None = None,
+) -> dict[str, Any]:
+    """Walk already-produced validation rounds under the convergence law.
+
+    `validations[0]` is the traversal's first fresh validation; every later
+    element is a repair round the orchestrator produced after fixing findings.
+
+    Returns a mapping with:
+
+    - ``report``: the exact nine-key `rpi-report.v1` object. `checked` opens
+      with one `repair round N: k open findings` line per round; open findings
+      never enter `not_checked`, which keeps its meaning (unverified in-scope
+      acceptance).
+    - ``open_findings``: the findings still open at the stop, deduplicated by id.
+    - ``rounds_used``: repair rounds actually spent (the first validation is
+      round 0 and spends none).
+    - ``stop_reason``: one of :data:`STOP_REASONS`.
+    """
+    rounds = [normalize_round(entry) for entry in validations]
+    if not rounds:
+        raise ValueError("the repair phase needs at least one validation round")
+    if not isinstance(repair_rounds, int) or isinstance(repair_rounds, bool) or repair_rounds < 0:
+        raise ValueError("repair_rounds must be a non-negative integer")
+
+    checked: list[str] = []
+    closed_ids: set[str] = set()
+    rounds_used = 0
+    current = rounds[0]
+    previous = rounds[0]
+    stop_reason = "not_converged"
+
+    for index, candidate in enumerate(rounds):
+        if index > 0:
+            # Condition 1: the caller's bound, checked before the round counts.
+            if rounds_used >= repair_rounds:
+                stop_reason = "repair_budget_exhausted"
+                break
+            rounds_used += 1
+            current = candidate
+            checked.append(
+                f"repair round {rounds_used}: {len(current['open_ids'])} open findings"
+            )
+            violation = law_violation(previous, current, closed_ids)
+            if violation is not None:
+                stop_reason = violation
+                break
+            closed_ids |= previous["open_ids"] - current["open_ids"]
+        else:
+            current = candidate
+            checked.append(f"repair round 0: {len(current['open_ids'])} open findings")
+
+        converged, reason = _converged(current, risky_surface)
+        previous = current
+        if converged:
+            stop_reason = "converged"
+            break
+        if reason is not None:
+            stop_reason = reason
+            break
+    else:
+        stop_reason = "not_converged"
+
+    status = current["status"]
+    if stop_reason == "diversity_unsatisfied":
+        status = "NOT_PROVEN"
+
+    return {
+        "report": report(
+            status,
+            intent_ref=intent_ref,
+            acceptance_digest=acceptance_digest,
+            subject_digest=current["subject_digest"],
+            verdict_ref=verdict_ref,
+            verdict_digest=verdict_digest,
+            checked=checked + current["checked"],
+            not_checked=list(current["not_checked"]),
+        ),
+        "open_findings": list(current["open_findings"]),
+        "rounds_used": rounds_used,
+        "stop_reason": stop_reason,
+    }
+
+
+def _converged(current: Mapping[str, Any], risky_surface: bool) -> tuple[bool, str | None]:
+    """Converged ⇔ fresh PASS, plus a cross-family PASS on a risky surface."""
+    if current["status"] != "PASS":
+        return False, None
+    if risky_surface and len(current["families"]) < 2:
+        # No authorized second family judged the risky surface, so same-family
+        # agreement is not independence: NOT_PROVEN, never a convergence.
+        return False, "diversity_unsatisfied"
+    return True, None

--- a/skills/rpi/scripts/validate.sh
+++ b/skills/rpi/scripts/validate.sh
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 skill_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# ADR-0017: RPI is no longer single-pass. Validate repeats inside the bounded
+# repair phase, so this contract asserts the phase lock that survives (Plan and
+# Implement once) plus positive canaries that each condition of the convergence
+# law is present by name.
 grep -q '^name: rpi$' "$skill_dir/SKILL.md"
-grep -Fq 'Plan -> Implement -> fresh Validate -> report' "$skill_dir/SKILL.md"
+grep -Fq 'Plan -> Implement -> fresh Validate -> bounded repair -> report' "$skill_dir/SKILL.md"
 grep -Fq 'dependencies: [anti-ceremony, plan, implement, validate]' "$skill_dir/SKILL.md"
 grep -Fq 'invokes the guard exactly once before Plan' "$skill_dir/SKILL.md"
 grep -Fq '`STOP`, dispatch no core phase' "$skill_dir/SKILL.md"
-grep -Fq 'dispatches each core phase at most once' "$skill_dir/SKILL.md"
+grep -Fq 'dispatches Plan and Implement at most once' "$skill_dir/SKILL.md"
+grep -Fq '## The convergence law' "$skill_dir/SKILL.md"
+grep -Fq 'rounds_used < repair_rounds' "$skill_dir/SKILL.md"
+grep -Fq "larger than the previous round" "$skill_dir/SKILL.md"
+grep -Fq 'No finding id closed in an earlier round reopens.' "$skill_dir/SKILL.md"
+grep -Fq 'the subject-manifest digest changed' "$skill_dir/SKILL.md"
+grep -Fq 'repair round N: k open findings' "$skill_dir/SKILL.md"
+grep -Fq '## Waves' "$skill_dir/SKILL.md"
+grep -Fq '## Cross-family validation' "$skill_dir/SKILL.md"
 grep -Fq 'creates no AgentOps packet' "$skill_dir/SKILL.md"
 grep -Fq 'Plan is closed for that intent' "$skill_dir/SKILL.md"
 grep -Fq 'spiral breaker' "$skill_dir/SKILL.md"

--- a/skills/rpi/tests/test_run_once.py
+++ b/skills/rpi/tests/test_run_once.py
@@ -329,10 +329,41 @@ class RepairPhaseTests(unittest.TestCase):
         outcome = self.repair(
             [
                 validation_round("NOT_PROVEN", ["gap"], digest="a" * 64),
-                validation_round("NOT_PROVEN", ["gap"], digest="a" * 64, evidence=("receipt-2",)),
+                validation_round(
+                    "NOT_PROVEN", ["gap"], digest="a" * 64,
+                    evidence=({"ref": "receipt-2", "subject_digest": "a" * 64, "resolves": ["gap"]},),
+                ),
+            ]
+        )
+        # "resolves" claims gap, but gap is still open: nothing was resolved.
+        self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
+
+    def test_a_bare_new_evidence_label_does_not_admit_an_unchanged_digest(self):
+        outcome = self.repair(
+            [
+                validation_round("NOT_PROVEN", ["gap", "other"], digest="a" * 64),
+                validation_round("NOT_PROVEN", ["other"], digest="a" * 64, evidence=("receipt-2",)),
             ]
         )
         self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
+
+    def test_evidence_bound_to_another_digest_does_not_admit(self):
+        outcome = self.repair(
+            [
+                validation_round("NOT_PROVEN", ["gap", "other"], digest="a" * 64),
+                validation_round(
+                    "NOT_PROVEN", ["other"], digest="a" * 64,
+                    evidence=({"ref": "receipt-2", "subject_digest": "b" * 64, "resolves": ["gap"]},),
+                ),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
+
+    def test_scalar_evidence_refs_are_rejected(self):
+        bad = validation_round("FAIL", ["f1"])
+        bad["evidence_refs"] = "receipt-1"
+        with self.assertRaisesRegex(ValueError, "evidence_refs must be a list"):
+            self.repair([bad])
 
     def test_new_evidence_does_not_admit_a_current_fail_over_unchanged_bytes(self):
         outcome = self.repair(
@@ -439,7 +470,10 @@ class RepairPhaseTests(unittest.TestCase):
                 validation_round(
                     "NOT_PROVEN", ["gap1"], digest="a" * 64, evidence=["r1"]
                 ),
-                validation_round("PASS", [], digest="a" * 64, evidence=["r1", "r2"]),
+                validation_round(
+                    "PASS", [], digest="a" * 64,
+                    evidence=["r1", {"ref": "r2", "subject_digest": "a" * 64, "resolves": ["gap1"]}],
+                ),
             ]
         )
         self.assertEqual(outcome["stop_reason"], "converged")

--- a/skills/rpi/tests/test_run_once.py
+++ b/skills/rpi/tests/test_run_once.py
@@ -309,6 +309,67 @@ class RepairPhaseTests(unittest.TestCase):
         kwargs.setdefault("acceptance_digest", INTENT_DIGEST)
         return MODULE.run_repair_phase(rounds, **kwargs)
 
+    def test_repair_rounds_zero_with_findings_is_budget_exhausted(self):
+        outcome = self.repair([validation_round("FAIL", ["f1"])], repair_rounds=0)
+        self.assertEqual(outcome["stop_reason"], "repair_budget_exhausted")
+        self.assertEqual(outcome["rounds_used"], 0)
+        self.assertEqual(outcome["report"]["status"], "FAIL")
+
+    def test_a_pass_over_unchanged_bytes_after_a_fail_is_a_flip_not_a_proof(self):
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1"], digest="a" * 64),
+                validation_round("PASS", [], digest="a" * 64),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
+        self.assertEqual(outcome["report"]["status"], "NOT_PROVEN")
+
+    def test_new_evidence_must_resolve_a_prior_finding_to_admit_an_unchanged_digest(self):
+        outcome = self.repair(
+            [
+                validation_round("NOT_PROVEN", ["gap"], digest="a" * 64),
+                validation_round("NOT_PROVEN", ["gap"], digest="a" * 64, evidence=("receipt-2",)),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
+
+    def test_new_evidence_does_not_admit_a_current_fail_over_unchanged_bytes(self):
+        outcome = self.repair(
+            [
+                validation_round("NOT_PROVEN", ["gap", "bug"], digest="a" * 64),
+                validation_round("FAIL", ["bug"], digest="a" * 64, evidence=("receipt-2",)),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
+        self.assertEqual(outcome["report"]["status"], "FAIL")
+
+    def test_malformed_rounds_are_rejected_not_swallowed(self):
+        cases = {
+            "pass with findings": validation_round("PASS", ["f1"]),
+            "fail without findings": validation_round("FAIL", []),
+            "missing digest": validation_round("FAIL", ["f1"], digest=None),
+        }
+        for name, bad in cases.items():
+            with self.subTest(case=name):
+                with self.assertRaises(ValueError):
+                    self.repair([bad])
+        duplicate = validation_round("FAIL", ["f1"])
+        duplicate["findings"].append({"id": "f1", "summary": "again"})
+        with self.assertRaisesRegex(ValueError, "twice"):
+            self.repair([duplicate])
+
+    def test_rounds_past_the_bound_are_never_normalized(self):
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1"], digest="a" * 64),
+                validation_round("FAIL", ["f1"], digest="b" * 64),
+                {"status": "garbage-that-would-raise"},
+            ],
+            repair_rounds=1,
+        )
+        self.assertEqual(outcome["stop_reason"], "repair_budget_exhausted")
+
     def test_a_first_round_pass_converges_without_spending_a_repair_round(self):
         outcome = self.repair([validation_round("PASS", [])])
         self.assertEqual(outcome["stop_reason"], "converged")

--- a/skills/rpi/tests/test_run_once.py
+++ b/skills/rpi/tests/test_run_once.py
@@ -359,6 +359,18 @@ class RepairPhaseTests(unittest.TestCase):
         )
         self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
 
+    def test_missing_findings_or_evidence_keys_are_rejected(self):
+        for key in ("findings", "evidence_refs"):
+            with self.subTest(missing=key):
+                bad = validation_round("PASS", [])
+                del bad[key]
+                with self.assertRaisesRegex(ValueError, key):
+                    self.repair([bad])
+        bad = validation_round("PASS", [])
+        bad["checked"] = "acceptance"
+        with self.assertRaisesRegex(ValueError, "checked must be a list"):
+            self.repair([bad])
+
     def test_scalar_evidence_refs_are_rejected(self):
         bad = validation_round("FAIL", ["f1"])
         bad["evidence_refs"] = "receipt-1"

--- a/skills/rpi/tests/test_run_once.py
+++ b/skills/rpi/tests/test_run_once.py
@@ -30,6 +30,33 @@ VALIDATE_SPEC.loader.exec_module(VALIDATE)
 INTENT_DIGEST = "c" * 64
 
 
+def validation_round(
+    status,
+    finding_ids,
+    *,
+    digest="a" * 64,
+    evidence=(),
+    family="fresh",
+    summaries=None,
+    checked=("acceptance",),
+    not_checked=(),
+):
+    """One validate leg's result, as the repair phase consumes it (pure data)."""
+    summaries = summaries or {}
+    return {
+        "status": status,
+        "findings": [
+            {"id": fid, "summary": summaries.get(fid, f"finding {fid}")}
+            for fid in finding_ids
+        ],
+        "subject_digest": digest,
+        "evidence_refs": list(evidence),
+        "validator_family": family,
+        "checked": list(checked),
+        "not_checked": list(not_checked),
+    }
+
+
 def continue_guard(intent):
     return {
         "decision": "CONTINUE",
@@ -146,11 +173,30 @@ class RunOnceTests(unittest.TestCase):
         self.assertEqual(result["acceptance_digest"], INTENT_DIGEST)
         self.assertNotIn("next_action", result)
 
-    def test_fail_reports_and_stops_without_another_dispatch(self):
+    def test_fail_from_one_experiment_feeds_the_repair_phase(self):
+        """Replaces the old stop-on-FAIL test (ADR-0017).
+
+        One experiment still dispatches Plan and Implement exactly once, and the
+        FAIL it produces is no longer terminal by itself: it is the first round
+        handed to the bounded repair phase, which owns the stop decision.
+        """
         calls, plan, implement, validate = self.phases("FAIL")
         result = MODULE.invoke_once("intent", continue_guard, plan, implement, validate)
         self.assertEqual(calls, ["plan", "implement", "validate"])
         self.assertEqual(result["status"], "FAIL")
+
+        outcome = MODULE.run_repair_phase(
+            [
+                validation_round("FAIL", ["f1"], digest="a" * 64),
+                validation_round("PASS", [], digest="d" * 64),
+            ],
+            repair_rounds=2,
+            intent_ref=result["intent_ref"],
+            acceptance_digest=result["acceptance_digest"],
+        )
+        self.assertEqual(outcome["stop_reason"], "converged")
+        self.assertEqual(outcome["report"]["status"], "PASS")
+        self.assertEqual(outcome["rounds_used"], 1)
 
     def test_fresh_validation_does_not_require_persisted_verdict(self):
         calls, plan, implement, validate = self.phases()
@@ -247,6 +293,223 @@ class RunOnceTests(unittest.TestCase):
 
                 with self.assertRaisesRegex(ValueError, "acceptance_digest"):
                     MODULE.invoke_once("intent", continue_guard, undeclared, implement, validate)
+
+
+class RepairPhaseTests(unittest.TestCase):
+    """The bounded repair phase and its convergence law (ADR-0017).
+
+    RPI is no longer single-pass: a `FAIL` or `NOT_PROVEN` with findings may be
+    repaired and re-validated while all four law conditions hold. The loop is
+    modelled here as pure data — a sequence of already-produced validate rounds
+    — so the stop semantics are executable without Git, `ao`, or a tracker.
+    """
+
+    def repair(self, rounds, **kwargs):
+        kwargs.setdefault("intent_ref", "bead:agentops-test")
+        kwargs.setdefault("acceptance_digest", INTENT_DIGEST)
+        return MODULE.run_repair_phase(rounds, **kwargs)
+
+    def test_a_first_round_pass_converges_without_spending_a_repair_round(self):
+        outcome = self.repair([validation_round("PASS", [])])
+        self.assertEqual(outcome["stop_reason"], "converged")
+        self.assertEqual(outcome["report"]["status"], "PASS")
+        self.assertEqual(outcome["rounds_used"], 0)
+        self.assertEqual(outcome["open_findings"], [])
+        self.assertEqual(
+            outcome["report"]["checked"][0], "repair round 0: 0 open findings"
+        )
+
+    def test_repair_stops_at_the_declared_repair_rounds_budget(self):
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1"], digest="a" * 64),
+                validation_round("FAIL", ["f1"], digest="b" * 64),
+                validation_round("FAIL", ["f1"], digest="c" * 64),
+            ],
+            repair_rounds=1,
+        )
+        self.assertEqual(outcome["stop_reason"], "repair_budget_exhausted")
+        self.assertEqual(outcome["rounds_used"], 1)
+        self.assertEqual(outcome["report"]["status"], "FAIL")
+        self.assertEqual(
+            outcome["report"]["checked"][:2],
+            ["repair round 0: 1 open findings", "repair round 1: 1 open findings"],
+        )
+
+    def test_repair_stops_when_the_open_finding_set_grows(self):
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1"], digest="a" * 64),
+                validation_round("FAIL", ["f1", "f2"], digest="b" * 64),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "finding_set_grew")
+        self.assertEqual(outcome["report"]["status"], "FAIL")
+        self.assertEqual(outcome["rounds_used"], 1)
+        self.assertEqual(
+            sorted(f["id"] for f in outcome["open_findings"]), ["f1", "f2"]
+        )
+
+    def test_repair_stops_when_a_closed_finding_reopens(self):
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1", "f2"], digest="a" * 64),
+                validation_round("FAIL", ["f1"], digest="b" * 64),
+                validation_round("FAIL", ["f2"], digest="c" * 64),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "reopened_finding")
+        self.assertEqual(outcome["rounds_used"], 2)
+        self.assertEqual(outcome["report"]["status"], "FAIL")
+
+    def test_repair_stops_when_the_digest_is_unchanged_and_no_new_evidence(self):
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1"], digest="a" * 64, evidence=["r1"]),
+                validation_round("FAIL", ["f1"], digest="a" * 64, evidence=["r1"]),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
+        self.assertEqual(outcome["rounds_used"], 1)
+
+    def test_not_proven_is_resolved_by_new_evidence_with_an_unchanged_digest(self):
+        outcome = self.repair(
+            [
+                validation_round(
+                    "NOT_PROVEN", ["gap1"], digest="a" * 64, evidence=["r1"]
+                ),
+                validation_round("PASS", [], digest="a" * 64, evidence=["r1", "r2"]),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "converged")
+        self.assertEqual(outcome["report"]["status"], "PASS")
+        self.assertEqual(outcome["rounds_used"], 1)
+        self.assertEqual(outcome["report"]["subject_manifest_digest"], "a" * 64)
+
+    def test_new_evidence_does_not_rescue_a_fail_round(self):
+        """Condition 4's evidence branch is NOT_PROVEN-only.
+
+        A FAIL means the subject is wrong, so only a moved subject digest is
+        progress; extra evidence over the same bytes is not.
+        """
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1"], digest="a" * 64, evidence=["r1"]),
+                validation_round("FAIL", ["f1"], digest="a" * 64, evidence=["r1", "r2"]),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "no_subject_or_evidence_change")
+
+    def test_a_reworded_summary_with_the_same_id_is_the_same_finding(self):
+        outcome = self.repair(
+            [
+                validation_round(
+                    "FAIL", ["f1"], digest="a" * 64, summaries={"f1": "gate fails"}
+                ),
+                validation_round(
+                    "FAIL",
+                    ["f1"],
+                    digest="b" * 64,
+                    summaries={"f1": "the deterministic gate still rejects the tree"},
+                ),
+            ]
+        )
+        self.assertEqual(outcome["rounds_used"], 1)
+        self.assertEqual(outcome["stop_reason"], "not_converged")
+        self.assertEqual([f["id"] for f in outcome["open_findings"]], ["f1"])
+        self.assertEqual(
+            outcome["open_findings"][0]["summary"],
+            "the deterministic gate still rejects the tree",
+        )
+
+    def test_open_findings_are_the_union_of_fresh_and_cross_family_ids(self):
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1", "f2", "f3"], digest="a" * 64),
+                [
+                    validation_round("FAIL", ["f1"], digest="b" * 64, family="fresh"),
+                    validation_round("FAIL", ["f2"], digest="b" * 64, family="codex"),
+                ],
+            ]
+        )
+        self.assertEqual(outcome["rounds_used"], 1)
+        self.assertEqual(sorted(f["id"] for f in outcome["open_findings"]), ["f1", "f2"])
+        self.assertEqual(
+            outcome["report"]["checked"][1], "repair round 1: 2 open findings"
+        )
+
+    def test_a_generated_only_change_that_moves_the_digest_counts_as_a_round(self):
+        outcome = self.repair(
+            [
+                validation_round("FAIL", ["f1"], digest="a" * 64),
+                validation_round("PASS", [], digest="b" * 64),
+            ]
+        )
+        self.assertEqual(outcome["stop_reason"], "converged")
+        self.assertEqual(outcome["rounds_used"], 1)
+        self.assertEqual(
+            outcome["report"]["checked"][:2],
+            ["repair round 0: 1 open findings", "repair round 1: 0 open findings"],
+        )
+
+    def test_open_findings_never_land_in_not_checked(self):
+        outcome = self.repair(
+            [
+                validation_round(
+                    "FAIL",
+                    ["f1"],
+                    digest="a" * 64,
+                    not_checked=["edge case acceptance"],
+                )
+            ],
+            repair_rounds=0,
+        )
+        self.assertEqual(outcome["report"]["not_checked"], ["edge case acceptance"])
+        self.assertEqual([f["id"] for f in outcome["open_findings"]], ["f1"])
+        self.assertNotIn("finding f1", outcome["report"]["not_checked"])
+
+    def test_a_risky_surface_needs_a_second_validator_family_to_converge(self):
+        single = self.repair(
+            [validation_round("PASS", [], family="fresh")], risky_surface=True
+        )
+        self.assertEqual(single["stop_reason"], "diversity_unsatisfied")
+        self.assertEqual(single["report"]["status"], "NOT_PROVEN")
+
+        crossed = self.repair(
+            [
+                [
+                    validation_round("PASS", [], family="fresh"),
+                    validation_round("PASS", [], family="codex"),
+                ]
+            ],
+            risky_surface=True,
+        )
+        self.assertEqual(crossed["stop_reason"], "converged")
+        self.assertEqual(crossed["report"]["status"], "PASS")
+
+    def test_the_report_keeps_the_nine_key_rpi_report_shape(self):
+        outcome = self.repair([validation_round("PASS", [])])
+        self.assertEqual(
+            sorted(outcome["report"]),
+            sorted(
+                [
+                    "schema_version",
+                    "status",
+                    "intent_ref",
+                    "acceptance_digest",
+                    "subject_manifest_digest",
+                    "verdict_ref",
+                    "verdict_digest",
+                    "checked",
+                    "not_checked",
+                ]
+            ),
+        )
+        self.assertEqual(outcome["report"]["schema_version"], "rpi-report.v1")
+
+    def test_the_repair_phase_needs_at_least_one_validation_round(self):
+        with self.assertRaisesRegex(ValueError, "at least one validation round"):
+            self.repair([])
 
 
 class ComposedIdentityContractTests(unittest.TestCase):

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -84,9 +84,10 @@ freshness attestation notes; do not change the `verdict.v2` schema.
 
 When no authorized live adapter is available, disclose the unsatisfied
 diversity request as `diversity_unsatisfied`. Off a risky surface that
-disclosure rides along with a same-model result. On a risky surface it is an
-unverified acceptance surface: the result is `NOT_PROVEN`, and same-family
-agreement never counts as convergence.
+disclosure rides along with a same-model result. On a risky surface a
+single-family PASS is an unverified acceptance surface: the result is
+`NOT_PROVEN`, and same-family agreement never counts as convergence. A
+single-family FAIL stands as FAIL; a wrong subject needs no second judge.
 
 ## Mutating-check quarantine
 

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -64,7 +64,7 @@ the diff touches a risky surface:
 - `skills/*/scripts/**`
 - `skills/cc-hooks/policies/**`
 - `lib/**`
-- anything `security-gate.sh` scans
+- `.github/workflows/**` and `scripts/security-gate.sh` (the gate scans the whole tree, so "anything it scans" is not a predicate)
 
 Outside that list the second validator is caller-elected and a single fresh
 validator remains the default shape.

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -53,16 +53,40 @@ to reconstruct Plan or Candidate packets.
 Missing, colliding, or unattested identities produce `NOT_PROVEN`. This is a
 declared trust fact, not cryptographic proof that contexts were isolated.
 
-## Cross-model fresh validator (caller-elected)
+## Cross-family fresh validator (default on risky surfaces)
 
-A caller may request that the fresh validator run on a different model than
-the author. Dispatch via the controller-session recipe in
-the `agent-native` model-dispatch recipe (`codex-exec` and/or `ntm`,
-probed at runtime). Record author and validator `model_identity` in evidence
-refs and freshness attestation notes — do not change `verdict.v2` schema. If
-the requested validator model has no live adapter, disclose the unsatisfied
-diversity request and proceed same-model; never invoke `claude -p` /
-`claude --print`. Single fresh validator remains the default shape.
+A second fresh validator from a different model family runs by default whenever
+the diff touches a risky surface:
+
+- `cli/internal/gates/**`
+- `scripts/check-*.sh`
+- `tests/**`
+- `skills/*/scripts/**`
+- `skills/cc-hooks/policies/**`
+- `lib/**`
+- anything `security-gate.sh` scans
+
+Outside that list the second validator is caller-elected and a single fresh
+validator remains the default shape.
+
+Dispatch is fixed by the runtime floor: never `claude -p` or `claude --print`,
+directly or indirectly.
+
+| Orchestrating runtime | Cross-family judge leg |
+|---|---|
+| Claude | a read-only `codex exec` judge leg |
+| Codex | a caller-selected interactive Claude session in an NTM pane |
+
+Probe the adapters at runtime through the `agent-native` model-dispatch recipe
+(`codex-exec` and/or `ntm`). The judge leg reads and judges; it never mutates
+the subject. Record author and validator `model_identity` in evidence refs and
+freshness attestation notes; do not change the `verdict.v2` schema.
+
+When no authorized live adapter is available, disclose the unsatisfied
+diversity request as `diversity_unsatisfied`. Off a risky surface that
+disclosure rides along with a same-model result. On a risky surface it is an
+unverified acceptance surface: the result is `NOT_PROVEN`, and same-family
+agreement never counts as convergence.
 
 ## Mutating-check quarantine
 
@@ -169,6 +193,10 @@ python3 "$SKILL_DIR/scripts/validate.py" manifest \
    `verdict_dir`.
 7. Return the semantic result and, when persisted, the artifact path and digest.
    Stop.
+
+Routine rounds keep the bounded, receipt-driven freshness contract below, and
+the repository's full literal CI command set, as quoted in `AGENTS.md`, is
+required once, on the final integrated subject.
 
 The digest is SHA-256 over canonical JSON with `artifact_digest` omitted. Writes
 use a same-directory temporary file, flush, fsync, and atomic rename. Identical

--- a/tests/explicit-skill-requests/prompts/crank.txt
+++ b/tests/explicit-skill-requests/prompts/crank.txt
@@ -1,1 +1,1 @@
-Use /crank to execute this epic autonomously
+Use /crank to execute the one wave I selected and report per-lane evidence

--- a/tests/scripts/agentops-product-boundary.bats
+++ b/tests/scripts/agentops-product-boundary.bats
@@ -61,7 +61,7 @@ PY
   done
 
   require_text AGENTS.md \
-    "RPI -> Plan -> Implement -> fresh Validate -> report and stop"
+    "RPI -> Plan -> Implement -> fresh Validate -> repair to convergence -> report"
   require_text AGENTS.md \
     "Persist \`verdict.v2\` only when"
   require_text PRODUCT.md \

--- a/tests/scripts/agents-operating-contract.bats
+++ b/tests/scripts/agents-operating-contract.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-@test "root contract routes the single-pass product boundary" {
+@test "root contract routes the RPI product boundary" {
   repo_root="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
   contract="$repo_root/AGENTS.md"
   [ -f "$contract" ]
@@ -9,7 +9,7 @@
     "operations layer for agentic engineering" \
     "federated integration graph" \
     "Standard RPI traversal" \
-    "RPI -> Plan -> Implement -> fresh Validate -> report and stop" \
+    "RPI -> Plan -> Implement -> fresh Validate -> repair to convergence -> report" \
     "Persist \`verdict.v2\` only when" \
     "It owns no retry" \
     "fresh independent judgment" \

--- a/tests/scripts/check-routing-probe-goldens.bats
+++ b/tests/scripts/check-routing-probe-goldens.bats
@@ -275,7 +275,7 @@ print(value)
     run --separate-stderr bash "$REPO_ROOT/scripts/check-routing-probe-goldens.sh" --json
 
     [ "$status" -eq 0 ]
-    [ "$(json_field "$output" total)" = "6" ]
+    [ "$(json_field "$output" total)" = "7" ]
     [ "$(json_field "$output" failed)" = "0" ]
-    [ "$(json_field "$output" passed)" = "6" ]
+    [ "$(json_field "$output" passed)" = "7" ]
 }

--- a/tests/scripts/codex-portable-conformance.bats
+++ b/tests/scripts/codex-portable-conformance.bats
@@ -14,7 +14,7 @@ write_skill() {
 @test "checked-in Codex release projection is portable" {
   run bash "$GATE"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"PASS [portable] 56 package(s)"* ]]
+  [[ "$output" == *"PASS [portable] 57 package(s)"* ]]
 }
 
 @test "portable gate accepts the minimal Agent Skills package" {

--- a/tests/scripts/legible-l1-codex-descriptions.bats
+++ b/tests/scripts/legible-l1-codex-descriptions.bats
@@ -165,7 +165,7 @@ PYCHECK
     }
 
     expect validate 'Freshly judge a finished change against its acceptance: PASS, FAIL, or NOT_PROVEN. Triggers: "validate", "is this proven".'
-    expect rpi 'Coordinate one RPI traversal: one bounded Plan, Implement, and fresh Validate experiment, then report and stop. Triggers: "run rpi", "run one traversal", "execute this plan", orchestration or worker delegation that implements changes.'
+    expect rpi 'Coordinate one RPI traversal: one bounded Plan and Implement experiment, then fresh Validate and a bounded repair phase to convergence. Triggers: "run rpi", "run one traversal", "execute this plan", orchestration or worker delegation that implements changes.'
     expect plan 'Shape or refine the existing bead or caller intent without a second planning artifact. Triggers: "plan", "discover and plan", "shape this goal".'
     expect council 'Collect independent perspectives for an explicitly high-stakes or contested judgment. Triggers: "council", "multi-judge review", "independent perspectives".'
     expect domain 'Load the AgentOps language and bounded-context contracts when a term needs precise meaning. Triggers: "define this domain term", "check the bounded context".'

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -125,8 +125,12 @@ identity, acceptance, write scope, changed paths, check receipts, and author
 context id — never the implementer's narrative. Any dead stage degrades the
 result to `NOT_PROVEN` with an `error` naming the stage.
 
-Doctrine: one pass, no retry loop, no revision path, no lifecycle ownership —
-the authoring context structurally cannot issue its own binding PASS.
+Doctrine (ADR-0017): Plan and Implement once; Validate freshly; on FAIL or
+NOT_PROVEN with findings a bounded repair phase repairs and re-validates under
+the convergence law within the caller's `repairRounds` (default 2), and stops
+when converged, stopped by the law, or out of rounds. No revision path beyond
+that, no lifecycle ownership, and the authoring context structurally cannot
+issue its own binding PASS.
 
 Cross-vendor validation: with `validator: { kind: 'command', command: '<judge>' }`
 the spawned fresh Validate context becomes a broker for an external judge — it

--- a/workflows/rpi.js
+++ b/workflows/rpi.js
@@ -57,11 +57,12 @@ const IMPLEMENT_SCHEMA = {
 const VALIDATE_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['verdict', 'verdictPath', 'criteria', 'validatorContextId', 'subjectDigest', 'findings'],
+  required: ['verdict', 'verdictPath', 'criteria', 'validatorContextId', 'subjectDigest', 'findings', 'evidenceRefs'],
   properties: {
     verdict: { enum: ['PASS', 'FAIL', 'NOT_PROVEN'] },
     verdictPath: { type: 'string' },
     subjectDigest: { type: 'string' },
+    evidenceRefs: { type: 'array', items: { type: 'string' } },
     findings: {
       type: 'array',
       items: {
@@ -99,7 +100,8 @@ function badArgs(detail) {
   throw new Error(
     'rpi: bad args (' + detail + '). Expected ' +
       '{ intent: string, root?: string, writeScope?: [string, ...], acceptance?: string, ' +
-      "repairRounds?: integer >= 0, validator?: { kind: 'spawned' | 'command', command?: string } }"
+      "repairRounds?: integer >= 0, validator?: { kind: 'spawned' | 'command', command?: string }, " +
+      "crossFamily?: { command: string } }"
   );
 }
 
@@ -130,6 +132,23 @@ if (
   badArgs('repairRounds must be a non-negative integer when given');
 }
 const repairRounds = input.repairRounds === undefined ? 2 : input.repairRounds;
+// CONTRACT (ADR-0017): on a risky surface validation is cross-family by default.
+// The second leg is an external judge command from ANOTHER model family (LAW 0:
+// a headless Claude leg is never legal, so from a Claude session this is a
+// read-only `codex exec` command). Absent or same as the primary judge means
+// diversity_unsatisfied, and a risky-surface PASS then degrades to NOT_PROVEN.
+if (input.crossFamily !== undefined) {
+  const cf = input.crossFamily;
+  if (typeof cf !== 'object' || cf === null || Array.isArray(cf) || typeof cf.command !== 'string' || !cf.command.trim()) {
+    badArgs('crossFamily must be { command: non-empty string } when given');
+  }
+}
+const crossFamilyCommand = input.crossFamily !== undefined ? input.crossFamily.command.trim() : null;
+const RISKY_SURFACE = [
+  /^cli\/internal\/gates\//, /^scripts\/check-[^/]*\.sh$/, /^tests\//, /^skills\/[^/]+\/scripts\//,
+  /^skills\/cc-hooks\/policies\//, /^lib\//, /^\.github\/workflows\//, /^scripts\/security-gate\.sh$/,
+];
+const isRiskySurface = (paths) => paths.some((p) => RISKY_SURFACE.some((re) => re.test(p)));
 // CONTRACT: validator selects who judges — the default spawned fresh context,
 // or an external judge command brokered by that fresh context. The command is
 // opaque caller input; invalid shapes die here, never as a runtime surprise.
@@ -279,12 +298,11 @@ const FINDINGS_BLOCK =
   '\n- Return subjectDigest: the manifest digest you computed over the changed paths.\n' +
   '- Return findings: one entry {id, summary} per open defect that blocks PASS (empty on PASS). Ids are ' +
   'STABLE keys of the form <criterion-slug>:<defect-slug> so the same defect keeps its id across rounds ' +
-  'however you reword the summary; never mint a new id for a defect you already named.';
+  'however you reword the summary; never mint a new id for a defect you already named.\n' +
+  '- Return evidenceRefs: the paths of the receipts, transcripts, or verdict files your judgment relied on.';
 
-async function validateOnce(facts) {
-let validation;
-if (externalJudge === null) {
-validation = await agent(
+async function spawnedLeg(facts) {
+  return await agent(
   'You are a fresh, independent Validate context. You did not author the candidate and you have not seen ' +
     'the author\'s reasoning — only the facts below. Judge the exact content; the author\'s claims do not exist ' +
     'for you.\n\n' +
@@ -323,19 +341,16 @@ validation = await agent(
     'evidence of a criteria entry.' + FINDINGS_BLOCK,
   { label: 'validate', phase: 'Validate', schema: VALIDATE_SCHEMA, effort: 'high' }
 );
-} else {
-// CONTRACT (external judge mode): the fresh context is a BROKER, not the
-// judge. Load-bearing honesty rules: no verdict laundering (the persisted
-// verdict is exactly the external ruling; ambiguity degrades to NOT_PROVEN),
-// no silent fallback (a dead command is NOT_PROVEN, never re-judged in-run),
-// and the broker attests under its own id, distinct from author and judge.
-validation = await agent(
+}
+
+async function brokerLeg(facts, command) {
+  return await agent(
   'You are a fresh, independent Validate context acting as the BROKER for an external judge. You did not ' +
     'author the candidate and you have not seen the author\'s reasoning — only the facts below. You do NOT ' +
     'judge the acceptance yourself: the external judge command below rules, and you transcribe its ruling ' +
     'faithfully.\n\n' +
     'External judge command (opaque caller input — assume nothing about which tool it is):\n' +
-    '  ' + externalJudge + '\n\n' +
+    '  ' + command + '\n\n' +
     'Evidence packet for the judge (these facts and NOTHING more may reach it — the freshness wall is ' +
     'unchanged):\n' +
     '- intentDigest: ' + plan.intentDigest + '\n' +
@@ -379,7 +394,66 @@ validation = await agent(
   { label: 'validate', phase: 'Validate', schema: VALIDATE_SCHEMA, effort: 'high' }
 );
 }
-return validation;
+
+// Worst-of ordering for merged legs: a FAIL anywhere is a FAIL; a NOT_PROVEN
+// anywhere without a FAIL is NOT_PROVEN; PASS needs every leg to PASS.
+const VERDICT_RANK = { PASS: 0, NOT_PROVEN: 1, FAIL: 2 };
+function mergeLegs(legs, risky, diversity) {
+  let verdict = 'PASS';
+  const findings = new Map();
+  const evidence = new Set();
+  const criteria = [];
+  let digest = null;
+  let digestConflict = false;
+  for (const leg of legs) {
+    const r = leg.result;
+    if (VERDICT_RANK[r.verdict] > VERDICT_RANK[verdict]) verdict = r.verdict;
+    for (const f of r.findings || []) findings.set(f.id, { id: f.id, summary: f.summary, family: leg.family });
+    for (const e of r.evidenceRefs || []) evidence.add(e);
+    for (const c of r.criteria || []) criteria.push(c);
+    if (digest === null) digest = r.subjectDigest;
+    else if (r.subjectDigest !== digest) digestConflict = true;
+  }
+  if (digestConflict) {
+    verdict = 'NOT_PROVEN';
+    findings.set('identity:digest-disagreement', { id: 'identity:digest-disagreement', summary: 'validator legs computed different subject digests', family: 'merge' });
+  }
+  if (verdict === 'PASS' && findings.size > 0) {
+    // A PASS that names open defects is malformed; it cannot certify.
+    verdict = 'NOT_PROVEN';
+  }
+  if (risky && diversity !== 'satisfied' && verdict === 'PASS') {
+    verdict = 'NOT_PROVEN';
+    findings.set('diversity:unsatisfied', { id: 'diversity:unsatisfied', summary: 'risky surface judged by one model family only; no authorized cross-family leg', family: 'merge' });
+  }
+  return {
+    verdict,
+    verdictPath: legs[0].result.verdictPath,
+    validatorContextId: legs.map((l) => l.result.validatorContextId).join('+'),
+    subjectDigest: digest,
+    findings: [...findings.values()],
+    evidenceRefs: [...evidence],
+    criteria,
+    families: legs.map((l) => l.family),
+    risky,
+    diversity,
+  };
+}
+
+async function validateOnce(facts) {
+  const risky = isRiskySurface(facts.changedPaths);
+  const legs = [];
+  const primary = externalJudge === null ? await spawnedLeg(facts) : await brokerLeg(facts, externalJudge);
+  if (!primary) return null;
+  legs.push({ family: externalJudge === null ? 'spawned' : 'external', result: primary });
+  let diversity = risky ? 'unsatisfied' : 'not-required';
+  if (risky && crossFamilyCommand !== null && crossFamilyCommand !== externalJudge) {
+    const second = await brokerLeg(facts, crossFamilyCommand);
+    if (!second) return null;
+    legs.push({ family: 'cross-family', result: second });
+    diversity = 'satisfied';
+  }
+  return mergeLegs(legs, risky, diversity);
 }
 
 let validation = await validateOnce(impl);
@@ -409,7 +483,14 @@ const closedIds = new Set();
 let facts = { contextId: impl.contextId, changedPaths: impl.changedPaths.slice(), checkReceipts: impl.checkReceipts };
 let roundsUsed = 0;
 let stoppedBy = null;
+// A diversity gap is not a defect in the subject and cannot be repaired by
+// editing it: on a risky surface with no cross-family leg the traversal stops
+// as NOT_PROVEN (diversity_unsatisfied) without spending a repair round.
+if (validation && validation.risky && validation.diversity === 'unsatisfied') {
+  stoppedBy = 'diversity_unsatisfied: risky surface, no authorized cross-family leg';
+}
 while (
+  stoppedBy === null &&
   validation &&
   (validation.verdict === 'FAIL' || validation.verdict === 'NOT_PROVEN') &&
   openIds(validation).size > 0
@@ -439,23 +520,58 @@ while (
     { label: 'repair:' + (roundsUsed + 1), phase: 'Repair', schema: REPAIR_SCHEMA }
   );
   roundsUsed += 1;
-  if (!repair) { stoppedBy = 'repair stage failed in round ' + roundsUsed; break; }
+  if (!repair) {
+    // A failed repair may have mutated the subject: no stale verdict identity survives it.
+    return {
+      verdict: 'NOT_PROVEN', verdictPath: null, intentDigest: plan.intentDigest,
+      changedPaths: facts.changedPaths, filesSummary: impl.filesSummary, criteria: [],
+      findings: validation.findings || [], converged: false, repairRoundsUsed: roundsUsed,
+      repairLog: repairLog.concat(['repair round ' + roundsUsed + ': repair stage failed']),
+      stoppedBy: 'repair stage failed in round ' + roundsUsed, subjectDigest: null,
+      error: 'Repair stage failed after the subject may have changed; the prior verdict no longer binds',
+    };
+  }
   const union = new Set(facts.changedPaths);
   for (const p of repair.changedPaths) union.add(p);
   facts = { contextId: repair.contextId, changedPaths: [...union], checkReceipts: repair.checkReceipts };
   const next = await validateOnce(facts);
-  if (!next) { stoppedBy = 'validate stage failed in round ' + roundsUsed; break; }
+  if (!next) {
+    return {
+      verdict: 'NOT_PROVEN', verdictPath: null, intentDigest: plan.intentDigest,
+      changedPaths: facts.changedPaths, filesSummary: impl.filesSummary, criteria: [],
+      findings: validation.findings || [], converged: false, repairRoundsUsed: roundsUsed,
+      repairLog: repairLog.concat(['repair round ' + roundsUsed + ': validate stage failed']),
+      stoppedBy: 'validate stage failed in round ' + roundsUsed, subjectDigest: null,
+      error: 'Validate stage failed after a repair; the repaired candidate was never freshly judged',
+    };
+  }
   const nextIds = openIds(next);
-  for (const id of prevIds) if (!nextIds.has(id)) closedIds.add(id);
+  const resolved = [...prevIds].filter((id) => !nextIds.has(id));
+  const prevEvidence = new Set(validation.evidenceRefs || []);
+  const newEvidence = (next.evidenceRefs || []).filter((e) => !prevEvidence.has(e));
   let violation = null;
   if (nextIds.size > prevIds.size) violation = 'open finding set grew (' + prevIds.size + ' -> ' + nextIds.size + ')';
   else if ([...nextIds].some((id) => closedIds.has(id))) violation = 'a closed finding reopened';
-  else if (next.verdict !== 'PASS' && next.subjectDigest === prevDigest) violation = 'subject digest unchanged without new evidence';
+  else if (next.subjectDigest === prevDigest) {
+    // Condition 4: unchanged bytes are admitted only when a NOT_PROVEN round
+    // was resolved by new evidence that closed at least one finding; a FAIL is
+    // never rescued by evidence, and a PASS over unchanged bytes is a flip.
+    const evidenceResolved =
+      validation.verdict === 'NOT_PROVEN' && next.verdict !== 'FAIL' && newEvidence.length > 0 && resolved.length > 0;
+    if (!evidenceResolved) violation = next.verdict === 'PASS'
+      ? 'verdict flipped to PASS over an unchanged subject'
+      : 'subject digest unchanged without new resolving evidence';
+  }
+  for (const id of resolved) closedIds.add(id);
   repairLog.push('repair round ' + roundsUsed + ': ' + nextIds.size + ' open findings' + (violation ? ' — stopped by the law: ' + violation : ''));
   validation = next;
-  if (violation) { stoppedBy = 'law: ' + violation; break; }
+  if (violation) {
+    stoppedBy = 'law: ' + violation;
+    if (validation.verdict === 'PASS') validation = { ...validation, verdict: 'NOT_PROVEN' };
+    break;
+  }
 }
-const converged = !!validation && validation.verdict === 'PASS';
+const converged = !!validation && validation.verdict === 'PASS' && stoppedBy === null;
 if (!converged && stoppedBy === null && validation && openIds(validation).size === 0 && validation.verdict !== 'PASS') {
   stoppedBy = 'validator returned ' + validation.verdict + ' with no findings to repair';
 }
@@ -471,6 +587,9 @@ return {
   filesSummary: impl.filesSummary,
   criteria: validation.criteria,
   findings: validation.findings || [],
+  subjectDigest: validation.subjectDigest || null,
+  validatorFamilies: validation.families || [],
+  diversity: validation.diversity || 'not-required',
   converged,
   repairRoundsUsed: roundsUsed,
   repairLog,

--- a/workflows/rpi.js
+++ b/workflows/rpi.js
@@ -1,12 +1,13 @@
 export const meta = {
   name: 'rpi',
   description:
-    'One RPI traversal: Plan shapes one behavior and snapshots intent identity, Implement runs one bounded RED->GREEN experiment, then a structurally fresh Validate context judges the exact content and persists verdict.v2 for this workflow\'s return contract. No retry, no revision, no lifecycle.',
-  whenToUse: 'When a caller intent (behavior request or bead text) should be driven through Plan -> Implement -> fresh Validate exactly once, ending in a durable PASS | FAIL | NOT_PROVEN verdict. Not for multi-lane waves (implement-wave) or verdict-only re-checks (verify-fixes).',
+    'One RPI traversal: Plan shapes one behavior and snapshots intent identity, Implement runs one bounded RED->GREEN experiment, then a structurally fresh Validate context judges the exact content and persists verdict.v2. A FAIL or NOT_PROVEN enters a bounded repair phase that stops when converged, stopped by the convergence law, or out of repairRounds. No lifecycle.',
+  whenToUse: 'When a caller intent (behavior request or bead text) should be driven through Plan -> Implement -> fresh Validate -> bounded repair, ending in a durable PASS | FAIL | NOT_PROVEN verdict. Not for multi-lane waves (implement-wave) or verdict-only re-checks (verify-fixes).',
   phases: [
     { title: 'Plan', detail: 'shape one active behavior; snapshot exact intent bytes under SHA-256 identity' },
     { title: 'Implement', detail: 'one bounded RED->GREEN experiment strictly inside write scope' },
     { title: 'Validate', detail: 'fresh context re-verifies identity, judges acceptance, persists verdict.v2' },
+    { title: 'Repair', detail: 'bounded repair rounds under the convergence law; stop when converged, stopped by the law, or out of budget' },
   ],
 };
 
@@ -49,13 +50,30 @@ const IMPLEMENT_SCHEMA = {
   },
 };
 
+// CONTRACT (ADR-0017): findings[].id is the convergence law's key. Ids must be
+// STABLE across rounds — the same defect keeps its id however the summary is
+// reworded — because "the open set did not grow" and "nothing reopened" are
+// meaningless over unstable ids. subjectDigest is the law's progress signal.
 const VALIDATE_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['verdict', 'verdictPath', 'criteria', 'validatorContextId'],
+  required: ['verdict', 'verdictPath', 'criteria', 'validatorContextId', 'subjectDigest', 'findings'],
   properties: {
     verdict: { enum: ['PASS', 'FAIL', 'NOT_PROVEN'] },
     verdictPath: { type: 'string' },
+    subjectDigest: { type: 'string' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['id', 'summary'],
+        properties: {
+          id: { type: 'string' },
+          summary: { type: 'string' },
+        },
+      },
+    },
     criteria: {
       type: 'array',
       items: {
@@ -73,11 +91,15 @@ const VALIDATE_SCHEMA = {
   },
 };
 
+// The repair stage returns the same derived facts as Implement: the freshness
+// wall is identical, so a repair round's narrative never reaches the validator.
+const REPAIR_SCHEMA = IMPLEMENT_SCHEMA;
+
 function badArgs(detail) {
   throw new Error(
     'rpi: bad args (' + detail + '). Expected ' +
       '{ intent: string, root?: string, writeScope?: [string, ...], acceptance?: string, ' +
-      "validator?: { kind: 'spawned' | 'command', command?: string } }"
+      "repairRounds?: integer >= 0, validator?: { kind: 'spawned' | 'command', command?: string } }"
   );
 }
 
@@ -98,6 +120,16 @@ if (
 if (input.acceptance !== undefined && (typeof input.acceptance !== 'string' || !input.acceptance.trim())) {
   badArgs('acceptance must be a non-empty string when given');
 }
+// CONTRACT (ADR-0017): the repair bound is the CALLER's declaration, not the
+// workflow's budget. It is never widened at runtime; 0 reproduces the old
+// single-pass behavior exactly.
+if (
+  input.repairRounds !== undefined &&
+  (!Number.isInteger(input.repairRounds) || input.repairRounds < 0)
+) {
+  badArgs('repairRounds must be a non-negative integer when given');
+}
+const repairRounds = input.repairRounds === undefined ? 2 : input.repairRounds;
 // CONTRACT: validator selects who judges — the default spawned fresh context,
 // or an external judge command brokered by that fresh context. The command is
 // opaque caller input; invalid shapes die here, never as a runtime surprise.
@@ -151,7 +183,7 @@ const toolingBlock =
 phase('Plan');
 
 const plan = await agent(
-  'You are the Plan stage of one RPI traversal (Plan -> Implement -> fresh Validate -> report and stop).\n\n' +
+  'You are the Plan stage of one RPI traversal (Plan -> Implement -> fresh Validate -> bounded repair -> report).\n\n' +
     'Caller intent (behavior request or bead text):\n' + input.intent + '\n\n' +
     (input.acceptance
       ? 'The caller fixed the acceptance criteria — adopt them verbatim as your acceptance output:\n' + input.acceptance + '\n\n'
@@ -196,7 +228,7 @@ const writeScope = input.writeScope !== undefined ? input.writeScope : plan.writ
 phase('Implement');
 
 const impl = await agent(
-  'You are the Implement stage of one RPI traversal (Plan -> Implement -> fresh Validate -> report and stop). ' +
+  'You are the Implement stage of one RPI traversal (Plan -> Implement -> fresh Validate -> bounded repair -> report). ' +
     'A separate fresh context will judge your work against the acceptance below using only derived facts — ' +
     'it will never see your narrative, so evidence lives in receipts, not prose.\n\n' +
     'Caller intent:\n' + input.intent + '\n\n' +
@@ -240,6 +272,16 @@ phase('Validate');
 // wall is identical in both modes: in external-judge mode the same fresh
 // context brokers the same packet to the caller-supplied command and
 // transcribes its ruling without interpretation.
+
+// CONTRACT (ADR-0017): validators return the subject-manifest digest and the open
+// findings under STABLE ids so the repair phase can apply the convergence law.
+const FINDINGS_BLOCK =
+  '\n- Return subjectDigest: the manifest digest you computed over the changed paths.\n' +
+  '- Return findings: one entry {id, summary} per open defect that blocks PASS (empty on PASS). Ids are ' +
+  'STABLE keys of the form <criterion-slug>:<defect-slug> so the same defect keeps its id across rounds ' +
+  'however you reword the summary; never mint a new id for a defect you already named.';
+
+async function validateOnce(facts) {
 let validation;
 if (externalJudge === null) {
 validation = await agent(
@@ -251,11 +293,11 @@ validation = await agent(
     '- intent snapshot path: ' + plan.intentPath + '\n\n' +
     'Acceptance criteria to judge:\n' + acceptance + '\n\n' +
     'Declared write scope:\n' + writeScope.map((s) => '  - ' + s).join('\n') + '\n\n' +
-    'Author context id: ' + impl.contextId + '\n\n' +
+    'Author context id: ' + facts.contextId + '\n\n' +
     'Changed paths (derived, judge these exact files):\n' +
-    (impl.changedPaths.length ? impl.changedPaths.map((p) => '  - ' + p).join('\n') : '  (none reported)') + '\n\n' +
+    (facts.changedPaths.length ? facts.changedPaths.map((p) => '  - ' + p).join('\n') : '  (none reported)') + '\n\n' +
     'Check receipts (factual command outcomes, re-derivable — rerun them yourself):\n' +
-    JSON.stringify(impl.checkReceipts, null, 2) + '\n\n' +
+    JSON.stringify(facts.checkReceipts, null, 2) + '\n\n' +
     'Procedure:\n' +
     '- ' + where + '\n' +
     '- ' + toolingBlock + '\n' +
@@ -278,7 +320,7 @@ validation = await agent(
     'verdictPath.\n' +
     '- Read-only over the subject: fix nothing, commit nothing. The verdict file is the only thing you persist.\n' +
     '- If the tooling is absent or persistence fails, the verdict is NOT_PROVEN with the real error in the ' +
-    'evidence of a criteria entry.',
+    'evidence of a criteria entry.' + FINDINGS_BLOCK,
   { label: 'validate', phase: 'Validate', schema: VALIDATE_SCHEMA, effort: 'high' }
 );
 } else {
@@ -300,10 +342,10 @@ validation = await agent(
     '- intent snapshot path: ' + plan.intentPath + '\n' +
     '- Acceptance criteria to judge:\n' + acceptance + '\n' +
     '- Declared write scope:\n' + writeScope.map((s) => '  - ' + s).join('\n') + '\n' +
-    '- Author context id: ' + impl.contextId + '\n' +
+    '- Author context id: ' + facts.contextId + '\n' +
     '- Changed paths (derived):\n' +
-    (impl.changedPaths.length ? impl.changedPaths.map((p) => '  - ' + p).join('\n') : '  (none reported)') + '\n' +
-    '- Check receipts (factual command outcomes):\n' + JSON.stringify(impl.checkReceipts, null, 2) + '\n\n' +
+    (facts.changedPaths.length ? facts.changedPaths.map((p) => '  - ' + p).join('\n') : '  (none reported)') + '\n' +
+    '- Check receipts (factual command outcomes):\n' + JSON.stringify(facts.checkReceipts, null, 2) + '\n\n' +
     'Procedure:\n' +
     '- ' + where + '\n' +
     '- ' + toolingBlock + '\n' +
@@ -333,10 +375,14 @@ validation = await agent(
     '- Read-only over the subject: fix nothing, commit nothing. The transcript and the verdict file are the ' +
     'only things you persist.\n' +
     '- If the tooling is absent or persistence fails, the verdict is NOT_PROVEN with the real error in the ' +
-    'evidence of a criteria entry.',
+    'evidence of a criteria entry.' + FINDINGS_BLOCK,
   { label: 'validate', phase: 'Validate', schema: VALIDATE_SCHEMA, effort: 'high' }
 );
 }
+return validation;
+}
+
+let validation = await validateOnce(impl);
 
 if (!validation) {
   return {
@@ -350,13 +396,83 @@ if (!validation) {
   };
 }
 
-// Report and stop: script-assembled, no fourth agent, no next action.
+// REPAIR PHASE (ADR-0017): bounded by the caller's repairRounds and stopped by
+// the convergence law. The fix step is an Implement-shaped agent that sees the
+// open findings; every judge leg stays non-mutating. Law, per round:
+//   1. roundsUsed < repairRounds
+//   2. open finding set (stable ids) is not larger than the previous round's
+//   3. no id closed in an earlier round reopens
+//   4. the subject digest changed, or the round resolved NOT_PROVEN with new evidence
+const openIds = (v) => new Set((v.findings || []).map((f) => f.id));
+const repairLog = [];
+const closedIds = new Set();
+let facts = { contextId: impl.contextId, changedPaths: impl.changedPaths.slice(), checkReceipts: impl.checkReceipts };
+let roundsUsed = 0;
+let stoppedBy = null;
+while (
+  validation &&
+  (validation.verdict === 'FAIL' || validation.verdict === 'NOT_PROVEN') &&
+  openIds(validation).size > 0
+) {
+  if (roundsUsed >= repairRounds) { stoppedBy = 'out of repair_rounds (' + repairRounds + ')'; break; }
+  phase('Repair');
+  const prevIds = openIds(validation);
+  const prevDigest = validation.subjectDigest;
+  const repair = await agent(
+    'You are the Repair stage of one RPI traversal, round ' + (roundsUsed + 1) + ' of at most ' + repairRounds +
+      '. A fresh validator judged the current candidate and returned ' + validation.verdict +
+      ' with these open findings; fix exactly these, nothing else, inside the write scope.\n\n' +
+      'Open findings (stable ids):\n' +
+      (validation.findings || []).map((f) => '  - ' + f.id + ': ' + f.summary).join('\n') + '\n\n' +
+      'Acceptance the validator judges against:\n' + acceptance + '\n\n' +
+      'Write scope — you may create or edit ONLY paths matching:\n' +
+      writeScope.map((s) => '  - ' + s).join('\n') + '\n\n' +
+      'Paths changed so far:\n' + facts.changedPaths.map((p) => '  - ' + p).join('\n') + '\n\n' +
+      'Process rules (non-negotiable):\n' +
+      '- ' + where + '\n' +
+      '- Repair the named findings; rerun the repository\'s real checks and record each as a checkReceipts ' +
+      'entry {name, command, outcome}. Do not weaken tests, gates, or acceptance to obtain green.\n' +
+      '- Stay strictly inside the write scope; record any unmet out-of-scope need as a receipt, never an edit.\n' +
+      '- Generate your own author context id (random bytes via bash, hex-encoded) and return it as contextId.\n' +
+      '- List every path you changed under changedPaths. filesSummary is for the caller only.\n' +
+      '- No lifecycle: do not commit, push, tag, or close anything.',
+    { label: 'repair:' + (roundsUsed + 1), phase: 'Repair', schema: REPAIR_SCHEMA }
+  );
+  roundsUsed += 1;
+  if (!repair) { stoppedBy = 'repair stage failed in round ' + roundsUsed; break; }
+  const union = new Set(facts.changedPaths);
+  for (const p of repair.changedPaths) union.add(p);
+  facts = { contextId: repair.contextId, changedPaths: [...union], checkReceipts: repair.checkReceipts };
+  const next = await validateOnce(facts);
+  if (!next) { stoppedBy = 'validate stage failed in round ' + roundsUsed; break; }
+  const nextIds = openIds(next);
+  for (const id of prevIds) if (!nextIds.has(id)) closedIds.add(id);
+  let violation = null;
+  if (nextIds.size > prevIds.size) violation = 'open finding set grew (' + prevIds.size + ' -> ' + nextIds.size + ')';
+  else if ([...nextIds].some((id) => closedIds.has(id))) violation = 'a closed finding reopened';
+  else if (next.verdict !== 'PASS' && next.subjectDigest === prevDigest) violation = 'subject digest unchanged without new evidence';
+  repairLog.push('repair round ' + roundsUsed + ': ' + nextIds.size + ' open findings' + (violation ? ' — stopped by the law: ' + violation : ''));
+  validation = next;
+  if (violation) { stoppedBy = 'law: ' + violation; break; }
+}
+const converged = !!validation && validation.verdict === 'PASS';
+if (!converged && stoppedBy === null && validation && openIds(validation).size === 0 && validation.verdict !== 'PASS') {
+  stoppedBy = 'validator returned ' + validation.verdict + ' with no findings to repair';
+}
+
+// Report: script-assembled, no extra agent, no next action. The caller owns
+// continuation; repairRounds was the caller's declaration and is never widened.
 // filesSummary reaches only this caller-facing report — never the validator.
 return {
   verdict: validation.verdict,
   verdictPath: validation.verdictPath,
   intentDigest: plan.intentDigest,
-  changedPaths: impl.changedPaths,
+  changedPaths: facts.changedPaths,
   filesSummary: impl.filesSummary,
   criteria: validation.criteria,
+  findings: validation.findings || [],
+  converged,
+  repairRoundsUsed: roundsUsed,
+  repairLog,
+  stoppedBy,
 };

--- a/workflows/rpi.js
+++ b/workflows/rpi.js
@@ -57,12 +57,31 @@ const IMPLEMENT_SCHEMA = {
 const VALIDATE_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['verdict', 'verdictPath', 'criteria', 'validatorContextId', 'subjectDigest', 'findings', 'evidenceRefs'],
+  required: ['verdict', 'verdictPath', 'criteria', 'validatorContextId', 'subjectDigest', 'findings', 'evidenceRefs', 'derivedChangedPaths'],
   properties: {
     verdict: { enum: ['PASS', 'FAIL', 'NOT_PROVEN'] },
     verdictPath: { type: 'string' },
     subjectDigest: { type: 'string' },
-    evidenceRefs: { type: 'array', items: { type: 'string' } },
+    // CONTRACT (ADR-0017, condition 4): evidence is a BINDING, not a label. An
+    // entry admits an unchanged subject only when its subjectDigest equals the
+    // round's digest and it names a finding id the round actually closed.
+    evidenceRefs: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['ref', 'subjectDigest', 'resolves'],
+        properties: {
+          ref: { type: 'string' },
+          subjectDigest: { type: 'string' },
+          resolves: { type: 'array', items: { type: 'string' } },
+        },
+      },
+    },
+    // CONTRACT: the validator derives the changed set itself (git status and
+    // diff against the clean pre-run tree) so author-reported paths cannot hide
+    // an edit from coverage or from risky-surface classification.
+    derivedChangedPaths: { type: 'array', items: { type: 'string' } },
     findings: {
       type: 'array',
       items: {
@@ -299,7 +318,11 @@ const FINDINGS_BLOCK =
   '- Return findings: one entry {id, summary} per open defect that blocks PASS (empty on PASS). Ids are ' +
   'STABLE keys of the form <criterion-slug>:<defect-slug> so the same defect keeps its id across rounds ' +
   'however you reword the summary; never mint a new id for a defect you already named.\n' +
-  '- Return evidenceRefs: the paths of the receipts, transcripts, or verdict files your judgment relied on.';
+  '- Return evidenceRefs as bindings {ref, subjectDigest, resolves}: ref is the receipt/transcript/verdict path, ' +
+  'subjectDigest is the manifest digest it was produced against, resolves lists the finding ids it closes (empty if none).\n' +
+  '- Return derivedChangedPaths: derive the changed set YOURSELF from the working tree (git status --porcelain and ' +
+  'git diff --name-only against HEAD, including untracked files); do not copy the author list. Any path you derive that ' +
+  'the author did not report is a coverage finding (id coverage:unreported:<path>).';
 
 async function spawnedLeg(facts) {
   return await agent(
@@ -409,7 +432,7 @@ function mergeLegs(legs, risky, diversity) {
     const r = leg.result;
     if (VERDICT_RANK[r.verdict] > VERDICT_RANK[verdict]) verdict = r.verdict;
     for (const f of r.findings || []) findings.set(f.id, { id: f.id, summary: f.summary, family: leg.family });
-    for (const e of r.evidenceRefs || []) evidence.add(e);
+    for (const e of r.evidenceRefs || []) evidence.add(JSON.stringify(e));
     for (const c of r.criteria || []) criteria.push(c);
     if (digest === null) digest = r.subjectDigest;
     else if (r.subjectDigest !== digest) digestConflict = true;
@@ -426,13 +449,20 @@ function mergeLegs(legs, risky, diversity) {
     verdict = 'NOT_PROVEN';
     findings.set('diversity:unsatisfied', { id: 'diversity:unsatisfied', summary: 'risky surface judged by one model family only; no authorized cross-family leg', family: 'merge' });
   }
+  const derived = new Set();
+  for (const leg of legs) for (const p of leg.result.derivedChangedPaths || []) derived.add(p);
+  // A persisted verdict path is exposed only when every leg agrees with the
+  // aggregate; a PASS file behind a FAIL/NOT_PROVEN result would launder it.
+  const allAgree = legs.every((l) => l.result.verdict === verdict);
   return {
     verdict,
-    verdictPath: legs[0].result.verdictPath,
+    verdictPath: allAgree ? legs[0].result.verdictPath : null,
+    legVerdictPaths: legs.map((l) => ({ family: l.family, verdict: l.result.verdict, verdictPath: l.result.verdictPath })),
     validatorContextId: legs.map((l) => l.result.validatorContextId).join('+'),
     subjectDigest: digest,
     findings: [...findings.values()],
-    evidenceRefs: [...evidence],
+    evidenceRefs: [...evidence].map((e) => JSON.parse(e)),
+    derivedChangedPaths: [...derived],
     criteria,
     families: legs.map((l) => l.family),
     risky,
@@ -440,20 +470,34 @@ function mergeLegs(legs, risky, diversity) {
   };
 }
 
+// Family distinctness is asserted by the CALLER's choice of crossFamily.command
+// (a different vendor's read-only CLI); this script cannot verify a model's
+// identity and does not pretend to. From a Claude session the legal second leg
+// is a read-only `codex exec` (LAW 0: never a headless Claude leg).
 async function validateOnce(facts) {
-  const risky = isRiskySurface(facts.changedPaths);
   const legs = [];
   const primary = externalJudge === null ? await spawnedLeg(facts) : await brokerLeg(facts, externalJudge);
   if (!primary) return null;
   legs.push({ family: externalJudge === null ? 'spawned' : 'external', result: primary });
+  // Risk is classified over the union of author-reported and validator-derived
+  // paths, so an unreported edit on a gate or test cannot dodge cross-family.
+  const allPaths = new Set([...facts.changedPaths, ...(primary.derivedChangedPaths || [])]);
+  const risky = isRiskySurface([...allPaths]);
+  const elected = crossFamilyCommand !== null && crossFamilyCommand !== externalJudge;
   let diversity = risky ? 'unsatisfied' : 'not-required';
-  if (risky && crossFamilyCommand !== null && crossFamilyCommand !== externalJudge) {
+  if (elected) {
     const second = await brokerLeg(facts, crossFamilyCommand);
     if (!second) return null;
     legs.push({ family: 'cross-family', result: second });
-    diversity = 'satisfied';
+    diversity = risky ? 'satisfied' : 'elected';
   }
-  return mergeLegs(legs, risky, diversity);
+  const merged = mergeLegs(legs, risky, diversity);
+  const unreported = merged.derivedChangedPaths.filter((p) => !facts.changedPaths.includes(p));
+  if (unreported.length > 0) {
+    for (const p of unreported) merged.findings.push({ id: 'coverage:unreported:' + p, summary: 'changed path not reported by the author', family: 'merge' });
+    if (merged.verdict === 'PASS') merged.verdict = 'NOT_PROVEN';
+  }
+  return merged;
 }
 
 let validation = await validateOnce(impl);
@@ -531,7 +575,7 @@ while (
       error: 'Repair stage failed after the subject may have changed; the prior verdict no longer binds',
     };
   }
-  const union = new Set(facts.changedPaths);
+  const union = new Set([...facts.changedPaths, ...(validation.derivedChangedPaths || [])]);
   for (const p of repair.changedPaths) union.add(p);
   facts = { contextId: repair.contextId, changedPaths: [...union], checkReceipts: repair.checkReceipts };
   const next = await validateOnce(facts);
@@ -547,8 +591,11 @@ while (
   }
   const nextIds = openIds(next);
   const resolved = [...prevIds].filter((id) => !nextIds.has(id));
-  const prevEvidence = new Set(validation.evidenceRefs || []);
-  const newEvidence = (next.evidenceRefs || []).filter((e) => !prevEvidence.has(e));
+  const prevEvidence = new Set((validation.evidenceRefs || []).map((e) => e.ref));
+  const resolvedSet = new Set(resolved);
+  const bindingEvidence = (next.evidenceRefs || []).filter(
+    (e) => !prevEvidence.has(e.ref) && e.subjectDigest === next.subjectDigest && (e.resolves || []).some((id) => resolvedSet.has(id))
+  );
   let violation = null;
   if (nextIds.size > prevIds.size) violation = 'open finding set grew (' + prevIds.size + ' -> ' + nextIds.size + ')';
   else if ([...nextIds].some((id) => closedIds.has(id))) violation = 'a closed finding reopened';
@@ -557,7 +604,7 @@ while (
     // was resolved by new evidence that closed at least one finding; a FAIL is
     // never rescued by evidence, and a PASS over unchanged bytes is a flip.
     const evidenceResolved =
-      validation.verdict === 'NOT_PROVEN' && next.verdict !== 'FAIL' && newEvidence.length > 0 && resolved.length > 0;
+      validation.verdict === 'NOT_PROVEN' && next.verdict !== 'FAIL' && bindingEvidence.length > 0;
     if (!evidenceResolved) violation = next.verdict === 'PASS'
       ? 'verdict flipped to PASS over an unchanged subject'
       : 'subject digest unchanged without new resolving evidence';

--- a/workflows/rpi.js
+++ b/workflows/rpi.js
@@ -163,6 +163,8 @@ if (input.crossFamily !== undefined) {
   }
 }
 const crossFamilyCommand = input.crossFamily !== undefined ? input.crossFamily.command.trim() : null;
+// Explicit list; the skill contract names the same paths. (security-gate.sh
+// scans the whole repository, so "anything it scans" is not a usable predicate.)
 const RISKY_SURFACE = [
   /^cli\/internal\/gates\//, /^scripts\/check-[^/]*\.sh$/, /^tests\//, /^skills\/[^/]+\/scripts\//,
   /^skills\/cc-hooks\/policies\//, /^lib\//, /^\.github\/workflows\//, /^scripts\/security-gate\.sh$/,
@@ -454,9 +456,10 @@ function mergeLegs(legs, risky, diversity) {
   // A persisted verdict path is exposed only when every leg agrees with the
   // aggregate; a PASS file behind a FAIL/NOT_PROVEN result would launder it.
   const allAgree = legs.every((l) => l.result.verdict === verdict);
+  const persistedMatches = allAgree && legs[0].result.verdict === verdict;
   return {
     verdict,
-    verdictPath: allAgree ? legs[0].result.verdictPath : null,
+    verdictPath: persistedMatches ? legs[0].result.verdictPath : null,
     legVerdictPaths: legs.map((l) => ({ family: l.family, verdict: l.result.verdict, verdictPath: l.result.verdictPath })),
     validatorContextId: legs.map((l) => l.result.validatorContextId).join('+'),
     subjectDigest: digest,
@@ -494,10 +497,22 @@ async function validateOnce(facts) {
   const merged = mergeLegs(legs, risky, diversity);
   const unreported = merged.derivedChangedPaths.filter((p) => !facts.changedPaths.includes(p));
   if (unreported.length > 0) {
-    for (const p of unreported) merged.findings.push({ id: 'coverage:unreported:' + p, summary: 'changed path not reported by the author', family: 'merge' });
-    if (merged.verdict === 'PASS') merged.verdict = 'NOT_PROVEN';
+    const byId = new Map(merged.findings.map((f) => [f.id, f]));
+    for (const p of unreported) {
+      const id = 'coverage:unreported:' + p;
+      if (!byId.has(id)) byId.set(id, { id, summary: 'changed path not reported by the author', family: 'merge' });
+    }
+    merged.findings = [...byId.values()];
+    if (merged.verdict === 'PASS') return degrade(merged, 'NOT_PROVEN');
   }
   return merged;
+}
+
+// CONTRACT: every aggregate verdict mutation goes through here so a persisted
+// verdict file whose ruling differs from the reported verdict is never exposed.
+function degrade(result, verdict) {
+  if (result.verdict === verdict) return result;
+  return { ...result, verdict, verdictPath: null };
 }
 
 let validation = await validateOnce(impl);
@@ -528,16 +543,20 @@ let facts = { contextId: impl.contextId, changedPaths: impl.changedPaths.slice()
 let roundsUsed = 0;
 let stoppedBy = null;
 // A diversity gap is not a defect in the subject and cannot be repaired by
-// editing it: on a risky surface with no cross-family leg the traversal stops
-// as NOT_PROVEN (diversity_unsatisfied) without spending a repair round.
-if (validation && validation.risky && validation.diversity === 'unsatisfied') {
+// editing it. Real findings on a risky surface still enter repair (the
+// contract: FAIL with findings repairs); only when the remaining findings are
+// diversity-only does the traversal stop as NOT_PROVEN (diversity_unsatisfied)
+// without spending a repair round.
+const repairable = (v) => (v.findings || []).some((f) => !String(f.id).startsWith('diversity:'));
+const diversityOnly = (v) => v && v.risky && v.diversity === 'unsatisfied' && !repairable(v);
+if (diversityOnly(validation)) {
   stoppedBy = 'diversity_unsatisfied: risky surface, no authorized cross-family leg';
 }
 while (
   stoppedBy === null &&
   validation &&
   (validation.verdict === 'FAIL' || validation.verdict === 'NOT_PROVEN') &&
-  openIds(validation).size > 0
+  repairable(validation)
 ) {
   if (roundsUsed >= repairRounds) { stoppedBy = 'out of repair_rounds (' + repairRounds + ')'; break; }
   phase('Repair');
@@ -614,7 +633,11 @@ while (
   validation = next;
   if (violation) {
     stoppedBy = 'law: ' + violation;
-    if (validation.verdict === 'PASS') validation = { ...validation, verdict: 'NOT_PROVEN' };
+    if (validation.verdict === 'PASS') validation = degrade(validation, 'NOT_PROVEN');
+    break;
+  }
+  if (diversityOnly(validation)) {
+    stoppedBy = 'diversity_unsatisfied: risky surface, no authorized cross-family leg';
     break;
   }
 }


### PR DESCRIPTION
## Loop restore: converge and crank as control flow under the verdict contract (ADR-0017)

Intent source: `docs/plans/2026-09-03-loop-restore.md` (in this PR). Decision record: `docs/adr/ADR-0017-loop-as-control-flow-not-knowledge.md`.

**Why.** The 2026-07-14 single-pass cut (`482307762`) removed the iterate loop (discovery, crank, converge, evolve, the learn write-half) together with the unproven compounding claim, although ADR-0011 demoted only the latter. The control flow was never demoted, and its absence showed on 2026-09-02, when a three-lane fix needed eight validators and two stops because the contract had no repair phase. This restores the loop as control flow and nothing else: no knowledge store, no `ao converge`/`ao crank`, no evolve, no canary. ADR-0004 and ADR-0011 stay in force.

**What changes.**
- **RPI gains a bounded repair phase.** On `FAIL` or `NOT_PROVEN` with findings, repair and re-validate freshly under the convergence law: caller-declared `repair_rounds` (default 2); open finding set keyed by stable `findings[].id`, union across validator families, non-growing; no closed id reopens; the subject digest changed or, for `NOT_PROVEN`, new digest-bound evidence resolved a named gap. Converged = fresh PASS plus cross-family PASS on risky surfaces. Plan and Implement keep their single dispatch. `skills/rpi/scripts/run_once.py` models the law as pure data (33 tests): rounds are validated for shape (digest required, no duplicate ids, no PASS with findings, no FAIL without findings), condition 4's evidence branch needs a NOT_PROVEN previous round, a non-FAIL current round, new evidence, and a resolved finding, and a PASS over unchanged bytes after a FAIL is a flip that reports NOT_PROVEN. `workflows/rpi.js` runs validation as legs (spawned or external primary, plus a caller-supplied `crossFamily.command` on risky surfaces) merged worst-of with a union of stable ids; a risky surface without a cross-family leg is `diversity_unsatisfied` and never converges or enters repair; a failed repair or re-validation returns NOT_PROVEN with no stale verdict. Validators return `subjectDigest`, stable finding ids, and `evidenceRefs`.
- **crank returns as a thin wave executor** (113 lines): the caller selects the wave and the repair bound, crank invokes RPI per lane (parallel only on disjoint write and regen scopes), runs the wave acceptance once, returns evidence, and stops. No retry, budget, queue, claim, lease, Git, closure, or next-work ownership. Routing golden `rq-07-wave-execution` ranks it first.
- **validate is cross-family by default on risky surfaces** (`cli/internal/gates/**`, `scripts/check-*.sh`, `tests/**`, `skills/*/scripts/**`, hook policies, `lib/**`, security-scanned paths) with the LAW-0 dispatch table: Claude orchestrating uses read-only `codex exec`; Codex orchestrating uses an interactive Claude session in an NTM pane, never `claude -p`. No live adapter means `diversity_unsatisfied`, which on a risky surface is `NOT_PROVEN`. The full literal CI command set runs once on the final integrated subject; routine rounds keep the receipt-driven freshness contract.
- **Conformance assertions flipped under ADR-0017 only:** `scripts/check-cathedral-cut-conformance.py` (crank live; "Stop regardless" replaced by positive canaries for the law's four conditions; a bounded `for` loop that compares against `repair_rounds` is required in `run_repair_phase`, and the gate executes the law's canaries against the reference behavior), `workflows/rpi.js`, `skills/rpi/scripts/validate.sh`, `evals/agentops-core/rpi-behavior.json`, `skills/rpi/references/rpi.feature`. Every single-pass public surface (README, AGENTS.md, PRODUCT.md, CI-CD, agent-workflow-reference, rpi-traversal, cli/README, quickstart and demo commands, the operating-contract and product-boundary bats, the Codex-description oracle) now states repair to convergence.

**Known approximation, disclosed.** The Claude conveyor has no deterministic shell primitive, so changed paths are derived by the fresh validator (git status and diff against the clean pre-run tree) and unioned with the implementer's report; risk is classified over that union and unreported paths are coverage findings. A validator is still a model; runtime derivation outside every agent is a follow-up. Family distinctness of the cross-family leg is asserted by the caller's choice of command and not verified by the script.

**Not in scope.** Premortem stays a single advisory judge and Plan still only names the first check (phase boundaries unchanged). No `verdict.v2` or `rpi-report.v1` change. The loop's own effect on outcomes is unmeasured and owed a seeded-defect probe, like the rest of the corpus.

**Evidence on the tip.** Regen check clean; full gate green with a HEAD-built binary; CI's bats command green; Go build/vet/test green; golangci-lint clean; security gate quick PASS; one fresh validator over the whole diff; one cross-family read of the design before implementation (13 findings folded) and two of the integrated diff (9 findings in round one, 11 by round two, 15 by round three, each round repaired and re-reviewed; the fresh validator passed the tip after round two and the final tip 1e8adb72d passed a fresh validator (14-scenario independent harness of the law, full gate 71/71 with a HEAD-built binary, CI bats 1164/0) and a cross-family read by Gemini 3.8 via AGY, which closed all six remaining residues with no new findings; Codex was unreachable at push time).

**Follow-ups filed from the final reviews, not blockers:** the JS violation check tests growth before reopen while Python tests reopen first (same stop, different label when both occur in one round); `cli/testdata/compatibility-baseline/families/{demo,quickstart}/case.json` assert help-text substrings Cobra never prints (pre-existing, no consumer); runtime derivation of changed paths outside every agent in the Claude conveyor.
