### PR TITLE
Preserve work-session associations before handoff

### DIFF
--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -105,7 +105,7 @@
 | `doc` | produces | `documentation` |
 | `domain` | produces | `stdout` |
 | `fitness` | produces | `goal-measurement-report` |
-| `handoff` | produces | `caller-selected handoff path or .agents/ao/handoff/*` |
+| `handoff` | produces | `caller-selected handoff artifact` |
 | `human-only-skills` | produces | `stdout` |
 | `idea-genie` | consumes | `repo-context` |
 | `idea-genie` | consumes | `task-question` |

--- a/images/gemini/skills/agent-native/SKILL.md
+++ b/images/gemini/skills/agent-native/SKILL.md
@@ -66,9 +66,23 @@ stalled, and rescue is usually cheaper than rerun.
 
 ## Contract
 
-1. Require an explicit packet, role, workspace, context identity, and evidence
-   destination before starting a worker.
-2. Prove runtime readiness and engagement from observable state; a successful
+1. Require caller intent, role, workspace, authorized source/output scope and
+   evidence destination before starting a worker. Pass source-store/project/work
+   identity and permitted intent locators before execution can fail. Record this
+   dispatch association in caller-owned native comments/metadata or runtime
+   facts, with actual worker session/context IDs explicitly unknown until
+   observed; a requested ID is not an observed ID. This adds no AO packet schema.
+2. Capture observed native runtime/session/context identity at startup, before
+   substantive work and independently of final handoff. Return the observation
+   through the caller-owned native recording channel with its provenance and
+   permitted source locator. Preserve launch failures and unknowns if startup
+   never becomes observable. Follow
+   [session associations](../cass/references/SESSION_FORMATS.md#work-to-session-associations)
+   for separate parent/resume links, supported multi-work spans and frozen source
+   bounds. A controller is not necessarily a native parent; every requested
+   child and resumed execution needs its own observed association. If recording
+   fails, report the gap; do not claim crash recovery from prompt delivery alone.
+   Prove runtime readiness and engagement from observable state; a successful
    prompt send is not proof of work.
 3. Keep concurrent writers disjoint and isolated. Runtime coordination is not a
    claim, lease, queue, or completion state in AgentOps.

--- a/images/gemini/skills/agent-native/references/model-dispatch.md
+++ b/images/gemini/skills/agent-native/references/model-dispatch.md
@@ -17,8 +17,11 @@ majority vote establishes truth. Authors cannot issue their own binding PASS.
 One request selects one worker and one result destination. Before dispatch,
 resolve role, exact subject/acceptance references, authorized input bytes,
 workspace, read/write scope, output/evidence destination, requested model,
-fresh context identity distinct from the author and every peer, finite
-input/output limits and timeout from the caller and native runtime. These are invocation facts, not a new AO packet schema,
+requirement for a fresh context distinct from the author and every peer, finite
+input/output limits and timeout from the caller and native runtime. Actual
+context identity remains unknown until the native runtime reports it; verify
+freshness and distinctness against that observed identity before relying on
+judgment. These are invocation facts, not a new AO packet schema,
 work store or budget account. Retry remains the caller's decision. Judge legs
 receive read-only subject access; only their declared evidence output is writable.
 
@@ -37,6 +40,31 @@ prompt restrictions, a worktree or a same-user unrestricted process do not.
 Unsupported protection prevents restricted-source dispatch. The repository
 contract is ADR-0016, State tiers; this installed skill carries the requirements
 above without depending on a repository-relative documentation link.
+
+## Association before execution
+
+Before launch, pass source-store/project/work identity and permitted frozen
+intent references through the selected runtime input. The caller records the
+dispatch association in native work comments/metadata or existing runtime facts
+before execution can fail, with worker identity explicitly unknown if not yet
+observed. At startup, capture actual runtime/session/context identity and return
+it to that caller-owned channel before substantive work; final handoff is only
+an additional reference. Do this for a child or resumed execution as well.
+
+Keep requested model/ID, observed model/ID, controller identity, native parent
+and resume predecessor distinct. Use the selected runtime's observed resume
+identity even if it retains the original session ID; invocation observations
+must still remain distinguishable. Never infer parentage from workspace,
+filename, title or proximity. An unavailable startup/recording operation stays
+a named failure with unknown identity, not a fabricated successful launch.
+
+[Session associations](../../cass/references/SESSION_FORMATS.md#work-to-session-associations)
+owns the fact distinctions: provenance, permitted locators, source bounds and
+multi-work spans. Record only metadata authorized for the source owner and
+recipient/destination; BD/Dolt is versioned, not secret storage. Neither this
+reference nor the core phases gain tracker mutation, a new association store,
+or runtime lifecycle authority. Required judgment freshness remains unsatisfied
+when observed identities or their provenance are missing.
 
 ## Selected adapters
 

--- a/images/gemini/skills/cass/SKILL.md
+++ b/images/gemini/skills/cass/SKILL.md
@@ -41,8 +41,34 @@ This skill carries only the AgentOps operating doctrine: when to reach for cass,
 ## Constraints
 
 - Never run bare `cass` because it launches a blocking TUI; use a JSON, robot, or explicit file-output command.
-- Treat a stale index as searchable and refresh it with a bounded background command because stale is not broken and an unbounded rebuild can stall the lane.
+- Within authorized sources and destinations, treat a stale index as searchable
+  and refresh it only when the selected invocation permits indexing, using a
+  bounded background command; stale is not broken.
 - Preserve source sessions and require explicit permission for destructive cleanup; recovery may rebuild only derived index state.
+
+## Authorization and episode association
+
+Before any search, view, context lookup, export, index recovery or sync, check
+source-owner, task, model/provider and destination authorization. Indexes,
+hit metadata, source paths and tracker comments inherit source restrictions;
+read permission does not permit forwarding to another model or versioning in
+Git. The recovery defaults below apply only inside this authorized envelope;
+source sync and model downloads also require the selected egress authority.
+Unavailable controls leave restricted-source operations unavailable, without
+retrieving first and redacting later. Missing, restricted, unavailable,
+no-match and insufficient evidence are different outcomes.
+
+Capture work identity at dispatch/start and observed native IDs at startup
+through the caller-owned native comments/metadata or runtime facts, independently
+of handoff. Use [SESSION_FORMATS.md](references/SESSION_FORMATS.md#work-to-session-associations)
+for source-store/work identity, parent/resume provenance, supported work spans,
+permitted locators and available frozen source bounds/digests. Native logs retain
+execution authority; CASS discovers candidates. Search/view/expand/context
+output does not prove a complete episode was read or that a related hit is a
+parent. Record query, filters, limit, index freshness and discovery cutoff;
+zero hits means no match within those observed limits, not absence everywhere.
+Missing children, new tails and unknown source lengths remain explicit. T09 owns
+later coverage verification; this skill does not implement or certify it.
 
 ## When to Use
 
@@ -53,7 +79,10 @@ This skill carries only the AgentOps operating doctrine: when to reach for cass,
 
 ### Folded triggers (ag-s43tg wave 1): `casr` + `cass-memory` route here
 
-- **`casr` → cross-harness resume.** Cross Agent Session Resumer: convert and resume sessions across Claude Code, Codex, Gemini, and other providers — `cass resume` plus [RESUME.md](references/RESUME.md) own this lane (resolve subagent logs to their parent via `cass context` first; subagent files are not resumable).
+- **`casr` → cross-harness resume.** [RESUME.md](references/RESUME.md)
+  distinguishes `cass resume` (same-harness command resolution) from the separate
+  cross-harness converter. `cass context` discovers candidate relations; verify
+  a native parent link before choosing a parent session to resume.
 - **`cass-memory` → `cm` procedural memory.** Use when starting non-trivial work, mining lessons, or preventing repeated mistakes with cm procedural memory — mine past sessions here first, then promote the durable lessons through `cm` instead of re-deriving them each session.
 
 ## The Goldmine Principle
@@ -77,9 +106,9 @@ routing:
   cite `source_path` and line in whatever you build on it.
 - **Adjacent hit** — prior work borders the problem. Extract the working
   fragments, then derive only the missing part fresh.
-- **Verified absence** — zero hits after retrying against discovered workspace
-  keys (`--aggregate workspace`). Now derivation is justified, and the absence
-  itself is worth noting: you are in new territory, so budget accordingly.
+- **Bounded no-match** — zero hits after retrying against authorized discovered
+  workspace keys (`--aggregate workspace`). Derive from available evidence and
+  report the query/index limits; this does not establish global absence.
 
 The named failure mode is re-derivation drift: solving the same problem
 slightly differently each session, so the corpus accumulates near-duplicate
@@ -119,17 +148,17 @@ Mined lessons are evidence with a shelf life, not doctrine:
    cass search "KEYWORD" --workspace /data/projects/PROJECT --json --fields minimal --limit 50 \
      | jq '[.hits[] | select(.line_number <= 3)]'
 
-3. Follow hits: View the actual content
+3. Follow authorized hits: View a bounded excerpt of the actual content
    cass view /path/from/source_path.jsonl -n LINE -C 20
 
-4. Expand context: See the full conversation flow
+4. Expand context: Inspect another bounded conversation window
    cass expand /path/from/source_path.jsonl --line LINE --context 3
 
-5. Discover related: Find the whole work cluster
+5. Discover related: Find candidates, not proven parents or a complete cluster
    cass context /path/from/source_path.jsonl --json
 ```
 
-Why it works: aggregations first (know the terrain), `--fields minimal` (5x smaller output), `line_number <= 3` (user prompts live at the top), context clustering (one good hit → many related sessions). >10 matches for a prompt = a ritual; document and reuse it.
+Why it works: aggregations first (know the terrain), `--fields minimal` (5x smaller output), `line_number <= 3` (a discovery heuristic, not guaranteed prompt position), context clustering (one good hit → many related sessions). >10 matches for a prompt = a ritual; document and reuse it.
 
 ## Operating Doctrine: Stale ≠ Broken
 
@@ -186,7 +215,7 @@ cass evolves quickly; the released binary may lack HEAD features. When a flag re
 | Running `cass index --full` whenever `status` says unhealthy | A 25s rebuild for a 30-min stale index is wasteful | Check `index.stale` separately from `database.exists`; prefer incremental |
 | Running bare `cass` to "see what's there" | Launches blocking TUI in the agent's session | Always `--json` or `--robot`; never bare |
 | Piping `cass export` into `head`/`jq` | Broken-pipe panic on large sessions | `cass export ... -o /tmp/x.json` first, then operate on the file |
-| Treating subagent files as parent sessions | Subagents are separate logs with their own line-2 prompt; also NOT resumable | Filter by `select(.source_path \| contains("subagent"))`; resolve to parent via `cass context` before `cass resume` |
+| Treating subagent files as parent sessions | Subagents have separate logs; prompt positions vary and logs may not be resumable | Filter by `select(.source_path \| contains("subagent"))`; use `cass context` for candidates, then verify native parent evidence before `cass resume` |
 | Using `--limit 0` for "no limit" | Earlier cass panics | Use a real limit (`--limit 50`); `--limit 1` minimum for aggregations |
 | Trusting 0 hits with `--workspace /X` | Workspace strings are case- and trailing-slash-sensitive | Re-run with `--aggregate workspace --limit 1` to discover the canonical key |
 | Skipping `--fields minimal` on wide scans | ~3KB per hit × 100 hits = 300KB context burn | `--fields minimal` for wide passes; upgrade to `summary`/`full` for keepers |
@@ -199,7 +228,7 @@ Long-form versions with mined evidence: [ANTI_PATTERNS.md](references/ANTI_PATTE
 
 ## Safety Boundaries
 
-Pre-authorized (rebuilds derived index data only, never destroys source sessions): `cass doctor --fix --json`, `cass index --full --force-rebuild --json`, `cass sources doctor/sync`, `cass models install/verify`.
+Within the authorized source/model/destination and egress envelope above, the following operate on derived state rather than granting new source access: `cass doctor --fix --json`, `cass index --full --force-rebuild --json`, `cass sources doctor/sync`, `cass models install/verify`.
 
 Do NOT without explicit permission: delete `core.NNNNN` coredumps, delete `.beads/`, `git reset --hard`, or hand-edit `~/.config/cass/sources.toml` — the CLI commands above already do everything safely. Never run bare `cass` (blocking TUI) inside an agent loop.
 
@@ -228,7 +257,7 @@ When the right reference isn't obvious from titles, `grep -ni "SYMPTOM" referenc
 
 ## Scripts
 
-Scripts live under `scripts/`. They execute, never load — zero context tokens. Consistent with the Safety Boundaries above, `recover.sh` and `quick_analysis.sh` may rebuild **derived index state** autonomously (pre-authorized: `doctor --fix`, `index --full`) and `multi_machine_search.sh` reads remote sources over ssh; none destroy source sessions, and nothing destructive (coredump/`.beads` deletion, `git reset --hard`, source edits) runs without explicit confirmation.
+Scripts live under `scripts/`. Inspect their access and write scope before use when uncertain. Consistent with the Safety Boundaries above, `recover.sh` and `quick_analysis.sh` may rebuild **derived index state** autonomously (pre-authorized: `doctor --fix`, `index --full`) and `multi_machine_search.sh` reads remote sources over ssh; none destroy source sessions, and nothing destructive (coredump/`.beads` deletion, `git reset --hard`, source edits) runs without explicit confirmation.
 
 | Script | Usage |
 |--------|-------|
@@ -260,5 +289,5 @@ If `false`, run: `cass index --json`
 ## Quality Checklist
 
 - Results come from a canonical workspace key and include enough source location to reopen the session context.
-- A zero-hit result was retried against discovered workspace keys before concluding that no prior art exists.
+- A zero-hit result was retried against authorized discovered workspace keys and reported as bounded no-match with its discovery limits.
 - Index recovery stayed bounded and preserved source sessions; no stale state was misreported as broken.

--- a/images/gemini/skills/cass/references/RESUME.md
+++ b/images/gemini/skills/cass/references/RESUME.md
@@ -13,6 +13,26 @@
 
 ---
 
+## Authorization and startup evidence
+
+Resolving a command does not authorize executing it. Before reading a source or
+resuming, verify task/source-owner/model/provider/destination authorization and
+that the caller selected this runtime operation. Cross-harness conversion sends
+content to a new recipient and requires its own applicable authorization.
+
+Before execution, pass source-store/project/work identity and permitted intent
+locators, and have the caller record the dispatch/resume request in native
+comments/metadata or runtime facts. Keep the requested predecessor separate
+from the actual resumed context. At startup, record the selected runtime's
+observed session/context ID and resume relation with observation provenance;
+it may reuse an ID or create another context. Until observed, use explicit
+unknowns. Command text, a filename and successful command resolution do not
+prove that resumption occurred. Preserve failed starts and unresolved links
+without waiting for handoff. Follow
+[session associations](SESSION_FORMATS.md#work-to-session-associations) for
+supported spans and available frozen source boundaries/digests; never transfer
+all work associations from a predecessor automatically.
+
 ## The Three Modes
 
 ```bash
@@ -25,7 +45,7 @@ cass resume /path/to/session.jsonl
 # 2. Emit a single shell-escaped command line
 cass resume /path/to/session.jsonl --shell
 # claude resume '8efcc298-90d8-4764-9144-944c40f1a321'
-eval "$(cass resume /path/to/session.jsonl --shell)"
+# Inspect the emitted command; execute only the caller-authorized native resume.
 
 # 3. Replace the current process (mutually exclusive with --shell/--json)
 cass resume /path/to/session.jsonl --exec
@@ -66,32 +86,23 @@ cass resume /home/x/.claude/projects/<ws>/subagents/agent-a0b4d4b58a1fd73da.json
 #  "hint":"Did you pass a project directory or notes file instead..."}}
 ```
 
-Recover the parent session via `cass context`. The schema is:
-
-```json
-{
-  "source":  {"path": "...", "agent": "...", "workspace": "...", ...},
-  "counts":  {"same_workspace": 12, "same_day": 8, "same_agent": 15},
-  "related": {
-    "same_workspace": [{"path": "...", "agent": "...", "title": "...", ...}, ...],
-    "same_day":       [...],
-    "same_agent":     [...]
-  }
-}
-```
-
-Note: items use `.path` (not `.source_path`) and `related` is an **object**, not a flat array.
+Use `cass context` only to discover candidate sessions. Its `related` object
+contains `same_workspace`, `same_day` and `same_agent` lists; their entries use
+`.path`, not `.source_path`. These are similarity groups, not parent edges.
 
 ```bash
-# Find the parent (first non-subagent file in same_workspace)
-cass context /path/to/subagents/agent-XXXXX.jsonl --json \
-  | jq -r '.related.same_workspace[]
-            | select(.path | contains("subagents") | not)
-            | .path' \
-  | head -1
+# Bounded candidate discovery for an authorized source; do not select a parent.
+cass context /path/to/subagents/agent-XXXXX.jsonl --json
 ```
 
-Then `cass resume` that path.
+Verify parentage using an authorized native startup/dispatch observation or
+explicit parent link in native runtime metadata, with its exact permitted
+source locator. A dispatch-attested controller relation is distinct from a
+native parent relation. The first non-subagent workspace hit, a matching title,
+a filename or a guessed prompt line is never proof. If no link is observable,
+record parent unknown and stop parent-based resume selection. Only after the
+link is verified and the caller selects execution may `cass resume` target the
+verified parent; do not erase the child's separate source/work association.
 
 ---
 
@@ -107,7 +118,7 @@ HIT=$(cass search "implement auth flow" --workspace /myrepo --json --fields summ
 # 2. Print the command without executing
 cass resume "$HIT" --shell
 
-# 3. Drop the user into the resumed conversation
+# 3. Only after caller authorization and pre-execution association recording
 cass resume "$HIT" --exec
 ```
 
@@ -123,7 +134,7 @@ cass expand "$HIT" --line 1 --context 5    # see the original prompt
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `session_id_not_found` for `agent-*.jsonl` | Subagent file | Use `cass context` to find parent |
+| `session_id_not_found` for `agent-*.jsonl` | Subagent file | Discover candidates with `cass context`; verify a native parent link or leave parent unknown |
 | `unknown harness` | Path doesn't match any connector layout | Pass `--agent` explicitly |
 | Resumed session won't open | The native CLI was upgraded and changed its session schema | Try the harness's own `--list` to see if the ID is still valid; the source jsonl is your fallback |
 | `cross_agent_session_resumer#9` style: Codex → Pi resumption broken | Cross-harness resume requires casr (separate tool) | Use the matching native CLI; cass resume only does *same-harness* |

--- a/images/gemini/skills/cass/references/SESSION_FORMATS.md
+++ b/images/gemini/skills/cass/references/SESSION_FORMATS.md
@@ -1,9 +1,12 @@
 # Session File Formats by Agent
 
-> **Critical knowledge for parsing raw session logs.** Each agent stores conversations in JSONL with different structures.
+> Format examples are connector/version-specific inspection aids, not identity
+> or completeness guarantees. Read only sources authorized for the task, owner,
+> model/provider and destination; raw native stores retain authority.
 
 ## Contents
 
+- [Work-to-session associations](#work-to-session-associations)
 - [Quick Detection](#quick-detection)
 - [Claude Code Format](#claude-code-format)
 - [Codex CLI Format](#codex-cli-format)
@@ -15,7 +18,66 @@
 
 ---
 
+## Work-to-session associations
+
+The caller passes work identity at dispatch/start before execution can fail,
+and records the dispatch reference in native work comments/metadata or existing
+runtime facts. At startup, record observed identity in that caller-owned channel
+before substantive work, independently of final handoff. These are versioned
+facts under their source owners, not a new AO association database, lifecycle,
+packet schema or permanent writer. Core skills return facts; tracker mutation
+requires the caller's authority. No memory/evidence file belongs in a consumer
+checkout by default; requested CDLC evidence uses owner-selected protected
+external non-Git storage.
+
+Keep these facts distinct in the native record or its permitted evidence:
+
+| Fact | Required distinction |
+|---|---|
+| Source work | Backend/store identity, database/project identity where available, native work ID and permitted source revision/intent locator; a bead ID alone or workspace basename is not globally unique. |
+| Execution | Selected runtime and requested model/ID separately from actual observed model/session/context IDs; absent observations are explicit unknowns, never synthetic UUIDs. |
+| Relations | Native parent, dispatch controller and resume predecessor are separate links, each with its observation source. Record the selected runtime's actual resume identity even when it reuses a session ID. Unknown is distinct from an observed absence of parent. |
+| Provenance | Who or which runtime observed the fact, when, through which native operation/record, and its permitted locator. Caller-supplied facts remain labeled as supplied; do not upgrade inference to observation. |
+| Discovery | Exact query/filters/limits, index freshness, observed cutoff and missing/unavailable/restricted sources. CASS results discover candidates, not every episode member. |
+| Source extent | Permitted native locator plus available frozen byte length/bounds and digest, with the cutoff and digest scope. Unknown or unreadable extent/digest remains unknown, never zero or a hash of an excerpt represented as the full source. |
+| Work span | Only the source interval supported by explicit work/start/switch observations. Where frozen byte offsets are available use half-open `[start, end)` ranges tied to that source identity/digest. A search line is a locator, not an inferred byte boundary. |
+
+For a child, pass its work identity before launch, then record the child's
+observed ID and independently supported parent link at startup. For resume,
+retain the predecessor reference and add the observed resume relation; a
+requested resume ID does not prove a resumed execution. Workspace adjacency,
+matching task titles, filenames and guessed line numbers establish neither
+identity nor parentage. A native session can cover multiple work items: record
+only supported spans for each, preserve unrelated and unassigned spans, and
+leave an unknown end unknown until an observation supports it. Never assign a
+whole session to a work item because one hit names that work.
+
+If launch, startup observation or native recording fails, retain the caller's
+pre-execution record, available bounded failure facts and explicit unknowns;
+report any recording gap. Recovery reopens permitted startup/native sources
+without depending on a final handoff, preserving earlier failures/unknowns as
+history when later observations resolve them. Do not fill gaps with invented
+IDs, inferred edges or unrelated source spans.
+
+All metadata follows source-owner and recipient/model/destination authorization,
+including locators, native comments, filenames and diagnostics. BD/Dolt is
+versioned and is not a secret store. Use permitted opaque locators rather than
+restricted paths/excerpts or credentials; opacity grants no clearance. Check
+access before resolving a locator, never retrieve denied bytes and redact later.
+
+Association is not coverage: CASS discovery, `view`/`expand` windows and tool-call
+mining do not prove full prose/outcome reading. Preserve missing sources and
+unknown lengths. Frozen bounds/digests identify available evidence; they do not
+prove bytes were emitted, delivered to the host or semantically processed.
+Head/tail excerpts leave the middle unread; new tails or children belong to a
+later observation, not a rewritten completed denominator. T09 owns the later
+coverage verifier; no coverage command or acceptance claim is introduced here.
+
 ## Quick Detection
+
+These probes illustrate older formats only. Metadata may precede messages;
+unknown format stays unknown until the selected connector/version is observed.
+Do not infer a native session ID from either probe.
 
 ```bash
 # Detect agent type from first line
@@ -147,29 +209,32 @@ jq 'select(.role == "user") | .content' session.jsonl
 ### Subagent Structure
 
 ```
+Possible older layout, not guaranteed:
 Line 1: Session metadata (type, model info)
-Line 2: THE USER PROMPT (this is gold — the extraction prompt that worked)
+Line 2: User prompt
 Line 3+: Agent execution and responses
 ```
 
 ### Why Subagents Matter
 
-Deep dive extraction prompts live here. The prompt at line 2 is copy-paste ready — it's the exact instruction that produced the extraction.
+Subagent prompts may live here. Inspect the actual authorized message type and
+source position before citing a prompt; line 2 is only a legacy heuristic and
+never evidence of identity, parentage or complete reading.
 
 ### Extract Subagent Prompt
 
 ```bash
-# View prompt with context
+# Inspect the possible prompt position; verify the actual message before use
 cass view /path/subagents/agent-XXXXX.jsonl -n 2 -C 1
 
-# Extract just the text
+# Legacy-layout excerpt only, after verifying the actual prompt position
 sed -n '2p' /path/subagents/agent-XXXXX.jsonl | jq '.message.content'
 
 # Or with jq slurp
 jq -s '.[1].message.content' /path/subagents/agent-XXXXX.jsonl
 ```
 
-### Find All Subagent Sessions
+### Discover Candidate Subagent Sessions
 
 ```bash
 # Via cass search
@@ -184,11 +249,11 @@ find ~/.claude/projects -path "*/subagents/*.jsonl" | head -20
 
 ## Universal Extraction Patterns
 
-### Detect and Extract (Any Agent)
+### Detect and Extract (Legacy Examples)
 
 ```bash
 #!/bin/bash
-# extract_prompts.sh — works with any agent format
+# Legacy-format example; unsupported formats remain unknown
 
 FILE="$1"
 

--- a/images/gemini/skills/handoff/SKILL.md
+++ b/images/gemini/skills/handoff/SKILL.md
@@ -4,7 +4,7 @@ description: 'Write compact caller-authored session evidence without choosing co
 practices: [adr, wiki-knowledge-surface, code-complete]
 hexagonal_role: supporting
 consumes: []
-produces: [caller-selected handoff path or .agents/ao/handoff/*]
+produces: [caller-selected handoff artifact]
 context_rel: []
 skill_api_version: 1
 context:
@@ -42,9 +42,9 @@ Observable in the trace, without reading the prose:
 
 - Every completed item names an exact evidence path like
   `cli/internal/gates/regen.go`, not a chronological narration.
-- The artifact lands at the caller-named path or `.agents/ao/handoff/`.
-- `cat .agents/ao/handoff/<id>.json` after writing shows the same
-  content it wrote.
+- The artifact lands at the caller-named authorized path; new CDLC evidence
+  uses an explicitly selected external non-Git location.
+- Readback of that exact artifact path shows the content written.
 - Only caller-supplied `continuation` text appears as next action; no
   owner, tracker state, or verdict is invented.
 
@@ -59,7 +59,26 @@ Write a factual session artifact that another context can read. Include:
   allowance or explicit measurement gaps, and whether the one helper for the
   current HOLD incident was already used, with existing evidence references;
 - optional caller-supplied continuation text;
-- best-effort read-only repository identity when useful.
+- best-effort read-only repository identity when useful;
+- the permitted startup association reference, source-store/project/work
+  identity, and observed runtime/session/context IDs or explicit unknowns;
+- separately evidenced parent and resume links, observation provenance and
+  cutoff, and any supported work spans with available frozen source bounds and
+  digests, following [session associations](../cass/references/SESSION_FORMATS.md#work-to-session-associations).
+
+The caller records the work association at dispatch/start and observed native
+identity at startup through native comments/metadata or runtime facts. Handoff
+adds end-state evidence; it must not be the first or only work/session link.
+For an interrupted session, reconstruct only what permitted startup records
+and native observations support. Missing handoff, missing source, unknown
+length, unobserved ID or unproved relationship remains explicit; never invent
+an ID or assign an entire multi-work session to one bead. Preserve earlier
+unknown/failure observations when later evidence resolves a link.
+
+Check source-owner and recipient/model/destination authorization before reading
+or copying association metadata. BD/Dolt is versioned and is not a secret
+store. Use permitted opaque locators where necessary; omit restricted excerpts
+and sensitive paths from unauthorized destinations. A locator grants no access.
 
 Do not infer a next action, select work, assign ownership, consume the artifact,
 change tracker or Git state, classify a verdict, govern retries, or restart a
@@ -77,15 +96,17 @@ Anti-pattern: narrating the session chronologically ("first I tried…, then…"
 Corrective: record end-state facts — artifacts, paths, unresolved risks — and
 drop the journey.
 
-Write the artifact to the caller-owned handoff location when the caller names
-one; otherwise it is explicit requested proof under `.agents/ao/handoff/`.
-There is no permanent generic handoff store — an artifact nobody consumes is
-scratch, not evidence.
+Write the artifact to the caller-owned authorized handoff location. For new
+CDLC memory/episode evidence, require the caller-selected protected external
+non-Git location; missing routing is a reported gap, with no fallback file in
+the consumer checkout. Existing requested evidence stays preserved. Standalone
+non-CDLC handoff retains the explicit requested-proof default below. There is
+no permanent generic handoff store — an artifact nobody consumes is scratch.
 
-The ao session handoff and ao session rehydrate commands implement the same
-boundary for JSON artifacts under `.agents/ao/handoff/`. The skill may write
-Markdown when that better serves a human, but the content semantics remain
-identical.
+The skill may write Markdown when that better serves a human. The existing
+`ao session handoff` and `ao session rehydrate` JSON compatibility behavior
+below does not itself establish startup associations or an external CDLC route;
+use only a command whose actual destination support matches the invocation.
 
 ### Earlier default compatibility
 

--- a/images/gemini/skills/implement/SKILL.md
+++ b/images/gemini/skills/implement/SKILL.md
@@ -42,8 +42,9 @@ return the manifest digest and check receipts, stop.
 
 ## It's working if
 
-- The first transcript command is the acceptance check, and its output shows
-  the expected failure (or a green baseline for a relocation or refactor).
+- After source activation and startup association, the first behavior check
+  is the acceptance check; its output shows the expected failure (or an honest
+  green structural baseline for documentation, relocation, or refactor work).
 - Every path in `git diff --stat` falls inside the declared scope; an outside
   consumer is reported as `file:line`, not absorbed.
 - The response carries the `subject-manifest.v1` digest, author context ID,
@@ -53,7 +54,17 @@ return the manifest digest and check receipts, stop.
 
 1. Read the intent, acceptance, and scope from their existing source; before
    the first write, read `boundaries.md` in the rpi skill's `references`
-   directory for what Implement does not own.
+   directory for what Implement does not own. Before execution can fail, the
+   caller passes source-store/project/work identity and permitted intent
+   locators at dispatch/start. At startup, return observed native runtime,
+   session/context identity (or explicit unknowns) through the caller-owned
+   runtime channel for native comments/metadata recording; do not defer this
+   association until handoff. Follow the fact distinctions in
+   [session associations](../cass/references/SESSION_FORMATS.md#work-to-session-associations).
+   Parent and resume links need observed provenance; controller dispatch alone
+   does not establish native parentage. If startup observation or recording
+   fails, preserve that failure and the pre-execution reference with the caller,
+   leaving unobserved IDs unknown. Implement does not mutate the tracker.
 2. Run the declared first acceptance check before changing behavior. RED-first
    applies when acceptance is behavioral: preserve evidence that the check
    fails for the expected missing behavior. Relocations, doc merges, and pure

--- a/images/gemini/skills/rpi/SKILL.md
+++ b/images/gemini/skills/rpi/SKILL.md
@@ -101,6 +101,7 @@ comment alone is not that.
    caller-owned source by reference and digest, or, only when no durable
    source exists, the exact resolved bytes snapshotted by the runtime under
    their digest.
+   For selected CDLC work, the caller carries and records work/startup identities before substantive work for every child or resume, following [session associations](../cass/references/SESSION_FORMATS.md#work-to-session-associations) independently of final handoff; unknowns and failures remain explicit, and RPI never mutates the tracker.
 3. When the write scope touches a risky surface (the short list
    [`validate`](../validate/SKILL.md) names), have one fresh judge read the
    frozen plan before Implement. A blocking finding sends the plan back to the

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -375,8 +375,8 @@
     {
       "name": "agent-native",
       "source_skill": "skills/agent-native",
-      "source_hash": "57ff92e59975404af52aa71b7ec64e45389d1dce26ee899bdb10b9d9ae0788cf",
-      "generated_hash": "c7fb89d595199a14d7b00754603bd4a90cadbcc4ae496663161fca97463b7d81"
+      "source_hash": "5776f850e6004e24a9348a1ae4eba137061af292e47f71fea076dd6d31de3f78",
+      "generated_hash": "3379750defcc316401fc594a15f5746c2c321aaa78ec6a65304dbce4c0870301"
     },
     {
       "name": "agy-native",
@@ -405,8 +405,8 @@
     {
       "name": "cass",
       "source_skill": "skills/cass",
-      "source_hash": "87bd3747933a20e2dbc90191812d855a9b73bde5a966a576fbd6022907bf8e13",
-      "generated_hash": "1f25050e2f004faf4d4e24a76ebc66ee1877774119fbb4a2d3730dcb379e30dc"
+      "source_hash": "7cb1e367d30d8cdf8482eae60ee6acb25187e4642fe5089e7452d72ed0578215",
+      "generated_hash": "633b8a299b60ef25621291a97c4c0e5d89312f115daa3a39bfdf3a4923e67172"
     },
     {
       "name": "cc-hooks",
@@ -477,8 +477,8 @@
     {
       "name": "handoff",
       "source_skill": "skills/handoff",
-      "source_hash": "5d6921b7d42edcc15d6c6a95c0469c520941dec0a6175db178151583db4a5dd6",
-      "generated_hash": "06d2d26f9e670f7df7503a2d3c03daab0a09f3da18f5a70086d9012ba4724592"
+      "source_hash": "0011762be4d71bb359ea78a0088ad3eec2ca9d704718f5dc70abe38a89966fd5",
+      "generated_hash": "d4e35cd31aad23fa9462f71a7efa43da1abe7671d9a29638541ec9951107b7a7"
     },
     {
       "name": "human-only-skills",
@@ -495,8 +495,8 @@
     {
       "name": "implement",
       "source_skill": "skills/implement",
-      "source_hash": "49987f367c5d345e164fccab65a9cc207a8da61ff38de44bffbc0dc13680fb47",
-      "generated_hash": "375b34a916228126c2b20f269dbeb5e1444abe4e478e51bf6a8fdaf8c6efd584"
+      "source_hash": "d24c73ea0104aabff2ca0b9c8826014b07604af64d3c5f9dd56a896973a7ecfa",
+      "generated_hash": "f2e4c6a5c7c3a4c0b15096165197a29f3813bf5161f495655b45273fdfec2615"
     },
     {
       "name": "learn",
@@ -597,8 +597,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "62895cade9636d266190382c422d806193ae246c21589ca6dc98c8a31d988c6d",
-      "generated_hash": "a56999a2700ac4629ffaf2f4dd59bf8797af104920f7622ee8c65754dc7892a2"
+      "source_hash": "44814912c9d640bf6d9ae4bdc27a75f4437b81435954178e3ac44f3c76758ed0",
+      "generated_hash": "c25f250b18d19ac492ec95c4552f510d128ff5b7fb1ef1f4129d17bbb4c818ee"
     },
     {
       "name": "sbh",

--- a/skills-codex/agent-native/.agentops-generated.json
+++ b/skills-codex/agent-native/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/agent-native",
   "layout": "modular",
-  "source_hash": "57ff92e59975404af52aa71b7ec64e45389d1dce26ee899bdb10b9d9ae0788cf",
-  "generated_hash": "c7fb89d595199a14d7b00754603bd4a90cadbcc4ae496663161fca97463b7d81"
+  "source_hash": "5776f850e6004e24a9348a1ae4eba137061af292e47f71fea076dd6d31de3f78",
+  "generated_hash": "3379750defcc316401fc594a15f5746c2c321aaa78ec6a65304dbce4c0870301"
 }

--- a/skills-codex/agent-native/SKILL.md
+++ b/skills-codex/agent-native/SKILL.md
@@ -44,9 +44,23 @@ stalled, and rescue is usually cheaper than rerun.
 
 ## Contract
 
-1. Require an explicit packet, role, workspace, context identity, and evidence
-   destination before starting a worker.
-2. Prove runtime readiness and engagement from observable state; a successful
+1. Require caller intent, role, workspace, authorized source/output scope and
+   evidence destination before starting a worker. Pass source-store/project/work
+   identity and permitted intent locators before execution can fail. Record this
+   dispatch association in caller-owned native comments/metadata or runtime
+   facts, with actual worker session/context IDs explicitly unknown until
+   observed; a requested ID is not an observed ID. This adds no AO packet schema.
+2. Capture observed native runtime/session/context identity at startup, before
+   substantive work and independently of final handoff. Return the observation
+   through the caller-owned native recording channel with its provenance and
+   permitted source locator. Preserve launch failures and unknowns if startup
+   never becomes observable. Follow
+   [session associations](../cass/references/SESSION_FORMATS.md#work-to-session-associations)
+   for separate parent/resume links, supported multi-work spans and frozen source
+   bounds. A controller is not necessarily a native parent; every requested
+   child and resumed execution needs its own observed association. If recording
+   fails, report the gap; do not claim crash recovery from prompt delivery alone.
+   Prove runtime readiness and engagement from observable state; a successful
    prompt send is not proof of work.
 3. Keep concurrent writers disjoint and isolated. Runtime coordination is not a
    claim, lease, queue, or completion state in AgentOps.

--- a/skills-codex/agent-native/references/model-dispatch.md
+++ b/skills-codex/agent-native/references/model-dispatch.md
@@ -17,8 +17,11 @@ majority vote establishes truth. Authors cannot issue their own binding PASS.
 One request selects one worker and one result destination. Before dispatch,
 resolve role, exact subject/acceptance references, authorized input bytes,
 workspace, read/write scope, output/evidence destination, requested model,
-fresh context identity distinct from the author and every peer, finite
-input/output limits and timeout from the caller and native runtime. These are invocation facts, not a new AO packet schema,
+requirement for a fresh context distinct from the author and every peer, finite
+input/output limits and timeout from the caller and native runtime. Actual
+context identity remains unknown until the native runtime reports it; verify
+freshness and distinctness against that observed identity before relying on
+judgment. These are invocation facts, not a new AO packet schema,
 work store or budget account. Retry remains the caller's decision. Judge legs
 receive read-only subject access; only their declared evidence output is writable.
 
@@ -37,6 +40,31 @@ prompt restrictions, a worktree or a same-user unrestricted process do not.
 Unsupported protection prevents restricted-source dispatch. The repository
 contract is ADR-0016, State tiers; this installed skill carries the requirements
 above without depending on a repository-relative documentation link.
+
+## Association before execution
+
+Before launch, pass source-store/project/work identity and permitted frozen
+intent references through the selected runtime input. The caller records the
+dispatch association in native work comments/metadata or existing runtime facts
+before execution can fail, with worker identity explicitly unknown if not yet
+observed. At startup, capture actual runtime/session/context identity and return
+it to that caller-owned channel before substantive work; final handoff is only
+an additional reference. Do this for a child or resumed execution as well.
+
+Keep requested model/ID, observed model/ID, controller identity, native parent
+and resume predecessor distinct. Use the selected runtime's observed resume
+identity even if it retains the original session ID; invocation observations
+must still remain distinguishable. Never infer parentage from workspace,
+filename, title or proximity. An unavailable startup/recording operation stays
+a named failure with unknown identity, not a fabricated successful launch.
+
+[Session associations](../../cass/references/SESSION_FORMATS.md#work-to-session-associations)
+owns the fact distinctions: provenance, permitted locators, source bounds and
+multi-work spans. Record only metadata authorized for the source owner and
+recipient/destination; BD/Dolt is versioned, not secret storage. Neither this
+reference nor the core phases gain tracker mutation, a new association store,
+or runtime lifecycle authority. Required judgment freshness remains unsatisfied
+when observed identities or their provenance are missing.
 
 ## Selected adapters
 

--- a/skills-codex/cass/.agentops-generated.json
+++ b/skills-codex/cass/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/cass",
   "layout": "modular",
-  "source_hash": "87bd3747933a20e2dbc90191812d855a9b73bde5a966a576fbd6022907bf8e13",
-  "generated_hash": "1f25050e2f004faf4d4e24a76ebc66ee1877774119fbb4a2d3730dcb379e30dc"
+  "source_hash": "7cb1e367d30d8cdf8482eae60ee6acb25187e4642fe5089e7452d72ed0578215",
+  "generated_hash": "633b8a299b60ef25621291a97c4c0e5d89312f115daa3a39bfdf3a4923e67172"
 }

--- a/skills-codex/cass/SKILL.md
+++ b/skills-codex/cass/SKILL.md
@@ -19,8 +19,34 @@ This skill carries only the AgentOps operating doctrine: when to reach for cass,
 ## Constraints
 
 - Never run bare `cass` because it launches a blocking TUI; use a JSON, robot, or explicit file-output command.
-- Treat a stale index as searchable and refresh it with a bounded background command because stale is not broken and an unbounded rebuild can stall the lane.
+- Within authorized sources and destinations, treat a stale index as searchable
+  and refresh it only when the selected invocation permits indexing, using a
+  bounded background command; stale is not broken.
 - Preserve source sessions and require explicit permission for destructive cleanup; recovery may rebuild only derived index state.
+
+## Authorization and episode association
+
+Before any search, view, context lookup, export, index recovery or sync, check
+source-owner, task, model/provider and destination authorization. Indexes,
+hit metadata, source paths and tracker comments inherit source restrictions;
+read permission does not permit forwarding to another model or versioning in
+Git. The recovery defaults below apply only inside this authorized envelope;
+source sync and model downloads also require the selected egress authority.
+Unavailable controls leave restricted-source operations unavailable, without
+retrieving first and redacting later. Missing, restricted, unavailable,
+no-match and insufficient evidence are different outcomes.
+
+Capture work identity at dispatch/start and observed native IDs at startup
+through the caller-owned native comments/metadata or runtime facts, independently
+of handoff. Use [SESSION_FORMATS.md](references/SESSION_FORMATS.md#work-to-session-associations)
+for source-store/work identity, parent/resume provenance, supported work spans,
+permitted locators and available frozen source bounds/digests. Native logs retain
+execution authority; CASS discovers candidates. Search/view/expand/context
+output does not prove a complete episode was read or that a related hit is a
+parent. Record query, filters, limit, index freshness and discovery cutoff;
+zero hits means no match within those observed limits, not absence everywhere.
+Missing children, new tails and unknown source lengths remain explicit. T09 owns
+later coverage verification; this skill does not implement or certify it.
 
 ## When to Use
 
@@ -31,7 +57,10 @@ This skill carries only the AgentOps operating doctrine: when to reach for cass,
 
 ### Folded triggers (ag-s43tg wave 1): `casr` + `cass-memory` route here
 
-- **`casr` → cross-harness resume.** Cross Agent Session Resumer: convert and resume sessions across Claude Code, Codex, Gemini, and other providers — `cass resume` plus [RESUME.md](references/RESUME.md) own this lane (resolve subagent logs to their parent via `cass context` first; subagent files are not resumable).
+- **`casr` → cross-harness resume.** [RESUME.md](references/RESUME.md)
+  distinguishes `cass resume` (same-harness command resolution) from the separate
+  cross-harness converter. `cass context` discovers candidate relations; verify
+  a native parent link before choosing a parent session to resume.
 - **`cass-memory` → `cm` procedural memory.** Use when starting non-trivial work, mining lessons, or preventing repeated mistakes with cm procedural memory — mine past sessions here first, then promote the durable lessons through `cm` instead of re-deriving them each session.
 
 ## The Goldmine Principle
@@ -55,9 +84,9 @@ routing:
   cite `source_path` and line in whatever you build on it.
 - **Adjacent hit** — prior work borders the problem. Extract the working
   fragments, then derive only the missing part fresh.
-- **Verified absence** — zero hits after retrying against discovered workspace
-  keys (`--aggregate workspace`). Now derivation is justified, and the absence
-  itself is worth noting: you are in new territory, so budget accordingly.
+- **Bounded no-match** — zero hits after retrying against authorized discovered
+  workspace keys (`--aggregate workspace`). Derive from available evidence and
+  report the query/index limits; this does not establish global absence.
 
 The named failure mode is re-derivation drift: solving the same problem
 slightly differently each session, so the corpus accumulates near-duplicate
@@ -97,17 +126,17 @@ Mined lessons are evidence with a shelf life, not doctrine:
    cass search "KEYWORD" --workspace /data/projects/PROJECT --json --fields minimal --limit 50 \
      | jq '[.hits[] | select(.line_number <= 3)]'
 
-3. Follow hits: View the actual content
+3. Follow authorized hits: View a bounded excerpt of the actual content
    cass view /path/from/source_path.jsonl -n LINE -C 20
 
-4. Expand context: See the full conversation flow
+4. Expand context: Inspect another bounded conversation window
    cass expand /path/from/source_path.jsonl --line LINE --context 3
 
-5. Discover related: Find the whole work cluster
+5. Discover related: Find candidates, not proven parents or a complete cluster
    cass context /path/from/source_path.jsonl --json
 ```
 
-Why it works: aggregations first (know the terrain), `--fields minimal` (5x smaller output), `line_number <= 3` (user prompts live at the top), context clustering (one good hit → many related sessions). >10 matches for a prompt = a ritual; document and reuse it.
+Why it works: aggregations first (know the terrain), `--fields minimal` (5x smaller output), `line_number <= 3` (a discovery heuristic, not guaranteed prompt position), context clustering (one good hit → many related sessions). >10 matches for a prompt = a ritual; document and reuse it.
 
 ## Operating Doctrine: Stale ≠ Broken
 
@@ -164,7 +193,7 @@ cass evolves quickly; the released binary may lack HEAD features. When a flag re
 | Running `cass index --full` whenever `status` says unhealthy | A 25s rebuild for a 30-min stale index is wasteful | Check `index.stale` separately from `database.exists`; prefer incremental |
 | Running bare `cass` to "see what's there" | Launches blocking TUI in the agent's session | Always `--json` or `--robot`; never bare |
 | Piping `cass export` into `head`/`jq` | Broken-pipe panic on large sessions | `cass export ... -o /tmp/x.json` first, then operate on the file |
-| Treating subagent files as parent sessions | Subagents are separate logs with their own line-2 prompt; also NOT resumable | Filter by `select(.source_path \| contains("subagent"))`; resolve to parent via `cass context` before `cass resume` |
+| Treating subagent files as parent sessions | Subagents have separate logs; prompt positions vary and logs may not be resumable | Filter by `select(.source_path \| contains("subagent"))`; use `cass context` for candidates, then verify native parent evidence before `cass resume` |
 | Using `--limit 0` for "no limit" | Earlier cass panics | Use a real limit (`--limit 50`); `--limit 1` minimum for aggregations |
 | Trusting 0 hits with `--workspace /X` | Workspace strings are case- and trailing-slash-sensitive | Re-run with `--aggregate workspace --limit 1` to discover the canonical key |
 | Skipping `--fields minimal` on wide scans | ~3KB per hit × 100 hits = 300KB context burn | `--fields minimal` for wide passes; upgrade to `summary`/`full` for keepers |
@@ -177,7 +206,7 @@ Long-form versions with mined evidence: [ANTI_PATTERNS.md](references/ANTI_PATTE
 
 ## Safety Boundaries
 
-Pre-authorized (rebuilds derived index data only, never destroys source sessions): `cass doctor --fix --json`, `cass index --full --force-rebuild --json`, `cass sources doctor/sync`, `cass models install/verify`.
+Within the authorized source/model/destination and egress envelope above, the following operate on derived state rather than granting new source access: `cass doctor --fix --json`, `cass index --full --force-rebuild --json`, `cass sources doctor/sync`, `cass models install/verify`.
 
 Do NOT without explicit permission: delete `core.NNNNN` coredumps, delete `.beads/`, `git reset --hard`, or hand-edit `~/.config/cass/sources.toml` — the CLI commands above already do everything safely. Never run bare `cass` (blocking TUI) inside an agent loop.
 
@@ -206,7 +235,7 @@ When the right reference isn't obvious from titles, `grep -ni "SYMPTOM" referenc
 
 ## Scripts
 
-Scripts live under `scripts/`. They execute, never load — zero context tokens. Consistent with the Safety Boundaries above, `recover.sh` and `quick_analysis.sh` may rebuild **derived index state** autonomously (pre-authorized: `doctor --fix`, `index --full`) and `multi_machine_search.sh` reads remote sources over ssh; none destroy source sessions, and nothing destructive (coredump/`.beads` deletion, `git reset --hard`, source edits) runs without explicit confirmation.
+Scripts live under `scripts/`. Inspect their access and write scope before use when uncertain. Consistent with the Safety Boundaries above, `recover.sh` and `quick_analysis.sh` may rebuild **derived index state** autonomously (pre-authorized: `doctor --fix`, `index --full`) and `multi_machine_search.sh` reads remote sources over ssh; none destroy source sessions, and nothing destructive (coredump/`.beads` deletion, `git reset --hard`, source edits) runs without explicit confirmation.
 
 | Script | Usage |
 |--------|-------|
@@ -238,5 +267,5 @@ If `false`, run: `cass index --json`
 ## Quality Checklist
 
 - Results come from a canonical workspace key and include enough source location to reopen the session context.
-- A zero-hit result was retried against discovered workspace keys before concluding that no prior art exists.
+- A zero-hit result was retried against authorized discovered workspace keys and reported as bounded no-match with its discovery limits.
 - Index recovery stayed bounded and preserved source sessions; no stale state was misreported as broken.

--- a/skills-codex/cass/references/RESUME.md
+++ b/skills-codex/cass/references/RESUME.md
@@ -13,6 +13,26 @@
 
 ---
 
+## Authorization and startup evidence
+
+Resolving a command does not authorize executing it. Before reading a source or
+resuming, verify task/source-owner/model/provider/destination authorization and
+that the caller selected this runtime operation. Cross-harness conversion sends
+content to a new recipient and requires its own applicable authorization.
+
+Before execution, pass source-store/project/work identity and permitted intent
+locators, and have the caller record the dispatch/resume request in native
+comments/metadata or runtime facts. Keep the requested predecessor separate
+from the actual resumed context. At startup, record the selected runtime's
+observed session/context ID and resume relation with observation provenance;
+it may reuse an ID or create another context. Until observed, use explicit
+unknowns. Command text, a filename and successful command resolution do not
+prove that resumption occurred. Preserve failed starts and unresolved links
+without waiting for handoff. Follow
+[session associations](SESSION_FORMATS.md#work-to-session-associations) for
+supported spans and available frozen source boundaries/digests; never transfer
+all work associations from a predecessor automatically.
+
 ## The Three Modes
 
 ```bash
@@ -25,7 +45,7 @@ cass resume /path/to/session.jsonl
 # 2. Emit a single shell-escaped command line
 cass resume /path/to/session.jsonl --shell
 # claude resume '8efcc298-90d8-4764-9144-944c40f1a321'
-eval "$(cass resume /path/to/session.jsonl --shell)"
+# Inspect the emitted command; execute only the caller-authorized native resume.
 
 # 3. Replace the current process (mutually exclusive with --shell/--json)
 cass resume /path/to/session.jsonl --exec
@@ -66,32 +86,23 @@ cass resume /home/x/.claude/projects/<ws>/subagents/agent-a0b4d4b58a1fd73da.json
 #  "hint":"Did you pass a project directory or notes file instead..."}}
 ```
 
-Recover the parent session via `cass context`. The schema is:
-
-```json
-{
-  "source":  {"path": "...", "agent": "...", "workspace": "...", ...},
-  "counts":  {"same_workspace": 12, "same_day": 8, "same_agent": 15},
-  "related": {
-    "same_workspace": [{"path": "...", "agent": "...", "title": "...", ...}, ...],
-    "same_day":       [...],
-    "same_agent":     [...]
-  }
-}
-```
-
-Note: items use `.path` (not `.source_path`) and `related` is an **object**, not a flat array.
+Use `cass context` only to discover candidate sessions. Its `related` object
+contains `same_workspace`, `same_day` and `same_agent` lists; their entries use
+`.path`, not `.source_path`. These are similarity groups, not parent edges.
 
 ```bash
-# Find the parent (first non-subagent file in same_workspace)
-cass context /path/to/subagents/agent-XXXXX.jsonl --json \
-  | jq -r '.related.same_workspace[]
-            | select(.path | contains("subagents") | not)
-            | .path' \
-  | head -1
+# Bounded candidate discovery for an authorized source; do not select a parent.
+cass context /path/to/subagents/agent-XXXXX.jsonl --json
 ```
 
-Then `cass resume` that path.
+Verify parentage using an authorized native startup/dispatch observation or
+explicit parent link in native runtime metadata, with its exact permitted
+source locator. A dispatch-attested controller relation is distinct from a
+native parent relation. The first non-subagent workspace hit, a matching title,
+a filename or a guessed prompt line is never proof. If no link is observable,
+record parent unknown and stop parent-based resume selection. Only after the
+link is verified and the caller selects execution may `cass resume` target the
+verified parent; do not erase the child's separate source/work association.
 
 ---
 
@@ -107,7 +118,7 @@ HIT=$(cass search "implement auth flow" --workspace /myrepo --json --fields summ
 # 2. Print the command without executing
 cass resume "$HIT" --shell
 
-# 3. Drop the user into the resumed conversation
+# 3. Only after caller authorization and pre-execution association recording
 cass resume "$HIT" --exec
 ```
 
@@ -123,7 +134,7 @@ cass expand "$HIT" --line 1 --context 5    # see the original prompt
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `session_id_not_found` for `agent-*.jsonl` | Subagent file | Use `cass context` to find parent |
+| `session_id_not_found` for `agent-*.jsonl` | Subagent file | Discover candidates with `cass context`; verify a native parent link or leave parent unknown |
 | `unknown harness` | Path doesn't match any connector layout | Pass `--agent` explicitly |
 | Resumed session won't open | The native CLI was upgraded and changed its session schema | Try the harness's own `--list` to see if the ID is still valid; the source jsonl is your fallback |
 | `cross_agent_session_resumer#9` style: Codex → Pi resumption broken | Cross-harness resume requires casr (separate tool) | Use the matching native CLI; cass resume only does *same-harness* |

--- a/skills-codex/cass/references/SESSION_FORMATS.md
+++ b/skills-codex/cass/references/SESSION_FORMATS.md
@@ -1,9 +1,12 @@
 # Session File Formats by Agent
 
-> **Critical knowledge for parsing raw session logs.** Each agent stores conversations in JSONL with different structures.
+> Format examples are connector/version-specific inspection aids, not identity
+> or completeness guarantees. Read only sources authorized for the task, owner,
+> model/provider and destination; raw native stores retain authority.
 
 ## Contents
 
+- [Work-to-session associations](#work-to-session-associations)
 - [Quick Detection](#quick-detection)
 - [Claude Code Format](#claude-code-format)
 - [Codex CLI Format](#codex-cli-format)
@@ -15,7 +18,66 @@
 
 ---
 
+## Work-to-session associations
+
+The caller passes work identity at dispatch/start before execution can fail,
+and records the dispatch reference in native work comments/metadata or existing
+runtime facts. At startup, record observed identity in that caller-owned channel
+before substantive work, independently of final handoff. These are versioned
+facts under their source owners, not a new AO association database, lifecycle,
+packet schema or permanent writer. Core skills return facts; tracker mutation
+requires the caller's authority. No memory/evidence file belongs in a consumer
+checkout by default; requested CDLC evidence uses owner-selected protected
+external non-Git storage.
+
+Keep these facts distinct in the native record or its permitted evidence:
+
+| Fact | Required distinction |
+|---|---|
+| Source work | Backend/store identity, database/project identity where available, native work ID and permitted source revision/intent locator; a bead ID alone or workspace basename is not globally unique. |
+| Execution | Selected runtime and requested model/ID separately from actual observed model/session/context IDs; absent observations are explicit unknowns, never synthetic UUIDs. |
+| Relations | Native parent, dispatch controller and resume predecessor are separate links, each with its observation source. Record the selected runtime's actual resume identity even when it reuses a session ID. Unknown is distinct from an observed absence of parent. |
+| Provenance | Who or which runtime observed the fact, when, through which native operation/record, and its permitted locator. Caller-supplied facts remain labeled as supplied; do not upgrade inference to observation. |
+| Discovery | Exact query/filters/limits, index freshness, observed cutoff and missing/unavailable/restricted sources. CASS results discover candidates, not every episode member. |
+| Source extent | Permitted native locator plus available frozen byte length/bounds and digest, with the cutoff and digest scope. Unknown or unreadable extent/digest remains unknown, never zero or a hash of an excerpt represented as the full source. |
+| Work span | Only the source interval supported by explicit work/start/switch observations. Where frozen byte offsets are available use half-open `[start, end)` ranges tied to that source identity/digest. A search line is a locator, not an inferred byte boundary. |
+
+For a child, pass its work identity before launch, then record the child's
+observed ID and independently supported parent link at startup. For resume,
+retain the predecessor reference and add the observed resume relation; a
+requested resume ID does not prove a resumed execution. Workspace adjacency,
+matching task titles, filenames and guessed line numbers establish neither
+identity nor parentage. A native session can cover multiple work items: record
+only supported spans for each, preserve unrelated and unassigned spans, and
+leave an unknown end unknown until an observation supports it. Never assign a
+whole session to a work item because one hit names that work.
+
+If launch, startup observation or native recording fails, retain the caller's
+pre-execution record, available bounded failure facts and explicit unknowns;
+report any recording gap. Recovery reopens permitted startup/native sources
+without depending on a final handoff, preserving earlier failures/unknowns as
+history when later observations resolve them. Do not fill gaps with invented
+IDs, inferred edges or unrelated source spans.
+
+All metadata follows source-owner and recipient/model/destination authorization,
+including locators, native comments, filenames and diagnostics. BD/Dolt is
+versioned and is not a secret store. Use permitted opaque locators rather than
+restricted paths/excerpts or credentials; opacity grants no clearance. Check
+access before resolving a locator, never retrieve denied bytes and redact later.
+
+Association is not coverage: CASS discovery, `view`/`expand` windows and tool-call
+mining do not prove full prose/outcome reading. Preserve missing sources and
+unknown lengths. Frozen bounds/digests identify available evidence; they do not
+prove bytes were emitted, delivered to the host or semantically processed.
+Head/tail excerpts leave the middle unread; new tails or children belong to a
+later observation, not a rewritten completed denominator. T09 owns the later
+coverage verifier; no coverage command or acceptance claim is introduced here.
+
 ## Quick Detection
+
+These probes illustrate older formats only. Metadata may precede messages;
+unknown format stays unknown until the selected connector/version is observed.
+Do not infer a native session ID from either probe.
 
 ```bash
 # Detect agent type from first line
@@ -147,29 +209,32 @@ jq 'select(.role == "user") | .content' session.jsonl
 ### Subagent Structure
 
 ```
+Possible older layout, not guaranteed:
 Line 1: Session metadata (type, model info)
-Line 2: THE USER PROMPT (this is gold — the extraction prompt that worked)
+Line 2: User prompt
 Line 3+: Agent execution and responses
 ```
 
 ### Why Subagents Matter
 
-Deep dive extraction prompts live here. The prompt at line 2 is copy-paste ready — it's the exact instruction that produced the extraction.
+Subagent prompts may live here. Inspect the actual authorized message type and
+source position before citing a prompt; line 2 is only a legacy heuristic and
+never evidence of identity, parentage or complete reading.
 
 ### Extract Subagent Prompt
 
 ```bash
-# View prompt with context
+# Inspect the possible prompt position; verify the actual message before use
 cass view /path/subagents/agent-XXXXX.jsonl -n 2 -C 1
 
-# Extract just the text
+# Legacy-layout excerpt only, after verifying the actual prompt position
 sed -n '2p' /path/subagents/agent-XXXXX.jsonl | jq '.message.content'
 
 # Or with jq slurp
 jq -s '.[1].message.content' /path/subagents/agent-XXXXX.jsonl
 ```
 
-### Find All Subagent Sessions
+### Discover Candidate Subagent Sessions
 
 ```bash
 # Via cass search
@@ -184,11 +249,11 @@ find ~/.claude/projects -path "*/subagents/*.jsonl" | head -20
 
 ## Universal Extraction Patterns
 
-### Detect and Extract (Any Agent)
+### Detect and Extract (Legacy Examples)
 
 ```bash
 #!/bin/bash
-# extract_prompts.sh — works with any agent format
+# Legacy-format example; unsupported formats remain unknown
 
 FILE="$1"
 

--- a/skills-codex/handoff/.agentops-generated.json
+++ b/skills-codex/handoff/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/handoff",
   "layout": "modular",
-  "source_hash": "5d6921b7d42edcc15d6c6a95c0469c520941dec0a6175db178151583db4a5dd6",
-  "generated_hash": "06d2d26f9e670f7df7503a2d3c03daab0a09f3da18f5a70086d9012ba4724592"
+  "source_hash": "0011762be4d71bb359ea78a0088ad3eec2ca9d704718f5dc70abe38a89966fd5",
+  "generated_hash": "d4e35cd31aad23fa9462f71a7efa43da1abe7671d9a29638541ec9951107b7a7"
 }

--- a/skills-codex/handoff/SKILL.md
+++ b/skills-codex/handoff/SKILL.md
@@ -23,9 +23,9 @@ Observable in the trace, without reading the prose:
 
 - Every completed item names an exact evidence path like
   `cli/internal/gates/regen.go`, not a chronological narration.
-- The artifact lands at the caller-named path or `.agents/ao/handoff/`.
-- `cat .agents/ao/handoff/<id>.json` after writing shows the same
-  content it wrote.
+- The artifact lands at the caller-named authorized path; new CDLC evidence
+  uses an explicitly selected external non-Git location.
+- Readback of that exact artifact path shows the content written.
 - Only caller-supplied `continuation` text appears as next action; no
   owner, tracker state, or verdict is invented.
 
@@ -40,7 +40,26 @@ Write a factual session artifact that another context can read. Include:
   allowance or explicit measurement gaps, and whether the one helper for the
   current HOLD incident was already used, with existing evidence references;
 - optional caller-supplied continuation text;
-- best-effort read-only repository identity when useful.
+- best-effort read-only repository identity when useful;
+- the permitted startup association reference, source-store/project/work
+  identity, and observed runtime/session/context IDs or explicit unknowns;
+- separately evidenced parent and resume links, observation provenance and
+  cutoff, and any supported work spans with available frozen source bounds and
+  digests, following [session associations](../cass/references/SESSION_FORMATS.md#work-to-session-associations).
+
+The caller records the work association at dispatch/start and observed native
+identity at startup through native comments/metadata or runtime facts. Handoff
+adds end-state evidence; it must not be the first or only work/session link.
+For an interrupted session, reconstruct only what permitted startup records
+and native observations support. Missing handoff, missing source, unknown
+length, unobserved ID or unproved relationship remains explicit; never invent
+an ID or assign an entire multi-work session to one bead. Preserve earlier
+unknown/failure observations when later evidence resolves a link.
+
+Check source-owner and recipient/model/destination authorization before reading
+or copying association metadata. BD/Dolt is versioned and is not a secret
+store. Use permitted opaque locators where necessary; omit restricted excerpts
+and sensitive paths from unauthorized destinations. A locator grants no access.
 
 Do not infer a next action, select work, assign ownership, consume the artifact,
 change tracker or Git state, classify a verdict, govern retries, or restart a
@@ -58,15 +77,17 @@ Anti-pattern: narrating the session chronologically ("first I tried…, then…"
 Corrective: record end-state facts — artifacts, paths, unresolved risks — and
 drop the journey.
 
-Write the artifact to the caller-owned handoff location when the caller names
-one; otherwise it is explicit requested proof under `.agents/ao/handoff/`.
-There is no permanent generic handoff store — an artifact nobody consumes is
-scratch, not evidence.
+Write the artifact to the caller-owned authorized handoff location. For new
+CDLC memory/episode evidence, require the caller-selected protected external
+non-Git location; missing routing is a reported gap, with no fallback file in
+the consumer checkout. Existing requested evidence stays preserved. Standalone
+non-CDLC handoff retains the explicit requested-proof default below. There is
+no permanent generic handoff store — an artifact nobody consumes is scratch.
 
-The ao session handoff and ao session rehydrate commands implement the same
-boundary for JSON artifacts under `.agents/ao/handoff/`. The skill may write
-Markdown when that better serves a human, but the content semantics remain
-identical.
+The skill may write Markdown when that better serves a human. The existing
+`ao session handoff` and `ao session rehydrate` JSON compatibility behavior
+below does not itself establish startup associations or an external CDLC route;
+use only a command whose actual destination support matches the invocation.
 
 ### Earlier default compatibility
 

--- a/skills-codex/implement/.agentops-generated.json
+++ b/skills-codex/implement/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/implement",
   "layout": "modular",
-  "source_hash": "49987f367c5d345e164fccab65a9cc207a8da61ff38de44bffbc0dc13680fb47",
-  "generated_hash": "375b34a916228126c2b20f269dbeb5e1444abe4e478e51bf6a8fdaf8c6efd584"
+  "source_hash": "d24c73ea0104aabff2ca0b9c8826014b07604af64d3c5f9dd56a896973a7ecfa",
+  "generated_hash": "f2e4c6a5c7c3a4c0b15096165197a29f3813bf5161f495655b45273fdfec2615"
 }

--- a/skills-codex/implement/SKILL.md
+++ b/skills-codex/implement/SKILL.md
@@ -19,8 +19,9 @@ return the manifest digest and check receipts, stop.
 
 ## It's working if
 
-- The first transcript command is the acceptance check, and its output shows
-  the expected failure (or a green baseline for a relocation or refactor).
+- After source activation and startup association, the first behavior check
+  is the acceptance check; its output shows the expected failure (or an honest
+  green structural baseline for documentation, relocation, or refactor work).
 - Every path in `git diff --stat` falls inside the declared scope; an outside
   consumer is reported as `file:line`, not absorbed.
 - The response carries the `subject-manifest.v1` digest, author context ID,
@@ -30,7 +31,17 @@ return the manifest digest and check receipts, stop.
 
 1. Read the intent, acceptance, and scope from their existing source; before
    the first write, read `boundaries.md` in the rpi skill's `references`
-   directory for what Implement does not own.
+   directory for what Implement does not own. Before execution can fail, the
+   caller passes source-store/project/work identity and permitted intent
+   locators at dispatch/start. At startup, return observed native runtime,
+   session/context identity (or explicit unknowns) through the caller-owned
+   runtime channel for native comments/metadata recording; do not defer this
+   association until handoff. Follow the fact distinctions in
+   [session associations](../cass/references/SESSION_FORMATS.md#work-to-session-associations).
+   Parent and resume links need observed provenance; controller dispatch alone
+   does not establish native parentage. If startup observation or recording
+   fails, preserve that failure and the pre-execution reference with the caller,
+   leaving unobserved IDs unknown. Implement does not mutate the tracker.
 2. Run the declared first acceptance check before changing behavior. RED-first
    applies when acceptance is behavioral: preserve evidence that the check
    fails for the expected missing behavior. Relocations, doc merges, and pure

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "62895cade9636d266190382c422d806193ae246c21589ca6dc98c8a31d988c6d",
-  "generated_hash": "a56999a2700ac4629ffaf2f4dd59bf8797af104920f7622ee8c65754dc7892a2"
+  "source_hash": "44814912c9d640bf6d9ae4bdc27a75f4437b81435954178e3ac44f3c76758ed0",
+  "generated_hash": "c25f250b18d19ac492ec95c4552f510d128ff5b7fb1ef1f4129d17bbb4c818ee"
 }

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -68,6 +68,7 @@ comment alone is not that.
    caller-owned source by reference and digest, or, only when no durable
    source exists, the exact resolved bytes snapshotted by the runtime under
    their digest.
+   For selected CDLC work, the caller carries and records work/startup identities before substantive work for every child or resume, following [session associations](../cass/references/SESSION_FORMATS.md#work-to-session-associations) independently of final handoff; unknowns and failures remain explicit, and RPI never mutates the tracker.
 3. When the write scope touches a risky surface (the short list
    [`validate`](../validate/SKILL.md) names), have one fresh judge read the
    frozen plan before Implement. A blocking finding sends the plan back to the

--- a/skills/agent-native/SKILL.md
+++ b/skills/agent-native/SKILL.md
@@ -66,9 +66,23 @@ stalled, and rescue is usually cheaper than rerun.
 
 ## Contract
 
-1. Require an explicit packet, role, workspace, context identity, and evidence
-   destination before starting a worker.
-2. Prove runtime readiness and engagement from observable state; a successful
+1. Require caller intent, role, workspace, authorized source/output scope and
+   evidence destination before starting a worker. Pass source-store/project/work
+   identity and permitted intent locators before execution can fail. Record this
+   dispatch association in caller-owned native comments/metadata or runtime
+   facts, with actual worker session/context IDs explicitly unknown until
+   observed; a requested ID is not an observed ID. This adds no AO packet schema.
+2. Capture observed native runtime/session/context identity at startup, before
+   substantive work and independently of final handoff. Return the observation
+   through the caller-owned native recording channel with its provenance and
+   permitted source locator. Preserve launch failures and unknowns if startup
+   never becomes observable. Follow
+   [session associations](../cass/references/SESSION_FORMATS.md#work-to-session-associations)
+   for separate parent/resume links, supported multi-work spans and frozen source
+   bounds. A controller is not necessarily a native parent; every requested
+   child and resumed execution needs its own observed association. If recording
+   fails, report the gap; do not claim crash recovery from prompt delivery alone.
+   Prove runtime readiness and engagement from observable state; a successful
    prompt send is not proof of work.
 3. Keep concurrent writers disjoint and isolated. Runtime coordination is not a
    claim, lease, queue, or completion state in AgentOps.

--- a/skills/agent-native/references/model-dispatch.md
+++ b/skills/agent-native/references/model-dispatch.md
@@ -17,8 +17,11 @@ majority vote establishes truth. Authors cannot issue their own binding PASS.
 One request selects one worker and one result destination. Before dispatch,
 resolve role, exact subject/acceptance references, authorized input bytes,
 workspace, read/write scope, output/evidence destination, requested model,
-fresh context identity distinct from the author and every peer, finite
-input/output limits and timeout from the caller and native runtime. These are invocation facts, not a new AO packet schema,
+requirement for a fresh context distinct from the author and every peer, finite
+input/output limits and timeout from the caller and native runtime. Actual
+context identity remains unknown until the native runtime reports it; verify
+freshness and distinctness against that observed identity before relying on
+judgment. These are invocation facts, not a new AO packet schema,
 work store or budget account. Retry remains the caller's decision. Judge legs
 receive read-only subject access; only their declared evidence output is writable.
 
@@ -37,6 +40,31 @@ prompt restrictions, a worktree or a same-user unrestricted process do not.
 Unsupported protection prevents restricted-source dispatch. The repository
 contract is ADR-0016, State tiers; this installed skill carries the requirements
 above without depending on a repository-relative documentation link.
+
+## Association before execution
+
+Before launch, pass source-store/project/work identity and permitted frozen
+intent references through the selected runtime input. The caller records the
+dispatch association in native work comments/metadata or existing runtime facts
+before execution can fail, with worker identity explicitly unknown if not yet
+observed. At startup, capture actual runtime/session/context identity and return
+it to that caller-owned channel before substantive work; final handoff is only
+an additional reference. Do this for a child or resumed execution as well.
+
+Keep requested model/ID, observed model/ID, controller identity, native parent
+and resume predecessor distinct. Use the selected runtime's observed resume
+identity even if it retains the original session ID; invocation observations
+must still remain distinguishable. Never infer parentage from workspace,
+filename, title or proximity. An unavailable startup/recording operation stays
+a named failure with unknown identity, not a fabricated successful launch.
+
+[Session associations](../../cass/references/SESSION_FORMATS.md#work-to-session-associations)
+owns the fact distinctions: provenance, permitted locators, source bounds and
+multi-work spans. Record only metadata authorized for the source owner and
+recipient/destination; BD/Dolt is versioned, not secret storage. Neither this
+reference nor the core phases gain tracker mutation, a new association store,
+or runtime lifecycle authority. Required judgment freshness remains unsatisfied
+when observed identities or their provenance are missing.
 
 ## Selected adapters
 

--- a/skills/cass/SKILL.md
+++ b/skills/cass/SKILL.md
@@ -41,8 +41,34 @@ This skill carries only the AgentOps operating doctrine: when to reach for cass,
 ## Constraints
 
 - Never run bare `cass` because it launches a blocking TUI; use a JSON, robot, or explicit file-output command.
-- Treat a stale index as searchable and refresh it with a bounded background command because stale is not broken and an unbounded rebuild can stall the lane.
+- Within authorized sources and destinations, treat a stale index as searchable
+  and refresh it only when the selected invocation permits indexing, using a
+  bounded background command; stale is not broken.
 - Preserve source sessions and require explicit permission for destructive cleanup; recovery may rebuild only derived index state.
+
+## Authorization and episode association
+
+Before any search, view, context lookup, export, index recovery or sync, check
+source-owner, task, model/provider and destination authorization. Indexes,
+hit metadata, source paths and tracker comments inherit source restrictions;
+read permission does not permit forwarding to another model or versioning in
+Git. The recovery defaults below apply only inside this authorized envelope;
+source sync and model downloads also require the selected egress authority.
+Unavailable controls leave restricted-source operations unavailable, without
+retrieving first and redacting later. Missing, restricted, unavailable,
+no-match and insufficient evidence are different outcomes.
+
+Capture work identity at dispatch/start and observed native IDs at startup
+through the caller-owned native comments/metadata or runtime facts, independently
+of handoff. Use [SESSION_FORMATS.md](references/SESSION_FORMATS.md#work-to-session-associations)
+for source-store/work identity, parent/resume provenance, supported work spans,
+permitted locators and available frozen source bounds/digests. Native logs retain
+execution authority; CASS discovers candidates. Search/view/expand/context
+output does not prove a complete episode was read or that a related hit is a
+parent. Record query, filters, limit, index freshness and discovery cutoff;
+zero hits means no match within those observed limits, not absence everywhere.
+Missing children, new tails and unknown source lengths remain explicit. T09 owns
+later coverage verification; this skill does not implement or certify it.
 
 ## When to Use
 
@@ -53,7 +79,10 @@ This skill carries only the AgentOps operating doctrine: when to reach for cass,
 
 ### Folded triggers (ag-s43tg wave 1): `casr` + `cass-memory` route here
 
-- **`casr` → cross-harness resume.** Cross Agent Session Resumer: convert and resume sessions across Claude Code, Codex, Gemini, and other providers — `cass resume` plus [RESUME.md](references/RESUME.md) own this lane (resolve subagent logs to their parent via `cass context` first; subagent files are not resumable).
+- **`casr` → cross-harness resume.** [RESUME.md](references/RESUME.md)
+  distinguishes `cass resume` (same-harness command resolution) from the separate
+  cross-harness converter. `cass context` discovers candidate relations; verify
+  a native parent link before choosing a parent session to resume.
 - **`cass-memory` → `cm` procedural memory.** Use when starting non-trivial work, mining lessons, or preventing repeated mistakes with cm procedural memory — mine past sessions here first, then promote the durable lessons through `cm` instead of re-deriving them each session.
 
 ## The Goldmine Principle
@@ -77,9 +106,9 @@ routing:
   cite `source_path` and line in whatever you build on it.
 - **Adjacent hit** — prior work borders the problem. Extract the working
   fragments, then derive only the missing part fresh.
-- **Verified absence** — zero hits after retrying against discovered workspace
-  keys (`--aggregate workspace`). Now derivation is justified, and the absence
-  itself is worth noting: you are in new territory, so budget accordingly.
+- **Bounded no-match** — zero hits after retrying against authorized discovered
+  workspace keys (`--aggregate workspace`). Derive from available evidence and
+  report the query/index limits; this does not establish global absence.
 
 The named failure mode is re-derivation drift: solving the same problem
 slightly differently each session, so the corpus accumulates near-duplicate
@@ -119,17 +148,17 @@ Mined lessons are evidence with a shelf life, not doctrine:
    cass search "KEYWORD" --workspace /data/projects/PROJECT --json --fields minimal --limit 50 \
      | jq '[.hits[] | select(.line_number <= 3)]'
 
-3. Follow hits: View the actual content
+3. Follow authorized hits: View a bounded excerpt of the actual content
    cass view /path/from/source_path.jsonl -n LINE -C 20
 
-4. Expand context: See the full conversation flow
+4. Expand context: Inspect another bounded conversation window
    cass expand /path/from/source_path.jsonl --line LINE --context 3
 
-5. Discover related: Find the whole work cluster
+5. Discover related: Find candidates, not proven parents or a complete cluster
    cass context /path/from/source_path.jsonl --json
 ```
 
-Why it works: aggregations first (know the terrain), `--fields minimal` (5x smaller output), `line_number <= 3` (user prompts live at the top), context clustering (one good hit → many related sessions). >10 matches for a prompt = a ritual; document and reuse it.
+Why it works: aggregations first (know the terrain), `--fields minimal` (5x smaller output), `line_number <= 3` (a discovery heuristic, not guaranteed prompt position), context clustering (one good hit → many related sessions). >10 matches for a prompt = a ritual; document and reuse it.
 
 ## Operating Doctrine: Stale ≠ Broken
 
@@ -186,7 +215,7 @@ cass evolves quickly; the released binary may lack HEAD features. When a flag re
 | Running `cass index --full` whenever `status` says unhealthy | A 25s rebuild for a 30-min stale index is wasteful | Check `index.stale` separately from `database.exists`; prefer incremental |
 | Running bare `cass` to "see what's there" | Launches blocking TUI in the agent's session | Always `--json` or `--robot`; never bare |
 | Piping `cass export` into `head`/`jq` | Broken-pipe panic on large sessions | `cass export ... -o /tmp/x.json` first, then operate on the file |
-| Treating subagent files as parent sessions | Subagents are separate logs with their own line-2 prompt; also NOT resumable | Filter by `select(.source_path \| contains("subagent"))`; resolve to parent via `cass context` before `cass resume` |
+| Treating subagent files as parent sessions | Subagents have separate logs; prompt positions vary and logs may not be resumable | Filter by `select(.source_path \| contains("subagent"))`; use `cass context` for candidates, then verify native parent evidence before `cass resume` |
 | Using `--limit 0` for "no limit" | Earlier cass panics | Use a real limit (`--limit 50`); `--limit 1` minimum for aggregations |
 | Trusting 0 hits with `--workspace /X` | Workspace strings are case- and trailing-slash-sensitive | Re-run with `--aggregate workspace --limit 1` to discover the canonical key |
 | Skipping `--fields minimal` on wide scans | ~3KB per hit × 100 hits = 300KB context burn | `--fields minimal` for wide passes; upgrade to `summary`/`full` for keepers |
@@ -199,7 +228,7 @@ Long-form versions with mined evidence: [ANTI_PATTERNS.md](references/ANTI_PATTE
 
 ## Safety Boundaries
 
-Pre-authorized (rebuilds derived index data only, never destroys source sessions): `cass doctor --fix --json`, `cass index --full --force-rebuild --json`, `cass sources doctor/sync`, `cass models install/verify`.
+Within the authorized source/model/destination and egress envelope above, the following operate on derived state rather than granting new source access: `cass doctor --fix --json`, `cass index --full --force-rebuild --json`, `cass sources doctor/sync`, `cass models install/verify`.
 
 Do NOT without explicit permission: delete `core.NNNNN` coredumps, delete `.beads/`, `git reset --hard`, or hand-edit `~/.config/cass/sources.toml` — the CLI commands above already do everything safely. Never run bare `cass` (blocking TUI) inside an agent loop.
 
@@ -228,7 +257,7 @@ When the right reference isn't obvious from titles, `grep -ni "SYMPTOM" referenc
 
 ## Scripts
 
-Scripts live under `scripts/`. They execute, never load — zero context tokens. Consistent with the Safety Boundaries above, `recover.sh` and `quick_analysis.sh` may rebuild **derived index state** autonomously (pre-authorized: `doctor --fix`, `index --full`) and `multi_machine_search.sh` reads remote sources over ssh; none destroy source sessions, and nothing destructive (coredump/`.beads` deletion, `git reset --hard`, source edits) runs without explicit confirmation.
+Scripts live under `scripts/`. Inspect their access and write scope before use when uncertain. Consistent with the Safety Boundaries above, `recover.sh` and `quick_analysis.sh` may rebuild **derived index state** autonomously (pre-authorized: `doctor --fix`, `index --full`) and `multi_machine_search.sh` reads remote sources over ssh; none destroy source sessions, and nothing destructive (coredump/`.beads` deletion, `git reset --hard`, source edits) runs without explicit confirmation.
 
 | Script | Usage |
 |--------|-------|
@@ -260,5 +289,5 @@ If `false`, run: `cass index --json`
 ## Quality Checklist
 
 - Results come from a canonical workspace key and include enough source location to reopen the session context.
-- A zero-hit result was retried against discovered workspace keys before concluding that no prior art exists.
+- A zero-hit result was retried against authorized discovered workspace keys and reported as bounded no-match with its discovery limits.
 - Index recovery stayed bounded and preserved source sessions; no stale state was misreported as broken.

--- a/skills/cass/references/RESUME.md
+++ b/skills/cass/references/RESUME.md
@@ -13,6 +13,26 @@
 
 ---
 
+## Authorization and startup evidence
+
+Resolving a command does not authorize executing it. Before reading a source or
+resuming, verify task/source-owner/model/provider/destination authorization and
+that the caller selected this runtime operation. Cross-harness conversion sends
+content to a new recipient and requires its own applicable authorization.
+
+Before execution, pass source-store/project/work identity and permitted intent
+locators, and have the caller record the dispatch/resume request in native
+comments/metadata or runtime facts. Keep the requested predecessor separate
+from the actual resumed context. At startup, record the selected runtime's
+observed session/context ID and resume relation with observation provenance;
+it may reuse an ID or create another context. Until observed, use explicit
+unknowns. Command text, a filename and successful command resolution do not
+prove that resumption occurred. Preserve failed starts and unresolved links
+without waiting for handoff. Follow
+[session associations](SESSION_FORMATS.md#work-to-session-associations) for
+supported spans and available frozen source boundaries/digests; never transfer
+all work associations from a predecessor automatically.
+
 ## The Three Modes
 
 ```bash
@@ -25,7 +45,7 @@ cass resume /path/to/session.jsonl
 # 2. Emit a single shell-escaped command line
 cass resume /path/to/session.jsonl --shell
 # claude resume '8efcc298-90d8-4764-9144-944c40f1a321'
-eval "$(cass resume /path/to/session.jsonl --shell)"
+# Inspect the emitted command; execute only the caller-authorized native resume.
 
 # 3. Replace the current process (mutually exclusive with --shell/--json)
 cass resume /path/to/session.jsonl --exec
@@ -66,32 +86,23 @@ cass resume /home/x/.claude/projects/<ws>/subagents/agent-a0b4d4b58a1fd73da.json
 #  "hint":"Did you pass a project directory or notes file instead..."}}
 ```
 
-Recover the parent session via `cass context`. The schema is:
-
-```json
-{
-  "source":  {"path": "...", "agent": "...", "workspace": "...", ...},
-  "counts":  {"same_workspace": 12, "same_day": 8, "same_agent": 15},
-  "related": {
-    "same_workspace": [{"path": "...", "agent": "...", "title": "...", ...}, ...],
-    "same_day":       [...],
-    "same_agent":     [...]
-  }
-}
-```
-
-Note: items use `.path` (not `.source_path`) and `related` is an **object**, not a flat array.
+Use `cass context` only to discover candidate sessions. Its `related` object
+contains `same_workspace`, `same_day` and `same_agent` lists; their entries use
+`.path`, not `.source_path`. These are similarity groups, not parent edges.
 
 ```bash
-# Find the parent (first non-subagent file in same_workspace)
-cass context /path/to/subagents/agent-XXXXX.jsonl --json \
-  | jq -r '.related.same_workspace[]
-            | select(.path | contains("subagents") | not)
-            | .path' \
-  | head -1
+# Bounded candidate discovery for an authorized source; do not select a parent.
+cass context /path/to/subagents/agent-XXXXX.jsonl --json
 ```
 
-Then `cass resume` that path.
+Verify parentage using an authorized native startup/dispatch observation or
+explicit parent link in native runtime metadata, with its exact permitted
+source locator. A dispatch-attested controller relation is distinct from a
+native parent relation. The first non-subagent workspace hit, a matching title,
+a filename or a guessed prompt line is never proof. If no link is observable,
+record parent unknown and stop parent-based resume selection. Only after the
+link is verified and the caller selects execution may `cass resume` target the
+verified parent; do not erase the child's separate source/work association.
 
 ---
 
@@ -107,7 +118,7 @@ HIT=$(cass search "implement auth flow" --workspace /myrepo --json --fields summ
 # 2. Print the command without executing
 cass resume "$HIT" --shell
 
-# 3. Drop the user into the resumed conversation
+# 3. Only after caller authorization and pre-execution association recording
 cass resume "$HIT" --exec
 ```
 
@@ -123,7 +134,7 @@ cass expand "$HIT" --line 1 --context 5    # see the original prompt
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `session_id_not_found` for `agent-*.jsonl` | Subagent file | Use `cass context` to find parent |
+| `session_id_not_found` for `agent-*.jsonl` | Subagent file | Discover candidates with `cass context`; verify a native parent link or leave parent unknown |
 | `unknown harness` | Path doesn't match any connector layout | Pass `--agent` explicitly |
 | Resumed session won't open | The native CLI was upgraded and changed its session schema | Try the harness's own `--list` to see if the ID is still valid; the source jsonl is your fallback |
 | `cross_agent_session_resumer#9` style: Codex → Pi resumption broken | Cross-harness resume requires casr (separate tool) | Use the matching native CLI; cass resume only does *same-harness* |

--- a/skills/cass/references/SESSION_FORMATS.md
+++ b/skills/cass/references/SESSION_FORMATS.md
@@ -1,9 +1,12 @@
 # Session File Formats by Agent
 
-> **Critical knowledge for parsing raw session logs.** Each agent stores conversations in JSONL with different structures.
+> Format examples are connector/version-specific inspection aids, not identity
+> or completeness guarantees. Read only sources authorized for the task, owner,
+> model/provider and destination; raw native stores retain authority.
 
 ## Contents
 
+- [Work-to-session associations](#work-to-session-associations)
 - [Quick Detection](#quick-detection)
 - [Claude Code Format](#claude-code-format)
 - [Codex CLI Format](#codex-cli-format)
@@ -15,7 +18,66 @@
 
 ---
 
+## Work-to-session associations
+
+The caller passes work identity at dispatch/start before execution can fail,
+and records the dispatch reference in native work comments/metadata or existing
+runtime facts. At startup, record observed identity in that caller-owned channel
+before substantive work, independently of final handoff. These are versioned
+facts under their source owners, not a new AO association database, lifecycle,
+packet schema or permanent writer. Core skills return facts; tracker mutation
+requires the caller's authority. No memory/evidence file belongs in a consumer
+checkout by default; requested CDLC evidence uses owner-selected protected
+external non-Git storage.
+
+Keep these facts distinct in the native record or its permitted evidence:
+
+| Fact | Required distinction |
+|---|---|
+| Source work | Backend/store identity, database/project identity where available, native work ID and permitted source revision/intent locator; a bead ID alone or workspace basename is not globally unique. |
+| Execution | Selected runtime and requested model/ID separately from actual observed model/session/context IDs; absent observations are explicit unknowns, never synthetic UUIDs. |
+| Relations | Native parent, dispatch controller and resume predecessor are separate links, each with its observation source. Record the selected runtime's actual resume identity even when it reuses a session ID. Unknown is distinct from an observed absence of parent. |
+| Provenance | Who or which runtime observed the fact, when, through which native operation/record, and its permitted locator. Caller-supplied facts remain labeled as supplied; do not upgrade inference to observation. |
+| Discovery | Exact query/filters/limits, index freshness, observed cutoff and missing/unavailable/restricted sources. CASS results discover candidates, not every episode member. |
+| Source extent | Permitted native locator plus available frozen byte length/bounds and digest, with the cutoff and digest scope. Unknown or unreadable extent/digest remains unknown, never zero or a hash of an excerpt represented as the full source. |
+| Work span | Only the source interval supported by explicit work/start/switch observations. Where frozen byte offsets are available use half-open `[start, end)` ranges tied to that source identity/digest. A search line is a locator, not an inferred byte boundary. |
+
+For a child, pass its work identity before launch, then record the child's
+observed ID and independently supported parent link at startup. For resume,
+retain the predecessor reference and add the observed resume relation; a
+requested resume ID does not prove a resumed execution. Workspace adjacency,
+matching task titles, filenames and guessed line numbers establish neither
+identity nor parentage. A native session can cover multiple work items: record
+only supported spans for each, preserve unrelated and unassigned spans, and
+leave an unknown end unknown until an observation supports it. Never assign a
+whole session to a work item because one hit names that work.
+
+If launch, startup observation or native recording fails, retain the caller's
+pre-execution record, available bounded failure facts and explicit unknowns;
+report any recording gap. Recovery reopens permitted startup/native sources
+without depending on a final handoff, preserving earlier failures/unknowns as
+history when later observations resolve them. Do not fill gaps with invented
+IDs, inferred edges or unrelated source spans.
+
+All metadata follows source-owner and recipient/model/destination authorization,
+including locators, native comments, filenames and diagnostics. BD/Dolt is
+versioned and is not a secret store. Use permitted opaque locators rather than
+restricted paths/excerpts or credentials; opacity grants no clearance. Check
+access before resolving a locator, never retrieve denied bytes and redact later.
+
+Association is not coverage: CASS discovery, `view`/`expand` windows and tool-call
+mining do not prove full prose/outcome reading. Preserve missing sources and
+unknown lengths. Frozen bounds/digests identify available evidence; they do not
+prove bytes were emitted, delivered to the host or semantically processed.
+Head/tail excerpts leave the middle unread; new tails or children belong to a
+later observation, not a rewritten completed denominator. T09 owns the later
+coverage verifier; no coverage command or acceptance claim is introduced here.
+
 ## Quick Detection
+
+These probes illustrate older formats only. Metadata may precede messages;
+unknown format stays unknown until the selected connector/version is observed.
+Do not infer a native session ID from either probe.
 
 ```bash
 # Detect agent type from first line
@@ -147,29 +209,32 @@ jq 'select(.role == "user") | .content' session.jsonl
 ### Subagent Structure
 
 ```
+Possible older layout, not guaranteed:
 Line 1: Session metadata (type, model info)
-Line 2: THE USER PROMPT (this is gold — the extraction prompt that worked)
+Line 2: User prompt
 Line 3+: Agent execution and responses
 ```
 
 ### Why Subagents Matter
 
-Deep dive extraction prompts live here. The prompt at line 2 is copy-paste ready — it's the exact instruction that produced the extraction.
+Subagent prompts may live here. Inspect the actual authorized message type and
+source position before citing a prompt; line 2 is only a legacy heuristic and
+never evidence of identity, parentage or complete reading.
 
 ### Extract Subagent Prompt
 
 ```bash
-# View prompt with context
+# Inspect the possible prompt position; verify the actual message before use
 cass view /path/subagents/agent-XXXXX.jsonl -n 2 -C 1
 
-# Extract just the text
+# Legacy-layout excerpt only, after verifying the actual prompt position
 sed -n '2p' /path/subagents/agent-XXXXX.jsonl | jq '.message.content'
 
 # Or with jq slurp
 jq -s '.[1].message.content' /path/subagents/agent-XXXXX.jsonl
 ```
 
-### Find All Subagent Sessions
+### Discover Candidate Subagent Sessions
 
 ```bash
 # Via cass search
@@ -184,11 +249,11 @@ find ~/.claude/projects -path "*/subagents/*.jsonl" | head -20
 
 ## Universal Extraction Patterns
 
-### Detect and Extract (Any Agent)
+### Detect and Extract (Legacy Examples)
 
 ```bash
 #!/bin/bash
-# extract_prompts.sh — works with any agent format
+# Legacy-format example; unsupported formats remain unknown
 
 FILE="$1"
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -669,7 +669,7 @@
         "code-complete"
       ],
       "produces": [
-        "caller-selected handoff path or .agents/ao/handoff/*"
+        "caller-selected handoff artifact"
       ],
       "references_count": 1,
       "tier": "session",

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -4,7 +4,7 @@ description: 'Write compact caller-authored session evidence without choosing co
 practices: [adr, wiki-knowledge-surface, code-complete]
 hexagonal_role: supporting
 consumes: []
-produces: [caller-selected handoff path or .agents/ao/handoff/*]
+produces: [caller-selected handoff artifact]
 context_rel: []
 skill_api_version: 1
 context:
@@ -42,9 +42,9 @@ Observable in the trace, without reading the prose:
 
 - Every completed item names an exact evidence path like
   `cli/internal/gates/regen.go`, not a chronological narration.
-- The artifact lands at the caller-named path or `.agents/ao/handoff/`.
-- `cat .agents/ao/handoff/<id>.json` after writing shows the same
-  content it wrote.
+- The artifact lands at the caller-named authorized path; new CDLC evidence
+  uses an explicitly selected external non-Git location.
+- Readback of that exact artifact path shows the content written.
 - Only caller-supplied `continuation` text appears as next action; no
   owner, tracker state, or verdict is invented.
 
@@ -59,7 +59,26 @@ Write a factual session artifact that another context can read. Include:
   allowance or explicit measurement gaps, and whether the one helper for the
   current HOLD incident was already used, with existing evidence references;
 - optional caller-supplied continuation text;
-- best-effort read-only repository identity when useful.
+- best-effort read-only repository identity when useful;
+- the permitted startup association reference, source-store/project/work
+  identity, and observed runtime/session/context IDs or explicit unknowns;
+- separately evidenced parent and resume links, observation provenance and
+  cutoff, and any supported work spans with available frozen source bounds and
+  digests, following [session associations](../cass/references/SESSION_FORMATS.md#work-to-session-associations).
+
+The caller records the work association at dispatch/start and observed native
+identity at startup through native comments/metadata or runtime facts. Handoff
+adds end-state evidence; it must not be the first or only work/session link.
+For an interrupted session, reconstruct only what permitted startup records
+and native observations support. Missing handoff, missing source, unknown
+length, unobserved ID or unproved relationship remains explicit; never invent
+an ID or assign an entire multi-work session to one bead. Preserve earlier
+unknown/failure observations when later evidence resolves a link.
+
+Check source-owner and recipient/model/destination authorization before reading
+or copying association metadata. BD/Dolt is versioned and is not a secret
+store. Use permitted opaque locators where necessary; omit restricted excerpts
+and sensitive paths from unauthorized destinations. A locator grants no access.
 
 Do not infer a next action, select work, assign ownership, consume the artifact,
 change tracker or Git state, classify a verdict, govern retries, or restart a
@@ -77,15 +96,17 @@ Anti-pattern: narrating the session chronologically ("first I tried…, then…"
 Corrective: record end-state facts — artifacts, paths, unresolved risks — and
 drop the journey.
 
-Write the artifact to the caller-owned handoff location when the caller names
-one; otherwise it is explicit requested proof under `.agents/ao/handoff/`.
-There is no permanent generic handoff store — an artifact nobody consumes is
-scratch, not evidence.
+Write the artifact to the caller-owned authorized handoff location. For new
+CDLC memory/episode evidence, require the caller-selected protected external
+non-Git location; missing routing is a reported gap, with no fallback file in
+the consumer checkout. Existing requested evidence stays preserved. Standalone
+non-CDLC handoff retains the explicit requested-proof default below. There is
+no permanent generic handoff store — an artifact nobody consumes is scratch.
 
-The ao session handoff and ao session rehydrate commands implement the same
-boundary for JSON artifacts under `.agents/ao/handoff/`. The skill may write
-Markdown when that better serves a human, but the content semantics remain
-identical.
+The skill may write Markdown when that better serves a human. The existing
+`ao session handoff` and `ao session rehydrate` JSON compatibility behavior
+below does not itself establish startup associations or an external CDLC route;
+use only a command whose actual destination support matches the invocation.
 
 ### Earlier default compatibility
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -42,8 +42,9 @@ return the manifest digest and check receipts, stop.
 
 ## It's working if
 
-- The first transcript command is the acceptance check, and its output shows
-  the expected failure (or a green baseline for a relocation or refactor).
+- After source activation and startup association, the first behavior check
+  is the acceptance check; its output shows the expected failure (or an honest
+  green structural baseline for documentation, relocation, or refactor work).
 - Every path in `git diff --stat` falls inside the declared scope; an outside
   consumer is reported as `file:line`, not absorbed.
 - The response carries the `subject-manifest.v1` digest, author context ID,
@@ -53,7 +54,17 @@ return the manifest digest and check receipts, stop.
 
 1. Read the intent, acceptance, and scope from their existing source; before
    the first write, read `boundaries.md` in the rpi skill's `references`
-   directory for what Implement does not own.
+   directory for what Implement does not own. Before execution can fail, the
+   caller passes source-store/project/work identity and permitted intent
+   locators at dispatch/start. At startup, return observed native runtime,
+   session/context identity (or explicit unknowns) through the caller-owned
+   runtime channel for native comments/metadata recording; do not defer this
+   association until handoff. Follow the fact distinctions in
+   [session associations](../cass/references/SESSION_FORMATS.md#work-to-session-associations).
+   Parent and resume links need observed provenance; controller dispatch alone
+   does not establish native parentage. If startup observation or recording
+   fails, preserve that failure and the pre-execution reference with the caller,
+   leaving unobserved IDs unknown. Implement does not mutate the tracker.
 2. Run the declared first acceptance check before changing behavior. RED-first
    applies when acceptance is behavioral: preserve evidence that the check
    fails for the expected missing behavior. Relocations, doc merges, and pure

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -101,6 +101,7 @@ comment alone is not that.
    caller-owned source by reference and digest, or, only when no durable
    source exists, the exact resolved bytes snapshotted by the runtime under
    their digest.
+   For selected CDLC work, the caller carries and records work/startup identities before substantive work for every child or resume, following [session associations](../cass/references/SESSION_FORMATS.md#work-to-session-associations) independently of final handoff; unknowns and failures remain explicit, and RPI never mutates the tracker.
 3. When the write scope touches a risky surface (the short list
    [`validate`](../validate/SKILL.md) names), have one fresh judge read the
    frozen plan before Implement. A blocking finding sends the plan back to the


### PR DESCRIPTION
Interrupted agents can lose their connection to work when that connection is recorded only in the final handoff. The RPI, Implement, native dispatch, Handoff and CASS skills now carry the work identity into startup and preserve observed session, child and resume relationships through caller-owned native records. Unknown identities and unrelated work spans remain explicit, and retrieval follows the source’s access and disclosure policy.

The generated Codex and Gemini projections are updated from the source skills. Validation exercised the installed skills with fresh, forked and resumed native sessions interrupted before handoff, checked source injection and access denials, and reconstructed startup facts from native work records. The supported installation used repository links; portable package acceptance remains separate.

Local verification: full Go build/vet/tests and race/shuffle, all Bats suites, the aggregate runner, regeneration check, and all 72 AO gates passed on the final subject.
